### PR TITLE
Extend the number of unique particles per cpu we can have at once.

### DIFF
--- a/Src/Particle/AMReX_Particle.H
+++ b/Src/Particle/AMReX_Particle.H
@@ -85,7 +85,7 @@ struct ParticleCPUWrapper
         // zero out the first 24 bits, which are used to store the cpu number
         m_idata &= (~ 0x00FFFFFF);
 
-        AMREX_ASSERT(cpu > 0);
+        AMREX_ASSERT(cpu >= 0);
         AMREX_ASSERT(cpu <= 16777215);  // 2**24-1, the max representable number
 
         m_idata |= cpu;

--- a/Src/Particle/AMReX_Particle.H
+++ b/Src/Particle/AMReX_Particle.H
@@ -123,10 +123,10 @@ struct ConstParticleIDWrapper
 
 struct ConstParticleCPUWrapper
 {
-    const int64_t& m_idata;
+    const uint64_t& m_idata;
 
     AMREX_GPU_HOST_DEVICE
-    ConstParticleCPUWrapper (const int64_t& idata) noexcept
+    ConstParticleCPUWrapper (const uint64_t& idata) noexcept
         : m_idata(idata)
     {}
 

--- a/Src/Particle/AMReX_Particle.H
+++ b/Src/Particle/AMReX_Particle.H
@@ -22,6 +22,108 @@ namespace
     constexpr int NoSplitParticleID  = std::numeric_limits<int>::max()-4;
 }
 
+struct ParticleIDWrapper
+{
+    uint64_t& m_idata;
+
+    ParticleIDWrapper (uint64_t& idata)
+        : m_idata(idata)
+    {}
+
+    ParticleIDWrapper& operator= (const Long id)
+    {
+        // zero out the 40 leftmost bits, which store the sign and the abs of the id;
+        m_idata &= 0x00FFFFFF;
+
+        uint64_t val;
+        uint64_t sign = id >= 0;
+        if (sign)
+        {
+            // 2**39-1, the max value representible in this fashion
+            AMREX_ASSERT(id <= 549755813887L);
+            val = id;
+        }
+        else
+        {
+            // -2**39-1, the min value representible in this fashion
+            AMREX_ASSERT(id >= -549755813887L);
+            val = -id;
+        }
+
+        m_idata |= (sign << 63);  // put the sign in the leftmost bit
+        m_idata |= (val << 24);   // put the val in the next 39
+        return *this;
+    }
+
+    operator long ()
+    {
+        long r = 0;
+
+        uint64_t sign = m_idata >> 63;  // extract leftmost sign bit
+        uint64_t val  = ((m_idata >> 24) & 0x7FFFFFFFFF);  // extract next 39 id bits
+
+        r = sign ? val : -val;
+        return r;
+    }
+};
+
+struct ParticleCPUWrapper
+{
+    uint64_t& m_idata;
+
+    ParticleCPUWrapper (uint64_t& idata)
+        : m_idata(idata)
+    {}
+
+    ParticleCPUWrapper& operator= (const int cpu)
+    {
+        // zero out the first 24 bits, which are used to store the cpu number
+        m_idata &= (~ 0x00FFFFFF);
+
+        AMREX_ASSERT(cpu > 0);
+        AMREX_ASSERT(cpu <= 16777215);  // 2**24-1, the max representable number
+
+        m_idata |= cpu;
+        return *this;
+    }
+
+    operator int ()
+    {
+        return (m_idata & 0x00FFFFFF);
+    }
+};
+
+struct ConstParticleIDWrapper
+{
+    const uint64_t& m_idata;
+
+    ConstParticleIDWrapper (const uint64_t& idata)
+        : m_idata(idata)
+    {}
+
+    operator long ()
+    {
+        long r = 0;
+
+        uint64_t sign = m_idata >> 63;  // extract leftmost sign bit
+        uint64_t val  = ((m_idata >> 24) & 0x7FFFFFFFFF);  // extract next 39 id bits
+
+        r = (sign) ? val : -val;
+        return r;
+    }
+};
+
+struct ConstParticleCPUWrapper
+{
+    const int64_t& m_idata;
+
+    ConstParticleCPUWrapper (const int64_t& idata)
+        : m_idata(idata)
+    {}
+
+    operator int () { return (m_idata & 0x00FFFFFF); }
+};
+
 /** \brief The struct used to store particles.
  *
  * \tparam T_NReal The number of extra Real components
@@ -54,14 +156,19 @@ struct Particle
     * The integer data. We always have id and cpu, and optionally we
     * have NInt additional integer attributes.
     */
