### PR TITLE
Change default max_level in AmrCore tutorial from 0 to 2.

### DIFF
--- a/Tutorials/Amr/Advection_AmrCore/Exec/inputs
+++ b/Tutorials/Amr/Advection_AmrCore/Exec/inputs
@@ -26,7 +26,7 @@ amr.v              = 1       # verbosity in Amr
 # Resolution and refinement
 # *****************************************************************
 amr.n_cell          = 64 64 8
-amr.max_level       = 0       # maximum level number allowed -- 
+amr.max_level       = 2       # maximum level number allowed -- 
                               # number of levels = max_level + 1
 
 amr.ref_ratio       = 2 2 2 2 # refinement ratio between levels


### PR DESCRIPTION
## Summary

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
