### PR TITLE
Add get_pmap method to amrex_distromap (Fortran)

### DIFF
--- a/Src/F_Interfaces/Base/AMReX_distromap_fi.cpp
+++ b/Src/F_Interfaces/Base/AMReX_distromap_fi.cpp
@@ -33,7 +33,7 @@ extern "C" {
 	Long dmsize = dm->size();
 	AMREX_ASSERT(plen >= dmsize);
 	for (int i = 0; i < dmsize; ++i)
-            pmap[i] = dm[i];
+            pmap[i] = (*dm)[i];
     }
 
     void amrex_fi_print_distromap (const DistributionMapping* dm)

--- a/Src/F_Interfaces/Base/AMReX_distromap_fi.cpp
+++ b/Src/F_Interfaces/Base/AMReX_distromap_fi.cpp
@@ -28,6 +28,14 @@ extern "C" {
 	dmo = new DistributionMapping(*dmi);
     }
 
+    void amrex_fi_distromap_get_pmap (DistributionMapping*& dm, int* pmap, const int plen)
+    {
+	Long dmsize = dm->size();
+	AMREX_ASSERT(plen >= dmsize);
+	for (int i = 0; i < dmsize; ++i)
+            pmap[i] = dm[i];
+    }
+
     void amrex_fi_print_distromap (const DistributionMapping* dm)
     {
 	AllPrint() << *dm;

--- a/Src/F_Interfaces/Base/AMReX_distromap_fi.cpp
+++ b/Src/F_Interfaces/Base/AMReX_distromap_fi.cpp
@@ -32,7 +32,7 @@ extern "C" {
     {
 	Long dmsize = dm->size();
 	AMREX_ASSERT(plen >= dmsize);
-	for (int i = 0; i < dmsize; ++i)
+	for (int i = 0; i < dmsize && i < plen; ++i)
             pmap[i] = (*dm)[i];
     }
 

--- a/Src/F_Interfaces/Base/AMReX_distromap_fi.cpp
+++ b/Src/F_Interfaces/Base/AMReX_distromap_fi.cpp
@@ -28,7 +28,7 @@ extern "C" {
 	dmo = new DistributionMapping(*dmi);
     }
 
-    void amrex_fi_distromap_get_pmap (DistributionMapping*& dm, int* pmap, const int plen)
+    void amrex_fi_distromap_get_pmap (const DistributionMapping* dm, int* pmap, const int plen)
     {
 	Long dmsize = dm->size();
 	AMREX_ASSERT(plen >= dmsize);

--- a/Src/F_Interfaces/Base/AMReX_distromap_mod.F90
+++ b/Src/F_Interfaces/Base/AMReX_distromap_mod.F90
@@ -17,6 +17,7 @@ module amrex_distromap_module
      generic   :: assignment(=) => amrex_distromap_assign, amrex_distromap_install   ! shallow copy
      procedure :: clone         => amrex_distromap_clone    ! deep copy
      procedure :: move          => amrex_distromap_move     ! transfer ownership
+     procedure :: get_pmap      => amrex_distromap_get_pmap ! fill caller-owned array of PEs
      procedure, private :: amrex_distromap_assign
      procedure, private :: amrex_distromap_install 
 #if !defined(__GFORTRAN__) || (__GNUC__ > 4)
@@ -70,6 +71,14 @@ module amrex_distromap_module
        type(c_ptr), value :: dm
        integer(c_int), value :: n
      end subroutine amrex_fi_distromap_maxsize
+
+     subroutine amrex_fi_distromap_get_pmap (dm,pmap,plen) bind(c)
+       import
+       implicit none
+       type(c_ptr) :: dm
+       integer(c_int), intent(out) :: pmap(*)
+       integer(c_int), value :: plen
+     end subroutine amrex_fi_distromap_get_pmap
 
      subroutine amrex_fi_print_distromap (dm) bind(c)
        import
@@ -133,6 +142,12 @@ contains
     src%owner = .false.
     src%p = c_null_ptr
   end subroutine amrex_distromap_move
+
+  subroutine amrex_distromap_get_pmap (dm, pmap)
+    class(amrex_distromap) :: dm
+    integer, intent(out) :: pmap(:)
+    call amrex_fi_distromap_get_pmap(dm%p,pmap, size(pmap))
+  end subroutine amrex_distromap_build_pmap
 
   subroutine amrex_distromap_print (dm)
     type(amrex_distromap), intent(in) :: dm

--- a/Src/F_Interfaces/Base/AMReX_distromap_mod.F90
+++ b/Src/F_Interfaces/Base/AMReX_distromap_mod.F90
@@ -75,7 +75,7 @@ module amrex_distromap_module
      subroutine amrex_fi_distromap_get_pmap (dm,pmap,plen) bind(c)
        import
        implicit none
-       type(c_ptr) :: dm
+       type(c_ptr), value :: dm
        integer(c_int), intent(out) :: pmap(*)
        integer(c_int), value :: plen
      end subroutine amrex_fi_distromap_get_pmap

--- a/Src/F_Interfaces/Base/AMReX_distromap_mod.F90
+++ b/Src/F_Interfaces/Base/AMReX_distromap_mod.F90
@@ -147,7 +147,7 @@ contains
     class(amrex_distromap) :: dm
     integer, intent(out) :: pmap(:)
     call amrex_fi_distromap_get_pmap(dm%p,pmap, size(pmap))
-  end subroutine amrex_distromap_build_pmap
+  end subroutine amrex_distromap_get_pmap
 
   subroutine amrex_distromap_print (dm)
     type(amrex_distromap), intent(in) :: dm


### PR DESCRIPTION
## Summary
Add a new method to the `amrex_distromap` type in F_Interfaces. `get_pmap` fills a caller-owned array of PEs.

Changes to make this more elegant are welcome.

## Additional background
We need something like this in order to actually look into a distribution mapping computed by AMReX from Fortran code.
(Currently this functionality is desired for Implementing a parallel restart capability from FLASH checkpoint files in FLASH.)

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
