### PR TITLE
Fill in last_checkpoint/last_plotfile after a restart

### DIFF
--- a/Src/Amr/AMReX_Amr.cpp
+++ b/Src/Amr/AMReX_Amr.cpp
@@ -1686,6 +1686,13 @@ Amr::restart (const std::string& filename)
        }
     }
 
+    // Save the number of steps taken so far. This mainly
+    // helps in the edge case where we end up not taking
+    // any timesteps before the run terminates, so that
+    // we know not to unnecessarily overwrite the old file.
+    last_checkpoint = level_steps[0];
+    last_plotfile = level_steps[0];
+
     for (int lev = 0; lev <= finest_level; ++lev)
     {
 	Box restart_domain(Geom(lev).Domain());


### PR DESCRIPTION
Castro and Nyx have logic in main.cpp that says to only dump a checkpoint if the coarse timestep of the last checkpoint is older than the current coarse timestep. In the edge case where the simulation doesn't actually take any timesteps after a restart, this results in a checkpoint and plotfile being written from the same data we restarted from, which unnecessarily clobbers the old data and creates a duplicate checkpoint/plotfile.

If the user explicitly wants a new checkpoint on restart, perhaps because they are doing some kind of transformation, they can still take advantage of the flags checkpoint_on_restart and plotfile_on_restart.