### PR TITLE
Fix line length issues in fixed-form Fortran sources

### DIFF
--- a/Src/CMakeLists.txt
+++ b/Src/CMakeLists.txt
@@ -81,10 +81,6 @@ endif ()
 
 if (ENABLE_LINEAR_SOLVERS)
    add_subdirectory(LinearSolvers)
-   target_link_libraries(amrex
-      PUBLIC
-      $<BUILD_INTERFACE:Flags_Fortran_REQUIRED>
-      )
 endif ()
 
 if (ENABLE_FORTRAN_INTERFACES)
@@ -100,10 +96,6 @@ endif ()
 #
 if (ENABLE_AMRDATA)
    add_subdirectory(Extern/amrdata)
-   target_link_libraries(amrex
-      PUBLIC
-      $<BUILD_INTERFACE:Flags_Fortran_REQUIRED>
-      )
 endif()
 
 if (ENABLE_PROFPARSER)

--- a/Src/Extern/ProfParser/AMReX_AVGDOWN_2D.F
+++ b/Src/Extern/ProfParser/AMReX_AVGDOWN_2D.F
@@ -196,7 +196,8 @@ c
             do j=lo(2),hi(2)
                do i=lo(1),hi(1)
                   do joff=0,lrat-1
-                     crse(i,j,n) = crse(i,j,n) + vol_inv*fine(lrat*i,lrat*j+joff,n)
+                     crse(i,j,n) = crse(i,j,n) +
+     $                    vol_inv*fine(lrat*i,lrat*j+joff,n)
                   end do
                end do
             end do
@@ -206,7 +207,8 @@ c
             do j=lo(2),hi(2)
                do i=lo(1),hi(1)
                   do ioff=0,lrat-1
-                     crse(i,j,n) = crse(i,j,n) + vol_inv*fine(lrat*i+ioff,lrat*j,n)
+                     crse(i,j,n) = crse(i,j,n) +
+     $                    vol_inv*fine(lrat*i+ioff,lrat*j,n)
                   end do
                end do
             end do

--- a/Src/Extern/ProfParser/AMReX_AVGDOWN_3D.F
+++ b/Src/Extern/ProfParser/AMReX_AVGDOWN_3D.F
@@ -13,7 +13,8 @@
 #define SDIM 3
 
       subroutine FORT_CV_AVGDOWN (
-     &     crse,DIMS(crse),nvar,
+     &     crse,DIMS(crse),
+     &     nvar,
      &     fine,DIMS(fine),
      &     lo,hi,ratios)
 c     ----------------------------------------------------------
@@ -31,8 +32,10 @@ c     ----------------------------------------------------------
       integer  lo(SDIM), hi(SDIM)
       integer  nvar
       integer  ratios(SDIM)
-      REAL_T   crse(DIMV(crse),nvar)
-      REAL_T   fine(DIMV(fine),nvar)
+      REAL_T
+     $     crse(DIMV(crse),nvar)
+      REAL_T
+     $     fine(DIMV(fine),nvar)
 
       integer  i, j, k, n, ic, jc, kc, ioff, joff, koff
       integer  lratx,lraty,lratz
@@ -66,7 +69,8 @@ c
                      do ioff = 0, lratx-1
                         do ic = lo(1), hi(1)
                            i = ic*lratx + ioff
-                           crse(ic,jc,kc,n) = crse(ic,jc,kc,n) + fine(i,j,k,n)
+                           crse(ic,jc,kc,n) = crse(ic,jc,kc,n) +
+     $                          fine(i,j,k,n)
                         end do
                      end do
                   end do
@@ -87,7 +91,8 @@ c
       end
       subroutine FORT_CV_AVGDOWN_STAG (
      &     nodal_dir,
-     &     crse,DIMS(crse),nvar,
+     &     crse,DIMS(crse),
+     &     nvar,
      &     fine,DIMS(fine),
      &     lo,hi,ratios)
 c     ----------------------------------------------------------
