### PR TITLE
More changes for per-fab fluxregister fineadd use from FLASH

### DIFF
--- a/Src/AmrCore/AMReX_FluxRegister.H
+++ b/Src/AmrCore/AMReX_FluxRegister.H
@@ -165,6 +165,9 @@ public:
                   int              destcomp,
                   int              numcomp,
                   Real             mult);
+    //
+    // Set flux correction data for a fine box (given by boxno) to a given value.
+    //
     void FineSetVal (int              dir,
                   int              boxno,
                   int              destcomp,

--- a/Src/AmrCore/AMReX_FluxRegister.H
+++ b/Src/AmrCore/AMReX_FluxRegister.H
@@ -165,6 +165,11 @@ public:
                   int              destcomp,
                   int              numcomp,
                   Real             mult);
+    void FineSetVal (int              dir,
+                  int              boxno,
+                  int              destcomp,
+                  int              numcomp,
+                  Real             val);
     //
     // Apply flux correction.  Note that this takes the coarse Geometry.
     //

--- a/Src/AmrCore/AMReX_FluxRegister.cpp
+++ b/Src/AmrCore/AMReX_FluxRegister.cpp
@@ -396,41 +396,15 @@ FluxRegister::FineSetVal (int              dir,
                        int              numcomp,
                        Real             val)
 {
-    // BL_ASSERT(numcomp <= flux.nComp());
     BL_ASSERT(destcomp >= 0 && destcomp+numcomp <= ncomp);
 
-    // const Box&  flxbox   = flux.box();
-    // const int*  flo      = flxbox.loVect();
-    // const int*  fhi      = flxbox.hiVect();
-    // const Real* flxdat   = flux.dataPtr(srccomp);
-
     FArrayBox& loreg = bndry[Orientation(dir,Orientation::low)][boxno];
-
-#ifdef AMREX_DEBUG
     BL_ASSERT(numcomp <= loreg.nComp());
-#endif
     loreg.setVal(val, loreg.box(), destcomp, numcomp);
-    // const int* rlo = loreg.box().loVect();
-    // const int* rhi = loreg.box().hiVect();
-    // Real* lodat = loreg.dataPtr(destcomp);
-    // amrex_frfaadd(lodat,AMREX_ARLIM(rlo),AMREX_ARLIM(rhi),
-    //              flxdat,AMREX_ARLIM(flo),AMREX_ARLIM(fhi),
-    //              area_dat,AMREX_ARLIM(alo),AMREX_ARLIM(ahi),
-    //              &numcomp,&dir,ratio.getVect(),&mult);
 
     FArrayBox& hireg = bndry[Orientation(dir,Orientation::high)][boxno];
-
-#ifdef AMREX_DEBUG
     BL_ASSERT(numcomp <= hireg.nComp());
-#endif
     hireg.setVal(val, hireg.box(), destcomp, numcomp);
-    // rlo = hireg.box().loVect();
-    // rhi = hireg.box().hiVect();
-    // Real* hidat = hireg.dataPtr(destcomp);
-    // amrex_frfaadd(hidat,AMREX_ARLIM(rlo),AMREX_ARLIM(rhi),
-    //              flxdat,AMREX_ARLIM(flo),AMREX_ARLIM(fhi),
-    //              area_dat,AMREX_ARLIM(alo),AMREX_ARLIM(ahi),
-    //              &numcomp,&dir,ratio.getVect(),&mult);
 }
 
 void 

--- a/Src/AmrCore/AMReX_FluxRegister.cpp
+++ b/Src/AmrCore/AMReX_FluxRegister.cpp
@@ -389,6 +389,50 @@ FluxRegister::FineAdd (const FArrayBox& flux,
                  &numcomp,&dir,ratio.getVect(),&mult);
 }
 
