### PR TITLE
Support for DPCPP USM prefetch and mem_advise

### DIFF
--- a/Src/Base/AMReX_BaseFab.H
+++ b/Src/Base/AMReX_BaseFab.H
@@ -1647,9 +1647,10 @@ void
 BaseFab<T>::prefetchToHost () const noexcept
 {
 #if defined(AMREX_USE_DPCPP)
-    std::size_t s = sizeof(T)*this->nvar*this->domain.numPts();
-    auto& q = Device::streamQueue();
-    q.submit([&] (sycl::handler& h) { h.prefetch(this->dptr, s); });
+    // xxxxx DPCPP todo: prefetchToHost
+    // std::size_t s = sizeof(T)*this->nvar*this->domain.numPts();
+    // auto& q = Gpu::Device::streamQueue();
+    // q.submit([&] (sycl::handler& h) { h.prefetch(this->dptr, s); });
 #elif defined(AMREX_USE_CUDA)
     std::size_t s = sizeof(T)*this->nvar*this->domain.numPts();
     AMREX_CUDA_SAFE_CALL(cudaMemPrefetchAsync(this->dptr, s,
@@ -1666,7 +1667,7 @@ BaseFab<T>::prefetchToDevice () const noexcept
 {
 #if defined(AMREX_USE_DPCPP)
     std::size_t s = sizeof(T)*this->nvar*this->domain.numPts();
-    auto& q = Device::streamQueue();
+    auto& q = Gpu::Device::streamQueue();
     q.submit([&] (sycl::handler& h) { h.prefetch(this->dptr, s); });
 #elif defined(AMREX_USE_CUDA)
     std::size_t s = sizeof(T)*this->nvar*this->domain.numPts();

--- a/Src/Base/AMReX_BaseFab.H
+++ b/Src/Base/AMReX_BaseFab.H
@@ -1647,7 +1647,9 @@ void
 BaseFab<T>::prefetchToHost () const noexcept
 {
 #if defined(AMREX_USE_DPCPP)
-    // xxxxx DPCPP todo: how to prefetchToHost
+    std::size_t s = sizeof(T)*this->nvar*this->domain.numPts();
+    auto& q = Device::streamQueue();
+    q.submit([&] (sycl::handler& h) { h.prefetch(this->dptr, s); });
 #elif defined(AMREX_USE_CUDA)
     std::size_t s = sizeof(T)*this->nvar*this->domain.numPts();
     AMREX_CUDA_SAFE_CALL(cudaMemPrefetchAsync(this->dptr, s,
@@ -1663,7 +1665,9 @@ void
 BaseFab<T>::prefetchToDevice () const noexcept
 {
 #if defined(AMREX_USE_DPCPP)
-    // xxxxx DPCPP todo: how to prefetchToDevice
+    std::size_t s = sizeof(T)*this->nvar*this->domain.numPts();
+    auto& q = Device::streamQueue();
+    q.submit([&] (sycl::handler& h) { h.prefetch(this->dptr, s); });
 #elif defined(AMREX_USE_CUDA)
     std::size_t s = sizeof(T)*this->nvar*this->domain.numPts();
     AMREX_CUDA_SAFE_CALL(cudaMemPrefetchAsync(this->dptr, s,

--- a/Src/Base/AMReX_GpuDevice.H
+++ b/Src/Base/AMReX_GpuDevice.H
@@ -28,6 +28,8 @@ using gpuDeviceProp_t = cudaDeviceProp;
         int maxGridSize[3];
         int warpSize;
         Long maxMemAllocSize; // oneAPI only
+        int managedMemory;
+        int concurrentManagedAccess;
     };
 #endif
 
@@ -76,7 +78,7 @@ public:
 #endif
 
 #if ( defined(__CUDACC__) && (__CUDACC_VER_MAJOR__ >= 10) )
-    // Generic graph selection. These should be called by users. 
+    // Generic graph selection. These should be called by users.
     static void startGraphRecording(bool first_iter, void* h_ptr, void* d_ptr, size_t sz);
     static cudaGraphExec_t stopGraphRecording(bool last_iter);
 

--- a/Src/Base/AMReX_GpuDevice.cpp
+++ b/Src/Base/AMReX_GpuDevice.cpp
@@ -745,13 +745,13 @@ Device::mem_advise_set_preferred (void* p, const std::size_t sz, const int devic
         AMREX_CUDA_SAFE_CALL(cudaMemAdvise(p, sz, cudaMemAdviseSetPreferredLocation, device));
     }
 #elif defined(AMREX_USE_DPCPP)
-    if (device_prop.managedMemory == 1 && device_prop.concurrentManagedAccess == 1)
-    {
-        auto& q = streamQueue();
-        q.mem_advise(p, sz, PI_MEM_ADVICE_SET_PREFERRED_LOCATION);
-    }
+    // xxxxx DPCPP todo: mem_advise
+    // if (device_prop.managedMemory == 1 && device_prop.concurrentManagedAccess == 1)
+    // {
+    //     auto& q = Gpu::Device::streamQueue();
+    //     q.mem_advise(p, sz, PI_MEM_ADVICE_SET_PREFERRED_LOCATION);
+    // }
 #endif
-
 }
 
 void
@@ -766,11 +766,12 @@ Device::mem_advise_set_readonly (void* p, const std::size_t sz)
         AMREX_CUDA_SAFE_CALL(cudaMemAdvise(p, sz, cudaMemAdviseSetReadMostly, cudaCpuDeviceId));
     }
 #elif defined(AMREX_USE_DPCPP)
-    if (device_prop.managedMemory == 1 && device_prop.concurrentManagedAccess == 1)
-    {
-        auto& q = streamQueue();
-        q.mem_advise(p, sz, PI_MEM_ADVICE_SET_READ_MOSTLY);
-    }
+    // xxxxx DPCPP todo: mem_advise
+    // if (device_prop.managedMemory == 1 && device_prop.concurrentManagedAccess == 1)
+    // {
+    //     auto& q = Gpu::Device::streamQueue();
+    //     q.mem_advise(p, sz, PI_MEM_ADVICE_SET_READ_MOSTLY);
+    // }
 #endif
 }
 


### PR DESCRIPTION
1. Adds support for DPCPP USM's `prefetch()`
2. Support for DPCPP USM's `mem_advise()`
3. Adding a couple of device_prop attributes to DPCPP mode to mimic CUDA's `memoryManaged` and `concurrentManagedAccess` 