### PR TITLE
VisMF: Remove Shadow Warning

### DIFF
--- a/Src/Base/AMReX_VisMF.H
+++ b/Src/Base/AMReX_VisMF.H
@@ -314,7 +314,6 @@ private:
     static void FindOffsets (const FabArray<FArrayBox> &fafab,
 			     const std::string &fafab_name,
                              VisMF::Header &hdr,
-			     bool groupSets,
 			     VisMF::Header::Version whichVersion,
 			     NFilesIter &nfi,
                              MPI_Comm comm = ParallelDescriptor::Communicator());

--- a/Src/Base/AMReX_VisMF.cpp
+++ b/Src/Base/AMReX_VisMF.cpp
@@ -1079,7 +1079,7 @@ VisMF::Write (const FabArray<FArrayBox>&    mf,
       hdr.CalculateMinMax(mf, coordinatorProc);
     }
 
-    VisMF::FindOffsets(mf, filePrefix, hdr, groupSets, currentVersion, nfi,
+    VisMF::FindOffsets(mf, filePrefix, hdr, currentVersion, nfi,
                        ParallelDescriptor::Communicator());
 
     bytesWritten += VisMF::WriteHeader(mf_name, hdr, coordinatorProc);
@@ -1128,7 +1128,6 @@ void
 VisMF::FindOffsets (const FabArray<FArrayBox> &mf,
 		    const std::string &filePrefix,
                     VisMF::Header &hdr,
-		    bool groupSets,
 		    VisMF::Header::Version whichVersion,
 		    NFilesIter &nfi, MPI_Comm comm)
 {


### PR DESCRIPTION
Change a private static interface to use the only-usage, same-class static control variable it passes to avoid variable name shadowing.