### PR TITLE
Fix potential out of bounds access in #1441

### DIFF
--- a/Src/AmrCore/AMReX_ErrorList.H
+++ b/Src/AmrCore/AMReX_ErrorList.H
@@ -428,7 +428,7 @@ std::ostream& operator << (std::ostream& os, const ErrorList& elst);
       : m_test(test), m_field(field), m_info(info)
       {
           m_value.resize(info.m_max_level);
-          for (int i = 0; i < info.m_max_level; ++i) {
+          for (int i = 0; i < m_value.size(); ++i) {
               m_value[i] = value;
           }
           m_ngrow = SetNGrow();
@@ -442,7 +442,7 @@ std::ostream& operator << (std::ostream& os, const ErrorList& elst);
       {
           AMREX_ASSERT(value.size() > 0);
           m_value.resize(info.m_max_level);
-          for (int i = 0; i < value.size(); ++i) {
+          for (int i = 0; i < m_value.size(); ++i) {
               m_value[i] = value[i];
           }
           // If the user didn't provided a value for every level,


### PR DESCRIPTION
## Summary

The user may have given us a vector that has too many values, so we just ignore the remainder.

## Additional background

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
