### PR TITLE
Add copy filter

### DIFF
--- a/Src/Particle/AMReX_ParticleContainerI.H
+++ b/Src/Particle/AMReX_ParticleContainerI.H
@@ -384,30 +384,56 @@ template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt>
 Vector<Long>
 ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>::NumberOfParticlesInGrid (int lev, bool only_valid, bool only_local) const
 {
-  auto ngrids = ParticleBoxArray(lev).size();
-  Vector<Long> nparticles(ngrids, 0);
+    AMREX_ASSERT(lev >= 0 && lev < int(m_particles.size()));
 
-  if (lev >= 0 && lev < int(m_particles.size())) {
-    for (const auto& kv : GetParticles(lev)) {
-      int gid = kv.first.first;
-      const auto& ptile = kv.second;
+    LayoutData<Long> np_per_grid_local(ParticleBoxArray(lev),
+                                       ParticleDistributionMap(lev));
 
-      if (only_valid) {
-	for (int k = 0; k < ptile.GetArrayOfStructs().numParticles(); ++k) {
-	  const ParticleType& p = ptile.GetArrayOfStructs()[k];
-	  if (p.id() > 0) ++nparticles[gid];
-	}
-      } else {
-	nparticles[gid] += ptile.numParticles();
-      }
+    for (ParConstIterType pti(*this, lev); pti.isValid(); ++pti)
+    {
+        int gid = pti.index();
+        if (only_valid)
+        {
+            const auto& ptile = ParticlesAt(lev, pti);
+            const auto& aos = ptile.GetArrayOfStructs();
+            const auto pstruct = aos().dataPtr();
+            const int np = ptile.numParticles();
+
+            ReduceOps<ReduceOpSum> reduce_op;
+            ReduceData<int> reduce_data(reduce_op);
+            using ReduceTuple = typename decltype(reduce_data)::Type;
+
+            reduce_op.eval(np, reduce_data,
+                           [=] AMREX_GPU_DEVICE (int i) -> ReduceTuple
+                           {
+                               return (pstruct[i].id() > 0) ? 1 : 0;
+                           });
+
+            int np_valid = amrex::get<0>(reduce_data.value());
+            np_per_grid_local[gid] += np_valid;
+        } else
+        {
+            np_per_grid_local[gid] += pti.numParticles();
+        }
+    }
+        
+    Vector<Long> nparticles(np_per_grid_local.size(), 0);
+    if (only_local)
+    {
+        for (ParConstIterType pti(*this, lev); pti.isValid(); ++pti)
+        {
+            nparticles[pti.index()] = np_per_grid_local[pti.index()];
+        }
+    } 
+    else
+    {
+        ParallelDescriptor::GatherLayoutDataToVector(np_per_grid_local, nparticles,
+                                                     ParallelContext::IOProcessorNumberSub());
+        ParallelDescriptor::Bcast(&nparticles[0], nparticles.size(), 
+                                  ParallelContext::IOProcessorNumberSub());
     }
 
-    if (!only_local) {
-        ParallelAllReduce::Sum(&nparticles[0], ngrids, ParallelContext::CommunicatorSub());
-    }
-  }
-
-  return nparticles;
+    return nparticles;
 }
 
 template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt>

--- a/Src/Particle/AMReX_ParticleContainerI.H
+++ b/Src/Particle/AMReX_ParticleContainerI.H
@@ -935,15 +935,35 @@ void
 ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>::
 copyParticles (const ParticleContainerType& other, bool local)
 {
-    BL_PROFILE("ParticleContainer::copyParticles");
-    clearParticles();
-    addParticles(other, local);
+    using PData = ConstParticleTileData<NStructReal, NStructInt, NArrayReal, NArrayInt>;
+    copyParticles(other, [=] AMREX_GPU_HOST_DEVICE (const PData& data, int i) { return true; }, local);
 }
 
 template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt>
 void
 ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>::
 addParticles (const ParticleContainerType& other, bool local)
+{
+    using PData = ConstParticleTileData<NStructReal, NStructInt, NArrayReal, NArrayInt>; 
+    addParticles(other, [=] AMREX_GPU_HOST_DEVICE (const PData& data, int i) { return true; }, local);
+}
+
+template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt>
+template <class F>
+void
+ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>::
+copyParticles (const ParticleContainerType& other, F&& f, bool local)
+{
+    BL_PROFILE("ParticleContainer::copyParticles");
+    clearParticles();
+    addParticles(other, std::forward<F>(f), local);
+}
+
+template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt>
+template <class F>
+void
+ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>::
+addParticles (const ParticleContainerType& other, F&& f, bool local)
 {
     BL_PROFILE("ParticleContainer::addParticles");
 
@@ -964,7 +984,8 @@ addParticles (const ParticleContainerType& other, bool local)
             auto dst_index = ptile.numParticles();
             ptile.resize(dst_index + np);
 
-            amrex::copyParticles(ptile, ptile_other, 0, dst_index, np);
+            auto count = amrex::filterParticles(ptile, ptile_other, std::forward<F>(f), 0, dst_index, np);
+            ptile.resize(dst_index + count);
         }
     }
 

