### PR TITLE
Use rvalues for functions that take callables

### DIFF
--- a/Src/Particle/AMReX_DenseBins.H
+++ b/Src/Particle/AMReX_DenseBins.H
@@ -74,7 +74,7 @@ public:
      * \param f a function object that maps items to bins
      */
     template <typename N, typename F>
-    void build (N nitems, T const* v, const Box& bx, F f)
+    void build (N nitems, T const* v, const Box& bx, F&& f)
     {
         BL_PROFILE("DenseBins<T>::build");
 

--- a/Src/Particle/AMReX_NeighborList.H
+++ b/Src/Particle/AMReX_NeighborList.H
@@ -138,7 +138,7 @@ public:
     template <class PTile, class CheckPair>
     void build (PTile& ptile,
                 const amrex::Box& bx, const amrex::Geometry& geom,
-                CheckPair check_pair, int num_cells=1)
+                CheckPair&& check_pair, int num_cells=1)
     {
         auto& vec = ptile.GetArrayOfStructs()();
         m_pstruct = vec.dataPtr();

--- a/Src/Particle/AMReX_NeighborParticles.H
+++ b/Src/Particle/AMReX_NeighborParticles.H
@@ -241,7 +241,7 @@ public:
     /// Build a Neighbor List for each tile
     ///
     template <class CheckPair>
-    void buildNeighborList (CheckPair check_pair, bool sort=false);
+    void buildNeighborList (CheckPair&& check_pair, bool sort=false);
 
     void printNeighborList ();
 

--- a/Src/Particle/AMReX_NeighborParticlesI.H
+++ b/Src/Particle/AMReX_NeighborParticlesI.H
@@ -661,7 +661,7 @@ template <int NStructReal, int NStructInt>
 template <class CheckPair>
 void
 NeighborParticleContainer<NStructReal, NStructInt>::
-buildNeighborList (CheckPair check_pair, bool sort) 
+buildNeighborList (CheckPair&& check_pair, bool sort) 
 {
     AMREX_ASSERT(numParticlesOutOfRange(*this, m_num_neighbor_cells) == 0);
 
@@ -705,7 +705,9 @@ buildNeighborList (CheckPair check_pair, bool sort)
             bx.coarsen(ref_fac);
             bx.grow(m_num_neighbor_cells);
             
-            m_neighbor_list[lev][index].build(ptile, bx, geom, check_pair, m_num_neighbor_cells);
+            m_neighbor_list[lev][index].build(ptile, bx, geom,
+                                              std::forward<CheckPair>(check_pair),
+                                              m_num_neighbor_cells);
 #ifndef AMREX_USE_GPU
             const auto& counts = m_neighbor_list[lev][index].GetCounts();
             const auto& list   = m_neighbor_list[lev][index].GetList();

--- a/Src/Particle/AMReX_ParticleCommunication.H
+++ b/Src/Particle/AMReX_ParticleCommunication.H
@@ -318,7 +318,7 @@ void packBuffer (const PC& pc, const ParticleCopyOp& op, const ParticleCopyPlan&
 
 template <class PC, class Buffer, class UnpackPolicy,
           EnableIf_t<IsParticleContainer<PC>::value, int> foo = 0>
-void unpackBuffer (PC& pc, const ParticleCopyPlan& plan, const Buffer& snd_buffer, const UnpackPolicy policy)
+void unpackBuffer (PC& pc, const ParticleCopyPlan& plan, const Buffer& snd_buffer, const UnpackPolicy&& policy)
 {
     BL_PROFILE("amrex::unpackBuffer");
 
@@ -502,7 +502,7 @@ void communicateParticlesFinish (const ParticleCopyPlan& plan);
 
 template <class PC, class Buffer, class UnpackPolicy,
           EnableIf_t<IsParticleContainer<PC>::value, int> foo = 0>
-void unpackRemotes (PC& pc, const ParticleCopyPlan& plan, Buffer& rcv_buffer, const UnpackPolicy& policy)
+void unpackRemotes (PC& pc, const ParticleCopyPlan& plan, Buffer& rcv_buffer, UnpackPolicy&& policy)
 {
     BL_PROFILE("amrex::unpackRemotes");
 

--- a/Src/Particle/AMReX_SparseBins.H
+++ b/Src/Particle/AMReX_SparseBins.H
@@ -100,7 +100,7 @@ public:
      * \param f a function object that maps items to bins 
      */        
     template <typename N, typename F>
-    void build (N nitems, T const* v, const Box& bx, F f)
+    void build (N nitems, T const* v, const Box& bx, F&& f)
     {
         BL_PROFILE("SparseBins<T>::build");
 


### PR DESCRIPTION
There is no downside to doing it this way, and it may have better performance for some compilers / situations, although tests on Summit did not see a noticeable change.

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
