### PR TITLE
EB smoother

### DIFF
--- a/Src/LinearSolvers/MLMG/AMReX_MLCellLinOp.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLCellLinOp.cpp
@@ -763,6 +763,14 @@ MLCellLinOp::prepareForSolve ()
             BndryRegister& undrrelxr = m_undrrelxr[amrlev][mglev];
             MultiFab foo(m_grids[amrlev][mglev], m_dmap[amrlev][mglev], ncomp, 0, MFInfo().SetAlloc(false));
 
+#ifdef AMREX_USE_EB
+            auto factory = dynamic_cast<EBFArrayBoxFactory const*>(m_factory[amrlev][mglev].get());
+            const FabArray<EBCellFlagFab>* flags =
+                (factory) ? &(factory->getMultiEBCellFlagFab()) : nullptr;
+            auto area = (factory) ? factory->getAreaFrac()
+                : Array<const MultiCutFab*,AMREX_SPACEDIM>{AMREX_D_DECL(nullptr,nullptr,nullptr)};
+#endif
+
             MFItInfo mfi_info;
             if (Gpu::notInLaunchRegion()) mfi_info.SetDynamic(true);
 
@@ -775,6 +783,10 @@ MLCellLinOp::prepareForSolve ()
 
                 const auto & bdlv = bcondloc.bndryLocs(mfi);
                 const auto & bdcv = bcondloc.bndryConds(mfi);
