### PR TITLE
Allow to create shallow IndexSpace's 

### DIFF
--- a/Src/EB/AMReX_EB2.H
+++ b/Src/EB/AMReX_EB2.H
@@ -58,6 +58,10 @@ class IndexSpaceImp
 {
 public:
 
+    IndexSpaceImp (const G& gshop, const Geometry& geom, const IntVect& refine_ratio,
+                   int required_coarsening_level, int max_coarsening_level,
+                   int ngrow);
+
     IndexSpaceImp (const G& gshop, const Geometry& geom,
                    int required_coarsening_level, int max_coarsening_level,
                    int ngrow);
@@ -78,7 +82,6 @@ public:
     using F = typename G::FunctionType;
 
 private:
-
     Vector<GShopLevel<G> > m_gslevel;
     Vector<Geometry> m_geom;
     Vector<Box> m_domain;
@@ -87,6 +90,19 @@ private:
 };
 
 #include <AMReX_EB2_IndexSpaceI.H>
+
+template <typename G>
+void
+Build (const G& gshop, const Geometry& geom, const IntVect& refine_ratio,
+       int required_coarsening_level, int max_coarsening_level,
+       int ngrow = 4)
+{
+    BL_PROFILE("EB2::Initialize()");
+    IndexSpace::push(new IndexSpaceImp<G>(gshop, geom, refine_ratio,
+                                          required_coarsening_level,
+                                          max_coarsening_level,
+                                          ngrow));
+}
 
 template <typename G>
 void

--- a/Src/EB/AMReX_EB2_IndexSpaceI.H
+++ b/Src/EB/AMReX_EB2_IndexSpaceI.H
@@ -59,7 +59,7 @@ IndexSpaceImp<G>::IndexSpaceImp (const G& gshop, const Geometry& geom,
                                  int required_coarsening_level,
                                  int max_coarsening_level,
                                  int ngrow) 
-                                : IndexSpaceImp(ghost, geom, IntVect(2), required_coarsening_level, max_coarsening_level, ngrow)
+                                : IndexSpaceImp(gshop, geom, IntVect(2), required_coarsening_level, max_coarsening_level, ngrow)
                                  {}
 
 template <typename G>

--- a/Src/EB/AMReX_EB2_IndexSpaceI.H
+++ b/Src/EB/AMReX_EB2_IndexSpaceI.H
@@ -1,6 +1,6 @@
 
 template <typename G>
-IndexSpaceImp<G>::IndexSpaceImp (const G& gshop, const Geometry& geom,
+IndexSpaceImp<G>::IndexSpaceImp (const G& gshop, const Geometry& geom, const IntVect& refine_ratio,
                                  int required_coarsening_level,
                                  int max_coarsening_level,
                                  int ngrow)
@@ -23,7 +23,7 @@ IndexSpaceImp<G>::IndexSpaceImp (const G& gshop, const Geometry& geom,
 
     for (int ilev = 1; ilev <= max_coarsening_level; ++ilev)
     {
-        bool coarsenable = m_geom.back().Domain().coarsenable(2,2);
+        bool coarsenable = m_geom.back().Domain().coarsenable(refine_ratio,2);
         if (!coarsenable) {
             if (ilev <= required_coarsening_level) {
                 amrex::Abort("IndexSpaceImp: domain is not coarsenable at level "+std::to_string(ilev));
@@ -34,8 +34,8 @@ IndexSpaceImp<G>::IndexSpaceImp (const G& gshop, const Geometry& geom,
 
         int ng = (ilev > required_coarsening_level) ? 0 : m_ngrow.back()/2;
 
-        Box cdomain = amrex::coarsen(m_geom.back().Domain(),2);
-        Geometry cgeom = amrex::coarsen(m_geom.back(),2);
+        Box cdomain = amrex::coarsen(m_geom.back().Domain(), refine_ratio);
+        Geometry cgeom = amrex::coarsen(m_geom.back(), refine_ratio);
         m_gslevel.emplace_back(this, ilev, EB2::max_grid_size, ng, cgeom, m_gslevel[ilev-1]);
         if (!m_gslevel.back().isOK()) {
             m_gslevel.pop_back();
@@ -53,6 +53,14 @@ IndexSpaceImp<G>::IndexSpaceImp (const G& gshop, const Geometry& geom,
     m_impfunc.reset(new F(gshop.GetImpFunc()));
 }
 
+
+template <typename G>
+IndexSpaceImp<G>::IndexSpaceImp (const G& gshop, const Geometry& geom,
+                                 int required_coarsening_level,
+                                 int max_coarsening_level,
+                                 int ngrow) 
+                                : IndexSpaceImp(ghost, geom, IntVect(2), required_coarsening_level, max_coarsening_level, ngrow)
+                                 {}
 
 template <typename G>
 const Level&

--- a/Src/EB/AMReX_EB2_IndexSpaceI.H
+++ b/Src/EB/AMReX_EB2_IndexSpaceI.H
@@ -23,7 +23,7 @@ IndexSpaceImp<G>::IndexSpaceImp (const G& gshop, const Geometry& geom, const Int
 
     for (int ilev = 1; ilev <= max_coarsening_level; ++ilev)
     {
-        bool coarsenable = m_geom.back().Domain().coarsenable(refine_ratio,2);
+        bool coarsenable = m_geom.back().Domain().coarsenable(refine_ratio);
         if (!coarsenable) {
             if (ilev <= required_coarsening_level) {
                 amrex::Abort("IndexSpaceImp: domain is not coarsenable at level "+std::to_string(ilev));


### PR DESCRIPTION
Currently, it is not possible to create "thin" IndexSpaces with multiple refinement levels because of a `coarsenable` restriction. These changes enable me to use it as in the example

```cpp
  const int n_cells = 128;
  const std::array<double, 2> xlower{0.0, 0.0};
  const std::array<double, 2> xupper{+1.0, +0.03};
  const std::array<int, 2> periodicity{0, 0};

  const amrex::RealBox xbox(xlower, xupper);
  const amrex::Box domain({0, 0}, {n_cells - 1, 0});

  const amrex::IntVect refine_ratio{2, 1};

  amrex::Geometry geom(domain, &xbox, -1, periodicity.data());
  geom.refine(refine_ratio);
  auto all_regular = amrex::EB2::makeShop(amrex::EB2::AllRegularIF());
  amrex::EB2::Build(all_regular, geom, refine_ratio, 1, 1);
```

The most relevant change is from

```cpp
bool coarsenable = m_geom.back().Domain().coarsenable(2,2);
```

to

```cpp
bool coarsenable = m_geom.back().Domain().coarsenable(refine_ratio);
```

as it might change its meaning. What do you think?