### PR TITLE
DPCPP: Scan

### DIFF
--- a/Src/Base/AMReX_Scan.H
+++ b/Src/Base/AMReX_Scan.H
@@ -229,7 +229,7 @@ T PrefixSum (int n, FIN && fin, FOUT && fout, Type type)
         if (gridDimx > 1) {
             int& virtual_block_id_shared = *((int*)(shared2+nwarps));
             if (threadIdxx == 0) {
-                unsigned int bid = Gpu::Atomic::Inc<sycl::access::address_space::local_space>
+                unsigned int bid = Gpu::Atomic::Inc<sycl::access::address_space::global_space>
                     (virtual_block_id_p, gridDimx);
                 virtual_block_id_shared = bid;
             }


### PR DESCRIPTION
## Summary
Need to use global address space when doing atomic inc on virtual block id.

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
