### PR TITLE
Added begin and end methods to IntVect and RealVect classes

### DIFF
--- a/Src/AmrCore/AMReX_Interp_3D_C.H
+++ b/Src/AmrCore/AMReX_Interp_3D_C.H
@@ -391,8 +391,8 @@ cellconslin_fine_alpha (Box const& bx, Array4<Real> const& alpha,
     const auto lo = amrex::lbound(bx);
     const auto hi = amrex::ubound(bx);
 
-    const auto slo = amrex::lbound(slopes);
-    const auto shi = amrex::ubound(slopes);
+    // const auto slo = amrex::lbound(slopes); SET_BUT_NOT_USED 
+    // const auto shi = amrex::ubound(slopes); SET_BUT_NOT_USED 
 
     const Array4<Real const> mm(slopes, ncomp*AMREX_SPACEDIM);  // min and max
 

--- a/Src/Base/AMReX_IntVect.H
+++ b/Src/Base/AMReX_IntVect.H
@@ -173,6 +173,22 @@ public:
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     const int& operator[] (int i) const noexcept { BL_ASSERT(i>=0 && i < AMREX_SPACEDIM); return vect[i]; }
 
+    //! Returns a pointer to the first element of the IntVect.
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    int* begin () noexcept { return &vect[0]; }
+
+    //! Returns a pointer to the first element of the IntVect.
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    const int* begin () const noexcept { return &vect[0]; }
+
+    //! Returns a pointer to the (last+1) element of the IntVect.
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    int* end () noexcept { return &vect[AMREX_SPACEDIM]; }
+
+    //! Returns a pointer to the (last+1) element of the IntVect.
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    const int* end () const noexcept { return &vect[AMREX_SPACEDIM]; }
+
     //! Set i'th coordinate of IntVect to val.
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     IntVect& setVal (int i, int val) noexcept

--- a/Src/Base/AMReX_MultiFabUtil.cpp
+++ b/Src/Base/AMReX_MultiFabUtil.cpp
@@ -151,7 +151,7 @@ namespace amrex
 	AMREX_ASSERT(cc.nComp() >= AMREX_SPACEDIM);
 	AMREX_ASSERT(fc[0]->nComp() == 1); // We only expect fc to have the gradient perpendicular to the face
 
-        const GeometryData gd = geom.data();
+        // const GeometryData gd = geom.data(); SET_BUT_NOT_USED
 
 #ifdef _OPENMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())

--- a/Src/Base/AMReX_RealVect.H
+++ b/Src/Base/AMReX_RealVect.H
@@ -101,6 +101,41 @@ public:
   /*@}*/
 
   /**
+     \name Iterators
+  */
+  /*@{*/
+
+  ///
+  /**
+     Return pointer to the first component.
+  */
+  inline
+  Real* begin () noexcept;
+  
+  ///
+  /**
+     Return pointer to the first component.
+  */
+  inline
+  const Real* begin () const noexcept;
+  
+  ///
+  /**
+     Return pointer to the one past last component
+  */
+  inline
+  Real* end () noexcept;
+  
+  ///
+  /**
+     Return pointer to the one past last component
+  */
+  inline
+  const Real* end () const noexcept;
+  
+  /*@}*/
+
+  /**
      \name Comparison Operators
   */
   /*@{*/
@@ -516,6 +551,26 @@ inline const Real& RealVect::operator[] (int i) const noexcept
 {
   assert(i>=0 && i < SpaceDim);
   return vect[i];
+}
+
+inline Real* RealVect::begin () noexcept
+{ 
+  return &vect[0];
+}
+
+inline const Real* RealVect::begin () const noexcept
+{
+  return &vect[0];
+}
+
+inline Real* RealVect::end () noexcept
+{
+  return &vect[SpaceDim];
+}
+
+inline const Real* RealVect::end () const noexcept
+{
+  return &vect[SpaceDim];
 }
 
 inline RealVect::RealVect (const RealVect &iv) noexcept

--- a/Src/EB/AMReX_EB2_Level.H
+++ b/Src/EB/AMReX_EB2_Level.H
@@ -192,7 +192,7 @@ GShopLevel<G>::GShopLevel (IndexSpace const* is, G const& gshop, const Geometry&
     }
 
     const auto dx = geom.CellSizeArray();
-    const auto dxinv = geom.InvCellSizeArray();
+    // const auto dxinv = geom.InvCellSizeArray(); SET_BUT_NOT_USED
     const auto problo = geom.ProbLoArray();
 
     RunOn gshop_run_on = (Gpu::inLaunchRegion() && gshop.isGPUable())

--- a/Src/LinearSolvers/MLMG/AMReX_MLCellABecLap.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLCellABecLap.cpp
@@ -80,7 +80,7 @@ MLCellABecLap::applyInhomogNeumannTerm (int amrlev, MultiFab& rhs) const
     const int mglev = 0;
 
     const auto problo = m_geom[amrlev][mglev].ProbLoArray();
-    const auto probhi = m_geom[amrlev][mglev].ProbHiArray();
+    // const auto probhi = m_geom[amrlev][mglev].ProbHiArray(); SET_BUT_NOT_USED
     const Real dxi = m_geom[amrlev][mglev].InvCellSize(0);
     const Real dyi = (AMREX_SPACEDIM >= 2) ? m_geom[amrlev][mglev].InvCellSize(1) : 1.0;
     const Real dzi = (AMREX_SPACEDIM == 3) ? m_geom[amrlev][mglev].InvCellSize(2) : 1.0;

--- a/Src/LinearSolvers/MLMG/AMReX_MLCellABecLap.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLCellABecLap.cpp
@@ -80,7 +80,9 @@ MLCellABecLap::applyInhomogNeumannTerm (int amrlev, MultiFab& rhs) const
     const int mglev = 0;
 
     const auto problo = m_geom[amrlev][mglev].ProbLoArray();
-    // const auto probhi = m_geom[amrlev][mglev].ProbHiArray(); SET_BUT_NOT_USED
+#if (AMREX_SPACEDIM == 1) or (AMREX_SPACEDIM == 2)
+    const auto probhi = m_geom[amrlev][mglev].ProbHiArray();
+#endif
     const Real dxi = m_geom[amrlev][mglev].InvCellSize(0);
     const Real dyi = (AMREX_SPACEDIM >= 2) ? m_geom[amrlev][mglev].InvCellSize(1) : 1.0;
     const Real dzi = (AMREX_SPACEDIM == 3) ? m_geom[amrlev][mglev].InvCellSize(2) : 1.0;

--- a/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap.cpp
@@ -493,7 +493,7 @@ MLEBABecLap::Fsmooth (int amrlev, int mglev, MultiFab& sol, const MultiFab& rhs,
     AMREX_D_TERM(const Real dhx = m_b_scalar/(h[0]*h[0]);,
                  const Real dhy = m_b_scalar/(h[1]*h[1]);,
                  const Real dhz = m_b_scalar/(h[2]*h[2]));
-    const auto dxinv = m_geom[amrlev][mglev].InvCellSizeArray();
+    // const auto dxinv = m_geom[amrlev][mglev].InvCellSizeArray(); SET_BUT_NOT_USED
     const Real alpha = m_a_scalar;
 
     auto factory = dynamic_cast<EBFArrayBoxFactory const*>(m_factory[amrlev][mglev].get());

--- a/Src/LinearSolvers/MLMG/AMReX_MLMG.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLMG.cpp
@@ -1429,8 +1429,8 @@ MLMG::compResidual (const Vector<MultiFab*>& a_res, const Vector<MultiFab*>& a_s
     BL_PROFILE("MLMG::compResidual()");
 
     const int ncomp = linop.getNComp();
-    int nghost = 0;
-    if (cf_strategy == CFStrategy::ghostnodes) nghost = linop.getNGrow();
+    // int nghost = 0; SET_BUT_NOT_USED
+    // if (cf_strategy == CFStrategy::ghostnodes) nghost = linop.getNGrow();
    
     sol.resize(namrlevs);
     sol_raii.resize(namrlevs);


### PR DESCRIPTION
The begin() and end() methods are needed in order to use STL algorithms such as std::fill, std::transform, etc...