### PR TITLE
Emmanuel/velocity gradients for les

### DIFF
--- a/Src/LinearSolvers/MLMG/AMReX_MLTensorOp.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLTensorOp.H
@@ -71,7 +71,10 @@ public:
 
     virtual void compFlux (int amrlev, const Array<MultiFab*,AMREX_SPACEDIM>& fluxes,
                            MultiFab& sol, Location loc) const override;
-  
+ 
+    virtual void compVelGrad (int amrlev, const Array<MultiFab*,AMREX_SPACEDIM>& fluxes,
+                              MultiFab& sol, Location loc) const;
+ 
 protected:
 
     bool m_needs_update = true;

--- a/Src/LinearSolvers/MLMG/AMReX_MLTensorOp.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLTensorOp.cpp
@@ -369,4 +369,91 @@ MLTensorOp::compFlux (int amrlev, const Array<MultiFab*,AMREX_SPACEDIM>& fluxes,
 }
 
 
+
+void
+MLTensorOp::compVelGrad (int amrlev, const Array<MultiFab*,AMREX_SPACEDIM>& fluxes,
+                       MultiFab& sol, Location loc) const
+{
+#if (AMREX_SPACEDIM > 1)
+    BL_PROFILE("MLTensorOp::compVelGrad()");
+
+    const int mglev = 0;
+
+
+//    MLABecLaplacian::compFlux(amrlev, fluxes, sol, loc);
+
+    applyBCTensor(amrlev, mglev, sol, BCMode::Inhomogeneous, StateMode::Solution, m_bndry_sol[amrlev].get());
+
+    const auto dxinv = m_geom[amrlev][mglev].InvCellSizeArray();
+    const int dim_fluxes = pow(AMREX_SPACEDIM,2);
+
+amrex::Print() << "\n DEBUG IN compVelGrad \n" << " dim_fluxes = " << dim_fluxes << "\n";
+
+
+#ifdef _OPENMP
+#pragma omp parallel if (Gpu::notInLaunchRegion())
+#endif
+    {
+        Array<FArrayBox,AMREX_SPACEDIM> fluxfab_tmp;
+
+        for (MFIter mfi(sol, TilingIfNotGPU()); mfi.isValid(); ++mfi)
+        {
+            Array4<Real const> const vfab = sol.const_array(mfi);
+            AMREX_D_TERM(Box const xbx = mfi.nodaltilebox(0);,
+                         Box const ybx = mfi.nodaltilebox(1);,
+                         Box const zbx = mfi.nodaltilebox(2););
+            AMREX_D_TERM(fluxfab_tmp[0].resize(xbx,dim_fluxes);,
+                         fluxfab_tmp[1].resize(ybx,dim_fluxes);,
+                         fluxfab_tmp[2].resize(zbx,dim_fluxes););
+            AMREX_D_TERM(Elixir fxeli = fluxfab_tmp[0].elixir();,
+                         Elixir fyeli = fluxfab_tmp[1].elixir();,
+                         Elixir fzeli = fluxfab_tmp[2].elixir(););
+            AMREX_D_TERM(Array4<Real> const fxfab = fluxfab_tmp[0].array();,
+                         Array4<Real> const fyfab = fluxfab_tmp[1].array();,
+                         Array4<Real> const fzfab = fluxfab_tmp[2].array(););
+            AMREX_LAUNCH_HOST_DEVICE_LAMBDA
+            ( xbx, txbx,
+              {
+                  mltensor_vel_grads_fx(txbx,fxfab,vfab,dxinv);
+
+//  amrex::Print() << fxfab;
+//  amrex::Print() << fluxfab_tmp[0];
+              }
+            , ybx, tybx,
+              {
+                  mltensor_vel_grads_fy(tybx,fyfab,vfab,dxinv);
+
+
+//amrex::Print() << fyfab;
+//amrex::Print() << fluxfab_tmp[1];
+
+              }
+#if (AMREX_SPACEDIM == 3)
+            , zbx, tzbx,
+              {
+  //                mltensor_cross_terms_fz(tzbx,fzfab,vfab,etazfab,kapzfab,dxinv);
+              }
+#endif
+            );
+
+            for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+                const Box& nbx = mfi.nodaltilebox(idim);
+                Array4<Real      > dst = fluxes[idim]->array(mfi);
+                Array4<Real const> src = fluxfab_tmp[idim].const_array();
+                AMREX_HOST_DEVICE_PARALLEL_FOR_4D (nbx, dim_fluxes, i, j, k, n,
+                {
+                    dst(i,j,k,n) = src(i,j,k,n);
+                });
+            }
+
+        }
+    }
+#endif
+}
+
+
+
+
+
+
 }

