### PR TITLE
FPE trap in DPC++

### DIFF
--- a/Src/Base/AMReX.cpp
+++ b/Src/Base/AMReX.cpp
@@ -430,7 +430,8 @@ amrex::Initialize (int& argc, char**& argv, bool build_parm_parse,
             if (invalid)   curr_fpe_excepts |= FE_INVALID;
             if (divbyzero) curr_fpe_excepts |= FE_DIVBYZERO;
             if (overflow)  curr_fpe_excepts |= FE_OVERFLOW;
-#if !defined(__PGI) || (__PGIC__ >= 16)
+#if !defined(AMREX_USE_DPCPP) && (!defined(__PGI) || (__PGIC__ >= 16))
+            // xxxxx DPCPP todo: fpe trap
             prev_fpe_excepts = fegetexcept();
             if (curr_fpe_excepts != 0) {
                 feenableexcept(curr_fpe_excepts);  // trap floating point exceptions


### PR DESCRIPTION
## Summary

Due to a bug in DPC++ compiler, we disable fpe trapping.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
