### PR TITLE
WARN_ALL

### DIFF
--- a/Docs/sphinx_documentation/source/BuildingAMReX.rst
+++ b/Docs/sphinx_documentation/source/BuildingAMReX.rst
@@ -56,6 +56,9 @@ list of important variables.
    +------------+-------------------------------------+--------------------+
    | USE_RPATH  | TRUE or FALSE                       | FALSE              |
    +------------+-------------------------------------+--------------------+
+   | WARN_ALL   | TRUE or FALSE                       | TRUE for DEBUG     |
+   |            |                                     | FALSE otherwise    |
+   +------------+-------------------------------------+--------------------+
 
 .. raw:: latex
 
@@ -108,6 +111,8 @@ If enabled, the library path at link time will be saved as a
 `rpath hint <https://en.wikipedia.org/wiki/Rpath>`_ in created binaries.
 When disabled, dynamic library paths could be provided via ``export LD_LIBRARY_PATH``
 hints at runtime.
+
+For GCC and Clang, the variable ``WARN_ALL`` controls the compiler's warning options.
 
 After defining these make variables, a number of files, ``Make.defs,
 Make.package`` and ``Make.rules``, are included in the GNUmakefile. AMReX-based

--- a/Src/AmrCore/AMReX_Cluster.cpp
+++ b/Src/AmrCore/AMReX_Cluster.cpp
@@ -35,6 +35,8 @@ class InBox
 public:
     explicit InBox (const Box& b) noexcept : m_box(b) {}
 
