### PR TITLE
Added plot_log_per

### DIFF
--- a/Src/Amr/AMReX_Amr.H
+++ b/Src/Amr/AMReX_Amr.H
@@ -129,10 +129,14 @@ public:
     int plotInt () const { return plot_int; }
     //! Time between plot files.
     Real plotPer () const { return plot_per; }
+    //! Spacing in log10(time) of logarithmically spaced plot files
+    Real plotLogPer () const { return plot_log_per; }
     //! Number of time steps between small plot files.
     int smallplotInt () const { return small_plot_int; }
     //! Time between plot files.
     Real smallplotPer () const { return small_plot_per; }
+    //! Spacing in log10(time) of logarithmically spaced small plot files
+    Real smallplotLogPer () const { return small_plot_log_per; }
     /**
     * \brief The names of state variables to output in the
     * plotfile.  They can be set using the amr.plot_vars variable
@@ -426,8 +430,10 @@ protected:
     int              last_smallplotfile;   //!< Step number of previous small plotfile.
     int              plot_int;        //!< How often plotfile (# of time steps)
     Real             plot_per;        //!< How often plotfile (in units of time)
+    Real             plot_log_per;    //!< How often plotfile (in units of log10(time))
     int              small_plot_int;  //!< How often small plotfile (# of time steps)
     Real             small_plot_per;  //!< How often small plotfile (in units of time)
+    Real             small_plot_log_per;  //!< How often small plotfile (in units of log10(time))
     int              write_plotfile_with_checkpoint;  //!< Write out a plotfile whenever we checkpoint
     int              file_name_digits; //!< How many digits to use in the plotfile and checkpoint names
     int              message_int;     //!< How often checking messages touched by user, such as "stop_run"

--- a/Src/Amr/AMReX_Amr.cpp
+++ b/Src/Amr/AMReX_Amr.cpp
@@ -1211,11 +1211,11 @@ Amr::init (Real strt_time,
         initialInit(strt_time,stop_time);
         checkPoint();
 
-        if(plot_int > 0 || plot_per > 0) {
+        if(plot_int > 0 || plot_per > 0 || plot_log_per > 0) {
             writePlotFile();
         }
 
-        if (small_plot_int > 0 || small_plot_per > 0)
+        if (small_plot_int > 0 || small_plot_per > 0 || small_plot_log_per > 0)
 	        writeSmallPlotFile();
 
         updateInSitu();
@@ -2644,6 +2644,31 @@ Amr::writePlotNow()
 
     }
 
+    if (plot_log_per > 0.0)
+    {
+
+        // Check to see if we've crossed a plot_log_per interval by comparing
+        // the number of intervals that have elapsed for both the current
+        // time and the time at the beginning of this timestep.
+        // This only works when cumtime > 0.
+
+        int num_per_old = 0;
+        int num_per_new = 0;
+
+        if (cumtime-dt_level[0] > 0.) {
+            num_per_old = log10(cumtime-dt_level[0]) / plot_log_per;
+        }
+        if (cumtime > 0.) {
+            num_per_new = log10(cumtime) / plot_log_per;
+        }
+
+        if (num_per_old != num_per_new)
+        {
+            plot_test = 1;
+        }
+
+    }
+
     return ( (plot_int > 0 && level_steps[0] % plot_int == 0) || 
               plot_test == 1 ||
               amr_level[0]->writePlotNow());
@@ -2689,6 +2714,31 @@ Amr::writeSmallPlotNow()
 	{
             plot_test = 1;
 	}
+
+    }
+
+    if (small_plot_log_per > 0.0)
+    {
+
+        // Check to see if we've crossed a small_plot_log_per interval by comparing
+        // the number of intervals that have elapsed for both the current
+        // time and the time at the beginning of this timestep.
+        // This only works when cumtime > 0.
+
+        int num_per_old = 0;
+        int num_per_new = 0;
+
+        if (cumtime-dt_level[0] > 0.) {
+            num_per_old = log10(cumtime-dt_level[0]) / small_plot_log_per;
+        }
+        if (cumtime > 0.) {
+            num_per_new = log10(cumtime) / small_plot_log_per;
+        }
+
+        if (num_per_old != num_per_new)
+        {
+            plot_test = 1;
+        }
 
     }
 
@@ -3427,6 +3477,9 @@ Amr::initPltAndChk ()
     plot_per = -1.0;
     pp.query("plot_per",plot_per);
 
+    plot_log_per = -1.0;
+    pp.query("plot_log_per",plot_log_per);
+
     if (plot_int > 0 && plot_per > 0)
     {
         if (ParallelDescriptor::IOProcessor())
@@ -3441,6 +3494,9 @@ Amr::initPltAndChk ()
 
     small_plot_per = -1.0;
     pp.query("small_plot_per",small_plot_per);
+
+    small_plot_log_per = -1.0;
+    pp.query("small_plot_log_per",small_plot_log_per);
 
     if (small_plot_int > 0 && small_plot_per > 0)
     {


### PR DESCRIPTION
This adds a capability of making plot files that are spaced logarithmically in time. For example, with plot_log_per = 0.2, five plot files will be mode over each factor of 10 increase in time.