### PR TITLE
Replaces #375 Spline Implicit function for EB

### DIFF
--- a/Src/EB/AMReX_EB2.cpp
+++ b/Src/EB/AMReX_EB2.cpp
@@ -6,7 +6,7 @@
 #include <AMReX_EB2_IF_Plane.H>
 #include <AMReX_EB2_IF_Sphere.H>
 #include <AMReX_EB2_IF_Torus.H>
-
+#include <AMReX_EB2_IF_Spline.H>
 #include <AMReX_EB2_GeometryShop.H>
 #include <AMReX_EB2.H>
 #include <AMReX_ParmParse.H>

--- a/Src/EB/AMReX_EB2_IF.H
+++ b/Src/EB/AMReX_EB2_IF.H
@@ -16,6 +16,7 @@
 #include <AMReX_EB2_IF_Scale.H>
 #include <AMReX_EB2_IF_Sphere.H>
 #include <AMReX_EB2_IF_Torus.H>
+#include <AMReX_EB2_IF_Spline.H>
 #include <AMReX_EB2_IF_Translation.H>
 #include <AMReX_EB2_IF_Union.H>
 

--- a/Src/EB/AMReX_EB2_IF_Spline.H
+++ b/Src/EB/AMReX_EB2_IF_Spline.H
@@ -1,0 +1,62 @@
+
+#ifndef AMREX_EB2_IF_SPLINE_H_
+#define AMREX_EB2_IF_SPLINE_H_
+
+#include <vector>
+#include "AMReX_RealVect.H"
+#include "AMReX.H"
+#include "AMReX_Vector.H"
+#include "AMReX_Array.H"
+#include "AMReX_distFcnElement.H"
+
+namespace amrex { namespace EB2 {
+
+/*
+ * Implicit function to specify a spline through a set of control points
+ */
+class SplineIF {
+ public:
+  // Constructor
+  SplineIF() {}
+
+  // Destructor
+  ~SplineIF() {}
+
+  void addSplineElement(std::vector<amrex::RealVect> pts) {
+    SplineDistFcnElement2d * theSpline = new SplineDistFcnElement2d();
+    theSpline->set_control_points(pts);
+    theSpline->calc_D();
+    geomElements.push_back(theSpline);
+  }
+
+  void addLineElement(std::vector<amrex::RealVect> pts) {
+    LineDistFcnElement2d * theLine = new LineDistFcnElement2d();
+    theLine->set_control_points(pts);
+    geomElements.push_back(theLine);
+  }
+
+  amrex::Real operator() (const amrex::RealArray& p) const {
+    amrex::RealVect cp;
+    distFcnElement2d * closesetGeomElement;
+    amrex::Real dist;
+    dist = 1.0e29;
+    amrex::RealVect x;
+    x[0] = p[0];x[1] = p[1]; x[2] = p[2];
+    for (auto * geom : geomElements ) {
+      amrex::Real d = geom->cpdist(x, cp);
+      if (d < dist) {
+        dist = d;
+        closesetGeomElement = geom;
+      }
+    }
+    amrex::Real side = closesetGeomElement->cpside(x,cp);
+    return dist*side;
+  }
+
+  // private:
+  // The geometry elements used to compute distance function
+  amrex::Vector<distFcnElement2d*> geomElements;
+};
+
+}}
+#endif

--- a/Src/EB/AMReX_distFcnElement.H
+++ b/Src/EB/AMReX_distFcnElement.H
@@ -6,6 +6,8 @@
 #include "AMReX.H"
 #include "AMReX_Vector.H"
 
