### PR TITLE
Optimization of FPinfo and complementIn

### DIFF
--- a/Src/Amr/AMReX_AmrLevel.cpp
+++ b/Src/Amr/AMReX_AmrLevel.cpp
@@ -3086,7 +3086,9 @@ FillPatchIterator::initFillPatch(int boxGrow, int time, int index, int scomp, in
                              }
                           }
 			  Box c_dom= amrex::coarsen(geom_fine->Domain(), m_amrlevel.crse_ratio);
-                          m_fpc = &FabArrayBase::TheFPinfo(*(smf_fine[0]), m_fabs, fdomain_g, IntVect(ngrow), coarsener, c_dom, NULL);
+                          m_fpc = &FabArrayBase::TheFPinfo(*(smf_fine[0]), m_fabs, IntVect(ngrow),
+                                                           coarsener, *geom_fine, *geom_crse,
+                                                           nullptr);
                       }
 #ifdef USE_PERILLA_PTHREADS
 //                    perilla::syncAllThreads();

--- a/Src/AmrCore/AMReX_FillPatchUtil_I.H
+++ b/Src/AmrCore/AMReX_FillPatchUtil_I.H
@@ -164,9 +164,20 @@ namespace {
                                       int>::type = 0>
     MF make_mf_crse_patch (FabArrayBase::FPinfo const& fpc, int ncomp)
     {
-        MF mf_crse_patch(fpc.ba_crse_patch, fpc.dm_crse_patch, ncomp, 0, MFInfo(),
+        MF mf_crse_patch(fpc.ba_crse_patch, fpc.dm_patch, ncomp, 0, MFInfo(),
                          *fpc.fact_crse_patch);
         return mf_crse_patch;
+    }
+
+    template <typename MF,
+              typename std::enable_if<std::is_same<typename MF::FABType::value_type,
+                                                   FArrayBox>::value,
+                                      int>::type = 0>
+    MF make_mf_fine_patch (FabArrayBase::FPinfo const& fpc, int ncomp)
+    {
+        MF mf_fine_patch(fpc.ba_fine_patch, fpc.dm_patch, ncomp, 0, MFInfo(),
+                         *fpc.fact_fine_patch);
+        return mf_fine_patch;
     }
 
     template <typename MF,
@@ -175,23 +186,32 @@ namespace {
                                       int>::type = 0>
     MF make_mf_crse_patch (FabArrayBase::FPinfo const& fpc, int ncomp)
     {
-        return MF(fpc.ba_crse_patch, fpc.dm_crse_patch, ncomp, 0);
-    }
-
-    template <typename MF,
-              typename std::enable_if<std::is_same<typename MF::FABType::value_type,
-                                                   FArrayBox>::value,
-                                      int>::type = 0>
-    void mf_set_domain_bndry (MF &mf, Geometry const & cgeom)
-    {
-        mf.setDomainBndry(std::numeric_limits<Real>::quiet_NaN(), cgeom);
+        return MF(fpc.ba_crse_patch, fpc.dm_patch, ncomp, 0);
     }
 
     template <typename MF,
               typename std::enable_if<!std::is_same<typename MF::FABType::value_type,
                                                     FArrayBox>::value,
                                       int>::type = 0>
-    void mf_set_domain_bndry (MF &/*mf*/, Geometry const & /*cgeom*/)
+    MF make_mf_fine_patch (FabArrayBase::FPinfo const& fpc, int ncomp)
+    {
+        return MF(fpc.ba_fine_patch, fpc.dm_patch, ncomp, 0);
+    }
+
+    template <typename MF,
+              typename std::enable_if<std::is_same<typename MF::FABType::value_type,
+                                                   FArrayBox>::value,
+                                      int>::type = 0>
+    void mf_set_domain_bndry (MF &mf, Geometry const & geom)
+    {
+        mf.setDomainBndry(std::numeric_limits<Real>::quiet_NaN(), geom);
+    }
+
+    template <typename MF,
+              typename std::enable_if<!std::is_same<typename MF::FABType::value_type,
+                                                    FArrayBox>::value,
+                                      int>::type = 0>
+    void mf_set_domain_bndry (MF &/*mf*/, Geometry const & /*geom*/)
     {
         // nothing
     }
@@ -199,88 +219,73 @@ namespace {
     template <typename MF, typename BC, typename Interp, typename PreInterpHook, typename PostInterpHook>
     EnableIf_t<IsFabArray<MF>::value>
     FillPatchTwoLevels_doit (MF& mf, IntVect const& nghost, Real time,
-			     const Vector<MF*>& cmf, const Vector<Real>& ct,
-			     const Vector<MF*>& fmf, const Vector<Real>& ft,
-			     int scomp, int dcomp, int ncomp,
-			     const Geometry& cgeom, const Geometry& fgeom,
-			     BC& cbc, int cbccomp,
+                             const Vector<MF*>& cmf, const Vector<Real>& ct,
+                             const Vector<MF*>& fmf, const Vector<Real>& ft,
+                             int scomp, int dcomp, int ncomp,
+                             const Geometry& cgeom, const Geometry& fgeom,
+                             BC& cbc, int cbccomp,
                              BC& fbc, int fbccomp,
-			     const IntVect& ratio,
-			     Interp* mapper,
+                             const IntVect& ratio,
+                             Interp* mapper,
                              const Vector<BCRec>& bcs, int bcscomp,
                              const PreInterpHook& pre_interp,
                              const PostInterpHook& post_interp,
                              EB2::IndexSpace const* index_space)
     {
-	BL_PROFILE("FillPatchTwoLevels");
+        BL_PROFILE("FillPatchTwoLevels");
 
         using FAB = typename MF::FABType::value_type;
 
-	if (nghost.max() > 0 || mf.getBDKey() != fmf[0]->getBDKey())
-	{
-	    const InterpolaterBoxCoarsener& coarsener = mapper->BoxCoarsener(ratio);
+        if (nghost.max() > 0 || mf.getBDKey() != fmf[0]->getBDKey())
+        {
+            const InterpolaterBoxCoarsener& coarsener = mapper->BoxCoarsener(ratio);
 
-	    Box fdomain = fgeom.Domain();
-	    fdomain.convert(mf.boxArray().ixType());
-	    Box fdomain_g(fdomain);
-	    for (int i = 0; i < AMREX_SPACEDIM; ++i) {
-		if (fgeom.isPeriodic(i)) {
-		    fdomain_g.grow(i,nghost[i]);
-		}
-	    }
-
-	    const FabArrayBase::FPinfo& fpc = FabArrayBase::TheFPinfo(*fmf[0], mf, fdomain_g,
+            const FabArrayBase::FPinfo& fpc = FabArrayBase::TheFPinfo(*fmf[0], mf,
                                                                       nghost,
                                                                       coarsener,
-                                                                      amrex::coarsen(fgeom.Domain(),ratio),
+                                                                      fgeom,
+                                                                      cgeom,
                                                                       index_space);
 
-	    if ( ! fpc.ba_crse_patch.empty())
-	    {
+            if ( ! fpc.ba_crse_patch.empty())
+            {
                 MF mf_crse_patch = make_mf_crse_patch<MF>(fpc, ncomp);
                 mf_set_domain_bndry (mf_crse_patch, cgeom);
 
-		FillPatchSingleLevel(mf_crse_patch, time, cmf, ct, scomp, 0, ncomp, cgeom, cbc, cbccomp);
+                FillPatchSingleLevel(mf_crse_patch, time, cmf, ct, scomp, 0, ncomp, cgeom, cbc, cbccomp);
 
-		int idummy1=0, idummy2=0;
-		bool cc = fpc.ba_crse_patch.ixType().cellCentered();
-                ignore_unused(cc);
+                MF mf_fine_patch = make_mf_fine_patch<MF>(fpc, ncomp);
+
+                Box const& fdomain = amrex::convert(fgeom.Domain(),mf.ixType());
+                int idummy=0;
 #ifdef _OPENMP
+                bool cc = fpc.ba_crse_patch.ixType().cellCentered();
 #pragma omp parallel if (cc && Gpu::notInLaunchRegion())
 #endif
                 {
                     Vector<BCRec> bcr(ncomp);
-                    for (MFIter mfi(mf_crse_patch); mfi.isValid(); ++mfi)
+                    for (MFIter mfi(mf_fine_patch); mfi.isValid(); ++mfi)
                     {
                         FAB& sfab = mf_crse_patch[mfi];
-                        int li = mfi.LocalIndex();
-                        int gi = fpc.dst_idxs[li];
-                        FAB& dfab = mf[gi];
-                        const Box& dbx = fpc.dst_boxes[li] & dfab.box();
+                        FAB& dfab = mf_fine_patch[mfi];
+                        const Box& dbx = dfab.box();
 
                         amrex::setBC(dbx,fdomain,bcscomp,0,ncomp,bcs,bcr);
 
                         pre_interp(sfab, sfab.box(), 0, ncomp);
 
-                        mapper->interp(sfab,
-                                       0,
-                                       dfab,
-                                       dcomp,
-                                       ncomp,
-                                       dbx,
-                                       ratio,
-                                       cgeom,
-                                       fgeom,
-                                       bcr,
-                                       idummy1, idummy2, RunOn::Gpu);
+                        mapper->interp(sfab, 0, dfab, 0, ncomp, dbx, ratio,
+                                       cgeom, fgeom, bcr, dcomp, idummy, RunOn::Gpu);
 
-                        post_interp(dfab, dbx, dcomp, ncomp);
+                        post_interp(dfab, dbx, 0, ncomp);
                     }
                 }
+
+                mf.ParallelCopy(mf_fine_patch, 0, dcomp, ncomp, IntVect{0}, nghost);
 	    }
 	}
 
-	FillPatchSingleLevel(mf, nghost, time, fmf, ft, scomp, dcomp, ncomp,
+        FillPatchSingleLevel(mf, nghost, time, fmf, ft, scomp, dcomp, ncomp,
                              fgeom, fbc, fbccomp);
     } }
 

--- a/Src/Base/AMReX_Box.H
+++ b/Src/Base/AMReX_Box.H
@@ -1032,7 +1032,7 @@ public:
 
 inline BoxConverter::~BoxConverter () { }
 
-void AllGatherBoxes (Vector<Box>& bxs);
+void AllGatherBoxes (Vector<Box>& bxs, int n_extra_reserve=0);
 
     /**
     * \brief Grow Box in all directions by given amount.

--- a/Src/Base/AMReX_Box.cpp
+++ b/Src/Base/AMReX_Box.cpp
@@ -104,24 +104,24 @@ BoxCommHelper::BoxCommHelper (const Box& bx, int* p_)
 }
 
 void
-AllGatherBoxes (Vector<Box>& bxs)
+AllGatherBoxes (Vector<Box>& bxs, int n_extra_reserve)
 {
 #ifdef BL_USE_MPI
-    const int count = bxs.size();
-    const auto& countvec = ParallelDescriptor::Gather(count, ParallelDescriptor::IOProcessorNumber());
-    
-    Long count_tot = 0L;
-    Vector<int> offset(countvec.size(),0);
-    if (ParallelDescriptor::IOProcessor())
-    {
-        count_tot = countvec[0];
-        for (int i = 1, N = offset.size(); i < N; ++i) {
-            offset[i] = offset[i-1] + countvec[i-1];
-            count_tot += countvec[i];
-        }
-    }
 
-    ParallelDescriptor::Bcast(&count_tot, 1, ParallelDescriptor::IOProcessorNumber());
+#if 0
+    // In principle, MPI_Allgather/MPI_Allgatherv should not be slower than
+    // MPI_Gather/MPI_Gatherv followed by MPI_Bcast.  But that's not true on Summit.
+    MPI_Comm comm = ParallelContext::CommunicatorSub();
+    const int count = bxs.size();
+    Vector<int> countvec(ParallelContext::NProcsSub());
+    MPI_Allgather(&count, 1, MPI_INT, countvec.data(), 1, MPI_INT, comm);
+
+    Vector<int> offset(countvec.size(),0);
+    Long count_tot = countvec[0];
+    for (int i = 1, N = offset.size(); i < N; ++i) {
+        offset[i] = offset[i-1] + countvec[i-1];
+        count_tot += countvec[i];
+    }
 
     if (count_tot == 0) return;
 
@@ -129,15 +129,55 @@ AllGatherBoxes (Vector<Box>& bxs)
         amrex::Abort("AllGatherBoxes: not many boxes");
     }
 
-    Vector<Box> recv_buffer(count_tot);
-    ParallelDescriptor::Gatherv(bxs.data(), count, recv_buffer.data(), countvec, offset,
-                                ParallelDescriptor::IOProcessorNumber());
+    Vector<Box> recv_buffer;
+    recv_buffer.reserve(count_tot+n_extra_reserve);
+    recv_buffer.resize(count_tot);
+    MPI_Allgatherv(bxs.data(), count, ParallelDescriptor::Mpi_typemap<Box>::type(),
+                   recv_buffer.data(), countvec.data(), offset.data(),
+                   ParallelDescriptor::Mpi_typemap<Box>::type(), comm);
 
-    ParallelDescriptor::Bcast(recv_buffer.data(), count_tot, ParallelDescriptor::IOProcessorNumber());
-
-    bxs = std::move(recv_buffer);
+    std::swap(bxs,recv_buffer);
 #else
-    amrex::ignore_unused(bxs);
+    MPI_Comm comm = ParallelContext::CommunicatorSub();
+    const int root = ParallelContext::IOProcessorNumberSub();
+    const int myproc = ParallelContext::MyProcSub();
+    const int nprocs = ParallelContext::NProcsSub();
+    const int count = bxs.size();
+    Vector<int> countvec(nprocs);
+    MPI_Gather(&count, 1, MPI_INT, countvec.data(), 1, MPI_INT, root, comm);
+
+    Long count_tot = 0L;
+    Vector<int> offset(countvec.size(),0);
+    if (myproc == root) {
+        count_tot = countvec[0];
+        for (int i = 1, N = offset.size(); i < N; ++i) {
+            offset[i] = offset[i-1] + countvec[i-1];
+            count_tot += countvec[i];
+        }
+    }
+
+    MPI_Bcast(&count_tot, 1, MPI_INT, root, comm);
+
+    if (count_tot == 0) return;
+
+    if (count_tot > static_cast<Long>(std::numeric_limits<int>::max())) {
+        amrex::Abort("AllGatherBoxes: not many boxes");
+    }
+
+    Vector<Box> recv_buffer;
+    recv_buffer.reserve(count_tot+n_extra_reserve);
+    recv_buffer.resize(count_tot);
+    MPI_Gatherv(bxs.data(), count, ParallelDescriptor::Mpi_typemap<Box>::type(),
+                recv_buffer.data(), countvec.data(), offset.data(),
+                ParallelDescriptor::Mpi_typemap<Box>::type(), root, comm);
+    MPI_Bcast(recv_buffer.data(), count_tot, ParallelDescriptor::Mpi_typemap<Box>::type(),
+              root, comm);
+
+    std::swap(bxs,recv_buffer);
+#endif
+
+#else
+    amrex::ignore_unused(bxs,n_extra_reserve);
 #endif
 }
 

--- a/Src/Base/AMReX_BoxDomain.cpp
+++ b/Src/Base/AMReX_BoxDomain.cpp
@@ -63,6 +63,7 @@ BoxDomain&
 BoxDomain::complementIn (const Box&       b,
                          const BoxDomain& bl)
 {
+    BL_PROFILE("BoxDomain::complementIn()");
     BoxList::complementIn(b,bl);
     BL_ASSERT(ok());
     return *this;

--- a/Src/Base/AMReX_BoxList.H
+++ b/Src/Base/AMReX_BoxList.H
@@ -139,11 +139,13 @@ public:
     //! Remove empty Boxes from this BoxList.
     BoxList& removeEmpty();
 
-    BoxList& complementIn (const Box&     b,
-                           const BoxList& bl);
-    BoxList& complementIn (const Box&     b,
-                            BoxList&&     bl);
+    BoxList& complementIn (const Box& b, const BoxList& bl);
+    BoxList& complementIn (const Box& b, BoxList&& bl);
     BoxList& complementIn (const Box& b, const BoxArray& ba);
+    BoxList& parallelComplementIn (const Box& b, const BoxList& bl);
+    BoxList& parallelComplementIn (const Box& b, BoxList&& bl);
+    BoxList& parallelComplementIn (const Box& b, const BoxArray& ba);
+
     //! Refine each Box in the BoxList by the ratio.
     BoxList& refine (int ratio);
     //! Refine each Box in the BoxList by the ratio.

--- a/Src/Base/AMReX_DistributionMapping.cpp
+++ b/Src/Base/AMReX_DistributionMapping.cpp
@@ -857,7 +857,8 @@ DistributionMapping::KnapSackProcessorMap (const BoxArray& boxes,
 					   int             nprocs)
 {
     BL_ASSERT(boxes.size() > 0);
-    BL_ASSERT(m_ref->m_pmap.size() == boxes.size());
+
+    m_ref->m_pmap.resize(boxes.size());
 
     if (boxes.size() <= nprocs || nprocs < 2)
     {
@@ -883,6 +884,7 @@ namespace
         class Compare
         {
         public:
+            AMREX_FORCE_INLINE
             bool operator () (const SFCToken& lhs,
                               const SFCToken& rhs) const;
         };
@@ -901,6 +903,7 @@ namespace
 
 int SFCToken::MaxPower = 64;
 
+AMREX_FORCE_INLINE
 bool
 SFCToken::Compare::operator () (const SFCToken& lhs,
                                 const SFCToken& rhs) const

--- a/Src/Base/AMReX_FabArrayBase.H
+++ b/Src/Base/AMReX_FabArrayBase.H
@@ -325,6 +325,7 @@ public:
                 const Box&          dstdomain,
                 const IntVect&      dstng,
                 const BoxConverter& coarsener,
+                const Box&          fdomain,
                 const Box&          cdomain,
                 const EB2::IndexSpace* index_space);
 
@@ -333,16 +334,16 @@ public:
         Long bytes () const;
 
         BoxArray            ba_crse_patch;
-        DistributionMapping dm_crse_patch;
+        BoxArray            ba_fine_patch;
+        DistributionMapping dm_patch;
         std::unique_ptr<FabFactory<FArrayBox> > fact_crse_patch;
-        Vector<int>          dst_idxs;
-        Vector<Box>          dst_boxes;
+        std::unique_ptr<FabFactory<FArrayBox> > fact_fine_patch;
         //
         BDKey               m_srcbdk;
         BDKey               m_dstbdk;
         Box                 m_dstdomain;
         IntVect             m_dstng;
-        BoxConverter*       m_coarsener;
+        std::unique_ptr<BoxConverter> m_coarsener;
         //
         Long                m_nuse;
     };
@@ -356,10 +357,10 @@ public:
 
     static const FPinfo& TheFPinfo (const FabArrayBase& srcfa,
                                     const FabArrayBase& dstfa,
-                                    const Box&          dstdomain,
                                     const IntVect&      dstng,
                                     const BoxConverter& coarsener,
-                                    const Box&          cdomain,
+                                    const Geometry&     fgeom,
+                                    const Geometry&     cgeom,
                                     const EB2::IndexSpace*);
 
     void flushFPinfo (bool no_assertion=false);

--- a/Src/Base/AMReX_FabArrayBase.cpp
+++ b/Src/Base/AMReX_FabArrayBase.cpp
@@ -1119,10 +1119,11 @@ FabArrayBase::getFB (const IntVect& nghost, const Periodicity& period,
 }
 
 FabArrayBase::FPinfo::FPinfo (const FabArrayBase& srcfa,
-			      const FabArrayBase& dstfa,
-			      const Box&          dstdomain,
-			      const IntVect&      dstng,
-			      const BoxConverter& coarsener,
+                              const FabArrayBase& dstfa,
+                              const Box&          dstdomain,
+                              const IntVect&      dstng,
+                              const BoxConverter& coarsener,
+                              const Box&          fdomain,
                               const Box&          cdomain,
                               const EB2::IndexSpace* index_space)
     : m_srcbdk   (srcfa.getBDKey()),
@@ -1132,90 +1133,189 @@ FabArrayBase::FPinfo::FPinfo (const FabArrayBase& srcfa,
       m_coarsener(coarsener.clone()),
       m_nuse     (0)
 {
-    amrex::ignore_unused(cdomain,index_space);
+    amrex::ignore_unused(fdomain,cdomain,index_space);
     BL_PROFILE("FPinfo::FPinfo()");
+
     const BoxArray& srcba = srcfa.boxArray();
     const BoxArray& dstba = dstfa.boxArray();
     BL_ASSERT(srcba.ixType() == dstba.ixType());
 
+    BoxArray srcba_simplified = srcba.simplified();
+    BoxArray dstba_simplified = dstba.simplified();
+
     const IndexType& boxtype = dstba.ixType();
     BL_ASSERT(boxtype == dstdomain.ixType());
-     
+
     BL_ASSERT(dstng.allLE(dstfa.nGrowVect()));
 
-    const DistributionMapping& dstdm = dstfa.DistributionMap();
-    
-    const int myproc = ParallelDescriptor::MyProc();
-
     BoxList bl(boxtype);
-    Vector<int> iprocs;
-
-    BoxArray srcba_simplified = srcba.simplified();
-
-    for (int i = 0, N = dstba.size(); i < N; ++i)
-    {
-        Box bx = dstba[i];
+    const int Ndst = dstba_simplified.size();
+    const int nprocs = ParallelContext::NProcsSub();
+    int iboxlo, iboxhi;
+    bool parallel_ci;
+    if (Ndst > 8) {
+        parallel_ci = true;
+        const int navg = Ndst / nprocs;
+        const int nextra = Ndst - navg*nprocs;
+        const int myproc = ParallelContext::MyProcSub();
+        iboxlo = (myproc < nextra) ? myproc*(navg+1) : myproc*navg+nextra;
+        iboxhi = (myproc < nextra) ? iboxlo+navg+1-1 : iboxlo+navg-1;
+    } else {
+        parallel_ci = false;
+        iboxlo = 0;
+        iboxhi = Ndst-1;
+    }
+    for (int i = iboxlo; i <= iboxhi; ++i) {
+        Box bx = dstba_simplified[i];
         bx.grow(m_dstng);
         bx &= m_dstdomain;
-
-        BoxList leftover = srcba_simplified.complementIn(bx);
-
-        bool ismybox = (dstdm[i] == myproc);
-        for (BoxList::const_iterator bli = leftover.begin(); bli != leftover.end(); ++bli)
-        {
-            bl.push_back(m_coarsener->doit(*bli));
-            if (ismybox) {
-                dst_boxes.push_back(*bli);
-                dst_idxs.push_back(i);
-            }
-            iprocs.push_back(dstdm[i]);
+        BoxList const& leftover = srcba_simplified.complementIn(bx);
+        if (leftover.isNotEmpty()) {
+            bl.join(leftover);
         }
     }
 
-    if (!iprocs.empty()) {
-        ba_crse_patch.define(bl);
-        dm_crse_patch.define(std::move(iprocs));
-#ifdef AMREX_USE_EB
-        if (index_space)
-        {
-            fact_crse_patch = makeEBFabFactory(index_space,
-                                               index_space->getGeometry(cdomain),
-                                               ba_crse_patch,
-                                               dm_crse_patch,
-                                               {0,0,0}, EBSupport::basic);
-        }
-        else
+    if (parallel_ci) {
+        amrex::AllGatherBoxes(bl.data());
+    }
+
+    if (bl.isEmpty()) return;
+
+    Long ncells_total = 0L;
+    Long ncells_max = 0L;
+    for (auto const& b : bl) {
+        auto n = b.numPts();
+        ncells_total += n;
+        ncells_max = std::max(ncells_max, n);
+    }
+
+    Long ncells_avg = ncells_total / ParallelContext::NProcsSub();
+    Long ncells_target = std::max(2*ncells_avg, Long(8*8*8));
+    if (ncells_max > ncells_target) {
+        BoxList bltmp(boxtype);
+        Vector<Box>& bltmpvec = bltmp.data();
+        for (Box const& b : bl) {
+            Long const npts = b.numPts();
+            if (npts <= ncells_target) {
+                bltmp.push_back(b);
+            } else {
+                IntVect const len = b.length();
+                IntVect numblk{1};
+                while (npts > (AMREX_D_TERM(numblk[0],*numblk[1],*numblk[2])) * ncells_target) {
+#if (AMREX_SPACEDIM == 3)
+                    int longdir = (len[2] >= len[0] && len[2] >= len[1]) ? 2 :
+                        (len[1] >= len[0]) ? 1 : 0;
+#elif (AMREX_SPACEDIM == 2)
+                    int longdir = (len[1] >= len[0]) ? 1 : 0;
+#elif (AMREX_SPACEDIM == 1)
+                    int longdir = 0;
+#else
+                    static_assert(false, "FabArrayBase::FPinfo() unsupported AMREX_SPACEDIM");
 #endif
-        {
-            fact_crse_patch.reset(new FArrayBoxFactory());
+                    numblk[longdir] *= 2;
+                }
+                numblk.min(len);
+                IntVect sz, extra;
+                for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+                    sz[idim] = len[idim] / numblk[idim];
+                    extra[idim] =  len[idim] - sz[idim] * numblk[idim];
+                }
+                if (numblk == 1) {
+                    bltmp.push_back(b);
+                } else {
+                    IntVect const& boxlo = b.smallEnd();
+#if (AMREX_SPACEDIM == 3)
+                    for (int k = 0; k < numblk[2]; ++k) {
+                        int klo = (k < extra[2]) ? k*(sz[2]+1) : (k*sz[2]+extra[2]);
+                        int khi = (k < extra[2]) ? klo+(sz[2]+1)-1 : klo+sz[2]-1;
+                        klo += boxlo[2];
+                        khi += boxlo[2];
+#endif
+#if (AMREX_SPACEDIM >= 2)
+                        for (int j = 0; j < numblk[1]; ++j) {
+                            int jlo = (j < extra[1]) ? j*(sz[1]+1) : (j*sz[1]+extra[1]);
+                            int jhi = (j < extra[1]) ? jlo+(sz[1]+1)-1 : jlo+sz[1]-1;
+                            jlo += boxlo[1];
+                            jhi += boxlo[1];
+#endif
+                            for (int i = 0; i < numblk[0]; ++i) {
+                                int ilo = (i < extra[0]) ? i*(sz[0]+1) : (i*sz[0]+extra[0]);
+                                int ihi = (i < extra[0]) ? ilo+(sz[0]+1)-1 : ilo+sz[0]-1;
+                                ilo += boxlo[0];
+                                ihi += boxlo[0];
+                                bltmpvec.emplace_back(IntVect(AMREX_D_DECL(ilo,jlo,klo)),
+                                                      IntVect(AMREX_D_DECL(ihi,jhi,khi)),
+                                                      boxtype);
+                    AMREX_D_TERM(},},})
+                }
+            }
         }
+        std::swap(bl,bltmp);
+    }
+
+    BoxList blcrse(boxtype);
+    blcrse.reserve(bl.size());
+    for (auto const& b : bl) {
+        blcrse.push_back(coarsener.doit(b));
+    }
+
+    ba_crse_patch.define(std::move(blcrse));
+    ba_fine_patch.define(std::move(bl));
+    dm_patch.KnapSackProcessorMap(ba_fine_patch, ParallelContext::NProcsSub());
+
+#ifdef AMREX_USE_EB
+    if (index_space)
+    {
+        fact_crse_patch = makeEBFabFactory(index_space,
+                                           index_space->getGeometry(cdomain),
+                                           ba_crse_patch,
+                                           dm_patch,
+                                           {0,0,0}, EBSupport::basic);
+        fact_fine_patch = makeEBFabFactory(index_space,
+                                           index_space->getGeometry(fdomain),
+                                           ba_fine_patch,
+                                           dm_patch,
+                                           {0,0,0}, EBSupport::basic);
+    }
+    else
+#endif
+    {
+        fact_crse_patch.reset(new FArrayBoxFactory());
+        fact_fine_patch.reset(new FArrayBoxFactory());
     }
 }
 
 FabArrayBase::FPinfo::~FPinfo ()
 {
-    delete m_coarsener;
 }
 
 Long
 FabArrayBase::FPinfo::bytes () const
 {
     Long cnt = sizeof(FabArrayBase::FPinfo);
-    cnt += sizeof(Box) * (ba_crse_patch.capacity() + dst_boxes.capacity());
-    cnt += sizeof(int) * (dm_crse_patch.capacity() + dst_idxs.capacity());
+    cnt += sizeof(Box) * (ba_crse_patch.capacity() + ba_fine_patch.capacity());
+    cnt += sizeof(int) * dm_patch.capacity();
     return cnt;
 }
 
 const FabArrayBase::FPinfo&
 FabArrayBase::TheFPinfo (const FabArrayBase& srcfa,
                          const FabArrayBase& dstfa,
-                         const Box&          dstdomain,
                          const IntVect&      dstng,
                          const BoxConverter& coarsener,
-                         const Box&          cdomain,
+                         const Geometry&     fgeom,
+                         const Geometry&     cgeom,
                          const EB2::IndexSpace* index_space)
 {
     BL_PROFILE("FabArrayBase::TheFPinfo()");
+
+    Box dstdomain = fgeom.Domain();
+    dstdomain.convert(dstfa.boxArray().ixType());
+    for (int i = 0; i < AMREX_SPACEDIM; ++i) {
+        if (fgeom.isPeriodic(i)) {
+            dstdomain.grow(i,dstng[i]);
+        }
+    }
 
     const BDKey& srckey = srcfa.getBDKey();
     const BDKey& dstkey = dstfa.getBDKey();
@@ -1238,7 +1338,8 @@ FabArrayBase::TheFPinfo (const FabArrayBase& srcfa,
     }
 
     // Have to build a new one
-    FPinfo* new_fpc = new FPinfo(srcfa, dstfa, dstdomain, dstng, coarsener, cdomain, index_space);
+    FPinfo* new_fpc = new FPinfo(srcfa, dstfa, dstdomain, dstng, coarsener,
+                                 fgeom.Domain(), cgeom.Domain(), index_space);
 
 #ifdef AMREX_MEM_PROFILING
     m_FPinfo_stats.bytes += new_fpc->bytes();


### PR DESCRIPTION
## Summary

Use simplified BoxArray in FPinfo and parallelize FPinfo.  Add parallel version of
BoxList::parallelComplementIn and use it in AmrMesh::MakeNewGrids.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
