### PR TITLE
Fix sign-compare warnings

### DIFF
--- a/Src/Particle/AMReX_NeighborList.H
+++ b/Src/Particle/AMReX_NeighborList.H
@@ -142,7 +142,7 @@ public:
                 for (int jj = amrex::max(iy-num_cells, 0); jj <= amrex::min(iy+num_cells, ny-1); ++jj) {
                     for (int kk = amrex::max(iz-num_cells, 0); kk <= amrex::min(iz+num_cells, nz-1); ++kk) {
                         int index = (ii * ny + jj) * nz + kk;
-                        for (int p = poffset[index]; p < poffset[index+1]; ++p) {
+                        for (auto p = poffset[index]; p < poffset[index+1]; ++p) {
                             if (pperm[p] == i) continue;
                             if (check_pair(pstruct_ptr[i], pstruct_ptr[pperm[p]]))
                                 count += 1;
@@ -183,7 +183,7 @@ public:
                 for (int jj = amrex::max(iy-num_cells, 0); jj <= amrex::min(iy+num_cells, ny-1); ++jj) {
                     for (int kk = amrex::max(iz-num_cells, 0); kk <= amrex::min(iz+num_cells, nz-1); ++kk) {
                         int index = (ii * ny + jj) * nz + kk;
-                        for (int p = poffset[index]; p < poffset[index+1]; ++p) {
+                        for (auto p = poffset[index]; p < poffset[index+1]; ++p) {
                             if (pperm[p] == i) continue;
                             if (check_pair(pstruct_ptr[i], pstruct_ptr[pperm[p]])) {
                                 pm_nbor_list[pnbor_offset[i] + n] = pperm[p]; 

--- a/Src/Particle/AMReX_NeighborParticlesCPUImpl.H
+++ b/Src/Particle/AMReX_NeighborParticlesCPUImpl.H
@@ -284,7 +284,7 @@ NeighborParticleContainer<NStructReal, NStructInt>
 #ifdef _OPENMP
 #pragma omp parallel for
 #endif
-                for (unsigned i = 0; i < num_tags; ++i) {
+                for (int i = 0; i < num_tags; ++i) {
                     const NeighborCopyTag& tag = tags[i];
                     const int who = this->ParticleDistributionMap(tag.level)[tag.grid];
                     ParticleType p = particles[tag.src_index];  // copy

--- a/Src/Particle/AMReX_NeighborParticlesI.H
+++ b/Src/Particle/AMReX_NeighborParticlesI.H
@@ -1,4 +1,3 @@
-
 template <int NStructReal, int NStructInt>
 bool NeighborParticleContainer<NStructReal, NStructInt>::use_mask = false;
 
@@ -352,7 +351,7 @@ NeighborParticleContainer<NStructReal, NStructInt>
                 auto& cache = buffer_tag_cache[lev][src_index][thread_num];
 
                 auto& particles = pti.GetArrayOfStructs();
-                for (unsigned i = 0; i < pti.numParticles(); ++i) {
+                for (int i = 0; i < pti.numParticles(); ++i) {
                     const ParticleType& p = particles[i];
 
                     getNeighborTags(tags, p, m_num_neighbor_cells, src_tag, pti);
@@ -722,7 +721,7 @@ buildNeighborList (CheckPair check_pair, bool sort)
             {
                 auto cnt = counts[i];
                 neighbor_list[lev][index].push_back(cnt);
-                for (int j = 0; j < cnt; ++j)
+                for (size_t j = 0; j < cnt; ++j)
                 {
                     neighbor_list[lev][index].push_back(list[li++]+1);
                 }

--- a/Src/Particle/AMReX_ParticleTile.H
+++ b/Src/Particle/AMReX_ParticleTile.H
@@ -466,10 +466,10 @@ struct ParticleTile
 
     ConstParticleTileDataType getConstParticleTileData () const
     {
-        for (int i = 0; i < m_runtime_r_ptrs.size(); ++i) {
+        for (size_t i = 0; i < m_runtime_r_ptrs.size(); ++i) {
             m_runtime_r_cptrs[i] = m_soa_tile.GetRealData(NArrayReal + i).dataPtr();
         }
-        for (int i = 0; i < m_runtime_i_ptrs.size(); ++i) 
+        for (size_t i = 0; i < m_runtime_i_ptrs.size(); ++i)
             m_runtime_i_cptrs[i] = m_soa_tile.GetIntData(NArrayInt + i).dataPtr();
 
         ConstParticleTileDataType ptd;


### PR DESCRIPTION
Using `-Werror=sign-compare` with GCC 9.3.0

Example:
```
Src/Particle/AMReX_ParticleTile.H:469:27: error: comparison of integer expressions of different signedness: 'int' and 'amrex::PODVector<double*, std::allocator<double*> >::size_type' {aka 'long unsigned int'} [-Werror=sign-compare]
  469 |         for (int i = 0; i < m_runtime_r_ptrs.size(); ++i) {
      |                         ~~^~~~~~~~~~~~~~~~~~~~~~~~~
Src/Particle/AMReX_ParticleTile.H:472:27: error: comparison of integer expressions of different signedness: 'int' and 'amrex::PODVector<int*, std::allocator<int*> >::size_type' {aka 'long unsigned int'} [-Werror=sign-compare]
  472 |         for (int i = 0; i < m_runtime_i_ptrs.size(); ++i)
      |                         ~~^~~~~~~~~~~~~~~~~~~~~~~~~
```