### PR TITLE
Add computeGradient and EB_computeGradient

### DIFF
--- a/Src/Base/AMReX_MultiFabUtil.H
+++ b/Src/Base/AMReX_MultiFabUtil.H
@@ -179,6 +179,10 @@ namespace amrex
     void computeGradient (MultiFab& grad, const Array<MultiFab const*,AMREX_SPACEDIM>& umac,
                           const Geometry& geom);
 
+    //! Computes gradient of face-data stored in the umac MultiFab.
+    void computeGradient (const Array<MultiFab*,AMREX_SPACEDIM>& grad, const MultiFab& mf, 
+                          const Geometry& geom);
+
     //! Convert iMultiFab to MultiFab
     MultiFab ToMultiFab (const iMultiFab& imf);
     //! Convert iMultiFab to Long

--- a/Src/Base/AMReX_MultiFabUtil.cpp
+++ b/Src/Base/AMReX_MultiFabUtil.cpp
@@ -839,8 +839,6 @@ namespace amrex
     void computeGradient (const Array<MultiFab*,AMREX_SPACEDIM>& grad, const MultiFab& mf,
                           const Geometry& geom)
     {
-        AMREX_ASSERT(mf.nComp() == 1);
-
         AMREX_ASSERT(grad[0]->nComp() == mf.nComp());
         AMREX_ASSERT(grad[1]->nComp() == mf.nComp());
 #if (AMREX_SPACEDIM==3)
@@ -866,10 +864,10 @@ namespace amrex
         for (MFIter mfi(mf,TilingIfNotGPU()); mfi.isValid(); ++mfi)
         {
             const Box& bx = mfi.tilebox();
-            const auto& mfarr = mf.const_array(mfi);
             AMREX_D_TERM(const auto& gradxarr = grad[0]->array(mfi);,
                          const auto& gradyarr = grad[1]->array(mfi);,
                          const auto& gradzarr = grad[2]->array(mfi););
+            const auto& mfarr = mf.const_array(mfi);
 #if (AMREX_SPACEDIM==2)
             if (geom.IsRZ()) {
                 Array4<Real const> const&  ax =  areax.array(mfi);
@@ -878,7 +876,7 @@ namespace amrex
 
                 AMREX_LAUNCH_HOST_DEVICE_LAMBDA (bx, tbx,
                 {
-                    amrex_compute_gradient_rz(tbx,
+                    amrex_compute_gradient_rz(tbx,mf.nComp(),
                       AMREX_D_DECL(gradxarr,gradyarr,gradzarr),mfarr,ax,ay,vol);
                 });
             } else
@@ -886,7 +884,7 @@ namespace amrex
             {
                 AMREX_LAUNCH_HOST_DEVICE_LAMBDA (bx, tbx,
                 {
-                    amrex_compute_gradient(tbx,
+                    amrex_compute_gradient(tbx,mf.nComp(),
                       AMREX_D_DECL(gradxarr,gradyarr,gradzarr),mfarr,dxinv);
                 });
             }

--- a/Src/Base/AMReX_MultiFabUtil.cpp
+++ b/Src/Base/AMReX_MultiFabUtil.cpp
@@ -841,10 +841,10 @@ namespace amrex
     {
         AMREX_ASSERT(mf.nComp() == 1);
 
-        AMREX_ASSERT(grad[0].nComp() == mf.nComp());
-        AMREX_ASSERT(grad[1].nComp() == mf.nComp());
+        AMREX_ASSERT(grad[0]->nComp() == mf.nComp());
+        AMREX_ASSERT(grad[1]->nComp() == mf.nComp());
 #if (AMREX_SPACEDIM==3)
-        AMREX_ASSERT(grad[2].nComp() == mf.nComp());
+        AMREX_ASSERT(grad[2]->nComp() == mf.nComp());
 #endif
 
 #if (AMREX_SPACEDIM==2)

--- a/Src/Base/AMReX_MultiFabUtil.cpp
+++ b/Src/Base/AMReX_MultiFabUtil.cpp
@@ -848,8 +848,8 @@ namespace amrex
 #endif
 
 #if (AMREX_SPACEDIM==2)
-        const auto& ba = grad.boxArray();
-        const auto& dm = grad.DistributionMap();
+        const auto& ba = mf.boxArray();
+        const auto& dm = mf.DistributionMap();
         MultiFab volume, areax, areay;
         if (geom.IsRZ()) {
             geom.GetVolume(volume, ba, dm, 0);

--- a/Src/Base/AMReX_MultiFabUtil_1D_C.H
+++ b/Src/Base/AMReX_MultiFabUtil_1D_C.H
@@ -301,6 +301,25 @@ void amrex_compute_gradient (Box const& bx, Array4<Real> const& grad,
     }
 }
 
+AMREX_GPU_HOST_DEVICE
+inline
+void amrex_compute_gradient (Box const& bx, const int nComps,
+                             Array4<Real> const& grad,
+                             Array4<Real const> const& mf,
+                             GpuArray<Real,AMREX_SPACEDIM> const& dxinv) noexcept
+{
+    const auto lo = lbound(bx);
+    const auto hi = ubound(bx);
+    const Real dxi = dxinv[0];
+
+    for (int n = 0; n < nComps; ++n) {
+        AMREX_PRAGMA_SIMD
+        for (int i = lo.x; i <= hi.x; ++i) {
+            grad(i,0,0,n) = dxi * (mf(i+1,0,0,n)-mf(i,0,0,n));
+        }
+    }
+}
+
 }
 
 #endif

--- a/Src/Base/AMReX_MultiFabUtil_2D_C.H
+++ b/Src/Base/AMReX_MultiFabUtil_2D_C.H
@@ -322,7 +322,8 @@ void amrex_compute_gradient (Box const& bx, Array4<Real> const& grad,
 
 AMREX_GPU_HOST_DEVICE
 inline
-void amrex_compute_gradient (Box const& bx, Array4<Real const> const& mf,
+void amrex_compute_gradient (Box const& bx, const int nComps,
+                             Array4<Real const> const& mf,
                              Array4<Real> const& gradx,
                              Array4<Real> const& grady,
                              GpuArray<Real,AMREX_SPACEDIM> const& dxinv) noexcept
@@ -332,12 +333,14 @@ void amrex_compute_gradient (Box const& bx, Array4<Real const> const& mf,
     const Real dxi = dxinv[0];
     const Real dyi = dxinv[1];
 
-    for     (int j = lo.y; j <= hi.y; ++j) {
-        AMREX_PRAGMA_SIMD
-        for (int i = lo.x; i <= hi.x; ++i) {
-            const Real val = mf(i,j,0);
-            gradx(i,j,0,0) = dxi * (mf(i+1,j,0)-val);
-            grady(i,j,0,0) = dyi * (mf(i,j+1,0)-val);
+    for         (int n = 0; n < nComps; ++n) {
+        for     (int j = lo.y; j <= hi.y; ++j) {
+            AMREX_PRAGMA_SIMD
+            for (int i = lo.x; i <= hi.x; ++i) {
+                const Real val = mf(i,j,0,n);
+                gradx(i,j,0,n) = dxi * (mf(i+1,j,0,n)-val);
+                grady(i,j,0,n) = dyi * (mf(i,j+1,0,n)-val);
+            }
         }
     }
 }
@@ -410,6 +413,31 @@ void amrex_compute_gradient_rz (Box const& bx, Array4<Real> const& grad,
         for (int i = lo.x; i <= hi.x; ++i) {
             grad(i,j,0,0) = (ax(i+1,j,0,0)*u(i+1,j,0)-ax(i,j,0,0)*u(i,j,0))/vol(i,j,0,0);
             grad(i,j,0,1) = (ay(i,j+1,0,0)*v(i,j+1,0)-ay(i,j,0,0)*v(i,j,0))/vol(i,j,0,0);
+        }
+    }
+}
+
+AMREX_GPU_HOST_DEVICE
+inline
+void amrex_compute_gradient_rz (Box const& bx, const int nComps,
+                                Array4<Real> const& gradx,
+                                Array4<Real> const& grady,
+                                Array4<Real const> const& mf,
+                                Array4<Real const> const& ax,
+                                Array4<Real const> const& ay,
+                                Array4<Real const> const& vol) noexcept
+{
+    const auto lo = lbound(bx);
+    const auto hi = ubound(bx);
+
+    for         (int n = 0; n < nComps; ++n) {
+        for     (int j = lo.y; j <= hi.y; ++j) {
+            AMREX_PRAGMA_SIMD
+            for (int i = lo.x; i <= hi.x; ++i) {
+                const Real val = mf(i,j,0,n);
+                gradx(i,j,0,n) = (ax(i+1,j,0,0)*mf(i+1,j,n)-ax(i,j,0,0)*val)/vol(i,j,0,0);
+                grady(i,j,0,n) = (ay(i,j+1,0,0)*mf(i,j+1,n)-ay(i,j,0,0)*val)/vol(i,j,0,0);
+            }
         }
     }
 }

--- a/Src/Base/AMReX_MultiFabUtil_2D_C.H
+++ b/Src/Base/AMReX_MultiFabUtil_2D_C.H
@@ -323,9 +323,9 @@ void amrex_compute_gradient (Box const& bx, Array4<Real> const& grad,
 AMREX_GPU_HOST_DEVICE
 inline
 void amrex_compute_gradient (Box const& bx, const int nComps,
-                             Array4<Real const> const& mf,
                              Array4<Real> const& gradx,
                              Array4<Real> const& grady,
+                             Array4<Real const> const& mf,
                              GpuArray<Real,AMREX_SPACEDIM> const& dxinv) noexcept
 {
     const auto lo = lbound(bx);

--- a/Src/Base/AMReX_MultiFabUtil_2D_C.H
+++ b/Src/Base/AMReX_MultiFabUtil_2D_C.H
@@ -322,6 +322,28 @@ void amrex_compute_gradient (Box const& bx, Array4<Real> const& grad,
 
 AMREX_GPU_HOST_DEVICE
 inline
+void amrex_compute_gradient (Box const& bx, Array4<Real const> const& mf,
+                             Array4<Real> const& gradx,
+                             Array4<Real> const& grady,
+                             GpuArray<Real,AMREX_SPACEDIM> const& dxinv) noexcept
+{
+    const auto lo = lbound(bx);
+    const auto hi = ubound(bx);
+    const Real dxi = dxinv[0];
+    const Real dyi = dxinv[1];
+
+    for     (int j = lo.y; j <= hi.y; ++j) {
+        AMREX_PRAGMA_SIMD
+        for (int i = lo.x; i <= hi.x; ++i) {
+            const Real val = mf(i,j,0);
+            gradx(i,j,0,0) = dxi * (mf(i+1,j,0)-val);
+            grady(i,j,0,0) = dyi * (mf(i,j+1,0)-val);
+        }
+    }
+}
+
+AMREX_GPU_HOST_DEVICE
+inline
 void amrex_compute_convective_difference (Box const& bx, Array4<amrex::Real> const& diff,
                                           Array4<Real const> const& u_face,
                                           Array4<Real const> const& v_face,

--- a/Src/Base/AMReX_MultiFabUtil_3D_C.H
+++ b/Src/Base/AMReX_MultiFabUtil_3D_C.H
@@ -420,10 +420,10 @@ void amrex_compute_gradient (Box const& bx, Array4<Real> const& grad,
 AMREX_GPU_HOST_DEVICE
 inline
 void amrex_compute_gradient (Box const& bx, const int nComps,
-                             Array4<Real const> const& mf,
                              Array4<Real> const& gradx,
                              Array4<Real> const& grady,
                              Array4<Real> const& gradz,
+                             Array4<Real const> const& mf,
                              GpuArray<Real,AMREX_SPACEDIM> const& dxinv) noexcept
 {
     const auto lo = lbound(bx);
@@ -431,7 +431,6 @@ void amrex_compute_gradient (Box const& bx, const int nComps,
     const Real dxi = dxinv[0];
     const Real dyi = dxinv[1];
     const Real dzi = dxinv[2];
-
 
     for             (int n = 0; n < nComps; ++n) {
         for         (int k = lo.z; k <= hi.z; ++k) {

--- a/Src/Base/AMReX_MultiFabUtil_3D_C.H
+++ b/Src/Base/AMReX_MultiFabUtil_3D_C.H
@@ -419,6 +419,33 @@ void amrex_compute_gradient (Box const& bx, Array4<Real> const& grad,
 
 AMREX_GPU_HOST_DEVICE
 inline
+void amrex_compute_gradient (Box const& bx, Array4<Real const> const& mf,
+                             Array4<Real> const& gradx,
+                             Array4<Real> const& grady,
+                             Array4<Real> const& gradz,
+                             GpuArray<Real,AMREX_SPACEDIM> const& dxinv) noexcept
+{
+    const auto lo = lbound(bx);
+    const auto hi = ubound(bx);
+    const Real dxi = dxinv[0];
+    const Real dyi = dxinv[1];
+    const Real dzi = dxinv[2];
+
+    for         (int k = lo.z; k <= hi.z; ++k) {
+        for     (int j = lo.y; j <= hi.y; ++j) {
+            AMREX_PRAGMA_SIMD
+            for (int i = lo.x; i <= hi.x; ++i) {
+                const Real val = mf(i,j,k,0);
+                gradx(i,j,k,0) = dxi * (mf(i+1,j,k,0)-val);
+                grady(i,j,k,0) = dyi * (mf(i,j+1,k,0)-val);
+                gradz(i,j,k,0) = dzi * (mf(i,j,k+1,0)-val);
+            }
+        }
+    }
+}
+
+AMREX_GPU_HOST_DEVICE
+inline
 void amrex_compute_convective_difference (Box const& bx, Array4<Real> const& diff,
                                           Array4<Real const> const& u_face,
                                           Array4<Real const> const& v_face,

--- a/Src/Base/AMReX_MultiFabUtil_3D_C.H
+++ b/Src/Base/AMReX_MultiFabUtil_3D_C.H
@@ -419,7 +419,8 @@ void amrex_compute_gradient (Box const& bx, Array4<Real> const& grad,
 
 AMREX_GPU_HOST_DEVICE
 inline
-void amrex_compute_gradient (Box const& bx, Array4<Real const> const& mf,
+void amrex_compute_gradient (Box const& bx, const int nComps,
+                             Array4<Real const> const& mf,
                              Array4<Real> const& gradx,
                              Array4<Real> const& grady,
                              Array4<Real> const& gradz,
@@ -431,14 +432,17 @@ void amrex_compute_gradient (Box const& bx, Array4<Real const> const& mf,
     const Real dyi = dxinv[1];
     const Real dzi = dxinv[2];
 
-    for         (int k = lo.z; k <= hi.z; ++k) {
-        for     (int j = lo.y; j <= hi.y; ++j) {
-            AMREX_PRAGMA_SIMD
-            for (int i = lo.x; i <= hi.x; ++i) {
-                const Real val = mf(i,j,k,0);
-                gradx(i,j,k,0) = dxi * (mf(i+1,j,k,0)-val);
-                grady(i,j,k,0) = dyi * (mf(i,j+1,k,0)-val);
-                gradz(i,j,k,0) = dzi * (mf(i,j,k+1,0)-val);
+
+    for             (int n = 0; n < nComps; ++n) {
+        for         (int k = lo.z; k <= hi.z; ++k) {
+            for     (int j = lo.y; j <= hi.y; ++j) {
+                AMREX_PRAGMA_SIMD
+                for (int i = lo.x; i <= hi.x; ++i) {
+                    const Real val = mf(i,j,k,n);
+                    gradx(i,j,k,n) = dxi * (mf(i+1,j,k,n)-val);
+                    grady(i,j,k,n) = dyi * (mf(i,j+1,k,n)-val);
+                    gradz(i,j,k,n) = dzi * (mf(i,j,k+1,n)-val);
+                }
             }
         }
     }

--- a/Src/EB/AMReX_EBMultiFabUtil.H
+++ b/Src/EB/AMReX_EBMultiFabUtil.H
@@ -44,6 +44,9 @@ namespace amrex
     void EB_computeDivergence (MultiFab& divu, const Array<MultiFab const*,AMREX_SPACEDIM>& umac,
                                const Geometry& geom, bool already_on_centroids);
 
+    void EB_computeGradient (const Array<MultiFab*,AMREX_SPACEDIM>& grad, const MultiFab& mf, 
+                             const Geometry& geom, bool already_on_centroids);
+
     // Cell faces to cell centers
     void EB_average_face_to_cellcenter (MultiFab& ccmf, int dcomp,
                                         const Array<MultiFab const*,AMREX_SPACEDIM>& fmf);

--- a/Src/EB/AMReX_EBMultiFabUtil.cpp
+++ b/Src/EB/AMReX_EBMultiFabUtil.cpp
@@ -806,7 +806,7 @@ void EB_computeGradient (const Array<MultiFab*,AMREX_SPACEDIM>& grad, const Mult
             } else if (fabtyp == FabType::regular) {
                 AMREX_LAUNCH_HOST_DEVICE_LAMBDA(bx, b,
                 {
-                    amrex_compute_gradient(b,
+                    amrex_compute_gradient(b,mf.nComp(),
                       AMREX_D_DECL(gradxarr,gradyarr,gradzarr),mfarr,dxinv);
                 });
             } else {

--- a/Src/EB/AMReX_EBMultiFabUtil_2D_C.H
+++ b/Src/EB/AMReX_EBMultiFabUtil_2D_C.H
@@ -211,6 +211,72 @@ void eb_compute_divergence (int i, int j, int k, int n, Array4<Real> const& divu
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void eb_compute_gradient (int i, int j, int k, int n, Array4<Real> const& gradx,
+                          Array4<Real> const& grady, Array4<Real const> const& mf,
+                          Array4<int const> const& ccm, Array4<EBCellFlag const> const& flag,
+                          Array4<Real const> const& vfrc, Array4<Real const> const& apx,
+                          Array4<Real const> const& apy, Array4<Real const> const& fcx,
+                          Array4<Real const> const& fcy, GpuArray<Real,2> const& dxinv,
+                          bool already_on_centroids)
+{
+    if (flag(i,j,k).isCovered())
+    {
+        gradx(i,j,k,n) = 0.0;
+        grady(i,j,k,n) = 0.0;
+    }
+    else if (flag(i,j,k).isRegular())
+    {
+        const Real val = mf(i,j,k,n);
+
+        gradx(i,j,k,n) = dxinv[0] * (mf(i+1,j,k,n)-val);
+        grady(i,j,k,n) = dxinv[1] * (mf(i,j+1,k,n)-val);
+    }
+    else if (already_on_centroids)
+    {
+        const Real val = mf(i,j,k,n);
+        const Real coeff = 1.0/vfrc(i,j,k);
+
+        gradx(i,j,k,n) = coeff * dxinv[0] * (apx(i+1,j,k)*mf(i+1,j,k,n)-apx(i,j,k)*val);
+        grady(i,j,k,n) = coeff * dxinv[1] * (apy(i,j+1,k)*mf(i,j+1,k,n)-apy(i,j,k)*val);
+        gradz(i,j,k,n) = coeff * dxinv[2] * (apz(i,j,k+1)*mf(i,j,k+1,n)-apz(i,j,k)*val);
+    }
+    else
+    {
+        Real fxm = mf(i,j,k,n);
+        if (apx(i,j,k) != 0.0 and apx(i,j,k) != 1.0) {
+            int jj = j + static_cast<int>(amrex::Math::copysign(1.0,fcx(i,j,k)));
+            Real fracy = (ccm(i-1,jj,k) || ccm(i,jj,k)) ? amrex::Math::abs(fcx(i,j,k)) : 0.0;
+            fxm = (1.0-fracy)*fxm + fracy*mf(i,jj,k,n);
+        }
+
+        Real fxp = mf(i+1,j,k,n);
+        if (apx(i+1,j,k) != 0.0 and apx(i+1,j,k) != 1.0) {
+            int jj = j + static_cast<int>(amrex::Math::copysign(1.0,fcx(i+1,j,k)));
+            Real fracy = (ccm(i,jj,k) || ccm(i+1,jj,k)) ? amrex::Math::abs(fcx(i+1,j,k)) : 0.0;
+            fxp = (1.0-fracy)*fxp + fracy*mf(i+1,jj,k,n);
+        }
+
+        Real fym = fxm;
+        if (apy(i,j,k) != 0.0 and apy(i,j,k) != 1.0) {
+            int ii = i + static_cast<int>(amrex::Math::copysign(1.0,fcy(i,j,k)));
+            Real fracx = (ccm(ii,j-1,k) || ccm(ii,j,k)) ? amrex::Math::abs(fcy(i,j,k)) : 0.0;
+            fym = (1.0-fracx)*fym + fracx*mf(ii,j,k,n);
+        }
+
+        Real fyp = mf(i,j+1,k,n);
+        if (apy(i,j+1,k) != 0.0 and apy(i,j+1,k) != 1.0) {
+            int ii = i + static_cast<int>(amrex::Math::copysign(1.0,fcy(i,j+1,k)));
+            Real fracx = (ccm(ii,j,k) || ccm(ii,j+1,k)) ? amrex::Math::abs(fcy(i,j+1,k)) : 0.0;
+            fyp = (1.0-fracx)*fyp + fracx*mf(ii,j+1,k,n);
+        }
+
+        const Real coeff = 1.0/vfrc(i,j,k);
+        gradx(i,j,k,n) = coeff * dxinv[0] * (apx(i+1,j,k)*fxp-apx(i,j,k)*fxm);
+        grady(i,j,k,n) = coeff * dxinv[1] * (apy(i,j+1,k)*fyp-apy(i,j,k)*fym);
+    }
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 void eb_avg_fc_to_cc (int i, int j, int k, int n, Array4<Real> const& cc,
                       Array4<Real const> const& fx, Array4<Real const> const& fy,
                       Array4<Real const> const& ax, Array4<Real const> const& ay,

--- a/Src/EB/AMReX_EBMultiFabUtil_3D_C.H
+++ b/Src/EB/AMReX_EBMultiFabUtil_3D_C.H
@@ -330,6 +330,119 @@ void eb_compute_divergence (int i, int j, int k, int n, Array4<Real> const& divu
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void eb_compute_gradient (int i, int j, int k, int n, Array4<Real> const& gradx,
+                          Array4<Real> const& grady, Array4<Real> const& gradz,
+                          Array4<Real const> const& mf, Array4<int const> const& ccm,
+                          Array4<EBCellFlag const> const& flag, Array4<Real const> const& vfrc,
+                          Array4<Real const> const& apx, Array4<Real const> const& apy,
+                          Array4<Real const> const& apz, Array4<Real const> const& fcx,
+                          Array4<Real const> const& fcy, Array4<Real const> const& fcz,
+                          GpuArray<Real,3> const& dxinv, bool already_on_centroids)
+{
+    if (flag(i,j,k).isCovered())
+    {
+        gradx(i,j,k,n) = 0.0;
+        grady(i,j,k,n) = 0.0;
+        gradz(i,j,k,n) = 0.0;
+    }
+    else if (flag(i,j,k).isRegular())
+    {
+        const Real val = mf(i,j,k,n);
+        gradx(i,j,k,n) = dxinv[0] * (mf(i+1,j,k,n)-val);
+        grady(i,j,k,n) = dxinv[1] * (mf(i,j+1,k,n)-val);
+        gradz(i,j,k,n) = dxinv[2] * (mf(i,j,k+1,n)-val);
+    }
+    else if (already_on_centroids)
+    {
+        const Real val = mf(i,j,k,n);
+        const Real coeff = 1.0/vfrc(i,j,k);
+        gradx(i,j,k,n) = coeff * dxinv[0] * (apx(i+1,j,k)*mf(i+1,j,k,n)-apx(i,j,k)*val);
+        grady(i,j,k,n) = coeff * dxinv[1] * (apy(i,j+1,k)*mf(i,j+1,k,n)-apy(i,j,k)*val);
+        gradz(i,j,k,n) = coeff * dxinv[2] * (apz(i,j,k+1)*mf(i,j,k+1,n)-apz(i,j,k)*val);
+    }
+    else
+    {
+        Real fxm = mf(i,j,k,n);
+        if (apx(i,j,k) != 0.0 and apx(i,j,k) != 1.0) {
+            int jj = j + static_cast<int>(amrex::Math::copysign(1.0, fcx(i,j,k,0)));
+            int kk = k + static_cast<int>(amrex::Math::copysign(1.0, fcx(i,j,k,1)));
+            Real fracy = (ccm(i-1,jj,k) || ccm(i,jj,k)) ? amrex::Math::abs(fcx(i,j,k,0)) : 0.0;
+            Real fracz = (ccm(i-1,j,kk) || ccm(i,j,kk)) ? amrex::Math::abs(fcx(i,j,k,1)) : 0.0;
+            fxm = (1.0-fracy)*(1.0-fracz)*fxm
+                +      fracy *(1.0-fracz)*mf(i,jj,k ,n)
+                +      fracz *(1.0-fracy)*mf(i,j ,kk,n)
+                +      fracy *     fracz *mf(i,jj,kk,n);
+        }
+
+        Real fxp = mf(i+1,j,k,n);
+        if (apx(i+1,j,k) != 0.0 and apx(i+1,j,k) != 1.0) {
+            int jj = j + static_cast<int>(amrex::Math::copysign(1.0,fcx(i+1,j,k,0)));
+            int kk = k + static_cast<int>(amrex::Math::copysign(1.0,fcx(i+1,j,k,1)));
+            Real fracy = (ccm(i,jj,k) || ccm(i+1,jj,k)) ? amrex::Math::abs(fcx(i+1,j,k,0)) : 0.0;
+            Real fracz = (ccm(i,j,kk) || ccm(i+1,j,kk)) ? amrex::Math::abs(fcx(i+1,j,k,1)) : 0.0;
+            fxp = (1.0-fracy)*(1.0-fracz)*fxp
+                +      fracy *(1.0-fracz)*mf(i+1,jj,k ,n)
+                +      fracz *(1.0-fracy)*mf(i+1,j ,kk,n)
+                +      fracy *     fracz *mf(i+1,jj,kk,n);
+        }
+
+        Real fym = fxm;
+        if (apy(i,j,k) != 0.0 and apy(i,j,k) != 1.0) {
+            int ii = i + static_cast<int>(amrex::Math::copysign(1.0,fcy(i,j,k,0)));
+            int kk = k + static_cast<int>(amrex::Math::copysign(1.0,fcy(i,j,k,1)));
+            Real fracx = (ccm(ii,j-1,k) || ccm(ii,j,k)) ? amrex::Math::abs(fcy(i,j,k,0)) : 0.0;
+            Real fracz = (ccm(i,j-1,kk) || ccm(i,j,kk)) ? amrex::Math::abs(fcy(i,j,k,1)) : 0.0;
+            fym = (1.0-fracx)*(1.0-fracz)*fym
+                +      fracx *(1.0-fracz)*mf(ii,j,k ,n)
+                +      fracz *(1.0-fracx)*mf(i ,j,kk,n)
+                +      fracx *     fracz *mf(ii,j,kk,n);
+        }
+
+        Real fyp = mf(i,j+1,k,n);
+        if (apy(i,j+1,k) != 0.0 and apy(i,j+1,k) != 1.0) {
+            int ii = i + static_cast<int>(amrex::Math::copysign(1.0,fcy(i,j+1,k,0)));
+            int kk = k + static_cast<int>(amrex::Math::copysign(1.0,fcy(i,j+1,k,1)));
+            Real fracx = (ccm(ii,j,k) || ccm(ii,j+1,k)) ? amrex::Math::abs(fcy(i,j+1,k,0)) : 0.0;
+            Real fracz = (ccm(i,j,kk) || ccm(i,j+1,kk)) ? amrex::Math::abs(fcy(i,j+1,k,1)) : 0.0;
+            fyp = (1.0-fracx)*(1.0-fracz)*fyp
+                +      fracx *(1.0-fracz)*mf(ii,j+1,k ,n)
+                +      fracz *(1.0-fracx)*mf(i ,j+1,kk,n)
+                +      fracx *     fracz *mf(ii,j+1,kk,n);
+        }
+
+        Real fzm = fxm;
+        if (apz(i,j,k) != 0.0 and apz(i,j,k) != 1.0) {
+            int ii = i + static_cast<int>(amrex::Math::copysign(1.0,fcz(i,j,k,0)));
+            int jj = j + static_cast<int>(amrex::Math::copysign(1.0,fcz(i,j,k,1)));
+            Real fracx = (ccm(ii,j,k-1) || ccm(ii,j,k)) ? amrex::Math::abs(fcz(i,j,k,0)) : 0.0;
+            Real fracy = (ccm(i,jj,k-1) || ccm(i,jj,k)) ? amrex::Math::abs(fcz(i,j,k,1)) : 0.0;
+            fzm = (1.0-fracx)*(1.0-fracy)*fzm
+                +      fracx *(1.0-fracy)*mf(ii,j ,k,n)
+                +      fracy *(1.0-fracx)*mf(i ,jj,k,n)
+                +      fracx *     fracy *mf(ii,jj,k,n);
+        }
+
+        Real fzp = mf(i,j,k+1,n);
+        if (apz(i,j,k+1) != 0.0 and apz(i,j,k+1) != 1.0) {
+            int ii = i + static_cast<int>(amrex::Math::copysign(1.0,fcz(i,j,k+1,0)));
+            int jj = j + static_cast<int>(amrex::Math::copysign(1.0,fcz(i,j,k+1,1)));
+            Real fracx = (ccm(ii,j,k) || ccm(ii,j,k+1)) ? amrex::Math::abs(fcz(i,j,k+1,0)) : 0.0;
+            Real fracy = (ccm(i,jj,k) || ccm(i,jj,k+1)) ? amrex::Math::abs(fcz(i,j,k+1,1)) : 0.0;
+            fzp = (1.0-fracx)*(1.0-fracy)*fzp
+                +      fracx *(1.0-fracy)*mf(ii,j ,k+1,n)
+                +      fracy *(1.0-fracx)*mf(i ,jj,k+1,n)
+                +      fracx *     fracy *mf(ii,jj,k+1,n);
+        }
+
+        const Real coeff = 1.0/vfrc(i,j,k);
+
+        gradx(i,j,k,n) = coeff * dxinv[0] * (apx(i+1,j,k)*fxp-apx(i,j,k)*fxm);
+        grady(i,j,k,n) = coeff * dxinv[1] * (apy(i,j+1,k)*fyp-apy(i,j,k)*fym);
+        gradz(i,j,k,n) = coeff * dxinv[2] * (apz(i,j,k+1)*fzp-apz(i,j,k)*fzm);
+    }
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 void eb_avg_fc_to_cc (int i, int j, int k, int n, Array4<Real> const& cc,
                       Array4<Real const> const& fx, Array4<Real const> const& fy,
                       Array4<Real const> const& fz, Array4<Real const> const& ax,


### PR DESCRIPTION
## Summary
This PR adds new methods for MultiFab gradient computation, similar to what is already implemented for the MultiFab divergence.

## Additional background
Some methods for gradient computation already exist, but they seem specifically targeted for velocity gradient computation.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
