### PR TITLE
volume multifab must be defined before calling GetVolume(volume)

### DIFF
--- a/Src/LinearSolvers/Projections/AMReX_NodalProjector.cpp
+++ b/Src/LinearSolvers/Projections/AMReX_NodalProjector.cpp
@@ -478,7 +478,7 @@ NodalProjector::averageDown (const amrex::Vector<amrex::MultiFab*> a_var)
 #ifdef AMREX_USE_EB
         const auto ebf = dynamic_cast<EBFArrayBoxFactory const&>(a_var[lev+1]->Factory());
 
-        amrex::MultiFab volume;
+        amrex::MultiFab volume(a_var[lev+1]->boxArray(),a_var[lev+1]->DistributionMap(),1,0);
         m_geom[lev+1].GetVolume(volume);
 
         EB_average_down(*a_var[lev+1], *a_var[lev], volume, ebf.getVolFrac(),


### PR DESCRIPTION
## Summary

## Additional background

## Checklist

The proposed changes:
- [x ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