@@ -106,8 +111,10 @@ c     ----------------------------------------------------------
       integer  lo(SDIM), hi(SDIM)
       integer  nvar
       integer  ratios(SDIM)
-      REAL_T   crse(DIMV(crse),nvar)
-      REAL_T   fine(DIMV(fine),nvar)
+      REAL_T
+     $     crse(DIMV(crse),nvar)
+      REAL_T
+     $     fine(DIMV(fine),nvar)
 
       integer  i, j, k, n, ic, jc, kc, ioff, joff, koff
       integer  lrat
@@ -147,8 +154,8 @@ c
                   do i=lo(1),hi(1)
                      do koff=0,lrat-1
                         do joff=0,lrat-1
-                           crse(i,j,k,n) = crse(i,j,k,n) + 
-     &                          vol_inv*fine(lrat*i,lrat*j+joff,lrat*k+koff,n)
+                           crse(i,j,k,n) = crse(i,j,k,n) + vol_inv*
+     $                          fine(lrat*i,lrat*j+joff,lrat*k+koff,n)
                         end do
                      end do
                   end do
@@ -162,8 +169,8 @@ c
                   do i=lo(1),hi(1)
                      do koff=0,lrat-1
                         do ioff=0,lrat-1
-                           crse(i,j,k,n) = crse(i,j,k,n) + 
-     &                          vol_inv*fine(lrat*i+ioff,lrat*j,lrat*k+koff,n)
+                           crse(i,j,k,n) = crse(i,j,k,n) + vol_inv
+     $                          *fine(lrat*i+ioff,lrat*j,lrat*k+koff,n)
                         end do
                      end do
                   end do
@@ -177,8 +184,8 @@ c
                   do i=lo(1),hi(1)
                      do joff=0,lrat-1
                         do ioff=0,lrat-1
-                           crse(i,j,k,n) = crse(i,j,k,n) + 
-     &                          vol_inv*fine(lrat*i+ioff,lrat*j+joff,lrat*k,n)
+                           crse(i,j,k,n) = crse(i,j,k,n) + vol_inv
+     $                          *fine(lrat*i+ioff,lrat*j+joff,lrat*k,n)
                         end do
                      end do
                   end do
