### PR TITLE
Fix tensor solver with periodic boundaries

### DIFF
--- a/Src/LinearSolvers/MLMG/AMReX_MLEBTensorOp.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBTensorOp.cpp
@@ -402,14 +402,12 @@ MLEBTensorOp::applyBCTensor (int amrlev, int mglev, MultiFab& vel,
         }
     }
 
-    vel.EnforcePeriodicity(0, AMREX_SPACEDIM, IntVect(1),
-                           m_geom[amrlev][mglev].periodicity());
+    // Notet that it is incorrect to call EnforcePeriodicity on vel.
 }
 
 void
 MLEBTensorOp::compCrossTerms(int amrlev, int mglev, MultiFab const& mf) const
 {
-
     auto factory = dynamic_cast<EBFArrayBoxFactory const*>(m_factory[amrlev][mglev].get());
     const FabArray<EBCellFlagFab>* flags = (factory) ? &(factory->getMultiEBCellFlagFab()) : nullptr;
     auto area = (factory) ? factory->getAreaFrac()

--- a/Src/LinearSolvers/MLMG/AMReX_MLTensorOp.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLTensorOp.cpp
@@ -384,8 +384,7 @@ MLTensorOp::applyBCTensor (int amrlev, int mglev, MultiFab& vel,
 #endif
     }
 
-    vel.EnforcePeriodicity(0, AMREX_SPACEDIM, IntVect(1),
-                           m_geom[amrlev][mglev].periodicity());
+    // Notet that it is incorrect to call EnforcePeriodicity on vel.
 #endif
 }
 


### PR DESCRIPTION
## Summary

Remove erroneous calls to EnforcePeriodicity.  When coarse/fine boundary
meets periodic boundary with fine grids form an L-shape, the uncovered fine
ghost cell at the corner is actually "multi-valued". That is the cells with
the same indices has different values in different boxes.  That's why
calling EnforcePeriodicity is erroneous.  For CPU runs, this bug introduces
deterministic errors, but the solver still converges.  For GPU runs, this
causes convergence issues too because EnforcePeriodicity is not
deterministic when the values inside domain are not consistent.

## Additional background

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [x] changes answers in the test suite to more than roundoff level
- [x] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
