### PR TITLE
Assert no nested MFIters

### DIFF
--- a/Src/Base/AMReX_MFIter.H
+++ b/Src/Base/AMReX_MFIter.H
@@ -227,6 +227,7 @@ protected:
 #endif
 
     static int nextDynamicIndex;
+    static int depth;
 
     void Initialize ();
 };


### PR DESCRIPTION
## Summary
Add assertion to catch nested MFIters (e.g., MultiFab functions are called inside MFIter).

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
