### PR TITLE
Particle locator fix

### DIFF
--- a/Src/Particle/AMReX_ParticleCommunication.H
+++ b/Src/Particle/AMReX_ParticleCommunication.H
@@ -63,9 +63,10 @@ struct ParticleCopyOp
     void resize (const int gid, const int lev, const int size);
 
     int numCopies (const int gid, const int lev) const 
-    { 
+    {
         if (m_boxes.size() <= lev) return 0;
-        return m_boxes[lev].at(gid).size(); 
+        auto mit = m_boxes[lev].find(gid);
+        return mit == m_boxes[lev].end() ? 0 : mit->second.size();
     }
 };
     

--- a/Src/Particle/AMReX_ParticleLocator.H
+++ b/Src/Particle/AMReX_ParticleLocator.H
@@ -260,7 +260,8 @@ public:
 
     bool isValid (const Vector<BoxArray>& a_ba) const
     {
-        if ( (m_locators.size() == 0) or !m_defined) return false;
+        if ( !m_defined or (m_locators.size() == 0) or
+             (m_locators.size() != a_ba.size()) ) return false;
         bool all_valid = true;
         int num_levels = m_locators.size();
         for (int lev = 0; lev < num_levels; ++lev)


### PR DESCRIPTION
1. The logic for rebuilding the particle locator needed to fixed for sub-cycling.
2. Also when calling Redistribute with lev_min != 0, some map entries in the ParticleBufferMap won't be there. The numCopies function should return 0 in those cases. 