### PR TITLE
Cori-gpu make update for testing USE_MPI=TRUE USE_CUDA=FALSE

### DIFF
--- a/Src/Base/AMReX_Machine.cpp
+++ b/Src/Base/AMReX_Machine.cpp
@@ -306,6 +306,7 @@ class Machine
 
     std::string hostname;
     std::string nersc_host;
+    std::string cluster_name;
     std::string partition;
     std::string node_list;
     std::string topo_addr;
@@ -339,6 +340,7 @@ class Machine
     {
         hostname   = get_env_str("HOSTNAME");
         nersc_host = get_env_str("NERSC_HOST");
+        cluster_name = get_env_str("SLURM_CLUSTER_NAME");
 #ifdef AMREX_USE_CUDA
         flag_nersc_df = false;
 #else
@@ -375,6 +377,8 @@ class Machine
                 }
 #ifdef BL_USE_MPI
             } else {
+                if (cluster_name == "escori")
+		    tag = "cgpu";
                 auto mpi_proc_name = get_mpi_processor_name();
                 Print() << "MPI_Get_processor_name: " << mpi_proc_name << std::endl;
                 pos = mpi_proc_name.find(tag);

--- a/Tools/GNUMake/Make.defs
+++ b/Tools/GNUMake/Make.defs
@@ -1020,6 +1020,12 @@ else ifeq ($(USE_CUDA),TRUE)
 
           OMPI_CFLAGS_ORIG = $(shell mpicc -showme:compile)
           export OMPI_CFLAGS := $(subst -pthread,-Xcompiler$(space)-pthread,$(OMPI_CXXFLAGS_ORIG))
+
+          # If we're compiling with PGI, it doesn't know -pthread, replace
+          # with -lpthread.
+
+          OMPI_FCFLAGS_ORIG = $(shell mpif90 -showme:compile)
+          export OMPI_FCFLAGS := $(subst -pthread,-lpthread,$(OMPI_FCFLAGS_ORIG))
         endif
 
       endif

--- a/Tools/GNUMake/Make.machines
+++ b/Tools/GNUMake/Make.machines
@@ -22,9 +22,14 @@ ifeq ($(host_name), $(findstring $(host_name), $(CCSE_MACHINES)))
   which_computer := $(host_name)
 endif
 
-ifeq ($(findstring cori, $(NERSC_HOST)), cori)
+ifeq ($(findstring cori, $(host_name)), cori)
   which_site := nersc
   which_computer := cori
+endif
+
+ifeq ($(findstring cgpu, $(host_name)), cgpu)
+  which_site := nersc
+  which_computer := cgpu
 endif
 
 ifeq ($(findstring titan, $(host_name)), titan)

--- a/Tools/GNUMake/sites/Make.nersc
+++ b/Tools/GNUMake/sites/Make.nersc
@@ -2,81 +2,154 @@
 # For NERSC machines: Cori and corigpu
 #
 
-ifneq ($(which_computer),$(filter $(which_computer),cori))
+NERSC_MACHINES := cori cgpu
+
+ifneq ($(which_computer),$(filter $(which_computer), ${NERSC_MACHINES}))
   $(error Unknown NERSC computer, $(which_computer))
 endif
 
+ifeq ($(which_computer),$(filter $(which_computer),cori))
 
-ifdef PE_ENV
-ifneq ($(USE_CUDA),TRUE)
-  lowercase_peenv := $(shell echo $(PE_ENV) | tr A-Z a-z)
-  ifneq ($(lowercase_peenv),$(lowercase_comp))
-    has_compiler_mismatch = COMP=$(COMP) does not match PrgEnv-$(lowercase_peenv)
+  ifdef PE_ENV
+  ifneq ($(USE_CUDA),TRUE)
+    lowercase_peenv := $(shell echo $(PE_ENV) | tr A-Z a-z)
+    ifneq ($(lowercase_peenv),$(lowercase_comp))
+      has_compiler_mismatch = COMP=$(COMP) does not match PrgEnv-$(lowercase_peenv)
+    endif
   endif
-endif
-endif
+  endif
 
+  ifeq ($(USE_MPI),TRUE)
+  ifeq ($(USE_CUDA),TRUE)
+    CC  = mpicc
+    CXX = mpic++ 
+    FC  = mpif90
+    F90 = mpif90
+    cori_mvapich_link_flags := $(shell mpic++ -link_info)
 
-ifeq ($(USE_MPI),TRUE)
-ifeq ($(USE_CUDA),TRUE)
-  CC  = mpicc
-  CXX = mpic++ 
-  FC  = mpif90
-  F90 = mpif90
-  cori_mvapich_link_flags := $(shell mpic++ -link_info)
+  # Using OPENMPI + UCX
+    ifeq ($(cori_mvapich_link_flags),)
+      CXX := nvcc
+      cori_openmpi_compile_flags := $(shell mpic++ --showme:compile)
+      cori_openmpi_link_flags := $(shell mpic++ --showme:link)
 
-# Using OPENMPI + UCX
-  ifeq ($(cori_mvapich_link_flags),)
-    CXX := nvcc
-    cori_openmpi_compile_flags := $(shell mpic++ --showme:compile)
-    cori_openmpi_link_flags := $(shell mpic++ --showme:link)
+      ifeq ($(findstring -pthread,$(cori_openmpi_compile_flags)),-pthread)
+        CXXFLAGS += -Xcompiler='-pthread'
+      endif
 
-    ifeq ($(findstring -pthread,$(cori_openmpi_compile_flags)),-pthread)
-       CXXFLAGS += -Xcompiler='-pthread'
-    endif
+      ifeq ($(findstring -pthread,$(cori_openmpi_link_flags)),-pthread)
+          LDFLAGS += -Xcompiler='-pthread'
+      endif
 
-    ifeq ($(findstring -pthread,$(cori_openmpi_link_flags)),-pthread)
-        LDFLAGS += -Xcompiler='-pthread'
-    endif
-
-    includes += $(wordlist 1,1024,$(filter-out -pthread,$(cori_openmpi_compile_flags)))
+      includes += $(wordlist 1,1024,$(filter-out -pthread,$(cori_openmpi_compile_flags)))
 #   NOTE: MUST be done in LIBRARIES so -Wl -> -Xlinker substitution occurs. 
-    LIBRARIES  += $(wordlist 1,1024,$(filter-out -pthread,$(cori_openmpi_link_flags)))
+      LIBRARIES  += $(wordlist 1,1024,$(filter-out -pthread,$(cori_openmpi_link_flags)))
 
 # Using mvapich
-  else
+    else
 
-    ifneq ($(LINK_WITH_FORTRAN_COMPILER),TRUE)
-      LIBRARIES += --compiler-options '-fPIC' $(wordlist 2,1024,$(filter-out -m64,$(filter-out -fPIC,$(cori_mvapich_link_flags))))
+      ifneq ($(LINK_WITH_FORTRAN_COMPILER),TRUE)
+        LIBRARIES += --compiler-options '-fPIC' $(wordlist 2,1024,$(filter-out -m64,$(filter-out -fPIC,$(cori_mvapich_link_flags))))
+      endif
+
     endif
 
+  else
+    CC  = cc
+    CXX = CC
+    FC  = ftn
+    F90 = ftn
+    LIBRARIES += -lmpichf90
+  endif
   endif
 
-else
-  CC  = cc
-  CXX = CC
-  FC  = ftn
-  F90 = ftn
-  LIBRARIES += -lmpichf90
-endif
-endif
+  ifeq ($(USE_CUDA),TRUE)
 
-ifeq ($(USE_CUDA),TRUE)
+    ifneq ($(CUDA_ROOT),)
+        SYSTEM_CUDA_PATH := $(CUDA_ROOT)
+        COMPILE_CUDA_PATH := $(CUDA_ROOT)
+    else ifneq ($(CUDA_HOME),)
+        SYSTEM_CUDA_PATH := $(CUDA_HOME)
+        COMPILE_CUDA_PATH := $(CUDA_HOME)
+    endif
 
-  ifneq ($(CUDA_ROOT),)
-      SYSTEM_CUDA_PATH := $(CUDA_ROOT)
-      COMPILE_CUDA_PATH := $(CUDA_ROOT)
-  else ifneq ($(CUDA_HOME),)
-      SYSTEM_CUDA_PATH := $(CUDA_HOME)
-      COMPILE_CUDA_PATH := $(CUDA_HOME)
+    CUDA_ARCH = 70
+    GPUS_PER_NODE = 8
+    GPUS_PER_SOCKET = 4
   endif
 
-  CUDA_ARCH = 70
-  GPUS_PER_NODE = 8
-  GPUS_PER_SOCKET = 4
+  ifeq ($(USE_SENSEI_INSITU),TRUE)
+    CXXFLAGS += -fPIC -dynamic
+    LIBRARIES += -ldl
+  endif
+
 endif
 
-ifeq ($(USE_SENSEI_INSITU),TRUE)
-  CXXFLAGS += -fPIC -dynamic
-  LIBRARIES += -ldl
+ifeq ($(which_computer),$(filter $(which_computer),cgpu))
+
+  ifeq ($(USE_MPI),TRUE)
+  ifeq ($(USE_CUDA),TRUE)
+    CC  = mpicc
+    CXX = mpic++ 
+    FC  = mpif90
+    F90 = mpif90
+    cori_mvapich_link_flags := $(shell mpic++ -link_info)
+
+  # Using OPENMPI + UCX
+    ifeq ($(cori_mvapich_link_flags),)
+      CXX := nvcc
+      cori_openmpi_compile_flags := $(shell mpic++ --showme:compile)
+      cori_openmpi_link_flags := $(shell mpic++ --showme:link)
+
+      ifeq ($(findstring -pthread,$(cori_openmpi_compile_flags)),-pthread)
+        CXXFLAGS += -Xcompiler='-pthread'
+      endif
+
+      ifeq ($(findstring -pthread,$(cori_openmpi_link_flags)),-pthread)
+          LDFLAGS += -Xcompiler='-pthread'
+      endif
+
+      includes += $(wordlist 1,1024,$(filter-out -pthread,$(cori_openmpi_compile_flags)))
+#   NOTE: MUST be done in LIBRARIES so -Wl -> -Xlinker substitution occurs. 
+      LIBRARIES  += $(wordlist 1,1024,$(filter-out -pthread,$(cori_openmpi_link_flags)))
+
+# Using mvapich
+    else
+
+      ifneq ($(LINK_WITH_FORTRAN_COMPILER),TRUE)
+        LIBRARIES += --compiler-options '-fPIC' $(wordlist 2,1024,$(filter-out -m64,$(filter-out -fPIC,$(cori_mvapich_link_flags))))
+      endif
+
+    endif
+
+  else
+
+    CC  = mpicc
+    CXX = mpic++
+    FC  = mpif90
+    F90 = mpif90
+
+  endif
+  endif
+
+  ifeq ($(USE_CUDA),TRUE)
+
+    ifneq ($(CUDA_ROOT),)
+        SYSTEM_CUDA_PATH := $(CUDA_ROOT)
+        COMPILE_CUDA_PATH := $(CUDA_ROOT)
+    else ifneq ($(CUDA_HOME),)
+        SYSTEM_CUDA_PATH := $(CUDA_HOME)
+        COMPILE_CUDA_PATH := $(CUDA_HOME)
+    endif
+
+    CUDA_ARCH = 70
+    GPUS_PER_NODE = 8
+    GPUS_PER_SOCKET = 4
+  endif
+
+  ifeq ($(USE_SENSEI_INSITU),TRUE)
+    CXXFLAGS += -fPIC -dynamic
+    LIBRARIES += -ldl
+  endif
+
 endif

--- a/Tools/GNUMake/sites/Make.nersc
+++ b/Tools/GNUMake/sites/Make.nersc
@@ -21,39 +21,7 @@ ifeq ($(which_computer),$(filter $(which_computer),cori))
 
   ifeq ($(USE_MPI),TRUE)
   ifeq ($(USE_CUDA),TRUE)
-    CC  = mpicc
-    CXX = mpic++ 
-    FC  = mpif90
-    F90 = mpif90
-    cori_mvapich_link_flags := $(shell mpic++ -link_info)
-
-  # Using OPENMPI + UCX
-    ifeq ($(cori_mvapich_link_flags),)
-      CXX := nvcc
-      cori_openmpi_compile_flags := $(shell mpic++ --showme:compile)
-      cori_openmpi_link_flags := $(shell mpic++ --showme:link)
-
-      ifeq ($(findstring -pthread,$(cori_openmpi_compile_flags)),-pthread)
-        CXXFLAGS += -Xcompiler='-pthread'
-      endif
-
-      ifeq ($(findstring -pthread,$(cori_openmpi_link_flags)),-pthread)
-          LDFLAGS += -Xcompiler='-pthread'
-      endif
-
-      includes += $(wordlist 1,1024,$(filter-out -pthread,$(cori_openmpi_compile_flags)))
-#   NOTE: MUST be done in LIBRARIES so -Wl -> -Xlinker substitution occurs. 
-      LIBRARIES  += $(wordlist 1,1024,$(filter-out -pthread,$(cori_openmpi_link_flags)))
-
-# Using mvapich
-    else
-
-      ifneq ($(LINK_WITH_FORTRAN_COMPILER),TRUE)
-        LIBRARIES += --compiler-options '-fPIC' $(wordlist 2,1024,$(filter-out -m64,$(filter-out -fPIC,$(cori_mvapich_link_flags))))
-      endif
-
-    endif
-
+    $(error USE_CUDA is not allowed on the cori login nodes, please build from a cgpu node))
   else
     CC  = cc
     CXX = CC
