### PR TITLE
Small volfrac

### DIFF
--- a/Src/EB/AMReX_EB2_2D_C.cpp
+++ b/Src/EB/AMReX_EB2_2D_C.cpp
@@ -277,28 +277,44 @@ void build_cells (Box const& bx, Array4<EBCellFlag> const& cell,
         }
     });
 
+    // set cells in the extended region to covered if the
+    // corresponding cell on the domain face is covered
     if(extend_domain_face) {
        AMREX_HOST_DEVICE_FOR_3D ( bxg1, i, j, k,
        {
            const auto & dlo = geom.Domain().loVect();
            const auto & dhi = geom.Domain().hiVect();
 
-           if(not cell(i,j,k).isCovered()) {
+           // find the cell(ii,jj,kk) on the corr. domain face
+           // this would have already been set to correct value
+           int ii = i;
+           int jj = j;
+           int kk = k;
+           if(i < dlo[0]) {
+               ii = dlo[0];
+           }
+           else if(i > dhi[0]) {
+               ii = dhi[0];
+           }
 
-              if(not geom.isPeriodic(0)) {
-                 if( (i < dlo[0] and cell(dlo[0],j,k).isCovered()) or 
-                     (i > dhi[0] and cell(dhi[0],j,k).isCovered()) ) 
-                 {
-                     set_covered(i,j,cell,vfrac,vcent,barea,bcent,bnorm);
-                 }
+           if(j < dlo[1]) {
+               jj = dlo[1];
+           }
+           else if(j > dhi[1]) {
+               jj = dhi[1];
+           }
+
+           // set cell on extendable region to covered
+           if( (not cell(i,j,k).isCovered()) and 
+               cell(ii,jj,kk).isCovered() ) 
+           {
+
+              if( (not geom.isPeriodic(0)) and (i < dlo[0] or i > dhi[0]) ) {
+                  set_covered(i,j,cell,vfrac,vcent,barea,bcent,bnorm);
               }
 
-              if(not geom.isPeriodic(1)) {
-                 if( (j < dlo[1] and cell(i,dlo[1],k).isCovered()) or 
-                     (j > dhi[1] and cell(i,dhi[1],k).isCovered()) ) 
-                 {
-                     set_covered(i,j,cell,vfrac,vcent,barea,bcent,bnorm);
-                 }
+              if( (not geom.isPeriodic(1)) and (j < dlo[1] or j > dhi[1]) ) {
+                  set_covered(i,j,cell,vfrac,vcent,barea,bcent,bnorm);
               }
            }
        });

--- a/Src/EB/AMReX_EB2_2D_C.cpp
+++ b/Src/EB/AMReX_EB2_2D_C.cpp
@@ -106,6 +106,7 @@ void set_eb_data (const int i, const int j,
     }
 }
 
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 void set_covered(const int i, const int j,
                  Array4<EBCellFlag> const& cell,
                  Array4<Real> const& vfrac, Array4<Real> const& vcent,

--- a/Src/EB/AMReX_EB2_2D_C.cpp
+++ b/Src/EB/AMReX_EB2_2D_C.cpp
@@ -292,8 +292,8 @@ void build_cells (Box const& bx, Array4<EBCellFlag> const& cell,
        if (not gdomain.contains(bxg1)) {
        AMREX_HOST_DEVICE_FOR_3D ( bxg1, i, j, k,
        {
-              const auto & dlo = gdomain().loVect();
-              const auto & dhi = gdomain().hiVect();
+              const auto & dlo = gdomain.loVect();
+              const auto & dhi = gdomain.hiVect();
 
               // find the cell(ii,jj,kk) on the corr. domain face
               // this would have already been set to correct value

--- a/Src/EB/AMReX_EB2_3D_C.cpp
+++ b/Src/EB/AMReX_EB2_3D_C.cpp
@@ -236,6 +236,27 @@ void cut_face_2d (Real& areafrac, Real& centx, Real& centy,
         }
     }
 }
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void set_covered (const int i, const int j, const int k,
+                  Array4<EBCellFlag> const& cell,
+                  Array4<Real> const& vfrac, Array4<Real> const& vcent,
+                  Array4<Real> const& barea, Array4<Real> const& bcent,
+                  Array4<Real> const& bnorm)
+{
+    vfrac(i,j,k) = 0.0;
+    vcent(i,j,k,0) = 0.0;
+    vcent(i,j,k,1) = 0.0;
+    vcent(i,j,k,2) = 0.0;
+    bcent(i,j,k,0) = -1.0;
+    bcent(i,j,k,1) = -1.0;
+    bcent(i,j,k,2) = -1.0;
+    bnorm(i,j,k,0) = 0.0;
+    bnorm(i,j,k,1) = 0.0;
+    bnorm(i,j,k,2) = 0.0;
+    barea(i,j,k) = 0.0;
+    cell(i,j,k).setCovered();
+}
 }
 
 void build_faces (Box const& bx, Array4<EBCellFlag> const& cell,
@@ -646,7 +667,8 @@ void build_cells (Box const& bx, Array4<EBCellFlag> const& cell,
 
             // remove small cells
             if (vfrac(i,j,k) < small_volfrac) {
-                vfrac(i,j,k) = 0.0;
+                set_covered(i,j,k,cell,vfrac,vcent,barea,bcent,bnorm);
+                /*vfrac(i,j,k) = 0.0;
                 vcent(i,j,k,0) = 0.0;
                 vcent(i,j,k,1) = 0.0;
                 vcent(i,j,k,2) = 0.0;
@@ -657,7 +679,32 @@ void build_cells (Box const& bx, Array4<EBCellFlag> const& cell,
                 bnorm(i,j,k,1) = 0.0;
                 bnorm(i,j,k,2) = 0.0;
                 barea(i,j,k) = 0.0;
-                cell(i,j,k).setCovered();
+                cell(i,j,k).setCovered();*/
+                if(i == 0) {
+                  amrex::Print() << "Covering corresponding ghost cell: " << IntVect(i-1,j,k) << std::endl;
+                  set_covered(i-1,j,k,cell,vfrac,vcent,barea,bcent,bnorm);
+                }
+                if(j == 0) {
+                  amrex::Print() << "Covering corresponding ghost cell: " << IntVect(i,j-1,k) << std::endl;
+                  set_covered(i,j-1,k,cell,vfrac,vcent,barea,bcent,bnorm);
+                }
+                if(k == 0) {
+                  amrex::Print() << "Covering corresponding ghost cell: " << IntVect(i,j,k-1) << std::endl;
+                  set_covered(i,j,k-1,cell,vfrac,vcent,barea,bcent,bnorm);
+                }
+                  /*vfrac(i,j,k-1) = 0.0;
+                  vcent(i,j,k-1,0) = 0.0;
+                  vcent(i,j,k-1,1) = 0.0;
+                  vcent(i,j,k-1,2) = 0.0;
+                  bcent(i,j,k-1,0) = -1.0;
+                  bcent(i,j,k-1,1) = -1.0;
+                  bcent(i,j,k-1,2) = -1.0;
+                  bnorm(i,j,k-1,0) = 0.0;
+                  bnorm(i,j,k-1,1) = 0.0;
+                  bnorm(i,j,k-1,2) = 0.0;
+                  barea(i,j,k-1) = 0.0;
+                  cell(i,j,k-1).setCovered();
+                }*/
             }
         }
     });

--- a/Src/EB/AMReX_EB2_3D_C.cpp
+++ b/Src/EB/AMReX_EB2_3D_C.cpp
@@ -633,10 +633,7 @@ void build_cells (Box const& bx, Array4<EBCellFlag> const& cell,
                   Real small_volfrac, 
                   Geometry const& geom, bool extend_domain_face)
 {
-
     const Box& bxg1 = amrex::grow(bx,1);
-
-
     AMREX_HOST_DEVICE_FOR_3D ( bxg1, i, j, k,
     {
         if (cell(i,j,k).isRegular()) {
@@ -793,7 +790,6 @@ void build_cells (Box const& bx, Array4<EBCellFlag> const& cell,
         for (int i = lo.x; i <= hi.x; ++i)
         {
             if (vfrac(i,j,k-1) < small_volfrac or vfrac(i,j,k) < small_volfrac) {
-                //amrex::Print() << "Here: " << vfrac(i,j,k-1) << ", " << vfrac(i,j,k) << std::endl;
                 fz(i,j,k) = Type::covered;
                 apz(i,j,k) = 0.0;
 

--- a/Src/EB/AMReX_EB2_3D_C.cpp
+++ b/Src/EB/AMReX_EB2_3D_C.cpp
@@ -680,39 +680,35 @@ void build_cells (Box const& bx, Array4<EBCellFlag> const& cell,
                    const auto & lo = bxg1.loVect();
                    const auto & hi = bxg1.hiVect();
 
+                   // if cell lies on any of the 6 domain faces, force
+                   // all layers of corresponding ghost cells to be convered
                    if(i == dlo[0]) {
-                     for(int ii = lo[0]; ii < dlo[0]; ++ii) { //all layers of ghost cells
-                        amrex::Print() << "Cover left ghost cell: " << IntVect(ii,j,k) << std::endl;
+                     for(int ii = lo[0]; ii < dlo[0]; ++ii) {
                         set_covered(ii,j,k,cell,vfrac,vcent,barea,bcent,bnorm);
                      }
                    }
                    if(i == dhi[0]) {
-                     for(int ii = hi[0]; ii > dhi[0]; --ii) { //all layers of ghost cells
-                        amrex::Print() << "Cover right ghost cell: " << IntVect(ii,j,k) << std::endl;
+                     for(int ii = hi[0]; ii > dhi[0]; --ii) {
                         set_covered(ii,j,k,cell,vfrac,vcent,barea,bcent,bnorm);
                      }
                    }
                    if(j == dlo[1]) {
-                     for(int jj = lo[1]; jj < dlo[1]; ++jj) { //all layers of ghost cells
-                        amrex::Print() << "Cover front ghost cell: " << IntVect(i,jj,k) << std::endl;
+                     for(int jj = lo[1]; jj < dlo[1]; ++jj) {
                         set_covered(i,jj,k,cell,vfrac,vcent,barea,bcent,bnorm);
                      }
                    }
                    if(j == dhi[1]) {
-                     for(int jj = hi[1]; jj > dhi[1]; --jj) { //all layers of ghost cells
-                        amrex::Print() << "Cover back ghost cell: " << IntVect(i,jj,k) << std::endl;
+                     for(int jj = hi[1]; jj > dhi[1]; --jj) {
                         set_covered(i,jj,k,cell,vfrac,vcent,barea,bcent,bnorm);
                      }
                    }
                    if(k == dlo[2]) {
-                     for(int kk = lo[2]; kk < dlo[2]; ++kk) { //all layers of ghost cells
-                        amrex::Print() << "Cover bottom ghost cell: " << IntVect(i,j,kk) << std::endl;
+                     for(int kk = lo[2]; kk < dlo[2]; ++kk) {
                         set_covered(i,j,kk,cell,vfrac,vcent,barea,bcent,bnorm);
                      }
                    }
                    if(k == dhi[2]) {
-                     for(int kk = hi[2]; kk > dhi[2]; --kk) { //all layers of ghost cells
-                        amrex::Print() << "Cover top ghost cell: " << IntVect(i,j,kk) << std::endl;
+                     for(int kk = hi[2]; kk > dhi[2]; --kk) {
                         set_covered(i,j,kk,cell,vfrac,vcent,barea,bcent,bnorm);
                      }
                    }

--- a/Src/EB/AMReX_EB2_3D_C.cpp
+++ b/Src/EB/AMReX_EB2_3D_C.cpp
@@ -676,55 +676,62 @@ void build_cells (Box const& bx, Array4<EBCellFlag> const& cell,
     // set cells in the extended region to covered if the
     // corresponding cell on the domain face is covered
     if(extend_domain_face) {
-       AMREX_HOST_DEVICE_FOR_3D ( bxg1, i, j, k,
-       {
-           const auto & dlo = geom.Domain().loVect();
-           const auto & dhi = geom.Domain().hiVect();
 
-           // find the cell(ii,jj,kk) on the corr. domain face
-           // this would have already been set to correct value
-           int ii = i;
-           int jj = j;
-           int kk = k;
-           if(i < dlo[0]) {
-               ii = dlo[0];
+       Box gdomain = geom.Domain();
+       for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+           if (geom.isPeriodic(idim)) {
+               gdomain.setSmall(idim, std::min(gdomain.smallEnd(idim), bxg1.smallEnd(idim)));
+               gdomain.setBig(idim, std::max(gdomain.bigEnd(idim), bxg1.bigEnd(idim)));
            }
-           else if(i > dhi[0]) {
-               ii = dhi[0];
-           }
+       }
 
-           if(j < dlo[1]) {
-               jj = dlo[1];
-           }
-           else if(j > dhi[1]) {
-               jj = dhi[1];
-           }
+       if (not gdomain.contains(bxg1)) {
+          AMREX_HOST_DEVICE_FOR_3D ( bxg1, i, j, k,
+          {
+              const auto & dlo = gdomain.loVect();
+              const auto & dhi = gdomain.hiVect();
 
-           if(k < dlo[2]) {
-               kk = dlo[2];
-           }
-           else if(k > dhi[2]) {
-               kk = dhi[2];
-           }
-
-           // set cell on extendable region to covered
-           if( (not cell(i,j,k).isCovered()) and 
-               cell(ii,jj,kk).isCovered() ) 
-           {
-
-              if( (not geom.isPeriodic(0)) and (i < dlo[0] or i > dhi[0]) ) {
-                  set_covered(i,j,k,cell,vfrac,vcent,barea,bcent,bnorm);
+              // find the cell(ii,jj,kk) on the corr. domain face
+              // this would have already been set to correct value
+              bool in_extended_domain = false;
+              int ii = i;
+              int jj = j;
+              int kk = k;
+              if(i < dlo[0]) {
+                  in_extended_domain = true;
+                  ii = dlo[0];
+              }
+              else if(i > dhi[0]) {
+                  in_extended_domain = true;
+                  ii = dhi[0];
               }
 
-              if( (not geom.isPeriodic(1)) and (j < dlo[1] or j > dhi[1]) ) {
-                  set_covered(i,j,k,cell,vfrac,vcent,barea,bcent,bnorm);
+              if(j < dlo[1]) {
+                  in_extended_domain = true;
+                  jj = dlo[1];
+              }
+              else if(j > dhi[1]) {
+                  in_extended_domain = true;
+                  jj = dhi[1];
               }
 
-              if( (not geom.isPeriodic(2)) and (k < dlo[2] or k > dhi[2]) ) {
+              if(k < dlo[2]) {
+                  in_extended_domain = true;
+                  kk = dlo[2];
+              }
+              else if(k > dhi[2]) {
+                  in_extended_domain = true;
+                  kk = dhi[2];
+              }
+
+              // set cell in extendable region to covered if necessary
+              if( in_extended_domain and (not cell(i,j,k).isCovered()) 
+                  and cell(ii,jj,kk).isCovered() ) 
+              {
                   set_covered(i,j,k,cell,vfrac,vcent,barea,bcent,bnorm);
               }
-           }
-       });
+          });
+       }
     }
 
     // fix faces for small cells

--- a/Src/EB/AMReX_EB2_3D_C.cpp
+++ b/Src/EB/AMReX_EB2_3D_C.cpp
@@ -630,7 +630,8 @@ void build_cells (Box const& bx, Array4<EBCellFlag> const& cell,
                   Array4<Real> const& vfrac, Array4<Real> const& vcent,
                   Array4<Real> const& barea, Array4<Real> const& bcent,
                   Array4<Real> const& bnorm, Array4<EBCellFlag> const& ctmp,
-                  Real small_volfrac, Box const& domain)
+                  Real small_volfrac, 
+                  Box const& domain, bool extend_domain_face)
 {
     const auto dlo = domain.loVect();
     const auto dhi = domain.hiVect();
@@ -672,31 +673,33 @@ void build_cells (Box const& bx, Array4<EBCellFlag> const& cell,
             if (vfrac(i,j,k) < small_volfrac) {
                 set_covered(i,j,k,cell,vfrac,vcent,barea,bcent,bnorm);
                 
-                if(i == dlo[0]) {
-                  amrex::Print() << "Covering ghost cell: " << IntVect(i-1,j,k) << std::endl;
-                  set_covered(i-1,j,k,cell,vfrac,vcent,barea,bcent,bnorm);
-                }
-                else if(i == dhi[0]) {
-                  amrex::Print() << "Covering ghost cell: " << IntVect(i+1,j,k) << std::endl;
-                  set_covered(i+1,j,k,cell,vfrac,vcent,barea,bcent,bnorm);
-                }
+                if(extend_domain_face) {
+                   if(i == dlo[0]) {
+                     amrex::Print() << "Covering ghost cell: " << IntVect(i-1,j,k) << std::endl;
+                     set_covered(i-1,j,k,cell,vfrac,vcent,barea,bcent,bnorm);
+                   }
+                   else if(i == dhi[0]) {
+                     amrex::Print() << "Covering ghost cell: " << IntVect(i+1,j,k) << std::endl;
+                     set_covered(i+1,j,k,cell,vfrac,vcent,barea,bcent,bnorm);
+                   }
 
-                if(j == dlo[1]) {
-                  amrex::Print() << "Covering ghost cell: " << IntVect(i,j-1,k) << std::endl;
-                  set_covered(i,j-1,k,cell,vfrac,vcent,barea,bcent,bnorm);
-                }
-                else if(j == dhi[1]) {
-                  amrex::Print() << "Covering ghost cell: " << IntVect(i,j+1,k) << std::endl;
-                  set_covered(i,j+1,k,cell,vfrac,vcent,barea,bcent,bnorm);
-                }
+                   if(j == dlo[1]) {
+                     amrex::Print() << "Covering ghost cell: " << IntVect(i,j-1,k) << std::endl;
+                     set_covered(i,j-1,k,cell,vfrac,vcent,barea,bcent,bnorm);
+                   }
+                   else if(j == dhi[1]) {
+                     amrex::Print() << "Covering ghost cell: " << IntVect(i,j+1,k) << std::endl;
+                     set_covered(i,j+1,k,cell,vfrac,vcent,barea,bcent,bnorm);
+                   }
 
-                if(k == dlo[2]) {
-                  amrex::Print() << "Covering ghost cell: " << IntVect(i,j,k-1) << std::endl;
-                  set_covered(i,j,k-1,cell,vfrac,vcent,barea,bcent,bnorm);
-                }
-                else if(k == dhi[2]) {
-                  amrex::Print() << "Covering ghost cell: " << IntVect(i,j,k+1) << std::endl;
-                  set_covered(i,j,k+1,cell,vfrac,vcent,barea,bcent,bnorm);
+                   if(k == dlo[2]) {
+                     amrex::Print() << "Covering ghost cell: " << IntVect(i,j,k-1) << std::endl;
+                     set_covered(i,j,k-1,cell,vfrac,vcent,barea,bcent,bnorm);
+                   }
+                   else if(k == dhi[2]) {
+                     amrex::Print() << "Covering ghost cell: " << IntVect(i,j,k+1) << std::endl;
+                     set_covered(i,j,k+1,cell,vfrac,vcent,barea,bcent,bnorm);
+                   }
                 }
             }
         }

--- a/Src/EB/AMReX_EB2_3D_C.cpp
+++ b/Src/EB/AMReX_EB2_3D_C.cpp
@@ -681,7 +681,7 @@ void build_cells (Box const& bx, Array4<EBCellFlag> const& cell,
                    const auto & hi = bxg1.hiVect();
 
                    // if cell lies on any of the 6 domain faces, force
-                   // all layers of corresponding ghost cells to be convered
+                   // all layers of corresponding ghost cells to be covered
                    if(i == dlo[0]) {
                      for(int ii = lo[0]; ii < dlo[0]; ++ii) {
                         set_covered(ii,j,k,cell,vfrac,vcent,barea,bcent,bnorm);

--- a/Src/EB/AMReX_EB2_3D_C.cpp
+++ b/Src/EB/AMReX_EB2_3D_C.cpp
@@ -633,10 +633,10 @@ void build_cells (Box const& bx, Array4<EBCellFlag> const& cell,
                   Real small_volfrac, 
                   Box const& domain, bool extend_domain_face)
 {
-    const auto dlo = domain.loVect();
-    const auto dhi = domain.hiVect();
 
     const Box& bxg1 = amrex::grow(bx,1);
+
+
     AMREX_HOST_DEVICE_FOR_3D ( bxg1, i, j, k,
     {
         if (cell(i,j,k).isRegular()) {
@@ -671,34 +671,50 @@ void build_cells (Box const& bx, Array4<EBCellFlag> const& cell,
 
             // remove small cells
             if (vfrac(i,j,k) < small_volfrac) {
+
                 set_covered(i,j,k,cell,vfrac,vcent,barea,bcent,bnorm);
                 
                 if(extend_domain_face) {
+                   const auto & dlo = domain.loVect();
+                   const auto & dhi = domain.hiVect();
+                   const auto & lo = bxg1.loVect();
+                   const auto & hi = bxg1.hiVect();
+
                    if(i == dlo[0]) {
-                     amrex::Print() << "Covering ghost cell: " << IntVect(i-1,j,k) << std::endl;
-                     set_covered(i-1,j,k,cell,vfrac,vcent,barea,bcent,bnorm);
+                     for(int ii = lo[0]; ii < dlo[0]; ++ii) { //all layers of ghost cells
+                        amrex::Print() << "Cover left ghost cell: " << IntVect(ii,j,k) << std::endl;
+                        set_covered(ii,j,k,cell,vfrac,vcent,barea,bcent,bnorm);
+                     }
                    }
-                   else if(i == dhi[0]) {
-                     amrex::Print() << "Covering ghost cell: " << IntVect(i+1,j,k) << std::endl;
-                     set_covered(i+1,j,k,cell,vfrac,vcent,barea,bcent,bnorm);
+                   if(i == dhi[0]) {
+                     for(int ii = hi[0]; ii > dhi[0]; --ii) { //all layers of ghost cells
+                        amrex::Print() << "Cover right ghost cell: " << IntVect(ii,j,k) << std::endl;
+                        set_covered(ii,j,k,cell,vfrac,vcent,barea,bcent,bnorm);
+                     }
                    }
-
                    if(j == dlo[1]) {
-                     amrex::Print() << "Covering ghost cell: " << IntVect(i,j-1,k) << std::endl;
-                     set_covered(i,j-1,k,cell,vfrac,vcent,barea,bcent,bnorm);
+                     for(int jj = lo[1]; jj < dlo[1]; ++jj) { //all layers of ghost cells
+                        amrex::Print() << "Cover front ghost cell: " << IntVect(i,jj,k) << std::endl;
+                        set_covered(i,jj,k,cell,vfrac,vcent,barea,bcent,bnorm);
+                     }
                    }
-                   else if(j == dhi[1]) {
-                     amrex::Print() << "Covering ghost cell: " << IntVect(i,j+1,k) << std::endl;
-                     set_covered(i,j+1,k,cell,vfrac,vcent,barea,bcent,bnorm);
+                   if(j == dhi[1]) {
+                     for(int jj = hi[1]; jj > dhi[1]; --jj) { //all layers of ghost cells
+                        amrex::Print() << "Cover back ghost cell: " << IntVect(i,jj,k) << std::endl;
+                        set_covered(i,jj,k,cell,vfrac,vcent,barea,bcent,bnorm);
+                     }
                    }
-
                    if(k == dlo[2]) {
-                     amrex::Print() << "Covering ghost cell: " << IntVect(i,j,k-1) << std::endl;
-                     set_covered(i,j,k-1,cell,vfrac,vcent,barea,bcent,bnorm);
+                     for(int kk = lo[2]; kk < dlo[2]; ++kk) { //all layers of ghost cells
+                        amrex::Print() << "Cover bottom ghost cell: " << IntVect(i,j,kk) << std::endl;
+                        set_covered(i,j,kk,cell,vfrac,vcent,barea,bcent,bnorm);
+                     }
                    }
-                   else if(k == dhi[2]) {
-                     amrex::Print() << "Covering ghost cell: " << IntVect(i,j,k+1) << std::endl;
-                     set_covered(i,j,k+1,cell,vfrac,vcent,barea,bcent,bnorm);
+                   if(k == dhi[2]) {
+                     for(int kk = hi[2]; kk > dhi[2]; --kk) { //all layers of ghost cells
+                        amrex::Print() << "Cover top ghost cell: " << IntVect(i,j,kk) << std::endl;
+                        set_covered(i,j,kk,cell,vfrac,vcent,barea,bcent,bnorm);
+                     }
                    }
                 }
             }

--- a/Src/EB/AMReX_EB2_3D_C.cpp
+++ b/Src/EB/AMReX_EB2_3D_C.cpp
@@ -668,7 +668,6 @@ void build_cells (Box const& bx, Array4<EBCellFlag> const& cell,
             // remove small cells
             if (vfrac(i,j,k) < small_volfrac) {
                 set_covered(i,j,k,cell,vfrac,vcent,barea,bcent,bnorm);
-                cell(i,j,k).setCovered();
                 
                 //left
                 if(i == 0) {

--- a/Src/EB/AMReX_EB2_3D_C.cpp
+++ b/Src/EB/AMReX_EB2_3D_C.cpp
@@ -681,30 +681,47 @@ void build_cells (Box const& bx, Array4<EBCellFlag> const& cell,
            const auto & dlo = geom.Domain().loVect();
            const auto & dhi = geom.Domain().hiVect();
 
-           if(not cell(i,j,k).isCovered()) {
+           // find the cell(ii,jj,kk) on the corr. domain face
+           // this would have already been set to correct value
+           int ii = i;
+           int jj = j;
+           int kk = k;
+           if(i < dlo[0]) {
+               ii = dlo[0];
+           }
+           else if(i > dhi[0]) {
+               ii = dhi[0];
+           }
 
-              if(not geom.isPeriodic(0)) {
-                 if( (i < dlo[0] and cell(dlo[0],j,k).isCovered()) or
-                     (i > dhi[0] and cell(dhi[0],j,k).isCovered()) ) 
-                 {   
-                     set_covered(i,j,k,cell,vfrac,vcent,barea,bcent,bnorm);
-                 }
+           if(j < dlo[1]) {
+               jj = dlo[1];
+           }
+           else if(j > dhi[1]) {
+               jj = dhi[1];
+           }
+
+           if(k < dlo[2]) {
+               kk = dlo[2];
+           }
+           else if(k > dhi[2]) {
+               kk = dhi[2];
+           }
+
+           // set cell on extendable region to covered
+           if( (not cell(i,j,k).isCovered()) and 
+               cell(ii,jj,kk).isCovered() ) 
+           {
+
+              if( (not geom.isPeriodic(0)) and (i < dlo[0] or i > dhi[0]) ) {
+                  set_covered(i,j,k,cell,vfrac,vcent,barea,bcent,bnorm);
               }
 
-              if(not geom.isPeriodic(1)) {
-                 if( (j < dlo[1] and cell(i,dlo[1],k).isCovered()) or
-                     (j > dhi[1] and cell(i,dhi[1],k).isCovered()) ) 
-                 {
-                     set_covered(i,j,k,cell,vfrac,vcent,barea,bcent,bnorm);
-                 }
+              if( (not geom.isPeriodic(1)) and (j < dlo[1] or j > dhi[1]) ) {
+                  set_covered(i,j,k,cell,vfrac,vcent,barea,bcent,bnorm);
               }
 
-              if(not geom.isPeriodic(2)) {
-                 if( (k < dlo[2] and cell(i,j,dlo[2]).isCovered()) or
-                     (k > dhi[2] and cell(i,j,dhi[2]).isCovered()) ) 
-                 {
-                     set_covered(i,j,k,cell,vfrac,vcent,barea,bcent,bnorm);
-                 }
+              if( (not geom.isPeriodic(2)) and (k < dlo[2] or k > dhi[2]) ) {
+                  set_covered(i,j,k,cell,vfrac,vcent,barea,bcent,bnorm);
               }
            }
        });

--- a/Src/EB/AMReX_EB2_3D_C.cpp
+++ b/Src/EB/AMReX_EB2_3D_C.cpp
@@ -668,43 +668,28 @@ void build_cells (Box const& bx, Array4<EBCellFlag> const& cell,
             // remove small cells
             if (vfrac(i,j,k) < small_volfrac) {
                 set_covered(i,j,k,cell,vfrac,vcent,barea,bcent,bnorm);
-                /*vfrac(i,j,k) = 0.0;
-                vcent(i,j,k,0) = 0.0;
-                vcent(i,j,k,1) = 0.0;
-                vcent(i,j,k,2) = 0.0;
-                bcent(i,j,k,0) = -1.0;
-                bcent(i,j,k,1) = -1.0;
-                bcent(i,j,k,2) = -1.0;
-                bnorm(i,j,k,0) = 0.0;
-                bnorm(i,j,k,1) = 0.0;
-                bnorm(i,j,k,2) = 0.0;
-                barea(i,j,k) = 0.0;
-                cell(i,j,k).setCovered();*/
+                cell(i,j,k).setCovered();
+                
+                //left
                 if(i == 0) {
-                  amrex::Print() << "Covering corresponding ghost cell: " << IntVect(i-1,j,k) << std::endl;
+                  amrex::Print() << "Covering ghost cell: " << IntVect(i-1,j,k) << std::endl;
                   set_covered(i-1,j,k,cell,vfrac,vcent,barea,bcent,bnorm);
                 }
+                //TODO: right
+                
+                //front
                 if(j == 0) {
-                  amrex::Print() << "Covering corresponding ghost cell: " << IntVect(i,j-1,k) << std::endl;
+                  amrex::Print() << "Covering ghost cell: " << IntVect(i,j-1,k) << std::endl;
                   set_covered(i,j-1,k,cell,vfrac,vcent,barea,bcent,bnorm);
                 }
+                //TODO: back
+
+                //bottom
                 if(k == 0) {
-                  amrex::Print() << "Covering corresponding ghost cell: " << IntVect(i,j,k-1) << std::endl;
+                  amrex::Print() << "Covering ghost cell: " << IntVect(i,j,k-1) << std::endl;
                   set_covered(i,j,k-1,cell,vfrac,vcent,barea,bcent,bnorm);
                 }
-                  /*vfrac(i,j,k-1) = 0.0;
-                  vcent(i,j,k-1,0) = 0.0;
-                  vcent(i,j,k-1,1) = 0.0;
-                  vcent(i,j,k-1,2) = 0.0;
-                  bcent(i,j,k-1,0) = -1.0;
-                  bcent(i,j,k-1,1) = -1.0;
-                  bcent(i,j,k-1,2) = -1.0;
-                  bnorm(i,j,k-1,0) = 0.0;
-                  bnorm(i,j,k-1,1) = 0.0;
-                  bnorm(i,j,k-1,2) = 0.0;
-                  barea(i,j,k-1) = 0.0;
-                  cell(i,j,k-1).setCovered();
-                }*/
+                //TODO: top
             }
         }
     });

--- a/Src/EB/AMReX_EB2_3D_C.cpp
+++ b/Src/EB/AMReX_EB2_3D_C.cpp
@@ -630,8 +630,11 @@ void build_cells (Box const& bx, Array4<EBCellFlag> const& cell,
                   Array4<Real> const& vfrac, Array4<Real> const& vcent,
                   Array4<Real> const& barea, Array4<Real> const& bcent,
                   Array4<Real> const& bnorm, Array4<EBCellFlag> const& ctmp,
-                  Real small_volfrac)
+                  Real small_volfrac, Box const& domain)
 {
+    const auto dlo = domain.loVect();
+    const auto dhi = domain.hiVect();
+
     const Box& bxg1 = amrex::grow(bx,1);
     AMREX_HOST_DEVICE_FOR_3D ( bxg1, i, j, k,
     {
@@ -669,26 +672,32 @@ void build_cells (Box const& bx, Array4<EBCellFlag> const& cell,
             if (vfrac(i,j,k) < small_volfrac) {
                 set_covered(i,j,k,cell,vfrac,vcent,barea,bcent,bnorm);
                 
-                //left
-                if(i == 0) {
+                if(i == dlo[0]) {
                   amrex::Print() << "Covering ghost cell: " << IntVect(i-1,j,k) << std::endl;
                   set_covered(i-1,j,k,cell,vfrac,vcent,barea,bcent,bnorm);
                 }
-                //TODO: right
-                
-                //front
-                if(j == 0) {
+                else if(i == dhi[0]) {
+                  amrex::Print() << "Covering ghost cell: " << IntVect(i+1,j,k) << std::endl;
+                  set_covered(i+1,j,k,cell,vfrac,vcent,barea,bcent,bnorm);
+                }
+
+                if(j == dlo[1]) {
                   amrex::Print() << "Covering ghost cell: " << IntVect(i,j-1,k) << std::endl;
                   set_covered(i,j-1,k,cell,vfrac,vcent,barea,bcent,bnorm);
                 }
-                //TODO: back
+                else if(j == dhi[1]) {
+                  amrex::Print() << "Covering ghost cell: " << IntVect(i,j+1,k) << std::endl;
+                  set_covered(i,j+1,k,cell,vfrac,vcent,barea,bcent,bnorm);
+                }
 
-                //bottom
-                if(k == 0) {
+                if(k == dlo[2]) {
                   amrex::Print() << "Covering ghost cell: " << IntVect(i,j,k-1) << std::endl;
                   set_covered(i,j,k-1,cell,vfrac,vcent,barea,bcent,bnorm);
                 }
-                //TODO: top
+                else if(k == dhi[2]) {
+                  amrex::Print() << "Covering ghost cell: " << IntVect(i,j,k+1) << std::endl;
+                  set_covered(i,j,k+1,cell,vfrac,vcent,barea,bcent,bnorm);
+                }
             }
         }
     });

--- a/Src/EB/AMReX_EB2_C.H
+++ b/Src/EB/AMReX_EB2_C.H
@@ -57,7 +57,7 @@ void build_cells (Box const& bx, Array4<EBCellFlag> const& cell,
                   Array4<Real> const& vfrac, Array4<Real> const& vcent,
                   Array4<Real> const& barea, Array4<Real> const& bcent,
                   Array4<Real> const& bnorm, Array4<EBCellFlag> const& ctmp,
-                  Real small_volfrac);
+                  Real small_volfrac, Box const& geom);
 
 #endif
 

--- a/Src/EB/AMReX_EB2_C.H
+++ b/Src/EB/AMReX_EB2_C.H
@@ -4,6 +4,7 @@
 #include <AMReX_FArrayBox.H>
 #include <AMReX_EBCellFlag.H>
 #include <AMReX_EB2_Graph.H>
+#include <AMReX_Geometry.H>
 
 #if (AMREX_SPACEDIM == 2)
 #include <AMReX_EB2_2D_C.H>
@@ -30,7 +31,7 @@ void build_cells (Box const& bx, Array4<EBCellFlag> const& cell,
                   Array4<Real> const& vfrac, Array4<Real> const& vcent,
                   Array4<Real> const& barea, Array4<Real> const& bcent,
                   Array4<Real> const& bnorm, Real small_volfrac, 
-                  Box const& geom, bool extend_domain_face);
+                  Geometry const& geom, bool extend_domain_face);
 
 #elif (AMREX_SPACEDIM == 3)
 
@@ -59,7 +60,7 @@ void build_cells (Box const& bx, Array4<EBCellFlag> const& cell,
                   Array4<Real> const& barea, Array4<Real> const& bcent,
                   Array4<Real> const& bnorm, Array4<EBCellFlag> const& ctmp,
                   Real small_volfrac, 
-                  Box const& geom, bool extend_domain_face);
+                  Geometry const& geom, bool extend_domain_face);
 
 #endif
 

--- a/Src/EB/AMReX_EB2_C.H
+++ b/Src/EB/AMReX_EB2_C.H
@@ -29,7 +29,8 @@ void build_cells (Box const& bx, Array4<EBCellFlag> const& cell,
                   Array4<Real> const& apx, Array4<Real> const& apy,
                   Array4<Real> const& vfrac, Array4<Real> const& vcent,
                   Array4<Real> const& barea, Array4<Real> const& bcent,
-                  Array4<Real> const& bnorm, Real small_volfrac, Box const& geom);
+                  Array4<Real> const& bnorm, Real small_volfrac, 
+                  Box const& geom, bool extend_domain_face);
 
 #elif (AMREX_SPACEDIM == 3)
 
@@ -57,7 +58,8 @@ void build_cells (Box const& bx, Array4<EBCellFlag> const& cell,
                   Array4<Real> const& vfrac, Array4<Real> const& vcent,
                   Array4<Real> const& barea, Array4<Real> const& bcent,
                   Array4<Real> const& bnorm, Array4<EBCellFlag> const& ctmp,
-                  Real small_volfrac, Box const& geom);
+                  Real small_volfrac, 
+                  Box const& geom, bool extend_domain_face);
 
 #endif
 

--- a/Src/EB/AMReX_EB2_C.H
+++ b/Src/EB/AMReX_EB2_C.H
@@ -29,7 +29,7 @@ void build_cells (Box const& bx, Array4<EBCellFlag> const& cell,
                   Array4<Real> const& apx, Array4<Real> const& apy,
                   Array4<Real> const& vfrac, Array4<Real> const& vcent,
                   Array4<Real> const& barea, Array4<Real> const& bcent,
-                  Array4<Real> const& bnorm, Real small_volfrac);
+                  Array4<Real> const& bnorm, Real small_volfrac, Box const& geom);
 
 #elif (AMREX_SPACEDIM == 3)
 

--- a/Src/EB/AMReX_EB2_Level.H
+++ b/Src/EB/AMReX_EB2_Level.H
@@ -302,7 +302,7 @@ GShopLevel<G>::GShopLevel (IndexSpace const* is, G const& gshop, const Geometry&
 
             build_cells(vbx, cfg, ftx, fty, ftz, apx, apy, apz,
                         fcx, fcy, fcz, xm2, ym2, zm2, vfr, ctr,
-                        bar, bct, bnm, cfgtmp, small_volfrac);
+                        bar, bct, bnm, cfgtmp, small_volfrac, geom.Domain());
 
 #elif (AMREX_SPACEDIM == 2)
             for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
@@ -332,7 +332,7 @@ GShopLevel<G>::GShopLevel (IndexSpace const* is, G const& gshop, const Geometry&
 
             build_faces(vbx, cfg, ftx, fty, lst, xip, yip, apx, apy, fcx, fcy, dx, problo);
 
-            build_cells(vbx, cfg, ftx, fty, apx, apy, vfr, ctr, bar, bct, bnm, small_volfrac);
+            build_cells(vbx, cfg, ftx, fty, apx, apy, vfr, ctr, bar, bct, bnm, small_volfrac, geom.Domain());
 #endif
         }
     }

--- a/Src/EB/AMReX_EB2_Level.H
+++ b/Src/EB/AMReX_EB2_Level.H
@@ -302,7 +302,8 @@ GShopLevel<G>::GShopLevel (IndexSpace const* is, G const& gshop, const Geometry&
 
             build_cells(vbx, cfg, ftx, fty, ftz, apx, apy, apz,
                         fcx, fcy, fcz, xm2, ym2, zm2, vfr, ctr,
-                        bar, bct, bnm, cfgtmp, small_volfrac, geom.Domain());
+                        bar, bct, bnm, cfgtmp, small_volfrac, 
+                        geom.Domain(), extend_domain_face);
 
 #elif (AMREX_SPACEDIM == 2)
             for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
@@ -332,7 +333,8 @@ GShopLevel<G>::GShopLevel (IndexSpace const* is, G const& gshop, const Geometry&
 
             build_faces(vbx, cfg, ftx, fty, lst, xip, yip, apx, apy, fcx, fcy, dx, problo);
 
-            build_cells(vbx, cfg, ftx, fty, apx, apy, vfr, ctr, bar, bct, bnm, small_volfrac, geom.Domain());
+            build_cells(vbx, cfg, ftx, fty, apx, apy, vfr, ctr, bar, bct, bnm, small_volfrac, 
+                        geom.Domain(), extend_domain_face);
 #endif
         }
     }

--- a/Src/EB/AMReX_EB2_Level.H
+++ b/Src/EB/AMReX_EB2_Level.H
@@ -303,7 +303,7 @@ GShopLevel<G>::GShopLevel (IndexSpace const* is, G const& gshop, const Geometry&
             build_cells(vbx, cfg, ftx, fty, ftz, apx, apy, apz,
                         fcx, fcy, fcz, xm2, ym2, zm2, vfr, ctr,
                         bar, bct, bnm, cfgtmp, small_volfrac, 
-                        geom.Domain(), extend_domain_face);
+                        geom, extend_domain_face);
 
 #elif (AMREX_SPACEDIM == 2)
             for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
@@ -334,7 +334,7 @@ GShopLevel<G>::GShopLevel (IndexSpace const* is, G const& gshop, const Geometry&
             build_faces(vbx, cfg, ftx, fty, lst, xip, yip, apx, apy, fcx, fcy, dx, problo);
 
             build_cells(vbx, cfg, ftx, fty, apx, apy, vfr, ctr, bar, bct, bnm, small_volfrac, 
-                        geom.Domain(), extend_domain_face);
+                        geom, extend_domain_face);
 #endif
         }
     }


### PR DESCRIPTION
## Summary

When extend_domain_face is set to true we do the following: If we set a cell that lies on one of the 6 faces of the domain as covered because its volfrac is less than the small_volfrac , we are forcing the corresponding ghost cells on that face to also be covered.

## Additional background

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [x] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
