### PR TITLE
turn tiling off by default for gpu

### DIFF
--- a/Src/Base/AMReX_FabArrayBase.cpp
+++ b/Src/Base/AMReX_FabArrayBase.cpp
@@ -25,7 +25,7 @@ namespace amrex {
 //
 int     FabArrayBase::MaxComp;
 
-#if defined(AMREX_USE_GPU) && defined(AMREX_USE_GPU_PRAGMA)
+#if defined(AMREX_USE_GPU)
 
 #if AMREX_SPACEDIM == 1
 IntVect FabArrayBase::mfiter_tile_size(1024000);


### PR DESCRIPTION
Tiling is turned off by default for GPU.  There are still two ways tiling can be turned on.  Users can change the default tiling size in their inputs files.  If explicit tile size is passed to `MFIter`, it will be chosen over the default value.

