### PR TITLE
Hypre IJ interface: Enable access to additional solvers and preconditioners available in Hypre

### DIFF
--- a/Src/Extern/HYPRE/AMReX_Hypre.H
+++ b/Src/Extern/HYPRE/AMReX_Hypre.H
@@ -51,7 +51,10 @@ public:
                              static_cast<HYPRE_Int>(v[1]),
                              static_cast<HYPRE_Int>(v[2]))};
     }
-    
+
+
+    void setHypreOptionsNamespace (const std::string& ns) noexcept
+    { options_namespace = ns; }
     void setHypreOldDefault (bool l) noexcept {old_default = l;}
     void setHypreRelaxType (int n) noexcept {relax_type = n;}
     void setHypreRelaxOrder (int n) noexcept {relax_order = n;}
@@ -72,6 +75,8 @@ protected:
     int relax_order = 1; // uses C/F relaxation
     int num_sweeps = 2;  // Sweeeps on each level
     Real strong_threshold = 0.25; // Hypre default is 0.25
+
+    std::string options_namespace{"hypre"};
 
     MultiFab acoefs;
     Array<MultiFab,AMREX_SPACEDIM> bcoefs;

--- a/Src/Extern/HYPRE/AMReX_HypreABecLap3.H
+++ b/Src/Extern/HYPRE/AMReX_HypreABecLap3.H
@@ -5,9 +5,7 @@
 
 #include <AMReX_iMultiFab.H>
 #include <AMReX_LayoutData.H>
-
-#include "HYPRE_parcsr_ls.h"
-#include "_hypre_parcsr_mv.h"
+#include <AMReX_HypreIJIface.H>
 
 #include <algorithm>
 
@@ -31,11 +29,12 @@ public:
 #endif
 
 private :
+    std::unique_ptr<HypreIJIface> hypre_ij;
 
+    // Non-owning references to hypre matrix, rhs, and solution data
     HYPRE_IJMatrix A = NULL;
     HYPRE_IJVector b = NULL;
     HYPRE_IJVector x = NULL;
-    HYPRE_Solver solver = NULL;
 
     LayoutData<HYPRE_Int> ncells_grid;
     LayoutData<Gpu::ManagedDeviceVector<HYPRE_Int> > cell_id_vec;

--- a/Src/Extern/HYPRE/AMReX_HypreABecLap3.cpp
+++ b/Src/Extern/HYPRE/AMReX_HypreABecLap3.cpp
@@ -235,6 +235,7 @@ HypreABecLap3::prepareSolver ()
     HYPRE_Int iupper = proc_end-1;
 
     hypre_ij.reset(new HypreIJIface(comm, ilower, iupper, verbose));
+    hypre_ij->parse_inputs(options_namespace);
 
     // Obtain non-owning references to the matrix, rhs, and solution data
     A = hypre_ij->A();

