### PR TITLE
fix PGI compilation

### DIFF
--- a/Src/F_BaseLib/knapsack.f90
+++ b/Src/F_BaseLib/knapsack.f90
@@ -30,7 +30,7 @@ contains
     knapsack_verbose = yesorno
   end subroutine knapsack_set_verbose
 
-  pure function greater_d(a,b) result(r)
+  function greater_d(a,b) result(r)
     logical :: r
     real(kind=dp_t), intent(in) :: a, b
     r = a > b


### PR DESCRIPTION
PGI complains that with the 'pure' keyword here:

PGF90-S-0074-Illegal number or type of arguments to heapsort_indirect_d - arguments of greater_d and cmp do not agree (/home/zingale/development/AMReX//Src/F_BaseLib/knapsack.f90: 85)

This allows Castro to compiile with the new PGI Community Edition compilers released today (18.4)