### PR TITLE
Initialize the particles in the first cell of each tile for EM PIC tutorial

### DIFF
--- a/Tutorials/Particles/ElectromagneticPIC/Source/EMParticleContainerInit.cpp
+++ b/Tutorials/Particles/ElectromagneticPIC/Source/EMParticleContainerInit.cpp
@@ -139,7 +139,7 @@ InitParticles(const IntVect& a_num_particles_per_cell,
             unsigned int uiz = amrex::min(nz-1,amrex::max(0,iz));
             unsigned int cellid = (uix * ny + uiy) * nz + uiz;
 
-            int pidx = poffset[cellid]-1;
+            int pidx = poffset[cellid] - poffset[0];
 
             for (int i_part=0; i_part<num_ppc;i_part++)
             {


### PR DESCRIPTION
Particle initialization in this tutorial counts the number of particles in each cell to introduce and then uses an inclusive scan to generate index offsets for indexing into the particle tile's array of structs after resizing the particle tile.

This will result in each entry in `offsets` containing: (index of last particle in current cell + 1)

Because of this, when looping over cells to initialize the newly created particles, it's necessary to subtract the number of particles in the first cell of the tile from the inclusive scan values in `offsets`.

Doing this will make sure `pidx = 0` for the first cell in each tile. And `pidx = (index of last particle in previous cell + 1)` for all subsequent cells.