### PR TITLE
Fix #1375

### DIFF
--- a/Src/Particle/AMReX_ParticleTile.H
+++ b/Src/Particle/AMReX_ParticleTile.H
@@ -506,7 +506,7 @@ struct ParticleTile
 
         index = NArrayInt;
 #ifdef AMREX_USE_GPU
-        Gpu::HostVector<int*> h_runtime_i_ptrs;
+        Gpu::HostVector<int*> h_runtime_i_ptrs(m_runtime_i_ptrs.size());
         for (auto& i_ptr : h_runtime_i_ptrs) {
             i_ptr = m_soa_tile.GetIntData(index++).dataPtr();
         }


### PR DESCRIPTION
## Summary

A Bug was introduced in #1375.  The host vector should have an initial size.

## Additional background

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
