### PR TITLE
EB updates

### DIFF
--- a/Src/EB/AMReX_ebcellflag_mod.F90
+++ b/Src/EB/AMReX_ebcellflag_mod.F90
@@ -5,7 +5,7 @@ module amrex_ebcellflag_module
   private
   public :: is_regular_cell, is_single_valued_cell, is_multi_valued_cell, &
        is_covered_cell, get_neighbor_cells, num_neighbor_cells, &
-       set_regular_cell, amrex_ebcellflag_count
+       set_regular_cell, amrex_ebcellflag_count, get_neighbor_cells_int_single
   
   integer, parameter :: w_type      = 2
   integer, parameter :: w_numvofs   = 3
@@ -25,6 +25,18 @@ module amrex_ebcellflag_module
   end interface get_neighbor_cells
 
 contains
+
+  pure function get_neighbor_cells_int_single (flag,i,j,k)
+    integer, intent(in) :: flag
+    integer, intent(in) :: i, j, k
+    integer :: get_neighbor_cells_int_single
+
+    if (btest(flag,pos_ngbr(i,j,k))) then
+      get_neighbor_cells_int_single = 1
+    else
+      get_neighbor_cells_int_single = 0
+    end if
+  end function get_neighbor_cells_int_single
   
   elemental logical function is_regular_cell (flag)
     integer, intent(in) :: flag

--- a/Src/EB/AMReX_ebcellflag_mod.F90
+++ b/Src/EB/AMReX_ebcellflag_mod.F90
@@ -26,7 +26,7 @@ module amrex_ebcellflag_module
 
 contains
 
-  pure function get_neighbor_cells_int_single (flag,i,j,k)
+  elemental function get_neighbor_cells_int_single (flag,i,j,k)
     integer, intent(in) :: flag
     integer, intent(in) :: i, j, k
     integer :: get_neighbor_cells_int_single

--- a/Src/EB/AMReX_ebcellflag_mod.F90
+++ b/Src/EB/AMReX_ebcellflag_mod.F90
@@ -50,7 +50,7 @@ contains
 
   pure subroutine get_neighbor_cells_int (flag, ngbr)
     integer, intent(in) :: flag
-    integer, intent(inout) :: ngbr(-1:1,-1:1)
+    integer, intent(out) :: ngbr(-1:1,-1:1)
     integer :: i, j
     do j = -1,1
        do i = -1,1
@@ -65,7 +65,7 @@ contains
 
   pure subroutine get_neighbor_cells_real (flag, ngbr)
     integer, intent(in) :: flag
-    real(amrex_real), intent(inout) :: ngbr(-1:1,-1:1)
+    real(amrex_real), intent(out) :: ngbr(-1:1,-1:1)
     integer :: i, j
     do j = -1,1
        do i = -1,1
@@ -89,7 +89,7 @@ contains
 
   pure subroutine get_neighbor_cells_int (flag, ngbr)
     integer, intent(in) :: flag
-    integer, intent(inout) :: ngbr(-1:1,-1:1,-1:1)
+    integer, intent(out) :: ngbr(-1:1,-1:1,-1:1)
     integer :: i, j, k
     do k = -1,1
        do j = -1,1
@@ -106,7 +106,7 @@ contains
 
   pure subroutine get_neighbor_cells_real (flag, ngbr)
     integer, intent(in) :: flag
-    real(amrex_real), intent(inout) :: ngbr(-1:1,-1:1,-1:1)
+    real(amrex_real), intent(out) :: ngbr(-1:1,-1:1,-1:1)
     integer :: i, j, k
     do k = -1,1
        do j = -1,1

--- a/Tutorials/EB/CNS/Source/diffusion/cns_eb_diff_mod.F90
+++ b/Tutorials/EB/CNS/Source/diffusion/cns_eb_diff_mod.F90
@@ -16,7 +16,7 @@ contains
        flux2, fd2_lo, fd2_hi, &
        flux3, fd3_lo, fd3_hi, &
        flag, fglo, fghi)
-    use amrex_ebcellflag_module, only : get_neighbor_cells
+    use amrex_ebcellflag_module, only : get_neighbor_cells, get_neighbor_cells_int_single
     integer, intent(in) :: qd_lo(3), qd_hi(3)
     integer, intent(in) :: lo(3), hi(3), fglo(3), fghi(3)
     integer, intent(in) :: clo(3), chi(3)
@@ -56,13 +56,10 @@ contains
              dvdx = (q(i,j,k,qv)-q(i-1,j,k,qv))*dxinv(1)
              dwdx = (q(i,j,k,qw)-q(i-1,j,k,qw))*dxinv(1)
 
-             call get_neighbor_cells(flag(i-1,j,k), nbrlo)
-             call get_neighbor_cells(flag(i  ,j,k), nbrhi)
-
-             jhip = j + nbrhi(0, 1,0)
-             jhim = j - nbrhi(0,-1,0)
-             jlop = j + nbrlo(0, 1,0)
-             jlom = j - nbrlo(0,-1,0)
+             jhip = j + get_neighbor_cells_int_single(flag(i  ,j,k),0, 1,0)
+             jhim = j - get_neighbor_cells_int_single(flag(i  ,j,k),0,-1,0)
+             jlop = j + get_neighbor_cells_int_single(flag(i-1,j,k),0, 1,0)
+             jlom = j - get_neighbor_cells_int_single(flag(i-1,j,k),0,-1,0)
              whi = weights(jhip-jhim)
              wlo = weights(jlop-jlom)
              dudy = (0.5d0*dxinv(2)) * &
@@ -72,10 +69,10 @@ contains
                   ((q(i  ,jhip,k,qv)-q(i  ,jhim,k,qv))*whi &
                   +(q(i-1,jlop,k,qv)-q(i-1,jlom,k,qv))*wlo)
 
