### PR TITLE
Fix --ghost option.  Do not advance farg in case(--ghost) section bec…

### DIFF
--- a/Tools/Postprocessing/F_Src/fcompare.f90
+++ b/Tools/Postprocessing/F_Src/fcompare.f90
@@ -182,7 +182,6 @@ program fcompare
         read(fname, *) norm
 
      case ('-g','--ghost')
-        farg = farg + 1
         do_ghost = .true.
 
      case ('-z','--zone_info')


### PR DESCRIPTION
…ause --ghost does not take any arguments.