### PR TITLE
DPC++ kernel too big

### DIFF
--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLap_3D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLap_3D_K.H
@@ -237,6 +237,9 @@ inline void mlndlap_bc_doit (Box const& vbx, Array4<T> const& a, Box const& doma
                              GpuArray<bool,AMREX_SPACEDIM> const& bflo,
                              GpuArray<bool,AMREX_SPACEDIM> const& bfhi) noexcept
 {
+#ifdef AMREX_USE_DPCPP
+    amrex::Abort("xxxxx DPCPP todo: mlndlap_bc_doit: kernel too big");
+#else
     Box gdomain = domain;
     for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
         if (not bflo[idim]) gdomain.growLo(idim,1);
@@ -728,6 +731,7 @@ inline void mlndlap_bc_doit (Box const& vbx, Array4<T> const& a, Box const& doma
             }
         }
     });
+#endif
 }
 
 //

--- a/Tutorials/GPU/CNS/Source/hydro/CNS_hydro_K.H
+++ b/Tutorials/GPU/CNS/Source/hydro/CNS_hydro_K.H
@@ -214,8 +214,8 @@ riemann (const amrex::Real gamma, const amrex::Real smallp, const amrex::Real sm
         wlsq = (.5*(gamma-1.)*(pstar+pl)+pstar)*rl;
         wrsq = (.5*(gamma-1.)*(pstar+pr)+pstar)*rr;
 
-        wl = 1./sqrt(wlsq);
-        wr = 1./sqrt(wrsq);
+        wl = 1./std::sqrt(wlsq);
+        wr = 1./std::sqrt(wrsq);
 
         amrex::Real ustnm1 = ustarm;
         amrex::Real ustnp1 = ustarp;
@@ -269,7 +269,7 @@ riemann (const amrex::Real gamma, const amrex::Real smallp, const amrex::Real sm
     amrex::Real wo = std::sqrt(wosq);
     amrex::Real dpjmp = pstar-po;
     amrex::Real rstar = ro/(1.-ro*dpjmp/wosq);
-    amrex::Real cstar = sqrt(gamma * pstar / rstar);
+    amrex::Real cstar = std::sqrt(gamma * pstar / rstar);
     amrex::Real spout = co-sgnm*uo;
     amrex::Real spin = cstar - sgnm*uo;
     if(pstar >= po) {


### PR DESCRIPTION
This kernel's parameters are too big for DPCPP on Gen9 that has a limit of 1KB.
