### PR TITLE
Average down faces

### DIFF
--- a/Src/Base/AMReX_MultiFabUtil.H
+++ b/Src/Base/AMReX_MultiFabUtil.H
@@ -71,6 +71,14 @@ namespace amrex
     void average_down_faces (const MultiFab& fine, MultiFab& crse,
                              const IntVect& ratio, int ngcrse=0);
 
+    //  This version takes periodicity into account.
+    void average_down_faces (const Array<const MultiFab*,AMREX_SPACEDIM>& fine,
+                             const Array<MultiFab*,AMREX_SPACEDIM>& crse,
+                             const IntVect& ratio, const Geometry& crse_geom);
+    //  This version takes periodicity into account.
+    void average_down_faces (const MultiFab& fine, MultiFab& crse,
+                             const IntVect& ratio, const Geometry& crse_geom);
+
     //! Average fine edge-based MultiFab onto crse edge-based MultiFab.
     void average_down_edges (const Vector<const MultiFab*>& fine,
                              const Vector<MultiFab*>& crse,

--- a/Src/Base/AMReX_MultiFabUtil.cpp
+++ b/Src/Base/AMReX_MultiFabUtil.cpp
@@ -501,6 +501,25 @@ namespace amrex
         }
     }
 
+    void average_down_faces (const Array<const MultiFab*,AMREX_SPACEDIM>& fine,
+                             const Array<MultiFab*,AMREX_SPACEDIM>& crse,
+                             const IntVect& ratio, const Geometry& crse_geom)
+    {
+        for (int idim = 0; idim < AMREX_SPACEDIM; ++idim)
+        {
+            average_down_faces(*fine[idim], *crse[idim], ratio, crse_geom);
+        }
+    }
+
+    void average_down_faces (const MultiFab& fine, MultiFab& crse,
+                             const IntVect& ratio, const Geometry& crse_geom)
+    {
+        MultiFab ctmp(amrex::coarsen(fine.boxArray(),ratio), fine.DistributionMap(),
+                      crse.nComp(), 0);
+        average_down_faces(fine, ctmp, ratio, 0);
+        crse.ParallelCopy(ctmp,0,0,crse.nComp(),0,0,crse_geom.periodicity());
+    }
+
     //! Average fine edge-based MultiFab onto crse edge-based MultiFab.
     //! This routine assumes that the crse BoxArray is a coarsened version of the fine BoxArray.
     void average_down_edges (const Vector<const MultiFab*>& fine, const Vector<MultiFab*>& crse,


### PR DESCRIPTION
New average_down_faces functions that take coarse Geometry and average down periodically.

<!-- Thank you for your pull request to AMReX!

  1. Be sure the title above is descriptive
  2. Provide a summary of the proposed changes
  3. Provide any background to help reviewers understand the proposed changes
  4. Fill out the checklist (using [x] to check the box)

NOTE: All text between < and > will not be formatted in md previewers
-->

## Summary

Add new versions of average_down faces factions that take coarse Geometry as an argument.  The average-down takes periodicity into account.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
