### PR TITLE
Internal container of IntVectSet

### DIFF
--- a/Src/GeometryShop/AMReX_IntVectSet.H
+++ b/Src/GeometryShop/AMReX_IntVectSet.H
@@ -15,7 +15,7 @@
 #define __IntVectSet__H_
 
 #include "AMReX_Box.H"
-#include <set>
+#include <unordered_set>
 
 using namespace std;
 namespace amrex
@@ -49,6 +49,12 @@ namespace amrex
 
     ///
     ~IntVectSet(){;}
+
+    ///
+    IntVectSet (IntVectSet&& a_rhs) noexcept = default;
+
+    ///
+    IntVectSet& operator= (IntVectSet&& a_rhs) noexcept = default;
 
     ///
     void define(const Box&);
@@ -143,11 +149,19 @@ namespace amrex
 
     ///
     void linearIn(const void* const buffer );
-    
+
+    using container_type = std::unordered_set<IntVect, IntVect::shift_hasher>;
+    container_type::iterator begin () { return m_stdSet.begin(); }
+    container_type::const_iterator begin() const { return m_stdSet.begin(); }
+    container_type::const_iterator cbegin() const { return m_stdSet.cbegin(); }
+    container_type::iterator end () { return m_stdSet.end(); }
+    container_type::const_iterator end() const { return m_stdSet.end(); }
+    container_type::const_iterator cend() const { return m_stdSet.cend(); }
+      
   private:
 
     void getVectorIV(std::vector<IntVect>& a_vect) const;
-    std::set<IntVect, lex_compare_iv> m_stdSet;
+    container_type m_stdSet;
   };
 
   ///
@@ -182,7 +196,8 @@ namespace amrex
     void clear();
   private:
     const IntVectSet* m_ivs;
-    std::set<IntVect, lex_compare_iv>::iterator m_iter;
+//    std::set<IntVect, lex_compare_iv>::iterator m_iter;
+    IntVectSet::container_type::const_iterator m_iter;
   };
 }
 #endif //  STDSETIVS_H

--- a/Src/GeometryShop/AMReX_IntVectSet.cpp
+++ b/Src/GeometryShop/AMReX_IntVectSet.cpp
@@ -108,12 +108,7 @@ namespace amrex
   IntVectSet::
   operator|=(const IntVectSet& a_sivs)
   {
-    const std::set<IntVect, lex_compare_iv> inputset = a_sivs.m_stdSet;
-    std::set<IntVect,lex_compare_iv>::iterator it;
-    for(it = inputset.begin(); it!=  inputset.end(); ++it)
-      {
-        m_stdSet.insert(*it);
-      }
+    m_stdSet.insert(a_sivs.cbegin(), a_sivs.cend());
     return *this;
   }
   ///
@@ -142,17 +137,13 @@ namespace amrex
   {
     if(&a_sivs != this)
       {
-        std::set<IntVect, lex_compare_iv> newSet;
-        std::set<IntVect, lex_compare_iv>::iterator it;
-        for(it = m_stdSet.begin(); it != m_stdSet.end(); ++it)
-          {
-            const IntVect& iv = *it;
-            if(contains(iv) && a_sivs.contains(iv))
-              {
-                newSet.insert(iv);
-              }
-          }
-        m_stdSet = newSet;
+        std::unordered_set<IntVect, IntVect::shift_hasher> newSet;
+	for (const auto& iv : *this) {
+	    if (contains(iv) && a_sivs.contains(iv)) {
+		newSet.insert(iv);
+	    }
+	}
+	m_stdSet = std::move(newSet);
       }
     return *this;
   }
