### PR TITLE
Fix multi-component nodal solver tutorial

### DIFF
--- a/Tutorials/LinearSolvers/MultiComponent/MCNodalLinOp.cpp
+++ b/Tutorials/LinearSolvers/MultiComponent/MCNodalLinOp.cpp
@@ -388,13 +388,13 @@ void MCNodalLinOp::restriction (int amrlev, int cmglev, MultiFab& crse, MultiFab
 	}
 
 	MultiFab* pcrse = (need_parallel_copy) ? &cfine : &crse;
+        pcrse->setVal(0.0);
 
 	for (MFIter mfi(*pcrse, amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi)
 	{
 		Box bx = mfi.tilebox();
 		bx = bx & cdomain;
 
-		pcrse->setVal(0.0);
 		amrex::Array4<const amrex::Real> const& fdata = fine.array(mfi);
 		amrex::Array4<amrex::Real> const& cdata       = pcrse->array(mfi);
 


### PR DESCRIPTION
## Summary
`MultiFab::setVal` should not be called inside `MFIter`.

## Additional background
This was caught by #1530.

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
