### PR TITLE
Retain old timestep data during post-timestep regrid

### DIFF
--- a/Src/Amr/AMReX_Amr.cpp
+++ b/Src/Amr/AMReX_Amr.cpp
@@ -2843,9 +2843,12 @@ Amr::regrid (int  lbase,
 
     //
     // Reclaim old-time grid space for all remain levels > lbase.
+    // But skip this if we're in the middle of a post-timestep regrid.
     //
     for(int lev = start; lev <= finest_level; ++lev) {
-	amr_level[lev]->removeOldData();
+        if (!amr_level[lev]->postStepRegrid()) {
+            amr_level[lev]->removeOldData();
+        }
     }
     //
     // Reclaim all remaining storage for levels > new_finest.


### PR DESCRIPTION
Castro uses the post-timestep regrid functionality to trigger a regrid at the end of a timestep instead of at the beginning. However as part of this regrid process we need to be able to retain the old-time level data because we may refer to it in post_timestep. So if we're regridding at the end of a step, we retain that old data rather than immediately reclaiming the space. This way Castro can FillPatch from that data (AMReX-Astro/Castro#1122).