### PR TITLE
Add a hook so that an AmrLevel can force a post-timestep regrid

### DIFF
--- a/Src/Amr/AMReX_Amr.cpp
+++ b/Src/Amr/AMReX_Amr.cpp
@@ -1759,6 +1759,9 @@ Amr::timeStep (int  level,
     //      when regridding is called with possible lbase > level.
     which_level_being_advanced = level;
 
+    // Update so that by default, we don't force a post-step regrid.
+    amr_level[level]->setPostStepRegrid(0);
+
     //
     // Allow regridding of level 0 calculation on restart.
     //
@@ -1854,6 +1857,29 @@ Amr::timeStep (int  level,
 #ifdef USE_SLABSTAT
     AmrLevel::get_slabstat_lst().update(*amr_level[level],time,dt_level[level]);
 #endif
+
+    // If the level signified that it wants a regrid after the advance has
+    // occurred, do that now.
+
+    if (amr_level[level]->postStepRegrid()) {
+
+	int old_finest = finest_level;
+
+	regrid(level, time);
+
+	if (old_finest < finest_level)
+	{
+	    //
+	    // The new levels will not have valid time steps.
+	    //
+	    for (int k = old_finest + 1; k <= finest_level; ++k)
+	    {
+		dt_level[k] = dt_level[k-1] / n_cycle[k];
+	    }
+	}
+
+    }
+
     //
     // Advance grids at higher level.
     //

--- a/Src/Amr/AMReX_AmrLevel.H
+++ b/Src/Amr/AMReX_AmrLevel.H
@@ -284,6 +284,10 @@ public:
     static const DescriptorList& get_desc_lst () { return desc_lst; }
     //! Returns list of derived variables.
     static DeriveList& get_derive_lst ();
+    //! Returns whether or not we want a post-timestep regrid.
+    int postStepRegrid () { return post_step_regrid; }
+    //! Sets a new value for the post-timestep regrid trigger.
+    void setPostStepRegrid (int new_val) { post_step_regrid = new_val; }
 
 #ifdef USE_SLABSTAT
     //! Returns list of slab stats.
@@ -384,6 +388,8 @@ protected:
 
     BoxArray              m_AreaNotToTag; //Area which shouldn't be tagged on this level.
     Box                   m_AreaToTag;    //Area which is allowed to be tagged on this level.
+
+    int                   post_step_regrid; // Whether or not to do a regrid after the timestep.
 
     bool                  levelDirectoryCreated;    // for checkpoints and plotfiles
 


### PR DESCRIPTION
The motivation for this change is that sometimes, during the course of a coarse
timestep, the timestep will found to be unstable due to a lack of resolution. In
this case the coarse level may want to signal that more resolution is required
immediately (as opposed to waiting for a future regrid), because even a single
unstable step may cause significant harm to the integrity of the simulation. An
example is a spurious numerical detonation caused by insufficient resolution in
a thermonuclear burning region. If this numerically-seeded detonation is detected
at the end of a timestep, more levels can be added immediately so that the fine
levels can improve the situation and quench the detonation (since they will
overwrite the coarse data at the end of the timestep).

Each AmrLevel now has a member variable post_step_regrid. To trigger a regrid
at the end of a step, but before any fine timesteps would be taken, they only need
to set this variable to one. At the beginning of every timestep, it will be reset to 0.