### PR TITLE
add inline namespace literals and use in CNS and Heat Equation tutorials

### DIFF
--- a/Src/Base/AMReX_REAL.H
+++ b/Src/Base/AMReX_REAL.H
@@ -68,6 +68,8 @@ namespace amrex {
     using Real = amrex_real;
     using ParticleReal = amrex_particle_real;
 
+inline namespace literals {
+
     /** @{
       C++ user literals ``_rt`` &  ``_prt`` for short-hand notations
 
@@ -101,6 +103,7 @@ namespace amrex {
         return ParticleReal( x );
     }
     /// @}
+} // namespace literals
 } // namespace amrex
 #endif
 

--- a/Tutorials/Basic/HeatEquation_EX1_C/Source/main.cpp
+++ b/Tutorials/Basic/HeatEquation_EX1_C/Source/main.cpp
@@ -62,8 +62,8 @@ void main_main ()
         ba.maxSize(max_grid_size);
 
        // This defines the physical box, [-1,1] in each direction.
-        RealBox real_box({AMREX_D_DECL(-1.0,-1.0,-1.0)},
-                         {AMREX_D_DECL( 1.0, 1.0, 1.0)});
+        RealBox real_box({AMREX_D_DECL(-1.0_rt,-1.0_rt,-1.0_rt)},
+                         {AMREX_D_DECL( 1.0_rt, 1.0_rt, 1.0_rt)});
 
         // periodic in all direction
         Array<int,AMREX_SPACEDIM> is_periodic{AMREX_D_DECL(1,1,1)};
@@ -90,10 +90,10 @@ void main_main ()
     init_phi(phi_new, geom);
     // ========================================
 
-    Real dt = 0.9*dx[0]*dx[0] / (2.0*AMREX_SPACEDIM);
+    Real dt = 0.9_rt*dx[0]*dx[0] / (2.0_rt*AMREX_SPACEDIM);
 
     // time = starting time in the simulation
-    Real time = 0.0;
+    Real time = 0.0_rt;
 
     // Write a plotfile of the initial data if plot_int > 0 (plot_int was defined in the inputs file)
     if (plot_int > 0)

--- a/Tutorials/Basic/HeatEquation_EX1_C/Source/myfunc.H
+++ b/Tutorials/Basic/HeatEquation_EX1_C/Source/myfunc.H
@@ -4,8 +4,6 @@
 #include <AMReX_Geometry.H>
 #include <AMReX_MultiFab.H>
 
-using namespace amrex;
-
 void main_main ();
 
 void advance (amrex::MultiFab& phi_old,

--- a/Tutorials/Basic/HeatEquation_EX1_C/Source/myfunc.cpp
+++ b/Tutorials/Basic/HeatEquation_EX1_C/Source/myfunc.cpp
@@ -2,6 +2,8 @@
 #include "myfunc.H"
 #include "mykernel.H"
 
+using namespace amrex;
+
 void advance (MultiFab& phi_old,
               MultiFab& phi_new,
 	      Array<MultiFab, AMREX_SPACEDIM>& flux,

--- a/Tutorials/Basic/HeatEquation_EX1_C/Source/mykernel.H
+++ b/Tutorials/Basic/HeatEquation_EX1_C/Source/mykernel.H
@@ -6,18 +6,20 @@
 AMREX_GPU_DEVICE AMREX_FORCE_INLINE
 void init_phi (int i, int j, int k,
                amrex::Array4<amrex::Real> const& phi,
-               GpuArray<amrex::Real,AMREX_SPACEDIM> const& dx,
-               GpuArray<amrex::Real,AMREX_SPACEDIM> const& prob_lo)
+               amrex::GpuArray<amrex::Real,AMREX_SPACEDIM> const& dx,
+               amrex::GpuArray<amrex::Real,AMREX_SPACEDIM> const& prob_lo)
 {
-    amrex::Real x = prob_lo[0] + (i+0.5) * dx[0];
-    amrex::Real y = prob_lo[1] + (j+0.5) * dx[1];
+    using namespace amrex::literals;
+
+    amrex::Real x = prob_lo[0] + (i+0.5_rt) * dx[0];
+    amrex::Real y = prob_lo[1] + (j+0.5_rt) * dx[1];
 #if (AMREX_SPACEDIM > 2)
-    amrex::Real z = prob_lo[2] + (k+0.5) * dx[2];
+    amrex::Real z = prob_lo[2] + (k+0.5_rt) * dx[2];
 #else
-    amrex::Real z = 0.;
+    amrex::Real z = 0._rt;
 #endif
-    amrex::Real r2 = ((x-0.25)*(x-0.25)+(y-0.25)*(y-0.25)+(z-0.25)*(z-0.25))/0.01;
-    phi(i,j,k) = 1. + std::exp(-r2);
+    amrex::Real r2 = ((x-0.25_rt)*(x-0.25_rt)+(y-0.25_rt)*(y-0.25_rt)+(z-0.25_rt)*(z-0.25_rt))/0.01_rt;
+    phi(i,j,k) = 1._rt + std::exp(-r2);
 }
 
 

--- a/Tutorials/GPU/CNS/Exec/RT/cns_prob.H
+++ b/Tutorials/GPU/CNS/Exec/RT/cns_prob.H
@@ -13,20 +13,22 @@ void
 cns_initdata (int i, int j, int k, amrex::Array4<amrex::Real> const& state,
               amrex::GeometryData const& geomdata, Parm const& parm, ProbParm const& prob_parm)
 {
+    using namespace amrex::literals;
+
     const amrex::Real* prob_lo = geomdata.ProbLo();
     const amrex::Real* prob_hi = geomdata.ProbHi();
     const amrex::Real* dx      = geomdata.CellSize();
 
-    constexpr amrex::Real pi = 3.14159265358979323846264338327950288;
-    const amrex::Real splitx = 0.5*(prob_lo[0]+prob_hi[0]);
-    const amrex::Real splity = 0.5*(prob_lo[1]+prob_hi[1]);
-    const amrex::Real splitz = 0.5*(prob_lo[2]+prob_hi[2]);
+    constexpr amrex::Real pi = 3.14159265358979323846264338327950288_rt;
+    const amrex::Real splitx = 0.5_rt*(prob_lo[0]+prob_hi[0]);
+    const amrex::Real splity = 0.5_rt*(prob_lo[1]+prob_hi[1]);
+    const amrex::Real splitz = 0.5_rt*(prob_lo[2]+prob_hi[2]);
     const amrex::Real L_x = prob_hi[0] - prob_lo[0];
     const amrex::Real presmid = prob_parm.p0_base - prob_parm.rho_1*splitz;
 
-    const amrex::Real z = prob_lo[2] + (k+0.5)*dx[2];
-    const amrex::Real y = prob_lo[1] + (j+0.5)*dx[1];
-    const amrex::Real x = prob_lo[0] + (i+0.5)*dx[0];
+    const amrex::Real z = prob_lo[2] + (k+0.5_rt)*dx[2];
+    const amrex::Real y = prob_lo[1] + (j+0.5_rt)*dx[1];
+    const amrex::Real x = prob_lo[0] + (i+0.5_rt)*dx[0];
 
     amrex::Real Pt;
     if (z < splitz) {
@@ -34,19 +36,19 @@ cns_initdata (int i, int j, int k, amrex::Array4<amrex::Real> const& state,
     } else {
         Pt = presmid - prob_parm.rho_2*(z-splitz);
     }
-    const amrex::Real rhoet = Pt/(parm.eos_gamma-1.0);
+    const amrex::Real rhoet = Pt/(parm.eos_gamma-1.0_rt);
 
-    const Real r2d = amrex::min(std::hypot((x-splitx),(y-splity)), 0.5*L_x);
-    const Real pertheight = 0.5 - 0.01*std::cos(2.0*pi*r2d/L_x);
-    const Real rhot = prob_parm.rho_1 + ((prob_parm.rho_2-prob_parm.rho_1)/2.0)*(1.0+std::tanh((z-pertheight)/0.005));
+    const Real r2d = amrex::min(std::hypot((x-splitx),(y-splity)), 0.5_rt*L_x);
+    const Real pertheight = 0.5_rt - 0.01_rt*std::cos(2.0_rt*pi*r2d/L_x);
+    const Real rhot = prob_parm.rho_1 + ((prob_parm.rho_2-prob_parm.rho_1)/2.0_rt)*(1.0_rt+std::tanh((z-pertheight)/0.005_rt));
 
     state(i,j,k,URHO ) = rhot;
-    state(i,j,k,UMX  ) = 0.0;
-    state(i,j,k,UMY  ) = 0.0;
-    state(i,j,k,UMZ  ) = 0.0;
+    state(i,j,k,UMX  ) = 0.0_rt;
+    state(i,j,k,UMY  ) = 0.0_rt;
+    state(i,j,k,UMZ  ) = 0.0_rt;
     state(i,j,k,UEINT) = rhoet;
     state(i,j,k,UEDEN) = rhoet;
-    state(i,j,k,UTEMP) = 0.0;
+    state(i,j,k,UTEMP) = 0.0_rt;
 }
 
 #endif

--- a/Tutorials/GPU/CNS/Exec/RT/cns_prob_parm.H
+++ b/Tutorials/GPU/CNS/Exec/RT/cns_prob_parm.H
@@ -4,12 +4,14 @@
 #include <AMReX_REAL.H>
 #include <AMReX_GpuMemory.H>
 
+using namespace amrex::literals;
+
 struct ProbParm
     : amrex::Gpu::Managed
 {
-    amrex::Real rho_1 = 0.5;
-    amrex::Real rho_2 = 2.0;
-    amrex::Real p0_base = 5.0;
+    amrex::Real rho_1 = 0.5_rt;
+    amrex::Real rho_2 = 2.0_rt;
+    amrex::Real p0_base = 5.0_rt;
 };
 
 #endif

--- a/Tutorials/GPU/CNS/Exec/Sod/cns_prob.H
+++ b/Tutorials/GPU/CNS/Exec/Sod/cns_prob.H
@@ -13,12 +13,14 @@ void
 cns_initdata (int i, int j, int k, amrex::Array4<amrex::Real> const& state,
               amrex::GeometryData const& geomdata, Parm const& parm, ProbParm const& prob_parm)
 {
+    using namespace amrex::literals;
+
     const amrex::Real* prob_lo = geomdata.ProbLo();
     const amrex::Real* dx      = geomdata.CellSize();
 
-    amrex::Real x = prob_lo[0] + (i+0.5)*dx[0];
+    amrex::Real x = prob_lo[0] + (i+0.5_rt)*dx[0];
     amrex::Real Pt, rhot, uxt;
-    if (x < 0.5) {
+    if (x < 0.5_rt) {
         Pt = prob_parm.p_l;
         rhot = prob_parm.rho_l;
         uxt = prob_parm.u_l;
@@ -29,12 +31,12 @@ cns_initdata (int i, int j, int k, amrex::Array4<amrex::Real> const& state,
     }
     state(i,j,k,URHO ) = rhot;
     state(i,j,k,UMX  ) = rhot*uxt;
-    state(i,j,k,UMY  ) = 0.0;
-    state(i,j,k,UMZ  ) = 0.0;
-    amrex::Real et = Pt/(parm.eos_gamma-1.0);
+    state(i,j,k,UMY  ) = 0.0_rt;
+    state(i,j,k,UMZ  ) = 0.0_rt;
+    amrex::Real et = Pt/(parm.eos_gamma-1.0_rt);
     state(i,j,k,UEINT) = et;
-    state(i,j,k,UEDEN) = et + 0.5*rhot*uxt*uxt;
-    state(i,j,k,UTEMP) = 0.0;
+    state(i,j,k,UEDEN) = et + 0.5_rt*rhot*uxt*uxt;
+    state(i,j,k,UTEMP) = 0.0_rt;
 }
 
 #endif

--- a/Tutorials/GPU/CNS/Exec/Sod/cns_prob_parm.H
+++ b/Tutorials/GPU/CNS/Exec/Sod/cns_prob_parm.H
@@ -4,15 +4,17 @@
 #include <AMReX_REAL.H>
 #include <AMReX_GpuMemory.H>
 
+using namespace amrex::literals;
+
 struct ProbParm
     : amrex::Gpu::Managed
 {
-    amrex::Real p_l = 1.0;
-    amrex::Real p_r = 0.1;
-    amrex::Real rho_l = 1.0;
-    amrex::Real rho_r = 0.125;
-    amrex::Real u_l = 0.0;
-    amrex::Real u_r = 0.0;
+    amrex::Real p_l = 1.0_rt;
+    amrex::Real p_r = 0.1_rt;
+    amrex::Real rho_l = 1.0_rt;
+    amrex::Real rho_r = 0.125_rt;
+    amrex::Real u_l = 0.0_rt;
+    amrex::Real u_r = 0.0_rt;
 };
 
 #endif

--- a/Tutorials/GPU/CNS/Source/CNS.cpp
+++ b/Tutorials/GPU/CNS/Source/CNS.cpp
@@ -17,12 +17,12 @@ BCRec     CNS::phys_bc;
 
 int       CNS::verbose = 0;
 IntVect   CNS::hydro_tile_size {AMREX_D_DECL(1024,16,16)};
-Real      CNS::cfl       = 0.3;
+Real      CNS::cfl       = 0.3_rt;
 int       CNS::do_reflux = 1;
 int       CNS::refine_max_dengrad_lev   = -1;
-Real      CNS::refine_dengrad           = 1.0e10;
+Real      CNS::refine_dengrad           = 1.0e10_rt;
 
-Real      CNS::gravity = 0.0;
+Real      CNS::gravity = 0.0_rt;
 
 CNS::CNS ()
 {}
@@ -127,9 +127,9 @@ CNS::computeInitialDt (int                    finest_level,
     //
     // Limit dt's by the value of stop_time.
     //
-    const Real eps = 0.001*dt_0;
+    const Real eps = 0.001_rt*dt_0;
     Real cur_time  = state[State_Type].curTime();
-    if (stop_time >= 0.0) {
+    if (stop_time >= 0.0_rt) {
         if ((cur_time + dt_0) > (stop_time - eps))
             dt_0 = stop_time - cur_time;
     }
@@ -201,9 +201,9 @@ CNS::computeNewDt (int                    finest_level,
     //
     // Limit dt's by the value of stop_time.
     //
-    const Real eps = 0.001*dt_0;
+    const Real eps = 0.001_rt*dt_0;
     Real cur_time  = state[State_Type].curTime();
-    if (stop_time >= 0.0) {
+    if (stop_time >= 0.0_rt) {
         if ((cur_time + dt_0) > (stop_time - eps)) {
             dt_0 = stop_time - cur_time;
         }
@@ -230,7 +230,7 @@ CNS::post_timestep (int iteration)
     if (do_reflux && level < parent->finestLevel()) {
         MultiFab& S = get_new_data(State_Type);
         CNS& fine_level = getLevel(level+1);
-        fine_level.flux_reg->Reflux(S, 1.0, 0, 0, NUM_STATE, geom);
+        fine_level.flux_reg->Reflux(S, 1.0_rt, 0, 0, NUM_STATE, geom);
     }
 
     if (level < parent->finestLevel()) {
@@ -383,7 +383,7 @@ CNS::buildMetrics ()
 {
     // make sure dx == dy == dz
     const Real* dx = geom.CellSize();
-    if (std::abs(dx[0]-dx[1]) > 1.e-12*dx[0] || std::abs(dx[0]-dx[2]) > 1.e-12*dx[0]) {
+    if (std::abs(dx[0]-dx[1]) > 1.e-12_rt*dx[0] || std::abs(dx[0]-dx[2]) > 1.e-12_rt*dx[0]) {
         amrex::Abort("CNS: must have dx == dy == dz\n");
     }
 }

--- a/Tutorials/GPU/CNS/Source/CNS_K.H
+++ b/Tutorials/GPU/CNS/Source/CNS_K.H
@@ -16,12 +16,14 @@ cns_estdt (amrex::Box const& bx, amrex::Array4<Real const> const& state,
            amrex::GpuArray<amrex::Real,AMREX_SPACEDIM> const& dx,
            Parm const& parm) noexcept
 {
+    using namespace amrex::literals;
+
     const auto lo = amrex::lbound(bx);
     const auto hi = amrex::ubound(bx);
 #if !defined(__CUDACC__) || (__CUDACC_VER_MAJOR__ != 9) || (__CUDACC_VER_MINOR__ != 2)
     amrex::Real dt = std::numeric_limits<amrex::Real>::max();
 #else
-    amrex::Real dt = 1.e37;
+    amrex::Real dt = 1.e37_rt;
 #endif
 
     for         (int k = lo.z; k <= hi.z; ++k) {
@@ -32,11 +34,11 @@ cns_estdt (amrex::Box const& bx, amrex::Array4<Real const> const& state,
                 amrex::Real my  = state(i,j,k,UMY);
                 amrex::Real mz  = state(i,j,k,UMY);
                 amrex::Real ei  = state(i,j,k,UEINT);
-                amrex::Real rhoinv = 1.0/amrex::max(rho,parm.smallr);
+                amrex::Real rhoinv = 1.0_rt/amrex::max(rho,parm.smallr);
                 amrex::Real vx = mx*rhoinv;
                 amrex::Real vy = my*rhoinv;
                 amrex::Real vz = mz*rhoinv;
-                amrex::Real p = amrex::max((parm.eos_gamma-1.0)*ei, parm.smallp);
+                amrex::Real p = amrex::max((parm.eos_gamma-1.0_rt)*ei, parm.smallp);
                 amrex::Real cs = std::sqrt(parm.eos_gamma*p*rhoinv);
                 amrex::Real dtx = dx[0]/(amrex::Math::abs(vx)+cs);
                 amrex::Real dty = dx[1]/(amrex::Math::abs(vy)+cs);
@@ -56,12 +58,14 @@ void
 cns_compute_temperature (int i, int j, int k, amrex::Array4<amrex::Real> const& u,
                          Parm const& parm) noexcept
 {
-    amrex::Real rhoinv = 1.0/u(i,j,k,URHO);
+    using namespace amrex::literals;
+
+    amrex::Real rhoinv = 1.0_rt/u(i,j,k,URHO);
     amrex::Real mx = u(i,j,k,UMX);
     amrex::Real my = u(i,j,k,UMY);
     amrex::Real mz = u(i,j,k,UMZ);
-    u(i,j,k,UEINT) = u(i,j,k,UEDEN) - 0.5 * rhoinv * (mx*mx+my*my+mz*mz);
-    u(i,j,k,UTEMP) = rhoinv * u(i,j,k,UEINT) * (1.0/parm.cv);
+    u(i,j,k,UEINT) = u(i,j,k,UEDEN) - 0.5_rt * rhoinv * (mx*mx+my*my+mz*mz);
+    u(i,j,k,UTEMP) = rhoinv * u(i,j,k,UEINT) * (1.0_rt/parm.cv);
 }
 
 #endif

--- a/Tutorials/GPU/CNS/Source/CNS_advance.cpp
+++ b/Tutorials/GPU/CNS/Source/CNS_advance.cpp
@@ -32,24 +32,24 @@ CNS::advance (Real time, Real dt, int iteration, int ncycle)
     }
 
     if (fr_as_crse) {
-        fr_as_crse->setVal(0.0);
+        fr_as_crse->setVal(0.0_rt);
     }
 
     // RK2 stage 1
     FillPatch(*this, Sborder, NUM_GROW, time, State_Type, 0, NUM_STATE);
-    compute_dSdt(Sborder, dSdt, 0.5*dt, fr_as_crse, fr_as_fine);
+    compute_dSdt(Sborder, dSdt, 0.5_rt*dt, fr_as_crse, fr_as_fine);
     // U^* = U^n + dt*dUdt^n
-    MultiFab::LinComb(S_new, 1.0, Sborder, 0, dt, dSdt, 0, 0, NUM_STATE, 0);
+    MultiFab::LinComb(S_new, 1.0_rt, Sborder, 0, dt, dSdt, 0, 0, NUM_STATE, 0);
     computeTemp(S_new,0);
 
     // RK2 stage 2
     // After fillpatch Sborder = U^n+dt*dUdt^n
     FillPatch(*this, Sborder, NUM_GROW, time+dt, State_Type, 0, NUM_STATE);
-    compute_dSdt(Sborder, dSdt, 0.5*dt, fr_as_crse, fr_as_fine);
+    compute_dSdt(Sborder, dSdt, 0.5_rt*dt, fr_as_crse, fr_as_fine);
     // S_new = 0.5*(Sborder+S_old) = U^n + 0.5*dt*dUdt^n
-    MultiFab::LinComb(S_new, 0.5, Sborder, 0, 0.5, S_old, 0, 0, NUM_STATE, 0);
+    MultiFab::LinComb(S_new, 0.5_rt, Sborder, 0, 0.5_rt, S_old, 0, 0, NUM_STATE, 0);
     // S_new += 0.5*dt*dSdt
-    MultiFab::Saxpy(S_new, 0.5*dt, dSdt, 0, 0, NUM_STATE, 0);
+    MultiFab::Saxpy(S_new, 0.5_rt*dt, dSdt, 0, 0, NUM_STATE, 0);
     // We now have S_new = U^{n+1} = (U^n+0.5*dt*dUdt^n) + 0.5*dt*dUdt^*
     computeTemp(S_new,0);
     
@@ -117,7 +117,7 @@ CNS::compute_dSdt (const MultiFab& S, MultiFab& dSdt, Real dt,
         [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
             cns_riemann_x(i, j, k, fxfab, slope, q, *lparm);
-            for (int n = neqns; n < ncons; ++n) fxfab(i,j,k,n) = 0.0;
+            for (int n = neqns; n < ncons; ++n) fxfab(i,j,k,n) = 0.0_rt;
         });
 
         // y-direction
@@ -133,7 +133,7 @@ CNS::compute_dSdt (const MultiFab& S, MultiFab& dSdt, Real dt,
         [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
             cns_riemann_y(i, j, k, fyfab, slope, q, *lparm);
-            for (int n = neqns; n < ncons; ++n) fyfab(i,j,k,n) = 0.0;
+            for (int n = neqns; n < ncons; ++n) fyfab(i,j,k,n) = 0.0_rt;
         });
 
         // z-direction
@@ -149,7 +149,7 @@ CNS::compute_dSdt (const MultiFab& S, MultiFab& dSdt, Real dt,
         [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
             cns_riemann_z(i, j, k, fzfab, slope, q, *lparm);
-            for (int n = neqns; n < ncons; ++n) fzfab(i,j,k,n) = 0.0;
+            for (int n = neqns; n < ncons; ++n) fzfab(i,j,k,n) = 0.0_rt;
         });
 
         // don't have to do this, but we could
@@ -162,7 +162,7 @@ CNS::compute_dSdt (const MultiFab& S, MultiFab& dSdt, Real dt,
             cns_flux_to_dudt(i, j, k, n, dsdtfab, AMREX_D_DECL(fxfab,fyfab,fzfab), dxinv);
         });
 
-        if (gravity != 0.0) {
+        if (gravity != 0.0_rt) {
             const Real g = gravity;
             const int irho = Density;
             const int imz = Zmom;

--- a/Tutorials/GPU/CNS/Source/CNS_parm.H
+++ b/Tutorials/GPU/CNS/Source/CNS_parm.H
@@ -4,21 +4,23 @@
 #include <AMReX_REAL.H>
 #include <AMReX_GpuMemory.H>
 
+using namespace amrex::literals;
+
 struct Parm
     : public amrex::Gpu::Managed
 {
-    amrex::Real eos_gamma = 1.4;
-    amrex::Real eos_mu = 28.97;  // mean molecular weight
+    amrex::Real eos_gamma = 1.4_rt;
+    amrex::Real eos_mu = 28.97_rt;  // mean molecular weight
 
     amrex::Real cv;
     amrex::Real cp;
 
-    amrex::Real Pr  = 0.72;     // Prandtl number
-    amrex::Real C_S = 1.458e-5; // constant in Sutherland's law
-    amrex::Real T_S = 110.4;    // Sutherland temperature
+    amrex::Real Pr  = 0.72_rt;     // Prandtl number
+    amrex::Real C_S = 1.458e-5_rt; // constant in Sutherland's law
+    amrex::Real T_S = 110.4_rt;    // Sutherland temperature
 
-    amrex::Real smallr = 1.e-19;
-    amrex::Real smallp = 1.e-10;
+    amrex::Real smallr = 1.e-19_rt;
+    amrex::Real smallp = 1.e-10_rt;
 
     void Initialize ();
 };

--- a/Tutorials/GPU/CNS/Source/CNS_parm.cpp
+++ b/Tutorials/GPU/CNS/Source/CNS_parm.cpp
@@ -3,7 +3,7 @@
 
 void Parm::Initialize ()
 {
-    constexpr amrex::Real Ru = 8.31451e7;
-    cv = Ru / (eos_mu * (eos_gamma-1.0));
-    cp = eos_gamma * Ru / (eos_mu * (eos_gamma-1.0));
+    constexpr amrex::Real Ru = 8.31451e7_rt;
+    cv = Ru / (eos_mu * (eos_gamma-1.0_rt));
+    cp = eos_gamma * Ru / (eos_mu * (eos_gamma-1.0_rt));
 }

--- a/Tutorials/GPU/CNS/Source/hydro/CNS_hydro_K.H
+++ b/Tutorials/GPU/CNS/Source/hydro/CNS_hydro_K.H
@@ -14,15 +14,17 @@ cns_ctoprim (int i, int j, int k,
              amrex::Array4<amrex::Real> const& q,
              Parm const& parm) noexcept
 {
+    using namespace amrex::literals;
+
     amrex::Real rho = amrex::max(u(i,j,k,URHO),parm.smallr);
-    amrex::Real rhoinv = 1.0/rho;
+    amrex::Real rhoinv = 1.0_rt/rho;
     amrex::Real ux = u(i,j,k,UMX)*rhoinv;
     amrex::Real uy = u(i,j,k,UMY)*rhoinv;
     amrex::Real uz = u(i,j,k,UMZ)*rhoinv;
-    amrex::Real kineng = 0.5*rho*(ux*ux+uy*uy+uz*uz);
+    amrex::Real kineng = 0.5_rt*rho*(ux*ux+uy*uy+uz*uz);
     amrex::Real ei = u(i,j,k,UEDEN) - kineng;
-    if (ei <= 0.0) ei = u(i,j,k,UEINT);
-    amrex::Real p = amrex::max((parm.eos_gamma-1.0)*ei,parm.smallp);
+    if (ei <= 0.0_rt) ei = u(i,j,k,UEINT);
+    amrex::Real p = amrex::max((parm.eos_gamma-1.0_rt)*ei,parm.smallp);
     ei *= rhoinv;
 
     q(i,j,k,QRHO) = rho;
@@ -32,7 +34,7 @@ cns_ctoprim (int i, int j, int k,
     q(i,j,k,QEINT) = ei;
     q(i,j,k,QPRES) = p;
     q(i,j,k,QCS) = std::sqrt(parm.eos_gamma*p*rhoinv);
-    q(i,j,k,QTEMP) = 0.0;
+    q(i,j,k,QTEMP) = 0.0_rt;
 }
 
 AMREX_GPU_DEVICE
@@ -55,10 +57,12 @@ namespace {
 AMREX_GPU_DEVICE AMREX_FORCE_INLINE
 amrex::Real limiter (amrex::Real dlft, amrex::Real drgt) noexcept
 {
-    amrex::Real dcen = 0.5*(dlft+drgt);
-    amrex::Real dsgn = amrex::Math::copysign(1.0, dcen);
-    amrex::Real slop = 2.0 * amrex::min(amrex::Math::abs(dlft),amrex::Math::abs(drgt));
-    amrex::Real dlim = (dlft*drgt >= 0.0) ? slop : 0.0;
+    using namespace amrex::literals;
+
+    amrex::Real dcen = 0.5_rt*(dlft+drgt);
+    amrex::Real dsgn = amrex::Math::copysign(1.0_rt, dcen);
+    amrex::Real slop = 2.0_rt * amrex::min(amrex::Math::abs(dlft),amrex::Math::abs(drgt));
+    amrex::Real dlim = (dlft*drgt >= 0.0_rt) ? slop : 0.0_rt;
     return dsgn * amrex::min(dlim,amrex::Math::abs(dcen));
 }
 
@@ -71,8 +75,10 @@ cns_slope_x (int i, int j, int k,
              amrex::Array4<amrex::Real> const& dq,
              amrex::Array4<amrex::Real const> const& q) noexcept
 {
-    amrex::Real dlft = 0.5*(q(i,j,k,QPRES)-q(i-1,j,k,QPRES))/q(i,j,k,QCS) - 0.5*q(i,j,k,QRHO)*(q(i,j,k,QU) - q(i-1,j,k,QU));
-    amrex::Real drgt = 0.5*(q(i+1,j,k,QPRES)-q(i,j,k,QPRES))/q(i,j,k,QCS) - 0.5*q(i,j,k,QRHO)*(q(i+1,j,k,QU) - q(i,j,k,QU));
+    using namespace amrex::literals;
+
+    amrex::Real dlft = 0.5_rt*(q(i,j,k,QPRES)-q(i-1,j,k,QPRES))/q(i,j,k,QCS) - 0.5_rt*q(i,j,k,QRHO)*(q(i,j,k,QU) - q(i-1,j,k,QU));
+    amrex::Real drgt = 0.5_rt*(q(i+1,j,k,QPRES)-q(i,j,k,QPRES))/q(i,j,k,QCS) - 0.5_rt*q(i,j,k,QRHO)*(q(i+1,j,k,QU) - q(i,j,k,QU));
     amrex::Real d0 = limiter(dlft, drgt);
 
     amrex::Real cs2 = q(i,j,k,QCS)*q(i,j,k,QCS);
@@ -80,8 +86,8 @@ cns_slope_x (int i, int j, int k,
     drgt = (q(i+1,j,k,QRHO)-q(i,j,k,QRHO)) - (q(i+1,j,k,QPRES) - q(i,j,k,QPRES))/cs2;
     amrex::Real d1 = limiter(dlft, drgt);
 
-    dlft = 0.5*(q(i,j,k,QPRES)-q(i-1,j,k,QPRES))/q(i,j,k,QCS) + 0.5*q(i,j,k,QRHO)*(q(i,j,k,QU) - q(i-1,j,k,QU));
-    drgt = 0.5*(q(i+1,j,k,QPRES)-q(i,j,k,QPRES))/q(i,j,k,QCS) + 0.5*q(i,j,k,QRHO)*(q(i+1,j,k,QU) - q(i,j,k,QU));
+    dlft = 0.5_rt*(q(i,j,k,QPRES)-q(i-1,j,k,QPRES))/q(i,j,k,QCS) + 0.5_rt*q(i,j,k,QRHO)*(q(i,j,k,QU) - q(i-1,j,k,QU));
+    drgt = 0.5_rt*(q(i+1,j,k,QPRES)-q(i,j,k,QPRES))/q(i,j,k,QCS) + 0.5_rt*q(i,j,k,QRHO)*(q(i+1,j,k,QU) - q(i,j,k,QU));
     amrex::Real d2 = limiter(dlft, drgt);
 
     dlft = q(i,j,k,QV) - q(i-1,j,k,QV);
@@ -106,8 +112,10 @@ cns_slope_y (int i, int j, int k,
              amrex::Array4<amrex::Real> const& dq,
              amrex::Array4<amrex::Real const> const& q) noexcept
 {
-    amrex::Real dlft = 0.5*(q(i,j,k,QPRES)-q(i,j-1,k,QPRES))/q(i,j,k,QCS) - 0.5*q(i,j,k,QRHO)*(q(i,j,k,QV) - q(i,j-1,k,QV));
-    amrex::Real drgt = 0.5*(q(i,j+1,k,QPRES)-q(i,j,k,QPRES))/q(i,j,k,QCS) - 0.5*q(i,j,k,QRHO)*(q(i,j+1,k,QV) - q(i,j,k,QV));
+    using namespace amrex::literals;
+
+    amrex::Real dlft = 0.5_rt*(q(i,j,k,QPRES)-q(i,j-1,k,QPRES))/q(i,j,k,QCS) - 0.5_rt*q(i,j,k,QRHO)*(q(i,j,k,QV) - q(i,j-1,k,QV));
+    amrex::Real drgt = 0.5_rt*(q(i,j+1,k,QPRES)-q(i,j,k,QPRES))/q(i,j,k,QCS) - 0.5_rt*q(i,j,k,QRHO)*(q(i,j+1,k,QV) - q(i,j,k,QV));
     amrex::Real d0 = limiter(dlft, drgt);
 
     amrex::Real cs2 = q(i,j,k,QCS)*q(i,j,k,QCS);
@@ -115,8 +123,8 @@ cns_slope_y (int i, int j, int k,
     drgt = (q(i,j+1,k,QRHO)-q(i,j,k,QRHO)) - (q(i,j+1,k,QPRES) - q(i,j,k,QPRES))/cs2;
     amrex::Real d1 = limiter(dlft, drgt);
 
-    dlft = 0.5*(q(i,j,k,QPRES)-q(i,j-1,k,QPRES))/q(i,j,k,QCS) + 0.5*q(i,j,k,QRHO)*(q(i,j,k,QV) - q(i,j-1,k,QV));
-    drgt = 0.5*(q(i,j+1,k,QPRES)-q(i,j,k,QPRES))/q(i,j,k,QCS) + 0.5*q(i,j,k,QRHO)*(q(i,j+1,k,QV) - q(i,j,k,QV));
+    dlft = 0.5_rt*(q(i,j,k,QPRES)-q(i,j-1,k,QPRES))/q(i,j,k,QCS) + 0.5_rt*q(i,j,k,QRHO)*(q(i,j,k,QV) - q(i,j-1,k,QV));
+    drgt = 0.5_rt*(q(i,j+1,k,QPRES)-q(i,j,k,QPRES))/q(i,j,k,QCS) + 0.5_rt*q(i,j,k,QRHO)*(q(i,j+1,k,QV) - q(i,j,k,QV));
     amrex::Real d2 = limiter(dlft, drgt);
 
     dlft = q(i,j,k,QU) - q(i,j-1,k,QU);
@@ -141,8 +149,10 @@ cns_slope_z (int i, int j, int k,
              amrex::Array4<amrex::Real> const& dq,
              amrex::Array4<amrex::Real const> const& q) noexcept
 {
-    amrex::Real dlft = 0.5*(q(i,j,k,QPRES)-q(i,j,k-1,QPRES))/q(i,j,k,QCS) - 0.5*q(i,j,k,QRHO)*(q(i,j,k,QW) - q(i,j,k-1,QW));
-    amrex::Real drgt = 0.5*(q(i,j,k+1,QPRES)-q(i,j,k,QPRES))/q(i,j,k,QCS) - 0.5*q(i,j,k,QRHO)*(q(i,j,k+1,QW) - q(i,j,k,QW));
+    using namespace amrex::literals;
+
+    amrex::Real dlft = 0.5_rt*(q(i,j,k,QPRES)-q(i,j,k-1,QPRES))/q(i,j,k,QCS) - 0.5_rt*q(i,j,k,QRHO)*(q(i,j,k,QW) - q(i,j,k-1,QW));
+    amrex::Real drgt = 0.5_rt*(q(i,j,k+1,QPRES)-q(i,j,k,QPRES))/q(i,j,k,QCS) - 0.5_rt*q(i,j,k,QRHO)*(q(i,j,k+1,QW) - q(i,j,k,QW));
     amrex::Real d0 = limiter(dlft, drgt);
 
     amrex::Real cs2 = q(i,j,k,QCS)*q(i,j,k,QCS);
@@ -150,8 +160,8 @@ cns_slope_z (int i, int j, int k,
     drgt = (q(i,j,k+1,QRHO)-q(i,j,k,QRHO)) - (q(i,j,k+1,QPRES) - q(i,j,k,QPRES))/cs2;
     amrex::Real d1 = limiter(dlft, drgt);
 
-    dlft = 0.5*(q(i,j,k,QPRES)-q(i,j,k-1,QPRES))/q(i,j,k,QCS) + 0.5*q(i,j,k,QRHO)*(q(i,j,k,QW) - q(i,j,k-1,QW));
-    drgt = 0.5*(q(i,j,k+1,QPRES)-q(i,j,k,QPRES))/q(i,j,k,QCS) + 0.5*q(i,j,k,QRHO)*(q(i,j,k+1,QW) - q(i,j,k,QW));
+    dlft = 0.5_rt*(q(i,j,k,QPRES)-q(i,j,k-1,QPRES))/q(i,j,k,QCS) + 0.5_rt*q(i,j,k,QRHO)*(q(i,j,k,QW) - q(i,j,k-1,QW));
+    drgt = 0.5_rt*(q(i,j,k+1,QPRES)-q(i,j,k,QPRES))/q(i,j,k,QCS) + 0.5_rt*q(i,j,k,QRHO)*(q(i,j,k+1,QW) - q(i,j,k,QW));
     amrex::Real d2 = limiter(dlft, drgt);
 
     dlft = q(i,j,k,QU) - q(i,j,k-1,QU);
@@ -182,8 +192,10 @@ riemann (const amrex::Real gamma, const amrex::Real smallp, const amrex::Real sm
          amrex::Real& flxrho, amrex::Real& flxu, amrex::Real& flxut,
          amrex::Real& flxutt, amrex::Real& flxe) noexcept
 {
-    constexpr amrex::Real weakwv = 1.e-3;
-    constexpr amrex::Real small = 1.e-6;
+    using namespace amrex::literals;
+
+    constexpr amrex::Real weakwv = 1.e-3_rt;
+    constexpr amrex::Real small = 1.e-6_rt;
 
     amrex::Real clsql = gamma*pl*rl;
     amrex::Real clsqr = gamma*pr*rr;
@@ -197,8 +209,8 @@ riemann (const amrex::Real gamma, const amrex::Real smallp, const amrex::Real sm
     pstar = amrex::max(pstar,smallp);
     amrex::Real pstnm1 = pstar;
 
-    amrex::Real wlsq = (.5*(gamma-1.)*(pstar+pl)+pstar)*rl;
-    amrex::Real wrsq = (.5*(gamma-1.)*(pstar+pr)+pstar)*rr;
+    amrex::Real wlsq = (.5_rt*(gamma-1._rt)*(pstar+pl)+pstar)*rl;
+    amrex::Real wrsq = (.5_rt*(gamma-1._rt)*(pstar+pr)+pstar)*rr;
 
     wl = std::sqrt(wlsq);
     wr = std::sqrt(wrsq);
@@ -211,11 +223,11 @@ riemann (const amrex::Real gamma, const amrex::Real smallp, const amrex::Real sm
     amrex::Real ustar;
     for (int iter = 0; iter < 3; ++iter)
     {
-        wlsq = (.5*(gamma-1.)*(pstar+pl)+pstar)*rl;
-        wrsq = (.5*(gamma-1.)*(pstar+pr)+pstar)*rr;
+        wlsq = (.5_rt*(gamma-1._rt)*(pstar+pl)+pstar)*rl;
+        wrsq = (.5_rt*(gamma-1._rt)*(pstar+pr)+pstar)*rr;
 
-        wl = 1./std::sqrt(wlsq);
-        wr = 1./std::sqrt(wrsq);
+        wl = 1._rt/std::sqrt(wlsq);
+        wr = 1._rt/std::sqrt(wrsq);
 
         amrex::Real ustnm1 = ustarm;
         amrex::Real ustnp1 = ustarp;
@@ -225,11 +237,11 @@ riemann (const amrex::Real gamma, const amrex::Real smallp, const amrex::Real sm
 
         amrex::Real dpditer = amrex::Math::abs(pstnm1-pstar);
         amrex::Real zp = amrex::Math::abs(ustarp-ustnp1);
-        if (zp-weakwv*cleft < 0.0 ) {
+        if (zp-weakwv*cleft < 0.0_rt ) {
             zp = dpditer*wl;
         }
         amrex::Real zm = amrex::Math::abs(ustarm-ustnm1);
-        if (zm-weakwv*cright < 0.0 ) {
+        if (zm-weakwv*cright < 0.0_rt ) {
             zm = dpditer*wr;
         }
 
@@ -238,37 +250,37 @@ riemann (const amrex::Real gamma, const amrex::Real smallp, const amrex::Real sm
         pstnm1 = pstar;
         pstar = pstar - denom*(ustarm-ustarp);
         pstar = amrex::max(pstar,smallp);
-        ustar = 0.5*(ustarm+ustarp);
+        ustar = 0.5_rt*(ustarm+ustarp);
     }
 
     amrex::Real ro, uo, po, sgnm, utrans1, utrans2;
-    if (ustar > 0.) {
+    if (ustar > 0._rt) {
         ro = rl;
         uo = ul;
         po = pl;
-        sgnm = 1.;
+        sgnm = 1._rt;
         utrans1 = ut1l;
         utrans2 = ut2l;
-    } else if (ustar < 0.) {
+    } else if (ustar < 0._rt) {
         ro = rr;
         uo = ur;
         po = pr;
-        sgnm = -1.;
+        sgnm = -1._rt;
         utrans1 = ut1r;
         utrans2 = ut2r;
     } else {
-        uo = 0.5*(ur+ul);
-        po = 0.5*(pr+pl);
-        ro = 2.*(rl*rr)/(rl+rr);
-        sgnm = 1.;
-        utrans1 = 0.5*(ut1l+ut1r);
-        utrans2 = 0.5*(ut2l+ut2r);
+        uo = 0.5_rt*(ur+ul);
+        po = 0.5_rt*(pr+pl);
+        ro = 2._rt*(rl*rr)/(rl+rr);
+        sgnm = 1._rt;
+        utrans1 = 0.5_rt*(ut1l+ut1r);
+        utrans2 = 0.5_rt*(ut2l+ut2r);
     }
-    amrex::Real wosq = (.5*(gamma-1.)*(pstar+po)+pstar)*ro;
+    amrex::Real wosq = (.5_rt*(gamma-1._rt)*(pstar+po)+pstar)*ro;
     amrex::Real co = std::sqrt(gamma * po / ro);
     amrex::Real wo = std::sqrt(wosq);
     amrex::Real dpjmp = pstar-po;
-    amrex::Real rstar = ro/(1.-ro*dpjmp/wosq);
+    amrex::Real rstar = ro/(1._rt-ro*dpjmp/wosq);
     amrex::Real cstar = std::sqrt(gamma * pstar / rstar);
     amrex::Real spout = co-sgnm*uo;
     amrex::Real spin = cstar - sgnm*uo;
@@ -277,28 +289,28 @@ riemann (const amrex::Real gamma, const amrex::Real smallp, const amrex::Real sm
         spout = spin;
     }
     amrex::Real ss = amrex::max(spout-spin, spout+spin);
-    amrex::Real frac = 0.5*(1.+(spin+spout)/amrex::max(ss,ccsmall));
+    amrex::Real frac = 0.5_rt*(1._rt+(spin+spout)/amrex::max(ss,ccsmall));
 
     amrex::Real rgdnv, ugdnv, pgdnv;
-    if (spout < 0.) {
+    if (spout < 0._rt) {
         rgdnv = ro;
         ugdnv = uo;
         pgdnv = po;
-    } else if(spin >= 0.) {
+    } else if(spin >= 0._rt) {
         rgdnv = rstar;
         ugdnv = ustar;
         pgdnv = pstar;
     } else {
-        rgdnv = frac*rstar + (1. - frac)* ro;
-        ugdnv = frac*ustar + (1. - frac)* uo;
-        pgdnv = frac*pstar + (1. - frac)* po;
+        rgdnv = frac*rstar + (1._rt - frac)* ro;
+        ugdnv = frac*ustar + (1._rt - frac)* uo;
+        pgdnv = frac*pstar + (1._rt - frac)* po;
     }
     
     flxrho = rgdnv*ugdnv;
     flxu = rgdnv*ugdnv*ugdnv+pgdnv;
     flxut = rgdnv*ugdnv*utrans1;
     flxutt = rgdnv*ugdnv*utrans2;
-    flxe = ugdnv*(0.5*rgdnv*(ugdnv*ugdnv+utrans1*utrans1+utrans2*utrans2) + pgdnv/(gamma -1.) + pgdnv);
+    flxe = ugdnv*(0.5_rt*rgdnv*(ugdnv*ugdnv+utrans1*utrans1+utrans2*utrans2) + pgdnv/(gamma -1._rt) + pgdnv);
 }
 }
 
@@ -311,23 +323,25 @@ cns_riemann_x (int i, int j, int k,
                amrex::Array4<amrex::Real const> const& q,
                Parm const& parm) noexcept
 {
+    using namespace amrex::literals;
+
     amrex::Real cspeed = q(i-1,j,k,QCS);
-    amrex::Real rl = q(i-1,j,k,QRHO) + 0.5 * ( (dq(i-1,j,k,0)+dq(i-1,j,k,2))/cspeed + dq(i-1,j,k,1));
+    amrex::Real rl = q(i-1,j,k,QRHO) + 0.5_rt * ( (dq(i-1,j,k,0)+dq(i-1,j,k,2))/cspeed + dq(i-1,j,k,1));
     rl = amrex::max(rl, parm.smallr);
-    amrex::Real ul = q(i-1,j,k,QU) + 0.5 * ( (dq(i-1,j,k,2)-dq(i-1,j,k,0))/q(i-1,j,k,QRHO));
-    amrex::Real pl = q(i-1,j,k,QPRES) + 0.5 *  (dq(i-1,j,k,0)+dq(i-1,j,k,2))*cspeed;
+    amrex::Real ul = q(i-1,j,k,QU) + 0.5_rt * ( (dq(i-1,j,k,2)-dq(i-1,j,k,0))/q(i-1,j,k,QRHO));
+    amrex::Real pl = q(i-1,j,k,QPRES) + 0.5_rt *  (dq(i-1,j,k,0)+dq(i-1,j,k,2))*cspeed;
     pl = amrex::max(pl, parm.smallp);
-    amrex::Real ut1l = q(i-1,j,k,QV) + 0.5 * dq(i-1,j,k,3);
-    amrex::Real ut2l = q(i-1,j,k,QW) + 0.5 * dq(i-1,j,k,4);
+    amrex::Real ut1l = q(i-1,j,k,QV) + 0.5_rt * dq(i-1,j,k,3);
+    amrex::Real ut2l = q(i-1,j,k,QW) + 0.5_rt * dq(i-1,j,k,4);
 
     cspeed = q(i,j,k,QCS);
-    amrex::Real rr = q(i,j,k,QRHO) - 0.5 * ( (dq(i,j,k,0)+dq(i,j,k,2))/cspeed + dq(i,j,k,1));
+    amrex::Real rr = q(i,j,k,QRHO) - 0.5_rt * ( (dq(i,j,k,0)+dq(i,j,k,2))/cspeed + dq(i,j,k,1));
     rr = amrex::max(rr, parm.smallr);
-    amrex::Real ur = q(i,j,k,QU) - 0.5 * ( (dq(i,j,k,2)-dq(i,j,k,0))/q(i,j,k,QRHO));
-    amrex::Real pr = q(i,j,k,QPRES) - 0.5 * (dq(i,j,k,0)+dq(i,j,k,2))*cspeed;
+    amrex::Real ur = q(i,j,k,QU) - 0.5_rt * ( (dq(i,j,k,2)-dq(i,j,k,0))/q(i,j,k,QRHO));
+    amrex::Real pr = q(i,j,k,QPRES) - 0.5_rt * (dq(i,j,k,0)+dq(i,j,k,2))*cspeed;
     pr = amrex::max(pr, parm.smallp);
-    amrex::Real ut1r = q(i,j,k,QV) - 0.5 * dq(i,j,k,3);
-    amrex::Real ut2r = q(i,j,k,QW) - 0.5 * dq(i,j,k,4);
+    amrex::Real ut1r = q(i,j,k,QV) - 0.5_rt * dq(i,j,k,3);
+    amrex::Real ut2r = q(i,j,k,QW) - 0.5_rt * dq(i,j,k,4);
 
     riemann(parm.eos_gamma, parm.smallp, parm.smallr,
             rl, ul, pl, ut1l, ut2l, rr, ur, pr, ut1r, ut2r,
@@ -343,23 +357,25 @@ cns_riemann_y (int i, int j, int k,
                amrex::Array4<amrex::Real const> const& q,
                Parm const& parm) noexcept
 {
+    using namespace amrex::literals;
+
     amrex::Real cspeed = q(i,j-1,k,QCS);
-    amrex::Real rl = q(i,j-1,k,QRHO) + 0.5 * ( (dq(i,j-1,k,0)+dq(i,j-1,k,2))/cspeed + dq(i,j-1,k,1));
+    amrex::Real rl = q(i,j-1,k,QRHO) + 0.5_rt * ( (dq(i,j-1,k,0)+dq(i,j-1,k,2))/cspeed + dq(i,j-1,k,1));
     rl = amrex::max(rl, parm.smallr);
-    amrex::Real ul = q(i,j-1,k,QV) + 0.5 * ( (dq(i,j-1,k,2)-dq(i,j-1,k,0))/q(i,j-1,k,QRHO));
-    amrex::Real pl = q(i,j-1,k,QPRES) + 0.5 *  (dq(i,j-1,k,0)+dq(i,j-1,k,2))*cspeed;
+    amrex::Real ul = q(i,j-1,k,QV) + 0.5_rt * ( (dq(i,j-1,k,2)-dq(i,j-1,k,0))/q(i,j-1,k,QRHO));
+    amrex::Real pl = q(i,j-1,k,QPRES) + 0.5_rt *  (dq(i,j-1,k,0)+dq(i,j-1,k,2))*cspeed;
     pl = amrex::max(pl, parm.smallp);
-    amrex::Real ut1l = q(i,j-1,k,QU) + 0.5 * dq(i,j-1,k,3);
-    amrex::Real ut2l = q(i,j-1,k,QW) + 0.5 * dq(i,j-1,k,4);
+    amrex::Real ut1l = q(i,j-1,k,QU) + 0.5_rt * dq(i,j-1,k,3);
+    amrex::Real ut2l = q(i,j-1,k,QW) + 0.5_rt * dq(i,j-1,k,4);
 
     cspeed = q(i,j,k,QCS);
-    amrex::Real rr = q(i,j,k,QRHO) - 0.5 * ( (dq(i,j,k,0)+dq(i,j,k,2))/cspeed + dq(i,j,k,1));
+    amrex::Real rr = q(i,j,k,QRHO) - 0.5_rt * ( (dq(i,j,k,0)+dq(i,j,k,2))/cspeed + dq(i,j,k,1));
     rr = amrex::max(rr, parm.smallr);
-    amrex::Real ur = q(i,j,k,QV) - 0.5 * ( (dq(i,j,k,2)-dq(i,j,k,0))/q(i,j,k,QRHO));
-    amrex::Real pr = q(i,j,k,QPRES) - 0.5 * (dq(i,j,k,0)+dq(i,j,k,2))*cspeed;
+    amrex::Real ur = q(i,j,k,QV) - 0.5_rt * ( (dq(i,j,k,2)-dq(i,j,k,0))/q(i,j,k,QRHO));
+    amrex::Real pr = q(i,j,k,QPRES) - 0.5_rt * (dq(i,j,k,0)+dq(i,j,k,2))*cspeed;
     pr = amrex::max(pr, parm.smallp);
-    amrex::Real ut1r = q(i,j,k,QU) - 0.5 * dq(i,j,k,3);
-    amrex::Real ut2r = q(i,j,k,QW) - 0.5 * dq(i,j,k,4);
+    amrex::Real ut1r = q(i,j,k,QU) - 0.5_rt * dq(i,j,k,3);
+    amrex::Real ut2r = q(i,j,k,QW) - 0.5_rt * dq(i,j,k,4);
 
     riemann(parm.eos_gamma, parm.smallp, parm.smallr,
             rl, ul, pl, ut1l, ut2l, rr, ur, pr, ut1r, ut2r,
@@ -375,23 +391,25 @@ cns_riemann_z (int i, int j, int k,
                amrex::Array4<amrex::Real const> const& q,
                Parm const& parm) noexcept
 {
+    using namespace amrex::literals;
+
     amrex::Real cspeed = q(i,j,k-1,QCS);
-    amrex::Real rl = q(i,j,k-1,QRHO) + 0.5 * ( (dq(i,j,k-1,0)+dq(i,j,k-1,2))/cspeed + dq(i,j,k-1,1));
+    amrex::Real rl = q(i,j,k-1,QRHO) + 0.5_rt * ( (dq(i,j,k-1,0)+dq(i,j,k-1,2))/cspeed + dq(i,j,k-1,1));
     rl = amrex::max(rl, parm.smallr);
-    amrex::Real ul = q(i,j,k-1,QW) + 0.5 * ( (dq(i,j,k-1,2)-dq(i,j,k-1,0))/q(i,j,k-1,QRHO));
-    amrex::Real pl = q(i,j,k-1,QPRES) + 0.5 *  (dq(i,j,k-1,0)+dq(i,j,k-1,2))*cspeed;
+    amrex::Real ul = q(i,j,k-1,QW) + 0.5_rt * ( (dq(i,j,k-1,2)-dq(i,j,k-1,0))/q(i,j,k-1,QRHO));
+    amrex::Real pl = q(i,j,k-1,QPRES) + 0.5_rt *  (dq(i,j,k-1,0)+dq(i,j,k-1,2))*cspeed;
     pl = amrex::max(pl, parm.smallp);
-    amrex::Real ut1l = q(i,j,k-1,QU) + 0.5 * dq(i,j,k-1,3);
-    amrex::Real ut2l = q(i,j,k-1,QV) + 0.5 * dq(i,j,k-1,4);
+    amrex::Real ut1l = q(i,j,k-1,QU) + 0.5_rt * dq(i,j,k-1,3);
+    amrex::Real ut2l = q(i,j,k-1,QV) + 0.5_rt * dq(i,j,k-1,4);
 
     cspeed = q(i,j,k,QCS);
-    amrex::Real rr = q(i,j,k,QRHO) - 0.5 * ( (dq(i,j,k,0)+dq(i,j,k,2))/cspeed + dq(i,j,k,1));
+    amrex::Real rr = q(i,j,k,QRHO) - 0.5_rt * ( (dq(i,j,k,0)+dq(i,j,k,2))/cspeed + dq(i,j,k,1));
     rr = amrex::max(rr, parm.smallr);
-    amrex::Real ur = q(i,j,k,QW) - 0.5 * ( (dq(i,j,k,2)-dq(i,j,k,0))/q(i,j,k,QRHO));
-    amrex::Real pr = q(i,j,k,QPRES) - 0.5 *  (dq(i,j,k,0)+dq(i,j,k,2))*cspeed;
+    amrex::Real ur = q(i,j,k,QW) - 0.5_rt * ( (dq(i,j,k,2)-dq(i,j,k,0))/q(i,j,k,QRHO));
+    amrex::Real pr = q(i,j,k,QPRES) - 0.5_rt *  (dq(i,j,k,0)+dq(i,j,k,2))*cspeed;
     pr = amrex::max(pr, parm.smallp);
-    amrex::Real ut1r = q(i,j,k,QU) - 0.5 * dq(i,j,k,3);
-    amrex::Real ut2r = q(i,j,k,QV) - 0.5 * dq(i,j,k,4);
+    amrex::Real ut1r = q(i,j,k,QU) - 0.5_rt * dq(i,j,k,3);
+    amrex::Real ut2r = q(i,j,k,QV) - 0.5_rt * dq(i,j,k,4);
 
     riemann(parm.eos_gamma, parm.smallp, parm.smallr,
             rl, ul, pl, ut1l, ut2l, rr, ur, pr, ut1r, ut2r,

--- a/Tutorials/GPU/CNS/Source/main.cpp
+++ b/Tutorials/GPU/CNS/Source/main.cpp
@@ -15,8 +15,8 @@ int main (int argc, char* argv[])
     BL_PROFILE_VAR("main()", pmain);
 
     Real timer_tot = amrex::second();
-    Real timer_init = 0.;
-    Real timer_advance = 0.;
+    Real timer_init = 0._rt;
+    Real timer_advance = 0._rt;
 
     int  max_step;
     Real strt_time;
@@ -26,19 +26,19 @@ int main (int argc, char* argv[])
         ParmParse pp; 
 
         max_step  = -1;
-        strt_time =  0.0;
-        stop_time = -1.0;
+        strt_time =  0.0_rt;
+        stop_time = -1.0_rt;
 
         pp.query("max_step",max_step);
         pp.query("strt_time",strt_time);
         pp.query("stop_time",stop_time);
     }
 
-    if (strt_time < 0.0) {
+    if (strt_time < 0.0_rt) {
         amrex::Abort("MUST SPECIFY a non-negative strt_time"); 
     }
 
-    if (max_step < 0 && stop_time < 0.0) {
+    if (max_step < 0 && stop_time < 0.0_rt) {
 	amrex::Abort("Exiting because neither max_step nor stop_time is non-negative.");
     }
 
@@ -54,7 +54,7 @@ int main (int argc, char* argv[])
 
 	while ( amr.okToContinue() &&
   	       (amr.levelSteps(0) < max_step || max_step < 0) &&
-	       (amr.cumTime() < stop_time || stop_time < 0.0) )
+	       (amr.cumTime() < stop_time || stop_time < 0.0_rt) )
 	    
 	{
 	    //


### PR DESCRIPTION
Users can use `using namespace amrex::literals;` to import amrex literals without importing others.
