### PR TITLE
Makes `>>` operators for reading checkpoint files dimension agnostic

### DIFF
--- a/Src/Amr/AMReX_Amr.cpp
+++ b/Src/Amr/AMReX_Amr.cpp
@@ -1468,11 +1468,13 @@ Amr::restart (const std::string& filename)
         spdim = atoi(first_line.c_str());
     }
 
+#ifndef AMREX_PERMISSIVE_SPACEDIM
     if (spdim != AMREX_SPACEDIM)
     {
         amrex::ErrorStream() << "Amr::restart(): bad spacedim = " << spdim << '\n';
         amrex::Abort();
     }
+#endif
 
     is >> cumtime;
     int mx_lev;
@@ -1663,6 +1665,7 @@ Amr::restart (const std::string& filename)
     last_checkpoint = level_steps[0];
     last_plotfile = level_steps[0];
 
+#ifndef AMREX_PERMISSIVE_SPACEDIM
     for (int lev = 0; lev <= finest_level; ++lev)
     {
         Box restart_domain(Geom(lev).Domain());
@@ -1677,6 +1680,7 @@ Amr::restart (const std::string& filename)
             amrex::Abort(ss.str());
         }
     }
+#endif
 
     if (verbose > 0)
     {

--- a/Src/Base/AMReX_CoordSys.cpp
+++ b/Src/Base/AMReX_CoordSys.cpp
@@ -437,14 +437,18 @@ operator>> (std::istream& is,
     int coord;
     is.ignore(BL_IGNORE_MAX, '(') >> coord;
     c.c_sys = (CoordSys::CoordType) coord;
-    AMREX_D_EXPR(is.ignore(BL_IGNORE_MAX, '(') >> c.offset[0],
-                 is.ignore(BL_IGNORE_MAX, ',') >> c.offset[1],
-                 is.ignore(BL_IGNORE_MAX, ',') >> c.offset[2]);
+    is.ignore(BL_IGNORE_MAX, '(') >> c.offset[0];
+    if (!amrex::is_next_non_space(is, ')') && AMREX_SPACEDIM >= 2)
+        is.ignore(BL_IGNORE_MAX, ',') >> c.offset[1];
+    if (!amrex::is_next_non_space(is, ')') && AMREX_SPACEDIM == 3)
+        is.ignore(BL_IGNORE_MAX, ',') >> c.offset[2];
     is.ignore(BL_IGNORE_MAX, ')');
-    Real cellsize[3];
-    AMREX_D_EXPR(is.ignore(BL_IGNORE_MAX, '(') >> cellsize[0],
-                 is.ignore(BL_IGNORE_MAX, ',') >> cellsize[1],
-                 is.ignore(BL_IGNORE_MAX, ',') >> cellsize[2]);
+    Real cellsize[3] {1.0, 1.0, 1.0};
+    is.ignore(BL_IGNORE_MAX, '(') >> cellsize[0];
+    if (!amrex::is_next_non_space(is, ')'))
+        is.ignore(BL_IGNORE_MAX, ',') >> cellsize[1];
+    if (!amrex::is_next_non_space(is, ')'))
+        is.ignore(BL_IGNORE_MAX, ',') >> cellsize[2];
     is.ignore(BL_IGNORE_MAX, ')');
     int tmp;
     is >> tmp;

--- a/Src/Base/AMReX_Geometry.H
+++ b/Src/Base/AMReX_Geometry.H
@@ -94,7 +94,7 @@ public:
     }
 
     //! Read static values from ParmParse database.
-    static void Setup (const RealBox* rb = nullptr, int coord = -1, int const* is_per = nullptr) noexcept;
+    static void Setup (const RealBox* rb = nullptr, int coord = -1, int const* is_per = nullptr, bool reset = false) noexcept;
     static void ResetDefaultProbDomain (const RealBox& rb) noexcept;
     static void ResetDefaultPeriodicity (const Array<int,AMREX_SPACEDIM>& is_per) noexcept;
     static void ResetDefaultCoord (int coord) noexcept;

--- a/Src/Base/AMReX_Geometry.cpp
+++ b/Src/Base/AMReX_Geometry.cpp
@@ -113,11 +113,11 @@ Geometry::define (const Box& dom, const RealBox* rb, int coord,
 }
 
 void
-Geometry::Setup (const RealBox* rb, int coord, int const* isper) noexcept
+Geometry::Setup (const RealBox* rb, int coord, int const* isper, bool reset) noexcept
 {
     Geometry* gg = AMReX::top()->getDefaultGeometry();
 
-    if (gg->ok) return;
+    if (gg->ok && !reset) return;
 
 #ifdef _OPENMP
     BL_ASSERT(!omp_in_parallel());

--- a/Src/Base/AMReX_RealBox.cpp
+++ b/Src/Base/AMReX_RealBox.cpp
@@ -57,18 +57,25 @@ operator >> (std::istream &is, RealBox& b)
         amrex::Abort();
     }
 
-    Real lo[AMREX_SPACEDIM];
-    Real hi[AMREX_SPACEDIM];
+    Real lo[AMREX_SPACEDIM] {};
+    Real hi[AMREX_SPACEDIM] {};
 #ifdef BL_USE_FLOAT
     double dlotemp, dhitemp;
     for (int i = 0; i < AMREX_SPACEDIM; i++) {
         is >> dlotemp >> dhitemp;
         lo[i] = dlotemp;
         hi[i] = dhitemp;
+
+        if (amrex::is_next_non_space(is, ')'))
+            break;
     }
 #else
-    for (int i = 0; i < AMREX_SPACEDIM; i++)
+    for (int i = 0; i < AMREX_SPACEDIM; i++) {
         is >> lo[i] >> hi[i];
+
+        if (amrex::is_next_non_space(is, ')'))
+            break;
+    }
 #endif
 
     is.ignore(BL_IGNORE_MAX, ')');

--- a/Src/Base/AMReX_Utility.H
+++ b/Src/Base/AMReX_Utility.H
@@ -57,6 +57,10 @@ namespace amrex
     std::string Concatenate (const std::string& root,
                              int                num,
                              int                mindigits = 5);
+
+    //! Check if the given stream contains the supplied character after any amount of whitespace
+    bool is_next_non_space(std::istream& is, char c);
+
     /**
     *  \brief Creates the specified directories.  path may be either a full pathname
     *  or a relative pathname.  It will create all the directories in the

--- a/Src/Base/AMReX_Utility.cpp
+++ b/Src/Base/AMReX_Utility.cpp
@@ -145,6 +145,34 @@ amrex::Concatenate (const std::string& root,
     return result.str();
 }
 
+bool
+amrex::is_next_non_space(std::istream& is, char c)
+{
+    // save current position
+    const int pos = is.tellg();
+    const int cseek = static_cast<int>(c);
+
+    bool found = false;
+    int ic;
+
+    // search for first non-whitespace char and test if c
+    while (! is.eof()) {
+      ic = is.peek();
+      if (ic == cseek) {
+        found = true;
+        break;
+      } else if (! isspace(ic))
+        break;
+
+      is.seekg(1, is.cur);
+    }
+
+    // reset input stream is
+    is.clear();
+    is.seekg(pos);
+
+    return found;
+}
 
 bool
 amrex::UtilCreateDirectory (const std::string& path,


### PR DESCRIPTION
Previously, we needed to compile AMReX with the same dimensionality of the checkpoint files when using `Amr::restart()` because some of the classes define `>>` operators that used `AMREX_D_EXPR` to read data from the checkpoint header.

This PR is to support compiling in 3D and loading a checkpoint file from 1D or 2D, needed for postprocessing where we want to read a 2D checkpoint file and convert it to a 3D checkpoint file that we can restart from.

This will let us create an `Amr` object for the 2D checkpoint and a second `Amr` object for the 3D domain we want to fill.