### PR TITLE
Improve move assignment operators for BoxArray and DistributionMapping

### DIFF
--- a/Src/Base/AMReX_BoxArray.H
+++ b/Src/Base/AMReX_BoxArray.H
@@ -211,6 +211,21 @@ public:
     //! Construct an empty BoxArray.
     BoxArray ();
 
+    //! The copy constructor.
+    BoxArray (const BoxArray& rhs);
+
+    //! The assignment operator.
+    BoxArray& operator= (const BoxArray& rhs);
+
+    //! The move constructor.
+    BoxArray (BoxArray&& rhs) noexcept = default;
+
+    //! The move assignment operator.
+    BoxArray& operator=(BoxArray&& rhs) noexcept = default;
+
+    //! The destructor.
+    ~BoxArray() noexcept = default;
+
     //! Make a boxarray out of a single box
     explicit BoxArray (const Box& bx);
 
@@ -227,17 +242,7 @@ public:
 
     BoxArray (const BoxArray& rhs, const BATransformer& trans);
 
-    //! The copy constructor.
-    BoxArray (const BoxArray& rhs);
-
-    //! The assignment operator.
-    BoxArray& operator= (const BoxArray& rhs);
-
-    //! The move constructor
-    BoxArray (BoxArray&& rhs) noexcept;
-
-    //! The destructor.
-    ~BoxArray ();
+    
     /**
     * \brief Initialize the BoxArray from a single box.
     * It is an error if the BoxArray has already been initialized.

--- a/Src/Base/AMReX_BoxArray.cpp
+++ b/Src/Base/AMReX_BoxArray.cpp
@@ -357,18 +357,6 @@ BoxArray::BoxArray (const BoxArray& rhs)
     m_ref(rhs.m_ref)
 {}
 
-BoxArray::BoxArray(BoxArray&& rhs) noexcept
-    :
-    m_transformer(std::move(rhs.m_transformer)),
-    m_typ(rhs.m_typ),
-    m_crse_ratio(rhs.m_crse_ratio),
-    m_simple(rhs.m_simple),
-    m_ref(std::move(rhs.m_ref))
-{}
-
-BoxArray::~BoxArray ()
-{}
-
 BoxArray&
 BoxArray::operator= (const BoxArray& rhs)
 {

--- a/Src/Base/AMReX_DistributionMapping.H
+++ b/Src/Base/AMReX_DistributionMapping.H
@@ -48,6 +48,21 @@ class DistributionMapping
     //! The default constructor.
     DistributionMapping ();
 
+    //! The copy constructor.
+    DistributionMapping (const DistributionMapping& rhs) = default;
+
+    //! The copy assignment operator.
+    DistributionMapping& operator= (const DistributionMapping& rhs) = default;
+
+    //! The move constructor.
+    DistributionMapping (DistributionMapping&& rhs) noexcept = default;
+
+    //! The move assignment operator.
+    DistributionMapping& operator= (DistributionMapping&& rhs) noexcept = default;
+
+   //! The destructor.
+    ~DistributionMapping() noexcept = default;
+
     /**
     * \brief Create an object with the specified mapping.
     */
@@ -62,18 +77,6 @@ class DistributionMapping
     */
     DistributionMapping (const DistributionMapping& d1,
                          const DistributionMapping& d2);
-
-    //! The destructor.
-    ~DistributionMapping ();
-
-    //! Copy constructor.
-    DistributionMapping (const DistributionMapping& rhs);
-
-    //! Assignment operator.
-    DistributionMapping& operator= (const DistributionMapping& rhs);
-
-    //! Move constructor.
-    DistributionMapping (DistributionMapping&& rhs) noexcept;
 
     /**
     * \brief Build mapping out of BoxArray over nprocs processors.

--- a/Src/Base/AMReX_DistributionMapping.cpp
+++ b/Src/Base/AMReX_DistributionMapping.cpp
@@ -305,25 +305,6 @@ DistributionMapping::DistributionMapping ()
 {
 }
 
-DistributionMapping::DistributionMapping (const DistributionMapping& rhs)
-    :
-    m_ref(rhs.m_ref)
-{
-}
-
-DistributionMapping&
-DistributionMapping::operator= (const DistributionMapping& rhs)
-{
-    m_ref = rhs.m_ref;
-    return *this;
-}
-
-DistributionMapping::DistributionMapping (DistributionMapping&& rhs) noexcept
-    :
-    m_ref(std::move(rhs.m_ref))
-{
-}
-
 DistributionMapping::DistributionMapping (const Vector<int>& pmap)
     :
     m_ref(std::make_shared<Ref>(pmap))
@@ -379,8 +360,6 @@ DistributionMapping::define (Vector<int>&& pmap) noexcept
     m_ref->clear();
     m_ref->m_pmap = std::move(pmap);
 }
-
-DistributionMapping::~DistributionMapping () { }
 
 void
 DistributionMapping::RoundRobinDoIt (int                  nboxes,


### PR DESCRIPTION
The current move assignment operators of `BoxArray` and `DistributionMapping` are not `noexcept` although their move constructors are. I assume this to be an oversight. This PR applies "The Rule of Six" by defaulting or defining all six special constructors for these classes.

To given an example which can be compiled after these changes apply

```cpp
#include <AMReX_BoxArray.H>
#include <AMReX_DistributionMapping.H>
#include <AMReX_MultiFab.H>

#include <type_traits>

static_assert(std::is_nothrow_move_assignable<amrex::BoxArray>::value, 
              "Move Assign Operator of BoxArray is not noexcept.");

static_assert(std::is_nothrow_move_assignable<amrex::DistributionMapping>::value, 
              "Move Assign Operator of DistributionMapping is not noexcept.");

struct LevelData {
    // Special Constructors

    LevelData() = default;

    LevelData(const LevelData&) = delete;
    LevelData& operator=(const LevelData&) = delete;

    LevelData(LevelData&&) noexcept = default;
    LevelData& operator=(LevelData&&) noexcept = default;

    ~LevelData() = default;

    // More Constructors

    LevelData(amrex::BoxArray, amrex::DistributionMapping);

    amrex::BoxArray ba{};
    amrex::DistributionMapping dm{};
    amrex::MultiFab mf{};
};
```

Compiler Output:
```
<source>:7:1: error: static_assert failed due to requirement 'std::is_nothrow_move_assignable<amrex::BoxArray>::value' "Move Assign Operator of BoxArray is not noexcept."

static_assert(std::is_nothrow_move_assignable<amrex::BoxArray>::value, 

^             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

<source>:10:1: error: static_assert failed due to requirement 'std::is_nothrow_move_assignable<amrex::DistributionMapping>::value' "Move Assign Operator of DistributionMapping is not noexcept."

static_assert(std::is_nothrow_move_assignable<amrex::DistributionMapping>::value, 

^             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

<source>:22:16: error: exception specification of explicitly defaulted move assignment operator does not match the calculated one

    LevelData& operator=(LevelData&&) noexcept = default;
```