### PR TITLE
Fix bug in the 'intarray' method of StructOfArrays

### DIFF
--- a/Src/Particle/AMReX_StructOfArrays.H
+++ b/Src/Particle/AMReX_StructOfArrays.H
@@ -148,7 +148,7 @@ struct StructOfArrays {
         GpuArray<int*, NInt> arr;
         for (int i = 0; i < NInt; ++i)
         {
-            arr[i] = m_rdata[i].dataPtr();
+            arr[i] = m_idata[i].dataPtr();
         }
         return arr;
     }


### PR DESCRIPTION
Thanks to @rporcu for finding this.

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
