### PR TITLE
CMake: improve MSVC+CUDA support

### DIFF
--- a/Tools/CMake/AMReXFlagsTargets.cmake
+++ b/Tools/CMake/AMReXFlagsTargets.cmake
@@ -94,10 +94,17 @@ add_library(AMReX::Flags_CXX_REQUIRED ALIAS Flags_CXX_REQUIRED)
 
 target_compile_options( Flags_CXX_REQUIRED
    INTERFACE
-   $<${_cxx_msvc}:/Za /bigobj
-   $<IF:$<VERSION_LESS:$<CXX_COMPILER_VERSION>,19.26>,/experimental:preprocessor,/Zc:preprocessor> >
+   $<${_cxx_msvc}:/Za /bigobj>
    )
 
+# Currently can't make this a generator expression as amrex_evaluate_genex fails
+# to parse it and propagate the flags to cuda
+if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC" AND CXX_COMPILER_VERSION VERSION_LESS 19.26)
+   target_compile_options( Flags_CXX_REQUIRED
+      INTERFACE
+      $<${_cxx_msvc}:/experimental:preprocessor /Zc:preprocessor>
+   )
+endif()
 #
 # Fortran REQUIRED flags -- This is for internal use only: it is useless to export it
 #

--- a/Tools/CMake/AMReX_SetupCUDA.cmake
+++ b/Tools/CMake/AMReX_SetupCUDA.cmake
@@ -111,9 +111,9 @@ if (NOT (CMAKE_SYSTEM_NAME STREQUAL "Windows" ) )
    # For Linux and MAC, we need to enforce that manually
    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -m64")
 endif ()
-set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --expt-relaxed-constexpr --expt-extended-lambda")
-set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Wno-deprecated-gpu-targets ${NVCC_ARCH_FLAGS}")
-set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -maxrregcount=${CUDA_MAXREGCOUNT}")
+string(APPEND CMAKE_CUDA_FLAGS " --expt-relaxed-constexpr --expt-extended-lambda")
+string(APPEND CMAKE_CUDA_FLAGS " -Wno-deprecated-gpu-targets ${NVCC_ARCH_FLAGS}")
+string(APPEND CMAKE_CUDA_FLAGS " -maxrregcount=${CUDA_MAXREGCOUNT}")
 
 if (ENABLE_CUDA_FASTMATH)
    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --use_fast_math")


### PR DESCRIPTION
The primary issue now is that nvcc doesn't seem to be parsing with
/Za enabled, so alternate tokens are causing compile failures.