### PR TITLE
MFIter reducer belongs only to AMREX_USE_GPU_PRAGMA

### DIFF
--- a/Src/Base/AMReX_MFIter.H
+++ b/Src/Base/AMReX_MFIter.H
@@ -81,7 +81,7 @@ public:
 	SkipInit      = 0x08
     };
 
-#ifdef AMREX_USE_GPU
+#ifdef AMREX_USE_GPU_PRAGMA
     enum MFReducer { SUM = 0, MAX, MIN };
 #endif
 
@@ -164,7 +164,7 @@ public:
     //! The the number of tiles in the current grid;
     int numLocalTiles() const noexcept {return num_local_tiles ? (*num_local_tiles)[currentIndex] : 1;}
 
-#ifdef AMREX_USE_GPU
+#ifdef AMREX_USE_GPU_PRAGMA
     //! Maintain a list of values to reduce.
     template<typename T>
     T* add_reduce_value(T* val, MFReducer r) { return val; }
@@ -212,7 +212,7 @@ protected:
     const Vector<int>* local_tile_index_map;
     const Vector<int>* num_local_tiles;
 
-#ifdef AMREX_USE_GPU
+#ifdef AMREX_USE_GPU_PRAGMA
     mutable Vector<Real*> real_reduce_val;
 
     mutable MFReducer reducer;

--- a/Src/Base/AMReX_MFIter.cpp
+++ b/Src/Base/AMReX_MFIter.cpp
@@ -216,11 +216,11 @@ MFIter::~MFIter ()
     if (device_sync) Gpu::synchronize();
 #endif
 
-#ifdef AMREX_USE_GPU
+#ifdef AMREX_USE_GPU_PRAGMA
     reduce();
 #endif
 
-#ifdef AMREX_USE_GPU
+#ifdef AMREX_USE_GPU_PRAGMA
     if (Gpu::inLaunchRegion()) {
         for (int i = 0; i < real_reduce_list.size(); ++i)
             for (int j = 0; j < real_reduce_list[i].size(); ++j)
@@ -496,6 +496,7 @@ MFIter::operator++ () noexcept
 #endif
         
         bool use_gpu = (numOmpThreads == 1) && Gpu::inLaunchRegion();
+#ifdef AMREX_USE_GPU_PRAGMA
         if (use_gpu) {
             if (!real_reduce_list.empty()) {
                 for (int i = 0; i < real_reduce_list[currentIndex].size(); ++i) {
@@ -505,6 +506,7 @@ MFIter::operator++ () noexcept
                 }
             }
         }
+#endif
 #endif
 
         ++currentIndex;
@@ -521,7 +523,7 @@ MFIter::operator++ () noexcept
     }
 }
 
-#ifdef AMREX_USE_GPU
+#ifdef AMREX_USE_GPU_PRAGMA
 Real*
 MFIter::add_reduce_value(Real* val, MFReducer r)
 {
@@ -583,7 +585,7 @@ MFIter::add_reduce_value(Real* val, MFReducer r)
 }
 #endif
 
-#ifdef AMREX_USE_GPU
+#ifdef AMREX_USE_GPU_PRAGMA
 // Reduce over the values in the list.
 void
 MFIter::reduce()

--- a/Src/Base/AMReX_MFIter.cpp
+++ b/Src/Base/AMReX_MFIter.cpp
@@ -488,16 +488,8 @@ MFIter::operator++ () noexcept
     else
 #endif
     {
-#ifdef AMREX_USE_GPU
-#ifdef _OPENMP
-        int numOmpThreads = omp_get_num_threads();
-#else
-        int numOmpThreads = 1;
-#endif
-        
-        bool use_gpu = (numOmpThreads == 1) && Gpu::inLaunchRegion();
 #ifdef AMREX_USE_GPU_PRAGMA
-        if (use_gpu) {
+        if (Gpu::inLaunchRegion()) {
             if (!real_reduce_list.empty()) {
                 for (int i = 0; i < real_reduce_list[currentIndex].size(); ++i) {
                     Gpu::dtoh_memcpy_async(&real_reduce_list[currentIndex][i],
@@ -507,12 +499,11 @@ MFIter::operator++ () noexcept
             }
         }
 #endif
-#endif
 
         ++currentIndex;
 
 #ifdef AMREX_USE_GPU
-        if (use_gpu) {
+        if (Gpu::inLaunchRegion()) {
             Gpu::Device::setStreamIndex((streams > 0) ? currentIndex%streams : -1);
             AMREX_GPU_ERROR_CHECK();
 #ifdef AMREX_DEBUG


### PR DESCRIPTION
Only AMReX-Astro uses this reduction code inside MFIter (when using the CUDA build), so this restricts the ifdef appropriately. Eventually this code will be removed.