### PR TITLE
Including the cell itself in the non-conservative computation

### DIFF
--- a/Src/EB/AMReX_EB_utils.cpp
+++ b/Src/EB/AMReX_EB_utils.cpp
@@ -98,8 +98,7 @@ namespace amrex {
             for (int kk(ks); kk <= ke; ++kk) {
               for (int jj(-1); jj <= 1; ++jj) {
                 for (int ii(-1); ii <= 1; ++ii) {
-		        if( (ii != 0 or jj != 0 or kk != 0) and
-			    flags(i,j,k).isConnected(ii,jj,kk) and
+		        if( flags(i,j,k).isConnected(ii,jj,kk) and
 			    dbox.contains(IntVect(AMREX_D_DECL(i+ii,j+jj,k+kk))))
                         {
 


### PR DESCRIPTION
## Summary
In the eb_redistribution algorithm, the computation of the non-conservative divergence should include the cell itself.

## Additional background

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [x] changes answers in the test suite to more than roundoff level
- [x] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