--- a/Src/LinearSolvers/MLMG/AMReX_MLTensorOp.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLTensorOp.cpp
@@ -431,11 +431,17 @@ amrex::Print() << "\n DEBUG IN compVelGrad \n" << " dim_fluxes = " << dim_fluxes
 #if (AMREX_SPACEDIM == 3)
             , zbx, tzbx,
               {
-  //                mltensor_cross_terms_fz(tzbx,fzfab,vfab,etazfab,kapzfab,dxinv);
+                  mltensor_vel_grads_fz(tzbx,fzfab,vfab,dxinv);
               }
 #endif
             );
 
+// The derivatives are put in the array with the following order:
+// component: 0    ,  1    ,  2    ,  3    ,  4    , 5    ,  6    ,  7    ,  8   
+// in 2D:     dU/dx,  dV/dx,  dU/dy,  dV/dy 
+// in 3D:     dU/dx,  dV/dx,  dW/dx,  dU/dy,  dV/dy, dW/dy,  dU/dz,  dV/dz,  dW/dz      
+            
+            
             for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
                 const Box& nbx = mfi.nodaltilebox(idim);
                 Array4<Real      > dst = fluxes[idim]->array(mfi);

--- a/Src/LinearSolvers/MLMG/AMReX_MLTensorOp.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLTensorOp.cpp
@@ -379,16 +379,10 @@ MLTensorOp::compVelGrad (int amrlev, const Array<MultiFab*,AMREX_SPACEDIM>& flux
 
     const int mglev = 0;
 
-
-//    MLABecLaplacian::compFlux(amrlev, fluxes, sol, loc);
-
     applyBCTensor(amrlev, mglev, sol, BCMode::Inhomogeneous, StateMode::Solution, m_bndry_sol[amrlev].get());
 
     const auto dxinv = m_geom[amrlev][mglev].InvCellSizeArray();
     const int dim_fluxes = pow(AMREX_SPACEDIM,2);
-
-amrex::Print() << "\n DEBUG IN compVelGrad \n" << " dim_fluxes = " << dim_fluxes << "\n";
-
 
 #ifdef _OPENMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
@@ -415,18 +409,10 @@ amrex::Print() << "\n DEBUG IN compVelGrad \n" << " dim_fluxes = " << dim_fluxes
             ( xbx, txbx,
               {
                   mltensor_vel_grads_fx(txbx,fxfab,vfab,dxinv);
-
-//  amrex::Print() << fxfab;
-//  amrex::Print() << fluxfab_tmp[0];
               }
             , ybx, tybx,
               {
                   mltensor_vel_grads_fy(tybx,fyfab,vfab,dxinv);
-
-
-//amrex::Print() << fyfab;
-//amrex::Print() << fluxfab_tmp[1];
-
               }
 #if (AMREX_SPACEDIM == 3)
             , zbx, tzbx,
@@ -456,10 +442,6 @@ amrex::Print() << "\n DEBUG IN compVelGrad \n" << " dim_fluxes = " << dim_fluxes
     }
 #endif
 }
-
-
-
-
 
 
 }

--- a/Src/LinearSolvers/MLMG/AMReX_MLTensor_2D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLTensor_2D_K.H
@@ -201,6 +201,60 @@ void mltensor_cross_terms (Box const& box, Array4<Real> const& Ax,
     }
 }
 
