### PR TITLE
HDF5 integration

### DIFF
--- a/Src/Amr/AMReX_Amr.H
+++ b/Src/Amr/AMReX_Amr.H
@@ -355,6 +355,9 @@ public:
   H5& getRestartHDF5() { return restart_h5; }
 #endif
 
+  std::string& getPlotType() {return plot_file_type;}
+  std::string& getCheckType() {return check_file_type;}
+
 protected:
 
     //! Initialize grid hierarchy -- called by Amr::init.

--- a/Src/Amr/AMReX_Amr.H
+++ b/Src/Amr/AMReX_Amr.H
@@ -12,12 +12,17 @@
 #include <AMReX_Array.H>
 #include <AMReX_Vector.H>
 #include <AMReX_BCRec.H>
+#include <AMReX_VisMF.H>
 
 #include <AMReX_AmrCore.H>
 
 #ifdef USE_PERILLA
 #include <RegionGraph.H>
 #include <Perilla.H>
+#endif
+
+#ifdef AMREX_USE_HDF5
+#include <AMReX_HDF5.H>
 #endif
 
 namespace amrex {
@@ -249,12 +254,18 @@ public:
 
     //! Write the plot file to be used for visualization.
     virtual void writePlotFile ();
+#ifdef AMREX_USE_HDF5
+    virtual void writePlotFileHDF5();
+#endif
     int stepOfLastPlotFile () const noexcept {return last_plotfile;}
     //! Write the small plot file to be used for visualization.
     virtual void writeSmallPlotFile ();
     int stepOfLastSmallPlotFile () const noexcept {return last_smallplotfile;}
     //! Write current state into a chk* file.
     virtual void checkPoint ();
+#ifdef AMREX_USE_HDF5
+    virtual void checkPointHDF5 (bool dump_old=true);
+#endif
     int stepOfLastCheckPoint () const noexcept {return last_checkpoint;}
 
     const Vector<BoxArray>& getInitialBA() noexcept;
@@ -332,6 +343,18 @@ public:
 
     bool UsingPrecreateDirectories () noexcept;
 
+    std::string& getPlotRoot() { return plot_file_root; }
+    std::string& getCheckpointRoot() { return check_file_root; }
+
+    std::string& getOutputName() { return output_name; }
+    std::ofstream& getOutputStream() { return output_stream; }
+    VisMF::How& getOutputHow() { return output_how; }
+
+#ifdef AMREX_USE_HDF5
+  H5& getOutputHDF5() { return output_h5; }
+  H5& getRestartHDF5() { return restart_h5; }
+#endif
+
 protected:
 
     //! Initialize grid hierarchy -- called by Amr::init.
@@ -343,6 +366,7 @@ protected:
     void checkInput ();
     //! Restart from a checkpoint file.
     void restart (const std::string& filename);
+    void restartHDF5 (const std::string& filename);
     //! Define and initialize coarsest level.
     void defBaseLevel (Real start_time, const BoxArray* lev0_grids = 0, const Vector<int>* pmap = 0);
     //! Define and initialize refined levels.
@@ -426,6 +450,7 @@ protected:
     int              check_int;       //!< How often checkpoint (# time steps).
     Real             check_per;       //!< How often checkpoint (units of time).
     std::string      check_file_root; //!< Root name of checkpoint file.
+    std::string      check_file_type; //!< Type of file output
     int              last_plotfile;   //!< Step number of previous plotfile.
     int              last_smallplotfile;   //!< Step number of previous small plotfile.
     int              plot_int;        //!< How often plotfile (# of time steps)
@@ -438,6 +463,7 @@ protected:
     int              file_name_digits; //!< How many digits to use in the plotfile and checkpoint names
     int              message_int;     //!< How often checking messages touched by user, such as "stop_run"
     std::string      plot_file_root;  //!< Root name of plotfile.
+    std::string      plot_file_type;  //!< Type of file output
     std::string      small_plot_file_root;  //!< Root name of small plotfile.
 
     int              which_level_being_advanced; //!< Only >=0 if we are in Amr::timeStep(level,...)
@@ -462,6 +488,16 @@ protected:
     Real             loadbalance_max_fac;
 
     bool             bUserStopRequest;
+
+    // output parameters
+    std::string output_name;
+    std::ofstream output_stream;
+    VisMF::How output_how;
+
+#ifdef AMREX_USE_HDF5
+    H5 output_h5;
+    H5 restart_h5;
+#endif
 
     //
     // The static data ...

--- a/Src/Amr/AMReX_Amr.cpp
+++ b/Src/Amr/AMReX_Amr.cpp
@@ -1047,11 +1047,6 @@ void Amr::writePlotFileHDF5() {
     amr_level[k]->writePlotHDF5(plot_data, plot_names);
   }
 
-#ifdef AMREX_PARTICLES
-  // save any particle data
-  amr_level[0]->checkPointParticlesHDF5(output_h5);
-#endif
-
   for (int k(0); k <= finest_level; ++k) {
     amr_level[k]->writePlotHDF5Post();
   }
@@ -2066,11 +2061,6 @@ Amr::checkPointHDF5 (bool dump_old)
   for (int i = 0; i <= finest_level; ++i) {
       amr_level[i]->checkPointHDF5(output_h5, dump_old);
   }
-
-#ifdef AMREX_PARTICLES
-  // save any particle data
-  amr_level[0]->checkPointParticlesHDF5(output_h5);
-#endif
 
   for (int i = 0; i <= finest_level; ++i) {
       amr_level[i]->checkPointHDF5Post();
@@ -3867,8 +3857,8 @@ Amr::initPltAndChk ()
     pp.query("checkpoint_files_output", checkpoint_files_output);
     pp.query("plot_files_output", plot_files_output);
 
-
-    pp.query("plot_files_type", plot_files_output);
+    plot_file_type = "DEFAULT";
+    pp.query("plot_file_type", plot_file_type);
 
     pp.query("plot_nfiles", plot_nfiles);
     pp.query("checkpoint_nfiles", checkpoint_nfiles);

--- a/Src/Amr/AMReX_AmrLevel.H
+++ b/Src/Amr/AMReX_AmrLevel.H
@@ -82,23 +82,17 @@ public:
     }
 
     /**
-     * \brief Get data we want to plot.  This is a
-     * pure virtual function and hence MUST be implemented by
-     * derived classes.
+     * \brief Get data we want to plot.
      */
     virtual void getPlotData(MultiFab& plot_data,
                              std::vector<std::string>& plot_names);
 
     /**
-    * \brief Write plot file stuff to specified directory.  This is a
-    * pure virtual function and hence MUST be implemented by
-    * derived classes.
+    * \brief Write plot file stuff to specified directory.
     */
     virtual void writePlotFile (const std::string& dir,
                                 std::ostream&      os,
                                 VisMF::How         how = VisMF::NFiles);
-
-    void writePlotFile(MultiFab& plot_data, std::vector<std::string>& plot_names);
 
 #ifdef AMREX_USE_HDF5
     void writeLevelAttrHDF5(H5& h5);
@@ -108,12 +102,10 @@ public:
 #endif
 
     //! Do pre-plotfile work to avoid synchronizations while writing the amr hierarchy
-    virtual void writePlotFilePre ();
     virtual void writePlotFilePre (const std::string& dir,
                                    std::ostream&      os);
 
     //! Do post-plotfile work to avoid synchronizations while writing the amr hierarchy
-    virtual void writePlotFilePost ();
     virtual void writePlotFilePost (const std::string& dir,
                                     std::ostream&      os);
 
@@ -138,11 +130,9 @@ public:
 #endif
 
     //! Do pre-checkpoint work to avoid synchronizations while writing the amr hierarchy
-    virtual void checkPointPre ();
     virtual void checkPointPre (const std::string& dir,
                                 std::ostream&      os);
     //! Do post-checkpoint work to avoid synchronizations while writing the amr hierarchy
-    virtual void checkPointPost ();
     virtual void checkPointPost (const std::string& dir,
                                  std::ostream&      os);
     //! Restart from a checkpoint file.

--- a/Src/Amr/AMReX_AmrLevel.H
+++ b/Src/Amr/AMReX_AmrLevel.H
@@ -80,6 +80,15 @@ public:
         static const std::string the_plot_file_type("HyperCLaw-V1.1");
         return the_plot_file_type;
     }
