### PR TITLE
conduit blueprint: add topo name option to particle container wrapper

### DIFF
--- a/Src/Extern/Conduit/AMReX_Conduit_Blueprint.H
+++ b/Src/Extern/Conduit/AMReX_Conduit_Blueprint.H
@@ -98,7 +98,8 @@ namespace amrex
                                                                NArrayInt> &pc,
                                        const Vector<std::string> &real_comp_names,
                                        const Vector<std::string> &int_comp_names,
-                                       conduit::Node &bp_mesh);
+                                       conduit::Node &bp_mesh,
+                                       const std::string &topology_name="particles");
 #endif
 
     // Writes a Mesh Blueprint representation to a set of files that

--- a/Src/Extern/Conduit/AMReX_Conduit_Blueprint.H
+++ b/Src/Extern/Conduit/AMReX_Conduit_Blueprint.H
@@ -91,6 +91,10 @@ namespace amrex
     //   real_comp_names are first mapped in order to the aos then soa reals
     //   int_comp_names are first mapped in order to the aos then soa ints
     //
+    // `topology_name` allows you to control the name of the topology, 
+    //  coordset and fields used to represent the passed particle container. 
+    //  This allows you to use unique names to wrap multiple particle containers
+    //  into a single blueprint tree.
     template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt>
     void ParticleContainerToBlueprint (const ParticleContainer<NStructReal,
                                                                NStructInt,

--- a/Src/Extern/Conduit/AMReX_Conduit_Blueprint_ParticlesI.H
+++ b/Src/Extern/Conduit/AMReX_Conduit_Blueprint_ParticlesI.H
@@ -28,7 +28,8 @@ ParticleTileToBlueprint(const ParticleTile<NStructReal,
                                            NArrayInt> &ptile,
                         const Vector<std::string> &real_comp_names,
                         const Vector<std::string> &int_comp_names,
-                        conduit::Node &res)
+                        conduit::Node &res,
+                        const std::string &topology_name)
 {
     int num_particles = ptile.GetArrayOfStructs().size();
     int struct_size   = sizeof(Particle<NStructReal, NStructInt>);
@@ -40,17 +41,19 @@ ParticleTileToBlueprint(const ParticleTile<NStructReal,
     const auto &p_aos = ptile.GetArrayOfStructs()[0];
 
     // setup a blueprint description for the particle mesh
-    
-    conduit::Node &n_coords  = res["coordsets/particle_coords"];
+    // create a coordinate set
+    std::string coordset_name = topology_name + "_coords";
+    conduit::Node &n_coords = res["coordsets"][coordset_name];
     n_coords["type"] = "explicit";
 
-    res["topologies/particles/coordset"] = "particle_coords";
     // create an explicit points topology
-    res["topologies/particles/type"] = "unstructured";
-    res["topologies/particles/elements/shape"] = "point";
-    res["topologies/particles/elements/connectivity"].set(
+    conduit::Node &n_topo = res["topologies"][topology_name];
+    n_topo["coordset"] = coordset_name;
+    n_topo["type"] = "unstructured";
+    n_topo["elements/shape"] = "point";
+    n_topo["elements/connectivity"].set(
                                     conduit::DataType::c_int(num_particles));
-    int *conn = res["topologies/particles/elements/connectivity"].value();
+    int *conn = n_topo["elements/connectivity"].value();
 
     for(int i = 0; i < num_particles ; i++)
     {
@@ -87,9 +90,9 @@ ParticleTileToBlueprint(const ParticleTile<NStructReal,
     //----------------------------------//
 
     // id is the first int entry
-    conduit::Node &n_f_id = n_fields["particle_id"];
+    conduit::Node &n_f_id = n_fields[topology_name + "_id"];
 
-    n_f_id["topology"] = "particles";
+    n_f_id["topology"] = topology_name;
     n_f_id["association"] = "element";
     n_f_id["values"].set_external(const_cast<int*>(&p_aos.m_idata.arr[0]),
                                   num_particles,
@@ -97,9 +100,9 @@ ParticleTileToBlueprint(const ParticleTile<NStructReal,
                                   struct_size);
 
     // cpu is the second int entry
-    conduit::Node &n_f_cpu = n_fields["particle_cpu"];
+    conduit::Node &n_f_cpu = n_fields[topology_name + "_cpu"];
 
-    n_f_cpu["topology"] = "particles";
+    n_f_cpu["topology"] = topology_name;
     n_f_cpu["association"] = "element";
     n_f_cpu["values"].set_external(const_cast<int*>(&p_aos.m_idata.arr[1]),
                                    num_particles,
@@ -116,7 +119,7 @@ ParticleTileToBlueprint(const ParticleTile<NStructReal,
     for (int i = AMREX_SPACEDIM; i < AMREX_SPACEDIM + NStructReal; i++)
     {
         conduit::Node &n_f = n_fields[real_comp_names[vname_real_idx]];
-        n_f["topology"] = "particles";
+        n_f["topology"] = topology_name;
         n_f["association"] = "element";
         n_f["values"].set_external(const_cast<ParticleReal*>(&p_aos.m_rdata.arr[i]),
                                    num_particles,
@@ -132,7 +135,7 @@ ParticleTileToBlueprint(const ParticleTile<NStructReal,
     for (int i = 2; i < 2 + NStructInt; i++)
     {
         conduit::Node &n_f = n_fields[int_comp_names[vname_int_idx]];
-        n_f["topology"] = "particles";
+        n_f["topology"] = topology_name;
         n_f["association"] = "element";
         n_f["values"].set_external(const_cast<int*>(&p_aos.m_idata.arr[i]),
                                    num_particles,
@@ -154,7 +157,7 @@ ParticleTileToBlueprint(const ParticleTile<NStructReal,
     for (int i = 0; i < NArrayReal; i++)
     {
         conduit::Node &n_f = n_fields[real_comp_names[vname_real_idx]];
-        n_f["topology"] = "particles";
+        n_f["topology"] = topology_name;
         n_f["association"] = "element";
         n_f["values"].set_external(const_cast<ParticleReal*>(&soa.GetRealData(i)[0]),
                                    num_particles);
@@ -166,7 +169,7 @@ ParticleTileToBlueprint(const ParticleTile<NStructReal,
     for (int i = 0; i < NArrayInt; i++)
     {
         conduit::Node &n_f = n_fields[int_comp_names[vname_int_idx]];
-        n_f["topology"] = "particles";
+        n_f["topology"] = topology_name;
         n_f["association"] = "element";
         n_f["values"].set_external(const_cast<int*>(&soa.GetIntData(i)[0]),
                                    num_particles);
@@ -186,7 +189,8 @@ ParticleContainerToBlueprint(const ParticleContainer<NStructReal,
                                                      NArrayInt> &pc,
                              const Vector<std::string> &real_comp_names,
                              const Vector<std::string> &int_comp_names,
-                             conduit::Node &res)
+                             conduit::Node &res,
+                             const std::string &topology_name)
 {
     BL_PROFILE("ParticleContainerToBlueprint()");
     
@@ -284,7 +288,8 @@ ParticleContainerToBlueprint(const ParticleContainer<NStructReal,
             ParticleTileToBlueprint(ptile,
                                     real_comp_names,
                                     int_comp_names,
-                                    patch);
+                                    patch,
+                                    topology_name);
             num_lvl_local_tiles += 1;
         }
     }
@@ -297,7 +302,7 @@ ParticleContainerToBlueprint(const ParticleContainer<NStructReal,
         // ERROR -- doesn't conform to the mesh blueprint
         // show what went wrong
         amrex::Print() << "ERROR: Conduit Mesh Blueprint Verify Failed!\n"
-                       << info.to_json();
+                       << info.to_yaml();
     }
 }
 


### PR DESCRIPTION
This adds a new optional argument to ParticleContainerToBlueprint that allows you to explicitly set the topology named used to wrap a ParticleContainer.

This is necessary for codes like WarpX that can use multiple ParticleContainer to represent different species.
