### PR TITLE
Particle parallel context

### DIFF
--- a/Src/Base/AMReX_ParallelDescriptor.H
+++ b/Src/Base/AMReX_ParallelDescriptor.H
@@ -42,9 +42,9 @@
 #include <csignal>
 
 namespace amrex {
-    
+
 template <typename T> class LayoutData;
-    
+
 //! Parallel frontend that abstracts functionalities needed to spawn processes and handle communication
 namespace ParallelDescriptor
 {

--- a/Src/Particle/AMReX_NeighborParticles.H
+++ b/Src/Particle/AMReX_NeighborParticles.H
@@ -141,13 +141,13 @@ private:
             amrex::Error("operator<<(ostream&, const InverseCopyTag&) failed");
         return os;
     }
-    
+
     struct NeighborCommTag {
 
         NeighborCommTag (int pid, int lid, int gid, int tid)
             : proc_id(pid), level_id(lid), grid_id(gid), tile_id(tid)
             {}
-        
+
         int proc_id;
         int level_id;
         int grid_id;
@@ -318,7 +318,7 @@ protected:
     void sumNeighborsMPI (std::map<int, Vector<char> >& not_ours,
                           int real_start_comp, int real_num_comp,
                           int int_start_comp, int int_num_comp);
-    
+
     ///
     /// Perform handshake to figure out how many bytes each proc should receive
     ///
@@ -365,7 +365,7 @@ protected:
     static bool enable_inverse;
 
 #ifdef AMREX_USE_GPU
-    
+
     struct NeighborTask {
         int grid_id;
         Box box;
@@ -388,7 +388,7 @@ protected:
             return false;
         }
     };
-        
+
     // These are used to keep track of which particles need to be ghosted to which grids
     bool m_neighbor_mask_initialized = false;
     std::unique_ptr<amrex::iMultiFab> m_neighbor_mask_ptr;
@@ -408,20 +408,20 @@ protected:
 #endif
 
     Vector<std::map<std::pair<int, int>, amrex::NeighborList<ParticleType> > > m_neighbor_list;
-    
+
     bool hasNeighbors() const { return m_has_neighbors; };
-  
+
     bool m_has_neighbors = false;
 };
-    
+
 #include "AMReX_NeighborParticlesI.H"
-    
+
 #ifdef AMREX_USE_GPU
 #include "AMReX_NeighborParticlesGPUImpl.H"
 #else
 #include "AMReX_NeighborParticlesCPUImpl.H"
 #endif
-    
+
 }
 
 #endif // _NEIGHBORPARTICLES_H_

--- a/Src/Particle/AMReX_NeighborParticlesCPUImpl.H
+++ b/Src/Particle/AMReX_NeighborParticlesCPUImpl.H
@@ -19,25 +19,25 @@ NeighborParticleContainer<NStructReal, NStructInt>
                    int int_start_comp,  int int_num_comp)
 {
     BL_PROFILE("NeighborParticleContainer::sumNeighborsCPU");
-    
+
     if ( not enableInverse() )
     {
         amrex::Abort("Need to enable inverse to true to use sumNeighbors. \n");
     }
-    
-    const int MyProc = ParallelDescriptor::MyProc();
+
+    const int MyProc = ParallelContext::MyProcSub();
 
     std::map<int, Vector<char> > isend_data;
-    
+
     for (int lev = 0; lev < this->numLevels(); ++lev)
     {
         for (MyParIter pti(*this, lev); pti.isValid(); ++pti)
         {
             PairIndex src_index(pti.index(), pti.LocalTileIndex());
             const auto& tags = inverse_tags[lev][src_index];
-            const auto& neighbs = neighbors[lev][src_index];            
+            const auto& neighbs = neighbors[lev][src_index];
             AMREX_ASSERT(tags.size() == neighbs.size());
-            
+
             const int num_neighbs = neighbs.size();
             for (int i = 0; i < num_neighbs; ++i)
             {
@@ -48,25 +48,25 @@ NeighborParticleContainer<NStructReal, NStructInt>
                 const int dst_tile = tag.src_tile;
                 const int dst_index = tag.src_index;
                 const int dst_level = tag.src_level;
-                
+
                 if (dst_proc == MyProc)
                 {
                     auto pair = std::make_pair(dst_grid, dst_tile);
                     auto& dst_ptile = this->GetParticles(dst_level)[pair];
                     auto& dst_parts = dst_ptile.GetArrayOfStructs();
                     auto& p = dst_parts[dst_index];
-                    
+
                     for (int comp = real_start_comp; comp < real_start_comp + real_num_comp; ++comp)
                     {
-                        p.rdata(comp) += neighb.rdata(comp);                        
+                        p.rdata(comp) += neighb.rdata(comp);
                     }
 
                     for (int comp = int_start_comp; comp < int_start_comp + int_num_comp; ++comp)
                     {
-                        p.idata(comp) += neighb.idata(comp);                        
+                        p.idata(comp) += neighb.idata(comp);
                     }
                 }
-                
+
                 else
                 {
                     auto& sdata = isend_data[dst_proc];
@@ -91,7 +91,7 @@ NeighborParticleContainer<NStructReal, NStructInt>
                         dst += sizeof(int);
                     }
                 }
-            }                    
+            }
         }
     }
 
