### PR TITLE
Fix warnings for USE_SINGLE_PRECISION_PARTICLES=TRUE, PRECISION=DOUBLE

### DIFF
--- a/Src/F_Interfaces/Particle/AMReX_particlecontainer_fi.cpp
+++ b/Src/F_Interfaces/Particle/AMReX_particlecontainer_fi.cpp
@@ -49,7 +49,7 @@ extern "C" {
     }
 
     void amrex_fi_get_particles_mfi(FParticleContainer* particlecontainer,
-                                    int lev, MFIter* mfi, Real*& dp, Long& np)
+                                    int lev, MFIter* mfi, ParticleReal*& dp, Long& np)
     {
         const int grid = mfi->index();
         const int tile = mfi->LocalTileIndex();
@@ -96,7 +96,7 @@ extern "C" {
     }
 
     void amrex_fi_get_particles_i(FParticleContainer* particlecontainer,
-                                  int lev, int grid, int tile, Real*& dp, Long& np)
+                                  int lev, int grid, int tile, ParticleReal*& dp, Long& np)
     {
         auto& particle_level = particlecontainer->GetParticles(lev);
         auto search = particle_level.find(std::make_pair(grid, tile));

--- a/Src/Particle/AMReX_ParticleContainerI.H
+++ b/Src/Particle/AMReX_ParticleContainerI.H
@@ -1399,8 +1399,8 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
                       char* dst = &particles_to_send[old_size] + particle_size;
                       for (int comp = 0; comp < NumRealComps(); comp++) {
                           if (communicate_real_comp[comp]) {
-                              std::memcpy(dst, &soa.GetRealData(comp)[pindex], sizeof(Real));
-                              dst += sizeof(Real);
+                              std::memcpy(dst, &soa.GetRealData(comp)[pindex], sizeof(ParticleReal));
+                              dst += sizeof(ParticleReal);
                           }
                       }
                       for (int comp = 0; comp < NumIntComps(); comp++) {
@@ -1806,9 +1806,9 @@ RedistributeMPI (std::map<int, Vector<char> >& not_ours,
                 ptile.push_back(p);
                 for (int comp = 0; comp < NumRealComps(); ++comp) {
                     if (communicate_real_comp[comp]) {
-                        Real rdata;
-                        std::memcpy(&rdata, pbuf, sizeof(Real));
-                        pbuf += sizeof(Real);
+                        ParticleReal rdata;
+                        std::memcpy(&rdata, pbuf, sizeof(ParticleReal));
+                        pbuf += sizeof(ParticleReal);
                         ptile.push_back_real(comp, rdata);
                     } else {
                         ptile.push_back_real(comp, 0.0);

--- a/Src/Particle/AMReX_ParticleUtil.H
+++ b/Src/Particle/AMReX_ParticleUtil.H
@@ -211,18 +211,18 @@ bool enforcePeriodic (P& p,
         if (not is_per[idim]) continue;
         if (p.pos(idim) >= phi[idim]) {
             while (p.pos(idim) >= phi[idim]) {
-                p.pos(idim) -= (phi[idim] - plo[idim]);
+                p.pos(idim) -= static_cast<ParticleReal>(phi[idim] - plo[idim]);
             }
             // clamp to avoid precision issues;
-            if (p.pos(idim) < plo[idim]) p.pos(idim) = plo[idim];
+            if (p.pos(idim) < plo[idim]) p.pos(idim) = static_cast<ParticleReal>(plo[idim]);
             shifted = true;
         }
         else if (p.pos(idim) < plo[idim]) {
             while (p.pos(idim) < plo[idim]) {
-                p.pos(idim) += (phi[idim] - plo[idim]);
+                p.pos(idim) += static_cast<ParticleReal>(phi[idim] - plo[idim]);
             }
             // clamp to avoid precision issues;
-            if (p.pos(idim) == phi[idim]) p.pos(idim) = plo[idim];
+            if (p.pos(idim) == phi[idim]) p.pos(idim) = static_cast<ParticleReal>(plo[idim]);
             if (p.pos(idim) > phi[idim]) p.pos(idim) = std::nextafter( (amrex::ParticleReal) phi[idim], (amrex::ParticleReal) plo[idim]);
             shifted = true;
         }

--- a/Src/Particle/AMReX_TracerParticle_mod_K.H
+++ b/Src/Particle/AMReX_TracerParticle_mod_K.H
@@ -19,7 +19,7 @@ void cic_interpolate (const P& p,
 		      amrex::GpuArray<amrex::Real,AMREX_SPACEDIM> const& plo,
 		      amrex::GpuArray<amrex::Real,AMREX_SPACEDIM> const& dxi,
 		      const amrex::Array4<amrex::Real const> &  uccarr,
-		      amrex::Real * val){
+		      amrex::ParticleReal * val){
 
   AMREX_ASSERT(val != 0);
 
@@ -35,9 +35,10 @@ void cic_interpolate (const P& p,
 
     for (int d=0; d < AMREX_SPACEDIM; ++d)
     {
+        val[d] = 0.0_prt;
         for (int ii = 0; ii<=1; ++ii)
 	{
-            val[d] += sx[ii]*uccarr(i+ii,0,0,d);
+            val[d] += static_cast<ParticleReal>(sx[ii]*uccarr(i+ii,0,0,d));
         }
     }
 
@@ -58,12 +59,12 @@ void cic_interpolate (const P& p,
 
     for (int d=0; d < AMREX_SPACEDIM; ++d)
       {
-        val[d] = 0.0;
+        val[d] = 0.0_prt;
         for (int jj = 0; jj <= 1; ++jj)
 	  {
             for (int ii = 0; ii <= 1; ++ii)
 	      {
-                val[d] += sx[ii]*sy[jj]*uccarr(i+ii,j+jj,0,d);
+                  val[d] += static_cast<ParticleReal>(sx[ii]*sy[jj]*uccarr(i+ii,j+jj,0,d));
               }
           }
       }
@@ -89,14 +90,14 @@ void cic_interpolate (const P& p,
 
     for (int d=0; d < AMREX_SPACEDIM; ++d)
     {
-        val[d] = 0.0;
+        val[d] = 0.0_prt;
         for (int kk = 0; kk<=1; ++kk)
 	{
             for (int jj = 0; jj <= 1; ++jj)
             {
                 for (int ii = 0; ii <= 1; ++ii)
                 {
-                    val[d] += sx[ii]*sy[jj]*sz[kk]*uccarr(i+ii,j+jj,k+kk,d);
+                    val[d] += static_cast<ParticleReal>(sx[ii]*sy[jj]*sz[kk]*uccarr(i+ii,j+jj,k+kk,d));
                 }
             }
         }
@@ -112,7 +113,7 @@ void mac_interpolate (const P& p,
 		      amrex::GpuArray<amrex::Real,AMREX_SPACEDIM> const& plo,
 		      amrex::GpuArray<amrex::Real,AMREX_SPACEDIM> const& dxi,
 		      amrex::GpuArray<amrex::Array4<amrex::Real const>,AMREX_SPACEDIM> const& p_uccarr,
-		      amrex::Real * val)
+		      amrex::ParticleReal * val)
 {
 
 #if (AMREX_SPACEDIM == 1)
@@ -126,10 +127,10 @@ void mac_interpolate (const P& p,
 
         amrex::Real sx[] = {1._rt - xint, xint};
 
-        val[d] = 0.0;
+        val[d] = 0.0_prt;
         for (int ii = 0; ii <= 1; ++ii)
         {
-            val[d] += (p_uccarr[d])(i+ii, 0, 0, 0)*sx[ii];
+            val[d] += static_cast<ParticleReal>((p_uccarr[d])(i+ii, 0, 0, 0)*sx[ii]);
         }
     }
 
@@ -149,12 +150,12 @@ void mac_interpolate (const P& p,
       amrex::Real sx[] = {1._rt - xint, xint};
       amrex::Real sy[] = {1._rt - yint, yint};
 
-      val[d] = 0.0;
+      val[d] = 0.0_prt;
       for (int jj = 0; jj <= 1; ++jj)
       {
           for (int ii = 0; ii <= 1; ++ii)
           {
-              val[d] += (p_uccarr[d])(i+ii, j+jj, 0, 0)*sx[ii]*sy[jj];
+              val[d] += static_cast<ParticleReal>((p_uccarr[d])(i+ii, j+jj, 0, 0)*sx[ii]*sy[jj]);
           }
       }
   }
@@ -180,14 +181,14 @@ void mac_interpolate (const P& p,
       amrex::Real sy[] = {1._rt - yint, yint};
       amrex::Real sz[] = {1._rt - zint, zint};
 
-      val[d] = 0.0;
+      val[d] = 0.0_prt;
       for (int kk = 0; kk <=1; ++kk)
       {
 	  for (int jj = 0; jj <= 1; ++jj)
           {
 	      for (int ii = 0; ii <= 1; ++ii)
               {
-		  val[d] += (p_uccarr[d])(i+ii, j+jj, k+kk ,0)*sx[ii]*sy[jj]*sz[kk];
+		  val[d] += static_cast<ParticleReal>((p_uccarr[d])(i+ii, j+jj, k+kk ,0)*sx[ii]*sy[jj]*sz[kk]);
               }
           }
       }

--- a/Src/Particle/AMReX_TracerParticles.cpp
+++ b/Src/Particle/AMReX_TracerParticles.cpp
@@ -80,21 +80,21 @@ TracerParticleContainer::AdvectWithUmac (MultiFab* umac, int lev, Real dt)
             {
                 ParticleType& p = p_pbox[i];
                 if (p.id() <= 0) return;
-                Real v[AMREX_SPACEDIM];
+                ParticleReal v[AMREX_SPACEDIM];
                 mac_interpolate(p, plo, dxi, umacarr, v);
                 if (ipass == 0)
                 {
                     for (int dim=0; dim < AMREX_SPACEDIM; dim++)
                     {
                         p.rdata(dim) = p.pos(dim);
-                        p.pos(dim) += 0.5*dt*v[dim];
+                        p.pos(dim) += static_cast<ParticleReal>(0.5_prt*dt*v[dim]);
                     }
                 }
                 else
                 {
                     for (int dim=0; dim < AMREX_SPACEDIM; dim++)
                     {
-                        p.pos(dim) = p.rdata(dim) + dt*v[dim];
+                        p.pos(dim) = p.rdata(dim) + static_cast<ParticleReal>(dt*v[dim]);
                         p.rdata(dim) = v[dim];
                     }
                 }
@@ -158,7 +158,7 @@ TracerParticleContainer::AdvectWithUcc (const MultiFab& Ucc, int lev, Real dt)
             {
                 ParticleType& p  = p_pbox[i];
                 if (p.id() <= 0) return;
-                Real v[AMREX_SPACEDIM];
+                ParticleReal v[AMREX_SPACEDIM];
 
                 cic_interpolate(p, plo, dxi, uccarr, v);
 
@@ -167,14 +167,14 @@ TracerParticleContainer::AdvectWithUcc (const MultiFab& Ucc, int lev, Real dt)
                     for (int dim=0; dim < AMREX_SPACEDIM; dim++)
                     {
                         p.rdata(dim) = p.pos(dim);
-                        p.pos(dim) += 0.5*dt*v[dim];
+                        p.pos(dim) += static_cast<ParticleReal>(0.5_prt*dt*v[dim]);
                     }
                 }
                 else
                 {
                     for (int dim=0; dim < AMREX_SPACEDIM; dim++)
                     {
-                        p.rdata(dim) = p.rdata(dim) + dt*v[dim];
+                        p.rdata(dim) = p.rdata(dim) + static_cast<ParticleReal>(dt*v[dim]);
                         p.rdata(dim) = v[dim];
                     }
                 }


### PR DESCRIPTION
Note that one of these is an actual bug that went undetected for years. That's why you pay attention to warnings I guess...

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
