### PR TITLE
Disable OpenMPI C++ binding in GNU make system

### DIFF
--- a/Tools/GNUMake/sites/Make.unknown
+++ b/Tools/GNUMake/sites/Make.unknown
@@ -77,6 +77,8 @@ ifeq ($(USE_MPI),TRUE)
       LIBRARIES += $(filter -l%,$(mpicxx_link_flags))
 #    endif
 
+     DEFINES += -DOMPI_SKIP_MPICXX
+
   else ifneq ($(findstring Spectrum MPI, $(shell $(MPI_OTHER_COMP) -showme:version 2>&1)),)
 
     #


### PR DESCRIPTION
## Summary

This should fix the warning reported in #1397.  Note that C++ binding has
been removed from the MPI-3 standard.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
