### PR TITLE
amrex::EB_average_down(): Fix indexing error.

### DIFF
--- a/Src/EB/AMReX_EBMultiFabUtil.cpp
+++ b/Src/EB/AMReX_EBMultiFabUtil.cpp
@@ -482,7 +482,7 @@ EB_average_down (const MultiFab& S_fine, MultiFab& S_crse, int scomp, int ncomp,
                     Array4<Real const> const& vfrc = vfrac_fine.const_array(mfi);
                     AMREX_HOST_DEVICE_FOR_3D(tbx, i, j, k,
                     {
-                        eb_avgdown(i,j,k,fine_arr,scomp,crse_arr,scomp,vfrc,dratio,ncomp);
+                        eb_avgdown(i,j,k,fine_arr,scomp,crse_arr,0,vfrc,dratio,ncomp);
                     });
                 }
                 else


### PR DESCRIPTION
## Summary
Fix indexing error in EB_average_down.

## Additional background

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
