### PR TITLE
CMake: enable testing via CTest.

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -234,3 +234,23 @@ jobs:
         ./configure --dim 3 --enable-eb yes --enable-xsdk-defaults yes --with-omp yes --debug yes
         make -j2 WARN_ALL=TRUE WARN_ERROR=TRUE
         make install
+
+  # Build libamrex and run all tests
+  tests:
+    name: GNU@7.5 C++14 [tests]
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Dependencies
+      run: .github/workflows/dependencies/dependencies.sh
+    - name: Build & Install
+      run: |
+        mkdir build
+        cd build
+        cmake ..                        \
+            -DENABLE_OMP=ON             \
+            -DCMAKE_VERBOSE_MAKEFILE=ON \
+            -DAMReX_ENABLE_TESTS=ON     \
+            -DENABLE_PARTICLES=ON
+        make -j 2
+        ctest --output-on-failure

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -255,4 +255,5 @@ jobs:
         make -j 2
     - name: Run tests
       run: |
+        cd build
         ctest --output-on-failure -R

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -253,4 +253,6 @@ jobs:
             -DAMReX_ENABLE_TESTS=ON     \
             -DENABLE_PARTICLES=ON
         make -j 2
+    - name: Run tests
+      run: |
         ctest --output-on-failure

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -255,4 +255,4 @@ jobs:
         make -j 2
     - name: Run tests
       run: |
-        ctest --output-on-failure
+        ctest --output-on-failure -R

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,3 +159,13 @@ if (ENABLE_PLOTFILE_TOOLS)
    # because it needs to get installed
    add_subdirectory(Tools/Plotfile)
 endif ()
+
+
+#
+# Enable CTests
+#
+option(AMReX_ENABLE_TESTS "Enable CTest suite for AMReX"  NO)
+if (AMReX_ENABLE_TESTS)
+   enable_testing()
+   add_subdirectory(Tests)
+endif ()

--- a/Tests/Algoim/CMakeLists.txt
+++ b/Tests/Algoim/CMakeLists.txt
@@ -1,0 +1,11 @@
+if (NOT ENABLE_EB)
+   return()
+endif ()
+
+set(_sources     main.cpp)
+set(_input_files )
+
+setup_test(_sources _input_files)
+
+unset(_sources)
+unset(_input_files)

--- a/Tests/AsyncOut/multifab/CMakeLists.txt
+++ b/Tests/AsyncOut/multifab/CMakeLists.txt
@@ -1,0 +1,7 @@
+set(_sources     main.cpp)
+set(_input_files inputs  )
+
+setup_test(_sources _input_files)
+
+unset(_sources)
+unset(_input_files)

--- a/Tests/BBIOBenchmark/CMakeLists.txt
+++ b/Tests/BBIOBenchmark/CMakeLists.txt
@@ -1,0 +1,7 @@
+set(_sources     BBIOTest.cpp BBIOTestDriver.cpp )
+set(_input_files )
+
+setup_test(_sources _input_files)
+
+unset(_sources)
+unset(_input_files)

--- a/Tests/BaseFabTesting/CMakeLists.txt
+++ b/Tests/BaseFabTesting/CMakeLists.txt
@@ -1,0 +1,7 @@
+set(_sources     main.cpp)
+set(_input_files inputs  )
+
+setup_test(_sources _input_files)
+
+unset(_sources)
+unset(_input_files)

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -61,7 +61,7 @@ function (setup_test _srcs  _inputs)
       set(_exe_dir ${CMAKE_CURRENT_BINARY_DIR})
    endif ()
 
-   set( _exe_name  ${_base_name} )
+   set( _exe_name  Test_${_base_name} )
    set( _test_name ${_base_name} )
 
    add_executable( ${_exe_name} )
@@ -99,7 +99,7 @@ function (setup_test _srcs  _inputs)
    #
    # Assemble the commands sequence to launch the test
    #
