### PR TITLE
Gpu::Atomic::AddNoRet

### DIFF
--- a/Src/Base/AMReX_FBI.H
+++ b/Src/Base/AMReX_FBI.H
@@ -203,7 +203,7 @@ struct CellAtomicAdd
     AMREX_GPU_DEVICE AMREX_FORCE_INLINE void
     operator() (U* d, U s) const noexcept
     {
-        Gpu::Atomic::Add(d,s);
+        Gpu::Atomic::AddNoRet(d,s);
     }
 };
 

--- a/Src/Base/AMReX_GpuAtomic.H
+++ b/Src/Base/AMReX_GpuAtomic.H
@@ -127,6 +127,33 @@ namespace detail {
     }
 
 ////////////////////////////////////////////////////////////////////////
+//  AddNoRet
+////////////////////////////////////////////////////////////////////////
+
+    template<class T>
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    void AddNoRet (T* const sum, T const value) noexcept
+    {
+#if AMREX_DEVICE_COMPILE
+        Add_device(sum, value);
+#else
+        *sum += value;
+#endif
+    }
+
+#if defined(AMREX_USE_HIP)
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    void AddNoRet (float* const sum, float const value) noexcept
+    {
+#if AMREX_DEVICE_COMPILE
+        atomicAddNoRet(sum, value);
+#else
+        *sum += value;
+#endif
+    }
+#endif
+
+////////////////////////////////////////////////////////////////////////
 //  Min
 ////////////////////////////////////////////////////////////////////////
 
@@ -403,7 +430,7 @@ namespace HostDevice { namespace Atomic {
     void Add (T* const sum, T const value) noexcept
     {
 #if AMREX_DEVICE_COMPILE
-        Gpu::Atomic::Add(sum,value);
+        Gpu::Atomic::AddNoRet(sum,value);
 #else
 #ifdef _OPENMP
 #pragma omp atomic update

--- a/Src/Base/AMReX_GpuReduce.H
+++ b/Src/Base/AMReX_GpuReduce.H
@@ -72,7 +72,7 @@ void deviceReduceSum (T * dest, T source, Gpu::Handler const& h) noexcept
 {
     source = Gpu::blockReduce<Gpu::Device::warp_size>
         (source, Gpu::warpReduce<Gpu::Device::warp_size,T,amrex::Plus<T> >(), (T)0, h);
-    if (h.item.get_local_id(0) == 0) Gpu::Atomic::Add(dest, source);
+    if (h.item.get_local_id(0) == 0) Gpu::Atomic::AddNoRet(dest, source);
 }
 
 template <typename T>
@@ -153,7 +153,7 @@ void deviceReduceSum (T * dest, T source) noexcept
 {
     source = Gpu::blockReduce<Gpu::Device::warp_size>
         (source, Gpu::warpReduce<Gpu::Device::warp_size,T,amrex::Plus<T> >(), (T)0);
-    if (threadIdx.x == 0) Gpu::Atomic::Add(dest, source);
+    if (threadIdx.x == 0) Gpu::Atomic::AddNoRet(dest, source);
 }
 
 template <typename T>

--- a/Src/Base/AMReX_MultiFab.cpp
+++ b/Src/Base/AMReX_MultiFab.cpp
@@ -1267,7 +1267,7 @@ MultiFab::OverlapMask (const Periodicity& period) const
     [=] AMREX_GPU_DEVICE (int i, int j, int k, int n, Array4<Real> const& a) noexcept
     {
         Real* p = a.ptr(i,j,k,n);
-        Gpu::Atomic::Add(p, Real(1.0));
+        Gpu::Atomic::AddNoRet(p, Real(1.0));
     });
 #endif
 

--- a/Src/Base/AMReX_TypeTraits.H
+++ b/Src/Base/AMReX_TypeTraits.H
@@ -50,8 +50,8 @@ namespace amrex
 
     template <class T, class Enable = void>
     struct HasAtomicAdd : std::false_type {};
-    // CUDA supports atomicAdd for the following types
     template <> struct HasAtomicAdd<int> : std::true_type {};
+    template <> struct HasAtomicAdd<long> : std::true_type {};
     template <> struct HasAtomicAdd<unsigned int> : std::true_type {};
     template <> struct HasAtomicAdd<unsigned long long> : std::true_type {};
     template <> struct HasAtomicAdd<float> : std::true_type {};

--- a/Src/EB/AMReX_EB_utils.cpp
+++ b/Src/EB/AMReX_EB_utils.cpp
@@ -159,7 +159,7 @@ namespace amrex {
                             (flags(i,j,k).isConnected(ii,jj,kk)) and
                             bx.contains(IntVect(AMREX_D_DECL(i+ii,j+jj,k+kk))) )
                         {
-                            Gpu::Atomic::Add(&optmp(i+ii,j+jj,k+kk,n),
+                            Gpu::Atomic::AddNoRet(&optmp(i+ii,j+jj,k+kk,n),
                                              delm(i,j,k,n) * wtot * mask(i+ii,j+jj,k+kk) * wt(i+ii,j+jj,k+kk));
                         }
                 }}}

