### PR TITLE
Avoid compiler warnings

### DIFF
--- a/Src/Base/AMReX_FBI.H
+++ b/Src/Base/AMReX_FBI.H
@@ -335,7 +335,6 @@ FabArray<FAB>::FB_local_copy_cpu (const FB& TheFB, int scomp, int ncomp)
             {
                 auto const sfab = tag.sfab->array();
                 const auto offset = tag.offset.dim3();
-                const Box sbox = tag.dbox + tag.offset;
                 amrex::LoopConcurrentOnCpu(tag.dbox, ncomp,
                 [=] (int i, int j, int k, int n) noexcept
                 {

--- a/Src/Base/AMReX_FabArrayCommI.H
+++ b/Src/Base/AMReX_FabArrayCommI.H
@@ -120,7 +120,7 @@ FabArray<FAB>::FBEP_nowait (int scomp, int ncomp, const IntVect& nghost,
                 nbytes += (*this)[cct.srcIndex].nBytes(cct.sbox,scomp,ncomp);
             }
             
-            BL_ASSERT(nbytes < std::numeric_limits<int>::max());
+            BL_ASSERT(nbytes < std::size_t(std::numeric_limits<int>::max()));
             
             total_volume += nbytes;
 
@@ -444,7 +444,7 @@ FabArray<FAB>::ParallelCopy (const FabArray<FAB>& src,
                     nbytes += src[cct.srcIndex].nBytes(cct.sbox,SC,NC);
                 }
 		
-		BL_ASSERT(nbytes < std::numeric_limits<int>::max());
+		BL_ASSERT(nbytes < std::size_t(std::numeric_limits<int>::max()));
 
                 total_volume += nbytes;
 
@@ -668,7 +668,7 @@ FabArray<FAB>::PostRcvs (const MapOfCopyComTagContainers&  m_RcvTags,
             nbytes += (*this)[cct.dstIndex].nBytes(cct.dbox,icomp,ncomp);
         }
 
-        BL_ASSERT(nbytes < std::numeric_limits<int>::max());
+        BL_ASSERT(nbytes < std::size_t(std::numeric_limits<int>::max()));
 
         TotalRcvsVolume += nbytes;
 


### PR DESCRIPTION
Avoid warnings about signed/unsigned comparisons and about unused variables.