### PR TITLE
Add check for empty probin_file in Amr::restart

### DIFF
--- a/Src/Amr/AMReX_Amr.cpp
+++ b/Src/Amr/AMReX_Amr.cpp
@@ -1375,7 +1375,10 @@ Amr::restart (const std::string& filename)
     //
     int linit = false;
 
-    readProbinFile(linit);
+    if (!probin_file.empty()) {
+        readProbinFile(linit);
+    }
+
     //
     // Start calculation from given restart file.
     //


### PR DESCRIPTION
## Summary
This adds the same empty check in Amr::restart that is used in Amr::InitializeInit
## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
