### PR TITLE
Development, added gnu-7 compiler definition

### DIFF
--- a/Docs/Readme.sphinx
+++ b/Docs/Readme.sphinx
@@ -42,9 +42,12 @@ You should now be able to successfully "make html" in amrex/Docs/sphinx.
 If you would like to make a pdf document from the *rst files, first 
 
 sudo apt-get install latexmk
+(if you are using macOS, latexmk is installed via the TexLive Utility)
 
 Then in the amrex/Docs/sphinx directory, type 
 
 make latexpdf
+(if you have the slimmed-down latex install, then you need to also install the following packages via TexLive Utility: tabulary, varwidth, framed, wrapfig, capt-of, needspace, courier)
+
 
 This will create amrex/Docs/sphinx/build/latex/amrex.pdf

--- a/Tools/GNUMake/Make.defs
+++ b/Tools/GNUMake/Make.defs
@@ -163,7 +163,11 @@ FORT_EXE_OUTPUT_OPTION = -o $(objEXETempDir)/$*.o
 
 lowercase_comp := $(shell echo $(COMP) | tr A-Z a-z)
 
-ifeq ($(lowercase_comp),$(filter $(lowercase_comp),gcc gnu g++))
+ifeq ($(lowercase_comp),$(filter $(lowercase_comp),gcc-7 gnu-7 g++-7))
+  lowercase_comp = gnu-7
+  $(info Loading $(AMREX_HOME)/Tools/GNUMake/comps/gnu.mak...)
+  include        $(AMREX_HOME)/Tools/GNUMake/comps/gnu-7.mak
+else ifeq ($(lowercase_comp),$(filter $(lowercase_comp),gcc gnu g++))
   lowercase_comp = gnu
   $(info Loading $(AMREX_HOME)/Tools/GNUMake/comps/gnu.mak...)
   include        $(AMREX_HOME)/Tools/GNUMake/comps/gnu.mak


### PR DESCRIPTION
Sometimes multiple versions of gcc are installed on a system. This happens with macOS X, where the default gcc is version 4.2. Installing newer versions of gcc (say gcc version 7.3) are then linked to gcc-7, g++-7, gfortran-7, ...

This build target is needed to compile Amrvis on a mac.