### PR TITLE
PhysBCFunct: Final Warning

### DIFF
--- a/Src/Base/AMReX_PhysBCFunct.H
+++ b/Src/Base/AMReX_PhysBCFunct.H
@@ -103,13 +103,13 @@ public:
 inline PhysBCFunctBase::~PhysBCFunctBase () {}
 
 
-class PhysBCFunctNoOp
+class PhysBCFunctNoOp final
     : public PhysBCFunctBase
 {
 public:
     virtual void FillBoundary (MultiFab& mf, int dcomp, int ncomp, Real time, int bccomp)
-        override final {}
-    virtual ~PhysBCFunctNoOp () override final {}
+        override {}
+    virtual ~PhysBCFunctNoOp () override {}
 };
 
 


### PR DESCRIPTION
Warning with Clang:
```
../amrex/Src/Base/AMReX_PhysBCFunct.H:112:42: warning: class with destructor marked 'final' cannot be inherited from [-Wfinal-dtor-non-final-class]
    virtual ~PhysBCFunctNoOp () override final {}
                                         ^
../amrex/Src/Base/AMReX_PhysBCFunct.H:106:7: note: mark 'amrex::PhysBCFunctNoOp' as 'final' to silence this warning
class PhysBCFunctNoOp
```