### PR TITLE
Added check for RedistributeCPU edge case 

### DIFF
--- a/Src/Particle/AMReX_ParticleContainerI.H
+++ b/Src/Particle/AMReX_ParticleContainerI.H
@@ -181,10 +181,15 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
                 {
                     grid = local_grid;
                 }
-                else
-                {
-                    grid = (*redistribute_mask_ptr)[local_grid](Index(p, lev), 0);
-                }
+		else
+		{
+		    ba.intersections(Box(iv, iv), isects, true, 0);
+		    grid = isects.empty() ? -1 : isects[0].first;
+		    if(grid == -1)
+		    {
+		        grid = (*redistribute_mask_ptr)[local_grid](Index(p, lev), 0);
+		    }
+		}
 	    }
             
             if (grid >= 0) {


### PR DESCRIPTION
Edge case where particle gets reset to lo boundary, but is not contained in the Box it came from