### PR TITLE
Removed all hard coding in Advection_F

### DIFF
--- a/Tutorials/Amr/Advection_F/Exec/SingleVortex/Prob_2d.f90
+++ b/Tutorials/Amr/Advection_F/Exec/SingleVortex/Prob_2d.f90
@@ -1,6 +1,8 @@
 
 module prob_module
 
+ use amr_data_module
+
   implicit none
 
   private
@@ -19,7 +21,7 @@ contains
     real(amrex_real), intent(in) :: time
     real(amrex_real), intent(inout) :: phi(phi_lo(1):phi_hi(1), &
          &                                 phi_lo(2):phi_hi(2), &
-         &                                 phi_lo(3):phi_hi(3))
+         &                                 phi_lo(3):phi_hi(3),ncomp)
     real(amrex_real), intent(in) :: dx(3), prob_lo(3)
     
     integer          :: i,j,k
@@ -35,10 +37,10 @@ contains
              
              if ( amrex_spacedim .eq. 2) then
                 r2 = ((x-0.5d0)**2 + (y-0.75d0)**2) / 0.01d0
-                phi(i,j,k) = 1.d0 + exp(-r2)
+                phi(i,j,k,:) = 1.d0 + exp(-r2)
              else
                 r2 = ((x-0.5d0)**2 + (y-0.75d0)**2 + (z-0.5d0)**2) / 0.01d0
-                phi(i,j,k) = 1.d0 + exp(-r2)
+                phi(i,j,k,:) = 1.d0 + exp(-r2)
              end if
           end do
        end do

--- a/Tutorials/Amr/Advection_F/Exec/SingleVortex/Prob_3d.f90
+++ b/Tutorials/Amr/Advection_F/Exec/SingleVortex/Prob_3d.f90
@@ -1,5 +1,7 @@
 module prob_module
 
+use amr_data_module
+
   implicit none
 
   private
@@ -30,7 +32,7 @@ subroutine init_prob_data(level, time, lo, hi, &
   double precision, intent(in) :: time
   double precision, intent(inout) :: phi(phi_lo(1):phi_hi(1), &
        &                                 phi_lo(2):phi_hi(2), &
-       &                                 phi_lo(3):phi_hi(3))
+       &                                 phi_lo(3):phi_hi(3),ncomp)
   double precision, intent(in) :: dx(3), prob_lo(3)
 
   integer          :: dm
