### PR TITLE
Ascent: Use Default Name for Mesh Ghost

### DIFF
--- a/Src/Extern/Conduit/AMReX_Conduit_Blueprint.cpp
+++ b/Src/Extern/Conduit/AMReX_Conduit_Blueprint.cpp
@@ -231,7 +231,7 @@ void AddFabGhostIndicatorField (const FArrayBox& fab,
                                 int ngrow,
                                 Node &res)
 {
-    Node &n_field = res["fields/ghost_indicator"];
+    Node &n_field = res["fields/ascent_ghosts"];
     n_field["association"] = "element";
     n_field["topology"] = "topo";
     n_field["values"].set(DataType::float64(fab.box().numPts()));


### PR DESCRIPTION
## Summary

Use the default name for ghost cells in Ascent. The current name is non-default and causes issues at domain-boundaries during volume rendering (unless one overwrites the `ghost_field_name` keyword in the options).

Thanks to @mclarsen and @cyrush  for debugging and hinting this with me.

## Additional background

Seen with WarpX.

Pre-PR:
![replay_000400(9)](https://user-images.githubusercontent.com/1353258/97613195-9eed1c80-19d5-11eb-9934-cafeffc51458.png)

Post-PR:
![replay_000400(10)](https://user-images.githubusercontent.com/1353258/97614230-eb852780-19d6-11eb-8dcd-4ca4d86d2e21.png)

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