--- a/Src/Particle/AMReX_DenseBins.H
+++ b/Src/Particle/AMReX_DenseBins.H
@@ -104,7 +104,7 @@ public:
             index_type uiy = amrex::min(ny-1,amrex::max(0,iv3.y));
             index_type uiz = amrex::min(nz-1,amrex::max(0,iv3.z));
             pcell[i] = (uix * ny + uiy) * nz + uiz;
-            Gpu::Atomic::Add(&pcount[pcell[i]], index_type{ 1 });
+            Gpu::Atomic::AddNoRet(&pcount[pcell[i]], index_type{ 1 });
         });
 
         Gpu::exclusive_scan(m_counts.begin(), m_counts.end(), m_offsets.begin());
@@ -143,7 +143,7 @@ public:
         amrex::ParallelFor(nitems, [=] AMREX_GPU_DEVICE (int i) noexcept
         {
             pcell[i] = f(v[i]);
-            Gpu::Atomic::Add(&pcount[pcell[i]], index_type{ 1 });
+            Gpu::Atomic::AddNoRet(&pcount[pcell[i]], index_type{ 1 });
         });
 
         Gpu::exclusive_scan(m_counts.begin(), m_counts.end(), m_offsets.begin());

--- a/Src/Particle/AMReX_Particle_mod_K.H
+++ b/Src/Particle/AMReX_Particle_mod_K.H
@@ -24,12 +24,12 @@ void amrex_deposit_cic (P const& p, int nc, amrex::Array4<amrex::Real> const& rh
     amrex::Real sx[2] = {Real(1.0) - xint, xint};
     
     for (int ii = 0; ii <= 1; ++ii) { 
-        amrex::Gpu::Atomic::Add(&rho(i+ii-1, 0, 0, 0), static_cast<Real>(sx[ii]*p.rdata(0)));
+        amrex::Gpu::Atomic::AddNoRet(&rho(i+ii-1, 0, 0, 0), static_cast<Real>(sx[ii]*p.rdata(0)));
     }
     
     for (int comp=1; comp < nc; ++comp) {
         for (int ii = 0; ii <= 1; ++ii) { 
-            amrex::Gpu::Atomic::Add(&rho(i+ii-1, 0, 0, comp), 
+            amrex::Gpu::Atomic::AddNoRet(&rho(i+ii-1, 0, 0, comp), 
                                     static_cast<Real>(sx[ii]*p.rdata(0)*p.rdata(comp)));
         }
     }
@@ -48,7 +48,7 @@ void amrex_deposit_cic (P const& p, int nc, amrex::Array4<amrex::Real> const& rh
 
     for (int jj = 0; jj <= 1; ++jj) { 
         for (int ii = 0; ii <= 1; ++ii) { 
-            amrex::Gpu::Atomic::Add(&rho(i+ii-1, j+jj-1, 0, 0),
+            amrex::Gpu::Atomic::AddNoRet(&rho(i+ii-1, j+jj-1, 0, 0),
                                     static_cast<Real>(sx[ii]*sy[jj]*p.rdata(0)));
         }
     }
@@ -56,7 +56,7 @@ void amrex_deposit_cic (P const& p, int nc, amrex::Array4<amrex::Real> const& rh
     for (int comp=1; comp < nc; ++comp) {
         for (int jj = 0; jj <= 1; ++jj) { 
             for (int ii = 0; ii <= 1; ++ii) {                 
-                amrex::Gpu::Atomic::Add(&rho(i+ii-1, j+jj-1, 0, comp),
+                amrex::Gpu::Atomic::AddNoRet(&rho(i+ii-1, j+jj-1, 0, comp),
                                         static_cast<Real>(sx[ii]*sy[jj]*p.rdata(0)*p.rdata(comp)));
             }
         }
@@ -82,7 +82,7 @@ void amrex_deposit_cic (P const& p, int nc, amrex::Array4<amrex::Real> const& rh
     for (int kk = 0; kk <= 1; ++kk) { 
         for (int jj = 0; jj <= 1; ++jj) { 
             for (int ii = 0; ii <= 1; ++ii) {
-                amrex::Gpu::Atomic::Add(&rho(i+ii-1, j+jj-1, k+kk-1, 0),
+                amrex::Gpu::Atomic::AddNoRet(&rho(i+ii-1, j+jj-1, k+kk-1, 0),
                                         static_cast<Real>(sx[ii]*sy[jj]*sz[kk]*p.rdata(0)));
             }
         }
@@ -92,7 +92,7 @@ void amrex_deposit_cic (P const& p, int nc, amrex::Array4<amrex::Real> const& rh
         for (int kk = 0; kk <= 1; ++kk) { 
             for (int jj = 0; jj <= 1; ++jj) { 
                 for (int ii = 0; ii <= 1; ++ii) {
-                    amrex::Gpu::Atomic::Add(&rho(i+ii-1, j+jj-1, k+kk-1, comp),
+                    amrex::Gpu::Atomic::AddNoRet(&rho(i+ii-1, j+jj-1, k+kk-1, comp),
                                             static_cast<Real>(sx[ii]*sy[jj]*sz[kk]*p.rdata(0)*p.rdata(comp)));
                 }
             }
@@ -125,7 +125,7 @@ void amrex_deposit_particle_dx_cic (P const& p, int nc, amrex::Array4<amrex::Rea
         if (i < rho.begin.x || i >= rho.end.x) continue;
         amrex::Real wx = amrex::min(hx - i, amrex::Real(1.0)) - amrex::max(lx - i, amrex::Real(0.0));
         amrex::Real weight = wx*factor;                
-        amrex::Gpu::Atomic::Add(&rho(i, 0, 0, 0), static_cast<Real>(weight*p.rdata(0)));
+        amrex::Gpu::Atomic::AddNoRet(&rho(i, 0, 0, 0), static_cast<Real>(weight*p.rdata(0)));
     }
 
     for (int comp = 1; comp < nc; ++comp)
@@ -134,7 +134,7 @@ void amrex_deposit_particle_dx_cic (P const& p, int nc, amrex::Array4<amrex::Rea
             if (i < rho.begin.x || i >= rho.end.x) continue;
             amrex::Real wx = amrex::min(hx - i, amrex::Real(1.0)) - amrex::max(lx - i, amrex::Real(0.0));            
             amrex::Real weight = wx*factor;
-            amrex::Gpu::Atomic::Add(&rho(i, 0, 0, comp), static_cast<Real>(weight*p.rdata(0)*p.rdata(comp)));
+            amrex::Gpu::Atomic::AddNoRet(&rho(i, 0, 0, comp), static_cast<Real>(weight*p.rdata(0)*p.rdata(comp)));
         }
     }
 
@@ -160,7 +160,7 @@ void amrex_deposit_particle_dx_cic (P const& p, int nc, amrex::Array4<amrex::Rea
             if (i < rho.begin.x || i >= rho.end.x) continue;
             amrex::Real wx = amrex::min(hx - i, amrex::Real(1.0)) - amrex::max(lx - i, amrex::Real(0.0));
             amrex::Real weight = wx*wy*factor;
-            amrex::Gpu::Atomic::Add(&rho(i, j, 0, 0), static_cast<Real>(weight*p.rdata(0)));
+            amrex::Gpu::Atomic::AddNoRet(&rho(i, j, 0, 0), static_cast<Real>(weight*p.rdata(0)));
         }
     }
 
@@ -172,7 +172,7 @@ void amrex_deposit_particle_dx_cic (P const& p, int nc, amrex::Array4<amrex::Rea
                 if (i < rho.begin.x || i >= rho.end.x) continue;
                 amrex::Real wx = amrex::min(hx - i, amrex::Real(1.0)) - amrex::max(lx - i, amrex::Real(0.0));
                 amrex::Real weight = wx*wy*factor;
-                amrex::Gpu::Atomic::Add(&rho(i, j, 0, comp), static_cast<Real>(weight*p.rdata(0)*p.rdata(comp)));
+                amrex::Gpu::Atomic::AddNoRet(&rho(i, j, 0, comp), static_cast<Real>(weight*p.rdata(0)*p.rdata(comp)));
             }
         }
     }
@@ -206,7 +206,7 @@ void amrex_deposit_particle_dx_cic (P const& p, int nc, amrex::Array4<amrex::Rea
                 if (i < rho.begin.x || i >= rho.end.x) continue;
                 amrex::Real wx = amrex::min(hx - i, amrex::Real(1.0)) - amrex::max(lx - i, amrex::Real(0.0));
                 amrex::Real weight = wx*wy*wz*factor;
-                amrex::Gpu::Atomic::Add(&rho(i, j, k, 0), static_cast<Real>(weight*p.rdata(0)));
+                amrex::Gpu::Atomic::AddNoRet(&rho(i, j, k, 0), static_cast<Real>(weight*p.rdata(0)));
             }
         }
     }
@@ -222,7 +222,7 @@ void amrex_deposit_particle_dx_cic (P const& p, int nc, amrex::Array4<amrex::Rea
                     if (i < rho.begin.x || i >= rho.end.x) continue;
                     amrex::Real wx = amrex::min(hx - i, amrex::Real(1.0)) - amrex::max(lx - i, amrex::Real(0.0));
                     amrex::Real weight = wx*wy*wz*factor;
-                    amrex::Gpu::Atomic::Add(&rho(i, j, k, comp), static_cast<Real>(weight*p.rdata(0)*p.rdata(comp)));
+                    amrex::Gpu::Atomic::AddNoRet(&rho(i, j, k, comp), static_cast<Real>(weight*p.rdata(0)*p.rdata(comp)));
                 }
             }
         }

--- a/Tests/Particles/NeighborParticles/MDParticleContainer.cpp
+++ b/Tests/Particles/NeighborParticles/MDParticleContainer.cpp
@@ -236,7 +236,7 @@ void MDParticleContainer::checkNeighborParticles()
         for (int i = 0; i < np; i++)
         {
             ParticleType& p1 = pstruct[i];
-            Gpu::Atomic::Add(&(p_num_per_grid[p1.idata(0)]),1);
+            Gpu::Atomic::AddNoRet(&(p_num_per_grid[p1.idata(0)]),1);
         }
 
         amrex::AllPrintToFile("neighbor_test") << "FOR GRID " << gid << "\n";;
@@ -274,9 +274,9 @@ void MDParticleContainer::checkNeighborParticles()
         {
             ParticleType& p1 = pstruct[i];
 
-            // Gpu::Atomic::Add(p_mine,1);
+            // Gpu::Atomic::AddNoRet(p_mine,1);
 
-            Gpu::Atomic::Add(&(p_num_per_grid[p1.idata(0)]),1);
+            Gpu::Atomic::AddNoRet(&(p_num_per_grid[p1.idata(0)]),1);
         });
 
         Gpu::Device::synchronize();
@@ -359,14 +359,14 @@ void MDParticleContainer::checkNeighborList()
 
 		if (r2 <= cutoff_sq)
 		{
-                   Gpu::Atomic::Add(&(p_full_count[i]),1);
+                   Gpu::Atomic::AddNoRet(&(p_full_count[i]),1);
                    full_nbors.push_back(p2.id());
 		}
             }
 
             for (const auto& p2 : nbor_data.getNeighbors(i))
             {               
-                Gpu::Atomic::Add(&(p_neighbor_count[i]),1);
+                Gpu::Atomic::AddNoRet(&(p_neighbor_count[i]),1);
                 nbor_nbors.push_back(p2.id());
             }
 

--- a/Tests/Particles/ParticleMesh/main.cpp
+++ b/Tests/Particles/ParticleMesh/main.cpp
@@ -89,7 +89,7 @@ void testParticleMesh(TestParams& parms)
           for (int kk = 0; kk <= 1; ++kk) { 
               for (int jj = 0; jj <= 1; ++jj) { 
                   for (int ii = 0; ii <= 1; ++ii) {
-                      amrex::Gpu::Atomic::Add(&rho(i+ii-1, j+jj-1, k+kk-1, 0),
+                      amrex::Gpu::Atomic::AddNoRet(&rho(i+ii-1, j+jj-1, k+kk-1, 0),
                                               sx[ii]*sy[jj]*sz[kk]*p.rdata(0));
                   }
               }
@@ -99,7 +99,7 @@ void testParticleMesh(TestParams& parms)
              for (int kk = 0; kk <= 1; ++kk) { 
                   for (int jj = 0; jj <= 1; ++jj) { 
                       for (int ii = 0; ii <= 1; ++ii) {
-                          amrex::Gpu::Atomic::Add(&rho(i+ii-1, j+jj-1, k+kk-1, comp),
+                          amrex::Gpu::Atomic::AddNoRet(&rho(i+ii-1, j+jj-1, k+kk-1, comp),
                                                   sx[ii]*sy[jj]*sz[kk]*p.rdata(0)*p.rdata(comp));
                       }
                   }

--- a/Tutorials/Particles/ElectromagneticPIC/Exec/CUDA/em_pic_K.H
+++ b/Tutorials/Particles/ElectromagneticPIC/Exec/CUDA/em_pic_K.H
@@ -220,9 +220,9 @@ void deposit_current (amrex::Array4<amrex::Real> const& jx,
     for         (int loff = 0; loff < 2; ++loff) {
         for     (int koff = 0; koff < 2; ++koff) {
             for (int joff = 0; joff < 2; ++joff) {
-                amrex::Gpu::Atomic::Add(&jx(j0+joff,k +koff,l +loff), sx0[joff]*sy [koff]*sz [loff]*wqx);
-                amrex::Gpu::Atomic::Add(&jy(j +joff,k0+koff,l +loff), sx [joff]*sy0[koff]*sz [loff]*wqy);
-                amrex::Gpu::Atomic::Add(&jz(j +joff,k +koff,l0+loff), sx [joff]*sy [koff]*sz0[loff]*wqz);
+                amrex::Gpu::Atomic::AddNoRet(&jx(j0+joff,k +koff,l +loff), sx0[joff]*sy [koff]*sz [loff]*wqx);
+                amrex::Gpu::Atomic::AddNoRet(&jy(j +joff,k0+koff,l +loff), sx [joff]*sy0[koff]*sz [loff]*wqy);
+                amrex::Gpu::Atomic::AddNoRet(&jz(j +joff,k +koff,l0+loff), sx [joff]*sy [koff]*sz0[loff]*wqz);
             }
         }
     }


### PR DESCRIPTION
## Summary
Add Gpu::Atomic::AddNoRet to use HIP's atomicAddNoRet for float, which is
much faster than atomicAdd for float that is currently implemented with CAS.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
