### PR TITLE
Allow users to set a Geometry object for ParticleContainer independently of the AmrCore / AmrLevel object.

### DIFF
--- a/Src/AmrCore/AMReX_AmrParGDB.H
+++ b/Src/AmrCore/AMReX_AmrParGDB.H
@@ -13,25 +13,30 @@ public:
 
     explicit AmrParGDB (AmrCore* amr) noexcept
 	: m_amrcore(amr),
+          m_geom(amr->maxLevel()+1),
+          m_has_geom(amr->maxLevel()+1, 0),
 	  m_dmap(amr->maxLevel()+1),
 	  m_ba(amr->maxLevel()+1)
 	{ }
 
     virtual ~AmrParGDB () {;}
-    
+
+    virtual const Geometry& ParticleGeom (int level) const override;
     virtual const Geometry& Geom (int level) const override;
-    virtual const DistributionMapping& ParticleDistributionMap 
+    virtual const DistributionMapping& ParticleDistributionMap
                                              (int level) const override;
-    virtual const DistributionMapping&         DistributionMap 
+    virtual const DistributionMapping&         DistributionMap
                                              (int level) const override;
     virtual const BoxArray& ParticleBoxArray (int level) const override;
     virtual const BoxArray&         boxArray (int level) const override;
 
     virtual void SetParticleBoxArray (int level, const BoxArray& new_ba) override;
     virtual void SetParticleDistributionMap (int level,	const DistributionMapping& new_dm) override;
+    virtual void SetParticleGeometry (int level, const Geometry& new_geom) override;
 
     virtual void ClearParticleBoxArray (int level) override;
     virtual void ClearParticleDistributionMap (int level) override;
+    virtual void ClearParticleGeometry (int level) override;
 
     virtual bool LevelDefined (int level) const override;
     virtual int finestLevel () const override;
@@ -41,20 +46,34 @@ public:
     virtual int MaxRefRatio (int level) const override;
 
 protected:
-    AmrCore* m_amrcore;
+
+    AmrCore*                    m_amrcore;
+    Vector<Geometry>            m_geom;
+    Vector<int>                 m_has_geom;
     Vector<DistributionMapping> m_dmap;
     Vector<BoxArray>            m_ba;
 };
 
-inline 
-const Geometry& 
+inline
+const Geometry&
+AmrParGDB::ParticleGeom (int level) const
+{
+    if (m_has_geom[level]) {
+        return m_amrcore->Geom(level);
+    } else {
+        m_geom[level];
+    }
+}
+
+inline
+const Geometry&
 AmrParGDB::Geom (int level) const
 {
     return m_amrcore->Geom(level);
 }
 
-inline 
-const DistributionMapping& 
+inline
+const DistributionMapping&
 AmrParGDB::ParticleDistributionMap (int level) const
 {
     if (m_dmap[level].empty()) {
@@ -64,14 +83,14 @@ AmrParGDB::ParticleDistributionMap (int level) const
     }
 }
 
-inline 
-const DistributionMapping& 
+inline
+const DistributionMapping&
 AmrParGDB::DistributionMap (int level) const
 {
     return m_amrcore->DistributionMap(level);
 }
 
