### PR TITLE
Multicomponent advection and Helmholtz

### DIFF
--- a/Tutorials/Amr/Advection_Helmholtz_F/CMakeLists.txt
+++ b/Tutorials/Amr/Advection_Helmholtz_F/CMakeLists.txt
@@ -1,0 +1,46 @@
+#
+# This test requires a 2D build
+# 
+if ( NOT (${DIM} EQUAL 2) )
+   return ()
+endif ()
+
+set ( EXENAME  "Advection_F.exe")
+
+
+#
+#  We use this very bad method to find sources
+#  automagically
+#
+scan_for_sources (F90SRC F77SRC CXXSRC ALLHEADERS)
+
+#
+# Find input files 
+#
+file ( GLOB_RECURSE inputs LIST_DIRECTORIES false 
+   ${CMAKE_CURRENT_LIST_DIR}/input* )
+
+#
+# Copy input files to corresponding build dir
+#
+file ( COPY ${inputs} DESTINATION ${CMAKE_CURRENT_BINARY_DIR} ) 
+
+#
+# Create executable 
+# 
+add_executable ( ${EXENAME} EXCLUDE_FROM_ALL
+   ${F90SRC} ${F77SRC} ${CXXSRC} ${ALLHEADERS} )
+
+target_link_libraries ( ${EXENAME} amrex ${AMREX_EXTRA_Fortran_LINK_LINE} )
+
+
+# Fortran modules for the target will not be added to the amrex mod_files folder 
+set ( MOD_DIR ${CMAKE_CURRENT_BINARY_DIR}/mod_files )
+
+set_target_properties ( ${EXENAME} PROPERTIES
+   INCLUDE_DIRECTORIES "${MOD_DIR};${AMREX_INCLUDE_PATHS}"
+   Fortran_MODULE_DIRECTORY ${MOD_DIR}
+   RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR} )
+
+add_tutorial (${EXENAME})   
+

--- a/Tutorials/Amr/Advection_Helmholtz_F/Exec/Make.Adv
+++ b/Tutorials/Amr/Advection_Helmholtz_F/Exec/Make.Adv
@@ -1,0 +1,23 @@
+AMREX_HOME ?= ../../../../..
+TOP := $(AMREX_HOME)/Tutorials/Amr/Advection_Helmholtz_F
+
+include $(AMREX_HOME)/Tools/GNUMake/Make.defs
+
+Bdirs 	:= Source Source/Src_$(DIM)d
+Bpack	+= $(foreach dir, $(Bdirs), $(TOP)/$(dir)/Make.package)
+Blocs	+= $(foreach dir, $(Bdirs), $(TOP)/$(dir))
+
+include $(Bpack)
+
+INCLUDE_LOCATIONS += $(Blocs)
+VPATH_LOCATIONS   += $(Blocs)
+
+Pdirs 	:= Base Boundary AmrCore F_Interfaces/Base F_Interfaces/AmrCore
+Pdirs   += LinearSolvers/C_CellMG LinearSolvers/MLMG F_Interfaces/LinearSolvers
+Ppack	+= $(foreach dir, $(Pdirs), $(AMREX_HOME)/Src/$(dir)/Make.package)
+
+$(info $(Ppack))
+
+include $(Ppack)
+
+include $(AMREX_HOME)/Tools/GNUMake/Make.rules

--- a/Tutorials/Amr/Advection_Helmholtz_F/Exec/SingleVortex/GNUmakefile
+++ b/Tutorials/Amr/Advection_Helmholtz_F/Exec/SingleVortex/GNUmakefile
@@ -1,0 +1,22 @@
+
+DEBUG     = TRUE
+DEBUG     = FALSE
+
+USE_MPI   = TRUE
+USE_OMP   = FALSE
+USE_MPI3  = FALSE
+
+MEM_PROFILE  = FALSE
+TINY_PROFILE = FALSE
+
+COMP      = gnu
+
+DIM       = 2
+#DIM       = 3
+
+Bpack   := ./Make.package 
+Blocs   := . 
+
+include ../Make.Adv
+
+

--- a/Tutorials/Amr/Advection_Helmholtz_F/Exec/SingleVortex/Make.package
+++ b/Tutorials/Amr/Advection_Helmholtz_F/Exec/SingleVortex/Make.package
@@ -1,0 +1,3 @@
+f90EXE_sources += Prob.f90
+
+F90EXE_sources += face_velocity_$(DIM)d.F90

--- a/Tutorials/Amr/Advection_Helmholtz_F/Exec/SingleVortex/Prob.f90
+++ b/Tutorials/Amr/Advection_Helmholtz_F/Exec/SingleVortex/Prob.f90
@@ -1,0 +1,52 @@
+
+module prob_module
+
+ use amr_data_module
+
+  implicit none
+
+  private
+
+  public :: init_prob_data
+
+contains
+
+  subroutine init_prob_data(level, time, lo, hi, phi, phi_lo, phi_hi, &
+       dx, prob_lo)
+
+    use amrex_fort_module, only : amrex_spacedim, amrex_real
+    
+    implicit none
+    integer, intent(in) :: level, lo(3), hi(3), phi_lo(3), phi_hi(3)
+    real(amrex_real), intent(in) :: time
+    real(amrex_real), intent(inout) :: phi(phi_lo(1):phi_hi(1), &
+         &                                 phi_lo(2):phi_hi(2), &
+         &                                 phi_lo(3):phi_hi(3),ncomp)
+    real(amrex_real), intent(in) :: dx(3), prob_lo(3)
+    
+    integer          :: i,j,k
+    real(amrex_real) :: x,y,z,r2
+    
+    !$omp parallel do private(i,j,k,x,y,z,r2) collapse(2)
+    do k=lo(3),hi(3)
+       do j=lo(2),hi(2)
+          z = prob_lo(3) + (dble(k)+0.5d0) * dx(3)
+          y = prob_lo(2) + (dble(j)+0.5d0) * dx(2)
+          do i=lo(1),hi(1)
+             x = prob_lo(1) + (dble(i)+0.5d0) * dx(1)
+             
+             if ( amrex_spacedim .eq. 2) then
+                r2 = ((x-0.5d0)**2 + (y-0.75d0)**2) / 0.01d0
+                phi(i,j,k,:) = 1.d0 + exp(-r2)
+             else
+                r2 = ((x-0.5d0)**2 + (y-0.75d0)**2 + (z-0.5d0)**2) / 0.01d0
+                phi(i,j,k,:) = 1.d0 + exp(-r2)
+             end if
+          end do
+       end do
+    end do
+    !$omp end parallel do
+    
+  end subroutine init_prob_data
+
+end module prob_module

--- a/Tutorials/Amr/Advection_Helmholtz_F/Exec/SingleVortex/face_velocity_2d.F90
+++ b/Tutorials/Amr/Advection_Helmholtz_F/Exec/SingleVortex/face_velocity_2d.F90
@@ -1,0 +1,65 @@
+module face_velocity_module
+
+  implicit none
+  private
+
+  public :: get_face_velocity
+
+contains
+
+  subroutine get_face_velocity(time, &
+       vx, vxlo, vxhi, &
+       vy, vylo, vyhi, &
+       dx, prob_lo)
+    use amrex_base_module
+
+    real(amrex_real), intent(in) :: time
+    integer, intent(in) :: vxlo(2), vxhi(2), vylo(2), vyhi(2)
+    real(amrex_real), intent(out) :: vx(vxlo(1):vxhi(1),vxlo(2):vxhi(2))
+    real(amrex_real), intent(out) :: vy(vylo(1):vyhi(1),vylo(2):vyhi(2))
+    real(amrex_real), intent(in) :: dx(2), prob_lo(2)
+
+    integer :: i, j, plo(2), phi(2)
+    real(amrex_real) :: x, y
+    real(amrex_real), pointer, contiguous :: psi(:,:)
+    real(amrex_real), parameter :: M_PI = 3.141592653589793238462643383279502884197d0
+
+    plo(1) = min(vxlo(1)-1, vylo(1)-1)
+    plo(2) = min(vxlo(2)-1, vylo(2)-1)
+    phi(1) = max(vxhi(1)  , vyhi(1)+1)
+    phi(2) = max(vxhi(2)+1, vyhi(2)  )
+    
+    call amrex_allocate(psi, plo, phi)
+    
+    ! streamfunction psi
+    do j = plo(2), phi(2)
+       y = (dble(j)+0.5d0)*dx(2) + prob_lo(2)
+       do i = plo(1), phi(1)
+          x = (dble(i)+0.5d0)*dx(1) + prob_lo(1)
+          psi(i,j) =  sin(M_PI*x)**2 * sin(M_PI*y)**2 * cos (M_PI*time/2.d0) * (1.d0 / M_PI)
+       end do
+    end do
+    
+    ! x velocity
+    do j = vxlo(2), vxhi(2)
+       y = (dble(j)+0.5d0) * dx(2) + prob_lo(2)
+       do i = vxlo(1), vxhi(1)
+          x = dble(i) * dx(1) + prob_lo(1)
+          vx(i,j) =  -( (psi(i,j+1)+psi(i-1,j+1)) - (psi(i,j-1)+psi(i-1,j-1)) ) * (0.25d0/dx(2))
+       end do
+    end do
+    
+    ! y velocity
+    do j = vylo(2), vyhi(2)
+       y = dble(j) * dx(2) + prob_lo(2)
+       do i = vylo(1), vyhi(1)
+          x = (dble(i)+0.5d0) * dx(1) + prob_lo(1)
+          vy(i,j) = ( (psi(i+1,j)+psi(i+1,j-1)) - (psi(i-1,j)+psi(i-1,j-1)) ) * (0.25d0/dx(1))
+       end do
+    end do
+    
+    call amrex_deallocate(psi)
+  
+  end subroutine get_face_velocity
+
+end module face_velocity_module

--- a/Tutorials/Amr/Advection_Helmholtz_F/Exec/SingleVortex/face_velocity_3d.F90
+++ b/Tutorials/Amr/Advection_Helmholtz_F/Exec/SingleVortex/face_velocity_3d.F90
@@ -1,0 +1,88 @@
+module face_velocity_module
+
+  implicit none
+  private
+
+  public :: get_face_velocity
+
+contains
+
+subroutine get_face_velocity(time, &
+     vx, vxlo, vxhi, &
+     vy, vylo, vyhi, &
+     vz, vzlo, vzhi, &
+     dx, prob_lo) bind(C, name="get_face_velocity")
+
+use amrex_base_module
+
+  implicit none
+
+  !integer, intent(in) :: level
+  double precision, intent(in) :: time
+  integer, intent(in) :: vxlo(3),vxhi(3)
+  integer, intent(in) :: vylo(3),vyhi(3)
+  integer, intent(in) :: vzlo(3),vzhi(3)
+  double precision, intent(out) :: vx(vxlo(1):vxhi(1),vxlo(2):vxhi(2),vxlo(3):vxhi(3))
+  double precision, intent(out) :: vy(vylo(1):vyhi(1),vylo(2):vyhi(2),vylo(3):vyhi(3))
+  double precision, intent(out) :: vz(vzlo(1):vzhi(1),vzlo(2):vzhi(2),vzlo(3):vzhi(3))
+  double precision, intent(in) :: dx(3), prob_lo(3)
+
+  integer :: i, j, k, plo(2), phi(2)
+  double precision :: x, y, z
+  double precision, pointer, contiguous :: psi(:,:)
+  double precision, parameter :: M_PI = 3.141592653589793238462643383279502884197d0
+  integer :: vx_l1,vx_l2,vx_l3,vy_l1,vy_l2,vy_l3,vz_l1,vz_l2,vz_l3
+  integer :: vx_h1,vx_h2,vx_h3,vy_h1,vy_h2,vy_h3,vz_h1,vz_h2,vz_h3
+
+  vx_l1=vxlo(1);vx_l2=vxlo(2);vx_l3=vxlo(3)
+  vy_l1=vylo(1);vy_l2=vylo(2);vy_l3=vylo(3)
+  vz_l1=vzlo(1);vz_l2=vzlo(2);vz_l3=vzlo(3) 
+  vx_h1=vxhi(1);vx_h2=vxhi(2);vx_h3=vxhi(3)
+  vy_h1=vyhi(1);vy_h2=vyhi(2);vy_h3=vyhi(3)
+  vz_h1=vzhi(1);vz_h2=vzhi(2);vz_h3=vzhi(3)
+
+  plo(1) = min(vx_l1-1, vy_l1-1)
+  plo(2) = min(vx_l2-1, vy_l2-1)
+  phi(1) = max(vx_h1  , vy_h1+1)
+  phi(2) = max(vx_h2+1, vy_h2  )
+  
+  call bl_allocate(psi, plo(1), phi(1), plo(2), phi(2))
+
+  ! streamfunction psi
+  do j = plo(2), phi(2)
+     y = (dble(j)+0.5d0)*dx(2) + prob_lo(2)
+     do i = plo(1), phi(1)
+        x = (dble(i)+0.5d0)*dx(1) + prob_lo(1)
+        psi(i,j) =  sin(M_PI*x)**2 * sin(M_PI*y)**2 * cos (M_PI*time/2.d0) * (1.d0 / M_PI)
+     end do
+  end do
+  
+  ! x velocity
+  do k = vx_l3, vx_h3
+  do j = vx_l2, vx_h2
+     y = (dble(j)+0.5d0) * dx(2) + prob_lo(2)
+     do i = vx_l1, vx_h1
+        x = dble(i) * dx(1) + prob_lo(1)
+        vx(i,j,k) =  -( (psi(i,j+1)+psi(i-1,j+1)) - (psi(i,j-1)+psi(i-1,j-1)) ) * (0.25d0/dx(2))
+     end do
+  end do
+  end do
+
+  ! y velocity
+  do k = vy_l3, vy_h3
+  do j = vy_l2, vy_h2
+     y = dble(j) * dx(2) + prob_lo(2)
+     do i = vy_l1, vy_h1
+        x = (dble(i)+0.5d0) * dx(1) + prob_lo(1)
+        vy(i,j,k) = ( (psi(i+1,j)+psi(i+1,j-1)) - (psi(i-1,j)+psi(i-1,j-1)) ) * (0.25d0/dx(1))
+     end do
+  end do
+  end do
+
+  vz = 1.d0
+
+  call bl_deallocate(psi)
+
+end subroutine get_face_velocity
+
+end module face_velocity_module

--- a/Tutorials/Amr/Advection_Helmholtz_F/Exec/SingleVortex/inputs
+++ b/Tutorials/Amr/Advection_Helmholtz_F/Exec/SingleVortex/inputs
@@ -1,0 +1,34 @@
+max_step  = 100000
+stop_time = 200.0
+
+# PROBLEM SIZE & GEOMETRY
+geometry.is_periodic =  0  0  0
+geometry.coord_sys   =  0       # 0 => cart
+geometry.prob_lo     =  0.0  0.0  0.0 
+geometry.prob_hi     =  1.0  1.0  1.0
+amr.n_cell           =  64  64  64
+
+# VERBOSITY
+amr.v              = 1       # verbosity in Amr
+
+# NO. OF COMPONENTS
+amr.ncomp          = 4
+
+# REFINEMENT
+amr.max_level       = 2       # maximum level number allowed
+amr.ref_ratio       = 2 2 2 2 # refinement ratio
+amr.blocking_factor = 8       # block factor in grid generation
+amr.max_grid_size   = 16
+
+amr.regrid_int      = 2       # how often to regrid
+
+# PLOTFILES
+amr.plot_file  = plt    # root name of plot file
+amr.plot_int   = 10     # number of timesteps between plot files
+
+myamr.verbose   = 2
+myamr.cfl       = 0.6
+myamr.do_reflux = 1
+
+# Tagging
+myamr.phierr    = 1.01  1.1  1.5