+
+    /**
+     * \brief Get data we want to plot.  This is a
+     * pure virtual function and hence MUST be implemented by
+     * derived classes.
+     */
+    virtual void getPlotData(MultiFab& plot_data,
+                             std::vector<std::string>& plot_names);
+
     /**
     * \brief Write plot file stuff to specified directory.  This is a
     * pure virtual function and hence MUST be implemented by
@@ -89,11 +98,22 @@ public:
                                 std::ostream&      os,
                                 VisMF::How         how = VisMF::NFiles);
 
+    void writePlotFile(MultiFab& plot_data, std::vector<std::string>& plot_names);
+
+#ifdef AMREX_USE_HDF5
+    void writeLevelAttrHDF5(H5& h5);
+    void writePlotHDF5(MultiFab& data_mf, const std::vector<std::string> data_names);
+    virtual void writePlotHDF5Pre ();
+    virtual void writePlotHDF5Post ();
+#endif
+
     //! Do pre-plotfile work to avoid synchronizations while writing the amr hierarchy
+    virtual void writePlotFilePre ();
     virtual void writePlotFilePre (const std::string& dir,
                                    std::ostream&      os);
 
     //! Do post-plotfile work to avoid synchronizations while writing the amr hierarchy
+    virtual void writePlotFilePost ();
     virtual void writePlotFilePost (const std::string& dir,
                                     std::ostream&      os);
 
@@ -110,10 +130,19 @@ public:
                              std::ostream&      os,
                              VisMF::How         how = VisMF::NFiles,
                              bool               dump_old = true);
+#ifdef AMREX_USE_HDF5
+    virtual void checkPointHDF5 (H5& h5, bool dump_old=true);
+    virtual void checkPointHDF5Pre();
+    virtual void checkPointHDF5Post();
+    virtual void restartHDF5 (Amr& papa, H5& h5);
+#endif
+
     //! Do pre-checkpoint work to avoid synchronizations while writing the amr hierarchy
+    virtual void checkPointPre ();
     virtual void checkPointPre (const std::string& dir,
                                 std::ostream&      os);
     //! Do post-checkpoint work to avoid synchronizations while writing the amr hierarchy
+    virtual void checkPointPost ();
     virtual void checkPointPost (const std::string& dir,
                                  std::ostream&      os);
     //! Restart from a checkpoint file.

--- a/Src/Amr/AMReX_AmrLevel.cpp
+++ b/Src/Amr/AMReX_AmrLevel.cpp
@@ -149,8 +149,9 @@ AmrLevel::AmrLevel (Amr&            papa,
     finishConstructor();
 }
 
-void AmrLevel::getPlotData(MultiFab& plot_data,
-                           std::vector<std::string>& plot_names) {
+void
+AmrLevel::getPlotData(MultiFab&                 plot_data,
+                      std::vector<std::string>& plot_names) {
   plot_names.resize(0);
 
   std::vector<std::pair<int, int> > plot_var_map;
@@ -474,15 +475,10 @@ void AmrLevel::writePlotHDF5Post() {}
 
 #endif
 
-void AmrLevel::writePlotFilePre() {}
-
 void
 AmrLevel::writePlotFilePre (const std::string& dir,
                             std::ostream&      os)
-{
-}
-
-void AmrLevel::writePlotFilePost() {}
+{}
 
 void
 AmrLevel::writePlotFilePost (const std::string& dir,
@@ -727,34 +723,6 @@ AmrLevel::checkPointHDF5Post ()
     BL_PROFILE("AmrLevel::checkPointHDF5Post()");
 }
 
-#ifdef AMREX_PARTICLES
-void AmrLevel::checkPointParticlesHDF5(H5& h5)
-{
-  if (level > 0) {
-    return;
-  }
-
-  std::map<std::string, int> aInt;
-  std::map<std::string, double> aReal;
-  std::map<std::string, std::string> aString;
-
-  H5 prt = h5.createGroup("Particles");
-
-  for (int pi=0; pi<particles.size(); ++pi) {
-    AmrTracerParticleContainer* TracerPC = particles[pi];
-    std::string& name = particle_names[pi];
-    TracerPC->CheckpointHDF5(prt, name);
-    aString["collection_"+num2str(pi)] = name;
-  }
-
-  aInt["num_collections"] = (int) particles.size();
-  prt.writeAttribute(aInt, aReal, aString);
-
-  prt.closeGroup();
-}
-
-#endif
-
 void AmrLevel::restartHDF5 (Amr& papa, H5& h5)
 {
     BL_PROFILE("AmrLevel::restartHDF5()");
@@ -830,23 +798,18 @@ void AmrLevel::restartHDF5 (Amr& papa, H5& h5)
 #endif
 
 void
-AmrLevel::checkPointPre ()
-{
-    BL_PROFILE("AmrLevel::checkPointPre()");
-}
-
-void
 AmrLevel::checkPointPre (const std::string& dir,
                          std::ostream&      os)
 {
     BL_PROFILE("AmrLevel::checkPointPre()");
-}
 
-
-void
-AmrLevel::checkPointPost ()
-{
-    BL_PROFILE("AmrLevel::checkPointPost()");
+#ifdef AMREX_USE_HDF5
+    if (parent->getCheckType() == "HDF5")
+    {
+        checkPointHDF5Pre();
+        return;
+    }
+#endif
 }
 
 void
@@ -854,6 +817,13 @@ AmrLevel::checkPointPost (const std::string& dir,
                           std::ostream&      os)
 {
     BL_PROFILE("AmrLevel::checkPointPost()");
+#ifdef AMREX_USE_HDF5
+    if (parent->getCheckType() == "HDF5")
+    {
+        checkPointHDF5Post();
+        return;
+    }
+#endif
 }
 
 

--- a/Src/Amr/AMReX_StateData.H
+++ b/Src/Amr/AMReX_StateData.H
@@ -17,6 +17,11 @@
 #include <AMReX_Geometry.H>
 #include <AMReX_RealBox.H>
 #include <AMReX_StateDescriptor.H>
+#include <AMReX_HDF5.H>
+
+#ifdef AMREX_USE_HDF5
+#include <AMReX_HDF5.H>
+#endif
 
 namespace amrex {
 
@@ -273,6 +278,17 @@ public:
                   const FabFactory<FArrayBox>& factroy,
                   const StateDescriptor& d,
                   const std::string&     restart_file);
+
+#ifdef AMREX_USE_HDF5
+    void checkPointHDF5 (H5& h5, bool dump_old = true);
+
+    void restartHDF5 (H5&                    h5,
+                      const Box&             p_domain,
+                      const BoxArray&        grds,
+                      const DistributionMapping& dm,
+                      const FabFactory<FArrayBox>& factroy,
+                      const StateDescriptor& d);
+#endif
 
     /**
     * \brief or from another similar state

--- a/Src/Base/AMReX_BoxArray.H
+++ b/Src/Base/AMReX_BoxArray.H
@@ -12,6 +12,7 @@
 #include <AMReX_Array.H>
 #include <AMReX_Vector.H>
 
+
 namespace amrex
 {
     class BoxArray;
@@ -205,6 +206,10 @@ struct DefaultBATransformer final
 
 class MFIter;
 
+#ifdef AMREX_USE_HDF5
+class H5;
+#endif
+
 class BoxArray
 {
 public:
@@ -285,6 +290,11 @@ public:
 
     //! Output this BoxArray to a checkpoint file.
     std::ostream& writeOn (std::ostream&) const;
+
+#ifdef AMREX_USE_HDF5
+    void readFromHDF5 (H5& h5, const std::string &name);
+    void writeOnHDF5 (H5& h5, const std::string &name);
+#endif
 
     //! Are the BoxArrays equal?
     bool operator== (const BoxArray& rhs) const noexcept;

--- a/Src/Base/AMReX_HDF5.H
+++ b/Src/Base/AMReX_HDF5.H
@@ -12,67 +12,67 @@
 namespace amrex {
 
 typedef struct {
-#if BL_SPACEDIM >= 1
+#if AMREX_SPACEDIM >= 1
   double x;
 #endif
-#if BL_SPACEDIM >= 2
+#if AMREX_SPACEDIM >= 2
   double y;
 #endif
-#if BL_SPACEDIM >= 3
+#if AMREX_SPACEDIM >= 3
   double z;
 #endif
 } real_h5_t;
 
 typedef struct {
-#if BL_SPACEDIM >= 1
+#if AMREX_SPACEDIM >= 1
   int i;
 #endif
-#if BL_SPACEDIM >= 2
+#if AMREX_SPACEDIM >= 2
   int j;
 #endif
-#if BL_SPACEDIM >= 3
+#if AMREX_SPACEDIM >= 3
   int k;
 #endif
 } int_h5_t;
 
 typedef struct {
-#if BL_SPACEDIM >= 1
+#if AMREX_SPACEDIM >= 1
   int lo_i;
 #endif
-#if BL_SPACEDIM >= 2
+#if AMREX_SPACEDIM >= 2
   int lo_j;
 #endif
-#if BL_SPACEDIM >= 3
+#if AMREX_SPACEDIM >= 3
   int lo_k;
 #endif
-#if BL_SPACEDIM >= 1
+#if AMREX_SPACEDIM >= 1
   int hi_i;
 #endif
-#if BL_SPACEDIM >= 2
+#if AMREX_SPACEDIM >= 2
   int hi_j;
 #endif
-#if BL_SPACEDIM >= 3
+#if AMREX_SPACEDIM >= 3
   int hi_k;
 #endif
 } box_h5_t;
 
 typedef struct {
-#if BL_SPACEDIM >= 1
+#if AMREX_SPACEDIM >= 1
   double lo_x;
 #endif
-#if BL_SPACEDIM >= 2
+#if AMREX_SPACEDIM >= 2
   double lo_y;
 #endif
-#if BL_SPACEDIM >= 3
+#if AMREX_SPACEDIM >= 3
   double lo_z;
 #endif
-#if BL_SPACEDIM >= 1
+#if AMREX_SPACEDIM >= 1
   double hi_x;
 #endif
-#if BL_SPACEDIM >= 2
+#if AMREX_SPACEDIM >= 2
   double hi_y;
 #endif
-#if BL_SPACEDIM >= 3
+#if AMREX_SPACEDIM >= 3
   double hi_z;
 #endif
 } rbox_h5_t;
@@ -172,7 +172,7 @@ class H5 {
     herr_t ret;
     // check if the attribute exists
     ret = H5Aexists(m_obj, vName.c_str());
-    if (ret = 0) {
+    if (ret == 0) {
       amrex::Abort(" Attribute " + vName + "does not exist");
     }
     if (ret < 0) {

--- a/Src/Base/AMReX_HDF5.H
+++ b/Src/Base/AMReX_HDF5.H
@@ -1,0 +1,389 @@
+#ifndef AMREX_HDF5_H
+#define AMREX_HDF5_H
+
+#ifdef AMREX_USE_HDF5
+
+#include <AMReX_Utility.H>
+#include <AMReX_Box.H>
+#include <AMReX_RealBox.H>
+#include <hdf5.h>
+#include <list>
+
+namespace amrex {
+
+typedef struct {
+#if BL_SPACEDIM >= 1
+  double x;
+#endif
+#if BL_SPACEDIM >= 2
+  double y;
+#endif
+#if BL_SPACEDIM >= 3
+  double z;
+#endif
+} real_h5_t;
+
+typedef struct {
+#if BL_SPACEDIM >= 1
+  int i;
+#endif
+#if BL_SPACEDIM >= 2
+  int j;
+#endif
+#if BL_SPACEDIM >= 3
+  int k;
+#endif
+} int_h5_t;
+
+typedef struct {
+#if BL_SPACEDIM >= 1
+  int lo_i;
+#endif
+#if BL_SPACEDIM >= 2
+  int lo_j;
+#endif
+#if BL_SPACEDIM >= 3
+  int lo_k;
+#endif
+#if BL_SPACEDIM >= 1
+  int hi_i;
+#endif
+#if BL_SPACEDIM >= 2
+  int hi_j;
+#endif
+#if BL_SPACEDIM >= 3
+  int hi_k;
+#endif
+} box_h5_t;
+
+typedef struct {
+#if BL_SPACEDIM >= 1
+  double lo_x;
+#endif
+#if BL_SPACEDIM >= 2
+  double lo_y;
+#endif
+#if BL_SPACEDIM >= 3
+  double lo_z;
+#endif
+#if BL_SPACEDIM >= 1
+  double hi_x;
+#endif
+#if BL_SPACEDIM >= 2
+  double hi_y;
+#endif
+#if BL_SPACEDIM >= 3
+  double hi_z;
+#endif
+} rbox_h5_t;
+
+class H5;
+
+hid_t makeH5Box();
+box_h5_t writeH5Box(const amrex::Box &b);
+void writeH5Box(const amrex::Box &b, box_h5_t &box);
+amrex::Box readH5Box(box_h5_t &b);
+void writeBoxOnHDF5(const amrex::Box& box, H5& h5, const std::string name);
+amrex::Box readBoxFromHDF5(H5& h5, const std::string name);
+
+hid_t makeH5RealBox();
+rbox_h5_t writeH5RealBox(const amrex::RealBox &b);
+amrex::RealBox readH5RealBox(rbox_h5_t &b);
+void writeRealBoxOnHDF5(const RealBox& box, H5& h5, const std::string name);
+amrex::RealBox readRealBoxFromHDF5(H5& h5, const std::string name);
+
+hid_t makeH5IntVec();
+int_h5_t writeH5IntVec(const int* in);
+void readH5IntVec(int_h5_t &in, int *out);
+
+hid_t makeH5RealVec();
+real_h5_t writeH5RealVec(const Real* in);
+void readH5RealVec(real_h5_t &in, double* out);
+
+class H5 {
+ public:
+  hid_t m_obj;  // the data object on which we will operate, may be a file,
+              // dataset, etc
+  herr_t m_status;
+  std::string m_name;
+
+  H5();
+  H5(std::string name);
+  H5(std::string name, MPI_Comm comm);
+  H5(hid_t h5);
+  ~H5();
+
+  void createFile(const std::string name, MPI_Comm comm = MPI_COMM_WORLD);
+  void openFile(const std::string name, MPI_Comm comm = MPI_COMM_WORLD);
+  void closeFile();
+
+  bool groupExists(const std::string name);
+  H5 createGroup(const std::string name);
+  H5 openGroup(const std::string name);
+  void closeGroup();
+
+  H5 openDataset(const std::string name);
+  void closeDataset();
+
+  // compound types
+  template <class T>
+  void writeAttribute(const std::string vName, T& vData, long H5Ttype) {
+    hid_t aid = H5Screate(H5S_SCALAR);
+    hid_t attr;
+    if (H5Aexists(m_obj, vName.c_str())) {
+      attr = H5Aopen(m_obj, vName.c_str(),H5P_DEFAULT);
+    } else {
+      attr = H5Acreate2(m_obj, vName.c_str(), H5Ttype, aid, H5P_DEFAULT, H5P_DEFAULT);
+    }
+    if (attr < 0) {
+      amrex::Abort(" Problem writing attribute " + vName);
+    }
+    m_status = H5Awrite(attr, H5Ttype, &vData);
+    H5Sclose(aid);
+    H5Aclose(attr);
+  }
+
+  template <class T>
+  herr_t readAttribute(const std::string vName, T& vData) {
+    herr_t ret;
+    // check if the attribute exists
+    ret = H5Aexists(m_obj, vName.c_str());
+    if (ret == 0) {
+      amrex::Abort(" Attribute " + vName + "does not exist");
+    }
+    if (ret < 0) {
+      amrex::Abort(" Problem reading attribute " + vName);
+    }
+
+    // open the attribute
+    hid_t attr = H5Aopen(m_obj, vName.c_str(), H5P_DEFAULT);
+
+    // read it
+    ret = H5Aread(attr, H5Aget_type(attr), &vData);
+
+    // close it
+    H5Aclose(attr);
+
+    return ret;
+  }
+
+  template <class T>
+  herr_t readAttribute(const std::string vName, std::vector<T>& vData) {
+    herr_t ret;
+    // check if the attribute exists
+    ret = H5Aexists(m_obj, vName.c_str());
+    if (ret = 0) {
+      amrex::Abort(" Attribute " + vName + "does not exist");
+    }
+    if (ret < 0) {
+      amrex::Abort(" Problem reading attribute " + vName);
+    }
+
+    // open the attribute
+    hid_t attr = H5Aopen(m_obj, vName.c_str(), H5P_DEFAULT);
+
+    // get the size of the attribute
+    hsize_t size =  H5Aget_storage_size(attr);
+
+    hid_t type = H5Aget_type(attr);
+
+    // allocate space
+    vData.resize(size/sizeof(type));
+
+    // read it
+    ret = H5Aread(attr, type, vData.data());
+
+    // close it
+    H5Tclose(type);
+    H5Aclose(attr);
+
+    return ret;
+  }
+
+
+  template <class T>
+  void readType(const std::string name, std::vector<T>& data) {
+
+    hid_t dset, plist, space;
+
+    // open dataset
+    dset = H5Dopen2(m_obj, name.c_str(), H5P_DEFAULT);
+
+    if (dset < 0) {
+      amrex::Abort("Error: H5Dopen2 failed to open " + name);
+    }
+
+    plist = H5Pcreate(H5P_DATASET_XFER);
+    H5Pset_dxpl_mpio(plist, H5FD_MPIO_COLLECTIVE);
+    //    H5Pset_dxpl_mpio(plist_id, H5FD_MPIO_INDEPENDENT);
+
+    // get how big the buffer needs to be
+    space = H5Dget_space(dset);
+    hssize_t npoints = H5Sget_simple_extent_npoints(space);
+
+    data.resize(npoints);
+
+    // read dataset
+    m_status = H5Dread(dset, H5Dget_type(dset), H5S_ALL, H5S_ALL, plist, data.data());
+
+    H5Dclose(dset);
+    H5Pclose(plist);
+    H5Sclose(space);
+
+    if (m_status < 0) {
+      amrex::Abort("Error: failed to read " + name);
+    }
+
+    return;
+  }
+
+  template <class T>
+  void writeType(const std::string name, const std::vector<hsize_t>& dims,
+                const std::vector<T>& data, long H5Ttype) {
+
+    // if it alrready exists, silently return
+    if (H5Lexists(m_obj, name.c_str(), H5P_DEFAULT) > 0) {
+      return;
+    }
+
+    hid_t dset, plist, space;
+
+    plist = H5Pcreate(H5P_DATASET_XFER);
+    H5Pset_dxpl_mpio(plist, H5FD_MPIO_COLLECTIVE);
+    //    H5Pset_dxpl_mpio(plist_id, H5FD_MPIO_INDEPENDENT);
+    space = H5Screate_simple(dims.size(), dims.data(), NULL);
+    dset = H5Dcreate(m_obj, name.c_str(), H5Ttype, space, H5P_DEFAULT,
+                   H5P_DEFAULT, H5P_DEFAULT);
+
+    m_status = H5Dwrite(dset, H5Ttype, H5S_ALL, H5S_ALL, plist, data.data());
+
+    H5Dclose(dset);
+    H5Sclose(space);
+    H5Pclose(plist);
+
+
+    return;
+  }
+
+
+  template <class T>
+  void writeType(const std::string name, const std::vector<hsize_t>& dims,
+                T* data, long H5Ttype) {
+
+    // if it alrready exists, silently return
+    if (H5Lexists(m_obj, name.c_str(), H5P_DEFAULT) > 0) {
+      return;
+    }
+
+    hid_t dset, plist, space;
+
+    plist = H5Pcreate(H5P_DATASET_XFER);
+    H5Pset_dxpl_mpio(plist, H5FD_MPIO_COLLECTIVE);
+    //    H5Pset_dxpl_mpio(plist_id, H5FD_MPIO_INDEPENDENT);
+    space = H5Screate_simple(dims.size(), dims.data(), NULL);
+    dset = H5Dcreate(m_obj, name.c_str(), H5Ttype, space, H5P_DEFAULT,
+                   H5P_DEFAULT, H5P_DEFAULT);
+
+    m_status = H5Dwrite(dset, H5Ttype, H5S_ALL, H5S_ALL, plist, data);
+
+    H5Dclose(dset);
+    H5Sclose(space);
+    H5Pclose(plist);
+
+
+    return;
+  }
+
+  template <class T>
+  void writeSlab(const std::string name, const std::vector<hsize_t>& full_dims,
+                const std::vector<hsize_t>& local_dims,
+                const std::vector<hsize_t>& offset, std::vector<T>& data,
+                hid_t type) {
+    // generate the dataset
+    hid_t space, dset, memspace, filespace, plist_id;
+
+    space = H5Screate_simple(full_dims.size(), full_dims.data(), NULL);
+    dset = H5Dcreate(m_obj, name.c_str(), type, space, H5P_DEFAULT, H5P_DEFAULT,
+                     H5P_DEFAULT);
+
+
+    // now write the bit that we have passed in
+
+    // create the space associated with this slab
+    memspace =
+        H5Screate_simple(local_dims.size(), local_dims.data(), NULL);
+
+    // Select hyperslab in the file.
+    filespace = H5Dget_space(dset);
+    H5Sselect_hyperslab(filespace, H5S_SELECT_SET, offset.data(), NULL,
+                        local_dims.data(), NULL);
+
+    plist_id = H5Pcreate(H5P_DATASET_XFER);
+    H5Pset_dxpl_mpio(plist_id, H5FD_MPIO_COLLECTIVE);
+    //    H5Pset_dxpl_mpio(plist_id, H5FD_MPIO_INDEPENDENT);
+
+    //    if (data.size()) {
+    m_status = H5Dwrite(dset, type, memspace, filespace, plist_id, data.data());
+    //    }
+
+    H5Sclose(space);
+    H5Sclose(filespace);
+    H5Sclose(memspace);
+    H5Pclose(plist_id);
+    H5Dclose(dset);
+  }
+
+  template <class T>
+  void readSlab(const std::string name, const std::vector<hsize_t>& local_dims,
+                const std::vector<hsize_t>& offset, std::vector<T>& data) {
+    // open the dataset
+    hid_t dset, dataspace, filespace, plist_id;
+
+    dset = H5Dopen2(m_obj, name.c_str(), H5P_DEFAULT);
+
+    dataspace = H5Dget_space(dset);
+    filespace = H5Screate_simple(local_dims.size(), local_dims.data(), NULL);
+    H5Sselect_hyperslab(dataspace, H5S_SELECT_SET, offset.data(), NULL, local_dims.data(), NULL);
+
+    plist_id = H5Pcreate(H5P_DATASET_XFER);
+    //H5Pset_dxpl_mpio(plist_id, H5FD_MPIO_COLLECTIVE);
+    H5Pset_dxpl_mpio(plist_id, H5FD_MPIO_INDEPENDENT);
+
+    // make sure the buffer is the correct size
+    hsize_t size=1;
+    for (hsize_t d : local_dims) {
+      size *= d;
+    }
+    data.resize(size);
+
+    m_status = H5Dread(dset, H5Dget_type(dset), filespace, dataspace, plist_id, data.data());
+
+    if (m_status < 0) {
+      amrex::Abort("ERROR: AMREX_USE_HDF5::readSlab : H5Dread failed to read " + name);
+    }
+
+    H5Sclose(dataspace);
+    H5Sclose(filespace);
+    H5Pclose(plist_id);
+    H5Dclose(dset);
+  }
+
+  herr_t writeAttribute(std::map<std::string, int>& m_int,
+                       std::map<std::string, double>& m_real,
+                       std::map<std::string, std::string>& m_string);
+
+  void writeString(const std::string name, const std::string& data);
+  void writeString(const std::string name, const std::vector<std::string>& data);
+
+  private:
+   static std::list<std::string> tracker;
+   void track(const std::string name);
+   void discard(const std::string name);
+
+};
+
+}
+
+#endif
+
+#endif // AMREX_HDF5_H

--- a/Src/Base/AMReX_HDF5.cpp
+++ b/Src/Base/AMReX_HDF5.cpp
@@ -1,0 +1,495 @@
+#include <AMReX_HDF5.H>
+#include <iostream>
+
+#ifdef AMREX_USE_HDF5
+
+namespace amrex
+{
+
+hid_t makeH5Box() {
+  hid_t box_id = H5Tcreate(H5T_COMPOUND, sizeof(box_h5_t));
+#if BL_SPACEDIM >= 1
+  H5Tinsert(box_id, "lo_i", HOFFSET(box_h5_t, lo_i), H5T_NATIVE_INT);
+#endif
+#if BL_SPACEDIM >= 2
+  H5Tinsert(box_id, "lo_j", HOFFSET(box_h5_t, lo_j), H5T_NATIVE_INT);
+#endif
+#if BL_SPACEDIM >= 3
+  H5Tinsert(box_id, "lo_k", HOFFSET(box_h5_t, lo_k), H5T_NATIVE_INT);
+#endif
+#if BL_SPACEDIM >= 1
+  H5Tinsert(box_id, "hi_i", HOFFSET(box_h5_t, hi_i), H5T_NATIVE_INT);
+#endif
+#if BL_SPACEDIM >= 2
+  H5Tinsert(box_id, "hi_j", HOFFSET(box_h5_t, hi_j), H5T_NATIVE_INT);
+#endif
+#if BL_SPACEDIM >= 3
+  H5Tinsert(box_id, "hi_k", HOFFSET(box_h5_t, hi_k), H5T_NATIVE_INT);
+#endif
+
+  return box_id;
+}
+
+box_h5_t writeH5Box(const Box &b) {
+  box_h5_t box;
+#if BL_SPACEDIM >= 1
+  box.lo_i = b.smallEnd(0);
+  box.hi_i = b.bigEnd(0);
+#endif
+#if BL_SPACEDIM >= 2
+  box.lo_j = b.smallEnd(1);
+  box.hi_j = b.bigEnd(1);
+#endif
+#if BL_SPACEDIM >= 3
+  box.lo_k = b.smallEnd(2);
+  box.hi_k = b.bigEnd(2);
+#endif
+  return box;
+}
+
+void writeH5Box(const Box &b, box_h5_t &box) {
+#if BL_SPACEDIM >= 1
+  box.lo_i = b.smallEnd(0);
+  box.hi_i = b.bigEnd(0);
+#endif
+#if BL_SPACEDIM >= 2
+  box.lo_j = b.smallEnd(1);
+  box.hi_j = b.bigEnd(1);
+#endif
+#if BL_SPACEDIM >= 3
+  box.lo_k = b.smallEnd(2);
+  box.hi_k = b.bigEnd(2);
+#endif
+  return;
+}
+
+Box readH5Box(box_h5_t &box) {
+  IntVect lo(AMREX_D_DECL(box.lo_i, box.lo_j, box.lo_k));
+  IntVect hi(AMREX_D_DECL(box.hi_i, box.hi_j, box.hi_k));
+  Box b(lo, hi);
+  return b;
+}
+
+void writeBoxOnHDF5(const Box& box, H5& h5, const std::string name)
+{
+  hid_t box_id = makeH5Box();
+  box_h5_t h5box = writeH5Box(box);
+  h5.writeAttribute(name, h5box, box_id);
+  H5Tclose(box_id);
+  return;
+}
+
+Box readBoxFromHDF5(H5& h5, const std::string name)
+{
+  box_h5_t box;
+  h5.readAttribute(name, box);
+  Box out = readH5Box(box);
+  return out;
+}
+
+
+hid_t makeH5RealBox() {
+  hid_t box_id = H5Tcreate(H5T_COMPOUND, sizeof(rbox_h5_t));
+#if BL_SPACEDIM >= 1
+  H5Tinsert(box_id, "lo_x", HOFFSET(rbox_h5_t, lo_x), H5T_NATIVE_DOUBLE);
+#endif
+#if BL_SPACEDIM >= 2
+  H5Tinsert(box_id, "lo_y", HOFFSET(rbox_h5_t, lo_y), H5T_NATIVE_DOUBLE);
+#endif
+#if BL_SPACEDIM >= 3
+  H5Tinsert(box_id, "lo_z", HOFFSET(rbox_h5_t, lo_z), H5T_NATIVE_DOUBLE);
+#endif
+#if BL_SPACEDIM >= 1
+  H5Tinsert(box_id, "hi_x", HOFFSET(rbox_h5_t, hi_x), H5T_NATIVE_DOUBLE);
+#endif
+#if BL_SPACEDIM >= 2
+  H5Tinsert(box_id, "hi_y", HOFFSET(rbox_h5_t, hi_y), H5T_NATIVE_DOUBLE);
+#endif
+#if BL_SPACEDIM >= 3
+  H5Tinsert(box_id, "hi_z", HOFFSET(rbox_h5_t, hi_z), H5T_NATIVE_DOUBLE);
+#endif
+
+  return box_id;
+}
+
+rbox_h5_t writeH5RealBox(const RealBox &b) {
+  rbox_h5_t box;
+#if BL_SPACEDIM >= 1
+  box.lo_x = b.lo(0);
+  box.hi_x = b.hi(0);
+#endif
+#if BL_SPACEDIM >= 2
+  box.lo_y = b.lo(1);
+  box.hi_y = b.hi(1);
+#endif
+#if BL_SPACEDIM >= 3
+  box.lo_z = b.lo(2);
+  box.hi_z = b.hi(2);
+#endif
+  return box;
+}
+
+RealBox readH5RealBox(rbox_h5_t &box) {
+  std::array<Real,AMREX_SPACEDIM> lo = {AMREX_D_DECL(box.lo_x, box.lo_y, box.lo_z)};
+  std::array<Real, AMREX_SPACEDIM> hi = {AMREX_D_DECL(box.hi_x, box.hi_y, box.hi_z)};
+  RealBox b(lo, hi);
+  return b;
+}
+
+void writeRealBoxOnHDF5(const RealBox& box, H5& h5, const std::string name)
+{
+  hid_t rbox_id = makeH5RealBox();
+  rbox_h5_t rbox = writeH5RealBox(box);
+  h5.writeAttribute(name, rbox, rbox_id);
+  H5Tclose(rbox_id);
+  return;
+}
+
+RealBox readRealBoxFromHDF5(H5& h5, const std::string name)
+{
+  rbox_h5_t rbox;
+  h5.readAttribute(name, rbox);
+  RealBox out = readH5RealBox(rbox);
+  return out;
+}
+
+hid_t makeH5IntVec() {
+  hid_t intvect_id = H5Tcreate(H5T_COMPOUND, sizeof(int_h5_t));
+#if BL_SPACEDIM >= 1
+  H5Tinsert(intvect_id, "intvecti", HOFFSET(int_h5_t, i), H5T_NATIVE_INT);
+#endif
+#if BL_SPACEDIM >= 2
+  H5Tinsert(intvect_id, "intvectj", HOFFSET(int_h5_t, j), H5T_NATIVE_INT);
+#endif
+#if BL_SPACEDIM >= 3
+  H5Tinsert(intvect_id, "intvectk", HOFFSET(int_h5_t, k), H5T_NATIVE_INT);
+#endif
+  return intvect_id;
+}
+
+int_h5_t writeH5IntVec(const int* in) {
+  int_h5_t i;
+#if BL_SPACEDIM >= 1
+  i.i = in[0];
+#endif
+#if BL_SPACEDIM >= 2
+  i.j = in[1];
+#endif
+#if BL_SPACEDIM >= 3
+  i.k = in[2];
+#endif
+  return i;
+}
+
+void readH5IntVec(int_h5_t &in, int *out) {
+#if BL_SPACEDIM >= 1
+  out[0] = in.i;
+#endif
+#if BL_SPACEDIM >= 2
+  out[1] = in.j;
+#endif
+#if BL_SPACEDIM >= 3
+  out[2] = in.k;
+#endif
+}
+
+hid_t makeH5RealVec() {
+hid_t realvect_id = H5Tcreate(H5T_COMPOUND, sizeof(real_h5_t));
+#if BL_SPACEDIM >= 1
+  H5Tinsert(realvect_id, "x", HOFFSET(real_h5_t, x), H5T_NATIVE_DOUBLE);
+#endif
+#if BL_SPACEDIM >= 2
+  H5Tinsert(realvect_id, "y", HOFFSET(real_h5_t, y), H5T_NATIVE_DOUBLE);
+#endif
+#if BL_SPACEDIM >= 3
+  H5Tinsert(realvect_id, "z", HOFFSET(real_h5_t, z), H5T_NATIVE_DOUBLE);
+#endif
+  return realvect_id;
+}
+
+real_h5_t writeH5RealVec(const Real *in) {
+  real_h5_t vec;
+#if BL_SPACEDIM >= 1
+  vec.x = in[0];
+#endif
+#if BL_SPACEDIM >= 2
+  vec.y = in[1];
+#endif
+#if BL_SPACEDIM >= 3
+  vec.z = in[2];
+#endif
+  return vec;
+}
+
+void readH5RealVec(real_h5_t &in, double *out) {
+#if BL_SPACEDIM >= 1
+  out[0] = in.x;
+#endif
+#if BL_SPACEDIM >= 2
+  out[1] = in.y;
+#endif
+#if BL_SPACEDIM >= 3
+  out[2] = in.z;
+#endif
+}
+
+//==================================================================================
+// H5
+//==================================================================================
+
+
+H5::H5() {}
+
+H5::H5(std::string name) { createFile(name); }
+
+H5::H5(std::string name, MPI_Comm comm) { createFile(name, comm); }
+
+H5::H5(hid_t h5) { m_obj = h5; }
+
+H5::~H5() {}
+
+void H5::createFile(const std::string name, MPI_Comm comm) {
+  // assume MPI already initialized
+  hid_t file_access = H5Pcreate(H5P_FILE_ACCESS);
+  H5Pset_fapl_mpio(file_access, comm, MPI_INFO_NULL);
+
+  m_obj = H5Fcreate(name.c_str(), H5F_ACC_TRUNC, H5P_DEFAULT, file_access);
+  m_name = name;
+  H5Pclose(file_access);
+
+  track(name);
+
+  return;
+}
+
+void H5::openFile(const std::string name, MPI_Comm comm) {
+
+
+  hid_t file_access = H5Pcreate (H5P_FILE_ACCESS);
+  H5Pset_fapl_mpio(file_access,  comm, MPI_INFO_NULL);
+
+
+  m_obj = H5Fopen(name.c_str(), H5F_ACC_RDWR, file_access);
+  if (m_obj < 0) {
+    amrex::Abort("Unbale to open " + name);
+  }
+
+  m_name = name;
+
+  H5Pclose(file_access);
+
+  track(name);
+
+  return;
+}
+
+void H5::closeFile() {
+  discard(m_name);
+#ifdef AMREX_DEBUG
+  if (!tracker.empty()) {
+    std::cout << "H5 tracker outstanding items";
+    for (auto& name : tracker) {
+      std::cout << name << "\n";
+    }
+  }
+#endif
+
+  H5Fclose(m_obj);
+
+}
+
+bool H5::groupExists(const std::string name) {
+  const char* msg="an error has occured\n";
+  herr_t status = H5Eset_auto2(H5E_DEFAULT, NULL, (void*)msg);
+  status = H5Gget_objinfo (m_obj, name.c_str(), 0, NULL);
+
+  if (status == 0) {
+    return true;
+  } else {
+    return false;
+  }
+}
+
+H5 H5::createGroup(const std::string name) {
+  H5 out;
+
+  if (groupExists(name)) {
+    out.m_obj = H5Gopen2(m_obj, name.c_str(), H5P_DEFAULT);
+  } else {
+    out.m_obj = H5Gcreate(m_obj, name.c_str(), H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+  }
+
+  if (out.m_obj < 0) {
+    amrex::Abort(" Problem creating group " + name);
+  }
+  out.m_name = name;
+  track(name);
+  return out;
+}
+
+H5 H5::openGroup(const std::string name) {
+  H5 out;
+  out.m_obj = H5Gopen2(m_obj, name.c_str(), H5P_DEFAULT);
+  if (out.m_obj < 0) {
+    amrex::Abort(" Problem opening group " + name);
+  }
+  out.m_name = name;
+  track(name);
+  return out;
+}
+
+void H5::closeGroup() {
+  H5Gclose(m_obj);
+  discard(m_name);
+}
+
+H5 H5::openDataset(const std::string name) {
+  H5 out;
+  out.m_obj = H5Dopen2(m_obj, name.c_str(), H5P_DEFAULT);
+  out.m_name = name;
+  track(name);
+  return out;
+}
+
+void H5::closeDataset() {
+  H5Dclose(m_obj);
+  discard(m_name);
+}
+
+herr_t H5::writeAttribute(std::map<std::string, int>& m_int,
+                         std::map<std::string, double>& m_real,
+                         std::map<std::string, std::string>& m_string) {
+  H5E_auto_t efunc;
+  void* edata;
+  H5Eget_auto2(H5E_DEFAULT, &efunc, &edata);
+  herr_t ret;
+
+#define INSERT2(Ttype, mapName, H5Ttype)                                      \
+  for (std::map<std::string, Ttype>::const_iterator p = mapName.begin();      \
+       p != mapName.end(); ++p) {                                             \
+    hid_t aid = H5Screate(H5S_SCALAR);                                        \
+    H5Eset_auto2(H5E_DEFAULT, NULL, NULL);                                    \
+    hid_t attr = H5Acreate2(m_obj, p->first.c_str(), H5Ttype, aid, H5P_DEFAULT, \
+                            H5P_DEFAULT);                                     \
+    if (attr < 0) {                                                           \
+      H5Adelete(m_obj, p->first.c_str());                                       \
+      attr = H5Acreate2(m_obj, p->first.c_str(), H5Ttype, aid, H5P_DEFAULT,     \
+                        H5P_DEFAULT);                                         \
+      if (attr < 0) {                                                         \
+        amrex::Abort(" Problem writing attribute " + p->first);       \
+      }                                                                       \
+    }                                                                         \
+    H5Eset_auto2(H5E_DEFAULT, efunc, edata);                                  \
+    Ttype tmp = p->second;                                                    \
+    ret = H5Awrite(attr, H5Ttype, &tmp);                                      \
+    if (ret < 0) return ret;                                                  \
+    H5Sclose(aid);                                                            \
+    H5Aclose(attr);                                                           \
+  }
+  INSERT2(double, m_real, H5T_NATIVE_DOUBLE);
+  INSERT2(int, m_int, H5T_NATIVE_INT);
+
+  // string is different, of course
+  for (std::map<std::string, std::string>::const_iterator p = m_string.begin();
+       p != m_string.end(); ++p) {
+    hid_t s_type = H5Tcopy(H5T_C_S1);
+    H5Tset_size(s_type, p->second.length());  // extra requirement for strings
+    hid_t aid = H5Screate(H5S_SCALAR);
+    H5Eset_auto2(H5E_DEFAULT, NULL, NULL);
+    hid_t attr = H5Acreate2(m_obj, p->first.c_str(), s_type, aid, H5P_DEFAULT,
+                            H5P_DEFAULT);
+    if (attr < 0) {
+      H5Adelete(m_obj, p->first.c_str());
+      attr = H5Acreate2(m_obj, p->first.c_str(), s_type, aid, H5P_DEFAULT,
+                        H5P_DEFAULT);
+      if (attr < 0) {
+        amrex::Abort(" Problem writing attribute " + p->first);
+      }
+    }
+    H5Eset_auto2(H5E_DEFAULT, efunc, edata);
+    char* tmp = (char*)p->second.c_str();
+    ret = H5Awrite(attr, s_type, tmp);
+    if (ret < 0) return ret;
+    H5Sclose(aid);
+    H5Aclose(attr);
+    H5Tclose(s_type);
+  }
+
+  return 0;
+}
+
+void H5::writeString(const std::string name, const std::string& data) {
+  // write a single string to obj
+
+  hid_t type, space, dset;
+
+  type = H5Tcopy(H5T_C_S1);
+  H5Tset_size(type, data.size());
+
+  hsize_t dims[1] = {1};
+  space = H5Screate_simple(1, dims, NULL);
+
+  dset = H5Dcreate(m_obj, name.c_str(), type, space, H5P_DEFAULT, H5P_DEFAULT,
+                   H5P_DEFAULT);
+  H5Dwrite(dset, type, H5S_ALL, H5S_ALL, H5P_DEFAULT, data.data());
+
+  H5Dclose(dset);
+  H5Sclose(space);
+  H5Tclose(type);
+
+  return;
+}
+
+void H5::writeString(const std::string name,
+                    const std::vector<std::string>& data) {
+  // write a list of strings
+  // all strings must be the same length
+
+  // create a 1d buffer of all the characters
+
+  std::vector<char> buffer;
+
+  for (std::string S : data) {
+    for (size_t i = 0; i < S.size(); ++i) {
+      buffer.push_back(S[i]);
+    }
+  }
+
+  hsize_t dims[1] = {data.size()};
+  hid_t type, space, dset;
+
+  type = H5Tcopy(H5T_C_S1);
+  H5Tset_size(type, data[0].size());
+
+  space = H5Screate_simple(1, dims, NULL);
+
+  dset = H5Dcreate(m_obj, name.c_str(), type, space, H5P_DEFAULT, H5P_DEFAULT,
+                   H5P_DEFAULT);
+  H5Dwrite(dset, type, H5S_ALL, H5S_ALL, H5P_DEFAULT, buffer.data());
+
+  H5Dclose(dset);
+  H5Sclose(space);
+  H5Tclose(type);
+
+  return;
+}
+
+std::list<std::string> H5::tracker = {};
+void H5::track(const std::string name)
+{
+#ifdef AMREX_DEBUG
+  tracker.push_back(name);
+#endif
+}
+
+void H5::discard(const std::string name)
+{
+#ifdef AMREX_DEBUG
+  tracker.remove(name);
+#endif
+}
+
+
+}
+
+#endif

--- a/Src/Base/AMReX_HDF5.cpp
+++ b/Src/Base/AMReX_HDF5.cpp
@@ -8,22 +8,22 @@ namespace amrex
 
 hid_t makeH5Box() {
   hid_t box_id = H5Tcreate(H5T_COMPOUND, sizeof(box_h5_t));
-#if BL_SPACEDIM >= 1
+#if AMREX_SPACEDIM >= 1
   H5Tinsert(box_id, "lo_i", HOFFSET(box_h5_t, lo_i), H5T_NATIVE_INT);
 #endif
-#if BL_SPACEDIM >= 2
+#if AMREX_SPACEDIM >= 2
   H5Tinsert(box_id, "lo_j", HOFFSET(box_h5_t, lo_j), H5T_NATIVE_INT);
 #endif
-#if BL_SPACEDIM >= 3
+#if AMREX_SPACEDIM >= 3
   H5Tinsert(box_id, "lo_k", HOFFSET(box_h5_t, lo_k), H5T_NATIVE_INT);
 #endif
-#if BL_SPACEDIM >= 1
+#if AMREX_SPACEDIM >= 1
   H5Tinsert(box_id, "hi_i", HOFFSET(box_h5_t, hi_i), H5T_NATIVE_INT);
 #endif
-#if BL_SPACEDIM >= 2
+#if AMREX_SPACEDIM >= 2
   H5Tinsert(box_id, "hi_j", HOFFSET(box_h5_t, hi_j), H5T_NATIVE_INT);
 #endif
-#if BL_SPACEDIM >= 3
+#if AMREX_SPACEDIM >= 3
   H5Tinsert(box_id, "hi_k", HOFFSET(box_h5_t, hi_k), H5T_NATIVE_INT);
 #endif
 
@@ -32,15 +32,15 @@ hid_t makeH5Box() {
 
 box_h5_t writeH5Box(const Box &b) {
   box_h5_t box;
-#if BL_SPACEDIM >= 1
+#if AMREX_SPACEDIM >= 1
   box.lo_i = b.smallEnd(0);
   box.hi_i = b.bigEnd(0);
 #endif
-#if BL_SPACEDIM >= 2
+#if AMREX_SPACEDIM >= 2
   box.lo_j = b.smallEnd(1);
   box.hi_j = b.bigEnd(1);
 #endif
-#if BL_SPACEDIM >= 3
+#if AMREX_SPACEDIM >= 3
   box.lo_k = b.smallEnd(2);
   box.hi_k = b.bigEnd(2);
 #endif
@@ -48,15 +48,15 @@ box_h5_t writeH5Box(const Box &b) {
 }
 
 void writeH5Box(const Box &b, box_h5_t &box) {
-#if BL_SPACEDIM >= 1
+#if AMREX_SPACEDIM >= 1
   box.lo_i = b.smallEnd(0);
   box.hi_i = b.bigEnd(0);
 #endif
-#if BL_SPACEDIM >= 2
+#if AMREX_SPACEDIM >= 2
   box.lo_j = b.smallEnd(1);
   box.hi_j = b.bigEnd(1);
 #endif
-#if BL_SPACEDIM >= 3
+#if AMREX_SPACEDIM >= 3
   box.lo_k = b.smallEnd(2);
   box.hi_k = b.bigEnd(2);
 #endif
@@ -90,22 +90,22 @@ Box readBoxFromHDF5(H5& h5, const std::string name)
 
 hid_t makeH5RealBox() {
   hid_t box_id = H5Tcreate(H5T_COMPOUND, sizeof(rbox_h5_t));
-#if BL_SPACEDIM >= 1
+#if AMREX_SPACEDIM >= 1
   H5Tinsert(box_id, "lo_x", HOFFSET(rbox_h5_t, lo_x), H5T_NATIVE_DOUBLE);
 #endif
-#if BL_SPACEDIM >= 2
+#if AMREX_SPACEDIM >= 2
   H5Tinsert(box_id, "lo_y", HOFFSET(rbox_h5_t, lo_y), H5T_NATIVE_DOUBLE);
 #endif
-#if BL_SPACEDIM >= 3
+#if AMREX_SPACEDIM >= 3
   H5Tinsert(box_id, "lo_z", HOFFSET(rbox_h5_t, lo_z), H5T_NATIVE_DOUBLE);
 #endif
-#if BL_SPACEDIM >= 1
+#if AMREX_SPACEDIM >= 1
   H5Tinsert(box_id, "hi_x", HOFFSET(rbox_h5_t, hi_x), H5T_NATIVE_DOUBLE);
 #endif
-#if BL_SPACEDIM >= 2
+#if AMREX_SPACEDIM >= 2
   H5Tinsert(box_id, "hi_y", HOFFSET(rbox_h5_t, hi_y), H5T_NATIVE_DOUBLE);
 #endif
-#if BL_SPACEDIM >= 3
+#if AMREX_SPACEDIM >= 3
   H5Tinsert(box_id, "hi_z", HOFFSET(rbox_h5_t, hi_z), H5T_NATIVE_DOUBLE);
 #endif
 
@@ -114,15 +114,15 @@ hid_t makeH5RealBox() {
 
 rbox_h5_t writeH5RealBox(const RealBox &b) {
   rbox_h5_t box;
-#if BL_SPACEDIM >= 1
+#if AMREX_SPACEDIM >= 1
   box.lo_x = b.lo(0);
   box.hi_x = b.hi(0);
 #endif
-#if BL_SPACEDIM >= 2
+#if AMREX_SPACEDIM >= 2
   box.lo_y = b.lo(1);
   box.hi_y = b.hi(1);
 #endif
-#if BL_SPACEDIM >= 3
+#if AMREX_SPACEDIM >= 3
   box.lo_z = b.lo(2);
   box.hi_z = b.hi(2);
 #endif
@@ -155,13 +155,13 @@ RealBox readRealBoxFromHDF5(H5& h5, const std::string name)
 
 hid_t makeH5IntVec() {
   hid_t intvect_id = H5Tcreate(H5T_COMPOUND, sizeof(int_h5_t));
-#if BL_SPACEDIM >= 1
+#if AMREX_SPACEDIM >= 1
   H5Tinsert(intvect_id, "intvecti", HOFFSET(int_h5_t, i), H5T_NATIVE_INT);
 #endif
-#if BL_SPACEDIM >= 2
+#if AMREX_SPACEDIM >= 2
   H5Tinsert(intvect_id, "intvectj", HOFFSET(int_h5_t, j), H5T_NATIVE_INT);
 #endif
-#if BL_SPACEDIM >= 3
+#if AMREX_SPACEDIM >= 3
   H5Tinsert(intvect_id, "intvectk", HOFFSET(int_h5_t, k), H5T_NATIVE_INT);
 #endif
   return intvect_id;
@@ -169,39 +169,39 @@ hid_t makeH5IntVec() {
 
 int_h5_t writeH5IntVec(const int* in) {
   int_h5_t i;
-#if BL_SPACEDIM >= 1
+#if AMREX_SPACEDIM >= 1
   i.i = in[0];
 #endif
-#if BL_SPACEDIM >= 2
+#if AMREX_SPACEDIM >= 2
   i.j = in[1];
 #endif
-#if BL_SPACEDIM >= 3
+#if AMREX_SPACEDIM >= 3
   i.k = in[2];
 #endif
   return i;
 }
 
 void readH5IntVec(int_h5_t &in, int *out) {
-#if BL_SPACEDIM >= 1
+#if AMREX_SPACEDIM >= 1
   out[0] = in.i;
 #endif
-#if BL_SPACEDIM >= 2
+#if AMREX_SPACEDIM >= 2
   out[1] = in.j;
 #endif
-#if BL_SPACEDIM >= 3
+#if AMREX_SPACEDIM >= 3
   out[2] = in.k;
 #endif
 }
 
 hid_t makeH5RealVec() {
 hid_t realvect_id = H5Tcreate(H5T_COMPOUND, sizeof(real_h5_t));
-#if BL_SPACEDIM >= 1
+#if AMREX_SPACEDIM >= 1
   H5Tinsert(realvect_id, "x", HOFFSET(real_h5_t, x), H5T_NATIVE_DOUBLE);
 #endif
-#if BL_SPACEDIM >= 2
+#if AMREX_SPACEDIM >= 2
   H5Tinsert(realvect_id, "y", HOFFSET(real_h5_t, y), H5T_NATIVE_DOUBLE);
 #endif
-#if BL_SPACEDIM >= 3
+#if AMREX_SPACEDIM >= 3
   H5Tinsert(realvect_id, "z", HOFFSET(real_h5_t, z), H5T_NATIVE_DOUBLE);
 #endif
   return realvect_id;
@@ -209,26 +209,26 @@ hid_t realvect_id = H5Tcreate(H5T_COMPOUND, sizeof(real_h5_t));
 
 real_h5_t writeH5RealVec(const Real *in) {
   real_h5_t vec;
-#if BL_SPACEDIM >= 1
+#if AMREX_SPACEDIM >= 1
   vec.x = in[0];
 #endif
-#if BL_SPACEDIM >= 2
+#if AMREX_SPACEDIM >= 2
   vec.y = in[1];
 #endif
-#if BL_SPACEDIM >= 3
+#if AMREX_SPACEDIM >= 3
   vec.z = in[2];
 #endif
   return vec;
 }
 
 void readH5RealVec(real_h5_t &in, double *out) {
-#if BL_SPACEDIM >= 1
+#if AMREX_SPACEDIM >= 1
   out[0] = in.x;
 #endif
-#if BL_SPACEDIM >= 2
+#if AMREX_SPACEDIM >= 2
   out[1] = in.y;
 #endif
-#if BL_SPACEDIM >= 3
+#if AMREX_SPACEDIM >= 3
   out[2] = in.z;
 #endif
 }

--- a/Src/Base/AMReX_MultiFabUtil.H
+++ b/Src/Base/AMReX_MultiFabUtil.H
@@ -12,6 +12,10 @@
 
 #include <AMReX_MultiFabUtilI.H>
 
+#ifdef AMREX_USE_HDF5
+#include <AMReX_HDF5.H>
+#endif
+
 namespace amrex
 {
     //! Average nodal-based MultiFab onto cell-centered MultiFab.
@@ -298,6 +302,33 @@ void average_down_nodal (const FabArray<FAB>& fine, FabArray<FAB>& crse,
     }
 }
 
+
+
+#ifdef AMREX_USE_HDF5
+    //! Get a sorted list of grids and processors to aid in saving to HDF5
+    class SortedGrids
+    {
+      public:
+      std::map<int, Vector<std::pair<int,Box> > > gridMap; // = {proc_id:[(index,box),..], ...}
+      BoxArray sortedGrids;
+      Vector<int> sortedProcs;
+      Vector<unsigned long long> offsets;
+      Vector<unsigned long long> procOffsets;
+      Vector<unsigned long long> procBufferSize;
+
+      SortedGrids();
+      SortedGrids(const BoxArray& grids, const DistributionMapping& dmap);
+      void update(const BoxArray& grids, const DistributionMapping& dmap);
+      void update(MultiFab* data_mf);
+      void update(const Vector<long> count, const int size);
+
+    };
+
+    void writeMultiFab(H5& obj, MultiFab* data_mf, const Real time,
+                       const std::vector<std::string> data_names=std::vector<std::string>());
+
+    void readMultiFab(H5& obj, MultiFab* data_mf);
+#endif
 }
 
 #endif

--- a/Src/Base/AMReX_Utility.H
+++ b/Src/Base/AMReX_Utility.H
@@ -396,4 +396,13 @@ amrex::hash_vector (const Vector<T> & vec, uint64_t seed) noexcept
     return seed;
 }
 
+//! Convert a number to a string
+template <typename T>
+std::string num2str(const T Number) {
+  std::ostringstream ss;
+  ss.precision(16);
+  ss << Number;
+  return ss.str();
+}
+
 #endif /*BL_UTILITY_H*/

