### PR TITLE
Fix AMREX_HOME in Tests and Tutorials only

### DIFF
--- a/Tests/Algoim/GNUmakefile
+++ b/Tests/Algoim/GNUmakefile
@@ -13,7 +13,7 @@ COMP = gnu
 
 DIM = 3
 
-AMREX_HOME ?= ../../..
+AMREX_HOME = ../../..
 
 include $(AMREX_HOME)/Tools/GNUMake/Make.defs
 include ./Make.package

--- a/Tests/AsyncOut/multifab/GNUmakefile
+++ b/Tests/AsyncOut/multifab/GNUmakefile
@@ -1,4 +1,4 @@
-AMREX_HOME ?= ../../../
+AMREX_HOME = ../../../
 
 DEBUG = FALSE
 DIM = 3

--- a/Tests/BBIOBenchmark/GNUmakefile
+++ b/Tests/BBIOBenchmark/GNUmakefile
@@ -1,4 +1,4 @@
-AMREX_HOME ?= ../../../amrex
+AMREX_HOME = ../../../amrex
 
 PROFILE   = FALSE
 PRECISION = DOUBLE

--- a/Tests/BaseFabTesting/GNUmakefile
+++ b/Tests/BaseFabTesting/GNUmakefile
@@ -1,4 +1,4 @@
-AMREX_HOME ?= ../../
+AMREX_HOME = ../../
 
 DEBUG   = FALSE
 #DEBUG   = TRUE

--- a/Tests/GPU/CudaGraphs/BuildingGraphs/GNUmakefile
+++ b/Tests/GPU/CudaGraphs/BuildingGraphs/GNUmakefile
@@ -1,4 +1,4 @@
-AMREX_HOME ?= ../../../..
+AMREX_HOME = ../../../..
 
 DEBUG	= FALSE
 #DEBUG	= TRUE

--- a/Tests/GPU/CudaGraphs/GraphBoundary/GNUmakefile
+++ b/Tests/GPU/CudaGraphs/GraphBoundary/GNUmakefile
@@ -1,4 +1,4 @@
-AMREX_HOME ?= ../../../..
+AMREX_HOME = ../../../..
 
 DEBUG	= FALSE
 #DEBUG	= TRUE

--- a/Tests/GPU/CudaGraphs/GraphInitTest/GNUmakefile
+++ b/Tests/GPU/CudaGraphs/GraphInitTest/GNUmakefile
@@ -1,4 +1,4 @@
-AMREX_HOME ?= ../../../..
+AMREX_HOME = ../../../..
 
 DEBUG	= FALSE
 #DEBUG	= TRUE

--- a/Tests/GPU/CudaGraphs/GraphReuseCopy/GNUmakefile
+++ b/Tests/GPU/CudaGraphs/GraphReuseCopy/GNUmakefile
@@ -1,4 +1,4 @@
-AMREX_HOME ?= ../../../..
+AMREX_HOME = ../../../..
 
 DEBUG	= FALSE
 #DEBUG	= TRUE

--- a/Tests/GPU/CudaGraphs/GraphWithMemcpy/GNUmakefile
+++ b/Tests/GPU/CudaGraphs/GraphWithMemcpy/GNUmakefile
@@ -1,4 +1,4 @@
-AMREX_HOME ?= ../../../..
+AMREX_HOME = ../../../..
 
 DEBUG	= FALSE
 #DEBUG	= TRUE

--- a/Tests/GPU/CuptiTest/Exec/CUDA/GNUmakefile
+++ b/Tests/GPU/CuptiTest/Exec/CUDA/GNUmakefile
@@ -1,6 +1,5 @@
 # AMREX_HOME defines the directory in which we will find all the AMReX code.
-# If you set AMREX_HOME as an environment variable, this line will be ignored
-AMREX_HOME ?= ../../../../../
+AMREX_HOME = ../../../../../
 
 DEBUG     = FALSE
 USE_MPI   = TRUE 

--- a/Tests/GPU/Fuse/GNUmakefile
+++ b/Tests/GPU/Fuse/GNUmakefile
@@ -1,4 +1,4 @@
-AMREX_HOME ?= ../../..
+AMREX_HOME = ../../..
 
 DEBUG	= TRUE
 DEBUG	= FALSE

--- a/Tests/GPU/Locking/GNUmakefile
+++ b/Tests/GPU/Locking/GNUmakefile
@@ -1,4 +1,4 @@
-AMREX_HOME ?= ../../../
+AMREX_HOME = ../../../
 
 DEBUG	= FALSE
 

--- a/Tests/GPU/RandomNumberGeneration/GNUmakefile
+++ b/Tests/GPU/RandomNumberGeneration/GNUmakefile
@@ -1,4 +1,4 @@
-AMREX_HOME ?= ../../../
+AMREX_HOME = ../../../
 
 DEBUG	= FALSE
 

--- a/Tests/GPU/Vector/GNUmakefile
+++ b/Tests/GPU/Vector/GNUmakefile
@@ -1,4 +1,4 @@
-AMREX_HOME ?= ../../../
+AMREX_HOME = ../../../
 
 DEBUG	= FALSE
 

--- a/Tests/GPU/libamrex_CUDA/GNUmakefile
+++ b/Tests/GPU/libamrex_CUDA/GNUmakefile
@@ -1,4 +1,4 @@
-AMREX_INSTALL_DIR = ../../../tmp_install_dir
+AMREX_INSTALL_DIR = ?../../../tmp_install_dir
 CUDA_ARCH ?= 60
 
 CXX = nvcc

--- a/Tests/GPU/libamrex_CUDA/GNUmakefile
+++ b/Tests/GPU/libamrex_CUDA/GNUmakefile
@@ -1,4 +1,4 @@
-AMREX_INSTALL_DIR ?= ../../../tmp_install_dir
+AMREX_INSTALL_DIR = ../../../tmp_install_dir
 CUDA_ARCH ?= 60
 
 CXX = nvcc

--- a/Tests/HDF5Benchmark/GNUmakefile
+++ b/Tests/HDF5Benchmark/GNUmakefile
@@ -1,4 +1,4 @@
-AMREX_HOME ?= ../../
+AMREX_HOME = ../../
 
 DEBUG	= TRUE
 DEBUG	= FALSE

--- a/Tests/LinearSolvers/CellEB/GNUmakefile
+++ b/Tests/LinearSolvers/CellEB/GNUmakefile
@@ -15,7 +15,7 @@ COMP = gnu
 
 DIM = 2
 
-AMREX_HOME ?= ../../..
+AMREX_HOME = ../../..
 
 include $(AMREX_HOME)/Tools/GNUMake/Make.defs
 include ./Make.package

--- a/Tests/LinearSolvers/CellEB2/GNUmakefile
+++ b/Tests/LinearSolvers/CellEB2/GNUmakefile
@@ -14,7 +14,7 @@ COMP = gnu
 
 DIM = 2
 
-AMREX_HOME ?= ../../..
+AMREX_HOME = ../../..
 
 include $(AMREX_HOME)/Tools/GNUMake/Make.defs
 

--- a/Tests/LinearSolvers/CellOverset/GNUmakefile
+++ b/Tests/LinearSolvers/CellOverset/GNUmakefile
@@ -18,7 +18,7 @@ COMP = gnu
 
 DIM = 2
 
-AMREX_HOME ?= ../../..
+AMREX_HOME = ../../..
 
 include $(AMREX_HOME)/Tools/GNUMake/Make.defs
 include ./Make.package

--- a/Tests/LinearSolvers/EBConvergenceTest/GNUmakefile
+++ b/Tests/LinearSolvers/EBConvergenceTest/GNUmakefile
@@ -13,7 +13,7 @@ COMP = gnu
 
 DIM = 2
 