-   set(_cmd ${_test_name})
+   set(_cmd ${_exe_name})
 
    if (_CMDLINE_PARAMS)
       list(APPEND _cmd ${_CMDLINE_PARAMS})

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -1,38 +1,16 @@
 #
 # List of subdirectories to search for CMakeLists.
 #
-# CUrrently missing C_BaseLib, GPU, IOBENCHMARK
 set( AMREX_TESTS_SUBDIRS
-   AsyncOut BaseFabTesting BBIOBenchmark complementIn FillBoundaryComparison
-    )
+   AsyncOut
+   BaseFabTesting
+   BBIOBenchmark
+   FillBoundaryComparison
+   )
 
-# if (ENABLE_ASCENT)
-#    list(APPEND AMREX_TESTS_SUBDIRS Blueprint)
-# endif ()
-
-# if (ENABLE_EB)
-#    list(APPEND AMREX_TESTS_SUBDIRS Algoim)
-# endif ()
-
-# if (ENABLE_LINEAR_SOLVERS)
-#    list(APPEND AMREX_TESTS_SUBDIRS LinearSolvers)
-# endif ()
-
-# if (ENABLE_PARTICLES)
-#    list(APPEND AMREX_TESTS_SUBDIRS Particles HDF5Benchmark)
-# endif ()
-
-# if (ENABLE_SUNDIALS)
-#    list(APPEND AMREX_TESTS_SUBDIRS CVODE SUNDIALS)
-# endif ()
-
-# if (ENABLE_FORTRAN_INTERFACES)
-#    list(APPEND AMREX_TESTS_SUBDIRS FortranInterface)
-# endif ()
-
-# if (ENABLE_CUDA)
-#    list(APPEND AMREX_TESTS_SUBDIRS GPU)
-# endif ()
+if (ENABLE_PARTICLES)
+   list(APPEND AMREX_TESTS_SUBDIRS Particles)
+endif ()
 
 if (ENABLE_AMRDATA)
    list(APPEND AMREX_TESTS_SUBDIRS DataServicesTest0)

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -99,15 +99,15 @@ function (setup_test _srcs  _inputs)
    #
    # Assemble the commands sequence to launch the test
    #
-   set(_cmd ${_exe_name})
+   set(_cmd ${_test_name})
 
    if (_CMDLINE_PARAMS)
-      set(_cmd "${_cmd} ${_CMDLINE_PARAMS}")
+      list(APPEND _cmd ${_CMDLINE_PARAMS})
    endif ()
 
    if (${_inputs})
       file( COPY ${${_inputs}} DESTINATION ${_exe_dir} )
-      set(_cmd "${_cmd} ${${_inputs}}")
+      list(APPEND _cmd ${${_inputs}})
    endif ()
 
    #

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -24,7 +24,7 @@ list(TRANSFORM AMREX_TESTS_SUBDIRS PREPEND "${CMAKE_CURRENT_LIST_DIR}/")
 function (setup_test _srcs  _inputs)
 
    cmake_parse_arguments( "" "HAS_FORTRAN_MODULES"
-      "BASE_NAME;RUNTIME_SUBDIR;EXTRA_DEFINITIONS;CMDLINE_PARAMS" "" ${ARGN} )
+      "BASE_NAME;RUNTIME_SUBDIR;EXTRA_DEFINITIONS;CMDLINE_PARAMS;NTASKS;NTHREADS" "" ${ARGN} )
 
    if (_BASE_NAME)
       set(_base_name ${_BASE_NAME})
@@ -77,7 +77,7 @@ function (setup_test _srcs  _inputs)
    #
    # Assemble the commands sequence to launch the test
    #
-   set(_cmd ${_exe_name})
+   set(_cmd ${_exe_dir}/${_exe_name})
 
    if (_CMDLINE_PARAMS)
       list(APPEND _cmd ${_CMDLINE_PARAMS})
@@ -96,6 +96,37 @@ function (setup_test _srcs  _inputs)
       COMMAND            ${_cmd}
       WORKING_DIRECTORY  ${_exe_dir}
       )
