### PR TITLE
Put static constexpr members back to ParticleTile

### DIFF
--- a/Src/Particle/AMReX_ParticleTile.H
+++ b/Src/Particle/AMReX_ParticleTile.H
@@ -13,6 +13,8 @@ namespace amrex {
 template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt>
 struct ParticleTileData
 {
+    static constexpr int NAR = NArrayReal;
+    static constexpr int NAI = NArrayInt;
     using ParticleType = Particle<NStructReal, NStructInt>;
     using SuperParticleType = Particle<NStructReal+NArrayReal, NStructInt+NArrayInt>;
 
@@ -151,6 +153,8 @@ struct ParticleTileData
 template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt>
 struct ConstParticleTileData
 {
+    static constexpr int NAR = NArrayReal;
+    static constexpr int NAI = NArrayInt;
     using ParticleType = Particle<NStructReal, NStructInt>;
     using SuperParticleType = Particle<NStructReal+NArrayReal, NStructInt+NArrayInt>;
 
@@ -232,6 +236,9 @@ template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt,
 struct ParticleTile
 {
     using ParticleType = Particle<NStructReal, NStructInt>;
+    static constexpr int NAR = NArrayReal;
+    static constexpr int NAI = NArrayInt;
+
     using SuperParticleType = Particle<NStructReal + NArrayReal, NStructInt + NArrayInt>;
 
     using AoS = ArrayOfStructs<NStructReal, NStructInt, Allocator>;


### PR DESCRIPTION
## Summary

They should not be removed in #1375.

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
