### PR TITLE
CMake: AMReX::amrex Alias

### DIFF
--- a/Src/CMakeLists.txt
+++ b/Src/CMakeLists.txt
@@ -6,6 +6,7 @@
 # setting the compile definitions and so on
 #
 add_library( amrex )
+add_library( AMReX::amrex ALIAS amrex )
 
 # Where to store Fortran modules
 set_target_properties( amrex

--- a/Tools/CMake/AMReXFlagsTargets.cmake
+++ b/Tools/CMake/AMReXFlagsTargets.cmake
@@ -47,6 +47,7 @@ endforeach ()
 # C++ flags
 # 
 add_library(Flags_CXX INTERFACE)
+add_library(AMReX::Flags_CXX ALIAS Flags_CXX)
 
 target_compile_options( Flags_CXX
    INTERFACE
@@ -64,6 +65,7 @@ target_compile_options( Flags_CXX
 # Fortran flags
 # 
 add_library(Flags_Fortran INTERFACE)
+add_library(AMReX::Flags_Fortran ALIAS Flags_Fortran)
 
 target_compile_options( Flags_Fortran
    INTERFACE
@@ -82,6 +84,7 @@ target_compile_options( Flags_Fortran
 # Fortran REQUIRED flags -- This is for internal use only: it is useless to export it
 #
 add_library(Flags_Fortran_REQUIRED INTERFACE)
+add_library(AMReX::Flags_Fortran_REQUIRED ALIAS Flags_Fortran_REQUIRED)
 
 target_compile_options( Flags_Fortran_REQUIRED
    INTERFACE
@@ -96,6 +99,7 @@ target_compile_options( Flags_Fortran_REQUIRED
 # Floating point exceptions
 # 
 add_library(Flags_FPE INTERFACE)
+add_library(AMReX::Flags_FPE ALIAS Flags_FPE)
 
 target_compile_options ( Flags_FPE
    INTERFACE


### PR DESCRIPTION
Adding a project alias on `CMakeLists.txt` level that is identical to the installed CMake namespace.

This is a community-convention in CMake and makes sure that both `add_subdirectory(AMReX_DIR)` as well as `find_package(AMReX)` targets can just be accessed as `AMReX::amrex` in all cases in user code.

cc @mic84 