### PR TITLE
Handle an edge case where the block size is less than a warp

### DIFF
--- a/Src/Base/AMReX_GpuReduce.H
+++ b/Src/Base/AMReX_GpuReduce.H
@@ -42,7 +42,7 @@ T blockReduce (T x, WARPREDUCE && warp_reduce, T x0)
     __syncthreads();
     if (lane == 0) shared[wid] = x;
     __syncthreads();
-    bool b = (threadIdx.x < std::max(blockDim.x, warpSize) / warpSize);
+    bool b = (threadIdx.x == 0) or (threadIdx.x < blockDim.x / warpSize);
     x =  b ? shared[lane] : x0;
     if (wid == 0) x = warp_reduce(x);
     return x;

--- a/Src/Base/AMReX_GpuReduce.H
+++ b/Src/Base/AMReX_GpuReduce.H
@@ -42,7 +42,7 @@ T blockReduce (T x, WARPREDUCE && warp_reduce, T x0)
     __syncthreads();
     if (lane == 0) shared[wid] = x;
     __syncthreads();
-    bool b = (threadIdx.x < blockDim.x / warpSize);
+    bool b = (threadIdx.x < std::max(blockDim.x, warpSize) / warpSize);
     x =  b ? shared[lane] : x0;
     if (wid == 0) x = warp_reduce(x);
     return x;

--- a/Src/Base/AMReX_fort_mod.F90
+++ b/Src/Base/AMReX_fort_mod.F90
@@ -195,7 +195,7 @@ contains
 
     call syncthreads()
 
-    if ((threadIdx%x-1) < blockDim%x / warpsize) then
+    if ((threadIdx%x-1) < max(blockDim%x, warpsize) / warpsize) then
        y = s(lane)
     else
        y = 0


### PR DESCRIPTION
The algorithm we use for a block reduction doesn't work if there are fewer threads in a block than threads in a warp. This is a simple fix for that edge case.