### PR TITLE
GNU Make option to turn warnings into errors

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -205,7 +205,7 @@ jobs:
     - name: Build & Install
       run: |
         ./configure --dim 2 --with-fortran no --comp llvm --with-mpi no
-        make -j2 WARN_ALL=TRUE
+        make -j2 WARN_ALL=TRUE WARN_ERROR=TRUE
         make install
 
   # Build 3D libamrex with configure
@@ -219,5 +219,5 @@ jobs:
     - name: Build & Install
       run: |
         ./configure --dim 3 --enable-eb yes --enable-xsdk-defaults yes
-        make -j2 WARN_ALL=TRUE
+        make -j2 WARN_ALL=TRUE WARN_ERROR=TRUE
         make install

--- a/Docs/sphinx_documentation/source/BuildingAMReX.rst
+++ b/Docs/sphinx_documentation/source/BuildingAMReX.rst
@@ -112,7 +112,8 @@ If enabled, the library path at link time will be saved as a
 When disabled, dynamic library paths could be provided via ``export LD_LIBRARY_PATH``
 hints at runtime.
 
-For GCC and Clang, the variable ``WARN_ALL`` controls the compiler's warning options.
+For GCC and Clang, the variable ``WARN_ALL`` controls the compiler's warning options.  There is
+also a make variable ``WARN_ERROR`` (with default of ``FALSE``) to turn warnings into errors.
 
 After defining these make variables, a number of files, ``Make.defs,
 Make.package`` and ``Make.rules``, are included in the GNUmakefile. AMReX-based

--- a/Tools/GNUMake/Make.defs
+++ b/Tools/GNUMake/Make.defs
@@ -304,6 +304,12 @@ else
 endif
 endif
 
+ifdef WARN_ERROR
+  WARN_ERROR := $(strip $(WARN_ERROR))
+else
+  WARN_ERROR := FALSE
+endif
+
 ifdef USE_GPU_PRAGMA
   USE_GPU_PRAGMA := $(strip $(USE_GPU_PRAGMA))
   GPU_PRAGMA_NO_HOST_VERSION ?= FALSE

--- a/Tools/GNUMake/comps/gnu.mak
+++ b/Tools/GNUMake/comps/gnu.mak
@@ -113,6 +113,11 @@ ifeq ($(WARN_ALL),TRUE)
   CFLAGS += $(warning_flags)
 endif
 
+ifeq ($(WARN_ERROR),TRUE)
+  CXXFLAGS += -Werror
+  CFLAGS += -Werror
+endif
+
 ifeq ($(USE_GPROF),TRUE)
   CXXFLAGS += -pg
   CFLAGS += -pg

--- a/Tools/GNUMake/comps/llvm.mak
+++ b/Tools/GNUMake/comps/llvm.mak
@@ -55,6 +55,11 @@ ifeq ($(WARN_ALL),TRUE)
   CFLAGS += $(warning_flags)
 endif
 
+ifeq ($(WARN_ERROR),TRUE)
+  CXXFLAGS += -Werror
+  CFLAGS += -Werror
+endif
+
 ########################################################################
 
 ifdef CXXSTD


### PR DESCRIPTION
Add `WARN_ERROR` (with default of `FALSE`) to the GNU Make system to turn warnings into errors for
GCC and Clang.  Add `WARN_ERROR` to the 2d and 3d CIs using GNU Make.