### PR TITLE
Make aggregation type and buffer static member data of ParticleContainer.

### DIFF
--- a/Src/Particle/AMReX_Particle.H
+++ b/Src/Particle/AMReX_Particle.H
@@ -15,8 +15,6 @@ namespace amrex {
 
 namespace
 {
-    std::string   aggregation_type   = "";
-    int           aggregation_buffer = 1;
     constexpr int GhostParticleID    = std::numeric_limits<int>::max();
     constexpr int VirtualParticleID  = std::numeric_limits<int>::max()-1;
     constexpr int LastParticleID     = std::numeric_limits<int>::max()-2;

--- a/Src/Particle/AMReX_ParticleContainerI.H
+++ b/Src/Particle/AMReX_ParticleContainerI.H
@@ -10,6 +10,16 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
 ::tile_size { AMREX_D_DECL(1024000,8,8) };
 
 template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt>
+std::string
+ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
+::aggregation_type = "";
+
+template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt>
+int
+ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
+::aggregation_buffer = 1;
+
+template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt>
 void
 ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt> :: SetParticleSize ()
 {

--- a/Src/Particle/AMReX_Particles.H
+++ b/Src/Particle/AMReX_Particles.H
@@ -1301,6 +1301,9 @@ private:
     int num_real_comm_comps, num_int_comm_comps;
     Vector<ParticleLevel> m_particles;
     Vector<std::unique_ptr<MultiFab> > m_dummy_mf;
+
+    static std::string aggregation_type;
+    static int aggregation_buffer;
 };
 
 #include "AMReX_ParticleInit.H"


### PR DESCRIPTION
This silences a warning about unused variables.