### PR TITLE
Base: add support for querying Process Management Interface (PMI)

### DIFF
--- a/Src/Base/AMReX.cpp
+++ b/Src/Base/AMReX.cpp
@@ -256,6 +256,10 @@ amrex::Initialize (int& argc, char**& argv, bool build_parm_parse,
 {
     ParallelDescriptor::StartParallel(&argc, &argv, mpi_comm);
 
+#ifdef PMI
+    ParallelDescriptor::PMI_Initialize();
+#endif
+
     //
     // Make sure to catch new failures.
     //

--- a/Src/Base/AMReX.cpp
+++ b/Src/Base/AMReX.cpp
@@ -256,7 +256,7 @@ amrex::Initialize (int& argc, char**& argv, bool build_parm_parse,
 {
     ParallelDescriptor::StartParallel(&argc, &argv, mpi_comm);
 
-#ifdef PMI
+#ifdef AMREX_PMI
     ParallelDescriptor::PMI_Initialize();
 #endif
 

--- a/Src/Base/AMReX_ParallelDescriptor.H
+++ b/Src/Base/AMReX_ParallelDescriptor.H
@@ -27,6 +27,10 @@
 #include <AMReX_Lazy.H>
 #endif
 
+#ifdef PMI
+#include <pmi.h>
+#endif
+
 #include <iostream>
 #include <vector>
 #include <string>
@@ -846,6 +850,13 @@ namespace ParallelDescriptor
 			  const MPI_Comm &comm = Communicator() );
     void IProbe(int src_pid, int tag, int &mflag, MPI_Status &status);
     void IProbe(int src_pid, int tag, MPI_Comm comm, int &mflag, MPI_Status &status);
+
+    // PMI = Process Management Interface, available on Crays. Provides API to
+    // query topology of the job.
+#ifdef PMI
+    void PMI_Initialize();
+    void PMI_PrintMeshcoords(const pmi_mesh_coord_t *pmi_mesh_coord);
+#endif
 }
 }
 

--- a/Src/Base/AMReX_ParallelDescriptor.H
+++ b/Src/Base/AMReX_ParallelDescriptor.H
@@ -27,7 +27,7 @@
 #include <AMReX_Lazy.H>
 #endif
 
-#ifdef PMI
+#ifdef AMREX_PMI
 #include <pmi.h>
 #endif
 
@@ -853,7 +853,7 @@ namespace ParallelDescriptor
 
     // PMI = Process Management Interface, available on Crays. Provides API to
     // query topology of the job.
-#ifdef PMI
+#ifdef AMREX_PMI
     void PMI_Initialize();
     void PMI_PrintMeshcoords(const pmi_mesh_coord_t *pmi_mesh_coord);
 #endif

--- a/Src/Base/AMReX_ParallelDescriptor.cpp
+++ b/Src/Base/AMReX_ParallelDescriptor.cpp
@@ -20,7 +20,7 @@
 #include <AMReX_ccse-mpi.H>
 #endif
 
-#ifdef PMI
+#ifdef AMREX_PMI
 #include <pmi.h>
 #include <unordered_set>
 #endif
@@ -176,7 +176,7 @@ namespace ParallelDescriptor
     typedef std::list<ParallelDescriptor::PTR_TO_SIGNAL_HANDLER> SH_LIST;
     SH_LIST The_Signal_Handler_List;
 
-#ifdef PMI
+#ifdef AMREX_PMI
     void PMI_Initialize()
     {
       int pmi_nid;

--- a/Src/Base/AMReX_ParallelDescriptor.cpp
+++ b/Src/Base/AMReX_ParallelDescriptor.cpp
@@ -256,6 +256,7 @@ namespace ParallelDescriptor
       std::unordered_set<unsigned short> PMI_y_meshcoord(all_y_meshcoords, all_y_meshcoords + ParallelDescriptor::NProcsAll());
       std::unordered_set<unsigned short> PMI_z_meshcoord(all_z_meshcoords, all_z_meshcoords + ParallelDescriptor::NProcsAll());
 
+      amrex::Print() << "PMI statistics:" << std::endl;
       amrex::Print() << "# of unique groups: " << PMI_x_meshcoord.size() << std::endl;
       amrex::Print() << "# of unique chassis: " << PMI_y_meshcoord.size() << std::endl;
       amrex::Print() << "# of unique slots: " << PMI_z_meshcoord.size() << std::endl;

--- a/Tools/GNUMake/Make.defs
+++ b/Tools/GNUMake/Make.defs
@@ -91,7 +91,7 @@ else
 endif
 
 ifeq ($(USE_PMI), TRUE)
-  DEFINES += -DPMI
+  DEFINES += -DAMREX_PMI
 endif
 
 ifdef USE_UPCXX

--- a/Tools/GNUMake/Make.defs
+++ b/Tools/GNUMake/Make.defs
@@ -90,6 +90,10 @@ else
   USE_MPI := FALSE
 endif
 
+ifeq ($(USE_PMI), TRUE)
+  DEFINES += -DPMI
+endif
+
 ifdef USE_UPCXX
   USE_UPCXX := $(strip $(USE_UPCXX))
 else


### PR DESCRIPTION
PMI is available on Cray systems and provides information about the topology of
the job on the network. One can use this information to apply optimizations at
run time which exploit higher bandwidth, lower-latency connections between
particular groups of processes on the network.

PMI support is disabled by default, and can be activated by setting
USE_PMI=TRUE in the makefile.