### PR TITLE
Use amrex_constants_module in amrex_filcc_2d

### DIFF
--- a/Src/Base/AMReX_FILCC_1D.F90
+++ b/Src/Base/AMReX_FILCC_1D.F90
@@ -5,7 +5,6 @@
 #endif
 
 #include "AMReX_REAL.H"
-#include "AMReX_CONSTANTS.H"
 #include "AMReX_BC_TYPES.H"
 
 #define SDIM 1

--- a/Src/Base/AMReX_FILCC_2D.F90
+++ b/Src/Base/AMReX_FILCC_2D.F90
@@ -5,7 +5,6 @@
 #endif
 
 #include "AMReX_REAL.H"
-#include "AMReX_CONSTANTS.H"
 #include "AMReX_BC_TYPES.H"
 
 #define SDIM 2
@@ -50,6 +49,8 @@ subroutine filcc(q,q_l1,q_l2,q_h1,q_h2,domlo,domhi,dx,xlo,bc)
 end subroutine filcc
 
 subroutine hoextraptocc(q,q_l1,q_l2,q_h1,q_h2,domlo,domhi,dx,xlo)
+
+  use amrex_constants_module
 
   implicit none
 


### PR DESCRIPTION
I missed this in my initial 3D amrex build testing.