### PR TITLE
CMake: FindPETSc must not overwrite CMAKE_Fortran_FLAGS

### DIFF
--- a/Tools/CMake/FindPETSc.cmake
+++ b/Tools/CMake/FindPETSc.cmake
@@ -36,9 +36,6 @@ message(STATUS "arch ${PETSC_INCLUDE_DIRS_ARCH}")
 set(PETSC_INCLUDE_DIRS ${PETSC_INCLUDE_DIRS_BASE} ${PETSC_INCLUDE_DIRS_ARCH})
 message(STATUS "joe ${PETSC_INCLUDE_DIRS}")
 
-#Set Fortran include directories TODO: currently overwrites any given values
-set(CMAKE_Fortran_FLAGS ${PETSC_INCLUDE_DIRS})
-
 # Find libraries
 find_library(PETSC_LIBRARIES PATHS ${PETSC_DIR}/${PETSC_ARCH}/lib NAMES petsc)
 


### PR DESCRIPTION
## Summary

FindPETSc used to set ```CMAKE_Fortran_FLAGS``` to the list of PETSc include directories. This caused problems with the compilation of Fortran files (see Issue #1463 ). This PR fixes this. 

## Additional background

## Checklist

The proposed changes:
- [X] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
