### PR TITLE
CI: DPC++

### DIFF
--- a/.github/workflows/cmake/dependencies_dpcpp.sh
+++ b/.github/workflows/cmake/dependencies_dpcpp.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+#
+# Copyright 2020 The AMReX Community
+#
+# License: BSD-3-Clause-LBNL
+# Authors: Axel Huebl
+
+set -eu -o pipefail
+
+# Ref.: https://github.com/rscohn2/oneapi-ci
+# intel-basekit intel-hpckit are too large in size
+sudo wget https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
+sudo apt-key add GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
+echo "deb https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
+
+sudo apt-get update
+
+sudo apt-get install -y --no-install-recommends \
+    build-essential \
+    intel-oneapi-dpcpp-compiler intel-oneapi-mkl \
+    g++ gfortran    \
+    libopenmpi-dev  \
+    openmpi-bin

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -132,3 +132,28 @@ jobs:
             -DCMAKE_Fortran_COMPILER=$(which gfortran-4.8)   \
             -DCUDA_ARCH=6.0
         make -j 2 tutorials
+
+  # Build libamrex and all tutorials with DPC++
+  tutorials-dpcpp:
+    name: DPCPP@PubBeta GFortran@7.5 C++14 [tutorials]
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Dependencies
+      run: .github/workflows/cmake/dependencies_dpcpp.sh
+    - name: Build & Install
+      run: |
+        set +e
+        source /opt/intel/inteloneapi/setvars.sh
+        set -e
+        mkdir build
+        cd build
+        cmake ..                                           \
+            -DCMAKE_VERBOSE_MAKEFILE=ON                    \
+            -DENABLE_TUTORIALS=ON                          \
+            -DENABLE_PARTICLES=ON                          \
+            -DENABLE_DPCPP=ON                              \
+            -DCMAKE_C_COMPILER=$(which clang)              \
+            -DCMAKE_CXX_COMPILER=$(which dpcpp)            \
+            -DCMAKE_Fortran_COMPILER=$(which gfortran)
+        make -j 2 tutorials


### PR DESCRIPTION
Prepares Intel DPC++ CI builds, backported from WarpX.

Let's intentionally not set the "required" option yet to this one, because we depend on a public beta release for CI that is a bit slower than other releases we have access to for development.