### PR TITLE
CMake: Fix CUDA Host Check

### DIFF
--- a/Tools/CMake/AMReX_SetupCUDA.cmake
+++ b/Tools/CMake/AMReX_SetupCUDA.cmake
@@ -19,9 +19,21 @@ endif ()
 # CUDAHOSTCXX and the CMake variable CMAKE_CUDA_HOST_COMPILER.
 # For the time being we force the CUDA host compiler to be the C++ compiler.
 #
-if ( ( CMAKE_CUDA_HOST_COMPILER AND NOT ("${CMAKE_CUDA_HOST_COMPILER}" STREQUAL "${CMAKE_CXX_COMPILER}") )
-      OR  ( NOT ("$ENV{CUDAHOSTCXX}" STREQUAL "") ) )
-   message(FATAl_ERROR "User-defined CUDA host compiler does not match C++ compiler")
+# Note: just comparing the CMAKE_..._COMPILER vars is not sufficient and raises
+#       false negatives on e.g. /usr/bin/g++-8 and /usr/bin/c++
+# Note: blocked by https://gitlab.kitware.com/cmake/cmake/-/issues/20901
+#
+if (CMAKE_CUDA_HOST_COMPILER)
+  if (NOT "${CMAKE_CXX_COMPILER}" STREQUAL "${CMAKE_CUDA_HOST_COMPILER}")
+    if (NOT "$ENV{CUDAHOSTCXX}" STREQUAL "" OR NOT "$ENV{CXX}" STREQUAL "")
+      message(WARNING "CUDA host compiler "
+                      "(${CMAKE_CUDA_HOST_COMPILER}) "
+                      "does not match the C++ compiler "
+                      "(${CMAKE_CXX_COMPILER})! "
+                      "Consider setting the CXX and CUDAHOSTCXX environment "
+                      "variables.")
+    endif ()
+  endif ()
 endif ()
 
 #


### PR DESCRIPTION
The check did only write a regular message due to a typo of the message type.

Then checking the test, I realized it is not save:
- false negatives are raised if e.g. `CXX` is set to `/usr/bin/g++-` while `CUDAHOSTCXX` defaults to `/usr/bin/c++` (and vice versa)
- checking only env variables is not sufficient to validate user intent: setting accidentally differing compilers with `-DCMAKE_..._COMPILER` slips through

The only save check we can implement is checking compiler name and ID, but that one is blocked by a missing upstream feature:
  https://gitlab.kitware.com/cmake/cmake/-/issues/20901

All in all: stay for now with (flawed) env-logic but only throw a warning.