### PR TITLE
Set SYSTEM_CUDA_PATH for unknown machine

### DIFF
--- a/Tools/GNUMake/sites/Make.unknown
+++ b/Tools/GNUMake/sites/Make.unknown
@@ -68,6 +68,7 @@ ifeq ($(USE_CUDA),TRUE)
   CUDA_HOME ?= /usr/local/cuda
 
   COMPILE_CUDA_PATH = $(CUDA_HOME)
+  SYSTEM_CUDA_PATH = $(CUDA_HOME)
 
   cuda_device_query_result := $(shell $(CUDA_HOME)/extras/demo_suite/deviceQuery | grep "CUDA Capability")
   ifneq ($(cuda_device_query_result),)


### PR DESCRIPTION
When compiling for GPU, it seems that not having `SYSTEM_CUDA_PATH` set leads to a linking error when using the `TINY_PROFILER`. (This is because, in `./Tools/GNUMake/Make.defs`, the compiler flag to link nvtx is only set if `SYSTEM_CUDA_PATH` or `CUDA_PATH` is set.)

When using either an LLNL or OLCF cluster, `SYSTEM_CUDA_PATH` is automatically set to `CUDA_HOME`. However, when using an unknown machine, it is not set. (and hence, compilation with the TINY_PROFILER fails). This PR corrects this issue.