### PR TITLE
.gitignore: build/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ nohup.out
 *.exe
 *.exe.dSYM
 *~
+build/
 tmp_build_dir/
 d/
 f/


### PR DESCRIPTION
## Summary

besides our currently assumed temporary build directories, a temporar build/ directory is quite common in CMake (although discouraged to build inside the tree at all, but this is safe enough).
## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