@@ -53,10 +55,10 @@ subroutine init_prob_data(level, time, lo, hi, &
            
            if ( dm.eq. 2) then
               r2 = ((x-0.5d0)**2 + (y-0.75d0)**2) / 0.01d0
-              phi(i,j,k) = 1.d0 + exp(-r2)
+              phi(i,j,k,:) = 1.d0 + exp(-r2)
            else
               r2 = ((x-0.5d0)**2 + (y-0.75d0)**2 + (z-0.5d0)**2) / 0.01d0
-              phi(i,j,k) = 1.d0 + exp(-r2)
+              phi(i,j,k,:) = 1.d0 + exp(-r2)
            end if
         end do
      end do

--- a/Tutorials/Amr/Advection_F/Exec/SingleVortex/inputs
+++ b/Tutorials/Amr/Advection_F/Exec/SingleVortex/inputs
@@ -1,4 +1,4 @@
-max_step  = 1000000
+max_step  = 100000
 stop_time = 2.0
 
 # PROBLEM SIZE & GEOMETRY
@@ -6,10 +6,13 @@ geometry.is_periodic =  1  1  1
 geometry.coord_sys   =  0       # 0 => cart
 geometry.prob_lo     =  0.0  0.0  0.0 
 geometry.prob_hi     =  1.0  1.0  1.0
-amr.n_cell           =  64   64   64
+amr.n_cell           =  64  64  64
 
 # VERBOSITY
 amr.v              = 1       # verbosity in Amr
+
+# NO. OF COMPONENTS
+amr.ncomp          = 5
 
 # REFINEMENT
 amr.max_level       = 2       # maximum level number allowed
@@ -23,7 +26,7 @@ amr.regrid_int      = 2       # how often to regrid
 amr.plot_file  = plt    # root name of plot file
 amr.plot_int   = 10     # number of timesteps between plot files
 
-myamr.verbose   = 1
+myamr.verbose   = 2
 myamr.cfl       = 0.7
 myamr.do_reflux = 1
 

--- a/Tutorials/Amr/Advection_F/README
+++ b/Tutorials/Amr/Advection_F/README
@@ -1,5 +1,6 @@
-AMR_Adv_CF: This code advects a single scalar field with a velocity
-field that is specified on faces.
+AMR_Adv_CF: This code advects a specified number of scalar fields with a velocity
+field that is specified on faces. The number of components is taken as an input - ncomp
+from the input file
 
 It is a AMReX based code designed to run in parallel using MPI/OMP.
 It uses the Fortran interfaces of AMReX.

--- a/Tutorials/Amr/Advection_F/Source/Src_2d/advect_2d_mod.F90
+++ b/Tutorials/Amr/Advection_F/Source/Src_2d/advect_2d_mod.F90
@@ -2,6 +2,7 @@
 module advect_module
 
   use amrex_base_module
+  use amr_data_module
 
   implicit none
   private
@@ -29,18 +30,19 @@ contains
     integer, intent(in) :: vy_lo(2), vy_hi(2)
     integer, intent(in) :: fx_lo(2), fx_hi(2)
     integer, intent(in) :: fy_lo(2), fy_hi(2)
-    real(amrex_real), intent(in   ) :: uin (ui_lo(1):ui_hi(1),ui_lo(2):ui_hi(2))
-    real(amrex_real), intent(inout) :: uout(uo_lo(1):uo_hi(1),uo_lo(2):uo_hi(2))
+    real(amrex_real), intent(in   ) :: uin (ui_lo(1):ui_hi(1),ui_lo(2):ui_hi(2),ncomp)
+    real(amrex_real), intent(inout) :: uout(uo_lo(1):uo_hi(1),uo_lo(2):uo_hi(2),ncomp)
     real(amrex_real), intent(in   ) :: vx  (vx_lo(1):vx_hi(1),vx_lo(2):vx_hi(2))
     real(amrex_real), intent(in   ) :: vy  (vy_lo(1):vy_hi(1),vy_lo(2):vy_hi(2))
-    real(amrex_real), intent(  out) :: flxx(fx_lo(1):fx_hi(1),fx_lo(2):fx_hi(2))
-    real(amrex_real), intent(  out) :: flxy(fy_lo(1):fy_hi(1),fy_lo(2):fy_hi(2))
+    real(amrex_real), intent(  out) :: flxx(fx_lo(1):fx_hi(1),fx_lo(2):fx_hi(2),ncomp)
+    real(amrex_real), intent(  out) :: flxy(fy_lo(1):fy_hi(1),fy_lo(2):fy_hi(2),ncomp)
     
     integer :: i, j
     integer :: glo(2), ghi(2)
     real(amrex_real) :: dtdx(2), umax, vmax
     
     real(amrex_real), dimension(:,:), pointer, contiguous :: phix_1d, phiy_1d, phix, phiy, slope
+    integer :: icomp
 
     dtdx = dt/dx
     
@@ -71,49 +73,53 @@ contains
        call amrex_error("CFL violation. Use smaller adv.cfl.")
     end if
 
+    do icomp=1,ncomp
+
     ! call a function to compute flux
     call compute_flux_2d(lo, hi, dt, dx, &
-                         uin, ui_lo, ui_hi, &
+                         uin(:,:,icomp), ui_lo, ui_hi, &
                          vx, vx_lo, vx_hi, &
                          vy, vy_lo, vy_hi, &
                          flxx, fx_lo, fx_hi, &
                          flxy, fy_lo, fy_hi, &
-                         phix_1d, phiy_1d, phix, phiy, slope, glo, ghi)
+                         phix_1d, phiy_1d, phix, phiy, slope, glo, ghi,icomp)
 
     ! Final fluxes
     do    j = lo(2), hi(2)
        do i = lo(1), hi(1)+1
-          flxx(i,j) = phix(i,j) * vx(i,j)
+          flxx(i,j,icomp) = phix(i,j) * vx(i,j)
        end do
     end do
     !
     do    j = lo(2), hi(2)+1
        do i = lo(1), hi(1)
-          flxy(i,j) = phiy(i,j) * vy(i,j)
+          flxy(i,j,icomp) = phiy(i,j) * vy(i,j)
        end do
     end do
     
     ! Do a conservative update
     do    j = lo(2),hi(2)
        do i = lo(1),hi(1)
