### PR TITLE
Switch to nvtxRangePush() and nvtxRangePop() in TinyProfiler

### DIFF
--- a/Src/Base/AMReX_TinyProfiler.H
+++ b/Src/Base/AMReX_TinyProfiler.H
@@ -89,10 +89,6 @@ private:
     static std::map<std::string,std::map<std::string, Stats> > statsmap;
     static double t_init;
 
-#ifdef AMREX_USE_CUDA
-    nvtxRangeId_t nvtx_id;
-#endif
-
     static void PrintStats (std::map<std::string,Stats>& regstats, double dt_max);
 };
 

--- a/Src/Base/AMReX_TinyProfiler.cpp
+++ b/Src/Base/AMReX_TinyProfiler.cpp
@@ -88,7 +88,7 @@ TinyProfiler::start () noexcept
 	global_depth = ttstack.size();
 
 #ifdef AMREX_USE_CUDA
-	nvtx_id = nvtxRangeStartA(fname.c_str());
+	nvtxRangePush(fname.c_str());
 #endif
 
         for (auto const& region : regionstack)
@@ -162,7 +162,7 @@ TinyProfiler::stop () noexcept
         }
 
 #ifdef AMREX_USE_CUDA
-        nvtxRangeEnd(nvtx_id);
+        nvtxRangePop();
 #endif
 	} else {
 	    improperly_nested_timers.insert(fname);
@@ -230,7 +230,7 @@ TinyProfiler::stop (unsigned boxUintID) noexcept
             }
 
 #ifdef AMREX_USE_CUDA
-            nvtxRangeEnd(nvtx_id);
+            nvtxRangePop();
 #endif
         } else 
         {


### PR DESCRIPTION
This enables support for Nsight Systems' option to name CUDA kernels by the innermost NVTX region.