### PR TITLE
Fix function type for HIP

### DIFF
--- a/Src/Base/AMReX_MultiFab.cpp
+++ b/Src/Base/AMReX_MultiFab.cpp
@@ -47,7 +47,7 @@ MultiFab::Dot (const MultiFab& x, int xcomp,
 #ifdef AMREX_USE_GPU
     if (Gpu::inLaunchRegion()) {
         sm = amrex::ReduceSum(x, y, nghost,
-        [=] AMREX_GPU_DEVICE (Box const& bx, Array4<Real const> const& xfab, Array4<Real const> const& yfab) -> Real
+        [=] AMREX_GPU_HOST_DEVICE (Box const& bx, Array4<Real const> const& xfab, Array4<Real const> const& yfab) -> Real
         {
             Real t = 0.0;
             AMREX_LOOP_4D(bx, numcomp, i, j, k, n,


### PR DESCRIPTION
## Summary

Currently in HIP we do not have a way to do SFINAE based on whether the
function is callable on host or not.  So we have to replace the device
lambda with host and device lambda for HIP to compile.

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
