### PR TITLE
Use Fortran intrinsic flush instead of call flush

### DIFF
--- a/Src/F_BaseLib/multifab_physbc_edgevel.f90
+++ b/Src/F_BaseLib/multifab_physbc_edgevel.f90
@@ -76,7 +76,7 @@ contains
 
     print *, 'in multifab_physbc_edgevel ', lo, hi, phys_bc(1,1), INLET
     print *, OUTLET, SYMMETRY, INTERIOR, PERIODIC, INLET, SLIP_WALL, NO_SLIP_WALL
-    call flush(6)
+    flush(6)
     
     ! impose lo i side bc's
     select case(phys_bc(1,1))

--- a/Src/LinearSolvers/F_MG/cc_mg_cpp.f90
+++ b/Src/LinearSolvers/F_MG/cc_mg_cpp.f90
@@ -101,7 +101,7 @@ subroutine mgt_flush_copyassoc_cache()
 end subroutine mgt_flush_copyassoc_cache
 
 subroutine mgt_flush_output()
-  call flush(6)
+  flush(6)
 end subroutine mgt_flush_output
 
 subroutine mgt_cc_alloc(dm, nlevel, stencil_type)


### PR DESCRIPTION
This is part of F03 so modern compilers should support it. But IBM's compiler doesn't like "call flush."