### PR TITLE
Update the default CUDA architecture to cc70 (Volta V100)

### DIFF
--- a/Tools/GNUMake/Make.defs
+++ b/Tools/GNUMake/Make.defs
@@ -189,7 +189,7 @@ endif
 
 ifeq ($(USE_CUDA),TRUE)
   # Set the default CUDA architecture version.
-  CUDA_ARCH ?= 60
+  CUDA_ARCH ?= 70
 
   # Maximum number of CUDA threads per block.
   CUDA_MAX_THREADS ?= 256


### PR DESCRIPTION
Volta has been out long enough now that it's going to be the target platform for most users.