### PR TITLE
Change default hypre interface to ij for non-EB

### DIFF
--- a/Src/LinearSolvers/MLMG/AMReX_MLMG.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLMG.H
@@ -212,14 +212,10 @@ private:
 
     //! Hypre
 #ifdef AMREX_USE_HYPRE
-#ifdef AMREX_USE_EB
-    Hypre::Interface hypre_interface = Hypre::Interface::ij;
-#else
-
     // Hypre::Interface hypre_interface = Hypre::Interface::structed;
-    Hypre::Interface hypre_interface = Hypre::Interface::semi_structed;
-    // Hypre::Interface hypre_interface = Hypre::Interface::ij;
-#endif
+    // Hypre::Interface hypre_interface = Hypre::Interface::semi_structed;
+    Hypre::Interface hypre_interface = Hypre::Interface::ij;
+
     std::unique_ptr<Hypre> hypre_solver;
     std::unique_ptr<MLMGBndry> hypre_bndry;
     std::unique_ptr<HypreNodeLap> hypre_node_solver;


### PR DESCRIPTION
## Additional background
The ij interface has more options to use hypre's various solvers.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
