### PR TITLE
DPCPP: use C++17 and disable mkl warnings

### DIFF
--- a/Src/Base/AMReX_Random.H
+++ b/Src/Base/AMReX_Random.H
@@ -95,6 +95,7 @@ namespace amrex
 #elif defined(__HIP_DEVICE_COMPILE__)
         return hiprand_poisson(random_engine.rand_state, lambda);
 #elif defined (__SYCL_DEVICE_ONLY__)
+        amrex::ignore_unused(lambda,random_engine);
         amrex::Abort("RandomPossion not supported in DPC++ device code");
         return 0; // xxxxx DPCPP todo: Poisson distribution
 #else

--- a/Src/Base/AMReX_RandomEngine.H
+++ b/Src/Base/AMReX_RandomEngine.H
@@ -12,7 +12,7 @@
 #elif defined(AMREX_USE_DPCPP)
 #include <CL/sycl.hpp>
 namespace sycl = cl::sycl;
-// Disable warnings in mkl's rng header.  Too many noises.
+// Disable warnings in mkl's rng header.  Too much noise.
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wmissing-braces"
 #pragma clang diagnostic ignored "-Wunused-variable"

--- a/Src/Base/AMReX_RandomEngine.H
+++ b/Src/Base/AMReX_RandomEngine.H
@@ -12,7 +12,13 @@
 #elif defined(AMREX_USE_DPCPP)
 #include <CL/sycl.hpp>
 namespace sycl = cl::sycl;
+// Disable warnings in mkl's rng header.  Too many noises.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wmissing-braces"
+#pragma clang diagnostic ignored "-Wunused-variable"
+#pragma clang diagnostic ignored "-Wextra-semi"
 #include <mkl_rng_sycl_device.hpp>
+#pragma clang diagnostic pop
 #if (__SYCL_COMPILER_VERSION >= 20200827)
 namespace mkl = oneapi::mkl;
 #endif

--- a/Tools/GNUMake/comps/dpcpp.mak
+++ b/Tools/GNUMake/comps/dpcpp.mak
@@ -57,7 +57,13 @@ endif
 
 ########################################################################
 
-CXXFLAGS += -std=c++17 -Wno-error=sycl-strict -fsycl
+ifdef CXXSTD
+  CXXFLAGS += -std=$(strip $(CXXSTD))
+else
+  CXXFLAGS += -std=c++17
+endif
+
+CXXFLAGS += -Wno-error=sycl-strict -fsycl
 CFLAGS   += -std=c99
 
 ifneq ($(DEBUG),TRUE)  # There is currently a bug that DEBUG build will crash.

--- a/Tools/GNUMake/comps/dpcpp.mak
+++ b/Tools/GNUMake/comps/dpcpp.mak
@@ -57,11 +57,7 @@ endif
 
 ########################################################################
 
-ifdef CXXSTD
-  CXXFLAGS += -std=$(strip $(CXXSTD))
-endif
-
-CXXFLAGS += -Wno-error=sycl-strict -fsycl
+CXXFLAGS += -std=c++17 -Wno-error=sycl-strict -fsycl
 CFLAGS   += -std=c99
 
 ifneq ($(DEBUG),TRUE)  # There is currently a bug that DEBUG build will crash.


### PR DESCRIPTION
* Explicitly use C++17 because MKL contains C++17 codes.

* Disable warnings caused by MKL RNG header.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
