### PR TITLE
Change default CUDA_VERSION to 9.0 in Fortran build system.

### DIFF
--- a/Tools/F_mk/GMakedefs.mak
+++ b/Tools/F_mk/GMakedefs.mak
@@ -105,7 +105,7 @@ ifdef CUDA
   FPPFLAGS += -DCUDA
 
   ifndef CUDA_VERSION
-    CUDA_VERSION := 8.0
+    CUDA_VERSION := 9.0
   endif
 endif
 


### PR DESCRIPTION
This changes the default CUDA version in the Fortran build system back to 9.0 instead of 8.0.

CUDA 9.0 was formerly (cf. commit 23486c89f022a276af249514a91480b7663379a6) the default version of CUDA in the Fortran build system.