### PR TITLE
Fixes to the spline IF routines

### DIFF
--- a/Src/EB/AMReX_distFcnElement.H
+++ b/Src/EB/AMReX_distFcnElement.H
@@ -22,7 +22,7 @@ class distFcnElement2d {
                    std::vector<amrex::Real> diag,
                    std::vector<amrex::Real> diagplus,
                    std::vector<amrex::Real> rhs,
-                   std::vector<amrex::Real>& X);
+                   std::vector<amrex::Real> &X);
 };
 
 
@@ -69,7 +69,7 @@ class SplineDistFcnElement2d: public distFcnElement2d {
   void print_control_points() const;
   void print_spline() const;
 
-  void calc_D(bool clamped_bc = true);
+  void calc_D(bool clamped_bc = false);
 
   virtual  amrex::Real cpdist(amrex::RealVect pt, amrex::RealVect& cp) const override;
   virtual  amrex::Real cpside(amrex::RealVect pt, amrex::RealVect& cp) const override;

--- a/Src/EB/AMReX_distFcnElement.H
+++ b/Src/EB/AMReX_distFcnElement.H
@@ -18,9 +18,9 @@ class distFcnElement2d {
 
   virtual  amrex::Real cpdist(amrex::RealVect pt, amrex::RealVect& cp) const = 0;
   virtual  amrex::Real cpside(amrex::RealVect pt, amrex::RealVect& cp) const = 0;
-  int solve_thomas(std::vector<amrex::Real> diagminus,
+  int solve_thomas(const std::vector<amrex::Real> &diagminus,
                    std::vector<amrex::Real> diag,
-                   std::vector<amrex::Real> diagplus,
+                   const std::vector<amrex::Real> &diagplus,
                    std::vector<amrex::Real> rhs,
                    std::vector<amrex::Real> &X);
 };

--- a/Src/EB/AMReX_distFcnElement.cpp
+++ b/Src/EB/AMReX_distFcnElement.cpp
@@ -6,17 +6,11 @@
 
 namespace amrex {
 
-int distFcnElement2d::solve_thomas(std::vector<amrex::Real> ain,
-                                   std::vector<amrex::Real> bin,
-                                   std::vector<amrex::Real> cin,
-                                   std::vector<amrex::Real> din,
+int distFcnElement2d::solve_thomas(const std::vector<amrex::Real> &a,
+                                   std::vector<amrex::Real> b,
+                                   const std::vector<amrex::Real> &c,
+                                   std::vector<amrex::Real> d,
                                    std::vector<amrex::Real> &x) {
-  std::vector<amrex::Real> a, b, c, d;
-  a = ain;  // off diagonal on low side
-  b = bin;  // diagonal
-  c = cin;  // off diagonal on high side
-  d = din;  // rhs
-
   unsigned n;
   n = d.size();
   x.resize(n);

--- a/Src/EB/AMReX_distFcnElement.cpp
+++ b/Src/EB/AMReX_distFcnElement.cpp
@@ -10,7 +10,7 @@ int distFcnElement2d::solve_thomas(std::vector<amrex::Real> ain,
                                    std::vector<amrex::Real> bin,
                                    std::vector<amrex::Real> cin,
                                    std::vector<amrex::Real> din,
-                                   std::vector<amrex::Real>& x) {
+                                   std::vector<amrex::Real> &x) {
   std::vector<amrex::Real> a, b, c, d;
   a = ain;  // off diagonal on low side
   b = bin;  // diagonal
@@ -27,13 +27,13 @@ int distFcnElement2d::solve_thomas(std::vector<amrex::Real> ain,
     b[i] -= m*c[i-1];
     d[i] -= m*d[i-1];
   }
-  x = b;
+
   x[n-1] = d[n-1] / b[n-1];
 
-
-  for (unsigned i=n-2; i > 0; --i) {
+  for (int i=n-2; i > -1; --i) {
     x[i] = (d[i]-c[i]*x[i+1])/b[i];
   }
+
   return 0;
 }
 
@@ -242,26 +242,23 @@ void SplineDistFcnElement2d::calc_D(bool clamped_bc) {
   Dx.resize(nsplines+1);
   Dy.resize(nsplines+1);
 
-  for (int i=0; i<nsplines-1; ++i) {
+  for (int i=0; i<nsplines; ++i) {
     diag[i] = 4.0;
     diagminus[i] = 1.0;
     diagplus[i] = 1.0;
   }
-  diag[nsplines-1] = 4.0;
-
-
 
   for (int i=1; i<nsplines; ++i) {
-    rhsx[i] = control_points_x[i+1] - control_points_x[i-1];
-    rhsy[i] = control_points_y[i+1] - control_points_y[i-1];
+    rhsx[i] = 3.0*(control_points_x[i+1] - control_points_x[i-1]);
+    rhsy[i] = 3.0*(control_points_y[i+1] - control_points_y[i-1]);
   }
 
   if (clamped_bc) {
     diag[0] = 1.0;
-    diagplus[0] = 0.0;
+    diagminus[0] = 0.0;
 
     diag[nsplines] = 1.0;
-    diagminus[nsplines-1] = 0.0;
+    diagplus[nsplines] = 0.0;
 
     rhsx[0] = control_points_x[0] - bc_pt_start[0];
     rhsx[nsplines] = -control_points_x[nsplines-1] + bc_pt_end[0];
@@ -330,9 +327,9 @@ void SplineDistFcnElement2d::print_spline() const {
       amrex::Real y = eval(j*dt, control_points_y[i],
                            control_points_y[i+1], Dy[i], Dy[i+1]);
 
-      std::cout << x << "  " <<  y << std::endl;
     }
   }
+
 }
 
 
@@ -408,6 +405,7 @@ amrex::Real LineDistFcnElement2d::cpside(amrex::RealVect pt,
     }
     */
   }
+  amrex::Abort("Should not get here");
 }
 
 void LineDistFcnElement2d::set_control_points

--- a/Tutorials/EB/GeometryGeneration/main.cpp
+++ b/Tutorials/EB/GeometryGeneration/main.cpp
@@ -25,7 +25,8 @@ int main (int argc, char* argv[])
 
         Geometry geom;
         {
-            RealBox rb({-0.5,-0.5,-0.5}, {0.5,0.5,0.5}); // physical domain
+            RealBox rb({-1.3,-1.3,-0.475}, {1.3,1.3,0.5}); // physical domain
+            // RealBox rb({-5.2,-5.2,-1.9}, {5.2,5.2,2.0}); // physical domain
             Array<int,AMREX_SPACEDIM> is_periodic{false, false, false};
             Geometry::Setup(&rb, 0, is_periodic.data());
             Box domain(IntVect(0), IntVect(n_cell-1));
@@ -49,63 +50,66 @@ int main (int argc, char* argv[])
         } else if (which_geom == 1) {
           // This geometry uses splines to put an interesting 'piston bowl' shape at the
           // bottom of the cylinder
+          Real scaleFact;
+          scaleFact = 0.25;
+
           std::vector<amrex::RealVect> splpts;
           amrex::RealVect p;
-          p = amrex::RealVect(D_DECL(36.193*0.1, 7.8583*0.1, 0.0));
+          p = amrex::RealVect(D_DECL(36.193*0.1*scaleFact, 7.8583*0.1*scaleFact, 0.0));
           splpts.push_back(p);
-          p = amrex::RealVect(D_DECL(35.924*0.1, 7.7881*0.1, 0.0));
+          p = amrex::RealVect(D_DECL(35.924*0.1*scaleFact, 7.7881*0.1*scaleFact, 0.0));
           splpts.push_back(p);
-          p = amrex::RealVect(D_DECL(35.713*0.1, 7.5773*0.1, 0.0));
+          p = amrex::RealVect(D_DECL(35.713*0.1*scaleFact, 7.5773*0.1*scaleFact, 0.0));
           splpts.push_back(p);
-          p = amrex::RealVect(D_DECL(35.643*0.1, 7.3083*0.1, 0.0));
+          p = amrex::RealVect(D_DECL(35.643*0.1*scaleFact, 7.3083*0.1*scaleFact, 0.0));
           splpts.push_back(p);
-          p = amrex::RealVect(D_DECL(35.3*0.1, 7.0281*0.1, 0.0));
+          p = amrex::RealVect(D_DECL(35.3*0.1*scaleFact, 7.0281*0.1*scaleFact, 0.0));
           splpts.push_back(p);
-          p = amrex::RealVect(D_DECL(35.421*0.1, 6.241*0.1, 0.0));
+          p = amrex::RealVect(D_DECL(35.421*0.1*scaleFact, 6.241*0.1*scaleFact, 0.0));
           splpts.push_back(p);
-          p = amrex::RealVect(D_DECL(34.82*0.1, 5.686*0.1, 0.0));
+          p = amrex::RealVect(D_DECL(34.82*0.1*scaleFact, 5.686*0.1*scaleFact, 0.0));
           splpts.push_back(p);
-          p = amrex::RealVect(D_DECL(30.539*0.1, 3.5043*0.1, 0.0));
+          p = amrex::RealVect(D_DECL(30.539*0.1*scaleFact, 3.5043*0.1*scaleFact, 0.0));
           splpts.push_back(p);
-          p = amrex::RealVect(D_DECL(29.677*0.1, 2.6577*0.1, 0.0));
+          p = amrex::RealVect(D_DECL(29.677*0.1*scaleFact, 2.6577*0.1*scaleFact, 0.0));
           splpts.push_back(p);
-          p = amrex::RealVect(D_DECL(29.457*0.1, 1.47*0.1, 0.0));
+          p = amrex::RealVect(D_DECL(29.457*0.1*scaleFact, 1.47*0.1*scaleFact, 0.0));
           splpts.push_back(p);
-          p = amrex::RealVect(D_DECL(28.364*0.1, -5.7632*0.1, 0.0));
+          p = amrex::RealVect(D_DECL(28.364*0.1*scaleFact, -5.7632*0.1*scaleFact, 0.0));
           splpts.push_back(p);
-          p = amrex::RealVect(D_DECL(27.151*0.1, -6.8407*0.1, 0.0));
+          p = amrex::RealVect(D_DECL(27.151*0.1*scaleFact, -6.8407*0.1*scaleFact, 0.0));
           splpts.push_back(p);
-          p = amrex::RealVect(D_DECL(25.694*0.1, -7.5555*0.1, 0.0));
+          p = amrex::RealVect(D_DECL(25.694*0.1*scaleFact, -7.5555*0.1*scaleFact, 0.0));
           splpts.push_back(p);
-          p = amrex::RealVect(D_DECL(24.035*0.1, -7.8586*0.1, 0.0));
+          p = amrex::RealVect(D_DECL(24.035*0.1*scaleFact, -7.8586*0.1*scaleFact, 0.0));
           splpts.push_back(p);
-          p = amrex::RealVect(D_DECL(22.358*0.1, -7.6902*0.1, 0.0));
+          p = amrex::RealVect(D_DECL(22.358*0.1*scaleFact, -7.6902*0.1*scaleFact, 0.0));
           splpts.push_back(p);
           EB2::SplineIF Piston;
           Piston.addSplineElement(splpts);
+          
           std::vector<amrex::RealVect> lnpts;
 
-          p = amrex::RealVect(D_DECL(22.358*0.1, -7.6902*0.1, 0.0));
+          p = amrex::RealVect(D_DECL(22.358*0.1*scaleFact, -7.6902*0.1*scaleFact, 0.0));
           lnpts.push_back(p);
-          p = amrex::RealVect(D_DECL(1.9934*0.1, 3.464*0.1, 0.0));
+          p = amrex::RealVect(D_DECL(1.9934*0.1*scaleFact, 3.464*0.1*scaleFact, 0.0));
           lnpts.push_back(p);
-          p = amrex::RealVect(D_DECL(0.0, 3.464*0.1, 0.0));
-          lnpts.push_back(p);
-          Piston.addLineElement(lnpts);
-          lnpts.clear();
-
-          p = amrex::RealVect(D_DECL(49.0*0.1, 7.8583*0.1,  0.0));
-          lnpts.push_back(p);
-          p = amrex::RealVect(D_DECL(36.193*0.1, 7.8583*0.1, 0.0));
+          p = amrex::RealVect(D_DECL(0.0, 3.464*0.1*scaleFact, 0.0));
           lnpts.push_back(p);
           Piston.addLineElement(lnpts);
           lnpts.clear();
 
-          EB2::CylinderIF cylinder(4.80, 7.0, 2, {0.0, 0.0, -1.0}, false);
+          p = amrex::RealVect(D_DECL(49.0*0.1*scaleFact, 7.8583*0.1*scaleFact,  0.0));
+          lnpts.push_back(p);
+          p = amrex::RealVect(D_DECL(36.193*0.1*scaleFact, 7.8583*0.1*scaleFact, 0.0));
+          lnpts.push_back(p);
+          Piston.addLineElement(lnpts);
+          lnpts.clear();
+
+          EB2::CylinderIF cylinder(4.80*scaleFact, 7.0*scaleFact, 2, {0.0, 0.0, -1.0*scaleFact}, true);
 
           auto revolvePiston  = EB2::lathe(Piston);
-          auto PistonComplement = EB2::makeComplement(revolvePiston);
-          auto PistonCylinder = EB2::makeIntersection(PistonComplement, cylinder);
+          auto PistonCylinder = EB2::makeUnion(revolvePiston, cylinder);
           auto gshop = EB2::makeShop(PistonCylinder);
           EB2::Build(gshop, geom, 0, 0);
 


### PR DESCRIPTION
This pull request continues the fix introduced by Weiqun  (@WeiqunZhang ) to the distFcnElement2D routine. A couple of fixes to the first derivative calculation in CalcD and solveThomas routine. 

Introduced a test case in the Tutorials/EB/GeometryGeneration. This test case builds a stepped lip piston bowl geometry. Also compared the code against the original python based implementation by Ray Grout (@rgrout).  