### PR TITLE
BaseIVFAB and BaseIFFAB

### DIFF
--- a/Src/GeometryShop/AMReX_BaseIFFAB.H
+++ b/Src/GeometryShop/AMReX_BaseIFFAB.H
@@ -160,6 +160,12 @@ namespace amrex
     T& operator() (const FaceIndex& a_face,const int& varlocin);
     const T& operator()(const FaceIndex& a_face,const int& varlocin) const;
 
+    T& operator() (int a_iface, int varlocin) {
+	return *(getIndex(a_iface, varlocin));
+    }
+    const T& operator()(int a_iface, int varlocin) const {
+	return *(getIndex(a_iface, varlocin));
+    }
 
 ///
     T* dataPtr(const int& a_comp);
@@ -243,6 +249,19 @@ namespace amrex
     T* m_data;
 
     bool    m_isDefined;
+
+    int getFaceIndexIndex (const FaceIndex& a_face) const {
+	auto low = std::lower_bound(m_faces.begin(), m_faces.end(), a_face);
+	if (low == m_faces.end() || a_face != *low) {
+	    amrex::Error("BaseIFFAB:index not found");
+	}
+	return low - m_faces.begin();
+    }
+
+    T* getIndex(int ifaceindex, int a_comp) const {
+	return m_data + ifaceindex + a_comp*m_nFaces;
+    }
+
   private:
 //we disallow copy construction and assigment for data holders
     void operator= (const BaseIFFAB<T>&)

--- a/Src/GeometryShop/AMReX_BaseIFFABI.H
+++ b/Src/GeometryShop/AMReX_BaseIFFABI.H
@@ -74,6 +74,7 @@ namespace amrex
 
     FaceIterator faceit(m_ivs, a_ebgraph, m_direction, FaceStop::SurroundingWithBoundary);
     m_faces = faceit.getVector();
+    std::sort(m_faces.begin(), m_faces.end());
     m_nFaces = m_faces.size();
 
     m_data = new T[m_nComp*m_nFaces];
@@ -134,11 +135,12 @@ namespace amrex
       if ((intBox.contains(ivHi) || intBox.contains(ivLo)) &&
 	  (ivsintersect.contains(ivHi) || ivsintersect.contains(ivLo)))
       {
+	int src_ifaceindex = a_src.getFaceIndexIndex(face);
         for (int icomp = 0; icomp < a_numcomp; icomp++)
         {
           int isrccomp = a_srccomp  + icomp;
           int idstcomp = a_destcomp + icomp;
-          (*this)(face, idstcomp) = a_src(face, isrccomp);
+          (*this)(iface, idstcomp) = a_src(src_ifaceindex, isrccomp);
         }
       }
     }
@@ -166,31 +168,8 @@ namespace amrex
   {
     assert(m_isDefined);
     assert((a_comp >= 0) && (a_comp < this->m_nComp));
-
-    T* dataPtr =  this->m_data;
-    bool found = false;
-    T* retval=NULL;
-    for (int iface = 0; iface < m_faces.size(); ++iface)
-    {
-      if (a_face == m_faces[iface])
-      {
-        found = true;
-        retval=dataPtr;
-      }
-      if (found) break;
-      dataPtr++;
-    }
-    if (!found)
-    {
-      pout() << "BaseIFFAB::getIndex, index  = " << a_face << endl;
-      pout() << "my faces  = " << endl;
-      dumpFaces(m_faces);
-      
-      amrex::Error("BaseIFFAB:index not found");
-    }
-    retval += a_comp*this->m_nFaces;
-    return retval;
-
+    int ifaceindex = this->getFaceIndexIndex(a_face);
+    return this->getIndex(ifaceindex, a_comp);
   }
 /*********/
   template <class T> inline

--- a/Src/GeometryShop/AMReX_BaseIVFAB.H
+++ b/Src/GeometryShop/AMReX_BaseIVFAB.H
@@ -169,7 +169,7 @@ namespace amrex
     /**
        needs to be public so that bulk stencils can be constructed
     */
-    virtual T* getIndex(const VolIndex& a_vof,const int& a_comp) const;
+    T* getIndex(const VolIndex& a_vof,const int& a_comp) const;
 
     int numDataTypes() const
       {
@@ -217,6 +217,16 @@ namespace amrex
         return *(getIndex(a_vof, a_comp));
       }
 
+    ///
+    T& operator() (int a_ivof, int a_comp)
+      {  return *(getIndex(a_ivof, a_comp));}
+
+    ///
+    const T& operator() (int a_ivof, int a_comp) const
+      {
+        return *(getIndex(a_ivof, a_comp));
+      }
+
     int numVoFs() const;
 
     int nComp() const {return m_nComp;}
@@ -238,6 +248,18 @@ namespace amrex
     std::vector<T>  m_Memory;
     T* m_data   = nullptr;
 