@@ -193,7 +200,8 @@ c
 
 
       subroutine FORT_AVGDOWN (
-     &     crse,DIMS(crse),nvar,
+     &     crse,DIMS(crse),
+     &      nvar,
      &     fine,DIMS(fine),
      &     cv,DIMS(cv),
      &     fv,DIMS(fv),
@@ -217,9 +225,11 @@ c     ----------------------------------------------------------
       integer  lo(SDIM), hi(SDIM)
       integer  nvar
       integer  ratios(SDIM)
-      REAL_T   crse(DIMV(crse),nvar)
+      REAL_T
+     $     crse(DIMV(crse),nvar)
       REAL_T     cv(DIMV(cv))
-      REAL_T   fine(DIMV(fine),nvar)
+      REAL_T
+     $     fine(DIMV(fine),nvar)
       REAL_T     fv(DIMV(fv))
 
       integer  i, j, k, n, ic, jc, kc, ioff, joff, koff

--- a/Src/Extern/amrdata/AMReX_FABUTIL_2D.F
+++ b/Src/Extern/amrdata/AMReX_FABUTIL_2D.F
@@ -199,8 +199,9 @@ c                         --- break ---
 
 
 c ::: --------------------------------------------------------------
-      subroutine FORT_PCINTERP (fine,floi1,floi2,fhii1,fhii2,fblo, fbhi,lrat,
-     $ nvar, crse,cloi1,cloi2,chii1,chii2,cblo, cbhi,temp,tloi,thii)
+      subroutine FORT_PCINTERP (fine,floi1,floi2,fhii1,fhii2,fblo,
+     $     fbhi,lrat,nvar,crse,cloi1,cloi2,chii1,chii2,cblo,
+     $     cbhi,temp,tloi,thii)
 
       integer floi1,floi2
       integer fhii1,fhii2

--- a/Src/Extern/amrdata/AMReX_FABUTIL_3D.F
+++ b/Src/Extern/amrdata/AMReX_FABUTIL_3D.F
@@ -53,7 +53,7 @@ c ::: --------------------------------------------------------------
       integer cblo(3), cbhi(3)
       integer fslo(3), fshi(3)
       integer lratio, nvar, clen, flen, clo, chi
-      REAL_T fine(floi1 :fhii1 ,floi2 :fhii2 ,floi3 :fhii3, nvar)
+      REAL_T fine(floi1:fhii1,floi2:fhii2,floi3:fhii3,nvar)
       REAL_T crse(clo:chi, nvar)
       REAL_T cslope(clo:chi, 3)
       REAL_T fslope(flen, 3)
@@ -356,8 +356,8 @@ c ::: --------------------------------------------------------------
       integer fblo(3), fbhi(3)
       integer cblo(3), cbhi(3)
       integer lrat, nvar, tloi, thii
-      REAL_T fine(floi1 :fhii1 ,floi2 :fhii2 ,floi3 :fhii3, nvar)
-      REAL_T crse(cloi1 :chii1 ,cloi2 :chii2 ,cloi3 :chii3, nvar)
+      REAL_T fine(floi1:fhii1,floi2:fhii2,floi3:fhii3, nvar)
+      REAL_T crse(cloi1:chii1,cloi2:chii2,cloi3:chii3, nvar)
       REAL_T temp(tloi:thii + 1)
 c ::: ::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 c ::: pcinterp:  use piecewise constant interpolation to define
@@ -418,7 +418,7 @@ c ::: --------------------------------------------------------------
       integer cblo(3), cbhi(3)
       integer fslo(3), fshi(3)
       integer lratio, nvar, clen, flen, clo, chi
-      REAL_T fine(floi1 :fhii1 ,floi2 :fhii2 ,floi3 :fhii3, nvar)
+      REAL_T fine(floi1:fhii1,floi2:fhii2,floi3:fhii3,nvar)
       REAL_T crse(clo:chi, nvar)
       REAL_T cslope(clo:chi, 3)
       REAL_T fslope(flen, 3)

--- a/Tools/CMake/AMReXFlagsTargets.cmake
+++ b/Tools/CMake/AMReXFlagsTargets.cmake
@@ -5,7 +5,6 @@
 #   Flags_CXX                 --> Optional flags for C++ code
 #   Flags_Fortran             --> Optional flags for Fortran code
 #   Flags_CXX_REQUIRED        --> Required C++ flags
-#   Flags_Fortran_REQUIRED    --> Required Fortran flags for some components of AMReX
 #   Flags_FPE                 --> Floating-Point Exception flags for both C++ and Fortran
 #
 # These INTERFACE targets can be added to the AMReX export set.
@@ -112,21 +111,6 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
          )
    endif ()
 endif()
-
-#
-# Fortran REQUIRED flags -- This is for internal use only: it is useless to export it
-#
-add_library(Flags_Fortran_REQUIRED INTERFACE)
-add_library(AMReX::Flags_Fortran_REQUIRED ALIAS Flags_Fortran_REQUIRED)
-
-target_compile_options( Flags_Fortran_REQUIRED
-   INTERFACE
-   $<${_fortran_gnu}:-ffixed-line-length-none -ffree-line-length-none>
-   $<${_fortran_intel}:-extend_source>
-   $<${_fortran_pgi}:-Mextend>
-   $<${_fortran_cray}:-N 255 -h list=a>
-   )
-
 
 #
 # Floating point exceptions


### PR DESCRIPTION
Special compilation flags are required to compile fixed-form Fortran sources in order to workaround old Fortran maximum line length limitation.

This PR fixes the few places where the maximum line length is actually exceeded so that no extra-flags will be required. 