### PR TITLE
clrdDiffuSolve

### DIFF
--- a/Src/Base/AMReX_ParallelDescriptor.cpp
+++ b/Src/Base/AMReX_ParallelDescriptor.cpp
@@ -380,14 +380,18 @@ ParallelDescriptor::init_clr_vars()
   m_nProcs_sub = m_nProcs_comp/m_nCommColors;
   /* Remaining proc.'s */
   int const numRemProcs = m_nProcs_comp-m_nCommColors*m_nProcs_sub;
-  /* All numbers of proc.'s per color */
+  /* All numbers of proc.'s per color (clear) */
+  m_num_procs_clr.clear();
+  /* All numbers of proc.'s per color (init.) */
   m_num_procs_clr.resize(m_nCommColors,m_nProcs_sub);
   /* Distribute remaining proc.'s */
   for (int clr = 0; clr < numRemProcs; ++clr)
   {
     ++(m_num_procs_clr[clr]);
   }
-  /* All first proc.'s */
+  /* All first proc.'s (clear) */
+  m_first_procs_clr.clear();
+  /* All first proc.'s (init.) */
   m_first_procs_clr.resize(m_nCommColors,0);
   /* Add the previous `clr's `nProc's */
   for (int clr = 1; clr < m_nCommColors; ++clr)

--- a/Tools/GNUMake/sites/Make.unknown
+++ b/Tools/GNUMake/sites/Make.unknown
@@ -12,8 +12,7 @@ ifeq ($(USE_MPI),TRUE)
   F90 := mpif90
 
   # Link to MPI f90 library.
-
-  ifneq ($(findstring mpich, $(shell $(F90) -show 2>&1)),)
+  ifneq ($(findstring $(shell echo 'mpich' | tr '[:upper:]' '[:lower:]'), $(shell $(F90) -show 2>&1)),)
 
     #
     # mpich


### PR DESCRIPTION
Fixed issue with `nProcs%nColors == 0`; MPICH installation prefix can now contain `MPICH` as well