### PR TITLE
Gpu synchronization is needed to avoid deadlock situations

### DIFF
--- a/Src/Particle/AMReX_ParticleCommunication.H
+++ b/Src/Particle/AMReX_ParticleCommunication.H
@@ -566,6 +566,8 @@ void unpackRemotes (PC& pc, const ParticleCopyPlan& plan, Buffer& rcv_buffer, Un
                 ptd.unpackParticleData(p_rcv_buffer, src_offset, dst_index,
                                        p_comm_real, p_comm_int);
               });
+
+            Gpu::synchronize();
           }
     }
 #else


### PR DESCRIPTION
## Summary
MFIX_Exa was experiencing deadlock situations during calls to ParticleCointainer::Redistribute method.

## Additional background
We were running on 19 NETL Joule nodes with 37 MPI tasks and 37 GPUs. We found out that the call to Gpu::synchronize() after the AMREX_FOR_1D call in unpackRemotes function, solved the deadlock issue.

## Checklist

The proposed changes:
- [x ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
