### PR TITLE
Add interfaces for bottom solve Hypre configuration

### DIFF
--- a/Src/Extern/HYPRE/AMReX_Hypre.H
+++ b/Src/Extern/HYPRE/AMReX_Hypre.H
@@ -52,6 +52,12 @@ public:
                              static_cast<HYPRE_Int>(v[2]))};
     }
     
+    void setHypreOldDefault (bool l) noexcept {old_default = l;}
+    void setHypreRelaxType (int n) noexcept {relax_type = n;}
+    void setHypreRelaxOrder (int n) noexcept {relax_order = n;}
+    void setHypreNumSweeps (int n) noexcept {num_sweeps = n;}
+    void setHypreStrongThreshold (Real t) noexcept {strong_threshold = t;}
+
 protected:
 
     static constexpr HYPRE_Int regular_stencil_size = 2*AMREX_SPACEDIM + 1;
@@ -61,6 +67,11 @@ protected:
     Geometry geom;
 
     int verbose = 0;
+    bool old_default = true; // Falgout coarsening with modified classical interpolation
+    int relax_type = 6;  // G-S/Jacobi hybrid relaxation
+    int relax_order = 1; // uses C/F relaxation
+    int num_sweeps = 2;  // Sweeeps on each level
+    Real strong_threshold = 0.25; // Hypre default is 0.25
 
     MultiFab acoefs;
     Array<MultiFab,AMREX_SPACEDIM> bcoefs;

--- a/Src/Extern/HYPRE/AMReX_HypreABecLap3.cpp
+++ b/Src/Extern/HYPRE/AMReX_HypreABecLap3.cpp
@@ -406,13 +406,13 @@ HypreABecLap3::prepareSolver ()
     // Create solver
     HYPRE_BoomerAMGCreate(&solver);
 
-    HYPRE_BoomerAMGSetOldDefault(solver); // Falgout coarsening with modified classical interpolation
+    if (old_default) HYPRE_BoomerAMGSetOldDefault(solver); // Falgout coarsening with modified classical interpolation
 //    HYPRE_BoomerAMGSetCoarsenType(solver, 6);
 //    HYPRE_BoomerAMGSetCycleType(solver, 1);
-    HYPRE_BoomerAMGSetRelaxType(solver, 6);   /* G-S/Jacobi hybrid relaxation */
-    HYPRE_BoomerAMGSetRelaxOrder(solver, 1);   /* uses C/F relaxation */
-    HYPRE_BoomerAMGSetNumSweeps(solver, 2);   /* Sweeeps on each level */
-//    HYPRE_BoomerAMGSetStrongThreshold(solver, 0.6); // default is 0.25
+    HYPRE_BoomerAMGSetRelaxType(solver, relax_type);
+    HYPRE_BoomerAMGSetRelaxOrder(solver, relax_order);
+    HYPRE_BoomerAMGSetNumSweeps(solver, num_sweeps);
+    HYPRE_BoomerAMGSetStrongThreshold(solver, strong_threshold);
 
     int logging = (verbose >= 2) ? 1 : 0;
     HYPRE_BoomerAMGSetLogging(solver, logging);

--- a/Src/LinearSolvers/MLMG/AMReX_MLMG.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLMG.H
@@ -107,6 +107,13 @@ public:
         hypre_interface = f;
 #endif
     }
+
+    void setPreserveHypreSolver (bool l) noexcept {preserve_hypre_solver = l;}
+    void setHypreOldDefault (bool l) noexcept {hypre_old_default = l;}
+    void setHypreRelaxType (int n) noexcept {hypre_relax_type = n;}
+    void setHypreRelaxOrder (int n) noexcept {hypre_relax_order = n;}
+    void setHypreNumSweeps (int n) noexcept {hypre_num_sweeps = n;}
+    void setHypreStrongThreshold (Real t) noexcept {hypre_strong_threshold = t;}
 #endif
 
     void prepareForSolve (const Vector<MultiFab*>& a_sol, const Vector<MultiFab const*>& a_rhs);
@@ -214,6 +221,13 @@ private:
     std::unique_ptr<Hypre> hypre_solver;
     std::unique_ptr<MLMGBndry> hypre_bndry;
     std::unique_ptr<HypreNodeLap> hypre_node_solver;
