### PR TITLE
fix clamping in enforcePeriodic

### DIFF
--- a/Src/Particle/AMReX_ParticleUtil.H
+++ b/Src/Particle/AMReX_ParticleUtil.H
@@ -205,13 +205,6 @@ void enforcePeriodic (P& p,
                       amrex::GpuArray<amrex::Real,AMREX_SPACEDIM> const& phi,
                       amrex::GpuArray<int,AMREX_SPACEDIM> const& is_per) noexcept
 {
-    // In rare cases, degenerate cases can be found, filter out with a tolerance
-#if !defined(__CUDACC__) || (__CUDACC_VER_MAJOR__ != 9) || (__CUDACC_VER_MINOR__ != 2)
-    static constexpr Real eps = std::numeric_limits<Real>::epsilon();
-#else
-    static constexpr Real eps = DBL_EPSILON;
-#endif
-
     for (int idim = 0; idim < AMREX_SPACEDIM; ++idim)
     {
         if (not is_per[idim]) continue;
@@ -219,14 +212,16 @@ void enforcePeriodic (P& p,
             while (p.pos(idim) >= phi[idim]) {
                 p.pos(idim) -= (phi[idim] - plo[idim]);
             }
-            if (p.pos(idim) < plo[idim]) p.pos(idim) = plo[idim]; // clamp to avoid precision issues;
+            // clamp to avoid precision issues;
+            if (p.pos(idim) < plo[idim]) p.pos(idim) = plo[idim];
         }
         else if (p.pos(idim) < plo[idim]) {
             while (p.pos(idim) < plo[idim]) {
                 p.pos(idim) += (phi[idim] - plo[idim]);
             }
-            if (p.pos(idim) == phi[idim]) p.pos(idim) = plo[idim]; // clamp to avoid precision issues;
-            if (p.pos(idim) > phi[idim]) p.pos(idim) = phi[idim]-eps; // clamp to avoid precision issues;
+            // clamp to avoid precision issues;
+            if (p.pos(idim) == phi[idim]) p.pos(idim) = plo[idim];
+            if (p.pos(idim) > phi[idim]) p.pos(idim) = std::nextafter( (amrex::ParticleReal) phi[idim], (amrex::ParticleReal) plo[idim]);
         }
     }
 }


### PR DESCRIPTION
@jmsexton03 could you test this and see if it fixes your lost particle issue?

The enforcePeriodic function should always return values in the range [plo, phi). This is not the case in the current implementation, because the machine epsilon refers to the difference between 1.0 and the next representable number for a given floating point type, but that does not mean that, say, 1400.0 - eps is distinct from 1400.0. 

The proposed implementation uses `std::nextafter` to obtain the closest representable number less than phi. I tested this on Summit and it does seem to work in device code, even with cuda 9.2. I also did a test (using clang) that verified the proposed implementation does the right thing for all representable floats in the range plo - 1.0 to phi + 1.0; 