-AMREX_HOME ?= ../../..
+AMREX_HOME = ../../..
 
 include $(AMREX_HOME)/Tools/GNUMake/Make.defs
 

--- a/Tests/LinearSolvers/EBTensor/GNUmakefile
+++ b/Tests/LinearSolvers/EBTensor/GNUmakefile
@@ -13,7 +13,7 @@ COMP = gnu
 
 DIM = 3
 
-AMREX_HOME ?= ../../..
+AMREX_HOME = ../../..
 
 include $(AMREX_HOME)/Tools/GNUMake/Make.defs
 

--- a/Tests/LinearSolvers/EBflux_grad/GNUmakefile
+++ b/Tests/LinearSolvers/EBflux_grad/GNUmakefile
@@ -13,7 +13,7 @@ COMP = gnu
 
 DIM = 2
 
-AMREX_HOME ?= ../../..
+AMREX_HOME = ../../..
 
 include $(AMREX_HOME)/Tools/GNUMake/Make.defs
 

--- a/Tests/LinearSolvers/MLMG/GNUmakefile
+++ b/Tests/LinearSolvers/MLMG/GNUmakefile
@@ -1,4 +1,4 @@
-AMREX_HOME ?= ../../../
+AMREX_HOME = ../../../
 
 DEBUG	?= FALSE
 DIM	?= 3

--- a/Tests/LinearSolvers/NodalOverset/GNUmakefile
+++ b/Tests/LinearSolvers/NodalOverset/GNUmakefile
@@ -16,7 +16,7 @@ COMP = gnu
 
 DIM = 2
 
-AMREX_HOME ?= ../../..
+AMREX_HOME = ../../..
 
 include $(AMREX_HOME)/Tools/GNUMake/Make.defs
 include ./Make.package

--- a/Tests/LinearSolvers/NodeEB/GNUmakefile
+++ b/Tests/LinearSolvers/NodeEB/GNUmakefile
@@ -16,7 +16,7 @@ COMP = gnu
 
 DIM = 3
 
-AMREX_HOME ?= ../../..
+AMREX_HOME = ../../..
 
 include $(AMREX_HOME)/Tools/GNUMake/Make.defs
 include ./Make.package

--- a/Tests/LinearSolvers/TensorOverset/GNUmakefile
+++ b/Tests/LinearSolvers/TensorOverset/GNUmakefile
@@ -18,7 +18,7 @@ COMP = gnu
 
 DIM = 3
 
-AMREX_HOME ?= ../../..
+AMREX_HOME = ../../..
 
 include $(AMREX_HOME)/Tools/GNUMake/Make.defs
 include ./Make.package

--- a/Tests/MKDir/GNUmakefile
+++ b/Tests/MKDir/GNUmakefile
@@ -1,4 +1,4 @@
-AMREX_HOME ?= ../../../amrex
+AMREX_HOME = ../../../amrex
 
 DEBUG        = FALSE
 USE_MPI      = TRUE

--- a/Tests/NoFort/GNUmakefile
+++ b/Tests/NoFort/GNUmakefile
@@ -1,4 +1,4 @@
-AMREX_HOME ?= ../../
+AMREX_HOME = ../../
 
 DEBUG	= FALSE
 DEBUG	= TRUE

--- a/Tests/Particles/AssignDensity/GNUmakefile
+++ b/Tests/Particles/AssignDensity/GNUmakefile
@@ -1,4 +1,4 @@
-AMREX_HOME ?= ../../../
+AMREX_HOME = ../../../
 
 DEBUG	= TRUE
 DEBUG	= FALSE

--- a/Tests/Particles/AssignMultiLevelDensity/GNUmakefile
+++ b/Tests/Particles/AssignMultiLevelDensity/GNUmakefile
@@ -1,4 +1,4 @@
-AMREX_HOME ?= ../../../
+AMREX_HOME = ../../../
 
 DEBUG	= TRUE
 DEBUG	= FALSE

--- a/Tests/Particles/AsyncIO/GNUmakefile
+++ b/Tests/Particles/AsyncIO/GNUmakefile
@@ -1,4 +1,4 @@
-AMREX_HOME ?= ../../../
+AMREX_HOME = ../../../
 
 DEBUG	= TRUE
 DEBUG	= FALSE

--- a/Tests/Particles/GNUmakefile
+++ b/Tests/Particles/GNUmakefile
@@ -1,4 +1,4 @@
-AMREX_HOME ?= ../../
+AMREX_HOME = ../../
 
 DEBUG	= TRUE
 DEBUG	= FALSE

--- a/Tests/Particles/GhostsAndVirtuals/GNUmakefile
+++ b/Tests/Particles/GhostsAndVirtuals/GNUmakefile
@@ -1,4 +1,4 @@
-AMREX_HOME ?= ../../../
+AMREX_HOME = ../../../
 
 DEBUG	= TRUE
 DEBUG	= FALSE

--- a/Tests/Particles/InitFromAscii/GNUmakefile
+++ b/Tests/Particles/InitFromAscii/GNUmakefile
@@ -1,4 +1,4 @@
-AMREX_HOME ?= ../../../
+AMREX_HOME = ../../../
 
 DEBUG	= TRUE
 DEBUG	= FALSE

--- a/Tests/Particles/Intersection/GNUmakefile
+++ b/Tests/Particles/Intersection/GNUmakefile
@@ -1,4 +1,4 @@
-AMREX_HOME ?= ../../../
+AMREX_HOME = ../../../
 
 DEBUG	= TRUE
 DEBUG	= FALSE

--- a/Tests/Particles/NeighborParticles/GNUmakefile
+++ b/Tests/Particles/NeighborParticles/GNUmakefile
@@ -1,4 +1,4 @@
-AMREX_HOME ?= ../../../
+AMREX_HOME = ../../../
 
 DEBUG	= FALSE
 

--- a/Tests/Particles/ParallelContext/GNUmakefile
+++ b/Tests/Particles/ParallelContext/GNUmakefile
@@ -1,4 +1,4 @@
-AMREX_HOME ?= ../../../
+AMREX_HOME = ../../../
 
 DEBUG	= FALSE
 

--- a/Tests/Particles/ParticleIterator/GNUmakefile
+++ b/Tests/Particles/ParticleIterator/GNUmakefile
@@ -1,4 +1,4 @@
-AMREX_HOME ?= ../../../
+AMREX_HOME = ../../../
 
 DEBUG	= TRUE
 DEBUG	= FALSE

--- a/Tests/Particles/ParticleMesh/GNUmakefile
+++ b/Tests/Particles/ParticleMesh/GNUmakefile
@@ -1,4 +1,4 @@
-AMREX_HOME ?= ../../../
+AMREX_HOME = ../../../
 
 DEBUG	= TRUE
 DEBUG	= FALSE

--- a/Tests/Particles/ParticleReduce/GNUmakefile
+++ b/Tests/Particles/ParticleReduce/GNUmakefile
@@ -1,4 +1,4 @@
-AMREX_HOME ?= ../../../
+AMREX_HOME = ../../../
 
 DEBUG	= FALSE
 

--- a/Tests/Particles/ParticleTransformations/GNUmakefile
+++ b/Tests/Particles/ParticleTransformations/GNUmakefile
@@ -1,4 +1,4 @@
-AMREX_HOME ?= ../../../
+AMREX_HOME = ../../../
 
 DEBUG	= FALSE
 

--- a/Tests/Particles/Redistribute/GNUmakefile
+++ b/Tests/Particles/Redistribute/GNUmakefile
@@ -1,4 +1,4 @@
-AMREX_HOME ?= ../../../
+AMREX_HOME = ../../../
 
 DEBUG	= FALSE
 

