### PR TITLE
Add non-EB slopes and extend the generality of EB slope routines in 2D and 3D

### DIFF
--- a/Src/Base/AMReX_Slopes_K.H
+++ b/Src/Base/AMReX_Slopes_K.H
@@ -1,0 +1,426 @@
+#ifndef AMREX_SLOPES_K_H_
+#define AMREX_SLOPES_K_H_
+
+#include <AMReX_FArrayBox.H>
+
+namespace {
+
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE
+amrex::Real amrex_calc_xslope (int i, int j, int k, int n, int order,
+                               amrex::Array4<amrex::Real const> const& q) noexcept
+{
+    if (order == 2)
+    {
+        amrex::Real dl = 2.0*(q(i  ,j,k,n) - q(i-1,j,k,n));
+        amrex::Real dr = 2.0*(q(i+1,j,k,n) - q(i  ,j,k,n));
+        amrex::Real dc = 0.5*(q(i+1,j,k,n) - q(i-1,j,k,n));
+        amrex::Real slope = amrex::min(amrex::Math::abs(dl),amrex::Math::abs(dc),amrex::Math::abs(dr));
+        slope = (dr*dl > 0.0) ? slope : 0.0;
+        return (dc > 0.0) ? slope : -slope;
+
+    } else if (order == 4) {
+
+        amrex::Real dlft, drgt, dcen, dfm, dfp, dlim, dsgn, dtemp;
+        amrex::Real qm, qp, qi;
+        qi = q(i,j,k,n);
+        qm = q(i-1,j,k,n);
+        qp = q(i+1,j,k,n);
+
+        dlft = qm - q(i-2,j,k,n);
+        drgt = qi - qm;
+        dcen = 0.5*(dlft+drgt);
+        dsgn = amrex::Math::copysign(1.e0, dcen);
+        dlim = (dlft*drgt >= 0.0) ? 2.0*amrex::min(amrex::Math::abs(dlft), amrex::Math::abs(drgt)) : 0.0;
+        dfm = dsgn*amrex::min(dlim, amrex::Math::abs(dcen));
+
+        dlft = qp - qi;
+        drgt = q(i+2,j,k,n) - qp;
+        dcen = 0.5*(dlft+drgt);
+        dsgn = amrex::Math::copysign(1.e0, dcen);
+        dlim = (dlft*drgt >= 0.0) ? 2.0*amrex::min(amrex::Math::abs(dlft), amrex::Math::abs(drgt)) : 0.0;
+        dfp = dsgn*amrex::min(dlim, amrex::Math::abs(dcen));
+
+        dlft = qi - qm;
+        drgt = qp - qi;
+        dcen = 0.5*(dlft+drgt);
+        dsgn = amrex::Math::copysign(1.e0, dcen);
+        dlim = (dlft*drgt >= 0.0) ? 2.0*amrex::min(amrex::Math::abs(dlft), amrex::Math::abs(drgt)) : 0.0;
+
+        dtemp  = 4.0/3.0*dcen - 1.0/6.0*(dfp + dfm);
+
+        return dsgn*amrex::min(dlim, amrex::Math::abs(dtemp));
+
+    } else {
+        return 0.;
+    }
+}
+
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE
+amrex::Real amrex_calc_xslope_extdir (int i, int j, int k, int n, int order, 
+                                      amrex::Array4<amrex::Real const> const& q,
+                                      bool edlo, bool edhi, int domlo, int domhi) noexcept
+{
+    if (order == 2)
+    {
+        amrex::Real dl = 2.0*(q(i  ,j,k,n) - q(i-1,j,k,n));
+        amrex::Real dr = 2.0*(q(i+1,j,k,n) - q(i  ,j,k,n));
+        amrex::Real dc = 0.5*(q(i+1,j,k,n) - q(i-1,j,k,n));
+
+        if (edlo and i == domlo) {
+            dc = (q(i+1,j,k,n)+3.0*q(i,j,k,n)-4.0*q(i-1,j,k,n))/3.0;
+        } else if (edhi and i == domhi) {
+            dc = (4.0*q(i+1,j,k,n)-3.0*q(i,j,k,n)-q(i-1,j,k,n))/3.0;
+        }
+
+        amrex::Real slope = amrex::min(amrex::Math::abs(dl),amrex::Math::abs(dc),amrex::Math::abs(dr));
+        slope = (dr*dl > 0.0) ? slope : 0.0;
+        return (dc > 0.0) ? slope : -slope;
+
+    } else if (order == 4) {
+
+        amrex::Real dlft, drgt, dcen, dfm, dfp, dlim, dsgn, dtemp, dlimsh, dsgnsh;
+        amrex::Real qm, qp, qi;
+        qi = q(i,j,k,n);
+        qm = q(i-1,j,k,n);
+        qp = q(i+1,j,k,n);
+
+        dlft = qm - q(i-2,j,k,n);
+        drgt = qi - qm;
+        dcen = 0.5*(dlft+drgt);
+        dsgn = amrex::Math::copysign(1.e0, dcen);
+        dlim = (dlft*drgt >= 0.0) ? 2.0*amrex::min(amrex::Math::abs(dlft), amrex::Math::abs(drgt)) : 0.0;
+        dfm = dsgn*amrex::min(dlim, amrex::Math::abs(dcen));
+
+        dlft = qp - qi;
+        drgt = q(i+2,j,k,n) - qp;
+        dcen = 0.5*(dlft+drgt);
+        dsgn = amrex::Math::copysign(1.e0, dcen);
+        dlim = (dlft*drgt >= 0.0) ? 2.0*amrex::min(amrex::Math::abs(dlft), amrex::Math::abs(drgt)) : 0.0;
+        dfp = dsgn*amrex::min(dlim, amrex::Math::abs(dcen));
+
+        dlft = qi - qm;
+        drgt = qp - qi;
+        dcen = 0.5*(dlft+drgt);
+        dsgn = amrex::Math::copysign(1.e0, dcen);
+        dlim = (dlft*drgt >= 0.0) ? 2.0*amrex::min(amrex::Math::abs(dlft), amrex::Math::abs(drgt)) : 0.0;
+
+        dtemp  = 4.0/3.0*dcen - 1.0/6.0*(dfp + dfm);
+
+        if (edlo and i == domlo) {
+           dtemp  = -16./15.*q(i-1,j,k,n) + .5*q(i,j,k,n) + 2./3.*q(i+1,j,k,n) -  0.1*q(i+2,j,k,n);
+           dlft = 2.*(q(i  ,j,k,n)-q(i-1,j,k,n));
+           drgt = 2.*(q(i+1,j,k,n)-q(i  ,j,k,n));
+           dlim = (dlft*drgt >= 0.0) ? amrex::min(amrex::Math::abs(dlft), amrex::Math::abs(drgt)) : 0.0;
+           dsgn = amrex::Math::copysign(1.e0, dtemp);
+        } else if (edlo and i == domlo+1) {
+           dfm  = -16./15.*q(domlo-1,j,k,n) + .5*q(domlo,j,k,n) + 2./3.*q(domlo+1,j,k,n) -  0.1*q(domlo+2,j,k,n);
+           dlft = 2.*(q(domlo  ,j,k,n)-q(domlo-1,j,k,n));
+           drgt = 2.*(q(domlo+1,j,k,n)-q(domlo  ,j,k,n));
+           dlimsh = (dlft*drgt >= 0.0) ? amrex::min(amrex::Math::abs(dlft), amrex::Math::abs(drgt)) : 0.0;
+           dsgnsh = amrex::Math::copysign(1.e0, dfm);
+           dfm = dsgnsh*amrex::min(dlimsh, amrex::Math::abs(dfm));
+           dtemp  = 4.0/3.0*dcen - 1.0/6.0*(dfp + dfm);
+        }
+
+        if (edhi and i == domhi) {
+           dtemp  = 16./15.*q(i+1,j,k,n) - .5*q(i,j,k,n) - 2./3.*q(i-1,j,k,n) +  0.1*q(i-2,j,k,n);
+           dlft = 2.*(q(i  ,j,k,n)-q(i-1,j,k,n));
+           drgt = 2.*(q(i+1,j,k,n)-q(i  ,j,k,n));
+           dlim = (dlft*drgt >= 0.0) ? amrex::min(amrex::Math::abs(dlft), amrex::Math::abs(drgt)) : 0.0;
+           dsgn = amrex::Math::copysign(1.e0, dtemp);
+        } else if (edhi and i == domhi-1) {
+           dfp  = 16./15.*q(domhi+1,j,k,n) - .5*q(domhi,j,k,n) - 2./3.*q(domhi-1,j,k,n) +  0.1*q(domhi-2,j,k,n);
+           dlft = 2.*(q(domhi  ,j,k,n)-q(domhi-1,j,k,n));
+           drgt = 2.*(q(domhi+1,j,k,n)-q(domhi  ,j,k,n));
+           dlimsh = (dlft*drgt >= 0.0) ? amrex::min(amrex::Math::abs(dlft), amrex::Math::abs(drgt)) : 0.0;
+           dsgnsh = amrex::Math::copysign(1.e0, dfp);
+           dfp = dsgnsh*amrex::min(dlimsh, amrex::Math::abs(dfp));
+           dtemp  = 4.0/3.0*dcen - 1.0/6.0*(dfp + dfm);
+        }
+
+        return dsgn*amrex::min(dlim, amrex::Math::abs(dtemp));
+
+    } else {
+        return 0.;
+    }
+
+}
+
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE
+amrex::Real amrex_calc_yslope (int i, int j, int k, int n, int order,
+                               amrex::Array4<amrex::Real const> const& q) noexcept
+{
+    if (order == 2)
+    {
+        amrex::Real dl = 2.0*(q(i,j  ,k,n) - q(i,j-1,k,n));
+        amrex::Real dr = 2.0*(q(i,j+1,k,n) - q(i,j  ,k,n));
+        amrex::Real dc = 0.5*(q(i,j+1,k,n) - q(i,j-1,k,n));
+        amrex::Real slope = amrex::min(amrex::Math::abs(dl),amrex::Math::abs(dc),amrex::Math::abs(dr));
+        slope = (dr*dl > 0.0) ? slope : 0.0;
+        return (dc > 0.0) ? slope : -slope;
+
+    } else if (order == 4) {
+
+        amrex::Real dlft, drgt, dcen, dfm, dfp, dlim, dsgn, dtemp;
+        amrex::Real qm, qp, qj;
+        qj = q(i,j,k,n);
+        qm = q(i,j-1,k,n);
+        qp = q(i,j+1,k,n);
+
+        dlft = qm - q(i,j-2,k,n);
+        drgt = qj - qm;
+        dcen = 0.5*(dlft+drgt);
+        dsgn = amrex::Math::copysign(1.e0, dcen);
+        dlim = (dlft*drgt >= 0.0) ? 2.0*amrex::min(amrex::Math::abs(dlft), amrex::Math::abs(drgt)) : 0.0;
+        dfm = dsgn*amrex::min(dlim, amrex::Math::abs(dcen));
+
+        dlft = qp - qj;
+        drgt = q(i,j+2,k,n) - qp;
+        dcen = 0.5*(dlft+drgt);
+        dsgn = amrex::Math::copysign(1.e0, dcen);
+        dlim = (dlft*drgt >= 0.0) ? 2.0*amrex::min(amrex::Math::abs(dlft), amrex::Math::abs(drgt)) : 0.0;
+        dfp = dsgn*amrex::min(dlim, amrex::Math::abs(dcen));
+
+        dlft = qj - qm;
+        drgt = qp - qj;
+        dcen = 0.5*(dlft+drgt);
+        dsgn = amrex::Math::copysign(1.e0, dcen);
+        dlim = (dlft*drgt >= 0.0) ? 2.0*amrex::min(amrex::Math::abs(dlft), amrex::Math::abs(drgt)) : 0.0;
+
+        dtemp  = 4.0/3.0*dcen - 1.0/6.0*(dfp + dfm);
+        return dsgn*amrex::min(dlim, amrex::Math::abs(dtemp));
+
+    } else {
+        return 0.;
+    }
+}
+
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE
+amrex::Real amrex_calc_yslope_extdir (int i, int j, int k, int n, int order, 
+                                      amrex::Array4<amrex::Real const> const& q,
+                                      bool edlo, bool edhi, int domlo, int domhi) noexcept
+{
+    if (order == 2)
+    {
+        amrex::Real dl = 2.0*(q(i,j  ,k,n) - q(i,j-1,k,n));
+        amrex::Real dr = 2.0*(q(i,j+1,k,n) - q(i,j  ,k,n));
+        amrex::Real dc = 0.5*(q(i,j+1,k,n) - q(i,j-1,k,n));
+        if (edlo and j == domlo) {
+            dc = (q(i,j+1,k,n)+3.0*q(i,j,k,n)-4.0*q(i,j-1,k,n))/3.0;
+        } else if (edhi and j == domhi) {
+            dc = (4.0*q(i,j+1,k,n)-3.0*q(i,j,k,n)-q(i,j-1,k,n))/3.0;
+        }
+        amrex::Real slope = amrex::min(amrex::Math::abs(dl),amrex::Math::abs(dc),amrex::Math::abs(dr));
+        slope = (dr*dl > 0.0) ? slope : 0.0;
+        return (dc > 0.0) ? slope : -slope;
+    
+    } else if (order == 4) {
+
+        amrex::Real dlft, drgt, dcen, dfm, dfp, dlim, dsgn, dtemp, dlimsh,dsgnsh;
+        amrex::Real qm, qp, qj;
+        qj = q(i,j,k,n);
+        qm = q(i,j-1,k,n);
+        qp = q(i,j+1,k,n);
+
+        dlft = qm - q(i,j-2,k,n);
+        drgt = qj - qm;
+        dcen = 0.5*(dlft+drgt);
+        dsgn = amrex::Math::copysign(1.e0, dcen);
+        dlim = (dlft*drgt >= 0.0) ? 2.0*amrex::min(amrex::Math::abs(dlft), amrex::Math::abs(drgt)) : 0.0;
+        dfm = dsgn*amrex::min(dlim, amrex::Math::abs(dcen));
+
+        dlft = qp - qj;
+        drgt = q(i,j+2,k,n) - qp;
+        dcen = 0.5*(dlft+drgt);
+        dsgn = amrex::Math::copysign(1.e0, dcen);
+        dlim = (dlft*drgt >= 0.0) ? 2.0*amrex::min(amrex::Math::abs(dlft), amrex::Math::abs(drgt)) : 0.0;
+        dfp = dsgn*amrex::min(dlim, amrex::Math::abs(dcen));
+
+        dlft = qj - qm;
+        drgt = qp - qj;
+        dcen = 0.5*(dlft+drgt);
+        dsgn = amrex::Math::copysign(1.e0, dcen);
+        dlim = (dlft*drgt >= 0.0) ? 2.0*amrex::min(amrex::Math::abs(dlft), amrex::Math::abs(drgt)) : 0.0;
+
+        dtemp  = 4.0/3.0*dcen - 1.0/6.0*(dfp + dfm);
+
+        if (edlo and j == domlo) {
+           dtemp  = -16./15.*q(i,j-1,k,n) + .5*q(i,j,k,n) + 2./3.*q(i,j+1,k,n) -  0.1*q(i,j+2,k,n);
+           dlft = 2.*(q(i  ,j,k,n)-q(i,j-1,k,n));
+           drgt = 2.*(q(i,j+1,k,n)-q(i  ,j,k,n));
+           dlim = (dlft*drgt >= 0.0) ? amrex::min(amrex::Math::abs(dlft), amrex::Math::abs(drgt)) : 0.0;
+           dsgn = amrex::Math::copysign(1.e0, dtemp);
+        } else if (edlo and j == domlo+1) {
+           dfm  = -16./15.*q(i,domlo-1,k,n) + .5*q(i,domlo,k,n) + 2./3.*q(i,domlo+1,k,n) -  0.1*q(i,domlo+2,k,n);
+           dlft = 2.*(q(i  ,domlo,k,n)-q(i,domlo-1,k,n));
+           drgt = 2.*(q(i,domlo+1,k,n)-q(i  ,domlo,k,n));
+           dlimsh = (dlft*drgt >= 0.0) ? amrex::min(amrex::Math::abs(dlft), amrex::Math::abs(drgt)) : 0.0;
+           dsgnsh = amrex::Math::copysign(1.e0, dfm);
+           dfm = dsgnsh*amrex::min(dlimsh, amrex::Math::abs(dfm));
+           dtemp  = 4.0/3.0*dcen - 1.0/6.0*(dfp + dfm);
+        }
+
+        if (edhi and j == domhi) {
+           dtemp  = 16./15.*q(i,j+1,k,n) - .5*q(i,j,k,n) - 2./3.*q(i,j-1,k,n) +  0.1*q(i,j-2,k,n);
+           dlft = 2.*(q(i  ,j,k,n)-q(i,j-1,k,n));
+           drgt = 2.*(q(i,j+1,k,n)-q(i  ,j,k,n));
+           dlim = (dlft*drgt >= 0.0) ? amrex::min(amrex::Math::abs(dlft), amrex::Math::abs(drgt)) : 0.0;
+           dsgn = amrex::Math::copysign(1.e0, dtemp);
+        } else if (edhi and j == domhi-1) {
+           dfp  = 16./15.*q(i,domhi+1,k,n) - .5*q(i,domhi,k,n) - 2./3.*q(i,domhi-1,k,n) +  0.1*q(i,domhi-2,k,n);
+           dlft = 2.*(q(i  ,domhi,k,n)-q(i,domhi-1,k,n));
+           drgt = 2.*(q(i,domhi+1,k,n)-q(i  ,domhi,k,n));
+           dlimsh = (dlft*drgt >= 0.0) ? amrex::min(amrex::Math::abs(dlft), amrex::Math::abs(drgt)) : 0.0;
+           dsgnsh = amrex::Math::copysign(1.e0, dfp);
+           dfp = dsgnsh*amrex::min(dlimsh, amrex::Math::abs(dfp));
+           dtemp  = 4.0/3.0*dcen - 1.0/6.0*(dfp + dfm);
+        }
+
+        return dsgn*amrex::min(dlim, amrex::Math::abs(dtemp));
+
+    } else {
+        return 0.;
+    }
+}
+
+#if (AMREX_SPACEDIM == 3)
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE
+amrex::Real amrex_calc_zslope (int i, int j, int k, int n, int order,
+                               amrex::Array4<amrex::Real const> const& q) noexcept
+{
+    if (order == 2)
+    {
+        amrex::Real dl = 2.0*(q(i,j,k  ,n) - q(i,j,k-1,n));
+        amrex::Real dr = 2.0*(q(i,j,k+1,n) - q(i,j,k  ,n));
+        amrex::Real dc = 0.5*(q(i,j,k+1,n) - q(i,j,k-1,n));
+        amrex::Real slope = amrex::min(amrex::Math::abs(dl),amrex::Math::abs(dc),amrex::Math::abs(dr));
+        slope = (dr*dl > 0.0) ? slope : 0.0;
+        return (dc > 0.0) ? slope : -slope;
+
+    } else if (order == 4) {
+
+        amrex::Real dlft, drgt, dcen, dfm, dfp, dlim, dsgn, dtemp;
+        amrex::Real qm, qp, qk;
+        qk = q(i,j,k,n);
+        qm = q(i,j,k-1,n);
+        qp = q(i,j,k+1,n);
+
+        dlft = qm - q(i,j,k-2,n);
+        drgt = qk - qm;
+        dcen = 0.5*(dlft+drgt);
+        dsgn = amrex::Math::copysign(1.e0, dcen);
+        dlim = (dlft*drgt >= 0.0) ? 2.0*amrex::min(amrex::Math::abs(dlft), amrex::Math::abs(drgt)) : 0.0;
+        dfm = dsgn*amrex::min(dlim, amrex::Math::abs(dcen));
+
+        dlft = qp - qk;
+        drgt = q(i,j,k+2,n) - qp;
+        dcen = 0.5*(dlft+drgt);
+        dsgn = amrex::Math::copysign(1.e0, dcen);
+        dlim = (dlft*drgt >= 0.0) ? 2.0*amrex::min(amrex::Math::abs(dlft), amrex::Math::abs(drgt)) : 0.0;
+        dfp = dsgn*amrex::min(dlim, amrex::Math::abs(dcen));
+
+        dlft = qk - qm;
+        drgt = qp - qk;
+        dcen = 0.5*(dlft+drgt);
+        dsgn = amrex::Math::copysign(1.e0, dcen);
+        dlim = (dlft*drgt >= 0.0) ? 2.0*amrex::min(amrex::Math::abs(dlft), amrex::Math::abs(drgt)) : 0.0;
+
+        dtemp  = 4.0/3.0*dcen - 1.0/6.0*(dfp + dfm);
+        return dsgn*amrex::min(dlim, amrex::Math::abs(dtemp));
+
+    } else {
+        return 0.;
+    }
+}
+
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE
+amrex::Real amrex_calc_zslope_extdir (int i, int j, int k, int n, int order, 
+                                      amrex::Array4<amrex::Real const> const& q,
+                                      bool edlo, bool edhi, int domlo, int domhi) noexcept
+{
+    if (order == 2)
+    {
+
+        amrex::Real dl = 2.0*(vcc(i,j,k  ,n) - vcc(i,j,k-1,n));
+        amrex::Real dr = 2.0*(vcc(i,j,k+1,n) - vcc(i,j,k  ,n));
+        amrex::Real dc = 0.5*(vcc(i,j,k+1,n) - vcc(i,j,k-1,n));
+        if (edlo and k == domlo) {
+            dc = (vcc(i,j,k+1,n)+3.0*vcc(i,j,k,n)-4.0*vcc(i,j,k-1,n))/3.0;
+        } else if (edhi and k == domhi) {
+            dc = (4.0*vcc(i,j,k+1,n)-3.0*vcc(i,j,k,n)-vcc(i,j,k-1,n))/3.0;
+        }
+        amrex::Real slope = amrex::min(amrex::Math::abs(dl),amrex::Math::abs(dc),amrex::Math::abs(dr));
+        slope = (dr*dl > 0.0) ? slope : 0.0;
+        return (dc > 0.0) ? slope : -slope;
+    
+    } else if (order == 4) {
+
+        amrex::Real dlft, drgt, dcen, dfm, dfp, dlim, dsgn, dtemp, dlimsh, dsgnsh;
+        amrex::Real qm, qp, qk;
+        qk = q(i,j,k,n);
+        qm = q(i,j,k-1,n);
+        qp = q(i,j,k+1,n);
+
+        dlft = qm - q(i,j,k-2,n);
+        drgt = qk - qm;
+        dcen = 0.5*(dlft+drgt);
+        dsgn = amrex::Math::copysign(1.e0, dcen);
+        dlim = (dlft*drgt >= 0.0) ? 2.0*amrex::min(amrex::Math::abs(dlft), amrex::Math::abs(drgt)) : 0.0;
+        dfm = dsgn*amrex::min(dlim, amrex::Math::abs(dcen));
+
+        dlft = qp - qk;
+        drgt = q(i,j,k+2,n) - qp;
+        dcen = 0.5*(dlft+drgt);
+        dsgn = amrex::Math::copysign(1.e0, dcen);
+        dlim = (dlft*drgt >= 0.0) ? 2.0*amrex::min(amrex::Math::abs(dlft), amrex::Math::abs(drgt)) : 0.0;
+        dfp = dsgn*amrex::min(dlim, amrex::Math::abs(dcen));
+
+        dlft = qk - qm;
+        drgt = qp - qk;
+        dcen = 0.5*(dlft+drgt);
+        dsgn = amrex::Math::copysign(1.e0, dcen);
+        dlim = (dlft*drgt >= 0.0) ? 2.0*amrex::min(amrex::Math::abs(dlft), amrex::Math::abs(drgt)) : 0.0;
+
+        dtemp  = 4.0/3.0*dcen - 1.0/6.0*(dfp + dfm);
+
+        if (edlo and k == domlo) {
+           dtemp  = -16./15.*q(i,j,k-1,n) + .5*q(i,j,k,n) + 2./3.*q(i,j,k+1,n) -  0.1*q(i,j,k+2,n);
+           dlft = 2.*(q(i  ,j,k,n)-q(i,j,k-1,n));
+           drgt = 2.*(q(i,j,k+1,n)-q(i  ,j,k,n));
+           dlim = (dlft*drgt >= 0.0) ? amrex::min(amrex::Math::abs(dlft), amrex::Math::abs(drgt)) : 0.0;
+           dsgn = amrex::Math::copysign(1.e0, dtemp);
+        } else if (edlo and k == domlo+1) {
+           dfm  = -16./15.*q(i,j,domlo-1,n) + .5*q(i,j,domlo,n) + 2./3.*q(i,j,domlo+1,n) -  0.1*q(i,j,domlo+2,n);
+           dlft = 2.*(q(i  ,j,domlo,n)-q(i,j,domlo-1,n));
+           drgt = 2.*(q(i,j,domlo+1,n)-q(i  ,j,domlo,n));
+           dlimsh = (dlft*drgt >= 0.0) ? amrex::min(amrex::Math::abs(dlft), amrex::Math::abs(drgt)) : 0.0;
+           dsgnsh = amrex::Math::copysign(1.e0, dfm);
+           dfm = dsgnsh*amrex::min(dlimsh, amrex::Math::abs(dfm));
+           dtemp  = 4.0/3.0*dcen - 1.0/6.0*(dfp + dfm);
+        }
+
+        if (edhi and k == domhi) {
+           dtemp  = 16./15.*q(i,j,k+1,n) - .5*q(i,j,k,n) - 2./3.*q(i,j,k-1,n) +  0.1*q(i,j,k-2,n);
+           dlft = 2.*(q(i  ,j,k,n)-q(i,j,k-1,n));
+           drgt = 2.*(q(i,j,k+1,n)-q(i  ,j,k,n));
+           dlim = (dlft*drgt >= 0.0) ? amrex::min(amrex::Math::abs(dlft), amrex::Math::abs(drgt)) : 0.0;
+           dsgn = amrex::Math::copysign(1.e0, dtemp);
+        } else if (edhi and k == domhi-1) {
+           dfp  = 16./15.*q(i,j,domhi+1,n) - .5*q(i,j,domhi,n) - 2./3.*q(i,j,domhi-1,n) +  0.1*q(i,j,domhi-2,n);
+           dlft = 2.*(q(i  ,j,domhi,n)-q(i,j,domhi-1,n));
+           drgt = 2.*(q(i,j,domhi+1,n)-q(i  ,j,domhi,n));
+           dlimsh = (dlft*drgt >= 0.0) ? amrex::min(amrex::Math::abs(dlft), amrex::Math::abs(drgt)) : 0.0;
+           dsgnsh = amrex::Math::copysign(1.e0, dfp);
+           dfp = dsgnsh*amrex::min(dlimsh, amrex::Math::abs(dfp));
+           dtemp  = 4.0/3.0*dcen - 1.0/6.0*(dfp + dfm);
+        }
+        return dsgn*amrex::min(dlim, amrex::Math::abs(dtemp));
+
+    } else {
+        return 0.;
+    }
+}
+#endif
+
+}
+#endif

