### PR TITLE
Modify the use of HOST and HOSTNAME in make system

### DIFF
--- a/Tools/GNUMake/Make.machines
+++ b/Tools/GNUMake/Make.machines
@@ -4,6 +4,14 @@
 which_site := unknown
 which_computer := unknown
 
+ifdef HOSTNAME
+  host_name_env := $(strip $(HOSTNAME))
+else ifdef HOST
+  host_name_env := $(strip $(HOST))
+else
+  host_name_env := unknown
+endif
+
 host_name := $(shell hostname -f)
 host_name_short := $(shell hostname -s)
 
@@ -118,8 +126,8 @@ ifeq ($(findstring raijin, $(host_name)), raijin)
   which_computer := raijin
 endif
 
-ifneq (,$(filter $(host_name_short),poplar redwood tulip))
+ifneq (,$(filter $(host_name_env),poplar redwood tulip))
   which_site := frontier-coe
-  which_computer := $(host_name_short)
+  which_computer := $(host_name_env)
 endif
 

--- a/Tools/GNUMake/Make.machines
+++ b/Tools/GNUMake/Make.machines
@@ -4,14 +4,7 @@
 which_site := unknown
 which_computer := unknown
 
-ifdef HOSTNAME
-  host_name := $(strip $(HOSTNAME))
-else ifdef HOST
-  host_name := $(strip $(HOST))
-else
-  host_name := $(shell hostname -f)
-  host_name_short := $(shell hostname -s)
-endif
+host_name := $(shell hostname -f)
 host_name_short := $(shell hostname -s)
 
 # MACHINES supported


### PR DESCRIPTION
## Summary

PR #1275 fixed a bug in the use of `HOST` and `HOSTNAME` in the make system.
However, the fix broke on Summit because `HOSTNAME` on Summit login nodes
is set to something like `login1`.  We now set `host_name` to `hostname -f` and
`host_name_short` to `hostname -s` command, which is the behavior before the fix
in #1275.  We add a new make variable `host_name_env` that is set to
`HOSTNAME` and `HOST` from the environment and use it for tulip.

## Summary

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
