### PR TITLE
add support for additional AMD GPU SKUs and incl. poplar and redwood …

### DIFF
--- a/Tools/GNUMake/sites/Make.frontier-coe
+++ b/Tools/GNUMake/sites/Make.frontier-coe
@@ -1,6 +1,8 @@
-ifeq ($(which_computer),$(filter $(which_computer),tulip))
+ifeq (,$(filter $(which_computer),poplar redwood tulip))
+  $(error Unknown Frontier CoE computer, $(which_computer))
+else
   ifeq ($(USE_HIP),TRUE)
-    CXXFLAGS += --amdgpu-target=gfx906
-    HIPCC_FLAGS += --amdgpu-target=gfx906
+    CXXFLAGS += --amdgpu-target=gfx906,gfx908
+    HIPCC_FLAGS += --amdgpu-target=gfx906,gfx908
   endif
 endif


### PR DESCRIPTION
#1168  Summary
Changed Tools/GNUMake/sites/Make.frontier-coe to
1. add support for additional AMD GPU SKUs;
2. include poplar and redwood in the list of frontier-coe machines

## Additional background
Changed
   ifeq ($(which_computer),$(filter $(which_computer),tulip))
     ifeq ($(USE_HIP),TRUE)
       CXXFLAGS += --amdgpu-target=gfx906
       HIPCC_FLAGS += --amdgpu-target=gfx906
     endif
   endif
to
   ifeq (,$(filter $(which_computer),poplar redwood tulip))
     $(error Unknown Frontier CoE computer, $(which_computer))
   else
     ifeq ($(USE_HIP),TRUE)
       CXXFLAGS += --amdgpu-target=gfx906,gfx908
       HIPCC_FLAGS += --amdgpu-target=gfx906,gfx908
     endif
   endif
For AMD GPUs, the compile target should be exact to avoid runtime errors,
i.e., one should generally not assume that a binary targeting an older GPU
will always run correctly on a newer GPU.  However, building "fat binaries"
is possible, so that one does, typically, not need one separate binary
specifically built for each AMD GPU SKU available on the platform.



## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
