### PR TITLE
Roundoff domain bugfixes

### DIFF
--- a/Src/Base/AMReX_Geometry.H
+++ b/Src/Base/AMReX_Geometry.H
@@ -110,7 +110,6 @@ public:
     void ProbDomain (const RealBox& rb) noexcept
     {
         prob_domain = rb;
-        SetOffset(rb.lo());
         computeRoundoffDomain();
     }
     //! Returns the lo end of the problem domain in each dimension.
@@ -140,7 +139,11 @@ public:
     //! Returns our rectangular domain.
     const Box& Domain () const noexcept { return domain; }
     //! Sets our rectangular domain.
-    void Domain (const Box& bx) noexcept { domain = bx; }
+    void Domain (const Box& bx) noexcept
+    {
+        domain = bx;
+        computeRoundoffDomain();
+    }
     //! Define a multifab of areas and volumes with given grow factor.
     void GetVolume (MultiFab&       vol,
                     const BoxArray& grds,

--- a/Src/Base/AMReX_Geometry.cpp
+++ b/Src/Base/AMReX_Geometry.cpp
@@ -103,13 +103,6 @@ Geometry::define (const Box& dom, const RealBox* rb, int coord,
     domain = dom;
     ok     = true;
 
-    for (int k = 0; k < AMREX_SPACEDIM; k++)
-    {
-        offset[k] = prob_domain.lo(k);
-        dx[k] = prob_domain.length(k)/(Real(domain.length(k)));
-	inv_dx[k] = 1.0/dx[k];
-    }
-
     computeRoundoffDomain();
 }
 
@@ -403,6 +396,13 @@ Geometry::growPeriodicDomain (int ngrow) const noexcept
 void
 Geometry::computeRoundoffDomain ()
 {
+    for (int k = 0; k < AMREX_SPACEDIM; k++)
+    {
+        offset[k] = prob_domain.lo(k);
+        dx[k] = prob_domain.length(k)/(Real(domain.length(k)));
+        inv_dx[k] = 1.0/dx[k];
+    }
+
     roundoff_domain = prob_domain;
     for (int idim = 0; idim < AMREX_SPACEDIM; ++idim)
     {


### PR DESCRIPTION
This fixes two bugs. We now:

1) Always recompute offset, dx, and inv_dx whenever the roundoff domain is computed, to make sure it is up-to-date.
2) Recompute the roundoff domain when Domain() is changed, as well as ProbDomain().

MFIX triggered these because it sometimes grows the ProbDomain(), and only later changes the Domain().

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