+
+   #
+   # Add MPI test
+   #
+   if (ENABLE_MPI AND _NTASKS)
+      if (_NTASKS GREATER 2)
+         message(FATAL_ERROR "\nsetup_tests(): number of MPI tasks exceeds CI limit of 2")
+      endif ()
+
+      add_test(
+         NAME               ${_test_name}_MPI
+         COMMAND            mpiexec -n ${_NTASKS} ${_cmd}
+         WORKING_DIRECTORY  ${_exe_dir}
+         )
+
+      set_tests_properties(${_test_name}_MPI PROPERTIES ENVIRONMENT OMP_NUM_THREADS=1 )
+   endif ()
+
+   if (ENABLE_OMP AND _NTHREADS)
+      if (_NTHREADS GREATER 2)
+         message(FATAL_ERROR "\nsetup_tests(): number of OpenMP threads exceeds CI limit of 2")
+      endif ()
+
+      add_test(
+         NAME               ${_test_name}_OpenMP
+         COMMAND            ${_cmd}
+         WORKING_DIRECTORY  ${_exe_dir}
+         )
+
+      set_tests_properties(${_test_name}_OpenMP PROPERTIES ENVIRONMENT OMP_NUM_THREADS=${_NTHREADS} )
+   endif ()
 
 endfunction ()
 

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -38,7 +38,7 @@ set( AMREX_TESTS_SUBDIRS )
 #
 macro (setup_test _sources  _input_files)
 
-   cmake_parse_arguments( "" "HAS_FORTRAN_MODULES" "BASE_NAME;RUNTIME_SUBDIR;EXTRA_DEFINITIONS" "" ${ARGN} )
+   cmake_parse_arguments( "" "HAS_FORTRAN_MODULES" "BASE_NAME;RUNTIME_SUBDIR;EXTRA_DEFINITIONS;CMDLINE_PARAMS" "" ${ARGN} )
 
    if (_BASE_NAME)
       set(_base_name ${_BASE_NAME})
@@ -97,9 +97,14 @@ macro (setup_test _sources  _input_files)
       file( COPY ${${_input_files}} DESTINATION ${_exe_dir} )
    endif ()
 
+   set(_extra_args)
+   if (_CMDLINE_PARAMS)
+      set(_extra_args ${_CMDLINE_PARAMS})
+   endif ()
+
    add_test(
       NAME                 ${_test_name}
-      COMMAND              ${_exe_name} ${${_input_files}}
+      COMMAND              ${_exe_name} ${_extra_args} ${${_input_files}}
       WORKING_DIRECTORY    ${_exe_dir}
       )
 
@@ -107,6 +112,7 @@ macro (setup_test _sources  _input_files)
    unset(_test_name)
    unset(_exe_name)
    unset(_exe_dir)
+   unset(_extra_args)
 
 endmacro ()
 

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -1,37 +1,44 @@
 #
 # List of subdirectories to search for CMakeLists.
 #
-set( AMREX_TESTS_SUBDIRS )
+# CUrrently missing C_BaseLib, GPU, IOBENCHMARK
+set( AMREX_TESTS_SUBDIRS
+   AsyncOut BaseFabTesting BBIOBenchmark complementIn FillBoundaryComparison
+    )
 
 # if (ENABLE_ASCENT)
-#    list(APPEND AMREX_TUTORIALS_SUBDIRS Blueprint)
+#    list(APPEND AMREX_TESTS_SUBDIRS Blueprint)
 # endif ()
 
 # if (ENABLE_EB)
-#    list(APPEND AMREX_TUTORIALS_SUBDIRS EB)
+#    list(APPEND AMREX_TESTS_SUBDIRS Algoim)
 # endif ()
 
 # if (ENABLE_LINEAR_SOLVERS)
-#    list(APPEND AMREX_TUTORIALS_SUBDIRS LinearSolvers)
+#    list(APPEND AMREX_TESTS_SUBDIRS LinearSolvers)
 # endif ()
 
 # if (ENABLE_PARTICLES)
