### PR TITLE
Catch the case that the message size is too big.

### DIFF
--- a/Src/Base/AMReX_FabArrayBase.cpp
+++ b/Src/Base/AMReX_FabArrayBase.cpp
@@ -1699,6 +1699,8 @@ FabArrayBase::CheckRcvStats(Vector<MPI_Status>& recv_stats,
                               ParallelDescriptor::Mpi_typemap<ParallelDescriptor::lull_t>::type(),
                               &tmp_count);
                 count = sizeof(ParallelDescriptor::lull_t) * tmp_count;
+            } else {
+                amrex::Abort("TODO: message size is too big");
             }
 
 	    if (count != recv_size[i]) {


### PR DESCRIPTION
We are doing this elsewhere, but not in this instance. 

This is a compiler warning, at least with clang + DEBUG. 