--- a/Src/Base/AMReX_Slopes_K.H
+++ b/Src/Base/AMReX_Slopes_K.H
@@ -341,13 +341,13 @@ amrex::Real amrex_calc_zslope_extdir (int i, int j, int k, int n, int order,
     if (order == 2)
     {
 
-        amrex::Real dl = 2.0*(vcc(i,j,k  ,n) - vcc(i,j,k-1,n));
-        amrex::Real dr = 2.0*(vcc(i,j,k+1,n) - vcc(i,j,k  ,n));
-        amrex::Real dc = 0.5*(vcc(i,j,k+1,n) - vcc(i,j,k-1,n));
+        amrex::Real dl = 2.0*(q(i,j,k  ,n) - q(i,j,k-1,n));
+        amrex::Real dr = 2.0*(q(i,j,k+1,n) - q(i,j,k  ,n));
+        amrex::Real dc = 0.5*(q(i,j,k+1,n) - q(i,j,k-1,n));
         if (edlo and k == domlo) {
-            dc = (vcc(i,j,k+1,n)+3.0*vcc(i,j,k,n)-4.0*vcc(i,j,k-1,n))/3.0;
+            dc = (q(i,j,k+1,n)+3.0*q(i,j,k,n)-4.0*q(i,j,k-1,n))/3.0;
         } else if (edhi and k == domhi) {
-            dc = (4.0*vcc(i,j,k+1,n)-3.0*vcc(i,j,k,n)-vcc(i,j,k-1,n))/3.0;
+            dc = (4.0*q(i,j,k+1,n)-3.0*q(i,j,k,n)-q(i,j,k-1,n))/3.0;
         }
         amrex::Real slope = amrex::min(amrex::Math::abs(dl),amrex::Math::abs(dc),amrex::Math::abs(dr));
         slope = (dr*dl > 0.0) ? slope : 0.0;

--- a/Src/Base/CMakeLists.txt
+++ b/Src/Base/CMakeLists.txt
@@ -34,6 +34,7 @@ target_sources( amrex
    AMReX_Partition.H
    AMReX_Random.H
    AMReX_Random.cpp
+   AMReX_Slopes_K.H
    AMReX_BLassert.H
    AMReX_ArrayLim.H
    AMReX_REAL.H

--- a/Src/Base/Make.package
+++ b/Src/Base/Make.package
@@ -30,6 +30,8 @@ C$(AMREX_BASE)_sources += AMReX_FileSystem.cpp
 C$(AMREX_BASE)_headers += AMReX_Random.H
 C$(AMREX_BASE)_sources += AMReX_Random.cpp
 
+C$(AMREX_BASE)_headers += AMReX_Slopes_K.H
+
 C$(AMREX_BASE)_headers += AMReX_REAL.H AMReX_INT.H AMReX_CONSTANTS.H AMReX_SPACE.H
 
 C$(AMREX_BASE)_sources += AMReX_DistributionMapping.cpp AMReX_ParallelDescriptor.cpp

--- a/Src/EB/AMReX_EB_slopes_K.H
+++ b/Src/EB/AMReX_EB_slopes_K.H
@@ -15,6 +15,12 @@ namespace {
 #if (AMREX_SPACEDIM > 1)
 #ifdef AMREX_USE_EB
 
+#if (AMREX_SPACEDIM == 2)
+#define DIMA  9  
+#elif (AMREX_SPACEDIM == 3)
+#define DIMA 27  
+#endif
+
 // amrex_calc_slopes_eb calculates the slope in each coordinate direction using a 
 // least squares linear fit to the 9 in 2D / 27 in 3D nearest neighbors, with the function
 // going through the centroid of cell(i,j,k).  This does not assume that the cell centroids,
@@ -24,13 +30,6 @@ namespace {
 // defined on faces use the face centroid location.
 //
 // All the slopes are returned in one call.
-
-#if (AMREX_SPACEDIM == 2)
-#define DIMA  9  
-#elif (AMREX_SPACEDIM == 3)
-#define DIMA 27  
-#endif
-
 
 AMREX_GPU_DEVICE AMREX_FORCE_INLINE
 amrex::GpuArray<amrex::Real,AMREX_SPACEDIM>
@@ -65,6 +64,8 @@ amrex_calc_slopes_eb_given_A (int i, int j, int k, int n,
               du[lc] = 0.0;
             }
 
+//          if (i == 3 and j == 17 and k == 16) amrex::Print() << "DU " << 
+//                    ii << " " <<       jj << " " <<      kk  <<  " " << du[lc]  << std::endl; 
             lc++;
           }
         }
@@ -189,13 +190,13 @@ amrex_calc_slopes_eb (int i, int j, int k, int n,
 {
     amrex::Real A[DIMA][AMREX_SPACEDIM];
 
-    {
-      int lc=0;
+    int lc=0;
 #if (AMREX_SPACEDIM == 3)
-      for(int kk(-1); kk<=1; kk++){
+    for(int kk(-1); kk<=1; kk++)
 #else
-      int kk = 0;
+    int kk = 0;
 #endif
+    {
         for(int jj(-1); jj<=1; jj++){
           for(int ii(-1); ii<=1; ii++){
 
@@ -219,12 +220,14 @@ amrex_calc_slopes_eb (int i, int j, int k, int n,
                            A[lc][2] = 0.0;);
             }
 
+#if 0
+            if (i == 3 and j == 17 and k == 16) amrex::Print() << "A " << 
+                      ii << " " <<       jj << " " <<      kk  <<  " "  <<
+                A[lc][0] << " " << A[lc][1] << " " << A[lc][2] << std::endl; 
+#endif
             lc++;
           }
         }
-#if (AMREX_SPACEDIM == 3)
-      }
-#endif
     }
 
     // 
@@ -255,7 +258,7 @@ amrex_calc_slopes_eb (int i, int j, int k, int n,
 
 #if (AMREX_SPACEDIM == 3)
     // Z direction
-    if (flag(i,j,k).isRegular() and flag(i,j,k-1).isRegular() and flag(i,j,k).isRegular()) 
+    if (flag(i,j,k).isRegular() and flag(i,j,k-1).isRegular() and flag(i,j,k+1).isRegular()) 
     {
         int order = 2;
         zslope = amrex_calc_zslope(i,j,k,n,order,state);
@@ -369,8 +372,10 @@ amrex_calc_slopes_extdir_eb (int i, int j, int k, int n,
                                  A[lc][1] = 0.0;,
                                  A[lc][2] = 0.0;);
                 }
-//                    if (i == 0 and j == 14)
-//                    amrex::Print() << "STATE " << ii << " " << jj << " " << state(i+ii,j+jj,k) << std::endl;
+#if 0
+                      if (i == 0 and j == 4)
+                      amrex::Print() << "STATE " << ii << " " << jj << " " << state(i+ii,j+jj,k) << std::endl;
+#endif
 
                 lc++;
               }
@@ -379,7 +384,7 @@ amrex_calc_slopes_extdir_eb (int i, int j, int k, int n,
         }
 #endif
 #if 0
-        if (i == 0 and j == 15)
+        if (i == 0 and j == 4)
         for (int nn = 0; nn < 9; nn++) 
         {
            amrex::Print() << "A " << nn << " " << A[nn][0] << " " << A[nn][1] << std::endl;  
@@ -454,11 +459,7 @@ amrex_calc_slopes_extdir_eb (int i, int j, int k, int n,
     if ( (edlo_z and k == domlo_z) or (edlo_z and k == domhi_z) )
     {
         int lc=0;
-#if (AMREX_SPACEDIM == 3)
         for(int kk(-1); kk<=1; kk++) {
-#else
-            int kk = 0;
-#endif
             for(int jj(-1); jj<=1; jj++){
               for(int ii(-1); ii<=1; ii++){
 
@@ -471,24 +472,18 @@ amrex_calc_slopes_extdir_eb (int i, int j, int k, int n,
 
                     if (edlo_z and k == domlo_z and kk == -1) {
                         A[lc][0] = ii + fcz(i+ii,j+jj,k   ,0) - ccent(i,j,k,1);
-                        A[lc][1] = jj + fcz(i+ik,j+jj,k   ,1) - ccent(i,j,k,1);
-#if (AMREX_SPACEDIM == 3)
+                        A[lc][1] = jj + fcz(i+ii,j+jj,k   ,1) - ccent(i,j,k,1);
                         A[lc][2] = -0.5                       - ccent(i,j,k,2);
-#endif
                     } 
                     else if (edhi_z and k == domhi_z and kk == 1) 
                     {
                         A[lc][0] = ii + fcz(i+ii,j+jj,k+kk,0) - ccent(i,j,k,0);
-                        A[lc][1] = jj + fcz(i+ik,j+jj,k+kk,1) - ccent(i,j,k,1);
-#if (AMREX_SPACEDIM == 3)
+                        A[lc][1] = jj + fcz(i+ii,j+jj,k+kk,1) - ccent(i,j,k,1);
                         A[lc][2] = 0.5                        - ccent(i,j,k,2);
-#endif
                     } else {
                         A[lc][0] = ii + ccent(i+ii,j+jj,k+kk,0) - ccent(i,j,k,0);
                         A[lc][1] = jj + ccent(i+ii,j+jj,k+kk,1) - ccent(i,j,k,1);
-#if (AMREX_SPACEDIM == 3)
                         A[lc][2] = kk + ccent(i+ii,j+jj,k+kk,2) - ccent(i,j,k,2);
-#endif
                     }
 
                  } else {
@@ -500,9 +495,7 @@ amrex_calc_slopes_extdir_eb (int i, int j, int k, int n,
                 lc++;
               }
             }
-#if (AMREX_SPACEDIM == 3)
         }
-#endif
         const auto& slopes = amrex_calc_slopes_eb_given_A (i,j,k,n,A,state,flag);
 
         AMREX_D_TERM(xslope = slopes[0];,
@@ -526,7 +519,7 @@ amrex_calc_slopes_extdir_eb (int i, int j, int k, int n,
            yslope = amrex_calc_yslope(i,j,k,n,order,state);
          }
 #if (AMREX_SPACEDIM == 3)
-         if ( !( (edlo_z and k == domlo_z) or (edlo_z and k == domhi_k) ) and 
+         if ( !( (edlo_z and k == domlo_z) or (edlo_z and k == domhi_z) ) and 
                (flag(i,j,k).isRegular() and flag(i,j,k-1).isRegular() and flag(i,j,k+1).isRegular()) ) 
          {
            int order = 2;
@@ -546,7 +539,7 @@ amrex_calc_slopes_extdir_eb (int i, int j, int k, int n,
            xslope = amrex_calc_xslope(i,j,k,n,order,state);
          }
 #if (AMREX_SPACEDIM == 3)
-         if ( !( (edlo_z and k == domlo_z) or (edlo_z and k == domhi_k) ) and 
+         if ( !( (edlo_z and k == domlo_z) or (edlo_z and k == domhi_z) ) and 
                (flag(i,j,k).isRegular() and flag(i,j,k-1).isRegular() and flag(i,j,k+1).isRegular()) ) 
          {
            int order = 2;

--- a/Src/EB/AMReX_EB_slopes_K.H
+++ b/Src/EB/AMReX_EB_slopes_K.H
@@ -40,13 +40,13 @@ amrex_calc_slopes_eb_given_A (int i, int j, int k, int n,
 {
     amrex::Real du[DIMA];
 
-    {
-      int lc=0;
+    int lc=0;
 #if (AMREX_SPACEDIM == 3)
-      for(int kk(-1); kk<=1; kk++){
+    for(int kk(-1); kk<=1; kk++)
 #else
-      int kk = 0;
+    int kk = 0;
 #endif
+    {
         for(int jj(-1); jj<=1; jj++){
           for(int ii(-1); ii<=1; ii++){
 
@@ -64,14 +64,13 @@ amrex_calc_slopes_eb_given_A (int i, int j, int k, int n,
               du[lc] = 0.0;
             }
 
-//          if (i == 3 and j == 17 and k == 16) amrex::Print() << "DU " << 
-//                    ii << " " <<       jj << " " <<      kk  <<  " " << du[lc]  << std::endl; 
+#if 0
+            if (i == 0 and j == 17 and k == 16) amrex::Print() << "DU " << 
+                      ii << " " <<       jj << " " <<      kk  <<  " " << du[lc]  << std::endl; 
+#endif
             lc++;
           }
         }
-#if (AMREX_SPACEDIM == 3)
-      }
-#endif
     }
 
     amrex::Real AtA[AMREX_SPACEDIM][AMREX_SPACEDIM];
@@ -221,7 +220,7 @@ amrex_calc_slopes_eb (int i, int j, int k, int n,
             }
 
 #if 0
-            if (i == 3 and j == 17 and k == 16) amrex::Print() << "A " << 
+            if (i == 0 and j == 17 and k == 16) amrex::Print() << "A " << 
                       ii << " " <<       jj << " " <<      kk  <<  " "  <<
                 A[lc][0] << " " << A[lc][1] << " " << A[lc][2] << std::endl; 
 #endif
@@ -510,6 +509,7 @@ amrex_calc_slopes_extdir_eb (int i, int j, int k, int n,
     //
 
     // Overwrite the tangential slope from the regular stencils if we can compute from regular cells
+#if 0
     if ( (edlo_x and i == domlo_x) or (edlo_x and i == domhi_x) ) 
     {
          if ( !( (edlo_y and j == domlo_y) or (edlo_y and j == domhi_y) ) and 
@@ -527,11 +527,11 @@ amrex_calc_slopes_extdir_eb (int i, int j, int k, int n,
          }
 #endif
     }
+#endif
 
 
     // Overwrite the slope from the EB stencil if we can compute it from regular cells
-    if ( (edlo_y and j == domlo_y) or (edlo_y and j == domhi_y) )
-    {
+    if ( (edlo_y and j == domlo_y) or (edlo_y and j == domhi_y) ) {
          if ( !( (edlo_x and i == domlo_x) or (edlo_x and i == domhi_x) ) and 
                (flag(i,j,k).isRegular() and flag(i-1,j,k).isRegular() and flag(i+1,j,k).isRegular()) )
          {
@@ -568,22 +568,26 @@ amrex_calc_slopes_extdir_eb (int i, int j, int k, int n,
 
     }
 
-    {
     // Zero out slopes outside of an extdir (or hoextrap) boundary
     // TODO:  is this the right thing to do at a HOEXTRAP boundary??
 #if (AMREX_SPACEDIM == 2)
     if ( (edlo_x and i < domlo_x) or (edhi_x and i > domhi_x)   or
          (edlo_y and j < domlo_y) or (edhi_y and j > domhi_y) )  
     { 
-          AMREX_D_TERM(xslope = 0.;,  yslope = 0.;, zslope = 0.;);
+          AMREX_D_TERM(xslope = 0.;,  
+                       xslope = 0.; yslope = 0.;, 
+                       xslope = 0.; yslope = 0.; zslope = 0.;);
     } 
 #elif (AMREX_SPACEDIM == 3)
     if ( (edlo_x and i < domlo_x) or (edhi_x and i > domhi_x) or
          (edlo_y and j < domlo_y) or (edhi_y and j > domhi_y) or
          (edlo_z and k < domlo_z) or (edhi_z and k > domhi_z) )
-          AMREX_D_TERM(xslope = 0.;,  yslope = 0.;, zslope = 0.;);
-#endif
+    {
+          AMREX_D_TERM(xslope = 0.;,  
+                       xslope = 0.; yslope = 0.;, 
+                       xslope = 0.; yslope = 0.; zslope = 0.;);
     }
+#endif
 
     return {AMREX_D_DECL(xslope,yslope,zslope)};
 }

--- a/Src/EB/AMReX_EB_slopes_K.H
+++ b/Src/EB/AMReX_EB_slopes_K.H
@@ -63,11 +63,6 @@ amrex_calc_slopes_eb_given_A (int i, int j, int k, int n,
 
               du[lc] = 0.0;
             }
-
-#if 0
-            if (i == 0 and j == 17 and k == 16) amrex::Print() << "DU " << 
-                      ii << " " <<       jj << " " <<      kk  <<  " " << du[lc]  << std::endl; 
-#endif
             lc++;
           }
         }
@@ -218,12 +213,6 @@ amrex_calc_slopes_eb (int i, int j, int k, int n,
                            A[lc][1] = 0.0;,
                            A[lc][2] = 0.0;);
             }
-
-#if 0
-            if (i == 0 and j == 17 and k == 16) amrex::Print() << "A " << 
-                      ii << " " <<       jj << " " <<      kk  <<  " "  <<
-                A[lc][0] << " " << A[lc][1] << " " << A[lc][2] << std::endl; 
-#endif
             lc++;
           }
         }
@@ -330,10 +319,11 @@ amrex_calc_slopes_extdir_eb (int i, int j, int k, int n,
     {
         int lc=0;
 #if (AMREX_SPACEDIM == 3)
-        for(int kk(-1); kk<=1; kk++) {
+        for(int kk(-1); kk<=1; kk++) 
 #else
-            int kk = 0;
+        int kk = 0;
 #endif
+        {
             for(int jj(-1); jj<=1; jj++){
               for(int ii(-1); ii<=1; ii++){
 
@@ -371,39 +361,25 @@ amrex_calc_slopes_extdir_eb (int i, int j, int k, int n,
                                  A[lc][1] = 0.0;,
                                  A[lc][2] = 0.0;);
                 }
-#if 0
-                      if (i == 0 and j == 4)
-                      amrex::Print() << "STATE " << ii << " " << jj << " " << state(i+ii,j+jj,k) << std::endl;
-#endif
-
                 lc++;
               }
             }
-#if (AMREX_SPACEDIM == 3)
         }
-#endif
-#if 0
-        if (i == 0 and j == 4)
-        for (int nn = 0; nn < 9; nn++) 
-        {
-           amrex::Print() << "A " << nn << " " << A[nn][0] << " " << A[nn][1] << std::endl;  
-        }
-#endif
-
-            const auto& slopes = amrex_calc_slopes_eb_given_A (i,j,k,n,A,state,flag);
-            AMREX_D_TERM(xslope = slopes[0];,
-                         yslope = slopes[1];,
-                         zslope = slopes[2];);
+        const auto& slopes = amrex_calc_slopes_eb_given_A (i,j,k,n,A,state,flag);
+        AMREX_D_TERM(xslope = slopes[0];,
+                     yslope = slopes[1];,
+                     zslope = slopes[2];);
     }
 
     if ( (edlo_y and j == domlo_y) or (edlo_y and j == domhi_y) )
     {
         int lc=0;
 #if (AMREX_SPACEDIM == 3)
-        for(int kk(-1); kk<=1; kk++) {
+        for(int kk(-1); kk<=1; kk++) 
 #else
-            int kk = 0;
+        int kk = 0;
 #endif
+        {
             for(int jj(-1); jj<=1; jj++){
               for(int ii(-1); ii<=1; ii++){
 
@@ -445,9 +421,8 @@ amrex_calc_slopes_extdir_eb (int i, int j, int k, int n,
                 lc++;
               }
             }
-#if (AMREX_SPACEDIM == 3)
         }
-#endif
+
         const auto& slopes = amrex_calc_slopes_eb_given_A (i,j,k,n,A,state,flag);
         AMREX_D_TERM(xslope = slopes[0];,
                      yslope = slopes[1];,
@@ -455,7 +430,7 @@ amrex_calc_slopes_extdir_eb (int i, int j, int k, int n,
     }
 
 #if (AMREX_SPACEDIM == 3)
-    if ( (edlo_z and k == domlo_z) or (edlo_z and k == domhi_z) )
+    if ( (edlo_z and k == domlo_z) or (edhi_z and k == domhi_z) )
     {
         int lc=0;
         for(int kk(-1); kk<=1; kk++) {
@@ -463,14 +438,14 @@ amrex_calc_slopes_extdir_eb (int i, int j, int k, int n,
               for(int ii(-1); ii<=1; ii++){
 
                 if( flag(i,j,k).isConnected(ii,jj,kk) and
-                    not (ii==0 and jj==0 and kk==0)) {
-    
+                    not (ii==0 and jj==0 and kk==0)) 
+                {
                     // Not multplying by dx to be consistent with how the
                     // slope is stored. Also not including the global shift
                     // wrt plo or i,j,k. We only need relative distance.
 
                     if (edlo_z and k == domlo_z and kk == -1) {
-                        A[lc][0] = ii + fcz(i+ii,j+jj,k   ,0) - ccent(i,j,k,1);
+                        A[lc][0] = ii + fcz(i+ii,j+jj,k   ,0) - ccent(i,j,k,0);
                         A[lc][1] = jj + fcz(i+ii,j+jj,k   ,1) - ccent(i,j,k,1);
                         A[lc][2] = -0.5                       - ccent(i,j,k,2);
                     } 

--- a/Src/EB/AMReX_EB_slopes_K.H
+++ b/Src/EB/AMReX_EB_slopes_K.H
@@ -8,6 +8,8 @@
 #include <AMReX_FArrayBox.H>
 #endif
 
+#include <AMReX_Slopes_K.H>
+
 namespace {
 
 #if (AMREX_SPACEDIM > 1)
@@ -16,28 +18,28 @@ namespace {
 // amrex_calc_slopes_eb calculates the slope in each coordinate direction using a 
 // least squares linear fit to the 9 in 2D / 27 in 3D nearest neighbors, with the function
 // going through the centroid of cell(i,j,k).  This does not assume that the cell centroids,
-// where the data is assume to live, are the same as cell centers.
-//
-// No boundary conditions are used in this call.
+// where the data is assume to live, are the same as cell centers.  Note that this routine
+// is called either by amrex_calc_slopes_eb or amrex_calc_slopes_extdir_eb; in the former
+// A is defined with the cell centroids; in the latter, the A values corresponding to values
+// defined on faces use the face centroid location.
 //
 // All the slopes are returned in one call.
 
-AMREX_GPU_DEVICE AMREX_FORCE_INLINE
-amrex::GpuArray<amrex::Real,AMREX_SPACEDIM>
-amrex_calc_slopes_eb (int i, int j, int k, int n,
-                      amrex::Array4<amrex::Real const> const& state,
-                      amrex::Array4<amrex::Real const> const& ccent,
-                      amrex::Array4<amrex::EBCellFlag const> const& flag) noexcept
-{
-
-#if (AMREX_SPACEDIM == 3)
-    constexpr int m_size = 27;
-#else
-    constexpr int m_size = 9;
+#if (AMREX_SPACEDIM == 2)
+#define DIMA  9  
+#elif (AMREX_SPACEDIM == 3)
+#define DIMA 27  
 #endif
 
-    amrex::Real A[m_size][AMREX_SPACEDIM];
-    amrex::Real du[m_size];
+
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE
+amrex::GpuArray<amrex::Real,AMREX_SPACEDIM>
+amrex_calc_slopes_eb_given_A (int i, int j, int k, int n,
+                              amrex::Real A[DIMA][AMREX_SPACEDIM],
+                              amrex::Array4<amrex::Real const> const& state,
+                              amrex::Array4<amrex::EBCellFlag const> const& flag) noexcept
+{
+    amrex::Real du[DIMA];
 
     {
       int lc=0;
@@ -56,18 +58,9 @@ amrex_calc_slopes_eb (int i, int j, int k, int n,
             // slope is stored. Also not including the global shift
             // wrt plo or i,j,k. We only need relative distance.
 
-              A[lc][0] = ii + ccent(i+ii,j+jj,k+kk,0) - ccent(i,j,k,0);
-              A[lc][1] = jj + ccent(i+ii,j+jj,k+kk,1) - ccent(i,j,k,1);
-#if (AMREX_SPACEDIM == 3)
-              A[lc][2] = kk + ccent(i+ii,j+jj,k+kk,2) - ccent(i,j,k,2);
-#endif
               du[lc] = state(i+ii,j+jj,k+kk,n) - state(i,j,k,n);
 
             } else {
-
-              AMREX_D_TERM(A[lc][0] = 0.0;,
-                           A[lc][1] = 0.0;,
-                           A[lc][2] = 0.0;);
 
               du[lc] = 0.0;
             }
@@ -92,7 +85,7 @@ amrex_calc_slopes_eb (int i, int j, int k, int n,
 
     {
 
-      for(int lc(0); lc<m_size; ++lc){
+      for(int lc(0); lc<DIMA; ++lc){
         AtA[0][0] += A[lc][0]* A[lc][0];
         AtA[0][1] += A[lc][0]* A[lc][1];
 #if (AMREX_SPACEDIM == 3)
@@ -134,43 +127,19 @@ amrex_calc_slopes_eb (int i, int j, int k, int n,
                  amrex::Real ys = 0.0;,
                  amrex::Real zs = 0.0;);
 
-    // X direction
-    if(flag(i  ,j,k).isSingleValued() or
-      (flag(i-1,j,k).isSingleValued() or not flag(i,j,k).isConnected(-1,0,0)) or
-      (flag(i+1,j,k).isSingleValued() or not flag(i,j,k).isConnected( 1,0,0))) 
-    {
-
 #if (AMREX_SPACEDIM == 3)
-      amrex::Real detAtA_x =
+    amrex::Real detAtA_x =
         Atb[0]   *(AtA[1][1]*AtA[2][2] - AtA[1][2]*AtA[1][2]) -
         AtA[0][1]*(Atb[1] *  AtA[2][2] - AtA[1][2]*Atb[2]   ) +
         AtA[0][2]*(Atb[1] *  AtA[2][1] - AtA[1][1]*Atb[2]   );
 #else
-      amrex::Real detAtA_x =
+    amrex::Real detAtA_x =
         (Atb[0]   *AtA[1][1]) -
         (AtA[0][1]*Atb[1]); 
 #endif
 
-      // Slope at centroid of (i,j,k)
-      xs = detAtA_x / detAtA;
-
-    } else {
-
-      amrex::Real du_xl = 2.0*(state(i  ,j,k,n) - state(i-1,j,k,n));
-      amrex::Real du_xr = 2.0*(state(i+1,j,k,n) - state(i  ,j,k,n));
-      amrex::Real du_xc = 0.5*(state(i+1,j,k,n) - state(i-1,j,k,n));
-
-      amrex::Real xslope = amrex::min(amrex::Math::abs(du_xl), amrex::Math::abs(du_xc), amrex::Math::abs(du_xr));
-      xslope = (du_xr*du_xl > 0.0) ? xslope : 0.0;
-      xs = (du_xc > 0.0) ? xslope : -xslope;
-
-    }
-
-    // Y direction
-    if(flag(i,j  ,k).isSingleValued() or
-      (flag(i,j-1,k).isSingleValued() or not flag(i,j,k).isConnected(0,-1,0)) or
-      (flag(i,j+1,k).isSingleValued() or not flag(i,j,k).isConnected(0, 1,0))) 
-    {
+    // Slope at centroid of (i,j,k)
+    xs = detAtA_x / detAtA;
 
 #if (AMREX_SPACEDIM == 3)
       amrex::Real detAtA_y =
@@ -186,168 +155,425 @@ amrex_calc_slopes_eb (int i, int j, int k, int n,
       // Slope at centroid of (i,j,k)
       ys = detAtA_y / detAtA;
 
-    } else {
-
-      amrex::Real du_yl = 2.0*(state(i,j  ,k,n) - state(i,j-1,k,n));
-      amrex::Real du_yr = 2.0*(state(i,j+1,k,n) - state(i,j  ,k,n));
-      amrex::Real du_yc = 0.5*(state(i,j+1,k,n) - state(i,j-1,k,n));
-
-      amrex::Real yslope = amrex::min(amrex::Math::abs(du_yl), amrex::Math::abs(du_yc), amrex::Math::abs(du_yr));
-      yslope = (du_yr*du_yl > 0.0) ? yslope : 0.0;
-      ys = (du_yc > 0.0) ? yslope : -yslope;
-    }
 #if (AMREX_SPACEDIM == 3)
-    // Z direction
-    if(flag(i,j,k  ).isSingleValued() or
-      (flag(i,j,k-1).isSingleValued() or not flag(i,j,k).isConnected(0,0,-1)) or
-      (flag(i,j,k+1).isSingleValued() or not flag(i,j,k).isConnected(0,0, 1))) 
-    {
-
       amrex::Real detAtA_z =
         AtA[0][0]*(AtA[1][1]*Atb[2]    - Atb[1]   *AtA[1][2]) -
         AtA[0][1]*(AtA[1][0]*Atb[2]    - Atb[1]   *AtA[2][0]) +
         Atb[0]   *(AtA[1][0]*AtA[2][1] - AtA[1][1]*AtA[2][0]);
 
       zs = detAtA_z / detAtA;
-
-    } else {
-
-      amrex::Real du_zl = 2.0*(state(i,j,k  ,n) - state(i,j,k-1,n));
-      amrex::Real du_zr = 2.0*(state(i,j,k+1,n) - state(i,j,k  ,n));
-      amrex::Real du_zc = 0.5*(state(i,j,k+1,n) - state(i,j,k-1,n));
-
-      amrex::Real zslope = amrex::min(amrex::Math::abs(du_zl), amrex::Math::abs(du_zc), amrex::Math::abs(du_zr));
-      zslope = (du_zr*du_zl > 0.0) ? zslope : 0.0;
-      zs = (du_zc > 0.0) ? zslope : -zslope;
-    }
 #endif
 
    return {AMREX_D_DECL(xs,ys,zs)};
 }
 
+// amrex_calc_slopes_eb calculates the slope in each coordinate direction using a 
+// 1) standard 2nd order limited slope if all three cells in the stencil are regular cells
+// OR
+// 2) least squares linear fit to the at-most 9 in 2D / 27 in 3D nearest neighbors, with the function
+// going through the centroid of cell(i,j,k).  This does not assume that the cell centroids,
+// where the data is assume to live, are the same as cell centers.  Note that calc_slopes_eb
+// defines the matrix A and passes this A to amrex_calc_slopes_eb_given_A.
+//
+// This routine assumes that there are no relevant hoextrap/extdir domain boundary conditions for this cell -- 
+//     it does not test for them so this should not be called if such boundaries might be present
+//
+// All the slopes are returned in one call.
+
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE
+amrex::GpuArray<amrex::Real,AMREX_SPACEDIM>
+amrex_calc_slopes_eb (int i, int j, int k, int n,
+                      amrex::Array4<amrex::Real const> const& state,
+                      amrex::Array4<amrex::Real const> const& ccent,
+                      amrex::Array4<amrex::EBCellFlag const> const& flag) noexcept
+{
+    amrex::Real A[DIMA][AMREX_SPACEDIM];
+
+    {
+      int lc=0;
+#if (AMREX_SPACEDIM == 3)
+      for(int kk(-1); kk<=1; kk++){
+#else
+      int kk = 0;
+#endif
+        for(int jj(-1); jj<=1; jj++){
+          for(int ii(-1); ii<=1; ii++){
+
+            if( flag(i,j,k).isConnected(ii,jj,kk) and
+                not (ii==0 and jj==0 and kk==0)) {
+
+            // Not multplying by dx to be consistent with how the
+            // slope is stored. Also not including the global shift
+            // wrt plo or i,j,k. We only need relative distance.
+
+              A[lc][0] = ii + ccent(i+ii,j+jj,k+kk,0) - ccent(i,j,k,0);
+              A[lc][1] = jj + ccent(i+ii,j+jj,k+kk,1) - ccent(i,j,k,1);
+#if (AMREX_SPACEDIM == 3)
+              A[lc][2] = kk + ccent(i+ii,j+jj,k+kk,2) - ccent(i,j,k,2);
+#endif
+
+            } else {
+
+              AMREX_D_TERM(A[lc][0] = 0.0;,
+                           A[lc][1] = 0.0;,
+                           A[lc][2] = 0.0;);
+            }
+
+            lc++;
+          }
+        }
+#if (AMREX_SPACEDIM == 3)
+      }
+#endif
+    }
+
+    // 
+    // These slopes use the EB stencil without testing whether it is actually needed
+    // 
+    const auto& slopes = amrex_calc_slopes_eb_given_A (i,j,k,n,A,state,flag);
+    AMREX_D_TERM(amrex::Real xslope = slopes[0];,
+                 amrex::Real yslope = slopes[1];,
+                 amrex::Real zslope = slopes[2];);
+
+    // 
+    // Here we over-write -- if possible -- with a stencil not using the EB stencil
+    // 
+
+    // X direction
+    if (flag(i,j,k).isRegular() and flag(i-1,j,k).isRegular() and flag(i+1,j,k).isRegular()) 
+    {
+        int order = 2;
+        xslope = amrex_calc_xslope(i,j,k,n,order,state);
+    }
+
+    // Y direction
+    if (flag(i,j,k).isRegular() and flag(i,j-1,k).isRegular() and flag(i,j+1,k).isRegular()) 
+    {
+        int order = 2;
+        yslope = amrex_calc_yslope(i,j,k,n,order,state);
+    }
+
+#if (AMREX_SPACEDIM == 3)
+    // Z direction
+    if (flag(i,j,k).isRegular() and flag(i,j,k-1).isRegular() and flag(i,j,k).isRegular()) 
+    {
+        int order = 2;
+        zslope = amrex_calc_zslope(i,j,k,n,order,state);
+    }
+#endif
+    
+    return {AMREX_D_DECL(xslope,yslope,zslope)};
+}
+
 // amrex_calc_slopes_extdir_eb calculates the slope in each coordinate direction using a 
+// 1) standard limited slope if all three cells in the stencil are regular cells
+//    (this stencil sees the extdir/hoextrap boundary condition if there is one)
+// OR
+// 2) least squares linear fit to the at-most 9 in 2D / 27 in 3D nearest neighbors, with the function
 // least squares linear fit to the 9 in 2D / 27 in 3D nearest neighbors, with the function
 // going through the centroid of cell(i,j,k).  This does not assume that the cell centroids,
 // where the data is assume to live, are the same as cell centers.
 //
-// No boundary conditions are used in this call.
-//
 // All the slopes are returned in one call.
 //
-// This differs from the previous call in that it over-rides the slope in the direction
-// normal to a domain boundary when the boundary condition is imposed as external Dirichlet.
-// We note that this is only correct in the case where the EB normals are parallel to the domain 
-// boundary so that the transverse locations of the centroids in the cells being used are identical.
 
 AMREX_GPU_DEVICE AMREX_FORCE_INLINE
 amrex::GpuArray<amrex::Real,AMREX_SPACEDIM>
 amrex_calc_slopes_extdir_eb (int i, int j, int k, int n,
                              amrex::Array4<amrex::Real const> const& state,
                              amrex::Array4<amrex::Real const> const& ccent,
+                             AMREX_D_DECL(
+                             amrex::Array4<amrex::Real const> const& fcx, 
+                             amrex::Array4<amrex::Real const> const& fcy,
+                             amrex::Array4<amrex::Real const> const& fcz),
                              amrex::Array4<amrex::EBCellFlag const> const& flag,
                              AMREX_D_DECL(bool edlo_x, bool edlo_y, bool edlo_z),
                              AMREX_D_DECL(bool edhi_x, bool edhi_y, bool edhi_z), 
                              AMREX_D_DECL(int domlo_x, int domlo_y, int domlo_z),
                              AMREX_D_DECL(int domhi_x, int domhi_y, int domhi_z)) noexcept
 {
+    AMREX_D_TERM(amrex::Real xslope;,
+                 amrex::Real yslope;,
+                 amrex::Real zslope;);
+
     // First get EB-aware slope that doesn't know about extdir
-    amrex::GpuArray<amrex::Real,AMREX_SPACEDIM> eb_slope = amrex_calc_slopes_eb (i,j,k,n,state,ccent,flag);
-    AMREX_D_TERM(amrex::Real xslope = eb_slope[0];,
-                 amrex::Real yslope = eb_slope[1];,
-                 amrex::Real zslope = eb_slope[2];);
-
-    // Now correct only those cells which are not affected by EB but are by extdir
-    if        (edlo_x and i == domlo_x) {
-        if( !( flag(i  ,j,k).isSingleValued() or
-              (flag(i-1,j,k).isSingleValued() or not flag(i,j,k).isConnected(-1,0,0)) or
-              (flag(i+1,j,k).isSingleValued() or not flag(i,j,k).isConnected( 1,0,0))) ) 
-        {
-           amrex::Real dl = 2.0*(state(i  ,j,k,n) - state(i-1,j,k,n));
-           amrex::Real dr = 2.0*(state(i+1,j,k,n) - state(i  ,j,k,n));
-           amrex::Real dc = 
-              (state(i+1,j,k,n)+3.0*state(i,j,k,n)-4.0*state(i-1,j,k,n))/3.0;
-
-           amrex::Real slope = amrex::min(amrex::Math::abs(dl),amrex::Math::abs(dc),amrex::Math::abs(dr));
-           slope = (dr*dl > 0.0) ? slope : 0.0;
-           xslope = (dc > 0.0) ? slope : -slope;
-        }
-
-    } else if (edhi_x and i == domhi_x) {
-        if( !( flag(i  ,j,k).isSingleValued() or
-              (flag(i-1,j,k).isSingleValued() or not flag(i,j,k).isConnected(-1,0,0)) or
-              (flag(i+1,j,k).isSingleValued() or not flag(i,j,k).isConnected( 1,0,0))) )
-        {
-           amrex::Real dl = 2.0*(state(i  ,j,k,n) - state(i-1,j,k,n));
-           amrex::Real dr = 2.0*(state(i+1,j,k,n) - state(i  ,j,k,n));
-           amrex::Real dc = 
-              (4.0*state(i+1,j,k,n)-3.0*state(i,j,k,n)-state(i-1,j,k,n))/3.0;
-
-           amrex::Real slope = amrex::min(amrex::Math::abs(dl),amrex::Math::abs(dc),amrex::Math::abs(dr));
-           slope = (dr*dl > 0.0) ? slope : 0.0;
-           xslope = (dc > 0.0) ? slope : -slope;
-        }
-    }
-
-    if        (edlo_y and j == domlo_y) {
-        if( !( flag(i,j  ,k).isSingleValued() or
-              (flag(i,j-1,k).isSingleValued() or not flag(i,j,k).isConnected(0,-1,0)) or
-              (flag(i,j+1,k).isSingleValued() or not flag(i,j,k).isConnected(0, 1,0))) )
-        {
-           amrex::Real dl = 2.0*(state(i,j  ,k,n) - state(i,j-1,k,n));
-           amrex::Real dr = 2.0*(state(i,j+1,k,n) - state(i,j  ,k,n));
-           amrex::Real dc = 
-              (state(i,j+1,k,n)+3.0*state(i,j,k,n)-4.0*state(i,j-1,k,n))/3.0;
-
-           amrex::Real slope = amrex::min(amrex::Math::abs(dl),amrex::Math::abs(dc),amrex::Math::abs(dr));
-           slope = (dr*dl > 0.0) ? slope : 0.0;
-           yslope = (dc > 0.0) ? slope : -slope;
-        }
-    } else if (edhi_y and j == domhi_y) {
-        if( !(flag(i,j  ,k).isSingleValued() or
-           (flag(i,j-1,k).isSingleValued() or not flag(i,j,k).isConnected(0,-1,0)) or
-           (flag(i,j+1,k).isSingleValued() or not flag(i,j,k).isConnected(0, 1,0))) )
-        {
-           amrex::Real dl = 2.0*(state(i,j  ,k,n) - state(i,j-1,k,n));
-           amrex::Real dr = 2.0*(state(i,j+1,k,n) - state(i,j  ,k,n));
-           amrex::Real dc = 
-              (4.0*state(i,j+1,k,n)-3.0*state(i,j,k,n)-state(i,j-1,k,n))/3.0;
-
-           amrex::Real slope = amrex::min(amrex::Math::abs(dl),amrex::Math::abs(dc),amrex::Math::abs(dr));
-           slope = (dr*dl > 0.0) ? slope : 0.0;
-           yslope = (dc > 0.0) ? slope : -slope;
-        }
-    }
+    bool needs_bdry_stencil = (edlo_x and i <= domlo_x) or (edhi_x and i >= domhi_x) or
+                              (edlo_y and j <= domlo_y) or (edhi_y and j >= domhi_y);
 #if (AMREX_SPACEDIM == 3)
-    if        (edlo_z and k == domlo_z) {
-        if( !( flag(i,j,k  ).isSingleValued() or
-              (flag(i,j,k-1).isSingleValued() or not flag(i,j,k).isConnected(0,0,-1)) or
-              (flag(i,j,k+1).isSingleValued() or not flag(i,j,k).isConnected(0,0, 1))) )
-        {
-           amrex::Real dl = 2.0*(state(i,j,k  ,n) - state(i,j,k-1,n));
-           amrex::Real dr = 2.0*(state(i,j,k+1,n) - state(i,j,k  ,n));
-           amrex::Real dc = 
-              (state(i,j,k+1,n)+3.0*state(i,j,k,n)-4.0*state(i,j,k-1,n))/3.0;
+         needs_bdry_stencil = needs_bdry_stencil or 
+                              (edlo_z and k <= domlo_z) or (edhi_z and k >= domhi_z);
+#endif
 
-           amrex::Real slope = amrex::min(amrex::Math::abs(dl),amrex::Math::abs(dc),amrex::Math::abs(dr));
-           slope = (dr*dl > 0.0) ? slope : 0.0;
-           zslope = (dc > 0.0) ? slope : -slope;
-        }
-    } else if (edhi_z and k == domhi_z) {
-        if( !( flag(i,j,k  ).isSingleValued() or
-             (flag(i,j,k-1).isSingleValued() or not flag(i,j,k).isConnected(0,0,-1)) or
-             (flag(i,j,k+1).isSingleValued() or not flag(i,j,k).isConnected(0,0, 1))) )
-        {
-           amrex::Real dl = 2.0*(state(i,j,k  ,n) - state(i,j,k-1,n));
-           amrex::Real dr = 2.0*(state(i,j,k+1,n) - state(i,j,k  ,n));
-           amrex::Real dc = 
-              (4.0*state(i,j,k+1,n)-3.0*state(i,j,k,n)-state(i,j,k-1,n))/3.0;
+    //
+    // This call does not have any knowledge of extdir / hoextrap boundary conditions
+    //
+    if (!needs_bdry_stencil)
+    {
+        // This returns slopes calculated with the regular 1-d approach if all cells in the stencil
+        //      are regular.  If not, it uses the EB-aware least squares approach to fit a linear profile 
+        //      using the neighboring un-covered cells.
+        const auto& slopes = amrex_calc_slopes_eb (i,j,k,n,state,ccent,flag);
+        return slopes;
 
-           amrex::Real slope = amrex::min(amrex::Math::abs(dl),amrex::Math::abs(dc),amrex::Math::abs(dr));
-           slope = (dr*dl > 0.0) ? slope : 0.0;
-           zslope = (dc > 0.0) ? slope : -slope;
+    } else {
+
+    amrex::Real A[DIMA][AMREX_SPACEDIM];
+
+    //
+    // Correct only those cells which are affected by extdir:
+    //    1) Here if any of the cells are not regular we use the face and cell centroids
+    //
+
+    if ( (edlo_x and i == domlo_x) or (edlo_x and i == domhi_x) )
+    {
+        int lc=0;
+#if (AMREX_SPACEDIM == 3)
+        for(int kk(-1); kk<=1; kk++) {
+#else
+            int kk = 0;
+#endif
+            for(int jj(-1); jj<=1; jj++){
+              for(int ii(-1); ii<=1; ii++){
+
+                if( flag(i,j,k).isConnected(ii,jj,kk) and
+                    not (ii==0 and jj==0 and kk==0)) {
+    
+                    // Not multplying by dx to be consistent with how the
+                    // slope is stored. Also not including the global shift
+                    // wrt plo or i,j,k. We only need relative distance.
+
+                    if ( (edlo_x and i == domlo_x) and ii == -1) {
+                        if (i == 0 and j == 15) std::cout << "FCX " << jj << " " << fcx(i,j+jj,k+kk,0) << std::endl;;
+                        if (i == 0 and j == 15) std::cout << "CCY " << jj << " " << ccent(i,j,k,1) << std::endl;;
+                        A[lc][0] = -0.5                       - ccent(i,j,k,0);
+                        A[lc][1] = jj + fcx(i   ,j+jj,k+kk,0) - ccent(i,j,k,1);
+#if (AMREX_SPACEDIM == 3)
+                        A[lc][2] = kk + fcx(i   ,j+jj,k+kk,1) - ccent(i,j,k,2);
+#endif
+                    } 
+                    else if ( (edhi_x and i == domhi_x) and ii == 1) 
+                    {
+                        A[lc][0] = 0.5                        - ccent(i,j,k,0);
+                        A[lc][1] = jj + fcx(i+ii,j+jj,k+kk,0) - ccent(i,j,k,1);
+#if (AMREX_SPACEDIM == 3)
+                        A[lc][2] = kk + fcx(i+ii,j+jj,k+kk,1) - ccent(i,j,k,2);
+#endif
+                    } else {
+                        A[lc][0] = ii + ccent(i+ii,j+jj,k+kk,0) - ccent(i,j,k,0);
+                        A[lc][1] = jj + ccent(i+ii,j+jj,k+kk,1) - ccent(i,j,k,1);
+#if (AMREX_SPACEDIM == 3)
+                        A[lc][2] = kk + ccent(i+ii,j+jj,k+kk,2) - ccent(i,j,k,2);
+#endif
+                    }
+
+                 } else {
+                    AMREX_D_TERM(A[lc][0] = 0.0;,
+                                 A[lc][1] = 0.0;,
+                                 A[lc][2] = 0.0;);
+                }
+
+                lc++;
+              }
+            }
+#if (AMREX_SPACEDIM == 3)
         }
+#endif
+            const auto& slopes = amrex_calc_slopes_eb_given_A (i,j,k,n,A,state,flag);
+            AMREX_D_TERM(xslope = slopes[0];,
+                         yslope = slopes[1];,
+                         zslope = slopes[2];);
+    }
+
+    if ( (edlo_y and j == domlo_y) or (edlo_y and j == domhi_y) )
+    {
+        int lc=0;
+#if (AMREX_SPACEDIM == 3)
+        for(int kk(-1); kk<=1; kk++) {
+#else
+            int kk = 0;
+#endif
+            for(int jj(-1); jj<=1; jj++){
+              for(int ii(-1); ii<=1; ii++){
+
+                if( flag(i,j,k).isConnected(ii,jj,kk) and
+                    not (ii==0 and jj==0 and kk==0)) {
+    
+                    // Not multplying by dx to be consistent with how the
+                    // slope is stored. Also not including the global shift
+                    // wrt plo or i,j,k. We only need relative distance.
+
+                    if (edlo_y and j == domlo_y and jj == -1) {
+                        A[lc][0] = ii + fcy(i+ii,j   ,k+kk,0) - ccent(i,j,k,0);
+                        A[lc][1] = -0.5                       - ccent(i,j,k,1);
+#if (AMREX_SPACEDIM == 3)
+                        A[lc][2] = kk + fcy(i+ii,j   ,k+kk,1) - ccent(i,j,k,2);
+#endif
+                    } 
+                    else if (edhi_y and j == domhi_y and jj == 1) 
+                    {
+                        A[lc][0] = ii + fcy(i+ii,j+jj,k+kk,0) - ccent(i,j,k,0);
+                        A[lc][1] = 0.5                        - ccent(i,j,k,1);
+#if (AMREX_SPACEDIM == 3)
+                        A[lc][2] = kk + fcy(i+ii,j+jj,k+kk,1) - ccent(i,j,k,2);
+#endif
+                    } else {
+                        A[lc][0] = ii + ccent(i+ii,j+jj,k+kk,0) - ccent(i,j,k,0);
+                        A[lc][1] = jj + ccent(i+ii,j+jj,k+kk,1) - ccent(i,j,k,1);
+#if (AMREX_SPACEDIM == 3)
+                        A[lc][2] = kk + ccent(i+ii,j+jj,k+kk,2) - ccent(i,j,k,2);
+#endif
+                    }
+
+                 } else {
+                    AMREX_D_TERM(A[lc][0] = 0.0;,
+                                 A[lc][1] = 0.0;,
+                                 A[lc][2] = 0.0;);
+                }
+
+                lc++;
+              }
+            }
+#if (AMREX_SPACEDIM == 3)
+        }
+#endif
+        const auto& slopes = amrex_calc_slopes_eb_given_A (i,j,k,n,A,state,flag);
+        AMREX_D_TERM(xslope = slopes[0];,
+                     yslope = slopes[1];,
+                     zslope = slopes[2];);
+    }
+
+#if (AMREX_SPACEDIM == 3)
+    if ( (edlo_z and k == domlo_z) or (edlo_z and k == domhi_z) )
+    {
+        int lc=0;
+#if (AMREX_SPACEDIM == 3)
+        for(int kk(-1); kk<=1; kk++) {
+#else
+            int kk = 0;
+#endif
+            for(int jj(-1); jj<=1; jj++){
+              for(int ii(-1); ii<=1; ii++){
+
+                if( flag(i,j,k).isConnected(ii,jj,kk) and
+                    not (ii==0 and jj==0 and kk==0)) {
+    
+                    // Not multplying by dx to be consistent with how the
+                    // slope is stored. Also not including the global shift
+                    // wrt plo or i,j,k. We only need relative distance.
+
+                    if (edlo_z and k == domlo_z and kk == -1) {
+                        A[lc][0] = ii + fcz(i+ii,j+jj,k   ,0) - ccent(i,j,k,1);
+                        A[lc][1] = jj + fcz(i+ik,j+jj,k   ,1) - ccent(i,j,k,1);
+#if (AMREX_SPACEDIM == 3)
+                        A[lc][2] = -0.5                       - ccent(i,j,k,2);
+#endif
+                    } 
+                    else if (edhi_z and k == domhi_z and kk == 1) 
+                    {
+                        A[lc][0] = ii + fcz(i+ii,j+jj,k+kk,0) - ccent(i,j,k,0);
+                        A[lc][1] = jj + fcz(i+ik,j+jj,k+kk,1) - ccent(i,j,k,1);
+#if (AMREX_SPACEDIM == 3)
+                        A[lc][2] = 0.5                        - ccent(i,j,k,2);
+#endif
+                    } else {
+                        A[lc][0] = ii + ccent(i+ii,j+jj,k+kk,0) - ccent(i,j,k,0);
+                        A[lc][1] = jj + ccent(i+ii,j+jj,k+kk,1) - ccent(i,j,k,1);
+#if (AMREX_SPACEDIM == 3)
+                        A[lc][2] = kk + ccent(i+ii,j+jj,k+kk,2) - ccent(i,j,k,2);
+#endif
+                    }
+
+                 } else {
+                    AMREX_D_TERM(A[lc][0] = 0.0;,
+                                 A[lc][1] = 0.0;,
+                                 A[lc][2] = 0.0;);
+                }
+
+                lc++;
+              }
+            }
+#if (AMREX_SPACEDIM == 3)
+        }
+#endif
+        const auto& slopes = amrex_calc_slopes_eb_given_A (i,j,k,n,A,state,flag);
+
+        AMREX_D_TERM(xslope = slopes[0];,
+                     yslope = slopes[1];,
+                     zslope = slopes[2];);
     }
 #endif
+
+    //
+    // Correct only those cells which are affected by extdir:
+    //    2) If all the cells are regular we use the "regular slope" in the extdir direction
+    //
+
+    // Overwrite the tangential slope from the regular stencils if we can compute from regular cells
+    if ( (edlo_x and i == domlo_x) or (edlo_x and i == domhi_x) ) 
+    {
+         if (flag(i,j,k).isRegular() and flag(i,j-1,k).isRegular() and flag(i,j+1,k).isRegular()) 
+         {
+           int order = 2;
+           yslope = amrex_calc_yslope(i,j,k,n,order,state);
+         }
+#if (AMREX_SPACEDIM == 3)
+         if (flag(i,j,k).isRegular() and flag(i,j,k-1).isRegular() and flag(i,j,k+1).isRegular()) 
+         {
+           int order = 2;
+           zslope = amrex_calc_zslope(i,j,k,n,order,state);
+         }
+#endif
+    }
+
+
+    // Overwrite the slope from the EB stencil if we can compute it from regular cells
+    if ( (edlo_y and j == domlo_y) or (edlo_y and j == domhi_y) )
+    {
+         if (flag(i,j,k).isRegular() and flag(i-1,j,k).isRegular() and flag(i+1,j,k).isRegular()) 
+         {
+           int order = 2;
+           xslope = amrex_calc_xslope(i,j,k,n,order,state);
+         }
+#if (AMREX_SPACEDIM == 3)
+         if (flag(i,j,k).isRegular() and flag(i,j,k-1).isRegular() and flag(i,j,k+1).isRegular()) 
+         {
+           int order = 2;
+           zslope = amrex_calc_zslope(i,j,k,n,order,state);
+         }
+#endif
+    }
+
+#if (AMREX_SPACEDIM == 3)
+    if ( (edlo_z and k == domlo_z) or (edlo_z and k == domhi_z) )
+    {
+         if (flag(i,j,k).isRegular() and flag(i-1,j,k).isRegular() and flag(i+1,j,k).isRegular()) 
+         {
+           int order = 2;
+           xslope = amrex_calc_xslope(i,j,k,n,order,state);
+         }
+         if (flag(i,j,k).isRegular() and flag(i,j-1,k).isRegular() and flag(i,j+1,k).isRegular()) 
+         {
+           int order = 2;
+           yslope = amrex_calc_yslope(i,j,k,n,order,state);
+         }
+    }
+#endif
+
+    }
+
+    {
+    // Zero out slopes outside of an extdir (or hoextrap) boundary
+    // TODO:  is this the right thing to do at a HOEXTRAP boundary??
+#if (AMREX_SPACEDIM == 2)
+    if ( ( (edlo_x and i < domlo_x) or (edlo_x and i > domhi_x) ) or
+         ( (edlo_y and j < domlo_y) or (edlo_y and j > domhi_y) ) )
+#elif (AMREX_SPACEDIM == 3)
+    if ( ( (edlo_x and i < domlo_x) or (edlo_x and i > domhi_x) ) or
+         ( (edlo_y and j < domlo_y) or (edlo_y and j > domhi_y) ) or
+         ( (edlo_z and k < domlo_z) or (edlo_  and k > domhi_z) ) )
+#endif
+          AMREX_D_TERM(xslope = 0.;,  yslope = 0.;, zslope = 0.;);
+    }
 
     return {AMREX_D_DECL(xslope,yslope,zslope)};
 }

--- a/Src/EB/AMReX_EB_slopes_K.H
+++ b/Src/EB/AMReX_EB_slopes_K.H
@@ -343,8 +343,6 @@ amrex_calc_slopes_extdir_eb (int i, int j, int k, int n,
                     // wrt plo or i,j,k. We only need relative distance.
 
                     if ( (edlo_x and i == domlo_x) and ii == -1) {
-                        if (i == 0 and j == 15) std::cout << "FCX " << jj << " " << fcx(i,j+jj,k+kk,0) << std::endl;;
-                        if (i == 0 and j == 15) std::cout << "CCY " << jj << " " << ccent(i,j,k,1) << std::endl;;
                         A[lc][0] = -0.5                       - ccent(i,j,k,0);
                         A[lc][1] = jj + fcx(i   ,j+jj,k+kk,0) - ccent(i,j,k,1);
 #if (AMREX_SPACEDIM == 3)
@@ -371,6 +369,8 @@ amrex_calc_slopes_extdir_eb (int i, int j, int k, int n,
                                  A[lc][1] = 0.0;,
                                  A[lc][2] = 0.0;);
                 }
+//                    if (i == 0 and j == 14)
+//                    amrex::Print() << "STATE " << ii << " " << jj << " " << state(i+ii,j+jj,k) << std::endl;
 
                 lc++;
               }
@@ -378,6 +378,14 @@ amrex_calc_slopes_extdir_eb (int i, int j, int k, int n,
 #if (AMREX_SPACEDIM == 3)
         }
 #endif
+#if 0
+        if (i == 0 and j == 15)
+        for (int nn = 0; nn < 9; nn++) 
+        {
+           amrex::Print() << "A " << nn << " " << A[nn][0] << " " << A[nn][1] << std::endl;  
+        }
+#endif
+
             const auto& slopes = amrex_calc_slopes_eb_given_A (i,j,k,n,A,state,flag);
             AMREX_D_TERM(xslope = slopes[0];,
                          yslope = slopes[1];,
@@ -511,13 +519,15 @@ amrex_calc_slopes_extdir_eb (int i, int j, int k, int n,
     // Overwrite the tangential slope from the regular stencils if we can compute from regular cells
     if ( (edlo_x and i == domlo_x) or (edlo_x and i == domhi_x) ) 
     {
-         if (flag(i,j,k).isRegular() and flag(i,j-1,k).isRegular() and flag(i,j+1,k).isRegular()) 
+         if ( !( (edlo_y and j == domlo_y) or (edlo_y and j == domhi_y) ) and 
+               (flag(i,j,k).isRegular() and flag(i,j-1,k).isRegular() and flag(i,j+1,k).isRegular()) )
          {
            int order = 2;
            yslope = amrex_calc_yslope(i,j,k,n,order,state);
          }
 #if (AMREX_SPACEDIM == 3)
-         if (flag(i,j,k).isRegular() and flag(i,j,k-1).isRegular() and flag(i,j,k+1).isRegular()) 
+         if ( !( (edlo_z and k == domlo_z) or (edlo_z and k == domhi_k) ) and 
+               (flag(i,j,k).isRegular() and flag(i,j,k-1).isRegular() and flag(i,j,k+1).isRegular()) ) 
          {
            int order = 2;
            zslope = amrex_calc_zslope(i,j,k,n,order,state);
@@ -529,13 +539,15 @@ amrex_calc_slopes_extdir_eb (int i, int j, int k, int n,
     // Overwrite the slope from the EB stencil if we can compute it from regular cells
     if ( (edlo_y and j == domlo_y) or (edlo_y and j == domhi_y) )
     {
-         if (flag(i,j,k).isRegular() and flag(i-1,j,k).isRegular() and flag(i+1,j,k).isRegular()) 
+         if ( !( (edlo_x and i == domlo_x) or (edlo_x and i == domhi_x) ) and 
+               (flag(i,j,k).isRegular() and flag(i-1,j,k).isRegular() and flag(i+1,j,k).isRegular()) )
          {
            int order = 2;
            xslope = amrex_calc_xslope(i,j,k,n,order,state);
          }
 #if (AMREX_SPACEDIM == 3)
-         if (flag(i,j,k).isRegular() and flag(i,j,k-1).isRegular() and flag(i,j,k+1).isRegular()) 
+         if ( !( (edlo_z and k == domlo_z) or (edlo_z and k == domhi_k) ) and 
+               (flag(i,j,k).isRegular() and flag(i,j,k-1).isRegular() and flag(i,j,k+1).isRegular()) ) 
          {
            int order = 2;
            zslope = amrex_calc_zslope(i,j,k,n,order,state);
@@ -546,12 +558,14 @@ amrex_calc_slopes_extdir_eb (int i, int j, int k, int n,
 #if (AMREX_SPACEDIM == 3)
     if ( (edlo_z and k == domlo_z) or (edlo_z and k == domhi_z) )
     {
-         if (flag(i,j,k).isRegular() and flag(i-1,j,k).isRegular() and flag(i+1,j,k).isRegular()) 
+         if ( !( (edlo_x and i == domlo_x) or (edlo_x and i == domhi_x) ) and 
+               (flag(i,j,k).isRegular() and flag(i-1,j,k).isRegular() and flag(i+1,j,k).isRegular()) )
          {
            int order = 2;
            xslope = amrex_calc_xslope(i,j,k,n,order,state);
          }
-         if (flag(i,j,k).isRegular() and flag(i,j-1,k).isRegular() and flag(i,j+1,k).isRegular()) 
+         if ( !( (edlo_y and j == domlo_y) or (edlo_y and j == domhi_y) ) and 
+               (flag(i,j,k).isRegular() and flag(i,j-1,k).isRegular() and flag(i,j+1,k).isRegular()) )
          {
            int order = 2;
            yslope = amrex_calc_yslope(i,j,k,n,order,state);
@@ -565,14 +579,17 @@ amrex_calc_slopes_extdir_eb (int i, int j, int k, int n,
     // Zero out slopes outside of an extdir (or hoextrap) boundary
     // TODO:  is this the right thing to do at a HOEXTRAP boundary??
 #if (AMREX_SPACEDIM == 2)
-    if ( ( (edlo_x and i < domlo_x) or (edlo_x and i > domhi_x) ) or
-         ( (edlo_y and j < domlo_y) or (edlo_y and j > domhi_y) ) )
-#elif (AMREX_SPACEDIM == 3)
-    if ( ( (edlo_x and i < domlo_x) or (edlo_x and i > domhi_x) ) or
-         ( (edlo_y and j < domlo_y) or (edlo_y and j > domhi_y) ) or
-         ( (edlo_z and k < domlo_z) or (edlo_  and k > domhi_z) ) )
-#endif
+    if ( (edlo_x and i < domlo_x) or (edhi_x and i > domhi_x)   or
+         (edlo_y and j < domlo_y) or (edhi_y and j > domhi_y) )  
+    { 
           AMREX_D_TERM(xslope = 0.;,  yslope = 0.;, zslope = 0.;);
+    } 
+#elif (AMREX_SPACEDIM == 3)
+    if ( (edlo_x and i < domlo_x) or (edhi_x and i > domhi_x) or
+         (edlo_y and j < domlo_y) or (edhi_y and j > domhi_y) or
+         (edlo_z and k < domlo_z) or (edhi_z and k > domhi_z) )
+          AMREX_D_TERM(xslope = 0.;,  yslope = 0.;, zslope = 0.;);
+#endif
     }
 
     return {AMREX_D_DECL(xslope,yslope,zslope)};

--- a/Src/EB/AMReX_EB_slopes_K.H
+++ b/Src/EB/AMReX_EB_slopes_K.H
@@ -15,12 +15,6 @@ namespace {
 #if (AMREX_SPACEDIM > 1)
 #ifdef AMREX_USE_EB
 
-#if (AMREX_SPACEDIM == 2)
-#define DIMA  9  
-#elif (AMREX_SPACEDIM == 3)
-#define DIMA 27  
-#endif
-
 // amrex_calc_slopes_eb calculates the slope in each coordinate direction using a 
 // least squares linear fit to the 9 in 2D / 27 in 3D nearest neighbors, with the function
 // going through the centroid of cell(i,j,k).  This does not assume that the cell centroids,
@@ -31,31 +25,97 @@ namespace {
 //
 // All the slopes are returned in one call.
 
+#if (AMREX_SPACEDIM == 2) 
 AMREX_GPU_DEVICE AMREX_FORCE_INLINE
 amrex::GpuArray<amrex::Real,AMREX_SPACEDIM>
 amrex_calc_slopes_eb_given_A (int i, int j, int k, int n,
-                              amrex::Real A[DIMA][AMREX_SPACEDIM],
+                              amrex::Real A[9][AMREX_SPACEDIM],
                               amrex::Array4<amrex::Real const> const& state,
                               amrex::Array4<amrex::EBCellFlag const> const& flag) noexcept
 {
-    amrex::Real du[DIMA];
+    amrex::Real du[9];
 
     int lc=0;
-#if (AMREX_SPACEDIM == 3)
+    {
+        for(int jj(-1); jj<=1; jj++){
+          for(int ii(-1); ii<=1; ii++){
+
+            if( flag(i,j,0).isConnected(ii,jj,0) and
+                not (ii==0 and jj==0)) {
+
+              du[lc] = state(i+ii,j+jj,0,n) - state(i,j,0,n);
+
+            } else {
+
+              du[lc] = 0.0;
+            }
+            lc++;
+          }
+        }
+    }
+
+    amrex::Real AtA[AMREX_SPACEDIM][AMREX_SPACEDIM];
+    amrex::Real Atb[AMREX_SPACEDIM];
+
+    for(int jj(0); jj<AMREX_SPACEDIM; ++jj)
+    {
+      for(int ii(0); ii<AMREX_SPACEDIM; ++ii){
+        AtA[ii][jj] = 0.0;
+      }
+      Atb[jj] = 0.0;
+    }
+
+    for(int lc(0); lc<9; ++lc)
+    {
+        AtA[0][0] += A[lc][0]* A[lc][0];
+        AtA[0][1] += A[lc][0]* A[lc][1];
+        AtA[1][1] += A[lc][1]* A[lc][1];
+
+        Atb[0] += A[lc][0]*du[lc];
+        Atb[1] += A[lc][1]*du[lc];
+    }
+
+    // Fill in symmetric
+    AtA[1][0] = AtA[0][1];
+
+    amrex::Real detAtA =
+      (AtA[0][0]*AtA[1][1])-
+      (AtA[0][1]*AtA[1][0]);
+
+    amrex::Real detAtA_x =
+        (Atb[0]   *AtA[1][1]) -
+        (AtA[0][1]*Atb[1]); 
+
+    // Slope at centroid of (i,j,k)
+    amrex::Real xs = detAtA_x / detAtA;
+
+    amrex::Real detAtA_y =
+        (AtA[0][0]*Atb[1]) -
+        (Atb[0] * AtA[1][0]);
+
+    // Slope at centroid of (i,j,k)
+    amrex::Real ys = detAtA_y / detAtA;
+
+   return {xs,ys};
+}
+#elif (AMREX_SPACEDIM == 3)
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE
+amrex::GpuArray<amrex::Real,AMREX_SPACEDIM>
+amrex_calc_slopes_eb_given_A (int i, int j, int k, int n,
+                              amrex::Real A[27][AMREX_SPACEDIM],
+                              amrex::Array4<amrex::Real const> const& state,
+                              amrex::Array4<amrex::EBCellFlag const> const& flag) noexcept
+{
+    amrex::Real du[27];
+
+    int lc=0;
     for(int kk(-1); kk<=1; kk++)
-#else
-    int kk = 0;
-#endif
     {
         for(int jj(-1); jj<=1; jj++){
           for(int ii(-1); ii<=1; ii++){
 
             if( flag(i,j,k).isConnected(ii,jj,kk) and
                 not (ii==0 and jj==0 and kk==0)) {
-
-            // Not multplying by dx to be consistent with how the
-            // slope is stored. Also not including the global shift
-            // wrt plo or i,j,k. We only need relative distance.
 
               du[lc] = state(i+ii,j+jj,k+kk,n) - state(i,j,k,n);
 
@@ -78,89 +138,57 @@ amrex_calc_slopes_eb_given_A (int i, int j, int k, int n,
       Atb[jj] = 0.0;
     }
 
+    for(int lc(0); lc < 27; ++lc)
     {
-
-      for(int lc(0); lc<DIMA; ++lc){
         AtA[0][0] += A[lc][0]* A[lc][0];
         AtA[0][1] += A[lc][0]* A[lc][1];
-#if (AMREX_SPACEDIM == 3)
         AtA[0][2] += A[lc][0]* A[lc][2];
-#endif
         AtA[1][1] += A[lc][1]* A[lc][1];
-#if (AMREX_SPACEDIM == 3)
         AtA[1][2] += A[lc][1]* A[lc][2];
         AtA[2][2] += A[lc][2]* A[lc][2];
-#endif
 
         Atb[0] += A[lc][0]*du[lc];
         Atb[1] += A[lc][1]*du[lc];
-#if (AMREX_SPACEDIM == 3)
         Atb[2] += A[lc][2]*du[lc];
-#endif
-      }
     }
 
     // Fill in symmetric
     AtA[1][0] = AtA[0][1];
-#if (AMREX_SPACEDIM == 3)
     AtA[2][0] = AtA[0][2];
     AtA[2][1] = AtA[1][2];
-#endif
 
-#if (AMREX_SPACEDIM == 3)
     amrex::Real detAtA =
       AtA[0][0]*(AtA[1][1]*AtA[2][2] - AtA[1][2]*AtA[2][1]) -
       AtA[0][1]*(AtA[1][0]*AtA[2][2] - AtA[1][2]*AtA[2][0]) +
       AtA[0][2]*(AtA[1][0]*AtA[2][1] - AtA[1][1]*AtA[2][0]);
-#else
-    amrex::Real detAtA =
-      (AtA[0][0]*AtA[1][1])-
-      (AtA[0][1]*AtA[1][0]);
-#endif
 
-    AMREX_D_TERM(amrex::Real xs = 0.0;,
-                 amrex::Real ys = 0.0;,
-                 amrex::Real zs = 0.0;);
-
-#if (AMREX_SPACEDIM == 3)
     amrex::Real detAtA_x =
         Atb[0]   *(AtA[1][1]*AtA[2][2] - AtA[1][2]*AtA[1][2]) -
         AtA[0][1]*(Atb[1] *  AtA[2][2] - AtA[1][2]*Atb[2]   ) +
         AtA[0][2]*(Atb[1] *  AtA[2][1] - AtA[1][1]*Atb[2]   );
-#else
-    amrex::Real detAtA_x =
-        (Atb[0]   *AtA[1][1]) -
-        (AtA[0][1]*Atb[1]); 
-#endif
 
     // Slope at centroid of (i,j,k)
-    xs = detAtA_x / detAtA;
+    amrex::Real xs = detAtA_x / detAtA;
 
-#if (AMREX_SPACEDIM == 3)
-      amrex::Real detAtA_y =
+    amrex::Real detAtA_y =
         AtA[0][0]*(Atb[1]  * AtA[2][2] - AtA[1][2]*Atb[2]   ) -
         Atb[0] *  (AtA[1][0]*AtA[2][2] - AtA[1][2]*AtA[2][0]) +
         AtA[0][2]*(AtA[1][0]*Atb[2]    - Atb[1]   *AtA[2][0]);
-#else
-      amrex::Real detAtA_y =
-        (AtA[0][0]*Atb[1]) -
-        (Atb[0] * AtA[1][0]);
-#endif
 
-      // Slope at centroid of (i,j,k)
-      ys = detAtA_y / detAtA;
+    // Slope at centroid of (i,j,k)
+    amrex::Real ys = detAtA_y / detAtA;
 
-#if (AMREX_SPACEDIM == 3)
-      amrex::Real detAtA_z =
+    amrex::Real detAtA_z =
         AtA[0][0]*(AtA[1][1]*Atb[2]    - Atb[1]   *AtA[1][2]) -
         AtA[0][1]*(AtA[1][0]*Atb[2]    - Atb[1]   *AtA[2][0]) +
         Atb[0]   *(AtA[1][0]*AtA[2][1] - AtA[1][1]*AtA[2][0]);
 
-      zs = detAtA_z / detAtA;
-#endif
+    // Slope at centroid of (i,j,k)
+    amrex::Real zs = detAtA_z / detAtA;
 
-   return {AMREX_D_DECL(xs,ys,zs)};
+    return {xs,ys,zs};
 }
+#endif
 
 // amrex_calc_slopes_eb calculates the slope in each coordinate direction using a 
 // 1) standard 2nd order limited slope if all three cells in the stencil are regular cells
@@ -182,7 +210,12 @@ amrex_calc_slopes_eb (int i, int j, int k, int n,
                       amrex::Array4<amrex::Real const> const& ccent,
                       amrex::Array4<amrex::EBCellFlag const> const& flag) noexcept
 {
-    amrex::Real A[DIMA][AMREX_SPACEDIM];
+#if (AMREX_SPACEDIM == 2)
+    constexpr int dim_a = 9;
+#elif (AMREX_SPACEDIM == 3)
+    constexpr int dim_a = 27;
+#endif
+    amrex::Real A[dim_a][AMREX_SPACEDIM];
 
     int lc=0;
 #if (AMREX_SPACEDIM == 3)
@@ -283,6 +316,12 @@ amrex_calc_slopes_extdir_eb (int i, int j, int k, int n,
                              AMREX_D_DECL(int domlo_x, int domlo_y, int domlo_z),
                              AMREX_D_DECL(int domhi_x, int domhi_y, int domhi_z)) noexcept
 {
+#if (AMREX_SPACEDIM == 2)
+    constexpr int dim_a = 9;
+#elif (AMREX_SPACEDIM == 3)
+    constexpr int dim_a = 27;
+#endif
+
     AMREX_D_TERM(amrex::Real xslope;,
                  amrex::Real yslope;,
                  amrex::Real zslope;);
@@ -308,7 +347,7 @@ amrex_calc_slopes_extdir_eb (int i, int j, int k, int n,
 
     } else {
 
-    amrex::Real A[DIMA][AMREX_SPACEDIM];
+    amrex::Real A[dim_a][AMREX_SPACEDIM];
 
     //
     // Correct only those cells which are affected by extdir:


### PR DESCRIPTION
## Summary
This commit adds a file with the non-EB slope routines, and updates the EB-aware routines to correctly compute slopes where an EB boundary intersects an hoextrap/extdir face, e.g. inflow.  This does not assume the geometry intersects without a slant.   This has been tested in 2D and 3D (with a function f(x,y,z) = 10 + 5 x + 2 y + 3 z specified at cell centroids) and with slanted cylinders intersecting inflow in each coordinate direction.
## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