+void
+FluxRegister::FineSetVal (int              dir,
+                       int              boxno,
+                       int              destcomp,
+                       int              numcomp,
+                       Real             val)
+{
+    // BL_ASSERT(numcomp <= flux.nComp());
+    BL_ASSERT(destcomp >= 0 && destcomp+numcomp <= ncomp);
+
+    // const Box&  flxbox   = flux.box();
+    // const int*  flo      = flxbox.loVect();
+    // const int*  fhi      = flxbox.hiVect();
+    // const Real* flxdat   = flux.dataPtr(srccomp);
+
+    FArrayBox& loreg = bndry[Orientation(dir,Orientation::low)][boxno];
+
+#ifdef AMREX_DEBUG
+    BL_ASSERT(numcomp <= loreg.nComp());
+#endif
+    loreg.setVal(val, loreg.box(), destcomp, numcomp);
+    // const int* rlo = loreg.box().loVect();
+    // const int* rhi = loreg.box().hiVect();
+    // Real* lodat = loreg.dataPtr(destcomp);
+    // amrex_frfaadd(lodat,AMREX_ARLIM(rlo),AMREX_ARLIM(rhi),
+    //              flxdat,AMREX_ARLIM(flo),AMREX_ARLIM(fhi),
+    //              area_dat,AMREX_ARLIM(alo),AMREX_ARLIM(ahi),
+    //              &numcomp,&dir,ratio.getVect(),&mult);
+
+    FArrayBox& hireg = bndry[Orientation(dir,Orientation::high)][boxno];
+
+#ifdef AMREX_DEBUG
+    BL_ASSERT(numcomp <= hireg.nComp());
+#endif
+    hireg.setVal(val, hireg.box(), destcomp, numcomp);
+    // rlo = hireg.box().loVect();
+    // rhi = hireg.box().hiVect();
+    // Real* hidat = hireg.dataPtr(destcomp);
+    // amrex_frfaadd(hidat,AMREX_ARLIM(rlo),AMREX_ARLIM(rhi),
+    //              flxdat,AMREX_ARLIM(flo),AMREX_ARLIM(fhi),
+    //              area_dat,AMREX_ARLIM(alo),AMREX_ARLIM(ahi),
+    //              &numcomp,&dir,ratio.getVect(),&mult);
+}
+
 void 
 FluxRegister::Reflux (MultiFab&       mf,
 		      const MultiFab& volume,

--- a/Src/F_Interfaces/AmrCore/AMReX_fluxregister_fi.cpp
+++ b/Src/F_Interfaces/AmrCore/AMReX_fluxregister_fi.cpp
@@ -24,13 +24,15 @@ extern "C"
         }
     }
 
-  void amrex_fi_fluxregister_fineadd_1fab_1dir (FluxRegister* flux_reg, const Real* fabdata,  const int* flo, const int* fhi, int dir, int boxno, int nfluxes, Real scale)
+  void amrex_fi_fluxregister_fineadd_1fab_1dir (FluxRegister* flux_reg, const Real* fabdata,  const int* flo, const int* fhi, int dir, int boxno, int zeroFirst, int nfluxes, Real scale)
     {
         Box bx;
 	bx = Box(IntVect(flo), IntVect(fhi));
 	bx.shiftHalf(dir,-1);
 
 	BL_ASSERT(flux_reg->nComp() == nfluxes);
+	if (zeroFirst)
+	  flux_reg->FineSetVal(dir, boxno, 0, flux_reg->nComp(), 0.0);
         const FArrayBox fab(bx, nfluxes, const_cast<Real*>(fabdata));
 	flux_reg->FineAdd(fab, dir, boxno, 0, 0, flux_reg->nComp(), scale);
     }


### PR DESCRIPTION
Changes for per-FAB fluxregister use from Fortran:
    
Added optional argument to amrex_fluxregister_fineadd_1fab for requesting zeroing of the corresponding fluxregister data storage before flux data from the current fab are added.

Added `FineSetVal` method to FluxRegister class.

Tested from FLASH (3D Sedov in Mode 3)
