### PR TITLE
Changes to make hipcc --save-temps work.

### DIFF
--- a/Src/Base/AMReX.H
+++ b/Src/Base/AMReX.H
@@ -98,28 +98,97 @@ namespace amrex
     //! Print out message to cerr and exit via amrex::Abort().
     void Error (const std::string& msg);
 
-    AMREX_GPU_EXTERNAL AMREX_GPU_HOST_DEVICE AMREX_NO_INLINE
-    void Error (const char * msg = 0);
+    void Error_host (const char* msg);
+
+#if defined(AMREX_USE_GPU) && !defined(NDEBUG)
+    AMREX_GPU_EXTERNAL AMREX_GPU_DEVICE AMREX_NO_INLINE
+    void Error_device (const char * msg);
+#endif
+
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    void Error (const char* msg = 0) {
+#if AMREX_DEVICE_COMPILE
+#ifdef NDEBUG
+        amrex::ignore_unused(msg);
+#else
+        Error_device(msg);
+#endif
+#else
+        Error_host(msg);
+#endif
+    }
 
     //! Print out warning message to cerr.
     void Warning (const std::string& msg);
 
-    AMREX_GPU_EXTERNAL AMREX_GPU_HOST_DEVICE AMREX_NO_INLINE
-    void Warning (const char * msg);
+    void Warning_host (const char * msg);
+
+#if defined(AMREX_USE_GPU) && !defined(NDEBUG)
+    AMREX_GPU_EXTERNAL AMREX_GPU_DEVICE AMREX_NO_INLINE
+    void Warning_device (const char * msg);
+#endif
+
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    void Warning (const char * msg) {
+#if AMREX_DEVICE_COMPILE
+#ifdef NDEBUG
+        amrex::ignore_unused(msg);
+#else
+        Warning_device(msg);
+#endif
+#else
+        Warning_host(msg);
+#endif
+    }
 
     //! Print out message to cerr and exit via abort().
     void Abort (const std::string& msg);
 
-    AMREX_GPU_EXTERNAL AMREX_GPU_HOST_DEVICE AMREX_NO_INLINE
-    void Abort (const char * msg = 0);
+    void Abort_host (const char * msg);
+
+#if defined(AMREX_USE_GPU) && !defined(NDEBUG)
+    AMREX_GPU_EXTERNAL AMREX_GPU_DEVICE AMREX_NO_INLINE
+    void Abort_device (const char * msg);
+#endif
+
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    void Abort (const char * msg = 0) {
+#if AMREX_DEVICE_COMPILE
+#ifdef NDEBUG
+        amrex::ignore_unused(msg);
+#else
+        Abort_device(msg);
+#endif
+#else
+        Abort_host(msg);
+#endif
+    }
 
     /**
     * \brief Prints assertion failed messages to cerr and exits
     * via abort().  Intended for use by the BL_ASSERT() macro
     * in <AMReX_BLassert.H>.
     */