-    int m_idata[2+NInt];
+    union im_t
+    {
+        uint64_t ids;
+        int arr[2+NInt];
+    };
+    im_t m_idata;
 
     static int the_next_id;
 
-    AMREX_GPU_HOST_DEVICE int&  id ()       & {return m_idata[0];}
-    AMREX_GPU_HOST_DEVICE int   id () const & {return m_idata[0];}
-    AMREX_GPU_HOST_DEVICE int& cpu ()       & {return m_idata[1];}
-    AMREX_GPU_HOST_DEVICE int  cpu () const & {return m_idata[1];}
+    AMREX_GPU_HOST_DEVICE ParticleCPUWrapper cpu () & { return ParticleCPUWrapper(m_idata.ids); }
+    AMREX_GPU_HOST_DEVICE ParticleIDWrapper id () & { return ParticleIDWrapper(m_idata.ids); }
+    AMREX_GPU_HOST_DEVICE ConstParticleCPUWrapper cpu () const & { return ConstParticleCPUWrapper(m_idata.ids); }
+    AMREX_GPU_HOST_DEVICE ConstParticleIDWrapper id () const & { return ConstParticleIDWrapper(m_idata.ids); }
 
     AMREX_GPU_HOST_DEVICE RealVect pos () const &
     {return RealVect(AMREX_D_DECL(m_rdata.pos[0], m_rdata.pos[1], m_rdata.pos[2]));}
@@ -105,12 +212,12 @@ struct Particle
     AMREX_GPU_HOST_DEVICE int& idata (int index) &
     {
         AMREX_ASSERT(index < NInt);
-        return m_idata[2 + index];
+        return m_idata.arr[2 + index];
     }
     AMREX_GPU_HOST_DEVICE int  idata (int index) const &
     {
         AMREX_ASSERT(index < NInt);
-        return m_idata[2 + index];
+        return m_idata.arr[2 + index];
     }
 
     static Real InterpDoit (const FArrayBox& fab, const Real* fracs, const IntVect* cells, int comp);
@@ -694,7 +801,7 @@ operator<< (std::ostream& os, const Particle<NReal, NInt>& p)
         os << p.m_rdata.arr[i] << ' ';
 
     for (int i = 2; i < 2 + NInt; i++)
-        os << p.m_idata[i] << ' ';
+        os << p.m_idata.arr[i] << ' ';
 
     if (!os.good())
         amrex::Error("operator<<(ostream&,Particle<NReal, NInt>&) failed");

--- a/Src/Particle/AMReX_Particle.H
+++ b/Src/Particle/AMReX_Particle.H
@@ -18,8 +18,8 @@ namespace
     constexpr Long GhostParticleID    = 549755813887L; // 2**39-1
     constexpr Long VirtualParticleID  = GhostParticleID-1;
     constexpr Long LastParticleID     = GhostParticleID-2;
-    constexpr Long DoSplitParticleID  = GhostParticleID-3;;
-    constexpr Long NoSplitParticleID  = GhostParticleID-4;;
+    constexpr Long DoSplitParticleID  = GhostParticleID-3;
+    constexpr Long NoSplitParticleID  = GhostParticleID-4;
 }
 
 struct ParticleIDWrapper

