### PR TITLE
removed AMREX_NOEXCEPT from main.cpp:L139 to avoid 'error: expected b…

### DIFF
--- a/Tutorials/GPU/ParallelReduce/main.cpp
+++ b/Tutorials/GPU/ParallelReduce/main.cpp
@@ -136,7 +136,7 @@ void main_main ()
                 Real rmax = -1.e30; // we should use numeric_limits.
                 Long lsum = 0;
                 amrex::Loop(bx,
-                [=,&rsum,&rmin,&rmax,&lsum] (int i, int j, int k) AMREX_NOEXCEPT {
+                [=,&rsum,&rmin,&rmax,&lsum] (int i, int j, int k) {
                     Real x =  fab(i,j,k);
                     Long ix = static_cast<Long>(ifab(i,j,k));
                     rsum += x;


### PR DESCRIPTION
removed AMREX_NOEXCEPT from main.cpp:L139 to avoid 'error: expected body of lambda expression'

## Summary
With USE_HIP=TRUE, the AMREX_NOEXCEPT
on line 139 of amrex/Tutorials/GPU/ParallelReduce/main.cpp triggers the compile error 
Loading ../../../Tools/GNUMake/comps/hip.mak...
Loading ../../../Tools/GNUMake/sites/Make.frontier-coe...
Compiling main.cpp ...
/opt/rocm-3.6.0/hip/bin/hipcc -std=c++14 -m64 -g -O3  --amdgpu-target=gfx906,gfx908   -DAMREX_TINY_PROFILING -DBL_USE_MPI -DAMREX_USE_MPI -DAMREX_USE_HIP -DAMREX_HIP_PLATFORM=clang -DAMREX_USE_GPU -DBL_COALESCE_FABS -DBL_SPACEDIM=3 -DAMREX_SPACEDIM=3 -DBL_FORT_USE_UNDERSCORE -DAMREX_FORT_USE_UNDERSCORE -DBL_Linux -DAMREX_Linux -DNDEBUG -I. -I/opt/rocm-3.6.0/hip/include -I/opt/rocm-3.6.0/rocrand/include -I/opt/rocm-3.6.0/hiprand/include -I/opt/rocm-3.6.0/rocprim/include -I../../../Src/Base -I/cm/shared/apps/mpich/ge/gcc/64/3.3/include -c main.cpp -o tmp_build_dir/o/3d.hip.x86-naples.TPROF.MPI.HIP.EXE/main.o
main.cpp:139:67: error: expected body of lambda expression
                [=,&rsum,&rmin,&rmax,&lsum] (int i, int j, int k) AMREX_NOEXCEPT {
                                                                  ^
1 error generated when compiling for gfx906.
make: *** [tmp_build_dir/o/3d.hip.x86-naples.TPROF.MPI.HIP.EXE/main.o] Error 1

Removing AMREX_NOEXCEPT allowed successful compilation and linking and
the resulting binary executable worked.

## Additional background

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