+namespace amrex {
+
 class distFcnElement2d {
  public:
   // Constructor
@@ -105,5 +107,7 @@ class SplineDistFcnElement2d: public distFcnElement2d {
   std::vector<amrex::Real> Dx;
   std::vector<amrex::Real> Dy;
 };
+
+}
 
 #endif

--- a/Src/EB/AMReX_distFcnElement.H
+++ b/Src/EB/AMReX_distFcnElement.H
@@ -1,0 +1,109 @@
+#ifndef AMREX_DISTFCNELEMENT_H_
+#define AMREX_DISTFCNELEMENT_H_
+
+#include <vector>
+#include "AMReX_RealVect.H"
+#include "AMReX.H"
+#include "AMReX_Vector.H"
+
+class distFcnElement2d {
+ public:
+  // Constructor
+  distFcnElement2d() {}
+  ~distFcnElement2d() {}
+
+  virtual distFcnElement2d* newDistFcnElement2d() const;
+
+  virtual  amrex::Real cpdist(amrex::RealVect pt, amrex::RealVect& cp) const;
+  virtual  amrex::Real cpside(amrex::RealVect pt, amrex::RealVect& cp) const;
+  int solve_thomas(std::vector<amrex::Real> diagminus,
+                   std::vector<amrex::Real> diag,
+                   std::vector<amrex::Real> diagplus,
+                   std::vector<amrex::Real> rhs,
+                   std::vector<amrex::Real> X);
+};
+
+
+class LineDistFcnElement2d: public distFcnElement2d {
+ public:
+  LineDistFcnElement2d() {}
+  ~LineDistFcnElement2d() {}
+
+  virtual distFcnElement2d* newDistFcnElement2d() const;
+
+  void set_control_points(std::vector<amrex::RealVect>  pts);
+
+  virtual  amrex::Real cpdist(amrex::RealVect pt, amrex::RealVect& cp) const;
+  virtual  amrex::Real cpside(amrex::RealVect pt, amrex::RealVect& cp) const;
+
+  void print_control_points();
+
+ protected:
+  void single_seg_cpdist(amrex::RealVect pt,
+                         amrex::Real x0, amrex::Real x1,
+                         amrex::Real y0, amrex::Real y1,
+                         amrex::RealVect& cp,
+                         amrex::Real& dist) const;
+
+ private:
+  std::vector<amrex::Real> control_points_x;
+  std::vector<amrex::Real> control_points_y;
+
+
+};
+
+
+class SplineDistFcnElement2d: public distFcnElement2d {
+ public:
+  SplineDistFcnElement2d() {}
+  ~SplineDistFcnElement2d() {}
+
+  virtual distFcnElement2d* newDistFcnElement2d() const;
+
+
+  void set_control_points(std::vector<amrex::RealVect>  pts);
+  void set_bc_points(amrex::RealVect start, amrex::RealVect end);
+
+  void print_control_points() const;
+  void print_spline() const;
+
+  void calc_D(bool clamped_bc = true);
+
+  virtual  amrex::Real cpdist(amrex::RealVect pt, amrex::RealVect& cp) const;
+  virtual  amrex::Real cpside(amrex::RealVect pt, amrex::RealVect& cp) const;
+
+ protected:
+  amrex::Real eval(amrex::Real t, amrex::Real y0, amrex::Real y1,
+                   amrex::Real D0, amrex::Real D1) const;
+  void  dxbydt(amrex::Real t, amrex::Real y0, amrex::Real y1,
+               amrex::Real D0, amrex::Real D1, amrex::Real& dyf,
+               amrex::Real& d2yf) const;
+
+  void single_spline_cpdist(amrex::RealVect pt,
+                            amrex::Real x0, amrex::Real x1,
+                            amrex::Real Dx0, amrex::Real Dx1,
+                            amrex::Real y0, amrex::Real y1,
+                            amrex::Real Dy0, amrex::Real Dy1,
+                            amrex::Real& t, amrex::RealVect& cp,
+                            amrex::Real& dist) const;
+
+  amrex::Real dist(amrex::RealVect pt,
+                   amrex::Real x0, amrex::Real x1,
+                   amrex::Real Dx0, amrex::Real Dx1,
+                   amrex::Real y0, amrex::Real y1,
+                   amrex::Real Dy0, amrex::Real Dy1,
+                   amrex::Real& t,
+                   amrex::RealVect& spt) const;
+
+ private:
+  std::vector<amrex::Real> control_points_x;
+  std::vector<amrex::Real> control_points_y;
+
+  amrex::RealVect bc_pt_start;
+  amrex::RealVect bc_pt_end;
+
+  std::vector<amrex::Real> Dx;
+  std::vector<amrex::Real> Dy;
+};
+
+#endif

--- a/Src/EB/AMReX_distFcnElement.cpp
+++ b/Src/EB/AMReX_distFcnElement.cpp
@@ -1,0 +1,471 @@
+#include "AMReX_distFcnElement.H"
+
+/* ---------------------------------------------------------------------------*/
+/* Implementation for Distance Function 2D Base Class */
+/* ---------------------------------------------------------------------------*/
+
+amrex::Real distFcnElement2d::cpdist(amrex::RealVect pt,
+                                     amrex::RealVect & cpmin) const {
+  amrex::Abort("cp dist must be implemented by the derived class");
+}
+
+
+amrex::Real distFcnElement2d::cpside(amrex::RealVect pt,
+                                     amrex::RealVect & cpmin) const {
+  amrex::Abort("cp side must be implemented by the derived class");
+}
+
+distFcnElement2d* distFcnElement2d::newDistFcnElement2d() const {
+  amrex::Abort("new distfcn must be implemented by the derived class");
+}
+
+
+int distFcnElement2d::solve_thomas(std::vector<amrex::Real> ain,
+                                   std::vector<amrex::Real> bin,
+                                   std::vector<amrex::Real> cin,
+                                   std::vector<amrex::Real> din,
+                                   std::vector<amrex::Real> x) {
+  std::vector<amrex::Real> a, b, c, d;
+  a = ain;  // off diagonal on low side
+  b = bin;  // diagonal
+  c = cin;  // off diagonal on high side
+  d = din;  // rhs
+
+  unsigned n;
+  n = d.size();
+  x.resize(n);
+
+  amrex::Real m;
+  for (unsigned i=1; i < n; ++i) {
+    m = a[i-1]/b[i-1];
+    b[i] -= m*c[i-1];
+    d[i] -= m*d[i-1];
+  }
+  x = b;
+  x[n-1] = d[n-1] / b[n-1];
+
+
+  for (unsigned i=n-2; i > 0; --i) {
+    x[i] = (d[i]-c[i]*x[i+1])/b[i];
+  }
+  return 0;
+}
+
+
+/* ---------------------------------------------------------------------------*/
+/* Implementation for Splines */
+/* ---------------------------------------------------------------------------*/
+
+distFcnElement2d* SplineDistFcnElement2d::newDistFcnElement2d() const {
+  SplineDistFcnElement2d* newSpline = new SplineDistFcnElement2d();
+  newSpline->control_points_x = control_points_x;
+  newSpline->control_points_y = control_points_y;
+  newSpline->bc_pt_start = bc_pt_start;
+  newSpline->bc_pt_end = bc_pt_end;
+  newSpline->Dx = Dx;
+  newSpline->Dy = Dy;
+  return static_cast<distFcnElement2d*>(newSpline);
+}
+
+amrex::Real SplineDistFcnElement2d::eval(amrex::Real t,
+                                         amrex::Real y0, amrex::Real y1,
+                                         amrex::Real D0, amrex::Real D1) const {
+  amrex::Real c, d;
+
+  c = 3.0*(y1 - y0) - 2.0*D0 - D1;
+  d = 2.0*(y0-y1) + D0 + D1;
+  return y0 + D0*t + c*t*t + d*t*t*t;
+}
+
+amrex::Real SplineDistFcnElement2d::dist(amrex::RealVect pt,
+                           amrex::Real x0, amrex::Real x1,
+                           amrex::Real Dx0, amrex::Real Dx1,
+                           amrex::Real y0, amrex::Real y1,
+                           amrex::Real Dy0, amrex::Real Dy1,
+                           amrex::Real& t,
+                           amrex::RealVect& spt) const {
+  amrex::RealVect delta;
+  spt[0] = eval(t, x0, x1, Dx0, Dx1);
+  spt[1] = eval(t, y0, y1, Dy0, Dy1);
+
+  delta = spt - pt;
+
+  amrex::Real dist;
+  dist = sqrt(delta[0]*delta[0] + delta[1]*delta[1]);
+
+  return dist;
+}
+
+
+amrex::Real SplineDistFcnElement2d::cpdist(amrex::RealVect pt,
+                                           amrex::RealVect & cpmin) const {
+  amrex::Real dmin = 1.0e29;
+  amrex::Real t;
+  amrex::RealVect cp;
+  amrex::Real dist;
+  int nsplines = Dx.size() - 1;
+  for (int i=0; i<nsplines; ++i) {
+    single_spline_cpdist(pt, control_points_x[i], control_points_x[i+1],
+                         Dx[i], Dx[i+1],
+                         control_points_y[i], control_points_y[i+1],
+                         Dy[i], Dy[i+1],
+                         t, cp, dist);
+    if (dist < dmin) {
+      dmin = dist;
+      cpmin = cp;
+    }
+  }
+  return dmin;
+}
+
+
+amrex::Real SplineDistFcnElement2d::cpside(amrex::RealVect pt,
+                                           amrex::RealVect & cpmin)
+                                           const {
+  amrex::Real dmin = 1.0e29;
+  amrex::Real t;
+  amrex::RealVect cp;
+  amrex::Real dist;
+  amrex::Real x0, x1, y0, y1, Dx0, Dx1, Dy0, Dy1, tmin;
+  int nsplines = Dx.size() - 1;
+  for (int i=0; i<nsplines; ++i) {
+    single_spline_cpdist(pt, control_points_x[i], control_points_x[i+1],
+                         Dx[i], Dx[i+1],
+                         control_points_y[i], control_points_y[i+1],
+                         Dy[i], Dy[i+1],
+                         t, cp, dist);
+    if (dist < dmin) {
+      dmin = dist;
+      cpmin = cp;
+      tmin = t;
+      x0 = control_points_x[i];
+      x1 = control_points_x[i+1];
+      y0 = control_points_y[i];
+      y1 = control_points_y[i+1];
+      Dx0 = Dx[i];
+      Dx1 = Dx[i+1];
+      Dy0 = Dy[i];
+      Dy1 = Dy[i+1];
+    }
+  }
+
+  // Now that we've found the closest spline, find which side
+  // it is on
+  amrex::RealVect A = pt - cpmin;
+  amrex::RealVect B;
+  amrex::Real dx, dx2, dy, dy2;
+
+  amrex::Real tangentDist = 0.001;
+  if (dmin < tangentDist) {
+    // by the cross product
+    // with tangent and vector to point
+    dxbydt(tmin, x0, x1, Dx0, Dx1, dx, dx2);
+    dxbydt(tmin, y0, y1, Dy0, Dy1, dy, dy2);
+    B[0] = dx;
+    B[1] = dy;
+  } else {
+    // If 'far', by cross product with line between control points
+    B[0] = x1-x0;
+    B[1] = y1-y0;
+  }
+
+  amrex::Real AcrossB = A[0]*B[1] - A[1]*B[0];
+
+  amrex::Real side;
+  if (AcrossB < 0) {
+    side = 1.0;
+  } else if (AcrossB > 0) {
+    side = -1.0;
+  } else {
+   side = 0.0;
+  }
+  return side;
+}
+
+
+void SplineDistFcnElement2d::single_spline_cpdist(amrex::RealVect pt,
+                                    amrex::Real x0, amrex::Real x1,
+                                    amrex::Real Dx0, amrex::Real Dx1,
+                                    amrex::Real y0, amrex::Real y1,
+                                    amrex::Real Dy0, amrex::Real Dy1,
+                                    amrex::Real& t, amrex::RealVect& mincp,
+                                    amrex::Real& mindist) const {
+  t = 0.5;
+
+  amrex::RealVect spt, deltapt;
+  const int maxIters = 1;
+
+  amrex::Real dxf, d2xf, dyf, d2yf, tnew;
+
+  for (int i=0; i<maxIters; ++i) {
+    mindist = dist(pt, x0, x1, Dx0, Dx1, y0, y1, Dy0, Dy1, t, spt);
+    dxbydt(t, y0, y1, Dy0, Dy1, dyf, d2yf);
+    dxbydt(t, x0, x1, Dx0, Dx1, dxf, d2xf);
+
+    deltapt =  spt - pt;
+    tnew = t - (deltapt[0]*dxf + deltapt[1]*dyf) / (
+      dxf*dxf + dyf*dyf + deltapt[0]*d2xf + deltapt[1]*d2yf);
+
+    if (tnew < 0.0) {
+      tnew = 0.0;
+    } else if (tnew > 1.0) {
+      tnew = 1.0;
+    }
+    t = tnew;
+  }
+  mindist = dist(pt, x0, x1, Dx0, Dx1, y0, y1, Dy0, Dy1, tnew, spt);
+  mincp = spt;
+
+  if (mindist == 0.0) {
+    std::cout << "identified minimum distance of 0.0 at t = " << t
+              << "; cp = " << mincp << " for p = " << pt << std::endl;
+  }
+  return;
+}
+
+
+void SplineDistFcnElement2d::dxbydt(amrex::Real t,
+                                    amrex::Real y0, amrex::Real y1,
+                                    amrex::Real D0, amrex::Real D1,
+                                    amrex::Real& dyf, amrex::Real& d2yf)
+                                    const {
+  amrex::Real c, d;
+  c = 3.0*(y1 - y0) - 2.0*D0 - D1;
+  d = 2.0*(y0-y1) + D0 + D1;
+
+  dyf = D0 + 2.0*c*t + 3.0*d*t*t;
+  d2yf = 2.0*c + 6.0*d*t;
+  return;
+}
+
+
+void SplineDistFcnElement2d::calc_D(bool clamped_bc) {
+  unsigned nsplines = control_points_x.size() - 1;
+
+  std::vector<amrex::Real> rhsx, rhsy, diag, diagminus, diagplus;
+  rhsx.resize(nsplines+1);
+  rhsy.resize(nsplines+1);
+  diag.resize(nsplines+1);
+  diagminus.resize(nsplines);
+  diagplus.resize(nsplines);
+
+  Dx.resize(nsplines+1);
+  Dy.resize(nsplines+1);
+
+  for (int i=0; i<nsplines-1; ++i) {
+    diag[i] = 4.0;
+    diagminus[i] = 1.0;
+    diagplus[i] = 1.0;
+  }
+  diag[nsplines-1] = 4.0;
+
+
+
+  for (int i=1; i<nsplines; ++i) {
+    rhsx[i] = control_points_x[i+1] - control_points_x[i-1];
+    rhsy[i] = control_points_y[i+1] - control_points_y[i-1];
+  }
+
+  if (clamped_bc) {
+    diag[0] = 1.0;
+    diagplus[0] = 0.0;
+
+    diag[nsplines] = 1.0;
+    diagminus[nsplines-1] = 0.0;
+
+    rhsx[0] = control_points_x[0] - bc_pt_start[0];
+    rhsx[nsplines] = -control_points_x[nsplines-1] + bc_pt_end[0];
+
+    rhsy[0] = control_points_y[0] - bc_pt_start[1];
+    rhsy[nsplines] = -control_points_y[nsplines-1] + bc_pt_end[1];
+
+  } else {
+    // Natural boundary conditions
+    diag[0] = 2.0;
+    diag[nsplines] = 2.0;
+
+    rhsx[0] = 3.0*(control_points_x[1]-control_points_x[0]);
+    rhsx[nsplines] = 3.0 * (control_points_x[nsplines] -
+                            control_points_x[nsplines-1]);
+
+    rhsy[0] = 3.0*(control_points_y[1]-control_points_y[0]);
+    rhsy[nsplines] = 3.0 * (control_points_y[nsplines] -
+                            control_points_y[nsplines-1]);
+  }
+
+  solve_thomas(diagminus, diag, diagplus, rhsx, Dx);
+  solve_thomas(diagminus, diag, diagplus, rhsy, Dy);
+}
+
+
+
+void SplineDistFcnElement2d::set_control_points
+(std::vector<amrex::RealVect> pts) {
+  for (auto & pt : pts) {
+    control_points_x.push_back(pt[0]);
+    control_points_y.push_back(pt[1]);
+    //  std::cout << "Added point (" << pt[0] << "," << pt[1] << ")" << std::endl;
+  }
+}
+
+
+void SplineDistFcnElement2d::set_bc_points(amrex::RealVect start,
+                                           amrex::RealVect end) {
+  bc_pt_start = start;
+  bc_pt_end = end;
+}
+
+
+void SplineDistFcnElement2d::print_control_points() const {
+  for (unsigned i=0; i<control_points_x.size(); ++i) {
+    std::cout << "(" << control_points_x[i] << ","
+              << control_points_y[i] << ")" << std::endl;
+  }
+
+  std::cout << "(" << bc_pt_start[0] << ","
+            << bc_pt_start[1] << ")" << std::endl;
+  std::cout << "(" << bc_pt_end[0] << "," << bc_pt_end[1] << ")" << std::endl;
+}
+
+
+void SplineDistFcnElement2d::print_spline() const {
+  int nsplines = Dx.size();
+
+  amrex::Real dt = 0.01;
+  int nt = 1.0/dt;
+  for (int i=0; i<nsplines-1; i++) {
+    for (int j=0; j<nt; j++) {
+      amrex::Real x = eval(j*dt, control_points_x[i],
+                           control_points_x[i+1], Dx[i], Dx[i+1]);
+      amrex::Real y = eval(j*dt, control_points_y[i],
+                           control_points_y[i+1], Dy[i], Dy[i+1]);
+
+      std::cout << x << "  " <<  y << std::endl;
+    }
+  }
+}
+
+
+/* ---------------------------------------------------------------------------*/
+/* Implementation for Lines */
+/* ---------------------------------------------------------------------------*/
+amrex::Real LineDistFcnElement2d::cpdist(amrex::RealVect pt,
+                                         amrex::RealVect & cpmin) const {
+
+  amrex::Real mindist, dist;
+  mindist = 1.0e29;
+  amrex::RealVect cp;
+
+  for (int i=1; i<control_points_x.size(); ++i) {
+    single_seg_cpdist(pt,
+                      control_points_x[i-1], control_points_x[i],
+                      control_points_y[i-1], control_points_y[i],
+                      cp, dist);
+    if (dist < mindist) {
+      mindist = dist;
+      cpmin = cp;
+    }
+  }
+  return mindist;
+
+}
+amrex::Real LineDistFcnElement2d::cpside(amrex::RealVect pt,
+                                         amrex::RealVect & cpmin) const {
+
+  amrex::Real mindist, dist;
+  mindist = 1.0e29;
+  amrex::RealVect cp;
+  amrex::RealVect l0, l1;
+
+  for (int i=1; i<control_points_x.size(); ++i) {
+    single_seg_cpdist(pt,
+                      control_points_x[i-1], control_points_x[i],
+                      control_points_y[i-1], control_points_y[i],
+                      cp, dist);
+    if (dist < mindist) {
+      mindist = dist;
+      cpmin = cp;
+      l0 = amrex::RealVect(D_DECL(control_points_x[i-1], control_points_y[i-1],0.0));
+      l1 = amrex::RealVect(D_DECL(control_points_x[i], control_points_y[i],0.0));
+    }
+  }
+
+  //amrex::RealVect B = l1 - cpmin;
+  amrex::RealVect B = l1 - l0;
+  amrex::RealVect A = pt - cpmin;
+  amrex::Real AcrossB = A[0]*B[1] - A[1]*B[0];
+
+  if (AcrossB < 0.0) {
+    return 1.0;
+  } else if (AcrossB > 0.0) {
+    return -1.0;
+  } else {
+    return 0.0;
+    /*
+    // AcrossB is zero, try extending line segment
+    if (B[0]*B[0] + B[1]*B[1] != 0.0) {
+      amrex::RealVect cext = amrex::RealVect(l1 - l0)*1.05 + l0;
+      B = cext - cpmin;
+      AcrossB = A[0]*B[1] - A[1]*B[0];
+      if (AcrossB < 0.0) {
+        return 1.0;
+      } else if (AcrossB > 0.0) {
+        return -1.0;
+      }
+    } else {
+        // Point must be on the line, put it inside
+        return 0.0;
+    }
+    */
+  }
+  amrex::Abort("Should not get here");
+}
+
+void LineDistFcnElement2d::set_control_points
+(std::vector<amrex::RealVect> pts) {
+  for (auto & pt : pts) {
+    control_points_x.push_back(pt[0]);
+    control_points_y.push_back(pt[1]);
+    //  std::cout << "Added point (" << pt[0] << "," << pt[1] << ")" << std::endl;
+  }
+}
+
+void LineDistFcnElement2d::single_seg_cpdist(amrex::RealVect pt,
+                                             amrex::Real x0, amrex::Real x1,
+                                             amrex::Real y0, amrex::Real y1,
+                                             amrex::RealVect& cp,
+                                             amrex::Real& dist) const {
+  amrex::RealVect A(D_DECL(pt[0]-x0, pt[1]-y0,0.0));
+  amrex::RealVect B(D_DECL(x1-x0, y1-y0,0.0));
+
+  amrex::Real magBsq = B[0]*B[0] + B[1]*B[1];
+  amrex::Real t =  (A[0]*B[0] + A[1]*B[1])/magBsq;
+
+  if (t < 0) {
+    cp = amrex::RealVect(D_DECL(x0,y0,0.0));
+  } else if (t > 1.0) {
+    cp = amrex::RealVect(D_DECL(x1,y1,0.0));
+  } else {
+    cp  = amrex::RealVect(D_DECL(x0,y0,0.0)) + t*B;
+  }
+
+  amrex::RealVect delta = pt - cp;
+  dist = sqrt(delta[0]*delta[0] + delta[1]*delta[1] );
+
+  return;
+}
+
+  void LineDistFcnElement2d::print_control_points() {
+
+  for (int i=1; i<control_points_x.size(); ++i) {
+  std::cout << "(" << control_points_x[i-1] << ", "<< control_points_y[i-1] << ")" << "---"
+            << "(" << control_points_x[i] << ", " << control_points_y[i] << ")" << std::endl;
+}
+}
+
+distFcnElement2d* LineDistFcnElement2d::newDistFcnElement2d() const {
+  LineDistFcnElement2d* newLine = new LineDistFcnElement2d();
+  newLine->control_points_x = control_points_x;
+  newLine->control_points_y = control_points_y;
+  return static_cast<distFcnElement2d*>(newLine);
+}

--- a/Src/EB/AMReX_distFcnElement.cpp
+++ b/Src/EB/AMReX_distFcnElement.cpp
@@ -4,6 +4,8 @@
 /* Implementation for Distance Function 2D Base Class */
 /* ---------------------------------------------------------------------------*/
 
+namespace amrex {
+
 amrex::Real distFcnElement2d::cpdist(amrex::RealVect pt,
                                      amrex::RealVect & cpmin) const {
   amrex::Abort("cp dist must be implemented by the derived class");
@@ -51,10 +53,14 @@ int distFcnElement2d::solve_thomas(std::vector<amrex::Real> ain,
   return 0;
 }
 
+}
+
 
 /* ---------------------------------------------------------------------------*/
 /* Implementation for Splines */
 /* ---------------------------------------------------------------------------*/
+
+namespace amrex {
 
 distFcnElement2d* SplineDistFcnElement2d::newDistFcnElement2d() const {
   SplineDistFcnElement2d* newSpline = new SplineDistFcnElement2d();
@@ -468,4 +474,6 @@ distFcnElement2d* LineDistFcnElement2d::newDistFcnElement2d() const {
   newLine->control_points_x = control_points_x;
   newLine->control_points_y = control_points_y;
   return static_cast<distFcnElement2d*>(newLine);
+}
+
 }

--- a/Src/EB/CMakeLists.txt
+++ b/Src/EB/CMakeLists.txt
@@ -34,6 +34,8 @@ add_sources ( AMReX_EB2_MultiGFab.H   AMReX_EB2_IF_AllRegular.H AMReX_EB2_IF_Int
 add_sources ( AMReX_EB2_IF_Translation.H AMReX_EB2_IF_Rotation.H AMReX_EB2_IF_Polynomial.H)
 add_sources ( AMReX_EB2_IF_Extrusion.H AMReX_EB2_IF_Difference.H )
 add_sources ( AMReX_EB2_IF.H )
+add_sources ( AMReX_distFcnElement.H )
+add_sources ( AMReX_distFcnElement.cpp )
 
 add_sources( AMReX_EB2.cpp  AMReX_EB2_Level.cpp  AMReX_EB2_MultiGFab.cpp )
 

--- a/Src/EB/Make.package
+++ b/Src/EB/Make.package
@@ -60,9 +60,9 @@ CEXE_headers += AMReX_EB2_IF_Ellipsoid.H
 CEXE_headers += AMReX_EB2_IF_Plane.H
 CEXE_headers += AMReX_EB2_IF_Sphere.H
 CEXE_headers += AMReX_EB2_IF_Torus.H
+CEXE_headers += AMReX_distFcnElement.H
+CEXE_headers += AMReX_EB2_IF_Spline.H
 CEXE_headers += AMReX_EB2_IF_Polynomial.H
-
-
 CEXE_headers += AMReX_EB2_IF_Complement.H
 CEXE_headers += AMReX_EB2_IF_Intersection.H
 CEXE_headers += AMReX_EB2_IF_Lathe.H
@@ -74,6 +74,8 @@ CEXE_headers += AMReX_EB2_IF_Extrusion.H
 CEXE_headers += AMReX_EB2_IF_Difference.H
 CEXE_headers += AMReX_EB2_IF.H
 
+CEXE_sources += AMReX_distFcnElement.cpp
+
 
 CEXE_headers += AMReX_EB2_GeometryShop.H AMReX_EB2.H AMReX_EB2_IndexSpaceI.H AMReX_EB2_Level.H
 CEXE_headers += AMReX_EB2_Graph.H AMReX_EB2_MultiGFab.H
@@ -82,7 +84,6 @@ CEXE_sources += AMReX_EB2.cpp AMReX_EB2_Level.cpp AMReX_EB2_MultiGFab.cpp
 
 CEXE_headers += AMReX_EB2_F.H
 F90EXE_sources += AMReX_eb2_$(DIM)d.F90
-
 
 VPATH_LOCATIONS += $(AMREX_HOME)/Src/EB
 INCLUDE_LOCATIONS += $(AMREX_HOME)/Src/EB

--- a/Tutorials/EB/GeometryGeneration/main.cpp
+++ b/Tutorials/EB/GeometryGeneration/main.cpp
@@ -8,111 +8,124 @@ using namespace amrex;
 
 int main (int argc, char* argv[])
 {
-  amrex::Initialize(argc, argv);
-
-  {
-    int n_cell = 128;
-    int max_grid_size = 32;
-
-    // read parameters
-    {
-      ParmParse pp;
-      pp.query("n_cell", n_cell);
-      pp.query("max_grid_size", max_grid_size);
-    }
-
-    Geometry geom;
-    {
-      RealBox rb({-5.2,-5.2,-1.0}, {5.2,5.2,2.0}); // physical domain
-      Array<int,AMREX_SPACEDIM> is_periodic{false, false, false};
-      Geometry::Setup(&rb, 0, is_periodic.data());
-      Box domain(IntVect(0), IntVect(n_cell-1));
-      geom.define(domain);            
-    }
+    amrex::Initialize(argc, argv);
 
     {
-      std::vector<amrex::RealVect> splpts;
-      amrex::RealVect p;
-      p = amrex::RealVect(D_DECL(36.193*0.1, 7.8583*0.1, 0.0));
-      splpts.push_back(p);
-      p = amrex::RealVect(D_DECL(35.924*0.1, 7.7881*0.1, 0.0));
-      splpts.push_back(p);
-      p = amrex::RealVect(D_DECL(35.713*0.1, 7.5773*0.1, 0.0));
-      splpts.push_back(p);
-      p = amrex::RealVect(D_DECL(35.643*0.1, 7.3083*0.1, 0.0));
-      splpts.push_back(p);
-      p = amrex::RealVect(D_DECL(35.3*0.1, 7.0281*0.1, 0.0));
-      splpts.push_back(p);
-      p = amrex::RealVect(D_DECL(35.421*0.1, 6.241*0.1, 0.0));
-      splpts.push_back(p);
-      p = amrex::RealVect(D_DECL(34.82*0.1, 5.686*0.1, 0.0));
-      splpts.push_back(p);
-      p = amrex::RealVect(D_DECL(30.539*0.1, 3.5043*0.1, 0.0));
-      splpts.push_back(p);
-      p = amrex::RealVect(D_DECL(29.677*0.1, 2.6577*0.1, 0.0));
-      splpts.push_back(p);
-      p = amrex::RealVect(D_DECL(29.457*0.1, 1.47*0.1, 0.0));
-      splpts.push_back(p);
-      // p = amrex::RealVect(D_DECL(29.38*0.1, -1.1038*0.1, 0.0));
-      // splpts.push_back(p);
-      // p = amrex::RealVect(D_DECL(29.3*0.1, -2.7262*0.1, 0.0));
-      // splpts.push_back(p);
-      // p = amrex::RealVect(D_DECL(29.273*0.1, -4.3428*0.1, 0.0));
-      // splpts.push_back(p);
-      p = amrex::RealVect(D_DECL(28.364*0.1, -5.7632*0.1, 0.0));
-      splpts.push_back(p);
-      p = amrex::RealVect(D_DECL(27.151*0.1, -6.8407*0.1, 0.0));
-      splpts.push_back(p);
-      p = amrex::RealVect(D_DECL(25.694*0.1, -7.5555*0.1, 0.0));
-      splpts.push_back(p);
-      p = amrex::RealVect(D_DECL(24.035*0.1, -7.8586*0.1, 0.0));
-      splpts.push_back(p);
-      p = amrex::RealVect(D_DECL(22.358*0.1, -7.6902*0.1, 0.0));
-      splpts.push_back(p);
-      EB2::SplineIF Piston;
-      Piston.addSplineElement(splpts);
-      std::vector<amrex::RealVect> lnpts;
+        int n_cell = 128;
+        int max_grid_size = 32;
+        int which_geom = 0;
 
-      p = amrex::RealVect(D_DECL(22.358*0.1, -7.6902*0.1, 0.0));
-      lnpts.push_back(p);
-      p = amrex::RealVect(D_DECL(1.9934*0.1, 3.464*0.1, 0.0));
-      lnpts.push_back(p);
-      p = amrex::RealVect(D_DECL(0.0, 3.464*0.1, 0.0));
-      lnpts.push_back(p);
-      Piston.addLineElement(lnpts);
-      lnpts.clear();
+        // read parameters
+        {
+            ParmParse pp;
+            pp.query("n_cell", n_cell);
+            pp.query("max_grid_size", max_grid_size);
+            pp.query("which_geom", which_geom);
+        }
 
-      p = amrex::RealVect(D_DECL(49.0*0.1, 7.8583*0.1,  0.0));
-      lnpts.push_back(p);
-      p = amrex::RealVect(D_DECL(36.193*0.1, 7.8583*0.1, 0.0));
-      lnpts.push_back(p);
-      Piston.addLineElement(lnpts);
-      lnpts.clear();
+        Geometry geom;
+        {
+            RealBox rb({-0.5,-0.5,-0.5}, {0.5,0.5,0.5}); // physical domain
+            Array<int,AMREX_SPACEDIM> is_periodic{false, false, false};
+            Geometry::Setup(&rb, 0, is_periodic.data());
+            Box domain(IntVect(0), IntVect(n_cell-1));
+            geom.define(domain);            
+        }
 
-      EB2::CylinderIF cylinder(4.80, 7.0, 2, {0.0, 0.0, -1.0}, false);
+        if (which_geom == 0) {
+            EB2::SphereIF sphere(0.5, {0.0,0.0,0.0}, false);
+            EB2::BoxIF cube({-0.4,-0.4,-0.4}, {0.4,0.4,0.4}, false);
+            auto cubesphere = EB2::makeIntersection(sphere, cube);
+            
+            EB2::CylinderIF cylinder_x(0.25, 0, {0.0,0.0,0.0}, false);
+            EB2::CylinderIF cylinder_y(0.25, 1, {0.0,0.0,0.0}, false);
+            EB2::CylinderIF cylinder_z(0.25, 2, {0.0,0.0,0.0}, false);
+            auto three_cylinders = EB2::makeUnion(cylinder_x, cylinder_y, cylinder_z);
 
-      auto revolvePiston  = EB2::lathe(Piston);
-      auto PistonComplement = EB2::makeComplement(revolvePiston);
-      auto PistonCylinder = EB2::makeIntersection(PistonComplement, cylinder);
-      auto gshop = EB2::makeShop(PistonCylinder);
-      EB2::Build(gshop, geom, 0, 0);
+            auto csg = EB2::makeDifference(cubesphere, three_cylinders);
+
+            auto gshop = EB2::makeShop(csg);
+            EB2::Build(gshop, geom, 0, 0);
+        } else if (which_geom == 1) {
+          // This geometry uses splines to put an interesting 'piston bowl' shape at the
+          // bottom of the cylinder
+          std::vector<amrex::RealVect> splpts;
+          amrex::RealVect p;
+          p = amrex::RealVect(D_DECL(36.193*0.1, 7.8583*0.1, 0.0));
+          splpts.push_back(p);
+          p = amrex::RealVect(D_DECL(35.924*0.1, 7.7881*0.1, 0.0));
+          splpts.push_back(p);
+          p = amrex::RealVect(D_DECL(35.713*0.1, 7.5773*0.1, 0.0));
+          splpts.push_back(p);
+          p = amrex::RealVect(D_DECL(35.643*0.1, 7.3083*0.1, 0.0));
+          splpts.push_back(p);
+          p = amrex::RealVect(D_DECL(35.3*0.1, 7.0281*0.1, 0.0));
+          splpts.push_back(p);
+          p = amrex::RealVect(D_DECL(35.421*0.1, 6.241*0.1, 0.0));
+          splpts.push_back(p);
+          p = amrex::RealVect(D_DECL(34.82*0.1, 5.686*0.1, 0.0));
+          splpts.push_back(p);
+          p = amrex::RealVect(D_DECL(30.539*0.1, 3.5043*0.1, 0.0));
+          splpts.push_back(p);
+          p = amrex::RealVect(D_DECL(29.677*0.1, 2.6577*0.1, 0.0));
+          splpts.push_back(p);
+          p = amrex::RealVect(D_DECL(29.457*0.1, 1.47*0.1, 0.0));
+          splpts.push_back(p);
+          p = amrex::RealVect(D_DECL(28.364*0.1, -5.7632*0.1, 0.0));
+          splpts.push_back(p);
+          p = amrex::RealVect(D_DECL(27.151*0.1, -6.8407*0.1, 0.0));
+          splpts.push_back(p);
+          p = amrex::RealVect(D_DECL(25.694*0.1, -7.5555*0.1, 0.0));
+          splpts.push_back(p);
+          p = amrex::RealVect(D_DECL(24.035*0.1, -7.8586*0.1, 0.0));
+          splpts.push_back(p);
+          p = amrex::RealVect(D_DECL(22.358*0.1, -7.6902*0.1, 0.0));
+          splpts.push_back(p);
+          EB2::SplineIF Piston;
+          Piston.addSplineElement(splpts);
+          std::vector<amrex::RealVect> lnpts;
+
+          p = amrex::RealVect(D_DECL(22.358*0.1, -7.6902*0.1, 0.0));
+          lnpts.push_back(p);
+          p = amrex::RealVect(D_DECL(1.9934*0.1, 3.464*0.1, 0.0));
+          lnpts.push_back(p);
+          p = amrex::RealVect(D_DECL(0.0, 3.464*0.1, 0.0));
+          lnpts.push_back(p);
+          Piston.addLineElement(lnpts);
+          lnpts.clear();
+
+          p = amrex::RealVect(D_DECL(49.0*0.1, 7.8583*0.1,  0.0));
+          lnpts.push_back(p);
+          p = amrex::RealVect(D_DECL(36.193*0.1, 7.8583*0.1, 0.0));
+          lnpts.push_back(p);
+          Piston.addLineElement(lnpts);
+          lnpts.clear();
+
+          EB2::CylinderIF cylinder(4.80, 7.0, 2, {0.0, 0.0, -1.0}, false);
+
+          auto revolvePiston  = EB2::lathe(Piston);
+          auto PistonComplement = EB2::makeComplement(revolvePiston);
+          auto PistonCylinder = EB2::makeIntersection(PistonComplement, cylinder);
+          auto gshop = EB2::makeShop(PistonCylinder);
+          EB2::Build(gshop, geom, 0, 0);
+
+        }
+
+        MultiFab mf;
+        {
+            BoxArray ba(geom.Domain());
+            ba.maxSize(max_grid_size);
+            DistributionMapping dm{ba};
+
+            std::unique_ptr<EBFArrayBoxFactory> factory
+                = amrex::makeEBFabFactory(geom, ba, dm, {2,2,2}, EBSupport::full);
+
+            mf.define(ba, dm, 1, 0, MFInfo(), *factory);
+            mf.setVal(1.0);
+        }
+
+        EB_WriteSingleLevelPlotfile("plt", mf, {"rho"}, geom, 0.0, 0);
     }
 
-    MultiFab mf;
-    {
-      BoxArray ba(geom.Domain());
-      ba.maxSize(max_grid_size);
-      DistributionMapping dm{ba};
-
-      std::unique_ptr<EBFArrayBoxFactory> factory
-          = amrex::makeEBFabFactory(geom, ba, dm, {2,2,2}, EBSupport::full);
-
-      mf.define(ba, dm, 1, 0, MFInfo(), *factory);
-      mf.setVal(1.0);
-    }
-
-    EB_WriteSingleLevelPlotfile("plt", mf, {"rho"}, geom, 0.0, 0);
-  }
-
-  amrex::Finalize();
+    amrex::Finalize();
 }

--- a/Tutorials/EB/GeometryGeneration/main.cpp
+++ b/Tutorials/EB/GeometryGeneration/main.cpp
@@ -8,59 +8,111 @@ using namespace amrex;
 
 int main (int argc, char* argv[])
 {
-    amrex::Initialize(argc, argv);
+  amrex::Initialize(argc, argv);
 
+  {
+    int n_cell = 128;
+    int max_grid_size = 32;
+
+    // read parameters
     {
-        int n_cell = 128;
-        int max_grid_size = 32;
-
-        // read parameters
-        {
-            ParmParse pp;
-            pp.query("n_cell", n_cell);
-            pp.query("max_grid_size", max_grid_size);
-        }
-
-        Geometry geom;
-        {
-            RealBox rb({-0.5,-0.5,-0.5}, {0.5,0.5,0.5}); // physical domain
-            Array<int,AMREX_SPACEDIM> is_periodic{false, false, false};
-            Geometry::Setup(&rb, 0, is_periodic.data());
-            Box domain(IntVect(0), IntVect(n_cell-1));
-            geom.define(domain);            
-        }
-
-        {
-            EB2::SphereIF sphere(0.5, {0.0,0.0,0.0}, false);
-            EB2::BoxIF cube({-0.4,-0.4,-0.4}, {0.4,0.4,0.4}, false);
-            auto cubesphere = EB2::makeIntersection(sphere, cube);
-            
-            EB2::CylinderIF cylinder_x(0.25, 0, {0.0,0.0,0.0}, false);
-            EB2::CylinderIF cylinder_y(0.25, 1, {0.0,0.0,0.0}, false);
-            EB2::CylinderIF cylinder_z(0.25, 2, {0.0,0.0,0.0}, false);
-            auto three_cylinders = EB2::makeUnion(cylinder_x, cylinder_y, cylinder_z);
-
-            auto csg = EB2::makeDifference(cubesphere, three_cylinders);
-
-            auto gshop = EB2::makeShop(csg);
-            EB2::Build(gshop, geom, 0, 0);
-        }
-
-        MultiFab mf;
-        {
-            BoxArray ba(geom.Domain());
-            ba.maxSize(max_grid_size);
-            DistributionMapping dm{ba};
-
-            std::unique_ptr<EBFArrayBoxFactory> factory
-                = amrex::makeEBFabFactory(geom, ba, dm, {2,2,2}, EBSupport::full);
-
-            mf.define(ba, dm, 1, 0, MFInfo(), *factory);
-            mf.setVal(1.0);
-        }
-
-        EB_WriteSingleLevelPlotfile("plt", mf, {"rho"}, geom, 0.0, 0);
+      ParmParse pp;
+      pp.query("n_cell", n_cell);
+      pp.query("max_grid_size", max_grid_size);
     }
 
-    amrex::Finalize();
+    Geometry geom;
+    {
+      RealBox rb({-5.2,-5.2,-1.0}, {5.2,5.2,2.0}); // physical domain
+      Array<int,AMREX_SPACEDIM> is_periodic{false, false, false};
+      Geometry::Setup(&rb, 0, is_periodic.data());
+      Box domain(IntVect(0), IntVect(n_cell-1));
+      geom.define(domain);            
+    }
+
+    {
+      std::vector<amrex::RealVect> splpts;
+      amrex::RealVect p;
+      p = amrex::RealVect(D_DECL(36.193*0.1, 7.8583*0.1, 0.0));
+      splpts.push_back(p);
+      p = amrex::RealVect(D_DECL(35.924*0.1, 7.7881*0.1, 0.0));
+      splpts.push_back(p);
+      p = amrex::RealVect(D_DECL(35.713*0.1, 7.5773*0.1, 0.0));
+      splpts.push_back(p);
+      p = amrex::RealVect(D_DECL(35.643*0.1, 7.3083*0.1, 0.0));
+      splpts.push_back(p);
+      p = amrex::RealVect(D_DECL(35.3*0.1, 7.0281*0.1, 0.0));
+      splpts.push_back(p);
+      p = amrex::RealVect(D_DECL(35.421*0.1, 6.241*0.1, 0.0));
+      splpts.push_back(p);
+      p = amrex::RealVect(D_DECL(34.82*0.1, 5.686*0.1, 0.0));
+      splpts.push_back(p);
+      p = amrex::RealVect(D_DECL(30.539*0.1, 3.5043*0.1, 0.0));
+      splpts.push_back(p);
+      p = amrex::RealVect(D_DECL(29.677*0.1, 2.6577*0.1, 0.0));
+      splpts.push_back(p);
+      p = amrex::RealVect(D_DECL(29.457*0.1, 1.47*0.1, 0.0));
+      splpts.push_back(p);
+      // p = amrex::RealVect(D_DECL(29.38*0.1, -1.1038*0.1, 0.0));
+      // splpts.push_back(p);
+      // p = amrex::RealVect(D_DECL(29.3*0.1, -2.7262*0.1, 0.0));
+      // splpts.push_back(p);
+      // p = amrex::RealVect(D_DECL(29.273*0.1, -4.3428*0.1, 0.0));
+      // splpts.push_back(p);
+      p = amrex::RealVect(D_DECL(28.364*0.1, -5.7632*0.1, 0.0));
+      splpts.push_back(p);
+      p = amrex::RealVect(D_DECL(27.151*0.1, -6.8407*0.1, 0.0));
+      splpts.push_back(p);
+      p = amrex::RealVect(D_DECL(25.694*0.1, -7.5555*0.1, 0.0));
+      splpts.push_back(p);
+      p = amrex::RealVect(D_DECL(24.035*0.1, -7.8586*0.1, 0.0));
+      splpts.push_back(p);
+      p = amrex::RealVect(D_DECL(22.358*0.1, -7.6902*0.1, 0.0));
+      splpts.push_back(p);
+      EB2::SplineIF Piston;
+      Piston.addSplineElement(splpts);
+      std::vector<amrex::RealVect> lnpts;
+
+      p = amrex::RealVect(D_DECL(22.358*0.1, -7.6902*0.1, 0.0));
+      lnpts.push_back(p);
+      p = amrex::RealVect(D_DECL(1.9934*0.1, 3.464*0.1, 0.0));
+      lnpts.push_back(p);
+      p = amrex::RealVect(D_DECL(0.0, 3.464*0.1, 0.0));
+      lnpts.push_back(p);
+      Piston.addLineElement(lnpts);
+      lnpts.clear();
+
+      p = amrex::RealVect(D_DECL(49.0*0.1, 7.8583*0.1,  0.0));
+      lnpts.push_back(p);
+      p = amrex::RealVect(D_DECL(36.193*0.1, 7.8583*0.1, 0.0));
+      lnpts.push_back(p);
+      Piston.addLineElement(lnpts);
+      lnpts.clear();
+
+      EB2::CylinderIF cylinder(4.80, 7.0, 2, {0.0, 0.0, -1.0}, false);
+
+      auto revolvePiston  = EB2::lathe(Piston);
+      auto PistonComplement = EB2::makeComplement(revolvePiston);
+      auto PistonCylinder = EB2::makeIntersection(PistonComplement, cylinder);
+      auto gshop = EB2::makeShop(PistonCylinder);
+      EB2::Build(gshop, geom, 0, 0);
+    }
+
+    MultiFab mf;
+    {
+      BoxArray ba(geom.Domain());
+      ba.maxSize(max_grid_size);
+      DistributionMapping dm{ba};
+
+      std::unique_ptr<EBFArrayBoxFactory> factory
+          = amrex::makeEBFabFactory(geom, ba, dm, {2,2,2}, EBSupport::full);
+
+      mf.define(ba, dm, 1, 0, MFInfo(), *factory);
+      mf.setVal(1.0);
+    }
+
+    EB_WriteSingleLevelPlotfile("plt", mf, {"rho"}, geom, 0.0, 0);
+  }
+
+  amrex::Finalize();
 }


### PR DESCRIPTION
Modified original pull request:

_Added this additional functionality of constructing an implicit function for EB, based on splines and line segments. User provides input in terms of a few control points on a spline which is then used to construct a surface separating the fluid and solid zones. First version of this code developed by Ray Grout for EB1 formulation, that code was adapted to EB2 in this current version._

To address review comments and fix conflicts.