### PR TITLE
update linear solver documentation and remove misleading MLMG flag

### DIFF
--- a/Src/F_Interfaces/LinearSolvers/AMReX_multigrid_fi.cpp
+++ b/Src/F_Interfaces/LinearSolvers/AMReX_multigrid_fi.cpp
@@ -96,9 +96,9 @@
          }
      }
 
-     void amrex_fi_multigrid_set_cg_verbose (MLMG* mlmg, int n)
+     void amrex_fi_multigrid_set_bottom_verbose (MLMG* mlmg, int n)
      {
-         mlmg->setCGVerbose(n);
+         mlmg->setBottomVerbose(n);
      }
      
      void amrex_fi_multigrid_set_always_use_bnorm (MLMG* mlmg, int f)

--- a/Src/F_Interfaces/LinearSolvers/AMReX_multigrid_mod.F90
+++ b/Src/F_Interfaces/LinearSolvers/AMReX_multigrid_mod.F90
@@ -30,7 +30,7 @@ module amrex_multigrid_module
      procedure :: set_max_fmg_iter      => amrex_multigrid_set_max_fmg_iter
      procedure :: set_fixed_iter        => amrex_multigrid_set_fixed_iter
      procedure :: set_bottom_solver     => amrex_multigrid_set_bottom_solver
-     procedure :: set_cg_verbose        => amrex_multigrid_set_cg_verbose
+     procedure :: set_bottom_verbose    => amrex_multigrid_set_bottom_verbose
      procedure :: set_always_use_bnorm  => amrex_multigrid_set_always_use_bnorm
      procedure :: set_final_fill_bc     => amrex_multigrid_set_final_fill_bc
      procedure, private :: amrex_multigrid_assign
@@ -42,7 +42,7 @@ module amrex_multigrid_module
      procedure, private :: amrex_multigrid_set_max_iter
      procedure, private :: amrex_multigrid_set_max_fmg_iter
      procedure, private :: amrex_multigrid_set_fixed_iter
-     procedure, private :: amrex_multigrid_set_cg_verbose
+     procedure, private :: amrex_multigrid_set_bottom_verbose
      procedure, private :: amrex_multigrid_set_always_use_bnorm
      procedure, private :: amrex_multigrid_set_final_fill_bc
 
@@ -132,12 +132,12 @@ module amrex_multigrid_module
        integer(c_int), value :: s
      end subroutine amrex_fi_multigrid_set_bottom_solver
 
-     subroutine amrex_fi_multigrid_set_cg_verbose (mg, v) bind(c)
+     subroutine amrex_fi_multigrid_set_bottom_verbose (mg, v) bind(c)
        import
        implicit none
        type(c_ptr), value :: mg
        integer(c_int), value :: v
-     end subroutine amrex_fi_multigrid_set_cg_verbose
+     end subroutine amrex_fi_multigrid_set_bottom_verbose
 
      subroutine amrex_fi_multigrid_set_always_use_bnorm (mg, f) bind(c)
        import
@@ -283,11 +283,11 @@ contains
   end subroutine amrex_multigrid_set_bottom_solver
 
 
-  subroutine amrex_multigrid_set_cg_verbose (mg, v)
+  subroutine amrex_multigrid_set_bottom_verbose (mg, v)
     class(amrex_multigrid), intent(inout) :: mg
     integer, intent(in) :: v
-    call amrex_fi_multigrid_set_cg_verbose(mg%p, v)
-  end subroutine amrex_multigrid_set_cg_verbose
+    call amrex_fi_multigrid_set_bottom_verbose(mg%p, v)
+  end subroutine amrex_multigrid_set_bottom_verbose
 
 
   subroutine amrex_multigrid_set_always_use_bnorm (mg, f)

--- a/Src/LinearSolvers/MLMG/AMReX_MLMG.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLMG.H
@@ -87,9 +87,6 @@ public:
     void setBottomTolerance (Real t) noexcept { bottom_reltol = t; }
     void setBottomToleranceAbs (Real t) noexcept { bottom_abstol = t;}
     Real getBottomToleranceAbs () noexcept{ return bottom_abstol; }
