### PR TITLE
The average_down_faces calls between AMR levels in the linear solvers need to see periodicity

### DIFF
--- a/Src/EB/AMReX_EBMultiFabUtil.H
+++ b/Src/EB/AMReX_EBMultiFabUtil.H
@@ -25,11 +25,16 @@ namespace amrex
                           const IntVect& ratio);
 
     void EB_average_down_faces (const Array<const MultiFab*,AMREX_SPACEDIM>& fine,
-                                const Array<MultiFab*,AMREX_SPACEDIM>& crse,
+                                const Array<      MultiFab*,AMREX_SPACEDIM>& crse,
                                 int ratio, int ngcrse);
     void EB_average_down_faces (const Array<const MultiFab*,AMREX_SPACEDIM>& fine,
-                                const Array<MultiFab*,AMREX_SPACEDIM>& crse,
+                                const Array<      MultiFab*,AMREX_SPACEDIM>& crse,
                                 const IntVect& ratio, int ngcrse);
+
+    //  This version takes periodicity into account.
+    void EB_average_down_faces (const Array<const MultiFab*,AMREX_SPACEDIM>& fine,
+                                const Array<      MultiFab*,AMREX_SPACEDIM>& crse,
+                                const IntVect& ratio, const Geometry& crse_geom);
 
     void EB_average_down_boundaries (const MultiFab& fine, MultiFab& crse,
                                      int ratio, int ngcrse);

--- a/Src/LinearSolvers/MLMG/AMReX_MLABecLaplacian.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLABecLaplacian.cpp
@@ -319,7 +319,7 @@ MLABecLaplacian::averageDownCoeffsToCoarseAmrLevel (int flev)
 
     amrex::average_down_faces(amrex::GetArrOfConstPtrs(fine_b_coeffs),
                               amrex::GetArrOfPtrs(crse_b_coeffs),
-                              mg_coarsen_ratio, 0);
+                              IntVect(mg_coarsen_ratio), m_geom[flev-1][0]);
 }
 
 void

--- a/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap.cpp
@@ -621,7 +621,7 @@ MLEBABecLap::averageDownCoeffsToCoarseAmrLevel (int flev)
 
     amrex::EB_average_down_faces(amrex::GetArrOfConstPtrs(fine_b_coeffs),
                                  amrex::GetArrOfPtrs(crse_b_coeffs),
-                                 mg_coarsen_ratio, 0);
+                                 IntVect(mg_coarsen_ratio), m_geom[flev-1][0]);
 
     if (fine_eb_b_coeffs) {
         amrex::EB_average_down_boundaries(*fine_eb_b_coeffs, *crse_eb_b_coeffs, mg_coarsen_ratio, 0);

--- a/Src/LinearSolvers/MLMG/AMReX_MLEBTensorOp.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBTensorOp.cpp
@@ -146,7 +146,7 @@ MLEBTensorOp::prepareForSolve ()
             if (amrlev > 0) {
                 amrex::EB_average_down_faces(GetArrOfConstPtrs(m_kappa[amrlev  ].back()),
                                              GetArrOfPtrs     (m_kappa[amrlev-1].front()),
-                                             IntVect(mg_coarsen_ratio), 0);
+                                             IntVect(mg_coarsen_ratio), m_geom[amrlev-1][0]);
             }
         }
     } else {

--- a/Src/LinearSolvers/MLMG/AMReX_MLTensorOp.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLTensorOp.cpp
@@ -138,7 +138,7 @@ MLTensorOp::prepareForSolve ()
             if (amrlev > 0) {
                 amrex::average_down_faces(GetArrOfConstPtrs(m_kappa[amrlev  ].back()),
                                           GetArrOfPtrs     (m_kappa[amrlev-1].front()),
-                                          IntVect(mg_coarsen_ratio), 0);
+                                          IntVect(mg_coarsen_ratio), m_geom[amrlev-1][0]);
             }
         }
     } else {


### PR DESCRIPTION
The average_down_faces calls between AMR levels need to use the interfaces that sees the periodicity.  This requires adding that functionality to EB_average_down_faces (it has already been added to non-EB average_down_faces.)

## Summary
Recently we added the functionality for an average_down_faces call to average fine data from one side to average not only onto the face under it but also onto the face on the other side of the domain if periodic in that direction.  This PR 1) extends that functionality to the EB_average_down_faces call and 2) uses this new functionality when averaging down face-based coefficients between AMR levels in the cell-centered linear solvers.

NOTE: I have left a "TODO" in amrex/Src/EB/AMReX_EBMultiFabUtil.cpp -- I wasn't sure how to best implement the functionality in that case

## Additional background

## Checklist
 
The proposed changes:
- [X] fix a bug or incorrect behavior in AMReX
- [X] add new capabilities to AMReX
- [X] changes answers in the test suite to more than roundoff level
- [X] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
