### PR TITLE
Always clear neighbor particles before calling Redistribute(). Closes #1410.

### DIFF
--- a/Src/Particle/AMReX_NeighborParticles.H
+++ b/Src/Particle/AMReX_NeighborParticles.H
@@ -258,6 +258,13 @@ public:
         return neighbors[lev][std::make_pair(grid,tile)];
     }
 
+    void Redistribute (int lev_min=0, int lev_max=-1, int nGrow=0, int local=0)
+    {
+        clearNeighbors();
+        ParticleContainer<NStructReal, NStructInt, 0, 0>::Redistribute(lev_min, lev_max,
+                                                                       nGrow, local);
+    }
+
     void RedistributeLocal ()
     {
         const int lev_min = 0;


### PR DESCRIPTION
Redistribute() assumes neighbor particles are already clear. This wraps the function so that this will always be the case. Since the neighbor particles make use of particle indices, they are invalidated by the Redistribute() call anway. 

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
