### PR TITLE
Async IO: Check Runtime Threading

### DIFF
--- a/Src/Base/AMReX_AsyncOut.cpp
+++ b/Src/Base/AMReX_AsyncOut.cpp
@@ -41,12 +41,20 @@ void Initialize ()
     if (s_asyncout and s_noutfiles < nprocs)
     {
 #ifdef AMREX_MPI_THREAD_MULTIPLE
+        int provided = -1;
+        MPI_Query_thread(&provided);
+        if (provided < MPI_THREAD_MULTIPLE)
+            amrex::Abort("AsyncOut with " + std::to_string(s_noutfiles) + " and "
+                         +std::to_string(nprocs) + " processes requires "
+                         +"MPI_THREAD_MULTIPLE at runtime");
+
         int myproc = ParallelDescriptor::MyProc();
         s_info = GetWriteInfo(myproc);
         MPI_Comm_split(ParallelDescriptor::Communicator(), s_info.ifile, myproc, &s_comm);
 #else
         amrex::Abort("AsyncOut with " + std::to_string(s_noutfiles) + " and "
-                     +std::to_string(nprocs) + " processes requires MPI_THREAD_MULTIPLE");
+                     +std::to_string(nprocs) + " processes requires "
+                     +"AMREX_MPI_THREAD_MULTIPLE at compile time");
 #endif
     }
 

--- a/Src/Base/AMReX_AsyncOut.cpp
+++ b/Src/Base/AMReX_AsyncOut.cpp
@@ -45,8 +45,9 @@ void Initialize ()
         MPI_Query_thread(&provided);
         if (provided < MPI_THREAD_MULTIPLE)
             amrex::Abort("AsyncOut with " + std::to_string(s_noutfiles) + " and "
-                         +std::to_string(nprocs) + " processes requires "
-                         +"MPI_THREAD_MULTIPLE at runtime");
+                         + std::to_string(nprocs) + " processes requires "
+                         + "MPI_THREAD_MULTIPLE at runtime, but got "
+                         + ParallelDescriptor::mpi_level_to_string(provided));
 
         int myproc = ParallelDescriptor::MyProc();
         s_info = GetWriteInfo(myproc);

--- a/Src/Base/AMReX_AsyncOut.cpp
+++ b/Src/Base/AMReX_AsyncOut.cpp
@@ -38,9 +38,9 @@ void Initialize ()
     int nprocs = ParallelDescriptor::NProcs();
     s_noutfiles = std::min(s_noutfiles, nprocs);
 
+#ifdef AMREX_USE_MPI
     if (s_asyncout and s_noutfiles < nprocs)
     {
-#ifdef AMREX_MPI_THREAD_MULTIPLE
         int provided = -1;
         MPI_Query_thread(&provided);
         if (provided < MPI_THREAD_MULTIPLE)
@@ -51,12 +51,8 @@ void Initialize ()
         int myproc = ParallelDescriptor::MyProc();
         s_info = GetWriteInfo(myproc);
         MPI_Comm_split(ParallelDescriptor::Communicator(), s_info.ifile, myproc, &s_comm);
-#else
-        amrex::Abort("AsyncOut with " + std::to_string(s_noutfiles) + " and "
-                     +std::to_string(nprocs) + " processes requires "
-                     +"AMREX_MPI_THREAD_MULTIPLE at compile time");
-#endif
     }
+#endif
 
     if (s_asyncout) s_thread.reset(new BackgroundThread());
 

--- a/Src/Base/AMReX_ParallelDescriptor.H
+++ b/Src/Base/AMReX_ParallelDescriptor.H
@@ -565,6 +565,14 @@ while ( false )
     void IProbe(int src_pid, int tag, int &mflag, MPI_Status &status);
     void IProbe(int src_pid, int tag, MPI_Comm comm, int &mflag, MPI_Status &status);
 
+    /** Convert an MPI_THREAD_<X> level to string
+     *
+     * @param mtlev MPI_THREAD_<X> level
+     * @return string representation of the equivalent MPI macro name
+     */
+    std::string
+    mpi_level_to_string (int mtlev);
+
     // PMI = Process Management Interface, available on Crays. Provides API to
     // query topology of the job.
 #ifdef AMREX_PMI

--- a/Src/Base/AMReX_ParallelDescriptor.cpp
+++ b/Src/Base/AMReX_ParallelDescriptor.cpp
@@ -334,19 +334,7 @@ ParallelDescriptor::StartParallel (int*    argc,
 
         if (provided < requested)
         {
-            auto f = [] (int tlev) -> std::string {
-                if (tlev == MPI_THREAD_SINGLE) {
-                    return std::string("MPI_THREAD_SINGLE");
-                } else if (tlev == MPI_THREAD_FUNNELED) {
-                    return std::string("MPI_THREAD_FUNNELED");
-                } else if (tlev == MPI_THREAD_SERIALIZED) {
-                    return std::string("MPI_THREAD_SERIALIZED");
-                } else if (tlev == MPI_THREAD_MULTIPLE) {
-                    return std::string("MPI_THREAD_MULTIPLE");
-                } else {
-                    return std::string("UNKNOWN");
-                }
-            };
+            auto f = ParallelDescriptor::mpi_level_to_string;
             std::cout << "MPI provided < requested: " << f(provided) << " < "
                       << f(requested) << std::endl;;
             std::abort();
@@ -2230,6 +2218,25 @@ void
 ParallelDescriptor::EndTeams ()
 {
     m_Team.clear();
+}
+
+std::string
+ParallelDescriptor::mpi_level_to_string (int mtlev)
+{
+    switch (mtlev) {
+#ifdef AMREX_USE_MPI
+        case MPI_THREAD_SINGLE:
+            return std::string("MPI_THREAD_SINGLE");
+        case MPI_THREAD_FUNNELED:
+            return std::string("MPI_THREAD_FUNNELED");
+        case MPI_THREAD_SERIALIZED:
+            return std::string("MPI_THREAD_SERIALIZED");
+        case MPI_THREAD_MULTIPLE:
+            return std::string("MPI_THREAD_MULTIPLE");
+#endif
+        default:
+            return std::string("UNKNOWN");
+    }
 }
 
 #ifdef BL_USE_MPI


### PR DESCRIPTION
##  Summary

Even if `AMREX_MPI_THREAD_MULTIPLE` is defined at compile time, applications might provide their own MPI init routines and/or MPI implementations, runtime arguments or environment arguments can influence the actually provided MPI thread safety level at runtime.

Therefore, we need to check the MPI thread safety level again at runtime where we require a certain minimum.

## Additional background

WarpX PR: https://github.com/ECP-WarpX/WarpX/pull/1298

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
