### PR TITLE
added begin() and end() to GpuArray

### DIFF
--- a/Src/Base/AMReX_Array.H
+++ b/Src/Base/AMReX_Array.H
@@ -41,6 +41,14 @@ namespace amrex {
         inline const T* data() const noexcept { return arr; };
         AMREX_GPU_HOST_DEVICE
         inline std::size_t size() const noexcept { return N; };
+        AMREX_GPU_HOST_DEVICE
+        inline const T* begin() const noexcept { return arr; };
+        AMREX_GPU_HOST_DEVICE
+        inline const T* end() const noexcept { return arr + N; };
+        AMREX_GPU_HOST_DEVICE
+        inline T* begin() noexcept { return arr; };
+        AMREX_GPU_HOST_DEVICE
+        inline T* end() noexcept { return arr + N; };
 
         T arr[N];
     };


### PR DESCRIPTION
This pull request adds ```begin()``` and ```end()``` methods to GpuArray if ```AMREX_USE_GPU``` is defined (if  ```AMREX_USE_GPU``` is not defined, GpuArray is identical to the STL, which already has this methods).

This allows for instance to use a GpuArray in a range-based loop, e.g. :
```
GpuArray<Real,3> gg;
for(auto& el : gg)
	el = 1.0;
```

Should I add some tests somewhere?
 