### PR TITLE
Compare real kinds directly

### DIFF
--- a/Src/F_Interfaces/Base/AMReX_parallel_mod.F90
+++ b/Src/F_Interfaces/Base/AMReX_parallel_mod.F90
@@ -89,9 +89,9 @@ contains
     end if
     call MPI_Comm_Size(m_comm, m_nprocs, ierr)
     call MPI_Comm_Rank(m_comm, m_myproc, ierr)
-    if (c_sizeof(amrex_real) .eq. c_sizeof(c_double)) then
+    if (amrex_real == c_double) then
        amrex_mpi_real = MPI_DOUBLE_PRECISION
-    else if (c_sizeof(amrex_real) .eq. c_sizeof(c_float)) then
+    else if (amrex_real == c_float) then
        amrex_mpi_real = MPI_REAL
     else
        call amrex_abort("amrex_parallel_init: size of amrex_real is unknown")


### PR DESCRIPTION
In order to determine if the real kinds are equal, one can just compare them
directly, they are just integers. This is simpler, and also allows these lines
to be compiled with NAG. For some reason NAG does not seem to have `c_sizeof()`
as part of the `iso_c_binding` module and so it fails on these lines. This
commit fixes it.