--- a/Src/Base/Make.package
+++ b/Src/Base/Make.package
@@ -231,6 +231,12 @@ endif
 CEXE_headers += AMReX_Machine.H
 CEXE_sources += AMReX_Machine.cpp
 
+# HDF5
+ifeq ($(USE_HDF5),TRUE)
+  C$(AMREX_BASE)_headers += AMReX_HDF5.H
+  C$(AMREX_BASE)_sources += AMReX_HDF5.cpp
+endif
+
 VPATH_LOCATIONS += $(AMREX_HOME)/Src/Base
 INCLUDE_LOCATIONS += $(AMREX_HOME)/Src/Base
 

--- a/Tutorials/EB/CNS/Exec/Make.CNS
+++ b/Tutorials/EB/CNS/Exec/Make.CNS
@@ -9,6 +9,15 @@ USE_EB := TRUE
 
 LAZY := TRUE
 
+USE_HDF5 ?= FALSE
+
+ifeq ($(USE_HDF5), TRUE)
+DEFINES += -DAMREX_USE_HDF5
+INCLUDE_LOCATIONS += $(HDF5_HOME)/include
+LIBRARIES         += -lhdf5 -L$(HDF5_HOME)/lib
+USERSuffix := $(USERSuffix).HDF5
+endif
+
 include $(AMREX_HOME)/Tools/GNUMake/Make.defs
 
 # CNS uses a coarse grained OMP approach

