### PR TITLE
Update GNU make for Cori GPU node

### DIFF
--- a/Tools/GNUMake/Make.machines
+++ b/Tools/GNUMake/Make.machines
@@ -17,14 +17,16 @@ host_name_short := $(shell hostname -s)
 
 # MACHINES supported
 
+ifdef NERSC_HOST
 ifeq ($(findstring cgpu, $(host_name)), cgpu)
   which_site := nersc
   which_computer := cgpu
-else ifdef NERSC_HOST
-  ifeq ($(NERSC_HOST), cori)
-    which_site := nersc
-    which_computer := cori
-  endif
+else
+ifeq ($(NERSC_HOST), cori)
+  which_site := nersc
+  which_computer := cori
+endif
+endif
 endif
 
 ifeq ($(findstring summit, $(host_name)), summit)

--- a/Tools/GNUMake/sites/Make.nersc
+++ b/Tools/GNUMake/sites/Make.nersc
@@ -71,7 +71,11 @@ ifeq ($(which_computer),$(filter $(which_computer),cgpu))
         COMPILE_CUDA_PATH := $(CUDA_HOME)
     endif
 
-    CUDA_ARCH = 70
+    ifeq ($(findstring :dgx, $(LOADEDMODULES)), :dgx)
+      CUDA_ARCH = 80
+    else
+      CUDA_ARCH = 70
+    endif
     GPUS_PER_NODE = 8
     GPUS_PER_SOCKET = 4
   endif


### PR DESCRIPTION
## Summary
Set CUDA_ARCH to 80 for A100 on Cori.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
