### PR TITLE
EB: Add an additional overload for FillPatchTwoLevels.

### DIFF
--- a/Src/AmrCore/AMReX_FillPatchUtil.H
+++ b/Src/AmrCore/AMReX_FillPatchUtil.H
@@ -7,6 +7,10 @@
 #include <AMReX_Interpolater.H>
 #include <AMReX_Array.H>
 
+#ifdef AMREX_USE_EB
+#include <AMReX_EB2.H>
+#endif
+
 namespace amrex
 {
     class InterpHook {
@@ -43,6 +47,22 @@ namespace amrex
                              const Vector<BCRec>& bcs, int bcscomp,
                              const InterpHook& pre_interp = NullInterpHook(),
                              const InterpHook& post_interp = NullInterpHook());
+
+#ifdef AMREX_USE_EB
+    void FillPatchTwoLevels (MultiFab& mf, Real time,
+                             const EB2::IndexSpace& index_space,
+			     const Vector<MultiFab*>& cmf, const Vector<Real>& ct,
+			     const Vector<MultiFab*>& fmf, const Vector<Real>& ft,
+			     int scomp, int dcomp, int ncomp,
+			     const Geometry& cgeom, const Geometry& fgeom,
+			     PhysBCFunctBase& cbc, int cbccomp,
+                             PhysBCFunctBase& fbc, int fbccomp,
+			     const IntVect& ratio,
+			     Interpolater* mapper,
+                             const Vector<BCRec>& bcs, int bcscomp,
+                             const InterpHook& pre_interp,
+                             const InterpHook& post_interp);
+#endif
 
     void InterpFromCoarseLevel (MultiFab& mf, Real time,
 				const MultiFab& cmf, int scomp, int dcomp, int ncomp,

--- a/Src/AmrCore/AMReX_FillPatchUtil.cpp
+++ b/Src/AmrCore/AMReX_FillPatchUtil.cpp
@@ -251,10 +251,7 @@ namespace amrex
                                                                       ngrow,
                                                                       coarsener,
                                                                       amrex::coarsen(fgeom.Domain(),ratio), 
-                                                                      makeEBFabFactory(index_space, Geometry(cdomain),
-                                                                                       ba_crse_patch,
-                                                                                       dm_crse_patch,
-                                                                                       {0,0,0}, EBSupport::basic));
+                                                                      &index_space);
 
 	    if ( ! fpc.ba_crse_patch.empty())
 	    {

--- a/Src/AmrCore/AMReX_FillPatchUtil.cpp
+++ b/Src/AmrCore/AMReX_FillPatchUtil.cpp
@@ -215,6 +215,100 @@ namespace amrex
 	FillPatchSingleLevel(mf, time, fmf, ft, scomp, dcomp, ncomp, fgeom, fbc, fbccomp);
     }
 
