### PR TITLE
Remove CCSE-specific info from Tools/GNUMake.

### DIFF
--- a/Tools/GNUMake/Make.machines
+++ b/Tools/GNUMake/Make.machines
@@ -14,14 +14,6 @@ endif
 
 # MACHINES supported
 
-CCSE_MACHINES := angilas atragon baragon battra ebirah gamera garuda gigan
-CCSE_MACHINES += gimantis godzilla gojira hedorah kiryu kumonga manda
-CCSE_MACHINES += megalon mothra rodan varan naphta orga ghidorah
-ifeq ($(host_name), $(findstring $(host_name), $(CCSE_MACHINES)))
-  which_site := ccse
-  which_computer := $(host_name)
-endif
-
 ifeq ($(findstring cori, $(host_name)), cori)
   which_site := nersc
   which_computer := cori

--- a/Tools/GNUMake/sites/Make.ccse
+++ b/Tools/GNUMake/sites/Make.ccse
@@ -1,9 +1,0 @@
-#
-# CCSE machines just use the default now
-#
-
-include $(AMREX_HOME)/Tools/GNUMake/sites/Make.unknown
-
-ifeq ($(which_computer),garuda)
-  CUDA_ARCH=75
-endif


### PR DESCRIPTION
Remove ccse-machine-specific information from Tools/GNUMake (it has already been removed for cmake)