### PR TITLE
Single Precision: INVALID_TIME Value OoR

### DIFF
--- a/Src/Amr/AMReX_StateData.cpp
+++ b/Src/Amr/AMReX_StateData.cpp
@@ -1,5 +1,6 @@
 
 #include <iostream>
+#include <limits>
 #include <algorithm>
 
 #include <AMReX_RealBox.H>
@@ -14,7 +15,7 @@
 
 namespace amrex {
 
-static constexpr Real INVALID_TIME = -1.0e200;
+static constexpr Real INVALID_TIME = std::numeric_limits<Real>::lowest();
 
 static constexpr int MFNEWDATA = 0;
 static constexpr int MFOLDDATA = 1;

--- a/Src/Amr/AMReX_StateData.cpp
+++ b/Src/Amr/AMReX_StateData.cpp
@@ -15,7 +15,11 @@
 
 namespace amrex {
 
-static constexpr Real INVALID_TIME = std::numeric_limits<Real>::lowest();
+#ifdef AMREX_USE_FLOAT
+static constexpr Real INVALID_TIME = -1.0e20;
+#else
+static constexpr Real INVALID_TIME = -1.0e200; 
+#endif
 
 static constexpr int MFNEWDATA = 0;
 static constexpr int MFOLDDATA = 1;

--- a/Src/Amr/AMReX_StateData.cpp
+++ b/Src/Amr/AMReX_StateData.cpp
@@ -16,7 +16,7 @@
 namespace amrex {
 
 #ifdef AMREX_USE_FLOAT
-static constexpr Real INVALID_TIME = -1.0e20;
+static constexpr Real INVALID_TIME = -1.0e30;
 #else
 static constexpr Real INVALID_TIME = -1.0e200; 
 #endif


### PR DESCRIPTION
AppleClang 11.0.3 with single precision C++14 builds errors with the following in WarpX:
```
error: constexpr variable 'INVALID_TIME' must be initialized by a
       constant expression
static constexpr Real INVALID_TIME = -1.0e200;
                      ^              ~~~~~~~~
WarpX/build_sp/_deps/fetchedamrex-src/Src/Amr/AMReX_StateData.cpp:17:38:
  note: value -1.0E+200 is outside the range of representable values of
        type 'const amrex::Real' (aka 'const float')
static constexpr Real INVALID_TIME = -1.0e200;
```

This changes the numeric value of this constant to the lowest in the supported range of the underlying data type.