### PR TITLE
Conduit: Avoid const_cast

### DIFF
--- a/Src/Extern/Conduit/AMReX_Conduit_Blueprint_ParticlesI.H
+++ b/Src/Extern/Conduit/AMReX_Conduit_Blueprint_ParticlesI.H
@@ -38,7 +38,7 @@ ParticleTileToBlueprint(const ParticleTile<NStructReal,
     // and any user fields in the AOS
 
     // get the first particle's struct
-    const auto &pstruct = ptile.GetArrayOfStructs();
+    auto &pstruct = ptile.GetArrayOfStructs();
 
     // setup a blueprint description for the particle mesh
     // create a coordinate set
@@ -64,8 +64,7 @@ ParticleTileToBlueprint(const ParticleTile<NStructReal,
     // point locations from from aos
     //----------------------------------//
 
-    const char* pbuf_const = reinterpret_cast<const char*>(pstruct.data());
-    char* pbuf = const_cast<char*>(pbuf_const);
+    char* pbuf = reinterpret_cast<char*>(pstruct.data());
 
     ParticleReal* xp = reinterpret_cast<ParticleReal*>(pbuf); pbuf += sizeof(ParticleReal);
     n_coords["values/x"].set_external(xp,


### PR DESCRIPTION
Follow-up to #1057: Would this potentially work? Just trying to avoid `const_cast` across library boundaries.

cc @cyrush @WeiqunZhang 