### PR TITLE
Define ParticleTile in AddParticles

### DIFF
--- a/Src/Particle/AMReX_ParIter.H
+++ b/Src/Particle/AMReX_ParIter.H
@@ -70,11 +70,6 @@ public:
 
     SoARef GetStructOfArrays () const { return GetParticleTile().GetStructOfArrays(); }
 
-    template <typename Container>
-    void GetPosition (AMREX_D_DECL(Container& x,
-                                   Container& y,
-                                   Container& z)) const;
-
     int numParticles () const { return GetArrayOfStructs().numParticles(); }
 
     int numRealParticles () const { return GetArrayOfStructs().numRealParticles(); }
@@ -117,12 +112,6 @@ public:
     ParIter (ContainerType& pc, int level, MFItInfo& info)
         : ParIterBase<false,NStructReal,NStructInt,NArrayReal,NArrayInt>(pc,level,info)
         {}
-
-    template <typename Container>
-
-    void SetPosition (AMREX_D_DECL(const Container& x,
-                                   const Container& y,
-                                   const Container& z)) const;
 };
 
 template <int NStructReal, int NStructInt=0, int NArrayReal=0, int NArrayInt=0>
@@ -146,7 +135,6 @@ public:
     ParConstIter (ContainerType const& pc, int level, MFItInfo& info)
         : ParIterBase<true,NStructReal,NStructInt,NArrayReal,NArrayInt>(pc,level,info)
         {}
-
 };
 
 template <bool is_const, int NStructReal, int NStructInt, int NArrayReal, int NArrayInt>
@@ -233,60 +221,6 @@ ParIterBase<is_const, NStructReal, NStructInt, NArrayReal, NArrayInt>::ParIterBa
         currentIndex = beginIndex = m_valid_index.front();
         m_valid_index.push_back(endIndex);
     }
-}
-
-template <bool is_const, int NStructReal, int NStructInt, int NArrayReal, int NArrayInt>
-template <typename Container>
-void
-ParIterBase<is_const, NStructReal, NStructInt, NArrayReal, NArrayInt>::GetPosition
-(AMREX_D_DECL(Container& x, Container& y, Container& z)) const
-{
-    const auto& aos = GetArrayOfStructs();
-    const auto np = aos.numParticles();
-
-    AMREX_D_TERM(x.resize(np);, y.resize(np);, z.resize(np););
-    
-    const auto pstruct_ptr = aos().data();
-
-    AMREX_D_TERM(auto x_ptr = x.data();,
-                 auto y_ptr = y.data();,
-                 auto z_ptr = z.data();)
-    
-    AMREX_FOR_1D( np, i,
-    {
-        AMREX_D_TERM(x_ptr[i] = pstruct_ptr[i].pos(0);,
-                     y_ptr[i] = pstruct_ptr[i].pos(1);,
-                     z_ptr[i] = pstruct_ptr[i].pos(2);)
-    });
-
-    Gpu::streamSynchronize();
-}
-
-template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt>
-template <typename Container>
-void
-ParIter<NStructReal, NStructInt, NArrayReal, NArrayInt>::SetPosition
-(AMREX_D_DECL(const Container& x, const Container& y, const Container& z)) const
-{
-    auto& aos = this->GetArrayOfStructs();
-    const auto np = aos.numParticles();
-
-    auto pstruct_ptr = aos().data();
-
-    AMREX_D_TERM(const auto x_ptr = x.data();,
-                 const auto y_ptr = y.data();,
-                 const auto z_ptr = z.data();)
-    
-    AMREX_ASSERT(AMREX_D_TERM(x.size() == np, && y.size() == np, && z.size() == np));
-    
-    AMREX_FOR_1D( np, i,
-    {
-        AMREX_D_TERM(pstruct_ptr[i].pos(0) = x_ptr[i];,
-                     pstruct_ptr[i].pos(1) = y_ptr[i];,
-                     pstruct_ptr[i].pos(2) = z_ptr[i];)
-    });
-
-    Gpu::streamSynchronize();
 }
 
 }

--- a/Src/Particle/AMReX_ParticleContainerI.H
+++ b/Src/Particle/AMReX_ParticleContainerI.H
@@ -966,7 +966,7 @@ void
 ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>::
 addParticles (const ParticleContainerType& other, bool local)
 {
-    using PData = ConstParticleTileData<NStructReal, NStructInt, NArrayReal, NArrayInt>; 
+    using PData = ConstParticleTileData<NStructReal, NStructInt, NArrayReal, NArrayInt>;
     addParticles(other, [=] AMREX_GPU_HOST_DEVICE (const PData& /*data*/, int /*i*/) { return 1; }, local);
 }
 
@@ -1000,7 +1000,7 @@ addParticles (const ParticleContainerType& other, F&& f, bool local)
             auto index = std::make_pair(mfi.index(), mfi.LocalTileIndex());
             if(plevel_other.find(index) == plevel_other.end()) continue;
 
-            auto& ptile = plevel[index];
+            auto& ptile = DefineAndReturnParticleTile(lev, mfi.index(), mfi.LocalTileIndex());
             const auto& ptile_other = plevel_other.at(index);
             auto np = ptile_other.numParticles();
             if (np == 0) continue;


### PR DESCRIPTION
This assures that, when runtime components are used, the operation will succeed whether or not users have touched all the tiles yet.

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
