### PR TITLE
CMake: link against OpenMP_Fortran only when Fortran is enabled

### DIFF
--- a/Tools/CMake/AMReX_Config.cmake
+++ b/Tools/CMake/AMReX_Config.cmake
@@ -55,21 +55,25 @@ function (configure_amrex)
    # Setup OpenMP
    #
    if (ENABLE_OMP)
-      find_package(OpenMP REQUIRED CXX Fortran)
 
-      target_link_libraries(amrex
-         PUBLIC
-         OpenMP::OpenMP_CXX
-         OpenMP::OpenMP_Fortran)
+      find_package(OpenMP REQUIRED)
+      target_link_libraries(amrex PUBLIC OpenMP::OpenMP_CXX)
 
-      set_target_properties(
-         OpenMP::OpenMP_CXX OpenMP::OpenMP_Fortran
-         PROPERTIES
-         IMPORTED_GLOBAL True )
+      # Make imported target "global" so that it can be seen
+      # from other directories in the project.
+      # This is especially useful when get_target_properties_flattened()
+      # (see module AMReXTargetHelpers.cmake) is called to recover dependecy tree info
+      # in projects that use amrex directly in the build (via add_subdirectory()).
+      set_target_properties(OpenMP::OpenMP_CXX PROPERTIES IMPORTED_GLOBAL True )
+
+      if (CMAKE_Fortran_COMPILER_LOADED)
+         target_link_libraries(amrex PUBLIC OpenMP::OpenMP_Fortran )
+         set_target_properties(OpenMP::OpenMP_Fortran PROPERTIES IMPORTED_GLOBAL True )
+      endforeach ()
 
       # We have to manually pass OpenMP flags to host compiler if CUDA is enabled
       # Since OpenMP imported targets are generated only for the Compiler ID in use, i.e.
-      # they do not provide flags for all possible compiler ids, we assume the same compiler used
+      # they do not provide flags for all possible compiler ids, we assume the same compiler use
       # for building amrex will be used to build the application code
       if (ENABLE_CUDA)
          get_target_property(_cxx_omp_flags OpenMP::OpenMP_CXX INTERFACE_COMPILE_OPTIONS)

--- a/Tools/CMake/AMReX_Config.cmake
+++ b/Tools/CMake/AMReX_Config.cmake
@@ -69,7 +69,7 @@ function (configure_amrex)
       if (CMAKE_Fortran_COMPILER_LOADED)
          target_link_libraries(amrex PUBLIC OpenMP::OpenMP_Fortran )
          set_target_properties(OpenMP::OpenMP_Fortran PROPERTIES IMPORTED_GLOBAL True )
-      endforeach ()
+      endif ()
 
       # We have to manually pass OpenMP flags to host compiler if CUDA is enabled
       # Since OpenMP imported targets are generated only for the Compiler ID in use, i.e.


### PR DESCRIPTION
This should solve a bug reported in issue #751 .