### PR TITLE
Set backtrace threadprivate exception for PGI

### DIFF
--- a/Src/Base/AMReX_BLBackTrace.H
+++ b/Src/Base/AMReX_BLBackTrace.H
@@ -29,7 +29,7 @@ struct BLBackTrace
 
     static std::stack<std::pair<std::string, std::string> > bt_stack;
 // threadprivate here doesn't work with Cray and Intel
-#if defined(_OPENMP) && !defined(_CRAYC) && !defined(__INTEL_COMPILER)
+#if defined(_OPENMP) && !defined(_CRAYC) && !defined(__INTEL_COMPILER) && !defined(__PGI)
 #pragma omp threadprivate(bt_stack)
 #endif
 };


### PR DESCRIPTION
This threadprivate construct also doesn't work for PGI, e.g.

```
$ cat main.cpp
#include <AMReX.H>

int main (int argc, char* argv[]) {}
```

```
$ make COMP=pgi USE_OMP=TRUE
Compiling AMReX.cpp ...
pgc++  -O2 -fast -gopt  -mp=nonuma -Minfo=mp -noacc    -DBL_USE_OMP -DAMREX_USE_OMP -DAMREX_GIT_VERSION=\"20.06-94-g38572ef1ff1d-dirty\" -DAMREX_LAUNCH="" -DAMREX_DEVICE="" -DAMREX_CUDA_FORT_GLOBAL="" -DAMREX_CUDA_FORT_DEVICE="" -DAMREX_CUDA_FORT_HOST="" -DAMREX_CUDA_FORT_HOST_DEVICE="" -DBL_SPACEDIM=3 -DAMREX_SPACEDIM=3 -DBL_FORT_USE_UNDERSCORE -DAMREX_FORT_USE_UNDERSCORE -DBL_Linux -DAMREX_Linux -DNDEBUG -I. -I/global/homes/m/mkatz/codes/amrex/Src/Base -c /global/homes/m/mkatz/codes/amrex/Src/Base/AMReX.cpp -o tmp_build_dir/o/3d.pgi.OMP.EXE/AMReX.o
PGCC-S-0155-threadprivate class variables require constructors   (/global/homes/m/mkatz/codes/amrex/Src/Base/AMReX.cpp: 664)
PGCC/x86-64 Linux 19.10-0: compilation completed with severe errors
```