### PR TITLE
change char * to char const* so SWFFT code compiles with USE_CUDA=TRUE

### DIFF
--- a/Src/Extern/SWFFT/distribution.c
+++ b/Src/Extern/SWFFT/distribution.c
@@ -77,7 +77,7 @@ enum {
 #define DEBUG_CONDITION false
 
 // return comma or period depending on position in a list
-static inline char *separator(int i, int n)
+static inline char const *separator(int i, int n)
 {
   return i == (n - 1) ? "." : ", ";
 }


### PR DESCRIPTION
## Summary
change char * to char const* so SWFFT code compiles with USE_CUDA=TRUE

## Checklist
The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
