### PR TITLE
Ignore unused indices in AMREX_LOOP_3D and 4D

### DIFF
--- a/Src/Base/AMReX_BoxArray.cpp
+++ b/Src/Base/AMReX_BoxArray.cpp
@@ -1306,7 +1306,6 @@ BoxArray::complementIn (BoxList& bl, const Box& bx) const
     if (m_bat.is_null()) {
         AMREX_LOOP_3D(cbx, i, j, k,
         {
-            amrex::ignore_unused(j,k);
             auto it = BoxHashMap.find(IntVect(AMREX_D_DECL(i,j,k)));
             if (it != TheEnd) {
                 for (const int index : it->second) {
@@ -1322,7 +1321,6 @@ BoxArray::complementIn (BoxList& bl, const Box& bx) const
         IntVect cr = crseRatio();
         AMREX_LOOP_3D(cbx, i, j, k,
         {
-            amrex::ignore_unused(j,k);
             auto it = BoxHashMap.find(IntVect(AMREX_D_DECL(i,j,k)));
             if (it != TheEnd) {
                 for (const int index : it->second) {
@@ -1336,7 +1334,6 @@ BoxArray::complementIn (BoxList& bl, const Box& bx) const
     } else {
         AMREX_LOOP_3D(cbx, i, j, k,
         {
-            amrex::ignore_unused(j,k);
             auto it = BoxHashMap.find(IntVect(AMREX_D_DECL(i,j,k)));
             if (it != TheEnd) {
                 for (const int index : it->second) {

--- a/Src/Base/AMReX_Loop.H
+++ b/Src/Base/AMReX_Loop.H
@@ -217,6 +217,7 @@ void LoopConcurrentOnCpu (Box const& bx, int ncomp, F&& f) noexcept
     for (int k = amrex_i_lo.z; k <= amrex_i_hi.z; ++k) { \
     for (int j = amrex_i_lo.y; j <= amrex_i_hi.y; ++j) { \
     for (int i = amrex_i_lo.x; i <= amrex_i_hi.x; ++i) { \
+        AMREX_D_PICK(amrex::ignore_unused(j,k),amrex::ignore_unused(k),(void)0); \
         block \
     }}} \
 }
@@ -229,6 +230,7 @@ void LoopConcurrentOnCpu (Box const& bx, int ncomp, F&& f) noexcept
     for (int k = amrex_i_lo.z; k <= amrex_i_hi.z; ++k) { \
     for (int j = amrex_i_lo.y; j <= amrex_i_hi.y; ++j) { \
     for (int i = amrex_i_lo.x; i <= amrex_i_hi.x; ++i) { \
+        AMREX_D_PICK(amrex::ignore_unused(j,k),amrex::ignore_unused(k),(void)0); \
         block \
     }}}} \
 }


### PR DESCRIPTION
## Summary

Incorporate amrex::ignore_unused into AMREX_LOOP_3D and 4D so that the user does not have to see warnings.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
