### PR TITLE
C++ User Literal for amrex::ParticleReal (_prt)

### DIFF
--- a/Src/Base/AMReX_REAL.H
+++ b/Src/Base/AMReX_REAL.H
@@ -56,8 +56,8 @@ namespace amrex {
     using Real = amrex_real;
     using ParticleReal = amrex_particle_real;
 
-    /*
-      C++ user literals ``_rt`` &  ``p_rt`` for short-hand notations
+    /** @{
+      C++ user literals ``_rt`` &  ``_prt`` for short-hand notations
 
       Use this to properly add types to constant such as
       ```C++
@@ -88,7 +88,8 @@ namespace amrex {
     {
         return ParticleReal( x );
     }
-} // amrex
+    /// @}
+} // namespace amrex
 #endif
 
 #else

--- a/Src/Base/AMReX_REAL.H
+++ b/Src/Base/AMReX_REAL.H
@@ -57,7 +57,7 @@ namespace amrex {
     using ParticleReal = amrex_particle_real;
 
     /*
-      C++ user literal ``_rt`` for short-hand notations
+      C++ user literals ``_rt`` &  ``p_rt`` for short-hand notations
 
       Use this to properly add types to constant such as
       ```C++
@@ -75,6 +75,18 @@ namespace amrex {
     operator""_rt( unsigned long long int x )
     {
         return Real( x );
+    }
+
+    constexpr ParticleReal
+    operator""_prt( long double x )
+    {
+        return ParticleReal( x );
+    }
+
+    constexpr ParticleReal
+    operator""_prt( unsigned long long int x )
+    {
+        return ParticleReal( x );
     }
 } // amrex
 #endif


### PR DESCRIPTION
Same as the literal for `amrex::Real`. Follow-up to #577 

Throughout the code base, I could not find usages of `ParticleReal` literals yet.