### PR TITLE
CI: MSVC + OpenMP

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -15,3 +15,16 @@ jobs:
         cd build
         cmake .. -DCMAKE_BUILD_TYPE=Debug -DCMAKE_VERBOSE_MAKEFILE=ON -DAMReX_BUILD_TUTORIALS=ON -DAMReX_FORTRAN=OFF -DAMReX_MPI=OFF
         cmake --build . --config Debug
+
+  # Build libamrex and all tutorials
+  tutorials_omp:
+    name: MSVC C++17 w/ OMP w/o MPI w/o Fortran
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build & Install
+      run: |
+        mkdir build
+        cd build
+        cmake .. -DCMAKE_BUILD_TYPE=Debug -DCMAKE_VERBOSE_MAKEFILE=ON -DAMReX_BUILD_TUTORIALS=ON -DAMReX_FORTRAN=OFF -DAMReX_MPI=OFF -DAMReX_OMP=ON
+        cmake --build . --config Debug

--- a/Src/Base/AMReX_BLBackTrace.H
+++ b/Src/Base/AMReX_BLBackTrace.H
@@ -28,8 +28,8 @@ struct BLBackTrace
     static void print_backtrace_info (const std::string& filename);
 
     static std::stack<std::pair<std::string, std::string> > bt_stack;
-// threadprivate here doesn't work with Cray and Intel
-#if defined(_OPENMP) && !defined(_CRAYC) && !defined(__INTEL_COMPILER) && !defined(__PGI)
+// threadprivate here doesn't work with Cray, Intel, PGI and MSVC
+#if defined(_OPENMP) && !defined(_CRAYC) && !defined(__INTEL_COMPILER) && !defined(__PGI) && !defined(_MSC_VER)
 #pragma omp threadprivate(bt_stack)
 #endif
 };

--- a/Src/Base/AMReX_BaseFab.H
+++ b/Src/Base/AMReX_BaseFab.H
@@ -40,15 +40,22 @@ extern std::atomic<Long> atomic_total_bytes_allocated_in_fabs;
 extern std::atomic<Long> atomic_total_bytes_allocated_in_fabs_hwm;
 extern std::atomic<Long> atomic_total_cells_allocated_in_fabs;
 extern std::atomic<Long> atomic_total_cells_allocated_in_fabs_hwm;
+#ifdef _MSC_VER
+extern __declspec(thread) Long private_total_bytes_allocated_in_fabs;
+extern __declspec(thread) Long private_total_bytes_allocated_in_fabs_hwm;
+extern __declspec(thread) Long private_total_cells_allocated_in_fabs;
+extern __declspec(thread) Long private_total_cells_allocated_in_fabs_hwm;
+#else
 extern Long private_total_bytes_allocated_in_fabs;     //!< total bytes at any given time
 extern Long private_total_bytes_allocated_in_fabs_hwm; //!< high-water-mark over a given interval
 extern Long private_total_cells_allocated_in_fabs;     //!< total cells at any given time
 extern Long private_total_cells_allocated_in_fabs_hwm; //!< high-water-mark over a given interval
-#ifdef _OPENMP
-#pragma omp threadprivate(private_total_bytes_allocated_in_fabs)
-#pragma omp threadprivate(private_total_bytes_allocated_in_fabs_hwm)
-#pragma omp threadprivate(private_total_cells_allocated_in_fabs)
-#pragma omp threadprivate(private_total_cells_allocated_in_fabs_hwm)
+#   ifdef _OPENMP
+#       pragma omp threadprivate(private_total_bytes_allocated_in_fabs)
+#       pragma omp threadprivate(private_total_bytes_allocated_in_fabs_hwm)
+#       pragma omp threadprivate(private_total_cells_allocated_in_fabs)
+#       pragma omp threadprivate(private_total_cells_allocated_in_fabs_hwm)
+#   endif
 #endif
 
 Long TotalBytesAllocatedInFabs () noexcept;

--- a/Src/Base/AMReX_BoxArray.H
+++ b/Src/Base/AMReX_BoxArray.H
@@ -2,15 +2,17 @@
 #ifndef BL_BOXARRAY_H
 #define BL_BOXARRAY_H
 
