### PR TITLE
Add compile flags for building a code using the AMReX build system as an f2py library

### DIFF
--- a/Tools/GNUMake/Make.defs
+++ b/Tools/GNUMake/Make.defs
@@ -185,6 +185,9 @@ ifneq ($(USE_CUDA),TRUE)
   USE_GPU_PRAGMA = FALSE
 endif
 
+SKIP_LINKING ?= FALSE
+USE_COMPILE_PIC ?= FALSE
+
 AMREX_GIT_VERSION := $(shell cd $(AMREX_HOME); git describe --abbrev=12 --dirty --always --tags)
 DEFINES += -DAMREX_GIT_VERSION=\"$(AMREX_GIT_VERSION)\"
 

--- a/Tools/GNUMake/Make.rules
+++ b/Tools/GNUMake/Make.rules
@@ -24,6 +24,7 @@ endif
 # Rules for building executable.
 #
 $(executable): $(objForExecs)
+ifneq ($(SKIP_LINKING),TRUE)
 	@echo Linking $@ ...
 ifeq ($(LINK_WITH_FORTRAN_COMPILER),TRUE)
 	$(SILENT) $(F90) $(F90FLAGS) $(FINAL_CPPFLAGS) $(fincludes) $(LDFLAGS) -o $@ $^ $(libraries)
@@ -31,6 +32,7 @@ else
 	$(SILENT) $(CXX) $(CXXFLAGS) $(FINAL_CPPFLAGS) $(includes) $(LDFLAGS) -o $@ $^ $(libraries)
 endif
 #	@echo SUCCESS
+endif
 
 ifdef CRAY_CPU_TARGET
 	@echo "Built for target ===> $(CRAY_CPU_TARGET) <==="

--- a/Tools/GNUMake/comps/gnu.mak
+++ b/Tools/GNUMake/comps/gnu.mak
@@ -67,6 +67,16 @@ ifeq ($(USE_GPROF),TRUE)
 
 endif
 
+
+ifeq ($(USE_COMPILE_PIC),TRUE)
+
+  CXXFLAGS = -fPIC
+  CFLAGS = -fPIC
+  FFLAGS = -fPIC
+  F90FLAGS = -fPIC
+
+endif
+
 ########################################################################
 
 ifeq ($(gcc_major_version),4)


### PR DESCRIPTION
This PR allows us to build StarKiller Microphysics as a f2py library using f90wrap and f2py.

This lets us import StarKiller into a python script as a python module and call the Fortran eos and burner routines using f2py.

The changes needed to AMReX were:

- Add `-fPIC` compiler flags if `USE_COMPILE_PIC=TRUE` (defaults to `FALSE`)
- Skip the linking step when building the executable if `SKIP_LINKING=TRUE` (defaults to `FALSE`)
