### PR TITLE
work with ax3l: fail when fortran c interface could not be found

### DIFF
--- a/Tools/CMake/AMReX_Defines.cmake
+++ b/Tools/CMake/AMReX_Defines.cmake
@@ -93,6 +93,9 @@ function ( set_amrex_defines )
       # Fortran/C mangling scheme
       #
       include( FortranCInterface )
+      if(NOT FortranCInterface_GLOBAL_FOUND)
+          message(FATAL_ERROR "Failed to find the Fortan C Interface -- check the CMakeError.log")
+      endif()
       include( ${FortranCInterface_BINARY_DIR}/Output.cmake )
 
       set( FORTLINK "" )


### PR DESCRIPTION
Following #1126, worked with @ax3l to make cmake give a informative error message and then fail (always a good thing to check return codes)