--- a/Tutorials/EB/CNS/Exec/Sod/GNUmakefile
+++ b/Tutorials/EB/CNS/Exec/Sod/GNUmakefile
@@ -4,8 +4,10 @@ DEBUG = FALSE
 DIM=3
 USE_MPI = TRUE
 USE_OMP = FALSE
+
+# set the HDF5 library directory (below is for Ubuntu 18.04)
 HDF5_HOME   = /usr/lib/x86_64-linux-gnu/hdf5/openmpi
-USE_HDF5 = TRUE
+USE_HDF5 = FALSE
 
 
 

--- a/Tutorials/EB/CNS/Exec/Sod/GNUmakefile
+++ b/Tutorials/EB/CNS/Exec/Sod/GNUmakefile
@@ -4,6 +4,10 @@ DEBUG = FALSE
 DIM=3
 USE_MPI = TRUE
 USE_OMP = FALSE
+HDF5_HOME   = /usr/lib/x86_64-linux-gnu/hdf5/openmpi
+USE_HDF5 = TRUE
+
+
 
 include ./Make.package
 include ../Make.CNS

--- a/Tutorials/EB/CNS/Exec/Sod/inputs
+++ b/Tutorials/EB/CNS/Exec/Sod/inputs
@@ -39,17 +39,14 @@ amr.grid_eff        = 0.99     # what constitutes an efficient grid
 amr.checkpoint_files_output = 1
 amr.check_file              = chk    # root name of checkpoint file
 amr.check_int               = 1    # number of timesteps between checkpoints
