### PR TITLE
The Invisible PR

### DIFF
--- a/Docs/sphinx_documentation/source/AMReX_Profiling_Tools.rst
+++ b/Docs/sphinx_documentation/source/AMReX_Profiling_Tools.rst
@@ -238,7 +238,7 @@ AMRProfParser
 database. It is a command line application that can create performance
 summaries, plotfiles showing point to point communication and timelines, HTML
 call trees, communication call statistics, function timing graphs, and other
-data products. The parser’s data services functionality can be called from an
+data products. The parser's data services functionality can be called from an
 interactive environment such as Amrvis, from a sidecar for dynamic performance
 optimization, and from other utilities such as the command line version of the
 parser itself. It has been integrated into Amrvis for visual interpretation of

--- a/Docs/sphinx_documentation/source/AmrCore.rst
+++ b/Docs/sphinx_documentation/source/AmrCore.rst
@@ -25,7 +25,7 @@
 
 .. _fig:Adv:
 
-.. table:: Time sequence (:math:`t=0,0.5,1,1.5,2` s) of advection of a Gaussian profile using the SingleVortex tutorial. The analytic velocity field distorts the profile, and then restores the profile to the original configuration.  The red, green, and blue boxes indicate grids at AMR levels :math:`\ell=0,1`, and :math:`2`.  
+.. table:: Time sequence (:math:`t=0,0.5,1,1.5,2` s) of advection of a Gaussian profile using the SingleVortex tutorial. The analytic velocity field distorts the profile, and then restores the profile to the original configuration.  The red, green, and blue boxes indicate grids at AMR levels :math:`\ell=0,1`, and :math:`2`.  
    :align: center
    
    +-----+-----+-----+-----+-----+
@@ -85,7 +85,7 @@ The protected data members are:
         Vector<BoxArray>            grids;    
 
 The following parameters are frequently set via the inputs file or the command line.
-Their usage is described in the section on :ref:`sec:grid_creation`
+Their usage is described in the section on :ref:`sec:grid_creation`
 
 .. raw:: latex
 
@@ -165,7 +165,7 @@ TagBox, and Cluster
 
 These classes are used in the grid generation process.
 The :cpp:`TagBox` class is essentially a data structure that marks which
-cells are “tagged” for refinement.
+cells are "tagged" for refinement.
 :cpp:`Cluster` (and :cpp:`ClusterList` contained within the same file) are classes
 that help sort tagged cells and generate a grid structure that contains all
 the tagged cells. These classes and their member functions are largely
@@ -191,7 +191,7 @@ FillPatchUtil and Interpolater
    :cpp:`operator()` that fills domain boundaries for a :cpp:`MultiFab`.
 
 Many codes, including the Advection_AmrCore example, contain an array of MultiFabs
-(one for each level of refinement), and then use “fillpatch” operations to fill temporary
+(one for each level of refinement), and then use "fillpatch" operations to fill temporary
 MultiFabs that may include a different number of ghost cells. Fillpatch operations fill
 all cells, valid and ghost, from actual valid data at that level, space-time interpolated data
 from the next-coarser level, neighboring grids at the same level, and domain
@@ -272,7 +272,7 @@ difference in fluxes between the coarse grid and fine grid advance over each
 face over a given coarse time step. The simplest possible synchronization step
 is to modify the coarse grid solution in coarse cells immediately adjacent to
 the coarse-fine interface are updated to account for the mismatch stored in the
-FluxRegister. This can be done “simply” by taking the coarse-level divergence of
+FluxRegister. This can be done "simply" by taking the coarse-level divergence of
 the data in the FluxRegister using the :cpp:`reflux` function.
 
 The Fortran routines that perform the actual floating point work associated with
@@ -312,7 +312,7 @@ Gaussian profile. To integrate these equations on a given level, we use a simple
 
 where the velocities on faces are prescribed functions of space and time, and the scalars on faces
 are computed using a Godunov advection integration scheme. The fluxes in this case are the face-centered,
-time-centered “:math:`\phi u`” and “:math:`\phi v`” terms.
+time-centered ":math:`\phi u`" and ":math:`\phi v`" terms.
 
 We use a subcycling-in-time approach where finer levels are advanced with smaller
 time steps than coarser levels, and then synchronization is later performed between levels.
@@ -533,7 +533,7 @@ The synchronization is performed at the end of :cpp:`AmrCoreAdv::timeStep`:
 Regridding
 ----------
 
-The regrid function belongs to the :cpp:`AmrCore` class (it is virtual – in this
+The regrid function belongs to the :cpp:`AmrCore` class (it is virtual -- in this
 tutorial we use the instance in :cpp:`AmrCore`).
 
 At the beginning of each time step, we check whether we need to regrid.
@@ -569,7 +569,7 @@ advanced a multiple of :cpp:`regrid_int`, we call the :cpp:`regrid` function.
         }
         }
 
-Central to the regridding process is the concept of “tagging” which cells need refinement.
+Central to the regridding process is the concept of "tagging" which cells need refinement.
 :cpp:`ErrorEst` is a pure virtual function of :cpp:`AmrCore`, so each application code must
 contain an implementation. In AmrCoreAdv.cpp the ErrorEst function is essentially an
 interface to a Fortran routine that tags cells (in this case, :fortran:`state_error` in

--- a/Docs/sphinx_documentation/source/AmrLevel.rst
+++ b/Docs/sphinx_documentation/source/AmrLevel.rst
@@ -188,7 +188,7 @@ add the line ``USE_PARTICLES = TRUE`` and build the code
 (do a ``make realclean first``).
 In the inputs file, add the line ``adv.do_tracers = 1``.
 When you run the code, within each plotfile directory there will be a subdirectory
-called “Tracer”.
+called "Tracer".
 
 Copy the files from amrex/Tools/Py_util/amrex_particles_to_vtp into
 the run directory and type, e.g.,
@@ -199,4 +199,4 @@ the run directory and type, e.g.,
 
     python amrex_binary_particles_to_vtp.py plt00000 Tracer
 
-To generate a vtp file you can open with ParaView (Refer to the chapter on :ref:`Chap:Visualization`).
+To generate a vtp file you can open with ParaView (Refer to the chapter on :ref:`Chap:Visualization`).

--- a/Docs/sphinx_documentation/source/Basics.rst
+++ b/Docs/sphinx_documentation/source/Basics.rst
@@ -10,7 +10,7 @@ Dimensionality
 ==============
 
 As we have mentioned in :ref:`Chap:BuildingAMReX`, the dimensionality of
-AMReX must be set at compile time. A macro, ``AMREX_SPACEDIM``, is defined to
+AMReX must be set at compile time. A macro, ``AMREX_SPACEDIM``, is defined to
 be the number of spatial dimensions. C++ codes can also use the
 :cpp:`amrex::SpaceDim` variable. Fortran codes can use either the macro and
 preprocessing or do
@@ -46,7 +46,7 @@ Real
 ====
 
 AMReX can be compiled to use either double precision (which is the default) or
-single precision. :cpp:`amrex::Real` is typedef’d to either :cpp:`double` or
+single precision. :cpp:`amrex::Real` is typedef'd to either :cpp:`double` or
 :cpp:`float`. C codes can use :cpp:`amrex_real`. They are defined in
 :cpp:`AMReX_REAL.H`. The data type is accessible in Fortran codes via
 
@@ -72,9 +72,9 @@ C, the type alias is :cpp:`amrex_long`.  In Fortran, one can use
 ParallelDescriptor
 ==================
 
-AMReX users do not need to use MPI directly. Parallel communication is often
+AMReX users do not need to use MPI directly. Parallel communication is often
 handled by the data abstraction classes (e.g.,MultiFab; section on
-:ref:`sec:basics:multifab`). In addition, AMReX has provided namespace
+:ref:`sec:basics:multifab`). In addition, AMReX has provided namespace
 :cpp:`ParallelDescriptor` in ``AMReX_ParallelDescriptor.H.`` The frequently
 used functions are
 
@@ -169,8 +169,8 @@ a full listing of the available functions.
 Print
 =====
 
-AMReX provides classes in ``AMReX_Print.H`` for printing messages to standard
-output or any C++ :cpp:`ostream`. The main reason one should use them instead
+AMReX provides classes in ``AMReX_Print.H`` for printing messages to standard
+output or any C++ :cpp:`ostream`. The main reason one should use them instead
 of :cpp:`std::cout` is that messages from multiple processes or threads do not
 get mixed up. Below are some examples.
 
@@ -357,7 +357,7 @@ Example of AMR Grids
 In block-structured AMR, there is a hierarchy of logically rectangular grids.
 The computational domain on each AMR level is decomposed into a union of
 rectangular domains. :numref:`fig:basics:amrgrids` below shows an example of
-AMR with three total levels.  In the AMReX numbering convention, the coarsest
+AMR with three total levels.  In the AMReX numbering convention, the coarsest
 level is level 0. The coarsest grid (*black*) covers the domain with
 :math:`16^2` cells. Bold lines represent grid boundaries. There are two
 intermediate resolution grids (*blue*) at level 1 and the cells are a factor of
@@ -540,7 +540,7 @@ output, three integer tuples for each box are the lower corner indices, upper
 corner indices, and the index types. Note that 0 and 1 denote cell and node,
 respectively. For each tuple like :cpp:`(64,64,64)`, the 3 numbers are for 3
 directions. The two Boxes in the code above represent different indexing views
-of the same domain of :math:`64^3` cells. Note that in AMReX convention, the
+of the same domain of :math:`64^3` cells. Note that in AMReX convention, the
 lower side of a cell has the same integer value as the cell centered index.
 That is if we consider a cell based index represent :math:`i`, the nodal index
 with the same integer value represents :math:`i-1/2`.
@@ -749,12 +749,12 @@ Here the constructors take a cell-centered :cpp:`Box` specifying the indexing
 space domain, a :cpp:`RealBox` specifying the
 physical domain, an :cpp:`int` specifying coordinate system type, and
 an :cpp:`int` pointer or array specifying periodicity. If a :cpp:`RealBox` is not
-given in the first constructor, AMReX will construct one based on :cpp:`ParmParse` parameters,
+given in the first constructor, AMReX  will construct one based on :cpp:`ParmParse` parameters,
 ``geometry.prob_lo`` and ``geometry.prob_hi``, where each of the parameter is
-an array of ``AMREX_SPACEDIM`` real numbers. It’s a runtime error if this
+an array of ``AMREX_SPACEDIM`` real numbers. It's a runtime error if this
 fails. The argument for coordinate system is an integer type with
 valid values being 0 (Cartesian), or 1 (cylindrical), or 2 (spherical). If it
-is invalid as in the case of the default argument value of the first constructor, AMReX will query the
+is invalid as in the case of the default argument value of the first constructor, AMReX will query the
 :cpp:`ParmParse` database for ``geometry.coord_sys`` and use it if one is
 found. If it cannot find the parameter, the coordinate system is set to 0
 (i.e., Cartesian coordinates). The :cpp:`Geometry` class has the concept of
@@ -843,9 +843,9 @@ In AMReX, :cpp:`BoxArray` is a global data structure. It holds all the Boxes in
 a collection, even though a single process in a parallel run only owns some of
 the Boxes via domain decomposition. In the example above, a 4-process run may
 divide the work and each process owns say 2 Boxes (see section
-on :ref:`sec:basics:dm`). Each process can then allocate memory for the
+on :ref:`sec:basics:dm`). Each process can then allocate memory for the
 floating point data on the Boxes it owns (see sections
-on :ref:`sec:basics:multifab` & :ref:`sec:basics:fab`).
+on :ref:`sec:basics:multifab` & :ref:`sec:basics:fab`).
 
 :cpp:`BoxArray` has an indexing type, just like :cpp:`Box`. Each Box in a
 BoxArray has the same type as the BoxArray itself. In the following example, we
@@ -913,7 +913,7 @@ of them as completely independent of each other.
       ba2.coarsen(2);    // Modify the copy
       // The original copy is unmodified even though they share internal data.
 
-For advanced users, AMReX provides functions performing the intersection of a
+For advanced users, AMReX provides functions performing the intersection of a
 :cpp:`BoxArray` and a :cpp:`Box`. These functions are much faster than a naive
 implementation of performing intersection of the Box with each Box in the
 BoxArray. If one needs to perform those intersections, functions
@@ -974,7 +974,7 @@ mapping of grids to processes.
 BaseFab, FArrayBox, IArrayBox, and Array4
 =========================================
 