+#ifdef AMREX_USE_EB
+    void FillPatchTwoLevels (MultiFab& mf, Real time,
+                             const EB2::IndexSpace& index_space,
+			     const Vector<MultiFab*>& cmf, const Vector<Real>& ct,
+			     const Vector<MultiFab*>& fmf, const Vector<Real>& ft,
+			     int scomp, int dcomp, int ncomp,
+			     const Geometry& cgeom, const Geometry& fgeom,
+			     PhysBCFunctBase& cbc, int cbccomp,
+                             PhysBCFunctBase& fbc, int fbccomp,
+			     const IntVect& ratio,
+			     Interpolater* mapper,
+                             const Vector<BCRec>& bcs, int bcscomp,
+                             const InterpHook& pre_interp,
+                             const InterpHook& post_interp)
+    {
+	BL_PROFILE("FillPatchTwoLevels");
+
+	const IntVect& ngrow = mf.nGrowVect();
+
+	if (ngrow.max() > 0 || mf.getBDKey() != fmf[0]->getBDKey())
+	{
+	    const InterpolaterBoxCoarsener& coarsener = mapper->BoxCoarsener(ratio);
+
+	    Box fdomain = fgeom.Domain();
+	    fdomain.convert(mf.boxArray().ixType());
+	    Box fdomain_g(fdomain);
+	    for (int i = 0; i < AMREX_SPACEDIM; ++i) {
+		if (fgeom.isPeriodic(i)) {
+		    fdomain_g.grow(i,ngrow[i]);
+		}
+	    }
+
+	    const FabArrayBase::FPinfo& fpc = FabArrayBase::TheFPinfo(*fmf[0], mf, fdomain_g,
+                                                                      ngrow,
+                                                                      coarsener,
+                                                                      amrex::coarsen(fgeom.Domain(),ratio), 
+                                                                      makeEBFabFactory(index_space, Geometry(cdomain),
+                                                                                       ba_crse_patch,
+                                                                                       dm_crse_patch,
+                                                                                       {0,0,0}, EBSupport::basic));
+
+	    if ( ! fpc.ba_crse_patch.empty())
+	    {
+		MultiFab mf_crse_patch(fpc.ba_crse_patch, fpc.dm_crse_patch, ncomp, 0, MFInfo(),
+                                       *fpc.fact_crse_patch);
+
+                mf_crse_patch.setDomainBndry(std::numeric_limits<Real>::quiet_NaN(), cgeom);
+
+		FillPatchSingleLevel(mf_crse_patch, time, cmf, ct, scomp, 0, ncomp, cgeom, cbc, cbccomp);
+
+		int idummy1=0, idummy2=0;
+		bool cc = fpc.ba_crse_patch.ixType().cellCentered();
+                ignore_unused(cc);
+#ifdef _OPENMP
+#pragma omp parallel if (cc && Gpu::notInLaunchRegion())
+#endif
+                {
+                    Vector<BCRec> bcr(ncomp);
+                    for (MFIter mfi(mf_crse_patch); mfi.isValid(); ++mfi)
+                    {
+                        FArrayBox& sfab = mf_crse_patch[mfi];
+                        int li = mfi.LocalIndex();
+                        int gi = fpc.dst_idxs[li];
+                        FArrayBox& dfab = mf[gi];
+                        const Box& dbx = fpc.dst_boxes[li] & dfab.box();
+
+                        amrex::setBC(dbx,fdomain,bcscomp,0,ncomp,bcs,bcr);
+
+                        pre_interp(sfab, sfab.box(), 0, ncomp);
+                        
+                        FArrayBox const* sfabp = mf_crse_patch.fabPtr(mfi);
+                        FArrayBox* dfabp = mf.fabPtr(gi);
+                        mapper->interp(*sfabp,
+                                       0,
+                                       *dfabp,
+                                       dcomp,
+                                       ncomp,
+                                       dbx,
+                                       ratio,
+                                       cgeom,
+                                       fgeom,
+                                       bcr,
+                                       idummy1, idummy2);
+
+                        post_interp(dfab, dbx, dcomp, ncomp);
+                    }
+                }
+	    }
+	}
+
+	FillPatchSingleLevel(mf, time, fmf, ft, scomp, dcomp, ncomp, fgeom, fbc, fbccomp);
+    }
+#endif
+
     void InterpFromCoarseLevel (MultiFab& mf, Real time, const MultiFab& cmf,
 				int scomp, int dcomp, int ncomp,
 				const Geometry& cgeom, const Geometry& fgeom,

--- a/Src/Base/AMReX_FabArrayBase.H
+++ b/Src/Base/AMReX_FabArrayBase.H
@@ -27,6 +27,13 @@ class Perilla;
 class RegionGraph;
 #endif
 
+#ifdef AMREX_USE_EB
+namespace EB2 {
+class IndexSpace;
+const IndexSpace* TopIndexSpaceIfPresent() noexcept;
+}
+#endif
+
 class FabArrayBase
 {
     friend class MFIter;
@@ -285,13 +292,18 @@ public:
 
     struct FPinfo
     {
-	FPinfo (const FabArrayBase& srcfa,
-		const FabArrayBase& dstfa,
-		const Box&          dstdomain,
-		const IntVect&      dstng,
-		const BoxConverter& coarsener,
+        FPinfo (const FabArrayBase& srcfa,
+                const FabArrayBase& dstfa,
+                const Box&          dstdomain,
+                const IntVect&      dstng,
+                const BoxConverter& coarsener,
+#ifdef AMREX_USE_EB
                 const Box&          cdomain,
-                std::unique_ptr<FabFactory<FArrayBox> > factory = nullptr);
+                const EB2::IndexSpace* index_space = EB2::TopIndexSpaceIfPresent());
+#else 
+                const Box&          cdomain);
+#endif
+
 	~FPinfo ();
 
 	long bytes () const;
@@ -319,11 +331,16 @@ public:
     static CacheStats m_FPinfo_stats;
 
     static const FPinfo& TheFPinfo (const FabArrayBase& srcfa,
-				    const FabArrayBase& dstfa,
-				    const Box&          dstdomain,
-				    const IntVect&      dstng,
-				    const BoxConverter& coarsener,
+                                    const FabArrayBase& dstfa,
+                                    const Box&          dstdomain,
+                                    const IntVect&      dstng,
+                                    const BoxConverter& coarsener,
+#ifdef AMREX_USE_EB
+                                    const Box&          cdomain,
+                                    const EB2::IndexSpace* index_space = EB2::TopIndexSpaceIfPresent());
+#else 
                                     const Box&          cdomain);
+#endif
 
     void flushFPinfo (bool no_assertion=false);
 

--- a/Src/Base/AMReX_FabArrayBase.H
+++ b/Src/Base/AMReX_FabArrayBase.H
@@ -290,7 +290,8 @@ public:
 		const Box&          dstdomain,
 		const IntVect&      dstng,
 		const BoxConverter& coarsener,
-                const Box&          cdomain);
+                const Box&          cdomain,
+                std::unique_ptr<FabFactory<FArrayBox> > factory = nullptr);
 	~FPinfo ();
 
 	long bytes () const;

