### PR TITLE
CMAKE_INSTALL_PREFX: Only Toplevel

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,9 +69,9 @@ set( CMAKE_MODULE_PATH ${AMREX_CMAKE_MODULES_PATH} )
 #
 # Provide a default install directory
 #
-if ( CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT )
-   set ( CMAKE_INSTALL_PREFIX "${PROJECT_SOURCE_DIR}/installdir"
-      CACHE PATH "AMReX installation directory" FORCE)
+if ( CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR AND CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT )
+    set ( CMAKE_INSTALL_PREFIX "${PROJECT_SOURCE_DIR}/installdir"
+          CACHE PATH "AMReX installation directory" FORCE)
 endif ()
 
 #


### PR DESCRIPTION
Set a non-default CMAKE_INSTALL_PREFIX only if AMReX is the top-level CMake project. Otherwise, the default of a downstream project using AMReX as subproject will be placed in a quite confusing, temporary directory.

Example I saw downstream:
```
# ...
  Installation prefix: /home/axel/src/hipace-amrex/build/_deps/fetchedamrex-src/installdir
# ...
```

Refs.:
- https://stackoverflow.com/questions/42716466/how-can-i-tell-within-a-cmakelists-txt-whether-its-used-with-add-subdirectory