+
+#ifdef AMREX_USE_EB
+                auto fabtyp = (flags) ? (*flags)[mfi].getType(vbx) : FabType::regular;
+#endif
 
                 for (int idim = 0; idim < AMREX_SPACEDIM; ++idim)
                 {
@@ -792,42 +804,86 @@ MLCellLinOp::prepareForSolve ()
                         const BoundCond bcthi = bdcv[icomp][ohi];
                         const Real bcllo = bdlv[icomp][olo];
                         const Real bclhi = bdlv[icomp][ohi];
-                        if (idim == 0) {
-                            AMREX_LAUNCH_HOST_DEVICE_LAMBDA (
-                            blo, tboxlo, {
-                            mllinop_comp_interp_coef0_x
-                                (0, tboxlo, blen, flo, mlo, bctlo, bcllo,
-                                 imaxorder, dxi, icomp);
-                            },
-                            bhi, tboxhi, {
-                            mllinop_comp_interp_coef0_x
-                                (1, tboxhi, blen, fhi, mhi, bcthi, bclhi,
-                                 imaxorder, dxi, icomp);
-                            });
-                        } else if (idim == 1) {
-                            AMREX_LAUNCH_HOST_DEVICE_LAMBDA (
-                            blo, tboxlo, {
-                            mllinop_comp_interp_coef0_y
-                                (0, tboxlo, blen, flo, mlo, bctlo, bcllo,
-                                 imaxorder, dyi, icomp);
-                            },
-                            bhi, tboxhi, {
-                            mllinop_comp_interp_coef0_y
-                                (1, tboxhi, blen, fhi, mhi, bcthi, bclhi,
-                                 imaxorder, dyi, icomp);
-                            });
-                        } else {
-                            AMREX_LAUNCH_HOST_DEVICE_LAMBDA (
-                            blo, tboxlo, {
-                            mllinop_comp_interp_coef0_z
-                                (0, tboxlo, blen, flo, mlo, bctlo, bcllo,
-                                 imaxorder, dzi, icomp);
-                            },
-                            bhi, tboxhi, {
-                            mllinop_comp_interp_coef0_z
-                                (1, tboxhi, blen, fhi, mhi, bcthi, bclhi,
-                                 imaxorder, dzi, icomp);
-                            });
+#ifdef AMREX_USE_EB
+                        if (fabtyp == FabType::singlevalued) {
+                            Array4<Real const> const& ap = area[idim]->const_array(mfi);
+                            if (idim == 0) {
+                                AMREX_LAUNCH_HOST_DEVICE_LAMBDA (
+                                blo, tboxlo, {
+                                mllinop_comp_interp_coef0_x_eb
+                                    (0, tboxlo, blen, flo, mlo, ap, bctlo, bcllo,
+                                     imaxorder, dxi, icomp);
+                                },
+                                bhi, tboxhi, {
+                                mllinop_comp_interp_coef0_x_eb
+                                    (1, tboxhi, blen, fhi, mhi, ap, bcthi, bclhi,
+                                     imaxorder, dxi, icomp);
+                                });
+                            } else if (idim == 1) {
+                                AMREX_LAUNCH_HOST_DEVICE_LAMBDA (
+                                blo, tboxlo, {
+                                mllinop_comp_interp_coef0_y_eb
+                                    (0, tboxlo, blen, flo, mlo, ap, bctlo, bcllo,
+                                     imaxorder, dyi, icomp);
+                                },
+                                bhi, tboxhi, {
+                                mllinop_comp_interp_coef0_y_eb
+                                    (1, tboxhi, blen, fhi, mhi, ap, bcthi, bclhi,
+                                     imaxorder, dyi, icomp);
+                                });
+                            } else {
+                                AMREX_LAUNCH_HOST_DEVICE_LAMBDA (
+                                blo, tboxlo, {
+                                mllinop_comp_interp_coef0_z_eb
+                                    (0, tboxlo, blen, flo, mlo, ap, bctlo, bcllo,
+                                     imaxorder, dzi, icomp);
+                                },
+                                bhi, tboxhi, {
+                                mllinop_comp_interp_coef0_z_eb
+                                    (1, tboxhi, blen, fhi, mhi, ap, bcthi, bclhi,
+                                     imaxorder, dzi, icomp);
+                                });
+                            }
+                        } else
+#endif
+                        {
+                            if (idim == 0) {
+                                AMREX_LAUNCH_HOST_DEVICE_LAMBDA (
+                                blo, tboxlo, {
+                                mllinop_comp_interp_coef0_x
+                                    (0, tboxlo, blen, flo, mlo, bctlo, bcllo,
+                                     imaxorder, dxi, icomp);
+                                },
+                                bhi, tboxhi, {
+                                mllinop_comp_interp_coef0_x
+                                    (1, tboxhi, blen, fhi, mhi, bcthi, bclhi,
+                                     imaxorder, dxi, icomp);
+                                });
+                            } else if (idim == 1) {
+                                AMREX_LAUNCH_HOST_DEVICE_LAMBDA (
+                                blo, tboxlo, {
+                                mllinop_comp_interp_coef0_y
+                                    (0, tboxlo, blen, flo, mlo, bctlo, bcllo,
+                                     imaxorder, dyi, icomp);
+                                },
+                                bhi, tboxhi, {
+                                mllinop_comp_interp_coef0_y
+                                    (1, tboxhi, blen, fhi, mhi, bcthi, bclhi,
+                                     imaxorder, dyi, icomp);
+                                });
+                            } else {
+                                AMREX_LAUNCH_HOST_DEVICE_LAMBDA (
+                                blo, tboxlo, {
+                                mllinop_comp_interp_coef0_z
+                                    (0, tboxlo, blen, flo, mlo, bctlo, bcllo,
+                                     imaxorder, dzi, icomp);
+                                },
+                                bhi, tboxhi, {
+                                mllinop_comp_interp_coef0_z
+                                    (1, tboxhi, blen, fhi, mhi, bcthi, bclhi,
+                                     imaxorder, dzi, icomp);
+                                });
+                            }
                         }
                     }
                 }

