### PR TITLE
Add alternative error tagging class

### DIFF
--- a/Src/AmrCore/AMReX_ErrorList.H
+++ b/Src/AmrCore/AMReX_ErrorList.H
@@ -8,8 +8,12 @@
 #include <AMReX_Vector.H>
 #include <AMReX_REAL.H>
 #include <AMReX_ArrayLim.H>
+#include <AMReX_MultiFab.H>
+#include <AMReX_TagBox.H>
+#include <AMReX_Geometry.H>
 
 namespace amrex {
+
 
 extern "C"
 {
@@ -372,6 +376,86 @@ private:
 
 std::ostream& operator << (std::ostream& os, const ErrorList& elst);
 
+  struct AMRErrorTagInfo
+  {
+    int            m_max_level;
+    amrex::Real    m_min_time;
+    amrex::Real    m_max_time;
+    amrex::RealBox m_realbox;
+
+    AMRErrorTagInfo () noexcept : m_max_level(-1), m_min_time(-1), m_max_time(-1), m_realbox(amrex::RealBox()) {}
+
+    AMRErrorTagInfo& SetMaxLevel (int max_level) noexcept {
+      m_max_level = max_level;
+      return *this;
+    }
+    AMRErrorTagInfo& SetMinTime (amrex::Real min_time) noexcept {
+      m_min_time = min_time;
+      return *this;
+    }
+    AMRErrorTagInfo& SetMaxTime (amrex::Real max_time) noexcept {
+      m_max_time = max_time;
+      return *this;
+    }
+    AMRErrorTagInfo& SetRealBox (const amrex::RealBox& realbox) noexcept {
+      m_realbox = realbox;
+      return *this;
+    }
+  };
+
+  class AMRErrorTag
+  {
+  public:
+
+    enum TEST {GRAD=0, LESS, GREATER, VORT, BOX, USER};
+
+    struct UserFunc
+    {
+      virtual void operator() (const amrex::Box&                       bx,
+                               amrex::Array4<const amrex::Real> const& dat,
+                               amrex::Array4<char> const&              tag,
+                               amrex::Real                             time,
+                               int                                     level,
+                               int                                     tagval,
+                               int                                     clearval) = 0;
+    };
+
+    AMRErrorTag (const AMRErrorTagInfo& info = AMRErrorTagInfo()) noexcept
+      : m_test(BOX), m_field(std::string()), m_info(info) {SetNGrow();}
+
+    AMRErrorTag (amrex::Real            value,
+                 AMRErrorTag::TEST      test,
+                 const std::string&     field,
+                 const AMRErrorTagInfo& info = AMRErrorTagInfo()) noexcept
+      : m_value(value), m_test(test), m_field(field), m_info(info) {SetNGrow();}
+
+    AMRErrorTag (AMRErrorTag::UserFunc* userfunc,
+                 const std::string&     field,
+                 int                    ngrow,
+                 const AMRErrorTagInfo& info = AMRErrorTagInfo()) noexcept
+      : m_userfunc(userfunc), m_field(field), m_ngrow(ngrow), m_info(info) {}
+
+    virtual void operator() (amrex::TagBoxArray&    tb,
+                             const amrex::MultiFab* mf,
+                             int                    clearval,
+                             int                    tagval,
+                             amrex::Real            time,
+                             int                    level,
+                             const amrex::Geometry& geom) const noexcept;
+
+    int NGrow() const noexcept {return m_ngrow;}
+    const std::string& Field () const noexcept {return m_field;}
+
+  protected:
+    int SetNGrow () const noexcept;
+
+    Real m_value;    
+    TEST m_test;
+    UserFunc* m_userfunc = nullptr;
+    std::string m_field;
+    int m_ngrow;
+    AMRErrorTagInfo m_info;
+  };
 }
 
 #endif

--- a/Src/AmrCore/AMReX_ErrorList.H
+++ b/Src/AmrCore/AMReX_ErrorList.H
@@ -378,12 +378,10 @@ std::ostream& operator << (std::ostream& os, const ErrorList& elst);
 
   struct AMRErrorTagInfo
   {
-    int            m_max_level;
-    amrex::Real    m_min_time;
-    amrex::Real    m_max_time;
-    amrex::RealBox m_realbox;
-
-    AMRErrorTagInfo () noexcept : m_max_level(-1), m_min_time(-1), m_max_time(-1), m_realbox(amrex::RealBox()) {}
+    int m_max_level = 100000;
+    Real m_min_time = std::numeric_limits<Real>::lowest();
+    Real m_max_time = std::numeric_limits<Real>::max();
+    RealBox m_realbox;
 
     AMRErrorTagInfo& SetMaxLevel (int max_level) noexcept {
       m_max_level = max_level;
@@ -416,18 +414,18 @@ std::ostream& operator << (std::ostream& os, const ErrorList& elst);
                                amrex::Array4<char> const&              tag,
                                amrex::Real                             time,
                                int                                     level,
-                               int                                     tagval,
-                               int                                     clearval) = 0;
+                               char                                    tagval,
+                               char                                    clearval) = 0;
     };
 
