### PR TITLE
Communication buffers

### DIFF
--- a/Src/Base/AMReX_FabArrayBase.cpp
+++ b/Src/Base/AMReX_FabArrayBase.cpp
@@ -116,11 +116,15 @@ FabArrayBase::Initialize ()
         MaxComp = 1;
     }
 
+#ifdef AMREX_USE_GPU
     if (ParallelDescriptor::UseGpuAwareMpi()) {
         the_fa_arena = The_Device_Arena();
     } else {
         the_fa_arena = The_Pinned_Arena();
     }
+#else
+    the_fa_arena = The_Cpu_Arena();
+#endif
 
     amrex::ExecOnFinalize(FabArrayBase::Finalize);
 


### PR DESCRIPTION
Use The_Cpu_Arena (BArena) instead of The_Pinned_Arena (CArena) for communication buffers to avoid
the CArena fragmentation issue with the type of problems that allocate increasingly larger memory in
a contiguous chunk during simulation.  CArena then cannot effective use previous allocation chunks
because they are slightly smaller.  The fix is for CPU build only.  We still need to have a strategy
for this for GPU build.