### PR TITLE
NAG crash workaround

### DIFF
--- a/Src/F_Interfaces/AmrCore/AMReX_tagbox_mod.F90
+++ b/Src/F_Interfaces/AmrCore/AMReX_tagbox_mod.F90
@@ -40,10 +40,10 @@ contains
     this%p = p
   end subroutine amrex_tagboxarray_install
 
-  function amrex_tagboxarray_dataPtr (this, mfi) result(dp)
+  subroutine amrex_tagboxarray_dataPtr (this, mfi, dp)
     class(amrex_tagboxarray) :: this
     type(amrex_mfiter), intent(in) :: mfi
-    character(c_char), contiguous, pointer, dimension(:,:,:,:) :: dp
+    character(c_char), contiguous, pointer, dimension(:,:,:,:), intent(out) :: dp
     type(c_ptr) :: cp
     character(c_char), contiguous, pointer :: fp(:,:,:,:)
     integer(c_int) :: n(4)
@@ -53,6 +53,6 @@ contains
     n(4)   = 1
     call c_f_pointer(cp, fp, shape=n)
     dp(bx%lo(1):,bx%lo(2):,bx%lo(3):,1:) => fp
-  end function amrex_tagboxarray_dataPtr
+  end subroutine amrex_tagboxarray_dataPtr
   
 end module amrex_tagbox_module


### PR DESCRIPTION
For some reason, NAG 6.1 gives the following error:

	/tmp/AMReX_tagbox_mod.024836.f90:4:3: error: expected specifier-qualifier-list before ‘__NAGf90_ChDope4’

	   ^
	/tmp/AMReX_tagbox_mod.024836.f90:1:8: error: unknown type name ‘__NAGf90_ChDope4’
	 # 1 ".../amrex/Src/F_Interfaces/AmrCore/AMReX_tagbox_mod.F90"
			^~~~~~~~~~~~~~~~
	.../amrex/Src/F_Interfaces/AmrCore/AMReX_tagbox_mod.F90:43:18: error: conflicting types for ‘amrex_tagbox_module_MP_amrex_tagboxarray_dataptr’
	   function amrex_tagboxarray_dataPtr (this, mfi) result(dp)
					  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
	/tmp/AMReX_tagbox_mod.024836.f90:1:25: note: previous declaration of ‘amrex_tagbox_module_MP_amrex_tagboxarray_dataptr’ was here
	 # 1 ".../amrex/Src/F_Interfaces/AmrCore/AMReX_tagbox_mod.F90"
							 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
	.../amrex/Tools/GNUMake/Make.rules:147: recipe for target 'tmp_build_dir/o/2d.gnu.MPI.EXE/AMReX_tagbox_mod.o' failed

And it looks like it crashes due to the combination of returning the `dp` array
from the function and adding the function as a method of the class. One simple
workaround is just:

	-     procedure :: dataPtr       => amrex_tagboxarray_dataptr
	+!     procedure :: dataPtr       => amrex_tagboxarray_dataptr

But a better workaround implemented in this commit is to return the `dp` array as an `intent(out)` argument. Then everything seems to work.