+
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void mltensor_vel_grads_fx (Box const& box, Array4<Real> const& fx,
+                              Array4<Real const> const& vel,
+                              GpuArray<Real,AMREX_SPACEDIM> const& dxinv) noexcept
+{
+    const Real dxi = dxinv[0];
+    const Real dyi = dxinv[1];
+    const auto lo = amrex::lbound(box);
+    const auto hi = amrex::ubound(box);
+
+    for     (int j = lo.y; j <= hi.y; ++j) {
+        AMREX_PRAGMA_SIMD
+        for (int i = lo.x; i <= hi.x; ++i) {
+            Real dudx = (vel(i,j,0,0) - vel(i-1,j,0,0))*dxi;
+            Real dvdx = (vel(i,j,0,1) - vel(i-1,j,0,1))*dxi;
+            Real dudy = (vel(i,j+1,0,0)+vel(i-1,j+1,0,0)-vel(i,j-1,0,0)-vel(i-1,j-1,0,0))*(0.25*dyi);
+            Real dvdy = (vel(i,j+1,0,1)+vel(i-1,j+1,0,1)-vel(i,j-1,0,1)-vel(i-1,j-1,0,1))*(0.25*dyi);
+            fx(i,j,0,0) = dudx;
+            fx(i,j,0,1) = dvdx;
+            fx(i,j,0,2) = dudy;
+            fx(i,j,0,3) = dvdy;
+        }
+    }
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void mltensor_vel_grads_fy (Box const& box, Array4<Real> const& fy,
+                              Array4<Real const> const& vel,
+                              GpuArray<Real,AMREX_SPACEDIM> const& dxinv) noexcept
+{
+    const Real dxi = dxinv[0];
+    const Real dyi = dxinv[1];
+    const auto lo = amrex::lbound(box);
+    const auto hi = amrex::ubound(box);
+
+    for     (int j = lo.y; j <= hi.y; ++j) {
+        AMREX_PRAGMA_SIMD
+        for (int i = lo.x; i <= hi.x; ++i) {
+            Real dudx = (vel(i+1,j,0,0)+vel(i+1,j-1,0,0)-vel(i-1,j,0,0)-vel(i-1,j-1,0,0))*(0.25*dxi);
+            Real dvdx = (vel(i+1,j,0,1)+vel(i+1,j-1,0,1)-vel(i-1,j,0,1)-vel(i-1,j-1,0,1))*(0.25*dxi);
+            Real dudy = (vel(i,j,0,0) - vel(i,j-1,0,0))*dyi;
+            Real dvdy = (vel(i,j,0,1) - vel(i,j-1,0,1))*dyi;
+            fy(i,j,0,0) = dudx;
+            fy(i,j,0,1) = dvdx;
+            fy(i,j,0,2) = dudy;
+            fy(i,j,0,3) = dvdy;
+        }
+    }
+}
+
+
+
 }
 
 #endif

--- a/Src/LinearSolvers/MLMG/AMReX_MLTensor_2D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLTensor_2D_K.H
@@ -201,8 +201,6 @@ void mltensor_cross_terms (Box const& box, Array4<Real> const& Ax,
     }
 }
 
-
-
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 void mltensor_vel_grads_fx (Box const& box, Array4<Real> const& fx,
                               Array4<Real const> const& vel,
@@ -252,8 +250,6 @@ void mltensor_vel_grads_fy (Box const& box, Array4<Real> const& fy,
         }
     }
 }
-
-
 
 }
 

--- a/Src/LinearSolvers/MLMG/AMReX_MLTensor_3D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLTensor_3D_K.H
@@ -1182,6 +1182,139 @@ void mltensor_cross_terms (Box const& box, Array4<Real> const& Ax,
     }
 }
 
