### PR TITLE
Should use std::forward.

### DIFF
--- a/Src/Base/AMReX_FabArrayUtility.H
+++ b/Src/Base/AMReX_FabArrayUtility.H
@@ -12,7 +12,7 @@ template <class FAB, class F,
           class bar = amrex::EnableIf_t<IsBaseFab<FAB>::value> >
 typename FAB::value_type
 ReduceSum (FabArray<FAB> const& fa, int nghost, F&& f) {
-    return ReduceSum(fa, IntVect(nghost), std::move(f));
+    return ReduceSum(fa, IntVect(nghost), std::forward<F>(f));
 }
 
 namespace fudetail {
@@ -75,7 +75,7 @@ template <class FAB, class F>
 amrex::EnableIf_t<!amrex::DefinitelyNotHostRunnable<F>::value, typename FAB::value_type>
 ReduceSum_host_wrapper (FabArray<FAB> const& fa, IntVect const& nghost, F&& f)
 {
-    return ReduceSum_host(fa,nghost,std::move(f));
+    return ReduceSum_host(fa,nghost,std::forward<F>(f));
 }
 
 template <class FAB, class F>
@@ -94,9 +94,9 @@ typename FAB::value_type
 ReduceSum (FabArray<FAB> const& fa, IntVect const& nghost, F&& f)
 {
     if (Gpu::inLaunchRegion()) {
-        return fudetail::ReduceSum_device(fa, nghost, std::move(f));
+        return fudetail::ReduceSum_device(fa, nghost, std::forward<F>(f));
     } else {
-        return fudetail::ReduceSum_host_wrapper(fa, nghost, std::move(f));
+        return fudetail::ReduceSum_host_wrapper(fa, nghost, std::forward<F>(f));
     }
 }
 #else
@@ -105,7 +105,7 @@ template <class FAB, class F,
 typename FAB::value_type
 ReduceSum (FabArray<FAB> const& fa, IntVect const& nghost, F&& f)
 {
-    return fudetail::ReduceSum_host(fa, nghost, std::move(f));
+    return fudetail::ReduceSum_host(fa, nghost, std::forward<F>(f));
 }
 #endif
 
@@ -114,7 +114,7 @@ template <class FAB1, class FAB2, class F,
 typename FAB1::value_type
 ReduceSum (FabArray<FAB1> const& fa1, FabArray<FAB2> const& fa2,
            int nghost, F&& f) {
-    return ReduceSum(fa1, fa2, IntVect(nghost), std::move(f));
+    return ReduceSum(fa1, fa2, IntVect(nghost), std::forward<F>(f));
 }
 
 namespace fudetail {
@@ -182,7 +182,7 @@ amrex::EnableIf_t<!amrex::DefinitelyNotHostRunnable<F>::value, typename FAB1::va
 ReduceSum_host_wrapper (FabArray<FAB1> const& fa1, FabArray<FAB2> const& fa2,
                         IntVect const& nghost, F&& f)
 {
-    return ReduceSum_host(fa1,fa2,nghost,std::move(f));
+    return ReduceSum_host(fa1,fa2,nghost,std::forward<F>(f));
 }
 
 template <class FAB1, class FAB2, class F>
@@ -203,9 +203,9 @@ ReduceSum (FabArray<FAB1> const& fa1, FabArray<FAB2> const& fa2,
            IntVect const& nghost, F&& f)
 {
     if (Gpu::inLaunchRegion()) {
-        return fudetail::ReduceSum_device(fa1,fa2,nghost,std::move(f));
+        return fudetail::ReduceSum_device(fa1,fa2,nghost,std::forward<F>(f));
     } else {
-        return fudetail::ReduceSum_host_wrapper(fa1,fa2,nghost,std::move(f));
+        return fudetail::ReduceSum_host_wrapper(fa1,fa2,nghost,std::forward<F>(f));
     }
 }
 #else
@@ -215,7 +215,7 @@ typename FAB1::value_type
 ReduceSum (FabArray<FAB1> const& fa1, FabArray<FAB2> const& fa2,
            IntVect const& nghost, F&& f)
 {
-    return fudetail::ReduceSum_host(fa1,fa2,nghost,std::move(f));
+    return fudetail::ReduceSum_host(fa1,fa2,nghost,std::forward<F>(f));
 }
 #endif
 
@@ -225,7 +225,7 @@ typename FAB1::value_type
 ReduceSum (FabArray<FAB1> const& fa1, FabArray<FAB2> const& fa2, FabArray<FAB3> const& fa3,
            int nghost, F&& f)
 {
-  return ReduceSum(fa1, fa2, fa3, IntVect(nghost), std::move(f));
+  return ReduceSum(fa1, fa2, fa3, IntVect(nghost), std::forward<F>(f));
 }
 
 namespace fudetail {
@@ -295,7 +295,7 @@ amrex::EnableIf_t<!amrex::DefinitelyNotHostRunnable<F>::value, typename FAB1::va
 ReduceSum_host_wrapper (FabArray<FAB1> const& fa1, FabArray<FAB2> const& fa2,
                         FabArray<FAB3> const& fa3, IntVect const& nghost, F&& f)
 {
-    return fudetail::ReduceSum_host(fa1,fa2,fa3,nghost,std::move(f));
+    return fudetail::ReduceSum_host(fa1,fa2,fa3,nghost,std::forward<F>(f));
 }
 
 template <class FAB1, class FAB2, class FAB3, class F>
@@ -316,9 +316,9 @@ ReduceSum (FabArray<FAB1> const& fa1, FabArray<FAB2> const& fa2,
            FabArray<FAB3> const& fa3, IntVect const& nghost, F&& f)
 {
     if (Gpu::inLaunchRegion()) {
-        return fudetail::ReduceSum_device(fa1,fa2,fa3,nghost,std::move(f));
+        return fudetail::ReduceSum_device(fa1,fa2,fa3,nghost,std::forward<F>(f));
     } else {
-        return fudetail::ReduceSum_host_wrapper(fa1,fa2,fa3,nghost,std::move(f));
+        return fudetail::ReduceSum_host_wrapper(fa1,fa2,fa3,nghost,std::forward<F>(f));
     }
 }
 #else
@@ -328,7 +328,7 @@ typename FAB1::value_type
 ReduceSum (FabArray<FAB1> const& fa1, FabArray<FAB2> const& fa2,
            FabArray<FAB3> const& fa3, IntVect const& nghost, F&& f)
 {
-    return fudetail::ReduceSum_host(fa1,fa2,fa3,nghost,std::move(f));
+    return fudetail::ReduceSum_host(fa1,fa2,fa3,nghost,std::forward<F>(f));
 }
 #endif
 
@@ -337,7 +337,7 @@ template <class FAB, class F,
 typename FAB::value_type
 ReduceMin (FabArray<FAB> const& fa, int nghost, F&& f)
 {
-    return ReduceMin(fa, IntVect(nghost), std::move(f));
+    return ReduceMin(fa, IntVect(nghost), std::forward<F>(f));
 }
 
 namespace fudetail {
@@ -401,7 +401,7 @@ template <class FAB, class F>
 amrex::EnableIf_t<!amrex::DefinitelyNotHostRunnable<F>::value, typename FAB::value_type>
 ReduceMin_host_wrapper (FabArray<FAB> const& fa, IntVect const& nghost, F&& f)
 {
-    return ReduceMin_host(fa,nghost,std::move(f));
+    return ReduceMin_host(fa,nghost,std::forward<F>(f));
 }
 
 template <class FAB, class F>
@@ -420,9 +420,9 @@ typename FAB::value_type
 ReduceMin (FabArray<FAB> const& fa, IntVect const& nghost, F&& f)
 {
     if (Gpu::inLaunchRegion()) {
-        return fudetail::ReduceMin_device(fa, nghost, std::move(f));
+        return fudetail::ReduceMin_device(fa, nghost, std::forward<F>(f));
     } else {
-        return fudetail::ReduceMin_host_wrapper(fa, nghost, std::move(f));
+        return fudetail::ReduceMin_host_wrapper(fa, nghost, std::forward<F>(f));
     }
 }
 #else
@@ -431,7 +431,7 @@ template <class FAB, class F,
 typename FAB::value_type
 ReduceMin (FabArray<FAB> const& fa, IntVect const& nghost, F&& f)
 {
-    return fudetail::ReduceMin_host(fa, nghost, std::move(f));
+    return fudetail::ReduceMin_host(fa, nghost, std::forward<F>(f));
 }
 #endif
 
@@ -440,7 +440,7 @@ template <class FAB1, class FAB2, class F,
 typename FAB1::value_type
 ReduceMin (FabArray<FAB1> const& fa1, FabArray<FAB2> const& fa2, int nghost, F&& f)
 {
-    return ReduceMin(fa1, fa2, IntVect(nghost), std::move(f));
+    return ReduceMin(fa1, fa2, IntVect(nghost), std::forward<F>(f));
 }
 
 namespace fudetail {
@@ -510,7 +510,7 @@ amrex::EnableIf_t<!amrex::DefinitelyNotHostRunnable<F>::value, typename FAB1::va
 ReduceMin_host_wrapper (FabArray<FAB1> const& fa1, FabArray<FAB2> const& fa2,
                         IntVect const& nghost, F&& f)
 {
-    return fudetail::ReduceMin_host(fa1,fa2,nghost,std::move(f));
+    return fudetail::ReduceMin_host(fa1,fa2,nghost,std::forward<F>(f));
 }
 
 template <class FAB1, class FAB2, class F>
@@ -531,9 +531,9 @@ ReduceMin (FabArray<FAB1> const& fa1, FabArray<FAB2> const& fa2,
            IntVect const& nghost, F&& f)
 {
     if (Gpu::inLaunchRegion()) {
-        return fudetail::ReduceMin_device(fa1,fa2,nghost,std::move(f));
+        return fudetail::ReduceMin_device(fa1,fa2,nghost,std::forward<F>(f));
     } else {
-        return fudetail::ReduceMin_host_wrapper(fa1,fa2,nghost,std::move(f));
+        return fudetail::ReduceMin_host_wrapper(fa1,fa2,nghost,std::forward<F>(f));
     }
 }
 #else
@@ -543,7 +543,7 @@ typename FAB1::value_type
 ReduceMin (FabArray<FAB1> const& fa1, FabArray<FAB2> const& fa2,
            IntVect const& nghost, F&& f)
 {
-    return fudetail::ReduceMin_host(fa1,fa2,nghost,std::move(f));
+    return fudetail::ReduceMin_host(fa1,fa2,nghost,std::forward<F>(f));
 }
 #endif
 
@@ -553,7 +553,7 @@ typename FAB1::value_type
 ReduceMin (FabArray<FAB1> const& fa1, FabArray<FAB2> const& fa2, FabArray<FAB3> const& fa3,
            int nghost, F&& f)
 {
-    return ReduceMin(fa1, fa2, fa3, IntVect(nghost), std::move(f));
+    return ReduceMin(fa1, fa2, fa3, IntVect(nghost), std::forward<F>(f));
 }
 
 namespace fudetail {
@@ -625,7 +625,7 @@ amrex::EnableIf_t<!amrex::DefinitelyNotHostRunnable<F>::value, typename FAB1::va
 ReduceMin_host_wrapper (FabArray<FAB1> const& fa1, FabArray<FAB2> const& fa2,
                         FabArray<FAB3> const& fa3, IntVect const& nghost, F&& f)
 {
-    return fudetail::ReduceMin_host(fa1,fa2,fa3,nghost,std::move(f));
+    return fudetail::ReduceMin_host(fa1,fa2,fa3,nghost,std::forward<F>(f));
 }
 
 template <class FAB1, class FAB2, class FAB3, class F>
@@ -646,9 +646,9 @@ ReduceMin (FabArray<FAB1> const& fa1, FabArray<FAB2> const& fa2,
            FabArray<FAB3> const& fa3, IntVect const& nghost, F&& f)
 {
     if (Gpu::inLaunchRegion()) {
-        return fudetail::ReduceMin_device(fa1,fa2,fa3,nghost,std::move(f));
+        return fudetail::ReduceMin_device(fa1,fa2,fa3,nghost,std::forward<F>(f));
     } else {
-        return fudetail::ReduceMin_host_wrapper(fa1,fa2,fa3,nghost,std::move(f));
+        return fudetail::ReduceMin_host_wrapper(fa1,fa2,fa3,nghost,std::forward<F>(f));
     }
 }
 #else
@@ -658,7 +658,7 @@ typename FAB1::value_type
 ReduceMin (FabArray<FAB1> const& fa1, FabArray<FAB2> const& fa2,
            FabArray<FAB3> const& fa3, IntVect const& nghost, F&& f)
 {
-    return fudetail::ReduceMin_host(fa1,fa2,fa3,nghost,std::move(f));
+    return fudetail::ReduceMin_host(fa1,fa2,fa3,nghost,std::forward<F>(f));
 }
 #endif
 
@@ -667,7 +667,7 @@ template <class FAB, class F,
 typename FAB::value_type
 ReduceMax (FabArray<FAB> const& fa, int nghost, F&& f)
 {
-    return ReduceMax(fa, IntVect(nghost), std::move(f));
+    return ReduceMax(fa, IntVect(nghost), std::forward<F>(f));
 }
 
 namespace fudetail {
@@ -732,7 +732,7 @@ template <class FAB, class F>
 amrex::EnableIf_t<!amrex::DefinitelyNotHostRunnable<F>::value, typename FAB::value_type>
 ReduceMax_host_wrapper (FabArray<FAB> const& fa, IntVect const& nghost, F&& f)
 {
-    return ReduceMax_host(fa,nghost,std::move(f));
+    return ReduceMax_host(fa,nghost,std::forward<F>(f));
 }
 
 template <class FAB, class F>
@@ -751,9 +751,9 @@ typename FAB::value_type
 ReduceMax (FabArray<FAB> const& fa, IntVect const& nghost, F&& f)
 {
     if (Gpu::inLaunchRegion()) {
-        return fudetail::ReduceMax_device(fa,nghost,std::move(f));
+        return fudetail::ReduceMax_device(fa,nghost,std::forward<F>(f));
     } else {
-        return fudetail::ReduceMax_host_wrapper(fa,nghost,std::move(f));
+        return fudetail::ReduceMax_host_wrapper(fa,nghost,std::forward<F>(f));
     }
 }
 #else
@@ -762,7 +762,7 @@ template <class FAB, class F,
 typename FAB::value_type
 ReduceMax (FabArray<FAB> const& fa, IntVect const& nghost, F&& f)
 {
-    return fudetail::ReduceMax_host(fa,nghost,std::move(f));
+    return fudetail::ReduceMax_host(fa,nghost,std::forward<F>(f));
 }
 #endif
 
@@ -771,7 +771,7 @@ template <class FAB1, class FAB2, class F,
 typename FAB1::value_type
 ReduceMax (FabArray<FAB1> const& fa1, FabArray<FAB2> const& fa2, int nghost, F&& f)
 {
-    return ReduceMax(fa1, fa2, IntVect(nghost), std::move(f));
+    return ReduceMax(fa1, fa2, IntVect(nghost), std::forward<F>(f));
 }
 
 namespace fudetail {
@@ -841,7 +841,7 @@ amrex::EnableIf_t<!amrex::DefinitelyNotHostRunnable<F>::value, typename FAB1::va
 ReduceMax_host_wrapper (FabArray<FAB1> const& fa1, FabArray<FAB2> const& fa2,
                         IntVect const& nghost, F&& f)
 {
-    return ReduceMax_host(fa1,fa2,nghost,std::move(f));
+    return ReduceMax_host(fa1,fa2,nghost,std::forward<F>(f));
 }
 
 template <class FAB1, class FAB2, class F>
@@ -862,9 +862,9 @@ ReduceMax (FabArray<FAB1> const& fa1, FabArray<FAB2> const& fa2,
            IntVect const& nghost, F&& f)
 {
     if (Gpu::inLaunchRegion()) {
-        return fudetail::ReduceMax_device(fa1,fa2,nghost,std::move(f));
+        return fudetail::ReduceMax_device(fa1,fa2,nghost,std::forward<F>(f));
     } else {
-        return fudetail::ReduceMax_host_wrapper(fa1,fa2,nghost,std::move(f));
+        return fudetail::ReduceMax_host_wrapper(fa1,fa2,nghost,std::forward<F>(f));
     }
 }
 #else
@@ -874,7 +874,7 @@ typename FAB1::value_type
 ReduceMax (FabArray<FAB1> const& fa1, FabArray<FAB2> const& fa2,
            IntVect const& nghost, F&& f)
 {
-    return fudetail::ReduceMax_host(fa1,fa2,nghost,std::move(f));
+    return fudetail::ReduceMax_host(fa1,fa2,nghost,std::forward<F>(f));
 }
 #endif
 
@@ -884,7 +884,7 @@ typename FAB1::value_type
 ReduceMax (FabArray<FAB1> const& fa1, FabArray<FAB2> const& fa2, FabArray<FAB3> const& fa3,
            int nghost, F&& f)
 {
-    return ReduceMax(fa1, fa2, fa3, IntVect(nghost), std::move(f));
+    return ReduceMax(fa1, fa2, fa3, IntVect(nghost), std::forward<F>(f));
 }
 
 namespace fudetail {
@@ -956,7 +956,7 @@ amrex::EnableIf_t<!amrex::DefinitelyNotHostRunnable<F>::value, typename FAB1::va
 ReduceMax_host_wrapper (FabArray<FAB1> const& fa1, FabArray<FAB2> const& fa2,
                         FabArray<FAB3> const& fa3, IntVect const& nghost, F&& f)
 {
-    return fudetail::ReduceMax_host(fa1,fa2,fa3,nghost,std::move(f));
+    return fudetail::ReduceMax_host(fa1,fa2,fa3,nghost,std::forward<F>(f));
 }
 
 template <class FAB1, class FAB2, class FAB3, class F>
@@ -977,9 +977,9 @@ ReduceMax (FabArray<FAB1> const& fa1, FabArray<FAB2> const& fa2,
            FabArray<FAB3> const& fa3, IntVect const& nghost, F&& f)
 {
     if (Gpu::inLaunchRegion()) {
-        return fudetail::ReduceMax_device(fa1,fa2,fa3,nghost,std::move(f));
+        return fudetail::ReduceMax_device(fa1,fa2,fa3,nghost,std::forward<F>(f));
     } else {
-        return fudetail::ReduceMax_host_wrapper(fa1,fa2,fa3,nghost,std::move(f));
+        return fudetail::ReduceMax_host_wrapper(fa1,fa2,fa3,nghost,std::forward<F>(f));
     }
 }
 #else
@@ -989,7 +989,7 @@ typename FAB1::value_type
 ReduceMax (FabArray<FAB1> const& fa1, FabArray<FAB2> const& fa2,
            FabArray<FAB3> const& fa3, IntVect const& nghost, F&& f)
 {
-    return fudetail::ReduceMax_host(fa1,fa2,fa3,nghost,std::move(f));
+    return fudetail::ReduceMax_host(fa1,fa2,fa3,nghost,std::forward<F>(f));
 }
 #endif
 
@@ -998,7 +998,7 @@ template <class FAB, class F,
 bool
 ReduceLogicalAnd (FabArray<FAB> const& fa, int nghost, F&& f)
 {
-    return ReduceLogicalAnd(fa, IntVect(nghost), std::move(f));
+    return ReduceLogicalAnd(fa, IntVect(nghost), std::forward<F>(f));
 }
 
 namespace fudetail {
@@ -1060,7 +1060,7 @@ template <class FAB, class F>
 amrex::EnableIf_t<!amrex::DefinitelyNotHostRunnable<F>::value, bool>
 ReduceLogicalAnd_host_wrapper (FabArray<FAB> const& fa, IntVect const& nghost, F&& f)
 {
-    return ReduceLogicalAnd_host(fa,nghost,std::move(f));
+    return ReduceLogicalAnd_host(fa,nghost,std::forward<F>(f));
 }
 
 template <class FAB, class F>
@@ -1079,9 +1079,9 @@ bool
 ReduceLogicalAnd (FabArray<FAB> const& fa, IntVect const& nghost, F&& f)
 {
     if (Gpu::inLaunchRegion()) {
-        return fudetail::ReduceLogicalAnd_device(fa,nghost,std::move(f));
+        return fudetail::ReduceLogicalAnd_device(fa,nghost,std::forward<F>(f));
     } else {
-        return fudetail::ReduceLogicalAnd_host_wrapper(fa,nghost,std::move(f));
+        return fudetail::ReduceLogicalAnd_host_wrapper(fa,nghost,std::forward<F>(f));
     }
 }
 #else
@@ -1090,7 +1090,7 @@ template <class FAB, class F,
 bool
 ReduceLogicalAnd (FabArray<FAB> const& fa, IntVect const& nghost, F&& f)
 {
-    return fudetail::ReduceLogicalAnd_host(fa,nghost,std::move(f));
+    return fudetail::ReduceLogicalAnd_host(fa,nghost,std::forward<F>(f));
 }
 #endif
 
@@ -1100,7 +1100,7 @@ bool
 ReduceLogicalAnd (FabArray<FAB1> const& fa1, FabArray<FAB2> const& fa2,
                   int nghost, F&& f)
 {
-    return ReduceLogicalAnd(fa1, fa2, IntVect(nghost), std::move(f));
+    return ReduceLogicalAnd(fa1, fa2, IntVect(nghost), std::forward<F>(f));
 }
 
 namespace fudetail {
@@ -1167,7 +1167,7 @@ amrex::EnableIf_t<!amrex::DefinitelyNotHostRunnable<F>::value, bool>
 ReduceLogicalAnd_host_wrapper (FabArray<FAB1> const& fa1, FabArray<FAB2> const& fa2,
                   IntVect const& nghost, F&& f)
 {
-    return ReduceLogicalAnd_host(fa1,fa2,nghost,std::move(f));
+    return ReduceLogicalAnd_host(fa1,fa2,nghost,std::forward<F>(f));
 }
 
 template <class FAB1, class FAB2, class F>
@@ -1188,9 +1188,9 @@ ReduceLogicalAnd (FabArray<FAB1> const& fa1, FabArray<FAB2> const& fa2,
                   IntVect const& nghost, F&& f)
 {
     if (Gpu::inLaunchRegion()) {
-        return fudetail::ReduceLogicalAnd_device(fa1,fa2,nghost,std::move(f));
+        return fudetail::ReduceLogicalAnd_device(fa1,fa2,nghost,std::forward<F>(f));
     } else {
-        return fudetail::ReduceLogicalAnd_host_wrapper(fa1,fa2,nghost,std::move(f));
+        return fudetail::ReduceLogicalAnd_host_wrapper(fa1,fa2,nghost,std::forward<F>(f));
     }
 }
 #else
@@ -1200,7 +1200,7 @@ bool
 ReduceLogicalAnd (FabArray<FAB1> const& fa1, FabArray<FAB2> const& fa2,
                   IntVect const& nghost, F&& f)
 {
-    return fudetail::ReduceLogicalAnd_host(fa1,fa2,nghost,std::move(f));
+    return fudetail::ReduceLogicalAnd_host(fa1,fa2,nghost,std::forward<F>(f));
 }
 #endif
 
@@ -1209,7 +1209,7 @@ template <class FAB, class F,
 bool
 ReduceLogicalOr (FabArray<FAB> const& fa, int nghost, F&& f)
 {
-    return ReduceLogicalOr(fa, IntVect(nghost), std::move(f));
+    return ReduceLogicalOr(fa, IntVect(nghost), std::forward<F>(f));
 }
 
 namespace fudetail {
@@ -1271,7 +1271,7 @@ template <class FAB, class F>
 amrex::EnableIf_t<!amrex::DefinitelyNotHostRunnable<F>::value, bool>
 ReduceLogicalOr_host_wrapper (FabArray<FAB> const& fa, IntVect const& nghost, F&& f)
 {
-    return ReduceLogicalOr_host(fa,nghost,std::move(f));
+    return ReduceLogicalOr_host(fa,nghost,std::forward<F>(f));
 }
 
 template <class FAB, class F>
@@ -1290,9 +1290,9 @@ bool
 ReduceLogicalOr (FabArray<FAB> const& fa, IntVect const& nghost, F&& f)
 {
     if (Gpu::inLaunchRegion()) {
-        return fudetail::ReduceLogicalOr_device(fa,nghost,std::move(f));
+        return fudetail::ReduceLogicalOr_device(fa,nghost,std::forward<F>(f));
     } else {
-        return fudetail::ReduceLogicalOr_host_wrapper(fa,nghost,std::move(f));
+        return fudetail::ReduceLogicalOr_host_wrapper(fa,nghost,std::forward<F>(f));
     }
 }
 #else
@@ -1301,7 +1301,7 @@ template <class FAB, class F,
 bool
 ReduceLogicalOr (FabArray<FAB> const& fa, IntVect const& nghost, F&& f)
 {
-    return fudetail::ReduceLogicalOr_host(fa,nghost,std::move(f));
+    return fudetail::ReduceLogicalOr_host(fa,nghost,std::forward<F>(f));
 }
 #endif
 
@@ -1311,7 +1311,7 @@ bool
 ReduceLogicalOr (FabArray<FAB1> const& fa1, FabArray<FAB2> const& fa2,
                  int nghost, F&& f)
 {
-    return ReduceLogicalOr(fa1, fa2, IntVect(nghost), std::move(f));
+    return ReduceLogicalOr(fa1, fa2, IntVect(nghost), std::forward<F>(f));
 }
 
 namespace fudetail {
@@ -1378,7 +1378,7 @@ amrex::EnableIf_t<!amrex::DefinitelyNotHostRunnable<F>::value, bool>
 ReduceLogicalOr_host_wrapper (FabArray<FAB1> const& fa1, FabArray<FAB2> const& fa2,
                  IntVect const& nghost, F&& f)
 {
-    return fudetail::ReduceLogicalOr_host(fa1,fa2,nghost,std::move(f));
+    return fudetail::ReduceLogicalOr_host(fa1,fa2,nghost,std::forward<F>(f));
 }
 
 template <class FAB1, class FAB2, class F>
@@ -1399,9 +1399,9 @@ ReduceLogicalOr (FabArray<FAB1> const& fa1, FabArray<FAB2> const& fa2,
                  IntVect const& nghost, F&& f)
 {
     if (Gpu::inLaunchRegion()) {
-        return fudetail::ReduceLogicalOr_device(fa1,fa2,nghost,std::move(f));
+        return fudetail::ReduceLogicalOr_device(fa1,fa2,nghost,std::forward<F>(f));
     } else {
-        return fudetail::ReduceLogicalOr_host_wrapper(fa1,fa2,nghost,std::move(f));
+        return fudetail::ReduceLogicalOr_host_wrapper(fa1,fa2,nghost,std::forward<F>(f));
     }
 }
 #else
@@ -1411,7 +1411,7 @@ bool
 ReduceLogicalOr (FabArray<FAB1> const& fa1, FabArray<FAB2> const& fa2,
                  IntVect const& nghost, F&& f)
 {
-    return fudetail::ReduceLogicalOr_host(fa1,fa2,nghost,std::move(f));
+    return fudetail::ReduceLogicalOr_host(fa1,fa2,nghost,std::forward<F>(f));
 }
 #endif
 


### PR DESCRIPTION
## Summary

Should use std::forward instead of std::move.

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