-#    list(APPEND AMREX_TUTORIALS_SUBDIRS Particles)
+#    list(APPEND AMREX_TESTS_SUBDIRS Particles HDF5Benchmark)
 # endif ()
 
 # if (ENABLE_SUNDIALS)
-#    list(APPEND AMREX_TUTORIALS_SUBDIRS CVODE SUNDIALS)
+#    list(APPEND AMREX_TESTS_SUBDIRS CVODE SUNDIALS)
 # endif ()
 
 # if (ENABLE_FORTRAN_INTERFACES)
-#    list(APPEND AMREX_TUTORIALS_SUBDIRS FortranInterface)
+#    list(APPEND AMREX_TESTS_SUBDIRS FortranInterface)
 # endif ()
 
 # if (ENABLE_CUDA)
-#    list(APPEND AMREX_TUTORIALS_SUBDIRS GPU)
+#    list(APPEND AMREX_TESTS_SUBDIRS GPU)
 # endif ()
 
-#list(TRANSFORM AMREX_TUTORIALS_SUBDIRS PREPEND "${CMAKE_CURRENT_LIST_DIR}/")
+if (ENABLE_AMRDATA)
+   list(APPEND AMREX_TESTS_SUBDIRS DataServicesTest0)
+endif ()
+
+list(TRANSFORM AMREX_TESTS_SUBDIRS PREPEND "${CMAKE_CURRENT_LIST_DIR}/")
 
 #
 # Function to setup the tutorials
@@ -107,9 +114,9 @@ function (setup_test _srcs  _inputs)
    # Add the test
    #
    add_test(
-      NAME                 ${_test_name}
-      COMMAND              ${_cmd}
-      WORKING_DIRECTORY    ${_exe_dir}
+      NAME               ${_test_name}
+      COMMAND            ${_cmd}
+      WORKING_DIRECTORY  ${_exe_dir}
       )
 
 endfunction ()
@@ -118,15 +125,13 @@ endfunction ()
 #
 # Loop over subdirs and add to the build those containing CMakeLists.txt
 #
-#foreach (_subdir IN LISTS AMREX_TUTORIALS_SUBDIRS)
+foreach (_subdir IN LISTS AMREX_TESTS_SUBDIRS)
 
-   # file( GLOB_RECURSE _tutorials "${_subdir}/*CMakeLists.txt" )
-   file( GLOB_RECURSE _tests "${CMAKE_CURRENT_LIST_DIR}/*CMakeLists.txt" )
-   list(REMOVE_ITEM _tests ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt)
-   print_list(_tests)
+   file( GLOB_RECURSE _tests "${_subdir}/*CMakeLists.txt" )
+
    foreach ( _item  IN LISTS _tests)
       get_filename_component(_dir ${_item} DIRECTORY )
       add_subdirectory(${_dir})
    endforeach ()
 
-#endforeach ()
+endforeach ()

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -34,15 +34,15 @@ set( AMREX_TESTS_SUBDIRS )
 #list(TRANSFORM AMREX_TUTORIALS_SUBDIRS PREPEND "${CMAKE_CURRENT_LIST_DIR}/")
 
 #
-# Macro to setup the tutorials
+# Function to setup the tutorials
 #
-macro (setup_test _sources  _input_files)
+function (setup_test _srcs  _inputs)
 
-   cmake_parse_arguments( "" "HAS_FORTRAN_MODULES" "BASE_NAME;RUNTIME_SUBDIR;EXTRA_DEFINITIONS;CMDLINE_PARAMS" "" ${ARGN} )
+   cmake_parse_arguments( "" "HAS_FORTRAN_MODULES"
+      "BASE_NAME;RUNTIME_SUBDIR;EXTRA_DEFINITIONS;CMDLINE_PARAMS" "" ${ARGN} )
 
    if (_BASE_NAME)
       set(_base_name ${_BASE_NAME})
