### PR TITLE
Update makefile for NREL site to get higher vectorization from the Intel compiler

### DIFF
--- a/Tools/GNUMake/sites/Make.nrel
+++ b/Tools/GNUMake/sites/Make.nrel
@@ -4,6 +4,18 @@ endif
 
 os_type := $(shell uname)
 
+# Use automatic CPU dispatch for max 
+# vectorization with Intel compilers
+# since Peregrine has haswell and
+# ivybridge nodes. We're leaving out the
+# really old sandybridge nodes here.
+ifeq ($(COMP), intel)
+  CXXFLAGS += -axCORE-AVX2,CORE-AVX-I
+  CFLAGS   += -axCORE-AVX2,CORE-AVX-I
+  FFLAGS   += -axCORE-AVX2,CORE-AVX-I
+  F90FLAGS += -axCORE-AVX2,CORE-AVX-I
+endif
+
 ifeq ($(USE_MPI),TRUE)
   ifeq ($(COMP), intel)
     CXX := mpiicpc


### PR DESCRIPTION
Our main Peregrine machine at NREL has three generations of nodes, and this targets Haswell and Ivybridge with "fat binaries" that will use the highest level of vectorization for each target, which was not happening by default for us. This allows for fairly large gains in performance for our PeleC application when running on our newest Haswell nodes.