### PR TITLE
use __BYTE_ORDER__ to detect endianess

### DIFF
--- a/Src/Base/AMReX_FPC.cpp
+++ b/Src/Base/AMReX_FPC.cpp
@@ -4,6 +4,18 @@
 ///
 /// Set up endian-ness macros
 ///
+#if defined(__BYTE_ORDER__) && defined(__ORDER_LITTLE_ENDIAN__) && defined(__ORDER_BIG_ENDIAN__)
+
+#if (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
+#define AMREX_LITTLE_ENDIAN
+#elif (__BYTE_ORDER__ == __ORDER_BIG_ENDIAN__)
+#define AMREX_BIG_ENDIAN
+#else
+#error Unknow Byte Order
+#endif
+
+#else
+
 #if defined(__i486__) || \
     defined(i386) || \
     defined(__i386__) || \
@@ -12,7 +24,7 @@
     defined(__LITTLE_ENDIAN__) || \
     defined(__powerpc__) || \
     defined(powerpc)
-    #define AMREX_LITTLE_ENDIAN
+#define AMREX_LITTLE_ENDIAN
 #endif
 
 #if defined(__sgi) || \
@@ -23,26 +35,17 @@
     defined(_SX)   || \
     defined(__hpux)
 #if !defined(__LITTLE_ENDIAN__)
-    #define AMREX_BIG_ENDIAN
+#define AMREX_BIG_ENDIAN
 #endif
 #endif
 
-#if !(defined(_SX)      || \
-      defined(__sgi)    || \
-      defined(__sun)    || \
-      defined(__i486__) || \
-      defined(i386)     || \
-      defined(__ppc__) || \
-      defined(__ppc64__) || \
-      defined(__i386__) || \
-      defined(__amd64__) || \
-      defined(__x86_64) || \
-      defined(__hpux)   || \
-      defined(__powerpc__) || \
-      defined(powerpc)  || \
-      defined(__LITTLE_ENDIAN__)  || \
-      defined(_MSC_VER) || \
-      defined(_AIX))
+#endif
+
+#if defined(AMREX_LITTLE_ENDIAN) && defined(AMREX_BIG_ENDIAN)
+#error We cannot have both AMREX_LITTLE_ENDIAN and AMREX_BIG_ENDIAN defined
+#endif
+
+#if !defined(AMREX_LITTLE_ENDIAN) && !defined(AMREX_BIG_ENDIAN)
 #error We do not yet support FAB I/O on this machine
 #endif
 

--- a/Src/F_BaseLib/fabio_c.c
+++ b/Src/F_BaseLib/fabio_c.c
@@ -87,22 +87,18 @@ fabio_open_str(int* fdp, const int* ifilename, const int* flagp)
 /*
  * NORDER_? : normal byte order floats(f), doubles(d) on this architecture
  */
-static const char* str_ieee_d = "64 11 52 0 1 12 0 1023";
-static const char* str_ieee_f = "32 8 23 0 1 9 0 127";
-#if defined(__sgi) || \
-    defined(__sun) || \
-    defined(_AIX)  || \
-    defined(__ppc__) || \
-    defined(__ppc64__) || \
-    defined(_SX)   || \
-    defined(__hpux)
-#if !defined(__LITTLE_ENDIAN__)
-static const int norder_d[8] = { 1, 2, 3, 4, 5, 6, 7, 8};
-static const char* str_norder_d = "1 2 3 4 5 6 7 8";
-static const int norder_f[4] = { 1, 2, 3, 4};
-static const char* str_norder_f = "1 2 3 4";
+
+#if defined(__BYTE_ORDER__) && defined(__ORDER_LITTLE_ENDIAN__) && defined(__ORDER_BIG_ENDIAN__)
+
+#if (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
+#define AMREX_LITTLE_ENDIAN
+#elif (__BYTE_ORDER__ == __ORDER_BIG_ENDIAN__)
+#define AMREX_BIG_ENDIAN
+#else
+#error Unknow Byte Order
 #endif
-#endif
+
+#else
 
 #if defined(__i486__) || \
     defined(i386) || \
@@ -112,6 +108,41 @@ static const char* str_norder_f = "1 2 3 4";
     defined(__LITTLE_ENDIAN__) || \
     defined(__powerpc__) || \
     defined(powerpc)
+#define AMREX_LITTLE_ENDIAN
+#endif
+
+#if defined(__sgi) || \
+    defined(__sun) || \
+    defined(_AIX)  || \
+    defined(__ppc__) || \
+    defined(__ppc64__) || \
+    defined(_SX)   || \
+    defined(__hpux)
+#if !defined(__LITTLE_ENDIAN__)
+#define AMREX_BIG_ENDIAN
+#endif
+#endif
+
+#endif
+
+#if defined(AMREX_LITTLE_ENDIAN) && defined(AMREX_BIG_ENDIAN)
+#error We cannot have both AMREX_LITTLE_ENDIAN and AMREX_BIG_ENDIAN defined
+#endif
+
+#if !defined(AMREX_LITTLE_ENDIAN) && !defined(AMREX_BIG_ENDIAN)
+#error We do not yet support FAB I/O on this machine
+#endif
+
+static const char* str_ieee_d = "64 11 52 0 1 12 0 1023";
+static const char* str_ieee_f = "32 8 23 0 1 9 0 127";
+#if defined(AMREX_BIG_ENDIAN)
+static const int norder_d[8] = { 1, 2, 3, 4, 5, 6, 7, 8};
+static const char* str_norder_d = "1 2 3 4 5 6 7 8";
+static const int norder_f[4] = { 1, 2, 3, 4};
+static const char* str_norder_f = "1 2 3 4";
+#endif
+
+#if defined(AMREX_LITTLE_ENDIAN)
 static const int norder_d[8] = { 8, 7, 6, 5, 4, 3, 2, 1};
 static const char* str_norder_d = "8 7 6 5 4 3 2 1";
 static const int norder_f[4] = { 4, 3, 2, 1 };


### PR DESCRIPTION
It seems that using `__BYTE_ORDER__` is more portable way of detecting endianess.

