### PR TITLE
Sy/hypre - HYPRE IJ matrix interface

### DIFF
--- a/Src/Extern/HYPRE/AMReX_Hypre.H
+++ b/Src/Extern/HYPRE/AMReX_Hypre.H
@@ -3,6 +3,7 @@
 
 #include <AMReX_HypreABecLap.H>
 #include <AMReX_HypreABecLap2.H>
+#include <AMReX_HypreABecLap3.H>
 
 #include <memory>
 
@@ -31,6 +32,7 @@ private:
 
     std::unique_ptr<HypreABecLap> struct_solver;
     std::unique_ptr<HypreABecLap2> semi_struct_solver;
+    std::unique_ptr<HypreABecLap3> IJ_solver;
 };
 
 }

--- a/Src/Extern/HYPRE/AMReX_Hypre.cpp
+++ b/Src/Extern/HYPRE/AMReX_Hypre.cpp
@@ -25,6 +25,8 @@ Hypre::Hypre (const BoxArray& grids,
             solver_flag = 1;
         } else if (solver_flag_s == "boomeramg") {
             solver_flag = 2;
+        } else if (solver_flag_s == "boomeramgij") {
+            solver_flag = 3;
         } else if (solver_flag_s == "none") {
             pp.query("solver_flag", solver_flag);
         } else {
@@ -34,13 +36,16 @@ Hypre::Hypre (const BoxArray& grids,
 
     if (solver_flag == 2) {
         semi_struct_solver.reset(new HypreABecLap2(grids, dmap, geom, comm_));
-    } else {
+    } else if (solver_flag == 3) {
+        IJ_solver.reset(new HypreABecLap3(grids, dmap, geom, comm_));
+    }else {
         struct_solver.reset(new HypreABecLap(grids, dmap, geom, comm_));
     }
 }
 
 Hypre::~Hypre ()
 {
+
 }
 
 void
@@ -50,7 +55,9 @@ Hypre::setScalars (Real sa, Real sb)
         struct_solver->setScalars(sa,sb);
     } else if (semi_struct_solver) {
         semi_struct_solver->setScalars(sa,sb);
-    } else {
+    }else if (IJ_solver) {
+      IJ_solver->setScalars(sa,sb);
+    }else {
         amrex::Abort("Hypre::setScalars: How did this happen?");
     }
 }
@@ -62,6 +69,8 @@ Hypre::setACoeffs (const MultiFab& alpha)
         struct_solver->setACoeffs(alpha);
     } else if (semi_struct_solver) {
         semi_struct_solver->setACoeffs(alpha);
+    }else if (IJ_solver) {
+        IJ_solver->setACoeffs(alpha);
     } else {
         amrex::Abort("Hypre::setACoeffs: How did this happen?");
     }
@@ -74,6 +83,8 @@ Hypre::setBCoeffs (const std::array<const MultiFab*,BL_SPACEDIM>& beta)
         struct_solver->setBCoeffs(beta);
     } else if (semi_struct_solver) {
         semi_struct_solver->setBCoeffs(beta);
+    }else if (IJ_solver) {
+        IJ_solver->setBCoeffs(beta);
     } else {
         amrex::Abort("Hypre::setBCoeffs: How did this happen?");        
     }
@@ -86,6 +97,8 @@ Hypre::setVerbose (int _verbose)
         struct_solver->setVerbose(_verbose);
     } else if (semi_struct_solver) {
         semi_struct_solver->setVerbose(_verbose);
+    }else if (IJ_solver) {
+        IJ_solver->setVerbose(_verbose);
     } else {
         amrex::Abort("Hypre::setVerbose: How did this happen?");
     }
@@ -99,6 +112,8 @@ Hypre::solve (MultiFab& soln, const MultiFab& rhs, Real rel_tol, Real abs_tol,
         struct_solver->solve(soln, rhs, rel_tol, abs_tol, max_iter, bc_type, bc_value);
     } else if (semi_struct_solver) {
         semi_struct_solver->solve(soln, rhs, rel_tol, abs_tol, max_iter, bc_type, bc_value);
+    } else if (IJ_solver) {
+      IJ_solver->solve(soln, rhs, rel_tol, abs_tol, max_iter, bc_type, bc_value);
     } else {
         amrex::Abort("Hypre::solve: How did this happen?");
     }

--- a/Src/Extern/HYPRE/AMReX_HypreABecLap3.H
+++ b/Src/Extern/HYPRE/AMReX_HypreABecLap3.H
@@ -55,6 +55,7 @@ private :
     std::vector<int> CellsGIndex;
     std::vector<int> numCellsProc;
     std::vector<int> StartIndex;
+    std::vector<int> FaceBcOffset;
     
     HYPRE_IJMatrix A;
     HYPRE_ParCSRMatrix par_A;

--- a/Src/Extern/HYPRE/AMReX_HypreABecLap3.H
+++ b/Src/Extern/HYPRE/AMReX_HypreABecLap3.H
@@ -1,0 +1,85 @@
+#ifndef AMREX_HYPREABECLAP3_H_
+#define AMREX_HYPREABECLAP3_H_
+
+
+#include <AMReX_Geometry.H>
+#include <AMReX_MultiFab.H>
+#include <AMReX_iMultiFab.H>
+#include <AMReX_MacBndry.H>
+#include <AMReX_ParmParse.H>
+#include <AMReX_LO_BCTYPES.H>
+
+#include "_hypre_utilities.h"
+#include "HYPRE_krylov.h"
+#include "HYPRE.h"
+#include "HYPRE_parcsr_ls.h"
+#include "_hypre_parcsr_mv.h"
+#include <algorithm>
+
+namespace amrex
+{
+
+class HypreABecLap3
+{
+public:
+
+    HypreABecLap3 (const BoxArray& grids,
+                   const DistributionMapping& dmap,
+                   const Geometry& geom_,
+                   MPI_Comm comm_);
+    ~HypreABecLap3 ();
+
+    void setScalars(Real sa, Real sb);
+    void setACoeffs(const MultiFab& alpha);
+    void setBCoeffs(const std::array<const MultiFab*,BL_SPACEDIM>& beta);
+    void setVerbose(int _verbose);
+    void solve(MultiFab& soln, const MultiFab& rhs, Real rel_tol, Real abs_tol, 
+               int max_iter, LinOpBCType bc_type, Real bc_value);
+    void solve(MultiFab& soln, const MultiFab& rhs, Real rel_tol, Real abs_tol, 
+               int max_iter, const BndryData& _bndry);
+
+private :
+
+    MPI_Comm comm;
+    Geometry geom;
+
+    int verbose;
+
+    MultiFab acoefs;
+    std::array<MultiFab,BL_SPACEDIM> bcoefs;
+    Real scalar_a, scalar_b;
+    BndryData bd;
+
+    iMultiFab GbInd;
+
+    std::vector<int> CellsGIndex;
+    std::vector<int> numCellsProc;
+    std::vector<int> StartIndex;
+    
+    HYPRE_IJMatrix A;
+    HYPRE_ParCSRMatrix par_A;
+    HYPRE_IJVector b;
+    HYPRE_ParVector par_b;
+    HYPRE_IJVector x;
+    HYPRE_ParVector par_x;
+    HYPRE_Solver solver;
+
+    Real rel_tol, abs_tol;
+    int max_iter;
+
+    void loadBndryData (LinOpBCType bc_type, Real bc_value);
+    void loadMatrix ();
+    void finalizeMatrix ();
+    void loadVectors (MultiFab& soln, const MultiFab& rhs);
+    void finalizeVectors ();
+
+    void setupSolver (Real rel_tol_, Real abs_tol_, int max_iter_);
+    void solveDoIt ();
+    void clearSolver ();
+
+    void getSolution (MultiFab& soln);
+};
+
+}
+
+#endif

--- a/Src/Extern/HYPRE/AMReX_HypreABecLap3.H
+++ b/Src/Extern/HYPRE/AMReX_HypreABecLap3.H
@@ -55,7 +55,6 @@ private :
     std::vector<int> CellsGIndex;
     std::vector<int> numCellsProc;
     std::vector<int> StartIndex;
-    std::vector<int> FaceBcOffset;
     
     HYPRE_IJMatrix A;
     HYPRE_ParCSRMatrix par_A;

--- a/Src/Extern/HYPRE/AMReX_HypreABecLap3.cpp
+++ b/Src/Extern/HYPRE/AMReX_HypreABecLap3.cpp
@@ -265,13 +265,13 @@ void HypreABecLap3::loadMatrix() {
 
     for (OrientationIter oitr; oitr; oitr++) {
       int cdir(oitr());
+      FaceBcOffset[i*BL_SPACEDIM*2+cdir] = 0;
       if (reg[oitr()] == domain[oitr()]) {
         FaceBcOffset[i*BL_SPACEDIM*2+cdir] = 1;
-      } else {
-        FaceBcOffset[i*BL_SPACEDIM*2+cdir] = 0;
       }
     }
   }