-AMReX is a block-structured AMR framework. Although AMR introduces irregularity
+AMReX is a block-structured AMR framework. Although AMR introduces irregularity
 to the data and algorithms, there is regularity at the block/Box level because
 each is still logically rectangular, and the data structure at the Box level is
 conceptually simple. :cpp:`BaseFab` is a class template for multi-dimensional
@@ -988,7 +988,7 @@ contiguous block of memory because of the ordering. For example, a
 :cpp:`BaseFab<Real>` with 4 components defined on a three-dimensional
 :cpp:`Box(IntVect{-4,8,32},IntVect{32,64,48})` is like a Fortran array of
 :fortran:`real(amrex_real), dimension(-4:32,8:64,32:48,0:3)`.  Note that the
-convention in C++ part of AMReX is the component index is zero based. The code
+convention in C++ part of AMReX is the component index is zero based. The code
 for constructing such an object is as follows,
 
 .. highlight:: c++
@@ -1034,7 +1034,7 @@ To get a pointer to the array data, one can call
       const T* dataPtr(int n=0) const; // const version
 
 The typical usage of the returned pointer is then to pass it to a Fortran or C
-function that works on the array data (see the section on
+function that works on the array data (see the section on
 :ref:`sec:basics:fortran`).  :cpp:`BaseFab` has several functions that set the
 array data to a constant value. Two examples are as follows.
 
@@ -1113,7 +1113,7 @@ to run for these :cpp:`BaseFab` functions.  For example,
 
 For more complicated expressions that are not supported, one can write
 Fortran or C/C++ functions for those (see the section
-on :ref:`sec:basics:fortran`).  In C++, one can use :cpp:`Array4`,
+on :ref:`sec:basics:fortran`).  In C++, one can use :cpp:`Array4`,
 which is a class template for accessing :cpp:`BaseFab` data in a more
 array like manner using :cpp:`operator()`.  Below is an example of
 using :cpp:`Array4`.
@@ -1156,7 +1156,7 @@ to point to other data.  In the example above, neither ``m(i,j,k) =
 The behavior is in some sense similar to ``double const * const p``.
 
 :cpp:`BaseFab` and its derived classes are containers for data on :cpp:`Box`.
-Recall that :cpp:`Box` has various types (see the section on :ref:`sec:basics:box`).
+Recall that :cpp:`Box` has various types (see the section on :ref:`sec:basics:box`).
 The examples in this section so far use the default cell based type.  However,
 some functions will result in a runtime error if the types mismatch.  For
 example.
@@ -1172,7 +1172,7 @@ example.
       ccfab.setVal(0.0);
       ndfab.copy(ccfab);   // runtime error due to type mismatch
 
-Because it typically contains a lot of data, BaseFab’s copy constructor and
+Because it typically contains a lot of data, BaseFab's copy constructor and
 copy assignment operator are disabled to prevent performance degradation. However, BaseFab does
 provide a move constructor. In addition, it also provides a constructor for
 making an alias of an existing object. Here is an example using
@@ -1211,7 +1211,7 @@ FabArray, MultiFab and iMultiFab
 
 :cpp:`FabArray<FAB>` is a class template in AMReX_FabArray.H for a collection
 of FABs on the same AMR level associated with a :cpp:`BoxArray` (see the
-section on :ref:`sec:basics:ba`). The template parameter :cpp:`FAB` is usually
+section on :ref:`sec:basics:ba`). The template parameter :cpp:`FAB` is usually
 :cpp:`BaseFab<T>` or its derived classes (e.g., :cpp:`FArrayBox`). However, FabArray
 can also be used to hold other data structures. To construct a FabArray, a
 :cpp:`BoxArray` must be provided because the FabArray is intended to hold *grid* data
@@ -1224,7 +1224,7 @@ distributed among parallel processes. For each process, a FabArray contains
 only the FAB objects owned by that process, and the process operates only on
 its local data. For operations that require data owned by other processes,
 remote communications are involved. Thus, the construction of a :cpp:`FabArray`
-requires a :cpp:`DistributionMapping` (see the section on :ref:`sec:basics:dm`)
+requires a :cpp:`DistributionMapping` (see the section on :ref:`sec:basics:dm`)
 that specifies which process owns which Box. For level 2 (*red*) in
 :numref:`fig:basics:amrgrids`, there are two Boxes. Suppose there are two
 parallel processes, and we use a DistributionMapping that assigns one Box to
@@ -1251,7 +1251,7 @@ ways to define a MultiFab. For example,
 
 Here we define a :cpp:`MultiFab` with 4 components and 1 ghost cell. A MultiFab
 contains a number of :cpp:`FArrayBox`\ es (see the section
-on :ref:`sec:basics:fab`) defined on Boxes grown by the number of ghost cells
+on :ref:`sec:basics:fab`) defined on Boxes grown by the number of ghost cells
 (1 in this example). That is the :cpp:`Box` in the :cpp:`FArrayBox` is not
 exactly the same as in the :cpp:`BoxArray`.  If the :cpp:`BoxArray` has a
 :cpp:`Box{(7,7,7) (15,15,15)}`, the one used for constructing :cpp:`FArrayBox`
@@ -1290,7 +1290,7 @@ as follows.
 
 Here the first integer parameter is the starting component in the original
 :cpp:`MultiFab` that will become component 0 in the alias :cpp:`MultiFab` and
-the second integer parameter is the number of components in the alias. It’s a
+the second integer parameter is the number of components in the alias. It's a
 runtime error if the sum of the two integer parameters is greater than the
 number of the components in the original MultiFab. Note that the alias MultiFab
 has exactly the same number of ghost cells as the original MultiFab.
@@ -1317,7 +1317,7 @@ As we have repeatedly mentioned in this chapter that :cpp:`Box` and
 :cpp:`BoxArray` have various index types. Thus, :cpp:`MultiFab` also has an
 index type that is obtained from the :cpp:`BoxArray` used for defining the
 :cpp:`MultiFab`. It should be noted again that index type is a very important
-concept in AMReX. Let’s consider an example of a finite-volume code, in which
+concept in AMReX. Let's consider an example of a finite-volume code, in which
 the state is defined as cell averaged variables and the fluxes are defined as
 face averaged variables.
 
@@ -1401,7 +1401,7 @@ Note that :cpp:`FillBoundary` does not modify any valid cells. Also note that
 :cpp:`Geometry` has, and we can provide that information so that periodic
 boundaries can be filled as well. You might have noticed that a ghost cell
 could overlap with multiple valid cells from different FArrayBoxes in the case
-of nodal index type. In that case, it is unspecified that which valid cell’s
+of nodal index type. In that case, it is unspecified that which valid cell's
 value is used to fill the ghost cell. It ought to be the case the values in
 those overlapping valid cells are the same up to roundoff errors.  If
 a ghost cell does not overlap with any valid cells, its value will not
@@ -1464,10 +1464,10 @@ logical tiling can be launched via :cpp:`MFIter`.
 MFIter without Tiling
 ---------------------
 
-In the section on :ref:`sec:basics:multifab`, we have shown some of the
+In the section on :ref:`sec:basics:multifab`, we have shown some of the
 arithmetic functionalities of :cpp:`MultiFab`, such as adding two MultiFabs
 together. In this section, we will show how you can operate on the
-:cpp:`MultiFab` data with your own functions. AMReX  provides an iterator,
+:cpp:`MultiFab` data with your own functions. AMReX provides an iterator,
 :cpp:`MFIter` for looping over the FArrayBoxes in MultiFabs. For example,
 
 .. highlight:: c++
@@ -1613,7 +1613,7 @@ And the manually tiled loops might look like
       end do
 
 As we can see, to manually tile individual loops is very labor-intensive and
