### PR TITLE
updates for SENSEI 3.2 release

### DIFF
--- a/Src/Extern/SENSEI/AMReX_AmrDataAdaptor.H
+++ b/Src/Extern/SENSEI/AMReX_AmrDataAdaptor.H
@@ -6,7 +6,6 @@
 
 namespace amrex
 {
-
 class AmrDataAdaptor : public sensei::DataAdaptor
 {
 public:
@@ -21,15 +20,19 @@ public:
 
   // SENSEI API
   int GetNumberOfMeshes(unsigned int &numMeshes) override;
+#if SENSEI_VERSION_MAJOR >= 3
+  int GetMeshMetadata(unsigned int id, sensei::MeshMetadataPtr &metadata) override;
+#else
   int GetMeshName(unsigned int id, std::string &meshName) override;
-  int GetMesh(const std::string &meshName, bool structureOnly, vtkDataObject *&mesh) override;
   int GetMeshHasGhostNodes(const std::string &meshName, int &nLayers) override;
-  int AddGhostNodesArray(vtkDataObject* mesh, const std::string &meshName) override;
   int GetMeshHasGhostCells(const std::string &meshName, int &nLayers) override;
-  int AddGhostCellsArray(vtkDataObject* mesh, const std::string &meshName) override;
-  int AddArray(vtkDataObject* mesh, const std::string &meshName, int association, const std::string &arrayName) override;
   int GetNumberOfArrays(const std::string &meshName, int association, unsigned int &numberOfArrays) override;
   int GetArrayName(const std::string &meshName, int association, unsigned int index, std::string &arrayName) override;
+#endif
+  int GetMesh(const std::string &meshName, bool structureOnly, vtkDataObject *&mesh) override;
+  int AddGhostNodesArray(vtkDataObject* mesh, const std::string &meshName) override;
+  int AddGhostCellsArray(vtkDataObject* mesh, const std::string &meshName) override;
+  int AddArray(vtkDataObject* mesh, const std::string &meshName, int association, const std::string &arrayName) override;
   int ReleaseData() override;
 
 protected:

--- a/Src/Extern/SENSEI/AMReX_AmrDataAdaptor.cpp
+++ b/Src/Extern/SENSEI/AMReX_AmrDataAdaptor.cpp
@@ -1,8 +1,10 @@
 #include "AMReX_AmrDataAdaptor.H"
 
-#include "timer/Timer.h"
-#include "Error.h"
+#include "MPIUtils.h"
+#include "STLUtils.h"
 #include "VTKUtils.h"
+#include "Profiler.h"
+#include "Error.h"
 
 #include <vtkObjectFactory.h>
 #include <vtkOverlappingAMR.h>
@@ -99,7 +101,9 @@ struct AmrDataAdaptor::InternalsType
     amrex::Amr *SimData;
     int PinMesh;
     amrex::InSituUtils::DescriptorMap SimMetadata;
+#if SENSEI_VERSION_MAJOR < 3
     std::vector<vtkDataObject*> ManagedObjects;
+#endif
 };
 
 //-----------------------------------------------------------------------------
@@ -120,6 +124,8 @@ AmrDataAdaptor::~AmrDataAdaptor()
 //-----------------------------------------------------------------------------
 int AmrDataAdaptor::SetDataSource(amrex::Amr *amr)
 {
+    sensei::TimeEvent<64> event("AmrDataAdaptor::SetDataSource");
+
     this->ReleaseData();
 
     this->Internals->SimData = amr;
@@ -142,22 +148,339 @@ void AmrDataAdaptor::SetPinMesh(int pinMesh)
 //-----------------------------------------------------------------------------
 int AmrDataAdaptor::GetNumberOfMeshes(unsigned int &numMeshes)
 {
+    sensei::TimeEvent<64> event("AmrDataAdaptor::GetNumberOfMeshes");
     numMeshes = 1;
     return 0;
 }
 
+#if SENSEI_VERSION_MAJOR >= 3
 //-----------------------------------------------------------------------------
-int AmrDataAdaptor::GetMeshName(unsigned int id, std::string &meshName)
+int AmrDataAdaptor::GetMeshMetadata(unsigned int id,
+    sensei::MeshMetadataPtr &metadata)
 {
-    meshName = "mesh";
+    sensei::TimeEvent<64> event("AmrDataAdaptor::GetMeshMetadata");
+
+    if (id != 0)
+      {
+      SENSEI_ERROR("invalid mesh id " << id)
+      return -1;
+      }
+
+    // AMR data is always expected to be a global view
+    metadata->GlobalView = true;
+
+    metadata->MeshName = "mesh";
+    metadata->MeshType = VTK_OVERLAPPING_AMR;
+    metadata->BlockType = VTK_UNIFORM_GRID;
+    metadata->NumBlocks = 0;
+    metadata->NumBlocksLocal = {-1};
+    metadata->CoordinateType = InSituUtils::amrex_tt<amrex_real>::vtk_type_enum();
+    metadata->StaticMesh = 0;
+
+    // TODO
+    //metadata->PeriodicBoundary = ;
+
+    amrex::Vector<std::unique_ptr<amrex::AmrLevel>> &levels =
+     this->Internals->SimData->getAmrLevels();
+
+    // num levels and blocks per level
+    metadata->NumLevels = numActiveLevels(levels);
+
+    metadata->NumBlocks = 0;
+    metadata->BlocksPerLevel.resize(metadata->NumLevels);
+    for (unsigned int i = 0; i < metadata->NumLevels; ++i)
+    {
+        unsigned long nb = levels[i]->boxArray().size();
+        metadata->NumBlocks += nb;
+        metadata->BlocksPerLevel[i] = nb;
+    }
+
+    // bounds
+    const amrex::RealBox& pd = levels[0]->Geom().ProbDomain();
+
+    double pdLo[3] = {AMREX_ARLIM(pd.lo())};
+    double pdHi[3] = {AMREX_ARLIM(pd.hi())};
+
+    // PinMesh works around a bug in VisIt 2.13.2.
+    // force the origin to 0,0,0
+    if (this->Internals->PinMesh)
+    {
+        for (int i = 0; i < 3; ++i)
+        {
+            pdHi[i] = pdHi[i] - pdLo[i];
+            pdLo[i] = 0.0;
+        }
+    }
+
+    if (metadata->Flags.BlockBoundsSet())
+    {
+        metadata->Bounds = std::array<double,6>({pdLo[0], pdHi[0],
+            pdLo[1], pdHi[1], pdLo[2], pdHi[2]});
+
+        metadata->BlockBounds.reserve(metadata->NumBlocks);
+    }
+
+    // extent
+    const amrex::Box& dom = levels[0]->Geom().Domain();
+    int domLo[3] = {AMREX_ARLIM(dom.smallEnd())};
+    int domHi[3] = {AMREX_ARLIM(dom.bigEnd())};
+
+    if (metadata->Flags.BlockExtentsSet())
+    {
+        metadata->Extent = std::array<int,6>({domLo[0], domHi[0],
+            domLo[1], domHi[1], domLo[2], domHi[2]});
+
+        metadata->BlockExtents.reserve(metadata->NumBlocks);
+        metadata->BlockLevel.reserve(metadata->NumBlocks);
+    }
+
+    // ghost zones
+    metadata->NumGhostCells = levels[0]->get_new_data(0).nGrow();
+
+    // arrays
+    metadata->NumArrays = 0;
+    const DescriptorList &descriptors = levels[0]->get_desc_lst();
+    int ndesc = descriptors.size();
+    for (int i = 0; i < ndesc; ++i)
+    {
+        const StateDescriptor &desc = descriptors[i];
+
+        int ncomp = desc.nComp();
+        metadata->NumArrays += ncomp;
+
+        IndexType itype = desc.getType();
+
+        for (int j = 0; j < ncomp; ++j)
+        {
+            std::string arrayName = desc.name(j);
+            metadata->ArrayName.push_back(arrayName);
+            metadata->ArrayComponents.push_back(1);
+            metadata->ArrayType.push_back(InSituUtils::amrex_tt<amrex_real>::vtk_type_enum());
+
+            if (itype.cellCentered())
+                metadata->ArrayCentering.push_back(vtkDataObject::CELL);
+            else if (itype.nodeCentered())
+                metadata->ArrayCentering.push_back(vtkDataObject::POINT);
+            else
+                metadata->ArrayCentering.push_back(vtkDataObject::FIELD);
+        }
+
+    }
+
+    if (metadata->Flags.BlockArrayRangeSet())
+        metadata->BlockArrayRange.reserve(metadata->NumBlocks);
+
+    int rank = 0;
+    MPI_Comm_rank(this->GetCommunicator(), &rank);
+
+    // per-level and per-block metadata
+    long gid = 0;
+    for (unsigned int i = 0; i < metadata->NumLevels; ++i)
+    {
+        // domain decomp
+        const amrex::DistributionMapping &dmap = levels[i]->DistributionMap();
+
+        // ghost zones
+        unsigned int ng = levels[i]->get_new_data(0).nGrow();
+
+        // spacing
+        const amrex::Geometry &geom = levels[i]->Geom();
+        double spacing[3] = {AMREX_ARLIM(geom.CellSize())};
+
+        // refinement ratio
+        std::array<int,3> rr = {AMREX_ARLIM(levels[i]->fineRatio())};
+        metadata->RefRatio.push_back(rr);
+
+        // loop over boxes
+        const amrex::BoxArray& ba = levels[i]->boxArray();
+        unsigned int nBoxes = ba.size();
+
+        for (unsigned int j = 0; j < nBoxes; ++j)
+        {
+            // cell centered box
+            amrex::Box cbox = ba[j];
+
+            // add ghost zones
+            for (int q = 0; q < AMREX_SPACEDIM; ++q)
+                cbox.grow(q, ng);
+
+            // node centered box
+            amrex::Box nbox = surroundingNodes(cbox);
+
+            // node centered dimensions
+            int nboxLo[3] = {AMREX_ARLIM(nbox.loVect())};
+            int nboxHi[3] = {AMREX_ARLIM(nbox.hiVect())};
+
+            // domain decomp
+            if (metadata->Flags.BlockDecompSet())
+            {
+                metadata->BlockOwner.push_back(dmap[j]);
+                metadata->BlockIds.push_back(gid++);
+            }
+
+            // block sizes
+            if (metadata->Flags.BlockSizeSet())
+            {
+                metadata->BlockNumPoints.push_back(nbox.numPts());
+                metadata->BlockNumCells.push_back(cbox.numPts());
+            }
+
+            // block extent
+            if (metadata->Flags.BlockExtentsSet())
+            {
+                metadata->BlockExtents.push_back({nboxLo[0], nboxHi[0],
+                    nboxLo[1], nboxHi[1], nboxLo[2], nboxHi[2]});
+
+                metadata->BlockLevel.push_back(i);
+            }
+
+            // block bounds
+            if (metadata->Flags.BlockBoundsSet())
+                metadata->BlockBounds.push_back({pdLo[0] + spacing[0]*nboxLo[0],
+                    pdLo[0] + spacing[0]*nboxHi[0], pdLo[1] + spacing[1]*nboxLo[1],
+                    pdLo[1] + spacing[1]*nboxHi[1], pdLo[2] + spacing[2]*nboxLo[2],
+                    pdLo[2] + spacing[2]*nboxHi[2]});
+
+            // only for local blocks
+            if ((dmap[j] == rank) && (metadata->Flags.BlockArrayRangeSet()))
+            {
+                std::vector<std::array<double,2>> arrayRange;
+                arrayRange.reserve(metadata->NumArrays);
+
+                // block array range
+                for (int k = 0; k < ndesc; ++k)
+                {
+                    const StateDescriptor &desc = descriptors[k];
+                    amrex::MultiFab &state = levels[i]->get_new_data(k);
+
+                    int ncomp = desc.nComp();
+                    IndexType itype = desc.getType();
+
+                    for (int l = 0; l < ncomp; ++l)
+                    {
+                        // calculate min/max on this block for this array
+                        amrex_real mn = state[j].min(l);
+                        amrex_real mx = state[j].max(l);
+                        arrayRange.push_back({mn, mx});
+                    }
+                }
+
+                metadata->BlockArrayRange.push_back(arrayRange);
+            }
+        }
+    }
+
+    // make the block array range global
+    if (metadata->Flags.BlockArrayRangeSet())
+    {
+        sensei::MPIUtils::GlobalViewV(this->GetCommunicator(), metadata->BlockArrayRange);
+        sensei::STLUtils::ReduceRange(metadata->BlockArrayRange, metadata->ArrayRange);
+    }
+
     return 0;
 }
+
+#else
+
+//-----------------------------------------------------------------------------
+int AmrDataAdaptor::GetMeshHasGhostNodes(const std::string &meshName, int &nLayers)
+{
+    nLayers = 0;
+
+    if (meshName != "mesh")
+    {
+        SENSEI_ERROR("no mesh named \"" << meshName << "\"")
+        return -1;
+    }
+
+    return 0;
+}
+
+//-----------------------------------------------------------------------------
+int AmrDataAdaptor::GetMeshHasGhostCells(const std::string &meshName, int &nLayers)
+{
+    nLayers = 0;
+
+    if (meshName != "mesh")
+    {
+        SENSEI_ERROR("no mesh named \"" << meshName << "\"")
+        return -1;
+    }
+
+    if (!this->Internals->SimData)
+    {
+        SENSEI_ERROR("No simulation data")
+        return -1;
+    }
+
+    nLayers = 1;
+
+    return 0;
+}
+
+//-----------------------------------------------------------------------------
+int AmrDataAdaptor::GetNumberOfArrays(const std::string &meshName,
+    int association, unsigned int &numberOfArrays)
+{
+    timer::MarkEvent("AmrDataAdaptor::GetNumberOfArrays");
+
+    numberOfArrays = 0;
+
+    if (meshName != "mesh")
+    {
+        SENSEI_ERROR("no mesh named \"" << meshName << "\"")
+        return -1;
+    }
+
+    if ((association != vtkDataObject::POINT) &&
+        (association != vtkDataObject::CELL))
+    {
+        SENSEI_ERROR("Invalid association " << association)
+        return -1;
+    }
+
+    if (!this->Internals->SimData)
+    {
+        SENSEI_ERROR("No simulation data")
+        return -1;
+    }
+
+    numberOfArrays = this->Internals->SimMetadata.Size(association);
+
+    return 0;
+}
+
+//-----------------------------------------------------------------------------
+int AmrDataAdaptor::GetArrayName(const std::string &meshName,
+    int association, unsigned int index, std::string &arrayName)
+{
+    timer::MarkEvent("AmrDataAdaptor::GetArrayName");
+
+    if (meshName != "mesh")
+    {
+        SENSEI_ERROR("No mesh named \"" << meshName << "\"")
+        return -1;
+    }
+
+    if (this->Internals->SimMetadata.GetName(association, index, arrayName))
+    {
+        SENSEI_ERROR("No array named \"" << arrayName << "\" in "
+            << sensei::VTKUtils::GetAttributesName(association)
+            << " data")
+        return -1;
+    }
+
+    return 0;
+}
+
+
+#endif
 
 //-----------------------------------------------------------------------------
 int AmrDataAdaptor::GetMesh(const std::string &meshName,
     bool structureOnly, vtkDataObject *&mesh)
 {
-    timer::MarkEvent("AmrDataAdaptor::GetMesh");
+    sensei::TimeEvent<64> event("AmrDataAdaptor::GetMesh");
 
     mesh = nullptr;
 
@@ -168,7 +491,7 @@ int AmrDataAdaptor::GetMesh(const std::string &meshName,
     }
 
     int rank = 0;
-    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    MPI_Comm_rank(this->GetCommunicator(), &rank);
 
     // get levels
     amrex::Vector<std::unique_ptr<amrex::AmrLevel>> &levels =
@@ -178,7 +501,9 @@ int AmrDataAdaptor::GetMesh(const std::string &meshName,
 
     // initialize new vtk datasets
     vtkOverlappingAMR *amrMesh = vtkOverlappingAMR::New();
+#if SENSEI_VERSION_MAJOR < 3
     Internals->ManagedObjects.push_back(amrMesh);
+#endif
     mesh = amrMesh;
 
     // num levels and blocks per level
@@ -270,59 +595,10 @@ int AmrDataAdaptor::GetMesh(const std::string &meshName,
 }
 
 //-----------------------------------------------------------------------------
-int AmrDataAdaptor::GetMeshHasGhostNodes(const std::string &meshName, int &nLayers)
-{
-    nLayers = 0;
-
-    if (meshName != "mesh")
-    {
-        SENSEI_ERROR("no mesh named \"" << meshName << "\"")
-        return -1;
-    }
-
-    return 0;
-}
-
-//-----------------------------------------------------------------------------
-int AmrDataAdaptor::AddGhostNodesArray(vtkDataObject *mesh,
-    const std::string &meshName)
-{
-    if (meshName != "mesh")
-    {
-        SENSEI_ERROR("no mesh named \"" << meshName << "\"")
-        return -1;
-    }
-
-    return 0;
-}
-
-//-----------------------------------------------------------------------------
-int AmrDataAdaptor::GetMeshHasGhostCells(const std::string &meshName, int &nLayers)
-{
-    nLayers = 0;
-
-    if (meshName != "mesh")
-    {
-        SENSEI_ERROR("no mesh named \"" << meshName << "\"")
-        return -1;
-    }
-
-    if (!this->Internals->SimData)
-    {
-        SENSEI_ERROR("No simulation data")
-        return -1;
-    }
-
-    nLayers = 1;
-
-    return 0;
-}
-
-//-----------------------------------------------------------------------------
 int AmrDataAdaptor::AddGhostCellsArray(vtkDataObject* mesh,
     const std::string &meshName)
 {
-    timer::MarkEvent("AmrDataAdaptor::AddGhostCellsArray");
+    sensei::TimeEvent<64> event("AmrDataAdaptor::AddGhostCellsArray");
 
     if (meshName != "mesh")
     {
@@ -344,7 +620,7 @@ int AmrDataAdaptor::AddGhostCellsArray(vtkDataObject* mesh,
     }
 
     int rank = 0;
-    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    MPI_Comm_rank(this->GetCommunicator(), &rank);
 
     // loop over levels
     amrex::Vector<std::unique_ptr<amrex::AmrLevel>> &levels =
@@ -444,13 +720,28 @@ int AmrDataAdaptor::AddGhostCellsArray(vtkDataObject* mesh,
 }
 
 //-----------------------------------------------------------------------------
+int AmrDataAdaptor::AddGhostNodesArray(vtkDataObject *mesh,
+    const std::string &meshName)
+{
+    sensei::TimeEvent<64> event("AmrDataAdaptor::AddGhostNodesArray");
+
+    if (meshName != "mesh")
+    {
+        SENSEI_ERROR("no mesh named \"" << meshName << "\"")
+        return -1;
+    }
+
+    return 0;
+}
+
+//-----------------------------------------------------------------------------
 int AmrDataAdaptor::AddArray(vtkDataObject* mesh, const std::string &meshName,
     int association, const std::string &arrayName)
 {
-    timer::MarkEvent("AmrDataAdaptor::AddArray");
+    sensei::TimeEvent<64> event("AmrDataAdaptor::AddArray");
 
     int rank = 0;
-    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    MPI_Comm_rank(this->GetCommunicator(), &rank);
 
     if (meshName != "mesh")
     {
@@ -613,72 +904,19 @@ int AmrDataAdaptor::AddArray(vtkDataObject* mesh, const std::string &meshName,
 }
 
 //-----------------------------------------------------------------------------
-int AmrDataAdaptor::GetNumberOfArrays(const std::string &meshName,
-    int association, unsigned int &numberOfArrays)
-{
-    timer::MarkEvent("AmrDataAdaptor::GetNumberOfArrays");
-
-    numberOfArrays = 0;
-
-    if (meshName != "mesh")
-    {
-        SENSEI_ERROR("no mesh named \"" << meshName << "\"")
-        return -1;
-    }
-
-    if ((association != vtkDataObject::POINT) &&
-        (association != vtkDataObject::CELL))
-    {
-        SENSEI_ERROR("Invalid association " << association)
-        return -1;
-    }
-
-    if (!this->Internals->SimData)
-    {
-        SENSEI_ERROR("No simulation data")
-        return -1;
-    }
-
-    numberOfArrays = this->Internals->SimMetadata.Size(association);
-
-    return 0;
-}
-
-//-----------------------------------------------------------------------------
-int AmrDataAdaptor::GetArrayName(const std::string &meshName,
-    int association, unsigned int index, std::string &arrayName)
-{
-    timer::MarkEvent("AmrDataAdaptor::GetArrayName");
-
-    if (meshName != "mesh")
-    {
-        SENSEI_ERROR("No mesh named \"" << meshName << "\"")
-        return -1;
-    }
-
-    if (this->Internals->SimMetadata.GetName(association, index, arrayName))
-    {
-        SENSEI_ERROR("No array named \"" << arrayName << "\" in "
-            << sensei::VTKUtils::GetAttributesName(association)
-            << " data")
-        return -1;
-    }
-
-    return 0;
-}
-
-//-----------------------------------------------------------------------------
 int AmrDataAdaptor::ReleaseData()
 {
-    timer::MarkEvent("AmrDataAdaptor::ReleaseData");
+    sensei::TimeEvent<64> event("AmrDataAdaptor::ReleaseData");
 
     this->Internals->SimData = nullptr;
 
-    // free up mesh objects we allocated
-    size_t n = this->Internals->ManagedObjects.size();
-    for (size_t i = 0; i < n; ++i)
-        this->Internals->ManagedObjects[i]->Delete();
-    this->Internals->ManagedObjects.clear();
+#if SENSEI_VERSION_MAJOR < 3
+     // free up mesh objects we allocated
+     size_t n = this->Internals->ManagedObjects.size();
+     for (size_t i = 0; i < n; ++i)
+         this->Internals->ManagedObjects[i]->Delete();
+     this->Internals->ManagedObjects.clear();
+#endif
 
     return 0;
 }

--- a/Src/Extern/SENSEI/AMReX_AmrInSituBridge.cpp
+++ b/Src/Extern/SENSEI/AMReX_AmrInSituBridge.cpp
@@ -4,7 +4,7 @@
 #ifdef BL_USE_SENSEI_INSITU
 #include <chrono>
 #include <AnalysisAdaptor.h>
-#include <timer/Timer.h>
+#include <Profiler.h>
 #include <AMReX_AmrDataAdaptor.H>
 #endif
 
@@ -20,7 +20,7 @@ AmrInSituBridge::update(Amr *dataSource)
         amrex::Print() << "SENSEI Begin update..." << std::endl;
         auto t0 = std::chrono::high_resolution_clock::now();
 
-        timer::MarkEvent event("AMRInSituBridge::update");
+        sensei::TimeEvent<64> event("AMRInSituBridge::update");
 
         amrex::AmrDataAdaptor *data_adaptor = amrex::AmrDataAdaptor::New();
         if (comm != MPI_COMM_NULL)

--- a/Src/Extern/SENSEI/AMReX_AmrMeshDataAdaptor.H
+++ b/Src/Extern/SENSEI/AMReX_AmrMeshDataAdaptor.H
@@ -24,15 +24,19 @@ public:
 
   // SENSEI API
   int GetNumberOfMeshes(unsigned int &numMeshes) override;
+#if SENSEI_VERSION_MAJOR >= 3
+  int GetMeshMetadata(unsigned int id, sensei::MeshMetadataPtr &metadata) override;
+#else
   int GetMeshName(unsigned int id, std::string &meshName) override;
-  int GetMesh(const std::string &meshName, bool structureOnly, vtkDataObject *&mesh) override;
   int GetMeshHasGhostNodes(const std::string &meshName, int &nLayers) override;
-  int AddGhostNodesArray(vtkDataObject* mesh, const std::string &meshName) override;
   int GetMeshHasGhostCells(const std::string &meshName, int &nLayers) override;
-  int AddGhostCellsArray(vtkDataObject* mesh, const std::string &meshName) override;
-  int AddArray(vtkDataObject* mesh, const std::string &meshName, int association, const std::string &arrayName) override;
   int GetNumberOfArrays(const std::string &meshName, int association, unsigned int &numberOfArrays) override;
   int GetArrayName(const std::string &meshName, int association, unsigned int index, std::string &arrayName) override;
+#endif
+  int GetMesh(const std::string &meshName, bool structureOnly, vtkDataObject *&mesh) override;
+  int AddGhostNodesArray(vtkDataObject* mesh, const std::string &meshName) override;
+  int AddGhostCellsArray(vtkDataObject* mesh, const std::string &meshName) override;
+  int AddArray(vtkDataObject* mesh, const std::string &meshName, int association, const std::string &arrayName) override;
   int ReleaseData() override;
 
 protected:

--- a/Src/Extern/SENSEI/AMReX_AmrMeshInSituBridge.cpp
+++ b/Src/Extern/SENSEI/AMReX_AmrMeshInSituBridge.cpp
@@ -8,7 +8,7 @@
 #ifdef BL_USE_SENSEI_INSITU
 #include <chrono>
 #include <AnalysisAdaptor.h>
-#include <timer/Timer.h>
+#include <Profiler.h>
 #include <AMReX_AmrMeshDataAdaptor.H>
 #endif
 
@@ -26,7 +26,7 @@ AmrMeshInSituBridge::update(unsigned int step, double time,
         amrex::Print() << "SENSEI Begin update..." << std::endl;
         auto t0 = std::chrono::high_resolution_clock::now();
 
-        timer::MarkEvent event("AmrMeshInSituBridge::update");
+        sensei::TimeEvent<64> event("AmrMeshInSituBridge::update");
 
         amrex::AmrMeshDataAdaptor *data_adaptor = amrex::AmrMeshDataAdaptor::New();
         if (comm != MPI_COMM_NULL)

--- a/Src/Extern/SENSEI/AMReX_InSituUtils.H
+++ b/Src/Extern/SENSEI/AMReX_InSituUtils.H
@@ -23,40 +23,44 @@
 namespace amrex {
 namespace InSituUtils {
 
-//The following bit fields are consistent with VisIt ghost zones specification
-//For details, see http://www.visitusers.org/index.php?title=Representing_ghost_data
+// The following bit fields are consistent with VisIt ghost zones specification
+// For details, see http://www.visitusers.org/index.php?title=Representing_ghost_data
 
 enum CellGhostTypes
 {
-  DUPLICATECELL           = 1,  //the cell is present on multiple processors
-  HIGHCONNECTIVITYCELL    = 2,  //the cell has more neighbors than in a regular mesh
-  LOWCONNECTIVITYCELL     = 4,  //the cell has less neighbors than in a regular mesh
-  REFINEDCELL             = 8,  //other cells are present that refines it.
-  EXTERIORCELL            = 16, //the cell is on the exterior of the data set
-  HIDDENCELL              = 32  //the cell is needed to maintain connectivity, but the data values should be ignored.
+  DUPLICATECELL           = 1,  // the cell is present on multiple processors
+  HIGHCONNECTIVITYCELL    = 2,  // the cell has more neighbors than in a regular mesh
+  LOWCONNECTIVITYCELL     = 4,  // the cell has less neighbors than in a regular mesh
+  REFINEDCELL             = 8,  // other cells are present that refines it.
+  EXTERIORCELL            = 16, // the cell is on the exterior of the data set
+  HIDDENCELL              = 32  // the cell is needed to maintain connectivity,
+                                // but the data values should be ignored.
 };
 
 enum PointGhostTypes
 {
-  DUPLICATEPOINT          =1,   //the cell is present on multiple processors
-  HIDDENPOINT             =2    //the point is needed to maintain connectivity, but the data values should be ignored.
+  DUPLICATEPOINT          = 1,  // the cell is present on multiple processors
+  HIDDENPOINT             = 2   // the point is needed to maintain connectivity,
+                                // but the data values should be ignored.
 };
 
 
 
-// traits helper for delaing with amrex_real
+// traits helper for mapping between amrex_real and vtkDataArray
 template <typename cpp_t> struct amrex_tt {};
 
-
-#define amrex_tt_specialize(cpp_t, vtk_t)     \
-template <>                                   \
-struct amrex_tt<cpp_t>                        \
-{                                             \
-    using vtk_type = vtk_t;                   \
+#define amrex_tt_specialize(cpp_t, vtk_t, vtk_t_e)      \
+template <>                                             \
+struct amrex_tt<cpp_t>                                  \
+{                                                       \
+    using vtk_type = vtk_t;                             \
+                                                        \
+    static                                              \
+    constexpr int vtk_type_enum() { return vtk_t_e; }   \
 };
 
-amrex_tt_specialize(float, vtkFloatArray)
-amrex_tt_specialize(double, vtkDoubleArray)
+amrex_tt_specialize(float, vtkFloatArray, VTK_FLOAT)
+amrex_tt_specialize(double, vtkDoubleArray, VTK_DOUBLE)
 
 
 // helpers to modify values

--- a/Tutorials/SENSEI/Advection_AmrCore/Exec/SingleVortex/GNUmakefile
+++ b/Tutorials/SENSEI/Advection_AmrCore/Exec/SingleVortex/GNUmakefile
@@ -3,11 +3,9 @@ AMREX_HOME ?= ../../../../..
 PRECISION  = DOUBLE
 PROFILE    = FALSE
 
-DEBUG      = TRUE
 DEBUG      = FALSE
 
 DIM        = 2
-#DIM       = 3
 
 COMP	   = gnu
 
@@ -16,7 +14,7 @@ USE_OMP    = FALSE
 
 USE_SENSEI_INSITU = TRUE
 
-Bpack   := ./Make.package 
-Blocs   := . 
+Bpack   := ./Make.package
+Blocs   := .
 
 include ../Make.Adv

--- a/Tutorials/SENSEI/Advection_AmrCore/Exec/SingleVortex/inputs
+++ b/Tutorials/SENSEI/Advection_AmrCore/Exec/SingleVortex/inputs
@@ -1,10 +1,10 @@
-max_step  = 1000000
+max_step  = 100
 stop_time = 2.0
 
 # PROBLEM SIZE & GEOMETRY
 geometry.is_periodic =  1  1  1
 geometry.coord_sys   =  0       # 0 => cart
-geometry.prob_lo     =  0.0  0.0  0.0 
+geometry.prob_lo     =  0.0  0.0  0.0
 geometry.prob_hi     =  1.0  1.0  1.0
 amr.n_cell           =  64   64   64
 
@@ -32,21 +32,21 @@ adv.do_reflux = 1
 adv.phierr = 1.01  1.1  1.5
 
 # PLOTFILES
-amr.plot_files_output = 0  # 0 will disable plot files
 amr.plot_file  = plt    # root name of plot file
-amr.plot_int   = 10     # number of timesteps between plot files
+amr.plot_int   = -1     # number of timesteps between plot files
 
 # CHECKPOINT
-amr.checkpoint_files_output = 0 # 0 will disable checkpoint files
 amr.chk_file = chk      # root name of checkpoint file
-amr.chk_int  = 10       # number of timesteps between checkpoint files
+amr.chk_int  = -1      # number of timesteps between checkpoint files
 #amr.restart  = chk00060 # restart from this checkpoint file
 
 # SENSEI in situ
 # enable and choose the configuration based on your build
 sensei.enabled = 1
-sensei.config = sensei/render_iso_catalyst_2d.xml
+sensei.config = sensei/histogram_python.xml
+#sensei.config = sensei/render_iso_catalyst_2d.xml
 #sensei.config = sensei/render_iso_catalyst_3d.xml
 #sensei.config = sensei/render_iso_libsim_2d.xml
 #sensei.config = sensei/render_iso_libsim_3d.xml
+#sensei.config = sensei/write_vtk.xml
 sensei.frequency = 2

--- a/Tutorials/SENSEI/Advection_AmrCore/Exec/SingleVortex/sensei/histogram.py
+++ b/Tutorials/SENSEI/Advection_AmrCore/Exec/SingleVortex/sensei/histogram.py
@@ -1,0 +1,110 @@
+import sys
+import numpy as np
+import vtk.util.numpy_support as vtknp
+from vtk import vtkDataObject, vtkCompositeDataSet, vtkMultiBlockDataSet
+
+# default values of control parameters
+numBins = 10
+meshName = ''
+arrayName = ''
+arrayCen = vtkDataObject.POINT
+outFile = 'hist'
+verbose = True
+
+def Initialize():
+    r = comm.Get_rank()
+    if r == 0:
+        if verbose:
+            sys.stderr.write( \
+                'Initialize numBins=%d meshName=%s arrayName=%s arrayCen=%d outFile=%s\n'%( \
+                numBins, meshName, arrayName, arrayCen, outFile))
+
+        # check for valid control parameters
+        if not meshName:
+            raise RuntimeError('meshName was not set')
+        if not arrayName:
+            raise RuntimeError('arrayName was not set')
+
+def Execute(adaptor):
+    r = comm.Get_rank()
+
+    # get the mesh and array we need
+    mesh = adaptor.GetMesh(meshName, True)
+    adaptor.AddArray(mesh, meshName, arrayCen, arrayName)
+
+    # force composite data to simplify computations
+    if not isinstance(mesh, vtkCompositeDataSet):
+        s = comm.Get_size()
+        mb = vtkMultiBlockDataSet()
+        mb.SetNumberOfBlocks(s)
+        mb.SetBlock(r, mesh)
+        mesh = mb
+
+    # compute the min and max over local blocks
+    mn = sys.float_info.max
+    mx = -mn
+    it = mesh.NewIterator()
+    while not it.IsDoneWithTraversal():
+        do = it.GetCurrentDataObject()
+
+        atts = do.GetPointData() if arrayCen == vtkDataObject.POINT \
+             else do.GetCellData()
+
+        da = vtknp.vtk_to_numpy(atts.GetArray(arrayName))
+
+        mn = min(mn, np.min(da))
+        mx = max(mx, np.max(da))
+
+        it.GoToNextItem()
+
+    # compute global min and max
+    mn = comm.allreduce(mn, op=MPI.MIN)
+    mx = comm.allreduce(mx, op=MPI.MAX)
+
+    # compute the histogram over local blocks
+    it.InitTraversal()
+    while not it.IsDoneWithTraversal():
+        do = it.GetCurrentDataObject()
+
+        atts = do.GetPointData() if arrayCen == vtkDataObject.POINT \
+             else do.GetCellData()
+
+        da = vtknp.vtk_to_numpy(atts.GetArray(arrayName))
+
+        h,be = np.histogram(da, bins=numBins, range=(mn,mx))
+
+        hist = hist + h if 'hist' in globals() else h
+
+        it.GoToNextItem()
+
+    # compute the global histogram on rank 0
+    h = comm.reduce(hist, root=0, op=MPI.SUM)
+
+    # rank 0 write to disk
+    if r == 0:
+        t = adaptor.GetDataTime()
+        ts = adaptor.GetDataTimeStep()
+        fn = '%s_%s_%s_%05d.txt'%(outFile, meshName, arrayName, ts)
+        f = open(fn, 'w')
+        f.write('step : %d\n'%(ts))
+        f.write('time : %0.6g\n'%(t))
+        f.write('num bins : %d\n'%(numBins))
+        f.write('range : %0.6g %0.6g\n'%(mn, mx))
+        f.write('bin edges : ')
+        for v in be:
+            f.write('%0.6g '%(v))
+        f.write('\n')
+        f.write('counts : ')
+        for v in h:
+            f.write('%d '%(v))
+        f.write('\n')
+        f.close()
+        if verbose:
+            sys.stderr.write('Execute "%s" written\n'%(fn))
+
+def Finalize():
+    r = comm.Get_rank()
+    if r == 0 and verbose:
+        sys.stderr.write('Finalize\n')
+    return 0
+

--- a/Tutorials/SENSEI/Advection_AmrCore/Exec/SingleVortex/sensei/histogram_python.xml
+++ b/Tutorials/SENSEI/Advection_AmrCore/Exec/SingleVortex/sensei/histogram_python.xml
@@ -1,0 +1,10 @@
+<sensei>
+  <analysis type="python" script_file="sensei/histogram.py" enabled="1">
+    <initialize_source>
+numBins=10
+meshName='mesh'
+arrayName='phi'
+arrayCen=1
+     </initialize_source>
+  </analysis>
+</sensei>

--- a/Tutorials/SENSEI/Advection_AmrCore/Exec/SingleVortex/sensei/render_iso_catalyst_2d.py
+++ b/Tutorials/SENSEI/Advection_AmrCore/Exec/SingleVortex/sensei/render_iso_catalyst_2d.py
@@ -42,7 +42,7 @@ def CreateCoProcessor():
       renderView1.Background = [1.0, 1.0, 1.0]
 
       # init the 'GridAxes3DActor' selected for 'AxesGrid'
-      renderView1.AxesGrid.Visibility = 1
+      renderView1.AxesGrid.Visibility = 0
       renderView1.AxesGrid.XTitle = 'X'
       renderView1.AxesGrid.YTitle = 'Y '
       renderView1.AxesGrid.ZTitle = ''

--- a/Tutorials/SENSEI/Advection_AmrLevel/Exec/SingleVortex/GNUmakefile
+++ b/Tutorials/SENSEI/Advection_AmrLevel/Exec/SingleVortex/GNUmakefile
@@ -1,13 +1,12 @@
 AMREX_HOME ?= ../../../../..
+
 USE_EB = FALSE
 PRECISION  = DOUBLE
 PROFILE    = FALSE
 
-DEBUG      = TRUE
 DEBUG      = FALSE
 
 DIM        = 2
-#DIM       = 3
 
 COMP	   = gnu
 
@@ -18,7 +17,7 @@ USE_OMP    = FALSE
 
 USE_SENSEI_INSITU = TRUE
 
-Bpack   := ./Make.package 
-Blocs   := . 
+Bpack   := ./Make.package
+Blocs   := .
 
 include ../Make.Adv

--- a/Tutorials/SENSEI/Advection_AmrLevel/Exec/SingleVortex/inputs
+++ b/Tutorials/SENSEI/Advection_AmrLevel/Exec/SingleVortex/inputs
@@ -1,11 +1,11 @@
 # ------------------  INPUTS TO MAIN PROGRAM  -------------------
-max_step = 1000000
+max_step = 100
 stop_time = 2.0
 
 # PROBLEM SIZE & GEOMETRY
 geometry.is_periodic =  1  1  1
 geometry.coord_sys   =  0       # 0 => cart
-geometry.prob_lo     =  0.0  0.0  0.0 
+geometry.prob_lo     =  0.0  0.0  0.0
 geometry.prob_hi     =  1.0  1.0  1.0
 amr.n_cell           =  64   64   64
 
@@ -28,14 +28,12 @@ amr.blocking_factor = 8       # block factor in grid generation
 amr.max_grid_size   = 16
 
 # CHECKPOINT FILES
-amr.checkpoint_files_output = 0     # 0 will disable checkpoint files
 amr.check_file              = chk   # root name of checkpoint file
-amr.check_int               = 10    # number of timesteps between checkpoints
+amr.check_int               = -1    # number of timesteps between checkpoints
 
 # PLOTFILES
-amr.plot_files_output = 0      # 0 will disable plot files
 amr.plot_file         = plt    # root name of plot file
-amr.plot_int          = 100    # number of timesteps between plot files
+amr.plot_int          = -1   # number of timesteps between plot files
 
 # PROBIN FILENAME
 amr.probin_file = probin
@@ -46,7 +44,9 @@ adv.do_tracers = 0
 # SENSEI in situ
 # enable and choose the configuration based on your build
 sensei.enabled = 1
-sensei.config = sensei/render_iso_catalyst_2d.xml
+sensei.config = sensei/histogram_python.xml
+#sensei.config = sensei/render_iso_catalyst_2d.xml
+#sensei.config = sensei/write_vtk.xml
 #sensei.config = sensei/render_iso_catalyst_3d.xml
 #sensei.config = sensei/render_iso_libsim_2d.xml
 #sensei.config = sensei/render_iso_libsim_3d.xml

--- a/Tutorials/SENSEI/Advection_AmrLevel/Exec/SingleVortex/sensei/histogram.py
+++ b/Tutorials/SENSEI/Advection_AmrLevel/Exec/SingleVortex/sensei/histogram.py
@@ -1,0 +1,110 @@
+import sys
+import numpy as np
+import vtk.util.numpy_support as vtknp
+from vtk import vtkDataObject, vtkCompositeDataSet, vtkMultiBlockDataSet
+
+# default values of control parameters
+numBins = 10
+meshName = ''
+arrayName = ''
+arrayCen = vtkDataObject.POINT
+outFile = 'hist'
+verbose = True
+
+def Initialize():
+    r = comm.Get_rank()
+    if r == 0:
+        if verbose:
+            sys.stderr.write( \
+                'Initialize numBins=%d meshName=%s arrayName=%s arrayCen=%d outFile=%s\n'%( \
+                numBins, meshName, arrayName, arrayCen, outFile))
+
+        # check for valid control parameters
+        if not meshName:
+            raise RuntimeError('meshName was not set')
+        if not arrayName:
+            raise RuntimeError('arrayName was not set')
+
+def Execute(adaptor):
+    r = comm.Get_rank()
+
+    # get the mesh and array we need
+    mesh = adaptor.GetMesh(meshName, True)
+    adaptor.AddArray(mesh, meshName, arrayCen, arrayName)
+
+    # force composite data to simplify computations
+    if not isinstance(mesh, vtkCompositeDataSet):
+        s = comm.Get_size()
+        mb = vtkMultiBlockDataSet()
+        mb.SetNumberOfBlocks(s)
+        mb.SetBlock(r, mesh)
+        mesh = mb
+
+    # compute the min and max over local blocks
+    mn = sys.float_info.max
+    mx = -mn
+    it = mesh.NewIterator()
+    while not it.IsDoneWithTraversal():
+        do = it.GetCurrentDataObject()
+
+        atts = do.GetPointData() if arrayCen == vtkDataObject.POINT \
+             else do.GetCellData()
+
+        da = vtknp.vtk_to_numpy(atts.GetArray(arrayName))
+
+        mn = min(mn, np.min(da))
+        mx = max(mx, np.max(da))
+
+        it.GoToNextItem()
+
+    # compute global min and max
+    mn = comm.allreduce(mn, op=MPI.MIN)
+    mx = comm.allreduce(mx, op=MPI.MAX)
+
+    # compute the histogram over local blocks
+    it.InitTraversal()
+    while not it.IsDoneWithTraversal():
+        do = it.GetCurrentDataObject()
+
+        atts = do.GetPointData() if arrayCen == vtkDataObject.POINT \
+             else do.GetCellData()
+
+        da = vtknp.vtk_to_numpy(atts.GetArray(arrayName))
+
+        h,be = np.histogram(da, bins=numBins, range=(mn,mx))
+
+        hist = hist + h if 'hist' in globals() else h
+
+        it.GoToNextItem()
+
+    # compute the global histogram on rank 0
+    h = comm.reduce(hist, root=0, op=MPI.SUM)
+
+    # rank 0 write to disk
+    if r == 0:
+        t = adaptor.GetDataTime()
+        ts = adaptor.GetDataTimeStep()
+        fn = '%s_%s_%s_%05d.txt'%(outFile, meshName, arrayName, ts)
+        f = open(fn, 'w')
+        f.write('step : %d\n'%(ts))
+        f.write('time : %0.6g\n'%(t))
+        f.write('num bins : %d\n'%(numBins))
+        f.write('range : %0.6g %0.6g\n'%(mn, mx))
+        f.write('bin edges : ')
+        for v in be:
+            f.write('%0.6g '%(v))
+        f.write('\n')
+        f.write('counts : ')
+        for v in h:
+            f.write('%d '%(v))
+        f.write('\n')
+        f.close()
+        if verbose:
+            sys.stderr.write('Execute "%s" written\n'%(fn))
+
+def Finalize():
+    r = comm.Get_rank()
+    if r == 0 and verbose:
+        sys.stderr.write('Finalize\n')
+    return 0
+

--- a/Tutorials/SENSEI/Advection_AmrLevel/Exec/SingleVortex/sensei/histogram_python.xml
+++ b/Tutorials/SENSEI/Advection_AmrLevel/Exec/SingleVortex/sensei/histogram_python.xml
@@ -1,0 +1,10 @@
+<sensei>
+  <analysis type="python" script_file="sensei/histogram.py" enabled="1">
+    <initialize_source>
+numBins=10
+meshName='mesh'
+arrayName='phi'
+arrayCen=1
+     </initialize_source>
+  </analysis>
+</sensei>

--- a/Tutorials/SENSEI/Advection_AmrLevel/Exec/SingleVortex/sensei/iso_extract.xml
+++ b/Tutorials/SENSEI/Advection_AmrLevel/Exec/SingleVortex/sensei/iso_extract.xml
@@ -1,0 +1,12 @@
+<sensei>
+  <analysis type="SliceExtract" operation="iso_surface"
+    enable_partitioner="1" verbose="1" enabled="1">
+
+    <iso_values mesh_name="mesh" array_name="phi"
+       array_centering="cell">
+       1.5
+    </iso_values>
+
+    <writer mode="visit" output_dir="./isos" />
+  </analysis>
+</sensei>

--- a/Tutorials/SENSEI/Advection_AmrLevel/Exec/SingleVortex/sensei/read_adios2_bp4_default.xml
+++ b/Tutorials/SENSEI/Advection_AmrLevel/Exec/SingleVortex/sensei/read_adios2_bp4_default.xml
@@ -1,0 +1,3 @@
+<sensei>
+  <transport type="adios2" filename="single_vortex_advect.bp" method="bp4"/>
+</sensei>

--- a/Tutorials/SENSEI/Advection_AmrLevel/Exec/SingleVortex/sensei/read_adios2_sst_default.xml
+++ b/Tutorials/SENSEI/Advection_AmrLevel/Exec/SingleVortex/sensei/read_adios2_sst_default.xml
@@ -1,0 +1,3 @@
+<sensei>
+  <transport type="adios2" filename="single_vortex_advect.sst" engine="sst"/>
+</sensei>

--- a/Tutorials/SENSEI/Advection_AmrLevel/Exec/SingleVortex/sensei/render_iso_catalyst_2d.py
+++ b/Tutorials/SENSEI/Advection_AmrLevel/Exec/SingleVortex/sensei/render_iso_catalyst_2d.py
@@ -42,7 +42,7 @@ def CreateCoProcessor():
       renderView1.Background = [1.0, 1.0, 1.0]
 
       # init the 'GridAxes3DActor' selected for 'AxesGrid'
-      renderView1.AxesGrid.Visibility = 1
+      renderView1.AxesGrid.Visibility = 0
       renderView1.AxesGrid.XTitle = 'X'
       renderView1.AxesGrid.YTitle = 'Y '
       renderView1.AxesGrid.ZTitle = ''
@@ -118,7 +118,7 @@ def CreateCoProcessor():
       mesh_0000Display.GlyphTableIndexArray = 'None'
       mesh_0000Display.DataAxesGrid = 'GridAxesRepresentation'
       mesh_0000Display.PolarAxes = 'PolarAxesRepresentation'
-      mesh_0000Display.ScalarOpacityUnitDistance = 0.057873097067582834
+      #mesh_0000Display.ScalarOpacityUnitDistance = 0.057873097067582834
 
       # show data from contour1
       contour1Display = Show(contour1, renderView1)

--- a/Tutorials/SENSEI/Advection_AmrLevel/Exec/SingleVortex/sensei/render_iso_libsim_2d.session
+++ b/Tutorials/SENSEI/Advection_AmrLevel/Exec/SingleVortex/sensei/render_iso_libsim_2d.session
@@ -5057,7 +5057,7 @@
                                 <Field name="plotName" type="string">Plot0002</Field>
                                 <Field name="pluginID" type="string">Contour_1.0</Field>
                                 <Field name="sourceID" type="string">SOURCE00</Field>
-                                <Field name="variableName" type="string">phi</Field>
+                                <Field name="variableName" type="string">mesh/cell/phi</Field>
                                 <Field name="active" type="bool">false</Field>
                                 <Field name="hidden" type="bool">false</Field>
                                 <Field name="realized" type="bool">true</Field>

--- a/Tutorials/SENSEI/Advection_AmrLevel/Exec/SingleVortex/sensei/render_iso_libsim_2d.xml
+++ b/Tutorials/SENSEI/Advection_AmrLevel/Exec/SingleVortex/sensei/render_iso_libsim_2d.xml
@@ -4,5 +4,6 @@
     visitdir="/work/SENSEI/visit2.13.2-install" mode="batch"
     session="sensei/render_iso_libsim_2d.session"
     image-filename="ls_image_2d_%ts" image-width="800" image-height="800"
+    compute_nesting="0"
     image-format="png" frequency="1" enabled="1" />
 </sensei>

--- a/Tutorials/SENSEI/Advection_AmrLevel/Exec/SingleVortex/sensei/write_adios2_bp4.xml
+++ b/Tutorials/SENSEI/Advection_AmrLevel/Exec/SingleVortex/sensei/write_adios2_bp4.xml
@@ -1,0 +1,3 @@
+<sensei>
+  <analysis type="adios2" filename="single_vortex_advect.bp" engine="BP4" enabled="1" />
+</sensei>

--- a/Tutorials/SENSEI/Advection_AmrLevel/Exec/SingleVortex/sensei/write_adios2_sst.xml
+++ b/Tutorials/SENSEI/Advection_AmrLevel/Exec/SingleVortex/sensei/write_adios2_sst.xml
@@ -1,0 +1,3 @@
+<sensei>
+  <transport type="adios2" filename="single_vortex_advect.sst" engine="sst" enabled="1" />
+</sensei>

--- a/Tutorials/SENSEI/README.md
+++ b/Tutorials/SENSEI/README.md
@@ -5,6 +5,19 @@ one to chose the desired visualization and analysis back end for a given task
 with out limitting ones options, as the back ends can be inter-changed at run
 time via a text based config file.
 
+## Organization of the code ##
+There are two path ways to SENSEI through AMReX. Which one to use depends on
+if your code uses `amrex::Amr` or `amrex::AmrMesh`. Most codes will use `amrex::Amr`.
+The tutorial for `amrex::Amr` is in the `AmrLevel` directory. The tutorial for
+`amrex::AmrMesh` is in the `AmrCore` directory. Both tutorials work the same and
+will be compiled from the Exec/SingleVortex directories.
+
+## Compatible versions ##
+This code was tested on 5/22/2020 with SENSEI 3.2, ParaView 5.7, VisIt 3.0.2,
+and Python 3.7. As these dependencies evolve small upadtes to configurations
+supplied here may be needed. This tutorial assumes local installs of one or
+more of these dependencies.
+
 ## Configuring the environment ##
 First select the desired SENSEI install. Each install will support different set of
 backends. This is necessary because not all of the back ends are compatible with
@@ -22,7 +35,7 @@ module load sensei/2.1.0-libsim
 
 ## Compiling ##
 SENSEI features in AMReX are conditionally compiled when the Make file variable
-`USE_SENSEI_INSITU` is set. When this variable is set, the Make file will query
+`USE_SENSEI_INSITU` is set. When this variable is set, the Make file will querry
 environment variables to determine the list of include directories and link
 libraries needed to compile with SENSEI.
 


### PR DESCRIPTION
These changes bring the AMReX SENSEI instrumentation up to date with SENSEI 3.2. 

Updates were made to the classes in the `Extern/SENSEI` directory and the `Tutorials/SENSEI` directories and should not impact folks not using SENSEI instrumentation.

The new features in SENSEI 3.2 release that this exposes to AMReX codes are:
* ADIOS2 support (tested with IAMR on 1034 nodes on Cori) 
* Ascent support
* Python 3 support
* Better support for AMR data in SENSEI data model.