### PR TITLE
Update dpcpp flags

### DIFF
--- a/Tools/CMake/AMReXSYCL.cmake
+++ b/Tools/CMake/AMReXSYCL.cmake
@@ -31,7 +31,7 @@ target_link_libraries(SYCL INTERFACE ${LIBSYCL_GLIBC_OBJ})
 
 target_compile_options( SYCL
    INTERFACE
-   $<${_cxx_clang}:-Wno-error=sycl-strict -fsycl -fsycl-unnamed-lambda>
+   $<${_cxx_clang}:-Wno-error=sycl-strict -fsycl>
    $<${_cxx_clang}:$<$<BOOL:${ENABLE_DPCPP_SPLIT_KERNEL}>:-fsycl-device-code-split=per_kernel>>)
 
 # TODO: use $<LINK_LANG_AND_ID:> genex for CMake >=3.17
@@ -46,6 +46,12 @@ target_link_options( SYCL
 target_compile_options( SYCL
    INTERFACE
    $<${_cxx_clang}:-mlong-double-64 "SHELL:-Xclang -mlong-double-64">)
+
+# Beta09 has enabled eary optimizations by default.  But this causes many
+# tests to crash.  So we disable it.
+target_compile_options( SYCL
+   INTERFACE
+   $<${_cxx_clang}:-fno-sycl-early-optimizations>)
 
 if (ENABLE_DPCPP_AOT)
    message(FATAL_ERROR "\nAhead-of-time (AOT) compilation support not available yet.\nRe-configure with ENABLE_DPCPP_AOT=OFF.")

--- a/Tools/GNUMake/comps/dpcpp.mak
+++ b/Tools/GNUMake/comps/dpcpp.mak
@@ -24,7 +24,7 @@ ifeq ($(DEBUG),TRUE)
 else
 
   CXXFLAGS += -O3 # // xxxx DPCPP: todo -g in beta6 causes a lot of warning messages
-  CFLAGS   += -O3
+  CFLAGS   += -O3 #                       and makes linking much slower
 #  CXXFLAGS += -g -O3
 #  CFLAGS   += -g -O3
   FFLAGS   += -g -O3
@@ -61,7 +61,7 @@ ifdef CXXSTD
   CXXFLAGS += -std=$(strip $(CXXSTD))
 endif
 
-CXXFLAGS += -Wno-error=sycl-strict -fsycl -fsycl-unnamed-lambda
+CXXFLAGS += -Wno-error=sycl-strict -fsycl
 CFLAGS   += -std=c99
 
 ifneq ($(DEBUG),TRUE)  # There is currently a bug that DEBUG build will crash.
@@ -92,6 +92,10 @@ endif
 #   define "long double" as 64bit for C++ user-defined literals
 #   https://github.com/intel/llvm/issues/2187
 CXXFLAGS += -mlong-double-64 -Xclang -mlong-double-64
+
+# Beta09 has enabled early optimizations by default.  But this causes many
+# tests to crash.  So we disable it.
+CXXFLAGS += -fno-sycl-early-optimizations
 
 FFLAGS   += -ffixed-line-length-none -fno-range-check -fno-second-underscore
 F90FLAGS += -ffree-line-length-none -fno-range-check -fno-second-underscore -fimplicit-none


### PR DESCRIPTION
## Summary

* -fsycl-unnamed-lambda is enabled by default now.  So we do not need to
   pass the flag anymore.

* Early optimizations are enabled by default in beta09.  This makes a lot of
  tests crash.  So we disable it with -fno-sycl-early-optimizations.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
