### PR TITLE
Intersect and Concatenate assertion adjustments.

### DIFF
--- a/Src/Base/AMReX_BoxList.cpp
+++ b/Src/Base/AMReX_BoxList.cpp
@@ -70,7 +70,7 @@ BoxList::clear ()
 void
 BoxList::join (const BoxList& blist)
 {
-    BL_ASSERT(ixType() == blist.ixType());
+    BL_ASSERT(blist.size() == 0 || ixType() == blist.ixType());
     m_lbox.insert(std::end(m_lbox), std::begin(blist), std::end(blist));
 }
 
@@ -84,7 +84,7 @@ BoxList::join (const Vector<Box>& barr)
 void
 BoxList::catenate (BoxList& blist)
 {
-    BL_ASSERT(ixType() == blist.ixType());
+    BL_ASSERT(blist.size() == 0 || ixType() == blist.ixType());
     m_lbox.insert(std::end(m_lbox), std::begin(blist), std::end(blist));
     blist.m_lbox.clear();
 }


### PR DESCRIPTION
## Summary
Fixes bug in BoxList assertions that checks for type on an empty BoxList, leading to a spurious error.

## Additional background

## Checklist

The proposed changes:
- [X] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
