### PR TITLE
Optimization of TagBoxArray::collate

### DIFF
--- a/Src/AmrCore/AMReX_AmrMesh.cpp
+++ b/Src/AmrCore/AMReX_AmrMesh.cpp
@@ -682,10 +682,10 @@ AmrMesh::MakeNewGrids (int lbase, Real time, int& new_finest, Vector<BoxArray>& 
         //
         // Map tagged points through periodic boundaries, if any.
         //
-        tags.mapPeriodic(Geometry(pc_domain[levc],
-                                  Geom(levc).ProbDomain(),
-                                  Geom(levc).CoordInt(),
-                                  Geom(levc).isPeriodic()));
+        tags.mapPeriodicRemoveDuplicates(Geometry(pc_domain[levc],
+                                                  Geom(levc).ProbDomain(),
+                                                  Geom(levc).CoordInt(),
+                                                  Geom(levc).isPeriodic()));
         //
         // Remove cells outside proper nesting domain for this level.
         //
@@ -704,38 +704,41 @@ AmrMesh::MakeNewGrids (int lbase, Real time, int& new_finest, Vector<BoxArray>& 
             //
             if ( !(useFixedCoarseGrids() && levc<useFixedUpToLevel()) ) {
                 new_finest = std::max(new_finest,levf);
-	    }
-            //
-            // Construct initial cluster.
-            //
-            ClusterList clist(&tagvec[0], tagvec.size());
-            if (use_new_chop)
-            {
-               clist.new_chop(grid_eff);
-            } else {
-               clist.chop(grid_eff);
             }
-            BoxDomain bd;
-            bd.add(p_n[levc]);
-            clist.intersect(bd);
-            bd.clear();
-            //
-            // Efficient properly nested Clusters have been constructed
-            // now generate list of grids at level levf.
-            //
-            BoxList new_bx;
-            clist.boxList(new_bx);
-            new_bx.refine(bf_lev[levc]);
-            new_bx.simplify();
-            BL_ASSERT(new_bx.isDisjoint());
 
-	    if (new_bx.size()>0) {
-		if ( !(Geom(levc).Domain().contains(BoxArray(new_bx).minimalBox())) ) {
-		// Chop new grids outside domain, note that this is likely to result in
-		//  new grids that violate blocking_factor....see warning checking below
-		    new_bx = amrex::intersect(new_bx,Geom(levc).Domain());
-		}
-	    }
+            BoxList new_bx;
+            if (ParallelDescriptor::IOProcessor()) {
+                //
+                // Construct initial cluster.
+                //
+                ClusterList clist(&tagvec[0], tagvec.size());
+                if (use_new_chop) {
+                    clist.new_chop(grid_eff);
+                } else {
+                    clist.chop(grid_eff);
+                }
+                BoxDomain bd;
+                bd.add(p_n[levc]);
+                clist.intersect(bd);
+                bd.clear();
+                //
+                // Efficient properly nested Clusters have been constructed
+                // now generate list of grids at level levf.
+                //
+                clist.boxList(new_bx);
+                new_bx.refine(bf_lev[levc]);
+                new_bx.simplify();
+                BL_ASSERT(new_bx.isDisjoint());
+
+                if (new_bx.size()>0) {
+                    if ( !(Geom(levc).Domain().contains(BoxArray(new_bx).minimalBox())) ) {
+                        // Chop new grids outside domain, note that this is likely to result in
+                        //  new grids that violate blocking_factor....see warning checking below
+                        new_bx = amrex::intersect(new_bx,Geom(levc).Domain());
+                    }
+                }
+            }
+            new_bx.Bcast();  // Broadcast the enw BoxList to other processes
 
             const IntVect& largest_grid_size = max_grid_size[levf] / ref_ratio[levc];
             //
@@ -976,6 +979,22 @@ AmrMesh::checkInput ()
                  amrex::Print() << "blocking_factor is " << blocking_factor[i][idim] << std::endl;
                  amrex::Error("max_grid_size not divisible by blocking_factor");
               }
+            }
+        }
+    }
+
+    // Make sure TagBoxArray has no overlapped valid cells after coarsening by block_factor/ref_ratio
+    for (int i = 0; i < max_level; ++i) {
+        for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+            int bf_lev = std::max(1,blocking_factor[i+1][idim]/ref_ratio[i][idim]);
+            int min_grid_size = std::min(blocking_factor[i][idim],max_grid_size[i][idim]);
+            if (min_grid_size % bf_lev != 0) {
+                amrex::Print() << "On level " << i << " in direction " << idim
+                               << " max_grid_size is " << max_grid_size[i][idim]
+                               << " blocking factor is " << blocking_factor[i][idim] << "\n"
+                               << "On level " << i+1 << " in direction " << idim
+                               << " blocking_factor is " << blocking_factor[i+1][idim] << std::endl;
+                amrex::Error("Coarse level blocking factor not a multiple of fine level blocking factor divided by ref ratio");
             }
         }
     }

--- a/Src/AmrCore/AMReX_Cluster.cpp
+++ b/Src/AmrCore/AMReX_Cluster.cpp
@@ -5,6 +5,7 @@
 #include <AMReX_BoxDomain.H>
 #include <AMReX_Vector.H>
 #include <AMReX_Array.H>