--- a/Tests/Particles/SparseBins/GNUmakefile
+++ b/Tests/Particles/SparseBins/GNUmakefile
@@ -1,4 +1,4 @@
-AMREX_HOME ?= ../../../
+AMREX_HOME = ../../../
 
 DEBUG	= TRUE
 DEBUG	= FALSE

--- a/Tests/Particles/TypeDescriptor/GNUmakefile
+++ b/Tests/Particles/TypeDescriptor/GNUmakefile
@@ -1,4 +1,4 @@
-AMREX_HOME ?= ../../../
+AMREX_HOME = ../../../
 
 DEBUG	= TRUE
 DEBUG	= FALSE

--- a/Tests/PnetCDFBenchmark/GNUmakefile
+++ b/Tests/PnetCDFBenchmark/GNUmakefile
@@ -1,4 +1,4 @@
-AMREX_HOME ?= ../../
+AMREX_HOME = ../../
 
 DEBUG	= TRUE
 DEBUG	= FALSE

--- a/Tests/ProfTests/HeatEquation_EX1_C/Exec/GNUmakefile
+++ b/Tests/ProfTests/HeatEquation_EX1_C/Exec/GNUmakefile
@@ -1,6 +1,5 @@
 # AMREX_HOME defines the directory in which we will find all the AMReX code.
-# If you set AMREX_HOME as an environment variable, this line will be ignored
-AMREX_HOME ?= ../../../../
+AMREX_HOME = ../../../../
 
 DEBUG         = FALSE
 USE_MPI       = TRUE

--- a/Tests/ProfTests/ThirdParty/Exec/GNUmakefile
+++ b/Tests/ProfTests/ThirdParty/Exec/GNUmakefile
@@ -1,6 +1,5 @@
 # AMREX_HOME defines the directory in which we will find all the AMReX code.
-# If you set AMREX_HOME as an environment variable, this line will be ignored
-AMREX_HOME ?= ../../../..
+AMREX_HOME = ../../../..
 
 DEBUG     = FALSE
 USE_MPI   = TRUE 

--- a/Tests/SinglePrecision/GNUmakefile
+++ b/Tests/SinglePrecision/GNUmakefile
@@ -1,4 +1,4 @@
-AMREX_HOME ?= ../../
+AMREX_HOME = ../../
 
 PRECISION = FLOAT
 

--- a/Tests/Slice/GNUmakefile
+++ b/Tests/Slice/GNUmakefile
@@ -1,4 +1,4 @@
-AMREX_HOME ?= ../../
+AMREX_HOME = ../../
 
 DEBUG	= FALSE
 DEBUG	= TRUE

--- a/Tests/Stream/GNUmakefile
+++ b/Tests/Stream/GNUmakefile
@@ -1,4 +1,4 @@
-AMREX_HOME ?= ../../../
+AMREX_HOME = ../../../
 
 DEBUG     = FALSE
 USE_MPI   = TRUE

--- a/Tests/TypeCheck/GNUmakefile
+++ b/Tests/TypeCheck/GNUmakefile
@@ -1,4 +1,4 @@
-AMREX_HOME ?= ../../
+AMREX_HOME = ../../
 
 DEBUG	= FALSE
 DEBUG	= TRUE

--- a/Tests/Vectorization/GNUmakefile
+++ b/Tests/Vectorization/GNUmakefile
@@ -1,4 +1,4 @@
-AMREX_HOME ?= ../../
+AMREX_HOME = ../../
 
 DEBUG	= FALSE
 

--- a/Tests/complementIn/GNUmakefile
+++ b/Tests/complementIn/GNUmakefile
@@ -1,4 +1,4 @@
-AMREX_HOME ?= ../../
+AMREX_HOME = ../../
 
 DEBUG	= FALSE
 

--- a/Tutorials/Amr/Advection_AmrCore/Exec/SingleVortex/GNUmakefile
+++ b/Tutorials/Amr/Advection_AmrCore/Exec/SingleVortex/GNUmakefile
@@ -1,4 +1,4 @@
-AMREX_HOME ?= ../../../../..
+AMREX_HOME = ../../../../..
 
 PRECISION  = DOUBLE
 PROFILE    = FALSE

--- a/Tutorials/Amr/Advection_AmrLevel/Exec/SingleVortex/GNUmakefile
+++ b/Tutorials/Amr/Advection_AmrLevel/Exec/SingleVortex/GNUmakefile
@@ -1,4 +1,4 @@
-AMREX_HOME ?= ../../../../..
+AMREX_HOME = ../../../../..
 USE_EB = FALSE
 PRECISION  = DOUBLE
 PROFILE    = FALSE

--- a/Tutorials/Amr/Advection_AmrLevel/Exec/UniformVelocity/GNUmakefile
+++ b/Tutorials/Amr/Advection_AmrLevel/Exec/UniformVelocity/GNUmakefile
@@ -1,4 +1,4 @@
-AMREX_HOME ?= ../../../../..
+AMREX_HOME = ../../../../..
 USE_EB =FALSE
 PRECISION  = DOUBLE
 PROFILE    = FALSE

