### PR TITLE
Allow tagging value to vary by level

### DIFF
--- a/Src/AmrCore/AMReX_ErrorList.H
+++ b/Src/AmrCore/AMReX_ErrorList.H
@@ -378,7 +378,7 @@ std::ostream& operator << (std::ostream& os, const ErrorList& elst);
 
   struct AMRErrorTagInfo
   {
-    int m_max_level = 100000;
+    int m_max_level = 1000;
     Real m_min_time = std::numeric_limits<Real>::lowest();
     Real m_max_time = std::numeric_limits<Real>::max();
     RealBox m_realbox;
@@ -425,7 +425,33 @@ std::ostream& operator << (std::ostream& os, const ErrorList& elst);
                  AMRErrorTag::TEST      test,
                  const std::string&     field,
                  const AMRErrorTagInfo& info = AMRErrorTagInfo()) noexcept
-      : m_value(value), m_test(test), m_field(field), m_info(info) {m_ngrow = SetNGrow();}
+      : m_test(test), m_field(field), m_info(info)
+      {
+          m_value.resize(info.m_max_level);
+          for (int i = 0; i < info.m_max_level; ++i) {
+              m_value[i] = value;
+          }
+          m_ngrow = SetNGrow();
+      }
+
+    AMRErrorTag (amrex::Vector<amrex::Real>  value,
+                 AMRErrorTag::TEST           test,
+                 const std::string&          field,
+                 const AMRErrorTagInfo&      info = AMRErrorTagInfo()) noexcept
+      : m_test(test), m_field(field), m_info(info)
+      {
+          AMREX_ASSERT(value.size() > 0);
+          m_value.resize(info.m_max_level);
+          for (int i = 0; i < value.size(); ++i) {
+              m_value[i] = value[i];
+          }
+          // If the user didn't provided a value for every level,
+          // assume the last value holds for all higher levels.
+          for (int i = value.size(); i < m_value.size(); ++i) {
+              m_value[i] = value[value.size()-1];
+          }
+          m_ngrow = SetNGrow();
+      }
 
     AMRErrorTag (AMRErrorTag::UserFunc* userfunc,
                  const std::string&     field,
@@ -447,7 +473,7 @@ std::ostream& operator << (std::ostream& os, const ErrorList& elst);
   protected:
     int SetNGrow () const noexcept;
 
-    Real m_value;    
+    Vector<Real> m_value;
     TEST m_test;
     UserFunc* m_userfunc = nullptr;
     std::string m_field;

--- a/Src/AmrCore/AMReX_ErrorList.cpp
+++ b/Src/AmrCore/AMReX_ErrorList.cpp
@@ -395,19 +395,19 @@ operator << (std::ostream&    os,
 
             if (m_test == GRAD)
             {
-              AMRErrorTag_GRAD(bx, dat, tag, m_value, tagval);
+              AMRErrorTag_GRAD(bx, dat, tag, m_value[level], tagval);
             }
             else if (m_test == LESS)
             {
-              AMRErrorTag_LESS(bx, dat, tag, m_value, tagval);
+              AMRErrorTag_LESS(bx, dat, tag, m_value[level], tagval);
             }
             else if (m_test == GREATER)
             {
-              AMRErrorTag_GREATER(bx, dat, tag, m_value, tagval);
+              AMRErrorTag_GREATER(bx, dat, tag, m_value[level], tagval);
             }
             else if (m_test == VORT)
             {
-              AMRErrorTag_VORT(bx, dat, tag, level, m_value, tagval);
+              AMRErrorTag_VORT(bx, dat, tag, level, m_value[level], tagval);
             }
             else
             {


### PR DESCRIPTION
## Summary

The new error tagging scheme from #1166 is modified to allow the threshold value to vary by level. Using the example there, if we did:

```
amr.refinement_indicators = flame_tracer lo_temp
amr.refine.flame_tracer.max_level = 3
amr.refine.flame_tracer.value_greater = 1.e-6 1.e-5
amr.refine.flame_tracer.field_name = Y(H)

amr.refine.lo_temp.max_level = 2
amr.refine.lo_temp.value_less = 1000.
amr.refine.lo_temp.field_name = temp
```

Then level 0 would be tagged for refinement for Y(H) >= 1.e-6, while level 1 and all higher levels would be tagged for refinement for Y(H) >= 1.e-5. (If a value for every level is not provided, we assume the last value holds for all remaining levels, similar to how we treat quantities like amr.n_error_buf.)

## Additional background

This will help for cases where a field varies substantially on the domain and you want to have better control over refinement so that you don't have too many zones.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
