### PR TITLE
Update makefiles for NREL machines

### DIFF
--- a/Tools/GNUMake/Make.machines
+++ b/Tools/GNUMake/Make.machines
@@ -91,19 +91,18 @@ ifeq ($(findstring asterix, $(host_name)), asterix)
   which_computer := asterix
 endif
 
-ifeq ($(findstring merlin, $(host_name)), merlin)
-  which_site := nrel
-  which_computer := merlin
-endif
-
 ifeq ($(findstring aurora, $(host_name)), aurora)
   which_site := hs
   which_computer := aurora
 endif
 
-ifeq ($(findstring nrel, $(host_name)), nrel)
+ifeq ($(findstring peregrine, $(NREL_CLUSTER)), peregrine)
   which_site := nrel
-  which_computer := anymachine
+  which_computer := peregrine
+endif
+ifeq ($(findstring eagle, $(NREL_CLUSTER)), eagle)
+  which_site := nrel
+  which_computer := eagle
 endif
 
 ifeq ($(findstring daint, $(host_name)), daint)

--- a/Tools/GNUMake/sites/Make.nrel
+++ b/Tools/GNUMake/sites/Make.nrel
@@ -1,19 +1,32 @@
-ifneq ($(which_computer),$(filter $(which_computer),merlin anymachine))
+ifneq ($(which_computer),$(filter $(which_computer),peregrine eagle))
   $(error Unknown NREL computer, $(which_computer))
 endif
 
-os_type := $(shell uname)
-
+ifeq ($(which_computer), peregrine)
 # Use automatic CPU dispatch for max 
 # vectorization with Intel compilers
 # since Peregrine has haswell and
-# ivybridge nodes. We're leaving out the
-# really old sandybridge nodes here.
-ifeq ($(COMP), intel)
-  CXXFLAGS += -axCORE-AVX2,CORE-AVX-I
-  CFLAGS   += -axCORE-AVX2,CORE-AVX-I
-  FFLAGS   += -axCORE-AVX2,CORE-AVX-I
-  F90FLAGS += -axCORE-AVX2,CORE-AVX-I
+# ivybridge nodes.
+  ifeq ($(COMP), intel)
+    CXXFLAGS += -axCORE-AVX2,CORE-AVX-I
+    CFLAGS   += -axCORE-AVX2,CORE-AVX-I
+    FFLAGS   += -axCORE-AVX2,CORE-AVX-I
+    F90FLAGS += -axCORE-AVX2,CORE-AVX-I
+  endif
+else ifeq ($(which_computer), eagle)
+# Eagle is homogeneous at the moment
+# so we can be very specific about arch
+  ifeq ($(COMP), intel)
+    CXXFLAGS += -xSKYLAKE-AVX512
+    CFLAGS   += -xSKYLAKE-AVX512
+    FFLAGS   += -xSKYLAKE-AVX512
+    F90FLAGS += -xSKYLAKE-AVX512
+  else ifeq ($(COMP), gnu)
+    CXXFLAGS += -march=skylake-avx512 -mtune=skylake-avx512
+    CFLAGS   += -march=skylake-avx512 -mtune=skylake-avx512
+    FFLAGS   += -march=skylake-avx512 -mtune=skylake-avx512
+    F90FLAGS += -march=skylake-avx512 -mtune=skylake-avx512
+  endif
 endif
 
 ifeq ($(USE_MPI),TRUE)

--- a/Tools/GNUMake/sites/Make.nrel
+++ b/Tools/GNUMake/sites/Make.nrel
@@ -15,7 +15,9 @@ ifeq ($(which_computer), peregrine)
   endif
 else ifeq ($(which_computer), eagle)
 # Eagle is homogeneous at the moment
-# so we can be very specific about arch
+# so we can be very specific about arch.
+# We are not accomodating older compilers
+# that will fail with these flags.
   ifeq ($(COMP), intel)
     CXXFLAGS += -xSKYLAKE-AVX512
     CFLAGS   += -xSKYLAKE-AVX512

--- a/Tools/GNUMake/sites/Make.nrel
+++ b/Tools/GNUMake/sites/Make.nrel
@@ -21,7 +21,7 @@ else ifeq ($(which_computer), eagle)
     CFLAGS   += -xSKYLAKE-AVX512
     FFLAGS   += -xSKYLAKE-AVX512
     F90FLAGS += -xSKYLAKE-AVX512
-  else ifeq ($(COMP), gnu)
+  else ifeq ($(COMP), $(filter $(COMP),gnu gcc llvm))
     CXXFLAGS += -march=skylake-avx512 -mtune=skylake-avx512
     CFLAGS   += -march=skylake-avx512 -mtune=skylake-avx512
     FFLAGS   += -march=skylake-avx512 -mtune=skylake-avx512


### PR DESCRIPTION
We have a new machine at NREL called Eagle and we have new environment variables to detect the host. We also don't care about the Merlin machine anymore. This updates the makefiles in AMReX to account for these changes. I have tested this on both Eagle and Peregrine using Intel, GCC, and LLVM and it appears to work as expected.