### PR TITLE
CMake: AMReX_MPI options is dependent on SYCL, not HIP

### DIFF
--- a/Tools/CMake/AMReXOptions.cmake
+++ b/Tools/CMake/AMReXOptions.cmake
@@ -130,9 +130,6 @@ if (AMReX_DPCPP)
       message(FATAL_ERROR "\nAMReX_GPU_BACKEND=${AMReX_GPU_BACKEND} supports dpcpp compiler only."
          "Set CMAKE_CXX_COMPILER=dpccp and try again.")
    endif ()
-   if (AMReX_MPI)
-      message(FATAL_ERROR "\nAMReX_GPU_BACKEND=${AMReX_GPU_BACKEND} is incompatible with AMReX_MPI=${AMReX_MPI}.")
-   endif ()
 endif ()
 
 cmake_dependent_option( AMReX_DPCPP_AOT  "Enable DPCPP ahead-of-time compilation (WIP)"  OFF
@@ -164,7 +161,7 @@ endif ()
 #
 # Parallel backends    ========================================================
 #
-cmake_dependent_option( AMReX_MPI  "Enable MPI"  ON "NOT AMReX_GPU_BACKEND STREQUAL HIP" OFF)
+cmake_dependent_option( AMReX_MPI  "Enable MPI"  ON "NOT AMReX_GPU_BACKEND STREQUAL SYCL" OFF)
 print_option( AMReX_MPI )
 
 cmake_dependent_option( AMReX_MPI_THREAD_MULTIPLE


### PR DESCRIPTION
## Summary
Option AMReX_MPI should be available only if AMReX_GPU_BACKEND is not set to SYCL.

## Additional background

## Checklist

The proposed changes:
- [X] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