-      unset(_BASE_NAME)
    else ()
       string(REGEX REPLACE ".*Tests/" "" _base_name ${CMAKE_CURRENT_LIST_DIR})
       string(REPLACE "/" "_" _base_name ${_base_name})
@@ -50,7 +50,6 @@ macro (setup_test _sources  _input_files)
 
    if (_RUNTIME_SUBDIR)
       set(_exe_dir ${CMAKE_CURRENT_BINARY_DIR}/${_RUNTIME_SUBDIR})
-      unset(_RUNTIME_SUBDIR)
    else ()
       set(_exe_dir ${CMAKE_CURRENT_BINARY_DIR})
    endif ()
@@ -59,22 +58,20 @@ macro (setup_test _sources  _input_files)
    set( _test_name ${_base_name} )
 
    add_executable( ${_exe_name} )
-   target_sources( ${_exe_name} PRIVATE ${${_sources}} )
+   target_sources( ${_exe_name} PRIVATE ${${_srcs}} )
    set_target_properties( ${_exe_name} PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${_exe_dir} )
 
    if (_EXTRA_DEFINITIONS)
       target_compile_definitions(${_exe_name} PRIVATE ${_EXTRA_DEFINITIONS})
-      unset(_EXTRA_DEFINITIONS)
    endif ()
 
    # Find out which include directory is needed
-   set(_includes ${${_sources}})
+   set(_includes ${${_srcs}})
    list(FILTER _includes INCLUDE REGEX "\\.H")
    foreach(_item IN LISTS _includes)
-      get_filename_component( _include_dir ${_item} DIRECTORY)
+      get_filename_component( _include_dir ${_item} DIRECTORY )
       target_include_directories( ${_exe_name} PRIVATE  ${_include_dir} )
    endforeach()
-   unset(_includes)
 
    if (_HAS_FORTRAN_MODULES)
       target_include_directories(${_exe_name}
@@ -84,7 +81,6 @@ macro (setup_test _sources  _input_files)
          PROPERTIES
          Fortran_MODULE_DIRECTORY
          ${CMAKE_CURRENT_BINARY_DIR}/mod_files )
-      unset(_HAS_FORTRAN_MODULES)
    endif ()
 
    target_link_libraries( ${_exe_name} amrex )
@@ -93,28 +89,30 @@ macro (setup_test _sources  _input_files)
       setup_target_for_cuda_compilation( ${_exe_name} )
    endif ()
 
-   if (${_input_files})
-      file( COPY ${${_input_files}} DESTINATION ${_exe_dir} )
-   endif ()
+   #
+   # Assemble the commands sequence to launch the test
+   #
+   set(_cmd ${_exe_name})
 
-   set(_extra_args)
    if (_CMDLINE_PARAMS)
-      set(_extra_args ${_CMDLINE_PARAMS})
+      set(_cmd "${_cmd} ${_CMDLINE_PARAMS}")
    endif ()
 
+   if (${_inputs})
+      file( COPY ${${_inputs}} DESTINATION ${_exe_dir} )
+      set(_cmd "${_cmd} ${${_inputs}}")
+   endif ()
+
+   #
+   # Add the test
+   #
    add_test(
       NAME                 ${_test_name}
-      COMMAND              ${_exe_name} ${_extra_args} ${${_input_files}}
+      COMMAND              ${_cmd}
       WORKING_DIRECTORY    ${_exe_dir}
       )
 
-   unset(_base_name)
-   unset(_test_name)
-   unset(_exe_name)
-   unset(_exe_dir)
-   unset(_extra_args)
-
-endmacro ()
+endfunction ()
 
 
 #

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -1,19 +1,10 @@
 #
 # List of subdirectories to search for CMakeLists.
 #
-set( AMREX_TESTS_SUBDIRS
-   AsyncOut
-   BaseFabTesting
-   BBIOBenchmark
-   FillBoundaryComparison
-   )
+set( AMREX_TESTS_SUBDIRS AsyncOut )
 
 if (ENABLE_PARTICLES)
    list(APPEND AMREX_TESTS_SUBDIRS Particles)
