### PR TITLE
Petsc bottom solver in F_interface; update GNUmakefile

### DIFF
--- a/GNUmakefile.in
+++ b/GNUmakefile.in
@@ -24,6 +24,11 @@ ifeq ($(USE_HYPRE),TRUE)
       Pdirs += Extern/HYPRE
    endif
 endif
+ifeq ($(USE_PETSC),TRUE)
+   ifeq ($(USE_LINEAR_SOLVERS),TRUE)
+      Pdirs += Extern/PETSc
+   endif
+endif
 ifeq ($(USE_SENSEI_INSITU),TRUE)
 	Pdirs += Extern/SENSEI
 endif

--- a/GNUmakefile.in
+++ b/GNUmakefile.in
@@ -6,6 +6,9 @@ include $(AMREX_HOME)/Tools/GNUMake/Make.defs
 Pdirs := Base AmrCore Amr Boundary
 ifeq ($(USE_PARTICLES),TRUE)
     Pdirs += Particle
+   ifeq ($(USE_FORTRAN_INTERFACE),TRUE)
+     Pdirs += F_Interfaces/Particle
+   endif
 endif
 ifeq ($(USE_FORTRAN_INTERFACE),TRUE)
     Pdirs += F_Interfaces/Base F_Interfaces/Octree F_Interfaces/AmrCore

--- a/Src/F_Interfaces/LinearSolvers/AMReX_multigrid_fi.cpp
+++ b/Src/F_Interfaces/LinearSolvers/AMReX_multigrid_fi.cpp
@@ -84,6 +84,8 @@
              mlmg->setBottomSolver(MLMG::BottomSolver::cg);
          } else if (s == 3) {
              mlmg->setBottomSolver(MLMG::BottomSolver::hypre);
+         } else if (s == 4) {
+             mlmg->setBottomSolver(MLMG::BottomSolver::petsc);
          } else {
              amrex::Abort("amrex_fi_multigrid_set_bottom_solver: unknown bottom solver");
          }

--- a/Src/F_Interfaces/LinearSolvers/AMReX_multigrid_mod.F90
+++ b/Src/F_Interfaces/LinearSolvers/AMReX_multigrid_mod.F90
@@ -10,6 +10,7 @@ module amrex_multigrid_module
   integer, parameter, public :: amrex_bottom_bicgstab = 1
   integer, parameter, public :: amrex_bottom_cg       = 2
   integer, parameter, public :: amrex_bottom_hypre    = 3
+  integer, parameter, public :: amrex_bottom_petsc    = 4
   integer, parameter, public :: amrex_bottom_default  = 1
 
   private

--- a/Tools/libamrex/configure.py
+++ b/Tools/libamrex/configure.py
@@ -59,6 +59,10 @@ def configure(argv):
                         help="Enable Hypre as an option for bottom solver of AMReX linear solvers [default=no]",
                         choices=["yes","no"],
                         default="no")
+    parser.add_argument("--enable-petsc",
+                        help="Enable PETSc as an option for bottom solver of AMReX linear solvers [default=no]",
+                        choices=["yes","no"],
+                        default="no")
     parser.add_argument("--enable-eb",
                         help="Enable AMReX embedded boundary capability [default=no]",
                         choices=["yes","no"],
@@ -90,6 +94,7 @@ def configure(argv):
     f.write("USE_FORTRAN_INTERFACE = {}\n".format("FALSE" if args.enable_fortran_api == "no" else "TRUE"))
     f.write("USE_LINEAR_SOLVERS = {}\n".format("FALSE" if args.enable_linear_solver == "no" else "TRUE"))
     f.write("USE_HYPRE = {}\n".format("TRUE" if args.enable_hypre == "yes" else "FALSE"))
+    f.write("USE_PETSC = {}\n".format("TRUE" if args.enable_petsc == "yes" else "FALSE"))
     f.write("USE_EB = {}\n".format("TRUE" if args.enable_eb == "yes" else "FALSE"))
     f.write("AMREX_XSDK = {}\n".format("TRUE" if args.enable_xsdk_defaults == "yes" else "FALSE"))
     f.write("ALLOW_DIFFERENT_COMP = {}\n".format("FALSE" if args.allow_different_compiler == "no" else "TRUE"))


### PR DESCRIPTION
There are three small changes in this PR:
1) Adding the option of using PETSc as bottom solver in  F_Interfaces/LinearSolvers.
2) Add a new option `--enable-petsc` in the configure script to include related directories when enabled.
3) Adding F_Interfaces/Particle when using particles AND Fortran Interfaces.