### PR TITLE
CMake Tools: Fix CXX Host Compiler Check

### DIFF
--- a/Tools/CMake/AMReX_Config.cmake
+++ b/Tools/CMake/AMReX_Config.cmake
@@ -155,11 +155,11 @@ function (configure_amrex)
    #
    # GNU-specific defines
    #
-   if ( ${CMAKE_C_COMPILER_ID} STREQUAL "GNU" )
+   if ( ${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU" )
 
       if ( CMAKE_CXX_COMPILER_VERSION VERSION_LESS "4.8" )
          message( WARNING
-            " Your default GCC is version ${CMAKE_CXX_COMPILER_VERSION}.This might break during build. GCC>=4.8 is recommended.")
+            " Your default GCC is version ${CMAKE_CXX_COMPILER_VERSION}. This might break during build. GCC>=4.8 is recommended.")
       endif ()
 
       string( REPLACE "." ";" VERSION_LIST ${CMAKE_CXX_COMPILER_VERSION})


### PR DESCRIPTION
False Warning with Clang+Gfortran builds.

cc @mic84 