### PR TITLE
Fix a potential numerical overflow in BoxArray::minimalBox

### DIFF
--- a/Src/Base/AMReX_BoxArray.H
+++ b/Src/Base/AMReX_BoxArray.H
@@ -419,7 +419,7 @@ public:
 
     //! Return smallest Box that contains all Boxes in this BoxArray.
     Box minimalBox () const;
-    Box minimalBox (int& npts_avg_box) const;
+    Box minimalBox (long& npts_avg_box) const;
 
     /**
     * \brief True if the Box intersects with this BoxArray(+ghostcells).

--- a/Src/Base/AMReX_BoxArray.cpp
+++ b/Src/Base/AMReX_BoxArray.cpp
@@ -974,7 +974,7 @@ BoxArray::minimalBox () const
 }
 
 Box
-BoxArray::minimalBox (int& npts_avg_box) const
+BoxArray::minimalBox (long& npts_avg_box) const
 {
     BL_ASSERT(m_simple);
     Box minbox;

--- a/Src/Base/AMReX_BoxList.cpp
+++ b/Src/Base/AMReX_BoxList.cpp
@@ -344,7 +344,7 @@ BoxList::complementIn (const Box& b, const BoxArray& ba)
     }
     else
     {
-        int npts_avgbox;
+        long npts_avgbox;
 	Box mbox = ba.minimalBox(npts_avgbox);
         *this = amrex::boxDiff(b, mbox);
         auto mytyp = ixType();


### PR DESCRIPTION
If the number of points per dimension N is such that N^3 is larger than a 32-bit integer (or N^2, for 2D), then this implementation of minimalBox will overflow when accumulating into an n_pts variable. Solved by replacing the value holding the number of points with a long, which is consistent with similar calculations elsewhere in BoxArray.

Fixes #357