### PR TITLE
GCC 81 workaround for Async IO

### DIFF
--- a/Src/Particle/AMReX_WriteBinaryParticleData.H
+++ b/Src/Particle/AMReX_WriteBinaryParticleData.H
@@ -487,7 +487,7 @@ void WriteBinaryParticleDataAsync (PC const& pc,
 
     auto RD = pc.ParticleRealDescriptor;
 
-    AsyncOut::Submit([=] ()
+    AsyncOut::Submit([=] () mutable // workaround for gcc 8.1 bug
     {
         if (MyProc == IOProcNumber)
         {

--- a/Src/Particle/AMReX_WriteBinaryParticleData.H
+++ b/Src/Particle/AMReX_WriteBinaryParticleData.H
@@ -487,7 +487,10 @@ void WriteBinaryParticleDataAsync (PC const& pc,
 
     auto RD = pc.ParticleRealDescriptor;
 
-    AsyncOut::Submit([=] () mutable // workaround for gcc 8.1 bug
+    AsyncOut::Submit([=] () 
+#if defined(__GNUC__) && (__GNUC__ == 8) && (__GNUC_MINOR__ == 1)
+                     mutable // workaround for bug in gcc 8.1
+#endif
     {
         if (MyProc == IOProcNumber)
         {


### PR DESCRIPTION
Really this lambda should not have to be `mutable`, but gcc 8.1 will not compile this code unless it is.