### PR TITLE
Update OLCF makefile

### DIFF
--- a/Tools/GNUMake/Make.machines
+++ b/Tools/GNUMake/Make.machines
@@ -29,24 +29,16 @@ endif
 endif
 endif
 
-ifeq ($(findstring summit, $(host_name)), summit)
-  which_site := olcf
-  which_computer := summit
-endif
+ifdef OLCF_MODULEPATH_ROOT
+  ifeq ($(findstring summit, $(host_name)), summit)
+    which_site := olcf
+    which_computer := summit
+  endif
 
-ifeq ($(findstring summitdev, $(host_name)), summitdev)
-  which_site := olcf
-  which_computer := summitdev
-endif
-
-ifeq ($(findstring ascent, $(host_name)), ascent)
-  which_site := olcf
-  which_computer := ascent
-endif
-
-ifeq ($(findstring peak, $(host_name)), peak)
-  which_site := olcf
-  which_computer := peak
+  ifeq ($(findstring ascent, $(host_name)), ascent)
+    which_site := olcf
+    which_computer := ascent
+  endif
 endif
 
 ifeq ($(findstring sierra, $(host_name)), sierra)

--- a/Tools/GNUMake/sites/Make.olcf
+++ b/Tools/GNUMake/sites/Make.olcf
@@ -2,56 +2,13 @@
 # For Summit et al. at OLCF
 #
 
-OLCF_MACHINES := summitdev summit ascent peak
+OLCF_MACHINES := summit ascent
 
 ifneq ($(which_computer), $(findstring $(which_computer), $(OLCF_MACHINES)))
   $(error Unknown OLCF computer, $(which_computer))
 endif
 
-
-
-ifeq ($(which_computer),$(filter $(which_computer),summitdev))
-
-  ifeq ($(USE_MPI),TRUE)
-
-    CC  := mpicc
-    CXX := mpicxx
-    FC  := mpifort
-    F90 := mpifort
-
-    LIBRARIES += -lmpi_ibm_mpifh -lmpi_ibm
-
-  endif
-
-  ifeq ($(lowercase_comp),gnu)
-    override XTRALIBS := -lgfortran
-  endif
-
-  ifeq ($(lowercase_comp),ibm)
-    override XTRALIBS += -L$(OLCF_XLF_ROOT)/lib -L$(OLCF_XLC_ROOT)/lib
-  endif
-
-  # If the cuda module is loaded, CUDAPATH is set as the toolkit location.
-
-  SYSTEM_CUDA_PATH=$(CUDAPATH)
-
-  SYSTEM_NVML_PATH=/usr/lib64/nvidia
-
-  # Specify that we want to build for Pascal
-
-  CUDA_ARCH = 60
-  COMPILE_CUDA_PATH = $(OLCF_CUDA_ROOT)
-
-  # Provide system configuration information.
-
-  GPUS_PER_NODE=4
-  GPUS_PER_SOCKET=2
-
-endif
-
-
-
-ifeq ($(which_computer),$(filter $(which_computer),summit ascent peak))
+ifeq ($(which_computer),$(filter $(which_computer),summit ascent))
 
   ifeq ($(USE_MPI),TRUE)
 


### PR DESCRIPTION
## Summary

* Remove summitdev and peak.

* Environment variable OLCF_MODULEPATH_ROOT is used in addition to host name
  to detect OLCF machines.

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