--- a/Src/Extern/HYPRE/AMReX_HypreABecLap3.cpp
+++ b/Src/Extern/HYPRE/AMReX_HypreABecLap3.cpp
@@ -20,20 +20,10 @@ namespace amrex {
 HypreABecLap3::HypreABecLap3 (const BoxArray& grids, const DistributionMapping& dmap,
                               const Geometry& geom_, MPI_Comm comm_)
     : Hypre(grids, dmap, geom_, comm_)
-{
-}
-    
+{}
+
 HypreABecLap3::~HypreABecLap3 ()
-{
-    HYPRE_IJMatrixDestroy(A);
-    A = NULL;
-    HYPRE_IJVectorDestroy(b);
-    b = NULL;
-    HYPRE_IJVectorDestroy(x);
-    x = NULL;
-    HYPRE_BoomerAMGDestroy(solver);
-    solver = NULL;
-}
+{}
 
 void
 HypreABecLap3::solve (MultiFab& soln, const MultiFab& rhs, Real rel_tol, Real abs_tol,
@@ -43,7 +33,7 @@ HypreABecLap3::solve (MultiFab& soln, const MultiFab& rhs, Real rel_tol, Real ab
 
     BL_PROFILE("HypreABecLap3::solve()");
 
-    if (solver == NULL || m_bndry != &bndry || m_maxorder != max_bndry_order)
+    if (!hypre_ij || m_bndry != &bndry || m_maxorder != max_bndry_order)
     {
         m_bndry = &bndry;
         m_maxorder = max_bndry_order;
@@ -54,7 +44,7 @@ HypreABecLap3::solve (MultiFab& soln, const MultiFab& rhs, Real rel_tol, Real ab
     {
         m_factory = &(rhs.Factory());
     }
-    
+
     HYPRE_IJVectorInitialize(b);
     HYPRE_IJVectorInitialize(x);
     //
@@ -62,44 +52,8 @@ HypreABecLap3::solve (MultiFab& soln, const MultiFab& rhs, Real rel_tol, Real ab
     //
     HYPRE_IJVectorAssemble(x);
     HYPRE_IJVectorAssemble(b);
-    
-    HYPRE_ParCSRMatrix par_A = NULL;
-    HYPRE_ParVector par_b = NULL;
-    HYPRE_ParVector par_x = NULL;
-    HYPRE_IJMatrixGetObject(A, (void**)  &par_A);
-    HYPRE_IJVectorGetObject(b, (void **) &par_b);
-    HYPRE_IJVectorGetObject(x, (void **) &par_x);
 
-    HYPRE_BoomerAMGSetMinIter(solver, 1);
-    HYPRE_BoomerAMGSetMaxIter(solver, max_iter);
-    HYPRE_BoomerAMGSetTol(solver, rel_tol);
-    if (abs_tol > 0.0)
-    {
-        Real bnorm = hypre_ParVectorInnerProd(par_b, par_b);
-        bnorm = std::sqrt(bnorm);
-        
-        const BoxArray& grids = rhs.boxArray();
-        Real volume = grids.numPts();
-        Real rel_tol_new = (bnorm > 0.0) ? (abs_tol / bnorm * std::sqrt(volume)) : rel_tol;
-
-        if (rel_tol_new > rel_tol) {
-            HYPRE_BoomerAMGSetTol(solver, rel_tol_new);
-        }
-    }
-
-    HYPRE_BoomerAMGSolve(solver, par_A, par_b, par_x);
-
-    if (verbose >= 2)
-    {
-        HYPRE_Int num_iterations;
-        Real res;
-        HYPRE_BoomerAMGGetNumIterations(solver, &num_iterations);
-        HYPRE_BoomerAMGGetFinalRelativeResidualNorm(solver, &res);
-
-        amrex::Print() <<"\n" <<  num_iterations
-                       << " Hypre IJ BoomerAMG Iterations, Relative Residual "
-                       << res << std::endl;
-    }
+    hypre_ij->solve(rel_tol, abs_tol, max_iter);
 
     getSolution(soln);
 }
@@ -280,18 +234,12 @@ HypreABecLap3::prepareSolver ()
     HYPRE_Int ilower = proc_begin;
     HYPRE_Int iupper = proc_end-1;
 
-    //
-    HYPRE_IJMatrixCreate(comm, ilower, iupper, ilower, iupper, &A);
-    HYPRE_IJMatrixSetObjectType(A, HYPRE_PARCSR);
-    HYPRE_IJMatrixInitialize(A);
-    //
-    HYPRE_IJVectorCreate(comm, ilower, iupper, &b);
-    HYPRE_IJVectorSetObjectType(b, HYPRE_PARCSR);
-    //
-    HYPRE_IJVectorCreate(comm, ilower, iupper, &x);
-    HYPRE_IJVectorSetObjectType(x, HYPRE_PARCSR);
-    
-    // A.SetValues() & A.assemble()
+    hypre_ij.reset(new HypreIJIface(comm, ilower, iupper, verbose));
+
+    // Obtain non-owning references to the matrix, rhs, and solution data
+    A = hypre_ij->A();
+    b = hypre_ij->b();
+    x = hypre_ij->x();
 
     const Real* dx = geom.CellSize();
     const int bho = (m_maxorder > 2) ? 1 : 0;
@@ -402,24 +350,6 @@ HypreABecLap3::prepareSolver ()
         }
     }
     HYPRE_IJMatrixAssemble(A);
-
-    // Create solver
-    HYPRE_BoomerAMGCreate(&solver);
-
-    if (old_default) HYPRE_BoomerAMGSetOldDefault(solver); // Falgout coarsening with modified classical interpolation
-//    HYPRE_BoomerAMGSetCoarsenType(solver, 6);
-//    HYPRE_BoomerAMGSetCycleType(solver, 1);
-    HYPRE_BoomerAMGSetRelaxType(solver, relax_type);
-    HYPRE_BoomerAMGSetRelaxOrder(solver, relax_order);
-    HYPRE_BoomerAMGSetNumSweeps(solver, num_sweeps);
-    HYPRE_BoomerAMGSetStrongThreshold(solver, strong_threshold);
-
-    int logging = (verbose >= 2) ? 1 : 0;
-    HYPRE_BoomerAMGSetLogging(solver, logging);
-
-    HYPRE_ParCSRMatrix par_A = NULL;
-    HYPRE_IJMatrixGetObject(A, (void**)  &par_A);
-    HYPRE_BoomerAMGSetup(solver, par_A, NULL, NULL);
 }
 
 void

--- a/Src/Extern/HYPRE/AMReX_HypreIJIface.H
+++ b/Src/Extern/HYPRE/AMReX_HypreIJIface.H
@@ -1,0 +1,131 @@
+#ifndef AMREX_HYPREIJIFACE_H
+#define AMREX_HYPREIJIFACE_H
+
+#include <memory>
+
+#include <AMReX_MultiFab.H>
+
+#include <HYPRE.h>
+#include <HYPRE_parcsr_ls.h>
+#include <HYPRE_parcsr_mv.h>
+
+namespace amrex {
+
+class HypreIJIface
+{
+public:
+    using HypreIntType = HYPRE_Int;
+    using HypreRealType = HYPRE_Real;
+
+    HypreIJIface(MPI_Comm comm, const HypreIntType ilower, const HypreIntType iupper,
+                 int verbose);
+
+    ~HypreIJIface();
+
+    void solve(const HypreRealType rel_tol, const HypreRealType abs_tol, const HypreIntType max_iter);
+
+    //! IJ matrix instance
+    HYPRE_IJMatrix A() { return m_mat; }
+
+    //! Right hand side IJ vector instance
+    HYPRE_IJVector b() { return m_rhs; }
+
+    //! Solution IJ vector instance
+    HYPRE_IJVector x() { return m_sln; }
+
+    //! Number of iterations taken by the solver to reach the desired tolerance
+    HypreIntType getNumIters() { return m_num_iterations; }
+
+    //! Final residual norm after a linear solve
+    HypreRealType getFinalResidualNorm() { return m_final_res_norm; }
+
+private:
+    void parse_inputs(const std::string& prefix = "hypre");
+
+    void init_preconditioner(const std::string& prefix, const std::string& name);
+    void init_solver(const std::string& prefix, const std::string& name);
+
+    // Preconditioners
+    void boomeramg_precond_configure(const std::string& prefix);
+    void euclid_precond_configure(const std::string& prefix);
+
+    // Solvers
+    void boomeramg_solver_configure(const std::string& prefix);
+    void gmres_solver_configure(const std::string& prefix);
+    void cogmres_solver_configure(const std::string& prefix);
+    void lgmres_solver_configure(const std::string& prefix);
+    void flex_gmres_solver_configure(const std::string& prefix);
+    void bicgstab_solver_configure(const std::string& prefix);
+    void pcg_solver_configure(const std::string& prefix);
+
+
+    MPI_Comm m_comm{MPI_COMM_NULL};
+
+    HYPRE_IJMatrix m_mat{nullptr};
+    HYPRE_IJVector m_rhs{nullptr};
+    HYPRE_IJVector m_sln{nullptr};
+
+    HYPRE_ParCSRMatrix m_parA{nullptr};
+    HYPRE_ParVector m_parRhs{nullptr};
+    HYPRE_ParVector m_parSln{nullptr};
+
+    HYPRE_Solver m_solver{nullptr};
+    HYPRE_Solver m_precond{nullptr};
+
+    HypreIntType (*m_solverDestroyPtr)(HYPRE_Solver){nullptr};
+    HypreIntType (*m_solverSetupPtr)(
+        HYPRE_Solver, HYPRE_ParCSRMatrix, HYPRE_ParVector, HYPRE_ParVector){nullptr};
+    HypreIntType (*m_solverSolvePtr)(
+        HYPRE_Solver, HYPRE_ParCSRMatrix, HYPRE_ParVector, HYPRE_ParVector){nullptr};
+    HypreIntType (*m_solverPrecondPtr)(
+        HYPRE_Solver,
+        HYPRE_PtrToParSolverFcn,
+        HYPRE_PtrToParSolverFcn,
+        HYPRE_Solver){nullptr};
+
+    HypreIntType (*m_precondDestroyPtr)(HYPRE_Solver){nullptr};
+    HypreIntType (*m_precondSetupPtr)(
+        HYPRE_Solver, HYPRE_ParCSRMatrix, HYPRE_ParVector, HYPRE_ParVector){nullptr};
+    HypreIntType (*m_precondSolvePtr)(
+        HYPRE_Solver, HYPRE_ParCSRMatrix, HYPRE_ParVector, HYPRE_ParVector){nullptr};
+
+    HypreIntType (*m_solverSetTolPtr)(HYPRE_Solver, double){nullptr};
+    HypreIntType (*m_solverSetAbsTolPtr)(HYPRE_Solver, double){nullptr};
+    HypreIntType (*m_solverSetMaxIterPtr)(HYPRE_Solver, HypreIntType){nullptr};
+    HypreIntType (*m_solverNumItersPtr)(HYPRE_Solver, HypreIntType*){nullptr};
+    HypreIntType (*m_solverFinalResidualNormPtr)(HYPRE_Solver, double*){nullptr};
+
+    HypreIntType m_ilower{0};
+    HypreIntType m_iupper{0};
+
+    HypreRealType m_final_res_norm;
+    HypreIntType m_num_iterations;
+
+    std::string m_solver_name{"BoomerAMG"};
+    std::string m_preconditioner_name{"none"};
+    std::string m_file_prefix{"IJ"};
+
+    //! Verbosity of the HYPRE solvers
+    int m_verbose{0};
+
+    unsigned int m_write_counter{0};
+
+    //! Flag indicating whether a preconditioner has been set
+    bool m_has_preconditioner{false};
+
+    //! Flag indicating whether the solver/preconditioner has been setup
+    bool m_need_setup{true};
+
+    //! Flag indicating whether user has requested recomputation of preconditioner
+    bool m_recompute_preconditioner{true};
+
+    //! Flag indicating whether to dump matrix files
+    bool m_write_files{false};
+
+    //! Flag indicating whether the files are overwritten on subsequent writes
+    bool m_overwrite_files{true};
+};
+
+} // namespace amrex
+
+#endif /* AMREX_HYPREIJIFACE_H */

--- a/Src/Extern/HYPRE/AMReX_HypreIJIface.H
+++ b/Src/Extern/HYPRE/AMReX_HypreIJIface.H
@@ -22,6 +22,8 @@ public:
 
     ~HypreIJIface();
 
+    void parse_inputs(const std::string& prefix = "hypre");
+
     void solve(const HypreRealType rel_tol, const HypreRealType abs_tol, const HypreIntType max_iter);
 
     //! IJ matrix instance
@@ -40,8 +42,6 @@ public:
     HypreRealType getFinalResidualNorm() { return m_final_res_norm; }
 
 private:
-    void parse_inputs(const std::string& prefix = "hypre");
-
     void init_preconditioner(const std::string& prefix, const std::string& name);
     void init_solver(const std::string& prefix, const std::string& name);
 

--- a/Src/Extern/HYPRE/AMReX_HypreIJIface.H
+++ b/Src/Extern/HYPRE/AMReX_HypreIJIface.H
@@ -57,6 +57,7 @@ private:
     void flex_gmres_solver_configure(const std::string& prefix);
     void bicgstab_solver_configure(const std::string& prefix);
     void pcg_solver_configure(const std::string& prefix);
+    void hybrid_solver_configure(const std::string& prefix);
 
 
     MPI_Comm m_comm{MPI_COMM_NULL};

--- a/Src/Extern/HYPRE/AMReX_HypreIJIface.cpp
+++ b/Src/Extern/HYPRE/AMReX_HypreIJIface.cpp
@@ -231,7 +231,8 @@ void HypreIJIface::boomeramg_precond_configure(const std::string& prefix)
     hpp("bamg_relax_order", HYPRE_BoomerAMGSetRelaxOrder, 1);
     hpp("bamg_num_sweeps", HYPRE_BoomerAMGSetNumSweeps, 2);
     hpp("bamg_max_levels", HYPRE_BoomerAMGSetMaxLevels, 20);
-    hpp("bamg_strong_threshold", HYPRE_BoomerAMGSetStrongThreshold, 0.57);
+    hpp("bamg_strong_threshold", HYPRE_BoomerAMGSetStrongThreshold,
+        (AMREX_SPACEDIM == 3) ? 0.57 : 0.25);
     hpp("bamg_interp_type", HYPRE_BoomerAMGSetInterpType, 0);
 
     hpp("bamg_variant", HYPRE_BoomerAMGSetVariant);
@@ -331,13 +332,14 @@ void HypreIJIface::boomeramg_solver_configure(const std::string& prefix)
     hpp("verbose", HYPRE_BoomerAMGSetPrintLevel, m_verbose);
     hpp("logging", HYPRE_BoomerAMGSetLogging);
 
-    hpp("bamg_coarsen_type", HYPRE_BoomerAMGSetCoarsenType, 6);
     hpp("bamg_relax_type", HYPRE_BoomerAMGSetRelaxType, 6);
-    hpp("bamg_cycle_type", HYPRE_BoomerAMGSetCycleType, 1);
     hpp("bamg_relax_order", HYPRE_BoomerAMGSetRelaxOrder, 1);
     hpp("bamg_num_sweeps", HYPRE_BoomerAMGSetNumSweeps, 2);
-    hpp("bamg_max_levels", HYPRE_BoomerAMGSetMaxLevels, 20);
-    hpp("bamg_strong_threshold", HYPRE_BoomerAMGSetStrongThreshold, 0.6);
+    hpp("bamg_strong_threshold", HYPRE_BoomerAMGSetStrongThreshold,
+        (AMREX_SPACEDIM == 3) ? 0.57 : 0.25);
+    hpp("bamg_coarsen_type", HYPRE_BoomerAMGSetCoarsenType);
+    hpp("bamg_cycle_type", HYPRE_BoomerAMGSetCycleType);
+    hpp("bamg_max_levels", HYPRE_BoomerAMGSetMaxLevels);
 
     bool use_old_default = true;
     hpp.pp.query("bamg_use_old_default", use_old_default);

--- a/Src/Extern/HYPRE/AMReX_HypreIJIface.cpp
+++ b/Src/Extern/HYPRE/AMReX_HypreIJIface.cpp
@@ -1,0 +1,513 @@
+#include <AMReX_HypreIJIface.H>
+#include <AMReX.H>
+#include <AMReX_ParmParse.H>
+#include <AMReX_PlotFileUtil.H>
+
+namespace amrex {
+
+namespace {
+
+/** Helper object to parse HYPRE inputs and call API functions
+ */
+struct HypreOptParse
+{
+    //! Input file parser instance for the given namespace
+    amrex::ParmParse pp;
+
+    //! Hypre solver/precondtioner whose options are being set
+    HYPRE_Solver solver;
+
+    HypreOptParse(const std::string& prefix, HYPRE_Solver sinp)
+        : pp(prefix), solver(sinp)
+    {}
+
+    template <typename F>
+    void operator()(const std::string& key, F&& func)
+    {
+        if (pp.contains(key.c_str())) {
+            int val;
+            pp.query(key.c_str(), val);
+            func(solver, val);
+        }
+    }
+
+    template <typename F, typename T>
+    void operator()(const std::string& key, F&& func, T default_val)
+    {
+        T val = default_val;
+        pp.query(key.c_str(), val);
+        func(solver, val);
+    }
+
+    template <typename T, typename F>
+    void set(const std::string& key, F&& func)
+    {
+        if (pp.contains(key.c_str())) {
+            T val;
+            pp.query(key.c_str(), val);
+            func(solver, val);
+        }
+    }
+};
+
+} // namespace
+
+HypreIJIface::HypreIJIface(
+    MPI_Comm comm, HypreIntType ilower, HypreIntType iupper, int verbose)
+    : m_comm(comm), m_ilower(ilower), m_iupper(iupper), m_verbose(verbose)
+{
+    HYPRE_IJMatrixCreate(
+        m_comm, m_ilower, m_iupper, m_ilower, m_iupper, &m_mat);
+    HYPRE_IJMatrixSetObjectType(m_mat, HYPRE_PARCSR);
+    HYPRE_IJMatrixInitialize(m_mat);
+
+    HYPRE_IJVectorCreate(m_comm, m_ilower, m_iupper, &m_rhs);
+    HYPRE_IJVectorSetObjectType(m_rhs, HYPRE_PARCSR);
+    HYPRE_IJVectorInitialize(m_rhs);
+
+    HYPRE_IJVectorCreate(m_comm, m_ilower, m_iupper, &m_sln);
+    HYPRE_IJVectorSetObjectType(m_sln, HYPRE_PARCSR);
+    HYPRE_IJVectorInitialize(m_sln);
+
+    parse_inputs();
+}
+
+HypreIJIface::~HypreIJIface()
+{
+    HYPRE_IJMatrixDestroy(m_mat);
+    m_mat = nullptr;
+    HYPRE_IJVectorDestroy(m_rhs);
+    m_rhs = nullptr;
+    HYPRE_IJVectorDestroy(m_sln);
+    m_sln = nullptr;
+
+    if (m_solver != nullptr) {
+        m_solverDestroyPtr(m_solver);
+        m_solver = nullptr;
+    }
+
+    if (m_precond != nullptr) {
+        m_precondDestroyPtr(m_precond);
+        m_precond = nullptr;
+    }
+}
+
+void HypreIJIface::solve(
+    const HypreRealType rel_tol, const HypreRealType abs_tol, const HypreIntType max_iter)
+{
+    // Assuming that Matrix/rhs etc. has been assembled by calling code
+
+    HYPRE_IJMatrixGetObject(m_mat, (void**)&m_parA);
+    HYPRE_IJVectorGetObject(m_rhs, (void**)&m_parRhs);
+    HYPRE_IJVectorGetObject(m_sln, (void**)&m_parSln);
+
+    if (m_write_files) {
+        const std::string matfile = amrex::Concatenate(
+            m_file_prefix + "_A", m_write_counter) + ".out";
+        const std::string rhsfile = amrex::Concatenate(
+            m_file_prefix + "_b", m_write_counter) + ".out";
+        HYPRE_IJMatrixPrint(m_mat, matfile.c_str());
+        HYPRE_IJVectorPrint(m_rhs, rhsfile.c_str());
+    }
+
+    m_solverSetTolPtr(m_solver, rel_tol);
+    m_solverSetMaxIterPtr(m_solver, max_iter);
+    if ((abs_tol > 0.0) && (m_solverSetAbsTolPtr != nullptr))
+        m_solverSetAbsTolPtr(m_solver, abs_tol);
+
+    // setup
+    if (m_need_setup || m_recompute_preconditioner) {
+        if (m_has_preconditioner)
+            m_solverPrecondPtr(
+                m_solver, m_precondSolvePtr, m_precondSetupPtr, m_precond);
+
+        m_solverSetupPtr(m_solver, m_parA, m_parRhs, m_parSln);
+        m_need_setup = false;
+    }
+
+    // solve
+    m_solverSolvePtr(m_solver, m_parA, m_parRhs, m_parSln);
+
+    // diagnostics
+    m_solverNumItersPtr(m_solver, &m_num_iterations);
+    m_solverFinalResidualNormPtr(m_solver, &m_final_res_norm);
+
+    if (m_write_files) {
+        const std::string slnfile = amrex::Concatenate(
+            m_file_prefix + "_x", m_write_counter) + ".out";
+        HYPRE_IJVectorPrint(m_sln, slnfile.c_str());
+
+        // Increment counter if the user has requested output of multiple solves
+        if (!m_overwrite_files) ++m_write_counter;
+    }
+
+    if (m_verbose > 1)
+        amrex::Print() << "HYPRE " << m_solver_name
+                       << ": Num. iterations = " << m_num_iterations
+                       << "; Relative residual = " << m_final_res_norm
+                       << std::endl;
+}
+
+void HypreIJIface::parse_inputs(const std::string& prefix)
+{
+    amrex::ParmParse pp(prefix);
+
+    pp.query("hypre_solver", m_solver_name);
+    pp.query("hypre_preconditioner", m_preconditioner_name);
+    pp.query("recompute_preconditioner", m_recompute_preconditioner);
+    pp.query("write_matrix_files", m_write_files);
+    pp.query("overwrite_existing_matrix_files", m_overwrite_files);
+
+    if (m_verbose > 2)
+        amrex::Print() << "HYPRE: solver = " << m_solver_name
+                       << "; preconditioner = " << m_preconditioner_name
+                       << std::endl;
+
+    if (m_preconditioner_name == "none") {
+        m_has_preconditioner = false;
+    } else {
+        m_has_preconditioner = true;
+        init_preconditioner(prefix, m_preconditioner_name);
+    }
+
+    init_solver(prefix, m_solver_name);
+}
+
+void HypreIJIface::init_preconditioner(
+    const std::string& prefix, const std::string& name)
+{
+    if (name == "BoomerAMG") {
+        boomeramg_precond_configure(prefix);
+    } else if (name == "euclid") {
+        euclid_precond_configure(prefix);
+    } else {
+        amrex::Abort("Invalid HYPRE preconditioner specified: " + name);
+    }
+}
+
+void HypreIJIface::init_solver(
+    const std::string& prefix, const std::string& name)
+{
+    if (name == "BoomerAMG") {
+        boomeramg_solver_configure(prefix);
+    } else if (name == "GMRES") {
+        gmres_solver_configure(prefix);
+    } else if (name == "COGMRES") {
+        cogmres_solver_configure(prefix);
+    } else if (name == "LGMRES") {
+        lgmres_solver_configure(prefix);
+    } else if (name == "FlexGMRES") {
+        flex_gmres_solver_configure(prefix);
+    } else if (name == "BiCGSTAB") {
+        bicgstab_solver_configure(prefix);
+    } else if (name == "PCG") {
+        pcg_solver_configure(prefix);
+    } else {
+        amrex::Abort("Invalid HYPRE solver specified: " + name);
+    }
+}
+
+void HypreIJIface::boomeramg_precond_configure(const std::string& prefix)
+{
+    if (m_verbose > 2)
+        amrex::Print() << "Creating BoomerAMG preconditioner" << std::endl;
+    HYPRE_BoomerAMGCreate(&m_precond);
+
+    // Setup the pointers
+    m_precondDestroyPtr = &HYPRE_BoomerAMGDestroy;
+    m_precondSetupPtr = &HYPRE_BoomerAMGSetup;
+    m_precondSolvePtr = &HYPRE_BoomerAMGSolve;
+
+    // Parse options
+    HypreOptParse hpp(prefix, m_precond);
+    hpp("bamg_verbose", HYPRE_BoomerAMGSetPrintLevel, m_verbose);
+    hpp("bamg_logging", HYPRE_BoomerAMGSetLogging);
+
+    hpp("bamg_coarsen_type", HYPRE_BoomerAMGSetCoarsenType, 6);
+    hpp("bamg_cycle_type", HYPRE_BoomerAMGSetCycleType, 1);
+    hpp("bamg_relax_type", HYPRE_BoomerAMGSetRelaxType, 6);
+    hpp("bamg_relax_order", HYPRE_BoomerAMGSetRelaxOrder, 1);
+    hpp("bamg_num_sweeps", HYPRE_BoomerAMGSetNumSweeps, 2);
+    hpp("bamg_max_levels", HYPRE_BoomerAMGSetMaxLevels, 20);
+    hpp("bamg_strong_threshold", HYPRE_BoomerAMGSetStrongThreshold, 0.57);
+    hpp("bamg_interp_type", HYPRE_BoomerAMGSetInterpType, 0);
+
+    hpp("bamg_variant", HYPRE_BoomerAMGSetVariant);
+    hpp("bamg_keep_transpose", HYPRE_BoomerAMGSetKeepTranspose);
+    hpp("bamg_min_coarse_size", HYPRE_BoomerAMGSetMinCoarseSize);
+    hpp("bamg_max_coarse_size", HYPRE_BoomerAMGSetMaxCoarseSize);
+    hpp("bamg_pmax_elmts", HYPRE_BoomerAMGSetPMaxElmts);
+    hpp("bamg_agg_num_levels", HYPRE_BoomerAMGSetAggNumLevels);
+    hpp("bamg_agg_interp_type", HYPRE_BoomerAMGSetAggInterpType);
+    hpp("bamg_agg_pmax_elmts", HYPRE_BoomerAMGSetAggPMaxElmts);
+    hpp("bamg_set_trunc_factor", HYPRE_BoomerAMGSetTruncFactor);
+
+    if (hpp.pp.contains("bamg_non_galerkin_tol")) {
+        hpp("bamg_non_galerkin_tol", HYPRE_BoomerAMGSetNonGalerkinTol);
+
+        if (hpp.pp.contains("bamg_non_galerkin_level_tols")) {
+            std::vector<int> levels;
+            std::vector<double> tols;
+            hpp.pp.getarr("bamg_non_galerkin_level_levels", levels);
+            hpp.pp.getarr("bamg_non_galerkin_level_tols", tols);
+
+            if (levels.size() != tols.size())
+                amrex::Abort(
+                    "HypreIJIface: Invalid sizes for non-Galerkin level "
+                    "tolerances");
+
+            for (size_t i = 0; i < levels.size(); ++i)
+                HYPRE_BoomerAMGSetLevelNonGalerkinTol(
+                    m_precond, tols[i], levels[i]);
+        }
+    }
+
+    if (hpp.pp.contains("bamg_smooth_type")) {
+        int smooth_type;
+        hpp.pp.get("bamg_smooth_type", smooth_type);
+
+        hpp("bamg_smooth_type", HYPRE_BoomerAMGSetSmoothType);
+
+        // Process Euclid smoother parameters
+        if (smooth_type == 9) {
+            if (hpp.pp.contains("bamg_euclid_file")) {
+                std::string euclid_file;
+                hpp.pp.get("bamg_euclid_file", euclid_file);
+                HYPRE_BoomerAMGSetEuclidFile(
+                    m_precond, const_cast<char*>(euclid_file.c_str()));
+            }
+            hpp("bamg_smooth_num_levels", HYPRE_BoomerAMGSetSmoothNumLevels);
+            hpp("bamg_smooth_num_sweeps", HYPRE_BoomerAMGSetSmoothNumSweeps);
+        }
+    }
+}
+
+void HypreIJIface::euclid_precond_configure(const std::string& prefix)
+{
+    HYPRE_EuclidCreate(m_comm, &m_precond);
+
+    // Setup the pointers
+    m_precondDestroyPtr = &HYPRE_EuclidDestroy;
+    m_precondSetupPtr = &HYPRE_EuclidSetup;
+    m_precondSolvePtr = &HYPRE_EuclidSolve;
+
+    HypreOptParse hpp(prefix, m_precond);
+    // for 3D problems set to 1, for 2D set to 4-8
+    hpp("euclid_level", HYPRE_EuclidSetLevel, (AMREX_SPACEDIM == 3) ? 1 : 4);
+    // 0 = PILU; 1 = Block Jacobi
+    hpp("euclid_use_block_jacobi", HYPRE_EuclidSetBJ, 0);
+    // Flag indicating whether to write out euclid stats
+    hpp("euclid_stats", HYPRE_EuclidSetStats, 0);
+    // Flag indicating whether to print out memory diagnostic
+    hpp("euclid_mem", HYPRE_EuclidSetMem, 0);
+}
+
+void HypreIJIface::boomeramg_solver_configure(const std::string& prefix)
+{
+    if (m_has_preconditioner) {
+        amrex::Warning(
+            "HYPRE: Cannot use preconditioner with BoomerAMG solver");
+        m_has_preconditioner = false;
+    }
+
+    HYPRE_BoomerAMGCreate(&m_solver);
+
+    // Setup pointers
+    m_solverDestroyPtr = &HYPRE_BoomerAMGDestroy;
+    m_solverSetupPtr = &HYPRE_BoomerAMGSetup;
+    m_solverPrecondPtr = nullptr;
+    m_solverSolvePtr = &HYPRE_BoomerAMGSolve;
+
+    m_solverSetTolPtr = &HYPRE_BoomerAMGSetTol;
+    m_solverSetAbsTolPtr = nullptr;
+    m_solverSetMaxIterPtr = &HYPRE_BoomerAMGSetMaxIter;
+    m_solverNumItersPtr = &HYPRE_BoomerAMGGetNumIterations;
+    m_solverFinalResidualNormPtr = &HYPRE_BoomerAMGGetFinalRelativeResidualNorm;
+
+    // Parse options
+    HypreOptParse hpp(prefix, m_solver);
+    hpp("verbose", HYPRE_BoomerAMGSetPrintLevel, m_verbose);
+    hpp("logging", HYPRE_BoomerAMGSetLogging);
+
+    hpp("bamg_coarsen_type", HYPRE_BoomerAMGSetCoarsenType, 6);
+    hpp("bamg_relax_type", HYPRE_BoomerAMGSetRelaxType, 6);
+    hpp("bamg_cycle_type", HYPRE_BoomerAMGSetCycleType, 1);
+    hpp("bamg_relax_order", HYPRE_BoomerAMGSetRelaxOrder, 1);
+    hpp("bamg_num_sweeps", HYPRE_BoomerAMGSetNumSweeps, 2);
+    hpp("bamg_max_levels", HYPRE_BoomerAMGSetMaxLevels, 20);
+    hpp("bamg_strong_threshold", HYPRE_BoomerAMGSetStrongThreshold, 0.6);
+
+    bool use_old_default = true;
+    hpp.pp.query("bamg_use_old_default", use_old_default);
+    if (use_old_default)
+        HYPRE_BoomerAMGSetOldDefault(m_solver);
+}
+
+void HypreIJIface::gmres_solver_configure(const std::string& prefix)
+{
+    if (m_verbose > 2)
+        amrex::Print() << "Creating GMRES solver" << std::endl;
+    HYPRE_ParCSRGMRESCreate(m_comm, &m_solver);
+
+    // Setup pointers
+    m_solverDestroyPtr = &HYPRE_ParCSRGMRESDestroy;
+    m_solverSetupPtr = &HYPRE_ParCSRGMRESSetup;
+    m_solverPrecondPtr = &HYPRE_ParCSRGMRESSetPrecond;
+    m_solverSolvePtr = &HYPRE_ParCSRGMRESSolve;
+
+    m_solverSetTolPtr = &HYPRE_ParCSRGMRESSetTol;
+    m_solverSetAbsTolPtr = &HYPRE_ParCSRGMRESSetAbsoluteTol;
+    m_solverSetMaxIterPtr = &HYPRE_ParCSRGMRESSetMaxIter;
+    m_solverNumItersPtr = &HYPRE_ParCSRGMRESGetNumIterations;
+    m_solverFinalResidualNormPtr =
+        &HYPRE_ParCSRGMRESGetFinalRelativeResidualNorm;
+
+    // Parse options
+    HypreOptParse hpp(prefix, m_solver);
+    hpp("verbose", HYPRE_ParCSRGMRESSetPrintLevel, m_verbose);
+    hpp("logging", HYPRE_ParCSRGMRESSetLogging);
+
+    hpp("num_krylov", HYPRE_ParCSRGMRESSetKDim, 50);
+    hpp("max_iterations", HYPRE_ParCSRGMRESSetMaxIter, 200);
+    hpp.set<amrex::Real>("rtol", HYPRE_ParCSRGMRESSetTol);
+    hpp.set<amrex::Real>("atol", HYPRE_ParCSRGMRESSetAbsoluteTol);
+}
+
+void HypreIJIface::cogmres_solver_configure(const std::string& prefix)
+{
+    HYPRE_ParCSRCOGMRESCreate(m_comm, &m_solver);
+
+    // Setup pointers
+    m_solverDestroyPtr = &HYPRE_ParCSRCOGMRESDestroy;
+    m_solverSetupPtr = &HYPRE_ParCSRCOGMRESSetup;
+    m_solverPrecondPtr = &HYPRE_ParCSRCOGMRESSetPrecond;
+    m_solverSolvePtr = &HYPRE_ParCSRCOGMRESSolve;
+
+    m_solverSetTolPtr = &HYPRE_ParCSRCOGMRESSetTol;
+    m_solverSetAbsTolPtr = &HYPRE_ParCSRCOGMRESSetAbsoluteTol;
+    m_solverSetMaxIterPtr = &HYPRE_ParCSRCOGMRESSetMaxIter;
+    m_solverNumItersPtr = &HYPRE_ParCSRCOGMRESGetNumIterations;
+    m_solverFinalResidualNormPtr =
+        &HYPRE_ParCSRCOGMRESGetFinalRelativeResidualNorm;
+
+    // Parse options
+    HypreOptParse hpp(prefix, m_solver);
+    hpp("verbose", HYPRE_ParCSRCOGMRESSetPrintLevel, m_verbose);
+    hpp("logging", HYPRE_ParCSRCOGMRESSetLogging);
+
+    hpp("num_krylov", HYPRE_ParCSRCOGMRESSetKDim, 50);
+    hpp("max_iterations", HYPRE_ParCSRCOGMRESSetMaxIter, 200);
+    hpp.set<amrex::Real>("rtol", HYPRE_ParCSRCOGMRESSetTol);
+    hpp.set<amrex::Real>("atol", HYPRE_ParCSRCOGMRESSetAbsoluteTol);
+}
+
+void HypreIJIface::lgmres_solver_configure(const std::string& prefix)
+{
+    HYPRE_ParCSRLGMRESCreate(m_comm, &m_solver);
+
+    // Setup pointers
+    m_solverDestroyPtr = &HYPRE_ParCSRLGMRESDestroy;
+    m_solverSetupPtr = &HYPRE_ParCSRLGMRESSetup;
+    m_solverPrecondPtr = &HYPRE_ParCSRLGMRESSetPrecond;
+    m_solverSolvePtr = &HYPRE_ParCSRLGMRESSolve;
+
+    m_solverSetTolPtr = &HYPRE_ParCSRLGMRESSetTol;
+    m_solverSetAbsTolPtr = &HYPRE_ParCSRLGMRESSetAbsoluteTol;
+    m_solverSetMaxIterPtr = &HYPRE_ParCSRLGMRESSetMaxIter;
+    m_solverNumItersPtr = &HYPRE_ParCSRLGMRESGetNumIterations;
+    m_solverFinalResidualNormPtr =
+        &HYPRE_ParCSRLGMRESGetFinalRelativeResidualNorm;
+
+    // Parse options
+    HypreOptParse hpp(prefix, m_solver);
+    hpp("verbose", HYPRE_ParCSRLGMRESSetPrintLevel, m_verbose);
+    hpp("logging", HYPRE_ParCSRLGMRESSetLogging);
+
+    hpp("num_krylov", HYPRE_ParCSRLGMRESSetKDim, 50);
+    hpp("max_iterations", HYPRE_ParCSRLGMRESSetMaxIter, 200);
+    hpp.set<amrex::Real>("rtol", HYPRE_ParCSRLGMRESSetTol);
+    hpp.set<amrex::Real>("atol", HYPRE_ParCSRLGMRESSetAbsoluteTol);
+}
+
+void HypreIJIface::flex_gmres_solver_configure(const std::string& prefix)
+{
+    HYPRE_ParCSRFlexGMRESCreate(m_comm, &m_solver);
+
+    // Setup pointers
+    m_solverDestroyPtr = &HYPRE_ParCSRFlexGMRESDestroy;
+    m_solverSetupPtr = &HYPRE_ParCSRFlexGMRESSetup;
+    m_solverPrecondPtr = &HYPRE_ParCSRFlexGMRESSetPrecond;
+    m_solverSolvePtr = &HYPRE_ParCSRFlexGMRESSolve;
+
+    m_solverSetTolPtr = &HYPRE_ParCSRFlexGMRESSetTol;
+    m_solverSetAbsTolPtr = &HYPRE_ParCSRFlexGMRESSetAbsoluteTol;
+    m_solverSetMaxIterPtr = &HYPRE_ParCSRFlexGMRESSetMaxIter;
+    m_solverNumItersPtr = &HYPRE_ParCSRFlexGMRESGetNumIterations;
+    m_solverFinalResidualNormPtr =
+        &HYPRE_ParCSRFlexGMRESGetFinalRelativeResidualNorm;
+
+    // Parse options
+    HypreOptParse hpp(prefix, m_solver);
+    hpp("verbose", HYPRE_ParCSRFlexGMRESSetPrintLevel, m_verbose);
+    hpp("logging", HYPRE_ParCSRFlexGMRESSetLogging);
+
+    hpp("num_krylov", HYPRE_ParCSRFlexGMRESSetKDim, 50);
+    hpp("max_iterations", HYPRE_ParCSRFlexGMRESSetMaxIter, 200);
+    hpp.set<amrex::Real>("rtol", HYPRE_ParCSRFlexGMRESSetTol);
+    hpp.set<amrex::Real>("atol", HYPRE_ParCSRFlexGMRESSetAbsoluteTol);
+}
+
+void HypreIJIface::bicgstab_solver_configure(const std::string& prefix)
+{
+    HYPRE_ParCSRBiCGSTABCreate(m_comm, &m_solver);
+
+    // Setup pointers
+    m_solverDestroyPtr = &HYPRE_ParCSRBiCGSTABDestroy;
+    m_solverSetupPtr = &HYPRE_ParCSRBiCGSTABSetup;
+    m_solverPrecondPtr = &HYPRE_ParCSRBiCGSTABSetPrecond;
+    m_solverSolvePtr = &HYPRE_ParCSRBiCGSTABSolve;
+
+    m_solverSetTolPtr = &HYPRE_ParCSRBiCGSTABSetTol;
+    m_solverSetAbsTolPtr = &HYPRE_ParCSRBiCGSTABSetAbsoluteTol;
+    m_solverSetMaxIterPtr = &HYPRE_ParCSRBiCGSTABSetMaxIter;
+    m_solverNumItersPtr = &HYPRE_ParCSRBiCGSTABGetNumIterations;
+    m_solverFinalResidualNormPtr =
+        &HYPRE_ParCSRBiCGSTABGetFinalRelativeResidualNorm;
+
+    // Parse options
+    HypreOptParse hpp(prefix, m_solver);
+    hpp("verbose", HYPRE_ParCSRBiCGSTABSetPrintLevel, m_verbose);
+    hpp("logging", HYPRE_ParCSRBiCGSTABSetLogging);
+
+    hpp("max_iterations", HYPRE_ParCSRBiCGSTABSetMaxIter, 200);
+    hpp.set<amrex::Real>("rtol", HYPRE_ParCSRBiCGSTABSetTol);
+    hpp.set<amrex::Real>("atol", HYPRE_ParCSRBiCGSTABSetAbsoluteTol);
+}
+
+void HypreIJIface::pcg_solver_configure(const std::string& prefix)
+{
+    HYPRE_ParCSRPCGCreate(m_comm, &m_solver);
+
+    // Setup pointers
+    m_solverDestroyPtr = &HYPRE_ParCSRPCGDestroy;
+    m_solverSetupPtr = &HYPRE_ParCSRPCGSetup;
+    m_solverPrecondPtr = &HYPRE_ParCSRPCGSetPrecond;
+    m_solverSolvePtr = &HYPRE_ParCSRPCGSolve;
+
+    m_solverSetTolPtr = &HYPRE_ParCSRPCGSetTol;
+    m_solverSetAbsTolPtr = &HYPRE_ParCSRPCGSetAbsoluteTol;
+    m_solverSetMaxIterPtr = &HYPRE_ParCSRPCGSetMaxIter;
+    m_solverNumItersPtr = &HYPRE_ParCSRPCGGetNumIterations;
+    m_solverFinalResidualNormPtr = &HYPRE_ParCSRPCGGetFinalRelativeResidualNorm;
+
+    // Parse options
+    HypreOptParse hpp(prefix, m_solver);
+    hpp("verbose", HYPRE_ParCSRPCGSetPrintLevel, m_verbose);
+    hpp("logging", HYPRE_ParCSRPCGSetLogging);
+
+    hpp("max_iterations", HYPRE_ParCSRPCGSetMaxIter, 200);
+    hpp.set<amrex::Real>("rtol", HYPRE_ParCSRPCGSetTol);
+    hpp.set<amrex::Real>("atol", HYPRE_ParCSRPCGSetAbsoluteTol);
+}
+
+} // namespace amrex

--- a/Src/Extern/HYPRE/AMReX_HypreNodeLap.H
+++ b/Src/Extern/HYPRE/AMReX_HypreNodeLap.H
@@ -33,6 +33,9 @@ public:
 
     void fill_node_id (LayoutData<Int>& offset);
 
+    void setHypreOptionsNamespace(const std::string& ns)
+    { options_namespace = ns; }
+
 private:
 
     BoxArray grids;
@@ -56,6 +59,8 @@ private:
     LayoutData<Vector<Int> > node_id_vec;
     FabArray<BaseFab<Int> > node_id;
     MultiFab tmpsoln;
+
+    std::string options_namespace{"hypre"};
 
     void loadVectors (MultiFab& soln, const MultiFab& rhs);
     void getSolution (MultiFab& soln);

--- a/Src/Extern/HYPRE/AMReX_HypreNodeLap.H
+++ b/Src/Extern/HYPRE/AMReX_HypreNodeLap.H
@@ -10,11 +10,8 @@
 #include <AMReX_LayoutData.H>
 #include <AMReX_BndryData.H>
 #include <AMReX_MultiFabUtil.H>
+#include <AMReX_HypreIJIface.H>
 
-#include "HYPRE.h"
-#include "_hypre_utilities.h"
-#include "HYPRE_parcsr_ls.h"
-#include "_hypre_parcsr_mv.h"
 
 namespace amrex {
 
@@ -48,10 +45,12 @@ private:
     MLNodeLinOp const* linop = nullptr;
     int verbose = 0;
 
+    std::unique_ptr<HypreIJIface> hypre_ij;
+
+    // Non-owning references to Hypre matrix, rhs, and solution data
     HYPRE_IJMatrix A = NULL;
     HYPRE_IJVector b = NULL;
     HYPRE_IJVector x = NULL;
-    HYPRE_Solver solver = NULL;
 
     LayoutData<Int> nnodes_grid;
     LayoutData<Vector<Int> > node_id_vec;

--- a/Src/Extern/HYPRE/AMReX_HypreNodeLap.cpp
+++ b/Src/Extern/HYPRE/AMReX_HypreNodeLap.cpp
@@ -181,6 +181,7 @@ HypreNodeLap::HypreNodeLap (const BoxArray& grids_, const DistributionMapping& d
     Int iupper = proc_end-1;
 
     hypre_ij.reset(new HypreIJIface(comm, ilower, iupper, verbose));
+    hypre_ij->parse_inputs(options_namespace);
 
     // Obtain non-owning references to the matrix, rhs, and solution data
     A = hypre_ij->A();

--- a/Src/Extern/HYPRE/AMReX_HypreNodeLap.cpp
+++ b/Src/Extern/HYPRE/AMReX_HypreNodeLap.cpp
@@ -180,18 +180,12 @@ HypreNodeLap::HypreNodeLap (const BoxArray& grids_, const DistributionMapping& d
     Int ilower = proc_begin;
     Int iupper = proc_end-1;
 
-    //
-    HYPRE_IJMatrixCreate(comm, ilower, iupper, ilower, iupper, &A);
-    HYPRE_IJMatrixSetObjectType(A, HYPRE_PARCSR);
-    HYPRE_IJMatrixInitialize(A);
-    //
-    HYPRE_IJVectorCreate(comm, ilower, iupper, &b);
-    HYPRE_IJVectorSetObjectType(b, HYPRE_PARCSR);
-    //
-    HYPRE_IJVectorCreate(comm, ilower, iupper, &x);
-    HYPRE_IJVectorSetObjectType(x, HYPRE_PARCSR);
+    hypre_ij.reset(new HypreIJIface(comm, ilower, iupper, verbose));
 
-    // A.SetValues() & A.assemble()
+    // Obtain non-owning references to the matrix, rhs, and solution data
+    A = hypre_ij->A();
+    b = hypre_ij->b();
+    x = hypre_ij->x();
 
     Vector<Int> ncols;
     Vector<Int> cols;
@@ -235,37 +229,10 @@ HypreNodeLap::HypreNodeLap (const BoxArray& grids_, const DistributionMapping& d
         }
     }
     HYPRE_IJMatrixAssemble(A);
-
-    // Create solver
-    HYPRE_BoomerAMGCreate(&solver);
-
-    HYPRE_BoomerAMGSetOldDefault(solver); // Falgout coarsening with modified classical interpolation
-//    HYPRE_BoomerAMGSetCoarsenType(solver, 6);
-//    HYPRE_BoomerAMGSetCycleType(solver, 1);
-    HYPRE_BoomerAMGSetRelaxType(solver, 6);   /* G-S/Jacobi hybrid relaxation */
-    HYPRE_BoomerAMGSetRelaxOrder(solver, 1);   /* uses C/F relaxation */
-    HYPRE_BoomerAMGSetNumSweeps(solver, 2);   /* Sweeeps on each level */
-//    HYPRE_BoomerAMGSetStrongThreshold(solver, 0.6); // default is 0.25
-
-    int logging = (verbose >= 2) ? 1 : 0;
-    HYPRE_BoomerAMGSetLogging(solver, logging);
-
-    HYPRE_ParCSRMatrix par_A = NULL;
-    HYPRE_IJMatrixGetObject(A, (void**)  &par_A);
-    HYPRE_BoomerAMGSetup(solver, par_A, NULL, NULL);
 }
 
 HypreNodeLap::~HypreNodeLap ()
-{
-    HYPRE_IJMatrixDestroy(A);
-    A = NULL;
-    HYPRE_IJVectorDestroy(b);
-    b = NULL;
-    HYPRE_IJVectorDestroy(x);
-    x = NULL;
-    HYPRE_BoomerAMGDestroy(solver);
-    solver = NULL;
-}
+{}
 
 void
 HypreNodeLap::solve (MultiFab& soln, const MultiFab& rhs,
@@ -281,43 +248,7 @@ HypreNodeLap::solve (MultiFab& soln, const MultiFab& rhs,
     HYPRE_IJVectorAssemble(x);
     HYPRE_IJVectorAssemble(b);
 
-    HYPRE_ParCSRMatrix par_A = NULL;
-    HYPRE_ParVector par_b = NULL;
-    HYPRE_ParVector par_x = NULL;
-    HYPRE_IJMatrixGetObject(A, (void**)  &par_A);
-    HYPRE_IJVectorGetObject(b, (void **) &par_b);
-    HYPRE_IJVectorGetObject(x, (void **) &par_x);
-
-    HYPRE_BoomerAMGSetMinIter(solver, 1);
-    HYPRE_BoomerAMGSetMaxIter(solver, max_iter);
-    HYPRE_BoomerAMGSetTol(solver, rel_tol);
-    if (abs_tol > 0.0)
-    {
-        Real bnorm = hypre_ParVectorInnerProd(par_b, par_b);
-        bnorm = std::sqrt(bnorm);
-
-        const BoxArray& grd = rhs.boxArray();
-        Real volume = grd.numPts();
-        Real rel_tol_new = (bnorm > 0.0) ? (abs_tol / bnorm * std::sqrt(volume)) : rel_tol;
-
-        if (rel_tol_new > rel_tol) {
-            HYPRE_BoomerAMGSetTol(solver, rel_tol_new);
-        }
-    }
-
-    HYPRE_BoomerAMGSolve(solver, par_A, par_b, par_x);
-
-    if (verbose >= 2)
-    {
-        HYPRE_Int num_iterations;
-        Real res;
-        HYPRE_BoomerAMGGetNumIterations(solver, &num_iterations);
-        HYPRE_BoomerAMGGetFinalRelativeResidualNorm(solver, &res);
-
-        amrex::Print() <<"\n" <<  num_iterations
-                       << " Hypre IJ BoomerAMG Iterations, Relative Residual "
-                       << res << std::endl;
-    }
+    hypre_ij->solve(rel_tol, abs_tol, max_iter);
 
     getSolution(soln);
 }

--- a/Src/Extern/HYPRE/CMakeLists.txt
+++ b/Src/Extern/HYPRE/CMakeLists.txt
@@ -39,6 +39,8 @@ else ()
       AMReX_Habec_K.H
       AMReX_HypreNodeLap.cpp
       AMReX_HypreNodeLap.H
+      AMReX_HypreIJIface.cpp
+      AMReX_HypreIJIface.H
       )
 
 endif ()

--- a/Src/Extern/HYPRE/Make.package
+++ b/Src/Extern/HYPRE/Make.package
@@ -5,8 +5,8 @@ CEXE_headers += AMReX_HypreABecLap.H AMReX_HypreABecLap2.H AMReX_HypreABecLap3.H
 
 CEXE_headers += AMReX_Habec_$(DIM)D_K.H
 CEXE_headers += AMReX_Habec_K.H
-CEXE_headers += AMReX_HypreNodeLap.H
-CEXE_sources += AMReX_HypreNodeLap.cpp
+CEXE_headers += AMReX_HypreNodeLap.H AMReX_HypreIJIface.H
+CEXE_sources += AMReX_HypreNodeLap.cpp AMReX_HypreIJIface.cpp
 
 VPATH_LOCATIONS += $(AMREX_HOME)/Src/Extern/HYPRE
 INCLUDE_LOCATIONS += $(AMREX_HOME)/Src/Extern/HYPRE

--- a/Src/LinearSolvers/MLMG/AMReX_MLMG.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLMG.H
@@ -217,8 +217,8 @@ private:
 #else
 
     // Hypre::Interface hypre_interface = Hypre::Interface::structed;
-    // Hypre::Interface hypre_interface = Hypre::Interface::semi_structed;
-   Hypre::Interface hypre_interface = Hypre::Interface::ij;
+    Hypre::Interface hypre_interface = Hypre::Interface::semi_structed;
+    // Hypre::Interface hypre_interface = Hypre::Interface::ij;
 #endif
     std::unique_ptr<Hypre> hypre_solver;
     std::unique_ptr<MLMGBndry> hypre_bndry;

--- a/Src/LinearSolvers/MLMG/AMReX_MLMG.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLMG.H
@@ -105,6 +105,12 @@ public:
 #endif
     }
 
+    //! Set the namespace in input file for parsing HYPRE specific options
+    void setHypreOptionsNamespace(const std::string& prefix) noexcept
+    {
+        hypre_options_namespace = prefix;
+    }
+
     void setHypreOldDefault (bool l) noexcept {hypre_old_default = l;}
     void setHypreRelaxType (int n) noexcept {hypre_relax_type = n;}
     void setHypreRelaxOrder (int n) noexcept {hypre_relax_order = n;}
@@ -211,13 +217,14 @@ private:
 #else
 
     // Hypre::Interface hypre_interface = Hypre::Interface::structed;
-    Hypre::Interface hypre_interface = Hypre::Interface::semi_structed;
-//    Hypre::Interface hypre_interface = Hypre::Interface::ij;
+    // Hypre::Interface hypre_interface = Hypre::Interface::semi_structed;
+   Hypre::Interface hypre_interface = Hypre::Interface::ij;
 #endif
     std::unique_ptr<Hypre> hypre_solver;
     std::unique_ptr<MLMGBndry> hypre_bndry;
     std::unique_ptr<HypreNodeLap> hypre_node_solver;
 
+    std::string hypre_options_namespace = "hypre";
     bool hypre_old_default = true; // Falgout coarsening with modified classical interpolation
     int hypre_relax_type = 6;  // G-S/Jacobi hybrid relaxation
     int hypre_relax_order = 1; // uses C/F relaxation


### PR DESCRIPTION
This PR extends the AMReX _hypre_ IJ interface to allow access to additional solvers and preconditioners available in _hypre_. 

- Refactored `HypreABecLap3` and `HypreNodeLap` (IJ matrix/vector ParCSR interfaces) and created a new IJ interface class that provides a unified way to access Hypre ParCSR solvers. 
- In addition to BoomerAMG, adds support for 7 other [ParCSR solvers](https://hypre.readthedocs.io/en/latest/ch-solvers.html) (GMRES (4 variants), PCG, BiCGSTAB, and Hybrid). Also adds support for BoomerAMG and Euclid as preconditioners for solvers that can use a preconditioner. 
- Adds support to parse user options to configure hypre library via AMReX ParmParse interface and input file, using a custom namespace (default is `hypre`)
- Adds `MLMG::setHypreOptionsNamespace` that allow applications to customize the namespace for different types of linear solvers (e.g., `mac_proj.hypre.<option>`, `nodal_proj.hypre.<option>`, etc.)
- Add option to skip solver/preconditioner setup step `recompute_preconditioner` for cases where the matrix coefficients do not change. 
- Add option to dump linear system in _hypre_ `IJ{Matrix,Vector}` format for debugging.

## Additional background

The extensions to _hypre_ interface supports [ExaWind AMR-Wind](https://github.com/exawind/amr-wind) overset and RANS applications. 

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [X] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