-inline 
+inline
 const BoxArray&
 AmrParGDB::ParticleBoxArray (int level) const
 {
@@ -102,6 +121,13 @@ void AmrParGDB::SetParticleDistributionMap (int level, const DistributionMapping
 }
 
 inline
+void AmrParGDB::SetParticleGeometry (int level, const Geometry& new_geom)
+{
+    m_has_geom[lev] = 1;
+    m_geom[level] = new_geom;
+}
+
+inline
 void AmrParGDB::ClearParticleBoxArray (int level)
 {
     m_ba[level] = BoxArray();
@@ -113,36 +139,43 @@ void AmrParGDB::ClearParticleDistributionMap (int level)
     m_dmap[level] = DistributionMapping();
 }
 
-inline 
-bool 
+inline
+void AmrParGDB::ClearParticleGeometry (int level)
+{
+    m_geom[level] = Geometry();
+    m_has_geom[level] = 0;
+}
+
+inline
+bool
 AmrParGDB::LevelDefined (int level) const
 {
     return m_amrcore->LevelDefined(level);
 }
 
-inline 
-int 
+inline
+int
 AmrParGDB::finestLevel () const
 {
     return m_amrcore->finestLevel();
 }
 
-inline 
-int 
+inline
+int
 AmrParGDB::maxLevel () const
 {
     return m_amrcore->maxLevel();
 }
- 
-inline 
-IntVect 
+
+inline
+IntVect
 AmrParGDB::refRatio (int level) const
 {
     return m_amrcore->refRatio(level);
 }
 
-inline 
-int 
+inline
+int
 AmrParGDB::MaxRefRatio (int level) const
 {
     return m_amrcore->MaxRefRatio(level);

--- a/Src/AmrCore/AMReX_AmrParGDB.H
+++ b/Src/AmrCore/AMReX_AmrParGDB.H
@@ -61,7 +61,7 @@ AmrParGDB::ParticleGeom (int level) const
     if (m_has_geom[level]) {
         return m_amrcore->Geom(level);
     } else {
-        m_geom[level];
+        return m_geom[level];
     }
 }
 

--- a/Src/AmrCore/AMReX_AmrParGDB.H
+++ b/Src/AmrCore/AMReX_AmrParGDB.H
@@ -58,7 +58,7 @@ inline
 const Geometry&
 AmrParGDB::ParticleGeom (int level) const
 {
-    if (m_has_geom[level]) {
+    if (not m_has_geom[level]) {
         return m_amrcore->Geom(level);
     } else {
         return m_geom[level];

--- a/Src/AmrCore/AMReX_AmrParGDB.H
+++ b/Src/AmrCore/AMReX_AmrParGDB.H
@@ -123,7 +123,7 @@ void AmrParGDB::SetParticleDistributionMap (int level, const DistributionMapping
 inline
 void AmrParGDB::SetParticleGeometry (int level, const Geometry& new_geom)
 {
-    m_has_geom[lev] = 1;
+    m_has_geom[level] = 1;
     m_geom[level] = new_geom;
 }
 

--- a/Src/Particle/AMReX_ParGDB.H
+++ b/Src/Particle/AMReX_ParGDB.H
@@ -15,6 +15,7 @@ public:
     ParGDBBase () {;}
     virtual ~ParGDBBase () {;}
 
+    virtual const Geometry& ParticleGeom (int level) const = 0;
     virtual const Geometry& Geom (int level) const = 0;
     virtual const DistributionMapping& ParticleDistributionMap
                                              (int level) const = 0;
@@ -25,9 +26,11 @@ public:
 
     virtual void SetParticleBoxArray (int level, const BoxArray& new_ba) = 0;
     virtual void SetParticleDistributionMap (int level, const DistributionMapping& new_dm) = 0;
+    virtual void SetParticleGeometry (int level, const Geometry& new_geom) = 0;
 
     virtual void ClearParticleBoxArray (int level) = 0;
     virtual void ClearParticleDistributionMap (int level) = 0;
+    virtual void ClearParticleGeometry (int level) = 0;
 
     virtual bool LevelDefined (int level) const = 0;
     virtual int finestLevel () const = 0;
@@ -59,6 +62,7 @@ public:
 
     virtual ~ParGDB () {;}
 
+    virtual const Geometry& ParticleGeom (int level) const override;
     virtual const Geometry& Geom (int level) const override;
     virtual const DistributionMapping& ParticleDistributionMap
                                              (int level) const override;
@@ -69,9 +73,11 @@ public:
 
     virtual void SetParticleBoxArray (int level, const BoxArray& new_ba) override;
     virtual void SetParticleDistributionMap (int level,	const DistributionMapping& new_dm) override;
+    virtual void SetParticleGeometry (int level, const Geometry& new_geom) override;
 
     virtual void ClearParticleBoxArray (int level) override;
     virtual void ClearParticleDistributionMap (int level) override;
+    virtual void ClearParticleGeometry (int level) override;
 
     virtual bool LevelDefined (int level) const override;
     virtual int finestLevel () const override;
@@ -86,7 +92,7 @@ protected:
     Vector<DistributionMapping> m_dmap;
     Vector<BoxArray>            m_ba;
     Vector<int>                 m_rr;
-    int                        m_nlevels;
+    int                         m_nlevels;
 
 };
 
@@ -125,6 +131,13 @@ ParGDB::ParGDB (const Vector<Geometry>            & geom,
 inline
 const Geometry&
 ParGDB::Geom (int level) const
+{
+    return m_geom[level];
+}
+
+inline
+const Geometry&
+ParGDB::ParticleGeom (int level) const
 {
     return m_geom[level];
 }
@@ -175,6 +188,14 @@ ParGDB::SetParticleDistributionMap (int level, const DistributionMapping& new_dm
 
 inline
 void
+ParGDB::SetParticleGeometry (int level, const Geometry& new_geom)
+{
+    AMREX_ASSERT(level < m_nlevels);
+    m_geom[level] = new_geom;
+}
+
+inline
+void
 ParGDB::ClearParticleBoxArray (int level)
 {
     AMREX_ASSERT(level < m_nlevels);
@@ -187,6 +208,14 @@ ParGDB::ClearParticleDistributionMap (int level)
 {
     AMREX_ASSERT(level < m_nlevels);
     m_dmap[level] = DistributionMapping();
+}
+
+inline
+void
+ParGDB::ClearParticleGeometry (int level)
+{
+    AMREX_ASSERT(level < m_nlevels);
+    m_geom[level] = Geometry();
 }
 
 inline

--- a/Src/Particle/AMReX_Particles.H
+++ b/Src/Particle/AMReX_Particles.H
@@ -387,6 +387,16 @@ public:
     void SetParticleDistributionMap (int lev, const DistributionMapping& new_dmap)
 	{ m_gdb->SetParticleDistributionMap(lev, new_dmap); }
 
+    //! \brief Set the particle Geometry. If the container was previously set to
+    //! to track the AMR hierarchy of an AmrCore or AmrLevel object, that correspondence
+    //! will be broken here.
+    //!
+    //! \param lev The level on which to set the Geometry.
+    //! \param new_geom The new Geometry to use.
+    //!
+    void SetParticleGeometry (int lev, const Geometry& new_geom)
+	{ m_gdb->SetParticleGeometry(lev, new_geom); }
+
     //! \brief Get the BoxArray for a given level
     //!
     //! \param lev The level.
@@ -407,24 +417,30 @@ public:
     //!
     const Geometry& Geom (int lev) const { return m_gdb->Geom(lev); }
 
+    //! \brief Get the particle Geometry for a given level
+    //!
+    //! \param lev The level.
+    //!
+    const Geometry& ParticleGeom (int lev) const { return m_gdb->ParticleGeom(lev); }
+
     //! \brief the finest level actually defined for the ParticleContainer
     int finestLevel () const { return m_gdb->finestLevel(); }
 
     //! \brief the finest allowed level in the ParticleContainer, whether it is defined or not.
     int maxLevel ()    const { return m_gdb->maxLevel(); }
 
-    //! \brief the number of defined levels in the ParticleContainer    
+    //! \brief the number of defined levels in the ParticleContainer
     int numLevels()    const { return finestLevel() + 1; }
 
-    //! \brief The total number of tiles on this rank on this level     
+    //! \brief The total number of tiles on this rank on this level
     int numLocalTilesAtLevel (int lev) const { return m_particles[lev].size(); }
 
-    //! \brief Get the ParGDB object used to define this container (const version)    
+    //! \brief Get the ParGDB object used to define this container (const version)
     const ParGDBBase* GetParGDB () const { return m_gdb; }
 
     //! \brief Get the ParGDB object used to define this container
           ParGDBBase* GetParGDB ()       { return m_gdb; }
-    
+
     void reserveData ();
     void resizeData ();
 


### PR DESCRIPTION
The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