-             khip = k + nbrhi(0,0, 1)
-             khim = k - nbrhi(0,0,-1)
-             klop = k + nbrlo(0,0, 1)
-             klom = k - nbrlo(0,0,-1)
+             khip = k + get_neighbor_cells_int_single(flag(i  ,j,k),0,0, 1)
+             khim = k - get_neighbor_cells_int_single(flag(i  ,j,k),0,0,-1)
+             klop = k + get_neighbor_cells_int_single(flag(i-1,j,k),0,0, 1)
+             klom = k - get_neighbor_cells_int_single(flag(i-1,j,k),0,0,-1)
              whi = weights(khip-khim)
              wlo = weights(klop-klom)
              dudz = (0.5d0*dxinv(3)) * &
@@ -112,13 +109,10 @@ contains
              dvdy = (q(i,j,k,qv)-q(i,j-1,k,qv))*dxinv(2)
              dwdy = (q(i,j,k,qw)-q(i,j-1,k,qw))*dxinv(2)
 
-             call get_neighbor_cells(flag(i,j-1,k), nbrlo)
-             call get_neighbor_cells(flag(i,j  ,k), nbrhi)
-
-             ihip = i + nbrhi( 1,0,0)
-             ihim = i - nbrhi(-1,0,0)
-             ilop = i + nbrlo( 1,0,0)
-             ilom = i - nbrlo(-1,0,0)
+             ihip = i + get_neighbor_cells_int_single(flag(i,j  ,k), 1,0,0)
+             ihim = i - get_neighbor_cells_int_single(flag(i,j  ,k),-1,0,0)
+             ilop = i + get_neighbor_cells_int_single(flag(i,j-1,k), 1,0,0)
+             ilom = i - get_neighbor_cells_int_single(flag(i,j-1,k),-1,0,0)
              whi = weights(ihip-ihim)
              wlo = weights(ilop-ilom)
              dudx = (0.5d0*dxinv(1)) * &
@@ -128,10 +122,10 @@ contains
                   ((q(ihip,j  ,k,qv)-q(ihim,j  ,k,qv))*whi &
                   +(q(ilop,j-1,k,qv)-q(ilom,j-1,k,qv))*wlo)
 
-             khip = k + nbrhi(0,0, 1)
-             khim = k - nbrhi(0,0,-1)
-             klop = k + nbrlo(0,0, 1)
-             klom = k - nbrlo(0,0,-1)
+             khip = k + get_neighbor_cells_int_single(flag(i,j  ,k),0,0, 1)
+             khim = k - get_neighbor_cells_int_single(flag(i,j  ,k),0,0,-1)
+             klop = k + get_neighbor_cells_int_single(flag(i,j-1,k),0,0, 1)
+             klom = k - get_neighbor_cells_int_single(flag(i,j-1,k),0,0,-1)
              whi = weights(khip-khim)
              wlo = weights(klop-klom)
              dvdz = (0.5d0*dxinv(3)) * &
@@ -168,13 +162,10 @@ contains
              dvdz = (q(i,j,k,qv)-q(i,j,k-1,qv))*dxinv(3)
              dwdz = (q(i,j,k,qw)-q(i,j,k-1,qw))*dxinv(3)
 
-             call get_neighbor_cells(flag(i,j,k-1), nbrlo)
-             call get_neighbor_cells(flag(i,j,k  ), nbrhi)
-
-             ihip = i + nbrhi( 1,0,0)
-             ihim = i - nbrhi(-1,0,0)
-             ilop = i + nbrlo( 1,0,0)
-             ilom = i - nbrlo(-1,0,0)
+             ihip = i + get_neighbor_cells_int_single(flag(i,j,k  ), 1,0,0)
+             ihim = i - get_neighbor_cells_int_single(flag(i,j,k  ),-1,0,0)
+             ilop = i + get_neighbor_cells_int_single(flag(i,j,k-1), 1,0,0)
+             ilom = i - get_neighbor_cells_int_single(flag(i,j,k-1),-1,0,0)
              whi = weights(ihip-ihim)
              wlo = weights(ilop-ilom)
              dudx = (0.5d0*dxinv(1)) * &
@@ -184,10 +175,10 @@ contains
                   ((q(ihip,j,k  ,qw)-q(ihim,j,k  ,qw))*whi &
                   +(q(ilop,j,k-1,qw)-q(ilom,j,k-1,qw))*wlo)
 
-             jhip = j + nbrhi(0, 1,0)
-             jhim = j - nbrhi(0,-1,0)
-             jlop = j + nbrlo(0, 1,0)
-             jlom = j - nbrlo(0,-1,0)
+             jhip = j + get_neighbor_cells_int_single(flag(i,j,k  ),0 ,1,0)
+             jhim = j - get_neighbor_cells_int_single(flag(i,j,k  ),0,-1,0)
+             jlop = j + get_neighbor_cells_int_single(flag(i,j,k-1),0 ,1,0)
+             jlom = j - get_neighbor_cells_int_single(flag(i,j,k-1),0,-1,0)
              whi = weights(jhip-jhim)
              wlo = weights(jlop-jlom)
              dvdy = (0.5d0*dxinv(2)) * &


### PR DESCRIPTION
These commits attempt to optimize some of the EB neighbor cell computations. Switching the Combustor code from calling `get_neighbor_cells()` to `get_neighbor_cells_int_single()` yielded a 22% speedup in overall time step execution time on KNL, using 64 MPI processes on 1 node, with a 256^3 grid decomposed into 64^3 boxes. This was due entirely to vectorization of the (i,j,k) loop in the `eb_diff_mol_3d()` function, which was not possible with the original `get_neighbor_cells()` calls.