-error-prone for large applications. AMReX has incorporated the tiling construct
+error-prone for large applications. AMReX has incorporated the tiling construct
 into :cpp:`MFIter` so that the application codes can get the benefit of tiling
 easily. An :cpp:`MFIter` loop with tiling is almost the same as the non-tiling
 version. The first example in (see the previous section on
@@ -1638,7 +1638,7 @@ version. The first example in (see the previous section on
           f1(box, a);
       }
 
-The second example in the previous section on :ref:`sec:basics:mfiter:notiling`
+The second example in the previous section on :ref:`sec:basics:mfiter:notiling`
 also requires only two minor changes.
 
 .. highlight:: c++
@@ -1715,7 +1715,7 @@ The tile size can be explicitly set when defining :cpp:`MFIter`.
 
 An :cpp:`IntVect` is used to specify the tile size for every dimension.  A tile
 size larger than the grid size simply means tiling is disabled in that
-direction. AMReX has a default tile size :cpp:`IntVect{1024000,8,8}` in 3D and
+direction. AMReX has a default tile size :cpp:`IntVect{1024000,8,8}` in 3D and
 no tiling in 2D. This is used when tile size is not explicitly set but the
 tiling flag is on. One can change the default size using :cpp:`ParmParse`
 (section :ref:`sec:basics:parmparse`) parameter ``fabarray.mfiter_tile_size.``
@@ -1905,11 +1905,11 @@ These Fortran functions take C pointers and view them
 as multi-dimensional arrays of the shape specified by the additional integer
 arguments.  Note that Fortran takes arguments by reference unless the
 :fortran:`value` keyword is used. So an integer argument on the Fortran side
-matches an integer pointer on the C++ side. Thanks to Fortran 2003, function
+matches an integer pointer on the C++ side. Thanks to Fortran 2003, function
 name mangling is easily achieved by declaring the Fortran function as
 :fortran:`bind(c)`.
 
-AMReX provides many macros for passing an FArrayBox’s data into Fortran/C. For
+AMReX provides many macros for passing an FArrayBox's data into Fortran/C. For
 example
 
 .. highlight:: c++
@@ -1962,8 +1962,8 @@ one can use
       real(amrex_real),intent(inout)::u(ulo(1):uhi(1),ulo(2):uhi(2))
     end subroutine f2d
 
-Note that this does not require any changes in the C++ part, because when
-C++ passes an integer pointer pointing to an array of three integers Fortran
+Note that this does not require any changes in the C++ part, because when
+C++ passes an integer pointer pointing to an array of three integers Fortran
 can treat it as a 2-element integer array.
 
 Another commonly used macro is :cpp:`BL_TO_FORTRAN`. This macro takes an
@@ -2246,7 +2246,7 @@ coarse/fine boundary.
 The third type of boundary is the physical boundary at the physical domain.
 Note that both coarse and fine AMR levels could have grids touching the
 physical boundary. It is up to the application codes to properly fill the ghost
-cells at the physical boundary. However, AMReX does provide support for some
+cells at the physical boundary. However, AMReX does provide support for some
 common operations.  See the section on :ref:`sec:basics:boundary` for a
 discussion on domain boundary conditions in general, including how to implement
 physical (non-periodic) boundary conditions.
@@ -2258,7 +2258,7 @@ Boundary Conditions
 
 This section describes how to implement domain boundary conditions in AMReX.  A
 ghost cell that is outside of the valid region can be thought of as either
-“interior” (which includes periodic and coarse-fine ghost cells), or “physical”.
+"interior" (which includes periodic and coarse-fine ghost cells), or "physical".
 Physical boundary conditions can occur on domain boundaries and can
 be characterized as inflow, outflow, slip/no-slip walls, etc., and are
 ultimately linked to mathematical Dirichlet or Neumann conditions.
@@ -2301,11 +2301,11 @@ The basic idea behind physical boundary conditions is as follows:
            Interior, including periodic boundary
 
        ext_dir
-           “External Dirichlet”. It is the user’s responsibility to write a routine
+           "External Dirichlet". It is the user's responsibility to write a routine
            to fill ghost cells (more details below).
 
        foextrap
-           “First Order Extrapolation”
+           "First Order Extrapolation"
            First order extrapolation from last cell in interior.
 
        reflect_even
@@ -2339,12 +2339,12 @@ The basic idea behind physical boundary conditions is as follows:
    whatsoever, whereas for the GPU build, this marks the operator as a GPU
    device function.
 
--  It is the user’s responsibility to have a consisent definition of
-   what the ghost cells represent. A common option used in AMReX codes is to
+-  It is the user's responsibility to have a consisent definition of
+   what the ghost cells represent. A common option used in AMReX codes is to
    fill the domain ghost cells with the value that lies on the boundary (as
    opposed to another common option where the value in the ghost cell represents
    an extrapolated value based on the boundary condition type). Then in our
-   stencil based “work” codes, we also pass in the :cpp:`BCRec` object and use
+   stencil based "work" codes, we also pass in the :cpp:`BCRec` object and use
    modified stencils near the domain boundary that know the value in the first
    ghost cell represents the value on the boundary.
 
@@ -2387,7 +2387,7 @@ present more details in :ref:`sec:gpu:memory` in Chapter GPU.
 
 AMReX has a Fortran module, :fortran:`amrex_mempool_module` that can be used to
 allocate memory for Fortran pointers. The reason that such a module exists in
-AMReX, is that memory allocation is often very slow in multi-threaded OpenMP
+AMReX is that memory allocation is often very slow in multi-threaded OpenMP
 parallel regions. AMReX :cpp:`amrex_mempool_module` provides a much faster
 alternative approach, in which each thread has its own memory pool. Here are
 examples of using the module.

--- a/Docs/sphinx_documentation/source/Basics_Chapter.rst
+++ b/Docs/sphinx_documentation/source/Basics_Chapter.rst
@@ -4,7 +4,7 @@ Basics
 ===================
 
 In this chapter, we present the basics of AMReX. The implementation source
-codes are in ``amrex/Src/Base/``. Note that AMReX classes and functions are in
+codes are in ``amrex/Src/Base/``. Note that AMReX classes and functions are in
 namespace ``amrex``. For clarity, we usually drop ``amrex::`` in the example
 codes here. It is also assumed that headers have been properly included. We
 recommend you study the tutorial in

--- a/Docs/sphinx_documentation/source/BuildingAMReX.rst
+++ b/Docs/sphinx_documentation/source/BuildingAMReX.rst
@@ -96,7 +96,7 @@ precision by setting ``PRECISION=FLOAT``.
 Variables ``DEBUG``, ``USE_MPI`` and ``USE_OMP`` are optional with default set
 to FALSE.  The meaning of these variables should
 be obvious.  When ``DEBUG=TRUE``, aggressive compiler optimization flags are
-turned off and assertions in  source code are turned on. For production runs,
+turned off and assertions in source code are turned on. For production runs,
 ``DEBUG`` should be set to FALSE.
 
 Variables ``USE_CUDA``, ``USE_HIP`` and ``USE_DPCPP`` are used for
@@ -296,7 +296,7 @@ the configure script. In particular, one can specify the installation path for t
   ./configure --prefix=[AMReX library path]
 
 This approach is built on the AMReX GNU Make system. Thus
-the section on :ref:`sec:build:make` is recommended if any fine tuning is
+the section on :ref:`sec:build:make` is recommended if any fine tuning is
 needed.  The result of ``./configure`` is ``GNUmakefile`` in the AMReX
 top directory.  One can modify the make file for fine tuning.
 
@@ -331,8 +331,8 @@ library paths used to build AMReX::
 Building with CMake
 ===================
 
-An alternative to the approach described in the section on :ref:`sec:build:lib`
-is to install AMReX as an external library by using the CMake build system.  A
+An alternative to the approach described in the section on :ref:`sec:build:lib`
+is to install AMReX as an external library by using the CMake build system.  A
 CMake build is a two-step process. First ``cmake`` is invoked to create
 configuration files and makefiles in a chosen directory (``builddir``).  This
 is roughly equivalent to running ``./configure`` (see the section on
@@ -352,9 +352,9 @@ The CMake build process is summarized as follows:
     make  install
 
 In the above snippet, ``[options]`` indicates one or more options for the
-customization of the build, as described in the subsection on
+customization of the build, as described in the subsection on
 :ref:`sec:build:cmake:options`. If the option ``CMAKE_BUILD_TYPE`` is omitted,
-``CMAKE_BUILD_TYPE=Release`` is assumed. Although the AMReX source could be used as
+``CMAKE_BUILD_TYPE=Release`` is assumed. Although the AMReX source could be used as
 build directory, we advise against doing so.  After the installation is
 complete, ``builddir`` can be removed.
 
@@ -380,7 +380,7 @@ Configuration variables requiring a boolen value are evaluated to true if they
 are assigned a value of ``1``, ``ON``, ``YES``, ``TRUE``, ``Y``. Conversely they are evaluated to false
 if they are assigned a value of ``0``, ``OFF``, ``NO``, ``FALSE``, ``N``.
 Boolean configuration variables are case-insensitive.
-The list of available options is reported in the table on :ref:`tab:cmakevar`
+The list of available options is reported in the table on :ref:`tab:cmakevar`
 below.
 
 

--- a/Docs/sphinx_documentation/source/CVODE.rst
+++ b/Docs/sphinx_documentation/source/CVODE.rst
@@ -5,23 +5,23 @@
    :language: fortran
 
 
-Compiling AMReX with CVODE (Cray or Sundials version 2.7)
+Compiling AMReX with CVODE (Cray or Sundials version 2.7)
 -----------------------------------------------------------
 
-The following steps describe how to compile an AMReX application with
-CVODE support.  On Cray systems (e.g., Cori or Edison at NERSC), Cray provides
-a system module called ``cray-tpsl`` (“Cray Third-Party Scientific Libraries”)
-which contains the latest version of the SUNDIALS solver suite (including
+The following steps describe how to compile an AMReX application with
+CVODE support.  On Cray systems (e.g., Cori or Edison at NERSC), Cray provides
+a system module called ``cray-tpsl`` ("Cray Third-Party Scientific Libraries")
+which contains the latest version of the SUNDIALS solver suite (including
 CVODE).  Simply type ``module load cray-tpsl`` and set ``USE_CVODE=TRUE`` in
-the ``GNUmakefile``, and AMReX will automatically link the SUNDIALS libraries.
+the ``GNUmakefile``, and AMReX will automatically link the SUNDIALS libraries.
 
 On systems which are not Cray:
 
-#. Obtain the CVODE source code, which is hosted here:
+#. Obtain the CVODE source code, which is hosted here:
    https://computation.llnl.gov/projects/sundials/sundials-software.
-   One can download either the complete SUNDIALS package, or just the CVODE components.
+   One can download either the complete SUNDIALS package, or just the CVODE components.
 
-#. Unpack the CVODE / SUNDIALS tarball, and create a new “build” directory (it
+#. Unpack the CVODE / SUNDIALS tarball, and create a new "build" directory (it
    can be anywhere).
 
 #. Navigate to the new, empty build directory, and type
@@ -57,26 +57,26 @@ On systems which are not Cray:
    ``cc`` statement when compiling the source code.  Here one may wish to add
    something like ``"-O2 -g"`` to provide an optimized library that still
    contains debugging symbols; if one neglects debugging symbols in the CVODE
-   library, and if a code that uses CVODE encounters a segmentation fault in
+   library, and if a code that uses CVODE encounters a segmentation fault in
    the solve, then the backtrace has no information about where in the solver
    the error occurred.  Also, if one wishes to compile only the solver library
    itself and not the examples that come with the source (compiling the
    examples is enabled by default), one can add ``"-DEXAMPLES_ENABLE=OFF"``.
-   Users should be aware that the CVODE examples are linked dynamically, so
+   Users should be aware that the CVODE examples are linked dynamically, so
    when compiling the solver library on Cray system using the Cray compiler
    wrappers ``cc``, ``CC``, and ``ftn``, one should explicitly disable
    compiling the examples via the ``"-DEXAMPLES_ENABLE=OFF"`` flag.
 
-#. In the ``GNUmakefile`` for the  application which uses the Fortran 2003
+#. In the ``GNUmakefile`` for the application which uses the Fortran 2003
    interface to , add ``USE_CVODE = TRUE``, which will compile the Fortran 2003
-   interfaces and link the  libraries.  Note that one must define the
+   interfaces and link the libraries.  Note that one must define the
    ``CVODE_LIB_DIR`` environment variable to point to the location where the
    libraries are installed.
 
-CVODE Tutorials
+CVODE Tutorials
 ------------------
 
-AMReX provides two CVODE tutorials in the ``amrex/Tutorials/CVODE`` directory, called
+AMReX provides two CVODE tutorials in the ``amrex/Tutorials/CVODE`` directory, called
 ``EX1`` and ``EX2``.  See the Tutorials CVODE_ documentation for more detail.
 
 .. _CVODE: https://amrex-codes.github.io/amrex/tutorials_html/CVODE_Tutorial.html

--- a/Docs/sphinx_documentation/source/CVODE_top.rst
+++ b/Docs/sphinx_documentation/source/CVODE_top.rst
@@ -3,25 +3,25 @@
 CVODE
 =====
 
-AMReX supports local ODE integration using the CVODE solver, [1]_ which is part
-of the SUNDIALS framework. [2]_ CVODE contains solvers for stiff and non-stiff
+AMReX supports local ODE integration using the CVODE solver, [1]_ which is part
+of the SUNDIALS framework. [2]_ CVODE contains solvers for stiff and non-stiff
 ODEs, and as such is well suited for solving e.g., the complex chemistry
 networks in combustion simulations, or the nuclear reaction networks in
 astrophysical simulations.
 
-Most of CVODE is written in C, but many functions also come with two distinct
+Most of CVODE is written in C, but many functions also come with two distinct
 Fortran interfaces.  One interface is FCVODE, which is bundled with the stable
-release of CVODE.  Its usage is described in the CVODE documentation. [3]_
-However, the use of FCVODE is discouraged in AMReX due to its incompatibility
+release of CVODE.  Its usage is described in the CVODE documentation. [3]_
+However, the use of FCVODE is discouraged in AMReX due to its incompatibility
 with being used inside OpenMP parallel regions (which is the primary use case
-in AMReX applications).
+in AMReX applications).
 
-The alternative, and recommended, Fortran interface to  uses the
+The alternative, and recommended, Fortran interface to uses the
 ``iso_c_binding`` feature of the Fortran 2003 standard to implement a direct
 interface to the C functions in CVODE.  When compiling CVODE, one need not
-build the CVODE library with the FCVODE interface enabled at all.  Rather, the
-Fortran 2003 interface to CVODE is provided within AMReX itself.  The
-CVODE tutorials provided in AMReX use this new interface.
+build the CVODE library with the FCVODE interface enabled at all.  Rather, the
+Fortran 2003 interface to CVODE is provided within AMReX itself.  The
+CVODE tutorials provided in AMReX use this new interface.
 
 .. toctree::
    :maxdepth: 1

--- a/Docs/sphinx_documentation/source/EB.rst
+++ b/Docs/sphinx_documentation/source/EB.rst
@@ -41,7 +41,7 @@ meshes for rather complex geometries can be generated quickly and robustly.
 However, the technique can produce arbitrarily small cut cells in the domain.
 In practice such small cells can have significant impact on the robustness and
 stability of traditional finite volume methods. In this chapter we overview a
-class of approaches to deal with this “small cell” problem in a robust and
+class of approaches to deal with this "small cell" problem in a robust and
 efficient way, and discuss the tools and data that AMReX provides in order to
 implement them.
 
@@ -74,7 +74,7 @@ A conservative, finite volume discretization starts with the divergence theorm
 
 .. math:: \int_V \nabla \cdot F dV = \int_{\partial V} F \cdot n dA.
 
-In an embedded boundary cell, the “conservative divergence” is discretized (as
+In an embedded boundary cell, the "conservative divergence" is discretized (as
 :math:`D^c(F)`) as follows
 
 .. math::
@@ -141,7 +141,7 @@ conservation laws, a naive discretization in time of :eq:`eqn::hypsys` using
 would have a time step constraint :math:`\delta t \sim h \kappa^{1/D}/V_m`,
 which goes to zero as the size of the smallest volume fraction :math:`\kappa` in
 the calculation. Since EB volume fractions can be arbitrarily small, this is an
-unacceptable constraint. One way to remedy this is to create “non-conservative”
+unacceptable constraint. One way to remedy this is to create "non-conservative"
 approximation to the divergence :math:`D^{nc}`, which at a cell :math:`{\bf i}`,
 can be formed as an average of the conservative divergences in the neighborhood,
 :math:`N_{\bf i}`, of :math:`{\bf i}`.
@@ -159,7 +159,7 @@ mass gained or lost by not using :math:`D^c` directly,
 
 .. math:: \delta M_{\bf i}= \kappa (1-\kappa)(D^c(F)_{\bf i}- D^{nc}(F)_{\bf i})
 
-This “excess material” (mass, if :math:`U=\rho`) can be *redistributed* in a
+This "excess material" (mass, if :math:`U=\rho`) can be *redistributed* in a
 time-explicit fashion to neighboring cells, :math:`{\bf j}\in N_{\bf i}`:
 
 .. math:: \delta M_{\bf i}= \sum_{{\bf j}\in N_{\bf i}} \delta M_{{\bf j}, {\bf i}}.

--- a/Docs/sphinx_documentation/source/External_Profiling_Tools.rst
+++ b/Docs/sphinx_documentation/source/External_Profiling_Tools.rst
@@ -8,10 +8,10 @@ CrayPat
 =======
 
 The profiling suite available on Cray XC systems is Cray Performance
-Measurement and Analysis Tools (“CrayPat”) [1]_.  Most CrayPat functionality is
-supported for all compilers available in the Cray “programming environments“
-(modules which begin “``PrgEnv-``”); however, a few features, chiefly the
-“Reveal” tool, are supported only on applications compiled with Cray’s compiler
+Measurement and Analysis Tools ("CrayPat") [1]_.  Most CrayPat functionality is
+supported for all compilers available in the Cray "programming environments"
+(modules which begin "``PrgEnv-``"); however, a few features, chiefly the
+"Reveal" tool, are supported only on applications compiled with Cray's compiler
 CCE [2]_ [3]_.
 
 CrayPat supports both high-level profiling tools, as well as fine-grained
@@ -21,7 +21,7 @@ uses sampling to identify the most time-consuming functions in an application.
 High-level application profiling
 --------------------------------
 
-The simplest way to obtain a high-level overview of an application’s
+The simplest way to obtain a high-level overview of an application's
 performance consists of the following steps:
 
 #. Load the ``perftools-base`` module, then the ``perftools-lite`` module. (The

--- a/Docs/sphinx_documentation/source/Fortran.rst
+++ b/Docs/sphinx_documentation/source/Fortran.rst
@@ -8,13 +8,13 @@
 Getting Started
 ===============
 
-We have discussed AMReX’s build systems in the chapter on
+We have discussed AMReX's build systems in the chapter on
 :ref:`Chap:BuildingAMReX`.  To build with GNU Make, we need to include the
 Fortran interface source tree into the make system. The source codes for the
 Fortran interface are in ``amrex/Src/F_Interfaces`` and there are several
 sub-directories. The "Base" directory includes sources for the basic
 functionality, the "AmrCore" directory wraps around the :cpp:`AmrCore` class
-(see the chapter on :ref:`Chap:AmrCore`), and the "Octree" directory adds
+(see the chapter on :ref:`Chap:AmrCore`), and the "Octree" directory adds
 support for octree type of AMR grids. Each directory has a "Make.package" file
 that can be included in make files (see ``amrex/Tutorials/Basic/HelloWorld_F`` and
 ``amrex/Tutorials/Amr/Advection_F`` for examples). The libamrex approach includes the
@@ -37,11 +37,11 @@ is shown below in its entirety.
       call amrex_finalize()
     end program main
 
-To access the AMReX Fortran interfaces, we can use these three
+To access the AMReX Fortran interfaces, we can use these three
 modules, amrex_base_module for the basics functionalities
-(Section `2 <#sec:fi:basics>`__), amrex_amrcore_module for AMR
-support (Section `3 <#sec:fi:amrcore>`__) and amrex_octree_module
-for octree style AMR (Section `4 <#sec:fi:octree>`__).
+(Section `2 <#sec:fi:basics>`__), amrex_amrcore_module for AMR
+support (Section `3 <#sec:fi:amrcore>`__) and amrex_octree_module
+for octree style AMR (Section `4 <#sec:fi:octree>`__).
 
 .. _sec:fi:basics:
 
@@ -49,15 +49,15 @@ The Basics
 ==========
 
 Module :fortran:`amrex_base_module` is a collection of various Fortran modules
-providing interfaces to most of the basics of AMReX C++ library (see the
-chapter on :ref:`Chap:Basics`). These modules shown in this section can be used
+providing interfaces to most of the basics of AMReX C++ library (see the
+chapter on :ref:`Chap:Basics`). These modules shown in this section can be used
 without being explicitly included because they are included by
 :fortran:`amrex_base_module`.
 
 The spatial dimension is an integer parameter :fortran:`amrex_spacedim`.  We
 can also use the :fortran:`AMREX_SPACEDIM` macro in preprocessed Fortran codes
-(e.g., .F90 files) just like in the C++ codes. Unlike in C++, the convention
-for AMReX Fortran interface is that coordinate direction index starts at 1.
+(e.g., .F90 files) just like in the C++ codes. Unlike in C++, the convention
+for AMReX Fortran interface is that coordinate direction index starts at 1.
 
 There is an integer parameter :fortran:`amrex_real`, a Fortran kind parameter
 for :fortran:`real`. Fortran :fortran:`real(amrex_real)` corresponds to
@@ -67,11 +67,11 @@ the setting of precision.
 The module :fortran:`amrex_parallel_module` (
 ``amrex/Src/F_Interfaces/Base/AMReX_parallel_mod.F90``) includes wrappers to the
 :cpp:`ParallelDescriptor` namespace, which is in turn a wrapper to the parallel
-communication library used by AMReX (e.g. MPI).
+communication library used by AMReX (e.g. MPI).
 
 The module :cpp:`amrex_parmparse_module` (
 ``amrex/Src/Base/AMReX_parmparse_mod.F90``) provides interface to
-:cpp:`ParmParse` (see the section on :ref:`sec:basics:parmparse`). Here are some
+:cpp:`ParmParse` (see the section on :ref:`sec:basics:parmparse`). Here are some
 examples.
 
 .. highlight:: fortran
@@ -200,10 +200,10 @@ C++.
       call mf%parallel_copy(mfsrc, geom) ! Parallel copy from another multifab
 
 It should be emphasized that the component index for :fortran:`amrex_multifab`
-starts with 1 following Fortran convention. This is different from the C++ part
+starts with 1 following Fortran convention. This is different from the C++ part
 of AMReX.
 
-AMReX provides a Fortran interface to :fortran:`MFIter` for iterating over the
+AMReX provides a Fortran interface to :fortran:`MFIter` for iterating over the
 data in :fortran:`amrex_multifab`. The Fortran type for this is
 :fortran:`amrex_mfiter`. Here is an example of using :fortran:`amrex_mfiter` to
 loop over :fortran:`amrex_multifab` with tiling and launch a kernel function.
@@ -242,7 +242,7 @@ Here procedure :fortran:`update_phi` is
        ! ...
      end subroutine update_phi
 
-Note that amrex_multifab’s procedure :fortran:`dataptr` takes
+Note that amrex_multifab's procedure :fortran:`dataptr` takes
 :fortran:`amrex_mfiter` and returns a 4-dimensional Fortran pointer. For
 performance, we should declare the pointer as :fortran:`contiguous`. In C++,
 the similar operation returns a reference to :cpp:`FArrayBox`.  However,
@@ -251,10 +251,10 @@ array bound information. We can call :fortran:`lbound` and :fortran:`ubound` on
 the pointer to return its lower and upper bounds. The first three dimensions of
 the bounds are spatial and the fourth is for the number of component.
 
-Many of the derived Fortran types in  (e.g., :fortran:`amrex_multifab`,
+Many of the derived Fortran types in (e.g., :fortran:`amrex_multifab`,
 :fortran:`amrex_boxarray`, :fortran:`amrex_distromap`, :fortran:`amrex_mfiter`,
 and :fortran:`amrex_geometry`) contain a :fortran:`type(c_ptr)` that points a
-C++ object. They also contain a :fortran:`logical` type indicating whether or
+C++ object. They also contain a :fortran:`logical` type indicating whether or
 not this object owns the underlying object (i.e., responsible for deleting the
 object). Due to the semantics of Fortran, one should not return these types
 with functions. Instead we should pass them as arguments to procedures
@@ -295,7 +295,7 @@ If we need to transfer the ownership, :fortran:`amrex_multifab`,
 :fortran:`amrex_multifab` also has a type-bound :fortran:`swap` procedure for
 exchanging the data.
 
-AMReX also provides :fortran:`amrex_plotfile_module` for writing plotfiles. The
+AMReX also provides :fortran:`amrex_plotfile_module` for writing plotfiles. The
 interface is similar to the C++ versions.
 
 
@@ -325,7 +325,7 @@ infrastructure. With AMR, the main program might look like below,
 
 Here we need to call :fortran:`amrex_amrcore_init` and
 :fortran:`amrex_amrcore_finalize`. And usually we need to call application code
-specific procedures to provide some “hooks” needed by AMReX.  In C++, this is
+specific procedures to provide some "hooks" needed by AMReX.  In C++, this is
 achieved by using virtual functions. In Fortran, we need to call
 
 .. highlight:: fortran
@@ -383,7 +383,7 @@ interfaces:
 Tutorials/Amr/Advection_F/Source/my_amr_mod.F90 shows an
 example of the setup process. The user provided
 :fortran:`procedure(amrex_error_est_proc)` has a tags argument that
-is of type :fortran:`c_ptr` and its value is a pointer to a  
+is of type :fortran:`c_ptr` and its value is a pointer to a
 :fortran:`TagBoxArray` object. We need to convert this into a Fortran
 :fortran:`amrex_tagboxarray` object.
 
@@ -393,13 +393,13 @@ is of type :fortran:`c_ptr` and its value is a pointer to a  
       tag = tags
 
 The module :fortran:`amrex_fillpatch_module` provides interface to
-C++ functions :cpp:`FillPatchSinglelevel` and :cpp:`FillPatchTwoLevels`. To use
+C++ functions :cpp:`FillPatchSinglelevel` and :cpp:`FillPatchTwoLevels`. To use
 it, the application code needs to provide procedures for interpolation and
 filling physical boundaries.  See
 Tutorials/Amr/Advection_F/Source/fillpatch_mod.F90 for an example.
 
 Module :fortran:`amrex_fluxregister_module` provides interface to
-:cpp:`FluxRegister` (see the section on :ref:`sec:amrcore:fluxreg`). Its usage
+:cpp:`FluxRegister` (see the section on :ref:`sec:amrcore:fluxreg`). Its usage
 is demonstrated in the tutorial at Tutorials/Amr/Advection_F/.
 
 
@@ -410,9 +410,9 @@ Octree
 
 In AMReX, the union of fine level grids is properly contained within the union
 of coarse level grids. There are no required direct parent-child connections
-between levels. Therefore, grids in AMReX in general cannot be represented by
+between levels. Therefore, grids in AMReX in general cannot be represented by
 trees. Nevertheless, octree type grids are supported via Fortran interface,
-because  grids are more general than octree grids. A tutorial example using
+because grids are more general than octree grids. A tutorial example using
 amrex_octree_module ( ``amrex/Src/F_Interfaces/Octree/AMReX_octree_mod.f90``) is
 available at ``amrex/Tutorials/Amr/Advection_octree_F/``. Procedures
 :fortran:`amrex_octree_init` and :fortran:`amrex_octree_finalize` must be

--- a/Docs/sphinx_documentation/source/Fortran_Chapter.rst
+++ b/Docs/sphinx_documentation/source/Fortran_Chapter.rst
@@ -7,13 +7,13 @@ Fortran Interface
 =================
 
 
-The core of AMReX is written in C++. For Fortran users who want to write all of
-their programs in Fortran, AMReX provides Fortran interfaces around most of
-functionalities except for the :cpp:`AmrLevel` class (see the chapter on
-:ref:`Chap:AmrLevel`) and particles (see the chapter on :ref:`Chap:Particles`).
+The core of AMReX is written in C++. For Fortran users who want to write all of
+their programs in Fortran, AMReX provides Fortran interfaces around most of
+functionalities except for the :cpp:`AmrLevel` class (see the chapter on
+:ref:`Chap:AmrLevel`) and particles (see the chapter on :ref:`Chap:Particles`).
 We should not confuse the Fortran interface in this chapter with the Fortran
 kernel functions called inside :cpp:`MFIter` loops in codes (see the section
-on :ref:`sec:basics:fortran`). For the latter, Fortran is used in some sense as
+on :ref:`sec:basics:fortran`). For the latter, Fortran is used in some sense as
 a domain-specific language with native multi-dimensional arrays, whereas here
 Fortran is used to drive the whole application code. In order to better
 understand AMReX, Fortran interface users should read the rest of the documentation

--- a/Docs/sphinx_documentation/source/GPU.rst
+++ b/Docs/sphinx_documentation/source/GPU.rst
@@ -442,9 +442,9 @@ allocations and deallocations when (for example) resizing vectors.
 
     \begin{center}
 
-.. _tab:gpu:arena:
+.. _tab:gpu:gpuvectors:
 
-.. table:: Memory Arenas
+.. table:: Memory Arenas Associated with each Gpu Vector
 
     +----------------+----------------------+
     | Vector         | Arena                |

--- a/Docs/sphinx_documentation/source/GettingStarted.rst
+++ b/Docs/sphinx_documentation/source/GettingStarted.rst
@@ -42,9 +42,9 @@ first and last statements for the :cpp:`int main(...)` function of every
 program should be calling :cpp:`amrex::Initialize` and :cpp:`amrex::Finalize`,
 respectively. The second statement calls :cpp:`amrex::Print` to print out a
 string that includes the AMReX version returned by the :cpp:`amrex::Version`
-function. The example code includes two AMReX header files. Note that the name
-of all AMReX header files starts with ``AMReX_`` (or just AMReX in the case of
-AMReX.H). All AMReX C++ functions are in the :cpp:`amrex` namespace.
+function. The example code includes two AMReX header files. Note that the name
+of all AMReX header files starts with ``AMReX_`` (or just AMReX in the case of
+AMReX.H). All AMReX C++ functions are in the :cpp:`amrex` namespace.
 
 Building the Code
 -----------------
@@ -52,11 +52,11 @@ Building the Code
 You build the code in the ``amrex/Tutorials/Basic/HelloWorld_C/`` directory.
 Typing ``make`` will start the compilation process and result in an executable
 named ``main3d.gnu.DEBUG.ex``. The name shows that the GNU compiler with debug
-options set by AMReX is used.  It also shows that the executable is built for
+options set by AMReX is used.  It also shows that the executable is built for
 3D. Although this simple example code is dimension independent, dimensionality
 does matter for all non-trivial examples. The build process can be adjusted by
 modifying the ``amrex/Tutorials/Basic/HelloWorld_C/GNUmakefile`` file.  More
-details on how to build AMReX can be found in :ref:`Chap:BuildingAMReX`.
+details on how to build AMReX can be found in :ref:`Chap:BuildingAMReX`.
 
 Running the Code
 ----------------
@@ -81,7 +81,7 @@ The result may look like,
 
 The version string means the current commit 5775aed933c4 (note that the first
 letter g in g577.. is not part of the hash) is based on 17.05 with 30
-additional commits and the AMReX work tree is dirty (i.e. there are uncommitted
+additional commits and the AMReX work tree is dirty (i.e. there are uncommitted
 changes).
 
 In the GNUmakefile there are compilation options for DEBUG mode (less optimized
@@ -113,7 +113,7 @@ The result may look like,
       Hello world from AMReX version 17.05-30-g5775aed933c4-dirty
       AMReX (17.05-30-g5775aed933c4-dirty) finalized
 
-If the compilation fails, you are referred to :ref:`Chap:BuildingAMReX` for
+If the compilation fails, you are referred to :ref:`Chap:BuildingAMReX` for
 more details on how to configure the build system.  The *optional* command line
 argument ``amrex.v=1`` sets the AMReX verbosity level
 to 1 to print the number of MPI processes used.  The default verbosity

--- a/Docs/sphinx_documentation/source/GettingStarted_Chapter.rst
+++ b/Docs/sphinx_documentation/source/GettingStarted_Chapter.rst
@@ -3,7 +3,7 @@ Getting Started
 
 In this chapter, we will walk you through two simple examples. It is assumed
 here that your machine has GNU Make, Python, GCC (including gfortran), and MPI,
-although AMReX can be built with CMake and other compilers.
+although AMReX can be built with CMake and other compilers.
 
 .. toctree::
    :maxdepth: 1

--- a/Docs/sphinx_documentation/source/IO.rst
+++ b/Docs/sphinx_documentation/source/IO.rst
@@ -9,10 +9,10 @@
 Plotfile
 ========
 
-AMReX has its own native plotfile format. Many visualization tools are
-available for AMReX plotfiles (see the chapter on :ref:`Chap:Visualization`). 
-AMReX provides the following two functions for writing a generic AMReX plotfile.
-Many AMReX application codes may have their own plotfile routines that store
+AMReX has its own native plotfile format. Many visualization tools are
+available for AMReX plotfiles (see the chapter on :ref:`Chap:Visualization`). 
+AMReX provides the following two functions for writing a generic AMReX plotfile.
+Many AMReX application codes may have their own plotfile routines that store
 additional information such as compiler options, git hashes of the
 source codes and :cpp:`ParmParse` runtime parameters.
 
@@ -39,7 +39,7 @@ source codes and :cpp:`ParmParse` runtime parameters.
 :cpp:`WriteSingleLevelPlotfile` is for single level runs and
 :cpp:`WriteMultiLevelPlotfile` is for multiple levels. The name of the
 plotfile is specified by the plotfilename argument. This is the
-top level directory name for the plotfile. In AMReX convention, the
+top level directory name for the plotfile. In AMReX convention, the
 plotfile name consist of letters followed by numbers (e.g.,
 plt00258). :cpp:`amrex::Concatenate` is a useful helper function for
 making such strings.
@@ -68,7 +68,7 @@ that level. This involves local data copy in memory and is not
 expected to significantly increase the total wall time for writing
 plotfiles. For the multi-level version, the function expects
 :cpp:`Vector<const MultiFab*>`, whereas the multi-level data are often
-stored as :cpp:`Vector<std::unique_ptr<MultiFab>>`. AMReX has a
+stored as :cpp:`Vector<std::unique_ptr<MultiFab>>`. AMReX has a
 helper function for this and one can use it as follows,
 
 .. highlight:: c++
@@ -87,7 +87,7 @@ associated with the data. For multi-level plotfiles, the argument
 :cpp:`nlevels` is the total number of levels, and we also need to provide
 the refinement ratio via an :cpp:`Vector` of size nlevels-1.
 
-We note that AMReX does not overwrite old plotfiles if the new
+We note that AMReX does not overwrite old plotfiles if the new
 plotfile has the same name. The old plotfiles will be renamed to
 new directories named like plt00350.old.46576787980.
 
@@ -168,7 +168,7 @@ information such as
 the time, the physical domain size, grids, etc. that are necessary for
 restarting the simulation. To guarantee that precision is not lost
 for storing floating point number like time in clear text file, the
-file stream’s precision needs to be set properly. And a stream buffer
+file stream's precision needs to be set properly. And a stream buffer
 can also be used. For example,
 
 .. highlight:: c++

--- a/Docs/sphinx_documentation/source/IO_Chapter.rst
+++ b/Docs/sphinx_documentation/source/IO_Chapter.rst
@@ -5,7 +5,7 @@ I/O (Plotfile, Checkpoint)
 
 
 In this chapter, we will discuss parallel I/O capabilities for mesh
-data in AMReX. The section on :ref:`sec:Particles:IO` will discuss I/O for
+data in AMReX. The section on :ref:`sec:Particles:IO` will discuss I/O for
 particle data.
 
 .. toctree::

--- a/Docs/sphinx_documentation/source/LoadBalancing.rst
+++ b/Docs/sphinx_documentation/source/LoadBalancing.rst
@@ -21,7 +21,7 @@ already assigned to them (assign heaviest set of grids to the least loaded rank)
 Options supported by AMReX include the following; the default is SFC:
 
 - Knapsack: the default weight of a grid in the knapsack algorithm is the number of grid cells, 
-  but AMReX supports the option to pass an array of weights – one per grid – or alternatively 
+  but AMReX supports the option to pass an array of weights -- one per grid -- or alternatively 
   to pass in a MultiFab of weights per cell which is used to compute the weight per grid
 
 - SFC: enumerate grids with a space-filling Z-morton curve, then partition the 

--- a/Docs/sphinx_documentation/source/Particle.rst
+++ b/Docs/sphinx_documentation/source/Particle.rst
@@ -25,8 +25,8 @@ number of extra :cpp:`Real` variables this particle will have (either single or
 double precision [1]_), while the second is the number of extra integer
 variables.  It is important to note that this is the number of *extra* real and
 integer variables; a particle will always have at least :cpp:`BL_SPACEDIM` real
-components that store the particle’s position and 2 integer components that
-store the particle’s :cpp:`id` and :cpp:`cpu` numbers. [2]_
+components that store the particle's position and 2 integer components that
+store the particle's :cpp:`id` and :cpp:`cpu` numbers. [2]_
 
 The particle struct is designed to store these variables in a way that
 minimizes padding, which in practice means that the :cpp:`Real` components
@@ -47,8 +47,8 @@ Setting Particle data
 ---------------------
 
 The :cpp:`Particle` struct provides a number of methods for getting and setting
-a particle’s data. For the required particle components, there are special,
-named methods. For the “extra” real and integer data, you can use the
+a particle's data. For the required particle components, there are special,
+named methods. For the "extra" real and integer data, you can use the
 :cpp:`rdata` and :cpp:`idata` methods, respectively.
 
 .. highlight:: c++
@@ -124,7 +124,7 @@ Struct-of-Arrays as particle *attributes*. See the figure
    integer arrays.  In the tile shown, there are only 2 particles. We have
    labelled the extra real data member of the particle struct to be
    :cpp:`mass`, while the extra integer members of the particle struct are
-   labeled :cpp:`p`, and :cpp:`s`, for “phase” and “state”. The variables in
+   labeled :cpp:`p`, and :cpp:`s`, for "phase" and "state". The variables in
    the real and integer arrays are labelled :cpp:`foo`, :cpp:`bar`, :cpp:`l`,
    and :cpp:`n`, respectively. We have assumed that the particles are double
    precision.
@@ -142,11 +142,11 @@ inefficient, since most of the time you are reading 97 extra variables into
 cache that you will never use. By splitting up the particle variables into
 stuff that gets used all the time (stored in the AoS) and stuff that only gets
 used infrequently (stored in the SoA), you can in principle achieve much better
-cache reuse. Of course, the usage pattern of your application likely won’t be
+cache reuse. Of course, the usage pattern of your application likely won't be
 so clear-cut. Flexibility in how the particle data is stored also makes it
 easier to interface between AMReX and already-existing Fortran subroutines.
 
-Note that while “extra” particle data can be stored in either the SoA or AoS
+Note that while "extra" particle data can be stored in either the SoA or AoS
 style, the particle positions and id numbers are **always** stored in the
 particle structs. This is because these particle variables are special and used
 internally by AMReX to assign the particles to grids and to mark particles as
@@ -180,10 +180,10 @@ Or, if you have multiple levels, you can use following constructor instead:
                            const Vector<BoxArray>            & ba,
                            const Vector<int>                 & rr);
 
-Note the set of grids used to define the :cpp:`ParticleContainer` doesn’t have
-to be the same set used to define the simulation’s mesh data. However, it is
+Note the set of grids used to define the :cpp:`ParticleContainer` doesn't have
+to be the same set used to define the simulation's mesh data. However, it is
 often desirable to have the two hierarchies track each other. If you are using
-an :cpp:`AmrCore` class in your simulation (see the Chapter on
+an :cpp:`AmrCore` class in your simulation (see the Chapter on
 :ref:`Chap:AmrCore`), you can achieve this by using the
 :cpp:`AmrParticleContainer` class. The constructor for this class takes a
 pointer to your AmrCore derived class, instead:
@@ -210,7 +210,7 @@ what happens with mesh data. With mesh data, the tiling is strictly logical;
 the data is laid out in memory the same whether tiling is turned on or off.
 With particle data, however, the particles are actually stored in different
 arrays when tiling is enabled. As with mesh data, the particle tile size can be
-tuned so that an entire tile’s worth of particles will fit into a cache line at
+tuned so that an entire tile's worth of particles will fit into a cache line at
 once.
 
 Once the particles move, their data may no longer be in the right place in the
@@ -280,7 +280,7 @@ conditions for both SoA and AoS data. We loop over all the tiles using
 Often, it makes sense to have each process only generate particles that it
 owns, so that the particles are already in the right place in the container.
 In general, however, users may need to call :cpp:`Redistribute()` after adding
-particles, if the processes generate particles they don’t own (for example, if
+particles, if the processes generate particles they don't own (for example, if
 the particle positions are perturbed from the cell centers and thus end up
 outside their parent grid).
 
@@ -360,7 +360,7 @@ example, to iterate over all the AoS data:
     }
 
 The outer loop will execute once every grid (or tile, if tiling is enabled)
-*that contains particles*; grids or tiles that don’t have any particles will be
+*that contains particles*; grids or tiles that don't have any particles will be
 skipped. You can also access the SoA data using the :math:`ParIter` as follows:
 
 .. highlight:: c++
@@ -504,12 +504,12 @@ mesh refinement, please see ``amrex/Tutorials/Particles/ElectrostaticPIC``.
 Short Range Forces
 ==================
 
-In a PIC calculation, the particles don’t interact with each other directly;
+In a PIC calculation, the particles don't interact with each other directly;
 they only see each other through the mesh. An alternative use case is particles
 that exert short-range forces on each other. In this case, beyond some cut-off
-distance, the particles don’t interact with each other and therefore don’t need
+distance, the particles don't interact with each other and therefore don't need
 to be included in the force calculation. Our approach to these kind of
-particles is to fill “neighbor buffers” on each tile that contain copies of the
+particles is to fill "neighbor buffers" on each tile that contain copies of the
 particles on neighboring tiles that are within some number of cells :math:`N_g`
 of the tile boundaries. See :numref:`fig:particles:neighbor_particles`, below
 for an illustration. By choosing the number of ghost cells to match the
@@ -531,7 +531,7 @@ of each other using a variety of methods.
    calculations. Here, we have a domain consisting of one :math:`32 \times 32`
    grid, broken up into :math:`8 \times 8` tiles. The number of ghost cells is
    taken to be :math:`1`.  For the tile in green, particles on other tiles in
-   the entire shaded region will copied and packed into the green tile’s
+   the entire shaded region will copied and packed into the green tile's
    neighbor buffer. These particles can then be included in the force
    calculation. If the domain is periodic, particles in the grown region for
    the blue tile that lie on the other side of the domain will also be copied,
@@ -623,11 +623,11 @@ mesh data IO. For example:
     pc.Checkpoint("plt00000", "particle0");
 
 
-will create a plot file called “plt00000” and write the mesh data in :cpp:`output` to it, and then write the particle data in a subdirectory called “particle0”. There is also the :cpp:`WriteAsciiFile` method, which writes the particles in a human-readable text format. This is mainly useful for testing and debugging.
+will create a plot file called "plt00000" and write the mesh data in :cpp:`output` to it, and then write the particle data in a subdirectory called "particle0". There is also the :cpp:`WriteAsciiFile` method, which writes the particles in a human-readable text format. This is mainly useful for testing and debugging.
 
 The binary file format is currently readable by :cpp:`yt`. In additional, there is a Python conversion script in 
 ``amrex/Tools/Py_util/amrex_particles_to_vtp`` that can convert both the ASCII and the binary particle files to a 
-format readable by Paraview. See the chapter on :ref:`Chap:Visualization` for more information on visualizing AMReX datasets, including those with particles.
+format readable by Paraview. See the chapter on :ref:`Chap:Visualization` for more information on visualizing AMReX datasets, including those with particles.
 
 Inputs parameters
 =================
@@ -701,4 +701,4 @@ running on GPU platforms like Summit. We recommend leaving it off.
 
 .. [3]
    Note that for the extra particle components, which component refers to which
-   variable is an application-specific convention - the particles have 4 extra real comps, but which one is “mass” is up to the user. We suggest using an :cpp:`enum` to keep these indices straight; please see ``amrex/Tutorials/Particles/ElectrostaticPIC/ElectrosticParticleContainer.H`` for an example of this.
+   variable is an application-specific convention - the particles have 4 extra real comps, but which one is "mass" is up to the user. We suggest using an :cpp:`enum` to keep these indices straight; please see ``amrex/Tutorials/Particles/ElectrostaticPIC/ElectrosticParticleContainer.H`` for an example of this.

--- a/Docs/sphinx_documentation/source/SUNDIALS3.rst
+++ b/Docs/sphinx_documentation/source/SUNDIALS3.rst
@@ -5,22 +5,22 @@
    :language: fortran
 
 
-Compiling AMReX with Sundials version 3.X or later
+Compiling AMReX with Sundials version 3.X or later
 ---------------------------------------------------
 
-The following steps describe how to compile an AMReX application with
+The following steps describe how to compile an AMReX application with
 SUNDIALS_3.X support.  On Cray systems (e.g., Cori or Edison at NERSC), Cray provides
-a system module called ``cray-tpsl`` (“Cray Third-Party Scientific Libraries”)
-which as of this writing contains the 2.7 version of the SUNDIALS solver suite (including
+a system module called ``cray-tpsl`` ("Cray Third-Party Scientific Libraries")
+which as of this writing contains the 2.7 version of the SUNDIALS solver suite (including
 CVODE).  
 
 In order to use the Sundials 3.X version:
 
-#. Obtain the CVODE source code, which is hosted here:
+#. Obtain the CVODE source code, which is hosted here:
    https://computation.llnl.gov/projects/sundials/sundials-software.
-   One can download either the complete SUNDIALS package, or just the CVODE components.
+   One can download either the complete SUNDIALS package, or just the CVODE components.
 
-#. Unpack the CVODE / SUNDIALS tarball, and create a new “build” directory (it
+#. Unpack the CVODE / SUNDIALS tarball, and create a new "build" directory (it
    can be anywhere).
 
 #. Navigate to the new, empty build directory, and type
@@ -56,23 +56,23 @@ In order to use the Sundials 3.X version:
    ``cc`` statement when compiling the source code.  Here one may wish to add
    something like ``"-O2 -g"`` to provide an optimized library that still
    contains debugging symbols; if one neglects debugging symbols in the CVODE
-   library, and if a code that uses CVODE encounters a segmentation fault in
+   library, and if a code that uses CVODE encounters a segmentation fault in
    the solve, then the backtrace has no information about where in the solver
    the error occurred.  Also, if one wishes to compile only the solver library
    itself and not the examples that come with the source (compiling the
    examples is enabled by default), one can add ``"-DEXAMPLES_ENABLE=OFF"``.
-   Users should be aware that the CVODE examples are linked dynamically, so
+   Users should be aware that the CVODE examples are linked dynamically, so
    when compiling the solver library on Cray system using the Cray compiler
    wrappers ``cc``, ``CC``, and ``ftn``, one should explicitly disable
    compiling the examples via the ``"-DEXAMPLES_ENABLE=OFF"`` flag.
 
-#. In the ``GNUmakefile`` for the  application which uses the Fortran 2003
+#. In the ``GNUmakefile`` for the application which uses the Fortran 2003
    interface to CVODE or ARKODE, add ``SUNDIALS_3x4x = TRUE``, which will compile the Fortran 2003
-   interfaces and link the  libraries.  Note that one must define the
+   interfaces and link the libraries.  Note that one must define the
    ``CVODE_LIB_DIR`` environment variable to point to the location where the
    libraries are installed.
 
-#. In the ``GNUmakefile`` for the  application which uses the Fortran 2003
+#. In the ``GNUmakefile`` for the application which uses the Fortran 2003
    interface to ARKODE, also add ``USE_ARKODE_LIBS = TRUE``. It is assumed that the
    ``CVODE_LIB_DIR`` environment variable points to the location where the ARKODE
    libraries are installed as well.
@@ -80,10 +80,10 @@ In order to use the Sundials 3.X version:
 #. Fortran 2003 interfaces for the pgi compilers and for developmental versions of SUNDIALS
    are currently not supported.
 
-SUNDIALS 3.X Tutorials
+SUNDIALS 3.X Tutorials
 -------------------------
 
-AMReX provides six tutorials in the ``amrex/Tutorials/CVODE/SUNDIALS3_finterface`` directory.
+AMReX provides six tutorials in the ``amrex/Tutorials/CVODE/SUNDIALS3_finterface`` directory.
 ``EX1`` is modeled after the CVODE Tutorial ``EX1`` showing use with AMReX.
 The four ``EX_cv_*`` tutorials are based on examples provided with the interface, which
 are more closely modeled after CVODE examples. The ``EX_ark_analytic_fp`` tutorial is based

--- a/Docs/sphinx_documentation/source/Visualization.rst
+++ b/Docs/sphinx_documentation/source/Visualization.rst
@@ -10,7 +10,7 @@ Our favorite visualization tool is Amrvis. We heartily encourage you to build
 the ``amrvis1d``, ``amrvis2d``, and ``amrvis3d`` executables, and to try using
 them to visualize your data. A very useful feature is View/Dataset, which
 allows you to actually view the numbers in a spreadsheet that is nested to
-reflect the AMR hierarchy – this can be handy for debugging. You can modify how
+reflect the AMR hierarchy -- this can be handy for debugging. You can modify how
 many levels of data you want to see, whether you want to see the grid boxes or
 not, what palette you use, etc. Below are some instructions and tips for using
 Amrvis; you can find additional information in Amrvis/Docs/Amrvis.tex (which
@@ -41,10 +41,10 @@ you can build into a pdf using pdflatex).
 
    Then cd into volpack/ and type ``make``.
 
-   Note: Amrvis requires the OSF/Motif libraries and headers. If you don’t have
+   Note: Amrvis requires the OSF/Motif libraries and headers. If you don't have
    these you will need to install the development version of motif through your
    package manager.  ``lesstif`` gives some functionality and will allow you to
-   build the amrvis executable, but Amrvis may exhibit subtle anomalies.
+   build the amrvis executable, but Amrvis may exhibit subtle anomalies.
 
    On most Linux distributions, the motif library is provided by the
    ``openmotif`` package, and its header files (like Xm.h) are provided by
@@ -60,8 +60,8 @@ you can build into a pdf using pdflatex).
        alias amrvis2d /tmp/Amrvis/amrvis2d...ex
 
 #. Run the command ``cp Amrvis/amrvis.defaults ~/.amrvis.defaults``.  Then, in
-   your copy, edit the line containing “palette” line to point to, e.g.,
-   “palette /home/username/Amrvis/Palette”. The other lines control options
+   your copy, edit the line containing "palette" line to point to, e.g.,
+   "palette /home/username/Amrvis/Palette". The other lines control options
    such as the initial field to display, the number format, widow size, etc.
    If there are multiple instances of the same option, the last option takes
    precedence.
@@ -72,11 +72,11 @@ you can build into a pdf using pdflatex).
    plotfile, or for 2D data sets, ``amrvis2d -a plt*``, which will animate the
    sequence of plotfiles. FArrayBoxes and MultiFabs can also be viewed with the
    ``-fab`` and ``-mf`` options. When opening MultiFabs, use the name of the
-   MultiFab’s header file ``amrvis2d -mf MyMultiFab_H``.
+   MultiFab's header file ``amrvis2d -mf MyMultiFab_H``.
 
-   You can use the “Variable” menu to change the variable.
-   You can left-click drag a box around a region and click "View”
-   :math:`\rightarrow` “Dataset” in order to look at the actual numerical
+   You can use the "Variable" menu to change the variable.
+   You can left-click drag a box around a region and click "View"
+   :math:`\rightarrow` "Dataset" in order to look at the actual numerical
    values (see :numref:`Fig:Amrvis`).  Or you can simply left
    click on a point to obtain the numerical value.  You can also export the
    pictures in several different formats under "File/Export".  In 2D you can
@@ -84,7 +84,7 @@ you can build into a pdf using pdflatex).
    center click to change the planes, and the hold shift+(right or center)
    click to get line-out plots.
 
