### PR TITLE
Fix warning with default copy ctor + AMREX_USE_GPU

### DIFF
--- a/Src/Particle/AMReX_Particle.H
+++ b/Src/Particle/AMReX_Particle.H
@@ -88,7 +88,6 @@ struct ParticleCPUWrapper
         : m_idata(idata)
     {}
 
-    AMREX_GPU_HOST_DEVICE
     ParticleCPUWrapper (const ParticleCPUWrapper& rhs) = default;
 
     AMREX_GPU_HOST_DEVICE

--- a/Src/Particle/AMReX_Particle.H
+++ b/Src/Particle/AMReX_Particle.H
@@ -31,7 +31,6 @@ struct ParticleIDWrapper
         : m_idata(idata)
     {}
 
-    AMREX_GPU_HOST_DEVICE
     ParticleIDWrapper (const ParticleIDWrapper& rhs) = default;
 
     AMREX_GPU_HOST_DEVICE


### PR DESCRIPTION
Otherwise we get `warning #3057-D: __device__ annotation is ignored on a function("ParticleCPUWrapper") that is explicitly defaulted on its first declaration`, etc...
