### PR TITLE
Define PGI_OPT for any choice of AMREX_CCOMP and AMREX_FCOMP in pgi.mak

### DIFF
--- a/Tools/GNUMake/comps/pgi.mak
+++ b/Tools/GNUMake/comps/pgi.mak
@@ -38,6 +38,10 @@ else
   GENERIC_PGI_FLAGS += -noacc
 endif
 
+# Note that -O2 is the default optimization level for PGI
+
+PGI_OPT := -O2 -fast
+
 ########################################################################
 ########################################################################
 ########################################################################
@@ -51,10 +55,6 @@ CC  = pgcc
 
 CXXFLAGS =
 CFLAGS   =
-
-# Note that -O2 is the default optimization level for PGI
-
-PGI_OPT := -O2 -fast
 
 ifeq ($(DEBUG),TRUE)
 


### PR DESCRIPTION
Commit bd6b03f7e0 wrapped the definition of `PGI_OPT` inside `ifeq ($(AMREX_CCOMP),pgi)`.

As a result, when `AMREX_CCOMP=gnu` and `AMREX_FCOMP=pgi`, the `-O2 -fast` flags are not passed to pgfortran.

This PR moves the definition of `PGI_OPT` outside the compiler checks in `pgi.mak` so it will apply to `AMREX_CCOMP=pgi` and `AMREX_FCOMP=pgi` independent of each other's value.