### PR TITLE
CMake: improvements to handling of buildInfo

### DIFF
--- a/Tools/CMake/AMReXBuildInfo.cmake
+++ b/Tools/CMake/AMReXBuildInfo.cmake
@@ -215,6 +215,14 @@ function (generate_buildinfo _target _git_dir)
       WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/${_target}/
    )
 
-   target_link_libraries(${_target} PRIVATE buildInfo${_target})
+   target_link_libraries(${_target}
+      PUBLIC
+      $<BUILD_INTERFACE:buildInfo${_target}> )
+
+   # Set PIC property to be consistent with AMReX'
+   get_target_property(_pic AMReX::amrex POSITION_INDEPENDENT_CODE)
+   set_target_properties(buildInfo${_target}
+      PROPERTIES
+      POSITION_INDEPENDENT_CODE ${_pic} )
 
 endfunction ()


### PR DESCRIPTION
## Summary
BuildInfo targets were private and did not honor AMReX_PIC. This PR takes care of both issues.

Regression of #1545 

## Additional background

## Checklist

The proposed changes:
- [X] fix a bug or incorrect behavior in AMReX
- [X] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
