### PR TITLE
oneAPI Beta 8

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -155,11 +155,7 @@ jobs:
             -DCUDA_ARCH=6.0
         make -j 2 tutorials
 
-  # Build libamrex and all tutorials with DPC++
-  # broken in beta08
-  #   https://github.com/intel/llvm/issues/2187
   tutorials-dpcpp:
-    if: false
     name: DPCPP@PubBeta GFortran@7.5 C++17 [tutorials]
     runs-on: ubuntu-latest
     steps:
@@ -169,7 +165,7 @@ jobs:
     - name: Build & Install
       run: |
         set +e
-        source /opt/intel/inteloneapi/setvars.sh
+        source /opt/intel/oneapi/setvars.sh
         set -e
         mkdir build
         cd build

--- a/Src/Amr/AMReX_Amr.cpp
+++ b/Src/Amr/AMReX_Amr.cpp
@@ -3108,7 +3108,7 @@ Amr::printGridInfo (std::ostream& os,
         int                       numgrid = bs.size();
         Long                      ncells  = amr_level[lev]->countCells();
         double                    ntot    = Geom(lev).Domain().d_numPts();
-        Real                      frac    = 100.0_rt*(Real(ncells) / ntot);
+        Real                      frac    = Real(100.0)*(Real(ncells) / ntot);
         const DistributionMapping& map    = amr_level[lev]->get_new_data(0).DistributionMap();
 
         os << "  Level "

--- a/Src/Amr/AMReX_extrapolater_2D_K.H
+++ b/Src/Amr/AMReX_extrapolater_2D_K.H
@@ -26,7 +26,7 @@ amrex_first_order_extrap_cpu(amrex::Box const& bx,
       // set all crse cells to zero first
       for (int j = lo.y-1; j <= hi.y+1; ++j) {
          for (int i = lo.x-1; i <= hi.x+1; ++i) {
-            if (mask(i,j,k) == crsecell) data(i,j,k,n) = 0.0_rt;
+             if (mask(i,j,k) == crsecell) data(i,j,k,n) = Real(0.0);
          }
       }
 

--- a/Src/Amr/AMReX_extrapolater_3D_K.H
+++ b/Src/Amr/AMReX_extrapolater_3D_K.H
@@ -25,7 +25,7 @@ amrex_first_order_extrap_cpu(amrex::Box const& bx,
       for (int k = lo.z-1; k <= hi.z+1; ++k) {
          for (int j = lo.y-1; j <= hi.y+1; ++j) {
             for (int i = lo.x-1; i <= hi.x+1; ++i) {
-               if (mask(i,j,k) == crsecell) data(i,j,k,n) = 0.0_rt;
+               if (mask(i,j,k) == crsecell) data(i,j,k,n) = Real(0.0);
             }
          }
       }

--- a/Src/AmrCore/AMReX_AmrCore.cpp
+++ b/Src/AmrCore/AMReX_AmrCore.cpp
@@ -127,7 +127,7 @@ AmrCore::printGridSummary (std::ostream& os, int min_lev, int max_lev) const noe
         int                       numgrid = bs.size();
         Long                      ncells  = bs.numPts();
         double                    ntot    = Geom(lev).Domain().d_numPts();
-        Real                      frac    = 100.0_rt*(Real(ncells) / ntot);
+        Real                      frac    = Real(100.0)*(Real(ncells) / ntot);
 
         os << "  Level "
            << lev

--- a/Src/AmrCore/AMReX_ErrorList.cpp
+++ b/Src/AmrCore/AMReX_ErrorList.cpp
@@ -315,9 +315,9 @@ operator << (std::ostream&    os,
       amrex::ParallelFor(bx,
       [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k) noexcept
       {
-          GpuArray<Real,AMREX_SPACEDIM> pt = {{AMREX_D_DECL(plo[0]+(Real(i)+0.5_rt)*dx[0],
-                                                            plo[1]+(Real(j)+0.5_rt)*dx[1],
-                                                            plo[2]+(Real(k)+0.5_rt)*dx[2])}};
+          GpuArray<Real,AMREX_SPACEDIM> pt = {{AMREX_D_DECL(plo[0]+(Real(i)+Real(0.5))*dx[0],
+                                                            plo[1]+(Real(j)+Real(0.5))*dx[1],
+                                                            plo[2]+(Real(k)+Real(0.5))*dx[2])}};
         if (tag_rb.contains(pt.data())) {
           tag(i,j,k) = tagval;
         }

--- a/Src/AmrCore/AMReX_Interp_1D_C.H
+++ b/Src/AmrCore/AMReX_Interp_1D_C.H
@@ -33,8 +33,8 @@ ccinterp_compute_voff (Box const& cbx, IntVect const& ratio, Geometry const& cge
         const int ic = amrex::coarsen(i, ratio[0]);
         const int ii = i - flo.x;
         const int iic = ic - clo.x;
-        const Real fcen = 0.5_rt*(fvc[ii ]+fvc[ii +1]);
-        const Real ccen = 0.5_rt*(cvc[iic]+cvc[iic+1]);
+        const Real fcen = Real(0.5)*(fvc[ii ]+fvc[ii +1]);
+        const Real ccen = Real(0.5)*(cvc[iic]+cvc[iic+1]);
         xoff[ii] = (fcen-ccen)/(cvc[iic+1]-cvc[iic]);
     }
 
@@ -51,17 +51,17 @@ compute_slopes (const Dim3& lo, const Dim3& hi,
 {
     AMREX_PRAGMA_SIMD
     for (int i = lo.x; i <= hi.x; ++i) {
-        slopes(i,0,0,ns) = 0.5_rt*(u(i+1,0,0,nu)-u(i-1,0,0,nu));
+        slopes(i,0,0,ns) = Real(0.5)*(u(i+1,0,0,nu)-u(i-1,0,0,nu));
     }
 
     if (lo.x == slo.x && (bc.lo(0) == BCType::ext_dir || bc.lo(0) == BCType::hoextrap))
     {
         const int i = slo.x;
         if (shi.x-slo.x >= 1) {
-            slopes(i,0,0,ns) = -(16._rt/15._rt)*u(i-1,0,0,nu) + 0.5_rt*u(i,0,0,nu)
-                + (2._rt/3._rt)*u(i+1,0,0,nu) - 0.1_rt*u(i+2,0,0,nu);
+            slopes(i,0,0,ns) = -Real(16./15.)*u(i-1,0,0,nu) + Real(0.5)*u(i,0,0,nu)
+                + Real(2./3.)*u(i+1,0,0,nu) - Real(0.1)*u(i+2,0,0,nu);
         } else {
-            slopes(i,0,0,ns) = 0.25_rt*(u(i+1,0,0,nu)+5._rt*u(i,0,0,nu)-6._rt*u(i-1,0,0,nu));
+            slopes(i,0,0,ns) = Real(0.25)*(u(i+1,0,0,nu)+Real(5.)*u(i,0,0,nu)-Real(6.)*u(i-1,0,0,nu));
         }
     }
 
@@ -69,10 +69,10 @@ compute_slopes (const Dim3& lo, const Dim3& hi,
     {
         const int i = shi.x;
         if (shi.x-slo.x >= 1) {
-            slopes(i,0,0,ns) = (16._rt/15._rt)*u(i+1,0,0,nu) - 0.5_rt*u(i,0,0,nu)
-                - (2._rt/3._rt)*u(i-1,0,0,nu) + 0.1_rt*u(i-2,0,0,nu);
+            slopes(i,0,0,ns) = Real(16./15.)*u(i+1,0,0,nu) - Real(0.5)*u(i,0,0,nu)
+                - Real(2./3.)*u(i-1,0,0,nu) + Real(0.1)*u(i-2,0,0,nu);
         } else {
-            slopes(i,0,0,ns) = -0.25_rt*(u(i-1,0,0,nu)+5._rt*u(i,0,0,nu)-6._rt*u(i+1,0,0,nu));
+            slopes(i,0,0,ns) = -Real(0.25)*(u(i-1,0,0,nu)+Real(5.)*u(i,0,0,nu)-Real(6.)*u(i+1,0,0,nu));
         }
     }
 }
@@ -94,7 +94,7 @@ cellconslin_slopes_linlim (Box const& bx, Array4<Real> const& slopes,
 
     AMREX_PRAGMA_SIMD
     for (int i = lo.x; i <= hi.x; ++i) {
-        sf(i,0,0) = 1.0_rt;
+        sf(i,0,0) = Real(1.);
     }
 
     for (int n = 0; n < ncomp; ++n)
@@ -105,14 +105,14 @@ cellconslin_slopes_linlim (Box const& bx, Array4<Real> const& slopes,
         AMREX_PRAGMA_SIMD
         for (int i = lo.x; i <= hi.x; ++i) {
             Real cen  = slopes(i,0,0,n);
-            Real forw = 2.0_rt*(u(i+1,0,0,nu)-u(i  ,0,0,nu));
-            Real back = 2.0_rt*(u(i  ,0,0,nu)-u(i-1,0,0,nu));
-            Real slp = (forw*back >= 0.0_rt) ? amrex::min(amrex::Math::abs(forw),amrex::Math::abs(back)) : 0.0_rt;
-            slopes(i,0,0,n) = amrex::Math::copysign(1.0_rt,cen)*amrex::min(slp,amrex::Math::abs(cen));
-            if (cen != 0.0_rt) {
+            Real forw = Real(2.)*(u(i+1,0,0,nu)-u(i  ,0,0,nu));
+            Real back = Real(2.)*(u(i  ,0,0,nu)-u(i-1,0,0,nu));
+            Real slp = (forw*back >= Real(0.)) ? amrex::min(amrex::Math::abs(forw),amrex::Math::abs(back)) : Real(0.);
+            slopes(i,0,0,n) = amrex::Math::copysign(Real(1.),cen)*amrex::min(slp,amrex::Math::abs(cen));
+            if (cen != Real(0.)) {
                 sf(i,0,0) = amrex::min(sf(i,0,0), slopes(i,0,0,n)/cen);
             } else {
-                sf(i,0,0) = 0.0_rt;
+                sf(i,0,0) = Real(0.);
             }
         }
     }
@@ -181,10 +181,10 @@ cellconslin_slopes_mclim (Box const& bx, Array4<Real> const& slopes,
         AMREX_PRAGMA_SIMD
         for (int i = lo.x; i <= hi.x; ++i) {
             Real cen  = slopes(i,0,0,n);
-            Real forw = 2.0_rt*(u(i+1,0,0,nu)-u(i  ,0,0,nu));
-            Real back = 2.0_rt*(u(i  ,0,0,nu)-u(i-1,0,0,nu));
-            Real slp = (forw*back >= 0.0_rt) ? amrex::min(amrex::Math::abs(forw),amrex::Math::abs(back)) : 0.0_rt;
-            slopes(i,0,0,n) = amrex::Math::copysign(1.0_rt,cen)*amrex::min(slp,amrex::Math::abs(cen));
+            Real forw = Real(2.)*(u(i+1,0,0,nu)-u(i  ,0,0,nu));
+            Real back = Real(2.)*(u(i  ,0,0,nu)-u(i-1,0,0,nu));
+            Real slp = (forw*back >= Real(0.)) ? amrex::min(amrex::Math::abs(forw),amrex::Math::abs(back)) : Real(0.);
+            slopes(i,0,0,n) = amrex::Math::copysign(Real(1.),cen)*amrex::min(slp,amrex::Math::abs(cen));
         }
     }
 }
@@ -208,12 +208,12 @@ cellconslin_fine_alpha (Box const& bx, Array4<Real> const& alpha,
             const int ic = amrex::coarsen(i,ratio[0]);
             const Real dummy_fine = xoff[i-vlo.x]*slopes(ic,0,0,n);
 
-            if (dummy_fine > mm(ic,0,0,n+ncomp) && dummy_fine != 0.0_rt) {
+            if (dummy_fine > mm(ic,0,0,n+ncomp) && dummy_fine != Real(0.)) {
                 alpha(i,0,0,n) = mm(ic,0,0,n+ncomp) / dummy_fine;
-            } else if (dummy_fine < mm(ic,0,0,n) && dummy_fine != 0.0_rt) {
+            } else if (dummy_fine < mm(ic,0,0,n) && dummy_fine != Real(0.)) {
                 alpha(i,0,0,n) = mm(ic,0,0,n) / dummy_fine;
             } else {
-                alpha(i,0,0,n) = 1.0_rt;
+                alpha(i,0,0,n) = Real(1.);
             }
         }
     }
@@ -230,7 +230,7 @@ cellconslin_slopes_mmlim (Box const& bx, Array4<Real> const& slopes,
     for (int n = 0; n < ncomp; ++n) {
         for (int i = lo.x; i <= hi.x; ++i) {
             const int ii = i*ratio[0];
-            Real a = 1.0_rt;
+            Real a = Real(1.);
             for (int ioff = 0; ioff < ratio[0]; ++ioff) {
                 a = amrex::min(a, alpha(ii+ioff,0,0,n));
             }
@@ -265,7 +265,7 @@ nodebilin_slopes (Box const& bx, Array4<T> const& slope, Array4<T const> const& 
     const auto lo = amrex::lbound(bx);
     const auto hi = amrex::ubound(bx);
 
-    const Real rx = 1.0_rt/ratio[0];
+    const Real rx = Real(1.)/ratio[0];
 
     for (int n = 0; n < ncomp; ++n) {
         AMREX_PRAGMA_SIMD
@@ -302,8 +302,8 @@ face_linear_interp_x (int i, int /*j*/, int /*k*/, int n, Array4<T> const& fine,
                       Array4<T const> const& crse, IntVect const& ratio) noexcept
 {
     int ii = amrex::coarsen(i,ratio[0]);
-    Real const w = static_cast<Real>(i-ii*ratio[0]) * (1.0_rt/ratio[0]);
-    fine(i,0,0,n) = (1.0_rt-w) * crse(ii,0,0,n) + w * crse(ii+1,0,0,n);
+    Real const w = static_cast<Real>(i-ii*ratio[0]) * (Real(1.)/ratio[0]);
+    fine(i,0,0,n) = (Real(1.)-w) * crse(ii,0,0,n) + w * crse(ii+1,0,0,n);
 }
 
 }

--- a/Src/AmrCore/AMReX_Interp_2D_C.H
+++ b/Src/AmrCore/AMReX_Interp_2D_C.H
@@ -33,8 +33,8 @@ ccinterp_compute_voff (Box const& cbx, IntVect const& ratio, Geometry const& cge
         const int ic = amrex::coarsen(i, ratio[0]);
         const int ii = i - flo.x;
         const int iic = ic - clo.x;
-        const Real fcen = 0.5_rt*(fvc[ii ]+fvc[ii +1]);
-        const Real ccen = 0.5_rt*(cvc[iic]+cvc[iic+1]);
+        const Real fcen = Real(0.5)*(fvc[ii ]+fvc[ii +1]);
+        const Real ccen = Real(0.5)*(cvc[iic]+cvc[iic+1]);
         xoff[ii] = (fcen-ccen)/(cvc[iic+1]-cvc[iic]);
     }
 
@@ -47,8 +47,8 @@ ccinterp_compute_voff (Box const& cbx, IntVect const& ratio, Geometry const& cge
         const int jc = amrex::coarsen(j, ratio[1]);
         const int jj = j - flo.y;
         const int jjc = jc - clo.y;
-        const Real fcen = 0.5_rt*(fvc[jj ]+fvc[jj +1]);
-        const Real ccen = 0.5_rt*(cvc[jjc]+cvc[jjc+1]);
+        const Real fcen = Real(0.5)*(fvc[jj ]+fvc[jj +1]);
+        const Real ccen = Real(0.5)*(cvc[jjc]+cvc[jjc+1]);
         yoff[jj] = (fcen-ccen)/(cvc[jjc+1]-cvc[jjc]);
     }
 
@@ -66,8 +66,8 @@ compute_slopes (const Dim3& lo, const Dim3& hi,
     for     (int j = lo.y; j <= hi.y; ++j) {
         AMREX_PRAGMA_SIMD
         for (int i = lo.x; i <= hi.x; ++i) {
-            slopes(i,j,0,ns      ) = 0.5_rt*(u(i+1,j,0,nu)-u(i-1,j,0,nu));
-            slopes(i,j,0,ns+ncomp) = 0.5_rt*(u(i,j+1,0,nu)-u(i,j-1,0,nu));
+            slopes(i,j,0,ns      ) = Real(0.5)*(u(i+1,j,0,nu)-u(i-1,j,0,nu));
+            slopes(i,j,0,ns+ncomp) = Real(0.5)*(u(i,j+1,0,nu)-u(i,j-1,0,nu));
         }
     }
 
@@ -76,12 +76,12 @@ compute_slopes (const Dim3& lo, const Dim3& hi,
         const int i = slo.x;
         if (shi.x-slo.x >= 1) {
             for     (int j = lo.y; j <= hi.y; ++j) {
-                slopes(i,j,0,ns) = -(16._rt/15._rt)*u(i-1,j,0,nu) + 0.5_rt*u(i,j,0,nu)
-                    + (2._rt/3._rt)*u(i+1,j,0,nu) - 0.1_rt*u(i+2,j,0,nu);
+                slopes(i,j,0,ns) = -Real(16./15.)*u(i-1,j,0,nu) + Real(0.5)*u(i,j,0,nu)
+                    + Real(2./3.)*u(i+1,j,0,nu) - Real(0.1)*u(i+2,j,0,nu);
             }
         } else {
             for     (int j = lo.y; j <= hi.y; ++j) {
-                slopes(i,j,0,ns) = 0.25_rt*(u(i+1,j,0,nu)+5._rt*u(i,j,0,nu)-6._rt*u(i-1,j,0,nu));
+                slopes(i,j,0,ns) = Real(0.25)*(u(i+1,j,0,nu)+Real(5.)*u(i,j,0,nu)-Real(6.)*u(i-1,j,0,nu));
             }
         }
     }
@@ -91,12 +91,12 @@ compute_slopes (const Dim3& lo, const Dim3& hi,
         const int i = shi.x;
         if (shi.x-slo.x >= 1) {
             for     (int j = lo.y; j <= hi.y; ++j) {
-                slopes(i,j,0,ns) = (16._rt/15._rt)*u(i+1,j,0,nu) - 0.5_rt*u(i,j,0,nu)
-                    - (2._rt/3._rt)*u(i-1,j,0,nu) + 0.1_rt*u(i-2,j,0,nu);
+                slopes(i,j,0,ns) = Real(16./15.)*u(i+1,j,0,nu) - Real(0.5)*u(i,j,0,nu)
+                    - Real(2./3.)*u(i-1,j,0,nu) + Real(0.1)*u(i-2,j,0,nu);
             }
         } else {
             for     (int j = lo.y; j <= hi.y; ++j) {
-                slopes(i,j,0,ns) = -0.25_rt*(u(i-1,j,0,nu)+5._rt*u(i,j,0,nu)-6._rt*u(i+1,j,0,nu));
+                slopes(i,j,0,ns) = -Real(0.25)*(u(i-1,j,0,nu)+Real(5.)*u(i,j,0,nu)-Real(6.)*u(i+1,j,0,nu));
             }
         }
     }
@@ -107,13 +107,13 @@ compute_slopes (const Dim3& lo, const Dim3& hi,
         if (shi.y-slo.y >= 1) {
             AMREX_PRAGMA_SIMD
             for (int i = lo.x; i <= hi.x; ++i) {
-                slopes(i,j,0,ns+ncomp) = -(16._rt/15._rt)*u(i,j-1,0,nu) + 0.5_rt*u(i,j,0,nu)
-                    + (2._rt/3._rt)*u(i,j+1,0,nu) - 0.1_rt*u(i,j+2,0,nu);
+                slopes(i,j,0,ns+ncomp) = -Real(16./15.)*u(i,j-1,0,nu) + Real(0.5)*u(i,j,0,nu)
+                    + Real(2./3.)*u(i,j+1,0,nu) - Real(0.1)*u(i,j+2,0,nu);
             }
         } else {
             AMREX_PRAGMA_SIMD
             for (int i = lo.x; i <= hi.x; ++i) {
-                slopes(i,j,0,ns+ncomp) = 0.25_rt*(u(i,j+1,0,nu)+5._rt*u(i,j,0,nu)-6._rt*u(i,j-1,0,nu));
+                slopes(i,j,0,ns+ncomp) = Real(0.25)*(u(i,j+1,0,nu)+Real(5.)*u(i,j,0,nu)-Real(6.)*u(i,j-1,0,nu));
             }
         }
     }
@@ -124,13 +124,13 @@ compute_slopes (const Dim3& lo, const Dim3& hi,
         if (shi.y-slo.y >= 1) {
             AMREX_PRAGMA_SIMD
             for (int i = lo.x; i <= hi.x; ++i) {
-                slopes(i,j,0,ns+ncomp) = (16._rt/15._rt)*u(i,j+1,0,nu) - 0.5_rt*u(i,j,0,nu)
-                    - (2._rt/3._rt)*u(i,j-1,0,nu) + 0.1_rt*u(i,j-2,0,nu);
+                slopes(i,j,0,ns+ncomp) = Real(16./15.)*u(i,j+1,0,nu) - Real(0.5)*u(i,j,0,nu)
+                    - Real(2./3.)*u(i,j-1,0,nu) + Real(0.1)*u(i,j-2,0,nu);
             }
         } else {
             AMREX_PRAGMA_SIMD
             for (int i = lo.x; i <= hi.x; ++i) {
-                slopes(i,j,0,ns+ncomp) = -0.25_rt*(u(i,j-1,0,nu)+5._rt*u(i,j,0,nu)-6._rt*u(i,j+1,0,nu));
+                slopes(i,j,0,ns+ncomp) = -Real(0.25)*(u(i,j-1,0,nu)+Real(5.)*u(i,j,0,nu)-Real(6.)*u(i,j+1,0,nu));
             }
         }
     }
@@ -154,8 +154,8 @@ cellconslin_slopes_linlim (Box const& bx, Array4<Real> const& slopes,
     for     (int j = lo.y; j <= hi.y; ++j) {
         AMREX_PRAGMA_SIMD
         for (int i = lo.x; i <= hi.x; ++i) {
-            sf(i,j,0,0) = 1.0_rt;
-            sf(i,j,0,1) = 1.0_rt;
+            sf(i,j,0,0) = Real(1.);
+            sf(i,j,0,1) = Real(1.);
         }
     }
 
@@ -168,25 +168,25 @@ cellconslin_slopes_linlim (Box const& bx, Array4<Real> const& slopes,
             AMREX_PRAGMA_SIMD
             for (int i = lo.x; i <= hi.x; ++i) {
                 Real cen  = slopes(i,j,0,n);
-                Real forw = 2.0_rt*(u(i+1,j,0,nu)-u(i  ,j,0,nu));
-                Real back = 2.0_rt*(u(i  ,j,0,nu)-u(i-1,j,0,nu));
-                Real slp = (forw*back >= 0.0_rt) ? amrex::min(amrex::Math::abs(forw),amrex::Math::abs(back)) : 0.0_rt;
-                slopes(i,j,0,n) = amrex::Math::copysign(1.0_rt,cen)*amrex::min(slp,amrex::Math::abs(cen));
-                if (cen != 0.0_rt) {
+                Real forw = Real(2.)*(u(i+1,j,0,nu)-u(i  ,j,0,nu));
+                Real back = Real(2.)*(u(i  ,j,0,nu)-u(i-1,j,0,nu));
+                Real slp = (forw*back >= Real(0.)) ? amrex::min(amrex::Math::abs(forw),amrex::Math::abs(back)) : Real(0.);
+                slopes(i,j,0,n) = amrex::Math::copysign(Real(1.),cen)*amrex::min(slp,amrex::Math::abs(cen));
+                if (cen != Real(0.)) {
                     sf(i,j,0,0) = amrex::min(sf(i,j,0,0), slopes(i,j,0,n)/cen);
                 } else {
-                    sf(i,j,0,0) = 0.0_rt;
+                    sf(i,j,0,0) = Real(0.);
                 }
 
                 cen  = slopes(i,j,0,n+ncomp);
-                forw = 2.0_rt*(u(i,j+1,0,nu)-u(i,j  ,0,nu));
-                back = 2.0_rt*(u(i,j  ,0,nu)-u(i,j-1,0,nu));
-                slp = (forw*back >= 0.0_rt) ? amrex::min(amrex::Math::abs(forw),amrex::Math::abs(back)) : 0.0_rt;
-                slopes(i,j,0,n+ncomp) = amrex::Math::copysign(1.0_rt,cen)*amrex::min(slp,amrex::Math::abs(cen));
-                if (cen != 0.0_rt) {
+                forw = Real(2.)*(u(i,j+1,0,nu)-u(i,j  ,0,nu));
+                back = Real(2.)*(u(i,j  ,0,nu)-u(i,j-1,0,nu));
+                slp = (forw*back >= Real(0.)) ? amrex::min(amrex::Math::abs(forw),amrex::Math::abs(back)) : Real(0.);
+                slopes(i,j,0,n+ncomp) = amrex::Math::copysign(Real(1.),cen)*amrex::min(slp,amrex::Math::abs(cen));
+                if (cen != Real(0.)) {
                     sf(i,j,0,1) = amrex::min(sf(i,j,0,1), slopes(i,j,0,n+ncomp)/cen);
                 } else {
-                    sf(i,j,0,1) = 0.0_rt;
+                    sf(i,j,0,1) = Real(0.);
                 }
             }
         }
@@ -270,16 +270,16 @@ cellconslin_slopes_mclim (Box const& bx, Array4<Real> const& slopes,
             AMREX_PRAGMA_SIMD
             for (int i = lo.x; i <= hi.x; ++i) {
                 Real cen  = slopes(i,j,0,n);
-                Real forw = 2.0_rt*(u(i+1,j,0,nu)-u(i  ,j,0,nu));
-                Real back = 2.0_rt*(u(i  ,j,0,nu)-u(i-1,j,0,nu));
-                Real slp = (forw*back >= 0.0_rt) ? amrex::min(amrex::Math::abs(forw),amrex::Math::abs(back)) : 0.0_rt;
-                slopes(i,j,0,n) = amrex::Math::copysign(1.0_rt,cen)*amrex::min(slp,amrex::Math::abs(cen));
+                Real forw = Real(2.)*(u(i+1,j,0,nu)-u(i  ,j,0,nu));
+                Real back = Real(2.)*(u(i  ,j,0,nu)-u(i-1,j,0,nu));
+                Real slp = (forw*back >= Real(0.)) ? amrex::min(amrex::Math::abs(forw),amrex::Math::abs(back)) : Real(0.);
+                slopes(i,j,0,n) = amrex::Math::copysign(Real(1.),cen)*amrex::min(slp,amrex::Math::abs(cen));
 
                 cen  = slopes(i,j,0,n+ncomp);
-                forw = 2.0_rt*(u(i,j+1,0,nu)-u(i,j  ,0,nu));
-                back = 2.0_rt*(u(i,j  ,0,nu)-u(i,j-1,0,nu));
-                slp = (forw*back >= 0.0_rt) ? amrex::min(amrex::Math::abs(forw),amrex::Math::abs(back)) : 0.0_rt;
-                slopes(i,j,0,n+ncomp) = amrex::Math::copysign(1.0_rt,cen)*amrex::min(slp,amrex::Math::abs(cen));
+                forw = Real(2.)*(u(i,j+1,0,nu)-u(i,j  ,0,nu));
+                back = Real(2.)*(u(i,j  ,0,nu)-u(i,j-1,0,nu));
+                slp = (forw*back >= Real(0.)) ? amrex::min(amrex::Math::abs(forw),amrex::Math::abs(back)) : Real(0.);
+                slopes(i,j,0,n+ncomp) = amrex::Math::copysign(Real(1.),cen)*amrex::min(slp,amrex::Math::abs(cen));
             }
         }
     }
@@ -309,12 +309,12 @@ cellconslin_fine_alpha (Box const& bx, Array4<Real> const& alpha,
                 const Real dummy_fine = xoff[i-vlo.x]*slopes(ic,jc,0,n)
                     +                   yoff[j-vlo.y]*slopes(ic,jc,0,n+ncomp);
 
-                if (dummy_fine > mm(ic,jc,0,n+ncomp) && dummy_fine != 0.0_rt) {
+                if (dummy_fine > mm(ic,jc,0,n+ncomp) && dummy_fine != Real(0.)) {
                     alpha(i,j,0,n) = mm(ic,jc,0,n+ncomp) / dummy_fine;
-                } else if (dummy_fine < mm(ic,jc,0,n) && dummy_fine != 0.0_rt) {
+                } else if (dummy_fine < mm(ic,jc,0,n) && dummy_fine != Real(0.)) {
                     alpha(i,j,0,n) = mm(ic,jc,0,n) / dummy_fine;
                 } else {
-                    alpha(i,j,0,n) = 1.0_rt;
+                    alpha(i,j,0,n) = Real(1.);
                 }
             }
         }
@@ -334,7 +334,7 @@ cellconslin_slopes_mmlim (Box const& bx, Array4<Real> const& slopes,
             const int jj = j*ratio[1];
             for (int i = lo.x; i <= hi.x; ++i) {
                 const int ii = i*ratio[0];
-                Real a = 1.0_rt;
+                Real a = Real(1.);
                 for     (int joff = 0; joff < ratio[1]; ++joff) {
                     for (int ioff = 0; ioff < ratio[0]; ++ioff) {
                         a = amrex::min(a, alpha(ii+ioff,jj+joff,0,n));
@@ -382,8 +382,8 @@ nodebilin_slopes (Box const& bx, Array4<T> const& slope, Array4<T const> const& 
     const auto lo = amrex::lbound(bx);
     const auto hi = amrex::ubound(bx);
 
-    const Real rx = 1.0_rt/ratio[0];
-    const Real ry = 1.0_rt/ratio[1];
+    const Real rx = Real(1.)/ratio[0];
+    const Real ry = Real(1.)/ratio[1];
 
     for (int n = 0; n < ncomp; ++n) {
         for     (int j = lo.y; j <= hi.y; ++j) {
@@ -435,8 +435,8 @@ face_linear_interp_x (int i, int j, int /*k*/, int n, Array4<T> const& fine,
 {
     int ii = amrex::coarsen(i,ratio[0]);
     int jj = amrex::coarsen(j,ratio[1]);
-    Real const w = static_cast<Real>(i-ii*ratio[0]) * (1.0_rt/ratio[0]);
-    fine(i,j,0,n) = (1.0_rt-w) * crse(ii,jj,0,n) + w * crse(ii+1,jj,0,n);
+    Real const w = static_cast<Real>(i-ii*ratio[0]) * (Real(1.)/ratio[0]);
+    fine(i,j,0,n) = (Real(1.)-w) * crse(ii,jj,0,n) + w * crse(ii+1,jj,0,n);
 }
 
 template<typename T>
@@ -446,8 +446,8 @@ face_linear_interp_y (int i, int j, int /*k*/, int n, Array4<T> const& fine,
 {
     int ii = amrex::coarsen(i,ratio[0]);
     int jj = amrex::coarsen(j,ratio[1]);
-    Real const w = static_cast<Real>(j-jj*ratio[1]) * (1.0_rt/ratio[1]);
-    fine(i,j,0,n) = (1.0_rt-w) * crse(ii,jj,0,n) + w * crse(ii,jj+1,0,n);
+    Real const w = static_cast<Real>(j-jj*ratio[1]) * (Real(1.)/ratio[1]);
+    fine(i,j,0,n) = (Real(1.)-w) * crse(ii,jj,0,n) + w * crse(ii,jj+1,0,n);
 }
 
 }

--- a/Src/AmrCore/AMReX_Interp_3D_C.H
+++ b/Src/AmrCore/AMReX_Interp_3D_C.H
@@ -21,13 +21,13 @@ ccinterp_compute_voff (Box const& cbx, IntVect const& ratio, Geometry const& /*c
     const int nxyz = flen.x + flen.y + flen.z;
     Vector<Real> voff(nxyz);
     
-    const Real xrinv = 1._rt/ratio[0];
-    const Real yrinv = 1._rt/ratio[1];
-    const Real zrinv = 1._rt/ratio[2];
+    const Real xrinv = Real(1.)/ratio[0];
+    const Real yrinv = Real(1.)/ratio[1];
+    const Real zrinv = Real(1.)/ratio[2];
 
-    const Real xtmp = 0.5_rt*(xrinv-1.0_rt);
-    const Real ytmp = 0.5_rt*(yrinv-1.0_rt);
-    const Real ztmp = 0.5_rt*(zrinv-1.0_rt);
+    const Real xtmp = Real(0.5)*(xrinv-Real(1.));
+    const Real ytmp = Real(0.5)*(yrinv-Real(1.));
+    const Real ztmp = Real(0.5)*(zrinv-Real(1.));
 
     Real* AMREX_RESTRICT xoff = &voff[0];
     AMREX_PRAGMA_SIMD
@@ -68,9 +68,9 @@ compute_slopes (const Dim3& lo, const Dim3& hi,
         for     (int j = lo.y; j <= hi.y; ++j) {
             AMREX_PRAGMA_SIMD
             for (int i = lo.x; i <= hi.x; ++i) {
-                slopes(i,j,k,ns        ) = 0.5_rt*(u(i+1,j,k,nu)-u(i-1,j,k,nu));
-                slopes(i,j,k,ns+ncomp  ) = 0.5_rt*(u(i,j+1,k,nu)-u(i,j-1,k,nu));
-                slopes(i,j,k,ns+ncomp*2) = 0.5_rt*(u(i,j,k+1,nu)-u(i,j,k-1,nu));
+                slopes(i,j,k,ns        ) = Real(0.5)*(u(i+1,j,k,nu)-u(i-1,j,k,nu));
+                slopes(i,j,k,ns+ncomp  ) = Real(0.5)*(u(i,j+1,k,nu)-u(i,j-1,k,nu));
+                slopes(i,j,k,ns+ncomp*2) = Real(0.5)*(u(i,j,k+1,nu)-u(i,j,k-1,nu));
             }
         }
     }
@@ -81,14 +81,14 @@ compute_slopes (const Dim3& lo, const Dim3& hi,
         if (shi.x-slo.x >= 1) {
             for         (int k = lo.z; k <= hi.z; ++k) {
                 for     (int j = lo.y; j <= hi.y; ++j) {
-                    slopes(i,j,k,ns) = -(16._rt/15._rt)*u(i-1,j,k,nu) + 0.5_rt*u(i,j,k,nu)
-                        + (2._rt/3._rt)*u(i+1,j,k,nu) - 0.1_rt*u(i+2,j,k,nu);
+                    slopes(i,j,k,ns) = -Real(16./15.)*u(i-1,j,k,nu) + Real(0.5)*u(i,j,k,nu)
+                        + Real(2./3.)*u(i+1,j,k,nu) - Real(0.1)*u(i+2,j,k,nu);
                 }
             }
         } else {
             for         (int k = lo.z; k <= hi.z; ++k) {
                 for     (int j = lo.y; j <= hi.y; ++j) {
-                    slopes(i,j,k,ns) = 0.25_rt*(u(i+1,j,k,nu)+5._rt*u(i,j,k,nu)-6._rt*u(i-1,j,k,nu));
+                    slopes(i,j,k,ns) = Real(0.25)*(u(i+1,j,k,nu)+Real(5.)*u(i,j,k,nu)-Real(6.)*u(i-1,j,k,nu));
                 }
             }
         }
@@ -100,14 +100,14 @@ compute_slopes (const Dim3& lo, const Dim3& hi,
         if (shi.x-slo.x >= 1) {
             for         (int k = lo.z; k <= hi.z; ++k) {
                 for     (int j = lo.y; j <= hi.y; ++j) {
-                    slopes(i,j,k,ns) = (16._rt/15._rt)*u(i+1,j,k,nu) - 0.5_rt*u(i,j,k,nu)
-                        - (2._rt/3._rt)*u(i-1,j,k,nu) + 0.1_rt*u(i-2,j,k,nu);
+                    slopes(i,j,k,ns) = Real(16./15.)*u(i+1,j,k,nu) - Real(0.5)*u(i,j,k,nu)
+                        - Real(2./3.)*u(i-1,j,k,nu) + Real(0.1)*u(i-2,j,k,nu);
                 }
             }                
         } else {
             for         (int k = lo.z; k <= hi.z; ++k) {
                 for     (int j = lo.y; j <= hi.y; ++j) {
-                    slopes(i,j,k,ns) = -0.25_rt*(u(i-1,j,k,nu)+5._rt*u(i,j,k,nu)-6._rt*u(i+1,j,k,nu));
+                    slopes(i,j,k,ns) = -Real(0.25)*(u(i-1,j,k,nu)+Real(5.)*u(i,j,k,nu)-Real(6.)*u(i+1,j,k,nu));
                 }
             }
         }
@@ -120,15 +120,15 @@ compute_slopes (const Dim3& lo, const Dim3& hi,
             for     (int k = lo.z; k <= hi.z; ++k) {
                 AMREX_PRAGMA_SIMD
                 for (int i = lo.x; i <= hi.x; ++i) {
-                    slopes(i,j,k,ns+ncomp) = -(16._rt/15._rt)*u(i,j-1,k,nu) + 0.5_rt*u(i,j,k,nu)
-                        + (2._rt/3._rt)*u(i,j+1,k,nu) - 0.1_rt*u(i,j+2,k,nu);
+                    slopes(i,j,k,ns+ncomp) = -Real(16./15.)*u(i,j-1,k,nu) + Real(0.5)*u(i,j,k,nu)
+                        + Real(2./3.)*u(i,j+1,k,nu) - Real(0.1)*u(i,j+2,k,nu);
                 }
             }
         } else {
             for     (int k = lo.z; k <= hi.z; ++k) {
                 AMREX_PRAGMA_SIMD
                 for (int i = lo.x; i <= hi.x; ++i) {
-                    slopes(i,j,k,ns+ncomp) = 0.25_rt*(u(i,j+1,k,nu)+5._rt*u(i,j,k,nu)-6._rt*u(i,j-1,k,nu));
+                    slopes(i,j,k,ns+ncomp) = Real(0.25)*(u(i,j+1,k,nu)+Real(5.)*u(i,j,k,nu)-Real(6.)*u(i,j-1,k,nu));
                 }
             }
         }
@@ -141,15 +141,15 @@ compute_slopes (const Dim3& lo, const Dim3& hi,
             for     (int k = lo.z; k <= hi.z; ++k) {
                 AMREX_PRAGMA_SIMD
                 for (int i = lo.x; i <= hi.x; ++i) {
-                    slopes(i,j,k,ns+ncomp) = (16._rt/15._rt)*u(i,j+1,k,nu) - 0.5_rt*u(i,j,k,nu)
-                        - (2._rt/3._rt)*u(i,j-1,k,nu) + 0.1_rt*u(i,j-2,k,nu);
+                    slopes(i,j,k,ns+ncomp) = Real(16./15.)*u(i,j+1,k,nu) - Real(0.5)*u(i,j,k,nu)
+                        - Real(2./3.)*u(i,j-1,k,nu) + Real(0.1)*u(i,j-2,k,nu);
                 }
             }
         } else {
             for     (int k = lo.z; k <= hi.z; ++k) {
                 AMREX_PRAGMA_SIMD
                 for (int i = lo.x; i <= hi.x; ++i) {
-                    slopes(i,j,k,ns+ncomp) = -0.25_rt*(u(i,j-1,k,nu)+5._rt*u(i,j,k,nu)-6._rt*u(i,j+1,k,nu));
+                    slopes(i,j,k,ns+ncomp) = -Real(0.25)*(u(i,j-1,k,nu)+Real(5.)*u(i,j,k,nu)-Real(6.)*u(i,j+1,k,nu));
                 }
             }
         }
@@ -162,15 +162,15 @@ compute_slopes (const Dim3& lo, const Dim3& hi,
             for     (int j = lo.y; j <= hi.y; ++j) {
                 AMREX_PRAGMA_SIMD
                 for (int i = lo.x; i <= hi.x; ++i) {
-                    slopes(i,j,k,ns+2*ncomp) = -(16._rt/15._rt)*u(i,j,k-1,nu) + 0.5_rt*u(i,j,k,nu)
-                        + (2._rt/3._rt)*u(i,j,k+1,nu) - 0.1_rt*u(i,j,k+2,nu);
+                    slopes(i,j,k,ns+2*ncomp) = -Real(16./15.)*u(i,j,k-1,nu) + Real(0.5)*u(i,j,k,nu)
+                        + Real(2./3.)*u(i,j,k+1,nu) - Real(0.1)*u(i,j,k+2,nu);
                 }
             }
         } else {
             for     (int j = lo.y; j <= hi.y; ++j) {
                 AMREX_PRAGMA_SIMD
                 for (int i = lo.x; i <= hi.x; ++i) {
-                    slopes(i,j,k,ns+2*ncomp) = 0.25_rt*(u(i,j,k+1,nu)+5._rt*u(i,j,k,nu)-6._rt*u(i,j,k-1,nu));
+                    slopes(i,j,k,ns+2*ncomp) = Real(0.25)*(u(i,j,k+1,nu)+Real(5.)*u(i,j,k,nu)-Real(6.)*u(i,j,k-1,nu));
                 }
             }
         }
@@ -183,15 +183,15 @@ compute_slopes (const Dim3& lo, const Dim3& hi,
             for     (int j = lo.y; j <= hi.y; ++j) {
                 AMREX_PRAGMA_SIMD
                 for (int i = lo.x; i <= hi.x; ++i) {
-                    slopes(i,j,k,ns+2*ncomp) = (16._rt/15._rt)*u(i,j,k+1,nu) - 0.5_rt*u(i,j,k,nu)
-                        - (2._rt/3._rt)*u(i,j,k-1,nu) + 0.1_rt*u(i,j,k-2,nu);
+                    slopes(i,j,k,ns+2*ncomp) = Real(16./15.)*u(i,j,k+1,nu) - Real(0.5)*u(i,j,k,nu)
+                        - Real(2./3.)*u(i,j,k-1,nu) + Real(0.1)*u(i,j,k-2,nu);
                 }
             }
         } else {
             for     (int j = lo.y; j <= hi.y; ++j) {
                 AMREX_PRAGMA_SIMD
                 for (int i = lo.x; i <= hi.x; ++i) {
-                    slopes(i,j,k,ns+2*ncomp) = -0.25_rt*(u(i,j,k-1,nu)+5._rt*u(i,j,k,nu)-6._rt*u(i,j,k+1,nu));
+                    slopes(i,j,k,ns+2*ncomp) = -Real(0.25)*(u(i,j,k-1,nu)+Real(5.)*u(i,j,k,nu)-Real(6.)*u(i,j,k+1,nu));
                 }
             }
         }
@@ -217,9 +217,9 @@ cellconslin_slopes_linlim (Box const& bx, Array4<Real> const& slopes,
         for     (int j = lo.y; j <= hi.y; ++j) {
             AMREX_PRAGMA_SIMD
             for (int i = lo.x; i <= hi.x; ++i) {
-                sf(i,j,k,0) = 1.0_rt;
-                sf(i,j,k,1) = 1.0_rt;
-                sf(i,j,k,2) = 1.0_rt;
+                sf(i,j,k,0) = Real(1.);
+                sf(i,j,k,1) = Real(1.);
+                sf(i,j,k,2) = Real(1.);
             }
         }
     }
@@ -234,36 +234,36 @@ cellconslin_slopes_linlim (Box const& bx, Array4<Real> const& slopes,
                 AMREX_PRAGMA_SIMD
                 for (int i = lo.x; i <= hi.x; ++i) {
                     Real cen  = slopes(i,j,k,n);
-                    Real forw = 2.0_rt*(u(i+1,j,k,nu)-u(i  ,j,k,nu));
-                    Real back = 2.0_rt*(u(i  ,j,k,nu)-u(i-1,j,k,nu));
-                    Real slp = (forw*back >= 0.0_rt) ? amrex::min(amrex::Math::abs(forw),amrex::Math::abs(back)) : 0.0_rt;
-                    slopes(i,j,k,n) = amrex::Math::copysign(1.0_rt,cen)*amrex::min(slp,amrex::Math::abs(cen));
-                    if (cen != 0.0_rt) {
+                    Real forw = Real(2.)*(u(i+1,j,k,nu)-u(i  ,j,k,nu));
+                    Real back = Real(2.)*(u(i  ,j,k,nu)-u(i-1,j,k,nu));
+                    Real slp = (forw*back >= Real(0.)) ? amrex::min(amrex::Math::abs(forw),amrex::Math::abs(back)) : Real(0.);
+                    slopes(i,j,k,n) = amrex::Math::copysign(Real(1.),cen)*amrex::min(slp,amrex::Math::abs(cen));
+                    if (cen != Real(0.)) {
                         sf(i,j,k,0) = amrex::min(sf(i,j,k,0), slopes(i,j,k,n)/cen);
                     } else {
-                        sf(i,j,k,0) = 0.0_rt;
+                        sf(i,j,k,0) = Real(0.);
                     }
 
                     cen  = slopes(i,j,k,n+ncomp);
-                    forw = 2.0_rt*(u(i,j+1,k,nu)-u(i,j  ,k,nu));
-                    back = 2.0_rt*(u(i,j  ,k,nu)-u(i,j-1,k,nu));
-                    slp = (forw*back >= 0.0_rt) ? amrex::min(amrex::Math::abs(forw),amrex::Math::abs(back)) : 0.0_rt;
-                    slopes(i,j,k,n+ncomp) = amrex::Math::copysign(1.0_rt,cen)*amrex::min(slp,amrex::Math::abs(cen));
-                    if (cen != 0.0_rt) {
+                    forw = Real(2.)*(u(i,j+1,k,nu)-u(i,j  ,k,nu));
+                    back = Real(2.)*(u(i,j  ,k,nu)-u(i,j-1,k,nu));
+                    slp = (forw*back >= Real(0.)) ? amrex::min(amrex::Math::abs(forw),amrex::Math::abs(back)) : Real(0.);
+                    slopes(i,j,k,n+ncomp) = amrex::Math::copysign(Real(1.),cen)*amrex::min(slp,amrex::Math::abs(cen));
+                    if (cen != Real(0.)) {
                         sf(i,j,k,1) = amrex::min(sf(i,j,k,1), slopes(i,j,k,n+ncomp)/cen);
                     } else {
-                        sf(i,j,k,1) = 0.0_rt;
+                        sf(i,j,k,1) = Real(0.);
                     }
 
                     cen  = slopes(i,j,k,n+ncomp*2);
-                    forw = 2.0_rt*(u(i,j,k+1,nu)-u(i,j,k  ,nu));
-                    back = 2.0_rt*(u(i,j,k  ,nu)-u(i,j,k-1,nu));
-                    slp = (forw*back >= 0.0_rt) ? amrex::min(amrex::Math::abs(forw),amrex::Math::abs(back)) : 0.0_rt;
-                    slopes(i,j,k,n+ncomp*2) = amrex::Math::copysign(1.0_rt,cen)*amrex::min(slp,amrex::Math::abs(cen));
-                    if (cen != 0.0_rt) {
+                    forw = Real(2.)*(u(i,j,k+1,nu)-u(i,j,k  ,nu));
+                    back = Real(2.)*(u(i,j,k  ,nu)-u(i,j,k-1,nu));
+                    slp = (forw*back >= Real(0.)) ? amrex::min(amrex::Math::abs(forw),amrex::Math::abs(back)) : Real(0.);
+                    slopes(i,j,k,n+ncomp*2) = amrex::Math::copysign(Real(1.),cen)*amrex::min(slp,amrex::Math::abs(cen));
+                    if (cen != Real(0.)) {
                         sf(i,j,k,2) = amrex::min(sf(i,j,k,2), slopes(i,j,k,n+ncomp*2)/cen);
                     } else {
-                        sf(i,j,k,2) = 0.0_rt;
+                        sf(i,j,k,2) = Real(0.);
                     }
                 }
             }
@@ -361,22 +361,22 @@ cellconslin_slopes_mclim (Box const& bx, Array4<Real> const& slopes,
                 AMREX_PRAGMA_SIMD
                 for (int i = lo.x; i <= hi.x; ++i) {
                     Real cen  = slopes(i,j,k,n);
-                    Real forw = 2.0_rt*(u(i+1,j,k,nu)-u(i  ,j,k,nu));
-                    Real back = 2.0_rt*(u(i  ,j,k,nu)-u(i-1,j,k,nu));
-                    Real slp = (forw*back >= 0.0_rt) ? amrex::min(amrex::Math::abs(forw),amrex::Math::abs(back)) : 0.0_rt;
-                    slopes(i,j,k,n) = amrex::Math::copysign(1.0_rt,cen)*amrex::min(slp,amrex::Math::abs(cen));
+                    Real forw = Real(2.)*(u(i+1,j,k,nu)-u(i  ,j,k,nu));
+                    Real back = Real(2.)*(u(i  ,j,k,nu)-u(i-1,j,k,nu));
+                    Real slp = (forw*back >= Real(0.)) ? amrex::min(amrex::Math::abs(forw),amrex::Math::abs(back)) : Real(0.);
+                    slopes(i,j,k,n) = amrex::Math::copysign(Real(1.),cen)*amrex::min(slp,amrex::Math::abs(cen));
 
                     cen  = slopes(i,j,k,n+ncomp);
-                    forw = 2.0_rt*(u(i,j+1,k,nu)-u(i,j  ,k,nu));
-                    back = 2.0_rt*(u(i,j  ,k,nu)-u(i,j-1,k,nu));
-                    slp = (forw*back >= 0.0_rt) ? amrex::min(amrex::Math::abs(forw),amrex::Math::abs(back)) : 0.0_rt;
-                    slopes(i,j,k,n+ncomp) = amrex::Math::copysign(1.0_rt,cen)*amrex::min(slp,amrex::Math::abs(cen));
+                    forw = Real(2.)*(u(i,j+1,k,nu)-u(i,j  ,k,nu));
+                    back = Real(2.)*(u(i,j  ,k,nu)-u(i,j-1,k,nu));
+                    slp = (forw*back >= Real(0.)) ? amrex::min(amrex::Math::abs(forw),amrex::Math::abs(back)) : Real(0.);
+                    slopes(i,j,k,n+ncomp) = amrex::Math::copysign(Real(1.),cen)*amrex::min(slp,amrex::Math::abs(cen));
 
                     cen  = slopes(i,j,k,n+ncomp*2);
-                    forw = 2.0_rt*(u(i,j,k+1,nu)-u(i,j,k  ,nu));
-                    back = 2.0_rt*(u(i,j,k  ,nu)-u(i,j,k-1,nu));
-                    slp = (forw*back >= 0.0_rt) ? amrex::min(amrex::Math::abs(forw),amrex::Math::abs(back)) : 0.0_rt;
-                    slopes(i,j,k,n+ncomp*2) = amrex::Math::copysign(1.0_rt,cen)*amrex::min(slp,amrex::Math::abs(cen));
+                    forw = Real(2.)*(u(i,j,k+1,nu)-u(i,j,k  ,nu));
+                    back = Real(2.)*(u(i,j,k  ,nu)-u(i,j,k-1,nu));
+                    slp = (forw*back >= Real(0.)) ? amrex::min(amrex::Math::abs(forw),amrex::Math::abs(back)) : Real(0.);
+                    slopes(i,j,k,n+ncomp*2) = amrex::Math::copysign(Real(1.),cen)*amrex::min(slp,amrex::Math::abs(cen));
                 }
             }
         }
@@ -411,12 +411,12 @@ cellconslin_fine_alpha (Box const& bx, Array4<Real> const& alpha,
                         +                   yoff[j-vlo.y]*slopes(ic,jc,kc,n+ncomp)
                         +                   zoff[k-vlo.z]*slopes(ic,jc,kc,n+ncomp*2);
 
-                    if (dummy_fine > mm(ic,jc,kc,n+ncomp) && dummy_fine != 0.0_rt) {
+                    if (dummy_fine > mm(ic,jc,kc,n+ncomp) && dummy_fine != Real(0.)) {
                         alpha(i,j,k,n) = mm(ic,jc,kc,n+ncomp) / dummy_fine;
-                    } else if (dummy_fine < mm(ic,jc,kc,n) && dummy_fine != 0.0_rt) {
+                    } else if (dummy_fine < mm(ic,jc,kc,n) && dummy_fine != Real(0.)) {
                         alpha(i,j,k,n) = mm(ic,jc,kc,n) / dummy_fine;
                     } else {
-                        alpha(i,j,k,n) = 1.0_rt;
+                        alpha(i,j,k,n) = Real(1.);
                     }
                 }
             }
@@ -439,7 +439,7 @@ cellconslin_slopes_mmlim (Box const& bx, Array4<Real> const& slopes,
                 const int jj = j*ratio[1];
                 for (int i = lo.x; i <= hi.x; ++i) {
                     const int ii = i*ratio[0];
-                    Real a = 1.0_rt;
+                    Real a = Real(1.);
                     for         (int koff = 0; koff < ratio[2]; ++koff) {
                         for     (int joff = 0; joff < ratio[1]; ++joff) {
                             for (int ioff = 0; ioff < ratio[0]; ++ioff) {
@@ -498,9 +498,9 @@ nodebilin_slopes (Box const& bx, Array4<T> const& slope, Array4<T const> const& 
     const auto lo = amrex::lbound(bx);
     const auto hi = amrex::ubound(bx);
 
-    const Real rx = 1.0_rt/ratio[0];
-    const Real ry = 1.0_rt/ratio[1];
-    const Real rz = 1.0_rt/ratio[2];
+    const Real rx = Real(1.)/ratio[0];
+    const Real ry = Real(1.)/ratio[1];
+    const Real rz = Real(1.)/ratio[2];
 
     for (int n = 0; n < ncomp; ++n) {
         const int nu = n + icomp;
@@ -574,8 +574,8 @@ face_linear_interp_x (int i, int j, int k, int n, Array4<T> const& fine,
     int ii = amrex::coarsen(i,ratio[0]);
     int jj = amrex::coarsen(j,ratio[1]);
     int kk = amrex::coarsen(k,ratio[2]);
-    Real const w = static_cast<Real>(i-ii*ratio[0]) * (1.0_rt/ratio[0]);
-    fine(i,j,k,n) = (1.0_rt-w) * crse(ii,jj,kk,n) + w * crse(ii+1,jj,kk,n);
+    Real const w = static_cast<Real>(i-ii*ratio[0]) * (Real(1.)/ratio[0]);
+    fine(i,j,k,n) = (Real(1.)-w) * crse(ii,jj,kk,n) + w * crse(ii+1,jj,kk,n);
 }
 
 template<typename T>
@@ -586,8 +586,8 @@ face_linear_interp_y (int i, int j, int k, int n, Array4<T> const& fine,
     int ii = amrex::coarsen(i,ratio[0]);
     int jj = amrex::coarsen(j,ratio[1]);
     int kk = amrex::coarsen(k,ratio[2]);
-    Real const w = static_cast<Real>(j-jj*ratio[1]) * (1.0_rt/ratio[1]);
-    fine(i,j,k,n) = (1.0_rt-w) * crse(ii,jj,kk,n) + w * crse(ii,jj+1,kk,n);
+    Real const w = static_cast<Real>(j-jj*ratio[1]) * (Real(1.)/ratio[1]);
+    fine(i,j,k,n) = (Real(1.)-w) * crse(ii,jj,kk,n) + w * crse(ii,jj+1,kk,n);
 }
 
 template<typename T>
@@ -598,8 +598,8 @@ face_linear_interp_z (int i, int j, int k, int n, Array4<T> const& fine,
     int ii = amrex::coarsen(i,ratio[0]);
     int jj = amrex::coarsen(j,ratio[1]);
     int kk = amrex::coarsen(k,ratio[2]);
-    Real const w = static_cast<Real>(k-kk*ratio[2]) * (1.0_rt/ratio[2]);
-    fine(i,j,k,n) = (1.0_rt-w) * crse(ii,jj,kk,n) + w * crse(ii,jj,kk+1,n);
+    Real const w = static_cast<Real>(k-kk*ratio[2]) * (Real(1.)/ratio[2]);
+    fine(i,j,k,n) = (Real(1.)-w) * crse(ii,jj,kk,n) + w * crse(ii,jj,kk+1,n);
 }
 
 }

--- a/Src/AmrTask/Amr/AMReX_AmrTask.cpp
+++ b/Src/AmrTask/Amr/AMReX_AmrTask.cpp
@@ -2580,7 +2580,7 @@ Amr::printGridInfo (std::ostream& os,
         int                       numgrid = bs.size();
         long                      ncells  = amr_level[lev]->countCells();
         double                    ntot    = Geom(lev).Domain().d_numPts();
-        Real                      frac    = 100.0_rt*(Real(ncells) / ntot);
+        Real                      frac    = Real(100.0)*(Real(ncells) / ntot);
         const DistributionMapping& map    = amr_level[lev]->get_new_data(0).DistributionMap();
 
         os << "  Level "

--- a/Src/Base/AMReX_Dim3.H
+++ b/Src/Base/AMReX_Dim3.H
@@ -20,7 +20,7 @@ struct Dim3 { int x; int y; int z;
 };
 struct XDim3 { Real x; Real y; Real z;
     AMREX_GPU_HOST_DEVICE
-    constexpr XDim3 () : x(0._rt), y(0._rt), z(0._rt) {}
+    constexpr XDim3 () : x(0.), y(0.), z(0.) {}
     AMREX_GPU_HOST_DEVICE
     constexpr XDim3 (Real x_, Real y_, Real z_) // xxxxx HIP: todo
         : x(x_), y(y_), z(z_) {}

--- a/Src/Base/AMReX_FArrayBox.cpp
+++ b/Src/Base/AMReX_FArrayBox.cpp
@@ -748,7 +748,7 @@ FABio_8bit::write (std::ostream&    os,
 {
     BL_ASSERT(comp >= 0 && num_comp >= 1 && (comp+num_comp) <= f.nComp());
 
-    const Real eps = 1.0e-8_rt; // FIXME - whats a better value?
+    const Real eps = 1.0e-8; // FIXME - whats a better value?
     const Long siz = f.box().numPts();
 
     unsigned char *c = new unsigned char[siz];

--- a/Src/Base/AMReX_GpuReduce.H
+++ b/Src/Base/AMReX_GpuReduce.H
@@ -39,7 +39,11 @@ T blockReduce (T x, WARPREDUCE && warp_reduce, T x0, Gpu::Handler const& h)
     sycl::intel::sub_group const& sg = h.item.get_sub_group();
     int lane = sg.get_local_id()[0];
     int wid = sg.get_group_id()[0];
+#if (__SYCL_COMPILER_VERSION <= 20200715)
     int numwarps = sg.get_group_range();
+#else
+    int numwarps = sg.get_group_range()[0];
+#endif
     x = warp_reduce(x, sg);
     // __syncthreads() prior to writing to shared memory is necessary
     // if this reduction call is occurring multiple times in a kernel,

--- a/Src/Base/AMReX_MultiFab.cpp
+++ b/Src/Base/AMReX_MultiFab.cpp
@@ -1274,7 +1274,7 @@ MultiFab::OverlapMask (const Periodicity& period) const
     [=] AMREX_GPU_DEVICE (int i, int j, int k, int n, Array4<Real> const& a) noexcept
     {
         Real* p = a.ptr(i,j,k,n);
-        Gpu::Atomic::Add(p, 1.0_rt);
+        Gpu::Atomic::Add(p, Real(1.0));
     });
 #endif
 

--- a/Src/Base/AMReX_MultiFabUtil_nd_C.H
+++ b/Src/Base/AMReX_MultiFabUtil_nd_C.H
@@ -23,9 +23,9 @@ void amrex_fill_slice_interp (Box const& bx, Array4<Real> slice,
     int ihi = 0, jhi = 0, khi = 0;
 
     Real weight = (coord - gd.ProbLo(dir)) / gd.CellSize(dir);
-    int dirhi = static_cast<int>(amrex::Math::floor(weight + 0.5_rt));
+    int dirhi = static_cast<int>(amrex::Math::floor(weight + Real(0.5)));
     int dirlo = dirhi-1;
-    weight -= dirlo+0.5_rt;
+    weight -= dirlo+Real(0.5);
 
     if (weight < 0.5) {
         switch (dir)

--- a/Src/Base/AMReX_REAL.H
+++ b/Src/Base/AMReX_REAL.H
@@ -68,6 +68,63 @@ namespace amrex {
     using Real = amrex_real;
     using ParticleReal = amrex_particle_real;
 
+#ifdef AMREX_USE_DPCPP
+namespace detail {
+    constexpr double atof (const char* p)
+    {
+        while (*p == ' ' || *p == '\t') ++p;
+
+        double sign = (*p == '-') ? -1.0 : 1.0;
+        if (*p == '-' || *p == '+') ++p;
+
+        double r = 0.;
+        while (*p >= '0' && *p <= '9') {
+            r = r*10. + double(*(p++) - '0');
+        }
+
+        if (*p == '.') {
+            ++p;
+            double r2 = 0.;
+            double d = 1.;
+            while (*p >= '0' && *p <= '9') {
+                r2 = r2*10. + double(*(p++) - '0');
+                d *= 10;
+            }
+            r += r2/d;
+        }
+
+        if (*p == 'e') {
+            ++p;
+            int sexp = (*p == '-') ? -1 : 1;
+            if (*p == '-' || *p == '+') ++p;
+            int iexp = 0;
+            while (*p >= '0' && *p <= '9') {
+                iexp = iexp*10 + (*(p++) - '0');
+            }
+            // need to compute 10**iexp = 10**(\sum 2**n) = \prod 10**(2**n)
+            int nmax = 0;
+            unsigned short int tmp = iexp;
+            while (tmp >>= 1) ++nmax;
+            double d = 1.0;
+            constexpr double powers[] = {10.,100.,1.e4,1.e8,1.e16,1.e32,1.e64,1.e128,1.e256};
+            for (int n = 0; n <= nmax; ++n) {
+                if (iexp & 0x1) {
+                    d *= powers[n];
+                }
+                iexp >>= 1;
+            }
+            if (sexp == -1) {
+                r /= d;
+            } else {
+                r *= d;
+            }
+        }
+
+        return sign*r;
+    }
+}
+#endif
+
 inline namespace literals {
 
     /** @{
@@ -79,11 +136,19 @@ inline namespace literals {
       auto const sphere_volume = 4_rt / 3_rt * pow(r, 3) * mypi;
       ```
     */
+#ifdef AMREX_USE_DPCPP
+    constexpr Real
+    operator"" _rt( const char* x )
+    {
+        return Real( detail::atof(x) );
+    }
+#else
     constexpr Real
     operator"" _rt( long double x )
     {
         return Real( x );
     }
+#endif
 
     constexpr Real
     operator"" _rt( unsigned long long int x )
@@ -91,11 +156,19 @@ inline namespace literals {
         return Real( x );
     }
 
+#ifdef AMREX_USE_DPCPP
+    constexpr ParticleReal
+    operator"" _prt( const char* x )
+    {
+        return ParticleReal( detail::atof(x) );
+    }
+#else
     constexpr ParticleReal
     operator"" _prt( long double x )
     {
         return ParticleReal( x );
     }
+#endif
 
     constexpr ParticleReal
     operator"" _prt( unsigned long long int x )

--- a/Src/Base/AMReX_Random.cpp
+++ b/Src/Base/AMReX_Random.cpp
@@ -139,7 +139,7 @@ amrex::RandomNormal (amrex::Real mean, amrex::Real stddev)
 
     amrex::ignore_unused(mean,stddev);
     assert(0);
-    rand = 0.0_rt;
+    rand = Real(0.0);
     return rand;
 
 #else
@@ -180,7 +180,7 @@ amrex::Random ()
 #elif defined(__SYCL_DEVICE_ONLY__)
 
     assert(0);
-    rand = 0.0_rt;
+    rand = Real(0.0);
     return rand;
 
 #else     // on the host

--- a/Src/Base/AMReX_Scan.H
+++ b/Src/Base/AMReX_Scan.H
@@ -205,7 +205,11 @@ T PrefixSum (int n, FIN && fin, FOUT && fout, Type type)
         sycl::intel::sub_group const& sg = gh.item.get_sub_group();
         int lane = sg.get_local_id()[0];
         int warp = sg.get_group_id()[0];
+#if (__SYCL_COMPILER_VERSION <= 20200715)
         int nwarps = sg.get_group_range();
+#else
+        int nwarps = sg.get_group_range()[0];
+#endif
 
         int threadIdxx = gh.item.get_local_id(0);
         int blockDimx = gh.item.get_local_range(0);

--- a/Src/Boundary/AMReX_InterpBndryData_2D_K.H
+++ b/Src/Boundary/AMReX_InterpBndryData_2D_K.H
@@ -57,7 +57,7 @@ void interpbndrydata_x_o3 (int i, int j, int /*k*/, int n,
         NN = 1;
     }
 
-    Real xInt = -0.5_rt + (j-jc*r.y+0.5_rt)/r.y;
+    Real xInt = -Real(0.5) + (j-jc*r.y+Real(0.5))/r.y;
     poly_interp_coeff(xInt, x, NN, c);
     Real b = 0.0;
     for (int m = 0; m < NN; ++m) {
@@ -106,7 +106,7 @@ void interpbndrydata_y_o3 (int i, int j, int /*k*/, int n,
         NN = 1;
     }
 
-    Real xInt = -0.5_rt + (i-ic*r.x+0.5_rt)/r.x;
+    Real xInt = -Real(0.5) + (i-ic*r.x+Real(0.5))/r.x;
     poly_interp_coeff(xInt, x, NN, c);
     Real b = 0.0;
     for (int m = 0; m < NN; ++m) {

--- a/Src/Boundary/AMReX_InterpBndryData_3D_K.H
+++ b/Src/Boundary/AMReX_InterpBndryData_3D_K.H
@@ -29,23 +29,23 @@ void interpbndrydata_x_o3 (int i, int j, int k, int n,
 
     int lo = (mask(i,j-r.y,k) == not_covered) ? jc-1 : jc;
     int hi = (mask(i,j+r.y,k) == not_covered) ? jc+1 : jc;
-    Real fac = (hi == lo+1) ? 1.0_rt : 0.5_rt;
+    Real fac = (hi == lo+1) ? Real(1.0) : Real(0.5);
     Real dy = fac*(crse(ic,hi,kc,n+nc)-crse(ic,lo,kc,n+nc));
-    Real dy2 = (hi==lo+2) ? 0.5_rt*(crse(ic,jc+1,kc,n+nc) - 2._rt*crse(ic,jc,kc,n+nc) + crse(ic,jc-1,kc,n+nc)) : 0._rt;
+    Real dy2 = (hi==lo+2) ? Real(0.5)*(crse(ic,jc+1,kc,n+nc) - Real(2.)*crse(ic,jc,kc,n+nc) + crse(ic,jc-1,kc,n+nc)) : Real(0.);
 
     lo = (mask(i,j,k-r.z) == not_covered) ? kc-1 : kc;
     hi = (mask(i,j,k+r.z) == not_covered) ? kc+1 : kc;
-    fac = (hi == lo+1) ? 1.0_rt : 0.5_rt;
+    fac = (hi == lo+1) ? Real(1.0) : Real(0.5);
     Real dz = fac*(crse(ic,jc,hi,n+nc)-crse(ic,jc,lo,n+nc));
-    Real dz2 = (hi==lo+2) ? 0.5_rt*(crse(ic,jc,kc+1,n+nc) - 2._rt*crse(ic,jc,kc,n+nc) + crse(ic,jc,kc-1,n+nc)) : 0._rt;
+    Real dz2 = (hi==lo+2) ? Real(0.5)*(crse(ic,jc,kc+1,n+nc) - Real(2.)*crse(ic,jc,kc,n+nc) + crse(ic,jc,kc-1,n+nc)) : Real(0.);
 
     Real dyz = (mask(i,j-r.y,k-r.z) == not_covered and mask(i,j+r.y,k-r.z) == not_covered and
                 mask(i,j-r.y,k+r.z) == not_covered and mask(i,j+r.y,k+r.z) == not_covered)
-        ? 0.25_rt*(crse(ic,jc+1,kc+1,n+nc)-crse(ic,jc-1,kc+1,n+nc)+crse(ic,jc-1,kc-1,n+nc)-crse(ic,jc+1,kc-1,n+nc))
+        ? Real(0.25)*(crse(ic,jc+1,kc+1,n+nc)-crse(ic,jc-1,kc+1,n+nc)+crse(ic,jc-1,kc-1,n+nc)-crse(ic,jc+1,kc-1,n+nc))
         : 0.0;
 
-    Real y = -0.5_rt + (j-jc*r.y+0.5_rt)/r.y;
-    Real z = -0.5_rt + (k-kc*r.z+0.5_rt)/r.z;
+    Real y = -Real(0.5) + (j-jc*r.y+Real(0.5))/r.y;
+    Real z = -Real(0.5) + (k-kc*r.z+Real(0.5))/r.z;
     bdry(i,j,k,n+nb) = crse(ic,jc,kc,n+nc) + y*dy + (y*y)*dy2 + z*dz + (z*z)*dz2 + y*z*dyz;
 }
 
@@ -61,24 +61,24 @@ void interpbndrydata_y_o3 (int i, int j, int k, int n,
 
     int lo = (mask(i-r.x,j,k) == not_covered) ? ic-1 : ic;
     int hi = (mask(i+r.x,j,k) == not_covered) ? ic+1 : ic;
-    Real fac = (hi == lo+1) ? 1.0_rt : 0.5_rt;
+    Real fac = (hi == lo+1) ? Real(1.0) : Real(0.5);
     Real dx = fac*(crse(hi,jc,kc,n+nc)-crse(lo,jc,kc,n+nc));
-    Real dx2 = (hi==lo+2) ? 0.5_rt*(crse(ic+1,jc,kc,n+nc) - 2._rt*crse(ic,jc,kc,n+nc) + crse(ic-1,jc,kc,n+nc)) : 0._rt;
+    Real dx2 = (hi==lo+2) ? Real(0.5)*(crse(ic+1,jc,kc,n+nc) - Real(2.)*crse(ic,jc,kc,n+nc) + crse(ic-1,jc,kc,n+nc)) : Real(0.);
 
     lo = (mask(i,j,k-r.z) == not_covered) ? kc-1 : kc;
     hi = (mask(i,j,k+r.z) == not_covered) ? kc+1 : kc;
-    fac = (hi == lo+1) ? 1.0_rt : 0.5_rt;
+    fac = (hi == lo+1) ? Real(1.0) : Real(0.5);
     Real dz = fac*(crse(ic,jc,hi,n+nc)-crse(ic,jc,lo,n+nc));
-    Real dz2 = (hi==lo+2) ? 0.5_rt*(crse(ic,jc,kc+1,n+nc) - 2._rt*crse(ic,jc,kc,n+nc) + crse(ic,jc,kc-1,n+nc)) : 0._rt;
+    Real dz2 = (hi==lo+2) ? Real(0.5)*(crse(ic,jc,kc+1,n+nc) - Real(2.)*crse(ic,jc,kc,n+nc) + crse(ic,jc,kc-1,n+nc)) : Real(0.);
 
     Real dxz = (mask(i-r.x,j,k-r.z) == not_covered and mask(i+r.x,j,k-r.z) == not_covered and
                 mask(i-r.x,j,k+r.z) == not_covered and mask(i+r.x,j,k+r.z) == not_covered)
-        ? 0.25_rt*(crse(ic+1,jc,kc+1,n+nc)-crse(ic-1,jc,kc+1,n+nc)+crse(ic-1,jc,kc-1,n+nc)-crse(ic+1,jc,kc-1,n+nc))
+        ? Real(0.25)*(crse(ic+1,jc,kc+1,n+nc)-crse(ic-1,jc,kc+1,n+nc)+crse(ic-1,jc,kc-1,n+nc)-crse(ic+1,jc,kc-1,n+nc))
         : 0.0;
 
 
-    Real x = -0.5_rt + (i-ic*r.x+0.5_rt)/r.x;
-    Real z = -0.5_rt + (k-kc*r.z+0.5_rt)/r.z;
+    Real x = -Real(0.5) + (i-ic*r.x+Real(0.5))/r.x;
+    Real z = -Real(0.5) + (k-kc*r.z+Real(0.5))/r.z;
     bdry(i,j,k,n+nb) = crse(ic,jc,kc,n+nc) + x*dx + (x*x)*dx2 + z*dz + (z*z)*dz2 + x*z*dxz;
 }
 
@@ -94,23 +94,23 @@ void interpbndrydata_z_o3 (int i, int j, int k, int n,
 
     int lo = (mask(i-r.x,j,k) == not_covered) ? ic-1 : ic;
     int hi = (mask(i+r.x,j,k) == not_covered) ? ic+1 : ic;
-    Real fac = (hi == lo+1) ? 1.0_rt : 0.5_rt;
+    Real fac = (hi == lo+1) ? Real(1.0) : Real(0.5);
     Real dx = fac*(crse(hi,jc,kc,n+nc)-crse(lo,jc,kc,n+nc));
-    Real dx2 = (hi==lo+2) ? 0.5_rt*(crse(ic+1,jc,kc,n+nc) - 2._rt*crse(ic,jc,kc,n+nc) + crse(ic-1,jc,kc,n+nc)) : 0._rt;
+    Real dx2 = (hi==lo+2) ? Real(0.5)*(crse(ic+1,jc,kc,n+nc) - Real(2.)*crse(ic,jc,kc,n+nc) + crse(ic-1,jc,kc,n+nc)) : Real(0.);
 
     lo = (mask(i,j-r.y,k) == not_covered) ? jc-1 : jc;
     hi = (mask(i,j+r.y,k) == not_covered) ? jc+1 : jc;
-    fac = (hi == lo+1) ? 1.0_rt : 0.5_rt;
+    fac = (hi == lo+1) ? Real(1.0) : Real(0.5);
     Real dy = fac*(crse(ic,hi,kc,n+nc)-crse(ic,lo,kc,n+nc));
-    Real dy2 = (hi==lo+2) ? 0.5_rt*(crse(ic,jc+1,kc,n+nc) - 2._rt*crse(ic,jc,kc,n+nc) + crse(ic,jc-1,kc,n+nc)) : 0._rt;
+    Real dy2 = (hi==lo+2) ? Real(0.5)*(crse(ic,jc+1,kc,n+nc) - Real(2.)*crse(ic,jc,kc,n+nc) + crse(ic,jc-1,kc,n+nc)) : Real(0.);
 
     Real dxy = (mask(i-r.x,j-r.y,k) == not_covered and mask(i+r.x,j-r.y,k) == not_covered and
                 mask(i-r.x,j+r.y,k) == not_covered and mask(i+r.x,j+r.y,k) == not_covered)
-        ? 0.25_rt*(crse(ic+1,jc+1,kc,n+nc)-crse(ic-1,jc+1,kc,n+nc)+crse(ic-1,jc-1,kc,n+nc)-crse(ic+1,jc-1,kc,n+nc))
+        ? Real(0.25)*(crse(ic+1,jc+1,kc,n+nc)-crse(ic-1,jc+1,kc,n+nc)+crse(ic-1,jc-1,kc,n+nc)-crse(ic+1,jc-1,kc,n+nc))
         : 0.0;
 
-    Real x = -0.5_rt + (i-ic*r.x+0.5_rt)/r.x;
-    Real y = -0.5_rt + (j-jc*r.y+0.5_rt)/r.y;
+    Real x = -Real(0.5) + (i-ic*r.x+Real(0.5))/r.x;
+    Real y = -Real(0.5) + (j-jc*r.y+Real(0.5))/r.y;
     bdry(i,j,k,n+nb) = crse(ic,jc,kc,n+nc) + x*dx + (x*x)*dx2 + y*dy + (y*y)*dy2 + x*y*dxy;
 }
 

--- a/Src/EB/AMReX_algoim_K.H
+++ b/Src/EB/AMReX_algoim_K.H
@@ -370,7 +370,7 @@ struct ImplicitIntegral
         Real x_max = xrange.max(e0);
         roots[0] = x_min;
         int nroots = 1;
-        if (phi.grad(e0) != 0.0_rt) {
+        if (phi.grad(e0) != Real(0.0)) {
             for (int i = 0; i < psiCount; ++i)
             {
                 for (int dim = 0; dim < N; ++dim) {

--- a/Src/LinearSolvers/MLMG/AMReX_MLCGSolver.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLCGSolver.cpp
@@ -161,7 +161,7 @@ MLCGSolver::solve_bicgstab (MultiFab&       sol,
         Lp.normalize(amrlev, mglev, v);
 
         Real rhTv = dotxy(rh,v);
-        if ( rhTv != 0.0_rt )
+        if ( rhTv != Real(0.0) )
 	{
             alpha = rho/rhTv;
 	}
@@ -201,7 +201,7 @@ MLCGSolver::solve_bicgstab (MultiFab&       sol,
         ParallelAllReduce::Sum(tvals,2,Lp.BottomCommunicator());
         BL_PROFILE_VAR_STOP(blp_par);
 
-        if ( tvals[0] != 0.0_rt )
+        if ( tvals[0] != Real(0.0) )
 	{
             omega = tvals[1]/tvals[0];
 	}
@@ -334,7 +334,7 @@ MLCGSolver::solve_cg (MultiFab&       sol,
 
         Real alpha;
         Real pw = dotxy(p,q);
-        if ( pw != 0.0_rt)
+        if ( pw != Real(0.0))
 	{
             alpha = rho/pw;
 	}

--- a/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap_K.H
@@ -8,7 +8,7 @@
 namespace amrex { namespace {
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     Real get_dx_eb (Real kappa) noexcept {
-        return amrex::max(0.3_rt,(kappa*kappa-0.25_rt)/(2.0_rt*kappa));
+        return amrex::max(Real(0.3),(kappa*kappa-Real(0.25))/(Real(2.0)*kappa));
     }
 }}
 
@@ -62,17 +62,17 @@ void mlebabeclap_apply_bc_x (int side, Box const& box, int blen,
     case AMREX_LO_DIRICHLET:
     {
         const int NX = amrex::min(blen+1, maxorder);
-        GpuArray<Real,4> x{-bcl * dxinv, 0.5_rt, 1.5_rt, 2.5_rt};
+        GpuArray<Real,4> x{-bcl * dxinv, Real(0.5), Real(1.5), Real(2.5)};
         Array2D<Real, 0, 3, 0, 2> coef{};
         for (int r = 0; r <= maxorder-2; ++r) {
-            poly_interp_coeff(-0.5_rt, &x[0], NX, &(coef(0,r)));
+            poly_interp_coeff(-Real(0.5), &x[0], NX, &(coef(0,r)));
         }
         for     (int k = lo.z; k <= hi.z; ++k) {
             for (int j = lo.y; j <= hi.y; ++j) {
                 if (mask(i,j,k) == 0 and mask(i+s,j,k) == 1) {
                     int order = 1;
                     for (int r = 0; r <= NX-2; ++r) {
-                        if (area(i+(1-side)+s*r,j,k) > 0.0_rt) {
+                        if (area(i+(1-side)+s*r,j,k) > Real(0.0)) {
                             ++order;
                         } else {
                             break;
@@ -82,10 +82,10 @@ void mlebabeclap_apply_bc_x (int side, Box const& box, int blen,
                         if (inhomog) {
                             phi(i,j,k,icomp) = bcval(i,j,k,icomp);
                         } else {
-                            phi(i,j,k,icomp) = 0.0_rt;
+                            phi(i,j,k,icomp) = Real(0.0);
                         }
                     } else {
-                        Real tmp = 0.0_rt;
+                        Real tmp = Real(0.0);
                         for (int m = 1; m < order; ++m) {
                             tmp += phi(i+m*s,j,k,icomp) * coef(m,order-2);
                         }
@@ -142,17 +142,17 @@ void mlebabeclap_apply_bc_y (int side, Box const& box, int blen,
     case AMREX_LO_DIRICHLET:
     {
         const int NX = amrex::min(blen+1, maxorder);
-        GpuArray<Real,4> x{-bcl * dyinv, 0.5_rt, 1.5_rt, 2.5_rt};
+        GpuArray<Real,4> x{-bcl * dyinv, Real(0.5), Real(1.5), Real(2.5)};
         Array2D<Real, 0, 3, 0, 2> coef{};
         for (int r = 0; r <= maxorder-2; ++r) {
-            poly_interp_coeff(-0.5_rt, &x[0], NX, &(coef(0,r)));
+            poly_interp_coeff(-Real(0.5), &x[0], NX, &(coef(0,r)));
         }
         for     (int k = lo.z; k <= hi.z; ++k) {
             for (int i = lo.x; i <= hi.x; ++i) {
                 if (mask(i,j,k) == 0 and mask(i,j+s,k) == 1) {
                     int order = 1;
                     for (int r = 0; r <= NX-2; ++r) {
-                        if (area(i,j+(1-side)+s*r,k) > 0.0_rt) {
+                        if (area(i,j+(1-side)+s*r,k) > Real(0.0)) {
                             ++order;
                         } else {
                             break;
@@ -162,10 +162,10 @@ void mlebabeclap_apply_bc_y (int side, Box const& box, int blen,
                         if (inhomog) {
                             phi(i,j,k,icomp) = bcval(i,j,k,icomp);
                         } else {
-                            phi(i,j,k,icomp) = 0.0_rt;
+                            phi(i,j,k,icomp) = Real(0.0);
                         }
                     } else {
-                        Real tmp = 0.0_rt;
+                        Real tmp = Real(0.0);
                         for (int m = 1; m < order; ++m) {
                             tmp += phi(i,j+m*s,k,icomp) * coef(m,order-2);
                         }
@@ -222,17 +222,17 @@ void mlebabeclap_apply_bc_z (int side, Box const& box, int blen,
     case AMREX_LO_DIRICHLET:
     {
         const int NX = amrex::min(blen+1, maxorder);
-        GpuArray<Real,4> x{-bcl * dzinv, 0.5_rt, 1.5_rt, 2.5_rt};
+        GpuArray<Real,4> x{-bcl * dzinv, Real(0.5), Real(1.5), Real(2.5)};
         Array2D<Real, 0, 3, 0, 2> coef{};
         for (int r = 0; r <= maxorder-2; ++r) {
-            poly_interp_coeff(-0.5_rt, &x[0], NX, &(coef(0,r)));
+            poly_interp_coeff(-Real(0.5), &x[0], NX, &(coef(0,r)));
         }
         for     (int j = lo.y; j <= hi.y; ++j) {
             for (int i = lo.x; i <= hi.x; ++i) {
                 if (mask(i,j,k) == 0 and mask(i,j,k+s) == 1) {
                     int order = 1;
                     for (int r = 0; r <= NX-2; ++r) {
-                        if (area(i,j,k+(1-side)+s*r) > 0.0_rt) {
+                        if (area(i,j,k+(1-side)+s*r) > Real(0.0)) {
                             ++order;
                         } else {
                             break;
@@ -242,10 +242,10 @@ void mlebabeclap_apply_bc_z (int side, Box const& box, int blen,
                         if (inhomog) {
                             phi(i,j,k,icomp) = bcval(i,j,k,icomp);
                         } else {
-                            phi(i,j,k,icomp) = 0.0_rt;
+                            phi(i,j,k,icomp) = Real(0.0);
                         }
                     } else {
-                        Real tmp = 0.0_rt;
+                        Real tmp = Real(0.0);
                         for (int m = 1; m < order; ++m) {
                             tmp += phi(i,j,k+m*s,icomp) * coef(m,order-2);
                         }

--- a/Src/LinearSolvers/MLMG/AMReX_MLLinOp.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLLinOp.cpp
@@ -426,7 +426,7 @@ MLLinOp::defineGrids (const Vector<Geometry>& a_geom,
     else
     {
         int rr = mg_coarsen_ratio;
-        Real avg_npts = 0._rt;
+        Real avg_npts = 0.0;
         if (info.do_consolidation) {
             avg_npts = static_cast<Real>(a_grids[0].d_numPts()) / static_cast<Real>(ParallelContext::NProcsSub());
             if (consolidation_threshold == -1) {

--- a/Src/LinearSolvers/MLMG/AMReX_MLLinOp_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLLinOp_K.H
@@ -46,13 +46,13 @@ void mllinop_apply_bc_x (int side, Box const& box, int blen,
     case AMREX_LO_DIRICHLET:
     {
         const int NX = amrex::min(blen+1, maxorder);
-        GpuArray<Real,4> x{{-bcl * dxinv, 0.5_rt, 1.5_rt, 2.5_rt}};
+        GpuArray<Real,4> x{{-bcl * dxinv, Real(0.5), Real(1.5), Real(2.5)}};
         GpuArray<Real,4> coef{};
-        poly_interp_coeff(-0.5_rt, &x[0], NX, &coef[0]);
+        poly_interp_coeff(-Real(0.5), &x[0], NX, &coef[0]);
         for     (int k = lo.z; k <= hi.z; ++k) {
             for (int j = lo.y; j <= hi.y; ++j) {
                 if (mask(i,j,k) > 0) {
-                    Real tmp = 0.0_rt;
+                    Real tmp = Real(0.0);
                     for (int m = 1; m < NX; ++m) {
                         tmp += phi(i+m*s,j,k,icomp) * coef[m];
                     }
@@ -107,13 +107,13 @@ void mllinop_apply_bc_y (int side, Box const& box, int blen,
     case AMREX_LO_DIRICHLET:
     {
         const int NX = amrex::min(blen+1, maxorder);
-        GpuArray<Real,4> x{{-bcl * dyinv, 0.5_rt, 1.5_rt, 2.5_rt}};
+        GpuArray<Real,4> x{{-bcl * dyinv, Real(0.5), Real(1.5), Real(2.5)}};
         GpuArray<Real,4> coef{};
-        poly_interp_coeff(-0.5_rt, &x[0], NX, &coef[0]);
+        poly_interp_coeff(-Real(0.5), &x[0], NX, &coef[0]);
         for     (int k = lo.z; k <= hi.z; ++k) {
             for (int i = lo.x; i <= hi.x; ++i) {
                 if (mask(i,j,k) > 0) {
-                    Real tmp = 0.0_rt;
+                    Real tmp = Real(0.0);
                     for (int m = 1; m < NX; ++m) {
                         tmp += phi(i,j+m*s,k,icomp) * coef[m];
                     }
@@ -168,13 +168,13 @@ void mllinop_apply_bc_z (int side, Box const& box, int blen,
     case AMREX_LO_DIRICHLET:
     {
         const int NX = amrex::min(blen+1, maxorder);
-        GpuArray<Real,4> x{{-bcl * dzinv, 0.5_rt, 1.5_rt, 2.5_rt}};
+        GpuArray<Real,4> x{{-bcl * dzinv, Real(0.5), Real(1.5), Real(2.5)}};
         GpuArray<Real,4> coef{};
-        poly_interp_coeff(-0.5_rt, &x[0], NX, &coef[0]);
+        poly_interp_coeff(-Real(0.5), &x[0], NX, &coef[0]);
         for     (int j = lo.y; j <= hi.y; ++j) {
             for (int i = lo.x; i <= hi.x; ++i) {
                 if (mask(i,j,k) > 0) {
-                    Real tmp = 0.0_rt;
+                    Real tmp = Real(0.0);
                     for (int m = 1; m < NX; ++m) {
                         tmp += phi(i,j,k+m*s,icomp) * coef[m];
                     }
@@ -207,7 +207,7 @@ void mllinop_comp_interp_coef0_x (int side, Box const& box, int blen,
     {
         for     (int k = lo.z; k <= hi.z; ++k) {
             for (int j = lo.y; j <= hi.y; ++j) {
-                f(ii,j,k,icomp) = 1.0_rt;
+                f(ii,j,k,icomp) = Real(1.0);
             }
         }
         break;
@@ -216,7 +216,7 @@ void mllinop_comp_interp_coef0_x (int side, Box const& box, int blen,
     {
         for     (int k = lo.z; k <= hi.z; ++k) {
             for (int j = lo.y; j <= hi.y; ++j) {
-                f(ii,j,k,icomp) = (mask(ib,j,k) > 0) ? 1.0_rt : 0.0_rt;
+                f(ii,j,k,icomp) = (mask(ib,j,k) > 0) ? Real(1.0) : Real(0.0);
             }
         }
         break;
@@ -224,12 +224,12 @@ void mllinop_comp_interp_coef0_x (int side, Box const& box, int blen,
     case AMREX_LO_DIRICHLET:
     {
         const int NX = amrex::min(blen+1, maxorder);
-        GpuArray<Real,4> x{{-bcl * dxinv, 0.5_rt, 1.5_rt, 2.5_rt}};
+        GpuArray<Real,4> x{{-bcl * dxinv, Real(0.5), Real(1.5), Real(2.5)}};
         GpuArray<Real,4> coef{};
-        poly_interp_coeff(-0.5_rt, &x[0], NX, &coef[0]);
+        poly_interp_coeff(-Real(0.5), &x[0], NX, &coef[0]);
         for     (int k = lo.z; k <= hi.z; ++k) {
             for (int j = lo.y; j <= hi.y; ++j) {
-                f(ii,j,k,icomp) = (mask(ib,j,k) > 0) ? coef[1] : 0.0_rt;
+                f(ii,j,k,icomp) = (mask(ib,j,k) > 0) ? coef[1] : Real(0.0);
             }
         }
         break;
@@ -254,7 +254,7 @@ void mllinop_comp_interp_coef0_y (int side, Box const& box, int blen,
     {
         for     (int k = lo.z; k <= hi.z; ++k) {
             for (int i = lo.x; i <= hi.x; ++i) {
-                f(i,ji,k,icomp) = 1.0_rt;
+                f(i,ji,k,icomp) = Real(1.0);
             }
         }
         break;
@@ -263,7 +263,7 @@ void mllinop_comp_interp_coef0_y (int side, Box const& box, int blen,
     {
         for     (int k = lo.z; k <= hi.z; ++k) {
             for (int i = lo.x; i <= hi.x; ++i) {
-                f(i,ji,k,icomp) = (mask(i,jb,k) > 0) ? 1.0_rt : 0.0_rt;
+                f(i,ji,k,icomp) = (mask(i,jb,k) > 0) ? Real(1.0) : Real(0.0);
             }
         }
         break;
@@ -271,12 +271,12 @@ void mllinop_comp_interp_coef0_y (int side, Box const& box, int blen,
     case AMREX_LO_DIRICHLET:
     {
         const int NX = amrex::min(blen+1, maxorder);
-        GpuArray<Real,4> x{{-bcl * dyinv, 0.5_rt, 1.5_rt, 2.5_rt}};
+        GpuArray<Real,4> x{{-bcl * dyinv, Real(0.5), Real(1.5), Real(2.5)}};
         GpuArray<Real,4> coef{};
-        poly_interp_coeff(-0.5_rt, &x[0], NX, &coef[0]);
+        poly_interp_coeff(-Real(0.5), &x[0], NX, &coef[0]);
         for     (int k = lo.z; k <= hi.z; ++k) {
             for (int i = lo.x; i <= hi.x; ++i) {
-                f(i,ji,k,icomp) = (mask(i,jb,k) > 0) ? coef[1] : 0.0_rt;
+                f(i,ji,k,icomp) = (mask(i,jb,k) > 0) ? coef[1] : Real(0.0);
             }
         }
         break;
@@ -301,7 +301,7 @@ void mllinop_comp_interp_coef0_z (int side, Box const& box, int blen,
     {
         for     (int j = lo.y; j <= hi.y; ++j) {
             for (int i = lo.x; i <= hi.x; ++i) {
-                f(i,j,ki,icomp) = 1.0_rt;
+                f(i,j,ki,icomp) = Real(1.0);
             }
         }
         break;
@@ -310,7 +310,7 @@ void mllinop_comp_interp_coef0_z (int side, Box const& box, int blen,
     {
         for     (int j = lo.y; j <= hi.y; ++j) {
             for (int i = lo.x; i <= hi.x; ++i) {
-                f(i,j,ki,icomp) = (mask(i,j,kb) > 0) ? 1.0_rt : 0.0_rt;
+                f(i,j,ki,icomp) = (mask(i,j,kb) > 0) ? Real(1.0) : Real(0.0);
             }
         }
         break;
@@ -318,12 +318,12 @@ void mllinop_comp_interp_coef0_z (int side, Box const& box, int blen,
     case AMREX_LO_DIRICHLET:
     {
         const int NX = amrex::min(blen+1, maxorder);
-        GpuArray<Real,4> x{{-bcl * dzinv, 0.5_rt, 1.5_rt, 2.5_rt}};
+        GpuArray<Real,4> x{{-bcl * dzinv, Real(0.5), Real(1.5), Real(2.5)}};
         GpuArray<Real,4> coef{};
-        poly_interp_coeff(-0.5_rt, &x[0], NX, &coef[0]);
+        poly_interp_coeff(-Real(0.5), &x[0], NX, &coef[0]);
         for     (int j = lo.y; j <= hi.y; ++j) {
             for (int i = lo.x; i <= hi.x; ++i) {
-                f(i,j,ki,icomp) = (mask(i,j,kb) > 0) ? coef[1] : 0.0_rt;
+                f(i,j,ki,icomp) = (mask(i,j,kb) > 0) ? coef[1] : Real(0.0);
             }
         }
         break;
@@ -342,7 +342,7 @@ void mllinop_apply_innu_xlo (int i, int j, int k,
                              Real fac, bool has_bcoef, int icomp) noexcept
 {
     if (bct == AMREX_LO_NEUMANN and mask(i,j,k) == 2) {
-        Real b = (has_bcoef) ? bcoef(i+1,j,k,icomp) : 1.0_rt;
+        Real b = (has_bcoef) ? bcoef(i+1,j,k,icomp) : Real(1.0);
         rhs(i+1,j,k,icomp) -= fac*b*bcval(i,j,k,icomp);
     }
 }
@@ -357,7 +357,7 @@ void mllinop_apply_innu_xhi (int i, int j, int k,
                              Real fac, bool has_bcoef, int icomp) noexcept
 {
     if (bct == AMREX_LO_NEUMANN and mask(i,j,k) == 2) {
-        Real b = (has_bcoef) ? bcoef(i,j,k,icomp) : 1.0_rt;
+        Real b = (has_bcoef) ? bcoef(i,j,k,icomp) : Real(1.0);
         rhs(i-1,j,k,icomp) += fac*b*bcval(i,j,k,icomp);
     }
 }
@@ -372,7 +372,7 @@ void mllinop_apply_innu_ylo (int i, int j, int k,
                              Real fac, bool has_bcoef, int icomp) noexcept
 {
     if (bct == AMREX_LO_NEUMANN and mask(i,j,k) == 2) {
-        Real b = (has_bcoef) ? bcoef(i,j+1,k,icomp) : 1.0_rt;
+        Real b = (has_bcoef) ? bcoef(i,j+1,k,icomp) : Real(1.0);
         rhs(i,j+1,k,icomp) -= fac*b*bcval(i,j,k,icomp);
     }
 }
@@ -401,7 +401,7 @@ void mllinop_apply_innu_yhi (int i, int j, int k,
                              Real fac, bool has_bcoef, int icomp) noexcept
 {
     if (bct == AMREX_LO_NEUMANN and mask(i,j,k) == 2) {
-        Real b = (has_bcoef) ? bcoef(i,j,k,icomp) : 1.0_rt;
+        Real b = (has_bcoef) ? bcoef(i,j,k,icomp) : Real(1.0);
         rhs(i,j-1,k,icomp) += fac*b*bcval(i,j,k,icomp);
     }
 }
@@ -430,7 +430,7 @@ void mllinop_apply_innu_zlo (int i, int j, int k,
                              Real fac, bool has_bcoef, int icomp) noexcept
 {
     if (bct == AMREX_LO_NEUMANN and mask(i,j,k) == 2) {
-        Real b = (has_bcoef) ? bcoef(i,j,k+1,icomp) : 1.0_rt;
+        Real b = (has_bcoef) ? bcoef(i,j,k+1,icomp) : Real(1.0);
         rhs(i,j,k+1,icomp) -= fac*b*bcval(i,j,k,icomp);
     }
 }
@@ -445,7 +445,7 @@ void mllinop_apply_innu_zhi (int i, int j, int k,
                              Real fac, bool has_bcoef, int icomp) noexcept
 {
     if (bct == AMREX_LO_NEUMANN and mask(i,j,k) == 2) {
-        Real b = (has_bcoef) ? bcoef(i,j,k,icomp) : 1.0_rt;
+        Real b = (has_bcoef) ? bcoef(i,j,k,icomp) : Real(1.0);
         rhs(i,j,k-1,icomp) += fac*b*bcval(i,j,k,icomp);
     }
 }

--- a/Src/LinearSolvers/MLMG/AMReX_MLMG.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLMG.cpp
@@ -107,7 +107,7 @@ MLMG::solve (const Vector<MultiFab*>& a_sol, const Vector<MultiFab const*>& a_rh
         norm_name = "resid0";
         max_norm = resnorm0;
     }
-    const Real res_target = std::max(a_tol_abs, std::max(a_tol_rel,1.e-16_rt)*max_norm);
+    const Real res_target = std::max(a_tol_abs, std::max(a_tol_rel,Real(1.e-16))*max_norm);
 
     if (!is_nsolve && resnorm0 <= res_target) {
         composite_norminf = resnorm0;

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLap_1D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLap_1D_K.H
@@ -131,7 +131,7 @@ void mlndlap_divu (int /*i*/, int /*j*/, int /*k*/, Array4<Real> const& rhs, Arr
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 Real mlndlap_rhcc (int /*i*/, int /*j*/, int /*k*/, Array4<Real const> const& rhcc,
                    Array4<int const> const& msk) noexcept
-{ return 0._rt; }
+{ return Real(0.); }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 void mlndlap_mknewu (int /*i*/, int /*j*/, int /*k*/, Array4<Real> const& u, Array4<Real const> const& p,

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLap_2D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLap_2D_K.H
@@ -133,7 +133,7 @@ void mlndlap_zero_fine (int i, int j, int, Array4<Real> const& phi,
         msk(i-1,j  ,0) == fine_flag and
         msk(i  ,j  ,0) == fine_flag)
     {
-        phi(i,j,0) = 0.0;
+        phi(i,j,0) = Real(0.0);
     }
 }
 
@@ -280,7 +280,7 @@ void mlndlap_adotx_ha (int i, int j, int k, Array4<Real> const& y, Array4<Real c
                        GpuArray<Real,AMREX_SPACEDIM> const& dxinv) noexcept
 {
     if (msk(i,j,k)) {
-        y(i,j,k) = 0.0;
+        y(i,j,k) = Real(0.0);
     } else {
         Real facx = (1./6.)*dxinv[0]*dxinv[0];
         Real facy = (1./6.)*dxinv[1]*dxinv[1];
@@ -313,7 +313,7 @@ void mlndlap_adotx_aa (int i, int j, int k, Array4<Real> const& y, Array4<Real c
                        bool is_rz, GpuArray<Real,AMREX_SPACEDIM> const& dxinv) noexcept
 {
     if (msk(i,j,k)) {
-        y(i,j,k) = 0.0;
+        y(i,j,k) = Real(0.0);
     } else {
         Real facx = (1.0/6.0)*dxinv[0]*dxinv[0];
         Real facy = (1.0/6.0)*dxinv[1]*dxinv[1];
@@ -378,15 +378,15 @@ void mlndlap_jacobi_ha (Box const& bx, Array4<Real> const& sol, Array4<Real cons
                         Array4<Real const> const& sy, Array4<int const> const& msk,
                         GpuArray<Real,AMREX_SPACEDIM> const& dxinv) noexcept
 {
-    Real facx = -2.0 * (1.0/6.0)*dxinv[0]*dxinv[0];
-    Real facy = -2.0 * (1.0/6.0)*dxinv[1]*dxinv[1];
+    Real facx = -Real(2.0 * (1.0/6.0))*dxinv[0]*dxinv[0];
+    Real facy = -Real(2.0 * (1.0/6.0))*dxinv[1]*dxinv[1];
 
     amrex::LoopConcurrent(bx, [=] (int i, int j, int k) noexcept
     {
         if (msk(i,j,k)) {
-            sol(i,j,k) = 0.0;
+            sol(i,j,k) = Real(0.0);
         } else {
-            sol(i,j,k) += (2.0/3.0) * (rhs(i,j,k) - Ax(i,j,k))
+            sol(i,j,k) += Real(2.0/3.0) * (rhs(i,j,k) - Ax(i,j,k))
                 / (facx*(sx(i-1,j-1,k)+sx(i,j-1,k)+sx(i-1,j,k)+sx(i,j,k))
                 +  facy*(sy(i-1,j-1,k)+sy(i,j-1,k)+sy(i-1,j,k)+sy(i,j,k)));
         }
@@ -398,14 +398,14 @@ void mlndlap_jacobi_aa (Box const& bx, Array4<Real> const& sol, Array4<Real cons
                         Array4<Real const> const& rhs, Array4<Real const> const& sig,
                         Array4<int const> const& msk, GpuArray<Real,AMREX_SPACEDIM> const& dxinv) noexcept
 {
-    Real fac = -2.0 * (1.0/6.0)*(dxinv[0]*dxinv[0] + dxinv[1]*dxinv[1]);
+    Real fac = -Real(2.0 * (1.0/6.0))*(dxinv[0]*dxinv[0] + dxinv[1]*dxinv[1]);
 
     amrex::LoopConcurrent(bx, [=] (int i, int j, int k) noexcept
     {
         if (msk(i,j,k)) {
-            sol(i,j,k) = 0.0;
+            sol(i,j,k) = Real(0.0);
         } else {
-            sol(i,j,k) += (2.0/3.0) * (rhs(i,j,k) - Ax(i,j,k))
+            sol(i,j,k) += Real(2.0/3.0) * (rhs(i,j,k) - Ax(i,j,k))
                 / (fac*(sig(i-1,j-1,k)+sig(i,j-1,k)+sig(i-1,j,k)+sig(i,j,k)));
         }
     });
@@ -418,29 +418,29 @@ void mlndlap_gauss_seidel_ha (Box const& bx, Array4<Real> const& sol,
                               GpuArray<Real,AMREX_SPACEDIM> const& dxinv,
                               bool is_rz) noexcept
 {
-    Real facx = (1.0/6.0)*dxinv[0]*dxinv[0];
-    Real facy = (1.0/6.0)*dxinv[1]*dxinv[1];
+    Real facx = Real(1.0/6.0)*dxinv[0]*dxinv[0];
+    Real facy = Real(1.0/6.0)*dxinv[1]*dxinv[1];
 
     amrex::Loop(bx, [=] (int i, int j, int k) noexcept
     {
         if (msk(i,j,k)) {
-            sol(i,j,k) = 0.0;
+            sol(i,j,k) = Real(0.0);
         } else {
-            Real s0 = (-2.0)*(facx*(sx(i-1,j-1,k)+sx(i,j-1,k)+sx(i-1,j,k)+sx(i,j,k))
-                             +facy*(sy(i-1,j-1,k)+sy(i,j-1,k)+sy(i-1,j,k)+sy(i,j,k)));
+            Real s0 = Real(-2.0)*(facx*(sx(i-1,j-1,k)+sx(i,j-1,k)+sx(i-1,j,k)+sx(i,j,k))
+                                 +facy*(sy(i-1,j-1,k)+sy(i,j-1,k)+sy(i-1,j,k)+sy(i,j,k)));
 
             Real Ax = sol(i-1,j-1,k)*(facx*sx(i-1,j-1,k)+facy*sy(i-1,j-1,k))
                     + sol(i+1,j-1,k)*(facx*sx(i  ,j-1,k)+facy*sy(i  ,j-1,k))
                     + sol(i-1,j+1,k)*(facx*sx(i-1,j  ,k)+facy*sy(i-1,j  ,k))
                     + sol(i+1,j+1,k)*(facx*sx(i  ,j  ,k)+facy*sy(i  ,j  ,k))
-                    + sol(i-1,j,k)*(2.0*facx*(sx(i-1,j-1,k)+sx(i-1,j,k))
-                                  -     facy*(sy(i-1,j-1,k)+sx(i-1,j,k)))
-                    + sol(i+1,j,k)*(2.0*facx*(sx(i  ,j-1,k)+sx(i  ,j,k))
-                                  -     facy*(sy(i  ,j-1,k)+sx(i  ,j,k)))
+                    + sol(i-1,j,k)*(Real(2.0)*facx*(sx(i-1,j-1,k)+sx(i-1,j,k))
+                                        -     facy*(sy(i-1,j-1,k)+sx(i-1,j,k)))
+                    + sol(i+1,j,k)*(Real(2.0)*facx*(sx(i  ,j-1,k)+sx(i  ,j,k))
+                                        -     facy*(sy(i  ,j-1,k)+sx(i  ,j,k)))
                     + sol(i,j-1,k)*(   -facx*(sx(i-1,j-1,k)+sx(i,j-1,k))
-                                   +2.0*facy*(sy(i-1,j-1,k)+sy(i,j-1,k)))
+                             +Real(2.0)*facy*(sy(i-1,j-1,k)+sy(i,j-1,k)))
                     + sol(i,j+1,k)*(   -facx*(sx(i-1,j  ,k)+sx(i,j  ,k))
-                                   +2.0*facy*(sy(i-1,j  ,k)+sy(i,j  ,k)))
+                             +Real(2.0)*facy*(sy(i-1,j  ,k)+sy(i,j  ,k)))
                     + sol(i,j,k)*s0;
 
             if (is_rz) {
@@ -936,8 +936,8 @@ void mlndlap_divu_compute_fine_contrib (int i, int j, int, Box const& fvbx,
         if ((bchi[1] == LinOpBCType::Neumann or bchi[1] == LinOpBCType::inflow)
             and j == domhi.y) zero_jhi = 0.0; 
 
-        Real facx = 0.5_rt*dxinv[0];
-        Real facy = 0.5_rt*dxinv[1];
+        Real facx = Real(0.5)*dxinv[0];
+        Real facy = Real(0.5)*dxinv[1];
 
         frh(i,j,0) = facx*(-vel(i-1,j-1,0,0)*zero_jlo+vel(i,j-1,0,0)*zero_jlo-vel(i-1,j,0,0)*zero_jhi+vel(i,j,0,0)*zero_jhi)
             +        facy*(-vel(i-1,j-1,0,1)*zero_ilo-vel(i,j-1,0,1)*zero_ihi+vel(i-1,j,0,1)*zero_ilo+vel(i,j,0,1)*zero_ihi);
@@ -957,9 +957,9 @@ void mlndlap_divu_add_fine_contrib (int i, int j, int /*k*/, Box const& fvbx,
                                     Array4<Real> const& rhs, Array4<Real const> const& frh,
                                     Array4<int const> const& msk) noexcept
 {
-    constexpr Real rfd = 0.25_rt;
-    constexpr Real chip = 0.5_rt;
-    constexpr Real chip2 = 0.25_rt;
+    constexpr Real rfd = Real(0.25);
+    constexpr Real chip = Real(0.5);
+    constexpr Real chip2 = Real(0.25);
 
     int ii = 2*i;
     int jj = 2*j;
@@ -978,9 +978,9 @@ void mlndlap_rhcc_fine_contrib (int i, int j, int, Box const& fvbx,
                                 Array4<Real> const& rhs, Array4<Real const> const& cc,
                                 Array4<int const> const& msk) noexcept
 {
-    constexpr Real w1 = 9._rt/64._rt;
-    constexpr Real w2 = 3._rt/64._rt;
-    constexpr Real w3 = 1._rt/64._rt;
+    constexpr Real w1 = Real(9./64.);
+    constexpr Real w2 = Real(3./64.);
+    constexpr Real w3 = Real(1./64.);
 
     int ii = 2*i;
     int jj = 2*j;
@@ -1005,26 +1005,26 @@ void mlndlap_divu_cf_contrib (int i, int j, int, Array4<Real> const& rhs,
                               bool neumann_doubling) noexcept
 {
     if (!dmsk(i,j,0) and ndmsk(i,j,0) == crse_fine_node) {
-        Real facx = 0.5_rt * dxinv[0];
-        Real facy = 0.5_rt * dxinv[1];
+        Real facx = Real(0.5) * dxinv[0];
+        Real facy = Real(0.5) * dxinv[1];
         Real r = fc(i,j,0);
         if (rhcc) {
-            r += 0.25_rt*( (1._rt-ccmsk(i-1,j-1,0)) * rhcc(i-1,j-1,0)
-                         + (1._rt-ccmsk(i  ,j-1,0)) * rhcc(i  ,j-1,0)
-                         + (1._rt-ccmsk(i-1,j  ,0)) * rhcc(i-1,j  ,0)
-                         + (1._rt-ccmsk(i  ,j  ,0)) * rhcc(i  ,j  ,0));
+            r += Real(0.25)*( (Real(1.)-ccmsk(i-1,j-1,0)) * rhcc(i-1,j-1,0)
+                            + (Real(1.)-ccmsk(i  ,j-1,0)) * rhcc(i  ,j-1,0)
+                            + (Real(1.)-ccmsk(i-1,j  ,0)) * rhcc(i-1,j  ,0)
+                            + (Real(1.)-ccmsk(i  ,j  ,0)) * rhcc(i  ,j  ,0));
         }
-        r += (1._rt-ccmsk(i-1,j-1,0)) * (-facx*vel(i-1,j-1,0,0) - facy*vel(i-1,j-1,0,1))
-           + (1._rt-ccmsk(i  ,j-1,0)) * ( facx*vel(i  ,j-1,0,0) - facy*vel(i  ,j-1,0,1))
-           + (1._rt-ccmsk(i-1,j  ,0)) * (-facx*vel(i-1,j  ,0,0) + facy*vel(i-1,j  ,0,1))
-           + (1._rt-ccmsk(i  ,j  ,0)) * ( facx*vel(i  ,j  ,0,0) + facy*vel(i  ,j  ,0,1));
+        r += (Real(1.)-ccmsk(i-1,j-1,0)) * (-facx*vel(i-1,j-1,0,0) - facy*vel(i-1,j-1,0,1))
+           + (Real(1.)-ccmsk(i  ,j-1,0)) * ( facx*vel(i  ,j-1,0,0) - facy*vel(i  ,j-1,0,1))
+           + (Real(1.)-ccmsk(i-1,j  ,0)) * (-facx*vel(i-1,j  ,0,0) + facy*vel(i-1,j  ,0,1))
+           + (Real(1.)-ccmsk(i  ,j  ,0)) * ( facx*vel(i  ,j  ,0,0) + facy*vel(i  ,j  ,0,1));
         if (is_rz) {
             Real fm = facy / static_cast<Real>(6*i-3);
             Real fp = facy / static_cast<Real>(6*i+3);
-            r += fm*((1._rt-ccmsk(i-1,j  ,0))*vel(i-1,j  ,0,1)
-                    -(1._rt-ccmsk(i-1,j-1,0))*vel(i-1,j-1,0,1))
-               - fp*((1._rt-ccmsk(i  ,j  ,0))*vel(i  ,j  ,0,1)
-                    -(1._rt-ccmsk(i  ,j-1,0))*vel(i  ,j-1,0,1));
+            r += fm*((Real(1.)-ccmsk(i-1,j  ,0))*vel(i-1,j  ,0,1)
+                    -(Real(1.)-ccmsk(i-1,j-1,0))*vel(i-1,j-1,0,1))
+               - fp*((Real(1.)-ccmsk(i  ,j  ,0))*vel(i  ,j  ,0,1)
+                    -(Real(1.)-ccmsk(i  ,j-1,0))*vel(i  ,j-1,0,1));
         }
 
         if (neumann_doubling) {
@@ -1032,18 +1032,18 @@ void mlndlap_divu_cf_contrib (int i, int j, int, Array4<Real> const& rhs,
             const auto ndhi = amrex::ubound(nddom);
             if (i == ndlo.x and ( bclo[0] == LinOpBCType::Neumann or
                                   bclo[0] == LinOpBCType::inflow)) {
-                r *= 2._rt;
+                r *= Real(2.);
             } else if (i== ndhi.x and ( bchi[0] == LinOpBCType::Neumann or
                                         bchi[0] == LinOpBCType::inflow)) {
-                r *= 2._rt;
+                r *= Real(2.);
             }
 
             if (j == ndlo.y and ( bclo[1] == LinOpBCType::Neumann or
                                   bclo[1] == LinOpBCType::inflow)) {
-                r *= 2._rt;
+                r *= Real(2.);
             } else if (j == ndhi.y and ( bchi[1] == LinOpBCType::Neumann or
                                          bchi[1] == LinOpBCType::inflow)) {
-                r *= 2._rt;
+                r *= Real(2.);
             }
         }
 
@@ -1071,29 +1071,29 @@ void mlndlap_crse_resid (int i, int j, int k, Array4<Real> const& resid,
          msk(i-1,j  ,k  ) == 0 or
          msk(i  ,j  ,k  ) == 0))
     {
-        Real fac = 1.0_rt;
+        Real fac = Real(1.0);
         if (neumann_doubling) {
             const auto ndlo = amrex::lbound(nddom);
             const auto ndhi = amrex::ubound(nddom);
             if (i == ndlo.x and ( bclo[0] == LinOpBCType::Neumann or
                                   bclo[0] == LinOpBCType::inflow)) {
-                fac *= 2._rt;
+                fac *= Real(2.);
             } else if (i== ndhi.x and ( bchi[0] == LinOpBCType::Neumann or
                                         bchi[0] == LinOpBCType::inflow)) {
-                fac *= 2._rt;
+                fac *= Real(2.);
             }
             if (j == ndlo.y and ( bclo[1] == LinOpBCType::Neumann or
                                   bclo[1] == LinOpBCType::inflow)) {
-                fac *= 2._rt;
+                fac *= Real(2.);
             } else if (j == ndhi.y and ( bchi[1] == LinOpBCType::Neumann or
                                          bchi[1] == LinOpBCType::inflow)) {
-                fac *= 2._rt;
+                fac *= Real(2.);
             }
         }
 
         resid(i,j,k) = (rhs(i,j,k) - resid(i,j,k)) * fac;
     } else {
-        resid(i,j,k) = 0._rt;
+        resid(i,j,k) = Real(0.);
     }
 }
 
@@ -1109,11 +1109,11 @@ void mlndlap_res_fine_Ax (int i, int j, int, Box const& fvbx, Array4<Real> const
 {
     IntVect iv(i,j);
     if (fvbx.contains(iv) and !fvbx.strictly_contains(iv)) {
-        Real facx = (1._rt/6._rt)*dxinv[0]*dxinv[0];
-        Real facy = (1._rt/6._rt)*dxinv[1]*dxinv[1];
+        Real facx = Real(1./6.)*dxinv[0]*dxinv[0];
+        Real facy = Real(1./6.)*dxinv[1]*dxinv[1];
         Real fxy = facx + facy;
-        Real f2xmy = 2._rt*facx - facy;
-        Real fmx2y = 2._rt*facy - facx;
+        Real f2xmy = Real(2.)*facx - facy;
+        Real fmx2y = Real(2.)*facy - facx;
         Ax(i,j,0) = x(i-1,j-1,0)*fxy*sig(i-1,j-1,0)
             +       x(i+1,j-1,0)*fxy*sig(i  ,j-1,0)
             +       x(i-1,j+1,0)*fxy*sig(i-1,j  ,0)
@@ -1122,7 +1122,7 @@ void mlndlap_res_fine_Ax (int i, int j, int, Box const& fvbx, Array4<Real> const
             +       x(i+1,j,0)*f2xmy*(sig(i  ,j-1,0)+sig(i  ,j  ,0))
             +       x(i,j-1,0)*fmx2y*(sig(i-1,j-1,0)+sig(i  ,j-1,0))
             +       x(i,j+1,0)*fmx2y*(sig(i-1,j  ,0)+sig(i  ,j  ,0))
-            +       x(i,j,0)*(-2._rt)*fxy*(sig(i-1,j-1,0)+sig(i,j-1,0)
+            +       x(i,j,0)*Real(-2.)*fxy*(sig(i-1,j-1,0)+sig(i,j-1,0)
                                            +sig(i-1,j,0)+sig(i,j,0));
         if (is_rz) {
             Real fp = facy / static_cast<Real>(2*i+1);
@@ -1138,9 +1138,9 @@ void mlndlap_res_fine_contrib (int i, int j, int k, Array4<Real> const& f,
                                Array4<Real const> const& Ax,
                                Array4<int const> const& msk) noexcept
 {
-    constexpr Real rfd = 0.25_rt;
-    constexpr Real chip = 0.5_rt;
-    constexpr Real chip2 = 0.25_rt;
+    constexpr Real rfd = Real(0.25);
+    constexpr Real chip = Real(0.5);
+    constexpr Real chip2 = Real(0.25);
 
     int ii = 2*i;
     int jj = 2*j;
@@ -1165,8 +1165,8 @@ void mlndlap_res_cf_contrib (int i, int j, int, Array4<Real> const& res,
                              bool neumann_doubling) noexcept
 {
     if (!dmsk(i,j,0) and ndmsk(i,j,0) == crse_fine_node) {
-        Real facx = (1._rt/6._rt)*dxinv[0]*dxinv[0];
-        Real facy = (1._rt/6._rt)*dxinv[1]*dxinv[1];
+        Real facx = Real(1./6.)*dxinv[0]*dxinv[0];
+        Real facy = Real(1./6.)*dxinv[1]*dxinv[1];
 
         Real fp, fm;
         if (is_rz) {
@@ -1174,39 +1174,39 @@ void mlndlap_res_cf_contrib (int i, int j, int, Array4<Real> const& res,
             fm = facy / static_cast<Real>(2*i-1);
         }
 
-        Real Ax = 0._rt;
+        Real Ax = Real(0.);
         if (ccmsk(i-1,j-1,0) == crse_cell) {
-            Ax += sig(i-1,j-1,0)*(facx*(2._rt*(phi(i-1,j  ,0)-phi(i  ,j  ,0))
-                                        +     (phi(i-1,j-1,0)-phi(i  ,j-1,0)))
-                                + facy*(2._rt*(phi(i  ,j-1,0)-phi(i  ,j  ,0))
-                                        +     (phi(i-1,j-1,0)-phi(i-1,j  ,0))));
+            Ax += sig(i-1,j-1,0)*(facx*(Real(2.)*(phi(i-1,j  ,0)-phi(i  ,j  ,0))
+                                           +     (phi(i-1,j-1,0)-phi(i  ,j-1,0)))
+                                + facy*(Real(2.)*(phi(i  ,j-1,0)-phi(i  ,j  ,0))
+                                           +     (phi(i-1,j-1,0)-phi(i-1,j  ,0))));
             if (is_rz) {
                 Ax += fm*sig(i-1,j-1,0)*(phi(i,j-1,0)-phi(i,j,0));
             }
         }
         if (ccmsk(i,j-1,0) == crse_cell) {
-            Ax += sig(i,j-1,0)*(facx*(2._rt*(phi(i+1,j  ,0)-phi(i  ,j  ,0))
-                                      +     (phi(i+1,j-1,0)-phi(i  ,j-1,0)))
-                              + facy*(2._rt*(phi(i  ,j-1,0)-phi(i  ,j  ,0))
-                                      +     (phi(i+1,j-1,0)-phi(i+1,j  ,0))));
+            Ax += sig(i,j-1,0)*(facx*(Real(2.)*(phi(i+1,j  ,0)-phi(i  ,j  ,0))
+                                         +     (phi(i+1,j-1,0)-phi(i  ,j-1,0)))
+                              + facy*(Real(2.)*(phi(i  ,j-1,0)-phi(i  ,j  ,0))
+                                         +     (phi(i+1,j-1,0)-phi(i+1,j  ,0))));
             if (is_rz) {
                 Ax -= fp*sig(i,j-1,0)*(phi(i,j-1,0)-phi(i,j,0));
             }
         }
         if (ccmsk(i-1,j,0) == crse_cell) {
-            Ax += sig(i-1,j,0)*(facx*(2._rt*(phi(i-1,j  ,0)-phi(i  ,j  ,0))
-                                      +     (phi(i-1,j+1,0)-phi(i  ,j+1,0)))
-                              + facy*(2._rt*(phi(i  ,j+1,0)-phi(i  ,j  ,0))
-                                      +     (phi(i-1,j+1,0)-phi(i-1,j  ,0))));
+            Ax += sig(i-1,j,0)*(facx*(Real(2.)*(phi(i-1,j  ,0)-phi(i  ,j  ,0))
+                                         +     (phi(i-1,j+1,0)-phi(i  ,j+1,0)))
+                              + facy*(Real(2.)*(phi(i  ,j+1,0)-phi(i  ,j  ,0))
+                                         +     (phi(i-1,j+1,0)-phi(i-1,j  ,0))));
             if (is_rz) {
                 Ax += fm*sig(i-1,j,0)*(phi(i,j+1,0)-phi(i,j,0));
             }
         }
         if (ccmsk(i,j,0) == crse_cell) {
-            Ax += sig(i,j,0)*(facx*(2._rt*(phi(i+1,j  ,0)-phi(i  ,j  ,0))
-                                   +      (phi(i+1,j+1,0)-phi(i  ,j+1,0)))
-                            + facy*(2._rt*(phi(i  ,j+1,0)-phi(i  ,j  ,0))
-                                   +      (phi(i+1,j+1,0)-phi(i+1,j  ,0))));
+            Ax += sig(i,j,0)*(facx*(Real(2.)*(phi(i+1,j  ,0)-phi(i  ,j  ,0))
+                                      +      (phi(i+1,j+1,0)-phi(i  ,j+1,0)))
+                            + facy*(Real(2.)*(phi(i  ,j+1,0)-phi(i  ,j  ,0))
+                                      +      (phi(i+1,j+1,0)-phi(i+1,j  ,0))));
             if (is_rz) {
                 Ax -= fp*sig(i,j,0)*(phi(i,j+1,0)-phi(i,j,0));
             }
@@ -1219,18 +1219,18 @@ void mlndlap_res_cf_contrib (int i, int j, int, Array4<Real> const& res,
 
             if (i == ndlo.x and (bclo[0] == LinOpBCType::Neumann or
                                  bclo[0] == LinOpBCType::inflow)) {
-                Axf *= 2._rt;
+                Axf *= Real(2.);
             } else if (i== ndhi.x and (bchi[0] == LinOpBCType::Neumann or
                                        bchi[0] == LinOpBCType::inflow)) {
-                Axf *= 2._rt;
+                Axf *= Real(2.);
             }
 
             if (j == ndlo.y and (bclo[1] == LinOpBCType::Neumann or
                                  bclo[1] == LinOpBCType::inflow)) {
-                Axf *= 2._rt;
+                Axf *= Real(2.);
             } else if (j == ndhi.y and (bchi[1] == LinOpBCType::Neumann or
                                         bchi[1] == LinOpBCType::inflow)) {
-                Axf *= 2._rt;
+                Axf *= Real(2.);
             }
         }
 
@@ -1284,7 +1284,7 @@ void mlndlap_stencil_rap (int i, int j, int, Array4<Real> const& csten,
     auto interp_from_mm_to = [&fsten] (int i_, int j_) -> Real {
         Real wxm = amrex::Math::abs(fsten(i_-1,j_  ,0,1))/(amrex::Math::abs(fsten(i_-1,j_-1,0,3))+amrex::Math::abs(fsten(i_-1,j_  ,0,3))+eps);
         Real wym = amrex::Math::abs(fsten(i_  ,j_-1,0,2))/(amrex::Math::abs(fsten(i_-1,j_-1,0,3))+amrex::Math::abs(fsten(i_  ,j_-1,0,3))+eps);
-        Real wmm = amrex::Math::abs(fsten(i_-1,j_-1,0,3)) * (1._rt + wxm + wym);
+        Real wmm = amrex::Math::abs(fsten(i_-1,j_-1,0,3)) * (Real(1.) + wxm + wym);
         return wmm * fsten(i_,j_,0,4);
     };
 #endif
@@ -1292,21 +1292,21 @@ void mlndlap_stencil_rap (int i, int j, int, Array4<Real> const& csten,
     auto interp_from_mp_to = [&fsten] (int i_, int j_) -> Real {
         Real wxm = amrex::Math::abs(fsten(i_-1,j_  ,0,1))/(amrex::Math::abs(fsten(i_-1,j_-1,0,3))+amrex::Math::abs(fsten(i_-1,j_  ,0,3))+eps);
         Real wyp = amrex::Math::abs(fsten(i_  ,j_  ,0,2))/(amrex::Math::abs(fsten(i_-1,j_  ,0,3))+amrex::Math::abs(fsten(i_  ,j_  ,0,3))+eps);
-        Real wmp = amrex::Math::abs(fsten(i_-1,j_  ,0,3)) *(1._rt + wxm + wyp);
+        Real wmp = amrex::Math::abs(fsten(i_-1,j_  ,0,3)) *(Real(1.) + wxm + wyp);
         return wmp * fsten(i_,j_,0,4);
     };
 
     auto interp_from_pm_to = [&fsten] (int i_, int j_) -> Real {
         Real wxp = amrex::Math::abs(fsten(i_  ,j_  ,0,1))/(amrex::Math::abs(fsten(i_  ,j_-1,0,3))+amrex::Math::abs(fsten(i_  ,j_  ,0,3))+eps);
         Real wym = amrex::Math::abs(fsten(i_  ,j_-1,0,2))/(amrex::Math::abs(fsten(i_-1,j_-1,0,3))+amrex::Math::abs(fsten(i_  ,j_-1,0,3))+eps);
-        Real wpm = amrex::Math::abs(fsten(i_  ,j_-1,0,3)) * (1._rt + wxp + wym);
+        Real wpm = amrex::Math::abs(fsten(i_  ,j_-1,0,3)) * (Real(1.) + wxp + wym);
         return wpm * fsten(i_,j_,0,4);
     };
 
     auto interp_from_pp_to = [&fsten] (int i_, int j_) -> Real {
         Real wxp = amrex::Math::abs(fsten(i_  ,j_  ,0,1))/(amrex::Math::abs(fsten(i_  ,j_-1,0,3))+amrex::Math::abs(fsten(i_  ,j_  ,0,3))+eps);
         Real wyp = amrex::Math::abs(fsten(i_  ,j_  ,0,2))/(amrex::Math::abs(fsten(i_-1,j_  ,0,3))+amrex::Math::abs(fsten(i_  ,j_  ,0,3))+eps);
-        Real wpp = amrex::Math::abs(fsten(i_  ,j_  ,0,3)) * (1._rt + wxp + wyp);
+        Real wpp = amrex::Math::abs(fsten(i_  ,j_  ,0,3)) * (Real(1.) + wxp + wyp);
         return wpp * fsten(i_,j_,0,4);
     };
 
@@ -1368,7 +1368,7 @@ void mlndlap_stencil_rap (int i, int j, int, Array4<Real> const& csten,
     auto restrict_from_mm_to = [&fsten] (int ii_, int jj_) -> Real {
         Real wxp = amrex::Math::abs(fsten(ii_-1,jj_-1,0,1))/(amrex::Math::abs(fsten(ii_-1,jj_-2,0,3))+amrex::Math::abs(fsten(ii_-1,jj_-1,0,3))+eps);
         Real wyp = amrex::Math::abs(fsten(ii_-1,jj_-1,0,2))/(amrex::Math::abs(fsten(ii_-2,jj_-1,0,3))+amrex::Math::abs(fsten(ii_-1,jj_-1,0,3))+eps);
-        Real wpp = amrex::Math::abs(fsten(ii_-1,jj_-1,0,3))*(1._rt+wxp+wyp);
+        Real wpp = amrex::Math::abs(fsten(ii_-1,jj_-1,0,3))*(Real(1.)+wxp+wyp);
         return wpp * fsten(ii_-1,jj_-1,0,4);
     };
 #endif
@@ -1380,7 +1380,7 @@ void mlndlap_stencil_rap (int i, int j, int, Array4<Real> const& csten,
     auto restrict_from_pm_to = [&fsten] (int ii_, int jj_) -> Real {
         Real wxm = amrex::Math::abs(fsten(ii_  ,jj_-1,0,1))/(amrex::Math::abs(fsten(ii_,jj_-2,0,3))+amrex::Math::abs(fsten(ii_  ,jj_-1,0,3))+eps);
         Real wyp = amrex::Math::abs(fsten(ii_+1,jj_-1,0,2))/(amrex::Math::abs(fsten(ii_,jj_-1,0,3))+amrex::Math::abs(fsten(ii_+1,jj_-1,0,3))+eps);
-        Real wmp = amrex::Math::abs(fsten(ii_  ,jj_-1,0,3)) *(1._rt + wxm + wyp);
+        Real wmp = amrex::Math::abs(fsten(ii_  ,jj_-1,0,3)) *(Real(1.) + wxm + wyp);
         return wmp * fsten(ii_+1,jj_-1,0,4);
     };
 
@@ -1395,7 +1395,7 @@ void mlndlap_stencil_rap (int i, int j, int, Array4<Real> const& csten,
     auto restrict_from_mp_to = [&fsten] (int ii_, int jj_) -> Real {
         Real wxp = amrex::Math::abs(fsten(ii_-1,jj_+1,0,1))/(amrex::Math::abs(fsten(ii_-1,jj_,0,3))+amrex::Math::abs(fsten(ii_-1,jj_+1,0,3))+eps);
         Real wym = amrex::Math::abs(fsten(ii_-1,jj_  ,0,2))/(amrex::Math::abs(fsten(ii_-2,jj_,0,3))+amrex::Math::abs(fsten(ii_-1,jj_  ,0,3))+eps);
-        Real wpm = amrex::Math::abs(fsten(ii_-1,jj_  ,0,3)) * (1._rt + wxp + wym);
+        Real wpm = amrex::Math::abs(fsten(ii_-1,jj_  ,0,3)) * (Real(1.) + wxp + wym);
         return wpm * fsten(ii_-1,jj_+1,0,4);
     };
 
@@ -1406,7 +1406,7 @@ void mlndlap_stencil_rap (int i, int j, int, Array4<Real> const& csten,
     auto restrict_from_pp_to = [&fsten] (int ii_, int jj_) -> Real {
         Real wxm = amrex::Math::abs(fsten(ii_  ,jj_+1,0,1))/(amrex::Math::abs(fsten(ii_  ,jj_  ,0,3))+amrex::Math::abs(fsten(ii_  ,jj_+1,0,3))+eps);
         Real wym = amrex::Math::abs(fsten(ii_+1,jj_  ,0,2))/(amrex::Math::abs(fsten(ii_  ,jj_  ,0,3))+amrex::Math::abs(fsten(ii_+1,jj_  ,0,3))+eps);
-        Real wmm = amrex::Math::abs(fsten(ii_  ,jj_  ,0,3)) * (1._rt + wxm + wym);
+        Real wmm = amrex::Math::abs(fsten(ii_  ,jj_  ,0,3)) * (Real(1.) + wxm + wym);
         return wmm * fsten(ii_+1,jj_+1,0,4);
     };
 
@@ -1418,7 +1418,7 @@ void mlndlap_stencil_rap (int i, int j, int, Array4<Real> const& csten,
     p(-1,-1) = interp_from_pp_to(ii+1,jj-1);
     p( 0,-1) = interp_from_0p_to(ii+2,jj-1);
     p(-1, 0) = interp_from_p0_to(ii+1,jj  );
-    p( 0, 0) = 1._rt;
+    p( 0, 0) = Real(1.);
     p(-1, 1) = interp_from_pm_to(ii+1,jj+1);
     p( 0, 1) = interp_from_0m_to(ii+2,jj+1);
 
@@ -1433,7 +1433,7 @@ void mlndlap_stencil_rap (int i, int j, int, Array4<Real> const& csten,
     ap(1,1) = A0m(ii+1,jj+1)*p(-1,0) + Apm(ii+1,jj+1)*p(0,0)
         +     A00(ii+1,jj+1)*p(-1,1) + Ap0(ii+1,jj+1)*p(0,1);
 
-    csten(i,j,k,1) = 0.25_rt*(restrict_from_0m_to(ii,jj)*ap(0,-1)
+    csten(i,j,k,1) = Real(0.25)*(restrict_from_0m_to(ii,jj)*ap(0,-1)
                             + restrict_from_pm_to(ii,jj)*ap(1,-1)
                             + ap(0,0)
                             + restrict_from_p0_to(ii,jj)*ap(1,0)
@@ -1445,7 +1445,7 @@ void mlndlap_stencil_rap (int i, int j, int, Array4<Real> const& csten,
     p( 0,-1) = interp_from_0p_to(ii  ,jj+1);
     p( 1,-1) = interp_from_mp_to(ii+1,jj+1);
     p(-1, 0) = interp_from_p0_to(ii-1,jj+2);
-    p( 0, 0) = 1._rt;
+    p( 0, 0) = Real(1.);
     p( 1, 0) = interp_from_m0_to(ii+1,jj+2);
 
     ap(-1,0) = A0p(ii-1,jj)*p(-1,-1) + App(ii-1,jj)*p(0,-1);
@@ -1458,7 +1458,7 @@ void mlndlap_stencil_rap (int i, int j, int, Array4<Real> const& csten,
     ap(1,1) = Am0(ii+1,jj+1)*p(0,-1) + A00(ii+1,jj+1)*p(1,-1)
         +     Amp(ii+1,jj+1)*p(0,0) + A0p(ii+1,jj+1)*p(1,0);
 
-    csten(i,j,k,2) = 0.25_rt*(restrict_from_m0_to(ii,jj)*ap(-1,0)
+    csten(i,j,k,2) = Real(0.25)*(restrict_from_m0_to(ii,jj)*ap(-1,0)
                             + ap(0,0)
                             + restrict_from_p0_to(ii,jj)*ap(1,0)
                             + restrict_from_mp_to(ii,jj)*ap(-1,1)
@@ -1469,7 +1469,7 @@ void mlndlap_stencil_rap (int i, int j, int, Array4<Real> const& csten,
     p(-1,-1) = interp_from_pp_to(ii+1,jj+1);
     p( 0,-1) = interp_from_0p_to(ii+2,jj+1);
     p(-1, 0) = interp_from_p0_to(ii+1,jj+2);
-    p( 0, 0) = 1._rt;
+    p( 0, 0) = Real(1.);
 
     ap(0,0) = App(ii,jj)*p(-1,-1);
     ap(1,0) = A0p(ii+1,jj)*p(-1,-1) + App(ii+1,jj)*p(0,-1);
@@ -1477,14 +1477,14 @@ void mlndlap_stencil_rap (int i, int j, int, Array4<Real> const& csten,
     ap(1,1) = A00(ii+1,jj+1)*p(-1,-1) + Ap0(ii+1,jj+1)*p(0,-1)
         +     A0p(ii+1,jj+1)*p(-1,0) + App(ii+1,jj+1)*p(0,0);
 
-    Real cross1 = 0.25_rt*(ap(0,0)
+    Real cross1 = Real(0.25)*(ap(0,0)
                            + restrict_from_p0_to(ii,jj)*ap(1,0)
                            + restrict_from_0p_to(ii,jj)*ap(0,1)
                            + restrict_from_pp_to(ii,jj)*ap(1,1));
 
     p(0,-1) = interp_from_0p_to(ii,jj+1);
     p(1,-1) = interp_from_mp_to(ii+1,jj+1);
-    p(0, 0) = 1._rt;
+    p(0, 0) = Real(1.);
     p(1, 0) = interp_from_m0_to(ii+1,jj+2);
 
     ap(-1,0) = Amp(ii+1,jj)*p(0,-1) + A0p(ii+1,jj)*p(1,-1);
@@ -1493,12 +1493,12 @@ void mlndlap_stencil_rap (int i, int j, int, Array4<Real> const& csten,
         + A0p(ii+1,jj+1)*p(1,0);
     ap( 0,1) = Am0(ii+2,jj+1)*p(1,-1) + Amp(ii+2,jj+1)*p(1,0);
 
-    Real cross2 = 0.25_rt*(ap(0,0)
+    Real cross2 = Real(0.25)*(ap(0,0)
                            + restrict_from_m0_to(ii+2,jj)*ap(-1,0)
                            + restrict_from_mp_to(ii+2,jj)*ap(-1,1)
                            + restrict_from_0p_to(ii+2,jj)*ap( 0,1));
 
-    csten(i,j,k,3) = 0.5_rt*(cross1+cross2);
+    csten(i,j,k,3) = Real(0.5)*(cross1+cross2);
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
@@ -1670,19 +1670,19 @@ void mlndlap_set_connection (int i, int j, int, Array4<Real> const& conn,
                              Array4<EBCellFlag const> const& flag) noexcept
 {
     if (flag(i,j,0).isCovered()) {
-        for (int n = 0; n < 6; ++n) conn(i,j,0,n) = 0._rt;
+        for (int n = 0; n < 6; ++n) conn(i,j,0,n) = Real(0.);
     } else if (flag(i,j,0).isRegular() or vol(i,j,0) >= almostone) {
-        for (int n = 0; n < 6; ++n) conn(i,j,0,n) = 1._rt;
+        for (int n = 0; n < 6; ++n) conn(i,j,0,n) = Real(1.);
     } else {
         // Note that these are normalized so that they equal 1 in the case of a regular cell
 
-        conn(i,j,0,0) = 3._rt*(.25_rt*vol(i,j,0) + intg(i,j,0,i_S_y2) - intg(i,j,0,i_S_y));
-        conn(i,j,0,1) = 6._rt*(.25_rt*vol(i,j,0) - intg(i,j,0,i_S_y2));
-        conn(i,j,0,2) = 3._rt*(.25_rt*vol(i,j,0) + intg(i,j,0,i_S_y2) + intg(i,j,0,i_S_y));
+        conn(i,j,0,0) = Real(3.)*(Real(0.25)*vol(i,j,0) + intg(i,j,0,i_S_y2) - intg(i,j,0,i_S_y));
+        conn(i,j,0,1) = Real(6.)*(Real(0.25)*vol(i,j,0) - intg(i,j,0,i_S_y2));
+        conn(i,j,0,2) = Real(3.)*(Real(0.25)*vol(i,j,0) + intg(i,j,0,i_S_y2) + intg(i,j,0,i_S_y));
 
-        conn(i,j,0,3) = 3._rt*(.25_rt*vol(i,j,0) + intg(i,j,0,i_S_x2) - intg(i,j,0,i_S_x));
-        conn(i,j,0,4) = 6._rt*(.25_rt*vol(i,j,0) - intg(i,j,0,i_S_x2));
-        conn(i,j,0,5) = 3._rt*(.25_rt*vol(i,j,0) + intg(i,j,0,i_S_x2) + intg(i,j,0,i_S_x));
+        conn(i,j,0,3) = Real(3.)*(Real(0.25)*vol(i,j,0) + intg(i,j,0,i_S_x2) - intg(i,j,0,i_S_x));
+        conn(i,j,0,4) = Real(6.)*(Real(0.25)*vol(i,j,0) - intg(i,j,0,i_S_x2));
+        conn(i,j,0,5) = Real(3.)*(Real(0.25)*vol(i,j,0) + intg(i,j,0,i_S_x2) + intg(i,j,0,i_S_x));
     }
 }
 
@@ -1691,13 +1691,13 @@ void mlndlap_set_stencil_eb (int i, int j, int, Array4<Real> const& sten,
                              Array4<Real const> const& sig, Array4<Real const> const& conn,
                              GpuArray<Real,AMREX_SPACEDIM> const& dxinv) noexcept
 {
-    Real facx = (1._rt/6._rt)*dxinv[0]*dxinv[0];
-    Real facy = (1._rt/6._rt)*dxinv[1]*dxinv[1];
+    Real facx = Real(1./6.)*dxinv[0]*dxinv[0];
+    Real facy = Real(1./6.)*dxinv[1]*dxinv[1];
 
-    sten(i,j,0,1) = 2._rt*facx*(sig(i,j-1,0)*conn(i,j-1,0,2)+sig(i,j,0)*conn(i,j,0,0))
-                         -facy*(sig(i,j-1,0)*conn(i,j-1,0,4)+sig(i,j,0)*conn(i,j,0,4));
-    sten(i,j,0,2) = 2._rt*facy*(sig(i-1,j,0)*conn(i-1,j,0,5)+sig(i,j,0)*conn(i,j,0,3))
-                         -facx*(sig(i-1,j,0)*conn(i-1,j,0,1)+sig(i,j,0)*conn(i,j,0,1));
+    sten(i,j,0,1) = Real(2.)*facx*(sig(i,j-1,0)*conn(i,j-1,0,2)+sig(i,j,0)*conn(i,j,0,0))
+                            -facy*(sig(i,j-1,0)*conn(i,j-1,0,4)+sig(i,j,0)*conn(i,j,0,4));
+    sten(i,j,0,2) = Real(2.)*facy*(sig(i-1,j,0)*conn(i-1,j,0,5)+sig(i,j,0)*conn(i,j,0,3))
+                            -facx*(sig(i-1,j,0)*conn(i-1,j,0,1)+sig(i,j,0)*conn(i,j,0,1));
     sten(i,j,0,3) = (facx*conn(i,j,0,1)+facy*conn(i,j,0,4))*sig(i,j,0);
 }
 
@@ -1710,8 +1710,8 @@ void mlndlap_divu_eb (int i, int j, int, Array4<Real> const& rhs, Array4<Real co
                       GpuArray<LinOpBCType, AMREX_SPACEDIM> const& bclo,
                       GpuArray<LinOpBCType, AMREX_SPACEDIM> const& bchi) noexcept
 {
-    Real facx = 0.5_rt*dxinv[0];
-    Real facy = 0.5_rt*dxinv[1];
+    Real facx = Real(0.5)*dxinv[0];
+    Real facy = Real(0.5)*dxinv[1];
 
     const auto domlo = amrex::lbound(nodal_domain);
     const auto domhi = amrex::ubound(nodal_domain);
@@ -1734,16 +1734,16 @@ void mlndlap_divu_eb (int i, int j, int, Array4<Real> const& rhs, Array4<Real co
         if ((bchi[1] == LinOpBCType::Neumann or bchi[1] == LinOpBCType::inflow)
             and j == domhi.y) zero_jhi = 0.0; 
 
-        rhs(i,j,0) = facx*(-vel(i-1,j-1,0,0)*(vfrac(i-1,j-1,0)+2._rt*intg(i-1,j-1,0,1))*zero_jlo
-                           +vel(i  ,j-1,0,0)*(vfrac(i  ,j-1,0)+2._rt*intg(i  ,j-1,0,1))*zero_jlo
-                           -vel(i-1,j  ,0,0)*(vfrac(i-1,j  ,0)-2._rt*intg(i-1,j  ,0,1))*zero_jhi
-                           +vel(i  ,j  ,0,0)*(vfrac(i  ,j  ,0)-2._rt*intg(i  ,j  ,0,1))*zero_jhi)
-                   + facy*(-vel(i-1,j-1,0,1)*(vfrac(i-1,j-1,0)+2._rt*intg(i-1,j-1,0,0))*zero_ilo
-                           -vel(i  ,j-1,0,1)*(vfrac(i  ,j-1,0)-2._rt*intg(i  ,j-1,0,0))*zero_ihi
-                           +vel(i-1,j  ,0,1)*(vfrac(i-1,j  ,0)+2._rt*intg(i-1,j  ,0,0))*zero_ilo
-                           +vel(i  ,j  ,0,1)*(vfrac(i  ,j  ,0)-2._rt*intg(i  ,j  ,0,0))*zero_ihi);
+        rhs(i,j,0) = facx*(-vel(i-1,j-1,0,0)*(vfrac(i-1,j-1,0)+Real(2.)*intg(i-1,j-1,0,1))*zero_jlo
+                           +vel(i  ,j-1,0,0)*(vfrac(i  ,j-1,0)+Real(2.)*intg(i  ,j-1,0,1))*zero_jlo
+                           -vel(i-1,j  ,0,0)*(vfrac(i-1,j  ,0)-Real(2.)*intg(i-1,j  ,0,1))*zero_jhi
+                           +vel(i  ,j  ,0,0)*(vfrac(i  ,j  ,0)-Real(2.)*intg(i  ,j  ,0,1))*zero_jhi)
+                   + facy*(-vel(i-1,j-1,0,1)*(vfrac(i-1,j-1,0)+Real(2.)*intg(i-1,j-1,0,0))*zero_ilo
+                           -vel(i  ,j-1,0,1)*(vfrac(i  ,j-1,0)-Real(2.)*intg(i  ,j-1,0,0))*zero_ihi
+                           +vel(i-1,j  ,0,1)*(vfrac(i-1,j  ,0)+Real(2.)*intg(i-1,j  ,0,0))*zero_ilo
+                           +vel(i  ,j  ,0,1)*(vfrac(i  ,j  ,0)-Real(2.)*intg(i  ,j  ,0,0))*zero_ihi);
     } else {
-        rhs(i,j,0) = 0._rt;
+        rhs(i,j,0) = Real(0.);
     }
 }
 
@@ -1752,10 +1752,10 @@ void mlndlap_mknewu_eb (int i, int j, int, Array4<Real> const& u, Array4<Real co
                         Array4<Real const> const& sig, Array4<Real const> const& vfrac,
                         Array4<Real const> const& intg, GpuArray<Real,AMREX_SPACEDIM> const& dxinv) noexcept
 {
-    Real facx = 0.5_rt*dxinv[0];
-    Real facy = 0.5_rt*dxinv[1];
-    if (vfrac(i,j,0) == 0._rt) {
-        u(i,j,0,0) = u(i,j,0,1) = 0._rt;
+    Real facx = Real(0.5)*dxinv[0];
+    Real facy = Real(0.5)*dxinv[1];
+    if (vfrac(i,j,0) == Real(0.)) {
+        u(i,j,0,0) = u(i,j,0,1) = Real(0.);
     } else {
         Real dpdx = facx*(-p(i,j,0)+p(i+1,j,0)-p(i,j+1,0)+p(i+1,j+1,0));
         Real dpdy = facy*(-p(i,j,0)-p(i+1,j,0)+p(i,j+1,0)+p(i+1,j+1,0));
@@ -1772,23 +1772,23 @@ Real mlndlap_rhcc_eb (int i, int j, int, Array4<Real const> const& rhcc,
 {
     if (!msk(i,j,0)) {
         return
-            rhcc(i  ,j  ,0)*(0.25_rt*vfrac(i  ,j  ,0)-intg(i  ,j  ,0,i_S_x)-intg(i  ,j  ,0,i_S_y)+intg(i  ,j  ,0,i_S_xy)) +
-            rhcc(i-1,j  ,0)*(0.25_rt*vfrac(i-1,j  ,0)+intg(i-1,j  ,0,i_S_x)-intg(i-1,j  ,0,i_S_y)-intg(i-1,j  ,0,i_S_xy)) +
-            rhcc(i-1,j-1,0)*(0.25_rt*vfrac(i-1,j-1,0)+intg(i-1,j-1,0,i_S_x)+intg(i-1,j-1,0,i_S_y)+intg(i-1,j-1,0,i_S_xy)) +
-            rhcc(i  ,j-1,0)*(0.25_rt*vfrac(i  ,j-1,0)-intg(i  ,j-1,0,i_S_x)+intg(i  ,j-1,0,i_S_y)-intg(i  ,j-1,0,i_S_xy));
+            rhcc(i  ,j  ,0)*(Real(0.25)*vfrac(i  ,j  ,0)-intg(i  ,j  ,0,i_S_x)-intg(i  ,j  ,0,i_S_y)+intg(i  ,j  ,0,i_S_xy)) +
+            rhcc(i-1,j  ,0)*(Real(0.25)*vfrac(i-1,j  ,0)+intg(i-1,j  ,0,i_S_x)-intg(i-1,j  ,0,i_S_y)-intg(i-1,j  ,0,i_S_xy)) +
+            rhcc(i-1,j-1,0)*(Real(0.25)*vfrac(i-1,j-1,0)+intg(i-1,j-1,0,i_S_x)+intg(i-1,j-1,0,i_S_y)+intg(i-1,j-1,0,i_S_xy)) +
+            rhcc(i  ,j-1,0)*(Real(0.25)*vfrac(i  ,j-1,0)-intg(i  ,j-1,0,i_S_x)+intg(i  ,j-1,0,i_S_y)-intg(i  ,j-1,0,i_S_xy));
     } else {
-        return 0._rt;
+        return Real(0.);
     }
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 void mlndlap_set_integral (int i, int j, int, Array4<Real> const& intg) noexcept
 {
-    intg(i,j,0,i_S_x ) = 0._rt;
-    intg(i,j,0,i_S_y ) = 0._rt;
-    intg(i,j,0,i_S_x2) = (1._rt/12._rt);
-    intg(i,j,0,i_S_y2) = (1._rt/12._rt);
-    intg(i,j,0,i_S_xy) = 0._rt;
+    intg(i,j,0,i_S_x ) = Real(0.);
+    intg(i,j,0,i_S_y ) = Real(0.);
+    intg(i,j,0,i_S_x2) = Real(1./12.);
+    intg(i,j,0,i_S_y2) = Real(1./12.);
+    intg(i,j,0,i_S_xy) = Real(0.);
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
@@ -1798,17 +1798,17 @@ void mlndlap_set_integral_eb (int i, int j, int, Array4<Real> const& intg,
                               Array4<Real const> const& bcen) noexcept
 {
     if (flag(i,j,0).isCovered()) {
-        intg(i,j,0,i_S_x ) = 0._rt;
-        intg(i,j,0,i_S_y ) = 0._rt;
-        intg(i,j,0,i_S_x2) = 0._rt;
-        intg(i,j,0,i_S_y2) = 0._rt;
-        intg(i,j,0,i_S_xy) = 0._rt;
+        intg(i,j,0,i_S_x ) = Real(0.);
+        intg(i,j,0,i_S_y ) = Real(0.);
+        intg(i,j,0,i_S_x2) = Real(0.);
+        intg(i,j,0,i_S_y2) = Real(0.);
+        intg(i,j,0,i_S_xy) = Real(0.);
     } else if (flag(i,j,0).isRegular() or vol(i,j,0) >= almostone) {
-        intg(i,j,0,i_S_x ) = 0._rt;
-        intg(i,j,0,i_S_y ) = 0._rt;
-        intg(i,j,0,i_S_x2) = (1._rt/12._rt);
-        intg(i,j,0,i_S_y2) = (1._rt/12._rt);
-        intg(i,j,0,i_S_xy) = 0._rt;
+        intg(i,j,0,i_S_x ) = Real(0.);
+        intg(i,j,0,i_S_y ) = Real(0.);
+        intg(i,j,0,i_S_x2) = Real(1./12.);
+        intg(i,j,0,i_S_y2) = Real(1./12.);
+        intg(i,j,0,i_S_xy) = Real(0.);
     } else {
         Real axm = ax(i,j,0);
         Real axp = ax(i+1,j,0);
@@ -1816,11 +1816,11 @@ void mlndlap_set_integral_eb (int i, int j, int, Array4<Real> const& intg,
         Real ayp = ay(i,j+1,0);
 
         Real apnorm = std::sqrt((axm-axp)*(axm-axp) + (aym-ayp)*(aym-ayp));
-        if (apnorm == 0._rt) {
+        if (apnorm == Real(0.)) {
             amrex::Abort("amrex_mlndlap_set_integral: we are in trouble");
         }
 
-        Real apnorminv = 1._rt/apnorm;
+        Real apnorminv = Real(1.)/apnorm;
         Real anrmx = (axm-axp) * apnorminv;  // pointing to the wall
         Real anrmy = (aym-ayp) * apnorminv;
 
@@ -1828,58 +1828,58 @@ void mlndlap_set_integral_eb (int i, int j, int, Array4<Real> const& intg,
         Real bcy = bcen(i,j,0,1);
 
         Real Sx, Sy, Sx2, Sy2, Sxy;
-        if (anrmx == 0._rt) {
-            Sx = 0._rt;
-            Sx2 = (1._rt/24._rt)*(axm+axp);
-            Sxy = 0._rt;
-        } else if (anrmy == 0._rt) {
-            Sx  = (1._rt/8._rt) *(axp-axm) + anrmx*0.5_rt*(bcx*bcx);
-            Sx2 = (1._rt/24._rt)*(axp+axm) + anrmx*(1._rt/3._rt)*(bcx*bcx*bcx);
-            Sxy = 0._rt;
+        if (anrmx == Real(0.)) {
+            Sx = Real(0.);
+            Sx2 = Real(1./24.)*(axm+axp);
+            Sxy = Real(0.);
+        } else if (anrmy == Real(0.)) {
+            Sx  = Real(1./8.) *(axp-axm) + anrmx*Real(0.5)*(bcx*bcx);
+            Sx2 = Real(1./24.)*(axp+axm) + anrmx*Real(1./3.)*(bcx*bcx*bcx);
+            Sxy = Real(0.);
         } else {
             Real xmin, xmax;
-            if (anrmx > 0._rt) {
-                xmin = -0.5_rt + amrex::min(aym,ayp);
-                xmax = -0.5_rt + amrex::max(aym,ayp);
+            if (anrmx > Real(0.)) {
+                xmin = Real(-0.5) + amrex::min(aym,ayp);
+                xmax = Real(-0.5) + amrex::max(aym,ayp);
             } else {
-                xmin = 0.5_rt - amrex::max(aym,ayp);
-                xmax = 0.5_rt - amrex::min(aym,ayp);
+                xmin = Real(0.5) - amrex::max(aym,ayp);
+                xmax = Real(0.5) - amrex::min(aym,ayp);
             }
             Real xmin3 = xmin*xmin*xmin;
             Real xmin4 = xmin3*xmin;
             Real xmax3 = xmax*xmax*xmax;
             Real xmax4 = xmax3*xmax;
-            Sx  = (1._rt/8._rt) *(axp-axm) + (anrmx/amrex::Math::abs(anrmy))*(1._rt/6._rt) *(xmax3-xmin3);
-            Sx2 = (1._rt/24._rt)*(axp+axm) + (anrmx/amrex::Math::abs(anrmy))*(1._rt/12._rt)*(xmax4-xmin4);
+            Sx  = Real(1./8.) *(axp-axm) + (anrmx/amrex::Math::abs(anrmy))*Real(1./6.) *(xmax3-xmin3);
+            Sx2 = Real(1./24.)*(axp+axm) + (anrmx/amrex::Math::abs(anrmy))*Real(1./12.)*(xmax4-xmin4);
 
             Real kk = -anrmx/anrmy;
             Real bb = bcy-kk*bcx;
-            Sxy = (1._rt/8._rt)*kk*kk*(xmax4-xmin4) + (1._rt/3._rt)*kk*bb*(xmax3-xmin3)
-                + (0.25_rt*bb*bb-(1._rt/16._rt))*(xmax*xmax-xmin*xmin);
+            Sxy = Real(1./8.)*kk*kk*(xmax4-xmin4) + Real(1./3.)*kk*bb*(xmax3-xmin3)
+                + (Real(0.25)*bb*bb-Real(1./16.))*(xmax*xmax-xmin*xmin);
             Sxy = amrex::Math::copysign(Sxy, anrmy);
         }
 
-        if (anrmy == 0._rt) {
-            Sy = 0._rt;
-            Sy2 = (1._rt/24._rt)*(aym+ayp);
-        } else if (anrmx == 0._rt) {
-            Sy  = (1._rt/8._rt) *(ayp-aym) + anrmy*0.5_rt*(bcy*bcy);
-            Sy2 = (1._rt/24._rt)*(ayp+aym) + anrmy*(1._rt/3._rt)*(bcy*bcy*bcy);
+        if (anrmy == Real(0.)) {
+            Sy = Real(0.);
+            Sy2 = Real(1./24.)*(aym+ayp);
+        } else if (anrmx == Real(0.)) {
+            Sy  = Real(1./8.) *(ayp-aym) + anrmy*Real(0.5)*(bcy*bcy);
+            Sy2 = Real(1./24.)*(ayp+aym) + anrmy*Real(1./3.)*(bcy*bcy*bcy);
         } else {
             Real ymin, ymax;
-            if (anrmy > 0._rt) {
-                ymin = -0.5_rt + amrex::min(axm,axp);
-                ymax = -0.5_rt + amrex::max(axm,axp);
+            if (anrmy > Real(0.)) {
+                ymin = Real(-0.5) + amrex::min(axm,axp);
+                ymax = Real(-0.5) + amrex::max(axm,axp);
             } else {
-                ymin = 0.5_rt - amrex::max(axm,axp);
-                ymax = 0.5_rt - amrex::min(axm,axp);
+                ymin = Real(0.5) - amrex::max(axm,axp);
+                ymax = Real(0.5) - amrex::min(axm,axp);
             }
             Real ymin3 = ymin*ymin*ymin;
             Real ymin4 = ymin3*ymin;
             Real ymax3 = ymax*ymax*ymax;
             Real ymax4 = ymax3*ymax;
-            Sy  = (1._rt/8._rt) *(ayp-aym) + (anrmy/amrex::Math::abs(anrmx))*(1._rt/6._rt) *(ymax3-ymin3);
-            Sy2 = (1._rt/24._rt)*(ayp+aym) + (anrmy/amrex::Math::abs(anrmx))*(1._rt/12._rt)*(ymax4-ymin4);
+            Sy  = Real(1./8.) *(ayp-aym) + (anrmy/amrex::Math::abs(anrmx))*Real(1./6.) *(ymax3-ymin3);
+            Sy2 = Real(1./24.)*(ayp+aym) + (anrmy/amrex::Math::abs(anrmx))*Real(1./12.)*(ymax4-ymin4);
         }
 
         intg(i,j,0,i_S_x ) = Sx;

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLap_3D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLap_3D_K.H
@@ -1922,10 +1922,10 @@ void mlndlap_divu_add_fine_contrib (int i, int j, int k, Box const& fvbx,
                                     Array4<Real> const& rhs, Array4<Real const> const& frh,
                                     Array4<int const> const& msk) noexcept
 {
-    constexpr Real rfd = 0.125_rt;
-    constexpr Real chip = 0.5_rt;
-    constexpr Real chip2 = 0.25_rt;
-    constexpr Real chip3 = 0.125_rt;
+    constexpr Real rfd = Real(0.125);
+    constexpr Real chip = Real(0.5);
+    constexpr Real chip2 = Real(0.25);
+    constexpr Real chip3 = Real(0.125);
 
     int ii = 2*i;
     int jj = 2*j;
@@ -1953,7 +1953,7 @@ void mlndlap_rhcc_fine_contrib (int i, int j, int k, Box const& fvbx,
                                 Array4<Real> const& rhs, Array4<Real const> const& cc,
                                 Array4<int const> const& msk) noexcept
 {
-    constexpr Real fac[] = {0.125_rt, 0.375_rt, 0.375_rt, 0.125_rt};
+    constexpr Real fac[] = {Real(0.125), Real(0.375), Real(0.375), Real(0.125)};
     int ii = 2*i;
     int jj = 2*j;
     int kk = 2*k;
@@ -1981,19 +1981,19 @@ void mlndlap_divu_cf_contrib (int i, int j, int k, Array4<Real> const& rhs,
                               bool neumann_doubling) noexcept
 {
     if (!dmsk(i,j,k) and ndmsk(i,j,k) == crse_fine_node) {
-        Real facx = 0.25_rt * dxinv[0];
-        Real facy = 0.25_rt * dxinv[1];
-        Real facz = 0.25_rt * dxinv[2];
+        Real facx = Real(0.25) * dxinv[0];
+        Real facy = Real(0.25) * dxinv[1];
+        Real facz = Real(0.25) * dxinv[2];
         Real r = fc(i,j,k);
         if (rhcc) {
-            r += 0.125_rt*((1._rt-ccmsk(i-1,j-1,k-1)) * rhcc(i-1,j-1,k-1)
-                         + (1._rt-ccmsk(i  ,j-1,k-1)) * rhcc(i  ,j-1,k-1)
-                         + (1._rt-ccmsk(i-1,j  ,k-1)) * rhcc(i-1,j  ,k-1)
-                         + (1._rt-ccmsk(i  ,j  ,k-1)) * rhcc(i  ,j  ,k-1)
-                         + (1._rt-ccmsk(i-1,j-1,k  )) * rhcc(i-1,j-1,k  )
-                         + (1._rt-ccmsk(i  ,j-1,k  )) * rhcc(i  ,j-1,k  )
-                         + (1._rt-ccmsk(i-1,j  ,k  )) * rhcc(i-1,j  ,k  )
-                         + (1._rt-ccmsk(i  ,j  ,k  )) * rhcc(i  ,j  ,k  ));
+            r += Real(0.125)*((Real(1.)-ccmsk(i-1,j-1,k-1)) * rhcc(i-1,j-1,k-1)
+                            + (Real(1.)-ccmsk(i  ,j-1,k-1)) * rhcc(i  ,j-1,k-1)
+                            + (Real(1.)-ccmsk(i-1,j  ,k-1)) * rhcc(i-1,j  ,k-1)
+                            + (Real(1.)-ccmsk(i  ,j  ,k-1)) * rhcc(i  ,j  ,k-1)
+                            + (Real(1.)-ccmsk(i-1,j-1,k  )) * rhcc(i-1,j-1,k  )
+                            + (Real(1.)-ccmsk(i  ,j-1,k  )) * rhcc(i  ,j-1,k  )
+                            + (Real(1.)-ccmsk(i-1,j  ,k  )) * rhcc(i-1,j  ,k  )
+                            + (Real(1.)-ccmsk(i  ,j  ,k  )) * rhcc(i  ,j  ,k  ));
         }
         if (ccmsk(i-1,j-1,k-1) == crse_cell) {
             r += - facx*vel(i-1,j-1,k-1,0)
@@ -2041,26 +2041,26 @@ void mlndlap_divu_cf_contrib (int i, int j, int k, Array4<Real> const& rhs,
             const auto ndhi = amrex::ubound(nddom);
             if (i == ndlo.x and ( bclo[0] == LinOpBCType::Neumann or
                                   bclo[0] == LinOpBCType::inflow)) {
-                r *= 2._rt;
+                r *= Real(2.);
             } else if (i== ndhi.x and ( bchi[0] == LinOpBCType::Neumann or
                                         bchi[0] == LinOpBCType::inflow)) {
-                r *= 2._rt;
+                r *= Real(2.);
             }
 
             if (j == ndlo.y and ( bclo[1] == LinOpBCType::Neumann or
                                   bclo[1] == LinOpBCType::inflow)) {
-                r *= 2._rt;
+                r *= Real(2.);
             } else if (j == ndhi.y and ( bchi[1] == LinOpBCType::Neumann or
                                          bchi[1] == LinOpBCType::inflow)) {
-                r *= 2._rt;
+                r *= Real(2.);
             }
 
             if (k == ndlo.z and ( bclo[2] == LinOpBCType::Neumann or
                                   bclo[2] == LinOpBCType::inflow)) {
-                r *= 2._rt;
+                r *= Real(2.);
             } else if (k == ndhi.z and ( bchi[2] == LinOpBCType::Neumann or
                                          bchi[2] == LinOpBCType::inflow)) {
-                r *= 2._rt;
+                r *= Real(2.);
             }
         }
 
@@ -2096,35 +2096,35 @@ void mlndlap_crse_resid (int i, int j, int k, Array4<Real> const& resid,
          msk(i-1,j  ,k  ) == 0 or
          msk(i  ,j  ,k  ) == 0))
     {
-        Real fac = 1.0_rt;
+        Real fac = Real(1.0);
         if (neumann_doubling) {
             const auto ndlo = amrex::lbound(nddom);
             const auto ndhi = amrex::ubound(nddom);
             if (i == ndlo.x and ( bclo[0] == LinOpBCType::Neumann or
                                   bclo[0] == LinOpBCType::inflow)) {
-                fac *= 2._rt;
+                fac *= Real(2.);
             } else if (i== ndhi.x and ( bchi[0] == LinOpBCType::Neumann or
                                         bchi[0] == LinOpBCType::inflow)) {
-                fac *= 2._rt;
+                fac *= Real(2.);
             }
             if (j == ndlo.y and ( bclo[1] == LinOpBCType::Neumann or
                                   bclo[1] == LinOpBCType::inflow)) {
-                fac *= 2._rt;
+                fac *= Real(2.);
             } else if (j == ndhi.y and ( bchi[1] == LinOpBCType::Neumann or
                                          bchi[1] == LinOpBCType::inflow)) {
-                fac *= 2._rt;
+                fac *= Real(2.);
             }
             if (k == ndlo.z and ( bclo[2] == LinOpBCType::Neumann or
                                   bclo[2] == LinOpBCType::inflow)) {
-                fac *= 2._rt;
+                fac *= Real(2.);
             } else if (k == ndhi.z and ( bchi[2] == LinOpBCType::Neumann or
                                          bchi[2] == LinOpBCType::inflow)) {
-                fac *= 2._rt;
+                fac *= Real(2.);
             }
         }
         resid(i,j,k) = (rhs(i,j,k) - resid(i,j,k)) * fac;
     } else {
-        resid(i,j,k) = 0._rt;
+        resid(i,j,k) = Real(0.);
     }
 }
 
@@ -2139,17 +2139,17 @@ void mlndlap_res_fine_Ax (int i, int j, int k, Box const& fvbx, Array4<Real> con
 {
     IntVect iv(i,j,k);
     if (fvbx.contains(iv) and !fvbx.strictly_contains(iv)) {
-        Real facx = (1._rt/36._rt)*dxinv[0]*dxinv[0];
-        Real facy = (1._rt/36._rt)*dxinv[1]*dxinv[1];
-        Real facz = (1._rt/36._rt)*dxinv[2]*dxinv[2];
+        Real facx = Real(1./36.)*dxinv[0]*dxinv[0];
+        Real facy = Real(1./36.)*dxinv[1]*dxinv[1];
+        Real facz = Real(1./36.)*dxinv[2]*dxinv[2];
         Real fxyz = facx + facy + facz;
-        Real fmx2y2z = -facx + 2._rt*facy + 2._rt*facz;
-        Real f2xmy2z = 2._rt*facx - facy + 2._rt*facz;
-        Real f2x2ymz = 2._rt*facx + 2._rt*facy - facz;
-        Real f4xm2ym2z = 4._rt*facx - 2._rt*facy - 2._rt*facz;
-        Real fm2x4ym2z = -2._rt*facx + 4._rt*facy - 2._rt*facz;
-        Real fm2xm2y4z = -2._rt*facx - 2._rt*facy + 4._rt*facz;
-        Ax(i,j,k) = x(i,j,k)*(-4._rt)*fxyz*
+        Real fmx2y2z = -facx + Real(2.)*facy + Real(2.)*facz;
+        Real f2xmy2z = Real(2.)*facx - facy + Real(2.)*facz;
+        Real f2x2ymz = Real(2.)*facx + Real(2.)*facy - facz;
+        Real f4xm2ym2z = Real(4.)*facx - Real(2.)*facy - Real(2.)*facz;
+        Real fm2x4ym2z = -Real(2.)*facx + Real(4.)*facy - Real(2.)*facz;
+        Real fm2xm2y4z = -Real(2.)*facx - Real(2.)*facy + Real(4.)*facz;
+        Ax(i,j,k) = x(i,j,k)*Real(-4.)*fxyz*
             (sig(i-1,j-1,k-1)+sig(i,j-1,k-1)+sig(i-1,j,k-1)+sig(i,j,k-1)
             +sig(i-1,j-1,k  )+sig(i,j-1,k  )+sig(i-1,j,k  )+sig(i,j,k  ))
             //
@@ -2186,10 +2186,10 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 void mlndlap_res_fine_contrib (int i, int j, int k, Array4<Real> const& f,
                                Array4<Real const> const& Ax, Array4<int const> const& msk) noexcept
 {
-    constexpr Real rfd = 0.125_rt;
-    constexpr Real chip = 0.5_rt;
-    constexpr Real chip2 = 0.25_rt;
-    constexpr Real chip3 = 0.125_rt;
+    constexpr Real rfd = Real(0.125);
+    constexpr Real chip = Real(0.5);
+    constexpr Real chip2 = Real(0.25);
+    constexpr Real chip3 = Real(0.125);
 
     int ii = 2*i;
     int jj = 2*j;
@@ -2223,122 +2223,122 @@ void mlndlap_res_cf_contrib (int i, int j, int k, Array4<Real> const& res,
 {
     if (!dmsk(i,j,k) and ndmsk(i,j,k) == crse_fine_node) {
 
-        Real facx = (1._rt/36._rt)*dxinv[0]*dxinv[0];
-        Real facy = (1._rt/36._rt)*dxinv[1]*dxinv[1];
-        Real facz = (1._rt/36._rt)*dxinv[2]*dxinv[2];
+        Real facx = Real(1./36.)*dxinv[0]*dxinv[0];
+        Real facy = Real(1./36.)*dxinv[1]*dxinv[1];
+        Real facz = Real(1./36.)*dxinv[2]*dxinv[2];
 
-        Real Ax = 0._rt;
+        Real Ax = Real(0.);
         if (ccmsk(i-1,j-1,k-1) == crse_cell) {
-            Ax += sig(i-1,j-1,k-1)*(facx*(4._rt*(phi(i-1,j  ,k  )-phi(i  ,j  ,k  ))
-                                         +2._rt*(phi(i-1,j-1,k  )-phi(i  ,j-1,k  ))
-                                         +2._rt*(phi(i-1,j  ,k-1)-phi(i  ,j  ,k-1))
-                                          +     (phi(i-1,j-1,k-1)-phi(i  ,j-1,k-1)))
-                                  + facy*(4._rt*(phi(i  ,j-1,k  )-phi(i  ,j  ,k  ))
-                                         +2._rt*(phi(i-1,j-1,k  )-phi(i-1,j  ,k  ))
-                                         +2._rt*(phi(i  ,j-1,k-1)-phi(i  ,j  ,k-1))
-                                          +     (phi(i-1,j-1,k-1)-phi(i-1,j  ,k-1)))
-                                  + facz*(4._rt*(phi(i  ,j  ,k-1)-phi(i  ,j  ,k  ))
-                                         +2._rt*(phi(i-1,j  ,k-1)-phi(i-1,j  ,k  ))
-                                         +2._rt*(phi(i  ,j-1,k-1)-phi(i  ,j-1,k  ))
-                                          +     (phi(i-1,j-1,k-1)-phi(i-1,j-1,k  ))));
+            Ax += sig(i-1,j-1,k-1)*(facx*(Real(4.)*(phi(i-1,j  ,k  )-phi(i  ,j  ,k  ))
+                                         +Real(2.)*(phi(i-1,j-1,k  )-phi(i  ,j-1,k  ))
+                                         +Real(2.)*(phi(i-1,j  ,k-1)-phi(i  ,j  ,k-1))
+                                         +         (phi(i-1,j-1,k-1)-phi(i  ,j-1,k-1)))
+                                  + facy*(Real(4.)*(phi(i  ,j-1,k  )-phi(i  ,j  ,k  ))
+                                         +Real(2.)*(phi(i-1,j-1,k  )-phi(i-1,j  ,k  ))
+                                         +Real(2.)*(phi(i  ,j-1,k-1)-phi(i  ,j  ,k-1))
+                                         +         (phi(i-1,j-1,k-1)-phi(i-1,j  ,k-1)))
+                                  + facz*(Real(4.)*(phi(i  ,j  ,k-1)-phi(i  ,j  ,k  ))
+                                         +Real(2.)*(phi(i-1,j  ,k-1)-phi(i-1,j  ,k  ))
+                                         +Real(2.)*(phi(i  ,j-1,k-1)-phi(i  ,j-1,k  ))
+                                         +         (phi(i-1,j-1,k-1)-phi(i-1,j-1,k  ))));
         }
         if (ccmsk(i,j-1,k-1) == crse_cell) {
-            Ax += sig(i,j-1,k-1)*(facx*(4._rt*(phi(i+1,j  ,k  )-phi(i  ,j  ,k  ))
-                                       +2._rt*(phi(i+1,j-1,k  )-phi(i  ,j-1,k  ))
-                                       +2._rt*(phi(i+1,j  ,k-1)-phi(i  ,j  ,k-1))
-                                        +     (phi(i+1,j-1,k-1)-phi(i  ,j-1,k-1)))
-                                + facy*(4._rt*(phi(i  ,j-1,k  )-phi(i  ,j  ,k  ))
-                                       +2._rt*(phi(i+1,j-1,k  )-phi(i+1,j  ,k  ))
-                                       +2._rt*(phi(i  ,j-1,k-1)-phi(i  ,j  ,k-1))
-                                        +     (phi(i+1,j-1,k-1)-phi(i+1,j  ,k-1)))
-                                + facz*(4._rt*(phi(i  ,j  ,k-1)-phi(i  ,j  ,k  ))
-                                       +2._rt*(phi(i+1,j  ,k-1)-phi(i+1,j  ,k  ))
-                                       +2._rt*(phi(i  ,j-1,k-1)-phi(i  ,j-1,k  ))
-                                        +     (phi(i+1,j-1,k-1)-phi(i+1,j-1,k  ))));
+            Ax += sig(i,j-1,k-1)*(facx*(Real(4.)*(phi(i+1,j  ,k  )-phi(i  ,j  ,k  ))
+                                       +Real(2.)*(phi(i+1,j-1,k  )-phi(i  ,j-1,k  ))
+                                       +Real(2.)*(phi(i+1,j  ,k-1)-phi(i  ,j  ,k-1))
+                                       +         (phi(i+1,j-1,k-1)-phi(i  ,j-1,k-1)))
+                                + facy*(Real(4.)*(phi(i  ,j-1,k  )-phi(i  ,j  ,k  ))
+                                       +Real(2.)*(phi(i+1,j-1,k  )-phi(i+1,j  ,k  ))
+                                       +Real(2.)*(phi(i  ,j-1,k-1)-phi(i  ,j  ,k-1))
+                                       +         (phi(i+1,j-1,k-1)-phi(i+1,j  ,k-1)))
+                                + facz*(Real(4.)*(phi(i  ,j  ,k-1)-phi(i  ,j  ,k  ))
+                                       +Real(2.)*(phi(i+1,j  ,k-1)-phi(i+1,j  ,k  ))
+                                       +Real(2.)*(phi(i  ,j-1,k-1)-phi(i  ,j-1,k  ))
+                                       +         (phi(i+1,j-1,k-1)-phi(i+1,j-1,k  ))));
         }
         if (ccmsk(i-1,j,k-1) == crse_cell) {
-            Ax += sig(i-1,j,k-1)*(facx*(4._rt*(phi(i-1,j  ,k  )-phi(i  ,j  ,k  ))
-                                       +2._rt*(phi(i-1,j+1,k  )-phi(i  ,j+1,k  ))
-                                       +2._rt*(phi(i-1,j  ,k-1)-phi(i  ,j  ,k-1))
-                                        +     (phi(i-1,j+1,k-1)-phi(i  ,j+1,k-1)))
-                                 + facy*(4._rt*(phi(i  ,j+1,k  )-phi(i  ,j  ,k  ))
-                                        +2._rt*(phi(i-1,j+1,k  )-phi(i-1,j  ,k  ))
-                                        +2._rt*(phi(i  ,j+1,k-1)-phi(i  ,j  ,k-1))
-                                         +     (phi(i-1,j+1,k-1)-phi(i-1,j  ,k-1)))
-                                 + facz*(4._rt*(phi(i  ,j  ,k-1)-phi(i  ,j  ,k  ))
-                                        +2._rt*(phi(i-1,j  ,k-1)-phi(i-1,j  ,k  ))
-                                        +2._rt*(phi(i  ,j+1,k-1)-phi(i  ,j+1,k  ))
-                                         +     (phi(i-1,j+1,k-1)-phi(i-1,j+1,k  ))));
+            Ax += sig(i-1,j,k-1)*(facx*(Real(4.)*(phi(i-1,j  ,k  )-phi(i  ,j  ,k  ))
+                                       +Real(2.)*(phi(i-1,j+1,k  )-phi(i  ,j+1,k  ))
+                                       +Real(2.)*(phi(i-1,j  ,k-1)-phi(i  ,j  ,k-1))
+                                       +         (phi(i-1,j+1,k-1)-phi(i  ,j+1,k-1)))
+                                 + facy*(Real(4.)*(phi(i  ,j+1,k  )-phi(i  ,j  ,k  ))
+                                        +Real(2.)*(phi(i-1,j+1,k  )-phi(i-1,j  ,k  ))
+                                        +Real(2.)*(phi(i  ,j+1,k-1)-phi(i  ,j  ,k-1))
+                                        +         (phi(i-1,j+1,k-1)-phi(i-1,j  ,k-1)))
+                                 + facz*(Real(4.)*(phi(i  ,j  ,k-1)-phi(i  ,j  ,k  ))
+                                        +Real(2.)*(phi(i-1,j  ,k-1)-phi(i-1,j  ,k  ))
+                                        +Real(2.)*(phi(i  ,j+1,k-1)-phi(i  ,j+1,k  ))
+                                        +         (phi(i-1,j+1,k-1)-phi(i-1,j+1,k  ))));
         }
         if (ccmsk(i,j,k-1) == crse_cell) {
-            Ax += sig(i,j,k-1)*(facx*(4._rt*(phi(i+1,j  ,k  )-phi(i  ,j  ,k  ))
-                                     +2._rt*(phi(i+1,j+1,k  )-phi(i  ,j+1,k  ))
-                                     +2._rt*(phi(i+1,j  ,k-1)-phi(i  ,j  ,k-1))
-                                      +     (phi(i+1,j+1,k-1)-phi(i  ,j+1,k-1)))
-                              + facy*(4._rt*(phi(i  ,j+1,k  )-phi(i  ,j  ,k  ))
-                                     +2._rt*(phi(i+1,j+1,k  )-phi(i+1,j  ,k  ))
-                                     +2._rt*(phi(i  ,j+1,k-1)-phi(i  ,j  ,k-1))
-                                      +     (phi(i+1,j+1,k-1)-phi(i+1,j  ,k-1)))
-                              + facz*(4._rt*(phi(i  ,j  ,k-1)-phi(i  ,j  ,k  ))
-                                     +2._rt*(phi(i+1,j  ,k-1)-phi(i+1,j  ,k  ))
-                                     +2._rt*(phi(i  ,j+1,k-1)-phi(i  ,j+1,k  ))
-                                      +     (phi(i+1,j+1,k-1)-phi(i+1,j+1,k  ))));
+            Ax += sig(i,j,k-1)*(facx*(Real(4.)*(phi(i+1,j  ,k  )-phi(i  ,j  ,k  ))
+                                     +Real(2.)*(phi(i+1,j+1,k  )-phi(i  ,j+1,k  ))
+                                     +Real(2.)*(phi(i+1,j  ,k-1)-phi(i  ,j  ,k-1))
+                                     +         (phi(i+1,j+1,k-1)-phi(i  ,j+1,k-1)))
+                              + facy*(Real(4.)*(phi(i  ,j+1,k  )-phi(i  ,j  ,k  ))
+                                     +Real(2.)*(phi(i+1,j+1,k  )-phi(i+1,j  ,k  ))
+                                     +Real(2.)*(phi(i  ,j+1,k-1)-phi(i  ,j  ,k-1))
+                                     +         (phi(i+1,j+1,k-1)-phi(i+1,j  ,k-1)))
+                              + facz*(Real(4.)*(phi(i  ,j  ,k-1)-phi(i  ,j  ,k  ))
+                                     +Real(2.)*(phi(i+1,j  ,k-1)-phi(i+1,j  ,k  ))
+                                     +Real(2.)*(phi(i  ,j+1,k-1)-phi(i  ,j+1,k  ))
+                                     +         (phi(i+1,j+1,k-1)-phi(i+1,j+1,k  ))));
         }
         if (ccmsk(i-1,j-1,k) == crse_cell) {
-            Ax += sig(i-1,j-1,k)*(facx*(4._rt*(phi(i-1,j  ,k  )-phi(i  ,j  ,k  ))
-                                       +2._rt*(phi(i-1,j-1,k  )-phi(i  ,j-1,k  ))
-                                       +2._rt*(phi(i-1,j  ,k+1)-phi(i  ,j  ,k+1))
-                                        +     (phi(i-1,j-1,k+1)-phi(i  ,j-1,k+1)))
-                                + facy*(4._rt*(phi(i  ,j-1,k  )-phi(i  ,j  ,k  ))
-                                       +2._rt*(phi(i-1,j-1,k  )-phi(i-1,j  ,k  ))
-                                       +2._rt*(phi(i  ,j-1,k+1)-phi(i  ,j  ,k+1))
-                                        +     (phi(i-1,j-1,k+1)-phi(i-1,j  ,k+1)))
-                                + facz*(4._rt*(phi(i  ,j  ,k+1)-phi(i  ,j  ,k  ))
-                                       +2._rt*(phi(i-1,j  ,k+1)-phi(i-1,j  ,k  ))
-                                       +2._rt*(phi(i  ,j-1,k+1)-phi(i  ,j-1,k  ))
-                                        +     (phi(i-1,j-1,k+1)-phi(i-1,j-1,k  ))));
+            Ax += sig(i-1,j-1,k)*(facx*(Real(4.)*(phi(i-1,j  ,k  )-phi(i  ,j  ,k  ))
+                                       +Real(2.)*(phi(i-1,j-1,k  )-phi(i  ,j-1,k  ))
+                                       +Real(2.)*(phi(i-1,j  ,k+1)-phi(i  ,j  ,k+1))
+                                       +         (phi(i-1,j-1,k+1)-phi(i  ,j-1,k+1)))
+                                + facy*(Real(4.)*(phi(i  ,j-1,k  )-phi(i  ,j  ,k  ))
+                                       +Real(2.)*(phi(i-1,j-1,k  )-phi(i-1,j  ,k  ))
+                                       +Real(2.)*(phi(i  ,j-1,k+1)-phi(i  ,j  ,k+1))
+                                       +         (phi(i-1,j-1,k+1)-phi(i-1,j  ,k+1)))
+                                + facz*(Real(4.)*(phi(i  ,j  ,k+1)-phi(i  ,j  ,k  ))
+                                       +Real(2.)*(phi(i-1,j  ,k+1)-phi(i-1,j  ,k  ))
+                                       +Real(2.)*(phi(i  ,j-1,k+1)-phi(i  ,j-1,k  ))
+                                       +         (phi(i-1,j-1,k+1)-phi(i-1,j-1,k  ))));
         }
         if (ccmsk(i,j-1,k) == crse_cell) {
-            Ax += sig(i,j-1,k)*(facx*(4._rt*(phi(i+1,j  ,k  )-phi(i  ,j  ,k  ))
-                                     +2._rt*(phi(i+1,j-1,k  )-phi(i  ,j-1,k  ))
-                                     +2._rt*(phi(i+1,j  ,k+1)-phi(i  ,j  ,k+1))
-                                      +     (phi(i+1,j-1,k+1)-phi(i  ,j-1,k+1)))
-                              + facy*(4._rt*(phi(i  ,j-1,k  )-phi(i  ,j  ,k  ))
-                                     +2._rt*(phi(i+1,j-1,k  )-phi(i+1,j  ,k  ))
-                                     +2._rt*(phi(i  ,j-1,k+1)-phi(i  ,j  ,k+1))
-                                      +     (phi(i+1,j-1,k+1)-phi(i+1,j  ,k+1)))
-                              + facz*(4._rt*(phi(i  ,j  ,k+1)-phi(i  ,j  ,k  ))
-                                     +2._rt*(phi(i+1,j  ,k+1)-phi(i+1,j  ,k  ))
-                                     +2._rt*(phi(i  ,j-1,k+1)-phi(i  ,j-1,k  ))
-                                      +     (phi(i+1,j-1,k+1)-phi(i+1,j-1,k  ))));
+            Ax += sig(i,j-1,k)*(facx*(Real(4.)*(phi(i+1,j  ,k  )-phi(i  ,j  ,k  ))
+                                     +Real(2.)*(phi(i+1,j-1,k  )-phi(i  ,j-1,k  ))
+                                     +Real(2.)*(phi(i+1,j  ,k+1)-phi(i  ,j  ,k+1))
+                                     +         (phi(i+1,j-1,k+1)-phi(i  ,j-1,k+1)))
+                              + facy*(Real(4.)*(phi(i  ,j-1,k  )-phi(i  ,j  ,k  ))
+                                     +Real(2.)*(phi(i+1,j-1,k  )-phi(i+1,j  ,k  ))
+                                     +Real(2.)*(phi(i  ,j-1,k+1)-phi(i  ,j  ,k+1))
+                                     +         (phi(i+1,j-1,k+1)-phi(i+1,j  ,k+1)))
+                              + facz*(Real(4.)*(phi(i  ,j  ,k+1)-phi(i  ,j  ,k  ))
+                                     +Real(2.)*(phi(i+1,j  ,k+1)-phi(i+1,j  ,k  ))
+                                     +Real(2.)*(phi(i  ,j-1,k+1)-phi(i  ,j-1,k  ))
+                                     +         (phi(i+1,j-1,k+1)-phi(i+1,j-1,k  ))));
         }
         if (ccmsk(i-1,j,k) == crse_cell) {
-            Ax += sig(i-1,j,k)*(facx*(4._rt*(phi(i-1,j  ,k  )-phi(i  ,j  ,k  ))
-                                     +2._rt*(phi(i-1,j+1,k  )-phi(i  ,j+1,k  ))
-                                     +2._rt*(phi(i-1,j  ,k+1)-phi(i  ,j  ,k+1))
-                                      +     (phi(i-1,j+1,k+1)-phi(i  ,j+1,k+1)))
-                              + facy*(4._rt*(phi(i  ,j+1,k  )-phi(i  ,j  ,k  ))
-                                     +2._rt*(phi(i-1,j+1,k  )-phi(i-1,j  ,k  ))
-                                     +2._rt*(phi(i  ,j+1,k+1)-phi(i  ,j  ,k+1))
-                                      +     (phi(i-1,j+1,k+1)-phi(i-1,j  ,k+1)))
-                              + facz*(4._rt*(phi(i  ,j  ,k+1)-phi(i  ,j  ,k  ))
-                                     +2._rt*(phi(i-1,j  ,k+1)-phi(i-1,j  ,k  ))
-                                     +2._rt*(phi(i  ,j+1,k+1)-phi(i  ,j+1,k  ))
-                                      +     (phi(i-1,j+1,k+1)-phi(i-1,j+1,k  ))));
+            Ax += sig(i-1,j,k)*(facx*(Real(4.)*(phi(i-1,j  ,k  )-phi(i  ,j  ,k  ))
+                                     +Real(2.)*(phi(i-1,j+1,k  )-phi(i  ,j+1,k  ))
+                                     +Real(2.)*(phi(i-1,j  ,k+1)-phi(i  ,j  ,k+1))
+                                     +         (phi(i-1,j+1,k+1)-phi(i  ,j+1,k+1)))
+                              + facy*(Real(4.)*(phi(i  ,j+1,k  )-phi(i  ,j  ,k  ))
+                                     +Real(2.)*(phi(i-1,j+1,k  )-phi(i-1,j  ,k  ))
+                                     +Real(2.)*(phi(i  ,j+1,k+1)-phi(i  ,j  ,k+1))
+                                     +         (phi(i-1,j+1,k+1)-phi(i-1,j  ,k+1)))
+                              + facz*(Real(4.)*(phi(i  ,j  ,k+1)-phi(i  ,j  ,k  ))
+                                     +Real(2.)*(phi(i-1,j  ,k+1)-phi(i-1,j  ,k  ))
+                                     +Real(2.)*(phi(i  ,j+1,k+1)-phi(i  ,j+1,k  ))
+                                     +         (phi(i-1,j+1,k+1)-phi(i-1,j+1,k  ))));
         }
         if (ccmsk(i,j,k) == crse_cell) {
-            Ax += sig(i,j,k)*(facx*(4._rt*(phi(i+1,j  ,k  )-phi(i  ,j  ,k  ))
-                                   +2._rt*(phi(i+1,j+1,k  )-phi(i  ,j+1,k  ))
-                                   +2._rt*(phi(i+1,j  ,k+1)-phi(i  ,j  ,k+1))
-                                    +     (phi(i+1,j+1,k+1)-phi(i  ,j+1,k+1)))
-                            + facy*(4._rt*(phi(i  ,j+1,k  )-phi(i  ,j  ,k  ))
-                                   +2._rt*(phi(i+1,j+1,k  )-phi(i+1,j  ,k  ))
-                                   +2._rt*(phi(i  ,j+1,k+1)-phi(i  ,j  ,k+1))
-                                    +     (phi(i+1,j+1,k+1)-phi(i+1,j  ,k+1)))
-                            + facz*(4._rt*(phi(i  ,j  ,k+1)-phi(i  ,j  ,k  ))
-                                   +2._rt*(phi(i+1,j  ,k+1)-phi(i+1,j  ,k  ))
-                                   +2._rt*(phi(i  ,j+1,k+1)-phi(i  ,j+1,k  ))
-                                    +     (phi(i+1,j+1,k+1)-phi(i+1,j+1,k  ))));
+            Ax += sig(i,j,k)*(facx*(Real(4.)*(phi(i+1,j  ,k  )-phi(i  ,j  ,k  ))
+                                   +Real(2.)*(phi(i+1,j+1,k  )-phi(i  ,j+1,k  ))
+                                   +Real(2.)*(phi(i+1,j  ,k+1)-phi(i  ,j  ,k+1))
+                                   +         (phi(i+1,j+1,k+1)-phi(i  ,j+1,k+1)))
+                            + facy*(Real(4.)*(phi(i  ,j+1,k  )-phi(i  ,j  ,k  ))
+                                   +Real(2.)*(phi(i+1,j+1,k  )-phi(i+1,j  ,k  ))
+                                   +Real(2.)*(phi(i  ,j+1,k+1)-phi(i  ,j  ,k+1))
+                                   +         (phi(i+1,j+1,k+1)-phi(i+1,j  ,k+1)))
+                            + facz*(Real(4.)*(phi(i  ,j  ,k+1)-phi(i  ,j  ,k  ))
+                                   +Real(2.)*(phi(i+1,j  ,k+1)-phi(i+1,j  ,k  ))
+                                   +Real(2.)*(phi(i  ,j+1,k+1)-phi(i  ,j+1,k  ))
+                                   +         (phi(i+1,j+1,k+1)-phi(i+1,j+1,k  ))));
         }
 
         Real Axf = fc(i,j,k);
@@ -2348,26 +2348,26 @@ void mlndlap_res_cf_contrib (int i, int j, int k, Array4<Real> const& res,
 
             if (i == ndlo.x and (bclo[0] == LinOpBCType::Neumann or
                                  bclo[0] == LinOpBCType::inflow)) {
-                Axf *= 2._rt;
+                Axf *= Real(2.);
             } else if (i== ndhi.x and (bchi[0] == LinOpBCType::Neumann or
                                        bchi[0] == LinOpBCType::inflow)) {
-                Axf *= 2._rt;
+                Axf *= Real(2.);
             }
 
             if (j == ndlo.y and ( bclo[1] == LinOpBCType::Neumann or
                                   bclo[1] == LinOpBCType::inflow)) {
-                Axf *= 2._rt;
+                Axf *= Real(2.);
             } else if (j == ndhi.y and (bchi[1] == LinOpBCType::Neumann or
                                         bchi[1] == LinOpBCType::inflow)) {
-                Axf *= 2._rt;
+                Axf *= Real(2.);
             }
 
             if (k == ndlo.z and (bclo[2] == LinOpBCType::Neumann or
                                  bclo[2] == LinOpBCType::inflow)) {
-                Axf *= 2._rt;
+                Axf *= Real(2.);
             } else if (k == ndhi.z and (bchi[2] == LinOpBCType::Neumann or
                                         bchi[2] == LinOpBCType::inflow)) {
-                Axf *= 2._rt;
+                Axf *= Real(2.);
             }
         }
 
@@ -2490,7 +2490,7 @@ void mlndlap_stencil_rap (int i, int j, int k, Array4<Real> const& csten,
                           Array4<Real const> const& fsten) noexcept
 {
     auto interp_from_mmm_to = [&fsten] (int i_, int j_, int k_) -> Real {
-        Real p = 1._rt;
+        Real p = Real(1.);
         p += amrex::Math::abs(fsten(i_-1,j_  ,k_  ,ist_p00)) /
            ( amrex::Math::abs(fsten(i_-1,j_-1,k_-1,ist_ppp))
            + amrex::Math::abs(fsten(i_-1,j_  ,k_-1,ist_ppp))
@@ -2521,7 +2521,7 @@ void mlndlap_stencil_rap (int i, int j, int k, Array4<Real> const& csten,
     amrex::ignore_unused(interp_from_mmm_to);
 
     auto interp_from_pmm_to = [&fsten] (int i_, int j_, int k_) -> Real {
-        Real p = 1._rt;
+        Real p = Real(1.);
         p += amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_p00)) /
            ( amrex::Math::abs(fsten(i_  ,j_-1,k_-1,ist_ppp))
            + amrex::Math::abs(fsten(i_  ,j_  ,k_-1,ist_ppp))
@@ -2551,7 +2551,7 @@ void mlndlap_stencil_rap (int i, int j, int k, Array4<Real> const& csten,
     };
 
     auto interp_from_mpm_to = [&fsten] (int i_, int j_, int k_) -> Real {
-        Real p = 1._rt;
+        Real p = Real(1.);
         p += amrex::Math::abs(fsten(i_-1,j_  ,k_  ,ist_p00)) /
            ( amrex::Math::abs(fsten(i_-1,j_-1,k_-1,ist_ppp))
            + amrex::Math::abs(fsten(i_-1,j_  ,k_-1,ist_ppp))
@@ -2581,7 +2581,7 @@ void mlndlap_stencil_rap (int i, int j, int k, Array4<Real> const& csten,
     };
 
     auto interp_from_ppm_to = [&fsten] (int i_, int j_, int k_) -> Real {
-        Real p = 1._rt;
+        Real p = Real(1.);
         p += amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_p00)) /
            ( amrex::Math::abs(fsten(i_  ,j_-1,k_-1,ist_ppp))
            + amrex::Math::abs(fsten(i_  ,j_  ,k_-1,ist_ppp))
@@ -2611,7 +2611,7 @@ void mlndlap_stencil_rap (int i, int j, int k, Array4<Real> const& csten,
     };
 
     auto interp_from_mmp_to = [&fsten] (int i_, int j_, int k_) -> Real {
-        Real p = 1._rt;
+        Real p = Real(1.);
         p += amrex::Math::abs(fsten(i_-1,j_  ,k_  ,ist_p00)) /
            ( amrex::Math::abs(fsten(i_-1,j_-1,k_-1,ist_ppp))
            + amrex::Math::abs(fsten(i_-1,j_  ,k_-1,ist_ppp))
@@ -2641,7 +2641,7 @@ void mlndlap_stencil_rap (int i, int j, int k, Array4<Real> const& csten,
     };
 
     auto interp_from_pmp_to = [&fsten] (int i_, int j_, int k_) -> Real {
-        Real p = 1._rt;
+        Real p = Real(1.);
         p += amrex::Math::abs(fsten(i_  ,j_  ,k_,ist_p00)) /
            ( amrex::Math::abs(fsten(i_  ,j_-1,k_-1,ist_ppp))
            + amrex::Math::abs(fsten(i_  ,j_  ,k_-1,ist_ppp))
@@ -2671,7 +2671,7 @@ void mlndlap_stencil_rap (int i, int j, int k, Array4<Real> const& csten,
     };
 
     auto interp_from_mpp_to = [&fsten] (int i_, int j_, int k_) -> Real {
-        Real p = 1._rt;
+        Real p = Real(1.);
         p += amrex::Math::abs(fsten(i_-1,j_  ,k_  ,ist_p00)) /
            ( amrex::Math::abs(fsten(i_-1,j_-1,k_-1,ist_ppp))
            + amrex::Math::abs(fsten(i_-1,j_  ,k_-1,ist_ppp))
@@ -2701,7 +2701,7 @@ void mlndlap_stencil_rap (int i, int j, int k, Array4<Real> const& csten,
     };
 
     auto interp_from_ppp_to = [&fsten] (int i_, int j_, int k_) -> Real {
-        Real p = 1._rt;
+        Real p = Real(1.);
         p += amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_p00)) /
            ( amrex::Math::abs(fsten(i_  ,j_-1,k_-1,ist_ppp))
            + amrex::Math::abs(fsten(i_  ,j_  ,k_-1,ist_ppp))
@@ -2739,10 +2739,10 @@ void mlndlap_stencil_rap (int i, int j, int k, Array4<Real> const& csten,
                                                              +amrex::Math::abs(fsten(i_  ,j_  ,k_-1,ist_0pp)) + eps);
         Real w2p = amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_00p)) / (amrex::Math::abs(fsten(i_  ,j_-1,k_  ,ist_0pp))
                                                              +amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_0pp)) + eps);
-        Real wmm = amrex::Math::abs(fsten(i_  ,j_-1,k_-1,ist_0pp)) * (1._rt + w1m + w2m);
-        Real wpm = amrex::Math::abs(fsten(i_  ,j_  ,k_-1,ist_0pp)) * (1._rt + w1p + w2m);
-        Real wmp = amrex::Math::abs(fsten(i_  ,j_-1,k_  ,ist_0pp)) * (1._rt + w1m + w2p);
-        Real wpp = amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_0pp)) * (1._rt + w1p + w2p);
+        Real wmm = amrex::Math::abs(fsten(i_  ,j_-1,k_-1,ist_0pp)) * (Real(1.) + w1m + w2m);
+        Real wpm = amrex::Math::abs(fsten(i_  ,j_  ,k_-1,ist_0pp)) * (Real(1.) + w1p + w2m);
+        Real wmp = amrex::Math::abs(fsten(i_  ,j_-1,k_  ,ist_0pp)) * (Real(1.) + w1m + w2p);
+        Real wpp = amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_0pp)) * (Real(1.) + w1p + w2p);
         return wmm / (wmm+wpm+wmp+wpp+eps);
     };
 
@@ -2755,10 +2755,10 @@ void mlndlap_stencil_rap (int i, int j, int k, Array4<Real> const& csten,
                                                              +amrex::Math::abs(fsten(i_  ,j_  ,k_-1,ist_0pp)) + eps);
         Real w2p = amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_00p)) / (amrex::Math::abs(fsten(i_  ,j_-1,k_  ,ist_0pp))
                                                              +amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_0pp)) + eps);
-        Real wmm = amrex::Math::abs(fsten(i_  ,j_-1,k_-1,ist_0pp)) * (1._rt + w1m + w2m);
-        Real wpm = amrex::Math::abs(fsten(i_  ,j_  ,k_-1,ist_0pp)) * (1._rt + w1p + w2m);
-        Real wmp = amrex::Math::abs(fsten(i_  ,j_-1,k_  ,ist_0pp)) * (1._rt + w1m + w2p);
-        Real wpp = amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_0pp)) * (1._rt + w1p + w2p);
+        Real wmm = amrex::Math::abs(fsten(i_  ,j_-1,k_-1,ist_0pp)) * (Real(1.) + w1m + w2m);
+        Real wpm = amrex::Math::abs(fsten(i_  ,j_  ,k_-1,ist_0pp)) * (Real(1.) + w1p + w2m);
+        Real wmp = amrex::Math::abs(fsten(i_  ,j_-1,k_  ,ist_0pp)) * (Real(1.) + w1m + w2p);
+        Real wpp = amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_0pp)) * (Real(1.) + w1p + w2p);
         return wmp / (wmm+wpm+wmp+wpp+eps);
     };
 
@@ -2771,10 +2771,10 @@ void mlndlap_stencil_rap (int i, int j, int k, Array4<Real> const& csten,
                                                              +amrex::Math::abs(fsten(i_  ,j_  ,k_-1,ist_0pp)) + eps);
         Real w2p = amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_00p)) / (amrex::Math::abs(fsten(i_  ,j_-1,k_  ,ist_0pp))
                                                              +amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_0pp)) + eps);
-        Real wmm = amrex::Math::abs(fsten(i_  ,j_-1,k_-1,ist_0pp)) * (1._rt + w1m + w2m);
-        Real wpm = amrex::Math::abs(fsten(i_  ,j_  ,k_-1,ist_0pp)) * (1._rt + w1p + w2m);
-        Real wmp = amrex::Math::abs(fsten(i_  ,j_-1,k_  ,ist_0pp)) * (1._rt + w1m + w2p);
-        Real wpp = amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_0pp)) * (1._rt + w1p + w2p);
+        Real wmm = amrex::Math::abs(fsten(i_  ,j_-1,k_-1,ist_0pp)) * (Real(1.) + w1m + w2m);
+        Real wpm = amrex::Math::abs(fsten(i_  ,j_  ,k_-1,ist_0pp)) * (Real(1.) + w1p + w2m);
+        Real wmp = amrex::Math::abs(fsten(i_  ,j_-1,k_  ,ist_0pp)) * (Real(1.) + w1m + w2p);
+        Real wpp = amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_0pp)) * (Real(1.) + w1p + w2p);
         return wpm / (wmm+wpm+wmp+wpp+eps);
     };
 
@@ -2787,10 +2787,10 @@ void mlndlap_stencil_rap (int i, int j, int k, Array4<Real> const& csten,
                                                              +amrex::Math::abs(fsten(i_  ,j_  ,k_-1,ist_0pp)) + eps);
         Real w2p = amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_00p)) / (amrex::Math::abs(fsten(i_  ,j_-1,k_  ,ist_0pp))
                                                              +amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_0pp)) + eps);
-        Real wmm = amrex::Math::abs(fsten(i_  ,j_-1,k_-1,ist_0pp)) * (1._rt + w1m + w2m);
-        Real wpm = amrex::Math::abs(fsten(i_  ,j_  ,k_-1,ist_0pp)) * (1._rt + w1p + w2m);
-        Real wmp = amrex::Math::abs(fsten(i_  ,j_-1,k_  ,ist_0pp)) * (1._rt + w1m + w2p);
-        Real wpp = amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_0pp)) * (1._rt + w1p + w2p);
+        Real wmm = amrex::Math::abs(fsten(i_  ,j_-1,k_-1,ist_0pp)) * (Real(1.) + w1m + w2m);
+        Real wpm = amrex::Math::abs(fsten(i_  ,j_  ,k_-1,ist_0pp)) * (Real(1.) + w1p + w2m);
+        Real wmp = amrex::Math::abs(fsten(i_  ,j_-1,k_  ,ist_0pp)) * (Real(1.) + w1m + w2p);
+        Real wpp = amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_0pp)) * (Real(1.) + w1p + w2p);
         return wpp / (wmm+wpm+wmp+wpp+eps);
     };
 
@@ -2803,10 +2803,10 @@ void mlndlap_stencil_rap (int i, int j, int k, Array4<Real> const& csten,
                                                              +amrex::Math::abs(fsten(i_  ,j_  ,k_-1,ist_p0p)) + eps);
         Real w2p = amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_00p)) / (amrex::Math::abs(fsten(i_-1,j_  ,k_  ,ist_p0p))
                                                              +amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_p0p)) + eps);
-        Real wmm = amrex::Math::abs(fsten(i_-1,j_  ,k_-1,ist_p0p)) * (1._rt + w1m + w2m);
-        Real wpm = amrex::Math::abs(fsten(i_  ,j_  ,k_-1,ist_p0p)) * (1._rt + w1p + w2m);
-        Real wmp = amrex::Math::abs(fsten(i_-1,j_  ,k_  ,ist_p0p)) * (1._rt + w1m + w2p);
-        Real wpp = amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_p0p)) * (1._rt + w1p + w2p);
+        Real wmm = amrex::Math::abs(fsten(i_-1,j_  ,k_-1,ist_p0p)) * (Real(1.) + w1m + w2m);
+        Real wpm = amrex::Math::abs(fsten(i_  ,j_  ,k_-1,ist_p0p)) * (Real(1.) + w1p + w2m);
+        Real wmp = amrex::Math::abs(fsten(i_-1,j_  ,k_  ,ist_p0p)) * (Real(1.) + w1m + w2p);
+        Real wpp = amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_p0p)) * (Real(1.) + w1p + w2p);
         return wmm / (wmm+wpm+wmp+wpp+eps);
     };
 
@@ -2819,10 +2819,10 @@ void mlndlap_stencil_rap (int i, int j, int k, Array4<Real> const& csten,
                                                              +amrex::Math::abs(fsten(i_  ,j_  ,k_-1,ist_p0p)) + eps);
         Real w2p = amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_00p)) / (amrex::Math::abs(fsten(i_-1,j_  ,k_  ,ist_p0p))
                                                              +amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_p0p)) + eps);
-        Real wmm = amrex::Math::abs(fsten(i_-1,j_  ,k_-1,ist_p0p)) * (1._rt + w1m + w2m);
-        Real wpm = amrex::Math::abs(fsten(i_  ,j_  ,k_-1,ist_p0p)) * (1._rt + w1p + w2m);
-        Real wmp = amrex::Math::abs(fsten(i_-1,j_  ,k_  ,ist_p0p)) * (1._rt + w1m + w2p);
-        Real wpp = amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_p0p)) * (1._rt + w1p + w2p);
+        Real wmm = amrex::Math::abs(fsten(i_-1,j_  ,k_-1,ist_p0p)) * (Real(1.) + w1m + w2m);
+        Real wpm = amrex::Math::abs(fsten(i_  ,j_  ,k_-1,ist_p0p)) * (Real(1.) + w1p + w2m);
+        Real wmp = amrex::Math::abs(fsten(i_-1,j_  ,k_  ,ist_p0p)) * (Real(1.) + w1m + w2p);
+        Real wpp = amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_p0p)) * (Real(1.) + w1p + w2p);
         return wpm / (wmm+wpm+wmp+wpp+eps);
     };
 
@@ -2835,10 +2835,10 @@ void mlndlap_stencil_rap (int i, int j, int k, Array4<Real> const& csten,
                                                              +amrex::Math::abs(fsten(i_  ,j_  ,k_-1,ist_p0p)) + eps);
         Real w2p = amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_00p)) / (amrex::Math::abs(fsten(i_-1,j_  ,k_  ,ist_p0p))
                                                              +amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_p0p)) + eps);
-        Real wmm = amrex::Math::abs(fsten(i_-1,j_  ,k_-1,ist_p0p)) * (1._rt + w1m + w2m);
-        Real wpm = amrex::Math::abs(fsten(i_  ,j_  ,k_-1,ist_p0p)) * (1._rt + w1p + w2m);
-        Real wmp = amrex::Math::abs(fsten(i_-1,j_  ,k_  ,ist_p0p)) * (1._rt + w1m + w2p);
-        Real wpp = amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_p0p)) * (1._rt + w1p + w2p);
+        Real wmm = amrex::Math::abs(fsten(i_-1,j_  ,k_-1,ist_p0p)) * (Real(1.) + w1m + w2m);
+        Real wpm = amrex::Math::abs(fsten(i_  ,j_  ,k_-1,ist_p0p)) * (Real(1.) + w1p + w2m);
+        Real wmp = amrex::Math::abs(fsten(i_-1,j_  ,k_  ,ist_p0p)) * (Real(1.) + w1m + w2p);
+        Real wpp = amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_p0p)) * (Real(1.) + w1p + w2p);
         return wmp / (wmm+wpm+wmp+wpp+eps);
     };
 
@@ -2851,10 +2851,10 @@ void mlndlap_stencil_rap (int i, int j, int k, Array4<Real> const& csten,
                                                              +amrex::Math::abs(fsten(i_  ,j_  ,k_-1,ist_p0p)) + eps);
         Real w2p = amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_00p)) / (amrex::Math::abs(fsten(i_-1,j_  ,k_  ,ist_p0p))
                                                              +amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_p0p)) + eps);
-        Real wmm = amrex::Math::abs(fsten(i_-1,j_  ,k_-1,ist_p0p)) * (1._rt + w1m + w2m);
-        Real wpm = amrex::Math::abs(fsten(i_  ,j_  ,k_-1,ist_p0p)) * (1._rt + w1p + w2m);
-        Real wmp = amrex::Math::abs(fsten(i_-1,j_  ,k_  ,ist_p0p)) * (1._rt + w1m + w2p);
-        Real wpp = amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_p0p)) * (1._rt + w1p + w2p);
+        Real wmm = amrex::Math::abs(fsten(i_-1,j_  ,k_-1,ist_p0p)) * (Real(1.) + w1m + w2m);
+        Real wpm = amrex::Math::abs(fsten(i_  ,j_  ,k_-1,ist_p0p)) * (Real(1.) + w1p + w2m);
+        Real wmp = amrex::Math::abs(fsten(i_-1,j_  ,k_  ,ist_p0p)) * (Real(1.) + w1m + w2p);
+        Real wpp = amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_p0p)) * (Real(1.) + w1p + w2p);
         return wpp / (wmm+wpm+wmp+wpp+eps);
     };
 
@@ -2867,10 +2867,10 @@ void mlndlap_stencil_rap (int i, int j, int k, Array4<Real> const& csten,
                                                              +amrex::Math::abs(fsten(i_  ,j_-1,k_  ,ist_pp0)) + eps);
       Real w2p = amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_0p0)) / (amrex::Math::abs(fsten(i_-1,j_  ,k_  ,ist_pp0))
                                                             +amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_pp0)) + eps);
-        Real wmm = amrex::Math::abs(fsten(i_-1,j_-1,k_  ,ist_pp0)) * (1._rt + w1m + w2m);
-        Real wpm = amrex::Math::abs(fsten(i_  ,j_-1,k_  ,ist_pp0)) * (1._rt + w1p + w2m);
-        Real wmp = amrex::Math::abs(fsten(i_-1,j_  ,k_  ,ist_pp0)) * (1._rt + w1m + w2p);
-        Real wpp = amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_pp0)) * (1._rt + w1p + w2p);
+        Real wmm = amrex::Math::abs(fsten(i_-1,j_-1,k_  ,ist_pp0)) * (Real(1.) + w1m + w2m);
+        Real wpm = amrex::Math::abs(fsten(i_  ,j_-1,k_  ,ist_pp0)) * (Real(1.) + w1p + w2m);
+        Real wmp = amrex::Math::abs(fsten(i_-1,j_  ,k_  ,ist_pp0)) * (Real(1.) + w1m + w2p);
+        Real wpp = amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_pp0)) * (Real(1.) + w1p + w2p);
         return wmm / (wmm+wpm+wmp+wpp+eps);
     };
 
@@ -2883,10 +2883,10 @@ void mlndlap_stencil_rap (int i, int j, int k, Array4<Real> const& csten,
                                                              +amrex::Math::abs(fsten(i_  ,j_-1,k_  ,ist_pp0)) + eps);
         Real w2p = amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_0p0)) / (amrex::Math::abs(fsten(i_-1,j_  ,k_  ,ist_pp0))
                                                              +amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_pp0)) + eps);
-        Real wmm = amrex::Math::abs(fsten(i_-1,j_-1,k_  ,ist_pp0)) * (1._rt + w1m + w2m);
-        Real wpm = amrex::Math::abs(fsten(i_  ,j_-1,k_  ,ist_pp0)) * (1._rt + w1p + w2m);
-        Real wmp = amrex::Math::abs(fsten(i_-1,j_  ,k_  ,ist_pp0)) * (1._rt + w1m + w2p);
-        Real wpp = amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_pp0)) * (1._rt + w1p + w2p);
+        Real wmm = amrex::Math::abs(fsten(i_-1,j_-1,k_  ,ist_pp0)) * (Real(1.) + w1m + w2m);
+        Real wpm = amrex::Math::abs(fsten(i_  ,j_-1,k_  ,ist_pp0)) * (Real(1.) + w1p + w2m);
+        Real wmp = amrex::Math::abs(fsten(i_-1,j_  ,k_  ,ist_pp0)) * (Real(1.) + w1m + w2p);
+        Real wpp = amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_pp0)) * (Real(1.) + w1p + w2p);
         return wmp / (wmm+wpm+wmp+wpp+eps);
     };
 
@@ -2899,10 +2899,10 @@ void mlndlap_stencil_rap (int i, int j, int k, Array4<Real> const& csten,
                                                              +amrex::Math::abs(fsten(i_  ,j_-1,k_  ,ist_pp0)) + eps);
         Real w2p = amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_0p0)) / (amrex::Math::abs(fsten(i_-1,j_  ,k_  ,ist_pp0))
                                                              +amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_pp0)) + eps);
-        Real wmm = amrex::Math::abs(fsten(i_-1,j_-1,k_  ,ist_pp0)) * (1._rt + w1m + w2m);
-        Real wpm = amrex::Math::abs(fsten(i_  ,j_-1,k_  ,ist_pp0)) * (1._rt + w1p + w2m);
-        Real wmp = amrex::Math::abs(fsten(i_-1,j_  ,k_  ,ist_pp0)) * (1._rt + w1m + w2p);
-        Real wpp = amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_pp0)) * (1._rt + w1p + w2p);
+        Real wmm = amrex::Math::abs(fsten(i_-1,j_-1,k_  ,ist_pp0)) * (Real(1.) + w1m + w2m);
+        Real wpm = amrex::Math::abs(fsten(i_  ,j_-1,k_  ,ist_pp0)) * (Real(1.) + w1p + w2m);
+        Real wmp = amrex::Math::abs(fsten(i_-1,j_  ,k_  ,ist_pp0)) * (Real(1.) + w1m + w2p);
+        Real wpp = amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_pp0)) * (Real(1.) + w1p + w2p);
         return wpm / (wmm+wpm+wmp+wpp+eps);
     };
 
@@ -2915,18 +2915,18 @@ void mlndlap_stencil_rap (int i, int j, int k, Array4<Real> const& csten,
                                                              +amrex::Math::abs(fsten(i_  ,j_-1,k_  ,ist_pp0)) + eps);
         Real w2p = amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_0p0)) / (amrex::Math::abs(fsten(i_-1,j_  ,k_  ,ist_pp0))
                                                              +amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_pp0)) + eps);
-        Real wmm = amrex::Math::abs(fsten(i_-1,j_-1,k_  ,ist_pp0)) * (1._rt + w1m + w2m);
-        Real wpm = amrex::Math::abs(fsten(i_  ,j_-1,k_  ,ist_pp0)) * (1._rt + w1p + w2m);
-        Real wmp = amrex::Math::abs(fsten(i_-1,j_  ,k_  ,ist_pp0)) * (1._rt + w1m + w2p);
-        Real wpp = amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_pp0)) * (1._rt + w1p + w2p);
+        Real wmm = amrex::Math::abs(fsten(i_-1,j_-1,k_  ,ist_pp0)) * (Real(1.) + w1m + w2m);
+        Real wpm = amrex::Math::abs(fsten(i_  ,j_-1,k_  ,ist_pp0)) * (Real(1.) + w1p + w2m);
+        Real wmp = amrex::Math::abs(fsten(i_-1,j_  ,k_  ,ist_pp0)) * (Real(1.) + w1m + w2p);
+        Real wpp = amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_pp0)) * (Real(1.) + w1p + w2p);
         return wpp / (wmm+wpm+wmp+wpp+eps);
     };
 
     auto interp_from_00m_to = [&fsten] (int i_, int j_, int k_) -> Real {
         Real w1 = amrex::Math::abs(fsten(i_  ,j_  ,k_-1,ist_00p));
         Real w2 = amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_00p));
-        if (w1 == 0._rt and w2 == 0._rt) {
-            return 0.5_rt;
+        if (w1 == Real(0.) and w2 == Real(0.)) {
+            return Real(0.5);
         } else {
             return w1 / (w1+w2);
         }
@@ -2935,8 +2935,8 @@ void mlndlap_stencil_rap (int i, int j, int k, Array4<Real> const& csten,
     auto interp_from_00p_to = [&fsten] (int i_, int j_, int k_) -> Real {
         Real w1 = amrex::Math::abs(fsten(i_  ,j_  ,k_-1,ist_00p));
         Real w2 = amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_00p));
-        if (w1 == 0._rt and w2 == 0._rt) {
-            return 0.5_rt;
+        if (w1 == Real(0.) and w2 == Real(0.)) {
+            return Real(0.5);
         } else {
             return w2 / (w1+w2);
         }
@@ -2945,8 +2945,8 @@ void mlndlap_stencil_rap (int i, int j, int k, Array4<Real> const& csten,
     auto interp_from_0m0_to = [&fsten] (int i_, int j_, int k_) -> Real {
         Real w1 = amrex::Math::abs(fsten(i_  ,j_-1,k_  ,ist_0p0));
         Real w2 = amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_0p0));
-        if (w1 == 0._rt and w2 == 0._rt) {
-            return 0.5_rt;
+        if (w1 == Real(0.) and w2 == Real(0.)) {
+            return Real(0.5);
         } else {
             return w1 / (w1+w2);
         }
@@ -2955,8 +2955,8 @@ void mlndlap_stencil_rap (int i, int j, int k, Array4<Real> const& csten,
     auto interp_from_0p0_to = [&fsten] (int i_, int j_, int k_) -> Real {
         Real w1 = amrex::Math::abs(fsten(i_  ,j_-1,k_  ,ist_0p0));
         Real w2 = amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_0p0));
-        if (w1 == 0._rt and w2 == 0._rt) {
-            return 0.5_rt;
+        if (w1 == Real(0.) and w2 == Real(0.)) {
+            return Real(0.5);
         } else {
             return w2 / (w1+w2);
         }
@@ -2965,8 +2965,8 @@ void mlndlap_stencil_rap (int i, int j, int k, Array4<Real> const& csten,
     auto interp_from_m00_to = [&fsten] (int i_, int j_, int k_) -> Real {
         Real w1 = amrex::Math::abs(fsten(i_-1,j_  ,k_  ,ist_p00));
         Real w2 = amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_p00));
-        if (w1 == 0._rt and w2 == 0._rt) {
-            return 0.5_rt;
+        if (w1 == Real(0.) and w2 == Real(0.)) {
+            return Real(0.5);
         } else {
             return w1 / (w1+w2);
         }
@@ -2975,8 +2975,8 @@ void mlndlap_stencil_rap (int i, int j, int k, Array4<Real> const& csten,
     auto interp_from_p00_to = [&fsten] (int i_, int j_, int k_) -> Real {
         Real w1 = amrex::Math::abs(fsten(i_-1,j_  ,k_  ,ist_p00));
         Real w2 = amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_p00));
-        if (w1 == 0._rt and w2 == 0._rt) {
-            return 0.5_rt;
+        if (w1 == Real(0.) and w2 == Real(0.)) {
+            return Real(0.5);
         } else {
             return w2 / (w1+w2);
         }
@@ -3092,7 +3092,7 @@ void mlndlap_stencil_rap (int i, int j, int k, Array4<Real> const& csten,
     };
 
     auto restrict_from_mmm_to = [&fsten] (int ii_, int jj_, int kk_) -> Real {
-        Real r = 1._rt;
+        Real r = Real(1.);
         r += amrex::Math::abs(fsten(ii_-1,jj_-1,kk_-1,ist_p00)) /
            ( amrex::Math::abs(fsten(ii_-1,jj_-2,kk_-2,ist_ppp))
            + amrex::Math::abs(fsten(ii_-1,jj_-1,kk_-2,ist_ppp))
@@ -3131,15 +3131,15 @@ void mlndlap_stencil_rap (int i, int j, int k, Array4<Real> const& csten,
                                                               +amrex::Math::abs(fsten(ii_,jj_-1,kk_-2,ist_0pp)) + eps);
         Real w2p = amrex::Math::abs(fsten(ii_,jj_-1,kk_-1,ist_00p)) / (amrex::Math::abs(fsten(ii_,jj_-2,kk_-1,ist_0pp))
                                                               +amrex::Math::abs(fsten(ii_,jj_-1,kk_-1,ist_0pp)) + eps);
-        Real wmm = amrex::Math::abs(fsten(ii_,jj_-2,kk_-2,ist_0pp)) * (1._rt + w1m + w2m);
-        Real wpm = amrex::Math::abs(fsten(ii_,jj_-1,kk_-2,ist_0pp)) * (1._rt + w1p + w2m);
-        Real wmp = amrex::Math::abs(fsten(ii_,jj_-2,kk_-1,ist_0pp)) * (1._rt + w1m + w2p);
-        Real wpp = amrex::Math::abs(fsten(ii_,jj_-1,kk_-1,ist_0pp)) * (1._rt + w1p + w2p);
+        Real wmm = amrex::Math::abs(fsten(ii_,jj_-2,kk_-2,ist_0pp)) * (Real(1.) + w1m + w2m);
+        Real wpm = amrex::Math::abs(fsten(ii_,jj_-1,kk_-2,ist_0pp)) * (Real(1.) + w1p + w2m);
+        Real wmp = amrex::Math::abs(fsten(ii_,jj_-2,kk_-1,ist_0pp)) * (Real(1.) + w1m + w2p);
+        Real wpp = amrex::Math::abs(fsten(ii_,jj_-1,kk_-1,ist_0pp)) * (Real(1.) + w1p + w2p);
         return wpp / (wmm+wpm+wmp+wpp+eps);
     };
 
     auto restrict_from_pmm_to = [&fsten] (int ii_, int jj_, int kk_) -> Real {
-        Real r = 1._rt;
+        Real r = Real(1.);
         r += amrex::Math::abs(fsten(ii_  ,jj_-1,kk_-1,ist_p00)) /
            ( amrex::Math::abs(fsten(ii_  ,jj_-2,kk_-2,ist_ppp))
            + amrex::Math::abs(fsten(ii_  ,jj_-1,kk_-2,ist_ppp))
@@ -3177,18 +3177,18 @@ void mlndlap_stencil_rap (int i, int j, int k, Array4<Real> const& csten,
                                                               +amrex::Math::abs(fsten(ii_-1,jj_,kk_-2,ist_p0p)) + eps);
         Real w2p = amrex::Math::abs(fsten(ii_-1,jj_,kk_-1,ist_00p)) / (amrex::Math::abs(fsten(ii_-2,jj_,kk_-1,ist_p0p))
                                                               +amrex::Math::abs(fsten(ii_-1,jj_,kk_-1,ist_p0p)) + eps);
-        Real wmm = amrex::Math::abs(fsten(ii_-2,jj_,kk_-2,ist_p0p)) * (1._rt + w1m + w2m);
-        Real wpm = amrex::Math::abs(fsten(ii_-1,jj_,kk_-2,ist_p0p)) * (1._rt + w1p + w2m);
-        Real wmp = amrex::Math::abs(fsten(ii_-2,jj_,kk_-1,ist_p0p)) * (1._rt + w1m + w2p);
-        Real wpp = amrex::Math::abs(fsten(ii_-1,jj_,kk_-1,ist_p0p)) * (1._rt + w1p + w2p);
+        Real wmm = amrex::Math::abs(fsten(ii_-2,jj_,kk_-2,ist_p0p)) * (Real(1.) + w1m + w2m);
+        Real wpm = amrex::Math::abs(fsten(ii_-1,jj_,kk_-2,ist_p0p)) * (Real(1.) + w1p + w2m);
+        Real wmp = amrex::Math::abs(fsten(ii_-2,jj_,kk_-1,ist_p0p)) * (Real(1.) + w1m + w2p);
+        Real wpp = amrex::Math::abs(fsten(ii_-1,jj_,kk_-1,ist_p0p)) * (Real(1.) + w1p + w2p);
         return wpp / (wmm+wpm+wmp+wpp+eps);
     };
 
     auto restrict_from_00m_to = [&fsten] (int ii_, int jj_, int kk_) -> Real {
         Real w1 = amrex::Math::abs(fsten(ii_,jj_,kk_-2,ist_00p));
         Real w2 = amrex::Math::abs(fsten(ii_,jj_,kk_-1,ist_00p));
-        if (w1 == 0._rt and w2 == 0._rt) {
-            return 0.5_rt;
+        if (w1 == Real(0.) and w2 == Real(0.)) {
+            return Real(0.5);
         } else {
             return w2 / (w1+w2);
         }
@@ -3203,15 +3203,15 @@ void mlndlap_stencil_rap (int i, int j, int k, Array4<Real> const& csten,
                                                               +amrex::Math::abs(fsten(ii_+1,jj_,kk_-2,ist_p0p)) + eps);
         Real w2p = amrex::Math::abs(fsten(ii_+1,jj_,kk_-1,ist_00p)) / (amrex::Math::abs(fsten(ii_  ,jj_,kk_-1,ist_p0p))
                                                               +amrex::Math::abs(fsten(ii_+1,jj_,kk_-1,ist_p0p)) + eps);
-        Real wmm = amrex::Math::abs(fsten(ii_  ,jj_,kk_-2,ist_p0p)) * (1._rt + w1m + w2m);
-        Real wpm = amrex::Math::abs(fsten(ii_+1,jj_,kk_-2,ist_p0p)) * (1._rt + w1p + w2m);
-        Real wmp = amrex::Math::abs(fsten(ii_  ,jj_,kk_-1,ist_p0p)) * (1._rt + w1m + w2p);
-        Real wpp = amrex::Math::abs(fsten(ii_+1,jj_,kk_-1,ist_p0p)) * (1._rt + w1p + w2p);
+        Real wmm = amrex::Math::abs(fsten(ii_  ,jj_,kk_-2,ist_p0p)) * (Real(1.) + w1m + w2m);
+        Real wpm = amrex::Math::abs(fsten(ii_+1,jj_,kk_-2,ist_p0p)) * (Real(1.) + w1p + w2m);
+        Real wmp = amrex::Math::abs(fsten(ii_  ,jj_,kk_-1,ist_p0p)) * (Real(1.) + w1m + w2p);
+        Real wpp = amrex::Math::abs(fsten(ii_+1,jj_,kk_-1,ist_p0p)) * (Real(1.) + w1p + w2p);
         return wmp / (wmm+wpm+wmp+wpp+eps);
     };
 
     auto restrict_from_mpm_to = [&fsten] (int ii_, int jj_, int kk_) -> Real {
-        Real r = 1._rt;
+        Real r = Real(1.);
         r += amrex::Math::abs(fsten(ii_-1,jj_+1,kk_-1,ist_p00)) /
            ( amrex::Math::abs(fsten(ii_-1,jj_  ,kk_-2,ist_ppp))
            + amrex::Math::abs(fsten(ii_-1,jj_+1,kk_-2,ist_ppp))
@@ -3249,15 +3249,15 @@ void mlndlap_stencil_rap (int i, int j, int k, Array4<Real> const& csten,
                                                               +amrex::Math::abs(fsten(ii_,jj_+1,kk_-2,ist_0pp)) + eps);
         Real w2p = amrex::Math::abs(fsten(ii_,jj_+1,kk_-1,ist_00p)) / (amrex::Math::abs(fsten(ii_,jj_  ,kk_-1,ist_0pp))
                                                               +amrex::Math::abs(fsten(ii_,jj_+1,kk_-1,ist_0pp)) + eps);
-        Real wmm = amrex::Math::abs(fsten(ii_,jj_  ,kk_-2,ist_0pp)) * (1._rt + w1m + w2m);
-        Real wpm = amrex::Math::abs(fsten(ii_,jj_+1,kk_-2,ist_0pp)) * (1._rt + w1p + w2m);
-        Real wmp = amrex::Math::abs(fsten(ii_,jj_  ,kk_-1,ist_0pp)) * (1._rt + w1m + w2p);
-        Real wpp = amrex::Math::abs(fsten(ii_,jj_+1,kk_-1,ist_0pp)) * (1._rt + w1p + w2p);
+        Real wmm = amrex::Math::abs(fsten(ii_,jj_  ,kk_-2,ist_0pp)) * (Real(1.) + w1m + w2m);
+        Real wpm = amrex::Math::abs(fsten(ii_,jj_+1,kk_-2,ist_0pp)) * (Real(1.) + w1p + w2m);
+        Real wmp = amrex::Math::abs(fsten(ii_,jj_  ,kk_-1,ist_0pp)) * (Real(1.) + w1m + w2p);
+        Real wpp = amrex::Math::abs(fsten(ii_,jj_+1,kk_-1,ist_0pp)) * (Real(1.) + w1p + w2p);
         return wmp / (wmm+wpm+wmp+wpp+eps);
     };
 
     auto restrict_from_ppm_to = [&fsten] (int ii_, int jj_, int kk_) -> Real {
-        Real r = 1._rt;
+        Real r = Real(1.);
         r += amrex::Math::abs(fsten(ii_  ,jj_+1,kk_-1,ist_p00)) /
            ( amrex::Math::abs(fsten(ii_  ,jj_  ,kk_-2,ist_ppp))
            + amrex::Math::abs(fsten(ii_  ,jj_+1,kk_-2,ist_ppp))
@@ -3295,18 +3295,18 @@ void mlndlap_stencil_rap (int i, int j, int k, Array4<Real> const& csten,
                                                               +amrex::Math::abs(fsten(ii_-1,jj_-2,kk_,ist_pp0)) + eps);
         Real w2p = amrex::Math::abs(fsten(ii_-1,jj_-1,kk_,ist_0p0)) / (amrex::Math::abs(fsten(ii_-2,jj_-1,kk_,ist_pp0))
                                                               +amrex::Math::abs(fsten(ii_-1,jj_-1,kk_,ist_pp0)) + eps);
-        Real wmm = amrex::Math::abs(fsten(ii_-2,jj_-2,kk_,ist_pp0)) * (1._rt + w1m + w2m);
-        Real wpm = amrex::Math::abs(fsten(ii_-1,jj_-2,kk_,ist_pp0)) * (1._rt + w1p + w2m);
-        Real wmp = amrex::Math::abs(fsten(ii_-2,jj_-1,kk_,ist_pp0)) * (1._rt + w1m + w2p);
-        Real wpp = amrex::Math::abs(fsten(ii_-1,jj_-1,kk_,ist_pp0)) * (1._rt + w1p + w2p);
+        Real wmm = amrex::Math::abs(fsten(ii_-2,jj_-2,kk_,ist_pp0)) * (Real(1.) + w1m + w2m);
+        Real wpm = amrex::Math::abs(fsten(ii_-1,jj_-2,kk_,ist_pp0)) * (Real(1.) + w1p + w2m);
+        Real wmp = amrex::Math::abs(fsten(ii_-2,jj_-1,kk_,ist_pp0)) * (Real(1.) + w1m + w2p);
+        Real wpp = amrex::Math::abs(fsten(ii_-1,jj_-1,kk_,ist_pp0)) * (Real(1.) + w1p + w2p);
         return wpp / (wmm+wpm+wmp+wpp+eps);
     };
 
     auto restrict_from_0m0_to = [&fsten] (int ii_, int jj_, int kk_) -> Real {
         Real w1 = amrex::Math::abs(fsten(ii_,jj_-2,kk_,ist_0p0));
         Real w2 = amrex::Math::abs(fsten(ii_,jj_-1,kk_,ist_0p0));
-        if (w1 == 0._rt and w2 == 0._rt) {
-            return 0.5_rt;
+        if (w1 == Real(0.) and w2 == Real(0.)) {
+            return Real(0.5);
         } else {
             return w2 / (w1+w2);
         }
@@ -3321,32 +3321,32 @@ void mlndlap_stencil_rap (int i, int j, int k, Array4<Real> const& csten,
                                                               +amrex::Math::abs(fsten(ii_+1,jj_-2,kk_,ist_pp0)) + eps);
         Real w2p = amrex::Math::abs(fsten(ii_+1,jj_-1,kk_,ist_0p0)) / (amrex::Math::abs(fsten(ii_  ,jj_-1,kk_,ist_pp0))
                                                               +amrex::Math::abs(fsten(ii_+1,jj_-1,kk_,ist_pp0)) + eps);
-        Real wmm = amrex::Math::abs(fsten(ii_  ,jj_-2,kk_,ist_pp0)) * (1._rt + w1m + w2m);
-        Real wpm = amrex::Math::abs(fsten(ii_+1,jj_-2,kk_,ist_pp0)) * (1._rt + w1p + w2m);
-        Real wmp = amrex::Math::abs(fsten(ii_  ,jj_-1,kk_,ist_pp0)) * (1._rt + w1m + w2p);
-        Real wpp = amrex::Math::abs(fsten(ii_+1,jj_-1,kk_,ist_pp0)) * (1._rt + w1p + w2p);
+        Real wmm = amrex::Math::abs(fsten(ii_  ,jj_-2,kk_,ist_pp0)) * (Real(1.) + w1m + w2m);
+        Real wpm = amrex::Math::abs(fsten(ii_+1,jj_-2,kk_,ist_pp0)) * (Real(1.) + w1p + w2m);
+        Real wmp = amrex::Math::abs(fsten(ii_  ,jj_-1,kk_,ist_pp0)) * (Real(1.) + w1m + w2p);
+        Real wpp = amrex::Math::abs(fsten(ii_+1,jj_-1,kk_,ist_pp0)) * (Real(1.) + w1p + w2p);
         return wmp / (wmm+wpm+wmp+wpp+eps);
     };
 
     auto restrict_from_m00_to = [&fsten] (int ii_, int jj_, int kk_) -> Real {
         Real w1 = amrex::Math::abs(fsten(ii_-2,jj_,kk_,ist_p00));
         Real w2 = amrex::Math::abs(fsten(ii_-1,jj_,kk_,ist_p00));
-        if (w1 == 0._rt and w2 == 0._rt) {
-            return 0.5_rt;
+        if (w1 == Real(0.) and w2 == Real(0.)) {
+            return Real(0.5);
         } else {
             return w2 / (w1+w2);
         }
     };
 
     auto restrict_from_000_to = [] (int /*ii_*/, int /*jj_*/, int /*kk_*/) -> Real {
-        return 1._rt;
+        return Real(1.);
     };
 
     auto restrict_from_p00_to = [&fsten] (int ii_, int jj_, int kk_) -> Real {
         Real w1 = amrex::Math::abs(fsten(ii_  ,jj_,kk_,ist_p00));
         Real w2 = amrex::Math::abs(fsten(ii_+1,jj_,kk_,ist_p00));
-        if (w1 == 0._rt and w2 == 0._rt) {
-            return 0.5_rt;
+        if (w1 == Real(0.) and w2 == Real(0.)) {
+            return Real(0.5);
         } else {
             return w1 / (w1+w2);
         }
@@ -3361,18 +3361,18 @@ void mlndlap_stencil_rap (int i, int j, int k, Array4<Real> const& csten,
                                                               +amrex::Math::abs(fsten(ii_-1,jj_  ,kk_,ist_pp0)) + eps);
         Real w2p = amrex::Math::abs(fsten(ii_-1,jj_+1,kk_,ist_0p0)) / (amrex::Math::abs(fsten(ii_-2,jj_+1,kk_,ist_pp0))
                                                               +amrex::Math::abs(fsten(ii_-1,jj_+1,kk_,ist_pp0)) + eps);
-        Real wmm = amrex::Math::abs(fsten(ii_-2,jj_  ,kk_,ist_pp0)) * (1._rt + w1m + w2m);
-        Real wpm = amrex::Math::abs(fsten(ii_-1,jj_  ,kk_,ist_pp0)) * (1._rt + w1p + w2m);
-        Real wmp = amrex::Math::abs(fsten(ii_-2,jj_+1,kk_,ist_pp0)) * (1._rt + w1m + w2p);
-        Real wpp = amrex::Math::abs(fsten(ii_-1,jj_+1,kk_,ist_pp0)) * (1._rt + w1p + w2p);
+        Real wmm = amrex::Math::abs(fsten(ii_-2,jj_  ,kk_,ist_pp0)) * (Real(1.) + w1m + w2m);
+        Real wpm = amrex::Math::abs(fsten(ii_-1,jj_  ,kk_,ist_pp0)) * (Real(1.) + w1p + w2m);
+        Real wmp = amrex::Math::abs(fsten(ii_-2,jj_+1,kk_,ist_pp0)) * (Real(1.) + w1m + w2p);
+        Real wpp = amrex::Math::abs(fsten(ii_-1,jj_+1,kk_,ist_pp0)) * (Real(1.) + w1p + w2p);
         return wpm / (wmm+wpm+wmp+wpp+eps);
     };
 
     auto restrict_from_0p0_to = [&fsten] (int ii_, int jj_, int kk_) -> Real {
         Real w1 = amrex::Math::abs(fsten(ii_,jj_  ,kk_,ist_0p0));
         Real w2 = amrex::Math::abs(fsten(ii_,jj_+1,kk_,ist_0p0));
-        if (w1 == 0._rt and w2 == 0._rt) {
-            return 0.5_rt;
+        if (w1 == Real(0.) and w2 == Real(0.)) {
+            return Real(0.5);
         } else {
             return w1 / (w1+w2);
         }
@@ -3387,15 +3387,15 @@ void mlndlap_stencil_rap (int i, int j, int k, Array4<Real> const& csten,
                                                               +amrex::Math::abs(fsten(ii_+1,jj_  ,kk_,ist_pp0)) + eps);
         Real w2p = amrex::Math::abs(fsten(ii_+1,jj_+1,kk_,ist_0p0)) / (amrex::Math::abs(fsten(ii_  ,jj_+1,kk_,ist_pp0))
                                                               +amrex::Math::abs(fsten(ii_+1,jj_+1,kk_,ist_pp0)) + eps);
-        Real wmm = amrex::Math::abs(fsten(ii_  ,jj_  ,kk_,ist_pp0)) * (1._rt + w1m + w2m);
-        Real wpm = amrex::Math::abs(fsten(ii_+1,jj_  ,kk_,ist_pp0)) * (1._rt + w1p + w2m);
-        Real wmp = amrex::Math::abs(fsten(ii_  ,jj_+1,kk_,ist_pp0)) * (1._rt + w1m + w2p);
-        Real wpp = amrex::Math::abs(fsten(ii_+1,jj_+1,kk_,ist_pp0)) * (1._rt + w1p + w2p);
+        Real wmm = amrex::Math::abs(fsten(ii_  ,jj_  ,kk_,ist_pp0)) * (Real(1.) + w1m + w2m);
+        Real wpm = amrex::Math::abs(fsten(ii_+1,jj_  ,kk_,ist_pp0)) * (Real(1.) + w1p + w2m);
+        Real wmp = amrex::Math::abs(fsten(ii_  ,jj_+1,kk_,ist_pp0)) * (Real(1.) + w1m + w2p);
+        Real wpp = amrex::Math::abs(fsten(ii_+1,jj_+1,kk_,ist_pp0)) * (Real(1.) + w1p + w2p);
         return wmm / (wmm+wpm+wmp+wpp+eps);
     };
 
     auto restrict_from_mmp_to = [&fsten] (int ii_, int jj_, int kk_) -> Real {
-        Real r = 1._rt;
+        Real r = Real(1.);
         r += amrex::Math::abs(fsten(ii_-1,jj_-1,kk_+1,ist_p00)) /
            ( amrex::Math::abs(fsten(ii_-1,jj_-2,kk_  ,ist_ppp))
            + amrex::Math::abs(fsten(ii_-1,jj_-1,kk_  ,ist_ppp))
@@ -3433,15 +3433,15 @@ void mlndlap_stencil_rap (int i, int j, int k, Array4<Real> const& csten,
                                                               +amrex::Math::abs(fsten(ii_,jj_-1,kk_  ,ist_0pp)) + eps);
         Real w2p = amrex::Math::abs(fsten(ii_,jj_-1,kk_+1,ist_00p)) / (amrex::Math::abs(fsten(ii_,jj_-2,kk_+1,ist_0pp))
                                                               +amrex::Math::abs(fsten(ii_,jj_-1,kk_+1,ist_0pp)) + eps);
-        Real wmm = amrex::Math::abs(fsten(ii_,jj_-2,kk_  ,ist_0pp)) * (1._rt + w1m + w2m);
-        Real wpm = amrex::Math::abs(fsten(ii_,jj_-1,kk_  ,ist_0pp)) * (1._rt + w1p + w2m);
-        Real wmp = amrex::Math::abs(fsten(ii_,jj_-2,kk_+1,ist_0pp)) * (1._rt + w1m + w2p);
-        Real wpp = amrex::Math::abs(fsten(ii_,jj_-1,kk_+1,ist_0pp)) * (1._rt + w1p + w2p);
+        Real wmm = amrex::Math::abs(fsten(ii_,jj_-2,kk_  ,ist_0pp)) * (Real(1.) + w1m + w2m);
+        Real wpm = amrex::Math::abs(fsten(ii_,jj_-1,kk_  ,ist_0pp)) * (Real(1.) + w1p + w2m);
+        Real wmp = amrex::Math::abs(fsten(ii_,jj_-2,kk_+1,ist_0pp)) * (Real(1.) + w1m + w2p);
+        Real wpp = amrex::Math::abs(fsten(ii_,jj_-1,kk_+1,ist_0pp)) * (Real(1.) + w1p + w2p);
         return wpm / (wmm+wpm+wmp+wpp+eps);
     };
 
     auto restrict_from_pmp_to = [&fsten] (int ii_, int jj_, int kk_) -> Real {
-        Real r = 1._rt;
+        Real r = Real(1.);
         r += amrex::Math::abs(fsten(ii_  ,jj_-1,kk_+1,ist_p00)) /
            ( amrex::Math::abs(fsten(ii_  ,jj_-2,kk_  ,ist_ppp))
            + amrex::Math::abs(fsten(ii_  ,jj_-1,kk_  ,ist_ppp))
@@ -3479,18 +3479,18 @@ void mlndlap_stencil_rap (int i, int j, int k, Array4<Real> const& csten,
                                                               +amrex::Math::abs(fsten(ii_-1,jj_,kk_  ,ist_p0p)) + eps);
         Real w2p = amrex::Math::abs(fsten(ii_-1,jj_,kk_+1,ist_00p)) / (amrex::Math::abs(fsten(ii_-2,jj_,kk_+1,ist_p0p))
                                                               +amrex::Math::abs(fsten(ii_-1,jj_,kk_+1,ist_p0p)) + eps);
-        Real wmm = amrex::Math::abs(fsten(ii_-2,jj_,kk_  ,ist_p0p)) * (1._rt + w1m + w2m);
-        Real wpm = amrex::Math::abs(fsten(ii_-1,jj_,kk_  ,ist_p0p)) * (1._rt + w1p + w2m);
-        Real wmp = amrex::Math::abs(fsten(ii_-2,jj_,kk_+1,ist_p0p)) * (1._rt + w1m + w2p);
-        Real wpp = amrex::Math::abs(fsten(ii_-1,jj_,kk_+1,ist_p0p)) * (1._rt + w1p + w2p);
+        Real wmm = amrex::Math::abs(fsten(ii_-2,jj_,kk_  ,ist_p0p)) * (Real(1.) + w1m + w2m);
+        Real wpm = amrex::Math::abs(fsten(ii_-1,jj_,kk_  ,ist_p0p)) * (Real(1.) + w1p + w2m);
+        Real wmp = amrex::Math::abs(fsten(ii_-2,jj_,kk_+1,ist_p0p)) * (Real(1.) + w1m + w2p);
+        Real wpp = amrex::Math::abs(fsten(ii_-1,jj_,kk_+1,ist_p0p)) * (Real(1.) + w1p + w2p);
         return wpm / (wmm+wpm+wmp+wpp+eps);
     };
 
     auto restrict_from_00p_to = [&fsten] (int ii_, int jj_, int kk_) -> Real {
         Real w1 = amrex::Math::abs(fsten(ii_,jj_,kk_  ,ist_00p));
         Real w2 = amrex::Math::abs(fsten(ii_,jj_,kk_+1,ist_00p));
-        if (w1 == 0._rt and w2 == 0._rt) {
-            return 0.5_rt;
+        if (w1 == Real(0.) and w2 == Real(0.)) {
+            return Real(0.5);
         } else {
             return w1 / (w1+w2);
         }
@@ -3505,15 +3505,15 @@ void mlndlap_stencil_rap (int i, int j, int k, Array4<Real> const& csten,
                                                               +amrex::Math::abs(fsten(ii_+1,jj_,kk_  ,ist_p0p)) + eps);
         Real w2p = amrex::Math::abs(fsten(ii_+1,jj_,kk_+1,ist_00p)) / (amrex::Math::abs(fsten(ii_  ,jj_,kk_+1,ist_p0p))
                                                               +amrex::Math::abs(fsten(ii_+1,jj_,kk_+1,ist_p0p)) + eps);
-        Real wmm = amrex::Math::abs(fsten(ii_  ,jj_,kk_  ,ist_p0p)) * (1._rt + w1m + w2m);
-        Real wpm = amrex::Math::abs(fsten(ii_+1,jj_,kk_  ,ist_p0p)) * (1._rt + w1p + w2m);
-        Real wmp = amrex::Math::abs(fsten(ii_  ,jj_,kk_+1,ist_p0p)) * (1._rt + w1m + w2p);
-        Real wpp = amrex::Math::abs(fsten(ii_+1,jj_,kk_+1,ist_p0p)) * (1._rt + w1p + w2p);
+        Real wmm = amrex::Math::abs(fsten(ii_  ,jj_,kk_  ,ist_p0p)) * (Real(1.) + w1m + w2m);
+        Real wpm = amrex::Math::abs(fsten(ii_+1,jj_,kk_  ,ist_p0p)) * (Real(1.) + w1p + w2m);
+        Real wmp = amrex::Math::abs(fsten(ii_  ,jj_,kk_+1,ist_p0p)) * (Real(1.) + w1m + w2p);
+        Real wpp = amrex::Math::abs(fsten(ii_+1,jj_,kk_+1,ist_p0p)) * (Real(1.) + w1p + w2p);
         return wmm / (wmm+wpm+wmp+wpp+eps);
     };
 
     auto restrict_from_mpp_to = [&fsten] (int ii_, int jj_, int kk_) -> Real {
-        Real r = 1._rt;
+        Real r = Real(1.);
         r += amrex::Math::abs(fsten(ii_-1,jj_+1,kk_+1,ist_p00)) /
            ( amrex::Math::abs(fsten(ii_-1,jj_  ,kk_  ,ist_ppp))
            + amrex::Math::abs(fsten(ii_-1,jj_+1,kk_  ,ist_ppp))
@@ -3551,15 +3551,15 @@ void mlndlap_stencil_rap (int i, int j, int k, Array4<Real> const& csten,
                                                               +amrex::Math::abs(fsten(ii_,jj_+1,kk_  ,ist_0pp)) + eps);
         Real w2p = amrex::Math::abs(fsten(ii_,jj_+1,kk_+1,ist_00p)) / (amrex::Math::abs(fsten(ii_,jj_  ,kk_+1,ist_0pp))
                                                               +amrex::Math::abs(fsten(ii_,jj_+1,kk_+1,ist_0pp)) + eps);
-        Real wmm = amrex::Math::abs(fsten(ii_,jj_  ,kk_  ,ist_0pp)) * (1._rt + w1m + w2m);
-        Real wpm = amrex::Math::abs(fsten(ii_,jj_+1,kk_  ,ist_0pp)) * (1._rt + w1p + w2m);
-        Real wmp = amrex::Math::abs(fsten(ii_,jj_  ,kk_+1,ist_0pp)) * (1._rt + w1m + w2p);
-        Real wpp = amrex::Math::abs(fsten(ii_,jj_+1,kk_+1,ist_0pp)) * (1._rt + w1p + w2p);
+        Real wmm = amrex::Math::abs(fsten(ii_,jj_  ,kk_  ,ist_0pp)) * (Real(1.) + w1m + w2m);
+        Real wpm = amrex::Math::abs(fsten(ii_,jj_+1,kk_  ,ist_0pp)) * (Real(1.) + w1p + w2m);
+        Real wmp = amrex::Math::abs(fsten(ii_,jj_  ,kk_+1,ist_0pp)) * (Real(1.) + w1m + w2p);
+        Real wpp = amrex::Math::abs(fsten(ii_,jj_+1,kk_+1,ist_0pp)) * (Real(1.) + w1p + w2p);
         return wmm / (wmm+wpm+wmp+wpp+eps);
     };
 
     auto restrict_from_ppp_to = [&fsten] (int ii_, int jj_, int kk_) -> Real {
-        Real r = 1._rt;
+        Real r = Real(1.);
         r += amrex::Math::abs(fsten(ii_  ,jj_+1,kk_+1,ist_p00)) /
            ( amrex::Math::abs(fsten(ii_  ,jj_  ,kk_  ,ist_ppp))
            + amrex::Math::abs(fsten(ii_  ,jj_+1,kk_  ,ist_ppp))
@@ -3608,7 +3608,7 @@ void mlndlap_stencil_rap (int i, int j, int k, Array4<Real> const& csten,
     p(-1,-1, 0) = interp_from_pp0_to(iii+1,jjj-1,kkk  );
     p( 0,-1, 0) = interp_from_0p0_to(iii+2,jjj-1,kkk  );
     p(-1, 0, 0) = interp_from_p00_to(iii+1,jjj  ,kkk  );
-    p( 0, 0, 0) = 1._rt;
+    p( 0, 0, 0) = Real(1.);
     p(-1,+1, 0) = interp_from_pm0_to(iii+1,jjj+1,kkk  );
     p( 0,+1, 0) = interp_from_0m0_to(iii+2,jjj+1,kkk  );
     p(-1,-1,+1) = interp_from_ppm_to(iii+1,jjj-1,kkk+1);
@@ -3782,7 +3782,7 @@ void mlndlap_stencil_rap (int i, int j, int k, Array4<Real> const& csten,
       +              Apm0(iii+1,jjj+1,kkk+1) * p( 0, 0,+1)
       +              A000(iii+1,jjj+1,kkk+1) * p(-1,+1,+1)
       +              Ap00(iii+1,jjj+1,kkk+1) * p( 0,+1,+1);
-    csten(i,j,k,ist_p00) = 0.125_rt *
+    csten(i,j,k,ist_p00) = Real(0.125) *
       ( restrict_from_0mm_to(iii,jjj,kkk) * ap( 0,-1,-1)
       + restrict_from_pmm_to(iii,jjj,kkk) * ap(+1,-1,-1)
       + restrict_from_00m_to(iii,jjj,kkk) * ap( 0, 0,-1)
@@ -3816,7 +3816,7 @@ void mlndlap_stencil_rap (int i, int j, int k, Array4<Real> const& csten,
     p( 0,-1, 0) = interp_from_0p0_to(iii  ,jjj+1,kkk  );
     p(+1,-1, 0) = interp_from_mp0_to(iii+1,jjj+1,kkk  );
     p(-1, 0, 0) = interp_from_p00_to(iii-1,jjj+2,kkk  );
-    p( 0, 0, 0) = 1._rt;
+    p( 0, 0, 0) = Real(1.);
     p(+1, 0, 0) = interp_from_m00_to(iii+1,jjj+2,kkk  );
     p(-1,-1,+1) = interp_from_ppm_to(iii-1,jjj+1,kkk+1);
     p( 0,-1,+1) = interp_from_0pm_to(iii  ,jjj+1,kkk+1);
@@ -3989,7 +3989,7 @@ void mlndlap_stencil_rap (int i, int j, int k, Array4<Real> const& csten,
       +              A000(iii+1,jjj+1,kkk+1) * p(+1,-1,+1)
       +              Amp0(iii+1,jjj+1,kkk+1) * p( 0, 0,+1)
       +              A0p0(iii+1,jjj+1,kkk+1) * p(+1, 0,+1);
-    csten(i,j,k,ist_0p0) = 0.125_rt *
+    csten(i,j,k,ist_0p0) = Real(0.125) *
       ( restrict_from_m0m_to(iii,jjj,kkk) * ap(-1, 0,-1)
       + restrict_from_00m_to(iii,jjj,kkk) * ap( 0, 0,-1)
       + restrict_from_p0m_to(iii,jjj,kkk) * ap(+1, 0,-1)
@@ -4026,7 +4026,7 @@ void mlndlap_stencil_rap (int i, int j, int k, Array4<Real> const& csten,
     p( 0,-1, 0) = interp_from_0p0_to(iii  ,jjj-1,kkk+2);
     p(+1,-1, 0) = interp_from_mp0_to(iii+1,jjj-1,kkk+2);
     p(-1, 0, 0) = interp_from_p00_to(iii-1,jjj  ,kkk+2);
-    p( 0, 0, 0) = 1._rt;
+    p( 0, 0, 0) = Real(1.);
     p(+1, 0, 0) = interp_from_m00_to(iii+1,jjj  ,kkk+2);
     p(-1,+1, 0) = interp_from_pm0_to(iii-1,jjj+1,kkk+2);
     p( 0,+1, 0) = interp_from_0m0_to(iii  ,jjj+1,kkk+2);
@@ -4196,7 +4196,7 @@ void mlndlap_stencil_rap (int i, int j, int k, Array4<Real> const& csten,
       +              A0mp(iii+1,jjj+1,kkk+1) * p(+1, 0, 0)
       +              Am0p(iii+1,jjj+1,kkk+1) * p( 0,+1, 0)
       +              A00p(iii+1,jjj+1,kkk+1) * p(+1,+1, 0);
-    csten(i,j,k,ist_00p) = 0.125_rt *
+    csten(i,j,k,ist_00p) = Real(0.125) *
       ( restrict_from_mm0_to(iii,jjj,kkk) * ap(-1,-1, 0)
       + restrict_from_0m0_to(iii,jjj,kkk) * ap( 0,-1, 0)
       + restrict_from_pm0_to(iii,jjj,kkk) * ap(+1,-1, 0)
@@ -4227,7 +4227,7 @@ void mlndlap_stencil_rap (int i, int j, int k, Array4<Real> const& csten,
     p(-1,-1, 0) = interp_from_pp0_to(iii+1,jjj+1,kkk  );
     p( 0,-1, 0) = interp_from_0p0_to(iii+2,jjj+1,kkk  );
     p(-1, 0, 0) = interp_from_p00_to(iii+1,jjj+2,kkk  );
-    p( 0, 0, 0) = 1._rt;
+    p( 0, 0, 0) = Real(1.);
     p(-1,-1,+1) = interp_from_ppm_to(iii+1,jjj+1,kkk+1);
     p( 0,-1,+1) = interp_from_0pm_to(iii+2,jjj+1,kkk+1);
     p(-1, 0,+1) = interp_from_p0m_to(iii+1,jjj+2,kkk+1);
@@ -4307,7 +4307,7 @@ void mlndlap_stencil_rap (int i, int j, int k, Array4<Real> const& csten,
       +              Ap00(iii+1,jjj+1,kkk+1) * p( 0,-1,+1)
       +              A0p0(iii+1,jjj+1,kkk+1) * p(-1, 0,+1)
       +              App0(iii+1,jjj+1,kkk+1) * p( 0, 0,+1);
-    cs1 = 0.125_rt *
+    cs1 = Real(0.125) *
       ( restrict_from_00m_to(iii,jjj,kkk) * ap( 0, 0,-1)
       + restrict_from_p0m_to(iii,jjj,kkk) * ap(+1, 0,-1)
       + restrict_from_0pm_to(iii,jjj,kkk) * ap( 0,+1,-1)
@@ -4331,7 +4331,7 @@ void mlndlap_stencil_rap (int i, int j, int k, Array4<Real> const& csten,
     p(+1, 0,-1) = interp_from_m0p_to(iii-1,jjj+2,kkk-1);
     p( 0,-1, 0) = interp_from_0p0_to(iii-2,jjj+1,kkk  );
     p(+1,-1, 0) = interp_from_mp0_to(iii-1,jjj+1,kkk  );
-    p( 0, 0, 0) = 1._rt;
+    p( 0, 0, 0) = Real(1.);
     p(+1, 0, 0) = interp_from_m00_to(iii-1,jjj+2,kkk  );
     p( 0,-1,+1) = interp_from_0pm_to(iii-2,jjj+1,kkk+1);
     p(+1,-1,+1) = interp_from_mpm_to(iii-1,jjj+1,kkk+1);
@@ -4412,7 +4412,7 @@ void mlndlap_stencil_rap (int i, int j, int k, Array4<Real> const& csten,
       +              Ampm(iii,jjj+1,kkk+1) * p(+1, 0, 0)
       +              Am00(iii,jjj+1,kkk+1) * p(+1,-1,+1)
       +              Amp0(iii,jjj+1,kkk+1) * p(+1, 0,+1);
-    cs2 = 0.125_rt *
+    cs2 = Real(0.125) *
       ( restrict_from_m0m_to(iii,jjj,kkk) * ap(-1, 0,-1)
       + restrict_from_00m_to(iii,jjj,kkk) * ap( 0, 0,-1)
       + restrict_from_mpm_to(iii,jjj,kkk) * ap(-1,+1,-1)
@@ -4426,7 +4426,7 @@ void mlndlap_stencil_rap (int i, int j, int k, Array4<Real> const& csten,
       + restrict_from_mpp_to(iii,jjj,kkk) * ap(-1,+1,+1)
       + restrict_from_0pp_to(iii,jjj,kkk) * ap( 0,+1,+1));
 
-    csten(i,j,k,ist_pp0) = 0.5_rt*(cs1 + cs2);
+    csten(i,j,k,ist_pp0) = Real(0.5)*(cs1 + cs2);
 
     // csten(i,j,k,ist_p0p)
     iii = ii;
@@ -4441,7 +4441,7 @@ void mlndlap_stencil_rap (int i, int j, int k, Array4<Real> const& csten,
     p(-1,-1, 0) = interp_from_pp0_to(iii+1,jjj-1,kkk+2);
     p( 0,-1, 0) = interp_from_0p0_to(iii+2,jjj-1,kkk+2);
     p(-1, 0, 0) = interp_from_p00_to(iii+1,jjj  ,kkk+2);
-    p( 0, 0, 0) = 1._rt;
+    p( 0, 0, 0) = Real(1.);
     p(-1,+1, 0) = interp_from_pm0_to(iii+1,jjj+1,kkk+2);
     p( 0,+1, 0) = interp_from_0m0_to(iii+2,jjj+1,kkk+2);
     ap(0,-1,0) =
@@ -4519,7 +4519,7 @@ void mlndlap_stencil_rap (int i, int j, int k, Array4<Real> const& csten,
       +              Apmp(iii+1,jjj+1,kkk+1) * p( 0, 0, 0)
       +              A00p(iii+1,jjj+1,kkk+1) * p(-1,+1, 0)
       +              Ap0p(iii+1,jjj+1,kkk+1) * p( 0,+1, 0);
-    cs1 = 0.125_rt *
+    cs1 = Real(0.125) *
       ( restrict_from_0m0_to(iii,jjj,kkk) * ap( 0,-1, 0)
       + restrict_from_pm0_to(iii,jjj,kkk) * ap(+1,-1, 0)
       + restrict_from_000_to(iii,jjj,kkk) * ap( 0, 0, 0)
@@ -4545,7 +4545,7 @@ void mlndlap_stencil_rap (int i, int j, int k, Array4<Real> const& csten,
     p(+1,+1,-1) = interp_from_mmp_to(iii-1,jjj+1,kkk+1);
     p( 0,-1, 0) = interp_from_0p0_to(iii-2,jjj-1,kkk+2);
     p(+1,-1, 0) = interp_from_mp0_to(iii-1,jjj-1,kkk+2);
-    p( 0, 0, 0) = 1._rt;
+    p( 0, 0, 0) = Real(1.);
     p(+1, 0, 0) = interp_from_m00_to(iii-1,jjj  ,kkk+2);
     p( 0,+1, 0) = interp_from_0m0_to(iii-2,jjj+1,kkk+2);
     p(+1,+1, 0) = interp_from_mm0_to(iii-1,jjj+1,kkk+2);
@@ -4625,7 +4625,7 @@ void mlndlap_stencil_rap (int i, int j, int k, Array4<Real> const& csten,
       +              Am00(iii,jjj+1,kkk+1) * p(+1,+1,-1)
       +              Ammp(iii,jjj+1,kkk+1) * p(+1, 0, 0)
       +              Am0p(iii,jjj+1,kkk+1) * p(+1,+1, 0);
-    cs2 = 0.125_rt *
+    cs2 = Real(0.125) *
       ( restrict_from_mm0_to(iii,jjj,kkk) * ap(-1,-1, 0)
       + restrict_from_0m0_to(iii,jjj,kkk) * ap( 0,-1, 0)
       + restrict_from_m00_to(iii,jjj,kkk) * ap(-1, 0, 0)
@@ -4639,7 +4639,7 @@ void mlndlap_stencil_rap (int i, int j, int k, Array4<Real> const& csten,
       + restrict_from_mpp_to(iii,jjj,kkk) * ap(-1,+1,+1)
       + restrict_from_0pp_to(iii,jjj,kkk) * ap( 0,+1,+1));
 
-    csten(i,j,k,ist_p0p) = 0.5_rt*(cs1+cs2);
+    csten(i,j,k,ist_p0p) = Real(0.5)*(cs1+cs2);
 
     // csten(i,j,k,ist_0pp)
     iii = ii;
@@ -4655,7 +4655,7 @@ void mlndlap_stencil_rap (int i, int j, int k, Array4<Real> const& csten,
     p( 0,-1, 0) = interp_from_0p0_to(iii  ,jjj+1,kkk+2);
     p(+1,-1, 0) = interp_from_mp0_to(iii+1,jjj+1,kkk+2);
     p(-1, 0, 0) = interp_from_p00_to(iii-1,jjj+2,kkk+2);
-    p( 0, 0, 0) = 1._rt;
+    p( 0, 0, 0) = Real(1.);
     p(+1, 0, 0) = interp_from_m00_to(iii+1,jjj+2,kkk+2);
     ap(-1,0,0) =
                      A0pp(iii-1,jjj,kkk) * p(-1,-1,-1)
@@ -4732,7 +4732,7 @@ void mlndlap_stencil_rap (int i, int j, int k, Array4<Real> const& csten,
       +              A00p(iii+1,jjj+1,kkk+1) * p(+1,-1, 0)
       +              Ampp(iii+1,jjj+1,kkk+1) * p( 0, 0, 0)
       +              A0pp(iii+1,jjj+1,kkk+1) * p(+1, 0, 0);
-    cs1 = 0.125_rt *
+    cs1 = Real(0.125) *
       ( restrict_from_m00_to(iii,jjj,kkk) * ap(-1, 0, 0)
       + restrict_from_000_to(iii,jjj,kkk) * ap( 0, 0, 0)
       + restrict_from_p00_to(iii,jjj,kkk) * ap(+1, 0, 0)
@@ -4757,7 +4757,7 @@ void mlndlap_stencil_rap (int i, int j, int k, Array4<Real> const& csten,
     p( 0,+1,-1) = interp_from_0mp_to(iii  ,jjj-1,kkk+1);
     p(+1,+1,-1) = interp_from_mmp_to(iii+1,jjj-1,kkk+1);
     p(-1, 0, 0) = interp_from_p00_to(iii-1,jjj-2,kkk+2);
-    p( 0, 0, 0) = 1._rt;
+    p( 0, 0, 0) = Real(1.);
     p(+1, 0, 0) = interp_from_m00_to(iii+1,jjj-2,kkk+2);
     p(-1,+1, 0) = interp_from_pm0_to(iii-1,jjj-1,kkk+2);
     p( 0,+1, 0) = interp_from_0m0_to(iii  ,jjj-1,kkk+2);
@@ -4837,7 +4837,7 @@ void mlndlap_stencil_rap (int i, int j, int k, Array4<Real> const& csten,
       +              A0m0(iii+1,jjj,kkk+1) * p(+1,+1,-1)
       +              Ammp(iii+1,jjj,kkk+1) * p( 0,+1, 0)
       +              A0mp(iii+1,jjj,kkk+1) * p(+1,+1, 0);
-    cs2 = 0.125_rt *
+    cs2 = Real(0.125) *
       ( restrict_from_mm0_to(iii,jjj,kkk) * ap(-1,-1, 0)
       + restrict_from_0m0_to(iii,jjj,kkk) * ap( 0,-1, 0)
       + restrict_from_pm0_to(iii,jjj,kkk) * ap(+1,-1, 0)
@@ -4851,7 +4851,7 @@ void mlndlap_stencil_rap (int i, int j, int k, Array4<Real> const& csten,
       + restrict_from_00p_to(iii,jjj,kkk) * ap( 0, 0,+1)
       + restrict_from_p0p_to(iii,jjj,kkk) * ap(+1, 0,+1));
 
-    csten(i,j,k,ist_0pp) = 0.5_rt*(cs1+cs2);
+    csten(i,j,k,ist_0pp) = Real(0.5)*(cs1+cs2);
 
     // csten(i,j,k,ist_ppp)
     iii = ii;
@@ -4864,7 +4864,7 @@ void mlndlap_stencil_rap (int i, int j, int k, Array4<Real> const& csten,
     p(-1,-1, 0) = interp_from_pp0_to(iii+1,jjj+1,kkk+2);
     p( 0,-1, 0) = interp_from_0p0_to(iii+2,jjj+1,kkk+2);
     p(-1, 0, 0) = interp_from_p00_to(iii+1,jjj+2,kkk+2);
-    p( 0, 0, 0) = 1._rt;
+    p( 0, 0, 0) = Real(1.);
     ap(0,0,0) =
                      Appp(iii,jjj,kkk) * p(-1,-1,-1);
     ap(1,0,0) =
@@ -4900,7 +4900,7 @@ void mlndlap_stencil_rap (int i, int j, int k, Array4<Real> const& csten,
       +              Ap0p(iii+1,jjj+1,kkk+1) * p( 0,-1, 0)
       +              A0pp(iii+1,jjj+1,kkk+1) * p(-1, 0, 0)
       +              Appp(iii+1,jjj+1,kkk+1) * p( 0, 0, 0);
-    cs1 = 0.125_rt *
+    cs1 = Real(0.125) *
       ( restrict_from_000_to(iii,jjj,kkk) * ap( 0, 0, 0)
       + restrict_from_p00_to(iii,jjj,kkk) * ap(+1, 0, 0)
       + restrict_from_0p0_to(iii,jjj,kkk) * ap( 0,+1, 0)
@@ -4920,7 +4920,7 @@ void mlndlap_stencil_rap (int i, int j, int k, Array4<Real> const& csten,
     p(+1, 0,-1) = interp_from_m0p_to(iii-1,jjj+2,kkk+1);
     p( 0,-1, 0) = interp_from_0p0_to(iii-2,jjj+1,kkk+2);
     p(+1,-1, 0) = interp_from_mp0_to(iii-1,jjj+1,kkk+2);
-    p( 0, 0, 0) = 1._rt;
+    p( 0, 0, 0) = Real(1.);
     p(+1, 0, 0) = interp_from_m00_to(iii-1,jjj+2,kkk+2);
     ap(-1,0,0) =
                      Ampp(iii-1,jjj,kkk) * p( 0,-1,-1)
@@ -4957,7 +4957,7 @@ void mlndlap_stencil_rap (int i, int j, int k, Array4<Real> const& csten,
       +              Amp0(iii,jjj+1,kkk+1) * p(+1, 0,-1)
       +              Am0p(iii,jjj+1,kkk+1) * p(+1,-1, 0)
       +              Ampp(iii,jjj+1,kkk+1) * p(+1, 0, 0);
-    cs2 = 0.125_rt *
+    cs2 = Real(0.125) *
       ( restrict_from_m00_to(iii,jjj,kkk) * ap(-1, 0, 0)
       + restrict_from_000_to(iii,jjj,kkk) * ap( 0, 0, 0)
       + restrict_from_mp0_to(iii,jjj,kkk) * ap(-1,+1, 0)
@@ -4976,7 +4976,7 @@ void mlndlap_stencil_rap (int i, int j, int k, Array4<Real> const& csten,
     p(-1,+1,-1) = interp_from_pmp_to(iii+1,jjj-1,kkk+1);
     p( 0,+1,-1) = interp_from_0mp_to(iii+2,jjj-1,kkk+1);
     p(-1, 0, 0) = interp_from_p00_to(iii+1,jjj-2,kkk+2);
-    p( 0, 0, 0) = 1._rt;
+    p( 0, 0, 0) = Real(1.);
     p(-1,+1, 0) = interp_from_pm0_to(iii+1,jjj-1,kkk+2);
     p( 0,+1, 0) = interp_from_0m0_to(iii+2,jjj-1,kkk+2);
     ap(0,-1,0) =
@@ -5014,7 +5014,7 @@ void mlndlap_stencil_rap (int i, int j, int k, Array4<Real> const& csten,
       +              Apm0(iii+1,jjj,kkk+1) * p( 0,+1,-1)
       +              A0mp(iii+1,jjj,kkk+1) * p(-1,+1, 0)
       +              Apmp(iii+1,jjj,kkk+1) * p( 0,+1, 0);
-    cs3 = 0.125_rt *
+    cs3 = Real(0.125) *
       ( restrict_from_0m0_to(iii,jjj,kkk) * ap( 0,-1, 0)
       + restrict_from_pm0_to(iii,jjj,kkk) * ap(+1,-1, 0)
       + restrict_from_000_to(iii,jjj,kkk) * ap( 0, 0, 0)
@@ -5032,7 +5032,7 @@ void mlndlap_stencil_rap (int i, int j, int k, Array4<Real> const& csten,
     p(+1, 0,-1) = interp_from_m0p_to(iii-1,jjj-2,kkk+1);
     p( 0,+1,-1) = interp_from_0mp_to(iii-2,jjj-1,kkk+1);
     p(+1,+1,-1) = interp_from_mmp_to(iii-1,jjj-1,kkk+1);
-    p( 0, 0, 0) = 1._rt;
+    p( 0, 0, 0) = Real(1.);
     p(+1, 0, 0) = interp_from_m00_to(iii-1,jjj-2,kkk+2);
     p( 0,+1, 0) = interp_from_0m0_to(iii-2,jjj-1,kkk+2);
     p(+1,+1, 0) = interp_from_mm0_to(iii-1,jjj-1,kkk+2);
@@ -5071,7 +5071,7 @@ void mlndlap_stencil_rap (int i, int j, int k, Array4<Real> const& csten,
     ap(0,0,1) =
                      Amm0(iii,jjj,kkk+1) * p(+1,+1,-1)
       +              Ammp(iii,jjj,kkk+1) * p(+1,+1, 0);
-    cs4 = 0.125_rt *
+    cs4 = Real(0.125) *
       ( restrict_from_mm0_to(iii,jjj,kkk) * ap(-1,-1, 0)
       + restrict_from_0m0_to(iii,jjj,kkk) * ap( 0,-1, 0)
       + restrict_from_m00_to(iii,jjj,kkk) * ap(-1, 0, 0)
@@ -5081,7 +5081,7 @@ void mlndlap_stencil_rap (int i, int j, int k, Array4<Real> const& csten,
       + restrict_from_m0p_to(iii,jjj,kkk) * ap(-1, 0,+1)
       + restrict_from_00p_to(iii,jjj,kkk) * ap( 0, 0,+1));
 
-    csten(i,j,k,ist_ppp) = 0.25_rt*(cs1+cs2+cs3+cs4);
+    csten(i,j,k,ist_ppp) = Real(0.25)*(cs1+cs2+cs3+cs4);
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
@@ -6080,167 +6080,167 @@ void mlndlap_set_connection (int i, int j, int k, Array4<Real> const& conn,
                              Array4<EBCellFlag const> const& flag) noexcept
 {
     if (flag(i,j,k).isCovered()) {
-        for (int n = 0; n < n_conn; ++n) conn(i,j,k,n) = 0._rt;
+        for (int n = 0; n < n_conn; ++n) conn(i,j,k,n) = Real(0.);
     } else if (flag(i,j,k).isRegular() or vol(i,j,k) >= almostone) {
-        for (int n = 0; n < n_conn; ++n) conn(i,j,k,n) = 1._rt;
+        for (int n = 0; n < n_conn; ++n) conn(i,j,k,n) = Real(1.);
     } else {
         // Scaled by 9
-        conn(i,j,k,i_c_xmym) = 0.5625_rt*vol(i,j,k)
-            + 2.25_rt*(-intg(i,j,k,i_S_x ) - intg(i,j,k,i_S_y)
+        conn(i,j,k,i_c_xmym) = Real(0.5625)*vol(i,j,k)
+            + Real(2.25)*(-intg(i,j,k,i_S_x ) - intg(i,j,k,i_S_y)
                        +intg(i,j,k,i_S_x2) + intg(i,j,k,i_S_y2))
-            + 9._rt*( intg(i,j,k,i_S_x_y ) - intg(i,j,k,i_S_x2_y)
+            + Real(9.)*( intg(i,j,k,i_S_x_y ) - intg(i,j,k,i_S_x2_y)
                      -intg(i,j,k,i_S_x_y2) + intg(i,j,k,i_S_x2_y2));
 
         // Scaled by 18
-        conn(i,j,k,i_c_xmyb) = 1.125_rt*vol(i,j,k)
-            + 4.5_rt*(-intg(i,j,k,i_S_x) + intg(i,j,k,i_S_x2) - intg(i,j,k,i_S_y2))
-            + 18._rt*( intg(i,j,k,i_S_x_y2) - intg(i,j,k,i_S_x2_y2));
+        conn(i,j,k,i_c_xmyb) = Real(1.125)*vol(i,j,k)
+            + Real(4.5)*(-intg(i,j,k,i_S_x) + intg(i,j,k,i_S_x2) - intg(i,j,k,i_S_y2))
+            + Real(18.)*( intg(i,j,k,i_S_x_y2) - intg(i,j,k,i_S_x2_y2));
 
         // Scaled by 9
-        conn(i,j,k,i_c_xmyp) =  0.5625_rt*vol(i,j,k)
-            + 2.25_rt*(-intg(i,j,k,i_S_x ) + intg(i,j,k,i_S_y)
+        conn(i,j,k,i_c_xmyp) =  Real(0.5625)*vol(i,j,k)
+            + Real(2.25)*(-intg(i,j,k,i_S_x ) + intg(i,j,k,i_S_y)
                        +intg(i,j,k,i_S_x2) + intg(i,j,k,i_S_y2))
-            + 9._rt*(-intg(i,j,k,i_S_x_y ) + intg(i,j,k,i_S_x2_y)
+            + Real(9.)*(-intg(i,j,k,i_S_x_y ) + intg(i,j,k,i_S_x2_y)
                      -intg(i,j,k,i_S_x_y2) + intg(i,j,k,i_S_x2_y2));
 
         // Scaled by 18
-        conn(i,j,k,i_c_xbym) = 1.125_rt*vol(i,j,k)
-            + 4.5_rt*(-intg(i,j,k,i_S_y) - intg(i,j,k,i_S_x2) + intg(i,j,k,i_S_y2))
-            + 18._rt*(intg(i,j,k,i_S_x2_y) - intg(i,j,k,i_S_x2_y2));
+        conn(i,j,k,i_c_xbym) = Real(1.125)*vol(i,j,k)
+            + Real(4.5)*(-intg(i,j,k,i_S_y) - intg(i,j,k,i_S_x2) + intg(i,j,k,i_S_y2))
+            + Real(18.)*(intg(i,j,k,i_S_x2_y) - intg(i,j,k,i_S_x2_y2));
 
         // Scaled by 36
-        conn(i,j,k,i_c_xbyb) = 2.25_rt*vol(i,j,k)
-            + 9._rt*(-intg(i,j,k,i_S_x2) - intg(i,j,k,i_S_y2))
-            + 36._rt*intg(i,j,k,i_S_x2_y2);
+        conn(i,j,k,i_c_xbyb) = Real(2.25)*vol(i,j,k)
+            + Real(9.)*(-intg(i,j,k,i_S_x2) - intg(i,j,k,i_S_y2))
+            + Real(36.)*intg(i,j,k,i_S_x2_y2);
 
         // Scaled by 18
-        conn(i,j,k,i_c_xbyp) =  1.125_rt*vol(i,j,k)
-            + 4.5_rt*( intg(i,j,k,i_S_y) - intg(i,j,k,i_S_x2) + intg(i,j,k,i_S_y2))
-            + 18._rt*(-intg(i,j,k,i_S_x2_y) - intg(i,j,k,i_S_x2_y2));
+        conn(i,j,k,i_c_xbyp) =  Real(1.125)*vol(i,j,k)
+            + Real(4.5)*( intg(i,j,k,i_S_y) - intg(i,j,k,i_S_x2) + intg(i,j,k,i_S_y2))
+            + Real(18.)*(-intg(i,j,k,i_S_x2_y) - intg(i,j,k,i_S_x2_y2));
 
         // Scaled by 9
-        conn(i,j,k,i_c_xpym) = 0.5625_rt*vol(i,j,k)
-            + 2.25_rt*( intg(i,j,k,i_S_x ) - intg(i,j,k,i_S_y)
+        conn(i,j,k,i_c_xpym) = Real(0.5625)*vol(i,j,k)
+            + Real(2.25)*( intg(i,j,k,i_S_x ) - intg(i,j,k,i_S_y)
                         +intg(i,j,k,i_S_x2) + intg(i,j,k,i_S_y2))
-            + 9._rt*(-intg(i,j,k,i_S_x_y ) - intg(i,j,k,i_S_x2_y)
+            + Real(9.)*(-intg(i,j,k,i_S_x_y ) - intg(i,j,k,i_S_x2_y)
                      +intg(i,j,k,i_S_x_y2) + intg(i,j,k,i_S_x2_y2));
 
         // Scaled by 18
-        conn(i,j,k,i_c_xpyb) = 1.125_rt*vol(i,j,k)
-            + 4.5_rt*( intg(i,j,k,i_S_x) + intg(i,j,k,i_S_x2) - intg(i,j,k,i_S_y2))
-            + 18._rt*(-intg(i,j,k,i_S_x_y2) - intg(i,j,k,i_S_x2_y2));
+        conn(i,j,k,i_c_xpyb) = Real(1.125)*vol(i,j,k)
+            + Real(4.5)*( intg(i,j,k,i_S_x) + intg(i,j,k,i_S_x2) - intg(i,j,k,i_S_y2))
+            + Real(18.)*(-intg(i,j,k,i_S_x_y2) - intg(i,j,k,i_S_x2_y2));
 
         // Scaled by 9
-        conn(i,j,k,i_c_xpyp) =  0.5625_rt*vol(i,j,k)
-            + 2.25_rt*( intg(i,j,k,i_S_x ) + intg(i,j,k,i_S_y)
+        conn(i,j,k,i_c_xpyp) =  Real(0.5625)*vol(i,j,k)
+            + Real(2.25)*( intg(i,j,k,i_S_x ) + intg(i,j,k,i_S_y)
                         +intg(i,j,k,i_S_x2) + intg(i,j,k,i_S_y2))
-            + 9._rt*( intg(i,j,k,i_S_x_y ) + intg(i,j,k,i_S_x2_y)
+            + Real(9.)*( intg(i,j,k,i_S_x_y ) + intg(i,j,k,i_S_x2_y)
                       +intg(i,j,k,i_S_x_y2) + intg(i,j,k,i_S_x2_y2));
 
         // Scaled by 9
-        conn(i,j,k,i_c_xmzm) = 0.5625_rt*vol(i,j,k)
-            + 2.25_rt*(-intg(i,j,k,i_S_x) - intg(i,j,k,i_S_z)
+        conn(i,j,k,i_c_xmzm) = Real(0.5625)*vol(i,j,k)
+            + Real(2.25)*(-intg(i,j,k,i_S_x) - intg(i,j,k,i_S_z)
                        +intg(i,j,k,i_S_x2) + intg(i,j,k,i_S_z2))
-            + 9._rt*(intg(i,j,k,i_S_x_z) - intg(i,j,k,i_S_x2_z)
+            + Real(9.)*(intg(i,j,k,i_S_x_z) - intg(i,j,k,i_S_x2_z)
                      -intg(i,j,k,i_S_x_z2) + intg(i,j,k,i_S_x2_z2));
 
         // Scaled by 18
-        conn(i,j,k,i_c_xmzb) = 1.125_rt*vol(i,j,k)
-            + 4.5_rt*(-intg(i,j,k,i_S_x) + intg(i,j,k,i_S_x2) - intg(i,j,k,i_S_z2))
-            + 18._rt*(intg(i,j,k,i_S_x_z2) - intg(i,j,k,i_S_x2_z2));
+        conn(i,j,k,i_c_xmzb) = Real(1.125)*vol(i,j,k)
+            + Real(4.5)*(-intg(i,j,k,i_S_x) + intg(i,j,k,i_S_x2) - intg(i,j,k,i_S_z2))
+            + Real(18.)*(intg(i,j,k,i_S_x_z2) - intg(i,j,k,i_S_x2_z2));
 
         // Scaled by 9
-        conn(i,j,k,i_c_xmzp) = 0.5625_rt*vol(i,j,k)
-            + 2.25_rt*(-intg(i,j,k,i_S_x  ) + intg(i,j,k,i_S_z)
+        conn(i,j,k,i_c_xmzp) = Real(0.5625)*vol(i,j,k)
+            + Real(2.25)*(-intg(i,j,k,i_S_x  ) + intg(i,j,k,i_S_z)
                        +intg(i,j,k,i_S_x2) + intg(i,j,k,i_S_z2))
-            + 9._rt*(-intg(i,j,k,i_S_x_z  ) + intg(i,j,k,i_S_x2_z)
+            + Real(9.)*(-intg(i,j,k,i_S_x_z  ) + intg(i,j,k,i_S_x2_z)
                      -intg(i,j,k,i_S_x_z2) + intg(i,j,k,i_S_x2_z2));
 
         // Scaled by 18
-        conn(i,j,k,i_c_xbzm) = 1.125_rt*vol(i,j,k)
-            + 4.5_rt*(-intg(i,j,k,i_S_z) - intg(i,j,k,i_S_x2) + intg(i,j,k,i_S_z2))
-            + 18._rt*(intg(i,j,k,i_S_x2_z) - intg(i,j,k,i_S_x2_z2));
+        conn(i,j,k,i_c_xbzm) = Real(1.125)*vol(i,j,k)
+            + Real(4.5)*(-intg(i,j,k,i_S_z) - intg(i,j,k,i_S_x2) + intg(i,j,k,i_S_z2))
+            + Real(18.)*(intg(i,j,k,i_S_x2_z) - intg(i,j,k,i_S_x2_z2));
 
         // Scaled by 18
-        conn(i,j,k,i_c_xbzb) = 2.25_rt*vol(i,j,k)
-            + 9._rt*(-intg(i,j,k,i_S_x2) - intg(i,j,k,i_S_z2))
-            + 36._rt*intg(i,j,k,i_S_x2_z2);
+        conn(i,j,k,i_c_xbzb) = Real(2.25)*vol(i,j,k)
+            + Real(9.)*(-intg(i,j,k,i_S_x2) - intg(i,j,k,i_S_z2))
+            + Real(36.)*intg(i,j,k,i_S_x2_z2);
 
         // Scaled by 18
-        conn(i,j,k,i_c_xbzp) = 1.125_rt*vol(i,j,k)
-            + 4.5_rt*( intg(i,j,k,i_S_z) - intg(i,j,k,i_S_x2) + intg(i,j,k,i_S_z2))
-            + 18._rt*(-intg(i,j,k,i_S_x2_z) - intg(i,j,k,i_S_x2_z2));
+        conn(i,j,k,i_c_xbzp) = Real(1.125)*vol(i,j,k)
+            + Real(4.5)*( intg(i,j,k,i_S_z) - intg(i,j,k,i_S_x2) + intg(i,j,k,i_S_z2))
+            + Real(18.)*(-intg(i,j,k,i_S_x2_z) - intg(i,j,k,i_S_x2_z2));
 
         // Scaled by 9
-        conn(i,j,k,i_c_xpzm) = 0.5625_rt*vol(i,j,k)
-            + 2.25_rt*( intg(i,j,k,i_S_x ) - intg(i,j,k,i_S_z)
+        conn(i,j,k,i_c_xpzm) = Real(0.5625)*vol(i,j,k)
+            + Real(2.25)*( intg(i,j,k,i_S_x ) - intg(i,j,k,i_S_z)
                         +intg(i,j,k,i_S_x2) + intg(i,j,k,i_S_z2))
-            + 9._rt*(-intg(i,j,k,i_S_x_z ) - intg(i,j,k,i_S_x2_z)
+            + Real(9.)*(-intg(i,j,k,i_S_x_z ) - intg(i,j,k,i_S_x2_z)
                      +intg(i,j,k,i_S_x_z2) + intg(i,j,k,i_S_x2_z2));
 
         // Scaled by 18
-        conn(i,j,k,i_c_xpzb) = 1.125_rt*vol(i,j,k)
-            + 4.5_rt*( intg(i,j,k,i_S_x   ) + intg(i,j,k,i_S_x2   ) - intg(i,j,k,i_S_z2))
-            + 18._rt*(-intg(i,j,k,i_S_x_z2) - intg(i,j,k,i_S_x2_z2));
+        conn(i,j,k,i_c_xpzb) = Real(1.125)*vol(i,j,k)
+            + Real(4.5)*( intg(i,j,k,i_S_x   ) + intg(i,j,k,i_S_x2   ) - intg(i,j,k,i_S_z2))
+            + Real(18.)*(-intg(i,j,k,i_S_x_z2) - intg(i,j,k,i_S_x2_z2));
 
         // Scaled by 9
-        conn(i,j,k,i_c_xpzp) = 0.5625_rt*vol(i,j,k)
-            + 2.25_rt*( intg(i,j,k,i_S_x ) + intg(i,j,k,i_S_z)
+        conn(i,j,k,i_c_xpzp) = Real(0.5625)*vol(i,j,k)
+            + Real(2.25)*( intg(i,j,k,i_S_x ) + intg(i,j,k,i_S_z)
                         +intg(i,j,k,i_S_x2) + intg(i,j,k,i_S_z2))
-            + 9._rt*( intg(i,j,k,i_S_x_z ) + intg(i,j,k,i_S_x2_z)
+            + Real(9.)*( intg(i,j,k,i_S_x_z ) + intg(i,j,k,i_S_x2_z)
                       +intg(i,j,k,i_S_x_z2) + intg(i,j,k,i_S_x2_z2));
 
         // Scaled by 9
-        conn(i,j,k,i_c_ymzm) = 0.5625_rt*vol(i,j,k)
-            + 2.25_rt*(-intg(i,j,k,i_S_y) - intg(i,j,k,i_S_z)
+        conn(i,j,k,i_c_ymzm) = Real(0.5625)*vol(i,j,k)
+            + Real(2.25)*(-intg(i,j,k,i_S_y) - intg(i,j,k,i_S_z)
                        +intg(i,j,k,i_S_y2) + intg(i,j,k,i_S_z2))
-            + 9._rt*(intg(i,j,k,i_S_y_z) - intg(i,j,k,i_S_y2_z)
+            + Real(9.)*(intg(i,j,k,i_S_y_z) - intg(i,j,k,i_S_y2_z)
                      -intg(i,j,k,i_S_y_z2) + intg(i,j,k,i_S_y2_z2));
 
         // Scaled by 18
-        conn(i,j,k,i_c_ymzb) = 1.125_rt*vol(i,j,k)
-            + 4.5_rt*(-intg(i,j,k,i_S_y) + intg(i,j,k,i_S_y2) - intg(i,j,k,i_S_z2))
-            + 18._rt*(intg(i,j,k,i_S_y_z2) - intg(i,j,k,i_S_y2_z2));
+        conn(i,j,k,i_c_ymzb) = Real(1.125)*vol(i,j,k)
+            + Real(4.5)*(-intg(i,j,k,i_S_y) + intg(i,j,k,i_S_y2) - intg(i,j,k,i_S_z2))
+            + Real(18.)*(intg(i,j,k,i_S_y_z2) - intg(i,j,k,i_S_y2_z2));
 
         // Scaled by 9
-        conn(i,j,k,i_c_ymzp) = 0.5625_rt*vol(i,j,k)
-            + 2.25_rt*(-intg(i,j,k,i_S_y ) + intg(i,j,k,i_S_z)
+        conn(i,j,k,i_c_ymzp) = Real(0.5625)*vol(i,j,k)
+            + Real(2.25)*(-intg(i,j,k,i_S_y ) + intg(i,j,k,i_S_z)
                        +intg(i,j,k,i_S_y2) + intg(i,j,k,i_S_z2))
-            + 9._rt*(-intg(i,j,k,i_S_y_z ) + intg(i,j,k,i_S_y2_z)
+            + Real(9.)*(-intg(i,j,k,i_S_y_z ) + intg(i,j,k,i_S_y2_z)
                      -intg(i,j,k,i_S_y_z2) + intg(i,j,k,i_S_y2_z2));
 
         // Scaled by 18
-        conn(i,j,k,i_c_ybzm) = 1.125_rt*vol(i,j,k)
-            + 4.5_rt*(-intg(i,j,k,i_S_z) - intg(i,j,k,i_S_y2) + intg(i,j,k,i_S_z2))
-            + 18._rt*(intg(i,j,k,i_S_y2_z) - intg(i,j,k,i_S_y2_z2));
+        conn(i,j,k,i_c_ybzm) = Real(1.125)*vol(i,j,k)
+            + Real(4.5)*(-intg(i,j,k,i_S_z) - intg(i,j,k,i_S_y2) + intg(i,j,k,i_S_z2))
+            + Real(18.)*(intg(i,j,k,i_S_y2_z) - intg(i,j,k,i_S_y2_z2));
 
         // Scaled by 36
-        conn(i,j,k,i_c_ybzb) = 2.25_rt*vol(i,j,k)
-            + 9._rt*(-intg(i,j,k,i_S_y2) - intg(i,j,k,i_S_z2))
-                     + 36._rt*intg(i,j,k,i_S_y2_z2);
+        conn(i,j,k,i_c_ybzb) = Real(2.25)*vol(i,j,k)
+            + Real(9.)*(-intg(i,j,k,i_S_y2) - intg(i,j,k,i_S_z2))
+                     + Real(36.)*intg(i,j,k,i_S_y2_z2);
 
         // Scaled by 18
-        conn(i,j,k,i_c_ybzp) = 1.125_rt*vol(i,j,k)
-            + 4.5_rt*( intg(i,j,k,i_S_z) - intg(i,j,k,i_S_y2) + intg(i,j,k,i_S_z2))
-            + 18._rt*(-intg(i,j,k,i_S_y2_z) - intg(i,j,k,i_S_y2_z2));
+        conn(i,j,k,i_c_ybzp) = Real(1.125)*vol(i,j,k)
+            + Real(4.5)*( intg(i,j,k,i_S_z) - intg(i,j,k,i_S_y2) + intg(i,j,k,i_S_z2))
+            + Real(18.)*(-intg(i,j,k,i_S_y2_z) - intg(i,j,k,i_S_y2_z2));
 
         // Scaled by 9
-        conn(i,j,k,i_c_ypzm) = 0.5625_rt*vol(i,j,k)
-            + 2.25_rt*( intg(i,j,k,i_S_y ) - intg(i,j,k,i_S_z)
+        conn(i,j,k,i_c_ypzm) = Real(0.5625)*vol(i,j,k)
+            + Real(2.25)*( intg(i,j,k,i_S_y ) - intg(i,j,k,i_S_z)
                         +intg(i,j,k,i_S_y2) + intg(i,j,k,i_S_z2))
-            + 9._rt*(-intg(i,j,k,i_S_y_z ) - intg(i,j,k,i_S_y2_z)
+            + Real(9.)*(-intg(i,j,k,i_S_y_z ) - intg(i,j,k,i_S_y2_z)
                      +intg(i,j,k,i_S_y_z2) + intg(i,j,k,i_S_y2_z2));
 
         // Scaled by 18
-        conn(i,j,k,i_c_ypzb) = 1.125_rt*vol(i,j,k)
-            + 4.5_rt*( intg(i,j,k,i_S_y   ) + intg(i,j,k,i_S_y2) - intg(i,j,k,i_S_z2))
-            + 18._rt*(-intg(i,j,k,i_S_y_z2) - intg(i,j,k,i_S_y2_z2));
+        conn(i,j,k,i_c_ypzb) = Real(1.125)*vol(i,j,k)
+            + Real(4.5)*( intg(i,j,k,i_S_y   ) + intg(i,j,k,i_S_y2) - intg(i,j,k,i_S_z2))
+            + Real(18.)*(-intg(i,j,k,i_S_y_z2) - intg(i,j,k,i_S_y2_z2));
 
         // Scaled by 9
-        conn(i,j,k,i_c_ypzp) = 0.5625_rt*vol(i,j,k)
-            + 2.25_rt*( intg(i,j,k,i_S_y ) + intg(i,j,k,i_S_z)
+        conn(i,j,k,i_c_ypzp) = Real(0.5625)*vol(i,j,k)
+            + Real(2.25)*( intg(i,j,k,i_S_y ) + intg(i,j,k,i_S_z)
                         +intg(i,j,k,i_S_y2) + intg(i,j,k,i_S_z2))
-            + 9._rt*( intg(i,j,k,i_S_y_z ) + intg(i,j,k,i_S_y2_z)
+            + Real(9.)*( intg(i,j,k,i_S_y_z ) + intg(i,j,k,i_S_y2_z)
                       +intg(i,j,k,i_S_y_z2) + intg(i,j,k,i_S_y2_z2));
     }
 }
@@ -6250,45 +6250,45 @@ void mlndlap_set_stencil_eb (int i, int j, int k, Array4<Real> const& sten,
                              Array4<Real const> const& sig, Array4<Real const> const& conn,
                              GpuArray<Real,AMREX_SPACEDIM> const& dxinv) noexcept
 {
-    Real facx = (1._rt/36._rt)*dxinv[0]*dxinv[0];
-    Real facy = (1._rt/36._rt)*dxinv[1]*dxinv[1];
-    Real facz = (1._rt/36._rt)*dxinv[2]*dxinv[2];
+    Real facx = Real(1./36.)*dxinv[0]*dxinv[0];
+    Real facy = Real(1./36.)*dxinv[1]*dxinv[1];
+    Real facz = Real(1./36.)*dxinv[2]*dxinv[2];
 
     // i+1,j,k
     sten(i,j,k,ist_p00) = (
-        sig(i,j  ,k  )*(4._rt*facx*conn(i,j  ,k  ,i_c_ymzm) - 2._rt*facy*conn(i,j  ,k  ,i_c_xbzm) - 2._rt*facz*conn(i,j  ,k  ,i_c_xbym) ) +
-        sig(i,j-1,k  )*(4._rt*facx*conn(i,j-1,k  ,i_c_ypzm) - 2._rt*facy*conn(i,j-1,k  ,i_c_xbzm) - 2._rt*facz*conn(i,j-1,k  ,i_c_xbyp) ) +
-        sig(i,j  ,k-1)*(4._rt*facx*conn(i,j  ,k-1,i_c_ymzp) - 2._rt*facy*conn(i,j  ,k-1,i_c_xbzp) - 2._rt*facz*conn(i,j  ,k-1,i_c_xbym) ) +
-        sig(i,j-1,k-1)*(4._rt*facx*conn(i,j-1,k-1,i_c_ypzp) - 2._rt*facy*conn(i,j-1,k-1,i_c_xbzp) - 2._rt*facz*conn(i,j-1,k-1,i_c_xbyp) ) );
+        sig(i,j  ,k  )*(Real(4.)*facx*conn(i,j  ,k  ,i_c_ymzm) - Real(2.)*facy*conn(i,j  ,k  ,i_c_xbzm) - Real(2.)*facz*conn(i,j  ,k  ,i_c_xbym) ) +
+        sig(i,j-1,k  )*(Real(4.)*facx*conn(i,j-1,k  ,i_c_ypzm) - Real(2.)*facy*conn(i,j-1,k  ,i_c_xbzm) - Real(2.)*facz*conn(i,j-1,k  ,i_c_xbyp) ) +
+        sig(i,j  ,k-1)*(Real(4.)*facx*conn(i,j  ,k-1,i_c_ymzp) - Real(2.)*facy*conn(i,j  ,k-1,i_c_xbzp) - Real(2.)*facz*conn(i,j  ,k-1,i_c_xbym) ) +
+        sig(i,j-1,k-1)*(Real(4.)*facx*conn(i,j-1,k-1,i_c_ypzp) - Real(2.)*facy*conn(i,j-1,k-1,i_c_xbzp) - Real(2.)*facz*conn(i,j-1,k-1,i_c_xbyp) ) );
 
     // i,j+1,k
     sten(i,j,k,ist_0p0) = (
-        sig(i  ,j,k  )*(-2._rt*facx*conn(i  ,j,k  ,i_c_ybzm) + 4._rt*facy*conn(i  ,j,k  ,i_c_xmzm) - 2._rt*facz*conn(i  ,j,k  ,i_c_xmyb) ) +
-        sig(i-1,j,k  )*(-2._rt*facx*conn(i-1,j,k  ,i_c_ybzm) + 4._rt*facy*conn(i-1,j,k  ,i_c_xpzm) - 2._rt*facz*conn(i-1,j,k  ,i_c_xpyb) ) +
-        sig(i  ,j,k-1)*(-2._rt*facx*conn(i  ,j,k-1,i_c_ybzp) + 4._rt*facy*conn(i  ,j,k-1,i_c_xmzp) - 2._rt*facz*conn(i  ,j,k-1,i_c_xmyb) ) +
-        sig(i-1,j,k-1)*(-2._rt*facx*conn(i-1,j,k-1,i_c_ybzp) + 4._rt*facy*conn(i-1,j,k-1,i_c_xpzp) - 2._rt*facz*conn(i-1,j,k-1,i_c_xpyb) ) );
+        sig(i  ,j,k  )*(Real(-2.)*facx*conn(i  ,j,k  ,i_c_ybzm) + Real(4.)*facy*conn(i  ,j,k  ,i_c_xmzm) - Real(2.)*facz*conn(i  ,j,k  ,i_c_xmyb) ) +
+        sig(i-1,j,k  )*(Real(-2.)*facx*conn(i-1,j,k  ,i_c_ybzm) + Real(4.)*facy*conn(i-1,j,k  ,i_c_xpzm) - Real(2.)*facz*conn(i-1,j,k  ,i_c_xpyb) ) +
+        sig(i  ,j,k-1)*(Real(-2.)*facx*conn(i  ,j,k-1,i_c_ybzp) + Real(4.)*facy*conn(i  ,j,k-1,i_c_xmzp) - Real(2.)*facz*conn(i  ,j,k-1,i_c_xmyb) ) +
+        sig(i-1,j,k-1)*(Real(-2.)*facx*conn(i-1,j,k-1,i_c_ybzp) + Real(4.)*facy*conn(i-1,j,k-1,i_c_xpzp) - Real(2.)*facz*conn(i-1,j,k-1,i_c_xpyb) ) );
 
     // i,j,k+1
     sten(i,j,k,ist_00p) = (
-        sig(i  ,j  ,k)*(-2._rt*facx*conn(i  ,j  ,k,i_c_ymzb) - 2._rt*facy*conn(i  ,j  ,k,i_c_xmzb) + 4._rt*facz*conn(i  ,j  ,k,i_c_xmym) ) +
-        sig(i-1,j  ,k)*(-2._rt*facx*conn(i-1,j  ,k,i_c_ymzb) - 2._rt*facy*conn(i-1,j  ,k,i_c_xpzb) + 4._rt*facz*conn(i-1,j  ,k,i_c_xpym) ) +
-        sig(i  ,j-1,k)*(-2._rt*facx*conn(i  ,j-1,k,i_c_ypzb) - 2._rt*facy*conn(i  ,j-1,k,i_c_xmzb) + 4._rt*facz*conn(i  ,j-1,k,i_c_xmyp) ) +
-        sig(i-1,j-1,k)*(-2._rt*facx*conn(i-1,j-1,k,i_c_ypzb) - 2._rt*facy*conn(i-1,j-1,k,i_c_xpzb) + 4._rt*facz*conn(i-1,j-1,k,i_c_xpyp) ) );
+        sig(i  ,j  ,k)*(Real(-2.)*facx*conn(i  ,j  ,k,i_c_ymzb) - Real(2.)*facy*conn(i  ,j  ,k,i_c_xmzb) + Real(4.)*facz*conn(i  ,j  ,k,i_c_xmym) ) +
+        sig(i-1,j  ,k)*(Real(-2.)*facx*conn(i-1,j  ,k,i_c_ymzb) - Real(2.)*facy*conn(i-1,j  ,k,i_c_xpzb) + Real(4.)*facz*conn(i-1,j  ,k,i_c_xpym) ) +
+        sig(i  ,j-1,k)*(Real(-2.)*facx*conn(i  ,j-1,k,i_c_ypzb) - Real(2.)*facy*conn(i  ,j-1,k,i_c_xmzb) + Real(4.)*facz*conn(i  ,j-1,k,i_c_xmyp) ) +
+        sig(i-1,j-1,k)*(Real(-2.)*facx*conn(i-1,j-1,k,i_c_ypzb) - Real(2.)*facy*conn(i-1,j-1,k,i_c_xpzb) + Real(4.)*facz*conn(i-1,j-1,k,i_c_xpyp) ) );
 
     // i+1,j+1,k
     sten(i,j,k,ist_pp0) = (
-        sig(i,j,k  )*(2._rt*facx*conn(i,j,k  ,i_c_ybzm) + 2._rt*facy*conn(i,j,k  ,i_c_xbzm) - facz*conn(i,j,k  ,i_c_xbyb) ) +
-        sig(i,j,k-1)*(2._rt*facx*conn(i,j,k-1,i_c_ybzp) + 2._rt*facy*conn(i,j,k-1,i_c_xbzp) - facz*conn(i,j,k-1,i_c_xbyb) ) );
+        sig(i,j,k  )*(Real(2.)*facx*conn(i,j,k  ,i_c_ybzm) + Real(2.)*facy*conn(i,j,k  ,i_c_xbzm) - facz*conn(i,j,k  ,i_c_xbyb) ) +
+        sig(i,j,k-1)*(Real(2.)*facx*conn(i,j,k-1,i_c_ybzp) + Real(2.)*facy*conn(i,j,k-1,i_c_xbzp) - facz*conn(i,j,k-1,i_c_xbyb) ) );
 
     // i+1,j,k+1
     sten(i,j,k,ist_p0p) = (
-        sig(i,j,k  )*(2._rt*facx*conn(i,j,k  ,i_c_ymzb) - facy*conn(i,j,k  ,i_c_xbzb) + 2._rt*facz*conn(i,j,k  ,i_c_xbym) ) +
-        sig(i,j-1,k)*(2._rt*facx*conn(i,j-1,k,i_c_ypzb) - facy*conn(i,j-1,k,i_c_xbzb) + 2._rt*facz*conn(i,j-1,k,i_c_xbyp) ) );
+        sig(i,j,k  )*(Real(2.)*facx*conn(i,j,k  ,i_c_ymzb) - facy*conn(i,j,k  ,i_c_xbzb) + Real(2.)*facz*conn(i,j,k  ,i_c_xbym) ) +
+        sig(i,j-1,k)*(Real(2.)*facx*conn(i,j-1,k,i_c_ypzb) - facy*conn(i,j-1,k,i_c_xbzb) + Real(2.)*facz*conn(i,j-1,k,i_c_xbyp) ) );
 
     // i,j+1,k+1
     sten(i,j,k,ist_0pp) = (
-        sig(i  ,j,k)*(-facx*conn(i  ,j,k,i_c_ybzb) + 2._rt*facy*conn(i  ,j,k,i_c_xmzb) + 2._rt*facz*conn(i  ,j,k,i_c_xmyb) ) +
-        sig(i-1,j,k)*(-facx*conn(i-1,j,k,i_c_ybzb) + 2._rt*facy*conn(i-1,j,k,i_c_xpzb) + 2._rt*facz*conn(i-1,j,k,i_c_xpyb) ) );
+        sig(i  ,j,k)*(-facx*conn(i  ,j,k,i_c_ybzb) + Real(2.)*facy*conn(i  ,j,k,i_c_xmzb) + Real(2.)*facz*conn(i  ,j,k,i_c_xmyb) ) +
+        sig(i-1,j,k)*(-facx*conn(i-1,j,k,i_c_ybzb) + Real(2.)*facy*conn(i-1,j,k,i_c_xpzb) + Real(2.)*facz*conn(i-1,j,k,i_c_xpyb) ) );
 
     // i+1,j+1,k+1
     sten(i,j,k,ist_ppp) = sig(i,j,k) * (facx*conn(i,j,k,i_c_ybzb) + facy*conn(i,j,k,i_c_xbzb) + facz*conn(i,j,k,i_c_xbyb) );
@@ -6302,9 +6302,9 @@ void mlndlap_divu_eb (int i, int j, int k, Array4<Real> const& rhs, Array4<Real 
                       GpuArray<LinOpBCType, AMREX_SPACEDIM> const& bclo,
                       GpuArray<LinOpBCType, AMREX_SPACEDIM> const& bchi) noexcept
 {
-    Real facx = 0.25_rt*dxinv[0];
-    Real facy = 0.25_rt*dxinv[1];
-    Real facz = 0.25_rt*dxinv[2];
+    Real facx = Real(0.25)*dxinv[0];
+    Real facy = Real(0.25)*dxinv[1];
+    Real facz = Real(0.25)*dxinv[2];
 
     const auto domlo = amrex::lbound(nodal_domain);
     const auto domhi = amrex::ubound(nodal_domain);
@@ -6335,105 +6335,105 @@ void mlndlap_divu_eb (int i, int j, int k, Array4<Real> const& rhs, Array4<Real 
 
         rhs(i,j,k) = facx*(
             vel(i-1,j-1,k  ,0)*(    -vfrac(i-1,j-1,k  )
-                               -2._rt*intg(i-1,j-1,k  ,i_S_y)
-                               +2._rt*intg(i-1,j-1,k  ,i_S_z)
-                               +4._rt*intg(i-1,j-1,k  ,i_S_y_z))*zero_jlo*zero_khi
+                               -Real(2.)*intg(i-1,j-1,k  ,i_S_y)
+                               +Real(2.)*intg(i-1,j-1,k  ,i_S_z)
+                               +Real(4.)*intg(i-1,j-1,k  ,i_S_y_z))*zero_jlo*zero_khi
            +vel(i  ,j-1,k  ,0)*(     vfrac(i  ,j-1,k  )
-                               +2._rt*intg(i  ,j-1,k  ,i_S_y)
-                               -2._rt*intg(i  ,j-1,k  ,i_S_z)
-                               -4._rt*intg(i  ,j-1,k  ,i_S_y_z))*zero_jlo*zero_khi
+                               +Real(2.)*intg(i  ,j-1,k  ,i_S_y)
+                               -Real(2.)*intg(i  ,j-1,k  ,i_S_z)
+                               -Real(4.)*intg(i  ,j-1,k  ,i_S_y_z))*zero_jlo*zero_khi
            +vel(i-1,j  ,k  ,0)*(    -vfrac(i-1,j  ,k  )
-                               +2._rt*intg(i-1,j  ,k  ,i_S_y)
-                               +2._rt*intg(i-1,j  ,k  ,i_S_z)
-                               -4._rt*intg(i-1,j  ,k  ,i_S_y_z))*zero_jhi*zero_khi
+                               +Real(2.)*intg(i-1,j  ,k  ,i_S_y)
+                               +Real(2.)*intg(i-1,j  ,k  ,i_S_z)
+                               -Real(4.)*intg(i-1,j  ,k  ,i_S_y_z))*zero_jhi*zero_khi
            +vel(i  ,j  ,k  ,0)*(     vfrac(i  ,j  ,k  )
-                               -2._rt*intg(i  ,j  ,k  ,i_S_y)
-                               -2._rt*intg(i  ,j  ,k  ,i_S_z)
-                               +4._rt*intg(i  ,j  ,k  ,i_S_y_z))*zero_jhi*zero_khi
+                               -Real(2.)*intg(i  ,j  ,k  ,i_S_y)
+                               -Real(2.)*intg(i  ,j  ,k  ,i_S_z)
+                               +Real(4.)*intg(i  ,j  ,k  ,i_S_y_z))*zero_jhi*zero_khi
            +vel(i-1,j-1,k-1,0)*(    -vfrac(i-1,j-1,k-1)
-                               -2._rt*intg(i-1,j-1,k-1,i_S_y)
-                               -2._rt*intg(i-1,j-1,k-1,i_S_z)
-                               -4._rt*intg(i-1,j-1,k-1,i_S_y_z))*zero_jlo*zero_klo
+                               -Real(2.)*intg(i-1,j-1,k-1,i_S_y)
+                               -Real(2.)*intg(i-1,j-1,k-1,i_S_z)
+                               -Real(4.)*intg(i-1,j-1,k-1,i_S_y_z))*zero_jlo*zero_klo
            +vel(i  ,j-1,k-1,0)*(     vfrac(i  ,j-1,k-1)
-                               +2._rt*intg(i  ,j-1,k-1,i_S_y)
-                               +2._rt*intg(i  ,j-1,k-1,i_S_z)
-                               +4._rt*intg(i  ,j-1,k-1,i_S_y_z))*zero_jlo*zero_klo
+                               +Real(2.)*intg(i  ,j-1,k-1,i_S_y)
+                               +Real(2.)*intg(i  ,j-1,k-1,i_S_z)
+                               +Real(4.)*intg(i  ,j-1,k-1,i_S_y_z))*zero_jlo*zero_klo
            +vel(i-1,j  ,k-1,0)*(    -vfrac(i-1,j  ,k-1)
-                               +2._rt*intg(i-1,j  ,k-1,i_S_y)
-                               -2._rt*intg(i-1,j  ,k-1,i_S_z)
-                               +4._rt*intg(i-1,j  ,k-1,i_S_y_z))*zero_jhi*zero_klo
+                               +Real(2.)*intg(i-1,j  ,k-1,i_S_y)
+                               -Real(2.)*intg(i-1,j  ,k-1,i_S_z)
+                               +Real(4.)*intg(i-1,j  ,k-1,i_S_y_z))*zero_jhi*zero_klo
            +vel(i  ,j  ,k-1,0)*(     vfrac(i  ,j  ,k-1)
-                               -2._rt*intg(i  ,j  ,k-1,i_S_y)
-                               +2._rt*intg(i  ,j  ,k-1,i_S_z)
-                               -4._rt*intg(i  ,j  ,k-1,i_S_y_z))*zero_jhi*zero_klo )
+                               -Real(2.)*intg(i  ,j  ,k-1,i_S_y)
+                               +Real(2.)*intg(i  ,j  ,k-1,i_S_z)
+                               -Real(4.)*intg(i  ,j  ,k-1,i_S_y_z))*zero_jhi*zero_klo )
             + facy*(
             vel(i-1,j-1,k  ,1)*(    -vfrac(i-1,j-1,k  )
-                               -2._rt*intg(i-1,j-1,k  ,i_S_x)
-                               +2._rt*intg(i-1,j-1,k  ,i_S_z)
-                               +4._rt*intg(i-1,j-1,k  ,i_S_x_z))*zero_ilo*zero_khi
+                               -Real(2.)*intg(i-1,j-1,k  ,i_S_x)
+                               +Real(2.)*intg(i-1,j-1,k  ,i_S_z)
+                               +Real(4.)*intg(i-1,j-1,k  ,i_S_x_z))*zero_ilo*zero_khi
            +vel(i  ,j-1,k  ,1)*(    -vfrac(i  ,j-1,k  )
-                               +2._rt*intg(i  ,j-1,k  ,i_S_x)
-                               +2._rt*intg(i  ,j-1,k  ,i_S_z)
-                               -4._rt*intg(i  ,j-1,k  ,i_S_x_z))*zero_ihi*zero_khi
+                               +Real(2.)*intg(i  ,j-1,k  ,i_S_x)
+                               +Real(2.)*intg(i  ,j-1,k  ,i_S_z)
+                               -Real(4.)*intg(i  ,j-1,k  ,i_S_x_z))*zero_ihi*zero_khi
            +vel(i-1,j  ,k  ,1)*(     vfrac(i-1,j  ,k  )
-                               +2._rt*intg(i-1,j  ,k  ,i_S_x)
-                               -2._rt*intg(i-1,j  ,k  ,i_S_z)
-                               -4._rt*intg(i-1,j  ,k  ,i_S_x_z))*zero_ilo*zero_khi
+                               +Real(2.)*intg(i-1,j  ,k  ,i_S_x)
+                               -Real(2.)*intg(i-1,j  ,k  ,i_S_z)
+                               -Real(4.)*intg(i-1,j  ,k  ,i_S_x_z))*zero_ilo*zero_khi
            +vel(i  ,j  ,k  ,1)*(     vfrac(i  ,j  ,k  )
-                               -2._rt*intg(i  ,j  ,k  ,i_S_x)
-                               -2._rt*intg(i  ,j  ,k  ,i_S_z)
-                               +4._rt*intg(i  ,j  ,k  ,i_S_x_z))*zero_ihi*zero_khi
+                               -Real(2.)*intg(i  ,j  ,k  ,i_S_x)
+                               -Real(2.)*intg(i  ,j  ,k  ,i_S_z)
+                               +Real(4.)*intg(i  ,j  ,k  ,i_S_x_z))*zero_ihi*zero_khi
            +vel(i-1,j-1,k-1,1)*(    -vfrac(i-1,j-1,k-1)
-                               -2._rt*intg(i-1,j-1,k-1,i_S_x)
-                               -2._rt*intg(i-1,j-1,k-1,i_S_z)
-                               -4._rt*intg(i-1,j-1,k-1,i_S_x_z))*zero_ilo*zero_klo
+                               -Real(2.)*intg(i-1,j-1,k-1,i_S_x)
+                               -Real(2.)*intg(i-1,j-1,k-1,i_S_z)
+                               -Real(4.)*intg(i-1,j-1,k-1,i_S_x_z))*zero_ilo*zero_klo
            +vel(i  ,j-1,k-1,1)*(    -vfrac(i  ,j-1,k-1)
-                               +2._rt*intg(i  ,j-1,k-1,i_S_x)
-                               -2._rt*intg(i  ,j-1,k-1,i_S_z)
-                               +4._rt*intg(i  ,j-1,k-1,i_S_x_z))*zero_ihi*zero_klo
+                               +Real(2.)*intg(i  ,j-1,k-1,i_S_x)
+                               -Real(2.)*intg(i  ,j-1,k-1,i_S_z)
+                               +Real(4.)*intg(i  ,j-1,k-1,i_S_x_z))*zero_ihi*zero_klo
            +vel(i-1,j  ,k-1,1)*(     vfrac(i-1,j  ,k-1)
-                               +2._rt*intg(i-1,j  ,k-1,i_S_x)
-                               +2._rt*intg(i-1,j  ,k-1,i_S_z)
-                               +4._rt*intg(i-1,j  ,k-1,i_S_x_z))*zero_ilo*zero_klo
+                               +Real(2.)*intg(i-1,j  ,k-1,i_S_x)
+                               +Real(2.)*intg(i-1,j  ,k-1,i_S_z)
+                               +Real(4.)*intg(i-1,j  ,k-1,i_S_x_z))*zero_ilo*zero_klo
            +vel(i  ,j  ,k-1,1)*(     vfrac(i  ,j  ,k-1)
-                               -2._rt*intg(i  ,j  ,k-1,i_S_x)
-                               +2._rt*intg(i  ,j  ,k-1,i_S_z)
-                               -4._rt*intg(i  ,j  ,k-1,i_S_x_z))*zero_ihi*zero_klo )
+                               -Real(2.)*intg(i  ,j  ,k-1,i_S_x)
+                               +Real(2.)*intg(i  ,j  ,k-1,i_S_z)
+                               -Real(4.)*intg(i  ,j  ,k-1,i_S_x_z))*zero_ihi*zero_klo )
             + facz*(
             vel(i-1,j-1,k  ,2)*(     vfrac(i-1,j-1,k  )
-                               +2._rt*intg(i-1,j-1,k  ,i_S_x)
-                               +2._rt*intg(i-1,j-1,k  ,i_S_y)
-                               +4._rt*intg(i-1,j-1,k  ,i_S_x_y))*zero_ilo*zero_jlo
+                               +Real(2.)*intg(i-1,j-1,k  ,i_S_x)
+                               +Real(2.)*intg(i-1,j-1,k  ,i_S_y)
+                               +Real(4.)*intg(i-1,j-1,k  ,i_S_x_y))*zero_ilo*zero_jlo
            +vel(i  ,j-1,k  ,2)*(     vfrac(i  ,j-1,k  )
-                               -2._rt*intg(i  ,j-1,k  ,i_S_x)
-                               +2._rt*intg(i  ,j-1,k  ,i_S_y)
-                               -4._rt*intg(i  ,j-1,k  ,i_S_x_y))*zero_ihi*zero_jlo
+                               -Real(2.)*intg(i  ,j-1,k  ,i_S_x)
+                               +Real(2.)*intg(i  ,j-1,k  ,i_S_y)
+                               -Real(4.)*intg(i  ,j-1,k  ,i_S_x_y))*zero_ihi*zero_jlo
            +vel(i-1,j  ,k  ,2)*(     vfrac(i-1,j  ,k  )
-                               +2._rt*intg(i-1,j  ,k  ,i_S_x)
-                               -2._rt*intg(i-1,j  ,k  ,i_S_y)
-                               -4._rt*intg(i-1,j  ,k  ,i_S_x_y))*zero_ilo*zero_jhi
+                               +Real(2.)*intg(i-1,j  ,k  ,i_S_x)
+                               -Real(2.)*intg(i-1,j  ,k  ,i_S_y)
+                               -Real(4.)*intg(i-1,j  ,k  ,i_S_x_y))*zero_ilo*zero_jhi
            +vel(i  ,j  ,k  ,2)*(     vfrac(i  ,j  ,k  )
-                               -2._rt*intg(i  ,j  ,k  ,i_S_x)
-                               -2._rt*intg(i  ,j  ,k  ,i_S_y)
-                               +4._rt*intg(i  ,j  ,k  ,i_S_x_y))*zero_ihi*zero_jhi
+                               -Real(2.)*intg(i  ,j  ,k  ,i_S_x)
+                               -Real(2.)*intg(i  ,j  ,k  ,i_S_y)
+                               +Real(4.)*intg(i  ,j  ,k  ,i_S_x_y))*zero_ihi*zero_jhi
            +vel(i-1,j-1,k-1,2)*(    -vfrac(i-1,j-1,k-1)
-                               -2._rt*intg(i-1,j-1,k-1,i_S_x)
-                               -2._rt*intg(i-1,j-1,k-1,i_S_y)
-                               -4._rt*intg(i-1,j-1,k-1,i_S_x_y))*zero_ilo*zero_jlo
+                               -Real(2.)*intg(i-1,j-1,k-1,i_S_x)
+                               -Real(2.)*intg(i-1,j-1,k-1,i_S_y)
+                               -Real(4.)*intg(i-1,j-1,k-1,i_S_x_y))*zero_ilo*zero_jlo
            +vel(i  ,j-1,k-1,2)*(    -vfrac(i  ,j-1,k-1)
-                               +2._rt*intg(i  ,j-1,k-1,i_S_x)
-                               -2._rt*intg(i  ,j-1,k-1,i_S_y)
-                               +4._rt*intg(i  ,j-1,k-1,i_S_x_y))*zero_ihi*zero_jlo
+                               +Real(2.)*intg(i  ,j-1,k-1,i_S_x)
+                               -Real(2.)*intg(i  ,j-1,k-1,i_S_y)
+                               +Real(4.)*intg(i  ,j-1,k-1,i_S_x_y))*zero_ihi*zero_jlo
            +vel(i-1,j  ,k-1,2)*(    -vfrac(i-1,j  ,k-1)
-                               -2._rt*intg(i-1,j  ,k-1,i_S_x)
-                               +2._rt*intg(i-1,j  ,k-1,i_S_y)
-                               +4._rt*intg(i-1,j  ,k-1,i_S_x_y))*zero_ilo*zero_jhi
+                               -Real(2.)*intg(i-1,j  ,k-1,i_S_x)
+                               +Real(2.)*intg(i-1,j  ,k-1,i_S_y)
+                               +Real(4.)*intg(i-1,j  ,k-1,i_S_x_y))*zero_ilo*zero_jhi
            +vel(i  ,j  ,k-1,2)*(    -vfrac(i  ,j  ,k-1)
-                               +2._rt*intg(i  ,j  ,k-1,i_S_x)
-                               +2._rt*intg(i  ,j  ,k-1,i_S_y)
-                               -4._rt*intg(i  ,j  ,k-1,i_S_x_y))*zero_ihi*zero_jhi );
+                               +Real(2.)*intg(i  ,j  ,k-1,i_S_x)
+                               +Real(2.)*intg(i  ,j  ,k-1,i_S_y)
+                               -Real(4.)*intg(i  ,j  ,k-1,i_S_x_y))*zero_ihi*zero_jhi );
     } else {
-        rhs(i,j,k) = 0._rt;
+        rhs(i,j,k) = Real(0.);
     }
 }
 
@@ -6442,15 +6442,15 @@ void mlndlap_mknewu_eb (int i, int j, int k, Array4<Real> const& u, Array4<Real 
                         Array4<Real const> const& sig, Array4<Real const> const& vfrac,
                         Array4<Real const> const& intg, GpuArray<Real,AMREX_SPACEDIM> const& dxinv) noexcept
 {
-    if (vfrac(i,j,k) == 0._rt) {
-        u(i,j,k,0) = u(i,j,k,1) = u(i,j,k,2) = 0._rt;
+    if (vfrac(i,j,k) == Real(0.)) {
+        u(i,j,k,0) = u(i,j,k,1) = u(i,j,k,2) = Real(0.);
     } else {
-        Real dpdx = 0.25_rt*(-p(i,j,k  )+p(i+1,j,k  )-p(i,j+1,k  )+p(i+1,j+1,k  )
-                             -p(i,j,k+1)+p(i+1,j,k+1)-p(i,j+1,k+1)+p(i+1,j+1,k+1));
-        Real dpdy = 0.25_rt*(-p(i,j,k  )-p(i+1,j,k  )+p(i,j+1,k  )+p(i+1,j+1,k  )
-                             -p(i,j,k+1)-p(i+1,j,k+1)+p(i,j+1,k+1)+p(i+1,j+1,k+1));
-        Real dpdz = 0.25_rt*(-p(i,j,k  )-p(i+1,j,k  )-p(i,j+1,k  )-p(i+1,j+1,k  )
-                             +p(i,j,k+1)+p(i+1,j,k+1)+p(i,j+1,k+1)+p(i+1,j+1,k+1));
+        Real dpdx = Real(0.25)*(-p(i,j,k  )+p(i+1,j,k  )-p(i,j+1,k  )+p(i+1,j+1,k  )
+                                -p(i,j,k+1)+p(i+1,j,k+1)-p(i,j+1,k+1)+p(i+1,j+1,k+1));
+        Real dpdy = Real(0.25)*(-p(i,j,k  )-p(i+1,j,k  )+p(i,j+1,k  )+p(i+1,j+1,k  )
+                                -p(i,j,k+1)-p(i+1,j,k+1)+p(i,j+1,k+1)+p(i+1,j+1,k+1));
+        Real dpdz = Real(0.25)*(-p(i,j,k  )-p(i+1,j,k  )-p(i,j+1,k  )-p(i+1,j+1,k  )
+                                +p(i,j,k+1)+p(i+1,j,k+1)+p(i,j+1,k+1)+p(i+1,j+1,k+1));
 
         Real dpp_xy = (p(i+1,j+1,k+1) - p(i,j+1,k+1) - p(i+1,j,k+1) + p(i,j,k+1)
                       +p(i+1,j+1,k  ) - p(i,j+1,k  ) - p(i+1,j,k  ) + p(i,j,k  ) ) / vfrac(i,j,k);
@@ -6464,15 +6464,15 @@ void mlndlap_mknewu_eb (int i, int j, int k, Array4<Real> const& u, Array4<Real 
         Real dpp_xyz = (p(i+1,j+1,k+1) - p(i,j+1,k+1) - p(i+1,j,k+1) + p(i,j,k+1)
                        -p(i+1,j+1,k  ) + p(i,j+1,k  ) + p(i+1,j,k  ) - p(i,j,k  ) ) / vfrac(i,j,k);
 
-        u(i,j,k,0) -= sig(i,j,k)*dxinv[0]*(dpdx + .5_rt*intg(i,j,k,i_S_y  )*dpp_xy +
-                                                  .5_rt*intg(i,j,k,i_S_z  )*dpp_xz +
-                                                        intg(i,j,k,i_S_y_z)*dpp_xyz );
-        u(i,j,k,1) -= sig(i,j,k)*dxinv[1]*(dpdy + .5_rt*intg(i,j,k,i_S_x  )*dpp_xy +
-                                                  .5_rt*intg(i,j,k,i_S_z  )*dpp_yz +
-                                                        intg(i,j,k,i_S_x_z)*dpp_xyz );
-        u(i,j,k,2) -= sig(i,j,k)*dxinv[2]*(dpdz + .5_rt*intg(i,j,k,i_S_x  )*dpp_xz +
-                                                  .5_rt*intg(i,j,k,i_S_y  )*dpp_yz +
-                                                        intg(i,j,k,i_S_x_y)*dpp_xyz );
+        u(i,j,k,0) -= sig(i,j,k)*dxinv[0]*(dpdx + Real(0.5)*intg(i,j,k,i_S_y  )*dpp_xy +
+                                                  Real(0.5)*intg(i,j,k,i_S_z  )*dpp_xz +
+                                                            intg(i,j,k,i_S_y_z)*dpp_xyz );
+        u(i,j,k,1) -= sig(i,j,k)*dxinv[1]*(dpdy + Real(0.5)*intg(i,j,k,i_S_x  )*dpp_xy +
+                                                  Real(0.5)*intg(i,j,k,i_S_z  )*dpp_yz +
+                                                            intg(i,j,k,i_S_x_z)*dpp_xyz );
+        u(i,j,k,2) -= sig(i,j,k)*dxinv[2]*(dpdz + Real(0.5)*intg(i,j,k,i_S_x  )*dpp_xz +
+                                                  Real(0.5)*intg(i,j,k,i_S_y  )*dpp_yz +
+                                                            intg(i,j,k,i_S_x_y)*dpp_xyz );
     }
 }
 
@@ -6484,86 +6484,86 @@ Real mlndlap_rhcc_eb (int i, int j, int k, Array4<Real const> const& rhcc,
     if (!msk(i,j,k)) {
         return
                           rhcc(i  ,j  ,k  ) *
-            ( 0.125_rt * vfrac(i  ,j  ,k  )
-            + 0.25_rt * (-intg(i  ,j  ,k  ,i_S_x)
+         ( Real(0.125) * vfrac(i  ,j  ,k  )
+         + Real(0.25) * (-intg(i  ,j  ,k  ,i_S_x)
                          -intg(i  ,j  ,k  ,i_S_y)
                          -intg(i  ,j  ,k  ,i_S_z))
-            + 0.5_rt * (  intg(i  ,j  ,k  ,i_S_x_y)
+         + Real(0.5) * (  intg(i  ,j  ,k  ,i_S_x_y)
                          +intg(i  ,j  ,k  ,i_S_x_z)
                          +intg(i  ,j  ,k  ,i_S_y_z))
             +          ( -intg(i  ,j  ,k  ,i_S_xyz)))
             //
             +             rhcc(i-1,j  ,k  ) *
-            ( 0.125_rt * vfrac(i-1,j  ,k  )
-            + 0.25_rt * ( intg(i-1,j  ,k  ,i_S_x)
+         ( Real(0.125) * vfrac(i-1,j  ,k  )
+         + Real(0.25) * ( intg(i-1,j  ,k  ,i_S_x)
                          -intg(i-1,j  ,k  ,i_S_y)
                          -intg(i-1,j  ,k  ,i_S_z))
-            + 0.5_rt * ( -intg(i-1,j  ,k  ,i_S_x_y)
+         + Real(0.5) * ( -intg(i-1,j  ,k  ,i_S_x_y)
                          -intg(i-1,j  ,k  ,i_S_x_z)
                          +intg(i-1,j  ,k  ,i_S_y_z))
             +          (  intg(i-1,j  ,k  ,i_S_xyz)))
             //
             +             rhcc(i  ,j-1,k  ) *
-            ( 0.125_rt * vfrac(i  ,j-1,k  )
-            + 0.25_rt * (-intg(i  ,j-1,k  ,i_S_x)
+         ( Real(0.125) * vfrac(i  ,j-1,k  )
+         + Real(0.25) * (-intg(i  ,j-1,k  ,i_S_x)
                          +intg(i  ,j-1,k  ,i_S_y)
                          -intg(i  ,j-1,k  ,i_S_z))
-            + 0.5_rt * ( -intg(i  ,j-1,k  ,i_S_x_y)
+         + Real(0.5) * ( -intg(i  ,j-1,k  ,i_S_x_y)
                          +intg(i  ,j-1,k  ,i_S_x_z)
                          -intg(i  ,j-1,k  ,i_S_y_z))
             +          (  intg(i  ,j-1,k  ,i_S_xyz)))
             //
             +             rhcc(i-1,j-1,k  ) *
-            ( 0.125_rt * vfrac(i-1,j-1,k  )
-            + 0.25_rt * ( intg(i-1,j-1,k  ,i_S_x)
+         ( Real(0.125) * vfrac(i-1,j-1,k  )
+         + Real(0.25) * ( intg(i-1,j-1,k  ,i_S_x)
                          +intg(i-1,j-1,k  ,i_S_y)
                          -intg(i-1,j-1,k  ,i_S_z))
-            + 0.5_rt * (  intg(i-1,j-1,k  ,i_S_x_y)
+         + Real(0.5) * (  intg(i-1,j-1,k  ,i_S_x_y)
                          -intg(i-1,j-1,k  ,i_S_x_z)
                          -intg(i-1,j-1,k  ,i_S_y_z))
             +          ( -intg(i-1,j-1,k  ,i_S_xyz)))
             //
             +             rhcc(i  ,j  ,k-1) *
-            ( 0.125_rt * vfrac(i  ,j  ,k-1)
-            + 0.25_rt * (-intg(i  ,j  ,k-1,i_S_x)
+         ( Real(0.125) * vfrac(i  ,j  ,k-1)
+         + Real(0.25) * (-intg(i  ,j  ,k-1,i_S_x)
                          -intg(i  ,j  ,k-1,i_S_y)
                          +intg(i  ,j  ,k-1,i_S_z))
-            + 0.5_rt * (  intg(i  ,j  ,k-1,i_S_x_y)
+         + Real(0.5) * (  intg(i  ,j  ,k-1,i_S_x_y)
                          -intg(i  ,j  ,k-1,i_S_x_z)
                          -intg(i  ,j  ,k-1,i_S_y_z))
             +          (  intg(i  ,j  ,k-1,i_S_xyz)))
             //
             +             rhcc(i-1,j  ,k-1) *
-            ( 0.125_rt * vfrac(i-1,j  ,k-1)
-            + 0.25_rt * ( intg(i-1,j  ,k-1,i_S_x)
+         ( Real(0.125) * vfrac(i-1,j  ,k-1)
+         + Real(0.25) * ( intg(i-1,j  ,k-1,i_S_x)
                          -intg(i-1,j  ,k-1,i_S_y)
                          +intg(i-1,j  ,k-1,i_S_z))
-            + 0.5_rt * ( -intg(i-1,j  ,k-1,i_S_x_y)
+         + Real(0.5) * ( -intg(i-1,j  ,k-1,i_S_x_y)
                          +intg(i-1,j  ,k-1,i_S_x_z)
                          -intg(i-1,j  ,k-1,i_S_y_z))
             +          ( -intg(i-1,j  ,k-1,i_S_xyz)))
             //
             +             rhcc(i  ,j-1,k-1) *
-            ( 0.125_rt * vfrac(i  ,j-1,k-1)
-            + 0.25_rt * (-intg(i  ,j-1,k-1,i_S_x)
+         ( Real(0.125) * vfrac(i  ,j-1,k-1)
+         + Real(0.25) * (-intg(i  ,j-1,k-1,i_S_x)
                          +intg(i  ,j-1,k-1,i_S_y)
                          +intg(i  ,j-1,k-1,i_S_z))
-            + 0.5_rt * ( -intg(i  ,j-1,k-1,i_S_x_y)
+         + Real(0.5) * ( -intg(i  ,j-1,k-1,i_S_x_y)
                          -intg(i  ,j-1,k-1,i_S_x_z)
                          +intg(i  ,j-1,k-1,i_S_y_z))
             +          ( -intg(i  ,j-1,k-1,i_S_xyz)))
             //
             +             rhcc(i-1,j-1,k-1) *
-            ( 0.125_rt * vfrac(i-1,j-1,k-1)
-            + 0.25_rt * ( intg(i-1,j-1,k-1,i_S_x)
+         ( Real(0.125) * vfrac(i-1,j-1,k-1)
+         + Real(0.25) * ( intg(i-1,j-1,k-1,i_S_x)
                          +intg(i-1,j-1,k-1,i_S_y)
                          +intg(i-1,j-1,k-1,i_S_z))
-            + 0.5_rt * (  intg(i-1,j-1,k-1,i_S_x_y)
+         + Real(0.5) * (  intg(i-1,j-1,k-1,i_S_x_y)
                          +intg(i-1,j-1,k-1,i_S_x_z)
                          +intg(i-1,j-1,k-1,i_S_y_z))
              +         (  intg(i-1,j-1,k-1,i_S_xyz)));
     } else {
-        return 0._rt;
+        return Real(0.);
     }
 }
 

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLap_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLap_K.H
@@ -16,11 +16,11 @@ namespace {
     constexpr int crse_fine_node = 1;
     constexpr int fine_node = 2;
 #if (BL_USE_FLOAT)
-    constexpr double eps = 1.e-30;
+    constexpr float eps = 1.e-30;
 #else
     constexpr double eps = 1.e-100;
 #endif
-    constexpr Real almostone = 1._rt - 100._rt*std::numeric_limits<Real>::epsilon();
+    constexpr Real almostone = Real(1.) - Real(100.)*std::numeric_limits<Real>::epsilon();
 
 }
 

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeTensorLap_2D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeTensorLap_2D_K.H
@@ -8,13 +8,13 @@ namespace {
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     Real ts_interp_line_x (Array4<Real const> const& crse, int ic, int jc) noexcept
     {
-        return (crse(ic,jc,0)+crse(ic+1,jc,0))*0.5_rt;
+        return (crse(ic,jc,0)+crse(ic+1,jc,0))*Real(0.5);
     }
 
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     Real ts_interp_line_y (Array4<Real const> const& crse, int ic, int jc) noexcept
     {
-        return (crse(ic,jc,0)+crse(ic,jc+1,0))*0.5_rt;
+        return (crse(ic,jc,0)+crse(ic,jc+1,0))*Real(0.5);
     }
 
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
@@ -23,7 +23,7 @@ namespace {
         return (ts_interp_line_y(crse,ic  ,jc  ) +
                 ts_interp_line_y(crse,ic+1,jc  ) +
                 ts_interp_line_x(crse,ic  ,jc  ) +
-                ts_interp_line_x(crse,ic  ,jc+1)) * 0.25_rt;
+                ts_interp_line_x(crse,ic  ,jc+1)) * Real(0.25);
     }
 }
 

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeTensorLap_3D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeTensorLap_3D_K.H
@@ -9,21 +9,21 @@ namespace {
     Real ts_interp_line_x (Array4<Real const> const& crse,
                            int ic, int jc, int kc) noexcept
     {
-        return (crse(ic,jc,kc)+crse(ic+1,jc,kc))*0.5_rt;
+        return (crse(ic,jc,kc)+crse(ic+1,jc,kc))*Real(0.5);
     }
 
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     Real ts_interp_line_y (Array4<Real const> const& crse,
                            int ic, int jc, int kc) noexcept
     {
-        return (crse(ic,jc,kc)+crse(ic,jc+1,kc))*0.5_rt;
+        return (crse(ic,jc,kc)+crse(ic,jc+1,kc))*Real(0.5);
     }
 
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     Real ts_interp_line_z (Array4<Real const> const& crse,
                            int ic, int jc, int kc) noexcept
     {
-        return (crse(ic,jc,kc)+crse(ic,jc,kc+1))*0.5_rt;
+        return (crse(ic,jc,kc)+crse(ic,jc,kc+1))*Real(0.5);
     }
 
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
@@ -33,7 +33,7 @@ namespace {
         return (ts_interp_line_y(crse,ic  ,jc  ,kc) +
                 ts_interp_line_y(crse,ic+1,jc  ,kc) +
                 ts_interp_line_x(crse,ic  ,jc  ,kc) +
-                ts_interp_line_x(crse,ic  ,jc+1,kc)) * 0.25_rt;
+                ts_interp_line_x(crse,ic  ,jc+1,kc)) * Real(0.25);
     }
 
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
@@ -43,7 +43,7 @@ namespace {
         return (ts_interp_line_z(crse,ic  ,jc,kc  ) +
                 ts_interp_line_z(crse,ic+1,jc,kc  ) +
                 ts_interp_line_x(crse,ic  ,jc,kc  ) +
-                ts_interp_line_x(crse,ic  ,jc,kc+1)) * 0.25_rt;
+                ts_interp_line_x(crse,ic  ,jc,kc+1)) * Real(0.25);
     }
 
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
@@ -53,7 +53,7 @@ namespace {
         return (ts_interp_line_z(crse,ic,jc  ,kc  ) +
                 ts_interp_line_z(crse,ic,jc+1,kc  ) +
                 ts_interp_line_y(crse,ic,jc  ,kc  ) +
-                ts_interp_line_y(crse,ic,jc  ,kc+1)) * 0.25_rt;
+                ts_interp_line_y(crse,ic,jc  ,kc+1)) * Real(0.25);
     }
 }
 
@@ -75,7 +75,7 @@ void mlndtslap_interpadd (int i, int j, int k, Array4<Real> const& fine,
                             ts_interp_face_xz(crse,ic  ,jc  ,kc  ) +
                             ts_interp_face_xz(crse,ic  ,jc+1,kc  ) +
                             ts_interp_face_xy(crse,ic  ,jc  ,kc  ) +
-                            ts_interp_face_xy(crse,ic  ,jc  ,kc+1)) * (1._rt/6._rt);
+                            ts_interp_face_xy(crse,ic  ,jc  ,kc+1)) * Real(1./6.);
         } else if (j_is_odd and k_is_odd) {
             // Node on a Y-Z face
             fine(i,j,k) += ts_interp_face_yz(crse,ic,jc,kc);

--- a/Tutorials/Basic/HeatEquation_EX1_C/Source/main.cpp
+++ b/Tutorials/Basic/HeatEquation_EX1_C/Source/main.cpp
@@ -62,8 +62,8 @@ void main_main ()
         ba.maxSize(max_grid_size);
 
        // This defines the physical box, [-1,1] in each direction.
-        RealBox real_box({AMREX_D_DECL(-1.0_rt,-1.0_rt,-1.0_rt)},
-                         {AMREX_D_DECL( 1.0_rt, 1.0_rt, 1.0_rt)});
+        RealBox real_box({AMREX_D_DECL(-Real(1.0),-Real(1.0),-Real(1.0))},
+                         {AMREX_D_DECL( Real(1.0), Real(1.0), Real(1.0))});
 
         // periodic in all direction
         Array<int,AMREX_SPACEDIM> is_periodic{AMREX_D_DECL(1,1,1)};
@@ -90,14 +90,14 @@ void main_main ()
     init_phi(phi_new, geom);
     // ========================================
 
-    Real cfl = 0.9_rt;
+    Real cfl = 0.9;
     Real coeff = AMREX_D_TERM(   1./(dx[0]*dx[0]),
                                + 1./(dx[1]*dx[1]),
                                + 1./(dx[2]*dx[2]) );
-    Real dt = cfl/(2.0_rt*coeff);
+    Real dt = cfl/(2.0*coeff);
 
     // time = starting time in the simulation
-    Real time = 0.0_rt;
+    Real time = 0.0;
 
     // Write a plotfile of the initial data if plot_int > 0 (plot_int was defined in the inputs file)
     if (plot_int > 0)

--- a/Tutorials/Basic/HeatEquation_EX1_C/Source/mykernel.H
+++ b/Tutorials/Basic/HeatEquation_EX1_C/Source/mykernel.H
@@ -9,20 +9,20 @@ void init_phi (int i, int j, int k,
                amrex::GpuArray<amrex::Real,AMREX_SPACEDIM> const& dx,
                amrex::GpuArray<amrex::Real,AMREX_SPACEDIM> const& prob_lo)
 {
-    using namespace amrex::literals;
+    using amrex::Real;;
 
-    amrex::Real x = prob_lo[0] + (i+0.5_rt) * dx[0];
-    amrex::Real y = prob_lo[1] + (j+0.5_rt) * dx[1];
+    Real x = prob_lo[0] + (i+Real(0.5)) * dx[0];
+    Real y = prob_lo[1] + (j+Real(0.5)) * dx[1];
 #if (AMREX_SPACEDIM > 2)
-    amrex::Real z = prob_lo[2] + (k+0.5_rt) * dx[2];
+    Real z = prob_lo[2] + (k+Real(0.5)) * dx[2];
 #else
-    amrex::Real z = 0._rt;
+    Real z = Real(0.);
 #endif
-    amrex::Real r2 = ((x-0.25_rt)*(x-0.25_rt)+(y-0.25_rt)*(y-0.25_rt)+(z-0.25_rt)*(z-0.25_rt))/0.01_rt;
+    Real r2 = ((x-Real(0.25))*(x-Real(0.25))+(y-Real(0.25))*(y-Real(0.25))+(z-Real(0.25))*(z-Real(0.25)))/Real(0.01);
 #ifdef AMREX_USE_HIP
-    phi(i,j,k) = 1._rt + ::exp(-r2); // xxxxx HIP todo
+    phi(i,j,k) = Real(1.) + ::exp(-r2); // xxxxx HIP todo
 #else
-    phi(i,j,k) = 1._rt + std::exp(-r2);
+    phi(i,j,k) = Real(1.) + std::exp(-r2);
 #endif
 }
 

--- a/Tutorials/Basic/HeatEquation_EX1_CF/Source/main.cpp
+++ b/Tutorials/Basic/HeatEquation_EX1_CF/Source/main.cpp
@@ -99,11 +99,11 @@ void main_main ()
     // compute the time step
     const Real* dx = geom.CellSize();
 
-    Real cfl = 0.9_rt;
+    Real cfl = 0.9;
     Real coeff = AMREX_D_TERM(   1./(dx[0]*dx[0]),
                                + 1./(dx[1]*dx[1]),
                                + 1./(dx[2]*dx[2]) );
-    Real dt = cfl/(2.0_rt*coeff);
+    Real dt = cfl/(2.0*coeff);
 
     // time = starting time in the simulation
     Real time = 0.0;

--- a/Tutorials/Basic/HeatEquation_EX2_C/Source/main.cpp
+++ b/Tutorials/Basic/HeatEquation_EX2_C/Source/main.cpp
@@ -144,11 +144,11 @@ void main_main ()
 	}
     }
 
-    Real cfl = 0.9_rt;
+    Real cfl = 0.9;
     Real coeff = AMREX_D_TERM(   1./(dx[0]*dx[0]),
                                + 1./(dx[1]*dx[1]),
                                + 1./(dx[2]*dx[2]) );
-    Real dt = cfl/(2.0_rt*coeff);
+    Real dt = cfl/(2.0*coeff);
 
     // time = starting time in the simulation
     Real time = 0.0;

--- a/Tutorials/Basic/HeatEquation_EX2_CF/Source/main.cpp
+++ b/Tutorials/Basic/HeatEquation_EX2_CF/Source/main.cpp
@@ -150,11 +150,11 @@ void main_main ()
 
     // compute the time step
     const Real* dx = geom.CellSize();
-    Real cfl = 0.9_rt;
+    Real cfl = 0.9;
     Real coeff = AMREX_D_TERM(   1./(dx[0]*dx[0]),
                                + 1./(dx[1]*dx[1]),
                                + 1./(dx[2]*dx[2]) );
-    Real dt = cfl/(2.0_rt*coeff);
+    Real dt = cfl/(2.0*coeff);
 
     // Write a plotfile of the initial data if plot_int > 0 (plot_int was defined in the inputs file)
     if (plot_int > 0)

--- a/Tutorials/Basic/HeatEquation_EX3_C/Source/main.cpp
+++ b/Tutorials/Basic/HeatEquation_EX3_C/Source/main.cpp
@@ -151,12 +151,12 @@ void main_main ()
     // Compute the time step
     // Implicit time step is imFactor*(explicit time step)
     const Real* dx = geom.CellSize();
-    Real cfl = 0.9_rt;
+    Real cfl = 0.9;
     Real coeff = AMREX_D_TERM(   1./(dx[0]*dx[0]),
                                + 1./(dx[1]*dx[1]),
                                + 1./(dx[2]*dx[2]) );
     const int imFactor = pow(10, AMREX_SPACEDIM-1);
-    Real dt = imFactor*cfl/(2.0_rt*coeff);
+    Real dt = imFactor*cfl/(2.0*coeff);
 
     // Write a plotfile of the initial data if plot_int > 0 (plot_int was defined in the inputs file)
     if (plot_int > 0)

--- a/Tutorials/GPU/CNS/Exec/RT/cns_prob.H
+++ b/Tutorials/GPU/CNS/Exec/RT/cns_prob.H
@@ -13,42 +13,42 @@ void
 cns_initdata (int i, int j, int k, amrex::Array4<amrex::Real> const& state,
               amrex::GeometryData const& geomdata, Parm const& parm, ProbParm const& prob_parm)
 {
-    using namespace amrex::literals;
+    using amrex::Real;
 
-    const amrex::Real* prob_lo = geomdata.ProbLo();
-    const amrex::Real* prob_hi = geomdata.ProbHi();
-    const amrex::Real* dx      = geomdata.CellSize();
+    const Real* prob_lo = geomdata.ProbLo();
+    const Real* prob_hi = geomdata.ProbHi();
+    const Real* dx      = geomdata.CellSize();
 
-    constexpr amrex::Real pi = 3.14159265358979323846264338327950288_rt;
-    const amrex::Real splitx = 0.5_rt*(prob_lo[0]+prob_hi[0]);
-    const amrex::Real splity = 0.5_rt*(prob_lo[1]+prob_hi[1]);
-    const amrex::Real splitz = 0.5_rt*(prob_lo[2]+prob_hi[2]);
-    const amrex::Real L_x = prob_hi[0] - prob_lo[0];
-    const amrex::Real presmid = prob_parm.p0_base - prob_parm.rho_1*splitz;
+    constexpr Real pi = Real(3.14159265358979323846264338327950288);
+    const Real splitx = Real(0.5)*(prob_lo[0]+prob_hi[0]);
+    const Real splity = Real(0.5)*(prob_lo[1]+prob_hi[1]);
+    const Real splitz = Real(0.5)*(prob_lo[2]+prob_hi[2]);
+    const Real L_x = prob_hi[0] - prob_lo[0];
+    const Real presmid = prob_parm.p0_base - prob_parm.rho_1*splitz;
 
-    const amrex::Real z = prob_lo[2] + (k+0.5_rt)*dx[2];
-    const amrex::Real y = prob_lo[1] + (j+0.5_rt)*dx[1];
-    const amrex::Real x = prob_lo[0] + (i+0.5_rt)*dx[0];
+    const Real z = prob_lo[2] + (k+Real(0.5))*dx[2];
+    const Real y = prob_lo[1] + (j+Real(0.5))*dx[1];
+    const Real x = prob_lo[0] + (i+Real(0.5))*dx[0];
 
-    amrex::Real Pt;
+    Real Pt;
     if (z < splitz) {
         Pt = prob_parm.p0_base - prob_parm.rho_1*z;
     } else {
         Pt = presmid - prob_parm.rho_2*(z-splitz);
     }
-    const amrex::Real rhoet = Pt/(parm.eos_gamma-1.0_rt);
+    const Real rhoet = Pt/(parm.eos_gamma-Real(1.0));
 
-    const Real r2d = amrex::min(std::hypot((x-splitx),(y-splity)), 0.5_rt*L_x);
-    const Real pertheight = 0.5_rt - 0.01_rt*std::cos(2.0_rt*pi*r2d/L_x);
-    const Real rhot = prob_parm.rho_1 + ((prob_parm.rho_2-prob_parm.rho_1)/2.0_rt)*(1.0_rt+std::tanh((z-pertheight)/0.005_rt));
+    const Real r2d = amrex::min(std::hypot((x-splitx),(y-splity)), Real(0.5)*L_x);
+    const Real pertheight = Real(0.5) - Real(0.01)*std::cos(Real(2.0)*pi*r2d/L_x);
+    const Real rhot = prob_parm.rho_1 + ((prob_parm.rho_2-prob_parm.rho_1)/Real(2.0))*(Real(1.0)+std::tanh((z-pertheight)/Real(0.005)));
 
     state(i,j,k,URHO ) = rhot;
-    state(i,j,k,UMX  ) = 0.0_rt;
-    state(i,j,k,UMY  ) = 0.0_rt;
-    state(i,j,k,UMZ  ) = 0.0_rt;
+    state(i,j,k,UMX  ) = Real(0.0);
+    state(i,j,k,UMY  ) = Real(0.0);
+    state(i,j,k,UMZ  ) = Real(0.0);
     state(i,j,k,UEINT) = rhoet;
     state(i,j,k,UEDEN) = rhoet;
-    state(i,j,k,UTEMP) = 0.0_rt;
+    state(i,j,k,UTEMP) = Real(0.0);
 }
 
 #endif

--- a/Tutorials/GPU/CNS/Exec/RT/cns_prob_parm.H
+++ b/Tutorials/GPU/CNS/Exec/RT/cns_prob_parm.H
@@ -9,9 +9,9 @@ using namespace amrex::literals;
 struct ProbParm
     : amrex::Gpu::Managed
 {
-    amrex::Real rho_1 = 0.5_rt;
-    amrex::Real rho_2 = 2.0_rt;
-    amrex::Real p0_base = 5.0_rt;
+    amrex::Real rho_1 = 0.5;
+    amrex::Real rho_2 = 2.0;
+    amrex::Real p0_base = 5.0;
 };
 
 #endif

--- a/Tutorials/GPU/CNS/Exec/Sod/cns_prob.H
+++ b/Tutorials/GPU/CNS/Exec/Sod/cns_prob.H
@@ -13,14 +13,14 @@ void
 cns_initdata (int i, int j, int k, amrex::Array4<amrex::Real> const& state,
               amrex::GeometryData const& geomdata, Parm const& parm, ProbParm const& prob_parm)
 {
-    using namespace amrex::literals;
+    using amrex::Real;
 
-    const amrex::Real* prob_lo = geomdata.ProbLo();
-    const amrex::Real* dx      = geomdata.CellSize();
+    const Real* prob_lo = geomdata.ProbLo();
+    const Real* dx      = geomdata.CellSize();
 
-    amrex::Real x = prob_lo[0] + (i+0.5_rt)*dx[0];
-    amrex::Real Pt, rhot, uxt;
-    if (x < 0.5_rt) {
+    Real x = prob_lo[0] + (i+Real(0.5))*dx[0];
+    Real Pt, rhot, uxt;
+    if (x < Real(0.5)) {
         Pt = prob_parm.p_l;
         rhot = prob_parm.rho_l;
         uxt = prob_parm.u_l;
@@ -31,12 +31,12 @@ cns_initdata (int i, int j, int k, amrex::Array4<amrex::Real> const& state,
     }
     state(i,j,k,URHO ) = rhot;
     state(i,j,k,UMX  ) = rhot*uxt;
-    state(i,j,k,UMY  ) = 0.0_rt;
-    state(i,j,k,UMZ  ) = 0.0_rt;
-    amrex::Real et = Pt/(parm.eos_gamma-1.0_rt);
+    state(i,j,k,UMY  ) = Real(0.0);
+    state(i,j,k,UMZ  ) = Real(0.0);
+    Real et = Pt/(parm.eos_gamma-Real(1.0));
     state(i,j,k,UEINT) = et;
-    state(i,j,k,UEDEN) = et + 0.5_rt*rhot*uxt*uxt;
-    state(i,j,k,UTEMP) = 0.0_rt;
+    state(i,j,k,UEDEN) = et + Real(0.5)*rhot*uxt*uxt;
+    state(i,j,k,UTEMP) = Real(0.0);
 }
 
 #endif

--- a/Tutorials/GPU/CNS/Exec/Sod/cns_prob_parm.H
+++ b/Tutorials/GPU/CNS/Exec/Sod/cns_prob_parm.H
@@ -9,12 +9,12 @@ using namespace amrex::literals;
 struct ProbParm
     : amrex::Gpu::Managed
 {
-    amrex::Real p_l = 1.0_rt;
-    amrex::Real p_r = 0.1_rt;
-    amrex::Real rho_l = 1.0_rt;
-    amrex::Real rho_r = 0.125_rt;
-    amrex::Real u_l = 0.0_rt;
-    amrex::Real u_r = 0.0_rt;
+    amrex::Real p_l = 1.0;
+    amrex::Real p_r = 0.1;
+    amrex::Real rho_l = 1.0;
+    amrex::Real rho_r = 0.125;
+    amrex::Real u_l = 0.0;
+    amrex::Real u_r = 0.0;
 };
 
 #endif

--- a/Tutorials/GPU/CNS/Source/CNS.cpp
+++ b/Tutorials/GPU/CNS/Source/CNS.cpp
@@ -17,12 +17,12 @@ BCRec     CNS::phys_bc;
 
 int       CNS::verbose = 0;
 IntVect   CNS::hydro_tile_size {AMREX_D_DECL(1024,16,16)};
-Real      CNS::cfl       = 0.3_rt;
+Real      CNS::cfl       = 0.3;
 int       CNS::do_reflux = 1;
 int       CNS::refine_max_dengrad_lev   = -1;
-Real      CNS::refine_dengrad           = 1.0e10_rt;
+Real      CNS::refine_dengrad           = 1.0e10;
 
-Real      CNS::gravity = 0.0_rt;
+Real      CNS::gravity = 0.0;
 
 CNS::CNS ()
 {}
@@ -127,9 +127,9 @@ CNS::computeInitialDt (int                    finest_level,
     //
     // Limit dt's by the value of stop_time.
     //
-    const Real eps = 0.001_rt*dt_0;
+    const Real eps = 0.001*dt_0;
     Real cur_time  = state[State_Type].curTime();
-    if (stop_time >= 0.0_rt) {
+    if (stop_time >= 0.0) {
         if ((cur_time + dt_0) > (stop_time - eps))
             dt_0 = stop_time - cur_time;
     }
@@ -201,9 +201,9 @@ CNS::computeNewDt (int                    finest_level,
     //
     // Limit dt's by the value of stop_time.
     //
-    const Real eps = 0.001_rt*dt_0;
+    const Real eps = 0.001*dt_0;
     Real cur_time  = state[State_Type].curTime();
-    if (stop_time >= 0.0_rt) {
+    if (stop_time >= 0.0) {
         if ((cur_time + dt_0) > (stop_time - eps)) {
             dt_0 = stop_time - cur_time;
         }
@@ -230,7 +230,7 @@ CNS::post_timestep (int iteration)
     if (do_reflux && level < parent->finestLevel()) {
         MultiFab& S = get_new_data(State_Type);
         CNS& fine_level = getLevel(level+1);
-        fine_level.flux_reg->Reflux(S, 1.0_rt, 0, 0, NUM_STATE, geom);
+        fine_level.flux_reg->Reflux(S, Real(1.0), 0, 0, NUM_STATE, geom);
     }
 
     if (level < parent->finestLevel()) {
@@ -383,7 +383,7 @@ CNS::buildMetrics ()
 {
     // make sure dx == dy == dz
     const Real* dx = geom.CellSize();
-    if (std::abs(dx[0]-dx[1]) > 1.e-12_rt*dx[0] || std::abs(dx[0]-dx[2]) > 1.e-12_rt*dx[0]) {
+    if (std::abs(dx[0]-dx[1]) > Real(1.e-12)*dx[0] || std::abs(dx[0]-dx[2]) > Real(1.e-12)*dx[0]) {
         amrex::Abort("CNS: must have dx == dy == dz\n");
     }
 }

--- a/Tutorials/GPU/CNS/Source/CNS_K.H
+++ b/Tutorials/GPU/CNS/Source/CNS_K.H
@@ -16,33 +16,33 @@ cns_estdt (amrex::Box const& bx, amrex::Array4<Real const> const& state,
            amrex::GpuArray<amrex::Real,AMREX_SPACEDIM> const& dx,
            Parm const& parm) noexcept
 {
-    using namespace amrex::literals;
+    using amrex::Real;
 
     const auto lo = amrex::lbound(bx);
     const auto hi = amrex::ubound(bx);
 #if !defined(__CUDACC__) || (__CUDACC_VER_MAJOR__ != 9) || (__CUDACC_VER_MINOR__ != 2)
-    amrex::Real dt = std::numeric_limits<amrex::Real>::max();
+    Real dt = std::numeric_limits<Real>::max();
 #else
-    amrex::Real dt = 1.e37_rt;
+    Real dt = Real(1.e37);
 #endif
 
     for         (int k = lo.z; k <= hi.z; ++k) {
         for     (int j = lo.y; j <= hi.y; ++j) {
             for (int i = lo.x; i <= hi.x; ++i) {
-                amrex::Real rho = state(i,j,k,URHO);
-                amrex::Real mx  = state(i,j,k,UMX);
-                amrex::Real my  = state(i,j,k,UMY);
-                amrex::Real mz  = state(i,j,k,UMY);
-                amrex::Real ei  = state(i,j,k,UEINT);
-                amrex::Real rhoinv = 1.0_rt/amrex::max(rho,parm.smallr);
-                amrex::Real vx = mx*rhoinv;
-                amrex::Real vy = my*rhoinv;
-                amrex::Real vz = mz*rhoinv;
-                amrex::Real p = amrex::max((parm.eos_gamma-1.0_rt)*ei, parm.smallp);
-                amrex::Real cs = amrex::Math::sqrt(parm.eos_gamma*p*rhoinv);
-                amrex::Real dtx = dx[0]/(amrex::Math::abs(vx)+cs);
-                amrex::Real dty = dx[1]/(amrex::Math::abs(vy)+cs);
-                amrex::Real dtz = dx[2]/(amrex::Math::abs(vz)+cs);
+                Real rho = state(i,j,k,URHO);
+                Real mx  = state(i,j,k,UMX);
+                Real my  = state(i,j,k,UMY);
+                Real mz  = state(i,j,k,UMY);
+                Real ei  = state(i,j,k,UEINT);
+                Real rhoinv = Real(1.0)/amrex::max(rho,parm.smallr);
+                Real vx = mx*rhoinv;
+                Real vy = my*rhoinv;
+                Real vz = mz*rhoinv;
+                Real p = amrex::max((parm.eos_gamma-Real(1.0))*ei, parm.smallp);
+                Real cs = amrex::Math::sqrt(parm.eos_gamma*p*rhoinv);
+                Real dtx = dx[0]/(amrex::Math::abs(vx)+cs);
+                Real dty = dx[1]/(amrex::Math::abs(vy)+cs);
+                Real dtz = dx[2]/(amrex::Math::abs(vz)+cs);
                 dt = amrex::min(dt,amrex::min(dtx,amrex::min(dty,dtz)));
             }
         }
@@ -58,14 +58,14 @@ void
 cns_compute_temperature (int i, int j, int k, amrex::Array4<amrex::Real> const& u,
                          Parm const& parm) noexcept
 {
-    using namespace amrex::literals;
+    using amrex::Real;
 
-    amrex::Real rhoinv = 1.0_rt/u(i,j,k,URHO);
-    amrex::Real mx = u(i,j,k,UMX);
-    amrex::Real my = u(i,j,k,UMY);
-    amrex::Real mz = u(i,j,k,UMZ);
-    u(i,j,k,UEINT) = u(i,j,k,UEDEN) - 0.5_rt * rhoinv * (mx*mx+my*my+mz*mz);
-    u(i,j,k,UTEMP) = rhoinv * u(i,j,k,UEINT) * (1.0_rt/parm.cv);
+    Real rhoinv = Real(1.0)/u(i,j,k,URHO);
+    Real mx = u(i,j,k,UMX);
+    Real my = u(i,j,k,UMY);
+    Real mz = u(i,j,k,UMZ);
+    u(i,j,k,UEINT) = u(i,j,k,UEDEN) - Real(0.5) * rhoinv * (mx*mx+my*my+mz*mz);
+    u(i,j,k,UTEMP) = rhoinv * u(i,j,k,UEINT) * (Real(1.0)/parm.cv);
 }
 
 #endif

--- a/Tutorials/GPU/CNS/Source/CNS_advance.cpp
+++ b/Tutorials/GPU/CNS/Source/CNS_advance.cpp
@@ -32,24 +32,24 @@ CNS::advance (Real time, Real dt, int iteration, int ncycle)
     }
 
     if (fr_as_crse) {
-        fr_as_crse->setVal(0.0_rt);
+        fr_as_crse->setVal(Real(0.0));
     }
 
     // RK2 stage 1
     FillPatch(*this, Sborder, NUM_GROW, time, State_Type, 0, NUM_STATE);
-    compute_dSdt(Sborder, dSdt, 0.5_rt*dt, fr_as_crse, fr_as_fine);
+    compute_dSdt(Sborder, dSdt, Real(0.5)*dt, fr_as_crse, fr_as_fine);
     // U^* = U^n + dt*dUdt^n
-    MultiFab::LinComb(S_new, 1.0_rt, Sborder, 0, dt, dSdt, 0, 0, NUM_STATE, 0);
+    MultiFab::LinComb(S_new, Real(1.0), Sborder, 0, dt, dSdt, 0, 0, NUM_STATE, 0);
     computeTemp(S_new,0);
 
     // RK2 stage 2
     // After fillpatch Sborder = U^n+dt*dUdt^n
     FillPatch(*this, Sborder, NUM_GROW, time+dt, State_Type, 0, NUM_STATE);
-    compute_dSdt(Sborder, dSdt, 0.5_rt*dt, fr_as_crse, fr_as_fine);
+    compute_dSdt(Sborder, dSdt, Real(0.5)*dt, fr_as_crse, fr_as_fine);
     // S_new = 0.5*(Sborder+S_old) = U^n + 0.5*dt*dUdt^n
-    MultiFab::LinComb(S_new, 0.5_rt, Sborder, 0, 0.5_rt, S_old, 0, 0, NUM_STATE, 0);
+    MultiFab::LinComb(S_new, Real(0.5), Sborder, 0, Real(0.5), S_old, 0, 0, NUM_STATE, 0);
     // S_new += 0.5*dt*dSdt
-    MultiFab::Saxpy(S_new, 0.5_rt*dt, dSdt, 0, 0, NUM_STATE, 0);
+    MultiFab::Saxpy(S_new, Real(0.5)*dt, dSdt, 0, 0, NUM_STATE, 0);
     // We now have S_new = U^{n+1} = (U^n+0.5*dt*dUdt^n) + 0.5*dt*dUdt^*
     computeTemp(S_new,0);
     
@@ -117,7 +117,7 @@ CNS::compute_dSdt (const MultiFab& S, MultiFab& dSdt, Real dt,
         [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
             cns_riemann_x(i, j, k, fxfab, slope, q, *lparm);
-            for (int n = neqns; n < ncons; ++n) fxfab(i,j,k,n) = 0.0_rt;
+            for (int n = neqns; n < ncons; ++n) fxfab(i,j,k,n) = Real(0.0);
         });
 
         // y-direction
@@ -133,7 +133,7 @@ CNS::compute_dSdt (const MultiFab& S, MultiFab& dSdt, Real dt,
         [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
             cns_riemann_y(i, j, k, fyfab, slope, q, *lparm);
-            for (int n = neqns; n < ncons; ++n) fyfab(i,j,k,n) = 0.0_rt;
+            for (int n = neqns; n < ncons; ++n) fyfab(i,j,k,n) = Real(0.0);
         });
 
         // z-direction
@@ -149,7 +149,7 @@ CNS::compute_dSdt (const MultiFab& S, MultiFab& dSdt, Real dt,
         [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
             cns_riemann_z(i, j, k, fzfab, slope, q, *lparm);
-            for (int n = neqns; n < ncons; ++n) fzfab(i,j,k,n) = 0.0_rt;
+            for (int n = neqns; n < ncons; ++n) fzfab(i,j,k,n) = Real(0.0);
         });
 
         // don't have to do this, but we could
@@ -162,7 +162,7 @@ CNS::compute_dSdt (const MultiFab& S, MultiFab& dSdt, Real dt,
             cns_flux_to_dudt(i, j, k, n, dsdtfab, AMREX_D_DECL(fxfab,fyfab,fzfab), dxinv);
         });
 
-        if (gravity != 0.0_rt) {
+        if (gravity != Real(0.0)) {
             const Real g = gravity;
             const int irho = Density;
             const int imz = Zmom;

--- a/Tutorials/GPU/CNS/Source/CNS_parm.H
+++ b/Tutorials/GPU/CNS/Source/CNS_parm.H
@@ -4,23 +4,21 @@
 #include <AMReX_REAL.H>
 #include <AMReX_GpuMemory.H>
 
-using namespace amrex::literals;
-
 struct Parm
     : public amrex::Gpu::Managed
 {
-    amrex::Real eos_gamma = 1.4_rt;
-    amrex::Real eos_mu = 28.97_rt;  // mean molecular weight
+    amrex::Real eos_gamma = 1.4;
+    amrex::Real eos_mu = 28.97;  // mean molecular weight
 
     amrex::Real cv;
     amrex::Real cp;
 
-    amrex::Real Pr  = 0.72_rt;     // Prandtl number
-    amrex::Real C_S = 1.458e-5_rt; // constant in Sutherland's law
-    amrex::Real T_S = 110.4_rt;    // Sutherland temperature
+    amrex::Real Pr  = 0.72;     // Prandtl number
+    amrex::Real C_S = 1.458e-5; // constant in Sutherland's law
+    amrex::Real T_S = 110.4;    // Sutherland temperature
 
-    amrex::Real smallr = 1.e-19_rt;
-    amrex::Real smallp = 1.e-10_rt;
+    amrex::Real smallr = 1.e-19;
+    amrex::Real smallp = 1.e-10;
 
     void Initialize ();
 };

--- a/Tutorials/GPU/CNS/Source/CNS_parm.cpp
+++ b/Tutorials/GPU/CNS/Source/CNS_parm.cpp
@@ -3,7 +3,7 @@
 
 void Parm::Initialize ()
 {
-    constexpr amrex::Real Ru = 8.31451e7_rt;
-    cv = Ru / (eos_mu * (eos_gamma-1.0_rt));
-    cp = eos_gamma * Ru / (eos_mu * (eos_gamma-1.0_rt));
+    constexpr amrex::Real Ru = amrex::Real(8.31451e7);
+    cv = Ru / (eos_mu * (eos_gamma-amrex::Real(1.0)));
+    cp = eos_gamma * Ru / (eos_mu * (eos_gamma-amrex::Real(1.0)));
 }

--- a/Tutorials/GPU/CNS/Source/hydro/CNS_hydro_K.H
+++ b/Tutorials/GPU/CNS/Source/hydro/CNS_hydro_K.H
@@ -14,17 +14,17 @@ cns_ctoprim (int i, int j, int k,
              amrex::Array4<amrex::Real> const& q,
              Parm const& parm) noexcept
 {
-    using namespace amrex::literals;
+    using amrex::Real;
 
-    amrex::Real rho = amrex::max(u(i,j,k,URHO),parm.smallr);
-    amrex::Real rhoinv = 1.0_rt/rho;
-    amrex::Real ux = u(i,j,k,UMX)*rhoinv;
-    amrex::Real uy = u(i,j,k,UMY)*rhoinv;
-    amrex::Real uz = u(i,j,k,UMZ)*rhoinv;
-    amrex::Real kineng = 0.5_rt*rho*(ux*ux+uy*uy+uz*uz);
-    amrex::Real ei = u(i,j,k,UEDEN) - kineng;
-    if (ei <= 0.0_rt) ei = u(i,j,k,UEINT);
-    amrex::Real p = amrex::max((parm.eos_gamma-1.0_rt)*ei,parm.smallp);
+    Real rho = amrex::max(u(i,j,k,URHO),parm.smallr);
+    Real rhoinv = Real(1.0)/rho;
+    Real ux = u(i,j,k,UMX)*rhoinv;
+    Real uy = u(i,j,k,UMY)*rhoinv;
+    Real uz = u(i,j,k,UMZ)*rhoinv;
+    Real kineng = Real(0.5)*rho*(ux*ux+uy*uy+uz*uz);
+    Real ei = u(i,j,k,UEDEN) - kineng;
+    if (ei <= Real(0.0)) ei = u(i,j,k,UEINT);
+    Real p = amrex::max((parm.eos_gamma-Real(1.0))*ei,parm.smallp);
     ei *= rhoinv;
 
     q(i,j,k,QRHO) = rho;
@@ -34,7 +34,7 @@ cns_ctoprim (int i, int j, int k,
     q(i,j,k,QEINT) = ei;
     q(i,j,k,QPRES) = p;
     q(i,j,k,QCS) = std::sqrt(parm.eos_gamma*p*rhoinv);
-    q(i,j,k,QTEMP) = 0.0_rt;
+    q(i,j,k,QTEMP) = Real(0.0);
 }
 
 AMREX_GPU_DEVICE
@@ -57,12 +57,12 @@ namespace {
 AMREX_GPU_DEVICE AMREX_FORCE_INLINE
 amrex::Real limiter (amrex::Real dlft, amrex::Real drgt) noexcept
 {
-    using namespace amrex::literals;
+    using amrex::Real;
 
-    amrex::Real dcen = 0.5_rt*(dlft+drgt);
-    amrex::Real dsgn = amrex::Math::copysign(1.0_rt, dcen);
-    amrex::Real slop = 2.0_rt * amrex::min(amrex::Math::abs(dlft),amrex::Math::abs(drgt));
-    amrex::Real dlim = (dlft*drgt >= 0.0_rt) ? slop : 0.0_rt;
+    Real dcen = Real(0.5)*(dlft+drgt);
+    Real dsgn = amrex::Math::copysign(Real(1.0), dcen);
+    Real slop = Real(2.0) * amrex::min(amrex::Math::abs(dlft),amrex::Math::abs(drgt));
+    Real dlim = (dlft*drgt >= Real(0.0)) ? slop : Real(0.0);
     return dsgn * amrex::min(dlim,amrex::Math::abs(dcen));
 }
 
@@ -75,28 +75,28 @@ cns_slope_x (int i, int j, int k,
              amrex::Array4<amrex::Real> const& dq,
              amrex::Array4<amrex::Real const> const& q) noexcept
 {
-    using namespace amrex::literals;
+    using amrex::Real;
 
-    amrex::Real dlft = 0.5_rt*(q(i,j,k,QPRES)-q(i-1,j,k,QPRES))/q(i,j,k,QCS) - 0.5_rt*q(i,j,k,QRHO)*(q(i,j,k,QU) - q(i-1,j,k,QU));
-    amrex::Real drgt = 0.5_rt*(q(i+1,j,k,QPRES)-q(i,j,k,QPRES))/q(i,j,k,QCS) - 0.5_rt*q(i,j,k,QRHO)*(q(i+1,j,k,QU) - q(i,j,k,QU));
-    amrex::Real d0 = limiter(dlft, drgt);
+    Real dlft = Real(0.5)*(q(i,j,k,QPRES)-q(i-1,j,k,QPRES))/q(i,j,k,QCS) - Real(0.5)*q(i,j,k,QRHO)*(q(i,j,k,QU) - q(i-1,j,k,QU));
+    Real drgt = Real(0.5)*(q(i+1,j,k,QPRES)-q(i,j,k,QPRES))/q(i,j,k,QCS) - Real(0.5)*q(i,j,k,QRHO)*(q(i+1,j,k,QU) - q(i,j,k,QU));
+    Real d0 = limiter(dlft, drgt);
 
-    amrex::Real cs2 = q(i,j,k,QCS)*q(i,j,k,QCS);
+    Real cs2 = q(i,j,k,QCS)*q(i,j,k,QCS);
     dlft = (q(i,j,k,QRHO)-q(i-1,j,k,QRHO)) - (q(i,j,k,QPRES) - q(i-1,j,k,QPRES))/cs2;
     drgt = (q(i+1,j,k,QRHO)-q(i,j,k,QRHO)) - (q(i+1,j,k,QPRES) - q(i,j,k,QPRES))/cs2;
-    amrex::Real d1 = limiter(dlft, drgt);
+    Real d1 = limiter(dlft, drgt);
 
-    dlft = 0.5_rt*(q(i,j,k,QPRES)-q(i-1,j,k,QPRES))/q(i,j,k,QCS) + 0.5_rt*q(i,j,k,QRHO)*(q(i,j,k,QU) - q(i-1,j,k,QU));
-    drgt = 0.5_rt*(q(i+1,j,k,QPRES)-q(i,j,k,QPRES))/q(i,j,k,QCS) + 0.5_rt*q(i,j,k,QRHO)*(q(i+1,j,k,QU) - q(i,j,k,QU));
-    amrex::Real d2 = limiter(dlft, drgt);
+    dlft = Real(0.5)*(q(i,j,k,QPRES)-q(i-1,j,k,QPRES))/q(i,j,k,QCS) + Real(0.5)*q(i,j,k,QRHO)*(q(i,j,k,QU) - q(i-1,j,k,QU));
+    drgt = Real(0.5)*(q(i+1,j,k,QPRES)-q(i,j,k,QPRES))/q(i,j,k,QCS) + Real(0.5)*q(i,j,k,QRHO)*(q(i+1,j,k,QU) - q(i,j,k,QU));
+    Real d2 = limiter(dlft, drgt);
 
     dlft = q(i,j,k,QV) - q(i-1,j,k,QV);
     drgt = q(i+1,j,k,QV) - q(i,j,k,QV);
-    amrex::Real d3 = limiter(dlft, drgt);
+    Real d3 = limiter(dlft, drgt);
 
     dlft = q(i,j,k,QW) - q(i-1,j,k,QW);
     drgt = q(i+1,j,k,QW) - q(i,j,k,QW);
-    amrex::Real d4 = limiter(dlft, drgt);
+    Real d4 = limiter(dlft, drgt);
 
     dq(i,j,k,0) = d0;
     dq(i,j,k,1) = d1;
@@ -112,28 +112,28 @@ cns_slope_y (int i, int j, int k,
              amrex::Array4<amrex::Real> const& dq,
              amrex::Array4<amrex::Real const> const& q) noexcept
 {
-    using namespace amrex::literals;
+    using amrex::Real;
 
-    amrex::Real dlft = 0.5_rt*(q(i,j,k,QPRES)-q(i,j-1,k,QPRES))/q(i,j,k,QCS) - 0.5_rt*q(i,j,k,QRHO)*(q(i,j,k,QV) - q(i,j-1,k,QV));
-    amrex::Real drgt = 0.5_rt*(q(i,j+1,k,QPRES)-q(i,j,k,QPRES))/q(i,j,k,QCS) - 0.5_rt*q(i,j,k,QRHO)*(q(i,j+1,k,QV) - q(i,j,k,QV));
-    amrex::Real d0 = limiter(dlft, drgt);
+    Real dlft = Real(0.5)*(q(i,j,k,QPRES)-q(i,j-1,k,QPRES))/q(i,j,k,QCS) - Real(0.5)*q(i,j,k,QRHO)*(q(i,j,k,QV) - q(i,j-1,k,QV));
+    Real drgt = Real(0.5)*(q(i,j+1,k,QPRES)-q(i,j,k,QPRES))/q(i,j,k,QCS) - Real(0.5)*q(i,j,k,QRHO)*(q(i,j+1,k,QV) - q(i,j,k,QV));
+    Real d0 = limiter(dlft, drgt);
 
-    amrex::Real cs2 = q(i,j,k,QCS)*q(i,j,k,QCS);
+    Real cs2 = q(i,j,k,QCS)*q(i,j,k,QCS);
     dlft = (q(i,j,k,QRHO)-q(i,j-1,k,QRHO)) - (q(i,j,k,QPRES) - q(i,j-1,k,QPRES))/cs2;
     drgt = (q(i,j+1,k,QRHO)-q(i,j,k,QRHO)) - (q(i,j+1,k,QPRES) - q(i,j,k,QPRES))/cs2;
-    amrex::Real d1 = limiter(dlft, drgt);
+    Real d1 = limiter(dlft, drgt);
 
-    dlft = 0.5_rt*(q(i,j,k,QPRES)-q(i,j-1,k,QPRES))/q(i,j,k,QCS) + 0.5_rt*q(i,j,k,QRHO)*(q(i,j,k,QV) - q(i,j-1,k,QV));
-    drgt = 0.5_rt*(q(i,j+1,k,QPRES)-q(i,j,k,QPRES))/q(i,j,k,QCS) + 0.5_rt*q(i,j,k,QRHO)*(q(i,j+1,k,QV) - q(i,j,k,QV));
-    amrex::Real d2 = limiter(dlft, drgt);
+    dlft = Real(0.5)*(q(i,j,k,QPRES)-q(i,j-1,k,QPRES))/q(i,j,k,QCS) + Real(0.5)*q(i,j,k,QRHO)*(q(i,j,k,QV) - q(i,j-1,k,QV));
+    drgt = Real(0.5)*(q(i,j+1,k,QPRES)-q(i,j,k,QPRES))/q(i,j,k,QCS) + Real(0.5)*q(i,j,k,QRHO)*(q(i,j+1,k,QV) - q(i,j,k,QV));
+    Real d2 = limiter(dlft, drgt);
 
     dlft = q(i,j,k,QU) - q(i,j-1,k,QU);
     drgt = q(i,j+1,k,QU) - q(i,j,k,QU);
-    amrex::Real d3 = limiter(dlft, drgt);
+    Real d3 = limiter(dlft, drgt);
 
     dlft = q(i,j,k,QW) - q(i,j-1,k,QW);
     drgt = q(i,j+1,k,QW) - q(i,j,k,QW);
-    amrex::Real d4 = limiter(dlft, drgt);
+    Real d4 = limiter(dlft, drgt);
 
     dq(i,j,k,0) = d0;
     dq(i,j,k,1) = d1;
@@ -149,28 +149,28 @@ cns_slope_z (int i, int j, int k,
              amrex::Array4<amrex::Real> const& dq,
              amrex::Array4<amrex::Real const> const& q) noexcept
 {
-    using namespace amrex::literals;
+    using amrex::Real;
 
-    amrex::Real dlft = 0.5_rt*(q(i,j,k,QPRES)-q(i,j,k-1,QPRES))/q(i,j,k,QCS) - 0.5_rt*q(i,j,k,QRHO)*(q(i,j,k,QW) - q(i,j,k-1,QW));
-    amrex::Real drgt = 0.5_rt*(q(i,j,k+1,QPRES)-q(i,j,k,QPRES))/q(i,j,k,QCS) - 0.5_rt*q(i,j,k,QRHO)*(q(i,j,k+1,QW) - q(i,j,k,QW));
-    amrex::Real d0 = limiter(dlft, drgt);
+    Real dlft = Real(0.5)*(q(i,j,k,QPRES)-q(i,j,k-1,QPRES))/q(i,j,k,QCS) - Real(0.5)*q(i,j,k,QRHO)*(q(i,j,k,QW) - q(i,j,k-1,QW));
+    Real drgt = Real(0.5)*(q(i,j,k+1,QPRES)-q(i,j,k,QPRES))/q(i,j,k,QCS) - Real(0.5)*q(i,j,k,QRHO)*(q(i,j,k+1,QW) - q(i,j,k,QW));
+    Real d0 = limiter(dlft, drgt);
 
-    amrex::Real cs2 = q(i,j,k,QCS)*q(i,j,k,QCS);
+    Real cs2 = q(i,j,k,QCS)*q(i,j,k,QCS);
     dlft = (q(i,j,k,QRHO)-q(i,j,k-1,QRHO)) - (q(i,j,k,QPRES) - q(i,j,k-1,QPRES))/cs2;
     drgt = (q(i,j,k+1,QRHO)-q(i,j,k,QRHO)) - (q(i,j,k+1,QPRES) - q(i,j,k,QPRES))/cs2;
-    amrex::Real d1 = limiter(dlft, drgt);
+    Real d1 = limiter(dlft, drgt);
 
-    dlft = 0.5_rt*(q(i,j,k,QPRES)-q(i,j,k-1,QPRES))/q(i,j,k,QCS) + 0.5_rt*q(i,j,k,QRHO)*(q(i,j,k,QW) - q(i,j,k-1,QW));
-    drgt = 0.5_rt*(q(i,j,k+1,QPRES)-q(i,j,k,QPRES))/q(i,j,k,QCS) + 0.5_rt*q(i,j,k,QRHO)*(q(i,j,k+1,QW) - q(i,j,k,QW));
-    amrex::Real d2 = limiter(dlft, drgt);
+    dlft = Real(0.5)*(q(i,j,k,QPRES)-q(i,j,k-1,QPRES))/q(i,j,k,QCS) + Real(0.5)*q(i,j,k,QRHO)*(q(i,j,k,QW) - q(i,j,k-1,QW));
+    drgt = Real(0.5)*(q(i,j,k+1,QPRES)-q(i,j,k,QPRES))/q(i,j,k,QCS) + Real(0.5)*q(i,j,k,QRHO)*(q(i,j,k+1,QW) - q(i,j,k,QW));
+    Real d2 = limiter(dlft, drgt);
 
     dlft = q(i,j,k,QU) - q(i,j,k-1,QU);
     drgt = q(i,j,k+1,QU) - q(i,j,k,QU);
-    amrex::Real d3 = limiter(dlft, drgt);
+    Real d3 = limiter(dlft, drgt);
 
     dlft = q(i,j,k,QV) - q(i,j,k-1,QV);
     drgt = q(i,j,k+1,QV) - q(i,j,k,QV);
-    amrex::Real d4 = limiter(dlft, drgt);
+    Real d4 = limiter(dlft, drgt);
 
     dq(i,j,k,0) = d0;
     dq(i,j,k,1) = d1;
@@ -192,125 +192,125 @@ riemann (const amrex::Real gamma, const amrex::Real smallp, const amrex::Real sm
          amrex::Real& flxrho, amrex::Real& flxu, amrex::Real& flxut,
          amrex::Real& flxutt, amrex::Real& flxe) noexcept
 {
-    using namespace amrex::literals;
+    using amrex::Real;
 
-    constexpr amrex::Real weakwv = 1.e-3_rt;
-    constexpr amrex::Real small = 1.e-6_rt;
+    constexpr Real weakwv = Real(1.e-3);
+    constexpr Real small = Real(1.e-6);
 
-    amrex::Real clsql = gamma*pl*rl;
-    amrex::Real clsqr = gamma*pr*rr;
-    amrex::Real wl = std::sqrt(clsql);
-    amrex::Real wr = std::sqrt(clsqr);
-    amrex::Real cleft = wl/rl;
-    amrex::Real cright = wr/rr;
-    amrex::Real ccsmall = small*(cleft+cright);
+    Real clsql = gamma*pl*rl;
+    Real clsqr = gamma*pr*rr;
+    Real wl = std::sqrt(clsql);
+    Real wr = std::sqrt(clsqr);
+    Real cleft = wl/rl;
+    Real cright = wr/rr;
+    Real ccsmall = small*(cleft+cright);
 
-    amrex::Real pstar = (wl*pr + wr*pl - wr*wl*(ur-ul))/(wl+wr);
+    Real pstar = (wl*pr + wr*pl - wr*wl*(ur-ul))/(wl+wr);
     pstar = amrex::max(pstar,smallp);
-    amrex::Real pstnm1 = pstar;
+    Real pstnm1 = pstar;
 
-    amrex::Real wlsq = (.5_rt*(gamma-1._rt)*(pstar+pl)+pstar)*rl;
-    amrex::Real wrsq = (.5_rt*(gamma-1._rt)*(pstar+pr)+pstar)*rr;
+    Real wlsq = (Real(0.5)*(gamma-Real(1.))*(pstar+pl)+pstar)*rl;
+    Real wrsq = (Real(0.5)*(gamma-Real(1.))*(pstar+pr)+pstar)*rr;
 
     wl = std::sqrt(wlsq);
     wr = std::sqrt(wrsq);
-    amrex::Real ustarp = ul - (pstar-pl)/wl;
-    amrex::Real ustarm = ur + (pstar-pr)/wr;
+    Real ustarp = ul - (pstar-pl)/wl;
+    Real ustarm = ur + (pstar-pr)/wr;
 
     pstar = (wl*pr + wr*pl - wr*wl*(ur-ul))/(wl+wr);
     pstar = amrex::max(pstar,smallp);
 
-    amrex::Real ustar;
+    Real ustar;
     for (int iter = 0; iter < 3; ++iter)
     {
-        wlsq = (.5_rt*(gamma-1._rt)*(pstar+pl)+pstar)*rl;
-        wrsq = (.5_rt*(gamma-1._rt)*(pstar+pr)+pstar)*rr;
+        wlsq = (Real(0.5)*(gamma-Real(1.))*(pstar+pl)+pstar)*rl;
+        wrsq = (Real(0.5)*(gamma-Real(1.))*(pstar+pr)+pstar)*rr;
 
-        wl = 1._rt/std::sqrt(wlsq);
-        wr = 1._rt/std::sqrt(wrsq);
+        wl = Real(1.)/std::sqrt(wlsq);
+        wr = Real(1.)/std::sqrt(wrsq);
 
-        amrex::Real ustnm1 = ustarm;
-        amrex::Real ustnp1 = ustarp;
+        Real ustnm1 = ustarm;
+        Real ustnp1 = ustarp;
 
         ustarm = ur - (pr - pstar)*wr;
         ustarp = ul + (pl - pstar)*wl;
 
-        amrex::Real dpditer = amrex::Math::abs(pstnm1-pstar);
-        amrex::Real zp = amrex::Math::abs(ustarp-ustnp1);
-        if (zp-weakwv*cleft < 0.0_rt ) {
+        Real dpditer = amrex::Math::abs(pstnm1-pstar);
+        Real zp = amrex::Math::abs(ustarp-ustnp1);
+        if (zp-weakwv*cleft < Real(0.0) ) {
             zp = dpditer*wl;
         }
-        amrex::Real zm = amrex::Math::abs(ustarm-ustnm1);
-        if (zm-weakwv*cright < 0.0_rt ) {
+        Real zm = amrex::Math::abs(ustarm-ustnm1);
+        if (zm-weakwv*cright < Real(0.0) ) {
             zm = dpditer*wr;
         }
 
-        amrex::Real zz = zp+zm;
-        amrex::Real denom = dpditer/ amrex::max(zz,ccsmall);
+        Real zz = zp+zm;
+        Real denom = dpditer/ amrex::max(zz,ccsmall);
         pstnm1 = pstar;
         pstar = pstar - denom*(ustarm-ustarp);
         pstar = amrex::max(pstar,smallp);
-        ustar = 0.5_rt*(ustarm+ustarp);
+        ustar = Real(0.5)*(ustarm+ustarp);
     }
 
-    amrex::Real ro, uo, po, sgnm, utrans1, utrans2;
-    if (ustar > 0._rt) {
+    Real ro, uo, po, sgnm, utrans1, utrans2;
+    if (ustar > Real(0.)) {
         ro = rl;
         uo = ul;
         po = pl;
-        sgnm = 1._rt;
+        sgnm = Real(1.);
         utrans1 = ut1l;
         utrans2 = ut2l;
-    } else if (ustar < 0._rt) {
+    } else if (ustar < Real(0.)) {
         ro = rr;
         uo = ur;
         po = pr;
-        sgnm = -1._rt;
+        sgnm = Real(-1.);
         utrans1 = ut1r;
         utrans2 = ut2r;
     } else {
-        uo = 0.5_rt*(ur+ul);
-        po = 0.5_rt*(pr+pl);
-        ro = 2._rt*(rl*rr)/(rl+rr);
-        sgnm = 1._rt;
-        utrans1 = 0.5_rt*(ut1l+ut1r);
-        utrans2 = 0.5_rt*(ut2l+ut2r);
+        uo = Real(0.5)*(ur+ul);
+        po = Real(0.5)*(pr+pl);
+        ro = Real(2.)*(rl*rr)/(rl+rr);
+        sgnm = Real(1.);
+        utrans1 = Real(0.5)*(ut1l+ut1r);
+        utrans2 = Real(0.5)*(ut2l+ut2r);
     }
-    amrex::Real wosq = (.5_rt*(gamma-1._rt)*(pstar+po)+pstar)*ro;
-    amrex::Real co = std::sqrt(gamma * po / ro);
-    amrex::Real wo = std::sqrt(wosq);
-    amrex::Real dpjmp = pstar-po;
-    amrex::Real rstar = ro/(1._rt-ro*dpjmp/wosq);
-    amrex::Real cstar = std::sqrt(gamma * pstar / rstar);
-    amrex::Real spout = co-sgnm*uo;
-    amrex::Real spin = cstar - sgnm*uo;
+    Real wosq = (Real(0.5)*(gamma-Real(1.))*(pstar+po)+pstar)*ro;
+    Real co = std::sqrt(gamma * po / ro);
+    Real wo = std::sqrt(wosq);
+    Real dpjmp = pstar-po;
+    Real rstar = ro/(Real(1.)-ro*dpjmp/wosq);
+    Real cstar = std::sqrt(gamma * pstar / rstar);
+    Real spout = co-sgnm*uo;
+    Real spin = cstar - sgnm*uo;
     if(pstar >= po) {
         spin = wo/ro-sgnm*uo;
         spout = spin;
     }
-    amrex::Real ss = amrex::max(spout-spin, spout+spin);
-    amrex::Real frac = 0.5_rt*(1._rt+(spin+spout)/amrex::max(ss,ccsmall));
+    Real ss = amrex::max(spout-spin, spout+spin);
+    Real frac = Real(0.5)*(Real(1.)+(spin+spout)/amrex::max(ss,ccsmall));
 
-    amrex::Real rgdnv, ugdnv, pgdnv;
-    if (spout < 0._rt) {
+    Real rgdnv, ugdnv, pgdnv;
+    if (spout < Real(0.)) {
         rgdnv = ro;
         ugdnv = uo;
         pgdnv = po;
-    } else if(spin >= 0._rt) {
+    } else if(spin >= Real(0.)) {
         rgdnv = rstar;
         ugdnv = ustar;
         pgdnv = pstar;
     } else {
-        rgdnv = frac*rstar + (1._rt - frac)* ro;
-        ugdnv = frac*ustar + (1._rt - frac)* uo;
-        pgdnv = frac*pstar + (1._rt - frac)* po;
+        rgdnv = frac*rstar + (Real(1.) - frac)* ro;
+        ugdnv = frac*ustar + (Real(1.) - frac)* uo;
+        pgdnv = frac*pstar + (Real(1.) - frac)* po;
     }
     
     flxrho = rgdnv*ugdnv;
     flxu = rgdnv*ugdnv*ugdnv+pgdnv;
     flxut = rgdnv*ugdnv*utrans1;
     flxutt = rgdnv*ugdnv*utrans2;
-    flxe = ugdnv*(0.5_rt*rgdnv*(ugdnv*ugdnv+utrans1*utrans1+utrans2*utrans2) + pgdnv/(gamma -1._rt) + pgdnv);
+    flxe = ugdnv*(Real(0.5)*rgdnv*(ugdnv*ugdnv+utrans1*utrans1+utrans2*utrans2) + pgdnv/(gamma -Real(1.)) + pgdnv);
 }
 }
 
@@ -323,25 +323,25 @@ cns_riemann_x (int i, int j, int k,
                amrex::Array4<amrex::Real const> const& q,
                Parm const& parm) noexcept
 {
-    using namespace amrex::literals;
+    using amrex::Real;
 
-    amrex::Real cspeed = q(i-1,j,k,QCS);
-    amrex::Real rl = q(i-1,j,k,QRHO) + 0.5_rt * ( (dq(i-1,j,k,0)+dq(i-1,j,k,2))/cspeed + dq(i-1,j,k,1));
+    Real cspeed = q(i-1,j,k,QCS);
+    Real rl = q(i-1,j,k,QRHO) + Real(0.5) * ( (dq(i-1,j,k,0)+dq(i-1,j,k,2))/cspeed + dq(i-1,j,k,1));
     rl = amrex::max(rl, parm.smallr);
-    amrex::Real ul = q(i-1,j,k,QU) + 0.5_rt * ( (dq(i-1,j,k,2)-dq(i-1,j,k,0))/q(i-1,j,k,QRHO));
-    amrex::Real pl = q(i-1,j,k,QPRES) + 0.5_rt *  (dq(i-1,j,k,0)+dq(i-1,j,k,2))*cspeed;
+    Real ul = q(i-1,j,k,QU) + Real(0.5) * ( (dq(i-1,j,k,2)-dq(i-1,j,k,0))/q(i-1,j,k,QRHO));
+    Real pl = q(i-1,j,k,QPRES) + Real(0.5) *  (dq(i-1,j,k,0)+dq(i-1,j,k,2))*cspeed;
     pl = amrex::max(pl, parm.smallp);
-    amrex::Real ut1l = q(i-1,j,k,QV) + 0.5_rt * dq(i-1,j,k,3);
-    amrex::Real ut2l = q(i-1,j,k,QW) + 0.5_rt * dq(i-1,j,k,4);
+    Real ut1l = q(i-1,j,k,QV) + Real(0.5) * dq(i-1,j,k,3);
+    Real ut2l = q(i-1,j,k,QW) + Real(0.5) * dq(i-1,j,k,4);
 
     cspeed = q(i,j,k,QCS);
-    amrex::Real rr = q(i,j,k,QRHO) - 0.5_rt * ( (dq(i,j,k,0)+dq(i,j,k,2))/cspeed + dq(i,j,k,1));
+    Real rr = q(i,j,k,QRHO) - Real(0.5) * ( (dq(i,j,k,0)+dq(i,j,k,2))/cspeed + dq(i,j,k,1));
     rr = amrex::max(rr, parm.smallr);
-    amrex::Real ur = q(i,j,k,QU) - 0.5_rt * ( (dq(i,j,k,2)-dq(i,j,k,0))/q(i,j,k,QRHO));
-    amrex::Real pr = q(i,j,k,QPRES) - 0.5_rt * (dq(i,j,k,0)+dq(i,j,k,2))*cspeed;
+    Real ur = q(i,j,k,QU) - Real(0.5) * ( (dq(i,j,k,2)-dq(i,j,k,0))/q(i,j,k,QRHO));
+    Real pr = q(i,j,k,QPRES) - Real(0.5) * (dq(i,j,k,0)+dq(i,j,k,2))*cspeed;
     pr = amrex::max(pr, parm.smallp);
-    amrex::Real ut1r = q(i,j,k,QV) - 0.5_rt * dq(i,j,k,3);
-    amrex::Real ut2r = q(i,j,k,QW) - 0.5_rt * dq(i,j,k,4);
+    Real ut1r = q(i,j,k,QV) - Real(0.5) * dq(i,j,k,3);
+    Real ut2r = q(i,j,k,QW) - Real(0.5) * dq(i,j,k,4);
 
     riemann(parm.eos_gamma, parm.smallp, parm.smallr,
             rl, ul, pl, ut1l, ut2l, rr, ur, pr, ut1r, ut2r,
@@ -357,25 +357,25 @@ cns_riemann_y (int i, int j, int k,
                amrex::Array4<amrex::Real const> const& q,
                Parm const& parm) noexcept
 {
-    using namespace amrex::literals;
+    using amrex::Real;
 
-    amrex::Real cspeed = q(i,j-1,k,QCS);
-    amrex::Real rl = q(i,j-1,k,QRHO) + 0.5_rt * ( (dq(i,j-1,k,0)+dq(i,j-1,k,2))/cspeed + dq(i,j-1,k,1));
+    Real cspeed = q(i,j-1,k,QCS);
+    Real rl = q(i,j-1,k,QRHO) + Real(0.5) * ( (dq(i,j-1,k,0)+dq(i,j-1,k,2))/cspeed + dq(i,j-1,k,1));
     rl = amrex::max(rl, parm.smallr);
-    amrex::Real ul = q(i,j-1,k,QV) + 0.5_rt * ( (dq(i,j-1,k,2)-dq(i,j-1,k,0))/q(i,j-1,k,QRHO));
-    amrex::Real pl = q(i,j-1,k,QPRES) + 0.5_rt *  (dq(i,j-1,k,0)+dq(i,j-1,k,2))*cspeed;
+    Real ul = q(i,j-1,k,QV) + Real(0.5) * ( (dq(i,j-1,k,2)-dq(i,j-1,k,0))/q(i,j-1,k,QRHO));
+    Real pl = q(i,j-1,k,QPRES) + Real(0.5) *  (dq(i,j-1,k,0)+dq(i,j-1,k,2))*cspeed;
     pl = amrex::max(pl, parm.smallp);
-    amrex::Real ut1l = q(i,j-1,k,QU) + 0.5_rt * dq(i,j-1,k,3);
-    amrex::Real ut2l = q(i,j-1,k,QW) + 0.5_rt * dq(i,j-1,k,4);
+    Real ut1l = q(i,j-1,k,QU) + Real(0.5) * dq(i,j-1,k,3);
+    Real ut2l = q(i,j-1,k,QW) + Real(0.5) * dq(i,j-1,k,4);
 
     cspeed = q(i,j,k,QCS);
-    amrex::Real rr = q(i,j,k,QRHO) - 0.5_rt * ( (dq(i,j,k,0)+dq(i,j,k,2))/cspeed + dq(i,j,k,1));
+    Real rr = q(i,j,k,QRHO) - Real(0.5) * ( (dq(i,j,k,0)+dq(i,j,k,2))/cspeed + dq(i,j,k,1));
     rr = amrex::max(rr, parm.smallr);
-    amrex::Real ur = q(i,j,k,QV) - 0.5_rt * ( (dq(i,j,k,2)-dq(i,j,k,0))/q(i,j,k,QRHO));
-    amrex::Real pr = q(i,j,k,QPRES) - 0.5_rt * (dq(i,j,k,0)+dq(i,j,k,2))*cspeed;
+    Real ur = q(i,j,k,QV) - Real(0.5) * ( (dq(i,j,k,2)-dq(i,j,k,0))/q(i,j,k,QRHO));
+    Real pr = q(i,j,k,QPRES) - Real(0.5) * (dq(i,j,k,0)+dq(i,j,k,2))*cspeed;
     pr = amrex::max(pr, parm.smallp);
-    amrex::Real ut1r = q(i,j,k,QU) - 0.5_rt * dq(i,j,k,3);
-    amrex::Real ut2r = q(i,j,k,QW) - 0.5_rt * dq(i,j,k,4);
+    Real ut1r = q(i,j,k,QU) - Real(0.5) * dq(i,j,k,3);
+    Real ut2r = q(i,j,k,QW) - Real(0.5) * dq(i,j,k,4);
 
     riemann(parm.eos_gamma, parm.smallp, parm.smallr,
             rl, ul, pl, ut1l, ut2l, rr, ur, pr, ut1r, ut2r,
@@ -391,25 +391,25 @@ cns_riemann_z (int i, int j, int k,
                amrex::Array4<amrex::Real const> const& q,
                Parm const& parm) noexcept
 {
-    using namespace amrex::literals;
+    using amrex::Real;
 
-    amrex::Real cspeed = q(i,j,k-1,QCS);
-    amrex::Real rl = q(i,j,k-1,QRHO) + 0.5_rt * ( (dq(i,j,k-1,0)+dq(i,j,k-1,2))/cspeed + dq(i,j,k-1,1));
+    Real cspeed = q(i,j,k-1,QCS);
+    Real rl = q(i,j,k-1,QRHO) + Real(0.5) * ( (dq(i,j,k-1,0)+dq(i,j,k-1,2))/cspeed + dq(i,j,k-1,1));
     rl = amrex::max(rl, parm.smallr);
-    amrex::Real ul = q(i,j,k-1,QW) + 0.5_rt * ( (dq(i,j,k-1,2)-dq(i,j,k-1,0))/q(i,j,k-1,QRHO));
-    amrex::Real pl = q(i,j,k-1,QPRES) + 0.5_rt *  (dq(i,j,k-1,0)+dq(i,j,k-1,2))*cspeed;
+    Real ul = q(i,j,k-1,QW) + Real(0.5) * ( (dq(i,j,k-1,2)-dq(i,j,k-1,0))/q(i,j,k-1,QRHO));
+    Real pl = q(i,j,k-1,QPRES) + Real(0.5) *  (dq(i,j,k-1,0)+dq(i,j,k-1,2))*cspeed;
     pl = amrex::max(pl, parm.smallp);
-    amrex::Real ut1l = q(i,j,k-1,QU) + 0.5_rt * dq(i,j,k-1,3);
-    amrex::Real ut2l = q(i,j,k-1,QV) + 0.5_rt * dq(i,j,k-1,4);
+    Real ut1l = q(i,j,k-1,QU) + Real(0.5) * dq(i,j,k-1,3);
+    Real ut2l = q(i,j,k-1,QV) + Real(0.5) * dq(i,j,k-1,4);
 
     cspeed = q(i,j,k,QCS);
-    amrex::Real rr = q(i,j,k,QRHO) - 0.5_rt * ( (dq(i,j,k,0)+dq(i,j,k,2))/cspeed + dq(i,j,k,1));
+    Real rr = q(i,j,k,QRHO) - Real(0.5) * ( (dq(i,j,k,0)+dq(i,j,k,2))/cspeed + dq(i,j,k,1));
     rr = amrex::max(rr, parm.smallr);
-    amrex::Real ur = q(i,j,k,QW) - 0.5_rt * ( (dq(i,j,k,2)-dq(i,j,k,0))/q(i,j,k,QRHO));
-    amrex::Real pr = q(i,j,k,QPRES) - 0.5_rt *  (dq(i,j,k,0)+dq(i,j,k,2))*cspeed;
+    Real ur = q(i,j,k,QW) - Real(0.5) * ( (dq(i,j,k,2)-dq(i,j,k,0))/q(i,j,k,QRHO));
+    Real pr = q(i,j,k,QPRES) - Real(0.5) *  (dq(i,j,k,0)+dq(i,j,k,2))*cspeed;
     pr = amrex::max(pr, parm.smallp);
-    amrex::Real ut1r = q(i,j,k,QU) - 0.5_rt * dq(i,j,k,3);
-    amrex::Real ut2r = q(i,j,k,QV) - 0.5_rt * dq(i,j,k,4);
+    Real ut1r = q(i,j,k,QU) - Real(0.5) * dq(i,j,k,3);
+    Real ut2r = q(i,j,k,QV) - Real(0.5) * dq(i,j,k,4);
 
     riemann(parm.eos_gamma, parm.smallp, parm.smallr,
             rl, ul, pl, ut1l, ut2l, rr, ur, pr, ut1r, ut2r,

--- a/Tutorials/GPU/CNS/Source/main.cpp
+++ b/Tutorials/GPU/CNS/Source/main.cpp
@@ -15,8 +15,8 @@ int main (int argc, char* argv[])
     BL_PROFILE_VAR("main()", pmain);
 
     Real timer_tot = amrex::second();
-    Real timer_init = 0._rt;
-    Real timer_advance = 0._rt;
+    Real timer_init = Real(0.);
+    Real timer_advance = Real(0.);
 
     int  max_step;
     Real strt_time;
@@ -26,19 +26,19 @@ int main (int argc, char* argv[])
         ParmParse pp; 
 
         max_step  = -1;
-        strt_time =  0.0_rt;
-        stop_time = -1.0_rt;
+        strt_time = Real( 0.0);
+        stop_time = Real(-1.0);
 
         pp.query("max_step",max_step);
         pp.query("strt_time",strt_time);
         pp.query("stop_time",stop_time);
     }
 
-    if (strt_time < 0.0_rt) {
+    if (strt_time < Real(0.0)) {
         amrex::Abort("MUST SPECIFY a non-negative strt_time"); 
     }
 
-    if (max_step < 0 && stop_time < 0.0_rt) {
+    if (max_step < 0 && stop_time < Real(0.0)) {
 	amrex::Abort("Exiting because neither max_step nor stop_time is non-negative.");
     }
 
@@ -54,7 +54,7 @@ int main (int argc, char* argv[])
 
 	while ( amr.okToContinue() &&
   	       (amr.levelSteps(0) < max_step || max_step < 0) &&
-	       (amr.cumTime() < stop_time || stop_time < 0.0_rt) )
+	       (amr.cumTime() < stop_time || stop_time < Real(0.0)) )
 	    
 	{
 	    //


### PR DESCRIPTION
## Summary

In beta8, C++11 user defined literals are broken because of the use of long
double (https://github.com/intel/llvm/issues/2187). 
We have implemented a workaround by overloading operator "" _rt
with `const char*` argument and our own `atof`.  But, because Clang does not
evaluate the new version of the operator at compile time, we now avoid using
`_rt` in AMReX.  In the long term, we may have to remove it entirely if the
long double issue is not resolved in DPC++.

With the workaround, we can enable the DPC++ CI test again.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
