### PR TITLE
Add fill method to GpuArray

### DIFF
--- a/Src/Base/AMReX_Array.H
+++ b/Src/Base/AMReX_Array.H
@@ -59,6 +59,10 @@ namespace amrex {
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         T* end() noexcept { return arr + N; }
 
+        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        void fill( const T& value ) noexcept
+        { for (std::size_t i = 0; i < N; ++i) arr[i] = value; }
+
         T arr[amrex::max(N,std::size_t{1})];
     };
 }
@@ -180,7 +184,7 @@ namespace amrex
     {
         return {{AMREX_D_DECL(a[0].get(), a[1].get(), a[2].get())}};
     }
-    
+
     template <class T>
     std::array<T const*,AMREX_SPACEDIM> GetArrOfConstPtrs (const std::array<T,AMREX_SPACEDIM>& a) noexcept
     {
@@ -216,4 +220,3 @@ namespace amrex
 }
 
 #endif
-


### PR DESCRIPTION
## Summary

I would like to propose to add a `fill` method to `GpuArray`. This PR implements just that.

## Additional background

I am wondering if it would be better to replace `i < N` with `i < amrex::max(N,std::size_t{1})`, in order to deal with the case `N=0`.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [X] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
