### PR TITLE
work around intel compiler crash

### DIFF
--- a/Tools/F_scripts/write_probin.py
+++ b/Tools/F_scripts/write_probin.py
@@ -338,9 +338,13 @@ def write_probin(probin_template, param_A_files, param_B_files,
                     type = params[n].type
 
                     if type == "logical":
-                        cmd = "merge(\"   \", \"[*]\", {} .eqv. {})".format(params[n].var, params[n].value)
+                        ltest = "\n{}ltest = {} .eqv. {}\n".format(indent, params[n].var, params[n].value)
                     else:
-                        cmd = "merge(\"   \", \"[*]\", {} == {})".format(params[n].var, params[n].value)
+                        ltest = "\n{}ltest = {} == {}\n".format(indent, params[n].var, params[n].value)
+
+                    fout.write(ltest)
+
+                    cmd = "merge(\"   \", \"[*]\", ltest)"
 
                     if type == "real":
                         fout.write("{}write (unit,102) {}, &\n \"{}\", {}\n".format(


### PR DESCRIPTION
This change avoids an intel ICE (versions 17 and 18 atleast).  This simply moves the logical comparison outside of the `merge()`.  Any code that uses this functionality (typically in a `runtime_pretty_print()` routine will need to define a new variable in the template, `logical :: ltest`.  I think only Castro and Maestro do so, and Castro has already been updated.