### PR TITLE
Add argument intent for pure subroutine required by F2003

### DIFF
--- a/Src/F_Interfaces/Base/AMReX_boxarray_mod.F90
+++ b/Src/F_Interfaces/Base/AMReX_boxarray_mod.F90
@@ -96,7 +96,7 @@ module amrex_boxarray_module
      pure subroutine amrex_fi_boxarray_nodal_type (ba, inodal) bind(c)
        import
        implicit none
-       type(c_ptr), value :: ba
+       type(c_ptr), value, intent(in) :: ba
        integer, intent(inout) :: inodal(3)
      end subroutine amrex_fi_boxarray_nodal_type
   end interface


### PR DESCRIPTION
The original code is correct for F2008, but not for F2003.  Apparently neither the Intel nor NAG compilers support  this F2008 feature yet, as they both give an error for the declaration of this pure subroutine interface.  (But gfortran does.)

F2003: (C1267) The specification-part of a pure subroutine subprogram shall specify the intents of all its non-pointer dummy data objects.

F2008: (C1277) The specification-part of a pure subroutine subprogram shall specify the intents of all its non-pointer dummy data objects that do not have the VALUE attribute.