### PR TITLE
CMake: More NVCC Controls

### DIFF
--- a/Docs/sphinx_documentation/source/BuildingAMReX.rst
+++ b/Docs/sphinx_documentation/source/BuildingAMReX.rst
@@ -423,9 +423,29 @@ below.
    +------------------------------+-------------------------------------------------+-------------+-----------------+
    | CUDA_ARCH                    |  CUDA target architecture                       | Auto        | User-defined    |
    +------------------------------+-------------------------------------------------+-------------+-----------------+
+   | CUDA_BACKTRACE               |  Host function symbol names (e.g. cuda-memcheck)| Auto        | YES, NO         |
+   +------------------------------+-------------------------------------------------+-------------+-----------------+
+   | CUDA_COMPILATION_TIMER       |  CSV table with time for each compilation phase | NO          | YES, NO         |
+   +------------------------------+-------------------------------------------------+-------------+-----------------+
+   | CUDA_DEBUG                   |  Device debug information (optimizations: off)  | NO          | YES, NO         |
+   +------------------------------+-------------------------------------------------+-------------+-----------------+
+   | CUDA_ERROR_CAPTURE_THIS      |  Error if a CUDA lambda captures a class' this  | NO          | YES, NO         |
+   +------------------------------+-------------------------------------------------+-------------+-----------------+
+   | CUDA_KEEP_FILES              |  Keep intermediately files (folder: nvcc_tmp)   | NO          | YES, NO         |
+   +------------------------------+-------------------------------------------------+-------------+-----------------+
+   | CUDA_LTO                     |  Enable CUDA link-time-optimization             | NO          | YES, NO         |
+   +------------------------------+-------------------------------------------------+-------------+-----------------+
    | CUDA_MAX_THREADS             |  Max number of CUDA threads per block           | 256         | User-defined    |
    +------------------------------+-------------------------------------------------+-------------+-----------------+
    | CUDA_MAXREGCOUNT             |  Limits the number of CUDA registers available  | 255         | User-defined    |
+   +------------------------------+-------------------------------------------------+-------------+-----------------+
+   | CUDA_PTX_VERBOSE             |  Verbose code generation statistics in ptxas    | NO          | YES, NO         |
+   +------------------------------+-------------------------------------------------+-------------+-----------------+
+   | CUDA_SHOW_CODELINES          |  Source information in PTX (optimizations: on)  | Auto        | YES, NO         |
+   +------------------------------+-------------------------------------------------+-------------+-----------------+
+   | CUDA_SHOW_LINENUMBERS        |  Line-number information (optimizations: on)    | Auto        | YES, NO         |
+   +------------------------------+-------------------------------------------------+-------------+-----------------+
+   | CUDA_WARN_CAPTURE_THIS       |  Warn if a CUDA lambda captures a class' this   | YES         | YES, NO         |
    +------------------------------+-------------------------------------------------+-------------+-----------------+
    | ENABLE_CUDA_FASTMATH         |  Enable CUDA fastmath library                   | YES         | YES, NO         |
    +------------------------------+-------------------------------------------------+-------------+-----------------+

--- a/Tools/CMake/AMReX_SetupCUDA.cmake
+++ b/Tools/CMake/AMReX_SetupCUDA.cmake
@@ -1,11 +1,23 @@
 #
 # Setup the CUDA enviroment
 #
-#  Author: Michele Rosso
-#  Date  : April 4, 2019
+#  Authors: Michele Rosso, Axel Huebl
+#  Date   : April 4, 2019
 #
 #
 include_guard(GLOBAL)
+
+include(CMakeDependentOption)
+
+#
+# Define a macro to print active options
+#
+macro (cuda_print_option _var)
+   if (${_var})
+      message( STATUS "   ${_var}")
+   endif ()
+endmacro ()
+
 
 get_property(_lang GLOBAL PROPERTY ENABLED_LANGUAGES)
 if (NOT ("CUDA" IN_LIST _lang ))
@@ -39,25 +51,81 @@ endif ()
 #
 #  CUDA-related options
 #
-message(STATUS "CUDA options:")
+message(STATUS "Enabled CUDA options:")
 
 set(CUDA_ARCH "Auto" CACHE STRING "CUDA architecture (Use 'Auto' for automatic detection)")
 
-option( ENABLE_CUDA_FASTMATH "Enable CUDA fastmath" ON )
-message(STATUS "   ENABLE_CUDA_FASTMATH = ${ENABLE_CUDA_FASTMATH}")
+option(ENABLE_CUDA_FASTMATH "Enable CUDA fastmath" ON)
+cuda_print_option( ENABLE_CUDA_FASTMATH )
 
 set(CUDA_MAX_THREADS "256" CACHE STRING
    "Maximum number of CUDA threads per block" )
