### PR TITLE
DistributionMapping::makeSFC - distribute to user-defined procs

### DIFF
--- a/Src/Base/AMReX_DistributionMapping.H
+++ b/Src/Base/AMReX_DistributionMapping.H
@@ -236,7 +236,9 @@ class DistributionMapping
     * if use_box_vol is true, weight boxes by their volume in Distribute
     * otherwise, all boxes will be treated with equal weight
     */
-    static std::vector<std::vector<int> > makeSFC (const BoxArray& ba, bool use_box_vol=true);
+    static std::vector<std::vector<int> > makeSFC (const BoxArray& ba, 
+                                                   bool use_box_vol=true,
+                                                   const int nprocs=ParallelContext::NProcsSub() );
 
     /** \brief Computes the average cost per MPI rank given a distribution mapping
      * global cost vector.

--- a/Src/Base/AMReX_DistributionMapping.cpp
+++ b/Src/Base/AMReX_DistributionMapping.cpp
@@ -1818,7 +1818,7 @@ DistributionMapping::makeSFC (const LayoutData<Real>& rcost_local,
 }
     
 std::vector<std::vector<int> >
-DistributionMapping::makeSFC (const BoxArray& ba, bool use_box_vol)
+DistributionMapping::makeSFC (const BoxArray& ba, bool use_box_vol, const int nprocs)
 {
     BL_PROFILE("makeSFC");
 
@@ -1857,7 +1857,6 @@ DistributionMapping::makeSFC (const BoxArray& ba, bool use_box_vol)
     //
     std::sort(tokens.begin(), tokens.end(), SFCToken::Compare());
 
-    const int nprocs = ParallelContext::NProcsSub();
     Real volper;
     volper = vol_sum / nprocs;
 


### PR DESCRIPTION
Extends the makeSFC method to take an additional argument where the user can override the number of processes a BoxArray is distributed to.

https://github.com/AMReX-Codes/amrex/blob/227bf82812793dc942fa8472974bcdd3d3e60ad3/Src/Base/AMReX_DistributionMapping.H#L235-L239