-    AMREX_GPU_EXTERNAL AMREX_GPU_HOST_DEVICE AMREX_NO_INLINE
-    void Assert (const char* EX, const char* file, int line, const char* msg = nullptr);
+
+    void Assert_host (const char* EX, const char* file, int line, const char* msg);
+
+#if defined(AMREX_USE_GPU) && !defined(NDEBUG)
+    AMREX_GPU_EXTERNAL AMREX_GPU_DEVICE AMREX_NO_INLINE
+    void Assert_device (const char* EX, const char* file, int line, const char* msg);
+#endif
+
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    void Assert (const char* EX, const char* file, int line, const char* msg = nullptr) {
+#if AMREX_DEVICE_COMPILE
+#ifdef NDEBUG
+        amrex::ignore_unused(EX,file,line,msg);
+#else
+        Assert_device(EX,file,line,msg);
+#endif
+#else
+        Assert_host(EX,file,line,msg);
+#endif
+    }
 
     /**
     * \brief This is used by amrex::Error(), amrex::Abort(), and amrex::Assert()

--- a/Src/Base/AMReX.cpp
+++ b/Src/Base/AMReX.cpp
@@ -148,7 +148,6 @@ amrex::write_to_stderr_without_buffering (const char* str)
     }
 }
 
-#if !AMREX_DEVICE_COMPILE
 namespace {
 void
 write_lib_id(const char* msg)
@@ -163,7 +162,6 @@ write_lib_id(const char* msg)
     }
 }
 }
-#endif
 
 void
 amrex::Error (const std::string& msg)
@@ -183,14 +181,9 @@ amrex::Warning (const std::string& msg)
     Warning(msg.c_str());
 }
 
-AMREX_GPU_HOST_DEVICE
 void
-amrex::Error (const char * msg)
+amrex::Error_host (const char * msg)
 {
-#if AMREX_DEVICE_COMPILE
-    if (msg) AMREX_DEVICE_PRINTF("Error %s\n", msg);
-    AMREX_DEVICE_ASSERT(0);
-#else
     if (system::error_handler) {
         system::error_handler(msg);
     } else if (system::throw_exception) {
@@ -203,31 +196,38 @@ amrex::Error (const char * msg)
 #endif
         ParallelDescriptor::Abort();
     }
-#endif
 }
 
-AMREX_GPU_HOST_DEVICE
+#if defined(AMREX_USE_GPU) && !defined(NDEBUG)
+AMREX_GPU_DEVICE
 void
-amrex::Warning (const char * msg)
+amrex::Error_device (const char * msg)
 {
-#if AMREX_DEVICE_COMPILE
-    if (msg) AMREX_DEVICE_PRINTF("Warning %s\n", msg);
-#else
-    if (msg)
-    {
+    if (msg) AMREX_DEVICE_PRINTF("Error %s\n", msg);
+    AMREX_DEVICE_ASSERT(0);
+}
+#endif
+
+void
+amrex::Warning_host (const char * msg)
+{
+    if (msg) {
 	amrex::Print(Print::AllProcs,amrex::ErrorStream()) << msg << '!' << '\n';
     }
-#endif
 }
 
-AMREX_GPU_HOST_DEVICE
+#if defined(AMREX_USE_GPU) && !defined(NDEBUG)
+AMREX_GPU_DEVICE
 void
-amrex::Abort (const char * msg)
+amrex::Warning_device (const char * msg)
 {
-#if AMREX_DEVICE_COMPILE
-    if (msg) AMREX_DEVICE_PRINTF("Abort %s\n", msg);
-    AMREX_DEVICE_ASSERT(0);
-#else
+    if (msg) AMREX_DEVICE_PRINTF("Warning %s\n", msg);
+}
+#endif
+
+void
+amrex::Abort_host (const char * msg)
+{
     if (system::error_handler) {
         system::error_handler(msg);
     } else if (system::throw_exception) {
@@ -240,23 +240,21 @@ amrex::Abort (const char * msg)
 #endif
        ParallelDescriptor::Abort();
    }
-#endif
 }
 
-AMREX_GPU_HOST_DEVICE
+#if defined(AMREX_USE_GPU) && !defined(NDEBUG)
+AMREX_GPU_DEVICE
 void
-amrex::Assert (const char* EX, const char* file, int line, const char* msg)
+amrex::Abort_device (const char * msg)
 {
-#if AMREX_DEVICE_COMPILE
-    if (msg) {
-        AMREX_DEVICE_PRINTF("Assertion `%s' failed, file \"%s\", line %d, Msg: %s",
-                            EX, file, line, msg);
-    } else {
-        AMREX_DEVICE_PRINTF("Assertion `%s' failed, file \"%s\", line %d",
-                            EX, file, line);
-    }
+    if (msg) AMREX_DEVICE_PRINTF("Abort %s\n", msg);
     AMREX_DEVICE_ASSERT(0);
-#else
+}
+#endif
+
+void
+amrex::Assert_host (const char* EX, const char* file, int line, const char* msg)
+{
     const int N = 512;
 
     char buf[N];
@@ -289,8 +287,23 @@ amrex::Assert (const char* EX, const char* file, int line, const char* msg)
 #endif
        ParallelDescriptor::Abort();
    }
-#endif
 }
+
+#if defined(AMREX_USE_GPU) && !defined(NDEBUG)
+AMREX_GPU_DEVICE
+void
+amrex::Assert_device (const char* EX, const char* file, int line, const char* msg)
+{
+    if (msg) {
+        AMREX_DEVICE_PRINTF("Assertion `%s' failed, file \"%s\", line %d, Msg: %s",
+                            EX, file, line, msg);
+    } else {
+        AMREX_DEVICE_PRINTF("Assertion `%s' failed, file \"%s\", line %d",
+                            EX, file, line);
+    }
+    AMREX_DEVICE_ASSERT(0);
+}
+#endif
 
 namespace
 {

--- a/Tools/GNUMake/Make.defs
+++ b/Tools/GNUMake/Make.defs
@@ -961,6 +961,14 @@ ifeq ($(USE_HIP),TRUE)
     LINKFLAGS = $(HIPCC_FLAGS)
     AMREX_LINKER = hipcc
 
+    ifeq ($(HIP_SAVE_TEMPS),TRUE)
+      # Issue: hipcc does not seem to respect the arg to --save-temps
+      CXXFLAGS += --save-temps=$(objEXETempDir)
+      ifeq ($(DEBUG),TRUE) # --save-temps does not like AMREX_GPU_EXTERNAL
+        CPPFLAGS += -DNDEBUG
+      endif
+    endif
+
 else ifeq ($(USE_CUDA),TRUE)
 
     # Allow the user to specify the location of the CUDA toolkit.


### PR DESCRIPTION
## Summary
It does not like AMREX_GPU_DEVICE_EXTERNAL.

Also changed is the device version of `Error`, `Abort` and `Warning`.  If `NDEBUG` is defined, they do not do anything.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
