### PR TITLE
ParallelDescriptor: Check MPI If Self

### DIFF
--- a/Src/Base/AMReX_ParallelDescriptor.cpp
+++ b/Src/Base/AMReX_ParallelDescriptor.cpp
@@ -327,7 +327,7 @@ ParallelDescriptor::StartParallel (int*    argc,
     amrex::ignore_unused(tfoo);
 
 #ifdef AMREX_MPI_THREAD_MULTIPLE
-    {
+    if ( ! sflag) {  // we initialized
         int requested = MPI_THREAD_MULTIPLE;
         int provided = -1;
         MPI_Query_thread(&provided);


### PR DESCRIPTION
## Summary

Only check the requested MPI Threading level if AMReX also initialized MPI.

Follow-up to #1351

## Additional background

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
