### PR TITLE
Nag fix for #241

### DIFF
--- a/Src/Base/AMReX_ArrayLim.H
+++ b/Src/Base/AMReX_ArrayLim.H
@@ -111,6 +111,55 @@
 #define DIMARG(a) a##(1),a##(2),a##(3)
 #endif
 
+#elif NAGFOR
+
+#ifndef CONCAT
+#define IDENTITY(a) a
+#define CONCAT(a,b) IDENTITY(a)IDENTITY(b)
+#endif
+
+#if (AMREX_SPACEDIM == 1)
+#define DIMS(a) CONCAT(a,_l1), CONCAT(a,_h1)
+#define DIMDEC(a) CONCAT(a,_l1), CONCAT(a,_h1)
+#define DIMV(a) CONCAT(a,_l1):CONCAT(a,_h1)
+#define DIM1(a) CONCAT(a,_l1):CONCAT(a,_h1)
+#define ARG_L1(a) CONCAT(a,_l1)
+#define ARG_H1(a) CONCAT(a,_h1)
+#define DIMARG(a) CONCAT(a,(1))
+#endif
+
+#if (AMREX_SPACEDIM == 2)
+#define DIMS(a) CONCAT(a,_l1), CONCAT(a,_l2), CONCAT(a,_h1), CONCAT(a,_h2)
+#define DIMDEC(a) CONCAT(a,_l1), CONCAT(a,_l2), CONCAT(a,_h1), CONCAT(a,_h2)
+#define DIMV(a) CONCAT(a,_l1):CONCAT(a,_h1), CONCAT(a,_l2):CONCAT(a,_h2)
+#define DIM1(a) CONCAT(a,_l1):CONCAT(a,_h1)
+#define DIM2(a) CONCAT(a,_l2):CONCAT(a,_h2)
+#define ARG_L1(a) CONCAT(a,_l1)
+#define ARG_L2(a) CONCAT(a,_l2)
+#define ARG_H1(a) CONCAT(a,_h1)
+#define ARG_H2(a) CONCAT(a,_h2)
+#define DIMARG(a) CONCAT(a,(1)),CONCAT(a,(2))
+#endif
+
+#if (AMREX_SPACEDIM == 3)
+#define DIMS(a) CONCAT(a,_l1), CONCAT(a,_l2), CONCAT(a,_l3), CONCAT(a,_h1), CONCAT(a,_h2), CONCAT(a,_h3)
+#define DIMDEC(a) CONCAT(a,_l1), CONCAT(a,_l2), CONCAT(a,_l3), CONCAT(a,_h1), CONCAT(a,_h2), CONCAT(a,_h3)
+#define DIMV(a) CONCAT(a,_l1):CONCAT(a,_h1), CONCAT(a,_l2):CONCAT(a,_h2), CONCAT(a,_l3):CONCAT(a,_h3)
+#define DIM1(a) CONCAT(a,_l1):CONCAT(a,_h1)
+#define DIM2(a) CONCAT(a,_l2):CONCAT(a,_h2)
+#define DIM3(a) CONCAT(a,_l3):CONCAT(a,_h3)
+#define DIM12(a) CONCAT(a,_l1):CONCAT(a,_h1), CONCAT(a,_l2):CONCAT(a,_h2)
+#define DIM23(a) CONCAT(a,_l2):CONCAT(a,_h2), CONCAT(a,_l3):CONCAT(a,_h3)
+#define DIM13(a) CONCAT(a,_l1):CONCAT(a,_h1), CONCAT(a,_l3):CONCAT(a,_h3)
+#define ARG_L1(a) CONCAT(a,_l1)
+#define ARG_L2(a) CONCAT(a,_l2)
+#define ARG_L3(a) CONCAT(a,_l3)
+#define ARG_H1(a) CONCAT(a,_h1)
+#define ARG_H2(a) CONCAT(a,_h2)
+#define ARG_H3(a) CONCAT(a,_h3)
+#define DIMARG(a) CONCAT(a,(1)),CONCAT(a,(2)),CONCAT(a,(3))
+#endif
+
 #else
 
 #if (AMREX_SPACEDIM == 1)

--- a/Src/Base/AMReX_REAL.H
+++ b/Src/Base/AMReX_REAL.H
@@ -64,11 +64,21 @@ namespace amrex {
   when compiling any module that uses floating-point.
 */
 
+#ifdef NAGFOR
+#ifndef CONCAT
+#define IDENTITY(a) a
+#define CONCAT(a,b) IDENTITY(a)IDENTITY(b)
+#endif
+#endif
+
 #ifdef BL_USE_FLOAT
 #    define REAL_T REAL
 #if __STDC__==1 || defined(__INTEL_COMPILER)
 #        define BL_REAL(a) a##E0
 #        define BL_REAL_E(a,b) a##E##b
+#elif NAGFOR
+#        define BL_REAL(a) CONCAT(a,E0)
+#        define BL_REAL_E(a,b) CONCAT(,CONCAT(E,b))
 #else
 #        define BL_REAL(a) a/**/E0
 #        define BL_REAL_E(a,b) a/**/E/**/b
@@ -78,6 +88,9 @@ namespace amrex {
 #if __STDC__==1 || defined(__INTEL_COMPILER)
 #        define BL_REAL(a) a##D0
 #        define BL_REAL_E(a,b) a##D##b
+#elif NAGFOR
+#        define BL_REAL(a) CONCAT(a,D0)
+#        define BL_REAL_E(a,b) CONCAT(,CONCAT(D,b))
 #else
 #        define BL_REAL(a) a/**/D0
 #        define BL_REAL_E(a,b) a/**/D/**/b


### PR DESCRIPTION
This is a fix for #241 that only involves some additional special cases for the NAG compiler in several header files.  This is a possible alternative to 2f4d3a8 (which didn't fully fix the problem).

*I'm necessarily looking for this to be merged.*  A PR seemed to be the easiest way of  showing a possible fix.  The definition of the `CONCAT` macro for NAG is done in two separate places where it is needed, and there may be a better place to put it.