### PR TITLE
Additions to the Fortran imultifab interface

### DIFF
--- a/Src/F_Interfaces/Base/AMReX_multifab_fi.cpp
+++ b/Src/F_Interfaces/Base/AMReX_multifab_fi.cpp
@@ -150,9 +150,9 @@ extern "C" {
 
     void amrex_fi_new_imultifab (iMultiFab*& imf, const BoxArray*& ba, 
 				 const DistributionMapping*& dm,
-				 int nc, int ng)
+				 int nc, int ng, const int* nodal)
     {
-	imf = new iMultiFab(*ba, *dm, nc, ng);
+	imf = new iMultiFab(amrex::convert(*ba, IntVect(nodal)), *dm, nc, ng);
 	ba = &(imf->boxArray());
 	dm = &(imf->DistributionMap());
     }
@@ -173,6 +173,11 @@ extern "C" {
 	    lo[i] = lov[i];
 	    hi[i] = hiv[i];
 	}
+    }
+
+    void amrex_fi_imultifab_setval (iMultiFab* imf, int val, int ic, int nc, int ng)
+    {
+        imf->setVal(val, ic, nc, ng);
     }
 
     // MFIter routines

--- a/Src/F_Interfaces/Base/AMReX_multifab_mod.F90
+++ b/Src/F_Interfaces/Base/AMReX_multifab_mod.F90
@@ -77,6 +77,7 @@ module amrex_multifab_module
      procedure :: ncomp         => amrex_imultifab_ncomp
      procedure :: nghost        => amrex_imultifab_nghost
      procedure :: dataPtr       => amrex_imultifab_dataptr
+     procedure :: setval        => amrex_imultifab_setval
      procedure, private :: amrex_imultifab_assign
 #if !defined(__GFORTRAN__) || (__GNUC__ > 4)
      final :: amrex_imultifab_destroy
@@ -273,11 +274,12 @@ module amrex_multifab_module
   end interface
 
   interface
-     subroutine amrex_fi_new_imultifab (imf,ba,dm,nc,ng) bind(c)
+     subroutine amrex_fi_new_imultifab (imf,ba,dm,nc,ng,nodal) bind(c)
        import
        implicit none
        type(c_ptr) :: imf, ba, dm
        integer(c_int), value :: nc, ng
+       integer(c_int), intent(in) :: nodal(3)
      end subroutine amrex_fi_new_imultifab
      
      subroutine amrex_fi_delete_imultifab (imf) bind(c)
@@ -293,6 +295,14 @@ module amrex_multifab_module
        type(c_ptr) :: dp
        integer(c_int) :: lo(3), hi(3)
      end subroutine amrex_fi_imultifab_dataptr
+
+     subroutine amrex_fi_imultifab_setval (imf, val, ic, nc, ng) bind(c)
+       import
+       implicit none
+       type(c_ptr), value :: imf
+       integer(c_int), value :: val
+       integer(c_int), value :: ic, nc, ng
+     end subroutine amrex_fi_imultifab_setval
   end interface
 
   interface
@@ -650,17 +660,25 @@ contains
 
 !------ imultifab routines ------!
 
-  subroutine amrex_imultifab_build (imf, ba, dm, nc, ng)
+  subroutine amrex_imultifab_build (imf, ba, dm, nc, ng, nodal)
     type(amrex_imultifab) :: imf
     type(amrex_boxarray), intent(in ) :: ba
     type(amrex_distromap), intent(in ) :: dm
     integer, intent(in) :: nc, ng
+    logical, intent(in), optional :: nodal(*)
+    integer :: inodal(3), dir
     imf%owner = .true.
     imf%nc = nc
     imf%ng = ng
+    inodal = 0
+    if (present(nodal)) then
+       do dir = 1, ndims
+          if (nodal(dir)) inodal(dir) = 1
+       end do
+    end if
     imf%ba = ba
     imf%dm = dm
-    call amrex_fi_new_imultifab(imf%p, imf%ba%p, imf%dm%p, imf%nc, imf%ng)
+    call amrex_fi_new_imultifab(imf%p, imf%ba%p, imf%dm%p, imf%nc, imf%ng, inodal)
   end subroutine amrex_imultifab_build
 
   impure elemental subroutine amrex_imultifab_destroy (this)
@@ -712,6 +730,17 @@ contains
     call c_f_pointer(cp, fp, shape=n)
     dp(bx%lo(1):,bx%lo(2):,bx%lo(3):,1:) => fp
   end function amrex_imultifab_dataPtr
+
+  subroutine amrex_imultifab_setval (this, val, icomp, ncomp, nghost)
+    class(amrex_imultifab), intent(inout) :: this
+    integer, intent(in) :: val
+    integer, intent(in), optional :: icomp, ncomp, nghost
+    integer :: ic, nc, ng
+    ic = 0;         if (present(icomp))  ic = icomp-1
+    nc = this%nc;   if (present(ncomp))  nc = ncomp
+    ng = this%ng;   if (present(nghost)) ng = nghost
+    call amrex_fi_imultifab_setval(this%p, val, ic, nc, ng)
+  end subroutine amrex_imultifab_setval
 
 !------ MFIter routines ------!
 


### PR DESCRIPTION
This extends the Fortran imultifab interface to include the setval method, and adds the optional nodal argument to amrex_imultifab_build, as is defined for amrex_multifab_build.