### PR TITLE
allow MLEBABecLap to solve for multiple components

### DIFF
--- a/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap.H
@@ -20,7 +20,8 @@ public:
                  const Vector<BoxArray>& a_grids,
                  const Vector<DistributionMapping>& a_dmap,
                  const LPInfo& a_info,
-                 const Vector<EBFArrayBoxFactory const*>& a_factory);
+                 const Vector<EBFArrayBoxFactory const*>& a_factory,
+                 const int ncomp = 1);
 
     virtual ~MLEBABecLap ();
 

--- a/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap.H
@@ -20,7 +20,8 @@ public:
                  const Vector<BoxArray>& a_grids,
                  const Vector<DistributionMapping>& a_dmap,
                  const LPInfo& a_info,
-                 const Vector<EBFArrayBoxFactory const*>& a_factory);
+                 const Vector<EBFArrayBoxFactory const*>& a_factory,
+                 const int a_ncomp = 1);
 
     virtual ~MLEBABecLap ();
 
@@ -58,6 +59,8 @@ public:
     void setEBHomogDirichlet (int amrlev,                      const MultiFab& beta);
     void setEBHomogDirichlet (int amrlev,                      Real beta);
     void setEBHomogDirichlet (int amrlev,                      Vector<Real> const& beta);
+
+    virtual int getNComp () const { return m_ncomp; }
 
     virtual bool needsUpdate () const override {
         return (m_needs_update || MLCellABecLap::needsUpdate());
@@ -118,6 +121,8 @@ public:
 #endif
 
 protected:
+
+    int m_ncomp;
 
     bool m_needs_update = true;
 

--- a/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap.H
@@ -20,8 +20,7 @@ public:
                  const Vector<BoxArray>& a_grids,
                  const Vector<DistributionMapping>& a_dmap,
                  const LPInfo& a_info,
-                 const Vector<EBFArrayBoxFactory const*>& a_factory,
-                 const int ncomp = 1);
+                 const Vector<EBFArrayBoxFactory const*>& a_factory);
 
     virtual ~MLEBABecLap ();
 

--- a/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap.H
@@ -60,7 +60,7 @@ public:
     void setEBHomogDirichlet (int amrlev,                      Real beta);
     void setEBHomogDirichlet (int amrlev,                      Vector<Real> const& beta);
 
-    virtual int getNComp () const { return m_ncomp; }
+    virtual int getNComp () const override { return m_ncomp; }
 
     virtual bool needsUpdate () const override {
         return (m_needs_update || MLCellABecLap::needsUpdate());

--- a/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap.cpp
@@ -24,7 +24,9 @@ MLEBABecLap::MLEBABecLap (const Vector<Geometry>& a_geom,
                           const Vector<BoxArray>& a_grids,
                           const Vector<DistributionMapping>& a_dmap,
                           const LPInfo& a_info,
-                          const Vector<EBFArrayBoxFactory const*>& a_factory)
+                          const Vector<EBFArrayBoxFactory const*>& a_factory,
+                          const int a_ncomp)
+    : m_ncomp(a_ncomp)
 {
     define(a_geom, a_grids, a_dmap, a_info, a_factory);
 }

--- a/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap.cpp
@@ -24,10 +24,8 @@ MLEBABecLap::MLEBABecLap (const Vector<Geometry>& a_geom,
                           const Vector<BoxArray>& a_grids,
                           const Vector<DistributionMapping>& a_dmap,
                           const LPInfo& a_info,
-                          const Vector<EBFArrayBoxFactory const*>& a_factory,
-                          const int ncomp)
+                          const Vector<EBFArrayBoxFactory const*>& a_factory)
 {
-    setNComp(ncomp);
     define(a_geom, a_grids, a_dmap, a_info, a_factory);
 }
 

--- a/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap.cpp
@@ -24,8 +24,10 @@ MLEBABecLap::MLEBABecLap (const Vector<Geometry>& a_geom,
                           const Vector<BoxArray>& a_grids,
                           const Vector<DistributionMapping>& a_dmap,
                           const LPInfo& a_info,
-                          const Vector<EBFArrayBoxFactory const*>& a_factory)
+                          const Vector<EBFArrayBoxFactory const*>& a_factory,
+                          const int ncomp)
 {
+    setNComp(ncomp);
     define(a_geom, a_grids, a_dmap, a_info, a_factory);
 }
 

--- a/Src/LinearSolvers/MLMG/AMReX_MLLinOp.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLLinOp.H
@@ -178,8 +178,7 @@ public:
     bool getEnforceSingularSolvable () const noexcept { return enforceSingularSolvable; }
 
     virtual BottomSolver getDefaultBottomSolver () const { return BottomSolver::bicgstab; }
-    virtual void setNComp (int ncomp) noexcept { m_ncomp = ncomp; }
-    virtual int getNComp () const { return m_ncomp; }
+    virtual int getNComp () const { return 1; }
     virtual int getNGrow () const { return 0; }
 
     virtual bool needsUpdate () const { return false; }
@@ -281,8 +280,6 @@ protected:
     int maxorder = 3;
 
     bool enforceSingularSolvable = true;
-
-    int m_ncomp = 1;
 
     int m_num_amr_levels;
     Vector<int> m_amr_ref_ratio;

--- a/Src/LinearSolvers/MLMG/AMReX_MLLinOp.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLLinOp.H
@@ -178,7 +178,8 @@ public:
     bool getEnforceSingularSolvable () const noexcept { return enforceSingularSolvable; }
 
     virtual BottomSolver getDefaultBottomSolver () const { return BottomSolver::bicgstab; }
-    virtual int getNComp () const { return 1; }
+    virtual void setNComp (int ncomp) noexcept { m_ncomp = ncomp; }
+    virtual int getNComp () const { return m_ncomp; }
     virtual int getNGrow () const { return 0; }
 
     virtual bool needsUpdate () const { return false; }
@@ -280,6 +281,8 @@ protected:
     int maxorder = 3;
 
     bool enforceSingularSolvable = true;
+
+    int m_ncomp = 1;
 
     int m_num_amr_levels;
     Vector<int> m_amr_ref_ratio;


### PR DESCRIPTION
## Summary
MLLinOp::getNComp()  is returning 1 and right now MLEBABecLap is working only with MultiFabs having 1 component.

## Additional background
This PR has the goal to generalize MLEBABecLap solver for a generic N number of components.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
