### PR TITLE
MacProjector: allow for re-use of the object and enhance multi-level algorithm.

### DIFF
--- a/Src/LinearSolvers/Projections/AMReX_MacProjector.H
+++ b/Src/LinearSolvers/Projections/AMReX_MacProjector.H
@@ -107,6 +107,7 @@ private:
     Vector<Array<MultiFab*,AMREX_SPACEDIM> > m_umac;
     Vector<MultiFab> m_rhs;
     Vector<MultiFab> m_phi;
+    Vector<MultiFab> m_divu;
     Vector<Array<MultiFab,AMREX_SPACEDIM> > m_fluxes;
 
     Vector<Geometry> m_geom;

--- a/Src/LinearSolvers/Projections/AMReX_MacProjector.H
+++ b/Src/LinearSolvers/Projections/AMReX_MacProjector.H
@@ -95,6 +95,8 @@ private:
 
     void setOptions ();
 
+    void averageDownVelocity ();
+
     std::unique_ptr<MLABecLaplacian> m_abeclap;
 #ifdef AMREX_USE_EB
     std::unique_ptr<MLEBABecLap> m_eb_abeclap;


### PR DESCRIPTION
## Summary

Originally the MacProjector object was not designed to be re-used for multiple solves, i.e. it had to be created anew for each solve. Furthermore, it was up to the user to average down velocities before and after the projection for multi-level solves.

This bug enhance the behavior of the MacProjector by

1) taking care of the averaging-down of the velocities internally, and 
2) allowing the same object to be re-used for multiple solves as long as the system coefficients don't change

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [X] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
