### PR TITLE
Remove _rt and _prt from the particle code, for reasons explained in PR 1243.

### DIFF
--- a/Src/Particle/AMReX_Particle.H
+++ b/Src/Particle/AMReX_Particle.H
@@ -367,9 +367,9 @@ Particle<NReal, NInt>::CIC_Cells_Fracs_Basic (const Particle<NReal, NInt>& p,
     //
     // "cells" should be dimensioned: IntVect cells[AMREX_D_TERM(2,+2,+4)]
     //
-    const Real len[AMREX_SPACEDIM] = { AMREX_D_DECL(static_cast<Real>((p.m_rdata.pos[0]-plo[0])/dx[0] + 0.5_rt),
-                                                    static_cast<Real>((p.m_rdata.pos[1]-plo[1])/dx[1] + 0.5_rt),
-                                                    static_cast<Real>((p.m_rdata.pos[2]-plo[2])/dx[2] + 0.5_rt)) };
+    const Real len[AMREX_SPACEDIM] = { AMREX_D_DECL(static_cast<Real>((p.m_rdata.pos[0]-plo[0])/dx[0] + Real(0.5)),
+                                                    static_cast<Real>((p.m_rdata.pos[1]-plo[1])/dx[1] + Real(0.5)),
+                                                    static_cast<Real>((p.m_rdata.pos[2]-plo[2])/dx[2] + Real(0.5))) };
 
     const IntVect cell(AMREX_D_DECL(static_cast<int>(amrex::Math::floor(len[0])),
                                     static_cast<int>(amrex::Math::floor(len[1])),
@@ -431,34 +431,34 @@ Particle<NReal, NInt>::CIC_Cells_Fracs (const Particle<NReal, NInt>& p,
     for (int xi = locell[0]; xi <= hicell[0]; xi++)
     {
         cells[i][0] = xi;
-        fracs[i] = (std::min(hilen[0]-xi,1_rt)-std::max(lolen[0]-xi,0_rt))*cell_density;
+        fracs[i] = (std::min(hilen[0]-xi,Real(1.0))-std::max(lolen[0]-xi,Real(0.0)))*cell_density;
         i++;
     }
 #elif (AMREX_SPACEDIM == 2)
     for (int yi = locell[1]; yi <= hicell[1]; yi++)
     {
-        const Real yf = std::min(hilen[1]-yi,1_rt)-std::max(lolen[1]-yi,0_rt);
+        const Real yf = std::min(hilen[1]-yi,Real(1.0))-std::max(lolen[1]-yi,Real(0.0));
         for (int xi = locell[0]; xi <= hicell[0]; xi ++)
         {
             cells[i][0] = xi;
             cells[i][1] = yi;
-            fracs[i] = yf * (std::min(hilen[0]-xi,1_rt)-std::max(lolen[0]-xi,0_rt))*cell_density;
+            fracs[i] = yf * (std::min(hilen[0]-xi,Real(1.0))-std::max(lolen[0]-xi,Real(0.0)))*cell_density;
             i++;
         }
     }
 #elif (AMREX_SPACEDIM == 3)
     for (int zi = locell[2]; zi <= hicell[2]; zi++)
     {
-        const Real zf = std::min(hilen[2]-zi,1_rt)-std::max(lolen[2]-zi,0_rt);
+        const Real zf = std::min(hilen[2]-zi,Real(1.0))-std::max(lolen[2]-zi,Real(0.0));
         for (int yi = locell[1]; yi <= hicell[1]; yi++)
         {
-            const Real yf = std::min(hilen[1]-yi,1_rt)-std::max(lolen[1]-yi,0_rt);
+            const Real yf = std::min(hilen[1]-yi,Real(1.0))-std::max(lolen[1]-yi,Real(0.0));
             for (int xi = locell[0]; xi <= hicell[0]; xi++)
             {
                 cells[i][0] = xi;
                 cells[i][1] = yi;
                 cells[i][2] = zi;
-                fracs[i] = zf * yf * (std::min(hilen[0]-xi,1_rt)-std::max(lolen[0]-xi,0_rt)) * cell_density;
+                fracs[i] = zf * yf * (std::min(hilen[0]-xi,Real(1.0))-std::max(lolen[0]-xi,Real(0.0))) * cell_density;
                 i++;
             }
         }

--- a/Src/Particle/AMReX_Particle_mod_K.H
+++ b/Src/Particle/AMReX_Particle_mod_K.H
@@ -21,7 +21,7 @@ void amrex_deposit_cic (P const& p, int nc, amrex::Array4<amrex::Real> const& rh
     
     amrex::Real xint = lx - i;
     
-    amrex::Real sx[2] = {1.0_rt - xint, xint};
+    amrex::Real sx[2] = {Real(1.0) - xint, xint};
     
     for (int ii = 0; ii <= 1; ++ii) { 
         amrex::Gpu::Atomic::Add(&rho(i+ii-1, 0, 0, 0), static_cast<Real>(sx[ii]*p.rdata(0)));
@@ -43,8 +43,8 @@ void amrex_deposit_cic (P const& p, int nc, amrex::Array4<amrex::Real> const& rh
     amrex::Real xint = lx - i;
     amrex::Real yint = ly - j;
 
-    amrex::Real sx[2] = {1.0_rt - xint, xint};
-    amrex::Real sy[2] = {1.0_rt - yint, yint};
+    amrex::Real sx[2] = {Real(1.0) - xint, xint};
+    amrex::Real sy[2] = {Real(1.0) - yint, yint};
 
     for (int jj = 0; jj <= 1; ++jj) { 
         for (int ii = 0; ii <= 1; ++ii) { 
@@ -75,9 +75,9 @@ void amrex_deposit_cic (P const& p, int nc, amrex::Array4<amrex::Real> const& rh
     amrex::Real yint = ly - j;
     amrex::Real zint = lz - k;
 
-    amrex::Real sx[] = {1.0_rt - xint, xint};
-    amrex::Real sy[] = {1.0_rt - yint, yint};
-    amrex::Real sz[] = {1.0_rt - zint, zint};
+    amrex::Real sx[] = {Real(1.0) - xint, xint};
+    amrex::Real sy[] = {Real(1.0) - yint, yint};
+    amrex::Real sz[] = {Real(1.0) - zint, zint};
     
     for (int kk = 0; kk <= 1; ++kk) { 
         for (int jj = 0; jj <= 1; ++jj) { 
@@ -249,7 +249,7 @@ void amrex_interpolate_cic (P const& p, int nc, amrex::Array4<amrex::Real const>
     
     amrex::Real xint = lx - i;
     
-    amrex::Real sx[] = {1.0_rt-xint, xint};
+    amrex::Real sx[] = {Real(1.0)-xint, xint};
 
     for (int comp=0; comp < nc; ++comp) {    
         for (int ii = 0; ii <= 1; ++ii) { 
@@ -267,8 +267,8 @@ void amrex_interpolate_cic (P const& p, int nc, amrex::Array4<amrex::Real const>
     amrex::Real xint = lx - i;
     amrex::Real yint = ly - j;
     
-    amrex::Real sx[] = {1.0_rt-xint, xint};
-    amrex::Real sy[] = {1.0_rt-yint, yint};
+    amrex::Real sx[] = {Real(1.0)-xint, xint};
+    amrex::Real sy[] = {Real(1.0)-yint, yint};
 
     for (int comp=0; comp < nc; ++comp) {    
         for (int jj = 0; jj <= 1; ++jj) { 
@@ -291,9 +291,9 @@ void amrex_interpolate_cic (P const& p, int nc, amrex::Array4<amrex::Real const>
     amrex::Real yint = ly - j;
     amrex::Real zint = lz - k;
     
-    amrex::Real sx[] = {1.0_rt-xint, xint};
-    amrex::Real sy[] = {1.0_rt-yint, yint};
-    amrex::Real sz[] = {1.0_rt-zint, zint};
+    amrex::Real sx[] = {Real(1.0)-xint, xint};
+    amrex::Real sy[] = {Real(1.0)-yint, yint};
+    amrex::Real sz[] = {Real(1.0)-zint, zint};
 
     for (int comp=0; comp < nc; ++comp) {                    
         for (int kk = 0; kk <= 1; ++kk) { 

--- a/Src/Particle/AMReX_TracerParticle_mod_K.H
+++ b/Src/Particle/AMReX_TracerParticle_mod_K.H
@@ -31,11 +31,11 @@ void cic_interpolate (const P& p,
 
     amrex::Real xint = lx - i; //frac
 
-    amrex::Real sx[] = {1._rt - xint, xint};
+    amrex::Real sx[] = {Real(1.0) - xint, xint};
 
     for (int d=0; d < AMREX_SPACEDIM; ++d)
     {
-        val[d] = 0.0_prt;
+        val[d] = ParticleReal(0.0);
         for (int ii = 0; ii<=1; ++ii)
 	{
             val[d] += static_cast<ParticleReal>(sx[ii]*uccarr(i+ii,0,0,d));
@@ -54,12 +54,12 @@ void cic_interpolate (const P& p,
     amrex::Real xint = lx - i;
     amrex::Real yint = ly - j;
 
-    amrex::Real sx[] = {1._rt - xint, xint};
-    amrex::Real sy[] = {1._rt - yint, yint};
+    amrex::Real sx[] = {Real(1.0) - xint, xint};
+    amrex::Real sy[] = {Real(1.0) - yint, yint};
 
     for (int d=0; d < AMREX_SPACEDIM; ++d)
       {
-        val[d] = 0.0_prt;
+        val[d] = ParticleReal(0.0);
         for (int jj = 0; jj <= 1; ++jj)
 	  {
             for (int ii = 0; ii <= 1; ++ii)
@@ -84,13 +84,13 @@ void cic_interpolate (const P& p,
     amrex::Real const yint = ly - j;
     amrex::Real const zint = lz - k;
 
-    amrex::Real sx[] = {1._rt - xint, xint};
-    amrex::Real sy[] = {1._rt - yint, yint};
-    amrex::Real sz[] = {1._rt - zint, zint};
+    amrex::Real sx[] = {Real(1.0) - xint, xint};
+    amrex::Real sy[] = {Real(1.0) - yint, yint};
+    amrex::Real sz[] = {Real(1.0) - zint, zint};
 
     for (int d=0; d < AMREX_SPACEDIM; ++d)
     {
-        val[d] = 0.0_prt;
+        val[d] = ParticleReal(0.0);
         for (int kk = 0; kk<=1; ++kk)
 	{
             for (int jj = 0; jj <= 1; ++jj)
@@ -125,9 +125,9 @@ void mac_interpolate (const P& p,
 
         amrex::Real const xint = lx - i;
 
-        amrex::Real sx[] = {1._rt - xint, xint};
+        amrex::Real sx[] = {Real(1.0) - xint, xint};
 
-        val[d] = 0.0_prt;
+        val[d] = ParticleReal(0.0);
         for (int ii = 0; ii <= 1; ++ii)
         {
             val[d] += static_cast<ParticleReal>((p_uccarr[d])(i+ii, 0, 0, 0)*sx[ii]);
@@ -147,10 +147,10 @@ void mac_interpolate (const P& p,
       amrex::Real const xint = lx - i;
       amrex::Real const yint = ly - j;
 
-      amrex::Real sx[] = {1._rt - xint, xint};
-      amrex::Real sy[] = {1._rt - yint, yint};
+      amrex::Real sx[] = {Real(1.0) - xint, xint};
+      amrex::Real sy[] = {Real(1.0) - yint, yint};
 
-      val[d] = 0.0_prt;
+      val[d] = ParticleReal(0.0);
       for (int jj = 0; jj <= 1; ++jj)
       {
           for (int ii = 0; ii <= 1; ++ii)
@@ -177,11 +177,11 @@ void mac_interpolate (const P& p,
       amrex::Real const yint = ly - j;
       amrex::Real const zint = lz - k;
 
-      amrex::Real sx[] = {1._rt - xint, xint};
-      amrex::Real sy[] = {1._rt - yint, yint};
-      amrex::Real sz[] = {1._rt - zint, zint};
+      amrex::Real sx[] = {Real(1.0) - xint, xint};
+      amrex::Real sy[] = {Real(1.0) - yint, yint};
+      amrex::Real sz[] = {Real(1.0) - zint, zint};
 
-      val[d] = 0.0_prt;
+      val[d] = ParticleReal(0.0);
       for (int kk = 0; kk <=1; ++kk)
       {
 	  for (int jj = 0; jj <= 1; ++jj)

--- a/Src/Particle/AMReX_TracerParticles.cpp
+++ b/Src/Particle/AMReX_TracerParticles.cpp
@@ -87,7 +87,7 @@ TracerParticleContainer::AdvectWithUmac (MultiFab* umac, int lev, Real dt)
                     for (int dim=0; dim < AMREX_SPACEDIM; dim++)
                     {
                         p.rdata(dim) = p.pos(dim);
-                        p.pos(dim) += static_cast<ParticleReal>(0.5_prt*dt*v[dim]);
+                        p.pos(dim) += static_cast<ParticleReal>(ParticleReal(0.5)*dt*v[dim]);
                     }
                 }
                 else
@@ -167,7 +167,7 @@ TracerParticleContainer::AdvectWithUcc (const MultiFab& Ucc, int lev, Real dt)
                     for (int dim=0; dim < AMREX_SPACEDIM; dim++)
                     {
                         p.rdata(dim) = p.pos(dim);
-                        p.pos(dim) += static_cast<ParticleReal>(0.5_prt*dt*v[dim]);
+                        p.pos(dim) += static_cast<ParticleReal>(ParticleReal(0.5)*dt*v[dim]);
                     }
                 }
                 else


### PR DESCRIPTION
The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