--- a/Tutorials/Amr/Advection_AmrLevel/Source/Src_2d/Adv_2d.f90
+++ b/Tutorials/Amr/Advection_AmrLevel/Source/Src_2d/Adv_2d.f90
@@ -51,7 +51,7 @@ subroutine advect(time, lo, hi, &
   ! We like to allocate these **pointers** here and then pass them to a function
   ! to remove their pointerness for performance, because normally pointers could
   ! be aliasing.  We need to use pointers instead of allocatable arrays because
-  ! we like to use BoxLib's bl_allocate to allocate memeory instead of the intrinsic
+  ! we like to use AMReX's bl_allocate to allocate memeory instead of the intrinsic
   ! allocate.  Bl_allocate is much faster than allocate inside OMP.  
   ! Note that one MUST CALL BL_DEALLOCATE.
 

--- a/Tutorials/Amr/Advection_AmrLevel/Source/Src_3d/Adv_3d.f90
+++ b/Tutorials/Amr/Advection_AmrLevel/Source/Src_3d/Adv_3d.f90
@@ -63,7 +63,7 @@ subroutine advect(time, lo, hi, &
   ! We like to allocate these **pointers** here and then pass them to a function
   ! to remove their pointerness for performance, because normally pointers could
   ! be aliasing.  We need to use pointers instead of allocatable arrays because
-  ! we like to use BoxLib's bl_allocate to allocate memeory instead of the intrinsic
+  ! we like to use AMReX's bl_allocate to allocate memeory instead of the intrinsic
   ! allocate.  Bl_allocate is much faster than allocate inside OMP.  
   ! Note that one MUST CALL BL_DEALLOCATE.
 

--- a/Tutorials/AmrTask/MiniApps/Adv_Async_OnDemand/Exec/SingleVortex/GNUmakefile
+++ b/Tutorials/AmrTask/MiniApps/Adv_Async_OnDemand/Exec/SingleVortex/GNUmakefile
@@ -1,4 +1,4 @@
-AMREX_HOME ?= ../../../../../../
+AMREX_HOME = ../../../../../../
 
 PRECISION  = DOUBLE
 PROFILE    = FALSE

--- a/Tutorials/AmrTask/MiniApps/Adv_Async_OnDemand/Exec/UniformVelocity/GNUmakefile
+++ b/Tutorials/AmrTask/MiniApps/Adv_Async_OnDemand/Exec/UniformVelocity/GNUmakefile
@@ -1,4 +1,4 @@
-BOXLIB_HOME ?= ../../../..
+AMREX_HOME = ../../../..
 
 PRECISION  = DOUBLE
 PROFILE    = FALSE

--- a/Tutorials/AmrTask/MiniApps/Adv_Async_OnDemand/README
+++ b/Tutorials/AmrTask/MiniApps/Adv_Async_OnDemand/README
@@ -1,7 +1,7 @@
 AMR_Adv_C: This code advects a single scalar field with a velocity
 field that is specified on faces.
 
-It is a BoxLib based code designed to run in parallel using MPI/OMP.
+It is a AMReX-based code designed to run in parallel using MPI/OMP.
 
 The directory Exec/SingleVortex includes a makefile and a sample inputs file.  
 Plotfiles are generated that can be viewed with amrvis2d / amrvis3d. 

--- a/Tutorials/AmrTask/MiniApps/Adv_Async_OnDemand/Source/Src_2d/Adv_2d.f90
+++ b/Tutorials/AmrTask/MiniApps/Adv_Async_OnDemand/Source/Src_2d/Adv_2d.f90
@@ -51,7 +51,7 @@ subroutine advect(time, lo, hi, &
   ! We like to allocate these **pointers** here and then pass them to a function
   ! to remove their pointerness for performance, because normally pointers could
   ! be aliasing.  We need to use pointers instead of allocatable arrays because
-  ! we like to use BoxLib's bl_allocate to allocate memeory instead of the intrinsic
+  ! we like to use AMReX's bl_allocate to allocate memeory instead of the intrinsic
   ! allocate.  Bl_allocate is much faster than allocate inside OMP.  
   ! Note that one MUST CALL BL_DEALLOCATE.
 

--- a/Tutorials/AmrTask/MiniApps/Adv_Async_OnDemand/Source/Src_3d/Adv_3d.f90
+++ b/Tutorials/AmrTask/MiniApps/Adv_Async_OnDemand/Source/Src_3d/Adv_3d.f90
@@ -64,7 +64,7 @@ subroutine advect(time, lo, hi, &
   ! We like to allocate these **pointers** here and then pass them to a function
   ! to remove their pointerness for performance, because normally pointers could
   ! be aliasing.  We need to use pointers instead of allocatable arrays because
-  ! we like to use BoxLib's bl_allocate to allocate memeory instead of the intrinsic
+  ! we like to use AMReX's bl_allocate to allocate memeory instead of the intrinsic
   ! allocate.  Bl_allocate is much faster than allocate inside OMP.  
   ! Note that one MUST CALL BL_DEALLOCATE.
 

--- a/Tutorials/AmrTask/MiniApps/Adv_phaseAsync/Exec/SingleVortex/GNUmakefile
+++ b/Tutorials/AmrTask/MiniApps/Adv_phaseAsync/Exec/SingleVortex/GNUmakefile
@@ -1,4 +1,4 @@
-AMREX_HOME ?= ../../../../../../
+AMREX_HOME = ../../../../../../
 
 PRECISION  = DOUBLE
 PROFILE    = FALSE

--- a/Tutorials/AmrTask/MiniApps/Adv_phaseAsync/Exec/UniformVelocity/GNUmakefile
+++ b/Tutorials/AmrTask/MiniApps/Adv_phaseAsync/Exec/UniformVelocity/GNUmakefile
@@ -1,4 +1,4 @@
-BOXLIB_HOME ?= ../../../..
+AMREX_HOME = ../../../..
 
 PRECISION  = DOUBLE
 PROFILE    = FALSE

--- a/Tutorials/AmrTask/MiniApps/Adv_phaseAsync/README
+++ b/Tutorials/AmrTask/MiniApps/Adv_phaseAsync/README
@@ -1,7 +1,7 @@
 AMR_Adv_C: This code advects a single scalar field with a velocity
 field that is specified on faces.
 
-It is a BoxLib based code designed to run in parallel using MPI/OMP.
+It is a AMReX-based code designed to run in parallel using MPI/OMP.
 
 The directory Exec/SingleVortex includes a makefile and a sample inputs file.  
 Plotfiles are generated that can be viewed with amrvis2d / amrvis3d. 

--- a/Tutorials/AmrTask/MiniApps/Adv_phaseAsync/Source/Src_2d/Adv_2d.f90
+++ b/Tutorials/AmrTask/MiniApps/Adv_phaseAsync/Source/Src_2d/Adv_2d.f90
@@ -51,7 +51,7 @@ subroutine advect(time, lo, hi, &
   ! We like to allocate these **pointers** here and then pass them to a function
   ! to remove their pointerness for performance, because normally pointers could
   ! be aliasing.  We need to use pointers instead of allocatable arrays because
-  ! we like to use BoxLib's bl_allocate to allocate memeory instead of the intrinsic
+  ! we like to use AMReX's bl_allocate to allocate memeory instead of the intrinsic
   ! allocate.  Bl_allocate is much faster than allocate inside OMP.  
   ! Note that one MUST CALL BL_DEALLOCATE.
 

--- a/Tutorials/AmrTask/MiniApps/Adv_phaseAsync/Source/Src_3d/Adv_3d.f90
+++ b/Tutorials/AmrTask/MiniApps/Adv_phaseAsync/Source/Src_3d/Adv_3d.f90
@@ -64,7 +64,7 @@ subroutine advect(time, lo, hi, &
   ! We like to allocate these **pointers** here and then pass them to a function
   ! to remove their pointerness for performance, because normally pointers could
   ! be aliasing.  We need to use pointers instead of allocatable arrays because
-  ! we like to use BoxLib's bl_allocate to allocate memeory instead of the intrinsic
+  ! we like to use AMReX's bl_allocate to allocate memeory instead of the intrinsic
   ! allocate.  Bl_allocate is much faster than allocate inside OMP.  
   ! Note that one MUST CALL BL_DEALLOCATE.
 

--- a/Tutorials/AmrTask/MiniApps/Adv_phaseAsync_rgi/Exec/SingleVortex/GNUmakefile
+++ b/Tutorials/AmrTask/MiniApps/Adv_phaseAsync_rgi/Exec/SingleVortex/GNUmakefile
@@ -1,4 +1,4 @@
-AMREX_HOME ?= ../../../../../../
+AMREX_HOME = ../../../../../../
 
 PRECISION  = DOUBLE
 PROFILE    = FALSE

--- a/Tutorials/AmrTask/MiniApps/Adv_phaseAsync_rgi/Exec/UniformVelocity/GNUmakefile
+++ b/Tutorials/AmrTask/MiniApps/Adv_phaseAsync_rgi/Exec/UniformVelocity/GNUmakefile
@@ -1,4 +1,4 @@
-BOXLIB_HOME ?= ../../../..
+AMREX_HOME = ../../../..
 
 PRECISION  = DOUBLE
 PROFILE    = FALSE

--- a/Tutorials/AmrTask/MiniApps/Adv_phaseAsync_rgi/README
+++ b/Tutorials/AmrTask/MiniApps/Adv_phaseAsync_rgi/README
@@ -1,7 +1,7 @@
 AMR_Adv_C: This code advects a single scalar field with a velocity
 field that is specified on faces.
 
-It is a BoxLib based code designed to run in parallel using MPI/OMP.
+It is a AMReX-based code designed to run in parallel using MPI/OMP.
 
 The directory Exec/SingleVortex includes a makefile and a sample inputs file.  
 Plotfiles are generated that can be viewed with amrvis2d / amrvis3d. 

--- a/Tutorials/AmrTask/MiniApps/Adv_phaseAsync_rgi/Source/Src_2d/Adv_2d.f90
+++ b/Tutorials/AmrTask/MiniApps/Adv_phaseAsync_rgi/Source/Src_2d/Adv_2d.f90
@@ -51,7 +51,7 @@ subroutine advect(time, lo, hi, &
   ! We like to allocate these **pointers** here and then pass them to a function
   ! to remove their pointerness for performance, because normally pointers could
   ! be aliasing.  We need to use pointers instead of allocatable arrays because
-  ! we like to use BoxLib's bl_allocate to allocate memeory instead of the intrinsic
+  ! we like to use AMReX's bl_allocate to allocate memeory instead of the intrinsic
   ! allocate.  Bl_allocate is much faster than allocate inside OMP.  
   ! Note that one MUST CALL BL_DEALLOCATE.
 

--- a/Tutorials/AmrTask/MiniApps/Adv_phaseAsync_rgi/Source/Src_3d/Adv_3d.f90
+++ b/Tutorials/AmrTask/MiniApps/Adv_phaseAsync_rgi/Source/Src_3d/Adv_3d.f90
@@ -64,7 +64,7 @@ subroutine advect(time, lo, hi, &
   ! We like to allocate these **pointers** here and then pass them to a function
   ! to remove their pointerness for performance, because normally pointers could
   ! be aliasing.  We need to use pointers instead of allocatable arrays because
-  ! we like to use BoxLib's bl_allocate to allocate memeory instead of the intrinsic
+  ! we like to use AMReX's bl_allocate to allocate memeory instead of the intrinsic
   ! allocate.  Bl_allocate is much faster than allocate inside OMP.  
   ! Note that one MUST CALL BL_DEALLOCATE.
 

--- a/Tutorials/Basic/Build_with_libamrex/GNUmakefile
+++ b/Tutorials/Basic/Build_with_libamrex/GNUmakefile
@@ -1,4 +1,4 @@
-AMREX_INSTALL_DIR = ../../../tmp_install_dir
+AMREX_INSTALL_DIR ?= ../../../tmp_install_dir
 
 #CXX = CC
 #FC = ftn

--- a/Tutorials/Basic/Build_with_libamrex/GNUmakefile
+++ b/Tutorials/Basic/Build_with_libamrex/GNUmakefile
@@ -1,4 +1,4 @@
-AMREX_INSTALL_DIR ?= ../../../tmp_install_dir
+AMREX_INSTALL_DIR = ../../../tmp_install_dir
 
 #CXX = CC
 #FC = ftn

--- a/Tutorials/Basic/HeatEquation_EX1_C/Exec/GNUmakefile
+++ b/Tutorials/Basic/HeatEquation_EX1_C/Exec/GNUmakefile
@@ -1,6 +1,5 @@
 # AMREX_HOME defines the directory in which we will find all the AMReX code.
-# If you set AMREX_HOME as an environment variable, this line will be ignored
-AMREX_HOME ?= ../../../../
+AMREX_HOME = ../../../../
 
 DEBUG        = FALSE
 USE_MPI      = FALSE

--- a/Tutorials/Basic/HeatEquation_EX1_CF/Exec/GNUmakefile
+++ b/Tutorials/Basic/HeatEquation_EX1_CF/Exec/GNUmakefile
@@ -1,6 +1,5 @@
 # AMREX_HOME defines the directory in which we will find all the AMReX code.
-# If you set AMREX_HOME as an environment variable, this line will be ignored
-AMREX_HOME ?= ../../../../
+AMREX_HOME = ../../../../
 
 DEBUG     = FALSE
 USE_MPI   = FALSE

--- a/Tutorials/Basic/HeatEquation_EX1_F/GNUmakefile
+++ b/Tutorials/Basic/HeatEquation_EX1_F/GNUmakefile
@@ -1,6 +1,5 @@
 # AMREX_HOME defines the directory in which we will find all the AMReX code
-# If you set AMREX_HOME as an environment variable, this line will be ignored
-AMREX_HOME ?= ../../..
+AMREX_HOME = ../../..
 
 DEBUG     = TRUE
 

--- a/Tutorials/Basic/HeatEquation_EX1_F/inputs
+++ b/Tutorials/Basic/HeatEquation_EX1_F/inputs
@@ -13,5 +13,5 @@ geometry.coord_sys = 0
 geometry.prob_lo = -1.0  -1.0  -1.0
 geometry.prob_hi =  1.0   1.0   1.0
 
-# Periodic? Default in BoxLib is set to 0 (no).
+# Periodic? Default in AMReX is set to 0 (no).
 geometry.is_periodic = 1  1  1

--- a/Tutorials/Basic/HeatEquation_EX2_C/Exec/GNUmakefile
+++ b/Tutorials/Basic/HeatEquation_EX2_C/Exec/GNUmakefile
@@ -1,6 +1,5 @@
 # AMREX_HOME defines the directory in which we will find all the AMReX code.
-# If you set AMREX_HOME as an environment variable, this line will be ignored
-AMREX_HOME ?= ../../../../
+AMREX_HOME = ../../../../
 
 DEBUG     = FALSE
 USE_MPI   = TRUE 

--- a/Tutorials/Basic/HeatEquation_EX2_CF/Exec/GNUmakefile
+++ b/Tutorials/Basic/HeatEquation_EX2_CF/Exec/GNUmakefile
@@ -1,6 +1,5 @@
 # AMREX_HOME defines the directory in which we will find all the AMReX code.
-# If you set AMREX_HOME as an environment variable, this line will be ignored
-AMREX_HOME ?= ../../../../
+AMREX_HOME = ../../../../
 
 DEBUG     = FALSE
 USE_MPI   = FALSE

--- a/Tutorials/Basic/HeatEquation_EX3_C/Exec/GNUmakefile
+++ b/Tutorials/Basic/HeatEquation_EX3_C/Exec/GNUmakefile
@@ -1,6 +1,5 @@
 # AMREX_HOME defines the directory in which we will find all the AMReX code.
-# If you set AMREX_HOME as an environment variable, this line will be ignored
-AMREX_HOME ?= ../../../../
+AMREX_HOME = ../../../../
 
 DEBUG     = FALSE
 USE_MPI   = FALSE

--- a/Tutorials/Basic/HelloWorld_C/GNUmakefile
+++ b/Tutorials/Basic/HelloWorld_C/GNUmakefile
@@ -1,4 +1,4 @@
-AMREX_HOME ?= ../../../
+AMREX_HOME = ../../../
 
 DEBUG	= FALSE
 DEBUG	= TRUE

--- a/Tutorials/Basic/HelloWorld_F/GNUmakefile
+++ b/Tutorials/Basic/HelloWorld_F/GNUmakefile
@@ -1,4 +1,4 @@
-AMREX_HOME ?= ../../../
+AMREX_HOME = ../../../
 
 DEBUG	= FALSE
 DEBUG	= TRUE

--- a/Tutorials/Basic/PrefixSum_MultiFab/GNUmakefile
+++ b/Tutorials/Basic/PrefixSum_MultiFab/GNUmakefile
@@ -1,6 +1,5 @@
 # AMREX_HOME defines the directory in which we will find all the AMReX code.
-# If you set AMREX_HOME as an environment variable, this line will be ignored
-AMREX_HOME ?= ../../../
+AMREX_HOME = ../../../
 
 DEBUG     = FALSE
 USE_MPI   = TRUE

--- a/Tutorials/Basic/main_C/GNUmakefile
+++ b/Tutorials/Basic/main_C/GNUmakefile
@@ -1,4 +1,4 @@
-AMREX_HOME ?= ../../../
+AMREX_HOME = ../../../
 
 DEBUG	= FALSE
 DEBUG	= TRUE

--- a/Tutorials/Basic/main_F/GNUmakefile
+++ b/Tutorials/Basic/main_F/GNUmakefile
@@ -1,4 +1,4 @@
-AMREX_HOME ?= ../../../
+AMREX_HOME = ../../../
 
 DEBUG	= FALSE
 DEBUG	= TRUE

--- a/Tutorials/Blueprint/AssignMultiLevelDensity/GNUmakefile
+++ b/Tutorials/Blueprint/AssignMultiLevelDensity/GNUmakefile
@@ -1,4 +1,4 @@
-AMREX_HOME ?= ../../../
+AMREX_HOME = ../../../
 
 #
 # This example requires installs of:

--- a/Tutorials/Blueprint/CellSortedParticles/GNUmakefile
+++ b/Tutorials/Blueprint/CellSortedParticles/GNUmakefile
@@ -1,4 +1,4 @@
-AMREX_HOME ?= ../../../
+AMREX_HOME = ../../../
 
 DEBUG	= TRUE
 DEBUG	= FALSE

--- a/Tutorials/Blueprint/HeatEquation_EX1_C/Exec/GNUmakefile
+++ b/Tutorials/Blueprint/HeatEquation_EX1_C/Exec/GNUmakefile
@@ -1,6 +1,5 @@
 # AMREX_HOME defines the directory in which we will find all the AMReX code.
-# If you set AMREX_HOME as an environment variable, this line will be ignored
-AMREX_HOME ?= ../../../../
+AMREX_HOME = ../../../../
 
 #
 # This example requires installs of:

--- a/Tutorials/CVODE/SUNDIALS2_finterface/EX1/GNUmakefile
+++ b/Tutorials/CVODE/SUNDIALS2_finterface/EX1/GNUmakefile
@@ -1,6 +1,5 @@
-# AMREX_HOME defines the directory in which we will find all the BoxLib code
-# If you set AMREX_HOME as an environment variable, this line will be ignored
-AMREX_HOME ?= ../..
+# AMREX_HOME defines the directory in which we will find all the AMReX code
+AMREX_HOME = ../..
 
 DEBUG     = FALSE
 USE_MPI   = TRUE

--- a/Tutorials/CVODE/SUNDIALS2_finterface/EX2/GNUmakefile
+++ b/Tutorials/CVODE/SUNDIALS2_finterface/EX2/GNUmakefile
@@ -1,6 +1,5 @@
-# AMREX_HOME defines the directory in which we will find all the BoxLib code
-# If you set AMREX_HOME as an environment variable, this line will be ignored
-AMREX_HOME ?= ../..
+# AMREX_HOME defines the directory in which we will find all the AMReX code
+AMREX_HOME = ../..
 
 DEBUG     = FALSE
 USE_MPI   = TRUE

--- a/Tutorials/CVODE/SUNDIALS3_cppversion/EX1_CUDA_NVEC/GNUmakefile
+++ b/Tutorials/CVODE/SUNDIALS3_cppversion/EX1_CUDA_NVEC/GNUmakefile
@@ -1,6 +1,5 @@
-# AMREX_HOME defines the directory in which we will find all the BoxLib code
-# If you set AMREX_HOME as an environment variable, this line will be ignored
-AMREX_HOME ?= ../../../
+# AMREX_HOME defines the directory in which we will find all the AMReX code
+AMREX_HOME = ../../../
 
 DEBUG            = FALSE
 USE_MPI          = TRUE #True should also work here

--- a/Tutorials/CVODE/SUNDIALS3_cppversion/EX1_SERIAL_NVEC/GNUmakefile
+++ b/Tutorials/CVODE/SUNDIALS3_cppversion/EX1_SERIAL_NVEC/GNUmakefile
@@ -1,6 +1,5 @@
-# AMREX_HOME defines the directory in which we will find all the BoxLib code
-# If you set AMREX_HOME as an environment variable, this line will be ignored
-AMREX_HOME ?= ../../../../
+# AMREX_HOME defines the directory in which we will find all the AMReX code
+AMREX_HOME = ../../../../
 
 DEBUG            = FALSE
 USE_MPI          = TRUE #True should also work here

--- a/Tutorials/CVODE/SUNDIALS3_finterface/EX1/GNUmakefile
+++ b/Tutorials/CVODE/SUNDIALS3_finterface/EX1/GNUmakefile
@@ -1,6 +1,5 @@
-# AMREX_HOME defines the directory in which we will find all the BoxLib code
-# If you set AMREX_HOME as an environment variable, this line will be ignored
-AMREX_HOME ?= ../../../
+# AMREX_HOME defines the directory in which we will find all the AMReX code
+AMREX_HOME = ../../../
 
 DEBUG     = FALSE
 USE_MPI   = TRUE

--- a/Tutorials/CVODE/SUNDIALS3_finterface/EX_ark_analytic_fp/GNUmakefile
+++ b/Tutorials/CVODE/SUNDIALS3_finterface/EX_ark_analytic_fp/GNUmakefile
@@ -1,6 +1,5 @@
-# AMREX_HOME defines the directory in which we will find all the BoxLib code
-# If you set AMREX_HOME as an environment variable, this line will be ignored
-AMREX_HOME ?= ../../../
+# AMREX_HOME defines the directory in which we will find all the AMReX code
+AMREX_HOME = ../../../
 
 DEBUG     = FALSE
 USE_MPI   = FALSE

--- a/Tutorials/CVODE/SUNDIALS3_finterface/EX_cv_analytic_fp/GNUmakefile
+++ b/Tutorials/CVODE/SUNDIALS3_finterface/EX_cv_analytic_fp/GNUmakefile
@@ -1,6 +1,5 @@
-# AMREX_HOME defines the directory in which we will find all the BoxLib code
-# If you set AMREX_HOME as an environment variable, this line will be ignored
-AMREX_HOME ?= ../../../
+# AMREX_HOME defines the directory in which we will find all the AMReX code
+AMREX_HOME = ../../../
 
 DEBUG     = FALSE
 USE_MPI   = FALSE

--- a/Tutorials/CVODE/SUNDIALS3_finterface/EX_cv_analytic_sys_dns/GNUmakefile
+++ b/Tutorials/CVODE/SUNDIALS3_finterface/EX_cv_analytic_sys_dns/GNUmakefile
@@ -1,6 +1,5 @@
-# AMREX_HOME defines the directory in which we will find all the BoxLib code
-# If you set AMREX_HOME as an environment variable, this line will be ignored
-AMREX_HOME ?= ../../../
+# AMREX_HOME defines the directory in which we will find all the AMReX code
+AMREX_HOME = ../../../
 
 DEBUG     = FALSE
 USE_MPI   = FALSE

--- a/Tutorials/CVODE/SUNDIALS3_finterface/EX_cv_analytic_sys_dns_jac/GNUmakefile
+++ b/Tutorials/CVODE/SUNDIALS3_finterface/EX_cv_analytic_sys_dns_jac/GNUmakefile
@@ -1,6 +1,5 @@
-# AMREX_HOME defines the directory in which we will find all the BoxLib code
-# If you set AMREX_HOME as an environment variable, this line will be ignored
-AMREX_HOME ?= ../../../
+# AMREX_HOME defines the directory in which we will find all the AMReX code
+AMREX_HOME = ../../../
 
 DEBUG     = FALSE
 USE_MPI   = FALSE

--- a/Tutorials/CVODE/SUNDIALS3_finterface/EX_cv_brusselator_dns/GNUmakefile
+++ b/Tutorials/CVODE/SUNDIALS3_finterface/EX_cv_brusselator_dns/GNUmakefile
@@ -1,6 +1,5 @@
-# AMREX_HOME defines the directory in which we will find all the BoxLib code
-# If you set AMREX_HOME as an environment variable, this line will be ignored
-AMREX_HOME ?= ../../../
+# AMREX_HOME defines the directory in which we will find all the AMReX code
+AMREX_HOME = ../../../
 
 DEBUG     = FALSE
 USE_MPI   = FALSE

--- a/Tutorials/CVODE/SUNDIALS4/EX-CUSOLVER/GNUmakefile
+++ b/Tutorials/CVODE/SUNDIALS4/EX-CUSOLVER/GNUmakefile
@@ -23,7 +23,7 @@ EBASE = main
 
 EXTERN_SEARCH += .
 
-AMREX_HOME ?= ../../..
+AMREX_HOME = ../../..
 CVODE_HOME ?= ../CVODE
 CUDA_HOME  ?= /usr/local/cuda-9.2
 

--- a/Tutorials/CVODE/SUNDIALS4/EX_ark_analytic/GNUmakefile
+++ b/Tutorials/CVODE/SUNDIALS4/EX_ark_analytic/GNUmakefile
@@ -1,6 +1,5 @@
-# AMREX_HOME defines the directory in which we will find all the BoxLib code
-# If you set AMREX_HOME as an environment variable, this line will be ignored
-AMREX_HOME ?= ../../../
+# AMREX_HOME defines the directory in which we will find all the AMReX code
+AMREX_HOME = ../../../
 
 DEBUG     = FALSE
 USE_MPI   = FALSE

--- a/Tutorials/EB/GeometryGeneration/GNUmakefile
+++ b/Tutorials/EB/GeometryGeneration/GNUmakefile
@@ -11,7 +11,7 @@ COMP = gnu
 
 DIM = 3
 
-AMREX_HOME ?= ../../..
+AMREX_HOME = ../../..
 
 include $(AMREX_HOME)/Tools/GNUMake/Make.defs
 

--- a/Tutorials/EB/MacProj/GNUmakefile
+++ b/Tutorials/EB/MacProj/GNUmakefile
@@ -9,7 +9,7 @@ COMP = gnu
 
 DIM = 2
 
-AMREX_HOME ?= ../../..
+AMREX_HOME = ../../..
 
 include $(AMREX_HOME)/Tools/GNUMake/Make.defs
 

--- a/Tutorials/EB/Poisson/GNUmakefile
+++ b/Tutorials/EB/Poisson/GNUmakefile
@@ -9,7 +9,7 @@ COMP = gnu
 
 DIM = 2
 
-AMREX_HOME ?= ../../..
+AMREX_HOME = ../../..
 
 include $(AMREX_HOME)/Tools/GNUMake/Make.defs
 

--- a/Tutorials/ForkJoin/MLMG/GNUmakefile
+++ b/Tutorials/ForkJoin/MLMG/GNUmakefile
@@ -1,4 +1,4 @@
-AMREX_HOME ?= ../../..
+AMREX_HOME = ../../..
 
 DEBUG ?= TRUE
 DIM ?= 2

--- a/Tutorials/ForkJoin/Simple/GNUmakefile
+++ b/Tutorials/ForkJoin/Simple/GNUmakefile
@@ -1,4 +1,4 @@
-AMREX_HOME ?= ../../..
+AMREX_HOME = ../../..
 
 DEBUG ?= FALSE
 DIM ?= 3

--- a/Tutorials/FortranInterface/Advection_F/Source/Src_2d/advect_2d_mod.F90
+++ b/Tutorials/FortranInterface/Advection_F/Source/Src_2d/advect_2d_mod.F90
@@ -58,7 +58,7 @@ contains
     ! We like to allocate these **pointers** here and then pass them to a function
     ! to remove their pointerness for performance, because normally pointers could
     ! be aliasing.  We need to use pointers instead of allocatable arrays because
-    ! we like to use BoxLib's amrex_allocate to allocate memeory instead of the intrinsic
+    ! we like to use AMReX's amrex_allocate to allocate memeory instead of the intrinsic
     ! allocate.  Amrex_allocate is much faster than allocate inside OMP.  
     ! Note that one MUST CALL AMREX_DEALLOCATE.
     

--- a/Tutorials/FortranInterface/Advection_F/Source/Src_3d/Adv_3d.f90
+++ b/Tutorials/FortranInterface/Advection_F/Source/Src_3d/Adv_3d.f90
@@ -73,7 +73,7 @@ subroutine advect(time, lo, hi, &
   ! We like to allocate these **pointers** here and then pass them to a function
   ! to remove their pointerness for performance, because normally pointers could
   ! be aliasing.  We need to use pointers instead of allocatable arrays because
-  ! we like to use BoxLib's bl_allocate to allocate memeory instead of the intrinsic
+  ! we like to use AMReX's bl_allocate to allocate memeory instead of the intrinsic
   ! allocate.  Bl_allocate is much faster than allocate inside OMP.  
   ! Note that one MUST CALL BL_DEALLOCATE.
 

--- a/Tutorials/FortranInterface/Advection_octree_F/Source/Src_2d/advect_2d_mod.F90
+++ b/Tutorials/FortranInterface/Advection_octree_F/Source/Src_2d/advect_2d_mod.F90
@@ -58,7 +58,7 @@ contains
     ! We like to allocate these **pointers** here and then pass them to a function
     ! to remove their pointerness for performance, because normally pointers could
     ! be aliasing.  We need to use pointers instead of allocatable arrays because
-    ! we like to use BoxLib's amrex_allocate to allocate memeory instead of the intrinsic
+    ! we like to use AMReX's amrex_allocate to allocate memeory instead of the intrinsic
     ! allocate.  Amrex_allocate is much faster than allocate inside OMP.  
     ! Note that one MUST CALL AMREX_DEALLOCATE.
     

--- a/Tutorials/GPU/Advection_AmrCore/Exec/SingleVortex/GNUmakefile
+++ b/Tutorials/GPU/Advection_AmrCore/Exec/SingleVortex/GNUmakefile
@@ -1,4 +1,4 @@
-AMREX_HOME ?= ../../../../..
+AMREX_HOME = ../../../../..
 
 PRECISION  = DOUBLE
 PROFILE    = FALSE

--- a/Tutorials/GPU/Launch/GNUmakefile
+++ b/Tutorials/GPU/Launch/GNUmakefile
@@ -1,4 +1,4 @@
-AMREX_HOME ?= ../../../
+AMREX_HOME = ../../../
 
 DEBUG	= FALSE
 

--- a/Tutorials/GPU/ParallelReduce/GNUmakefile
+++ b/Tutorials/GPU/ParallelReduce/GNUmakefile
@@ -1,4 +1,4 @@
-AMREX_HOME ?= ../../..
+AMREX_HOME = ../../..
 
 DEBUG	= FALSE
 

--- a/Tutorials/GPU/ParallelScan/GNUmakefile
+++ b/Tutorials/GPU/ParallelScan/GNUmakefile
@@ -1,4 +1,4 @@
-AMREX_HOME ?= ../../..
+AMREX_HOME = ../../..
 
 DEBUG	= FALSE
 

--- a/Tutorials/LinearSolvers/ABecLaplacian_C/GNUmakefile
+++ b/Tutorials/LinearSolvers/ABecLaplacian_C/GNUmakefile
@@ -10,7 +10,7 @@ COMP = gnu
 
 DIM = 3
 
-AMREX_HOME ?= ../../..
+AMREX_HOME = ../../..
 
 include $(AMREX_HOME)/Tools/GNUMake/Make.defs
 

--- a/Tutorials/LinearSolvers/ABecLaplacian_F/GNUmakefile
+++ b/Tutorials/LinearSolvers/ABecLaplacian_F/GNUmakefile
@@ -8,7 +8,7 @@ COMP = gnu
 
 DIM = 3
 
-AMREX_HOME ?= ../../..
+AMREX_HOME = ../../..
 
 include $(AMREX_HOME)/Tools/GNUMake/Make.defs
 

--- a/Tutorials/LinearSolvers/MAC_Projection_EB/GNUmakefile
+++ b/Tutorials/LinearSolvers/MAC_Projection_EB/GNUmakefile
@@ -7,7 +7,7 @@ DIM = 3
 
 DEBUG = FALSE
 
-AMREX_HOME ?= ../../..
+AMREX_HOME = ../../..
 
 USE_EB = TRUE
 

--- a/Tutorials/LinearSolvers/MultiComponent/GNUmakefile
+++ b/Tutorials/LinearSolvers/MultiComponent/GNUmakefile
@@ -1,4 +1,4 @@
-AMREX_HOME ?= ../../../
+AMREX_HOME = ../../../
 
 DEBUG	?= FALSE
 DIM	?= 3

--- a/Tutorials/LinearSolvers/NodalPoisson/GNUmakefile
+++ b/Tutorials/LinearSolvers/NodalPoisson/GNUmakefile
@@ -7,7 +7,7 @@ COMP = gnu
 
 DIM = 3
 
-AMREX_HOME ?= ../../..
+AMREX_HOME = ../../..
 
 include $(AMREX_HOME)/Tools/GNUMake/Make.defs
 

--- a/Tutorials/LinearSolvers/Nodal_Projection_EB/GNUmakefile
+++ b/Tutorials/LinearSolvers/Nodal_Projection_EB/GNUmakefile
@@ -7,7 +7,7 @@ DIM = 3
 
 DEBUG = FALSE
 
-AMREX_HOME ?= ../../..
+AMREX_HOME = ../../..
 
 USE_EB = TRUE
 

--- a/Tutorials/LinearSolvers/NodeTensorLap/GNUmakefile
+++ b/Tutorials/LinearSolvers/NodeTensorLap/GNUmakefile
@@ -9,7 +9,7 @@ COMP = gnu
 
 DIM = 2
 
-AMREX_HOME ?= ../../..
+AMREX_HOME = ../../..
 
 include $(AMREX_HOME)/Tools/GNUMake/Make.defs
 

--- a/Tutorials/MUI/Exec_01/GNUmakefile
+++ b/Tutorials/MUI/Exec_01/GNUmakefile
@@ -1,6 +1,6 @@
 # AMREX_HOME defines the directory in which we will find all the AMReX code.
 # If you set AMREX_HOME as an environment variable, this line will be ignored
-AMREX_HOME ?= ../../../
+AMREX_HOME = ../../../
 MUI_HOME ?= ../../../../MUI/
 
 DEBUG     = FALSE

--- a/Tutorials/MUI/Exec_02/GNUmakefile
+++ b/Tutorials/MUI/Exec_02/GNUmakefile
@@ -1,6 +1,6 @@
 # AMREX_HOME defines the directory in which we will find all the AMReX code.
 # If you set AMREX_HOME as an environment variable, this line will be ignored
-AMREX_HOME ?= ../../../
+AMREX_HOME = ../../../
 MUI_HOME ?= ../../../../MUI/
 
 DEBUG     = FALSE

--- a/Tutorials/Particles/ElectromagneticPIC/Exec/CUDA/GNUmakefile
+++ b/Tutorials/Particles/ElectromagneticPIC/Exec/CUDA/GNUmakefile
@@ -1,4 +1,4 @@
-AMREX_HOME ?= ../../../../..
+AMREX_HOME = ../../../../..
 
 DEBUG	= TRUE
 DEBUG	= FALSE

--- a/Tutorials/Particles/ElectromagneticPIC/Exec/OpenACC/GNUmakefile
+++ b/Tutorials/Particles/ElectromagneticPIC/Exec/OpenACC/GNUmakefile
@@ -1,4 +1,4 @@
-AMREX_HOME ?= ../../../../..
+AMREX_HOME = ../../../../..
 
 DEBUG	= TRUE
 DEBUG	= FALSE

--- a/Tutorials/Particles/ElectromagneticPIC/Exec/OpenMP/GNUmakefile
+++ b/Tutorials/Particles/ElectromagneticPIC/Exec/OpenMP/GNUmakefile
@@ -1,4 +1,4 @@
-AMREX_HOME ?= ../../../../../
+AMREX_HOME = ../../../../../
 
 DEBUG	= TRUE
 DEBUG	= FALSE

--- a/Tutorials/SDC/MISDC_ADR_2d/Exec/GNUmakefile
+++ b/Tutorials/SDC/MISDC_ADR_2d/Exec/GNUmakefile
@@ -1,6 +1,5 @@
 # AMREX_HOME defines the directory in which we will find all the AMReX code.
-# If you set AMREX_HOME as an environment variable, this line will be ignored
-AMREX_HOME ?= ../../../../
+AMREX_HOME = ../../../../
 
 DEBUG     = FALSE
 USE_MPI   = FALSE

--- a/Tutorials/SENSEI/Advection_AmrCore/Exec/SingleVortex/GNUmakefile
+++ b/Tutorials/SENSEI/Advection_AmrCore/Exec/SingleVortex/GNUmakefile
@@ -1,4 +1,4 @@
-AMREX_HOME ?= ../../../../..
+AMREX_HOME = ../../../../..
 
 PRECISION  = DOUBLE
 PROFILE    = FALSE

--- a/Tutorials/SENSEI/Advection_AmrLevel/Exec/SingleVortex/GNUmakefile
+++ b/Tutorials/SENSEI/Advection_AmrLevel/Exec/SingleVortex/GNUmakefile
@@ -1,4 +1,4 @@
-AMREX_HOME ?= ../../../../..
+AMREX_HOME = ../../../../..
 
 USE_EB = FALSE
 PRECISION  = DOUBLE

--- a/Tutorials/SENSEI/Advection_AmrLevel/Source/Src_2d/Adv_2d.f90
+++ b/Tutorials/SENSEI/Advection_AmrLevel/Source/Src_2d/Adv_2d.f90
@@ -51,7 +51,7 @@ subroutine advect(time, lo, hi, &
   ! We like to allocate these **pointers** here and then pass them to a function
   ! to remove their pointerness for performance, because normally pointers could
   ! be aliasing.  We need to use pointers instead of allocatable arrays because
-  ! we like to use BoxLib's bl_allocate to allocate memeory instead of the intrinsic
+  ! we like to use AMReX's bl_allocate to allocate memeory instead of the intrinsic
   ! allocate.  Bl_allocate is much faster than allocate inside OMP.  
   ! Note that one MUST CALL BL_DEALLOCATE.
 

--- a/Tutorials/SENSEI/Advection_AmrLevel/Source/Src_3d/Adv_3d.f90
+++ b/Tutorials/SENSEI/Advection_AmrLevel/Source/Src_3d/Adv_3d.f90
@@ -63,7 +63,7 @@ subroutine advect(time, lo, hi, &
   ! We like to allocate these **pointers** here and then pass them to a function
   ! to remove their pointerness for performance, because normally pointers could
   ! be aliasing.  We need to use pointers instead of allocatable arrays because
-  ! we like to use BoxLib's bl_allocate to allocate memeory instead of the intrinsic
+  ! we like to use AMReX's bl_allocate to allocate memeory instead of the intrinsic
   ! allocate.  Bl_allocate is much faster than allocate inside OMP.  
   ! Note that one MUST CALL BL_DEALLOCATE.
 


### PR DESCRIPTION
1) Replace all instances of "AMREX_HOME ?=" by "AMREX_HOME =" in Tests and Tutorials only.    Since these exist within the amrex directory structure the default should be that they  always use the amrex they are part of, not the one set by the user's environment variable

2) Replace all instances of BoxLib/BOXLIB/boxlib by AMReX.

## Summary

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
