### PR TITLE
amrex::Vector implicit conversion from std::vector

### DIFF
--- a/Src/Base/AMReX_Vector.H
+++ b/Src/Base/AMReX_Vector.H
@@ -27,6 +27,12 @@ public:
     using std::vector<T, Allocator>::vector;
     using typename std::vector<T, Allocator>::size_type;
 
+    Vector(const std::vector<T, Allocator>& other)
+      : vector(other) {}
+
+    Vector(std::vector<T, Allocator>&& other) noexcept
+      : vector(std::move(other)) {}
+
     T& operator[] (size_type i) noexcept
     {
         BL_ASSERT( i < (this->std::vector<T, Allocator>::size()) );

--- a/Src/Base/AMReX_Vector.H
+++ b/Src/Base/AMReX_Vector.H
@@ -27,6 +27,8 @@ public:
     using std::vector<T, Allocator>::vector;
     using typename std::vector<T, Allocator>::size_type;
 
+    Vector() = default;
+
     Vector(const std::vector<T, Allocator>& other)
       : std::vector<T, Allocator>(other) {}
 

--- a/Src/Base/AMReX_Vector.H
+++ b/Src/Base/AMReX_Vector.H
@@ -28,10 +28,10 @@ public:
     using typename std::vector<T, Allocator>::size_type;
 
     Vector(const std::vector<T, Allocator>& other)
-      : vector(other) {}
+      : std::vector<T, Allocator>(other) {}
 
     Vector(std::vector<T, Allocator>&& other) noexcept
-      : vector(std::move(other)) {}
+      : std::vector<T, Allocator>(std::move(other)) {}
 
     T& operator[] (size_type i) noexcept
     {


### PR DESCRIPTION
Hi,

this change allows to pass `std::vector<T, Allocator>` objects directly to functions which take an  `amrex::Vector<T, Allocator>` argument. Currently one need to call another constructor as in `amrex::Vector<T>(v.begin(), v.end())`

What do you think?