### PR TITLE
Remove instructions....not needed and clutters Slack notices

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,18 +1,8 @@
-<!-- Thank you for your pull request to AMReX!
-
-  1. Be sure the title above is descriptive
-  2. Provide a summary of the proposed changes
-  3. Provide any background to help reviewers understand the proposed changes
-  4. Fill out the checklist (using [x] to check the box)
-
-NOTE: All text between < and > will not be formatted in md previewers
--->
-
 ## Summary
 
 ## Additional background
 
-## Checklist
+## Checklist <-- use [x] to check the box -->
 
 The proposed changes:
 - [ ] fix a bug or incorrect behavior in AMReX

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,7 +2,7 @@
 
 ## Additional background
 
-## Checklist <-- use [x] to check the box -->
+## Checklist
 
 The proposed changes:
 - [ ] fix a bug or incorrect behavior in AMReX


### PR DESCRIPTION
## Summary 

Although the instructions were commented out in the formatted PR text, they clutter up the Slack notices, and aren't really necessary anyway.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
