### PR TITLE
Allow customization of the allocator used for ParticleTile

### DIFF
--- a/Src/Base/AMReX_GpuAllocators.H
+++ b/Src/Base/AMReX_GpuAllocators.H
@@ -164,8 +164,13 @@ namespace amrex {
 
 #endif // AMREX_USE_GPU
 
+#ifdef AMREX_USE_GPU
+    template <class T>
+    using DefaultAllocator = amrex::ArenaAllocator<T>;
+#else
     template <class T>
     using DefaultAllocator = std::allocator<T>;
+#endif // AMREX_USE_GPU
 
 } // namespace amrex
 

--- a/Src/Base/AMReX_GpuAllocators.H
+++ b/Src/Base/AMReX_GpuAllocators.H
@@ -20,9 +20,7 @@ namespace amrex {
 
     template <typename T>
     struct RunOnGpu : std::false_type {};
-        
-#ifdef AMREX_USE_GPU
-  
+
     template<typename T>
     class ArenaAllocator
     {
@@ -33,14 +31,14 @@ namespace amrex {
         inline value_type* allocate(std::size_t n)
         {
 	    value_type* result = nullptr;
-            result = (value_type*) The_Arena()->alloc(n * sizeof(T));  
+            result = (value_type*) The_Arena()->alloc(n * sizeof(T));
 	    return result;
         }
-    
+
         inline void deallocate(value_type* ptr, std::size_t)
         {
             The_Arena()->free(ptr);
-        }    
+        }
     };
 
     template<typename T>
@@ -53,14 +51,14 @@ namespace amrex {
         inline value_type* allocate(std::size_t n)
         {
 	    value_type* result = nullptr;
-            result = (value_type*) The_Device_Arena()->alloc(n * sizeof(T));  
+            result = (value_type*) The_Device_Arena()->alloc(n * sizeof(T));
 	    return result;
         }
-    
+
         inline void deallocate(value_type* ptr, std::size_t)
         {
             The_Device_Arena()->free(ptr);
-        }    
+        }
     };
 
     template<typename T>
@@ -73,14 +71,14 @@ namespace amrex {
         inline value_type* allocate(std::size_t n)
         {
 	    value_type* result = nullptr;
-            result = (value_type*) The_Pinned_Arena()->alloc(n * sizeof(T));  
+            result = (value_type*) The_Pinned_Arena()->alloc(n * sizeof(T));
 	    return result;
         }
-    
+
         inline void deallocate(value_type* ptr, std::size_t)
         {
             The_Pinned_Arena()->free(ptr);
-        }    
+        }
     };
 
     template<typename T>
@@ -93,14 +91,14 @@ namespace amrex {
         inline value_type* allocate(std::size_t n)
         {
 	    value_type* result = nullptr;
-            result = (value_type*) The_Managed_Arena()->alloc(n * sizeof(T));  
+            result = (value_type*) The_Managed_Arena()->alloc(n * sizeof(T));
 	    return result;
         }
-    
+
         inline void deallocate(value_type* ptr, std::size_t)
         {
             The_Managed_Arena()->free(ptr);
-        }    
+        }
     };
 
     template<typename T>
@@ -113,7 +111,7 @@ namespace amrex {
         inline value_type* allocate(std::size_t n)
         {
 	    value_type* result = nullptr;
-            if (ParallelDescriptor::UseGpuAwareMpi()) 
+            if (ParallelDescriptor::UseGpuAwareMpi())
             {
                 result = (value_type*) The_Device_Arena()->alloc(n * sizeof(T));
             }
@@ -123,10 +121,10 @@ namespace amrex {
             }
 	    return result;
         }
-    
+
         inline void deallocate(value_type* ptr, std::size_t)
         {
-            if (ParallelDescriptor::UseGpuAwareMpi()) 
+            if (ParallelDescriptor::UseGpuAwareMpi())
             {
                 The_Device_Arena()->free(ptr);
             }
@@ -134,7 +132,7 @@ namespace amrex {
             {
                 The_Pinned_Arena()->free(ptr);
             }
-        }    
+        }
     };
 
     template <template <typename> class Allocator, class T, class U>
