### PR TITLE
CMake: do not set Fortran properties when Fortran is disabled.

### DIFF
--- a/Src/CMakeLists.txt
+++ b/Src/CMakeLists.txt
@@ -9,21 +9,23 @@ add_library( amrex )
 add_library( AMReX::amrex ALIAS amrex )
 
 # Where to store Fortran modules
-set_target_properties( amrex
-   PROPERTIES
-   Fortran_MODULE_DIRECTORY
-   ${PROJECT_BINARY_DIR}/mod_files
-   INTERFACE_INCLUDE_DIRECTORIES
-   $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/mod_files>
-   )
-# adding those is a work-around that avoids that downstream C++ projects have
-# to `enable_language(Fortran)`
-target_link_libraries(amrex PUBLIC ${CMAKE_Fortran_IMPLICIT_LINK_LIBRARIES})
+if (CMAKE_Fortran_COMPILER_LOADED)
+   set_target_properties( amrex
+      PROPERTIES
+      Fortran_MODULE_DIRECTORY
+      ${PROJECT_BINARY_DIR}/mod_files
+      INTERFACE_INCLUDE_DIRECTORIES
+      $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/mod_files>
+      )
+   # adding those is a work-around that avoids that downstream C++ projects have
+   # to `enable_language(Fortran)`
+   target_link_libraries(amrex PUBLIC ${CMAKE_Fortran_IMPLICIT_LINK_LIBRARIES})
+endif ()
 
 # Load Flags targets and use them if no user-defined flags is given
 include(AMReXFlagsTargets)
 
-if (NOT CMAKE_Fortran_FLAGS)
+if (CMAKE_Fortran_COMPILER_LOADED AND (NOT CMAKE_Fortran_FLAGS) )
    target_link_libraries(amrex
       PUBLIC
       $<BUILD_INTERFACE:Flags_Fortran>


### PR DESCRIPTION
In particular, do not specify Fortran module files path when
Fortran is off, else superbuilds will fail.