### PR TITLE
CI: Clang 6.0 C++17 SP NOMPI

### DIFF
--- a/.github/workflows/dependencies/dependencies_clang6.sh
+++ b/.github/workflows/dependencies/dependencies_clang6.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+#
+# Copyright 2020 The AMReX Community
+#
+# License: BSD-3-Clause-LBNL
+# Authors: Axel Huebl
+
+set -eu -o pipefail
+
+sudo apt-get update
+
+sudo apt-get install -y  \
+    build-essential      \
+    clang gfortran

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -19,7 +19,33 @@ jobs:
             -DCMAKE_VERBOSE_MAKEFILE=ON           \
             -DCMAKE_INSTALL_PREFIX=/tmp/my-amrex  \
             -DCMAKE_CXX_STANDARD=17
-        make -j 2 VERBOSE=ON
+        make -j 2
+        make install
+
+  library_clang:
+    name: Clang@6.0 C++14 SP NOMPI Debug [lib]
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Dependencies
+      run: .github/workflows/dependencies/dependencies_clang6.sh
+    - name: Build & Install
+      run: |
+        mkdir build
+        cd build
+        cmake ..                        \
+            -DCMAKE_BUILD_TYPE=Debug    \
+            -DCMAKE_VERBOSE_MAKEFILE=ON \
+            -DCMAKE_INSTALL_PREFIX=/tmp/my-amrex  \
+            -DENABLE_MPI=OFF            \
+            -DENABLE_PARTICLES=ON       \
+            -DENABLE_DP=OFF             \
+            -DENABLE_DP_PARTICLES=OFF   \
+            -DCMAKE_CXX_STANDARD=14     \
+            -DCMAKE_C_COMPILER=$(which clang)         \
+            -DCMAKE_CXX_COMPILER=$(which clang++)     \
+            -DCMAKE_Fortran_COMPILER=$(which gfortran)
+        make -j 2
         make install
 
   # Build libamrex and all tutorials
@@ -66,7 +92,7 @@ jobs:
 
   # Build libamrex and all tutorials w/o MPI
   tutorials-nonmpi:
-    name: GNU@7.5 C++14 non-MPI [tutorials]
+    name: GNU@7.5 C++14 NOMPI [tutorials]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -131,7 +157,7 @@ jobs:
 
   # Build libamrex and all tutorials with DPC++
   tutorials-dpcpp:
-    name: DPCPP@PubBeta GFortran@7.5 C++14 [tutorials]
+    name: DPCPP@PubBeta GFortran@7.5 C++17 [tutorials]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Add a Clang build to CI that also covers single precision (SP).

Related to #1180 (adds coverage for SP and Clang).