### PR TITLE
[CMake] Require only C bindings to MPI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,6 @@
 cmake_minimum_required(VERSION 3.14)
 project(AMReX)
+enable_language(C) # needed for find_package(MPI REQUIRED "C")
 enable_language(CXX)
 enable_language(Fortran)
 

--- a/Src/Base/CMakeLists.txt
+++ b/Src/Base/CMakeLists.txt
@@ -2,8 +2,8 @@ target_include_directories(amrex PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_D
 
 # MPI header is incapsulated in AMReX_ccse-mpi.H
 if (ENABLE_MPI)
-   find_package(MPI REQUIRED CXX)
-   target_link_libraries(amrex PUBLIC MPI::MPI_CXX) 
+   find_package(MPI REQUIRED C)
+   target_link_libraries(amrex PUBLIC MPI::MPI_C) 
 endif ()  
 
 target_sources( amrex

--- a/Tools/CMake/AMReXConfig.cmake.in
+++ b/Tools/CMake/AMReXConfig.cmake.in
@@ -86,7 +86,7 @@ set(AMREX_ENABLE_HYPRE              @ENABLE_HYPRE@)
 # Find dependencies if needed
 #
 if (AMREX_ENABLE_MPI)
-   set( _mpi_components CXX )
+   set( _mpi_components "C" )
    if (AMREX_ENABLE_FORTRAN_INTERFACES)
          set( _mpi_components "${_mpi_components} Fortran" )
    endif ()


### PR DESCRIPTION
AFAIK, `find_package(MPI REQUIRED CXX)` will fail if it can not find the (deprecated) C++ bindings for MPI. Since AMReX only uses the C interface of MPI a `find_package(MPI REQUIRED C)` call will be enough. **It has the drawback that consumer projects will need to enable the C language in their CMakeLists.**

