### PR TITLE
CMake: Regex Version Validator

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ if ( EXISTS ${CMAKE_CURRENT_LIST_DIR}/.git AND ${GIT_FOUND} )
       OUTPUT_VARIABLE _tmp )
    string( STRIP ${_tmp} _tmp )
    # filter invalid descriptions in shallow git clones
-   if (NOT _tmp VERSION_GREATER "0.0.0")
+   if (NOT _tmp MATCHES "^([0-9]+)\\.([0-9]+)(\\.([0-9]+))*(-.*)*$")
        set( _tmp "")
    endif ()
 endif()


### PR DESCRIPTION
If what we get from `git describe` does not match `<Numbers>.<Numbers>[.<Numbers>][-something]` then we treat that as not a proper version.

Things that are valid versions for `project(VERSION ...)`: e.g. `20.04-57-g3f1e6e06bc33-dirty`

cc @jrood-nrel

Fix https://github.com/AMReX-Codes/amrex/issues/731#issuecomment-611795847