@@ -143,13 +141,17 @@ namespace amrex {
     {
         return true;
     }
-    
+
     template <template <typename> class Allocator, class T, class U>
     bool
     operator!=(Allocator<T> const& x, Allocator<U> const& y) noexcept
     {
         return !(x == y);
     }
+
+#ifdef AMREX_USE_GPU
+    template <class T>
+    using DefaultAllocator = amrex::ArenaAllocator<T>;
 
     template <typename T>
     struct RunOnGpu<ArenaAllocator<T> > : std::true_type {};
@@ -161,6 +163,9 @@ namespace amrex {
     struct RunOnGpu<ManagedArenaAllocator<T> > : std::true_type {};
 
 #endif // AMREX_USE_GPU
+
+    template <class T>
+    using DefaultAllocator = std::allocator<T>;
 
 } // namespace amrex
 

--- a/Src/Particle/AMReX_ArrayOfStructs.H
+++ b/Src/Particle/AMReX_ArrayOfStructs.H
@@ -7,13 +7,14 @@
 
 namespace amrex {
 
-template <int NReal, int NInt>
+template <int NReal, int NInt,
+          template<class> class Allocator=DefaultAllocator>
 class ArrayOfStructs {
 public:
     using ParticleType  = Particle<NReal, NInt>;
     using RealType      = typename ParticleType::RealType;
 
-    using ParticleVector = Gpu::DeviceVector<ParticleType>;
+    using ParticleVector = amrex::PODVector<ParticleType, Allocator<ParticleType> >;
 
     using Iterator      = typename ParticleVector::iterator;
     using ConstIterator = typename ParticleVector::const_iterator;
@@ -107,8 +108,11 @@ public:
 private:
     ParticleVector m_data;
 };
+
 #if __cplusplus < 201703L
-template <int NReal, int NInt> constexpr int ArrayOfStructs<NReal, NInt>::SizeInReal;
+template <int NReal, int NInt,
+          template<class> class Allocator>
+constexpr int ArrayOfStructs<NReal, NInt, Allocator>::SizeInReal;
 #endif
 
 } // namespace amrex

--- a/Src/Particle/AMReX_ParticleTile.H
+++ b/Src/Particle/AMReX_ParticleTile.H
@@ -14,14 +14,14 @@ template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt>
 struct ParticleTileData
 {
     static constexpr int NAR = NArrayReal;
-    static constexpr int NAI = NArrayInt;    
+    static constexpr int NAI = NArrayInt;
     using ParticleType = Particle<NStructReal, NStructInt>;
     using SuperParticleType = Particle<NStructReal+NArrayReal, NStructInt+NArrayInt>;
 
     Long m_size;
     ParticleType* AMREX_RESTRICT m_aos;
     GpuArray<ParticleReal* AMREX_RESTRICT, NArrayReal> m_rdata;
-    GpuArray<int* AMREX_RESTRICT, NArrayInt> m_idata;    
+    GpuArray<int* AMREX_RESTRICT, NArrayInt> m_idata;
 
     int m_num_runtime_real;
     int m_num_runtime_int;
@@ -67,7 +67,7 @@ struct ParticleTileData
                 memcpy(dst, m_runtime_idata[i] + src_index, sizeof(int));
                 dst += sizeof(int);
             }
-        }        
+        }
     }
 
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
@@ -231,17 +231,18 @@ struct ConstParticleTileData
     }
 };
 
