### PR TITLE
CI: Verbose Make

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -16,6 +16,7 @@ jobs:
         mkdir build
         cd build
         cmake ..                                  \
+            -DCMAKE_VERBOSE_MAKEFILE=ON           \
             -DCMAKE_INSTALL_PREFIX=/tmp/my-amrex  \
             -DCMAKE_CXX_STANDARD=17
         make -j 2 VERBOSE=ON
@@ -33,10 +34,11 @@ jobs:
       run: |
         mkdir build
         cd build
-        cmake ..                     \
-            -DCMAKE_BUILD_TYPE=Debug \
-            -DENABLE_BACKTRACE=ON    \
-            -DENABLE_TUTORIALS=ON    \
+        cmake ..                        \
+            -DCMAKE_BUILD_TYPE=Debug    \
+            -DCMAKE_VERBOSE_MAKEFILE=ON \
+            -DENABLE_BACKTRACE=ON       \
+            -DENABLE_TUTORIALS=ON       \
             -DENABLE_PARTICLES=ON
         make -j 2 tutorials
 
@@ -52,12 +54,13 @@ jobs:
       run: |
         mkdir build
         cd build
-        cmake ..                     \
-            -DCMAKE_BUILD_TYPE=Debug \
-            -DENABLE_BACKTRACE=ON    \
-            -DENABLE_TUTORIALS=ON    \
-            -DENABLE_PARTICLES=ON    \
-            -DCMAKE_CXX_STANDARD=20  \
+        cmake ..                        \
+            -DCMAKE_BUILD_TYPE=Debug    \
+            -DCMAKE_VERBOSE_MAKEFILE=ON \
+            -DENABLE_BACKTRACE=ON       \
+            -DENABLE_TUTORIALS=ON       \
+            -DENABLE_PARTICLES=ON       \
+            -DCMAKE_CXX_STANDARD=20     \
             -DCMAKE_C_COMPILER=$(which gcc-10)              \
             -DCMAKE_CXX_COMPILER=$(which g++-10)            \
             -DCMAKE_Fortran_COMPILER=$(which gfortran-10)
@@ -75,11 +78,12 @@ jobs:
       run: |
         mkdir build
         cd build
-        cmake ..                     \
-            -DCMAKE_BUILD_TYPE=Debug \
-            -DENABLE_BACKTRACE=ON    \
-            -DENABLE_TUTORIALS=ON    \
-            -DENABLE_MPI=OFF         \
+        cmake ..                        \
+            -DCMAKE_BUILD_TYPE=Debug    \
+            -DCMAKE_VERBOSE_MAKEFILE=ON \
+            -DENABLE_BACKTRACE=ON       \
+            -DENABLE_TUTORIALS=ON       \
+            -DENABLE_MPI=OFF            \
             -DENABLE_PARTICLES=ON
         make -j 2 tutorials
 
@@ -95,12 +99,13 @@ jobs:
       run: |
         mkdir build
         cd build
-        cmake ..                     \
-            -DCMAKE_BUILD_TYPE=Debug \
-            -DENABLE_BACKTRACE=ON    \
-            -DENABLE_TUTORIALS=ON    \
-            -DENABLE_PARTICLES=ON    \
-            -DENABLE_FORTRAN=OFF     \
+        cmake ..                        \
+            -DCMAKE_BUILD_TYPE=Debug    \
+            -DCMAKE_VERBOSE_MAKEFILE=ON \
+            -DENABLE_BACKTRACE=ON       \
+            -DENABLE_TUTORIALS=ON       \
+            -DENABLE_PARTICLES=ON       \
+            -DENABLE_FORTRAN=OFF        \
             -DCMAKE_CXX_STANDARD=11
         make -j 2 tutorials
 
@@ -117,6 +122,7 @@ jobs:
         mkdir build
         cd build
         cmake ..                                         \
+            -DCMAKE_VERBOSE_MAKEFILE=ON                  \
             -DENABLE_TUTORIALS=ON                        \
             -DENABLE_PARTICLES=ON                        \
             -DENABLE_CUDA=ON                             \

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -15,9 +15,10 @@ jobs:
       run: |
         mkdir build
         cd build
-        cmake ..                     \
-            -DCMAKE_BUILD_TYPE=Debug \
-            -DENABLE_BACKTRACE=ON    \
-            -DENABLE_TUTORIALS=ON    \
+        cmake ..                        \
+            -DCMAKE_BUILD_TYPE=Debug    \
+            -DCMAKE_VERBOSE_MAKEFILE=ON \
+            -DENABLE_BACKTRACE=ON       \
+            -DENABLE_TUTORIALS=ON       \
             -DENABLE_PARTICLES=ON
         make -j 2 tutorials

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -13,5 +13,5 @@ jobs:
       run: |
         mkdir build
         cd build
-        cmake .. -DCMAKE_BUILD_TYPE=Debug -DENABLE_TUTORIALS=ON -DENABLE_FORTRAN=OFF -DENABLE_MPI=OFF -DCMAKE_CXX_STANDARD=17
+        cmake .. -DCMAKE_BUILD_TYPE=Debug -DCMAKE_VERBOSE_MAKEFILE=ON -DENABLE_TUTORIALS=ON -DENABLE_FORTRAN=OFF -DENABLE_MPI=OFF -DCMAKE_CXX_STANDARD=17
         cmake --build . --config Debug --target tutorials


### PR DESCRIPTION
Although we build with `-j2` to speed up CI on all available cores, this can improve understanding if things fail.