### PR TITLE
Wreorder: ErrorList

### DIFF
--- a/Src/AmrCore/AMReX_ErrorList.H
+++ b/Src/AmrCore/AMReX_ErrorList.H
@@ -431,7 +431,7 @@ std::ostream& operator << (std::ostream& os, const ErrorList& elst);
                  const std::string&     field,
                  int                    ngrow,
                  const AMRErrorTagInfo& info = AMRErrorTagInfo()) noexcept
-      : m_userfunc(userfunc), m_field(field), m_ngrow(ngrow), m_info(info) {}
+      : m_userfunc(userfunc), m_field(field), m_info(info), m_ngrow(ngrow) {}
 
     virtual void operator() (amrex::TagBoxArray&    tb,
                              const amrex::MultiFab* mf,


### PR DESCRIPTION
Fix:
```
AMReX_ErrorList.H:434:47: warning: field 'm_ngrow' will be initialized after field 'm_info' [-Wreorder]
```

Related to #1180