### PR TITLE
In ParticleToMesh, apply SumBoundary & finalize MultiFab for both GPU and CPU

### DIFF
--- a/Src/Particle/AMReX_ParticleMesh.H
+++ b/Src/Particle/AMReX_ParticleMesh.H
@@ -71,14 +71,14 @@ ParticleToMesh (PC const& pc, MF& mf, int lev, F&& f)
                 fab.atomicAdd(local_fab, tile_box, tile_box, 0, 0, mf_pointer->nComp());
             }
         }
+    }
 
-        mf_pointer->SumBoundary(pc.Geom(lev).periodicity());
+    mf_pointer->SumBoundary(pc.Geom(lev).periodicity());
 
-        if (mf_pointer != &mf)
-        {
-            mf.copy(*mf_pointer,0,0,mf_pointer->nComp());
-            delete mf_pointer;
-        }
+    if (mf_pointer != &mf)
+    {
+        mf.copy(*mf_pointer,0,0,mf_pointer->nComp());
+        delete mf_pointer;
     }
 }
 


### PR DESCRIPTION
This moves the call to `SumBoundary` and the MultiFab copy and cleanup from inside the scope of the `else` condition for `Gpu::inLaunchRegion()` to the outer scope of the `ParticleToMesh` function so we do this independent of whether we're on the GPU.