--- a/Src/Particle/AMReX_ParticleContainerI.H
+++ b/Src/Particle/AMReX_ParticleContainerI.H
@@ -936,7 +936,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>::
 copyParticles (const ParticleContainerType& other, bool local)
 {
     using PData = ConstParticleTileData<NStructReal, NStructInt, NArrayReal, NArrayInt>;
-    copyParticles(other, [=] AMREX_GPU_HOST_DEVICE (const PData& data, int i) { return true; }, local);
+    copyParticles(other, [=] AMREX_GPU_HOST_DEVICE (const PData& data, int i) { return 1; }, local);
 }
 
 template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt>
@@ -945,11 +945,12 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>::
 addParticles (const ParticleContainerType& other, bool local)
 {
     using PData = ConstParticleTileData<NStructReal, NStructInt, NArrayReal, NArrayInt>; 
-    addParticles(other, [=] AMREX_GPU_HOST_DEVICE (const PData& data, int i) { return true; }, local);
+    addParticles(other, [=] AMREX_GPU_HOST_DEVICE (const PData& data, int i) { return 1; }, local);
 }
 
 template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt>
-template <class F>
+template <class F,
+          amrex::EnableIf_t<! std::is_integral<F>::value, int> foo>
 void
 ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>::
 copyParticles (const ParticleContainerType& other, F&& f, bool local)
@@ -960,7 +961,8 @@ copyParticles (const ParticleContainerType& other, F&& f, bool local)
 }
 
 template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt>
-template <class F>
+template <class F,
+          amrex::EnableIf_t<! std::is_integral<F>::value, int> foo>
 void
 ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>::
 addParticles (const ParticleContainerType& other, F&& f, bool local)
@@ -985,6 +987,7 @@ addParticles (const ParticleContainerType& other, F&& f, bool local)
             ptile.resize(dst_index + np);
 
             auto count = amrex::filterParticles(ptile, ptile_other, std::forward<F>(f), 0, dst_index, np);
+
             ptile.resize(dst_index + count);
         }
     }

