### PR TITLE
Avoid accessing device memory directly on host

### DIFF
--- a/Src/Particle/AMReX_ParticleLocator.H
+++ b/Src/Particle/AMReX_ParticleLocator.H
@@ -250,11 +250,23 @@ public:
         int num_levels = a_ba.size();
         m_locators.resize(num_levels);
         m_grid_assignors.resize(num_levels);
+#ifdef AMREX_USE_GPU
+        Gpu::HostVector<AssignGrid<BinIteratorFactory> > h_grid_assignors(num_levels);
+        for (int lev = 0; lev < num_levels; ++lev)
+        {
+            m_locators[lev].build(a_ba[lev], a_geom[lev]);
+            h_grid_assignors[lev] = m_locators[lev].getGridAssignor();
+        }
+        Gpu::htod_memcpy(m_grid_assignors.data(), h_grid_assignors.data(),
+                         sizeof(AssignGrid<BinIteratorFactory>)*num_levels);
+        Gpu::synchronize();
+#else
         for (int lev = 0; lev < num_levels; ++lev)
         {
             m_locators[lev].build(a_ba[lev], a_geom[lev]);
             m_grid_assignors[lev] = m_locators[lev].getGridAssignor();
         }
+#endif
     }
 
     void build (const ParGDBBase* a_gdb)
@@ -293,11 +305,23 @@ public:
     void setGeometry (const ParGDBBase* a_gdb)
     {
         int num_levels = a_gdb->finestLevel()+1;
+#ifdef AMREX_USE_GPU
+        Gpu::HostVector<AssignGrid<BinIteratorFactory> > h_grid_assignors(num_levels);
+        for (int lev = 0; lev < num_levels; ++lev)
+        {
+            m_locators[lev].setGeometry(a_gdb->Geom(lev));
+            h_grid_assignors[lev] = m_locators[lev].getGridAssignor();
+        }
+        Gpu::htod_memcpy(m_grid_assignors.data(), h_grid_assignors.data(),
+                         sizeof(AssignGrid<BinIteratorFactory>)*num_levels);
+        Gpu::synchronize();
+#else
         for (int lev = 0; lev < num_levels; ++lev)
         {
             m_locators[lev].setGeometry(a_gdb->Geom(lev));
             m_grid_assignors[lev] = m_locators[lev].getGridAssignor();
         }
+#endif
     }
 
     AmrAssignGrid<BinIteratorFactory> getGridAssignor () const noexcept

