### PR TITLE
Enable compilation on Cori interactive nodes

### DIFF
--- a/Tools/GNUMake/Make.machines
+++ b/Tools/GNUMake/Make.machines
@@ -17,14 +17,14 @@ host_name_short := $(shell hostname -s)
 
 # MACHINES supported
 
-ifeq ($(findstring cori, $(host_name)), cori)
-  which_site := nersc
-  which_computer := cori
-endif
-
 ifeq ($(findstring cgpu, $(host_name)), cgpu)
   which_site := nersc
   which_computer := cgpu
+else ifdef NERSC_HOST
+  ifeq ($(NERSC_HOST), cori)
+    which_site := nersc
+    which_computer := cori
+  endif
 endif
 
 ifeq ($(findstring titan, $(host_name)), titan)


### PR DESCRIPTION
## Summary

This enables compilation in Cori interactive jobs.

Previously, in interactive jobs on Cori Haswell and KNL, `hostname -f` returned a string like `nid00018` so we were loading `Make.unknown`, causing compilation failure.

@WeiqunZhang suggested checking the `NERSC_HOST` environment variable instead, which is defined on Cori login, interactive (Haswell & KNL), and GPU nodes.

This PR moves the check in `Make.machines` for Cori to follow the logic for Cori GPU, and we check if `NERSC_HOST` is set to `cori`.

I've tested this works on Haswell & KNL interactive jobs and that we are still setting `which_computer` correctly on Cori GPU.

## Additional background

## Checklist

The proposed changes:
- [X] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
