### PR TITLE
Make the id and cpu members of amrex_particle private, as they should…

### DIFF
--- a/Src/F_Interfaces/Particle/AMReX_particlecontainer_mod.F90
+++ b/Src/F_Interfaces/Particle/AMReX_particlecontainer_mod.F90
@@ -18,8 +18,8 @@ module amrex_particlecontainer_module
   type, bind(C), public :: amrex_particle
      real(amrex_particle_real)    :: pos(AMREX_SPACEDIM) !< Position
      real(amrex_particle_real)    :: vel(AMREX_SPACEDIM) !< Particle velocity
-     integer(c_int)               :: id
-     integer(c_int)               :: cpu
+     integer(c_int), private      :: id
+     integer(c_int), private      :: cpu
   end type amrex_particle
 
   type, public :: amrex_particlecontainer


### PR DESCRIPTION
… no longer be accessed directly

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
