### PR TITLE
Overlooked this in GNUMake. AMReX should build fine now...

### DIFF
--- a/Tools/GNUMake/Make.defs
+++ b/Tools/GNUMake/Make.defs
@@ -163,11 +163,7 @@ FORT_EXE_OUTPUT_OPTION = -o $(objEXETempDir)/$*.o
 
 lowercase_comp = $(shell echo $(COMP) | tr A-Z a-z)
 
-ifeq ($(lowercase_comp),$(filter $(lowercase_comp),gcc-7 gnu-7 g++-7))
-  lowercase_comp = gnu-7
-  $(info Loading $(AMREX_HOME)/Tools/GNUMake/comps/gnu.mak...)
-  include        $(AMREX_HOME)/Tools/GNUMake/comps/gnu-7.mak
-else ifeq ($(lowercase_comp),$(filter $(lowercase_comp),gcc gnu g++))
+ifeq ($(lowercase_comp),$(filter $(lowercase_comp),gcc gnu g++))
   lowercase_comp = gnu
   $(info Loading $(AMREX_HOME)/Tools/GNUMake/comps/gnu.mak...)
   include        $(AMREX_HOME)/Tools/GNUMake/comps/gnu.mak


### PR DESCRIPTION
Accidentally left the gnu-7 build target in the Make.defs. This should fix it.