### PR TITLE
Catch unhandled RealDescriptor logic in VisMf::Write

### DIFF
--- a/Src/Base/AMReX_VisMF.cpp
+++ b/Src/Base/AMReX_VisMF.cpp
@@ -915,13 +915,15 @@ VisMF::Write (const FabArray<FArrayBox>&    mf,
 
     // ---- add stream retry
     // ---- add stream buffer (to nfiles)
-    RealDescriptor *whichRD;
+    RealDescriptor *whichRD = nullptr;
     if(FArrayBox::getFormat() == FABio::FAB_NATIVE) {
       whichRD = FPC::NativeRealDescriptor().clone();
     } else if(FArrayBox::getFormat() == FABio::FAB_NATIVE_32) {
       whichRD = FPC::Native32RealDescriptor().clone();
     } else if(FArrayBox::getFormat() == FABio::FAB_IEEE_32) {
       whichRD = FPC::Ieee32NormalRealDescriptor().clone();
+    } else {
+      Abort("VisMF::Write unable to execute with the current fab.format setting.  Use NATIVE, NATIVE_32 or IEEE_32");
     }
     bool doConvert(*whichRD != FPC::NativeRealDescriptor());
 


### PR DESCRIPTION
Not all RealDescriptor cases are caught in defining a pointer to one.  As a result, a nullptr is dereferenced later causing a segfault.  Can see problem if running with fab.format=ASCII, for example.

I think I still to be able to set Fab formats to ASCII at some point, but this way is currently no longer supported, so I added this Abort to say so.