+#include <AMReX_Array.H>
+#include <AMReX_BoxList.H>
+#include <AMReX_IndexType.H>
+#include <AMReX_OpenMP.H>
+#include <AMReX_Vector.H>
+
 #include <iostream>
 #include <cstddef>
 #include <map>
 #include <unordered_map>
 
-#include <AMReX_IndexType.H>
-#include <AMReX_BoxList.H>
-#include <AMReX_Array.H>
-#include <AMReX_Vector.H>
 
 namespace amrex
 {
@@ -74,12 +76,17 @@ struct BARef
 #endif
 
     inline bool HasHashMap () const {
+#ifdef _MSC_VER
+        int r = 0;
+        AMREX_OMP_ATOMIC_READ
+        r += has_hashmap;
+        return bool(r);
+#else
         bool r;
-#ifdef _OPENMP
-#pragma omp atomic read
-#endif
+        AMREX_OMP_ATOMIC_READ
         r = has_hashmap;
         return r;
+#endif
     }
 
     //

--- a/Src/Base/AMReX_BoxArray.cpp
+++ b/Src/Base/AMReX_BoxArray.cpp
@@ -1526,8 +1526,12 @@ BoxArray::getHashMap () const
 #endif
 
 #ifdef _OPENMP
-#pragma omp flush
-#pragma omp atomic write
+#   pragma omp flush
+#   ifdef _MSC_VER
+#       pragma omp critical
+#   else
+#       pragma omp atomic write
+#   endif
 #endif
             m_ref->has_hashmap = true;
         }

