### PR TITLE
Linker: Use RPath

### DIFF
--- a/Docs/sphinx_documentation/source/BuildingAMReX.rst
+++ b/Docs/sphinx_documentation/source/BuildingAMReX.rst
@@ -43,6 +43,8 @@ list of important variables.
    +------------+-------------------------------------+-------------+
    | USE_OMP    | TRUE or FALSE                       | FALSE       |
    +------------+-------------------------------------+-------------+
+   | USE_RPATH  | TRUE or FALSE                       | TRUE        |
+   +------------+-------------------------------------+-------------+
 
 .. raw:: latex
 
@@ -82,6 +84,12 @@ to TRUE, FALSE and FALSE, respectively.  The meaning of these variables should
 be obvious.  When ``DEBUG = TRUE``, aggressive compiler optimization flags are
 turned off and assertions in  source code are turned on. For production runs,
 ``DEBUG`` should be set to FALSE.
+
+The variable ``USE_RPATH`` controls the link mechanism to dependent libraries.
+By default, the library path at link time will be saved as a
+`rpath hint <https://en.wikipedia.org/wiki/Rpath>`_ in created binaries.
+When disabled, library paths must be provided via ``export LD_LIBRARY_PATH``
+hints at runtime.
 
 After defining these make variables, a number of files, ``Make.defs,
 Make.package`` and ``Make.rules``, are included in the GNUmakefile. AMReX-based

--- a/Docs/sphinx_documentation/source/BuildingAMReX.rst
+++ b/Docs/sphinx_documentation/source/BuildingAMReX.rst
@@ -43,7 +43,7 @@ list of important variables.
    +------------+-------------------------------------+-------------+
    | USE_OMP    | TRUE or FALSE                       | FALSE       |
    +------------+-------------------------------------+-------------+
-   | USE_RPATH  | TRUE or FALSE                       | TRUE        |
+   | USE_RPATH  | TRUE or FALSE                       | FALSE       |
    +------------+-------------------------------------+-------------+
 
 .. raw:: latex
@@ -86,7 +86,7 @@ turned off and assertions in  source code are turned on. For production runs,
 ``DEBUG`` should be set to FALSE.
 
 The variable ``USE_RPATH`` controls the link mechanism to dependent libraries.
-By default, the library path at link time will be saved as a
+If enabled, the library path at link time will be saved as a
 `rpath hint <https://en.wikipedia.org/wiki/Rpath>`_ in created binaries.
 When disabled, library paths must be provided via ``export LD_LIBRARY_PATH``
 hints at runtime.

--- a/Tools/GNUMake/Make.defs
+++ b/Tools/GNUMake/Make.defs
@@ -32,7 +32,8 @@ ifdef USE_RPATH
   USE_RPATH := $(strip $(USE_RPATH))
 else
   # the syntax we use below works for all compilers but CCE "classic"
-  USE_RPATH := TRUE
+  # we plan to enable this feature by default in the future
+  USE_RPATH := FALSE
 endif
 
 ifdef DEBUG

--- a/Tools/GNUMake/Make.defs
+++ b/Tools/GNUMake/Make.defs
@@ -28,6 +28,13 @@ else
   PRECISION := DOUBLE
 endif
 
+ifdef USE_RPATH
+  USE_RPATH := $(strip $(USE_RPATH))
+else
+  # the syntax we use below works for all compilers but CCE "classic"
+  USE_RPATH := TRUE
+endif
+
 ifdef DEBUG
   DEBUG := $(strip $(DEBUG))
 else
@@ -717,7 +724,11 @@ CPPFLAGS	+= $(DEFINES)
 
 libraries	= $(LIBRARIES) $(XTRALIBS)
 
-LDFLAGS		+= -L. $(addprefix -L, $(LIBRARY_LOCATIONS))
+ifeq ($(USE_RPATH),TRUE)
+  LDFLAGS	+= -Xlinker -rpath -Xlinker . $(addprefix -Xlinker -rpath -Xlinker , $(LIBRARY_LOCATIONS))
+else
+  LDFLAGS	+= -L. $(addprefix -L, $(LIBRARY_LOCATIONS))
+endif
 
 machineSuffix	= $(lowercase_comp)$(archSuffix)$(PrecisionSuffix)$(DebugSuffix)$(ProfSuffix)$(MProfSuffix)$(BTSuffix)$(MPISuffix)$(UPCXXSuffix)$(OMPSuffix)$(ACCSuffix)$(GPUSuffix)$(USERSuffix)
 


### PR DESCRIPTION
Although AMReX does not come with much dependencies besides runtimes, the build system allows to add various libraries for downstream application dependencies.

In the case of WarpX, we link auxiliary libraries for I/O among others. When linking against shared libraries, these dependent libraries (think: `.so`|`.dylib`|`.dll` files) must be present and accessible at runtime again. Usually, one sets their paths in `export LD_LIBRARY_PATH` hints which is both cumbersome for users as well as bad for file-systems which will be heavily loaded with meta-data operations while searching for the corresponding dependencies, especially at scale.

Luckily, all modern Unix systems support RPath hints, which embed the location of a dependent shared library at link time into the generated binary.
  https://en.wikipedia.org/wiki/Rpath
We now enable this feature by default. The linker flag is implemented in a generic way that works with the most common compilers:
- clang :heavy_check_mark:
- gcc :heavy_check_mark:
- nvcc :heavy_check_mark:
- icc :heavy_check_mark:
- pgcc :heavy_check_mark:
- xlC :heavy_check_mark:
- crayc++ "classic" :heavy_multiplication_x:
- crayc++ 9.0+ "LLVM": :heavy_check_mark:

~~In case there are any regressions or one desires not to use RPaths, users can just set `USE_RPATH=FALSE` as `make` option.~~
Update: Downstream projects can set the `USE_RPATH=TRUE` option to enable this new feature. Feedback on any problems that might appear when setting this is very welcome and if we can make this a robust feature we would like to enable this by default in the future.