### PR TITLE
CMake: MSVC Pre-Processor Flags (Fix Old/New)

### DIFF
--- a/Tools/CMake/AMReXFlagsTargets.cmake
+++ b/Tools/CMake/AMReXFlagsTargets.cmake
@@ -99,12 +99,20 @@ target_compile_options( Flags_CXX_REQUIRED
 
 # Currently can't make this a generator expression as amrex_evaluate_genex fails
 # to parse it and propagate the flags to cuda
-if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC" AND CXX_COMPILER_VERSION VERSION_LESS 19.26)
-   target_compile_options( Flags_CXX_REQUIRED
-      INTERFACE
-      $<${_cxx_msvc}:/experimental:preprocessor /Zc:preprocessor>
-   )
+if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+   if (CXX_COMPILER_VERSION VERSION_LESS 19.26)
+      target_compile_options( Flags_CXX_REQUIRED
+         INTERFACE
+         $<${_cxx_msvc}:/experimental:preprocessor>
+         )
+   else ()
+      target_compile_options( Flags_CXX_REQUIRED
+         INTERFACE
+         $<${_cxx_msvc}:/Zc:preprocessor>
+         )
+   endif ()
 endif()
+
 #
 # Fortran REQUIRED flags -- This is for internal use only: it is useless to export it
 #


### PR DESCRIPTION
Follow-up to #996

Fix the experimental preprocessor flag for older MSVC and the new one for newer versions.