### PR TITLE
Tools/GNUMake - Add Australian machines

### DIFF
--- a/Tools/GNUMake/Make.machines
+++ b/Tools/GNUMake/Make.machines
@@ -1,4 +1,4 @@
-# This file defines which_site and which_computer. 
+# This file defines which_site and which_computer.
 # Thus this decides which Make.$(which_site) file is included by Make.defs.
 
 which_site := unknown
@@ -113,4 +113,14 @@ endif
 ifeq ($(findstring daint, $(host_name)), daint)
   which_site := cscs
   which_computer := daint
+endif
+
+ifeq ($(findstring magnus, $(host_name)), magnus)
+  which_site := pawsey
+  which_computer := magnus
+endif
+
+ifeq ($(findstring raijin, $(host_name)), raijin)
+  which_site := nci
+  which_computer := raijin
 endif

--- a/Tools/GNUMake/sites/Make.nci
+++ b/Tools/GNUMake/sites/Make.nci
@@ -1,0 +1,72 @@
+#
+# For NCI machines: Raijin
+#
+
+# Set the default node architecture to NONE
+NCI_NODE_ARCH ?= NONE
+NCI_NODE_ARCHS := SANDYBRIDGE BROADWELL SKYLAKE SKYLAKE-512 SKYLAKE-512-ZMM KNL
+
+ifneq ($(which_computer),$(filter $(which_computer),raijin))
+  $(error Unknown NCI computer, $(which_computer))
+else
+  $(info Loading compiler settings for Raijin@NCI)
+  ifneq ($(NCI_NODE_ARCH), $(findstring $(NCI_NODE_ARCH), $(NCI_NODE_ARCHS)))
+    $(warning Unknown node architecture: $(NCI_NODE_ARCH))
+  else
+    $(info Node architecture: $(NCI_NODE_ARCH))
+  endif
+endif
+
+CFLAGS   := $(subst -O2,-O3,$(CFLAGS))
+CXXFLAGS := $(subst -O2,-O3,$(CXXFLAGS))
+FFLAGS   := $(subst -O2,-O3,$(FFLAGS))
+F90FLAGS := $(subst -O2,-O3,$(F90FLAGS))
+
+ifeq ($(NCI_NODE_ARCH),SANDYBRIDGE)
+  CFLAGS   += -xSANDYBRIDGE
+  CXXFLAGS += -xSANDYBRIDGE
+  FFLAGS   += -xSANDYBRIDGE
+  F90FLAGS += -xSANDYBRIDGE
+endif
+
+ifeq ($(NCI_NODE_ARCH),BROADWELL)
+  CFLAGS   += -xBROADWELL -fma
+  CXXFLAGS += -xBROADWELL -fma
+  FFLAGS   += -xBROADWELL -fma
+  F90FLAGS += -xBROADWELL -fma
+endif
+
+ifeq ($(NCI_NODE_ARCH),SKYLAKE)
+  CFLAGS   += -xSKYLAKE -fma
+  CXXFLAGS += -xSKYLAKE -fma
+  FFLAGS   += -xSKYLAKE -fma
+  F90FLAGS += -xSKYLAKE -fma
+endif
+
+ifeq ($(NCI_NODE_ARCH),SKYLAKE-512)
+  CFLAGS   += -xSKYLAKE-AVX512 -fma
+  CXXFLAGS += -xSKYLAKE-AVX512 -fma
+  FFLAGS   += -xSKYLAKE-AVX512 -fma
+  F90FLAGS += -xSKYLAKE-AVX512 -fma
+endif
+
+ifeq ($(NCI_NODE_ARCH),SKYLAKE-512-ZMM)
+  CFLAGS   += -xSKYLAKE-AVX512 -fma -qopt-zmm-usage=high
+  CXXFLAGS += -xSKYLAKE-AVX512 -fma -qopt-zmm-usage=high
+  FFLAGS   += -xSKYLAKE-AVX512 -fma -qopt-zmm-usage=high
+  F90FLAGS += -xSKYLAKE-AVX512 -fma -qopt-zmm-usage=high
+endif
+
+ifeq ($(NCI_NODE_ARCH),KNL)
+  CFLAGS   += -xMIC-AVX512
+  CXXFLAGS += -xMIC-AVX512
+  FFLAGS   += -xMIC-AVX512
+  F90FLAGS += -xMIC-AVX512
+endif
+
+ifeq ($(USE_MPI),TRUE)
+  CC  = mpicc
+  CXX = mpicxx
+  FC  = mpifort
+  F90 = mpifort
+endif

--- a/Tools/GNUMake/sites/Make.pawsey
+++ b/Tools/GNUMake/sites/Make.pawsey
@@ -1,0 +1,40 @@
+#
+# For PAWSEY machines: Magnus
+#
+
+ifneq ($(which_computer),$(filter $(which_computer),magnus))
+  $(error Unknown PAWSEY computer, $(which_computer))
+else
+  $(info Loading compiler settings for Magnus@PAWSEY)
+endif
+
+
+ifdef PE_ENV
+  lowercase_peenv := $(shell echo $(PE_ENV) | tr A-Z a-z)
+  ifneq ($(lowercase_peenv),$(lowercase_comp))
+    has_compiler_mismatch = COMP=$(COMP) does not match PrgEnv-$(lowercase_peenv)
+  endif
+endif
+
+CFLAGS   := $(subst -O2,-O3,$(CFLAGS))
+CXXFLAGS := $(subst -O2,-O3,$(CXXFLAGS))
+FFLAGS   := $(subst -O2,-O3,$(FFLAGS))
+F90FLAGS := $(subst -O2,-O3,$(F90FLAGS))
+
+CFLAGS   += -xHASWELL -fma
+CXXFLAGS += -xHASWELL -fma
+FFLAGS   += -xHASWELL -fma
+F90FLAGS += -xHASWELL -fma
+
+ifeq ($(USE_MPI),TRUE)
+  CC  = cc
+  CXX = CC
+  FC  = ftn
+  F90 = ftn
+  LIBRARIES += -lmpichf90
+endif
+
+ifeq ($(USE_SENSEI_INSITU),TRUE)
+  CXXFLAGS += -fPIC -dynamic
+  LIBRARIES += -ldl
+endif


### PR DESCRIPTION
This pull request adds Make files for Australia's supercomputers, namely Magnus@Pawsey (a Cray XC40) and Raijin@NCI (a hybrid Fujitsu Primergy-Lenovo NeXtScale system).

Information regarding those machines can be found from:
https://pawsey.org.au/systems/magnus/
https://nci.org.au/our-systems/hpc-systems
https://opus.nci.org.au/display/Help/Compute+Node+Specs+and+Information

As this is my first contribution to AMReX, please let me know if there is something wrong or I should change something.