### PR TITLE
Add option for device sync at beginning and end of TinyProfiler region

### DIFF
--- a/Src/Base/AMReX_TinyProfiler.H
+++ b/Src/Base/AMReX_TinyProfiler.H
@@ -88,7 +88,7 @@ private:
     static std::deque<std::tuple<double,double,std::string*> > ttstack;
     static std::map<std::string,std::map<std::string, Stats> > statsmap;
     static double t_init;
-    static int device_synchronize_on_region_end;
+    static int device_synchronize_around_region;
 
     static void PrintStats (std::map<std::string,Stats>& regstats, double dt_max);
 };

--- a/Src/Base/AMReX_TinyProfiler.H
+++ b/Src/Base/AMReX_TinyProfiler.H
@@ -88,6 +88,7 @@ private:
     static std::deque<std::tuple<double,double,std::string*> > ttstack;
     static std::map<std::string,std::map<std::string, Stats> > statsmap;
     static double t_init;
+    static int device_synchronize_on_region_end;
 
     static void PrintStats (std::map<std::string,Stats>& regstats, double dt_max);
 };


### PR DESCRIPTION
## Summary

Now when setting `tiny_profiler.device_synchronize_on_region_end  = 1` in the inputs file, we will synchronize before calling nvtxRangePop() and nvtxRangePush(), which means that TINY_PROFILE regions will include the full kernel time, rather than just the kernel launch time.

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
