### PR TITLE
GatherLayoutDataToVector and DistributionMapping

### DIFF
--- a/Src/Base/AMReX_DistributionMapping.cpp
+++ b/Src/Base/AMReX_DistributionMapping.cpp
@@ -1522,42 +1522,45 @@ DistributionMapping::ComputeDistributionMappingEfficiency (const DistributionMap
     *efficiency = (std::accumulate(rankToCost.begin(),
                                    rankToCost.end(), 0.0) / (nprocs*maxCost));
 }
-  
+
+namespace {
+Vector<Long>
+gather_weights (const MultiFab& weight)
+{
+#ifdef AMREX_USE_MPI
+    LayoutData<Real> costld;
+#ifdef _OPENMP
+#pragma omp parallel if (Gpu::notInLaunchRegion())
+#endif
+    for (MFIter mfi(weight); mfi.isValid(); ++mfi) {
+        costld[mfi] = weight[mfi].sum<RunOn::Device>(mfi.validbox(),0);
+    }
+    Vector<Real> rcost(weight.size());
+    ParallelDescriptor::GatherLayoutDataToVector(costld, rcost,
+                                                 ParallelContext::IOProcessorNumberSub());
+    ParallelDescriptor::Bcast(rcost.data(), rcost.size(), ParallelContext::IOProcessorNumberSub());
+    Real wmax = *std::max_element(rcost.begin(), rcost.end());
+    Real scale = (wmax == 0) ? 1.e9 : 1.e9/wmax;
+    Vector<Long> lcost(rcost.size());
+    for (int i = 0; i < rcost.size(); ++i) {
+        lcost[i] = static_cast<Long>(rcost[i]*scale) + 1L;
+    }
+    return lcost;
+#else
+    return Vector<Long>(weight.size(), 1L);
+#endif
+}
+}
+
 DistributionMapping
 DistributionMapping::makeKnapSack (const MultiFab& weight, int nmax)
 {
     BL_PROFILE("makeKnapSack");
-
-    DistributionMapping r;
-
-    Vector<Long> cost(weight.size());
-#ifdef BL_USE_MPI
-    {
-	Vector<Real> rcost(cost.size(), 0.0);
-#ifdef _OPENMP
-#pragma omp parallel
-#endif
-	for (MFIter mfi(weight); mfi.isValid(); ++mfi) {
-	    int i = mfi.index();
-	    rcost[i] = weight[mfi].sum<RunOn::Device>(mfi.validbox(),0);
-	}
-
-	ParallelAllReduce::Sum(&rcost[0], rcost.size(), ParallelContext::CommunicatorSub());
-
-	Real wmax = *std::max_element(rcost.begin(), rcost.end());
-	Real scale = (wmax == 0) ? 1.e9 : 1.e9/wmax;
-
-	for (int i = 0; i < rcost.size(); ++i) {
-	    cost[i] = Long(rcost[i]*scale) + 1L;
-	}
-    }
-#endif
-
+    Vector<Long> cost = gather_weights(weight);
     int nprocs = ParallelContext::NProcsSub();
     Real eff;
-
+    DistributionMapping r;
     r.KnapSackProcessorMap(cost, nprocs, &eff, true, nmax);
-
     return r;
 }
 
@@ -1565,71 +1568,21 @@ DistributionMapping
 DistributionMapping::makeKnapSack (const MultiFab& weight, Real& eff, int nmax)
 {
     BL_PROFILE("makeKnapSack");
-
-    DistributionMapping r;
-
-    Vector<Long> cost(weight.size());
-#ifdef BL_USE_MPI
-    {
-        Vector<Real> rcost(cost.size(), 0.0);
-#ifdef _OPENMP
-#pragma omp parallel
-#endif
-        for (MFIter mfi(weight); mfi.isValid(); ++mfi) {
-            int i = mfi.index();
-            rcost[i] = weight[mfi].sum<RunOn::Device>(mfi.validbox(),0);
-        }
-
-        ParallelAllReduce::Sum(&rcost[0], rcost.size(), ParallelContext::CommunicatorSub());
-
-        Real wmax = *std::max_element(rcost.begin(), rcost.end());
-        Real scale = (wmax == 0) ? 1.e9 : 1.e9/wmax;
-
-        for (int i = 0; i < rcost.size(); ++i) {
-            cost[i] = Long(rcost[i]*scale) + 1L;
-        }
-    }
-#endif
-
+    Vector<Long> cost = gather_weights(weight);
     int nprocs = ParallelContext::NProcsSub();
-
+    DistributionMapping r;
     r.KnapSackProcessorMap(cost, nprocs, &eff, true, nmax);
-
     return r;
 }
 
 DistributionMapping
 DistributionMapping::makeRoundRobin (const MultiFab& weight)
 {
-    DistributionMapping r;
-
-    Vector<Long> cost(weight.size());
-#ifdef BL_USE_MPI
-    {
-	Vector<Real> rcost(cost.size(), 0.0);
-#ifdef _OPENMP
-#pragma omp parallel
-#endif
-	for (MFIter mfi(weight); mfi.isValid(); ++mfi) {
-	    int i = mfi.index();
-	    rcost[i] = weight[mfi].sum<RunOn::Device>(mfi.validbox(),0);
-	}
-
-	ParallelAllReduce::Sum(&rcost[0], rcost.size(), ParallelContext::CommunicatorSub());
-
-	Real wmax = *std::max_element(rcost.begin(), rcost.end());
-        Real scale = (wmax == 0) ? 1.e9 : 1.e9/wmax;
-
-	for (int i = 0; i < rcost.size(); ++i) {
-	    cost[i] = Long(rcost[i]*scale) + 1L;
-	}
-    }
-#endif
-
+    BL_PROFILE("makeRoundRobin");
+    Vector<Long> cost = gather_weights(weight);
     int nprocs = ParallelContext::NProcsSub();
-
+    DistributionMapping r;
     r.RoundRobinProcessorMap(cost, nprocs);
-
     return r;
 }
 
