### PR TITLE
amrex::Math::abs for beta8 on DG1

### DIFF
--- a/Src/Base/AMReX_Math.H
+++ b/Src/Base/AMReX_Math.H
@@ -35,7 +35,8 @@ namespace amrex { namespace Math {
 
 //using sycl::abs;
 // We have to do this because somehow sycl::abs(int) return unsigned int.
-template <typename T> T abs (T a) { return sycl::abs(a); }
+//template <typename T> T abs (T a) { return sycl::abs(a); } // The compiler seems to have trouble with this on DG1.
+template <typename T> T abs (T a) { return (a >= T(0)) ? a : -a; }
 
 using sycl::ceil;
 using sycl::copysign;


### PR DESCRIPTION
## Summary

Due to a compiler bug (I believe), we have to modify amrex::Math::abs for
beta8 on DG1.

## Additional background

After spending many hours debugging Tutorial/Amr/Adevection_AmrCore/
on DG1, it is found that `MultiFab::norm0` does not return the correct
result, because of the use of `amrex::Math::abs`.  After making the change
in this PR, the test now produces correct results with AMR.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
