### PR TITLE
Enable FFTW Compilation on corigpu

### DIFF
--- a/Tools/GNUMake/sites/Make.nersc
+++ b/Tools/GNUMake/sites/Make.nersc
@@ -46,6 +46,7 @@ ifeq ($(which_computer),$(filter $(which_computer),cgpu))
     CXX = mpic++
     FC  = mpif90
     F90 = mpif90
+    CXXFLAGS += $(FFTW)
 
     ifneq ($(LINK_WITH_FORTRAN_COMPILER),TRUE)
       ifneq ($(findstring mvapich,$(shell mpif90 -show 2>&1 | tr A-Z a-z)),)


### PR DESCRIPTION
## Summary
add CXXFLAGS += $(FFTW) to Make.nersc to enable fftw compilation on cori

## Additional background

## Checklist
