### PR TITLE
Some long -> amrex::Long 

### DIFF
--- a/Src/Particle/AMReX_ParticleCommunication.H
+++ b/Src/Particle/AMReX_ParticleCommunication.H
@@ -187,7 +187,7 @@ struct ParticleCopyPlan
 
 private:
     
-    void buildMPIStart (const ParticleBufferMap& map, long psize);
+    void buildMPIStart (const ParticleBufferMap& map, Long psize);
 
     //
     // Snds - a Vector with the number of bytes that is process will send to each proc.
@@ -235,10 +235,10 @@ struct GetSendBufferOffset
     {}
     
     AMREX_FORCE_INLINE AMREX_GPU_HOST_DEVICE
-    long operator() (int dst_box, int dst_lev, std::size_t psize, int i) const
+    Long operator() (int dst_box, int dst_lev, std::size_t psize, int i) const
     {
         int dst_pid = m_buck_to_pid[m_box_perm[m_lev_offsets[dst_lev]+dst_box]];
-        long dst_offset = psize*(m_box_offsets[m_box_perm[m_lev_offsets[dst_lev]+dst_box]] + i);
+        Long dst_offset = psize*(m_box_offsets[m_box_perm[m_lev_offsets[dst_lev]+dst_box]] + i);
         dst_offset += m_pad_correction[dst_pid];
         return dst_offset;
     }
