### PR TITLE
Remove error message for unknown MPI in Make.nrel

### DIFF
--- a/Tools/GNUMake/sites/Make.nrel
+++ b/Tools/GNUMake/sites/Make.nrel
@@ -31,6 +31,7 @@ else ifeq ($(which_computer), rhodes)
   endif
 endif
 
+# Account for Intel-MPI, MPICH, OpenMPI, and MPT
 ifeq ($(USE_MPI),TRUE)
   ifeq ($(COMP), intel)
     CXX := mpiicpc
@@ -48,8 +49,6 @@ ifeq ($(USE_MPI),TRUE)
     else ifneq ($(findstring Open MPI, $(shell $(F90) -showme:version 2>&1)),)
       mpif90_link_flags := $(shell $(F90) -showme:link)
       LIBRARIES += $(mpif90_link_flags)
-    else
-      $(error unknown mpi implementation)
     endif
   endif
 endif


### PR DESCRIPTION

## Summary

Currently we error out for unrecognized MPI implementations. We want to also use MPT at NREL, so we will just let any MPI implementation compile and this seems fine.

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