-    AMRErrorTag (const AMRErrorTagInfo& info = AMRErrorTagInfo()) noexcept
-      : m_test(BOX), m_field(std::string()), m_info(info) {SetNGrow();}
+    explicit AMRErrorTag (const AMRErrorTagInfo& info = AMRErrorTagInfo()) noexcept
+      : m_test(BOX), m_field(std::string()), m_info(info) {m_ngrow = SetNGrow();}
 
     AMRErrorTag (amrex::Real            value,
                  AMRErrorTag::TEST      test,
                  const std::string&     field,
                  const AMRErrorTagInfo& info = AMRErrorTagInfo()) noexcept
-      : m_value(value), m_test(test), m_field(field), m_info(info) {SetNGrow();}
+      : m_value(value), m_test(test), m_field(field), m_info(info) {m_ngrow = SetNGrow();}
 
     AMRErrorTag (AMRErrorTag::UserFunc* userfunc,
                  const std::string&     field,
@@ -437,8 +435,8 @@ std::ostream& operator << (std::ostream& os, const ErrorList& elst);
 
     virtual void operator() (amrex::TagBoxArray&    tb,
                              const amrex::MultiFab* mf,
-                             int                    clearval,
-                             int                    tagval,
+                             char                   clearval,
+                             char                   tagval,
                              amrex::Real            time,
                              int                    level,
                              const amrex::Geometry& geom) const noexcept;
@@ -453,8 +451,8 @@ std::ostream& operator << (std::ostream& os, const ErrorList& elst);
     TEST m_test;
     UserFunc* m_userfunc = nullptr;
     std::string m_field;
-    int m_ngrow;
     AMRErrorTagInfo m_info;
+    int m_ngrow;
   };
 }
 


### PR DESCRIPTION
This PR introduces an alternative to ErrorRec/ErrorList for managing error tagging.  It supports building (GPU-SAFE) tagging functions on the fly via ParmParse inputs, something like:
```
amrex::Vector<amrex::AMRErrorTag> errtags;
errtags.push_back(AMRErrorTag(value,AMRErrorTag::GREATER,field,info));
```
Then later, they are called to tag as:
```
  for (int j=0; j<errtags.size(); ++j) {
    std::unique_ptr<MultiFab> mf;
    if (errtags[0].Field() != std::string()) {
      mf = std::unique_ptr<MultiFab>(derive(errtags[j].Field(), time, errtags[j].NGrow()));
    }
    errtags[j](tags,mf.get(),clearval,tagval,time,level,geom);
  }
```
At the moment, standard support is provided for BOX (over physical region), LESS, GREATER, GRAD, as well as a special one, VORT, for vorticity over AMR levels. and USER.  USER is close to AMReX-classic error tagging functions. In the initial implementation, the inputs can specify a start and stop time, max level for each criteria to apply to, the field to base the decision on, and a physical box to limit the checking. ParmParse input can be organized as follows, e.g.:
```
amr.refinement_indicators = flame_tracer lo_temp
amr.refine.flame_tracer.max_level = 3
amr.refine.flame_tracer.value_greater = 1.e-6
amr.refine.flame_tracer.field_name = Y(H)

amr.refine.lo_temp.max_level = 2
amr.refine.lo_temp.value_less = 1000.
amr.refine.lo_temp.field_name = temp
```
This will tag regions up to level 3 where Y(H)>1.e-6 and up to level 2 where temp<1000.