### PR TITLE
fcompare: fix logic error when comparing both rel/abs tolerances

### DIFF
--- a/Tools/Plotfile/fcompare.cpp
+++ b/Tools/Plotfile/fcompare.cpp
@@ -370,9 +370,6 @@ int main_main()
                        << "absolute = " << atol
                        << " relative = " << rtol << std::endl;
         return EXIT_SUCCESS;
-    } else if (global_rerror <= rtol) {
-        amrex::Print() << " PLOTFILE AGREE to relative tolerance " << rtol << std::endl;
-        return EXIT_SUCCESS;
     } else {
         return EXIT_FAILURE;
     }

--- a/Tools/Plotfile/fcompare.cpp
+++ b/Tools/Plotfile/fcompare.cpp
@@ -364,7 +364,7 @@ int main_main()
     if (global_error == 0.0 and !any_nans) {
         amrex::Print() << " PLOTFILE AGREE" << std::endl;
         return EXIT_SUCCESS;
-    } else if ((abserr_for_global_rerror <= atol) &&
+    } else if ((abserr_for_global_rerror <= atol) ||
                (global_rerror <= rtol)) {
         amrex::Print() << " PLOTFILE AGREE to specified tolerances: "
                        << "absolute = " << atol


### PR DESCRIPTION
PR #1537 introduced the option to allow tolerance checks on both absolute and
relative tolerances. However, the check used `and` instead of `or` to allow
tests to pass when either absolute or relative error was below user-specified
tolerance.

## Checklist

The proposed changes:
- [X] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