-   We have created a number of routines to convert AMReX plotfile data other
+   We have created a number of routines to convert AMReX plotfile data other
    formats (such as matlab), but in order to properly interpret the
    hierarchical AMR data, each tends to have its own idiosyncrasies. If you
    would like to display the data in another format, please contact Marc Day
@@ -127,29 +127,29 @@ dependencies are installed in the locations that Homebrew uses. Namely the
 VisIt
 =====
 
-AMReX data can also be visualized by VisIt, an open source visualization and
+AMReX data can also be visualized by VisIt, an open source visualization and
 analysis software. To follow along with this example, first build and run the
 first heat equation tutorial code (see the section on :ref:`sec:heat
 equation`).
 
 Next, download and install VisIt from
 https://wci.llnl.gov/simulation/computer-codes/visit.  To open a single
-plotfile, run VisIt, then select “File” :math:`\rightarrow` “Open file ...”,
+plotfile, run VisIt, then select "File" :math:`\rightarrow` "Open file ...",
 then select the Header file associated the the plotfile of interest (e.g.,
 plt00000/Header).  Assuming you ran the simulation in 2D, here are instructions
 for making a simple plot:
 
--  To view the data, select “Add” :math:`\rightarrow` “Pseudocolor”
-   :math:`\rightarrow` “phi”, and then select “Draw”.
+-  To view the data, select "Add" :math:`\rightarrow` "Pseudocolor"
+   :math:`\rightarrow` "phi", and then select "Draw".
 
 -  To view the grid structure (not particularly interesting yet, but when we
-   add AMR it will be), select “Add” :math:`\rightarrow` “Subset”
-   :math:`\rightarrow` “levels”. Then double-click the text “Subset - levels”,
-   enable the “Wireframe” option, select “Apply”, select “Dismiss”, and then
-   select “Draw”.
+   add AMR it will be), select "Add" :math:`\rightarrow` "Subset"
+   :math:`\rightarrow` "levels". Then double-click the text "Subset - levels",
+   enable the "Wireframe" option, select "Apply", select "Dismiss", and then
+   select "Draw".
 