-          uout(i,j) = uin(i,j) + &
-               ( (flxx(i,j) - flxx(i+1,j)) * dtdx(1) &
-               + (flxy(i,j) - flxy(i,j+1)) * dtdx(2) )
+          uout(i,j,icomp) = uin(i,j,icomp) + &
+               ( (flxx(i,j,icomp) - flxx(i+1,j,icomp)) * dtdx(1) &
+               + (flxy(i,j,icomp) - flxy(i,j+1,icomp)) * dtdx(2) )
        enddo
     enddo
     
     ! Scale by face area in order to correctly reflx
     do    j = lo(2), hi(2)
        do i = lo(1), hi(1)+1
-          flxx(i,j) = flxx(i,j) * ( dt * dx(2))
+          flxx(i,j,icomp) = flxx(i,j,icomp) * ( dt * dx(2))
        enddo
     enddo
     
     ! Scale by face area in order to correctly reflx
     do    j = lo(2), hi(2)+1 
        do i = lo(1), hi(1)
-          flxy(i,j) = flxy(i,j) * (dt * dx(1))
+          flxy(i,j,icomp) = flxy(i,j,icomp) * (dt * dx(1))
        enddo
+    enddo
+ 
     enddo
     
     call amrex_deallocate(phix_1d)

--- a/Tutorials/Amr/Advection_F/Source/Src_2d/compute_flux_2d.f90
+++ b/Tutorials/Amr/Advection_F/Source/Src_2d/compute_flux_2d.f90
@@ -1,6 +1,7 @@
 module compute_flux_module
 
   use amrex_base_module
+  use amr_data_module
 
   implicit none
 
@@ -16,7 +17,7 @@ contains
                              vmac,  v_lo,  v_hi, &
                              flxx, fx_lo, fx_hi, &
                              flxy, fy_lo, fy_hi, &
-                             phix_1d, phiy_1d, phix, phiy, slope, glo, ghi)
+                             phix_1d, phiy_1d, phix, phiy, slope, glo, ghi,icomp)
 
     use slope_module, only: slopex, slopey
 
@@ -30,13 +31,15 @@ contains
     real(amrex_real), intent(in   ) :: phi (ph_lo(1):ph_hi(1),ph_lo(2):ph_hi(2))
     real(amrex_real), intent(in   ) :: umac( u_lo(1): u_hi(1), u_lo(2): u_hi(2))
     real(amrex_real), intent(in   ) :: vmac( v_lo(1): v_hi(1), v_lo(2): v_hi(2))
-    real(amrex_real), intent(  out) :: flxx(fx_lo(1):fx_hi(1),fx_lo(2):fx_hi(2))
-    real(amrex_real), intent(  out) :: flxy(fy_lo(1):fy_hi(1),fy_lo(2):fy_hi(2))
+    real(amrex_real), intent(  out) :: flxx(fx_lo(1):fx_hi(1),fx_lo(2):fx_hi(2),ncomp)
+    real(amrex_real), intent(  out) :: flxy(fy_lo(1):fy_hi(1),fy_lo(2):fy_hi(2),ncomp)
     real(amrex_real), dimension(glo(1):ghi(1),glo(2):ghi(2)) :: &
          phix_1d, phiy_1d, phix, phiy, slope
          
     integer :: i, j, k
     real(amrex_real) :: hdtdx(2)
+    integer :: icomp
+
 
     hdtdx = 0.5_amrex_real*(dt/dx)
 
@@ -87,7 +90,7 @@ contains
           end if
 
           ! compute final x-fluxes
-          flxx(i,j) = phix(i,j)*umac(i,j)
+          flxx(i,j,icomp) = phix(i,j)*umac(i,j)
 
        end do
     end do
@@ -105,7 +108,7 @@ contains
           end if
 
           ! compute final y-fluxes
-          flxy(i,j) = phiy(i,j)*vmac(i,j)
+          flxy(i,j,icomp) = phiy(i,j)*vmac(i,j)
 
        end do
     end do

--- a/Tutorials/Amr/Advection_F/Source/Src_3d/Adv_3d.f90
+++ b/Tutorials/Amr/Advection_F/Source/Src_3d/Adv_3d.f90
@@ -2,6 +2,9 @@ module advect_module
 
   use amrex_base_module
 
