### PR TITLE
add the ability to specify a prefix to preprocessor variables

### DIFF
--- a/Src/Base/AMReX_BLBoxLib_F.f
+++ b/Src/Base/AMReX_BLBoxLib_F.f
@@ -4,7 +4,7 @@ c-----------------------------------------------------------------------
       integer NSTR
       parameter (NSTR = 128)
       integer istr(NSTR)
-      call flush(6)
+      flush(6)
       call blstr2int(istr, NSTR, str)
       call bl_error_cpp(istr, NSTR)
       end
@@ -14,7 +14,7 @@ c-----------------------------------------------------------------------
       integer NSTR
       parameter (NSTR = 128)
       integer istr(NSTR)
-      call flush(6)
+      flush(6)
       call blstr2int(istr, NSTR, str)
       call bl_warning_cpp(istr, NSTR)
       end
@@ -24,7 +24,7 @@ c-----------------------------------------------------------------------
       integer NSTR
       parameter (NSTR = 128)
       integer istr(NSTR)
-      call flush(6)
+      flush(6)
       call blstr2int(istr, NSTR, str)
       call bl_abort_cpp(istr, NSTR)
       end

--- a/Src/F_BaseLib/layout.f90
+++ b/Src/F_BaseLib/layout.f90
@@ -3530,7 +3530,7 @@ contains
           cp => cp%next
           i = i+1
        end do
-       call flush(6)
+       flush(6)
     end if
   end subroutine layout_copyassoc_print
 

--- a/Src/F_BaseLib/parallel.f90
+++ b/Src/F_BaseLib/parallel.f90
@@ -363,7 +363,7 @@ contains
        if ( (procs(i) .lt. 0) .or. (procs(i) .ge. parallel_nprocs()) ) then
           if ( parallel_IOProcessor() ) then
              print*, 'procs must be in range: [0,nprocs)'
-             call flush(6)
+             flush(6)
           end if
           call parallel_abort()
        end if

--- a/Tools/GNUMake/Make.defs
+++ b/Tools/GNUMake/Make.defs
@@ -305,7 +305,7 @@ fincludes	= $(includes)
 fmoddir         = $(objEXETempDir)
 
 CPPFLAGS	+= $(DEFINES)
-F_CPPFLAGS := $(addprefix $(CPP_PREFIX), $(CPPFLAGS))
+FINAL_CPPFLAGS := $(addprefix $(CPP_PREFIX), $(CPPFLAGS))
 
 libraries	= $(LIBRARIES) $(XTRALIBS)
 

--- a/Tools/GNUMake/Make.defs
+++ b/Tools/GNUMake/Make.defs
@@ -305,7 +305,6 @@ fincludes	= $(includes)
 fmoddir         = $(objEXETempDir)
 
 CPPFLAGS	+= $(DEFINES)
-FINAL_CPPFLAGS := $(addprefix $(CPP_PREFIX), $(CPPFLAGS))
 
 libraries	= $(LIBRARIES) $(XTRALIBS)
 

--- a/Tools/GNUMake/Make.rules
+++ b/Tools/GNUMake/Make.rules
@@ -10,6 +10,8 @@ vpath %.cpp  $(FINAL_VPATH_LOCATIONS)
 vpath %.h    $(FINAL_VPATH_LOCATIONS)
 vpath %.H    $(FINAL_VPATH_LOCATIONS)
 
+FINAL_CPPFLAGS := $(addprefix $(CPP_PREFIX), $(CPPFLAGS))
+
 # Suppress display of executed commands.  Default verbose
 SILENT =
 ifeq ($(VERBOSE),OFF)

--- a/Tools/GNUMake/Make.rules
+++ b/Tools/GNUMake/Make.rules
@@ -23,7 +23,7 @@ endif
 #
 $(executable):	$(objForExecs)
 	@echo Linking $@ ...
-	$(SILENT) $(CXX) $(CXXFLAGS) $(CPPFLAGS) $(includes) $(LDFLAGS) -o $@ $^ $(libraries)
+	$(SILENT) $(CXX) $(CXXFLAGS) $(FINAL_CPPFLAGS) $(includes) $(LDFLAGS) -o $@ $^ $(libraries)
 #	@echo SUCCESS
 
 
@@ -64,7 +64,7 @@ install_fortran_modules:
 $(amrexIncludeDir)/AMReX_Config.H: FORCE
 	@echo Generating AMReX_config.H ...
 	@if [ ! -d $(amrexIncludeDir) ]; then mkdir -p $(amrexIncludeDir); fi