--  To save the image, select “File” :math:`\rightarrow` “Set save options”,
-   then customize the image format to your liking, then click “Save”.
+-  To save the image, select "File" :math:`\rightarrow` "Set save options",
+   then customize the image format to your liking, then click "Save".
 
 Your image should look similar to the left side of :numref:`Fig:VisIt`.
 
@@ -176,8 +176,8 @@ Your image should look similar to the left side of :numref:`Fig:VisIt`.
 
    \end{center}
 
-In 3D, you must apply the “Operators” :math:`\rightarrow` “Slicing”
-:math:`\rightarrow` “ThreeSlice”, with the “ThreeSlice operator attribute” set
+In 3D, you must apply the "Operators" :math:`\rightarrow` "Slicing"
+:math:`\rightarrow` "ThreeSlice", with the "ThreeSlice operator attribute" set
 to ``x=0.25``, ``y=0.25``, and ``z=0.25``. You can left-click and drag over the
 image to rotate the image to generate something similar to right side of
 :numref:`Fig:VisIt`.
@@ -203,10 +203,10 @@ done using the command:
     plt09000/Header
     plt10000/Header
 
-The next step is to run VisIt, select “File” :math:`\rightarrow` “Open file
-...”, then select movie.visit. Create an image to your liking and press the
-“play” button on the VCR-like control panel to preview all the frames. To save
-the movie, choose “File” :math:`\rightarrow` “Save movie ...”, and follow the
+The next step is to run VisIt, select "File" :math:`\rightarrow` "Open file...",
+then select movie.visit. Create an image to your liking and press the
+"play"  button on the VCR-like control panel to preview all the frames. To save
+the movie, choose "File" :math:`\rightarrow` "Save movie ...", and follow the
 on-screen instructions.
 
 Caveat: 
