### PR TITLE
Change Spelling: Env AMREX_CUDA_ARCH

### DIFF
--- a/Docs/sphinx_documentation/source/GPU.rst
+++ b/Docs/sphinx_documentation/source/GPU.rst
@@ -247,8 +247,9 @@ For example, on Cori GPUs you can specify the architecture as follows:
    cmake [options] -DAMReX_GPU_BACKEND=CUDA -DAMReX_CUDA_ARCH=Volta /path/to/amrex/source
 
 
-If no architecture is specified, CMake will default to the architecture defined in the environmental
-variable ``AMReX_CUDA_ARCH``. If the latter is not defined, CMake will try to determine which GPU
+If no architecture is specified, CMake will default to the architecture defined in the
+*environment variable* ``AMREX_CUDA_ARCH`` (note: all caps).
+If the latter is not defined, CMake will try to determine which GPU
 architecture is supported by the system. If more than one is found, CMake will build for all of them.
 This will generally results in a larger library and longer build times.
 If autodetection fails, a set of "common" architectures is assumed.

--- a/Tools/CMake/AMReX_SetupCUDA.cmake
+++ b/Tools/CMake/AMReX_SetupCUDA.cmake
@@ -54,8 +54,8 @@ endif ()
 message(STATUS "Enabled CUDA options:")
 
 set(AMReX_CUDA_ARCH_DEFAULT "Auto")
-if(DEFINED ENV{AMReX_CUDA_ARCH})
-    set(AMReX_CUDA_ARCH_DEFAULT "$ENV{AMReX_CUDA_ARCH}")
+if(DEFINED ENV{AMREX_CUDA_ARCH})
+    set(AMReX_CUDA_ARCH_DEFAULT "$ENV{AMREX_CUDA_ARCH}")
 endif()
 set(AMReX_CUDA_ARCH ${AMReX_CUDA_ARCH_DEFAULT} CACHE STRING "CUDA architecture (Use 'Auto' for automatic detection)")
 


### PR DESCRIPTION
## Summary

Make the _environment variable_ that sets a default CUDA architecture all-caps, as this is way more common in Unix.

Typical Values: `7.0` or `Volta` (i.e. for V100)

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