@@ -103,62 +103,65 @@ void
 NeighborParticleContainer<NStructReal, NStructInt>::
 sumNeighborsMPI (std::map<int, Vector<char> >& not_ours,
                  int real_start_comp, int real_num_comp,
-                 int int_start_comp, int int_num_comp) 
+                 int int_start_comp, int int_num_comp)
 {
     BL_PROFILE("NeighborParticleContainer::sumNeighborsMPI");
-    
+
 #ifdef AMREX_USE_MPI
-    const int NProcs = ParallelDescriptor::NProcs();
-    
+    const int NProcs = ParallelContext::NProcsSub();
+
     Vector<Long> isnds(NProcs, 0);
     Vector<Long> ircvs(NProcs, 0);
     for (int i = 0; i < NProcs; ++i)
         ircvs[i] = 0;
-    
+
     {
         // each proc figures out how many bytes it will send, and how
         // many it will receive
-        
+
         Long num_isnds = 0;
         for (const auto& kv : not_ours)
         {
             num_isnds      += kv.second.size();
             isnds[kv.first] = kv.second.size();
         }
-        ParallelDescriptor::ReduceLongMax(num_isnds);
-        
+
+        ParallelAllReduce::Max(num_isnds, ParallelContext::CommunicatorSub());
+
         if (num_isnds == 0) return;
-        
+
         const int num_ircvs = neighbor_procs.size();
         Vector<MPI_Status>  stats(num_ircvs);
         Vector<MPI_Request> rreqs(num_ircvs);
-        
+
         const int SeqNum = ParallelDescriptor::SeqNum();
-        
+
         // Post receives
         for (int i = 0; i < num_ircvs; ++i)
         {
             const int Who = neighbor_procs[i];
             const Long Cnt = 1;
-            
+
             AMREX_ASSERT(Who >= 0 && Who < NProcs);
-            
-            rreqs[i] = ParallelDescriptor::Arecv(&ircvs[Who], Cnt, Who, SeqNum).req();
+
+            rreqs[i] = ParallelDescriptor::Arecv(&ircvs[Who], Cnt, Who, SeqNum,
+                                                 ParallelContext::CommunicatorSub()).req();
         }
-        
+
         // Send.
         for (int i = 0; i < num_ircvs; ++i) {
         const int Who = neighbor_procs[i];
         const Long Cnt = 1;
-        
+
         AMREX_ASSERT(Who >= 0 && Who < NProcs);
-        
-        ParallelDescriptor::Send(&isnds[Who], Cnt, Who, SeqNum);
+
+        ParallelDescriptor::Send(&isnds[Who], Cnt, Who, SeqNum,
+                                 ParallelContext::CommunicatorSub());
         }
-        
-        if (num_ircvs > 0) ParallelDescriptor::Waitall(rreqs, stats);        
+
+        if (num_ircvs > 0) ParallelDescriptor::Waitall(rreqs, stats);
     }
-    
+
     Vector<int> RcvProc;
     Vector<std::size_t> rOffset; // Offset (in bytes) in the receive buffer
     std::size_t TotRcvBytes = 0;
@@ -189,19 +192,21 @@ sumNeighborsMPI (std::map<int, Vector<char> >& not_ours,
         AMREX_ASSERT(Cnt < std::numeric_limits<int>::max());
         AMREX_ASSERT(Who >= 0 && Who < NProcs);
 
-        rreqs[i] = ParallelDescriptor::Arecv(&recvdata[offset], Cnt, Who, SeqNum).req();
+        rreqs[i] = ParallelDescriptor::Arecv(&recvdata[offset], Cnt, Who, SeqNum,
+                                             ParallelContext::CommunicatorSub()).req();
     }
 
     // Send.
     for (const auto& kv : not_ours) {
         const auto Who = kv.first;
         const auto Cnt = kv.second.size();
-        
+
         AMREX_ASSERT(Cnt > 0);
         AMREX_ASSERT(Who >= 0 && Who < NProcs);
         AMREX_ASSERT(Cnt < std::numeric_limits<int>::max());
 
-        ParallelDescriptor::Send(kv.second.data(), Cnt, Who, SeqNum);
+        ParallelDescriptor::Send(kv.second.data(), Cnt, Who, SeqNum,
+                                 ParallelContext::CommunicatorSub());
     }
 
     // unpack the received data and put them into the proper neighbor buffers
@@ -210,7 +215,7 @@ sumNeighborsMPI (std::map<int, Vector<char> >& not_ours,
         ParallelDescriptor::Waitall(rreqs, stats);
 
         const size_t data_size = real_num_comp*sizeof(Real) + int_num_comp*sizeof(int) + 4 * sizeof(int);
-        
+
         if (recvdata.size() % data_size != 0) {
             amrex::Print() << recvdata.size() << " " << data_size << "\n";
             if (this->m_verbose) {
@@ -263,7 +268,7 @@ NeighborParticleContainer<NStructReal, NStructInt>
 
     BL_PROFILE_VAR("NeighborParticleContainer::updateNeighborsCPU", update);
 
-    const int MyProc = ParallelDescriptor::MyProc();
+    const int MyProc = ParallelContext::MyProcSub();
 
     for (int lev = 0; lev < this->numLevels(); ++lev) {
         const Periodicity& periodicity = this->Geom(lev).periodicity();
@@ -407,7 +412,7 @@ getRcvCountsMPI () {
     BL_PROFILE("NeighborParticleContainer::getRcvCountsMPI");
 
 #ifdef AMREX_USE_MPI
-    const int NProcs = ParallelDescriptor::NProcs();
+    const int NProcs = ParallelContext::NProcsSub();
 
     // each proc figures out how many bytes it will send, and how
     // many it will receive
@@ -421,7 +426,9 @@ getRcvCountsMPI () {
         num_snds      += kv.second.size();
         snds[kv.first] = kv.second.size();
     }
-    ParallelDescriptor::ReduceLongMax(num_snds);
+
+    ParallelAllReduce::Max(num_snds, ParallelContext::CommunicatorSub());
+
     if (num_snds == 0) return;
 
     const int num_rcvs = neighbor_procs.size();
@@ -429,7 +436,7 @@ getRcvCountsMPI () {
     Vector<MPI_Request> rreqs(num_rcvs);
 
     const int SeqNum = ParallelDescriptor::SeqNum();
-    
+
     // Post receives
     for (int i = 0; i < num_rcvs; ++i) {
         const int Who = neighbor_procs[i];
@@ -437,7 +444,8 @@ getRcvCountsMPI () {
 
         AMREX_ASSERT(Who >= 0 && Who < NProcs);
 
-        rreqs[i] = ParallelDescriptor::Arecv(&rcvs[Who], Cnt, Who, SeqNum).req();
+        rreqs[i] = ParallelDescriptor::Arecv(&rcvs[Who], Cnt, Who, SeqNum,
+                                             ParallelContext::CommunicatorSub()).req();
     }
 
     // Send.
@@ -447,7 +455,8 @@ getRcvCountsMPI () {
 
         AMREX_ASSERT(Who >= 0 && Who < NProcs);
 
-        ParallelDescriptor::Send(&snds[Who], Cnt, Who, SeqNum);
+        ParallelDescriptor::Send(&snds[Who], Cnt, Who, SeqNum,
+                                 ParallelContext::CommunicatorSub());
     }
 
     if (num_rcvs > 0) ParallelDescriptor::Waitall(rreqs, stats);
@@ -463,7 +472,7 @@ fillNeighborsMPI (bool reuse_rcv_counts) {
     BL_PROFILE("NeighborParticleContainer::fillNeighborsMPI");
 
 #ifdef AMREX_USE_MPI
-    const int NProcs = ParallelDescriptor::NProcs();
+    const int NProcs = ParallelContext::NProcsSub();
 
     // each proc figures out how many bytes it will send, and how
     // many it will receive
@@ -500,7 +509,8 @@ fillNeighborsMPI (bool reuse_rcv_counts) {
         AMREX_ASSERT(Cnt < std::numeric_limits<int>::max());
         AMREX_ASSERT(Who >= 0 && Who < NProcs);
 
-        rreqs[i] = ParallelDescriptor::Arecv(&recvdata[offset], Cnt, Who, SeqNum).req();
+        rreqs[i] = ParallelDescriptor::Arecv(&recvdata[offset], Cnt, Who, SeqNum,
+                                             ParallelContext::CommunicatorSub()).req();
     }
 
     // Send.
@@ -545,7 +555,7 @@ fillNeighborsMPI (bool reuse_rcv_counts) {
                     inverse_tags[lev][dst_index].resize(new_size);
                 }
                 neighbors[lev][dst_index].resize(new_size);
-                
+
                 char* dst = (char*) &neighbors[lev][dst_index][old_size];
                 char* src = buffer;
 
@@ -571,10 +581,10 @@ fillNeighborsMPI (bool reuse_rcv_counts) {
                         auto& tag = inverse_tags[lev][dst_index][old_size+n];
                         std::memcpy(&(tag.src_grid),src,sizeof(int));
                         src += sizeof(int);
-                        
+
                         std::memcpy(&(tag.src_tile),src,sizeof(int));
                         src += sizeof(int);
-                        
+
                         std::memcpy(&(tag.src_index),src,sizeof(int));
                         src += sizeof(int);
 

--- a/Src/Particle/AMReX_NeighborParticlesCPUImpl.H
+++ b/Src/Particle/AMReX_NeighborParticlesCPUImpl.H
@@ -44,7 +44,8 @@ NeighborParticleContainer<NStructReal, NStructInt>
                 const auto& neighb = neighbs[i];
                 const auto& tag = tags[i];
                 const int dst_grid = tag.src_grid;
-                const int dst_proc = this->ParticleDistributionMap(lev)[dst_grid];
+                const int global_rank = this->ParticleDistributionMap(lev)[dst_grid];
+                const int dst_proc = ParallelContext::global_to_local_rank(global_rank);
                 const int dst_tile = tag.src_tile;
                 const int dst_index = tag.src_index;
                 const int dst_level = tag.src_level;
@@ -291,7 +292,8 @@ NeighborParticleContainer<NStructReal, NStructInt>
 #endif
                 for (int i = 0; i < num_tags; ++i) {
                     const NeighborCopyTag& tag = tags[i];
-                    const int who = this->ParticleDistributionMap(tag.level)[tag.grid];
+                    const int global_who = this->ParticleDistributionMap(tag.level)[tag.grid];
+                    const int who = ParallelContext::global_to_local_rank(global_who);
                     ParticleType p = particles[tag.src_index];  // copy
                     if (periodicity.isAnyPeriodic()) {
                         for (int dir = 0; dir < AMREX_SPACEDIM; ++dir) {

--- a/Src/Particle/AMReX_NeighborParticlesGPUImpl.H
+++ b/Src/Particle/AMReX_NeighborParticlesGPUImpl.H
@@ -38,7 +38,7 @@ namespace detail
                 }
             }
         }
-        
+
         RemoveDuplicates(bl);
         return bl;
     }
@@ -48,9 +48,9 @@ template <int NStructReal, int NStructInt>
 void
 NeighborParticleContainer<NStructReal, NStructInt>::
 buildNeighborMask ()
-{    
+{
     BL_PROFILE("NeighborParticleContainer<NStructReal, NStructInt>::buildNeighborMask");
-    AMREX_ALWAYS_ASSERT(this->numLevels() == 1);    
+    AMREX_ALWAYS_ASSERT(this->numLevels() == 1);
     m_neighbor_mask_initialized = true;
     const int lev = 0;
     const Geometry& geom = this->Geom(lev);
@@ -73,24 +73,24 @@ buildNeighborMask ()
         {
             int grid = mfi.index();
 	    int num_codes = 0;
-       
+
             std::set<NeighborTask> neighbor_grids;
             for (auto pit=pshifts.cbegin(); pit!=pshifts.cend(); ++pit)
             {
                 const Box box = ba[mfi] + *pit;
-                
+
                 const bool first_only = false;
                 auto isecs = ba.intersections(box, first_only, m_num_neighbor_cells);
-                
+
                 for (auto& isec : isecs)
                 {
                     int nbor_grid = isec.first;
                     const Box isec_box = isec.second - *pit;
-                    if ( (grid == nbor_grid) and (*pit == IntVect(AMREX_D_DECL(0, 0, 0)))) continue; 
+                    if ( (grid == nbor_grid) and (*pit == IntVect(AMREX_D_DECL(0, 0, 0)))) continue;
                     neighbor_grids.insert(NeighborTask(nbor_grid, isec_box, *pit));
                 }
             }
-            
+
             BoxList isec_bl;
             std::vector<int> isec_grids;
             std::vector<IntVect> isec_pshifts;
@@ -101,20 +101,20 @@ buildNeighborMask ()
                 isec_pshifts.push_back(nbor_grid.periodic_shift);
             }
             BoxArray isec_ba(isec_bl);
-            
+
             Vector<Box> bl = detail::getBoundaryBoxes(
                 amrex::grow(ba[mfi], -m_num_neighbor_cells), m_num_neighbor_cells);
-            
+
             m_grid_map[grid].resize(bl.size());
 	    m_code_offsets[grid].push_back(0);
             for (int i = 0; i < static_cast<int>(bl.size()); ++i)
             {
                 const Box& box = bl[i];
-            
+
                 const int nGrow = 0;
                 const bool first_only = false;
                 auto isecs = isec_ba.intersections(box, first_only, nGrow);
-                
+
                 if (! isecs.empty() ) (*m_neighbor_mask_ptr)[mfi].setVal<RunOn::Host>(i, box);
 
                 for (auto& isec : isecs)
@@ -124,11 +124,12 @@ buildNeighborMask ()
                     code.periodic_shift = isec_pshifts[isec.first];
                     m_grid_map[grid][i].push_back(code);
 		    m_code_array[grid].push_back(code);
-                    neighbor_procs.push_back(dmap[code.grid_id]);
+                    const int global_rank = dmap[code.grid_id];
+                    neighbor_procs.push_back(ParallelContext::global_to_local_rank(global_rank));
 		    ++num_codes;
                 }
    	        m_code_offsets[grid].push_back(m_code_array[grid].size());
-            }        
+            }
 	}
         RemoveDuplicates(neighbor_procs);
     }

--- a/Src/Particle/AMReX_NeighborParticlesI.H
+++ b/Src/Particle/AMReX_NeighborParticlesI.H
@@ -184,7 +184,8 @@ NeighborParticleContainer<NStructReal, NStructInt>
                 if (grid >= 0) {
                     const int tile = (*mask_ptr[lev])[mfi](iv, MaskComps::tile);
                     const int level = (*mask_ptr[lev])[mfi](iv, MaskComps::level);
-                    const int proc = this->ParticleDistributionMap(level)[grid];
+                    const int global_proc = this->ParticleDistributionMap(level)[grid];
+                    const int proc = ParallelContext::global_to_local_rank(global_proc);
                     NeighborCommTag comm_tag(proc, level, grid, tile);
                     local_neighbors.push_back(comm_tag);
                     if (proc != ParallelContext::MyProcSub())
@@ -265,7 +266,8 @@ NeighborParticleContainer<NStructReal, NStructInt>
             ba.intersections(pbox, isects, first_only, 0);
             for (const auto& isec : isects) {
                 const int grid = isec.first;
-                const int proc = this->ParticleDistributionMap(lev)[grid];
+                const int global_proc = this->ParticleDistributionMap(level)[grid];
+                const int proc = ParallelContext::global_to_local_rank(global_proc);
                 for (IntVect iv = pbox.smallEnd(); iv <= pbox.bigEnd(); pbox.next(iv))
                 {
                     if (ba[grid].contains(iv))
@@ -366,7 +368,8 @@ NeighborParticleContainer<NStructReal, NStructInt>
                         const int cache_index = cache.size();
                         cache.push_back(tag);
 
-                        const int who = this->ParticleDistributionMap(tag.level)[tag.grid];
+                        const int global_who = this->ParticleDistributionMap(tag.level)[tag.grid];
+                        const int who = ParallelContext::global_to_local_rank(global_who);
                         NeighborIndexMap nim(tag.level, dst_index.first, dst_index.second, -1,
                                              lev, src_index.first, src_index.second,
                                              cache_index, thread_num);

--- a/Src/Particle/AMReX_NeighborParticlesI.H
+++ b/Src/Particle/AMReX_NeighborParticlesI.H
@@ -187,7 +187,7 @@ NeighborParticleContainer<NStructReal, NStructInt>
                     const int proc = this->ParticleDistributionMap(level)[grid];
                     NeighborCommTag comm_tag(proc, level, grid, tile);
                     local_neighbors.push_back(comm_tag);
-                    if (proc != ParallelDescriptor::MyProc())
+                    if (proc != ParallelContext::MyProcSub())
                         neighbor_procs.push_back(proc);
                 }
             }
@@ -204,7 +204,7 @@ NeighborParticleContainer<NStructReal, NStructInt>
                 GetCommTagsBox(comm_tags, lev, box);
                 for (auto const& tag : comm_tags) {
                     local_neighbors.push_back(tag);
-                    if (tag.proc_id != ParallelDescriptor::MyProc())
+                    if (tag.proc_id != ParallelContext::MyProcSub())
                         neighbor_procs.push_back(tag.proc_id);
                 }
             }
@@ -295,7 +295,7 @@ NeighborParticleContainer<NStructReal, NStructInt>
 
     AMREX_ASSERT(hasNeighbors() == false);
 
-    const int MyProc = ParallelDescriptor::MyProc();
+    const int MyProc = ParallelContext::MyProcSub();
 
     amrex::Vector<std::map<PairIndex,       Vector<NeighborIndexMap> > > local_map;
     std::map<NeighborCommTag, Vector<NeighborIndexMap> > remote_map;

--- a/Src/Particle/AMReX_ParticleBufferMap.cpp
+++ b/Src/Particle/AMReX_ParticleBufferMap.cpp
@@ -23,12 +23,12 @@ void ParticleBufferMap::define (const ParGDBBase* a_gdb)
         m_ba[lev] = a_gdb->ParticleBoxArray(lev);
         m_dm[lev] = a_gdb->ParticleDistributionMap(lev);
     }
-    
+
     m_lev_offsets.resize(0);
     m_lev_offsets.push_back(0);
     for (int lev = 0; lev < num_levels; ++lev)
         m_lev_offsets.push_back(m_lev_offsets.back() + m_ba[lev].size());
-            
+
     int num_buckets = m_lev_offsets.back();
 
     m_bucket_to_gid.resize(0);
@@ -46,11 +46,12 @@ void ParticleBufferMap::define (const ParGDBBase* a_gdb)
 
     for (int lev = 0; lev < num_levels; ++lev) {
         for (int i = 0; i < m_ba[lev].size(); ++i) {
-            box_lev_proc_ids.push_back(std::make_tuple(i, lev, m_dm[lev][i]));
+            int rank = ParallelContext::global_to_local_rank(m_dm[lev][i]);
+            box_lev_proc_ids.push_back(std::make_tuple(i, lev, rank));
         }
     }
-    
-    std::sort(box_lev_proc_ids.begin(), box_lev_proc_ids.end(), 
+
+    std::sort(box_lev_proc_ids.begin(), box_lev_proc_ids.end(),
               [](const ThreeIntTuple& a, const ThreeIntTuple& b) -> bool
               {
                   int pid_a = std::get<2>(a);
@@ -95,10 +96,10 @@ void ParticleBufferMap::define (const ParGDBBase* a_gdb)
         m_proc_box_offsets.push_back(m_proc_box_offsets.back() + count);
 
     d_bucket_to_pid.resize(0);
-    d_bucket_to_pid.resize(num_buckets);    
-    
+    d_bucket_to_pid.resize(num_buckets);
+
     d_lev_gid_to_bucket.resize(0);
-    d_lev_gid_to_bucket.resize(num_buckets);    
+    d_lev_gid_to_bucket.resize(num_buckets);
 
     d_lev_offsets.resize(0);
     d_lev_offsets.resize(m_lev_offsets.size());

--- a/Src/Particle/AMReX_ParticleBufferMap.cpp
+++ b/Src/Particle/AMReX_ParticleBufferMap.cpp
@@ -79,7 +79,7 @@ void ParticleBufferMap::define (const ParGDBBase* a_gdb)
     }
 
     m_proc_box_counts.resize(0);
-    m_proc_box_counts.resize(ParallelDescriptor::NProcs(), 0);
+    m_proc_box_counts.resize(ParallelContext::NProcsSub(), 0);
 
     for (int i = 0; i < num_buckets; ++i)
     {

--- a/Src/Particle/AMReX_ParticleCommunication.H
+++ b/Src/Particle/AMReX_ParticleCommunication.H
@@ -552,7 +552,8 @@ void unpackRemotes (PC& pc, const ParticleCopyPlan& plan, Buffer& rcv_buffer, co
             auto& tile = pc.DefineAndReturnParticleTile(lev, gid, tid);
             auto ptd = tile.getParticleTileData();
 
-            AMREX_ASSERT(MyProc == pc.ParticleDistributionMap(lev)[gid]);
+            const int global_who = pc.ParticleDistributionMap(lev)[gid];
+            AMREX_ASSERT(MyProc == ParallelContext::global_to_local_rank(global_who));
 
             int dst_offset = offsets[uindex];
             int size = sizes[uindex];

--- a/Src/Particle/AMReX_ParticleCommunication.H
+++ b/Src/Particle/AMReX_ParticleCommunication.H
@@ -14,7 +14,7 @@ namespace amrex {
 
 struct NeighborUnpackPolicy
 {
-    template <class PTile> 
+    template <class PTile>
     void resizeTiles (std::vector<PTile*>& tiles, const std::vector<int>& sizes, std::vector<int>& offsets) const
     {
         for(int i = 0; i < static_cast<int>(sizes.size()); ++i)
@@ -29,9 +29,9 @@ struct NeighborUnpackPolicy
 
 struct RedistributeUnpackPolicy
 {
-    template <class PTile> 
+    template <class PTile>
     void resizeTiles (std::vector<PTile*>& tiles, const std::vector<int>& sizes, std::vector<int>& offsets) const
-    {        
+    {
         int N = static_cast<int>(sizes.size());
 
         std::map<PTile*, int> tile_sizes;
@@ -49,7 +49,7 @@ struct RedistributeUnpackPolicy
     }
 };
 
-struct ParticleCopyOp 
+struct ParticleCopyOp
 {
     Vector<std::map<int, Gpu::DeviceVector<int> > > m_boxes;
     Vector<std::map<int, Gpu::DeviceVector<int> > > m_levels;
@@ -62,18 +62,18 @@ struct ParticleCopyOp
 
     void resize (const int gid, const int lev, const int size);
 
-    int numCopies (const int gid, const int lev) const 
+    int numCopies (const int gid, const int lev) const
     {
         if (m_boxes.size() <= lev) return 0;
         auto mit = m_boxes[lev].find(gid);
         return mit == m_boxes[lev].end() ? 0 : mit->second.size();
     }
 };
-    
-struct ParticleCopyPlan 
+
+struct ParticleCopyPlan
 {
     Vector<std::map<int, Gpu::DeviceVector<int> > > m_dst_indices;
-    
+
     Gpu::DeviceVector<unsigned int> m_box_counts;
     Gpu::DeviceVector<unsigned int> m_box_offsets;
 
@@ -95,7 +95,7 @@ struct ParticleCopyPlan
     Vector<Long> m_rcv_num_particles;
 
     Vector<int> m_neighbor_procs;
-        
+
     Vector<Long> m_Snds;
     Vector<Long> m_Rcvs;
     Vector<int> m_RcvProc;
@@ -110,12 +110,12 @@ struct ParticleCopyPlan
 
     Vector<std::size_t> m_rcv_pad_correction_h;
     Gpu::DeviceVector<std::size_t> m_rcv_pad_correction_d;
-    
+
     template <class PC, EnableIf_t<IsParticleContainer<PC>::value, int> foo = 0>
     void build (const PC& pc, const ParticleCopyOp& op, bool local)
     {
         BL_PROFILE("ParticleCopyPlan::build");
-        
+
         m_local = local;
 
         const int ngrow = 1;  // note - fix
@@ -123,13 +123,13 @@ struct ParticleCopyPlan
         const int num_levels = pc.BufferMap().numLevels();
         const int num_buckets = pc.BufferMap().numBuckets();
 
-        if (m_local) 
+        if (m_local)
         {
             m_neighbor_procs = pc.NeighborProcs(ngrow);
         }
-        else 
+        else
         {
-            m_neighbor_procs.resize(ParallelDescriptor::NProcs());
+            m_neighbor_procs.resize(ParallelContext::NProcsSub());
             std::iota(m_neighbor_procs.begin(), m_neighbor_procs.end(), 0);
         }
 
@@ -141,7 +141,7 @@ struct ParticleCopyPlan
         auto p_box_perm = pc.BufferMap().levGridToBucketPtr();
 
         constexpr unsigned int max_unsigned_int = std::numeric_limits<unsigned int>::max();
-                
+
         m_dst_indices.resize(num_levels);
         for (int lev = 0; lev < num_levels; ++lev)
         {
@@ -151,11 +151,11 @@ struct ParticleCopyPlan
                 int num_copies = op.numCopies(gid, lev);
                 if (num_copies == 0) continue;
                 m_dst_indices[lev][gid].resize(num_copies);
-            
+
                 auto p_boxes = op.m_boxes[lev].at(gid).dataPtr();
                 auto p_levs = op.m_levels[lev].at(gid).dataPtr();
                 auto p_dst_indices = m_dst_indices[lev][gid].dataPtr();
-                
+
                 AMREX_FOR_1D ( num_copies, i,
                 {
                     int dst_box = p_boxes[i];
@@ -173,12 +173,12 @@ struct ParticleCopyPlan
         amrex::Gpu::exclusive_scan(m_box_counts.begin(), m_box_counts.end(), m_box_offsets.begin());
 
         m_snd_pad_correction_h.resize(0);
-        m_snd_pad_correction_h.resize(ParallelDescriptor::NProcs()+1, 0);
+        m_snd_pad_correction_h.resize(ParallelContext::NProcsSub()+1, 0);
 
         m_snd_pad_correction_d.resize(m_snd_pad_correction_h.size());
         Gpu::copy(Gpu::hostToDevice, m_snd_pad_correction_h.begin(), m_snd_pad_correction_h.end(),
                   m_snd_pad_correction_d.begin());
-        
+
         buildMPIStart(pc.BufferMap(), pc.superParticleSize());
     }
 
@@ -187,7 +187,7 @@ struct ParticleCopyPlan
     void buildMPIFinish (const ParticleBufferMap& map);
 
 private:
-    
+
     void buildMPIStart (const ParticleBufferMap& map, Long psize);
 
     //
@@ -203,7 +203,7 @@ private:
     // this purely with point-to-point communication.
     //
     void doHandShakeLocal (const Vector<Long>& Snds, Vector<Long>& Rcvs) const;
-    
+
     //
     // In the global version, we don't know who we'll receive from, so we
     // need to do some collective communication first.
@@ -212,7 +212,7 @@ private:
 
     //
     // Another version of the above that is implemented using MPI All-to-All
-    //    
+    //
     void doHandShakeAllToAll (const Vector<Long>& Snds, Vector<Long>& Rcvs) const;
 
     bool m_local;
@@ -220,7 +220,7 @@ private:
 
 struct GetSendBufferOffset
 {
-    const unsigned int* m_box_offsets;        
+    const unsigned int* m_box_offsets;
     const std::size_t* m_pad_correction;
 
     const int* m_lev_offsets;
@@ -234,7 +234,7 @@ struct GetSendBufferOffset
           m_box_perm(map.levGridToBucketPtr()),
           m_buck_to_pid(map.bucketToPIDPtr())
     {}
-    
+
     AMREX_FORCE_INLINE AMREX_GPU_HOST_DEVICE
     Long operator() (int dst_box, int dst_lev, std::size_t psize, int i) const
     {
@@ -264,7 +264,7 @@ void packBuffer (const PC& pc, const ParticleCopyOp& op, const ParticleCopyPlan&
     auto p_comm_int  = pc.communicate_int_comp.dataPtr();
 
     for (int lev = 0; lev < num_levels; ++lev)
-    {       
+    {
         const auto& geom = pc.Geom(lev);
         auto& plev = pc.GetParticles(lev);
         auto& ba = pc.ParticleBoxArray(lev);
@@ -277,19 +277,19 @@ void packBuffer (const PC& pc, const ParticleCopyOp& op, const ParticleCopyPlan&
             int gid = kv.first.first;
             int tid = kv.first.second;
             auto index = std::make_pair(gid, tid);
-            
+
             auto& src_tile = plev.at(index);
             auto& aos   = src_tile.GetArrayOfStructs();
             const auto ptd = src_tile.getConstParticleTileData();
-            
+
             int num_copies = op.numCopies(gid, lev);
             if (num_copies == 0) continue;
-            
+
             auto p_boxes = op.m_boxes[lev].at(gid).dataPtr();
             auto p_levels = op.m_levels[lev].at(gid).dataPtr();
             auto p_src_indices = op.m_src_indices[lev].at(gid).dataPtr();
             auto p_periodic_shift = op.m_periodic_shift[lev].at(gid).dataPtr();
-            auto p_dst_indices = plan.m_dst_indices[lev].at(gid).dataPtr();           
+            auto p_dst_indices = plan.m_dst_indices[lev].at(gid).dataPtr();
             auto p_snd_buffer = snd_buffer.dataPtr();
             GetSendBufferOffset get_offset(plan, pc.BufferMap());
 
@@ -299,17 +299,17 @@ void packBuffer (const PC& pc, const ParticleCopyOp& op, const ParticleCopyPlan&
                 if (dst_box >= 0)
                 {
                     int dst_lev = p_levels[i];
-                    auto dst_offset = get_offset(dst_box, dst_lev, psize, p_dst_indices[i]); 
+                    auto dst_offset = get_offset(dst_box, dst_lev, psize, p_dst_indices[i]);
                     int src_index = p_src_indices[i];
                     ptd.packParticleData(p_snd_buffer, src_index, dst_offset, p_comm_real, p_comm_int);
-                
+
                     ParticleType* p = (ParticleType*) &p_snd_buffer[dst_offset];
                     const IntVect& pshift = p_periodic_shift[i];
                     for (int idim = 0; idim < AMREX_SPACEDIM; ++idim)
                     {
                         if (not is_per[idim]) continue;
-                        if (pshift[idim] > 0) 
-                            p->pos(idim) += phi[idim] - plo[idim]; 
+                        if (pshift[idim] > 0)
+                            p->pos(idim) += phi[idim] - plo[idim];
                         else if (pshift[idim] < 0)
                             p->pos(idim) -= phi[idim] - plo[idim];
                     }
@@ -334,7 +334,7 @@ void unpackBuffer (PC& pc, const ParticleCopyPlan& plan, const Buffer& snd_buffe
     std::vector<int> sizes;
     std::vector<PTile*> tiles;
     for (int lev = 0; lev < num_levels; ++lev)
-    {       
+    {
         for(MFIter mfi = pc.MakeMFIter(lev); mfi.isValid(); ++mfi)
         {
             int gid = mfi.index();
@@ -356,24 +356,24 @@ void unpackBuffer (PC& pc, const ParticleCopyPlan& plan, const Buffer& snd_buffe
     // local unpack
     int uindex = 0;
     for (int lev = 0; lev < num_levels; ++lev)
-    {       
+    {
         auto& plev  = pc.GetParticles(lev);
         for(MFIter mfi = pc.MakeMFIter(lev); mfi.isValid(); ++mfi)
         {
             int gid = mfi.index();
             int tid = mfi.LocalTileIndex();
             auto index = std::make_pair(gid, tid);
-            
+
             auto& tile = plev[index];
             auto& aos   = tile.GetArrayOfStructs();
 
             GetSendBufferOffset get_offset(plan, pc.BufferMap());
             auto p_snd_buffer = snd_buffer.dataPtr();
-            
+
             int offset = offsets[uindex];
             int size = sizes[uindex];
             ++uindex;
-        
+
             auto ptd = tile.getParticleTileData();
             AMREX_FOR_1D ( size, i,
             {
@@ -390,13 +390,13 @@ template <class PC, class Buffer,
 void communicateParticlesStart (const PC& pc, ParticleCopyPlan& plan, const Buffer& snd_buffer, Buffer& rcv_buffer)
 {
     BL_PROFILE("amrex::communicateParticlesStart");
-    
+
     Long psize = pc.superParticleSize();
 
 #ifdef AMREX_USE_MPI
-    const int NProcs = ParallelDescriptor::NProcs();
-    const int MyProc = ParallelDescriptor::MyProc();
-    
+    const int NProcs = ParallelContext::NProcsSub();
+    const int MyProc = ParallelContext::MyProcSub();
+
     if (NProcs == 1) return;
 
     Vector<int> RcvProc;
@@ -426,7 +426,7 @@ void communicateParticlesStart (const PC& pc, ParticleCopyPlan& plan, const Buff
     plan.m_rcv_pad_correction_d.resize(plan.m_rcv_pad_correction_h.size());
     Gpu::copy(Gpu::hostToDevice, plan.m_rcv_pad_correction_h.begin(), plan.m_rcv_pad_correction_h.end(),
               plan.m_rcv_pad_correction_d.begin());
-    
+
     rcv_buffer.resize(TotRcvBytes);
 
     plan.m_nrcvs = RcvProc.size();
@@ -436,7 +436,7 @@ void communicateParticlesStart (const PC& pc, ParticleCopyPlan& plan, const Buff
 
     plan.m_particle_rreqs.resize(0);
     plan.m_particle_rreqs.resize(plan.m_nrcvs);
-    
+
     const int SeqNum = ParallelDescriptor::SeqNum();
 
     // Post receives.
@@ -454,21 +454,21 @@ void communicateParticlesStart (const PC& pc, ParticleCopyPlan& plan, const Buff
 
         const int comm_data_type = ParallelDescriptor::select_comm_data_type(nbytes);
         if (comm_data_type == 1) {
-            plan.m_particle_rreqs[i] = 
-                ParallelDescriptor::Arecv((char*) (rcv_buffer.dataPtr() + offset), Cnt, Who, SeqNum).req();
+            plan.m_particle_rreqs[i] =
+                ParallelDescriptor::Arecv((char*) (rcv_buffer.dataPtr() + offset), Cnt, Who, SeqNum, ParallelContext::CommunicatorSub()).req();
         } else if (comm_data_type == 2) {
-            plan.m_particle_rreqs[i] = 
-                ParallelDescriptor::Arecv((unsigned long long*) (rcv_buffer.dataPtr() + offset), Cnt, Who, SeqNum).req();
+            plan.m_particle_rreqs[i] =
+                ParallelDescriptor::Arecv((unsigned long long*) (rcv_buffer.dataPtr() + offset), Cnt, Who, SeqNum, ParallelContext::CommunicatorSub()).req();
         } else if (comm_data_type == 3) {
-            plan.m_particle_rreqs[i] = 
-                ParallelDescriptor::Arecv((ParallelDescriptor::lull_t *) (rcv_buffer.dataPtr() + offset), Cnt, Who, SeqNum).req();
+            plan.m_particle_rreqs[i] =
+                ParallelDescriptor::Arecv((ParallelDescriptor::lull_t *) (rcv_buffer.dataPtr() + offset), Cnt, Who, SeqNum, ParallelContext::CommunicatorSub()).req();
         } else {
             amrex::Abort("TODO: message size is too big");
         }
     }
 
     if (plan.m_NumSnds == 0) return;
-    
+
     // Send.
     for (int i = 0; i < NProcs; ++i)
     {
@@ -484,14 +484,15 @@ void communicateParticlesStart (const PC& pc, ParticleCopyPlan& plan, const Buff
         AMREX_ASSERT(Who >= 0 && Who < NProcs);
         AMREX_ASSERT(Cnt < std::numeric_limits<int>::max());
         AMREX_ASSERT(snd_offset % acd == 0);
-        
+
         const int comm_data_type = ParallelDescriptor::select_comm_data_type(nbytes);
         if (comm_data_type == 1) {
-            ParallelDescriptor::Send((char*)(snd_buffer.dataPtr()+snd_offset), Cnt, Who, SeqNum);
+            ParallelDescriptor::Send((char*)(snd_buffer.dataPtr()+snd_offset), Cnt, Who, SeqNum,
+                                     ParallelContext::CommunicatorSub());
         } else if (comm_data_type == 2) {
-            ParallelDescriptor::Send((unsigned long long*)(snd_buffer.dataPtr()+snd_offset), Cnt, Who, SeqNum);
+            ParallelDescriptor::Send((unsigned long long*)(snd_buffer.dataPtr()+snd_offset), Cnt, Who, SeqNum, ParallelContext::CommunicatorSub());
         } else if (comm_data_type == 3) {
-            ParallelDescriptor::Send((ParallelDescriptor::lull_t *)(snd_buffer.dataPtr()+snd_offset), Cnt, Who, SeqNum);
+            ParallelDescriptor::Send((ParallelDescriptor::lull_t *)(snd_buffer.dataPtr()+snd_offset), Cnt, Who, SeqNum, ParallelContext::CommunicatorSub());
         } else {
             amrex::Abort("TODO: message size is too big");
         }
@@ -506,12 +507,12 @@ template <class PC, class Buffer, class UnpackPolicy,
 void unpackRemotes (PC& pc, const ParticleCopyPlan& plan, Buffer& rcv_buffer, const UnpackPolicy& policy)
 {
     BL_PROFILE("amrex::unpackRemotes");
-    
+
 #ifdef AMREX_USE_MPI
-    const int NProcs = ParallelDescriptor::NProcs();
+    const int NProcs = ParallelContext::NProcsSub();
     if (NProcs == 1) return;
 
-    const int MyProc = ParallelDescriptor::MyProc();
+    const int MyProc = ParallelContext::MyProcSub();
     amrex::ignore_unused(MyProc);
     using PTile = typename PC::ParticleTileType;
 
@@ -558,8 +559,8 @@ void unpackRemotes (PC& pc, const ParticleCopyPlan& plan, Buffer& rcv_buffer, co
             ++uindex;
 
             Long psize = pc.superParticleSize();
-            auto p_pad_adjust = plan.m_rcv_pad_correction_d.dataPtr();            
-            
+            auto p_pad_adjust = plan.m_rcv_pad_correction_d.dataPtr();
+
             AMREX_FOR_1D ( size, ip,
 	    {
                 Long src_offset = psize*(offset + ip) + p_pad_adjust[procindex];
@@ -568,7 +569,7 @@ void unpackRemotes (PC& pc, const ParticleCopyPlan& plan, Buffer& rcv_buffer, co
                                        p_comm_real, p_comm_int);
             });
 	}
-    }    
+    }
 #endif // MPI
 }
 

--- a/Src/Particle/AMReX_ParticleCommunication.cpp
+++ b/Src/Particle/AMReX_ParticleCommunication.cpp
@@ -215,10 +215,10 @@ void ParticleCopyPlan::buildMPIFinish (const ParticleBufferMap& map)
 
         Gpu::HostVector<int> rcv_box_offsets;
         Gpu::HostVector<int> rcv_box_counts;
-        Gpu::HostVector<int> rcv_box_ids;        
+        Gpu::HostVector<int> rcv_box_ids;
         Gpu::HostVector<int> rcv_box_levs;
-        Gpu::HostVector<int> rcv_box_pids;        
-        
+        Gpu::HostVector<int> rcv_box_pids;
+
         rcv_box_offsets.push_back(0);
         for (int i = 0; i < m_rcv_data.size(); i+=4)
         {
@@ -229,13 +229,13 @@ void ParticleCopyPlan::buildMPIFinish (const ParticleBufferMap& map)
             rcv_box_pids.push_back(m_rcv_data[i+3]);
             rcv_box_offsets.push_back(rcv_box_offsets.back() + rcv_box_counts.back());
         }
-        
+
         m_rcv_box_counts.resize(rcv_box_counts.size());
         Gpu::copy(Gpu::hostToDevice, rcv_box_counts.begin(), rcv_box_counts.end(), m_rcv_box_counts.begin());
-        
+
         m_rcv_box_offsets.resize(rcv_box_offsets.size());
         Gpu::copy(Gpu::hostToDevice, rcv_box_offsets.begin(), rcv_box_offsets.end(), m_rcv_box_offsets.begin());
-        
+
         m_rcv_box_ids.resize(rcv_box_ids.size());
         Gpu::copy(Gpu::hostToDevice, rcv_box_ids.begin(), rcv_box_ids.end(), m_rcv_box_ids.begin());
 
@@ -245,13 +245,13 @@ void ParticleCopyPlan::buildMPIFinish (const ParticleBufferMap& map)
         m_rcv_box_pids.resize(rcv_box_pids.size());
         Gpu::copy(Gpu::hostToDevice, rcv_box_pids.begin(), rcv_box_pids.end(), m_rcv_box_pids.begin());
     }
-    
+
     for (int j = 0; j < m_nrcvs; ++j)
     {
         const auto Who    = m_RcvProc[j];
         const auto offset = m_rOffset[j];
         const auto Cnt    = m_Rcvs[Who]/sizeof(int);
-        
+
         Long nparticles = 0;
         for (int i = offset; i < offset + Cnt; i +=4)
         {
@@ -277,31 +277,31 @@ void ParticleCopyPlan::doHandShakeLocal (const Vector<Long>& Snds, Vector<Long>&
     const int num_rcvs = m_neighbor_procs.size();
     Vector<MPI_Status>  stats(num_rcvs);
     Vector<MPI_Request> rreqs(num_rcvs);
-    
+
     // Post receives
     for (int i = 0; i < num_rcvs; ++i)
     {
         const int Who = m_neighbor_procs[i];
         const Long Cnt = 1;
-        
+
         AMREX_ASSERT(Who >= 0 && Who < ParallelContext::NProcsSub());
-        
+
         rreqs[i] = ParallelDescriptor::Arecv(&Rcvs[Who], Cnt, Who, SeqNum,
                                              ParallelContext::CommunicatorSub()).req();
     }
-        
+
     // Send.
     for (int i = 0; i < num_rcvs; ++i)
     {
         const int Who = m_neighbor_procs[i];
         const Long Cnt = 1;
-        
+
         AMREX_ASSERT(Who >= 0 && Who < ParallelContext::NProcsSub());
-        
+
         ParallelDescriptor::Send(&Snds[Who], Cnt, Who, SeqNum,
                                  ParallelContext::CommunicatorSub());
     }
-        
+
     if (num_rcvs > 0)
     {
         ParallelDescriptor::Waitall(rreqs, stats);

--- a/Src/Particle/AMReX_ParticleContainerI.H
+++ b/Src/Particle/AMReX_ParticleContainerI.H
@@ -170,7 +170,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
             IntVect iv;
             const BoxArray& ba = ParticleBoxArray(lev);
             AMREX_ASSERT(ba.ixType().cellCentered());
-            
+
 	    if (local_grid < 0) {
                 iv = Index(p_prime, lev);
                 ba.intersections(Box(iv, iv), isects, true, 0);
@@ -191,14 +191,14 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
 		    }
 		}
 	    }
-            
+
             if (grid >= 0) {
                 AMREX_D_TERM(p.pos(0) = p_prime.pos(0);,
                              p.pos(1) = p_prime.pos(1);,
                              p.pos(2) = p_prime.pos(2););
-                
+
                 const Box& bx = ba.getCellCenteredBox(grid);
-                
+
                 pld.m_lev  = lev;
                 pld.m_grid = grid;
 		pld.m_tile = getTileIndex(iv, bx, do_tiling, tile_size, pld.m_tilebox);
@@ -209,7 +209,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
             }
         }
     }
-    
+
     return false;
 }
 
@@ -310,21 +310,21 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>::resizeData ()
 
 template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt>
 void
-ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>::RedefineDummyMF (int lev) 
+ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>::RedefineDummyMF (int lev)
 {
     if (lev > m_dummy_mf.size()-1) m_dummy_mf.resize(lev+1);
-    
-    if (m_dummy_mf[lev] == nullptr || 
+
+    if (m_dummy_mf[lev] == nullptr ||
         ! BoxArray::SameRefs(m_dummy_mf[lev]->boxArray(),
                              ParticleBoxArray(lev))          ||
-        ! DistributionMapping::SameRefs(m_dummy_mf[lev]->DistributionMap(), 
+        ! DistributionMapping::SameRefs(m_dummy_mf[lev]->DistributionMap(),
                                         ParticleDistributionMap(lev)))
     {
         m_dummy_mf[lev].reset(new MultiFab(ParticleBoxArray(lev),
                                            ParticleDistributionMap(lev),
                                            1,0,MFInfo().SetAlloc(false)));
     };
-}  
+}
 
 template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt>
 void
@@ -1052,7 +1052,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
 #ifdef AMREX_USE_GPU
 
     if (local) AMREX_ASSERT(numParticlesOutOfRange(*this, lev_min, lev_max, local) == 0);
-    
+
     // sanity check
     AMREX_ASSERT(do_tiling == false);
 
@@ -1063,7 +1063,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
 
     if (lev_max < 0)
         lev_max = GetParGDB()->finestLevel();
-    
+
     this->defineBufferMap();
 
     int num_levels = numLevels();
@@ -1086,12 +1086,11 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
     BL_PROFILE_VAR_START(blp_partition);
     ParticleCopyOp op;
     op.setNumLevels(num_levels);
-    Vector<std::map<int, int> > new_sizes(num_levels);    
+    Vector<std::map<int, int> > new_sizes(num_levels);
     for (int lev = lev_min; lev <= lev_max; ++lev)
     {
         const Geometry& geom = Geom(lev);
         const BoxArray& ba   = ParticleBoxArray(lev);
-        const DistributionMapping& dmap = ParticleDistributionMap(lev);
 
         auto& plev = m_particles[lev];
         for (auto& kv : plev)
@@ -1099,7 +1098,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
             int gid = kv.first.first;
             int tid = kv.first.second;
             auto index = std::make_pair(gid, tid);
-            
+
             auto& src_tile = plev[index];
             auto& aos = src_tile.GetArrayOfStructs();
             const size_t np = aos.numParticles();
@@ -1262,22 +1261,22 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
   if (int(m_particles.size()) < theEffectiveFinestLevel+1) {
       if (Verbose()) {
           amrex::Print() << "ParticleContainer::Redistribute() resizing containers from "
-                         << m_particles.size() << " to " 
+                         << m_particles.size() << " to "
                          << theEffectiveFinestLevel + 1 << '\n';
       }
       m_particles.resize(theEffectiveFinestLevel+1);
       m_dummy_mf.resize(theEffectiveFinestLevel+1);
   }
-  
-  // It is important to do this even if we don't have more levels because we may have changed the 
+
+  // It is important to do this even if we don't have more levels because we may have changed the
   // grids at this level in a regrid.
   for (int lev = 0; lev < theEffectiveFinestLevel+1; ++lev)
       RedefineDummyMF(lev);
-  
+
   int nlevs_particles;
   if (lev_max == -1) {
       lev_max = theEffectiveFinestLevel;
-      nlevs_particles = m_particles.size() - 1; 
+      nlevs_particles = m_particles.size() - 1;
   } else {
       nlevs_particles = lev_max;
   }
@@ -1285,14 +1284,14 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
 
   // This will hold the valid particles that go to another process
   std::map<int, Vector<char> > not_ours;
-  
+
   int num_threads = 1;
 #ifdef _OPENMP
 #pragma omp parallel
 #pragma omp single
   num_threads = omp_get_num_threads();
 #endif
-  
+
   // these are temporary buffers for each thread
   std::map<int, Vector<Vector<char> > > tmp_remote;
   Vector<std::map<std::pair<int, int>, Vector<ParticleVector> > > tmp_local;
@@ -1332,7 +1331,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
           grid_tile_ids.push_back(kv.first);
           ptile_ptrs.push_back(&(kv.second));
       }
-      
+
 #ifdef _OPENMP
 #pragma omp parallel for
 #endif
@@ -1383,7 +1382,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
                       continue;
                   }
 
-                  const int who = ParticleDistributionMap(pld.m_lev)[pld.m_grid];
+                  const int who = ParallelContext::global_to_local_rank(ParticleDistributionMap(pld.m_lev)[pld.m_grid]);
                   if (who == MyProc) {
                       if (pld.m_lev != lev || pld.m_grid != grid || pld.m_tile != tile) {
                           // We own it but must shift it to another place.
@@ -1604,7 +1603,7 @@ template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt>
 void
 ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>::
 BuildRedistributeMask (int lev, int nghost) const
-{    
+{
     BL_PROFILE("ParticleContainer::BuildRedistributeMask");
     AMREX_ASSERT(lev == 0);
 
@@ -1616,12 +1615,12 @@ BuildRedistributeMask (int lev, int nghost) const
         const Geometry& geom = this->Geom(lev);
         const BoxArray& ba = this->ParticleBoxArray(lev);
         const DistributionMapping& dmap = this->ParticleDistributionMap(lev);
-        
+
         redistribute_mask_nghost = nghost;
         redistribute_mask_ptr.reset(new iMultiFab(ba, dmap, 2, nghost));
         redistribute_mask_ptr->setVal(-1, nghost);
 
-        const auto tile_size_do = this->do_tiling ? this->tile_size : IntVect::TheZeroVector();            
+        const auto tile_size_do = this->do_tiling ? this->tile_size : IntVect::TheZeroVector();
 
 #ifdef _OPENMP
 #pragma omp parallel
@@ -1634,11 +1633,11 @@ BuildRedistributeMask (int lev, int nghost) const
             (*redistribute_mask_ptr)[mfi].template setVal<RunOn::Host>(grid_id, box, 0, 1);
             (*redistribute_mask_ptr)[mfi].template setVal<RunOn::Host>(tile_id, box, 1, 1);
         }
-        
+
         redistribute_mask_ptr->FillBoundary(geom.periodicity());
 
         neighbor_procs.clear();
-        for (MFIter mfi(*redistribute_mask_ptr, tile_size_do); mfi.isValid(); ++mfi) 
+        for (MFIter mfi(*redistribute_mask_ptr, tile_size_do); mfi.isValid(); ++mfi)
         {
             const Box& box = mfi.growntilebox();
             for (IntVect iv = box.smallEnd(); iv <= box.bigEnd(); box.next(iv))
@@ -1646,14 +1645,15 @@ BuildRedistributeMask (int lev, int nghost) const
                 const int grid = (*redistribute_mask_ptr)[mfi](iv, 0);
                 if (grid >= 0)
                 {
-                    const int proc = this->ParticleDistributionMap(lev)[grid];
-                    if (proc != ParallelContext::MyProcSub())  
-                        neighbor_procs.push_back(proc);
+                    const int global_rank = this->ParticleDistributionMap(lev)[grid];
+                    const int rank = ParallelContext::global_to_local_rank(global_rank);
+                    if (rank != ParallelContext::MyProcSub())
+                        neighbor_procs.push_back(rank);
                 }
             }
         }
         RemoveDuplicates(neighbor_procs);
-    }    
+    }
 }
 
 template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt>
@@ -1669,7 +1669,7 @@ RedistributeMPI (std::map<int, Vector<char> >& not_ours,
 #ifdef AMREX_USE_MPI
 
     using buffer_type = unsigned long long;
-    
+
     std::map<int, Vector<buffer_type> > mpi_snd_data;
     for (const auto& kv : not_ours)
     {
@@ -1677,10 +1677,10 @@ RedistributeMPI (std::map<int, Vector<char> >& not_ours,
         mpi_snd_data[kv.first].resize(nbt);
         std::memcpy((char*) mpi_snd_data[kv.first].data(), kv.second.data(), kv.second.size());
     }
-    
+
     const int NProcs = ParallelContext::NProcsSub();
     const int NNeighborProcs = neighbor_procs.size();
-    
+
     // We may now have particles that are rightfully owned by another CPU.
     Vector<Long> Snds(NProcs, 0), Rcvs(NProcs, 0);  // bytes!
 
@@ -1698,7 +1698,7 @@ RedistributeMPI (std::map<int, Vector<char> >& not_ours,
     }
 
     const int SeqNum = ParallelDescriptor::SeqNum();
-    
+
     if ((not local) and NumSnds == 0)
         return;  // There's no parallel work to do.
 
@@ -1712,12 +1712,12 @@ RedistributeMPI (std::map<int, Vector<char> >& not_ours,
         }
         if ( (tot_snds_this_proc == 0) and (tot_rcvs_this_proc == 0) ) {
             return; // There's no parallel work to do.
-        } 
+        }
     }
 
     Vector<int> RcvProc;
     Vector<std::size_t> rOffset; // Offset (in bytes) in the receive buffer
-    
+
     std::size_t TotRcvInts = 0;
     std::size_t TotRcvBytes = 0;
     for (int i = 0; i < NProcs; ++i) {
@@ -1804,9 +1804,9 @@ RedistributeMPI (std::map<int, Vector<char> >& not_ours,
         {
             const auto offset = rOffset[i];
             const auto Who    = RcvProc[i];
-            const auto Cnt = Rcvs[Who] / superparticle_size;            
+            const auto Cnt = Rcvs[Who] / superparticle_size;
             for (int j = 0; j < int(Cnt); ++j)
-            {                
+            {
                 auto& ptile = m_particles[rcv_levs[ipart]][std::make_pair(rcv_grid[ipart],
                                                                           rcv_tile[ipart])];
                 char* pbuf = ((char*) &recvdata[offset]) + j*superparticle_size;
@@ -1825,7 +1825,7 @@ RedistributeMPI (std::map<int, Vector<char> >& not_ours,
                         ptile.push_back_real(comp, 0.0);
                     }
                 }
-            
+
                 for (int comp = 0; comp < NumIntComps(); ++comp) {
                     if (communicate_int_comp[comp]) {
                         int idata;
@@ -1838,7 +1838,7 @@ RedistributeMPI (std::map<int, Vector<char> >& not_ours,
                 }
                 ++ipart;
             }
-        }	    
+        }
 #else
 	Vector<std::map<std::pair<int, int>, Gpu::HostVector<ParticleType> > > host_particles;
 	host_particles.reserve(15);
@@ -1859,9 +1859,9 @@ RedistributeMPI (std::map<int, Vector<char> >& not_ours,
         {
             const auto offset = rOffset[i];
             const auto Who    = RcvProc[i];
-            const auto Cnt = Rcvs[Who] / superparticle_size;            
+            const auto Cnt = Rcvs[Who] / superparticle_size;
             for (int j = 0; j < Cnt; ++j)
-            {                
+            {
                 int lev = rcv_levs[ipart];
                 std::pair<int, int> ind(std::make_pair(rcv_grid[ipart], rcv_tile[ipart]));
 
@@ -1870,10 +1870,10 @@ RedistributeMPI (std::map<int, Vector<char> >& not_ours,
                 ParticleType p;
                 std::memcpy(&p, pbuf, sizeof(ParticleType));
                 pbuf += sizeof(ParticleType);
-                
+
                 host_real_attribs[lev][ind].resize(NumRealComps());
                 host_int_attribs[lev][ind].resize(NumIntComps());
-	  
+
                 // add the struct
                 host_particles[lev][ind].push_back(p);
 	  

--- a/Src/Particle/AMReX_ParticleContainerI.H
+++ b/Src/Particle/AMReX_ParticleContainerI.H
@@ -24,8 +24,8 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt> :: SetParticle
     }
 
     particle_size = sizeof(ParticleType);
-    superparticle_size = particle_size + 
-        num_real_comm_comps*sizeof(ParticleReal) + num_int_comm_comps*sizeof(int);    
+    superparticle_size = particle_size +
+        num_real_comm_comps*sizeof(ParticleReal) + num_int_comm_comps*sizeof(int);
 }
 
 template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt>
@@ -376,7 +376,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>::TotalNumberOf
         nparticles += NumberOfParticlesAtLevel(lev,only_valid,true);
     }
     if (!only_local) {
-	ParallelDescriptor::ReduceLongSum(nparticles);
+        ParallelAllReduce::Max(nparticles, ParallelContext::CommunicatorSub());
     }
     return nparticles;
 }
@@ -392,7 +392,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>::NumberOfParti
     for (const auto& kv : GetParticles(lev)) {
       int gid = kv.first.first;
       const auto& ptile = kv.second;
-      
+
       if (only_valid) {
 	for (int k = 0; k < ptile.GetArrayOfStructs().numParticles(); ++k) {
 	  const ParticleType& p = ptile.GetArrayOfStructs()[k];
@@ -402,8 +402,10 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>::NumberOfParti
 	nparticles[gid] += ptile.numParticles();
       }
     }
-    
-    if (!only_local) ParallelDescriptor::ReduceLongSum(&nparticles[0],ngrids);
+
+    if (!only_local) {
+        ParallelAllReduce::Sum(&nparticles[0], ngrids, ParallelContext::CommunicatorSub());
+    }
   }
 
   return nparticles;
@@ -417,7 +419,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>::NumberOfParti
 
     if (lev >= 0 && lev < int(m_particles.size())) {
         for (const auto& kv : GetParticles(lev)) {
-            const auto& ptile = kv.second;	
+            const auto& ptile = kv.second;
             if (only_valid) {
                 for (int k = 0; k < ptile.GetArrayOfStructs().numParticles(); ++k) {
                     const ParticleType& p = ptile.GetArrayOfStructs()[k];
@@ -429,8 +431,10 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>::NumberOfParti
         }
     }
 
-    if (!only_local) ParallelDescriptor::ReduceLongSum(nparticles);
-    
+    if (!only_local) {
+        ParallelAllReduce::Sum(nparticles, ParallelContext::CommunicatorSub());
+    }
+
     return nparticles;
 }
 
@@ -454,25 +458,25 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>::ByteSpread ()
 
     Long mn = cnt, mx = mn;
 
-    const int IOProc = ParallelDescriptor::IOProcessorNumber();
+    const int IOProc = ParallelContext::IOProcessorNumberSub();
     const std::size_t sz = sizeof(ParticleType)+NumRealComps()*sizeof(Real)+NumIntComps()*sizeof(int);
 
 #ifdef AMREX_LAZY
     Lazy::QueueReduction( [=] () mutable {
 #endif
-    ParallelDescriptor::ReduceLongMin(mn, IOProc);
-    ParallelDescriptor::ReduceLongMax(mx, IOProc);
-    ParallelDescriptor::ReduceLongSum(cnt,IOProc);
+            ParallelReduce::Min(mn,  IOProc, ParallelContext::CommunicatorSub());
+            ParallelReduce::Max(mx,  IOProc, ParallelContext::CommunicatorSub());
+            ParallelReduce::Sum(cnt, IOProc, ParallelContext::CommunicatorSub());
 
-    amrex::Print() << "ParticleContainer byte spread across MPI nodes: ["
-                   << mn*sz
-                   << " (" << mn << ")"
-                   << " ... "
-                   << mx*sz
-                   << " (" << mx << ")"
-                   << "] total particles: (" << cnt << ")\n";
+            amrex::Print() << "ParticleContainer byte spread across MPI nodes: ["
+                           << mn*sz
+                           << " (" << mn << ")"
+                           << " ... "
+                           << mx*sz
+                           << " (" << mx << ")"
+                           << "] total particles: (" << cnt << ")\n";
 #ifdef AMREX_LAZY
-    });
+        });
 #endif
 }
 
@@ -492,24 +496,24 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>::PrintCapacity
 
     Long mn = cnt, mx = mn;
 
-    const int IOProc = ParallelDescriptor::IOProcessorNumber();
+    const int IOProc = ParallelContext::IOProcessorNumberSub();
 
 #ifdef AMREX_LAZY
     Lazy::QueueReduction( [=] () mutable {
 #endif
-    ParallelDescriptor::ReduceLongMin(mn, IOProc);
-    ParallelDescriptor::ReduceLongMax(mx, IOProc);
-    ParallelDescriptor::ReduceLongSum(cnt,IOProc);
+            ParallelReduce::Min(mn,  IOProc, ParallelContext::CommunicatorSub());
+            ParallelReduce::Max(mx,  IOProc, ParallelContext::CommunicatorSub());
+            ParallelReduce::Sum(cnt, IOProc, ParallelContext::CommunicatorSub());
 
-    amrex::Print() << "ParticleContainer byte spread across MPI nodes: ["
-                   << mn
-                   << " (" << mn << ")"
-                   << " ... "
-                   << mx
-                   << " (" << mx << ")"
-                   << "] total memory: (" << cnt << ")\n";
+            amrex::Print() << "ParticleContainer byte spread across MPI nodes: ["
+                           << mn
+                           << " (" << mn << ")"
+                           << " ... "
+                           << mx
+                           << " (" << mx << ")"
+                           << "] total memory: (" << cnt << ")\n";
 #ifdef AMREX_LAZY
-    });
+        });
 #endif
 }
 
@@ -633,18 +637,20 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>::IncrementWith
           }
       }
   }
-  
+
   // If mf is not defined on the particle_box_array, then we need
   // to copy here from mf_pointer into mf.   I believe that we don't
   // need any information in ghost cells so we don't copy those.
-  if (mf_pointer != &mf) 
+  if (mf_pointer != &mf)
     {
-      mf.copy(*mf_pointer,0,0,mf.nComp());  
+      mf.copy(*mf_pointer,0,0,mf.nComp());
       delete mf_pointer;
     }
-  
-  if (!local) ParallelDescriptor::ReduceLongSum(num_particles_in_domain);
-  
+
+  if (!local) {
+      ParallelAllReduce::Sum(num_particles_in_domain, ParallelContext::CommunicatorSub());
+  }
+
   return num_particles_in_domain;
 }
 
@@ -655,9 +661,9 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>::sumParticleMa
   BL_PROFILE("ParticleContainer::sumParticleMass(lev)");
   AMREX_ASSERT(NStructReal >= 1);
   AMREX_ASSERT(lev >= 0 && lev < int(m_particles.size()));
-  
+
   Real msum = 0;
-  
+
   const auto& pmap = m_particles[lev];
   for (const auto& kv : pmap) {
       const auto& pbox = kv.second.GetArrayOfStructs();
@@ -668,9 +674,11 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>::sumParticleMa
 	  }
       }
   }
-  
-  if (!local) ParallelDescriptor::ReduceRealSum(msum);
-  
+
+  if (!local) {
+      ParallelAllReduce::Sum(msum, ParallelContext::CommunicatorSub());
+  }
+
   return msum;
 }
 
@@ -680,7 +688,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>::RemoveParticl
 {
     BL_PROFILE("ParticleContainer::RemoveParticlesAtLevel()");
     if (level >= int(this->m_particles.size())) return;
-    
+
     if (!this->m_particles[level].empty())
     {
         ParticleLevel().swap(this->m_particles[level]);
@@ -693,9 +701,9 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>::RemoveParticl
 {
   BL_PROFILE("ParticleContainer::RemoveParticlesNotAtFinestLevel()");
   AMREX_ASSERT(this->finestLevel()+1 == int(this->m_particles.size()));
-  
+
   Long cnt = 0;
-  
+
   for (unsigned lev = 0; lev < m_particles.size() - 1; ++lev) {
       auto& pmap = m_particles[lev];
       if (!pmap.empty()) {
@@ -711,7 +719,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>::RemoveParticl
   // Print how many particles removed on each processor if any were removed.
   //
   if (this->m_verbose > 1 && cnt > 0) {
-      amrex::AllPrint() << "Processor " << ParallelDescriptor::MyProc() << " removed " << cnt
+      amrex::AllPrint() << "Processor " << ParallelContext::MyProcSub() << " removed " << cnt
                         << " particles not in finest level\n";
   }
 }
@@ -1159,7 +1167,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
     {
         auto& pmap = m_particles[lev];
         for (auto pmap_it = pmap.begin(); pmap_it != pmap.end(); /* no ++ */)
-        {          
+        {
             if (pmap_it->second.empty())
             {
                 pmap.erase(pmap_it++);
@@ -1177,7 +1185,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
         communicateParticlesStart(*this, plan, snd_buffer, rcv_buffer);
         unpackBuffer(*this, plan, snd_buffer, RedistributeUnpackPolicy());
         communicateParticlesFinish(plan);
-        unpackRemotes(*this, plan, rcv_buffer, RedistributeUnpackPolicy());        
+        unpackRemotes(*this, plan, rcv_buffer, RedistributeUnpackPolicy());
     }
     else
     {
@@ -1189,14 +1197,14 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
         plan.buildMPIFinish(BufferMap());
         Gpu::Device::synchronize();
         communicateParticlesStart(*this, plan, pinned_snd_buffer, pinned_rcv_buffer);
-        rcv_buffer.resize(pinned_rcv_buffer.size());   
+        rcv_buffer.resize(pinned_rcv_buffer.size());
         unpackBuffer(*this, plan, snd_buffer, RedistributeUnpackPolicy());
-        communicateParticlesFinish(plan);        
+        communicateParticlesFinish(plan);
         Gpu::htod_memcpy_async(rcv_buffer.dataPtr(), pinned_rcv_buffer.dataPtr(), pinned_rcv_buffer.size());
         unpackRemotes(*this, plan, rcv_buffer, RedistributeUnpackPolicy());
     }
 
-    Gpu::Device::synchronize();    
+    Gpu::Device::synchronize();
     AMREX_ASSERT(numParticlesOutOfRange(*this, lev_min, lev_max, nGrow) == 0);
 #endif
 }
@@ -1238,10 +1246,10 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
 ::RedistributeCPU (int lev_min, int lev_max, int nGrow, int local)
 {
   BL_PROFILE("ParticleContainer::RedistributeCPU()");
-    
-  const int MyProc    = ParallelDescriptor::MyProc();
+
+  const int MyProc    = ParallelContext::MyProcSub();
   Real      strttime  = amrex::second();
-  
+
   if (local > 0) BuildRedistributeMask(0, local);
 
   // On startup there are cases where Redistribute() could be called
@@ -1308,7 +1316,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
     for (int i = 0; i < neighbor_procs.size(); ++i)
       tmp_remote[neighbor_procs[i]].resize(num_threads);
   } else {
-    for (int i = 0; i < ParallelDescriptor::NProcs(); ++i)
+    for (int i = 0; i < ParallelContext::NProcsSub(); ++i)
       tmp_remote[i].resize(num_threads);
   }
 
@@ -1547,29 +1555,31 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
                          << m_particles.size() << " to " << theEffectiveFinestLevel+1 << '\n';
       }
       AMREX_ASSERT(int(m_particles.size()) >= 2);
-      
+
       m_particles.resize(theEffectiveFinestLevel + 1);
       m_dummy_mf.resize(theEffectiveFinestLevel + 1);
   }
-  
-  if (ParallelDescriptor::NProcs() == 1) {
+
+  if (ParallelContext::NProcsSub() == 1) {
       AMREX_ASSERT(not_ours.empty());
   }
   else {
       RedistributeMPI(not_ours, lev_min, lev_max, nGrow, local);
   }
-  
+
   AMREX_ASSERT(OK(lev_min, lev_max, nGrow));
-  
+
   if (m_verbose > 0) {
       Real stoptime = amrex::second() - strttime;
-      
+
       ByteSpread();
-      
+
 #ifdef AMREX_LAZY
       Lazy::QueueReduction( [=] () mutable {
 #endif
-              ParallelDescriptor::ReduceRealMax(stoptime,ParallelDescriptor::IOProcessorNumber());
+              ParallelReduce::Max(stoptime, ParallelContext::IOProcessorNumberSub(),
+                                  ParallelContext::CommunicatorSub());
+
               amrex::Print() << "ParticleContainer::Redistribute() time: " << stoptime << "\n\n";
 #ifdef AMREX_LAZY
           });
@@ -1581,7 +1591,7 @@ template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt>
 void
 ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>::
 defineBufferMap () const
-{    
+{
     BL_PROFILE("ParticleContainer::defineBufferMap");
 
     if (not m_buffer_map.isValid(GetParGDB()))
@@ -1637,7 +1647,7 @@ BuildRedistributeMask (int lev, int nghost) const
                 if (grid >= 0)
                 {
                     const int proc = this->ParticleDistributionMap(lev)[grid];
-                    if (proc != ParallelDescriptor::MyProc())  
+                    if (proc != ParallelContext::MyProcSub())  
                         neighbor_procs.push_back(proc);
                 }
             }
@@ -1668,7 +1678,7 @@ RedistributeMPI (std::map<int, Vector<char> >& not_ours,
         std::memcpy((char*) mpi_snd_data[kv.first].data(), kv.second.data(), kv.second.size());
     }
     
-    const int NProcs = ParallelDescriptor::NProcs();
+    const int NProcs = ParallelContext::NProcsSub();
     const int NNeighborProcs = neighbor_procs.size();
     
     // We may now have particles that are rightfully owned by another CPU.
@@ -1719,14 +1729,14 @@ RedistributeMPI (std::map<int, Vector<char> >& not_ours,
             TotRcvInts += nbt;
         }
     }
-    
+
     const int nrcvs = RcvProc.size();
     Vector<MPI_Status>  stats(nrcvs);
     Vector<MPI_Request> rreqs(nrcvs);
-    
+
     // Allocate data for rcvs as one big chunk.
     Vector<unsigned long long> recvdata(TotRcvInts);
-    
+
     // Post receives.
     for (int i = 0; i < nrcvs; ++i) {
         const auto Who    = RcvProc[i];
@@ -1735,29 +1745,31 @@ RedistributeMPI (std::map<int, Vector<char> >& not_ours,
         AMREX_ASSERT(Cnt > 0);
         AMREX_ASSERT(Cnt < size_t(std::numeric_limits<int>::max()));
         AMREX_ASSERT(Who >= 0 && Who < NProcs);
-        
-        rreqs[i] = ParallelDescriptor::Arecv(&recvdata[offset], Cnt, Who, SeqNum).req();
+
+        rreqs[i] = ParallelDescriptor::Arecv(&recvdata[offset], Cnt, Who, SeqNum,
+                                             ParallelContext::CommunicatorSub()).req();
     }
-    
+
     // Send.
     for (const auto& kv : mpi_snd_data) {
         const auto Who = kv.first;
         const auto Cnt = kv.second.size();
-        
+
         AMREX_ASSERT(Cnt > 0);
         AMREX_ASSERT(Who >= 0 && Who < NProcs);
         AMREX_ASSERT(Cnt < std::numeric_limits<int>::max());
-        
-        ParallelDescriptor::Send(kv.second.data(), Cnt, Who, SeqNum);
+
+        ParallelDescriptor::Send(kv.second.data(), Cnt, Who, SeqNum,
+                                 ParallelContext::CommunicatorSub());
     }
-    
+
     if (nrcvs > 0) {
         ParallelDescriptor::Waitall(rreqs, stats);
-     
+
 	BL_PROFILE_VAR_START(blp_locate);
-   
+
         int npart = TotRcvBytes / superparticle_size;
-        
+
         Vector<int> rcv_levs(npart);
         Vector<int> rcv_grid(npart);
         Vector<int> rcv_tile(npart);
@@ -1768,7 +1780,7 @@ RedistributeMPI (std::map<int, Vector<char> >& not_ours,
         {
             const auto offset = rOffset[j];
             const auto Who    = RcvProc[j];
-            const auto Cnt    = Rcvs[Who] / superparticle_size;            
+            const auto Cnt    = Rcvs[Who] / superparticle_size;
             for (int i = 0; i < int(Cnt); ++i)
             {
                 char* pbuf = ((char*) &recvdata[offset]) + i*superparticle_size;
@@ -2069,7 +2081,7 @@ AssignCellDensitySingleLevel (int rho_index,
                     amrex_deposit_particle_dx_cic(pstruct[i], ncomp, rhoarr, plo, dxi, pdxi);
                 });
             }
-                
+
 #ifdef _OPENMP
             if (Gpu::notInLaunchRegion())
             {
@@ -2078,10 +2090,10 @@ AssignCellDensitySingleLevel (int rho_index,
 #endif
         }
     }
-    
+
     mf_pointer->SumBoundary(Geom(lev).periodicity());
-    
-    // If ncomp > 1, first divide the momenta (component n) 
+
+    // If ncomp > 1, first divide the momenta (component n)
     // by the mass (component 0) in order to get velocities.
     // Be careful not to divide by zero.
     for (int n = 1; n < ncomp; n++)
@@ -2091,15 +2103,15 @@ AssignCellDensitySingleLevel (int rho_index,
             (*mf_pointer)[mfi].protected_divide<RunOn::Device>((*mf_pointer)[mfi],0,n,1);
         }
     }
-    
+
     // Only multiply the first component by (1/vol) because this converts mass
     // to density. If there are additional components (like velocity), we don't
     // want to divide those by volume.
     const Real* dx = Geom(lev).CellSize();
     const Real vol = AMREX_D_TERM(dx[0], *dx[1], *dx[2]);
-    
+
     mf_pointer->mult(1.0/vol, 0, 1, mf_pointer->nGrow());
-    
+
     // If mf_to_be_filled is not defined on the particle_box_array, then we need
     // to copy here from mf_pointer into mf_to_be_filled. I believe that we don't
     // need any information in ghost cells so we don't copy those.
@@ -2108,13 +2120,14 @@ AssignCellDensitySingleLevel (int rho_index,
         mf_to_be_filled.copy(*mf_pointer,0,0,ncomp);
         delete mf_pointer;
     }
-    
+
     if (m_verbose > 1)
     {
         Real stoptime = amrex::second() - strttime;
-        
-        ParallelDescriptor::ReduceRealMax(stoptime,ParallelDescriptor::IOProcessorNumber());
-        
+
+        ParallelReduce::Max(stoptime, ParallelContext::IOProcessorNumberSub(),
+                            ParallelContext::CommunicatorSub());
+
         amrex::Print() << "ParticleContainer::AssignCellDensitySingleLevel) time: "
                        << stoptime << '\n';
     }
@@ -2122,12 +2135,12 @@ AssignCellDensitySingleLevel (int rho_index,
 
 template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt>
 void
-ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>::Interpolate (Vector<std::unique_ptr<MultiFab> >& mesh_data, 
+ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>::Interpolate (Vector<std::unique_ptr<MultiFab> >& mesh_data,
                                                                                 int lev_min, int lev_max)
 {
     BL_PROFILE("ParticleContainer::Interpolate()");
     for (int lev = lev_min; lev <= lev_max; ++lev) {
-        InterpolateSingleLevel(*mesh_data[lev], lev); 
+        InterpolateSingleLevel(*mesh_data[lev], lev);
     }
 }
 
@@ -2137,16 +2150,16 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>::
 InterpolateSingleLevel (MultiFab& mesh_data, int lev)
 {
     BL_PROFILE("ParticleContainer::InterpolateSingleLevel()");
-    
+
     if (mesh_data.nGrow() < 1)
         amrex::Error("Must have at least one ghost cell when in InterpolateSingleLevel");
-    
+
     const Geometry& gm = Geom(lev);
     const auto     plo = gm.ProbLoArray();
     const auto     dxi = gm.InvCellSizeArray();
 
     using ParIter = ParIter<NStructReal, NStructInt, NArrayReal, NArrayInt>;
-    
+
 #ifdef _OPENMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
@@ -2157,7 +2170,7 @@ InterpolateSingleLevel (MultiFab& mesh_data, int lev)
         FArrayBox& fab = mesh_data[pti];
         const auto fabarr = fab.array();
         const Long np = particles.numParticles();
-        
+
         int nComp = fab.nComp();
         AMREX_FOR_1D( np, i,
         {

--- a/Src/Particle/AMReX_ParticleContainerI.H
+++ b/Src/Particle/AMReX_ParticleContainerI.H
@@ -376,7 +376,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>::TotalNumberOf
         nparticles += NumberOfParticlesAtLevel(lev,only_valid,true);
     }
     if (!only_local) {
-        ParallelAllReduce::Max(nparticles, ParallelContext::CommunicatorSub());
+        ParallelAllReduce::Sum(nparticles, ParallelContext::CommunicatorSub());
     }
     return nparticles;
 }

--- a/Src/Particle/AMReX_ParticleUtil.H
+++ b/Src/Particle/AMReX_ParticleUtil.H
@@ -43,10 +43,10 @@ numParticlesOutOfRange (Iterator const& pti, int nGrow)
     const auto domain = geom.Domain();
     const auto plo = geom.ProbLoArray();
     const auto dxi = geom.InvCellSizeArray();
-    
+
     Box box = pti.tilebox();
     box.grow(nGrow);
-        
+
     ReduceOps<ReduceOpSum> reduce_op;
     ReduceData<int> reduce_data(reduce_op);
     using ReduceTuple = typename decltype(reduce_data)::Type;
@@ -66,7 +66,7 @@ numParticlesOutOfRange (Iterator const& pti, int nGrow)
     int hv = amrex::get<0>(reduce_data.value());
     return hv;
 }
-    
+
 /**
  * \brief Returns the number of particles that are more than nGrow cells
  * from their assigned box.
@@ -78,7 +78,7 @@ numParticlesOutOfRange (Iterator const& pti, int nGrow)
  * \param pc the particle container to test
  * \param nGrow the number of grow cells allowed.
  *
- */    
+ */
 template <class PC, EnableIf_t<IsParticleContainer<PC>::value, int> foo = 0>
 int
 numParticlesOutOfRange (PC const& pc, int nGrow)
@@ -99,7 +99,7 @@ numParticlesOutOfRange (PC const& pc, int nGrow)
  * \param lev_max the maximum level to test
  * \param nGrow the number of grow cells allowed.
  *
- */        
+ */
 template <class PC, EnableIf_t<IsParticleContainer<PC>::value, int> foo = 0>
 int
 numParticlesOutOfRange (PC const& pc, int lev_min, int lev_max, int nGrow)
@@ -118,13 +118,13 @@ numParticlesOutOfRange (PC const& pc, int lev_min, int lev_max, int nGrow)
             num_wrong += numParticlesOutOfRange(pti, nGrow);
         }
     }
-    ParallelDescriptor::ReduceIntSum(num_wrong);
+    ParallelAllReduce::Sum(num_wrong, ParallelContext::CommunicatorSub());
 
     return num_wrong;
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-int getTileIndex (const IntVect& iv, const Box& box, const bool a_do_tiling, 
+int getTileIndex (const IntVect& iv, const Box& box, const bool a_do_tiling,
 		  const IntVect& a_tile_size, Box& tbx)
 {
     if (a_do_tiling == false) {
@@ -193,7 +193,7 @@ int getParticleGrid (P const& p, amrex::Array4<int> const& mask,
                      amrex::GpuArray<amrex::Real,AMREX_SPACEDIM> const& dxi,
                      const Box& domain) noexcept
 {
-    if (p.id() < 0) return -1;    
+    if (p.id() < 0) return -1;
     IntVect iv = getParticleCell(p, plo, dxi, domain);
     return mask(iv);
 }
@@ -215,15 +215,15 @@ void enforcePeriodic (P& p,
     for (int idim = 0; idim < AMREX_SPACEDIM; ++idim)
     {
         if (not is_per[idim]) continue;
-        if (p.pos(idim) >= phi[idim]) { 
-            while (p.pos(idim) >= phi[idim]) { 
+        if (p.pos(idim) >= phi[idim]) {
+            while (p.pos(idim) >= phi[idim]) {
                 p.pos(idim) -= (phi[idim] - plo[idim]);
             }
             if (p.pos(idim) < plo[idim]) p.pos(idim) = plo[idim]; // clamp to avoid precision issues;
-        } 
+        }
         else if (p.pos(idim) < plo[idim]) {
             while (p.pos(idim) < plo[idim]) {
-                p.pos(idim) += (phi[idim] - plo[idim]); 
+                p.pos(idim) += (phi[idim] - plo[idim]);
             }
             if (p.pos(idim) == phi[idim]) p.pos(idim) = plo[idim]; // clamp to avoid precision issues;
             if (p.pos(idim) > phi[idim]) p.pos(idim) = phi[idim]-eps; // clamp to avoid precision issues;
@@ -247,16 +247,16 @@ partitionParticlesByDest (PTile& ptile, const PLocator& ploc, const ParticleBuff
     const int np = aos.numParticles();
 
     if (np == 0) return 0;
-    
+
     auto p_lev_offsets = pmap.levelOffsetsPtr();
     auto p_box_perm = pmap.levGridToBucketPtr();
     auto p_pids = pmap.bucketToPIDPtr();
     auto p_ptr = &(aos[0]);
-    
-    int pid = ParallelDescriptor::MyProc();
+
+    int pid = ParallelContext::MyProcSub();
     int chunk_size = 256*256*256;
     int num_chunks = std::max(1, (np + (chunk_size - 1)) / chunk_size);
-    
+
     PTile ptile_tmp;
     ptile_tmp.define(ptile.NumRuntimeRealComps(), ptile.NumRuntimeIntComps());
     ptile_tmp.resize(std::min(np, chunk_size));
@@ -269,16 +269,16 @@ partitionParticlesByDest (PTile& ptile, const PLocator& ploc, const ParticleBuff
     {
         int this_offset = ichunk*chunk_size;
         int this_chunk_size = std::min(chunk_size, np - this_offset);
-        
+
         int num_stay;
         {
             auto particle_stays = [=] AMREX_GPU_DEVICE (int i) -> int
             {
                 int assigned_grid;
                 int assigned_lev;
-        
+
                 auto& p = p_ptr[i+this_offset];
-                
+
                 if (p.id() < 0 )
                 {
                     assigned_grid = -1;
@@ -291,13 +291,13 @@ partitionParticlesByDest (PTile& ptile, const PLocator& ploc, const ParticleBuff
                     assigned_grid = amrex::get<0>(tup);
                     assigned_lev  = amrex::get<1>(tup);
                 }
-        
+
                 return ((assigned_grid == gid) && (assigned_lev == lev)
                         && (p_pids[p_box_perm[p_lev_offsets[lev]+gid]] == pid));
             };
-        
-            num_stay = Scan::PrefixSum<int> (this_chunk_size, 
-                          [=] AMREX_GPU_DEVICE (int i) -> int 
+
+            num_stay = Scan::PrefixSum<int> (this_chunk_size,
+                          [=] AMREX_GPU_DEVICE (int i) -> int
                           {
                               return particle_stays(i);
                           },
@@ -311,7 +311,7 @@ partitionParticlesByDest (PTile& ptile, const PLocator& ploc, const ParticleBuff
                               {
                                   copyParticle(dst_data, src_data, i + this_offset, this_chunk_size-1-(i-s));
                               }
-                          }, 
+                          },
                           Scan::Type::exclusive);
         }
 
@@ -326,7 +326,7 @@ partitionParticlesByDest (PTile& ptile, const PLocator& ploc, const ParticleBuff
                              copyParticle(src_data, dst_data, i, i + this_offset);
                          });
         }
-        
+
         if ( ichunk > 0 )
         {
             int num_swap = std::min(this_offset - last_offset, num_stay);

--- a/Src/Particle/AMReX_ParticleUtil.cpp
+++ b/Src/Particle/AMReX_ParticleUtil.cpp
@@ -22,7 +22,7 @@ IntVect computeRefFac (const ParGDBBase* a_gdb, int src_lev, int lev)
 Vector<int> computeNeighborProcs (const ParGDBBase* a_gdb, int ngrow)
 {
     BL_PROFILE("amrex::computeNeighborProcs");
-    
+
     Vector<int> neighbor_procs;
     for (int src_lev = 0; src_lev < a_gdb->finestLevel()+1; ++src_lev)
     {
@@ -39,11 +39,11 @@ Vector<int> computeNeighborProcs (const ParGDBBase* a_gdb, int ngrow)
                 if (ref_fac < IntVect::TheZeroVector()) box.coarsen(-1*ref_fac);
                 else if (ref_fac > IntVect::TheZeroVector()) box.refine(ref_fac);
                 box.grow(computeRefFac(a_gdb, 0, src_lev)*ngrow);
-                
+
                 const Periodicity& periodicity = a_gdb->Geom(lev).periodicity();
                 const std::vector<IntVect>& pshifts = periodicity.shiftIntVect();
                 const BoxArray& ba = a_gdb->ParticleBoxArray(lev);
-                
+
                 for (auto pit=pshifts.cbegin(); pit!=pshifts.cend(); ++pit)
                 {
                     const Box& pbox = box + (*pit);
@@ -52,7 +52,8 @@ Vector<int> computeNeighborProcs (const ParGDBBase* a_gdb, int ngrow)
                     for (const auto& isec : isects)
                     {
                         const int grid = isec.first;
-                        const int proc = a_gdb->ParticleDistributionMap(lev)[grid];
+                        const int global_proc = a_gdb->ParticleDistributionMap(lev)[grid];
+                        const int proc = ParallelContext::global_to_local_rank(global_proc);
                         neighbor_procs.push_back(proc);
                     }
                 }

--- a/Src/Particle/AMReX_TracerParticles.cpp
+++ b/Src/Particle/AMReX_TracerParticles.cpp
@@ -109,15 +109,16 @@ TracerParticleContainer::AdvectWithUmac (MultiFab* umac, int lev, Real dt)
 #ifdef AMREX_LAZY
 	Lazy::QueueReduction( [=] () mutable {
 #endif
-        ParallelDescriptor::ReduceRealMax(stoptime,ParallelDescriptor::IOProcessorNumber());
+                ParallelReduce::Max(stoptime, ParallelContext::IOProcessorNumberSub(),
+                                    ParallelContext::CommunicatorSub());
 
-        amrex::Print() << "TracerParticleContainer::AdvectWithUmac() time: " << stoptime << '\n';
+                amrex::Print() << "TracerParticleContainer::AdvectWithUmac() time: " << stoptime << '\n';
 #ifdef AMREX_LAZY
 	});
 #endif
     }
 }
-	
+
 //
 // Uses midpoint method to advance particles using cell-centered velocity
 //
@@ -188,11 +189,12 @@ TracerParticleContainer::AdvectWithUcc (const MultiFab& Ucc, int lev, Real dt)
 #ifdef AMREX_LAZY
 	Lazy::QueueReduction( [=] () mutable {
 #endif
-        ParallelDescriptor::ReduceRealMax(stoptime,ParallelDescriptor::IOProcessorNumber());
+                ParallelReduce::Max(stoptime, ParallelContext::IOProcessorNumberSub(),
+                                    ParallelContext::CommunicatorSub());
 
-        amrex::Print() << "TracerParticleContainer::AdvectWithUcc() time: " << stoptime << '\n';
+                amrex::Print() << "TracerParticleContainer::AdvectWithUcc() time: " << stoptime << '\n';
 #ifdef AMREX_LAZY
-	});
+            });
 #endif
     }
 }
@@ -220,7 +222,7 @@ TracerParticleContainer::Timestamp (const std::string&      basename,
     const Real strttime = amrex::second();
 
     const int   MyProc    = ParallelDescriptor::MyProc();
-    const int   NProcs    = ParallelDescriptor::NProcs();
+    const int   NProcs    = ParallelContext::NProcsSub();
     // We'll spread the output over this many files.
     int nOutFiles(64);
     ParmParse pp("particles");

--- a/Tests/Particles/ParallelContext/GNUmakefile
+++ b/Tests/Particles/ParallelContext/GNUmakefile
@@ -1,0 +1,21 @@
+AMREX_HOME ?= ../../../
+
+DEBUG	= FALSE
+
+DIM	= 3
+
+COMP    = gcc
+
+USE_MPI   = TRUE
+USE_OMP   = FALSE
+USE_CUDA  = FALSE
+
+TINY_PROFILE = TRUE
+
+include $(AMREX_HOME)/Tools/GNUMake/Make.defs
+
+include ./Make.package
+include $(AMREX_HOME)/Src/Base/Make.package
+include $(AMREX_HOME)/Src/Particle/Make.package
+
+include $(AMREX_HOME)/Tools/GNUMake/Make.rules

--- a/Tests/Particles/ParallelContext/Make.package
+++ b/Tests/Particles/ParallelContext/Make.package
@@ -1,0 +1,4 @@
+CEXE_sources += main.cpp
+
+
+

--- a/Tests/Particles/ParallelContext/inputs.rt
+++ b/Tests/Particles/ParallelContext/inputs.rt
@@ -1,0 +1,14 @@
+redistribute.size = (64, 64, 64)
+redistribute.max_grid_size = 32
+redistribute.is_periodic = 1
+redistribute.num_ppc = 1
+redistribute.move_dir = (1, 1, 1)
+redistribute.do_random = 1
+redistribute.nsteps = 100
+redistribute.nlevs = 1
+redistribute.do_regrid = 1
+
+redistribute.num_runtime_real = 0
+redistribute.num_runtime_int = 0
+
+particles.do_tiling=1

--- a/Tests/Particles/ParallelContext/inputs.rt
+++ b/Tests/Particles/ParallelContext/inputs.rt
@@ -1,12 +1,11 @@
-redistribute.size = (64, 64, 64)
+redistribute.size = (64, 64, 128)
 redistribute.max_grid_size = 32
 redistribute.is_periodic = 1
 redistribute.num_ppc = 1
-redistribute.move_dir = (1, 1, 1)
-redistribute.do_random = 1
+redistribute.move_dir = (1, 0, 0)
+redistribute.do_random = 0
 redistribute.nsteps = 100
-redistribute.nlevs = 1
-redistribute.do_regrid = 1
+redistribute.do_regrid = 0
 
 redistribute.num_runtime_real = 0
 redistribute.num_runtime_int = 0

--- a/Tests/Particles/ParallelContext/main.cpp
+++ b/Tests/Particles/ParallelContext/main.cpp
@@ -375,7 +375,7 @@ void testRedistribute ()
             geom[lev].define(amrex::refine(geom[lev-1].Domain(), rr[lev-1]),
                              &real_box, CoordSys::cartesian, is_per);
         }
-    
+
         Vector<BoxArray> ba(params.nlevs);
         Vector<DistributionMapping> dm(params.nlevs);
         IntVect lo = IntVect(D_DECL(0, 0, 0));
@@ -407,7 +407,9 @@ void testRedistribute ()
             if (params.sort) pc.SortParticlesByCell();
             pc.checkAnswer();
         }
-        
+
+        amrex::Print() << np_old << " " << pc.TotalNumberOfParticles() << "\n";
+
         if (geom[0].isAllPeriodic()) AMREX_ALWAYS_ASSERT(np_old == pc.TotalNumberOfParticles());
 
     }

--- a/Tests/Particles/ParallelContext/main.cpp
+++ b/Tests/Particles/ParallelContext/main.cpp
@@ -1,0 +1,416 @@
+#include <AMReX.H>
+#include <AMReX_ParmParse.H>
+#include <AMReX_MultiFab.H>
+#include <AMReX_Particles.H>
+
+using namespace amrex;
+
+static constexpr int NSR = 4;
+static constexpr int NSI = 3;
+static constexpr int NAR = 2;
+static constexpr int NAI = 1;
+
+int num_runtime_real = 0;
+int num_runtime_int = 0;
+
+void get_position_unit_cell(Real* r, const IntVect& nppc, int i_part)
+{
+    int nx = nppc[0];
+#if AMREX_SPACEDIM > 1
+    int ny = nppc[1];
+#else
+    int ny = 1;
+#endif
+#if AMREX_SPACEDIM > 2
+    int nz = nppc[2];
+#else
+    int nz = 1;
+#endif
+    
+    int ix_part = i_part/(ny * nz);
+    int iy_part = (i_part % (ny * nz)) % ny;
+    int iz_part = (i_part % (ny * nz)) / ny;
+    
+    r[0] = (0.5+ix_part)/nx;
+    r[1] = (0.5+iy_part)/ny;
+    r[2] = (0.5+iz_part)/nz;
+}
+
+class TestParticleContainer
+    : public amrex::ParticleContainer<NSR, NSI, NAR, NAI>
+{
+
+public:
+
+    TestParticleContainer (const Vector<amrex::Geometry>            & a_geom,
+                           const Vector<amrex::DistributionMapping> & a_dmap,
+                           const Vector<amrex::BoxArray>            & a_ba,
+                           const Vector<amrex::IntVect>             & a_rr)
+        : amrex::ParticleContainer<NSR, NSI, NAR, NAI>(a_geom, a_dmap, a_ba, a_rr)
+    {
+        for (int i = 0; i < num_runtime_real; ++i)
+        {
+            AddRealComp(true);
+        }
+        for (int i = 0; i < num_runtime_int; ++i)
+        {
+            AddIntComp(true);
+        }
+    }
+
+    void RedistributeLocal ()
+    {
+        const int lev_min = 0;
+        const int lev_max = finestLevel();
+        const int nGrow = 0;
+        const int local = 1;
+        Redistribute(lev_min, lev_max, nGrow, local);
+    }
+
+    void RedistributeGlobal ()
+    {
+        const int lev_min = 0;
+        const int lev_max = finestLevel();
+        const int nGrow = 0;
+        const int local = 0;
+        Redistribute(lev_min, lev_max, nGrow, local);
+    }
+    
+    void InitParticles (const amrex::IntVect& a_num_particles_per_cell)
+    {
+        BL_PROFILE("InitParticles");
+        
+        const int lev = 0;  // only add particles on level 0
+        const Real* dx = Geom(lev).CellSize();
+        const Real* plo = Geom(lev).ProbLo();
+    
+        const int num_ppc = AMREX_D_TERM( a_num_particles_per_cell[0],
+                                         *a_num_particles_per_cell[1],
+                                         *a_num_particles_per_cell[2]);
+
+        for(MFIter mfi = MakeMFIter(lev); mfi.isValid(); ++mfi)
+        {
+            const Box& tile_box  = mfi.tilebox();
+
+            Gpu::HostVector<ParticleType> host_particles;
+            std::array<Gpu::HostVector<Real>, NAR> host_real;
+            std::array<Gpu::HostVector<int>, NAI> host_int;
+
+            std::vector<Gpu::HostVector<Real> > host_runtime_real(NumRuntimeRealComps());
+            std::vector<Gpu::HostVector<int> > host_runtime_int(NumRuntimeIntComps());
+
+            for (IntVect iv = tile_box.smallEnd(); iv <= tile_box.bigEnd(); tile_box.next(iv))
+            {
+                for (int i_part=0; i_part<num_ppc;i_part++) {
+                    Real r[3];
+                    get_position_unit_cell(r, a_num_particles_per_cell, i_part);
+                
+                    ParticleType p;
+                    p.id()  = ParticleType::NextID();
+                    p.cpu() = ParallelDescriptor::MyProc();                
+                    p.pos(0) = plo[0] + (iv[0] + r[0])*dx[0];
+#if AMREX_SPACEDIM > 1
+                    p.pos(1) = plo[1] + (iv[1] + r[1])*dx[1];
+#endif
+#if AMREX_SPACEDIM > 2
+                    p.pos(2) = plo[2] + (iv[2] + r[2])*dx[2];
+#endif
+                    
+                    for (int i = 0; i < NSR; ++i) p.rdata(i) = p.id();
+                    for (int i = 0; i < NSI; ++i) p.idata(i) = p.id();
+                    
+                    host_particles.push_back(p);
+                    for (int i = 0; i < NAR; ++i)
+                        host_real[i].push_back(p.id());
+                    for (int i = 0; i < NAI; ++i)
+                        host_int[i].push_back(p.id());
+                    for (int i = 0; i < NumRuntimeRealComps(); ++i)
+                        host_runtime_real[i].push_back(p.id());
+                    for (int i = 0; i < NumRuntimeIntComps(); ++i)
+                        host_runtime_int[i].push_back(p.id());
+                }
+            }
+        
+            auto& particle_tile = DefineAndReturnParticleTile(lev, mfi.index(), mfi.LocalTileIndex());
+            auto old_size = particle_tile.GetArrayOfStructs().size();
+            auto new_size = old_size + host_particles.size();
+            particle_tile.resize(new_size);
+            
+            Gpu::copy(Gpu::hostToDevice,
+                      host_particles.begin(),
+                      host_particles.end(),
+                      particle_tile.GetArrayOfStructs().begin() + old_size);        
+
+            auto& soa = particle_tile.GetStructOfArrays();
+            for (int i = 0; i < NAR; ++i)
+            {
+                Gpu::copy(Gpu::hostToDevice,
+                          host_real[i].begin(),
+                          host_real[i].end(),
+                          soa.GetRealData(i).begin() + old_size);
+            }
+
+            for (int i = 0; i < NAI; ++i)
+            {
+                Gpu::copy(Gpu::hostToDevice,
+                          host_int[i].begin(),
+                          host_int[i].end(),
+                          soa.GetIntData(i).begin() + old_size);
+            }
+            for (int i = 0; i < NumRuntimeRealComps(); ++i)
+            {
+                Gpu::copy(Gpu::hostToDevice,
+                          host_runtime_real[i].begin(),
+                          host_runtime_real[i].end(),
+                          soa.GetRealData(NAR+i).begin() + old_size);
+            }
+
+            for (int i = 0; i < NumRuntimeIntComps(); ++i)
+            {
+                Gpu::copy(Gpu::hostToDevice,
+                          host_runtime_int[i].begin(),
+                          host_runtime_int[i].end(),
+                          soa.GetIntData(NAI+i).begin() + old_size);
+            }
+        }
+
+        RedistributeLocal();
+    }
+
+    void moveParticles (const IntVect& move_dir, int do_random)
+    {
+        BL_PROFILE("TestParticleContainer::moveParticles");
+
+        for (int lev = 0; lev <= finestLevel(); ++lev)
+        {
+            const Geometry& geom = Geom(lev);
+            const auto dx = Geom(lev).CellSizeArray();
+            auto& plev  = GetParticles(lev);
+        
+            for(MFIter mfi = MakeMFIter(lev); mfi.isValid(); ++mfi)
+            {
+                int gid = mfi.index();
+                int tid = mfi.LocalTileIndex();            
+                auto& ptile = plev[std::make_pair(gid, tid)];
+                auto& aos   = ptile.GetArrayOfStructs();
+                ParticleType* pstruct = &(aos[0]);            
+                const size_t np = aos.numParticles();
+
+                if (do_random == 0)
+                {
+                    AMREX_FOR_1D ( np, i,
+                    {
+                        ParticleType& p = pstruct[i];
+                        p.pos(0) += move_dir[0]*dx[0];
+#if AMREX_SPACEDIM > 1
+                        p.pos(1) += move_dir[1]*dx[1];
+#endif
+#if AMREX_SPACEDIM > 2
+                        p.pos(2) += move_dir[2]*dx[2];
+#endif
+                    });
+                }            
+                else
+                {
+                    AMREX_FOR_1D ( np, i,
+                    {
+                        ParticleType& p = pstruct[i];
+
+                        p.pos(0) += (2*amrex::Random()-1)*move_dir[0]*dx[0];
+#if AMREX_SPACEDIM > 1
+                        p.pos(1) += (2*amrex::Random()-1)*move_dir[1]*dx[1];
+#endif
+#if AMREX_SPACEDIM > 2
+                        p.pos(2) += (2*amrex::Random()-1)*move_dir[2]*dx[2];
+#endif
+                    });
+                }
+            }
+        }
+    }
+
+    void checkAnswer () const
+    {
+        BL_PROFILE("TestParticleContainer::checkAnswer");
+        
+        AMREX_ALWAYS_ASSERT(OK());
+        
+        int num_rr = NumRuntimeRealComps();
+        int num_ii = NumRuntimeIntComps();
+
+        for (int lev = 0; lev <= finestLevel(); ++lev)
+        {
+            const Geometry& geom = Geom(lev);
+            const auto dx = Geom(lev).CellSizeArray();
+            auto& plev  = GetParticles(lev);
+            
+            for(MFIter mfi = MakeMFIter(lev); mfi.isValid(); ++mfi)
+            {
+                int gid = mfi.index();
+                int tid = mfi.LocalTileIndex();            
+                auto& ptile = plev.at(std::make_pair(gid, tid));
+                const auto ptd = ptile.getConstParticleTileData();
+                const size_t np = ptile.numParticles();
+                
+                AMREX_FOR_1D ( np, i,
+                {
+                    for (int j = 0; j < NSR; ++j)
+                    {
+                        AMREX_ALWAYS_ASSERT(ptd.m_aos[i].rdata(j) == ptd.m_aos[i].id());
+                    }
+                    for (int j = 0; j < NSI; ++j)
+                    {
+                        AMREX_ALWAYS_ASSERT(ptd.m_aos[i].idata(j) == ptd.m_aos[i].id());
+                    }
+                    for (int j = 0; j < NAR; ++j)
+                    {
+                        AMREX_ALWAYS_ASSERT(ptd.m_rdata[j][i] == ptd.m_aos[i].id());
+                    }
+                    for (int j = 0; j < NAI; ++j)
+                    {
+                        AMREX_ALWAYS_ASSERT(ptd.m_idata[j][i] == ptd.m_aos[i].id());
+                    }
+                    for (int j = 0; j < num_rr; ++j)
+                    {
+                        AMREX_ALWAYS_ASSERT(ptd.m_runtime_rdata[j][i] == ptd.m_aos[i].id());
+                    }
+                    for (int j = 0; j < num_ii; ++j)
+                    {
+                        AMREX_ALWAYS_ASSERT(ptd.m_runtime_idata[j][i] == ptd.m_aos[i].id());
+                    }
+                });
+            }
+        }
+    }
+};
+
+struct TestParams
+{
+    IntVect size;
+    int max_grid_size;
+    int num_ppc;
+    int is_periodic;
+    IntVect move_dir;
+    int do_random;
+    int nsteps;
+    int nlevs;
+    int do_regrid;
+    int sort;
+};
+
+void testRedistribute();
+
+int main (int argc, char* argv[])
+{
+    amrex::Initialize(argc,argv);
+
+    amrex::Print() << "Running redistribute test \n";
+    testRedistribute();
+
+    amrex::Finalize();
+}
+
+void get_test_params(TestParams& params, const std::string& prefix)
+{
+    ParmParse pp(prefix);
+    pp.get("size", params.size);
+    pp.get("max_grid_size", params.max_grid_size);
+    pp.get("num_ppc", params.num_ppc);
+    pp.get("is_periodic", params.is_periodic);
+    pp.get("move_dir", params.move_dir);
+    pp.get("do_random", params.do_random);    
+    pp.get("nsteps", params.nsteps);
+    pp.get("nlevs", params.nlevs);
+    pp.get("do_regrid", params.do_regrid);
+    pp.query("num_runtime_real", num_runtime_real);
+    pp.query("num_runtime_int", num_runtime_int);
+
+    params.sort = 0;
+    pp.query("sort", params.sort);
+}
+
+void testRedistribute ()
+{
+    BL_PROFILE("testRedistribute");
+
+    int rank_n = ParallelContext::NProcsSub();
+    int myproc = ParallelContext::MyProcSub();
+    int task_me = myproc / 2;
+
+    MPI_Comm new_comm;
+    MPI_Comm_split(ParallelContext::CommunicatorSub(), task_me, myproc, &new_comm);
+    
+    const int io_rank = 0;
+    ParallelContext::push(new_comm, task_me, io_rank);
+    
+    {
+
+        amrex::Print() << ParallelContext::NProcsSub() << "\n";
+
+        TestParams params;
+        get_test_params(params, "redistribute");
+
+        int is_per[BL_SPACEDIM];
+        for (int i = 0; i < BL_SPACEDIM; i++)
+            is_per[i] = params.is_periodic;
+
+        Vector<IntVect> rr(params.nlevs-1);
+        for (int lev = 1; lev < params.nlevs; lev++)
+            rr[lev-1] = IntVect(D_DECL(2,2,2));
+
+        RealBox real_box;
+        for (int n = 0; n < BL_SPACEDIM; n++)
+        {
+            real_box.setLo(n, 0.0);
+            real_box.setHi(n, params.size[n]);
+        }
+
+        IntVect domain_lo(AMREX_D_DECL(0, 0, 0));
+        IntVect domain_hi(AMREX_D_DECL(params.size[0]-1,params.size[1]-1,params.size[2]-1));
+        const Box base_domain(domain_lo, domain_hi);
+
+        Vector<Geometry> geom(params.nlevs);
+        geom[0].define(base_domain, &real_box, CoordSys::cartesian, is_per);
+        for (int lev = 1; lev < params.nlevs; lev++) {
+            geom[lev].define(amrex::refine(geom[lev-1].Domain(), rr[lev-1]),
+                             &real_box, CoordSys::cartesian, is_per);
+        }
+    
+        Vector<BoxArray> ba(params.nlevs);
+        Vector<DistributionMapping> dm(params.nlevs);
+        IntVect lo = IntVect(D_DECL(0, 0, 0));
+        IntVect size = params.size;
+        for (int lev = 0; lev < params.nlevs; ++lev)
+        {
+            ba[lev].define(Box(lo, lo+params.size-1));
+            ba[lev].maxSize(params.max_grid_size);
+            dm[lev].define(ba[lev], ParallelContext::NProcsSub());
+            lo += size/2;
+            size *= 2;
+        }
+
+        TestParticleContainer pc(geom, dm, ba, rr);
+
+        int npc = params.num_ppc;
+        IntVect nppc = IntVect(AMREX_D_DECL(npc, npc, npc));
+
+        pc.InitParticles(nppc);
+
+        pc.checkAnswer();
+
+        auto np_old = pc.TotalNumberOfParticles();
+
+        for (int i = 0; i < params.nsteps; ++i)
+        {
+            pc.moveParticles(params.move_dir, params.do_random);
+            pc.RedistributeLocal();
+            if (params.sort) pc.SortParticlesByCell();
+            pc.checkAnswer();
+        }
+        
+        if (geom[0].isAllPeriodic()) AMREX_ALWAYS_ASSERT(np_old == pc.TotalNumberOfParticles());
+
+    }
+
+    ParallelContext::pop();
+}

--- a/Tests/Particles/ParallelContext/main.cpp
+++ b/Tests/Particles/ParallelContext/main.cpp
@@ -329,6 +329,8 @@ void testRedistribute ()
     int myproc = ParallelContext::MyProcSub();
     int task_me = myproc / (amrex::max(rank_n, 2) / 2);
 
+    if (task_me > 1) task_me = 1;
+
     MPI_Comm new_comm;
     MPI_Comm_split(ParallelContext::CommunicatorSub(), task_me, myproc, &new_comm);
 

--- a/Tests/Particles/ParallelContext/main.cpp
+++ b/Tests/Particles/ParallelContext/main.cpp
@@ -26,11 +26,11 @@ void get_position_unit_cell(Real* r, const IntVect& nppc, int i_part)
 #else
     int nz = 1;
 #endif
-    
+
     int ix_part = i_part/(ny * nz);
     int iy_part = (i_part % (ny * nz)) % ny;
     int iz_part = (i_part % (ny * nz)) / ny;
-    
+
     r[0] = (0.5+ix_part)/nx;
     r[1] = (0.5+iy_part)/ny;
     r[2] = (0.5+iz_part)/nz;
@@ -42,11 +42,10 @@ class TestParticleContainer
 
 public:
 
-    TestParticleContainer (const Vector<amrex::Geometry>            & a_geom,
-                           const Vector<amrex::DistributionMapping> & a_dmap,
-                           const Vector<amrex::BoxArray>            & a_ba,
-                           const Vector<amrex::IntVect>             & a_rr)
-        : amrex::ParticleContainer<NSR, NSI, NAR, NAI>(a_geom, a_dmap, a_ba, a_rr)
+    TestParticleContainer (const amrex::Geometry& a_geom,
+                           const amrex::DistributionMapping& a_dmap,
+                           const amrex::BoxArray& a_ba)
+        : amrex::ParticleContainer<NSR, NSI, NAR, NAI>(a_geom, a_dmap, a_ba)
     {
         for (int i = 0; i < num_runtime_real; ++i)
         {
@@ -61,29 +60,20 @@ public:
     void RedistributeLocal ()
     {
         const int lev_min = 0;
-        const int lev_max = finestLevel();
+        const int lev_max = 0;
         const int nGrow = 0;
         const int local = 1;
         Redistribute(lev_min, lev_max, nGrow, local);
     }
 
-    void RedistributeGlobal ()
-    {
-        const int lev_min = 0;
-        const int lev_max = finestLevel();
-        const int nGrow = 0;
-        const int local = 0;
-        Redistribute(lev_min, lev_max, nGrow, local);
-    }
-    
     void InitParticles (const amrex::IntVect& a_num_particles_per_cell)
     {
         BL_PROFILE("InitParticles");
-        
+
         const int lev = 0;  // only add particles on level 0
         const Real* dx = Geom(lev).CellSize();
         const Real* plo = Geom(lev).ProbLo();
-    
+
         const int num_ppc = AMREX_D_TERM( a_num_particles_per_cell[0],
                                          *a_num_particles_per_cell[1],
                                          *a_num_particles_per_cell[2]);
@@ -104,10 +94,10 @@ public:
                 for (int i_part=0; i_part<num_ppc;i_part++) {
                     Real r[3];
                     get_position_unit_cell(r, a_num_particles_per_cell, i_part);
-                
+
                     ParticleType p;
                     p.id()  = ParticleType::NextID();
-                    p.cpu() = ParallelDescriptor::MyProc();                
+                    p.cpu() = ParallelDescriptor::MyProc();
                     p.pos(0) = plo[0] + (iv[0] + r[0])*dx[0];
 #if AMREX_SPACEDIM > 1
                     p.pos(1) = plo[1] + (iv[1] + r[1])*dx[1];
@@ -115,10 +105,10 @@ public:
 #if AMREX_SPACEDIM > 2
                     p.pos(2) = plo[2] + (iv[2] + r[2])*dx[2];
 #endif
-                    
+
                     for (int i = 0; i < NSR; ++i) p.rdata(i) = p.id();
                     for (int i = 0; i < NSI; ++i) p.idata(i) = p.id();
-                    
+
                     host_particles.push_back(p);
                     for (int i = 0; i < NAR; ++i)
                         host_real[i].push_back(p.id());
@@ -130,16 +120,16 @@ public:
                         host_runtime_int[i].push_back(p.id());
                 }
             }
-        
+
             auto& particle_tile = DefineAndReturnParticleTile(lev, mfi.index(), mfi.LocalTileIndex());
             auto old_size = particle_tile.GetArrayOfStructs().size();
             auto new_size = old_size + host_particles.size();
             particle_tile.resize(new_size);
-            
+
             Gpu::copy(Gpu::hostToDevice,
                       host_particles.begin(),
                       host_particles.end(),
-                      particle_tile.GetArrayOfStructs().begin() + old_size);        
+                      particle_tile.GetArrayOfStructs().begin() + old_size);
 
             auto& soa = particle_tile.GetStructOfArrays();
             for (int i = 0; i < NAR; ++i)
@@ -186,14 +176,14 @@ public:
             const Geometry& geom = Geom(lev);
             const auto dx = Geom(lev).CellSizeArray();
             auto& plev  = GetParticles(lev);
-        
+
             for(MFIter mfi = MakeMFIter(lev); mfi.isValid(); ++mfi)
             {
                 int gid = mfi.index();
-                int tid = mfi.LocalTileIndex();            
+                int tid = mfi.LocalTileIndex();
                 auto& ptile = plev[std::make_pair(gid, tid)];
                 auto& aos   = ptile.GetArrayOfStructs();
-                ParticleType* pstruct = &(aos[0]);            
+                ParticleType* pstruct = &(aos[0]);
                 const size_t np = aos.numParticles();
 
                 if (do_random == 0)
@@ -209,7 +199,7 @@ public:
                         p.pos(2) += move_dir[2]*dx[2];
 #endif
                     });
-                }            
+                }
                 else
                 {
                     AMREX_FOR_1D ( np, i,
@@ -232,9 +222,9 @@ public:
     void checkAnswer () const
     {
         BL_PROFILE("TestParticleContainer::checkAnswer");
-        
+
         AMREX_ALWAYS_ASSERT(OK());
-        
+
         int num_rr = NumRuntimeRealComps();
         int num_ii = NumRuntimeIntComps();
 
@@ -243,15 +233,15 @@ public:
             const Geometry& geom = Geom(lev);
             const auto dx = Geom(lev).CellSizeArray();
             auto& plev  = GetParticles(lev);
-            
+
             for(MFIter mfi = MakeMFIter(lev); mfi.isValid(); ++mfi)
             {
                 int gid = mfi.index();
-                int tid = mfi.LocalTileIndex();            
+                int tid = mfi.LocalTileIndex();
                 auto& ptile = plev.at(std::make_pair(gid, tid));
                 const auto ptd = ptile.getConstParticleTileData();
                 const size_t np = ptile.numParticles();
-                
+
                 AMREX_FOR_1D ( np, i,
                 {
                     for (int j = 0; j < NSR; ++j)
@@ -293,7 +283,6 @@ struct TestParams
     IntVect move_dir;
     int do_random;
     int nsteps;
-    int nlevs;
     int do_regrid;
     int sort;
 };
@@ -318,9 +307,8 @@ void get_test_params(TestParams& params, const std::string& prefix)
     pp.get("num_ppc", params.num_ppc);
     pp.get("is_periodic", params.is_periodic);
     pp.get("move_dir", params.move_dir);
-    pp.get("do_random", params.do_random);    
+    pp.get("do_random", params.do_random);
     pp.get("nsteps", params.nsteps);
-    pp.get("nlevs", params.nlevs);
     pp.get("do_regrid", params.do_regrid);
     pp.query("num_runtime_real", num_runtime_real);
     pp.query("num_runtime_int", num_runtime_int);
@@ -333,20 +321,21 @@ void testRedistribute ()
 {
     BL_PROFILE("testRedistribute");
 
+    AMREX_ALWAYS_ASSERT(AMREX_SPACEDIM == 3);
+
+    // we always make two subcommunicators.
+    // one takes the left half of the domain in direction 0, the other the right.
     int rank_n = ParallelContext::NProcsSub();
     int myproc = ParallelContext::MyProcSub();
-    int task_me = myproc / 2;
+    int task_me = myproc / (amrex::max(rank_n, 2) / 2);
 
     MPI_Comm new_comm;
     MPI_Comm_split(ParallelContext::CommunicatorSub(), task_me, myproc, &new_comm);
-    
+
     const int io_rank = 0;
     ParallelContext::push(new_comm, task_me, io_rank);
-    
+
     {
-
-        amrex::Print() << ParallelContext::NProcsSub() << "\n";
-
         TestParams params;
         get_test_params(params, "redistribute");
 
@@ -354,64 +343,83 @@ void testRedistribute ()
         for (int i = 0; i < BL_SPACEDIM; i++)
             is_per[i] = params.is_periodic;
 
-        Vector<IntVect> rr(params.nlevs-1);
-        for (int lev = 1; lev < params.nlevs; lev++)
-            rr[lev-1] = IntVect(D_DECL(2,2,2));
+        // Each comm gets a different domain
+        IntVect hs = params.size / 2;
 
         RealBox real_box;
         for (int n = 0; n < BL_SPACEDIM; n++)
         {
-            real_box.setLo(n, 0.0);
-            real_box.setHi(n, params.size[n]);
+            Real physlo = (n == 0) ? task_me*hs[n] : 0.0;
+            Real physhi = (n == 0) ? task_me*hs[n] + hs[n] : params.size[n];
+            real_box.setLo(n, physlo);
+            real_box.setHi(n, physhi);
         }
 
-        IntVect domain_lo(AMREX_D_DECL(0, 0, 0));
-        IntVect domain_hi(AMREX_D_DECL(params.size[0]-1,params.size[1]-1,params.size[2]-1));
+        IntVect domain_lo(AMREX_D_DECL(task_me*hs[0], 0, 0));
+        IntVect domain_hi(AMREX_D_DECL(task_me*hs[0] + hs[0] - 1,
+                                       params.size[1] - 1,
+                                       params.size[2] - 1));
         const Box base_domain(domain_lo, domain_hi);
 
-        Vector<Geometry> geom(params.nlevs);
-        geom[0].define(base_domain, &real_box, CoordSys::cartesian, is_per);
-        for (int lev = 1; lev < params.nlevs; lev++) {
-            geom[lev].define(amrex::refine(geom[lev-1].Domain(), rr[lev-1]),
-                             &real_box, CoordSys::cartesian, is_per);
-        }
+        Geometry geom;
+        geom.define(base_domain, &real_box, CoordSys::cartesian, is_per);
 
-        Vector<BoxArray> ba(params.nlevs);
-        Vector<DistributionMapping> dm(params.nlevs);
-        IntVect lo = IntVect(D_DECL(0, 0, 0));
-        IntVect size = params.size;
-        for (int lev = 0; lev < params.nlevs; ++lev)
+        BoxArray ba;
+        ba.define(base_domain);
+        ba.maxSize(params.max_grid_size);
+
+        DistributionMapping dm;
+        dm.define(ba, ParallelContext::NProcsSub());
+
+        // by doing it this way, we have each subcommunicator making
+        // separate Redisitribute calls at the same time.
+        if (task_me == 0)
         {
-            ba[lev].define(Box(lo, lo+params.size-1));
-            ba[lev].maxSize(params.max_grid_size);
-            dm[lev].define(ba[lev], ParallelContext::NProcsSub());
-            lo += size/2;
-            size *= 2;
-        }
+            TestParticleContainer pc(geom, dm, ba);
 
-        TestParticleContainer pc(geom, dm, ba, rr);
+            int npc = params.num_ppc;
+            IntVect nppc = IntVect(AMREX_D_DECL(npc, npc, npc));
 
-        int npc = params.num_ppc;
-        IntVect nppc = IntVect(AMREX_D_DECL(npc, npc, npc));
+            pc.InitParticles(nppc);
 
-        pc.InitParticles(nppc);
-
-        pc.checkAnswer();
-
-        auto np_old = pc.TotalNumberOfParticles();
-
-        for (int i = 0; i < params.nsteps; ++i)
-        {
-            pc.moveParticles(params.move_dir, params.do_random);
-            pc.RedistributeLocal();
-            if (params.sort) pc.SortParticlesByCell();
             pc.checkAnswer();
+
+            auto np_old = pc.TotalNumberOfParticles();
+
+            for (int i = 0; i < params.nsteps; ++i)
+            {
+                pc.moveParticles(params.move_dir, params.do_random);
+                pc.RedistributeLocal();
+                if (params.sort) pc.SortParticlesByCell();
+                pc.checkAnswer();
+            }
+
+            if (geom.isAllPeriodic()) AMREX_ALWAYS_ASSERT(np_old == pc.TotalNumberOfParticles());
         }
 
-        amrex::Print() << np_old << " " << pc.TotalNumberOfParticles() << "\n";
+        if (task_me == 1)
+        {
+            TestParticleContainer pc(geom, dm, ba);
 
-        if (geom[0].isAllPeriodic()) AMREX_ALWAYS_ASSERT(np_old == pc.TotalNumberOfParticles());
+            int npc = params.num_ppc;
+            IntVect nppc = IntVect(AMREX_D_DECL(npc, npc, npc));
 
+            pc.InitParticles(nppc);
+
+            pc.checkAnswer();
+
+            auto np_old = pc.TotalNumberOfParticles();
+
+            for (int i = 0; i < params.nsteps; ++i)
+            {
+                pc.moveParticles(params.move_dir, params.do_random);
+                pc.RedistributeLocal();
+                if (params.sort) pc.SortParticlesByCell();
+                pc.checkAnswer();
+            }
+
+            if (geom.isAllPeriodic()) AMREX_ALWAYS_ASSERT(np_old == pc.TotalNumberOfParticles());
+        }
     }
 
     ParallelContext::pop();

--- a/Tests/Particles/ParallelContext/main.cpp
+++ b/Tests/Particles/ParallelContext/main.cpp
@@ -287,14 +287,14 @@ struct TestParams
     int sort;
 };
 
-void testRedistribute();
+void testParallelContext();
 
 int main (int argc, char* argv[])
 {
     amrex::Initialize(argc,argv);
 
     amrex::Print() << "Running redistribute test \n";
-    testRedistribute();
+    testParallelContext();
 
     amrex::Finalize();
 }
@@ -317,9 +317,9 @@ void get_test_params(TestParams& params, const std::string& prefix)
     pp.query("sort", params.sort);
 }
 
-void testRedistribute ()
+void testParallelContext ()
 {
-    BL_PROFILE("testRedistribute");
+    BL_PROFILE("testParallelContext");
 
     AMREX_ALWAYS_ASSERT(AMREX_SPACEDIM == 3);
 

--- a/Tests/Particles/ParallelContext/main.cpp
+++ b/Tests/Particles/ParallelContext/main.cpp
@@ -374,7 +374,7 @@ void testRedistribute ()
         dm.define(ba, ParallelContext::NProcsSub());
 
         // by doing it this way, we have each subcommunicator making
-        // separate Redisitribute calls at the same time.
+        // separate Redistribute calls at the same time.
         if (task_me == 0)
         {
             TestParticleContainer pc(geom, dm, ba);


### PR DESCRIPTION
This makes particle operations like Redistribute() respect the current `ParallelContext`. 