### PR TITLE
filterParticles and filterAndTransformParticles need to take callables with and without RNG

### DIFF
--- a/Src/Particle/AMReX_ParticleTransformation.H
+++ b/Src/Particle/AMReX_ParticleTransformation.H
@@ -6,6 +6,7 @@
 #include <AMReX_Gpu.H>
 #include <AMReX_Print.H>
 #include <AMReX_ParticleTile.H>
+#include <AMReX_ParticleUtil.H>
 
 namespace amrex
 {
@@ -371,7 +372,7 @@ auto filterParticles (DstTile& dst, const SrcTile& src, Pred&& p) noexcept
  * \param dst_start the offset at which to start writing particles to dst
  * \param n the number of particles to apply the operation to
  *
- */    
+ */
 template <typename DstTile, typename SrcTile, typename Pred, typename Index, typename N>
 auto filterParticles (DstTile& dst, const SrcTile& src, Pred&& p,
                       Index src_start, Index dst_start, N n) noexcept
@@ -382,10 +383,11 @@ auto filterParticles (DstTile& dst, const SrcTile& src, Pred&& p,
 
     auto p_mask = mask.dataPtr();
     const auto src_data = src.getConstParticleTileData();
-    
-    AMREX_HOST_DEVICE_FOR_1D(np, i,
+
+    amrex::ParallelForRNG(np,
+    [=] AMREX_GPU_DEVICE (int i, amrex::RandomEngine const& engine) noexcept
     {
-        p_mask[i] = p(src_data, i);
+        p_mask[i] = particle_detail::call_f(p, src_data, i, engine);
     });
 
     return filterParticles(dst, src, mask.dataPtr(), src_start, dst_start, n);
@@ -394,7 +396,7 @@ auto filterParticles (DstTile& dst, const SrcTile& src, Pred&& p,
 /**
  * \brief Conditionally copy particles from src to dst based on the value of mask.
  * A transformation will also be applied to the particles on copy.
- * 
+ *
  * \tparam DstTile the dst particle tile type
  * \tparam SrcTile the src particle tile type
  * \tparam Index the index type, e.g. unsigned int
@@ -457,10 +459,11 @@ auto filterAndTransformParticles (DstTile& dst, const SrcTile& src, Pred&& p, F&
 
     auto p_mask = mask.dataPtr();
     const auto src_data = src.getConstParticleTileData();
-    
-    AMREX_HOST_DEVICE_FOR_1D(np, i,
+
+    amrex::ParallelForRNG(np,
+    [=] AMREX_GPU_DEVICE (int i, amrex::RandomEngine const& engine) noexcept
     {
-        p_mask[i] = p(src_data, i);
+        p_mask[i] = particle_detail::call_f(p, src_data, i, engine);
     });
 
     return filterAndTransformParticles(dst, src, mask.dataPtr(), std::forward<F>(f));
@@ -540,10 +543,11 @@ auto filterAndTransformParticles (DstTile1& dst1, DstTile2& dst2, const SrcTile&
 
     auto p_mask = mask.dataPtr();
     const auto src_data = src.getConstParticleTileData();
-    
-    AMREX_HOST_DEVICE_FOR_1D(np, i,
+
+    amrex::ParallelForRNG(np,
+    [=] AMREX_GPU_DEVICE (int i, amrex::RandomEngine const& engine) noexcept
     {
-        p_mask[i] = p(src_data, i);
+        p_mask[i] = particle_detail::call_f(p, src_data, i, engine);
     });
 
     return filterAndTransformParticles(dst1, dst2, src, mask.dataPtr(), std::forward<F>(f));

--- a/Src/Particle/AMReX_ParticleUtil.H
+++ b/Src/Particle/AMReX_ParticleUtil.H
@@ -18,6 +18,42 @@
 namespace amrex
 {
 
+namespace particle_detail {
+
+template <typename F, typename P>
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE
+auto call_f (F const& f, P const& p, amrex::RandomEngine const& engine) noexcept
+    -> decltype(f(P{},RandomEngine{}))
+{
+    return f(p,engine);
+}
+
+template <typename F, typename P>
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE
+auto call_f (F const& f, P const& p, amrex::RandomEngine const&) noexcept
+    -> decltype(f(P{}))
+{
+    return f(p);
+}
+
+template <typename F, typename SrcData, typename N>
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE
+auto call_f (F const& f, SrcData const& src, N i, amrex::RandomEngine const& engine) noexcept
+    -> decltype(f(SrcData{},N{},RandomEngine{}))
+{
+    return f(src,i,engine);
+}
+
+template <typename F, typename SrcData, typename N>
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE
+auto call_f (F const& f, SrcData const& src, N i, amrex::RandomEngine const& engine) noexcept
+    -> decltype(f(SrcData{},N{}))
+{
+    return f(src,i);
+}
+
+}
+
 /**
  * \brief Returns the number of particles that are more than nGrow cells
  * from the box correspond to the input iterator.

--- a/Src/Particle/AMReX_ParticleUtil.H
+++ b/Src/Particle/AMReX_ParticleUtil.H
@@ -46,7 +46,7 @@ auto call_f (F const& f, SrcData const& src, N i, amrex::RandomEngine const& eng
 
 template <typename F, typename SrcData, typename N>
 AMREX_GPU_DEVICE AMREX_FORCE_INLINE
-auto call_f (F const& f, SrcData const& src, N i, amrex::RandomEngine const& engine) noexcept
+auto call_f (F const& f, SrcData const& src, N i, amrex::RandomEngine const&) noexcept
     -> decltype(f(SrcData{},N{}))
 {
     return f(src,i);

--- a/Src/Particle/AMReX_WriteBinaryParticleData.H
+++ b/Src/Particle/AMReX_WriteBinaryParticleData.H
@@ -3,11 +3,10 @@
 
 #include <AMReX_TypeTraits.H>
 #include <AMReX_Particles.H>
-
-// note - namespace
+#include <AMReX_ParticleUtil.H>
 
 struct KeepValidFilter
-{    
+{
     template <typename SrcData>
     AMREX_GPU_HOST_DEVICE
     int operator() (const SrcData& src, int i) const noexcept
@@ -22,26 +21,6 @@ std::size_t PSizeInFile (const Vector<int>& wrc, const Vector<int>& wic)
     std::size_t rsize = sizeof(ParticleReal)*std::accumulate(wrc.begin(), wrc.end(), 0);
     std::size_t isize = sizeof(int)*std::accumulate(wic.begin(), wic.end(), 0);
     return rsize + isize + AMREX_SPACEDIM*sizeof(ParticleReal) + 2*sizeof(int);
-}
-
-namespace particle_detail {
-
-template <typename F, typename P>
-AMREX_GPU_DEVICE AMREX_FORCE_INLINE
-auto call_f (F const& f, P const& p, amrex::RandomEngine const& engine) noexcept
-    -> decltype(f(P{},RandomEngine{}))
-{
-    return f(p,engine);
-}
-
-template <typename F, typename P>
-AMREX_GPU_DEVICE AMREX_FORCE_INLINE
-auto call_f (F const& f, P const& p, amrex::RandomEngine const&) noexcept
-    -> decltype(f(P{}))
-{
-    return f(p);
-}
-
 }
 
 template <class PC, class F, EnableIf_t<IsParticleContainer<PC>::value, int> foo = 0>


### PR DESCRIPTION
The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