+  use amr_data_module
+  use my_amr_module
+
   implicit none
   private
 
@@ -35,18 +38,21 @@ subroutine advect(time, lo, hi, &
   integer, intent(in) :: fx_lo(3), fx_hi(3)
   integer, intent(in) :: fy_lo(3), fy_hi(3)
   integer, intent(in) :: fz_lo(3), fz_hi(3)
-  double precision, intent(in   ) :: uin (ui_lo(1):ui_hi(1),ui_lo(2):ui_hi(2),ui_lo(3):ui_hi(3))
-  double precision, intent(inout) :: uout(uo_lo(1):uo_hi(1),uo_lo(2):uo_hi(2),uo_lo(3):uo_hi(3))
+  double precision, intent(in   ) :: uin (ui_lo(1):ui_hi(1),ui_lo(2):ui_hi(2),ui_lo(3):ui_hi(3),ncomp)
+  double precision, intent(inout) :: uout(uo_lo(1):uo_hi(1),uo_lo(2):uo_hi(2),uo_lo(3):uo_hi(3),ncomp)
   double precision, intent(in   ) :: vx  (vx_lo(1):vx_hi(1),vx_lo(2):vx_hi(2),vx_lo(3):vx_hi(3))
   double precision, intent(in   ) :: vy  (vy_lo(1):vy_hi(1),vy_lo(2):vy_hi(2),vy_lo(3):vy_hi(3))
   double precision, intent(in   ) :: vz  (vz_lo(1):vz_hi(1),vz_lo(2):vz_hi(2),vz_lo(3):vz_hi(3))
-  double precision, intent(  out) :: flxx(fx_lo(1):fx_hi(1),fx_lo(2):fx_hi(2),fx_lo(3):fx_hi(3))
-  double precision, intent(  out) :: flxy(fy_lo(1):fy_hi(1),fy_lo(2):fy_hi(2),fy_lo(3):fy_hi(3))
-  double precision, intent(  out) :: flxz(fz_lo(1):fz_hi(1),fz_lo(2):fz_hi(2),fz_lo(3):fz_hi(3))
+  double precision, intent(  out) :: flxx(fx_lo(1):fx_hi(1),fx_lo(2):fx_hi(2),fx_lo(3):fx_hi(3),ncomp)
+  double precision, intent(  out) :: flxy(fy_lo(1):fy_hi(1),fy_lo(2):fy_hi(2),fy_lo(3):fy_hi(3),ncomp)
+  double precision, intent(  out) :: flxz(fz_lo(1):fz_hi(1),fz_lo(2):fz_hi(2),fz_lo(3):fz_hi(3),ncomp)
 
   integer :: i, j, k
   integer :: glo(3), ghi(3)
   double precision :: dtdx(3), umax, vmax, wmax
+  
+  integer :: icomp
+
 
   ! Some compiler may not support 'contiguous'.  Remove it in that case.
   double precision, dimension(:,:,:), pointer, contiguous :: &
@@ -88,9 +94,11 @@ subroutine advect(time, lo, hi, &
      call bl_error("CFL violation. Use smaller adv.cfl.")
   end if
 
+  do icomp=1,ncomp
+
   ! call a function to compute flux
   call compute_flux_3d(lo, hi, dt, dx, &
-                       uin, ui_lo, ui_hi, &
+                       uin(:,:,:,icomp), ui_lo, ui_hi, &
                        vx, vx_lo, vx_hi, &
                        vy, vy_lo, vy_hi, &
                        vz, vz_lo, vz_hi, &
@@ -100,43 +108,49 @@ subroutine advect(time, lo, hi, &
                        phix, phix_y, phix_z, &
                        phiy, phiy_x, phiy_z, &
                        phiz, phiz_x, phiz_y, &
-                       slope, glo, ghi)
+                       slope, glo, ghi,icomp)
+ 
+   enddo
+  
+  do icomp=1,ncomp
 
   ! Do a conservative update
   do       k = lo(3), hi(3)
      do    j = lo(2), hi(2)
         do i = lo(1), hi(1)
-           uout(i,j,k) = uin(i,j,k) + &
-                ( (flxx(i,j,k) - flxx(i+1,j,k)) * dtdx(1) &
-                + (flxy(i,j,k) - flxy(i,j+1,k)) * dtdx(2) &
-                + (flxz(i,j,k) - flxz(i,j,k+1)) * dtdx(3) )
+           uout(i,j,k,icomp) = uin(i,j,k,icomp) + &
+                ( (flxx(i,j,k,icomp) - flxx(i+1,j,k,icomp)) * dtdx(1) &
+                + (flxy(i,j,k,icomp) - flxy(i,j+1,k,icomp)) * dtdx(2) &
+                + (flxz(i,j,k,icomp) - flxz(i,j,k+1,icomp)) * dtdx(3) )
         enddo
      enddo
   enddo
+
 
   ! Scale by face area in order to correctly reflx
   do       k = lo(3), hi(3)
      do    j = lo(2), hi(2)
         do i = lo(1), hi(1)+1
-           flxx(i,j,k) = flxx(i,j,k) * (dt * dx(2)*dx(3))
+           flxx(i,j,k,icomp) = flxx(i,j,k,icomp) * (dt * dx(2)*dx(3))
         enddo
      enddo
   enddo
   do       k = lo(3), hi(3)
      do    j = lo(2), hi(2)+1 
         do i = lo(1), hi(1)
-           flxy(i,j,k) = flxy(i,j,k) * (dt * dx(1)*dx(3))
+           flxy(i,j,k,icomp) = flxy(i,j,k,icomp) * (dt * dx(1)*dx(3))
         enddo
      enddo
   enddo
   do       k = lo(3), hi(3)+1
      do    j = lo(2), hi(2)
         do i = lo(1), hi(1)
-           flxz(i,j,k) = flxz(i,j,k) * (dt * dx(1)*dx(2))
+           flxz(i,j,k,icomp) = flxz(i,j,k,icomp) * (dt * dx(1)*dx(2))
         enddo
      enddo
   enddo
 
+  enddo
   call bl_deallocate(phix  )
   call bl_deallocate(phix_y)
   call bl_deallocate(phix_z)

--- a/Tutorials/Amr/Advection_F/Source/Src_3d/compute_flux_3d.f90
+++ b/Tutorials/Amr/Advection_F/Source/Src_3d/compute_flux_3d.f90
@@ -1,5 +1,8 @@
 module compute_flux_module
 
+  use amr_data_module
+  use my_amr_module
+
   implicit none
 
   private
@@ -19,7 +22,7 @@ contains
                              phix, phix_y, phix_z, &
                              phiy, phiy_x, phiy_z, &
                              phiz, phiz_x, phiz_y, &
-                             slope, glo, ghi)
+                             slope, glo, ghi,icomp)
 
     use slope_module, only: slopex, slopey, slopez
 
