### PR TITLE
Development

### DIFF
--- a/Src/AmrCore/AMReX_INTERP_2D.F90
+++ b/Src/AmrCore/AMReX_INTERP_2D.F90
@@ -58,52 +58,29 @@ contains
       real(amrex_real)  strip(strip_lo:strip_hi)
 
 
-#define SLX 1
-#define SLY 2
-#define SLXY 3
-
       integer lx, ly, hratx, hraty, ic, jc, jfn, jfc, i, n
-      real(amrex_real) x, y, denomx, denomy, su, xt, xb, yt, yb
+      real(amrex_real) x, y, denomx, denomy, xt, xb
 
-      denomx = 1._amrex_real/real(2*lratiox,amrex_real)
-      denomy = 1._amrex_real/real(2*lratioy,amrex_real)
-
-    !  denomx = 1./dble(2*lratiox)
-    !  denomy = 1./dble(2*lratioy)
+      denomx = one/real(2*lratiox,amrex_real)
+      denomy = one/real(2*lratioy,amrex_real)
 
       hratx = lratiox/2
       hraty = lratioy/2
 
       do n = 1, nvar
          do jc = cb_l2, cb_h2-1 
-
-            do ic = cb_l1, cb_h1-1
-               sl(ic,SLX) = crse(ic+1,jc,n)-crse(ic,jc,n)
-               sl(ic,SLY) = crse(ic,jc+1,n)-crse(ic,jc,n) 
-               sl(ic,SLXY) = (crse(ic+1,jc+1,n)-crse(ic+1,jc,n)) + (- crse(ic  ,jc+1,n)+crse(ic  ,jc,n))
-            end do
-
             do ly = 0, lratioy-1 
                jfn = jc*lratioy + ly
                jfc = jfn + hraty
                if (jfc .ge. fb_l2  .and.  jfc .le. fb_h2) then
-                  y = denomy*(2._amrex_real*real(ly,amrex_real) + 1._amrex_real)
+                  y = denomy*(two*real(ly,amrex_real) + one)
                   do lx = 0, lratiox-1
                      do ic = cb_l1, cb_h1-1
                         i = ic*lratiox + lx
-                        x = denomx*(2._amrex_real*real(lx,amrex_real) + 1._amrex_real)
-                        xB = crse(ic,jc,n) + x*(crse(ic+1,jc,n)-crse(ic,jc,n))
+                        x = denomx*(two*real(lx,amrex_real) + one)
+                        xB = crse(ic,jc,  n) + x*(crse(ic+1,jc,  n)-crse(ic,jc,  n))
                         xT = crse(ic,jc+1,n) + x*(crse(ic+1,jc+1,n)-crse(ic,jc+1,n))
                         strip(i) = XB + y*(XT - XB)
-
-                        strip(i) = crse(ic,jc,n) + x*sl(ic,SLX) + &
-                                   y*sl(ic,SLY) + x*y*sl(ic,SLXY)
-
-                       !  yB = crse(ic,jc,n) + y*(crse(ic,jc+1,n)-crse(ic,jc,n))
-                       !  yT = crse(ic+1,jc,n) + y*(crse(ic+1,jc+1,n)-crse(ic+1,jc,n))
-                       !  strip(i) = YB + x*(YT - YB)
-                         !strip(i) = crse(ic,jc,n) + x*(crse(ic+1,jc,n)-crse(ic,jc,n)) + y*(crse(ic,jc+1,n)-crse(ic,jc,n)) + &
-                         !           x*y*((crse(ic+1,jc+1,n) - crse(ic,jc+1,n)) - (crse(ic+1,jc,n) - crse(ic,jc,n)))
                      end do
                   end do
                   do i = fb_l1, fb_h1 
@@ -116,9 +93,6 @@ contains
 
     end subroutine AMREX_CBINTERP
 
