### PR TITLE
Readme: Add CI Badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 [![Citing](http://joss.theoj.org/papers/10.21105/joss.01370/status.svg)](https://doi.org/10.21105/joss.01370)
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.2555438.svg)](https://doi.org/10.5281/zenodo.2555438)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.2555438.svg)](https://doi.org/10.5281/zenodo.2555438)  
+![CI: CMake on development](https://github.com/AMReX-codes/amrex/workflows/cmake/badge.svg?branch=development)
+![CI: Travis on development](https://img.shields.io/travis/AMReX-codes/amrex/development)
 
 ## License
 


### PR DESCRIPTION
Add Travis-CI and GitHub Action status badges for the `development` branch.

cc @atmyers @mic84 @maxpkatz 