-amr.check_file_type         = HDF5
-amr.check_file_type         = DEFAULT
-
-amr.restart = restart.hdf5
+amr.check_file_type         = DEFAULT # choice of file type, HDF5 or DEFAULT
 
 # PLOTFILES
 amr.plot_files_output = 1
 amr.plot_file         = plt     # root name of plotfile
 amr.plot_int          = 1      # number of timesteps between plotfiles
 amr.derive_plot_vars  = pressure x_velocity y_velocity z_velocity
-amr.plot_file_type    = HDF5
+amr.plot_file_type    = HDF5 # choice of file type, HDF5 or DEFAULT
 
 # EB
 eb2.sphere_radius = 0.125

--- a/Tutorials/EB/CNS/Exec/Sod/inputs
+++ b/Tutorials/EB/CNS/Exec/Sod/inputs
@@ -39,14 +39,14 @@ amr.grid_eff        = 0.99     # what constitutes an efficient grid
 amr.checkpoint_files_output = 1
 amr.check_file              = chk    # root name of checkpoint file
 amr.check_int               = 1    # number of timesteps between checkpoints
-amr.check_file_type         = DEFAULT # choice of file type, HDF5 or DEFAULT
+#amr.check_file_type         = HDF5 # choice of file type, HDF5 or DEFAULT
 
 # PLOTFILES
 amr.plot_files_output = 1
 amr.plot_file         = plt     # root name of plotfile
 amr.plot_int          = 1      # number of timesteps between plotfiles
 amr.derive_plot_vars  = pressure x_velocity y_velocity z_velocity
