### PR TITLE
Mini PR: Fix XLinker option to allow spaces in directory names

### DIFF
--- a/Tools/GNUMake/Make.defs
+++ b/Tools/GNUMake/Make.defs
@@ -726,7 +726,7 @@ CPPFLAGS	+= $(DEFINES)
 libraries	= $(LIBRARIES) $(XTRALIBS)
 
 ifeq ($(USE_RPATH),TRUE)
-  LDFLAGS	+= -Xlinker -rpath -Xlinker $(abspath .) $(addprefix -Xlinker -rpath -Xlinker , $(abspath $(LIBRARY_LOCATIONS)))
+  LDFLAGS	+= -Xlinker -rpath -Xlinker '$(abspath .)' $(addprefix -Xlinker -rpath -Xlinker , $(abspath $(LIBRARY_LOCATIONS)))
 endif
 LDFLAGS	+= -L. $(addprefix -L, $(LIBRARY_LOCATIONS))
 


### PR DESCRIPTION
As the title says, this fix is needed in case the current directory has spaces in the name. If there is another way of fixing this, that would be fine too.

Without this, the final linking fails since the extra spaces mess up the rpath xlinker options. Note that single quotes are used since double quotes mess up makebuildinfo_C.py since the linker_flags is already wrapped in double quotes.