### PR TITLE
Add -Xcudafe --diag_suppress=esa_on_defaulted_function_ignored to suppress spurious warnings from nvcc.

### DIFF
--- a/Tools/CMake/AMReX_SetupCUDA.cmake
+++ b/Tools/CMake/AMReX_SetupCUDA.cmake
@@ -209,6 +209,9 @@ string(APPEND CMAKE_CUDA_FLAGS " --expt-relaxed-constexpr --expt-extended-lambda
 string(APPEND CMAKE_CUDA_FLAGS " -Wno-deprecated-gpu-targets ${NVCC_ARCH_FLAGS}")
 string(APPEND CMAKE_CUDA_FLAGS " -maxrregcount=${CUDA_MAXREGCOUNT}")
 
+# This is to work around a bug with nvcc, see: https://github.com/kokkos/kokkos/issues/1473
+string(APPEND CMAKE_CUDA_FLAGS " -Xcudafe --diag_suppress=esa_on_defaulted_function_ignored")
+
 if (ENABLE_CUDA_FASTMATH)
    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --use_fast_math")
 endif ()

--- a/Tools/GNUMake/comps/nvcc.mak
+++ b/Tools/GNUMake/comps/nvcc.mak
@@ -115,6 +115,8 @@ else
 endif
 
 NVCC_FLAGS = -Wno-deprecated-gpu-targets -m64 -arch=compute_$(CUDA_ARCH) -code=sm_$(CUDA_ARCH) -maxrregcount=$(CUDA_MAXREGCOUNT) --expt-relaxed-constexpr --expt-extended-lambda
+# This is to work around a bug with nvcc, see: https://github.com/kokkos/kokkos/issues/1473
+NVCC_FLAGS += -Xcudafe --diag_suppress=esa_on_defaulted_function_ignored
 # Unfortunately, on cori with cuda 10.0 this fails in thrust code
 # NVCC_FLAGS += --Werror=cross-execution-space-call
 


### PR DESCRIPTION
This silences warnings like `warning #3057-D: __host__ annotation is ignored on a function("ParticleIDWrapper") that is explicitly defaulted on its first declaration` we are currently getting on recent versions of amrex.

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
