### PR TITLE
Optimization of regrid

### DIFF
--- a/Src/AmrCore/AMReX_AmrMesh.cpp
+++ b/Src/AmrCore/AMReX_AmrMesh.cpp
@@ -727,7 +727,6 @@ AmrMesh::MakeNewGrids (int lbase, Real time, int& new_finest, Vector<BoxArray>& 
                     clist.boxList(new_bx);
                     new_bx.refine(bf_lev[levc]);
                     new_bx.simplify();
-                    BL_ASSERT(new_bx.isDisjoint());
 
                     if (new_bx.size()>0) {
                         // Chop new grids outside domain

--- a/Src/Base/AMReX_BoxArray.H
+++ b/Src/Base/AMReX_BoxArray.H
@@ -516,6 +516,7 @@ using BndryBATransformer = BATransformer;
 */
 
 class MFIter;
+class AmrMesh;
 
 class BoxArray
 {
@@ -551,6 +552,8 @@ public:
     explicit BoxArray (BoxList&& bl) noexcept;
 
     BoxArray (const BoxArray& rhs, const BATransformer& trans);
+
+    BoxArray (BoxList&& bl, IntVect const& max_grid_size);
     
     /**
     * \brief Initialize the BoxArray from a single box.
@@ -796,9 +799,14 @@ public:
     //! Make ourselves unique.
     void uniqify ();
 
+    friend class AmrMesh;
+
 private:
     //!  Update BoxArray index type according the box type, and then convert boxes to cell-centered.
     void type_update ();
+
+    BoxList const& simplified_list () const; // For regular AMR grids only
+    BoxArray simplified () const;
 
     BARef::HashType& getHashMap () const;
 
@@ -808,6 +816,7 @@ private:
     BATransformer m_bat;
     //! The data -- a reference-counted pointer to a Ref.
     std::shared_ptr<BARef> m_ref;
+    mutable std::shared_ptr<BoxList> m_simplified_list;
 };
 
 //! Write a BoxArray to an ostream in ASCII format.

--- a/Src/Base/AMReX_BoxArray.H
+++ b/Src/Base/AMReX_BoxArray.H
@@ -517,6 +517,7 @@ using BndryBATransformer = BATransformer;
 
 class MFIter;
 class AmrMesh;
+class FabArrayBase;
 
 class BoxArray
 {
@@ -800,6 +801,7 @@ public:
     void uniqify ();
 
     friend class AmrMesh;
+    friend class FabArrayBase;
 
 private:
     //!  Update BoxArray index type according the box type, and then convert boxes to cell-centered.

--- a/Src/Base/AMReX_BoxArray.cpp
+++ b/Src/Base/AMReX_BoxArray.cpp
@@ -1585,7 +1585,7 @@ BoxArray::simplified_list () const
 BoxArray
 BoxArray::simplified () const
 {
-    return BoxArray(simplified_list());
+    return BoxArray(simplified_list()).convert(ixType());
 }
 
 std::ostream&

--- a/Src/Base/AMReX_BoxList.H
+++ b/Src/Base/AMReX_BoxList.H
@@ -173,6 +173,8 @@ public:
     * is O(N-squared) while the other algorithm is O(N).
     */
     int simplify (bool best = false);
+    //! Assuming the boxes are nicely ordered
+    int ordered_simplify ();
     //! Forces each Box in the BoxList to have sides of length <= chunk.
     BoxList& maxSize (int chunk);
     //! Forces each Box in the BoxList to have dimth side of length <= chunk[dim].
@@ -214,7 +216,7 @@ public:
 
 private:
     //! Core simplify routine.
-    int simplify_doit (bool best);
+    int simplify_doit (int depth);
 
     //! The list of Boxes.
     Vector<Box> m_lbox;

--- a/Src/Base/AMReX_BoxList.cpp
+++ b/Src/Base/AMReX_BoxList.cpp
@@ -275,21 +275,28 @@ BoxList&
 BoxList::intersect (const Box& b)
 {
     BL_ASSERT(ixType() == b.ixType());
-
-    for (Box& bx : m_lbox)
-    {
-        const Box& isect = bx & b;
-        if (isect.ok())
-        {
-            bx = isect;
-        }
-        else
-        {
-            bx = Box();
+    int N0 = m_lbox.size();
+    int N = N0;
+    for (int i = 0; i < N; ) {
+        if (b.contains(m_lbox[i])) {
+            ++i;
+        } else {
+            Box isect = b & m_lbox[i];
+            if (isect.isEmpty()) {
+                --N;
+                if (i < N) {
+                    m_lbox[i] = m_lbox[N];
+                }
+            } else {
+                m_lbox[i] = isect;
+                ++i;
+            }
         }
     }
 
-    removeEmpty();
+    if (N < N0) {
+        m_lbox.resize(N);
+    }
 
     return *this;
 }
@@ -564,11 +571,28 @@ BoxList::simplify (bool best)
     std::sort(m_lbox.begin(), m_lbox.end(), [](const Box& l, const Box& r) {
             return l.smallEnd() < r.smallEnd(); });
 
-    return simplify_doit(best);
+    //
+    // If we're not looking for the "best" we can do in one pass, we
+    // limit how far afield we look for abutting boxes.  This greatly
+    // speeds up this routine for large numbers of boxes.  It does not
+    // do quite as good a job though as full brute force.
+    //
+    int depth = best ? size() : 100;
+    return simplify_doit(depth);
 }
 
 int
-BoxList::simplify_doit (bool best)
+BoxList::ordered_simplify ()
+{
+    int count;
+    for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+        count = simplify_doit(1);
+    }
+    return count;
+}
+
+int
+BoxList::simplify_doit (int depth)
 {
     //
     // Try to merge adjacent boxes.
@@ -579,16 +603,9 @@ BoxList::simplify_doit (bool best)
     {
         const int* alo   = bla->loVect();
         const int* ahi   = bla->hiVect();
-        //
-        // If we're not looking for the "best" we can do in one pass, we
-        // limit how far afield we look for abutting boxes.  This greatly
-        // speeds up this routine for large numbers of boxes.  It does not
-        // do quite as good a job though as full brute force.
-        //
-        const int MaxCnt = (best ? size() : 100);
 
         iterator blb = bla + 1;
-        for (int cnt = 0; blb != End && cnt < MaxCnt; ++cnt, ++blb)
+        for (int cnt = 0; blb != End && cnt < depth; ++cnt, ++blb)
         {
             const int* blo = blb->loVect();
             const int* bhi = blb->hiVect();
@@ -663,55 +680,55 @@ BoxList&
 BoxList::maxSize (const IntVect& chunk)
 {
     Vector<Box> new_boxes;
-
-    for (int i = 0; i < AMREX_SPACEDIM; ++i)
-    {
-        new_boxes.clear();
-        for (auto& bx : m_lbox)
-        {
-            const IntVect& boxlen = bx.size();
-            const int* len = boxlen.getVect();
-
-            if (len[i] > chunk[i])
-            {
-                //
-                // Reduce by powers of 2.
-                //
-                int ratio = 1;
-                int bs    = chunk[i];
-                int nlen  = len[i];
-                while ((bs%2 == 0) && (nlen%2 == 0))
-                {
-                    ratio *= 2;
+    for (auto const& bx : m_lbox) {
+        const IntVect boxlen = amrex::enclosedCells(bx).size();
+        const IntVect boxlo = bx.smallEnd();
+        IntVect ratio{1}, numblk{1}, extra{0};
+        IntVect sz = boxlen;
+        for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+            if (boxlen[idim] > chunk[idim]) {
+                int bs    = chunk[idim];
+                int nlen  = boxlen[idim];
+                while ((bs%2 == 0) && (nlen%2 == 0)) {
+                    ratio[idim] *= 2;
                     bs    /= 2;
                     nlen  /= 2;
                 }
-                //
-                // Determine number and size of (coarsened) cuts.
-                //
-                const int numblk = nlen/bs + (nlen%bs ? 1 : 0);
-                const int sz     = nlen/numblk;
-                const int extra  = nlen%numblk;
-                //
-                // Number of cuts = number of blocks - 1.
-                //
-                for (int k = 0; k < numblk-1; k++)
-                {
-                    //
-                    // Compute size of this chunk, expand by power of 2.
-                    //
-                    const int ksize = (k < extra ? sz+1 : sz) * ratio;
-                    //
-                    // Chop from high end.
-                    //
-                    const int pos = bx.bigEnd(i) - ksize + 1;
-
-                    new_boxes.push_back(bx.chop(i,pos));
-                }
+                numblk[idim] = (nlen+bs-1)/bs;
+                sz[idim] = nlen/numblk[idim];
+                extra[idim] = nlen - sz[idim]*numblk[idim];
             }
         }
-        join(new_boxes);
+        if (numblk == 1) {
+            new_boxes.push_back(bx);
+        } else {
+#if (AMREX_SPACEDIM == 3)
+            for (int k = 0; k < numblk[2]; ++k) {
+                int klo = (k < extra[2]) ? k*(sz[2]+1)*ratio[2] : (k*sz[2]+extra[2])*ratio[2];
+                int khi = (k < extra[2]) ? klo+(sz[2]+1)*ratio[2]-1 : klo+sz[2]*ratio[2]-1;
+                klo += boxlo[2];
+                khi += boxlo[2];
+#endif
+#if (AMREX_SPACEDIM >= 2)
+                for (int j = 0; j < numblk[1]; ++j) {
+                    int jlo = (j < extra[1]) ? j*(sz[1]+1)*ratio[1] : (j*sz[1]+extra[1])*ratio[1];
+                    int jhi = (j < extra[1]) ? jlo+(sz[1]+1)*ratio[1]-1 : jlo+sz[1]*ratio[1]-1;
+                    jlo += boxlo[1];
+                    jhi += boxlo[1];
+#endif
+                    for (int i = 0; i < numblk[0]; ++i) {
+                        int ilo = (i < extra[0]) ? i*(sz[0]+1)*ratio[0] : (i*sz[0]+extra[0])*ratio[0];
+                        int ihi = (i < extra[0]) ? ilo+(sz[0]+1)*ratio[0]-1 : ilo+sz[0]*ratio[0]-1;
+                        ilo += boxlo[0];
+                        ihi += boxlo[0];
+                        new_boxes.push_back(Box(IntVect(AMREX_D_DECL(ilo,jlo,klo)),
+                                                IntVect(AMREX_D_DECL(ihi,jhi,khi))).
+                                            convert(ixType()));
+            AMREX_D_TERM(},},})
+        }
     }
+    std::swap(new_boxes, m_lbox);
+
     return *this;
 }
 

--- a/Src/Base/AMReX_BoxList.cpp
+++ b/Src/Base/AMReX_BoxList.cpp
@@ -98,8 +98,7 @@ BoxList::removeEmpty()
 }
 
 BoxList
-intersect (const BoxList& bl,
-           const Box&     b)
+intersect (const BoxList& bl, const Box& b)
 {
     BL_ASSERT(bl.ixType() == b.ixType());
     BoxList newbl(bl);
@@ -108,8 +107,7 @@ intersect (const BoxList& bl,
 }
 
 BoxList
-refine (const BoxList& bl,
-        int            ratio)
+refine (const BoxList& bl, int ratio)
 {
     BoxList nbl(bl);
     nbl.refine(ratio);
@@ -117,8 +115,7 @@ refine (const BoxList& bl,
 }
 
 BoxList
-coarsen (const BoxList& bl,
-         int            ratio)
+coarsen (const BoxList& bl, int ratio)
 {
     BoxList nbl(bl);
     nbl.coarsen(ratio);
@@ -126,8 +123,7 @@ coarsen (const BoxList& bl,
 }
 
 BoxList
-accrete (const BoxList& bl,
-         int            sz)
+accrete (const BoxList& bl, int sz)
 {
     BoxList nbl(bl);
     nbl.accrete(sz);
@@ -275,28 +271,21 @@ BoxList&
 BoxList::intersect (const Box& b)
 {
     BL_ASSERT(ixType() == b.ixType());
-    int N0 = m_lbox.size();
-    int N = N0;
-    for (int i = 0; i < N; ) {
-        if (b.contains(m_lbox[i])) {
-            ++i;
-        } else {
-            Box isect = b & m_lbox[i];
-            if (isect.isEmpty()) {
-                --N;
-                if (i < N) {
-                    m_lbox[i] = m_lbox[N];
-                }
-            } else {
-                m_lbox[i] = isect;
-                ++i;
-            }
+
+    for (Box& bx : m_lbox)
+    {
+        const Box& isect = bx & b;
+        if (isect.ok())
+        {
+            bx = isect;
+        }
+        else
+        {
+            bx = Box();
         }
     }
 
-    if (N < N0) {
-        m_lbox.resize(N);
-    }
+    removeEmpty();
 
     return *this;
 }
@@ -310,8 +299,7 @@ BoxList::intersect (const BoxList& bl)
 }
 
 BoxList
-complementIn (const Box&     b,
-              const BoxList& bl)
+complementIn (const Box& b, const BoxList& bl)
 {
     BL_ASSERT(bl.ixType() == b.ixType());
     BoxList newb(b.ixType());
@@ -320,16 +308,14 @@ complementIn (const Box&     b,
 }
 
 BoxList&
-BoxList::complementIn (const Box&     b,
-                       const BoxList& bl)
+BoxList::complementIn (const Box& b, const BoxList& bl)
 {
     BoxArray ba(bl);
     return complementIn(b, ba);
 }
 
 BoxList&
-BoxList::complementIn (const Box& b,
-                       BoxList&&  bl)
+BoxList::complementIn (const Box& b, BoxList&&  bl)
 {
     BoxArray ba(std::move(bl));
     return complementIn(b, ba);
@@ -474,8 +460,7 @@ BoxList::accrete (const IntVect& sz)
 }
 
 BoxList&
-BoxList::shift (int dir,
-                int nzones)
+BoxList::shift (int dir, int nzones)
 {
     for (auto& bx : m_lbox)
     {
@@ -485,8 +470,7 @@ BoxList::shift (int dir,
 }
 
 BoxList&
-BoxList::shiftHalf (int dir,
-                    int num_halfs)
+BoxList::shiftHalf (int dir, int num_halfs)
 {
     for (auto& bx : m_lbox)
     {
@@ -510,8 +494,7 @@ BoxList::shiftHalf (const IntVect& iv)
 //
 
 BoxList
-boxDiff (const Box& b1in,
-         const Box& b2)
+boxDiff (const Box& b1in, const Box& b2)
 {
    BL_ASSERT(b1in.sameType(b2));  
    BoxList bl_diff(b1in.ixType());
@@ -790,8 +773,7 @@ BoxList::convert (IndexType typ) noexcept
 }
 
 std::ostream&
-operator<< (std::ostream&  os,
-            const BoxList& blist)
+operator<< (std::ostream& os, const BoxList& blist)
 {
     BoxList::const_iterator bli = blist.begin(), End = blist.end();
     os << "(BoxList " << blist.size() << ' ' << blist.ixType() << '\n';

--- a/Src/Base/AMReX_FabArrayBase.cpp
+++ b/Src/Base/AMReX_FabArrayBase.cpp
@@ -1115,13 +1115,15 @@ FabArrayBase::FPinfo::FPinfo (const FabArrayBase& srcfa,
     BoxList bl(boxtype);
     Vector<int> iprocs;
 
+    BoxArray srcba_simplified = srcba.simplified();
+
     for (int i = 0, N = dstba.size(); i < N; ++i)
     {
         Box bx = dstba[i];
         bx.grow(m_dstng);
         bx &= m_dstdomain;
 
-        BoxList leftover = srcba.complementIn(bx);
+        BoxList leftover = srcba_simplified.complementIn(bx);
 
         bool ismybox = (dstdm[i] == myproc);
         for (BoxList::const_iterator bli = leftover.begin(); bli != leftover.end(); ++bli)


### PR DESCRIPTION
New BoxList::maxSize function that keeps Boxes after chopping in an order that is easy to merge them
back into original Box.

New BoxList::order_simplify function that assumes the BoxList is in the order that we only need to
search the next Box in the list.

Minor optimization of BoxList::intersect.

Cache simplified BoxList inside BoxArray.