### PR TITLE
CI: Check More Warnings

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -7,7 +7,7 @@ jobs:
   library:
     name: GNU@7.5 C++17 Release [lib]
     runs-on: ubuntu-latest
-    env: {CXXFLAGS: "-Werror"}
+    env: {CXXFLAGS: "-Werror -Wshadow -Woverloaded-virtual -Wunreachable-code"}
     steps:
     - uses: actions/checkout@v2
     - name: Dependencies
@@ -26,7 +26,7 @@ jobs:
   library_clang:
     name: Clang@6.0 C++14 SP NOMPI Debug [lib]
     runs-on: ubuntu-latest
-    env: {CXXFLAGS: "-Werror"}
+    env: {CXXFLAGS: "-Werror -Wshadow -Woverloaded-virtual -Wextra-semi -Wunreachable-code"}
     steps:
     - uses: actions/checkout@v2
     - name: Dependencies
@@ -54,7 +54,7 @@ jobs:
   tutorials:
     name: GNU@7.5 C++14 [tutorials]
     runs-on: ubuntu-latest
-    env: {CXXFLAGS: "-Werror"}
+    env: {CXXFLAGS: "-Werror -Wshadow -Woverloaded-virtual -Wunreachable-code"}
     steps:
     - uses: actions/checkout@v2
     - name: Dependencies
@@ -74,7 +74,7 @@ jobs:
   tutorials_cxx20:
     name: GNU@10.1 C++20 [tutorials]
     runs-on: ubuntu-latest
-    env: {CXXFLAGS: "-Werror -Wno-error=deprecated-declarations"}
+    env: {CXXFLAGS: "-Werror -Wno-error=deprecated-declarations -Wshadow -Woverloaded-virtual -Wunreachable-code"}
     steps:
     - uses: actions/checkout@v2
     - name: Dependencies
@@ -98,7 +98,7 @@ jobs:
   tutorials-nonmpi:
     name: GNU@7.5 C++14 NOMPI [tutorials]
     runs-on: ubuntu-latest
-    env: {CXXFLAGS: "-Werror"}
+    env: {CXXFLAGS: "-Werror -Wshadow -Woverloaded-virtual -Wunreachable-code"}
     steps:
     - uses: actions/checkout@v2
     - name: Dependencies
@@ -119,7 +119,7 @@ jobs:
   tutorials-nofortran:
     name: GNU@7.5 C++11 w/o Fortran [tutorials]
     runs-on: ubuntu-latest
-    env: {CXXFLAGS: "-Werror"}
+    env: {CXXFLAGS: "-Werror -Wshadow -Woverloaded-virtual -Wunreachable-code"}
     steps:
     - uses: actions/checkout@v2
     - name: Dependencies
@@ -271,7 +271,7 @@ jobs:
   tests:
     name: GNU@7.5 C++14 [tests]
     runs-on: ubuntu-latest
-    env: {CXXFLAGS: "-Werror"}
+    env: {CXXFLAGS: "-Werror -Wshadow -Woverloaded-virtual -Wunreachable-code"}
     steps:
     - uses: actions/checkout@v2
     - name: Dependencies

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -3,7 +3,7 @@ name: macos
 on: [push, pull_request]
 
 env:
-  CXXFLAGS: "-Werror"
+  CXXFLAGS: "-Werror -Wshadow -Woverloaded-virtual -Wextra-semi -Wunreachable-code"
 
 jobs:
   # Build libamrex and all tutorials

--- a/Src/Particle/AMReX_NeighborParticles.H
+++ b/Src/Particle/AMReX_NeighborParticles.H
@@ -417,7 +417,7 @@ protected:
 
     Vector<std::map<std::pair<int, int>, amrex::NeighborList<ParticleType> > > m_neighbor_list;
 
-    bool hasNeighbors() const { return m_has_neighbors; };
+    bool hasNeighbors() const { return m_has_neighbors; }
 
     bool m_has_neighbors = false;
 };

--- a/Tutorials/Basic/PrefixSum_MultiFab/main.cpp
+++ b/Tutorials/Basic/PrefixSum_MultiFab/main.cpp
@@ -117,7 +117,7 @@ void main_main ()
         int reverse;
         Real exclusive_sum;
 
-        GidLo(Long id, int smallend, int reverse_order) : gid(id), lo(smallend), reverse(reverse_order), exclusive_sum(0.0) {};
+        GidLo(Long id, int smallend, int reverse_order) : gid(id), lo(smallend), reverse(reverse_order), exclusive_sum(0.0) {}
 
         // sort grids either increasing (forward) or decreasing (reverse) by their lo index
         bool operator<(const GidLo& other) const

--- a/Tutorials/Particles/CellSortedParticles/cell_sorted_F.H
+++ b/Tutorials/Particles/CellSortedParticles/cell_sorted_F.H
@@ -21,7 +21,7 @@ extern "C"
                         const amrex_real* dt);
     
 #ifdef __cplusplus
-};
+}
 #endif
 
 #endif /*_EM_PIC_F_H_*/

--- a/Tutorials/Particles/ElectromagneticPIC/Exec/OpenMP/em_pic_F.H
+++ b/Tutorials/Particles/ElectromagneticPIC/Exec/OpenMP/em_pic_F.H
@@ -126,7 +126,7 @@ extern "C"
 
 
 #ifdef __cplusplus
-};
+}
 #endif
 
 #endif /*_EM_PIC_F_H_*/

--- a/Tutorials/Particles/ElectrostaticPIC/ElectrostaticParticleContainer.cpp
+++ b/Tutorials/Particles/ElectrostaticPIC/ElectrostaticParticleContainer.cpp
@@ -273,7 +273,7 @@ FieldGather(const VectorMeshData& E,
             }
         }
     }
-};
+}
 
 void 
 ElectrostaticParticleContainer::

--- a/Tutorials/Particles/NeighborList/MDParticleContainer.cpp
+++ b/Tutorials/Particles/NeighborList/MDParticleContainer.cpp
@@ -265,8 +265,6 @@ Real MDParticleContainer::computeStepSize(amrex::Real& cfl)
 {
     BL_PROFILE("MDParticleContainer::computeStepSize");
 
-    using ParticleType = MDParticleContainer::ParticleType;
-
     Real maxVel = amrex::ReduceMax(*this, 0,
     [=] AMREX_GPU_HOST_DEVICE (const ParticleType& p) noexcept -> Real
                               {


### PR DESCRIPTION
## Summary

Checks for more warnings that are likely to uncover nifty bugs: `-Wshadow -Woverloaded-virtual -Wunreachable-code`
Also checks for superfluous `;` with `-Wextra-semi` (only a flag in Clang).

## Additional background

Does not yet add `-Wall -Wextra -Wpedantic` because there are quite a few places where we need to add casts to avoid signed-unsigned-comparisons, etc.

WarpX' CI covers currently:
* GNU: `-Wall -Wextra -Wpedantic -Wshadow -Woverloaded-virtual -Wunreachable-code`
* Clang: `-Wall -Wextra -Wpedantic -Wshadow -Woverloaded-virtual -Wextra-semi -Wunreachable-code`

Even with super-builds, we current include AMReX with `-isystem` and build AMReX with default compiler flags; this enables us to suppress most AMReX build warnings besides the ones that drop-through from macros defined in headers, which atm. are all fixed for the code sections we use.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
