### PR TITLE
GNUMake: remove links to FCVODE, the old Fortran wrapper to CVODE

### DIFF
--- a/Tools/GNUMake/packages/Make.cvode
+++ b/Tools/GNUMake/packages/Make.cvode
@@ -7,6 +7,5 @@ CPPFLAGS += -DUSE_CVODE
 
 CVODE_LIB_DIR ?= $(HOME)/cvode/lib
 
-LIBRARIES += -L$(CVODE_LIB_DIR) -lsundials_fcvode
 LIBRARIES += -L$(CVODE_LIB_DIR) -lsundials_cvode
-LIBRARIES += -L$(CVODE_LIB_DIR) -lsundials_fnvecserial -lsundials_nvecserial
+LIBRARIES += -L$(CVODE_LIB_DIR) -lsundials_nvecserial


### PR DESCRIPTION
FCVODE comes with CVODE and provides a Fortran interface to the CVODE library,
but is not thread-safe. Recently the SUNDIALS developers provided us with a
Fortran 2003 interface to CVODE which uses iso_c_binding to most of the
functions in the library. So remove the links to the old FCVODE library since
we don't need it anymore.