### PR TITLE
Improve AmrCore and AmrMesh constructors.

### DIFF
--- a/Src/AmrCore/AMReX_AmrCore.H
+++ b/Src/AmrCore/AMReX_AmrCore.H
@@ -26,7 +26,7 @@ class AmrCore
 public:
 
     AmrCore ();
-    AmrCore (const RealBox* rb, int max_level_in, const Vector<int>& n_cell_in, int coord=-1, const Vector<IntVect>& ref_ratios = Vector<IntVect>());
+    AmrCore (const RealBox* rb, int max_level_in, const Vector<int>& n_cell_in, int coord=-1, Vector<IntVect> ref_ratios = Vector<IntVect>());
 
     AmrCore (const AmrCore& rhs) = delete;
     AmrCore& operator= (const AmrCore& rhs) = delete;

--- a/Src/AmrCore/AMReX_AmrCore.H
+++ b/Src/AmrCore/AMReX_AmrCore.H
@@ -26,7 +26,7 @@ class AmrCore
 public:
 
     AmrCore ();
-    AmrCore (const RealBox* rb, int max_level_in, const Vector<int>& n_cell_in, int coord=-1);
+    AmrCore (const RealBox* rb, int max_level_in, const Vector<int>& n_cell_in, int coord=-1, const Vector<IntVect>& ref_ratios = Vector<IntVect>());
 
     AmrCore (const AmrCore& rhs) = delete;
     AmrCore& operator= (const AmrCore& rhs) = delete;

--- a/Src/AmrCore/AMReX_AmrCore.cpp
+++ b/Src/AmrCore/AMReX_AmrCore.cpp
@@ -40,8 +40,8 @@ AmrCore::AmrCore ()
     InitAmrCore();
 }
 
-AmrCore::AmrCore (const RealBox* rb, int max_level_in, const Vector<int>& n_cell_in, int coord, const Vector<IntVect>& ref_ratios)
-  : AmrMesh(rb, max_level_in, n_cell_in, coord, ref_ratios)
+AmrCore::AmrCore (const RealBox* rb, int max_level_in, const Vector<int>& n_cell_in, int coord, Vector<IntVect> ref_ratios)
+  : AmrMesh(rb, max_level_in, n_cell_in, coord, std::move(ref_ratios))
 {
     Initialize();
     InitAmrCore();

--- a/Src/AmrCore/AMReX_AmrCore.cpp
+++ b/Src/AmrCore/AMReX_AmrCore.cpp
@@ -40,8 +40,8 @@ AmrCore::AmrCore ()
     InitAmrCore();
 }
 
-AmrCore::AmrCore (const RealBox* rb, int max_level_in, const Vector<int>& n_cell_in, int coord)
-    : AmrMesh(rb, max_level_in, n_cell_in, coord)
+AmrCore::AmrCore (const RealBox* rb, int max_level_in, const Vector<int>& n_cell_in, int coord, const Vector<IntVect>& ref_ratios)
+  : AmrMesh(rb, max_level_in, n_cell_in, coord, ref_ratios)
 {
     Initialize();
     InitAmrCore();

--- a/Src/AmrCore/AMReX_AmrMesh.H
+++ b/Src/AmrCore/AMReX_AmrMesh.H
@@ -17,7 +17,7 @@ class AmrMesh
 public:
     AmrMesh ();
     AmrMesh (const RealBox* rb, int max_level_in, const Vector<int>& n_cell_in, int coord=-1,
-             std::vector<int> refrat = std::vector<int>());
+             Vector<IntVect> refrat = Vector<IntVect>());
 
     AmrMesh (const AmrMesh& rhs) = delete;
     AmrMesh& operator= (const AmrMesh& rhs) = delete;
@@ -204,7 +204,7 @@ protected:
 
 private:
     void InitAmrMesh (int max_level_in, const Vector<int>& n_cell_in,
-                      std::vector<int> refrat = std::vector<int>());
+                      Vector<IntVect> refrat = Vector<IntVect>());
 
     static void ProjPeriodic (BoxList& bd, const Geometry& geom);
 };

--- a/Src/AmrCore/AMReX_AmrMesh.cpp
+++ b/Src/AmrCore/AMReX_AmrMesh.cpp
@@ -42,7 +42,7 @@ AmrMesh::AmrMesh (const RealBox* rb, int max_level_in, const Vector<int>& n_cell
   Initialize();
 
   Geometry::Setup(rb,coord);
-  InitAmrMesh(max_level_in,n_cell_in, a_refrat);
+  InitAmrMesh(max_level_in,n_cell_in, std::move(a_refrat));
 }
 
 AmrMesh::~AmrMesh ()

--- a/Src/AmrCore/AMReX_AmrMesh.cpp
+++ b/Src/AmrCore/AMReX_AmrMesh.cpp
@@ -37,7 +37,7 @@ AmrMesh::AmrMesh ()
 }
 
 AmrMesh::AmrMesh (const RealBox* rb, int max_level_in, const Vector<int>& n_cell_in, int coord,
-                  std::vector<int> a_refrat)
+                  Vector<IntVect> a_refrat)
 {
   Initialize();
 
@@ -51,7 +51,7 @@ AmrMesh::~AmrMesh ()
 }
 
 void
-AmrMesh::InitAmrMesh (int max_level_in, const Vector<int>& n_cell_in, std::vector<int> a_refrat)
+AmrMesh::InitAmrMesh (int max_level_in, const Vector<int>& n_cell_in, Vector<IntVect> a_refrat)
 {
     verbose   = 0;
     grid_eff  = 0.7;
@@ -215,8 +215,7 @@ AmrMesh::InitAmrMesh (int max_level_in, const Vector<int>& n_cell_in, std::vecto
     {
       for (int i = 0; i < max_level; i++)
       {
-        for (int n = 0; n < AMREX_SPACEDIM; n++)
-          ref_ratio[i][n] = a_refrat[i];
+          ref_ratio[i] = a_refrat[i];
       }
     }
 


### PR DESCRIPTION
Change the refinement ratio paramter of AmrMesh's constructor from
std::vector<int> to amrex::Vector<IntVect> to be more consistent with
non-uniform refinement ratios.

Add a refrat parameter to AmrCore's constructor. Before this change
AmrMesh's refinment parameter was never set to this custom value.

This fixes issue #462 which occured because AmrMesh was intialized by a default refinement ratio (2,2,2) and generated its geometry domains internally with this ratio.

Currently, if one changes the refinement ratio after construction the geometries are not regenerated which should be a problem which this PR does not address.

I propose to rethink the protected variables of AmrMesh and only rely on getters and setters to keep the invariants of AmrMesh intact (which in this case means that the stored geom's are compatible with the refinement ratios).