### PR TITLE
GNUMake: update the env var pointing to the VTune directory at NERSC

### DIFF
--- a/Tools/GNUMake/tools/Make.vtune
+++ b/Tools/GNUMake/tools/Make.vtune
@@ -34,8 +34,8 @@ ifeq ($(lowercase_comp),intel)
     # periodically.
     ifeq ($(USE_ITTNOTIFY),TRUE)
       DEFINES += -DITTNOTIFY
-      INCLUDE_LOCATIONS += $(VTUNE_AMPLIFIER_XE_2016_DIR)/include
-      LIBRARY_LOCATIONS += $(VTUNE_AMPLIFIER_XE_2016_DIR)/lib64
+      INCLUDE_LOCATIONS += $(VTUNE_AMPLIFIER_XE_2017_DIR)/include
+      LIBRARY_LOCATIONS += $(VTUNE_AMPLIFIER_XE_2017_DIR)/lib64
       LIBRARIES +=  -littnotify
     
     	# Intel Software Development Emulator (SDE) is a tool we use to count


### PR DESCRIPTION
The default version at NERSC is now VTune 2017, so we need to update this
environment variable or else compiling will fail.