--- a/Src/Base/AMReX_FabArrayUtility.H
+++ b/Src/Base/AMReX_FabArrayUtility.H
@@ -1808,7 +1808,7 @@ indexFromValue (FabArray<FAB> const& mf, int comp, IntVect const& nghost,
                 bool old;
 // we should be able to test on _OPENMP < 201107 for capture (version 3.1)
 // but we must work around a bug in gcc < 4.9
-#if defined(_OPENMP) && _OPENMP < 201307 // OpenMP 4.0
+#if defined(_OPENMP) && (_OPENMP < 201307 || defined(_MSC_VER)) // OpenMP 4.0
 #pragma omp critical (amrex_indexfromvalue)
 #elif defined(_OPENMP)
 #pragma omp atomic capture

--- a/Src/Base/AMReX_FabArrayUtility.H
+++ b/Src/Base/AMReX_FabArrayUtility.H
@@ -352,7 +352,7 @@ ReduceMin_host (FabArray<FAB> const& fa, IntVect const& nghost, F&& f)
     constexpr value_type value_max = std::numeric_limits<value_type>::max();
     value_type r = value_max;
 
-#ifdef _OPENMP
+#if defined(_OPENMP) && !defined(_MSC_VER)
 #pragma omp parallel reduction(min:r)
 #endif
     for (MFIter mfi(fa,true); mfi.isValid(); ++mfi)
@@ -456,7 +456,7 @@ ReduceMin_host (FabArray<FAB1> const& fa1, FabArray<FAB2> const& fa2,
     constexpr value_type value_max = std::numeric_limits<value_type>::max();
     value_type r = value_max;
 
-#ifdef _OPENMP
+#if defined(_OPENMP) && !defined(_MSC_VER)
 #pragma omp parallel reduction(min:r)
 #endif
     for (MFIter mfi(fa1,true); mfi.isValid(); ++mfi)
@@ -569,7 +569,7 @@ ReduceMin_host (FabArray<FAB1> const& fa1, FabArray<FAB2> const& fa2,
     constexpr value_type value_max = std::numeric_limits<value_type>::max();
     value_type r = value_max;
 
-#ifdef _OPENMP
+#if defined(_OPENMP) && !defined(_MSC_VER)
 #pragma omp parallel reduction(min:r)
 #endif
     for (MFIter mfi(fa1,true); mfi.isValid(); ++mfi)
@@ -682,7 +682,7 @@ ReduceMax_host (FabArray<FAB> const& fa, IntVect const& nghost, F&& f)
     constexpr value_type value_lowest = std::numeric_limits<value_type>::lowest();
     value_type r = value_lowest;
 
-#ifdef _OPENMP
+#if defined(_OPENMP) && !defined(_MSC_VER)
 #pragma omp parallel reduction(max:r)
 #endif
     for (MFIter mfi(fa,true); mfi.isValid(); ++mfi)
@@ -787,7 +787,7 @@ ReduceMax_host (FabArray<FAB1> const& fa1, FabArray<FAB2> const& fa2,
     constexpr value_type value_lowest = std::numeric_limits<value_type>::lowest();
     value_type r = value_lowest;
 
-#ifdef _OPENMP
+#if defined(_OPENMP) && !defined(_MSC_VER)
 #pragma omp parallel reduction(max:r)
 #endif
     for (MFIter mfi(fa1,true); mfi.isValid(); ++mfi)
@@ -900,7 +900,7 @@ ReduceMax_host (FabArray<FAB1> const& fa1, FabArray<FAB2> const& fa2,
     constexpr value_type value_lowest = std::numeric_limits<value_type>::lowest();
     value_type r = value_lowest;
 
-#ifdef _OPENMP
+#if defined(_OPENMP) && !defined(_MSC_VER)
 #pragma omp parallel reduction(max:r)
 #endif
     for (MFIter mfi(fa1,true); mfi.isValid(); ++mfi)

--- a/Src/Base/AMReX_GpuAtomic.H
+++ b/Src/Base/AMReX_GpuAtomic.H
@@ -443,7 +443,11 @@ namespace HostDevice { namespace Atomic {
         Gpu::Atomic::AddNoRet(sum,value);
 #else
 #ifdef _OPENMP
-#pragma omp atomic update
+#   ifdef _MSC_VER
+#       pragma omp atomic
+#   else
+#       pragma omp atomic update
+#   endif
 #endif
         *sum += value;
 #endif

--- a/Src/Base/AMReX_MFIter.cpp
+++ b/Src/Base/AMReX_MFIter.cpp
@@ -497,7 +497,7 @@ MFIter::grownnodaltilebox (int dir, IntVect const& a_ng) const noexcept
 void
 MFIter::operator++ () noexcept
 {
-#ifdef _OPENMP
+#if defined(_OPENMP) && !defined(_MSC_VER)
     if (dynamic)
     {
 #pragma omp atomic capture

--- a/Src/Base/AMReX_OpenMP.H
+++ b/Src/Base/AMReX_OpenMP.H
@@ -14,6 +14,13 @@ namespace OpenMP {
 
 }}
 
+// work-arounds
+#   ifdef _MSC_VER
+#       define AMREX_OMP_ATOMIC_READ __pragma(omp atomic)
+#   else
+#       define AMREX_OMP_ATOMIC_READ _Pragma("omp atomic read")
+#   endif
+
 #else
 
 namespace amrex {
@@ -26,6 +33,9 @@ namespace OpenMP {
 
 }}
 
-#endif
+// work-arounds
+#   define AMREX_OMP_ATOMIC_READ
 
-#endif
+#endif // _OPENMP
+
+#endif // AMREX_OPENMP_H_

--- a/Src/EB/AMReX_EB2_Level.cpp
+++ b/Src/EB/AMReX_EB2_Level.cpp
@@ -97,7 +97,7 @@ Level::coarsenFromFine (Level& fineLevel, bool fill_boundary)
 
     if (Gpu::notInLaunchRegion())
     {
-#ifdef _OPENMP
+#if defined(_OPENMP) && !defined(_MSC_VER)
 #pragma omp parallel reduction(max:mvmc_error)
 #endif
         for (MFIter mfi(m_levelset,true); mfi.isValid(); ++mfi)
@@ -248,7 +248,7 @@ Level::coarsenFromFine (Level& fineLevel, bool fill_boundary)
 
     if (Gpu::notInLaunchRegion())
     {
-#ifdef _OPENMP
+#if defined(_OPENMP) && !defined(_MSC_VER)
 #pragma omp parallel reduction(max:error)
 #endif
         for (MFIter mfi(m_volfrac,true); mfi.isValid(); ++mfi)

--- a/Src/Particle/AMReX_ParIter.H
+++ b/Src/Particle/AMReX_ParIter.H
@@ -42,7 +42,7 @@ public:
 
     ParIterBase (ContainerRef pc, int level, MFItInfo& info);
 
-#ifdef _OPENMP
+#if defined(_OPENMP) && !defined(_MSC_VER)
     void operator++ ()
     {
         if (dynamic) {

--- a/Src/Particle/AMReX_Particle.H
+++ b/Src/Particle/AMReX_Particle.H
@@ -762,7 +762,7 @@ Particle<NReal, NInt>::NextID ()
     Long next;
 // we should be able to test on _OPENMP < 201107 for capture (version 3.1)
 // but we must work around a bug in gcc < 4.9
-#if defined(_OPENMP) && _OPENMP < 201307
+#if defined(_OPENMP) && (_OPENMP < 201307 || defined(_MSC_VER)) // OpenMP 4.0
 #pragma omp critical (amrex_particle_nextid)
 #elif defined(_OPENMP)
 #pragma omp atomic capture

--- a/Src/Particle/AMReX_ParticleReduce.H
+++ b/Src/Particle/AMReX_ParticleReduce.H
@@ -243,7 +243,7 @@ ReduceMax (PC const& pc, int lev_min, int lev_max, F&& f) -> decltype(f(typename
     {
         for (int lev = lev_min; lev <= lev_max; ++lev)
         {
-#ifdef _OPENMP
+#if defined(_OPENMP) && !defined(_MSC_VER)
 #pragma omp parallel if (!system::regtest_reduction) reduction(max:r)
 #endif
             for(ParIter pti(pc, lev); pti.isValid(); ++pti)
@@ -367,7 +367,7 @@ ReduceMin (PC const& pc, int lev_min, int lev_max, F&& f) -> decltype(f(typename
     {
         for (int lev = lev_min; lev <= lev_max; ++lev)
         {
-#ifdef _OPENMP
+#if defined(_OPENMP) && !defined(_MSC_VER)
 #pragma omp parallel if (!system::regtest_reduction) reduction(min:r)
 #endif
             for(ParIter pti(pc, lev); pti.isValid(); ++pti)

--- a/Tutorials/Amr/Advection_AmrLevel/Source/AmrLevelAdv.cpp
+++ b/Tutorials/Amr/Advection_AmrLevel/Source/AmrLevelAdv.cpp
@@ -366,7 +366,7 @@ AmrLevelAdv::estTimeStep (Real)
     const Real cur_time = state[Phi_Type].curTime();
     const MultiFab& S_new = get_new_data(Phi_Type);
 
-#ifdef _OPENMP
+#if defined(_OPENMP) && !defined(_MSC_VER)
 #pragma omp parallel reduction(min:dt_est)
 #endif
     {

--- a/Tutorials/EB/CNS/Source/CNS.cpp
+++ b/Tutorials/EB/CNS/Source/CNS.cpp
@@ -475,7 +475,7 @@ CNS::estTimeStep ()
     auto const& fact = dynamic_cast<EBFArrayBoxFactory const&>(S.Factory());
     auto const& flags = fact.getMultiEBCellFlagFab();
 
-#ifdef _OPENMP
+#if defined(_OPENMP) && !defined(_MSC_VER)
 #pragma omp parallel reduction(min:estdt)
 #endif
     {


### PR DESCRIPTION
## Summary

Try if we can compile with MSVC's OpenMP support on Windows.

## Additional background

Wow, OpenMP 2.0 support (`_OPENMP` is `200203`) but exposes itself as `2019` with `/openmp:experimental`, which in turn just adds some SIMD parts: https://docs.microsoft.com/en-us/cpp/build/reference/openmp-enable-openmp-2-0-support?view=msvc-160

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
