### PR TITLE
Fix some more clang warnings

### DIFF
--- a/Src/AmrCore/AMReX_ErrorList.cpp
+++ b/Src/AmrCore/AMReX_ErrorList.cpp
@@ -315,9 +315,9 @@ operator << (std::ostream&    os,
       amrex::ParallelFor(bx,
       [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
       {
-        GpuArray<Real,AMREX_SPACEDIM> pt = {AMREX_D_DECL(plo[0]+(Real(i)+0.5_rt)*dx[0],
-                                                         plo[1]+(Real(j)+0.5_rt)*dx[1],
-                                                         plo[2]+(Real(k)+0.5_rt)*dx[2])};
+          GpuArray<Real,AMREX_SPACEDIM> pt = {{AMREX_D_DECL(plo[0]+(Real(i)+0.5_rt)*dx[0],
+                                                            plo[1]+(Real(j)+0.5_rt)*dx[1],
+                                                            plo[2]+(Real(k)+0.5_rt)*dx[2])}};
         if (tag_rb.contains(pt.data())) {
           tag(i,j,k) = tagval;
         }

--- a/Src/AmrCore/AMReX_FillPatchUtil.cpp
+++ b/Src/AmrCore/AMReX_FillPatchUtil.cpp
@@ -15,8 +15,8 @@ namespace amrex
                                      int ref_ratio)
     {
         InterpCrseFineBndryEMfield(interp_type,
-                                   {AMREX_D_DECL(&crse[0],&crse[1],&crse[2])},
-                                   {AMREX_D_DECL(&fine[0],&fine[1],&fine[2])},
+                                   {{AMREX_D_DECL(&crse[0],&crse[1],&crse[2])}},
+                                   {{AMREX_D_DECL(&fine[0],&fine[1],&fine[2])}},
                                    cgeom, fgeom, ref_ratio);
     }
 

--- a/Src/Base/AMReX_Array.H
+++ b/Src/Base/AMReX_Array.H
@@ -166,31 +166,31 @@ namespace amrex
     template <class T, typename = typename T::FABType>
     std::array<T*,AMREX_SPACEDIM> GetArrOfPtrs (std::array<T,AMREX_SPACEDIM>& a) noexcept
     {
-        return {AMREX_D_DECL(&a[0], &a[1], &a[2])};
+        return {{AMREX_D_DECL(&a[0], &a[1], &a[2])}};
     }
 
     template <class T>
     std::array<T*,AMREX_SPACEDIM> GetArrOfPtrs (const std::array<std::unique_ptr<T>,AMREX_SPACEDIM>& a) noexcept
     {
-        return {AMREX_D_DECL(a[0].get(), a[1].get(), a[2].get())};
+        return {{AMREX_D_DECL(a[0].get(), a[1].get(), a[2].get())}};
     }
     
     template <class T>
     std::array<T const*,AMREX_SPACEDIM> GetArrOfConstPtrs (const std::array<T,AMREX_SPACEDIM>& a) noexcept
     {
-        return {AMREX_D_DECL(&a[0], &a[1], &a[2])};
+        return {{AMREX_D_DECL(&a[0], &a[1], &a[2])}};
     }
 
     template <class T>
     std::array<T const*,AMREX_SPACEDIM> GetArrOfConstPtrs (const std::array<T*,AMREX_SPACEDIM>& a) noexcept
     {
-       return {AMREX_D_DECL(a[0], a[1], a[2])};
+        return {{AMREX_D_DECL(a[0], a[1], a[2])}};
     }
 
     template <class T>
     std::array<T const*,AMREX_SPACEDIM> GetArrOfConstPtrs (const std::array<std::unique_ptr<T>,AMREX_SPACEDIM>& a) noexcept
     {
-        return {AMREX_D_DECL(a[0].get(), a[1].get(), a[2].get())};
+        return {{AMREX_D_DECL(a[0].get(), a[1].get(), a[2].get())}};
     }
 
 }

--- a/Src/Base/AMReX_Box.H
+++ b/Src/Base/AMReX_Box.H
@@ -152,33 +152,33 @@ public:
     AMREX_GPU_HOST_DEVICE
     GpuArray<int,3> length3d () const noexcept {
 #if (AMREX_SPACEDIM == 1)
-        return {bigend[0]-smallend[0]+1, 1, 1};
+        return {{bigend[0]-smallend[0]+1, 1, 1}};
 #elif (AMREX_SPACEDIM == 2)
-        return {bigend[0]-smallend[0]+1, bigend[1]-smallend[1]+1, 1};
+        return {{bigend[0]-smallend[0]+1, bigend[1]-smallend[1]+1, 1}};
 #elif (AMREX_SPACEDIM == 3)
-        return {bigend[0]-smallend[0]+1, bigend[1]-smallend[1]+1, bigend[2]-smallend[2]+1};
+        return {{bigend[0]-smallend[0]+1, bigend[1]-smallend[1]+1, bigend[2]-smallend[2]+1}};
 #endif
     }
 
     AMREX_GPU_HOST_DEVICE
     GpuArray<int,3> loVect3d () const noexcept {
 #if (AMREX_SPACEDIM == 1)
-        return {smallend[0], 0, 0};
+        return {{smallend[0], 0, 0}};
 #elif (AMREX_SPACEDIM == 2)
-        return {smallend[0], smallend[1], 0};
+        return {{smallend[0], smallend[1], 0}};
 #elif (AMREX_SPACEDIM == 3)
-        return {smallend[0], smallend[1], smallend[2]};
+        return {{smallend[0], smallend[1], smallend[2]}};
 #endif
     }
 
     AMREX_GPU_HOST_DEVICE
     GpuArray<int,3> hiVect3d () const noexcept {
 #if (AMREX_SPACEDIM == 1)
-        return {bigend[0], 0, 0};
+        return {{bigend[0], 0, 0}};
 #elif (AMREX_SPACEDIM == 2)
-        return {bigend[0], bigend[1], 0};
+        return {{bigend[0], bigend[1], 0}};
 #elif (AMREX_SPACEDIM == 3)
-        return {bigend[0], bigend[1], bigend[2]};
+        return {{bigend[0], bigend[1], bigend[2]}};
 #endif
     }
 

--- a/Src/Base/AMReX_CoordSys.H
+++ b/Src/Base/AMReX_CoordSys.H
@@ -82,7 +82,7 @@ public:
 
     GpuArray<Real,AMREX_SPACEDIM> CellSizeArray () const noexcept {
         BL_ASSERT(ok);
-        return { AMREX_D_DECL(dx[0],dx[1],dx[2]) };
+        return {{ AMREX_D_DECL(dx[0],dx[1],dx[2]) }};
     }
 
     //! Returns the inverse cellsize for each coordinate direction.
@@ -93,7 +93,7 @@ public:
 
     GpuArray<Real,AMREX_SPACEDIM> InvCellSizeArray () const noexcept {
         BL_ASSERT(ok);
-        return { AMREX_D_DECL(inv_dx[0],inv_dx[1],inv_dx[2]) };
+        return {{ AMREX_D_DECL(inv_dx[0],inv_dx[1],inv_dx[2]) }};
     }
 
     //! Returns location of cell center in specified direction.

--- a/Src/Base/AMReX_CoordSys.cpp
+++ b/Src/Base/AMReX_CoordSys.cpp
@@ -206,7 +206,7 @@ CoordSys::SetVolume (FArrayBox& a_volfab,
     AMREX_ASSERT(region.cellCentered());
 
     auto vol = a_volfab.array();
-    GpuArray<Real,AMREX_SPACEDIM> a_dx{AMREX_D_DECL(dx[0], dx[1], dx[2])};
+    GpuArray<Real,AMREX_SPACEDIM> a_dx{{AMREX_D_DECL(dx[0], dx[1], dx[2])}};
 
 #if (AMREX_SPACEDIM == 3)
     AMREX_ASSERT(IsCartesian());
@@ -216,7 +216,7 @@ CoordSys::SetVolume (FArrayBox& a_volfab,
         vol(i,j,k) = dv;
     });
 #else
-    GpuArray<Real,AMREX_SPACEDIM> a_offset{AMREX_D_DECL(offset[0],offset[1],offset[2])};
+    GpuArray<Real,AMREX_SPACEDIM> a_offset{{AMREX_D_DECL(offset[0],offset[1],offset[2])}};
     int coord = (int) c_sys;
     AMREX_LAUNCH_HOST_DEVICE_LAMBDA ( region, tbx,
     {

--- a/Src/Base/AMReX_Geometry.H
+++ b/Src/Base/AMReX_Geometry.H
@@ -120,11 +120,11 @@ public:
     Real ProbHi (int dir) const noexcept { return prob_domain.hi(dir); }
 
     GpuArray<Real,AMREX_SPACEDIM> ProbLoArray () const noexcept {
-        return {AMREX_D_DECL(prob_domain.lo(0),prob_domain.lo(1),prob_domain.lo(2))};
+        return {{AMREX_D_DECL(prob_domain.lo(0),prob_domain.lo(1),prob_domain.lo(2))}};
     }
 
     GpuArray<Real,AMREX_SPACEDIM> ProbHiArray () const noexcept {
-        return {AMREX_D_DECL(prob_domain.hi(0),prob_domain.hi(1),prob_domain.hi(2))};
+        return {{AMREX_D_DECL(prob_domain.hi(0),prob_domain.hi(1),prob_domain.hi(2))}};
     }
 
     //! Returns the overall size of the domain by multiplying the ProbLength's together
@@ -190,16 +190,16 @@ public:
         return AMREX_D_TERM(isPeriodic(0),&&isPeriodic(1),&&isPeriodic(2));
     }
     Array<int,AMREX_SPACEDIM> isPeriodic () const noexcept {
-        return {AMREX_D_DECL(static_cast<int>(is_periodic[0]),
-                             static_cast<int>(is_periodic[1]),
-                             static_cast<int>(is_periodic[2]))};
+        return {{AMREX_D_DECL(static_cast<int>(is_periodic[0]),
+                              static_cast<int>(is_periodic[1]),
+                              static_cast<int>(is_periodic[2]))}};
     }
     GpuArray<int,AMREX_SPACEDIM> isPeriodicArray () const noexcept {
 // HIP FIX HERE - Initialization List
 #ifdef AMREX_USE_HIP
         GpuArray<int, AMREX_SPACEDIM> arr;
         for (int i=0; i<AMREX_SPACEDIM; ++i)
-            { arr[i] = static_cast<int>(is_periodic[i]); }
+        { arr[i] = static_cast<int>(is_periodic[i]); }
         return arr;
 /*
         return {(int[AMREX_SPACEDIM]){AMREX_D_DECL(static_cast<int>(is_periodic[0]),
@@ -207,9 +207,9 @@ public:
                                                    static_cast<int>(is_periodic[2]))}};
 */
 #else
-        return {AMREX_D_DECL(static_cast<int>(is_periodic[0]),
-                             static_cast<int>(is_periodic[1]),
-                             static_cast<int>(is_periodic[2]))};
+        return {{AMREX_D_DECL(static_cast<int>(is_periodic[0]),
+                              static_cast<int>(is_periodic[1]),
+                              static_cast<int>(is_periodic[2]))}};
 #endif
     }
     //! What's period in specified direction?
@@ -250,9 +250,9 @@ public:
     //!
     Array<int,AMREX_SPACEDIM>
     setPeriodicity (Array<int,AMREX_SPACEDIM> const& period) noexcept {
-        Array<int,AMREX_SPACEDIM> r{AMREX_D_DECL(is_periodic[0],
-                                                 is_periodic[1],
-                                                 is_periodic[2])};
+        Array<int,AMREX_SPACEDIM> r{{AMREX_D_DECL(is_periodic[0],
+                                                  is_periodic[1],
+                                                  is_periodic[2])}};
         AMREX_D_TERM(is_periodic[0] = period[0];,
                      is_periodic[1] = period[1];,
                      is_periodic[2] = period[2];);

--- a/Src/Base/AMReX_Geometry.cpp
+++ b/Src/Base/AMReX_Geometry.cpp
@@ -37,7 +37,7 @@ operator>> (std::istream& is,
         is >> c;
         IntVect is_per;
         is >> is_per;
-        g.setPeriodicity({AMREX_D_DECL(is_per[0],is_per[1],is_per[2])});
+        g.setPeriodicity({{AMREX_D_DECL(is_per[0],is_per[1],is_per[2])}});
     } else {
         g.setPeriodicity(DefaultGeometry().isPeriodic());
     }

--- a/Src/Base/AMReX_Machine.cpp
+++ b/Src/Base/AMReX_Machine.cpp
@@ -80,7 +80,7 @@ Coord df_id_to_coord (int id)
     int slot = id % 16; id /= 16;
     int chas = id % 6;  id /= 6;
     int group = id;
-    return Coord {node, slot, chas, group};
+    return Coord {{node, slot, chas, group}};
 }
 
 template <class T, size_t N>

--- a/Src/Base/AMReX_MultiFabUtil.cpp
+++ b/Src/Base/AMReX_MultiFabUtil.cpp
@@ -102,7 +102,7 @@ namespace amrex
         const Vector<const MultiFab*>& fc, int ngrow)
     {
         average_face_to_cellcenter(cc, dcomp,
-            Array<MultiFab const*,AMREX_SPACEDIM>{AMREX_D_DECL(fc[0],fc[1],fc[2])},
+            Array<MultiFab const*,AMREX_SPACEDIM>{{AMREX_D_DECL(fc[0],fc[1],fc[2])}},
             ngrow);
     }
 
@@ -111,7 +111,7 @@ namespace amrex
     {
         average_face_to_cellcenter(cc,
                                    Array<MultiFab const*,AMREX_SPACEDIM>
-                                                  {AMREX_D_DECL(fc[0],fc[1],fc[2])},
+                                   {{AMREX_D_DECL(fc[0],fc[1],fc[2])}},
                                    geom);
     }
 
@@ -184,7 +184,7 @@ namespace amrex
     void average_cellcenter_to_face (const Vector<MultiFab*>& fc, const MultiFab& cc,
 				     const Geometry& geom)
     {
-        average_cellcenter_to_face(Array<MultiFab*,AMREX_SPACEDIM>{AMREX_D_DECL(fc[0],fc[1],fc[2])},
+        average_cellcenter_to_face(Array<MultiFab*,AMREX_SPACEDIM>{{AMREX_D_DECL(fc[0],fc[1],fc[2])}},
                                    cc, geom);
     }
 
@@ -429,9 +429,9 @@ namespace amrex
                              const IntVect& ratio, int ngcrse)
     {
         average_down_faces(Array<const MultiFab*,AMREX_SPACEDIM>
-                                   {AMREX_D_DECL(fine[0],fine[1],fine[2])},
+                                   {{AMREX_D_DECL(fine[0],fine[1],fine[2])}},
                            Array<MultiFab*,AMREX_SPACEDIM>
-                                   {AMREX_D_DECL(crse[0],crse[1],crse[2])},
+                                   {{AMREX_D_DECL(crse[0],crse[1],crse[2])}},
                            ratio, ngcrse);
     }
 

--- a/Src/Base/AMReX_ParallelReduce.H
+++ b/Src/Base/AMReX_ParallelReduce.H
@@ -22,13 +22,13 @@ namespace detail {
 #ifdef BL_USE_MPI
 
     // NOTE: the order of these needs to match the order in the ReduceOp enum above
-    const std::array<MPI_Op, 5> mpi_ops = {
+    const std::array<MPI_Op, 5> mpi_ops = {{
         MPI_MAX,
         MPI_MIN,
         MPI_SUM,
         MPI_LOR,
         MPI_LAND
-    };
+    }};
 
     template<typename T>
     inline void Reduce (ReduceOp op, T* v, int cnt, int root, MPI_Comm comm)

--- a/Src/Base/AMReX_PhysBCFunct.H
+++ b/Src/Base/AMReX_PhysBCFunct.H
@@ -402,12 +402,12 @@ GpuBndryFuncFab<F>::ccdoit (Box const& bx, FArrayBox& dest,
     // filcc on the faces first
     {
         Array<Box,2*AMREX_SPACEDIM> dom_face_boxes
-            = { AMREX_D_DECL(amrex::adjCellLo(gdomain, 0, len[0]),
-                             amrex::adjCellLo(gdomain, 1, len[1]),
-                             amrex::adjCellLo(gdomain, 2, len[2])),
-                AMREX_D_DECL(amrex::adjCellHi(gdomain, 0, len[0]),
-                             amrex::adjCellHi(gdomain, 1, len[1]),
-                             amrex::adjCellHi(gdomain, 2, len[2])) };
+            = {{ AMREX_D_DECL(amrex::adjCellLo(gdomain, 0, len[0]),
+                              amrex::adjCellLo(gdomain, 1, len[1]),
+                              amrex::adjCellLo(gdomain, 2, len[2])),
+                 AMREX_D_DECL(amrex::adjCellHi(gdomain, 0, len[0]),
+                              amrex::adjCellHi(gdomain, 1, len[1]),
+                              amrex::adjCellHi(gdomain, 2, len[2])) }};
 
         for (const Box& b : dom_face_boxes) {
             Box tmp = b & bx;
@@ -428,26 +428,26 @@ GpuBndryFuncFab<F>::ccdoit (Box const& bx, FArrayBox& dest,
     {
 #if (AMREX_SPACEDIM == 2)
         Array<Box,4> dom_edge_boxes
-            = { amrex::adjCellLo(amrex::adjCellLo(gdomain,0,len[0]),1,len[1]),
-                amrex::adjCellLo(amrex::adjCellHi(gdomain,0,len[0]),1,len[1]),
-                amrex::adjCellHi(amrex::adjCellLo(gdomain,0,len[0]),1,len[1]),
-                amrex::adjCellHi(amrex::adjCellHi(gdomain,0,len[0]),1,len[1]) };
+            = {{ amrex::adjCellLo(amrex::adjCellLo(gdomain,0,len[0]),1,len[1]),
+                 amrex::adjCellLo(amrex::adjCellHi(gdomain,0,len[0]),1,len[1]),
+                 amrex::adjCellHi(amrex::adjCellLo(gdomain,0,len[0]),1,len[1]),
+                 amrex::adjCellHi(amrex::adjCellHi(gdomain,0,len[0]),1,len[1]) }};
 #else
         Array<Box,12> dom_edge_boxes
-            = { amrex::adjCellLo(amrex::adjCellLo(gdomain,0,len[0]),1,len[1]),
-                amrex::adjCellLo(amrex::adjCellHi(gdomain,0,len[0]),1,len[1]),
-                amrex::adjCellHi(amrex::adjCellLo(gdomain,0,len[0]),1,len[1]),
-                amrex::adjCellHi(amrex::adjCellHi(gdomain,0,len[0]),1,len[1]),
-                //
-                amrex::adjCellLo(amrex::adjCellLo(gdomain,0,len[0]),2,len[2]),
-                amrex::adjCellLo(amrex::adjCellHi(gdomain,0,len[0]),2,len[2]),
-                amrex::adjCellHi(amrex::adjCellLo(gdomain,0,len[0]),2,len[2]),
-                amrex::adjCellHi(amrex::adjCellHi(gdomain,0,len[0]),2,len[2]),
-                //
-                amrex::adjCellLo(amrex::adjCellLo(gdomain,1,len[1]),2,len[2]),
-                amrex::adjCellLo(amrex::adjCellHi(gdomain,1,len[1]),2,len[2]),
-                amrex::adjCellHi(amrex::adjCellLo(gdomain,1,len[1]),2,len[2]),
-                amrex::adjCellHi(amrex::adjCellHi(gdomain,1,len[1]),2,len[2]) };
+            = {{ amrex::adjCellLo(amrex::adjCellLo(gdomain,0,len[0]),1,len[1]),
+                 amrex::adjCellLo(amrex::adjCellHi(gdomain,0,len[0]),1,len[1]),
+                 amrex::adjCellHi(amrex::adjCellLo(gdomain,0,len[0]),1,len[1]),
+                 amrex::adjCellHi(amrex::adjCellHi(gdomain,0,len[0]),1,len[1]),
+                 //
+                 amrex::adjCellLo(amrex::adjCellLo(gdomain,0,len[0]),2,len[2]),
+                 amrex::adjCellLo(amrex::adjCellHi(gdomain,0,len[0]),2,len[2]),
+                 amrex::adjCellHi(amrex::adjCellLo(gdomain,0,len[0]),2,len[2]),
+                 amrex::adjCellHi(amrex::adjCellHi(gdomain,0,len[0]),2,len[2]),
+                 //
+                 amrex::adjCellLo(amrex::adjCellLo(gdomain,1,len[1]),2,len[2]),
+                 amrex::adjCellLo(amrex::adjCellHi(gdomain,1,len[1]),2,len[2]),
+                 amrex::adjCellHi(amrex::adjCellLo(gdomain,1,len[1]),2,len[2]),
+                 amrex::adjCellHi(amrex::adjCellHi(gdomain,1,len[1]),2,len[2]) }};
 #endif
 
         for (const Box& b : dom_edge_boxes) {
@@ -469,14 +469,14 @@ GpuBndryFuncFab<F>::ccdoit (Box const& bx, FArrayBox& dest,
     // filcc on corners
     {
         Array<Box,8> dom_corner_boxes
-            = { amrex::adjCellLo(amrex::adjCellLo(amrex::adjCellLo(gdomain,0,len[0]),1,len[1]),2,len[2]),
-                amrex::adjCellLo(amrex::adjCellLo(amrex::adjCellHi(gdomain,0,len[0]),1,len[1]),2,len[2]),
-                amrex::adjCellLo(amrex::adjCellHi(amrex::adjCellLo(gdomain,0,len[0]),1,len[1]),2,len[2]),
-                amrex::adjCellLo(amrex::adjCellHi(amrex::adjCellHi(gdomain,0,len[0]),1,len[1]),2,len[2]),
-                amrex::adjCellHi(amrex::adjCellLo(amrex::adjCellLo(gdomain,0,len[0]),1,len[1]),2,len[2]),
-                amrex::adjCellHi(amrex::adjCellLo(amrex::adjCellHi(gdomain,0,len[0]),1,len[1]),2,len[2]),
-                amrex::adjCellHi(amrex::adjCellHi(amrex::adjCellLo(gdomain,0,len[0]),1,len[1]),2,len[2]),
-                amrex::adjCellHi(amrex::adjCellHi(amrex::adjCellHi(gdomain,0,len[0]),1,len[1]),2,len[2]) };
+            = {{ amrex::adjCellLo(amrex::adjCellLo(amrex::adjCellLo(gdomain,0,len[0]),1,len[1]),2,len[2]),
+                 amrex::adjCellLo(amrex::adjCellLo(amrex::adjCellHi(gdomain,0,len[0]),1,len[1]),2,len[2]),
+                 amrex::adjCellLo(amrex::adjCellHi(amrex::adjCellLo(gdomain,0,len[0]),1,len[1]),2,len[2]),
+                 amrex::adjCellLo(amrex::adjCellHi(amrex::adjCellHi(gdomain,0,len[0]),1,len[1]),2,len[2]),
+                 amrex::adjCellHi(amrex::adjCellLo(amrex::adjCellLo(gdomain,0,len[0]),1,len[1]),2,len[2]),
+                 amrex::adjCellHi(amrex::adjCellLo(amrex::adjCellHi(gdomain,0,len[0]),1,len[1]),2,len[2]),
+                 amrex::adjCellHi(amrex::adjCellHi(amrex::adjCellLo(gdomain,0,len[0]),1,len[1]),2,len[2]),
+                 amrex::adjCellHi(amrex::adjCellHi(amrex::adjCellHi(gdomain,0,len[0]),1,len[1]),2,len[2]) }};
 
         for (const Box& b : dom_corner_boxes) {
             Box tmp = b & bx;

--- a/Src/Base/AMReX_PlotFileDataImpl.cpp
+++ b/Src/Base/AMReX_PlotFileDataImpl.cpp
@@ -57,7 +57,7 @@ PlotFileDataImpl::PlotFileDataImpl (std::string const& plotfile_name)
         is >> m_level_steps[i];
     }
 
-    m_cell_size.resize(m_nlevels, Array<Real,AMREX_SPACEDIM>{AMREX_D_DECL(1.,1.,1.)});
+    m_cell_size.resize(m_nlevels, Array<Real,AMREX_SPACEDIM>{{AMREX_D_DECL(1.,1.,1.)}});
     for (int ilev = 0; ilev < m_nlevels; ++ilev) {
         for (int idim = 0; idim < m_spacedim; ++idim) {
             is >> m_cell_size[ilev][idim];

--- a/Src/Boundary/AMReX_YAFluxRegister.cpp
+++ b/Src/Boundary/AMReX_YAFluxRegister.cpp
@@ -280,12 +280,12 @@ YAFluxRegister::FineAdd (const MFIter& mfi,
     const int nc = m_cfpatch.nComp();
 
     const Real ratio = static_cast<Real>(AMREX_D_TERM(m_ratio[0],*m_ratio[1],*m_ratio[2]));
-    std::array<Real,AMREX_SPACEDIM> dtdx{AMREX_D_DECL(dt/(dx[0]*ratio),
-                                                      dt/(dx[1]*ratio),
-                                                      dt/(dx[2]*ratio))};
+    std::array<Real,AMREX_SPACEDIM> dtdx{{AMREX_D_DECL(dt/(dx[0]*ratio),
+                                                       dt/(dx[1]*ratio),
+                                                       dt/(dx[2]*ratio))}};
     const Dim3 rr = m_ratio.dim3();
 
-    std::array<FArrayBox const*,AMREX_SPACEDIM> flux{AMREX_D_DECL(a_flux[0],a_flux[1],a_flux[2])};
+    std::array<FArrayBox const*,AMREX_SPACEDIM> flux{{AMREX_D_DECL(a_flux[0],a_flux[1],a_flux[2])}};
     bool use_gpu = (runon == RunOn::Gpu) && Gpu::inLaunchRegion();
     amrex::ignore_unused(use_gpu);
     std::array<FArrayBox,AMREX_SPACEDIM> ftmp;

--- a/Src/F_Interfaces/AmrCore/AMReX_FlashFluxRegister.cpp
+++ b/Src/F_Interfaces/AmrCore/AMReX_FlashFluxRegister.cpp
@@ -34,9 +34,9 @@ void FlashFluxRegister::define (const BoxArray& fba, const BoxArray& cba,
     {
         BoxArray const& fndba = amrex::convert(fba,IntVect::TheNodeVector());
         Array<BoxList,AMREX_SPACEDIM> bl
-            {AMREX_D_DECL(BoxList(IndexType(IntVect::TheDimensionVector(0))),
-                          BoxList(IndexType(IntVect::TheDimensionVector(1))),
-                          BoxList(IndexType(IntVect::TheDimensionVector(2))))};
+        {{AMREX_D_DECL(BoxList(IndexType(IntVect::TheDimensionVector(0))),
+                       BoxList(IndexType(IntVect::TheDimensionVector(1))),
+                       BoxList(IndexType(IntVect::TheDimensionVector(2))))}};
         Array<Vector<int>,AMREX_SPACEDIM> procmap;
         Array<Vector<int>,AMREX_SPACEDIM> my_global_indices;
         std::vector<std::pair<int,Box> > isects;
@@ -83,7 +83,7 @@ void FlashFluxRegister::define (const BoxArray& fba, const BoxArray& cba,
                     if (found != m_fine_map.end()) {
                         found->second[idim] = &(m_fine_fluxes[idim][mfi]);
                     } else {
-                        Array<FArrayBox*,AMREX_SPACEDIM> t{AMREX_D_DECL(nullptr,nullptr,nullptr)};
+                        Array<FArrayBox*,AMREX_SPACEDIM> t{{AMREX_D_DECL(nullptr,nullptr,nullptr)}};
                         t[idim] = &(m_fine_fluxes[idim][mfi]);
                         m_fine_map.insert(std::make_pair(gi,t));
                     }
@@ -96,9 +96,9 @@ void FlashFluxRegister::define (const BoxArray& fba, const BoxArray& cba,
     {
         BoxArray const fba_coarsened = amrex::coarsen(fba,ref_ratio);
         Array<BoxList,AMREX_SPACEDIM> bl
-            {AMREX_D_DECL(BoxList(IndexType(IntVect::TheDimensionVector(0))),
-                          BoxList(IndexType(IntVect::TheDimensionVector(1))),
-                          BoxList(IndexType(IntVect::TheDimensionVector(2))))};
+        {{AMREX_D_DECL(BoxList(IndexType(IntVect::TheDimensionVector(0))),
+                       BoxList(IndexType(IntVect::TheDimensionVector(1))),
+                       BoxList(IndexType(IntVect::TheDimensionVector(2))))}};
         Array<Vector<int>,AMREX_SPACEDIM> procmap;
         Array<Vector<int>,AMREX_SPACEDIM> my_global_indices;
         std::vector<std::pair<int,Box> > isects;
@@ -158,8 +158,8 @@ void FlashFluxRegister::define (const BoxArray& fba, const BoxArray& cba,
                     if (found != m_crse_map.end()) {
                         found->second[index] = &(m_crse_fluxes[idim][mfi]);
                     } else {
-                        Array<FArrayBox*,2*AMREX_SPACEDIM> t{AMREX_D_DECL(nullptr,nullptr,nullptr),
-                                                             AMREX_D_DECL(nullptr,nullptr,nullptr)};
+                        Array<FArrayBox*,2*AMREX_SPACEDIM> t{{AMREX_D_DECL(nullptr,nullptr,nullptr),
+                                    AMREX_D_DECL(nullptr,nullptr,nullptr)}};
                         t[index] = &(m_crse_fluxes[idim][mfi]);
                         m_crse_map.insert(std::make_pair(gi,t));
                     }

--- a/Src/F_Interfaces/AmrCore/AMReX_fluxregister_fi.cpp
+++ b/Src/F_Interfaces/AmrCore/AMReX_fluxregister_fi.cpp
@@ -72,7 +72,7 @@ extern "C"
                                           Real scale, const Geometry* crse_geom)
     {
         const int ncomp = flux_reg->nComp();
-        flux_reg->OverwriteFlux({AMREX_D_DECL(crse_flxs[0], crse_flxs[1], crse_flxs[2])},
+        flux_reg->OverwriteFlux({{AMREX_D_DECL(crse_flxs[0], crse_flxs[1], crse_flxs[2])}},
                                 scale, 0, 0, ncomp, *crse_geom);
     }
 }

--- a/Src/F_Interfaces/LinearSolvers/AMReX_abeclaplacian_fi.cpp
+++ b/Src/F_Interfaces/LinearSolvers/AMReX_abeclaplacian_fi.cpp
@@ -43,7 +43,7 @@ extern "C" {
     void amrex_fi_abeclap_set_bcoeffs (MLLinOp* linop, int amrlev, const MultiFab* beta[])
     {
         MLABecLaplacian& abeclap = dynamic_cast<MLABecLaplacian&>(*linop);
-        std::array<MultiFab const*, AMREX_SPACEDIM> b{AMREX_D_DECL(beta[0],beta[1],beta[2])};
+        std::array<MultiFab const*, AMREX_SPACEDIM> b{{AMREX_D_DECL(beta[0],beta[1],beta[2])}};
         abeclap.setBCoeffs(amrlev, b);
     }
 }

--- a/Src/F_Interfaces/LinearSolvers/AMReX_linop_fi.cpp
+++ b/Src/F_Interfaces/LinearSolvers/AMReX_linop_fi.cpp
@@ -18,13 +18,13 @@ extern "C" {
     void amrex_fi_linop_set_domain_bc (MLLinOp* linop, const int* ilobc, const int* ihibc)
     {
         std::array<LinOpBCType,AMREX_SPACEDIM> lobc
-             {AMREX_D_DECL(static_cast<LinOpBCType>(ilobc[0]),
-                           static_cast<LinOpBCType>(ilobc[1]),
-                           static_cast<LinOpBCType>(ilobc[2]))};
+        {{AMREX_D_DECL(static_cast<LinOpBCType>(ilobc[0]),
+                       static_cast<LinOpBCType>(ilobc[1]),
+                       static_cast<LinOpBCType>(ilobc[2]))}};
         std::array<LinOpBCType,AMREX_SPACEDIM> hibc
-             {AMREX_D_DECL(static_cast<LinOpBCType>(ihibc[0]),
-                           static_cast<LinOpBCType>(ihibc[1]),
-                           static_cast<LinOpBCType>(ihibc[2]))};
+        {{AMREX_D_DECL(static_cast<LinOpBCType>(ihibc[0]),
+                       static_cast<LinOpBCType>(ihibc[1]),
+                       static_cast<LinOpBCType>(ihibc[2]))}};
         linop->setDomainBC(lobc,hibc);
     }
 

--- a/Src/LinearSolvers/MLMG/AMReX_MLABecLaplacian.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLABecLaplacian.cpp
@@ -663,9 +663,9 @@ MLABecLaplacian::FFlux (int amrlev, const MFIter& mfi,
     const Real* dxinv = m_geom[amrlev][mglev].InvCellSize();
     const int ncomp = getNComp();
     FFlux(box, dxinv, m_b_scalar,
-          Array<FArrayBox const*,AMREX_SPACEDIM>{AMREX_D_DECL(&(m_b_coeffs[amrlev][mglev][0][mfi]),
-                                                              &(m_b_coeffs[amrlev][mglev][1][mfi]),
-                                                              &(m_b_coeffs[amrlev][mglev][2][mfi]))},
+          Array<FArrayBox const*,AMREX_SPACEDIM>{{AMREX_D_DECL(&(m_b_coeffs[amrlev][mglev][0][mfi]),
+                                                               &(m_b_coeffs[amrlev][mglev][1][mfi]),
+                                                               &(m_b_coeffs[amrlev][mglev][2][mfi]))}},
           flux, sol, face_only, ncomp);
 }
 

--- a/Src/LinearSolvers/MLMG/AMReX_MLALaplacian.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLALaplacian.H
@@ -51,7 +51,7 @@ public:
     virtual MultiFab const* getACoeffs (int amrlev, int mglev) const final override
         { return &(m_a_coeffs[amrlev][mglev]); }
     virtual Array<MultiFab const*,AMREX_SPACEDIM> getBCoeffs (int /*amrlev*/, int /*mglev*/) const final override
-        { return { AMREX_D_DECL(nullptr,nullptr,nullptr)}; }
+        { return {{ AMREX_D_DECL(nullptr,nullptr,nullptr)}}; }
 
     virtual std::unique_ptr<MLLinOp> makeNLinOp (int /*grid_size*/) const final override {
         amrex::Abort("MLALaplacian::makeNLinOp: Not implmented");

--- a/Src/LinearSolvers/MLMG/AMReX_MLCellLinOp.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLCellLinOp.cpp
@@ -138,9 +138,9 @@ MLCellLinOp::defineBC ()
                                             m_amr_ref_ratio[amrlev-1], BCRec());
 
         Vector<Array<LinOpBCType,AMREX_SPACEDIM> > bclohi
-            (ncomp,Array<LinOpBCType,AMREX_SPACEDIM>{AMREX_D_DECL(BCType::Dirichlet,
-                                                                  BCType::Dirichlet,
-                                                                  BCType::Dirichlet)});
+            (ncomp,Array<LinOpBCType,AMREX_SPACEDIM>{{AMREX_D_DECL(BCType::Dirichlet,
+                                                                   BCType::Dirichlet,
+                                                                   BCType::Dirichlet)}});
         m_bndry_cor[amrlev]->setLOBndryConds(bclohi, bclohi, m_amr_ref_ratio[amrlev-1], RealVect{});
     }
 
@@ -605,8 +605,8 @@ MLCellLinOp::reflux (int crse_amrlev,
 #endif
     {
         Array<FArrayBox,AMREX_SPACEDIM> flux;
-        Array<FArrayBox*,AMREX_SPACEDIM> pflux { AMREX_D_DECL(&flux[0], &flux[1], &flux[2]) };
-        Array<FArrayBox const*,AMREX_SPACEDIM> cpflux { AMREX_D_DECL(&flux[0], &flux[1], &flux[2]) };
+        Array<FArrayBox*,AMREX_SPACEDIM> pflux {{ AMREX_D_DECL(&flux[0], &flux[1], &flux[2]) }};
+        Array<FArrayBox const*,AMREX_SPACEDIM> cpflux {{ AMREX_D_DECL(&flux[0], &flux[1], &flux[2]) }};
 
         for (MFIter mfi(crse_sol, mfi_info);  mfi.isValid(); ++mfi)
         {
@@ -668,7 +668,7 @@ MLCellLinOp::compFlux (int amrlev, const Array<MultiFab*,AMREX_SPACEDIM>& fluxes
 #endif
     {
         Array<FArrayBox,AMREX_SPACEDIM> flux;
-        Array<FArrayBox*,AMREX_SPACEDIM> pflux { AMREX_D_DECL(&flux[0], &flux[1], &flux[2]) };
+        Array<FArrayBox*,AMREX_SPACEDIM> pflux {{ AMREX_D_DECL(&flux[0], &flux[1], &flux[2]) }};
         for (MFIter mfi(sol, mfi_info);  mfi.isValid(); ++mfi)
         {
             const Box& tbx = mfi.tilebox();

--- a/Src/LinearSolvers/MLMG/AMReX_MLLinOp.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLLinOp.H
@@ -339,14 +339,14 @@ protected:
     }
 
     GpuArray<BCType,AMREX_SPACEDIM> LoBC (int icomp = 0) const noexcept {
-        return GpuArray<BCType,AMREX_SPACEDIM>{AMREX_D_DECL(m_lobc[icomp][0],
-                                                            m_lobc[icomp][1],
-                                                            m_lobc[icomp][2])};
+        return GpuArray<BCType,AMREX_SPACEDIM>{{AMREX_D_DECL(m_lobc[icomp][0],
+                                                             m_lobc[icomp][1],
+                                                             m_lobc[icomp][2])}};
     }
     GpuArray<BCType,AMREX_SPACEDIM> HiBC (int icomp = 0) const noexcept {
-        return GpuArray<BCType,AMREX_SPACEDIM>{AMREX_D_DECL(m_hibc[icomp][0],
-                                                            m_hibc[icomp][1],
-                                                            m_hibc[icomp][2])};
+        return GpuArray<BCType,AMREX_SPACEDIM>{{AMREX_D_DECL(m_hibc[icomp][0],
+                                                             m_hibc[icomp][1],
+                                                             m_hibc[icomp][2])}};
     }
 
 #ifdef BL_USE_MPI

--- a/Src/LinearSolvers/MLMG/AMReX_MLLinOp_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLLinOp_K.H
@@ -46,7 +46,7 @@ void mllinop_apply_bc_x (int side, Box const& box, int blen,
     case AMREX_LO_DIRICHLET:
     {
         const int NX = amrex::min(blen+1, maxorder);
-        GpuArray<Real,4> x{-bcl * dxinv, 0.5_rt, 1.5_rt, 2.5_rt};
+        GpuArray<Real,4> x{{-bcl * dxinv, 0.5_rt, 1.5_rt, 2.5_rt}};
         GpuArray<Real,4> coef{};
         poly_interp_coeff(-0.5_rt, &x[0], NX, &coef[0]);
         for     (int k = lo.z; k <= hi.z; ++k) {
@@ -107,7 +107,7 @@ void mllinop_apply_bc_y (int side, Box const& box, int blen,
     case AMREX_LO_DIRICHLET:
     {
         const int NX = amrex::min(blen+1, maxorder);
-        GpuArray<Real,4> x{-bcl * dyinv, 0.5_rt, 1.5_rt, 2.5_rt};
+        GpuArray<Real,4> x{{-bcl * dyinv, 0.5_rt, 1.5_rt, 2.5_rt}};
         GpuArray<Real,4> coef{};
         poly_interp_coeff(-0.5_rt, &x[0], NX, &coef[0]);
         for     (int k = lo.z; k <= hi.z; ++k) {
@@ -168,7 +168,7 @@ void mllinop_apply_bc_z (int side, Box const& box, int blen,
     case AMREX_LO_DIRICHLET:
     {
         const int NX = amrex::min(blen+1, maxorder);
-        GpuArray<Real,4> x{-bcl * dzinv, 0.5_rt, 1.5_rt, 2.5_rt};
+        GpuArray<Real,4> x{{-bcl * dzinv, 0.5_rt, 1.5_rt, 2.5_rt}};
         GpuArray<Real,4> coef{};
         poly_interp_coeff(-0.5_rt, &x[0], NX, &coef[0]);
         for     (int j = lo.y; j <= hi.y; ++j) {
@@ -224,7 +224,7 @@ void mllinop_comp_interp_coef0_x (int side, Box const& box, int blen,
     case AMREX_LO_DIRICHLET:
     {
         const int NX = amrex::min(blen+1, maxorder);
-        GpuArray<Real,4> x{-bcl * dxinv, 0.5_rt, 1.5_rt, 2.5_rt};
+        GpuArray<Real,4> x{{-bcl * dxinv, 0.5_rt, 1.5_rt, 2.5_rt}};
         GpuArray<Real,4> coef{};
         poly_interp_coeff(-0.5_rt, &x[0], NX, &coef[0]);
         for     (int k = lo.z; k <= hi.z; ++k) {
@@ -271,7 +271,7 @@ void mllinop_comp_interp_coef0_y (int side, Box const& box, int blen,
     case AMREX_LO_DIRICHLET:
     {
         const int NX = amrex::min(blen+1, maxorder);
-        GpuArray<Real,4> x{-bcl * dyinv, 0.5_rt, 1.5_rt, 2.5_rt};
+        GpuArray<Real,4> x{{-bcl * dyinv, 0.5_rt, 1.5_rt, 2.5_rt}};
         GpuArray<Real,4> coef{};
         poly_interp_coeff(-0.5_rt, &x[0], NX, &coef[0]);
         for     (int k = lo.z; k <= hi.z; ++k) {
@@ -318,7 +318,7 @@ void mllinop_comp_interp_coef0_z (int side, Box const& box, int blen,
     case AMREX_LO_DIRICHLET:
     {
         const int NX = amrex::min(blen+1, maxorder);
-        GpuArray<Real,4> x{-bcl * dzinv, 0.5_rt, 1.5_rt, 2.5_rt};
+        GpuArray<Real,4> x{{-bcl * dzinv, 0.5_rt, 1.5_rt, 2.5_rt}};
         GpuArray<Real,4> coef{};
         poly_interp_coeff(-0.5_rt, &x[0], NX, &coef[0]);
         for     (int j = lo.y; j <= hi.y; ++j) {

--- a/Src/LinearSolvers/MLMG/AMReX_MLMGBndry.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLMGBndry.cpp
@@ -35,7 +35,7 @@ MLMGBndry::setLOBndryConds (const Vector<Array<LinOpBCType,AMREX_SPACEDIM> >& lo
         for (int icomp = 0; icomp < nComp(); ++icomp) {
             BCTuple bct;
             setBoxBC(bloc, bct, grd, domain, lo[icomp], hi[icomp], dx, ratio,
-                     a_loc, {AMREX_D_DECL(0.,0.,0.)}, {AMREX_D_DECL(0.,0.,0.)},
+                     a_loc, {{AMREX_D_DECL(0.,0.,0.)}}, {{AMREX_D_DECL(0.,0.,0.)}},
                      is_periodic);
             for (int idim = 0; idim < 2*AMREX_SPACEDIM; ++idim) {
                 bctag[idim][icomp] = bct[idim];

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLap_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLap_K.H
@@ -86,12 +86,12 @@ void mlndlap_fillbc_cc (Box const& vbx, Array4<T> const& sigma, Box const& domai
                         GpuArray<LinOpBCType, AMREX_SPACEDIM> bclo,
                         GpuArray<LinOpBCType, AMREX_SPACEDIM> bchi) noexcept
 {
-    GpuArray<bool,AMREX_SPACEDIM> bflo{AMREX_D_DECL(bclo[0] != LinOpBCType::Periodic,
-                                                    bclo[1] != LinOpBCType::Periodic,
-                                                    bclo[2] != LinOpBCType::Periodic)};
-    GpuArray<bool,AMREX_SPACEDIM> bfhi{AMREX_D_DECL(bchi[0] != LinOpBCType::Periodic,
-                                                    bchi[1] != LinOpBCType::Periodic,
-                                                    bchi[2] != LinOpBCType::Periodic)};
+    GpuArray<bool,AMREX_SPACEDIM> bflo{{AMREX_D_DECL(bclo[0] != LinOpBCType::Periodic,
+                                                     bclo[1] != LinOpBCType::Periodic,
+                                                     bclo[2] != LinOpBCType::Periodic)}};
+    GpuArray<bool,AMREX_SPACEDIM> bfhi{{AMREX_D_DECL(bchi[0] != LinOpBCType::Periodic,
+                                                     bchi[1] != LinOpBCType::Periodic,
+                                                     bchi[2] != LinOpBCType::Periodic)}};
     mlndlap_bc_doit(vbx, sigma, domain, bflo, bfhi);
 }
 
@@ -100,18 +100,18 @@ void mlndlap_applybc (Box const& vbx, Array4<T> const& phi, Box const& domain,
                       GpuArray<LinOpBCType, AMREX_SPACEDIM> bclo,
                       GpuArray<LinOpBCType, AMREX_SPACEDIM> bchi) noexcept
 {
-    GpuArray<bool,AMREX_SPACEDIM> bflo{AMREX_D_DECL(bclo[0] == LinOpBCType::Neumann or
-                                                    bclo[0] == LinOpBCType::inflow,
-                                                    bclo[1] == LinOpBCType::Neumann or
-                                                    bclo[1] == LinOpBCType::inflow,
-                                                    bclo[2] == LinOpBCType::Neumann or
-                                                    bclo[2] == LinOpBCType::inflow)};
-    GpuArray<bool,AMREX_SPACEDIM> bfhi{AMREX_D_DECL(bchi[0] == LinOpBCType::Neumann or
-                                                    bchi[0] == LinOpBCType::inflow,
-                                                    bchi[1] == LinOpBCType::Neumann or
-                                                    bchi[1] == LinOpBCType::inflow,
-                                                    bchi[2] == LinOpBCType::Neumann or
-                                                    bchi[2] == LinOpBCType::inflow)};
+    GpuArray<bool,AMREX_SPACEDIM> bflo{{AMREX_D_DECL(bclo[0] == LinOpBCType::Neumann or
+                                                     bclo[0] == LinOpBCType::inflow,
+                                                     bclo[1] == LinOpBCType::Neumann or
+                                                     bclo[1] == LinOpBCType::inflow,
+                                                     bclo[2] == LinOpBCType::Neumann or
+                                                     bclo[2] == LinOpBCType::inflow)}};
+    GpuArray<bool,AMREX_SPACEDIM> bfhi{{AMREX_D_DECL(bchi[0] == LinOpBCType::Neumann or
+                                                     bchi[0] == LinOpBCType::inflow,
+                                                     bchi[1] == LinOpBCType::Neumann or
+                                                     bchi[1] == LinOpBCType::inflow,
+                                                     bchi[2] == LinOpBCType::Neumann or
+                                                     bchi[2] == LinOpBCType::inflow)}};
     mlndlap_bc_doit(vbx, phi, domain, bflo, bfhi);
 }
 

--- a/Src/LinearSolvers/MLMG/AMReX_MLPoisson.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLPoisson.H
@@ -48,7 +48,7 @@ public:
     virtual Real getBScalar () const final override { return -1.0; }
     virtual MultiFab const* getACoeffs (int /*amrlev*/, int /*mglev*/) const final override { return nullptr; }
     virtual Array<MultiFab const*,AMREX_SPACEDIM> getBCoeffs (int /*amrlev*/, int /*mglev*/) const final override
-        { return { AMREX_D_DECL(nullptr,nullptr,nullptr)}; }
+        { return {{ AMREX_D_DECL(nullptr,nullptr,nullptr)}}; }
 
     virtual std::unique_ptr<MLLinOp> makeNLinOp (int grid_size) const final override;
 

--- a/Src/Particle/AMReX_ParticleCommunication.H
+++ b/Src/Particle/AMReX_ParticleCommunication.H
@@ -554,7 +554,7 @@ void unpackRemotes (PC& pc, const ParticleCopyPlan& plan, Buffer& rcv_buffer, co
             auto ptd = tile.getParticleTileData();
 
             AMREX_ASSERT(MyProc ==
-                ParallelContext::global_to_local_rank(pc.ParticleDistributionMap(lev)[gid];));
+                ParallelContext::global_to_local_rank(pc.ParticleDistributionMap(lev)[gid]));
 
             int dst_offset = offsets[uindex];
             int size = sizes[uindex];

--- a/Src/Particle/AMReX_ParticleCommunication.H
+++ b/Src/Particle/AMReX_ParticleCommunication.H
@@ -553,8 +553,8 @@ void unpackRemotes (PC& pc, const ParticleCopyPlan& plan, Buffer& rcv_buffer, co
             auto& tile = pc.DefineAndReturnParticleTile(lev, gid, tid);
             auto ptd = tile.getParticleTileData();
 
-            const int global_who = pc.ParticleDistributionMap(lev)[gid];
-            AMREX_ASSERT(MyProc == ParallelContext::global_to_local_rank(global_who));
+            AMREX_ASSERT(MyProc ==
+                ParallelContext::global_to_local_rank(pc.ParticleDistributionMap(lev)[gid];));
 
             int dst_offset = offsets[uindex];
             int size = sizes[uindex];

--- a/Src/Particle/AMReX_TracerParticles.cpp
+++ b/Src/Particle/AMReX_TracerParticles.cpp
@@ -71,9 +71,9 @@ TracerParticleContainer::AdvectWithUmac (MultiFab* umac, int lev, Real dt)
 
             //array of these pointers to pass to the GPU
             amrex::GpuArray<amrex::Array4<const Real>, AMREX_SPACEDIM>
-            const umacarr {AMREX_D_DECL((*fab[0]).array(),
-                                        (*fab[1]).array(),
-                                        (*fab[2]).array() )};
+                const umacarr {{AMREX_D_DECL((*fab[0]).array(),
+                                             (*fab[1]).array(),
+                                             (*fab[2]).array() )}};
 
             amrex::ParallelFor(n,
                                [=] AMREX_GPU_DEVICE (int i)


### PR DESCRIPTION
Most of these have to do with the "curly braces" warning clang loves to complain about.