### PR TITLE
Support CUDA arch < 6.0

### DIFF
--- a/Src/Base/AMReX_BaseFab.H
+++ b/Src/Base/AMReX_BaseFab.H
@@ -1645,10 +1645,12 @@ BaseFab<T>::prefetchToHost () const noexcept
         // auto& q = Gpu::Device::streamQueue();
         // q.submit([&] (sycl::handler& h) { h.prefetch(this->dptr, s); });
 #elif defined(AMREX_USE_CUDA)
-        std::size_t s = sizeof(T)*this->nvar*this->domain.numPts();
-        AMREX_CUDA_SAFE_CALL(cudaMemPrefetchAsync(this->dptr, s,
-                                                  cudaCpuDeviceId,
-                                                  Gpu::gpuStream()));
+        if (Gpu::Device::devicePropMajor() >= 6) {
+            std::size_t s = sizeof(T)*this->nvar*this->domain.numPts();
+            AMREX_CUDA_SAFE_CALL(cudaMemPrefetchAsync(this->dptr, s,
+                                                      cudaCpuDeviceId,
+                                                      Gpu::gpuStream()));
+        }
 #elif defined(AMREX_USE_HIP)
         // xxxxx HIP FIX HERE after managed memory is supported
 #endif
@@ -1667,10 +1669,12 @@ BaseFab<T>::prefetchToDevice () const noexcept
         auto& q = Gpu::Device::streamQueue();
         q.submit([&] (sycl::handler& h) { h.prefetch(this->dptr, s); });
 #elif defined(AMREX_USE_CUDA)
-        std::size_t s = sizeof(T)*this->nvar*this->domain.numPts();
-        AMREX_CUDA_SAFE_CALL(cudaMemPrefetchAsync(this->dptr, s,
-                                                  Gpu::Device::deviceId(),
-                                                  Gpu::gpuStream()));
+        if (Gpu::Device::devicePropMajor() >= 6) {
+            std::size_t s = sizeof(T)*this->nvar*this->domain.numPts();
+            AMREX_CUDA_SAFE_CALL(cudaMemPrefetchAsync(this->dptr, s,
+                                                      Gpu::Device::deviceId(),
+                                                      Gpu::gpuStream()));
+        }
 #elif defined(AMREX_USE_HIP)
         // xxxxx HIP FIX HERE after managed memory is supported
 #endif

--- a/Src/Base/AMReX_GpuAtomic.H
+++ b/Src/Base/AMReX_GpuAtomic.H
@@ -111,6 +111,16 @@ namespace detail {
 
 #endif
 
+#if defined(AMREX_USE_CUDA) && (__CUDA_ARCH__ < 600)
+
+    AMREX_GPU_DEVICE AMREX_FORCE_INLINE
+    Long Add_device (double* const sum, double const value) noexcept
+    {
+        return detail::atomic_op<double, unsigned long long>(sum, value, amrex::Plus<double>());
+    }
+
+#endif
+
 #endif
 
     template<class T>

--- a/Src/Base/AMReX_GpuDevice.H
+++ b/Src/Base/AMReX_GpuDevice.H
@@ -115,6 +115,11 @@ public:
     static std::string deviceName () noexcept { return std::string(device_prop.name); }
 #endif
 
+#ifdef AMREX_USE_CUDA
+    static int devicePropMajor () noexcept { return device_prop.major; }
+    static int devicePropMinor () noexcept { return device_prop.minor; }
+#endif
+
     static std::size_t freeMemAvailable ();
 
 #ifdef AMREX_USE_GPU

--- a/Src/Base/AMReX_GpuDevice.cpp
+++ b/Src/Base/AMReX_GpuDevice.cpp
@@ -412,7 +412,8 @@ Device::initialize_gpu ()
 #elif defined(AMREX_USE_CUDA)
     AMREX_CUDA_SAFE_CALL(cudaGetDeviceProperties(&device_prop, device_id));
 
-    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(device_prop.major >= 6, "Compute capability must be >= 6");
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(device_prop.major >= 4 || (device_prop.major == 3 && device_prop.minor >= 5),
+                                     "Compute capability must be >= 3.5");
 
     // Prefer L1 cache to shared memory (this has no effect on GPUs with a fixed L1 cache size).
     AMREX_CUDA_SAFE_CALL(cudaDeviceSetCacheConfig(cudaFuncCachePreferL1));

--- a/Tools/CMake/AMReX_SetupCUDA.cmake
+++ b/Tools/CMake/AMReX_SetupCUDA.cmake
@@ -146,18 +146,6 @@ cuda_select_nvcc_arch_flags(_nvcc_arch_flags ${AMReX_CUDA_ARCH})
 #
 string(REPLACE "-gencode;" "-gencode=" _nvcc_arch_flags "${_nvcc_arch_flags}")
 
-foreach (_item IN LISTS _nvcc_arch_flags)
-   # Match one time the regex [0-9]+.
-   # [0-9]+ means any number between 0 and 9 will be matched one or more times (option +)
-   string(REGEX MATCH "[0-9]+" _cuda_compute_capability "${_item}")
-
-   if (_cuda_compute_capability LESS 60)
-      message(STATUS "Ignoring unsupported CUDA architecture ${_cuda_compute_capability}")
-      list(REMOVE_ITEM _nvcc_arch_flags ${_item})
-   endif ()
-
-endforeach ()
-
 if (AMReX_CUDA_LTO)
     # we replace
     #   -gencode=arch=compute_NN,code=sm_NN


### PR DESCRIPTION
## Summary
* Implement atomicAdd for CUDA arch < 6.0.

* Remove the CUDA arch check in CMake.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
