### PR TITLE
Revert "DPCPP Beta09: Package Broken (#1361)"

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -155,8 +155,6 @@ jobs:
             -DCUDA_ARCH=6.0
         make -j 2 tutorials
 
-  # quick-fix for beta09: activate beta08 compiler
-  # bug report: 04801443 on https://supporttickets.intel.com
   tutorials-dpcpp:
     name: DPCPP@PubBeta GFortran@7.5 C++17 [tutorials]
     runs-on: ubuntu-latest
@@ -168,7 +166,6 @@ jobs:
       run: |
         set +e
         source /opt/intel/oneapi/setvars.sh
-        source /opt/intel/oneapi/compiler/2021.1-beta08/env/vars.sh
         set -e
         mkdir build
         cd build


### PR DESCRIPTION
## Summary

This reverts commit 198a4958cc2cbfd5a7e1d639d5ff750489104df6.

The workaround does not work with #1363 because of mkl.  We have now
temporarily removed dpc++ from the list of required checks.  So we can
revert this change now.  Once the packages are fixed, we will make the check
required again.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
