### PR TITLE
hypre: Update nodal Laplacian interface to accept custom options

### DIFF
--- a/Src/Extern/HYPRE/AMReX_HypreNodeLap.H
+++ b/Src/Extern/HYPRE/AMReX_HypreNodeLap.H
@@ -23,7 +23,8 @@ public:
     HypreNodeLap (const BoxArray& grids_, const DistributionMapping& dmap_,
                   const Geometry& geom_, const FabFactory<FArrayBox>& factory_,
                   const iMultiFab& owner_mask_, const iMultiFab& dirichlet_mask_,
-                  MPI_Comm comm_, MLNodeLinOp const* linop_, int verbose_);
+                  MPI_Comm comm_, MLNodeLinOp const* linop_, int verbose_,
+                  const std::string& options_namespace_);
     ~HypreNodeLap ();
 
     using Int = HYPRE_Int;

--- a/Src/Extern/HYPRE/AMReX_HypreNodeLap.cpp
+++ b/Src/Extern/HYPRE/AMReX_HypreNodeLap.cpp
@@ -18,10 +18,12 @@ namespace amrex {
 HypreNodeLap::HypreNodeLap (const BoxArray& grids_, const DistributionMapping& dmap_,
                             const Geometry& geom_, const FabFactory<FArrayBox>& factory_,
                             const iMultiFab& owner_mask_, const iMultiFab& dirichlet_mask_,
-                            MPI_Comm comm_, MLNodeLinOp const* linop_, int verbose_)
+                            MPI_Comm comm_, MLNodeLinOp const* linop_, int verbose_,
+                            const std::string& options_namespace_)
     : grids(grids_), dmap(dmap_), geom(geom_), factory(&factory_),
       owner_mask(&owner_mask_), dirichlet_mask(&dirichlet_mask_),
-      comm(comm_), linop(linop_), verbose(verbose_)
+      comm(comm_), linop(linop_), verbose(verbose_),
+      options_namespace(options_namespace_)
 {
     Gpu::LaunchSafeGuard lsg(false); // xxxxx TODO: gpu
 

--- a/Src/LinearSolvers/MLMG/AMReX_MLLinOp.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLLinOp.H
@@ -250,7 +250,10 @@ public:
         amrex::Abort("MLLinOp::makeHypre: How did we get here?");
         return {nullptr};
     }
-    virtual std::unique_ptr<HypreNodeLap> makeHypreNodeLap (int /*bottom_verbose*/) const {
+    virtual std::unique_ptr<HypreNodeLap> makeHypreNodeLap(
+        int /*bottom_verbose*/,
+        const std::string& /* options_namespace */) const
+    {
         amrex::Abort("MLLinOp::makeHypreNodeLap: How did we get here?");
         return {nullptr};
     }

--- a/Src/LinearSolvers/MLMG/AMReX_MLMG.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLMG.cpp
@@ -1880,8 +1880,8 @@ MLMG::bottomSolveWithHypre (MultiFab& x, const MultiFab& b)
     {
         if (hypre_node_solver == nullptr)
         {
-            hypre_node_solver = linop.makeHypreNodeLap(bottom_verbose);
-            hypre_node_solver->setHypreOptionsNamespace(hypre_options_namespace);
+            hypre_node_solver =
+                linop.makeHypreNodeLap(bottom_verbose, hypre_options_namespace);
         }
         hypre_node_solver->solve(x, b, bottom_reltol, bottom_abstol, bottom_maxiter);
     }

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLinOp.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLinOp.H
@@ -96,7 +96,9 @@ public:
     void setOversetMask (int amrlev, const iMultiFab& a_omask);
 
 #ifdef AMREX_USE_HYPRE
-    virtual std::unique_ptr<HypreNodeLap> makeHypreNodeLap (int bottom_verbose) const override;
+    virtual std::unique_ptr<HypreNodeLap> makeHypreNodeLap(
+        int bottom_verbose,
+        const std::string& options_namespace) const override;
 
     virtual void fillIJMatrix (MFIter const& /*mfi*/, Array4<HypreNodeLap::Int const> const& /*nid*/,
                                Array4<int const> const& /*owner*/,

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLinOp.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLinOp.cpp
@@ -379,7 +379,7 @@ MLNodeLinOp::applyBC (int amrlev, int mglev, MultiFab& phi, BCMode/* bc_mode*/, 
 
 #ifdef AMREX_USE_HYPRE
 std::unique_ptr<HypreNodeLap>
-MLNodeLinOp::makeHypreNodeLap (int bottom_verbose) const
+MLNodeLinOp::makeHypreNodeLap (int bottom_verbose, const std::string& options_namespace) const
 {
     const BoxArray& ba = m_grids[0].back();
     const DistributionMapping& dm = m_dmap[0].back();
@@ -391,7 +391,7 @@ MLNodeLinOp::makeHypreNodeLap (int bottom_verbose) const
 
     std::unique_ptr<HypreNodeLap> hypre_solver
         (new amrex::HypreNodeLap(ba, dm, geom, factory, owner_mask, dirichlet_mask,
-                                 comm, this, bottom_verbose));
+                                 comm, this, bottom_verbose, options_namespace));
 
     return hypre_solver;
 }


### PR DESCRIPTION
HypreNodeLap class creates the hypre IJ instance in its constructor. Therefore,
the custom option namespace specified by user must be part of the constructor
arguments.
