### PR TITLE
Random Number Generation on Device

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -166,6 +166,7 @@ jobs:
       run: |
         set +e
         source /opt/intel/oneapi/setvars.sh
+        source /opt/intel/oneapi/mkl/latest/env/vars.sh
         set -e
         mkdir build
         cd build

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -166,7 +166,7 @@ jobs:
       run: |
         set +e
         source /opt/intel/oneapi/setvars.sh
-        source /opt/intel/oneapi/mkl/latest/env/vars.sh
+        source /opt/intel/oneapi/mkl/env/vars.sh
         set -e
         mkdir build
         cd build

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -166,7 +166,6 @@ jobs:
       run: |
         set +e
         source /opt/intel/oneapi/setvars.sh
-        source /opt/intel/oneapi/mkl/env/vars.sh
         set -e
         mkdir build
         cd build

--- a/Src/Base/AMReX_Extension.H
+++ b/Src/Base/AMReX_Extension.H
@@ -148,7 +148,14 @@
 #define AMREX_FALLTHROUGH ((void)0)
 #endif
 
-
 #endif /* !BL_LANG_FORT */
 
 #endif
+
+/*
+ * DPCPP version strings
+ * beta8 #define __SYCL_COMPILER_VERSION=20200715
+ * beta9 #define __SYCL_COMPILER_VERSION 20200827
+ *       #define __INTEL_CLANG_COMPILER 202110
+ *       #define __INTEL_LLVM_COMPILER  202110
+*/

--- a/Src/Base/AMReX_GpuDevice.H
+++ b/Src/Base/AMReX_GpuDevice.H
@@ -120,7 +120,7 @@ public:
 #ifdef AMREX_USE_GPU
     static constexpr int warp_size = AMREX_HIP_OR_CUDA_OR_DPCPP(64,32,16);
 
-    static int maxBlocksPerLaunch () noexcept { return max_blocks_per_launch; }
+    static unsigned int maxBlocksPerLaunch () noexcept { return max_blocks_per_launch; }
 
 #ifdef AMREX_USE_DPCPP
     static Long maxMemAllocSize () noexcept { return device_prop.maxMemAllocSize; }
@@ -153,7 +153,7 @@ private:
     static gpuStream_t gpu_default_stream;
     static Vector<gpuStream_t> gpu_stream;
     static gpuDeviceProp_t device_prop;
-    static int max_blocks_per_launch;
+    static unsigned int max_blocks_per_launch;
 
 #ifdef AMREX_USE_DPCPP
     static std::unique_ptr<sycl::context> sycl_context;

--- a/Src/Base/AMReX_GpuDevice.cpp
+++ b/Src/Base/AMReX_GpuDevice.cpp
@@ -54,7 +54,7 @@ constexpr int Device::max_gpu_streams;
 dim3 Device::numThreadsMin      = dim3(1, 1, 1);
 dim3 Device::numThreadsOverride = dim3(0, 0, 0);
 dim3 Device::numBlocksOverride  = dim3(0, 0, 0);
-int  Device::max_blocks_per_launch = 640;
+unsigned int Device::max_blocks_per_launch = 2560;
 
 std::array<gpuStream_t,Device::max_gpu_streams> Device::gpu_streams;
 gpuStream_t                                     Device::gpu_default_stream;
@@ -516,9 +516,9 @@ Device::initialize_gpu ()
     }
 
 #ifdef AMREX_USE_DPCPP
-    max_blocks_per_launch = 1000000; // xxxxx DPCPP todo
+    // max_blocks_per_launch = 100000; // xxxxx DPCPP todo
 #else
-    max_blocks_per_launch = numMultiProcessors() * maxThreadsPerMultiProcessor() / AMREX_GPU_MAX_THREADS;
+    max_blocks_per_launch = 4 * numMultiProcessors() * maxThreadsPerMultiProcessor() / AMREX_GPU_MAX_THREADS;
 #endif
 
 #endif

--- a/Src/Base/AMReX_GpuLaunch.H
+++ b/Src/Base/AMReX_GpuLaunch.H
@@ -16,6 +16,8 @@
 #include <AMReX_BLassert.H>
 #include <AMReX_TypeTraits.H>
 #include <AMReX_GpuLaunchGlobal.H>
+#include <AMReX_RandomEngine.H>
+#include <AMReX_Algorithm.H>
 #include <cstddef>
 #include <limits>
 #include <algorithm>

--- a/Src/Base/AMReX_GpuLaunchFunctsC.H
+++ b/Src/Base/AMReX_GpuLaunchFunctsC.H
@@ -315,6 +315,40 @@ void HostDeviceFor (Box const& box1, T1 ncomp1, L1&& f1,
         box3,ncomp3,std::forward<L3>(f3));
 }
 
+template <typename T, typename L, typename M=amrex::EnableIf_t<std::is_integral<T>::value> >
+void ParallelForRNG (T n, L&& f) noexcept
+{
+    for (T i = 0; i < n; ++i) {
+        f(i,RandomEngine{});
+    }
+}
+
+template <typename L>
+void ParallelForRNG (Box const& box, L&& f) noexcept
+{
+    const auto lo = amrex::lbound(box);
+    const auto hi = amrex::ubound(box);
+    for (int k = lo.z; k <= hi.z; ++k) {
+    for (int j = lo.y; j <= hi.y; ++j) {
+    for (int i = lo.x; i <= hi.x; ++i) {
+        f(i,j,k,RandomEngine{});
+    }}}
+}
+
+template <typename T, typename L, typename M=amrex::EnableIf_t<std::is_integral<T>::value> >
+void ParallelForRNG (Box const& box, T ncomp, L&& f) noexcept
+{
+    const auto lo = amrex::lbound(box);
+    const auto hi = amrex::ubound(box);
+    for (T n = 0; n < ncomp; ++n) {
+        for (int k = lo.z; k <= hi.z; ++k) {
+        for (int j = lo.y; j <= hi.y; ++j) {
+        for (int i = lo.x; i <= hi.x; ++i) {
+            f(i,j,k,n,RandomEngine{});
+        }}}
+    }
+}
+
 }
 
 #endif

--- a/Src/Base/AMReX_GpuLaunchFunctsG.H
+++ b/Src/Base/AMReX_GpuLaunchFunctsG.H
@@ -197,6 +197,130 @@ void ParallelFor (Box const& box, T ncomp, L&& f) noexcept
     }
 }
 
