### PR TITLE
Tools: update compiler flags for Cray compiler v9

### DIFF
--- a/Tools/GNUMake/comps/cray.mak
+++ b/Tools/GNUMake/comps/cray.mak
@@ -13,36 +13,60 @@ F90FLAGS =
 
 ########################################################################
 
-cray_version = $(shell $(CXX) -V 2>&1 | grep 'Version')
-
-COMP_VERSION = $(cray_version)
+# CRAY_CC_VERSION is defined by the 'cce' module. Starting with CCE 9, Cray
+# changed the C and C++ compilers to clang/LLVM based, so all of the
+# options/flags for those compilers changed. But the Cray Fortran compiler is
+# still based on CCE 8 and so it has the same options as before.
+COMP_VERSION = $(shell echo $(CRAY_CC_VERSION) | cut -f 1 -d .)
 
 ########################################################################
 
 ifeq ($(DEBUG),TRUE)
 
-  GENERIC_COMP_FLAGS += -K trap=fp
+  ifeq ($(COMP_VERSION),9)
+    CXXFLAGS += -g -O0
+    CFLAGS   += -g -O0
+    FFLAGS   += -g -O0 -e i -K trap=fp
+    F90FLAGS += -g -O0 -e i -K trap=fp
+  else
+    GENERIC_COMP_FLAGS += -K trap=fp
 
-  CXXFLAGS += -g -O0
-  CFLAGS   += -g -O0
-  FFLAGS   += -g -O0 -e i
-  F90FLAGS += -g -O0 -e i
+    CXXFLAGS += -g -O0
+    CFLAGS   += -g -O0
+    FFLAGS   += -g -O0 -e i
+    F90FLAGS += -g -O0 -e i
+  endif
 
 else
+  ifeq ($(COMP_VERSION),9)
+    # The LLVM optimizer is not as aggressive as the native Cray optimizer from
+    # CCE <= 8. So we adjust some flags to achieve similar optimization. See
+    # this page:
+    # http://pubs.cray.com/content/S-5212/9.0/cray-compiling-environment-cce-release-overview/cce-900-software-enhancements
+    CXXFLAGS += -O2 -ffast-math -fsave-loopmark -fsave-decompile
+    CFLAGS   += -O2 -ffast-math -fsave-loopmark -fsave-decompile
+    FFLAGS   += -O2 -h list=a
+    F90FLAGS += -O2 -h list=a
+  else
+    GENERIC_COMP_FLAGS += -h list=a
 
-  GENERIC_COMP_FLAGS += -h list=a
-
-  CXXFLAGS += -O2
-  CFLAGS   += -O2
-  FFLAGS   += -O2
-  F90FLAGS += -O2
+    CXXFLAGS += -O2
+    CFLAGS   += -O2
+    FFLAGS   += -O2
+    F90FLAGS += -O2
+  endif
 
 endif
 
 ########################################################################
 
-CXXFLAGS += -h std=c++11
-CFLAGS   += -h c99
+ifeq ($(COMP_VERSION),9)
+  CXXFLAGS += -std=c++11
+  CFLAGS   += -std=c99
+else
+  CXXFLAGS += -h std=c++11
+  CFLAGS   += -h c99
+endif
 
 F90FLAGS += -N 255 -em
 FFLAGS   += -N 255 -em
@@ -51,12 +75,32 @@ FMODULES = -I $(fmoddir) -J $(fmoddir)
 
 ########################################################################
 
-ifneq ($(USE_OMP),TRUE)
-  GENERIC_COMP_FLAGS += -h noomp
+ifeq ($(USE_OMP),TRUE)
+  # Starting in CCE 9, OpenMP is disabled by default in each of C/C++/Fortran
+  # compilers.
+  ifeq ($(COMP_VERSION),9)
+    CXXFLAGS += -fopenmp
+    CFLAGS   += -fopenmp
+    FFLAGS   += -h omp
+    F90FLAGS += -h omp
+  else
+    GENERIC_COMP_FLAGS += -h omp
+  endif
+else
+  ifneq ($(COMP_VERSION),9)
+    GENERIC_COMP_FLAGS += -h noomp
+  endif
 endif
 
-ifneq ($(USE_ACC),TRUE)
-  GENERIC_COMP_FLAGS += -h noacc
+ifeq ($(USE_ACC),TRUE)
+  # OpenACC is removed from CCE altogether in CCE 9.
+  ifeq ($(COMP_VERSION),9)
+    $(error OpenACC has been removed from CCE 9.)
+  endif
+else
+  ifneq ($(COMP_VERSION),9)
+    GENERIC_COMP_FLAGS += -h noacc
+  endif
 endif
 
 CXXFLAGS += $(GENERIC_COMP_FLAGS)


### PR DESCRIPTION
In CCE 9, Cray overhauled their C/C++ compilers and moved to clang/LLVM, so the
flags for C/C++ compilers are totally different than in previous versions of
CCE. Confusingly, the Fortran compiler was *not* changed significantly in CCE
9, so its flags are the same as before. As a result, we need some more complex
logic to get the right flags for the right version of CCE.