### PR TITLE
Remove compilation Warnings

### DIFF
--- a/Src/EB/AMReX_EB2_IF_Polynomial.H
+++ b/Src/EB/AMReX_EB2_IF_Polynomial.H
@@ -43,8 +43,8 @@ public:
           m_inside(a_inside),
           m_sign( a_inside ? 1.0 : -1.0 ),
           m_size(m_polynomial.size()),
-          m_dp(static_cast<PolyTerm*>(The_Device_Arena()->alloc(sizeof(PolyTerm)*m_size))),
-          m_sp(m_dp,Gpu::Deleter(The_Device_Arena()))
+          m_dp(static_cast<PolyTerm*>(The_Device_Arena()->alloc(sizeof(PolyTerm)*m_size)))
+          //m_sp(m_dp,Gpu::Deleter(The_Device_Arena()))
     {
 #ifdef AMREX_USE_GPU
         Gpu::htod_memcpy(m_dp, m_polynomial.data(), m_size*sizeof(PolyTerm));
@@ -84,7 +84,7 @@ protected:
     Real             m_sign;
     int              m_size;
     PolyTerm*        m_dp;
-    std::shared_ptr<PolyTerm> m_sp;
+    //std::shared_ptr<PolyTerm> m_sp;
 };
 
 }}


### PR DESCRIPTION
## Summary
Class `PolynomialIF` has a member called `m_sp` which is of type `std::shared_ptr<PolyTerm>`, which is not used and causes warnings when compiling with GPU enabled.

## Additional background

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
