### PR TITLE
bcf/hpcsdk-updates

### DIFF
--- a/Tools/GNUMake/comps/hpcsdk.mak
+++ b/Tools/GNUMake/comps/hpcsdk.mak
@@ -24,7 +24,7 @@ COMP_VERSION = $(hpcsdk_version)
 GENERIC_HPCSDK_FLAGS =
 
 ifeq ($(USE_OMP),TRUE)
-  GENERIC_HPCSDK_FLAGS += -mp -Mconcur=nonuma -Minfo=mp
+  GENERIC_HPCSDK_FLAGS += -mp -Minfo=mp
 endif
 
 ifeq ($(USE_ACC),TRUE)

--- a/Tools/GNUMake/comps/hpcsdk.mak
+++ b/Tools/GNUMake/comps/hpcsdk.mak
@@ -214,7 +214,7 @@ F90FLAGS += $(GENERIC_HPCSDK_FLAGS)
 
 ########################################################################
 
-override XTRALIBS += -lstdc++ -latomic
+override XTRALIBS += -lstdc++ -latomic -lnvf
 
 LINK_WITH_FORTRAN_COMPILER ?= $(USE_F_INTERFACES)
 


### PR DESCRIPTION
## Summary

This PR fixes two wrong compile/link flags in the NVIDIA HPC SDK which are documented in #1347.

## Additional background

The wrong/missing flags are documented in #1347.

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
