### PR TITLE
Enforce singular solvable

### DIFF
--- a/Src/LinearSolvers/MLMG/AMReX_MLLinOp.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLLinOp.H
@@ -174,7 +174,7 @@ public:
     void setMaxOrder (int o) noexcept { maxorder = o; }
     int getMaxOrder () const noexcept { return maxorder; }
 
-    void setEnforceSingularSolvable (int o) noexcept { enforceSingularSolvable = o; }
+    void setEnforceSingularSolvable (bool o) noexcept { enforceSingularSolvable = o; }
     bool getEnforceSingularSolvable () const noexcept { return enforceSingularSolvable; }
 
     virtual BottomSolver getDefaultBottomSolver () const { return BottomSolver::bicgstab; }

--- a/Src/LinearSolvers/MLMG/AMReX_MLLinOp.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLLinOp.H
@@ -175,7 +175,7 @@ public:
     int getMaxOrder () const noexcept { return maxorder; }
 
     void setEnforceSingularSolvable (int o) noexcept { enforceSingularSolvable = o; }
-    int getEnforceSingularSolvable () const noexcept { return enforceSingularSolvable; }
+    bool getEnforceSingularSolvable () const noexcept { return enforceSingularSolvable; }
 
     virtual BottomSolver getDefaultBottomSolver () const { return BottomSolver::bicgstab; }
     virtual int getNComp () const { return 1; }
@@ -276,7 +276,7 @@ protected:
 
     int maxorder = 3;
 
-    bool enforceSingularSolvable = 1;
+    bool enforceSingularSolvable = true;
 
     int m_num_amr_levels;
     Vector<int> m_amr_ref_ratio;

--- a/Src/LinearSolvers/MLMG/AMReX_MLLinOp.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLLinOp.H
@@ -174,6 +174,9 @@ public:
     void setMaxOrder (int o) noexcept { maxorder = o; }
     int getMaxOrder () const noexcept { return maxorder; }
 
+    void setEnforceSingularSolvable (int o) noexcept { enforceSingularSolvable = o; }
+    int getEnforceSingularSolvable () const noexcept { return enforceSingularSolvable; }
+
     virtual BottomSolver getDefaultBottomSolver () const { return BottomSolver::bicgstab; }
     virtual int getNComp () const { return 1; }
     virtual int getNGrow () const { return 0; }
@@ -272,6 +275,8 @@ protected:
     int verbose = 0;
 
     int maxorder = 3;
+
+    bool enforceSingularSolvable = 1;
 
     int m_num_amr_levels;
     Vector<int> m_amr_ref_ratio;

--- a/Src/LinearSolvers/MLMG/AMReX_MLMG.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLMG.cpp
@@ -247,7 +247,7 @@ void MLMG::oneIter (int iter)
     // coarsest amr level
     {
         // enforce solvability if appropriate
-        if (linop.isSingular(0))
+        if (linop.isSingular(0) && linop.getEnforceSingularSolvable())
         {
             makeSolvable(0,0,res[0][0]);
         }
@@ -929,7 +929,7 @@ MLMG::actualBottomSolve ()
     {
         MultiFab* bottom_b = &b;
         MultiFab raii_b;
-        if (linop.isBottomSingular())
+        if (linop.isBottomSingular() && linop.getEnforceSingularSolvable())
         {
             raii_b.define(b.boxArray(), b.DistributionMap(), ncomp, b.nGrow(),
                           MFInfo(), *linop.Factory(amrlev,mglev));
@@ -1210,7 +1210,7 @@ MLMG::prepareForSolve (const Vector<MultiFab*>& a_sol, const Vector<MultiFab con
     }
     
     // enforce solvability if appropriate
-    if (linop.isSingular(0))
+    if (linop.isSingular(0) && linop.getEnforceSingularSolvable())
     {
         computeVolInv();
         makeSolvable();
@@ -1888,7 +1888,7 @@ MLMG::bottomSolveWithHypre (MultiFab& x, const MultiFab& b)
 
     // For singular problems there may be a large constant added to all values of the solution
     // For precision reasons we enforce that the average of the correction from hypre is 0
-    if (linop.isSingular(amrlev))
+    if (linop.isSingular(amrlev) && linop.getEnforceSingularSolvable())
     {
         makeSolvable(amrlev, mglev, x);
     }


### PR DESCRIPTION
## Summary
 Option to make the code NOT enforce solvability for singular problems.
This is accomplished by calling linop.setEnforceSingularSolvable(false)
The default behavior is true, so no results will change in existing codes

## Additional background

## Checklist

The proposed changes:
- [x] add new capabilities to AMReX
