### PR TITLE
CMake: Fix missing compile time definitions for HYPRE/PETSc

### DIFF
--- a/Tools/CMake/AMReX_Config.H.in
+++ b/Tools/CMake/AMReX_Config.H.in
@@ -42,6 +42,8 @@
 #cmakedefine AMREX_PARTICLES
 #cmakedefine AMREX_USE_HDF5
 #cmakedefine AMREX_USE_HDF5_ASYNC
+#cmakedefine AMREX_USE_HYPRE
+#cmakedefine AMREX_USE_PETSC
 #ifdef __cplusplus@COMP_DECLS@
 @OMP_DECLS@
 #endif


### PR DESCRIPTION
When building application codes with an _external_ AMReX install, the `AMReX_Config.H` file that is used does not include the required `AMREX_USE_HYPRE` and `AMREX_USE_PETSC` compile time definitions enabled, even if AMReX was compiled with these options. This PR adds the necessary entries in `CMake/AMReX_Config.H.in` to add these if these were enabled during the CMake build. 