### PR TITLE
Add charstring compiler flag

### DIFF
--- a/Tools/GNUMake/comps/pgi.mak
+++ b/Tools/GNUMake/comps/pgi.mak
@@ -101,6 +101,9 @@ ifeq ($(USE_CUDA),TRUE)
   F90FLAGS += -Mcuda=cc$(CUDA_ARCH),ptxinfo,fastmath
   FFLAGS   += -Mcuda=cc$(CUDA_ARCH),ptxinfo,fastmath
 
+  F90FLAGS += -Mcuda=charstring
+  FFLAGS   += -Mcuda=charstring
+
   ifeq ($(DEBUG),TRUE)
     F90FLAGS += -Mcuda=debug
     FFLAGSS  += -Mcuda=debug


### PR DESCRIPTION
Adds -Mcuda=charstring flag to pgi.mak. This is needed for offloading some of the gravity routines to GPU in Castro.