### PR TITLE
DPCPP Makefile: Fix CC Typo

### DIFF
--- a/Tools/GNUMake/comps/dpcpp.mak
+++ b/Tools/GNUMake/comps/dpcpp.mak
@@ -2,7 +2,7 @@
 # Generic setup for using gcc
 #
 CXX = dpcpp
-CC  = fpcpp
+CC  = dpcpp
 FC  = none
 F90 = none
 


### PR DESCRIPTION
Typo: treat C as C++ code for now. We can also use a shipped `clang` instead with DPC++ installs.