@@ -163,11 +154,8 @@ namespace amrex
   operator&=(const Box& a_box)
   {
     IntVectSet removeivs;
-    std::set<IntVect, lex_compare_iv>::iterator it;
-    for(it = m_stdSet.begin(); it!=  m_stdSet.end();  ++it)
+    for( const auto& iv : *this)
       {
-        //leaving out the ++it because  erase 
-        const IntVect& iv = *it;
         if(!a_box.contains(iv))
         {
           removeivs |= iv;
@@ -181,9 +169,8 @@ namespace amrex
   IntVectSet::
   operator-=(const IntVectSet& a_sivs)
   {
-    std::set<IntVect, lex_compare_iv>::iterator it;
     //leaving out the ++it because  erase 
-    for(it = m_stdSet.begin(); it!=  m_stdSet.end(); )
+    for(auto it = m_stdSet.begin(); it!=  m_stdSet.end(); )
       {
         if(a_sivs.contains(*it))
           {
@@ -192,8 +179,9 @@ namespace amrex
         else
           {
             ++it;
-          }
+         }
       }
+
     return *this;
   }
   ///not
@@ -223,22 +211,7 @@ namespace amrex
   IntVectSet::
   operator==(const IntVectSet& a_lhs) const
   {
-    if(a_lhs.m_stdSet.size() != m_stdSet.size())
-      {
-        return false;
-      }
-
-    bool retval = true;
-    std::set<IntVect, lex_compare_iv>::iterator it;
-    for(it = m_stdSet.begin(); it!=  m_stdSet.end(); ++it)
-      {
-        if((!contains(*it)) || (!a_lhs.contains(*it)))
-          {
-            retval = false;
-            break;
-          }
-      }
-    return retval;
+      return this->m_stdSet == a_lhs.m_stdSet;
   }
 
   ///
@@ -246,7 +219,7 @@ namespace amrex
   IntVectSet::
   contains(const IntVect& a_iv) const
   {
-    std::set<IntVect, lex_compare_iv>::iterator it = m_stdSet.find(a_iv);
+    auto it = m_stdSet.find(a_iv);
     return (it != m_stdSet.end());
   }
 
@@ -289,15 +262,13 @@ namespace amrex
   grow(int igrow)
   {
     IntVectSet newSet;
-    std::set<IntVect, lex_compare_iv>::iterator it;
-    for(it = m_stdSet.begin(); it != m_stdSet.end(); ++it)
+    for(const auto& iv : *this)
       {
-        const IntVect& iv = *it;
         Box grid(iv, iv);
         grid.grow(igrow);
         newSet |= grid;
       }
-    *this = newSet;
+    *this = std::move(newSet);
   }
 
   ///
@@ -306,15 +277,13 @@ namespace amrex
   grow(int idir, int igrow)
   {
     IntVectSet newSet;
-    std::set<IntVect, lex_compare_iv>::iterator it;
-    for(it = m_stdSet.begin(); it != m_stdSet.end(); ++it)
+    for(const auto& iv : *this)
       {
-        const IntVect& iv = *it;
         Box grid(iv, iv);
         grid.grow(idir, igrow);
         newSet |= grid;
       }
-    *this = newSet;
+    *this = std::move(newSet);
   }
 
   ///
@@ -334,15 +303,13 @@ namespace amrex
   growHi(int a_dir)
   {
     IntVectSet newSet;
-    std::set<IntVect, lex_compare_iv>::iterator it;
-    for(it = m_stdSet.begin(); it != m_stdSet.end(); ++it)
+    for(const auto& iv : *this)
       {
-        const IntVect& iv = *it;
         Box grid(iv, iv);
         grid.growHi(a_dir);
         newSet |= grid;
       }
-    *this = newSet;
+    *this = std::move(newSet);
   }
 
   ///
@@ -351,15 +318,13 @@ namespace amrex
   refine(int iref)
   {
     IntVectSet newSet;
-    std::set<IntVect, lex_compare_iv>::iterator it;
-    for(it = m_stdSet.begin(); it != m_stdSet.end(); ++it)
+    for(const auto& iv : *this)
       {
-        const IntVect& iv = *it;
         Box grid(iv, iv);
         grid.refine(iref);
         newSet |= grid;
       }
-    *this = newSet;
+    *this = std::move(newSet);
   }
 
   ///
@@ -367,16 +332,13 @@ namespace amrex
   IntVectSet::
   coarsen(int iref)
   {
-    std::set<IntVect, lex_compare_iv> newSet;
-    std::set<IntVect, lex_compare_iv>::iterator it;
-    for(it = m_stdSet.begin(); it != m_stdSet.end(); ++it)
+    container_type newSet;
+    for(auto ivcoar : *this)
       {
-        const IntVect& iv = *it;
-        IntVect ivcoar = iv;
         ivcoar.coarsen(iref);
         newSet.insert(ivcoar);
       }
-    m_stdSet = newSet;
+    m_stdSet = std::move(newSet);
   }
 
   ///
@@ -384,15 +346,13 @@ namespace amrex
   IntVectSet::
   shift(const IntVect& a_iv)
   {
-    std::set<IntVect, lex_compare_iv> newSet;
-    std::set<IntVect, lex_compare_iv>::iterator it;
-    for(it = m_stdSet.begin(); it != m_stdSet.end(); ++it)
+    container_type newSet;
+    for(auto iv : *this)
       {
-        IntVect iv = *it;
         iv.shift(a_iv);
         newSet.insert(iv);
       }
-    m_stdSet = newSet;
+    m_stdSet = std::move(newSet);
   }
 
   ///
@@ -400,8 +360,7 @@ namespace amrex
   IntVectSet::
   clear()
   {
-    std::set<IntVect, lex_compare_iv> newSet;
-    m_stdSet = newSet;
+    m_stdSet.clear();
   }
 
   ///
@@ -412,10 +371,8 @@ namespace amrex
     int bignum = 100000;
     IntVect lo = bignum*IntVect::TheUnitVector();
     IntVect hi =-bignum*IntVect::TheUnitVector();
-    std::set<IntVect, lex_compare_iv>::iterator it;
-    for(it = m_stdSet.begin(); it != m_stdSet.end(); ++it)
+    for (const auto& iv : *this)
       {
-        const IntVect& iv = *it;
         for(int idir = 0; idir < SpaceDim; idir++)
           {
             lo[idir] = std::min(lo[idir], iv[idir]);
@@ -432,7 +389,7 @@ namespace amrex
   IntVectSet::
   isEmpty() const
   {
-    return (m_stdSet.size() == 0);
+      return m_stdSet.empty();
   }
   ///
   void 
@@ -440,14 +397,7 @@ namespace amrex
   getVectorIV(std::vector<IntVect>& a_vect) const
   {
     a_vect.resize(m_stdSet.size());
-
-    std::set<IntVect, lex_compare_iv>::iterator it;
-    int ivec = 0;
-    for(it = m_stdSet.begin(); it != m_stdSet.end(); ++it)
-      {
-        a_vect[ivec] = *it;
-        ivec++;
-      }
+    std::copy(std::begin(*this), std::end(*this), std::begin(a_vect));
   }
   ///
   void 


### PR DESCRIPTION
`IntVectSet` currently uses `std::set` as its internal data container.  However, many operations of `set` have complexity of `log(N)`.   For some tests, a significant fraction of the time (e.g., 40%) is spent on `IntVectSet` operations.  This pull request changes the internal data container to `std::unordered_set`.  A test using 256^3 cells on Cori shows that the `IntVectSet` operations are more than twice faster with the new version.

