### PR TITLE
Fix issues RealBox equality check

### DIFF
--- a/Src/Base/AMReX_RealBox.H
+++ b/Src/Base/AMReX_RealBox.H
@@ -95,7 +95,7 @@ public:
     //! Is the specified point contained in the RealBox?
     AMREX_GPU_HOST_DEVICE
     bool contains (const Real* point,
-                   Real eps = std::numeric_limits<Real>::round_error()) const noexcept {
+                   Real eps = std::numeric_limits<Real>::epsilon()) const noexcept {
         return  AMREX_D_TERM((xlo[0]-eps < point[0]) && (point[0] < xhi[0]+eps),
                           && (xlo[1]-eps < point[1]) && (point[1] < xhi[1]+eps),
                           && (xlo[2]-eps < point[2]) && (point[2] < xhi[2]+eps));
@@ -103,12 +103,12 @@ public:
 
     //! Is the specified RealVect contained in this RealBox?
     bool contains (const RealVect& rv,
-                   Real eps=std::numeric_limits<Real>::round_error()) const noexcept { return contains(rv.dataPtr(), eps); }
+                   Real eps=std::numeric_limits<Real>::epsilon()) const noexcept { return contains(rv.dataPtr(), eps); }
 
     //! Is the specified RealBox contained in this RealBox?
     AMREX_GPU_HOST_DEVICE
     bool contains (const RealBox& rb,
-                   Real eps = std::numeric_limits<Real>::round_error()) const noexcept {
+                   Real eps = std::numeric_limits<Real>::epsilon()) const noexcept {
         return contains(rb.xlo, eps) && contains(rb.xhi, eps);
     }
 
@@ -138,7 +138,7 @@ std::istream& operator>> (std::istream&, RealBox&);
 //! Check for equality of real boxes within a certain tolerance
 bool AlmostEqual (const RealBox& box1,
                   const RealBox& box2,
-                  Real eps = std::numeric_limits<Real>::round_error()) noexcept;
+                  Real eps = std::numeric_limits<Real>::epsilon()) noexcept;
 
 }
 

--- a/Src/Base/AMReX_RealBox.H
+++ b/Src/Base/AMReX_RealBox.H
@@ -95,7 +95,7 @@ public:
     //! Is the specified point contained in the RealBox?
     AMREX_GPU_HOST_DEVICE
     bool contains (const Real* point,
-                   Real eps = std::numeric_limits<Real>::epsilon()) const noexcept {
+                   Real eps = 0.0) const noexcept {
         return  AMREX_D_TERM((xlo[0]-eps < point[0]) && (point[0] < xhi[0]+eps),
                           && (xlo[1]-eps < point[1]) && (point[1] < xhi[1]+eps),
                           && (xlo[2]-eps < point[2]) && (point[2] < xhi[2]+eps));
@@ -103,12 +103,12 @@ public:
 
     //! Is the specified RealVect contained in this RealBox?
     bool contains (const RealVect& rv,
-                   Real eps=std::numeric_limits<Real>::epsilon()) const noexcept { return contains(rv.dataPtr(), eps); }
+                   Real eps=0.0) const noexcept { return contains(rv.dataPtr(), eps); }
 
     //! Is the specified RealBox contained in this RealBox?
     AMREX_GPU_HOST_DEVICE
     bool contains (const RealBox& rb,
-                   Real eps = std::numeric_limits<Real>::epsilon()) const noexcept {
+                   Real eps = 0.0) const noexcept {
         return contains(rb.xlo, eps) && contains(rb.xhi, eps);
     }
 
@@ -136,9 +136,11 @@ std::ostream& operator<< (std::ostream&, const RealBox&);
 std::istream& operator>> (std::istream&, RealBox&);
 
 //! Check for equality of real boxes within a certain tolerance
+//! Can use std::numeric_precision::epsilon() * abs(x + y) * ulps for inexact comparison
+//! See https://en.cppreference.com/w/cpp/types/numeric_limits/epsilon
 bool AlmostEqual (const RealBox& box1,
                   const RealBox& box2,
-                  Real eps = std::numeric_limits<Real>::epsilon()) noexcept;
+                  Real eps = 0.0) noexcept;
 
 }
 

--- a/Src/Base/AMReX_RealBox.cpp
+++ b/Src/Base/AMReX_RealBox.cpp
@@ -85,8 +85,8 @@ bool AlmostEqual (const RealBox& box1,
     bool almostEqual = true;
     for(int i = 0; i < AMREX_SPACEDIM && almostEqual; ++i)
     {
-        almostEqual = almostEqual && std::abs(box1.lo(i) - box2.lo(i)) < eps;
-        almostEqual = almostEqual && std::abs(box1.hi(i) - box2.hi(i)) < eps;
+        almostEqual = almostEqual && std::abs(box1.lo(i) - box2.lo(i)) <= eps;
+        almostEqual = almostEqual && std::abs(box1.hi(i) - box2.hi(i)) <= eps;
     }
     return almostEqual;
 }

--- a/Src/Base/AMReX_RealBox.cpp
+++ b/Src/Base/AMReX_RealBox.cpp
@@ -80,13 +80,13 @@ operator >> (std::istream &is, RealBox& b)
 
 bool AlmostEqual (const RealBox& box1,
                   const RealBox& box2,
-                  Real eps /* = std::numeric_limits<Real>::round_error() */) noexcept
+                  Real eps /* = std::numeric_limits<Real>::epsilon() */) noexcept
 {
     bool almostEqual = true;
     for(int i = 0; i < AMREX_SPACEDIM && almostEqual; ++i)
     {
-        almostEqual &= abs(box1.lo(i) - box2.lo(i)) < eps;
-        almostEqual &= abs(box1.hi(i) - box2.hi(i)) < eps;
+        almostEqual = almostEqual && std::abs(box1.lo(i) - box2.lo(i)) < eps;
+        almostEqual = almostEqual && std::abs(box1.hi(i) - box2.hi(i)) < eps;
     }
     return almostEqual;
 }

--- a/Src/Base/AMReX_RealBox.cpp
+++ b/Src/Base/AMReX_RealBox.cpp
@@ -80,7 +80,7 @@ operator >> (std::istream &is, RealBox& b)
 
 bool AlmostEqual (const RealBox& box1,
                   const RealBox& box2,
-                  Real eps /* = std::numeric_limits<Real>::epsilon() */) noexcept
+                  Real eps /* = 0.0 */) noexcept
 {
     bool almostEqual = true;
     for(int i = 0; i < AMREX_SPACEDIM && almostEqual; ++i)


### PR DESCRIPTION
This fixes the issues relating to #511. Doing exact comparison by default looks preferable to attempting to use std::numeric_precision::epsilon(), given the documentation [here](https://en.cppreference.com/w/cpp/types/numeric_limits/epsilon).