@@ -412,7 +412,7 @@ void communicateParticlesStart (const PC& pc, ParticleCopyPlan& plan, const Buff
         if (plan.m_rcv_num_particles[i] > 0) {
             RcvProc.push_back(i);
             rOffset.push_back(TotRcvBytes);
-            long nbytes = plan.m_rcv_num_particles[i]*psize;
+            Long nbytes = plan.m_rcv_num_particles[i]*psize;
             std::size_t acd = ParallelDescriptor::alignof_comm_data(nbytes);
             TotRcvBytes = amrex::aligned_size(acd, TotRcvBytes);
             TotRcvBytes += amrex::aligned_size(acd, nbytes);
@@ -445,7 +445,7 @@ void communicateParticlesStart (const PC& pc, ParticleCopyPlan& plan, const Buff
     for (int i = 0; i < plan.m_nrcvs; ++i) {
         const auto Who    = RcvProc[i];
         const auto offset = rOffset[i];
-        long nbytes       = plan.m_rcv_num_particles[Who]*psize;
+        Long nbytes       = plan.m_rcv_num_particles[Who]*psize;
         std::size_t acd   = ParallelDescriptor::alignof_comm_data(nbytes);
         const auto Cnt    = amrex::aligned_size(acd, nbytes) / acd;
 
@@ -476,7 +476,7 @@ void communicateParticlesStart (const PC& pc, ParticleCopyPlan& plan, const Buff
     {
         if (i == MyProc) continue;
         const auto Who  = i;
-        long nbytes     = plan.m_snd_num_particles[i]*psize;
+        Long nbytes     = plan.m_snd_num_particles[i]*psize;
         std::size_t acd = ParallelDescriptor::alignof_comm_data(nbytes);
         const auto Cnt  = plan.m_snd_counts[i] / acd;
         if (Cnt == 0) continue;
@@ -565,7 +565,7 @@ void unpackRemotes (PC& pc, const ParticleCopyPlan& plan, Buffer& rcv_buffer, co
             
             AMREX_FOR_1D ( size, ip,
 	    {
-                long src_offset = psize*(offset + ip) + p_pad_adjust[procindex];
+                Long src_offset = psize*(offset + ip) + p_pad_adjust[procindex];
                 int dst_index = dst_offset + ip;
                 ptd.unpackParticleData(p_rcv_buffer, src_offset, dst_index,
                                        p_comm_real, p_comm_int);

--- a/Src/Particle/AMReX_ParticleCommunication.cpp
+++ b/Src/Particle/AMReX_ParticleCommunication.cpp
@@ -42,7 +42,7 @@ void ParticleCopyPlan::clear ()
     m_rcv_box_ids.clear();
 }
 
-void ParticleCopyPlan::buildMPIStart (const ParticleBufferMap& map, long psize)
+void ParticleCopyPlan::buildMPIStart (const ParticleBufferMap& map, Long psize)
 {
     BL_PROFILE("ParticleCopyPlan::buildMPIStart");
 
@@ -178,10 +178,10 @@ void ParticleCopyPlan::buildMPIStart (const ParticleBufferMap& map, long psize)
     m_snd_pad_correction_h.push_back(0);
     for (int i = 0; i < NProcs; ++i)
     {
-        long nbytes = m_snd_num_particles[i]*psize;
+        Long nbytes = m_snd_num_particles[i]*psize;
         std::size_t acd = ParallelDescriptor::alignof_comm_data(nbytes);
-        long Cnt = amrex::aligned_size(acd, nbytes);
-        long bytes_to_send = (i == MyProc) ? 0 : Cnt;
+        Long Cnt = amrex::aligned_size(acd, nbytes);
+        Long bytes_to_send = (i == MyProc) ? 0 : Cnt;
         m_snd_counts.push_back(bytes_to_send);
         m_snd_offsets.push_back(amrex::aligned_size(acd, m_snd_offsets.back()) + Cnt);
         m_snd_pad_correction_h.push_back(m_snd_pad_correction_h.back() + nbytes);
@@ -251,7 +251,7 @@ void ParticleCopyPlan::buildMPIFinish (const ParticleBufferMap& map)
         const auto offset = m_rOffset[j];
         const auto Cnt    = m_Rcvs[Who]/sizeof(int);
         
-        long nparticles = 0;
+        Long nparticles = 0;
         for (int i = offset; i < offset + Cnt; i +=4)
         {
             nparticles += m_rcv_data[i];

--- a/Src/Particle/AMReX_ParticleTile.H
+++ b/Src/Particle/AMReX_ParticleTile.H
@@ -71,7 +71,7 @@ struct ParticleTileData
     }
 
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-    void unpackParticleData (const char* buffer, long src_offset, int dst_index,
+    void unpackParticleData (const char* buffer, Long src_offset, int dst_index,
                              const int* comm_real, const int* comm_int) const noexcept
     {
         AMREX_ASSERT(dst_index < m_size);
@@ -161,7 +161,7 @@ struct ConstParticleTileData
     const int* AMREX_RESTRICT * AMREX_RESTRICT m_runtime_idata;
 
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-    void packParticleData(char* buffer, int src_index, long dst_offset,
+    void packParticleData(char* buffer, int src_index, Long dst_offset,
                           const int* comm_real, const int * comm_int) const noexcept
     {
         AMREX_ASSERT(src_index < m_size);

--- a/Src/Particle/AMReX_ParticleTransformation.H
+++ b/Src/Particle/AMReX_ParticleTransformation.H
@@ -136,7 +136,7 @@ void copyParticles (PTile& dst, const PTile& src) noexcept
  * 
  * \tparam PTile the particle tile type
  * \tparam Index the index type, e.g. unsigned int
- * \tparam N the size type, e.g. long
+ * \tparam N the size type, e.g. Long
  *
  * \param dst the destination tile
  * \param src the source tile
@@ -186,7 +186,7 @@ void transformParticles (DstTile& dst, const SrcTile& src, F&& f) noexcept
  * \tparam DstTile the dst particle tile type
  * \tparam SrcTile the src particle tile type
  * \tparam Index the index type, e.g. unsigned int
- * \tparam N the size type, e.g. long
+ * \tparam N the size type, e.g. Long
  * \tparam F a function object
  *
  * \param dst the destination tile
@@ -241,7 +241,7 @@ void transformParticles (DstTile1& dst1, DstTile2& dst2, const SrcTile& src, F&&
  * \tparam DstTile2 the dst2 particle tile type
  * \tparam SrcTile the src particle tile type
  * \tparam Index the index type, e.g. unsigned int
- * \tparam N the size type, e.g. long
+ * \tparam N the size type, e.g. Long
  * \tparam F a function object
  *
  * \param dst1 the first destination tile
@@ -500,7 +500,7 @@ auto filterAndTransformParticles (DstTile1& dst1, DstTile2& dst2, const SrcTile&
  * will be copied to the index i in dst.
  * 
  * \tparam PTile the particle tile type
- * \tparam N the size type, e.g. long
+ * \tparam N the size type, e.g. Long
  * \tparam Index the index type, e.g. unsigned int
  *
  * \param dst the destination tile
@@ -528,7 +528,7 @@ void gatherParticles (PTile& dst, const PTile& src, N np, const Index* inds)
  * will be copied to the index inds[i] in dst.
  * 
  * \tparam PTile the particle tile type
- * \tparam N the size type, e.g. long
+ * \tparam N the size type, e.g. Long
  * \tparam Index the index type, e.g. unsigned int
  *
  * \param dst the destination tile


### PR DESCRIPTION
I reverted a few of these long -> Long changes when merging my mpi_datatype branch. This uses `amrex::Long` consistently in the `Src/Particle`.  