+    // You might see compiler warning on this is never referenced.
+    // The compiler is wrong.
     bool operator() (const IntVect& iv) const noexcept
     {
         return m_box.contains(iv);
@@ -247,6 +249,8 @@ class Cut
 public:
     Cut (const IntVect& cut, int dir) : m_cut(cut), m_dir(dir) {}
 
+    // You might see compiler warning on this is never referenced.
+    // The compiler is wrong.
     bool operator() (const IntVect& iv) const
     {
         return iv[m_dir] < m_cut[m_dir];

--- a/Src/AmrCore/AMReX_FluxRegister.cpp
+++ b/Src/AmrCore/AMReX_FluxRegister.cpp
@@ -455,7 +455,7 @@ FluxRegister::FineSetVal (int              dir,
                           int              destcomp,
                           int              numcomp,
                           Real             val,
-                          RunOn            runon) noexcept
+                          RunOn           /*runon*/) noexcept
 {
     Gpu::LaunchSafeGuard lsg(false); // xxxxx gpu todo
 

--- a/Src/AmrCore/AMReX_Interp_3D_C.H
+++ b/Src/AmrCore/AMReX_Interp_3D_C.H
@@ -11,8 +11,8 @@ namespace amrex {
 AMREX_GPU_HOST
 inline
 Vector<Real>
-ccinterp_compute_voff (Box const& cbx, IntVect const& ratio, Geometry const& cgeom,
-                       Geometry const& fgeom) noexcept
+ccinterp_compute_voff (Box const& cbx, IntVect const& ratio, Geometry const& /*cgeom*/,
+                       Geometry const& /*fgeom*/) noexcept
 {
     const Box& fbx = amrex::refine(cbx,ratio);
     const auto& flen = amrex::length(fbx);

--- a/Src/Base/AMReX_BCUtil.cpp
+++ b/Src/Base/AMReX_BCUtil.cpp
@@ -6,11 +6,11 @@ namespace amrex
 
 namespace {
 
-void dummy_cpu_fill_extdir (Box const& bx, Array4<Real> const& dest,
-                            const int dcomp, const int numcomp,
-                            GeometryData const& geom, const Real time,
-                            const BCRec* bcr, const int bcomp,
-                            const int orig_comp)
+void dummy_cpu_fill_extdir (Box const& /*bx*/, Array4<Real> const& /*dest*/,
+                            const int /*dcomp*/, const int /*numcomp*/,
+                            GeometryData const& /*geom*/, const Real /*time*/,
+                            const BCRec* /*bcr*/, const int /*bcomp*/,
+                            const int /*orig_comp*/)
 {
     // do something for external Dirichlet (BCType::ext_dir) if there are
 }
@@ -18,11 +18,11 @@ void dummy_cpu_fill_extdir (Box const& bx, Array4<Real> const& dest,
 struct dummy_gpu_fill_extdir
 {
     AMREX_GPU_DEVICE
-    void operator() (const IntVect& iv, Array4<Real> const& dest,
-                     const int dcomp, const int numcomp,
-                     GeometryData const& geom, const Real time,
-                     const BCRec* bcr, const int bcomp,
-                     const int orig_comp) const
+    void operator() (const IntVect& /*iv*/, Array4<Real> const& /*dest*/,
+                     const int /*dcomp*/, const int /*numcomp*/,
+                     GeometryData const& /*geom*/, const Real /*time*/,
+                     const BCRec* /*bcr*/, const int /*bcomp*/,
+                     const int /*orig_comp*/) const
         {
             // do something for external Dirichlet (BCType::ext_dir) if there are
         }

--- a/Src/Base/AMReX_BaseFab.H
+++ b/Src/Base/AMReX_BaseFab.H
@@ -298,7 +298,7 @@ public:
     }
 
     //! Returns bytes used in the Box for those components
-    std::size_t nBytes (const Box& bx, int start_comp, int ncomps) const noexcept
+    std::size_t nBytes (const Box& bx, int ncomps) const noexcept
         { return bx.numPts() * sizeof(T) * ncomps; }
 
     //! Returns the number of components

--- a/Src/Base/AMReX_CArena.H
+++ b/Src/Base/AMReX_CArena.H
@@ -59,7 +59,7 @@ public:
     void PrintUsage (std::string const& name) const;
 
     //! The default memory hunk size to grab from the heap.
-    enum { DefaultHunkSize = 1024*1024*8 };
+    constexpr static std::size_t DefaultHunkSize = 1024*1024*8;
 
 protected:
     //! The nodes in our free list and block list.

--- a/Src/Base/AMReX_CoordSys.cpp
+++ b/Src/Base/AMReX_CoordSys.cpp
@@ -239,6 +239,8 @@ CoordSys::SetDLogA (FArrayBox& a_dlogafab,
                     const Box& region,
                     int        dir) const
 {
+    amrex::ignore_unused(dir);
+
     AMREX_ASSERT(ok);
     AMREX_ASSERT(region.cellCentered());
 
@@ -491,6 +493,7 @@ CoordSys::Volume (const Real xlo[AMREX_SPACEDIM],
 Real
 CoordSys::AreaLo (const IntVect& point, int dir) const noexcept
 {
+    amrex::ignore_unused(point);
 #if (AMREX_SPACEDIM==2)
     Real xlo[AMREX_SPACEDIM];
     switch (c_sys)
@@ -526,6 +529,7 @@ CoordSys::AreaLo (const IntVect& point, int dir) const noexcept
 Real
 CoordSys::AreaHi (const IntVect& point, int dir) const noexcept
 {
+    amrex::ignore_unused(point);
 #if (AMREX_SPACEDIM==2)
     Real xhi[AMREX_SPACEDIM];
     switch (c_sys)

--- a/Src/Base/AMReX_EArena.H
+++ b/Src/Base/AMReX_EArena.H
@@ -41,7 +41,7 @@ public:
     std::size_t free_space_available () const noexcept;
 
     //! The default memory hunk size to grab from the heap.
-    enum { DefaultHunkSize = 1024*1024*8 };
+    constexpr static std::size_t DefaultHunkSize = 1024*1024*8;
 
 protected:
 

--- a/Src/Base/AMReX_FArrayBox.cpp
+++ b/Src/Base/AMReX_FArrayBox.cpp
@@ -527,7 +527,7 @@ FABio::read_header (std::istream& is,
 FABio*
 FABio::read_header (std::istream& is,
                     FArrayBox&    f,
-		    int           compIndex,
+		    int           /*compIndex*/,
 		    int&          nCompAvailable)
 {
 //    BL_PROFILE("FArrayBox::read_header_is_i");
@@ -718,9 +718,9 @@ FABio_ascii::skip (std::istream& is,
 }
 
 void
-FABio_ascii::skip (std::istream& is,
-                   FArrayBox&    f,
-		   int           nCompToSkip) const
+FABio_ascii::skip (std::istream& /*is*/,
+                   FArrayBox&    /*f*/,
+		   int           /*nCompToSkip*/) const
 {
     amrex::Error("FABio_ascii::skip(..., int nCompToSkip) not implemented");
 }

--- a/Src/Base/AMReX_FBI.H
+++ b/Src/Base/AMReX_FBI.H
@@ -1084,6 +1084,8 @@ FabArray<FAB>::pack_send_buffer_gpu (FabArray<FAB> const& src, int scomp, int nc
                                      Vector<std::size_t> const& send_size,
                                      Vector<CopyComTagsContainer const*> const& send_cctc)
 {
+    amrex::ignore_unused(send_size);
+
     const int N_snds = send_data.size();
     if (N_snds == 0) return;
 
@@ -1124,6 +1126,8 @@ FabArray<FAB>::unpack_recv_buffer_gpu (FabArray<FAB>& dst, int dcomp, int ncomp,
                                        Vector<CopyComTagsContainer const*> const& recv_cctc,
                                        CpOp op, bool is_thread_safe)
 {
+    amrex::ignore_unused(recv_size);
+
     const int N_rcvs = recv_cctc.size();
     if (N_rcvs == 0) return;
 
@@ -1211,6 +1215,8 @@ FabArray<FAB>::pack_send_buffer_cpu (FabArray<FAB> const& src, int scomp, int nc
                                      Vector<std::size_t> const& send_size,
                                      Vector<CopyComTagsContainer const*> const& send_cctc)
 {
+    amrex::ignore_unused(send_size);
+
     const int N_snds = send_data.size();
     if (N_snds == 0) return;
 
@@ -1248,6 +1254,8 @@ FabArray<FAB>::unpack_recv_buffer_cpu (FabArray<FAB>& dst, int dcomp, int ncomp,
                                        Vector<CopyComTagsContainer const*> const& recv_cctc,
                                        CpOp op, bool is_thread_safe)
 {
+    amrex::ignore_unused(recv_size);
+
     const int N_rcvs = recv_cctc.size();
     if (N_rcvs == 0) return;
 

--- a/Src/Base/AMReX_FabArray.H
+++ b/Src/Base/AMReX_FabArray.H
@@ -48,7 +48,7 @@
 namespace amrex {
 
 template <typename T, typename std::enable_if<!IsBaseFab<T>::value,int>::type = 0>
-Long nBytesOwned (T const& t) noexcept { return 0; }
+Long nBytesOwned (T const&) noexcept { return 0; }
 
 template <typename T>
 Long nBytesOwned (BaseFab<T> const& fab) noexcept { return fab.nBytesOwned(); }
@@ -837,7 +837,6 @@ private:
                    Vector<std::size_t>&                   recv_size,
                    Vector<int>&                           recv_from,
                    Vector<MPI_Request>&                   recv_reqs,
-                   int                                    icomp,
                    int                                    ncomp,
                    int                                    SeqNum);
 
@@ -2003,8 +2002,8 @@ FabArray<FAB>::setVal (value_type val, const CommMetaData& thecmd, int scomp, in
 #ifdef AMREX_USE_GPU
     if (Gpu::inLaunchRegion())
     {
-        CMD_local_setVal_gpu(val, thecmd, 0, ncomp);
-        CMD_remote_setVal_gpu(val, thecmd, 0, ncomp);
+        CMD_local_setVal_gpu(val, thecmd, scomp, ncomp);
+        CMD_remote_setVal_gpu(val, thecmd, scomp, ncomp);
     }
     else
 #endif
@@ -2017,7 +2016,7 @@ FabArray<FAB>::setVal (value_type val, const CommMetaData& thecmd, int scomp, in
 #endif
         for (int i = 0; i < N_locs; ++i) {
             const CopyComTag& tag = LocTags[i];
-            (*this)[tag.dstIndex].template setVal<RunOn::Host>(val, tag.dbox, 0, ncomp);
+            (*this)[tag.dstIndex].template setVal<RunOn::Host>(val, tag.dbox, scomp, ncomp);
         }
 
         for (auto it = RcvTags.begin(); it != RcvTags.end(); ++it) {
@@ -2027,7 +2026,7 @@ FabArray<FAB>::setVal (value_type val, const CommMetaData& thecmd, int scomp, in
 #endif
             for (int i = 0; i < N; ++i) {
                 const CopyComTag& tag = it->second[i];
-                (*this)[tag.dstIndex].template setVal<RunOn::Host>(val, tag.dbox, 0, ncomp);
+                (*this)[tag.dstIndex].template setVal<RunOn::Host>(val, tag.dbox, scomp, ncomp);
             }
         }
     }

--- a/Src/Base/AMReX_FabArrayBase.cpp
+++ b/Src/Base/AMReX_FabArrayBase.cpp
@@ -509,6 +509,7 @@ FabArrayBase::CPC::CPC (const BoxArray& ba, const IntVect& ng,
 void
 FabArrayBase::flushCPC (bool no_assertion) const
 {
+    amrex::ignore_unused(no_assertion);
     BL_ASSERT(no_assertion || getBDKey() == m_bdkey);
 
     std::vector<CPCacheIter> others;
@@ -1010,6 +1011,7 @@ FabArrayBase::FB::~FB ()
 void
 FabArrayBase::flushFB (bool no_assertion) const
 {
+    amrex::ignore_unused(no_assertion);
     BL_ASSERT(no_assertion || getBDKey() == m_bdkey);
     std::pair<FBCacheIter,FBCacheIter> er_it = m_TheFBCache.equal_range(m_bdkey);
     for (FBCacheIter it = er_it.first; it != er_it.second; ++it)
@@ -1090,7 +1092,8 @@ FabArrayBase::FPinfo::FPinfo (const FabArrayBase& srcfa,
       m_dstng    (dstng),
       m_coarsener(coarsener.clone()),
       m_nuse     (0)
-{ 
+{
+    amrex::ignore_unused(cdomain,index_space);
     BL_PROFILE("FPinfo::FPinfo()");
     const BoxArray& srcba = srcfa.boxArray();
     const BoxArray& dstba = dstfa.boxArray();
@@ -1215,6 +1218,7 @@ FabArrayBase::TheFPinfo (const FabArrayBase& srcfa,
 void
 FabArrayBase::flushFPinfo (bool no_assertion)
 {
+    amrex::ignore_unused(no_assertion);
     BL_ASSERT(no_assertion || getBDKey() == m_bdkey);
 
     std::vector<FPinfoCacheIter> others;
@@ -1374,6 +1378,7 @@ FabArrayBase::TheCFinfo (const FabArrayBase& finefa,
 void
 FabArrayBase::flushCFinfo (bool no_assertion)
 {
+    amrex::ignore_unused(no_assertion);
     BL_ASSERT(no_assertion || getBDKey() == m_bdkey);
     auto er_it = m_TheCrseFineCache.equal_range(m_bdkey);
     for (auto it = er_it.first; it != er_it.second; ++it)
@@ -1554,6 +1559,7 @@ FabArrayBase::buildTileArray (const IntVect& tileSize, TileArray& ta) const
 void
 FabArrayBase::flushTileArray (const IntVect& tileSize, bool no_assertion) const
 {
+    amrex::ignore_unused(no_assertion);
     BL_ASSERT(no_assertion || getBDKey() == m_bdkey);
 
     TACache& tao = m_TheTileArrayCache;
@@ -1658,6 +1664,7 @@ FabArrayBase::WaitForAsyncSends (int                 N_snds,
                                  Vector<char*>&       send_data,
                                  Vector<MPI_Status>&  stats)
 {
+    amrex::ignore_unused(send_data);
 #ifdef BL_USE_MPI
     BL_ASSERT(N_snds > 0);
 

--- a/Src/Base/AMReX_FabArrayCommI.H
+++ b/Src/Base/AMReX_FabArrayCommI.H
@@ -83,7 +83,7 @@ FabArray<FAB>::FBEP_nowait (int scomp, int ncomp, const IntVect& nghost,
     if (N_rcvs > 0) {
         PostRcvs(*TheFB.m_RcvTags, fb_the_recv_data,
                  fb_recv_data, fb_recv_size, fb_recv_from, fb_recv_reqs,
-                 scomp, ncomp, SeqNum);
+                 ncomp, SeqNum);
         fb_recv_stat.resize(N_rcvs);
     }
 
@@ -118,7 +118,7 @@ FabArray<FAB>::FBEP_nowait (int scomp, int ncomp, const IntVect& nghost,
             std::size_t nbytes = 0;
             for (auto const& cct : kv.second)
             {
-                nbytes += (*this)[cct.srcIndex].nBytes(cct.sbox,scomp,ncomp);
+                nbytes += (*this)[cct.srcIndex].nBytes(cct.sbox,ncomp);
             }
 
             std::size_t acd = ParallelDescriptor::alignof_comm_data(nbytes);
@@ -439,7 +439,7 @@ FabArray<FAB>::ParallelCopy (const FabArray<FAB>& src,
         int actual_n_rcvs = 0;
 	if (N_rcvs > 0) {
             PostRcvs(*thecpc.m_RcvTags, the_recv_data,
-                     recv_data, recv_size, recv_from, recv_reqs, SC, NC, SeqNum);
+                     recv_data, recv_size, recv_from, recv_reqs, NC, SeqNum);
             actual_n_rcvs = N_rcvs - std::count(recv_size.begin(), recv_size.end(), 0);
 	}
 
@@ -471,7 +471,7 @@ FabArray<FAB>::ParallelCopy (const FabArray<FAB>& src,
                 std::size_t nbytes = 0;
                 for (auto const& cct : kv.second)
                 {
-                    nbytes += src[cct.srcIndex].nBytes(cct.sbox,SC,NC);
+                    nbytes += src[cct.srcIndex].nBytes(cct.sbox,NC);
                 }
 
                 std::size_t acd = ParallelDescriptor::alignof_comm_data(nbytes);
@@ -701,7 +701,6 @@ FabArray<FAB>::PostRcvs (const MapOfCopyComTagContainers&  m_RcvTags,
                          Vector<std::size_t>&              recv_size,
                          Vector<int>&                      recv_from,
                          Vector<MPI_Request>&              recv_reqs,
-                         int                               icomp,
                          int                               ncomp,
                          int                               SeqNum)
 {
@@ -717,7 +716,7 @@ FabArray<FAB>::PostRcvs (const MapOfCopyComTagContainers&  m_RcvTags,
         std::size_t nbytes = 0;
         for (auto const& cct : kv.second)
         {
-            nbytes += (*this)[cct.dstIndex].nBytes(cct.dbox,icomp,ncomp);
+            nbytes += (*this)[cct.dstIndex].nBytes(cct.dbox,ncomp);
         }
 
         std::size_t acd = ParallelDescriptor::alignof_comm_data(nbytes);

--- a/Src/Base/AMReX_FabArrayUtility.H
+++ b/Src/Base/AMReX_FabArrayUtility.H
@@ -1629,6 +1629,8 @@ prefetchToHost (FabArray<FAB> const& fa, const bool synchronous = true)
             fa.prefetchToHost(mfi);
         }
     }
+#else
+    amrex::ignore_unused(fa,synchronous);
 #endif
 }
 
@@ -1642,6 +1644,8 @@ prefetchToDevice (FabArray<FAB> const& fa, const bool synchronous = true)
             fa.prefetchToDevice(mfi);
         }
     }
+#else
+    amrex::ignore_unused(fa,synchronous);
 #endif
 }
 
@@ -1689,7 +1693,7 @@ dtoh_memcpy (FabArray<FAB>& dst, FabArray<FAB> const& src,
     for (MFIter mfi(dst); mfi.isValid(); ++mfi) {
         void* pdst = dst[mfi].dataPtr(dcomp);
         void const* psrc = src[mfi].dataPtr(scomp);
-        Gpu::dtoh_memcpy_async(pdst, psrc, dst[mfi].nBytes(mfi.fabbox(), dcomp, ncomp));
+        Gpu::dtoh_memcpy_async(pdst, psrc, dst[mfi].nBytes(mfi.fabbox(), ncomp));
     }
 #else
     Copy(dst, src, scomp, dcomp, ncomp, dst.nGrowVect());
@@ -1714,7 +1718,7 @@ htod_memcpy (FabArray<FAB>& dst, FabArray<FAB> const& src,
     for (MFIter mfi(dst); mfi.isValid(); ++mfi) {
         void* pdst = dst[mfi].dataPtr(dcomp);
         void const* psrc = src[mfi].dataPtr(scomp);
-        Gpu::htod_memcpy_async(pdst, psrc, dst[mfi].nBytes(mfi.fabbox(), dcomp, ncomp));
+        Gpu::htod_memcpy_async(pdst, psrc, dst[mfi].nBytes(mfi.fabbox(), ncomp));
     }
 #else
     Copy(dst, src, scomp, dcomp, ncomp, dst.nGrowVect());

--- a/Src/Base/AMReX_FabConv.cpp
+++ b/Src/Base/AMReX_FabConv.cpp
@@ -221,7 +221,7 @@ selectOrdering (int prec,
 RealDescriptor*
 RealDescriptor::newRealDescriptor (int         iot,
                                    int         prec,
-                                   const char* sys,
+                                   const char* /*sys*/,
                                    int         ordering)
 {
     RealDescriptor* rd = 0;
@@ -498,7 +498,7 @@ _pd_reorder (char*      arr,
              const int* ord)
 {
     const int MAXLINE = 16;
-    char local[MAXLINE];
+    char local[MAXLINE] = {0};
 
     for (int j; nitems > 0; nitems--)
     {

--- a/Src/Base/AMReX_FilCC_C.cpp
+++ b/Src/Base/AMReX_FilCC_C.cpp
@@ -3,7 +3,7 @@
 namespace amrex {
 
 void fab_filcc (Box const& bx, Array4<Real> const& qn, int ncomp,
-                Box const& domain, Real const* dx, Real const* xlo,
+                Box const& domain, Real const* /*dx*/, Real const* /*xlo*/,
                 BCRec const* bcn)
 {
     const auto lo = amrex::lbound(bx);

--- a/Src/Base/AMReX_FilND_C.cpp
+++ b/Src/Base/AMReX_FilND_C.cpp
@@ -3,7 +3,7 @@
 namespace amrex {
 
 void fab_filnd (Box const& bx, Array4<Real> const& qn, int ncomp,
-                Box const& domain, Real const* dx, Real const* xlo,
+                Box const& domain, Real const* /*dx*/, Real const* /*xlo*/,
                 BCRec const* bcn)
 {
     const auto lo = amrex::lbound(bx);

--- a/Src/Base/AMReX_GpuAsyncArray.cpp
+++ b/Src/Base/AMReX_GpuAsyncArray.cpp
@@ -5,11 +5,11 @@
 #if !defined(AMREX_USE_DPCPP)
 extern "C" {
 #if defined(AMREX_USE_HIP)
-    void HIPRT_CB  amrex_asyncarray_delete ( hipStream_t stream,  hipError_t error, void* p)
+    void HIPRT_CB  amrex_asyncarray_delete ( hipStream_t /*stream*/,  hipError_t /*error*/, void* p)
 #elif defined(__CUDACC__) && (__CUDACC_VER_MAJOR__ >= 10)
     void CUDART_CB amrex_asyncarray_delete (void* p)
 #elif defined(AMREX_USE_CUDA)
-    void CUDART_CB amrex_asyncarray_delete (cudaStream_t stream, cudaError_t error, void* p)
+    void CUDART_CB amrex_asyncarray_delete (cudaStream_t /*stream*/, cudaError_t /*error*/, void* p)
 #endif
     {
         void** pp = (void**)p;

--- a/Src/Base/AMReX_GpuDevice.cpp
+++ b/Src/Base/AMReX_GpuDevice.cpp
@@ -76,6 +76,8 @@ namespace {
 
     void InitializeGraph(int graph_size)
     {
+        amrex::ignore_unused(graph_size);
+
 #if ( defined(__CUDACC__) && (__CUDACC_VER_MAJOR__ >= 10) )
 
         BL_PROFILE("InitGraph");
@@ -537,6 +539,7 @@ Device::numDevicesUsed () noexcept
 void
 Device::setStreamIndex (const int idx) noexcept
 {
+    amrex::ignore_unused(idx);
 #ifdef AMREX_USE_GPU
     if (idx < 0) {
         gpu_stream[OpenMP::get_thread_num()] = gpu_default_stream;
@@ -737,6 +740,7 @@ Device::executeGraph(const cudaGraphExec_t &graphExec, bool synch)
 void
 Device::mem_advise_set_preferred (void* p, const std::size_t sz, const int device)
 {
+    amrex::ignore_unused(p,sz,device);
     // HIP does not support memory advise.
 #ifdef AMREX_USE_CUDA
 #ifndef AMREX_USE_HIP
@@ -758,6 +762,7 @@ Device::mem_advise_set_preferred (void* p, const std::size_t sz, const int devic
 void
 Device::mem_advise_set_readonly (void* p, const std::size_t sz)
 {
+    amrex::ignore_unused(p,sz);
     // HIP does not support memory advise.
 #ifdef AMREX_USE_CUDA
 #ifndef AMREX_USE_HIP

--- a/Src/Base/AMReX_GpuElixir.cpp
+++ b/Src/Base/AMReX_GpuElixir.cpp
@@ -19,11 +19,11 @@ namespace {
 
 extern "C" {
 #if defined(AMREX_USE_HIP)
-    void HIPRT_CB  amrex_elixir_delete ( hipStream_t stream,  hipError_t error, void* p)
+    void HIPRT_CB  amrex_elixir_delete ( hipStream_t /*stream*/,  hipError_t /*error*/, void* p)
 #elif defined(__CUDACC__) && (__CUDACC_VER_MAJOR__ >= 10)
     void CUDART_CB amrex_elixir_delete (void* p)
 #elif defined(AMREX_USE_CUDA)
-    void CUDART_CB amrex_elixir_delete (cudaStream_t stream, cudaError_t error, void* p)
+    void CUDART_CB amrex_elixir_delete (cudaStream_t /*stream*/, cudaError_t /*error*/, void* p)
 #endif
     {
         void** pp = (void**)p;

--- a/Src/Base/AMReX_GpuLaunch.H
+++ b/Src/Base/AMReX_GpuLaunch.H
@@ -114,6 +114,7 @@ namespace Gpu {
         iv += bx.smallEnd();
         return (bx & Box(iv,iv,bx.type()));
 #else
+        amrex::ignore_unused(offset);
         return bx;
 #endif
     }

--- a/Src/Base/AMReX_GpuLaunchFunctsC.H
+++ b/Src/Base/AMReX_GpuLaunchFunctsC.H
@@ -4,13 +4,13 @@
 namespace amrex {
 
 template<typename T, typename L>
-void launch (T const& n, L&& f, std::size_t shared_mem_bytes=0) noexcept
+void launch (T const& n, L&& f, std::size_t /*shared_mem_bytes*/=0) noexcept
 {
     f(n);
 }
 
 template <typename T, typename L, typename M=amrex::EnableIf_t<std::is_integral<T>::value> >
-void For (T n, L&& f, std::size_t shared_mem_bytes=0) noexcept
+void For (T n, L&& f, std::size_t /*shared_mem_bytes*/=0) noexcept
 {
     for (T i = 0; i < n; ++i) {
         f(i);
@@ -18,7 +18,7 @@ void For (T n, L&& f, std::size_t shared_mem_bytes=0) noexcept
 }
 
 template <typename T, typename L, typename M=amrex::EnableIf_t<std::is_integral<T>::value> >
-void ParallelFor (T n, L&& f, std::size_t shared_mem_bytes=0) noexcept
+void ParallelFor (T n, L&& f, std::size_t /*shared_mem_bytes*/=0) noexcept
 {
     AMREX_PRAGMA_SIMD
     for (T i = 0; i < n; ++i) {
@@ -27,7 +27,7 @@ void ParallelFor (T n, L&& f, std::size_t shared_mem_bytes=0) noexcept
 }
 
 template <typename L>
-void For (Box const& box, L&& f, std::size_t shared_mem_bytes=0) noexcept
+void For (Box const& box, L&& f, std::size_t /*shared_mem_bytes*/=0) noexcept
 {
     const auto lo = amrex::lbound(box);
     const auto hi = amrex::ubound(box);
@@ -39,7 +39,7 @@ void For (Box const& box, L&& f, std::size_t shared_mem_bytes=0) noexcept
 }
 
 template <typename L>
-void ParallelFor (Box const& box, L&& f, std::size_t shared_mem_bytes=0) noexcept
+void ParallelFor (Box const& box, L&& f, std::size_t /*shared_mem_bytes*/=0) noexcept
 {
     const auto lo = amrex::lbound(box);
     const auto hi = amrex::ubound(box);
@@ -52,7 +52,7 @@ void ParallelFor (Box const& box, L&& f, std::size_t shared_mem_bytes=0) noexcep
 }
 
 template <typename T, typename L, typename M=amrex::EnableIf_t<std::is_integral<T>::value> >
-void For (Box const& box, T ncomp, L&& f, std::size_t shared_mem_bytes=0) noexcept
+void For (Box const& box, T ncomp, L&& f, std::size_t /*shared_mem_bytes*/=0) noexcept
 {
     const auto lo = amrex::lbound(box);
     const auto hi = amrex::ubound(box);
@@ -66,7 +66,7 @@ void For (Box const& box, T ncomp, L&& f, std::size_t shared_mem_bytes=0) noexce
 }
 
 template <typename T, typename L, typename M=amrex::EnableIf_t<std::is_integral<T>::value> >
-void ParallelFor (Box const& box, T ncomp, L&& f, std::size_t shared_mem_bytes=0) noexcept
+void ParallelFor (Box const& box, T ncomp, L&& f, std::size_t /*shared_mem_bytes*/=0) noexcept
 {
     const auto lo = amrex::lbound(box);
     const auto hi = amrex::ubound(box);
@@ -82,7 +82,7 @@ void ParallelFor (Box const& box, T ncomp, L&& f, std::size_t shared_mem_bytes=0
 
 template <typename L1, typename L2>
 void For (Box const& box1, Box const& box2, L1&& f1, L2&& f2,
-          std::size_t shared_mem_bytes=0) noexcept
+          std::size_t /*shared_mem_bytes*/=0) noexcept
 {
     For(box1, std::forward<L1>(f1));
     For(box2, std::forward<L2>(f2));
@@ -90,7 +90,7 @@ void For (Box const& box1, Box const& box2, L1&& f1, L2&& f2,
 
 template <typename L1, typename L2, typename L3>
 void For (Box const& box1, Box const& box2, Box const& box3, L1&& f1, L2&& f2, L3&& f3,
-          std::size_t shared_mem_bytes=0) noexcept
+          std::size_t /*shared_mem_bytes*/=0) noexcept
 {
     For(box1, std::forward<L1>(f1));
     For(box2, std::forward<L2>(f2));
@@ -102,7 +102,7 @@ template <typename T1, typename T2, typename L1, typename L2,
           typename M2=amrex::EnableIf_t<std::is_integral<T2>::value> >
 void For (Box const& box1, T1 ncomp1, L1&& f1,
           Box const& box2, T2 ncomp2, L2&& f2,
-          std::size_t shared_mem_bytes=0) noexcept
+          std::size_t /*shared_mem_bytes*/=0) noexcept
 {
     For(box1, ncomp1, std::forward<L1>(f1));
     For(box2, ncomp2, std::forward<L2>(f2));
@@ -115,7 +115,7 @@ template <typename T1, typename T2, typename T3, typename L1, typename L2, typen
 void For (Box const& box1, T1 ncomp1, L1&& f1,
           Box const& box2, T2 ncomp2, L2&& f2,
           Box const& box3, T3 ncomp3, L3&& f3,
-          std::size_t shared_mem_bytes=0) noexcept
+          std::size_t /*shared_mem_bytes*/=0) noexcept
 {
     For(box1, ncomp1, std::forward<L1>(f1));
     For(box2, ncomp2, std::forward<L2>(f2));
@@ -124,7 +124,7 @@ void For (Box const& box1, T1 ncomp1, L1&& f1,
 
 template <typename L1, typename L2>
 void ParallelFor (Box const& box1, Box const& box2, L1&& f1, L2&& f2,
-                  std::size_t shared_mem_bytes=0) noexcept
+                  std::size_t /*shared_mem_bytes*/=0) noexcept
 {
     ParallelFor(box1, std::forward<L1>(f1));
     ParallelFor(box2, std::forward<L2>(f2));
@@ -132,7 +132,7 @@ void ParallelFor (Box const& box1, Box const& box2, L1&& f1, L2&& f2,
 
 template <typename L1, typename L2, typename L3>
 void ParallelFor (Box const& box1, Box const& box2, Box const& box3, L1&& f1, L2&& f2, L3&& f3,
-                  std::size_t shared_mem_bytes=0) noexcept
+                  std::size_t /*shared_mem_bytes*/=0) noexcept
 {
     ParallelFor(box1, std::forward<L1>(f1));
     ParallelFor(box2, std::forward<L2>(f2));
@@ -144,7 +144,7 @@ template <typename T1, typename T2, typename L1, typename L2,
           typename M2=amrex::EnableIf_t<std::is_integral<T2>::value> >
 void ParallelFor (Box const& box1, T1 ncomp1, L1&& f1,
                   Box const& box2, T2 ncomp2, L2&& f2,
-                  std::size_t shared_mem_bytes=0) noexcept
+                  std::size_t /*shared_mem_bytes*/=0) noexcept
 {
     ParallelFor(box1, ncomp1, std::forward<L1>(f1));
     ParallelFor(box2, ncomp2, std::forward<L2>(f2));
@@ -157,7 +157,7 @@ template <typename T1, typename T2, typename T3, typename L1, typename L2, typen
 void ParallelFor (Box const& box1, T1 ncomp1, L1&& f1,
                   Box const& box2, T2 ncomp2, L2&& f2,
                   Box const& box3, T3 ncomp3, L3&& f3,
-                  std::size_t shared_mem_bytes=0) noexcept
+                  std::size_t /*shared_mem_bytes*/=0) noexcept
 {
     ParallelFor(box1, ncomp1, std::forward<L1>(f1));
     ParallelFor(box2, ncomp2, std::forward<L2>(f2));
@@ -167,7 +167,7 @@ void ParallelFor (Box const& box1, T1 ncomp1, L1&& f1,
 template <typename N, typename T, typename L1, typename L2,
           typename M=amrex::EnableIf_t<std::is_integral<N>::value> >
 void FabReduce (Box const& box, N ncomp, T const& init_val,
-                L1&& f1, L2&& f2, std::size_t shared_mem_bytes=0) noexcept
+                L1&& f1, L2&& f2, std::size_t /*shared_mem_bytes*/=0) noexcept
 {
     auto r = init_val;
     const auto lo = amrex::lbound(box);
@@ -184,7 +184,7 @@ void FabReduce (Box const& box, N ncomp, T const& init_val,
 
 template <typename T, typename L1, typename L2>
 void FabReduce (Box const& box, T const& init_val,
-                L1&& f1, L2&& f2, std::size_t shared_mem_bytes=0) noexcept
+                L1&& f1, L2&& f2, std::size_t /*shared_mem_bytes*/=0) noexcept
 {
     auto r = init_val;
     const auto lo = amrex::lbound(box);
@@ -200,7 +200,7 @@ void FabReduce (Box const& box, T const& init_val,
 template <typename N, typename T, typename L1, typename L2,
           typename M=amrex::EnableIf_t<std::is_integral<N>::value> >
 void VecReduce (N n, T const& init_val,
-                L1&& f1, L2&& f2, std::size_t shared_mem_bytes=0) noexcept
+                L1&& f1, L2&& f2, std::size_t /*shared_mem_bytes*/=0) noexcept
 {
     auto r = init_val;
     for (N i = 0; i < n; ++i) {

--- a/Src/Base/AMReX_MFCopyDescriptor.cpp
+++ b/Src/Base/AMReX_MFCopyDescriptor.cpp
@@ -24,6 +24,8 @@ InterpAddBox (MultiFabCopyDescriptor& fabCopyDesc,
 		      int                     num_comp,
 		      bool                    extrap)
 {
+    amrex::ignore_unused(extrap);
+
     const Real teps = (t2-t1)/1000.0;
 
     BL_ASSERT(extrap || ( (t>=t1-teps) && (t <= t2+teps) ) );
@@ -85,6 +87,8 @@ InterpFillFab (MultiFabCopyDescriptor& fabCopyDesc,
 		       int                     num_comp,
 		       bool                    extrap)
 {
+    amrex::ignore_unused(extrap);
+
     const Real teps = (t2-t1)/1000.0;
 
     BL_ASSERT(extrap || ( (t>=t1-teps) && (t <= t2+teps) ) );

--- a/Src/Base/AMReX_MultiFab.cpp
+++ b/Src/Base/AMReX_MultiFab.cpp
@@ -692,7 +692,7 @@ MultiFab::contains_inf (int scomp, int ncomp, IntVect const& ngrow, bool local) 
 bool 
 MultiFab::contains_inf (int scomp, int ncomp, int ngrow, bool local) const
 {
-    return contains_inf(0,ncomp,IntVect(ngrow),local);
+    return contains_inf(scomp,ncomp,IntVect(ngrow),local);
 }
 
 bool 
@@ -907,6 +907,8 @@ MultiFab::norm0 (const iMultiFab& mask, int comp, int nghost, bool local) const
 Real
 MultiFab::norm0 (int comp, int nghost, bool local, bool ignore_covered ) const
 {
+    amrex::ignore_unused(ignore_covered);
+
     Real nm0;
 
 #ifdef AMREX_USE_EB
@@ -1015,6 +1017,8 @@ MultiFab::norm2 (const Vector<int>& comps) const
 Real
 MultiFab::norm1 (int comp, const Periodicity& period, bool ignore_covered ) const
 {
+    amrex::ignore_unused(ignore_covered);
+
     MultiFab tmpmf(this->boxArray(), this->DistributionMap(), 1, 0,
                    MFInfo(), this->Factory());
 

--- a/Src/Base/AMReX_MultiFabUtil.cpp
+++ b/Src/Base/AMReX_MultiFabUtil.cpp
@@ -198,6 +198,8 @@ namespace amrex
 
 #if (AMREX_SPACEDIM == 1)
         const GeometryData& gd = geom.data();
+#else
+        amrex::ignore_unused(geom);
 #endif
 
 #ifdef _OPENMP
@@ -254,6 +256,7 @@ namespace amrex
         }
 
 #if (AMREX_SPACEDIM == 3)
+        amrex::ignore_unused(fgeom,cgeom);
 	amrex::average_down(S_fine, S_crse, scomp, ncomp, ratio);
 	return;
 #else
@@ -308,7 +311,7 @@ namespace amrex
 
     void sum_fine_to_coarse(const MultiFab& S_fine, MultiFab& S_crse,
                             int scomp, int ncomp, const IntVect& ratio,
-                            const Geometry& cgeom, const Geometry& fgeom)
+                            const Geometry& cgeom, const Geometry& /*fgeom*/)
     {
         AMREX_ASSERT(S_crse.nComp() == S_fine.nComp());
         AMREX_ASSERT(ratio == ratio[0]);

--- a/Src/Base/AMReX_PODVector.H
+++ b/Src/Base/AMReX_PODVector.H
@@ -72,7 +72,7 @@ namespace amrex
 
         template <typename T>
         typename std::enable_if<!RunOnGpu<T>::value>::type
-        memMoveImpl (void* dst, const void* src, std::size_t count, T& allocator)
+        memMoveImpl (void* dst, const void* src, std::size_t count, T& /*allocator*/)
         {
             std::memmove(dst, src, count);
         }

--- a/Src/Base/AMReX_ParallelDescriptor.cpp
+++ b/Src/Base/AMReX_ParallelDescriptor.cpp
@@ -408,6 +408,8 @@ ParallelDescriptor::second () noexcept
 void
 ParallelDescriptor::Barrier (const std::string &message)
 {
+    amrex::ignore_unused(message);
+
 #ifdef BL_LAZY
     Lazy::EvalReduction();
 #endif
@@ -423,6 +425,8 @@ ParallelDescriptor::Barrier (const std::string &message)
 void
 ParallelDescriptor::Barrier (const MPI_Comm &comm, const std::string &message)
 {
+    amrex::ignore_unused(message);
+
 #ifdef BL_LAZY
     int r;
     MPI_Comm_compare(comm, Communicator(), &r);

--- a/Src/Base/AMReX_PlotFileUtil.cpp
+++ b/Src/Base/AMReX_PlotFileUtil.cpp
@@ -61,7 +61,7 @@ std::string MultiFabFileFullPrefix (int level,
 
 void
 PreBuildDirectorHierarchy (const std::string &dirName,
-                           const std::string &subDirPrefix,
+                           const std::string &/*subDirPrefix*/,
                            int nSubDirs, bool callBarrier)
 {
   UtilCreateCleanDirectory(dirName, false);  // ---- dont call barrier

--- a/Src/Base/AMReX_Random.cpp
+++ b/Src/Base/AMReX_Random.cpp
@@ -327,6 +327,8 @@ void amrex::ResetRandomSeed (amrex::ULong seed)
 void
 amrex::ResizeRandomSeed (int N)
 {
+    amrex::ignore_unused(N);
+
     BL_PROFILE("ResizeRandomSeed");
 
 #ifdef AMREX_USE_DPCPP

--- a/Src/Base/AMReX_Reduce.H
+++ b/Src/Base/AMReX_Reduce.H
@@ -214,7 +214,7 @@ public:
     using Type = GpuTuple<Ts...>;
 
     template <typename... Ps>
-    explicit ReduceData (ReduceOps<Ps...> const& ops)
+    explicit ReduceData (ReduceOps<Ps...> const&)
         : m_host_tuple(),
           m_device_tuple((Type*)(The_Device_Arena()->alloc(2*sizeof(m_host_tuple))))
     {
@@ -648,7 +648,7 @@ public:
     using Type = GpuTuple<Ts...>;
 
     template <typename... Ps>
-    explicit ReduceData (ReduceOps<Ps...> const& ops)
+    explicit ReduceData (ReduceOps<Ps...> const&)
         : m_tuple()
     {
         Reduce::detail::for_each_init<0, Type, Ps...>(m_tuple);

--- a/Src/Base/AMReX_TinyProfiler.cpp
+++ b/Src/Base/AMReX_TinyProfiler.cpp
@@ -110,16 +110,17 @@ TinyProfiler::stop () noexcept
     {
         double t;
 	int nKernelCalls = 0;
-	if (!uCUPTI) {
-	    t = amrex::second();
-	} else {
 #ifdef AMREX_USE_CUPTI
-	    cudaDeviceSynchronize();
-	    cuptiActivityFlushAll(0);
-	    t = computeElapsedTimeUserdata(activityRecordUserdata);
-	    nKernelCalls = activityRecordUserdata.size();
+        if (uCUPTI) {
+            cudaDeviceSynchronize();
+            cuptiActivityFlushAll(0);
+            t = computeElapsedTimeUserdata(activityRecordUserdata);
+            nKernelCalls = activityRecordUserdata.size();
+        } else
 #endif
-	}
+        {
+	    t = amrex::second();
+        }
 
 	while (static_cast<int>(ttstack.size()) > global_depth) {
 	    ttstack.pop_back();

--- a/Src/Base/AMReX_VisMF.cpp
+++ b/Src/Base/AMReX_VisMF.cpp
@@ -1169,7 +1169,7 @@ void
 VisMF::FindOffsets (const FabArray<FArrayBox> &mf,
 		    const std::string &filePrefix,
                     VisMF::Header &hdr,
-		    VisMF::Header::Version whichVersion,
+		    VisMF::Header::Version /*whichVersion*/,
 		    NFilesIter &nfi, MPI_Comm comm)
 {
 //    BL_PROFILE("VisMF::FindOffsets");

--- a/Src/Boundary/AMReX_InterpBndryData.H
+++ b/Src/Boundary/AMReX_InterpBndryData.H
@@ -96,7 +96,7 @@ public:
     */
     virtual void setBndryConds (const BCRec&   phys_bc,
                                 const IntVect& ratio,
-				int            comp = 0) {}
+				int            /*comp*/ = 0) {}
 
     /**
     * \brief set bndry values at coarse level (non interpolation performed)

--- a/Src/LinearSolvers/MLMG/AMReX_MLABecLaplacian.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLABecLaplacian.H
@@ -77,7 +77,7 @@ public:
     virtual Array<MultiFab const*,AMREX_SPACEDIM> getBCoeffs (int amrlev, int mglev) const final override
         { return amrex::GetArrOfConstPtrs(m_b_coeffs[amrlev][mglev]); }
 
-    virtual std::unique_ptr<MLLinOp> makeNLinOp (int grid_size) const final override {
+    virtual std::unique_ptr<MLLinOp> makeNLinOp (int /*grid_size*/) const final override {
         amrex::Abort("MLABecLaplacian::makeNLinOp: Not implmented");
         return std::unique_ptr<MLLinOp>{};
     }

--- a/Src/LinearSolvers/MLMG/AMReX_MLABecLaplacian.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLABecLaplacian.cpp
@@ -126,10 +126,10 @@ MLABecLaplacian::define (const Vector<Geometry>& a_geom,
     ParallelAllReduce::Min(max_overset_mask_coarsening_level, ParallelContext::CommunicatorSub());
     m_overset_mask[amrlev].resize(max_overset_mask_coarsening_level+1);
 
-    LPInfo info = a_info;
-    info.max_coarsening_level = std::min(a_info.max_coarsening_level,
-                                         max_overset_mask_coarsening_level);
-    define(a_geom, a_grids, a_dmap, info, a_factory);
+    LPInfo linfo = a_info;
+    linfo.max_coarsening_level = std::min(a_info.max_coarsening_level,
+                                          max_overset_mask_coarsening_level);
+    define(a_geom, a_grids, a_dmap, linfo, a_factory);
 
     amrlev = 0;
     for (int mglev = 1; mglev < m_num_mg_levels[amrlev]; ++mglev) {
@@ -141,7 +141,7 @@ MLABecLaplacian::define (const Vector<Geometry>& a_geom,
         }
     }
 
-    for (int amrlev = 0; amrlev < m_num_amr_levels; ++amrlev) {
+    for (amrlev = 0; amrlev < m_num_amr_levels; ++amrlev) {
         for (int mglev = 0; mglev < m_num_mg_levels[amrlev]; ++mglev) {
             m_overset_mask[amrlev][mglev]->setBndry(0);
             m_overset_mask[amrlev][mglev]->FillBoundary(m_geom[amrlev][mglev].periodicity());

--- a/Src/LinearSolvers/MLMG/AMReX_MLALaplacian.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLALaplacian.H
@@ -50,10 +50,10 @@ public:
     virtual Real getBScalar () const final override { return m_b_scalar; }
     virtual MultiFab const* getACoeffs (int amrlev, int mglev) const final override
         { return &(m_a_coeffs[amrlev][mglev]); }
-    virtual Array<MultiFab const*,AMREX_SPACEDIM> getBCoeffs (int amrlev, int mglev) const final override
+    virtual Array<MultiFab const*,AMREX_SPACEDIM> getBCoeffs (int /*amrlev*/, int /*mglev*/) const final override
         { return { AMREX_D_DECL(nullptr,nullptr,nullptr)}; }
 
-    virtual std::unique_ptr<MLLinOp> makeNLinOp (int grid_size) const final override {
+    virtual std::unique_ptr<MLLinOp> makeNLinOp (int /*grid_size*/) const final override {
         amrex::Abort("MLALaplacian::makeNLinOp: Not implmented");
         return std::unique_ptr<MLLinOp>{};
     }

--- a/Src/LinearSolvers/MLMG/AMReX_MLCellABecLap.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLCellABecLap.H
@@ -37,8 +37,8 @@ public:
     virtual void getFluxes (const Vector<Array<MultiFab*,AMREX_SPACEDIM> >& a_flux,
                             const Vector<MultiFab*>& a_sol,
                             Location a_loc) const final override;
-    virtual void getFluxes (const Vector<MultiFab*>& a_flux,
-                            const Vector<MultiFab*>& a_sol) const final override {
+    virtual void getFluxes (const Vector<MultiFab*>& /*a_flux*/,
+                            const Vector<MultiFab*>& /*a_sol*/) const final override {
         amrex::Abort("MLCellABecLap::getFluxes: How did we get here?");
     }
 

--- a/Src/LinearSolvers/MLMG/AMReX_MLCellLinOp.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLCellLinOp.cpp
@@ -459,9 +459,9 @@ MLCellLinOp::applyBC (int amrlev, int mglev, MultiFab& in, BCMode bc_mode, State
     const int imaxorder = maxorder;
 
     const Real* dxinv = m_geom[amrlev][mglev].InvCellSize();
-    const Real dxi = m_geom[amrlev][mglev].InvCellSize(0);
-    const Real dyi = (AMREX_SPACEDIM >= 2) ? m_geom[amrlev][mglev].InvCellSize(1) : 1.0;
-    const Real dzi = (AMREX_SPACEDIM == 3) ? m_geom[amrlev][mglev].InvCellSize(2) : 1.0;
+    const Real dxi = dxinv[0];
+    const Real dyi = (AMREX_SPACEDIM >= 2) ? dxinv[1] : 1.0;
+    const Real dzi = (AMREX_SPACEDIM == 3) ? dxinv[2] : 1.0;
 
     const auto& maskvals = m_maskvals[amrlev][mglev];
     const auto& bcondloc = *m_bcondloc[amrlev][mglev];
@@ -546,12 +546,12 @@ MLCellLinOp::applyBC (int amrlev, int mglev, MultiFab& in, BCMode bc_mode, State
         }
         else
         {
+#ifndef BL_NO_FORT
             const RealTuple & bdl = bdlv[0];
             const BCTuple   & bdc = bdcv[0];
 
             for (OrientationIter oitr; oitr; ++oitr)
             {
-#ifndef BL_NO_FORT
                 const Orientation ori = oitr();
 
                 int  cdr = ori;
@@ -568,10 +568,10 @@ MLCellLinOp::applyBC (int amrlev, int mglev, MultiFab& in, BCMode bc_mode, State
                                        cdr, bct, bcl,
                                        BL_TO_FORTRAN_ANYD(fsfab),
                                        maxorder, dxinv, flagbc, ncomp, cross);
+            }
 #else
                 amrex::Abort("amrex_mllinop_apply_bc not available when BL_NO_FORT=TRUE");
 #endif
-            }
         }
     }
 }
@@ -694,7 +694,7 @@ MLCellLinOp::compFlux (int amrlev, const Array<MultiFab*,AMREX_SPACEDIM>& fluxes
 
 void
 MLCellLinOp::compGrad (int amrlev, const Array<MultiFab*,AMREX_SPACEDIM>& grad,
-                       MultiFab& sol, Location loc) const
+                       MultiFab& sol, Location /*loc*/) const
 {
     BL_PROFILE("MLCellLinOp::compGrad()");
 
@@ -837,7 +837,7 @@ MLCellLinOp::prepareForSolve ()
 }
 
 Real
-MLCellLinOp::xdoty (int amrlev, int mglev, const MultiFab& x, const MultiFab& y, bool local) const
+MLCellLinOp::xdoty (int /*amrlev*/, int /*mglev*/, const MultiFab& x, const MultiFab& y, bool local) const
 {
     const int ncomp = getNComp();
     const int nghost = 0;
@@ -888,6 +888,7 @@ MLCellLinOp::BndryCondLoc::setLOBndryConds (const Geometry& geom, const Real* dx
 void
 MLCellLinOp::applyMetricTerm (int amrlev, int mglev, MultiFab& rhs) const
 {
+    amrex::ignore_unused(amrlev,mglev,rhs);
 #if (AMREX_SPACEDIM != 3)
     
     if (!m_has_metric_term) return;
@@ -943,6 +944,7 @@ MLCellLinOp::applyMetricTerm (int amrlev, int mglev, MultiFab& rhs) const
 void
 MLCellLinOp::unapplyMetricTerm (int amrlev, int mglev, MultiFab& rhs) const
 {
+    amrex::ignore_unused(amrlev,mglev,rhs);
 #if (AMREX_SPACEDIM != 3)
     
     if (!m_has_metric_term) return;

--- a/Src/LinearSolvers/MLMG/AMReX_MLLinOp.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLLinOp.H
@@ -192,7 +192,7 @@ public:
                          bool skip_fillboundary=false) const = 0;
 
     // Divide mf by the diagonal component of the operator. Used by bicgstab.
-    virtual void normalize (int amrlev, int mglev, MultiFab& mf) const {}
+    virtual void normalize (int /*amrlev*/, int /*mglev*/, MultiFab& /*mf*/) const {}
 
     virtual void solutionResidual (int amrlev, MultiFab& resid, MultiFab& x, const MultiFab& b,
                                    const MultiFab* crse_bcdata=nullptr) = 0;
@@ -211,43 +211,43 @@ public:
     virtual void unapplyMetricTerm (int amrlev, int mglev, MultiFab& rhs) const = 0;
     virtual void fillSolutionBC (int amrlev, MultiFab& sol, const MultiFab* crse_bcdata=nullptr) = 0;
 
-    virtual void unimposeNeumannBC (int amrlev, MultiFab& rhs) const {} // only nodal solver might need it
-    virtual void applyInhomogNeumannTerm (int amrlev, MultiFab& rhs) const {}
-    virtual void applyOverset (int amlev, MultiFab& rhs) const {}
+    virtual void unimposeNeumannBC (int /*amrlev*/, MultiFab& /*rhs*/) const {} // only nodal solver might need it
+    virtual void applyInhomogNeumannTerm (int /*amrlev*/, MultiFab& /*rhs*/) const {}
+    virtual void applyOverset (int /*amlev*/, MultiFab& /*rhs*/) const {}
 
     virtual void prepareForSolve () = 0;
     virtual bool isSingular (int amrlev) const = 0;
     virtual bool isBottomSingular () const = 0;
     virtual Real xdoty (int amrlev, int mglev, const MultiFab& x, const MultiFab& y, bool local) const = 0;
 
-    virtual void fixUpResidualMask (int amrlev, iMultiFab& resmsk) { }
-    virtual void nodalSync (int amrlev, int mglev, MultiFab& mf) const {}
+    virtual void fixUpResidualMask (int /*amrlev*/, iMultiFab& /*resmsk*/) { }
+    virtual void nodalSync (int /*amrlev*/, int /*mglev*/, MultiFab& /*mf*/) const {}
 
     virtual std::unique_ptr<MLLinOp> makeNLinOp (int grid_size) const = 0;
 
-    virtual void getFluxes (const Vector<Array<MultiFab*,AMREX_SPACEDIM> >& a_flux,
-                            const Vector<MultiFab*>& a_sol,
-                            Location a_loc) const {
+    virtual void getFluxes (const Vector<Array<MultiFab*,AMREX_SPACEDIM> >& /*a_flux*/,
+                            const Vector<MultiFab*>& /*a_sol*/,
+                            Location /*a_loc*/) const {
         amrex::Abort("MLLinOp::getFluxes: How did we get here?");
     }
-    virtual void getFluxes (const Vector<MultiFab*>& a_flux,
-                            const Vector<MultiFab*>& a_sol) const {
+    virtual void getFluxes (const Vector<MultiFab*>& /*a_flux*/,
+                            const Vector<MultiFab*>& /*a_sol*/) const {
         amrex::Abort("MLLinOp::getFluxes: How did we get here?");
     }
 
 #ifdef AMREX_USE_EB
-    virtual void getEBFluxes (const Vector<MultiFab*>& a_flux,
+    virtual void getEBFluxes (const Vector<MultiFab*>& /*a_flux*/,
                               const Vector<MultiFab*>& a_sol) const {
         amrex::Abort("MLLinOp::getEBFluxes: How did we get here?");
     }
 #endif
 
 #ifdef AMREX_USE_HYPRE
-    virtual std::unique_ptr<Hypre> makeHypre (Hypre::Interface hypre_interface) const {
+    virtual std::unique_ptr<Hypre> makeHypre (Hypre::Interface /*hypre_interface*/) const {
         amrex::Abort("MLLinOp::makeHypre: How did we get here?");
         return {nullptr};
     }
-    virtual std::unique_ptr<HypreNodeLap> makeHypreNodeLap (int bottom_verbose) const {
+    virtual std::unique_ptr<HypreNodeLap> makeHypreNodeLap (int /*bottom_verbose*/) const {
         amrex::Abort("MLLinOp::makeHypreNodeLap: How did we get here?");
         return {nullptr};
     }
@@ -367,7 +367,7 @@ protected:
 
     void make (Vector<Vector<MultiFab> >& mf, int nc, int ng) const;
 
-    virtual std::unique_ptr<FabFactory<FArrayBox> > makeFactory (int amrlev, int mglev) const {
+    virtual std::unique_ptr<FabFactory<FArrayBox> > makeFactory (int /*amrlev*/, int /*mglev*/) const {
         return std::unique_ptr<FabFactory<FArrayBox> >(new FArrayBoxFactory());
     }
 
@@ -385,7 +385,7 @@ private:
     MPI_Comm makeSubCommunicator (const DistributionMapping& dm);
     void remapNeighborhoods (Vector<DistributionMapping> & dms);
 
-    virtual void checkPoint (std::string const& file_name) const {
+    virtual void checkPoint (std::string const& /*file_name*/) const {
         amrex::Abort("MLLinOp:checkPoint: not implemented");
     }
 };

--- a/Src/LinearSolvers/MLMG/AMReX_MLLinOp.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLLinOp.cpp
@@ -132,6 +132,8 @@ MLLinOp::define (const Vector<Geometry>& a_geom,
                  const Vector<FabFactory<FArrayBox> const*>& a_factory,
                  bool eb_limit_coarsening)
 {
+    amrex::ignore_unused(eb_limit_coarsening);
+
     BL_PROFILE("MLLinOp::define()");
 
     if (!initialized) {
@@ -267,7 +269,7 @@ MLLinOp::defineGrids (const Vector<Geometry>& a_geom,
 
     bool agged = false;
     bool coned = false;
-    int agg_lev, con_lev;
+    int agg_lev, con_lev = 0;
 
     if (info.do_agglomeration && aggable)
     {
@@ -424,7 +426,7 @@ MLLinOp::defineGrids (const Vector<Geometry>& a_geom,
     else
     {
         int rr = mg_coarsen_ratio;
-        Real avg_npts;
+        Real avg_npts = 0._rt;
         if (info.do_consolidation) {
             avg_npts = static_cast<Real>(a_grids[0].d_numPts()) / static_cast<Real>(ParallelContext::NProcsSub());
             if (consolidation_threshold == -1) {
@@ -535,18 +537,18 @@ MLLinOp::defineGrids (const Vector<Geometry>& a_geom,
                     ++(m_num_mg_levels[0]);
                     ++num_semicoarsening_level;
 
-                    IntVect rr_0(AMREX_D_DECL(rr_vec[0]*mg_coarsen_ratio, 1, 1));
-                    is_coarsenable_x = ( a_geom[0].Domain().coarsenable(rr_0, mg_domain_min_width) and
-                                         a_grids[0].coarsenable(rr_0, mg_box_min_width));
+                    IntVect rrr_0(AMREX_D_DECL(rr_vec[0]*mg_coarsen_ratio, 1, 1));
+                    is_coarsenable_x = ( a_geom[0].Domain().coarsenable(rrr_0, mg_domain_min_width) and
+                                         a_grids[0].coarsenable(rrr_0, mg_box_min_width));
 #if (AMREX_SPACEDIM >= 2)
-                    IntVect rr_1(AMREX_D_DECL(1, rr_vec[1]*mg_coarsen_ratio, 1));
-                    is_coarsenable_y = ( a_geom[0].Domain().coarsenable(rr_1, mg_domain_min_width) and
-                                         a_grids[0].coarsenable(rr_1, mg_box_min_width));
+                    IntVect rrr_1(AMREX_D_DECL(1, rr_vec[1]*mg_coarsen_ratio, 1));
+                    is_coarsenable_y = ( a_geom[0].Domain().coarsenable(rrr_1, mg_domain_min_width) and
+                                         a_grids[0].coarsenable(rrr_1, mg_box_min_width));
 
 #if (AMREX_SPACEDIM == 3)
-                    IntVect rr_2(AMREX_D_DECL(1,1,rr_vec[2]*mg_coarsen_ratio));
-                    is_coarsenable_z = ( a_geom[0].Domain().coarsenable(rr_2, mg_domain_min_width) and
-                                         a_grids[0].coarsenable(rr_2, mg_box_min_width));
+                    IntVect rrr_2(AMREX_D_DECL(1,1,rr_vec[2]*mg_coarsen_ratio));
+                    is_coarsenable_z = ( a_geom[0].Domain().coarsenable(rrr_2, mg_domain_min_width) and
+                                         a_grids[0].coarsenable(rrr_2, mg_box_min_width));
 #endif
 #endif
 

--- a/Src/LinearSolvers/MLMG/AMReX_MLLinOp_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLLinOp_K.H
@@ -337,7 +337,7 @@ void mllinop_apply_innu_xlo (int i, int j, int k,
                              Array4<Real> const& rhs,
                              Array4<int const> const& mask,
                              Array4<Real const> const& bcoef,
-                             BoundCond bct, Real bcl,
+                             BoundCond bct, Real /*bcl*/,
                              Array4<Real const> const& bcval,
                              Real fac, bool has_bcoef, int icomp) noexcept
 {
@@ -352,7 +352,7 @@ void mllinop_apply_innu_xhi (int i, int j, int k,
                              Array4<Real> const& rhs,
                              Array4<int const> const& mask,
                              Array4<Real const> const& bcoef,
-                             BoundCond bct, Real bcl,
+                             BoundCond bct, Real /*bcl*/,
                              Array4<Real const> const& bcval,
                              Real fac, bool has_bcoef, int icomp) noexcept
 {
@@ -367,7 +367,7 @@ void mllinop_apply_innu_ylo (int i, int j, int k,
                              Array4<Real> const& rhs,
                              Array4<int const> const& mask,
                              Array4<Real const> const& bcoef,
-                             BoundCond bct, Real bcl,
+                             BoundCond bct, Real /*bcl*/,
                              Array4<Real const> const& bcval,
                              Real fac, bool has_bcoef, int icomp) noexcept
 {
@@ -381,7 +381,7 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 void mllinop_apply_innu_ylo_m (int i, int j, int k,
                                Array4<Real> const& rhs,
                                Array4<int const> const& mask,
-                               BoundCond bct, Real bcl,
+                               BoundCond bct, Real /*bcl*/,
                                Array4<Real const> const& bcval,
                                Real fac, Real xlo, Real dx, int icomp) noexcept
 {
@@ -396,7 +396,7 @@ void mllinop_apply_innu_yhi (int i, int j, int k,
                              Array4<Real> const& rhs,
                              Array4<int const> const& mask,
                              Array4<Real const> const& bcoef,
-                             BoundCond bct, Real bcl,
+                             BoundCond bct, Real /*bcl*/,
                              Array4<Real const> const& bcval,
                              Real fac, bool has_bcoef, int icomp) noexcept
 {
@@ -410,7 +410,7 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 void mllinop_apply_innu_yhi_m (int i, int j, int k,
                                Array4<Real> const& rhs,
                                Array4<int const> const& mask,
-                               BoundCond bct, Real bcl,
+                               BoundCond bct, Real /*bcl*/,
                                Array4<Real const> const& bcval,
                                Real fac, Real xlo, Real dx, int icomp) noexcept
 {
@@ -425,7 +425,7 @@ void mllinop_apply_innu_zlo (int i, int j, int k,
                              Array4<Real> const& rhs,
                              Array4<int const> const& mask,
                              Array4<Real const> const& bcoef,
-                             BoundCond bct, Real bcl,
+                             BoundCond bct, Real /*bcl*/,
                              Array4<Real const> const& bcval,
                              Real fac, bool has_bcoef, int icomp) noexcept
 {
@@ -440,7 +440,7 @@ void mllinop_apply_innu_zhi (int i, int j, int k,
                              Array4<Real> const& rhs,
                              Array4<int const> const& mask,
                              Array4<Real const> const& bcoef,
-                             BoundCond bct, Real bcl,
+                             BoundCond bct, Real /*bcl*/,
                              Array4<Real const> const& bcval,
                              Real fac, bool has_bcoef, int icomp) noexcept
 {

--- a/Src/LinearSolvers/MLMG/AMReX_MLMG.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLMG.cpp
@@ -390,7 +390,7 @@ MLMG::miniCycle (int amrlev)
 
 namespace {
 
-void make_str_helper (std::ostringstream & oss) { }
+void make_str_helper (std::ostringstream & /*oss*/) { }
 
 template <class T, class... Ts>
 void make_str_helper (std::ostringstream & oss, T x, Ts... xs) {
@@ -1379,7 +1379,7 @@ MLMG::getFluxes (const Vector<MultiFab*> & a_flux, Location a_loc)
 }
 
 void
-MLMG::getFluxes (const Vector<MultiFab*> & a_flux, const Vector<MultiFab*>& a_sol, Location a_loc)
+MLMG::getFluxes (const Vector<MultiFab*> & a_flux, const Vector<MultiFab*>& a_sol, Location /*a_loc*/)
 {
     AMREX_ASSERT(a_flux[0]->nComp() >= AMREX_SPACEDIM);
 
@@ -1815,6 +1815,7 @@ void
 MLMG::bottomSolveWithHypre (MultiFab& x, const MultiFab& b)
 {
 #if !defined(AMREX_USE_HYPRE)
+    amrex::ignore_unused(x,b);
     amrex::Abort("bottomSolveWithHypre is called without building with Hypre");
 #else
 
@@ -1874,6 +1875,7 @@ void
 MLMG::bottomSolveWithPETSc (MultiFab& x, const MultiFab& b)
 {
 #if !defined(AMREX_USE_PETSC)
+    amrex::ignore_unused(x,b);
     amrex::Abort("bottomSolveWithPETSc is called without building with PETSc");
 #else
 

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLap_3D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLap_3D_K.H
@@ -3280,7 +3280,7 @@ void mlndlap_stencil_rap (int i, int j, int k, Array4<Real> const& csten,
         }
     };
 
-    auto restrict_from_000_to = [] (int ii_, int jj_, int kk_) -> Real {
+    auto restrict_from_000_to = [] (int /*ii_*/, int /*jj_*/, int /*kk_*/) -> Real {
         return 1._rt;
     };
 

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian.H
@@ -96,9 +96,9 @@ public :
 
     virtual void fixUpResidualMask (int amrlev, iMultiFab& resmsk) final override;
 
-    virtual void getFluxes (const Vector<Array<MultiFab*,AMREX_SPACEDIM> >& a_flux,
-                            const Vector<MultiFab*>& a_sol,
-                            Location a_loc) const final override {
+    virtual void getFluxes (const Vector<Array<MultiFab*,AMREX_SPACEDIM> >& /*a_flux*/,
+                            const Vector<MultiFab*>& /*a_sol*/,
+                            Location /*a_loc*/) const final override {
         amrex::Abort("MLLinOp::getFluxes: How did we get here?");
     }
     virtual void getFluxes (const Vector<MultiFab*>& a_flux,

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLinOp.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLinOp.H
@@ -34,7 +34,7 @@ public:
                  const LPInfo& a_info = LPInfo(),
                  const Vector<FabFactory<FArrayBox> const*>& a_factory = {});
 
-    virtual void setLevelBC (int amrlev, const MultiFab* levelbcdata) final override {}
+    virtual void setLevelBC (int /*amrlev*/, const MultiFab* /*levelbcdata*/) final override {}
 
     virtual void apply (int amrlev, int mglev, MultiFab& out, MultiFab& in, BCMode bc_mode,
                         StateMode s_mode, const MLMGBndry* bndry=nullptr) const final override;
@@ -46,19 +46,20 @@ public:
                                    const MultiFab* crse_bcdata=nullptr) override;
     virtual void correctionResidual (int amrlev, int mglev, MultiFab& resid, MultiFab& x, const MultiFab& b,
                                      BCMode bc_mode, const MultiFab* crse_bcdata=nullptr) override;
-    virtual void compFlux (int amrlev, const Array<MultiFab*,AMREX_SPACEDIM>& fluxes,
-                           MultiFab& sol, Location loc) const final override {
+    virtual void compFlux (int /*amrlev*/, const Array<MultiFab*,AMREX_SPACEDIM>& /*fluxes*/,
+                           MultiFab& /*sol*/, Location /*loc*/) const final override {
         amrex::Abort("AMReX_MLNodeLinOp::compFlux::How did we get here?");
     }
-    virtual void compGrad (int amrlev, const Array<MultiFab*,AMREX_SPACEDIM>& grad,
-                           MultiFab& sol, Location loc) const final override {
+    virtual void compGrad (int /*amrlev*/, const Array<MultiFab*,AMREX_SPACEDIM>& /*grad*/,
+                           MultiFab& /*sol*/, Location /*loc*/) const final override {
         amrex::Abort("AMReX_MLNodeLinOp::compGrad::How did we get here?");
     }
     
-    virtual void applyMetricTerm (int amrlev, int mglev, MultiFab& rhs) const final override {}
-    virtual void unapplyMetricTerm (int amrlev, int mglev, MultiFab& rhs) const final override {}
+    virtual void applyMetricTerm (int /*amrlev*/, int /*mglev*/, MultiFab& /*rhs*/) const final override {}
+    virtual void unapplyMetricTerm (int /*amrlev*/, int /*mglev*/, MultiFab& /*rhs*/) const final override {}
 
-    virtual void fillSolutionBC (int amrlev, MultiFab& sol, const MultiFab* crse_bcdata=nullptr) final override {
+    virtual void fillSolutionBC (int /*amrlev*/, MultiFab& /*sol*/,
+                                 const MultiFab* /*crse_bcdata*/=nullptr) final override {
         amrex::Abort("AMReX_MLNodeLinOp::fillSolutionBC::How did we get here?");
     }
 
@@ -80,7 +81,7 @@ public:
 
     virtual void nodalSync (int amrlev, int mglev, MultiFab& mf) const final override;
 
-    virtual std::unique_ptr<MLLinOp> makeNLinOp (int grid_size) const final override {
+    virtual std::unique_ptr<MLLinOp> makeNLinOp (int /*grid_size*/) const final override {
         amrex::Abort("MLNodeLinOp::makeNLinOp: N-Solve not supported");
         return std::unique_ptr<MLLinOp>{};
     }

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLinOp.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLinOp.cpp
@@ -83,7 +83,7 @@ MLNodeLinOp::nodalSync (int amrlev, int mglev, MultiFab& mf) const
 
 void
 MLNodeLinOp::solutionResidual (int amrlev, MultiFab& resid, MultiFab& x, const MultiFab& b,
-                               const MultiFab* crse_bcdata)
+                               const MultiFab* /*crse_bcdata*/)
 {
     const int mglev = 0;
     const int ncomp = b.nComp();
@@ -112,7 +112,7 @@ MLNodeLinOp::solutionResidual (int amrlev, MultiFab& resid, MultiFab& x, const M
 
 void
 MLNodeLinOp::correctionResidual (int amrlev, int mglev, MultiFab& resid, MultiFab& x, const MultiFab& b,
-                                 BCMode bc_mode, const MultiFab* crse_bcdata)
+                                 BCMode /*bc_mode*/, const MultiFab* /*crse_bcdata*/)
 {
     apply(amrlev, mglev, resid, x, BCMode::Homogeneous, StateMode::Correction);
     int ncomp = b.nComp();
@@ -140,6 +140,7 @@ MLNodeLinOp::smooth (int amrlev, int mglev, MultiFab& sol, const MultiFab& rhs,
 Real
 MLNodeLinOp::xdoty (int amrlev, int mglev, const MultiFab& x, const MultiFab& y, bool local) const
 {
+    amrex::ignore_unused(amrlev);
     AMREX_ASSERT(amrlev==0);
     AMREX_ASSERT(mglev+1==m_num_mg_levels[0] || mglev==0);
     const auto& mask = (mglev+1 == m_num_mg_levels[0]) ? m_bottom_dot_mask : m_coarse_dot_mask;
@@ -160,6 +161,7 @@ MLNodeLinOp::xdoty (int amrlev, int mglev, const MultiFab& x, const MultiFab& y,
 void
 MLNodeLinOp::applyInhomogNeumannTerm (int amrlev, MultiFab& rhs) const
 {
+    amrex::ignore_unused(amrlev);
     int ncomp = rhs.nComp();
     for (int n = 0; n < ncomp; ++n)
     {

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeTensorLap_3D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeTensorLap_3D_K.H
@@ -7,53 +7,53 @@ namespace {
 
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     Real ts_interp_line_x (Array4<Real const> const& crse,
-                           int i, int j, int k, int ic, int jc, int kc) noexcept
+                           int ic, int jc, int kc) noexcept
     {
         return (crse(ic,jc,kc)+crse(ic+1,jc,kc))*0.5_rt;
     }
 
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     Real ts_interp_line_y (Array4<Real const> const& crse,
-                           int i, int j, int k, int ic, int jc, int kc) noexcept
+                           int ic, int jc, int kc) noexcept
     {
         return (crse(ic,jc,kc)+crse(ic,jc+1,kc))*0.5_rt;
     }
 
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     Real ts_interp_line_z (Array4<Real const> const& crse,
-                           int i, int j, int k, int ic, int jc, int kc) noexcept
+                           int ic, int jc, int kc) noexcept
     {
         return (crse(ic,jc,kc)+crse(ic,jc,kc+1))*0.5_rt;
     }
 
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     Real ts_interp_face_xy (Array4<Real const> const& crse,
-                            int i, int j, int k, int ic, int jc, int kc) noexcept
+                            int ic, int jc, int kc) noexcept
     {
-        return (ts_interp_line_y(crse,i-1,j  ,k,ic  ,jc  ,kc) +
-                ts_interp_line_y(crse,i+1,j  ,k,ic+1,jc  ,kc) +
-                ts_interp_line_x(crse,i  ,j-1,k,ic  ,jc  ,kc) +
-                ts_interp_line_x(crse,i  ,j+1,k,ic  ,jc+1,kc)) * 0.25_rt;
+        return (ts_interp_line_y(crse,ic  ,jc  ,kc) +
+                ts_interp_line_y(crse,ic+1,jc  ,kc) +
+                ts_interp_line_x(crse,ic  ,jc  ,kc) +
+                ts_interp_line_x(crse,ic  ,jc+1,kc)) * 0.25_rt;
     }
 
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     Real ts_interp_face_xz (Array4<Real const> const& crse,
-                            int i, int j, int k, int ic, int jc, int kc) noexcept
+                            int ic, int jc, int kc) noexcept
     {
-        return (ts_interp_line_z(crse,i-1,j,k  ,ic  ,jc,kc  ) +
-                ts_interp_line_z(crse,i+1,j,k  ,ic+1,jc,kc  ) +
-                ts_interp_line_x(crse,i  ,j,k-1,ic  ,jc,kc  ) +
-                ts_interp_line_x(crse,i  ,j,k+1,ic  ,jc,kc+1)) * 0.25_rt;
+        return (ts_interp_line_z(crse,ic  ,jc,kc  ) +
+                ts_interp_line_z(crse,ic+1,jc,kc  ) +
+                ts_interp_line_x(crse,ic  ,jc,kc  ) +
+                ts_interp_line_x(crse,ic  ,jc,kc+1)) * 0.25_rt;
     }
 
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     Real ts_interp_face_yz (Array4<Real const> const& crse,
-                            int i, int j, int k, int ic, int jc, int kc) noexcept
+                            int ic, int jc, int kc) noexcept
     {
-        return (ts_interp_line_z(crse,i,j-1,k  ,ic,jc  ,kc  ) +
-                ts_interp_line_z(crse,i,j+1,k  ,ic,jc+1,kc  ) +
-                ts_interp_line_y(crse,i,j  ,k-1,ic,jc  ,kc  ) +
-                ts_interp_line_y(crse,i,j  ,k+1,ic,jc  ,kc+1)) * 0.25_rt;
+        return (ts_interp_line_z(crse,ic,jc  ,kc  ) +
+                ts_interp_line_z(crse,ic,jc+1,kc  ) +
+                ts_interp_line_y(crse,ic,jc  ,kc  ) +
+                ts_interp_line_y(crse,ic,jc  ,kc+1)) * 0.25_rt;
     }
 }
 
@@ -70,30 +70,30 @@ void mlndtslap_interpadd (int i, int j, int k, Array4<Real> const& fine,
         bool k_is_odd = (kc*2 != k);
         if (i_is_odd and j_is_odd and k_is_odd) {
             // Fine node at center of cell
-            fine(i,j,k) += (ts_interp_face_yz(crse,i-1,j  ,k  ,ic  ,jc  ,kc  ) +
-                            ts_interp_face_yz(crse,i+1,j  ,k  ,ic+1,jc  ,kc  ) +
-                            ts_interp_face_xz(crse,i  ,j-1,k  ,ic  ,jc  ,kc  ) +
-                            ts_interp_face_xz(crse,i  ,j+1,k  ,ic  ,jc+1,kc  ) +
-                            ts_interp_face_xy(crse,i  ,j  ,k-1,ic  ,jc  ,kc  ) +
-                            ts_interp_face_xy(crse,i  ,j  ,k+1,ic  ,jc  ,kc+1)) * (1._rt/6._rt);
+            fine(i,j,k) += (ts_interp_face_yz(crse,ic  ,jc  ,kc  ) +
+                            ts_interp_face_yz(crse,ic+1,jc  ,kc  ) +
+                            ts_interp_face_xz(crse,ic  ,jc  ,kc  ) +
+                            ts_interp_face_xz(crse,ic  ,jc+1,kc  ) +
+                            ts_interp_face_xy(crse,ic  ,jc  ,kc  ) +
+                            ts_interp_face_xy(crse,ic  ,jc  ,kc+1)) * (1._rt/6._rt);
         } else if (j_is_odd and k_is_odd) {
             // Node on a Y-Z face
-            fine(i,j,k) += ts_interp_face_yz(crse,i,j,k,ic,jc,kc);
+            fine(i,j,k) += ts_interp_face_yz(crse,ic,jc,kc);
         } else if (i_is_odd and k_is_odd) {
             // Node on a Z-X face
-            fine(i,j,k) += ts_interp_face_xz(crse,i,j,k,ic,jc,kc);
+            fine(i,j,k) += ts_interp_face_xz(crse,ic,jc,kc);
         } else if (i_is_odd and j_is_odd) {
             // Node on a X-Y face
-            fine(i,j,k) += ts_interp_face_xy(crse,i,j,k,ic,jc,kc);
+            fine(i,j,k) += ts_interp_face_xy(crse,ic,jc,kc);
         } else if (i_is_odd) {
             // Node on X line
-            fine(i,j,k) += ts_interp_line_x(crse,i,j,k,ic,jc,kc);
+            fine(i,j,k) += ts_interp_line_x(crse,ic,jc,kc);
         } else if (j_is_odd) {
             // Node on Y line
-            fine(i,j,k) += ts_interp_line_y(crse,i,j,k,ic,jc,kc);
+            fine(i,j,k) += ts_interp_line_y(crse,ic,jc,kc);
         } else if (k_is_odd) {
             // Node on Z line
-            fine(i,j,k) += ts_interp_line_z(crse,i,j,k,ic,jc,kc);
+            fine(i,j,k) += ts_interp_line_z(crse,ic,jc,kc);
         } else {
             // Node coincident with coarse node
             fine(i,j,k) += crse(ic,jc,kc);
@@ -103,7 +103,7 @@ void mlndtslap_interpadd (int i, int j, int k, Array4<Real> const& fine,
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 void mlndtslap_adotx (Box const& b, Array4<Real> const& y, Array4<Real const> const& x,
-                      Array4<int const> const& msk, GpuArray<Real,6> const& s,
+                      Array4<int const> const& /*msk*/, GpuArray<Real,6> const& s,
                       GpuArray<Real,AMREX_SPACEDIM> const& dxinv) noexcept
 {
     const Real h00 = dxinv[0]*dxinv[0];

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeTensorLaplacian.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeTensorLaplacian.cpp
@@ -128,8 +128,8 @@ MLNodeTensorLaplacian::interpolation (int amrlev, int fmglev, MultiFab& fine,
 }
 
 void
-MLNodeTensorLaplacian::averageDownSolutionRHS (int camrlev, MultiFab& crse_sol, MultiFab& crse_rhs,
-                                               const MultiFab& fine_sol, const MultiFab& fine_rhs)
+MLNodeTensorLaplacian::averageDownSolutionRHS (int camrlev, MultiFab& crse_sol, MultiFab& /*crse_rhs*/,
+                                               const MultiFab& fine_sol, const MultiFab& /*fine_rhs*/)
 {
     const auto& amrrr = AMRRefRatio(camrlev);
     amrex::average_down(fine_sol, crse_sol, 0, 1, amrrr);
@@ -141,9 +141,9 @@ MLNodeTensorLaplacian::averageDownSolutionRHS (int camrlev, MultiFab& crse_sol, 
 }
 
 void
-MLNodeTensorLaplacian::reflux (int crse_amrlev,
-                               MultiFab& res, const MultiFab& crse_sol, const MultiFab& crse_rhs,
-                               MultiFab& fine_res, MultiFab& fine_sol, const MultiFab& fine_rhs) const
+MLNodeTensorLaplacian::reflux (int /*crse_amrlev*/,
+                               MultiFab& /*res*/, const MultiFab& /*crse_sol*/, const MultiFab& /*crse_rhs*/,
+                               MultiFab& /*fine_res*/, MultiFab& /*fine_sol*/, const MultiFab& /*fine_rhs*/) const
 {
     amrex::Abort("MLNodeTensorLaplacian::reflux: TODO");
 }
@@ -215,6 +215,7 @@ MLNodeTensorLaplacian::Fsmooth (int amrlev, int mglev, MultiFab& sol, const Mult
 void
 MLNodeTensorLaplacian::normalize (int amrlev, int mglev, MultiFab& mf) const
 {
+    amrex::ignore_unused(amrlev,mglev,mf);
     return;
 
 #if 0
@@ -242,7 +243,7 @@ MLNodeTensorLaplacian::normalize (int amrlev, int mglev, MultiFab& mf) const
 }
 
 void
-MLNodeTensorLaplacian::fixUpResidualMask (int amrlev, iMultiFab& resmsk)
+MLNodeTensorLaplacian::fixUpResidualMask (int /*amrlev*/, iMultiFab& /*resmsk*/)
 {
     amrex::Abort("MLNodeTensorLaplacian::fixUpResidualMask: TODO");
 }

--- a/Src/LinearSolvers/MLMG/AMReX_MLPoisson.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLPoisson.H
@@ -46,8 +46,8 @@ public:
 
     virtual Real getAScalar () const final override { return  0.0; }
     virtual Real getBScalar () const final override { return -1.0; }
-    virtual MultiFab const* getACoeffs (int amrlev, int mglev) const final override { return nullptr; }
-    virtual Array<MultiFab const*,AMREX_SPACEDIM> getBCoeffs (int amrlev, int mglev) const final override
+    virtual MultiFab const* getACoeffs (int /*amrlev*/, int /*mglev*/) const final override { return nullptr; }
+    virtual Array<MultiFab const*,AMREX_SPACEDIM> getBCoeffs (int /*amrlev*/, int /*mglev*/) const final override
         { return { AMREX_D_DECL(nullptr,nullptr,nullptr)}; }
 
     virtual std::unique_ptr<MLLinOp> makeNLinOp (int grid_size) const final override;

--- a/Src/LinearSolvers/MLMG/AMReX_MLPoisson.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLPoisson.cpp
@@ -112,6 +112,7 @@ MLPoisson::Fapply (int amrlev, int mglev, MultiFab& out, const MultiFab& in) con
 void
 MLPoisson::normalize (int amrlev, int mglev, MultiFab& mf) const
 {
+    amrex::ignore_unused(amrlev,mglev,mf);
 #if (AMREX_SPACEDIM != 3)
     BL_PROFILE("MLPoisson::normalize()");
 

--- a/Src/LinearSolvers/MLMG/AMReX_MLTensorOp.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLTensorOp.H
@@ -76,7 +76,7 @@ public:
     }
 
     virtual void prepareForSolve () final override;
-    virtual bool isSingular (int armlev) const final override { return false; }
+    virtual bool isSingular (int /*armlev*/) const final override { return false; }
     virtual bool isBottomSingular () const final override { return false; }
 
     virtual void apply (int amrlev, int mglev, MultiFab& out, MultiFab& in, BCMode bc_mode,

--- a/Src/LinearSolvers/MLMG/AMReX_MLTensorOp.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLTensorOp.cpp
@@ -470,7 +470,7 @@ MLTensorOp::compFlux (int amrlev, const Array<MultiFab*,AMREX_SPACEDIM>& fluxes,
 
 void
 MLTensorOp::compVelGrad (int amrlev, const Array<MultiFab*,AMREX_SPACEDIM>& fluxes,
-                       MultiFab& sol, Location loc) const
+                       MultiFab& sol, Location /*loc*/) const
 {
 #if (AMREX_SPACEDIM > 1)
     BL_PROFILE("MLTensorOp::compVelGrad()");
@@ -480,7 +480,7 @@ MLTensorOp::compVelGrad (int amrlev, const Array<MultiFab*,AMREX_SPACEDIM>& flux
     applyBCTensor(amrlev, mglev, sol, BCMode::Inhomogeneous, StateMode::Solution, m_bndry_sol[amrlev].get());
 
     const auto dxinv = m_geom[amrlev][mglev].InvCellSizeArray();
-    const int dim_fluxes = pow(AMREX_SPACEDIM,2);
+    const int dim_fluxes = AMREX_SPACEDIM*AMREX_SPACEDIM;
 
 #ifdef _OPENMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())

--- a/Src/Particle/AMReX_ParticleCommunication.cpp
+++ b/Src/Particle/AMReX_ParticleCommunication.cpp
@@ -202,6 +202,8 @@ void ParticleCopyPlan::buildMPIStart (const ParticleBufferMap& map, Long psize)
 
 void ParticleCopyPlan::buildMPIFinish (const ParticleBufferMap& map)
 {
+    amrex::ignore_unused(map);
+
     BL_PROFILE("ParticleCopyPlan::buildMPIFinish");
 
 #ifdef AMREX_USE_MPI
@@ -259,7 +261,6 @@ void ParticleCopyPlan::buildMPIFinish (const ParticleBufferMap& map)
         }
         m_rcv_num_particles[Who] = nparticles;
     }
-
 #endif // MPI
 }
 

--- a/Src/Particle/AMReX_ParticleContainerI.H
+++ b/Src/Particle/AMReX_ParticleContainerI.H
@@ -909,7 +909,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>::
 addParticles (const ParticleContainerType& other, bool local)
 {
     using PData = ConstParticleTileData<NStructReal, NStructInt, NArrayReal, NArrayInt>; 
-    addParticles(other, [=] AMREX_GPU_HOST_DEVICE (const PData& data, int i) { return 1; }, local);
+    addParticles(other, [=] AMREX_GPU_HOST_DEVICE (const PData& /*data*/, int /*i*/) { return 1; }, local);
 }
 
 template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt>

--- a/Src/Particle/AMReX_ParticleUtil.H
+++ b/Src/Particle/AMReX_ParticleUtil.H
@@ -237,7 +237,7 @@ bool enforcePeriodic (P& p,
 template <typename PTile, typename PLocator>
 int
 partitionParticlesByDest (PTile& ptile, const PLocator& ploc, const ParticleBufferMap& pmap,
-                          const Geometry& geom, int lev, int gid, int tid,
+                          const Geometry& geom, int lev, int gid, int /*tid*/,
                           int lev_min, int lev_max, int nGrow)
 {
     const auto plo    = geom.ProbLoArray();

--- a/Tools/GNUMake/Make.defs
+++ b/Tools/GNUMake/Make.defs
@@ -294,6 +294,16 @@ else
   USE_FORCE_INLINE := FALSE
 endif
 
+ifdef WARN_ALL
+  WARN_ALL := $(strip $(WARN_ALL))
+else
+ifeq ($(DEBUG),TRUE)
+  WARN_ALL := TRUE
+else
+  WARN_ALL := FALSE
+endif
+endif
+
 ifdef USE_GPU_PRAGMA
   USE_GPU_PRAGMA := $(strip $(USE_GPU_PRAGMA))
   GPU_PRAGMA_NO_HOST_VERSION ?= FALSE

--- a/Tools/GNUMake/comps/llvm.mak
+++ b/Tools/GNUMake/comps/llvm.mak
@@ -23,8 +23,8 @@ COMP_VERSION = $(clang_version)
 
 ifeq ($(DEBUG),TRUE)
 
-  CXXFLAGS += -g -O0 -Wall -Wextra -Wno-sign-compare -Wno-unused-parameter -Wno-unused-variable -Wno-missing-braces -Wmissing-field-initializers -ftrapv
-  CFLAGS   += -g -O0 -Wall -Wextra -Wno-sign-compare -Wno-unused-parameter -Wno-unused-variable -Wno-missing-braces -Wmissing-field-initializers -ftrapv
+  CXXFLAGS += -g -O0 -ftrapv
+  CFLAGS   += -g -O0 -ftrapv
 
   FFLAGS   += -g -O0 -ggdb -fbounds-check -fbacktrace -Wuninitialized -Wunused -ffpe-trap=invalid,zero -finit-real=snan -finit-integer=2147483647 -ftrapv
   F90FLAGS += -g -O0 -ggdb -fbounds-check -fbacktrace -Wuninitialized -Wunused -ffpe-trap=invalid,zero -finit-real=snan -finit-integer=2147483647 -ftrapv
@@ -36,6 +36,22 @@ else
   FFLAGS   += -g -O3
   F90FLAGS += -g -O3
 
+endif
+
+ifeq ($(WARN_ALL),TRUE)
+  warning_flags = -Wall -Wextra -Wno-sign-compare -Wunreachable-code -Wnull-dereference
+  warning_flags += -Wfloat-conversion -Wextra-semi
+
+  ifneq ($(USE_CUDA),TRUE)
+    warning_flags += -Wpedantic
+  endif
+
+  ifneq ($(WARN_SHADOW),FALSE)
+    warning_flags += -Wshadow
+  endif
+
+  CXXFLAGS += $(warning_flags) -Woverloaded-virtual
+  CFLAGS += $(warning_flags)
 endif
 
 ########################################################################


### PR DESCRIPTION
Add WARN_ALL option to GNUMake system to turn on more compiler warnings for gcc and clang.  The
default is FALSE.  Fix a couple of bugs found by the warning and a number of warnings.