### PR TITLE
Fix warning maybe-uninitialized for: the_send_data

### DIFF
--- a/Src/Base/AMReX_FabArrayCommI.H
+++ b/Src/Base/AMReX_FabArrayCommI.H
@@ -446,7 +446,7 @@ FabArray<FAB>::ParallelCopy (const FabArray<FAB>& src,
 	//
 	// Post send's
 	//
-        char*                               the_send_data;
+        char*                               the_send_data = nullptr;
 	Vector<char*>                       send_data;
 	Vector<std::size_t>                 send_size;
 	Vector<int>                         send_rank;


### PR DESCRIPTION
Compiler warning with GCC 9.3:

```
.../Src/Base/AMReX_FabArrayCommI.H: In member function 'void amrex::FabArray<FAB>::ParallelCopy(const amrex::FabArray<FAB>&, int, int, int, const amrex::IntVect&, const amrex::IntVect&, const amrex::Periodicity&, amrex::FabArrayBase::CpOp, const amrex::FabArrayBase::CPC*) [with FAB = amrex::FArrayBox]':
.../Src/Base/AMReX_FabArrayCommI.H:611:40: error: 'the_send_data' may be used uninitialized in this function [-Werror=maybe-uninitialized]
             amrex::The_FA_Arena()->free(the_send_data);
             ~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~
```