### PR TITLE
Avoid divide-by-zero in 2D EB

### DIFF
--- a/Src/EB/AMReX_EB2_2D_C.cpp
+++ b/Src/EB/AMReX_EB2_2D_C.cpp
@@ -64,14 +64,14 @@ void set_eb_data (const int i, const int j,
         bnorm(i,j,0,1) = signy;
         vfrac(i,j,0) = 0.5*(axm+axp);
         vcent(i,j,0,0) = 0.0;
-        vcent(i,j,0,1) = (0.125*(ayp-aym) + ny*0.5*bcent(i,j,0,1)*bcent(i,j,0,1)) / vfrac(i,j,0);
+        vcent(i,j,0,1) = (0.125*(ayp-aym) + ny*0.5*bcent(i,j,0,1)*bcent(i,j,0,1)) / (vfrac(i,j,0) + 1.e-30);
     } else if (nyabs < tiny or nxabs > almostone) {
         barea(i,j,0) = 1.0;
         bcent(i,j,0,1) = 0.0;
         bnorm(i,j,0,0) = signx;
         bnorm(i,j,0,1) = 0.0;
         vfrac(i,j,0) = 0.5*(aym+ayp);
-        vcent(i,j,0,0) = (0.125*(axp-axm) + nx*0.5*bcent(i,j,0,0)*bcent(i,j,0,0)) / vfrac(i,j,0);
+        vcent(i,j,0,0) = (0.125*(axp-axm) + nx*0.5*bcent(i,j,0,0)*bcent(i,j,0,0)) / (vfrac(i,j,0) + 1.e-30);
         vcent(i,j,0,1) = 0.0;
     } else {
         Real aa = nxabs/ny;

--- a/Src/EB/AMReX_EB2_3D_C.cpp
+++ b/Src/EB/AMReX_EB2_3D_C.cpp
@@ -36,7 +36,7 @@ void set_eb_data (const int i, const int j, const int k,
 
     Real dapx = axm - axp;
     Real dapy = aym - ayp;
-            Real dapz = azm - azp;
+    Real dapz = azm - azp;
     Real apnorm = std::sqrt(dapx*dapx+dapy*dapy+dapz*dapz);
             AMREX_ALWAYS_ASSERT_WITH_MESSAGE(apnorm != 0.0,
                                      "amrex::EB2:build_cells: apnorm==0");


### PR DESCRIPTION
## Summary

Fix a 2D corner case where divide-by-zero happens resulting in a crash if
`amrex.fpe_trap_zero=1` is used.  Note that the affected cells will be set to covered, with
or without this fix.  So this does not change any behavior if `fpe_trap_zero=0`.

## Additional background

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