-amr.plot_file_type    = HDF5 # choice of file type, HDF5 or DEFAULT
+#amr.plot_file_type    = HDF5 # choice of file type, HDF5 or DEFAULT
 
 # EB
 eb2.sphere_radius = 0.125

--- a/Tutorials/EB/CNS/Exec/Sod/inputs
+++ b/Tutorials/EB/CNS/Exec/Sod/inputs
@@ -1,13 +1,13 @@
 amrex.fpe_trap_invalid=1
 
-max_step  = 100
+max_step  = 10
 stop_time = 0.2
 
 geometry.is_periodic = 0 0 0
 geometry.coord_sys   = 0  # 0 => cart, 1 => RZ  2=>spherical
 geometry.prob_lo     =   0.0     0.0     0.0
 geometry.prob_hi     =   1.0     1.0     1.0
-amr.n_cell           =    64      64      64
+amr.n_cell           =    16      16      16
 
 # >>>>>>>>>>>>>  BC FLAGS <<<<<<<<<<<<<<<<
 # 0 = Interior           3 = Symmetry
@@ -36,15 +36,20 @@ amr.n_error_buf     = 0 0 0 0 # number of buffer cells in error est
 amr.grid_eff        = 0.99     # what constitutes an efficient grid
 
 # CHECKPOINT FILES
