### PR TITLE
CI: macOS

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -37,6 +37,21 @@ jobs:
         make -j 2 tutorials
 
   # Build libamrex and all tutorials
+  tutorials-macos:
+    name: AppleClang@11.0 GFortran@9.3 [tutorials]
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Dependencies
+      run: .github/workflows/cmake/dependencies_mac.sh
+    - name: Build & Install
+      run: |
+        mkdir build
+        cd build
+        cmake .. -DENABLE_TUTORIALS=ON
+        make -j 2 tutorials
+
+  # Build libamrex and all tutorials
   tutorials-nofortran:
     name: GNU@7.5 C++11 w/o Fortran [tutorials]
     runs-on: ubuntu-latest

--- a/.github/workflows/cmake/dependencies_mac.sh
+++ b/.github/workflows/cmake/dependencies_mac.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+#
+# Copyright 2020 Axel Huebl
+#
+# License: BSD-3-Clause-LBNL
+
+# search recursive inside a folder if a file contains tabs
+#
+# @result 0 if no files are found, else 1
+#
+
+set -eu -o pipefail
+
+brew update
+brew install openmpi


### PR DESCRIPTION
Since more than half of our developers use macOS for development, its time to check how well we support native compilers.

Adds CMake checks.