### PR TITLE
CMake install step: make header modification more cross-platform

### DIFF
--- a/Tools/CMake/modify_installed_headers.cmake
+++ b/Tools/CMake/modify_installed_headers.cmake
@@ -1,4 +1,4 @@
-#
+r#
 # Add line #include<AMReX_Config.H> to all installed headers
 # 
 message(STATUS "Modifying installed headers")
@@ -6,7 +6,7 @@ file(GLOB _installed_headers "${CMAKE_INSTALL_PREFIX}/include/*.H")
 list(REMOVE_ITEM _installed_headers "${CMAKE_INSTALL_PREFIX}/include/AMReX_Config.H")
 
 foreach( _header IN LISTS _installed_headers)
-   # This command only affect the first line of each file. Therefore, it can be used countless
-   # times on the same file and it always gives the same result (i.e. it does not keep prepending)
-   execute_process(COMMAND bash "-c" "sed -i '1s/^/#include <AMReX_Config.H>\\n\\n/' ${_header}" )
+   file(READ ${_header} _contents)
+   string(PREPEND _contents "#include <AMReX_Config.H>\n")
+   file(WRITE ${_header} "${_contents}")
 endforeach()

--- a/Tools/CMake/modify_installed_headers.cmake
+++ b/Tools/CMake/modify_installed_headers.cmake
@@ -1,4 +1,4 @@
-r#
+#
 # Add line #include<AMReX_Config.H> to all installed headers
 # 
 message(STATUS "Modifying installed headers")
@@ -6,7 +6,27 @@ file(GLOB _installed_headers "${CMAKE_INSTALL_PREFIX}/include/*.H")
 list(REMOVE_ITEM _installed_headers "${CMAKE_INSTALL_PREFIX}/include/AMReX_Config.H")
 
 foreach( _header IN LISTS _installed_headers)
-   file(READ ${_header} _contents)
-   string(PREPEND _contents "#include <AMReX_Config.H>\n")
-   file(WRITE ${_header} "${_contents}")
+  file(READ ${_header} _contents)
+  # Regex looks for:
+  # - Anything before include guard
+  # - #ifndef CPP_IDENTIFIER
+  # - #define CPP_IDENTIFIER
+  # - Rest of file
+  if (_contents MATCHES "^(.*)#ifndef +([A-Za-z0-9_]+)\n#define +([A-Za-z0-9_]+) *\n(.+)")
+    # We have found an include guard
+    if (${CMAKE_MATCH_2} STREQUAL ${CMAKE_MATCH_3})
+      # The guard defines match and are hence OK
+    else()
+      message(FATAL_ERROR "Include guard is wrong up for header file ${_header}")
+    endif()
+
+    # Insert the #include <AMReX_Config.H> between include guard and the rest of the file
+    string(CONCAT "_contents" "${CMAKE_MATCH_1}" "#ifndef " "${CMAKE_MATCH_2}" "\n#define " "${CMAKE_MATCH_3}" "\n#include <AMReX_Config.H>\n" "${CMAKE_MATCH_4}")
+
+  else()
+    message(WARNING "No include guard in header ${_header}")
+    string(PREPEND _contents "#include <AMReX_Config.H>\n")
+  endif()
+  # Rewrite
+  file(WRITE ${_header} "${_contents}")
 endforeach()


### PR DESCRIPTION
This PR will close #524 

The install step of the CMake build uses `sed` to insert `#include <AMReX_Config.H>` at the top of the file. Since GNU sed and BSD sed have different behaviour this fails. Here I instead use pure CMake to do the same thing.

