### PR TITLE
CMake: CXX Downstream Transitive Fortran

### DIFF
--- a/Src/CMakeLists.txt
+++ b/Src/CMakeLists.txt
@@ -16,6 +16,9 @@ set_target_properties( amrex
    INTERFACE_INCLUDE_DIRECTORIES
    $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/mod_files>
    )
+# adding those is a work-around that avoids that downstream C++ projects have
+# to `enable_language(Fortran)`
+target_link_libraries(amrex PUBLIC ${CMAKE_Fortran_IMPLICIT_LINK_LIBRARIES})
 
 # Load Flags targets and use them if no user-defined flags is given
 include(AMReXFlagsTargets)

--- a/Tutorials/Basic/HelloWorld_C/CMakeLists.txt
+++ b/Tutorials/Basic/HelloWorld_C/CMakeLists.txt
@@ -1,8 +1,7 @@
 # Preamble ####################################################################
 #
 cmake_minimum_required(VERSION 3.14.0)
-project(HelloWorld LANGUAGES CXX Fortran)
-#                                ^^^^^^^ required: CMake bug
+project(HelloWorld LANGUAGES CXX)
 
 
 # Options and Variants ########################################################


### PR DESCRIPTION
CMake currently has the bug that some transitive, implicit language dependencies as not commuted downstream if the downstream project does not `enable_language` the same lang. as upstream.

This is mostly visible in missing `-lgfortran` links.

- [x] demonstrate bug (first commit)
- [x] add work-around (second commit)

cc @mic84 