@@ -36,14 +39,16 @@ contains
     double precision, intent(in   ) :: umac( u_lo(1): u_hi(1), u_lo(2): u_hi(2), u_lo(3): u_hi(3))
     double precision, intent(in   ) :: vmac( v_lo(1): v_hi(1), v_lo(2): v_hi(2), v_lo(3): v_hi(3))
     double precision, intent(in   ) :: wmac( w_lo(1): w_hi(1), w_lo(2): w_hi(2), w_lo(3): w_hi(3))
-    double precision, intent(  out) :: flxx(fx_lo(1):fx_hi(1),fx_lo(2):fx_hi(2),fx_lo(3):fx_hi(3))
-    double precision, intent(  out) :: flxy(fy_lo(1):fy_hi(1),fy_lo(2):fy_hi(2),fy_lo(3):fy_hi(3))
-    double precision, intent(  out) :: flxz(fz_lo(1):fz_hi(1),fz_lo(2):fz_hi(2),fz_lo(3):fz_hi(3))
+    double precision, intent(  out) :: flxx(fx_lo(1):fx_hi(1),fx_lo(2):fx_hi(2),fx_lo(3):fx_hi(3),ncomp)
+    double precision, intent(  out) :: flxy(fy_lo(1):fy_hi(1),fy_lo(2):fy_hi(2),fy_lo(3):fy_hi(3),ncomp)
+    double precision, intent(  out) :: flxz(fz_lo(1):fz_hi(1),fz_lo(2):fz_hi(2),fz_lo(3):fz_hi(3),ncomp)
     double precision, dimension(glo(1):ghi(1),glo(2):ghi(2),glo(3):ghi(3)) :: &
          phix, phix_y, phix_z, phiy, phiy_x, phiy_z, phiz, phiz_x, phiz_y, slope
          
     integer :: i, j, k
     double precision :: hdtdx(3), tdtdx(3)
