### PR TITLE
No inline for assertion

### DIFF
--- a/Src/Base/AMReX.H
+++ b/Src/Base/AMReX.H
@@ -7,6 +7,7 @@
 #include <AMReX_GpuAssert.H>
 #include <AMReX_ccse-mpi.H>
 #include <AMReX_Exception.H>
+#include <AMReX_Extension.H>
 #include <AMReX_INT.H>
 #include <AMReX_REAL.H>
 #include <AMReX_Math.H>
@@ -96,64 +97,29 @@ namespace amrex
 
     //! Print out message to cerr and exit via amrex::Abort().
     void Error (const std::string& msg);
-    namespace detail { void Error_host_doit (const char * msg); }
-    AMREX_GPU_HOST_DEVICE inline
-    void Error (const char * msg = 0) {
-#if AMREX_DEVICE_COMPILE
-        if (msg) AMREX_DEVICE_PRINTF("Error %s\n", msg);
-        AMREX_DEVICE_ASSERT(0);
-#else
-        detail::Error_host_doit(msg);
-#endif
-    }
+
+    AMREX_GPU_EXTERNAL AMREX_GPU_HOST_DEVICE AMREX_NO_INLINE
+    void Error (const char * msg = 0);
 
     //! Print out warning message to cerr.
     void Warning (const std::string& msg);
-    namespace detail { void Warning_host_doit (const char * msg); }
-    AMREX_GPU_HOST_DEVICE inline
-    void Warning (const char * msg) {
-#if AMREX_DEVICE_COMPILE
-        if (msg) AMREX_DEVICE_PRINTF("Warning %s\n", msg);
-#else
-        detail::Warning_host_doit(msg);
-#endif
-    }
+
+    AMREX_GPU_EXTERNAL AMREX_GPU_HOST_DEVICE AMREX_NO_INLINE
+    void Warning (const char * msg);
 
     //! Print out message to cerr and exit via abort().
     void Abort (const std::string& msg);
-    namespace detail { void Abort_host_doit (const char * msg); }
-    AMREX_GPU_HOST_DEVICE inline
-    void Abort (const char * msg = 0) {
-#if AMREX_DEVICE_COMPILE
-        if (msg) AMREX_DEVICE_PRINTF("Abort %s\n", msg);
-        AMREX_DEVICE_ASSERT(0);
-#else
-        detail::Abort_host_doit(msg);
-#endif
-    }
+
+    AMREX_GPU_EXTERNAL AMREX_GPU_HOST_DEVICE AMREX_NO_INLINE
+    void Abort (const char * msg = 0);
 
     /**
     * \brief Prints assertion failed messages to cerr and exits
     * via abort().  Intended for use by the BL_ASSERT() macro
     * in <AMReX_BLassert.H>.
     */
-    namespace detail { void Assert_host_doit (const char* EX, const char* file, int line,
-                                              const char* msg); }
-    AMREX_GPU_HOST_DEVICE inline
-    void Assert (const char* EX, const char* file, int line, const char* msg = nullptr) {
-#if AMREX_DEVICE_COMPILE
-        if (msg) {
-            AMREX_DEVICE_PRINTF("Assertion `%s' failed, file \"%s\", line %d, Msg: %s",
-                                EX, file, line, msg);
-        } else {
-            AMREX_DEVICE_PRINTF("Assertion `%s' failed, file \"%s\", line %d",
-                                EX, file, line);
-        }
-        AMREX_DEVICE_ASSERT(0);
-#else
-        detail::Assert_host_doit(EX, file, line, msg);
-#endif
-    }
+    AMREX_GPU_EXTERNAL AMREX_GPU_HOST_DEVICE AMREX_NO_INLINE
+    void Assert (const char* EX, const char* file, int line, const char* msg = nullptr);
 
     /**
     * \brief This is used by amrex::Error(), amrex::Abort(), and amrex::Assert()

--- a/Src/Base/AMReX_Extension.H
+++ b/Src/Base/AMReX_Extension.H
@@ -118,7 +118,7 @@
 #endif
 
 // no inline
-#if defined(__GNUC__)
+#if defined(__GNUC__) || defined(__clang__) || defined(__CUDACC__) || defined(__HIP__) || defined(__SYCL_COMPILER_VERSION)
 #define AMREX_NO_INLINE __attribute__((noinline))
 #else
 #define AMREX_NO_INLINE

--- a/Src/Base/AMReX_GpuDevice.cpp
+++ b/Src/Base/AMReX_GpuDevice.cpp
@@ -1043,11 +1043,13 @@ std::size_t
 Device::freeMemAvailable ()
 {
 #ifdef AMREX_USE_GPU
-    std::size_t f, t;
+    std::size_t f;
+#ifndef AMREX_USE_DPCPP
+    std::size_t t;
+#endif
     AMREX_HIP_OR_CUDA_OR_DPCPP( AMREX_HIP_SAFE_CALL(hipMemGetInfo(&f,&t));,
                                 AMREX_CUDA_SAFE_CALL(cudaMemGetInfo(&f,&t));,
                                 f = device_prop.totalGlobalMem; ); // xxxxx DPCPP todo
-    amrex::ignore_unused(t);
     return f;
 #else
     return 0;


### PR DESCRIPTION
## Summary

It is recommended that assertion calls on device are not inlined because
of performance issues.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