+
 
   for (MFIter mfi(acoefs); mfi.isValid(); ++mfi) {
     int i = mfi.index();
@@ -290,8 +290,7 @@ void HypreABecLap3::loadMatrix() {
     for (int idim = 0; idim < BL_SPACEDIM; idim++) {
       amrex_hmbc_ij(BL_TO_FORTRAN(bcoefs[idim][mfi]),
                     ARLIM(reg.loVect()), ARLIM(reg.hiVect()), scalar_b,
-                    geom.CellSize(), idim, A, BL_TO_FORTRAN(GbInd[mfi]),
-                    BL_SPACEDIM*2, &BCface[i*BL_SPACEDIM*2]);
+                    geom.CellSize(), idim, A, BL_TO_FORTRAN(GbInd[mfi]));
     }
 
     // add b.c.'s to matrix diagonal, and

--- a/Src/Extern/HYPRE/AMReX_HypreABecLap3.cpp
+++ b/Src/Extern/HYPRE/AMReX_HypreABecLap3.cpp
@@ -1,0 +1,548 @@
+#include <AMReX_HypreABecLap3.H>
+#include <AMReX_HypreABec_F.H>
+
+#include <cmath>
+
+namespace {
+    static int ispow2(int i)
+    {
+        return (i == 1) ? 1 : (((i <= 0) || (i & 1)) ? 0 : ispow2(i / 2));
+    }
+}
+
+namespace amrex
+{
+
+HypreABecLap3::HypreABecLap3 (const BoxArray& grids,
+                              const DistributionMapping& dmap,
+                              const Geometry& geom_,
+                              MPI_Comm comm_)
+    : comm(comm_),
+      geom(geom_),
+      verbose(1),
+      A(NULL), b(NULL), x(NULL)
+{
+    const int ncomp = 1;
+    const int ngrow = 0;
+    acoefs.define(grids, dmap, ncomp, ngrow);
+    acoefs.setVal(0.0);
+
+    for (int i = 0; i < BL_SPACEDIM; ++i) {
+        BoxArray edge_boxes(grids);
+        edge_boxes.surroundingNodes(i);
+        bcoefs[i].define(edge_boxes, dmap, ncomp, ngrow);        
+        bcoefs[i].setVal(0.0);
+    }
+
+    bd.define(grids, dmap, ncomp, geom);
+
+    int num_procs, myid;
+    MPI_Comm_size(comm, &num_procs );
+    MPI_Comm_rank(comm, &myid );
+
+    // Store the global integer index
+    GbInd.define(grids, dmap, ncomp, ngrow);
+    GbInd.setVal(0);
+    
+    // Store the global integer index
+    GbInd.define(grids, dmap, ncomp, ngrow);
+    GbInd.setVal(0);
+
+    // Arrays needed to build the global indices for all procs
+    CellsGIndex.resize(grids.size());
+    numCellsProc.resize(num_procs+1);
+
+    // These arrays store the starting and ending global indices of all the boxes involved
+    StartIndex.resize(grids.size());
+    
+    //Initialize all the arrays to 0 
+    std::fill(CellsGIndex.begin() ,CellsGIndex.end(), 0);
+    std::fill(numCellsProc.begin(),numCellsProc.end(), 0);
+    std::fill(StartIndex.begin(),StartIndex.end(),0);
+    
+    // Fill the numpoints in the box and in the proc where this box resides
+    for (int i = 0; i < grids.size(); i++) {
+        const Box& bx = grids[i];
+        CellsGIndex[i] = numCellsProc[ dmap[i]+1 ] ;
+        numCellsProc[ dmap[i]+1 ] = numCellsProc[ dmap[i]+1 ] + bx.numPts();
+    }
+
+    // making sure that counting starts from 0 for procId = 0
+    for (int i = 1; i<(num_procs+1);i++){
+        if(numCellsProc[i]==0) {
+            amrex::Abort("No rows in this core - Check domain decomposition");
+        }
+        numCellsProc[i] += numCellsProc[i-1];
+    }
+
+    // Box starting index starting from the proc offset
+    for (int i = 0; i < grids.size(); i++) {
+        CellsGIndex[i] = CellsGIndex[i] + numCellsProc[dmap[i]];
+    }
+
+    // Starting and ending global index for each box
+    for (int i = 0; i < (grids.size()-1); i++) {
+        StartIndex[i] = CellsGIndex[i];
+    }
+    StartIndex[grids.size()-1] = CellsGIndex[grids.size()-1];
+
+    // Fill up the Imultifab with global indices
+    for (MFIter mfi(GbInd); mfi.isValid(); ++mfi)
+    {
+        int i = mfi.index();
+        const Box &reg = mfi.validbox();
+        // build the global index for all cells on this level
+        amrex_BuildGlobalIndex(BL_TO_FORTRAN(GbInd[mfi]),ARLIM(reg.loVect()), ARLIM(reg.hiVect()),CellsGIndex[i]);
+    }
+    
+    const int nghost = 0;
+    bool local = true;
+    int ilower = GbInd.min(0, nghost,local);
+    int iupper = GbInd.max(0, nghost,local);
+
+    // Create the HYPRE matrix object 
+    HYPRE_IJMatrixCreate(comm,ilower,iupper,ilower,iupper, &A);
+    
+    // Parallel csr format storage
+    HYPRE_IJMatrixSetObjectType(A, HYPRE_PARCSR);
+    
+    // Initialize before setting coefficients
+    HYPRE_IJMatrixInitialize(A);
+
+    // Create the RHS and solution vector object
+    HYPRE_IJVectorCreate(comm, ilower, iupper,&b);
+    HYPRE_IJVectorSetObjectType(b, HYPRE_PARCSR);
+    HYPRE_IJVectorInitialize(b);
+
+    HYPRE_IJVectorCreate(comm, ilower, iupper,&x);
+    HYPRE_IJVectorSetObjectType(x, HYPRE_PARCSR);
+    HYPRE_IJVectorInitialize(x);
+    
+}
+    
+HypreABecLap3::~HypreABecLap3 ()
+{
+    HYPRE_IJMatrixDestroy(A);
+    HYPRE_IJVectorDestroy(b);
+    HYPRE_IJVectorDestroy(x);
+}
+
+void
+HypreABecLap3::setScalars (Real sa, Real sb)
+{
+    scalar_a = sa;
+    scalar_b = sb;
+}
+
+void
+HypreABecLap3::setACoeffs (const MultiFab& alpha)
+{
+    MultiFab::Copy(acoefs, alpha, 0, 0, 1, 0);
+}
+
+void
+HypreABecLap3::setBCoeffs (const std::array<const MultiFab*,BL_SPACEDIM>& beta)
+{
+    for (int idim=0; idim<BL_SPACEDIM; idim++) {
+        MultiFab::Copy(bcoefs[idim], *beta[idim], 0, 0, 1, 0);
+    }
+}
+
+void
+HypreABecLap3::setVerbose (int _verbose)
+{
+    verbose = _verbose;
+}
+
+void
+HypreABecLap3::solve (MultiFab& soln, const MultiFab& rhs, Real rel_tol_, Real abs_tol_, 
+                      int max_iter_, LinOpBCType bc_type, Real bc_value)
+{
+    
+    loadBndryData(bc_type, bc_value);
+
+    loadMatrix();
+
+    finalizeMatrix();
+
+    loadVectors(soln, rhs);
+
+    finalizeVectors();
+
+    setupSolver(rel_tol_, abs_tol_, max_iter_);
+
+    solveDoIt();
+
+    getSolution(soln);
+        
+    clearSolver();
+}
+
+void
+HypreABecLap3::solve (MultiFab& soln, const MultiFab& rhs, Real rel_tol_, Real abs_tol_, 
+                      int max_iter_, const BndryData& _bndry)
+{
+    bd = _bndry;
+
+    loadMatrix();
+    finalizeMatrix();
+    
+    loadVectors(soln, rhs);
+    finalizeVectors();
+    
+    setupSolver(rel_tol_, abs_tol_, max_iter_);
+    solveDoIt();
+    getSolution(soln);
+    
+    clearSolver();
+}
+
+void
+HypreABecLap3::loadBndryData (LinOpBCType bc_type, Real bc_value)
+{
+    const int comp = 0;
+    const Real* dx = geom.CellSize();
+    for (int n=0; n<BL_SPACEDIM; ++n) {
+        for (MFIter mfi(acoefs); mfi.isValid(); ++mfi ) {
+            int i = mfi.index(); 
+            
+            const Box& bx = mfi.validbox();
+            
+            // Our default will be that the face of this grid is either touching another grid
+            //  across an interior boundary or a periodic boundary.  We will test for the other
+            //  cases below.
+            {
+                // Define the type of boundary conditions to be Dirichlet (even for periodic)
+                bd.setBoundCond(Orientation(n, Orientation::low) ,i,comp,LO_DIRICHLET);
+                bd.setBoundCond(Orientation(n, Orientation::high),i,comp,LO_DIRICHLET);
+                
+                // Set the boundary conditions to the cell centers outside the domain
+                bd.setBoundLoc(Orientation(n, Orientation::low) ,i,0.5*dx[n]);
+                bd.setBoundLoc(Orientation(n, Orientation::high),i,0.5*dx[n]);
+            }
+            
+            // Now test to see if we should override the above with Dirichlet or Neumann physical bc's
+            if (bc_type != LinOpBCType::interior)
+            { 
+                int ibnd = static_cast<int>(bc_type); // either LO_DIRICHLET or LO_NEUMANN
+                
+                // We are on the low side of the domain in coordinate direction n
+                if (bx.smallEnd(n) == geom.Domain().smallEnd(n)) {
+                    // Set the boundary conditions to live exactly on the faces of the domain
+                    bd.setBoundLoc(Orientation(n, Orientation::low) ,i,0.0 );
+                    
+                    // Set the Dirichlet/Neumann boundary values 
+                    bd.setValue(Orientation(n, Orientation::low) ,i, bc_value);
+                    
+                    // Define the type of boundary conditions 
+                    bd.setBoundCond(Orientation(n, Orientation::low) ,i,comp,ibnd);
+                }
+                
+                // We are on the high side of the domain in coordinate direction n
+                if (bx.bigEnd(n) == geom.Domain().bigEnd(n)) {
+                    // Set the boundary conditions to live exactly on the faces of the domain
+                    bd.setBoundLoc(Orientation(n, Orientation::high) ,i,0.0 );
+                    
+                    // Set the Dirichlet/Neumann boundary values
+                    bd.setValue(Orientation(n, Orientation::high) ,i, bc_value);
+                    
+                    // Define the type of boundary conditions 
+                    bd.setBoundCond(Orientation(n, Orientation::high) ,i,comp,ibnd);
+                }
+            }
+        }
+    }
+}
+
+void
+HypreABecLap3::loadMatrix ()
+{
+    static_assert(BL_SPACEDIM > 1, "HypreABecLap2: 1D not supported");
+
+    const int size = 2 * BL_SPACEDIM + 1;
+    
+    const int bho = 0;
+    const Real* dx = geom.CellSize();
+
+    for (MFIter mfi(acoefs); mfi.isValid(); ++mfi)
+    {
+        int i = mfi.index();
+        const Box &reg = mfi.validbox();
+
+        int volume = reg.numPts();
+        
+        // build matrix interior
+
+        amrex_hmac_ij(BL_TO_FORTRAN(acoefs[mfi]),ARLIM(reg.loVect()), ARLIM(reg.hiVect()),
+                      scalar_a, A,BL_TO_FORTRAN(GbInd[mfi]));
+
+         for (int idim = 0; idim < BL_SPACEDIM; idim++) {
+             amrex_hmbc_ij(BL_TO_FORTRAN(bcoefs[idim][mfi]),
+                           ARLIM(reg.loVect()), ARLIM(reg.hiVect()), scalar_b,
+                           geom.CellSize(), idim, A,BL_TO_FORTRAN(GbInd[mfi]));
+         }
+
+        // add b.c.'s to matrix diagonal, and
+        // zero out offdiag values at domain boundaries
+
+        const Vector< Vector<BoundCond> > & bcs_i = bd.bndryConds(i);
+        const BndryData::RealTuple      & bcl_i = bd.bndryLocs(i);
+        
+        const Box& domain = geom.Domain();
+        for (OrientationIter oitr; oitr; oitr++) {
+            int cdir(oitr());
+            int idim = oitr().coordDir();
+            const int bctype = bcs_i[cdir][0];
+            const Real &bcl  = bcl_i[cdir];
+            const Mask &msk  = bd.bndryMasks(oitr())[mfi];
+
+            // Treat an exposed grid edge here as a boundary condition
+            // for the linear solver:
+            
+             if (reg[oitr()] == domain[oitr()]) {
+                 amrex_hmmat3_ij(ARLIM(reg.loVect()), ARLIM(reg.hiVect()),
+                              cdir, bctype, bho, bcl,
+                              BL_TO_FORTRAN(msk),
+                              BL_TO_FORTRAN(bcoefs[idim][mfi]),
+                                 scalar_b, dx, A,BL_TO_FORTRAN(GbInd[mfi]));
+
+             }
+             else {
+                 amrex_hmmat_ij(ARLIM(reg.loVect()), ARLIM(reg.hiVect()),
+                             cdir, bctype, bho, bcl,
+                             BL_TO_FORTRAN(msk),
+                             BL_TO_FORTRAN(bcoefs[idim][mfi]),
+                             scalar_b, dx, A,BL_TO_FORTRAN(GbInd[mfi]));
+
+             }
+            
+        }
+
+    }
+}
+
+void
+HypreABecLap3::finalizeMatrix ()
+{
+    // Assemble after setting the coefficients
+    HYPRE_IJMatrixAssemble(A);
+}
+
+void
+HypreABecLap3::loadVectors (MultiFab& soln, const MultiFab& rhs)
+{
+    const int bho = 0;
+    const Real* dx = geom.CellSize();
+
+    FArrayBox fnew;
+
+    soln.setVal(0.0);
+
+    for (MFIter mfi(soln); mfi.isValid(); ++mfi)
+    {
+        int i = mfi.index();
+        const Box &reg = mfi.validbox();
+
+        // initialize soln, since we will reuse the space to set up rhs below:
+
+        FArrayBox *f;
+        if (soln.nGrow() == 0) { // need a temporary if soln is the wrong size
+            f = &soln[mfi];
+        }
+        else {
+            f = &fnew;
+            f->resize(reg);
+            f->copy(soln[mfi], 0, 0, 1);
+        }
+        Real* vec = f->dataPtr(); // sharing space, soln will be overwritten below
+
+        Real *VecGB       = hypre_CTAlloc(double, reg.numPts());
+        int *VecIndices   = hypre_CTAlloc(int, reg.numPts());
+
+        // Convert the 3D vec array to 1D array with indices corresponding to row indices in the matrix
+        amrex_conv_Vec_Local_Global(vec,VecGB,VecIndices,reg.numPts(),ARLIM(reg.loVect()), ARLIM(reg.hiVect()),
+                            BL_TO_FORTRAN(GbInd[mfi]));
+
+        // Set the solution vector
+        HYPRE_IJVectorSetValues(x, reg.numPts(), VecIndices, VecGB);
+        
+        // Copy the rhs vector
+        f->copy(rhs[mfi], 0, 0, 1);
+
+        // add b.c.'s to rhs
+
+        const Vector< Vector<BoundCond> > & bcs_i = bd.bndryConds(i);
+        const BndryData::RealTuple      & bcl_i = bd.bndryLocs(i);
+
+        const Box& domain = geom.Domain();
+        for (OrientationIter oitr; oitr; oitr++) {
+            int cdir(oitr());
+            int idim = oitr().coordDir();
+            const int bctype = bcs_i[cdir][0];
+            const Real &bcl  = bcl_i[cdir];
+
+            const Mask &msk  = bd.bndryMasks(oitr())[mfi];
+            const FArrayBox &fs = bd.bndryValues(oitr())[mfi];
+
+            // Treat an exposed grid edge here as a boundary condition
+            // for the linear solver:
+            
+            if (reg[oitr()] == domain[oitr()]) {
+                amrex_hbvec3(vec, ARLIM(reg.loVect()), ARLIM(reg.hiVect()),
+                             cdir, bctype, bho, bcl,
+                             BL_TO_FORTRAN(fs),
+                             BL_TO_FORTRAN(msk),
+                             BL_TO_FORTRAN(bcoefs[idim][mfi]),
+                             scalar_b, dx);
+            }
+            else {
+                amrex_hbvec(vec, ARLIM(reg.loVect()), ARLIM(reg.hiVect()),
+                            cdir, bctype, bho, bcl,
+                            BL_TO_FORTRAN(fs),
+                            BL_TO_FORTRAN(msk),
+                            BL_TO_FORTRAN(bcoefs[idim][mfi]),
+                            scalar_b, dx);
+            }
+        }
+
+        // initialize rhs
+        amrex_conv_Vec_Local_Global(vec,VecGB,VecIndices,reg.numPts(),ARLIM(reg.loVect()), ARLIM(reg.hiVect()),
+                                    BL_TO_FORTRAN(GbInd[mfi]));
+
+        HYPRE_IJVectorSetValues(b, reg.numPts(), VecIndices, VecGB);
+
+        hypre_TFree(VecGB);
+        hypre_TFree(VecIndices);
+
+        
+    }
+}
+
+void
+HypreABecLap3::finalizeVectors ()
+{
+    HYPRE_IJVectorAssemble(x);
+    HYPRE_IJVectorAssemble(b);
+
+}
+
+void
+HypreABecLap3::setupSolver (Real rel_tol_, Real abs_tol_, int max_iter_)
+{
+    rel_tol = rel_tol_;
+    abs_tol = abs_tol_;
+    max_iter = max_iter_;
+
+    HYPRE_BoomerAMGCreate(&solver);
+
+    HYPRE_BoomerAMGSetMinIter(solver, 1);
+    HYPRE_BoomerAMGSetMaxIter(solver, max_iter);
+    HYPRE_BoomerAMGSetTol(solver, rel_tol);
+
+    // Set some parameters (See Reference Manual for more parameters)
+    HYPRE_BoomerAMGSetOldDefault(solver); /* Falgout coarsening with modified classical interpolation */
+    HYPRE_BoomerAMGSetCoarsenType(solver,6);
+    HYPRE_BoomerAMGSetCycleType (solver, 1);
+    HYPRE_BoomerAMGSetRelaxType(solver, 6);   /* G-S/Jacobi hybrid relaxation */
+    HYPRE_BoomerAMGSetRelaxOrder(solver, 1);   /* uses C/F relaxation */
+    HYPRE_BoomerAMGSetNumSweeps(solver, 2);   /* Sweeeps on each level */
+    HYPRE_BoomerAMGSetMaxLevels(solver, 20);  /* maximum number of levels */
+    HYPRE_BoomerAMGSetStrongThreshold (solver,0.6);
+    
+    // Get the parcsr matrix object to use 
+    HYPRE_IJMatrixGetObject(A, (void**) &par_A);
+    HYPRE_IJVectorGetObject(b, (void **) &par_b);
+    HYPRE_IJVectorGetObject(x, (void **) &par_x);
+    
+    HYPRE_BoomerAMGSetup(solver, par_A, par_b, par_x);
+
+}
+
+void
+HypreABecLap3::clearSolver ()
+{
+    HYPRE_BoomerAMGDestroy(solver);
+}
+
+void
+HypreABecLap3::solveDoIt ()
+{
+    if (abs_tol > 0.0)
+    {
+        Real bnorm;
+        bnorm = hypre_ParVectorInnerProd (par_b ,par_b);
+        bnorm = std::sqrt(bnorm);
+
+        const BoxArray& grids = acoefs.boxArray();
+        Real volume = grids.numPts();
+        Real rel_tol_new = bnorm > 0.0 ? abs_tol / bnorm * std::sqrt(volume) : rel_tol;
+
+        if (rel_tol_new > rel_tol) {
+            HYPRE_BoomerAMGSetTol(solver, rel_tol_new);
+        }
+    }
+
+    HYPRE_BoomerAMGSolve(solver, par_A, par_b, par_x);
+    
+    if (verbose >= 2 && ParallelDescriptor::IOProcessor()) {
+        int num_iterations;
+        Real res;
+        HYPRE_BoomerAMGGetNumIterations(solver, &num_iterations);
+        HYPRE_BoomerAMGGetFinalRelativeResidualNorm(solver, &res);
+        
+        int oldprec = std::cout.precision(17);
+        std::cout <<"\n" <<  num_iterations
+                  << " Hypre Multigrid Iterations, Relative Residual "
+                  << res << std::endl;
+        std::cout.precision(oldprec);
+    }
+}
+
+void
+HypreABecLap3::getSolution (MultiFab& soln)
+{
+    const int part = 0;
+
+    std::vector<int> VecIndices;
+
+    FArrayBox fnew;
+    for (MFIter mfi(soln); mfi.isValid(); ++mfi)
+    {
+        const Box &reg = mfi.validbox();
+
+        FArrayBox *f;
+        if (soln.nGrow() == 0) { // need a temporary if soln is the wrong size
+            f = &soln[mfi];
+        }
+        else {
+            f = &fnew;
+            f->resize(reg);
+        }
+
+        int i = mfi.index();
+
+        // Storage for the solution vector returned by HYPRE
+        Real *VecGB       = hypre_CTAlloc(double, reg.numPts());
+
+        // Generate indices corresponding to all the boxes
+        VecIndices.resize(reg.numPts());
+        std::iota (VecIndices.begin(),VecIndices.end(), StartIndex[i]);
+        int* RowIndices = VecIndices.data();
+
+        // Get the solution from HYPRE 
+        HYPRE_IJVectorGetValues(x, reg.numPts(),RowIndices, VecGB);
+
+        // Move the solution vector back to the soln multifab
+        amrex_conv_Vec_Global_Local(BL_TO_FORTRAN(*f), VecGB,reg.numPts(),ARLIM(reg.loVect()), ARLIM(reg.hiVect()));
+
+        if (soln.nGrow() != 0) {
+            soln[mfi].copy(*f, 0, 0, 1);
+        }
+
+        hypre_TFree(VecGB);
+	
+        
+    }
+}
+
+}

--- a/Src/Extern/HYPRE/AMReX_HypreABecLap3.cpp
+++ b/Src/Extern/HYPRE/AMReX_HypreABecLap3.cpp
@@ -1,548 +1,525 @@
 #include <AMReX_HypreABecLap3.H>
 #include <AMReX_HypreABec_F.H>
-
 #include <cmath>
 
 namespace {
-    static int ispow2(int i)
-    {
-        return (i == 1) ? 1 : (((i <= 0) || (i & 1)) ? 0 : ispow2(i / 2));
-    }
+static int ispow2(int i) {
+  return (i == 1) ? 1 : (((i <= 0) || (i & 1)) ? 0 : ispow2(i / 2));
+}
 }
 
-namespace amrex
-{
+namespace amrex {
 
-HypreABecLap3::HypreABecLap3 (const BoxArray& grids,
-                              const DistributionMapping& dmap,
-                              const Geometry& geom_,
-                              MPI_Comm comm_)
+HypreABecLap3::HypreABecLap3(const BoxArray& grids,
+                             const DistributionMapping& dmap,
+                             const Geometry& geom_,
+                             MPI_Comm comm_)
     : comm(comm_),
       geom(geom_),
       verbose(1),
-      A(NULL), b(NULL), x(NULL)
-{
-    const int ncomp = 1;
-    const int ngrow = 0;
-    acoefs.define(grids, dmap, ncomp, ngrow);
-    acoefs.setVal(0.0);
+      A(NULL), b(NULL), x(NULL) {
 
-    for (int i = 0; i < BL_SPACEDIM; ++i) {
-        BoxArray edge_boxes(grids);
-        edge_boxes.surroundingNodes(i);
-        bcoefs[i].define(edge_boxes, dmap, ncomp, ngrow);        
-        bcoefs[i].setVal(0.0);
+  const int ncomp = 1;
+  int ngrow = 0;
+  acoefs.define(grids, dmap, ncomp, ngrow);
+  acoefs.setVal(0.0);
+
+  for (int i = 0; i < BL_SPACEDIM; ++i) {
+    BoxArray edge_boxes(grids);
+    edge_boxes.surroundingNodes(i);
+    bcoefs[i].define(edge_boxes, dmap, ncomp, ngrow);
+    bcoefs[i].setVal(0.0);
+  }
+
+  bd.define(grids, dmap, ncomp, geom);
+
+  int num_procs, myid;
+  MPI_Comm_size(comm, &num_procs);
+  MPI_Comm_rank(comm, &myid);
+
+  // initialize with ngrow = 1
+  ngrow = 1;
+
+  // Store the global integer index
+  GbInd.define(grids, dmap, ncomp, ngrow);
+  GbInd.setVal(0);
+
+  // Arrays needed to build the global indices for all procs
+  CellsGIndex.resize(grids.size());
+  numCellsProc.resize(num_procs+1);
+
+  // These arrays store the starting global indices of all the boxes involved
+  StartIndex.resize(grids.size());
+
+  // Check if a face is at the physical boundary or interface between boxes
+  FaceBcOffset.resize(grids.size()*BL_SPACEDIM*2);
+
+  // Initialize all the arrays to 0
+  std::fill(CellsGIndex.begin(), CellsGIndex.end(), 0);
+  std::fill(numCellsProc.begin(), numCellsProc.end(), 0);
+  std::fill(StartIndex.begin(), StartIndex.end(), 0);
+  std::fill(FaceBcOffset.begin(), FaceBcOffset.end(), 0);
+
+  // Fill the numpoints in the box and in the proc where this box resides
+  for (int i = 0; i < grids.size(); i++) {
+    const Box& bx = grids[i];
+    CellsGIndex[i] = numCellsProc[ dmap[i]+1 ];
+    numCellsProc[ dmap[i]+1 ] = numCellsProc[ dmap[i]+1 ] + bx.numPts();
+  }
+
+  // making sure that counting starts from 0 for procId = 0
+  for (int i = 1; i< (num_procs+1); i++) {
+    if (numCellsProc[i] == 0) {
+      amrex::Abort("No rows in this core - Check domain decomposition");
     }
+    numCellsProc[i] += numCellsProc[i-1];
+  }
 
-    bd.define(grids, dmap, ncomp, geom);
+  // Box starting index starting from the proc offset
+  for (int i = 0; i < grids.size(); i++) {
+    CellsGIndex[i] = CellsGIndex[i] + numCellsProc[dmap[i]];
+  }
 
-    int num_procs, myid;
-    MPI_Comm_size(comm, &num_procs );
-    MPI_Comm_rank(comm, &myid );
+  // Starting and ending global index for each box
+  for (int i = 0; i < (grids.size()-1); i++) {
+    StartIndex[i] = CellsGIndex[i];
+  }
+  StartIndex[grids.size()-1] = CellsGIndex[grids.size()-1];
 
-    // Store the global integer index
-    GbInd.define(grids, dmap, ncomp, ngrow);
-    GbInd.setVal(0);
-    
-    // Store the global integer index
-    GbInd.define(grids, dmap, ncomp, ngrow);
-    GbInd.setVal(0);
+  // Fill up the imultifab with global indices
+  for (MFIter mfi(GbInd); mfi.isValid(); ++mfi) {
+    int i = mfi.index();
+    const Box &reg = mfi.validbox();
 
-    // Arrays needed to build the global indices for all procs
-    CellsGIndex.resize(grids.size());
-    numCellsProc.resize(num_procs+1);
+    // build the global index for all cells on this level
+    amrex_BuildGlobalIndex(BL_TO_FORTRAN(GbInd[mfi]), ARLIM(reg.loVect()),
+                           ARLIM(reg.hiVect()), CellsGIndex[i]);
+  }
 
-    // These arrays store the starting and ending global indices of all the boxes involved
-    StartIndex.resize(grids.size());
-    
-    //Initialize all the arrays to 0 
-    std::fill(CellsGIndex.begin() ,CellsGIndex.end(), 0);
-    std::fill(numCellsProc.begin(),numCellsProc.end(), 0);
-    std::fill(StartIndex.begin(),StartIndex.end(),0);
-    
-    // Fill the numpoints in the box and in the proc where this box resides
-    for (int i = 0; i < grids.size(); i++) {
-        const Box& bx = grids[i];
-        CellsGIndex[i] = numCellsProc[ dmap[i]+1 ] ;
-        numCellsProc[ dmap[i]+1 ] = numCellsProc[ dmap[i]+1 ] + bx.numPts();
-    }
+  const int nghost = 0;
+  bool local = true;
+  int ilower = GbInd.min(0, nghost, local);
+  int iupper = GbInd.max(0, nghost, local);
 
-    // making sure that counting starts from 0 for procId = 0
-    for (int i = 1; i<(num_procs+1);i++){
-        if(numCellsProc[i]==0) {
-            amrex::Abort("No rows in this core - Check domain decomposition");
-        }
-        numCellsProc[i] += numCellsProc[i-1];
-    }
+  // Fill the global indices in the ghost cells along the grid edges
+  GbInd.FillBoundary();
 
-    // Box starting index starting from the proc offset
-    for (int i = 0; i < grids.size(); i++) {
-        CellsGIndex[i] = CellsGIndex[i] + numCellsProc[dmap[i]];
-    }
+  // Create the HYPRE matrix object
+  HYPRE_IJMatrixCreate(comm, ilower, iupper, ilower, iupper, &A);
 
-    // Starting and ending global index for each box
-    for (int i = 0; i < (grids.size()-1); i++) {
-        StartIndex[i] = CellsGIndex[i];
-    }
-    StartIndex[grids.size()-1] = CellsGIndex[grids.size()-1];
+  // Parallel csr format storage
+  HYPRE_IJMatrixSetObjectType(A, HYPRE_PARCSR);
 
-    // Fill up the Imultifab with global indices
-    for (MFIter mfi(GbInd); mfi.isValid(); ++mfi)
-    {
-        int i = mfi.index();
-        const Box &reg = mfi.validbox();
-        // build the global index for all cells on this level
-        amrex_BuildGlobalIndex(BL_TO_FORTRAN(GbInd[mfi]),ARLIM(reg.loVect()), ARLIM(reg.hiVect()),CellsGIndex[i]);
-    }
-    
-    const int nghost = 0;
-    bool local = true;
-    int ilower = GbInd.min(0, nghost,local);
-    int iupper = GbInd.max(0, nghost,local);
+  // Initialize before setting coefficients
+  HYPRE_IJMatrixInitialize(A);
 
-    // Create the HYPRE matrix object 
-    HYPRE_IJMatrixCreate(comm,ilower,iupper,ilower,iupper, &A);
-    
-    // Parallel csr format storage
-    HYPRE_IJMatrixSetObjectType(A, HYPRE_PARCSR);
-    
-    // Initialize before setting coefficients
-    HYPRE_IJMatrixInitialize(A);
+  // Create the RHS and solution vector object
+  HYPRE_IJVectorCreate(comm, ilower, iupper, &b);
+  HYPRE_IJVectorSetObjectType(b, HYPRE_PARCSR);
+  HYPRE_IJVectorInitialize(b);
 
-    // Create the RHS and solution vector object
-    HYPRE_IJVectorCreate(comm, ilower, iupper,&b);
-    HYPRE_IJVectorSetObjectType(b, HYPRE_PARCSR);
-    HYPRE_IJVectorInitialize(b);
-
-    HYPRE_IJVectorCreate(comm, ilower, iupper,&x);
-    HYPRE_IJVectorSetObjectType(x, HYPRE_PARCSR);
-    HYPRE_IJVectorInitialize(x);
-    
+  HYPRE_IJVectorCreate(comm, ilower, iupper, &x);
+  HYPRE_IJVectorSetObjectType(x, HYPRE_PARCSR);
+  HYPRE_IJVectorInitialize(x);
 }
-    
-HypreABecLap3::~HypreABecLap3 ()
-{
-    HYPRE_IJMatrixDestroy(A);
-    HYPRE_IJVectorDestroy(b);
-    HYPRE_IJVectorDestroy(x);
+
+HypreABecLap3::~HypreABecLap3() {
+  HYPRE_IJMatrixDestroy(A);
+  HYPRE_IJVectorDestroy(b);
+  HYPRE_IJVectorDestroy(x);
+}
+
+void HypreABecLap3::setScalars(Real sa, Real sb) {
+  scalar_a = sa;
+  scalar_b = sb;
 }
 
 void
-HypreABecLap3::setScalars (Real sa, Real sb)
-{
-    scalar_a = sa;
-    scalar_b = sb;
+HypreABecLap3::setACoeffs(const MultiFab& alpha) {
+  MultiFab::Copy(acoefs, alpha, 0, 0, 1, 0);
 }
 
 void
-HypreABecLap3::setACoeffs (const MultiFab& alpha)
-{
-    MultiFab::Copy(acoefs, alpha, 0, 0, 1, 0);
+HypreABecLap3::setBCoeffs(const std::array<const MultiFab*,
+                          BL_SPACEDIM>& beta) {
+  for (int idim=0; idim < BL_SPACEDIM; idim++) {
+    MultiFab::Copy(bcoefs[idim], *beta[idim], 0, 0, 1, 0);
+  }
+}
+
+void HypreABecLap3::setVerbose(int _verbose) {
+  verbose = _verbose;
 }
 
 void
-HypreABecLap3::setBCoeffs (const std::array<const MultiFab*,BL_SPACEDIM>& beta)
-{
-    for (int idim=0; idim<BL_SPACEDIM; idim++) {
-        MultiFab::Copy(bcoefs[idim], *beta[idim], 0, 0, 1, 0);
-    }
+HypreABecLap3::solve(MultiFab& soln, const MultiFab& rhs,
+                     Real rel_tol_, Real abs_tol_,
+                     int max_iter_, LinOpBCType bc_type, Real bc_value) {
+  loadBndryData(bc_type, bc_value);
+  loadMatrix();
+  finalizeMatrix();
+  loadVectors(soln, rhs);
+  finalizeVectors();
+  setupSolver(rel_tol_, abs_tol_, max_iter_);
+  solveDoIt();
+  getSolution(soln);
+  clearSolver();
 }
 
 void
-HypreABecLap3::setVerbose (int _verbose)
-{
-    verbose = _verbose;
+HypreABecLap3::solve(MultiFab& soln, const MultiFab& rhs,
+                     Real rel_tol_, Real abs_tol_,
+                     int max_iter_, const BndryData& _bndry) {
+  bd = _bndry;
+
+  loadMatrix();
+  finalizeMatrix();
+  loadVectors(soln, rhs);
+  finalizeVectors();
+  setupSolver(rel_tol_, abs_tol_, max_iter_);
+  solveDoIt();
+  getSolution(soln);
+  clearSolver();
 }
 
-void
-HypreABecLap3::solve (MultiFab& soln, const MultiFab& rhs, Real rel_tol_, Real abs_tol_, 
-                      int max_iter_, LinOpBCType bc_type, Real bc_value)
-{
-    
-    loadBndryData(bc_type, bc_value);
+void HypreABecLap3::loadBndryData(LinOpBCType bc_type, Real bc_value) {
+  const int comp = 0;
+  const Real* dx = geom.CellSize();
+  for (int n=0; n< BL_SPACEDIM; ++n) {
+    for (MFIter mfi(acoefs); mfi.isValid(); ++mfi) {
+      int i = mfi.index();
 
-    loadMatrix();
+      const Box& bx = mfi.validbox();
 
-    finalizeMatrix();
+      // Our default will be that the face of this grid is
+      // either touching another grid
+      // across an interior boundary or a periodic boundary.
+      // We will test for the other
+      // cases below.
+      {
+        // Define the type of boundary conditions to be Dirichlet
+        // (even for periodic)
+        bd.setBoundCond(Orientation(n, Orientation::low), i,
+                        comp, LO_DIRICHLET);
+        bd.setBoundCond(Orientation(n, Orientation::high), i,
+                        comp, LO_DIRICHLET);
 
-    loadVectors(soln, rhs);
+        // Set the boundary conditions to the
+        // cell centers outside the domain
+        bd.setBoundLoc(Orientation(n, Orientation::low), i, 0.5*dx[n]);
+        bd.setBoundLoc(Orientation(n, Orientation::high), i, 0.5*dx[n]);
+      }
 
-    finalizeVectors();
+      // Now test to see if we should override
+      // the above with Dirichlet or Neumann physical bc's
+      if(bc_type != LinOpBCType::interior) {
+        int ibnd = static_cast<int>(bc_type);
+        // either LO_DIRICHLET or LO_NEUMANN
 
-    setupSolver(rel_tol_, abs_tol_, max_iter_);
+        // We are on the low side of the
+        // domain in coordinate direction n
 
-    solveDoIt();
+        if (bx.smallEnd(n) == geom.Domain().smallEnd(n)) {
+          // Set the boundary conditions to
+          // live exactly on the faces of the domain
+          bd.setBoundLoc(Orientation(n, Orientation::low), i, 0.0);
 
-    getSolution(soln);
-        
-    clearSolver();
-}
+          // Set the Dirichlet/Neumann boundary values
+          bd.setValue(Orientation(n, Orientation::low), i, bc_value);
 
-void
-HypreABecLap3::solve (MultiFab& soln, const MultiFab& rhs, Real rel_tol_, Real abs_tol_, 
-                      int max_iter_, const BndryData& _bndry)
-{
-    bd = _bndry;
-
-    loadMatrix();
-    finalizeMatrix();
-    
-    loadVectors(soln, rhs);
-    finalizeVectors();
-    
-    setupSolver(rel_tol_, abs_tol_, max_iter_);
-    solveDoIt();
-    getSolution(soln);
-    
-    clearSolver();
-}
-
-void
-HypreABecLap3::loadBndryData (LinOpBCType bc_type, Real bc_value)
-{
-    const int comp = 0;
-    const Real* dx = geom.CellSize();
-    for (int n=0; n<BL_SPACEDIM; ++n) {
-        for (MFIter mfi(acoefs); mfi.isValid(); ++mfi ) {
-            int i = mfi.index(); 
-            
-            const Box& bx = mfi.validbox();
-            
-            // Our default will be that the face of this grid is either touching another grid
-            //  across an interior boundary or a periodic boundary.  We will test for the other
-            //  cases below.
-            {
-                // Define the type of boundary conditions to be Dirichlet (even for periodic)
-                bd.setBoundCond(Orientation(n, Orientation::low) ,i,comp,LO_DIRICHLET);
-                bd.setBoundCond(Orientation(n, Orientation::high),i,comp,LO_DIRICHLET);
-                
-                // Set the boundary conditions to the cell centers outside the domain
-                bd.setBoundLoc(Orientation(n, Orientation::low) ,i,0.5*dx[n]);
-                bd.setBoundLoc(Orientation(n, Orientation::high),i,0.5*dx[n]);
-            }
-            
-            // Now test to see if we should override the above with Dirichlet or Neumann physical bc's
-            if (bc_type != LinOpBCType::interior)
-            { 
-                int ibnd = static_cast<int>(bc_type); // either LO_DIRICHLET or LO_NEUMANN
-                
-                // We are on the low side of the domain in coordinate direction n
-                if (bx.smallEnd(n) == geom.Domain().smallEnd(n)) {
-                    // Set the boundary conditions to live exactly on the faces of the domain
-                    bd.setBoundLoc(Orientation(n, Orientation::low) ,i,0.0 );
-                    
-                    // Set the Dirichlet/Neumann boundary values 
-                    bd.setValue(Orientation(n, Orientation::low) ,i, bc_value);
-                    
-                    // Define the type of boundary conditions 
-                    bd.setBoundCond(Orientation(n, Orientation::low) ,i,comp,ibnd);
-                }
-                
-                // We are on the high side of the domain in coordinate direction n
-                if (bx.bigEnd(n) == geom.Domain().bigEnd(n)) {
-                    // Set the boundary conditions to live exactly on the faces of the domain
-                    bd.setBoundLoc(Orientation(n, Orientation::high) ,i,0.0 );
-                    
-                    // Set the Dirichlet/Neumann boundary values
-                    bd.setValue(Orientation(n, Orientation::high) ,i, bc_value);
-                    
-                    // Define the type of boundary conditions 
-                    bd.setBoundCond(Orientation(n, Orientation::high) ,i,comp,ibnd);
-                }
-            }
-        }
-    }
-}
-
-void
-HypreABecLap3::loadMatrix ()
-{
-    static_assert(BL_SPACEDIM > 1, "HypreABecLap2: 1D not supported");
-
-    const int size = 2 * BL_SPACEDIM + 1;
-    
-    const int bho = 0;
-    const Real* dx = geom.CellSize();
-
-    for (MFIter mfi(acoefs); mfi.isValid(); ++mfi)
-    {
-        int i = mfi.index();
-        const Box &reg = mfi.validbox();
-
-        int volume = reg.numPts();
-        
-        // build matrix interior
-
-        amrex_hmac_ij(BL_TO_FORTRAN(acoefs[mfi]),ARLIM(reg.loVect()), ARLIM(reg.hiVect()),
-                      scalar_a, A,BL_TO_FORTRAN(GbInd[mfi]));
-
-         for (int idim = 0; idim < BL_SPACEDIM; idim++) {
-             amrex_hmbc_ij(BL_TO_FORTRAN(bcoefs[idim][mfi]),
-                           ARLIM(reg.loVect()), ARLIM(reg.hiVect()), scalar_b,
-                           geom.CellSize(), idim, A,BL_TO_FORTRAN(GbInd[mfi]));
-         }
-
-        // add b.c.'s to matrix diagonal, and
-        // zero out offdiag values at domain boundaries
-
-        const Vector< Vector<BoundCond> > & bcs_i = bd.bndryConds(i);
-        const BndryData::RealTuple      & bcl_i = bd.bndryLocs(i);
-        
-        const Box& domain = geom.Domain();
-        for (OrientationIter oitr; oitr; oitr++) {
-            int cdir(oitr());
-            int idim = oitr().coordDir();
-            const int bctype = bcs_i[cdir][0];
-            const Real &bcl  = bcl_i[cdir];
-            const Mask &msk  = bd.bndryMasks(oitr())[mfi];
-
-            // Treat an exposed grid edge here as a boundary condition
-            // for the linear solver:
-            
-             if (reg[oitr()] == domain[oitr()]) {
-                 amrex_hmmat3_ij(ARLIM(reg.loVect()), ARLIM(reg.hiVect()),
-                              cdir, bctype, bho, bcl,
-                              BL_TO_FORTRAN(msk),
-                              BL_TO_FORTRAN(bcoefs[idim][mfi]),
-                                 scalar_b, dx, A,BL_TO_FORTRAN(GbInd[mfi]));
-
-             }
-             else {
-                 amrex_hmmat_ij(ARLIM(reg.loVect()), ARLIM(reg.hiVect()),
-                             cdir, bctype, bho, bcl,
-                             BL_TO_FORTRAN(msk),
-                             BL_TO_FORTRAN(bcoefs[idim][mfi]),
-                             scalar_b, dx, A,BL_TO_FORTRAN(GbInd[mfi]));
-
-             }
-            
+          // Define the type of boundary conditions
+          bd.setBoundCond(Orientation(n, Orientation::low),
+                          i, comp, ibnd);
         }
 
+        // We are on the high side of the
+        // domain in coordinate direction n
+        if (bx.bigEnd(n) == geom.Domain().bigEnd(n)) {
+          // Set the boundary conditions to
+          // live exactly on the faces of the domain
+          bd.setBoundLoc(Orientation(n, Orientation::high), i, 0.0);
+
+          // Set the Dirichlet/Neumann boundary values
+          bd.setValue(Orientation(n, Orientation::high), i, bc_value);
+
+          // Define the type of boundary conditions
+          bd.setBoundCond(Orientation(n, Orientation::high),
+                          i, comp, ibnd);
+        }
+      }
     }
+  }
 }
 
-void
-HypreABecLap3::finalizeMatrix ()
-{
-    // Assemble after setting the coefficients
-    HYPRE_IJMatrixAssemble(A);
-}
+void HypreABecLap3::loadMatrix() {
+  static_assert(BL_SPACEDIM > 1, "HypreABecLap2: 1D not supported");
 
-void
-HypreABecLap3::loadVectors (MultiFab& soln, const MultiFab& rhs)
-{
-    const int bho = 0;
-    const Real* dx = geom.CellSize();
+  const int size = 2 * BL_SPACEDIM + 1;
+  const int bho = 0;
+  const Real* dx = geom.CellSize();
 
-    FArrayBox fnew;
+  for (MFIter mfi(acoefs); mfi.isValid(); ++mfi) {
+    int i = mfi.index();
+    const Box &reg = mfi.validbox();
+    const Box& domain = geom.Domain();
 
-    soln.setVal(0.0);
-
-    for (MFIter mfi(soln); mfi.isValid(); ++mfi)
-    {
-        int i = mfi.index();
-        const Box &reg = mfi.validbox();
-
-        // initialize soln, since we will reuse the space to set up rhs below:
-
-        FArrayBox *f;
-        if (soln.nGrow() == 0) { // need a temporary if soln is the wrong size
-            f = &soln[mfi];
-        }
-        else {
-            f = &fnew;
-            f->resize(reg);
-            f->copy(soln[mfi], 0, 0, 1);
-        }
-        Real* vec = f->dataPtr(); // sharing space, soln will be overwritten below
-
-        Real *VecGB       = hypre_CTAlloc(double, reg.numPts());
-        int *VecIndices   = hypre_CTAlloc(int, reg.numPts());
-
-        // Convert the 3D vec array to 1D array with indices corresponding to row indices in the matrix
-        amrex_conv_Vec_Local_Global(vec,VecGB,VecIndices,reg.numPts(),ARLIM(reg.loVect()), ARLIM(reg.hiVect()),
-                            BL_TO_FORTRAN(GbInd[mfi]));
-
-        // Set the solution vector
-        HYPRE_IJVectorSetValues(x, reg.numPts(), VecIndices, VecGB);
-        
-        // Copy the rhs vector
-        f->copy(rhs[mfi], 0, 0, 1);
-
-        // add b.c.'s to rhs
-
-        const Vector< Vector<BoundCond> > & bcs_i = bd.bndryConds(i);
-        const BndryData::RealTuple      & bcl_i = bd.bndryLocs(i);
-
-        const Box& domain = geom.Domain();
-        for (OrientationIter oitr; oitr; oitr++) {
-            int cdir(oitr());
-            int idim = oitr().coordDir();
-            const int bctype = bcs_i[cdir][0];
-            const Real &bcl  = bcl_i[cdir];
-
-            const Mask &msk  = bd.bndryMasks(oitr())[mfi];
-            const FArrayBox &fs = bd.bndryValues(oitr())[mfi];
-
-            // Treat an exposed grid edge here as a boundary condition
-            // for the linear solver:
-            
-            if (reg[oitr()] == domain[oitr()]) {
-                amrex_hbvec3(vec, ARLIM(reg.loVect()), ARLIM(reg.hiVect()),
-                             cdir, bctype, bho, bcl,
-                             BL_TO_FORTRAN(fs),
-                             BL_TO_FORTRAN(msk),
-                             BL_TO_FORTRAN(bcoefs[idim][mfi]),
-                             scalar_b, dx);
-            }
-            else {
-                amrex_hbvec(vec, ARLIM(reg.loVect()), ARLIM(reg.hiVect()),
-                            cdir, bctype, bho, bcl,
-                            BL_TO_FORTRAN(fs),
-                            BL_TO_FORTRAN(msk),
-                            BL_TO_FORTRAN(bcoefs[idim][mfi]),
-                            scalar_b, dx);
-            }
-        }
-
-        // initialize rhs
-        amrex_conv_Vec_Local_Global(vec,VecGB,VecIndices,reg.numPts(),ARLIM(reg.loVect()), ARLIM(reg.hiVect()),
-                                    BL_TO_FORTRAN(GbInd[mfi]));
-
-        HYPRE_IJVectorSetValues(b, reg.numPts(), VecIndices, VecGB);
-
-        hypre_TFree(VecGB);
-        hypre_TFree(VecIndices);
-
-        
+    for (OrientationIter oitr; oitr; oitr++) {
+      int cdir(oitr());
+      if (reg[oitr()] == domain[oitr()]) {
+        FaceBcOffset[i*BL_SPACEDIM*2+cdir] = 1;
+      } else {
+        FaceBcOffset[i*BL_SPACEDIM*2+cdir] = 0;
+      }
     }
-}
+  }
 
-void
-HypreABecLap3::finalizeVectors ()
-{
-    HYPRE_IJVectorAssemble(x);
-    HYPRE_IJVectorAssemble(b);
+  for (MFIter mfi(acoefs); mfi.isValid(); ++mfi) {
+    int i = mfi.index();
+    const Box &reg = mfi.validbox();
 
-}
+    int volume = reg.numPts();
 
-void
-HypreABecLap3::setupSolver (Real rel_tol_, Real abs_tol_, int max_iter_)
-{
-    rel_tol = rel_tol_;
-    abs_tol = abs_tol_;
-    max_iter = max_iter_;
+    // build matrix interior
 
-    HYPRE_BoomerAMGCreate(&solver);
+    amrex_hmac_ij(BL_TO_FORTRAN(acoefs[mfi]), ARLIM(reg.loVect()),
+                  ARLIM(reg.hiVect()), scalar_a,
+                  A, BL_TO_FORTRAN(GbInd[mfi]));
 
-    HYPRE_BoomerAMGSetMinIter(solver, 1);
-    HYPRE_BoomerAMGSetMaxIter(solver, max_iter);
-    HYPRE_BoomerAMGSetTol(solver, rel_tol);
+    int* BCface = FaceBcOffset.data();
 
-    // Set some parameters (See Reference Manual for more parameters)
-    HYPRE_BoomerAMGSetOldDefault(solver); /* Falgout coarsening with modified classical interpolation */
-    HYPRE_BoomerAMGSetCoarsenType(solver,6);
-    HYPRE_BoomerAMGSetCycleType (solver, 1);
-    HYPRE_BoomerAMGSetRelaxType(solver, 6);   /* G-S/Jacobi hybrid relaxation */
-    HYPRE_BoomerAMGSetRelaxOrder(solver, 1);   /* uses C/F relaxation */
-    HYPRE_BoomerAMGSetNumSweeps(solver, 2);   /* Sweeeps on each level */
-    HYPRE_BoomerAMGSetMaxLevels(solver, 20);  /* maximum number of levels */
-    HYPRE_BoomerAMGSetStrongThreshold (solver,0.6);
-    
-    // Get the parcsr matrix object to use 
-    HYPRE_IJMatrixGetObject(A, (void**) &par_A);
-    HYPRE_IJVectorGetObject(b, (void **) &par_b);
-    HYPRE_IJVectorGetObject(x, (void **) &par_x);
-    
-    HYPRE_BoomerAMGSetup(solver, par_A, par_b, par_x);
-
-}
-
-void
-HypreABecLap3::clearSolver ()
-{
-    HYPRE_BoomerAMGDestroy(solver);
-}
-
-void
-HypreABecLap3::solveDoIt ()
-{
-    if (abs_tol > 0.0)
-    {
-        Real bnorm;
-        bnorm = hypre_ParVectorInnerProd (par_b ,par_b);
-        bnorm = std::sqrt(bnorm);
-
-        const BoxArray& grids = acoefs.boxArray();
-        Real volume = grids.numPts();
-        Real rel_tol_new = bnorm > 0.0 ? abs_tol / bnorm * std::sqrt(volume) : rel_tol;
-
-        if (rel_tol_new > rel_tol) {
-            HYPRE_BoomerAMGSetTol(solver, rel_tol_new);
-        }
+    for (int idim = 0; idim < BL_SPACEDIM; idim++) {
+      amrex_hmbc_ij(BL_TO_FORTRAN(bcoefs[idim][mfi]),
+                    ARLIM(reg.loVect()), ARLIM(reg.hiVect()), scalar_b,
+                    geom.CellSize(), idim, A, BL_TO_FORTRAN(GbInd[mfi]),
+                    BL_SPACEDIM*2, &BCface[i*BL_SPACEDIM*2]);
     }
 
-    HYPRE_BoomerAMGSolve(solver, par_A, par_b, par_x);
-    
-    if (verbose >= 2 && ParallelDescriptor::IOProcessor()) {
-        int num_iterations;
-        Real res;
-        HYPRE_BoomerAMGGetNumIterations(solver, &num_iterations);
-        HYPRE_BoomerAMGGetFinalRelativeResidualNorm(solver, &res);
-        
-        int oldprec = std::cout.precision(17);
-        std::cout <<"\n" <<  num_iterations
-                  << " Hypre Multigrid Iterations, Relative Residual "
-                  << res << std::endl;
-        std::cout.precision(oldprec);
+    // add b.c.'s to matrix diagonal, and
+    // zero out offdiag values at domain boundaries
+
+    const Vector< Vector<BoundCond> > & bcs_i = bd.bndryConds(i);
+    const BndryData::RealTuple      & bcl_i = bd.bndryLocs(i);
+
+    const Box& domain = geom.Domain();
+    for (OrientationIter oitr; oitr; oitr++) {
+      int cdir(oitr());
+      int idim = oitr().coordDir();
+      const int bctype = bcs_i[cdir][0];
+      const Real &bcl  = bcl_i[cdir];
+      const Mask &msk  = bd.bndryMasks(oitr())[mfi];
+
+      // Treat an exposed grid edge here as a boundary condition
+      // for the linear solver:
+
+      if (reg[oitr()] == domain[oitr()]) {
+        amrex_hmmat3_ij(ARLIM(reg.loVect()), ARLIM(reg.hiVect()),
+                        cdir, bctype, bho, bcl,
+                        BL_TO_FORTRAN(msk),
+                        BL_TO_FORTRAN(bcoefs[idim][mfi]),
+                        scalar_b, dx, A, BL_TO_FORTRAN(GbInd[mfi]));
+      } else {
+        amrex_hmmat_ij(ARLIM(reg.loVect()), ARLIM(reg.hiVect()),
+                       cdir, bctype, bho, bcl,
+                       BL_TO_FORTRAN(msk),
+                       BL_TO_FORTRAN(bcoefs[idim][mfi]),
+                       scalar_b, dx, A, BL_TO_FORTRAN(GbInd[mfi]));
+      }
     }
+  }
 }
 
-void
-HypreABecLap3::getSolution (MultiFab& soln)
-{
-    const int part = 0;
+void HypreABecLap3::finalizeMatrix() {
+  // Assemble after setting the coefficients
+  HYPRE_IJMatrixAssemble(A);
+}
 
-    std::vector<int> VecIndices;
+void HypreABecLap3::loadVectors(MultiFab& soln, const MultiFab& rhs) {
+  const int bho = 0;
+  const Real* dx = geom.CellSize();
 
-    FArrayBox fnew;
-    for (MFIter mfi(soln); mfi.isValid(); ++mfi)
-    {
-        const Box &reg = mfi.validbox();
+  FArrayBox fnew;
 
-        FArrayBox *f;
-        if (soln.nGrow() == 0) { // need a temporary if soln is the wrong size
-            f = &soln[mfi];
-        }
-        else {
-            f = &fnew;
-            f->resize(reg);
-        }
+  soln.setVal(0.0);
 
-        int i = mfi.index();
+  for (MFIter mfi(soln); mfi.isValid(); ++mfi) {
+    int i = mfi.index();
+    const Box &reg = mfi.validbox();
 
-        // Storage for the solution vector returned by HYPRE
-        Real *VecGB       = hypre_CTAlloc(double, reg.numPts());
+    // initialize soln, since we will reuse the space to set up rhs below:
 
-        // Generate indices corresponding to all the boxes
-        VecIndices.resize(reg.numPts());
-        std::iota (VecIndices.begin(),VecIndices.end(), StartIndex[i]);
-        int* RowIndices = VecIndices.data();
-
-        // Get the solution from HYPRE 
-        HYPRE_IJVectorGetValues(x, reg.numPts(),RowIndices, VecGB);
-
-        // Move the solution vector back to the soln multifab
-        amrex_conv_Vec_Global_Local(BL_TO_FORTRAN(*f), VecGB,reg.numPts(),ARLIM(reg.loVect()), ARLIM(reg.hiVect()));
-
-        if (soln.nGrow() != 0) {
-            soln[mfi].copy(*f, 0, 0, 1);
-        }
-
-        hypre_TFree(VecGB);
-	
-        
+    FArrayBox *f;
+    if (soln.nGrow() == 0) {  // need a temporary if soln is the wrong size
+      f = &soln[mfi];
+    } else {
+      f = &fnew;
+      f->resize(reg);
+      f->copy(soln[mfi], 0, 0, 1);
     }
+    // sharing space, soln will be overwritten below
+    Real* vec = f->dataPtr();
+
+    // Convert the 3D vec array to 1D array with indices
+    // corresponding to row indices in the matrix
+    amrex_conv_Vec_Local_Global(x, vec, reg.numPts(),
+                                ARLIM(reg.loVect()), ARLIM(reg.hiVect()),
+                                BL_TO_FORTRAN(GbInd[mfi]));
+
+    // Copy the rhs vector
+    f->copy(rhs[mfi], 0, 0, 1);
+
+    // add b.c.'s to rhs
+    const Vector< Vector<BoundCond> > & bcs_i = bd.bndryConds(i);
+    const BndryData::RealTuple      & bcl_i = bd.bndryLocs(i);
+
+    const Box& domain = geom.Domain();
+    for (OrientationIter oitr; oitr; oitr++) {
+      int cdir(oitr());
+      int idim = oitr().coordDir();
+      const int bctype = bcs_i[cdir][0];
+      const Real &bcl  = bcl_i[cdir];
+
+      const Mask &msk  = bd.bndryMasks(oitr())[mfi];
+      const FArrayBox &fs = bd.bndryValues(oitr())[mfi];
+
+      // Treat an exposed grid edge here as a boundary condition
+      // for the linear solver:
+      if (reg[oitr()] == domain[oitr()]) {
+        amrex_hbvec3(vec, ARLIM(reg.loVect()), ARLIM(reg.hiVect()),
+                     cdir, bctype, bho, bcl,
+                     BL_TO_FORTRAN(fs),
+                     BL_TO_FORTRAN(msk),
+                     BL_TO_FORTRAN(bcoefs[idim][mfi]),
+                     scalar_b, dx);
+      } else {
+        amrex_hbvec(vec, ARLIM(reg.loVect()), ARLIM(reg.hiVect()),
+                    cdir, bctype, bho, bcl,
+                    BL_TO_FORTRAN(fs),
+                    BL_TO_FORTRAN(msk),
+                    BL_TO_FORTRAN(bcoefs[idim][mfi]),
+                    scalar_b, dx);
+      }
+    }
+
+    // initialize rhs
+    amrex_conv_Vec_Local_Global(b, vec, reg.numPts(),
+                                ARLIM(reg.loVect()), ARLIM(reg.hiVect()),
+                                BL_TO_FORTRAN(GbInd[mfi]));
+  }
 }
 
+void HypreABecLap3::finalizeVectors() {
+  HYPRE_IJVectorAssemble(x);
+  HYPRE_IJVectorAssemble(b);
 }
+
+void HypreABecLap3::setupSolver(Real rel_tol_, Real abs_tol_, int max_iter_) {
+  rel_tol = rel_tol_;
+  abs_tol = abs_tol_;
+  max_iter = max_iter_;
+
+  HYPRE_BoomerAMGCreate(&solver);
+
+  HYPRE_BoomerAMGSetMinIter(solver, 1);
+  HYPRE_BoomerAMGSetMaxIter(solver, max_iter);
+  HYPRE_BoomerAMGSetTol(solver, rel_tol);
+
+  // Set some parameters (See Reference Manual for more parameters)
+  // Falgout coarsening with modified classical interpolation
+  HYPRE_BoomerAMGSetOldDefault(solver);
+  HYPRE_BoomerAMGSetCoarsenType(solver, 6);
+  HYPRE_BoomerAMGSetCycleType(solver, 1);
+  HYPRE_BoomerAMGSetRelaxType(solver, 6);   /* G-S/Jacobi hybrid relaxation */
+  HYPRE_BoomerAMGSetRelaxOrder(solver, 1);   /* uses C/F relaxation */
+  HYPRE_BoomerAMGSetNumSweeps(solver, 2);   /* Sweeeps on each level */
+  HYPRE_BoomerAMGSetMaxLevels(solver, 20);  /* maximum number of levels */
+  HYPRE_BoomerAMGSetStrongThreshold(solver, 0.6);
+
+  // Get the parcsr matrix object to use
+
+  HYPRE_IJMatrixGetObject(A, (void**)  &par_A);
+  HYPRE_IJVectorGetObject(b, (void **) &par_b);
+  HYPRE_IJVectorGetObject(x, (void **) &par_x);
+
+  HYPRE_BoomerAMGSetup(solver, par_A, par_b, par_x);
+}
+
+void HypreABecLap3::clearSolver() {
+  HYPRE_BoomerAMGDestroy(solver);
+}
+
+void HypreABecLap3::solveDoIt() {
+  if (abs_tol > 0.0) {
+    Real bnorm;
+    bnorm = hypre_ParVectorInnerProd(par_b, par_b);
+    bnorm = std::sqrt(bnorm);
+
+    const BoxArray& grids = acoefs.boxArray();
+    Real volume = grids.numPts();
+    Real rel_tol_new = bnorm > 0.0 ? abs_tol / bnorm *
+        std::sqrt(volume) : rel_tol;
+
+    if (rel_tol_new > rel_tol) {
+      HYPRE_BoomerAMGSetTol(solver, rel_tol_new);
+    }
+  }
+
+  HYPRE_BoomerAMGSolve(solver, par_A, par_b, par_x);
+  if (verbose >= 2 && ParallelDescriptor::IOProcessor()) {
+    int num_iterations;
+    Real res;
+    HYPRE_BoomerAMGGetNumIterations(solver, &num_iterations);
+    HYPRE_BoomerAMGGetFinalRelativeResidualNorm(solver, &res);
+
+    int oldprec = std::cout.precision(17);
+    std::cout <<"\n" <<  num_iterations
+              << " Hypre Multigrid Iterations, Relative Residual "
+              << res << std::endl;
+    std::cout.precision(oldprec);
+  }
+}
+
+void HypreABecLap3::getSolution(MultiFab& soln) {
+  const int part = 0;
+
+  std::vector<int> VecIndices;
+
+  FArrayBox fnew;
+  for (MFIter mfi(soln); mfi.isValid(); ++mfi) {
+    const Box &reg = mfi.validbox();
+
+    FArrayBox *f;
+    if (soln.nGrow() == 0) {
+      // need a temporary if soln is the wrong size
+      f = &soln[mfi];
+    } else {
+      f = &fnew;
+      f->resize(reg);
+    }
+
+    int i = mfi.index();
+
+    // Storage for the solution vector returned by HYPRE
+    Real *VecGB = hypre_CTAlloc(double, reg.numPts(), HYPRE_MEMORY_HOST);
+
+    // Generate indices corresponding to all the boxes
+    VecIndices.resize(reg.numPts());
+    std::iota(VecIndices.begin(), VecIndices.end(), StartIndex[i]);
+    int* RowIndices = VecIndices.data();
+
+    // Get the solution from HYPRE
+    HYPRE_IJVectorGetValues(x, reg.numPts(), RowIndices, VecGB);
+
+    // Move the solution vector back to the soln multifab
+    amrex_conv_Vec_Global_Local(BL_TO_FORTRAN(*f), VecGB,
+                                reg.numPts(), ARLIM(reg.loVect()),
+                                ARLIM(reg.hiVect()));
+
+    if (soln.nGrow() != 0) {
+      soln[mfi].copy(*f, 0, 0, 1);
+    }
+
+    hypre_TFree(VecGB, HYPRE_MEMORY_HOST);
+  }
+}
+
+}  // namespace amrex

--- a/Src/Extern/HYPRE/AMReX_HypreABec_F.H
+++ b/Src/Extern/HYPRE/AMReX_HypreABec_F.H
@@ -97,8 +97,7 @@ extern "C" {
     void amrex_hmbc_ij(BL_FORT_FAB_ARG(bcoefs),
                     ARLIM_P(reglo), ARLIM_P(reghi),
                     const amrex::Real& beta, const amrex::Real* dx, const int& n, 
-                    HYPRE_IJMatrix &A, BL_FORT_IFAB_ARG(Index),
-                    const int& ndim, const int* bcFace);
+                    HYPRE_IJMatrix &A, BL_FORT_IFAB_ARG(Index));
     
     void amrex_hmmat(amrex::Real* mat, ARLIM_P(reglo), ARLIM_P(reghi),
                      const int& cdir, const int& bct,
@@ -157,7 +156,7 @@ extern "C" {
                                 ARLIM_P(reglo), ARLIM_P(reghi),
                                 BL_FORT_IFAB_ARG(Index), const int& nDim);
     
-  void amrex_conv_Vec_Local_Global(HYPRE_IJVector &x, amrex::Real* vec,
+    void amrex_conv_Vec_Local_Global(HYPRE_IJVector &x, amrex::Real* vec,
                                    const int& nRows,
                                    ARLIM_P(reglo), ARLIM_P(reghi),
                                    BL_FORT_IFAB_ARG(Index) );

--- a/Src/Extern/HYPRE/AMReX_HypreABec_F.H
+++ b/Src/Extern/HYPRE/AMReX_HypreABec_F.H
@@ -59,6 +59,8 @@
 
 #include <AMReX_ArrayLim.H>
 #include <AMReX_BLFort.H>
+#include "HYPRE_parcsr_ls.h" 
+#include "_hypre_parcsr_mv.h" 
 
 #ifdef __cplusplus
 extern "C" {
@@ -78,30 +80,56 @@ extern "C" {
 		    const int* msk, ARLIM_P(mlo), ARLIM_P(mhi),
 		    const amrex_real* bcv, ARLIM_P(bvlo), ARLIM_P(bvhi));
 
-  void amrex_hmac(amrex::Real* mat, 
-	    BL_FORT_FAB_ARG(acoefs),
-	    ARLIM_P(reglo), ARLIM_P(reghi),
-	    const amrex::Real& alpha);
+    void amrex_hmac(amrex::Real* mat, 
+                    BL_FORT_FAB_ARG(acoefs),
+                    ARLIM_P(reglo), ARLIM_P(reghi),
+                    const amrex::Real& alpha);
+    
+    void amrex_hmac_ij(BL_FORT_FAB_ARG(acoefs),
+                ARLIM_P(reglo), ARLIM_P(reghi),
+                const amrex::Real& alpha, HYPRE_IJMatrix &A, BL_FORT_IFAB_ARG(Index));
+    
+    void amrex_hmbc(amrex::Real* mat,
+                    BL_FORT_FAB_ARG(bcoefs),
+                    ARLIM_P(reglo), ARLIM_P(reghi),
+                    const amrex::Real& beta, const amrex::Real* dx, const int& n);
 
-  void amrex_hmbc(amrex::Real* mat,
-	    BL_FORT_FAB_ARG(bcoefs),
-	    ARLIM_P(reglo), ARLIM_P(reghi),
-	    const amrex::Real& beta, const amrex::Real* dx, const int& n);
+    void amrex_hmbc_ij(BL_FORT_FAB_ARG(bcoefs),
+                    ARLIM_P(reglo), ARLIM_P(reghi),
+                    const amrex::Real& beta, const amrex::Real* dx, const int& n, 
+                    HYPRE_IJMatrix &A, BL_FORT_IFAB_ARG(Index));
+    
+    void amrex_hmmat(amrex::Real* mat, ARLIM_P(reglo), ARLIM_P(reghi),
+                     const int& cdir, const int& bct,
+                     const int& bho, const amrex::Real& bcl,
+                     const BL_FORT_IFAB_ARG(mask),
+                     BL_FORT_FAB_ARG(bcoefs),
+                     const amrex::Real& beta, const amrex::Real* dx);
 
-  void amrex_hmmat(amrex::Real* mat, ARLIM_P(reglo), ARLIM_P(reghi),
-	     const int& cdir, const int& bct,
-	     const int& bho, const amrex::Real& bcl,
-	     const BL_FORT_IFAB_ARG(mask),
-	     BL_FORT_FAB_ARG(bcoefs),
-	     const amrex::Real& beta, const amrex::Real* dx);
+    void amrex_hmmat_ij(ARLIM_P(reglo), ARLIM_P(reghi),
+                     const int& cdir, const int& bct,
+                     const int& bho, const amrex::Real& bcl,
+                     const BL_FORT_IFAB_ARG(mask),
+                     BL_FORT_FAB_ARG(bcoefs),
+                     const amrex::Real& beta, const amrex::Real* dx,
+                     HYPRE_IJMatrix &A, BL_FORT_IFAB_ARG(Index));
 
-  void amrex_hmmat3(amrex::Real* mat, ARLIM_P(reglo), ARLIM_P(reghi),
-	      const int& cdir, const int& bctype,
-	      const int& bho, const amrex::Real& bcl,
-	      const BL_FORT_IFAB_ARG(mask),
-	      BL_FORT_FAB_ARG(bcoefs),
-	      const amrex::Real& beta, const amrex::Real* dx);
+    void amrex_hmmat3(amrex::Real* mat, ARLIM_P(reglo), ARLIM_P(reghi),
+                      const int& cdir, const int& bctype,
+                      const int& bho, const amrex::Real& bcl,
+                      const BL_FORT_IFAB_ARG(mask),
+                      BL_FORT_FAB_ARG(bcoefs),
+                      const amrex::Real& beta, const amrex::Real* dx);
+    
+    void amrex_hmmat3_ij(ARLIM_P(reglo), ARLIM_P(reghi),
+                      const int& cdir, const int& bctype,
+                      const int& bho, const amrex::Real& bcl,
+                      const BL_FORT_IFAB_ARG(mask),
+                      BL_FORT_FAB_ARG(bcoefs),
+                      const amrex::Real& beta, const amrex::Real* dx,
+                      HYPRE_IJMatrix &A, BL_FORT_IFAB_ARG(Index));
 
+    
     void amrex_hbvec (amrex::Real* vec, ARLIM_P(reglo), ARLIM_P(reghi),
                 const int& cdir, const int& bctype,
                 const int& bho, const amrex::Real& bcl,
@@ -118,6 +146,22 @@ extern "C" {
                 const BL_FORT_FAB_ARG(bcoefs),
                 const amrex::Real& beta, const amrex::Real* dx);
 
+    void amrex_BuildGlobalIndex(BL_FORT_IFAB_ARG(Index),ARLIM_P(reglo), ARLIM_P(reghi),
+                                const int& numCellsProc);
+    
+    void amrex_MatConvertGlobal(amrex::Real* mat, int* rows, int* cols, amrex::Real* values, int* numCols,
+                                const int& nCSR, const int& nRows,
+                                ARLIM_P(reglo), ARLIM_P(reghi),
+                                BL_FORT_IFAB_ARG(Index), const int& nDim);
+    
+    void amrex_conv_Vec_Local_Global(amrex::Real* vec,amrex::Real* VecGB,int* VecIndices,const int& nRows,
+                                     ARLIM_P(reglo), ARLIM_P(reghi),
+                                     BL_FORT_IFAB_ARG(Index) );
+
+    void amrex_conv_Vec_Global_Local(BL_FORT_FAB_ARG(vec), amrex::Real* VecGB, const int& nRows,
+                                     ARLIM_P(reglo), ARLIM_P(reghi));
+
+    
 #ifdef __cplusplus
 };
 #endif

--- a/Src/Extern/HYPRE/AMReX_HypreABec_F.H
+++ b/Src/Extern/HYPRE/AMReX_HypreABec_F.H
@@ -97,7 +97,8 @@ extern "C" {
     void amrex_hmbc_ij(BL_FORT_FAB_ARG(bcoefs),
                     ARLIM_P(reglo), ARLIM_P(reghi),
                     const amrex::Real& beta, const amrex::Real* dx, const int& n, 
-                    HYPRE_IJMatrix &A, BL_FORT_IFAB_ARG(Index));
+                    HYPRE_IJMatrix &A, BL_FORT_IFAB_ARG(Index),
+                    const int& ndim, const int* bcFace);
     
     void amrex_hmmat(amrex::Real* mat, ARLIM_P(reglo), ARLIM_P(reghi),
                      const int& cdir, const int& bct,
@@ -146,19 +147,23 @@ extern "C" {
                 const BL_FORT_FAB_ARG(bcoefs),
                 const amrex::Real& beta, const amrex::Real* dx);
 
-    void amrex_BuildGlobalIndex(BL_FORT_IFAB_ARG(Index),ARLIM_P(reglo), ARLIM_P(reghi),
+    void amrex_BuildGlobalIndex(BL_FORT_IFAB_ARG(Index),
+                                ARLIM_P(reglo), ARLIM_P(reghi),
                                 const int& numCellsProc);
     
-    void amrex_MatConvertGlobal(amrex::Real* mat, int* rows, int* cols, amrex::Real* values, int* numCols,
+    void amrex_MatConvertGlobal(amrex::Real* mat, int* rows, int* cols,
+                                amrex::Real* values, int* numCols,
                                 const int& nCSR, const int& nRows,
                                 ARLIM_P(reglo), ARLIM_P(reghi),
                                 BL_FORT_IFAB_ARG(Index), const int& nDim);
     
-    void amrex_conv_Vec_Local_Global(amrex::Real* vec,amrex::Real* VecGB,int* VecIndices,const int& nRows,
-                                     ARLIM_P(reglo), ARLIM_P(reghi),
-                                     BL_FORT_IFAB_ARG(Index) );
+  void amrex_conv_Vec_Local_Global(HYPRE_IJVector &x, amrex::Real* vec,
+                                   const int& nRows,
+                                   ARLIM_P(reglo), ARLIM_P(reghi),
+                                   BL_FORT_IFAB_ARG(Index) );
 
-    void amrex_conv_Vec_Global_Local(BL_FORT_FAB_ARG(vec), amrex::Real* VecGB, const int& nRows,
+    void amrex_conv_Vec_Global_Local(BL_FORT_FAB_ARG(vec), amrex::Real* VecGB,
+                                     const int& nRows,
                                      ARLIM_P(reglo), ARLIM_P(reghi));
 
     

--- a/Src/Extern/HYPRE/Make.package
+++ b/Src/Extern/HYPRE/Make.package
@@ -1,7 +1,7 @@
 
-CEXE_sources += AMReX_HypreABecLap.cpp AMReX_HypreABecLap2.cpp AMReX_Hypre.cpp
+CEXE_sources += AMReX_HypreABecLap.cpp AMReX_HypreABecLap2.cpp AMReX_HypreABecLap3.cpp AMReX_Hypre.cpp
 
-CEXE_headers += AMReX_HypreABecLap.H AMReX_HypreABecLap2.H AMReX_Hypre.H
+CEXE_headers += AMReX_HypreABecLap.H AMReX_HypreABecLap2.H AMReX_HypreABecLap3.H AMReX_Hypre.H
 
 FEXE_headers += AMReX_HypreABec_F.H 
 


### PR DESCRIPTION
Added the HYPRE IJ Matrix in AMREX. With this functionality we can provide a generalized matrix to HYPRE to solve using Krylov solvers with BoomerAMG as preconditioner or BoomerAMG as the solver. Removes the following 7 point stencil constraints we had with Struct and SStruct interfaces in HYPRE. Will be useful for higher order discretization. 
Have tested it and compared against the SStruct interface already implemented in HYPRE. Used the Tutorials/HYPRE/ABecLaplacian test case to test this functionality. @asalmgren and @WeiqunZhang  please review this and let me know what you think. 