+
+    integer :: icomp
 
     hdtdx = 0.5*(dt/dx)
     tdtdx = (1.d0/3.d0)*(dt/dx)
@@ -231,7 +236,7 @@ contains
              end if
 
              ! compute final x-fluxes
-             flxx(i,j,k) = umac(i,j,k)*phix(i,j,k)
+             flxx(i,j,k,icomp) = umac(i,j,k)*phix(i,j,k)
 
           end do
        end do
@@ -253,7 +258,7 @@ contains
              end if
 
              ! compute final y-fluxes
-             flxy(i,j,k) = vmac(i,j,k)*phiy(i,j,k)
+             flxy(i,j,k,icomp) = vmac(i,j,k)*phiy(i,j,k)
 
           end do
        end do
@@ -275,7 +280,7 @@ contains
              end if
 
              ! compute final z-fluxes
-             flxz(i,j,k) = wmac(i,j,k)*phiz(i,j,k)
+             flxz(i,j,k,icomp) = wmac(i,j,k)*phiz(i,j,k)
 
           end do
        end do

--- a/Tutorials/Amr/Advection_F/Source/amr_data_mod.F90
+++ b/Tutorials/Amr/Advection_F/Source/amr_data_mod.F90
@@ -4,11 +4,12 @@ module amr_data_module
   use iso_c_binding
   use amrex_amr_module
   use amrex_fort_module, only : rt => amrex_real
-
+  use amrex_base_module
+ 
   implicit none
 
   private
-  public :: t_new, t_old, phi_new, phi_old, flux_reg
+  public :: t_new, t_old, phi_new, phi_old, flux_reg, ba_new, dm_new, ncomp
   public :: amr_data_init, amr_data_finalize
 
   real(rt), allocatable :: t_new(:)
@@ -16,12 +17,18 @@ module amr_data_module
 
   type(amrex_multifab), allocatable :: phi_new(:)
   type(amrex_multifab), allocatable :: phi_old(:)
-
+  
   type(amrex_fluxregister), allocatable :: flux_reg(:)
+
+  type(amrex_boxarray), allocatable, save :: ba_new(:)
+  type(amrex_distromap), allocatable, save :: dm_new(:)
+
+  integer :: ncomp
 
 contains
 
   subroutine amr_data_init ()
+
     allocate(t_new(0:amrex_max_level))
     t_new = 0.0_rt
 
@@ -32,6 +39,10 @@ contains
     allocate(phi_old(0:amrex_max_level))
 
     allocate(flux_reg(0:amrex_max_level))
+    
+    allocate(ba_new(0:amrex_max_level))
+    allocate(dm_new(0:amrex_max_level))
+
   end subroutine amr_data_init
 
   subroutine amr_data_finalize

--- a/Tutorials/Amr/Advection_F/Source/averagedown_mod.F90
+++ b/Tutorials/Amr/Advection_F/Source/averagedown_mod.F90
@@ -3,6 +3,7 @@ module averagedown_module
   use amrex_amr_module
 
   use amr_data_module, only : phi_new
+  use my_amr_module
 
   implicit none
   private
@@ -12,18 +13,26 @@ module averagedown_module
 contains
 
   subroutine averagedown ()
-    integer :: lev, finest_level
+    integer :: lev, finest_level, icomp
     finest_level = amrex_get_finest_level()
-    do lev = finest_level-1, 0, -1
+
+   do icomp=1,ncomp
+      do lev = finest_level-1, 0, -1
        call amrex_average_down(phi_new(lev+1), phi_new(lev), amrex_geom(lev+1), amrex_geom(lev), &
-            1, 1, amrex_ref_ratio(lev))
+            icomp, 1, amrex_ref_ratio(lev))
+       enddo
     end do
   end subroutine averagedown
 
   subroutine averagedownto (clev)
     integer, intent(in) :: clev
-    call amrex_average_down(phi_new(clev+1), phi_new(clev), amrex_geom(clev+1), amrex_geom(clev), &
-         1, 1, amrex_ref_ratio(clev))    
+    integer :: icomp
+   
+    do icomp=1,ncomp
+	    call amrex_average_down(phi_new(clev+1), phi_new(clev), amrex_geom(clev+1), amrex_geom(clev), &
+            icomp, 1, amrex_ref_ratio(clev))    
+    enddo	
+
   end subroutine averagedownto
 
 end module averagedown_module

