### PR TITLE
SetBoxArray

### DIFF
--- a/Src/AmrCore/AMReX_AmrMesh.H
+++ b/Src/AmrCore/AMReX_AmrMesh.H
@@ -249,6 +249,7 @@ protected:
     Vector<BoxArray>            grids;
 
     unsigned int num_setdm = 0;
+    unsigned int num_setba = 0;
 
     void checkInput();
 

--- a/Src/AmrCore/AMReX_AmrMesh.cpp
+++ b/Src/AmrCore/AMReX_AmrMesh.cpp
@@ -380,6 +380,7 @@ AmrMesh::SetDistributionMap (int lev, const DistributionMapping& dmap_in) noexce
 void
 AmrMesh::SetBoxArray (int lev, const BoxArray& ba_in) noexcept
 {
+    ++num_setba;
     if (grids[lev] != ba_in) grids[lev] = ba_in;
 }
 
@@ -791,10 +792,13 @@ AmrMesh::MakeNewGrids (Real time)
 	const BoxArray& ba = MakeBaseGrids();
 	DistributionMapping dm(ba);
         const auto old_num_setdm = num_setdm;
+        const auto old_num_setba = num_setba;
 
 	MakeNewLevelFromScratch(0, time, ba, dm);
 
-        SetBoxArray(0, ba);
+        if (old_num_setba == num_setba) {
+            SetBoxArray(0, ba);
+        }
         if (old_num_setdm == num_setdm) {
             SetDistributionMap(0, dm);
         }


### PR DESCRIPTION

## Summary

If SetBoxArray is called in Level 0's MakeNewLevelFromScrach, the set
BoxArray will be used.  This makes it consistent with the behavior of
SetDistributionMap.

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