-endif ()
-
-if (ENABLE_AMRDATA)
-   list(APPEND AMREX_TESTS_SUBDIRS DataServicesTest0)
 endif ()
 
 list(TRANSFORM AMREX_TESTS_SUBDIRS PREPEND "${CMAKE_CURRENT_LIST_DIR}/")

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -1,0 +1,128 @@
+#
+# List of subdirectories to search for CMakeLists.
+#
+set( AMREX_TESTS_SUBDIRS )
+
+# if (ENABLE_ASCENT)
+#    list(APPEND AMREX_TUTORIALS_SUBDIRS Blueprint)
+# endif ()
+
+# if (ENABLE_EB)
+#    list(APPEND AMREX_TUTORIALS_SUBDIRS EB)
+# endif ()
+
+# if (ENABLE_LINEAR_SOLVERS)
+#    list(APPEND AMREX_TUTORIALS_SUBDIRS LinearSolvers)
+# endif ()
+
+# if (ENABLE_PARTICLES)
+#    list(APPEND AMREX_TUTORIALS_SUBDIRS Particles)
+# endif ()
+
+# if (ENABLE_SUNDIALS)
+#    list(APPEND AMREX_TUTORIALS_SUBDIRS CVODE SUNDIALS)
+# endif ()
+
+# if (ENABLE_FORTRAN_INTERFACES)
+#    list(APPEND AMREX_TUTORIALS_SUBDIRS FortranInterface)
+# endif ()
+
+# if (ENABLE_CUDA)
+#    list(APPEND AMREX_TUTORIALS_SUBDIRS GPU)
+# endif ()
+
+#list(TRANSFORM AMREX_TUTORIALS_SUBDIRS PREPEND "${CMAKE_CURRENT_LIST_DIR}/")
+
+#
+# Macro to setup the tutorials
+#
+macro (setup_test _sources  _input_files)
+
+   cmake_parse_arguments( "" "HAS_FORTRAN_MODULES" "BASE_NAME;RUNTIME_SUBDIR;EXTRA_DEFINITIONS" "" ${ARGN} )
+
+   if (_BASE_NAME)
+      set(_base_name ${_BASE_NAME})
+      unset(_BASE_NAME)
+   else ()
+      string(REGEX REPLACE ".*Tests/" "" _base_name ${CMAKE_CURRENT_LIST_DIR})
+      string(REPLACE "/" "_" _base_name ${_base_name})
+   endif()
+
+   if (_RUNTIME_SUBDIR)
+      set(_exe_dir ${CMAKE_CURRENT_BINARY_DIR}/${_RUNTIME_SUBDIR})
+      unset(_RUNTIME_SUBDIR)
+   else ()
+      set(_exe_dir ${CMAKE_CURRENT_BINARY_DIR})
+   endif ()
+
+   set( _exe_name  ${_base_name} )
+   set( _test_name ${_base_name} )
+
+   add_executable( ${_exe_name} )
+   target_sources( ${_exe_name} PRIVATE ${${_sources}} )
+   set_target_properties( ${_exe_name} PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${_exe_dir} )
+
+   if (_EXTRA_DEFINITIONS)
+      target_compile_definitions(${_exe_name} PRIVATE ${_EXTRA_DEFINITIONS})
+      unset(_EXTRA_DEFINITIONS)
+   endif ()
+
+   # Find out which include directory is needed
+   set(_includes ${${_sources}})
+   list(FILTER _includes INCLUDE REGEX "\\.H")
+   foreach(_item IN LISTS _includes)
+      get_filename_component( _include_dir ${_item} DIRECTORY)
+      target_include_directories( ${_exe_name} PRIVATE  ${_include_dir} )
+   endforeach()
+   unset(_includes)
+
+   if (_HAS_FORTRAN_MODULES)
+      target_include_directories(${_exe_name}
+         PRIVATE
+         ${CMAKE_CURRENT_BINARY_DIR}/mod_files)
+      set_target_properties( ${_exe_name}
+         PROPERTIES
+         Fortran_MODULE_DIRECTORY
+         ${CMAKE_CURRENT_BINARY_DIR}/mod_files )
+      unset(_HAS_FORTRAN_MODULES)
+   endif ()
+
+   target_link_libraries( ${_exe_name} amrex )
+
+   if (ENABLE_CUDA)
+      setup_target_for_cuda_compilation( ${_exe_name} )
+   endif ()
+
+   if (${_input_files})
+      file( COPY ${${_input_files}} DESTINATION ${_exe_dir} )
+   endif ()
+
+   add_test(
+      NAME                 ${_test_name}
+      COMMAND              ${_exe_name} ${${_input_files}}
+      WORKING_DIRECTORY    ${_exe_dir}
+      )
+
+   unset(_base_name)
+   unset(_test_name)
+   unset(_exe_name)
+   unset(_exe_dir)
+
+endmacro ()
+
+
+#
+# Loop over subdirs and add to the build those containing CMakeLists.txt
+#
+#foreach (_subdir IN LISTS AMREX_TUTORIALS_SUBDIRS)
+
+   # file( GLOB_RECURSE _tutorials "${_subdir}/*CMakeLists.txt" )
+   file( GLOB_RECURSE _tests "${CMAKE_CURRENT_LIST_DIR}/*CMakeLists.txt" )
+   list(REMOVE_ITEM _tests ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt)
+   print_list(_tests)
+   foreach ( _item  IN LISTS _tests)
+      get_filename_component(_dir ${_item} DIRECTORY )
+      add_subdirectory(${_dir})
+   endforeach ()
+
+#endforeach ()