--- a/Tutorials/Amr/Advection_F/Source/bc_mod.F90
+++ b/Tutorials/Amr/Advection_F/Source/bc_mod.F90
@@ -6,7 +6,7 @@ module bc_module
   implicit none
 
   ! periodic bc.  See amrex_bc_types_module for a list of bc types.
-  integer, save :: lo_bc(amrex_spacedim,1) = amrex_bc_int_dir  ! the second dimension is the
-  integer, save :: hi_bc(amrex_spacedim,1) = amrex_bc_int_dir  ! number of components
+  integer, allocatable :: lo_bc(:,:)
+  integer, allocatable :: hi_bc(:,:)
   
 end module bc_module

--- a/Tutorials/Amr/Advection_F/Source/fillpatch_mod.F90
+++ b/Tutorials/Amr/Advection_F/Source/fillpatch_mod.F90
@@ -2,6 +2,7 @@ module fillpatch_module
 
   use iso_c_binding
   use amrex_amr_module
+  use amr_data_module
 
   implicit none
 
@@ -19,7 +20,12 @@ contains
     real(amrex_real), intent(in) :: time
     type(amrex_multifab), intent(inout) :: phi
     
-    integer, parameter :: src_comp=1, dst_comp=1, num_comp=1  ! for this test code
+    !integer, parameter :: src_comp=2, dst_comp=2, num_comp=1  ! for this test code
+    integer, parameter :: num_comp=1  ! for this test code
+    integer :: src_comp, dst_comp
+
+    do src_comp=1,ncomp
+       dst_comp=src_comp       
 
     if (lev .eq. 0) then
        call amrex_fillpatch(phi, t_old(lev), phi_old(lev), &
@@ -38,6 +44,8 @@ contains
             &               lo_bc, hi_bc)
        ! see amrex_interpolater_module for a list of interpolaters
     end if
+
+    enddo
   end subroutine fillpatch
 
   subroutine fillcoarsepatch (lev, time, phi)
@@ -47,8 +55,13 @@ contains
     real(amrex_real), intent(in) :: time
     type(amrex_multifab), intent(inout) :: phi
 
-    integer, parameter :: src_comp=1, dst_comp=1, num_comp=1  ! for this test code
-    
+    !integer, parameter :: src_comp=2, dst_comp=2, num_comp=1  ! for this test code
+    integer, parameter :: num_comp=1  ! for this test code
+    integer :: src_comp, dst_comp
+
+    do src_comp=1,ncomp
+       dst_comp=src_comp       
+
     call amrex_fillcoarsepatch(phi, t_old(lev-1), phi_old(lev-1),  &
          &                          t_new(lev-1), phi_new(lev-1),  &
          &                     amrex_geom(lev-1),    fill_physbc,  &
@@ -57,6 +70,9 @@ contains
          &                     amrex_ref_ratio(lev-1), amrex_interp_cell_cons, &
          &                     lo_bc, hi_bc)
        ! see amrex_interpolater_module for a list of interpolaters
+
+     enddo
+
   end subroutine fillcoarsepatch
 
   subroutine fill_physbc (pmf, scomp, ncomp, time, pgeom) bind(c)
@@ -74,6 +90,7 @@ contains
     integer :: plo(4), phi(4)
 
     if (.not. amrex_is_all_periodic()) then
+
        geom = pgeom
        mf = pmf
 

--- a/Tutorials/Amr/Advection_F/Source/plotfile_mod.F90
+++ b/Tutorials/Amr/Advection_F/Source/plotfile_mod.F90
@@ -1,7 +1,9 @@
 module plotfile_module
 
   use amrex_amr_module
-  use my_amr_module, only : plot_file, phi_new, t_new, stepno
+  use my_amr_module, only : plot_file, phi_new, t_new, stepno, ncomp
+  
+  use amr_data_module
 
   implicit none
 
@@ -13,11 +15,43 @@ contains
 
   subroutine writeplotfile ()
 
