### PR TITLE
Fix for USE_CUDA=TRUE case

### DIFF
--- a/Tests/HDF5Benchmark/GNUmakefile
+++ b/Tests/HDF5Benchmark/GNUmakefile
@@ -18,6 +18,14 @@ TINY_PROFILE = TRUE
 
 EBASE     = main
 
+# HDF5_HOME   = /home/khl7265/.local
+USE_HDF5 = TRUE
+ifeq ($(USE_HDF5), TRUE)
+DEFINES += -DAMREX_USE_HDF5
+INCLUDE_LOCATIONS += $(HDF5_HOME)/include
+LIBRARIES         += -lhdf5 -lz -ldl -L$(HDF5_HOME)/lib
+endif
+
 include $(AMREX_HOME)/Tools/GNUMake/Make.defs
 
 include ./Make.package
@@ -26,10 +34,3 @@ include $(AMREX_HOME)/Src/Particle/Make.package
 
 include $(AMREX_HOME)/Tools/GNUMake/Make.rules
 
-# HDF5_HOME   = /home/khl7265/.local
-USE_HDF5 = TRUE
-ifeq ($(USE_HDF5), TRUE)
-DEFINES += -DAMREX_USE_HDF5
-INCLUDE_LOCATIONS += $(HDF5_HOME)/include
-LIBRARIES         += -lhdf5 -lz -ldl -L$(HDF5_HOME)/lib
-endif


### PR DESCRIPTION
A more extensive fix would to get this properly into the Tools/GNUMake portion of amrex, which would also help with automatically determining which environment variables reference which directory the library and headers live in.