### PR TITLE
Do not initialize dt_level on levels that do not yet exist

### DIFF
--- a/Src/Amr/AMReX_Amr.cpp
+++ b/Src/Amr/AMReX_Amr.cpp
@@ -1285,7 +1285,7 @@ Amr::FinalizeInit (Real              strt_time,
     dt_min[0]  = dt_level[0];
     n_cycle[0] = 1;
 
-    for (int lev = 1; lev <= max_level; lev++)
+    for (int lev = 1; lev <= finest_level; lev++)
     {
         dt0           /= n_cycle[lev];
         dt_level[lev]  = dt0;


### PR DESCRIPTION
The way we set dt_level and dt_min in Amr::FinalizeInit is problematic if the level 0 timestep when the simulation starts is significantly different from the timestep later on in the simulation when we add refinement. In particular, this will happen if the simulation code shrinks the initial timestep by some factor. If the fine levels are only added later on once the timestep has caught back up to its normal limited level, then the first timestep on the fine level will be effectively limited by the initial level 0 timestep, which can sharply decrease the timestep for no reason.