-template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt>
+template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt,
+          template<class> class Allocator=DefaultAllocator>
 struct ParticleTile
 {
     using ParticleType = Particle<NStructReal, NStructInt>;
     static constexpr int NAR = NArrayReal;
     static constexpr int NAI = NArrayInt;
 
-    using AoS = ArrayOfStructs<NStructReal, NStructInt>;
+    using AoS = ArrayOfStructs<NStructReal, NStructInt, Allocator>;
     using ParticleVector = typename AoS::ParticleVector;
 
-    using SoA = StructOfArrays<NArrayReal, NArrayInt>;
+    using SoA = StructOfArrays<NArrayReal, NArrayInt, Allocator>;
     using RealVector = typename SoA::RealVector;
     using IntVector = typename SoA::IntVector;
 
@@ -261,7 +262,7 @@ struct ParticleTile
         m_runtime_r_cptrs.resize(a_num_runtime_real);
         m_runtime_i_cptrs.resize(a_num_runtime_int);
     }
-    
+
     AoS&       GetArrayOfStructs ()       { return m_aos_tile; }
     const AoS& GetArrayOfStructs () const { return m_aos_tile; }
 
@@ -269,7 +270,7 @@ struct ParticleTile
     const SoA& GetStructOfArrays () const { return m_soa_tile; }
 
     bool empty () const { return m_aos_tile.empty(); }
-    
+
     /**
     * \brief Returns the total number of particles (real and neighbor)
     *

--- a/Src/Particle/AMReX_ParticleTile.H
+++ b/Src/Particle/AMReX_ParticleTile.H
@@ -294,7 +294,7 @@ struct ParticleTile
     * \brief Returns the number of neighbor particles (excluding reals)
     *
     */
-    int numNeighborParticles () const { return m_aos_tile.numNeighborParticles(); }    
+    int numNeighborParticles () const { return m_aos_tile.numNeighborParticles(); }
 
     /**
     * \brief Returns the total number of particles, real and neighbor
@@ -302,13 +302,13 @@ struct ParticleTile
     */
     int numTotalParticles () const { return m_aos_tile.numTotalParticles() ; }
 
-    void setNumNeighbors (int num_neighbors) 
+    void setNumNeighbors (int num_neighbors)
     {
         m_soa_tile.setNumNeighbors(num_neighbors);
         m_aos_tile.setNumNeighbors(num_neighbors);
     }
 