--- a/Tutorials/Amr/Advection_Helmholtz_F/Exec/SingleVortex/inputs.physbc
+++ b/Tutorials/Amr/Advection_Helmholtz_F/Exec/SingleVortex/inputs.physbc
@@ -1,0 +1,31 @@
+max_step  = 1000000
+stop_time = 2.0
+
+# PROBLEM SIZE & GEOMETRY
+geometry.is_periodic =  0    0    0
+geometry.coord_sys   =  0       # 0 => cart
+geometry.prob_lo     =  0.0  0.0  0.0 
+geometry.prob_hi     =  1.0  1.0  1.0
+amr.n_cell           =  64   64   64
+
+# VERBOSITY
+amr.v              = 1       # verbosity in Amr
+
+# REFINEMENT
+amr.max_level       = 2       # maximum level number allowed
+amr.ref_ratio       = 2 2 2 2 # refinement ratio
+amr.blocking_factor = 8       # block factor in grid generation
+amr.max_grid_size   = 16
+
+amr.regrid_int      = 2       # how often to regrid
+
+# PLOTFILES
+amr.plot_file  = plt    # root name of plot file
+amr.plot_int   = 10     # number of timesteps between plot files
+
+myamr.verbose   = 1
+myamr.cfl       = 0.7
+myamr.do_reflux = 1
+
+# Tagging
+myamr.phierr    = 1.01  1.1  1.5

--- a/Tutorials/Amr/Advection_Helmholtz_F/Exec/SingleVortex/inputs.rt
+++ b/Tutorials/Amr/Advection_Helmholtz_F/Exec/SingleVortex/inputs.rt
@@ -1,0 +1,31 @@
+max_step  = 1000000
+stop_time = 2.0
+
+# PROBLEM SIZE & GEOMETRY
+geometry.is_periodic =  0  0  0
+geometry.coord_sys   =  0       # 0 => cart
+geometry.prob_lo     =  0.0  0.0  0.0 
+geometry.prob_hi     =  1.0  1.0  1.0
+amr.n_cell           =  64   64   64
+
+# VERBOSITY
+amr.v              = 1       # verbosity in Amr
+
+# REFINEMENT
+amr.max_level       = 2       # maximum level number allowed
+amr.ref_ratio       = 2 2 2 2 # refinement ratio
+amr.blocking_factor = 8       # block factor in grid generation
+amr.max_grid_size   = 16
+
+amr.regrid_int      = 2       # how often to regrid
+
+# PLOTFILES
+amr.plot_file  = plt    # root name of plot file
+amr.plot_int   = 100    # number of timesteps between plot files
+
+myamr.verbose   = 1
+myamr.cfl       = 0.7
+myamr.do_reflux = 1
+
+# Tagging
+myamr.phierr    = 1.01  1.1  1.5

