### PR TITLE
For CPU, GpuArray is no longer an alias to std::array

### DIFF
--- a/Src/Base/AMReX_Array.H
+++ b/Src/Base/AMReX_Array.H
@@ -25,43 +25,37 @@ namespace amrex {
 
 }
 
-// If on GPUs, use a simple array wrapper that 
-// designates needed functions as __host__ __device__
-#ifdef AMREX_USE_GPU
-
 namespace amrex {
     template <class T, std::size_t N>
     struct GpuArray
     {
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         const T& operator [] (int i) const noexcept { return arr[i]; }
+
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         T& operator [] (int i) noexcept { return arr[i]; }
+
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         const T* data() const noexcept { return arr; };
+
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         std::size_t size() const noexcept { return N; };
+
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         const T* begin() const noexcept { return arr; };
+
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         const T* end() const noexcept { return arr + N; };
+
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         T* begin() noexcept { return arr; };
+
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         T* end() noexcept { return arr + N; };
 
         T arr[N];
     };
 }
-
-#else
-
-namespace amrex {
-    template <class T, std::size_t N>
-    using GpuArray = std::array<T,N>;
-}
-
-#endif
 
 namespace amrex {
     template <class T, int XLO, int XHI>

--- a/Tutorials/LinearSolvers/MultiComponent/MCNodalLinOp.cpp
+++ b/Tutorials/LinearSolvers/MultiComponent/MCNodalLinOp.cpp
@@ -287,7 +287,7 @@ void MCNodalLinOp::buildMasks ()
 				}
 
                                 mlndlap_fillbc_cc<int>(mfi.validbox(), fab.array(), ccdom,
-                                                       m_lobc[0], m_hibc[0]);
+                                                       LoBC(0), HiBC(0));
 			}
 		}
 
@@ -324,7 +324,7 @@ void MCNodalLinOp::buildMasks ()
 			const Box& bx = mfi.tilebox();
                         Array4<Real> const& dfab = m_bottom_dot_mask.array(mfi);
                         Array4<int const> const& sfab = omask.const_array(mfi);
-                        mlndlap_set_dot_mask(bx, dfab, sfab, nddomain, m_lobc[0], m_hibc[0]);
+                        mlndlap_set_dot_mask(bx, dfab, sfab, nddomain, LoBC(0), HiBC(0));
 		}
 	}
 }


### PR DESCRIPTION
I don't think there is any good reason to make GpuArray our own type for GPU build, but an alias to `std::array` for CPU build.  The documentation on this will be updated soon.