--- a/Tests/C_BaseLib/CMakeLists.txt
+++ b/Tests/C_BaseLib/CMakeLists.txt
@@ -1,0 +1,21 @@
+
+#
+# Disabled for NOW
+#
+return()
+
+
+if (NOT CMAKE_Fortran_COMPILER_LOADED)
+   return()
+endif ()
+
+set(_sources AMRProfTestBL.cpp tBA.cpp tDM.cpp tFillFab.cpp tParmParse.cpp  TPROFILER_F.H  tread.cpp  tVisMF.cpp )
+list(APPEND _sources AMRPROFTEST_F.H  tCArena.cpp  tFAC.cpp tMFcopy.cpp  tProfiler.cpp tRABcast.cpp tUMap.cpp    )
+list(APPEND _sources fillfab.f  t8BIT.cpp tDir.cpp tFB.cpp  tMF.cpp TPROFILER.F tRan.cpp tVisMF2.cpp )
+
+set(_input_files )
+
+setup_test(_sources _input_files)
+
+unset(_sources)
+unset(_input_files)

--- a/Tests/DataServicesTest0/CMakeLists.txt
+++ b/Tests/DataServicesTest0/CMakeLists.txt
@@ -1,7 +1,3 @@
-if (NOT ENABLE_AMRDATA)
-   return()
-endif ()
-
 set(_sources     DataServicesTest0.cpp)
 set(_input_files )
 

--- a/Tests/DataServicesTest0/CMakeLists.txt
+++ b/Tests/DataServicesTest0/CMakeLists.txt
@@ -1,0 +1,11 @@
+if (NOT ENABLE_AMRDATA)
+   return()
+endif ()
+
+set(_sources     DataServicesTest0.cpp)
+set(_input_files )
+
+setup_test(_sources _input_files)
+
+unset(_sources)
+unset(_input_files)

--- a/Tests/FillBoundaryComparison/CMakeLists.txt
+++ b/Tests/FillBoundaryComparison/CMakeLists.txt
@@ -1,0 +1,7 @@
+set(_sources     main.cpp)
+set(_input_files ba.max)
+
+setup_test(_sources _input_files)
+
+unset(_sources)
+unset(_input_files)

