### PR TITLE
TagBoxArray::hasTags

### DIFF
--- a/Src/AmrCore/AMReX_TagBox.H
+++ b/Src/AmrCore/AMReX_TagBox.H
@@ -225,6 +225,9 @@ public:
     */
     void collate (Vector<IntVect>& TheGlobalCollateSpace) const;
 
+    // \brief Are there tags in the region defined by bx?
+    bool hasTags (Box const& bx) const;
+
     void local_collate_cpu (Vector<IntVect>& v) const;
 #ifdef AMREX_USE_GPU
     void local_collate_gpu (Vector<IntVect>& v) const;


### PR DESCRIPTION
## Summary

In #1258, TagBoxArray::numtags was removed.  However, IAMR still needs it.
So a new function, hasTags, is added for IAMR.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
