### PR TITLE
nvcc -MM

### DIFF
--- a/Tools/GNUMake/comps/nvcc.mak
+++ b/Tools/GNUMake/comps/nvcc.mak
@@ -21,6 +21,16 @@ ifeq ($(shell expr $(nvcc_major_version) \>= 11),1)
   nvcc_forward_unknowns = 1
 endif
 
+ifeq ($(shell expr $(nvcc_major_version) \< 10),1)
+  DEPFLAGS = -M  # -MM not supported in < 10
+endif
+
+ifeq ($(shell expr $(nvcc_major_version) \= 10),1)
+ifeq ($(shell expr $(nvcc_minor_version) \= 0),1)
+  DEPFLAGS = -M  # -MM not supported in 10.0
+endif
+endif
+
 #
 # nvcc compiler driver does not always accept pgc++
 # as a host compiler at present. However, if we're using


### PR DESCRIPTION
## Summary

`-MM` is not supported for nvcc <= 10.0.

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
