### PR TITLE
disable unqualified abs function with amrex namespace

### DIFF
--- a/Src/Base/AMReX.H
+++ b/Src/Base/AMReX.H
@@ -8,6 +8,7 @@
 #include <AMReX_ccse-mpi.H>
 #include <AMReX_Exception.H>
 #include <AMReX_INT.H>
+#include <AMReX_Math.H>
 
 #include <iostream>
 #include <functional>

--- a/Src/Base/AMReX_Math.H
+++ b/Src/Base/AMReX_Math.H
@@ -11,7 +11,12 @@ namespace sycl = cl::sycl;
 #endif
 
 namespace amrex { inline namespace disabled {
-    // disable unqualified abs function
+    // If it is inside namespace amrex, or amrex namespace is imported with
+    // using namespace amrex or amrex::disabled, unqualified abs functions are
+    // disabled with a link time error such as, undefined reference to
+    // `amrex::disabled::abs(double)'.  To fix it, one can use `std::abs` or
+    // `amrex::Math::abs`.  The latter works in both host and device functions,
+    // whereas `std::abs` does not currently work on device with HIP and DPC++.
     AMREX_GPU_HOST_DEVICE double abs (double);
     AMREX_GPU_HOST_DEVICE float abs (float);
     AMREX_GPU_HOST_DEVICE long double abs (long double);

--- a/Src/Base/AMReX_Math.H
+++ b/Src/Base/AMReX_Math.H
@@ -10,6 +10,16 @@
 namespace sycl = cl::sycl;
 #endif
 
+namespace amrex { inline namespace disabled {
+    // disable unqualified abs function
+    AMREX_GPU_HOST_DEVICE double abs (double);
+    AMREX_GPU_HOST_DEVICE float abs (float);
+    AMREX_GPU_HOST_DEVICE long double abs (long double);
+    AMREX_GPU_HOST_DEVICE int abs (int);
+    AMREX_GPU_HOST_DEVICE long abs (long);
+    AMREX_GPU_HOST_DEVICE long long abs (long long);
+}}
+
 namespace amrex { namespace Math {
 
 #ifdef AMREX_USE_DPCPP


### PR DESCRIPTION
Using unqualified `abs` function is often a bug due implicit conversion of `double` to `int`.  This disables the use within `namespace amrex`, and with `using namespace amrex;` or `using namespace amrex::disabled;`.