-message(STATUS "   CUDA_MAX_THREADS = ${CUDA_MAX_THREADS}")
+message( STATUS "   CUDA_MAX_THREADS = ${CUDA_MAX_THREADS}")
 
 set(CUDA_MAXREGCOUNT "255" CACHE STRING
    "Limit the maximum number of registers available" )
-message(STATUS "   CUDA_MAXREGCOUNT = ${CUDA_MAXREGCOUNT}")
+message( STATUS "   CUDA_MAXREGCOUNT = ${CUDA_MAXREGCOUNT}")
+
+# if this works well and does not add too much compile-time we should enable it by default
+cmake_dependent_option(CUDA_LTO "Enable CUDA link-time-optimization" OFF
+   "CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL 11.0.167" OFF)
+cuda_print_option(CUDA_LTO)
+
+# this warns on a typical user bug when developing on (forgiving) Power9 machines (e.g. Summit)
+cmake_dependent_option(CUDA_WARN_CAPTURE_THIS
+   "Warn if a CUDA lambda captures a class' this" ON
+   "CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL 11.0.194" OFF)
+# no code should ever ship -Werror, but one can turn this on manually in CI if one likes
+cmake_dependent_option(CUDA_ERROR_CAPTURE_THIS
+   "Error if a CUDA lambda captures a class' this" OFF
+   "CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL 11.0.194" OFF)
+cuda_print_option(CUDA_WARN_CAPTURE_THIS)
+cuda_print_option(CUDA_ERROR_CAPTURE_THIS)
+
+# makes things more robust for -Xcompiler pre-fixing unknown nvcc flags
+# note: available with NVCC 10.2.89+; default in CMake 3.17.0+ for supporting NVCCs
+#       https://gitlab.kitware.com/cmake/cmake/-/blob/v3.17.0/Modules/Compiler/NVIDIA-CUDA.cmake
+cmake_dependent_option(CUDA_FORWARD_UNKNOWN_FLAGS_HOST
+   "Forward unknown NVCC flags to the host compiler" ON
+   "CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL 10.2.89;CMAKE_VERSION VERSION_LESS 3.17" OFF)
+
+option(CUDA_PTX_VERBOSE "Verbose code generation statistics in ptxas" OFF)
+cuda_print_option(CUDA_PTX_VERBOSE)
+
+option(CUDA_COMPILATION_TIMER "Generate CSV table with time for each compilation phase" OFF)
+cuda_print_option(CUDA_COMPILATION_TIMER)
+
+# not a good default-candidate for CMAKE_BUILD_TYPE "Debug": often does not
+# compile at all, is very sensitive to further set options, or compiles super slowly;
+# im some cases, such as recursive function usage, apps need to increase
+# `cudaLimitStackSize` in order to not stack overflow with device debug symbols
+# (this costs some extra DRAM).
+option(CUDA_DEBUG "Generate debug information for device code (optimizations: off)" OFF)
+cuda_print_option(CUDA_DEBUG)
+
+set(_CUDA_PERF_NEUTRAL_DEBUG OFF)
+if ("${CMAKE_BUILD_TYPE}" MATCHES "Debug" OR "${CMAKE_BUILD_TYPE}" MATCHES "RelWithDebInfo")
+    set(_CUDA_PERF_NEUTRAL_DEBUG ON)
+endif ()
+
+# both are performance-neutral debug symbols
+option(CUDA_SHOW_LINENUMBERS "Generate line-number information (optimizations: on)"
+       ${_CUDA_PERF_NEUTRAL_DEBUG})
+option(CUDA_SHOW_CODELINES "Generate source information in PTX (optimizations: on)"
+       ${_CUDA_PERF_NEUTRAL_DEBUG})
+cuda_print_option(CUDA_SHOW_LINENUMBERS)
+cuda_print_option(CUDA_SHOW_CODELINES)
+
+option(CUDA_BACKTRACE "Generate host function symbol names (better cuda-memcheck)" ${CUDA_DEBUG})
+cuda_print_option(CUDA_BACKTRACE)
+
+option(CUDA_KEEP_FILES "Keep intermediately generated files (folder: nvcc_tmp)" OFF)
+cuda_print_option(CUDA_KEEP_FILES)
 
 #
 # Error if NVCC is too old
 #
-If (CMAKE_CUDA_COMPILER_VERSION VERSION_LESS "8.0")
+if (CMAKE_CUDA_COMPILER_VERSION VERSION_LESS "8.0")
    message(FATAL_ERROR "Your nvcc version is ${CMAKE_CUDA_COMPILER_VERSION}."
       "This is unsupported. Please use CUDA toolkit version 8.0 or newer.")
 endif ()
