### PR TITLE
Feature/virtual make base grids

### DIFF
--- a/Src/AmrCore/AMReX_AmrMesh.H
+++ b/Src/AmrCore/AMReX_AmrMesh.H
@@ -229,6 +229,14 @@ public:
     //! Manually tag.  Note that tags is built on level lev grids coarsened by bf_lev[lev].
     virtual void ManualTagsPlacement (int lev, TagBoxArray& tags, const Vector<IntVect>& bf_lev) {}
 
+    //! Apply some user-defined changes the to base grids.
+    //!
+    //! This function is only called by MakeNewGrids after computing a box array for the coarsest level
+    //! and before calling MakeNewLevelFromScratch.
+    //!
+    //! For example, use this function if you want to remove covered grids on the coarsest refinement level.
+    virtual void PostProcessBaseGrids(BoxArray& box_array) {}
+
     virtual BoxArray GetAreaNotToTag (int lev) { return BoxArray(); }
 
     long CountCells (int lev) noexcept;

--- a/Src/AmrCore/AMReX_AmrMesh.H
+++ b/Src/AmrCore/AMReX_AmrMesh.H
@@ -235,7 +235,7 @@ public:
     //! and before calling MakeNewLevelFromScratch.
     //!
     //! For example, use this function if you want to remove covered grids on the coarsest refinement level.
-    virtual void PostProcessBaseGrids(BoxArray& box_array) {}
+    virtual void PostProcessBaseGrids(BoxArray& box_array) const {}
 
     virtual BoxArray GetAreaNotToTag (int lev) { return BoxArray(); }
 

--- a/Src/AmrCore/AMReX_AmrMesh.cpp
+++ b/Src/AmrCore/AMReX_AmrMesh.cpp
@@ -458,6 +458,7 @@ AmrMesh::MakeBaseGrids () const
     if (ba == grids[0]) {
         ba = grids[0];  // to avoid duplicates
     }
+    PostProcessBaseGrids(ba);
     return ba;
 }
 


### PR DESCRIPTION
This patch adds a hook to MakeBaseGrids such that the user can manipulate the generated BoxArray before it is getting used.

As an example, I use the below code to remove covered grids from the coarsest AMR level.
I've tested it in 2D toy problems only so far.

```cpp
void GriddingAlgorithm::PostProcessBaseGrids(::amrex::BoxArray& ba) const {
  if (hierarchy_.GetOptions().remove_covered_grids) {
    ::amrex::DistributionMapping dm(ba);
    std::unique_ptr<::amrex::EBFArrayBoxFactory> eb_factory =
        ::amrex::makeEBFabFactory(hierarchy_.GetOptions().index_spaces[0],
                                  hierarchy_.GetGeometry(0), ba, dm, {0, 0, 0},
                                  ::amrex::EBSupport::basic);
    const ::amrex::FabArray<::amrex::EBCellFlagFab>& flags =
        eb_factory->getMultiEBCellFlagFab();
    ::amrex::Vector<::amrex::Box> not_covered{};
    ForEachFab(ba, dm, [&](const ::amrex::MFIter& mfi) {
      if (flags[mfi].getType() != ::amrex::FabType::covered) {
        not_covered.push_back(mfi.validbox());
      }
    });
    ::amrex::AllGatherBoxes(not_covered);
    ba = ::amrex::BoxArray{::amrex::BoxList(std::move(not_covered))};
  }
}
```