+#include <AMReX_BLProfiler.H>
 
 namespace amrex {
 
@@ -522,6 +523,7 @@ ClusterList::boxList (BoxList& blst) const
 void
 ClusterList::chop (Real eff)
 {
+    BL_PROFILE("ClusterList::chop()");
 
     for (std::list<Cluster*>::iterator cli = lst.begin(); cli != lst.end(); )
     {
@@ -539,6 +541,7 @@ ClusterList::chop (Real eff)
 void
 ClusterList::new_chop (Real eff)
 {
+    BL_PROFILE("ClusterList::new_chop()");
 
     for (std::list<Cluster*>::iterator cli = lst.begin(); cli != lst.end(); )
     {
@@ -556,6 +559,8 @@ ClusterList::new_chop (Real eff)
 void
 ClusterList::intersect (const BoxDomain& dom)
 {
+    BL_PROFILE("ClusterList::intersect()");
+
     //
     // Make a BoxArray covering dom.
     // We'll use this to speed up the contains() test below.

--- a/Src/AmrCore/AMReX_TagBox.H
+++ b/Src/AmrCore/AMReX_TagBox.H
@@ -57,11 +57,8 @@ public:
     /**
     * \brief Construct and return a new tagbox in which the coarsened cell
     * is tagged of any of the corresponding fine cells are tagged.
-    *
-    * \param ratio
-    * \param owner
     */
-    void coarsen (const IntVect& ratio) noexcept;
+    void coarsen (const IntVect& ratio, const Box& cbox) noexcept;
 
     /**
     * \brief Mark neighbors of every tagged cell a distance nbuff away
@@ -72,13 +69,6 @@ public:
     * \param nwid
     */
     void buffer (const IntVect& nbuf, const IntVect& nwid) noexcept;
-
-    /**
-    * \brief Tag cells on intersect with src if corresponding src cell is tagged.
-    *
-    * \param src
-    */
-    void merge (const TagBox& src) noexcept;
 
     /**
     * \brief Add location of every tagged cell to IntVect array,
@@ -183,16 +173,10 @@ public:
     ~TagBoxArray () override = default;
 
     TagBoxArray (TagBoxArray&& rhs) noexcept = default;
+    TagBoxArray& operator= (TagBoxArray&& rhs) noexcept = default;
 
     TagBoxArray (const TagBoxArray& rhs) = delete;
     TagBoxArray& operator= (const TagBoxArray& rhs) = delete;
-    TagBoxArray& operator= (TagBoxArray&& rhs) = delete;
-
-
-    /**
-    * \brief Returns the grow factor for the TagBoxArray.
-    */
-    IntVect borderSize () const noexcept;
 
     /**
     * \brief Calls buffer() on all contained TagBoxes.
@@ -202,12 +186,12 @@ public:
     void buffer (const IntVect& nbuf);
 
     /**
-    * \brief Map tagged cells through a periodic boundary to other grids in
-    * TagBoxArray cells which were outside domain are set to TagBox::CLEAR.
+    * \brief This funciton does two things.  Map tagged cells through a periodic boundary to other
+    * grids in TagBoxArray cells, and remove duplicates.
     *
     * \param geom
     */
-    void mapPeriodic (const Geometry& geom);
+    void mapPeriodicRemoveDuplicates (const Geometry& geom);
 
     /**
     * \brief Set values in bl to val.

--- a/Src/Base/AMReX_BoxList.H
+++ b/Src/Base/AMReX_BoxList.H
@@ -210,6 +210,8 @@ public:
 	std::swap(btype, rhs.btype);
     }
 
+    void Bcast ();
+
 private:
     //! Core simplify routine.
     int simplify_doit (bool best);

--- a/Src/Base/AMReX_BoxList.cpp
+++ b/Src/Base/AMReX_BoxList.cpp
@@ -802,4 +802,16 @@ BoxList::operator== (const BoxList& rhs) const
     return true;
 }
 
+void
+BoxList::Bcast ()
+{
+    int nboxes = this->size();
+    const int IOProcNumber = ParallelDescriptor::IOProcessorNumber();
+    ParallelDescriptor::Bcast(&nboxes, 1, IOProcNumber);
+    if (ParallelDescriptor::MyProc() != IOProcNumber) {
+        m_lbox.resize(nboxes);
+    }
+    ParallelDescriptor::Bcast(m_lbox.data(), nboxes, IOProcNumber);
+}
+
 }


### PR DESCRIPTION
Use a new way to remove duplicated tags.  Instead of removing duplicated from vector, we remove
duplicates when tags are still stored in FabArray.  Because they are in FabArray with a BoxArray
that has no overlapped valid cells, we can use ParallelAdd to remove duplicates due to the overlap
of valid cells with ghost cells.

Assertion in AmrCore on blocking factor to make sure that there are no overlapped valid cells in
TagBoxArray after coarsening.

Use int version of Gatherv.  The long version is not scalable.

Broadcast pre-maxsized BoxList instead of tags.  In most cases, this should reduce the amount of
data to be broadcasted.