### PR TITLE
Fixes for Amrvis warnings

### DIFF
--- a/Src/Base/AMReX_BLProfiler.cpp
+++ b/Src/Base/AMReX_BLProfiler.cpp
@@ -513,11 +513,13 @@ namespace BLProfilerUtils {
 void WriteHeader(std::ostream &ios, const int colWidth,
                  const Real maxlen, const bool bwriteavg)
 {
+  int maxlenI = int(maxlen);
+
   if(bwriteavg) {
-    ios << std::setfill('-') << std::setw(maxlen+4 + 7 * (colWidth+2))
+    ios << std::setfill('-') << std::setw(maxlenI+4 + 7 * (colWidth+2))
         << std::left << "Total times " << '\n';
     ios << std::right << std::setfill(' ');
-    ios << std::setw(maxlen + 2) << "Function Name"
+    ios << std::setw(maxlenI + 2) << "Function Name"
         << std::setw(colWidth + 2) << "NCalls"
         << std::setw(colWidth + 2) << "Min"
         << std::setw(colWidth + 2) << "Avg"
@@ -527,10 +529,10 @@ void WriteHeader(std::ostream &ios, const int colWidth,
         << std::setw(colWidth + 4) << "Percent %"
         << '\n';
   } else {
-    ios << std::setfill('-') << std::setw(maxlen+4 + 3 * (colWidth+2))
+    ios << std::setfill('-') << std::setw(maxlenI+4 + 3 * (colWidth+2))
         << std::left << "Total times " << '\n';
     ios << std::right << std::setfill(' ');
-    ios << std::setw(maxlen + 2) << "Function Name"
+    ios << std::setw(maxlenI + 2) << "Function Name"
         << std::setw(colWidth + 2) << "NCalls"
         << std::setw(colWidth + 2) << "Time"
         << std::setw(colWidth + 4) << "Percent %"
@@ -544,6 +546,7 @@ void WriteRow(std::ostream &ios, const std::string &fname,
 	      const int colWidth, const Real maxlen,
 	      const bool bwriteavg)
 {
+    int maxlenI = int(maxlen);
     int numPrec(4), pctPrec(2);
     Real stdDev(0.0), coeffVariation(0.0);
     if(pstats.variance > 0.0) {
@@ -555,7 +558,7 @@ void WriteRow(std::ostream &ios, const std::string &fname,
 
     if(bwriteavg) {
       ios << std::right;
-      ios << std::setw(maxlen + 2) << fname << "  "
+      ios << std::setw(maxlenI + 2) << fname << "  "
           << std::setw(colWidth) << pstats.nCalls << "  "
           << std::setprecision(numPrec) << std::fixed << std::setw(colWidth)
 	  << pstats.minTime << "  "
@@ -570,7 +573,7 @@ void WriteRow(std::ostream &ios, const std::string &fname,
           << std::setprecision(pctPrec) << std::fixed << std::setw(colWidth)
 	  << percent << " %" << '\n';
     } else {
-      ios << std::setw(maxlen + 2) << fname << "  "
+      ios << std::setw(maxlenI + 2) << fname << "  "
           << std::setw(colWidth) << pstats.nCalls << "  "
           << std::setprecision(numPrec) << std::fixed << std::setw(colWidth)
 	  << pstats.totalTime << "  "
@@ -770,7 +773,7 @@ void WriteStats(std::ostream &ios,
 }  // end namespace BLProfilerUtils
 
 void BLProfiler::WriteBaseProfile(bool bFlushing, bool memCheck) {   // ---- write basic profiling data
-
+  amrex::ignore_unused(memCheck);
   // --------------------------------------- gather global stats
   Real baseProfStart(amrex::second());  // time the timer
   const int nProcs(ParallelDescriptor::NProcs());
@@ -1162,8 +1165,9 @@ void BLProfiler::WriteCallTrace(bool bFlushing, bool memCheck) {   // ---- write
 
 
 
-void BLProfiler::WriteCommStats(bool bFlushing, bool memCheck) {
-
+void BLProfiler::WriteCommStats(bool bFlushing, bool memCheck)
+{
+  amrex::ignore_unused(bFlushing);
   Real wcsStart(amrex::second());
   bool bAllCFTypesExcluded(OnExcludeList(AllCFTypes));
   if( ! bAllCFTypesExcluded) {
@@ -1461,6 +1465,7 @@ void BLProfiler::AddAllReduce(const CommFuncType cft, const int size,
 void BLProfiler::AddWait(const CommFuncType cft, const MPI_Request &req,
 			 const MPI_Status &status, const bool beforecall)
 {
+  amrex::ignore_unused(req);
 #ifdef BL_USE_MPI
   if(OnExcludeList(cft)) {
     return;
@@ -1481,6 +1486,7 @@ void BLProfiler::AddWaitsome(const CommFuncType cft, const Vector<MPI_Request> &
                              const int completed, const Vector<MPI_Status> &status,
                              const bool beforecall)
 {
+  amrex::ignore_unused(reqs);
 #ifdef BL_USE_MPI
   if(OnExcludeList(cft)) {
     return;

--- a/Src/Base/AMReX_BoxList.cpp
+++ b/Src/Base/AMReX_BoxList.cpp
@@ -425,7 +425,7 @@ BoxList::parallelComplementIn (const Box& b, BoxArray const& ba)
     }
     else
     {
-        BL_PROFILE("BoxList::pci");
+        BL_PROFILE_VAR("BoxList::pci", boxlistpci);
 
         Long npts_avgbox;
         Box mbox = ba.minimalBox(npts_avgbox);

--- a/Src/Extern/ProfParser/AMReX_BLProfStats.H
+++ b/Src/Extern/ProfParser/AMReX_BLProfStats.H
@@ -168,54 +168,54 @@ class BLProfStats {
                               bool graphTopPct = true);
     virtual void AddCalcEndTime(double cet) { calcEndTime = cet; }
 
-    virtual void SetCPVersion(const int cpv) { }
-    virtual void SetCSSize(const int css) { }
-    virtual void InitCommDataBlock(const int proc, const long ncommstats,
-                               const std::string &filename, const long seekpos,
-			       const std::string &nodename = "",
-			       const int nodenumber = -1) { }
-    virtual void AddBarrier(long bnum, const std::string &bname, long index) { }
-    virtual void AddReduction(const long rnum, const long index) { }
-    virtual void AddTimeMinMax(const double tmin, const double tmax) { }
-    virtual void AddTimerTime(const double tt) { }
-    virtual void AddNameTag(const long ntnindex, const long seekindex) { }
-    virtual void AddNameTagName(const std::string &name) { }
-    virtual void AddTagRange(const long tmin, const long tmax) { }
-    virtual void AddGridLevel(const int level, const int ngrids) { }
-    virtual void AddGrid3D(int level, int xlo, int ylo, int zlo,
-                           int xhi, int yhi, int zhi,
-                           int xc,  int yc,  int zc,
-                           int xn,  int yn,  int zn, int proc) { }
-    virtual void AddFinestLevel(const int lev) { }
-    virtual void AddMaxLevel(const int lev) { }
-    virtual void AddRefRatio(const int lev, const amrex::IntVect &rr) { }
-    virtual void AddTopoCoord(const int nid, const int node,
-                      const int tx, const int ty, const int tz,
-                      const bool servicenode = false) { }
+    virtual void SetCPVersion(const int /*cpv*/) { }
+    virtual void SetCSSize(const int /*css*/) { }
+    virtual void InitCommDataBlock(const int /*proc*/, const long /*ncommstats*/,
+                               const std::string &/*filename*/, const long /*seekpos*/,
+			       const std::string &/*nodename*/ = "",
+			       const int /*nodenumber*/ = -1) { }
+    virtual void AddBarrier(long /*bnum*/, const std::string &/*bname*/, long /*index*/) { }
+    virtual void AddReduction(const long /*rnum*/, const long /*index*/) { }
+    virtual void AddTimeMinMax(const double /*tmin*/, const double /*tmax*/) { }
+    virtual void AddTimerTime(const double /*tt*/) { }
+    virtual void AddNameTag(const long /*ntnindex*/, const long /*seekindex*/) { }
+    virtual void AddNameTagName(const std::string &/*name*/) { }
+    virtual void AddTagRange(const long /*tmin*/, const long /*tmax*/) { }
+    virtual void AddGridLevel(const int /*level*/, const int /*ngrids*/) { }
+    virtual void AddGrid3D(int /*level*/, int /*xlo*/, int /*ylo*/, int /*zlo*/,
+                           int /*xhi*/,   int /*yhi*/, int /*zhi*/,
+                           int /*xc*/,    int /*yc*/,  int /*zc*/,
+                           int /*xn*/,    int /*yn*/,  int /*zn*/, int /*proc*/) { }
+    virtual void AddFinestLevel(const int /*lev*/) { }
+    virtual void AddMaxLevel(const int /*lev*/) { }
+    virtual void AddRefRatio(const int /*lev*/, const amrex::IntVect &/*rr*/) { }
+    virtual void AddTopoCoord(const int /*nid*/, const int /*node*/,
+                      const int /*tx*/, const int /*ty*/, const int /*tz*/,
+                      const bool /*servicenode*/ = false) { }
 
-    virtual void AddCommHeaderFileName(const std::string &hfn) { }
-    virtual void SetCSVersion(int csv)  { }
-    virtual void AddCStatsHeaderFileName(const std::string &hfn) { }
-    virtual void AddFunctionName(const std::string &fname, int fnumber) { }
-    virtual void InitCStatsDataBlock(int proc, long nrss, long ntracestats,
-                                     const std::string &filename, long seekpos) { }
+    virtual void AddCommHeaderFileName(const std::string &/*hfn*/) { }
+    virtual void SetCSVersion(int /*csv*/)  { }
+    virtual void AddCStatsHeaderFileName(const std::string &/*hfn*/) { }
+    virtual void AddFunctionName(const std::string &/*fname*/, int /*fnumber*/) { }
+    virtual void InitCStatsDataBlock(int /*proc*/, long /*nrss*/, long /*ntracestats*/,
+                                     const std::string &/*filename*/, long /*seekpos*/) { }
     static void SetInitDataBlocks(bool b) { bInitDataBlocks = b;    }
     static bool InitDBlocks()             { return bInitDataBlocks; }
 
     static void SetGPercent(Real p)  { gPercent = p/100.0; }
 
-    virtual void AddProbDomain(const int lev, const amrex::Box &pd) { }
-    virtual TimeRange MakeRegionPlt(amrex::FArrayBox &rFab, int noregionnumber,
-                               int width, int height,
-			       amrex::Vector<amrex::Vector<amrex::Box>> &regionBoxes)
+    virtual void AddProbDomain(const int /*lev*/, const amrex::Box &/*pd*/) { }
+    virtual TimeRange MakeRegionPlt(amrex::FArrayBox &/*rFab*/, int /*noregionnumber*/,
+                               int /*width*/, int /*height*/,
+			       amrex::Vector<amrex::Vector<amrex::Box>> &/*regionBoxes*/)
 			       { return TimeRange(); }
 
     static void OpenAllStreams(const std::string &dirname);
     static void CloseAllStreams();
 
-    virtual void AddEdisonPID(int X, int Y, int Z,
-                              int col, int row, int cage, int slot,
-                              int cpu, int pid) { }
+    virtual void AddEdisonPID(int /*X*/,   int /*Y*/, int /*Z*/,
+                              int /*col*/, int /*row*/, int /*cage*/, int /*slot*/,
+                              int /*cpu*/, int /*pid*/) { }
 
     static bool TimeRangeInitialized() { return bTimeRangeInitialized; }
 

--- a/Src/Extern/ProfParser/AMReX_BLProfStats.cpp
+++ b/Src/Extern/ProfParser/AMReX_BLProfStats.cpp
@@ -243,7 +243,7 @@ void BLProfStats::MakeFilterFile(const std::string &ffname) {
 
 // ----------------------------------------------------------------------
 void BLProfStats::SetFilter(BLProfStats::FilterStatus fs,
-                            const std::string &ffname, int rnumber)
+                            const std::string &/*ffname*/, int rnumber)
 {
   if(fs == BLProfStats::FilterStatus::ON) {
     includeSet.insert(rnumber);
@@ -473,7 +473,7 @@ void BLProfStats::ReadBlock(BLPDataBlock &dBlock) {
 
 
 // ----------------------------------------------------------------------
-void BLProfStats::ReadBlockNoOpen(BLPDataBlock &dBlock)
+void BLProfStats::ReadBlockNoOpen(BLPDataBlock &/*dBlock*/)
 {
 amrex::Abort("not implemented yet.");
 }
@@ -513,7 +513,7 @@ void BLProfStats::CollectFuncStats(Vector<Vector<FuncStat> > &funcStats)
 
 
 // ----------------------------------------------------------------------
-void BLProfStats::WriteSummary(std::ostream &ios, bool bwriteavg,
+void BLProfStats::WriteSummary(std::ostream &ios, bool /*bwriteavg*/,
                                int whichProc, bool graphTopPct)
 {
   if( ! ParallelDescriptor::IOProcessor()) {

--- a/Src/Extern/ProfParser/AMReX_BLProfUtilities.cpp
+++ b/Src/Extern/ProfParser/AMReX_BLProfUtilities.cpp
@@ -208,7 +208,7 @@ void amrex::RedistFiles() {
       iss.open(readCPHFile.c_str(), std::ios::in);
       iss.seekg(0, std::ios::end);
       long fileLength(iss.tellg());
-      char charBuf[fileLength];
+      char* charBuf = (char*) malloc(fileLength);
       iss.seekg(0, std::ios::beg);
       iss.read(charBuf, fileLength);
       iss.close();
@@ -216,13 +216,14 @@ void amrex::RedistFiles() {
       oss.open(writeCPHFile.c_str(), std::ios::out);
       oss.write(charBuf, fileLength);
       oss.close();
+      free(charBuf);
     }
 
     {  // header files
       iss.open(readHFile.c_str(), std::ios::in);
       iss.seekg(0, std::ios::end);
       long fileLength(iss.tellg());
-      char charBuf[fileLength];
+      char* charBuf = (char*) malloc(fileLength);
       iss.seekg(0, std::ios::beg);
       iss.read(charBuf, fileLength);
       iss.close();
@@ -230,13 +231,14 @@ void amrex::RedistFiles() {
       oss.open(writeHFile.c_str(), std::ios::out);
       oss.write(charBuf, fileLength);
       oss.close();
+      free(charBuf);
     }
 
     {  // data files
       iss.open(readDFile.c_str(), std::ios::in);
       iss.seekg(0, std::ios::end);
       long fileLength(iss.tellg());
-      char charBuf[fileLength];
+      char* charBuf = (char*) malloc(fileLength);
       iss.seekg(0, std::ios::beg);
       iss.read(charBuf, fileLength);
       iss.close();
@@ -244,6 +246,7 @@ void amrex::RedistFiles() {
       oss.open(writeDFile.c_str(), std::ios::out);
       oss.write(charBuf, fileLength);
       oss.close();
+      free(charBuf);
     }
 }
 

--- a/Src/Extern/ProfParser/AMReX_CommProfStats.H
+++ b/Src/Extern/ProfParser/AMReX_CommProfStats.H
@@ -121,7 +121,7 @@ class CommProfStats : public BLProfStats {
       inline static long HashLong(int fp, int tp, int t) {
 	return(fp + tp + 64*t);
       }
-      inline static long HashLong(int fp, int tp, int ds, int t) {
+      inline static long HashLong(int fp, int tp, int /*ds*/, int t) {
 	//if(fp < 0 || tp < 0 || ds < 0 || t < 0) {
 	  //cout << ":::: HashLong:  negative values:  fp tp ds t = "
 	       //<< fp << "  " << tp << "  " << ds << "  " << t << endl;

--- a/Src/Extern/ProfParser/AMReX_CommProfStats.cpp
+++ b/Src/Extern/ProfParser/AMReX_CommProfStats.cpp
@@ -156,7 +156,7 @@ void CommProfStats::InitCommDataBlock(const int proc, const long ncommstats,
 
 
 // ----------------------------------------------------------------------
-int CommProfStats::AfterBarrier(const int proc, const double t) {
+int CommProfStats::AfterBarrier(const int /*proc*/, const double /*t*/) {
 /*
   if(bExitTimesDone) {
     if(barrierExitTimes[proc][0] > t) {
@@ -238,14 +238,14 @@ void CommProfStats::AddTimerTime(const double tt) {
 
 
 // ----------------------------------------------------------------------
-void CommProfStats::AddGridLevel(const int level, const int ngrids) {
+void CommProfStats::AddGridLevel(const int /*level*/, const int /*ngrids*/) {
 }
 
 
 // ----------------------------------------------------------------------
-void CommProfStats::AddGrid3D(int level, int xlo, int ylo, int zlo,
-			      int xhi, int yhi, int zhi,
-			      int xc,  int yc,  int zc,
+void CommProfStats::AddGrid3D(int /*level*/, int /*xlo*/, int /*ylo*/, int /*zlo*/,
+			      int /*xhi*/, int /*yhi*/, int /*zhi*/,
+			      int /*xc*/,  int /*yc*/,  int /*zc*/,
 			      int xn,  int yn,  int zn, int proc)
 {
   long nPoints(xn * yn * zn);
@@ -286,9 +286,10 @@ void CommProfStats::AddProbDomain(const int level, const Box &pd) {
 // ----------------------------------------------------------------------
 void CommProfStats::AddTopoCoord(const int nid, const int node,
                                  const int tx, const int ty, const int tz,
-                                 const bool servicenode)
+                                 const bool /*servicenode*/)
 {
 #if (BL_SPACEDIM == 2)
+  amrex::ignore_unused(nid, node, tx, ty, tz);
   cout << "**** Error:  CommProfStats::AddTopoCoord not supported for 2D" << endl;
 #else
   cout << "TopoMap.size() = " << TopoMap.size() << " nid node = " << nid << "  " << node << endl;
@@ -867,6 +868,8 @@ void CommProfStats::ReportStats(long &totalSentData, long &totalNCommStats,
                                 Real &timeMin, Real &timeMax, Real &timerTime,
 				Vector<int> &rankNodeNumbers)
 {
+  amrex::ignore_unused(timerTime);
+
   amrex::Print(Print::AllProcs) << ParallelDescriptor::MyProc() << "::Processing "
                                 << dataBlocks.size() << " data blocks:" << endl;
 
@@ -956,6 +959,8 @@ void CommProfStats::TimelineFAB(FArrayBox &timelineFAB, const Box &probDomain,
 {
   BL_PROFILE("CommProfStats::TimelineFAB()");
 
+  amrex::ignore_unused(rankMin, rankMax, ntnMultiplier, bnMultiplier);
+
   Real tlo = tr.startTime;
   Real thi = tr.stopTime;
   Real timeRangeAll(thi - tlo);
@@ -997,7 +1002,7 @@ void CommProfStats::TimelineFAB(FArrayBox &timelineFAB, const Box &probDomain,
       BLProfiler::CommStats &cs = dBlock.vCommStats[i];
       Real ts(cs.timeStamp);
       if((ts <= fabTimeHi && ts >= fabTimeLo) && InTimeRange(dBlock.proc, ts)) {  // within time range
-        xi = nTimeSlotsFab * ((ts - fabTimeLo) * ooTimeRangeFab);
+        xi = long( nTimeSlotsFab * ((ts - fabTimeLo) * ooTimeRangeFab) );
 	if(xi == nTimeSlotsFab) {
 	  --xi;
 	}
@@ -1064,7 +1069,7 @@ void CommProfStats::TimelineFAB(FArrayBox &timelineFAB, const Box &probDomain,
 	      cout << "::::  prevTs fabTimeLo = " << prevTs << "  " << fabTimeLo << endl;
 	      prevTs = fabTimeLo;
 	    }
-            long prevXi(nTimeSlotsFab * ((prevTs - fabTimeLo) * ooTimeRangeFab));
+            long prevXi = long(nTimeSlotsFab * ((prevTs - fabTimeLo) * ooTimeRangeFab));
             prevIndex = (((proc - fabRankLo) / rankStride) * nTimeSlotsFab) + prevXi;
 	    for(long idx(prevIndex); idx < index; ++idx) {
 	      if(idx < 0 || idx >= timelineFAB.box().numPts() || idx > index) {
@@ -1174,6 +1179,8 @@ void CommProfStats::SendRecvList(std::multimap<Real, SendRecvPairUnpaired> &srMM
 void CommProfStats::SendRecvData(const std::string &filenameprefix,
                                   const double tlo, const double thi)
 {
+  amrex::ignore_unused(filenameprefix, tlo, thi);
+
   double dstart(amrex::ParallelDescriptor::second());
   Real timeMin(std::numeric_limits<Real>::max());
   Real timeMax(-std::numeric_limits<Real>::max());
@@ -1234,7 +1241,7 @@ void CommProfStats::SendRecvData(const std::string &filenameprefix,
     for(int idb(0); idb < dataBlocks.size(); ++idb) {
       //cout << "idb dB.proc = " << idb << "  " << dataBlocks[idb].proc << endl;
       //cout << idb << "  " << dataBlocks[idb].proc << endl;
-      int t0(dataBlocks[idb].timeMin * 1.0);
+      int t0 = int(dataBlocks[idb].timeMin * 1.0);
       idbMM[t0].insert(std::pair<int, int>(dataBlocks[idb].proc, idb));
       ++countI;
     }
@@ -1265,7 +1272,9 @@ void CommProfStats::SendRecvData(const std::string &filenameprefix,
 
 
   while(anyDataLeft) {
+#ifdef _OPENMP
 #pragma omp parallel for
+#endif
   //for(idb = 0; idb < dataBlocks.size(); ++idb) {
   for(int idbII = 0; idbII < dataBlocks.size(); ++idbII) {
     int idb(idbIndex[idbII]);
@@ -1836,6 +1845,8 @@ void CommProfStats::AddEdisonPID(int X, int Y, int Z,
                                  int cab, int row, int cage, int slot,
                                  int cpu, int pid)
 {
+  amrex::ignore_unused(cage, slot);
+
   int ix, iy, iz, index;
   int ixGroup, ixCab, ixSlot, ixNode, iyCage, iySlot, izGroup, izNode;
 

--- a/Src/Extern/ProfParser/AMReX_ProfParserBatch.cpp
+++ b/Src/Extern/ProfParser/AMReX_ProfParserBatch.cpp
@@ -99,6 +99,8 @@ bool ProfParserBatchFunctions(int argc, char *argv[], bool runDefault,
   string outfileName, delimString("\t");
   Vector<string> actFNames;
 
+  amrex::ignore_unused(bParseFilterFile);
+
   bParserProf = false;
 
   if(argc > 2) {  // parse the command line

--- a/Src/Extern/ProfParser/AMReX_RegionsProfStats.H
+++ b/Src/Extern/ProfParser/AMReX_RegionsProfStats.H
@@ -72,6 +72,8 @@ class RegionsProfStats : public BLProfStats {
     void SetMaxFNumber(int n)  { maxFNumber = n; }
     int  GetMaxFNumber() const  { return maxFNumber; }
 
+    void AddFunctionName(const std::string &/*fname*/)
+        { amrex::Abort("Wrong AddFunctionName for RegionsProfStats. Use (string, int)."); }
     virtual void AddFunctionName(const std::string &fname, int fnumber);
     virtual void AddTimeMinMax(double tmin, double tmax);
 

--- a/Src/Extern/ProfParser/AMReX_RegionsProfStats.cpp
+++ b/Src/Extern/ProfParser/AMReX_RegionsProfStats.cpp
@@ -204,6 +204,8 @@ BLProfStats::TimeRange RegionsProfStats::MakeRegionPlt(FArrayBox &rFab, int nore
                                      int width, int height,
 				     Vector<Vector<Box>> &regionBoxes)
 {
+  amrex::ignore_unused(noregionnumber);
+
 #if (BL_SPACEDIM != 2)
   cout << "**** Error:  RegionsProfStats::MakeRegionPlt only supported for 2D" << endl;
   return TimeRange(0, 0);
@@ -255,8 +257,8 @@ BLProfStats::TimeRange RegionsProfStats::MakeRegionPlt(FArrayBox &rFab, int nore
         } else {                             // stopping
           Real rtStart(rStartTime[rss.rssRNumber]), rtStop(rss.rssTime);
           rStartTime[rss.rssRNumber] = -1.0;
-          int xStart(xLength * rtStart / timeMax);
-          int xStop(xLength * rtStop / timeMax);
+          int xStart = int(xLength * rtStart / timeMax);
+          int xStop = int(xLength * rtStop / timeMax);
 	  xStop = std::min(xStop, xLength - 1);
           int yLo(rss.rssRNumber * yHeight), yHi(((rss.rssRNumber + 1) *  yHeight) - 1);
           Box rBox(IntVect(xStart, yLo), IntVect(xStop, yHi));
@@ -505,7 +507,7 @@ bool RegionsProfStats::InitRegionTimeRanges(const Box &procBox) {
 
 
 // ----------------------------------------------------------------------
-bool RegionsProfStats::Include(const FuncStat &fs) {
+bool RegionsProfStats::Include(const FuncStat &/*fs*/) {
   std::set<int>::iterator it;
   bool binclude(bDefaultInclude);
   return binclude;
@@ -660,7 +662,7 @@ void RegionsProfStats::CollectFuncStats(Vector<Vector<FuncStat> > &funcStats)
 
 
 // ----------------------------------------------------------------------
-void RegionsProfStats::WriteSummary(std::ostream &ios, bool bwriteavg,
+void RegionsProfStats::WriteSummary(std::ostream &ios, bool /*bwriteavg*/,
                                     int whichProc, bool graphTopPct)
 {
   if( ! ParallelDescriptor::IOProcessor()) {
@@ -1577,7 +1579,7 @@ void RegionsProfStats::ReadBlockNoOpen(DataBlock &dBlock, bool readRSS,
 
 
 // ----------------------------------------------------------------------
-bool RegionsProfStats::ReadBlock(DataBlock &dBlock, const int nmessages) {
+bool RegionsProfStats::ReadBlock(DataBlock &/*dBlock*/, const int /*nmessages*/) {
 amrex::Abort("not implemented yet.");
 return false;
 /*

--- a/Src/Extern/ProfParser/BLProfParser.y
+++ b/Src/Extern/ProfParser/BLProfParser.y
@@ -645,7 +645,7 @@ word: WORD {
 
 %%
 
-int yyerror(void *outpptr, const char *s) {
+int yyerror(void * /*outpptr*/, const char * /*s*/) {
   cerr << "*** Unrecognized output at line " << yylineno << "  ::  " << yytext << endl;
   return -1;
 }
@@ -654,6 +654,7 @@ int yyerror(void *outpptr, const char *s) {
 
 void CPIV(amrex::IntVect &bliv, IVec &ivec) {
 #if (BL_SPACEDIM == 2)
+  amrex::ignore_unused(bliv, ivec);
 #else
   bliv[0] = ivec[0];
   bliv[1] = ivec[1];

--- a/Src/Extern/amrdata/AMReX_AmrData.cpp
+++ b/Src/Extern/amrdata/AMReX_AmrData.cpp
@@ -805,7 +805,7 @@ bool AmrData::ReadData(const string &filename, Amrvis::FileType filetype) {
 
 
 // ---------------------------------------------------------------
-bool AmrData::ReadNonPlotfileData(const string &filename, Amrvis::FileType filetype) {
+bool AmrData::ReadNonPlotfileData(const string &filename, Amrvis::FileType /*filetype*/) {
   const int LevelZero(0), LevelOne(1), BoxZero(0), ComponentZero(0);
   const int NVarZero(0), FabZero(0), IndexZero(0);
   const int iopNum(ParallelDescriptor::IOProcessorNumber());
@@ -1572,7 +1572,7 @@ void AmrData::FillVar(Vector<FArrayBox *> &destFabs, const Vector<Box> &destBoxe
 
 
 // ---------------------------------------------------------------
-void AmrData::FillInterior(FArrayBox &dest, int level, const Box &subbox) {
+void AmrData::FillInterior(FArrayBox &/*dest*/, int /*level*/, const Box &/*subbox*/) {
    amrex::Abort("Error:  should not be in AmrData::FillInterior");
 }
 

--- a/Src/Extern/amrdata/AMReX_DataServices.cpp
+++ b/Src/Extern/amrdata/AMReX_DataServices.cpp
@@ -1586,7 +1586,7 @@ int DataServices::NumDeriveFunc() const {
 
 
 // ---------------------------------------------------------------
-void DataServices::PointValue(int pointBoxArraySize, Box *pointBoxArray,
+void DataServices::PointValue(int /*pointBoxArraySize*/, Box *pointBoxArray,
 		              const string &currentDerived,
 		              int coarsestLevelToSearch,
 			      int finestLevelToSearch,
@@ -1639,7 +1639,7 @@ void DataServices::PointValue(int pointBoxArraySize, Box *pointBoxArray,
 
 
 // ---------------------------------------------------------------
-void DataServices::LineValues(int lineBoxArraySize, Box *lineBoxArray, int whichDir,
+void DataServices::LineValues(int /*lineBoxArraySize*/, Box *lineBoxArray, int whichDir,
                               const string &currentDerived,
                               int coarsestLevelToSearch, int finestLevelToSearch,
                               XYPlotDataList *dataList, bool &bLineIsValid) {


### PR DESCRIPTION
## Summary

Warnings from compiling Amrvis using GCC 7.5 with DEBUG=TRUE, DIM=2 and DIM=3. (Build on dogora). Primarily ignore_unused, commenting out function parameter declarations and a few manual type casts. Some unique warning adjustments as well (e.g. a shadowed BL_PROFILER).

To be paired with a matching PR in the Amrvis repo.

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
