### PR TITLE
Fix when small_volfrac is used -- we need to adjust the data in cut c…

### DIFF
--- a/Src/EB/AMReX_EB2_2D_C.cpp
+++ b/Src/EB/AMReX_EB2_2D_C.cpp
@@ -341,12 +341,12 @@ void build_cells (Box const& bx, Array4<EBCellFlag> const& cell,
             if (vfrac(i-1,j,0) < small_volfrac or vfrac(i,j,0) < small_volfrac) {
                 fx(i,j,0) = Type::covered;
                 apx(i,j,0) = 0.0;
-                if (cell(i,j,0).isRegular())
+                if (not cell(i,j,0).isCovered())
                 {
                     cell(i,j,0).setSingleValued();
                     set_eb_data(i,j,apx,apy,vfrac,vcent,barea,bcent,bnorm);
                 }
-                if (cell(i-1,j,0).isRegular())
+                if (not cell(i-1,j,0).isCovered())
                 {
                     cell(i-1,j,0).setSingleValued();
                     set_eb_data(i-1,j,apx,apy,vfrac,vcent,barea,bcent,bnorm);
@@ -362,12 +362,12 @@ void build_cells (Box const& bx, Array4<EBCellFlag> const& cell,
             if (vfrac(i,j-1,0) < small_volfrac or vfrac(i,j,0) < small_volfrac) {
                 fy(i,j,0) = Type::covered;
                 apy(i,j,0) = 0.0;
-                if (cell(i,j,0).isRegular())
+                if (not cell(i,j,0).isCovered())
                 {
                     cell(i,j,0).setSingleValued();
                     set_eb_data(i,j,apx,apy,vfrac,vcent,barea,bcent,bnorm);
                 }
-                if (cell(i,j-1,0).isRegular())
+                if (not cell(i,j-1,0).isCovered())
                 {
                     cell(i,j-1,0).setSingleValued();
                     set_eb_data(i,j-1,apx,apy,vfrac,vcent,barea,bcent,bnorm);

--- a/Src/EB/AMReX_EB2_3D_C.cpp
+++ b/Src/EB/AMReX_EB2_3D_C.cpp
@@ -764,14 +764,14 @@ void build_cells (Box const& bx, Array4<EBCellFlag> const& cell,
             if (vfrac(i-1,j,k) < small_volfrac or vfrac(i,j,k) < small_volfrac) {
                 fx(i,j,k) = Type::covered;
                 apx(i,j,k) = 0.0;
-                if (cell(i  ,j,k).isRegular())
+                if (not cell(i  ,j,k).isCovered())
                 {
                     cell(i  ,j,k).setSingleValued();
                     set_eb_data(i,j,k,apx,apy,apz,
                                 fcx,fcy,fcz,m2x,m2y,m2z,vfrac,vcent,
                                 barea,bcent,bnorm);
                 }
-                if (cell(i-1,j,k).isRegular())
+                if (not cell(i-1,j,k).isCovered())
                 {
                     cell(i-1,j,k).setSingleValued();
                     set_eb_data(i-1,j,k,apx,apy,apz,
@@ -790,14 +790,14 @@ void build_cells (Box const& bx, Array4<EBCellFlag> const& cell,
             if (vfrac(i,j-1,k) < small_volfrac or vfrac(i,j,k) < small_volfrac) {
                 fy(i,j,k) = Type::covered;
                 apy(i,j,k) = 0.0;
-                if (cell(i,j  ,k).isRegular())
+                if (not cell(i,j  ,k).isCovered())
                 {
                     cell(i,j  ,k).setSingleValued();
                     set_eb_data(i,j,k,apx,apy,apz,
                                 fcx,fcy,fcz,m2x,m2y,m2z,vfrac,vcent,
                                 barea,bcent,bnorm);
                 }
-                if (cell(i,j-1,k).isRegular())
+                if (not cell(i,j-1,k).isCovered())
                 {
                     cell(i,j-1,k).setSingleValued();
                     set_eb_data(i,j-1,k,apx,apy,apz,
@@ -817,14 +817,14 @@ void build_cells (Box const& bx, Array4<EBCellFlag> const& cell,
                 fz(i,j,k) = Type::covered;
                 apz(i,j,k) = 0.0;
 
-                if (cell(i,j,k  ).isRegular())
+                if (not cell(i,j,k  ).isCovered())
                 {
                     cell(i,j,k  ).setSingleValued();
                     set_eb_data(i,j,k,apx,apy,apz,
                                 fcx,fcy,fcz,m2x,m2y,m2z,vfrac,vcent,
                                 barea,bcent,bnorm);
                 }
-                if (cell(i,j,k-1).isRegular())
+                if (not cell(i,j,k-1).isCovered())
                 {
                     cell(i,j,k-1).setSingleValued();
                     set_eb_data(i,j,k-1,apx,apy,apz,


### PR DESCRIPTION
Fix when small_volfrac is used -- we need to adjust the data in cut cell neighbors as well as regular neighbors

This addresses  issue #1450

## Summary

## Additional background

## Checklist

The proposed changes:
- [X] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
