### PR TITLE
Expand section on building libamrex

### DIFF
--- a/Docs/sphinx_documentation/source/BuildingAMReX.rst
+++ b/Docs/sphinx_documentation/source/BuildingAMReX.rst
@@ -253,10 +253,40 @@ use AMReX, an external AMReX library can be created instead. In this approach, o
 runs ``./configure``, followed by ``make`` and ``make install``.
 Other make options include ``make distclean`` and ``make uninstall``.  In the top
 AMReX directory, one can run ``./configure -h`` to show the various options for
-the configure script. This approach is built on the AMReX GNU Make system. Thus
+the configure script. In particular, one can specify the installation path for the AMReX library using::
+
+  ./configure --prefix=[AMReX library path]
+
+This approach is built on the AMReX GNU Make system. Thus
 the section on :ref:`sec:build:make` is recommended if any fine tuning is
 needed.  The result of ``./configure`` is ``GNUmakefile`` in the AMReX
 top directory.  One can modify the make file for fine tuning.
+
+To compile an application code against the external AMReX library, it
+is necessary to set appropriate compiler flags and set the library
+paths for linking. To assist with this, when the AMReX library is
+built, a configuration file is created in ``[AMReX library path]/lib/pkgconfig/amrex.pc``.
+This file contains the Fortran and
+C++ flags used to compile the AMReX library as well as the appropriate
+library and include entries.
+
+The following sample GNU Makefile will compile a ``main.cpp`` source
+file against an external AMReX library, using the C++ flags and
+library paths used to build AMReX::
+
+  AMREX_LIBRARY_HOME ?= [AMReX library path]
+
+  LIBDIR := $(AMREX_LIBRARY_HOME)/lib
+  INCDIR := $(AMREX_LIBRARY_HOME)/include
+
+  COMPILE_CPP_FLAGS ?= $(shell awk '/Cflags:/ {$$1=$$2=""; print $$0}' $(LIBDIR)/pkgconfig/amrex.pc)
+  COMPILE_LIB_FLAGS ?= $(shell awk '/Libs:/ {$$1=$$2=""; print $$0}' $(LIBDIR)/pkgconfig/amrex.pc)
+
+  CFLAGS := -I$(INCDIR) $(COMPILE_CPP_FLAGS)
+  LFLAGS := -L$(LIBDIR) $(COMPILE_LIB_FLAGS)
+
+  all:
+          g++ -o main.exe main.cpp $(CFLAGS) $(LFLAGS)
 
 .. _sec:build:cmake:
 


### PR DESCRIPTION
This expands the docs section on building AMReX as a library with details about how to set the C++ compiler flags and linker flags for an application code.

Also includes a sample GNU Make file that extracts these flags from the package configuration file written when the AMReX library is compiled.
