### PR TITLE
Fix typo.

### DIFF
--- a/Src/Amr/AMReX_extrapolater_3D_K.H
+++ b/Src/Amr/AMReX_extrapolater_3D_K.H
@@ -150,7 +150,7 @@ amrex_first_order_extrap_cpu(amrex::Box const& bx,
                data(i,j,k,n) = (  mask(i-1,j+1,k) * data(i-1,j+1,k,n) 
                                 + mask(i-1,j,k+1) * data(i-1,j,k+1,n) 
                                 + mask(i,j+1,k+1) * data(i,j+1,k+1,n) )
-                               / ( mask(i-1,j+1,k) + mask(i+1,j,k+1) + mask(i,j+1,k+1) );
+                               / ( mask(i-1,j+1,k) + mask(i-1,j,k+1) + mask(i,j+1,k+1) );
             } else {
                data(i,j,k,n) = data(i-1,j+1,k+1,n);
             }


### PR DESCRIPTION
## Summary
Fix a typo in AMReX_extrapolater_3D_K.H

## Additional background
Some IAMR runs were crashing with out of bounds errors. This fixes those, and brings this C version in agreement with what the old F90 version was doing.

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
