### PR TITLE
Use AMREX_D_DECL for the 2D case.

### DIFF
--- a/Src/EB/AMReX_EB_LSCoreBase.cpp
+++ b/Src/EB/AMReX_EB_LSCoreBase.cpp
@@ -560,7 +560,7 @@ void LSCoreBase::FillLevelSet( MultiFab & level_set, const MultiFab & ls_crse,
     Real min_dx       = LSUtility::min_dx(geom);
     Real ls_threshold = min_dx * (eb_pad + 1);
 
-    const IntVect max_grow{eb_pad, eb_pad, eb_pad};
+    const IntVect max_grow{AMREX_D_DECL(eb_pad, eb_pad, eb_pad)};
 
 #ifdef _OPENMP
 #pragma omp parallel


### PR DESCRIPTION
This fixes the build for me when building with DIM=2 and enabling embedded boundaries.