+template <typename T, typename L, typename M=amrex::EnableIf_t<std::is_integral<T>::value> >
+void ParallelForRNG (T n, L&& f) noexcept
+{
+    if (amrex::isEmpty(n)) return;
+    const auto ec = Gpu::ExecutionConfig(n);
+    // If we are on default queue, block all other streams
+    if (Gpu::onNullStream()) Gpu::nonNullStreamSynchronize();
+    int nthreads_per_block = ec.numThreads.x;
+    int nthreads_total = nthreads_per_block * amrex::min(ec.numBlocks.x,Gpu::Device::maxBlocksPerLaunch());
+    auto& q = Gpu::Device::nullQueue();
+    auto& engdescr = *(getRandEngineDescriptor());
+    try {
+        q.submit([&] (sycl::handler& h) {
+            auto engine_acc = engdescr.get_access(h);
+            h.parallel_for(sycl::nd_range<1>(sycl::range<1>(nthreads_total),
+                                             sycl::range<1>(nthreads_per_block)),
+            [=] (sycl::nd_item<1> item)
+            AMREX_REQUIRE_SUBGROUP_SIZE(Gpu::Device::warp_size)
+            {
+                int tid = item.get_global_id(0);
+                auto engine = engine_acc.load(tid);
+                RandomEngine rand_eng{&engine};
+                for (T i = tid, stride = item.get_global_range(0); i < n; i += stride) {
+                    f(i,rand_eng);
+                }
+                engine_acc.store(engine, tid);
+            });
+        });
+        q.wait_and_throw(); // because next launch might be on a different queue
+    } catch (sycl::exception const& ex) {
+        amrex::Abort(std::string("ParallelFor: ")+ex.what()+"!!!!!");
+    }
+}
+
+template <typename L>
+void ParallelForRNG (Box const& box, L&& f) noexcept
+{
+    if (amrex::isEmpty(box)) return;
+    int ncells = box.numPts();
+    const auto lo  = amrex::lbound(box);
+    const auto len = amrex::length(box);
+    const auto ec = Gpu::ExecutionConfig(ncells);
+    // If we are on default queue, block all other streams
+    if (Gpu::onNullStream()) Gpu::nonNullStreamSynchronize();
+    int nthreads_per_block = ec.numThreads.x;
+    int nthreads_total = nthreads_per_block * amrex::min(ec.numBlocks.x,Gpu::Device::maxBlocksPerLaunch());
+    auto& q = Gpu::Device::nullQueue();
+    auto& engdescr = *(getRandEngineDescriptor());
+    try {
+        q.submit([&] (sycl::handler& h) {
+            auto engine_acc = engdescr.get_access(h);
+            h.parallel_for(sycl::nd_range<1>(sycl::range<1>(nthreads_total),
+                                             sycl::range<1>(nthreads_per_block)),
+            [=] (sycl::nd_item<1> item)
+            AMREX_REQUIRE_SUBGROUP_SIZE(Gpu::Device::warp_size)
+            {
+                int tid = item.get_global_id(0);
+                auto engine = engine_acc.load(tid);
+                RandomEngine rand_eng{&engine};
+                for (int icell = tid, stride = item.get_global_range(0);
+                     icell < ncells; icell += stride) {
+                    int k =  icell /   (len.x*len.y);
+                    int j = (icell - k*(len.x*len.y)) /   len.x;
+                    int i = (icell - k*(len.x*len.y)) - j*len.x;
+                    i += lo.x;
+                    j += lo.y;
+                    k += lo.z;
+                    f(i,j,k,rand_eng);
+                }
+                engine_acc.store(engine, tid);
+            });
+        });
+        q.wait_and_throw(); // because next launch might be on a different queue
+    } catch (sycl::exception const& ex) {
+        amrex::Abort(std::string("ParallelFor: ")+ex.what()+"!!!!!");
+    }
+}
+
+template <typename T, typename L, typename M=amrex::EnableIf_t<std::is_integral<T>::value> >
+void ParallelForRNG (Box const& box, T ncomp, L&& f) noexcept
+{
+    if (amrex::isEmpty(box)) return;
+    int ncells = box.numPts();
+    const auto lo  = amrex::lbound(box);
+    const auto len = amrex::length(box);
+    const auto ec = Gpu::ExecutionConfig(ncells);
+    // If we are on default queue, block all other streams
+    if (Gpu::onNullStream()) Gpu::nonNullStreamSynchronize();
+    int nthreads_per_block = ec.numThreads.x;
+    int nthreads_total = nthreads_per_block * amrex::min(ec.numBlocks.x,Gpu::Device::maxBlocksPerLaunch());
+    auto& q = Gpu::Device::streamQueue();
+    auto& engdescr = *(getRandEngineDescriptor());
+    try {
+        q.submit([&] (sycl::handler& h) {
+            auto engine_acc = engdescr.get_access(h);
+            h.parallel_for(sycl::nd_range<1>(sycl::range<1>(nthreads_total),
+                                             sycl::range<1>(nthreads_per_block)),
+            [=] (sycl::nd_item<1> item)
+            AMREX_REQUIRE_SUBGROUP_SIZE(Gpu::Device::warp_size)
+            {
+                int tid = item.get_global_id(0);
+                auto engine = engine_acc.load(tid);
+                RandomEngine rand_eng{&engine};
+                for (int icell = tid, stride = item.get_global_range(0);
+                     icell < ncells; icell += stride) {
+                    int k =  icell /   (len.x*len.y);
+                    int j = (icell - k*(len.x*len.y)) /   len.x;
+                    int i = (icell - k*(len.x*len.y)) - j*len.x;
+                    i += lo.x;
+                    j += lo.y;
+                    k += lo.z;
+                    for (T n = 0; n < ncomp; ++n) {
+                        f(i,j,k,n,rand_eng);
+                    }
+                }
+                engine_acc.store(engine, tid);
+            });
+        });
+        q.wait_and_throw(); // because next launch might be on a different queue
+    } catch (sycl::exception const& ex) {
+        amrex::Abort(std::string("ParallelFor: ")+ex.what()+"!!!!!");
+    }
+}
+
 template <typename L1, typename L2>
 void ParallelFor (Box const& box1, Box const& box2, L1&& f1, L2&& f2) noexcept
 {
@@ -477,7 +601,7 @@ void FabReduce (Box const& box, T const& init_val, L1&& f1, L2&& f2) noexcept
     const auto lo  = amrex::lbound(box);
     const auto len = amrex::length(box);
     auto ec = Gpu::ExecutionConfig(ncells);
-    ec.numBlocks.x = std::min(ec.numBlocks.x, static_cast<unsigned int>(Gpu::Device::maxBlocksPerLaunch()));
+    ec.numBlocks.x = std::min(ec.numBlocks.x, Gpu::Device::maxBlocksPerLaunch());
     // If we are on default queue, block all other streams
     if (Gpu::onNullStream()) Gpu::nonNullStreamSynchronize();
     int nthreads_per_block = ec.numThreads.x;
@@ -518,7 +642,7 @@ void FabReduce (Box const& box, N ncomp, T const& init_val, L1&& f1, L2&& f2) no
     const auto lo  = amrex::lbound(box);
     const auto len = amrex::length(box);
     auto ec = Gpu::ExecutionConfig(ncells);
-    ec.numBlocks.x = std::min(ec.numBlocks.x, static_cast<unsigned int>(Gpu::Device::maxBlocksPerLaunch()));
+    ec.numBlocks.x = std::min(ec.numBlocks.x, Gpu::Device::maxBlocksPerLaunch());
     // If we are on default queue, block all other streams
     if (Gpu::onNullStream()) Gpu::nonNullStreamSynchronize();
     int nthreads_per_block = ec.numThreads.x;
@@ -558,7 +682,7 @@ void VecReduce (N n, T const& init_val, L1&& f1, L2&& f2) noexcept
 {
     if (amrex::isEmpty(n)) return;
     auto ec = Gpu::ExecutionConfig(n);
-    ec.numBlocks.x = std::min(ec.numBlocks.x, static_cast<unsigned int>(Gpu::Device::maxBlocksPerLaunch()));
+    ec.numBlocks.x = std::min(ec.numBlocks.x, Gpu::Device::maxBlocksPerLaunch());
     // If we are on default queue, block all other streams
     if (Gpu::onNullStream()) Gpu::nonNullStreamSynchronize();
     int nthreads_per_block = ec.numThreads.x;
@@ -688,6 +812,83 @@ ParallelFor (Box const& box, T ncomp, L&& f) noexcept
             k += lo.z;
             for (T n = 0; n < ncomp; ++n) {
                 f(i,j,k,n);
+            }
+        }
+    });
+    AMREX_GPU_ERROR_CHECK();
+}
+
+template <typename T, typename L, typename M=amrex::EnableIf_t<std::is_integral<T>::value> >
+amrex::EnableIf_t<MaybeDeviceRunnable<L>::value>
+ParallelForRNG (T n, L&& f) noexcept
+{
+    if (amrex::isEmpty(n)) return;
+    randState_t* rand_state = getRandState();
+    const auto ec = Gpu::ExecutionConfig(n);
+    AMREX_LAUNCH_KERNEL(amrex::min(ec.numBlocks.x, Gpu::Device::maxBlocksPerLaunch()),
+                        ec.numThreads, 0, Gpu::nullStream(),  // use null stream
+    [=] AMREX_GPU_DEVICE () noexcept {
+        int tid = blockDim.x*blockIdx.x+threadIdx.x;
+        RandomEngine engine{&(rand_state[tid])};
+        for (T i = tid, stride = blockDim.x*gridDim.x; i < n; i += stride) {
+            f(i,engine);
+        }
+    });
+    AMREX_GPU_ERROR_CHECK();
+}
+
+template <typename L>
+amrex::EnableIf_t<MaybeDeviceRunnable<L>::value>
+ParallelForRNG (Box const& box, L&& f) noexcept
+{
+    if (amrex::isEmpty(box)) return;
+    randState_t* rand_state = getRandState();
+    int ncells = box.numPts();
+    const auto lo  = amrex::lbound(box);
+    const auto len = amrex::length(box);
+    const auto ec = Gpu::ExecutionConfig(ncells);
+    AMREX_LAUNCH_KERNEL(amrex::min(ec.numBlocks.x, Gpu::Device::maxBlocksPerLaunch()),
+                        ec.numThreads, 0, Gpu::nullStream(),  // use null stream
+    [=] AMREX_GPU_DEVICE () noexcept {
+        int tid = blockDim.x*blockIdx.x+threadIdx.x;
+        RandomEngine engine{&(rand_state[tid])};
+        for (int icell = tid, stride = blockDim.x*gridDim.x; icell < ncells; icell += stride) {
+            int k =  icell /   (len.x*len.y);
+            int j = (icell - k*(len.x*len.y)) /   len.x;
+            int i = (icell - k*(len.x*len.y)) - j*len.x;
+            i += lo.x;
+            j += lo.y;
+            k += lo.z;
+            f(i,j,k,engine);
+        }
+    });
+    AMREX_GPU_ERROR_CHECK();
+}
+
+template <typename T, typename L, typename M=amrex::EnableIf_t<std::is_integral<T>::value> >
+amrex::EnableIf_t<MaybeDeviceRunnable<L>::value>
+ParallelForRNG (Box const& box, T ncomp, L&& f) noexcept
+{
+    if (amrex::isEmpty(box)) return;
+    randState_t* rand_state = getRandState();
+    int ncells = box.numPts();
+    const auto lo  = amrex::lbound(box);
+    const auto len = amrex::length(box);
+    const auto ec = Gpu::ExecutionConfig(ncells);
+    AMREX_LAUNCH_KERNEL(amrex::min(ec.numBlocks.x, Gpu::Device::maxBlocksPerLaunch()),
+                        ec.numThreads, 0, Gpu::nullStream(), // use null stream
+    [=] AMREX_GPU_DEVICE () noexcept {
+        int tid = blockDim.x*blockIdx.x+threadIdx.x;
+        RandomEngine engine{&(rand_state[tid])};
+        for (int icell = tid, stride = blockDim.x*gridDim.x; icell < ncells; icell += stride) {
+            int k =  icell /   (len.x*len.y);
+            int j = (icell - k*(len.x*len.y)) /   len.x;
+            int i = (icell - k*(len.x*len.y)) - j*len.x;
+            i += lo.x;
+            j += lo.y;
+            k += lo.z;
+            for (T n = 0; n < ncomp; ++n) {
+                f(i,j,k,n,engine);
             }
         }
     });
@@ -905,7 +1106,7 @@ FabReduce (Box const& box, T const& init_val, L1&& f1, L2&& f2) noexcept
     const auto lo  = amrex::lbound(box);
     const auto len = amrex::length(box);
     auto ec = Gpu::ExecutionConfig(ncells);
-    ec.numBlocks.x = std::min(ec.numBlocks.x, static_cast<unsigned int>(Gpu::Device::maxBlocksPerLaunch()));
+    ec.numBlocks.x = std::min(ec.numBlocks.x, Gpu::Device::maxBlocksPerLaunch());
     AMREX_LAUNCH_KERNEL(ec.numBlocks, ec.numThreads, 0, Gpu::gpuStream(),
     [=] AMREX_GPU_DEVICE () noexcept {
         auto r = init_val;
@@ -934,7 +1135,7 @@ FabReduce (Box const& box, N ncomp, T const& init_val, L1&& f1, L2&& f2) noexcep
     const auto lo  = amrex::lbound(box);
     const auto len = amrex::length(box);
     auto ec = Gpu::ExecutionConfig(ncells);
-    ec.numBlocks.x = std::min(ec.numBlocks.x, static_cast<unsigned int>(Gpu::Device::maxBlocksPerLaunch()));
+    ec.numBlocks.x = std::min(ec.numBlocks.x, Gpu::Device::maxBlocksPerLaunch());
     AMREX_LAUNCH_KERNEL(ec.numBlocks, ec.numThreads, 0, Gpu::gpuStream(),
     [=] AMREX_GPU_DEVICE () noexcept {
         auto r = init_val;
@@ -962,7 +1163,7 @@ VecReduce (N n, T const& init_val, L1&& f1, L2&& f2) noexcept
 {
     if (amrex::isEmpty(n)) return;
     auto ec = Gpu::ExecutionConfig(n);
-    ec.numBlocks.x = std::min(ec.numBlocks.x, static_cast<unsigned int>(Gpu::Device::maxBlocksPerLaunch()));
+    ec.numBlocks.x = std::min(ec.numBlocks.x, Gpu::Device::maxBlocksPerLaunch());
     AMREX_LAUNCH_KERNEL(ec.numBlocks, ec.numThreads, 0, Gpu::gpuStream(),
     [=] AMREX_GPU_DEVICE () noexcept {
         auto r = init_val;

--- a/Src/Base/AMReX_Random.H
+++ b/Src/Base/AMReX_Random.H
@@ -95,6 +95,7 @@ namespace amrex
 #elif defined(__HIP_DEVICE_COMPILE__)
         return hiprand_poisson(random_engine.rand_state, lambda);
 #elif defined (__SYCL_DEVICE_ONLY__)
+        amrex::Abort("RandomPossion not supported in DPC++ device code");
         return 0; // xxxxx DPCPP todo: Poisson distribution
 #else
         amrex::ignore_unused(random_engine);
@@ -120,6 +121,7 @@ namespace amrex
             mkl::rng::device::uniform<std::int32_t> distr(0,static_cast<std::int32_t>(n));
             return mkl::rng::device::generate(distr, *random_engine.engine);
         } else {
+            amrex::Abort("Random_int not supported in DPC++ device code, if n > INT_MAX");
             return 0; // xxxxx DPCPP todo: unsigned uniform distribution
         }
 #else

--- a/Src/Base/AMReX_Random.H
+++ b/Src/Base/AMReX_Random.H
@@ -1,15 +1,50 @@
 #ifndef AMREX_RAND_H
 #define AMREX_RAND_H
 
+#include <AMReX.H>
 #include <AMReX_GpuQualifiers.H>
 #include <AMReX_ParallelDescriptor.H>
-
-// xxxxx DPCPP todo
+#include <AMReX_RandomEngine.H>
+#include <limits>
+#include <cstdint>
 
 namespace amrex
 {
     /**
-    * \brief Generate a psuedo-random double using C++11's mt19937.
+    * \brief Generate a psuedo-random double from uniform distribution
+    *
+    *  Generates one pseudorandom real number (double) from a uniform
+    *  distribution between 0.0 and 1.0 (0.0 included, 1.0 excluded)
+    *
+    */
+    AMREX_GPU_EXTERNAL AMREX_GPU_HOST_DEVICE Real Random ();
+
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    Real Random (RandomEngine const& random_engine)
+    {
+#if defined(__CUDA_ARCH__)
+#ifdef BL_USE_FLOAT
+        return 1.0f - curand_uniform(random_engine.rand_state);
+#else
+        return 1.0 - curand_uniform_double(random_engine.rand_state);
+#endif
+#elif defined(__HIP_DEVICE_COMPILE__)
+#ifdef BL_USE_FLOAT
+        return 1.0f - hiprand_uniform(random_engine.rand_state);
+#else
+        return 1.0 - hiprand_uniform_double(random_engine.rand_state);
+#endif
+#elif defined (__SYCL_DEVICE_ONLY__)
+        mkl::rng::device::uniform<Real> distr;
+        return mkl::rng::device::generate(distr, *random_engine.engine);
+#else
+        amrex::ignore_unused(random_engine);
+        return Random();
+#endif
+    }
+
+    /**
+    * \brief Generate a psuedo-random double from a normal distribution
     *
     *  Generates one pseudorandom real number (double) from a normal
     *  distribution with mean 'mean' and standard deviation 'stddev'.
@@ -17,14 +52,29 @@ namespace amrex
     */
     AMREX_GPU_EXTERNAL AMREX_GPU_HOST_DEVICE Real RandomNormal (Real mean, Real stddev);
 
-    /**
-    * \brief Generate a psuedo-random double using C++11's mt19937.
-    *
-    *  Generates one pseudorandom real number (double) from a uniform
-    *  distribution between 0.0 and 1.0 (0.0 included, 1.0 excluded)
-    *
-    */
-    AMREX_GPU_EXTERNAL AMREX_GPU_HOST_DEVICE Real Random ();
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    Real RandomNormal (Real mean, Real stddev, RandomEngine const& random_engine)
+    {
+#if defined(__CUDA_ARCH__)
+#ifdef BL_USE_FLOAT
+        return stddev * curand_normal(random_engine.rand_state) + mean;
+#else
+        return stddev * curand_normal_double(random_engine.rand_state) + mean;
+#endif
+#elif defined(__HIP_DEVICE_COMPILE__)
+#ifdef BL_USE_FLOAT
+        return stddev * hiprand_normal(random_engine.rand_state) + mean;
+#else
+        return stddev * hiprand_normal_double(random_engine.rand_state) + mean;
+#endif
+#elif defined (__SYCL_DEVICE_ONLY__)
+        mkl::rng::device::gaussian<Real> distr(mean, stddev);
+        return mkl::rng::device::generate(distr, *random_engine.engine);
+#else
+        amrex::ignore_unused(random_engine);
+        return RandomNormal(mean, stddev);
+#endif
+    }
 
     /**
     * \brief Generate a psuedo-random integer from a Poisson distribution
@@ -37,14 +87,20 @@ namespace amrex
     */
     AMREX_GPU_EXTERNAL AMREX_GPU_HOST_DEVICE unsigned int RandomPoisson (Real lambda);
 
-
-
-#ifdef AMREX_USE_GPU
-    // Locking mechanism functions for locking and unlocking
-    AMREX_GPU_DEVICE int get_state (int tid);
-    AMREX_GPU_DEVICE void free_state (int tid);
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    unsigned int RandomPoisson (Real lambda, RandomEngine const& random_engine)
+    {
+#if defined(__CUDA_ARCH__)
+        return curand_poisson(random_engine.rand_state, lambda);
+#elif defined(__HIP_DEVICE_COMPILE__)
+        return hiprand_poisson(random_engine.rand_state, lambda);
+#elif defined (__SYCL_DEVICE_ONLY__)
+        return 0; // xxxxx DPCPP todo: Poisson distribution
+#else
+        amrex::ignore_unused(random_engine);
+        return RandomPoisson(lambda);
 #endif
-
+    }
 
     /**
     * \brief Generates one pseudorandom unsigned integer which is
@@ -54,6 +110,38 @@ namespace amrex
     * The GPU version uses CURAND's XORWOW generator.
     */
     AMREX_GPU_EXTERNAL AMREX_GPU_HOST_DEVICE unsigned int Random_int (unsigned int n); // [0,n-1]
+
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    unsigned int Random_int (unsigned int n, RandomEngine const& random_engine)
+    {
+#if AMREX_DEVICE_COMPILE
+#if defined(__SYCL_DEVICE_ONLY__)
+        if (n <= static_cast<unsigned int>(std::numeric_limits<std::int32_t>::max())) {
+            mkl::rng::device::uniform<std::int32_t> distr(0,static_cast<std::int32_t>(n));
+            return mkl::rng::device::generate(distr, *random_engine.engine);
+        } else {
+            return 0; // xxxxx DPCPP todo: unsigned uniform distribution
+        }
+#else
+        int rand;
+        constexpr unsigned int RAND_M = 4294967295; // 2**32-1
+        do {
+            AMREX_HIP_OR_CUDA( rand = hiprand(random_engine.rand_state);,
+                               rand =  curand(random_engine.rand_state) );
+        } while (rand > (RAND_M - RAND_M % n));
+        return rand % n;
+#endif
+#else
+        amrex::ignore_unused(random_engine);
+        return Random_int(n);
+#endif
+    }
+
+#ifdef AMREX_USE_GPU
+    // Locking mechanism functions for locking and unlocking
+    AMREX_GPU_DEVICE int get_state (int tid);
+    AMREX_GPU_DEVICE void free_state (int tid);
+#endif
 
     /**
     * \brief Generates one pseudorandom unsigned long which is
@@ -78,19 +166,7 @@ namespace amrex
     */
     void InitRandom (ULong seed, int nprocs=ParallelDescriptor::NProcs());
 
-    /**
-    * \brief Resize seed array and copy address to global symbol
-    */
-    void ResizeRandomSeed (int N);
     void ResetRandomSeed (ULong seed);
-
-    /**
-    * \brief Set the seeds of the random number generator for each CUDA thread .
-    *  An in-built CUDA library, curand_init is used here.
-    *  The pseusorandom sequence currently implemented is obtained
-    *  from the XORWOW and MRG32k3a generator
-    */
-    void InitRandSeedOnDevice (int N);
 
     /**
     * \brief Save and restore random state.
@@ -117,14 +193,6 @@ namespace amrex
     *   The remainder items are randomly assigned.
     */
     void NItemsPerBin (int totalItems, Vector<int> &binCounts);
-
-    /**
-    * \brief Set the seeds of the random number generator for each CUDA thread .
-    *  An in-built CUDA library, curand_init is used here.
-    *  The pseusorandom sequence currently implemented is obtained
-    *  from the XORWOW and MRG32k3a generator
-    */
-    void InitRandSeedOnDevice (int N);
 
     void DeallocateRandomSeedDevArray ();
 }

--- a/Src/Base/AMReX_Random.cpp
+++ b/Src/Base/AMReX_Random.cpp
@@ -6,21 +6,8 @@
 #include <AMReX_Print.H>
 #include <AMReX_Random.H>
 #include <AMReX_BlockMutex.H>
-#include <AMReX_GpuLaunch.H>
-#include <AMReX_GpuDevice.H>
+#include <AMReX_Gpu.H>
 #include <AMReX_OpenMP.H>
-
-#ifdef AMREX_USE_HIP
-#include <hiprand.hpp>
-#endif
-
-#ifdef AMREX_USE_HIP
-using randState_t = hiprandState_t;
-#elif defined(AMREX_USE_CUDA)
-using randState_t =  curandState_t;
-#elif defined(AMREX_USE_DPCPP)
-struct randState_t {};
-#endif
 
 namespace
 {
@@ -28,31 +15,77 @@ namespace
 
     amrex::Vector<std::mt19937> generators;
 
-#ifdef AMREX_USE_GPU
-    // This seems to be a good default value on NVIDIA V100 GPUs
-    constexpr int gpu_nstates_default = 1e5;
+#if defined(AMREX_USE_CUDA) || defined(AMREX_USE_HIP)
+    AMREX_GPU_DEVICE int gpu_nstates_d;
 
-    int gpu_nstates_h = 0;
-#ifndef AMREX_USE_DPCPP
-    AMREX_GPU_DEVICE int gpu_nstates_d = 0;
-#endif
-
-    randState_t* d_states_h_ptr = nullptr;
-#ifndef AMREX_USE_DPCPP
-    AMREX_GPU_DEVICE randState_t* d_states_d_ptr;
-#endif
+    AMREX_GPU_DEVICE amrex::randState_t* d_states_d_ptr;
 
     amrex::BlockMutex* h_mutex_h_ptr = nullptr;
     amrex::BlockMutex* d_mutex_h_ptr = nullptr;
-
-#ifndef AMREX_USE_DPCPP
-    AMREX_GPU_DEVICE
-    amrex::BlockMutex* d_mutex_d_ptr = nullptr;
+    AMREX_GPU_DEVICE amrex::BlockMutex* d_mutex_d_ptr = nullptr;
 #endif
-
-#endif
-
 }
+
+#ifdef AMREX_USE_GPU
+namespace amrex {
+#ifdef AMREX_USE_DPCPP
+    dpcpp_rng_descr* rand_engine_descr = nullptr;
+#else
+    amrex::randState_t* d_states_h_ptr = nullptr;
+#endif
+}
+#endif
+
+#ifdef AMREX_USE_GPU
+namespace {
+void ResizeRandomSeed ()
+{
+    BL_PROFILE("ResizeRandomSeed");
+
+    using namespace amrex;
+
+    DeallocateRandomSeedDevArray();
+
+    const int N = Gpu::Device::maxBlocksPerLaunch() * AMREX_GPU_MAX_THREADS;
+
+#ifdef AMREX_USE_DPCPP
+
+    rand_engine_descr = new dpcpp_rng_descr
+        (Gpu::Device::nullQueue(), sycl::range<1>(N),
+         ParallelDescriptor::MyProc()*1234567ULL + 12345ULL, 1);
+
+#elif defined(AMREX_USE_CUDA) || defined(AMREX_USE_HIP)
+
+    d_states_h_ptr =  static_cast<randState_t*>(The_Arena()->alloc(N*sizeof(randState_t)));
+
+    h_mutex_h_ptr = new amrex::BlockMutex(N);
+    d_mutex_h_ptr = static_cast<amrex::BlockMutex*> (The_Arena()->alloc(sizeof(amrex::BlockMutex)));
+    amrex::Gpu::htod_memcpy(d_mutex_h_ptr, h_mutex_h_ptr, sizeof(amrex::BlockMutex));
+
+    randState_t* d_states_h_ptr_local = d_states_h_ptr;
+    amrex::BlockMutex* d_mutex_h_ptr_local = d_mutex_h_ptr;
+
+    amrex::single_task([=] AMREX_GPU_DEVICE () noexcept
+    {
+        d_states_d_ptr = d_states_h_ptr_local;
+        d_mutex_d_ptr = d_mutex_h_ptr_local;
+        gpu_nstates_d = N;
+    });
+
+    const int MyProc = amrex::ParallelDescriptor::MyProc();
+    amrex::ParallelFor(N, [=] AMREX_GPU_DEVICE (int idx) noexcept
+    {
+        amrex::ULong seed = MyProc*1234567ULL + 12345ULL ;
+        int seqstart = idx + 10 * idx ;
+        AMREX_HIP_OR_CUDA( hiprand_init(seed, seqstart, 0, &d_states_d_ptr[idx]);,
+                            curand_init(seed, seqstart, 0, &d_states_d_ptr[idx]); )
+    });
+#endif
+
+    Gpu::synchronize();
+}
+}
+#endif
 
 void
 amrex::InitRandom (amrex::ULong seed, int nprocs)
@@ -70,8 +103,7 @@ amrex::InitRandom (amrex::ULong seed, int nprocs)
     }
 
 #ifdef AMREX_USE_GPU
-    DeallocateRandomSeedDevArray();
-    ResizeRandomSeed(gpu_nstates_default);
+    ResizeRandomSeed();
 #endif
 }
 
@@ -337,81 +369,19 @@ void amrex::ResetRandomSeed (amrex::ULong seed)
 }
 
 void
-amrex::ResizeRandomSeed (int N)
-{
-    amrex::ignore_unused(N);
-
-    BL_PROFILE("ResizeRandomSeed");
-
-#ifdef AMREX_USE_DPCPP
-    // xxxxx DPCPP todo
-
-#elif defined(AMREX_USE_CUDA) || defined(AMREX_USE_HIP)
-
-    if (N <= gpu_nstates_h) return;
-
-    int PrevSize = gpu_nstates_h;
-    int SizeDiff = N - PrevSize;
-
-    randState_t* new_data;
-    new_data = static_cast<randState_t*>  (The_Device_Arena()->alloc(N*sizeof(randState_t)));
-
-    if (h_mutex_h_ptr != nullptr)
-    {
-        delete h_mutex_h_ptr;
-        h_mutex_h_ptr = nullptr;
-    }
-
-    if (d_mutex_h_ptr != nullptr)
-    {
-        The_Device_Arena()->free(d_mutex_h_ptr);
-        d_mutex_h_ptr = nullptr;
-    }
-
-    h_mutex_h_ptr = new amrex::BlockMutex(N);
-    d_mutex_h_ptr = static_cast<amrex::BlockMutex*> (The_Device_Arena()->alloc(sizeof(amrex::BlockMutex)));
-    amrex::Gpu::htod_memcpy(d_mutex_h_ptr, h_mutex_h_ptr, sizeof(amrex::BlockMutex));
-
-    if (d_states_h_ptr != nullptr)
-    {
-        amrex::Gpu::dtod_memcpy(new_data, d_states_h_ptr, PrevSize*sizeof(randState_t));
-        The_Device_Arena()->free(d_states_h_ptr);
-    }
-
-    d_states_h_ptr = new_data;
-    gpu_nstates_h = N;
-    amrex::BlockMutex* d_mutex_h_ptr_local = d_mutex_h_ptr;
-
-    // xxxxx HIP FIX HERE - hipMemcpyToSymbol doesn't work with pointers.
-    amrex::ParallelFor(1, [=] AMREX_GPU_DEVICE (int)
-    {
-        d_states_d_ptr = new_data;
-        d_mutex_d_ptr = d_mutex_h_ptr_local;
-        gpu_nstates_d = N;
-    });
-
-    const int MyProc = amrex::ParallelDescriptor::MyProc();
-    amrex::ParallelFor (SizeDiff, [=] AMREX_GPU_DEVICE (int idx) noexcept
-    {
-        amrex::ULong seed = MyProc*1234567ULL + 12345ULL ;
-        int seqstart = idx + 10 * idx ;
-        int loc = idx + PrevSize;
-
-        AMREX_HIP_OR_CUDA( hiprand_init(seed, seqstart, 0, &d_states_d_ptr[loc]);,
-                            curand_init(seed, seqstart, 0, &d_states_d_ptr[loc]); )
-    });
-
-#endif
-
-}
-
-void
 amrex::DeallocateRandomSeedDevArray ()
 {
 #ifdef AMREX_USE_GPU
+#ifdef AMREX_USE_DPCPP
+    if (rand_engine_descr) {
+        delete rand_engine_descr;
+        Gpu::synchronize();
+        rand_engine_descr = nullptr;
+    }
+#else
     if (d_states_h_ptr != nullptr)
     {
-        The_Device_Arena()->free(d_states_h_ptr);
+        The_Arena()->free(d_states_h_ptr);
         d_states_h_ptr = nullptr;
     }
 
@@ -423,11 +393,10 @@ amrex::DeallocateRandomSeedDevArray ()
 
     if (d_mutex_h_ptr != nullptr)
     {
-        The_Device_Arena()->free(d_mutex_h_ptr);
+        The_Arena()->free(d_mutex_h_ptr);
         d_mutex_h_ptr = nullptr;
     }
-
-    gpu_nstates_h = 0;
+#endif
 #endif
 }
 

--- a/Src/Base/AMReX_RandomEngine.H
+++ b/Src/Base/AMReX_RandomEngine.H
@@ -1,0 +1,67 @@
+#ifndef AMREX_RANDOM_ENGINE_H_
+#define AMREX_RANDOM_ENGINE_H_
+
+#include <AMReX_GpuQualifiers.H>
+#include <AMReX_Extension.H>
+
+#if defined(AMREX_USE_HIP)
+#include <hiprand.hpp>
+#elif defined(AMREX_USE_CUDA)
+#include <curand.h>
+#include <curand_kernel.h>
+#elif defined(AMREX_USE_DPCPP)
+#include <CL/sycl.hpp>
+namespace sycl = cl::sycl;
+#include <mkl_rng_sycl_device.hpp>
+#if (__SYCL_COMPILER_VERSION >= 20200827)
+namespace mkl = oneapi::mkl;
+#endif
+#endif
+
+namespace amrex
+{
+#ifdef AMREX_USE_GPU
+
+#ifdef AMREX_USE_DPCPP
+
+    using dpcpp_rng_engine = mkl::rng::device::philox4x32x10<>;
+    using dpcpp_rng_descr = mkl::rng::device::engine_descriptor<dpcpp_rng_engine>;
+    using dpcpp_rng_acc = mkl::rng::device::engine_accessor<dpcpp_rng_engine>;
+
+    extern dpcpp_rng_descr* rand_engine_descr;
+
+    AMREX_FORCE_INLINE
+    dpcpp_rng_descr* getRandEngineDescriptor () { return rand_engine_descr; }
+
+    struct RandomEngine {
+        dpcpp_rng_engine* engine;
+    };
+
+#else
+
+#ifdef AMREX_USE_HIP
+    using randState_t = hiprandState_t;
+#else
+    using randState_t = curandState_t;
+#endif
+
+    extern randState_t* d_states_h_ptr;
+
+    AMREX_FORCE_INLINE
+    randState_t* getRandState () { return d_states_h_ptr; }
+
+    struct RandomEngine {
+        randState_t* rand_state = nullptr;
+    };
+
+#endif
+
+#else
+
+    struct RandomEngine {}; // CPU
+
+#endif
+
+}
+
+#endif

--- a/Src/Base/AMReX_RandomEngine.H
+++ b/Src/Base/AMReX_RandomEngine.H
@@ -51,7 +51,7 @@ namespace amrex
     randState_t* getRandState () { return d_states_h_ptr; }
 
     struct RandomEngine {
-        randState_t* rand_state = nullptr;
+        randState_t* rand_state;
     };
 
 #endif

--- a/Src/Base/AMReX_Reduce.H
+++ b/Src/Base/AMReX_Reduce.H
@@ -287,7 +287,7 @@ public:
         const auto len = amrex::length(box);
         IndexType ixtype = box.ixType();
         auto ec = Gpu::ExecutionConfig(ncells);
-        ec.numBlocks.x = std::min(ec.numBlocks.x, static_cast<unsigned int>(Gpu::Device::maxBlocksPerLaunch()));
+        ec.numBlocks.x = std::min(ec.numBlocks.x, Gpu::Device::maxBlocksPerLaunch());
 #ifdef AMREX_USE_DPCPP
         // device reduce needs local(i.e., shared) memory
         constexpr std::size_t shared_mem_bytes = sizeof(unsigned long long)*Gpu::Device::warp_size;
@@ -338,7 +338,7 @@ public:
         const auto lo  = amrex::lbound(box);
         const auto len = amrex::length(box);
         auto ec = Gpu::ExecutionConfig(ncells);
-        ec.numBlocks.x = std::min(ec.numBlocks.x, static_cast<unsigned int>(Gpu::Device::maxBlocksPerLaunch()));
+        ec.numBlocks.x = std::min(ec.numBlocks.x, Gpu::Device::maxBlocksPerLaunch());
 #ifdef AMREX_USE_DPCPP
         // device reduce needs local(i.e., shared) memory
         constexpr std::size_t shared_mem_bytes = sizeof(unsigned long long)*Gpu::Device::warp_size;
@@ -390,7 +390,7 @@ public:
         using ReduceTuple = typename D::Type;
         auto dp = reduce_data.devicePtr();
         auto ec = Gpu::ExecutionConfig(n);
-        ec.numBlocks.x = std::min(ec.numBlocks.x, static_cast<unsigned int>(Gpu::Device::maxBlocksPerLaunch()));
+        ec.numBlocks.x = std::min(ec.numBlocks.x, Gpu::Device::maxBlocksPerLaunch());
 #ifdef AMREX_USE_DPCPP
         // device reduce needs local(i.e., shared) memory
         constexpr std::size_t shared_mem_bytes = sizeof(unsigned long long)*Gpu::Device::warp_size;
@@ -568,7 +568,7 @@ bool AnyOf (N n, T const* v, P&& pred)
     });
 #else
     auto ec = Gpu::ExecutionConfig(n);
-    ec.numBlocks.x = std::min(ec.numBlocks.x, static_cast<unsigned int>(Gpu::Device::maxBlocksPerLaunch()));
+    ec.numBlocks.x = std::min(ec.numBlocks.x, Gpu::Device::maxBlocksPerLaunch());
     amrex::launch(ec.numBlocks.x, ec.numThreads.x, 0, 0,
     [=] AMREX_GPU_DEVICE () noexcept {
         __shared__ int has_any;
@@ -610,7 +610,7 @@ bool AnyOf (Box const& box, P&& pred)
     const auto lo  = amrex::lbound(box);
     const auto len = amrex::length(box);
     auto ec = Gpu::ExecutionConfig(ncells);
-    ec.numBlocks.x = std::min(ec.numBlocks.x, static_cast<unsigned int>(Gpu::Device::maxBlocksPerLaunch()));
+    ec.numBlocks.x = std::min(ec.numBlocks.x, Gpu::Device::maxBlocksPerLaunch());
     AMREX_LAUNCH_KERNEL(ec.numBlocks, ec.numThreads, 0, 0,
     [=] AMREX_GPU_DEVICE () noexcept {
         __shared__ int has_any;

--- a/Src/Base/CMakeLists.txt
+++ b/Src/Base/CMakeLists.txt
@@ -31,6 +31,7 @@ target_sources( amrex
    AMReX_Scan.H
    AMReX_Partition.H
    AMReX_Random.H
+   AMReX_RandomEngine.H
    AMReX_Random.cpp
    AMReX_Slopes_K.H
    AMReX_BLassert.H

--- a/Src/Base/Make.package
+++ b/Src/Base/Make.package
@@ -27,7 +27,7 @@ C$(AMREX_BASE)_headers += AMReX_Functional.H AMReX_Reduce.H AMReX_Scan.H AMReX_P
 C$(AMREX_BASE)_headers += AMReX_FileSystem.H
 C$(AMREX_BASE)_sources += AMReX_FileSystem.cpp
 
-C$(AMREX_BASE)_headers += AMReX_Random.H
+C$(AMREX_BASE)_headers += AMReX_Random.H AMReX_RandomEngine.H
 C$(AMREX_BASE)_sources += AMReX_Random.cpp
 
 C$(AMREX_BASE)_headers += AMReX_Slopes_K.H

--- a/Tests/AsyncOut/multifab/main.cpp
+++ b/Tests/AsyncOut/multifab/main.cpp
@@ -77,10 +77,11 @@ void main_main ()
 
         auto arrs_ptr = arrs.dataPtr();
 
-        amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        amrex::ParallelForRNG(bx,
+        [=] AMREX_GPU_DEVICE (int i, int j, int k, RandomEngine const& engine) noexcept
         {
             for (int m = 0; m < nwrites; ++m) {
-               arrs_ptr[m](i,j,k) = amrex::Random();
+               arrs_ptr[m](i,j,k) = amrex::Random(engine);
             }
         });
         Gpu::streamSynchronize(); // because of arrs

--- a/Tests/GPU/RandomNumberGeneration/inputs
+++ b/Tests/GPU/RandomNumberGeneration/inputs
@@ -1,2 +1,1 @@
-num_states = 100
-num_draw = 10000
+num_draw = 1000000

--- a/Tests/Particles/ParallelContext/main.cpp
+++ b/Tests/Particles/ParallelContext/main.cpp
@@ -190,7 +190,8 @@ public:
 
                 if (do_random == 0)
                 {
-                    AMREX_FOR_1D ( np, i,
+                    amrex::ParallelFor(np,
+                    [=] AMREX_GPU_DEVICE (size_t i) noexcept
                     {
                         ParticleType& p = pstruct[i];
                         p.pos(0) += move_dir[0]*dx[0];
@@ -204,16 +205,17 @@ public:
                 }
                 else
                 {
-                    AMREX_FOR_1D ( np, i,
+                    amrex::ParallelForRNG(np,
+                    [=] AMREX_GPU_DEVICE (size_t i, RandomEngine const& engine) noexcept
                     {
                         ParticleType& p = pstruct[i];
 
-                        p.pos(0) += (2*amrex::Random()-1)*move_dir[0]*dx[0];
+                        p.pos(0) += (2*amrex::Random(engine)-1)*move_dir[0]*dx[0];
 #if AMREX_SPACEDIM > 1
-                        p.pos(1) += (2*amrex::Random()-1)*move_dir[1]*dx[1];
+                        p.pos(1) += (2*amrex::Random(engine)-1)*move_dir[1]*dx[1];
 #endif
 #if AMREX_SPACEDIM > 2
-                        p.pos(2) += (2*amrex::Random()-1)*move_dir[2]*dx[2];
+                        p.pos(2) += (2*amrex::Random(engine)-1)*move_dir[2]*dx[2];
 #endif
                     });
                 }

--- a/Tests/Particles/Redistribute/main.cpp
+++ b/Tests/Particles/Redistribute/main.cpp
@@ -213,16 +213,17 @@ public:
                 }
                 else
                 {
-                    amrex::ParallelFor( np, [=] AMREX_GPU_DEVICE (int i) noexcept
+                    amrex::ParallelForRNG( np,
+                    [=] AMREX_GPU_DEVICE (int i, RandomEngine const& engine) noexcept
                     {
                         ParticleType& p = pstruct[i];
 
-                        p.pos(0) += (2*amrex::Random()-1)*move_dir[0]*dx[0];
+                        p.pos(0) += (2*amrex::Random(engine)-1)*move_dir[0]*dx[0];
 #if AMREX_SPACEDIM > 1
-                        p.pos(1) += (2*amrex::Random()-1)*move_dir[1]*dx[1];
+                        p.pos(1) += (2*amrex::Random(engine)-1)*move_dir[1]*dx[1];
 #endif
 #if AMREX_SPACEDIM > 2
-                        p.pos(2) += (2*amrex::Random()-1)*move_dir[2]*dx[2];
+                        p.pos(2) += (2*amrex::Random(engine)-1)*move_dir[2]*dx[2];
 #endif
                     });
                 }

--- a/Tutorials/GPU/ParallelReduce/main.cpp
+++ b/Tutorials/GPU/ParallelReduce/main.cpp
@@ -45,19 +45,11 @@ void main_main ()
         auto const& fab = mf.array(mfi);
         auto const& ifab = imf.array(mfi);
 
-        amrex::ParallelFor(bx,
-        [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept 
+        amrex::ParallelForRNG(bx,
+        [=] AMREX_GPU_DEVICE (int i, int j, int k, RandomEngine const& engine) noexcept
         {
-
-#if defined(AMREX_USE_HIP) || defined(AMREX_USE_DPCPP)
-//          Currently needed for HIP to work correctly.
-//          Random lock is under investigation.
-            fab(i,j,k) = 1.0;
-            ifab(i,j,k) = 1;
-#else
-            fab(i,j,k) = amrex::Random();
-            ifab(i,j,k) = (amrex::Random() > 0.5) ? 1 : 0;
-#endif
+            fab(i,j,k) = amrex::Random(engine);
+            ifab(i,j,k) = amrex::Random_int(2,engine);
         });
     }
 
@@ -259,12 +251,10 @@ void main_main ()
     int N = 1000000;
     Gpu::DeviceVector<Real> vec(N);
     Real* pvec = vec.dataPtr();
-    amrex::ParallelFor(N, [=] AMREX_GPU_DEVICE (int i) noexcept {
-#if defined(AMREX_USE_HIP) || defined(AMREX_USE_DPCPP)
-           pvec[i] = 1.5;
-#else
-           pvec[i] = amrex::Random() - 0.5;
-#endif
+    amrex::ParallelForRNG( N,
+    [=] AMREX_GPU_DEVICE (int i, RandomEngine const& engine) noexcept
+    {
+        pvec[i] = amrex::Random(engine) - 0.5;
     });
 
     {


### PR DESCRIPTION
## Summary

In order to support RNG on device with DPC++, we have to change the API
because DPC++ does not support global device variables.  We introduce a new
`ParallelForRNG` function that takes a device lambda with an extra
`RandomEngine` argument.  Random numbers can be generated by calling
`amrex::Random(RandomEngine const&)`.  To maintain backward compatibility in
the short term, the old way of calling `amrex::Random()` on device is kept.
But it will be removed soon because no locking is needed in the new way
unlike in `Random()`.  Note that only the device version of
`amrex::Random()` is deprecated.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
