### PR TITLE
fix a semicoarsening bug for nodal solver

### DIFF
--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLap_1D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLap_1D_K.H
@@ -32,6 +32,11 @@ void mlndlap_avgdown_coeff_x (int /*i*/, int /*j*/, int /*k*/, Array4<Real> cons
                               Array4<Real const> const& fine) noexcept
 {}
 
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void mlndlap_semi_avgdown_coeff (int /*i*/, int /*j*/, int /*k*/, Array4<Real> const& crse,
+                              Array4<Real const> const& fine, int idir) noexcept
+{}
+
 template <typename T>
 inline void mlndlap_bc_doit (Box const& vbx, Array4<T> const& a, Box const& domain,
                              GpuArray<bool,AMREX_SPACEDIM> const& bflo,

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLap_2D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLap_2D_K.H
@@ -159,6 +159,21 @@ void mlndlap_avgdown_coeff_y (int i, int j, int k, Array4<Real> const& crse,
     crse(i,j,k) = a*b/(a+b);
 }
 
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void mlndlap_semi_avgdown_coeff (int i, int j, int k, Array4<Real> const& crse,
+                              Array4<Real const> const& fine, int idir) noexcept
+{   
+    if (idir == 1) {
+        Real a = fine(2*i  ,j,k);
+        Real b = fine(2*i+1,j,k);
+        crse(i,j,k) = 2.0*a*b/(a+b);
+    } else {
+        Real a = fine(i,2*j  ,k);
+        Real b = fine(i,2*j+1,k);
+        crse(i,j,k) = 2.0*a*b/(a+b);
+    }
+}
+
 //
 // bc
 //

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLap_3D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLap_3D_K.H
@@ -228,6 +228,24 @@ void mlndlap_avgdown_coeff_z (int i, int j, int k, Array4<Real> const& crse,
     crse(i,j,k) = 0.5*cl*cr/(cl+cr);
 }
 
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void mlndlap_semi_avgdown_coeff (int i, int j, int k, Array4<Real> const& crse,
+                              Array4<Real const> const& fine, int idir) noexcept
+{
+    if (idir == 2) {
+        Real cl = fine(2*i  ,2*j,k) + fine(2*i  ,2*j+1,k);
+        Real cr = fine(2*i+1,2*j,k) + fine(2*i+1,2*j+1,k);
+        crse(i,j,k) = cl*cr/(cl+cr);    
+    } else if (idir == 1) {
+        Real cl = fine(2*i  ,j,2*k) + fine(2*i  ,j,2*k+1);
+        Real cr = fine(2*i+1,j,2*k) + fine(2*i+1,j,2*k+1);
+        crse(i,j,k) = cl*cr/(cl+cr);
+    } else {
+        Real cl = fine(i,2*j  ,2*k) + fine(i,2*j  ,2*k+1);
+        Real cr = fine(i,2*j+1,2*k) + fine(i,2*j+1,2*k+1);
+        crse(i,j,k) = cl*cr/(cl+cr);
+    }
+}
 //
 // bc
 //

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian.cpp
@@ -751,7 +751,7 @@ MLNodeLaplacian::averageDownCoeffsSameAmrLevel (int amrlev)
             bool need_parallel_copy = !amrex::isMFIterSafe(crse, fine);
             MultiFab cfine;
             if (need_parallel_copy) {
-                const BoxArray& ba = amrex::coarsen(fine.boxArray(), 2);
+                const BoxArray& ba = amrex::coarsen(fine.boxArray(), ratio);
                 cfine.define(ba, fine.DistributionMap(), 1, 0);
             }
 
@@ -796,19 +796,10 @@ MLNodeLaplacian::averageDownCoeffsSameAmrLevel (int amrlev)
                     const Box& bx = mfi.tilebox();
                     Array4<Real> const& cfab = pcrse->array(mfi);
                     Array4<Real const> const& ffab = fine.const_array(mfi);
-                    if (idir != 0) {
-                        AMREX_HOST_DEVICE_PARALLEL_FOR_3D ( bx, i, j, k,
-                        {
-                            mlndlap_avgdown_coeff_x(i,j,k,cfab,ffab);
-                        });
-                    } else {
-#if (AMREX_SPACEDIM >= 2)
-                        AMREX_HOST_DEVICE_PARALLEL_FOR_3D ( bx, i, j, k,
-                        {
-                            mlndlap_avgdown_coeff_y(i,j,k,cfab,ffab);
-                        });
-#endif
-                    } 
+                    AMREX_HOST_DEVICE_PARALLEL_FOR_3D ( bx, i, j, k,
+                    {
+                        mlndlap_semi_avgdown_coeff(i,j,k,cfab,ffab,idir);
+                    });
                 }
             }
             if (need_parallel_copy) {


### PR DESCRIPTION
## Summary
Fix a semicoarsening bug for nodal solver.
## Additional background
In avgdown coefficient, there is a place use coarsen ratio instead of the mg_coarsen_ratio_vec. Also, build the semi_avgdown for nodal solver. 
## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