--- a/Src/Particle/AMReX_ParticleReduce.H
+++ b/Src/Particle/AMReX_ParticleReduce.H
@@ -105,7 +105,7 @@ ReduceSum (PC const& pc, int lev_min, int lev_max, F&& f) -> decltype(f(typename
             {
                 const auto& tile = pti.GetParticleTile();
                 const auto np = tile.numParticles();
-				const auto ptd = tile.getConstParticleTileData();
+                const auto ptd = tile.getConstParticleTileData();
                 reduce_op.eval(np, reduce_data,
                 [=] AMREX_GPU_DEVICE (const int i) -> ReduceTuple {return {f(ptd.getSuperParticle(i))};});
             }

--- a/Src/Particle/AMReX_ParticleTile.H
+++ b/Src/Particle/AMReX_ParticleTile.H
@@ -13,8 +13,6 @@ namespace amrex {
 template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt>
 struct ParticleTileData
 {
-    static constexpr int NAR = NArrayReal;
-    static constexpr int NAI = NArrayInt;
     using ParticleType = Particle<NStructReal, NStructInt>;
     using SuperParticleType = Particle<NStructReal+NArrayReal, NStructInt+NArrayInt>;
 
@@ -153,8 +151,6 @@ struct ParticleTileData
 template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt>
 struct ConstParticleTileData
 {
-    static constexpr int NAR = NArrayReal;
-    static constexpr int NAI = NArrayInt;
     using ParticleType = Particle<NStructReal, NStructInt>;
     using SuperParticleType = Particle<NStructReal+NArrayReal, NStructInt+NArrayInt>;
 
@@ -236,9 +232,6 @@ template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt,
 struct ParticleTile
 {
     using ParticleType = Particle<NStructReal, NStructInt>;
-    static constexpr int NAR = NArrayReal;
-    static constexpr int NAI = NArrayInt;
-
     using SuperParticleType = Particle<NStructReal + NArrayReal, NStructInt + NArrayInt>;
 
     using AoS = ArrayOfStructs<NStructReal, NStructInt, Allocator>;
@@ -489,14 +482,37 @@ struct ParticleTile
     ParticleTileDataType getParticleTileData ()
     {
         int index = NArrayReal;
+#ifdef AMREX_USE_GPU
+        Gpu::HostVector<ParticleReal*> h_runtime_r_ptrs(m_runtime_r_ptrs.size());
+        for (auto& r_ptr : h_runtime_r_ptrs) {
+            r_ptr = m_soa_tile.GetRealData(index++).dataPtr();
+        }
+        if (h_runtime_r_ptrs.size() > 0) {
+            Gpu::htod_memcpy_async(m_runtime_r_ptrs.data(), h_runtime_r_ptrs.data(),
+                                   h_runtime_r_ptrs.size()*sizeof(ParticleReal*));
+        }
+#else
         for (auto& r_ptr : m_runtime_r_ptrs) {
             r_ptr = m_soa_tile.GetRealData(index++).dataPtr();
         }
+#endif
 
         index = NArrayInt;
+#ifdef AMREX_USE_GPU
+        Gpu::HostVector<int*> h_runtime_i_ptrs;
+        for (auto& i_ptr : h_runtime_i_ptrs) {
+            i_ptr = m_soa_tile.GetIntData(index++).dataPtr();
+        }
+        if (h_runtime_i_ptrs.size() > 0) {
+            Gpu::htod_memcpy_async(m_runtime_i_ptrs.data(), h_runtime_i_ptrs.data(),
+                                   h_runtime_i_ptrs.size()*sizeof(int*));
+        }
+#else
         for (auto& i_ptr : m_runtime_i_ptrs) {
             i_ptr = m_soa_tile.GetIntData(index++).dataPtr();
         }
+#endif
+
         ParticleTileDataType ptd;
         ptd.m_aos = m_aos_tile().dataPtr();
         for (int i = 0; i < NArrayReal; ++i)
@@ -508,20 +524,49 @@ struct ParticleTile
         ptd.m_num_runtime_int = m_runtime_i_ptrs.size();
         ptd.m_runtime_rdata = m_runtime_r_ptrs.dataPtr();
         ptd.m_runtime_idata = m_runtime_i_ptrs.dataPtr();
+
+#ifdef AMREX_USE_GPU
+        if ((h_runtime_r_ptrs.size() > 0) or (h_runtime_i_ptrs.size() > 0)) {
+            Gpu::synchronize();
+        }
+#endif
+
         return ptd;
     }
 
     ConstParticleTileDataType getConstParticleTileData () const
     {
         int index = NArrayReal;
+#ifdef AMREX_USE_GPU
+        Gpu::HostVector<ParticleReal const*> h_runtime_r_cptrs(m_runtime_r_cptrs.size());
+        for (auto& r_ptr : h_runtime_r_cptrs) {
+            r_ptr = m_soa_tile.GetRealData(index++).dataPtr();
+        }
+        if (h_runtime_r_cptrs.size() > 0) {
+            Gpu::htod_memcpy_async(m_runtime_r_cptrs.data(), h_runtime_r_cptrs.data(),
+                                   h_runtime_r_cptrs.size()*sizeof(ParticleReal const*));
+        }
+#else
         for (auto& r_ptr : m_runtime_r_cptrs) {
             r_ptr = m_soa_tile.GetRealData(index++).dataPtr();
         }
+#endif
 
         index = NArrayInt;
+#ifdef AMREX_USE_GPU
+        Gpu::HostVector<int const*> h_runtime_i_cptrs(m_runtime_i_cptrs.size());
+        for (auto& i_ptr : h_runtime_i_cptrs) {
+            i_ptr = m_soa_tile.GetIntData(index++).dataPtr();
+        }
+        if (h_runtime_i_cptrs.size() > 0) {
+            Gpu::htod_memcpy_async(m_runtime_i_cptrs.data(), h_runtime_i_cptrs.data(),
+                                   h_runtime_i_cptrs.size()*sizeof(int const*));
+        }
+#else
         for (auto& i_ptr : m_runtime_i_cptrs) {
             i_ptr = m_soa_tile.GetIntData(index++).dataPtr();
         }
+#endif
 
         ConstParticleTileDataType ptd;
         ptd.m_aos = m_aos_tile().dataPtr();
@@ -534,6 +579,13 @@ struct ParticleTile
         ptd.m_num_runtime_int = m_runtime_i_cptrs.size();
         ptd.m_runtime_rdata = m_runtime_r_cptrs.dataPtr();
         ptd.m_runtime_idata = m_runtime_i_cptrs.dataPtr();
+
+#ifdef AMREX_USE_GPU
+        if ((h_runtime_r_cptrs.size() > 0) or (h_runtime_i_cptrs.size() > 0)) {
+            Gpu::synchronize();
+        }
+#endif
+
         return ptd;
     }
 


### PR DESCRIPTION
## Summary

ParticleLocator and ParticleTile contain vectors using device memory.  To
remove the dependency on unified memory we avoid accessing them directly on
the host.

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
