### PR TITLE
fcompare: Add option for an absolute tolerance check

### DIFF
--- a/Tools/Plotfile/fcompare.cpp
+++ b/Tools/Plotfile/fcompare.cpp
@@ -21,6 +21,7 @@ int main_main()
 
     Real global_error = 0.0;
     Real global_rerror = 0.0;
+    Real abserr_for_global_rerror = 0.0;
     bool any_nans = false;
     ErrZone err_zone;
     bool all_variables_found = true;
@@ -33,6 +34,7 @@ int main_main()
     int zone_info = false;
     int allow_diff_grids = false;
     Real rtol = 0.0;
+    Real atol = 0.0;
     std::string zone_info_var_name;
     Vector<std::string> plot_names(1);
     bool abort_if_not_all_found = false;
@@ -56,6 +58,8 @@ int main_main()
             allow_diff_grids = true;
         } else if (fname == "-r" or fname == "--rel_tol") {
             rtol = std::stod(amrex::get_command_argument(++farg));
+        } else if (fname == "--abs_tol") {
+            atol = std::stod(amrex::get_command_argument(++farg));
         } else if (fname == "--abort_if_not_all_found") {
             abort_if_not_all_found = true;            
         } else {
@@ -79,7 +83,7 @@ int main_main()
             << " variable.\n"
             << "\n"
             << " usage:\n"
-            << "    fcompare [-n|--norm num] [-d|--diffvar var] [-z|--zone_info var] [-a|--allow_diff_grids] [-r|rel_tol] file1 file2\n"
+            << "    fcompare [-n|--norm num] [-d|--diffvar var] [-z|--zone_info var] [-a|--allow_diff_grids] [-r|rel_tol] [--abs_tol] file1 file2\n"
             << "\n"
             << " optional arguments:\n"
             << "    -n|--norm num         : what norm to use (default is 0 for inf norm)\n"
@@ -89,6 +93,7 @@ int main_main()
             << "                            to the maximum error for the given variable\n"
             << "    -a|--allow_diff_grids : allow different BoxArrays covering the same domain\n"
             << "    -r|--rel_tol rtol     : relative tolerance (default is 0)\n"
+            << "    --abs_tol atol        : absolute tolerance (default is 0)\n"
             << std::endl;
         return 0;
     }
@@ -298,9 +303,12 @@ int main_main()
         global_error = std::max(global_error,
                                 *(std::max_element(aerror.begin(),
                                                    aerror.end())));
-        global_rerror = std::max(global_rerror,
-                                 *(std::max_element(rerror.begin(),
-                                                    rerror.end())));
+
+        const auto max_rerr = std::max_element(rerror.begin(), rerror.end());
+        global_rerror = std::max(global_rerror, *max_rerr);
+        const auto idx = std::distance(rerror.begin(), max_rerr);
+        abserr_for_global_rerror = std::max(
+            abserr_for_global_rerror, aerror[idx]);
         for (int icomp_a = 0; icomp_a < ncomp_a; ++icomp_a) {
             any_nans = any_nans or has_nan_a[icomp_a] or has_nan_b[icomp_a];
         }
@@ -355,6 +363,12 @@ int main_main()
 
     if (global_error == 0.0 and !any_nans) {
         amrex::Print() << " PLOTFILE AGREE" << std::endl;
+        return EXIT_SUCCESS;
+    } else if ((abserr_for_global_rerror <= atol) &&
+               (global_rerror <= rtol)) {
+        amrex::Print() << " PLOTFILE AGREE to specified tolerances: "
+                       << "absolute = " << atol
+                       << " relative = " << rtol << std::endl;
         return EXIT_SUCCESS;
     } else if (global_rerror <= rtol) {
         amrex::Print() << " PLOTFILE AGREE to relative tolerance " << rtol << std::endl;


### PR DESCRIPTION
This PR adds a command line option to `fcompare` that takes in a user-specified tolerance for absolute error and adds logic to compare both absolute and relative errors against user-specified tolerances.

Since `-a` is already used as a short-form for `--allow_diff_grids`, I have only used `--abs_tol` as the option without a short version when parsing command line options. 

## Additional background

For ExaWind/AMR-Wind we would like to compare our nightly regression tests executing on GPUs against plot files generated on CPUs. However, due to indeterministic execution of nodal projection on GPUs the solutions are slightly different for each GPU run. In most cases, the relative tolerance specification is sufficient. However, for particular cases when the absolute error is really small, there are situations when relative error exceeds the specified tolerance and the check fails, as shown in the following fcompare output. Here `gpx, gpy, velocityy, velocityz` are failing checks. Having an absolute tolerance check will allow skipping these corner cases. 

```
--------------------------------------------------------------------------

            variable name            absolute error            relative error
                                        (||A - B||)         (||A - B||/||A||)
 ----------------------------------------------------------------------------
 level = 0
 density                                          0                         0
 gpx                                1.108446668e-14           1.669216956e-10
 gpy                                 5.96855898e-15           1.675179285e-07
 gpz                                9.048317651e-15           4.122654211e-14
 mu_turb                            7.160938509e-15           2.134236096e-14
 p                                  1.136868377e-13           3.862064706e-15
 temperature                        4.547473509e-13           1.697082323e-15
 tke                                4.468647674e-15           4.855703851e-14
 velocityx                          1.065814104e-14           1.332264646e-15
 velocityy                          3.714614144e-15           1.064078537e-10
 velocityz                           1.17857113e-14           1.076369457e-10
 velocity_mueff                     7.160938509e-15           2.134236096e-14
```

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [X] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
