### PR TITLE
Print build target on Cray

### DIFF
--- a/Tools/GNUMake/Make.rules
+++ b/Tools/GNUMake/Make.rules
@@ -32,6 +32,10 @@ else
 endif
 #	@echo SUCCESS
 
+ifdef CRAY_CPU_TARGET
+	@echo "Built for target ===> $(CRAY_CPU_TARGET) <==="
+endif
+
 ifeq ($(USE_PROFPARSER),TRUE)
 BLProfParser.tab.H BLProfParser.tab.cpp: $(AMREX_HOME)/Src/Extern/ProfParser/BLProfParser.y
 	cat $(AMREX_HOME)/Src/Extern/ProfParser/BLProfParser.y $(SED0) $(SED1) > BLProfParserNC.y


### PR DESCRIPTION
AMReX does not have separate compiler flags for different architectures on Cray
systems, e.g., separate compile flags for AVX2 vs. AVX-512 instructions. The
user is responsible for choosing the correct build target, via the
"craype-<arch>" modules. To make clear which target the user is compiling for,
print the target at link time.