-amr.checkpoint_files_output = 0
+amr.checkpoint_files_output = 1
 amr.check_file              = chk    # root name of checkpoint file
-amr.check_int               = 100    # number of timesteps between checkpoints
+amr.check_int               = 1    # number of timesteps between checkpoints
+amr.check_file_type         = HDF5
+amr.check_file_type         = DEFAULT
+
+amr.restart = restart.hdf5
 
 # PLOTFILES
 amr.plot_files_output = 1
 amr.plot_file         = plt     # root name of plotfile
-amr.plot_int          = 10      # number of timesteps between plotfiles
+amr.plot_int          = 1      # number of timesteps between plotfiles
 amr.derive_plot_vars  = pressure x_velocity y_velocity z_velocity
+amr.plot_file_type    = HDF5
 
 # EB
 eb2.sphere_radius = 0.125
@@ -54,7 +59,7 @@ eb2.sphere_center = 0.7 0.5 0.5
 eb2.sphere_has_fluid_inside = 0
 
 eb2.geom_type = sphere
-#eb2.geom_type = all_regular
+eb2.geom_type = all_regular
 
 cns.refine_cutcells = 0
 

--- a/Tutorials/EB/CNS/Source/CNS.H
+++ b/Tutorials/EB/CNS/Source/CNS.H
@@ -35,14 +35,19 @@ public:
                             amrex::VisMF::How  how = amrex::VisMF::NFiles,
                             bool               dump_old = true) override;
 
