### PR TITLE
Fix character kind declarations

### DIFF
--- a/Src/Base/AMReX_error_mod.F90
+++ b/Src/Base/AMReX_error_mod.F90
@@ -13,12 +13,12 @@ module amrex_error_module
   interface
      subroutine amrex_fi_error (message) bind(c)
        import
-       character(c_char), intent(in) :: message(*)
+       character(kind=c_char), intent(in) :: message(*)
      end subroutine amrex_fi_error
 
      subroutine amrex_fi_abort (message) bind(c)
        import
-       character(c_char), intent(in) :: message(*)
+       character(kind=c_char), intent(in) :: message(*)
      end subroutine amrex_fi_abort       
   end interface
 

--- a/Src/F_BaseLib/bl_random_f.f90
+++ b/Src/F_BaseLib/bl_random_f.f90
@@ -100,7 +100,7 @@ module bl_random_module
        use, intrinsic :: iso_c_binding
        implicit none
        type(c_ptr), value :: eng
-       character(c_char), intent(in) :: name(*)
+       character(kind=c_char), intent(in) :: name(*)
      end subroutine bl_rng_save_engine_c
 
      subroutine bl_rng_copy_engine_c(eng_dst, eng_src) bind(c)
@@ -114,7 +114,7 @@ module bl_random_module
        use, intrinsic :: iso_c_binding
        implicit none
        type(c_ptr) :: eng
-       character(c_char), intent(in) :: name(*)
+       character(kind=c_char), intent(in) :: name(*)
      end subroutine bl_rng_restore_engine_c
   end interface
 
@@ -144,14 +144,14 @@ module bl_random_module
        use, intrinsic :: iso_c_binding
        implicit none
        type(c_ptr), value :: rng
-       character(c_char), intent(in) :: name(*)
+       character(kind=c_char), intent(in) :: name(*)
      end subroutine bl_rng_save_uniform_real_c
 
      subroutine bl_rng_restore_uniform_real_c(rng, name) bind(c)
        use, intrinsic :: iso_c_binding
        implicit none
        type(c_ptr) :: rng
-       character(c_char), intent(in) :: name(*)
+       character(kind=c_char), intent(in) :: name(*)
      end subroutine bl_rng_restore_uniform_real_c
   end interface
 
@@ -181,14 +181,14 @@ module bl_random_module
        use, intrinsic :: iso_c_binding
        implicit none
        type(c_ptr), value :: rng
-       character(c_char), intent(in) :: name(*)
+       character(kind=c_char), intent(in) :: name(*)
      end subroutine bl_rng_save_normal_c
 
      subroutine bl_rng_restore_normal_c(rng, name) bind(c)
        use, intrinsic :: iso_c_binding
        implicit none
        type(c_ptr) :: rng
-       character(c_char), intent(in) :: name(*)
+       character(kind=c_char), intent(in) :: name(*)
      end subroutine bl_rng_restore_normal_c
   end interface
 
@@ -218,14 +218,14 @@ module bl_random_module
        use, intrinsic :: iso_c_binding
        implicit none
        type(c_ptr), value :: rng
-       character(c_char), intent(in) :: name(*)
+       character(kind=c_char), intent(in) :: name(*)
      end subroutine bl_rng_save_poisson_c
 
      subroutine bl_rng_restore_poisson_c(rng, name) bind(c)
        use, intrinsic :: iso_c_binding
        implicit none
        type(c_ptr) :: rng
-       character(c_char), intent(in) :: name(*)
+       character(kind=c_char), intent(in) :: name(*)
      end subroutine bl_rng_restore_poisson_c
   end interface
 
@@ -256,21 +256,21 @@ module bl_random_module
        use, intrinsic :: iso_c_binding
        implicit none
        type(c_ptr), value :: rng
-       character(c_char), intent(in) :: name(*)
+       character(kind=c_char), intent(in) :: name(*)
      end subroutine bl_rng_save_binomial_c
 
      subroutine bl_rng_restore_binomial_c(rng, name) bind(c)
        use, intrinsic :: iso_c_binding
        implicit none
        type(c_ptr) :: rng
-       character(c_char), intent(in) :: name(*)
+       character(kind=c_char), intent(in) :: name(*)
      end subroutine bl_rng_restore_binomial_c
   end interface
 
 contains
 
   subroutine bl_rng_filename(filename, dirname)
