### PR TITLE
Use ++ to prefix makebuildinfo_C.py arguments.

### DIFF
--- a/Tools/CMake/AMReXBuildInfo.cmake
+++ b/Tools/CMake/AMReXBuildInfo.cmake
@@ -19,9 +19,9 @@ of the python script "makebuildinfo_C.py" located in
 AMReXBuildInfo.cpp has to be created by the build system once all the
 details of the build are known.
 
-This module 
+This module
 
-* sets internal variables AMREX_C_SCRIPTS_DIR, AMREX_MAKEBUILD_SCRIPT, 
+* sets internal variables AMREX_C_SCRIPTS_DIR, AMREX_MAKEBUILD_SCRIPT,
   and AMREX_TOP_DIR
 
 * provides function "generate_buildinfo(_target _git_dir)"
@@ -30,10 +30,10 @@ This module
 
 #
 # This include brings in function "get_target_properties_flattened()"
-# 
+#
 include(AMReXTargetHelpers)
 
-# 
+#
 # Set paths
 #
 string(REPLACE "CMake" "C_scripts" AMREX_C_SCRIPTS_DIR ${CMAKE_CURRENT_LIST_DIR})
@@ -56,21 +56,21 @@ set( AMREX_TOP_DIR ${AMREX_TOP_DIR} CACHE INTERNAL "Path to AMReX' dir")
 #
 # If the keyword REQUIRED is passed in, the function will issue
 # an error if Pyhon >=2.7 cannot be found.
-# 
+#
 macro (generate_buildinfo _target _git_dir)
-   
+
    cmake_parse_arguments("_arg" "REQUIRED" "" "" ${ARGN})
 
-   # 
+   #
    # check if _target is a valid target
-   # 
+   #
    if (NOT TARGET ${_target} )
       message(FATAL_ERROR "Target ${_target} does not exists")
    endif ()
-   
+
    #
    # Look for python
-   # 
+   #
    find_package(Python)
 
    # If Python >= 2.7 is available, generate AMReX_BuildInfo.cpp
@@ -85,15 +85,15 @@ macro (generate_buildinfo _target _git_dir)
       set(_lang CXX Fortran)
       set(_prop _includes _defines _flags _link_line )
 
-      # Loop over all combinations of language and property and extract 
-      # what you need 
+      # Loop over all combinations of language and property and extract
+      # what you need
       foreach( _p IN LISTS _prop )
          foreach( _l IN LISTS _lang )
 
             string(TOLOWER ${_l} _ll) # Lower case language name
 
             # _${_ll}${_p} is a variable named as _lang_property,
