### PR TITLE
Less surprising behavior for the ok() method of FabArray.

### DIFF
--- a/Src/Base/AMReX_FabArray.H
+++ b/Src/Base/AMReX_FabArray.H
@@ -1217,6 +1217,8 @@ template <class FAB>
 bool
 FabArray<FAB>::ok () const
 {
+    if (!define_function_called) return false;
+
     int isok = 1;
 
     for (MFIter fai(*this); fai.isValid() && isok; ++fai)

--- a/Src/Base/AMReX_FabArray.H
+++ b/Src/Base/AMReX_FabArray.H
@@ -270,7 +270,8 @@ public:
 
     /**
     * \brief Return true if the FabArray is well-defined.  That is,
-    * if FABs are allocated for each Box in the BoxArray and the
+    * the FabArray has a BoxArray and DistributionMapping, the
+    * FABs are allocated for each Box in the BoxArray and the
     * sizes of the FABs and the number of components are consistent
     * with the definition of the FabArray.
     */


### PR DESCRIPTION
This makes the `ok()` method of FabArray return `false` instead of crashing if the `define()` method has yet to be called.

We allow FabArray and its derived classes to be default constructed, which places them in a unusable state until the the `define` method has been called. We also provide an `ok()` method, which according to its doxygen strings returns whether the FabArray is well-defined. Currently, this method will crash with a not-particularly instructive error message if it is called on a default-constructed-but-not-defined FabArray. This pull request changes it to return `false` instead, which I'd argue is more intuitive - if it's legal to construct a FabArray and define it later, then it should be legal to test whether that has been done or not. I have also updated the doxygen string for the method in question. 

Even if we want this to crash instead of returning `false`, it should do so with its own assertion and a clear error message.

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [x] are described in the proposed changes to the AMReX documentation, if appropriate
