### PR TITLE
Tensor solver and extension of EB domain face

### DIFF
--- a/Src/EB/AMReX_EB2.cpp
+++ b/Src/EB/AMReX_EB2.cpp
@@ -18,7 +18,7 @@ namespace amrex { namespace EB2 {
 Vector<std::unique_ptr<IndexSpace> > IndexSpace::m_instance;
 
 int max_grid_size = 64;
-bool extend_domain_face = false;
+bool extend_domain_face = true;
 
 void Initialize ()
 {

--- a/Src/EB/AMReX_EB2_Level.H
+++ b/Src/EB/AMReX_EB2_Level.H
@@ -110,6 +110,10 @@ GShopLevel<G>::GShopLevel (IndexSpace const* is, G const& gshop, const Geometry&
         return;
     }
 
+    if (amrex::Verbose() > 0 && extend_domain_face == false) {
+        amrex::Print() << "AMReX WARNING: extend_domain_face=false is not recommended!\n";
+    }
+
     BL_PROFILE("EB2::GShopLevel()-fine");
 
     Real small_volfrac = 1.e-14;

--- a/Src/LinearSolvers/MLMG/AMReX_MLEBTensor_2D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBTensor_2D_K.H
@@ -19,10 +19,7 @@ void mlebtensor_cross_terms_fx (Box const& box, Array4<Real> const& fx,
                                 Array4<Real const> const& kapx,
                                 Array4<Real const> const& apx,
                                 Array4<EBCellFlag const> const& flag,
-                                GpuArray<Real,AMREX_SPACEDIM> const& dxinv,
-                                const Dim3& dlo, const Dim3& dhi,
-                                Array2D<BoundCond,0,2*AMREX_SPACEDIM-1,0,AMREX_SPACEDIM-1> const& bct,
-                                const int& is_periodic) noexcept
+                                GpuArray<Real,AMREX_SPACEDIM> const& dxinv) noexcept
 {
     const Real dyi = dxinv[1];
     const auto lo = amrex::lbound(box);
@@ -43,45 +40,12 @@ void mlebtensor_cross_terms_fx (Box const& box, Array4<Real> const& fx,
                 int jhim = j - flag(i  ,j,0).isConnected(0,-1,0);
                 int jlop = j + flag(i-1,j,0).isConnected(0, 1,0);
                 int jlom = j - flag(i-1,j,0).isConnected(0,-1,0);
-
                 Real whi = mlebtensor_weight(jhip-jhim);
                 Real wlo = mlebtensor_weight(jlop-jlom);
-
                 Real dudy = (0.5*dyi) * ((vel(i  ,jhip,0,0)-vel(i  ,jhim,0,0))*whi
                                         +(vel(i-1,jlop,0,0)-vel(i-1,jlom,0,0))*wlo);
-
                 Real dvdy = (0.5*dyi) * ((vel(i  ,jhip,0,1)-vel(i  ,jhim,0,1))*whi
                                         +(vel(i-1,jlop,0,1)-vel(i-1,jlom,0,1))*wlo);
-
-                if (i==dhi.x+1 and !is_periodic){
-                    if (bct(Orientation(Direction::x,Orientation::high),0)==AMREX_LO_NEUMANN){
-                        dudy = (dyi) * ((vel(i-1,jlop,0,0)-vel(i-1,jlom,0,0))*wlo);
-                    }
-                    if (bct(Orientation(Direction::x,Orientation::high),1)==AMREX_LO_NEUMANN){
-                        dvdy = (dyi) * ((vel(i-1,jlop,0,1)-vel(i-1,jlom,0,1))*wlo);
-                    }
-                    if (bct(Orientation(Direction::x,Orientation::high),0)==AMREX_LO_DIRICHLET){
-                        dudy = (dyi) * ((vel(i  ,jhip,0,0)-vel(i  ,jhim,0,0))*whi);
-                    }
-                    if (bct(Orientation(Direction::x,Orientation::high),1)==AMREX_LO_DIRICHLET){
-                        dvdy = (dyi) * ((vel(i  ,jhip,0,1)-vel(i  ,jhim,0,1))*whi);
-                    }
-                }
-                if (i==dlo.x and !is_periodic){
-                    if (bct(Orientation(Direction::x,Orientation::low),0)==AMREX_LO_NEUMANN){
-                        dudy = (dyi) * ((vel(i  ,jhip,0,0)-vel(i  ,jhim,0,0))*whi);
-                    }
-                    if (bct(Orientation(Direction::x,Orientation::low),1)==AMREX_LO_NEUMANN){
-                        dvdy = (dyi) * ((vel(i  ,jhip,0,1)-vel(i  ,jhim,0,1))*whi);
-                    }
-                    if (bct(Orientation(Direction::x,Orientation::low),0)==AMREX_LO_DIRICHLET){
-                        dudy = (dyi) * ((vel(i-1,jlop,0,0)-vel(i-1,jlom,0,0))*wlo);
-                    }
-                    if (bct(Orientation(Direction::x,Orientation::low),1)==AMREX_LO_DIRICHLET){
-                        dvdy = (dyi) * ((vel(i-1,jlop,0,1)-vel(i-1,jlom,0,1))*wlo);
-                    }
-                }
-
 		Real divu = dvdy;
                 Real xif = kapx(i,j,0);
                 Real mun = 0.75*(etax(i,j,0,0)-xif);  // restore the original eta
@@ -100,10 +64,7 @@ void mlebtensor_cross_terms_fy (Box const& box, Array4<Real> const& fy,
                                 Array4<Real const> const& kapy,
                                 Array4<Real const> const& apy,
                                 Array4<EBCellFlag const> const& flag,
-                                GpuArray<Real,AMREX_SPACEDIM> const& dxinv,
-                                const Dim3& dlo, const Dim3& dhi,
-                                Array2D<BoundCond,0,2*AMREX_SPACEDIM-1,0,AMREX_SPACEDIM-1> const& bct,
-                                const int& is_periodic) noexcept
+                                GpuArray<Real,AMREX_SPACEDIM> const& dxinv) noexcept
 {
     const Real dxi = dxinv[0];
     const auto lo = amrex::lbound(box);
@@ -124,43 +85,12 @@ void mlebtensor_cross_terms_fy (Box const& box, Array4<Real> const& fy,
                 int ihim = i - flag(i,j  ,0).isConnected(-1,0,0);
                 int ilop = i + flag(i,j-1,0).isConnected( 1,0,0);
                 int ilom = i - flag(i,j-1,0).isConnected(-1,0,0);
-
                 Real whi = mlebtensor_weight(ihip-ihim);
                 Real wlo = mlebtensor_weight(ilop-ilom);
-
                 Real dudx = (0.5*dxi) * ((vel(ihip,j  ,0,0)-vel(ihim,j  ,0,0))*whi
                                         +(vel(ilop,j-1,0,0)-vel(ilom,j-1,0,0))*wlo);
                 Real dvdx = (0.5*dxi) * ((vel(ihip,j  ,0,1)-vel(ihim,j  ,0,1))*whi
                                         +(vel(ilop,j-1,0,1)-vel(ilom,j-1,0,1))*wlo);
-
-                if (j==dhi.y+1 and !is_periodic){
-                    if (bct(Orientation(Direction::y,Orientation::high),0)==AMREX_LO_NEUMANN){
-                        dudx = (dxi) * ((vel(ilop,j-1,0,0)-vel(ilom,j-1,0,0))*wlo);
-                    }
-                    if (bct(Orientation(Direction::y,Orientation::high),1)==AMREX_LO_NEUMANN){
-                        dvdx = (dxi) * ((vel(ilop,j-1,0,1)-vel(ilom,j-1,0,1))*wlo);
-                    }
-                    if (bct(Orientation(Direction::y,Orientation::high),0)==AMREX_LO_DIRICHLET){
-                        dudx = (dxi) * ((vel(ihip,j  ,0,0)-vel(ihim,j  ,0,0))*whi);
-                    }
-                    if (bct(Orientation(Direction::y,Orientation::high),1)==AMREX_LO_DIRICHLET){
-                        dvdx = (dxi) * ((vel(ihip,j  ,0,1)-vel(ihim,j  ,0,1))*whi);
-                    }
-                }
-                if (j==dlo.y and !is_periodic){
-                    if (bct(Orientation(Direction::y,Orientation::low),0)==AMREX_LO_NEUMANN){
-                        dudx = (dxi) * ((vel(ihip,j  ,0,0)-vel(ihim,j  ,0,0))*whi);
-                    }
-                    if (bct(Orientation(Direction::y,Orientation::low),1)==AMREX_LO_NEUMANN){
-                        dvdx = (dxi) * ((vel(ihip,j  ,0,1)-vel(ihim,j  ,0,1))*whi);
-                    }
-                    if (bct(Orientation(Direction::y,Orientation::low),0)==AMREX_LO_DIRICHLET){
-                        dudx = (dxi) * ((vel(ilop,j-1,0,0)-vel(ilom,j-1,0,0))*wlo);
-                    }
-                    if (bct(Orientation(Direction::y,Orientation::low),1)==AMREX_LO_DIRICHLET){
-                        dvdx = (dxi) * ((vel(ilop,j-1,0,1)-vel(ilom,j-1,0,1))*wlo);
-                    }
-                }
 
 		Real divu = dudx;
                 Real xif = kapy(i,j,0);

--- a/Src/LinearSolvers/MLMG/AMReX_MLEBTensor_3D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBTensor_3D_K.H
@@ -19,10 +19,7 @@ void mlebtensor_cross_terms_fx (Box const& box, Array4<Real> const& fx,
                                 Array4<Real const> const& kapx,
                                 Array4<Real const> const& apx,
                                 Array4<EBCellFlag const> const& flag,
-                                GpuArray<Real,AMREX_SPACEDIM> const& dxinv,
-                                const Dim3& dlo, const Dim3& dhi,
-                                Array2D<BoundCond,0,2*AMREX_SPACEDIM-1,0,AMREX_SPACEDIM-1> const& bct,
-                                const int& is_periodic) noexcept
+                                GpuArray<Real,AMREX_SPACEDIM> const& dxinv) noexcept
 {
     const Real dyi = dxinv[1];
     const Real dzi = dxinv[2];
@@ -42,90 +39,27 @@ void mlebtensor_cross_terms_fx (Box const& box, Array4<Real> const& fx,
                 }
                 else
                 {
-
                     int jhip = j + flag(i  ,j,k).isConnected(0, 1,0);
                     int jhim = j - flag(i  ,j,k).isConnected(0,-1,0);
                     int jlop = j + flag(i-1,j,k).isConnected(0, 1,0);
                     int jlom = j - flag(i-1,j,k).isConnected(0,-1,0);
-
                     Real whi = mlebtensor_weight(jhip-jhim);
                     Real wlo = mlebtensor_weight(jlop-jlom);
-
                     Real dudy = (0.5*dyi) * ((vel(i  ,jhip,k,0)-vel(i  ,jhim,k,0))*whi
                                             +(vel(i-1,jlop,k,0)-vel(i-1,jlom,k,0))*wlo);
                     Real dvdy = (0.5*dyi) * ((vel(i  ,jhip,k,1)-vel(i  ,jhim,k,1))*whi
                                             +(vel(i-1,jlop,k,1)-vel(i-1,jlom,k,1))*wlo);
 
-                    if (i==dhi.x+1 and !is_periodic){
-                        if (bct(Orientation(Direction::x,Orientation::high),0)==AMREX_LO_NEUMANN){
-                            dudy = (dyi) * ((vel(i-1,jlop,k,0)-vel(i-1,jlom,k,0))*wlo);
-                        }
-                        if (bct(Orientation(Direction::x,Orientation::high),1)==AMREX_LO_NEUMANN){
-                            dvdy = (dyi) * ((vel(i-1,jlop,k,1)-vel(i-1,jlom,k,1))*wlo);
-                        }
-                        if (bct(Orientation(Direction::x,Orientation::high),0)==AMREX_LO_DIRICHLET){
-                            dudy = (dyi) * ((vel(i  ,jhip,k,0)-vel(i  ,jhim,k,0))*whi);
-                        }
-                        if (bct(Orientation(Direction::x,Orientation::high),1)==AMREX_LO_DIRICHLET){
-                            dvdy = (dyi) * ((vel(i  ,jhip,k,1)-vel(i  ,jhim,k,1))*whi);
-                        }
-                    }
-                    if (i==dlo.x and !is_periodic){
-                        if (bct(Orientation(Direction::x,Orientation::low),0)==AMREX_LO_NEUMANN){
-                            dudy = (dyi) * ((vel(i  ,jhip,k,0)-vel(i  ,jhim,k,0))*whi);
-                        }
-                        if (bct(Orientation(Direction::x,Orientation::low),1)==AMREX_LO_NEUMANN){
-                            dvdy = (dyi) * ((vel(i  ,jhip,k,1)-vel(i  ,jhim,k,1))*whi);
-                        }
-                        if (bct(Orientation(Direction::x,Orientation::low),0)==AMREX_LO_DIRICHLET){
-                            dudy = (dyi) * ((vel(i-1,jlop,k,0)-vel(i-1,jlom,k,0))*wlo);
-                        }
-                        if (bct(Orientation(Direction::x,Orientation::low),1)==AMREX_LO_DIRICHLET){
-                            dvdy = (dyi) * ((vel(i-1,jlop,k,1)-vel(i-1,jlom,k,1))*wlo);
-                        }
-                    }
-
                     int khip = k + flag(i  ,j,k).isConnected(0,0, 1);
                     int khim = k - flag(i  ,j,k).isConnected(0,0,-1);
                     int klop = k + flag(i-1,j,k).isConnected(0,0, 1);
                     int klom = k - flag(i-1,j,k).isConnected(0,0,-1);
-
                     whi = mlebtensor_weight(khip-khim);
                     wlo = mlebtensor_weight(klop-klom);
-
                     Real dudz = (0.5*dzi) * ((vel(i  ,j,khip,0)-vel(i  ,j,khim,0))*whi
                                             +(vel(i-1,j,klop,0)-vel(i-1,j,klom,0))*wlo);
                     Real dwdz = (0.5*dzi) * ((vel(i  ,j,khip,2)-vel(i  ,j,khim,2))*whi
                                             +(vel(i-1,j,klop,2)-vel(i-1,j,klom,2))*wlo);
-
-                    if (i==dhi.x+1 and !is_periodic){
-                        if (bct(Orientation(Direction::x,Orientation::high),0)==AMREX_LO_NEUMANN){
-                            dudz = (dzi) * ((vel(i-1,j,klop,0)-vel(i-1,j,klom,0))*wlo);
-                        }
-                        if (bct(Orientation(Direction::x,Orientation::high),2)==AMREX_LO_NEUMANN){
-                            dwdz = (dzi) * ((vel(i-1,j,klop,2)-vel(i-1,j,klom,2))*wlo);
-                        }
-                        if (bct(Orientation(Direction::x,Orientation::high),0)==AMREX_LO_DIRICHLET){
-                            dudz = (dzi) * ((vel(i  ,j,khip,0)-vel(i  ,j,khim,0))*whi);
-                        }
-                        if (bct(Orientation(Direction::x,Orientation::high),2)==AMREX_LO_DIRICHLET){
-                            dwdz = (dzi) * ((vel(i  ,j,khip,2)-vel(i  ,j,khim,2))*whi);
-                        }
-                    }
-                    if (i==dlo.x and !is_periodic){
-                        if (bct(Orientation(Direction::x,Orientation::low),0)==AMREX_LO_NEUMANN){
-                            dudz = (dzi) * ((vel(i  ,j,khip,0)-vel(i  ,j,khim,0))*whi);
-                        }
-                        if (bct(Orientation(Direction::x,Orientation::low),2)==AMREX_LO_NEUMANN){
-                            dwdz = (dzi) * ((vel(i  ,j,khip,2)-vel(i  ,j,khim,2))*whi);
-                        }
-                        if (bct(Orientation(Direction::x,Orientation::low),0)==AMREX_LO_DIRICHLET){
-                            dudz = (dzi) * ((vel(i-1,j,klop,0)-vel(i-1,j,klom,0))*wlo);
-                        }
-                        if (bct(Orientation(Direction::x,Orientation::low),2)==AMREX_LO_DIRICHLET){
-                            dwdz = (dzi) * ((vel(i-1,j,klop,2)-vel(i-1,j,klom,2))*wlo);
-                        }
-                    }
 
                     Real divu = dvdy + dwdz;
                     Real xif = kapx(i,j,k);
@@ -147,10 +81,7 @@ void mlebtensor_cross_terms_fy (Box const& box, Array4<Real> const& fy,
                                 Array4<Real const> const& kapy,
                                 Array4<Real const> const& apy,
                                 Array4<EBCellFlag const> const& flag,
-                                GpuArray<Real,AMREX_SPACEDIM> const& dxinv,
-                                const Dim3& dlo, const Dim3& dhi,
-                                Array2D<BoundCond,0,2*AMREX_SPACEDIM-1,0,AMREX_SPACEDIM-1> const& bct,
-                                const int& is_periodic) noexcept
+                                GpuArray<Real,AMREX_SPACEDIM> const& dxinv) noexcept
 {
     const Real dxi = dxinv[0];
     const Real dzi = dxinv[2];
@@ -174,85 +105,23 @@ void mlebtensor_cross_terms_fy (Box const& box, Array4<Real> const& fy,
                     int ihim = i - flag(i,j  ,k).isConnected(-1,0,0);
                     int ilop = i + flag(i,j-1,k).isConnected( 1,0,0);
                     int ilom = i - flag(i,j-1,k).isConnected(-1,0,0);
-
                     Real whi = mlebtensor_weight(ihip-ihim);
                     Real wlo = mlebtensor_weight(ilop-ilom);
-
                     Real dudx = (0.5*dxi) * ((vel(ihip,j  ,k,0)-vel(ihim,j  ,k,0))*whi
                                             +(vel(ilop,j-1,k,0)-vel(ilom,j-1,k,0))*wlo);
                     Real dvdx = (0.5*dxi) * ((vel(ihip,j  ,k,1)-vel(ihim,j  ,k,1))*whi
                                             +(vel(ilop,j-1,k,1)-vel(ilom,j-1,k,1))*wlo);
 
-                    if (j==dhi.y+1 and !is_periodic){ 
-                        if (bct(Orientation(Direction::y,Orientation::high),0)==AMREX_LO_NEUMANN){
-                            dudx = (dxi) * ((vel(ilop,j-1,k,0)-vel(ilom,j-1,k,0))*wlo);
-                        }
-                        if (bct(Orientation(Direction::y,Orientation::high),1)==AMREX_LO_NEUMANN){
-                            dvdx = (dxi) * ((vel(ilop,j-1,k,1)-vel(ilom,j-1,k,1))*wlo);
-                        }
-                        if (bct(Orientation(Direction::y,Orientation::high),0)==AMREX_LO_DIRICHLET){
-                            dudx = (dxi) * ((vel(ihip,j  ,k,0)-vel(ihim,j  ,k,0))*whi);
-                        }
-                        if (bct(Orientation(Direction::y,Orientation::high),1)==AMREX_LO_DIRICHLET){
-                            dvdx = (dxi) * ((vel(ihip,j  ,k,1)-vel(ihim,j  ,k,1))*whi);
-                        }
-                    }
-                    if (j==dlo.y and !is_periodic){
-                        if (bct(Orientation(Direction::y,Orientation::low),0)==AMREX_LO_NEUMANN){
-                            dudx = (dxi) * ((vel(ihip,j  ,k,0)-vel(ihim,j  ,k,0))*whi);
-                        }
-                        if (bct(Orientation(Direction::y,Orientation::low),1)==AMREX_LO_NEUMANN){
-                            dvdx = (dxi) * ((vel(ihip,j  ,k,1)-vel(ihim,j  ,k,1))*whi);
-                        }
-                        if (bct(Orientation(Direction::y,Orientation::low),0)==AMREX_LO_DIRICHLET){
-                            dudx = (dxi) * ((vel(ilop,j-1,k,0)-vel(ilom,j-1,k,0))*wlo);
-                        }
-                        if (bct(Orientation(Direction::y,Orientation::low),1)==AMREX_LO_DIRICHLET){
-                            dvdx = (dxi) * ((vel(ilop,j-1,k,1)-vel(ilom,j-1,k,1))*wlo);
-                        }
-                    }
-
                     int khip = k + flag(i,j  ,k).isConnected(0,0, 1);
                     int khim = k - flag(i,j  ,k).isConnected(0,0,-1);
                     int klop = k + flag(i,j-1,k).isConnected(0,0, 1);
                     int klom = k - flag(i,j-1,k).isConnected(0,0,-1);
-
                     whi = mlebtensor_weight(khip-khim);
                     wlo = mlebtensor_weight(klop-klom);
-
                     Real dvdz = (0.5*dzi) * ((vel(i,j  ,khip,1)-vel(i,j  ,khim,1))*whi
                                             +(vel(i,j-1,klop,1)-vel(i,j-1,klom,1))*wlo);
                     Real dwdz = (0.5*dzi) * ((vel(i,j  ,khip,2)-vel(i,j  ,khim,2))*whi
                                             +(vel(i,j-1,klop,2)-vel(i,j-1,klom,2))*wlo);
-
-                    if (j==dhi.y+1 and !is_periodic){
-                        if (bct(Orientation(Direction::y,Orientation::high),1)==AMREX_LO_NEUMANN){
-                            dvdz = (dzi) * ((vel(i,j-1,klop,1)-vel(i,j-1,klom,1))*wlo);
-                        }
-                        if (bct(Orientation(Direction::y,Orientation::high),2)==AMREX_LO_NEUMANN){
-                            dwdz = (dzi) * ((vel(i,j-1,klop,2)-vel(i,j-1,klom,2))*wlo);
-                        }
-                        if (bct(Orientation(Direction::y,Orientation::high),1)==AMREX_LO_DIRICHLET){
-                            dvdz = (dzi) * ((vel(i,j  ,khip,1)-vel(i,j  ,khim,1))*whi);
-                        }
-                        if (bct(Orientation(Direction::y,Orientation::high),2)==AMREX_LO_DIRICHLET){
-                            dwdz = (dzi) * ((vel(i,j  ,khip,2)-vel(i,j  ,khim,2))*whi);
-                        }
-                    }
-                    if (j==dlo.y and !is_periodic){
-                        if (bct(Orientation(Direction::y,Orientation::low),1)==AMREX_LO_NEUMANN){
-                            dvdz = (dzi) * ((vel(i,j  ,khip,1)-vel(i,j  ,khim,1))*whi);
-                        }
-                        if (bct(Orientation(Direction::y,Orientation::low),2)==AMREX_LO_NEUMANN){
-                            dwdz = (dzi) * ((vel(i,j  ,khip,2)-vel(i,j  ,khim,2))*whi);
-                        }
-                        if (bct(Orientation(Direction::y,Orientation::low),1)==AMREX_LO_DIRICHLET){
-                            dvdz = (dzi) * ((vel(i,j-1,klop,1)-vel(i,j-1,klom,1))*wlo);
-                        }
-                        if (bct(Orientation(Direction::y,Orientation::low),2)==AMREX_LO_DIRICHLET){
-                            dwdz = (dzi) * ((vel(i,j-1,klop,2)-vel(i,j-1,klom,2))*wlo);
-                        }
-                    }
 
                     Real divu = dudx + dwdz;
                     Real xif = kapy(i,j,k);
@@ -274,10 +143,7 @@ void mlebtensor_cross_terms_fz (Box const& box, Array4<Real> const& fz,
                                 Array4<Real const> const& kapz,
                                 Array4<Real const> const& apz,
                                 Array4<EBCellFlag const> const& flag,
-                                GpuArray<Real,AMREX_SPACEDIM> const& dxinv,
-                                const Dim3& dlo, const Dim3& dhi,
-                                Array2D<BoundCond,0,2*AMREX_SPACEDIM-1,0,AMREX_SPACEDIM-1> const& bct,
-                                const int& is_periodic) noexcept
+                                GpuArray<Real,AMREX_SPACEDIM> const& dxinv) noexcept
 {
     const Real dxi = dxinv[0];
     const Real dyi = dxinv[1];
@@ -301,7 +167,6 @@ void mlebtensor_cross_terms_fz (Box const& box, Array4<Real> const& fz,
                     int ihim = i - flag(i,j,k  ).isConnected(-1,0,0);
                     int ilop = i + flag(i,j,k-1).isConnected( 1,0,0);
                     int ilom = i - flag(i,j,k-1).isConnected(-1,0,0);
-
                     Real whi = mlebtensor_weight(ihip-ihim);
                     Real wlo = mlebtensor_weight(ilop-ilom);
 
@@ -310,76 +175,16 @@ void mlebtensor_cross_terms_fz (Box const& box, Array4<Real> const& fz,
                     Real dwdx = (0.5*dxi) * ((vel(ihip,j,k  ,2)-vel(ihim,j,k  ,2))*whi
                                             +(vel(ilop,j,k-1,2)-vel(ilom,j,k-1,2))*wlo);
 
-                    if (k==dhi.z+1 and !is_periodic){
-                        if (bct(Orientation(Direction::z,Orientation::high),0)==AMREX_LO_NEUMANN){
-                            dudx = (dxi) * ((vel(ilop,j,k-1,0)-vel(ilom,j,k-1,0))*wlo);
-                        }
-                        if (bct(Orientation(Direction::z,Orientation::high),2)==AMREX_LO_NEUMANN){
-                            dwdx = (dxi) * ((vel(ilop,j,k-1,2)-vel(ilom,j,k-1,2))*wlo);
-                        }
-                        if (bct(Orientation(Direction::z,Orientation::high),0)==AMREX_LO_DIRICHLET){
-                            dudx = (dxi) * ((vel(ihip,j,k  ,0)-vel(ihim,j,k  ,0))*whi);
-                        }
-                        if (bct(Orientation(Direction::z,Orientation::high),2)==AMREX_LO_DIRICHLET){
-                            dwdx = (dxi) * ((vel(ihip,j,k  ,2)-vel(ihim,j,k  ,2))*whi);
-                        }
-                    }
-                    if (k==dlo.z and !is_periodic){
-                        if (bct(Orientation(Direction::z,Orientation::low),0)==AMREX_LO_NEUMANN){
-                            dudx = (dxi) * ((vel(ihip,j,k  ,0)-vel(ihim,j,k  ,0))*whi);
-                        }
-                        if (bct(Orientation(Direction::z,Orientation::low),2)==AMREX_LO_NEUMANN){
-                            dwdx = (dxi) * ((vel(ihip,j,k  ,2)-vel(ihim,j,k  ,2))*whi);
-                        }
-                        if (bct(Orientation(Direction::z,Orientation::low),0)==AMREX_LO_DIRICHLET){
-                            dudx = (dxi) * ((vel(ilop,j,k-1,0)-vel(ilom,j,k-1,0))*wlo);
-                        }
-                        if (bct(Orientation(Direction::z,Orientation::low),2)==AMREX_LO_DIRICHLET){
-                            dwdx = (dxi) * ((vel(ilop,j,k-1,2)-vel(ilom,j,k-1,2))*wlo);
-                        }
-                    }
-
                     int jhip = j + flag(i,j,k  ).isConnected(0, 1,0);
                     int jhim = j - flag(i,j,k  ).isConnected(0,-1,0);
                     int jlop = j + flag(i,j,k-1).isConnected(0, 1,0);
                     int jlom = j - flag(i,j,k-1).isConnected(0,-1,0);
-
                     whi = mlebtensor_weight(jhip-jhim);
                     wlo = mlebtensor_weight(jlop-jlom);
-
                     Real dvdy = (0.5*dyi) * ((vel(i,jhip,k  ,1)-vel(i,jhim,k  ,1))*whi
                                             +(vel(i,jlop,k-1,1)-vel(i,jlom,k-1,1))*wlo);
                     Real dwdy = (0.5*dyi) * ((vel(i,jhip,k  ,2)-vel(i,jhim,k  ,2))*whi
                                             +(vel(i,jlop,k-1,2)-vel(i,jlom,k-1,2))*wlo);
-
-                    if (k==dhi.z+1 and !is_periodic){
-                        if (bct(Orientation(Direction::z,Orientation::high),1)==AMREX_LO_NEUMANN){
-                            dvdy = (dyi) * ((vel(i,jlop,k-1,1)-vel(i,jlom,k-1,1))*wlo);
-                        }
-                        if (bct(Orientation(Direction::z,Orientation::high),2)==AMREX_LO_NEUMANN){
-                            dwdy = (dyi) * ((vel(i,jlop,k-1,2)-vel(i,jlom,k-1,2))*wlo);
-                        }
-                        if (bct(Orientation(Direction::z,Orientation::high),1)==AMREX_LO_DIRICHLET){
-                            dvdy = (dyi) * ((vel(i,jhip,k  ,1)-vel(i,jhim,k  ,1))*whi);
-                        }
-                        if (bct(Orientation(Direction::z,Orientation::high),2)==AMREX_LO_DIRICHLET){
-                            dwdy = (dyi) * ((vel(i,jhip,k  ,2)-vel(i,jhim,k  ,2))*whi);
-                        }
-                    }
-                    if (k==dlo.z and !is_periodic){
-                        if (bct(Orientation(Direction::z,Orientation::low),1)==AMREX_LO_NEUMANN){
-                            dvdy = (dyi) * ((vel(i,jhip,k  ,1)-vel(i,jhim,k  ,1))*whi);
-                        }
-                        if (bct(Orientation(Direction::z,Orientation::low),2)==AMREX_LO_NEUMANN){
-                            dwdy = (dyi) * ((vel(i,jhip,k  ,2)-vel(i,jhim,k  ,2))*whi);
-                        }
-                        if (bct(Orientation(Direction::z,Orientation::low),1)==AMREX_LO_DIRICHLET){
-                            dvdy = (dyi) * ((vel(i,jlop,k-1,1)-vel(i,jlom,k-1,1))*wlo);
-                        }
-                        if (bct(Orientation(Direction::z,Orientation::low),2)==AMREX_LO_DIRICHLET){
-                            dwdy = (dyi) * ((vel(i,jlop,k-1,2)-vel(i,jlom,k-1,2))*wlo);
-                        }
-                    }
 
                     Real divu = dudx + dvdy;
                     Real xif = kapz(i,j,k);

--- a/Src/LinearSolvers/MLMG/AMReX_MLTensorOp.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLTensorOp.cpp
@@ -211,12 +211,6 @@ MLTensorOp::apply (int amrlev, int mglev, MultiFab& out, MultiFab& in, BCMode bc
     applyBCTensor(amrlev, mglev, in, bc_mode, s_mode, bndry );
 
     const auto dxinv = m_geom[amrlev][mglev].InvCellSizeArray();
-    const Geometry& geom = m_geom[amrlev][mglev];
-    const Box& domain = geom.Domain();
-    const auto dlo = amrex::lbound(domain);
-    const auto dhi = amrex::ubound(domain);
-    const GpuArray<int,AMREX_SPACEDIM>& is_periodic = geom.isPeriodicArray();
-    const auto& bcondloc = *m_bcondloc[amrlev][mglev];
 
     Array<MultiFab,AMREX_SPACEDIM> const& etamf = m_b_coeffs[amrlev][mglev];
     Array<MultiFab,AMREX_SPACEDIM> const& kapmf = m_kappa[amrlev][mglev];
@@ -251,27 +245,18 @@ MLTensorOp::apply (int amrlev, int mglev, MultiFab& out, MultiFab& in, BCMode bc
                          Array4<Real> const fyfab = fluxfab_tmp[1].array();,
                          Array4<Real> const fzfab = fluxfab_tmp[2].array(););
 
-            const auto & bdcv = bcondloc.bndryConds(mfi);
-            Array2D<BoundCond,0,2*AMREX_SPACEDIM-1,0,AMREX_SPACEDIM-1> bct;
-            for (int icomp = 0; icomp < AMREX_SPACEDIM; ++icomp) {
-                for (OrientationIter face; face; ++face) {
-                    Orientation ori = face(); 
-                    bct(ori,icomp) = bdcv[icomp][ori];
-                }
-            }
-
             AMREX_LAUNCH_HOST_DEVICE_LAMBDA_DIM
             ( xbx, txbx,
               {
-                  mltensor_cross_terms_fx(txbx,fxfab,vfab,etaxfab,kapxfab,dxinv,dlo,dhi,bct,is_periodic[0]);
+                  mltensor_cross_terms_fx(txbx,fxfab,vfab,etaxfab,kapxfab,dxinv);
               }
             , ybx, tybx,
               {
-                  mltensor_cross_terms_fy(tybx,fyfab,vfab,etayfab,kapyfab,dxinv,dlo,dhi,bct,is_periodic[1]);
+                  mltensor_cross_terms_fy(tybx,fyfab,vfab,etayfab,kapyfab,dxinv);
               }
             , zbx, tzbx,
               {
-                  mltensor_cross_terms_fz(tzbx,fzfab,vfab,etazfab,kapzfab,dxinv,dlo,dhi,bct,is_periodic[2]);
+                  mltensor_cross_terms_fz(tzbx,fzfab,vfab,etazfab,kapzfab,dxinv);
               }
             );
 
@@ -418,12 +403,6 @@ MLTensorOp::compFlux (int amrlev, const Array<MultiFab*,AMREX_SPACEDIM>& fluxes,
     applyBCTensor(amrlev, mglev, sol, BCMode::Inhomogeneous, StateMode::Solution, m_bndry_sol[amrlev].get());
 
     const auto dxinv = m_geom[amrlev][mglev].InvCellSizeArray();
-    const Geometry& geom = m_geom[amrlev][mglev];
-    const Box& domain = geom.Domain();
-    const auto dlo = amrex::lbound(domain);
-    const auto dhi = amrex::ubound(domain);
-    const GpuArray<int,AMREX_SPACEDIM>& is_periodic = geom.isPeriodicArray();
-    const auto& bcondloc = *m_bcondloc[amrlev][mglev];
 
     Array<MultiFab,AMREX_SPACEDIM> const& etamf = m_b_coeffs[amrlev][mglev];
     Array<MultiFab,AMREX_SPACEDIM> const& kapmf = m_kappa[amrlev][mglev];
@@ -457,27 +436,18 @@ MLTensorOp::compFlux (int amrlev, const Array<MultiFab*,AMREX_SPACEDIM>& fluxes,
                          Array4<Real> const fyfab = fluxfab_tmp[1].array();,
                          Array4<Real> const fzfab = fluxfab_tmp[2].array(););
 
-            const auto & bdcv = bcondloc.bndryConds(mfi);
-            Array2D<BoundCond,0,2*AMREX_SPACEDIM-1,0,AMREX_SPACEDIM-1> bct;
-            for (int icomp = 0; icomp < AMREX_SPACEDIM; ++icomp) {
-                for (OrientationIter face; face; ++face) {
-                    Orientation ori = face();
-                    bct(ori,icomp) = bdcv[icomp][ori];
-                }
-            }
-
             AMREX_LAUNCH_HOST_DEVICE_LAMBDA_DIM
             ( xbx, txbx,
               {
-                  mltensor_cross_terms_fx(txbx,fxfab,vfab,etaxfab,kapxfab,dxinv,dlo,dhi,bct,is_periodic[0]);
+                  mltensor_cross_terms_fx(txbx,fxfab,vfab,etaxfab,kapxfab,dxinv);
               }
             , ybx, tybx,
               {
-                  mltensor_cross_terms_fy(tybx,fyfab,vfab,etayfab,kapyfab,dxinv,dlo,dhi,bct,is_periodic[1]);
+                  mltensor_cross_terms_fy(tybx,fyfab,vfab,etayfab,kapyfab,dxinv);
               }
             , zbx, tzbx,
               {
-                  mltensor_cross_terms_fz(tzbx,fzfab,vfab,etazfab,kapzfab,dxinv,dlo,dhi,bct,is_periodic[2]);
+                  mltensor_cross_terms_fz(tzbx,fzfab,vfab,etazfab,kapzfab,dxinv);
               }
             );
 

--- a/Src/LinearSolvers/MLMG/AMReX_MLTensor_2D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLTensor_2D_K.H
@@ -129,10 +129,7 @@ void mltensor_cross_terms_fx (Box const& box, Array4<Real> const& fx,
                               Array4<Real const> const& vel,
                               Array4<Real const> const& etax,
                               Array4<Real const> const& kapx,
-                              GpuArray<Real,AMREX_SPACEDIM> const& dxinv,
-                              const Dim3& dlo, const Dim3& dhi,
-                              Array2D<BoundCond,0,2*AMREX_SPACEDIM-1,0,AMREX_SPACEDIM-1> const& bct,
-                              const int& is_periodic) noexcept
+                              GpuArray<Real,AMREX_SPACEDIM> const& dxinv) noexcept
 {
     const Real dyi = dxinv[1];
     const auto lo = amrex::lbound(box);
@@ -144,34 +141,6 @@ void mltensor_cross_terms_fx (Box const& box, Array4<Real> const& fx,
         for (int i = lo.x; i <= hi.x; ++i) {
             Real dudy = (vel(i,j+1,0,0)+vel(i-1,j+1,0,0)-vel(i,j-1,0,0)-vel(i-1,j-1,0,0))*(0.25*dyi);
             Real dvdy = (vel(i,j+1,0,1)+vel(i-1,j+1,0,1)-vel(i,j-1,0,1)-vel(i-1,j-1,0,1))*(0.25*dyi);
-            if (i==dhi.x+1 and !is_periodic){
-                if (bct(Orientation(Direction::x,Orientation::high),0)==AMREX_LO_NEUMANN){
-                    dudy = (0.5*dyi) * (vel(i-1,j+1,0,0)-vel(i-1,j-1,0,0));
-                }
-                if (bct(Orientation(Direction::x,Orientation::high),1)==AMREX_LO_NEUMANN){
-                    dvdy = (0.5*dyi) * (vel(i-1,j+1,0,1)-vel(i-1,j-1,0,1));
-                }
-                if (bct(Orientation(Direction::x,Orientation::high),0)==AMREX_LO_DIRICHLET){
-                    dudy = (0.5*dyi) * (vel(i  ,j+1,0,0)-vel(i  ,j-1,0,0));
-                }
-                if (bct(Orientation(Direction::x,Orientation::high),1)==AMREX_LO_DIRICHLET){
-                    dvdy = (0.5*dyi) * (vel(i  ,j+1,0,1)-vel(i  ,j-1,0,1));
-                }
-            }
-            if (i==dlo.x and !is_periodic){
-                if (bct(Orientation(Direction::x,Orientation::low),0)==AMREX_LO_NEUMANN){
-                    dudy = (0.5*dyi) * (vel(i  ,j+1,0,0)-vel(i  ,j-1,0,0));
-                }
-                if (bct(Orientation(Direction::x,Orientation::low),1)==AMREX_LO_NEUMANN){
-                    dvdy = (0.5*dyi) * (vel(i  ,j+1,0,1)-vel(i  ,j-1,0,1));
-                }
-                if (bct(Orientation(Direction::x,Orientation::low),0)==AMREX_LO_DIRICHLET){
-                    dudy = (0.5*dyi) * (vel(i-1,j+1,0,0)-vel(i-1,j-1,0,0));
-                }
-                if (bct(Orientation(Direction::x,Orientation::low),1)==AMREX_LO_DIRICHLET){
-                    dvdy = (0.5*dyi) * (vel(i-1,j+1,0,1)-vel(i-1,j-1,0,1));
-                }
-            }
             Real divu = dvdy;
             Real xif = kapx(i,j,0);
             Real mun = 0.75*(etax(i,j,0,0)-xif);  // restore the original eta
@@ -187,10 +156,7 @@ void mltensor_cross_terms_fy (Box const& box, Array4<Real> const& fy,
                               Array4<Real const> const& vel,
                               Array4<Real const> const& etay,
                               Array4<Real const> const& kapy,
-                              GpuArray<Real,AMREX_SPACEDIM> const& dxinv,
-                              const Dim3& dlo, const Dim3& dhi,
-                              Array2D<BoundCond,0,2*AMREX_SPACEDIM-1,0,AMREX_SPACEDIM-1> const& bct,
-                              const int& is_periodic) noexcept
+                              GpuArray<Real,AMREX_SPACEDIM> const& dxinv) noexcept
 {
     const Real dxi = dxinv[0];
     const auto lo = amrex::lbound(box);
@@ -202,35 +168,6 @@ void mltensor_cross_terms_fy (Box const& box, Array4<Real> const& fy,
         for (int i = lo.x; i <= hi.x; ++i) {
             Real dudx = (vel(i+1,j,0,0)+vel(i+1,j-1,0,0)-vel(i-1,j,0,0)-vel(i-1,j-1,0,0))*(0.25*dxi);
             Real dvdx = (vel(i+1,j,0,1)+vel(i+1,j-1,0,1)-vel(i-1,j,0,1)-vel(i-1,j-1,0,1))*(0.25*dxi);
-            if (j==dhi.y+1 and !is_periodic){
-                if (bct(Orientation(Direction::y,Orientation::high),0)==AMREX_LO_NEUMANN){
-                    dudx = (0.5*dxi) * (vel(i+1,j-1,0,0)-vel(i-1,j-1,0,0));
-                }
-                if (bct(Orientation(Direction::y,Orientation::high),1)==AMREX_LO_NEUMANN){
-                    dvdx = (0.5*dxi) * (vel(i+1,j-1,0,1)-vel(i-1,j-1,0,1));
-                }
-                if (bct(Orientation(Direction::y,Orientation::high),0)==AMREX_LO_DIRICHLET){
-                    dudx = (0.5*dxi) * (vel(i+1,j  ,0,0)-vel(i-1,j  ,0,0));
-                }
-                if (bct(Orientation(Direction::y,Orientation::high),1)==AMREX_LO_DIRICHLET){
-                    dvdx = (0.5*dxi) * (vel(i+1,j  ,0,1)-vel(i-1,j  ,0,1));
-                }
-            }
-            if (j==dlo.y and !is_periodic){
-                if (bct(Orientation(Direction::y,Orientation::low),0)==AMREX_LO_NEUMANN){
-                    dudx = (0.5*dxi) * (vel(i+1,j  ,0,0)-vel(i-1,j  ,0,0));
-                }
-                if (bct(Orientation(Direction::y,Orientation::low),1)==AMREX_LO_NEUMANN){
-                    dvdx = (0.5*dxi) * (vel(i+1,j  ,0,1)-vel(i-1,j  ,0,1));
-                }
-                if (bct(Orientation(Direction::y,Orientation::low),0)==AMREX_LO_DIRICHLET){
-                    dudx = (0.5*dxi) * (vel(i+1,j-1,0,0)-vel(i-1,j-1,0,0));
-                }
-                if (bct(Orientation(Direction::y,Orientation::low),1)==AMREX_LO_DIRICHLET){
-                    dvdx = (0.5*dxi) * (vel(i+1,j-1,0,1)-vel(i-1,j-1,0,1));
-                }
-            }
-
             Real divu = dudx;
             Real xif = kapy(i,j,0);
             Real mun = 0.75*(etay(i,j,0,1)-xif);  // restore the original eta

--- a/Src/LinearSolvers/MLMG/AMReX_MLTensor_3D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLTensor_3D_K.H
@@ -1056,10 +1056,7 @@ void mltensor_cross_terms_fx (Box const& box, Array4<Real> const& fx,
                               Array4<Real const> const& vel,
                               Array4<Real const> const& etax,
                               Array4<Real const> const& kapx,
-                              GpuArray<Real,AMREX_SPACEDIM> const& dxinv,
-                              const Dim3& dlo, const Dim3& dhi,
-                              Array2D<BoundCond,0,2*AMREX_SPACEDIM-1,0,AMREX_SPACEDIM-1> const& bct,
-                              const int& is_periodic) noexcept
+                              GpuArray<Real,AMREX_SPACEDIM> const& dxinv) noexcept
 {
     const Real dyi = dxinv[1];
     const Real dzi = dxinv[2];
@@ -1073,65 +1070,8 @@ void mltensor_cross_terms_fx (Box const& box, Array4<Real> const& fx,
             for (int i = lo.x; i <= hi.x; ++i) {
                 Real dudy = (vel(i,j+1,k,0)+vel(i-1,j+1,k,0)-vel(i,j-1,k,0)-vel(i-1,j-1,k,0))*(0.25*dyi);
                 Real dvdy = (vel(i,j+1,k,1)+vel(i-1,j+1,k,1)-vel(i,j-1,k,1)-vel(i-1,j-1,k,1))*(0.25*dyi);
-                if (i==dhi.x+1 and !is_periodic){
-                    if (bct(Orientation(Direction::x,Orientation::high),0)==AMREX_LO_NEUMANN){
-                        dudy = (0.5*dyi) * (vel(i-1,j+1,k,0)-vel(i-1,j-1,k,0));
-                    }
-                    if (bct(Orientation(Direction::x,Orientation::high),1)==AMREX_LO_NEUMANN){
-                        dvdy = (0.5*dyi) * (vel(i-1,j+1,k,1)-vel(i-1,j-1,k,1));
-                    }
-                    if (bct(Orientation(Direction::x,Orientation::high),0)==AMREX_LO_DIRICHLET){
-                        dudy = (0.5*dyi) * (vel(i  ,j+1,k,0)-vel(i  ,j-1,k,0));
-                    }
-                    if (bct(Orientation(Direction::x,Orientation::high),1)==AMREX_LO_DIRICHLET){
-                        dvdy = (0.5*dyi) * (vel(i  ,j+1,k,1)-vel(i  ,j-1,k,1));
-                    }
-                }
-                if (i==dlo.x and !is_periodic){
-                    if (bct(Orientation(Direction::x,Orientation::low),0)==AMREX_LO_NEUMANN){
-                        dudy = (0.5*dyi) * (vel(i  ,j+1,k,0)-vel(i  ,j-1,k,0));
-                    }
-                    if (bct(Orientation(Direction::x,Orientation::low),1)==AMREX_LO_NEUMANN){
-                        dvdy = (0.5*dyi) * (vel(i  ,j+1,k,1)-vel(i  ,j-1,k,1));
-                    }
-                    if (bct(Orientation(Direction::x,Orientation::low),0)==AMREX_LO_DIRICHLET){
-                        dudy = (0.5*dyi) * (vel(i-1,j+1,k,0)-vel(i-1,j-1,k,0));
-                    }
-                    if (bct(Orientation(Direction::x,Orientation::low),1)==AMREX_LO_DIRICHLET){
-                        dvdy = (0.5*dyi) * (vel(i-1,j+1,k,1)-vel(i-1,j-1,k,1));
-                    }
-                }
                 Real dudz = (vel(i,j,k+1,0)+vel(i-1,j,k+1,0)-vel(i,j,k-1,0)-vel(i-1,j,k-1,0))*(0.25*dzi);
                 Real dwdz = (vel(i,j,k+1,2)+vel(i-1,j,k+1,2)-vel(i,j,k-1,2)-vel(i-1,j,k-1,2))*(0.25*dzi);
-                if (i==dhi.x+1 and !is_periodic){
-                    if (bct(Orientation(Direction::x,Orientation::high),0)==AMREX_LO_NEUMANN){
-                        dudz = (0.5*dzi) * (vel(i-1,j,k+1,0)-vel(i-1,j,k-1,0));
-                    }
-                    if (bct(Orientation(Direction::x,Orientation::high),2)==AMREX_LO_NEUMANN){
-                        dwdz = (0.5*dzi) * (vel(i-1,j,k+1,2)-vel(i-1,j,k-1,2));
-                    }
-                    if (bct(Orientation(Direction::x,Orientation::high),0)==AMREX_LO_DIRICHLET){
-                        dudz = (0.5*dzi) * (vel(i  ,j,k+1,0)-vel(i  ,j,k-1,0));
-                    }
-                    if (bct(Orientation(Direction::x,Orientation::high),2)==AMREX_LO_DIRICHLET){
-                        dwdz = (0.5*dzi) * (vel(i  ,j,k+1,2)-vel(i  ,j,k-1,2));
-                    }
-                }
-                if (i==dlo.x and !is_periodic){
-                    if (bct(Orientation(Direction::x,Orientation::low),0)==AMREX_LO_NEUMANN){
-                        dudz = (0.5*dzi) * (vel(i  ,j,k+1,0)-vel(i  ,j,k-1,0));
-                    }
-                    if (bct(Orientation(Direction::x,Orientation::low),2)==AMREX_LO_NEUMANN){
-                        dwdz = (0.5*dzi) * (vel(i  ,j,k+1,2)-vel(i  ,j,k-1,2));
-                    }
-                    if (bct(Orientation(Direction::x,Orientation::low),0)==AMREX_LO_DIRICHLET){
-                        dudz = (0.5*dzi) * (vel(i-1,j,k+1,0)-vel(i-1,j,k-1,0));
-                    }
-                    if (bct(Orientation(Direction::x,Orientation::low),2)==AMREX_LO_DIRICHLET){
-                        dwdz = (0.5*dzi) * (vel(i-1,j,k+1,2)-vel(i-1,j,k-1,2));
-                    }
-                }
-
                 Real divu = dvdy + dwdz;
                 Real xif = kapx(i,j,k);
                 Real mun = 0.75*(etax(i,j,k,0)-xif);  // restore the original eta
@@ -1149,10 +1089,7 @@ void mltensor_cross_terms_fy (Box const& box, Array4<Real> const& fy,
                               Array4<Real const> const& vel,
                               Array4<Real const> const& etay,
                               Array4<Real const> const& kapy,
-                              GpuArray<Real,AMREX_SPACEDIM> const& dxinv,
-                              const Dim3& dlo, const Dim3& dhi,
-                              Array2D<BoundCond,0,2*AMREX_SPACEDIM-1,0,AMREX_SPACEDIM-1> const& bct,
-                              const int& is_periodic) noexcept
+                              GpuArray<Real,AMREX_SPACEDIM> const& dxinv) noexcept
 {
     const Real dxi = dxinv[0];
     const Real dzi = dxinv[2];
@@ -1166,64 +1103,8 @@ void mltensor_cross_terms_fy (Box const& box, Array4<Real> const& fy,
             for (int i = lo.x; i <= hi.x; ++i) {
                 Real dudx = (vel(i+1,j,k,0)+vel(i+1,j-1,k,0)-vel(i-1,j,k,0)-vel(i-1,j-1,k,0))*(0.25*dxi);
                 Real dvdx = (vel(i+1,j,k,1)+vel(i+1,j-1,k,1)-vel(i-1,j,k,1)-vel(i-1,j-1,k,1))*(0.25*dxi);
-                if (j==dhi.y+1 and !is_periodic){
-                    if (bct(Orientation(Direction::y,Orientation::high),0)==AMREX_LO_NEUMANN){
-                        dudx = (0.5*dxi) * (vel(i+1,j-1,k,0)-vel(i-1,j-1,k,0));
-                    }
-                    if (bct(Orientation(Direction::y,Orientation::high),1)==AMREX_LO_NEUMANN){
-                        dvdx = (0.5*dxi) * (vel(i+1,j-1,k,1)-vel(i-1,j-1,k,1));
-                    }
-                    if (bct(Orientation(Direction::y,Orientation::high),0)==AMREX_LO_DIRICHLET){
-                        dudx = (0.5*dxi) * (vel(i+1,j  ,k,0)-vel(i-1,j  ,k,0));
-                    }
-                    if (bct(Orientation(Direction::y,Orientation::high),1)==AMREX_LO_DIRICHLET){
-                        dvdx = (0.5*dxi) * (vel(i+1,j  ,k,1)-vel(i-1,j  ,k,1));
-                    }
-                }
-                if (j==dlo.y and !is_periodic){
-                    if (bct(Orientation(Direction::y,Orientation::low),0)==AMREX_LO_NEUMANN){
-                        dudx = (0.5*dxi) * (vel(i+1,j  ,k,0)-vel(i-1,j  ,k,0));
-                    }
-                    if (bct(Orientation(Direction::y,Orientation::low),1)==AMREX_LO_NEUMANN){
-                        dvdx = (0.5*dxi) * (vel(i+1,j  ,k,1)-vel(i-1,j  ,k,1));
-                    }
-                    if (bct(Orientation(Direction::y,Orientation::low),0)==AMREX_LO_DIRICHLET){
-                        dudx = (0.5*dxi) * (vel(i+1,j-1,k,0)-vel(i-1,j-1,k,0));
-                    }
-                    if (bct(Orientation(Direction::y,Orientation::low),1)==AMREX_LO_DIRICHLET){
-                        dvdx = (0.5*dxi) * (vel(i+1,j-1,k,1)-vel(i-1,j-1,k,1));
-                    }
-                }
                 Real dvdz = (vel(i,j,k+1,1)+vel(i,j-1,k+1,1)-vel(i,j,k-1,1)-vel(i,j-1,k-1,1))*(0.25*dzi);
                 Real dwdz = (vel(i,j,k+1,2)+vel(i,j-1,k+1,2)-vel(i,j,k-1,2)-vel(i,j-1,k-1,2))*(0.25*dzi);
-                if (j==dhi.y+1 and !is_periodic){
-                    if (bct(Orientation(Direction::y,Orientation::high),1)==AMREX_LO_NEUMANN){
-                        dvdz = (0.5*dzi) * (vel(i,j-1,k+1,1)-vel(i,j-1,k-1,1));
-                    }
-                    if (bct(Orientation(Direction::y,Orientation::high),2)==AMREX_LO_NEUMANN){
-                        dwdz = (0.5*dzi) * (vel(i,j-1,k+1,2)-vel(i,j-1,k-1,2));
-                    }
-                    if (bct(Orientation(Direction::y,Orientation::high),1)==AMREX_LO_DIRICHLET){
-                        dvdz = (0.5*dzi) * (vel(i,j  ,k+1,1)-vel(i,j  ,k-1,1));
-                    }
-                    if (bct(Orientation(Direction::y,Orientation::high),2)==AMREX_LO_DIRICHLET){
-                        dwdz = (0.5*dzi) * (vel(i,j  ,k+1,2)-vel(i,j  ,k-1,2));
-                    }
-                }
-                if (j==dlo.y and !is_periodic){
-                    if (bct(Orientation(Direction::y,Orientation::low),1)==AMREX_LO_NEUMANN){
-                        dvdz = (0.5*dzi) * (vel(i,j  ,k+1,1)-vel(i,j  ,k-1,1));
-                    }
-                    if (bct(Orientation(Direction::y,Orientation::low),2)==AMREX_LO_NEUMANN){
-                        dwdz = (0.5*dzi) * (vel(i,j  ,k+1,2)-vel(i,j  ,k-1,2));
-                    }
-                    if (bct(Orientation(Direction::y,Orientation::low),1)==AMREX_LO_DIRICHLET){
-                        dvdz = (0.5*dzi) * (vel(i,j-1,k+1,1)-vel(i,j-1,k-1,1));
-                    }
-                    if (bct(Orientation(Direction::y,Orientation::low),2)==AMREX_LO_DIRICHLET){
-                        dwdz = (0.5*dzi) * (vel(i,j-1,k+1,2)-vel(i,j-1,k-1,2));
-                    }
-                }
                 Real divu = dudx + dwdz;
                 Real xif = kapy(i,j,k);
                 Real mun = 0.75*(etay(i,j,k,1)-xif);  // restore the original eta
@@ -1241,10 +1122,7 @@ void mltensor_cross_terms_fz (Box const& box, Array4<Real> const& fz,
                               Array4<Real const> const& vel,
                               Array4<Real const> const& etaz,
                               Array4<Real const> const& kapz,
-                              GpuArray<Real,AMREX_SPACEDIM> const& dxinv,
-                              const Dim3& dlo, const Dim3& dhi,
-                              Array2D<BoundCond,0,2*AMREX_SPACEDIM-1,0,AMREX_SPACEDIM-1> const& bct,
-                              const int& is_periodic) noexcept
+                              GpuArray<Real,AMREX_SPACEDIM> const& dxinv) noexcept
 {
     const Real dxi = dxinv[0];
     const Real dyi = dxinv[1];
@@ -1258,65 +1136,8 @@ void mltensor_cross_terms_fz (Box const& box, Array4<Real> const& fz,
             for (int i = lo.x; i <= hi.x; ++i) {
                 Real dudx = (vel(i+1,j,k,0)+vel(i+1,j,k-1,0)-vel(i-1,j,k,0)-vel(i-1,j,k-1,0))*(0.25*dxi);
                 Real dwdx = (vel(i+1,j,k,2)+vel(i+1,j,k-1,2)-vel(i-1,j,k,2)-vel(i-1,j,k-1,2))*(0.25*dxi);
-                if (k==dhi.z+1 and !is_periodic){
-                    if (bct(Orientation(Direction::z,Orientation::high),0)==AMREX_LO_NEUMANN){
-                        dudx = (0.5*dxi) * (vel(i+1,j,k-1,0)-vel(i-1,j,k-1,0));
-                    }
-                    if (bct(Orientation(Direction::z,Orientation::high),2)==AMREX_LO_NEUMANN){
-                        dwdx = (0.5*dxi) * (vel(i+1,j,k-1,2)-vel(i-1,j,k-1,2));
-                    }
-                    if (bct(Orientation(Direction::z,Orientation::high),0)==AMREX_LO_DIRICHLET){
-                        dudx = (0.5*dxi) * (vel(i+1,j,k  ,0)-vel(i-1,j,k  ,0));
-                    }
-                    if (bct(Orientation(Direction::z,Orientation::high),2)==AMREX_LO_DIRICHLET){
-                        dwdx = (0.5*dxi) * (vel(i+1,j,k  ,2)-vel(i-1,j,k  ,2));
-                    }
-                }
-                if (k==dlo.z and !is_periodic){
-                    if (bct(Orientation(Direction::z,Orientation::low),0)==AMREX_LO_NEUMANN){
-                        dudx = (0.5*dxi) * (vel(i+1,j,k  ,0)-vel(i-1,j,k  ,0));
-                    }
-                    if (bct(Orientation(Direction::z,Orientation::low),2)==AMREX_LO_NEUMANN){
-                        dwdx = (0.5*dxi) * (vel(i+1,j,k  ,2)-vel(i-1,j,k  ,2));
-                    }
-                    if (bct(Orientation(Direction::z,Orientation::low),0)==AMREX_LO_DIRICHLET){
-                        dudx = (0.5*dxi) * (vel(i+1,j,k-1,0)-vel(i-1,j,k-1,0));
-                    }
-                    if (bct(Orientation(Direction::z,Orientation::low),2)==AMREX_LO_DIRICHLET){
-                        dwdx = (0.5*dxi) * (vel(i+1,j,k-1,2)-vel(i-1,j,k-1,2));
-                    }
-                }
                 Real dvdy = (vel(i,j+1,k,1)+vel(i,j+1,k-1,1)-vel(i,j-1,k,1)-vel(i,j-1,k-1,1))*(0.25*dyi);
                 Real dwdy = (vel(i,j+1,k,2)+vel(i,j+1,k-1,2)-vel(i,j-1,k,2)-vel(i,j-1,k-1,2))*(0.25*dyi);
-                if (k==dhi.z+1 and !is_periodic){
-                    if (bct(Orientation(Direction::z,Orientation::high),1)==AMREX_LO_NEUMANN){
-                        dvdy = (0.5*dyi) * (vel(i,j+1,k-1,1)-vel(i,j-1,k-1,1));
-                    }
-                    if (bct(Orientation(Direction::z,Orientation::high),2)==AMREX_LO_NEUMANN){
-                        dwdy = (0.5*dyi) * (vel(i,j+1,k-1,2)-vel(i,j-1,k-1,2));
-                    }
-                    if (bct(Orientation(Direction::z,Orientation::high),1)==AMREX_LO_DIRICHLET){
-                        dvdy = (0.5*dyi) * (vel(i,j+1,k  ,1)-vel(i,j-1,k  ,1));
-                    }
-                    if (bct(Orientation(Direction::z,Orientation::high),2)==AMREX_LO_DIRICHLET){
-                        dwdy = (0.5*dyi) * (vel(i,j+1,k  ,2)-vel(i,j-1,k  ,2));
-                    }
-                }
-                if (k==dlo.z and !is_periodic){
-                    if (bct(Orientation(Direction::z,Orientation::low),1)==AMREX_LO_NEUMANN){
-                        dvdy = (0.5*dyi) * (vel(i,j+1,k  ,1)-vel(i,j-1,k  ,1));
-                    }
-                    if (bct(Orientation(Direction::z,Orientation::low),2)==AMREX_LO_NEUMANN){
-                        dwdy = (0.5*dyi) * (vel(i,j+1,k  ,2)-vel(i,j-1,k  ,2));
-                    }
-                    if (bct(Orientation(Direction::z,Orientation::low),1)==AMREX_LO_DIRICHLET){
-                        dvdy = (0.5*dyi) * (vel(i,j+1,k-1,1)-vel(i,j-1,k-1,1));
-                    }
-                    if (bct(Orientation(Direction::z,Orientation::low),2)==AMREX_LO_DIRICHLET){
-                        dwdy = (0.5*dyi) * (vel(i,j+1,k-1,2)-vel(i,j-1,k-1,2));
-                    }
-                }
-
                 Real divu = dudx + dvdy;
                 Real xif = kapz(i,j,k);
                 Real mun = 0.75*(etaz(i,j,k,2)-xif);  // restore the original eta


### PR DESCRIPTION
## Summary

ParmParse parameter eb2.extend_domain_face is now true by default.  The
reason for the change is that for most applications it's hard to imagine one
would want it to be false.  It will also solve the EB tensor solver issue
when there is a cut cell just outside the domain abutting a covered valid
cell.

Recent changes to the tensor solvers are incorrect and are reverted here.
They are incorrect because the ghost cells in the modified functions
actually have values at the cell centered.  Although the users put domain
face values in the ghost cells, that is not what the solver does.  The
solver stores the boundary values in boundary registers.  Before the stencil
is being applied, bc function is called to fill the ghost cells with
properly interpolated or extrapolated values so that the stencil operations
are just like working on normal interior cells.

Revert "Correcting tensor cross terms computation for periodic bcs (#1254)"
This reverts commit 1197adc5be6144bae9e362c114ca16b879006180.

Revert "Changing computation at inflow/outflow for tensor solve (#1235)"
This reverts commit b391885e918d63fa1741f954d2792e31426a6204.

Revert "Changing computation at outflow for the EBTensor (#1187)"
This reverts commit 9cd538802ea5b3ab7e6db10d6046933e937aa449.

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [x] changes answers in the test suite to more than roundoff level
- [x] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
