### PR TITLE
Remove the sumParticleMass function, which has been deprecated in fav…

### DIFF
--- a/Src/Particle/AMReX_ParticleContainerI.H
+++ b/Src/Particle/AMReX_ParticleContainerI.H
@@ -681,34 +681,6 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>::IncrementWith
 }
 
 template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt>
-Real
-ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>::sumParticleMass (int rho_index, int lev, bool local) const
-{
-  BL_PROFILE("ParticleContainer::sumParticleMass(lev)");
-  AMREX_ASSERT(NStructReal >= 1);
-  AMREX_ASSERT(lev >= 0 && lev < int(m_particles.size()));
-
-  Real msum = 0;
-
-  const auto& pmap = m_particles[lev];
-  for (const auto& kv : pmap) {
-      const auto& pbox = kv.second.GetArrayOfStructs();
-      for (int k = 0; k < pbox.numParticles(); ++k) {
-	  const ParticleType& p = pbox[k];
-	  if (p.id() > 0) {
-	      msum += p.rdata(rho_index);
-	  }
-      }
-  }
-
-  if (!local) {
-      ParallelAllReduce::Sum(msum, ParallelContext::CommunicatorSub());
-  }
-
-  return msum;
-}
-
-template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt>
 void
 ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>::RemoveParticlesAtLevel (int level)
 {

--- a/Src/Particle/AMReX_Particles.H
+++ b/Src/Particle/AMReX_Particles.H
@@ -516,15 +516,6 @@ public:
     Long IncrementWithTotal (MultiFab& mf, int level, bool local = false);
 
     /**
-    * \brief rho_index: rho index in rdata
-    *
-    * \param rho_index
-    * \param level
-    * \param local
-    */
-    Real sumParticleMass (int rho_index, int level, bool local = false) const;
-
-    /**
     * \brief Redistribute puts all the particles back in the right places (for some value of right)
     *
     * Assigns particles to the levels, grids, and tiles that contain their current positions. 


### PR DESCRIPTION
…or of the generic reduction functions that also work on the GPU.

This has been removed from Nyx, which is the only place where it was used.