### PR TITLE
Switch to `use mpi` from `include 'mpif.h'`

### DIFF
--- a/Src/F_Interfaces/Base/AMReX_parallel_mod.F90
+++ b/Src/F_Interfaces/Base/AMReX_parallel_mod.F90
@@ -1,8 +1,8 @@
 
 #ifdef BL_USE_MPI
 module amrex_fi_mpi
+  use mpi
   implicit none
-  include 'mpif.h'
 end module amrex_fi_mpi
 #endif
 


### PR DESCRIPTION
## Summary

This fixes #1382 

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
