### PR TITLE
Fix USE_ACC error; refactor for readability

### DIFF
--- a/Tools/libamrex/configure.py
+++ b/Tools/libamrex/configure.py
@@ -15,7 +15,7 @@ def configure(argv):
     parser.add_argument("--prefix",
                         help="Install libarmex, headers and Fortran modules in PREFIX directory [default=tmp_install_dir]",
                         default="tmp_install_dir")
-    parser.add_argument("--dim", 
+    parser.add_argument("--dim",
                         help="Dimension [default=3]",
                         choices=['1','2','3'],
                         default="3")
@@ -79,60 +79,21 @@ def configure(argv):
 
     f = open("GNUmakefile","w")
     f.write("AMREX_INSTALL_DIR = " + args.prefix.strip() + "\n")
-    f.write("DIM = "+args.dim.strip() + "\n")
-    if args.with_mpi == "no":
-        f.write("USE_MPI = FALSE\n")
-    else:
-        f.write("USE_MPI = TRUE\n")
-    if args.with_omp == "no":
-        f.write("USE_OMP = FALSE\n")
-    else:
-        f.write("USE_OMP = TRUE\n")
-    if args.with_cuda == "no":
-        f.write("USE_CUDA = FALSE\n")
-    else:
-        f.write("USE_CUDA = TRUE\n")
-    if args.with_acc == "no":
-        f.write("USE_ACC = FALSE\n")
-    else:
-        f.write("USE_OMP = TRUE\n")
+    f.write("DIM = " + args.dim.strip() + "\n")
+    f.write("USE_MPI = {}\n".format("FALSE" if args.with_mpi == "no" else "TRUE"))
+    f.write("USE_OMP = {}\n".format("FALSE" if args.with_omp == "no" else "TRUE"))
+    f.write("USE_CUDA = {}\n".format("FALSE" if args.with_cuda == "no" else "TRUE"))
+    f.write("USE_ACC = {}\n".format("FALSE" if args.with_acc == "no" else "TRUE"))
     f.write("COMP = " + args.comp.strip() + "\n")
-    if args.debug == "yes":
-        f.write("DEBUG = TRUE\n")
-    else:
-        f.write("DEBUG = FALSE\n")
-    if args.enable_particle == "no":
-        f.write("USE_PARTICLES = FALSE\n")
-    else:
-        f.write("USE_PARTICLES = TRUE\n")
-    if args.enable_fortran_api == "no":
-        f.write("USE_FORTRAN_INTERFACE = FALSE\n")
-    else:
-        f.write("USE_FORTRAN_INTERFACE = TRUE\n")
-    if args.enable_linear_solver == "no":
-        f.write("USE_LINEAR_SOLVERS = FALSE\n")
-    else:
-        f.write("USE_LINEAR_SOLVERS = TRUE\n")
-    if args.enable_hypre == "yes":
-        f.write("USE_HYPRE = TRUE\n")
-    else:
-        f.write("USE_HYPRE = FALSE\n")
-    if args.enable_eb == "yes":
-        f.write("USE_EB = TRUE\n")
-    else:
-        f.write("USE_EB = FALSE\n")
-    if args.enable_xsdk_defaults == "yes":
-        f.write("AMREX_XSDK = TRUE\n")
-    else:
-        f.write("AMREX_XSDK = FALSE\n")
-    if args.allow_different_compiler == "no":
-        f.write("ALLOW_DIFFERENT_COMP = FALSE\n")
-    else:
-        f.write("ALLOW_DIFFERENT_COMP = TRUE\n")
-    if args.with_sensei_insitu == "no":
-        f.write("USE_SENSEI_INSITU = FALSE\n")
-    else:
-        f.write("USE_SENSEI_INSITU = TRUE\n")
+    f.write("DEBUG = {}\n".format("TRUE" if args.debug == "yes" else "FALSE"))
+    f.write("USE_PARTICLES = {}\n".format("FALSE" if args.enable_particle == "no" else "TRUE"))
+    f.write("USE_FORTRAN_INTERFACE = {}\n".format("FALSE" if args.enable_fortran_api == "no" else "TRUE"))
+    f.write("USE_LINEAR_SOLVERS = {}\n".format("FALSE" if args.enable_linear_solver == "no" else "TRUE"))
+    f.write("USE_HYPRE = {}\n".format("TRUE" if args.enable_hypre == "yes" else "FALSE"))
+    f.write("USE_EB = {}\n".format("TRUE" if args.enable_eb == "yes" else "FALSE"))
+    f.write("AMREX_XSDK = {}\n".format("TRUE" if args.enable_xsdk_defaults == "yes" else "FALSE"))
+    f.write("ALLOW_DIFFERENT_COMP = {}\n".format("FALSE" if args.allow_different_compiler == "no" else "TRUE"))
+    f.write("USE_SENSEI_INSITU = {}\n".format("FALSE" if args.with_sensei_insitu == "no" else "TRUE"))
     f.write("\n")
 
     fin = open("GNUmakefile.in","r")


### PR DESCRIPTION
I noticed a typo:
https://github.com/AMReX-Codes/amrex/blob/master/Tools/libamrex/configure.py#L98
should be "USE_ACC = TRUE". Writing each line in the Makefile with one line of source could help prevent errors like that.