### PR TITLE
Move declaration of Array4 object

### DIFF
--- a/Src/AmrCore/AMReX_ErrorList.cpp
+++ b/Src/AmrCore/AMReX_ErrorList.cpp
@@ -383,32 +383,35 @@ operator << (std::ostream&    os,
         for (MFIter mfi(tba,TilingIfNotGPU()); mfi.isValid(); ++mfi)
         {
           const auto& bx    = mfi.tilebox();
-          auto const& dat   = mf->array(mfi);
           auto tag          = tba.array(mfi);
 
           if (m_test == BOX)
           {
             AMRErrorTag_BOX(bx, tag, m_info.m_realbox, geom, tagval);
           }
-          else if (m_test == GRAD)
-          {
-            AMRErrorTag_GRAD(bx, dat, tag, m_value, tagval);
-          }
-          else if (m_test == LESS)
-          {
-            AMRErrorTag_LESS(bx, dat, tag, m_value, tagval);
-          }
-          else if (m_test == GREATER)
-          {
-            AMRErrorTag_GREATER(bx, dat, tag, m_value, tagval);
-          }
-          else if (m_test == VORT)
-          {
-            AMRErrorTag_VORT(bx, dat, tag, level, m_value, tagval);
-          }
           else
           {
-            Abort("Bad AMRErrorTag test flag");
+            auto const& dat   = mf->array(mfi);
+
+            if (m_test == GRAD)
+            {
+              AMRErrorTag_GRAD(bx, dat, tag, m_value, tagval);
+            }
+            else if (m_test == LESS)
+            {
+              AMRErrorTag_LESS(bx, dat, tag, m_value, tagval);
+            }
+            else if (m_test == GREATER)
+            {
+              AMRErrorTag_GREATER(bx, dat, tag, m_value, tagval);
+            }
+            else if (m_test == VORT)
+            {
+              AMRErrorTag_VORT(bx, dat, tag, level, m_value, tagval);
+            }
+            {
+              Abort("Bad AMRErrorTag test flag");
+            }
           }
         }
       }

--- a/Src/AmrCore/AMReX_ErrorList.cpp
+++ b/Src/AmrCore/AMReX_ErrorList.cpp
@@ -409,6 +409,7 @@ operator << (std::ostream&    os,
             {
               AMRErrorTag_VORT(bx, dat, tag, level, m_value, tagval);
             }
+            else
             {
               Abort("Bad AMRErrorTag test flag");
             }


### PR DESCRIPTION
## Summary

The autogen function for refinement tagging on physical box doesn't make use of a field, but the controller was trying to make an Array4 using the field that doesn't exist in this case.  This fix moves the declaration down into a place where the data is guaranteed to exist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
