### PR TITLE
CMake: NVCC/cudafe Error Numbers

### DIFF
--- a/Tools/CMake/AMReX_SetupCUDA.cmake
+++ b/Tools/CMake/AMReX_SetupCUDA.cmake
@@ -214,6 +214,12 @@ if (ENABLE_CUDA_FASTMATH)
 endif ()
 
 #
+# Print numbers for warnings and errors
+#
+set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Xcudafe --display_error_number")
+
+
+#
 # CUDA specific warnings
 #
 if (CUDA_WARN_CAPTURE_THIS)


### PR DESCRIPTION
Activate this long-term available, undocumented flag to show error numbers in NVCC.
This is great if one wants to suppress (or report) them and should be standard.

Documentation request opened as Nvidia RFE 3074972.