-    integer :: nlevs
+   type(amrex_multifab) :: plotmf(0:amrex_max_level)
+    type(amrex_string), allocatable :: varname(:)
+    integer, dimension(0:amrex_max_level) :: steps, rr
+    integer :: ilev, nc
     character(len=127) :: name
     character(len=16)  :: current_step
-    type(amrex_string) :: varname(1)
-    
+    integer :: nlevs, icomp
+
+    character(len=10), allocatable :: varnamedummy(:)
+       
+    nc = ncomp
+
+    allocate(varname(nc))
+    allocate(varnamedummy(ncomp))
+
+    do icomp=1, ncomp
+      write(varnamedummy(icomp),'("phi",I2.2)')icomp
+    enddo
+
+    do icomp=1, ncomp
+       call amrex_string_build(varname(icomp), varnamedummy(icomp))
+    enddo
+
+    nlevs=amrex_get_finest_level()
+
+    do ilev=0,nlevs
+       ba_new(ilev)=phi_new(ilev)%ba
+       dm_new(ilev)=phi_new(ilev)%dm
+    enddo
+
+    do ilev = 0, nlevs
+       call amrex_multifab_build(plotmf(ilev), ba_new(ilev), dm_new(ilev), nc, 1)
+       do icomp=1,ncomp
+          call plotmf(ilev) % copy(phi_new(ilev), icomp, icomp, 1, 0)
+	enddo
+    end do
+
     if      (stepno(0) .lt. 1000000) then
        write(current_step,fmt='(i5.5)') stepno(0)
     else if (stepno(0) .lt. 10000000) then
@@ -29,16 +63,15 @@ contains
     else
        write(current_step,fmt='(i15.15)') stepno(0)
     end if
+
     name = trim(plot_file) // current_step
+	
+    call amrex_write_plotfile(name, nlevs+1, plotmf, varname, amrex_geom, t_new(0), stepno, amrex_ref_ratio)
 
-    nlevs = amrex_get_numlevels()
-
-    call amrex_string_build(varname(1), "phi")
-
-    call amrex_write_plotfile(name, nlevs, phi_new, varname, amrex_geom, &
-         t_new(0), stepno, amrex_ref_ratio)
-
+    ! let's not realy on finalizer, which is feature not all compilers support properly.
+    do ilev = 0, nlevs
+       call amrex_multifab_destroy(plotmf(ilev))
+    end do
   end subroutine writeplotfile
 
 end module plotfile_module
-

--- a/Tutorials/Amr/Advection_F/Source/tagging_mod.F90
+++ b/Tutorials/Amr/Advection_F/Source/tagging_mod.F90
@@ -3,6 +3,7 @@ module tagging_module
   use iso_c_binding
 
   use amrex_fort_module
+  use amr_data_module
 
   implicit none
 
@@ -15,7 +16,7 @@ contains
   subroutine tag_phi_error (level, time, lo, hi, phi, philo, phihi, tag, taglo, taghi, phierr, &
        settag, cleartag)
     integer, intent(in) :: level, lo(3), hi(3), philo(4), phihi(4), taglo(4), taghi(4)
-    real(amrex_real) , intent(in   ) :: phi(philo(1):phihi(1),philo(2):phihi(2),philo(3):phihi(3))
+    real(amrex_real) , intent(in   ) :: phi(philo(1):phihi(1),philo(2):phihi(2),philo(3):phihi(3),ncomp)
     character(kind=c_char), intent(inout) :: tag(taglo(1):taghi(1),taglo(2):taghi(2),taglo(3):taghi(3))
     real(amrex_real), intent(in) :: time, phierr
     character(kind=c_char), intent(in) :: settag, cleartag
@@ -39,7 +40,7 @@ contains
     do       k = lo(3), hi(3)
        do    j = lo(2), hi(2)
           do i = lo(1), hi(1)
-             if (phi(i,j,k) .ge. phierr_this) then
+             if (phi(i,j,k,1) .ge. phierr_this) then
                 tag(i,j,k) = settag
              endif
           enddo


### PR DESCRIPTION
Advection_F has been generalized to do multicomponent advection with a specified velocity field in both 2d and 3d.
All hard coding for single component advection has been removed.

1. Number of components ncomp is taken as an input from the inputs file. Currently it is set to 5.
2. The initial condition for all the components is currently the same so that it is easy to check the code works correctly. But it is easily changeable in Prob_2d.f90 or Prob_3d.f90. 