### PR TITLE
fix a bug in sensei AmrMeshDataAdaptor

### DIFF
--- a/Src/Extern/SENSEI/AMReX_AmrMeshDataAdaptor.cpp
+++ b/Src/Extern/SENSEI/AMReX_AmrMeshDataAdaptor.cpp
@@ -178,7 +178,7 @@ int AmrMeshDataAdaptor::GetMesh(const std::string &meshName,
         amrMesh->SetSpacing(i, spacing);
 
         // refinement ratio
-        int cRefRatio = this->Internals->Mesh->refRatio(i)[0];
+        int cRefRatio = nLevels > 1 ? this->Internals->Mesh->refRatio(i)[0] : 1;
         amrMesh->SetRefinementRatio(i, cRefRatio);
 
         // loop over boxes

--- a/Tutorials/Amr/Advection_AmrCore/Source/AmrCoreAdv.cpp
+++ b/Tutorials/Amr/Advection_AmrCore/Source/AmrCoreAdv.cpp
@@ -9,7 +9,6 @@
 
 #ifdef BL_USE_SENSEI_INSITU
 #include <AMReX_AmrMeshInSituBridge.H>
-#include <AMReX_AmrMeshDataAdaptor.H>
 #endif
 
 #ifdef BL_MEM_PROFILING
@@ -138,9 +137,6 @@ AmrCoreAdv::Evolve ()
         }
 
 #ifdef BL_USE_SENSEI_INSITU
-        std::vector<amrex::Vector<amrex::MultiFab>*> states(1, &phi_new);
-        std::vector<std::vector<std::string>> names(1, {"phi"});
-
         insitu_bridge->update(step, cur_time,
             static_cast<amrex::AmrMesh*>(this), {&phi_new}, {{"phi"}});
 #endif


### PR DESCRIPTION
ref ratios may be empty if only 1 level, and cleanup some
code in the tutorial that should not have been committed.