-    character(c_char), pointer, intent(inout) :: filename(:)
+    character(kind=c_char), pointer, intent(inout) :: filename(:)
     character(len=*), intent(in) :: dirname
     integer :: i, n
     character(len=16) :: procname
@@ -326,7 +326,7 @@ contains
   subroutine bl_rng_save_engine(eng, dirname)
     type(bl_rng_engine), intent(in) :: eng
     character(len=*), intent(in) :: dirname
-    character(c_char), pointer :: filename(:)
+    character(kind=c_char), pointer :: filename(:)
     if (parallel_IOProcessor()) then
        call fabio_mkdir(dirname)
     end if
@@ -346,7 +346,7 @@ contains
   subroutine bl_rng_restore_engine(eng, dirname)
     type(bl_rng_engine), intent(inout) :: eng
     character(len=*), intent(in) :: dirname
-    character(c_char), pointer :: filename(:)
+    character(kind=c_char), pointer :: filename(:)
     if (c_associated(eng%p)) call bl_rng_destroy_engine(eng) 
     call bl_rng_filename(filename, dirname)
     call bl_rng_restore_engine_c(eng%p,filename)
@@ -378,7 +378,7 @@ contains
   subroutine bl_rng_save_uniform_real(rng, dirname)
     type(bl_rng_uniform_real), intent(in) :: rng
     character(len=*), intent(in) :: dirname
-    character(c_char), pointer :: filename(:)
+    character(kind=c_char), pointer :: filename(:)
     if (parallel_IOProcessor()) then
        call fabio_mkdir(dirname)
     end if
@@ -391,7 +391,7 @@ contains
   subroutine bl_rng_restore_uniform_real(rng, dirname)
     type(bl_rng_uniform_real), intent(inout) :: rng
     character(len=*), intent(in) :: dirname
-    character(c_char), pointer :: filename(:)
+    character(kind=c_char), pointer :: filename(:)
     if (c_associated(rng%p)) call bl_rng_destroy_distro(rng) 
     call bl_rng_filename(filename, dirname)
     call bl_rng_restore_uniform_real_c(rng%p,filename)
@@ -423,7 +423,7 @@ contains
   subroutine bl_rng_save_normal(rng, dirname)
     type(bl_rng_normal), intent(in) :: rng
     character(len=*), intent(in) :: dirname
-    character(c_char), pointer :: filename(:)
+    character(kind=c_char), pointer :: filename(:)
     if (parallel_IOProcessor()) then
        call fabio_mkdir(dirname)
     end if
@@ -436,7 +436,7 @@ contains
   subroutine bl_rng_restore_normal(rng, dirname)
     type(bl_rng_normal), intent(inout) :: rng
     character(len=*), intent(in) :: dirname
-    character(c_char), pointer :: filename(:)
+    character(kind=c_char), pointer :: filename(:)
     if (c_associated(rng%p)) call bl_rng_destroy_distro(rng) 
     call bl_rng_filename(filename, dirname)
     call bl_rng_restore_normal_c(rng%p,filename)
@@ -468,7 +468,7 @@ contains
   subroutine bl_rng_save_poisson(rng, dirname)
     type(bl_rng_poisson), intent(in) :: rng
     character(len=*), intent(in) :: dirname
-    character(c_char), pointer :: filename(:)
+    character(kind=c_char), pointer :: filename(:)
     if (parallel_IOProcessor()) then
        call fabio_mkdir(dirname)
     end if
@@ -481,7 +481,7 @@ contains
   subroutine bl_rng_restore_poisson(rng, dirname)
     type(bl_rng_poisson), intent(inout) :: rng
     character(len=*), intent(in) :: dirname
-    character(c_char), pointer :: filename(:)
+    character(kind=c_char), pointer :: filename(:)
     if (c_associated(rng%p)) call bl_rng_destroy_distro(rng) 
     call bl_rng_filename(filename, dirname)
     call bl_rng_restore_poisson_c(rng%p,filename)
@@ -514,7 +514,7 @@ contains
   subroutine bl_rng_save_binomial(rng, dirname)
     type(bl_rng_binomial), intent(in) :: rng
     character(len=*), intent(in) :: dirname
-    character(c_char), pointer :: filename(:)
+    character(kind=c_char), pointer :: filename(:)
     if (parallel_IOProcessor()) then
        call fabio_mkdir(dirname)
     end if
@@ -527,7 +527,7 @@ contains
   subroutine bl_rng_restore_binomial(rng, dirname)
     type(bl_rng_binomial), intent(inout) :: rng
     character(len=*), intent(in) :: dirname
