### PR TITLE
Use Long for maxnextid in plot and checkfiles to accomodate the expanded range.

### DIFF
--- a/Src/Particle/AMReX_ParticleHDF5.H
+++ b/Src/Particle/AMReX_ParticleHDF5.H
@@ -325,7 +325,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
     }
 
     Long nparticles = 0;
-    int maxnextid;
+    Long maxnextid;
     
     if(usePrePost)
     {
@@ -353,7 +353,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
         
         ParallelDescriptor::ReduceLongSum(nparticles, IOProcNumber);
         ParticleType::NextID(maxnextid);
-        ParallelDescriptor::ReduceIntMax(maxnextid, IOProcNumber);
+        ParallelDescriptor::ReduceLongMax(maxnextid, IOProcNumber);
     }
 
     hid_t fapl, dxpl, fid, grp;
@@ -464,7 +464,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
         CreateWriteHDF5AttrLong(fid, "nparticles", 1, &nparticles);
 
         // The value of nextid that we need to restore on restart.
-        CreateWriteHDF5AttrInt(fid, "maxnextid", 1, &maxnextid);
+        CreateWriteHDF5AttrLong(fid, "maxnextid", 1, &maxnextid);
 
         // Then the finest level of the AMR hierarchy.
         int finest_level = finestLevel();
@@ -975,8 +975,8 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
     AMREX_ASSERT(nparticles >= 0);
     
     aname = "maxnextid";
-    int maxnextid;
-    ret = ReadHDF5AttrInt(fid, aname.c_str(), &maxnextid);
+    Long maxnextid;
+    ret = ReadHDF5AttrLong(fid, aname.c_str(), &maxnextid);
     if (ret < 0) {
         std::string msg("ParticleContainer::RestartHDF5(): unable to read attribute ");
         msg += aname;

--- a/Src/Particle/AMReX_ParticleIO.H
+++ b/Src/Particle/AMReX_ParticleIO.H
@@ -428,7 +428,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
 
     const int IOProcNumber = ParallelDescriptor::IOProcessorNumber();
     Long nparticles = 0;
-    int  maxnextid  = ParticleType::NextID();
+    Long  maxnextid  = ParticleType::NextID();
 
     for (int lev = 0; lev < m_particles.size();  lev++) {
         const auto& pmap = m_particles[lev];
@@ -448,7 +448,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
     ParallelDescriptor::ReduceLongSum(nparticles, IOProcNumber);
 
     ParticleType::NextID(maxnextid);
-    ParallelDescriptor::ReduceIntMax(maxnextid, IOProcNumber);
+    ParallelDescriptor::ReduceLongMax(maxnextid, IOProcNumber);
 
     nparticlesPrePost = nparticles;
     maxnextidPrePost  = maxnextid;
@@ -787,7 +787,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
     HdrFile >> nparticles;
     AMREX_ASSERT(nparticles >= 0);
 
-    int maxnextid;
+    Long maxnextid;
     HdrFile >> maxnextid;
     AMREX_ASSERT(maxnextid > 0);
     ParticleType::NextID(maxnextid);

--- a/Src/Particle/AMReX_WriteBinaryParticleData.H
+++ b/Src/Particle/AMReX_WriteBinaryParticleData.H
@@ -66,7 +66,7 @@ void WriteBinaryParticleDataSync (PC const& pc,
     std::ofstream HdrFile;
 
     Long nparticles = 0;
-    int maxnextid;
+    Long maxnextid;
 
     // evaluate f for every particle to determine which ones to output
     Vector<std::map<std::pair<int, int>, Gpu::DeviceVector<int> > > particle_io_flags(pc.GetParticles().size());
@@ -114,7 +114,7 @@ void WriteBinaryParticleDataSync (PC const& pc,
 
         ParallelDescriptor::ReduceLongSum(nparticles, IOProcNumber);
         PC::ParticleType::NextID(maxnextid);
-        ParallelDescriptor::ReduceIntMax(maxnextid, IOProcNumber);
+        ParallelDescriptor::ReduceLongMax(maxnextid, IOProcNumber);
     }
 
     if (ParallelDescriptor::IOProcessor())
@@ -438,8 +438,8 @@ void WriteBinaryParticleDataAsync (PC const& pc,
     }
     ParallelDescriptor::Barrier();
 
-    int maxnextid = PC::ParticleType::NextID();
-    ParallelDescriptor::ReduceIntMax(maxnextid, IOProcNumber);
+    Long maxnextid = PC::ParticleType::NextID();
+    ParallelDescriptor::ReduceLongMax(maxnextid, IOProcNumber);
 
     Vector<Long> np_on_rank(NProcs, 0L);
     std::size_t psize = PSizeInFile<ParticleReal>(write_real_comp, write_int_comp);


### PR DESCRIPTION
The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
