### PR TITLE
dpc++: unless explicitly specified, use default standard, which is c+…

### DIFF
--- a/Tools/CMake/AMReXSYCL.cmake
+++ b/Tools/CMake/AMReXSYCL.cmake
@@ -25,6 +25,8 @@ set(_cxx_clang "$<AND:$<COMPILE_LANGUAGE:CXX>,$<CXX_COMPILER_ID:Clang>>") # Only
 add_library(SYCL INTERFACE)
 add_library(AMReX::SYCL ALIAS SYCL)
 
+target_compile_features(SYCL INTERFACE cxx_std_17)
+
 target_link_libraries(SYCL INTERFACE ${LIBSYCL_GLIBC_OBJ})
 
 target_compile_options( SYCL

--- a/Tools/GNUMake/comps/dpcpp.mak
+++ b/Tools/GNUMake/comps/dpcpp.mak
@@ -47,12 +47,10 @@ endif
 ########################################################################
 
 ifdef CXXSTD
-  CXXSTD := $(strip $(CXXSTD))
-else
-  CXXSTD := c++14
+  CXXFLAGS += -std=$(strip $(CXXSTD))
 endif
 
-CXXFLAGS += -std=$(CXXSTD) -Wno-error=sycl-strict -fsycl -fsycl-unnamed-lambda
+CXXFLAGS += -Wno-error=sycl-strict -fsycl -fsycl-unnamed-lambda
 CFLAGS   += -std=c99
 
 ifneq ($(DEBUG),TRUE)  # There is currently a bug that DEBUG build will crash.


### PR DESCRIPTION
…+ 17 in beta 7