### PR TITLE
GCC 7.4.0 Warnings in Prints

### DIFF
--- a/Src/Base/AMReX_ParallelDescriptor.cpp
+++ b/Src/Base/AMReX_ParallelDescriptor.cpp
@@ -191,7 +191,7 @@ namespace
                         const char* call,
                         int         status)
     {
-	const int N = 512;
+	constexpr int N = 1024;
 	static char buf[N];
 	if ( status )
 	{


### PR DESCRIPTION
Fix warnings of the type
```
In file included from /usr/include/stdio.h:862,
                 from /usr/include/c++/8/cstdio:42,
                 from ../amrex/Src/Base/AMReX_ParallelDescriptor.cpp:2:
/usr/include/x86_64-linux-gnu/bits/stdio2.h:64:35: note: ‘__builtin___snprintf_chk’ output between 105 and 617 bytes into a destination of size 512
   return __builtin___snprintf_chk (__s, __n, __USE_FORTIFY_LEVEL - 1,
          ~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
        __bos (__s), __fmt, __va_arg_pack ());
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../amrex/Src/Base/AMReX_ParallelDescriptor.cpp: In function ‘void amrex::ParallelDescriptor::Barrier(const string&)’:
../amrex/Src/Base/AMReX_ParallelDescriptor.cpp:198:23: warning: ‘%s’ directive output may be truncated writing up to 512 bytes into a region of size 383 [-Wformat-truncation=]
      snprintf(buf, N, "AMReX MPI Error: File %s, line %d, %s: %s",
                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
when compiling with WarpX as discussed with @WeiqunZhang last week in Slack.