### PR TITLE
Physical locations in plotfiles

### DIFF
--- a/Src/Base/AMReX_PlotFileUtil.cpp
+++ b/Src/Base/AMReX_PlotFileUtil.cpp
@@ -144,14 +144,18 @@ WriteGenericPlotfileHeader (std::ostream &HeaderFile,
 	    HeaderFile << level << ' ' << bArray[level].size() << ' ' << time << '\n';
 	    HeaderFile << level_steps[level] << '\n';
 
-	    for (int i = 0; i < bArray[level].size(); ++i)
-	    {
-		const Box &b(bArray[level][i]);
-		RealBox loc = RealBox(b, geom[level].CellSize(), geom[level].ProbLo());
-		for (int n = 0; n < AMREX_SPACEDIM; ++n) {
-		    HeaderFile << loc.lo(n) << ' ' << loc.hi(n) << '\n';
-		}
-	    }
+            const IntVect& domain_lo = geom[level].Domain().smallEnd();
+            for (int i = 0; i < bArray[level].size(); ++i)
+            {
+                // Need to shift because the RealBox ctor we call takes the
+                // physical location of index (0,0,0).  This does not affect
+                // the usual cases where the domain index starts with 0.
+                const Box& b = amrex::shift(bArray[level][i], -domain_lo);
+                RealBox loc = RealBox(b, geom[level].CellSize(), geom[level].ProbLo());
+                for (int n = 0; n < AMREX_SPACEDIM; ++n) {
+                    HeaderFile << loc.lo(n) << ' ' << loc.hi(n) << '\n';
+                }
+            }
 
 	    HeaderFile << MultiFabHeaderPath(level, levelPrefix, mfPrefix) << '\n';
 	}


### PR DESCRIPTION
## Summary

Normally, the integer index of a Geometry's Domain starts with 0.  But if
not, the physical location of boxes stored in plotfiles is incorrect,
because the RealBox constructor we use takes the physical location of index
0.  So we need to shift the box before using RealBox.

## Additional background

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
