### PR TITLE
Compute levelset functions in C++

### DIFF
--- a/Src/EB/AMReX_EB_LSCore.H
+++ b/Src/EB/AMReX_EB_LSCore.H
@@ -15,9 +15,7 @@
 #include <AMReX_ArrayLim.H>
 #include <AMReX_FluxRegister.H>
 
-#include <AMReX_EB_F.H>
 #include <AMReX_EB_utils.H>
-#include <AMReX_EB_LSCore_F.H>
 #include <AMReX_EB_LSCoreBase.H>
 #include <AMReX_EB_levelset.H>
 

--- a/Src/EB/AMReX_EB_LSCoreBase.H
+++ b/Src/EB/AMReX_EB_LSCoreBase.H
@@ -30,6 +30,18 @@ class AmrMeshInSituBridge;
 
 namespace amrex {
 
+struct AmrLSCoreFill
+{
+    AMREX_GPU_DEVICE
+    void operator() (const amrex::IntVect& /*iv*/, amrex::Array4<amrex::Real> const& /*data*/,
+                     const int /*dcomp*/, const int /*numcomp*/,
+                     amrex::GeometryData const& /*geom*/, const amrex::Real /*time*/,
+                     const amrex::BCRec* /*bcr*/, const int /*bcomp*/,
+                     const int /*orig_comp*/) const
+        {
+            // do something for external Dirichlet (BCType::ext_dir)
+        }
+};
 
 class LSCoreBase
     : public AmrCore

--- a/Src/EB/AMReX_EB_LSCoreBase.H
+++ b/Src/EB/AMReX_EB_LSCoreBase.H
@@ -15,7 +15,6 @@
 #include <AMReX_TagBox.H>
 #include <AMReX_AmrCore.H>
 
-#include <AMReX_EB_LSCore_F.H>
 #include <AMReX_EB_levelset.H>
 
 

--- a/Src/EB/AMReX_EB_LSCoreBase.cpp
+++ b/Src/EB/AMReX_EB_LSCoreBase.cpp
@@ -605,17 +605,6 @@ void LSCoreBase::FillLevelSet( MultiFab & level_set, const MultiFab & ls_crse,
             const auto & if_tile   = mf_impfunc[mfi];
 
             if (n_facets > 0) {
-                // const auto & norm_tile = normal[mfi];
-                // const auto & bcent_tile = bndrycent[mfi];
-
-                // int c_facets = 0;
-                // amrex_eb_as_list(BL_TO_FORTRAN_BOX(eb_search), & c_facets,
-                //                  BL_TO_FORTRAN_3D(flag),
-                //                  BL_TO_FORTRAN_3D(norm_tile),
-                //                  BL_TO_FORTRAN_3D(bcent_tile),
-                //                  facet_list.dataPtr(), & facet_list_size,
-                //                  geom.CellSize()                          );
-
 
                 RealVect dx;
                 for (int d=0; d<AMREX_SPACEDIM; ++d)
@@ -638,8 +627,8 @@ void LSCoreBase::FillLevelSet( MultiFab & level_set, const MultiFab & ls_crse,
                                 // Compute facet center
                                 RealVect eb_cent, cell_corner{(Real) i, (Real) j, (Real) k};
                                 for (int d=0; d<AMREX_SPACEDIM; ++d) {
-                                    eb_cent[d] = bcent_array(i, j, k, d)
-                                               + cell_corner[d] + 0.5*dx[d];
+                                    eb_cent[d] = ( bcent_array(i, j, k, d)
+                                                  + cell_corner[d] + 0.5)*dx[d];
                                 }
 
                                 // Add data to eb facet vector
@@ -655,14 +644,6 @@ void LSCoreBase::FillLevelSet( MultiFab & level_set, const MultiFab & ls_crse,
                     }
                 }
 
-
-                // amrex_eb_fill_levelset_loc(BL_TO_FORTRAN_BOX(tile_box),
-                //                            facet_list.dataPtr(), & facet_list_size,
-                //                            BL_TO_FORTRAN_3D(v_tile),
-                //                            BL_TO_FORTRAN_3D(ls_tile_w),
-                //                            BL_TO_FORTRAN_3D(ls_tile), & ls_threshold,
-                //                            geom.CellSize(), geom.CellSize()         );
-
                 Array4<Real      > const & ls_array = level_set.array(mfi);
                 Array4<Real const> const & ls_guess = ls_crse.array(mfi);
                 Array4<int       > const &  v_array = eb_valid.array(mfi);
@@ -676,7 +657,7 @@ void LSCoreBase::FillLevelSet( MultiFab & level_set, const MultiFab & ls_crse,
                             for(int d=0; d<AMREX_SPACEDIM; ++d)
                                 pos_node[d] = pos_node[d] * dx[d];
 
-                            if (amrex::Math::abs(ls_guess(i, j, k) < ls_threshold)) {
+                            if (amrex::Math::abs(ls_guess(i, j, k)) < ls_threshold) {
                                 Real min_dist=0;
                                 bool proj_valid=true;
                                 geom::closest_dist (min_dist, proj_valid,

--- a/Src/EB/AMReX_EB_geom.H
+++ b/Src/EB/AMReX_EB_geom.H
@@ -2,9 +2,28 @@
 #define AMREX_EB_GEOMETRY_H_
 
 
+#include <AMReX_REAL.H>
+#include <AMReX_RealVect.H>
+
+#include <AMReX_MultiFab.H>
+#include <AMReX_iMultiFab.H>
+#include <AMReX_BoxArray.H>
+
+
+
 namespace amrex {
 namespace geom {
 
+
+
+RealVect facets_nearest_pt (const IntVect  & ind_pt, const IntVect  & ind_loop,
+                            const RealVect & r_vec,  const RealVect & eb_normal,
+                            const RealVect & eb_p0,  const RealVect & dx );
+
+
+void closest_dist (Real & min_dist, bool & proj_valid,
+                   const Vector<Real> & eb_data,
+                   const RealVect & dx_eb, const RealVect & pos);
 
 }
 }

--- a/Src/EB/AMReX_EB_geom.H
+++ b/Src/EB/AMReX_EB_geom.H
@@ -1,0 +1,13 @@
+#ifndef AMREX_EB_GEOMETRY_H_
+#define AMREX_EB_GEOMETRY_H_
+
+
+namespace amrex {
+namespace geom {
+
+
+}
+}
+
+
+#endif

--- a/Src/EB/AMReX_EB_geom.cpp
+++ b/Src/EB/AMReX_EB_geom.cpp
@@ -14,7 +14,7 @@ namespace geom {
 
 
 inline Real dot_3d_real (const RealVect & v1, const RealVect & v2) {
-    return v1[0]*v2[0] + v1[1]*v2[1] * v1[2]*v2[2];
+    return v1[0]*v2[0] + v1[1]*v2[1] + v1[2]*v2[2];
 }
 
 
@@ -249,7 +249,6 @@ void closest_dist (Real & min_dist, bool & proj_valid,
     int i_nearest  = 0;
 
 
-
     for (int i=0; i<l_eb; i+=2*AMREX_SPACEDIM) {
 
         RealVect eb_cent, eb_norm;
@@ -271,7 +270,6 @@ void closest_dist (Real & min_dist, bool & proj_valid,
         eb_cent[d] = eb_data[i_nearest + d];
         eb_norm[d] = eb_data[i_nearest + d + AMREX_SPACEDIM];
     }
-
 
     Real dist_proj = dot_3d_real( pos - eb_cent, -eb_norm );
 

--- a/Src/EB/AMReX_EB_geom.cpp
+++ b/Src/EB/AMReX_EB_geom.cpp
@@ -128,6 +128,17 @@ bool norm_all_eq (const RealVect & a, const RealVect & b) {
 
 
 
+bool all_eq (const IntVect & a, const IntVect & b) {
+
+    for (int d=0; d<AMREX_SPACEDIM; ++d)
+        if (a[d] != b[d])
+            return false;
+
+    return true;
+}
+
+
+
 RealVect facets_nearest_pt (const IntVect  & ind_pt, const IntVect  & ind_loop,
                             const RealVect & r_vec,  const RealVect & eb_normal,
                             const RealVect & eb_p0,  const RealVect & dx ) {
@@ -218,6 +229,97 @@ RealVect facets_nearest_pt (const IntVect  & ind_pt, const IntVect  & ind_loop,
 
     return c_vec;
 }
+
+
+
+void closest_dist (Real & min_dist, bool & proj_valid,
+                   const Vector<Real> & eb_data,
+                   const RealVect & dx_eb, const RealVect & pos) {
+
+    int l_eb = eb_data.size();
+
+    RealVect inv_dx;
+    for (int d=0; d<AMREX_SPACEDIM; ++d)
+        inv_dx[d] = 1. / dx_eb[d];
+
+    min_dist   = std::numeric_limits<Real>::max();
+    proj_valid = false;
+
+    Real min_dist2  = std::numeric_limits<Real>::max();
+    int i_nearest   = 0;
+
+
+
+    for (int i=0; i<l_eb; i+=2*AMREX_SPACEDIM) {
+
+        RealVect eb_cent, eb_norm;
+        for (int d=0; d<AMREX_SPACEDIM; ++d) {
+            eb_cent[d] = eb_data[i + d];
+            eb_cent[d] = eb_data[i + d + AMREX_SPACEDIM];
+        }
+
+        Real dist2 = dot_3d_real( pos - eb_cent, pos - eb_cent );
+
+        if ( dist2 < min_dist2 ) {
+            min_dist2 = dist2;
+            i_nearest = i;
+        }
+    }
+
+    RealVect eb_cent, eb_norm;
+    for (int d=0; d<AMREX_SPACEDIM; ++d) {
+        eb_cent[d] = eb_data[i_nearest + d];
+        eb_norm[d] = eb_data[i_nearest + d + AMREX_SPACEDIM];
+    }
+
+
+    Real dist_proj = dot_3d_real( pos - eb_cent, -eb_norm );
+
+    RealVect eb_min_pt;
+    IntVect  vi_cent, vi_pt;
+    for (int d=0; d<AMREX_SPACEDIM; ++d) {
+        eb_min_pt[d] = pos[d] + eb_norm[d] * dist_proj;
+
+        vi_cent[d] = amrex::Math::floor( eb_cent[d] * inv_dx[d]);
+        vi_pt[d]   = amrex::Math::floor( eb_min_pt[d] * inv_dx[d]);
+    }
+
+
+    bool min_pt_valid = false;
+    if ( all_eq( vi_pt, vi_cent ) ) {
+        min_pt_valid = true;
+    } else {
+        for (int k_shift = -1; k_shift <= 1; ++k_shift) {
+            for (int j_shift = -1; j_shift <= 1; ++j_shift) {
+                for (int i_shift = -1; i_shift <= 1; ++i_shift) {
+
+                    RealVect shift {AMREX_D_DECL(1.e-6*i_shift,
+                                                 1.e-6*j_shift,
+                                                 1.e-6*k_shift)};
+
+                    for (int d=0; d<AMREX_SPACEDIM; ++d)
+                        vi_pt[d] = amrex::Math::floor(
+                                (eb_min_pt[d] + shift[d]*dx_eb[d]) * inv_dx[d]
+                            );
+
+                    if ( all_eq( vi_pt, vi_cent ) ) min_pt_valid = true;
+                }
+            }
+        }
+    }
+
+
+    if ( min_pt_valid ) {
+        min_dist   = dist_proj;
+        proj_valid = true;
+    } else {
+        RealVect c_vec = facets_nearest_pt(vi_pt, vi_cent, pos, eb_norm, eb_cent, dx_eb);
+        Real min_edge_dist2 = dot_3d_real( c_vec - pos, c_vec - pos);
+        min_dist = -std::sqrt( std::min(min_dist2, min_edge_dist2) );
+    }
+
+}
+
 
 }
 }

--- a/Src/EB/AMReX_EB_geom.cpp
+++ b/Src/EB/AMReX_EB_geom.cpp
@@ -13,6 +13,7 @@ namespace amrex {
 namespace geom {
 
 
+// TODO: this can be replaced by RealVect::dotProduct
 inline Real dot_3d_real (const RealVect & v1, const RealVect & v2) {
     return v1[0]*v2[0] + v1[1]*v2[1] + v1[2]*v2[2];
 }

--- a/Src/EB/AMReX_EB_geom.cpp
+++ b/Src/EB/AMReX_EB_geom.cpp
@@ -278,8 +278,8 @@ void closest_dist (Real & min_dist, bool & proj_valid,
     for (int d=0; d<AMREX_SPACEDIM; ++d) {
         eb_min_pt[d] = pos[d] + eb_norm[d] * dist_proj;
 
-        vi_cent[d] = amrex::Math::floor( eb_cent[d] * inv_dx[d]);
-        vi_pt[d]   = amrex::Math::floor( eb_min_pt[d] * inv_dx[d]);
+        vi_cent[d] = static_cast<int>(amrex::Math::floor( eb_cent[d] * inv_dx[d]));
+        vi_pt[d]   = static_cast<int>(amrex::Math::floor( eb_min_pt[d] * inv_dx[d]));
     }
 
 
@@ -296,9 +296,9 @@ void closest_dist (Real & min_dist, bool & proj_valid,
                                                  1.e-6*k_shift)};
 
                     for (int d=0; d<AMREX_SPACEDIM; ++d)
-                        vi_pt[d] = amrex::Math::floor(
+                        vi_pt[d] = static_cast<int>(amrex::Math::floor(
                                 (eb_min_pt[d] + shift[d]*dx_eb[d]) * inv_dx[d]
-                            );
+                            ));
 
                     if ( all_eq( vi_pt, vi_cent ) ) min_pt_valid = true;
                 }

--- a/Src/EB/AMReX_EB_geom.cpp
+++ b/Src/EB/AMReX_EB_geom.cpp
@@ -123,7 +123,7 @@ bool norm_all_eq (const RealVect & a, const RealVect & b) {
         diff += amrex::Math::abs(abs_a - abs_b);
     }
 
-    return diff <= 10*eps; // 10 = fudge factor
+    return diff <= AMREX_SPACEDIM*eps;
 }
 
 
@@ -245,8 +245,8 @@ void closest_dist (Real & min_dist, bool & proj_valid,
     min_dist   = std::numeric_limits<Real>::max();
     proj_valid = false;
 
-    Real min_dist2  = std::numeric_limits<Real>::max();
-    int i_nearest   = 0;
+    Real min_dist2 = std::numeric_limits<Real>::max();
+    int i_nearest  = 0;
 
 
 
@@ -255,7 +255,7 @@ void closest_dist (Real & min_dist, bool & proj_valid,
         RealVect eb_cent, eb_norm;
         for (int d=0; d<AMREX_SPACEDIM; ++d) {
             eb_cent[d] = eb_data[i + d];
-            eb_cent[d] = eb_data[i + d + AMREX_SPACEDIM];
+            eb_norm[d] = eb_data[i + d + AMREX_SPACEDIM];
         }
 
         Real dist2 = dot_3d_real( pos - eb_cent, pos - eb_cent );

--- a/Src/EB/AMReX_EB_geom.cpp
+++ b/Src/EB/AMReX_EB_geom.cpp
@@ -1,0 +1,223 @@
+#include "AMReX_EB_geom.H"
+
+#include <AMReX_REAL.H>
+#include <AMReX_RealVect.H>
+
+#include <AMReX_MultiFab.H>
+#include <AMReX_iMultiFab.H>
+#include <AMReX_BoxArray.H>
+
+
+
+namespace amrex {
+namespace geom {
+
+
+inline Real dot_3d_real (const RealVect & v1, const RealVect & v2) {
+    return v1[0]*v2[0] + v1[1]*v2[1] * v1[2]*v2[2];
+}
+
+
+
+inline RealVect cross_3d_real (const RealVect & v1, const RealVect & v2) {
+    RealVect cross;
+
+    cross[0] = v1[1]*v2[2] - v1[2]*v2[1];
+    cross[1] = v1[2]*v2[0] - v1[0]*v2[2];
+    cross[2] = v1[0]*v2[1] - v1[1]*v2[0];
+
+    return cross;
+}
+
+
+
+void calc_facet_edge (      RealVect & p0,       RealVect & v,
+                            Real       h1,       Real       h2,
+                      const RealVect & n1, const RealVect & n2) {
+
+    Real c_dp   = dot_3d_real(n1, n2);
+    Real c_norm = 1 - c_dp * c_dp;
+
+    Real c1 = ( h1 - h2 * c_dp ) / c_norm;
+    Real c2 = ( h2 - h1 * c_dp ) / c_norm;
+
+    for (int d=0; d<AMREX_SPACEDIM; ++d)
+        p0[d] = c1 * n1[d] + c2 * n2[d];
+    v = cross_3d_real(n1, n2);
+}
+
+
+
+void lines_nearest_pt (Real & lambda_min, RealVect & nearest_pt,
+                       const RealVect & p0, const RealVect & v, const RealVect & pt) {
+
+    RealVect c;
+    for (int d=0; d<AMREX_SPACEDIM; ++d)
+        c[d] = p0[d] - pt[d];
+
+    lambda_min = - dot_3d_real(v, c) / dot_3d_real (v, v);
+    for (int d=0; d<AMREX_SPACEDIM; ++d)
+        nearest_pt[d] = p0[d] + lambda_min*v[d];
+}
+
+
+
+inline void swap_reals (Real & a, Real & b) {
+
+    Real c = a;
+    a      = b;
+    b      = c;
+
+}
+
+
+
+void lambda_bounds (Real & lambda_min, Real & lambda_max, const IntVect & id_cell,
+                    const RealVect & p0, const RealVect & v, const RealVect & dx) {
+
+
+    Real cx_lo = -std::numeric_limits<Real>::max();
+    Real cy_lo = -std::numeric_limits<Real>::max();
+    Real cz_lo = -std::numeric_limits<Real>::max();
+
+    Real cx_hi = std::numeric_limits<Real>::max();
+    Real cy_hi = std::numeric_limits<Real>::max();
+    Real cz_hi = std::numeric_limits<Real>::max();
+
+    Real eps = std::numeric_limits<Real>::epsilon();
+
+    if ( amrex::Math::abs(v[0]) > eps ) {
+        cx_lo = -( p0[0] -   id_cell[0]       * dx[0] ) / v[0];
+        cx_hi = -( p0[0] - ( id_cell[0] + 1 ) * dx[0] ) / v[0];
+
+        if ( v[0] < 0. ) swap_reals(cx_lo, cx_hi);
+    }
+
+    if ( amrex::Math::abs(v[1]) > eps ) {
+        cy_lo = -( p0[1] -   id_cell[1]       * dx[1] ) / v[1];
+        cy_hi = -( p0[1] - ( id_cell[1] + 1 ) * dx[1] ) / v[1];
+
+        if ( v[1] < 0. ) swap_reals(cy_lo, cy_hi);
+    }
+
+    if ( amrex::Math::abs(v[2]) > eps ) {
+        cz_lo = -( p0[2] -   id_cell[2]       * dx[2] ) / v[2];
+        cz_hi = -( p0[2] - ( id_cell[2] + 1 ) * dx[2] ) / v[2];
+
+        if ( v[2] < 0. ) swap_reals(cz_lo, cz_hi);
+    }
+
+
+    lambda_min = std::max(cx_lo, std::max(cy_lo, cz_lo));
+    lambda_max = std::min(cx_hi, std::min(cy_hi, cz_hi));
+}
+
+
+
+bool norm_all_eq (const RealVect & a, const RealVect & b) {
+
+    Real diff = 0, eps = std::numeric_limits<Real>::epsilon();
+    for (int d=0; d<AMREX_SPACEDIM; ++d) {
+        Real abs_a = amrex::Math::abs(a[d]);
+        Real abs_b = amrex::Math::abs(b[d]);
+        diff += amrex::Math::abs(abs_a - abs_b);
+    }
+
+    return diff <= 10*eps; // 10 = fudge factor
+}
+
+
+
+RealVect facets_nearest_pt (const IntVect  & ind_pt, const IntVect  & ind_loop,
+                            const RealVect & r_vec,  const RealVect & eb_normal,
+                            const RealVect & eb_p0,  const RealVect & dx ) {
+
+    int n_facets = 0;
+    IntVect ind_facets {AMREX_D_DECL(0, 0, 0)};
+
+    if ( ! (ind_pt[0] == ind_loop[0]) ) {
+        n_facets = n_facets + 1;
+        ind_facets[n_facets - 1] = 1;
+    }
+
+    if ( ! (ind_pt[1] == ind_loop[1]) ) {
+        n_facets = n_facets + 1;
+        ind_facets[n_facets - 1] = 2;
+    }
+
+    if ( ! (ind_pt[2] == ind_loop[2]) ) {
+        n_facets = n_facets + 1;
+        ind_facets[n_facets - 1] = 3;
+    }
+
+
+    Real eb_h = dot_3d_real(eb_normal, eb_p0);
+
+
+    Real min_dist = std::numeric_limits<Real>::max();
+    RealVect c_vec;
+    for (int i_facet=0; i_facet<n_facets; ++i_facet) {
+
+        int tmp_facet = ind_facets[i_facet];
+
+        RealVect facet_normal {AMREX_D_DECL(0., 0., 0.)};
+        facet_normal[tmp_facet - 1] = 1.;
+
+
+        if (norm_all_eq(eb_normal, facet_normal)) continue;
+
+        int ind_cell = ind_loop[tmp_facet - 1];
+        int ind_nb   = ind_pt[tmp_facet - 1];
+
+        Real f_c;
+        if (ind_cell < ind_nb) {
+            f_c = ( ind_cell + 1 ) * dx[tmp_facet - 1];
+        } else {
+            f_c =   ind_cell       * dx[tmp_facet - 1];
+        }
+
+        RealVect facet_p0;
+        for (int d=0; d<AMREX_SPACEDIM; ++d)
+            facet_p0[d] = (ind_loop[d] + 0.5) * dx[d];
+
+        facet_p0[tmp_facet - 1] = f_c;
+
+        Real facet_h = dot_3d_real(facet_normal, facet_p0);
+
+        RealVect edge_p0, edge_v;
+        calc_facet_edge(edge_p0, edge_v, eb_h, facet_h, eb_normal, facet_normal);
+
+        Real lambda_tmp;
+        RealVect c_vec_tmp;
+        lines_nearest_pt(lambda_tmp, c_vec_tmp, edge_p0, edge_v, r_vec);
+
+        Real lambda_min, lambda_max;
+        lambda_bounds(lambda_min, lambda_max, ind_loop, edge_p0, edge_v, dx);
+
+
+        if (lambda_tmp < lambda_min) {
+            lambda_tmp = lambda_min;
+        } else if ( lambda_tmp > lambda_max) {
+            lambda_tmp = lambda_max;
+        }
+
+        RealVect rc_vec;
+        for (int d=0; d<AMREX_SPACEDIM; ++d) {
+            c_vec_tmp[d] = edge_p0[d] + lambda_tmp*edge_v[d];
+            rc_vec[d] = c_vec_tmp[d] - r_vec[d];
+        }
+
+        Real min_dist_tmp = dot_3d_real(rc_vec, rc_vec);
+
+        if (min_dist_tmp < min_dist) {
+            min_dist = min_dist_tmp;
+            for (int d=0; d<AMREX_SPACEDIM; ++d)
+                c_vec[d] = c_vec_tmp[d];
+        }
+    }
+
+    return c_vec;
+}
+
+}
+}

--- a/Src/EB/AMReX_EB_geometry.F90
+++ b/Src/EB/AMReX_EB_geometry.F90
@@ -200,7 +200,7 @@ contains
         implicit none
 
         real(amrex_real),               intent(  out) :: lambda_min, lambda_max
-        integer,      dimension(3), intent(in   ) :: id_cell
+        integer,          dimension(3), intent(in   ) :: id_cell
         real(amrex_real), dimension(3), intent(in   ) :: p0, v, dx
 
         ! c... are the preliminary boundaries
@@ -273,7 +273,7 @@ contains
         implicit none
 
         real(amrex_real), dimension(3)             :: facets_nearest_pt
-        integer,      dimension(3), intent(in) :: ind_pt, ind_loop
+        integer,          dimension(3), intent(in) :: ind_pt, ind_loop
         real(amrex_real), dimension(3), intent(in) :: r_vec, eb_normal, eb_p0, dx
 
         integer,      dimension(3) :: ind_facets

--- a/Src/EB/AMReX_EB_levelset.H
+++ b/Src/EB/AMReX_EB_levelset.H
@@ -71,6 +71,12 @@ class LSFactory {
         //! BoxArray and Geometry (at a coarser level of refinement)
         void init_geom(const BoxArray & ba, const Geometry & geom, const DistributionMapping & dm);
 
+
+        AMREX_GPU_HOST_DEVICE static bool neighbour_is_valid(
+                Box const & bx, Array4<Real const> const & phi,
+                int i, int j, int k, int n_pad
+            );
+
         void fill_valid_kernel();
         void fill_valid(int n);
         void fill_valid();

--- a/Src/EB/AMReX_EB_levelset.H
+++ b/Src/EB/AMReX_EB_levelset.H
@@ -508,6 +508,128 @@ class LSUtility {
 
 
 
+//_______________________________________________________________________________
+//
+// Interpolator functions that interpolate the value of the level set function
+// (and its normal) from a nodal MF to any position of the cell interior. These
+// are designed to be called _within_ an MFIter loop => they will not search
+// for the right FAB before interpolating.
+//
+// NOTE: the norml function is the derivative of a trilinear interpolation
+// fuction => it can have discontinuities at nodes
+
+
+AMREX_GPU_HOST_DEVICE AMREX_INLINE
+Real interp_level_set (const GpuArray<Real, AMREX_SPACEDIM> & p,
+                       const int                              n_refine,
+                       const Array4<Real const>             & phi,
+                       const GpuArray<Real, AMREX_SPACEDIM> & plo,
+                       const GpuArray<Real, AMREX_SPACEDIM> & dxi)
+{
+    RealVect scaled_dxi(0.);
+    scaled_dxi[0] = n_refine * dxi[0];
+    scaled_dxi[1] = n_refine * dxi[1];
+    scaled_dxi[2] = n_refine * dxi[2];
+
+    Real x = (p[0] - plo[0]) * scaled_dxi[0];
+    Real y = (p[1] - plo[1]) * scaled_dxi[1];
+    Real z = (p[2] - plo[2]) * scaled_dxi[2];
+
+    int i = static_cast<int>(amrex::Math::floor(x));
+    int j = static_cast<int>(amrex::Math::floor(y));
+    int k = static_cast<int>(amrex::Math::floor(z));
+
+    Real wx_hi = x - i;
+    Real wy_hi = y - j;
+    Real wz_hi = z - k;
+
+    Real wx_lo = 1.0 - wx_hi;
+    Real wy_lo = 1.0 - wy_hi;
+    Real wz_lo = 1.0 - wz_hi;
+
+    Real ls_value = 0;
+    ls_value += phi(i,   j  , k  ) * wx_lo * wy_lo * wz_lo;
+    ls_value += phi(i+1, j  , k  ) * wx_hi * wy_lo * wz_lo;
+    ls_value += phi(i,   j+1, k  ) * wx_lo * wy_hi * wz_lo;
+    ls_value += phi(i+1, j+1, k  ) * wx_hi * wy_hi * wz_lo;
+    ls_value += phi(i,   j  , k+1) * wx_lo * wy_lo * wz_hi;
+    ls_value += phi(i+1, j  , k+1) * wx_hi * wy_lo * wz_hi;
+    ls_value += phi(i  , j+1, k+1) * wx_lo * wy_hi * wz_hi;
+    ls_value += phi(i+1, j+1, k+1) * wx_hi * wy_hi * wz_hi;
+
+    return ls_value;
+}
+
+
+
+AMREX_GPU_HOST_DEVICE AMREX_INLINE
+void level_set_normal (const GpuArray<Real, AMREX_SPACEDIM> & p,
+                       const int                              n_refine,
+                             RealVect                       & normal,
+                       const Array4<Real const>             & phi,
+                       const GpuArray<Real, AMREX_SPACEDIM> & plo,
+                       const GpuArray<Real, AMREX_SPACEDIM> & dxi)
+{
+    RealVect scaled_dxi(0.);
+    scaled_dxi[0] = n_refine * dxi[0];
+    scaled_dxi[1] = n_refine * dxi[1];
+    scaled_dxi[2] = n_refine * dxi[2];
+
+    Real x = (p[0] - plo[0]) * scaled_dxi[0];
+    Real y = (p[1] - plo[1]) * scaled_dxi[1];
+    Real z = (p[2] - plo[2]) * scaled_dxi[2];
+
+    int i = static_cast<int>(amrex::Math::floor(x));
+    int j = static_cast<int>(amrex::Math::floor(y));
+    int k = static_cast<int>(amrex::Math::floor(z));
+
+    Real wx_hi = x - i;
+    Real wy_hi = y - j;
+    Real wz_hi = z - k;
+
+    Real wx_lo = 1.0 - wx_hi;
+    Real wy_lo = 1.0 - wy_hi;
+    Real wz_lo = 1.0 - wz_hi;
+
+    normal[0] = 0.0;
+    normal[1] = 0.0;
+    normal[2] = 0.0;
+
+    normal[0] -= phi(i,   j  , k  ) * scaled_dxi[0] * wy_lo * wz_lo;
+    normal[0] += phi(i+1, j  , k  ) * scaled_dxi[0] * wy_lo * wz_lo;
+    normal[0] -= phi(i,   j+1, k  ) * scaled_dxi[0] * wy_hi * wz_lo;
+    normal[0] += phi(i+1, j+1, k  ) * scaled_dxi[0] * wy_hi * wz_lo;
+    normal[0] -= phi(i,   j  , k+1) * scaled_dxi[0] * wy_lo * wz_hi;
+    normal[0] += phi(i+1, j  , k+1) * scaled_dxi[0] * wy_lo * wz_hi;
+    normal[0] -= phi(i  , j+1, k+1) * scaled_dxi[0] * wy_hi * wz_hi;
+    normal[0] += phi(i+1, j+1, k+1) * scaled_dxi[0] * wy_hi * wz_hi;
+
+    normal[1] -= phi(i,   j  , k  ) * scaled_dxi[1] * wx_lo * wz_lo;
+    normal[1] += phi(i  , j+1, k  ) * scaled_dxi[1] * wx_lo * wz_lo;
+    normal[1] -= phi(i+1, j  , k  ) * scaled_dxi[1] * wx_hi * wz_lo;
+    normal[1] += phi(i+1, j+1, k  ) * scaled_dxi[1] * wx_hi * wz_lo;
+    normal[1] -= phi(i,   j  , k+1) * scaled_dxi[1] * wx_lo * wz_hi;
+    normal[1] += phi(i  , j+1, k+1) * scaled_dxi[1] * wx_lo * wz_hi;
+    normal[1] -= phi(i+1, j  , k+1) * scaled_dxi[1] * wx_hi * wz_hi;
+    normal[1] += phi(i+1, j+1, k+1) * scaled_dxi[1] * wx_hi * wz_hi;
+
+    normal[2] -= phi(i  , j  , k  ) * scaled_dxi[2] * wx_lo * wy_lo;
+    normal[2] += phi(i  , j  , k+1) * scaled_dxi[2] * wx_lo * wy_lo;
+    normal[2] -= phi(i+1, j  , k  ) * scaled_dxi[2] * wx_hi * wy_lo;
+    normal[2] += phi(i+1, j  , k+1) * scaled_dxi[2] * wx_hi * wy_lo;
+    normal[2] -= phi(i,   j+1, k  ) * scaled_dxi[2] * wx_lo * wy_hi;
+    normal[2] += phi(i  , j+1, k+1) * scaled_dxi[2] * wx_lo * wy_hi;
+    normal[2] -= phi(i+1, j+1, k  ) * scaled_dxi[2] * wx_hi * wy_hi;
+    normal[2] += phi(i+1, j+1, k+1) * scaled_dxi[2] * wx_hi * wy_hi;
+
+    Real inv_norm = 1.0 / std::sqrt(normal.dotProduct(normal));
+    normal[0] *= inv_norm;
+    normal[1] *= inv_norm;
+    normal[2] *= inv_norm;
+}
+
+//-------------------------------------------------------------------------------
+
 }
 
 #endif

--- a/Src/EB/AMReX_EB_levelset.cpp
+++ b/Src/EB/AMReX_EB_levelset.cpp
@@ -203,8 +203,8 @@ void LSFactory::fill_valid_kernel(){
                             tile_box, ls_tile, i, j, k, search_radius
                         );
 
-                    if (neighbour_is_valid) valid_tile(i, j, k) = 1;
-                    else                    valid_tile(i, j, k) = 0;
+                    if (valid_cell) valid_tile(i, j, k) = 1;
+                    else            valid_tile(i, j, k) = 0;
                 }
             );
     }

--- a/Src/EB/AMReX_EB_levelset.cpp
+++ b/Src/EB/AMReX_EB_levelset.cpp
@@ -67,12 +67,14 @@ LSFactory::LSFactory(int lev, int ls_ref, int eb_ref, int ls_pad, int eb_pad,
     for(MFIter mfi( * ls_grid, true); mfi.isValid(); ++mfi){
         // also initialize ghost cells => growntilebox. Note: if a direction is
         // not periodic, FillBoundary will never touch those ghost cells.
-        Box tile_box   = mfi.growntilebox();
-        auto & ls_tile = (* ls_grid)[mfi];
+        Box tile_box                 = mfi.growntilebox();
+        Array4<Real> const & ls_tile = ls_grid->array(mfi);
 
-        // Initialize in fortran land
-        amrex_eb_init_levelset(tile_box.loVect(), tile_box.hiVect(),
-                               ls_tile.dataPtr(), ls_tile.loVect(),  ls_tile.hiVect());
+        ParallelFor(tile_box,
+                [=] AMREX_GPU_DEVICE (int i, int j, int k) {
+                    ls_tile(i, j, k) = std::numeric_limits<Real>::max();
+                }
+            );
     }
 }
 

--- a/Src/EB/AMReX_EB_levelset.cpp
+++ b/Src/EB/AMReX_EB_levelset.cpp
@@ -431,7 +431,7 @@ std::unique_ptr<Vector<Real>> LSFactory::eb_facets(const FArrayBox & norm_tile,
                         // Compute facet center
                         RealVect eb_cent, cell_corner{(Real) i, (Real) j, (Real) k};
                         for (int d=0; d<AMREX_SPACEDIM; ++d) {
-                            eb_cent[d] = bcent_array(i, j, k, d) 
+                            eb_cent[d] = bcent_array(i, j, k, d)
                                        + cell_corner[d]
                                        + 0.5*dx_eb[d];
                         }
@@ -901,14 +901,6 @@ void LSFactory::fill_data (MultiFab & data, iMultiFab & valid,
             // capture it by value. Why by value? => In case we want to run
             // this code on device.
             auto facet_vect = *facets;
-
-            // amrex_eb_fill_levelset(BL_TO_FORTRAN_BOX(tile_box),
-            //                         facet_vect.dataPtr(), & len_facets,
-            //                         BL_TO_FORTRAN_3D(v_tile),
-            //                         BL_TO_FORTRAN_3D(ls_tile),
-            //                         dx.dataPtr(), dx_eb.dataPtr() );
-
-
 
             Array4<Real> const & ls_array = ls_tile.array();
             Array4<int > const &  v_array = v_tile.array();

--- a/Src/EB/AMReX_EB_levelset.cpp
+++ b/Src/EB/AMReX_EB_levelset.cpp
@@ -728,6 +728,10 @@ void LSFactory::fill_data (MultiFab & data, iMultiFab & valid,
 
 
 
+
+
+
+
 void LSFactory::fill_data (MultiFab & data, iMultiFab & valid,
                            const EBFArrayBoxFactory & eb_factory,
                            const MultiFab & eb_impfunc,
@@ -839,7 +843,7 @@ void LSFactory::fill_data (MultiFab & data, iMultiFab & valid,
             Array4<Real const> const & if_tile = eb_impfunc.array(mfi);
             Array4<int const>  const &  v_tile = eb_valid.array(mfi);
             Array4<Real      > const &     phi = data.array(mfi);
-            
+
             ParallelFor(tile_box,
                     [=] AMREX_GPU_DEVICE (int i, int j, int k) {
                         if (v_tile(i, j, k) == 0) {
@@ -852,6 +856,7 @@ void LSFactory::fill_data (MultiFab & data, iMultiFab & valid,
                         }
                     }
                 );
+
             continue;
         }
 

--- a/Src/EB/AMReX_EB_levelset.cpp
+++ b/Src/EB/AMReX_EB_levelset.cpp
@@ -431,9 +431,8 @@ std::unique_ptr<Vector<Real>> LSFactory::eb_facets(const FArrayBox & norm_tile,
                         // Compute facet center
                         RealVect eb_cent, cell_corner{(Real) i, (Real) j, (Real) k};
                         for (int d=0; d<AMREX_SPACEDIM; ++d) {
-                            eb_cent[d] = bcent_array(i, j, k, d)
-                                       + cell_corner[d]
-                                       + 0.5*dx_eb[d];
+                            eb_cent[d] = ( bcent_array(i, j, k, d)
+                                          + cell_corner[d] + 0.5 )*dx_eb[d];
                         }
 
                         // Add data to eb facet vector

--- a/Src/EB/AMReX_EB_levelset.cpp
+++ b/Src/EB/AMReX_EB_levelset.cpp
@@ -902,6 +902,14 @@ void LSFactory::fill_data (MultiFab & data, iMultiFab & valid,
             // this code on device.
             auto facet_vect = *facets;
 
+            // amrex_eb_fill_levelset(BL_TO_FORTRAN_BOX(tile_box),
+            //                         facet_vect.dataPtr(), & len_facets,
+            //                         BL_TO_FORTRAN_3D(v_tile),
+            //                         BL_TO_FORTRAN_3D(ls_tile),
+            //                         dx.dataPtr(), dx_eb.dataPtr() );
+
+
+
             Array4<Real> const & ls_array = ls_tile.array();
             Array4<int > const &  v_array = v_tile.array();
 
@@ -909,11 +917,11 @@ void LSFactory::fill_data (MultiFab & data, iMultiFab & valid,
                     [=] AMREX_GPU_DEVICE (int i, int j, int k) {
                         RealVect pos_node {AMREX_D_DECL( (Real) i, (Real) j, (Real) k)};
                         for(int d=0; d<AMREX_SPACEDIM; ++d)
-                            pos_node[d] *= dx[d];
+                            pos_node[d] = pos_node[d] * dx[d];
 
 
-                        Real min_dist;
-                        bool proj_valid;
+                        Real min_dist=0;
+                        bool proj_valid=true;
                         geom::closest_dist (min_dist, proj_valid,
                                             facet_vect, dx_eb, pos_node);
 

--- a/Src/EB/AMReX_EB_levelset.cpp
+++ b/Src/EB/AMReX_EB_levelset.cpp
@@ -478,7 +478,7 @@ void LSFactory::update_intersection(const MultiFab & ls_in, const iMultiFab & va
                         Real in_node = ls_in_tile(i, j, k);
                         Real ls_node = ls_tile(i, j, k);
                         if (in_node < ls_node) {
-                            ls_tile(i, j, k) == in_node;
+                            ls_tile(i, j, k) = in_node;
                             if (ls_node <= 0) {
                                 valid_tile(i, j, k) = 1;
                             }
@@ -562,7 +562,7 @@ void LSFactory::update_union(const MultiFab & ls_in, const iMultiFab & valid_in)
                         Real in_node = ls_in_tile(i, j, k);
                         Real ls_node = ls_tile(i, j, k);
                         if (in_node > ls_node) {
-                            ls_tile(i, j, k) == in_node;
+                            ls_tile(i, j, k) = in_node;
                             if (ls_node <= 0) {
                                 valid_tile(i, j, k) = 1;
                             }
@@ -755,10 +755,6 @@ void LSFactory::fill_data (MultiFab & data, iMultiFab & valid,
                          IntVect{AMREX_D_DECL(ebt_size, ebt_size, ebt_size)},
                          ls_ref, eb_ref, geom, geom_eb);
 }
-
-
-
-
 
 
 

--- a/Src/EB/AMReX_EB_levelset.cpp
+++ b/Src/EB/AMReX_EB_levelset.cpp
@@ -721,9 +721,15 @@ void LSFactory::invert() {
 #pragma omp parallel
 #endif
     for(MFIter mfi( * ls_grid, true); mfi.isValid(); ++ mfi){
-        FArrayBox & a_fab = (* ls_grid)[mfi];
-        for(BoxIterator bit(mfi.tilebox()); bit.ok(); ++bit)
-            a_fab(bit(), 0) = - a_fab(bit(), 0);
+        // FArrayBox & a_fab = (* ls_grid)[mfi];
+        // for(BoxIterator bit(mfi.tilebox()); bit.ok(); ++bit)
+        //     a_fab(bit(), 0) = - a_fab(bit(), 0);
+        Array4<Real> const & fab = ls_grid->array(mfi);
+        ParallelFor(mfi.tilebox(),
+                [=] AMREX_GPU_DEVICE (int i, int j, int k) {
+                    fab(i, j, k) =  - fab(i, j, k);
+                }
+            );
     }
 
     ls_grid->FillBoundary(geom_ls.periodicity());

--- a/Src/EB/AMReX_EB_levelset.cpp
+++ b/Src/EB/AMReX_EB_levelset.cpp
@@ -12,7 +12,6 @@
 #include "AMReX_BoxIterator.H"
 #include <AMReX_EBCellFlag.H>
 
-#include <AMReX_EB_F.H>
 #include <AMReX_EB_utils.H>
 
 #include <AMReX_EB2.H>

--- a/Src/EB/AMReX_EB_levelset_F.F90
+++ b/Src/EB/AMReX_EB_levelset_F.F90
@@ -149,7 +149,7 @@ contains
       real(amrex_real),                  intent(in   ) :: ls_thres
 
       real(amrex_real),  intent(  out) :: phi     (  p_lo(1):p_hi(1),     p_lo(2):p_hi(2),     p_lo(3):p_hi(3)  )
-      integer,       intent(  out) :: valid   (  v_lo(1):v_hi(1),     v_lo(2):v_hi(2),     v_lo(3):v_hi(3)  )
+      integer,           intent(  out) :: valid   (  v_lo(1):v_hi(1),     v_lo(2):v_hi(2),     v_lo(3):v_hi(3)  )
       real(amrex_real),  intent(in   ) :: ls_guess(lsg_lo(1):lsg_hi(1), lsg_lo(2):lsg_hi(2), lsg_lo(3):lsg_hi(3))
 
       ! ** define internal variables
@@ -211,12 +211,12 @@ contains
         implicit none
 
         integer,      dimension(3), intent(in   ) :: philo, phihi, vlo, vhi, periodic, domlo, domhi
-        real(amrex_real),               intent(  out) :: phi(philo(1):phihi(1), philo(2):phihi(2), philo(3):phihi(3))
+        real(amrex_real),           intent(  out) :: phi(philo(1):phihi(1), philo(2):phihi(2), philo(3):phihi(3))
         integer,                    intent(  out) :: valid(vlo(1):vhi(1),     vlo(2):vhi(2),     vlo(3):vhi(3))
 
         ! ** extra data used by fill levelset operation
         real(amrex_real), dimension(3),    intent(in   ) :: dx, dx_eb
-        integer,                       intent(in   ) :: l_eb
+        integer,                           intent(in   ) :: l_eb
         real(amrex_real), dimension(l_eb), intent(in   ) :: eb_list
 
 

--- a/Src/EB/AMReX_EB_levelset_F.F90
+++ b/Src/EB/AMReX_EB_levelset_F.F90
@@ -29,7 +29,7 @@ contains
 
         ! ** define I/O dummy variables
         integer,      dimension(3), intent(in   ) :: lo, hi, phlo, phhi
-        real(amrex_real),               intent(  out) :: phi ( phlo(1):phhi(1), phlo(2):phhi(2), phlo(3):phhi(3) )
+        real(amrex_real),           intent(  out) :: phi ( phlo(1):phhi(1), phlo(2):phhi(2), phlo(3):phhi(3) )
 
         ! ** define internal variables
         !    i, j, k: loop index variables
@@ -75,7 +75,7 @@ contains
         integer,      dimension(3),    intent(in   ) :: lo, hi, vlo, vhi, phlo, phhi
         real(amrex_real), dimension(l_eb), intent(in   ) :: eb_list
         real(amrex_real),                  intent(  out) :: phi     (phlo(1):phhi(1), phlo(2):phhi(2), phlo(3):phhi(3))
-        integer,                       intent(  out) :: valid   ( vlo(1):vhi(1),   vlo(2):vhi(2),   vlo(3):vhi(3) )
+        integer,                           intent(  out) :: valid   ( vlo(1):vhi(1),   vlo(2):vhi(2),   vlo(3):vhi(3) )
         real(amrex_real), dimension(3),    intent(in   ) :: dx, dx_eb
 
 
@@ -455,8 +455,8 @@ contains
       implicit none
 
       integer,      dimension(3), intent(in   ) :: lo, hi, phi_lo, phi_hi
-      real(amrex_real),               intent(in   ) :: threshold
-      real(amrex_real),               intent(inout) :: phi (phi_lo(1):phi_hi(1), &
+      real(amrex_real),           intent(in   ) :: threshold
+      real(amrex_real),           intent(inout) :: phi (phi_lo(1):phi_hi(1), &
                                                         phi_lo(2):phi_hi(2), &
                                                         phi_lo(3):phi_hi(3))
 
@@ -505,9 +505,9 @@ contains
 
         integer,      dimension(3), intent(in   ) :: lo, hi, imlo, imhi, vlo, vhi, phlo, phhi
         integer,                    intent(in   ) :: n_pad
-        real(amrex_real),               intent(in   ) :: impf  ( imlo(1):imhi(1), imlo(2):imhi(2), imlo(3):imhi(3) )
+        real(amrex_real),           intent(in   ) :: impf  ( imlo(1):imhi(1), imlo(2):imhi(2), imlo(3):imhi(3) )
         integer,                    intent(in   ) :: valid (  vlo(1):vhi(1),   vlo(2):vhi(2),   vlo(3):vhi(3)  )
-        real(amrex_real),               intent(inout) :: phi   ( phlo(1):phhi(1), phlo(2):phhi(2), phlo(3):phhi(3) )
+        real(amrex_real),           intent(inout) :: phi   ( phlo(1):phhi(1), phlo(2):phhi(2), phlo(3):phhi(3) )
 
         integer      :: ii, jj, kk
         real(amrex_real) :: levelset_node
@@ -541,8 +541,8 @@ contains
 
         integer, dimension(3), intent(in   ) :: phlo, phhi, vlo, vhi, periodic, domlo, domhi, imlo, imhi
         integer,               intent(in   ) :: valid (  vlo(1):vhi(1),   vlo(2):vhi(2),   vlo(3):vhi(3)  )
-        real(amrex_real),          intent(inout) :: phi   ( phlo(1):phhi(1), phlo(2):phhi(2), phlo(3):phhi(3) )
-        real(amrex_real),          intent(in   ) :: impf(imlo(1):imhi(1), imlo(2):imhi(2), imlo(3):imhi(3))
+        real(amrex_real),      intent(inout) :: phi   ( phlo(1):phhi(1), phlo(2):phhi(2), phlo(3):phhi(3) )
+        real(amrex_real),      intent(in   ) :: impf(imlo(1):imhi(1), imlo(2):imhi(2), imlo(3):imhi(3))
 
         integer, dimension(3) :: lo, hi
         !-------------------------------------------------------------------------------------------------------------
@@ -660,9 +660,9 @@ contains
 
         integer,      dimension(3), intent(in   ) :: lo, hi, vilo, vihi, lslo, lshi, vlo, vhi, phlo, phhi
         integer,                    intent(in   ) :: v_in  (vilo(1):vihi(1),vilo(2):vihi(2),vilo(3):vihi(3))
-        real(amrex_real),               intent(in   ) :: ls_in (lslo(1):lshi(1),lslo(2):lshi(2),lslo(3):lshi(3))
-        integer,                        intent(inout) :: valid ( vlo(1):vhi(1),  vlo(2):vhi(2),  vlo(3):vhi(3) )
-        real(amrex_real),               intent(inout) :: phi   (phlo(1):phhi(1),phlo(2):phhi(2),phlo(3):phhi(3))
+        real(amrex_real),           intent(in   ) :: ls_in (lslo(1):lshi(1),lslo(2):lshi(2),lslo(3):lshi(3))
+        integer,                    intent(inout) :: valid ( vlo(1):vhi(1),  vlo(2):vhi(2),  vlo(3):vhi(3) )
+        real(amrex_real),           intent(inout) :: phi   (phlo(1):phhi(1),phlo(2):phhi(2),phlo(3):phhi(3))
 
         real(amrex_real) :: ls_node, in_node
         integer      :: ii, jj, kk
@@ -702,9 +702,9 @@ contains
 
         integer, dimension(3), intent(in   ) :: vilo, vihi, lslo, lshi, vlo, vhi, phlo, phhi, periodic, domlo, domhi
         integer,               intent(in   ) :: v_in  (vilo(1):vihi(1),vilo(2):vihi(2),vilo(3):vihi(3))
-        real(amrex_real),          intent(in   ) :: ls_in (lslo(1):lshi(1),lslo(2):lshi(2),lslo(3):lshi(3))
-        integer,                   intent(inout) :: valid ( vlo(1):vhi(1),  vlo(2):vhi(2),  vlo(3):vhi(3) )
-        real(amrex_real),          intent(inout) :: phi   (phlo(1):phhi(1),phlo(2):phhi(2),phlo(3):phhi(3))
+        real(amrex_real),      intent(in   ) :: ls_in (lslo(1):lshi(1),lslo(2):lshi(2),lslo(3):lshi(3))
+        integer,               intent(inout) :: valid ( vlo(1):vhi(1),  vlo(2):vhi(2),  vlo(3):vhi(3) )
+        real(amrex_real),      intent(inout) :: phi   (phlo(1):phhi(1),phlo(2):phhi(2),phlo(3):phhi(3))
 
         integer, dimension(3) :: lo, hi
 
@@ -830,9 +830,9 @@ contains
 
         integer,      dimension(3), intent(in   ) :: lo, hi, vilo, vihi, lslo, lshi, vlo, vhi, phlo, phhi
         integer,                    intent(in   ) :: v_in  (vilo(1):vihi(1),vilo(2):vihi(2),vilo(3):vihi(3))
-        real(amrex_real),               intent(in   ) :: ls_in (lslo(1):lshi(1),lslo(2):lshi(2),lslo(3):lshi(3))
-        integer,                        intent(inout) :: valid ( vlo(1):vhi(1),  vlo(2):vhi(2),  vlo(3):vhi(3) )
-        real(amrex_real),               intent(inout) :: phi   (phlo(1):phhi(1),phlo(2):phhi(2),phlo(3):phhi(3))
+        real(amrex_real),           intent(in   ) :: ls_in (lslo(1):lshi(1),lslo(2):lshi(2),lslo(3):lshi(3))
+        integer,                    intent(inout) :: valid ( vlo(1):vhi(1),  vlo(2):vhi(2),  vlo(3):vhi(3) )
+        real(amrex_real),           intent(inout) :: phi   (phlo(1):phhi(1),phlo(2):phhi(2),phlo(3):phhi(3))
 
         real(amrex_real) :: ls_node, in_node
         integer      :: ii, jj, kk
@@ -872,9 +872,9 @@ contains
 
         integer, dimension(3), intent(in   ) :: vilo, vihi, lslo, lshi, vlo, vhi, phlo, phhi, periodic, domlo, domhi
         integer,               intent(in   ) :: v_in  (vilo(1):vihi(1),vilo(2):vihi(2),vilo(3):vihi(3))
-        real(amrex_real),          intent(in   ) :: ls_in (lslo(1):lshi(1),lslo(2):lshi(2),lslo(3):lshi(3))
-        integer,                   intent(inout) :: valid ( vlo(1):vhi(1),  vlo(2):vhi(2),  vlo(3):vhi(3) )
-        real(amrex_real),          intent(inout) :: phi   (phlo(1):phhi(1),phlo(2):phhi(2),phlo(3):phhi(3))
+        real(amrex_real),      intent(in   ) :: ls_in (lslo(1):lshi(1),lslo(2):lshi(2),lslo(3):lshi(3))
+        integer,               intent(inout) :: valid ( vlo(1):vhi(1),  vlo(2):vhi(2),  vlo(3):vhi(3) )
+        real(amrex_real),      intent(inout) :: phi   (phlo(1):phhi(1),phlo(2):phhi(2),phlo(3):phhi(3))
 
         !integer      :: i, j, k
         !real(amrex_real) :: ls_node, in_node
@@ -1123,7 +1123,7 @@ contains
 
         ! ** input types
         integer,      dimension(3), intent(in) :: phlo, phhi
-        real(amrex_real),               intent(in) :: phi( phlo(1):phhi(1), phlo(2):phhi(2), phlo(3):phhi(3) )
+        real(amrex_real),           intent(in) :: phi( phlo(1):phhi(1), phlo(2):phhi(2), phlo(3):phhi(3) )
         integer,                    intent(in) :: i, j, k, n_pad
 
 

--- a/Src/EB/AMReX_EB_levelset_F.F90
+++ b/Src/EB/AMReX_EB_levelset_F.F90
@@ -661,7 +661,7 @@ contains
         integer,      dimension(3), intent(in   ) :: lo, hi, vilo, vihi, lslo, lshi, vlo, vhi, phlo, phhi
         integer,                    intent(in   ) :: v_in  (vilo(1):vihi(1),vilo(2):vihi(2),vilo(3):vihi(3))
         real(amrex_real),               intent(in   ) :: ls_in (lslo(1):lshi(1),lslo(2):lshi(2),lslo(3):lshi(3))
-        integer,                    intent(inout) :: valid ( vlo(1):vhi(1),  vlo(2):vhi(2),  vlo(3):vhi(3) )
+        integer,                        intent(inout) :: valid ( vlo(1):vhi(1),  vlo(2):vhi(2),  vlo(3):vhi(3) )
         real(amrex_real),               intent(inout) :: phi   (phlo(1):phhi(1),phlo(2):phhi(2),phlo(3):phhi(3))
 
         real(amrex_real) :: ls_node, in_node
@@ -703,8 +703,8 @@ contains
         integer, dimension(3), intent(in   ) :: vilo, vihi, lslo, lshi, vlo, vhi, phlo, phhi, periodic, domlo, domhi
         integer,               intent(in   ) :: v_in  (vilo(1):vihi(1),vilo(2):vihi(2),vilo(3):vihi(3))
         real(amrex_real),          intent(in   ) :: ls_in (lslo(1):lshi(1),lslo(2):lshi(2),lslo(3):lshi(3))
-        integer,               intent(  out) :: valid ( vlo(1):vhi(1),  vlo(2):vhi(2),  vlo(3):vhi(3) )
-        real(amrex_real),          intent(  out) :: phi   (phlo(1):phhi(1),phlo(2):phhi(2),phlo(3):phhi(3))
+        integer,                   intent(inout) :: valid ( vlo(1):vhi(1),  vlo(2):vhi(2),  vlo(3):vhi(3) )
+        real(amrex_real),          intent(inout) :: phi   (phlo(1):phhi(1),phlo(2):phhi(2),phlo(3):phhi(3))
 
         integer, dimension(3) :: lo, hi
 
@@ -831,8 +831,8 @@ contains
         integer,      dimension(3), intent(in   ) :: lo, hi, vilo, vihi, lslo, lshi, vlo, vhi, phlo, phhi
         integer,                    intent(in   ) :: v_in  (vilo(1):vihi(1),vilo(2):vihi(2),vilo(3):vihi(3))
         real(amrex_real),               intent(in   ) :: ls_in (lslo(1):lshi(1),lslo(2):lshi(2),lslo(3):lshi(3))
-        integer,                    intent(  out) :: valid ( vlo(1):vhi(1),  vlo(2):vhi(2),  vlo(3):vhi(3) )
-        real(amrex_real),               intent(  out) :: phi   (phlo(1):phhi(1),phlo(2):phhi(2),phlo(3):phhi(3))
+        integer,                        intent(inout) :: valid ( vlo(1):vhi(1),  vlo(2):vhi(2),  vlo(3):vhi(3) )
+        real(amrex_real),               intent(inout) :: phi   (phlo(1):phhi(1),phlo(2):phhi(2),phlo(3):phhi(3))
 
         real(amrex_real) :: ls_node, in_node
         integer      :: ii, jj, kk
@@ -873,8 +873,8 @@ contains
         integer, dimension(3), intent(in   ) :: vilo, vihi, lslo, lshi, vlo, vhi, phlo, phhi, periodic, domlo, domhi
         integer,               intent(in   ) :: v_in  (vilo(1):vihi(1),vilo(2):vihi(2),vilo(3):vihi(3))
         real(amrex_real),          intent(in   ) :: ls_in (lslo(1):lshi(1),lslo(2):lshi(2),lslo(3):lshi(3))
-        integer,               intent(  out) :: valid ( vlo(1):vhi(1),  vlo(2):vhi(2),  vlo(3):vhi(3) )
-        real(amrex_real),          intent(  out) :: phi   (phlo(1):phhi(1),phlo(2):phhi(2),phlo(3):phhi(3))
+        integer,                   intent(inout) :: valid ( vlo(1):vhi(1),  vlo(2):vhi(2),  vlo(3):vhi(3) )
+        real(amrex_real),          intent(inout) :: phi   (phlo(1):phhi(1),phlo(2):phhi(2),phlo(3):phhi(3))
 
         !integer      :: i, j, k
         !real(amrex_real) :: ls_node, in_node
@@ -998,7 +998,7 @@ contains
         integer, dimension(3), intent(in   ) :: lo, hi, vlo, vhi, phlo, phhi
         integer,               intent(in   ) :: n_pad
         integer,               intent(  out) :: valid( vlo(1):vhi(1),   vlo(2):vhi(2),   vlo(3):vhi(3))
-        real(amrex_real),          intent(in   ) :: phi  (phlo(1):phhi(1), phlo(2):phhi(2), phlo(3):phhi(3))
+        real(amrex_real),      intent(in   ) :: phi  (phlo(1):phhi(1), phlo(2):phhi(2), phlo(3):phhi(3))
 
         integer :: i, j, k
         logical :: valid_cell

--- a/Src/EB/AMReX_EB_levelset_F.F90
+++ b/Src/EB/AMReX_EB_levelset_F.F90
@@ -346,8 +346,8 @@ contains
       implicit none
 
       ! ** define I/O dummy variables
-      integer,                       intent(in   ) :: l_eb
-      logical,                       intent(  out) :: proj_valid
+      integer,                           intent(in   ) :: l_eb
+      logical,                           intent(  out) :: proj_valid
       real(amrex_real),                  intent(  out) :: min_dist
       real(amrex_real), dimension(3),    intent(in   ) :: pos, dx_eb
       real(amrex_real), dimension(l_eb), intent(in   ) :: eb_data
@@ -396,8 +396,8 @@ contains
 
 
       ! Test if pos "projects onto" the nearest EB facet's interior
-      eb_cent(:)   = eb_data(i_nearest     : i_nearest + 2)
-      eb_norm(:)   = eb_data(i_nearest + 3 : i_nearest + 5)
+      eb_cent(:) = eb_data(i_nearest     : i_nearest + 2)
+      eb_norm(:) = eb_data(i_nearest + 3 : i_nearest + 5)
 
       dist_proj = dot_product( pos(:) - eb_cent(:), -eb_norm(:) )
       eb_min_pt(:) = pos(:) + eb_norm(:) * dist_proj

--- a/Src/EB/AMReX_EB_levelset_F.F90
+++ b/Src/EB/AMReX_EB_levelset_F.F90
@@ -1258,13 +1258,13 @@ contains
         implicit none
 
         real(amrex_real), dimension(3), intent(in   ) :: pos, plo
-        integer,      dimension(3), intent(in   ) :: phlo, phhi
-        integer,                    intent(in   ) :: n_refine
+        integer,          dimension(3), intent(in   ) :: phlo, phhi
+        integer,                        intent(in   ) :: n_refine
         real(amrex_real),               intent(in   ) :: phi( phlo(1):phhi(1), phlo(2):phhi(2), phlo(3):phhi(3) )
         real(amrex_real), dimension(3), intent(in   ) :: dx
         real(amrex_real),               intent(  out) :: phi_interp
 
-        integer                    :: i, j, k
+        integer                        :: i, j, k
         real(amrex_real)               :: xp, yp, zp, lx, ly, lz, wx_lo, wx_hi, wy_lo, wy_hi, wz_lo, wz_hi
         real(amrex_real), dimension(3) :: inv_dx
 
@@ -1313,13 +1313,13 @@ contains
         implicit none
 
         real(amrex_real), dimension(3), intent(in   ) :: pos, plo
-        integer,      dimension(3), intent(in   ) :: phlo, phhi
-        integer,                    intent(in   ) :: n_refine
+        integer,          dimension(3), intent(in   ) :: phlo, phhi
+        integer,                        intent(in   ) :: n_refine
         real(amrex_real),               intent(in   ) :: phi( phlo(1):phhi(1), phlo(2):phhi(2), phlo(3):phhi(3) )
         real(amrex_real), dimension(3), intent(in   ) :: dx
         real(amrex_real), dimension(3), intent(  out) :: normal
 
-        integer                    :: i, j, k
+        integer                        :: i, j, k
         real(amrex_real)               :: xp, yp, zp, lx, ly, lz, wx_lo, wx_hi, wy_lo, wy_hi, wz_lo, wz_hi
         real(amrex_real), dimension(3) :: inv_dx
 

--- a/Src/EB/CMakeLists.txt
+++ b/Src/EB/CMakeLists.txt
@@ -93,6 +93,8 @@ if (ENABLE_FORTRAN)
          AMReX_EB_LSCore.H
          AMReX_EB_LSCoreI.H
          AMReX_EB_LSCore_F.H
+         AMReX_EB_geom.H
+         AMReX_EB_geom.cpp
          )
   endif ()
 

--- a/Src/EB/Make.package
+++ b/Src/EB/Make.package
@@ -68,6 +68,9 @@ CEXE_sources += AMReX_EB2.cpp AMReX_EB2_Level.cpp AMReX_EB2_MultiGFab.cpp
 CEXE_sources += AMReX_EB2_$(DIM)D_C.cpp
 CEXE_headers += AMReX_EB2_C.H AMReX_EB2_$(DIM)D_C.H
 
+CEXE_headers += AMReX_EB_geom.H
+CEXE_sources += AMReX_EB_geom.cpp
+ 
 ifneq ($(BL_NO_FORT),TRUE)
   F90EXE_sources += AMReX_ebcellflag_mod.F90
   F90EXE_sources += AMReX_EBFluxRegister_nd.F90

--- a/Tutorials/EB/Donut/Exec/inputs
+++ b/Tutorials/EB/Donut/Exec/inputs
@@ -22,8 +22,8 @@ amr.v               = 1       # verbosity in Amr
 
 # REFINEMENT
 amr.ref_ratio       = 2 2 2 2 # refinement ratio
-amr.blocking_factor = 6       # block factor in grid generation
-amr.max_grid_size   = 6
+amr.blocking_factor = 4       # block factor in grid generation
+amr.max_grid_size   = 8
 
 
 amr.phierr = 1 .1


### PR DESCRIPTION
## Summary

I've started migrating the Fortran code that computes the levelset function (i.e. the code that's currently in `Src/EB/AMReX_EB_levelset_F.F90` and `Src/EB/AMReX_EB_geometry.F90`).

This is currently a work in progress: I've migrated the functions that compute and fill levelsets in the `LSFactory` and `LSCore` classes. There are odd bits and pieces that still need to be migrated:

1. [x] Intersection/LS-Building (through intersections and unions)
2. [x] Particle Interpolation

But I think now would be a good time to test this code in the AMReX apps that use the levelset code. 

## TODO:

1. [x] Finish migrating odds and ends (above)
2. [ ] Test on GPUs -- there are a few bits that I would appreciate @WeiqunZhang's input on:
    - I think that collecting EB facets will require some sort of atomics on the device -- this is because each thread is filling hte same list. See here: https://github.com/JBlaschke/amrex/blob/c2d6a2e6f8e0ae1b5bdd169ed830f8be94d6bd2e/Src/EB/AMReX_EB_levelset.cpp#L415
3. [ ] Update AMReX Documentation

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
    - If you consider fortran a bug
- [x] add new capabilities to AMReX
    - Compute levelsets on device and without the need for fortran compilers
- [x] changes answers in the test suite to more than roundoff level
    - Since we're changing out the code that computes the levelsets, and since particle-based codes can be a very sensitive to slight changes at how boundaries are defined (I'm looking at you MFIX), I expect that some reg tests need to be updated
- [x] are likely to significantly affect the results of downstream AMReX users
    - Drops fortran language requirement for level-set users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
    - That's still a bit of a todo