-    void setCGVerbose (int v) noexcept { bottom_verbose = v; }
-    void setCGMaxIter (int n) noexcept { bottom_maxiter = n; }
-    void setCGTolerance (Real t) noexcept { bottom_reltol = t; }
 
     void setAlwaysUseBNorm (int flag) noexcept { always_use_bnorm = flag; }
 

--- a/Tests/LinearSolvers/MLMG/inputs
+++ b/Tests/LinearSolvers/MLMG/inputs
@@ -20,7 +20,7 @@ max_grid_size = 64
 
 # For MLMG
 verbose = 2
-cg_verbose = 0
+bottom_verbose = 0
 max_iter = 100
 max_fmg_iter = 0     # # of F-cycles before switching to V.  To do pure V-cycle, set to 0
 linop_maxorder = 2

--- a/Tests/LinearSolvers/MLMG/inputs.boxes
+++ b/Tests/LinearSolvers/MLMG/inputs.boxes
@@ -19,7 +19,7 @@ max_grid_size = 64
 
 # For MLMG
 verbose = 2
-cg_verbose = 0
+bottom_verbose = 0
 max_iter = 100
 max_fmg_iter = 0     # # of F-cycles before switching to V.  To do pure V-cycle, set to 0
 linop_maxorder = 2

--- a/Tests/LinearSolvers/MLMG/solve_with_mlmg.cpp
+++ b/Tests/LinearSolvers/MLMG/solve_with_mlmg.cpp
@@ -15,7 +15,7 @@ static int max_iter = 100;
 static int max_fmg_iter = 20;
 static int max_coarsening_level = 30;
 static int verbose  = 2;
-static int cg_verbose = 0;
+static int bottom_verbose = 0;
 static int linop_maxorder = 2;
 static bool agglomeration = false;
 static bool consolidation = false;
