### PR TITLE
CMake 3.18+: CUDA Arch Policy (OLD)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,6 +93,12 @@ endif ()
 # Enable CUDA if requested
 #
 if (ENABLE_CUDA)
+    # CMake 3.18+: CMAKE_CUDA_ARCHITECTURES
+    # https://cmake.org/cmake/help/latest/policy/CMP0104.html
+    if(POLICY CMP0104)
+        cmake_policy(SET CMP0104 OLD)
+    endif()
+
     enable_language(CUDA)
     include(AMReX_SetupCUDA)
 endif ()


### PR DESCRIPTION
## Summary

Keep the old policy for now to avoid setting the code generation flags twice and silence a warning.

https://cmake.org/cmake/help/latest/policy/CMP0104.html

We should be able to transition this well, but I need to first find out how device LTO generation flags are handled here, if at all, and how to restore the default-detection of the local GPU architecture, e.g. on Summits head-nodes.

Note: also needs to be set in the a downstream (super-)project early enough when fetching AMReX, e.g.: https://github.com/ECP-WarpX/WarpX/pull/1459

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
