### PR TITLE
Add use of CUDA_HOME to Make.nrel.

### DIFF
--- a/Tools/GNUMake/sites/Make.nrel
+++ b/Tools/GNUMake/sites/Make.nrel
@@ -61,4 +61,3 @@ ifeq ($(USE_MPI),TRUE)
     endif
   endif
 endif
-

--- a/Tools/GNUMake/sites/Make.nrel
+++ b/Tools/GNUMake/sites/Make.nrel
@@ -52,3 +52,13 @@ ifeq ($(USE_MPI),TRUE)
     endif
   endif
 endif
+
+ifeq ($(USE_CUDA),TRUE)
+  ifneq ($(CUDA_HOME),)
+      SYSTEM_CUDA_PATH := $(CUDA_HOME)
+      COMPILE_CUDA_PATH := $(CUDA_HOME)
+  endif
+  CUDA_ARCH = 70
+  GPUS_PER_NODE = 2
+  GPUS_PER_SOCKET = 1
+endif

--- a/Tools/GNUMake/sites/Make.nrel
+++ b/Tools/GNUMake/sites/Make.nrel
@@ -21,6 +21,15 @@ ifeq ($(which_computer), eagle)
       F90FLAGS += -march=skylake-avx512 -mtune=skylake-avx512
     endif
   endif
+  ifeq ($(USE_CUDA),TRUE)
+    ifneq ($(CUDA_HOME),)
+        SYSTEM_CUDA_PATH := $(CUDA_HOME)
+        COMPILE_CUDA_PATH := $(CUDA_HOME)
+    endif
+    CUDA_ARCH = 70
+    GPUS_PER_NODE = 2
+    GPUS_PER_SOCKET = 1
+  endif
 else ifeq ($(which_computer), rhodes)
 # Rhodes is dedicated single node machine for testing
   ifeq ($(COMP), intel)
@@ -53,12 +62,3 @@ ifeq ($(USE_MPI),TRUE)
   endif
 endif
 
-ifeq ($(USE_CUDA),TRUE)
-  ifneq ($(CUDA_HOME),)
-      SYSTEM_CUDA_PATH := $(CUDA_HOME)
-      COMPILE_CUDA_PATH := $(CUDA_HOME)
-  endif
-  CUDA_ARCH = 70
-  GPUS_PER_NODE = 2
-  GPUS_PER_SOCKET = 1
-endif


### PR DESCRIPTION
## Summary
We set `CUDA_HOME` on machines at NREL so this adds its use to `Make.nrel`. This is mostly so that `-lnvToolsExt` will happen automatically for us when using the tiny profiler.

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
