### PR TITLE
Remove directly accessing the m_idata and m_rdata structs internally

### DIFF
--- a/Src/Extern/Conduit/AMReX_Conduit_Blueprint_ParticlesI.H
+++ b/Src/Extern/Conduit/AMReX_Conduit_Blueprint_ParticlesI.H
@@ -64,18 +64,18 @@ ParticleTileToBlueprint(const ParticleTile<NStructReal,
     // point locations from from aos
     //----------------------------------//
 
-    n_coords["values/x"].set_external(const_cast<ParticleReal*>(&p_aos.m_rdata.pos[0]),
+    n_coords["values/x"].set_external(const_cast<ParticleReal*>(&p_aos.pos(0)),
                                       num_particles,
                                       0,
                                       struct_size);
 #if AMREX_SPACEDIM > 1
-    n_coords["values/y"].set_external(const_cast<ParticleReal*>(&p_aos.m_rdata.pos[1]),
+    n_coords["values/y"].set_external(const_cast<ParticleReal*>(&p_aos.pos(1)),
                                       num_particles,
                                       0,
                                       struct_size);
 #endif
 #if AMREX_SPACEDIM > 2
-    n_coords["values/z"].set_external(const_cast<ParticleReal*>(&p_aos.m_rdata.pos[2]),
+    n_coords["values/z"].set_external(const_cast<ParticleReal*>(&p_aos.pos(2)),
                                       num_particles,
                                       0,
                                       struct_size);
@@ -94,7 +94,7 @@ ParticleTileToBlueprint(const ParticleTile<NStructReal,
 
     n_f_id["topology"] = topology_name;
     n_f_id["association"] = "element";
-    n_f_id["values"].set_external(const_cast<int*>(&p_aos.m_idata.arr[0]),
+    n_f_id["values"].set_external(const_cast<int*>(&p_aos.id()),
                                   num_particles,
                                   0,
                                   struct_size);
@@ -104,7 +104,7 @@ ParticleTileToBlueprint(const ParticleTile<NStructReal,
 
     n_f_cpu["topology"] = topology_name;
     n_f_cpu["association"] = "element";
-    n_f_cpu["values"].set_external(const_cast<int*>(&p_aos.m_idata.arr[1]),
+    n_f_cpu["values"].set_external(const_cast<int*>(&p_aos.cpu()),
                                    num_particles,
                                    0,
                                    struct_size);
@@ -116,12 +116,12 @@ ParticleTileToBlueprint(const ParticleTile<NStructReal,
     int vname_real_idx = 0;
     // struct real fields, the first set are always the particle positions
     // which we wrap above
-    for (int i = AMREX_SPACEDIM; i < AMREX_SPACEDIM + NStructReal; i++)
+    for (int i = 0; i < NStructReal; i++)
     {
         conduit::Node &n_f = n_fields[real_comp_names[vname_real_idx]];
         n_f["topology"] = topology_name;
         n_f["association"] = "element";
-        n_f["values"].set_external(const_cast<ParticleReal*>(&p_aos.m_rdata.arr[i]),
+        n_f["values"].set_external(const_cast<ParticleReal*>(&p_aos.rdata(i)),
                                    num_particles,
                                    0,
                                    struct_size);
@@ -130,14 +130,12 @@ ParticleTileToBlueprint(const ParticleTile<NStructReal,
     }
 
     int vname_int_idx = 0;
-    // struct int fields, first two are always id, and cpu --
-    // which we wrap above
-    for (int i = 2; i < 2 + NStructInt; i++)
+    for (int i = 0; i < NStructInt; i++)
     {
         conduit::Node &n_f = n_fields[int_comp_names[vname_int_idx]];
         n_f["topology"] = topology_name;
         n_f["association"] = "element";
-        n_f["values"].set_external(const_cast<int*>(&p_aos.m_idata.arr[i]),
+        n_f["values"].set_external(const_cast<int*>(&p_aos.idata(i)),
                                    num_particles,
                                    0,
                                    struct_size);
@@ -150,7 +148,7 @@ ParticleTileToBlueprint(const ParticleTile<NStructReal,
 
      const auto &soa = ptile.GetStructOfArrays();
 
-    // for soa entries, we can use standard strides, 
+    // for soa entries, we can use standard strides,
     // since these are contiguous arrays
 
     // array real fields

--- a/Src/Particle/AMReX_ArrayOfStructs.H
+++ b/Src/Particle/AMReX_ArrayOfStructs.H
@@ -67,8 +67,8 @@ public:
     
     bool empty () const { return m_data.empty(); }
     
-    const RealType* data () const { return &(m_data[0].m_rdata.arr[0]); }
-    RealType* data () { return &(m_data[0].m_rdata.arr[0]); }
+    const RealType* data () const { return &(m_data[0].pos(0)); }
+    RealType* data () { return &(m_data[0].pos(0)); }
 
     const RealType* dataPtr () const { return data(); }
     RealType*       dataPtr ()       { return data(); }

--- a/Src/Particle/AMReX_Particle.H
+++ b/Src/Particle/AMReX_Particle.H
@@ -66,43 +66,43 @@ struct Particle
 
     static int the_next_id;
 
-    AMREX_GPU_HOST_DEVICE int&  id()       & {return m_idata.id;}
-    AMREX_GPU_HOST_DEVICE int   id() const & {return m_idata.id;}
-    AMREX_GPU_HOST_DEVICE int& cpu()       & {return m_idata.cpu;}
-    AMREX_GPU_HOST_DEVICE int  cpu() const & {return m_idata.cpu;}
+    AMREX_GPU_HOST_DEVICE int&  id ()       & {return m_idata.id;}
+    AMREX_GPU_HOST_DEVICE int   id () const & {return m_idata.id;}
+    AMREX_GPU_HOST_DEVICE int& cpu ()       & {return m_idata.cpu;}
+    AMREX_GPU_HOST_DEVICE int  cpu () const & {return m_idata.cpu;}
 
-    AMREX_GPU_HOST_DEVICE RealVect pos() const &
+    AMREX_GPU_HOST_DEVICE RealVect pos () const &
     {return RealVect(AMREX_D_DECL(m_rdata.pos[0], m_rdata.pos[1], m_rdata.pos[2]));}
 
-    AMREX_GPU_HOST_DEVICE RealType& pos(int index)       &
+    AMREX_GPU_HOST_DEVICE RealType& pos (int index)       &
 	{
 		AMREX_ASSERT(index < AMREX_SPACEDIM);
 		return m_rdata.pos[index];
 	}
-    AMREX_GPU_HOST_DEVICE RealType  pos(int index) const &
+    AMREX_GPU_HOST_DEVICE RealType  pos (int index) const &
 	{
 		AMREX_ASSERT(index < AMREX_SPACEDIM);
 		return m_rdata.pos[index];
 	}
 
-    AMREX_GPU_HOST_DEVICE RealType& rdata(int index)       &
+    AMREX_GPU_HOST_DEVICE RealType& rdata (int index)       &
 	{
 		AMREX_ASSERT(index < NReal);
 		return m_rdata.arr[AMREX_SPACEDIM + index];
 	}
-    AMREX_GPU_HOST_DEVICE RealType  rdata(int index) const &
+    AMREX_GPU_HOST_DEVICE RealType  rdata (int index) const &
 	{
 		AMREX_ASSERT(index < NReal);
 		return m_rdata.arr[AMREX_SPACEDIM + index];
 	}
-    AMREX_GPU_HOST_DEVICE RealVect  rvec(AMREX_D_DECL(int indx, int indy, int indz)) const &
+    AMREX_GPU_HOST_DEVICE RealVect  rvec (AMREX_D_DECL(int indx, int indy, int indz)) const &
 	{
 		AMREX_ASSERT(AMREX_D_TERM(indx < NReal, and indy < NReal, and indz < NReal));
 		return RealVect(AMREX_D_DECL(m_rdata.arr[AMREX_SPACEDIM + indx],
                                  m_rdata.arr[AMREX_SPACEDIM + indy],
                                  m_rdata.arr[AMREX_SPACEDIM + indz]));
 	}
-    AMREX_GPU_HOST_DEVICE RealVect  rvec(const IntVect& indexes) const &
+    AMREX_GPU_HOST_DEVICE RealVect  rvec (const IntVect& indexes) const &
 	{
 		AMREX_ASSERT(indexes.max() < NReal);
 		return RealVect(AMREX_D_DECL(m_rdata.arr[AMREX_SPACEDIM + indexes[0]],
@@ -110,14 +110,14 @@ struct Particle
                                  m_rdata.arr[AMREX_SPACEDIM + indexes[2]]));
 	}
 
-    AMREX_GPU_HOST_DEVICE int& idata(int index)       &
+    AMREX_GPU_HOST_DEVICE int& idata (int index)       &
 	{
 		AMREX_ASSERT(index < NInt);
 		return m_idata.arr[2 + index];
 	}
-    AMREX_GPU_HOST_DEVICE int  idata(int index) const &
+    AMREX_GPU_HOST_DEVICE int  idata (int index) const &
 	{
-		AMREX_ASSERT(index < NInt);		
+		AMREX_ASSERT(index < NInt);
 		return m_idata.arr[2 + index];
 	}
 

--- a/Src/Particle/AMReX_ParticleContainerI.H
+++ b/Src/Particle/AMReX_ParticleContainerI.H
@@ -69,9 +69,9 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>::Index (const 
     IntVect iv;
     const Geometry& geom = Geom(lev);
 
-    AMREX_D_TERM(iv[0]=static_cast<int>(floor((p.m_rdata.pos[0]-geom.ProbLo(0))*geom.InvCellSize(0)));,
-                 iv[1]=static_cast<int>(floor((p.m_rdata.pos[1]-geom.ProbLo(1))*geom.InvCellSize(1)));,
-                 iv[2]=static_cast<int>(floor((p.m_rdata.pos[2]-geom.ProbLo(2))*geom.InvCellSize(2))););
+    AMREX_D_TERM(iv[0]=static_cast<int>(floor((p.pos(0)-geom.ProbLo(0))*geom.InvCellSize(0)));,
+                 iv[1]=static_cast<int>(floor((p.pos(1)-geom.ProbLo(1))*geom.InvCellSize(1)));,
+                 iv[2]=static_cast<int>(floor((p.pos(2)-geom.ProbLo(2))*geom.InvCellSize(2))););
 
     iv += geom.Domain().smallEnd();
 
@@ -193,9 +193,9 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
 	    }
             
             if (grid >= 0) {
-                AMREX_D_TERM(p.m_rdata.pos[0] = p_prime.m_rdata.pos[0];,
-                             p.m_rdata.pos[1] = p_prime.m_rdata.pos[1];,
-                             p.m_rdata.pos[2] = p_prime.m_rdata.pos[2];);
+                AMREX_D_TERM(p.pos(0) = p_prime.pos(0);,
+                             p.pos(1) = p_prime.pos(1);,
+                             p.pos(2) = p_prime.pos(2););
                 
                 const Box& bx = ba.getCellCenteredBox(grid);
                 
@@ -223,31 +223,31 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
 
     const Geometry& geom    = Geom(0);
     const Box&      dmn     = geom.Domain();
-    const IntVect&  iv      = Index(p, 0);    
-    bool            shifted = false;  
-    
+    const IntVect&  iv      = Index(p, 0);
+    bool            shifted = false;
+
     for (int i = 0; i < AMREX_SPACEDIM; i++)
     {
         if (!geom.isPeriodic(i)) continue;
 
         if (iv[i] > dmn.bigEnd(i))
         {
-            while (p.m_rdata.pos[i] >= (typename ParticleType::RealType) geom.ProbHi(i)) p.m_rdata.pos[i] -= (typename ParticleType::RealType) geom.ProbLength(i);
-            if (p.m_rdata.pos[i] < (typename ParticleType::RealType) geom.ProbLo(i)) p.m_rdata.pos[i] = (typename ParticleType::RealType) geom.ProbLo(i); // clamp to avoid precision issues;
+            while (p.pos(i) >= (typename ParticleType::RealType) geom.ProbHi(i)) p.pos(i) -= (typename ParticleType::RealType) geom.ProbLength(i);
+            if (p.pos(i) < (typename ParticleType::RealType) geom.ProbLo(i)) p.pos(i) = (typename ParticleType::RealType) geom.ProbLo(i); // clamp to avoid precision issues;
 	            shifted = true;
         }
         else if (iv[i] < dmn.smallEnd(i))
         {
-            while (p.m_rdata.pos[i] <  (typename ParticleType::RealType) geom.ProbLo(i)) p.m_rdata.pos[i] += (typename ParticleType::RealType) geom.ProbLength(i);
+            while (p.pos(i) <  (typename ParticleType::RealType) geom.ProbLo(i)) p.pos(i) += (typename ParticleType::RealType) geom.ProbLength(i);
 
             // clamp to avoid precision issues
-            if ( p.m_rdata.pos[i] == (typename ParticleType::RealType) geom.ProbHi(i)) p.m_rdata.pos[i] = (typename ParticleType::RealType) geom.ProbLo(i);
-            if ((p.m_rdata.pos[i] > (typename ParticleType::RealType) geom.ProbHi(i))) 
-                p.m_rdata.pos[i] = (typename ParticleType::RealType) geom.ProbHi(i) - std::numeric_limits<typename ParticleType::RealType>::epsilon();
+            if ( p.pos(i) == (typename ParticleType::RealType) geom.ProbHi(i)) p.pos(i) = (typename ParticleType::RealType) geom.ProbLo(i);
+            if ((p.pos(i) > (typename ParticleType::RealType) geom.ProbHi(i)))
+                p.pos(i) = (typename ParticleType::RealType) geom.ProbHi(i) - std::numeric_limits<typename ParticleType::RealType>::epsilon();
 
             shifted = true;
 	    }
-        AMREX_ASSERT( (p.m_rdata.pos[i] >= (typename ParticleType::RealType) geom.ProbLo(i) ) and ( p.m_rdata.pos[i] < (typename ParticleType::RealType) geom.ProbHi(i) ));
+        AMREX_ASSERT( (p.pos(i) >= (typename ParticleType::RealType) geom.ProbLo(i) ) and ( p.pos(i) < (typename ParticleType::RealType) geom.ProbHi(i) ));
     }
 
     return shifted;
@@ -279,9 +279,9 @@ Reset (ParticleType& p,
             amrex::AllPrint()<< "Invalidating out-of-domain particle: " << p << '\n'; 
 	}
 
-	AMREX_ASSERT(p.m_idata.id > 0);
+	AMREX_ASSERT(p.id() > 0);
 
-	p.m_idata.id = -p.m_idata.id;
+	p.id() = -p.id();
     }
 
     return pld;
@@ -328,15 +328,15 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>::RedefineDummy
 
 template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt>
 void
-ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>::locateParticle (ParticleType& p, ParticleLocData& pld, 
+ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>::locateParticle (ParticleType& p, ParticleLocData& pld,
                                                                                    int lev_min, int lev_max, int nGrow, int local_grid) const
 {
-    bool outside = AMREX_D_TERM(p.m_rdata.pos[0] <  Geom(0).ProbLo(0)
-                             || p.m_rdata.pos[0] >= Geom(0).ProbHi(0),
-                             || p.m_rdata.pos[1] <  Geom(0).ProbLo(1)
-                             || p.m_rdata.pos[1] >= Geom(0).ProbHi(1),
-                             || p.m_rdata.pos[2] <  Geom(0).ProbLo(2)
-                             || p.m_rdata.pos[2] >= Geom(0).ProbHi(2));
+    bool outside = AMREX_D_TERM(p.pos(0) <  Geom(0).ProbLo(0)
+                             || p.pos(0) >= Geom(0).ProbHi(0),
+                             || p.pos(1) <  Geom(0).ProbLo(1)
+                             || p.pos(1) >= Geom(0).ProbHi(1),
+                             || p.pos(2) <  Geom(0).ProbLo(2)
+                             || p.pos(2) >= Geom(0).ProbHi(2));
 
     bool success;
     if (outside)
@@ -346,7 +346,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>::locateParticl
       if (!success && lev_min == 0)
       {
           // The particle has left the domain; invalidate it.
-          p.m_idata.id = -p.m_idata.id;
+          p.id() = -p.id();
           success = true;
       }
     }
@@ -396,7 +396,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>::NumberOfParti
       if (only_valid) {
 	for (int k = 0; k < ptile.GetArrayOfStructs().numParticles(); ++k) {
 	  const ParticleType& p = ptile.GetArrayOfStructs()[k];
-	  if (p.m_idata.id > 0) ++nparticles[gid];
+	  if (p.id() > 0) ++nparticles[gid];
 	}
       } else {
 	nparticles[gid] += ptile.numParticles();
@@ -421,7 +421,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>::NumberOfParti
             if (only_valid) {
                 for (int k = 0; k < ptile.GetArrayOfStructs().numParticles(); ++k) {
                     const ParticleType& p = ptile.GetArrayOfStructs()[k];
-                    if (p.m_idata.id > 0) ++nparticles;
+                    if (p.id() > 0) ++nparticles;
                 }
             } else {
                 nparticles += ptile.numParticles();
@@ -563,14 +563,14 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>::MoveRandom (i
         for (int i = 0; i < n; i++)
         {
 	  ParticleType& p = aos[i];
-	  
-	  if (p.m_idata.id <= 0) continue;
-	  
+
+	  if (p.id() <= 0) continue;
+
 	  for (int j = 0; j < AMREX_SPACEDIM; j++)
               {
-                  p.m_rdata.pos[j] += dist[j]*(2*amrex::Random()-1);
+                  p.pos(j) += dist[j]*(2*amrex::Random()-1);
               }
-	  
+
 	  Reset(p, true);
         }
     }
@@ -625,7 +625,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>::IncrementWith
       FArrayBox&  fab  = (*mf_pointer)[gid];
       for (int k = 0; k < pbox.numParticles(); ++ k) {
 	const ParticleType& p = pbox[k];
-          if (p.m_idata.id > 0) {
+        if (p.id() > 0) {
               Where(p, pld);
               AMREX_ASSERT(pld.m_grid == gid);
               fab(pld.m_cell) += 1;
@@ -663,8 +663,8 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>::sumParticleMa
       const auto& pbox = kv.second.GetArrayOfStructs();
       for (int k = 0; k < pbox.numParticles(); ++k) {
 	  const ParticleType& p = pbox[k];
-	  if (p.m_idata.id > 0) {
-	      msum += p.m_rdata.arr[AMREX_SPACEDIM+rho_index];
+	  if (p.id() > 0) {
+	      msum += p.rdata(rho_index);
 	  }
       }
   }
@@ -751,7 +751,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
             for (auto it = pbox.cbegin(); it != pbox.cend(); ++it)
             {
 	        ParticleType p = *it;
-	        p.m_idata.id = VirtualParticleID;
+	        p.id() = VirtualParticleID;
                 virts.push_back(p);
             }
         }
@@ -781,18 +781,18 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
                     // It's in the no-aggregation buffer.
                     // Set its id to indicate that it's a virt.
 		    ParticleType p = *it;
-                    p.m_idata.id = VirtualParticleID;
+                    p.id() = VirtualParticleID;
                     virts.push_back(p);
                 }
                 else
                 {
                     //
-                    // Note that Cell aggregation assumes that p.m_rdata.arr[AMREX_SPACEDIM] is mass and
+                    // Note that Cell aggregation assumes that p.rdata(0) is mass and
                     // that all other components should be combined in a mass-weighted
                     // average.
                     //
                     auto agg_map_it = agg_map.find(cell);
-                    
+
                     if (agg_map_it == agg_map.end())
                     {
                         //
@@ -802,7 +802,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
                         //
                         // Set its id to indicate that it's a virt.
                         //
-                        p.m_idata.id = VirtualParticleID;
+                        p.id() = VirtualParticleID;
                         agg_map[cell] = p;
                     }
                     else
@@ -810,29 +810,29 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
                         AMREX_ASSERT(agg_map_it != agg_map.end());
                         const ParticleType&  pnew       = *it;
                         ParticleType&        pold       = agg_map_it->second;
-                        const Real           old_mass   = pold.m_rdata.arr[AMREX_SPACEDIM];
-                        const Real           new_mass   = pnew.m_rdata.arr[AMREX_SPACEDIM];
+                        const Real           old_mass   = pold.rdata(0);
+                        const Real           new_mass   = pnew.rdata(0);
                         const Real           total_mass = old_mass + new_mass;
                         //
                         // Set the position to the center of mass.
                         //
                         for (int i = 0; i < AMREX_SPACEDIM; i++)
                         {
-                            pold.m_rdata.pos[i] = (old_mass*pold.m_rdata.pos[i] + new_mass*pnew.m_rdata.pos[i])/total_mass;
+                            pold.pos(i) = (old_mass*pold.pos(i) + new_mass*pnew.pos(i))/total_mass;
                         }
                         AMREX_ASSERT(this->Index(pold, level) == cell);
                         //
                         // Set the metadata (presumably velocity) to the mass-weighted average.
                         //
-                        for (int i = AMREX_SPACEDIM + 1; i < AMREX_SPACEDIM + NStructReal; i++)
+                        for (int i = 1; i < NStructReal; i++)
                         {
-                            pold.m_rdata.arr[i] = (old_mass*pold.m_rdata.arr[i] + new_mass*pnew.m_rdata.arr[i])/total_mass;
+                            pold.rdata(i) = (old_mass*pold.rdata(i) + new_mass*pnew.rdata(i))/total_mass;
                         }
-                        pold.m_rdata.arr[AMREX_SPACEDIM] = total_mass;
+                        pold.rdata(0) = total_mass;
                     }
                 }
             }
-            
+
             //
             // Add the aggregated particles to the virtuals.
             //
@@ -872,7 +872,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
             {
                 amrex::ignore_unused(isec);
                 ParticleType p = *it;  // yes, make a copy
-                p.m_idata.id = GhostParticleID;	    
+                p.id() = GhostParticleID;
                 ghosts().push_back(p);
             }
         }
@@ -1339,7 +1339,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
           int tile = grid_tile_ids[pmap_it].second;
           auto& aos = ptile_ptrs[pmap_it]->GetArrayOfStructs();
           auto& soa = ptile_ptrs[pmap_it]->GetStructOfArrays();
-          unsigned npart = aos.numParticles();              
+          unsigned npart = aos.numParticles();
           ParticleLocData pld;
           if (npart != 0) {
               Long last = npart - 1;
@@ -1347,7 +1347,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
               while (pindex <= last) {
                   ParticleType& p = aos[pindex];
 
-                  if (p.m_idata.id < 0)
+                  if (p.id() < 0)
 		  {
                       aos[pindex] = aos[last];
                       for (int comp = 0; comp < NumRealComps(); comp++)
@@ -1358,12 +1358,12 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
                       --last;
                       continue;
                   }
-                      
+
                   locateParticle(p, pld, lev_min, lev_max, nGrow, local ? grid : -1);
 
                   particlePostLocate(p, pld, lev);
-                  
-                  if (p.m_idata.id < 0)
+
+                  if (p.id() < 0)
                   {
                       aos[pindex] = aos[last];
                       for (int comp = 0; comp < NumRealComps(); comp++)
@@ -1390,8 +1390,8 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
                               IntVector& arr = soa_local[pld.m_lev][index][thread_num].GetIntData(comp);
                               arr.push_back(soa.GetIntData(comp)[pindex]);
                           }
-                          
-                          p.m_idata.id = -p.m_idata.id; // Invalidate the particle
+
+                          p.id() = -p.id(); // Invalidate the particle
                       }
                   }
                   else {
@@ -1413,11 +1413,11 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
                               dst += sizeof(int);
                           }
                       }
-                      
-                      p.m_idata.id = -p.m_idata.id; // Invalidate the particle
+
+                      p.id() = -p.id(); // Invalidate the particle
                   }
-                  
-                  if (p.m_idata.id < 0)
+
+                  if (p.id() < 0)
 		  {
                       aos[pindex] = aos[last];
                       for (int comp = 0; comp < NumRealComps(); comp++)
@@ -1428,10 +1428,10 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
                       --last;
                       continue;
                   }
-                  
+
                   ++pindex;
               }
-              
+
               aos().erase(aos().begin() + last + 1, aos().begin() + npart);
               for (int comp = 0; comp < NumRealComps(); comp++) {
                   RealVector& rdata = soa.GetRealData(comp);
@@ -1444,11 +1444,11 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
           }
       }
   }
-  
+
   for (int lev = lev_min; lev <= lev_max; lev++) {
       auto& pmap = m_particles[lev];
       for (auto pmap_it = pmap.begin(); pmap_it != pmap.end(); /* no ++ */) {
-          
+
           // Remove any map entries for which the particle container is now empty.
           if (pmap_it->second.empty()) {
               pmap.erase(pmap_it++);
@@ -2214,11 +2214,11 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
         {
 	  ParticleType& p = pbox[i];
 
-	  if (p.m_idata.id > 0)
+	  if (p.id() > 0)
             {
 
 	      //
-	      // Note: rdata.arr[AMREX_SPACEDIM] is mass, AMREX_SPACEDIM+1 is v_x, ...
+	      // Note: rdata(0) is mass, AMREX_SPACEDIM+1 is v_x, ...
 	      //
 	      Real grav[AMREX_SPACEDIM];
 
@@ -2226,29 +2226,28 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
 	      //
 	      // Define (a u)^new = (a u)^half + dt/2 grav^new
 	      //
-	      AMREX_D_TERM(p.m_rdata.arr[AMREX_SPACEDIM+1] *= a_half;,
-		     p.m_rdata.arr[AMREX_SPACEDIM+2] *= a_half;,
-		     p.m_rdata.arr[AMREX_SPACEDIM+3] *= a_half;);
+	      AMREX_D_TERM(p.rdata(1) *= a_half;,
+                           p.rdata(2) *= a_half;,
+                           p.rdata(3) *= a_half;);
 
-	      AMREX_D_TERM(p.m_rdata.arr[AMREX_SPACEDIM+1] += half_dt * grav[0];,
-		     p.m_rdata.arr[AMREX_SPACEDIM+2] += half_dt * grav[1];,
-		     p.m_rdata.arr[AMREX_SPACEDIM+3] += half_dt * grav[2];);
+	      AMREX_D_TERM(p.rdata(1) += half_dt * grav[0];,
+                           p.rdata(2) += half_dt * grav[1];,
+                           p.rdata(3) += half_dt * grav[2];);
 
-	      AMREX_D_TERM(p.m_rdata.arr[AMREX_SPACEDIM+1] *= a_new_inv;,
-		     p.m_rdata.arr[AMREX_SPACEDIM+2] *= a_new_inv;,
-		     p.m_rdata.arr[AMREX_SPACEDIM+3] *= a_new_inv;);
+	      AMREX_D_TERM(p.rdata(1) *= a_new_inv;,
+                           p.rdata(2) *= a_new_inv;,
+                           p.rdata(3) *= a_new_inv;);
 
 	      if (start_comp_for_accel > AMREX_SPACEDIM)
-                {
-		  AMREX_D_TERM(p.m_rdata.arr[AMREX_SPACEDIM + start_comp_for_accel  ] = grav[0];,
-			 p.m_rdata.arr[AMREX_SPACEDIM + start_comp_for_accel+1] = grav[1];,
-			 p.m_rdata.arr[AMREX_SPACEDIM + start_comp_for_accel+2] = grav[2];);
-                }
+              {
+                    AMREX_D_TERM(p.rdata(start_comp_for_accel  ) = grav[0];,
+                                 p.rdata(start_comp_for_accel+1) = grav[1];,
+                                 p.rdata(start_comp_for_accel+2) = grav[2];);
+              }
             }
         }
     }
 
-    
     if (ac_pointer != &acceleration) delete ac_pointer;
 
     if (m_verbose > 1)

--- a/Src/Particle/AMReX_ParticleHDF5.H
+++ b/Src/Particle/AMReX_ParticleHDF5.H
@@ -344,7 +344,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
                 {
                     // Only count (and checkpoint) valid particles.
                     const ParticleType& p = aos[k];
-                    if (p.m_idata.id > 0) nparticles++;
+                    if (p.id() > 0) nparticles++;
                 }
             }
         }
@@ -601,7 +601,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
 	for (int k = 0; k < kv.second.GetArrayOfStructs().numParticles(); ++k)
 	{
 	    const ParticleType& p = kv.second.GetArrayOfStructs()[k];
-  	    if (p.m_idata.id > 0) {
+  	    if (p.id() > 0) {
                 cnt++;
 	    }	    
 	}
@@ -703,11 +703,14 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
             const auto& pbox = m_particles[lev].at(std::make_pair(grid, tile_map[grid][i]));
             for (int pindex = 0; pindex < pbox.GetArrayOfStructs().numParticles(); ++pindex) {
                 const ParticleType& p = pbox.GetArrayOfStructs()[pindex];
-                if (p.m_idata.id > 0) {
-                    for (int j = 0; j < 2 + NStructInt; j++) {
-                        iptr[j] = p.m_idata.arr[j];
+                if (p.id() > 0) {
+                    *iptr = p.id(); ++iptr;
+                    *iptr = p.cpu(); ++iptr;
+
+                    for (int j = 0; j < NStructInt; j++) {
+                        iptr[j] = p.idata(j);
                     }
-                    iptr += 2 + NStructInt;
+                    iptr += NStructInt;
                     const auto& soa  = pbox.GetStructOfArrays();
                     for (int j = 0; j < NArrayInt; j++) {
                         iptr[j] = soa.GetIntData(j)[pindex];
@@ -740,9 +743,12 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
             const auto& pbox = m_particles[lev].at(std::make_pair(grid, tile_map[grid][i]));
             for (int pindex = 0; pindex < pbox.GetArrayOfStructs().numParticles(); ++pindex) {
                 const ParticleType& p = pbox.GetArrayOfStructs()[pindex];
-                if (p.m_idata.id > 0) {
-                    for (int j = 0; j < AMREX_SPACEDIM + NStructReal; j++) {
-                        rptr[j] = p.m_rdata.arr[j];
+                if (p.id() > 0) {
+                    for (int j = 0; j < AMREX_SPACEDIM; j++) {
+                        rptr[j] = p.pos(j);
+                    }
+                    for (int j = 0; j < NStructReal; j++) {
+                        rptr[j] = p.rdata(j);
                     }
                     rptr += AMREX_SPACEDIM + NStructReal;
                     const auto& soa  = pbox.GetStructOfArrays();
@@ -1225,28 +1231,28 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
     host_int_attribs.resize(finest_level_in_file+1);
 
     for (int i = 0; i < cnt; i++) {
-        p.m_idata.id   = iptr[0];
-        p.m_idata.cpu  = iptr[1];
-        
+        p.id()   = iptr[0];
+        p.cpu()  = iptr[1];
+
         iptr += 2;
-            
+
         for (int j = 0; j < NStructInt; j++)
         {
-            p.m_idata.arr[2+j] = *iptr;
+            p.idata(j) = *iptr;
             ++iptr;
         }
 
-        AMREX_ASSERT(p.m_idata.id > 0);
-        
-        AMREX_D_TERM(p.m_rdata.pos[0] = rptr[0];,
-                     p.m_rdata.pos[1] = rptr[1];,
-                     p.m_rdata.pos[2] = rptr[2];);
-        
+        AMREX_ASSERT(p.id() > 0);
+
+        AMREX_D_TERM(p.pos(0) = rptr[0];,
+                     p.pos(1) = rptr[1];,
+                     p.pos(2) = rptr[2];);
+
         rptr += AMREX_SPACEDIM;
-        
+
         for (int j = 0; j < NStructReal; j++)
         {
-            p.m_rdata.arr[AMREX_SPACEDIM+j] = *rptr;
+            p.rdata(j) = *rptr;
             ++rptr;
         }
 

--- a/Src/Particle/AMReX_ParticleHDF5.H
+++ b/Src/Particle/AMReX_ParticleHDF5.H
@@ -747,10 +747,11 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
                     for (int j = 0; j < AMREX_SPACEDIM; j++) {
                         rptr[j] = p.pos(j);
                     }
+                    rptr += AMREX_SPACEDIM;
                     for (int j = 0; j < NStructReal; j++) {
                         rptr[j] = p.rdata(j);
                     }
-                    rptr += AMREX_SPACEDIM + NStructReal;
+                    rptr += NStructReal;
                     const auto& soa  = pbox.GetStructOfArrays();
                     for (int j = 0; j < NArrayReal; j++) {
                         rptr[j] = (typename ParticleType::RealType) soa.GetRealData(j)[pindex];

--- a/Src/Particle/AMReX_ParticleIO.H
+++ b/Src/Particle/AMReX_ParticleIO.H
@@ -9,7 +9,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
 {
     if (sizeof(typename ParticleType::RealType) == 4) {
         writeFloatData((float*) data, size, os, ParticleRealDescriptor);
-    } 
+    }
     else if (sizeof(typename ParticleType::RealType) == 8) {
         writeDoubleData((double*) data, size, os, ParticleRealDescriptor);
     }
@@ -23,7 +23,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
 {
     if (sizeof(typename ParticleType::RealType) == 4) {
         readFloatData((float*) data, size, is, ParticleRealDescriptor);
-    } 
+    }
     else if (sizeof(typename ParticleType::RealType) == 8) {
         readDoubleData((double*) data, size, is, ParticleRealDescriptor);
     }
@@ -719,7 +719,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
             const auto& aos = kv.second.GetArrayOfStructs();
             for (int k = 0; k < aos.numParticles(); ++k) {
                 const ParticleType& p = aos[k];
-                if (p.m_idata.id > 0) {
+                if (p.id() > 0) {
                     //
                     // Only count (and checkpoint) valid particles.
                     //
@@ -890,19 +890,19 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
                 if (pflags[pindex])
                 {
                     // always write these
-                    for (int j = 0; j < 2; j++) iptr[j] = p.m_idata.arr[j];
-                    iptr += 2;
-                    
+                    *iptr = p.id(); ++iptr;
+                    *iptr = p.cpu(); ++iptr;
+
                     // optionally write these
                     for (int j = 0; j < NStructInt; j++)
                     {
                         if (write_int_comp[j])
                         {
-                            *iptr = p.m_idata.arr[2+j];
+                            *iptr = p.idata(j);
                             ++iptr;
                         }
                     }
-                    
+
                     const auto& soa  = pbox.GetStructOfArrays();
                     for (int j = 0; j < NumIntComps(); j++)
                     {
@@ -934,23 +934,23 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
 			const auto& pflags = particle_io_flags[lev].at(ptile_index);
             for (int pindex = 0; pindex < pbox.GetArrayOfStructs().numParticles(); ++pindex) {
                 const auto& aos = pbox.GetArrayOfStructs();
-                const auto& p = aos[pindex];				
+                const auto& p = aos[pindex];
                 if (pflags[pindex])
                 {
                     // always write these
-                    for (int j = 0; j < AMREX_SPACEDIM; j++) rptr[j] = p.m_rdata.arr[j];
+                    for (int j = 0; j < AMREX_SPACEDIM; j++) rptr[j] = p.pos(j);
                     rptr += AMREX_SPACEDIM;
-                    
+
                     // optionally write these
                     for (int j = 0; j < NStructReal; j++)
                     {
                         if (write_real_comp[j])
                         {
-                            *rptr = p.m_rdata.arr[AMREX_SPACEDIM+j];
+                            *rptr = p.rdata(j);
                             ++rptr;
                         }
                     }
-                    
+
                     const auto& soa  = pbox.GetStructOfArrays();
                     for (int j = 0; j < NumRealComps(); j++)
                     {
@@ -1289,33 +1289,33 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
     host_int_attribs.resize(finest_level_in_file+1);
 
     for (int i = 0; i < cnt; i++) {
-        p.m_idata.id   = iptr[0];
-        p.m_idata.cpu  = iptr[1];
-        
+        p.id()   = iptr[0];
+        p.cpu()  = iptr[1];
+
         iptr += 2;
-            
+
         for (int j = 0; j < NStructInt; j++)
         {
-            p.m_idata.arr[2+j] = *iptr;
+            p.idata(j) = *iptr;
             ++iptr;
         }
 
-        AMREX_ASSERT(p.m_idata.id > 0);
-        
-        AMREX_D_TERM(p.m_rdata.pos[0] = rptr[0];,
-                     p.m_rdata.pos[1] = rptr[1];,
-                     p.m_rdata.pos[2] = rptr[2];);
-        
+        AMREX_ASSERT(p.id() > 0);
+
+        AMREX_D_TERM(p.pos(0) = rptr[0];,
+                     p.pos(1) = rptr[1];,
+                     p.pos(2) = rptr[2];);
+
         rptr += AMREX_SPACEDIM;
-        
+
         for (int j = 0; j < NStructReal; j++)
         {
-            p.m_rdata.arr[AMREX_SPACEDIM+j] = *rptr;
+            p.rdata(j) = *rptr;
             ++rptr;
         }
 
         locateParticle(p, pld, 0, finestLevel(), 0);
-        
+
 	std::pair<int, int> ind(grd, pld.m_tile);
 
         host_real_attribs[lev][ind].resize(NumRealComps());
@@ -1393,7 +1393,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>::WriteAsciiFil
 	    Gpu::copy(Gpu::deviceToHost, aos.begin(), aos.begin() + np, host_aos.begin());
 	    for (int k = 0; k < np; ++k) {
 	        const ParticleType& p = host_aos[k];
-                if (p.m_idata.id > 0)
+                if (p.id() > 0)
                     //
                     // Only count (and checkpoint) valid particles.
                     //
@@ -1469,51 +1469,51 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>::WriteAsciiFil
 
 		for (int index = 0; index < np; ++index) {
 		    const ParticleType* it = &host_aos[index];
-		    if (it->m_idata.id > 0) {
+		    if (it->id() > 0) {
 
-                        // write out the particle struct first... 
-                        AMREX_D_TERM(File << it->m_rdata.pos[0] << ' ',
-                               << it->m_rdata.pos[1] << ' ',
-                               << it->m_rdata.pos[2] << ' ');
+                        // write out the particle struct first...
+                        AMREX_D_TERM(File << it->pos(0) << ' ',
+                                          << it->pos(1) << ' ',
+                                          << it->pos(2) << ' ');
 
-                        for (int i = AMREX_SPACEDIM; i < AMREX_SPACEDIM + NStructReal; i++)
-                            File << it->m_rdata.arr[i] << ' ';
+                        for (int i = 0; i < NStructReal; i++)
+                            File << it->rdata(i) << ' ';
 
-                        File << it->m_idata.id  << ' ';
-                        File << it->m_idata.cpu << ' ';
-                        
-                        for (int i = 2; i < 2 + NStructInt; i++)
-                            File << it->m_idata.arr[i] << ' ';
-		      
+                        File << it->id()  << ' ';
+                        File << it->cpu() << ' ';
+
+                        for (int i = 0; i < NStructInt; i++)
+                            File << it->idata(i) << ' ';
+
                         // then the particle attributes.
                         for (int i = 0; i < NumRealComps(); i++)
                             File << soa.GetRealData(i)[index] << ' ';
-                        
+
                         for (int i = 0; i < NumIntComps(); i++)
                             File << soa.GetIntData(i)[index] << ' ';
-                        
-                        File << '\n';                                                    
+
+                        File << '\n';
                     }
                 }
               }
             }
-	    
+
             File.flush();
-	    
+
             File.close();
-            
+
             if (!File.good())
                 amrex::Abort("ParticleContainer::WriteAsciiFile(): problem writing file");
-	    
+
         }
-	
+
         ParallelDescriptor::Barrier();
     }
-    
+
     if (m_verbose > 1)
     {
         Real stoptime = amrex::second() - strttime;
-        
+
         ParallelDescriptor::ReduceRealMax(stoptime,ParallelDescriptor::IOProcessorNumber());
         
         amrex::Print() << "ParticleContainer::WriteAsciiFile() time: " << stoptime << '\n';
@@ -1540,7 +1540,7 @@ ParticleContainer<NStructReal,NStructInt,NArrayReal, NArrayInt>::WriteCoarsenedA
             const auto& aos = kv.second.GetArrayOfStructs();
             for (int k = 0; k < aos.numParticles(); ++k) {
 	        const ParticleType& p = aos[k];
-                if (p.m_idata.id > 0)
+                if (p.id() > 0)
                     //
                     // Only count (and checkpoint) valid particles.
                     //
@@ -1617,29 +1617,29 @@ ParticleContainer<NStructReal,NStructInt,NArrayReal, NArrayInt>::WriteCoarsenedA
                         {
                             
                             // Only keep particles in even cells               
-                            if (it->m_idata.id > 0) {
+                            if (it->id() > 0) {
                               
-                                File << it->m_idata.id  << ' ';
-                                File << it->m_idata.cpu << ' ';
+                                File << it->id()  << ' ';
+                                File << it->cpu() << ' ';
                               
-                                AMREX_D_TERM(File << it->m_rdata.pos[0] << ' ',
-                                                  << it->m_rdata.pos[1] << ' ',
-                                                  << it->m_rdata.pos[2] << ' ');
+                                AMREX_D_TERM(File << it->pos(0) << ' ',
+                                                  << it->pos(1) << ' ',
+                                                  << it->pos(2) << ' ');
                               
                                 for (int i = 0; i < NumRealComps(); i++) {
                                     File << soa.GetRealData(i)[index] << ' ';
                                 }
                                 index++;
                                 
-                                for (int i = AMREX_SPACEDIM; i < AMREX_SPACEDIM + NStructReal; i++) {
-                                    char ws = (i == AMREX_SPACEDIM + NStructReal - 1) ? '\n' : ' ';
-                                    if (i == AMREX_SPACEDIM) {
+                                for (int i = 0; i < NStructReal; i++) {
+                                    char ws = (i == NStructReal - 1) ? '\n' : ' ';
+                                    if (i == 0) {
                                         // Multiply mass by 8 since we are only taking 1/8 of the 
                                         // total particles and want to keep the mass in the domain the same.
-                                        File << 8.0* it->m_rdata.arr[i] << ws;
+                                        File << 8.0* it->rdata(i) << ws;
                                     }
                                     else {
-                                        File << it->m_rdata.arr[i] << ws;
+                                        File << it->rdata(i) << ws;
                                     }
                                 }
                             }

--- a/Src/Particle/AMReX_ParticleInit.H
+++ b/Src/Particle/AMReX_ParticleInit.H
@@ -23,10 +23,10 @@
   Parameters:
 
      file:      the name of the Ascii file with the particles
-     extradata: the number of real components to read in, beyond the AMREX_SPACEDIM 
+     extradata: the number of real components to read in, beyond the AMREX_SPACEDIM
                 positions
-     Nrep:      pointer to IntVect that lets you replicate the incoming particles 
-                across the domain so that you only need to specify a sub-volume of 
+     Nrep:      pointer to IntVect that lets you replicate the incoming particles
+                across the domain so that you only need to specify a sub-volume of
                 them. By default particles are not replicated.
  */
 template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt>
@@ -135,15 +135,15 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
 
         for (int i = 0; i < MyCnt; i++)
         {
-            AMREX_D_TERM(ifs >> p.m_rdata.pos[0];,
-                         ifs >> p.m_rdata.pos[1];,
-                         ifs >> p.m_rdata.pos[2];);
+            AMREX_D_TERM(ifs >> p.pos(0);,
+                         ifs >> p.pos(1);,
+                         ifs >> p.pos(2););
 
             for (int n = 0; n < extradata; n++)
             {
                 if (n < NStructReal)
                 {
-                    ifs >> p.m_rdata.arr[AMREX_SPACEDIM+n];
+                    ifs >> p.rdata(n);
                 }
                 else
                 {
@@ -166,10 +166,10 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
                 {
                     if (m_verbose) {
                         amrex::AllPrint() << "BAD PARTICLE ID WOULD BE " << ParticleType::NextID() << '\n'
-                                          << "BAD PARTICLE POS " 
-                                          << AMREX_D_TERM(   p.m_rdata.pos[0],
-                                                           << p.m_rdata.pos[1],
-                                                           << p.m_rdata.pos[2])
+                                          << "BAD PARTICLE POS "
+                                          << AMREX_D_TERM(   p.pos[0],
+                                                          << p.pos(1),
+                                                          << p.pos(2))
                                           << "\n";
                     }
                     amrex::Abort("ParticleContainer::InitFromAsciiFile(): invalid particle");
@@ -177,15 +177,15 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
             }
 
             // set these rather than reading them in
-            p.m_idata.id  = ParticleType::NextID();
-            p.m_idata.cpu = MyProc;
+            p.id()  = ParticleType::NextID();
+            p.cpu() = MyProc;
 
             nparticles.push_back(p);
             for (int n = NStructReal; n < extradata; n++)
             {
                 nreals[n-NStructReal].push_back(r[n-NStructReal]);
             }
-            
+
             how_many++;
             how_many_read++;
 
@@ -203,14 +203,14 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
                 for (rep[1] = 1; rep[1] <= lNrep[1]; rep[1]++)
                 {
 #endif
-                    for (rep[0] = 1; rep[0] <= lNrep[0]; rep[0]++) 
+                    for (rep[0] = 1; rep[0] <= lNrep[0]; rep[0]++)
                     {
                         if (!(AMREX_D_TERM( (rep[0] == 1), && (rep[1] == 1), && (rep[2] == 1) ) ) )
                         {
                             // Shift the position.
                             for (int d=0; d<AMREX_SPACEDIM; ++d)
                             {
-                                p_rep.m_rdata.pos[d] = p.m_rdata.pos[d] + (rep[d]-1)*DomSize[d];
+                                p_rep.pos(d) = p.pos(d) + (rep[d]-1)*DomSize[d];
                             }
 
                             // Copy the extra data
@@ -218,11 +218,10 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
                             {
                                 if (n < NStructReal)
                                 {
-                                    p_rep.m_rdata.arr[AMREX_SPACEDIM+n]
-                                        = p.m_rdata.arr[AMREX_SPACEDIM+n];
+                                    p_rep.rdata(n) = p.rdata(n);
                                 }
                             }
-                            
+
                             if (!Where(p_rep, pld))
                             {
                                 PeriodicShift(p_rep);
@@ -235,15 +234,15 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
                                 }
                             }
 
-                            p_rep.m_idata.id  = ParticleType::NextID();
-                            p_rep.m_idata.cpu = MyProc;
-   
+                            p_rep.id()  = ParticleType::NextID();
+                            p_rep.cpu() = MyProc;
+
                             nparticles.push_back(p_rep);
                             for (int n = NStructReal; n < extradata; n++)
                             {
                                 nreals[n-NStructReal].push_back(r[n-NStructReal]);
                             }
- 
+
                             how_many++;
                         }
                     }
@@ -717,9 +716,9 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>::InitFromBinar
 
                     ifs.read((char*)&fpos[0], AMREX_SPACEDIM*sizeof(float));
 
-                    AMREX_D_TERM(p.m_rdata.pos[0] = fpos[0];,
-                           p.m_rdata.pos[1] = fpos[1];,
-                           p.m_rdata.pos[2] = fpos[2];);
+                    AMREX_D_TERM(p.pos(0) = fpos[0];,
+                                 p.pos(1) = fpos[1];,
+                                 p.pos(2) = fpos[2];);
 
                 }
                 else if (RealSizeInFile == sizeof(double))
@@ -728,9 +727,9 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>::InitFromBinar
 
                     ifs.read((char*)&dpos[0], AMREX_SPACEDIM*sizeof(double));
 
-                    AMREX_D_TERM(p.m_rdata.pos[0] = dpos[0];,
-                           p.m_rdata.pos[1] = dpos[1];,
-                           p.m_rdata.pos[2] = dpos[2];);
+                    AMREX_D_TERM(p.pos(0) = dpos[0];,
+                                 p.pos(1) = dpos[1];,
+                                 p.pos(2) = dpos[2];);
                 }
 
                 //
@@ -743,14 +742,14 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>::InitFromBinar
                         ifs.read((char*)&fxtra[0], extradata*sizeof(float));
 
                         for (int ii = 0; ii < extradata; ii++)
-                            p.m_rdata.arr[AMREX_SPACEDIM+ii] = fxtra[ii];
+                            p.rdata(ii) = fxtra[ii];
                     }
                     else if (RealSizeInFile == sizeof(double))
                     {
                         ifs.read((char*)&dxtra[0], extradata*sizeof(double));
 
                         for (int ii = 0; ii < extradata; ii++)
-                            p.m_rdata.arr[AMREX_SPACEDIM+ii] = dxtra[ii];
+                            p.rdata(ii) = dxtra[ii];
                     }
                 }
                 //
@@ -784,18 +783,18 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>::InitFromBinar
                     {
                         if (m_verbose) {
                             amrex::AllPrint() << "BAD PARTICLE ID WOULD BE " << ParticleType::NextID() << '\n'
-                                              << "BAD PARTICLE POS " 
-                                              << AMREX_D_TERM(   p.m_rdata.pos[0],
-                                                                 << p.m_rdata.pos[2],
-                                                                 << p.m_rdata.pos[3])
+                                              << "BAD PARTICLE POS "
+                                              << AMREX_D_TERM(   p.pos(0),
+                                                              << p.pos(2),
+                                                              << p.pos(3))
                                               << "\n";
                         }
                         amrex::Abort("ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>::InitFromBinaryFile(): invalid particle");
                     }
                 }
 
-                p.m_idata.id  = ParticleType::NextID();
-                p.m_idata.cpu = MyProc;
+                p.id()  = ParticleType::NextID();
+                p.cpu() = MyProc;
 
                 host_particles[pld.m_lev][std::make_pair(pld.m_grid, pld.m_tile)].push_back(p);
             }
@@ -1010,11 +1009,11 @@ InitRandom (Long                    icount,
             ParticleType p;
 
             for (int i = 0; i < AMREX_SPACEDIM; i++) {
-                p.m_rdata.pos[i] = pos[j*AMREX_SPACEDIM + i];
+                p.pos(i) = pos[j*AMREX_SPACEDIM + i];
             }
 
             for (int i = 0; i < NStructReal; i++) {
-                p.m_rdata.arr[AMREX_SPACEDIM + i] = pdata.real_struct_data[i];
+                p.rdata(i) = pdata.real_struct_data[i];
             }
 
             if (!Where(p, pld)) {
@@ -1022,20 +1021,20 @@ InitRandom (Long                    icount,
             }
 
             AMREX_ASSERT(pld.m_lev >= 0 && pld.m_lev <= finestLevel());
-            std::pair<int, int> ind(pld.m_grid, pld.m_tile); 
+            std::pair<int, int> ind(pld.m_grid, pld.m_tile);
 
             const int who = ParticleDistributionMap(pld.m_lev)[pld.m_grid];
 
             if (who == MyProc) {
 
                 // We own it. Add it at the appropriate level.
-                p.m_idata.id  = ParticleType::NextID();
-                p.m_idata.cpu = MyProc;
+                p.id()  = ParticleType::NextID();
+                p.cpu() = MyProc;
 
                 for (int i = 0; i < NStructInt; i++) {
-                    p.m_idata.arr[2 + i] = pdata.int_struct_data[i];
+                    p.idata(i) = pdata.int_struct_data[i];
                 }
-                
+
                 // add the struct
                 host_particles[pld.m_lev][ind].push_back(p);
 
@@ -1117,32 +1116,31 @@ InitRandom (Long                    icount,
                     x = geom.ProbLo(i) + (r * len[i]);
                 }
                 while (x < xlo[i] || x > xhi[i]);
-                
-                p.m_rdata.pos[i] = x;
-                
-                AMREX_ASSERT(p.m_rdata.pos[i] < geom.ProbHi(i));
+
+                p.pos(i) = x;
+
+                AMREX_ASSERT(p.pos(i) < geom.ProbHi(i));
             }
-            
+
             for (int i = 0; i < NStructReal; i++) {
-                p.m_rdata.arr[AMREX_SPACEDIM + i] = pdata.real_struct_data[i];
+                p.rdata(i) = pdata.real_struct_data[i];
             }
-            
+
             // the int struct data
-            p.m_idata.id  = ParticleType::NextID();
-            p.m_idata.cpu = ParallelDescriptor::MyProc();
-            
+            p.id()  = ParticleType::NextID();
+            p.cpu() = ParallelDescriptor::MyProc();
+
             for (int i = 0; i < NStructInt; i++) {
-                p.m_idata.arr[2 + i] = pdata.int_struct_data[i];
+                p.idata(i) = pdata.int_struct_data[i];
             }
-            
+
             // locate the particle
             if (!Where(p, pld))
             {
                 amrex::Abort("ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>::InitRandom(): invalid particle");
             }
-            AMREX_ASSERT(pld.m_lev >= 0 && pld.m_lev <= finestLevel());            
-            std::pair<int, int> ind(pld.m_grid, pld.m_tile); 
-            
+            AMREX_ASSERT(pld.m_lev >= 0 && pld.m_lev <= finestLevel());
+            std::pair<int, int> ind(pld.m_grid, pld.m_tile);
 
 	    // add the struct
 	    host_particles[pld.m_lev][ind].push_back(p);
@@ -1257,15 +1255,15 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
 
             // the real struct data
             for (int i = 0; i < NStructReal; i++) {
-                p.m_rdata.arr[AMREX_SPACEDIM + i] = pdata.real_struct_data[i];
+                p.rdata(i) = pdata.real_struct_data[i];
             }
 
             // the int struct data
-            p.m_idata.id  = ParticleType::NextID();
-            p.m_idata.cpu = ParallelDescriptor::MyProc();
-            
+            p.id()  = ParticleType::NextID();
+            p.cpu() = ParallelDescriptor::MyProc();
+
             for (int i = 0; i < NStructInt; i++) {
-                p.m_idata.arr[2 + i] = pdata.int_struct_data[i];
+                p.idata(i) = pdata.int_struct_data[i];
             }
 
             // locate the particle
@@ -1329,29 +1327,29 @@ InitOnePerCell (Real x_off, Real y_off, Real z_off, const ParticleInitData& pdat
     for (MFIter mfi(*m_dummy_mf[0], false); mfi.isValid(); ++mfi) {
         Box grid = ParticleBoxArray(0)[mfi.index()];
         RealBox grid_box (grid,dx,geom.ProbLo());
-        
+
         for (IntVect beg = grid.smallEnd(), end=grid.bigEnd(),
-                 cell = grid.smallEnd(); cell <= end; grid.next(cell)) { 
+                 cell = grid.smallEnd(); cell <= end; grid.next(cell)) {
 
             // the real struct data
-            AMREX_D_TERM(p.m_rdata.pos[0] = grid_box.lo(0) + (x_off + cell[0]-beg[0])*dx[0];,
-                   p.m_rdata.pos[1] = grid_box.lo(1) + (y_off + cell[1]-beg[1])*dx[1];,
-                   p.m_rdata.pos[2] = grid_box.lo(2) + (z_off + cell[2]-beg[2])*dx[2];);
-            
+            AMREX_D_TERM(p.pos(0) = grid_box.lo(0) + (x_off + cell[0]-beg[0])*dx[0];,
+                         p.pos(1) = grid_box.lo(1) + (y_off + cell[1]-beg[1])*dx[1];,
+                         p.pos(2) = grid_box.lo(2) + (z_off + cell[2]-beg[2])*dx[2];);
+
             for (int d = 0; d < AMREX_SPACEDIM; ++d) {
-                AMREX_ASSERT(p.m_rdata.pos[d] < grid_box.hi(d));
+                AMREX_ASSERT(p.pos(d) < grid_box.hi(d));
             }
 
             for (int i = 0; i < NStructReal; i++) {
-                p.m_rdata.arr[AMREX_SPACEDIM + i] = pdata.real_struct_data[i];
+                p.rdata(i) = pdata.real_struct_data[i];
             }
 
             // the int struct data
-            p.m_idata.id  = ParticleType::NextID();
-            p.m_idata.cpu = ParallelDescriptor::MyProc();
+            p.id()  = ParticleType::NextID();
+            p.cpu() = ParallelDescriptor::MyProc();
 
             for (int i = 0; i < NStructInt; i++) {
-                p.m_idata.arr[2 + i] = pdata.int_struct_data[i];
+                p.idata(i) = pdata.int_struct_data[i];
             }
 
             // locate the particle
@@ -1428,29 +1426,29 @@ InitNRandomPerCell (int n_per_cell, const ParticleInitData& pdata)
 	Vector<std::map<std::pair<int, int>, std::array<Gpu::HostVector<int>, NArrayInt > > > host_int_attribs;
         host_int_attribs.reserve(15);
         host_int_attribs.resize(finestLevel()+1);
-        
+
         for (IntVect beg = grid.smallEnd(), end=grid.bigEnd(),
-                    cell = grid.smallEnd(); cell <= end; grid.next(cell)) { 
+                    cell = grid.smallEnd(); cell <= end; grid.next(cell)) {
 
             for (int n = 0; n < n_per_cell; n++)
             {
                 // the real struct data
                 for (int i = 0; i < AMREX_SPACEDIM; i++) {
                     r = amrex::Random();
-                    p.m_rdata.pos[i] = grid_box.lo(i) + (r + cell[i]-beg[i])*dx[i];
-                    AMREX_ASSERT(p.m_rdata.pos[i] < grid_box.hi(i));
+                    p.pos(i) = grid_box.lo(i) + (r + cell[i]-beg[i])*dx[i];
+                    AMREX_ASSERT(p.pos(i) < grid_box.hi(i));
                 }
-                                
+
                 for (int i = 0; i < NStructReal; i++) {
-                    p.m_rdata.arr[AMREX_SPACEDIM + i] = pdata.real_struct_data[i];
+                    p.rdata(i) = pdata.real_struct_data[i];
                 }
 
                 // the int struct data
-                p.m_idata.id  = ParticleType::NextID();
-                p.m_idata.cpu = ParallelDescriptor::MyProc();
+                p.id()  = ParticleType::NextID();
+                p.cpu() = ParallelDescriptor::MyProc();
 
                 for (int i = 0; i < NStructInt; i++) {
-                    p.m_idata.arr[2 + i] = pdata.int_struct_data[i];
+                    p.idata(i) = pdata.int_struct_data[i];
                 }
 
                 // locate the particle

--- a/Src/Particle/AMReX_ParticleInit.H
+++ b/Src/Particle/AMReX_ParticleInit.H
@@ -785,8 +785,8 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>::InitFromBinar
                             amrex::AllPrint() << "BAD PARTICLE ID WOULD BE " << ParticleType::NextID() << '\n'
                                               << "BAD PARTICLE POS "
                                               << AMREX_D_TERM(   p.pos(0),
-                                                              << p.pos(2),
-                                                              << p.pos(3))
+                                                              << p.pos(1),
+                                                              << p.pos(2))
                                               << "\n";
                         }
                         amrex::Abort("ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>::InitFromBinaryFile(): invalid particle");

--- a/Src/Particle/AMReX_ParticleTile.H
+++ b/Src/Particle/AMReX_ParticleTile.H
@@ -117,28 +117,36 @@ struct ParticleTileData
     {
         AMREX_ASSERT(index < m_size);
         SuperParticleType sp;
-        for (int i = 0; i < NStructReal+AMREX_SPACEDIM; ++i)
-            sp.m_rdata.arr[i] = m_aos[index].m_rdata.arr[i];
+        for (int i = 0; i < AMREX_SPACEDIM; ++i)
+            sp.pos(i) = m_aos[index].pos(i);
+        for (int i = 0; i < NStructReal; ++i)
+            sp.rdata(i) = m_aos[index].rdata(i);
         for (int i = 0; i < NArrayReal; ++i)
-            sp.m_rdata.arr[NStructReal+AMREX_SPACEDIM+i] = m_rdata[i][index];
-        for (int i = 0; i < NStructInt+2; ++i)
-            sp.m_idata.arr[i] = m_aos[index].m_idata.arr[i];
+            sp.rdata(NStructReal+i) = m_rdata[i][index];
+        sp.id() = m_aos[index].id();
+        sp.cpu() = m_aos[index].cpu();
+        for (int i = 0; i < NStructInt; ++i)
+            sp.idata(i) = m_aos[index].idata(i);
         for (int i = 0; i < NArrayInt; ++i)
-            sp.m_idata.arr[NStructInt+2+i] = m_idata[i][index];
+            sp.idata(NStructInt+i) = m_idata[i][index];
         return sp;
     }
 
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     void setSuperParticle (const SuperParticleType& sp, int index) const noexcept
     {
-        for (int i = 0; i < NStructReal+AMREX_SPACEDIM; ++i)
-            m_aos[index].m_rdata.arr[i] = sp.m_rdata.arr[i];
+        for (int i = 0; i < AMREX_SPACEDIM; ++i)
+            m_aos[index].pos(i) = sp.pos(i);
+        for (int i = 0; i < NStructReal; ++i)
+            m_aos[index].rdata(i) = sp.rdata(i);
         for (int i = 0; i < NArrayReal; ++i)
-            m_rdata[i][index] = sp.m_rdata.arr[NStructReal+AMREX_SPACEDIM+i];
-        for (int i = 0; i < NStructInt+2; ++i)
-            m_aos[index].m_idata.arr[i] = sp.m_idata.arr[i];
+            m_rdata[i][index] = sp.rdata(NStructReal+i);
+        m_aos[index].id() == sp.id();
+        m_aos[index].cpu() == sp.cpu();
+        for (int i = 0; i < NStructInt; ++i)
+            m_aos[index].idata(i) = sp.idata(i);
         for (int i = 0; i < NArrayInt; ++i)
-            m_idata[i][index] = sp.m_idata.arr[NStructInt+2+i];
+            m_idata[i][index] = sp.idata(NStructInt+i);
     }
 };
 
@@ -153,7 +161,7 @@ struct ConstParticleTileData
     Long m_size;
     const ParticleType* AMREX_RESTRICT m_aos;
     GpuArray<const ParticleReal* AMREX_RESTRICT, NArrayReal> m_rdata;
-    GpuArray<const int* AMREX_RESTRICT, NArrayInt > m_idata;    
+    GpuArray<const int* AMREX_RESTRICT, NArrayInt > m_idata;
 
     int m_num_runtime_real;
     int m_num_runtime_int;
@@ -199,22 +207,26 @@ struct ConstParticleTileData
                 memcpy(dst, m_runtime_idata[i] + src_index, sizeof(int));
                 dst += sizeof(int);
             }
-        }        
+        }
     }
 
-    AMREX_GPU_HOST_DEVICE
-    SuperParticleType getSuperParticle (int index) const
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    SuperParticleType getSuperParticle (int index) const noexcept
     {
         AMREX_ASSERT(index < m_size);
         SuperParticleType sp;
-        for (int i = 0; i < NStructReal+AMREX_SPACEDIM; ++i)
-            sp.m_rdata.arr[i] = m_aos[index].m_rdata.arr[i];
+        for (int i = 0; i < AMREX_SPACEDIM; ++i)
+            sp.pos(i) = m_aos[index].pos(i);
+        for (int i = 0; i < NStructReal; ++i)
+            sp.rdata(i) = m_aos[index].rdata(i);
         for (int i = 0; i < NArrayReal; ++i)
-            sp.m_rdata.arr[NStructReal+AMREX_SPACEDIM+i] = m_rdata[i][index];
-        for (int i = 0; i < NStructInt+2; ++i)
-            sp.m_idata.arr[i] = m_aos[index].m_idata.arr[i];
+            sp.rdata(NStructReal+i) = m_rdata[i][index];
+        sp.id() = m_aos[index].id();
+        sp.cpu() = m_aos[index].cpu();
+        for (int i = 0; i < NStructInt; ++i)
+            sp.idata(i) = m_aos[index].idata(i);
         for (int i = 0; i < NArrayInt; ++i)
-            sp.m_idata.arr[NStructInt+2+i] = m_idata[i][index];
+            sp.idata(NStructInt+i) = m_idata[i][index];
         return sp;
     }
 };

--- a/Src/Particle/AMReX_TracerParticle_mod_K.H
+++ b/Src/Particle/AMReX_TracerParticle_mod_K.H
@@ -12,7 +12,7 @@
 
 
 namespace amrex{
-  
+
 template <typename P>
 AMREX_GPU_HOST_DEVICE AMREX_INLINE
 void cic_interpolate (const P& p,
@@ -20,11 +20,11 @@ void cic_interpolate (const P& p,
 		      amrex::GpuArray<amrex::Real,AMREX_SPACEDIM> const& dxi,
 		      const amrex::Array4<amrex::Real const> &  uccarr,
 		      amrex::Real * val){
-  
+
   AMREX_ASSERT(val != 0);
 
 #if (AMREX_SPACEDIM == 1)
-  
+
     amrex::Real lx = (p.pos(0) - plo[0]) * dxi[0] - 0.5; //len
 
     int const i = static_cast<int>(amrex::Math::floor(lx)); //cell
@@ -41,16 +41,16 @@ void cic_interpolate (const P& p,
         }
     }
 
-  
+
 #elif (AMREX_SPACEDIM == 2)
 
-    amrex::Real lx = (p.pos(0) - plo[0]) * dxi[0] - 0.5; 
+    amrex::Real lx = (p.pos(0) - plo[0]) * dxi[0] - 0.5;
     amrex::Real ly = (p.pos(1) - plo[1]) * dxi[1] - 0.5;
 
     int const i = static_cast<int>(amrex::Math::floor(lx));
     int const j = static_cast<int>(amrex::Math::floor(ly));
 
-    amrex::Real xint = lx - i; 
+    amrex::Real xint = lx - i;
     amrex::Real yint = ly - j;
 
     amrex::Real sx[] = {1._rt - xint, xint};
@@ -100,7 +100,7 @@ void cic_interpolate (const P& p,
                 }
             }
         }
-    }    
+    }
 #endif
 }
 
@@ -118,37 +118,37 @@ void mac_interpolate (const P& p,
 #if (AMREX_SPACEDIM == 1)
     for (int d=0; d < AMREX_SPACEDIM; ++d)
     {
-      amrex::Real lx = (p.m_rdata.pos[0]-plo[0])*dxi[0] - (d != 0)*0.5;
-      
-      int const i = static_cast<int>(amrex::Math::floor(lx));
-      
-      amrex::Real const xint = lx - i;
-      
-      amrex::Real sx[] = {1._rt - xint, xint};
-      
-      val[d] = 0.0;
-      for (int ii = 0; ii <= 1; ++ii)
-      {
-          val[d] += (p_uccarr[d])(i+ii, 0, 0, 0)*sx[ii];
-      }      
-  }
-      
+        amrex::Real lx = (p.pos(0)-plo[0])*dxi[0] - (d != 0)*0.5;
+
+        int const i = static_cast<int>(amrex::Math::floor(lx));
+
+        amrex::Real const xint = lx - i;
+
+        amrex::Real sx[] = {1._rt - xint, xint};
+
+        val[d] = 0.0;
+        for (int ii = 0; ii <= 1; ++ii)
+        {
+            val[d] += (p_uccarr[d])(i+ii, 0, 0, 0)*sx[ii];
+        }
+    }
+
 #elif (AMREX_SPACEDIM == 2)
 
   for (int d=0; d < AMREX_SPACEDIM; ++d)
   {
-      amrex::Real lx = (p.m_rdata.pos[0]-plo[0])*dxi[0] - (d != 0)*0.5;
-      amrex::Real ly = (p.m_rdata.pos[1]-plo[1])*dxi[1] - (d != 1)*0.5;
-      
+      amrex::Real lx = (p.pos(0)-plo[0])*dxi[0] - (d != 0)*0.5;
+      amrex::Real ly = (p.pos(1)-plo[1])*dxi[1] - (d != 1)*0.5;
+
       int const i = static_cast<int>(amrex::Math::floor(lx));
       int const j = static_cast<int>(amrex::Math::floor(ly));
-      
+
       amrex::Real const xint = lx - i;
       amrex::Real const yint = ly - j;
-      
+
       amrex::Real sx[] = {1._rt - xint, xint};
       amrex::Real sy[] = {1._rt - yint, yint};
-      
+
       val[d] = 0.0;
       for (int jj = 0; jj <= 1; ++jj)
       {
@@ -161,25 +161,25 @@ void mac_interpolate (const P& p,
 
 
 #elif (AMREX_SPACEDIM == 3)
-  
+
   for (int d=0; d < AMREX_SPACEDIM; ++d)
   {
-      amrex::Real lx = (p.m_rdata.pos[0]-plo[0])*dxi[0] - (d != 0)*0.5;
-      amrex::Real ly = (p.m_rdata.pos[1]-plo[1])*dxi[1] - (d != 1)*0.5;
-      amrex::Real lz = (p.m_rdata.pos[2]-plo[2])*dxi[2] - (d != 2)*0.5;
-      
+      amrex::Real lx = (p.pos(0)-plo[0])*dxi[0] - (d != 0)*0.5;
+      amrex::Real ly = (p.pos(1)-plo[1])*dxi[1] - (d != 1)*0.5;
+      amrex::Real lz = (p.pos(2)-plo[2])*dxi[2] - (d != 2)*0.5;
+
       int const i = static_cast<int>(amrex::Math::floor(lx));
       int const j = static_cast<int>(amrex::Math::floor(ly));
       int const k = static_cast<int>(amrex::Math::floor(lz));
-      
+
       amrex::Real const xint = lx - i;
       amrex::Real const yint = ly - j;
       amrex::Real const zint = lz - k;
-      
+
       amrex::Real sx[] = {1._rt - xint, xint};
       amrex::Real sy[] = {1._rt - yint, yint};
       amrex::Real sz[] = {1._rt - zint, zint};
-      
+
       val[d] = 0.0;
       for (int kk = 0; kk <=1; ++kk)
       {
@@ -190,7 +190,7 @@ void mac_interpolate (const P& p,
 		  val[d] += (p_uccarr[d])(i+ii, j+jj, k+kk ,0)*sx[ii]*sy[jj]*sz[kk];
               }
           }
-      }      
+      }
   }
 #endif
 }

--- a/Src/Particle/AMReX_TracerParticles.cpp
+++ b/Src/Particle/AMReX_TracerParticles.cpp
@@ -27,7 +27,7 @@ TracerParticleContainer::AdvectWithUmac (MultiFab* umac, int lev, Real dt)
     const Geometry& geom     = m_gdb->Geom(lev);
     const auto          plo      = geom.ProbLoArray();
     const auto          dxi      = geom.InvCellSizeArray();
-    
+
     Vector<std::unique_ptr<MultiFab> > raii_umac(AMREX_SPACEDIM);
     Vector<MultiFab*> umac_pointer(AMREX_SPACEDIM);
     if (OnSameGrids(lev, umac[0]))
@@ -46,13 +46,13 @@ TracerParticleContainer::AdvectWithUmac (MultiFab* umac, int lev, Real dt)
 
 					                   m_gdb->ParticleDistributionMap(lev),
 					                   umac[i].nComp(), ng));
-					    
+
 
 	    umac_pointer[i] = raii_umac[i].get();
 	    umac_pointer[i]->copy(umac[i],0,0,umac[i].nComp(),ng,ng);
         }
     }
-    
+
     for (int ipass = 0; ipass < 2; ipass++)
     {
 #ifdef _OPENMP
@@ -68,40 +68,40 @@ TracerParticleContainer::AdvectWithUmac (MultiFab* umac, int lev, Real dt)
             const FArrayBox* fab[AMREX_SPACEDIM] = { AMREX_D_DECL(&((*umac_pointer[0])[grid]),
                                                                   &((*umac_pointer[1])[grid]),
                                                                   &((*umac_pointer[2])[grid])) };
-	  
+
             //array of these pointers to pass to the GPU
             amrex::GpuArray<amrex::Array4<const Real>, AMREX_SPACEDIM>
             const umacarr {AMREX_D_DECL((*fab[0]).array(),
                                         (*fab[1]).array(),
                                         (*fab[2]).array() )};
 
-            amrex::ParallelFor(n,   
-                               [=] AMREX_GPU_DEVICE (int i)      
-            {					
+            amrex::ParallelFor(n,
+                               [=] AMREX_GPU_DEVICE (int i)
+            {
                 ParticleType& p = p_pbox[i];
-                if (p.m_idata.id <= 0) return;
+                if (p.id() <= 0) return;
                 Real v[AMREX_SPACEDIM];
                 mac_interpolate(p, plo, dxi, umacarr, v);
                 if (ipass == 0)
                 {
                     for (int dim=0; dim < AMREX_SPACEDIM; dim++)
                     {
-                        p.m_rdata.arr[AMREX_SPACEDIM+dim] = p.m_rdata.pos[dim];     
-                        p.m_rdata.pos[dim] += 0.5*dt*v[dim];   		 
-                    }    		  
+                        p.rdata(dim) = p.pos(dim);
+                        p.pos(dim) += 0.5*dt*v[dim];
+                    }
                 }
                 else
                 {
                     for (int dim=0; dim < AMREX_SPACEDIM; dim++)
                     {
-                        p.m_rdata.pos[dim]  = p.m_rdata.arr[AMREX_SPACEDIM+dim] + dt*v[dim];
-                        p.m_rdata.arr[AMREX_SPACEDIM+dim] = v[dim];
+                        p.pos(dim) = p.rdata(dim) + dt*v[dim];
+                        p.rdata(dim) = v[dim];
                     }
                 }
             });
         }
     }
-    
+
     if (m_verbose > 1)
     {
         Real stoptime = amrex::second() - strttime;
@@ -156,31 +156,31 @@ TracerParticleContainer::AdvectWithUcc (const MultiFab& Ucc, int lev, Real dt)
                                [=] AMREX_GPU_DEVICE (int i)
             {
                 ParticleType& p  = p_pbox[i];
-                if (p.m_idata.id <= 0) return;
+                if (p.id() <= 0) return;
                 Real v[AMREX_SPACEDIM];
-                
+
                 cic_interpolate(p, plo, dxi, uccarr, v);
-                
+
                 if (ipass == 0)
                 {
                     for (int dim=0; dim < AMREX_SPACEDIM; dim++)
                     {
-                        p.m_rdata.arr[AMREX_SPACEDIM+dim] = p.m_rdata.pos[dim];
-                        p.m_rdata.pos[dim] += 0.5*dt*v[dim];
-                    }                  
+                        p.rdata(dim) = p.pos(dim);
+                        p.pos(dim) += 0.5*dt*v[dim];
+                    }
                 }
                 else
                 {
                     for (int dim=0; dim < AMREX_SPACEDIM; dim++)
                     {
-                        p.m_rdata.pos[dim]  = p.m_rdata.arr[AMREX_SPACEDIM+dim] + dt*v[dim];
-                        p.m_rdata.arr[AMREX_SPACEDIM+dim] = v[dim];
+                        p.rdata(dim) = p.rdata(dim) + dt*v[dim];
+                        p.rdata(dim) = v[dim];
                     }
                 }
             });
         }
     }
-    
+
     if (m_verbose > 1)
     {
         Real stoptime = amrex::second() - strttime;
@@ -247,7 +247,7 @@ TracerParticleContainer::Timestamp (const std::string&      basename,
 	      for (int k = 0; k < pbox.numParticles(); ++k)
 	      {
 		const ParticleType& p = pbox[k];
-		if (p.m_idata.id > 0) {
+		if (p.id() > 0) {
 		  gotwork = true;
 		  break;
 		}
@@ -291,25 +291,25 @@ TracerParticleContainer::Timestamp (const std::string&      basename,
 		    {
 		      const ParticleType& p = pbox[k];
 
-		      if (p.m_idata.id <= 0) continue;
+		      if (p.id() <= 0) continue;
 
 		      const IntVect& iv = Index(p,lev);
 
 		      if (!bx.contains(iv) && !ba.contains(iv)) continue;
 
-		      TimeStampFile << p.m_idata.id  << ' ' << p.m_idata.cpu << ' ';
+		      TimeStampFile << p.id()  << ' ' << p.cpu() << ' ';
 
-		      AMREX_D_TERM(TimeStampFile << p.m_rdata.pos[0] << ' ';,
-			     TimeStampFile << p.m_rdata.pos[1] << ' ';,
-			     TimeStampFile << p.m_rdata.pos[2] << ' ';);
+		      AMREX_D_TERM(TimeStampFile << p.pos(0) << ' ';,
+                                   TimeStampFile << p.pos(1) << ' ';,
+                                   TimeStampFile << p.pos(2) << ' ';);
 
 		      TimeStampFile << time;
 		      //
 		      // AdvectWithUmac stores the velocity in rdata ...
 		      //
-		      AMREX_D_TERM(TimeStampFile << ' ' << p.m_rdata.arr[AMREX_SPACEDIM+0];,
-			     TimeStampFile << ' ' << p.m_rdata.arr[AMREX_SPACEDIM+1];,
-			     TimeStampFile << ' ' << p.m_rdata.arr[AMREX_SPACEDIM+2];);
+		      AMREX_D_TERM(TimeStampFile << ' ' << p.rdata(0);,
+                                   TimeStampFile << ' ' << p.rdata(1);,
+                                   TimeStampFile << ' ' << p.rdata(2););
 
 		      if (M > 0)
                         {


### PR DESCRIPTION
Apologies for the long pull request...

This is a needed step along the way to dealing with the anonymous struct issue for the id and cpu numbers.