### PR TITLE
Reduce number of CUDA streams to 4

### DIFF
--- a/Src/Base/AMReX_GpuDevice.H
+++ b/Src/Base/AMReX_GpuDevice.H
@@ -144,7 +144,7 @@ private:
     static int verbose;
 
 #ifdef AMREX_USE_GPU
-    static constexpr int max_gpu_streams = 16;
+    static constexpr int max_gpu_streams = 4;
 #else
     // Equivalent to "single dependent stream". Fits best
     //  with math this is used in ("x/max_streams").

--- a/Src/Base/AMReX_MFIter.cpp
+++ b/Src/Base/AMReX_MFIter.cpp
@@ -497,10 +497,6 @@ MFIter::operator++ () noexcept
 
 #ifdef AMREX_USE_GPU
         if (use_gpu) {
-            if (Gpu::getNumCallbacks() > 0 && streams > 0) {
-                streams = 2;
-            }
-
             Gpu::Device::setStreamIndex((streams > 0) ? currentIndex%streams : -1);
             AMREX_GPU_ERROR_CHECK();
 #ifdef AMREX_DEBUG


### PR DESCRIPTION
Empirical testing with Castro shows that 4 CUDA streams is slightly better than the current default of 16, and is also better than 2 and 8. With 4 streams we can achieve concurrency even when there are callbacks (this is generally not enough streams to expose the stream serialization bug in the NVIDIA driver), and my observation is that there are never more than 4 streams used in practice by AMReX for any of its core operations, so there is no harm in this limit.