### PR TITLE
Make sure Vector bounds check catches negative indices.

### DIFF
--- a/Src/Base/AMReX_Vector.H
+++ b/Src/Base/AMReX_Vector.H
@@ -36,13 +36,13 @@ public:
 
     T& operator[] (std::size_t i) noexcept
     {
-	BL_ASSERT(static_cast<long>(i) < this->size() && static_cast<long>(i) >= 0);
+      BL_ASSERT( i < (this->std::vector<T, Allocator>::size()) );
 	return this->std::vector<T, Allocator>::operator[](i);
     }
 
     const T& operator[] (std::size_t i) const noexcept
     {
-	BL_ASSERT(static_cast<long>(i) < this->size() && static_cast<long>(i) >= 0);
+      BL_ASSERT( i < (this->std::vector<T, Allocator>::size()) );
 	return this->std::vector<T, Allocator>::operator[](i);
     }
 

--- a/Src/Base/AMReX_Vector.H
+++ b/Src/Base/AMReX_Vector.H
@@ -36,13 +36,13 @@ public:
 
     T& operator[] (std::size_t i) noexcept
     {
-	BL_ASSERT(static_cast<long>(i) < this->size());
+	BL_ASSERT(static_cast<long>(i) < this->size() && static_cast<long>(i) >= 0);
 	return this->std::vector<T, Allocator>::operator[](i);
     }
 
     const T& operator[] (std::size_t i) const noexcept
     {
-	BL_ASSERT(static_cast<long>(i) < this->size());
+	BL_ASSERT(static_cast<long>(i) < this->size() && static_cast<long>(i) >= 0);
 	return this->std::vector<T, Allocator>::operator[](i);
     }
 


### PR DESCRIPTION
in looking at a case of vector[-1] (which didn't throw an error for the debug build), I found 
	std::cout<<" i = "<<i<<"\n";
	std::cout<<" cast i = "<<(static_cast<long>(i))<<"\n";
gives 
        i = 18446744073709551615
        cast i = -1
