### PR TITLE
Added function for checking RealBox equality

### DIFF
--- a/Src/Base/AMReX_RealBox.H
+++ b/Src/Base/AMReX_RealBox.H
@@ -127,6 +127,11 @@ std::ostream& operator<< (std::ostream&, const RealBox&);
 //! Nice ASCII input.
 std::istream& operator>> (std::istream&, RealBox&);
 
+// Check for equality of real boxes within a certain tolerance
+bool AlmostEqual (const RealBox& box1,
+                  const RealBox& box2,
+                  Real eps = std::numeric_limits<Real>::round_error()) noexcept;
+
 }
 
 #endif /*_RealBox_H_*/

--- a/Src/Base/AMReX_RealBox.H
+++ b/Src/Base/AMReX_RealBox.H
@@ -127,7 +127,7 @@ std::ostream& operator<< (std::ostream&, const RealBox&);
 //! Nice ASCII input.
 std::istream& operator>> (std::istream&, RealBox&);
 
-// Check for equality of real boxes within a certain tolerance
+//! Check for equality of real boxes within a certain tolerance
 bool AlmostEqual (const RealBox& box1,
                   const RealBox& box2,
                   Real eps = std::numeric_limits<Real>::round_error()) noexcept;

--- a/Src/Base/AMReX_RealBox.cpp
+++ b/Src/Base/AMReX_RealBox.cpp
@@ -78,4 +78,17 @@ operator >> (std::istream &is, RealBox& b)
     return is;
 }
 
+bool AlmostEqual (const RealBox& box1,
+                  const RealBox& box2,
+                  Real eps /* = std::numeric_limits<Real>::round_error() */) noexcept
+{
+    bool almostEqual = true;
+    for(int i = 0; i < AMREX_SPACEDIM && almostEqual; ++i)
+    {
+        almostEqual &= abs(box1.lo(i) - box2.lo(i)) < eps;
+        almostEqual &= abs(box1.hi(i) - box2.hi(i)) < eps;
+    }
+    return almostEqual;
+}
+
 }


### PR DESCRIPTION
Added the AlmostEqual function to the amrex namespace, which checks
that the domains represented by two real boxes are the same within a
tolerance.