### PR TITLE
Tools: remove "-h std" flags from Cray C/C++ compiler

### DIFF
--- a/Tools/GNUMake/comps/cray.mak
+++ b/Tools/GNUMake/comps/cray.mak
@@ -21,6 +21,8 @@ COMP_VERSION := $(cray_version)
 
 ifeq ($(DEBUG),TRUE)
 
+  GENERIC_COMP_FLAGS += -K trap=fp
+
   CXXFLAGS += -g -O0
   CFLAGS   += -g -O0
   FFLAGS   += -g -O0 -e i

--- a/Tools/GNUMake/comps/cray.mak
+++ b/Tools/GNUMake/comps/cray.mak
@@ -28,6 +28,8 @@ ifeq ($(DEBUG),TRUE)
 
 else
 
+  GENERIC_COMP_FLAGS += -h list=a
+
   CXXFLAGS += -O2
   CFLAGS   += -O2
   FFLAGS   += -O2
@@ -44,8 +46,6 @@ F90FLAGS += -N 255 -I $(fmoddir) -J $(fmoddir) -em
 FFLAGS   += -N 255 -I $(fmoddir) -J $(fmoddir) -em
 
 ########################################################################
-
-GENERIC_COMP_FLAGS = -h list=a
 
 ifneq ($(USE_OMP),TRUE)
   GENERIC_COMP_FLAGS += -h noomp


### PR DESCRIPTION
As of CCE 8.6.2, the compiler defaults to "-h std=c11" for the C compiler, and
"-h std=c++14" for the C++ compiler, so these flags are not necessary.