### PR TITLE
CMake CUDA: Cleanups & CCache

### DIFF
--- a/Tools/CMake/AMReX_Config.cmake
+++ b/Tools/CMake/AMReX_Config.cmake
@@ -48,9 +48,14 @@ function (configure_amrex)
    # Moreover, it will also enforce such standard on all the consuming targets
    #
    set_target_properties(amrex PROPERTIES CXX_EXTENSIONS OFF)
-
    target_compile_features(amrex PUBLIC cxx_std_11)  # minimum: C++11
 
+   if (ENABLE_CUDA)
+       set_target_properties(amrex PROPERTIES CUDA_EXTENSIONS OFF)
+       target_compile_features(amrex PUBLIC cuda_std_11)  # minimum: C++11
+   endif()
+
+   # flags needed for MSVC on Windows
    target_compile_options(amrex PUBLIC
        $<$<CXX_COMPILER_ID:MSVC>:/Za;/bigobj;/experimental:preprocessor>)
 

--- a/Tools/CMake/AMReX_Config.cmake
+++ b/Tools/CMake/AMReX_Config.cmake
@@ -50,7 +50,7 @@ function (configure_amrex)
    set_target_properties(amrex PROPERTIES CXX_EXTENSIONS OFF)
    target_compile_features(amrex PUBLIC cxx_std_11)  # minimum: C++11
 
-   if (ENABLE_CUDA)
+   if (ENABLE_CUDA AND (CMAKE_VERSION VERSION_GREATER_EQUAL 3.17) )
        set_target_properties(amrex PROPERTIES CUDA_EXTENSIONS OFF)
        target_compile_features(amrex PUBLIC cuda_std_11)  # minimum: C++11
    endif()

--- a/Tools/CMake/AMReX_SetupCUDA.cmake
+++ b/Tools/CMake/AMReX_SetupCUDA.cmake
@@ -60,7 +60,7 @@ cuda_select_nvcc_arch_flags(_nvcc_arch_flags ${CUDA_ARCH})
 #
 # Remove unsupported architecture: anything less the 6.0 must go
 #
-string(REPLACE "-gencode;" "-gencode " _nvcc_arch_flags "${_nvcc_arch_flags}")
+string(REPLACE "-gencode;" "-gencode=" _nvcc_arch_flags "${_nvcc_arch_flags}")
 
 foreach (_item IN LISTS _nvcc_arch_flags)
    # Match one time the regex [0-9]+.


### PR DESCRIPTION
- gencode: use no-space syntax; this confuses/breaks with CCache<4.0 (all available releases today) and is complicating deduplication operations on lists (see e.g. https://github.com/alpaka-group/alpaka/pull/991)
- min. CXX standard in CUDA: technically the right thing to set this as well for the CMake CUDA C++ language

Now AMReX + CMake 3.17 + CUDA works with [CCache 3.7.9](https://ccache.dev/releasenotes.html#_ccache_3_7_9) ([more cross-links](https://github.com/spack/spack/pull/16902), [more](https://github.com/ccache/ccache/issues/560#issuecomment-597621694)). Since this is a severe productivity plus I label this "install" + "performance" ;-)

Note: downstream projects might want to add this to their `CMakeLists.txt`:
```cmake
find_program(CCACHE_PROGRAM ccache)
if(CCACHE_PROGRAM)
    set(CMAKE_CXX_COMPILER_LAUNCHER "${CCACHE_PROGRAM}")
    if(ENABLE_CUDA)
        set(CMAKE_CUDA_COMPILER_LAUNCHER "${CCACHE_PROGRAM}")
    endif()
endif()
```

CCache does [not support Fortran](https://ccache.dev/platform-compiler-language-support.html).