### PR TITLE
Tutorials: Build System Race Condition

### DIFF
--- a/Tutorials/Amr/Advection_AmrLevel/CMakeLists.txt
+++ b/Tutorials/Amr/Advection_AmrLevel/CMakeLists.txt
@@ -39,9 +39,9 @@ target_sources ( ${EXENAME}
 
 set_target_properties ( ${EXENAME} PROPERTIES
    INCLUDE_DIRECTORIES
-   "${INC1};${INC2};${INC3};${CMAKE_CURRENT_BINARY_DIR}/mod_files"
+   "${INC1};${INC2};${INC3};${CMAKE_CURRENT_BINARY_DIR}/${EXENAME}_mod_files"
    Fortran_MODULE_DIRECTORY
-   ${CMAKE_CURRENT_BINARY_DIR}/mod_files
+   ${CMAKE_CURRENT_BINARY_DIR}/${EXENAME}_mod_files
    RUNTIME_OUTPUT_DIRECTORY
    ${CMAKE_CURRENT_BINARY_DIR}/SingleVortex )
 
@@ -85,9 +85,9 @@ target_sources ( ${EXENAME}
 
 set_target_properties ( ${EXENAME} PROPERTIES
    INCLUDE_DIRECTORIES
-   "${INC1};${INC2};${INC3};${CMAKE_CURRENT_BINARY_DIR}/mod_files"
+   "${INC1};${INC2};${INC3};${CMAKE_CURRENT_BINARY_DIR}/${EXENAME}_mod_files"
    Fortran_MODULE_DIRECTORY
-   ${CMAKE_CURRENT_BINARY_DIR}/mod_files
+   ${CMAKE_CURRENT_BINARY_DIR}/${EXENAME}_mod_files
    RUNTIME_OUTPUT_DIRECTORY
    ${CMAKE_CURRENT_BINARY_DIR}/UniformVelocity )
 

--- a/Tutorials/SENSEI/Advection_AmrLevel/CMakeLists.txt
+++ b/Tutorials/SENSEI/Advection_AmrLevel/CMakeLists.txt
@@ -37,9 +37,9 @@ target_sources ( ${EXENAME}
 
 set_target_properties ( ${EXENAME} PROPERTIES      
    INCLUDE_DIRECTORIES
-   "${INC1};${INC2};${INC3};${CMAKE_CURRENT_BINARY_DIR}/mod_files"
+   "${INC1};${INC2};${INC3};${CMAKE_CURRENT_BINARY_DIR}/${EXENAME}_mod_files"
    Fortran_MODULE_DIRECTORY
-   ${CMAKE_CURRENT_BINARY_DIR}/mod_files
+   ${CMAKE_CURRENT_BINARY_DIR}/${EXENAME}_mod_files
    RUNTIME_OUTPUT_DIRECTORY
    ${CMAKE_CURRENT_BINARY_DIR}/SingleVortex )
 
@@ -80,9 +80,9 @@ target_sources ( ${EXENAME}
 
 set_target_properties ( ${EXENAME} PROPERTIES      
    INCLUDE_DIRECTORIES
-   "${INC1};${INC2};${INC3};${CMAKE_CURRENT_BINARY_DIR}/mod_files"
+   "${INC1};${INC2};${INC3};${CMAKE_CURRENT_BINARY_DIR}/${EXENAME}_mod_files"
    Fortran_MODULE_DIRECTORY
-   ${CMAKE_CURRENT_BINARY_DIR}/mod_files
+   ${CMAKE_CURRENT_BINARY_DIR}/${EXENAME}_mod_files
    RUNTIME_OUTPUT_DIRECTORY
    ${CMAKE_CURRENT_BINARY_DIR}/UniformVelocity )
 


### PR DESCRIPTION
Fix a naming collision in generated Fortran modules: with enough build parallelism (N>1), a race condition could lead to sporadically failing builds.

Fix #1025