### PR TITLE
make ParallelFor work for functors

### DIFF
--- a/Src/Base/AMReX_FabArrayUtility.H
+++ b/Src/Base/AMReX_FabArrayUtility.H
@@ -72,14 +72,14 @@ ReduceSum_device (FabArray<FAB> const& fa, IntVect const& nghost, F&& f)
 }
 
 template <class FAB, class F>
-amrex::EnableIf_t<amrex::HostRunnable<F>::value, typename FAB::value_type>
+amrex::EnableIf_t<!amrex::DefinitelyNotHostRunnable<F>::value, typename FAB::value_type>
 ReduceSum_host_wrapper (FabArray<FAB> const& fa, IntVect const& nghost, F&& f)
 {
     return ReduceSum_host(fa,nghost,std::move(f));
 }
 
 template <class FAB, class F>
-amrex::EnableIf_t<!amrex::HostRunnable<F>::value, typename FAB::value_type>
+amrex::EnableIf_t<amrex::DefinitelyNotHostRunnable<F>::value, typename FAB::value_type>
 ReduceSum_host_wrapper (FabArray<FAB> const& fa, IntVect const& nghost, F&& f)
 {
     amrex::Abort("ReduceSum: Launch Region is off. Device lambda cannot be called by host.");
@@ -177,7 +177,7 @@ ReduceSum_device (FabArray<FAB1> const& fa1, FabArray<FAB2> const& fa2,
 }
 
 template <class FAB1, class FAB2, class F>
-amrex::EnableIf_t<amrex::HostRunnable<F>::value, typename FAB1::value_type>
+amrex::EnableIf_t<!amrex::DefinitelyNotHostRunnable<F>::value, typename FAB1::value_type>
 ReduceSum_host_wrapper (FabArray<FAB1> const& fa1, FabArray<FAB2> const& fa2,
                         IntVect const& nghost, F&& f)
 {
@@ -185,7 +185,7 @@ ReduceSum_host_wrapper (FabArray<FAB1> const& fa1, FabArray<FAB2> const& fa2,
 }
 
 template <class FAB1, class FAB2, class F>
-amrex::EnableIf_t<!amrex::HostRunnable<F>::value, typename FAB1::value_type>
+amrex::EnableIf_t<amrex::DefinitelyNotHostRunnable<F>::value, typename FAB1::value_type>
 ReduceSum_host_wrapper (FabArray<FAB1> const& fa1, FabArray<FAB2> const& fa2,
                         IntVect const& nghost, F&& f)
 {
@@ -289,7 +289,7 @@ ReduceSum_device (FabArray<FAB1> const& fa1, FabArray<FAB2> const& fa2,
 }
 
 template <class FAB1, class FAB2, class FAB3, class F>
-amrex::EnableIf_t<amrex::HostRunnable<F>::value, typename FAB1::value_type>
+amrex::EnableIf_t<!amrex::DefinitelyNotHostRunnable<F>::value, typename FAB1::value_type>
 ReduceSum_host_wrapper (FabArray<FAB1> const& fa1, FabArray<FAB2> const& fa2,
                         FabArray<FAB3> const& fa3, IntVect const& nghost, F&& f)
 {
@@ -297,7 +297,7 @@ ReduceSum_host_wrapper (FabArray<FAB1> const& fa1, FabArray<FAB2> const& fa2,
 }
 
 template <class FAB1, class FAB2, class FAB3, class F>
-amrex::EnableIf_t<!amrex::HostRunnable<F>::value, typename FAB1::value_type>
+amrex::EnableIf_t<amrex::DefinitelyNotHostRunnable<F>::value, typename FAB1::value_type>
 ReduceSum_host_wrapper (FabArray<FAB1> const& fa1, FabArray<FAB2> const& fa2,
                         FabArray<FAB3> const& fa3, IntVect const& nghost, F&& f)
 {
@@ -395,14 +395,14 @@ ReduceMin_device (FabArray<FAB> const& fa, IntVect const& nghost, F&& f)
 }
 
 template <class FAB, class F>
-amrex::EnableIf_t<amrex::HostRunnable<F>::value, typename FAB::value_type>
+amrex::EnableIf_t<!amrex::DefinitelyNotHostRunnable<F>::value, typename FAB::value_type>
 ReduceMin_host_wrapper (FabArray<FAB> const& fa, IntVect const& nghost, F&& f)
 {
     return ReduceMin_host(fa,nghost,std::move(f));
 }
 
 template <class FAB, class F>
-amrex::EnableIf_t<!amrex::HostRunnable<F>::value, typename FAB::value_type>
+amrex::EnableIf_t<amrex::DefinitelyNotHostRunnable<F>::value, typename FAB::value_type>
 ReduceMin_host_wrapper (FabArray<FAB> const& fa, IntVect const& nghost, F&& f)
 {
     amrex::Abort("ReduceMin: Launch Region is off. Device lambda cannot be called by host.");
@@ -502,7 +502,7 @@ ReduceMin_device (FabArray<FAB1> const& fa1, FabArray<FAB2> const& fa2,
 }
 
 template <class FAB1, class FAB2, class F>
-amrex::EnableIf_t<amrex::HostRunnable<F>::value, typename FAB1::value_type>
+amrex::EnableIf_t<!amrex::DefinitelyNotHostRunnable<F>::value, typename FAB1::value_type>
 ReduceMin_host_wrapper (FabArray<FAB1> const& fa1, FabArray<FAB2> const& fa2,
                         IntVect const& nghost, F&& f)
 {
@@ -510,7 +510,7 @@ ReduceMin_host_wrapper (FabArray<FAB1> const& fa1, FabArray<FAB2> const& fa2,
 }
 
 template <class FAB1, class FAB2, class F>
-amrex::EnableIf_t<!amrex::HostRunnable<F>::value, typename FAB1::value_type>
+amrex::EnableIf_t<amrex::DefinitelyNotHostRunnable<F>::value, typename FAB1::value_type>
 ReduceMin_host_wrapper (FabArray<FAB1> const& fa1, FabArray<FAB2> const& fa2,
                         IntVect const& nghost, F&& f)
 {
@@ -616,7 +616,7 @@ ReduceMin_device (FabArray<FAB1> const& fa1, FabArray<FAB2> const& fa2,
 }
 
 template <class FAB1, class FAB2, class FAB3, class F>
-amrex::EnableIf_t<amrex::HostRunnable<F>::value, typename FAB1::value_type>
+amrex::EnableIf_t<!amrex::DefinitelyNotHostRunnable<F>::value, typename FAB1::value_type>
 ReduceMin_host_wrapper (FabArray<FAB1> const& fa1, FabArray<FAB2> const& fa2,
                         FabArray<FAB3> const& fa3, IntVect const& nghost, F&& f)
 {
@@ -624,7 +624,7 @@ ReduceMin_host_wrapper (FabArray<FAB1> const& fa1, FabArray<FAB2> const& fa2,
 }
 
 template <class FAB1, class FAB2, class FAB3, class F>
-amrex::EnableIf_t<!amrex::HostRunnable<F>::value, typename FAB1::value_type>
+amrex::EnableIf_t<amrex::DefinitelyNotHostRunnable<F>::value, typename FAB1::value_type>
 ReduceMin_host_wrapper (FabArray<FAB1> const& fa1, FabArray<FAB2> const& fa2,
                         FabArray<FAB3> const& fa3, IntVect const& nghost, F&& f)
 {
@@ -723,14 +723,14 @@ ReduceMax_device (FabArray<FAB> const& fa, IntVect const& nghost, F&& f)
 }
 
 template <class FAB, class F>
-amrex::EnableIf_t<amrex::HostRunnable<F>::value, typename FAB::value_type>
+amrex::EnableIf_t<!amrex::DefinitelyNotHostRunnable<F>::value, typename FAB::value_type>
 ReduceMax_host_wrapper (FabArray<FAB> const& fa, IntVect const& nghost, F&& f)
 {
     return ReduceMax_host(fa,nghost,std::move(f));
 }
 
 template <class FAB, class F>
-amrex::EnableIf_t<!amrex::HostRunnable<F>::value, typename FAB::value_type>
+amrex::EnableIf_t<amrex::DefinitelyNotHostRunnable<F>::value, typename FAB::value_type>
 ReduceMax_host_wrapper (FabArray<FAB> const& fa, IntVect const& nghost, F&& f)
 {
     amrex::Abort("ReduceMax: Launch Region is off. Device lambda cannot be called by host.");
@@ -830,7 +830,7 @@ ReduceMax_device (FabArray<FAB1> const& fa1, FabArray<FAB2> const& fa2,
 }
 
 template <class FAB1, class FAB2, class F>
-amrex::EnableIf_t<amrex::HostRunnable<F>::value, typename FAB1::value_type>
+amrex::EnableIf_t<!amrex::DefinitelyNotHostRunnable<F>::value, typename FAB1::value_type>
 ReduceMax_host_wrapper (FabArray<FAB1> const& fa1, FabArray<FAB2> const& fa2,
                         IntVect const& nghost, F&& f)
 {
@@ -838,7 +838,7 @@ ReduceMax_host_wrapper (FabArray<FAB1> const& fa1, FabArray<FAB2> const& fa2,
 }
 
 template <class FAB1, class FAB2, class F>
-amrex::EnableIf_t<!amrex::HostRunnable<F>::value, typename FAB1::value_type>
+amrex::EnableIf_t<amrex::DefinitelyNotHostRunnable<F>::value, typename FAB1::value_type>
 ReduceMax_host_wrapper (FabArray<FAB1> const& fa1, FabArray<FAB2> const& fa2,
                         IntVect const& nghost, F&& f)
 {
@@ -944,7 +944,7 @@ ReduceMax_device (FabArray<FAB1> const& fa1, FabArray<FAB2> const& fa2,
 }
 
 template <class FAB1, class FAB2, class FAB3, class F>
-amrex::EnableIf_t<amrex::HostRunnable<F>::value, typename FAB1::value_type>
+amrex::EnableIf_t<!amrex::DefinitelyNotHostRunnable<F>::value, typename FAB1::value_type>
 ReduceMax_host_wrapper (FabArray<FAB1> const& fa1, FabArray<FAB2> const& fa2,
                         FabArray<FAB3> const& fa3, IntVect const& nghost, F&& f)
 {
@@ -952,7 +952,7 @@ ReduceMax_host_wrapper (FabArray<FAB1> const& fa1, FabArray<FAB2> const& fa2,
 }
 
 template <class FAB1, class FAB2, class FAB3, class F>
-amrex::EnableIf_t<!amrex::HostRunnable<F>::value, typename FAB1::value_type>
+amrex::EnableIf_t<amrex::DefinitelyNotHostRunnable<F>::value, typename FAB1::value_type>
 ReduceMax_host_wrapper (FabArray<FAB1> const& fa1, FabArray<FAB2> const& fa2,
                         FabArray<FAB3> const& fa3, IntVect const& nghost, F&& f)
 {
@@ -1048,14 +1048,14 @@ ReduceLogicalAnd_device (FabArray<FAB> const& fa, IntVect const& nghost, F&& f)
 }
 
 template <class FAB, class F>
-amrex::EnableIf_t<amrex::HostRunnable<F>::value, bool>
+amrex::EnableIf_t<!amrex::DefinitelyNotHostRunnable<F>::value, bool>
 ReduceLogicalAnd_host_wrapper (FabArray<FAB> const& fa, IntVect const& nghost, F&& f)
 {
     return ReduceLogicalAnd_host(fa,nghost,std::move(f));
 }
 
 template <class FAB, class F>
-amrex::EnableIf_t<!amrex::HostRunnable<F>::value, bool>
+amrex::EnableIf_t<amrex::DefinitelyNotHostRunnable<F>::value, bool>
 ReduceLogicalAnd_host_wrapper (FabArray<FAB> const& fa, IntVect const& nghost, F&& f)
 {
     amrex::Abort("ReduceLogicalAnd: Launch Region is off. Device lambda cannot be called by host.");
@@ -1153,7 +1153,7 @@ ReduceLogicalAnd_device (FabArray<FAB1> const& fa1, FabArray<FAB2> const& fa2,
 }
 
 template <class FAB1, class FAB2, class F>
-amrex::EnableIf_t<amrex::HostRunnable<F>::value, bool>
+amrex::EnableIf_t<!amrex::DefinitelyNotHostRunnable<F>::value, bool>
 ReduceLogicalAnd_host_wrapper (FabArray<FAB1> const& fa1, FabArray<FAB2> const& fa2,
                   IntVect const& nghost, F&& f)
 {
@@ -1161,7 +1161,7 @@ ReduceLogicalAnd_host_wrapper (FabArray<FAB1> const& fa1, FabArray<FAB2> const& 
 }
 
 template <class FAB1, class FAB2, class F>
-amrex::EnableIf_t<!amrex::HostRunnable<F>::value, bool>
+amrex::EnableIf_t<amrex::DefinitelyNotHostRunnable<F>::value, bool>
 ReduceLogicalAnd_host_wrapper (FabArray<FAB1> const& fa1, FabArray<FAB2> const& fa2,
                                IntVect const& nghost, F&& f)
 {
@@ -1257,14 +1257,14 @@ ReduceLogicalOr_device (FabArray<FAB> const& fa, IntVect const& nghost, F&& f)
 }
 
 template <class FAB, class F>
-amrex::EnableIf_t<amrex::HostRunnable<F>::value, bool>
+amrex::EnableIf_t<!amrex::DefinitelyNotHostRunnable<F>::value, bool>
 ReduceLogicalOr_host_wrapper (FabArray<FAB> const& fa, IntVect const& nghost, F&& f)
 {
     return ReduceLogicalOr_host(fa,nghost,std::move(f));
 }
 
 template <class FAB, class F>
-amrex::EnableIf_t<!amrex::HostRunnable<F>::value, bool>
+amrex::EnableIf_t<amrex::DefinitelyNotHostRunnable<F>::value, bool>
 ReduceLogicalOr_host (FabArray<FAB> const& fa, IntVect const& nghost, F&& f)
 {
     amrex::Abort("ReduceLogicalOr: Launch Region is off. Device lambda cannot be called by host.");
@@ -1361,7 +1361,7 @@ ReduceLogicalOr_device (FabArray<FAB1> const& fa1, FabArray<FAB2> const& fa2,
 }
 
 template <class FAB1, class FAB2, class F>
-amrex::EnableIf_t<amrex::HostRunnable<F>::value, bool>
+amrex::EnableIf_t<!amrex::DefinitelyNotHostRunnable<F>::value, bool>
 ReduceLogicalOr_host_wrapper (FabArray<FAB1> const& fa1, FabArray<FAB2> const& fa2,
                  IntVect const& nghost, F&& f)
 {
@@ -1369,7 +1369,7 @@ ReduceLogicalOr_host_wrapper (FabArray<FAB1> const& fa1, FabArray<FAB2> const& f
 }
 
 template <class FAB1, class FAB2, class F>
-amrex::EnableIf_t<!amrex::HostRunnable<F>::value, bool>
+amrex::EnableIf_t<amrex::DefinitelyNotHostRunnable<F>::value, bool>
 ReduceLogicalOr_host_wrapper (FabArray<FAB1> const& fa1, FabArray<FAB2> const& fa2,
                               IntVect const& nghost, F&& f)
 {

--- a/Src/Base/AMReX_GpuLaunchFunctsG.H
+++ b/Src/Base/AMReX_GpuLaunchFunctsG.H
@@ -605,7 +605,7 @@ void launch (T const& n, L&& f) noexcept
 }
 
 template <typename T, typename L, typename M=amrex::EnableIf_t<std::is_integral<T>::value> >
-amrex::EnableIf_t<DeviceRunnable<L>::value>
+amrex::EnableIf_t<MaybeDeviceRunnable<L>::value>
 ParallelFor (T n, L&& f) noexcept
 {
     if (amrex::isEmpty(n)) return;
@@ -621,7 +621,7 @@ ParallelFor (T n, L&& f) noexcept
 }
 
 template <typename L>
-amrex::EnableIf_t<DeviceRunnable<L>::value>
+amrex::EnableIf_t<MaybeDeviceRunnable<L>::value>
 ParallelFor (Box const& box, L&& f) noexcept
 {
     if (amrex::isEmpty(box)) return;
@@ -646,7 +646,7 @@ ParallelFor (Box const& box, L&& f) noexcept
 }
 
 template <typename T, typename L, typename M=amrex::EnableIf_t<std::is_integral<T>::value> >
-amrex::EnableIf_t<DeviceRunnable<L>::value>
+amrex::EnableIf_t<MaybeDeviceRunnable<L>::value>
 ParallelFor (Box const& box, T ncomp, L&& f) noexcept
 {
     if (amrex::isEmpty(box)) return;
@@ -673,7 +673,7 @@ ParallelFor (Box const& box, T ncomp, L&& f) noexcept
 }
 
 template <typename L1, typename L2>
-amrex::EnableIf_t<DeviceRunnable<L1>::value and DeviceRunnable<L2>::value>
+amrex::EnableIf_t<MaybeDeviceRunnable<L1>::value and MaybeDeviceRunnable<L2>::value>
 ParallelFor (Box const& box1, Box const& box2, L1&& f1, L2&& f2) noexcept
 {
     if (amrex::isEmpty(box1) and amrex::isEmpty(box2)) return;
@@ -713,7 +713,7 @@ ParallelFor (Box const& box1, Box const& box2, L1&& f1, L2&& f2) noexcept
 }
 
 template <typename L1, typename L2, typename L3>
-amrex::EnableIf_t<DeviceRunnable<L1>::value and DeviceRunnable<L2>::value and DeviceRunnable<L3>::value>
+amrex::EnableIf_t<MaybeDeviceRunnable<L1>::value and MaybeDeviceRunnable<L2>::value and MaybeDeviceRunnable<L3>::value>
 ParallelFor (Box const& box1, Box const& box2, Box const& box3, L1&& f1, L2&& f2, L3&& f3) noexcept
 {
     if (amrex::isEmpty(box1) and amrex::isEmpty(box2) and amrex::isEmpty(box3)) return;
@@ -767,7 +767,7 @@ ParallelFor (Box const& box1, Box const& box2, Box const& box3, L1&& f1, L2&& f2
 template <typename T1, typename T2, typename L1, typename L2,
           typename M1=amrex::EnableIf_t<std::is_integral<T1>::value>,
           typename M2=amrex::EnableIf_t<std::is_integral<T2>::value> >
-amrex::EnableIf_t<DeviceRunnable<L1>::value and DeviceRunnable<L2>::value>
+amrex::EnableIf_t<MaybeDeviceRunnable<L1>::value and MaybeDeviceRunnable<L2>::value>
 ParallelFor (Box const& box1, T1 ncomp1, L1&& f1,
              Box const& box2, T2 ncomp2, L2&& f2) noexcept
 {
@@ -815,7 +815,7 @@ template <typename T1, typename T2, typename T3, typename L1, typename L2, typen
           typename M1=amrex::EnableIf_t<std::is_integral<T1>::value>,
           typename M2=amrex::EnableIf_t<std::is_integral<T2>::value>,
           typename M3=amrex::EnableIf_t<std::is_integral<T3>::value> >
-amrex::EnableIf_t<DeviceRunnable<L1>::value and DeviceRunnable<L2>::value and DeviceRunnable<L3>::value>
+amrex::EnableIf_t<MaybeDeviceRunnable<L1>::value and MaybeDeviceRunnable<L2>::value and MaybeDeviceRunnable<L3>::value>
 ParallelFor (Box const& box1, T1 ncomp1, L1&& f1,
              Box const& box2, T2 ncomp2, L2&& f2,
              Box const& box3, T3 ncomp3, L3&& f3) noexcept
@@ -875,7 +875,7 @@ ParallelFor (Box const& box1, T1 ncomp1, L1&& f1,
 }
 
 template <typename T, typename L1, typename L2>
-amrex::EnableIf_t<DeviceRunnable<L1>::value and DeviceRunnable<L2>::value>
+amrex::EnableIf_t<MaybeDeviceRunnable<L1>::value and MaybeDeviceRunnable<L2>::value>
 FabReduce (Box const& box, T const& init_val, L1&& f1, L2&& f2) noexcept
 {
     if (amrex::isEmpty(box)) return;
@@ -904,7 +904,7 @@ FabReduce (Box const& box, T const& init_val, L1&& f1, L2&& f2) noexcept
 
 template <typename N, typename T, typename L1, typename L2,
           typename M=amrex::EnableIf_t<std::is_integral<N>::value> >
-amrex::EnableIf_t<DeviceRunnable<L1>::value and DeviceRunnable<L2>::value>
+amrex::EnableIf_t<MaybeDeviceRunnable<L1>::value and MaybeDeviceRunnable<L2>::value>
 FabReduce (Box const& box, N ncomp, T const& init_val, L1&& f1, L2&& f2) noexcept
 {
     if (amrex::isEmpty(box)) return;
@@ -935,7 +935,7 @@ FabReduce (Box const& box, N ncomp, T const& init_val, L1&& f1, L2&& f2) noexcep
 
 template <typename N, typename T, typename L1, typename L2,
           typename M=amrex::EnableIf_t<std::is_integral<N>::value> >
-amrex::EnableIf_t<DeviceRunnable<L1>::value and DeviceRunnable<L2>::value>
+amrex::EnableIf_t<MaybeDeviceRunnable<L1>::value and MaybeDeviceRunnable<L2>::value>
 VecReduce (N n, T const& init_val, L1&& f1, L2&& f2) noexcept
 {
     if (amrex::isEmpty(n)) return;
@@ -1008,7 +1008,7 @@ void For (Box const& box1, T1 ncomp1, L1&& f1,
 }
 
 template <typename T, typename L, typename M=amrex::EnableIf_t<std::is_integral<T>::value> >
-amrex::EnableIf_t<HostDeviceRunnable<L>::value>
+amrex::EnableIf_t<MaybeHostDeviceRunnable<L>::value>
 HostDeviceParallelFor (T n, L&& f) noexcept
 {
     if (Gpu::inLaunchRegion()) {
@@ -1020,7 +1020,7 @@ HostDeviceParallelFor (T n, L&& f) noexcept
 }
 
 template <typename L>
-amrex::EnableIf_t<HostDeviceRunnable<L>::value>
+amrex::EnableIf_t<MaybeHostDeviceRunnable<L>::value>
 HostDeviceParallelFor (Box const& box, L&& f) noexcept
 {
     if (Gpu::inLaunchRegion()) {
@@ -1031,7 +1031,7 @@ HostDeviceParallelFor (Box const& box, L&& f) noexcept
 }
 
 template <typename T, typename L, typename M=amrex::EnableIf_t<std::is_integral<T>::value> >
-amrex::EnableIf_t<HostDeviceRunnable<L>::value>
+amrex::EnableIf_t<MaybeHostDeviceRunnable<L>::value>
 HostDeviceParallelFor (Box const& box, T ncomp, L&& f) noexcept
 {
     if (Gpu::inLaunchRegion()) {
@@ -1042,7 +1042,7 @@ HostDeviceParallelFor (Box const& box, T ncomp, L&& f) noexcept
 }
 
 template <typename L1, typename L2>
-amrex::EnableIf_t<HostDeviceRunnable<L1>::value and HostDeviceRunnable<L2>::value>
+amrex::EnableIf_t<MaybeHostDeviceRunnable<L1>::value and MaybeHostDeviceRunnable<L2>::value>
 HostDeviceParallelFor (Box const& box1, Box const& box2, L1&& f1, L2&& f2) noexcept
 {
     if (Gpu::inLaunchRegion()) {
@@ -1054,7 +1054,7 @@ HostDeviceParallelFor (Box const& box1, Box const& box2, L1&& f1, L2&& f2) noexc
 }
 
 template <typename L1, typename L2, typename L3>
-amrex::EnableIf_t<HostDeviceRunnable<L1>::value and HostDeviceRunnable<L2>::value and HostDeviceRunnable<L3>::value>
+amrex::EnableIf_t<MaybeHostDeviceRunnable<L1>::value and MaybeHostDeviceRunnable<L2>::value and MaybeHostDeviceRunnable<L3>::value>
 HostDeviceParallelFor (Box const& box1, Box const& box2, Box const& box3,
                        L1&& f1, L2&& f2, L3&& f3) noexcept
 {
@@ -1070,7 +1070,7 @@ HostDeviceParallelFor (Box const& box1, Box const& box2, Box const& box3,
 template <typename T1, typename T2, typename L1, typename L2,
           typename M1=amrex::EnableIf_t<std::is_integral<T1>::value>,
           typename M2=amrex::EnableIf_t<std::is_integral<T2>::value> >
-amrex::EnableIf_t<HostDeviceRunnable<L1>::value and HostDeviceRunnable<L2>::value>
+amrex::EnableIf_t<MaybeHostDeviceRunnable<L1>::value and MaybeHostDeviceRunnable<L2>::value>
 HostDeviceParallelFor (Box const& box1, T1 ncomp1, L1&& f1,
                        Box const& box2, T2 ncomp2, L2&& f2) noexcept
 {
@@ -1086,7 +1086,7 @@ template <typename T1, typename T2, typename T3, typename L1, typename L2, typen
           typename M1=amrex::EnableIf_t<std::is_integral<T1>::value>,
           typename M2=amrex::EnableIf_t<std::is_integral<T2>::value>,
           typename M3=amrex::EnableIf_t<std::is_integral<T3>::value> >
-amrex::EnableIf_t<HostDeviceRunnable<L1>::value and HostDeviceRunnable<L2>::value and HostDeviceRunnable<L3>::value>
+amrex::EnableIf_t<MaybeHostDeviceRunnable<L1>::value and MaybeHostDeviceRunnable<L2>::value and MaybeHostDeviceRunnable<L3>::value>
 HostDeviceParallelFor (Box const& box1, T1 ncomp1, L1&& f1,
                        Box const& box2, T2 ncomp2, L2&& f2,
                        Box const& box3, T3 ncomp3, L3&& f3) noexcept

--- a/Src/Base/AMReX_TypeTraits.H
+++ b/Src/Base/AMReX_TypeTraits.H
@@ -79,49 +79,30 @@ namespace amrex
 
 #ifdef AMREX_USE_GPU
 
+    template <class T, class Enable = void>
+    struct MaybeDeviceRunnable : std::true_type {};
+
+    template <class T, class Enable = void>
+    struct MaybeHostDeviceRunnable : std::true_type {};
+
+    template <class T, class Enable = void>
+    struct DefinitelyNotHostRunnable : std::false_type {};
+
 #if defined(AMREX_USE_CUDA)
 
-    template <class T, class Enable = void>
-    struct HostRunnable : std::true_type {};
-    //
     template <class T>
-    struct HostRunnable<T, amrex::EnableIf_t<__nv_is_extended_device_lambda_closure_type(T)> >
+    struct MaybeHostDeviceRunnable<T, amrex::EnableIf_t<__nv_is_extended_device_lambda_closure_type(T)> >
         : std::false_type {};
 
-    template <class T, class Enable = void>
-    struct DeviceRunnable : std::false_type {};
-    //
     template <class T>
-    struct DeviceRunnable<T, amrex::EnableIf_t<__nv_is_extended_host_device_lambda_closure_type(T)
-                                            or __nv_is_extended_device_lambda_closure_type(T)> >
+    struct DefinitelyNotHostRunnable<T, amrex::EnableIf_t<__nv_is_extended_device_lambda_closure_type(T)> >
         : std::true_type {};
 
 #elif defined(AMREX_USE_HIP)
 
     // xxxxx HIP todo
-    template <class T, class Enable = void>
-    struct HostRunnable : std::true_type {};
-
-    template <class T, class Enable = void>
-    struct DeviceRunnable : std::true_type {};
-
-#elif defined(AMREX_USE_DPCPP)
-
-    template <class T, class Enable = void>
-    struct HostRunnable : std::true_type {};
-
-    template <class T, class Enable = void>
-    struct DeviceRunnable : std::true_type {};
 
 #endif
-
-    template <class T, class Enable = void>
-    struct HostDeviceRunnable : std::false_type {};
-    //
-    template <class T>
-    struct HostDeviceRunnable<T, amrex::EnableIf_t<HostRunnable<T>::value
-                                                   and DeviceRunnable<T>::value> >
-        : std::true_type {};
 
 #endif
 


### PR DESCRIPTION
Unfortunately #790 broke WarpX because it passes functors to `ParallelFor`.  If we want to support both lambda and functor, the only thing we can be sure is CUDA extended device lambda does not run on host.