--- a/Src/Particle/AMReX_Particle.H
+++ b/Src/Particle/AMReX_Particle.H
@@ -65,7 +65,8 @@ struct ParticleIDWrapper
         uint64_t sign = m_idata >> 63;  // extract leftmost sign bit
         uint64_t val  = ((m_idata >> 24) & 0x7FFFFFFFFF);  // extract next 39 id bits
 
-        r = (sign) ? val : -val;
+        Long lval = static_cast<Long>(val);  // bc we take -
+        r = (sign) ? lval : -lval;
         return r;
     }
 };
@@ -116,7 +117,8 @@ struct ConstParticleIDWrapper
         uint64_t sign = m_idata >> 63;  // extract leftmost sign bit
         uint64_t val  = ((m_idata >> 24) & 0x7FFFFFFFFF);  // extract next 39 id bits
 
-        r = (sign) ? val : -val;
+        Long lval = static_cast<Long>(val);  // bc we take -
+        r = (sign) ? lval : -lval;
         return r;
     }
 };

--- a/Src/Particle/AMReX_Particle.H
+++ b/Src/Particle/AMReX_Particle.H
@@ -26,11 +26,13 @@ struct ParticleIDWrapper
 {
     uint64_t& m_idata;
 
-    ParticleIDWrapper (uint64_t& idata)
+    AMREX_GPU_HOST_DEVICE
+    ParticleIDWrapper (uint64_t& idata) noexcept
         : m_idata(idata)
     {}
 
-    ParticleIDWrapper& operator= (const Long id)
+    AMREX_GPU_HOST_DEVICE
+    ParticleIDWrapper& operator= (const Long id) noexcept
     {
         // zero out the 40 leftmost bits, which store the sign and the abs of the id;
         m_idata &= 0x00FFFFFF;
@@ -55,7 +57,8 @@ struct ParticleIDWrapper
         return *this;
     }
 
-    operator long ()
+    AMREX_GPU_HOST_DEVICE
+    operator long () noexcept
     {
         long r = 0;
 
@@ -71,11 +74,13 @@ struct ParticleCPUWrapper
 {
     uint64_t& m_idata;
 
-    ParticleCPUWrapper (uint64_t& idata)
+    AMREX_GPU_HOST_DEVICE
+    ParticleCPUWrapper (uint64_t& idata) noexcept
         : m_idata(idata)
     {}
 
-    ParticleCPUWrapper& operator= (const int cpu)
+    AMREX_GPU_HOST_DEVICE
+    ParticleCPUWrapper& operator= (const int cpu) noexcept
     {
         // zero out the first 24 bits, which are used to store the cpu number
         m_idata &= (~ 0x00FFFFFF);
@@ -87,7 +92,8 @@ struct ParticleCPUWrapper
         return *this;
     }
 
-    operator int ()
+    AMREX_GPU_HOST_DEVICE
+    operator int () noexcept
     {
         return (m_idata & 0x00FFFFFF);
     }
@@ -97,11 +103,13 @@ struct ConstParticleIDWrapper
 {
     const uint64_t& m_idata;
 
-    ConstParticleIDWrapper (const uint64_t& idata)
+    AMREX_GPU_HOST_DEVICE
+    ConstParticleIDWrapper (const uint64_t& idata) noexcept
         : m_idata(idata)
     {}
 
-    operator long ()
+    AMREX_GPU_HOST_DEVICE
+    operator long () noexcept
     {
         long r = 0;
 
@@ -117,11 +125,13 @@ struct ConstParticleCPUWrapper
 {
     const int64_t& m_idata;
 
-    ConstParticleCPUWrapper (const int64_t& idata)
+    AMREX_GPU_HOST_DEVICE
+    ConstParticleCPUWrapper (const int64_t& idata) noexcept
         : m_idata(idata)
     {}
 
-    operator int () { return (m_idata & 0x00FFFFFF); }
+    AMREX_GPU_HOST_DEVICE
+    operator int () noexcept { return (m_idata & 0x00FFFFFF); }
 };
 
 /** \brief The struct used to store particles.

--- a/Src/Particle/AMReX_Particle.H
+++ b/Src/Particle/AMReX_Particle.H
@@ -58,7 +58,7 @@ struct ParticleIDWrapper
     }
 
     AMREX_GPU_HOST_DEVICE
-    operator Long () noexcept
+    operator Long () const noexcept
     {
         Long r = 0;
 
@@ -109,7 +109,7 @@ struct ConstParticleIDWrapper
     {}
 
     AMREX_GPU_HOST_DEVICE
-    operator Long () noexcept
+    operator Long () const noexcept
     {
         Long r = 0;
 

--- a/Src/Particle/AMReX_Particle.H
+++ b/Src/Particle/AMReX_Particle.H
@@ -65,7 +65,7 @@ struct ParticleIDWrapper
         uint64_t sign = m_idata >> 63;  // extract leftmost sign bit
         uint64_t val  = ((m_idata >> 24) & 0x7FFFFFFFFF);  // extract next 39 id bits
 
-        r = sign ? val : -val;
+        r = (sign) ? val : -val;
         return r;
     }
 };

--- a/Src/Particle/AMReX_Particle.H
+++ b/Src/Particle/AMReX_Particle.H
@@ -15,11 +15,11 @@ namespace amrex {
 
 namespace
 {
-    constexpr int GhostParticleID    = std::numeric_limits<int>::max();
-    constexpr int VirtualParticleID  = std::numeric_limits<int>::max()-1;
-    constexpr int LastParticleID     = std::numeric_limits<int>::max()-2;
-    constexpr int DoSplitParticleID  = std::numeric_limits<int>::max()-3;
-    constexpr int NoSplitParticleID  = std::numeric_limits<int>::max()-4;
+    constexpr Long GhostParticleID    = 549755813887L; // 2**39-1
+    constexpr Long VirtualParticleID  = GhostParticleID-1;
+    constexpr Long LastParticleID     = GhostParticleID-2;
+    constexpr Long DoSplitParticleID  = GhostParticleID-3;;
+    constexpr Long NoSplitParticleID  = GhostParticleID-4;;
 }
 
 struct ParticleIDWrapper
@@ -158,12 +158,12 @@ struct Particle
     */
     union im_t
     {
-        uint64_t ids;
+        uint64_t ids = 0;
         int arr[2+NInt];
     };
     im_t m_idata;
 
-    static int the_next_id;
+    static Long the_next_id;
 
     AMREX_GPU_HOST_DEVICE ParticleCPUWrapper cpu () & { return ParticleCPUWrapper(m_idata.ids); }
     AMREX_GPU_HOST_DEVICE ParticleIDWrapper id () & { return ParticleIDWrapper(m_idata.ids); }
@@ -245,13 +245,13 @@ struct Particle
     * across all processors must be checkpointed and then restored on restart
     * so that we don't reuse particle IDs.
     */
-    static int NextID ();
+    static Long NextID ();
 
 
     /**
     * \brief This version can only be used inside omp critical.
     */
-    static int UnprotectedNextID ();
+    static Long UnprotectedNextID ();
 
 
     /**
@@ -259,7 +259,7 @@ struct Particle
     *
     * \param nextid
     */
-    static void NextID (int nextid);
+    static void NextID (Long nextid);
 
     static void CIC_Fracs (const Real* frac, Real* fracs);
 
@@ -314,7 +314,7 @@ struct Particle
                                 Vector<Real>&                 fracs,
                                 Vector<IntVect>&              cells);
 };
-template <int NReal, int NInt> int Particle<NReal, NInt>::the_next_id = 1;
+template <int NReal, int NInt> Long Particle<NReal, NInt>::the_next_id = 1;
 
 template<int NReal, int NInt>
 inline
@@ -666,17 +666,17 @@ Particle<NReal, NInt>::Version ()
 }
 
 template <int NReal, int NInt>
-int
+Long
 Particle<NReal, NInt>::NextID ()
 {
-    int next;
+    Long next;
 // we should be able to test on _OPENMP < 201107 for capture (version 3.1)
 // but we must work around a bug in gcc < 4.9
 #if defined(_OPENMP) && _OPENMP < 201307
 #pragma omp critical (amrex_particle_nextid)
 #elif defined(_OPENMP)
 #pragma omp atomic capture
-#endif    
+#endif
     next = the_next_id++;
 
     if (next > LastParticleID)
@@ -686,10 +686,10 @@ Particle<NReal, NInt>::NextID ()
 }
 
 template <int NReal, int NInt>
-int
+Long
 Particle<NReal, NInt>::UnprotectedNextID ()
 {
-    int next = the_next_id++;
+    Long next = the_next_id++;
     if (next > LastParticleID)
 	amrex::Abort("Particle<NReal, NInt>::NextID() -- too many particles");
     return next;
@@ -697,7 +697,7 @@ Particle<NReal, NInt>::UnprotectedNextID ()
 
 template <int NReal, int NInt>
 void
-Particle<NReal, NInt>::NextID (int nextid)
+Particle<NReal, NInt>::NextID (Long nextid)
 {
     the_next_id = nextid;
 }

--- a/Src/Particle/AMReX_Particle.H
+++ b/Src/Particle/AMReX_Particle.H
@@ -58,9 +58,9 @@ struct ParticleIDWrapper
     }
 
     AMREX_GPU_HOST_DEVICE
-    operator long () noexcept
+    operator Long () noexcept
     {
-        long r = 0;
+        Long r = 0;
 
         uint64_t sign = m_idata >> 63;  // extract leftmost sign bit
         uint64_t val  = ((m_idata >> 24) & 0x7FFFFFFFFF);  // extract next 39 id bits
@@ -109,9 +109,9 @@ struct ConstParticleIDWrapper
     {}
 
     AMREX_GPU_HOST_DEVICE
-    operator long () noexcept
+    operator Long () noexcept
     {
-        long r = 0;
+        Long r = 0;
 
         uint64_t sign = m_idata >> 63;  // extract leftmost sign bit
         uint64_t val  = ((m_idata >> 24) & 0x7FFFFFFFFF);  // extract next 39 id bits

--- a/Src/Particle/AMReX_ParticleContainerI.H
+++ b/Src/Particle/AMReX_ParticleContainerI.H
@@ -61,9 +61,10 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt> :: Initialize 
             for (int i=0; i<AMREX_SPACEDIM; ++i) tile_size[i] = tilesize[i];
         }
 
-        static_assert(std::is_standard_layout<ParticleType>::value
-                   && std::is_trivial<ParticleType>::value,
-                      "Particle type must be standard layout and trivial.");
+        static_assert(std::is_standard_layout<ParticleType>::value,
+                      "Particle type must be standard layout");
+        //                   && std::is_trivial<ParticleType>::value,
+        //                      "Particle type must be standard layout and trivial.");
 
         pp.query("use_prepost", usePrePost);
         pp.query("do_unlink", doUnlink);


### PR DESCRIPTION
Currently, we use two signed integers to store id numbers for each particle as well as the rank it was generated on. This allows unique combinations of 'id', and 'cpu' numbers to be generated without any communication between ranks. However, this does waste some space, since it's unlikely that 2**31-1 MPI ranks will be used any time soon, while the same limit for the id has actually been overflowed in real-world WarpX simulations. To address this, in this PR, we still use 64 bits to represent the combination of (id, cpu), but we devote 40 bits to the id and only 24 to the cpu. This allows ~0.5 trillion unique particles on each of 16.7 million MPI ranks, which should be good enough for the foreseeable future.

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
