### PR TITLE
Use amrex_constants_module in amrex_filcc_3d; trivial nag fix

### DIFF
--- a/Src/Base/AMReX_FILCC_3D.F90
+++ b/Src/Base/AMReX_FILCC_3D.F90
@@ -4,7 +4,6 @@
 #define BL_LANG_FORT
 #endif
 
-#include "AMReX_CONSTANTS.H"
 #include "AMReX_BC_TYPES.H"
 
 ! ::: -----------------------------------------------------------
@@ -53,6 +52,7 @@ end subroutine filcc
 subroutine hoextraptocc(q,q_l1,q_l2,q_l3,q_h1,q_h2,q_h3,domlo,domhi,dx,xlo)
 
   use amrex_fort_module, only: rt => amrex_real
+  use amrex_constants_module
 
   implicit none
 

--- a/Src/Base/AMReX_filcc_mod.F90
+++ b/Src/Base/AMReX_filcc_mod.F90
@@ -108,11 +108,11 @@ contains
 
     integer,          intent(in   ) :: lo(3), hi(3)
     integer,          intent(in   ) :: q_lo(3), q_hi(3)
+    integer,          intent(in   ) :: ncomp
     integer,          intent(in   ) :: domlo(amrex_spacedim), domhi(amrex_spacedim)
     real(amrex_real), intent(in   ) :: xlo(amrex_spacedim), dx(amrex_spacedim)
     real(amrex_real), intent(inout) :: q(q_lo(1):q_hi(1),q_lo(2):q_hi(2),q_lo(3):q_hi(3),ncomp)
     integer,          intent(in   ) :: bc(amrex_spacedim,2,ncomp)
-    integer,          intent(in   ) :: ncomp
 
     integer :: ilo, ihi, jlo, jhi, klo, khi
     integer :: is, ie, js, je, ks, ke


### PR DESCRIPTION
Two minor changes to get the development branch working again with the NAG compiler.