### PR TITLE
Fix a bug for Nodal semicoarsening

### DIFF
--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLap_3D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLap_3D_K.H
@@ -1246,7 +1246,6 @@ void mlndlap_gauss_seidel_with_line_solve_aa (Box const& bx, Array4<Real> const&
                         c_ls(k-lo.z) = fm2xm2y4z*(sig(i-1,j-1,k  )+sig(i,j-1,k  )+sig(i-1,j,k  )+sig(i,j,k  ));
                         u_ls(k-lo.z) = 0.;  
                         r_ls(k-lo.z) = rhs(i,j,k) - Ax;
-				
                     }
                 }
                 tridiagonal_solve(a_ls, b_ls, c_ls, r_ls, u_ls, gam, ilen);

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLap_3D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLap_3D_K.H
@@ -1329,11 +1329,11 @@ void mlndlap_gauss_seidel_with_line_solve_aa (Box const& bx, Array4<Real> const&
                 {
                     if (msk(i,j,k)) 
                     {
-                        a_ls(j-lo.y) = 0.;
-                        b_ls(j-lo.y) = 1.;
-                        c_ls(j-lo.y) = 0.;
-                        u_ls(j-lo.y) = 0.;
-                        r_ls(j-lo.y) = 0.;
+                        a_ls(i-lo.x) = 0.;
+                        b_ls(i-lo.x) = 1.;
+                        c_ls(i-lo.x) = 0.;
+                        u_ls(i-lo.x) = 0.;
+                        r_ls(i-lo.x) = 0.;
                     }
                     else
                     {

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian.cpp
@@ -801,7 +801,7 @@ MLNodeLaplacian::averageDownCoeffsSameAmrLevel (int amrlev)
 #if (AMREX_SPACEDIM >= 2)
                         AMREX_HOST_DEVICE_PARALLEL_FOR_3D ( bx, i, j, k,
                         {
-                            mlndlap_avgdown_coeff_z(i,j,k,cfab,ffab);
+                            mlndlap_avgdown_coeff_y(i,j,k,cfab,ffab);
                         });
 #endif
                     } 

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian.cpp
@@ -734,7 +734,6 @@ MLNodeLaplacian::averageDownCoeffsSameAmrLevel (int amrlev)
         int idir = 2;
         bool regular_coarsening = mg_coarsen_ratio_vec[mglev-1] == mg_coarsen_ratio;
         IntVect ratio = mg_coarsen_ratio_vec[mglev-1];
-        amrex::Print() << "regular_coarsening = " << regular_coarsening << ", idir = " << idir << std::endl;
         if (ratio[1] == 1) {
             idir = 1;
         } else if (ratio[0] == 1) {

--- a/Tutorials/LinearSolvers/NodalPoisson/MyTest.cpp
+++ b/Tutorials/LinearSolvers/NodalPoisson/MyTest.cpp
@@ -18,7 +18,13 @@ MyTest::solve ()
 {
     if (composite_solve)
     {
-        MLNodeLaplacian linop(geom, grids, dmap);
+        LPInfo info;
+        info.setAgglomeration(agglomeration);
+        info.setConsolidation(consolidation);
+        info.setSemicoarsening(semicoarsening);
+        info.setMaxSemicoarseningLevel(max_semicoarsening_level);
+
+        MLNodeLaplacian linop(geom, grids, dmap, info);
 
         linop.setDomainBC({AMREX_D_DECL(LinOpBCType::Dirichlet,
                                         LinOpBCType::Dirichlet,
@@ -139,6 +145,10 @@ MyTest::readParameters ()
     pp.query("reltol", reltol);
 
     pp.query("gpu_regtest", gpu_regtest);
+
+    pp.query("agglomeration", agglomeration);
+    pp.query("semicoarsening", semicoarsening);
+    pp.query("max_semicoarsening_level", max_semicoarsening_level);
 }
 
 void
@@ -154,10 +164,10 @@ MyTest::initData ()
     exact_solution.resize(nlevels);
     sigma.resize(nlevels);
 
-    RealBox rb({AMREX_D_DECL(0.,0.,0.)}, {AMREX_D_DECL(1.,1.,1.)});
+    RealBox rb({AMREX_D_DECL(0.,0.,0.)}, {AMREX_D_DECL(1.,64.,64.)});
     Array<int,AMREX_SPACEDIM> is_periodic{AMREX_D_DECL(0,0,0)};
     Geometry::Setup(&rb, 0, is_periodic.data());
-    Box domain0(IntVect{AMREX_D_DECL(0,0,0)}, IntVect{AMREX_D_DECL(n_cell-1,n_cell-1,n_cell-1)});
+    Box domain0(IntVect{AMREX_D_DECL(0,0,0)}, IntVect{AMREX_D_DECL(n_cell-1,64*n_cell-1,64*n_cell-1)});
     Box domain = domain0;
     for (int ilev = 0; ilev < nlevels; ++ilev)
     {

--- a/Tutorials/LinearSolvers/NodalPoisson/MyTest.cpp
+++ b/Tutorials/LinearSolvers/NodalPoisson/MyTest.cpp
@@ -164,10 +164,10 @@ MyTest::initData ()
     exact_solution.resize(nlevels);
     sigma.resize(nlevels);
 
-    RealBox rb({AMREX_D_DECL(0.,0.,0.)}, {AMREX_D_DECL(1.,1.,1.)});
+    RealBox rb({AMREX_D_DECL(0.,0.,0.)}, {AMREX_D_DECL(1.,64.,64.)});
     Array<int,AMREX_SPACEDIM> is_periodic{AMREX_D_DECL(0,0,0)};
     Geometry::Setup(&rb, 0, is_periodic.data());
-    Box domain0(IntVect{AMREX_D_DECL(0,0,0)}, IntVect{AMREX_D_DECL(n_cell-1,n_cell-1,n_cell-1)});
+    Box domain0(IntVect{AMREX_D_DECL(0,0,0)}, IntVect{AMREX_D_DECL(n_cell-1,64*n_cell-1,64*n_cell-1)});
     Box domain = domain0;
     for (int ilev = 0; ilev < nlevels; ++ilev)
     {

--- a/Tutorials/LinearSolvers/NodalPoisson/MyTest.cpp
+++ b/Tutorials/LinearSolvers/NodalPoisson/MyTest.cpp
@@ -164,10 +164,10 @@ MyTest::initData ()
     exact_solution.resize(nlevels);
     sigma.resize(nlevels);
 
-    RealBox rb({AMREX_D_DECL(0.,0.,0.)}, {AMREX_D_DECL(1.,64.,64.)});
+    RealBox rb({AMREX_D_DECL(0.,0.,0.)}, {AMREX_D_DECL(1.,1.,1.)});
     Array<int,AMREX_SPACEDIM> is_periodic{AMREX_D_DECL(0,0,0)};
     Geometry::Setup(&rb, 0, is_periodic.data());
-    Box domain0(IntVect{AMREX_D_DECL(0,0,0)}, IntVect{AMREX_D_DECL(n_cell-1,64*n_cell-1,64*n_cell-1)});
+    Box domain0(IntVect{AMREX_D_DECL(0,0,0)}, IntVect{AMREX_D_DECL(n_cell-1,n_cell-1,n_cell-1)});
     Box domain = domain0;
     for (int ilev = 0; ilev < nlevels; ++ilev)
     {

--- a/Tutorials/LinearSolvers/NodalPoisson/inputs-rt
+++ b/Tutorials/LinearSolvers/NodalPoisson/inputs-rt
@@ -7,8 +7,12 @@ max_grid_size = 64
 composite_solve = 1   # composite solve or level by level?
 
 # For MLMG
-verbose = 2
-bottom_verbose = 0
+verbose = 5
+bottom_verbose = 1
 max_iter = 100
 max_fmg_iter = 0     # # of F-cycles before switching to V.  To do pure V-cycle, set to 0
 reltol = 1.e-11
+
+agglomeration = 1
+semicoarsening = 1
+max_semicoarsening_level = 5

--- a/Tutorials/LinearSolvers/NodalPoisson/inputs-rt
+++ b/Tutorials/LinearSolvers/NodalPoisson/inputs-rt
@@ -1,18 +1,14 @@
 
 max_level = 1
 ref_ratio = 2
-n_cell = 8
+n_cell = 128
 max_grid_size = 64
 
 composite_solve = 1   # composite solve or level by level?
 
 # For MLMG
-verbose = 5
-bottom_verbose = 1
+verbose = 2
+bottom_verbose = 0
 max_iter = 100
 max_fmg_iter = 0     # # of F-cycles before switching to V.  To do pure V-cycle, set to 0
 reltol = 1.e-11
-
-agglomeration = 1
-semicoarsening = 1
-max_semicoarsening_level = 5

--- a/Tutorials/LinearSolvers/NodalPoisson/inputs-rt
+++ b/Tutorials/LinearSolvers/NodalPoisson/inputs-rt
@@ -1,14 +1,18 @@
 
 max_level = 1
 ref_ratio = 2
-n_cell = 128
+n_cell = 8
 max_grid_size = 64
 
 composite_solve = 1   # composite solve or level by level?
 
 # For MLMG
-verbose = 2
-bottom_verbose = 0
+verbose = 5
+bottom_verbose = 1
 max_iter = 100
 max_fmg_iter = 0     # # of F-cycles before switching to V.  To do pure V-cycle, set to 0
 reltol = 1.e-11
+
+agglomeration = 1
+semicoarsening = 1
+max_semicoarsening_level = 5

--- a/Tutorials/LinearSolvers/NodalPoisson/inputs-rt
+++ b/Tutorials/LinearSolvers/NodalPoisson/inputs-rt
@@ -7,12 +7,8 @@ max_grid_size = 64
 composite_solve = 1   # composite solve or level by level?
 
 # For MLMG
-verbose = 5
-bottom_verbose = 1
+verbose = 2
+bottom_verbose = 0
 max_iter = 100
 max_fmg_iter = 0     # # of F-cycles before switching to V.  To do pure V-cycle, set to 0
 reltol = 1.e-11
-
-agglomeration = 1
-semicoarsening = 1
-max_semicoarsening_level = 5


### PR DESCRIPTION
Fix a bug when doing semicoarsening with short x domain. Apply mlndlap_avgdown_coeff_y when the x is the short direction. Also add the info to mlmg solver in Tutoria. l  