### PR TITLE
EB2::PolyIF

### DIFF
--- a/Src/EB/AMReX_EB2_IF_Polynomial.H
+++ b/Src/EB/AMReX_EB2_IF_Polynomial.H
@@ -28,12 +28,46 @@ public:
     IntVect powers;
 };
 
-
-
-class PolynomialIF
-#ifndef AMREX_DEBUG
+template <unsigned int N>
+class PolyIF
     : public GPUable
-#endif
+{
+public:
+
+    //! inside: is the fluid inside the ellipsoid?
+    PolyIF (const GpuArray<PolyTerm,N> & a_polynomial, bool a_inside = true)
+        : m_polynomial(a_polynomial),
+          m_sign( a_inside ? 1.0 : -1.0 )
+    {}
+
+    PolyIF (const PolyIF& rhs) = default;
+    PolyIF (PolyIF&& rhs) = default;
+    PolyIF& operator= (const PolyIF& rhs) = delete;
+    PolyIF& operator= (PolyIF&& rhs) = delete;
+
+    AMREX_GPU_HOST_DEVICE inline
+    Real operator() (AMREX_D_DECL(Real x, Real y, Real z)) const noexcept
+    {
+        Real retval = 0.0_rt;
+        for (auto const& term : m_polynomial) {
+            retval += term.coef * AMREX_D_TERM(  std::pow(x, term.powers[0]),
+                                               * std::pow(y, term.powers[1]),
+                                               * std::pow(z, term.powers[2]));
+        }
+        return m_sign*retval;
+    }
+
+    inline Real operator() (const RealArray& p) const noexcept {
+        return this->operator()(AMREX_D_DECL(p[0],p[1],p[2]));
+    }
+
+protected:
+    GpuArray<PolyTerm,N> m_polynomial;
+    Real                 m_sign;
+};
+
+
+class PolynomialIF  // No GPU support
 {
 public:
 
@@ -42,34 +76,22 @@ public:
         : m_polynomial(a_polynomial),
           m_inside(a_inside),
           m_sign( a_inside ? 1.0 : -1.0 ),
-          m_size(m_polynomial.size()),
-          m_dp(static_cast<PolyTerm*>(The_Device_Arena()->alloc(sizeof(PolyTerm)*m_size))),
-          m_sp(m_dp,Gpu::Deleter(The_Device_Arena()))
-    {
-#ifdef AMREX_USE_GPU
-        Gpu::htod_memcpy(m_dp, m_polynomial.data(), m_size*sizeof(PolyTerm));
-#endif
-    }
-
+          m_size(m_polynomial.size())
+    {}
 
     PolynomialIF (const PolynomialIF& rhs) = default;
     PolynomialIF (PolynomialIF&& rhs) = default;
     PolynomialIF& operator= (const PolynomialIF& rhs) = delete;
     PolynomialIF& operator= (PolynomialIF&& rhs) = delete;
 
-    AMREX_GPU_HOST_DEVICE inline
+    inline
     Real operator() (AMREX_D_DECL(Real x, Real y, Real z)) const noexcept
     {
-#if AMREX_DEVICE_COMPILE
-        PolyTerm const* AMREX_RESTRICT pt = m_dp;
-#else
-        PolyTerm const* AMREX_RESTRICT pt = m_polynomial.data();
-#endif
-        Real retval = 0.0;
-        for (int iterm = 0; iterm < m_size; ++iterm) {
-            retval += pt[iterm].coef * AMREX_D_TERM(  std::pow(x, pt[iterm].powers[0]),
-                                                    * std::pow(y, pt[iterm].powers[1]),
-                                                    * std::pow(z, pt[iterm].powers[2]));
+        Real retval = 0.0_rt;
+        for (auto const& term : m_polynomial) {
+            retval += term.coef * AMREX_D_TERM(  std::pow(x, term.powers[0]),
+                                               * std::pow(y, term.powers[1]),
+                                               * std::pow(z, term.powers[2]));
         }
         return m_sign*retval;
     }
@@ -83,8 +105,6 @@ protected:
     bool             m_inside;
     Real             m_sign;
     int              m_size;
-    PolyTerm*        m_dp;
-    std::shared_ptr<PolyTerm> m_sp;
 };
 
 }}


### PR DESCRIPTION
## Summary

The existing PolynomialIF contains a dynamic size vector.  This makes it
hard to support it on GPU.  We have used an undocumented feature to get this
run on GPU.  However, this code can no longer compile, because the GNU make
system now makes cross execution space calls an error.  So we disable GPU
support for PolynomialIF and add a new PolyIF class with fixed size array
and therefore GPU support.

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