-	@ $(MKCONFIG) --defines "$(CPPFLAGS)" --undefine "BL_LANG_FORT" \
+	@ $(MKCONFIG) --defines "$(FINAL_CPPFLAGS)" --undefine "BL_LANG_FORT" \
 	              --comp "$(lowercase_comp)" \
 	              --allow-different-compiler "$(ALLOW_DIFFERENT_COMP)" \
 	              --use-omp "$(USE_OMP)" \
@@ -141,7 +141,7 @@ $(objEXETempDir)/%.o: %.f90
 $(objEXETempDir)/%.o: %.F90
 	@echo Compiling $*.F90 ...
 	@if [ ! -d $(objEXETempDir) ]; then mkdir -p $(objEXETempDir); fi
-	$(SILENT) $(F90CACHE) $(F90) $(F90FLAGS) -DBL_LANG_FORT $(CPPFLAGS) $(fincludes) -c $< $(FORT_EXE_OUTPUT_OPTION)
+	$(SILENT) $(F90CACHE) $(F90) $(F90FLAGS) $(CPP_PREFIX)-DBL_LANG_FORT $(FINAL_CPPFLAGS) $(fincludes) -c $< $(FORT_EXE_OUTPUT_OPTION)
 
 #
 # Rules for dependencies in bare object files.
@@ -235,7 +235,7 @@ $(tmpEXETempDir)/%.f90.orig: %.f90
 
 $(tmpEXETempDir)/%.F90.orig: %.F90
 	@if [ ! -d $(tmpEXETempDir) ]; then mkdir -p $(tmpEXETempDir); fi
-	$(SILENT) $(F90) $(F90FLAGS) -DBL_LANG_FORT $(CPPFLAGS) $(fincludes) -fsyntax-only -fdump-fortran-original $< > $@
+	$(SILENT) $(F90) $(F90FLAGS) $(CPP_PREFIX)-DBL_LANG_FORT $(FINAL_CPPFLAGS) $(fincludes) -fsyntax-only -fdump-fortran-original $< > $@
 
 $(tmpEXETempDir)/%.f.orig: %.f
 	@if [ ! -d $(tmpEXETempDir) ]; then mkdir -p $(tmpEXETempDir); fi
@@ -243,13 +243,13 @@ $(tmpEXETempDir)/%.f.orig: %.f
 
 $(tmpEXETempDir)/%.F.orig: %.F
 	@if [ ! -d $(tmpEXETempDir) ]; then mkdir -p $(tmpEXETempDir); fi
-	$(SILENT) $(F90) $(FFLAGS) -DBL_LANG_FORT $(CPPFLAGS) $(fincludes) -fsyntax-only -fdump-fortran-original $< > $@
+	$(SILENT) $(F90) $(FFLAGS) $(CPP_PREFIX)-DBL_LANG_FORT $(FINAL_CPPFLAGS) $(fincludes) -fsyntax-only -fdump-fortran-original $< > $@
 
 # fix amrex::Real and amrex_real
 # & --> *
 $(tmpEXETempDir)/%-cppd.h: %.H
 	@if [ ! -d $(tmpEXETempDir) ]; then mkdir -p $(tmpEXETempDir); fi
-	$(SILENT) $(CC) $(CPPFLAGS) $(includes) -E -P -x c -std=c99 $< -o $@
+	$(SILENT) $(CC) $(FINAL_CPPFLAGS) $(includes) -E -P -x c -std=c99 $< -o $@
 	@$(SHELL) -ec 'sed -i -e '\''s/amrex::Real/$(amrex_real)/g'\'' $@ ; \
 	               sed -i -e '\''s/amrex_real/$(amrex_real)/g'\''  $@ ; \
 	               sed -i -e '\''/typedef\s*$(amrex_real)/d'\''    $@ ; \
@@ -315,13 +315,13 @@ print-%:
 .PHONY: help
 help:
 	@echo ""
