### PR TITLE
Add parameter that stores OpenMP support version

### DIFF
--- a/Src/Base/AMReX_omp_mod.F90
+++ b/Src/Base/AMReX_omp_mod.F90
@@ -4,6 +4,12 @@ module amrex_omp_module
 
   implicit none
 
+#ifdef _OPENMP
+  integer, parameter :: amrex_omp_support = (_OPENMP)
+#else
+  integer, parameter :: amrex_omp_support = 0 ! Should this be allowed??
+#endif
+
   integer, external :: omp_get_num_threads
   integer, external :: omp_get_max_threads
   integer, external :: omp_get_thread_num
@@ -16,6 +22,8 @@ end module amrex_omp_module
 module amrex_omp_module
 
   implicit none
+
+  integer, parameter :: amrex_omp_support = 0 ! indicates no support
 
 contains
 


### PR DESCRIPTION
## Summary

Add a parameter to `AMReX_omp_mod` that can be used by Fortran code to check whether AMReX was built with OpenMP support, and, if yes, what the version number (_OPENMP) was at the time AMReX was compiled.

## Additional background
The name of the parameter is `amrex_omp_support`, the type is (default kind) integer.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new **(mini)**-capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
