### PR TITLE
Fix warning in FabSet for single precision

### DIFF
--- a/Src/Boundary/AMReX_FabSet.cpp
+++ b/Src/Boundary/AMReX_FabSet.cpp
@@ -181,10 +181,15 @@ FabSet::linComb (Real a, const MultiFab& mfa, int a_comp,
         const Box& bx = mfi.validbox();
         auto afab = bdrya.array(mfi);
         auto bfab = bdryb.array(mfi);
+#ifdef AMREX_USE_FLOAT
+        Real huge = 1.e30f;
+#else
+        Real huge = 1.e200;
+#endif
         AMREX_HOST_DEVICE_PARALLEL_FOR_4D ( bx, ncomp, i, j, k, n,
         {
-            afab(i,j,k,n) = 1.e200;
-            bfab(i,j,k,n) = 1.e200;
+            afab(i,j,k,n) = huge;
+            bfab(i,j,k,n) = huge;
         });
     }
 

--- a/Src/Boundary/AMReX_FabSet.cpp
+++ b/Src/Boundary/AMReX_FabSet.cpp
@@ -182,9 +182,9 @@ FabSet::linComb (Real a, const MultiFab& mfa, int a_comp,
         auto afab = bdrya.array(mfi);
         auto bfab = bdryb.array(mfi);
 #ifdef AMREX_USE_FLOAT
-        Real huge = 1.e30f;
+        const Real huge = 1.e30f;
 #else
-        Real huge = 1.e200;
+        const Real huge = 1.e200;
 #endif
         AMREX_HOST_DEVICE_PARALLEL_FOR_4D ( bx, ncomp, i, j, k, n,
         {


### PR DESCRIPTION
## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
