### PR TITLE
CMake: add helper function setup_target_for_cuda_compilation()

### DIFF
--- a/Src/CMakeLists.txt
+++ b/Src/CMakeLists.txt
@@ -170,7 +170,7 @@ set_target_properties( amrex PROPERTIES PUBLIC_HEADER "${AMREX_PUBLIC_HEADERS}")
 # If ENABLE_CUDA, C++ files will be compiled as CUDA sources
 #
 if (ENABLE_CUDA)
-   set_cpp_sources_to_cuda_language( amrex )
+   setup_target_for_cuda_compilation( amrex )
 endif ()
 
 

--- a/Tools/CMake/AMReXTargetHelpers.cmake
+++ b/Tools/CMake/AMReXTargetHelpers.cmake
@@ -114,6 +114,8 @@ endfunction ()
 # is compatible with amrex CUDA build.
 #
 function (setup_target_for_cuda_compilation _target)
+   # separable compilation:
+   #   mainly due to amrex::Random which uses global device variables
    set_target_properties( ${_target}
       PROPERTIES
       CUDA_SEPARABLE_COMPILATION ON      # This adds -dc

--- a/Tools/CMake/AMReXTargetHelpers.cmake
+++ b/Tools/CMake/AMReXTargetHelpers.cmake
@@ -119,7 +119,6 @@ function (setup_target_for_cuda_compilation _target)
    set_target_properties( ${_target}
       PROPERTIES
       CUDA_SEPARABLE_COMPILATION ON      # This adds -dc
-      CUDA_RESOLVE_DEVICE_SYMBOLS OFF
       )
    set_cpp_sources_to_cuda_language(${_target})
 endfunction ()

--- a/Tools/CMake/AMReXTargetHelpers.cmake
+++ b/Tools/CMake/AMReXTargetHelpers.cmake
@@ -107,3 +107,17 @@ function (set_cpp_sources_to_cuda_language _target)
    list(FILTER _sources INCLUDE REGEX "\\.cpp")
    set_source_files_properties(${_sources} PROPERTIES LANGUAGE CUDA )
 endfunction ()
+
+#
+# Setup an amrex-dependent target for cuda compilation.
+# This function ensures that the CUDA compilation of _target
+# is compatible with amrex CUDA build.
+#
+function (setup_target_for_cuda_compilation _target)
+   set_target_properties( ${_target}
+      PROPERTIES
+      CUDA_SEPARABLE_COMPILATION ON      # This adds -dc
+      CUDA_RESOLVE_DEVICE_SYMBOLS OFF
+      )
+   set_cpp_sources_to_cuda_language(${_target})
+endfunction ()

--- a/Tools/CMake/AMReX_Config.cmake
+++ b/Tools/CMake/AMReX_Config.cmake
@@ -104,12 +104,6 @@ function (configure_amrex)
          AMREX_NVCC_MAJOR_VERSION=${NVCC_VERSION_MAJOR}
          AMREX_NVCC_MINOR_VERSION=${NVCC_VERSION_MINOR} )
 
-      set_target_properties( amrex
-         PROPERTIES
-         CUDA_SEPARABLE_COMPILATION ON      # This adds -dc
-         CUDA_RESOLVE_DEVICE_SYMBOLS OFF
-         )
-
       #
       # Retrieve compile flags for the current configuration
       # I haven't find a way to set host compiler flags for all the


### PR DESCRIPTION
This function ensures that the CUDA compilation of a dependent
target is consistent with amrex CUDA build.