-	@echo "The rule for compiling foo.cpp  is: \$$(CXX) \$$(CXXFLAGS) \$$(CPPFLAGS) \$$(includes) -c foo.o foo.cpp"
-	@echo "The rule for compiling foo.c    is: \$$(CC) \$$(CFLAGS) \$$(CPPFLAGS) \$$(includes) -c foo.o foo.c"
+	@echo "The rule for compiling foo.cpp  is: \$$(CXX) \$$(CXXFLAGS) \$$(FINAL_CPPFLAGS) \$$(includes) -c foo.o foo.cpp"
+	@echo "The rule for compiling foo.c    is: \$$(CC) \$$(CFLAGS) \$$(FINAL_CPPFLAGS) \$$(includes) -c foo.o foo.c"
 	@echo "The rule for compiling foo.f90  is: \$$(F90) \$$(F90FLAGS) \$$(fincludes) -c foo.o foo.f90"
-	@echo "The rule for compiling foo.F90  is: \$$(F90) \$$(F90FLAGS) \$$(CPPFLAGS) \$$(fincludes) -c foo.o foo.F90"
+	@echo "The rule for compiling foo.F90  is: \$$(F90) \$$(F90FLAGS) \$$(FINAL_CPPFLAGS) \$$(fincludes) -c foo.o foo.F90"
 	@echo "The rule for compiling foo.[fF] is: \$$(FC) \$$(FFLAGS) \$$(fincludes) -c foo.o foo.f"
 	@echo "    Note that .F files are preprocessed with cpp into .f files before being compiled."
-	@echo "The rule for linking            is: \$$(CXX) \$$(CXXFLAGS) \$$(CPPFLAGS) \$$(includes) \$$(LDFLAGS) -o \$$(executable) *.o \$$(libraries)"
+	@echo "The rule for linking            is: \$$(CXX) \$$(CXXFLAGS) \$$(FINAL_CPPFLAGS) \$$(includes) \$$(LDFLAGS) -o \$$(executable) *.o \$$(libraries)"
 	@echo ""
 	@echo "Here the variables are set to:"
 	@echo "    CXX        = $(CXX)"
@@ -329,7 +329,7 @@ help:
 	@echo "    FC         = $(FC)"
 	@echo "    F90        = $(F90)"
 	@echo "    CPPFLAGS   = $(CPPFLAGS)"
-	@echo "    CPPFLAGS   = $(CPPFLAGS)"
+	@echo "    FINAL_CPPFLAGS   = $(FINAL_CPPFLAGS)"
 	@echo "    CXXFLAGS   = $(CXXFLAGS)"
 	@echo "    CFLAGS     = $(CFLAGS)"
 	@echo "    includes   = $(includes)"

--- a/Tools/GNUMake/comps/ibm.mak
+++ b/Tools/GNUMake/comps/ibm.mak
@@ -69,3 +69,7 @@ FFLAGS   += $(GENERIC_COMP_FLAGS)
 F90FLAGS += $(GENERIC_COMP_FLAGS)
 
 CPP_PREFIX = -WF,
+
+override XTRALIBS += -L $(OLCF_XLF_ROOT)/lib -lxlf90 -lm  -lxlfmath
+
+FORTLINK := LOWERCASE

--- a/Tools/GNUMake/comps/ibm.mak
+++ b/Tools/GNUMake/comps/ibm.mak
@@ -70,6 +70,7 @@ F90FLAGS += $(GENERIC_COMP_FLAGS)
 
 CPP_PREFIX = -WF,
 
-override XTRALIBS += -L $(OLCF_XLF_ROOT)/lib -lxlf90 -lm  -lxlfmath
+#override XTRALIBS += 
+override XTRALIBS = $(shell mpifort -showme:link) -L $(OLCF_XLF_ROOT)/lib -lxlf90_r -lm  -lxlfmath
 
 FORTLINK := LOWERCASE

--- a/Tools/GNUMake/comps/ibm.mak
+++ b/Tools/GNUMake/comps/ibm.mak
@@ -48,7 +48,7 @@ endif
 ########################################################################
 
 CXXFLAGS += -std=c++1y
-CFLAGS   += -std=c99
+CFLAGS   += -std=gnu99
 F90FLAGS += -qlanglvl=extended -qxlf2003=polymorphic
 
 FFLAGS   += -qmoddir=$(fmoddir) -I $(fmoddir)


### PR DESCRIPTION
With IBM XL compilers, preprocessor variables in Fortran need to be of the form -WF,-DNAME=VALUE.  These changes allow a compiler to define the prefix for Fortran (e.g. -WF,).

Also, change `call flush(6)` to `flush(6)` as permitted in the Fortran 2003 standard.  This is needed for linking with IBM.