### PR TITLE
Update package name in dpcpp CI

### DIFF
--- a/.github/workflows/dependencies/dependencies_dpcpp.sh
+++ b/.github/workflows/dependencies/dependencies_dpcpp.sh
@@ -18,7 +18,7 @@ sudo apt-get update
 
 sudo apt-get install -y --no-install-recommends \
     build-essential \
-    intel-oneapi-dpcpp-compiler intel-oneapi-mkl \
+    intel-oneapi-dpcpp-cpp-compiler intel-oneapi-mkl \
     g++ gfortran    \
     libopenmpi-dev  \
     openmpi-bin


### PR DESCRIPTION
## Summary

Since bet09, the dpcpp compiler package has been renamed to
intel-oneapi-dpcpp-cpp-compiler from intel-oneapi-dpcpp-compiler.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