--- a/Tests/FillBoundaryComparison/CMakeLists.txt
+++ b/Tests/FillBoundaryComparison/CMakeLists.txt
@@ -1,7 +1,7 @@
 set(_sources     main.cpp)
 set(_input_files ba.max)
 
-setup_test(_sources _input_files)
+setup_test(_sources _input_files CMDLINE_PARAMS nrounds=1)
 
 unset(_sources)
 unset(_input_files)

--- a/Tests/Particles/NeighborParticles/CMakeLists.txt
+++ b/Tests/Particles/NeighborParticles/CMakeLists.txt
@@ -2,7 +2,7 @@ set(_sources CheckPair.H Constants.H main.cpp  MDParticleContainer.cpp MDParticl
 
 set(_input_files inputs  )
 
-setup_test(_sources _input_files)
+setup_test(_sources _input_files NTASKS 2)
 
 unset(_sources)
 unset(_input_files)

--- a/Tests/Particles/ParticleMesh/CMakeLists.txt
+++ b/Tests/Particles/ParticleMesh/CMakeLists.txt
@@ -1,5 +1,4 @@
-set(_sources CheckPair.H Constants.H main.cpp  MDParticleContainer.cpp MDParticleContainer.H )
-
+set(_sources     main.cpp)
 set(_input_files inputs  )
 
 setup_test(_sources _input_files)

--- a/Tests/Particles/ParticleReduce/CMakeLists.txt
+++ b/Tests/Particles/ParticleReduce/CMakeLists.txt
@@ -1,7 +1,7 @@
 set(_sources     main.cpp)
 set(_input_files inputs  )
 
-setup_test(_sources _input_files)
+setup_test(_sources _input_files NTHREADS 2)
 
 unset(_sources)
 unset(_input_files)

--- a/Tests/Particles/ParticleReduce/CMakeLists.txt
+++ b/Tests/Particles/ParticleReduce/CMakeLists.txt
@@ -1,5 +1,4 @@
-set(_sources CheckPair.H Constants.H main.cpp  MDParticleContainer.cpp MDParticleContainer.H )
-
+set(_sources     main.cpp)
 set(_input_files inputs  )
 
 setup_test(_sources _input_files)

--- a/Tests/Particles/ParticleTransformations/CMakeLists.txt
+++ b/Tests/Particles/ParticleTransformations/CMakeLists.txt
@@ -1,5 +1,4 @@
-set(_sources CheckPair.H Constants.H main.cpp  MDParticleContainer.cpp MDParticleContainer.H )
-
+set(_sources     main.cpp)
 set(_input_files inputs  )
 
 setup_test(_sources _input_files)

--- a/Tests/Particles/Redistribute/CMakeLists.txt
+++ b/Tests/Particles/Redistribute/CMakeLists.txt
@@ -1,0 +1,7 @@
+set(_sources     main.cpp)
+set(_input_files inputs.rt  )  # There are others but we use only this one for now
+
+setup_test(_sources _input_files)
+
+unset(_sources)
+unset(_input_files)

--- a/Tests/Particles/Redistribute/CMakeLists.txt
+++ b/Tests/Particles/Redistribute/CMakeLists.txt
@@ -1,7 +1,7 @@
 set(_sources     main.cpp)
 set(_input_files inputs.rt  )  # There are others but we use only this one for now
 
-setup_test(_sources _input_files)
+setup_test(_sources _input_files NTASKS 2)
 
 unset(_sources)
 unset(_input_files)

--- a/Tests/complementIn/CMakeLists.txt
+++ b/Tests/complementIn/CMakeLists.txt
@@ -1,0 +1,7 @@
+set(_sources     main.cpp)
+set(_input_files )
+
+setup_test(_sources _input_files)
+
+unset(_sources)
+unset(_input_files)


### PR DESCRIPTION
## Summary
Implement testing capability in the CMake.

## Additional background
This covers the basic tests only. Once the Tests directory is refactored, more tests can be added.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
