### PR TITLE
Fix bug in FPinfo for EB

### DIFF
--- a/Src/Base/AMReX_FabArrayBase.cpp
+++ b/Src/Base/AMReX_FabArrayBase.cpp
@@ -1271,11 +1271,12 @@ FabArrayBase::FPinfo::FPinfo (const FabArrayBase& srcfa,
                                            ba_crse_patch,
                                            dm_patch,
                                            {0,0,0}, EBSupport::basic);
+        int ng = boxtype.cellCentered() ? 0 : 1; // to avoid dengerate box
         fact_fine_patch = makeEBFabFactory(index_space,
                                            index_space->getGeometry(fdomain),
                                            ba_fine_patch,
                                            dm_patch,
-                                           {0,0,0}, EBSupport::basic);
+                                           {ng,ng,ng}, EBSupport::basic);
     }
     else
 #endif


### PR DESCRIPTION
## Summary

PR #1224 introduced a bug that affects FillPatch on nodal grids for EB.
When there is only one ghost cell, the fine patch grids might be degenerate
in the sense that some boxes are only 1 node wide.  In that case, we cannot
build cell-centered EBCellFlags unless there are ghost cells.

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