-    character(c_char), pointer :: filename(:)
+    character(kind=c_char), pointer :: filename(:)
     if (c_associated(rng%p)) call bl_rng_destroy_distro(rng) 
     call bl_rng_filename(filename, dirname)
     call bl_rng_restore_binomial_c(rng%p,filename)

--- a/Src/F_BaseLib/multifab_c.f90
+++ b/Src/F_BaseLib/multifab_c.f90
@@ -82,7 +82,7 @@ contains
 
   subroutine share_multifab_with_f (mf_name, nc, ng, nd) &
        bind(c, name='share_multifab_with_f')
-    character(c_char), intent(in) :: mf_name(*)
+    character(kind=c_char), intent(in) :: mf_name(*)
     integer(c_int) , intent(in), value :: nc, ng
     integer(c_int), intent(in) :: nd(ndim)
 

--- a/Src/F_Interfaces/AmrCore/AMReX_amrcore_mod.F90
+++ b/Src/F_Interfaces/AmrCore/AMReX_amrcore_mod.F90
@@ -41,7 +41,7 @@ module amrex_amrcore_module
        integer, intent(in), value :: lev
        type(c_ptr), intent(in), value :: tags
        real(amrex_real), intent(in), value :: time
-       character(c_char), intent(in), value :: tagval, clearval
+       character(kind=c_char), intent(in), value :: tagval, clearval
      end subroutine amrex_error_est_proc
   end interface
 

--- a/Src/F_Interfaces/AmrCore/AMReX_tagbox_mod.F90
+++ b/Src/F_Interfaces/AmrCore/AMReX_tagbox_mod.F90
@@ -44,9 +44,9 @@ contains
   function amrex_tagboxarray_dataPtr (this, mfi) result(dp)
     class(amrex_tagboxarray) :: this
     type(amrex_mfiter), intent(in) :: mfi
-    character(c_char), contiguous, pointer, dimension(:,:,:,:) :: dp
+    character(kind=c_char), contiguous, pointer, dimension(:,:,:,:) :: dp
     type(c_ptr) :: cp
-    character(c_char), contiguous, pointer :: fp(:,:,:,:)
+    character(kind=c_char), contiguous, pointer :: fp(:,:,:,:)
     integer(c_int) :: n(4)
     type(amrex_box) :: bx
     call amrex_fi_tagboxarray_dataptr(this%p, mfi%p, cp, bx%lo, bx%hi)

--- a/Src/F_Interfaces/Base/AMReX_init_mod.F90
+++ b/Src/F_Interfaces/Base/AMReX_init_mod.F90
@@ -23,7 +23,7 @@ contains
        subroutine amrex_fi_init(cmd, fcomm, argpp, procpp) bind(c)
          import
          implicit none
-         character(c_char), intent(in) :: cmd(*)
+         character(kind=c_char), intent(in) :: cmd(*)
          integer, intent(in), value :: fcomm, argpp
          type(c_funptr), value, intent(in) :: procpp
        end subroutine amrex_fi_init

--- a/Src/F_Interfaces/Base/AMReX_multifab_mod.F90
+++ b/Src/F_Interfaces/Base/AMReX_multifab_mod.F90
@@ -235,7 +235,7 @@ module amrex_multifab_module
        import
        implicit none
        type(c_ptr), value :: mf
-       character(c_char), intent(in) :: name(*)
+       character(kind=c_char), intent(in) :: name(*)
      end subroutine amrex_fi_write_multifab
 
      subroutine amrex_fi_build_owner_imultifab (msk, ba, dm, data, geom) bind(c)

--- a/Src/F_Interfaces/Base/AMReX_plotfile_mod.F90
+++ b/Src/F_Interfaces/Base/AMReX_plotfile_mod.F90
@@ -17,7 +17,7 @@ module amrex_plotfile_module
      subroutine amrex_fi_write_plotfile (name, nlevs, mf, varname, geom, t, steps, rr) bind(c)
        import
        implicit none
-       character(c_char), intent(in) :: name(*)
+       character(kind=c_char), intent(in) :: name(*)
        integer(c_int), value :: nlevs
        type(c_ptr), intent(in) :: mf(*), varname(*), geom(*)
        real(amrex_real), value :: t