--- a/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap_K.H
@@ -65,7 +65,7 @@ void mlebabeclap_apply_bc_x (int side, Box const& box, int blen,
         GpuArray<Real,4> x{-bcl * dxinv, Real(0.5), Real(1.5), Real(2.5)};
         Array2D<Real, 0, 3, 0, 2> coef{};
         for (int r = 0; r <= maxorder-2; ++r) {
-            poly_interp_coeff(-Real(0.5), &x[0], r+1, &(coef(0,r)));
+            poly_interp_coeff(-Real(0.5), &x[0], r+2, &(coef(0,r)));
         }
         for     (int k = lo.z; k <= hi.z; ++k) {
             for (int j = lo.y; j <= hi.y; ++j) {
@@ -145,7 +145,7 @@ void mlebabeclap_apply_bc_y (int side, Box const& box, int blen,
         GpuArray<Real,4> x{-bcl * dyinv, Real(0.5), Real(1.5), Real(2.5)};
         Array2D<Real, 0, 3, 0, 2> coef{};
         for (int r = 0; r <= maxorder-2; ++r) {
-            poly_interp_coeff(-Real(0.5), &x[0], r+1, &(coef(0,r)));
+            poly_interp_coeff(-Real(0.5), &x[0], r+2, &(coef(0,r)));
         }
         for     (int k = lo.z; k <= hi.z; ++k) {
             for (int i = lo.x; i <= hi.x; ++i) {
@@ -225,7 +225,7 @@ void mlebabeclap_apply_bc_z (int side, Box const& box, int blen,
         GpuArray<Real,4> x{-bcl * dzinv, Real(0.5), Real(1.5), Real(2.5)};
         Array2D<Real, 0, 3, 0, 2> coef{};
         for (int r = 0; r <= maxorder-2; ++r) {
-            poly_interp_coeff(-Real(0.5), &x[0], r+1, &(coef(0,r)));
+            poly_interp_coeff(-Real(0.5), &x[0], r+2, &(coef(0,r)));
         }
         for     (int j = lo.y; j <= hi.y; ++j) {
             for (int i = lo.x; i <= hi.x; ++i) {

--- a/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap_K.H
@@ -71,13 +71,19 @@ void mlebabeclap_apply_bc_x (int side, Box const& box, int blen,
             for (int j = lo.y; j <= hi.y; ++j) {
                 if (mask(i,j,k) == 0 and mask(i+s,j,k) == 1) {
                     int order = 1;
+                    bool has_cutfaces = false;
                     for (int r = 0; r <= NX-2; ++r) {
-                        if (area(i+(1-side)+s*r,j,k) > Real(0.0)) {
+                        Real a = area(i+(1-side)+s*r,j,k);
+                        if (a > Real(0.0)) {
                             ++order;
+                            if (a < Real(1.0)) {
+                                has_cutfaces = true;
+                            }
                         } else {
                             break;
                         }
                     }
+                    if (has_cutfaces) order = amrex::min(2,order);
                     if (order == 1) {
                         if (inhomog) {
                             phi(i,j,k,icomp) = bcval(i,j,k,icomp);
@@ -151,13 +157,19 @@ void mlebabeclap_apply_bc_y (int side, Box const& box, int blen,
             for (int i = lo.x; i <= hi.x; ++i) {
                 if (mask(i,j,k) == 0 and mask(i,j+s,k) == 1) {
                     int order = 1;
+                    bool has_cutfaces = false;
                     for (int r = 0; r <= NX-2; ++r) {
-                        if (area(i,j+(1-side)+s*r,k) > Real(0.0)) {
+                        Real a = area(i,j+(1-side)+s*r,k);
+                        if (a > Real(0.0)) {
                             ++order;
+                            if (a < Real(1.0)) {
+                                has_cutfaces = true;
+                            }
                         } else {
                             break;
                         }
                     }
+                    if (has_cutfaces) order = amrex::min(2,order);
                     if (order == 1) {
                         if (inhomog) {
                             phi(i,j,k,icomp) = bcval(i,j,k,icomp);
@@ -231,13 +243,19 @@ void mlebabeclap_apply_bc_z (int side, Box const& box, int blen,
             for (int i = lo.x; i <= hi.x; ++i) {
                 if (mask(i,j,k) == 0 and mask(i,j,k+s) == 1) {
                     int order = 1;
+                    bool has_cutfaces = false;
                     for (int r = 0; r <= NX-2; ++r) {
-                        if (area(i,j,k+(1-side)+s*r) > Real(0.0)) {
+                        Real a = area(i,j,k+(1-side)+s*r);
+                        if (a > Real(0.0)) {
                             ++order;
+                            if (a < Real(1.0)) {
+                                has_cutfaces = true;
+                            }
                         } else {
                             break;
                         }
                     }
+                    if (has_cutfaces) order = amrex::min(2,order);
                     if (order == 1) {
                         if (inhomog) {
                             phi(i,j,k,icomp) = bcval(i,j,k,icomp);

--- a/Src/LinearSolvers/MLMG/AMReX_MLLinOp_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLLinOp_K.H
@@ -378,13 +378,19 @@ void mllinop_comp_interp_coef0_x_eb (int side, Box const& box, int blen,
             for (int j = lo.y; j <= hi.y; ++j) {
                 int order = 1;
                 if (mask(ib,j,k) > 0) {
+                    bool has_cutfaces = false;
                     for (int r = 0; r <= NX-2; ++r) {
-                        if (area(ii+side+s*r,j,k) > Real(0.0)) {
+                        Real a = area(ii+side+s*r,j,k);
+                        if (a > Real(0.0)) {
                             ++order;
+                            if (a < Real(1.0)) {
+                                has_cutfaces = true;
+                            }
                         } else {
                             break;
                         }
                     }
+                    if (has_cutfaces) order = amrex::min(2,order);
                 }
                 f(ii,j,k,icomp) = (order==1) ? Real(0.0) : coef(1,order-2);
             }
@@ -439,13 +445,19 @@ void mllinop_comp_interp_coef0_y_eb (int side, Box const& box, int blen,
             for (int i = lo.x; i <= hi.x; ++i) {
                 int order = 1;
                 if (mask(i,jb,k) > 0) {
+                    bool has_cutfaces = false;
                     for (int r = 0; r <= NX-2; ++r) {
-                        if (area(i,ji+side+s*r,k) > Real(0.0)) {
+                        Real a = area(i,ji+side+s*r,k);
+                        if (a > Real(0.0)) {
                             ++order;
+                            if (a < Real(1.0)) {
+                                has_cutfaces = true;
+                            }
                         } else {
                             break;
                         }
                     }
+                    if (has_cutfaces) order = amrex::min(2,order);
                 }
                 f(i,ji,k,icomp) = (order==1) ? Real(0.0) : coef(1,order-2);
             }
@@ -500,13 +512,19 @@ void mllinop_comp_interp_coef0_z_eb (int side, Box const& box, int blen,
             for (int i = lo.x; i <= hi.x; ++i) {
                 int order = 1;
                 if (mask(i,j,kb) > 0) {
+                    bool has_cutfaces = false;
                     for (int r = 0; r <= NX-2; ++r) {
-                        if (area(i,j,ki+side+s*r) > Real(0.0)) {
+                        Real a = area(i,j,ki+side+s*r);
+                        if (a > Real(0.0)) {
                             ++order;
+                            if (a < Real(1.0)) {
+                                has_cutfaces = true;
+                            }
                         } else {
                             break;
                         }
                     }
+                    if (has_cutfaces) order = amrex::min(2,order);
                 }
                 f(i,j,ki,icomp) = (order==1) ? Real(0.0) : coef(1,order-2);
             }

--- a/Src/LinearSolvers/MLMG/AMReX_MLLinOp_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLLinOp_K.H
@@ -372,7 +372,7 @@ void mllinop_comp_interp_coef0_x_eb (int side, Box const& box, int blen,
         GpuArray<Real,4> x{{-bcl * dxinv, Real(0.5), Real(1.5), Real(2.5)}};
         Array2D<Real, 0, 3, 0, 2> coef{};
         for (int r = 0; r <= maxorder-2; ++r) {
-            poly_interp_coeff(-Real(0.5), &x[0], r+1, &coef(0,r));
+            poly_interp_coeff(-Real(0.5), &x[0], r+2, &coef(0,r));
         }
         for     (int k = lo.z; k <= hi.z; ++k) {
             for (int j = lo.y; j <= hi.y; ++j) {
@@ -433,7 +433,7 @@ void mllinop_comp_interp_coef0_y_eb (int side, Box const& box, int blen,
         GpuArray<Real,4> x{{-bcl * dyinv, Real(0.5), Real(1.5), Real(2.5)}};
         Array2D<Real, 0, 3, 0, 2> coef{};
         for (int r = 0; r <= maxorder-2; ++r) {
-            poly_interp_coeff(-Real(0.5), &x[0], r+1, &coef(0,r));
+            poly_interp_coeff(-Real(0.5), &x[0], r+2, &coef(0,r));
         }
         for     (int k = lo.z; k <= hi.z; ++k) {
             for (int i = lo.x; i <= hi.x; ++i) {
@@ -494,7 +494,7 @@ void mllinop_comp_interp_coef0_z_eb (int side, Box const& box, int blen,
         GpuArray<Real,4> x{{-bcl * dzinv, Real(0.5), Real(1.5), Real(2.5)}};
         Array2D<Real, 0, 3, 0, 2> coef{};
         for (int r = 0; r <= maxorder-2; ++r) {
-            poly_interp_coeff(-Real(0.5), &x[0], r+1, &coef(0,r));
+            poly_interp_coeff(-Real(0.5), &x[0], r+2, &coef(0,r));
         }
         for     (int j = lo.y; j <= hi.y; ++j) {
             for (int i = lo.x; i <= hi.x; ++i) {

--- a/Src/LinearSolvers/MLMG/AMReX_MLLinOp_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLLinOp_K.H
@@ -332,6 +332,192 @@ void mllinop_comp_interp_coef0_z (int side, Box const& box, int blen,
     }
 }
 
+#ifdef AMREX_USE_EB
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void mllinop_comp_interp_coef0_x_eb (int side, Box const& box, int blen,
+                                     Array4<Real> const& f,
+                                     Array4<int const> const& mask,
+                                     Array4<Real const> const& area,
+                                     BoundCond bct, Real bcl,
+                                     int maxorder, Real dxinv, int icomp) noexcept
+{
+    const auto lo = amrex::lbound(box);
+    const auto hi = amrex::ubound(box);
+    const int ib = lo.x; // boundary cell
+    const int s = 1-2*side;  // +1 for lo and -1 for hi
+    const int ii = lo.x + s; // interior cell
+    switch (bct) {
+    case AMREX_LO_NEUMANN:
+    {
+        for     (int k = lo.z; k <= hi.z; ++k) {
+            for (int j = lo.y; j <= hi.y; ++j) {
+                f(ii,j,k,icomp) = Real(1.0);
+            }
+        }
+        break;
+    }
+    case AMREX_LO_REFLECT_ODD:
+    {
+        for     (int k = lo.z; k <= hi.z; ++k) {
+            for (int j = lo.y; j <= hi.y; ++j) {
+                f(ii,j,k,icomp) = (mask(ib,j,k) > 0) ? Real(1.0) : Real(0.0);
+            }
+        }
+        break;
+    }
+    case AMREX_LO_DIRICHLET:
+    {
+        const int NX = amrex::min(blen+1, maxorder);
+        GpuArray<Real,4> x{{-bcl * dxinv, Real(0.5), Real(1.5), Real(2.5)}};
+        Array2D<Real, 0, 3, 0, 2> coef{};
+        for (int r = 0; r <= maxorder-2; ++r) {
+            poly_interp_coeff(-Real(0.5), &x[0], r+1, &coef(0,r));
+        }
+        for     (int k = lo.z; k <= hi.z; ++k) {
+            for (int j = lo.y; j <= hi.y; ++j) {
+                int order = 1;
+                if (mask(ib,j,k) > 0) {
+                    for (int r = 0; r <= NX-2; ++r) {
+                        if (area(ii+side+s*r,j,k) > Real(0.0)) {
+                            ++order;
+                        } else {
+                            break;
+                        }
+                    }
+                }
+                f(ii,j,k,icomp) = (order==1) ? Real(0.0) : coef(1,order-2);
+            }
+        }
+        break;
+    }
+    default: {}
+    }
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void mllinop_comp_interp_coef0_y_eb (int side, Box const& box, int blen,
+                                     Array4<Real> const& f,
+                                     Array4<int const> const& mask,
+                                     Array4<Real const> const& area,
+                                     BoundCond bct, Real bcl,
+                                     int maxorder, Real dyinv, int icomp) noexcept
+{
+    const auto lo = amrex::lbound(box);
+    const auto hi = amrex::ubound(box);
+    const int jb = lo.y; // boundary cell
+    const int s = 1-2*side;  // +1 for lo and -1 for hi
+    const int ji = lo.y + s; // interior cell
+    switch (bct) {
+    case AMREX_LO_NEUMANN:
+    {
+        for     (int k = lo.z; k <= hi.z; ++k) {
+            for (int i = lo.x; i <= hi.x; ++i) {
+                f(i,ji,k,icomp) = Real(1.0);
+            }
+        }
+        break;
+    }
+    case AMREX_LO_REFLECT_ODD:
+    {
+        for     (int k = lo.z; k <= hi.z; ++k) {
+            for (int i = lo.x; i <= hi.x; ++i) {
+                f(i,ji,k,icomp) = (mask(i,jb,k) > 0) ? Real(1.0) : Real(0.0);
+            }
+        }
+        break;
+    }
+    case AMREX_LO_DIRICHLET:
+    {
+        const int NX = amrex::min(blen+1, maxorder);
+        GpuArray<Real,4> x{{-bcl * dyinv, Real(0.5), Real(1.5), Real(2.5)}};
+        Array2D<Real, 0, 3, 0, 2> coef{};
+        for (int r = 0; r <= maxorder-2; ++r) {
+            poly_interp_coeff(-Real(0.5), &x[0], r+1, &coef(0,r));
+        }
+        for     (int k = lo.z; k <= hi.z; ++k) {
+            for (int i = lo.x; i <= hi.x; ++i) {
+                int order = 1;
+                if (mask(i,jb,k) > 0) {
+                    for (int r = 0; r <= NX-2; ++r) {
+                        if (area(i,ji+side+s*r,k) > Real(0.0)) {
+                            ++order;
+                        } else {
+                            break;
+                        }
+                    }
+                }
+                f(i,ji,k,icomp) = (order==1) ? Real(0.0) : coef(1,order-2);
+            }
+        }
+        break;
+    }
+    default: {}
+    }
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void mllinop_comp_interp_coef0_z_eb (int side, Box const& box, int blen,
+                                     Array4<Real> const& f,
+                                     Array4<int const> const& mask,
+                                     Array4<Real const> const& area,
+                                     BoundCond bct, Real bcl,
+                                     int maxorder, Real dzinv, int icomp) noexcept
+{
+    const auto lo = amrex::lbound(box);
+    const auto hi = amrex::ubound(box);
+    const int kb = lo.z; // bound cell
+    const int s = 1-2*side;  // +1 for lo and -1 for hi
+    const int ki = lo.z + s; // interior cell
+    switch (bct) {
+    case AMREX_LO_NEUMANN:
+    {
+        for     (int j = lo.y; j <= hi.y; ++j) {
+            for (int i = lo.x; i <= hi.x; ++i) {
+                f(i,j,ki,icomp) = Real(1.0);
+            }
+        }
+        break;
+    }
+    case AMREX_LO_REFLECT_ODD:
+    {
+        for     (int j = lo.y; j <= hi.y; ++j) {
+            for (int i = lo.x; i <= hi.x; ++i) {
+                f(i,j,ki,icomp) = (mask(i,j,kb) > 0) ? Real(1.0) : Real(0.0);
+            }
+        }
+        break;
+    }
+    case AMREX_LO_DIRICHLET:
+    {
+        const int NX = amrex::min(blen+1, maxorder);
+        GpuArray<Real,4> x{{-bcl * dzinv, Real(0.5), Real(1.5), Real(2.5)}};
+        Array2D<Real, 0, 3, 0, 2> coef{};
+        for (int r = 0; r <= maxorder-2; ++r) {
+            poly_interp_coeff(-Real(0.5), &x[0], r+1, &coef(0,r));
+        }
+        for     (int j = lo.y; j <= hi.y; ++j) {
+            for (int i = lo.x; i <= hi.x; ++i) {
+                int order = 1;
+                if (mask(i,j,kb) > 0) {
+                    for (int r = 0; r <= NX-2; ++r) {
+                        if (area(i,j,ki+side+s*r) > Real(0.0)) {
+                            ++order;
+                        } else {
+                            break;
+                        }
+                    }
+                }
+                f(i,j,ki,icomp) = (order==1) ? Real(0.0) : coef(1,order-2);
+            }
+        }
+        break;
+    }
+    default: {}
+    }
+}
+#endif
+
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 void mllinop_apply_innu_xlo (int i, int j, int k,
                              Array4<Real> const& rhs,

--- a/Src/LinearSolvers/MLMG/AMReX_MLMG.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLMG.cpp
@@ -62,9 +62,13 @@ MLMG::solve (const Vector<MultiFab*>& a_sol, const Vector<MultiFab const*>& a_rh
         bottom_solver = linop.getDefaultBottomSolver();
     }
 
-    if (bottom_solver == BottomSolver::hypre) {
+    if (bottom_solver == BottomSolver::hypre || bottom_solver == BottomSolver::petsc) {
         int mo = linop.getMaxOrder();
-        linop.setMaxOrder(std::min(3,mo));  // maxorder = 4 not supported
+        if (a_sol[0]->hasEBFabFactory()) {
+            linop.setMaxOrder(2);
+        } else {
+            linop.setMaxOrder(std::min(3,mo));  // maxorder = 4 not supported
+        }
     }
     
     bool is_nsolve = linop.m_parent;


### PR DESCRIPTION
## Summary

In #1327, the interpolation coefficients for EB stencil in cell-centered
linear solvers were fixed.  Here, the EB smoother is also updated to use the
correct coefficients.

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [x] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
