### PR TITLE
Do not explicitly reset the device on finalize

### DIFF
--- a/Src/Base/AMReX_GpuDevice.cpp
+++ b/Src/Base/AMReX_GpuDevice.cpp
@@ -367,9 +367,6 @@ Device::Finalize ()
 #ifdef AMREX_USE_ACC
     amrex_finalize_acc();
 #endif
-
-    AMREX_HIP_OR_CUDA( AMREX_HIP_SAFE_CALL( hipDeviceReset());,
-                      AMREX_CUDA_SAFE_CALL(cudaDeviceReset()); ); 
 }
 
 void


### PR DESCRIPTION
This causes an error message at the end of the run when using cuda aware mpi on Summit.