-            # both lower case. 
+            # both lower case.
             evaluate_genex(${_p} _${_ll}${_p}
                LANG ${_l}
                COMP ${CMAKE_${_l}_COMPILER_ID}
@@ -103,25 +103,25 @@ macro (generate_buildinfo _target _git_dir)
             if (_${_ll}${_p})
 
                list(REMOVE_DUPLICATES _${_ll}${_p})
-               
+
                if ("${_p}" STREQUAL "_defines")
                   string(REPLACE ";" " -D" _${_ll}${_p} "-D${_${_ll}${_p}}")
                elseif ("${_p}" STREQUAL "_includes")
                   string(REPLACE ";" " -I" _${_ll}${_p} "-I${_${_ll}${_p}}")
                else()
                   string(REPLACE ";" " " _${_ll}${_p} "${_${_ll}${_p}}")
-               endif ()              
+               endif ()
 
             endif ()
-            
+
          endforeach()
       endforeach ()
-      
+
       unset(_ll)
 
       string(TOUPPER ${CMAKE_BUILD_TYPE} _ubuild_type)
       set(_cxx_flags "${CMAKE_CXX_FLAGS_${_ubuild_type}} ${CMAKE_CXX_FLAGS} ${_cxx_flags}")
-      set(_fortran_flags "${CMAKE_Fortran_FLAGS_${_ubuild_type}} ${CMAKE_Fortran_FLAGS} ${_fortran_flags}")     
+      set(_fortran_flags "${CMAKE_Fortran_FLAGS_${_ubuild_type}} ${CMAKE_Fortran_FLAGS} ${_fortran_flags}")
 
       # Prep GIT info to feed to build info script
       set(_git_cmd)
@@ -131,29 +131,29 @@ macro (generate_buildinfo _target _git_dir)
             set(_git_cmd  "${_git_cmd} ${AMREX_TOP_DIR}")
          endif ()
          set(_git_cmd --GIT "${_git_cmd}")
-      endif ()  
-      
+      endif ()
+
       add_custom_command(
          COMMAND ${Python_EXECUTABLE} ${AMREX_C_SCRIPTS_DIR}/${AMREX_MAKEBUILD_SCRIPT}
-                 --amrex_home ${AMREX_TOP_DIR}    
+                 ++amrex_home ${AMREX_TOP_DIR}
                  #  CXX
-                 --COMP ${CMAKE_CXX_COMPILER_ID}
-                 --COMP_VERSION ${CMAKE_CXX_COMPILER_VERSION}
-                 --CXX_comp_name ${CMAKE_CXX_COMPILER}
-                 --CXX_flags "${_cxx_defines} ${_cxx_includes} ${_cxx_flags}"
+                 ++COMP ${CMAKE_CXX_COMPILER_ID}
+                 ++COMP_VERSION ${CMAKE_CXX_COMPILER_VERSION}
+                 ++CXX_comp_name ${CMAKE_CXX_COMPILER}
+                 ++CXX_flags "${_cxx_defines} ${_cxx_includes} ${_cxx_flags}"
                  # Fortran
-                 --FCOMP ${CMAKE_Fortran_COMPILER_ID}
-                 --FCOMP_VERSION ${CMAKE_Fortran_COMPILER_VERSION}
-                 --F_comp_name ${CMAKE_Fortran_COMPILER}
-                 --F_flags "${_fortran_defines} ${_fortran_includes} ${_fortran_flags}"
+                 ++FCOMP ${CMAKE_Fortran_COMPILER_ID}
+                 ++FCOMP_VERSION ${CMAKE_Fortran_COMPILER_VERSION}
+                 ++F_comp_name ${CMAKE_Fortran_COMPILER}
+                 ++F_flags "${_fortran_defines} ${_fortran_includes} ${_fortran_flags}"
                  #--link_flags
-                 --libraries "${_cxx_link_line}"
+                 ++libraries "${_cxx_link_line}"
                  # GIT
-                 ${_git_cmd}                 
+                 ${_git_cmd}
          OUTPUT AMReX_buildInfo.cpp
          WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
          COMMENT "Generating AMReX_buildInfo.cpp" )
-      
+
       target_sources( ${_target}
          PRIVATE
          ${CMAKE_CURRENT_BINARY_DIR}/AMReX_buildInfo.cpp
@@ -179,23 +179,23 @@ macro (generate_buildinfo _target _git_dir)
 
       foreach( _p IN LISTS _prop)
          foreach(_l IN LISTS _lang)
-            unset(_${_ll}${_p})           
+            unset(_${_ll}${_p})
          endforeach()
       endforeach ()
 
       unset(_prop)
       unset(_lang)
-      
+
    else ()
-      
+
       if (_arg_REQUIRED)
          message(FATAL_ERROR "Cannot find Python > 2.7")
       else ()
          message(WARNING "Cannot find Python > 2.7: skipping generation of build info")
       endif ()
-      
+
    endif ()
 
    unset(_arg_REQUIRED)
-   
+
 endmacro ()

--- a/Tools/C_scripts/makebuildinfo_C.py
+++ b/Tools/C_scripts/makebuildinfo_C.py
@@ -194,60 +194,60 @@ def get_git_hash(d):
 
 if __name__ == "__main__":
 
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(prefix_chars="+")
 
-    parser.add_argument("--amrex_home", help="path to the AMReX source",
+    parser.add_argument("++amrex_home", help="path to the AMReX source",
                         type=str, default="")
 
-    parser.add_argument("--COMP",
+    parser.add_argument("++COMP",
                         help="Compiler system defined in AMReX's build system",
                         type=str, default="")
 
-    parser.add_argument("--COMP_VERSION", help="Compiler version",
+    parser.add_argument("++COMP_VERSION", help="Compiler version",
                         type=str, default="")
 
-    parser.add_argument("--CXX_comp_name",
+    parser.add_argument("++CXX_comp_name",
                         help="C++ compiler command", type=str, default="")
 
-    parser.add_argument("--CXX_flags",
+    parser.add_argument("++CXX_flags",
                         help="C++ compiler flags", type=str, default="")
 
-    parser.add_argument("--FCOMP",
+    parser.add_argument("++FCOMP",
                         help="Fortran compiler as defined by AMReX's build system (deprecated)",
                         type=str, default="")
 
-    parser.add_argument("--FCOMP_VERSION",
+    parser.add_argument("++FCOMP_VERSION",
                         help="Fortran compiler version (deprecated)",
                         type=str, default="")
 
-    parser.add_argument("--F_comp_name", help="Fortran compiler command",
+    parser.add_argument("++F_comp_name", help="Fortran compiler command",
                         type=str, default="")
 
-    parser.add_argument("--F_flags", help="Fortran compiler flags",
+    parser.add_argument("++F_flags", help="Fortran compiler flags",
                         type=str, default="")
 
-    parser.add_argument("--link_flags", help="linker flags", type=str, default="")
+    parser.add_argument("++link_flags", help="linker flags", type=str, default="")
 
-    parser.add_argument("--libraries", help="libraries linked", type=str, default="")
+    parser.add_argument("++libraries", help="libraries linked", type=str, default="")
 
-    parser.add_argument("--AUX",
+    parser.add_argument("++AUX",
                         help="auxillary information (EOS, network path) (deprecated)",
                         type=str, default="")
 
-    parser.add_argument("--MODULES",
+    parser.add_argument("++MODULES",
                        help="module information in the form of key=value (e.g., EOS=helmeos)",
                        type=str, default="")
 
-    parser.add_argument("--GIT",
+    parser.add_argument("++GIT",
                         help="the directories whose git hashes we should capture",
                         type=str, default="")
 
 
-    parser.add_argument("--build_git_name",
+    parser.add_argument("++build_git_name",
                         help="the name of the build directory if different from the main source -- we'll get the git hash of this.",
                         type=str, default="")
 
-    parser.add_argument("--build_git_dir",
+    parser.add_argument("++build_git_dir",
                         help="the full path to the build directory that corresponds to build_git_name",
                         type=str, default="")
 


### PR DESCRIPTION
To support arg values starting with -, e.g. --libaries -pthread