@@ -85,6 +153,20 @@ foreach (_item IN LISTS _nvcc_arch_flags)
    endif ()
 
 endforeach ()
+
+if (CUDA_LTO)
+    # we replace
+    #   -gencode=arch=compute_NN,code=sm_NN
+    # with
+    #   -gencode=arch=compute_NN,code=lto_NN
+    set(_nvcc_arch_flags_org ${_nvcc_arch_flags})
+    foreach (_item IN LISTS _nvcc_arch_flags_org)
+       string(REGEX MATCH "[0-9]+" _cuda_compute_capability "${_item}")
+       string(REPLACE "code=sm_${_cuda_compute_capability}"
+                      "code=lto_${_cuda_compute_capability}"
+              _nvcc_arch_flags "${_nvcc_arch_flags}")
+    endforeach ()
+endif ()
 
 if (NOT _nvcc_arch_flags)
    message(FATAL_ERROR "the given target CUDA architectures are not supported by AMReX")
@@ -129,4 +211,66 @@ string(APPEND CMAKE_CUDA_FLAGS " -maxrregcount=${CUDA_MAXREGCOUNT}")
 
 if (ENABLE_CUDA_FASTMATH)
    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --use_fast_math")
+endif ()
+
+#
+# CUDA specific warnings
+#
+if (CUDA_WARN_CAPTURE_THIS)
+    string(APPEND CMAKE_CUDA_FLAGS " --Wext-lambda-captures-this")
+endif()
+if (CUDA_ERROR_CAPTURE_THIS)
+    # note: prefer double-dash --Werror!
+    # https://github.com/ccache/ccache/issues/598
+    string(APPEND CMAKE_CUDA_FLAGS " --Werror ext-lambda-captures-this")
+endif()
+
+#
+# Forward unknown NVCC flags to the host compiler
+#
+if (CUDA_FORWARD_UNKNOWN_FLAGS_HOST)
+    string(APPEND CMAKE_CUDA_FLAGS " --forward-unknown-to-host-compiler")
+endif()
+
+#
+# Code generation
+#
+if (CUDA_PTX_VERBOSE)
+    string(APPEND CMAKE_CUDA_FLAGS " --ptxas-options=-v")
+endif()
+
+# keep intermediately generated files
+if (CUDA_KEEP_FILES)
+    make_directory("${PROJECT_BINARY_DIR}/nvcc_tmp")
+    string(APPEND CMAKE_CUDA_FLAGS " --keep --keep-dir ${PROJECT_BINARY_DIR}/nvcc_tmp")
+endif ()
+
+# compilation timings
+if (CUDA_COMPILATION_TIMER)
+    file(REMOVE "${PROJECT_BINARY_DIR}/nvcc_timings.csv")
+    string(APPEND CMAKE_CUDA_FLAGS " --time ${PROJECT_BINARY_DIR}/nvcc_timings.csv")
+endif ()
+
+#
+# Debugging
+#
+if (CUDA_DEBUG)
+    # is this unsupported with MSVC?
+    string(APPEND CMAKE_CUDA_FLAGS " -G")
+endif()
+
+if (CUDA_SHOW_LINENUMBERS AND NOT CUDA_DEBUG)
+    # nvcc warning : '--device-debug (-G)' overrides '--generate-line-info (-lineinfo)'
+    string(APPEND CMAKE_CUDA_FLAGS " --generate-line-info")
+endif ()
+if (CUDA_SHOW_CODELINES)
+    string(APPEND CMAKE_CUDA_FLAGS " --source-in-ptx")
+endif ()
+
+if (CUDA_BACKTRACE)
+    if (CMAKE_SYSTEM_NAME STREQUAL "Windows")
+        string(APPEND CMAKE_CUDA_FLAGS " -Xcompiler /Zi") # comes with Debug & RelWithDebInfo
+    else ()
+        string(APPEND CMAKE_CUDA_FLAGS " -Xcompiler -rdynamic")
+    endif ()
 endif ()


### PR DESCRIPTION
Add control for more debug and warning flags with NVCC.

- [x] ptx debug infos: performance neutral and good
- [x] compilation timer: useful for interactions with Nvidia engineers & compile-time tuning
- [x] keep files: good for inspecting generated PTX code
- [x] warnings: accidental capture of `this` (CUDA11+)
- [x] device LTO: awesome new feature to try (CUDA11+)
- [x] unknown flags: just forward to host compiler, make build more robust (CUDA10.2+) (automatically set with CMake 3.17.0+: https://gitlab.kitware.com/cmake/cmake/-/blob/v3.17.3/Modules/Compiler/NVIDIA-CUDA.cmake)
- [x] rebase as soon as #1081 was merged
- [x] testing
- [x] wait for GA release
- [x] add docs in the manual