-    int getNumNeighbors () 
+    int getNumNeighbors ()
     {
         AMREX_ASSERT( m_soa_tile.getNumNeighbors() == m_aos_tile.getNumNeighbors() );
         return m_aos_tile.getNumNeighbors();
@@ -329,7 +329,7 @@ struct ParticleTile
     /// Add a Real value to the struct-of-arrays at index comp.
     /// This sets the data for one particle.
     ///
-    void push_back_real (int comp, ParticleReal v) { 
+    void push_back_real (int comp, ParticleReal v) {
         m_soa_tile.GetRealData(comp).push_back(v);
     }
 
@@ -337,7 +337,7 @@ struct ParticleTile
     /// Add Real values to the struct-of-arrays, for all comps at once.
     /// This sets the data for one particle.
     ///
-    void push_back_real (const std::array<ParticleReal, NArrayReal>& v) { 
+    void push_back_real (const std::array<ParticleReal, NArrayReal>& v) {
         for (int i = 0; i < NArrayReal; ++i) {
             m_soa_tile.GetRealData(i).push_back(v[i]);
         }
@@ -506,11 +506,11 @@ private:
 
     bool m_defined;
 
-    Gpu::DeviceVector<ParticleReal*> m_runtime_r_ptrs;
-    Gpu::DeviceVector<int*> m_runtime_i_ptrs;
+    amrex::PODVector<ParticleReal*, Allocator<ParticleReal*> > m_runtime_r_ptrs;
+    amrex::PODVector<int*, Allocator<int*> > m_runtime_i_ptrs;
 
-    mutable Gpu::DeviceVector<const ParticleReal*> m_runtime_r_cptrs;
-    mutable Gpu::DeviceVector<const int*> m_runtime_i_cptrs;
+    mutable amrex::PODVector<const ParticleReal*, Allocator<const ParticleReal*> > m_runtime_r_cptrs;
+    mutable amrex::PODVector<const int*, Allocator<const int*> >m_runtime_i_cptrs;
 };
 
 } // namespace amrex;

--- a/Src/Particle/AMReX_StructOfArrays.H
+++ b/Src/Particle/AMReX_StructOfArrays.H
@@ -9,11 +9,12 @@
 
 namespace amrex {
 
-template <int NReal, int NInt>
+template <int NReal, int NInt,
+          template<class> class Allocator=DefaultAllocator>
 struct StructOfArrays {
 
-    using RealVector = Gpu::DeviceVector<ParticleReal>;
-    using IntVector = Gpu::DeviceVector<int>;    
+    using RealVector = amrex::PODVector<ParticleReal, Allocator<ParticleReal> >;
+    using IntVector = amrex::PODVector<int, Allocator<int> >;
 
     StructOfArrays()
         : m_num_neighbor_particles(0),
@@ -26,7 +27,7 @@ struct StructOfArrays {
         m_runtime_rdata.resize(a_num_runtime_real);
         m_runtime_idata.resize(a_num_runtime_int );
     }
-    
+
     int NumRealComps () const noexcept { return NReal + m_runtime_rdata.size(); }
 
     int NumIntComps () const noexcept { return NInt + m_runtime_idata.size(); }
@@ -45,7 +46,7 @@ struct StructOfArrays {
             return m_runtime_rdata[index - NReal];
         }
     }
-    
+
     const RealVector& GetRealData (const int index) const {
         AMREX_ASSERT(index < NReal + m_runtime_rdata.size());
         if (index < NReal) return m_rdata[index];
@@ -63,7 +64,7 @@ struct StructOfArrays {
             return m_runtime_idata[index - NInt];
         }
    }
-    
+
     const IntVector& GetIntData (const int index) const {
         AMREX_ASSERT(size_t(index) < NInt + m_runtime_idata.size());
         if (index < NInt) return m_idata[index];
@@ -81,7 +82,7 @@ struct StructOfArrays {
     {
         if (NReal > 0)
             return m_rdata[0].size();
-        else if (NInt > 0) 
+        else if (NInt > 0)
             return m_idata[0].size();
         else if (m_runtime_rdata.size() > 0)
             return m_runtime_rdata[0].size();
@@ -90,7 +91,7 @@ struct StructOfArrays {
         else
             return 0;
     }
-    
+
     /**
     * \brief Returns the number of real particles (excluding neighbors)
     *
@@ -116,7 +117,7 @@ struct StructOfArrays {
     int numTotalParticles () const { return size(); }
 
     void setNumNeighbors (int num_neighbors)
-    { 
+    {
         auto nrp = numRealParticles();
         m_num_neighbor_particles = num_neighbors;
         resize(nrp + num_neighbors);
@@ -127,7 +128,7 @@ struct StructOfArrays {
     void resize (size_t count)
     {
         for (int i = 0; i < NReal; ++i) m_rdata[i].resize(count);
-        for (int i = 0; i < NInt;  ++i) m_idata[i].resize(count); 
+        for (int i = 0; i < NInt;  ++i) m_idata[i].resize(count);
         for (int i = 0; i < (int) m_runtime_rdata.size(); ++i) m_runtime_rdata[i].resize(count);
         for (int i = 0; i < (int) m_runtime_idata.size(); ++i) m_runtime_idata[i].resize(count);
     }
@@ -160,7 +161,7 @@ private:
 
     std::vector<RealVector> m_runtime_rdata;
     std::vector<IntVector > m_runtime_idata;
-    
+
     bool m_defined;
 };
 


### PR DESCRIPTION
This will let us, for example, make temporary pinned particle buffers for IO. 