--- a/Tutorials/Amr/Advection_F/Source/my_amr_mod.F90
+++ b/Tutorials/Amr/Advection_F/Source/my_amr_mod.F90
@@ -218,7 +218,7 @@ contains
     integer, intent(in), value :: lev
     type(c_ptr), intent(in), value :: cp
     real(amrex_real), intent(in), value :: t
-    character(c_char), intent(in), value :: settag, cleartag
+    character(kind=c_char), intent(in), value :: settag, cleartag
 
     real(amrex_real), allocatable, save :: phierr(:)
     type(amrex_parmparse) :: pp
@@ -226,7 +226,7 @@ contains
     type(amrex_mfiter) :: mfi
     type(amrex_box) :: bx
     real(amrex_real), contiguous, pointer :: phiarr(:,:,:,:)
-    character(c_char), contiguous, pointer :: tagarr(:,:,:,:)
+    character(kind=c_char), contiguous, pointer :: tagarr(:,:,:,:)
 
     if (.not.allocated(phierr)) then
        call amrex_parmparse_build(pp, "myamr")

--- a/Tutorials/Amr/Advection_F/Source/tagging_mod.F90
+++ b/Tutorials/Amr/Advection_F/Source/tagging_mod.F90
@@ -16,9 +16,9 @@ contains
        settag, cleartag)
     integer, intent(in) :: level, lo(3), hi(3), philo(4), phihi(4), taglo(4), taghi(4)
     real(amrex_real) , intent(in   ) :: phi(philo(1):phihi(1),philo(2):phihi(2),philo(3):phihi(3))
-    character(c_char), intent(inout) :: tag(taglo(1):taghi(1),taglo(2):taghi(2),taglo(3):taghi(3))
+    character(kind=c_char), intent(inout) :: tag(taglo(1):taghi(1),taglo(2):taghi(2),taglo(3):taghi(3))
     real(amrex_real), intent(in) :: time, phierr
-    character(c_char), intent(in) :: settag, cleartag
+    character(kind=c_char), intent(in) :: settag, cleartag
 
     integer :: i,j,k
 

--- a/Tutorials/Amr/Advection_octree_F/Source/my_amr_mod.F90
+++ b/Tutorials/Amr/Advection_octree_F/Source/my_amr_mod.F90
@@ -198,7 +198,7 @@ contains
     integer, intent(in), value :: lev
     type(c_ptr), intent(in), value :: cp
     real(amrex_real), intent(in), value :: t
-    character(c_char), intent(in), value :: settag, cleartag
+    character(kind=c_char), intent(in), value :: settag, cleartag
 
     real(amrex_real), allocatable, save :: phierr(:)
     type(amrex_parmparse) :: pp
@@ -206,7 +206,7 @@ contains
     type(amrex_mfiter) :: mfi
     type(amrex_box) :: bx
     real(amrex_real), contiguous, pointer :: phiarr(:,:,:,:)
-    character(c_char), contiguous, pointer :: tagarr(:,:,:,:)
+    character(kind=c_char), contiguous, pointer :: tagarr(:,:,:,:)
 
     if (.not.allocated(phierr)) then
        call amrex_parmparse_build(pp, "myamr")

--- a/Tutorials/Amr/Advection_octree_F/Source/tagging_mod.F90
+++ b/Tutorials/Amr/Advection_octree_F/Source/tagging_mod.F90
@@ -16,9 +16,9 @@ contains
        settag, cleartag)
     integer, intent(in) :: level, lo(3), hi(3), philo(4), phihi(4), taglo(4), taghi(4)
     real(amrex_real) , intent(in   ) :: phi(philo(1):phihi(1),philo(2):phihi(2),philo(3):phihi(3))
-    character(c_char), intent(inout) :: tag(taglo(1):taghi(1),taglo(2):taghi(2),taglo(3):taghi(3))
+    character(kind=c_char), intent(inout) :: tag(taglo(1):taghi(1),taglo(2):taghi(2),taglo(3):taghi(3))
     real(amrex_real), intent(in) :: time, phierr
-    character(c_char), intent(in) :: settag, cleartag
+    character(kind=c_char), intent(in) :: settag, cleartag
 
     integer :: i,j,k
 


### PR DESCRIPTION
This replaces `character(c_char)` declarations with `character(kind=c_char)`, which is surely what was intended.  Unlike other intrinsic types, a single (unqualified) type parameter is taken as the `len` parameter for character, not `kind`.  This is a really easy error to make.  We lucked out here because with most compilers `c_char` seems to have the value 1 and the default kind is also 1.