### PR TITLE
Fix Warning in AMREX_DEVICE_COMPILE

### DIFF
--- a/Src/Base/AMReX.H
+++ b/Src/Base/AMReX.H
@@ -91,7 +91,7 @@ namespace amrex
     namespace detail { void Error_host_doit (const char * msg); }
     AMREX_GPU_HOST_DEVICE inline
     void Error (const char * msg = 0) {
-#if AMREX_DEVICE_COMPILE()
+#if AMREX_DEVICE_COMPILE
         if (msg) AMREX_DEVICE_PRINTF("Error %s\n", msg);
         AMREX_DEVICE_ASSERT(0);
 #else
@@ -104,7 +104,7 @@ namespace amrex
     namespace detail { void Warning_host_doit (const char * msg); }
     AMREX_GPU_HOST_DEVICE inline
     void Warning (const char * msg) {
-#if AMREX_DEVICE_COMPILE()
+#if AMREX_DEVICE_COMPILE
         if (msg) AMREX_DEVICE_PRINTF("Warning %s\n", msg);
 #else
         detail::Warning_host_doit(msg);
@@ -116,7 +116,7 @@ namespace amrex
     namespace detail { void Abort_host_doit (const char * msg); }
     AMREX_GPU_HOST_DEVICE inline
     void Abort (const char * msg = 0) {
-#if AMREX_DEVICE_COMPILE()
+#if AMREX_DEVICE_COMPILE
         if (msg) AMREX_DEVICE_PRINTF("Abort %s\n", msg);
         AMREX_DEVICE_ASSERT(0);
 #else
@@ -133,7 +133,7 @@ namespace amrex
                                               const char* msg); }
     AMREX_GPU_HOST_DEVICE inline
     void Assert (const char* EX, const char* file, int line, const char* msg = nullptr) {
-#if AMREX_DEVICE_COMPILE()
+#if AMREX_DEVICE_COMPILE
         if (msg) {
             AMREX_DEVICE_PRINTF("Assertion `%s' failed, file \"%s\", line %d, Msg: %s",
                                 EX, file, line, msg);

--- a/Src/Base/AMReX_Array4.H
+++ b/Src/Base/AMReX_Array4.H
@@ -169,7 +169,7 @@ namespace amrex {
         {
             if (i<begin.x || i>=end.x || j<begin.y || j>=end.y || k<begin.z || k>=end.z
                 || n < 0 || n >= ncomp) {
-#if AMREX_DEVICE_COMPILE()
+#if AMREX_DEVICE_COMPILE
                 AMREX_DEVICE_PRINTF(" (%d,%d,%d,%d) is out of bound (%d:%d,%d:%d,%d:%d,0:%d)\n",
                                     i, j, k, n, begin.x, end.x-1, begin.y, end.y-1,
                                     begin.z, end.z-1, ncomp-1);

--- a/Src/Base/AMReX_BaseFab.H
+++ b/Src/Base/AMReX_BaseFab.H
@@ -1534,7 +1534,7 @@ template <class T>
 AMREX_GPU_HOST_DEVICE
 BaseFab<T>::~BaseFab () noexcept
 {
-#if AMREX_DEVICE_COMPILE()
+#if AMREX_DEVICE_COMPILE
     ;
 #else
     clear();
@@ -2525,7 +2525,7 @@ BaseFab<T>::atomicAdd (const BaseFab<T>& src, const Box& srcbox, const Box& dest
     amrex::Loop(destbox, numcomp, [=] (int i, int j, int k, int n) AMREX_NOEXCEPT 
     {
         T* p = d.ptr(i,j,k,n+destcomp);
-#if AMREX_DEVICE_COMPILE()
+#if AMREX_DEVICE_COMPILE
         amrex::Gpu::Atomic::Add(p, s(i+offset.x,j+offset.y,k+offset.z,n+srccomp));
 #else
 #ifdef _OPENMP

--- a/Src/Base/AMReX_GpuAtomic.H
+++ b/Src/Base/AMReX_GpuAtomic.H
@@ -116,7 +116,7 @@ namespace detail {
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     T Add (T* sum, T value) noexcept
     {
-#if AMREX_DEVICE_COMPILE()
+#if AMREX_DEVICE_COMPILE
         return Add_device(sum, value);
 #else
         auto old = *sum;
@@ -175,7 +175,7 @@ namespace detail {
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     T Min (T* m, T value) noexcept
     {
-#if AMREX_DEVICE_COMPILE()
+#if AMREX_DEVICE_COMPILE
         return Min_device(m, value);
 #else
         auto old = *m;
@@ -234,7 +234,7 @@ namespace detail {
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     T Max (T* m, T value) noexcept
     {
-#if AMREX_DEVICE_COMPILE()
+#if AMREX_DEVICE_COMPILE
         return Max_device(m, value);
 #else
         auto old = *m;
@@ -387,7 +387,7 @@ namespace HostDevice { namespace Atomic {
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     void Add (T* sum, T value) noexcept
     {
-#if AMREX_DEVICE_COMPILE()
+#if AMREX_DEVICE_COMPILE
         Gpu::Atomic::Add(sum,value);
 #else
 #ifdef _OPENMP

--- a/Src/Base/AMReX_GpuLaunch.H
+++ b/Src/Base/AMReX_GpuLaunch.H
@@ -102,7 +102,7 @@ namespace Gpu {
     inline
     Box getThreadBox (const Box& bx, long offset) noexcept
     {
-#if AMREX_DEVICE_COMPILE()
+#if AMREX_DEVICE_COMPILE
         const auto len = bx.length3d();
         long k = offset / (len[0]*len[1]);
         long j = (offset - k*(len[0]*len[1])) / len[0];

--- a/Src/Base/AMReX_GpuQualifiers.H
+++ b/Src/Base/AMReX_GpuQualifiers.H
@@ -33,6 +33,6 @@
 
 #endif
 
-#define AMREX_DEVICE_COMPILE() defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__) || defined(__SYCL_DEVICE_ONLY__)
+#define AMREX_DEVICE_COMPILE (__CUDA_ARCH__ || __HIP_DEVICE_COMPILE__ || __SYCL_DEVICE_ONLY__)
 
 #endif

--- a/Src/Base/AMReX_GpuRange.H
+++ b/Src/Base/AMReX_GpuRange.H
@@ -31,7 +31,7 @@ long at (T const& b, long offset) noexcept { return offset; }
 AMREX_GPU_HOST_DEVICE
 AMREX_FORCE_INLINE long size (Box const& b) noexcept
 {
-#if AMREX_DEVICE_COMPILE()
+#if AMREX_DEVICE_COMPILE
     return b.numPts();
 #else
     return 1;
@@ -41,7 +41,7 @@ AMREX_FORCE_INLINE long size (Box const& b) noexcept
 AMREX_GPU_HOST_DEVICE
 AMREX_FORCE_INLINE Box at (Box const& b, long offset) noexcept
 {
-#if AMREX_DEVICE_COMPILE()
+#if AMREX_DEVICE_COMPILE
     auto len = b.length3d();
     long k = offset / (len[0]*len[1]);
     long j = (offset - k*(len[0]*len[1])) / len[0];

--- a/Src/EB/AMReX_EB2_GeometryShop.H
+++ b/Src/EB/AMReX_EB2_GeometryShop.H
@@ -26,7 +26,7 @@ AMREX_GPU_HOST_DEVICE
 Real
 IF_f (F const& f, GpuArray<Real,AMREX_SPACEDIM> const& p) noexcept
 {
-#if AMREX_DEVICE_COMPILE()
+#if AMREX_DEVICE_COMPILE
     amrex::Error("EB2::GeometryShop: how did this happen?");
     return 0.0;
 #else

--- a/Src/EB/AMReX_EB2_IF_Polynomial.H
+++ b/Src/EB/AMReX_EB2_IF_Polynomial.H
@@ -59,7 +59,7 @@ public:
     AMREX_GPU_HOST_DEVICE inline
     Real operator() (AMREX_D_DECL(Real x, Real y, Real z)) const noexcept
     {
-#if AMREX_DEVICE_COMPILE()
+#if AMREX_DEVICE_COMPILE
         PolyTerm const* AMREX_RESTRICT pt = m_dp;
 #else
         PolyTerm const* AMREX_RESTRICT pt = m_polynomial.data();


### PR DESCRIPTION
Adding `defined()` in a macro is raising warnings of undefined behavior (clang) or non-portable behavior (gcc).

Modern versions of GCC (used: v7.4.0) issue a `-Wexpansion-to-defined` warning on this.
```
Src/Base/AMReX_GpuAtomic.H:390:26:
  warning: this use of "defined" may not be portable
  [-Wexpansion-to-defined]
 #if AMREX_DEVICE_COMPILE()
```

Clang's warning:
```
  warning: macro expansion producing 'defined' has undefined behavior
    [-Wexpansion-to-defined] 
```

This tries to fix 2133x compile warnings in WarpX.

### To Do

- [x] it's late at night, verify again the warning is actually gone now
- [x] test-compile with nvcc to see everything is still working
- [x] feedback if DPC++ & HIP compile paths still work