### PR TITLE
For cuda > 10, use cudaLaunchHostFunc instead of cudaStreamAddCallback, which has been marked as deprecated

### DIFF
--- a/Src/Base/AMReX_GpuAsyncArray.H
+++ b/Src/Base/AMReX_GpuAsyncArray.H
@@ -18,7 +18,11 @@
 extern "C" {
 AMREX_HIP_OR_CUDA(
          void HIPRT_CB  amrex_asyncarray_delete ( hipStream_t stream,  hipError_t error, void* p);,
+#if ( defined(__CUDACC__) && (__CUDACC_VER_MAJOR__ >= 10) )
+         void CUDART_CB amrex_asyncarray_delete (void* p);)
+#else
          void CUDART_CB amrex_asyncarray_delete (cudaStream_t stream, cudaError_t error, void* p);)
+#endif
 }
 #endif
 
@@ -77,8 +81,13 @@ public:
                 AMREX_HIP_OR_CUDA(
                     AMREX_HIP_SAFE_CALL ( hipStreamAddCallback(Gpu::gpuStream(),
                                                                amrex_asyncarray_delete, p, 0));,
+#if ( defined(__CUDACC__) && (__CUDACC_VER_MAJOR__ >= 10) )
+                    AMREX_CUDA_SAFE_CALL(cudaLaunchHostFunc(Gpu::gpuStream(),
+                                                            amrex_asyncarray_delete, p)););
+#else                    
                     AMREX_CUDA_SAFE_CALL(cudaStreamAddCallback(Gpu::gpuStream(),
                                                                amrex_asyncarray_delete, p, 0)););
+#endif
                 Gpu::callbackAdded();
 #else
                 // xxxxx DPCPP todo

--- a/Src/Base/AMReX_GpuAsyncArray.cpp
+++ b/Src/Base/AMReX_GpuAsyncArray.cpp
@@ -11,7 +11,11 @@
 extern "C" {
 AMREX_HIP_OR_CUDA(
          void HIPRT_CB  amrex_asyncarray_delete ( hipStream_t stream,  hipError_t error, void* p),
+#if ( defined(__CUDACC__) && (__CUDACC_VER_MAJOR__ >= 10) )
+         void CUDART_CB amrex_asyncarray_delete (void* p))
+#else
          void CUDART_CB amrex_asyncarray_delete (cudaStream_t stream, cudaError_t error, void* p))
+#endif
     {
         void** pp = (void**)p;
         void* dp = pp[0];

--- a/Src/Base/AMReX_GpuElixir.cpp
+++ b/Src/Base/AMReX_GpuElixir.cpp
@@ -20,7 +20,11 @@ namespace {
 extern "C" {
 AMREX_HIP_OR_CUDA(
          void HIPRT_CB  amrex_elixir_delete ( hipStream_t stream,  hipError_t error, void* p),
+#if ( defined(__CUDACC__) && (__CUDACC_VER_MAJOR__ >= 10) )         
+         void CUDART_CB amrex_elixir_delete (void* p))
+#else
          void CUDART_CB amrex_elixir_delete (cudaStream_t stream, cudaError_t error, void* p))
+#endif
     {
         void** pp = (void**)p;
         void* d = pp[0];
@@ -48,8 +52,13 @@ Elixir::clear () noexcept
             AMREX_HIP_OR_CUDA(
                 AMREX_HIP_SAFE_CALL ( hipStreamAddCallback(Gpu::gpuStream(),
                                                            amrex_elixir_delete, p, 0));,
+#if ( defined(__CUDACC__) && (__CUDACC_VER_MAJOR__ >= 10) )
+                AMREX_CUDA_SAFE_CALL(cudaLaunchHostFunc(Gpu::gpuStream(),
+                                                        amrex_elixir_delete, p)););
+#else
                 AMREX_CUDA_SAFE_CALL(cudaStreamAddCallback(Gpu::gpuStream(),
                                                            amrex_elixir_delete, p, 0)););
+#endif
             Gpu::callbackAdded();
 #elif defined(AMREX_USE_DPCPP)
             // xxxxx DPCPP todo


### PR DESCRIPTION
There is a chance this will fix the problems @jordanm304 and @rporcu observed on Joule, but I think we should do it anyway since the stream callback way is deprecated. 