### PR TITLE
CMake: enforce C++17 as minimum C++ standard for ENABLE_DPCPP=ON

### DIFF
--- a/Tools/CMake/AMReX_Config.cmake
+++ b/Tools/CMake/AMReX_Config.cmake
@@ -48,8 +48,12 @@ function (configure_amrex)
    # Moreover, it will also enforce such standard on all the consuming targets
    #
    set_target_properties(amrex PROPERTIES CXX_EXTENSIONS OFF)
-   # minimum: C++11 on Linux, C++17 on Windows
-   target_compile_features(amrex PUBLIC $<IF:$<STREQUAL:$<PLATFORM_ID>,Windows>,cxx_std_17,cxx_std_11>)
+   # minimum: C++11 on Linux, C++17 on Windows, C++17 for dpc++
+   if (ENABLE_DPCPP)
+      target_compile_features(amrex PUBLIC cxx_std_17)
+   else ()
+      target_compile_features(amrex PUBLIC $<IF:$<STREQUAL:$<PLATFORM_ID>,Windows>,cxx_std_17,cxx_std_11>)
+   endif ()
 
    if (ENABLE_CUDA AND (CMAKE_VERSION VERSION_GREATER_EQUAL 3.17) )
       set_target_properties(amrex PROPERTIES CUDA_EXTENSIONS OFF)


### PR DESCRIPTION
## Summary
Set minimum C++ standard to 17 when dpc++ is used. Reason:  MKL is using C++17.

Meta-reason: SYCL 2020 is C++17 or newer only, too.

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