+
+    bool preserve_hypre_solver = false;
+    bool hypre_old_default = true; // Falgout coarsening with modified classical interpolation
+    int hypre_relax_type = 6;  // G-S/Jacobi hybrid relaxation
+    int hypre_relax_order = 1; // uses C/F relaxation
+    int hypre_num_sweeps = 2;  // Sweeps on each level
+    Real hypre_strong_threshold = 0.25; // Hypre default is 0.25
 #endif
 
     //! PETSc

--- a/Src/LinearSolvers/MLMG/AMReX_MLMG.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLMG.H
@@ -108,7 +108,6 @@ public:
 #endif
     }
 
-    void setPreserveHypreSolver (bool l) noexcept {preserve_hypre_solver = l;}
     void setHypreOldDefault (bool l) noexcept {hypre_old_default = l;}
     void setHypreRelaxType (int n) noexcept {hypre_relax_type = n;}
     void setHypreRelaxOrder (int n) noexcept {hypre_relax_order = n;}
@@ -222,7 +221,6 @@ private:
     std::unique_ptr<MLMGBndry> hypre_bndry;
     std::unique_ptr<HypreNodeLap> hypre_node_solver;
 
-    bool preserve_hypre_solver = false;
     bool hypre_old_default = true; // Falgout coarsening with modified classical interpolation
     int hypre_relax_type = 6;  // G-S/Jacobi hybrid relaxation
     int hypre_relax_order = 1; // uses C/F relaxation

--- a/Src/LinearSolvers/MLMG/AMReX_MLMG.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLMG.cpp
@@ -1132,9 +1132,11 @@ MLMG::prepareForSolve (const Vector<MultiFab*>& a_sol, const Vector<MultiFab con
     }
 
 #ifdef AMREX_USE_HYPRE
-    hypre_solver.reset();
-    hypre_bndry.reset();
-    hypre_node_solver.reset();
+    if (!preserve_hypre_solver) {
+      hypre_solver.reset();
+      hypre_bndry.reset();
+      hypre_node_solver.reset();
+    }
 #endif
 
 #ifdef AMREX_USE_PETSC
@@ -1829,6 +1831,11 @@ MLMG::bottomSolveWithHypre (MultiFab& x, const MultiFab& b)
         {
             hypre_solver = linop.makeHypre(hypre_interface);
             hypre_solver->setVerbose(bottom_verbose);
+            hypre_solver->setHypreOldDefault(hypre_old_default);
+            hypre_solver->setHypreRelaxType(hypre_relax_type);
+            hypre_solver->setHypreRelaxOrder(hypre_relax_order);
+            hypre_solver->setHypreNumSweeps(hypre_num_sweeps);
+            hypre_solver->setHypreStrongThreshold(hypre_strong_threshold);
 
             const BoxArray& ba = linop.m_grids[amrlev].back();
             const DistributionMapping& dm = linop.m_dmap[amrlev].back();

--- a/Src/LinearSolvers/MLMG/AMReX_MLMG.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLMG.cpp
@@ -1129,20 +1129,18 @@ MLMG::prepareForSolve (const Vector<MultiFab*>& a_sol, const Vector<MultiFab con
         linop_prepared = true;
     } else if (linop.needsUpdate()) {
         linop.update();
-    }
 
 #ifdef AMREX_USE_HYPRE
-    if (!preserve_hypre_solver) {
-      hypre_solver.reset();
-      hypre_bndry.reset();
-      hypre_node_solver.reset();
-    }
+        hypre_solver.reset();
+        hypre_bndry.reset();
+        hypre_node_solver.reset();
 #endif
 
 #ifdef AMREX_USE_PETSC
-    petsc_solver.reset(); 
-    petsc_bndry.reset(); 
+        petsc_solver.reset(); 
+        petsc_bndry.reset(); 
 #endif
+    }
 
     sol.resize(namrlevs);
     sol_raii.resize(namrlevs);


### PR DESCRIPTION
We use MLMG as an interface to Hypre to use as a preconditioner. This means we want to set up Hypre and then apply the solver to many different vectors, and only pay for a new Hypre setup call when we change the matrix. We also want a slightly different Hypre configuration than what is currently in AMReX.

This PR introduces some MLMG interfaces for a user to decide whether to preserve the Hypre solver (don't delete it at every solve call) and change the Hypre configuration. I've tried to maintain AMReX's default behavior, so if none of the new MLMG methods are called, the current behavior remains the same.

Please let me know if this looks alright / if you would like any changes. Thanks!