### PR TITLE
DPC++: sync after htod_memcpy on null stream

### DIFF
--- a/Src/Base/AMReX_GpuDevice.H
+++ b/Src/Base/AMReX_GpuDevice.H
@@ -212,6 +212,7 @@ htod_memcpy (void* p_d, const void* p_h, const std::size_t sz) noexcept
     } catch (sycl::exception const& ex) {
         amrex::Abort(std::string("htod_memcpy: ")+ex.what()+"!!!!!");
     }
+    if (Device::onNullStream()) Gpu::synchronize();
 #else
     AMREX_HIP_OR_CUDA(
         AMREX_HIP_SAFE_CALL(hipMemcpy(p_d, p_h, sz, hipMemcpyHostToDevice));,

--- a/Src/Base/AMReX_Reduce.H
+++ b/Src/Base/AMReX_Reduce.H
@@ -192,7 +192,6 @@ namespace detail {
         });
         Array<T,2> tmp{v,v};
         Gpu::htod_memcpy(p, tmp.data(), sizeof(T)*2);
-        Gpu::synchronize();
     }
 #else
     template <typename T>
@@ -549,7 +548,7 @@ std::pair<T,T> MinMax (N n, U const* v, MINOP minop, MAXOP maxop)
     Gpu::LaunchSafeGuard lsg(true);
     Array<T,2> hv{std::numeric_limits<T>::max(), std::numeric_limits<T>::lowest()};
     T* dp = (T*)(The_Device_Arena()->alloc(2*sizeof(T)));
-    Gpu::htod_memcpy(dp, hv.data(), 2*sizeof(T));
+    Gpu::htod_memcpy_async(dp, hv.data(), 2*sizeof(T));
     typedef GpuArray<T,2> Real2;
     amrex::VecReduce(n, Real2{hv[0],hv[1]},
     [=] AMREX_GPU_DEVICE (N i, Real2* r) noexcept


### PR DESCRIPTION
## Summary
DPC++ does not have the concept of null stream.  Adding a sync after
htod_memcpy on the "null" stream will help eliminate potential bugs (e.g.,
htod_memcpy is called before MFIter that uses non-null stream).

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
