### PR TITLE
If TheZeroVector() is passed in to SortParticlesByBin, do nothing instead of crashing.

### DIFF
--- a/Src/Particle/AMReX_ParticleContainerI.H
+++ b/Src/Particle/AMReX_ParticleContainerI.H
@@ -1051,6 +1051,8 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>::SortParticles
 {
     BL_PROFILE("ParticleContainer::SortParticlesByBin()");
 
+    if (bin_size == IntVect::TheZeroVector()) return;
+
     for (int lev = 0; lev < numLevels(); ++lev)
     {
         const Geometry& geom = Geom(lev);

--- a/Src/Particle/AMReX_Particles.H
+++ b/Src/Particle/AMReX_Particles.H
@@ -578,9 +578,12 @@ public:
 
     /**
      * \brief Sort the particles on each tile by groups of cells, given an IntVect bin_size
+     *
+     *        If bin_size is the zero vector, this operation is a no-op.
+     *
      */
     void SortParticlesByBin (IntVect bin_size);
-	
+
     /**
     * \brief OK checks that all particles are in the right places (for some value of right)
     *


### PR DESCRIPTION
The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
