### PR TITLE
Support for overset in cell-centered MLABecLaplacian

### DIFF
--- a/Src/LinearSolvers/MLMG/AMReX_MLABecLap_1D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLABecLap_1D_K.H
@@ -208,5 +208,20 @@ int coarsen_overset_mask (Box const& bx, Array4<int> const& cmsk, Array4<int con
     return nerrors;
 }
 
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void overset_rescale_bcoef_x (Box const& box, Array4<Real> const& bX, Array4<int const> const& osm,
+                              int ncomp, Real osfac) noexcept
+{
+    const auto lo = amrex::lbound(box);
+    const auto hi = amrex::ubound(box);
+    for (int n = 0; n < ncomp; ++n) {
+        for (int i = lo.x; i <= hi.x; ++i) {
+            if ((osm(i-1,0,0)+osm(i,0,0)) == 1) {
+                bX(i,0,0,n) *= osfac;
+            }
+        }
+    }
+}
+
 }
 #endif

--- a/Src/LinearSolvers/MLMG/AMReX_MLABecLap_1D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLABecLap_1D_K.H
@@ -27,6 +27,34 @@ void mlabeclap_adotx (Box const& box, Array4<Real> const& y,
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void mlabeclap_adotx_os (Box const& box, Array4<Real> const& y,
+                         Array4<Real const> const& x,
+                         Array4<Real const> const& a,
+                         Array4<Real const> const& bX,
+                         Array4<int const> const& osm,
+                         GpuArray<Real,AMREX_SPACEDIM> const& dxinv,
+                         Real alpha, Real beta, int ncomp) noexcept
+{
+    const Real dhx = beta*dxinv[0]*dxinv[0];
+
+    const auto lo = amrex::lbound(box);
+    const auto hi = amrex::ubound(box);
+
+    for (int n = 0; n < ncomp; ++n) {
+    AMREX_PRAGMA_SIMD
+    for (int i = lo.x; i <= hi.x; ++i) {
+        if (osm(i,0,0)) {
+            y(i,0,0,n) = 0.0;
+        } else {
+            y(i,0,0,n) = alpha*a(i,0,0)*x(i,0,0,n)
+                - dhx * (bX(i+1,0,0)*(x(i+1,0,0,n) - x(i  ,0,0,n))
+                       - bX(i  ,0,0)*(x(i  ,0,0,n) - x(i-1,0,0,n)));
+        }
+    }
+    }
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 void mlabeclap_normalize (Box const& box, Array4<Real> const& x,
                           Array4<Real const> const& a,
                           Array4<Real const> const& bX,
@@ -114,6 +142,70 @@ void abec_gsrb (Box const& box, Array4<Real> const& phi, Array4<Real const> cons
             }
         }
     }
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void abec_gsrb_os (Box const& box, Array4<Real> const& phi, Array4<Real const> const& rhs,
+                   Real alpha, Array4<Real const> const& a,
+                   Real dhx,
+                   Array4<Real const> const& bX,
+                   Array4<int const> const& m0,
+                   Array4<int const> const& m1,
+                   Array4<Real const> const& f0,
+                   Array4<Real const> const& f1,
+                   Array4<int const> const& osm,
+                   Box const& vbox, int redblack, int nc) noexcept
+{
+    const auto lo = amrex::lbound(box);
+    const auto hi = amrex::ubound(box);
+    const auto vlo = amrex::lbound(vbox);
+    const auto vhi = amrex::ubound(vbox);
+
+    for (int n = 0; n < nc; ++n) {
+        AMREX_PRAGMA_SIMD
+        for (int i = lo.x; i <= hi.x; ++i) {
+            if ((i+redblack)%2 == 0) {
+                if (osm(i,0,0)) {
+                    phi(i,0,0) = 0.0;
+                } else {
+                    Real cf0 = (i == vlo.x and m0(vlo.x-1,0,0) > 0)
+                        ? f0(vlo.x,0,0,n) : 0.0;
+                    Real cf1 = (i == vhi.x and m1(vhi.x+1,0,0) > 0)
+                        ? f1(vhi.x,0,0,n) : 0.0;
+
+                    Real delta = dhx*(bX(i,0,0)*cf0 + bX(i+1,0,0)*cf1);
+
+                    Real gamma = alpha*a(i,0,0)
+                        +   dhx*( bX(i,0,0) + bX(i+1,0,0) );
+
+                    Real rho = dhx*(bX(i  ,0  ,0)*phi(i-1,0  ,0,n)
+                                  + bX(i+1,0  ,0)*phi(i+1,0  ,0,n));
+
+                    phi(i,0,0,n) = (rhs(i,0,0,n) + rho - phi(i,0,0,n)*delta)
+                        / (gamma - delta);
+                }
+            }
+        }
+    }
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+int coarsen_overset_mask (Box const& bx, Array4<int> const& cmsk, Array4<int const> const& fmsk)
+    noexcept
+{
+    int nerrors = 0;
+    const auto lo = amrex::lbound(bx);
+    const auto hi = amrex::ubound(bx);
+    for (int i = lo.x; i <= hi.x; ++i) {
+        int ii = 2*i;
+        cmsk(i,0,0) = fmsk(ii,0,0) + fmsk(ii+1,0,0);
+        if (cmsk(i,0,0) == 2) {
+            cmsk(i,0,0) = 1;
+        } else if (cmsk(i,0,0) != 0) {
+            ++nerrors;
+        }
+    }
+    return nerrors;
 }
 
 }

--- a/Src/LinearSolvers/MLMG/AMReX_MLABecLap_2D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLABecLap_2D_K.H
@@ -33,6 +33,40 @@ void mlabeclap_adotx (Box const& box, Array4<Real> const& y,
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void mlabeclap_adotx_os (Box const& box, Array4<Real> const& y,
+                         Array4<Real const> const& x,
+                         Array4<Real const> const& a,
+                         Array4<Real const> const& bX,
+                         Array4<Real const> const& bY,
+                         Array4<int const> const& osm,
+                         GpuArray<Real,AMREX_SPACEDIM> const& dxinv,
+                         Real alpha, Real beta, int ncomp) noexcept
+{
+    const Real dhx = beta*dxinv[0]*dxinv[0];
+    const Real dhy = beta*dxinv[1]*dxinv[1];
+
+    const auto lo = amrex::lbound(box);
+    const auto hi = amrex::ubound(box);
+
+    for (int n = 0; n < ncomp; ++n) {
+    for     (int j = lo.y; j <= hi.y; ++j) {
+        AMREX_PRAGMA_SIMD
+        for (int i = lo.x; i <= hi.x; ++i) {
+            if (osm(i,j,0)) {
+                y(i,j,0,n) = 0.0;
+            } else {
+                y(i,j,0,n) = alpha*a(i,j,0)*x(i,j,0,n)
+                    - dhx * (bX(i+1,j,0,n)*(x(i+1,j,0,n) - x(i  ,j,0,n))
+                           - bX(i  ,j,0,n)*(x(i  ,j,0,n) - x(i-1,j,0,n)))
+                    - dhy * (bY(i,j+1,0,n)*(x(i,j+1,0,n) - x(i,j  ,0,n))
+                           - bY(i,j  ,0,n)*(x(i,j  ,0,n) - x(i,j-1,0,n)));
+            }
+        }
+    }
+    }
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 void mlabeclap_normalize (Box const& box, Array4<Real> const& x,
                           Array4<Real const> const& a,
                           Array4<Real const> const& bX,
@@ -178,6 +212,82 @@ void abec_gsrb (Box const& box, Array4<Real> const& phi, Array4<Real const> cons
             }
         }
     }
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void abec_gsrb_os (Box const& box, Array4<Real> const& phi, Array4<Real const> const& rhs,
+                   Real alpha, Array4<Real const> const& a,
+                   Real dhx, Real dhy,
+                   Array4<Real const> const& bX, Array4<Real const> const& bY,
+                   Array4<int const> const& m0, Array4<int const> const& m2,
+                   Array4<int const> const& m1, Array4<int const> const& m3,
+                   Array4<Real const> const& f0, Array4<Real const> const& f2,
+                   Array4<Real const> const& f1, Array4<Real const> const& f3,
+                   Array4<int const> const& osm,
+                   Box const& vbox, int redblack, int nc) noexcept
+{
+    const auto lo = amrex::lbound(box);
+    const auto hi = amrex::ubound(box);
+    const auto vlo = amrex::lbound(vbox);
+    const auto vhi = amrex::ubound(vbox);
+
+    for (int n = 0; n < nc; ++n) {
+        for     (int j = lo.y; j <= hi.y; ++j) {
+            AMREX_PRAGMA_SIMD
+            for (int i = lo.x; i <= hi.x; ++i) {
+                if ((i+j+redblack)%2 == 0) {
+                    if (osm(i,j,0)) {
+                        phi(i,j,0,n) = 0.0;
+                    } else {
+                        Real cf0 = (i == vlo.x and m0(vlo.x-1,j,0) > 0)
+                            ? f0(vlo.x,j,0,n) : 0.0;
+                        Real cf1 = (j == vlo.y and m1(i,vlo.y-1,0) > 0)
+                            ? f1(i,vlo.y,0,n) : 0.0;
+                        Real cf2 = (i == vhi.x and m2(vhi.x+1,j,0) > 0)
+                            ? f2(vhi.x,j,0,n) : 0.0;
+                        Real cf3 = (j == vhi.y and m3(i,vhi.y+1,0) > 0)
+                            ? f3(i,vhi.y,0,n) : 0.0;
+
+                        Real delta = dhx*(bX(i,j,0,n)*cf0 + bX(i+1,j,0,n)*cf2)
+                                  +  dhy*(bY(i,j,0,n)*cf1 + bY(i,j+1,0,n)*cf3);
+
+                        Real gamma = alpha*a(i,j,0)
+                            +   dhx*( bX(i,j,0,n) + bX(i+1,j,0,n) )
+                            +   dhy*( bY(i,j,0,n) + bY(i,j+1,0,n) );
+
+                        Real rho = dhx*(bX(i  ,j  ,0,n)*phi(i-1,j  ,0,n)
+                                      + bX(i+1,j  ,0,n)*phi(i+1,j  ,0,n))
+                                  +dhy*(bY(i  ,j  ,0,n)*phi(i  ,j-1,0,n)
+                                      + bY(i  ,j+1,0,n)*phi(i  ,j+1,0,n));
+
+                        phi(i,j,0,n) = (rhs(i,j,0,n) + rho - phi(i,j,0,n)*delta)
+                            / (gamma - delta);
+                    }
+                }
+            }
+        }
+    }
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+int coarsen_overset_mask (Box const& bx, Array4<int> const& cmsk, Array4<int const> const& fmsk)
+    noexcept
+{
+    int nerrors = 0;
+    const auto lo = amrex::lbound(bx);
+    const auto hi = amrex::ubound(bx);
+    for (int j = lo.y; j <= hi.y; ++j) {
+    for (int i = lo.x; i <= hi.x; ++i) {
+        int ii = 2*i;
+        int jj = 2*j;
+        cmsk(i,j,0) = fmsk(ii,jj,0) + fmsk(ii+1,jj,0) + fmsk(ii,jj+1,0) + fmsk(ii+1,jj+1,0);
+        if (cmsk(i,j,0) == 4) {
+            cmsk(i,j,0) = 1;
+        } else if (cmsk(i,j,0) != 0) {
+            ++nerrors;
+        }
+    }}
+    return nerrors;
 }
 
 }

--- a/Src/LinearSolvers/MLMG/AMReX_MLABecLap_2D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLABecLap_2D_K.H
@@ -290,5 +290,37 @@ int coarsen_overset_mask (Box const& bx, Array4<int> const& cmsk, Array4<int con
     return nerrors;
 }
 
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void overset_rescale_bcoef_x (Box const& box, Array4<Real> const& bX, Array4<int const> const& osm,
+                              int ncomp, Real osfac) noexcept
+{
+    const auto lo = amrex::lbound(box);
+    const auto hi = amrex::ubound(box);
+    for (int n = 0; n < ncomp; ++n) {
+        for (int j = lo.y; j <= hi.y; ++j) {
+        for (int i = lo.x; i <= hi.x; ++i) {
+            if ((osm(i-1,j,0)+osm(i,j,0)) == 1) {
+                bX(i,j,0,n) *= osfac;
+            }
+        }}
+    }
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void overset_rescale_bcoef_y (Box const& box, Array4<Real> const& bY, Array4<int const> const& osm,
+                              int ncomp, Real osfac) noexcept
+{
+    const auto lo = amrex::lbound(box);
+    const auto hi = amrex::ubound(box);
+    for (int n = 0; n < ncomp; ++n) {
+        for (int j = lo.y; j <= hi.y; ++j) {
+        for (int i = lo.x; i <= hi.x; ++i) {
+            if ((osm(i,j-1,0)+osm(i,j,0)) == 1) {
+                bY(i,j,0,n) *= osfac;
+            }
+        }}
+    }
+}
+
 }
 #endif

--- a/Src/LinearSolvers/MLMG/AMReX_MLABecLap_3D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLABecLap_3D_K.H
@@ -401,5 +401,56 @@ int coarsen_overset_mask (Box const& bx, Array4<int> const& cmsk, Array4<int con
     return nerrors;
 }
 
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void overset_rescale_bcoef_x (Box const& box, Array4<Real> const& bX, Array4<int const> const& osm,
+                              int ncomp, Real osfac) noexcept
+{
+    const auto lo = amrex::lbound(box);
+    const auto hi = amrex::ubound(box);
+    for (int n = 0; n < ncomp; ++n) {
+        for (int k = lo.z; k <= hi.z; ++k) {
+        for (int j = lo.y; j <= hi.y; ++j) {
+        for (int i = lo.x; i <= hi.x; ++i) {
+            if ((osm(i-1,j,k)+osm(i,j,k)) == 1) {
+                bX(i,j,k,n) *= osfac;
+            }
+        }}}
+    }
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void overset_rescale_bcoef_y (Box const& box, Array4<Real> const& bY, Array4<int const> const& osm,
+                              int ncomp, Real osfac) noexcept
+{
+    const auto lo = amrex::lbound(box);
+    const auto hi = amrex::ubound(box);
+    for (int n = 0; n < ncomp; ++n) {
+        for (int k = lo.z; k <= hi.z; ++k) {
+        for (int j = lo.y; j <= hi.y; ++j) {
+        for (int i = lo.x; i <= hi.x; ++i) {
+            if ((osm(i,j-1,k)+osm(i,j,k)) == 1) {
+                bY(i,j,k,n) *= osfac;
+            }
+        }}}
+    }
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void overset_rescale_bcoef_z (Box const& box, Array4<Real> const& bZ, Array4<int const> const& osm,
+                              int ncomp, Real osfac) noexcept
+{
+    const auto lo = amrex::lbound(box);
+    const auto hi = amrex::ubound(box);
+    for (int n = 0; n < ncomp; ++n) {
+        for (int k = lo.z; k <= hi.z; ++k) {
+        for (int j = lo.y; j <= hi.y; ++j) {
+        for (int i = lo.x; i <= hi.x; ++i) {
+            if ((osm(i,j-1,k)+osm(i,j,k)) == 1) {
+                bZ(i,j,k,n) *= osfac;
+            }
+        }}}
+    }
+}
+
 }
 #endif

--- a/Src/LinearSolvers/MLMG/AMReX_MLABecLap_3D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLABecLap_3D_K.H
@@ -445,7 +445,7 @@ void overset_rescale_bcoef_z (Box const& box, Array4<Real> const& bZ, Array4<int
         for (int k = lo.z; k <= hi.z; ++k) {
         for (int j = lo.y; j <= hi.y; ++j) {
         for (int i = lo.x; i <= hi.x; ++i) {
-            if ((osm(i,j-1,k)+osm(i,j,k)) == 1) {
+            if ((osm(i,j,k-1)+osm(i,j,k)) == 1) {
                 bZ(i,j,k,n) *= osfac;
             }
         }}}

--- a/Src/LinearSolvers/MLMG/AMReX_MLABecLap_3D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLABecLap_3D_K.H
@@ -385,9 +385,9 @@ int coarsen_overset_mask (Box const& bx, Array4<int> const& cmsk, Array4<int con
     for (int k = lo.z; k <= hi.z; ++k) {
     for (int j = lo.y; j <= hi.y; ++j) {
     for (int i = lo.x; i <= hi.x; ++i) {
-        int kk = 2*k;
         int ii = 2*i;
         int jj = 2*j;
+        int kk = 2*k;
         cmsk(i,j,k) = fmsk(ii,jj  ,kk  ) + fmsk(ii+1,jj  ,kk  )
             +         fmsk(ii,jj+1,kk  ) + fmsk(ii+1,jj+1,kk  )
             +         fmsk(ii,jj  ,kk+1) + fmsk(ii+1,jj  ,kk+1)

--- a/Src/LinearSolvers/MLMG/AMReX_MLABecLap_3D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLABecLap_3D_K.H
@@ -39,6 +39,46 @@ void mlabeclap_adotx (Box const& box, Array4<Real> const& y,
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void mlabeclap_adotx_os (Box const& box, Array4<Real> const& y,
+                         Array4<Real const> const& x,
+                         Array4<Real const> const& a,
+                         Array4<Real const> const& bX,
+                         Array4<Real const> const& bY,
+                         Array4<Real const> const& bZ,
+                         Array4<int const> const& osm,
+                         GpuArray<Real,AMREX_SPACEDIM> const& dxinv,
+                         Real alpha, Real beta, int ncomp) noexcept
+{
+    const Real dhx = beta*dxinv[0]*dxinv[0];
+    const Real dhy = beta*dxinv[1]*dxinv[1];
+    const Real dhz = beta*dxinv[2]*dxinv[2];
+
+    const auto lo = amrex::lbound(box);
+    const auto hi = amrex::ubound(box);
+
+    for (int n = 0; n < ncomp; ++n) {
+    for         (int k = lo.z; k <= hi.z; ++k) {
+        for     (int j = lo.y; j <= hi.y; ++j) {
+            AMREX_PRAGMA_SIMD
+            for (int i = lo.x; i <= hi.x; ++i) {
+                if (osm(i,j,k)) {
+                    y(i,j,k,n) = 0.0;
+                } else {
+                    y(i,j,k,n) = alpha*a(i,j,k)*x(i,j,k,n)
+                        - dhx * (bX(i+1,j,k,n)*(x(i+1,j,k,n) - x(i  ,j,k,n))
+                               - bX(i  ,j,k,n)*(x(i  ,j,k,n) - x(i-1,j,k,n)))
+                        - dhy * (bY(i,j+1,k,n)*(x(i,j+1,k,n) - x(i,j  ,k,n))
+                               - bY(i,j  ,k,n)*(x(i,j  ,k,n) - x(i,j-1,k,n)))
+                        - dhz * (bZ(i,j,k+1,n)*(x(i,j,k+1,n) - x(i,j,k  ,n))
+                               - bZ(i,j,k  ,n)*(x(i,j,k  ,n) - x(i,j,k-1,n)));
+                }
+            }
+        }
+    }
+    }
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 void mlabeclap_normalize (Box const& box, Array4<Real> const& x,
                           Array4<Real const> const& a,
                           Array4<Real const> const& bX,
@@ -260,6 +300,105 @@ void abec_gsrb (Box const& box, Array4<Real> const& phi, Array4<Real const> cons
             }
         }
     }
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void abec_gsrb_os (Box const& box, Array4<Real> const& phi, Array4<Real const> const& rhs,
+                   Real alpha, Array4<Real const> const& a,
+                   Real dhx, Real dhy, Real dhz,
+                   Array4<Real const> const& bX, Array4<Real const> const& bY,
+                   Array4<Real const> const& bZ,
+                   Array4<int const> const& m0, Array4<int const> const& m2,
+                   Array4<int const> const& m4,
+                   Array4<int const> const& m1, Array4<int const> const& m3,
+                   Array4<int const> const& m5,
+                   Array4<Real const> const& f0, Array4<Real const> const& f2,
+                   Array4<Real const> const& f4,
+                   Array4<Real const> const& f1, Array4<Real const> const& f3,
+                   Array4<Real const> const& f5,
+                   Array4<int const> const& osm,
+                   Box const& vbox, int redblack, int nc) noexcept
+{
+    const auto lo = amrex::lbound(box);
+    const auto hi = amrex::ubound(box);
+    const auto vlo = amrex::lbound(vbox);
+    const auto vhi = amrex::ubound(vbox);
+
+    constexpr Real omega = 1.15;
+
+    for (int n = 0; n < nc; ++n) {
+        for         (int k = lo.z; k <= hi.z; ++k) {
+            for     (int j = lo.y; j <= hi.y; ++j) {
+                AMREX_PRAGMA_SIMD
+                for (int i = lo.x; i <= hi.x; ++i) {
+                    if ((i+j+k+redblack)%2 == 0) {
+                        if (osm(i,j,k)) {
+                            phi(i,j,k,n) = 0.0;
+                        } else {
+                            Real cf0 = (i == vlo.x and m0(vlo.x-1,j,k) > 0)
+                                ? f0(vlo.x,j,k,n) : 0.0;
+                            Real cf1 = (j == vlo.y and m1(i,vlo.y-1,k) > 0)
+                                ? f1(i,vlo.y,k,n) : 0.0;
+                            Real cf2 = (k == vlo.z and m2(i,j,vlo.z-1) > 0)
+                                ? f2(i,j,vlo.z,n) : 0.0;
+                            Real cf3 = (i == vhi.x and m3(vhi.x+1,j,k) > 0)
+                                ? f3(vhi.x,j,k,n) : 0.0;
+                            Real cf4 = (j == vhi.y and m4(i,vhi.y+1,k) > 0)
+                                ? f4(i,vhi.y,k,n) : 0.0;
+                            Real cf5 = (k == vhi.z and m5(i,j,vhi.z+1) > 0)
+                                ? f5(i,j,vhi.z,n) : 0.0;
+
+                            Real gamma = alpha*a(i,j,k)
+                                +   dhx*(bX(i,j,k,n)+bX(i+1,j,k,n))
+                                +   dhy*(bY(i,j,k,n)+bY(i,j+1,k,n))
+                                +   dhz*(bZ(i,j,k,n)+bZ(i,j,k+1,n));
+
+                            Real g_m_d = gamma
+                                - (dhx*(bX(i,j,k,n)*cf0 + bX(i+1,j,k,n)*cf3)
+                                +  dhy*(bY(i,j,k,n)*cf1 + bY(i,j+1,k,n)*cf4)
+                                +  dhz*(bZ(i,j,k,n)*cf2 + bZ(i,j,k+1,n)*cf5));
+
+                            Real rho =  dhx*( bX(i  ,j,k,n)*phi(i-1,j,k,n)
+                                      +       bX(i+1,j,k,n)*phi(i+1,j,k,n) )
+                                      + dhy*( bY(i,j  ,k,n)*phi(i,j-1,k,n)
+                                      +       bY(i,j+1,k,n)*phi(i,j+1,k,n) )
+                                      + dhz*( bZ(i,j,k  ,n)*phi(i,j,k-1,n)
+                                      +       bZ(i,j,k+1,n)*phi(i,j,k+1,n) );
+
+                            Real res =  rhs(i,j,k,n) - (gamma*phi(i,j,k,n) - rho);
+                            phi(i,j,k,n) = phi(i,j,k,n) + omega/g_m_d * res;
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+int coarsen_overset_mask (Box const& bx, Array4<int> const& cmsk, Array4<int const> const& fmsk)
+    noexcept
+{
+    int nerrors = 0;
+    const auto lo = amrex::lbound(bx);
+    const auto hi = amrex::ubound(bx);
+    for (int k = lo.z; k <= hi.z; ++k) {
+    for (int j = lo.y; j <= hi.y; ++j) {
+    for (int i = lo.x; i <= hi.x; ++i) {
+        int kk = 2*k;
+        int ii = 2*i;
+        int jj = 2*j;
+        cmsk(i,j,k) = fmsk(ii,jj  ,kk  ) + fmsk(ii+1,jj  ,kk  )
+            +         fmsk(ii,jj+1,kk  ) + fmsk(ii+1,jj+1,kk  )
+            +         fmsk(ii,jj  ,kk+1) + fmsk(ii+1,jj  ,kk+1)
+            +         fmsk(ii,jj+1,kk+1) + fmsk(ii+1,jj+1,kk+1);
+        if (cmsk(i,j,k) == 8) {
+            cmsk(i,j,k) = 1;
+        } else if (cmsk(i,j,k) != 0) {
+            ++nerrors;
+        }
+    }}}
+    return nerrors;
 }
 
 }

--- a/Src/LinearSolvers/MLMG/AMReX_MLABecLaplacian.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLABecLaplacian.H
@@ -20,6 +20,12 @@ public:
                      const Vector<DistributionMapping>& a_dmap,
                      const LPInfo& a_info = LPInfo(),
                      const Vector<FabFactory<FArrayBox> const*>& a_factory = {});
+    MLABecLaplacian (const Vector<Geometry>& a_geom,
+                     const Vector<BoxArray>& a_grids,
+                     const Vector<DistributionMapping>& a_dmap,
+                     const Vector<iMultiFab const*>& a_overset_mask,
+                     const LPInfo& a_info = LPInfo(),
+                     const Vector<FabFactory<FArrayBox> const*>& a_factory = {});
     virtual ~MLABecLaplacian ();
 
     MLABecLaplacian (const MLABecLaplacian&) = delete;
@@ -30,6 +36,13 @@ public:
     void define (const Vector<Geometry>& a_geom,
                  const Vector<BoxArray>& a_grids,
                  const Vector<DistributionMapping>& a_dmap,
+                 const LPInfo& a_info = LPInfo(),
+                 const Vector<FabFactory<FArrayBox> const*>& a_factory = {});
+
+    void define (const Vector<Geometry>& a_geom,
+                 const Vector<BoxArray>& a_grids,
+                 const Vector<DistributionMapping>& a_dmap,
+                 const Vector<iMultiFab const*>& a_overset_mask,
                  const LPInfo& a_info = LPInfo(),
                  const Vector<FabFactory<FArrayBox> const*>& a_factory = {});
 
@@ -69,6 +82,8 @@ public:
         return std::unique_ptr<MLLinOp>{};
     }
 
+    virtual void interpolation (int amrlev, int fmglev, MultiFab& fine, const MultiFab& crse) const final override;
+
     void averageDownCoeffsSameAmrLevel (Vector<MultiFab>& a,
                                         Vector<Array<MultiFab,AMREX_SPACEDIM> >& b);
     void averageDownCoeffs ();
@@ -89,6 +104,8 @@ protected:
     Real m_b_scalar = std::numeric_limits<Real>::quiet_NaN();
     Vector<Vector<MultiFab> > m_a_coeffs;
     Vector<Vector<Array<MultiFab,AMREX_SPACEDIM> > > m_b_coeffs;
+
+    Vector<Vector<std::unique_ptr<iMultiFab> > > m_overset_mask;
 
     Vector<int> m_is_singular;
 };

--- a/Src/LinearSolvers/MLMG/AMReX_MLABecLaplacian.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLABecLaplacian.H
@@ -82,7 +82,7 @@ public:
         return std::unique_ptr<MLLinOp>{};
     }
 
-    virtual void interpolation (int amrlev, int fmglev, MultiFab& fine, const MultiFab& crse) const final override;
+    virtual void applyOverset (int amlev, MultiFab& rhs) const override;
 
     void averageDownCoeffsSameAmrLevel (int amrlev, Vector<MultiFab>& a,
                                         Vector<Array<MultiFab,AMREX_SPACEDIM> >& b);

--- a/Src/LinearSolvers/MLMG/AMReX_MLABecLaplacian.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLABecLaplacian.H
@@ -84,7 +84,7 @@ public:
 
     virtual void interpolation (int amrlev, int fmglev, MultiFab& fine, const MultiFab& crse) const final override;
 
-    void averageDownCoeffsSameAmrLevel (Vector<MultiFab>& a,
+    void averageDownCoeffsSameAmrLevel (int amrlev, Vector<MultiFab>& a,
                                         Vector<Array<MultiFab,AMREX_SPACEDIM> >& b);
     void averageDownCoeffs ();
     void averageDownCoeffsToCoarseAmrLevel (int flev);

--- a/Src/LinearSolvers/MLMG/AMReX_MLABecLaplacian.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLABecLaplacian.cpp
@@ -15,6 +15,16 @@ MLABecLaplacian::MLABecLaplacian (const Vector<Geometry>& a_geom,
     define(a_geom, a_grids, a_dmap, a_info, a_factory);
 }
 
+MLABecLaplacian::MLABecLaplacian (const Vector<Geometry>& a_geom,
+                                  const Vector<BoxArray>& a_grids,
+                                  const Vector<DistributionMapping>& a_dmap,
+                                  const Vector<iMultiFab const*>& a_overset_mask,
+                                  const LPInfo& a_info,
+                                  const Vector<FabFactory<FArrayBox> const*>& a_factory)
+{
+    define(a_geom, a_grids, a_dmap, a_overset_mask, a_info, a_factory);
+}
+
 void
 MLABecLaplacian::define (const Vector<Geometry>& a_geom,
                          const Vector<BoxArray>& a_grids,
@@ -30,10 +40,12 @@ MLABecLaplacian::define (const Vector<Geometry>& a_geom,
 
     m_a_coeffs.resize(m_num_amr_levels);
     m_b_coeffs.resize(m_num_amr_levels);
+    m_overset_mask.resize(m_num_amr_levels);
     for (int amrlev = 0; amrlev < m_num_amr_levels; ++amrlev)
     {
         m_a_coeffs[amrlev].resize(m_num_mg_levels[amrlev]);
         m_b_coeffs[amrlev].resize(m_num_mg_levels[amrlev]);
+        m_overset_mask[amrlev].resize(m_num_mg_levels[amrlev]);
         for (int mglev = 0; mglev < m_num_mg_levels[amrlev]; ++mglev)
         {
             m_a_coeffs[amrlev][mglev].define(m_grids[amrlev][mglev],
@@ -47,6 +59,83 @@ MLABecLaplacian::define (const Vector<Geometry>& a_geom,
                                                        m_dmap[amrlev][mglev],
                                                        ncomp, 0, MFInfo(), *m_factory[amrlev][mglev]);
             }
+        }
+    }
+}
+
+void
+MLABecLaplacian::define (const Vector<Geometry>& a_geom,
+                         const Vector<BoxArray>& a_grids,
+                         const Vector<DistributionMapping>& a_dmap,
+                         const Vector<iMultiFab const*>& a_overset_mask,
+                         const LPInfo& a_info,
+                         const Vector<FabFactory<FArrayBox> const*>& a_factory)
+{
+    BL_PROFILE("MLABecLaplacian::define(overset)");
+
+    int namrlevs = a_geom.size();
+    m_overset_mask.resize(namrlevs);
+    for (int amrlev = 0; amrlev < namrlevs; ++amrlev)
+    {
+        m_overset_mask[amrlev].emplace_back(new iMultiFab(a_grids[amrlev], a_dmap[amrlev], 1, 0));
+        iMultiFab::Copy(*m_overset_mask[amrlev][0], *a_overset_mask[amrlev], 0, 0, 1, 0);
+        if (amrlev > 1) {
+            AMREX_ALWAYS_ASSERT(amrex::refine(a_geom[amrlev-1].Domain(),2)
+                                == a_geom[amrlev].Domain());
+        }
+    }
+
+    int max_overset_mask_coarsening_level = 0;
+    int amrlev = 0;
+    Box dom = a_geom[0].Domain();
+    for (int mglev = 1; mglev <= a_info.max_coarsening_level; ++mglev)
+    {
+        AMREX_ALWAYS_ASSERT(mg_coarsen_ratio == 2);
+        iMultiFab const& fine = *m_overset_mask[amrlev][mglev-1];
+        if (dom.coarsenable(2) and fine.boxArray().coarsenable(2)) {
+            std::unique_ptr<iMultiFab> crse(new iMultiFab(amrex::coarsen(fine.boxArray(),2),
+                                                          fine.DistributionMap(), 1, 0));
+            ReduceOps<ReduceOpSum> reduce_op;
+            ReduceData<int> reduce_data(reduce_op);
+            using ReduceTuple = typename decltype(reduce_data)::Type;
+#ifdef _OPENMP
+#pragma omp parallel if (Gpu::notInLaunchRegion())
+#endif
+            for (MFIter mfi(*crse, TilingIfNotGPU()); mfi.isValid(); ++mfi)
+            {
+                const Box& bx = mfi.tilebox();
+                Array4<int const> const& fmsk = fine.const_array(mfi);
+                Array4<int> const& cmsk = crse->array(mfi);
+                reduce_op.eval(bx, reduce_data,
+                [=] AMREX_GPU_HOST_DEVICE (Box const& b) -> ReduceTuple
+                {
+                    return { coarsen_overset_mask(b, cmsk, fmsk) };
+                });
+            }
+            ReduceTuple hv = reduce_data.value();
+            if (amrex::get<0>(hv) == 0) {
+                m_overset_mask[amrlev].push_back(std::move(crse));
+                max_overset_mask_coarsening_level = mglev;
+            } else {
+                break;
+            }
+        } else {
+            break;
+        }
+    }
+
+    LPInfo info = a_info;
+    info.max_coarsening_level = std::min(a_info.max_coarsening_level,
+                                         max_overset_mask_coarsening_level);
+    define(a_geom, a_grids, a_dmap, info, a_factory);
+
+    amrlev = 0;
+    for (int mglev = 1; mglev < m_num_mg_levels[amrlev]; ++mglev) {
+        if (! isMFIterSafe(*m_overset_mask[amrlev][mglev], m_a_coeffs[amrlev][mglev])) {
+            std::unique_ptr<iMultiFab> osm(new iMultiFab(m_grids[amrlev][mglev],
+                                                         m_dmap[amrlev][mglev], 1, 0));
+            osm->ParallelCopy(*m_overset_mask[amrlev][mglev]);
+            std::swap(osm, m_overset_mask[amrlev][mglev]);
         }
     }
 }
@@ -123,7 +212,6 @@ MLABecLaplacian::setBCoeffs (int amrlev, Vector<Real> const& beta)
     }
     m_needs_update = true;
 }
-
 
 void
 MLABecLaplacian::averageDownCoeffs ()
@@ -211,6 +299,8 @@ MLABecLaplacian::prepareForSolve ()
 
     MLCellABecLap::prepareForSolve();
 
+    const int ncomp = getNComp();
+
 #if (AMREX_SPACEDIM != 3)
     applyMetricTermsCoeffs();
 #endif
@@ -273,12 +363,20 @@ MLABecLaplacian::Fapply (int amrlev, int mglev, MultiFab& out, const MultiFab& i
         AMREX_D_TERM(const auto& bxfab = bxcoef.array(mfi);,
                      const auto& byfab = bycoef.array(mfi);,
                      const auto& bzfab = bzcoef.array(mfi););
-
-        AMREX_LAUNCH_HOST_DEVICE_LAMBDA ( bx, tbx,
-        {
-            mlabeclap_adotx(tbx, yfab, xfab, afab, AMREX_D_DECL(bxfab,byfab,bzfab),
-                            dxinv, ascalar, bscalar, ncomp);
-        });
+        if (m_overset_mask[amrlev][mglev]) {
+            const auto& osm = m_overset_mask[amrlev][mglev]->array(mfi);
+            AMREX_LAUNCH_HOST_DEVICE_LAMBDA ( bx, tbx,
+            {
+                mlabeclap_adotx_os(tbx, yfab, xfab, afab, AMREX_D_DECL(bxfab,byfab,bzfab),
+                                   osm, dxinv, ascalar, bscalar, ncomp);
+            });
+        } else {
+            AMREX_LAUNCH_HOST_DEVICE_LAMBDA ( bx, tbx,
+            {
+                mlabeclap_adotx(tbx, yfab, xfab, afab, AMREX_D_DECL(bxfab,byfab,bzfab),
+                                dxinv, ascalar, bscalar, ncomp);
+            });
+        }
     }
 }
 
@@ -417,29 +515,60 @@ MLABecLaplacian::Fsmooth (int amrlev, int mglev, MultiFab& sol, const MultiFab& 
 #endif
         Gpu::AsyncArray<Array4<Real const> > aa(ha.data(), 2*AMREX_SPACEDIM);
         auto dp = aa.data();
-        AMREX_LAUNCH_HOST_DEVICE_LAMBDA ( tbx, thread_box,
-        {
-            abec_gsrb(thread_box, solnfab, rhsfab, alpha, afab,
-                      AMREX_D_DECL(dhx, dhy, dhz),
-                      AMREX_D_DECL(bxfab, byfab, bzfab),
-                      AMREX_D_DECL(m0,m2,m4),
-                      AMREX_D_DECL(m1,m3,m5),
-                      AMREX_D_DECL(dp[0],dp[2],dp[4]),
-                      AMREX_D_DECL(dp[1],dp[3],dp[5]),
-                      vbx, redblack, nc);
-        });
+
+        if (m_overset_mask[amrlev][mglev]) {
+            const auto& osm = m_overset_mask[amrlev][mglev]->array(mfi);
+            AMREX_LAUNCH_HOST_DEVICE_LAMBDA ( tbx, thread_box,
+            {
+                abec_gsrb_os(thread_box, solnfab, rhsfab, alpha, afab,
+                             AMREX_D_DECL(dhx, dhy, dhz),
+                             AMREX_D_DECL(bxfab, byfab, bzfab),
+                             AMREX_D_DECL(m0,m2,m4),
+                             AMREX_D_DECL(m1,m3,m5),
+                             AMREX_D_DECL(dp[0],dp[2],dp[4]),
+                             AMREX_D_DECL(dp[1],dp[3],dp[5]),
+                             osm, vbx, redblack, nc);
+            });
+        } else {
+            AMREX_LAUNCH_HOST_DEVICE_LAMBDA ( tbx, thread_box,
+            {
+                abec_gsrb(thread_box, solnfab, rhsfab, alpha, afab,
+                          AMREX_D_DECL(dhx, dhy, dhz),
+                          AMREX_D_DECL(bxfab, byfab, bzfab),
+                          AMREX_D_DECL(m0,m2,m4),
+                          AMREX_D_DECL(m1,m3,m5),
+                          AMREX_D_DECL(dp[0],dp[2],dp[4]),
+                          AMREX_D_DECL(dp[1],dp[3],dp[5]),
+                          vbx, redblack, nc);
+            });
+        }
 #else
-        AMREX_LAUNCH_HOST_DEVICE_LAMBDA ( tbx, thread_box,
-        {
-            abec_gsrb(thread_box, solnfab, rhsfab, alpha, afab,
-                      AMREX_D_DECL(dhx, dhy, dhz),
-                      AMREX_D_DECL(bxfab, byfab, bzfab),
-                      AMREX_D_DECL(m0,m2,m4),
-                      AMREX_D_DECL(m1,m3,m5),
-                      AMREX_D_DECL(f0fab,f2fab,f4fab),
-                      AMREX_D_DECL(f1fab,f3fab,f5fab),
-                      vbx, redblack, nc);
-        });
+        if (m_overset_mask[amrlev][mglev]) {
+            const auto& osm = m_overset_mask[amrlev][mglev]->array(mfi);
+            AMREX_LAUNCH_HOST_DEVICE_LAMBDA ( tbx, thread_box,
+            {
+                abec_gsrb_os(thread_box, solnfab, rhsfab, alpha, afab,
+                             AMREX_D_DECL(dhx, dhy, dhz),
+                             AMREX_D_DECL(bxfab, byfab, bzfab),
+                             AMREX_D_DECL(m0,m2,m4),
+                             AMREX_D_DECL(m1,m3,m5),
+                             AMREX_D_DECL(f0fab,f2fab,f4fab),
+                             AMREX_D_DECL(f1fab,f3fab,f5fab),
+                             osm, vbx, redblack, nc);
+            });
+        } else {
+            AMREX_LAUNCH_HOST_DEVICE_LAMBDA ( tbx, thread_box,
+            {
+                abec_gsrb(thread_box, solnfab, rhsfab, alpha, afab,
+                          AMREX_D_DECL(dhx, dhy, dhz),
+                          AMREX_D_DECL(bxfab, byfab, bzfab),
+                          AMREX_D_DECL(m0,m2,m4),
+                          AMREX_D_DECL(m1,m3,m5),
+                          AMREX_D_DECL(f0fab,f2fab,f4fab),
+                          AMREX_D_DECL(f1fab,f3fab,f5fab),
+                          vbx, redblack, nc);
+            });
+        }
 #endif
     }
 }
@@ -567,6 +696,37 @@ MLABecLaplacian::update ()
     }
 
     m_needs_update = false;
+}
+
+void
+MLABecLaplacian::interpolation (int amrlev, int fmglev, MultiFab& fine, const MultiFab& crse) const
+{
+    const int ncomp = getNComp();
+
+    if (m_overset_mask[amrlev][fmglev])
+    {
+#ifdef _OPENMP
+#pragma omp parallel if (Gpu::notInLaunchRegion())
+#endif
+        for (MFIter mfi(fine,TilingIfNotGPU()); mfi.isValid(); ++mfi)
+        {
+            const Box& bx    = mfi.tilebox();
+            Array4<Real const> const& cfab = crse.const_array(mfi);
+            Array4<Real> const& ffab = fine.array(mfi);
+            const auto& osm = m_overset_mask[amrlev][fmglev]->array(mfi);
+            AMREX_HOST_DEVICE_PARALLEL_FOR_4D ( bx, ncomp, i, j, k, n,
+            {
+                if (!osm(i,j,k)) {
+                    int ic = amrex::coarsen(i,2);
+                    int jc = amrex::coarsen(j,2);
+                    int kc = amrex::coarsen(k,2);
+                    ffab(i,j,k,n) += cfab(ic,jc,kc,n);
+                }
+            });
+        }
+    } else {
+        MLCellABecLap::interpolation(amrlev, fmglev, fine, crse);
+    }
 }
 
 }

--- a/Src/LinearSolvers/MLMG/AMReX_MLABecLaplacian.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLABecLaplacian.cpp
@@ -77,7 +77,7 @@ MLABecLaplacian::define (const Vector<Geometry>& a_geom,
     m_overset_mask.resize(namrlevs);
     for (int amrlev = 0; amrlev < namrlevs; ++amrlev)
     {
-        m_overset_mask[amrlev].emplace_back(new iMultiFab(a_grids[amrlev], a_dmap[amrlev], 1, 0));
+        m_overset_mask[amrlev].emplace_back(new iMultiFab(a_grids[amrlev], a_dmap[amrlev], 1, 1));
         iMultiFab::Copy(*m_overset_mask[amrlev][0], *a_overset_mask[amrlev], 0, 0, 1, 0);
         if (amrlev > 1) {
             AMREX_ALWAYS_ASSERT(amrex::refine(a_geom[amrlev-1].Domain(),2)
@@ -94,7 +94,7 @@ MLABecLaplacian::define (const Vector<Geometry>& a_geom,
         iMultiFab const& fine = *m_overset_mask[amrlev][mglev-1];
         if (dom.coarsenable(2) and fine.boxArray().coarsenable(2)) {
             std::unique_ptr<iMultiFab> crse(new iMultiFab(amrex::coarsen(fine.boxArray(),2),
-                                                          fine.DistributionMap(), 1, 0));
+                                                          fine.DistributionMap(), 1, 1));
             ReduceOps<ReduceOpSum> reduce_op;
             ReduceData<int> reduce_data(reduce_op);
             using ReduceTuple = typename decltype(reduce_data)::Type;
@@ -133,9 +133,16 @@ MLABecLaplacian::define (const Vector<Geometry>& a_geom,
     for (int mglev = 1; mglev < m_num_mg_levels[amrlev]; ++mglev) {
         if (! isMFIterSafe(*m_overset_mask[amrlev][mglev], m_a_coeffs[amrlev][mglev])) {
             std::unique_ptr<iMultiFab> osm(new iMultiFab(m_grids[amrlev][mglev],
-                                                         m_dmap[amrlev][mglev], 1, 0));
+                                                         m_dmap[amrlev][mglev], 1, 1));
             osm->ParallelCopy(*m_overset_mask[amrlev][mglev]);
             std::swap(osm, m_overset_mask[amrlev][mglev]);
+        }
+    }
+
+    for (int amrlev = 0; amrlev < m_num_amr_levels; ++amrlev) {
+        for (int mglev = 0; mglev < m_num_mg_levels[amrlev]; ++mglev) {
+            m_overset_mask[amrlev][mglev]->setBndry(0);
+            m_overset_mask[amrlev][mglev]->FillBoundary(m_geom[amrlev][mglev].periodicity());
         }
     }
 }
@@ -223,15 +230,15 @@ MLABecLaplacian::averageDownCoeffs ()
         auto& fine_a_coeffs = m_a_coeffs[amrlev];
         auto& fine_b_coeffs = m_b_coeffs[amrlev];
 
-        averageDownCoeffsSameAmrLevel(fine_a_coeffs, fine_b_coeffs);
+        averageDownCoeffsSameAmrLevel(amrlev, fine_a_coeffs, fine_b_coeffs);
         averageDownCoeffsToCoarseAmrLevel(amrlev);
     }
 
-    averageDownCoeffsSameAmrLevel(m_a_coeffs[0], m_b_coeffs[0]);
+    averageDownCoeffsSameAmrLevel(0, m_a_coeffs[0], m_b_coeffs[0]);
 }
 
 void
-MLABecLaplacian::averageDownCoeffsSameAmrLevel (Vector<MultiFab>& a,
+MLABecLaplacian::averageDownCoeffsSameAmrLevel (int amrlev, Vector<MultiFab>& a,
                                                 Vector<Array<MultiFab,AMREX_SPACEDIM> >& b)
 {
     int nmglevs = a.size();
@@ -254,6 +261,41 @@ MLABecLaplacian::averageDownCoeffsSameAmrLevel (Vector<MultiFab>& a,
                                              &(b[mglev][2]))};
         IntVect ratio {mg_coarsen_ratio};
         amrex::average_down_faces(fine, crse, ratio, 0);
+    }
+
+    for (int mglev = 1; mglev < nmglevs; ++mglev)
+    {
+        if (m_overset_mask[amrlev][mglev]) {
+            const Real fac = static_cast<Real>(1 << mglev); // 2**mglev
+            const Real osfac = 2.0*fac/(fac+1.0);
+            const int ncomp = getNComp();
+#ifdef _OPENMP
+#pragma omp parallel if (Gpu::notInLaunchRegion())
+#endif
+            for (MFIter mfi(a[mglev],TilingIfNotGPU()); mfi.isValid(); ++mfi)
+            {
+                AMREX_D_TERM(Box const& xbx = mfi.nodaltilebox(0);,
+                             Box const& ybx = mfi.nodaltilebox(1);,
+                             Box const& zbx = mfi.nodaltilebox(2));
+                AMREX_D_TERM(Array4<Real> const& bx = b[mglev][0].array(mfi);,
+                             Array4<Real> const& by = b[mglev][1].array(mfi);,
+                             Array4<Real> const& bz = b[mglev][2].array(mfi));
+                Array4<int const> const& osm = m_overset_mask[amrlev][mglev]->const_array(mfi);
+                AMREX_LAUNCH_HOST_DEVICE_LAMBDA_DIM
+                    (xbx, t_xbx,
+                     {
+                         overset_rescale_bcoef_x(t_xbx, bx, osm, ncomp, osfac);
+                     },
+                     ybx, t_ybx,
+                     {
+                         overset_rescale_bcoef_y(t_ybx, by, osm, ncomp, osfac);
+                     },
+                     zbx, t_zbx,
+                     {
+                         overset_rescale_bcoef_z(t_zbx, bz, osm, ncomp, osfac);
+                     });
+            }
+        }
     }
 }
 
@@ -350,6 +392,9 @@ MLABecLaplacian::Fapply (int amrlev, int mglev, MultiFab& out, const MultiFab& i
     const Real bscalar = m_b_scalar;
 
     const int ncomp = getNComp();
+
+    const Real fac = static_cast<Real>(1 << mglev); // 2**mglev
+    const Real osfac = 2.0*fac/(fac+1.0);
 
 #ifdef _OPENMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())

--- a/Src/LinearSolvers/MLMG/AMReX_MLLinOp.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLLinOp.H
@@ -209,6 +209,7 @@ public:
 
     virtual void unimposeNeumannBC (int amrlev, MultiFab& rhs) const {} // only nodal solver might need it
     virtual void applyInhomogNeumannTerm (int amrlev, MultiFab& rhs) const {}
+    virtual void applyOverset (int amlev, MultiFab& rhs) const {}
 
     virtual void prepareForSolve () = 0;
     virtual bool isSingular (int amrlev) const = 0;

--- a/Src/LinearSolvers/MLMG/AMReX_MLMG.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLMG.cpp
@@ -1166,6 +1166,7 @@ MLMG::prepareForSolve (const Vector<MultiFab*>& a_sol, const Vector<MultiFab con
         linop.applyMetricTerm(alev, 0, rhs[alev]);
         linop.unimposeNeumannBC(alev, rhs[alev]);
         linop.applyInhomogNeumannTerm(alev, rhs[alev]);
+        linop.applyOverset(alev, rhs[alev]);
 
 #ifdef AMREX_USE_EB
         auto factory = dynamic_cast<EBFArrayBoxFactory const*>(linop.Factory(alev));

--- a/Tests/LinearSolvers/CellOverset/GNUmakefile
+++ b/Tests/LinearSolvers/CellOverset/GNUmakefile
@@ -1,0 +1,34 @@
+
+DEBUG = FALSE
+
+TEST = TRUE
+USE_ASSERTION = TRUE
+
+BL_NO_FORT = TRUE
+
+USE_EB = FALSE
+
+USE_MPI  = TRUE
+USE_OMP  = FALSE
+
+USE_HYPRE  = FALSE
+USE_PETSC  = FALSE
+
+COMP = gnu
+
+DIM = 2
+
+AMREX_HOME ?= ../../..
+
+include $(AMREX_HOME)/Tools/GNUMake/Make.defs
+include ./Make.package
+
+Pdirs := Base Boundary
+Pdirs += LinearSolvers/MLMG
+
+Ppack	+= $(foreach dir, $(Pdirs), $(AMREX_HOME)/Src/$(dir)/Make.package)
+
+include $(Ppack)
+
+include $(AMREX_HOME)/Tools/GNUMake/Make.rules
+

--- a/Tests/LinearSolvers/CellOverset/Make.package
+++ b/Tests/LinearSolvers/CellOverset/Make.package
@@ -1,0 +1,3 @@
+CEXE_sources += main.cpp
+CEXE_sources += MyTest.cpp
+CEXE_headers += MyTest.H

--- a/Tests/LinearSolvers/CellOverset/MyTest.H
+++ b/Tests/LinearSolvers/CellOverset/MyTest.H
@@ -1,0 +1,48 @@
+#ifndef MY_TEST_H_
+#define MY_TEST_H_
+
+#include <AMReX_MLMG.H>
+
+class MyTest
+{
+public:
+
+    MyTest ();
+
+    void solve ();
+    void writePlotfile ();
+    void initData ();
+
+private:
+
+    void readParameters ();
+    void initGrids ();
+
+    int n_cell = 128;
+    int max_grid_size = 64;
+
+    std::string plot_file_name{"plot"};
+
+    // For MLMG solver
+    int verbose = 2;
+    int bottom_verbose = 2;
+    int max_coarsening_level = 30;
+
+    amrex::Geometry geom;
+    amrex::BoxArray grids;
+    amrex::DistributionMapping dmap;
+
+    amrex::MultiFab phi;
+    amrex::MultiFab rhs;
+    amrex::MultiFab exact_phi;
+    amrex::MultiFab acoef;
+    amrex::MultiFab bcoef;
+
+    amrex::Real ascalar = 1.e-3;
+    amrex::Real bscalar = 1.0;
+
+    int do_overset = 1;
+    amrex::iMultiFab oversetmask;
+};
+
+#endif

--- a/Tests/LinearSolvers/CellOverset/MyTest.cpp
+++ b/Tests/LinearSolvers/CellOverset/MyTest.cpp
@@ -208,7 +208,6 @@ MyTest::initData ()
                 if (loverset and overset_box.contains(IntVect(AMREX_D_DECL(i,j,k)))) {
                     mask(i,j,k) = 1;
                     phifab(i,j,k) = exact(i,j,k);
-                    rhsfab(i,j,k) = 0.0;
                 } else {
                     mask(i,j,k) = 0;
                 }

--- a/Tests/LinearSolvers/CellOverset/MyTest.cpp
+++ b/Tests/LinearSolvers/CellOverset/MyTest.cpp
@@ -124,8 +124,8 @@ MyTest::initData ()
     bcoef.define(grids, dmap, 1, 1);
     oversetmask.define(grids, dmap, 1, 0);
 
-//xxxxxx    Box overset_box = amrex::grow(geom.Domain(), -n_cell/4);
-    Box overset_box = amrex::shift(geom.Domain(), 0, n_cell/2);
+    Box overset_box = amrex::grow(geom.Domain(), -n_cell/4); // middle of the domain
+    // Box overset_box = amrex::shift(geom.Domain(), 0, n_cell/2); // right half
 
     const auto prob_lo = geom.ProbLoArray();
     const auto prob_hi = geom.ProbHiArray();

--- a/Tests/LinearSolvers/CellOverset/MyTest.cpp
+++ b/Tests/LinearSolvers/CellOverset/MyTest.cpp
@@ -1,0 +1,218 @@
+#include "MyTest.H"
+
+#include <AMReX_MLABecLaplacian.H>
+#include <AMReX_ParmParse.H>
+#include <AMReX_MultiFabUtil.H>
+#include <AMReX_PlotFileUtil.H>
+
+using namespace amrex;
+
+MyTest::MyTest ()
+{
+    readParameters();
+
+    initGrids();
+
+    initData();
+}
+
+//
+// Solve L(phi) = rhs
+//
+void
+MyTest::solve ()
+{
+    std::array<LinOpBCType,AMREX_SPACEDIM> mlmg_lobc;
+    std::array<LinOpBCType,AMREX_SPACEDIM> mlmg_hibc;
+    for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+        mlmg_lobc[idim] = LinOpBCType::Dirichlet;
+        mlmg_hibc[idim] = LinOpBCType::Dirichlet;
+    }
+
+    LPInfo info;
+    info.setMaxCoarseningLevel(max_coarsening_level);
+
+    std::unique_ptr<MLABecLaplacian> mlabec;
+    if (do_overset) {
+        mlabec.reset(new MLABecLaplacian({geom}, {grids}, {dmap}, {&oversetmask}, info));
+    } else {
+        mlabec.reset(new MLABecLaplacian({geom}, {grids}, {dmap}, info));
+    }
+
+    mlabec->setDomainBC(mlmg_lobc, mlmg_hibc);
+    mlabec->setLevelBC(0, &exact_phi);
+
+    mlabec->setScalars(ascalar, bscalar);
+    mlabec->setACoeffs(0, acoef);
+
+    Array<MultiFab,AMREX_SPACEDIM> face_bcoef;
+    for (int idim = 0; idim < AMREX_SPACEDIM; ++idim)
+    {
+        const BoxArray& ba = amrex::convert(bcoef.boxArray(),
+                                            IntVect::TheDimensionVector(idim));
+        face_bcoef[idim].define(ba, bcoef.DistributionMap(), 1, 0);
+    }
+    amrex::average_cellcenter_to_face(GetArrOfPtrs(face_bcoef),
+                                      bcoef, geom);
+    mlabec->setBCoeffs(0, amrex::GetArrOfConstPtrs(face_bcoef));
+
+    MLMG mlmg(*mlabec);
+    mlmg.setVerbose(verbose);
+    mlmg.setBottomVerbose(bottom_verbose);
+
+    // In region with overset mask = 0, phi has valid solution and rhs is zero.
+    Real mlmg_err = mlmg.solve({&phi}, {&rhs}, 1.e-11, 0.0);
+}
+
+void
+MyTest::writePlotfile ()
+{
+    Vector<std::string> varname = {"solution", "rhs", "exact_solution", "error", "acoef", "bcoef"};
+    MultiFab plotmf(grids, dmap, varname.size(), 0);
+    MultiFab::Copy(plotmf, phi       , 0, 0, 1, 0);
+    MultiFab::Copy(plotmf, rhs       , 0, 1, 1, 0);
+    MultiFab::Copy(plotmf, exact_phi , 0, 2, 1, 0);
+    MultiFab::Copy(plotmf, phi       , 0, 3, 1, 0);
+    MultiFab::Subtract(plotmf, plotmf, 2, 3, 1, 0); // error = soln - exact
+    MultiFab::Copy(plotmf, acoef     , 0, 4, 1, 0);
+    MultiFab::Copy(plotmf, bcoef     , 0, 5, 1, 0);
+    auto dx = geom.CellSize();
+    Real dvol = AMREX_D_TERM(dx[0],*dx[1],*dx[2]);
+    amrex::Print() << " max-norm error: " << plotmf.norminf(3)
+                   << " 1-norm error: " << plotmf.norm1(3)*dvol << std::endl;
+    WriteSingleLevelPlotfile("plot", plotmf, varname, geom, 0.0, 0);
+}
+
+void
+MyTest::readParameters ()
+{
+    ParmParse pp;
+    pp.query("n_cell", n_cell);
+    pp.query("max_grid_size", max_grid_size);
+
+    pp.query("plot_file", plot_file_name);
+
+    pp.query("verbose", verbose);
+    pp.query("bottom_verbose", bottom_verbose);
+    pp.query("max_coarsening_level", max_coarsening_level);
+
+    pp.query("do_overset", do_overset);
+}
+
+void
+MyTest::initGrids ()
+{
+    RealBox rb({AMREX_D_DECL(0.,0.,0.)}, {AMREX_D_DECL(1.,1.,1.)});
+    std::array<int,AMREX_SPACEDIM> isperiodic{AMREX_D_DECL(0,0,0)};
+    Geometry::Setup(&rb, 0, isperiodic.data());
+    Box domain(IntVect{AMREX_D_DECL(0,0,0)}, IntVect{AMREX_D_DECL(n_cell-1,n_cell-1,n_cell-1)});
+    geom.define(domain, rb, CoordSys::cartesian, isperiodic);
+
+    grids.define(domain);
+    grids.maxSize(max_grid_size);
+}
+
+void
+MyTest::initData ()
+{
+    dmap.define(grids);
+
+    phi.define(grids, dmap, 1, 1);
+    rhs.define(grids, dmap, 1, 0);
+    exact_phi.define(grids, dmap, 1, 1);
+    acoef.define(grids, dmap, 1, 0);
+    bcoef.define(grids, dmap, 1, 1);
+    oversetmask.define(grids, dmap, 1, 0);
+
+//xxxxxx    Box overset_box = amrex::grow(geom.Domain(), -n_cell/4);
+    Box overset_box = amrex::shift(geom.Domain(), 0, n_cell/2);
+
+    const auto prob_lo = geom.ProbLoArray();
+    const auto prob_hi = geom.ProbHiArray();
+    const auto dx      = geom.CellSizeArray();
+    auto a = ascalar;
+    auto b = bscalar;
+    auto loverset = do_overset;
+#ifdef _OPENMP
+#pragma omp parallel if (Gpu::notInLaunchRegion())
+#endif
+    for (MFIter mfi(rhs, TilingIfNotGPU()); mfi.isValid(); ++mfi)
+    {
+        const Box& vbx = mfi.tilebox();
+        const Box& gbx = mfi.growntilebox(1);
+
+        auto phifab = phi.array(mfi);
+        auto rhsfab = rhs.array(mfi);
+        auto exact = exact_phi.array(mfi);
+        auto alpha = acoef.array(mfi);
+        auto beta = bcoef.array(mfi);
+        auto mask = oversetmask.array(mfi);
+
+        amrex::ParallelFor(gbx,
+        [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        {
+            constexpr amrex::Real w = 0.05;
+            constexpr amrex::Real sigma = 10.;
+            const amrex::Real theta = 0.5*std::log(3.) / (w + 1.e-50);
+
+            constexpr amrex::Real pi = 3.1415926535897932;
+            constexpr amrex::Real tpi =  2.*pi;
+            constexpr amrex::Real fpi =  4.*pi;
+            constexpr amrex::Real fac = static_cast<amrex::Real>(AMREX_SPACEDIM)*4.*pi*pi;
+
+            amrex::Real xc = (prob_hi[0] + prob_lo[0])*0.5;
+            amrex::Real yc = (prob_hi[1] + prob_lo[1])*0.5;
+#if (AMREX_SPACEDIM == 2)
+            amrex::Real zc = 0.0;
+#else
+            amrex::Real zc = (prob_hi[2] + prob_lo[2])*0.5;
+#endif
+
+            amrex::Real x = prob_lo[0] + dx[0] * (i + 0.5);
+            amrex::Real y = prob_lo[1] + dx[1] * (j + 0.5);
+#if (AMREX_SPACEDIM == 2)
+            amrex::Real z = 0.0;
+#else
+            amrex::Real z = prob_lo[2] + dx[2] * (k + 0.5);
+#endif
+
+            amrex::Real r = std::sqrt((x-xc)*(x-xc) + (y-yc)*(y-yc) + (z-zc)*(z-zc));
+            amrex::Real tmp = std::cosh(theta*(r-0.25));
+            amrex::Real dbdrfac = (sigma-1.)/2./(tmp*tmp) * theta/r;
+            dbdrfac *= b;
+
+            // for domain boundary
+            x = amrex::min(prob_hi[0], amrex::max(prob_lo[0], x));
+            y = amrex::min(prob_hi[1], amrex::max(prob_lo[1], y));
+#if (AMREX_SPACEDIM == 3)
+            z = amrex::min(prob_hi[2], amrex::max(prob_lo[2], z));
+#endif
+
+            beta(i,j,k) = (sigma-1.)/2.*std::tanh(theta*(r-0.25)) + (sigma+1.)/2.;
+            exact(i,j,k) = std::cos(tpi*x) * std::cos(tpi*y) * std::cos(tpi*z)
+                   + .25 * std::cos(fpi*x) * std::cos(fpi*y) * std::cos(fpi*z);
+            phifab(i,j,k) = 0.0;
+
+            if (vbx.contains(IntVect(AMREX_D_DECL(i,j,k)))) {
+                alpha(i,j,k) = 1.;
+                rhsfab(i,j,k) = beta(i,j,k)*b*fac*(std::cos(tpi*x) * std::cos(tpi*y) * std::cos(tpi*z)
+                                                 + std::cos(fpi*x) * std::cos(fpi*y) * std::cos(fpi*z))
+                            + dbdrfac*((x-xc)*(tpi*std::sin(tpi*x) * std::cos(tpi*y) * std::cos(tpi*z)
+                                              + pi*std::sin(fpi*x) * std::cos(fpi*y) * std::cos(fpi*z))
+                                     + (y-yc)*(tpi*std::cos(tpi*x) * std::sin(tpi*y) * std::cos(tpi*z)
+                                              + pi*std::cos(fpi*x) * std::sin(fpi*y) * std::cos(fpi*z))
+                                     + (z-zc)*(tpi*std::cos(tpi*x) * std::cos(tpi*y) * std::sin(tpi*z)
+                                              + pi*std::cos(fpi*x) * std::cos(fpi*y) * std::sin(fpi*z)))
+                                            + a * (std::cos(tpi*x) * std::cos(tpi*y) * std::cos(tpi*z)
+                                          + 0.25 * std::cos(fpi*x) * std::cos(fpi*y) * std::cos(fpi*z));
+                if (loverset and overset_box.contains(IntVect(AMREX_D_DECL(i,j,k)))) {
+                    mask(i,j,k) = 1;
+                    phifab(i,j,k) = exact(i,j,k);
+                    rhsfab(i,j,k) = 0.0;
+                } else {
+                    mask(i,j,k) = 0;
+                }
+            }
+        });
+    }
+}

--- a/Tests/LinearSolvers/CellOverset/main.cpp
+++ b/Tests/LinearSolvers/CellOverset/main.cpp
@@ -1,0 +1,17 @@
+
+#include <AMReX.H>
+#include <AMReX_ParmParse.H>
+#include "MyTest.H"
+
+int main (int argc, char* argv[])
+{
+    amrex::Initialize(argc, argv);
+
+    {
+        MyTest mytest;
+        mytest.solve();
+        mytest.writePlotfile();
+    }
+
+    amrex::Finalize();
+}


### PR DESCRIPTION
The user needs to pass a mask the the constructor of `MLABecLapalcian`.   The mask is 1 for overset region and 0 otherwise.  The overset region's solution is passed in the `MulitFab` argument to `MLMG::solve`.