-    virtual std::string thePlotFileType () const override {
-        return {"HyperCLaw-V1.1"};
-    }
+    // get the data for the plot file
+    virtual void getPlotData(MultiFab&                 plot_data,
+                             std::vector<std::string>& plot_names) override;
 
-    // Write a plotfile to specified directory.
-    virtual void writePlotFile (const std::string& dir,
-                                std::ostream&      os,
-                                amrex::VisMF::How  how) override;
+
+    // some extra information for the plot file
+    virtual void writePlotFilePost (const std::string& dir,
+                                    std::ostream&      os) override;
+
+#ifdef AMREX_USE_HDF5
+    virtual void checkPointHDF5Post() override;
+    virtual void writePlotHDF5Post() override;
+#endif
 
     // Initialize data on this level from another CNS (during regrid).
     virtual void init (amrex::AmrLevel& old) override;

--- a/Tutorials/EB/CNS/Source/CNS.cpp
+++ b/Tutorials/EB/CNS/Source/CNS.cpp
@@ -301,10 +301,10 @@ void
 CNS::post_restart ()
 {
     if (do_reflux && level > 0) {
-        flux_reg.define(grids, parent->boxArray(level-1), dmap, 
-                        parent->DistributionMap(level-1), geom, 
-                        parent->Geom(level-1), parent->refRatio(level-1), 
-                        level, NUM_STATE);
+        flux_reg.define(grids, parent->boxArray(level-1),
+                        dmap,  parent->DistributionMap(level-1),
+                        geom,  parent->Geom(level-1),
+                        parent->refRatio(level-1), level, NUM_STATE);
     }
 
     buildMetrics();

--- a/Tutorials/EB/CNS/Source/CNS.cpp
+++ b/Tutorials/EB/CNS/Source/CNS.cpp
@@ -300,6 +300,14 @@ CNS::post_init (Real)
 void
 CNS::post_restart ()
 {
+    if (do_reflux && level > 0) {
+        flux_reg.define(grids, parent->boxArray(level-1), dmap, 
+                        parent->DistributionMap(level-1), geom, 
+                        parent->Geom(level-1), parent->refRatio(level-1), 
+                        level, NUM_STATE);
+    }
+
+    buildMetrics();
 }
 
 void
@@ -358,7 +366,7 @@ CNS::errorEst (TagBoxArray& tags, int, int, Real time, int, int)
         {
             const Box& bx = mfi.tilebox();
 
-            const auto& sfab = S_new[mfi];
+//            const auto& sfab = S_new[mfi];
             const auto& flag = flags[mfi];
 
             const FabType typ = flag.getType(bx);
@@ -484,7 +492,7 @@ CNS::estTimeStep ()
         {
             const Box& box = mfi.tilebox();
 
-            const auto& sfab = S[mfi];
+//            const auto& sfab = S[mfi];
             const auto& flag = flags[mfi];
 
             if (flag.getType(box) != FabType::covered) {
@@ -523,7 +531,7 @@ CNS::computeTemp (MultiFab& State, int ng)
     {
         const Box& bx = mfi.growntilebox(ng);
 
-        const auto& sfab = State[mfi];
+//        const auto& sfab = State[mfi];
         const auto& flag = flags[mfi];
 
         if (flag.getType(bx) != FabType::covered) {

--- a/Tutorials/EB/CNS/Source/CNS_advance.cpp
+++ b/Tutorials/EB/CNS/Source/CNS_advance.cpp
@@ -94,7 +94,7 @@ CNS::compute_dSdt (const MultiFab& S, MultiFab& dSdt, Real dt,
 
             const Box& bx = mfi.tilebox();
 
-            const auto& sfab = S[mfi];
+//            const auto& sfab = S[mfi];
             const auto& flag = flags[mfi];
 
             //if (1){

--- a/Tutorials/EB/CNS/Source/CNS_io.cpp
+++ b/Tutorials/EB/CNS/Source/CNS_io.cpp
@@ -9,14 +9,6 @@ CNS::restart (Amr& papa, std::istream& is, bool bReadSpecial)
 {
     AmrLevel::restart(papa,is,bReadSpecial);
 
-    if (do_reflux && level > 0) {
-        flux_reg.define(grids, papa.boxArray(level-1),
-                        dmap, papa.DistributionMap(level-1),
-                        geom, papa.Geom(level-1),
-                        papa.refRatio(level-1), level, NUM_STATE);
-    }
-
-    buildMetrics();
 }
 
 void 


### PR DESCRIPTION
Integrates HDF5 file operations into the plot and checkpoint methods. I have tried to implement these features unobtrusively and existing I/O should still work without modification.

The EB/CNS tutorial has been modified to provide an example and to serve as a test of the file I/O and restart capability.

Note that I have not made any changes to the hdf5 routines in `AMREX_PlotFileUtil` or `AMREX_ParticleIO` although all of the HDF5 data operations should probably be consolidated under `AMREX_HDF5` at some point. I am not advocating for my particular flavour of implementation, but having multiple implementations is clearly non-optimal.

See Issue #441 for the origin of this work.