@@ -61,21 +29,6 @@ ifeq ($(which_computer),$(filter $(which_computer),cori))
     F90 = ftn
     LIBRARIES += -lmpichf90
   endif
-  endif
-
-  ifeq ($(USE_CUDA),TRUE)
-
-    ifneq ($(CUDA_ROOT),)
-        SYSTEM_CUDA_PATH := $(CUDA_ROOT)
-        COMPILE_CUDA_PATH := $(CUDA_ROOT)
-    else ifneq ($(CUDA_HOME),)
-        SYSTEM_CUDA_PATH := $(CUDA_HOME)
-        COMPILE_CUDA_PATH := $(CUDA_HOME)
-    endif
-
-    CUDA_ARCH = 70
-    GPUS_PER_NODE = 8
-    GPUS_PER_SOCKET = 4
   endif
 
   ifeq ($(USE_SENSEI_INSITU),TRUE)
@@ -88,51 +41,17 @@ endif
 ifeq ($(which_computer),$(filter $(which_computer),cgpu))
 
   ifeq ($(USE_MPI),TRUE)
-  ifeq ($(USE_CUDA),TRUE)
-    CC  = mpicc
-    CXX = mpic++ 
-    FC  = mpif90
-    F90 = mpif90
-    cori_mvapich_link_flags := $(shell mpic++ -link_info)
-
-  # Using OPENMPI + UCX
-    ifeq ($(cori_mvapich_link_flags),)
-      CXX := nvcc
-      cori_openmpi_compile_flags := $(shell mpic++ --showme:compile)
-      cori_openmpi_link_flags := $(shell mpic++ --showme:link)
-
-      ifeq ($(findstring -pthread,$(cori_openmpi_compile_flags)),-pthread)
-        CXXFLAGS += -Xcompiler='-pthread'
-      endif
-
-      ifeq ($(findstring -pthread,$(cori_openmpi_link_flags)),-pthread)
-          LDFLAGS += -Xcompiler='-pthread'
-      endif
-
-      includes += $(wordlist 1,1024,$(filter-out -pthread,$(cori_openmpi_compile_flags)))
-#   NOTE: MUST be done in LIBRARIES so -Wl -> -Xlinker substitution occurs. 
-      LIBRARIES  += $(wordlist 1,1024,$(filter-out -pthread,$(cori_openmpi_link_flags)))
-
-# Using mvapich
-    else
-
-      ifneq ($(LINK_WITH_FORTRAN_COMPILER),TRUE)
-        LIBRARIES += --compiler-options '-fPIC' $(wordlist 2,1024,$(filter-out -m64,$(filter-out -fPIC,$(cori_mvapich_link_flags))))
-      endif
-
-    endif
-
-  else
 
     CC  = mpicc
     CXX = mpic++
     FC  = mpif90
     F90 = mpif90
-
+    
   endif
-  endif
-
+  
   ifeq ($(USE_CUDA),TRUE)
+
+    FIX_NVCC_PTHREAD=TRUE
 
     ifneq ($(CUDA_ROOT),)
         SYSTEM_CUDA_PATH := $(CUDA_ROOT)


### PR DESCRIPTION
Added which_computer=cgpu
Added test in AMReX_Machines.cpp for false flag that assumes cgpu## instead of .*nid(\d+)
Moved flags for pthreads from Make.nersc to Make.defs
Add error message for cgpu build on cori login node
