### PR TITLE
Add optional flag to RegridOnly for disabling I/O

### DIFF
--- a/Src/Amr/AMReX_Amr.H
+++ b/Src/Amr/AMReX_Amr.H
@@ -202,7 +202,7 @@ public:
     //! More work to be done?
     int okToContinue ();
     //! Regrid only!
-    void RegridOnly (Real time);
+    void RegridOnly (Real time, bool do_io = true);
     //! Should we regrid this level?
     bool okToRegrid (int level);
     //! Array of BoxArrays read in to initially define grid hierarchy

--- a/Src/Amr/AMReX_Amr.cpp
+++ b/Src/Amr/AMReX_Amr.cpp
@@ -1927,7 +1927,7 @@ Amr::checkPoint ()
 }
 
 void
-Amr::RegridOnly (Real time)
+Amr::RegridOnly (Real time, bool do_io)
 {
     BL_ASSERT(regrid_on_restart == 1);
 
@@ -1936,14 +1936,18 @@ Amr::RegridOnly (Real time)
     for (int i = 0; i <= lev_top; i++)
        regrid(i,time);
 
-    if (plotfile_on_restart)
-	writePlotFile();
+    if (do_io) {
 
-    if (checkpoint_on_restart)
-       checkPoint();
+        if (plotfile_on_restart)
+            writePlotFile();
 
-    if (insitu_on_restart)
-        updateInSitu();
+        if (checkpoint_on_restart)
+            checkPoint();
+
+        if (insitu_on_restart)
+            updateInSitu();
+
+    }
 }
 
 void


### PR DESCRIPTION
RegridOnly is useful as a public interface to regridding for the user code to call. For cases where the user wants to call it during a simulation, rather than immediately after restart, the I/O options aren't meaningful, so this allows the user to disable that in their call to RegridOnly (while still potentially allowing it in other cases where plotfile_on_restart et al. are desired).