### PR TITLE
Turn on AsyncOut by default for HIP

### DIFF
--- a/Src/Base/AMReX_AsyncOut.cpp
+++ b/Src/Base/AMReX_AsyncOut.cpp
@@ -11,7 +11,7 @@ namespace AsyncOut {
 
 namespace {
 
-#ifdef AMREX_USE_DPCPP
+#if defined(AMREX_USE_DPCPP) || defined(AMREX_USE_HIP)
 int s_asyncout = true; // Have this on by default for DPC++ for now so that
                        // I/O writing plotfile does not depend on unified
                        // memory.


### PR DESCRIPTION
## Summary

Currently for HIP, The_Arena allocates device memory.  We turn on AsyncOut
by default so that we can write plotfiles and VisMF files.  In the long term, we
should also fix VisMF::Write so that it can work with device memory.

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
