### PR TITLE
Reimplement SortParticlesByBin() to be consistent with FabArrayBase::buildTileArray

### DIFF
--- a/Src/Particle/AMReX_DenseBins.H
+++ b/Src/Particle/AMReX_DenseBins.H
@@ -54,7 +54,6 @@ class DenseBins
 public:
 
     using BinIteratorFactory = DenseBinIteratorFactory<T>;
-    using bin_type = IntVect;
     using index_type = unsigned int;
 
     /**
@@ -96,7 +95,7 @@ public:
         index_type* pcount  = m_counts.dataPtr();
         amrex::ParallelFor(nitems, [=] AMREX_GPU_DEVICE (int i) noexcept
         {
-            bin_type iv = f(v[i]);
+            auto iv = f(v[i]);
             auto iv3 = iv.dim3();
             int nx = hi.x-lo.x+1;
             int ny = hi.y-lo.y+1;
@@ -105,6 +104,45 @@ public:
             index_type uiy = amrex::min(ny-1,amrex::max(0,iv3.y));
             index_type uiz = amrex::min(nz-1,amrex::max(0,iv3.z));
             pcell[i] = (uix * ny + uiy) * nz + uiz;
+            Gpu::Atomic::Add(&pcount[pcell[i]], index_type{ 1 });
+        });
+
+        Gpu::exclusive_scan(m_counts.begin(), m_counts.end(), m_offsets.begin());
+
+        Gpu::copy(Gpu::deviceToDevice, m_offsets.begin(), m_offsets.end(), m_counts.begin());
+
+        index_type* pperm = m_perm.dataPtr();
+        constexpr index_type max_index = std::numeric_limits<index_type>::max();
+        amrex::ParallelFor(nitems, [=] AMREX_GPU_DEVICE (int i) noexcept
+        {
+            index_type index = Gpu::Atomic::Inc(&pcount[pcell[i]], max_index);
+            pperm[index] = i;
+        });
+
+        Gpu::Device::streamSynchronize();
+    }
+
+    template <typename N, typename F>
+    void build (N nitems, T const* v, int nbins, F&& f)
+    {
+        BL_PROFILE("DenseBins<T>::build");
+
+        m_items = v;
+
+        m_cells.resize(nitems);
+        m_perm.resize(nitems);
+
+        m_counts.resize(0);
+        m_counts.resize(nbins+1, 0);
+
+        m_offsets.resize(0);
+        m_offsets.resize(nbins+1);
+
+        index_type* pcell   = m_cells.dataPtr();
+        index_type* pcount  = m_counts.dataPtr();
+        amrex::ParallelFor(nitems, [=] AMREX_GPU_DEVICE (int i) noexcept
+        {
+            pcell[i] = f(v[i]);
             Gpu::Atomic::Add(&pcount[pcell[i]], index_type{ 1 });
         });
 

--- a/Src/Particle/AMReX_ParticleContainerI.H
+++ b/Src/Particle/AMReX_ParticleContainerI.H
@@ -1022,13 +1022,17 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>::SortParticles
             ptile_tmp.define(m_num_runtime_real, m_num_runtime_int);
             ptile_tmp.resize(np);
 
-            const Box& box = mfi.tilebox();
-            IntVect lo = box.smallEnd();
+            const Box& box = mfi.validbox();
 
-            m_bins.build(np, pstruct_ptr, mfi.tilebox(),
-                       [=] AMREX_GPU_HOST_DEVICE (const ParticleType& p) noexcept -> IntVect
+            int ntiles = numTilesInBox(box, true, bin_size);
+
+            m_bins.build(np, pstruct_ptr, ntiles,
+                       [=] AMREX_GPU_HOST_DEVICE (const ParticleType& p) noexcept -> unsigned int
                        {
-                           return (getParticleCell(p, plo, dxi, domain) - lo) / bin_size;
+                           Box tbx;
+                           auto iv = getParticleCell(p, plo, dxi, domain);
+                           auto tid = getTileIndex(iv, box, true, bin_size, tbx);
+                           return static_cast<unsigned int>(tid);
                        });
 
             gatherParticles(ptile_tmp, ptile, np, m_bins.permutationPtr());

--- a/Src/Particle/AMReX_ParticleUtil.H
+++ b/Src/Particle/AMReX_ParticleUtil.H
@@ -171,6 +171,32 @@ int getTileIndex (const IntVect& iv, const Box& box, const bool a_do_tiling,
     }
 }
 
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+int numTilesInBox (const Box& box, const bool a_do_tiling, const IntVect& a_tile_size)
+{
+    if (a_do_tiling == false) {
+        return 1;
+    } else {
+        //
+        // This function must be consistent with FabArrayBase::buildTileArray function!!!
+        //
+        auto tiling_1d = [](int lo, int hi, int tilesize, int& ntile) {
+            int ncells = hi-lo+1;
+            ntile = amrex::max(ncells/tilesize, 1);
+        };
+
+        const IntVect& small = box.smallEnd();
+        const IntVect& big   = box.bigEnd();
+        IntVect ntiles;
+
+        AMREX_D_TERM(tiling_1d(small[0], big[0], a_tile_size[0], ntiles[0]);,
+		     tiling_1d(small[1], big[1], a_tile_size[1], ntiles[1]);,
+		     tiling_1d(small[2], big[2], a_tile_size[2], ntiles[2]););
+
+        return AMREX_D_TERM(ntiles[0], *=ntiles[1], *=ntiles[2]);
+    }
+}
+
 template <typename P>
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 IntVect getParticleCell (P const& p,


### PR DESCRIPTION
Currently, the `SortParticlesByBin` method uses a different definition for its "bins" than the way tiles are defined in amrex. This re-implements that function to use the same tile definitions as `FabArrayBase::buildTileArray`. 

This is handy because to use shared memory for depositions, we'll want a strong a guarantee that all the particles in a thread block are located within a given tilebox, and we might as well re-use the already existing tiling machinery to achieve this.

This also leads to a nice ~6% speedup on a WarpX thermal plasma benchmark, even using the standard, non-shared memory form of the deposition algorithm.

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
