### PR TITLE
add synchronize statements to UpdateNeighbors

### DIFF
--- a/Src/Particle/AMReX_NeighborParticlesGPUImpl.H
+++ b/Src/Particle/AMReX_NeighborParticlesGPUImpl.H
@@ -264,9 +264,11 @@ updateNeighborsGPU ()
     }
     else
     {
+        Gpu::Device::synchronize();
         pinned_snd_buffer.resize(snd_buffer.size());
         Gpu::dtoh_memcpy_async(pinned_snd_buffer.dataPtr(), snd_buffer.dataPtr(), snd_buffer.size());
         neighbor_copy_plan.buildMPIFinish(this->BufferMap());
+        Gpu::Device::synchronize();
         communicateParticlesStart(*this, neighbor_copy_plan, pinned_snd_buffer, pinned_rcv_buffer);
         rcv_buffer.resize(pinned_rcv_buffer.size());
         unpackBuffer(*this, neighbor_copy_plan, snd_buffer, NeighborUnpackPolicy());
@@ -274,6 +276,8 @@ updateNeighborsGPU ()
         Gpu::htod_memcpy_async(rcv_buffer.dataPtr(), pinned_rcv_buffer.dataPtr(), pinned_rcv_buffer.size());
         unpackRemotes(*this, neighbor_copy_plan, rcv_buffer, NeighborUnpackPolicy());
     }
+
+    Gpu::Device::synchronize();
 }
 
 template <int NStructReal, int NStructInt>


### PR DESCRIPTION
These were needed in the corresponding code in `Redistribute()`, so they should be needed here too. 