### PR TITLE
Fix typo for OMP

### DIFF
--- a/Src/AmrCore/AMReX_TagBox.cpp
+++ b/Src/AmrCore/AMReX_TagBox.cpp
@@ -746,7 +746,7 @@ TagBoxArray::hasTags (Box const& a_bx) const
 #endif
     {
 #ifdef _OPENMP
-#pragma omp parallel reduction(||:has_Tags)
+#pragma omp parallel reduction(||:has_tags)
 #endif
         for (MFIter mfi(*this); mfi.isValid(); ++mfi)
         {


### PR DESCRIPTION
## Summary

The typo was introduced in #1274.

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
