### PR TITLE
Always check MPI buffer size for overflow

### DIFF
--- a/Src/Base/AMReX_FabArrayCommI.H
+++ b/Src/Base/AMReX_FabArrayCommI.H
@@ -120,7 +120,7 @@ FabArray<FAB>::FBEP_nowait (int scomp, int ncomp, const IntVect& nghost,
                 nbytes += (*this)[cct.srcIndex].nBytes(cct.sbox,scomp,ncomp);
             }
             
-            BL_ASSERT(nbytes < std::size_t(std::numeric_limits<int>::max()));
+            AMREX_ALWAYS_ASSERT(nbytes < std::size_t(std::numeric_limits<int>::max()));
             
             total_volume += nbytes;
 
@@ -448,7 +448,7 @@ FabArray<FAB>::ParallelCopy (const FabArray<FAB>& src,
                     nbytes += src[cct.srcIndex].nBytes(cct.sbox,SC,NC);
                 }
 		
-		BL_ASSERT(nbytes < std::size_t(std::numeric_limits<int>::max()));
+		AMREX_ALWAYS_ASSERT(nbytes < std::size_t(std::numeric_limits<int>::max()));
 
                 total_volume += nbytes;
 
@@ -672,7 +672,7 @@ FabArray<FAB>::PostRcvs (const MapOfCopyComTagContainers&  m_RcvTags,
             nbytes += (*this)[cct.dstIndex].nBytes(cct.dbox,icomp,ncomp);
         }
 
-        BL_ASSERT(nbytes < std::size_t(std::numeric_limits<int>::max()));
+        AMREX_ALWAYS_ASSERT(nbytes < std::size_t(std::numeric_limits<int>::max()));
 
         TotalRcvsVolume += nbytes;
 

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian.cpp
@@ -2273,7 +2273,7 @@ MLNodeLaplacian::buildIntegral ()
             MFItInfo mfi_info;
             if (Gpu::notInLaunchRegion()) mfi_info.EnableTiling().SetDynamic(true);
 #ifdef _OPENMP
-#pragma omp parallel if (Gpu::notInLaunchRegion());
+#pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
             for (MFIter mfi(*intg,mfi_info); mfi.isValid(); ++mfi)
             {


### PR DESCRIPTION
Always check MPI buffer size for overflow. This check is very fast compared to the overall communication time.

See #642.