### PR TITLE
Fortran build routine for non-owning fab

### DIFF
--- a/Src/F_Interfaces/AmrCore/AMReX_fluxregister_mod.F90
+++ b/Src/F_Interfaces/AmrCore/AMReX_fluxregister_mod.F90
@@ -145,10 +145,10 @@ contains
     call amrex_fi_fluxregister_fineadd(this%p, mf, scale)
   end subroutine amrex_fluxregister_fineadd
 
-  subroutine amrex_fluxregister_fineadd_1fab (this, fluxfabs, boxno, scale)
+  subroutine amrex_fluxregister_fineadd_1fab (this, fluxfabs, gridIdx, scale)
     class(amrex_fluxregister), intent(inout) :: this
     type(amrex_fab),  intent(in) :: fluxfabs(amrex_spacedim)
-    integer(c_int),   intent(in) :: boxno
+    integer(c_int),   intent(in) :: gridIdx
     real(amrex_real), intent(in) :: scale
     integer :: dir, nc
     type(c_ptr) :: cp
@@ -162,7 +162,7 @@ contains
          cp = c_loc(fp(flo(1),flo(2),flo(3),1))
          nc =  fab%nc
        end associate
-       call amrex_fi_fluxregister_fineadd_1fab_1dir(this%p, cp, flo,fhi, dir-1, boxno-1, nc, scale)
+       call amrex_fi_fluxregister_fineadd_1fab_1dir(this%p, cp, flo,fhi, dir-1, gridIdx, nc, scale)
     end do
   end subroutine amrex_fluxregister_fineadd_1fab
 

--- a/Src/F_Interfaces/Base/AMReX_fab_mod.F90
+++ b/Src/F_Interfaces/Base/AMReX_fab_mod.F90
@@ -31,13 +31,14 @@ module amrex_fab_module
   end type amrex_fab
 
   interface amrex_fab_build
-     module procedure amrex_fab_build
+     module procedure amrex_fab_build_alloc
      module procedure amrex_fab_build_install
   end interface amrex_fab_build
 
 contains
 
-  subroutine amrex_fab_build (fab, bx, nc)
+  ! Build a fab, allocate own memory
+  subroutine amrex_fab_build_alloc (fab, bx, nc)
     type(amrex_fab), intent(inout) :: fab
     type(amrex_box), intent(in   ) :: bx
     integer, intent(in) :: nc
@@ -47,24 +48,34 @@ contains
     fab%owner = .true.
     call amrex_allocate(fab%fp, bx%lo, bx%hi, nc)
     fab%cp = c_loc(fab%fp(bx%lo(1),bx%lo(2),bx%lo(3),1))
-  end subroutine amrex_fab_build
+  end subroutine amrex_fab_build_alloc
 
+  ! Build a fab, install memory which remains owned by caller
   subroutine amrex_fab_build_install (fab, dp, bx, nc)
     type(amrex_fab), intent(inout) :: fab
     real(amrex_real), contiguous, pointer, intent(in), dimension(:,:,:,:) :: dp
     type(amrex_box), intent(in   ) :: bx
     integer,optional, intent(in) :: nc
     integer :: mync
-    call amrex_fab_destroy(fab)
-    if (associated(dp)) then
+    call amrex_fab_destroy(fab)! sets owner .false.
+    if (associated(dp)) then   ! if passed disassociated dp, just remain in destroyed state
        if (present(nc)) then
           mync = nc
        else
           mync = size(dp,4)
        end if
+#ifdef AMREX_DEBUG
+       if ((bx%hi(1)-bx%lo(1)+1 .NE. size(dp,1)) .OR. &
+           (bx%hi(2)-bx%lo(2)+1 .NE. size(dp,2)) .OR. &
+           (bx%hi(3)-bx%lo(3)+1 .NE. size(dp,3))) then
+          ERROR STOP "amrex_fab_build_install: bx does not match shape of dp"
+       end if
+       if (mync > size(dp,4)) then
+          ERROR STOP "amrex_fab_build_install: nc does not match shape of dp"
+       end if
+#endif
        fab%bx    = bx
        fab%nc    = mync
-       fab%owner = .false.
        fab%fp(bx%lo(1):,bx%lo(2):,bx%lo(3):,1:) => dp
        fab%cp = c_loc(fab%fp(bx%lo(1),bx%lo(2),bx%lo(3),1))
     end if

--- a/Src/F_Interfaces/Base/AMReX_fab_mod.F90
+++ b/Src/F_Interfaces/Base/AMReX_fab_mod.F90
@@ -5,6 +5,7 @@ module amrex_fab_module
   use amrex_fort_module
   use amrex_box_module
   use amrex_mempool_module
+  use amrex_error_module
 
   implicit none
   private
@@ -68,10 +69,10 @@ contains
        if ((bx%hi(1)-bx%lo(1)+1 .NE. size(dp,1)) .OR. &
            (bx%hi(2)-bx%lo(2)+1 .NE. size(dp,2)) .OR. &
            (bx%hi(3)-bx%lo(3)+1 .NE. size(dp,3))) then
-          ERROR STOP "amrex_fab_build_install: bx does not match shape of dp"
+          call amrex_error("amrex_fab_build_install: bx does not match shape of dp")
        end if
        if (mync > size(dp,4)) then
-          ERROR STOP "amrex_fab_build_install: nc does not match shape of dp"
+          call amrex_error("amrex_fab_build_install: nc does not match shape of dp")
        end if
 #endif
        fab%bx    = bx

--- a/Src/F_Interfaces/Base/AMReX_fab_mod.F90
+++ b/Src/F_Interfaces/Base/AMReX_fab_mod.F90
@@ -30,6 +30,11 @@ module amrex_fab_module
 #endif
   end type amrex_fab
 
+  interface amrex_fab_build
+     module procedure amrex_fab_build
+     module procedure amrex_fab_build_install
+  end interface amrex_fab_build
+
 contains
 
   subroutine amrex_fab_build (fab, bx, nc)
@@ -43,6 +48,27 @@ contains
     call amrex_allocate(fab%fp, bx%lo, bx%hi, nc)
     fab%cp = c_loc(fab%fp(bx%lo(1),bx%lo(2),bx%lo(3),1))
   end subroutine amrex_fab_build
+
+  subroutine amrex_fab_build_install (fab, dp, bx, nc)
+    type(amrex_fab), intent(inout) :: fab
+    real(amrex_real), contiguous, pointer, intent(in), dimension(:,:,:,:) :: dp
+    type(amrex_box), intent(in   ) :: bx
+    integer,optional, intent(in) :: nc
+    integer :: mync
+    call amrex_fab_destroy(fab)
+    if (associated(dp)) then
+       if (present(nc)) then
+          mync = nc
+       else
+          mync = size(dp,4)
+       end if
+       fab%bx    = bx
+       fab%nc    = mync
+       fab%owner = .false.
+       fab%fp(bx%lo(1):,bx%lo(2):,bx%lo(3):,1:) => dp
+       fab%cp = c_loc(fab%fp(bx%lo(1),bx%lo(2),bx%lo(3),1))
+    end if
+  end subroutine amrex_fab_build_install
 
   impure elemental subroutine amrex_fab_destroy (fab)
     type(amrex_fab), intent(inout) :: fab


### PR DESCRIPTION
@WeiqunZhang Your improvement to #308 works for me, thanks!

I wanted something like this on the Fortran side, too, i.e., a routine 
"that takes a pointer and builds a non-owning" FAB. Thus this new PR.

Again please let me know if you would prefer to do this in a different way - or just make appropriate changes.