### PR TITLE
Add section to Make.unknown for intel mpi

### DIFF
--- a/Tools/GNUMake/sites/Make.unknown
+++ b/Tools/GNUMake/sites/Make.unknown
@@ -73,7 +73,7 @@ ifeq ($(USE_MPI),TRUE)
       LIBRARIES += $(filter -l%,$(mpicxx_link_flags))
 #    endif
 
-  else ifneq ($(findstring Spectrum MPI, $(shell $(MPI_OTHER_COMP) -showme:version 2>&1)),1)
+  else ifneq ($(findstring Spectrum MPI, $(shell $(MPI_OTHER_COMP) -showme:version 2>&1)),)
 
     #
     # Spectrum MPI
@@ -81,6 +81,25 @@ ifeq ($(USE_MPI),TRUE)
 #    ifneq ($(BL_NO_FORT),TRUE)
       mpif90_link_flags := $(shell $(MPI_OTHER_COMP) -showme:link)
       LIBRARIES += $(mpif90_link_flags)
+#    endif
+
+  else ifneq ($(findstring /intel/mpi-rt,$(shell $(MPI_OTHER_COMP) -show 2>&1)),)
+
+    #
+    # Intel mpi
+    #
+#
+#    ifneq ($(BL_NO_FORT),TRUE)
+      mpif90_link_flags := $(shell $(MPI_OTHER_COMP) -link_info)
+      #
+      # The first word is the underlying compiler say gfortran
+      #
+      LIBRARIES += $(wordlist 2,1024,$(mpif90_link_flags))
+#    endif
+
+#    ifneq ($(CXX),$(filter $(CXX),mpicxx mpic++))
+      mpicxx_link_flags := $(shell mpicxx -link_info)
+      LIBRARIES += $(filter -l%,$(mpicxx_link_flags))
 #    endif
 
   else


### PR DESCRIPTION
## Summary

Avoid another site-specific make setting by adding generic id for Intel MPI - seems to work for UT Austin's TACC center computer, Stampede2, for example.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
