### PR TITLE
C++ User Literal for amrex::Real (_rt)

### DIFF
--- a/Src/Amr/AMReX_Amr.cpp
+++ b/Src/Amr/AMReX_Amr.cpp
@@ -3165,7 +3165,7 @@ Amr::printGridInfo (std::ostream& os,
         int                       numgrid = bs.size();
         long                      ncells  = amr_level[lev]->countCells();
         double                    ntot    = Geom(lev).Domain().d_numPts();
-        Real                      frac    = 100.0*(Real(ncells) / ntot);
+        Real                      frac    = 100.0_rt*(Real(ncells) / ntot);
         const DistributionMapping& map    = amr_level[lev]->get_new_data(0).DistributionMap();
 
         os << "  Level "

--- a/Src/AmrCore/AMReX_AmrCore.cpp
+++ b/Src/AmrCore/AMReX_AmrCore.cpp
@@ -131,7 +131,7 @@ AmrCore::printGridSummary (std::ostream& os, int min_lev, int max_lev) const noe
         int                       numgrid = bs.size();
         long                      ncells  = bs.numPts();
         double                    ntot    = Geom(lev).Domain().d_numPts();
-        Real                      frac    = 100.0*(Real(ncells) / ntot);
+        Real                      frac    = 100.0_rt*(Real(ncells) / ntot);
 
         os << "  Level "
            << lev

--- a/Src/AmrTask/Amr/AMReX_AmrTask.cpp
+++ b/Src/AmrTask/Amr/AMReX_AmrTask.cpp
@@ -2580,7 +2580,7 @@ Amr::printGridInfo (std::ostream& os,
         int                       numgrid = bs.size();
         long                      ncells  = amr_level[lev]->countCells();
         double                    ntot    = Geom(lev).Domain().d_numPts();
-        Real                      frac    = 100.0*(Real(ncells) / ntot);
+        Real                      frac    = 100.0_rt*(Real(ncells) / ntot);
         const DistributionMapping& map    = amr_level[lev]->get_new_data(0).DistributionMap();
 
         os << "  Level "

--- a/Src/Base/AMReX_FArrayBox.cpp
+++ b/Src/Base/AMReX_FArrayBox.cpp
@@ -769,7 +769,7 @@ FABio_8bit::write (std::ostream&    os,
 {
     BL_ASSERT(comp >= 0 && num_comp >= 1 && (comp+num_comp) <= f.nComp());
 
-    const Real eps = Real(1.0e-8); // FIXME - whats a better value?
+    const Real eps = 1.0e-8_rt; // FIXME - whats a better value?
     const long siz = f.box().numPts();
 
     unsigned char *c = new unsigned char[siz];

--- a/Src/Base/AMReX_REAL.H
+++ b/Src/Base/AMReX_REAL.H
@@ -55,7 +55,28 @@ typedef double amrex_particle_real;
 namespace amrex {
     using Real = amrex_real;
     using ParticleReal = amrex_particle_real;
-}
+
+    /*
+      C++ user literal ``_rt`` for short-hand notations
+
+      Use this to properly add types to constant such as
+      ```C++
+      auto const mypi = 3.14_rt;
+      auto const sphere_volume = 4_rt / 3_rt * pow(r, 3) * mypi;
+      ```
+    */
+    constexpr Real
+    operator""_rt( long double x )
+    {
+        return Real( x );
+    }
+
+    constexpr Real
+    operator""_rt( unsigned long long int x )
+    {
+        return Real( x );
+    }
+} // amrex
 #endif
 
 #else

--- a/Src/Particle/AMReX_Particle.H
+++ b/Src/Particle/AMReX_Particle.H
@@ -325,9 +325,9 @@ Particle<NReal, NInt>::CIC_Cells_Fracs_Basic (const Particle<NReal, NInt>& p,
     //
     // "cells" should be dimensioned: IntVect cells[AMREX_D_TERM(2,+2,+4)]
     //
-    const Real len[AMREX_SPACEDIM] = { AMREX_D_DECL((p.m_rdata.pos[0]-plo[0])/dx[0] + Real(0.5),
-                                           (p.m_rdata.pos[1]-plo[1])/dx[1] + Real(0.5),
-                                           (p.m_rdata.pos[2]-plo[2])/dx[2] + Real(0.5)) };
+    const Real len[AMREX_SPACEDIM] = { AMREX_D_DECL((p.m_rdata.pos[0]-plo[0])/dx[0] + 0.5_rt,
+                                           (p.m_rdata.pos[1]-plo[1])/dx[1] + 0.5_rt,
+                                           (p.m_rdata.pos[2]-plo[2])/dx[2] + 0.5_rt) };
 
     const IntVect cell(AMREX_D_DECL(floor(len[0]), floor(len[1]), floor(len[2])));
 
@@ -384,34 +384,34 @@ Particle<NReal, NInt>::CIC_Cells_Fracs (const Particle<NReal, NInt>& p,
     for (int xi = locell[0]; xi <= hicell[0]; xi++)
     {
         cells[i][0] = xi;
-        fracs[i] = (std::min(hilen[0]-xi,Real(1))-std::max(lolen[0]-xi,Real(0)))*cell_density;
+        fracs[i] = (std::min(hilen[0]-xi,1_rt)-std::max(lolen[0]-xi,0_rt))*cell_density;
         i++;
     }
 #elif (AMREX_SPACEDIM == 2)
     for (int yi = locell[1]; yi <= hicell[1]; yi++)
     {
-        const Real yf = std::min(hilen[1]-yi,Real(1))-std::max(lolen[1]-yi,Real(0));
+        const Real yf = std::min(hilen[1]-yi,1_rt)-std::max(lolen[1]-yi,0_rt);
         for (int xi = locell[0]; xi <= hicell[0]; xi ++)
         {
             cells[i][0] = xi;
             cells[i][1] = yi;
-            fracs[i] = yf * (std::min(hilen[0]-xi,Real(1))-std::max(lolen[0]-xi,Real(0)))*cell_density;
+            fracs[i] = yf * (std::min(hilen[0]-xi,1_rt)-std::max(lolen[0]-xi,0_rt))*cell_density;
             i++;
         }
     }
 #elif (AMREX_SPACEDIM == 3)
     for (int zi = locell[2]; zi <= hicell[2]; zi++)
     {
-        const Real zf = std::min(hilen[2]-zi,Real(1))-std::max(lolen[2]-zi,Real(0));
+        const Real zf = std::min(hilen[2]-zi,1_rt)-std::max(lolen[2]-zi,0_rt);
         for (int yi = locell[1]; yi <= hicell[1]; yi++)
         {
-            const Real yf = std::min(hilen[1]-yi,Real(1))-std::max(lolen[1]-yi,Real(0));
+            const Real yf = std::min(hilen[1]-yi,1_rt)-std::max(lolen[1]-yi,0_rt);
             for (int xi = locell[0]; xi <= hicell[0]; xi++)
             {
                 cells[i][0] = xi;
                 cells[i][1] = yi;
                 cells[i][2] = zi;
-                fracs[i] = zf * yf * (std::min(hilen[0]-xi,Real(1))-std::max(lolen[0]-xi,Real(0))) * cell_density;
+                fracs[i] = zf * yf * (std::min(hilen[0]-xi,1_rt)-std::max(lolen[0]-xi,0_rt)) * cell_density;
                 i++;
             }
         }

--- a/Src/Particle/AMReX_ParticleContainerI.H
+++ b/Src/Particle/AMReX_ParticleContainerI.H
@@ -2236,8 +2236,8 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
     BL_ASSERT(lev >= 0 && lev < int(m_particles.size()));
 
     const Real strttime  = amrex::second();
-    const Real half_dt   = Real(0.5) * dt;
-    const Real a_new_inv = 1 / a_new;
+    const Real half_dt   = 0.5_rt * dt;
+    const Real a_new_inv = 1_rt / a_new;
     auto&      pmap      = m_particles[lev];
 
     MultiFab* ac_pointer;


### PR DESCRIPTION
This adds a user literal for `amrex::Real`. This is a [C++11 feature](https://en.cppreference.com/w/cpp/language/user_literal) and allows to type constants properly instead of relying on implicit conversation.

A typical fallacy is the following user code:
```C++
auto const mypi = 3.14;
Real const sphere_volume = 4 / 3 * mypi * pow(r,3);
```

The first term `4/3` makes the whole expression an `int` until the result is casted to `amrex::Real`. Urgh, `4/3 == 1`!

We can do better, with `amrex::Real(4) / amrex::Real(3)` but who wants to write such verbose code, right? Or `4./3.` which is always a `double` operation? No. So C++11 user literals to the rescue!
```C++
auto const mypi = 3.14_rt; // that's an amrex:Real, too!
Real const sphere_volume = 4_rt / 3_rt * mypi * pow(r,3);
```

Note: the naming `rt` is borrowed from the [Fortran equivalent](https://github.com/AMReX-Codes/amrex/search?q=rt+%3D%3E+amrex_real&unscoped_q=rt+%3D%3E+amrex_real) usage in AMReX.