### PR TITLE
Additional variant of FlashFluxRegister load method (untested)

### DIFF
--- a/Src/F_Interfaces/AmrCore/AMReX_FlashFluxRegister.H
+++ b/Src/F_Interfaces/AmrCore/AMReX_FlashFluxRegister.H
@@ -36,7 +36,7 @@ public:
     void store (int fine_global_index, int dir, FArrayBox const& fine_flux, FArrayBox const& area,
                 Real scaling_factor);
 
-    // flux_in_register = scaling_factor * \sum{fine_flux * area}, if the component is flux denisty
+    // flux_in_register = scaling_factor * \sum{fine_flux * area}, if the component is flux density
     //                    scaling_factor * \sum{fine_flux}       , otherwise
     void store (int fine_global_index, int dir, FArrayBox const& fine_flux, FArrayBox const& area,
                 const int* isFluxDensity, Real scaling_factor);
@@ -49,6 +49,9 @@ public:
     // crse_flux = flux_in_register * sf_f + cflux * sf_c
     void load (int coarse_global_index, int dir, FArrayBox& crse_flux, FArrayBox const& cflux,
                Real sf_f, Real sf_c) const;
+
+    // crse_flux = flux_in_register / area
+    void load (int coarse_global_index, int dir, FArrayBox& crse_flux, FArrayBox const& area) const;
 
     // crse_flux = flux_in_register/area * sf_f + cflux * sf_c
     void load (int coarse_global_index, int dir, FArrayBox& crse_flux, FArrayBox const& cflux,

--- a/Src/F_Interfaces/AmrCore/AMReX_flash_fluxregister_fi.cpp
+++ b/Src/F_Interfaces/AmrCore/AMReX_flash_fluxregister_fi.cpp
@@ -44,7 +44,19 @@ extern "C" {
         flux_reg->load(cgid, dir, fab, cfab, sf_f, sf_c);
     }
 
-    void amrex_fi_flash_fluxregister_load_area (FlashFluxRegister const* flux_reg, int cgid, int dir,
+    void amrex_fi_flash_fluxregister_load_1_area (FlashFluxRegister const* flux_reg, int cgid, int dir,
+                                                Real* flux, const int* flo, const int* fhi, int nc,
+                                                Real const* area)
+    {
+        Box bx;
+        bx = Box(IntVect(flo), IntVect(fhi));
+        bx.shiftHalf(dir,-1);
+        FArrayBox fab(bx,nc,flux);
+        const FArrayBox areafab(bx,1,const_cast<Real*>(area));
+        flux_reg->load(cgid, dir, fab, areafab);
+    }
+
+    void amrex_fi_flash_fluxregister_load_2_area (FlashFluxRegister const* flux_reg, int cgid, int dir,
                                                 Real* flux, const int* flo, const int* fhi, int nc,
                                                 Real const* cflux, Real const* area,
                                                 Real sf_f, Real sf_c)

--- a/Src/F_Interfaces/AmrCore/AMReX_flash_fluxregister_mod.F90
+++ b/Src/F_Interfaces/AmrCore/AMReX_flash_fluxregister_mod.F90
@@ -29,7 +29,8 @@ module amrex_flash_fluxregister_module
      procedure, private :: amrex_flash_fluxregister_assign
      procedure, private :: amrex_flash_fluxregister_load_1
      procedure, private :: amrex_flash_fluxregister_load_2
-     procedure, private :: amrex_flash_fluxregister_load_area
+     procedure, private :: amrex_flash_fluxregister_load_1_area
+     procedure, private :: amrex_flash_fluxregister_load_2_area
      procedure, private :: amrex_flash_fluxregister_load_area_ifd
      procedure, private :: amrex_flash_fluxregister_store
      procedure, private :: amrex_flash_fluxregister_store_area

--- a/Src/F_Interfaces/AmrCore/AMReX_flash_fluxregister_mod.F90
+++ b/Src/F_Interfaces/AmrCore/AMReX_flash_fluxregister_mod.F90
@@ -19,7 +19,8 @@ module amrex_flash_fluxregister_module
      generic   :: assignment(=) => amrex_flash_fluxregister_assign ! shallow copy
      generic   :: load          => amrex_flash_fluxregister_load_1, &
                                    amrex_flash_fluxregister_load_2, &
-                                   amrex_flash_fluxregister_load_area, &
+                                   amrex_flash_fluxregister_load_1_area, &
+                                   amrex_flash_fluxregister_load_2_area, &
                                    amrex_flash_fluxregister_load_area_ifd
      generic   :: store         => amrex_flash_fluxregister_store, &
                                    amrex_flash_fluxregister_store_area, &
@@ -74,7 +75,17 @@ module amrex_flash_fluxregister_module
        real(amrex_real), value :: sff, sfc
      end subroutine amrex_fi_flash_fluxregister_load_2
 
-     subroutine amrex_fi_flash_fluxregister_load_area (fr,cgid,dir,flux,flo,fhi,nc,cflux,a,sff,sfc) bind(c)
+     subroutine amrex_fi_flash_fluxregister_load_1_area (fr,cgid,dir,flux,flo,fhi,nc,a) bind(c)
+       import
+       implicit none
+       type(c_ptr), value :: fr
+       real(amrex_real), intent(inout) :: flux(*)
+       real(amrex_real), intent(in) :: a(*)
+       integer(c_int), value, intent(in) :: cgid, dir, nc
+       integer(c_int), intent(in) :: flo(*), fhi(*)
+     end subroutine amrex_fi_flash_fluxregister_load_1_area
+
+     subroutine amrex_fi_flash_fluxregister_load_2_area (fr,cgid,dir,flux,flo,fhi,nc,cflux,a,sff,sfc) bind(c)
        import
        implicit none
        type(c_ptr), value :: fr
@@ -83,7 +94,7 @@ module amrex_flash_fluxregister_module
        integer(c_int), value, intent(in) :: cgid, dir, nc
        integer(c_int), intent(in) :: flo(*), fhi(*)
        real(amrex_real), value :: sff, sfc
-     end subroutine amrex_fi_flash_fluxregister_load_area
+     end subroutine amrex_fi_flash_fluxregister_load_2_area
 
      subroutine amrex_fi_flash_fluxregister_load_area_ifd (fr,cgid,dir,flux,flo,fhi,nc,cflux,a,ifd,sff,sfc) bind(c)
        import
@@ -267,10 +278,20 @@ contains
        my_sf_c = -1._amrex_real
     end if
     call amrex_fi_flash_fluxregister_load_2(this%p, grid_idx, dir, &
-         flux, flo, fhi, fhi(4)-flo(4)+1, cflux, sf_f, sf_c)
+         flux, flo, fhi, fhi(4)-flo(4)+1, cflux, my_sf_f, my_sf_c)
   end subroutine amrex_flash_fluxregister_load_2
 
-  subroutine amrex_flash_fluxregister_load_area (this, flux, area, flo, fhi, cflux, grid_idx, dir, sf_f, sf_c)
+  subroutine amrex_flash_fluxregister_load_1_area (this, flux, area, flo, fhi, grid_idx, dir)
+    class(amrex_flash_fluxregister), intent(inout) :: this
+    integer, intent(in) :: flo(*), fhi(*), grid_idx, dir
+    real(amrex_real), intent(inout) ::  flux(flo(1):fhi(1),flo(2):fhi(2),flo(3):fhi(3),flo(4):fhi(4))
+    real(amrex_real), intent(in   ) ::  area(flo(1):fhi(1),flo(2):fhi(2),flo(3):fhi(3))
+    !
+    call amrex_fi_flash_fluxregister_load_1_area(this%p, grid_idx, dir, &
+         flux, flo, fhi, fhi(4)-flo(4)+1, area)
+  end subroutine amrex_flash_fluxregister_load_1_area
+
+  subroutine amrex_flash_fluxregister_load_2_area (this, flux, area, flo, fhi, cflux, grid_idx, dir, sf_f, sf_c)
     class(amrex_flash_fluxregister), intent(inout) :: this
     integer, intent(in) :: flo(*), fhi(*), grid_idx, dir
     real(amrex_real), intent(inout) ::  flux(flo(1):fhi(1),flo(2):fhi(2),flo(3):fhi(3),flo(4):fhi(4))
@@ -289,9 +310,9 @@ contains
     else
        my_sf_c = -1._amrex_real
     end if
-    call amrex_fi_flash_fluxregister_load_area(this%p, grid_idx, dir, &
-         flux, flo, fhi, fhi(4)-flo(4)+1, cflux, area, sf_f, sf_c)
-  end subroutine amrex_flash_fluxregister_load_area
+    call amrex_fi_flash_fluxregister_load_2_area(this%p, grid_idx, dir, &
+         flux, flo, fhi, fhi(4)-flo(4)+1, cflux, area, my_sf_f, my_sf_c)
+  end subroutine amrex_flash_fluxregister_load_2_area
 
   subroutine amrex_flash_fluxregister_load_area_ifd (this, flux, area, flo, fhi, isFluxDensity, &
        cflux, grid_idx, dir, sf_f, sf_c)
@@ -321,7 +342,7 @@ contains
        ifd = 0
     endwhere
     call amrex_fi_flash_fluxregister_load_area_ifd(this%p, grid_idx, dir, &
-         flux, flo, fhi, fhi(4)-flo(4)+1, cflux, area, ifd, sf_f, sf_c)
+         flux, flo, fhi, fhi(4)-flo(4)+1, cflux, area, ifd, my_sf_f, my_sf_c)
   end subroutine amrex_flash_fluxregister_load_area_ifd
 
 end module amrex_flash_fluxregister_module


### PR DESCRIPTION
1. Add another variant of load method, amrex_flash_fluxregister_load_1_area,
   Since we will frequently use this for FLASH. This is for when we
   have area factors, but do not use an additional (cflux) input as in
   amrex_flash_fluxregister_load_2_area. It turns out we never need a
   separate scalar scaling factor in this case, so I also removed that.

2. Rename previous
     amrex_flash_fluxregister_load_area -> amrex_flash_fluxregister_load_2_area
   and
     amrex_fi_flash_fluxregister_load_area -> amrex_fi_flash_fluxregister_load_2_area

3. Fix: Replace sf_f -> my_sf_f, sf_c -> my_sf_c in a couple
   amrex_fi_flash_fluxregister_load_foo calls, as apparently intended.