-#undef  SLX
-#undef  SLY
-#undef  SLXY
 
      subroutine AMREX_CQINTERP (fine, fine_l1,fine_l2,fine_h1,fine_h2, &
                                fb_l1, fb_l2, fb_h1, fb_h2, &

--- a/Src/AmrCore/AMReX_INTERP_3D.F90
+++ b/Src/AmrCore/AMReX_INTERP_3D.F90
@@ -76,7 +76,7 @@ contains
                kfn = kc*lratioz + lz
                kfc = kfn + hratz
                if (kfc .ge. fb_l3 .and. kfc .le. fb_h3) then
-                  z = denomz*(two*real(ly,amrex_real) + one)
+                  z = denomz*(two*real(lz,amrex_real) + one)
                   do ly = 0, lratioy-1
                      jfn = jc*lratioy + ly
                      jfc = jfn + hraty

--- a/Src/AmrCore/AMReX_INTERP_3D.F90
+++ b/Src/AmrCore/AMReX_INTERP_3D.F90
@@ -57,20 +57,13 @@ contains
       real(amrex_real) strip(strip_lo:strip_hi)
       real(amrex_real) sl(cb_l1:cb_h1, num_slp)
 
-#define SLX 1
-#define SLY 2
-#define SLZ 3
-#define SLXY 4
-#define SLXZ 5
-#define SLYZ 6
-#define SLXYZ 7
-
       integer lx, ly, lz, hratx, hraty, hratz, ic, jc, kc, jfn, jfc, kfn, kfc, i, n
       real(amrex_real) x, y, z, denomx, denomy, denomz
+      real(amrex_real) cx00, cx01, cx10, cx11, cy0, cy1
 
-      denomx = one/dble(2*lratiox)
-      denomy = one/dble(2*lratioy)
-      denomz = one/dble(2*lratioz)
+      denomx = one/real(2*lratiox,amrex_real)
+      denomy = one/real(2*lratioy,amrex_real)
+      denomz = one/real(2*lratioz,amrex_real)
 
       hratx = lratiox/2
       hraty = lratioy/2
@@ -79,41 +72,31 @@ contains
       do n = 1, nvar
          do kc = cb_l3, cb_h3-1
          do jc = cb_l2, cb_h2-1
-            do ic = cb_l1, cb_h1-1
-               sl(ic,SLX  ) = crse(ic+1,jc,  kc,  n)-crse(ic,  jc,  kc,  n)
-               sl(ic,SLY  ) = crse(ic,  jc+1,kc,  n)-crse(ic,  jc,  kc,  n)
-               sl(ic,SLZ  ) = crse(ic,  jc,  kc+1,n)-crse(ic,  jc,  kc,  n)
-               sl(ic,SLXY ) = crse(ic+1,jc+1,kc,  n)-crse(ic+1,jc,  kc,  n) &
-                            - crse(ic  ,jc+1,kc,  n)+crse(ic  ,jc,  kc,  n)
-               sl(ic,SLXZ ) = crse(ic+1,jc,  kc+1,n)-crse(ic+1,jc,  kc,  n) &
-                            - crse(ic,  jc,  kc+1,n)+crse(ic,  jc,  kc,  n)
-               sl(ic,SLYZ ) = crse(ic,  jc+1,kc+1,n)-crse(ic,  jc,  kc+1,n) &
-                            - crse(ic  ,jc+1,kc,  n)+crse(ic  ,jc,  kc,  n)
-               sl(ic,SLXYZ) = crse(ic+1,jc,  kc,  n)+crse(ic,  jc+1,kc,  n) &
-                            + crse(ic,  jc,  kc+1,n)-crse(ic,  jc+1,kc+1,n) &
-                            - crse(ic+1,jc,  kc+1,n)-crse(ic+1,jc+1,kc,  n) &
-                            + crse(ic+1,jc+1,kc+1,n)-crse(ic,  jc,  kc,  n)
-
-            end do
-
             do lz = 0, lratioz-1
                kfn = kc*lratioz + lz
                kfc = kfn + hratz
                if (kfc .ge. fb_l3 .and. kfc .le. fb_h3) then
-                  z = denomz*(two*lz + one)
+                  z = denomz*(two*real(ly,amrex_real) + one)
                   do ly = 0, lratioy-1
                      jfn = jc*lratioy + ly
                      jfc = jfn + hraty
                      if (jfc .ge. fb_l2  .and.  jfc .le. fb_h2) then
-                        y = denomy*(two*ly + one)
+                        y = denomy*(two*real(ly,amrex_real) + one)
                         do lx = 0, lratiox-1
                            do ic = cb_l1, cb_h1-1
                               i = ic*lratiox + lx
-                              x = denomx*(two*lx + one)
-                              strip(i) = crse(ic,jc,kc,n) +     x*sl(ic,SLX  ) + &
-                                           y*sl(ic,SLY )  +     z*sl(ic,SLZ  ) + &
-                                         x*y*sl(ic,SLXY)  +   x*z*sl(ic,SLXZ ) + &
-                                         y*z*sl(ic,SLYZ)  + x*y*z*sl(ic,SLXYZ)
+                              x = denomx*(two*real(lx,amrex_real)+ one)
+
+                              cx00 = crse(ic,jc  ,kc  ,n) + x*(crse(ic+1,jc  ,kc  ,n) - crse(ic,jc  ,kc  ,n))
+                              cx10 = crse(ic,jc+1,kc  ,n) + x*(crse(ic+1,jc+1,kc  ,n) - crse(ic,jc+1,kc  ,n))
+                              cx01 = crse(ic,jc  ,kc+1,n) + x*(crse(ic+1,jc  ,kc+1,n) - crse(ic,jc,  kc+1,n))
+                              cx11 = crse(ic,jc+1,kc+1,n) + x*(crse(ic+1,jc+1,kc+1,n) - crse(ic,jc+1,kc+1,n))
+
+                              cy0 = cx00 + y*(cx10 - cx00)
+                              cy1 = cx01 + y*(cx11 - cx01)
+
+                              strip(i) = cy0 + z*(cy1 - cy0)
+
                            end do
                         end do
                         do i = fb_l1, fb_h1


### PR DESCRIPTION
Fixed a strange issue with the AMReX Bilinear interp with Intel comp.

We were setting up a 1D simulation with a 2D grid (a planar methane-air flame) which should produce a transverse velocity of 0.  However, we found that there were significant transverse velocity fluctuations that grew to ~5 m/s and severely distorted the flame which should remain perfectly planar.  We fixed a few things with our code, but the root problem still persisted.  We noticed that the instability started at coarse-fine boundaries and did not occur with cell_cons_interp or pc_interp. Furthermore, we noticed that this only occurred with the compiler with DEBUG=FALSE.  The GNU compiler or Intel with DEBUG=TRUE did not cause this problem. 

We resolved the issue the changing the linear interpolation formulas from the compact formulation to the style that a student would perform with interpolating tables. We first interpolate along x-lines, then interpolate that data along the y-direction, and get the final interpolation by interpolating the y-results in the z-direction. The resulting algorithm is identical to the existing method (a little less efficient), but is mathematically identical.  For whatever reason, this makes the Intel compiler happier.  

We verified this against the Advection_AmrCore tutorial in 2D and 3D. 
