### PR TITLE
Fallthrough: ICC Warning

### DIFF
--- a/Src/Base/AMReX_Extension.H
+++ b/Src/Base/AMReX_Extension.H
@@ -142,7 +142,7 @@
 #define AMREX_FALLTHROUGH [[fallthrough]]
 #elif defined(__clang__)
 #define AMREX_FALLTHROUGH [[clang::fallthrough]]
-#elif defined(__GNUC__) && (__GNUC__ >= 7)
+#elif defined(__GNUC__) && (__GNUC__ >= 7) && !defined(__INTEL_COMPILER)
 #define AMREX_FALLTHROUGH [[gnu::fallthrough]]
 #else
 #define AMREX_FALLTHROUGH ((void)0)


### PR DESCRIPTION
## Summary

`gnu::fallthrough` is not defined with ICC 20.2.1.20200602 and throws a warning at compile-time in ParamsParse.

## Additional background

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
