### PR TITLE
updated CG solver for multicomponent solves

### DIFF
--- a/Src/LinearSolvers/MLMG/AMReX_MLCGSolver.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLCGSolver.cpp
@@ -251,7 +251,7 @@ MLCGSolver::solve_cg (MultiFab&       sol,
 {
     BL_PROFILE_REGION("MLCGSolver::cg");
 
-    const int nghost = sol.nGrow(), ncomp = 1;
+    const int nghost = sol.nGrow(), ncomp = sol.nComp();
 
     const BoxArray& ba = sol.boxArray();
     const DistributionMapping& dm = sol.DistributionMap();


### PR DESCRIPTION
Updated the CG solver to work for multicomponent solves by setting ncomp to the number of components of the solution fab.