### PR TITLE
Abort on unused inputs

### DIFF
--- a/Src/Base/AMReX.H
+++ b/Src/Base/AMReX.H
@@ -54,6 +54,7 @@ namespace amrex
         extern std::ostream* oserr;
         
         extern ErrorHandler error_handler;
+        extern int abort_on_unused_inputs;
     }
 
     std::string Version ();

--- a/Src/Base/AMReX.cpp
+++ b/Src/Base/AMReX.cpp
@@ -65,6 +65,7 @@ namespace system
     int call_addr2line;
     int throw_exception;
     int regtest_reduction;
+    int abort_on_unused_inputs = 0;
     std::ostream* osout = &std::cout;
     std::ostream* oserr = &std::cerr;
     ErrorHandler error_handler = nullptr;
@@ -428,6 +429,7 @@ amrex::Initialize (int& argc, char**& argv, bool build_parm_parse,
         pp.query("signal_handling", system::signal_handling);
         pp.query("throw_exception", system::throw_exception);
         pp.query("call_addr2line", system::call_addr2line);
+        pp.query("abort_on_unused_inputs", system::abort_on_unused_inputs);
 
         if (system::signal_handling)
         {

--- a/Src/Base/AMReX_ParmParse.cpp
+++ b/Src/Base/AMReX_ParmParse.cpp
@@ -1083,9 +1083,10 @@ ParmParse::Finalize ()
       if (finalize_verbose) amrex::OutStream() << "Unused ParmParse Variables:\n";
       finalize_table("  [TOP]", g_table);
       if (finalize_verbose) amrex::OutStream() << std::endl;
-	//
-	// First loop through and delete all queried entries.
-	//
+      //
+      // First loop through and delete all queried entries.
+      //
+      if (amrex::system::abort_on_unused_inputs) amrex::Abort("ERROR: unused ParmParse variables.");
     }
     g_table.clear();
 


### PR DESCRIPTION
This adds an option, requested by @MaxThevenet, to abort at the end of a run if unused ParmParse variables are present in the table. You turn it on by setting `amrex.abort_on_unused_inputs = 1`. 