### PR TITLE
Fix case-sensitive bug in gpu_fortran.py preprocessor script.

### DIFF
--- a/Tools/F_scripts/gpu_fortran.py
+++ b/Tools/F_scripts/gpu_fortran.py
@@ -179,7 +179,7 @@ def append_device_to_line(line, subs):
                 new_line = case_insensitive_replace(new_line, sub_name, sub_name + '_device', 
                                                     on_condition=lambda x: get_replace_procedure(x, sub_name.lower()))
 
-            elif sub_name in line.lower() and sub_name + '_device' not in line.lower():
+            elif sub_name.lower() in line.lower() and sub_name.lower() + '_device' not in line.lower():
                 # Catch function calls here.
                 # Make sure "bar(" is not any of "foobar(" or "foo % bar(" or "foo_bar("
                 old_fun = sub_name.lower() + '('


### PR DESCRIPTION
This bug affected only users of the `gpu_fortran.py` preprocessor script.

Before this change, function and subroutine names in module `use` statements were read in the case they were written. When we looked for calls in the source, we compared these names to lowercase source lines without making the subroutine/function names lowercase as well. So this effectively required that subroutine and function names in the module use statements be written in lowercase.

We now search lowercase source lines for lowercase subroutine and function names agnostic to the case used in the original source.