### PR TITLE
DPCPP: MPI

### DIFF
--- a/Tools/GNUMake/Make.defs
+++ b/Tools/GNUMake/Make.defs
@@ -33,9 +33,10 @@ ifeq ($(USE_DPCPP),TRUE)
   DEFINES += -DAMREX_USE_DPCPP -DAMREX_USE_GPU
   USE_CUDA := FALSE
   USE_HIP := FALSE
-  # disable mpi, fortran and ccache for now
-  USE_MPI := FALSE
+  # disable ccache for now
   USE_CCACHE := FALSE
+  # Make.unknown's mpi checking does not work with mpiipx
+  NO_MPI_CHECKING := TRUE
 endif
 
 ifdef USE_HIP
@@ -970,7 +971,18 @@ ifneq ("$(wildcard $(AMREX_HOME)/Tools/GNUMake/Make.local)","")
   include        $(AMREX_HOME)/Tools/GNUMake/Make.local
 endif
 
-ifeq ($(USE_HIP),TRUE)
+ifeq ($(USE_DPCPP),TRUE)
+
+    ifeq ($(USE_MPI),TRUE)
+        CC  = mpiicx
+        CXX = mpiicpx
+        FC  = mpiifx
+        F90 = mpiifx
+        # current version of mpiicpx does not have this on by default
+        CXXFLAGS += -fsycl-unnamed-lambda
+    endif
+
+else ifeq ($(USE_HIP),TRUE)
 
     LINKFLAGS = $(HIPCC_FLAGS)
     AMREX_LINKER = hipcc

--- a/Tools/GNUMake/Make.machines
+++ b/Tools/GNUMake/Make.machines
@@ -41,6 +41,11 @@ ifdef OLCF_MODULEPATH_ROOT
   endif
 endif
 
+ifeq ($(findstring theta, $(host_name)), theta)
+  which_site := alcf
+  which_computer := theta
+endif
+
 ifeq ($(findstring sierra, $(host_name)), sierra)
   which_site := llnl
   which_computer := sierra
@@ -69,16 +74,6 @@ endif
 ifeq ($(findstring rzansel, $(host_name)), rzansel)
   which_site := llnl
   which_computer := rzansel
-endif
-
-ifeq ($(findstring mira, $(host_name)), mira)
-  which_site := alcf
-  which_computer := mira
-endif
-
-ifeq ($(findstring theta, $(host_name)), theta)
-  which_site := alcf
-  which_computer := theta
 endif
 
 ifeq ($(findstring asterix, $(host_name)), asterix)

--- a/Tools/GNUMake/comps/dpcpp.mak
+++ b/Tools/GNUMake/comps/dpcpp.mak
@@ -32,7 +32,7 @@ else
 
 endif
 
-CXXFLAGS += -Wno-pass-failed  # disable this warning
+CXXFLAGS += -Wno-pass-failed # disable this warning
 
 ifeq ($(WARN_ALL),TRUE)
   warning_flags = -Wall -Wextra -Wno-sign-compare -Wunreachable-code -Wnull-dereference

--- a/Tools/GNUMake/sites/Make.alcf
+++ b/Tools/GNUMake/sites/Make.alcf
@@ -1,12 +1,10 @@
-#
-# For Theta at ALCF
-#
 
-ifeq ($(USE_MPI),TRUE)
-  CC  = cc
-  CXX = CC
-  FC  = ftn
-  F90 = ftn
-  LIBRARIES += -lmpichf90
+ifeq ($(which_computer),theta)
+  ifeq ($(USE_MPI),TRUE)
+    CC  = cc
+    CXX = CC
+    FC  = ftn
+    F90 = ftn
+    LIBRARIES += -lmpichf90
+  endif
 endif
-


### PR DESCRIPTION
## Summary

Allow MPI for dpcpp build in gnu make assuming mpiicpx is used.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
