### PR TITLE
update comments on abs function

### DIFF
--- a/Src/Base/AMReX_Math.H
+++ b/Src/Base/AMReX_Math.H
@@ -12,12 +12,12 @@ namespace sycl = cl::sycl;
 #endif
 
 namespace amrex { inline namespace disabled {
-    // If it is inside namespace amrex, or amrex namespace is imported with
-    // using namespace amrex or amrex::disabled, unqualified abs functions are
-    // disabled with a link time error such as, undefined reference to
-    // `amrex::disabled::abs(double)'.  To fix it, one can use `std::abs` or
-    // `amrex::Math::abs`.  The latter works in both host and device functions,
-    // whereas `std::abs` does not currently work on device with HIP and DPC++.
+    // If it is inside namespace amrex, or amrex namespace is imported with using namespace amrex or
+    // amrex::disabled, unqualified abs functions are disabled with a compile time error such as,
+    // call of overload abs(int&) is ambiguous, or a link time error such as, undefined reference to
+    // `amrex::disabled::abs(double)'.  To fix it, one can use `std::abs` or `amrex::Math::abs`.
+    // The latter works in both host and device functions, whereas `std::abs` does not currently
+    // work on device with HIP and DPC++.
     AMREX_GPU_HOST_DEVICE double abs (double);
     AMREX_GPU_HOST_DEVICE float abs (float);
     AMREX_GPU_HOST_DEVICE long double abs (long double);


### PR DESCRIPTION
When I first tested it, the error was at link time.  But it could also be a compile time error on ambiguous overload.  So the comments are updated.