@@ -39,7 +39,7 @@ void solve_with_mlmg(const Vector<Geometry>& geom, int ref_ratio,
     pp.query("max_fmg_iter", max_fmg_iter);
     pp.query("max_coarsening_level", max_coarsening_level);
     pp.query("verbose", verbose);
-    pp.query("cg_verbose", cg_verbose);
+    pp.query("bottom_verbose", bottom_verbose);
     pp.query("linop_maxorder", linop_maxorder);
     pp.query("agglomeration", agglomeration);
     pp.query("consolidation", consolidation);
@@ -94,7 +94,7 @@ void solve_with_mlmg(const Vector<Geometry>& geom, int ref_ratio,
     mlmg.setMaxFmgIter(max_fmg_iter);
     if (use_hypre) mlmg.setBottomSolver(MLMG::BottomSolver::hypre);
     mlmg.setVerbose(verbose);
-    mlmg.setBottomVerbose(cg_verbose);
+    mlmg.setBottomVerbose(bottom_verbose);
 
     mlmg.solve(psoln, prhs, tol_rel, tol_abs);
   } else {
@@ -136,7 +136,7 @@ void solve_with_mlmg(const Vector<Geometry>& geom, int ref_ratio,
       mlmg.setMaxIter(max_iter);
       mlmg.setMaxFmgIter(max_fmg_iter);
       mlmg.setVerbose(verbose);
-      mlmg.setBottomVerbose(cg_verbose);
+      mlmg.setBottomVerbose(bottom_verbose);
 
       mlmg.solve({&soln[ilev]}, {&rhs[ilev]}, tol_rel, tol_abs);
     }

--- a/Tutorials/Basic/HeatEquation_EX3_C/Source/advance.cpp
+++ b/Tutorials/Basic/HeatEquation_EX3_C/Source/advance.cpp
@@ -125,8 +125,8 @@ void advance (MultiFab& phi_old,
     mlmg.setMaxFmgIter(max_fmg_iter);
     int verbose = 2;
     mlmg.setVerbose(verbose);
-    int cg_verbose = 0;
-    mlmg.setCGVerbose(cg_verbose);
+    int bottom_verbose = 0;
+    mlmg.setBottomVerbose(bottom_verbose);
 
     // relative and absolute tolerances for linear solve
     const Real tol_rel = 1.e-10;

--- a/Tutorials/LinearSolvers/ABecLaplacian_F/inputs
+++ b/Tutorials/LinearSolvers/ABecLaplacian_F/inputs
@@ -12,7 +12,7 @@ prob_type = 1
 
 # For MLMG
 verbose = 2
-cg_verbose = 0
+bottom_verbose = 0
 max_iter = 100
 max_fmg_iter = 0     # # of F-cycles before switching to V.  To do pure V-cycle, set to 0
 linop_maxorder = 2

--- a/Tutorials/LinearSolvers/ABecLaplacian_F/inputs-rt-abeclap-lev
+++ b/Tutorials/LinearSolvers/ABecLaplacian_F/inputs-rt-abeclap-lev
@@ -12,7 +12,7 @@ prob_type = 2
 
 # For MLMG
 verbose = 2
-cg_verbose = 0
+bottom_verbose = 0
 max_iter = 100
 max_fmg_iter = 0     # # of F-cycles before switching to V.  To do pure V-cycle, set to 0
 linop_maxorder = 2

--- a/Tutorials/LinearSolvers/ABecLaplacian_F/inputs-rt-poisson-com
+++ b/Tutorials/LinearSolvers/ABecLaplacian_F/inputs-rt-poisson-com
@@ -12,7 +12,7 @@ prob_type = 1
 
 # For MLMG
 verbose = 2
-cg_verbose = 0
+bottom_verbose = 0
 max_iter = 100
 max_fmg_iter = 0     # # of F-cycles before switching to V.  To do pure V-cycle, set to 0
 linop_maxorder = 2

--- a/Tutorials/LinearSolvers/ABecLaplacian_F/mytest.F90
+++ b/Tutorials/LinearSolvers/ABecLaplacian_F/mytest.F90
@@ -20,7 +20,7 @@ module mytest_module
   integer, save :: prob_type = 1
 
   integer, save :: verbose = 2
-  integer, save :: cg_verbose = 0
+  integer, save :: bottom_verbose = 0
   integer, save :: max_iter = 100
   integer, save :: max_fmg_iter = 0
   integer, save :: bottom_solver = amrex_bottom_default
@@ -68,7 +68,7 @@ contains
     call pp % query("prob_type", prob_type)
 
     call pp % query("verbose", verbose)
-    call pp % query("cg_verbose", cg_verbose)
+    call pp % query("bottom_verbose", bottom_verbose)
     call pp % query("max_iter", max_iter)
     call pp % query("max_fmg_iter", max_fmg_iter)
     call pp % query("bottom_solver", bottom_solver)
@@ -201,7 +201,7 @@ contains
 
        call amrex_multigrid_build(multigrid, poisson)
        call multigrid % set_verbose(verbose)
-       call multigrid % set_cg_verbose(cg_verbose)
+       call multigrid % set_bottom_verbose(bottom_verbose)
        call multigrid % set_max_iter(max_iter)
        call multigrid % set_max_fmg_iter(max_fmg_iter)
        call multigrid % set_bottom_solver(bottom_solver)
@@ -241,7 +241,7 @@ contains
 
           call amrex_multigrid_build(multigrid, poisson);
           call multigrid % set_verbose(verbose)
-          call multigrid % set_cg_verbose(cg_verbose)
+          call multigrid % set_bottom_verbose(bottom_verbose)
           call multigrid % set_max_iter(max_iter)
           call multigrid % set_max_fmg_iter(max_fmg_iter)
           call multigrid % set_bottom_solver(bottom_solver)
@@ -303,7 +303,7 @@ contains
 
        call amrex_multigrid_build(multigrid, abeclap)
        call multigrid % set_verbose(verbose)
-       call multigrid % set_cg_verbose(cg_verbose)
+       call multigrid % set_bottom_verbose(bottom_verbose)
        call multigrid % set_max_iter(max_iter)
        call multigrid % set_max_fmg_iter(max_fmg_iter)
        call multigrid % set_bottom_solver(bottom_solver)
@@ -340,7 +340,7 @@ contains
 
        call amrex_multigrid_build(multigrid, abeclap)
        call multigrid % set_verbose(verbose)
-       call multigrid % set_cg_verbose(cg_verbose)
+       call multigrid % set_bottom_verbose(bottom_verbose)
        call multigrid % set_max_iter(max_iter)
        call multigrid % set_max_fmg_iter(max_fmg_iter)
        call multigrid % set_bottom_solver(bottom_solver)

--- a/Tutorials/LinearSolvers/MAC_Projection_EB/inputs_3d
+++ b/Tutorials/LinearSolvers/MAC_Projection_EB/inputs_3d
@@ -8,6 +8,6 @@ obstacles = 0 1 2 3 4 5 6 7 8            # this is how we choose which obstacles
 use_hypre = 0                            # if 1 then use hypre instead of geometric multigrid      (default: 0)
 
 mg_verbose = 2                           # specify verbosity of geometric multigrid solver         (default: 0)
-cg_verbose = 2                           # specify verbosity of the BiCGStab bottom solver if used (default: 0)
+bottom_verbose = 2                       # specify verbosity of the bottom solver                  (default: 0)
 
 regtest    = 0                           # If regtest == 1 then we don't plot zvel (used for regression testing with GPUs)

--- a/Tutorials/LinearSolvers/MAC_Projection_EB/main.cpp
+++ b/Tutorials/LinearSolvers/MAC_Projection_EB/main.cpp
@@ -52,7 +52,7 @@ int main (int argc, char* argv[])
 
     {
         int mg_verbose = 0;
-        int cg_verbose = 0;
+        int bottom_verbose = 0;
         int n_cell = 128;
         int max_grid_size = 32;
         int use_hypre  = 0;
@@ -64,7 +64,7 @@ int main (int argc, char* argv[])
         {
             ParmParse pp;
             pp.query("mg_verbose", mg_verbose);
-            pp.query("cg_verbose", cg_verbose);
+            pp.query("bottom_verbose", bottom_verbose);
             pp.query("n_cell", n_cell);
             pp.query("max_grid_size", max_grid_size);
             pp.query("use_hypre", use_hypre);
@@ -217,7 +217,7 @@ int main (int argc, char* argv[])
 					  LinOpBCType::Periodic)});
 
         macproj.setVerbose(mg_verbose);
-        macproj.getMLMG().setBottomVerbose(cg_verbose);
+        macproj.getMLMG().setBottomVerbose(bottom_verbose);
 
 	// Define the relative tolerance
         Real reltol = 1.e-8;

--- a/Tutorials/LinearSolvers/MultiComponent/inputs
+++ b/Tutorials/LinearSolvers/MultiComponent/inputs
@@ -4,7 +4,7 @@ mesh.max_grid_size = 32         # Maximum grid size (default = very large --> no
 
 mlmg.fixed_iter = 1000          # Number of iterations before exiting gracefully
 mlmg.verbose = 2                # Verbosity of MLMG
-mlmg.cg_verbose = 0             # Verbosity of bottom solve
+mlmg.bottom_verbose = 0         # Verbosity of bottom solve
 mlmg.max_iter = 100             # Max number of iterations before error
 mlmg.max_fmg_iter = 100         # Number of F-cycles 
 mlmg.agglomeration = 1          # Do agglomeration 

--- a/Tutorials/LinearSolvers/MultiComponent/main.cpp
+++ b/Tutorials/LinearSolvers/MultiComponent/main.cpp
@@ -71,7 +71,7 @@ int main (int argc, char* argv[])
     //
     struct {
         int verbose = -1;
-        int cg_verbose = -1;
+        int bottom_verbose = -1;
         int max_iter = -1;
         int fixed_iter = -1;
         int max_fmg_iter = -1;
@@ -83,7 +83,7 @@ int main (int argc, char* argv[])
     {
         ParmParse pp("mlmg");
         pp.query("verbose",mlmg.verbose);
-        pp.query("cg_verbose",mlmg.cg_verbose );
+        pp.query("bottom_verbose",mlmg.bottom_verbose );
         pp.query("max_iter",mlmg.max_iter);
         pp.query("max_fmg_iter",mlmg.max_fmg_iter);
         pp.query("agglomeration",mlmg.agglomeration);
@@ -209,7 +209,7 @@ int main (int argc, char* argv[])
     //
     MLMG solver(linop);
     if (mlmg.verbose >= 0)     solver.setVerbose(mlmg.verbose);
-    if (mlmg.cg_verbose >= 0)  solver.setCGVerbose(mlmg.cg_verbose);
+    if (mlmg.bottom_verbose >= 0)  solver.setBottomVerbose(mlmg.bottom_verbose);
     if (mlmg.fixed_iter >= 0)  solver.setFixedIter(mlmg.fixed_iter);
     if (mlmg.max_iter >= 0)    solver.setMaxIter(mlmg.max_iter);
     if (mlmg.max_fmg_iter >= 0)solver.setMaxFmgIter(mlmg.max_fmg_iter);

--- a/Tutorials/LinearSolvers/Nodal_Projection_EB/inputs_3d
+++ b/Tutorials/LinearSolvers/Nodal_Projection_EB/inputs_3d
@@ -8,4 +8,4 @@ obstacles = 0 1 2 3 4 5 6 7 8            # this is how we choose which obstacles
 use_hypre = 0                            # if 1 then use hypre instead of geometric multigrid      (default: 0)
 
 mg_verbose = 2                           # specify verbosity of geometric multigrid solver         (default: 0)
-cg_verbose = 2                           # specify verbosity of the BiCGStab bottom solver if used (default: 0)
+bottom_verbose = 2                       # specify verbosity of the bottom solver if used (default: 0)

--- a/Tutorials/LinearSolvers/Nodal_Projection_EB/main.cpp
+++ b/Tutorials/LinearSolvers/Nodal_Projection_EB/main.cpp
@@ -39,7 +39,7 @@ int main (int argc, char* argv[])
     
     {
         int mg_verbose = 0;
-        int cg_verbose = 0;
+        int bottom_verbose = 0;
         int n_cell = 128;
         int max_grid_size = 32;
         int use_hypre  = 0;
@@ -50,7 +50,7 @@ int main (int argc, char* argv[])
         {
             ParmParse pp;
             pp.query("mg_verbose", mg_verbose);
-            pp.query("cg_verbose", cg_verbose);
+            pp.query("bottom_verbose", bottom_verbose);
             pp.query("n_cell", n_cell);
             pp.query("max_grid_size", max_grid_size);
             pp.query("use_hypre", use_hypre);
@@ -236,10 +236,10 @@ int main (int argc, char* argv[])
  
         // We can specify the maximum number of iterations
         // nodal_solver.setMaxIter(nodal_mg_maxiter);
-        // nodal_solver.setCGMaxIter(nodal_mg_cg_maxiter);
+        // nodal_solver.setBottomMaxIter(nodal_mg_bottom_maxiter);
  
         nodal_solver.setVerbose(mg_verbose);
-        nodal_solver.setCGVerbose(cg_verbose);
+        nodal_solver.setBottomVerbose(bottom_verbose);
 
         // Set bottom-solver to use hypre instead of native BiCGStab 
         //   ( we could also have set this to cg, bicgcg, cgbicg)

--- a/Tutorials/SDC/MISDC_ADR_2d/Source/main.cpp
+++ b/Tutorials/SDC/MISDC_ADR_2d/Source/main.cpp
@@ -261,8 +261,8 @@ void main_main ()
   mlmg.setMaxFmgIter(max_fmg_iter);
   int verbose = 1;
   mlmg.setVerbose(verbose);
-  int cg_verbose = 0;
-  mlmg.setCGVerbose(cg_verbose);
+  int bottom_verbose = 0;
+  mlmg.setBottomVerbose(bottom_verbose);
   
 
   //  Do the time stepp[ing


### PR DESCRIPTION
1) remove flags setCGVerbose and setCGMaxIter since those are more accurately called
setBottomVerbose and setBottomMaxIter.   The "setCG..." flags are misleading since
they actually apply to non-CG bottom solvers as well.
2) add documentation in the Linear Solvers section about "maxorder" -- this was not previously documented.

## Summary

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [x] are described in the proposed changes to the AMReX documentation, if appropriate
