### PR TITLE
FORTLINK: Guess if Unknown

### DIFF
--- a/Tools/CMake/AMReX_Defines.cmake
+++ b/Tools/CMake/AMReX_Defines.cmake
@@ -97,7 +97,8 @@ function ( set_amrex_defines )
 
       set( FORTLINK "" )
 
-      if ( FortranCInterface_GLOBAL_SUFFIX STREQUAL "" )
+      if ( (FortranCInterface_GLOBAL_SUFFIX STREQUAL "" ) AND NOT
+          (FortranCInterface_GLOBAL_CASE STREQUAL "") )
          set(FORTLINK "${FortranCInterface_GLOBAL_CASE}CASE" )
          message(STATUS "Fortran name mangling scheme: ${FORTLINK} (no append underscore)")
       elseif ( (FortranCInterface_GLOBAL_SUFFIX STREQUAL "_")  AND

--- a/Tools/CMake/AMReX_Defines.cmake
+++ b/Tools/CMake/AMReX_Defines.cmake
@@ -105,7 +105,13 @@ function ( set_amrex_defines )
          set(FORTLINK "UNDERSCORE")
          message(STATUS "Fortran name mangling scheme: ${FORTLINK} (lower case, append underscore)")
       else ()
-         message(AUTHOR_WARNING "Fortran to C mangling not compatible with AMReX code")
+         # now we have to guess
+         if (CMAKE_Fortran_COMPILER_ID MATCHES XL) # old IBM prior to XLClang
+             set(FORTLINK "LOWERCASE")
+         else ()
+             set(FORTLINK "UNDERSCORE")
+         endif()
+         message(WARNING "Fortran to C mangling not compatible with AMReX code, assuming '${FORTLINK}'")
       endif ()
 
       add_amrex_define( BL_FORT_USE_${FORTLINK} )  # Only legacy form


### PR DESCRIPTION
Guess the FORTLINK API convention is `UNDERSCORE` for unknown values, unless it's the classic (non-clang) IBM Fortran compiler, where it's `LOWERCASE`.

@JBlaschke encountered this on macOS 10.14.6 with GNU 8.4.0 (from homebrew).