### PR TITLE
[WIP] Add GNUmakefile support for the NAG Fortran compiler

### DIFF
--- a/Tools/GNUMake/Make.defs
+++ b/Tools/GNUMake/Make.defs
@@ -156,8 +156,11 @@ else ifeq ($(lowercase_comp),$(filter $(lowercase_comp),llvm clang clang++))
   lowercase_comp = llvm
   $(info Loading $(AMREX_HOME)/Tools/GNUMake/comps/llvm.mak...)
   include        $(AMREX_HOME)/Tools/GNUMake/comps/llvm.mak
+else ifeq ($(lowercase_comp),nag)
+  $(info Loading $(AMREX_HOME)/Tools/GNUMake/comps/nag.mak...)
+  include        $(AMREX_HOME)/Tools/GNUMake/comps/nag.mak
 else
-  $(error Unknown compiler $(COMP). Supported compilers are gnu, intel, cray, pgi, ibm, and llvm)
+  $(error Unknown compiler $(COMP). Supported compilers are gnu, intel, cray, pgi, ibm, llvm, and nag)
 endif
 
 ifeq ($(MAKECMDGOALS),check_fortran)

--- a/Tools/GNUMake/comps/nag.mak
+++ b/Tools/GNUMake/comps/nag.mak
@@ -1,0 +1,90 @@
+#
+# Generic setup for using NAG
+#
+CXX = g++
+CC  = gcc
+FC  = nagfor
+F90 = nagfor
+
+CXXFLAGS =
+CFLAGS   =
+FFLAGS   =
+F90FLAGS =
+
+########################################################################
+
+gcc_version       := $(shell $(CXX) -dumpversion | head -1 | sed -e 's;.*  *;;')
+gcc_major_version := $(shell $(CXX) -dumpversion | head -1 | sed -e 's;.*  *;;' | sed -e 's;\..*;;')
+gcc_minor_version := $(shell $(CXX) -dumpversion | head -1 | sed -e 's;.*  *;;' | sed -e 's;[^.]*\.;;' | sed -e 's;\..*;;')
+
+COMP_VERSION := $(gcc_version)
+
+DEFINES += -DBL_GCC_VERSION='$(gcc_version)'
+DEFINES += -DBL_GCC_MAJOR_VERSION=$(gcc_major_version)
+DEFINES += -DBL_GCC_MINOR_VERSION=$(gcc_minor_version)
+
+########################################################################
+
+ifeq ($(DEBUG),TRUE)
+
+  CXXFLAGS += -g -O0 -fno-inline -ggdb -Wall -Wno-sign-compare -ftrapv
+  CFLAGS   += -g -O0 -fno-inline -ggdb -Wall -Wno-sign-compare -ftrapv
+
+  FFLAGS   += -g -O0 -nan -C
+  F90FLAGS += -g -O0 -nan -C
+
+else
+
+  CXXFLAGS += -g -O3
+  CFLAGS   += -g -O3
+  FFLAGS   += -g -O3
+  F90FLAGS += -g -O3
+
+endif
+
+
+ifeq ($(USE_GPROF),TRUE)
+
+  CXXFLAGS += -pg
+  CFLAGS += -pg
+  FFLAGS += -pg
+  F90FLAGS += -pg
+
+endif
+
+########################################################################
+
+ifeq ($(gcc_major_version),4)
+  CXXFLAGS += -std=c++11
+else ifeq ($(gcc_major_version),5)
+  CXXFLAGS += -std=c++14
+endif
+CFLAGS     += -std=gnu99
+
+FFLAGS   += -mismatch -mdir $(fmoddir) -I $(fmoddir)
+F90FLAGS += -mismatch -mdir $(fmoddir) -I $(fmoddir) -u
+
+########################################################################
+
+GENERIC_COMP_FLAGS =
+GENERIC_FORT_FLAGS =
+
+ifeq ($(THREAD_SANITIZER),TRUE)
+  GENERIC_COMP_FLAGS += -fsanitize=thread
+endif
+ifeq ($(FSANITIZER),TRUE)
+  GENERIC_COMP_FLAGS += -fsanitize=address -fsanitize=undefined
+endif
+
+ifeq ($(USE_OMP),TRUE)
+  GENERIC_COMP_FLAGS += -fopenmp
+  GENERIC_FORT_FLAGS += -openmp
+endif
+
+CXXFLAGS += $(GENERIC_COMP_FLAGS)
+CFLAGS   += $(GENERIC_COMP_FLAGS)
+FFLAGS   += $(GENERIC_FORT_FLAGS)
+F90FLAGS += $(GENERIC_FORT_FLAGS)
+
+########################################################################
+

--- a/Tools/libamrex/configure.py
+++ b/Tools/libamrex/configure.py
@@ -29,7 +29,7 @@ def configure(argv):
                         default="no")
     parser.add_argument("--comp",
                         help="Compiler [default=gnu]",
-                        choices=["gnu","intel","cray","pgi","llvm"],
+                        choices=["gnu","intel","cray","pgi","llvm","nag"],
                         default="gnu")
     parser.add_argument("--debug",
                         help="Debug build [default=no]",

--- a/Tools/libamrex/mkconfig.py
+++ b/Tools/libamrex/mkconfig.py
@@ -25,7 +25,7 @@ def doit(defines, undefines, comp, allow_diff_comp, use_omp):
 
     print("#undef",undefines)
 
-    if comp == "gnu":
+    if comp == "gnu" or comp == "nag":
         print("#ifndef __GNUC__")
         print('static_assert(false,"libamrex was built with GNU");')
         print("#endif")
@@ -72,7 +72,7 @@ if __name__ == "__main__":
                         default="")
     parser.add_argument("--comp",
                         help="compiler",
-                        choices=["gnu","intel","cray","pgi","llvm"])
+                        choices=["gnu","intel","cray","pgi","llvm","nag"])
     parser.add_argument("--allow-different-compiler",
                         help="allow an application to use a different compiler than the one used to build libamrex",
                         choices=["TRUE","FALSE"])


### PR DESCRIPTION
This PR adds "nag" as one of the compiler options for the `configure` script and adds the corresponding make includes to define compiler options, etc.  This uses gcc for the C/C++ compilers and nagfor for the Fortran compiler.