### PR TITLE
CMake: Discard Invalid Git Versions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,13 +9,20 @@ find_package (Git QUIET)
 
 set( _tmp "" )
 
+# Try to inquire software version from git
 if ( EXISTS ${CMAKE_CURRENT_LIST_DIR}/.git AND ${GIT_FOUND} )
    execute_process ( COMMAND git describe --abbrev=12 --dirty --always --tags
       WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
       OUTPUT_VARIABLE _tmp )
    string( STRIP ${_tmp} _tmp )
-else ()
-   # Grep first line from file CHANGES if cannot find version from Git
+   # filter invalid descriptions in shallow git clones
+   if (NOT _tmp VERSION_GREATER "0.0.0")
+       set( _tmp "")
+   endif ()
+endif()
+
+# Grep first line from file CHANGES if cannot find version from Git
+if (NOT _tmp)
    file(STRINGS ${CMAKE_CURRENT_LIST_DIR}/CHANGES ALL_VERSIONS REGEX "#")
    list(GET ALL_VERSIONS 0 _tmp)
    string(REPLACE "#" "" _tmp "${_tmp}")


### PR DESCRIPTION
In case a user only performed a shallow copy of the git repo, `git describe` will not find a latest tag and return only a hash. Hashes are not valid `VERSION` attributes in CMake and crash the configuration stage.

This fix just discards invalid versions and tries the fallback of parsing the change log file.

Fix #731 (continued, cc @maikel)

Ref.: https://github.com/AMReX-Codes/amrex/issues/731#issuecomment-596077396