### PR TITLE
CMake & DPC++: Avoid Flag Deduplication

### DIFF
--- a/.github/workflows/dependencies/dependencies_dpcpp.sh
+++ b/.github/workflows/dependencies/dependencies_dpcpp.sh
@@ -18,7 +18,7 @@ sudo apt-get update
 
 sudo apt-get install -y --no-install-recommends \
     build-essential \
-    intel-oneapi-dpcpp-compiler intel-oneapi-mkl \
+    intel-oneapi-dpcpp-cpp-compiler intel-oneapi-mkl \
     g++ gfortran    \
     libopenmpi-dev  \
     openmpi-bin

--- a/Tools/CMake/AMReXSYCL.cmake
+++ b/Tools/CMake/AMReXSYCL.cmake
@@ -45,7 +45,7 @@ target_link_options( SYCL
 #   https://github.com/intel/llvm/issues/2187
 target_compile_options( SYCL
    INTERFACE
-   $<${_cxx_clang}:-mlong-double-64 -Xclang -mlong-double-64>)
+   $<${_cxx_clang}:-mlong-double-64 "SHELL:-Xclang -mlong-double-64">)
 
 if (ENABLE_DPCPP_AOT)
    message(FATAL_ERROR "\nAhead-of-time (AOT) compilation support not available yet.\nRe-configure with ENABLE_DPCPP_AOT=OFF.")


### PR DESCRIPTION
## Summary

Avoid deduplication of `-mlong-double-64 -Xclang -mlong-double-64` into `-mlong-double-64 -Xclang`.

Update the apt package name, which was changed by upstream for beta09.

Follow-up to: #1366

Refs.:
- https://gitlab.kitware.com/cmake/cmake/-/issues/15826
- https://gitlab.kitware.com/cmake/cmake/-/merge_requests/1841

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