--- a/Src/Base/AMReX_FabArrayBase.cpp
+++ b/Src/Base/AMReX_FabArrayBase.cpp
@@ -13,6 +13,7 @@
 #endif
 
 #ifdef AMREX_USE_EB
+#include <AMReX_EB2.H>
 #include <AMReX_EBFabFactory.H>
 #endif
 
@@ -1062,8 +1063,12 @@ FabArrayBase::FPinfo::FPinfo (const FabArrayBase& srcfa,
 			      const Box&          dstdomain,
 			      const IntVect&      dstng,
 			      const BoxConverter& coarsener,
+#ifdef AMREX_USE_EB
                               const Box&          cdomain,
-                              std::unique_ptr<FabFactory<FArrayBox> > factory)
+                              const EB2::IndexSpace* index_space)
+#else
+                              const Box&          cdomain)
+#endif
     : m_srcbdk   (srcfa.getBDKey()),
       m_dstbdk   (dstfa.getBDKey()),
       m_dstdomain(dstdomain),
@@ -1072,7 +1077,6 @@ FabArrayBase::FPinfo::FPinfo (const FabArrayBase& srcfa,
       m_nuse     (0)
 { 
     BL_PROFILE("FPinfo::FPinfo()");
-
     const BoxArray& srcba = srcfa.boxArray();
     const BoxArray& dstba = dstfa.boxArray();
     BL_ASSERT(srcba.ixType() == dstba.ixType());
@@ -1091,39 +1095,39 @@ FabArrayBase::FPinfo::FPinfo (const FabArrayBase& srcfa,
 
     for (int i = 0, N = dstba.size(); i < N; ++i)
     {
-	Box bx = dstba[i];
-	bx.grow(m_dstng);
-	bx &= m_dstdomain;
+        Box bx = dstba[i];
+        bx.grow(m_dstng);
+        bx &= m_dstdomain;
 
-	BoxList leftover = srcba.complementIn(bx);
+        BoxList leftover = srcba.complementIn(bx);
 
-	bool ismybox = (dstdm[i] == myproc);
-	for (BoxList::const_iterator bli = leftover.begin(); bli != leftover.end(); ++bli)
-	{
-	    bl.push_back(m_coarsener->doit(*bli));
-	    if (ismybox) {
-		dst_boxes.push_back(*bli);
-		dst_idxs.push_back(i);
-	    }
-	    iprocs.push_back(dstdm[i]);
-	}
+        bool ismybox = (dstdm[i] == myproc);
+        for (BoxList::const_iterator bli = leftover.begin(); bli != leftover.end(); ++bli)
+        {
+            bl.push_back(m_coarsener->doit(*bli));
+            if (ismybox) {
+                dst_boxes.push_back(*bli);
+                dst_idxs.push_back(i);
+            }
+            iprocs.push_back(dstdm[i]);
+        }
     }
 
     if (!iprocs.empty()) {
-	ba_crse_patch.define(bl);
-	dm_crse_patch.define(std::move(iprocs));
-        if (factory) {
-            fact_crse_patch = std::move(factory);
-        } else {
+        ba_crse_patch.define(bl);
+        dm_crse_patch.define(std::move(iprocs));
 #ifdef AMREX_USE_EB
-            fact_crse_patch = makeEBFabFactory(Geometry(cdomain),
+        if (index_space) {
+                fact_crse_patch = makeEBFabFactory(index_space, Geometry(cdomain),
                                                ba_crse_patch,
                                                dm_crse_patch,
                                                {0,0,0}, EBSupport::basic);
-#else
-            fact_crse_patch.reset(new FArrayBoxFactory());
-#endif
+        } else {
+                fact_crse_patch.reset(new FArrayBoxFactory());
         }
+#else
+        fact_crse_patch.reset(new FArrayBoxFactory());
+#endif
     }
 }
 
@@ -1143,11 +1147,16 @@ FabArrayBase::FPinfo::bytes () const
 
 const FabArrayBase::FPinfo&
 FabArrayBase::TheFPinfo (const FabArrayBase& srcfa,
-			 const FabArrayBase& dstfa,
-			 const Box&          dstdomain,
-			 const IntVect&      dstng,
-			 const BoxConverter& coarsener,
+                         const FabArrayBase& dstfa,
+                         const Box&          dstdomain,
+                         const IntVect&      dstng,
+                         const BoxConverter& coarsener,
+#ifdef AMREX_USE_EB
+                         const Box&          cdomain,
+                         const EB2::IndexSpace* index_space)
+#else 
                          const Box&          cdomain)
+#endif
 {
     BL_PROFILE("FabArrayBase::TheFPinfo()");
 
@@ -1172,7 +1181,12 @@ FabArrayBase::TheFPinfo (const FabArrayBase& srcfa,
     }
 
     // Have to build a new one
+#ifdef AMREX_USE_EB
+    FPinfo* new_fpc = new FPinfo(srcfa, dstfa, dstdomain, dstng, coarsener, cdomain, index_space);
+#else
     FPinfo* new_fpc = new FPinfo(srcfa, dstfa, dstdomain, dstng, coarsener, cdomain);
+#endif
+
 
 #ifdef BL_MEM_PROFILING
     m_FPinfo_stats.bytes += new_fpc->bytes();

--- a/Src/Base/AMReX_FabArrayBase.cpp
+++ b/Src/Base/AMReX_FabArrayBase.cpp
@@ -1062,7 +1062,8 @@ FabArrayBase::FPinfo::FPinfo (const FabArrayBase& srcfa,
 			      const Box&          dstdomain,
 			      const IntVect&      dstng,
 			      const BoxConverter& coarsener,
-                              const Box&          cdomain)
+                              const Box&          cdomain,
+                              std::unique_ptr<FabFactory<FArrayBox> > factory)
     : m_srcbdk   (srcfa.getBDKey()),
       m_dstbdk   (dstfa.getBDKey()),
       m_dstdomain(dstdomain),
@@ -1111,14 +1112,18 @@ FabArrayBase::FPinfo::FPinfo (const FabArrayBase& srcfa,
     if (!iprocs.empty()) {
 	ba_crse_patch.define(bl);
 	dm_crse_patch.define(std::move(iprocs));
+        if (factory) {
+            fact_crse_patch = std::move(factory);
+        } else {
 #ifdef AMREX_USE_EB
-        fact_crse_patch = makeEBFabFactory(Geometry(cdomain),
-                                           ba_crse_patch,
-                                           dm_crse_patch,
-                                           {0,0,0}, EBSupport::basic);
+            fact_crse_patch = makeEBFabFactory(Geometry(cdomain),
+                                               ba_crse_patch,
+                                               dm_crse_patch,
+                                               {0,0,0}, EBSupport::basic);
 #else
-        fact_crse_patch.reset(new FArrayBoxFactory());
+            fact_crse_patch.reset(new FArrayBoxFactory());
 #endif
+        }
     }
 }
 

--- a/Src/EB/AMReX_EB2.H
+++ b/Src/EB/AMReX_EB2.H
@@ -28,11 +28,11 @@ public:
     virtual ~IndexSpace() {}
 
     static void push (IndexSpace* ispace) { m_instance.emplace_back(ispace); }
-    static void pop () { m_instance.pop_back(); }
-    static void clear () { m_instance.clear(); }
+    static void pop () noexcept { m_instance.pop_back(); }
+    static void clear () noexcept { m_instance.clear(); }
     static const IndexSpace& top () { return *(m_instance.back()); }
-    static bool empty () { return m_instance.empty(); }
-    static int size () { return m_instance.size(); }
+    static bool empty () noexcept { return m_instance.empty(); }
+    static int size () noexcept { return m_instance.size(); }
 
     virtual const Level& getLevel (const Geometry & geom) const = 0;
     virtual const Box& coarsestDomain () const = 0;
@@ -40,6 +40,8 @@ public:
 protected:
     static Vector<std::unique_ptr<IndexSpace> > m_instance;
 };
+
+const IndexSpace* TopIndexSpaceIfPresent() noexcept;
 
 template <typename G>
 class IndexSpaceImp

--- a/Src/EB/AMReX_EB2.cpp
+++ b/Src/EB/AMReX_EB2.cpp
@@ -33,6 +33,13 @@ void Finalize ()
     IndexSpace::clear();
 }
 
+const IndexSpace* TopIndexSpaceIfPresent() noexcept {
+    if (IndexSpace::size() > 0) {
+        return &IndexSpace::top();
+    }
+    return nullptr;
+}
+
 void
 Build (const Geometry& geom, int required_coarsening_level,
        int max_coarsening_level, int ngrow)


### PR DESCRIPTION
 * This adds an EB2::IndexSpace parameter to FillPatchTwoLevels.
   That way one can specify the exact EB2::IndexSpace for the
   interpolation region.
 * Add a defaulted FabFactory parameter to the constructor of FPInfo.

This is the first attempt for issue #468. Any thoughts and feedback are welcome