### PR TITLE
Fix a missing semicolon

### DIFF
--- a/Src/Base/AMReX_GpuLaunchFunctsG.H
+++ b/Src/Base/AMReX_GpuLaunchFunctsG.H
@@ -200,11 +200,11 @@ void ParallelFor (Box const& box, T ncomp, L&& f) noexcept
 template <typename L1, typename L2>
 void ParallelFor (Box const& box1, Box const& box2, L1&& f1, L2&& f2) noexcept
 {
-    if (amrex::isEmpty(box1) and amrex::isEmpty(box2)) return;
-    // xxxxx DPC++ todo: launch separate kernel to reduce kernel size
+    // xxxxx DPCPP todo: launch separate kernel to reduce kernel size
     ParallelFor(box1, std::forward<L1>(f1));
     ParallelFor(box2, std::forward<L2>(f2));
 #if 0
+    if (amrex::isEmpty(box1) and amrex::isEmpty(box2)) return;
     int ncells1 = box1.numPts();
     int ncells2 = box2.numPts();
     int ncells = amrex::max(ncells1, ncells2);
@@ -257,12 +257,12 @@ void ParallelFor (Box const& box1, Box const& box2, L1&& f1, L2&& f2) noexcept
 template <typename L1, typename L2, typename L3>
 void ParallelFor (Box const& box1, Box const& box2, Box const& box3, L1&& f1, L2&& f2, L3&& f3) noexcept
 {
-    if (amrex::isEmpty(box1) and amrex::isEmpty(box2) and amrex::isEmpty(box3)) return
-    // xxxxx DPC++ todo: launch separate kernel to reduce kernel size
+    // xxxxx DPCPP todo: launch separate kernel to reduce kernel size
     ParallelFor(box1, std::forward<L1>(f1));
     ParallelFor(box2, std::forward<L2>(f2));
     ParallelFor(box3, std::forward<L3>(f3));
 #if 0
+    if (amrex::isEmpty(box1) and amrex::isEmpty(box2) and amrex::isEmpty(box3)) return;
     int ncells1 = box1.numPts();
     int ncells2 = box2.numPts();
     int ncells3 = box3.numPts();
@@ -330,11 +330,11 @@ template <typename T1, typename T2, typename L1, typename L2,
 void ParallelFor (Box const& box1, T1 ncomp1, L1&& f1,
                   Box const& box2, T2 ncomp2, L2&& f2) noexcept
 {
-    if (amrex::isEmpty(box1) and amrex::isEmpty(box2)) return;
-    // xxxxx DPC++ todo: launch separate kernel to reduce kernel size
+    // xxxxx DPCPP todo: launch separate kernel to reduce kernel size
     ParallelFor(box1, ncomp1, std::forward<L1>(f1));
     ParallelFor(box2, ncomp2, std::forward<L2>(f2));
 #if 0
+    if (amrex::isEmpty(box1) and amrex::isEmpty(box2)) return;
     int ncells1 = box1.numPts();
     int ncells2 = box2.numPts();
     int ncells = amrex::max(ncells1, ncells2);
@@ -396,12 +396,12 @@ void ParallelFor (Box const& box1, T1 ncomp1, L1&& f1,
                   Box const& box2, T2 ncomp2, L2&& f2,
                   Box const& box3, T3 ncomp3, L3&& f3) noexcept
 {
-    if (amrex::isEmpty(box1) and amrex::isEmpty(box2) and amrex::isEmpty(box3)) return;
-    // xxxxx DPC++ todo: launch separate kernel to reduce kernel size
+    // xxxxx DPCPP todo: launch separate kernel to reduce kernel size
     ParallelFor(box1, ncomp1, std::forward<L1>(f1));
     ParallelFor(box2, ncomp2, std::forward<L2>(f2));
     ParallelFor(box3, ncomp3, std::forward<L3>(f3));
 #if 0
+    if (amrex::isEmpty(box1) and amrex::isEmpty(box2) and amrex::isEmpty(box3)) return;
     int ncells1 = box1.numPts();
     int ncells2 = box2.numPts();
     int ncells3 = box3.numPts();


### PR DESCRIPTION
The (DPC++ only) bug was in
```
if (....) return
ParallelFor(...);
ParallelFor(...);
```

A semicolon was missing and the code became
```
if(...) {
    return ParallelFor(...);
}
ParallelFor(...);
```

Maybe we should always use `{}` with `if` no matter how short the block is.
