### PR TITLE
CVODE, Tools: use Cray version of SUNDIALS if module is loaded

### DIFF
--- a/Docs/AMReXUsersGuide/CVODE/CVODE.tex
+++ b/Docs/AMReXUsersGuide/CVODE/CVODE.tex
@@ -11,10 +11,13 @@ When compiling \cvode, one need not build the \cvode\ library with the \fcvode\ 
 Rather, the Fortran 2003 interface to \cvode\ is provided within \amrex\ itself.
 The \cvode\ tutorials provided in \amrex\ use this new interface.
 
-\section{Compiling \cvode}
+\section{Compiling \amrex\ with \cvode}
 
-To use \cvode\ in an \amrex\ application, follow these steps:
+The following steps describe how to compile an \amrex\ application with \cvode\ support.
+On Cray systems (e.g., Cori or Edison at NERSC), Cray provides a system module called \texttt{cray-tpsl} (``Cray Third-Party Scientific Libraries'') which contains the latest version of the \sundials\ solver suite (including \cvode).
+Simply type \texttt{module load cray-tpsl} and set \texttt{USE\_CVODE=TRUE} in the \texttt{GNUmakefile}, and \amrex\ will automatically link the \sundials\ libraries.
 
+On systems which are not Cray:
 \begin{enumerate}
 
   \item Obtain the \cvode\ source code, which is hosted here: \url{https://computation.llnl.gov/projects/sundials/sundials-software}.

--- a/Tools/GNUMake/packages/Make.cvode
+++ b/Tools/GNUMake/packages/Make.cvode
@@ -1,11 +1,22 @@
+# Cray provides SUNDIALS (including CVODE) as part of their "Third Party
+# Scientific Library" system module "cray-tpsl". If the module is loaded, just
+# use that version of SUNDIALS. Otherwise, look for a home-cooked version.
+
+CPPFLAGS += -DUSE_CVODE
 include $(AMREX_HOME)/Src/Extern/CVODE/Make.package
+
+ifeq ($(findstring CRAY_TPSL, $(PE_PRODUCT_LIST)), CRAY_TPSL)
+  $(info Found Cray TPSL)
+  INCLUDE_LOCATIONS += $(CRAY_TPSL_PREFIX_DIR)
+  # If you loaded the cray-tpsl module, chances are you meant to use the Cray
+  # version of SUNDIALS, even if you have CVODE_LIB_DIR defined.
+  CVODE_LIB_DIR := $(CRAY_TPSL_PREFIX_DIR)/lib
+else
+  CVODE_LIB_DIR ?= $(HOME)/cvode/lib
+endif
 
 INCLUDE_LOCATIONS += $(AMREX_HOME)/Src/Extern/CVODE
 VPATH_LOCATIONS += $(AMREX_HOME)/Src/Extern/CVODE
-
-CPPFLAGS += -DUSE_CVODE
-
-CVODE_LIB_DIR ?= $(HOME)/cvode/lib
 
 LIBRARIES += -L$(CVODE_LIB_DIR) -lsundials_cvode
 LIBRARIES += -L$(CVODE_LIB_DIR) -lsundials_nvecserial


### PR DESCRIPTION
Cray includes SUNDIALS in the "cray-tpsl" module. Use that if the module is
loaded. If the module is not loaded, then look for the home-cooked version.