--- a/Src/Particle/AMReX_ParticleTransformation.H
+++ b/Src/Particle/AMReX_ParticleTransformation.H
@@ -313,9 +313,6 @@ template <typename DstTile, typename SrcTile, typename Index, typename N,
 Index filterParticles (DstTile& dst, const SrcTile& src, const Index* mask,
                        Index src_start, Index dst_start, N n) noexcept
 {
-
-    amrex::Print() << src_start << " " << dst_start << "\n";
-
     auto np = src.numParticles();
     Gpu::DeviceVector<Index> offsets(np);
     Gpu::exclusive_scan(mask, mask+np, offsets.begin());
@@ -323,7 +320,7 @@ Index filterParticles (DstTile& dst, const SrcTile& src, const Index* mask,
     Index last_mask, last_offset;
     Gpu::copyAsync(Gpu::deviceToHost, mask+np-1, mask + np, &last_mask);
     Gpu::copyAsync(Gpu::deviceToHost, offsets.data()+np-1, offsets.data()+np, &last_offset);    
-                               
+      
     auto p_offsets = offsets.dataPtr();
     
     const auto src_data = src.getConstParticleTileData();
@@ -379,7 +376,6 @@ auto filterParticles (DstTile& dst, const SrcTile& src, Pred&& p,
                       Index src_start, Index dst_start, N n) noexcept
     -> decltype(p(typename SrcTile::ConstParticleTileDataType(), 0))
 {
-    //    using Index = decltype(p(typename SrcTile::ConstParticleTileDataType(), 0));
     auto np = src.numParticles();
     Gpu::DeviceVector<Index> mask(np);
 

--- a/Src/Particle/AMReX_ParticleTransformation.H
+++ b/Src/Particle/AMReX_ParticleTransformation.H
@@ -144,6 +144,7 @@ void copyParticles (DstTile& dst, const SrcTile& src) noexcept
  * \param src the source tile
  * \param src_start the offset at which to start reading particles from src
  * \param dst_start the offset at which to start writing particles to dst
+ * \param n the number of particles to write
  *
  */
 template <typename DstTile, typename SrcTile, typename Index, typename N,
@@ -270,7 +271,7 @@ void transformParticles (DstTile1& dst1, DstTile2& dst2, const SrcTile& src,
         f(dst1_data, dst2_data, src_data, src_start+i, dst1_start+i, dst2_start+i);
     });
 }
-    
+
 /**
  * \brief Conditionally copy particles from src to dst based on the value of mask.
  * 
@@ -283,10 +284,38 @@ void transformParticles (DstTile1& dst1, DstTile2& dst2, const SrcTile& src,
  * \param mask pointer to the mask - 1 means copy, 0 means don't copy
  *
  */
-template <typename DstTile, typename SrcTile, typename Index,
+template <typename DstTile, typename SrcTile, typename Index, typename N,
           amrex::EnableIf_t<std::is_integral<Index>::value, int> foo = 0>
 Index filterParticles (DstTile& dst, const SrcTile& src, const Index* mask) noexcept
 {
+    return filterParticles(dst, src, mask, 0, 0, src.numParticles());
+}
+    
+/**
+ * \brief Conditionally copy particles from src to dst based on the value of mask.
+ *  This version conditionally copies n particles starting at index src_start, writing 
+ *  the result starting at dst_start.
+ * 
+ * \tparam DstTile the dst particle tile type
+ * \tparam SrcTile the src particle tile type
+ * \tparam Index the index type, e.g. unsigned int
+ *
+ * \param dst the destination tile
+ * \param src the source tile
+ * \param mask pointer to the mask - 1 means copy, 0 means don't copy
+ * \param src_start the offset at which to start reading particles from src
+ * \param dst_start the offset at which to start writing particles to dst
+ * \param n the number of particles to apply the operation to
+ *
+ */
+template <typename DstTile, typename SrcTile, typename Index, typename N,
+          amrex::EnableIf_t<std::is_integral<Index>::value, int> foo = 0>
+Index filterParticles (DstTile& dst, const SrcTile& src, const Index* mask,
+                       Index src_start, Index dst_start, N n) noexcept
+{
+
+    amrex::Print() << src_start << " " << dst_start << "\n";
+
     auto np = src.numParticles();
     Gpu::DeviceVector<Index> offsets(np);
     Gpu::exclusive_scan(mask, mask+np, offsets.begin());
@@ -300,9 +329,10 @@ Index filterParticles (DstTile& dst, const SrcTile& src, const Index* mask) noex
     const auto src_data = src.getConstParticleTileData();
           auto dst_data = dst.getParticleTileData();
 
-    AMREX_HOST_DEVICE_FOR_1D( np, i,
+    AMREX_HOST_DEVICE_FOR_1D( n, i,
     {
-        if (mask[i]) copyParticle(dst_data, src_data, i, p_offsets[i]);
+        if (mask[src_start+i]) copyParticle(dst_data, src_data, src_start+i, 
+                                            dst_start+p_offsets[src_start+i]);
     });
 
     Gpu::streamSynchronize();
@@ -323,9 +353,33 @@ Index filterParticles (DstTile& dst, const SrcTile& src, const Index* mask) noex
  */    
 template <typename DstTile, typename SrcTile, typename Pred>
 auto filterParticles (DstTile& dst, const SrcTile& src, Pred&& p) noexcept
+{
+    return filterParticles(dst, src, p, 0, 0, src.numParticles());
+}
+
+/**
+ * \brief Conditionally copy particles from src to dst based on a predicate.
+ *  This version conditionally copies n particles starting at index src_start, writing 
+ *  the result starting at dst_start.
+ * 
+ * \tparam DstTile the dst particle tile type
+ * \tparam SrcTile the src particle tile type
+ * \tparam Pred a function object
+ *
+ * \param dst the destination tile
+ * \param src the source tile
+ * \param p predicate function - particles will be copied if p returns true
+ * \param src_start the offset at which to start reading particles from src
+ * \param dst_start the offset at which to start writing particles to dst
+ * \param n the number of particles to apply the operation to
+ *
+ */    
+template <typename DstTile, typename SrcTile, typename Pred, typename Index, typename N>
+auto filterParticles (DstTile& dst, const SrcTile& src, Pred&& p,
+                      Index src_start, Index dst_start, N n) noexcept
     -> decltype(p(typename SrcTile::ConstParticleTileDataType(), 0))
 {
-    using Index = decltype(p(typename SrcTile::ConstParticleTileDataType(), 0));
+    //    using Index = decltype(p(typename SrcTile::ConstParticleTileDataType(), 0));
     auto np = src.numParticles();
     Gpu::DeviceVector<Index> mask(np);
 
@@ -337,7 +391,7 @@ auto filterParticles (DstTile& dst, const SrcTile& src, Pred&& p) noexcept
         p_mask[i] = p(src_data, i);
     });
 
-    return filterParticles(dst, src, mask.dataPtr());
+    return filterParticles(dst, src, mask.dataPtr(), src_start, dst_start, n);
 }
 
 /**

--- a/Src/Particle/AMReX_ParticleTransformation.H
+++ b/Src/Particle/AMReX_ParticleTransformation.H
@@ -350,6 +350,7 @@ Index filterParticles (DstTile& dst, const SrcTile& src, const Index* mask,
  */    
 template <typename DstTile, typename SrcTile, typename Pred>
 auto filterParticles (DstTile& dst, const SrcTile& src, Pred&& p) noexcept
+    -> decltype(p(typename SrcTile::ConstParticleTileDataType(), 0))
 {
     return filterParticles(dst, src, p, 0, 0, src.numParticles());
 }

--- a/Src/Particle/AMReX_Particles.H
+++ b/Src/Particle/AMReX_Particles.H
@@ -680,7 +680,7 @@ public:
     * \param f function to apply to each particle as a filter
     * \param local whether to call redistribute after
     */
-    template <class F>
+    template <class F, amrex::EnableIf_t<! std::is_integral<F>::value, int> foo = 0>
     void copyParticles (const ParticleContainerType& other, F&&f, bool local=false);
 
     /**
@@ -696,7 +696,7 @@ public:
     * \param f function to apply to each particle as a filter
     * \param local whether to call redistribute after
     */
-    template <class F>
+    template <class F, amrex::EnableIf_t<! std::is_integral<F>::value, int> foo = 0>
     void addParticles (const ParticleContainerType& other, F&& f, bool local=false);
 
     /**

--- a/Src/Particle/AMReX_Particles.H
+++ b/Src/Particle/AMReX_Particles.H
@@ -652,7 +652,8 @@ public:
     * particles from this container first. local controls whether or not to call
     * Redistribute() after adding the particles.
     *
-    * \param other
+    * \param other the other pc to copy from
+    * \param local whether to call redistribute after
     */
     void copyParticles (const ParticleContainerType& other, bool local=false);
 
@@ -660,9 +661,43 @@ public:
     * \brief Add particles from other to this ParticleContainer. local controls
     * whether or not to call Redistribute after adding the particles.
     *
-    * \param other
+    * \param other the other pc to copy from
+    * \param local whether to call redistribute after
     */
     void addParticles (const ParticleContainerType& other, bool local=false);
+
+    /**
+    * \brief Copy particles from other to this ParticleContainer. Will clear all the
+    * particles from this container first. local controls whether or not to call
+    * Redistribute() after adding the particles.
+    *
+    * This version conditionally copies based on a predicate function applied to 
+    * each particle.
+    *
+    * \tparam callable that takes a SuperParticle and returns a bool
+    *
+    * \param other the other pc to copy from
+    * \param f function to apply to each particle as a filter
+    * \param local whether to call redistribute after
+    */
+    template <class F>
+    void copyParticles (const ParticleContainerType& other, F&&f, bool local=false);
+
+    /**
+    * \brief Add particles from other to this ParticleContainer. local controls
+    * whether or not to call Redistribute after adding the particles.
+    *
+    * This version conditionally copies based on a predicate function applied to 
+    * each particle.
+    *
+    * \tparam callable that takes a SuperParticle and returns a bool
+    *
+    * \param other the other pc to copy from
+    * \param f function to apply to each particle as a filter
+    * \param local whether to call redistribute after
+    */
+    template <class F>
+    void addParticles (const ParticleContainerType& other, F&& f, bool local=false);
 
     /**
     * \brief Write a contiguous chunk of real particle data to an ostream.

--- a/Tests/Particles/ParticleTransformations/main.cpp
+++ b/Tests/Particles/ParticleTransformations/main.cpp
@@ -402,6 +402,8 @@ void testFilter (const PC& pc)
 
     auto np_new = pc2.TotalNumberOfParticles();
 
+    amrex::Print() << np_new << " " << np_old << "\n";
+
     AMREX_ALWAYS_ASSERT(2*np_new == np_old);
 
     auto all_odd = amrex::ReduceLogicalAnd(pc2, [=] AMREX_GPU_HOST_DEVICE (const PType& p) -> int { return p.id() % 2 == 1; });
@@ -409,10 +411,13 @@ void testFilter (const PC& pc)
     AMREX_ALWAYS_ASSERT(all_odd);
 
     pc2.clearParticles();
-    pc2.copyParticles(pc);
-    filterParticles(pc2, KeepEvenFilter());
+    pc2.copyParticles(pc, KeepEvenFilter());
+    //    filterParticles(pc2, KeepEvenFilter());
 
     np_new = pc2.TotalNumberOfParticles();
+
+    amrex::Print() << np_new << " " << np_old << "\n";
+
     AMREX_ALWAYS_ASSERT(2*np_new == np_old);
 
     auto all_even = amrex::ReduceLogicalAnd(pc2, [=] AMREX_GPU_HOST_DEVICE (const PType& p) -> int { return p.id() % 2 == 0; });

--- a/Tests/Particles/ParticleTransformations/main.cpp
+++ b/Tests/Particles/ParticleTransformations/main.cpp
@@ -299,6 +299,7 @@ void filterParticles (PC& pc, F&& f)
             ptile_tmp.resize(ptile.size());
             
             auto num_output = amrex::filterParticles(ptile_tmp, ptile, std::forward<F>(f));
+
             ptile.swap(ptile_tmp);
             ptile.resize(num_output);
         }
@@ -393,16 +394,12 @@ void testFilter (const PC& pc)
 {
     using PType = typename PC::SuperParticleType;
 
-    PC pc2(pc.Geom(0), pc.ParticleDistributionMap(0), pc.ParticleBoxArray(0));
-    pc2.copyParticles(pc);
+    auto np_old = pc.TotalNumberOfParticles();
 
-    auto np_old = pc2.TotalNumberOfParticles();
-    
-    filterParticles(pc2, KeepOddFilter());
+    PC pc2(pc.Geom(0), pc.ParticleDistributionMap(0), pc.ParticleBoxArray(0));
+    pc2.copyParticles(pc, KeepOddFilter());
 
     auto np_new = pc2.TotalNumberOfParticles();
-
-    amrex::Print() << np_new << " " << np_old << "\n";
 
     AMREX_ALWAYS_ASSERT(2*np_new == np_old);
 
@@ -412,11 +409,8 @@ void testFilter (const PC& pc)
 
     pc2.clearParticles();
     pc2.copyParticles(pc, KeepEvenFilter());
-    //    filterParticles(pc2, KeepEvenFilter());
 
     np_new = pc2.TotalNumberOfParticles();
-
-    amrex::Print() << np_new << " " << np_old << "\n";
 
     AMREX_ALWAYS_ASSERT(2*np_new == np_old);
 


### PR DESCRIPTION
When adding or copying particles between containers, allow an optional filter to be applied. 

This will be used to re-implement the particle IO filtering in WarpX, and I'll get to delete a lot of overloads in `AMReX_ParticleIO.H`.  