### PR TITLE
updated Make.machines to include new frontier-coe machines and change…

### DIFF
--- a/Tools/GNUMake/Make.machines
+++ b/Tools/GNUMake/Make.machines
@@ -9,7 +9,8 @@ ifdef $(HOSTNAME)
 else ifdef $(HOST)
   host_name := $(strip $(HOST))
 else
-  host_name := $(shell hostname)
+  host_name := $(shell hostname -f)
+  host_name_short := $(shell hostname -s)
 endif
 
 # MACHINES supported
@@ -123,8 +124,8 @@ ifeq ($(findstring raijin, $(host_name)), raijin)
   which_computer := raijin
 endif
 
-ifneq (,$(filter $(host_name),poplar redwood tulip))
+ifneq (,$(filter $(host_name_short),poplar redwood tulip))
   which_site := frontier-coe
-  which_computer := $(host_name)
+  which_computer := $(host_name_short)
 endif
 

--- a/Tools/GNUMake/Make.machines
+++ b/Tools/GNUMake/Make.machines
@@ -9,7 +9,7 @@ ifdef $(HOSTNAME)
 else ifdef $(HOST)
   host_name := $(strip $(HOST))
 else
-  host_name := $(shell hostname -f)
+  host_name := $(shell hostname)
 endif
 
 # MACHINES supported
@@ -123,7 +123,8 @@ ifeq ($(findstring raijin, $(host_name)), raijin)
   which_computer := raijin
 endif
 
-ifeq ($(findstring tulip, $(host_name)), tulip)
+ifneq (,$(filter $(host_name),poplar redwood tulip))
   which_site := frontier-coe
-  which_computer := tulip
+  which_computer := $(host_name)
 endif
+


### PR DESCRIPTION
…d 'hostname -f' command to 'hostname'

## Summary
updated Make.machines:
1. added poplar and redwood to frontier-coe machines;
2. changed name string matching for frontier-coe to only
    yield exact matches (filter); hence, !="" means exact match;
3. changed `hostname -f` command (which includes the domain) to `hostname` to
    avoid false negatives, e.g., not recognizing `hostname -f`==tulip.cm.cluster as tulip;

## Additional background

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
