### PR TITLE
Fix bug in #1156

### DIFF
--- a/Src/AmrCore/AMReX_AmrMesh.cpp
+++ b/Src/AmrCore/AMReX_AmrMesh.cpp
@@ -764,6 +764,24 @@ AmrMesh::MakeNewGrids (int lbase, Real time, int& new_finest, Vector<BoxArray>& 
         }
     }
 
+#ifdef AMREX_DEBUG
+    if (!useFixedCoarseGrids()) {
+        // check proper nesting
+        for (int lev = lbase+1; lev <= new_finest; ++lev) {
+            BoxArray const& cba = (lev == lbase+1) ? grids[lev-1] : new_grids[lev-1];
+            BoxArray const& fba = amrex::coarsen(new_grids[lev],ref_ratio[lev-1]);
+            IntVect np = bf_lev[lev-1] * n_proper;
+            Box const& cdomain = Geom(lev-1).Domain();
+            for (int i = 0, N = fba.size(); i < N; ++i) {
+                Box const& fb = amrex::grow(fba[i],np) & cdomain;
+                if (!cba.contains(fb,true)) {
+                    amrex::Abort("AmrMesh::MakeNewGrids: new grids not properly nested");
+                }
+            }
+        }
+    }
+#endif
+
     for (int lev = lbase+1; lev <= new_finest; ++lev) {
         if (new_grids[lev].empty())
         {

--- a/Src/AmrCore/AMReX_TagBox.cpp
+++ b/Src/AmrCore/AMReX_TagBox.cpp
@@ -8,6 +8,7 @@
 #include <AMReX_ParallelDescriptor.H>
 #include <AMReX_BLProfiler.H>
 #include <AMReX_ccse-mpi.H>
+#include <AMReX_iMultiFab.H>
 
 namespace amrex {
 
@@ -378,9 +379,23 @@ TagBoxArray::mapPeriodicRemoveDuplicates (const Geometry& geom)
 
     Gpu::LaunchSafeGuard lsg(false); // xxxxx TODO: gpu
 
-    TagBoxArray tmp(boxArray(),DistributionMap(),0); // note that tmp is filled w/ CLEAR.
+    TagBoxArray tmp(boxArray(),DistributionMap(),nGrowVect()); // note that tmp is filled w/ CLEAR.
 
-    tmp.ParallelAdd(*this, 0, 0, 1, nGrowVect(), IntVect{0}, geom.periodicity());
+    tmp.ParallelAdd(*this, 0, 0, 1, nGrowVect(), nGrowVect(), geom.periodicity());
+
+    const auto owner_mask = amrex::OwnerMask(tmp, geom.periodicity(), nGrowVect());
+#ifdef _OPENMP
+#pragma omp parallel if (Gpu::notInLaunchRegion())
+#endif
+    for (MFIter mfi(tmp); mfi.isValid(); ++mfi) {
+        Box const& box = mfi.fabbox();
+        Array4<TagType> const& tag = tmp.array(mfi);
+        Array4<int const> const& msk = owner_mask->const_array(mfi);
+        AMREX_HOST_DEVICE_FOR_3D(box, i, j, k,
+        {
+            if (!msk(i,j,k)) tag(i,j,k) = TagBox::CLEAR;
+        });
+    }
 
     std::swap(*this, tmp);
 }

--- a/Src/Base/AMReX_iMultiFab.H
+++ b/Src/Base/AMReX_iMultiFab.H
@@ -512,8 +512,10 @@ public:
     static void Finalize ();
 };
 
+// ngrow = IntVect{0} is a special case that should not be used in normal cases,
+// because it may mark valid cells as non-owner and ghost cells as owners.
 std::unique_ptr<iMultiFab>
-OwnerMask (FabArrayBase const& mf, const Periodicity& period);
+OwnerMask (FabArrayBase const& mf, const Periodicity& period, const IntVect& ngrow=IntVect{0});
 
 }
 

--- a/Src/Base/AMReX_iMultiFab.cpp
+++ b/Src/Base/AMReX_iMultiFab.cpp
@@ -525,7 +525,7 @@ iMultiFab::negate (const Box& region,
 }
 
 std::unique_ptr<iMultiFab>
-OwnerMask (FabArrayBase const& mf, const Periodicity& period)
+OwnerMask (FabArrayBase const& mf, const Periodicity& period, const IntVect& ngrow)
 {
     BL_PROFILE("OwnerMask()");
 
@@ -535,7 +535,7 @@ OwnerMask (FabArrayBase const& mf, const Periodicity& period)
     const int owner = 1;
     const int nonowner = 0;
 
-    std::unique_ptr<iMultiFab> p{new iMultiFab(ba,dm,1,0, MFInfo(),
+    std::unique_ptr<iMultiFab> p{new iMultiFab(ba,dm,1,ngrow, MFInfo(),
                                                DefaultFabFactory<IArrayBox>())};
     const std::vector<IntVect>& pshifts = period.shiftIntVect();
 
@@ -561,7 +561,7 @@ OwnerMask (FabArrayBase const& mf, const Periodicity& period)
 
             for (const auto& iv : pshifts)
             {
-                ba.intersections(bx+iv, isects);                    
+                ba.intersections(bx+iv, isects, false, ngrow);
                 for (const auto& is : isects)
                 {
                     const int oi = is.first;


### PR DESCRIPTION
In #1156, newly generated grids were not always properly nested because the tags in ghost cells were
discarded.  This is fixed and an assertion is added.