### PR TITLE
CNS tutorial: make [GC]puBndryFuncFab local instead of static

### DIFF
--- a/Tutorials/GPU/Advection_AmrCore/Source/AmrCoreAdv.cpp
+++ b/Tutorials/GPU/Advection_AmrCore/Source/AmrCoreAdv.cpp
@@ -397,7 +397,7 @@ AmrCoreAdv::FillPatch (int lev, Real time, MultiFab& mf, int icomp, int ncomp)
 
         if(Gpu::inLaunchRegion())
         {
-            GpuBndryFuncFab<AmrCoreFill> gpu_bndry_func(amrcore_fill_func);
+            GpuBndryFuncFab<AmrCoreFill> gpu_bndry_func(AmrCoreFill{});
             PhysBCFunct<GpuBndryFuncFab<AmrCoreFill> > physbc(geom[lev],bcs,gpu_bndry_func);
             amrex::FillPatchSingleLevel(mf, time, smf, stime, 0, icomp, ncomp, 
                                         geom[lev], physbc, 0);
@@ -421,7 +421,7 @@ AmrCoreAdv::FillPatch (int lev, Real time, MultiFab& mf, int icomp, int ncomp)
 
         if(Gpu::inLaunchRegion())
         {
-            GpuBndryFuncFab<AmrCoreFill> gpu_bndry_func(amrcore_fill_func);
+            GpuBndryFuncFab<AmrCoreFill> gpu_bndry_func(AmrCoreFill{});
             PhysBCFunct<GpuBndryFuncFab<AmrCoreFill> > cphysbc(geom[lev-1],bcs,gpu_bndry_func);
             PhysBCFunct<GpuBndryFuncFab<AmrCoreFill> > fphysbc(geom[lev],bcs,gpu_bndry_func);
 
@@ -462,7 +462,7 @@ AmrCoreAdv::FillCoarsePatch (int lev, Real time, MultiFab& mf, int icomp, int nc
 
     if(Gpu::inLaunchRegion())
     {
-        GpuBndryFuncFab<AmrCoreFill> gpu_bndry_func(amrcore_fill_func);
+        GpuBndryFuncFab<AmrCoreFill> gpu_bndry_func(AmrCoreFill{});
         PhysBCFunct<GpuBndryFuncFab<AmrCoreFill> > cphysbc(geom[lev-1],bcs,gpu_bndry_func);
         PhysBCFunct<GpuBndryFuncFab<AmrCoreFill> > fphysbc(geom[lev],bcs,gpu_bndry_func);
 

--- a/Tutorials/GPU/Advection_AmrCore/Source/bc_fill.H
+++ b/Tutorials/GPU/Advection_AmrCore/Source/bc_fill.H
@@ -20,8 +20,4 @@ struct AmrCoreFill
         }
 };
 
-namespace {
-    static AmrCoreFill amrcore_fill_func;
-}
-
 #endif

--- a/Tutorials/GPU/CNS/Source/CNS_bcfill.cpp
+++ b/Tutorials/GPU/CNS/Source/CNS_bcfill.cpp
@@ -18,12 +18,6 @@ struct CnsFillExtDir
         }
 };
 
-namespace {
-    static CnsFillExtDir cns_fill_ext_dir;
-    static GpuBndryFuncFab<CnsFillExtDir> gpu_bndry_func(cns_fill_ext_dir);
-    static CpuBndryFuncFab cpu_bndry_func(nullptr); // Without EXT_DIR (e.g., inflow), we can pass a nullptr
-}
-
 // bx                  : Cells outside physical domain and inside bx are filled.
 // data, dcomp, numcomp: Fill numcomp components of data starting from dcomp.
 // bcr, bcomp          : bcr[bcomp] specifies BC for component dcomp and so on.
@@ -36,8 +30,11 @@ void cns_bcfill (Box const& bx, FArrayBox& data,
                  const int scomp)
 {
     if (Gpu::inLaunchRegion()) {
+        GpuBndryFuncFab<CnsFillExtDir> gpu_bndry_func(CnsFillExtDir{});
         gpu_bndry_func(bx,data,dcomp,numcomp,geom,time,bcr,bcomp,scomp);
     } else {
+        // Without EXT_DIR (e.g., inflow), we can pass a nullptr
+        CpuBndryFuncFab cpu_bndry_func(nullptr);
         cpu_bndry_func(bx,data,dcomp,numcomp,geom,time,bcr,bcomp,scomp);
     }
 }

--- a/Tutorials/GPU/EBCNS/Source/CNS_bcfill.cpp
+++ b/Tutorials/GPU/EBCNS/Source/CNS_bcfill.cpp
@@ -18,12 +18,6 @@ struct CnsFillExtDir
         }
 };
 
-namespace {
-    static CnsFillExtDir cns_fill_ext_dir;
-    static GpuBndryFuncFab<CnsFillExtDir> gpu_bndry_func(cns_fill_ext_dir);
-    static CpuBndryFuncFab cpu_bndry_func(nullptr); // Without EXT_DIR (e.g., inflow), we can pass a nullptr
-}
-
 // bx                  : Cells outside physical domain and inside bx are filled.
 // data, dcomp, numcomp: Fill numcomp components of data starting from dcomp.
 // bcr, bcomp          : bcr[bcomp] specifies BC for component dcomp and so on.
@@ -36,8 +30,11 @@ void cns_bcfill (Box const& bx, FArrayBox& data,
                  const int scomp)
 {
     if (Gpu::inLaunchRegion()) {
+        GpuBndryFuncFab<CnsFillExtDir> gpu_bndry_func(CnsFillExtDir{});
         gpu_bndry_func(bx,data,dcomp,numcomp,geom,time,bcr,bcomp,scomp);
     } else {
+        // Without EXT_DIR (e.g., inflow), we can pass a nullptr
+        CpuBndryFuncFab cpu_bndry_func(nullptr);
         cpu_bndry_func(bx,data,dcomp,numcomp,geom,time,bcr,bcomp,scomp);
     }
 }


### PR DESCRIPTION
I don't remember why they were made static in the beginning.  I think it was because of the most vexing parse in C++ (https://en.wikipedia.org/wiki/Most_vexing_parse).  But we could get around it using `{}`.
