### PR TITLE
CMake: generate_buildinfo target

### DIFF
--- a/Tools/CMake/AMReXBuildInfo.cmake
+++ b/Tools/CMake/AMReXBuildInfo.cmake
@@ -187,28 +187,34 @@ function (generate_buildinfo _target _git_dir)
 
    # Generate AMReX_buildInfo.cpp
    configure_file( ${AMREX_BUILDINFO_IFILE}
-      ${CMAKE_CURRENT_BINARY_DIR}/AMReX_buildInfo.cpp @ONLY)
+      ${PROJECT_BINARY_DIR}/${_target}/AMReX_buildInfo.cpp @ONLY)
 
-   target_sources( ${_target}
+   # add a re-usable target
+   add_library(buildInfo${_target} STATIC)
+   add_library(buildInfo::${_target} ALIAS buildInfo${_target})
+
+   target_sources(buildInfo${_target}
       PRIVATE
-      ${CMAKE_CURRENT_BINARY_DIR}/AMReX_buildInfo.cpp
-      )
+      ${PROJECT_BINARY_DIR}/${_target}/AMReX_buildInfo.cpp
+   )
 
-   target_sources( ${_target}
+   target_sources(buildInfo${_target}
       PRIVATE
       ${AMREX_C_SCRIPTS_DIR}/AMReX_buildInfo.H
-      )
+   )
 
-   target_include_directories( ${_target}
+   target_include_directories(buildInfo${_target}
       PUBLIC
       $<BUILD_INTERFACE:${AMREX_C_SCRIPTS_DIR}>
-      )
+   )
 
    # Make AMReX_buildInfo.cpp always out of date before building
-   add_custom_command( TARGET ${_target}
+   add_custom_command(TARGET buildInfo${_target}
       PRE_BUILD
       COMMAND ${CMAKE_COMMAND} -E touch_nocreate AMReX_buildInfo.cpp
-      WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-      )
+      WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/${_target}/
+   )
+
+   target_link_libraries(${_target} PRIVATE buildInfo${_target})
 
 endfunction ()


### PR DESCRIPTION
## Summary

This commit generates a static library `buildInfo::<target>` for the passed user target. This target is then automatically linked. Also, the generated `.cpp` file is now scoped properly, avoiding collisions.

This solves the following corner cases:
- workflows with OBJECT libraries, that cannot be passed as   targets since they have no `PRE_BUILD` custom command support
- workflows with multiple targets that are not linked together   (those call `generate_buildinfo` multiple times)
- workflows with multiple targets that are linked together (those call `generate_buildinfo` once and re-use the `buildInfo::<target>`)

Thx to @mic84 for brain-storming & support.

## Additional background

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
