### PR TITLE
Define: _OPENMP -> AMREX_USE_OMP

### DIFF
--- a/Docs/sphinx_documentation/source/AmrCore.rst
+++ b/Docs/sphinx_documentation/source/AmrCore.rst
@@ -613,7 +613,7 @@ interface to a Fortran routine that tags cells (in this case, :fortran:`state_er
 
         const MultiFab& state = *phi_new[lev];
 
-    #ifdef _OPENMP
+    #ifdef AMREX_USE_OMP
     #pragma omp parallel
     #endif
         {

--- a/Docs/sphinx_documentation/source/Basics.rst
+++ b/Docs/sphinx_documentation/source/Basics.rst
@@ -1786,7 +1786,7 @@ parallel region:
   // Dynamic tiling, one box per OpenMP thread.
   // No further tiling details,
   //   so each thread works on a single tilebox.
-  #ifdef _OPENMP
+  #ifdef AMREX_USE_OMP
   #pragma omp parallel
   #endif
       for (MFIter mfi(mf,MFItInfo().SetDynamic(true)); mfi.isValid(); ++mfi)
@@ -1803,7 +1803,7 @@ Dynamic tiling also allows explicit definition of a tile size:
 
   // Dynamic tiling, one box per OpenMP thread.
   // No tiling in x-direction. Tile size is 16 for y and 32 for z.
-  #ifdef _OPENMP
+  #ifdef AMREX_USE_OMP
   #pragma omp parallel
   #endif
       for (MFIter mfi(mf,MFItInfo().SetDynamic(true).EnableTiling(1024000,16,32)); mfi.isValid(); ++mfi)
@@ -2232,7 +2232,7 @@ like below,
 
 ::
 
-  #ifdef _OPENMP
+  #ifdef AMREX_USE_OMP
   #pragma omp parallel if (Gpu::notInLaunchRegion())
   #endif
     for (MFIter mfi(mfa,TilingIfNotGPU()); mfi.isValid(); ++mfi)

--- a/Docs/sphinx_documentation/source/GPU.rst
+++ b/Docs/sphinx_documentation/source/GPU.rst
@@ -1240,7 +1240,7 @@ off using the conditional pragma and :cpp:`Gpu::notInLaunchRegion()`, as shown b
 
 ::
 
-    #ifdef _OPENMP
+    #ifdef AMREX_USE_OMP
     #pragma omp parallel if (Gpu::notInLaunchRegion())
     #endif
 
@@ -1262,7 +1262,7 @@ of common AMReX patterns, such as the one below:
 ::
 
    // Given MultiFab uin and uout
-   #ifdef _OPENMP
+   #ifdef AMREX_USE_OMP
    #pragma omp parallel
    #endif
    {
@@ -1309,7 +1309,7 @@ portable way.
 ::
 
    // Given MultiFab uin and uout
-   #ifdef _OPENMP
+   #ifdef AMREX_USE_OMP
    #pragma omp parallel if (Gpu::notInLaunchRegion())
    #endif
    {

--- a/Src/Amr/AMReX_Amr.cpp
+++ b/Src/Amr/AMReX_Amr.cpp
@@ -8,7 +8,7 @@
 #include <limits>
 #include <cmath>
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #include <omp.h>
 #endif
 

--- a/Src/Amr/AMReX_AmrLevel.cpp
+++ b/Src/Amr/AMReX_AmrLevel.cpp
@@ -1064,7 +1064,7 @@ FillPatchIterator::Initialize (int  boxGrow,
 						  desc.interp(SComp));
 	
 #if defined(AMREX_CRSEGRNDOMP) || (!defined(AMREX_XSDK) && defined(CRSEGRNDOMP))
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel
 #endif
 #endif
@@ -1590,7 +1590,7 @@ AmrLevel::FillCoarsePatch (MultiFab& mf,
 	    FillPatch(clev,crseMF,0,time,idx,SComp,NComp,0);
 	}
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
 	for (MFIter mfi(mf); mfi.isValid(); ++mfi)
@@ -1668,7 +1668,7 @@ AmrLevel::derive (const std::string& name, Real time, int ngrow)
 
         if (rec->derFuncFab() != nullptr)
         {
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
             for (MFIter mfi(*mf,TilingIfNotGPU()); mfi.isValid(); ++mfi)
@@ -1682,7 +1682,7 @@ AmrLevel::derive (const std::string& name, Real time, int ngrow)
         else
         {
 #if defined(AMREX_CRSEGRNDOMP) || (!defined(AMREX_XSDK) && defined(CRSEGRNDOMP))
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel
 #endif
         for (MFIter mfi(*mf,true); mfi.isValid(); ++mfi)
@@ -1819,7 +1819,7 @@ AmrLevel::derive (const std::string& name, Real time, MultiFab& mf, int dcomp)
 
         if (rec->derFuncFab() != nullptr)
         {
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
             for (MFIter mfi(mf,TilingIfNotGPU()); mfi.isValid(); ++mfi)
@@ -1834,7 +1834,7 @@ AmrLevel::derive (const std::string& name, Real time, MultiFab& mf, int dcomp)
         else
         {
 #if defined(AMREX_CRSEGRNDOMP) || (!defined(AMREX_XSDK) && defined(CRSEGRNDOMP))
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel
 #endif
         for (MFIter mfi(mf,true); mfi.isValid(); ++mfi)

--- a/Src/Amr/AMReX_Extrapolater.cpp
+++ b/Src/Amr/AMReX_Extrapolater.cpp
@@ -3,7 +3,7 @@
 #include <AMReX_extrapolater_K.H>
 #include <AMReX_iMultiFab.H>
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #include <omp.h>
 #endif
 
@@ -22,7 +22,7 @@ namespace Extrapolater
         mask.BuildMask(geom.Domain(), geom.periodicity(),
                        finebnd, crsebnd, physbnd, interior);
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
         for (MFIter mfi(mf); mfi.isValid(); ++mfi)

--- a/Src/Amr/AMReX_StateData.cpp
+++ b/Src/Amr/AMReX_StateData.cpp
@@ -9,7 +9,7 @@
 #include <AMReX_ParallelDescriptor.H>
 #include <AMReX_Utility.H>
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #include <omp.h>
 #endif
 
@@ -879,7 +879,7 @@ StateDataPhysBCFunct::operator() (MultiFab& mf, int dest_comp, int num_comp, Int
     bool run_on_gpu = statedata->desc->RunOnGPU() && Gpu::inLaunchRegion();
 
 #if defined(AMREX_CRSEGRNDOMP) || (!defined(AMREX_XSDK) && defined(CRSEGRNDOMP))
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (!run_on_gpu)
 #endif
 #endif

--- a/Src/Amr/AMReX_StateDescriptor.cpp
+++ b/Src/Amr/AMReX_StateDescriptor.cpp
@@ -51,7 +51,7 @@ StateDescriptor::BndryFunc::operator () (Real* data,const int* lo,const int* hi,
 	m_func3D(data,AMREX_ARLIM_3D(lo),AMREX_ARLIM_3D(hi),AMREX_ARLIM_3D(dom_lo),AMREX_ARLIM_3D(dom_hi),
                  AMREX_ZFILL(dx),AMREX_ZFILL(grd_lo),time,a_bc);
     } else {
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp critical (bndryfunc)
 #endif
       if (m_func != 0)
@@ -78,7 +78,7 @@ StateDescriptor::BndryFunc::operator () (Real* data,const int* lo,const int* hi,
 	  m_gfunc3D(data,AMREX_ARLIM_3D(lo),AMREX_ARLIM_3D(hi),AMREX_ARLIM_3D(dom_lo),AMREX_ARLIM_3D(dom_hi),
                     AMREX_ZFILL(dx),AMREX_ZFILL(grd_lo),time,a_bc);
     } else {
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp critical (bndryfunc)
 #endif
         if (m_gfunc != 0)

--- a/Src/AmrCore/AMReX_AmrCore.cpp
+++ b/Src/AmrCore/AMReX_AmrCore.cpp
@@ -8,7 +8,7 @@
 #include <AMReX_AmrParGDB.H>
 #endif
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #include <omp.h>
 #endif
 
@@ -147,7 +147,7 @@ AmrCore::printGridSummary (std::ostream& os, int min_lev, int max_lev) const noe
 	    int smin = std::numeric_limits<int>::max();
             int imax = std::numeric_limits<int>::lowest();
             int imin = std::numeric_limits<int>::lowest();
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel
 #endif	    
 	    {
@@ -157,7 +157,7 @@ AmrCore::printGridSummary (std::ostream& os, int min_lev, int max_lev) const noe
 		int smin_this = std::numeric_limits<int>::max();
                 int imax_this = std::numeric_limits<int>::lowest();
                 int imin_this = std::numeric_limits<int>::lowest();
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp for
 #endif	    	    
 		for (int k = 0; k < numgrid; k++) {
@@ -176,7 +176,7 @@ AmrCore::printGridSummary (std::ostream& os, int min_lev, int max_lev) const noe
 			imax_this = k;
 		    }
 		}
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp critical (amr_prtgs)
 #endif	    	    
 		{

--- a/Src/AmrCore/AMReX_ErrorList.cpp
+++ b/Src/AmrCore/AMReX_ErrorList.cpp
@@ -359,7 +359,7 @@ operator << (std::ostream&    os,
     {
       AMREX_ALWAYS_ASSERT_WITH_MESSAGE(m_userfunc!=nullptr,"UserFunc not properly set in AMRErrorTag");
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
       for (MFIter mfi(tba,TilingIfNotGPU()); mfi.isValid(); ++mfi)
@@ -377,7 +377,7 @@ operator << (std::ostream&    os,
           (time  <= m_info.m_max_time ) )
       {
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
         for (MFIter mfi(tba,TilingIfNotGPU()); mfi.isValid(); ++mfi)

--- a/Src/AmrCore/AMReX_FillPatchUtil.H
+++ b/Src/AmrCore/AMReX_FillPatchUtil.H
@@ -17,7 +17,7 @@
 #include <cmath>
 #include <limits>
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #include <omp.h>
 #endif
 

--- a/Src/AmrCore/AMReX_FillPatchUtil.cpp
+++ b/Src/AmrCore/AMReX_FillPatchUtil.cpp
@@ -67,7 +67,7 @@ namespace amrex
 
             const int use_limiter = 0;
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
             {

--- a/Src/AmrCore/AMReX_FillPatchUtil_I.H
+++ b/Src/AmrCore/AMReX_FillPatchUtil_I.H
@@ -93,7 +93,7 @@ FillPatchSingleLevel (MF& mf, IntVect const& nghost, Real time,
 
         if ((dmf != smf[0] && dmf != smf[1]) || scomp != dcomp)
         {
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
             for (MFIter mfi(*dmf,TilingIfNotGPU()); mfi.isValid(); ++mfi)
@@ -347,7 +347,7 @@ namespace {
 
                 Box const& fdomain = amrex::convert(fgeom.Domain(),mf.ixType());
                 int idummy=0;
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
                 bool cc = fpc.ba_crse_patch.ixType().cellCentered();
 #pragma omp parallel if (cc && Gpu::notInLaunchRegion())
 #endif
@@ -477,7 +477,7 @@ namespace {
                 }
 
                 int idummy=0;
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 //              bool cc = fpc.ba_crse_patch.ixType().cellCentered();
                 bool cc = false;        // can anything be done to allow threading, or can the OpenMP just be removed?
 #pragma omp parallel if (cc && Gpu::notInLaunchRegion() )
@@ -790,7 +790,7 @@ InterpFromCoarseLevel (MF& mf, IntVect const& nghost, Real time,
 
     int idummy1=0, idummy2=0;
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     {
@@ -921,7 +921,7 @@ InterpFromCoarseLevel (Array<MF*, AMREX_SPACEDIM> const& mf, IntVect const& ngho
     }
 
     int idummy1=0, idummy2=0;
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     {

--- a/Src/AmrCore/AMReX_FluxRegister.cpp
+++ b/Src/AmrCore/AMReX_FluxRegister.cpp
@@ -138,7 +138,7 @@ FluxRegister::SumReg (int comp) const
         else
 #endif
         {
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel reduction(+:sum)
 #endif
             for (FabSetIter fsi(lofabs); fsi.isValid(); ++fsi)
@@ -183,7 +183,7 @@ FluxRegister::CrseInit (const MultiFab& mflx,
     MultiFab mf(mflx.boxArray(),mflx.DistributionMap(),numcomp,0,
                 MFInfo(), mflx.Factory());
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif    
     for (MFIter mfi(mflx,TilingIfNotGPU()); mfi.isValid(); ++mfi)
@@ -214,7 +214,7 @@ FluxRegister::CrseInit (const MultiFab& mflx,
 
             fs.copyFrom(mf,0,0,0,numcomp);
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
             for (FabSetIter mfi(fs); mfi.isValid(); ++mfi)
@@ -270,7 +270,7 @@ FluxRegister::CrseAdd (const MultiFab& mflx,
     MultiFab mf(mflx.boxArray(),mflx.DistributionMap(),numcomp,0,
                 MFInfo(), mflx.Factory());
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     for (MFIter mfi(mflx,TilingIfNotGPU()); mfi.isValid(); ++mfi)
@@ -320,7 +320,7 @@ FluxRegister::FineAdd (const MultiFab& mflx,
                        int             numcomp,
                        Real            mult)
 {
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     for (MFIter mfi(mflx); mfi.isValid(); ++mfi)
@@ -339,7 +339,7 @@ FluxRegister::FineAdd (const MultiFab& mflx,
                        int             numcomp,
                        Real            mult)
 {
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     for (MFIter mfi(mflx); mfi.isValid(); ++mfi)
@@ -557,7 +557,7 @@ FluxRegister::Reflux (MultiFab& mf, const MultiFab& volume, Orientation face,
 
     bndry[face].copyTo(flux, 0, scomp, 0, nc, geom.periodicity());
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     for (MFIter mfi(mf,TilingIfNotGPU()); mfi.isValid(); ++mfi)
@@ -591,7 +591,7 @@ FluxRegister::ClearInternalBorders (const Geometry& geom)
 	const BoxArray& balo = frlo.boxArray();
 	const BoxArray& bahi = frhi.boxArray();
 	
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel
 #endif
         {
@@ -657,7 +657,7 @@ FluxRegister::OverwriteFlux (Array<MultiFab*,AMREX_SPACEDIM> const& crse_fluxes,
     {
         const std::vector<IntVect>& pshifts = cperiod.shiftIntVect();
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel
 #endif
         {
@@ -695,7 +695,7 @@ FluxRegister::OverwriteFlux (Array<MultiFab*,AMREX_SPACEDIM> const& crse_fluxes,
         bndry[lo_face].copyTo(fine_flux, 0, srccomp, 0, numcomp, cperiod);
         bndry[hi_face].plusTo(fine_flux, 0, srccomp, 0, numcomp, cperiod);
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel
 #endif
         for (MFIter mfi(crse_flux,true); mfi.isValid(); ++mfi)

--- a/Src/AmrCore/AMReX_TagBox.cpp
+++ b/Src/AmrCore/AMReX_TagBox.cpp
@@ -291,7 +291,7 @@ TagBoxArray::buffer (const IntVect& nbuf)
 
     if (nbuf.max() > 0)
     {
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
        for (MFIter mfi(*this); mfi.isValid(); ++mfi) {
@@ -315,7 +315,7 @@ TagBoxArray::mapPeriodicRemoveDuplicates (const Geometry& geom)
 
         // We need to keep tags in periodic boundary
         const auto owner_mask = amrex::OwnerMask(tmp, Periodicity::NonPeriodic(), nGrowVect());
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel
 #endif
         for (MFIter mfi(tmp); mfi.isValid(); ++mfi) {
@@ -341,7 +341,7 @@ TagBoxArray::mapPeriodicRemoveDuplicates (const Geometry& geom)
 
         // We need to keep tags in periodic boundary
         const auto owner_mask = amrex::OwnerMask(tmp, Periodicity::NonPeriodic(), nGrowVect());
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel
 #endif
         for (MFIter mfi(tmp); mfi.isValid(); ++mfi) {
@@ -364,7 +364,7 @@ TagBoxArray::local_collate_cpu (Vector<IntVect>& v) const
     if (this->local_size() == 0) return;
 
     Vector<int> count(this->local_size());
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel
 #endif
     for (MFIter fai(*this); fai.isValid(); ++fai)
@@ -386,7 +386,7 @@ TagBoxArray::local_collate_cpu (Vector<IntVect>& v) const
 
     if (v.empty()) return;
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel
 #endif
     for (MFIter fai(*this); fai.isValid(); ++fai)
@@ -658,7 +658,7 @@ TagBoxArray::setVal (const BoxArray& ba, TagBox::TagVal val)
 {
     Vector<Array4BoxTag<char> > tags;
     bool run_on_gpu = Gpu::inLaunchRegion();
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (!run_on_gpu)
 #endif
     {
@@ -701,7 +701,7 @@ TagBoxArray::coarsen (const IntVect & ratio)
         new_n_grow[idim] = (n_grow[idim]+ratio[idim]-1)/ratio[idim];
     }
 
-#if defined(_OPENMP)
+#if defined(AMREX_USE_OMP)
 #pragma omp parallel if (teamsize == 1 && Gpu::notInLaunchRegion())
 #endif
     for (MFIter mfi(*this,flags); mfi.isValid(); ++mfi)
@@ -743,7 +743,7 @@ TagBoxArray::hasTags (Box const& a_bx) const
     } else
 #endif
     {
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel reduction(||:has_tags)
 #endif
         for (MFIter mfi(*this); mfi.isValid(); ++mfi)

--- a/Src/Base/AMReX.cpp
+++ b/Src/Base/AMReX.cpp
@@ -47,7 +47,7 @@
 #include <AMReX_MemProfiler.H>
 #endif
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #include <omp.h>
 #endif
 
@@ -209,7 +209,7 @@ amrex::Error_host (const char * msg)
     } else {
         write_lib_id("Error");
         write_to_stderr_without_buffering(msg);
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp critical (amrex_abort_omp_critical)
 #endif
         ParallelDescriptor::Abort();
@@ -257,7 +257,7 @@ amrex::Abort_host (const char * msg)
     } else {
        write_lib_id("Abort");
        write_to_stderr_without_buffering(msg);
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp critical (amrex_abort_omp_critical)
 #endif
        ParallelDescriptor::Abort();
@@ -306,7 +306,7 @@ amrex::Assert_host (const char* EX, const char* file, int line, const char* msg)
         throw RuntimeError(buf);
     } else {
        write_to_stderr_without_buffering(buf);
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp critical (amrex_abort_omp_critical)
 #endif
        ParallelDescriptor::Abort();
@@ -592,7 +592,7 @@ amrex::Initialize (int& argc, char**& argv, bool build_parm_parse,
         amrex::Print() << "MPI initialized with thread support level " << provided << std::endl;
 #endif
         
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 //    static_assert(_OPENMP >= 201107, "OpenMP >= 3.1 is required.");
         amrex::Print() << "OMP initialized with "
                        << omp_get_max_threads()
@@ -660,7 +660,7 @@ amrex::Finalize (amrex::AMReX* pamrex)
 	if (ParallelDescriptor::NProcs() == 1) {
 	    if (mp_tot > 0) {
                 amrex::Print() << "MemPool: " 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
                                << "min used in a thread: " << mp_min << " MB, "
                                << "max used in a thread: " << mp_max << " MB, "
 #endif

--- a/Src/Base/AMReX_BLBackTrace.H
+++ b/Src/Base/AMReX_BLBackTrace.H
@@ -9,7 +9,7 @@
 #include <cstdio>
 #include <cstdlib>
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #include <omp.h>
 #endif
 
@@ -30,7 +30,7 @@ struct BLBackTrace
 
     static std::stack<std::pair<std::string, std::string> > bt_stack;
 // threadprivate here doesn't work with Cray and Intel
-#if defined(_OPENMP) && !defined(_CRAYC) && !defined(__INTEL_COMPILER) && !defined(__PGI)
+#if defined(AMREX_USE_OMP) && !defined(_CRAYC) && !defined(__INTEL_COMPILER) && !defined(__PGI)
 #pragma omp threadprivate(bt_stack)
 #endif
 };

--- a/Src/Base/AMReX_BLBackTrace.cpp
+++ b/Src/Base/AMReX_BLBackTrace.cpp
@@ -72,7 +72,7 @@ BLBackTrace::handler(int s)
     {
 	std::ostringstream ss;
 	ss << "Backtrace." << ParallelDescriptor::MyProc();
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
  	ss << "." << omp_get_thread_num();
 #endif
 	errfilename = ss.str();
@@ -211,7 +211,7 @@ BLBackTrace::print_backtrace_info (FILE* f)
         {
             fprintf(f, "%2d: %s\n", i, strings[i]);
 
-#if !defined(_OPENMP) || !defined(__INTEL_COMPILER)
+#if !defined(AMREX_USE_OMP) || !defined(__INTEL_COMPILER)
             std::string addr2line_result;
             if (amrex::system::call_addr2line && have_eu_addr2line) {
                 if (bt_buffer[i] != nullptr) {
@@ -305,7 +305,7 @@ BLBTer::BLBTer(const std::string& s, const char* file, int line)
     ss << "Line " << line << ", File " << file;
     line_file = ss.str();
     
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
     if (omp_in_parallel()) {
 	std::ostringstream ss0;
 	ss0 << "Proc. " << ParallelDescriptor::MyProc()
@@ -333,7 +333,7 @@ BLBTer::BLBTer(const std::string& s, const char* file, int line)
 
 BLBTer::~BLBTer()
 {
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
     if (omp_in_parallel()) {
 	pop_bt_stack();
     }

--- a/Src/Base/AMReX_BLProfiler.cpp
+++ b/Src/Base/AMReX_BLProfiler.cpp
@@ -313,7 +313,7 @@ void BLProfiler::PStop() {
 
 
 void BLProfiler::start() {
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp master
 #endif
 {
@@ -348,7 +348,7 @@ void BLProfiler::start() {
 
 
 void BLProfiler::stop() {
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp master
 #endif
 {

--- a/Src/Base/AMReX_BaseFab.H
+++ b/Src/Base/AMReX_BaseFab.H
@@ -21,7 +21,7 @@
 #include <AMReX_Gpu.H>
 #include <AMReX_Math.H>
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #include <omp.h>
 #endif
 
@@ -47,7 +47,7 @@ extern Long private_total_bytes_allocated_in_fabs;     //!< total bytes at any g
 extern Long private_total_bytes_allocated_in_fabs_hwm; //!< high-water-mark over a given interval
 extern Long private_total_cells_allocated_in_fabs;     //!< total cells at any given time
 extern Long private_total_cells_allocated_in_fabs_hwm; //!< high-water-mark over a given interval
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp threadprivate(private_total_bytes_allocated_in_fabs)
 #pragma omp threadprivate(private_total_bytes_allocated_in_fabs_hwm)
 #pragma omp threadprivate(private_total_cells_allocated_in_fabs)

--- a/Src/Base/AMReX_BaseFab.cpp
+++ b/Src/Base/AMReX_BaseFab.cpp
@@ -31,7 +31,7 @@ BaseFab_Initialize ()
     {
         basefab_initialized = true;
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel
         {
             amrex::private_total_bytes_allocated_in_fabs     = 0;
@@ -63,7 +63,7 @@ BaseFab_Finalize()
 Long
 TotalBytesAllocatedInFabs () noexcept
 {
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
     Long r=0;
 #pragma omp parallel reduction(+:r)
     {
@@ -80,7 +80,7 @@ TotalBytesAllocatedInFabs () noexcept
 Long
 TotalBytesAllocatedInFabsHWM () noexcept
 {
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
     Long r=0;
 #pragma omp parallel reduction(+:r)
     {
@@ -97,7 +97,7 @@ TotalBytesAllocatedInFabsHWM () noexcept
 Long
 TotalCellsAllocatedInFabs () noexcept
 {
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
     Long r=0;
 #pragma omp parallel reduction(+:r)
     {
@@ -114,7 +114,7 @@ TotalCellsAllocatedInFabs () noexcept
 Long
 TotalCellsAllocatedInFabsHWM () noexcept
 {
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
     Long r=0;
 #pragma omp parallel reduction(+:r)
     {
@@ -131,7 +131,7 @@ TotalCellsAllocatedInFabsHWM () noexcept
 void 
 ResetTotalBytesAllocatedInFabsHWM () noexcept
 {
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel
 #endif
     {
@@ -143,7 +143,7 @@ ResetTotalBytesAllocatedInFabsHWM () noexcept
 void
 update_fab_stats (Long n, Long s, size_t szt) noexcept
 {
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
     if (omp_in_parallel())
     {
         Long tst = s*szt;

--- a/Src/Base/AMReX_BaseUmap.H
+++ b/Src/Base/AMReX_BaseUmap.H
@@ -7,7 +7,7 @@
 #include <algorithm>
 #include <limits>
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #include <omp.h>
 #endif
 

--- a/Src/Base/AMReX_BoxArray.H
+++ b/Src/Base/AMReX_BoxArray.H
@@ -79,7 +79,7 @@ struct BARef
 
     inline bool HasHashMap () const {
         bool r;
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp atomic read
 #endif
         r = has_hashmap;

--- a/Src/Base/AMReX_BoxArray.cpp
+++ b/Src/Base/AMReX_BoxArray.cpp
@@ -392,7 +392,7 @@ BoxArray::numPts () const noexcept
     const int N = size();
     auto const& bxs = this->m_ref->m_abox;
     if (m_bat.is_null()) {
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel for reduction(+:result)
 #endif
         for (int i = 0; i < N; ++i)
@@ -402,7 +402,7 @@ BoxArray::numPts () const noexcept
     } else if (m_bat.is_simple()) {
         IndexType t = ixType();
         IntVect cr = crseRatio();
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel for reduction(+:result)
 #endif
         for (int i = 0; i < N; ++i)
@@ -410,7 +410,7 @@ BoxArray::numPts () const noexcept
             result += amrex::convert(amrex::coarsen(bxs[i],cr),t).numPts();
         }
     } else {
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel for reduction(+:result)
 #endif
         for (int i = 0; i < N; ++i)
@@ -429,7 +429,7 @@ BoxArray::d_numPts () const noexcept
     const int N = size();
     auto const& bxs = this->m_ref->m_abox;
     if (m_bat.is_null()) {
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel for reduction(+:result)
 #endif
         for (int i = 0; i < N; ++i)
@@ -439,7 +439,7 @@ BoxArray::d_numPts () const noexcept
     } else if (m_bat.is_simple()) {
         IndexType t = ixType();
         IntVect cr = crseRatio();
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel for reduction(+:result)
 #endif
         for (int i = 0; i < N; ++i)
@@ -447,7 +447,7 @@ BoxArray::d_numPts () const noexcept
             result += amrex::convert(amrex::coarsen(bxs[i],cr),t).d_numPts();
         }
     } else {
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel for reduction(+:result)
 #endif
         for (int i = 0; i < N; ++i)
@@ -580,7 +580,7 @@ BoxArray::refine (const IntVect& iv)
     uniqify();
 
     const int N = m_ref->m_abox.size();
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel for
 #endif
     for (int i = 0; i < N; i++) {
@@ -608,7 +608,7 @@ BoxArray::coarsenable(const IntVect& refinement_ratio, int min_width) const
 
     auto const& bxs = this->m_ref->m_abox;
     if (m_bat.is_null()) {
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel for reduction(&&:res)
 #endif
         for (Long ibox = 0; ibox < sz; ++ibox)
@@ -619,7 +619,7 @@ BoxArray::coarsenable(const IntVect& refinement_ratio, int min_width) const
     } else if (m_bat.is_simple()) {
         IndexType t = ixType();
         IntVect cr = crseRatio();
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel for reduction(&&:res)
 #endif
         for (Long ibox = 0; ibox < sz; ++ibox)
@@ -628,7 +628,7 @@ BoxArray::coarsenable(const IntVect& refinement_ratio, int min_width) const
             res = res && thisbox.coarsenable(refinement_ratio,min_width);
         }
     } else {
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel for reduction(&&:res)
 #endif
         for (Long ibox = 0; ibox < sz; ++ibox)
@@ -666,7 +666,7 @@ BoxArray::growcoarsen (IntVect const& ngrow, const IntVect& iv)
     uniqify();
 
     const int N = m_ref->m_abox.size();
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel for
 #endif
     for (int i = 0; i < N; i++) {
@@ -681,7 +681,7 @@ BoxArray::grow (int n)
     uniqify();
 
     const int N = m_ref->m_abox.size();
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel for
 #endif
     for (int i = 0; i < N; i++) {
@@ -696,7 +696,7 @@ BoxArray::grow (const IntVect& iv)
     uniqify();
 
     const int N = m_ref->m_abox.size();
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel for
 #endif
     for (int i = 0; i < N; i++) {
@@ -712,7 +712,7 @@ BoxArray::grow (int dir,
     uniqify();
 
     const int N = m_ref->m_abox.size();
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel for
 #endif
     for (int i = 0; i < N; i++) {
@@ -728,7 +728,7 @@ BoxArray::growLo (int dir,
     uniqify();
 
     const int N = m_ref->m_abox.size();
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel for
 #endif
     for (int i = 0; i < N; i++) {
@@ -744,7 +744,7 @@ BoxArray::growHi (int dir,
     uniqify();
 
     const int N = m_ref->m_abox.size();
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel for
 #endif
     for (int i = 0; i < N; i++) {
@@ -806,7 +806,7 @@ BoxArray::convert (Box (*fp)(const Box&))
     if (N > 0) {
         uniqify();
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel for
 #endif
         for (int i = 0; i < N; ++i) {
@@ -823,7 +823,7 @@ BoxArray::shift (int dir,
     uniqify();
 
     const int N = m_ref->m_abox.size();
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel for
 #endif
     for (int i = 0; i < N; i++) {
@@ -838,7 +838,7 @@ BoxArray::shift (const IntVect& iv)
     uniqify();
 
     const int N = m_ref->m_abox.size();
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel for
 #endif
     for (int i = 0; i < N; i++) {
@@ -1021,7 +1021,7 @@ BoxArray::minimalBox () const
     const int N = size();
     if (N > 0)
     {
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 	bool use_single_thread = omp_in_parallel();
 	const int nthreads = use_single_thread ? 1 : omp_get_max_threads();
 #else
@@ -1038,12 +1038,12 @@ BoxArray::minimalBox () const
 	else
 	{
 	    Vector<Box> bxs(nthreads, m_ref->m_abox[0]);
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel
 #endif
 	    {
                 int tid = OpenMP::get_thread_num();
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp for
 #endif
 		for (int i = 0; i < N; ++i) {
@@ -1069,7 +1069,7 @@ BoxArray::minimalBox (Long& npts_avg_box) const
     Long npts_tot = 0;
     if (N > 0)
     {
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
         bool use_single_thread = omp_in_parallel();
         const int nthreads = use_single_thread ? 1 : omp_get_max_threads();
 #else
@@ -1088,12 +1088,12 @@ BoxArray::minimalBox (Long& npts_avg_box) const
         else
         {
             Vector<Box> bxs(nthreads, m_ref->m_abox[0]);
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel reduction(+:npts_tot)
 #endif
             {
                 int tid = OpenMP::get_thread_num();
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp for
 #endif
                 for (int i = 0; i < N; ++i) {
@@ -1489,7 +1489,7 @@ BoxArray::getHashMap () const
 
     if (m_ref->HasHashMap()) return BoxHashMap;
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp critical(intersections_lock)
 #endif
     {
@@ -1525,7 +1525,7 @@ BoxArray::getHashMap () const
 	    m_ref->updateMemoryUsage_hash(1);
 #endif
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp flush
 #pragma omp atomic write
 #endif
@@ -1548,7 +1548,7 @@ BoxArray::uniqify ()
     IntVect cr = crseRatio();
     if (cr != IntVect::TheUnitVector()) {
         const int N = m_ref->m_abox.size();
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel for
 #endif
         for (int i = 0; i < N; i++) {
@@ -1628,7 +1628,7 @@ intersect (const BoxArray& ba,
     BoxArray r(N);
 
     if (N > 0) {
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel for
 #endif
         for (int i = 0; i < N; i++)
@@ -1654,7 +1654,7 @@ intersect (const BoxArray& ba,
     BoxArray r(N);
 
     if (N > 0) {
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel for
 #endif
         for (int i = 0; i < N; i++)

--- a/Src/Base/AMReX_BoxList.cpp
+++ b/Src/Base/AMReX_BoxList.cpp
@@ -9,7 +9,7 @@
 #include <AMReX_BLProfiler.H>
 #include <AMReX_ParallelDescriptor.H>
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #include <omp.h>
 #endif
 
@@ -357,7 +357,7 @@ BoxList::complementIn (const Box& b, const BoxArray& ba)
         bl_mesh.maxSize(block_size);
         const int N = bl_mesh.size();
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
         bool start_omp_parallel = !omp_in_parallel();
         const int nthreads = omp_get_max_threads();
 #else
@@ -366,7 +366,7 @@ BoxList::complementIn (const Box& b, const BoxArray& ba)
 
         if (start_omp_parallel)
         {
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
             Vector<BoxList> bl_priv(nthreads, BoxList(mytyp));
 #pragma omp parallel
             {
@@ -455,7 +455,7 @@ BoxList::parallelComplementIn (const Box& b, BoxArray const& ba)
 
         Vector<Box> local_boxes;
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
         bool start_omp_parallel = !omp_in_parallel();
         const int nthreads = omp_get_max_threads();
 #else
@@ -464,7 +464,7 @@ BoxList::parallelComplementIn (const Box& b, BoxArray const& ba)
 
         if (start_omp_parallel)
         {
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
             Vector<BoxList> bl_priv(nthreads, BoxList(mytyp));
             int ntot = 0;
 #pragma omp parallel reduction(+:ntot)

--- a/Src/Base/AMReX_DistributionMapping.cpp
+++ b/Src/Base/AMReX_DistributionMapping.cpp
@@ -1601,7 +1601,7 @@ gather_weights (const MultiFab& weight)
 {
 #ifdef AMREX_USE_MPI
     LayoutData<Real> costld(weight.boxArray(),weight.DistributionMap());
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     for (MFIter mfi(weight); mfi.isValid(); ++mfi) {

--- a/Src/Base/AMReX_Extension.H
+++ b/Src/Base/AMReX_Extension.H
@@ -49,7 +49,7 @@
 #elif defined(__HIP_DEVICE_COMPILE__)
 #define AMREX_PRAGMA_SIMD 
 
-//#elif defined(_OPENMP) && (_OPENMP >= 201307) && !defined(__PGI)
+//#elif defined(AMREX_USE_OMP) && defined(_OPENMP) && (_OPENMP >= 201307) && !defined(__PGI)
 //#define AMREX_PRAGMA_SIMD _Pragma("omp simd")
 
 #elif defined(__INTEL_COMPILER)

--- a/Src/Base/AMReX_FBI.H
+++ b/Src/Base/AMReX_FBI.H
@@ -369,7 +369,7 @@ FabArray<FAB>::FB_local_copy_cpu (const FB& TheFB, int scomp, int ncomp)
     bool is_thread_safe = TheFB.m_threadsafe_loc;
     if (is_thread_safe)
     {
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel for
 #endif
         for (int i = 0; i < N_locs; ++i)
@@ -397,7 +397,7 @@ FabArray<FAB>::FB_local_copy_cpu (const FB& TheFB, int scomp, int ncomp)
             loc_copy_tags[tag.dstIndex].push_back
                 ({this->fabPtr(tag.srcIndex), tag.dbox, tag.sbox.smallEnd()-tag.dbox.smallEnd()});
         }
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel
 #endif
         for (MFIter mfi(*this); mfi.isValid(); ++mfi)
@@ -1068,7 +1068,7 @@ FabArray<FAB>::pack_send_buffer_cpu (FabArray<FAB> const& src, int scomp, int nc
     const int N_snds = send_data.size();
     if (N_snds == 0) return;
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel for
 #endif
     for (int j = 0; j < N_snds; ++j)
@@ -1109,7 +1109,7 @@ FabArray<FAB>::unpack_recv_buffer_cpu (FabArray<FAB>& dst, int dcomp, int ncomp,
 
     if (is_thread_safe)
     {
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel for
 #endif
         for (int k = 0; k < N_rcvs; ++k)
@@ -1155,7 +1155,7 @@ FabArray<FAB>::unpack_recv_buffer_cpu (FabArray<FAB>& dst, int dcomp, int ncomp,
             }
         }
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel
 #endif
         for (MFIter mfi(dst); mfi.isValid(); ++mfi)

--- a/Src/Base/AMReX_FabArray.H
+++ b/Src/Base/AMReX_FabArray.H
@@ -13,7 +13,7 @@
 #include <set>
 #include <string>
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #include <omp.h>
 #endif
 
@@ -1472,7 +1472,7 @@ FabArray<FAB>::setBndry (value_type val,
 {
     if (n_grow.max() > 0)
     {
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
         for (MFIter fai(*this); fai.isValid(); ++fai)
@@ -1506,7 +1506,7 @@ FabArray<FAB>::setDomainBndry (value_type val,
         }
     }
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     for (MFIter fai(*this); fai.isValid(); ++fai)
@@ -1591,7 +1591,7 @@ FabArray<FAB>::setVal (value_type val,
 
     BL_PROFILE("FabArray::setVal()");
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     for (MFIter fai(*this,TilingIfNotGPU()); fai.isValid(); ++fai)
@@ -1631,7 +1631,7 @@ FabArray<FAB>::setVal (value_type val,
 
     BL_PROFILE("FabArray::setVal(val,region,comp,ncomp,nghost)");
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
     AMREX_ALWAYS_ASSERT(!omp_in_parallel());
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
@@ -1664,7 +1664,7 @@ FabArray<FAB>::abs (int comp, int ncomp, const IntVect& nghost)
 {
     BL_ASSERT(nghost.allGE(IntVect::TheZeroVector()) && nghost.allLE(n_grow));
     BL_ASSERT(comp+ncomp <= n_comp);
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     for (MFIter mfi(*this,TilingIfNotGPU()); mfi.isValid(); ++mfi)
@@ -1683,7 +1683,7 @@ template <class F, typename std::enable_if<IsBaseFab<F>::value,int>::type Z>
 void
 FabArray<FAB>::plus (value_type val, int comp, int num_comp, int nghost)
 {
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     for (MFIter mfi(*this,TilingIfNotGPU()); mfi.isValid(); ++mfi)
@@ -1702,7 +1702,7 @@ template <class F, typename std::enable_if<IsBaseFab<F>::value,int>::type Z>
 void
 FabArray<FAB>::plus (value_type val, const Box& region, int comp, int num_comp, int nghost)
 {
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     for (MFIter mfi(*this,TilingIfNotGPU()); mfi.isValid(); ++mfi)
@@ -1723,7 +1723,7 @@ template <class F, typename std::enable_if<IsBaseFab<F>::value,int>::type Z>
 void
 FabArray<FAB>::mult (value_type val, int comp, int num_comp, int nghost)
 {
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     for (MFIter mfi(*this,TilingIfNotGPU()); mfi.isValid(); ++mfi)
@@ -1742,7 +1742,7 @@ template <class F, typename std::enable_if<IsBaseFab<F>::value,int>::type Z>
 void
 FabArray<FAB>::mult (value_type val, const Box& region, int comp, int num_comp, int nghost)
 {
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     for (MFIter mfi(*this,TilingIfNotGPU()); mfi.isValid(); ++mfi)
@@ -1763,7 +1763,7 @@ template <class F, typename std::enable_if<IsBaseFab<F>::value,int>::type Z>
 void
 FabArray<FAB>::invert (value_type numerator, int comp, int num_comp, int nghost)
 {
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     for (MFIter mfi(*this,TilingIfNotGPU()); mfi.isValid(); ++mfi)
@@ -1782,7 +1782,7 @@ template <class F, typename std::enable_if<IsBaseFab<F>::value,int>::type Z>
 void
 FabArray<FAB>::invert (value_type numerator, const Box& region, int comp, int num_comp, int nghost)
 {
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     for (MFIter mfi(*this,TilingIfNotGPU()); mfi.isValid(); ++mfi)
@@ -1808,7 +1808,7 @@ FabArray<FAB>::shift (const IntVect& v)
       boxarray.shift(id, v[id]);
     }
     addThisBD();
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel
 #endif
     for (MFIter fai(*this); fai.isValid(); ++fai)
@@ -1977,7 +1977,7 @@ FabArray<FAB>::BuildMask (const Box& phys_domain, const Periodicity& period,
 	}
     }
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     for (MFIter mfi(*this,TilingIfNotGPU()); mfi.isValid(); ++mfi)
@@ -2020,7 +2020,7 @@ FabArray<FAB>::setVal (value_type val, const CommMetaData& thecmd, int scomp, in
         const CopyComTagsContainer&      LocTags = *(thecmd.m_LocTags);
         const MapOfCopyComTagContainers& RcvTags = *(thecmd.m_RcvTags);
         int N_locs = LocTags.size();
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel for if (thecmd.m_threadsafe_loc)
 #endif
         for (int i = 0; i < N_locs; ++i) {
@@ -2030,7 +2030,7 @@ FabArray<FAB>::setVal (value_type val, const CommMetaData& thecmd, int scomp, in
 
         for (auto it = RcvTags.begin(); it != RcvTags.end(); ++it) {
             int N = it->second.size();
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel for if (thecmd.m_threadsafe_rcv)
 #endif
             for (int i = 0; i < N; ++i) {
@@ -2047,7 +2047,7 @@ LayoutData<int>
 FabArray<FAB>::RecvLayoutMask (const CommMetaData& thecmd)
 {
     LayoutData<int> r(this->boxArray(), this->DistributionMap());
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (thecmd.m_threadsafe_rcv)
 #endif
     for (MFIter mfi(r); mfi.isValid(); ++mfi) {

--- a/Src/Base/AMReX_FabArrayBase.H
+++ b/Src/Base/AMReX_FabArrayBase.H
@@ -2,7 +2,7 @@
 #define BL_FABARRAYBASE_H_
 #include <AMReX_Config.H>
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #include <omp.h>
 #endif
 

--- a/Src/Base/AMReX_FabArrayBase.cpp
+++ b/Src/Base/AMReX_FabArrayBase.cpp
@@ -48,7 +48,7 @@ IntVect FabArrayBase::mfiter_tile_size(1024000,8,8);
 
 #endif
 
-#if defined(AMREX_USE_GPU) || !defined(_OPENMP)
+#if defined(AMREX_USE_GPU) || !defined(AMREX_USE_OMP)
 IntVect FabArrayBase::comm_tile_size(AMREX_D_DECL(1024000, 1024000, 1024000));
 IntVect FabArrayBase::mfghostiter_tile_size(AMREX_D_DECL(1024000, 1024000, 1024000));
 #else
@@ -388,7 +388,7 @@ FabArrayBase::CPC::define (const BoxArray& ba_dst, const DistributionMapping& dm
 #if defined(AMREX_USE_GPU)
         check_local = true;
         check_remote = true;
-#elif defined(_OPENMP)
+#elif defined(AMREX_USE_OMP)
 	if (omp_get_max_threads() > 1) {
 	    check_local = true;
 	    check_remote = true;
@@ -719,7 +719,7 @@ FabArrayBase::FB::define_fb (const FabArrayBase& fa)
 
     BaseFab<int> localtouch(The_Cpu_Arena()), remotetouch(The_Cpu_Arena());
     bool check_local = false, check_remote = false;
-#if defined(_OPENMP)
+#if defined(AMREX_USE_OMP)
     if (omp_get_max_threads() > 1) {
         check_local = true;
         check_remote = true;
@@ -939,7 +939,7 @@ FabArrayBase::FB::define_epo (const FabArrayBase& fa)
 
     BaseFab<int> localtouch(The_Cpu_Arena()), remotetouch(The_Cpu_Arena());
     bool check_local = false, check_remote = false;
-#if defined(_OPENMP)
+#if defined(AMREX_USE_OMP)
     if (omp_get_max_threads() > 1) {
 	check_local = true;
 	check_remote = true;
@@ -2110,7 +2110,7 @@ FabArrayBase::getTileArray (const IntVect& tilesize) const
 {
     TileArray* p;
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp critical(gettilearray)
 #endif
     {
@@ -2128,7 +2128,7 @@ FabArrayBase::getTileArray (const IntVect& tilesize) const
 					     m_TAC_stats.bytes);
 #endif
 	}
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp master
 #endif
 	{

--- a/Src/Base/AMReX_FabArrayCommI.H
+++ b/Src/Base/AMReX_FabArrayCommI.H
@@ -275,7 +275,7 @@ FabArray<FAB>::ParallelCopy (const FabArray<FAB>& src,
         // we're doing plus()s on cell-centered data.  Don't do plus()s on
         // non-cell-centered data this simplistic way.
         //
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
         for (MFIter fai(*this,TilingIfNotGPU()); fai.isValid(); ++fai)
@@ -720,7 +720,7 @@ FabArray<FAB>::Redistribute (const FabArray<FAB>& src,
 
     if (ParallelContext::NProcsSub() == 1)
     {
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
         for (MFIter fai(*this,true); fai.isValid(); ++fai)

--- a/Src/Base/AMReX_FabArrayUtility.H
+++ b/Src/Base/AMReX_FabArrayUtility.H
@@ -1808,7 +1808,7 @@ indexFromValue (FabArray<FAB> const& mf, int comp, IntVect const& nghost,
 
             if (priv_loc.allGT(IntVect::TheMinVector())) {
                 bool old;
-// we should be able to test on AMREX_USE_OMP < 201107 for capture (version 3.1)
+// we should be able to test on _OPENMP < 201107 for capture (version 3.1)
 // but we must work around a bug in gcc < 4.9
 #if defined(AMREX_USE_OMP) && defined(_OPENMP) && _OPENMP < 201307 // OpenMP 4.0
 #pragma omp critical (amrex_indexfromvalue)

--- a/Src/Base/AMReX_FabArrayUtility.H
+++ b/Src/Base/AMReX_FabArrayUtility.H
@@ -25,7 +25,7 @@ ReduceSum_host (FabArray<FAB> const& fa, IntVect const& nghost, F&& f)
     using value_type = typename FAB::value_type;
     value_type sm = 0;
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (!system::regtest_reduction) reduction(+:sm)
 #endif
     for (MFIter mfi(fa,true); mfi.isValid(); ++mfi)
@@ -128,7 +128,7 @@ ReduceSum_host (FabArray<FAB1> const& fa1, FabArray<FAB2> const& fa2,
     using value_type = typename FAB1::value_type;
     value_type sm = 0;
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (!system::regtest_reduction) reduction(+:sm)
 #endif
     for (MFIter mfi(fa1,true); mfi.isValid(); ++mfi)
@@ -241,7 +241,7 @@ ReduceSum_host (FabArray<FAB1> const& fa1, FabArray<FAB2> const& fa2,
     using value_type = typename FAB1::value_type;
     value_type sm = 0;
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (!system::regtest_reduction) reduction(+:sm)
 #endif
     for (MFIter mfi(fa1,true); mfi.isValid(); ++mfi)
@@ -353,7 +353,7 @@ ReduceMin_host (FabArray<FAB> const& fa, IntVect const& nghost, F&& f)
     constexpr value_type value_max = std::numeric_limits<value_type>::max();
     value_type r = value_max;
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel reduction(min:r)
 #endif
     for (MFIter mfi(fa,true); mfi.isValid(); ++mfi)
@@ -457,7 +457,7 @@ ReduceMin_host (FabArray<FAB1> const& fa1, FabArray<FAB2> const& fa2,
     constexpr value_type value_max = std::numeric_limits<value_type>::max();
     value_type r = value_max;
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel reduction(min:r)
 #endif
     for (MFIter mfi(fa1,true); mfi.isValid(); ++mfi)
@@ -570,7 +570,7 @@ ReduceMin_host (FabArray<FAB1> const& fa1, FabArray<FAB2> const& fa2,
     constexpr value_type value_max = std::numeric_limits<value_type>::max();
     value_type r = value_max;
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel reduction(min:r)
 #endif
     for (MFIter mfi(fa1,true); mfi.isValid(); ++mfi)
@@ -683,7 +683,7 @@ ReduceMax_host (FabArray<FAB> const& fa, IntVect const& nghost, F&& f)
     constexpr value_type value_lowest = std::numeric_limits<value_type>::lowest();
     value_type r = value_lowest;
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel reduction(max:r)
 #endif
     for (MFIter mfi(fa,true); mfi.isValid(); ++mfi)
@@ -788,7 +788,7 @@ ReduceMax_host (FabArray<FAB1> const& fa1, FabArray<FAB2> const& fa2,
     constexpr value_type value_lowest = std::numeric_limits<value_type>::lowest();
     value_type r = value_lowest;
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel reduction(max:r)
 #endif
     for (MFIter mfi(fa1,true); mfi.isValid(); ++mfi)
@@ -901,7 +901,7 @@ ReduceMax_host (FabArray<FAB1> const& fa1, FabArray<FAB2> const& fa2,
     constexpr value_type value_lowest = std::numeric_limits<value_type>::lowest();
     value_type r = value_lowest;
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel reduction(max:r)
 #endif
     for (MFIter mfi(fa1,true); mfi.isValid(); ++mfi)
@@ -1012,7 +1012,7 @@ ReduceLogicalAnd_host (FabArray<FAB> const& fa, IntVect const& nghost, F&& f)
 {
     int r = true;
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel reduction(&&:r)
 #endif
     for (MFIter mfi(fa,true); mfi.isValid(); ++mfi)
@@ -1115,7 +1115,7 @@ ReduceLogicalAnd_host (FabArray<FAB1> const& fa1, FabArray<FAB2> const& fa2,
 {
     int r = true;
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel reduction(&&:r)
 #endif
     for (MFIter mfi(fa1,true); mfi.isValid(); ++mfi)
@@ -1223,7 +1223,7 @@ ReduceLogicalOr_host (FabArray<FAB> const& fa, IntVect const& nghost, F&& f)
 {
     int r = false;
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel reduction(||:r)
 #endif
     for (MFIter mfi(fa,true); mfi.isValid(); ++mfi)
@@ -1326,7 +1326,7 @@ ReduceLogicalOr_host (FabArray<FAB1> const& fa1, FabArray<FAB2> const& fa2,
 {
     int r = false;
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel reduction(||:r)
 #endif
     for (MFIter mfi(fa1,true); mfi.isValid(); ++mfi)
@@ -1460,7 +1460,7 @@ template <class FAB,
 void
 Add (FabArray<FAB>& dst, FabArray<FAB> const& src, int srccomp, int dstcomp, int numcomp, const IntVect& nghost)
 {
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     for (MFIter mfi(dst,TilingIfNotGPU()); mfi.isValid(); ++mfi)
@@ -1492,7 +1492,7 @@ template <class FAB,
 void
 Copy (FabArray<FAB>& dst, FabArray<FAB> const& src, int srccomp, int dstcomp, int numcomp, const IntVect& nghost)
 {
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     for (MFIter mfi(dst,TilingIfNotGPU()); mfi.isValid(); ++mfi)
@@ -1524,7 +1524,7 @@ template <class FAB,
 void
 Subtract (FabArray<FAB>& dst, FabArray<FAB> const& src, int srccomp, int dstcomp, int numcomp, const IntVect& nghost)
 {
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     for (MFIter mfi(dst,TilingIfNotGPU()); mfi.isValid(); ++mfi)
@@ -1556,7 +1556,7 @@ template <class FAB,
 void
 Multiply (FabArray<FAB>& dst, FabArray<FAB> const& src, int srccomp, int dstcomp, int numcomp, const IntVect& nghost)
 {
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     for (MFIter mfi(dst,TilingIfNotGPU()); mfi.isValid(); ++mfi)
@@ -1588,7 +1588,7 @@ template <class FAB,
 void
 Divide (FabArray<FAB>& dst, FabArray<FAB> const& src, int srccomp, int dstcomp, int numcomp, const IntVect& nghost)
 {
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     for (MFIter mfi(dst,TilingIfNotGPU()); mfi.isValid(); ++mfi)
@@ -1619,7 +1619,7 @@ template <class FAB,
 void
 Abs (FabArray<FAB>& fa, int icomp, int numcomp, const IntVect& nghost)
 {
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     for (MFIter mfi(fa,TilingIfNotGPU()); mfi.isValid(); ++mfi)
@@ -1679,7 +1679,7 @@ OverrideSync (FabArray<FAB> & fa, FabArray<IFAB> const& msk, const Periodicity& 
     
     const int ncomp = fa.nComp();
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     for (MFIter mfi(fa,TilingIfNotGPU()); mfi.isValid(); ++mfi)
@@ -1791,7 +1791,7 @@ indexFromValue (FabArray<FAB> const& mf, int comp, IntVect const& nghost,
 #endif
     {
         bool f = false;
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel
 #endif
         {
@@ -1808,11 +1808,11 @@ indexFromValue (FabArray<FAB> const& mf, int comp, IntVect const& nghost,
 
             if (priv_loc.allGT(IntVect::TheMinVector())) {
                 bool old;
-// we should be able to test on _OPENMP < 201107 for capture (version 3.1)
+// we should be able to test on AMREX_USE_OMP < 201107 for capture (version 3.1)
 // but we must work around a bug in gcc < 4.9
-#if defined(_OPENMP) && _OPENMP < 201307 // OpenMP 4.0
+#if defined(AMREX_USE_OMP) && defined(_OPENMP) && _OPENMP < 201307 // OpenMP 4.0
 #pragma omp critical (amrex_indexfromvalue)
-#elif defined(_OPENMP)
+#elif defined(AMREX_USE_OMP)
 #pragma omp atomic capture
 #endif
                 {

--- a/Src/Base/AMReX_Geometry.H
+++ b/Src/Base/AMReX_Geometry.H
@@ -5,7 +5,7 @@
 #include <iosfwd>
 #include <map>
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #include <omp.h>
 #endif
 

--- a/Src/Base/AMReX_Geometry.cpp
+++ b/Src/Base/AMReX_Geometry.cpp
@@ -199,7 +199,7 @@ Geometry::GetVolume (MultiFab&       vol,
 void
 Geometry::GetVolume (MultiFab&       vol) const
 {
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     for (MFIter mfi(vol,TilingIfNotGPU()); mfi.isValid(); ++mfi)
@@ -226,7 +226,7 @@ Geometry::GetDLogA (MultiFab&       dloga,
                     int             ngrow) const
 {
     dloga.define(grds,dm,1,ngrow,MFInfo(),FArrayBoxFactory());
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     for (MFIter mfi(dloga,TilingIfNotGPU()); mfi.isValid(); ++mfi)
@@ -254,7 +254,7 @@ void
 Geometry::GetFaceArea (MultiFab&       area,
                        int             dir) const
 {
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     for (MFIter mfi(area,TilingIfNotGPU()); mfi.isValid(); ++mfi)

--- a/Src/Base/AMReX_GpuAtomic.H
+++ b/Src/Base/AMReX_GpuAtomic.H
@@ -443,7 +443,7 @@ namespace HostDevice { namespace Atomic {
 #if AMREX_DEVICE_COMPILE
         Gpu::Atomic::AddNoRet(sum,value);
 #else
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp atomic update
 #endif
         *sum += value;

--- a/Src/Base/AMReX_GpuReduce.H
+++ b/Src/Base/AMReX_GpuReduce.H
@@ -363,7 +363,7 @@ template <typename T>
 AMREX_FORCE_INLINE
 void deviceReduceSum_full (T * dest, T source) noexcept
 {
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp atomic
 #endif
     *dest += source;
@@ -380,7 +380,7 @@ template <typename T>
 AMREX_FORCE_INLINE
 void deviceReduceMin_full (T * dest, T source) noexcept
 {
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp critical (gpureduce_reducemin)
 #endif
     *dest = std::min(*dest, source);
@@ -397,7 +397,7 @@ template <typename T>
 AMREX_FORCE_INLINE
 void deviceReduceMax_full (T * dest, T source) noexcept
 {
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp critical (gpureduce_reducemax)
 #endif
     *dest = std::max(*dest, source);
@@ -413,7 +413,7 @@ void deviceReduceMax (T * dest, T source, Gpu::Handler const&) noexcept
 AMREX_FORCE_INLINE
 void deviceReduceLogicalAnd_full (int * dest, int source) noexcept
 {
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp critical (gpureduce_reduceand)
 #endif
     *dest = (*dest) && source;
@@ -428,7 +428,7 @@ void deviceReduceLogicalAnd (int * dest, int source, Gpu::Handler const&) noexce
 AMREX_FORCE_INLINE
 void deviceReduceLogicalOr_full (int * dest, int source) noexcept
 {
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp critical (gpureduce_reduceor)
 #endif
     *dest = (*dest) || source;

--- a/Src/Base/AMReX_GpuUtility.cpp
+++ b/Src/Base/AMReX_GpuUtility.cpp
@@ -1,7 +1,7 @@
 
 #include <AMReX_GpuUtility.H>
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #include <omp.h>
 #endif
 
@@ -39,7 +39,7 @@ StreamIter::init() noexcept
     amrex::ignore_unused(m_sync);
 #if defined(AMREX_USE_GPU)
     Gpu::Device::setStreamIndex(m_i);
-#elif defined(_OPENMP)
+#elif defined(AMREX_USE_OMP)
     int nthreads = omp_get_num_threads();
     if (nthreads > 1) {
         int tid = omp_get_thread_num();

--- a/Src/Base/AMReX_MFIter.H
+++ b/Src/Base/AMReX_MFIter.H
@@ -12,7 +12,7 @@
 
 #include <AMReX_Gpu.H>
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #include <omp.h>
 #endif
 

--- a/Src/Base/AMReX_MFIter.cpp
+++ b/Src/Base/AMReX_MFIter.cpp
@@ -87,7 +87,7 @@ MFIter::MFIter (const BoxArray& ba, const DistributionMapping& dm, unsigned char
     local_tile_index_map(nullptr),
     num_local_tiles(nullptr)
 {
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp single
 #endif
     {
@@ -111,7 +111,7 @@ MFIter::MFIter (const BoxArray& ba, const DistributionMapping& dm, bool do_tilin
     local_tile_index_map(nullptr),
     num_local_tiles(nullptr)
 {
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp single
 #endif
     {
@@ -137,7 +137,7 @@ MFIter::MFIter (const BoxArray& ba, const DistributionMapping& dm,
     local_tile_index_map(nullptr),
     num_local_tiles(nullptr)
 {
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp single
 #endif
     {
@@ -162,13 +162,13 @@ MFIter::MFIter (const BoxArray& ba, const DistributionMapping& dm, const MFItInf
     local_tile_index_map(nullptr),
     num_local_tiles(nullptr)
 {
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp single
 #endif
     {
         m_fa->addThisBD();
     }
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
     if (dynamic) {
 #pragma omp barrier
 #pragma omp single
@@ -194,7 +194,7 @@ MFIter::MFIter (const FabArrayBase& fabarray_, const MFItInfo& info)
     local_tile_index_map(nullptr),
     num_local_tiles(nullptr)
 {
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
     if (dynamic) {
 #pragma omp barrier
 #pragma omp single
@@ -209,7 +209,7 @@ MFIter::MFIter (const FabArrayBase& fabarray_, const MFItInfo& info)
 
 MFIter::~MFIter ()
 {
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp master
 #endif
     {
@@ -235,7 +235,7 @@ MFIter::~MFIter ()
 #endif
 
     if (m_fa) {
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp barrier
 #pragma omp single
 #endif
@@ -246,7 +246,7 @@ MFIter::~MFIter ()
 void
 MFIter::Initialize ()
 {
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp master
 #endif
     {
@@ -313,7 +313,7 @@ MFIter::Initialize ()
 	    }
 	}
 	
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 	int nthreads = omp_get_num_threads();
 	if (nthreads > 1)
 	{
@@ -494,7 +494,7 @@ MFIter::grownnodaltilebox (int dir, IntVect const& a_ng) const noexcept
 void
 MFIter::operator++ () noexcept
 {
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
     if (dynamic)
     {
 #pragma omp atomic capture

--- a/Src/Base/AMReX_MemPool.cpp
+++ b/Src/Base/AMReX_MemPool.cpp
@@ -55,7 +55,7 @@ void amrex_mempool_init ()
 #endif
 	}
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel num_threads(nthreads)
 #endif
 	{

--- a/Src/Base/AMReX_MultiFab.cpp
+++ b/Src/Base/AMReX_MultiFab.cpp
@@ -59,7 +59,7 @@ MultiFab::Dot (const MultiFab& x, int xcomp,
     } else
 #endif
     {
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel reduction(+:sm)
 #endif
         for (MFIter mfi(x,true); mfi.isValid(); ++mfi)
@@ -209,7 +209,7 @@ MultiFab::Swap (MultiFab& dst, MultiFab& src,
 
     } else {
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
         for (MFIter mfi(dst,TilingIfNotGPU()); mfi.isValid(); ++mfi)
@@ -308,7 +308,7 @@ MultiFab::Saxpy (MultiFab& dst, Real a, const MultiFab& src,
 
     BL_PROFILE("MultiFab::Saxpy()");
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     for (MFIter mfi(dst,TilingIfNotGPU()); mfi.isValid(); ++mfi)
@@ -343,7 +343,7 @@ MultiFab::Xpay (MultiFab& dst, Real a, const MultiFab& src,
 
     BL_PROFILE("MultiFab::Xpay()");
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     for (MFIter mfi(dst,TilingIfNotGPU()); mfi.isValid(); ++mfi)
@@ -383,7 +383,7 @@ MultiFab::LinComb (MultiFab& dst,
 
     BL_PROFILE("MultiFab::LinComb()");
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     for (MFIter mfi(dst,TilingIfNotGPU()); mfi.isValid(); ++mfi)
@@ -425,7 +425,7 @@ MultiFab::AddProduct (MultiFab& dst,
 
     BL_PROFILE("MultiFab::AddProduct()");
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     for (MFIter mfi(dst,TilingIfNotGPU()); mfi.isValid(); ++mfi)
@@ -605,7 +605,7 @@ MultiFab::define (const BoxArray&            bxs,
 void
 MultiFab::initVal ()
 {
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     for (MFIter mfi(*this); mfi.isValid(); ++mfi)
@@ -1227,7 +1227,7 @@ MultiFab::OverlapMask (const Periodicity& period) const
     Vector<Array4BoxTag<Real> > tags;
 
     bool run_on_gpu = Gpu::inLaunchRegion();
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (!run_on_gpu)
 #endif
     {

--- a/Src/Base/AMReX_MultiFabUtil.H
+++ b/Src/Base/AMReX_MultiFabUtil.H
@@ -194,7 +194,7 @@ namespace amrex
     {
         T mf_out(mf_in.boxArray(), mf_in.DistributionMap(), mf_in.nComp(), mf_in.nGrowVect());
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
         for (MFIter mfi(mf_in); mfi.isValid(); ++mfi)
@@ -283,7 +283,7 @@ void average_down_nodal (const FabArray<FAB>& fine, FabArray<FAB>& crse,
 
     if (mfiter_is_definitely_safe || isMFIterSafe(fine, crse))
     {
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
         for (MFIter mfi(crse,TilingIfNotGPU()); mfi.isValid(); ++mfi)

--- a/Src/Base/AMReX_MultiFabUtil.cpp
+++ b/Src/Base/AMReX_MultiFabUtil.cpp
@@ -58,7 +58,7 @@ namespace amrex
     void average_node_to_cellcenter (MultiFab& cc, int dcomp,
          const MultiFab& nd, int scomp, int ncomp, int ngrow)
     {
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
         for (MFIter mfi(cc,TilingIfNotGPU()); mfi.isValid(); ++mfi)
@@ -80,7 +80,7 @@ namespace amrex
         AMREX_ASSERT(cc.nComp() >= dcomp + AMREX_SPACEDIM);
         AMREX_ASSERT(edge.size() == AMREX_SPACEDIM);
         AMREX_ASSERT(edge[0]->nComp() == 1);
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
         for (MFIter mfi(cc,TilingIfNotGPU()); mfi.isValid(); ++mfi)
@@ -121,7 +121,7 @@ namespace amrex
         AMREX_ASSERT(cc.nComp() >= dcomp + AMREX_SPACEDIM);
         AMREX_ASSERT(fc[0]->nComp() == 1);
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
         for (MFIter mfi(cc,TilingIfNotGPU()); mfi.isValid(); ++mfi)
@@ -156,7 +156,7 @@ namespace amrex
         const GeometryData gd = geom.data();
         amrex::ignore_unused(gd);
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
         for (MFIter mfi(cc,TilingIfNotGPU()); mfi.isValid(); ++mfi)
@@ -202,7 +202,7 @@ namespace amrex
         amrex::ignore_unused(geom);
 #endif
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
 	for (MFIter mfi(cc,TilingIfNotGPU()); mfi.isValid(); ++mfi)
@@ -277,7 +277,7 @@ namespace amrex
 	MultiFab fvolume;
 	fgeom.GetVolume(fvolume, fine_BA, fine_dm, 0);
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
         for (MFIter mfi(crse_S_fine,TilingIfNotGPU()); mfi.isValid(); ++mfi)
@@ -327,7 +327,7 @@ namespace amrex
 
         MultiFab crse_S_fine(crse_S_fine_BA, S_fine.DistributionMap(), ncomp, nGrow, MFInfo(), FArrayBoxFactory());
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
         for (MFIter mfi(crse_S_fine, TilingIfNotGPU()); mfi.isValid(); ++mfi)
@@ -364,7 +364,7 @@ namespace amrex
 
         if (crse_S_fine_BA == S_crse.boxArray() && S_fine.DistributionMap() == S_crse.DistributionMap())
         {
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
             for (MFIter mfi(S_crse,TilingIfNotGPU()); mfi.isValid(); ++mfi)
@@ -391,7 +391,7 @@ namespace amrex
         {
             MultiFab crse_S_fine(crse_S_fine_BA, S_fine.DistributionMap(), ncomp, 0, MFInfo(), FArrayBoxFactory());
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
             for (MFIter mfi(crse_S_fine,TilingIfNotGPU()); mfi.isValid(); ++mfi)
@@ -477,7 +477,7 @@ namespace amrex
         const int ncomp = crse.nComp();
         if (isMFIterSafe(fine, crse))
         {
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
             for (MFIter mfi(crse,TilingIfNotGPU()); mfi.isValid(); ++mfi)
@@ -559,7 +559,7 @@ namespace amrex
         const int ncomp = crse.nComp();
         if (isMFIterSafe(fine, crse))
         {
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if(Gpu::notInLaunchRegion())
 #endif
             for (MFIter mfi(crse,TilingIfNotGPU()); mfi.isValid(); ++mfi)
@@ -624,7 +624,7 @@ namespace amrex
         Vector<int> slice_to_full_ba_map;
         std::unique_ptr<MultiFab> slice = allocateSlice(dir, cc, ncomp, geom, coord, slice_to_full_ba_map);
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
         for (MFIter mfi(*slice, TilingIfNotGPU()); mfi.isValid(); ++mfi)
@@ -678,7 +678,7 @@ namespace amrex
 
         const BoxArray& cfba = amrex::coarsen(fba,ratio);
         const std::vector<IntVect>& pshifts = period.shiftIntVect();
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (!run_on_gpu)
 #endif
         {
@@ -756,7 +756,7 @@ namespace amrex
 
         const GpuArray<Real,AMREX_SPACEDIM> dxinv = geom.InvCellSizeArray();
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
         for (MFIter mfi(divu,TilingIfNotGPU()); mfi.isValid(); ++mfi)
@@ -806,7 +806,7 @@ namespace amrex
 
         const GpuArray<Real,AMREX_SPACEDIM> dxinv = geom.InvCellSizeArray();
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
         for (MFIter mfi(grad,TilingIfNotGPU()); mfi.isValid(); ++mfi)

--- a/Src/Base/AMReX_NonLocalBCImpl.H
+++ b/Src/Base/AMReX_NonLocalBCImpl.H
@@ -163,7 +163,7 @@ local_copy_cpu (FabArray<FAB>& mf, int scomp, int ncomp, FabArrayBase::CommMetaD
     auto const& LocTags = *(cmd.m_LocTags);
     int N_locs = LocTags.size();
     if (N_locs == 0) return;
-#ifdef _OPENMP
+#ifdef _OPENMP // Note: intentionally not AMREX_USE_OMP
 #pragma omp parallel for
 #endif
     for (int itag = 0; itag < N_locs; ++itag) {
@@ -192,7 +192,7 @@ unpack_recv_buffer_cpu (FabArray<FAB>& mf, int scomp, int ncomp,
     if (N_rcvs == 0) return;
 
     using T = typename FAB::value_type;
-#ifdef _OPENMP
+#ifdef _OPENMP // Note: intentionally not AMREX_USE_OMP
 #pragma omp parallel for
 #endif
     for (int ircv = 0; ircv < N_rcvs; ++ircv) {
@@ -480,7 +480,7 @@ Rotate90 (FabArray<FAB>& mf, int scomp, int ncomp, IntVect const& nghost, Box co
     auto handler = Comm_nowait(mf, scomp, ncomp, TheRB90,Rotate90DstToSrc{});
 
     Box corner(-nghost, IntVect{AMREX_D_DECL(-1,-1,domain.bigEnd(2)+nghost[2])});
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     for (MFIter mfi(mf); mfi.isValid(); ++mfi) {

--- a/Src/Base/AMReX_NonLocalBCImpl.H
+++ b/Src/Base/AMReX_NonLocalBCImpl.H
@@ -163,7 +163,7 @@ local_copy_cpu (FabArray<FAB>& mf, int scomp, int ncomp, FabArrayBase::CommMetaD
     auto const& LocTags = *(cmd.m_LocTags);
     int N_locs = LocTags.size();
     if (N_locs == 0) return;
-#ifdef _OPENMP // Note: intentionally not AMREX_USE_OMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel for
 #endif
     for (int itag = 0; itag < N_locs; ++itag) {
@@ -192,7 +192,7 @@ unpack_recv_buffer_cpu (FabArray<FAB>& mf, int scomp, int ncomp,
     if (N_rcvs == 0) return;
 
     using T = typename FAB::value_type;
-#ifdef _OPENMP // Note: intentionally not AMREX_USE_OMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel for
 #endif
     for (int ircv = 0; ircv < N_rcvs; ++ircv) {

--- a/Src/Base/AMReX_OpenMP.H
+++ b/Src/Base/AMReX_OpenMP.H
@@ -2,7 +2,7 @@
 #define AMREX_OPENMP_H_
 #include <AMReX_Config.H>
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #include <omp.h>
 
 namespace amrex {

--- a/Src/Base/AMReX_PCI.H
+++ b/Src/Base/AMReX_PCI.H
@@ -12,7 +12,7 @@ FabArray<FAB>::PC_local_cpu (const CPC& thecpc, FabArray<FAB> const& src,
 
     if (is_thread_safe)
     {
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel for
 #endif
         for (int i = 0; i < N_locs; ++i)
@@ -45,7 +45,7 @@ FabArray<FAB>::PC_local_cpu (const CPC& thecpc, FabArray<FAB> const& src,
             }
         }
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel
 #endif
         for (MFIter mfi(*this); mfi.isValid(); ++mfi)

--- a/Src/Base/AMReX_ParallelDescriptor.H
+++ b/Src/Base/AMReX_ParallelDescriptor.H
@@ -19,7 +19,7 @@
 #include <atomic>
 #endif
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #include <omp.h>
 #endif
 
@@ -161,7 +161,7 @@ while ( false )
         //! memory fence
 	void MemoryBarrier () const {
 	    if (m_size > 1) {
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 		if (omp_in_parallel()) {
                     #pragma omp barrier
 	        }
@@ -351,7 +351,7 @@ while ( false )
 	    }
 	}
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 	int nthreads = omp_get_num_threads();
 	if (nthreads > 1) {
 	    int tid = omp_get_thread_num();

--- a/Src/Base/AMReX_ParallelDescriptor.cpp
+++ b/Src/Base/AMReX_ParallelDescriptor.cpp
@@ -31,7 +31,7 @@
 #include <AMReX_ParmParse.H>
 #endif
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #include <omp.h>
 #endif
 

--- a/Src/Base/AMReX_PhysBCFunct.H
+++ b/Src/Base/AMReX_PhysBCFunct.H
@@ -152,7 +152,7 @@ public:
             }
         }
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
         {

--- a/Src/Base/AMReX_Print.H
+++ b/Src/Base/AMReX_Print.H
@@ -175,7 +175,7 @@ namespace amrex
             if (rank == AllProcs || rank == my_proc) {
                 int my_proc_global = ParallelDescriptor::MyProc();
                 std::string proc_file_name = file_name + "." + std::to_string(my_proc_global);
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
                 proc_file_name += "." + std::to_string(omp_get_thread_num());
 #endif
                 ofs.open(proc_file_name, std::ios_base::app);

--- a/Src/Base/AMReX_Random.cpp
+++ b/Src/Base/AMReX_Random.cpp
@@ -93,7 +93,7 @@ amrex::InitRandom (amrex::ULong seed, int nprocs)
     nthreads = OpenMP::get_max_threads();
     generators.resize(nthreads);
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel
 #endif
     {

--- a/Src/Base/AMReX_Reduce.H
+++ b/Src/Base/AMReX_Reduce.H
@@ -842,7 +842,7 @@ template <typename T, typename N, typename F,
 T Sum (N n, F&& f, T init_val = 0)
 {
     T r = init_val;
-#ifdef _OPENMP
+#ifdef _OPENMP // Note: intentionally not AMREX_USE_OMP
 #pragma omp parallel for reduction(+:r)
 #endif
     for (N i = 0; i < n; ++i) {
@@ -879,7 +879,7 @@ template <typename T, typename N, typename F,
 T Min (N n, F&& f, T init_val = std::numeric_limits<T>::max())
 {
     T r = init_val;
-#ifdef _OPENMP
+#ifdef _OPENMP // Note: intentionally not AMREX_USE_OMP
 #pragma omp parallel for reduction(min:r)
 #endif
     for (N i = 0; i < n; ++i) {
@@ -916,7 +916,7 @@ template <typename T, typename N, typename F,
 T Max (N n, F&& f, T init_val = std::numeric_limits<T>::lowest())
 {
     T r = init_val;
-#ifdef _OPENMP
+#ifdef _OPENMP // Note: intentionally not AMREX_USE_OMP
 #pragma omp parallel for reduction(max:r)
 #endif
     for (N i = 0; i < n; ++i) {
@@ -957,7 +957,7 @@ std::pair<T,T> Min (N n, F&& f)
 {
     T r_min = std::numeric_limits<T>::max();
     T r_max = std::numeric_limits<T>::lowest();
-#ifdef _OPENMP
+#ifdef _OPENMP // Note: intentionally not AMREX_USE_OMP
 #pragma omp parallel for reduction(min:r_min) reduction(max:r_max)
 #endif
     for (N i = 0; i < n; ++i) {

--- a/Src/Base/AMReX_Reduce.H
+++ b/Src/Base/AMReX_Reduce.H
@@ -842,7 +842,7 @@ template <typename T, typename N, typename F,
 T Sum (N n, F&& f, T init_val = 0)
 {
     T r = init_val;
-#ifdef _OPENMP // Note: intentionally not AMREX_USE_OMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel for reduction(+:r)
 #endif
     for (N i = 0; i < n; ++i) {
@@ -879,7 +879,7 @@ template <typename T, typename N, typename F,
 T Min (N n, F&& f, T init_val = std::numeric_limits<T>::max())
 {
     T r = init_val;
-#ifdef _OPENMP // Note: intentionally not AMREX_USE_OMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel for reduction(min:r)
 #endif
     for (N i = 0; i < n; ++i) {
@@ -916,7 +916,7 @@ template <typename T, typename N, typename F,
 T Max (N n, F&& f, T init_val = std::numeric_limits<T>::lowest())
 {
     T r = init_val;
-#ifdef _OPENMP // Note: intentionally not AMREX_USE_OMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel for reduction(max:r)
 #endif
     for (N i = 0; i < n; ++i) {
@@ -957,7 +957,7 @@ std::pair<T,T> Min (N n, F&& f)
 {
     T r_min = std::numeric_limits<T>::max();
     T r_max = std::numeric_limits<T>::lowest();
-#ifdef _OPENMP // Note: intentionally not AMREX_USE_OMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel for reduction(min:r_min) reduction(max:r_max)
 #endif
     for (N i = 0; i < n; ++i) {

--- a/Src/Base/AMReX_TinyProfiler.cpp
+++ b/Src/Base/AMReX_TinyProfiler.cpp
@@ -22,7 +22,7 @@
 #include <cupti.h>
 #endif
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #include <omp.h>
 #endif
 
@@ -72,7 +72,7 @@ TinyProfiler::~TinyProfiler ()
 void
 TinyProfiler::start () noexcept
 {
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp master
 #endif
     if (stats.empty() && !regionstack.empty())
@@ -111,7 +111,7 @@ TinyProfiler::start () noexcept
 void
 TinyProfiler::stop () noexcept
 {
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp master
 #endif
     if (!stats.empty()) 
@@ -188,7 +188,7 @@ TinyProfiler::stop () noexcept
 void
 TinyProfiler::stop (unsigned boxUintID) noexcept
 {
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp master
 #endif
     if (!stats.empty()) 

--- a/Src/Base/AMReX_Utility.cpp
+++ b/Src/Base/AMReX_Utility.cpp
@@ -9,7 +9,7 @@
 #include <AMReX_BoxArray.H>
 #include <AMReX_Print.H>
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #include <omp.h>
 #endif
 

--- a/Src/Base/AMReX_iMultiFab.cpp
+++ b/Src/Base/AMReX_iMultiFab.cpp
@@ -353,7 +353,7 @@ iMultiFab::sum (int comp, int nghost, bool local) const
     else
 #endif
     {
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (!system::regtest_reduction) reduction(+:sm)
 #endif
         for (MFIter mfi(*this,true); mfi.isValid(); ++mfi)
@@ -547,7 +547,7 @@ OwnerMask (FabArrayBase const& mf, const Periodicity& period, const IntVect& ngr
     Vector<Array4BoxTag<int> > tags;
 
     bool run_on_gpu = Gpu::inLaunchRegion();
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (!run_on_gpu)
 #endif
     {

--- a/Src/Base/AMReX_omp_mod.F90
+++ b/Src/Base/AMReX_omp_mod.F90
@@ -4,7 +4,7 @@ module amrex_omp_module
 
   implicit none
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
   integer, parameter :: amrex_omp_support = (_OPENMP)
 #else
   integer, parameter :: amrex_omp_support = 0 ! Should this be allowed??
@@ -46,4 +46,3 @@ contains
 end module amrex_omp_module
 
 #endif
-

--- a/Src/Boundary/AMReX_BndryRegister.cpp
+++ b/Src/Boundary/AMReX_BndryRegister.cpp
@@ -66,7 +66,7 @@ BndryRegister::init (const BndryRegister& src)
         const int ncomp = src.bndry[idim].nComp();
         bndry[idim].define(src.bndry[idim].boxArray(), src.DistributionMap(), ncomp);
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
         for (FabSetIter mfi(src.bndry[idim]); mfi.isValid(); ++mfi)
@@ -160,7 +160,7 @@ BndryRegister::operator+= (const BndryRegister& rhs)
     for (OrientationIter face; face; ++face) {
         const auto f = face();
         const int ncomp = bndry[f].nComp();
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
 	for (FabSetIter bfsi(rhs[f]); bfsi.isValid(); ++bfsi) {

--- a/Src/Boundary/AMReX_FabSet.cpp
+++ b/Src/Boundary/AMReX_FabSet.cpp
@@ -4,7 +4,7 @@
 #include <AMReX_BLProfiler.H>
 #include <AMReX_VisMF.H>
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #include <omp.h>
 #endif
 
@@ -27,7 +27,7 @@ FabSet&
 FabSet::copyFrom (const FabSet& src, int scomp, int dcomp, int ncomp)
 {
     if (boxArray() == src.boxArray() && DistributionMap() == src.DistributionMap()) {
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
 	for (FabSetIter fsi(*this); fsi.isValid(); ++fsi) {
@@ -58,7 +58,7 @@ FabSet&
 FabSet::plusFrom (const FabSet& src, int scomp, int dcomp, int ncomp)
 {
     if (boxArray() == src.boxArray() && DistributionMap() == src.DistributionMap()) {
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
 	for (FabSetIter fsi(*this); fsi.isValid(); ++fsi) {
@@ -105,7 +105,7 @@ void
 FabSet::setVal (Real val)
 {
     const int ncomp = nComp();
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     for (FabSetIter fsi(*this); fsi.isValid(); ++fsi) {
@@ -121,7 +121,7 @@ FabSet::setVal (Real val)
 void
 FabSet::setVal (Real val, int comp, int num_comp)
 {
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     for (FabSetIter fsi(*this); fsi.isValid(); ++fsi) {
@@ -141,7 +141,7 @@ FabSet::linComb (Real a, Real b, const FabSet& src, int scomp, int dcomp, int nc
 {
     BL_ASSERT(size() == src.size());
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     for (FabSetIter fsi(*this); fsi.isValid(); ++fsi)
@@ -173,7 +173,7 @@ FabSet::linComb (Real a, const MultiFab& mfa, int a_comp,
     MultiFab bdrya(boxArray(),DistributionMap(),ncomp,0,MFInfo(),FArrayBoxFactory());
     MultiFab bdryb(boxArray(),DistributionMap(),ncomp,0,MFInfo(),FArrayBoxFactory());
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     for (MFIter mfi(bdrya); mfi.isValid(); ++mfi) // tiling is not safe for this BoxArray
@@ -196,7 +196,7 @@ FabSet::linComb (Real a, const MultiFab& mfa, int a_comp,
     bdrya.copy(mfa,a_comp,0,ncomp,ngrow,0);
     bdryb.copy(mfb,b_comp,0,ncomp,ngrow,0);
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     for (FabSetIter fsi(*this); fsi.isValid(); ++fsi)
@@ -239,7 +239,7 @@ FabSet::Copy (FabSet& dst, const FabSet& src)
     BL_ASSERT(amrex::match(dst.boxArray(), src.boxArray()));
     BL_ASSERT(dst.DistributionMap() == src.DistributionMap());
     int ncomp = dst.nComp();
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     for (FabSetIter fsi(dst); fsi.isValid(); ++fsi) {

--- a/Src/Boundary/AMReX_InterpBndryData.cpp
+++ b/Src/Boundary/AMReX_InterpBndryData.cpp
@@ -92,7 +92,7 @@ InterpBndryData::setBndryValues (const MultiFab& mf,
 	setBndryConds(bc, ref_ratio, n);
     }
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     for (MFIter mfi(mf,MFItInfo().SetDynamic(true)); mfi.isValid(); ++mfi)
@@ -182,7 +182,7 @@ InterpBndryData::BndryValuesDoIt (BndryRegister&  crse,
 
         MFItInfo info;
         if (Gpu::notInLaunchRegion()) info.SetDynamic(true);
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
         for (MFIter mfi(foo,info); mfi.isValid(); ++mfi)

--- a/Src/Boundary/AMReX_MultiMask.H
+++ b/Src/Boundary/AMReX_MultiMask.H
@@ -6,7 +6,7 @@
 #include <AMReX_FabArray.H>
 #include <AMReX_Geometry.H>
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #include <omp.h>
 #endif
 

--- a/Src/Boundary/AMReX_MultiMask.cpp
+++ b/Src/Boundary/AMReX_MultiMask.cpp
@@ -44,7 +44,7 @@ MultiMask::define (const BoxArray& regba, const DistributionMapping& dm, const G
             }
         }
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
         for (MFIter mfi(m_fa); mfi.isValid(); ++mfi)
@@ -77,7 +77,7 @@ MultiMask::Copy (MultiMask& dst, const MultiMask& src)
     BL_ASSERT(dst.boxArray() == src.boxArray());
     BL_ASSERT(dst.DistributionMap() == src.DistributionMap());
     const int ncomp = dst.nComp();
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     for (MFIter mfi(dst.m_fa); mfi.isValid(); ++mfi) {

--- a/Src/Boundary/AMReX_YAFluxRegister.cpp
+++ b/Src/Boundary/AMReX_YAFluxRegister.cpp
@@ -2,7 +2,7 @@
 #include <AMReX_YAFluxRegister.H>
 #include <AMReX_YAFluxRegister_K.H>
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #include <omp.h>
 #endif
 
@@ -55,7 +55,7 @@ YAFluxRegister::define (const BoxArray& fba, const BoxArray& cba,
         const FabArrayBase::CPC& cpc0 = m_crse_flag.getCPC(IntVect(1), foo, IntVect(0), cperiod);
         m_crse_flag.setVal(fine_cell, cpc0, 0, 1);
         auto recv_layout_mask = m_crse_flag.RecvLayoutMask(cpc0);
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
         for (MFIter mfi(m_crse_flag); mfi.isValid(); ++mfi) {
@@ -72,7 +72,7 @@ YAFluxRegister::define (const BoxArray& fba, const BoxArray& cba,
     const int n_cfba = cfba.size();
     cfba.uniqify();
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
     
     const int nthreads = omp_get_max_threads();
     Vector<BoxList> bl_priv(nthreads, BoxList());
@@ -176,7 +176,7 @@ YAFluxRegister::define (const BoxArray& fba, const BoxArray& cba,
 
         const Box& domainbox = m_crse_geom.Domain();
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (!run_on_gpu)
 #endif
         {
@@ -350,7 +350,7 @@ YAFluxRegister::Reflux (MultiFab& state, int dc)
     if (!m_cfp_mask.empty())
     {
         const int ncomp = m_ncomp;
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
         for (MFIter mfi(m_cfpatch); mfi.isValid(); ++mfi)

--- a/Src/EB/AMReX_EB2_Level.H
+++ b/Src/EB/AMReX_EB2_Level.H
@@ -19,7 +19,7 @@
 #include <cmath>
 #include <type_traits>
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #include <omp.h>
 #endif
 
@@ -231,7 +231,7 @@ GShopLevel<G>::GShopLevel (IndexSpace const* is, G const& gshop, const Geometry&
 
     bool hybrid = Gpu::inLaunchRegion() && (gshop_run_on == RunOn::Cpu);
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     {

--- a/Src/EB/AMReX_EB2_Level.cpp
+++ b/Src/EB/AMReX_EB2_Level.cpp
@@ -97,7 +97,7 @@ Level::coarsenFromFine (Level& fineLevel, bool fill_boundary)
 
     if (Gpu::notInLaunchRegion())
     {
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel reduction(max:mvmc_error)
 #endif
         for (MFIter mfi(m_levelset,true); mfi.isValid(); ++mfi)
@@ -202,7 +202,7 @@ Level::coarsenFromFine (Level& fineLevel, bool fill_boundary)
         {
             const std::vector<IntVect>& pshifts = fine_period.shiftIntVect();
             
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
             {
@@ -248,7 +248,7 @@ Level::coarsenFromFine (Level& fineLevel, bool fill_boundary)
 
     if (Gpu::notInLaunchRegion())
     {
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel reduction(max:error)
 #endif
         for (MFIter mfi(m_volfrac,true); mfi.isValid(); ++mfi)
@@ -400,7 +400,7 @@ Level::buildCellFlag ()
         m_areafrac[idim].FillBoundary(0,1,{AMREX_D_DECL(1,1,1)},m_geom.periodicity());
     }
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     for (MFIter mfi(m_cellflag,TilingIfNotGPU()); mfi.isValid(); ++mfi)
@@ -438,7 +438,7 @@ Level::fillEBCellFlag (FabArray<EBCellFlagFab>& cellflag, const Geometry& geom) 
     const std::vector<IntVect>& pshifts = geom.periodicity().shiftIntVect();
 
     auto cov_val = EBCellFlag::TheCoveredCell();
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     {
@@ -485,7 +485,7 @@ Level::fillVolFrac (MultiFab& vfrac, const Geometry& geom) const
 
     const std::vector<IntVect>& pshifts = geom.periodicity().shiftIntVect();
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     if (!m_covered_grids.empty())
@@ -514,7 +514,7 @@ namespace {
     void copyMultiFabToMultiCutFab (MultiCutFab& dstmf, const MultiFab& srcmf)
     {
         const int ncomp = srcmf.nComp();
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
         for (MFIter mfi(dstmf.data()); mfi.isValid(); ++mfi)
@@ -650,7 +650,7 @@ Level::fillAreaFrac (Array<MultiCutFab*,AMREX_SPACEDIM> const& a_areafrac, const
 
     const std::vector<IntVect>& pshifts = geom.periodicity().shiftIntVect();
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     if (!m_covered_grids.empty())
@@ -722,7 +722,7 @@ Level::fillAreaFrac (Array<MultiFab*,AMREX_SPACEDIM> const& a_areafrac, const Ge
 
     const std::vector<IntVect>& pshifts = geom.periodicity().shiftIntVect();
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     if (!m_covered_grids.empty())
@@ -821,7 +821,7 @@ Level::fillLevelSet (MultiFab& levelset, const Geometry& geom) const
 
     Real cov_val = 1.0; // for covered cells
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     if (!m_covered_grids.empty())

--- a/Src/EB/AMReX_EBAmrUtil.cpp
+++ b/Src/EB/AMReX_EBAmrUtil.cpp
@@ -3,7 +3,7 @@
 #include <AMReX_EBFArrayBox.H>
 #include <AMReX_EBCellFlag.H>
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #include <omp.h>
 #endif
 
@@ -18,7 +18,7 @@ TagCutCells (TagBoxArray& tags, const MultiFab& state)
     auto const& factory = dynamic_cast<EBFArrayBoxFactory const&>(state.Factory());
     auto const& flags = factory.getMultiEBCellFlagFab();
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     for (MFIter mfi(state, TilingIfNotGPU()); mfi.isValid(); ++mfi)
@@ -51,7 +51,7 @@ TagVolfrac (TagBoxArray& tags, const MultiFab& volfrac, Real tol)
 //    const char clearval = TagBox::CLEAR;
     const char   tagval = TagBox::SET;
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     for (MFIter mfi(volfrac, TilingIfNotGPU()); mfi.isValid(); ++mfi) {

--- a/Src/EB/AMReX_EBCellFlag.cpp
+++ b/Src/EB/AMReX_EBCellFlag.cpp
@@ -37,7 +37,7 @@ EBCellFlagFab::getType (const Box& bx_in) const noexcept
     {
         const Box& bx = amrex::enclosedCells(bx_in);
         std::map<Box,FabType>::iterator it;
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp critical (amrex_ebcellflagfab_gettype)
 #endif
         it = m_typemap.find(bx);
@@ -108,7 +108,7 @@ EBCellFlagFab::getType (const Box& bx_in) const noexcept
                 t = FabType::singlevalued;
             }
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp critical (amrex_ebcellflagfab_gettype)
 #endif
             m_typemap.insert({bx,t});

--- a/Src/EB/AMReX_EBFluxRegister.cpp
+++ b/Src/EB/AMReX_EBFluxRegister.cpp
@@ -3,7 +3,7 @@
 #include <AMReX_EBFluxRegister_C.H>
 #include <AMReX_EBFArrayBox.H>
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #include <omp.h>
 #endif
 
@@ -45,7 +45,7 @@ EBFluxRegister::defineExtra (const BoxArray& fba, const DistributionMapping& fdm
     BoxArray cfba = fba;
     cfba.coarsen(m_ratio);
     m_cfp_inside_mask.define(cfba, fdm, 1, 0, MFInfo(),DefaultFabFactory<IArrayBox>());
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     for (MFIter mfi(m_cfp_inside_mask); mfi.isValid(); ++mfi)
@@ -233,7 +233,7 @@ EBFluxRegister::Reflux (MultiFab& crse_state, const amrex::MultiFab& crse_vfrac,
 {
     if (!m_cfp_mask.empty())
     {
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
         for (MFIter mfi(m_cfpatch); mfi.isValid(); ++mfi)
@@ -265,7 +265,7 @@ EBFluxRegister::Reflux (MultiFab& crse_state, const amrex::MultiFab& crse_vfrac,
 
         MFItInfo info;
         if (Gpu::notInLaunchRegion()) info.EnableTiling().SetDynamic(true);
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
         for (MFIter mfi(m_crse_data, info); mfi.isValid(); ++mfi)
@@ -314,7 +314,7 @@ EBFluxRegister::Reflux (MultiFab& crse_state, const amrex::MultiFab& crse_vfrac,
 
     Dim3 ratio = m_ratio.dim3();
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     for (MFIter mfi(cf,TilingIfNotGPU()); mfi.isValid(); ++mfi)

--- a/Src/EB/AMReX_EBMultiFabUtil.cpp
+++ b/Src/EB/AMReX_EBMultiFabUtil.cpp
@@ -10,7 +10,7 @@
 
 #include <AMReX_VisMF.H>
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #include <omp.h>
 #endif
 
@@ -34,7 +34,7 @@ EB_set_covered (MultiFab& mf, int icomp, int ncomp, int ngrow, Real val)
     bool is_cell_centered = mf.ixType().cellCentered();
     int ng = std::min(mf.nGrow(),ngrow);
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     for (MFIter mfi(mf,TilingIfNotGPU()); mfi.isValid(); ++mfi)
@@ -80,7 +80,7 @@ EB_set_covered (MultiFab& mf, int icomp, int ncomp, int ngrow, const Vector<Real
     Gpu::copy(Gpu::hostToDevice, a_vals.begin(), a_vals.end(), vals_dv.begin());
     Real const* AMREX_RESTRICT vals = vals_dv.data();
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     for (MFIter mfi(mf,TilingIfNotGPU()); mfi.isValid(); ++mfi)
@@ -115,7 +115,7 @@ EB_set_covered_faces (const Array<MultiFab*,AMREX_SPACEDIM>& umac, Real val)
     const auto& flags = factory->getMultiEBCellFlagFab();
     const int ncomp = umac[0]->nComp();
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     for (MFIter mfi(*umac[0],TilingIfNotGPU()); mfi.isValid(); ++mfi)
@@ -231,7 +231,7 @@ EB_set_covered_faces (const Array<MultiFab*,AMREX_SPACEDIM>& umac, const int sco
     Gpu::copy(Gpu::hostToDevice, a_vals.begin(), a_vals.end(), vals_dv.begin());
     Real const* AMREX_RESTRICT vals = vals_dv.data();
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     for (MFIter mfi(*umac[0],TilingIfNotGPU()); mfi.isValid(); ++mfi)
@@ -349,7 +349,7 @@ EB_average_down (const MultiFab& S_fine, MultiFab& S_crse, const MultiFab& vol_f
 
     Dim3 dratio = ratio.dim3();
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     for (MFIter mfi(crse_S_fine,TilingIfNotGPU()); mfi.isValid(); ++mfi)
@@ -418,7 +418,7 @@ EB_average_down (const MultiFab& S_fine, MultiFab& S_crse, int scomp, int ncomp,
         if (crse_S_fine_BA == S_crse.boxArray()
             && S_fine.DistributionMap() == S_crse.DistributionMap())
         {
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
             for (MFIter mfi(S_crse,TilingIfNotGPU()); mfi.isValid(); ++mfi)
@@ -455,7 +455,7 @@ EB_average_down (const MultiFab& S_fine, MultiFab& S_crse, int scomp, int ncomp,
             MultiFab crse_S_fine(crse_S_fine_BA, S_fine.DistributionMap(),
                                  ncomp, 0, MFInfo(),FArrayBoxFactory());
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
             for (MFIter mfi(crse_S_fine,TilingIfNotGPU()); mfi.isValid(); ++mfi)
@@ -524,7 +524,7 @@ void EB_average_down_faces (const Array<const MultiFab*,AMREX_SPACEDIM>& fine,
 
         if (isMFIterSafe(*fine[0], *crse[0]))
         {
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
             for (int n=0; n<AMREX_SPACEDIM; ++n) {
@@ -643,7 +643,7 @@ void EB_average_down_boundaries (const MultiFab& fine, MultiFab& crse,
         {
             MFItInfo info;
             if (Gpu::notInLaunchRegion()) info.EnableTiling().SetDynamic(true);
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
             for (MFIter mfi(crse, info); mfi.isValid(); ++mfi)
@@ -708,7 +708,7 @@ void EB_computeDivergence (MultiFab& divu, const Array<MultiFab const*,AMREX_SPA
         const GpuArray<Real,AMREX_SPACEDIM> dxinv = geom.InvCellSizeArray();
         MFItInfo info;
         if (Gpu::notInLaunchRegion()) info.EnableTiling().SetDynamic(true);
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
         for (MFIter mfi(divu,info); mfi.isValid(); ++mfi)
@@ -771,7 +771,7 @@ EB_average_face_to_cellcenter (MultiFab& ccmf, int dcomp,
 
         MFItInfo info;
         if (Gpu::notInLaunchRegion()) info.EnableTiling().SetDynamic(true);
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
         for (MFIter mfi(ccmf,info); mfi.isValid(); ++mfi)
@@ -817,7 +817,7 @@ EB_interp_CC_to_Centroid (MultiFab& cent, const MultiFab& cc, int scomp, int dco
 
     MFItInfo mfi_info;
     if (Gpu::notInLaunchRegion()) mfi_info.SetDynamic(true);
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     for (MFIter mfi(cc, mfi_info);  mfi.isValid(); ++mfi)
@@ -900,7 +900,7 @@ EB_interp_CC_to_FaceCentroid (const MultiFab& cc,
     
     MFItInfo mfi_info;
     if (Gpu::notInLaunchRegion()) mfi_info.SetDynamic(true);
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     for (MFIter mfi(cc, mfi_info);  mfi.isValid(); ++mfi)
@@ -1039,7 +1039,7 @@ EB_interp_CellCentroid_to_FaceCentroid (const MultiFab& phi_centroid,
     
     MFItInfo mfi_info;
     if (Gpu::notInLaunchRegion()) mfi_info.SetDynamic(true);
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     for (MFIter mfi(phi_centroid, mfi_info);  mfi.isValid(); ++mfi)

--- a/Src/EB/AMReX_EB_utils.H
+++ b/Src/EB/AMReX_EB_utils.H
@@ -46,7 +46,7 @@ namespace amrex {
             }
         }
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
         for(MFIter mfi(mf); mfi.isValid(); ++ mfi) {

--- a/Src/EB/AMReX_EB_utils.cpp
+++ b/Src/EB/AMReX_EB_utils.cpp
@@ -443,7 +443,7 @@ void FillSignedDistance (MultiFab& mf, EB2::Level const& ls_lev,
     const auto dx_eb = eb_factory.Geom().CellSizeArray();
     Real ls_roof = amrex::min(AMREX_D_DECL(dx_eb[0],dx_eb[1],dx_eb[2])) * (flags.nGrow()+1);
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     for (MFIter mfi(mf); mfi.isValid(); ++mfi)

--- a/Src/EB/AMReX_MultiCutFab.cpp
+++ b/Src/EB/AMReX_MultiCutFab.cpp
@@ -2,7 +2,7 @@
 #include <AMReX_MultiCutFab.H>
 #include <AMReX_MultiFab.H>
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #include <omp.h>
 #endif
 
@@ -89,7 +89,7 @@ MultiCutFab::ok (const MFIter& mfi) const noexcept
 void
 MultiCutFab::setVal (Real val)
 {
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     for (MFIter mfi(m_data); mfi.isValid(); ++mfi)
@@ -116,7 +116,7 @@ MultiCutFab::ToMultiFab (Real regular_value, Real covered_value) const
 {
     const int ncomp = nComp();
     MultiFab mf(boxArray(), DistributionMap(), ncomp, nGrow());
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     for (MFIter mfi(mf); mfi.isValid(); ++mfi)

--- a/Src/EB/AMReX_algoim.cpp
+++ b/Src/EB/AMReX_algoim.cpp
@@ -32,7 +32,7 @@ compute_integrals (MultiFab& intgmf, IntVect nghost)
     MFItInfo mfi_info;
     if (Gpu::notInLaunchRegion()) mfi_info.EnableTiling().SetDynamic(true);
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if(Gpu::notInLaunchRegion())
 #endif
     for (MFIter mfi(intgmf,mfi_info); mfi.isValid(); ++mfi)

--- a/Src/Extern/HYPRE/AMReX_HypreABecLap.cpp
+++ b/Src/Extern/HYPRE/AMReX_HypreABecLap.cpp
@@ -259,7 +259,7 @@ HypreABecLap::loadVectors (MultiFab& soln, const MultiFab& rhs)
     soln.setVal(0.0);
 
     MultiFab rhs_diag(rhs.boxArray(), rhs.DistributionMap(), 1, 0);
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp paralle if (Gpu::notInLaunchRegion())
 #endif
     for (MFIter mfi(rhs_diag,TilingIfNotGPU()); mfi.isValid(); ++mfi)

--- a/Src/Extern/HYPRE/AMReX_HypreABecLap2.cpp
+++ b/Src/Extern/HYPRE/AMReX_HypreABecLap2.cpp
@@ -292,7 +292,7 @@ HypreABecLap2::loadVectors (MultiFab& soln, const MultiFab& rhs)
     soln.setVal(0.0);
 
     MultiFab rhs_diag(rhs.boxArray(), rhs.DistributionMap(), 1, 0);
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp paralle if (Gpu::notInLaunchRegion())
 #endif
     for (MFIter mfi(rhs_diag,TilingIfNotGPU()); mfi.isValid(); ++mfi)

--- a/Src/Extern/HYPRE/AMReX_HypreABecLap3.cpp
+++ b/Src/Extern/HYPRE/AMReX_HypreABecLap3.cpp
@@ -416,7 +416,7 @@ HypreABecLap3::loadVectors (MultiFab& soln, const MultiFab& rhs)
     soln.setVal(0.0);
 
     MultiFab rhs_diag(rhs.boxArray(), rhs.DistributionMap(), 1, 0);
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp paralle if (Gpu::notInLaunchRegion())
 #endif
     for (MFIter mfi(rhs_diag,TilingIfNotGPU()); mfi.isValid(); ++mfi)

--- a/Src/Extern/HYPRE/AMReX_HypreABecLap3.cpp
+++ b/Src/Extern/HYPRE/AMReX_HypreABecLap3.cpp
@@ -126,7 +126,7 @@ HypreABecLap3::prepareSolver ()
 #endif
 
     HYPRE_Int ncells_proc = 0;
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion()) reduction(+:ncells_proc)
 #endif
     for (MFIter mfi(cell_id); mfi.isValid(); ++mfi)
@@ -181,7 +181,7 @@ HypreABecLap3::prepareSolver ()
     AMREX_ALWAYS_ASSERT_WITH_MESSAGE(proc_end == proc_begin+ncells_proc,
                                      "HypreABecLap3::prepareSolver: how did this happen?");
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     for (MFIter mfi(cell_id,TilingIfNotGPU()); mfi.isValid(); ++mfi)

--- a/Src/Extern/HYPRE/AMReX_HypreNodeLap.cpp
+++ b/Src/Extern/HYPRE/AMReX_HypreNodeLap.cpp
@@ -59,7 +59,7 @@ HypreNodeLap::HypreNodeLap (const BoxArray& grids_, const DistributionMapping& d
     if (ebfactory)
     {
         const FabArray<EBCellFlagFab>& flags = ebfactory->getMultiEBCellFlagFab();
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel reduction(+:nnodes_proc)
 #endif
         for (MFIter mfi(node_id); mfi.isValid(); ++mfi)
@@ -112,7 +112,7 @@ HypreNodeLap::HypreNodeLap (const BoxArray& grids_, const DistributionMapping& d
     else
 #endif
     {
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel reduction(+:nnodes_proc)
 #endif
         for (MFIter mfi(node_id); mfi.isValid(); ++mfi)
@@ -169,7 +169,7 @@ HypreNodeLap::HypreNodeLap (const BoxArray& grids_, const DistributionMapping& d
     AMREX_ALWAYS_ASSERT_WITH_MESSAGE(proc_end == proc_begin+nnodes_proc,
                                      "HypreNodeLap: how did this happen?");
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
 

--- a/Src/Extern/PETSc/AMReX_PETSc.cpp
+++ b/Src/Extern/PETSc/AMReX_PETSc.cpp
@@ -185,7 +185,7 @@ PETScABecLap::prepareSolver ()
 #endif
 
     PetscInt ncells_proc = 0;
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion()) reduction(+:ncells_proc)
 #endif
     for (MFIter mfi(cell_id); mfi.isValid(); ++mfi)
@@ -244,7 +244,7 @@ PETScABecLap::prepareSolver ()
     AMREX_ALWAYS_ASSERT_WITH_MESSAGE(proc_end == proc_begin+ncells_proc,
                                      "PETScABecLap::prepareSolver: how did this happen?");
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     for (MFIter mfi(cell_id,TilingIfNotGPU()); mfi.isValid(); ++mfi)

--- a/Src/Extern/PETSc/AMReX_PETSc.cpp
+++ b/Src/Extern/PETSc/AMReX_PETSc.cpp
@@ -486,7 +486,7 @@ PETScABecLap::loadVectors (MultiFab& soln, const MultiFab& rhs)
     soln.setVal(0.0);
 
     MultiFab rhs_diag(rhs.boxArray(), rhs.DistributionMap(), 1, 0);
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp paralle if (Gpu::notInLaunchRegion())
 #endif
     for (MFIter mfi(rhs_diag,TilingIfNotGPU()); mfi.isValid(); ++mfi)

--- a/Src/Extern/ProfParser/AMReX_BLProfStats.cpp
+++ b/Src/Extern/ProfParser/AMReX_BLProfStats.cpp
@@ -37,7 +37,7 @@ using std::pair;
 
 using namespace amrex;
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #include <omp.h>
 #endif
 

--- a/Src/Extern/ProfParser/AMReX_CommProfStats.cpp
+++ b/Src/Extern/ProfParser/AMReX_CommProfStats.cpp
@@ -36,7 +36,7 @@ using std::pair;
 
 using namespace amrex;
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #include <omp.h>
 #endif
 
@@ -1203,7 +1203,7 @@ void CommProfStats::SendRecvData(const std::string &filenameprefix,
   //float maxLF0(0.0), maxLF1(0.0);
   Real filterTLo(00.0), filterTHi(30000.0);
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
   int nReads(4);
   Vector<omp_lock_t> locks(nReads);
   for(int i(0); i < locks.size(); ++i) {
@@ -1272,7 +1272,7 @@ void CommProfStats::SendRecvData(const std::string &filenameprefix,
 
 
   while(anyDataLeft) {
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel for
 #endif
   //for(idb = 0; idb < dataBlocks.size(); ++idb) {
@@ -1477,7 +1477,7 @@ s2 += amrex::ParallelDescriptor::second() - st2;
 
 
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
   for(int i(0); i < locks.size(); ++i) {
     omp_destroy_lock(&(locks[i]));
   }

--- a/Src/Extern/ProfParser/AMReX_RegionsProfStats.cpp
+++ b/Src/Extern/ProfParser/AMReX_RegionsProfStats.cpp
@@ -36,7 +36,7 @@ using std::pair;
 using namespace amrex;
 
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #include <omp.h>
 #endif
 

--- a/Src/Extern/hpgmg/BL_HPGMG.cpp
+++ b/Src/Extern/hpgmg/BL_HPGMG.cpp
@@ -74,7 +74,7 @@ void CreateHPGMGLevel (level_type* level,
 
     int omp_threads = 1;
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel
     {
 #pragma omp master
@@ -330,7 +330,7 @@ void SetupHPGMGCoefficients(const double a,
       const int BL_jStride = fabbox.length(0);
       const int BL_kStride = fabbox.length(0) * fabbox.length(1);
       const int BoxLib_ghosts = alpha.nGrow();
-      #ifdef _OPENMP
+      #ifdef AMREX_USE_OMP
       #pragma omp parallel for private(k,j,i) collapse(3)
       #endif
       for(k=0;k<dim_k;k++){
@@ -380,7 +380,7 @@ void SetupHPGMGCoefficients(const double a,
       const int BL_kStride = fabbox.length(0) * fabbox.length(1);
       const int BoxLib_ghosts = beta_cc.nGrow();
 
-      #ifdef _OPENMP
+      #ifdef AMREX_USE_OMP
       #pragma omp parallel for private(k,j,i) collapse(3)
       #endif
       for(k=0;k<=dim_k;k++){ // include high face
@@ -447,7 +447,7 @@ void ConvertToHPGMGLevel (const MultiFab& mf,
       const int   dim_k = level->my_boxes[box].dim;
       const int BoxLib_ghosts = mf.nGrow();
 
-      #ifdef _OPENMP
+      #ifdef AMREX_USE_OMP
       #pragma omp parallel for private(k,j,i) collapse(3)
       #endif
       for(k=0;k<dim_k;k++){
@@ -499,7 +499,7 @@ void ConvertFromHPGMGLevel(MultiFab& mf,
       const int BoxLib_ghosts = mf.nGrow();
 
       int i, j, k;
-      #ifdef _OPENMP
+      #ifdef AMREX_USE_OMP
       #pragma omp parallel for private(k,j,i) collapse(3)
       #endif
       for(k=0;k<dim_k;k++){

--- a/Src/F_Interfaces/Octree/AMReX_octree_fi.cpp
+++ b/Src/F_Interfaces/Octree/AMReX_octree_fi.cpp
@@ -7,7 +7,7 @@
 #include <AMReX_MultiFabUtil.H>
 #include <AMReX_MultiFabUtil_C.H>
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #include <omp.h>
 #endif
 
@@ -167,7 +167,7 @@ extern "C" {
     {
         const int n = leaves->size();
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel for
 #endif
         for (int i = 0; i < n; ++i) {
@@ -197,7 +197,7 @@ extern "C" {
             fgeom.GetVolume(fvolume, lba, ldm, 0);
         }
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
         for (MFIter mfi(lmf,TilingIfNotGPU()); mfi.isValid(); ++mfi)

--- a/Src/LinearSolvers/MLMG/AMReX_MLABecLaplacian.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLABecLaplacian.cpp
@@ -202,7 +202,7 @@ MLABecLaplacian::averageDownCoeffsSameAmrLevel (int amrlev, Vector<MultiFab>& a,
             const Real fac = static_cast<Real>(1 << mglev); // 2**mglev
             const Real osfac = Real(2.0)*fac/(fac+Real(1.0));
             const int ncomp = getNComp();
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
             for (MFIter mfi(a[mglev],TilingIfNotGPU()); mfi.isValid(); ++mfi)
@@ -325,7 +325,7 @@ MLABecLaplacian::Fapply (int amrlev, int mglev, MultiFab& out, const MultiFab& i
 
     const int ncomp = getNComp();
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     for (MFIter mfi(out, TilingIfNotGPU()); mfi.isValid(); ++mfi)
@@ -371,7 +371,7 @@ MLABecLaplacian::normalize (int amrlev, int mglev, MultiFab& mf) const
 
     const int ncomp = getNComp();
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     for (MFIter mfi(mf, TilingIfNotGPU()); mfi.isValid(); ++mfi)
@@ -442,7 +442,7 @@ MLABecLaplacian::Fsmooth (int amrlev, int mglev, MultiFab& sol, const MultiFab& 
     MFItInfo mfi_info;
     if (Gpu::notInLaunchRegion()) mfi_info.EnableTiling().SetDynamic(true);
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     for (MFIter mfi(sol,mfi_info); mfi.isValid(); ++mfi)

--- a/Src/LinearSolvers/MLMG/AMReX_MLALaplacian.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLALaplacian.cpp
@@ -157,7 +157,7 @@ MLALaplacian::Fapply (int amrlev, int mglev, MultiFab& out, const MultiFab& in) 
     const Real ascalar = m_a_scalar;
     const Real bscalar = m_b_scalar;
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     for (MFIter mfi(out, TilingIfNotGPU()); mfi.isValid(); ++mfi)
@@ -204,7 +204,7 @@ MLALaplacian::normalize (int amrlev, int mglev, MultiFab& mf) const
     const Real ascalar = m_a_scalar;
     const Real bscalar = m_b_scalar;
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     for (MFIter mfi(mf, TilingIfNotGPU()); mfi.isValid(); ++mfi)
@@ -280,7 +280,7 @@ MLALaplacian::Fsmooth (int amrlev, int mglev, MultiFab& sol, const MultiFab& rhs
     MFItInfo mfi_info;
     if (Gpu::notInLaunchRegion()) mfi_info.EnableTiling().SetDynamic(true);
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     for (MFIter mfi(sol,mfi_info); mfi.isValid(); ++mfi)

--- a/Src/LinearSolvers/MLMG/AMReX_MLCGSolver.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLCGSolver.cpp
@@ -7,7 +7,7 @@
 #include <AMReX_ParallelReduce.H>
 #include <AMReX_MLMG.H>
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #include <omp.h>
 #endif
 

--- a/Src/LinearSolvers/MLMG/AMReX_MLCellABecLap.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLCellABecLap.cpp
@@ -66,7 +66,7 @@ MLCellABecLap::define (const Vector<Geometry>& a_geom,
             ReduceOps<ReduceOpSum> reduce_op;
             ReduceData<int> reduce_data(reduce_op);
             using ReduceTuple = typename decltype(reduce_data)::Type;
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
             for (MFIter mfi(*crse, TilingIfNotGPU()); mfi.isValid(); ++mfi)
@@ -195,7 +195,7 @@ MLCellABecLap::applyInhomogNeumannTerm (int amrlev, MultiFab& rhs) const
     MFItInfo mfi_info;
     if (Gpu::notInLaunchRegion()) mfi_info.SetDynamic(true);
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     for (MFIter mfi(rhs, mfi_info); mfi.isValid(); ++mfi)
@@ -326,7 +326,7 @@ MLCellABecLap::applyOverset (int amrlev, MultiFab& rhs) const
 {
     if (m_overset_mask[amrlev][0]) {
         const int ncomp = getNComp();
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
         for (MFIter mfi(*m_overset_mask[amrlev][0],TilingIfNotGPU()); mfi.isValid(); ++mfi)

--- a/Src/LinearSolvers/MLMG/AMReX_MLCellLinOp.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLCellLinOp.cpp
@@ -306,7 +306,7 @@ MLCellLinOp::interpolation (int amrlev, int fmglev, MultiFab& fine, const MultiF
                  ratio3.y = ratio[1];,
                  ratio3.z = ratio[2];);
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     for (MFIter mfi(fine,TilingIfNotGPU()); mfi.isValid(); ++mfi)
@@ -475,7 +475,7 @@ MLCellLinOp::applyBC (int amrlev, int mglev, MultiFab& in, BCMode bc_mode, State
     AMREX_ALWAYS_ASSERT_WITH_MESSAGE(cross || tensorop || Gpu::notInLaunchRegion(),
                                      "non-cross stencil not support for gpu");
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     for (MFIter mfi(in, mfi_info); mfi.isValid(); ++mfi)
@@ -677,7 +677,7 @@ MLCellLinOp::reflux (int crse_amrlev,
     MFItInfo mfi_info;
     if (Gpu::notInLaunchRegion()) mfi_info.EnableTiling().SetDynamic(true);
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     {
@@ -702,7 +702,7 @@ MLCellLinOp::reflux (int crse_amrlev,
             }
         }
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp barrier
 #endif
 
@@ -742,7 +742,7 @@ MLCellLinOp::compFlux (int amrlev, const Array<MultiFab*,AMREX_SPACEDIM>& fluxes
     MFItInfo mfi_info;
     if (Gpu::notInLaunchRegion()) mfi_info.EnableTiling().SetDynamic(true);
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     {
@@ -790,7 +790,7 @@ MLCellLinOp::compGrad (int amrlev, const Array<MultiFab*,AMREX_SPACEDIM>& grad,
     AMREX_D_TERM(const Real dxi = m_geom[amrlev][mglev].InvCellSize(0);,
                  const Real dyi = m_geom[amrlev][mglev].InvCellSize(1);,
                  const Real dzi = m_geom[amrlev][mglev].InvCellSize(2););
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     for (MFIter mfi(sol, TilingIfNotGPU());  mfi.isValid(); ++mfi)
@@ -854,7 +854,7 @@ MLCellLinOp::prepareForSolve ()
             MFItInfo mfi_info;
             if (Gpu::notInLaunchRegion()) mfi_info.SetDynamic(true);
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
             for (MFIter mfi(foo, mfi_info); mfi.isValid(); ++mfi)
@@ -1162,7 +1162,7 @@ MLCellLinOp::BndryCondLoc::setLOBndryConds (const Geometry& geom, const Real* dx
 {
     const Box& domain = geom.Domain();
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel
 #endif
     for (MFIter mfi(bcloc); mfi.isValid(); ++mfi)
@@ -1210,7 +1210,7 @@ MLCellLinOp::applyMetricTerm (int amrlev, int mglev, MultiFab& rhs) const
     const Real dx = geom.CellSize(0);
     const Real probxlo = geom.ProbLo(0);
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     for (MFIter mfi(rhs,TilingIfNotGPU()); mfi.isValid(); ++mfi)
@@ -1266,7 +1266,7 @@ MLCellLinOp::unapplyMetricTerm (int amrlev, int mglev, MultiFab& rhs) const
     const Real dx = geom.CellSize(0);
     const Real probxlo = geom.ProbLo(0);
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     for (MFIter mfi(rhs,TilingIfNotGPU()); mfi.isValid(); ++mfi)

--- a/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap.cpp
@@ -208,7 +208,7 @@ MLEBABecLap::setEBDirichlet (int amrlev, const MultiFab& phi, const MultiFab& be
 
     MFItInfo mfi_info;
     if (Gpu::notInLaunchRegion()) mfi_info.EnableTiling().SetDynamic(true);
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     for (MFIter mfi(phi, mfi_info); mfi.isValid(); ++mfi)
@@ -277,7 +277,7 @@ MLEBABecLap::setEBDirichlet (int amrlev, const MultiFab& phi, Real beta)
 
     MFItInfo mfi_info;
     if (Gpu::notInLaunchRegion()) mfi_info.EnableTiling().SetDynamic(true);
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     for (MFIter mfi(phi, mfi_info); mfi.isValid(); ++mfi)
@@ -336,7 +336,7 @@ MLEBABecLap::setEBDirichlet (int amrlev, const MultiFab& phi, Vector<Real> const
 
     MFItInfo mfi_info;
     if (Gpu::notInLaunchRegion()) mfi_info.EnableTiling().SetDynamic(true);
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     for (MFIter mfi(phi, mfi_info); mfi.isValid(); ++mfi)
@@ -393,7 +393,7 @@ MLEBABecLap::setEBHomogDirichlet (int amrlev, const MultiFab& beta)
 
     MFItInfo mfi_info;
     if (Gpu::notInLaunchRegion()) mfi_info.EnableTiling().SetDynamic(true);
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     for (MFIter mfi(*m_eb_phi[amrlev], mfi_info); mfi.isValid(); ++mfi)
@@ -460,7 +460,7 @@ MLEBABecLap::setEBHomogDirichlet (int amrlev, Real beta)
 
     MFItInfo mfi_info;
     if (Gpu::notInLaunchRegion()) mfi_info.EnableTiling().SetDynamic(true);
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     for (MFIter mfi(*m_eb_phi[amrlev], mfi_info); mfi.isValid(); ++mfi)
@@ -519,7 +519,7 @@ MLEBABecLap::setEBHomogDirichlet (int amrlev, Vector<Real> const& hv_beta)
 
     MFItInfo mfi_info;
     if (Gpu::notInLaunchRegion()) mfi_info.EnableTiling().SetDynamic(true);
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     for (MFIter mfi(*m_eb_phi[amrlev], mfi_info); mfi.isValid(); ++mfi)
@@ -708,7 +708,7 @@ MLEBABecLap::Fapply (int amrlev, int mglev, MultiFab& out, const MultiFab& in) c
 
     MFItInfo mfi_info;
     if (Gpu::notInLaunchRegion()) mfi_info.EnableTiling().SetDynamic(true);
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     for (MFIter mfi(out, mfi_info); mfi.isValid(); ++mfi)
@@ -833,7 +833,7 @@ MLEBABecLap::Fsmooth (int amrlev, int mglev, MultiFab& sol, const MultiFab& rhs,
 
     MFItInfo mfi_info;
     if (Gpu::notInLaunchRegion()) mfi_info.SetDynamic(true);
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     for (MFIter mfi(sol, mfi_info);  mfi.isValid(); ++mfi)
@@ -1075,7 +1075,7 @@ MLEBABecLap::compGrad (int amrlev, const Array<MultiFab*,AMREX_SPACEDIM>& grad,
 
     MFItInfo mfi_info;
     if (Gpu::notInLaunchRegion()) mfi_info.EnableTiling().SetDynamic(true);
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     for (MFIter mfi(sol, mfi_info); mfi.isValid(); ++mfi)
@@ -1207,7 +1207,7 @@ MLEBABecLap::normalize (int amrlev, int mglev, MultiFab& mf) const
 
     MFItInfo mfi_info;
     if (Gpu::notInLaunchRegion()) mfi_info.EnableTiling();
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     for (MFIter mfi(mf, mfi_info); mfi.isValid(); ++mfi)
@@ -1280,7 +1280,7 @@ MLEBABecLap::interpolation (int amrlev, int fmglev, MultiFab& fine, const MultiF
 
     const int ncomp = getNComp();
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     for (MFIter mfi(fine,TilingIfNotGPU()); mfi.isValid(); ++mfi)
@@ -1369,7 +1369,7 @@ MLEBABecLap::applyBC (int amrlev, int mglev, MultiFab& in, BCMode bc_mode, State
     MFItInfo mfi_info;
     if (Gpu::notInLaunchRegion()) mfi_info.SetDynamic(true);
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     for (MFIter mfi(in, mfi_info); mfi.isValid(); ++mfi)
@@ -1566,7 +1566,7 @@ MLEBABecLap::getEBFluxes (const Vector<MultiFab*>& a_flux, const Vector<MultiFab
 
             MFItInfo mfi_info;
             if (Gpu::notInLaunchRegion()) mfi_info.EnableTiling().SetDynamic(true);
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
             for (MFIter mfi(*a_flux[amrlev], mfi_info); mfi.isValid(); ++mfi)

--- a/Src/LinearSolvers/MLMG/AMReX_MLEBTensorOp.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBTensorOp.cpp
@@ -224,7 +224,7 @@ MLEBTensorOp::apply (int amrlev, int mglev, MultiFab& out, MultiFab& in, BCMode 
 
     MFItInfo mfi_info;
     if (Gpu::notInLaunchRegion()) mfi_info.EnableTiling().SetDynamic(true);
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     for (MFIter mfi(out, mfi_info); mfi.isValid(); ++mfi)
@@ -295,7 +295,7 @@ MLEBTensorOp::applyBCTensor (int amrlev, int mglev, MultiFab& vel,
     
     MFItInfo mfi_info;
     if (Gpu::notInLaunchRegion()) mfi_info.SetDynamic(true);
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     for (MFIter mfi(vel, mfi_info); mfi.isValid(); ++mfi)
@@ -395,7 +395,7 @@ MLEBTensorOp::compCrossTerms(int amrlev, int mglev, MultiFab const& mf) const
     
     MFItInfo mfi_info;
     if (Gpu::notInLaunchRegion()) mfi_info.EnableTiling().SetDynamic(true);
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     for (MFIter mfi(mf, mfi_info); mfi.isValid(); ++mfi)
@@ -523,7 +523,7 @@ MLEBTensorOp::compFlux (int amrlev, const Array<MultiFab*,AMREX_SPACEDIM>& fluxe
 
     MFItInfo mfi_info;
     if (Gpu::notInLaunchRegion()) mfi_info.EnableTiling().SetDynamic(true);
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     for (MFIter mfi(sol, mfi_info); mfi.isValid(); ++mfi)
@@ -627,7 +627,7 @@ MLEBTensorOp::compVelGrad (int amrlev, const Array<MultiFab*,AMREX_SPACEDIM>& fl
 
     MFItInfo mfi_info;
     if (Gpu::notInLaunchRegion()) mfi_info.EnableTiling().SetDynamic(true);
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
   {

--- a/Src/LinearSolvers/MLMG/AMReX_MLMG.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLMG.cpp
@@ -614,7 +614,7 @@ MLMG::interpCorrection (int alev)
     {
         MFItInfo mfi_info;
         if (Gpu::notInLaunchRegion()) mfi_info.EnableTiling().SetDynamic(true);
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
         for (MFIter mfi(fine_cor, mfi_info); mfi.isValid(); ++mfi)
@@ -690,7 +690,7 @@ MLMG::interpCorrection (int alev)
     else
     {
         AMREX_ALWAYS_ASSERT(amrrr == 2);
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
         for (MFIter mfi(fine_cor, TilingIfNotGPU()); mfi.isValid(); ++mfi)
@@ -758,7 +758,7 @@ MLMG::interpCorrection (int alev, int mglev)
     {
         MFItInfo mfi_info;
         if (Gpu::notInLaunchRegion()) mfi_info.EnableTiling().SetDynamic(true);
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
         for (MFIter mfi(fine_cor, mfi_info); mfi.isValid(); ++mfi)
@@ -801,7 +801,7 @@ MLMG::interpCorrection (int alev, int mglev)
     }
     else
     {
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
         for (MFIter mfi(fine_cor, TilingIfNotGPU()); mfi.isValid(); ++mfi)

--- a/Src/LinearSolvers/MLMG/AMReX_MLMGBndry.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLMGBndry.cpp
@@ -22,7 +22,7 @@ MLMGBndry::setLOBndryConds (const Vector<Array<LinOpBCType,AMREX_SPACEDIM> >& lo
     const Box&      domain = geom.Domain();
     const GpuArray<int,AMREX_SPACEDIM>& is_periodic = geom.isPeriodicArray();
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel
 #endif
     for (FabSetIter fsi(bndry[Orientation(0,Orientation::low)]); fsi.isValid(); ++fsi)

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian.cpp
@@ -8,7 +8,7 @@
 #include <AMReX_algoim.H>
 #endif
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #include <omp.h>
 #endif
 
@@ -135,7 +135,7 @@ MLNodeLaplacian::unimposeNeumannBC (int amrlev, MultiFab& rhs) const
 
         MFItInfo mfi_info;
         if (Gpu::notInLaunchRegion()) mfi_info.EnableTiling().SetDynamic(true);
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
         for (MFIter mfi(rhs,mfi_info); mfi.isValid(); ++mfi)
@@ -216,7 +216,7 @@ MLNodeLaplacian::compRHS (const Vector<MultiFab*>& rhs, const Vector<MultiFab*>&
 
         MFItInfo mfi_info;
         if (Gpu::notInLaunchRegion()) mfi_info.EnableTiling().SetDynamic(true);
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
         for (MFIter mfi(*rhs[ilev],mfi_info); mfi.isValid(); ++mfi)
@@ -328,7 +328,7 @@ MLNodeLaplacian::compRHS (const Vector<MultiFab*>& rhs, const Vector<MultiFab*>&
 
         MFItInfo mfi_info;
         if (Gpu::notInLaunchRegion()) mfi_info.EnableTiling().SetDynamic(true);
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
         {
@@ -468,7 +468,7 @@ MLNodeLaplacian::compRHS (const Vector<MultiFab*>& rhs, const Vector<MultiFab*>&
 
         MFItInfo mfi_info;
         if (Gpu::notInLaunchRegion()) mfi_info.EnableTiling().SetDynamic(true);
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
         for (MFIter mfi(*rhs[ilev]); mfi.isValid(); ++mfi)
@@ -527,7 +527,7 @@ MLNodeLaplacian::updateVelocity (const Vector<MultiFab*>& vel, const Vector<Mult
     bool is_rz = m_is_rz;
 #endif
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     for (int amrlev = 0; amrlev < m_num_amr_levels; ++amrlev)
@@ -626,7 +626,7 @@ MLNodeLaplacian::compGrad (int amrlev, MultiFab& grad, MultiFab& sol) const
     const MultiFab* intg = m_integral[amrlev].get();
 #endif
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     for (MFIter mfi(grad, TilingIfNotGPU()); mfi.isValid(); ++mfi)
@@ -689,7 +689,7 @@ MLNodeLaplacian::getFluxes (const Vector<MultiFab*> & a_flux, const Vector<Multi
 
     AMREX_ASSERT(a_flux[0]->nComp() >= AMREX_SPACEDIM);
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     for (int amrlev = 0; amrlev < m_num_amr_levels; ++amrlev)
@@ -886,7 +886,7 @@ MLNodeLaplacian::averageDownCoeffsSameAmrLevel (int amrlev)
             MultiFab* pcrse = (need_parallel_copy) ? &cfine : &crse;
             
             if (regular_coarsening) {
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
                 for (MFIter mfi(*pcrse, TilingIfNotGPU()); mfi.isValid(); ++mfi)
@@ -916,7 +916,7 @@ MLNodeLaplacian::averageDownCoeffsSameAmrLevel (int amrlev)
                     }
                 }
             } else {
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
                 for (MFIter mfi(*pcrse, TilingIfNotGPU()); mfi.isValid(); ++mfi)
@@ -952,7 +952,7 @@ MLNodeLaplacian::FillBoundaryCoeff (MultiFab& sigma, const Geometry& geom)
 
         MFItInfo mfi_info;
         if (Gpu::notInLaunchRegion()) mfi_info.SetDynamic(true);
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
         for (MFIter mfi(sigma, mfi_info); mfi.isValid(); ++mfi)
@@ -1007,7 +1007,7 @@ MLNodeLaplacian::buildStencil ()
 
             MFItInfo mfi_info;
             if (Gpu::notInLaunchRegion()) mfi_info.EnableTiling().SetDynamic(true);
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
             {
@@ -1107,7 +1107,7 @@ MLNodeLaplacian::buildStencil ()
 
             // set_stencil_s0 has to be in a separate MFIter from set_stencil
             // because it uses other cells' data.
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
             for (MFIter mfi(*m_stencil[amrlev][0],TilingIfNotGPU()); mfi.isValid(); ++mfi)
@@ -1137,7 +1137,7 @@ MLNodeLaplacian::buildStencil ()
 
             MultiFab* pcrse = (need_parallel_copy) ? &cfine : &crse;
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
             for (MFIter mfi(*pcrse, TilingIfNotGPU()); mfi.isValid(); ++mfi)
@@ -1155,7 +1155,7 @@ MLNodeLaplacian::buildStencil ()
                 });
             }
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
             for (MFIter mfi(*pcrse,TilingIfNotGPU()); mfi.isValid(); ++mfi)
@@ -1188,7 +1188,7 @@ MLNodeLaplacian::fixUpResidualMask (int amrlev, iMultiFab& resmsk)
 
     const iMultiFab& cfmask = *m_nd_fine_mask[amrlev];
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     for (MFIter mfi(resmsk,TilingIfNotGPU()); mfi.isValid(); ++mfi)
@@ -1251,7 +1251,7 @@ MLNodeLaplacian::restriction (int amrlev, int cmglev, MultiFab& crse, MultiFab& 
         }
     }
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     for (MFIter mfi(*pcrse, TilingIfNotGPU()); mfi.isValid(); ++mfi)
@@ -1326,7 +1326,7 @@ MLNodeLaplacian::interpolation (int amrlev, int fmglev, MultiFab& fine, const Mu
         AMREX_ALWAYS_ASSERT(regular_coarsening);
     }
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     for (MFIter mfi(fine, TilingIfNotGPU()); mfi.isValid(); ++mfi)
@@ -1426,7 +1426,7 @@ MLNodeLaplacian::restrictInteriorNodes (int camrlev, MultiFab& crhs, MultiFab& a
 
     applyBC(camrlev+1, 0, *frhs, BCMode::Inhomogeneous, StateMode::Solution);
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     for (MFIter mfi(cfine, TilingIfNotGPU()); mfi.isValid(); ++mfi)
@@ -1458,7 +1458,7 @@ MLNodeLaplacian::restrictInteriorNodes (int camrlev, MultiFab& crhs, MultiFab& a
 
     MFItInfo mfi_info;
     if (Gpu::notInLaunchRegion()) mfi_info.EnableTiling().SetDynamic(true);
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     for (MFIter mfi(crhs, mfi_info); mfi.isValid(); ++mfi)
@@ -1491,7 +1491,7 @@ MLNodeLaplacian::Fapply (int amrlev, int mglev, MultiFab& out, const MultiFab& i
 
     const iMultiFab& dmsk = *m_dirichlet_mask[amrlev][mglev];
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     for (MFIter mfi(out,TilingIfNotGPU()); mfi.isValid(); ++mfi)
@@ -1668,7 +1668,7 @@ MLNodeLaplacian::Fsmooth (int amrlev, int mglev, MultiFab& sol, const MultiFab& 
         {
             if (m_coarsening_strategy == CoarseningStrategy::RAP)
             {
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel
 #endif
                 for (MFIter mfi(sol); mfi.isValid(); ++mfi)
@@ -1687,7 +1687,7 @@ MLNodeLaplacian::Fsmooth (int amrlev, int mglev, MultiFab& sol, const MultiFab& 
             else if (sigma[0] == nullptr)
             {
                 Real const_sigma = m_const_sigma;
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel
 #endif
                 for (MFIter mfi(sol); mfi.isValid(); ++mfi)
@@ -1709,7 +1709,7 @@ MLNodeLaplacian::Fsmooth (int amrlev, int mglev, MultiFab& sol, const MultiFab& 
             }
             else if (m_use_harmonic_average && mglev > 0)
             {
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel
 #endif
                 for (MFIter mfi(sol); mfi.isValid(); ++mfi)
@@ -1735,7 +1735,7 @@ MLNodeLaplacian::Fsmooth (int amrlev, int mglev, MultiFab& sol, const MultiFab& 
             }
             else
             {
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel
 #endif
                 for (MFIter mfi(sol); mfi.isValid(); ++mfi)
@@ -1779,7 +1779,7 @@ MLNodeLaplacian::Fsmooth (int amrlev, int mglev, MultiFab& sol, const MultiFab& 
 
             if (m_coarsening_strategy == CoarseningStrategy::RAP)
             {
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel
 #endif
                 for (MFIter mfi(sol,true); mfi.isValid(); ++mfi)
@@ -1797,7 +1797,7 @@ MLNodeLaplacian::Fsmooth (int amrlev, int mglev, MultiFab& sol, const MultiFab& 
             else if (sigma[0] == nullptr)
             {
                 Real const_sigma = m_const_sigma;
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel
 #endif
                 for (MFIter mfi(sol,true); mfi.isValid(); ++mfi)
@@ -1814,7 +1814,7 @@ MLNodeLaplacian::Fsmooth (int amrlev, int mglev, MultiFab& sol, const MultiFab& 
             }
             else if (m_use_harmonic_average && mglev > 0)
             {
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel
 #endif
                 for (MFIter mfi(sol,true); mfi.isValid(); ++mfi)
@@ -1834,7 +1834,7 @@ MLNodeLaplacian::Fsmooth (int amrlev, int mglev, MultiFab& sol, const MultiFab& 
             }
             else
             {
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel
 #endif
                 for (MFIter mfi(sol,true); mfi.isValid(); ++mfi)
@@ -1867,7 +1867,7 @@ MLNodeLaplacian::normalize (int amrlev, int mglev, MultiFab& mf) const
     const iMultiFab& dmsk = *m_dirichlet_mask[amrlev][mglev];
     const Real s0_norm0 = m_s0_norm0[amrlev][mglev];
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     for (MFIter mfi(mf,TilingIfNotGPU()); mfi.isValid(); ++mfi)
@@ -1931,7 +1931,7 @@ MLNodeLaplacian::compSyncResidualCoarse (MultiFab& sync_resid, const MultiFab& a
                                                  geom.periodicity(), owner, nonowner);
 
     const Box& ccdom = geom.Domain();
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     for (MFIter mfi(crse_cc_mask); mfi.isValid(); ++mfi)
@@ -1941,7 +1941,7 @@ MLNodeLaplacian::compSyncResidualCoarse (MultiFab& sync_resid, const MultiFab& a
     }
 
     MultiFab phi(ndba, dmap, 1, 1);
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     for (MFIter mfi(phi,TilingIfNotGPU()); mfi.isValid(); ++mfi)
@@ -1984,7 +1984,7 @@ MLNodeLaplacian::compSyncResidualCoarse (MultiFab& sync_resid, const MultiFab& a
 
     MFItInfo mfi_info;
     if (Gpu::notInLaunchRegion()) mfi_info.EnableTiling().SetDynamic(true);
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     {
@@ -2254,7 +2254,7 @@ MLNodeLaplacian::compSyncResidualFine (MultiFab& sync_resid, const MultiFab& phi
 
     MFItInfo mfi_info;
     if (Gpu::notInLaunchRegion()) mfi_info.EnableTiling().SetDynamic(true);
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     {
@@ -2534,7 +2534,7 @@ MLNodeLaplacian::reflux (int crse_amrlev,
 
     applyBC(crse_amrlev+1, 0, fine_res, BCMode::Inhomogeneous, StateMode::Solution);
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     for (MFIter mfi(fine_res_for_coarse, TilingIfNotGPU()); mfi.isValid(); ++mfi)
@@ -2565,7 +2565,7 @@ MLNodeLaplacian::reflux (int crse_amrlev,
 
     MFItInfo mfi_info;
     if (Gpu::notInLaunchRegion()) mfi_info.EnableTiling().SetDynamic(true);
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     {
@@ -2660,7 +2660,7 @@ MLNodeLaplacian::reflux (int crse_amrlev,
 
     const auto& csigma = m_sigma[crse_amrlev][0][0];
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     for (MFIter mfi(res,mfi_info); mfi.isValid(); ++mfi)
@@ -2751,7 +2751,7 @@ MLNodeLaplacian::buildIntegral ()
 
             MFItInfo mfi_info;
             if (Gpu::notInLaunchRegion()) mfi_info.EnableTiling().SetDynamic(true);
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
             for (MFIter mfi(*intg,mfi_info); mfi.isValid(); ++mfi)

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLinOp.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLinOp.cpp
@@ -3,7 +3,7 @@
 #include <AMReX_MLNodeLap_K.H>
 #include <AMReX_MultiFabUtil.H>
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #include <omp.h>
 #endif
 
@@ -90,7 +90,7 @@ MLNodeLinOp::solutionResidual (int amrlev, MultiFab& resid, MultiFab& x, const M
     apply(amrlev, mglev, resid, x, BCMode::Inhomogeneous, StateMode::Solution);
 
     const iMultiFab& dmsk = *m_dirichlet_mask[amrlev][0];
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     for (MFIter mfi(resid, TilingIfNotGPU()); mfi.isValid(); ++mfi)
@@ -190,7 +190,7 @@ void MLNodeLinOp_set_dot_mask (MultiFab& dot_mask, iMultiFab const& omask, Geome
         nddomain.grow(1000); // hack to avoid masks being modified at Neuman boundary
     }
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     for (MFIter mfi(dot_mask,TilingIfNotGPU()); mfi.isValid(); ++mfi)
@@ -248,7 +248,7 @@ MLNodeLinOp::buildMasks ()
                 const auto& dmask_fine = *m_dirichlet_mask[amrlev][mglev-1];
                 amrex::average_down_nodal(dmask_fine, dmask, IntVect(2));
             }
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
             for (MFIter mfi(dmask, mfi_info); mfi.isValid(); ++mfi)
@@ -277,7 +277,7 @@ MLNodeLinOp::buildMasks ()
                                       IntVect(AMRRefRatio(amrlev)), m_geom[amrlev][0].periodicity(),
                                       0, 1, has_cf); // coarse: 0, fine: 1
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
         for (MFIter mfi(cc_mask); mfi.isValid(); ++mfi)
@@ -287,7 +287,7 @@ MLNodeLinOp::buildMasks ()
             mlndlap_fillbc_cc<int>(bx,fab,ccdom,lobc,hibc);
         }
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
         for (MFIter mfi(nd_mask,TilingIfNotGPU()); mfi.isValid(); ++mfi)
@@ -303,7 +303,7 @@ MLNodeLinOp::buildMasks ()
     }
 
     auto& has_cf = *m_has_fine_bndry[m_num_amr_levels-1];
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel
 #endif
     for (MFIter mfi(has_cf); mfi.isValid(); ++mfi)
@@ -334,7 +334,7 @@ MLNodeLinOp::buildMasks ()
 void
 MLNodeLinOp::setOversetMask (int amrlev, const iMultiFab& a_dmask)
 {
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     for (MFIter mfi(*m_dirichlet_mask[amrlev][0], TilingIfNotGPU()); mfi.isValid(); ++mfi) {
@@ -366,7 +366,7 @@ MLNodeLinOp::applyBC (int amrlev, int mglev, MultiFab& phi, BCMode/* bc_mode*/, 
     {
         const auto lobc = LoBC();
         const auto hibc = HiBC();
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
         for (MFIter mfi(phi); mfi.isValid(); ++mfi)

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeTensorLaplacian.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeTensorLaplacian.cpp
@@ -75,7 +75,7 @@ MLNodeTensorLaplacian::restriction (int amrlev, int cmglev, MultiFab& crse, Mult
     MultiFab* pcrse = (need_parallel_copy) ? &cfine : &crse;
     const iMultiFab& dmsk = *m_dirichlet_mask[amrlev][cmglev-1];
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     for (MFIter mfi(*pcrse, TilingIfNotGPU()); mfi.isValid(); ++mfi)
@@ -113,7 +113,7 @@ MLNodeTensorLaplacian::interpolation (int amrlev, int fmglev, MultiFab& fine,
 
     const iMultiFab& dmsk = *m_dirichlet_mask[amrlev][fmglev];
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     for (MFIter mfi(fine, TilingIfNotGPU()); mfi.isValid(); ++mfi)
@@ -168,7 +168,7 @@ MLNodeTensorLaplacian::Fapply (int amrlev, int mglev, MultiFab& out, const Multi
     const auto dxinv = m_geom[amrlev][mglev].InvCellSizeArray();
     const auto s = m_sigma;
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     for (MFIter mfi(out,TilingIfNotGPU()); mfi.isValid(); ++mfi)
@@ -193,7 +193,7 @@ MLNodeTensorLaplacian::Fsmooth (int amrlev, int mglev, MultiFab& sol, const Mult
     const iMultiFab& dmsk = *m_dirichlet_mask[amrlev][mglev];
     const auto s = m_sigma;
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     for (MFIter mfi(sol); mfi.isValid(); ++mfi)
@@ -225,7 +225,7 @@ MLNodeTensorLaplacian::normalize (int amrlev, int mglev, MultiFab& mf) const
     const iMultiFab& dmsk = *m_dirichlet_mask[amrlev][mglev];
     const auto s = m_sigma;
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     for (MFIter mfi(mf,TilingIfNotGPU()); mfi.isValid(); ++mfi)

--- a/Src/LinearSolvers/MLMG/AMReX_MLPoisson.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLPoisson.cpp
@@ -90,7 +90,7 @@ MLPoisson::Fapply (int amrlev, int mglev, MultiFab& out, const MultiFab& in) con
     const Real probxlo = m_geom[amrlev][mglev].ProbLo(0);
 #endif
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     for (MFIter mfi(out, TilingIfNotGPU()); mfi.isValid(); ++mfi)
@@ -158,7 +158,7 @@ MLPoisson::normalize (int amrlev, int mglev, MultiFab& mf) const
     const Real dx = m_geom[amrlev][mglev].CellSize(0);
     const Real probxlo = m_geom[amrlev][mglev].ProbLo(0);
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     for (MFIter mfi(mf, TilingIfNotGPU()); mfi.isValid(); ++mfi)
@@ -226,7 +226,7 @@ MLPoisson::Fsmooth (int amrlev, int mglev, MultiFab& sol, const MultiFab& rhs, i
     MFItInfo mfi_info;
     if (Gpu::notInLaunchRegion()) mfi_info.EnableTiling().SetDynamic(true);
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     for (MFIter mfi(sol,mfi_info); mfi.isValid(); ++mfi)

--- a/Src/LinearSolvers/MLMG/AMReX_MLTensorOp.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLTensorOp.cpp
@@ -166,7 +166,7 @@ MLTensorOp::prepareForSolve ()
             if (m_has_kappa && m_overset_mask[amrlev][mglev]) {
                 const Real fac = static_cast<Real>(1 << mglev); // 2**mglev
                 const Real osfac = Real(2.0)*fac/(fac+Real(1.0));
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
                 for (MFIter mfi(m_kappa[amrlev][mglev][0],TilingIfNotGPU()); mfi.isValid(); ++mfi)
@@ -218,7 +218,7 @@ MLTensorOp::apply (int amrlev, int mglev, MultiFab& out, MultiFab& in, BCMode bc
     Array<MultiFab,AMREX_SPACEDIM> const& kapmf = m_kappa[amrlev][mglev];
     Real bscalar = m_b_scalar;
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     {
@@ -303,7 +303,7 @@ MLTensorOp::applyBCTensor (int amrlev, int mglev, MultiFab& vel,
 
     MFItInfo mfi_info;
     if (Gpu::notInLaunchRegion()) mfi_info.SetDynamic(true);
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     for (MFIter mfi(vel, mfi_info); mfi.isValid(); ++mfi)
@@ -396,7 +396,7 @@ MLTensorOp::compFlux (int amrlev, const Array<MultiFab*,AMREX_SPACEDIM>& fluxes,
     Array<MultiFab,AMREX_SPACEDIM> const& kapmf = m_kappa[amrlev][mglev];
     Real bscalar = m_b_scalar;
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     {
@@ -472,7 +472,7 @@ MLTensorOp::compVelGrad (int amrlev, const Array<MultiFab*,AMREX_SPACEDIM>& flux
     const auto dxinv = m_geom[amrlev][mglev].InvCellSizeArray();
     const int dim_fluxes = AMREX_SPACEDIM*AMREX_SPACEDIM;
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     {

--- a/Src/LinearSolvers/Projections/AMReX_NodalProjector.cpp
+++ b/Src/LinearSolvers/Projections/AMReX_NodalProjector.cpp
@@ -438,7 +438,7 @@ NodalProjector::setCoarseBoundaryVelocityForSync ()
         }
         else
         {
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
             for (MFIter mfi(*m_vel[0]); mfi.isValid(); ++mfi)

--- a/Src/Particle/AMReX_NeighborParticlesCPUImpl.H
+++ b/Src/Particle/AMReX_NeighborParticlesCPUImpl.H
@@ -284,7 +284,7 @@ NeighborParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
             for (int j = 0; j < num_threads; ++j) {
                 auto& tags = buffer_tag_cache[lev][src_index][j];
                 int num_tags = tags.size();
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel for
 #endif
                 for (int i = 0; i < num_tags; ++i) {
@@ -374,7 +374,7 @@ NeighborParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
             }
         }
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel
 #endif
         for (MFIter mfi = this->MakeMFIter(lev); mfi.isValid(); ++mfi) {

--- a/Src/Particle/AMReX_NeighborParticlesI.H
+++ b/Src/Particle/AMReX_NeighborParticlesI.H
@@ -144,7 +144,7 @@ NeighborParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
             mask_ptr[lev].reset(new iMultiFab(ba, dmap, num_mask_comps, m_num_neighbor_cells));
             mask_ptr[lev]->setVal(-1, m_num_neighbor_cells);
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel
 #endif
             for (MFIter mfi(*mask_ptr[lev],this->do_tiling ? this->tile_size : IntVect::TheZeroVector());
@@ -327,7 +327,7 @@ NeighborParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
     for (int lev = 0; lev < this->numLevels(); ++lev) {
         // First pass - each thread collects the NeighborIndexMaps it owes to other
         // grids / tiles / procs
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel
 #endif
         {
@@ -382,7 +382,7 @@ NeighborParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
 
     for (int lev = 0; lev < this->numLevels(); ++lev) {
         // second pass - for each tile, collect the neighbors owed from all threads
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel
 #endif
         for (MFIter mfi = this->MakeMFIter(lev); mfi.isValid(); ++mfi) {
@@ -401,12 +401,12 @@ NeighborParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
 
     // do the same for the remote neighbors
     typename std::map<NeighborCommTag, Vector<Vector<NeighborIndexMap> > >::iterator it;
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel
 #pragma omp single nowait
 #endif
     for (it=tmp_remote_map.begin(); it != tmp_remote_map.end(); it++) {
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp task firstprivate(it)
 #endif
         {
@@ -441,7 +441,7 @@ NeighborParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
             PairIndex dst_index(grid, tile);
             const Vector<NeighborIndexMap>& map = local_map[lev][dst_index];
             const int num_ghosts = map.size();
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel for
 #endif
             for (int i = 0; i < num_ghosts; ++i) {
@@ -482,7 +482,7 @@ NeighborParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
         std::memcpy(dst, &(kv.first.tile_id ), sizeof(int)); dst += sizeof(int);
         std::memcpy(dst, &data_size,           sizeof(int)); dst += sizeof(int);
         size_t buffer_offset = old_size + 4*sizeof(int);
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel for
 #endif
         for (int i = 0; i < np; ++i) {
@@ -690,7 +690,7 @@ buildNeighborList (CheckPair&& check_pair, bool /*sort*/)
               auto& plev = this->GetParticles(lev);
         const auto& geom = this->Geom(lev);
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
         for (MyParIter pti(*this, lev); pti.isValid(); ++pti)

--- a/Src/Particle/AMReX_ParIter.H
+++ b/Src/Particle/AMReX_ParIter.H
@@ -43,7 +43,7 @@ public:
 
     ParIterBase (ContainerRef pc, int level, MFItInfo& info);
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
     void operator++ ()
     {
         if (dynamic) {
@@ -171,7 +171,7 @@ ParIterBase<is_const, NStructReal, NStructInt, NArrayReal, NArrayInt>::ParIterBa
     {
         currentIndex = beginIndex = m_valid_index.front();
         if (dynamic) {
-#ifdef _OPENMP            
+#ifdef AMREX_USE_OMP            
             int ind = omp_get_thread_num();
             m_pariter_index += ind;
             if (ind < m_valid_index.size()) {

--- a/Src/Particle/AMReX_Particle.H
+++ b/Src/Particle/AMReX_Particle.H
@@ -761,7 +761,7 @@ Long
 Particle<NReal, NInt>::NextID ()
 {
     Long next;
-// we should be able to test on AMREX_USE_OMP < 201107 for capture (version 3.1)
+// we should be able to test on _OPENMP < 201107 for capture (version 3.1)
 // but we must work around a bug in gcc < 4.9
 #if defined(AMREX_USE_OMP) && defined(_OPENMP) && _OPENMP < 201307
 #pragma omp critical (amrex_particle_nextid)

--- a/Src/Particle/AMReX_Particle.H
+++ b/Src/Particle/AMReX_Particle.H
@@ -761,11 +761,11 @@ Long
 Particle<NReal, NInt>::NextID ()
 {
     Long next;
-// we should be able to test on _OPENMP < 201107 for capture (version 3.1)
+// we should be able to test on AMREX_USE_OMP < 201107 for capture (version 3.1)
 // but we must work around a bug in gcc < 4.9
-#if defined(_OPENMP) && _OPENMP < 201307
+#if defined(AMREX_USE_OMP) && defined(_OPENMP) && _OPENMP < 201307
 #pragma omp critical (amrex_particle_nextid)
-#elif defined(_OPENMP)
+#elif defined(AMREX_USE_OMP)
 #pragma omp atomic capture
 #endif
     next = the_next_id++;

--- a/Src/Particle/AMReX_ParticleContainerI.H
+++ b/Src/Particle/AMReX_ParticleContainerI.H
@@ -624,7 +624,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>::MoveRandom (i
     for (auto& kv : pmap) {
         auto& aos = kv.second.GetArrayOfStructs();
         const int n = aos.numParticles();
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel for
 #endif
         for (int i = 0; i < n; i++)
@@ -1343,7 +1343,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
           ptile_ptrs.push_back(&(kv.second));
       }
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel for
 #endif
       for (int pmap_it = 0; pmap_it < static_cast<int>(ptile_ptrs.size()); ++pmap_it)
@@ -1492,7 +1492,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
           pvec_ptrs.push_back(&(pmap_it->second));
       }
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel for
 #endif
       for (int pit = 0; pit < static_cast<int>(pvec_ptrs.size()); ++pit)
@@ -1535,7 +1535,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
       pbuff_ptrs.push_back(&(kv.second));
   }
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel for
 #endif
   for (int pmap_it = 0; pmap_it < static_cast<int>(pbuff_ptrs.size()); ++pmap_it)
@@ -1633,7 +1633,7 @@ BuildRedistributeMask (int lev, int nghost) const
 
         const auto tile_size_do = this->do_tiling ? this->tile_size : IntVect::TheZeroVector();
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel
 #endif
         for (MFIter mfi(*redistribute_mask_ptr, tile_size_do); mfi.isValid(); ++mfi)
@@ -2073,7 +2073,7 @@ AssignCellDensitySingleLevel (int rho_index,
 
     using ParConstIter = ParConstIter<NStructReal, NStructInt, NArrayReal, NArrayInt>;
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     {
@@ -2084,7 +2084,7 @@ AssignCellDensitySingleLevel (int rho_index,
             const Long np = pti.numParticles();
             FArrayBox& fab = (*mf_pointer)[pti];
             auto rhoarr = fab.array();
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
             Box tile_box;
             if (Gpu::notInLaunchRegion())
             {
@@ -2111,7 +2111,7 @@ AssignCellDensitySingleLevel (int rho_index,
                 });
             }
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
             if (Gpu::notInLaunchRegion())
             {
                 fab.atomicAdd<RunOn::Host>(local_rho, tile_box, tile_box, 0, 0, ncomp);
@@ -2188,7 +2188,7 @@ InterpolateSingleLevel (MultiFab& mesh_data, int lev)
 
     using ParIter = ParIter<NStructReal, NStructInt, NArrayReal, NArrayInt>;
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     for (ParIter pti(*this, lev); pti.isValid(); ++pti)

--- a/Src/Particle/AMReX_ParticleMesh.H
+++ b/Src/Particle/AMReX_ParticleMesh.H
@@ -44,7 +44,7 @@ ParticleToMesh (PC const& pc, MF& mf, int lev, F&& f)
     else
 #endif
     {
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
         {
@@ -98,7 +98,7 @@ MeshToParticle (PC& pc, MF const& mf, int lev, F&& f)
         
     auto& plevel = pc.GetParticles(lev);
     using ParIter = typename PC::ParIterType;
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     for(ParIter pti(pc, lev); pti.isValid(); ++pti)

--- a/Src/Particle/AMReX_ParticleReduce.H
+++ b/Src/Particle/AMReX_ParticleReduce.H
@@ -120,7 +120,7 @@ ReduceSum (PC const& pc, int lev_min, int lev_max, F&& f) -> decltype(f(typename
     {
         for (int lev = lev_min; lev <= lev_max; ++lev)
         {
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (!system::regtest_reduction) reduction(+:sm)
 #endif
             for(ParIter pti(pc, lev); pti.isValid(); ++pti)
@@ -244,7 +244,7 @@ ReduceMax (PC const& pc, int lev_min, int lev_max, F&& f) -> decltype(f(typename
     {
         for (int lev = lev_min; lev <= lev_max; ++lev)
         {
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (!system::regtest_reduction) reduction(max:r)
 #endif
             for(ParIter pti(pc, lev); pti.isValid(); ++pti)
@@ -368,7 +368,7 @@ ReduceMin (PC const& pc, int lev_min, int lev_max, F&& f) -> decltype(f(typename
     {
         for (int lev = lev_min; lev <= lev_max; ++lev)
         {
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (!system::regtest_reduction) reduction(min:r)
 #endif
             for(ParIter pti(pc, lev); pti.isValid(); ++pti)
@@ -490,7 +490,7 @@ ReduceLogicalAnd (PC const& pc, int lev_min, int lev_max, F&& f)
     {
         for (int lev = lev_min; lev <= lev_max; ++lev)
         {
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (!system::regtest_reduction) reduction(&&:r)
 #endif
             for(ParIter pti(pc, lev); pti.isValid(); ++pti)
@@ -612,7 +612,7 @@ ReduceLogicalOr (PC const& pc, int lev_min, int lev_max, F&& f)
     {
         for (int lev = lev_min; lev <= lev_max; ++lev)
         {
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (!system::regtest_reduction) reduction(||:r)
 #endif
             for(ParIter pti(pc, lev); pti.isValid(); ++pti)

--- a/Src/Particle/AMReX_ParticleUtil.H
+++ b/Src/Particle/AMReX_ParticleUtil.H
@@ -147,7 +147,7 @@ numParticlesOutOfRange (PC const& pc, int lev_min, int lev_max, int nGrow)
     int num_wrong = 0;
     for (int lev = lev_min; lev <= lev_max; ++lev)
     {
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion() && !system::regtest_reduction) reduction(+:num_wrong)
 #endif
         for(ParIter pti(pc, lev); pti.isValid(); ++pti)

--- a/Src/Particle/AMReX_Particles.H
+++ b/Src/Particle/AMReX_Particles.H
@@ -56,7 +56,7 @@
 #include <AMReX_Lazy.H>
 #endif
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #include <omp.h>
 #endif
 

--- a/Src/Particle/AMReX_TracerParticles.cpp
+++ b/Src/Particle/AMReX_TracerParticles.cpp
@@ -55,7 +55,7 @@ TracerParticleContainer::AdvectWithUmac (MultiFab* umac, int lev, Real dt)
 
     for (int ipass = 0; ipass < 2; ipass++)
     {
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
         for (ParIterType pti(*this, lev); pti.isValid(); ++pti)
@@ -140,7 +140,7 @@ TracerParticleContainer::AdvectWithUcc (const MultiFab& Ucc, int lev, Real dt)
 
     for (int ipass = 0; ipass < 2; ipass++)
     {
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
         for (ParIterType pti(*this, lev); pti.isValid(); ++pti)

--- a/Tests/FillBoundaryComparison/main.cpp
+++ b/Tests/FillBoundaryComparison/main.cpp
@@ -6,7 +6,7 @@
 #include <algorithm>
 #include <fstream>
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #include <omp.h>
 #endif
 

--- a/Tests/LinearSolvers/CellEB2/MyTest.cpp
+++ b/Tests/LinearSolvers/CellEB2/MyTest.cpp
@@ -346,7 +346,7 @@ MyTest::initData ()
         const MultiCutFab& bcent = factory[ilev]->getBndryCent();
         const MultiCutFab& cent = factory[ilev]->getCentroid();
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
         for (MFIter mfi(phiexact[ilev]); mfi.isValid(); ++mfi)

--- a/Tests/LinearSolvers/CellOverset/MyTest.cpp
+++ b/Tests/LinearSolvers/CellOverset/MyTest.cpp
@@ -144,7 +144,7 @@ MyTest::initData ()
     auto a = ascalar;
     auto b = bscalar;
     auto loverset = do_overset;
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     for (MFIter mfi(rhs, TilingIfNotGPU()); mfi.isValid(); ++mfi)

--- a/Tests/LinearSolvers/MLMG/init_prob.cpp
+++ b/Tests/LinearSolvers/MLMG/init_prob.cpp
@@ -57,7 +57,7 @@ void init_prob (const Vector<Geometry>& geom, Vector<MultiFab>& alpha, Vector<Mu
     }
 
     const int nlevels = geom.size();
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel
 #endif
     for (int ilev = 0; ilev < nlevels; ++ilev)

--- a/Tests/LinearSolvers/TensorOverset/MyTest.cpp
+++ b/Tests/LinearSolvers/TensorOverset/MyTest.cpp
@@ -137,7 +137,7 @@ MyTest::initData ()
     const auto probhi = geom.ProbHiArray();
     const auto dx     = geom.CellSizeArray();
     auto loverset = do_overset;
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     for (MFIter mfi(rhs, TilingIfNotGPU()); mfi.isValid(); ++mfi)

--- a/Tests/Particles/ParticleIterator/main.cpp
+++ b/Tests/Particles/ParticleIterator/main.cpp
@@ -59,7 +59,7 @@ int main(int argc, char* argv[])
 
   amrex::AllPrintToFile("outside") << "outside parallel region. \n";
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel
 #endif
   for (ParIter<1+BL_SPACEDIM> mfi(MyPC, 0); mfi.isValid(); ++mfi) {

--- a/Tools/Postprocessing/C_Src/IntegrateComp.cpp
+++ b/Tools/Postprocessing/C_Src/IntegrateComp.cpp
@@ -164,7 +164,7 @@ main (int   argc,
         MultiFab::Copy(mf,pfData,0,0,1,nGrow);
 
         Real sm = 0;
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel reduction(+:sm)
 #endif
         for (MFIter mfi(mf,true); mfi.isValid(); ++mfi) {

--- a/Tutorials/Amr/Advection_AmrCore/Source/AdvancePhiAllLevels.cpp
+++ b/Tutorials/Amr/Advection_AmrCore/Source/AdvancePhiAllLevels.cpp
@@ -37,7 +37,7 @@ AmrCoreAdv::AdvancePhiAllLevels (Real time, Real dt_lev, int /*iteration*/)
         MultiFab Sborder(grids[lev], dmap[lev], phi_new[lev].nComp(), num_grow);
         FillPatch(lev, time, Sborder, 0, Sborder.nComp());
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
         {
@@ -297,7 +297,7 @@ AmrCoreAdv::AdvancePhiAllLevels (Real time, Real dt_lev, int /*iteration*/)
     for (int lev = 0; lev <= finest_level; lev++)
     {
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
         {

--- a/Tutorials/Amr/Advection_AmrCore/Source/AdvancePhiAtLevel.cpp
+++ b/Tutorials/Amr/Advection_AmrCore/Source/AdvancePhiAtLevel.cpp
@@ -35,7 +35,7 @@ AmrCoreAdv::AdvancePhiAtLevel (int lev, Real time, Real dt_lev, int /*iteration*
     MultiFab Sborder(grids[lev], dmap[lev], S_new.nComp(), num_grow);
     FillPatch(lev, time, Sborder, 0, Sborder.nComp());
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     {

--- a/Tutorials/Amr/Advection_AmrCore/Source/AmrCoreAdv.H
+++ b/Tutorials/Amr/Advection_AmrCore/Source/AmrCoreAdv.H
@@ -5,7 +5,7 @@
 #include <limits>
 #include <memory>
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #include <omp.h>
 #endif
 

--- a/Tutorials/Amr/Advection_AmrCore/Source/AmrCoreAdv.cpp
+++ b/Tutorials/Amr/Advection_AmrCore/Source/AmrCoreAdv.cpp
@@ -277,7 +277,7 @@ void AmrCoreAdv::MakeNewLevelFromScratch (int lev, Real time, const BoxArray& ba
     const auto problo = Geom(lev).ProbLoArray();
     const auto dx     = Geom(lev).CellSizeArray();
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     for (MFIter mfi(state,TilingIfNotGPU()); mfi.isValid(); ++mfi)
@@ -324,7 +324,7 @@ AmrCoreAdv::ErrorEst (int lev, TagBoxArray& tags, Real /*time*/, int /*ngrow*/)
 
     const MultiFab& state = phi_new[lev];
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if(Gpu::notInLaunchRegion())
 #endif
     {

--- a/Tutorials/Amr/Advection_AmrCore/Source/DefineVelocity.cpp
+++ b/Tutorials/Amr/Advection_AmrCore/Source/DefineVelocity.cpp
@@ -17,7 +17,7 @@ AmrCoreAdv::DefineVelocityAtLevel (int lev, Real time)
 {
     const auto dx = geom[lev].CellSizeArray();
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     {

--- a/Tutorials/Amr/Advection_AmrLevel/Source/AmrLevelAdv.H
+++ b/Tutorials/Amr/Advection_AmrLevel/Source/AmrLevelAdv.H
@@ -11,7 +11,7 @@
 #include <memory>
 #include <iostream>
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #include <omp.h>
 #endif
 

--- a/Tutorials/Amr/Advection_AmrLevel/Source/AmrLevelAdv.cpp
+++ b/Tutorials/Amr/Advection_AmrLevel/Source/AmrLevelAdv.cpp
@@ -284,7 +284,7 @@ AmrLevelAdv::advance (Real time,
       Umac[i].define(ba, dmap, 1, iteration);
     }
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel
 #endif
     {
@@ -366,7 +366,7 @@ AmrLevelAdv::estTimeStep (Real)
     const Real cur_time = state[Phi_Type].curTime();
     const MultiFab& S_new = get_new_data(Phi_Type);
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel reduction(min:dt_est)
 #endif
     {
@@ -628,7 +628,7 @@ AmrLevelAdv::errorEst (TagBoxArray& tags,
 
     MultiFab& S_new = get_new_data(Phi_Type);
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel
 #endif
     {

--- a/Tutorials/Blueprint/CellSortedParticles/CellSortedPC.cpp
+++ b/Tutorials/Blueprint/CellSortedParticles/CellSortedPC.cpp
@@ -143,7 +143,7 @@ CellSortedParticleContainer::UpdateCellVectors()
     }
 
     // insert particles into vectors - this can be tiled
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel
 #endif    
     for (MyParIter pti(*this, lev); pti.isValid(); ++pti)
@@ -172,7 +172,7 @@ CellSortedParticleContainer::UpdateFortranStructures()
     
     const int lev = 0;
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel
 #endif
     for (MFIter mfi = MakeMFIter(lev); mfi.isValid(); ++mfi)
@@ -199,7 +199,7 @@ CellSortedParticleContainer::MoveParticles()
     const Real* plo = Geom(lev).ProbLo();
     const Real dt = 0.1;
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel
 #endif
     for (MyParIter pti(*this, lev); pti.isValid(); ++pti)
@@ -237,7 +237,7 @@ CellSortedParticleContainer::ReBin()
     
     const int lev = 0;
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel
 #endif
     for (MyParIter pti(*this, lev); pti.isValid(); ++pti)
@@ -288,7 +288,7 @@ CellSortedParticleContainer::SumCellVectors()
   const int lev = 0;
   int np = 0;
   
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel reduction(+:np)
 #endif    
     for (MyParIter pti(*this, lev); pti.isValid(); ++pti)
@@ -310,7 +310,7 @@ CellSortedParticleContainer::numUnsorted()
     const int lev = 0;
     int num_unsorted = 0;
     
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel reduction(+:num_unsorted)
 #endif    
     for (MyParIter pti(*this, lev); pti.isValid(); ++pti)
@@ -335,7 +335,7 @@ CellSortedParticleContainer::numWrongCell()
     const int lev = 0;
     int num_wrong = 0;
     
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel reduction(+:num_wrong)
 #endif    
     for (MyParIter pti(*this, lev); pti.isValid(); ++pti)

--- a/Tutorials/EB/CNS/Source/CNS.cpp
+++ b/Tutorials/EB/CNS/Source/CNS.cpp
@@ -98,7 +98,7 @@ CNS::initData ()
     MultiFab& S_new = get_new_data(State_Type);
     Real cur_time   = state[State_Type].curTime();
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel
 #endif
     for (MFIter mfi(S_new); mfi.isValid(); ++mfi)
@@ -318,7 +318,7 @@ CNS::errorEst (TagBoxArray& tags, int, int, Real time, int, int)
         const Real* problo = geom.ProbLo();
         const Real* dx = geom.CellSize();
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel
 #endif
         for (MFIter mfi(tags); mfi.isValid(); ++mfi)
@@ -352,7 +352,7 @@ CNS::errorEst (TagBoxArray& tags, int, int, Real time, int, int)
         auto const& fact = dynamic_cast<EBFArrayBoxFactory const&>(S_new.Factory());
         auto const& flags = fact.getMultiEBCellFlagFab();
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel
 #endif
         for (MFIter mfi(*rho,true); mfi.isValid(); ++mfi)
@@ -475,7 +475,7 @@ CNS::estTimeStep ()
     auto const& fact = dynamic_cast<EBFArrayBoxFactory const&>(S.Factory());
     auto const& flags = fact.getMultiEBCellFlagFab();
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel reduction(min:estdt)
 #endif
     {
@@ -515,7 +515,7 @@ CNS::computeTemp (MultiFab& State, int ng)
     auto const& flags = fact.getMultiEBCellFlagFab();
 
     // This will reset Eint and compute Temperature 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel
 #endif
     for (MFIter mfi(State,true); mfi.isValid(); ++mfi)

--- a/Tutorials/EB/CNS/Source/CNS_advance.cpp
+++ b/Tutorials/EB/CNS/Source/CNS_advance.cpp
@@ -78,7 +78,7 @@ CNS::compute_dSdt (const MultiFab& S, MultiFab& dSdt, Real dt,
     auto const& fact = dynamic_cast<EBFArrayBoxFactory const&>(S.Factory());
     auto const& flags = fact.getMultiEBCellFlagFab();
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel
 #endif
     {

--- a/Tutorials/EB/Poisson/Poisson.cpp
+++ b/Tutorials/EB/Poisson/Poisson.cpp
@@ -4,7 +4,7 @@ using namespace amrex;
 
 void InitData (MultiFab& State)
 {
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel
 #endif
     for (MFIter mfi(State,true); mfi.isValid(); ++mfi)

--- a/Tutorials/GPU/CNS/Source/CNS.cpp
+++ b/Tutorials/GPU/CNS/Source/CNS.cpp
@@ -84,7 +84,7 @@ CNS::initData ()
     Parm const* lparm = parm.get();
     ProbParm const* lprobparm = prob_parm.get();
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     for (MFIter mfi(S_new); mfi.isValid(); ++mfi)
@@ -305,7 +305,7 @@ CNS::errorEst (TagBoxArray& tags, int, int, Real /*time*/, int, int)
 //        const char clearval = TagBox::CLEAR;
         const Real dengrad_threshold = refine_dengrad;
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
         for (MFIter mfi(rho,TilingIfNotGPU()); mfi.isValid(); ++mfi)
@@ -423,7 +423,7 @@ CNS::computeTemp (MultiFab& State, int ng)
     Parm const* lparm = parm.get();
 
     // This will reset Eint and compute Temperature 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     for (MFIter mfi(State,TilingIfNotGPU()); mfi.isValid(); ++mfi)

--- a/Tutorials/GPU/EBCNS/Source/CNS.cpp
+++ b/Tutorials/GPU/EBCNS/Source/CNS.cpp
@@ -87,7 +87,7 @@ CNS::initData ()
     const auto geomdata = geom.data();
     MultiFab& S_new = get_new_data(State_Type);
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     for (MFIter mfi(S_new); mfi.isValid(); ++mfi)
@@ -308,7 +308,7 @@ CNS::errorEst (TagBoxArray& tags, int, int, Real time, int, int)
 //        const char clearval = TagBox::CLEAR;
         const Real dengrad_threshold = refine_dengrad;
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
         for (MFIter mfi(rho,TilingIfNotGPU()); mfi.isValid(); ++mfi)
@@ -438,7 +438,7 @@ CNS::computeTemp (MultiFab& State, int ng)
     BL_PROFILE("CNS::computeTemp()");
 
     // This will reset Eint and compute Temperature
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     for (MFIter mfi(State,TilingIfNotGPU()); mfi.isValid(); ++mfi)

--- a/Tutorials/LinearSolvers/ABecLaplacian_C/initProb.cpp
+++ b/Tutorials/LinearSolvers/ABecLaplacian_C/initProb.cpp
@@ -11,7 +11,7 @@ MyTest::initProbPoisson ()
     {
         const auto prob_lo = geom[ilev].ProbLoArray();
         const auto dx      = geom[ilev].CellSizeArray();
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
         for (MFIter mfi(rhs[ilev], TilingIfNotGPU()); mfi.isValid(); ++mfi)
@@ -40,7 +40,7 @@ MyTest::initProbABecLaplacian ()
         const auto dx      = geom[ilev].CellSizeArray();
         auto a = ascalar;
         auto b = bscalar;
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
         for (MFIter mfi(rhs[ilev], TilingIfNotGPU()); mfi.isValid(); ++mfi)
@@ -82,7 +82,7 @@ MyTest::initProbABecLaplacianInhomNeumann ()
         Box const& domain = geom[ilev].Domain();
         auto a = ascalar;
         auto b = bscalar;
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
         for (MFIter mfi(rhs[ilev], TilingIfNotGPU()); mfi.isValid(); ++mfi)

--- a/Tutorials/LinearSolvers/MultiComponent/MCNodalLinOp.cpp
+++ b/Tutorials/LinearSolvers/MultiComponent/MCNodalLinOp.cpp
@@ -346,7 +346,7 @@ void MCNodalLinOp::fixUpResidualMask (int amrlev, iMultiFab& resmsk)
 
 	const iMultiFab& cfmask = *m_nd_fine_mask[amrlev];
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel
 #endif
 	for (MFIter mfi(resmsk,true); mfi.isValid(); ++mfi)

--- a/Tutorials/LinearSolvers/NodalPoisson/MyTest.cpp
+++ b/Tutorials/LinearSolvers/NodalPoisson/MyTest.cpp
@@ -197,7 +197,7 @@ MyTest::initData ()
 
         const auto dx = geom[ilev].CellSizeArray();
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
         for (MFIter mfi(rhs[ilev],TilingIfNotGPU()); mfi.isValid(); ++mfi)

--- a/Tutorials/LinearSolvers/NodeTensorLap/MyTest.cpp
+++ b/Tutorials/LinearSolvers/NodeTensorLap/MyTest.cpp
@@ -151,7 +151,7 @@ MyTest::initData ()
 
         const auto dx = geom[ilev].CellSizeArray();
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
         for (MFIter mfi(rhs[ilev],TilingIfNotGPU()); mfi.isValid(); ++mfi)

--- a/Tutorials/Particles/CellSortedParticles/CellSortedPC.cpp
+++ b/Tutorials/Particles/CellSortedParticles/CellSortedPC.cpp
@@ -143,7 +143,7 @@ CellSortedParticleContainer::UpdateCellVectors()
     }
 
     // insert particles into vectors - this can be tiled
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel
 #endif    
     for (MyParIter pti(*this, lev); pti.isValid(); ++pti)
@@ -172,7 +172,7 @@ CellSortedParticleContainer::UpdateFortranStructures()
     
     const int lev = 0;
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel
 #endif
     for (MFIter mfi = MakeMFIter(lev); mfi.isValid(); ++mfi)
@@ -199,7 +199,7 @@ CellSortedParticleContainer::MoveParticles()
     const Real* plo = Geom(lev).ProbLo();
     const Real dt = 0.1;
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel
 #endif
     for (MyParIter pti(*this, lev); pti.isValid(); ++pti)
@@ -237,7 +237,7 @@ CellSortedParticleContainer::ReBin()
     
     const int lev = 0;
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel
 #endif
     for (MyParIter pti(*this, lev); pti.isValid(); ++pti)
@@ -288,7 +288,7 @@ CellSortedParticleContainer::SumCellVectors()
   const int lev = 0;
   int np = 0;
   
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel reduction(+:np)
 #endif    
     for (MyParIter pti(*this, lev); pti.isValid(); ++pti)
@@ -310,7 +310,7 @@ CellSortedParticleContainer::numUnsorted()
     const int lev = 0;
     int num_unsorted = 0;
     
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel reduction(+:num_unsorted)
 #endif    
     for (MyParIter pti(*this, lev); pti.isValid(); ++pti)
@@ -335,7 +335,7 @@ CellSortedParticleContainer::numWrongCell()
     const int lev = 0;
     int num_wrong = 0;
     
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel reduction(+:num_wrong)
 #endif    
     for (MyParIter pti(*this, lev); pti.isValid(); ++pti)


### PR DESCRIPTION
## Summary

Replace the define `_OPENMP` with `AMREX_USE_OMP` for all parallel "backend" implementations and control of MFIter loops.

This avoids accidentially enabling OpenMP for the parallel compute components, i.e. when a users explicitly uses OpenMP in auxiliary or implicit dependent functionality, but does not request to also OpenMP-parallelize those sections.

- [x] search & replace
- [x] self-review and review

## Additional background

Ref.: https://github.com/AMReX-Codes/amrex/pull/1558#discussion_r526466768

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
