### PR TITLE
use iso646 to provide alternative operator names for Windows

### DIFF
--- a/Src/Base/AMReX.H
+++ b/Src/Base/AMReX.H
@@ -8,6 +8,7 @@
 #include <AMReX_ccse-mpi.H>
 #include <AMReX_Exception.H>
 #include <AMReX_INT.H>
+#include <AMReX_REAL.H>
 #include <AMReX_Math.H>
 
 #include <iostream>

--- a/Src/Base/AMReX_Extension.H
+++ b/Src/Base/AMReX_Extension.H
@@ -137,6 +137,10 @@
 #define AMREX_ATTRIBUTE_WEAK __attribute__((weak))
 #endif
 
+#if defined(__cplusplus) && defined(_WIN32)
+#include <iso646.h>
+#endif
+
 #endif /* !BL_LANG_FORT */
 
 #endif

--- a/Tools/CMake/AMReXFlagsTargets.cmake
+++ b/Tools/CMake/AMReXFlagsTargets.cmake
@@ -94,7 +94,7 @@ add_library(AMReX::Flags_CXX_REQUIRED ALIAS Flags_CXX_REQUIRED)
 
 target_compile_options( Flags_CXX_REQUIRED
    INTERFACE
-   $<${_cxx_msvc}:/Za /bigobj>
+   $<${_cxx_msvc}:/bigobj>
    )
 
 # Currently can't make this a generator expression as amrex_evaluate_genex fails


### PR DESCRIPTION
Do not merge both #1003 and #1001.