+    // unfortunately, we return T*, not const T*
+    T* getIndex (int ivof, int icomp) const {
+	return m_data + ivof + icomp*m_vofs.size();
+    }
+
+    int getVolIndexIndex (const VolIndex& a_vof) const {
+	auto low = std::lower_bound(m_vofs.begin(), m_vofs.end(), a_vof);
+	if (low == m_vofs.end() || a_vof != *low) {
+	    amrex::Error("attempt to access data from vof that is not in BaseIVFAB");
+	}
+	return low - m_vofs.begin();
+    }
   };
 }
 #include "AMReX_BaseIVFABI.H"

--- a/Src/GeometryShop/AMReX_BaseIVFABI.H
+++ b/Src/GeometryShop/AMReX_BaseIVFABI.H
@@ -57,6 +57,8 @@ namespace amrex
     m_ivs = a_ivsin;
     VoFIterator vofit(a_ivsin, a_ebGraph);
     m_vofs = vofit.getVector();
+
+    std::sort(m_vofs.begin(), m_vofs.end());
     
     int nVoFs = m_vofs.size();
     
@@ -93,11 +95,12 @@ namespace amrex
       {
         if(a_src.m_ivs.contains(vof.gridIndex()))
         {
+	  int src_ivof = a_src.getVolIndexIndex(vof);
           for(int icomp = 0; icomp < a_numcomp; icomp++)
           {
             int isrc = a_srccomp + icomp;
             int idst = a_dstcomp + icomp;
-            (*this)(vof, idst) = a_src(vof, isrc);
+            (*this)(ivof, idst) = a_src(src_ivof, isrc);
           }
         }
       }
@@ -122,29 +125,10 @@ namespace amrex
   template <class T> inline
   T*
   BaseIVFAB<T>::getIndex(const VolIndex& a_vof, const int& a_comp) const
-  {
-    
+  {    
     BL_ASSERT((a_comp >= 0) && (a_comp < this->m_nComp));
-    
-    T* dataPtr =  (T*)&(this->m_data[0]);
-    int ivof = -1;
-    bool found = false;
-    for (unsigned int i=0; i<m_vofs.size(); ++i)
-    {
-      if (a_vof == m_vofs[i])
-      {
-        found = true;
-        ivof = i;
-      }
-      if(found) break;
-    }
-    if(!found)
-    {
-      amrex::Error("attempt to access data from vof that is not in BaseIVFAB");
-    }
-    dataPtr += ivof;
-    dataPtr += a_comp*m_vofs.size();
-    return dataPtr;
+    int ivof = this->getVolIndexIndex(a_vof);
+    return this->getIndex(ivof, a_comp);
   }
     
   /********************/

--- a/Src/GeometryShop/AMReX_FaceIndex.H
+++ b/Src/GeometryShop/AMReX_FaceIndex.H
@@ -89,7 +89,12 @@ namespace amrex
     ///
     /**
      */
-    bool operator== (const FaceIndex& a_facein) const;
+    bool operator== (const FaceIndex& a_facein) const {
+	return ((m_loIndex == a_facein.m_loIndex) &&
+		(m_hiIndex == a_facein.m_hiIndex) &&
+		(m_loiv == a_facein.m_loiv) &&
+		(m_hiiv == a_facein.m_hiiv));
+    }
 
     ///
     /**

--- a/Src/GeometryShop/AMReX_FaceIndex.cpp
+++ b/Src/GeometryShop/AMReX_FaceIndex.cpp
@@ -231,15 +231,6 @@ namespace amrex
   }
 
   /******************************/
-  bool FaceIndex::operator==(const FaceIndex& a_facein) const
-  {
-    return((m_loiv == a_facein.m_loiv) &&
-           (m_hiiv == a_facein.m_hiiv) &&
-           (m_loIndex == a_facein.m_loIndex) &&
-           (m_hiIndex == a_facein.m_hiIndex));
-  }
-
-  /******************************/
   bool FaceIndex::operator!=(const FaceIndex& a_facein) const
   {
     return (!(*this == a_facein));

--- a/Src/GeometryShop/AMReX_VolIndex.H
+++ b/Src/GeometryShop/AMReX_VolIndex.H
@@ -40,7 +40,10 @@ namespace amrex
 
     ///
     
-    bool operator== (const VolIndex& a_vofin) const;
+    bool operator== (const VolIndex& a_vofin) const {
+	return ((m_cellIndex == a_vofin.m_cellIndex) &&
+		(m_iv == a_vofin.m_iv));
+    }
 
     ///
     

--- a/Src/GeometryShop/AMReX_VolIndex.cpp
+++ b/Src/GeometryShop/AMReX_VolIndex.cpp
@@ -88,13 +88,6 @@ namespace amrex
   }
 
   bool
-  VolIndex::operator== (const VolIndex& a_vofin) const
-  {
-    return ((m_iv == a_vofin.m_iv)&&
-            (m_cellIndex == a_vofin.m_cellIndex));
-  }
-
-  bool
   VolIndex::operator!=(const VolIndex& rhs) const
   {
     return !(*this == rhs);


### PR DESCRIPTION
Changes were made to function `getIndex`.  The `IntVect` vector is now sorted.  This allows us to access the data given an `IntVect` with binary search instead of linear search.

Also note the `virtual` keyword is removed from `BaseIVFAB::getIndex`.  It seems that it does not need to be virtual.  If I am wrong, let me know.  I will put `virtual` back.

