### PR TITLE
Flux correction changes needed for FLASH

### DIFF
--- a/Src/AmrCore/AMReX_FLUXREG_nd.F90
+++ b/Src/AmrCore/AMReX_FLUXREG_nd.F90
@@ -4,6 +4,7 @@ module amrex_fluxreg_nd_module
   implicit none
 
   integer, parameter, private :: crse_cell = 0
+  integer, parameter, private :: fine_ontop = 1
 
 contains
 
@@ -15,16 +16,16 @@ contains
     real(amrex_real), intent(in   ) :: src(slo(1):shi(1),slo(2):shi(2),slo(3):shi(3),nc)
     real(amrex_real), intent(inout) :: dst(dlo(1):dhi(1),dlo(2):dhi(2),dlo(3):dhi(3),nc)
     integer,          intent(in   ) :: msk(mlo(1):mhi(1),mlo(2):mhi(2),mlo(3):mhi(3))
-    
+
     integer :: i,j,k,n
-    
+
     if (dir .eq. 0) then
        do n = 1, nc
           do k = lo(3), hi(3)
              do j = lo(2), hi(2)
                 do i = lo(1), hi(1)
-                   if ( (msk(i-1,j,k).eq.crse_cell .or. msk(i,j,k).eq.crse_cell) .and. &
-                        (msk(i-1,j,k).ne.crse_cell .or. msk(i,j,k).ne.crse_cell) ) then
+                   if ( (msk(i-1,j,k).eq.crse_cell  .and. msk(i,j,k).eq.fine_ontop) .or. &
+                        (msk(i-1,j,k).eq.fine_ontop .and. msk(i,j,k).eq.crse_cell ) ) then
                       dst(i,j,k,n) = scale*src(i,j,k,n)
                    end if
                 end do
@@ -36,8 +37,8 @@ contains
           do k = lo(3), hi(3)
              do j = lo(2), hi(2)
                 do i = lo(1), hi(1)
-                   if ( (msk(i,j-1,k).eq.crse_cell .or. msk(i,j,k).eq.crse_cell) .and. &
-                        (msk(i,j-1,k).ne.crse_cell .or. msk(i,j,k).ne.crse_cell) ) then
+                   if ( (msk(i,j-1,k).eq.crse_cell  .and. msk(i,j,k).eq.fine_ontop) .or. &
+                        (msk(i,j-1,k).eq.fine_ontop .and. msk(i,j,k).eq.crse_cell ) ) then
                       dst(i,j,k,n) = scale*src(i,j,k,n)
                    end if
                 end do
@@ -49,8 +50,8 @@ contains
           do k = lo(3), hi(3)
              do j = lo(2), hi(2)
                 do i = lo(1), hi(1)
-                   if ( (msk(i,j,k-1).eq.crse_cell .or. msk(i,j,k).eq.crse_cell) .and. &
-                        (msk(i,j,k-1).ne.crse_cell .or. msk(i,j,k).ne.crse_cell) ) then
+                   if ( (msk(i,j,k-1).eq.crse_cell  .and. msk(i,j,k).eq.fine_ontop) .or. &
+                        (msk(i,j,k-1).eq.fine_ontop .and. msk(i,j,k).eq.crse_cell ) ) then
                       dst(i,j,k,n) = scale*src(i,j,k,n)
                    end if
                 end do

--- a/Src/AmrCore/AMReX_FluxRegister.cpp
+++ b/Src/AmrCore/AMReX_FluxRegister.cpp
@@ -531,7 +531,6 @@ FluxRegister::OverwriteFlux (Array<MultiFab*,AMREX_SPACEDIM> const& crse_fluxes,
 
     // cell-centered mask: 0: coarse, 1: covered by fine, 2: phys bc
     const BoxArray& cba = amrex::convert(crse_fluxes[0]->boxArray(), IntVect::TheCellVector());
-    const BoxArray& cfba = amrex::coarsen(grids, ratio);
     iMultiFab cc_mask(cba, crse_fluxes[0]->DistributionMap(), 1, 1);
     {
         const std::vector<IntVect>& pshifts = cperiod.shiftIntVect();
@@ -551,7 +550,7 @@ FluxRegister::OverwriteFlux (Array<MultiFab*,AMREX_SPACEDIM> const& crse_fluxes,
                 const Box& bx = fab.box();
                 for (const auto& iv : pshifts)
                 {
-                    cfba.intersections(bx+iv, isects);
+                    grids.intersections(bx+iv, isects);
                     for (const auto& is : isects)
                     {
                         fab.setVal(1, is.second-iv, 0, 1);


### PR DESCRIPTION
@WeiqunZhang Fixed bug in OverwriteFlux routine.  The code was coarsening the grid in the
FluxRegister constructor and in the OverwriteFlux function.  It now just
coarsens at construction.  For FLASH, we only need to do flux correction at
fine/coarse boundaries.  Therefore, altered code to ignore physical boundaries.