--- a/Tutorials/Amr/Advection_Helmholtz_F/README
+++ b/Tutorials/Amr/Advection_Helmholtz_F/README
@@ -1,0 +1,20 @@
+Advection_Helmholtz_F: The features of this code are
+
+1. Multicomponent advection - Advects a specified number of scalar fields with a velocity
+field that is specified on faces with Neumann BC. The number of components is taken as an input - ncomp
+from the input file. The initial conditions for the components can be specified in Prob.f90.
+
+2. Helmholtz solver with Neumann BC integrated within the time loop. The Helmholtz problem (same as in LinearSolvers/ABecLaplacian_F)
+is constructed on the adapted grid and solved for within the time loop.
+
+3. Works in both 2d and 3d. make DIM=2 or DIM=3 to compile.
+
+4. Can be used as a starting template for CFD solvers.
+ 
+It is a AMReX based code designed to run in parallel using MPI.
+It uses the Fortran interfaces of AMReX.
+
+The directory Exec/SingleVortex includes a makefile and a sample inputs file.  
+Plotfiles are generated that can be viewed with amrvis2d / amrvis3d. 
+(CCSE's native vis / spreadsheet tool, downloadable separately from ccse.lbl.gov)
+or with Visit.

--- a/Tutorials/Amr/Advection_Helmholtz_F/Source/Make.package
+++ b/Tutorials/Amr/Advection_Helmholtz_F/Source/Make.package
@@ -1,0 +1,4 @@
+F90EXE_sources += fmain.F90 my_amr_mod.F90 initdata.F90 tagging_mod.F90 plotfile_mod.F90
+F90EXE_sources += averagedown_mod.F90 evolve_mod.F90 compute_dt_mod.F90 fillpatch_mod.F90
+F90EXE_sources += amr_data_mod.F90 bc_mod.F90
+F90EXE_sources += rhs_helmholtz.F90 solve_helmholtz.F90

--- a/Tutorials/Amr/Advection_Helmholtz_F/Source/Src_2d/Make.package
+++ b/Tutorials/Amr/Advection_Helmholtz_F/Source/Src_2d/Make.package
@@ -1,0 +1,5 @@
+
+F90EXE_sources += advect_$(DIM)d_mod.F90
+
+f90EXE_sources += compute_flux_$(DIM)d.f90 slope_$(DIM)d.f90
+

--- a/Tutorials/Amr/Advection_Helmholtz_F/Source/Src_2d/advect_2d_mod.F90
+++ b/Tutorials/Amr/Advection_Helmholtz_F/Source/Src_2d/advect_2d_mod.F90
@@ -1,0 +1,133 @@
+
+module advect_module
+
+  use amrex_base_module
+  use amr_data_module
+
+  implicit none
+  private
+  
+  public :: advect
+
+contains
+
+  subroutine advect(time, lo, hi, &
+       &            uin , ui_lo, ui_hi, &
+       &            uout, uo_lo, uo_hi, &
+       &            vx  , vx_lo, vx_hi, &
+       &            vy  , vy_lo, vy_hi, &
+       &            flxx, fx_lo, fx_hi, &
+       &            flxy, fy_lo, fy_hi, &
+       &            dx,dt)
+
+    use compute_flux_module, only : compute_flux_2d
+
+    integer, intent(in) :: lo(2), hi(2)
+    real(amrex_real), intent(in) :: dx(2), dt, time
+    integer, intent(in) :: ui_lo(2), ui_hi(2)
+    integer, intent(in) :: uo_lo(2), uo_hi(2)
+    integer, intent(in) :: vx_lo(2), vx_hi(2)
+    integer, intent(in) :: vy_lo(2), vy_hi(2)
+    integer, intent(in) :: fx_lo(2), fx_hi(2)
+    integer, intent(in) :: fy_lo(2), fy_hi(2)
+    real(amrex_real), intent(in   ) :: uin (ui_lo(1):ui_hi(1),ui_lo(2):ui_hi(2),ncomp)
+    real(amrex_real), intent(inout) :: uout(uo_lo(1):uo_hi(1),uo_lo(2):uo_hi(2),ncomp)
+    real(amrex_real), intent(in   ) :: vx  (vx_lo(1):vx_hi(1),vx_lo(2):vx_hi(2))
+    real(amrex_real), intent(in   ) :: vy  (vy_lo(1):vy_hi(1),vy_lo(2):vy_hi(2))
+    real(amrex_real), intent(  out) :: flxx(fx_lo(1):fx_hi(1),fx_lo(2):fx_hi(2),ncomp)
+    real(amrex_real), intent(  out) :: flxy(fy_lo(1):fy_hi(1),fy_lo(2):fy_hi(2),ncomp)
+    
+    integer :: i, j
+    integer :: glo(2), ghi(2)
+    real(amrex_real) :: dtdx(2), umax, vmax
+    
+    real(amrex_real), dimension(:,:), pointer, contiguous :: phix_1d, phiy_1d, phix, phiy, slope
+    integer :: icomp
+
+    dtdx = dt/dx
+    
+    glo = lo - 1
+    ghi = hi + 1
+
+    ! edge states
+    call amrex_allocate(phix_1d, glo, ghi)
+    call amrex_allocate(phiy_1d, glo, ghi)
+    call amrex_allocate(phix   , glo, ghi)
+    call amrex_allocate(phiy   , glo, ghi)
+    ! slope
+    call amrex_allocate(slope  , glo, ghi)
+
+    ! We like to allocate these **pointers** here and then pass them to a function
+    ! to remove their pointerness for performance, because normally pointers could
+    ! be aliasing.  We need to use pointers instead of allocatable arrays because
+    ! we like to use BoxLib's amrex_allocate to allocate memeory instead of the intrinsic
+    ! allocate.  Amrex_allocate is much faster than allocate inside OMP.  
+    ! Note that one MUST CALL AMREX_DEALLOCATE.
+    
+    ! check if CFL condition is violated.
+    umax = maxval(abs(vx))
+    vmax = maxval(abs(vy))
+    if ( umax*dt .ge. dx(1) .or. &
+         vmax*dt .ge. dx(2) ) then
+       print *, "umax = ", umax, ", vmax = ", vmax, ", dt = ", dt, ", dx = ", dx
+       call amrex_error("CFL violation. Use smaller adv.cfl.")
+    end if
+
+    do icomp=1,ncomp
+
+    ! call a function to compute flux
+    call compute_flux_2d(lo, hi, dt, dx, &
+                         uin(:,:,icomp), ui_lo, ui_hi, &
+                         vx, vx_lo, vx_hi, &
+                         vy, vy_lo, vy_hi, &
+                         flxx, fx_lo, fx_hi, &
+                         flxy, fy_lo, fy_hi, &
+                         phix_1d, phiy_1d, phix, phiy, slope, glo, ghi,icomp)
+
+    ! Final fluxes
+    do    j = lo(2), hi(2)
+       do i = lo(1), hi(1)+1
+          flxx(i,j,icomp) = phix(i,j) * vx(i,j)
+       end do
+    end do
+    !
+    do    j = lo(2), hi(2)+1
+       do i = lo(1), hi(1)
+          flxy(i,j,icomp) = phiy(i,j) * vy(i,j)
+       end do
+    end do
+    
+    ! Do a conservative update
+    do    j = lo(2),hi(2)
+       do i = lo(1),hi(1)
+          uout(i,j,icomp) = uin(i,j,icomp) + &
+               ( (flxx(i,j,icomp) - flxx(i+1,j,icomp)) * dtdx(1) &
+               + (flxy(i,j,icomp) - flxy(i,j+1,icomp)) * dtdx(2) )
+       enddo
+    enddo
+    
+    ! Scale by face area in order to correctly reflx
+    do    j = lo(2), hi(2)
+       do i = lo(1), hi(1)+1
+          flxx(i,j,icomp) = flxx(i,j,icomp) * ( dt * dx(2))
+       enddo
+    enddo
+    
+    ! Scale by face area in order to correctly reflx
+    do    j = lo(2), hi(2)+1 
+       do i = lo(1), hi(1)
+          flxy(i,j,icomp) = flxy(i,j,icomp) * (dt * dx(1))
+       enddo
+    enddo
+ 
+    enddo
+    
+    call amrex_deallocate(phix_1d)
+    call amrex_deallocate(phiy_1d)
+    call amrex_deallocate(phix)
+    call amrex_deallocate(phiy)
+    call amrex_deallocate(slope)
+    
+  end subroutine advect
+
+end module advect_module

--- a/Tutorials/Amr/Advection_Helmholtz_F/Source/Src_2d/compute_flux_2d.f90
+++ b/Tutorials/Amr/Advection_Helmholtz_F/Source/Src_2d/compute_flux_2d.f90
@@ -1,0 +1,118 @@
+module compute_flux_module
+
+  use amrex_base_module
+  use amr_data_module
+
+  implicit none
+
+  private
+
+  public :: compute_flux_2d
+
+contains
+
+  subroutine compute_flux_2d(lo, hi, dt, dx, &
+                             phi,ph_lo,ph_hi, &
+                             umac,  u_lo,  u_hi, &
+                             vmac,  v_lo,  v_hi, &
+                             flxx, fx_lo, fx_hi, &
+                             flxy, fy_lo, fy_hi, &
+                             phix_1d, phiy_1d, phix, phiy, slope, glo, ghi,icomp)
+
+    use slope_module, only: slopex, slopey
+
+    integer, intent(in) :: lo(2), hi(2), glo(2), ghi(2)
+    real(amrex_real), intent(in) :: dt, dx(2)
+    integer, intent(in) :: ph_lo(2), ph_hi(2)
+    integer, intent(in) ::  u_lo(2),  u_hi(2)
+    integer, intent(in) ::  v_lo(2),  v_hi(2)
+    integer, intent(in) :: fx_lo(2), fx_hi(2)
+    integer, intent(in) :: fy_lo(2), fy_hi(2)
+    real(amrex_real), intent(in   ) :: phi (ph_lo(1):ph_hi(1),ph_lo(2):ph_hi(2))
+    real(amrex_real), intent(in   ) :: umac( u_lo(1): u_hi(1), u_lo(2): u_hi(2))
+    real(amrex_real), intent(in   ) :: vmac( v_lo(1): v_hi(1), v_lo(2): v_hi(2))
+    real(amrex_real), intent(  out) :: flxx(fx_lo(1):fx_hi(1),fx_lo(2):fx_hi(2),ncomp)
+    real(amrex_real), intent(  out) :: flxy(fy_lo(1):fy_hi(1),fy_lo(2):fy_hi(2),ncomp)
+    real(amrex_real), dimension(glo(1):ghi(1),glo(2):ghi(2)) :: &
+         phix_1d, phiy_1d, phix, phiy, slope
+         
+    integer :: i, j, k
+    real(amrex_real) :: hdtdx(2)
+    integer :: icomp
+
+
+    hdtdx = 0.5_amrex_real*(dt/dx)
+
+    call slopex(glo, ghi, &
+                phi, ph_lo, ph_hi, &
+                slope, glo, ghi)
+
+    ! compute phi on x faces using umac to upwind; ignore transverse terms
+    do    j = lo(2)-1, hi(2)+1
+       do i = lo(1)  , hi(1)+1
+
+          if (umac(i,j) .lt. 0.d0) then
+             phix_1d(i,j) = phi(i  ,j) - (0.5d0 + hdtdx(1)*umac(i,j))*slope(i  ,j)
+          else
+             phix_1d(i,j) = phi(i-1,j) + (0.5d0 - hdtdx(1)*umac(i,j))*slope(i-1,j)
+          end if
+
+       end do
+    end do
+
+    call slopey(glo, ghi, &
+                phi, ph_lo, ph_hi, &
+                slope, glo, ghi)
+
+    ! compute phi on y faces using umac to upwind; ignore transverse terms
+    do    j = lo(2)  , hi(2)+1
+       do i = lo(1)-1, hi(1)+1
+
+          if (vmac(i,j) .lt. 0.d0) then
+             phiy_1d(i,j) = phi(i,j  ) - (0.5d0 + hdtdx(2)*vmac(i,j))*slope(i,j  )
+          else
+             phiy_1d(i,j) = phi(i,j-1) + (0.5d0 - hdtdx(2)*vmac(i,j))*slope(i,j-1)
+          end if
+
+       end do
+    end do
+
+    ! update phi on x faces by adding in y-transverse terms
+    do    j = lo(2), hi(2)
+       do i = lo(1), hi(1)+1
+
+          if (umac(i,j) .lt. 0.d0) then
+             phix(i,j) = phix_1d(i,j) &
+                  - hdtdx(2)*( 0.5d0*(vmac(i  ,j+1)+vmac(i  ,j)) * (phiy_1d(i  ,j+1)-phiy_1d(i  ,j)) )
+          else
+             phix(i,j) = phix_1d(i,j) &
+                  - hdtdx(2)*( 0.5d0*(vmac(i-1,j+1)+vmac(i-1,j)) * (phiy_1d(i-1,j+1)-phiy_1d(i-1,j)) )
+          end if
+
+          ! compute final x-fluxes
+          flxx(i,j,icomp) = phix(i,j)*umac(i,j)
+
+       end do
+    end do
+
+    ! update phi on y faces by adding in x-transverse terms
+    do    j = lo(2), hi(2)+1
+       do i = lo(1), hi(1)
+
+          if (vmac(i,j) .lt. 0.d0) then
+             phiy(i,j) = phiy_1d(i,j) &
+                  - hdtdx(1)*( 0.5d0*(umac(i+1,j  )+umac(i,j  )) * (phix_1d(i+1,j  )-phix_1d(i,j  )) )
+          else
+             phiy(i,j) = phiy_1d(i,j) &
+                  - hdtdx(1)*( 0.5d0*(umac(i+1,j-1)+umac(i,j-1)) * (phix_1d(i+1,j-1)-phix_1d(i,j-1)) )
+          end if
+
+          ! compute final y-fluxes
+          flxy(i,j,icomp) = phiy(i,j)*vmac(i,j)
+
+       end do
+    end do
+
+  end subroutine compute_flux_2d
+
+end module compute_flux_module

--- a/Tutorials/Amr/Advection_Helmholtz_F/Source/Src_2d/slope_2d.f90
+++ b/Tutorials/Amr/Advection_Helmholtz_F/Source/Src_2d/slope_2d.f90
@@ -1,0 +1,126 @@
+module slope_module
+
+  use amrex_base_module
+ 
+  implicit none
+
+  real(amrex_real), parameter:: four3rd=4._amrex_real/3._amrex_real, &
+       sixth=1._amrex_real/6._amrex_real
+  
+  private
+ 
+  public :: slopex, slopey
+ 
+contains
+ 
+  subroutine slopex(lo, hi, &
+                    q, qlo, qhi, &
+                    dq, dqlo, dqhi)
+
+    implicit none
+
+    integer, intent(in) :: lo(2), hi(2), qlo(2), qhi(2), dqlo(2), dqhi(2)
+    real(amrex_real), intent(in ) ::  q( qlo(1): qhi(1), qlo(2): qhi(2))
+    real(amrex_real), intent(out) :: dq(dqlo(1):dqhi(1),dqlo(2):dqhi(2))
+
+    integer :: i, j
+    real(amrex_real), dimension(lo(1)-1:hi(1)+1) :: dsgn, dlim, df, dcen
+    real(amrex_real) :: dlft, drgt, dq1
+
+    do j = lo(2), hi(2)
+
+       ! first compute Fromm slopes
+       do i = lo(1)-1, hi(1)+1
+          dlft = q(i  ,j) - q(i-1,j)
+          drgt = q(i+1,j) - q(i  ,j)
+          dcen(i) = .5d0 * (dlft+drgt)
+          dsgn(i) = sign(1.d0, dcen(i))
+          if (dlft*drgt .ge. 0.d0) then
+             dlim(i) = 2.d0 * min( abs(dlft), abs(drgt) )
+          else
+             dlim(i) = 0.d0
+          endif
+          df(i) = dsgn(i)*min( dlim(i), abs(dcen(i)) )
+       end do
+
+       ! Now limited fourth order slopes
+       do i = lo(1), hi(1)
+          dq1 = four3rd*dcen(i) - sixth*(df(i+1) + df(i-1))
+          dq(i,j) = dsgn(i)*min(dlim(i),abs(dq1))
+       end do
+    enddo
+
+  end subroutine slopex
+
+
+  subroutine slopey(lo, hi, &
+                    q, qlo, qhi, &
+                    dq, dqlo, dqhi)
+
+    integer, intent(in) :: lo(2), hi(2), qlo(2), qhi(2), dqlo(2), dqhi(2)
+    real(amrex_real), intent(in ) ::  q( qlo(1): qhi(1), qlo(2): qhi(2))
+    real(amrex_real), intent(out) :: dq(dqlo(1):dqhi(1),dqlo(2):dqhi(2))
+
+    real(amrex_real), dimension(:,:), pointer, contiguous :: dsgn, dlim, df, dcen
+
+    call amrex_allocate(dsgn, lo(1), hi(1), lo(2)-1, hi(2)+1)
+    call amrex_allocate(dlim, lo(1), hi(1), lo(2)-1, hi(2)+1)
+    call amrex_allocate(df  , lo(1), hi(1), lo(2)-1, hi(2)+1)
+    call amrex_allocate(dcen, lo(1), hi(1), lo(2)-1, hi(2)+1)
+
+    call slopey_doit(lo, hi, &
+                     q, qlo, qhi, &
+                     dq, dqlo, dqhi, &
+                     dsgn, dlim, df, dcen, (/lo(1),lo(2)-1/), (/hi(1),hi(2)+1/))
+
+    call amrex_deallocate(dsgn)
+    call amrex_deallocate(dlim)
+    call amrex_deallocate(df)
+    call amrex_deallocate(dcen)
+
+  end subroutine slopey
+
+  subroutine slopey_doit(lo, hi, &
+                         q, qlo, qhi, &
+                         dq, dqlo, dqhi, &
+                         dsgn, dlim, df, dcen, ddlo, ddhi)
+
+    integer, intent(in) :: lo(2), hi(2), qlo(2), qhi(2), dqlo(2), dqhi(2), &
+         ddlo(2), ddhi(2)
+    real(amrex_real), intent(in ) ::  q  ( qlo(1): qhi(1), qlo(2): qhi(2))
+    real(amrex_real), intent(out) :: dq  (dqlo(1):dqhi(1),dqlo(2):dqhi(2))
+    real(amrex_real)              :: dsgn(ddlo(1):ddhi(1),ddlo(2):ddhi(2))
+    real(amrex_real)              :: dlim(ddlo(1):ddhi(1),ddlo(2):ddhi(2))
+    real(amrex_real)              :: df  (ddlo(1):ddhi(1),ddlo(2):ddhi(2))
+    real(amrex_real)              :: dcen(ddlo(1):ddhi(1),ddlo(2):ddhi(2))
+
+    integer :: i, j
+    real(amrex_real) :: dlft, drgt, dq1
+
+    ! first compute Fromm slopes
+    do j    = lo(2)-1, hi(2)+1
+       do i = lo(1)  , hi(1)
+          dlft = q(i,j  ) - q(i,j-1)
+          drgt = q(i,j+1) - q(i,j  )
+          dcen(i,j) = .5d0 * (dlft+drgt)
+          dsgn(i,j) = sign( 1.d0, dcen(i,j) )
+          if (dlft*drgt .ge. 0.d0) then
+             dlim(i,j) = 2.d0 * min( abs(dlft), abs(drgt) )
+          else
+             dlim(i,j) = 0.d0
+          endif
+          df(i,j) = dsgn(i,j)*min( dlim(i,j),abs(dcen(i,j)) )
+       end do
+    end do
+
+    ! Now compute limited fourth order slopes
+    do j    = lo(2), hi(2)
+       do i = lo(1), hi(1)
+          dq1 = four3rd*dcen(i,j) - sixth*( df(i,j+1) + df(i,j-1) )
+          dq(i,j) = dsgn(i,j)*min(dlim(i,j),abs(dq1))
+       end do
+    end do
+
+  end subroutine slopey_doit
+
+end module slope_module 

--- a/Tutorials/Amr/Advection_Helmholtz_F/Source/Src_3d/Adv_3d.f90
+++ b/Tutorials/Amr/Advection_Helmholtz_F/Source/Src_3d/Adv_3d.f90
@@ -1,0 +1,167 @@
+module advect_module
+
+  use amrex_base_module
+
+  use amr_data_module
+  use my_amr_module
+
+  implicit none
+  private
+
+  public :: advect
+
+contains
+
+subroutine advect(time, lo, hi, &
+     &            uin , ui_lo, ui_hi, &
+     &            uout, uo_lo, uo_hi, &
+     &            vx  , vx_lo, vx_hi, &
+     &            vy  , vy_lo, vy_hi, &
+     &            vz  , vz_lo, vz_hi, &
+     &            flxx, fx_lo, fx_hi, &
+     &            flxy, fy_lo, fy_hi, &
+     &            flxz, fz_lo, fz_hi, &
+     &            dx,dt) bind(C, name="advect")
+  
+  use amrex_mempool_module, only : bl_allocate, bl_deallocate
+  use compute_flux_module, only : compute_flux_3d
+
+  implicit none
+
+  integer, intent(in) :: lo(3), hi(3)
+  double precision, intent(in) :: dx(3), dt, time
+  integer, intent(in) :: ui_lo(3), ui_hi(3)
+  integer, intent(in) :: uo_lo(3), uo_hi(3)
+  integer, intent(in) :: vx_lo(3), vx_hi(3)
+  integer, intent(in) :: vy_lo(3), vy_hi(3)
+  integer, intent(in) :: vz_lo(3), vz_hi(3)
+  integer, intent(in) :: fx_lo(3), fx_hi(3)
+  integer, intent(in) :: fy_lo(3), fy_hi(3)
+  integer, intent(in) :: fz_lo(3), fz_hi(3)
+  double precision, intent(in   ) :: uin (ui_lo(1):ui_hi(1),ui_lo(2):ui_hi(2),ui_lo(3):ui_hi(3),ncomp)
+  double precision, intent(inout) :: uout(uo_lo(1):uo_hi(1),uo_lo(2):uo_hi(2),uo_lo(3):uo_hi(3),ncomp)
+  double precision, intent(in   ) :: vx  (vx_lo(1):vx_hi(1),vx_lo(2):vx_hi(2),vx_lo(3):vx_hi(3))
+  double precision, intent(in   ) :: vy  (vy_lo(1):vy_hi(1),vy_lo(2):vy_hi(2),vy_lo(3):vy_hi(3))
+  double precision, intent(in   ) :: vz  (vz_lo(1):vz_hi(1),vz_lo(2):vz_hi(2),vz_lo(3):vz_hi(3))
+  double precision, intent(  out) :: flxx(fx_lo(1):fx_hi(1),fx_lo(2):fx_hi(2),fx_lo(3):fx_hi(3),ncomp)
+  double precision, intent(  out) :: flxy(fy_lo(1):fy_hi(1),fy_lo(2):fy_hi(2),fy_lo(3):fy_hi(3),ncomp)
+  double precision, intent(  out) :: flxz(fz_lo(1):fz_hi(1),fz_lo(2):fz_hi(2),fz_lo(3):fz_hi(3),ncomp)
+
+  integer :: i, j, k
+  integer :: glo(3), ghi(3)
+  double precision :: dtdx(3), umax, vmax, wmax
+  
+  integer :: icomp
+
+
+  ! Some compiler may not support 'contiguous'.  Remove it in that case.
+  double precision, dimension(:,:,:), pointer, contiguous :: &
+       phix, phix_y, phix_z, phiy, phiy_x, phiy_z, phiz, phiz_x, phiz_y, slope
+
+  dtdx = dt/dx
+
+  glo = lo - 1
+  ghi = hi + 1
+
+  ! edge states
+  call bl_allocate(phix  ,glo(1), ghi(1), glo(2), ghi(2), glo(3), ghi(3))
+  call bl_allocate(phix_y,glo(1), ghi(1), glo(2), ghi(2), glo(3), ghi(3))
+  call bl_allocate(phix_z,glo(1), ghi(1), glo(2), ghi(2), glo(3), ghi(3))
+  call bl_allocate(phiy  ,glo(1), ghi(1), glo(2), ghi(2), glo(3), ghi(3))
+  call bl_allocate(phiy_x,glo(1), ghi(1), glo(2), ghi(2), glo(3), ghi(3))
+  call bl_allocate(phiy_z,glo(1), ghi(1), glo(2), ghi(2), glo(3), ghi(3))
+  call bl_allocate(phiz  ,glo(1), ghi(1), glo(2), ghi(2), glo(3), ghi(3))
+  call bl_allocate(phiz_x,glo(1), ghi(1), glo(2), ghi(2), glo(3), ghi(3))
+  call bl_allocate(phiz_y,glo(1), ghi(1), glo(2), ghi(2), glo(3), ghi(3))
+  ! slope
+  call bl_allocate(slope,glo(1), ghi(1), glo(2), ghi(2), glo(3), ghi(3))  
+  
+  ! We like to allocate these **pointers** here and then pass them to a function
+  ! to remove their pointerness for performance, because normally pointers could
+  ! be aliasing.  We need to use pointers instead of allocatable arrays because
+  ! we like to use BoxLib's bl_allocate to allocate memeory instead of the intrinsic
+  ! allocate.  Bl_allocate is much faster than allocate inside OMP.  
+  ! Note that one MUST CALL BL_DEALLOCATE.
+
+  ! check if CFL condition is violated.
+  umax = maxval(abs(vx))
+  vmax = maxval(abs(vy))
+  wmax = maxval(abs(vz))
+  if ( umax*dt .ge. dx(1) .or. &
+       vmax*dt .ge. dx(2) .or. &
+       wmax*dt .ge. dx(3) ) then
+     print *, "umax = ", umax, ", vmax = ", vmax, ", wmax = ", wmax, ", dt = ", dt, ", dx = ", dx
+     call bl_error("CFL violation. Use smaller adv.cfl.")
+  end if
+
+  do icomp=1,ncomp
+
+  ! call a function to compute flux
+  call compute_flux_3d(lo, hi, dt, dx, &
+                       uin(:,:,:,icomp), ui_lo, ui_hi, &
+                       vx, vx_lo, vx_hi, &
+                       vy, vy_lo, vy_hi, &
+                       vz, vz_lo, vz_hi, &
+                       flxx, fx_lo, fx_hi, &
+                       flxy, fy_lo, fy_hi, &
+                       flxz, fz_lo, fz_hi, &
+                       phix, phix_y, phix_z, &
+                       phiy, phiy_x, phiy_z, &
+                       phiz, phiz_x, phiz_y, &
+                       slope, glo, ghi,icomp)
+ 
+   enddo
+  
+  do icomp=1,ncomp
+
+  ! Do a conservative update
+  do       k = lo(3), hi(3)
+     do    j = lo(2), hi(2)
+        do i = lo(1), hi(1)
+           uout(i,j,k,icomp) = uin(i,j,k,icomp) + &
+                ( (flxx(i,j,k,icomp) - flxx(i+1,j,k,icomp)) * dtdx(1) &
+                + (flxy(i,j,k,icomp) - flxy(i,j+1,k,icomp)) * dtdx(2) &
+                + (flxz(i,j,k,icomp) - flxz(i,j,k+1,icomp)) * dtdx(3) )
+        enddo
+     enddo
+  enddo
+
+
+  ! Scale by face area in order to correctly reflx
+  do       k = lo(3), hi(3)
+     do    j = lo(2), hi(2)
+        do i = lo(1), hi(1)+1
+           flxx(i,j,k,icomp) = flxx(i,j,k,icomp) * (dt * dx(2)*dx(3))
+        enddo
+     enddo
+  enddo
+  do       k = lo(3), hi(3)
+     do    j = lo(2), hi(2)+1 
+        do i = lo(1), hi(1)
+           flxy(i,j,k,icomp) = flxy(i,j,k,icomp) * (dt * dx(1)*dx(3))
+        enddo
+     enddo
+  enddo
+  do       k = lo(3), hi(3)+1
+     do    j = lo(2), hi(2)
+        do i = lo(1), hi(1)
+           flxz(i,j,k,icomp) = flxz(i,j,k,icomp) * (dt * dx(1)*dx(2))
+        enddo
+     enddo
+  enddo
+
+  enddo
+  call bl_deallocate(phix  )
+  call bl_deallocate(phix_y)
+  call bl_deallocate(phix_z)
+  call bl_deallocate(phiy  )
+  call bl_deallocate(phiy_x)
+  call bl_deallocate(phiy_z)
+  call bl_deallocate(phiz  )
+  call bl_deallocate(phiz_x)
+  call bl_deallocate(phiz_y)
+  call bl_deallocate(slope)
+
+end subroutine advect
+
+end module advect_module

--- a/Tutorials/Amr/Advection_Helmholtz_F/Source/Src_3d/Make.package
+++ b/Tutorials/Amr/Advection_Helmholtz_F/Source/Src_3d/Make.package
@@ -1,0 +1,3 @@
+f90EXE_sources += Adv_$(DIM)d.f90
+f90EXE_sources += slope_$(DIM)d.f90
+f90EXE_sources += compute_flux_$(DIM)d.f90

--- a/Tutorials/Amr/Advection_Helmholtz_F/Source/Src_3d/compute_flux_3d.f90
+++ b/Tutorials/Amr/Advection_Helmholtz_F/Source/Src_3d/compute_flux_3d.f90
@@ -1,0 +1,292 @@
+module compute_flux_module
+
+  use amr_data_module
+  use my_amr_module
+
+  implicit none
+
+  private
+
+  public :: compute_flux_3d
+
+contains
+
+  subroutine compute_flux_3d(lo, hi, dt, dx, &
+                             phi,ph_lo,ph_hi, &
+                             umac,  u_lo,  u_hi, &
+                             vmac,  v_lo,  v_hi, &
+                             wmac,  w_lo,  w_hi, &
+                             flxx, fx_lo, fx_hi, &
+                             flxy, fy_lo, fy_hi, &
+                             flxz, fz_lo, fz_hi, &
+                             phix, phix_y, phix_z, &
+                             phiy, phiy_x, phiy_z, &
+                             phiz, phiz_x, phiz_y, &
+                             slope, glo, ghi,icomp)
+
+    use slope_module, only: slopex, slopey, slopez
+
+    integer, intent(in) :: lo(3), hi(3), glo(3), ghi(3)
+    double precision, intent(in) :: dt, dx(3)
+    integer, intent(in) :: ph_lo(3), ph_hi(3)
+    integer, intent(in) ::  u_lo(3),  u_hi(3)
+    integer, intent(in) ::  v_lo(3),  v_hi(3)
+    integer, intent(in) ::  w_lo(3),  w_hi(3)
+    integer, intent(in) :: fx_lo(3), fx_hi(3)
+    integer, intent(in) :: fy_lo(3), fy_hi(3)
+    integer, intent(in) :: fz_lo(3), fz_hi(3)
+    double precision, intent(in   ) :: phi (ph_lo(1):ph_hi(1),ph_lo(2):ph_hi(2),ph_lo(3):ph_hi(3))
+    double precision, intent(in   ) :: umac( u_lo(1): u_hi(1), u_lo(2): u_hi(2), u_lo(3): u_hi(3))
+    double precision, intent(in   ) :: vmac( v_lo(1): v_hi(1), v_lo(2): v_hi(2), v_lo(3): v_hi(3))
+    double precision, intent(in   ) :: wmac( w_lo(1): w_hi(1), w_lo(2): w_hi(2), w_lo(3): w_hi(3))
+    double precision, intent(  out) :: flxx(fx_lo(1):fx_hi(1),fx_lo(2):fx_hi(2),fx_lo(3):fx_hi(3),ncomp)
+    double precision, intent(  out) :: flxy(fy_lo(1):fy_hi(1),fy_lo(2):fy_hi(2),fy_lo(3):fy_hi(3),ncomp)
+    double precision, intent(  out) :: flxz(fz_lo(1):fz_hi(1),fz_lo(2):fz_hi(2),fz_lo(3):fz_hi(3),ncomp)
+    double precision, dimension(glo(1):ghi(1),glo(2):ghi(2),glo(3):ghi(3)) :: &
+         phix, phix_y, phix_z, phiy, phiy_x, phiy_z, phiz, phiz_x, phiz_y, slope
+         
+    integer :: i, j, k
+    double precision :: hdtdx(3), tdtdx(3)
+
+    integer :: icomp
+
+    hdtdx = 0.5*(dt/dx)
+    tdtdx = (1.d0/3.d0)*(dt/dx)
+
+    call slopex(glo, ghi, &
+                phi, ph_lo, ph_hi, &
+                slope, glo, ghi)
+                
+    ! compute phi on x faces using umac to upwind; ignore transverse terms
+    do       k = lo(3)-1, hi(3)+1
+       do    j = lo(2)-1, hi(2)+1
+          do i = lo(1)  , hi(1)+1
+
+             if (umac(i,j,k) .lt. 0.d0) then
+                phix(i,j,k) = phi(i  ,j,k) - (0.5d0 + hdtdx(1)*umac(i,j,k))*slope(i  ,j,k)
+             else
+                phix(i,j,k) = phi(i-1,j,k) + (0.5d0 - hdtdx(1)*umac(i,j,k))*slope(i-1,j,k)
+             end if
+
+          end do
+       end do
+    end do
+
+    call slopey(glo, ghi, &
+                phi, ph_lo, ph_hi, &
+                slope, glo, ghi)
+                
+    ! compute phi on y faces using vmac to upwind; ignore transverse terms
+    do       k = lo(3)-1, hi(3)+1
+       do    j = lo(2)  , hi(2)+1
+          do i = lo(1)-1, hi(1)+1
+
+             if (vmac(i,j,k) .lt. 0.d0) then
+                phiy(i,j,k) = phi(i,j  ,k) - (0.5d0 + hdtdx(2)*vmac(i,j,k))*slope(i,j  ,k)
+             else
+                phiy(i,j,k) = phi(i,j-1,k) + (0.5d0 - hdtdx(2)*vmac(i,j,k))*slope(i,j-1,k)
+             end if
+
+          end do
+       end do
+    end do
+
+    call slopez(glo, ghi, &
+                phi, ph_lo, ph_hi, &
+                slope, glo, ghi)
+                
+    ! compute phi on z faces using wmac to upwind; ignore transverse terms
+    do       k = lo(3)  , hi(3)+1
+       do    j = lo(2)-1, hi(2)+1
+          do i = lo(1)-1, hi(1)+1
+
+             if (wmac(i,j,k) .lt. 0.d0) then
+                phiz(i,j,k) = phi(i,j,k  ) - (0.5d0 + hdtdx(3)*wmac(i,j,k))*slope(i,j,k  )
+             else
+                phiz(i,j,k) = phi(i,j,k-1) + (0.5d0 - hdtdx(3)*wmac(i,j,k))*slope(i,j,k-1)
+             end if
+
+          end do
+       end do
+    end do
+
+    !!!!!!!!!!!!!!!!!!!!
+    ! transverse terms
+    !!!!!!!!!!!!!!!!!!!!
+
+    ! update phi on x faces by adding in y-transverse terms
+    do       k=lo(3)-1, hi(3)+1
+       do    j=lo(2)  , hi(2)
+          do i=lo(1)  , hi(1)+1
+
+             if (umac(i,j,k) .lt. 0.d0) then
+                phix_y(i,j,k) = phix(i,j,k) &
+                     - tdtdx(2) * (0.5d0*(vmac(i  ,j+1,k)+vmac(i  ,j,k)) * (phiy(i  ,j+1,k)-phiy(i  ,j,k)) )
+             else
+                phix_y(i,j,k) = phix(i,j,k) &
+                     - tdtdx(2) * (0.5d0*(vmac(i-1,j+1,k)+vmac(i-1,j,k)) * (phiy(i-1,j+1,k)-phiy(i-1,j,k)) )
+             end if
+
+          end do
+       end do
+    end do
+
+    ! update phi on x faces by adding in z-transverse terms
+    do       k=lo(3)  , hi(3)
+       do    j=lo(2)-1, hi(2)+1
+          do i=lo(1)  , hi(1)+1
+
+             if (umac(i,j,k) .lt. 0.d0) then
+                phix_z(i,j,k) = phix(i,j,k) &
+                     - tdtdx(3) * (0.5d0*(wmac(i  ,j,k+1)+wmac(i  ,j,k)) * (phiz(i  ,j,k+1)-phiz(i  ,j,k)) )
+             else
+                phix_z(i,j,k) = phix(i,j,k) &
+                     - tdtdx(3) * (0.5d0*(wmac(i-1,j,k+1)+wmac(i-1,j,k)) * (phiz(i-1,j,k+1)-phiz(i-1,j,k)) )
+             end if
+
+          end do
+       end do
+    end do
+
+    ! update phi on y faces by adding in x-transverse terms
+    do       k = lo(3)-1, hi(3)+1
+       do    j = lo(2)  , hi(2)+1
+          do i = lo(1)  , hi(1)
+
+             if (vmac(i,j,k) .lt. 0.d0) then
+                phiy_x(i,j,k) = phiy(i,j,k) &
+                     - tdtdx(1) * (0.5d0*(umac(i+1,j  ,k)+umac(i,j  ,k)) * (phix(i+1,j  ,k)-phix(i,j  ,k)) )
+             else
+                phiy_x(i,j,k) = phiy(i,j,k) &
+                     - tdtdx(1) * (0.5d0*(umac(i+1,j-1,k)+umac(i,j-1,k)) * (phix(i+1,j-1,k)-phix(i,j-1,k)) )
+             end if
+
+          end do
+       end do
+    end do
+
+    ! update phi on y faces by adding in z-transverse terms
+    do       k = lo(3)  , hi(3)
+       do    j = lo(2)  , hi(2)+1
+          do i = lo(1)-1, hi(1)+1
+
+             if (vmac(i,j,k) .lt. 0.d0) then
+                phiy_z(i,j,k) = phiy(i,j,k) &
+                     - tdtdx(3) * (0.5d0*(wmac(i,j  ,k+1)+wmac(i,j  ,k)) * (phiz(i,j  ,k+1)-phiz(i,j  ,k)) )
+             else
+                phiy_z(i,j,k) = phiy(i,j,k) &
+                     - tdtdx(3) * (0.5d0*(wmac(i,j-1,k+1)+wmac(i,j-1,k)) * (phiz(i,j-1,k+1)-phiz(i,j-1,k)) )
+             end if
+
+          end do
+       end do
+    end do
+
+    ! update phi on z faces by adding in x-transverse terms
+    do       k = lo(3)  , hi(3)+1
+       do    j = lo(2)-1, hi(2)+1
+          do i = lo(1)  , hi(1)
+
+             if (wmac(i,j,k) .lt. 0.d0) then
+                phiz_x(i,j,k) = phiz(i,j,k) &
+                     - tdtdx(1) * (0.5d0*(umac(i+1,j,k  )+umac(i,j,k  )) * (phix(i+1,j,k  )-phix(i,j,k  )) )
+             else
+                phiz_x(i,j,k) = phiz(i,j,k) &
+                     - tdtdx(1) * (0.5d0*(umac(i+1,j,k-1)+umac(i,j,k-1)) * (phix(i+1,j,k-1)-phix(i,j,k-1)) )
+             end if
+
+          end do
+       end do
+    end do
+
+    ! update phi on z faces by adding in y-transverse terms
+    do       k = lo(3)  , hi(3)+1
+       do    j = lo(2)  , hi(2)
+          do i = lo(1)-1, hi(1)+1
+
+             if (wmac(i,j,k) .lt. 0.d0) then
+                phiz_y(i,j,k) = phiz(i,j,k) &
+                     - tdtdx(2) * (0.5d0*(vmac(i,j+1,k  )+vmac(i,j,k  )) * (phiy(i,j+1,k  )-phiy(i,j,k  )) )
+             else
+                phiz_y(i,j,k) = phiz(i,j,k) &
+                     - tdtdx(2) * (0.5d0*(vmac(i,j+1,k-1)+vmac(i,j,k-1)) * (phiy(i,j+1,k-1)-phiy(i,j,k-1)) )
+             end if
+
+          end do
+       end do
+    end do
+
+    !!!!!!!!!!!!!!!!!!!!
+    ! final edge states
+    !!!!!!!!!!!!!!!!!!!!
+
+    ! update phi on x faces by adding in yz and zy transverse terms
+    do       k = lo(3), hi(3)
+       do    j = lo(2), hi(2)
+          do i = lo(1), hi(1)+1
+
+             if (umac(i,j,k) .lt. 0.d0) then
+                phix(i,j,k) = phix(i,j,k) &
+                     - hdtdx(2)*( 0.5d0*(vmac(i  ,j+1,k  )+vmac(i  ,j,k)) * (phiy_z(i  ,j+1,k  )-phiy_z(i  ,j,k)) ) &
+                     - hdtdx(3)*( 0.5d0*(wmac(i  ,j  ,k+1)+wmac(i  ,j,k)) * (phiz_y(i  ,j  ,k+1)-phiz_y(i  ,j,k)) )
+             else
+                phix(i,j,k) = phix(i,j,k) &
+                     - hdtdx(2)*( 0.5d0*(vmac(i-1,j+1,k  )+vmac(i-1,j,k)) * (phiy_z(i-1,j+1,k  )-phiy_z(i-1,j,k)) ) &
+                     - hdtdx(3)*( 0.5d0*(wmac(i-1,j  ,k+1)+wmac(i-1,j,k)) * (phiz_y(i-1,j  ,k+1)-phiz_y(i-1,j,k)) )
+             end if
+
+             ! compute final x-fluxes
+             flxx(i,j,k,icomp) = umac(i,j,k)*phix(i,j,k)
+
+          end do
+       end do
+    end do
+
+    ! update phi on y faces by adding in xz and zx transverse terms
+    do       k = lo(3), hi(3)
+       do    j = lo(2), hi(2)+1
+          do i = lo(1), hi(1)
+
+             if (vmac(i,j,k) .lt. 0.d0) then
+                phiy(i,j,k) = phiy(i,j,k) &
+                     - hdtdx(1)*( 0.5d0*(umac(i+1,j  ,k  )+umac(i,j  ,k)) * (phix_z(i+1,j  ,k  )-phix_z(i,j  ,k)) ) &
+                     - hdtdx(3)*( 0.5d0*(wmac(i  ,j  ,k+1)+wmac(i,j  ,k)) * (phiz_x(i  ,j  ,k+1)-phiz_x(i,j  ,k)) )
+             else
+                phiy(i,j,k) = phiy(i,j,k) &
+                     - hdtdx(1)*( 0.5d0*(umac(i+1,j-1,k  )+umac(i,j-1,k)) * (phix_z(i+1,j-1,k  )-phix_z(i,j-1,k)) ) &
+                     - hdtdx(3)*( 0.5d0*(wmac(i  ,j-1,k+1)+wmac(i,j-1,k)) * (phiz_x(i  ,j-1,k+1)-phiz_x(i,j-1,k)) )
+             end if
+
+             ! compute final y-fluxes
+             flxy(i,j,k,icomp) = vmac(i,j,k)*phiy(i,j,k)
+
+          end do
+       end do
+    end do
+
+    ! update phi on z faces by adding in xy and yx transverse terms
+    do       k = lo(3), hi(3)+1
+       do    j = lo(2), hi(2)
+          do i = lo(1), hi(1)
+
+             if (wmac(i,j,k) .lt. 0.d0) then
+                phiz(i,j,k) = phiz(i,j,k) &
+                     - hdtdx(1)*( 0.5d0*(umac(i+1,j  ,k  )+umac(i  ,j,k)) * (phix_y(i+1,j  ,k  )-phix_y(i,j,k  )) ) &
+                     - hdtdx(2)*( 0.5d0*(vmac(i  ,j+1,k  )+vmac(i  ,j,k)) * (phiy_x(i  ,j+1,k  )-phiy_x(i,j,k  )) )
+             else
+                phiz(i,j,k) = phiz(i,j,k) &
+                     - hdtdx(1)*( 0.5d0*(umac(i+1,j  ,k-1)+umac(i,j,k-1)) * (phix_y(i+1,j  ,k-1)-phix_y(i,j,k-1)) ) &
+                     - hdtdx(2)*( 0.5d0*(vmac(i  ,j+1,k-1)+vmac(i,j,k-1)) * (phiy_x(i  ,j+1,k-1)-phiy_x(i,j,k-1)) )
+             end if
+
+             ! compute final z-fluxes
+             flxz(i,j,k,icomp) = wmac(i,j,k)*phiz(i,j,k)
+
+          end do
+       end do
+    end do
+
+
+  end subroutine compute_flux_3d
+
+end module compute_flux_module

--- a/Tutorials/Amr/Advection_Helmholtz_F/Source/Src_3d/slope_3d.f90
+++ b/Tutorials/Amr/Advection_Helmholtz_F/Source/Src_3d/slope_3d.f90
@@ -1,0 +1,211 @@
+module slope_module
+ 
+  implicit none
+
+  double precision, parameter:: four3rd=4.d0/3.d0, sixth=1.d0/6.d0
+  
+  private
+ 
+  public :: slopex, slopey, slopez
+ 
+contains
+ 
+  subroutine slopex(lo, hi, &
+                    q, qlo, qhi, &
+                    dq, dqlo, dqhi)
+
+    implicit none
+
+    integer, intent(in) :: lo(3), hi(3), qlo(3), qhi(3), dqlo(3), dqhi(3)
+    double precision, intent(in ) ::  q( qlo(1): qhi(1), qlo(2): qhi(2), qlo(3): qhi(3))
+    double precision, intent(out) :: dq(dqlo(1):dqhi(1),dqlo(2):dqhi(2),dqlo(3):dqhi(3))
+
+    integer :: i, j, k
+    double precision, dimension(lo(1)-1:hi(1)+1) :: dsgn, dlim, df, dcen
+    double precision :: dlft, drgt, dq1
+
+    do    k = lo(3), hi(3)
+       do j = lo(2), hi(2)
+
+          ! first compute Fromm slopes
+          do i = lo(1)-1, hi(1)+1
+             dlft = q(i  ,j,k) - q(i-1,j,k)
+             drgt = q(i+1,j,k) - q(i  ,j,k)
+             dcen(i) = .5d0 * (dlft+drgt)
+             dsgn(i) = sign(1.d0, dcen(i))
+             if (dlft*drgt .ge. 0.d0) then
+                dlim(i) = 2.d0 * min( abs(dlft), abs(drgt) )
+             else
+                dlim(i) = 0.d0
+             endif
+             df(i) = dsgn(i)*min( dlim(i), abs(dcen(i)) )
+          end do
+          
+          ! Now limited fourth order slopes
+          do i = lo(1), hi(1)
+             dq1 = four3rd*dcen(i) - sixth*(df(i+1) + df(i-1))
+             dq(i,j,k) = dsgn(i)*min(dlim(i),abs(dq1))
+          end do
+       end do
+    end do
+
+  end subroutine slopex
+
+
+  subroutine slopey(lo, hi, &
+                    q, qlo, qhi, &
+                    dq, dqlo, dqhi)
+
+    use amrex_mempool_module, only : bl_allocate, bl_deallocate
+
+    integer, intent(in) :: lo(3), hi(3), qlo(3), qhi(3), dqlo(3), dqhi(3)
+    double precision, intent(in ) ::  q( qlo(1): qhi(1), qlo(2): qhi(2), qlo(3): qhi(3))
+    double precision, intent(out) :: dq(dqlo(1):dqhi(1),dqlo(2):dqhi(2),dqlo(3):dqhi(3))
+
+    ! Some compiler may not support 'contiguous'.  Remove it in that case.
+    double precision, dimension(:,:), pointer, contiguous :: dsgn, dlim, df, dcen
+
+    call bl_allocate(dsgn, lo(1), hi(1), lo(2)-1, hi(2)+1)
+    call bl_allocate(dlim, lo(1), hi(1), lo(2)-1, hi(2)+1)
+    call bl_allocate(df  , lo(1), hi(1), lo(2)-1, hi(2)+1)
+    call bl_allocate(dcen, lo(1), hi(1), lo(2)-1, hi(2)+1)
+
+    call slopey_doit(lo, hi, &
+                     q, qlo, qhi, &
+                     dq, dqlo, dqhi, &
+                     dsgn, dlim, df, dcen, (/lo(1),lo(2)-1/), (/hi(1),hi(2)+1/))
+
+    call bl_deallocate(dsgn)
+    call bl_deallocate(dlim)
+    call bl_deallocate(df)
+    call bl_deallocate(dcen)
+
+  end subroutine slopey
+
+  subroutine slopey_doit(lo, hi, &
+                         q, qlo, qhi, &
+                         dq, dqlo, dqhi, &
+                         dsgn, dlim, df, dcen, ddlo, ddhi)
+
+    integer, intent(in) :: lo(3), hi(3), qlo(3), qhi(3), dqlo(3), dqhi(3), &
+         ddlo(2), ddhi(2)
+    double precision, intent(in ) ::  q  ( qlo(1): qhi(1), qlo(2): qhi(2), qlo(3): qhi(3))
+    double precision, intent(out) :: dq  (dqlo(1):dqhi(1),dqlo(2):dqhi(2),dqlo(3):dqhi(3))
+    double precision              :: dsgn(ddlo(1):ddhi(1),ddlo(2):ddhi(2))
+    double precision              :: dlim(ddlo(1):ddhi(1),ddlo(2):ddhi(2))
+    double precision              :: df  (ddlo(1):ddhi(1),ddlo(2):ddhi(2))
+    double precision              :: dcen(ddlo(1):ddhi(1),ddlo(2):ddhi(2))
+
+    integer :: i, j, k
+    double precision :: dlft, drgt, dq1
+
+    do k = lo(3), hi(3)
+
+       ! first compute Fromm slopes
+       do j    = lo(2)-1, hi(2)+1
+          do i = lo(1)  , hi(1)
+             dlft = q(i,j  ,k) - q(i,j-1,k)
+             drgt = q(i,j+1,k) - q(i,j  ,k)
+             dcen(i,j) = .5d0 * (dlft+drgt)
+             dsgn(i,j) = sign( 1.d0, dcen(i,j) )
+             if (dlft*drgt .ge. 0.d0) then
+                dlim(i,j) = 2.d0 * min( abs(dlft), abs(drgt) )
+             else
+                dlim(i,j) = 0.d0
+             endif
+             df(i,j) = dsgn(i,j)*min( dlim(i,j),abs(dcen(i,j)) )
+          end do
+       end do
+       
+       ! Now compute limited fourth order slopes
+       do j    = lo(2), hi(2)
+          do i = lo(1), hi(1)
+             dq1 = four3rd*dcen(i,j) - sixth*( df(i,j+1) + df(i,j-1) )
+             dq(i,j,k) = dsgn(i,j)*min(dlim(i,j),abs(dq1))
+          end do
+       end do
+
+    end do
+
+  end subroutine slopey_doit
+
+
+  subroutine slopez(lo, hi, &
+                    q, qlo, qhi, &
+                    dq, dqlo, dqhi)
+
+    use amrex_mempool_module, only : bl_allocate, bl_deallocate
+
+    integer, intent(in) :: lo(3), hi(3), qlo(3), qhi(3), dqlo(3), dqhi(3)
+    double precision, intent(in ) ::  q( qlo(1): qhi(1), qlo(2): qhi(2), qlo(3): qhi(3))
+    double precision, intent(out) :: dq(dqlo(1):dqhi(1),dqlo(2):dqhi(2),dqlo(3):dqhi(3))
+
+    ! Some compiler may not support 'contiguous'.  Remove it in that case.
+    double precision, dimension(:,:,:), pointer, contiguous :: dsgn, dlim, df, dcen
+
+    call bl_allocate(dsgn, lo(1), hi(1), lo(2), hi(2), lo(3)-1, hi(3)+1)
+    call bl_allocate(dlim, lo(1), hi(1), lo(2), hi(2), lo(3)-1, hi(3)+1)
+    call bl_allocate(df  , lo(1), hi(1), lo(2), hi(2), lo(3)-1, hi(3)+1)
+    call bl_allocate(dcen, lo(1), hi(1), lo(2), hi(2), lo(3)-1, hi(3)+1)
+
+    call slopez_doit(lo, hi, &
+                     q, qlo, qhi, &
+                     dq, dqlo, dqhi, &
+                     dsgn, dlim, df, dcen, &
+                     (/lo(1),lo(2),lo(3)-1/), (/hi(1),hi(2),hi(3)+1/))
+
+    call bl_deallocate(dsgn)
+    call bl_deallocate(dlim)
+    call bl_deallocate(df)
+    call bl_deallocate(dcen)
+
+  end subroutine slopez
+
+  subroutine slopez_doit(lo, hi, &
+                         q, qlo, qhi, &
+                         dq, dqlo, dqhi, &
+                         dsgn, dlim, df, dcen, ddlo, ddhi)
+
+    integer, intent(in) :: lo(3), hi(3), qlo(3), qhi(3), dqlo(3), dqhi(3), &
+         ddlo(3), ddhi(3)
+    double precision, intent(in ) ::  q  ( qlo(1): qhi(1), qlo(2): qhi(2), qlo(3): qhi(3))
+    double precision, intent(out) :: dq  (dqlo(1):dqhi(1),dqlo(2):dqhi(2),dqlo(3):dqhi(3))
+    double precision              :: dsgn(ddlo(1):ddhi(1),ddlo(2):ddhi(2),ddlo(3):ddhi(3))
+    double precision              :: dlim(ddlo(1):ddhi(1),ddlo(2):ddhi(2),ddlo(3):ddhi(3))
+    double precision              :: df  (ddlo(1):ddhi(1),ddlo(2):ddhi(2),ddlo(3):ddhi(3))
+    double precision              :: dcen(ddlo(1):ddhi(1),ddlo(2):ddhi(2),ddlo(3):ddhi(3))
+
+    integer :: i, j, k
+    double precision :: dlft, drgt, dq1
+
+    ! first compute Fromm slopes
+    do k       = lo(3)-1, hi(3)+1
+       do j    = lo(2)  , hi(2)
+          do i = lo(1)  , hi(1)
+             dlft = q(i,j,k  ) - q(i,j,k-1)
+             drgt = q(i,j,k+1) - q(i,j,k  )
+             dcen(i,j,k) = .5d0 * (dlft+drgt)
+             dsgn(i,j,k) = sign( 1.d0, dcen(i,j,k) )
+             if (dlft*drgt .ge. 0.d0) then
+                dlim(i,j,k) = 2.d0 * min( abs(dlft), abs(drgt) )
+             else
+                dlim(i,j,k) = 0.d0
+             endif
+             df(i,j,k) = dsgn(i,j,k)*min( dlim(i,j,k),abs(dcen(i,j,k)) )
+          end do
+       end do
+    end do
+       
+    ! Now compute limited fourth order slopes
+    do k       = lo(3), hi(3)
+       do j    = lo(2), hi(2)
+          do i = lo(1), hi(1)
+             dq1 = four3rd*dcen(i,j,k) - sixth*( df(i,j,k+1) + df(i,j,k-1) )
+             dq(i,j,k) = dsgn(i,j,k)*min(dlim(i,j,k),abs(dq1))
+          end do
+       end do
+    end do
+
+  end subroutine slopez_doit
+
+end module slope_module 

--- a/Tutorials/Amr/Advection_Helmholtz_F/Source/amr_data_mod.F90
+++ b/Tutorials/Amr/Advection_Helmholtz_F/Source/amr_data_mod.F90
@@ -1,0 +1,81 @@
+
+module amr_data_module
+
+  use iso_c_binding
+  use amrex_amr_module
+  use amrex_fort_module, only : rt => amrex_real
+  use amrex_base_module
+  use amrex_linear_solver_module
+ 
+  implicit none
+
+  logical, save :: composite_solve = .true.
+
+  integer, save :: verbose = 2
+  integer, save :: cg_verbose = 0
+  integer, save :: max_iter = 100
+  integer, save :: max_fmg_iter = 0
+  integer, save :: linop_maxorder = 2
+  logical, save :: agglomeration = .true.
+  logical, save :: consolidation = .true.
+  real(rt), allocatable :: t_new(:)
+  real(rt), allocatable :: t_old(:)
+
+  type(amrex_multifab), allocatable :: phi_new(:)
+  type(amrex_multifab), allocatable :: phi_old(:)
+  
+  type(amrex_fluxregister), allocatable :: flux_reg(:)
+
+  type(amrex_boxarray), allocatable, save :: ba_new(:)
+  type(amrex_distromap), allocatable, save :: dm_new(:)
+
+  type(amrex_multifab), allocatable, save :: solution(:)
+  type(amrex_multifab), allocatable, save :: rhs(:)
+  type(amrex_multifab), allocatable, save :: exact_solution(:)
+  type(amrex_multifab), allocatable, save :: acoef(:)
+  type(amrex_multifab), allocatable, save :: bcoef(:)
+  type(amrex_multifab),allocatable :: beta(:,:)
+  real(amrex_real), save :: ascalar, bscalar
+  type(amrex_abeclaplacian) :: abeclap
+
+  integer :: ncomp
+
+contains
+
+  subroutine amr_data_init ()
+
+    allocate(t_new(0:amrex_max_level))
+    t_new = 0.0_rt
+
+    allocate(t_old(0:amrex_max_level))
+    t_old = -1.0e100_rt
+
+    allocate(phi_new(0:amrex_max_level))
+    allocate(phi_old(0:amrex_max_level))
+
+    allocate(flux_reg(0:amrex_max_level))
+    
+    allocate(ba_new(0:amrex_max_level))
+    allocate(dm_new(0:amrex_max_level))
+
+    allocate(solution(0:amrex_max_level))
+    allocate(rhs(0:amrex_max_level))
+    allocate(exact_solution(0:amrex_max_level))
+    allocate(acoef(0:amrex_max_level))
+    allocate(bcoef(0:amrex_max_level))
+    allocate(beta(amrex_spacedim,0:amrex_max_level))
+
+  end subroutine amr_data_init
+
+  subroutine amr_data_finalize
+    integer :: lev
+    do lev = 0, amrex_max_level
+       call amrex_multifab_destroy(phi_new(lev))
+       call amrex_multifab_destroy(phi_old(lev))
+    end do
+    do lev = 1, amrex_max_level
+       call amrex_fluxregister_destroy(flux_reg(lev))
+    end do
+  end subroutine amr_data_finalize
+  
+end module amr_data_module

--- a/Tutorials/Amr/Advection_Helmholtz_F/Source/averagedown_mod.F90
+++ b/Tutorials/Amr/Advection_Helmholtz_F/Source/averagedown_mod.F90
@@ -1,0 +1,38 @@
+module averagedown_module
+
+  use amrex_amr_module
+
+  use amr_data_module, only : phi_new
+  use my_amr_module
+
+  implicit none
+  private
+  
+  public :: averagedown, averagedownto
+
+contains
+
+  subroutine averagedown ()
+    integer :: lev, finest_level, icomp
+    finest_level = amrex_get_finest_level()
+
+   do icomp=1,ncomp
+      do lev = finest_level-1, 0, -1
+       call amrex_average_down(phi_new(lev+1), phi_new(lev), amrex_geom(lev+1), amrex_geom(lev), &
+            icomp, 1, amrex_ref_ratio(lev))
+       enddo
+    end do
+  end subroutine averagedown
+
+  subroutine averagedownto (clev)
+    integer, intent(in) :: clev
+    integer :: icomp
+   
+    do icomp=1,ncomp
+	    call amrex_average_down(phi_new(clev+1), phi_new(clev), amrex_geom(clev+1), amrex_geom(clev), &
+            icomp, 1, amrex_ref_ratio(clev))    
+    enddo	
+
+  end subroutine averagedownto
+
+end module averagedown_module

--- a/Tutorials/Amr/Advection_Helmholtz_F/Source/bc_mod.F90
+++ b/Tutorials/Amr/Advection_Helmholtz_F/Source/bc_mod.F90
@@ -1,0 +1,12 @@
+
+module bc_module
+
+  use amrex_base_module
+
+  implicit none
+
+  ! periodic bc.  See amrex_bc_types_module for a list of bc types.
+  integer, allocatable :: lo_bc(:,:)
+  integer, allocatable :: hi_bc(:,:)
+  
+end module bc_module

--- a/Tutorials/Amr/Advection_Helmholtz_F/Source/compute_dt_mod.F90
+++ b/Tutorials/Amr/Advection_Helmholtz_F/Source/compute_dt_mod.F90
@@ -1,0 +1,106 @@
+module compute_dt_module
+
+  use amrex_amr_module
+
+  implicit none
+  private
+
+  public :: compute_dt
+
+contains
+
+  subroutine compute_dt ()
+    use my_amr_module, only : t_new, dt, stop_time, nsubsteps
+
+    integer :: lev, nlevs, n_factor
+    real(amrex_real) :: dt_0, eps
+    real(amrex_real), allocatable :: dt_tmp(:)
+    real(amrex_real), parameter :: change_max = 1.1_amrex_real
+
+    nlevs = amrex_get_numlevels()
+    
+    allocate(dt_tmp(0:nlevs-1))
+    do lev = 0, nlevs-1
+       dt_tmp(lev) = est_timestep(lev, t_new(lev))
+    end do
+    call amrex_parallel_reduce_min(dt_tmp, nlevs)
+ 
+    dt_0 = dt_tmp(0)
+    n_factor = 1
+    do lev = 0, nlevs-1
+       dt_tmp(lev) = min(dt_tmp(lev), change_max*dt(lev))
+       n_factor = n_factor * nsubsteps(lev)
+       dt_0 = min(dt_0, n_factor*dt_tmp(lev))
+    end do
+    
+    ! Limit dt's by the value of stop_time.
+    eps = 1.e-3_amrex_real * dt_0
+    if (t_new(0) + dt_0 .gt. stop_time - eps) then
+       dt_0 = stop_time - t_new(0)
+    end if
+
+    dt(0) = dt_0
+    do lev = 1, nlevs-1
+       dt(lev) = dt(lev-1) / nsubsteps(lev)
+    end do
+  end subroutine compute_dt
+
+
+  function est_timestep (lev, time) result(dt)
+    use my_amr_module, only : phi_new, cfl
+    use face_velocity_module, only : get_face_velocity
+    
+    real(amrex_real) :: dt
+    integer, intent(in) :: lev
+    real(amrex_real), intent(in) :: time
+
+    real(amrex_real) :: dt_est, umax
+    type(amrex_box) :: bx
+    type(amrex_fab) :: u
+    type(amrex_mfiter) :: mfi
+    real(amrex_real), contiguous, pointer :: p(:,:,:,:)
+
+    dt_est = huge(1._amrex_real)
+
+    !$omp parallel reduction(min:dt_est) private(umax,bx,u,mfi,p)
+    call amrex_mfiter_build(mfi, phi_new(lev), tiling=.true.)
+    do while(mfi%next())
+       bx = mfi%nodaltilebox()
+
+       call u%resize(bx,amrex_spacedim)
+       p => u%dataptr()
+
+       call get_face_velocity(time, &
+            p(:,:,:,1), bx%lo, bx%hi, &
+            p(:,:,:,2), bx%lo, bx%hi, &
+#if BL_SPACEDIM == 3
+            p(:,:,:,3), bx%lo, bx%hi, &
+#endif
+            amrex_geom(lev)%dx, amrex_problo)
+
+       umax = u%norminf(1,1)
+       if (umax > 1.e-100_amrex_real) then
+          dt_est = min(dt_est, amrex_geom(lev)%dx(1) / umax)
+       end if
+
+       umax = u%norminf(2,1)
+       if (umax > 1.e-100_amrex_real) then
+          dt_est = min(dt_est, amrex_geom(lev)%dx(2) / umax)
+       end if
+
+#if BL_SPACEDIM == 3
+       umax = u%norminf(3,1)
+       if (umax > 1.e-100_amrex_real) then
+          dt_est = min(dt_est, amrex_geom(lev)%dx(3) / umax)
+       end if
+#endif
+    end do
+    call amrex_mfiter_destroy(mfi)
+    call amrex_fab_destroy(u)
+    !$omp end parallel
+    
+    dt = dt_est * cfl
+
+  end function est_timestep
+
+end module compute_dt_module

--- a/Tutorials/Amr/Advection_Helmholtz_F/Source/evolve_mod.F90
+++ b/Tutorials/Amr/Advection_Helmholtz_F/Source/evolve_mod.F90
@@ -1,0 +1,270 @@
+module evolve_module
+
+  use amrex_amr_module
+  use rhs_helmholtz
+  use solve_helmholtz
+
+  implicit none
+  private
+
+  public :: evolve
+
+contains
+
+  subroutine evolve ()
+    use my_amr_module, only : stepno, max_step, stop_time, dt, plot_int
+    use amr_data_module
+    use compute_dt_module, only : compute_dt
+    use plotfile_module, only : writeplotfile
+    real(amrex_real) :: cur_time
+    integer :: last_plot_file_step, step, lev, substep, finest_level, nlevs, idim
+
+    cur_time = t_new(0)
+    last_plot_file_step = 0;
+
+    call init_prob_abeclaplacian
+    if (plot_int .gt. 0) call writeplotfile
+    
+    do step = stepno(0), max_step-1
+       if (cur_time .ge. stop_time) exit
+
+       if (amrex_parallel_ioprocessor()) then
+          print *, ""
+          print *, "STEP", step+1, "starts ..."
+       end if
+
+       call compute_dt()
+
+       lev = 0
+       substep = 1
+       call timestep(lev, cur_time, substep)
+ 
+       cur_time = cur_time + dt(0)
+
+       if (amrex_parallel_ioprocessor()) then
+          print *, "STEP", step+1, "end. TIME =", cur_time, "DT =", dt(0)
+       end if
+
+       ! sync up time to avoid roundoff errors
+       finest_level = amrex_get_finest_level()
+       do lev = 0, finest_level
+          t_new(lev) = cur_time
+       end do
+
+       call init_prob_abeclaplacian
+
+       call solve()
+
+       if (plot_int .gt. 0 .and. mod(step+1,plot_int) .eq. 0) then
+          last_plot_file_step = step+1
+          call writeplotfile()
+       end if
+
+       if (cur_time .ge. stop_time - 1.e-6_amrex_real*dt(0)) exit
+
+       nlevs=amrex_get_finest_level()
+
+       do lev=0,nlevs
+         call amrex_multifab_destroy(solution(lev))
+         call amrex_multifab_destroy(exact_solution(lev))
+         call amrex_multifab_destroy(rhs(lev))
+         call amrex_multifab_destroy(acoef(lev))
+         call amrex_multifab_destroy(bcoef(lev))
+
+         do idim = 1, amrex_spacedim
+            call amrex_multifab_destroy(beta(idim,lev))
+         enddo
+
+       enddo
+
+    end do
+
+    if (plot_int .gt. 0 .and. stepno(0) .gt. last_plot_file_step) then
+       call writeplotfile()
+    end if
+
+  end subroutine evolve
+
+  recursive subroutine timestep (lev, time, substep)
+    use my_amr_module, only : regrid_int, stepno, nsubsteps, dt, do_reflux
+    use amr_data_module, only : t_old, t_new, phi_old, phi_new, flux_reg
+    use averagedown_module, only : averagedownto
+    integer, intent(in) :: lev, substep
+    real(amrex_real), intent(in) :: time
+    
+    integer, allocatable, save :: last_regrid_step(:)
+    integer :: k, old_finest_level, finest_level, fine_substep
+
+    if (regrid_int .gt. 0) then
+       if (.not.allocated(last_regrid_step)) then
+          allocate(last_regrid_step(0:amrex_max_level))
+          last_regrid_step = 0
+       end if
+
+       ! regrid doesn't change the base level, so we don't regrid on amrex_max_level
+       if (lev .lt. amrex_max_level .and. stepno(lev) .gt. last_regrid_step(lev)) then
+          if (mod(stepno(lev), regrid_int) .eq. 0) then
+
+             old_finest_level = amrex_get_finest_level()
+             call amrex_regrid(lev, time) ! the finest level may change during regrid
+             finest_level = amrex_get_finest_level()
+
+             do k = lev, finest_level
+                last_regrid_step(k) = stepno(k)
+             end do
+
+             do k = old_finest_level+1, finest_level
+                dt(k) = dt(k-1) / amrex_ref_ratio(k-1)             
+             end do
+          end if
+       end if
+    end if
+
+    stepno(lev) = stepno(lev)+1
+
+    ! We need to update t_old(lev) and t_new(lev) before advance is called because of fillpath.
+    t_old(lev) = time
+    t_new(lev) = time + dt(lev)
+    ! swap phi_new(lev) and phi_old(lev) so they are consistent with t_new(lev) and t_old(lev)
+    call amrex_multifab_swap(phi_old(lev), phi_new(lev))
+
+    call advance(lev, time, dt(lev), stepno(lev), substep, nsubsteps(lev))
+
+    if (lev .lt. amrex_get_finest_level()) then
+       do fine_substep = 1, nsubsteps(lev+1)
+          call timestep(lev+1, time+(fine_substep-1)*dt(lev+1), fine_substep)
+       end do
+
+       if (do_reflux) then
+          call flux_reg(lev+1)%reflux(phi_new(lev), 1.0_amrex_real)
+       end if
+
+       call averagedownto(lev)
+    end if    
+  end subroutine timestep
+
+  ! update phi_new(lev)
+  subroutine advance (lev, time, dt, step, substep, nsub)
+    use my_amr_module, only : verbose, do_reflux
+    use amr_data_module, only : phi_new, flux_reg
+    use face_velocity_module, only : get_face_velocity
+    use advect_module, only : advect
+    use fillpatch_module, only : fillpatch
+    integer, intent(in) :: lev, step, substep, nsub
+    real(amrex_real), intent(in) :: time, dt
+
+    integer, parameter :: ngrow = 3
+    integer :: ncomp, idim
+    logical :: nodal(3)
+    type(amrex_multifab) :: phiborder
+    type(amrex_mfiter) :: mfi
+    type(amrex_box) :: bx, tbx
+    real(amrex_real), contiguous, pointer, dimension(:,:,:,:) :: pin,pout,pux,puy,puz,pfx,pfy,pfz, &
+         pf, pfab
+    type(amrex_fab) :: uface(amrex_spacedim)
+    type(amrex_fab) ::  flux(amrex_spacedim)
+    type(amrex_multifab) :: fluxes(amrex_spacedim)
+
+    if (verbose .gt. 0 .and. amrex_parallel_ioprocessor()) then
+       write(*,'(A, 1X, I0, 1X, A, 1X, I0, A, 1X, G0)') &
+            "[Level", lev, "step", step, "] ADVANCE with dt =", dt
+    end if
+
+    ncomp = phi_new(lev)%ncomp()
+
+    if (do_reflux) then
+       do idim = 1, amrex_spacedim
+          nodal = .false.
+          nodal(idim) = .true.
+          call amrex_multifab_build(fluxes(idim), phi_new(lev)%ba, phi_new(lev)%dm, ncomp, 0, nodal)
+       end do
+    end if
+
+    call amrex_multifab_build(phiborder, phi_new(lev)%ba, phi_new(lev)%dm, ncomp, ngrow)
+
+    call fillpatch(lev, time, phiborder)
+
+    !$omp parallel private(mfi,bx,tbx,pin,pout,pux,puy,puz,pfx,pfy,pfz,uface,flux)
+    call amrex_mfiter_build(mfi, phi_new(lev), tiling=.true.)
+    do while(mfi%next())
+       bx = mfi%tilebox()
+
+       pin  => phiborder%dataptr(mfi)
+       pout => phi_new(lev)%dataptr(mfi)
+
+       do idim = 1, amrex_spacedim
+          tbx = bx
+          call tbx%nodalize(idim)
+          call flux(idim)%resize(tbx,ncomp)
+          call tbx%grow(1)
+          call uface(idim)%resize(tbx,1)
+       end do
+
+       pux => uface(1)%dataptr()
+       pfx =>  flux(1)%dataptr()
+       puy => uface(2)%dataptr()
+       pfy =>  flux(2)%dataptr()
+#if BL_SPACEDIM == 3
+       puz => uface(3)%dataptr()
+       pfz =>  flux(3)%dataptr()
+#endif
+
+       call get_face_velocity(time+0.5_amrex_real*dt, &
+            pux, lbound(pux), ubound(pux), &
+            puy, lbound(puy), ubound(puy), &
+#if BL_SPACEDIM == 3
+            puz, lbound(puz), ubound(puz), &
+#endif
+            amrex_geom(lev)%dx, amrex_problo)
+
+       call advect(time, bx%lo, bx%hi, &
+            pin, lbound(pin), ubound(pin), &
+            pout,lbound(pout),ubound(pout), &
+            pux, lbound(pux), ubound(pux), &
+            puy, lbound(puy), ubound(puy), &
+#if BL_SPACEDIM == 3
+            puz, lbound(puz), ubound(puz), &
+#endif
+            pfx, lbound(pfx), ubound(pfx), &
+            pfy, lbound(pfy), ubound(pfy), &
+#if BL_SPACEDIM == 3
+            pfz, lbound(pfz), ubound(pfz), &
+#endif
+            amrex_geom(lev)%dx, dt)
+       
+       if (do_reflux) then
+          do idim = 1, amrex_spacedim
+             pf => fluxes(idim)%dataptr(mfi)
+             pfab => flux(idim)%dataptr()
+             tbx = mfi%nodaltilebox(idim)
+             pf       (tbx%lo(1):tbx%hi(1),tbx%lo(2):tbx%hi(2),tbx%lo(3):tbx%hi(3),:) = &
+                  pfab(tbx%lo(1):tbx%hi(1),tbx%lo(2):tbx%hi(2),tbx%lo(3):tbx%hi(3),:)
+          end do
+       end if
+    end do
+    call amrex_mfiter_destroy(mfi)
+    do idim = 1, amrex_spacedim
+       call amrex_fab_destroy(uface(idim))
+       call amrex_fab_destroy( flux(idim))
+    end do
+    !$omp end parallel
+
+    if (do_reflux) then
+       ! Note that the fluxes have already been scaled by dt and area.
+       if (lev > 0) then
+          call flux_reg(lev)%fineadd(fluxes, 1.0_amrex_real)
+       end if
+
+       if (lev < amrex_get_finest_level()) then
+          call flux_reg(lev+1)%crseinit(fluxes, -1.0_amrex_real)
+       end if
+
+       do idim = 1, amrex_spacedim
+          call amrex_multifab_destroy(fluxes(idim))
+       end do
+    end if
+
+    call amrex_multifab_destroy(phiborder)
+  end subroutine advance
+
+end module evolve_module

--- a/Tutorials/Amr/Advection_Helmholtz_F/Source/fillpatch_mod.F90
+++ b/Tutorials/Amr/Advection_Helmholtz_F/Source/fillpatch_mod.F90
@@ -1,0 +1,120 @@
+module fillpatch_module
+
+  use iso_c_binding
+  use amrex_amr_module
+  use amr_data_module
+
+  implicit none
+
+  private
+
+  public :: fillpatch, fillcoarsepatch
+
+contains
+
+  ! Fill phi with data from phi_old and phi_new of current level and one level below.
+  subroutine fillpatch (lev, time, phi)
+    use amr_data_module, only : t_old, t_new, phi_old, phi_new
+    use bc_module, only : lo_bc, hi_bc
+    integer, intent(in) :: lev
+    real(amrex_real), intent(in) :: time
+    type(amrex_multifab), intent(inout) :: phi
+    
+    !integer, parameter :: src_comp=2, dst_comp=2, num_comp=1  ! for this test code
+    integer, parameter :: num_comp=1  ! for this test code
+    integer :: src_comp, dst_comp
+
+    do src_comp=1,ncomp
+       dst_comp=src_comp       
+
+    if (lev .eq. 0) then
+       call amrex_fillpatch(phi, t_old(lev), phi_old(lev), &
+            &                    t_new(lev), phi_new(lev), &
+            &               amrex_geom(lev), fill_physbc , &
+            &               time, src_comp, dst_comp, num_comp)
+    else
+       call amrex_fillpatch(phi, t_old(lev-1), phi_old(lev-1), &
+            &                    t_new(lev-1), phi_new(lev-1), &
+            &               amrex_geom(lev-1), fill_physbc   , &
+            &                    t_old(lev  ), phi_old(lev  ), &
+            &                    t_new(lev  ), phi_new(lev  ), &
+            &               amrex_geom(lev  ), fill_physbc   , &
+            &               time, src_comp, dst_comp, num_comp, &
+            &               amrex_ref_ratio(lev-1), amrex_interp_cell_cons, &
+            &               lo_bc, hi_bc)
+       ! see amrex_interpolater_module for a list of interpolaters
+    end if
+
+    enddo
+  end subroutine fillpatch
+
+  subroutine fillcoarsepatch (lev, time, phi)
+    use amr_data_module, only : t_old, t_new, phi_old, phi_new
+    use bc_module, only : lo_bc, hi_bc
+    integer, intent(in) :: lev
+    real(amrex_real), intent(in) :: time
+    type(amrex_multifab), intent(inout) :: phi
+
+    !integer, parameter :: src_comp=2, dst_comp=2, num_comp=1  ! for this test code
+    integer, parameter :: num_comp=1  ! for this test code
+    integer :: src_comp, dst_comp
+
+    do src_comp=1,ncomp
+       dst_comp=src_comp       
+
+    call amrex_fillcoarsepatch(phi, t_old(lev-1), phi_old(lev-1),  &
+         &                          t_new(lev-1), phi_new(lev-1),  &
+         &                     amrex_geom(lev-1),    fill_physbc,  &
+         &                     amrex_geom(lev  ),    fill_physbc,  &
+         &                     time, src_comp, dst_comp, num_comp, &
+         &                     amrex_ref_ratio(lev-1), amrex_interp_cell_cons, &
+         &                     lo_bc, hi_bc)
+       ! see amrex_interpolater_module for a list of interpolaters
+
+     enddo
+
+  end subroutine fillcoarsepatch
+
+  subroutine fill_physbc (pmf, scomp, ncomp, time, pgeom) bind(c)
+    use amrex_geometry_module, only : amrex_is_all_periodic
+    use amrex_filcc_module, only : amrex_filcc
+    use bc_module, only : lo_bc, hi_bc
+    type(c_ptr), value :: pmf, pgeom
+    integer(c_int), value :: scomp, ncomp
+    real(amrex_real), value :: time
+
+    type(amrex_geometry) :: geom
+    type(amrex_multifab) :: mf
+    type(amrex_mfiter) :: mfi
+    real(amrex_real), contiguous, pointer, dimension(:,:,:,:) :: p
+    integer :: plo(4), phi(4)
+
+    if (.not. amrex_is_all_periodic()) then
+
+       geom = pgeom
+       mf = pmf
+
+       !$omp parallel private(mfi,p,plo,phi)
+       call amrex_mfiter_build(mfi, mf, tiling=.false.)
+       do while(mfi%next())
+          p => mf%dataptr(mfi)
+          if (.not. geom%domain%contains(p)) then ! part of this box is outside the domain
+             plo = lbound(p)
+             phi = ubound(p)
+             call amrex_filcc(p, plo, phi,         & ! fortran array and bounds
+                  geom%domain%lo, geom%domain%hi,  & ! index extent of whole problem domain
+                  geom%dx,                         & ! cell size in real
+                  geom%get_physical_location(plo), & ! physical location of lower left corner
+                  lo_bc, hi_bc)                      ! bc types for each component
+
+             ! amrex_filcc doesn't fill EXT_DIR (see amrex_bc_types_module for a list of bc types
+             ! In that case, the user needs to fill it.
+          end if
+       end do
+       !$omp end parallel
+
+    end if
+ 
+  end subroutine fill_physbc
+
+end module fillpatch_module

--- a/Tutorials/Amr/Advection_Helmholtz_F/Source/fmain.F90
+++ b/Tutorials/Amr/Advection_Helmholtz_F/Source/fmain.F90
@@ -1,0 +1,26 @@
+
+program main
+
+  use amrex_amr_module
+
+  use my_amr_module
+  use initdata_module
+  use evolve_module
+
+  implicit none
+
+  call amrex_init()
+  call amrex_amrcore_init()
+
+  call my_amr_init()
+
+  call initdata()
+
+  call evolve()
+
+  call my_amr_finalize()
+
+  call amrex_amrcore_finalize()
+  call amrex_finalize()
+
+end program main

--- a/Tutorials/Amr/Advection_Helmholtz_F/Source/initdata.F90
+++ b/Tutorials/Amr/Advection_Helmholtz_F/Source/initdata.F90
@@ -1,0 +1,27 @@
+module initdata_module
+
+  use amrex_amr_module
+
+  use my_amr_module, only : restart, plot_int
+  use plotfile_module, only : writeplotfile
+  use averagedown_module, only : averagedown
+
+  implicit none
+
+  private
+
+  public :: initdata
+
+contains
+
+  subroutine initdata ()
+    if (len_trim(restart) .eq. 0) then
+       call amrex_init_from_scratch(0.0_amrex_real)
+       call averagedown()
+      ! if (plot_int .gt. 0) call writeplotfile
+    else
+       call amrex_abort("init from checkpoint not implemented yet")
+    end if
+  end subroutine initdata
+
+end module initdata_module

--- a/Tutorials/Amr/Advection_Helmholtz_F/Source/my_amr_mod.F90
+++ b/Tutorials/Amr/Advection_Helmholtz_F/Source/my_amr_mod.F90
@@ -1,0 +1,279 @@
+module my_amr_module
+
+  use iso_c_binding
+  use amrex_amr_module
+  use amrex_fort_module, only : rt => amrex_real
+
+  use amrex_base_module
+  use amr_data_module
+  use bc_module
+
+  implicit none
+
+  ! runtime parameters
+
+  integer :: max_step   = huge(1)
+  integer :: regrid_int = 2
+  integer :: check_int  = -1
+  integer :: plot_int   = -1
+  !
+  logical :: do_reflux  = .true.
+  !
+  real(rt) :: stop_time  = huge(1._rt)
+  real(rt) :: cfl        = 0.7_rt
+  !
+  character(len=:), allocatable, save :: check_file
+  character(len=:), allocatable, save :: plot_file
+  character(len=:), allocatable, save :: restart
+
+  integer, allocatable, save :: stepno(:)
+  integer, allocatable, save :: nsubsteps(:)
+
+  real(rt), allocatable, save :: dt(:)
+
+  integer, private, parameter :: nghost = 0
+ 
+contains
+
+  subroutine my_amr_init ()
+    use bc_module, only : lo_bc, hi_bc
+    type(amrex_parmparse) :: pp
+    integer :: ilev
+
+    if (.not.amrex_amrcore_initialized()) call amrex_amrcore_init()
+    
+    call amrex_init_virtual_functions (my_make_new_level_from_scratch, &
+         &                             my_make_new_level_from_coarse,  &
+         &                             my_remake_level,                &
+         &                             my_clear_level,                 &
+         &                             my_error_estimate)
+
+    ! some default parameters
+    allocate(character(len=3)::check_file)
+    check_file = "chk"
+    allocate(character(len=3)::plot_file)
+    plot_file = "plt"
+    allocate(character(len=0)::restart)
+
+    ! Read parameters
+    call amrex_parmparse_build(pp)
+    call pp%query("max_step", max_step)
+    call pp%query("stop_time", stop_time)
+    call amrex_parmparse_destroy(pp)
+    
+    ! Parameters amr.*
+    call amrex_parmparse_build(pp, "amr")
+    call pp%query("regrid_int", regrid_int)
+    call pp%query("ncomp", ncomp)
+    call pp%query("check_int", check_int)
+    call pp%query("plot_int", plot_int)
+    call pp%query("check_file", check_file)
+    call pp%query("plot_file", plot_file)
+    call pp%query("restart", restart)
+    call amrex_parmparse_destroy(pp)
+    
+    ! Parameters myamr.*
+    call amrex_parmparse_build(pp, "myamr")
+    call pp%query("v", verbose)
+    call pp%query("verbose", verbose)
+    call pp%query("cfl", cfl)
+    call pp%query("do_reflux", do_reflux)
+    call amrex_parmparse_destroy(pp)
+
+    allocate(lo_bc(amrex_spacedim,ncomp))
+    allocate(hi_bc(amrex_spacedim,ncomp))
+
+    if (.not. amrex_is_all_periodic()) then
+       lo_bc = amrex_bc_foextrap
+       hi_bc = amrex_bc_foextrap
+    end if
+    
+    allocate(stepno(0:amrex_max_level))
+    stepno = 0
+
+    allocate(nsubsteps(0:amrex_max_level))
+    nsubsteps(0) = 1
+    do ilev = 1, amrex_max_level
+       nsubsteps(ilev) = amrex_ref_ratio(ilev-1)
+    end do
+
+    allocate(dt(0:amrex_max_level))
+    dt = 1.e100
+
+    call amr_data_init()
+    
+  end subroutine my_amr_init
+
+
+  subroutine my_amr_finalize ()
+    call amr_data_finalize()
+  end subroutine my_amr_finalize
+
+  ! Make a new level from scratch and put the data in phi_new.
+  ! Note tha phi_old contains no valid data after this.
+  subroutine my_make_new_level_from_scratch (lev, time, pba, pdm) bind(c)
+    use prob_module, only : init_prob_data
+    integer, intent(in), value :: lev
+    real(amrex_real), intent(in), value :: time
+    type(c_ptr), intent(in), value :: pba, pdm
+
+    type(amrex_boxarray) :: ba
+    type(amrex_distromap) :: dm
+    type(amrex_mfiter) :: mfi
+    type(amrex_box) :: bx
+    real(amrex_real), contiguous, pointer :: phi(:,:,:,:)
+
+    ba = pba
+    dm = pdm
+
+    t_new(lev) = time
+    t_old(lev) = time - 1.e200_amrex_real
+
+    call my_clear_level(lev)
+  
+    call amrex_multifab_build(phi_new(lev), ba, dm, ncomp, nghost)
+    call amrex_multifab_build(phi_old(lev), ba, dm, ncomp, nghost)
+
+    if (lev > 0 .and. do_reflux) then
+      call amrex_fluxregister_build(flux_reg(lev), ba, dm, amrex_ref_ratio(lev-1), lev, ncomp)
+    end if
+
+    call amrex_mfiter_build(mfi, phi_new(lev))
+
+    do while (mfi%next())
+       bx = mfi%tilebox()
+       phi => phi_new(lev)%dataptr(mfi)
+       call init_prob_data(lev, t_new(lev), bx%lo, bx%hi, phi, lbound(phi), ubound(phi), &
+            amrex_geom(lev)%dx, amrex_problo)
+    end do
+
+    call amrex_mfiter_destroy(mfi)
+  end subroutine my_make_new_level_from_scratch
+
+  ! Make a new level from coarse level and put the data in phi_new.
+  ! Note tha phi_old contains no valid data after this.
+  subroutine my_make_new_level_from_coarse (lev, time, pba, pdm) bind(c)
+    use fillpatch_module, only : fillcoarsepatch
+    integer, intent(in), value :: lev
+    real(amrex_real), intent(in), value :: time
+    type(c_ptr), intent(in), value :: pba, pdm
+
+    type(amrex_boxarray) :: ba
+    type(amrex_distromap) :: dm
+
+    type(amrex_multifab) :: new_phi_new
+    integer :: icomp
+
+    ba = pba
+    dm = pdm
+
+    call amrex_multifab_build(new_phi_new, ba, dm, ncomp, 0)
+
+    call fillcoarsepatch(lev, time, new_phi_new)
+
+    call my_clear_level(lev)
+
+    t_new(lev) = time
+    t_old(lev) = time - 1.e200_amrex_real
+
+    call amrex_multifab_build(phi_new(lev), ba, dm, ncomp, nghost)
+    call amrex_multifab_build(phi_old(lev), ba, dm, ncomp, nghost)
+
+    if (lev > 0 .and. do_reflux) then
+       call amrex_fluxregister_build(flux_reg(lev), ba, dm, amrex_ref_ratio(lev-1), lev, ncomp)
+    end if
+
+    do icomp=1,ncomp
+       call phi_new(lev)%copy(new_phi_new, icomp, icomp, 1, 0)
+    enddo
+
+    call amrex_multifab_destroy(new_phi_new)   
+  end subroutine my_make_new_level_from_coarse
+
+  ! Remake a level from current and coarse elvels and put the data in phi_new.
+  ! Note tha phi_old contains no valid data after this.
+  subroutine my_remake_level (lev, time, pba, pdm) bind(c)
+    use fillpatch_module, only : fillpatch
+    integer, intent(in), value :: lev
+    real(amrex_real), intent(in), value :: time
+    type(c_ptr), intent(in), value :: pba, pdm
+    
+    type(amrex_boxarray) :: ba
+    type(amrex_distromap) :: dm
+    type(amrex_multifab) :: new_phi_new
+
+    integer :: icomp
+
+    ba = pba
+    dm = pdm
+
+    call amrex_multifab_build(new_phi_new, ba, dm, ncomp, 0)
+
+    call fillpatch(lev, time, new_phi_new)
+
+    call my_clear_level(lev)
+
+    t_new(lev) = time
+    t_old(lev) = time - 1.e200_amrex_real
+
+    call amrex_multifab_build(phi_new(lev), ba, dm, ncomp, nghost)
+    call amrex_multifab_build(phi_old(lev), ba, dm, ncomp, nghost)
+
+    if (lev > 0 .and. do_reflux) then
+       call amrex_fluxregister_build(flux_reg(lev), ba, dm, amrex_ref_ratio(lev-1), lev, ncomp)
+    end if
+
+    do icomp=1,ncomp
+       call phi_new(lev)%copy(new_phi_new, icomp, icomp, 1, 0)
+    enddo
+
+    call amrex_multifab_destroy(new_phi_new)
+  end subroutine my_remake_level
+
+  subroutine my_clear_level (lev) bind(c)
+    integer, intent(in), value :: lev
+    call amrex_multifab_destroy(phi_new(lev))
+    call amrex_multifab_destroy(phi_old(lev))
+    call amrex_fluxregister_destroy(flux_reg(lev))
+  end subroutine my_clear_level
+
+  subroutine my_error_estimate (lev, cp, t, settag, cleartag) bind(c)
+    use tagging_module, only : tag_phi_error
+    integer, intent(in), value :: lev
+    type(c_ptr), intent(in), value :: cp
+    real(amrex_real), intent(in), value :: t
+    character(kind=c_char), intent(in), value :: settag, cleartag
+
+    real(amrex_real), allocatable, save :: phierr(:)
+    type(amrex_parmparse) :: pp
+    type(amrex_tagboxarray) :: tag
+    type(amrex_mfiter) :: mfi
+    type(amrex_box) :: bx
+    real(amrex_real), contiguous, pointer :: phiarr(:,:,:,:)
+    character(kind=c_char), contiguous, pointer :: tagarr(:,:,:,:)
+
+    if (.not.allocated(phierr)) then
+       call amrex_parmparse_build(pp, "myamr")
+       call pp%getarr("phierr", phierr)
+       call amrex_parmparse_destroy(pp)
+    end if
+
+    tag = cp
+
+    !$omp parallel private(mfi, bx, phiarr, tagarr)
+    call amrex_mfiter_build(mfi, phi_new(lev), tiling=.true.)
+    do while(mfi%next())
+       bx = mfi%tilebox()
+       phiarr => phi_new(lev)%dataptr(mfi)
+       tagarr => tag%dataptr(mfi)
+       call tag_phi_error(lev, t, bx%lo, bx%hi, &
+            phiarr, lbound(phiarr), ubound(phiarr), &
+            tagarr, lbound(tagarr), ubound(tagarr), &
+            phierr(lev+1), settag, cleartag)  ! +1 because level starts with 0, but phierr starts with 1
+    end do
+    call amrex_mfiter_destroy(mfi)
+    !$omp end parallel
+
+  end subroutine my_error_estimate
+  
+end module my_amr_module

--- a/Tutorials/Amr/Advection_Helmholtz_F/Source/plotfile_mod.F90
+++ b/Tutorials/Amr/Advection_Helmholtz_F/Source/plotfile_mod.F90
@@ -1,0 +1,87 @@
+module plotfile_module
+
+  use amrex_amr_module
+  use my_amr_module, only : plot_file, phi_new, t_new, stepno, ncomp
+  
+  use amr_data_module
+
+  implicit none
+
+  private
+
+  public :: writeplotfile
+
+contains
+
+  subroutine writeplotfile ()
+
+    type(amrex_multifab) :: plotmf(0:amrex_max_level)
+    type(amrex_string), allocatable :: varname(:)
+    integer, dimension(0:amrex_max_level) :: steps, rr
+    integer :: ilev, nc
+    character(len=127) :: name
+    character(len=16)  :: current_step
+    integer :: nlevs, icomp
+
+    character(len=10), allocatable :: varnamedummy(:)
+       
+    nc = ncomp+6
+
+    allocate(varname(nc))
+    allocate(varnamedummy(ncomp))
+
+    do icomp=1, ncomp
+      write(varnamedummy(icomp),'("phi",I2.2)')icomp
+    enddo
+
+    do icomp=1, ncomp
+       call amrex_string_build(varname(icomp), varnamedummy(icomp))
+    enddo
+
+    call amrex_string_build(varname(ncomp+1), "solution")
+    call amrex_string_build(varname(ncomp+2), "rhs")
+    call amrex_string_build(varname(ncomp+3), "exact_solution")
+    call amrex_string_build(varname(ncomp+4), "error")
+    call amrex_string_build(varname(ncomp+5), "acoef")
+    call amrex_string_build(varname(ncomp+6), "bcoef")
+   
+    nlevs=amrex_get_finest_level()
+
+      do ilev = 0, nlevs
+          call amrex_multifab_build(plotmf(ilev), phi_new(ilev)%ba, phi_new(ilev)%dm, nc, 1)
+   	do icomp=1,ncomp
+          call plotmf(ilev) % copy(phi_new(ilev), icomp, icomp, 1, 0)
+	enddo
+        call plotmf(ilev) % copy(      solution(ilev), 1, ncomp+1, 1, 0)
+        call plotmf(ilev) % copy(           rhs(ilev), 1, ncomp+2, 1, 0)
+        call plotmf(ilev) % copy(exact_solution(ilev), 1, ncomp+3, 1, 0)
+        call plotmf(ilev) % copy(      solution(ilev), 1, ncomp+4, 1, 0)
+        call plotmf(ilev) % subtract(exact_solution(ilev),1,ncomp+4,1,0)
+        call plotmf(ilev) % copy(acoef(ilev), 1, ncomp+5, 1, 0)
+        call plotmf(ilev) % copy(bcoef(ilev), 1, ncomp+6, 1, 0)
+    end do
+
+    if      (stepno(0) .lt. 1000000) then
+       write(current_step,fmt='(i5.5)') stepno(0)
+    else if (stepno(0) .lt. 10000000) then
+       write(current_step,fmt='(i6.6)') stepno(0)
+    else if (stepno(0) .lt. 100000000) then
+       write(current_step,fmt='(i7.7)') stepno(0)
+    else if (stepno(0) .lt. 1000000000) then
+       write(current_step,fmt='(i8.8)') stepno(0)
+    else
+       write(current_step,fmt='(i15.15)') stepno(0)
+    end if
+
+    name = trim(plot_file) // current_step
+	
+    call amrex_write_plotfile(name, nlevs+1, plotmf, varname, amrex_geom, t_new(0), stepno, amrex_ref_ratio)
+
+    ! let's not rely on finalizer, which is feature not all compilers support properly.
+    do ilev = 0, nlevs
+       call amrex_multifab_destroy(plotmf(ilev))
+    end do
+  end subroutine writeplotfile
+
+
+end module plotfile_module

--- a/Tutorials/Amr/Advection_Helmholtz_F/Source/rhs_helmholtz.F90
+++ b/Tutorials/Amr/Advection_Helmholtz_F/Source/rhs_helmholtz.F90
@@ -1,0 +1,191 @@
+module rhs_helmholtz
+  use amrex_base_module
+  use amrex_amr_module
+  use amr_data_module
+
+  implicit none
+  private
+  public :: init_prob_abeclaplacian
+
+  real(amrex_real), private, parameter :: a = 1.0d0
+  real(amrex_real), private, parameter :: b = 2.0d0
+
+contains
+
+  subroutine init_prob_abeclaplacian
+
+    integer :: ilev
+    integer :: rlo(4), rhi(4), elo(4), ehi(4), alo(4), ahi(4), blo(4), bhi(4)
+    type(amrex_box) :: bx, gbx
+    type(amrex_mfiter) :: mfi
+    real(amrex_real), contiguous, dimension(:,:,:,:), pointer :: prhs, pexact, pa, pb
+    integer :: nlevs
+    integer :: nc,ng,idim
+    logical :: nodal(3)
+
+    ascalar = a
+    bscalar = b
+
+    nlevs = amrex_get_finest_level()
+
+    do ilev = 0, nlevs
+
+      call amrex_multifab_build(solution(ilev), phi_new(ilev)%ba, phi_new(ilev)%dm, nc=1, ng=1)
+      call amrex_multifab_build(exact_solution(ilev), phi_new(ilev)%ba, phi_new(ilev)%dm, nc=1, ng=0)
+      call amrex_multifab_build(rhs(ilev), phi_new(ilev)%ba, phi_new(ilev)%dm, nc=1, ng=0)
+      call amrex_multifab_build(acoef(ilev), phi_new(ilev)%ba, phi_new(ilev)%dm, nc=1, ng=0)
+      call amrex_multifab_build(bcoef(ilev), phi_new(ilev)%ba, phi_new(ilev)%dm, nc=1, ng=1)
+
+      do idim = 1, amrex_spacedim
+          nodal = .false.
+          nodal(idim) = .true.
+          call amrex_multifab_build(beta(idim,ilev), phi_new(ilev)%ba, phi_new(ilev)%dm, 1, 0, nodal)
+       end do
+   enddo
+
+    do ilev = 0, nlevs
+
+       !$omp parallel private(rlo,rhi,elo,ehi,alo,ahi,blo,bhi,bx,mfi,prhs,pexact,pa,pb)
+       call amrex_mfiter_build(mfi, rhs(ilev), tiling=.true.)
+       
+       do while (mfi%next())
+          bx = mfi%tilebox()
+          gbx = mfi%growntilebox(1)
+          prhs   =>            rhs(ilev) % dataptr(mfi)
+          pexact => exact_solution(ilev) % dataptr(mfi)
+          pa     =>          acoef(ilev) % dataptr(mfi)
+          pb     =>          bcoef(ilev) % dataptr(mfi)
+          rlo = lbound(prhs)
+          rhi = ubound(prhs)
+          elo = lbound(pexact)
+          ehi = ubound(pexact)
+          alo = lbound(pa)
+          ahi = ubound(pa)
+          blo = lbound(pb)
+          bhi = ubound(pb)
+          call actual_init_abeclapcian(bx%lo, bx%hi, gbx%lo, gbx%hi, &
+               prhs, rlo(1:3), rhi(1:3), pexact, elo(1:3), ehi(1:3), &
+               pa, alo(1:3), ahi(1:3), pb, blo(1:3), bhi(1:3), &
+               amrex_problo, amrex_probhi, amrex_geom(ilev)%dx)
+
+       end do
+
+       call amrex_mfiter_destroy(mfi)
+       !$omp end parallel
+
+       ! This will be used to provide bc and initial guess for the solver.
+       call solution(ilev)%setVal(0.0_amrex_real)
+    end do
+
+  end subroutine init_prob_abeclaplacian
+
+  subroutine actual_init_abeclapcian (lo, hi, glo, ghi, rhs, rlo, rhi, exact, elo, ehi, &
+       alpha, alo, ahi, beta, blo, bhi, prob_lo, prob_hi, dx)
+    integer, dimension(3), intent(in) :: lo, hi, glo, ghi, rlo, rhi, elo, ehi, alo, ahi, blo, bhi
+    real(amrex_real), intent(inout) :: rhs  (rlo(1):rhi(1),rlo(2):rhi(2),rlo(3):rhi(3))
+    real(amrex_real), intent(inout) :: exact(elo(1):ehi(1),elo(2):ehi(2),elo(3):ehi(3))
+    real(amrex_real), intent(inout) :: alpha(alo(1):ahi(1),alo(2):ahi(2),alo(3):ahi(3))
+    real(amrex_real), intent(inout) :: beta (blo(1):bhi(1),blo(2):bhi(2),blo(3):bhi(3))
+    real(amrex_real), dimension(3), intent(in) :: prob_lo, prob_hi, dx
+
+    integer :: i,j,k
+    real(amrex_real) x, y, z, xc, yc, zc
+    real(amrex_real) r, theta, dbdrfac
+    real(amrex_real) pi, fpi, tpi, fac
+    real(amrex_real), parameter :: w = 0.05d0
+    real(amrex_real), parameter :: sigma = 10.d0
+
+    pi = 4.d0 * atan(1.d0)
+    tpi = 2.0d0 * pi
+    fpi = 4.0d0 * pi
+#if BL_SPACEDIM == 2
+    fac = 8.d0 * pi**2
+#endif
+#if BL_SPACEDIM == 3
+    fac = 12.d0 * pi**2
+#endif
+
+    xc = (prob_hi(1) + prob_lo(1))/2.d0
+    yc = (prob_hi(2) + prob_lo(2))/2.d0
+    zc = (prob_hi(3) + prob_lo(3))/2.d0
+
+    theta = 0.5d0*log(3.d0) / (w + 1.d-50)
+    
+    do k = glo(3), ghi(3)
+       z = prob_lo(3) + dx(3) * (dble(k)+0.5d0)
+       do j = glo(2), ghi(2)
+          y = prob_lo(2) + dx(2) * (dble(j)+0.5d0)
+          do i = glo(1), ghi(1)
+             x = prob_lo(1) + dx(1) * (dble(i)+0.5d0)
+    
+#if BL_SPACEDIM == 2
+             r = sqrt((x-xc)**2 + (y-yc)**2)
+#endif
+#if BL_SPACEDIM == 3	
+             r = sqrt((x-xc)**2 + (y-yc)**2 + (z-zc)**2)
+#endif	
+             beta(i,j,k) = (sigma-1.d0)/2.d0*tanh(theta*(r-0.25d0)) + (sigma+1.d0)/2.d0
+          end do
+       end do
+    end do
+    
+    do k = lo(3), hi(3)
+       z = prob_lo(3) + dx(3) * (dble(k)+0.5d0)
+       do j = lo(2), hi(2)
+          y = prob_lo(2) + dx(2) * (dble(j)+0.5d0)
+          do i = lo(1), hi(1)
+             x = prob_lo(1) + dx(1) * (dble(i)+0.5d0)
+             
+#if BL_SPACEDIM == 2
+             r = sqrt((x-xc)**2 + (y-yc)**2)
+#endif
+#if BL_SPACEDIM == 3	
+             r = sqrt((x-xc)**2 + (y-yc)**2 + (z-zc)**2)
+#endif	
+            
+             dbdrfac = (sigma-1.d0)/2.d0/(cosh(theta*(r-0.25d0)))**2 * theta/r
+             dbdrfac = dbdrfac * b
+             
+             alpha(i,j,k) = 1.d0
+
+#if BL_SPACEDIM == 2
+             exact(i,j,k) = 1.d0 * cos(tpi*x) * cos(tpi*y)   &
+                  &      + .25d0 * cos(fpi*x) * cos(fpi*y)
+
+
+             rhs(i,j,k) = beta(i,j,k)*b*fac*(cos(tpi*x) * cos(tpi*y)    &
+                  &                        + cos(fpi*x) * cos(fpi*y))   &
+                  &   + dbdrfac*((x-xc)*(tpi*sin(tpi*x) * cos(tpi*y)    &
+                  &                     + pi*sin(fpi*x) * cos(fpi*y))   &
+                  &            + (y-yc)*(tpi*cos(tpi*x) * sin(tpi*y)    &
+                  &                     + pi*cos(fpi*x) * sin(fpi*y)))  &
+                  &                   + a * (cos(tpi*x) * cos(tpi*y)    &
+                  &               + 0.25d0 * cos(fpi*x) * cos(fpi*y))
+#endif
+
+
+
+#if BL_SPACEDIM == 3
+             exact(i,j,k) = 1.d0 * cos(tpi*x) * cos(tpi*y) * cos(tpi*z)   &
+                  &      + .25d0 * cos(fpi*x) * cos(fpi*y) * cos(fpi*z)
+
+
+             rhs(i,j,k) = beta(i,j,k)*b*fac*(cos(tpi*x) * cos(tpi*y) * cos(tpi*z)   &
+                  &                        + cos(fpi*x) * cos(fpi*y) * cos(fpi*z))  &
+                  &   + dbdrfac*((x-xc)*(tpi*sin(tpi*x) * cos(tpi*y) * cos(tpi*z)   &
+                  &                     + pi*sin(fpi*x) * cos(fpi*y) * cos(fpi*z))  &
+                  &            + (y-yc)*(tpi*cos(tpi*x) * sin(tpi*y) * cos(tpi*z)   &
+                  &                     + pi*cos(fpi*x) * sin(fpi*y) * cos(fpi*z))  &
+                  &            + (z-zc)*(tpi*cos(tpi*x) * cos(tpi*y) * sin(tpi*z)   &
+                  &                     + pi*cos(fpi*x) * cos(fpi*y) * sin(fpi*z))) &
+                  &                   + a * (cos(tpi*x) * cos(tpi*y) * cos(tpi*z)   &
+                  &               + 0.25d0 * cos(fpi*x) * cos(fpi*y) * cos(fpi*z))
+#endif
+
+          end do
+       end do
+    end do
+
+  end subroutine actual_init_abeclapcian
+
+end module rhs_helmholtz

--- a/Tutorials/Amr/Advection_Helmholtz_F/Source/solve_helmholtz.F90
+++ b/Tutorials/Amr/Advection_Helmholtz_F/Source/solve_helmholtz.F90
@@ -1,0 +1,79 @@
+module solve_helmholtz
+
+ use amrex_amr_module
+ use amr_data_module
+
+ private
+ public :: solve
+
+contains  
+
+  subroutine solve ()
+    type(amrex_multigrid) :: multigrid
+    integer :: ilev, idim
+    integer(c_long) :: npts
+    real(amrex_real) :: err, avg1, avg2, offset
+    logical :: nodal(3)
+    type(amrex_multifab) :: null
+    integer :: nlevs,do_solve, total_levels
+
+    integer :: myrank, ierr
+    type(amrex_boxarray) :: batemp
+    type(amrex_distromap) :: dmtemp
+    logical :: periodic(3)
+
+    nlevs=amrex_get_finest_level()
+
+    ! For ABecLaplacian, the b coefficents are on faces
+
+    do ilev = 0, nlevs
+       call amrex_average_cellcenter_to_face(beta(:,ilev), bcoef(ilev), amrex_geom(ilev))
+    end do
+
+			
+    call amrex_abeclaplacian_build(abeclap, amrex_geom(0:nlevs), phi_new(0:nlevs)%ba, phi_new(0:nlevs)%dm, &
+            metric_term=.false., agglomeration=agglomeration, consolidation=consolidation)
+	 
+    call abeclap % set_maxorder(linop_maxorder)
+
+    ! This is set up to have homogeneous Neumann BC
+     call abeclap % set_domain_bc([amrex_lo_neumann, amrex_lo_neumann, amrex_lo_neumann], &
+          &                       [amrex_lo_neumann, amrex_lo_neumann, amrex_lo_neumann])
+
+     do ilev = 0, nlevs
+         ! for problem with pure homogeneous Neumann BC, we could pass an empty multifab
+         call abeclap % set_level_bc(ilev, solution(ilev))
+     end do
+
+     call abeclap % set_scalars(ascalar, bscalar)
+
+     do ilev = 0, nlevs
+        call abeclap % set_acoeffs(ilev, acoef(ilev))
+        call abeclap % set_bcoeffs(ilev, beta(:,ilev))
+     end do
+
+     call amrex_multigrid_build(multigrid, abeclap)
+     call multigrid % set_verbose(verbose)
+     call multigrid % set_cg_verbose(cg_verbose)
+     call multigrid % set_max_iter(max_iter)
+     call multigrid % set_max_fmg_iter(max_fmg_iter)
+
+     err = multigrid % solve(solution, rhs, 1.e-10_amrex_real, 0.0_amrex_real)
+
+     call amrex_abeclaplacian_destroy(abeclap)
+     call amrex_multigrid_destroy(multigrid)
+
+    ! Since this problem has Neumann BC, solution + constant is also a
+    ! solution.  So we are going to shift the solution by a constant
+    ! for comparison with the "exact solution".
+    npts = phi_new(0)%ba%num_pts()
+    avg1 = exact_solution(0) % sum()
+    avg2 = solution(0) % sum()
+    offset = (avg1-avg2)/npts
+    do ilev = 0, nlevs
+       call solution(ilev)%plus(offset, icomp=1, ncomp=1, nghost=0)
+    end do
+
+  end subroutine solve
+
+end module solve_helmholtz

--- a/Tutorials/Amr/Advection_Helmholtz_F/Source/tagging_mod.F90
+++ b/Tutorials/Amr/Advection_Helmholtz_F/Source/tagging_mod.F90
@@ -1,0 +1,52 @@
+module tagging_module
+
+  use iso_c_binding
+
+  use amrex_fort_module
+  use amr_data_module
+
+  implicit none
+
+  private
+
+  public :: tag_phi_error
+
+contains
+
+  subroutine tag_phi_error (level, time, lo, hi, phi, philo, phihi, tag, taglo, taghi, phierr, &
+       settag, cleartag)
+    integer, intent(in) :: level, lo(3), hi(3), philo(4), phihi(4), taglo(4), taghi(4)
+    real(amrex_real) , intent(in   ) :: phi(philo(1):phihi(1),philo(2):phihi(2),philo(3):phihi(3),ncomp)
+    character(kind=c_char), intent(inout) :: tag(taglo(1):taghi(1),taglo(2):taghi(2),taglo(3):taghi(3))
+    real(amrex_real), intent(in) :: time, phierr
+    character(kind=c_char), intent(in) :: settag, cleartag
+
+    integer :: i,j,k
+
+    real(amrex_real) :: phierr_this
+
+    phierr_this = phierr
+
+    if (level >= 1) then
+       !
+       !  This is here for testing only! 
+       !  Remove this if you use this as a template.
+       !
+       if (time > 0.75_amrex_real .and. time < 1.0_amrex_real) then
+          phierr_this = 2.0_amrex_real * phierr
+       end if
+    end if
+
+    do       k = lo(3), hi(3)
+       do    j = lo(2), hi(2)
+          do i = lo(1), hi(1)
+             if (phi(i,j,k,1) .ge. phierr_this) then
+                tag(i,j,k) = settag
+             endif
+          enddo
+       enddo
+    enddo
+  end subroutine tag_phi_error
+
+end module tagging_module
+


### PR DESCRIPTION
Advection_Helmholtz_F: The features of this code are

1. Multicomponent advection - Advects a specified number of scalar fields with a velocity
field that is specified on faces with Neumann BC. The number of components is taken as an input - ncomp from the input file. The initial conditions for the components can be specified in Prob.f90.

2. Helmholtz solver with Neumann BC integrated within the time loop. The Helmholtz problem (same as in LinearSolvers/ABecLaplacian_F) is constructed on the adapted grid and solved for within the time loop.

3. Works in both 2d and 3d. make DIM=2 or DIM=3 to compile.

4. Can be used as a starting template for CFD solvers.