### PR TITLE
Extern HIP device function

### DIFF
--- a/Src/Base/AMReX_GpuQualifiers.H
+++ b/Src/Base/AMReX_GpuQualifiers.H
@@ -12,14 +12,15 @@
 #define AMREX_GPU_GLOBAL __global__
 #define AMREX_GPU_HOST_DEVICE __host__ __device__
 #define AMREX_GPU_CONSTANT __constant__
-#define AMREX_GPU_EXTERNAL
 
 #if defined(AMREX_USE_HIP) && !defined(AMREX_USE_CUDA)
 #define AMREX_GPU_MANAGED __device__
 #define AMREX_GPU_DEVICE_MANAGED __device__
+#define AMREX_GPU_EXTERNAL __attribute__((weak))
 #else
 #define AMREX_GPU_MANAGED __managed__
 #define AMREX_GPU_DEVICE_MANAGED __device__ __managed__
+#define AMREX_GPU_EXTERNAL
 #endif
 
 #else


### PR DESCRIPTION
## Summary

We now need to use __attribute__((weak)) for extern HIP device function,
otherwise we get undefined hidden symbol error.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
