### PR TITLE
if we are doing `print-`, then don't do dependency checking

### DIFF
--- a/Tools/GNUMake/Make.rules
+++ b/Tools/GNUMake/Make.rules
@@ -295,7 +295,7 @@ ifneq ($(MAKECMDGOALS),realclean)
 ifneq ($(MAKECMDGOALS),clean)
 ifneq ($(MAKECMDGOALS),uninstall)
 ifneq ($(MAKECMDGOALS),distclean)
-
+ifneq ($(findstring print-,$(MAKECMDGOALS)),print-)
 ifdef CEXE_sources
 -include $(CEXE_sources:%.cpp=$(depEXETempDir)/%.d)
 endif
@@ -316,6 +316,7 @@ ifneq "$(strip $(f90EXE_sources) $(F90EXE_sources))" ""
 include $(depEXETempDir)/f90.depends
 endif
 
+endif
 endif
 endif
 endif


### PR DESCRIPTION
don't do dependency checking for `make print-*`

closes #155 