@@ -228,33 +228,33 @@ and print the value for "Cycle".  (It will still read and display the data itsel
 ParaView
 ========
 
-The open source visualization package ParaView v5.7 and later can be used to view 2D and 3D
+The open source visualization package ParaView v5.7 and later can be used to view 2D and 3D
 plotfiles, as well as particles data. Download the package at
 https://www.paraview.org/.
 
 To open a plotfile (for example, you could run the
 ``HeatEquation_EX1_C`` in 3D):
 
-#. Run ParaView v5.7, then select “File” :math:`\rightarrow` “Open”.
+#. Run ParaView v5.7, then select "File" :math:`\rightarrow` "Open".
 
 #. Navigate to your run directory, and select the fluid or particle plotfile.
    Note that you can either open single/multiple plotfile(s) at once by selecting
    them one by one or select an ensemble of file, labelled as ``plt..`` and indicated
    as a Group in the "Type" column of the file explorer (see :numref:`fig:ParaView_filegroup`).
    In the later case, Paraview will load the plotfiles as a time series.
-   ParaView will ask you about the file type – choose “AMReX/BoxLib Grid Reader" or
-   "AMReX/BoxLib Particles Reader”.
+   ParaView will ask you about the file type -- choose "AMReX/BoxLib Grid Reader" or
+   "AMReX/BoxLib Particles Reader".
 
-#. Under the “Cell Arrays” field, select a variable (e.g., “phi”) and click
-   “Apply”. Note that the default number of refinement levels loaded and vizualized is 1.
-   Change to the required number of AMR level before clicking “Apply”.
+#. Under the "Cell Arrays" field, select a variable (e.g., "phi") and click
+   "Apply". Note that the default number of refinement levels loaded and vizualized is 1.
+   Change to the required number of AMR level before clicking "Apply".
 
-#. Under “Representation” select “Surface”.
+#. Under "Representation" select "Surface".
 
-#. Under “Coloring” select the variable you chose above.
+#. Under "Coloring" select the variable you chose above.
 
 #. To add planes, near the top left you will see a cube icon with a green plane
-   slicing through it. If you hover your mouse over it, it will say “Slice”.
+   slicing through it. If you hover your mouse over it, it will say "Slice".
    Click that button.
 
 #. You can play with the Plane Parameters to define a plane of data to view, as
@@ -277,7 +277,7 @@ To open a plotfile (for example, you could run the
 
 Note that Paraview is not able to generate iso-surfaces from cell centered data. To build an iso-surface (or iso-line in 2D):
 
-#. Perform a cell to node interpolation: “Filters” :math:`\rightarrow` “Alphabetical” :math:`\rightarrow` "Cell Data to Point Data".
+#. Perform a cell to node interpolation: "Filters" :math:`\rightarrow` "Alphabetical" :math:`\rightarrow` "Cell Data to Point Data".
 
 #. Use the "Contour" icon (next to the calculator) to select the data from which to build the contour ("Contour by"), enters the iso-surfaces
    values and click "Apply".
@@ -300,17 +300,17 @@ run the ``ShortRangeParticles`` example):
 
    \end{center}
 
-#. Run ParaView v5.7, and select  then  “File” :math:`\rightarrow` “Open”. You
-   will see a combined “plt..” group. Click on “+” to expand the group, if you
+#. Run ParaView v5.7, and select  then  "File" :math:`\rightarrow` "Open". You
+   will see a combined "plt.." group. Click on "+" to expand the group, if you
    want inspect the files in the group. You can select an individual plotfile
    directory or select a group of directories to read them a time series, as
-   shown in :numref:`fig:ParaView_filegroup`, and click OK. ParaView will ask you about the file type – choose "AMReX/BoxLib Particles Reader".
+   shown in :numref:`fig:ParaView_filegroup`, and click OK. ParaView will ask you about the file type -- choose "AMReX/BoxLib Particles Reader".
 
-#. The “Properties” panel in ParaView allows you to specify the “Particle
-   Type”, which defaults to “particles”. Using the “Properties” panel, you can
+#. The "Properties" panel in ParaView allows you to specify the "Particle
+   Type", which defaults to "particles". Using the "Properties" panel, you can
    also choose which point arrays to read.
 
-#. Click “Apply” and under “Representation” select “Point Gaussian”.
+#. Click "Apply" and under "Representation" select "Point Gaussian".
 
 #. Change the Gaussian Radius if you like. You can scroll through the frames
    with the VCR-like controls at the top, as shown in
@@ -349,21 +349,21 @@ yt
 
 yt, an open source Python package available at http://yt-project.org/, can be
 used for analyzing and visualizing mesh and particle data generated by
-AMReX codes. Some of the AMReX developers are also yt project members.  Below
-we describe how to use  on both a local workstation, as well as at the NERSC
+AMReX codes. Some of the AMReX developers are also yt project members.  Below
+we describe how to use on both a local workstation, as well as at the NERSC
 HPC facility for high-throughput visualization of large data sets.
 
 Note - AMReX datasets require yt version 3.4 or greater.
 
-Using  on a local workstation
+Using on a local workstation
 -----------------------------
 
-Running yt on a local system generally provides good interactivity, but limited
+Running yt on a local system generally provides good interactivity, but limited
 performance. Consequently, this configuration is best when doing exploratory
 visualization (e.g., experimenting with camera angles, lighting, and color
 schemes) of small data sets.
 
-To use yt on an AMReX plot file, first start a Jupyter notebook or an IPython
+To use yt on an AMReX plot file, first start a Jupyter notebook or an IPython
 kernel, and import the ``yt`` module:
 
 .. highlight:: python
@@ -485,27 +485,27 @@ The output of this is :numref:`fig:yt_Nyx_vol_rend`.
    :numref:`fig:yt_Nyx_slice_plot`.
 
 
-Using yt at NERSC (*under development*)
+Using yt at NERSC (*under development*)
 ---------------------------------------
 
-Because yt is Python-based, it is portable and can be used in many software
-environments. Here we focus on yt’s capabilities at NERSC, which provides
+Because yt is Python-based, it is portable and can be used in many software
+environments. Here we focus on yt's capabilities at NERSC, which provides
 resources for performing both interactive and batch queue-based visualization
-and analysis of AMReX data. Coupled with yt’s MPI and OpenMP parallelization
+and analysis of AMReX data. Coupled with yt's MPI and OpenMP parallelization
 capabilities, this can enable high-throughput visualization and analysis
 workflows.
 
-Interactive yt with Jupyter notebooks
+Interactive yt with Jupyter notebooks
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Unlike VisIt (see the section on :ref:`sec:visit`), yt has no client-server
+Unlike VisIt (see the section on :ref:`sec:visit`), yt has no client-server
 interface. Such an interface is often crucial when one has large data sets
 generated on a remote system, but wishes to visualize the data on a local
 workstation. Both copying the data between the two systems, as well as
 visualizing the data itself on a workstation, can be prohibitively slow.
 
 Fortunately, NERSC has implemented several resources which allow one to
-interact with yt remotely, emulating a client-server model. In particular,
+interact with yt remotely, emulating a client-server model. In particular,
 NERSC now hosts Jupyter notebooks which run IPython kernels on the Cori system;
 this provides users access to the ``$HOME``, ``/project``, and ``$SCRATCH``
 file systems from a web browser-based Jupyter notebook.  ***Please note that
@@ -513,7 +513,7 @@ Jupyter hosting at NERSC is still under development, and the environment may
 change without notice.***
 
 NERSC also provides Anaconda Python, which allows users to create their own
-customizable Python environments. It is recommended to install yt in such an
+customizable Python environments. It is recommended to install yt in such an
 environment. One can do so with the following example:
 
 .. highlight:: console
@@ -534,30 +534,30 @@ https://ipython.nersc.gov, and on https://jupyter-dev.nersc.gov.  The latter
 likely reflects what the stable, production environment for Jupyter notebooks
 will look like at NERSC, but it is still under development and subject to
 change. To load this custom Python kernel in a Jupyter notebook, follow the
-instructions at this URL under the “Custom Kernels” heading:
+instructions at this URL under the "Custom Kernels" heading:
 http://www.nersc.gov/users/data-analytics/data-analytics/web-applications-for-data-analytics.
 After writing the appropriate ``kernel.json`` file, the custom kernel will
 appear as an available Jupyter notebook. Then one can interactively visualize
-AMReX plot files in the web browser. [1]_
+AMReX plot files in the web browser. [1]_
 
 Parallel
 ~~~~~~~~
 
 Besides the benefit of no longer needing to move data back and forth between
-NERSC and one’s local workstation to do visualization and analysis, an
-additional feature of yt which takes advantage of the computational resources
-at NERSC is its parallelization capabilities. yt supports both MPI- and
+NERSC and one's local workstation to do visualization and analysis, an
+additional feature of yt which takes advantage of the computational resources
+at NERSC is its parallelization capabilities. yt supports both MPI- and
 OpenMP-based parallelization of various tasks, which are discussed here:
 http://yt-project.org/doc/analyzing/parallel_computation.html.
 
-Configuring yt for MPI parallelization at NERSC is a more complex task than
-discussed in the official yt documentation; the command ``pip install mpi4py``
+Configuring yt for MPI parallelization at NERSC is a more complex task than
+discussed in the official yt documentation; the command ``pip install mpi4py``
 is not sufficient. Rather, one must compile ``mpi4py`` from source using the
 Cray compiler wrappers ``cc``, ``CC``, and ``ftn`` on Cori. Instructions for
 compiling ``mpi4py`` at NERSC are provided here:
 http://www.nersc.gov/users/data-analytics/data-analytics/python/anaconda-python/#toc-anchor-3.
 After ``mpi4py`` has been compiled, one can use the regular Python interpreter
-in the Anaconda environment as normal; when executing yt operations which
+in the Anaconda environment as normal; when executing yt operations which
 support MPI parallelization, the multiple MPI processes will spawn
 automatically.
 
@@ -566,15 +566,15 @@ particularly useful:
 
 - **Time series analysis.** Often one runs a simulation for many time steps
   and periodically writes plot files to disk for visualization and
-  post-processing. yt supports parallelization over time series data via the
-  ``DatasetSeries`` object. yt can iterate over a ``DatasetSeries`` in
+  post-processing. yt supports parallelization over time series data via the
+  ``DatasetSeries`` object. yt can iterate over a ``DatasetSeries`` in
   parallel, with different MPI processes operating on different elements of the
   series. This page provides more documentation:
   http://yt-project.org/doc/analyzing/time_series_analysis.html#time-series-analysis.
 
-- **Volume rendering**. yt implements spatial decomposition among MPI
+- **Volume rendering**. yt implements spatial decomposition among MPI
   processes for volume rendering procedures, which can be computationally
-  expensive. Note that yt also implements OpenMP parallelization in volume
+  expensive. Note that yt also implements OpenMP parallelization in volume
   rendering, and so one can execute volume rendering with a hybrid MPI+OpenMP
   approach. See this URL for more detail:
   http://yt-project.org/doc/visualizing/volume_rendering.html?highlight=openmp#openmp-parallelization.
@@ -584,11 +584,11 @@ particularly useful:
   translational or rotational operations on a camera to make a volume rendering
   in which the field of view moves through the simulation. In this case, one is
   applying a set of operations on a single object (a single plot file), rather
-  than over a time series of data. For this workflow, yt provides the
+  than over a time series of data. For this workflow, yt provides the
   ``parallel_objects()`` function. See this URL for more details:
   http://yt-project.org/doc/analyzing/parallel_computation.html#parallelizing-over-multiple-objects.
 
-   An example of MPI parallelization in yt is shown below, where one animates a
+   An example of MPI parallelization in yt is shown below, where one animates a
    time series of plot files from an IAMR simulation while revolving the camera
    such that it completes two full revolutions over the span of the animation:
 

--- a/Docs/sphinx_documentation/source/Visualization_Chapter.rst
+++ b/Docs/sphinx_documentation/source/Visualization_Chapter.rst
@@ -3,11 +3,11 @@
 Visualization
 =============
 
-There are several visualization tools that can be used for AMReX plotfiles. The
+There are several visualization tools that can be used for AMReX plotfiles. The
 standard tool used within the AMReX-community is Amrvis, a package developed
 and supported by CCSE that is designed specifically for highly efficient
 visualization of block-structured hierarchical AMR data. Plotfiles can also be
-viewed using the VisIt, ParaView, and yt packages. Particle data can be viewed
+viewed using the VisIt, ParaView, and yt packages. Particle data can be viewed
 using ParaView.
 
 

--- a/Docs/sphinx_tutorials/source/CVODE_Tutorial.rst
+++ b/Docs/sphinx_tutorials/source/CVODE_Tutorial.rst
@@ -7,10 +7,10 @@
 Tutorials/CVODE
 ==========================
 
-There are two CVODE tutorials in the ``amrex/Tutorials/CVODE`` directory, called
+There are two CVODE tutorials in the ``amrex/Tutorials/CVODE`` directory, called
 ``EX1`` and ``EX2``.  ``EX1`` consists of a single ODE that is integrated with
-CVODE within each cell of a 3-D grid.  It demonstrates how to initialize the
-CVODE solver, how to call the ODE right-hand-side (RHS), and, more importantly,
+CVODE within each cell of a 3-D grid.  It demonstrates how to initialize the
+CVODE solver, how to call the ODE right-hand-side (RHS), and, more importantly,
 how to *re-*\ initialize the solver between cells, which avoids allocating and
 freeing solver memory between each cell (see the call to ``FCVReInit()`` in the
 ``integrate_ode.f90`` file in the ``EX1`` directory.)
@@ -19,11 +19,11 @@ The ``EX2`` example demonstrates the slightly more complicated case of
 integrating a system of coupled ODEs within each cell.  Similarly to ``EX1``,
 it provides an RHS and some solver initialization.  However, it also
 demonstrates the performance effect of providing an analytic Jacobian matrix
-for the system of ODEs, rather than requiring the  solver to compute the
+for the system of ODEs, rather than requiring the solver to compute the
 Jacobian matrix numerically using a finite-difference approach.  The tutorial
 integrates the same system of ODEs on the same 3-D grid, but in one sweep it
-instructs CVODE to use the analytic function that computes the Jacobian matrix,
-and in the other case, it does not, which requires CVODE to compute it
+instructs CVODE to use the analytic function that computes the Jacobian matrix,
+and in the other case, it does not, which requires CVODE to compute it
 manually.  One observes a significant performance gain by providing the
 analytic Jacobian function.
 

--- a/Src/Extern/SWFFT/AlignedAllocator.h
+++ b/Src/Extern/SWFFT/AlignedAllocator.h
@@ -22,7 +22,7 @@
  *   1. Redistributions of source code must retain the above copyright notice,
  *      this list of conditions and the following disclaimer. Software changes,
  *      modifications, or derivative works, should be noted with comments and
- *      the author and organization’s name.
+ *      the author and organization's name.
  *
  *   2. Redistributions in binary form must reproduce the above copyright
  *      notice, this list of conditions and the following disclaimer in the

--- a/Src/Extern/SWFFT/COPYING
+++ b/Src/Extern/SWFFT/COPYING
@@ -21,7 +21,7 @@ modification, are permitted provided that the following conditions are met:
   1. Redistributions of source code must retain the above copyright notice,
      this list of conditions and the following disclaimer. Software changes,
      modifications, or derivative works, should be noted with comments and the
-     author and organization’s name.
+     author and organization's name.
 
   2. Redistributions in binary form must reproduce the above copyright notice,
      this list of conditions and the following disclaimer in the documentation

--- a/Src/Extern/SWFFT/CheckDecomposition.c
+++ b/Src/Extern/SWFFT/CheckDecomposition.c
@@ -22,7 +22,7 @@
  *   1. Redistributions of source code must retain the above copyright notice,
  *      this list of conditions and the following disclaimer. Software changes,
  *      modifications, or derivative works, should be noted with comments and
- *      the author and organization’s name.
+ *      the author and organization's name.
  *
  *   2. Redistributions in binary form must reproduce the above copyright
  *      notice, this list of conditions and the following disclaimer in the

--- a/Src/Extern/SWFFT/Dfft.H
+++ b/Src/Extern/SWFFT/Dfft.H
@@ -22,7 +22,7 @@
  *   1. Redistributions of source code must retain the above copyright notice,
  *      this list of conditions and the following disclaimer. Software changes,
  *      modifications, or derivative works, should be noted with comments and
- *      the author and organization’s name.
+ *      the author and organization's name.
  *
  *   2. Redistributions in binary form must reproduce the above copyright
  *      notice, this list of conditions and the following disclaimer in the

--- a/Src/Extern/SWFFT/DfftC.cpp
+++ b/Src/Extern/SWFFT/DfftC.cpp
@@ -22,7 +22,7 @@
  *   1. Redistributions of source code must retain the above copyright notice,
  *      this list of conditions and the following disclaimer. Software changes,
  *      modifications, or derivative works, should be noted with comments and
- *      the author and organization’s name.
+ *      the author and organization's name.
  *
  *   2. Redistributions in binary form must reproduce the above copyright
  *      notice, this list of conditions and the following disclaimer in the

--- a/Src/Extern/SWFFT/Distribution.H
+++ b/Src/Extern/SWFFT/Distribution.H
@@ -22,7 +22,7 @@
  *   1. Redistributions of source code must retain the above copyright notice,
  *      this list of conditions and the following disclaimer. Software changes,
  *      modifications, or derivative works, should be noted with comments and
- *      the author and organization’s name.
+ *      the author and organization's name.
  *
  *   2. Redistributions in binary form must reproduce the above copyright
  *      notice, this list of conditions and the following disclaimer in the

--- a/Src/Extern/SWFFT/DistributionC.cpp
+++ b/Src/Extern/SWFFT/DistributionC.cpp
@@ -22,7 +22,7 @@
  *   1. Redistributions of source code must retain the above copyright notice,
  *      this list of conditions and the following disclaimer. Software changes,
  *      modifications, or derivative works, should be noted with comments and
- *      the author and organization’s name.
+ *      the author and organization's name.
  *
  *   2. Redistributions in binary form must reproduce the above copyright
  *      notice, this list of conditions and the following disclaimer in the

--- a/Src/Extern/SWFFT/Error.h
+++ b/Src/Extern/SWFFT/Error.h
@@ -22,7 +22,7 @@
  *   1. Redistributions of source code must retain the above copyright notice,
  *      this list of conditions and the following disclaimer. Software changes,
  *      modifications, or derivative works, should be noted with comments and
- *      the author and organization’s name.
+ *      the author and organization's name.
  *
  *   2. Redistributions in binary form must reproduce the above copyright
  *      notice, this list of conditions and the following disclaimer in the

--- a/Src/Extern/SWFFT/TimingStats.h
+++ b/Src/Extern/SWFFT/TimingStats.h
@@ -22,7 +22,7 @@
  *   1. Redistributions of source code must retain the above copyright notice,
  *      this list of conditions and the following disclaimer. Software changes,
  *      modifications, or derivative works, should be noted with comments and
- *      the author and organization’s name.
+ *      the author and organization's name.
  *
  *   2. Redistributions in binary form must reproduce the above copyright
  *      notice, this list of conditions and the following disclaimer in the

--- a/Src/Extern/SWFFT/complex-type.h
+++ b/Src/Extern/SWFFT/complex-type.h
@@ -22,7 +22,7 @@
  *   1. Redistributions of source code must retain the above copyright notice,
  *      this list of conditions and the following disclaimer. Software changes,
  *      modifications, or derivative works, should be noted with comments and
- *      the author and organization’s name.
+ *      the author and organization's name.
  *
  *   2. Redistributions in binary form must reproduce the above copyright
  *      notice, this list of conditions and the following disclaimer in the

--- a/Src/Extern/SWFFT/distribution.c
+++ b/Src/Extern/SWFFT/distribution.c
@@ -22,7 +22,7 @@
  *   1. Redistributions of source code must retain the above copyright notice,
  *      this list of conditions and the following disclaimer. Software changes,
  *      modifications, or derivative works, should be noted with comments and
- *      the author and organization’s name.
+ *      the author and organization's name.
  *
  *   2. Redistributions in binary form must reproduce the above copyright
  *      notice, this list of conditions and the following disclaimer in the

--- a/Src/Extern/SWFFT/distribution_c.h
+++ b/Src/Extern/SWFFT/distribution_c.h
@@ -22,7 +22,7 @@
  *   1. Redistributions of source code must retain the above copyright notice,
  *      this list of conditions and the following disclaimer. Software changes,
  *      modifications, or derivative works, should be noted with comments and
- *      the author and organization’s name.
+ *      the author and organization's name.
  *
  *   2. Redistributions in binary form must reproduce the above copyright
  *      notice, this list of conditions and the following disclaimer in the

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -124,7 +124,7 @@ AMReX provides data structures and iterators for performing data-parallel partic
 The approach is particularly suited to particles that interact with data defined on a (possibly adaptive) 
 block-structured hierarchy of meshes. Example applications include those that use Particle-in-Cell (PIC) methods, 
 Lagrangian tracers, or solid particles that exchange momentum with the surrounding fluid through drag forces.
-AMReX’s particle implementation allows users flexibility in specifying how the particle data 
+AMReX's particle implementation allows users flexibility in specifying how the particle data 
 is laid out in memory and in choosing how to optimize parallel communication of particle data. 
 
 ### Complex Geometries
@@ -137,7 +137,7 @@ values in the valid domain are computed.  Examples are provided in the tutorials
 
 ### Parallelism
 
-AMReX’s GPU strategy focuses on providing performant GPU support with 
+AMReX's GPU strategy focuses on providing performant GPU support with 
 minimal changes to AMReX-based application codes and maximum flexibility. 
 This allows application teams to get running on GPUs quickly while allowing 
 long term performance tuning and programming model selection. 


### PR DESCRIPTION
Removes all of the non-ASCII characters (and fixes a small warning in GPU.rst).

You can't see them... but I can!

grep -n -r --color='auto' -P -n "[\x80-\xFF]" *