### PR TITLE
Skip MPI checking when doing make clean etc.

### DIFF
--- a/Tools/GNUMake/sites/Make.unknown
+++ b/Tools/GNUMake/sites/Make.unknown
@@ -4,6 +4,10 @@
 
 os_type := $(shell uname)
 
+ifneq ($(MAKECMDGOALS),realclean)
+ifneq ($(MAKECMDGOALS),clean)
+ifneq ($(MAKECMDGOALS),uninstall)
+ifneq ($(MAKECMDGOALS),distclean)
 ifneq ($(NO_MPI_CHECKING),TRUE)
 ifeq ($(USE_MPI),TRUE)
 
@@ -110,7 +114,10 @@ ifeq ($(USE_MPI),TRUE)
 
 endif
 endif
-
+endif
+endif
+endif
+endif
 
 ifneq ($(NO_CUDA_CHECKING),TRUE)
 ifeq ($(USE_CUDA),TRUE)


### PR DESCRIPTION
## Summary

When we do `make clean`, `make realclean` etc., we do not need to check MPI.  This can avoid unnecessary errors.

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
