### PR TITLE
Use Long type for pindex to avoid potential overflow.

### DIFF
--- a/Src/Particle/AMReX_ParticleContainerI.H
+++ b/Src/Particle/AMReX_ParticleContainerI.H
@@ -1349,7 +1349,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
           ParticleLocData pld;
           if (npart != 0) {
               Long last = npart - 1;
-              unsigned pindex = 0;
+              Long pindex = 0;
               while (pindex <= last) {
                   ParticleType& p = aos[pindex];
 


### PR DESCRIPTION
This has not come up yet, but potentially could now that we allow for a larger range of particles per CPU.

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
