### PR TITLE
For nvcc >= 10.2, tell it to forward unknowns to host compiler, and we…

### DIFF
--- a/Tools/GNUMake/Make.defs
+++ b/Tools/GNUMake/Make.defs
@@ -1036,40 +1036,43 @@ else ifeq ($(USE_CUDA),TRUE)
 
     DEFINES += -DAMREX_GPU_MAX_THREADS=$(CUDA_MAX_THREADS)
 
-    comm := ,
-    space :=
-    space +=
-
     ifneq ($(LINK_WITH_FORTRAN_COMPILER),TRUE)
       LINKFLAGS = $(NVCC_FLAGS)
-      # we are using nvcc for linking
-      libraries := $(subst -Wl$(comm),-Xlinker=,$(libraries))
-      ifeq ($(FIX_NVCC_PTHREAD),TRUE)
-        libraries := $(subst -pthread,-Xcompiler$(space)-pthread,$(libraries))
-      endif
       AMREX_LINKER = nvcc
     endif
 
-    ifeq ($(USE_MPI),TRUE)
+    ifeq ($(nvcc_forward_unknowns),0)
 
-      ifneq ($(findstring Open MPI, $(shell mpicxx -showme:version 2>&1)),)
+      comm := ,
+      space :=
+      space +=
 
+      ifeq ($(AMREX_LINKER),nvcc)
+        libraries := $(subst -Wl$(comm),-Xlinker=,$(libraries))
         ifeq ($(FIX_NVCC_PTHREAD),TRUE)
-          OMPI_CXXFLAGS_ORIG = $(shell mpicxx -showme:compile)
-          export OMPI_CXXFLAGS := $(subst -pthread,-Xcompiler$(space)-pthread,$(OMPI_CXXFLAGS_ORIG))
-
-          OMPI_CFLAGS_ORIG = $(shell mpicc -showme:compile)
-          export OMPI_CFLAGS := $(subst -pthread,-Xcompiler$(space)-pthread,$(OMPI_CXXFLAGS_ORIG))
-
-          # If we're compiling with PGI, it doesn't know -pthread, replace
-          # with -lpthread.
-
-          OMPI_FCFLAGS_ORIG = $(shell mpif90 -showme:compile)
-          export OMPI_FCFLAGS := $(subst -pthread,-lpthread,$(OMPI_FCFLAGS_ORIG))
+          libraries := $(subst -pthread,-Xcompiler$(space)-pthread,$(libraries))
         endif
-
       endif
 
-    endif
+      ifeq ($(USE_MPI),TRUE)
+
+        ifneq ($(findstring Open MPI, $(shell mpicxx -showme:version 2>&1)),)
+
+          ifeq ($(FIX_NVCC_PTHREAD),TRUE)
+            OMPI_CXXFLAGS_ORIG = $(shell mpicxx -showme:compile)
+            export OMPI_CXXFLAGS := $(subst -pthread,-Xcompiler$(space)-pthread,$(OMPI_CXXFLAGS_ORIG))
+
+            OMPI_CFLAGS_ORIG = $(shell mpicc -showme:compile)
+            export OMPI_CFLAGS := $(subst -pthread,-Xcompiler$(space)-pthread,$(OMPI_CXXFLAGS_ORIG))
+
+            OMPI_FCFLAGS_ORIG = $(shell mpif90 -showme:compile)
+            export OMPI_FCFLAGS := $(subst -pthread,-lpthread,$(OMPI_FCFLAGS_ORIG))
+          endif
+
+        endif # Open MPI
+
+      endif # USE_MPI
+
+    endif # nvcc_forward_unknowns == 0
 
 endif

--- a/Tools/GNUMake/Make.defs
+++ b/Tools/GNUMake/Make.defs
@@ -1064,9 +1064,6 @@ else ifeq ($(USE_CUDA),TRUE)
 
             OMPI_CFLAGS_ORIG = $(shell mpicc -showme:compile)
             export OMPI_CFLAGS := $(subst -pthread,-Xcompiler$(space)-pthread,$(OMPI_CXXFLAGS_ORIG))
-
-            OMPI_FCFLAGS_ORIG = $(shell mpif90 -showme:compile)
-            export OMPI_FCFLAGS := $(subst -pthread,-lpthread,$(OMPI_FCFLAGS_ORIG))
           endif
 
         endif # Open MPI

--- a/Tools/GNUMake/comps/nvcc.mak
+++ b/Tools/GNUMake/comps/nvcc.mak
@@ -11,6 +11,16 @@ ifeq ($(nvcc_major_lt_8),1)
   $(error Your nvcc version is $(nvcc_version). This is unsupported. Please use CUDA toolkit version 8.0 or newer.)
 endif
 
+nvcc_forward_unknowns = 0
+ifeq ($(shell expr $(nvcc_major_version) \= 10),1)
+ifeq ($(shell expr $(nvcc_minor_version) \>= 2),1)
+  nvcc_forward_unknowns = 1
+endif
+endif
+ifeq ($(shell expr $(nvcc_major_version) \>= 11),1)
+  nvcc_forward_unknowns = 1
+endif
+
 #
 # nvcc compiler driver does not always accept pgc++
 # as a host compiler at present. However, if we're using
@@ -119,6 +129,10 @@ ifneq ($(USE_CUDA_FAST_MATH),FALSE)
 endif
 
 NVCC_FLAGS += $(XTRA_NVCC_FLAGS)
+
+ifeq ($(nvcc_forward_unknowns),1)
+  NVCC_FLAGS += --forward-unknown-to-host-compiler
+endif
 
 CXXFLAGS = $(CXXFLAGS_FROM_HOST) $(NVCC_FLAGS) -dc -x cu
 CFLAGS   =   $(CFLAGS_FROM_HOST) $(NVCC_FLAGS) -dc -x cu

--- a/Tools/GNUMake/comps/pgi.mak
+++ b/Tools/GNUMake/comps/pgi.mak
@@ -192,6 +192,13 @@ ifeq ($(USE_CUDA),TRUE)
 
   LINK_WITH_FORTRAN_COMPILER = TRUE
 
+  ifeq ($(USE_MPI),TRUE)
+  ifneq ($(findstring Open MPI, $(shell mpicxx -showme:version 2>&1)),)
+    OMPI_FCFLAGS_ORIG = $(shell mpif90 -showme:compile)
+    export OMPI_FCFLAGS := $(subst -pthread,-lpthread,$(OMPI_FCFLAGS_ORIG))
+  endif
+  endif
+
 endif
 
 


### PR DESCRIPTION
… no longer need to sanitize options for nvcc.