### PR TITLE
GNU Make dependency

### DIFF
--- a/Tools/GNUMake/Make.defs
+++ b/Tools/GNUMake/Make.defs
@@ -366,7 +366,7 @@ CHECKFORT       = $(AMREX_HOME)/Tools/typechecker/typechecker.py
 MKCONFIG        = $(AMREX_HOME)/Tools/libamrex/mkconfig.py
 MKPKGCONFIG     = $(AMREX_HOME)/Tools/libamrex/mkpkgconfig.py
 
-DEPFLAGS        = -M
+DEPFLAGS        = -MM
 
 RANLIB          = ranlib
 


### PR DESCRIPTION
##Summary

Use `-MM` instead of `-M` to generate dependency in GNU Make system, because
we do not need to include dependency on headers in the system header
directories.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