+
+
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void mltensor_vel_grads_fx (Box const& box, Array4<Real> const& fx,
+                            Array4<Real const> const& vel,
+                            GpuArray<Real,AMREX_SPACEDIM> const& dxinv) noexcept
+{
+    const Real dxi = dxinv[0];
+    const Real dyi = dxinv[1];
+    const Real dzi = dxinv[2];
+    const auto lo = amrex::lbound(box);
+    const auto hi = amrex::ubound(box);
+
+    for         (int k = lo.z; k <= hi.z; ++k) {
+        for     (int j = lo.y; j <= hi.y; ++j) {
+            AMREX_PRAGMA_SIMD
+            for (int i = lo.x; i <= hi.x; ++i) {
+              
+                Real dudx = (vel(i,j,k,0) - vel(i-1,j,k,0))*dxi;
+                Real dvdx = (vel(i,j,k,1) - vel(i-1,j,k,1))*dxi;
+                Real dwdx = (vel(i,j,k,2) - vel(i-1,j,k,2))*dxi;
+              
+                Real dudy = (vel(i,j+1,k,0)+vel(i-1,j+1,k,0)-vel(i,j-1,k,0)-vel(i-1,j-1,k,0))*(0.25*dyi);
+                Real dvdy = (vel(i,j+1,k,1)+vel(i-1,j+1,k,1)-vel(i,j-1,k,1)-vel(i-1,j-1,k,1))*(0.25*dyi);
+                Real dwdy = (vel(i,j+1,k,2)+vel(i-1,j+1,k,2)-vel(i,j-1,k,2)-vel(i-1,j-1,k,2))*(0.25*dyi);
+                
+                Real dudz = (vel(i,j,k+1,0)+vel(i-1,j,k+1,0)-vel(i,j,k-1,0)-vel(i-1,j,k-1,0))*(0.25*dzi);
+                Real dvdz = (vel(i,j,k+1,1)+vel(i-1,j,k+1,1)-vel(i,j,k-1,1)-vel(i-1,j,k-1,1))*(0.25*dzi);
+                Real dwdz = (vel(i,j,k+1,2)+vel(i-1,j,k+1,2)-vel(i,j,k-1,2)-vel(i-1,j,k-1,2))*(0.25*dzi);
+                
+                fx(i,j,k,0) = dudx;
+                fx(i,j,k,1) = dvdx;
+                fx(i,j,k,2) = dwdx;
+                fx(i,j,k,3) = dudy;
+                fx(i,j,k,4) = dvdy;
+                fx(i,j,k,5) = dwdy;
+                fx(i,j,k,6) = dudz;
+                fx(i,j,k,7) = dvdz;
+                fx(i,j,k,8) = dwdz;
+                
+            }
+        }
+    }
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void mltensor_vel_grads_fy (Box const& box, Array4<Real> const& fy,
+                              Array4<Real const> const& vel,
+                              GpuArray<Real,AMREX_SPACEDIM> const& dxinv) noexcept
+{
+    const Real dxi = dxinv[0];
+    const Real dyi = dxinv[1];
+    const Real dzi = dxinv[2];
+    const auto lo = amrex::lbound(box);
+    const auto hi = amrex::ubound(box);
+
+    for         (int k = lo.z; k <= hi.z; ++k) {
+        for     (int j = lo.y; j <= hi.y; ++j) {
+            AMREX_PRAGMA_SIMD
+            for (int i = lo.x; i <= hi.x; ++i) {
+              
+                Real dudx = (vel(i+1,j,k,0)+vel(i+1,j-1,k,0)-vel(i-1,j,k,0)-vel(i-1,j-1,k,0))*(0.25*dxi);
+                Real dvdx = (vel(i+1,j,k,1)+vel(i+1,j-1,k,1)-vel(i-1,j,k,1)-vel(i-1,j-1,k,1))*(0.25*dxi);
+                Real dwdx = (vel(i+1,j,k,2)+vel(i+1,j-1,k,2)-vel(i-1,j,k,2)-vel(i-1,j-1,k,2))*(0.25*dxi);
+                
+                Real dudy = (vel(i,j,0,0) - vel(i,j-1,0,0))*dyi;
+                Real dvdy = (vel(i,j,0,1) - vel(i,j-1,0,1))*dyi;
+                Real dwdy = (vel(i,j,0,2) - vel(i,j-1,0,2))*dyi;
+                
+                Real dudz = (vel(i,j,k+1,0)+vel(i,j-1,k+1,0)-vel(i,j,k-1,0)-vel(i,j-1,k-1,0))*(0.25*dzi);
+                Real dvdz = (vel(i,j,k+1,1)+vel(i,j-1,k+1,1)-vel(i,j,k-1,1)-vel(i,j-1,k-1,1))*(0.25*dzi);
+                Real dwdz = (vel(i,j,k+1,2)+vel(i,j-1,k+1,2)-vel(i,j,k-1,2)-vel(i,j-1,k-1,2))*(0.25*dzi);
+                
+                fy(i,j,k,0) = dudx;
+                fy(i,j,k,1) = dvdx;
+                fy(i,j,k,2) = dwdx;
+                fy(i,j,k,3) = dudy;
+                fy(i,j,k,4) = dvdy;
+                fy(i,j,k,5) = dwdy;
+                fy(i,j,k,6) = dudz;
+                fy(i,j,k,7) = dvdz;
+                fy(i,j,k,8) = dwdz;
+
+            }
+        }
+    }
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void mltensor_vel_grads_fz (Box const& box, Array4<Real> const& fz,
+                              Array4<Real const> const& vel,
+                              GpuArray<Real,AMREX_SPACEDIM> const& dxinv) noexcept
+{
+    const Real dxi = dxinv[0];
+    const Real dyi = dxinv[1];
+    const Real dzi = dxinv[2];
+    const auto lo = amrex::lbound(box);
+    const auto hi = amrex::ubound(box);
+
+    for         (int k = lo.z; k <= hi.z; ++k) {
+        for     (int j = lo.y; j <= hi.y; ++j) {
+            AMREX_PRAGMA_SIMD
+            for (int i = lo.x; i <= hi.x; ++i) {
+              
+                Real dudx = (vel(i+1,j,k,0)+vel(i+1,j,k-1,0)-vel(i-1,j,k,0)-vel(i-1,j,k-1,0))*(0.25*dxi);
+                Real dvdx = (vel(i+1,j,k,1)+vel(i+1,j,k-1,1)-vel(i-1,j,k,1)-vel(i-1,j,k-1,1))*(0.25*dxi);
+                Real dwdx = (vel(i+1,j,k,2)+vel(i+1,j,k-1,2)-vel(i-1,j,k,2)-vel(i-1,j,k-1,2))*(0.25*dxi);
+                
+                Real dudy = (vel(i,j+1,k,0)+vel(i,j+1,k-1,0)-vel(i,j-1,k,0)-vel(i,j-1,k-1,0))*(0.25*dyi);
+                Real dvdy = (vel(i,j+1,k,1)+vel(i,j+1,k-1,1)-vel(i,j-1,k,1)-vel(i,j-1,k-1,1))*(0.25*dyi);
+                Real dwdy = (vel(i,j+1,k,2)+vel(i,j+1,k-1,2)-vel(i,j-1,k,2)-vel(i,j-1,k-1,2))*(0.25*dyi);
+                
+                Real dudz = (vel(i,j,k,0) - vel(i,j,k-1,0))*dzi;
+                Real dvdz = (vel(i,j,k,1) - vel(i,j,k-1,1))*dzi;
+                Real dwdz = (vel(i,j,k,2) - vel(i,j,k-1,2))*dzi;
+                
+                fz(i,j,k,0) = dudx;
+                fz(i,j,k,1) = dvdx;
+                fz(i,j,k,2) = dwdx;
+                fz(i,j,k,3) = dudy;
+                fz(i,j,k,4) = dvdy;
+                fz(i,j,k,5) = dwdy;
+                fz(i,j,k,6) = dudz;
+                fz(i,j,k,7) = dvdz;
+                fz(i,j,k,8) = dwdz;
+
+            }
+        }
+    } 
+}
+
+
 }
 
 #endif

--- a/Src/LinearSolvers/MLMG/AMReX_MLTensor_3D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLTensor_3D_K.H
@@ -1183,8 +1183,6 @@ void mltensor_cross_terms (Box const& box, Array4<Real> const& Ax,
 }
 
 
-
-
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 void mltensor_vel_grads_fx (Box const& box, Array4<Real> const& fx,
                             Array4<Real const> const& vel,
@@ -1248,9 +1246,9 @@ void mltensor_vel_grads_fy (Box const& box, Array4<Real> const& fy,
                 Real dvdx = (vel(i+1,j,k,1)+vel(i+1,j-1,k,1)-vel(i-1,j,k,1)-vel(i-1,j-1,k,1))*(0.25*dxi);
                 Real dwdx = (vel(i+1,j,k,2)+vel(i+1,j-1,k,2)-vel(i-1,j,k,2)-vel(i-1,j-1,k,2))*(0.25*dxi);
                 
-                Real dudy = (vel(i,j,0,0) - vel(i,j-1,0,0))*dyi;
-                Real dvdy = (vel(i,j,0,1) - vel(i,j-1,0,1))*dyi;
-                Real dwdy = (vel(i,j,0,2) - vel(i,j-1,0,2))*dyi;
+                Real dudy = (vel(i,j,k,0) - vel(i,j-1,k,0))*dyi;
+                Real dvdy = (vel(i,j,k,1) - vel(i,j-1,k,1))*dyi;
+                Real dwdy = (vel(i,j,k,2) - vel(i,j-1,k,2))*dyi;
                 
                 Real dudz = (vel(i,j,k+1,0)+vel(i,j-1,k+1,0)-vel(i,j,k-1,0)-vel(i,j-1,k-1,0))*(0.25*dzi);
                 Real dvdz = (vel(i,j,k+1,1)+vel(i,j-1,k+1,1)-vel(i,j,k-1,1)-vel(i,j-1,k-1,1))*(0.25*dzi);
@@ -1313,7 +1311,6 @@ void mltensor_vel_grads_fz (Box const& box, Array4<Real> const& fz,
         }
     } 
 }
-
 
 }
 


### PR DESCRIPTION
These additional routines provide all the gradients of each velocity component on each face of a cell.
It is done in the TensorOp object because for LES, the derivatives are used to compute a new subgrid viscosity that is put back in the TensorOp in order to get a new div.(tau) term. Thus, everything is done with the same operator and we ensure that it is consistent.