### PR TITLE
Do not use hardcoded numbers for real kinds

### DIFF
--- a/Src/Base/AMReX_mempool_f.f90
+++ b/Src/Base/AMReX_mempool_f.f90
@@ -7,7 +7,7 @@ module mempool_module
 
   implicit none
 
-  integer, parameter, private :: c_real = 8
+  integer, parameter, private :: c_real = kind(0d0)
 
   ! We could/should use Fortran 2008 c_sizeof here.
   integer (kind=c_size_t), parameter, private :: szr = c_real


### PR DESCRIPTION
Such numbers are compiler specific. In particular, the NAG compiler fails to
compile this line. One must use some platform independent way to get the real
kind. In this case, the number 8 means double precision in gfortran, so I have
changed it to kind(0d0) where 0d0 is a double precision number, and kind()
returns the proper kind on all platforms. Now this line compiles with NAG.