@@ -1637,36 +1590,10 @@ DistributionMapping
 DistributionMapping::makeSFC (const MultiFab& weight, bool sort)
 {
     BL_PROFILE("makeSFC");
-
-    DistributionMapping r;
-
-    Vector<Long> cost(weight.size());
-#ifdef BL_USE_MPI
-    {
-	Vector<Real> rcost(cost.size(), 0.0);
-#ifdef _OPENMP
-#pragma omp parallel
-#endif
-	for (MFIter mfi(weight); mfi.isValid(); ++mfi) {
-	    int i = mfi.index();
-	    rcost[i] = weight[mfi].sum<RunOn::Device>(mfi.validbox(),0);
-	}
-
-	ParallelAllReduce::Sum(&rcost[0], rcost.size(), ParallelContext::CommunicatorSub());
-
-	Real wmax = *std::max_element(rcost.begin(), rcost.end());
-        Real scale = (wmax == 0) ? 1.e9 : 1.e9/wmax;
-
-	for (int i = 0; i < rcost.size(); ++i) {
-	    cost[i] = Long(rcost[i]*scale) + 1L;
-	}
-    }
-#endif
-
+    Vector<Long> cost = gather_weights(weight);
     int nprocs = ParallelContext::NProcsSub();
-
+    DistributionMapping r;
     r.SFCProcessorMap(weight.boxArray(), cost, nprocs, sort);
-
     return r;
 }
 
@@ -1674,36 +1601,10 @@ DistributionMapping
 DistributionMapping::makeSFC (const MultiFab& weight, Real& eff, bool sort)
 {
     BL_PROFILE("makeSFC");
-
-    DistributionMapping r;
-
-    Vector<Long> cost(weight.size());
-#ifdef BL_USE_MPI
-    {
-        Vector<Real> rcost(cost.size(), 0.0);
-#ifdef _OPENMP
-#pragma omp parallel
-#endif
-        for (MFIter mfi(weight); mfi.isValid(); ++mfi) {
-            int i = mfi.index();
-            rcost[i] = weight[mfi].sum<RunOn::Device>(mfi.validbox(),0);
-        }
-
-	ParallelAllReduce::Sum(&rcost[0], rcost.size(), ParallelContext::CommunicatorSub());
-
-        Real wmax = *std::max_element(rcost.begin(), rcost.end());
-        Real scale = (wmax == 0) ? 1.e9 : 1.e9/wmax;
-
-        for (int i = 0; i < rcost.size(); ++i) {
-            cost[i] = Long(rcost[i]*scale) + 1L;
-        }
-    }
-#endif
-
+    Vector<Long> cost = gather_weights(weight);
     int nprocs = ParallelContext::NProcsSub();
-
+    DistributionMapping r;
     r.SFCProcessorMap(weight.boxArray(), cost, nprocs, eff, sort);
-
     return r;
 }
 

--- a/Src/Base/AMReX_ParallelDescriptor.H
+++ b/Src/Base/AMReX_ParallelDescriptor.H
@@ -1033,8 +1033,8 @@ ParallelDescriptor::GatherLayoutDataToVector (const LayoutData<T>& sendbuf,
         T_to_send.push_back(sendbuf[i]);
     }
 
-    int nprocs = ParallelDescriptor::NProcs();
-    Vector<Long> recvcount(nprocs, 0);
+    int nprocs = ParallelContext::NProcsSub();
+    Vector<int> recvcount(nprocs, 0);
     const Vector<int>& old_pmap = sendbuf.DistributionMap().ProcessorMap();
     for (int i=0; i<old_pmap.size(); ++i)
     {
@@ -1066,22 +1066,21 @@ ParallelDescriptor::GatherLayoutDataToVector (const LayoutData<T>& sendbuf,
         }
     }
 
-    Vector<Long> disp(nprocs);
+    Vector<int> disp(nprocs);
     disp[0] = 0;
     std::partial_sum(recvcount.begin(), recvcount.end()-1, disp.begin()+1);
     Vector<T> new_index_to_T(sendbuf.size());
 
-    ParallelDescriptor::Gatherv(&T_to_send[0],
-                                T_to_send.size(),
-                                &new_index_to_T[0],
-                                recvcount,
-                                disp,
-                                root);
+    MPI_Gatherv(T_to_send.data(), T_to_send.size(),
+                ParallelDescriptor::Mpi_typemap<T>::type(),
+                new_index_to_T.data(), recvcount.data(), disp.data(),
+                ParallelDescriptor::Mpi_typemap<T>::type(),
+                root, ParallelContext::CommunicatorSub());
 
     // Now work just on the root, which now has global information on the collected;
     // LayoutData information; with new_index_to_old_index and new_index_to_T,
     // sort the gathered vector in pre-gather index space
-    if (ParallelDescriptor::MyProc() == root)
+    if (ParallelContext::MyProcSub() == root)
     {
         // Invert the map (new_index) --> (old_index)
         Vector<int> old_index_to_new_index(sendbuf.size());


### PR DESCRIPTION
Use int version of gatherv because the long version is not scalable.  Use GatherLayoutDataToVector
in DistributionMapping because it is faster than ReduceSum.