### PR TITLE
[WIP] CMake: Assertions & FPEs in Subprojects

### DIFF
--- a/Tools/CMake/AMReX_Options.cmake
+++ b/Tools/CMake/AMReX_Options.cmake
@@ -206,17 +206,19 @@ endif ()
 option( ENABLE_PIC "Build position-independent code" OFF)
 print_option( ENABLE_PIC )
 
-option(ENABLE_FPE "Enable Floating Point Exceptions checks" OFF)
-print_option( ENABLE_FPE )
-
+set(ENABLE_FPE_DEFAULT OFF)
 set(ENABLE_ASSERTIONS_DEFAULT OFF)
 if ( "${CMAKE_BUILD_TYPE}" MATCHES "Debug" )
    set(ENABLE_ASSERTIONS_DEFAULT ON)
+   set(ENABLE_FPE_DEFAULT ON)
 endif ()
 cmake_dependent_option(ENABLE_ASSERTIONS "Enable assertions" ENABLE_ASSERTIONS_DEFAULT
     "ON" ENABLE_ASSERTIONS_DEFAULT)
+cmake_dependent_option(ENABLE_FPE "Enable Floating Point Exceptions checks" ENABLE_FPE_DEFAULT
+    "ON" ENABLE_FPE_DEFAULT)
 
 print_option( ENABLE_ASSERTIONS )
+print_option( ENABLE_FPE )
 
 
 #

--- a/Tools/CMake/AMReX_Options.cmake
+++ b/Tools/CMake/AMReX_Options.cmake
@@ -209,11 +209,12 @@ print_option( ENABLE_PIC )
 option(ENABLE_FPE "Enable Floating Point Exceptions checks" OFF)
 print_option( ENABLE_FPE )
 
+set(ENABLE_ASSERTIONS_DEFAULT OFF)
 if ( "${CMAKE_BUILD_TYPE}" MATCHES "Debug" )
-   option( ENABLE_ASSERTIONS "Enable assertions" ON)
-else ()
-   option( ENABLE_ASSERTIONS "Enable assertions" OFF)
+   set(ENABLE_ASSERTIONS_DEFAULT ON)
 endif ()
+cmake_dependent_option(ENABLE_ASSERTIONS "Enable assertions" ENABLE_ASSERTIONS_DEFAULT
+    "ON" ENABLE_ASSERTIONS_DEFAULT)
 
 print_option( ENABLE_ASSERTIONS )
 


### PR DESCRIPTION
Make sure `ENABLE_ASSERTIONS` and `ENABLE_FPE` work well with sub projects: Now show up as advanced option if set in a downstream project.
Passed to `cmake <path> -DCMAKE_BUILD_TYPE=Release -DENABLE_ASSERTIONS=ON` as an argument, one can enable assertions (of floating point exceptions with `-DENABLE_FPE=ON`) in super-builds without enabling the `Debug` build type.

Also, enables FPEs by default in Debug builds now as in GNUmake.