### PR TITLE
Make amrex::Random() return numbers in the same interval for both CPU and GPU: [0:1)

### DIFF
--- a/Src/Base/AMReX_Random.H
+++ b/Src/Base/AMReX_Random.H
@@ -20,8 +20,8 @@ namespace amrex
     /**
     * \brief Generate a psuedo-random double using C++11's mt19937.
     *
-    *  Generates one pseudorandom real number (double) from a normal
-    *  distribution with mean 'mean' and standard deviation 'stddev'.
+    *  Generates one pseudorandom real number (double) from a uniform
+    *  distribution between 0.0 and 1.0 (0.0 included, 1.0 excluded)
     *
     */
     AMREX_GPU_HOST_DEVICE Real Random ();


### PR DESCRIPTION
According to CUDA documentation, `curand_uniform` (https://docs.nvidia.com/cuda/curand/device-api-overview.html)
> returns a sequence of pseudorandom floats uniformly distributed between 0.0 and 1.0. It may return from 0.0 to 1.0, where 1.0 is included and 0.0 is excluded

while `std::uniform_real_distribution`  (https://en.cppreference.com/w/cpp/numeric/random/uniform_real_distribution)
> Produces random floating-point values i, uniformly distributed on the interval [a, b)

This PR should uniform the behaviour of `amrex::Random()`, which uses either `curand_uniform` or `std::uniform_real_distribution` depending on the architecture. 

The PR updates also the documentation block