### PR TITLE
Template specialization of MPI communication functions for char

### DIFF
--- a/Src/Base/AMReX_Arena.H
+++ b/Src/Base/AMReX_Arena.H
@@ -11,7 +11,15 @@ namespace amrex {
  * \brief Given a minimum required size of size bytes, this returns
  * the next largest arena size that will align to align_requirement bytes
  */
-std::size_t aligned_size (std::size_t align_requirement, std::size_t size);
+inline std::size_t aligned_size (std::size_t align_requirement, std::size_t size) noexcept
+{
+    return ((size + (align_requirement-1)) / align_requirement) * align_requirement;
+}
+
+inline bool is_aligned (const void* p, std::size_t alignment) noexcept
+{
+    return (reinterpret_cast<std::size_t>(p) % alignment) == 0;
+}
 
 class Arena;
 

--- a/Src/Base/AMReX_Arena.cpp
+++ b/Src/Base/AMReX_Arena.cpp
@@ -50,12 +50,6 @@ const std::size_t Arena::align_size;
 Arena::~Arena () {}
 
 std::size_t
-aligned_size (std::size_t align_requirement, std::size_t size)
-{
-    return ((size + (align_requirement-1)) / align_requirement) * align_requirement;
-}
-
-std::size_t
 Arena::align (std::size_t s)
 {
     return amrex::aligned_size(align_size, s);

--- a/Src/Base/AMReX_FabArrayCommI.H
+++ b/Src/Base/AMReX_FabArrayCommI.H
@@ -632,25 +632,8 @@ FabArray<FAB>::PostSnds (Vector<char*> const&       send_data,
     {
         if (send_size[j] > 0) {
             const int rank = ParallelContext::global_to_local_rank(send_rank[j]);
-            const int comm_data_type = ParallelDescriptor::select_comm_data_type(send_size[j]);
-            if (comm_data_type == 1) {
-                send_reqs[j] = ParallelDescriptor::Asend
-                    (send_data[j],
-                     send_size[j],
-                     rank, SeqNum, comm).req();
-            } else if (comm_data_type == 2) {
-                send_reqs[j] = ParallelDescriptor::Asend
-                    ((unsigned long long *)send_data[j],
-                     send_size[j]/sizeof(unsigned long long),
-                     rank, SeqNum, comm).req();
-            } else if (comm_data_type == 3) {
-                send_reqs[j] = ParallelDescriptor::Asend
-                    ((ParallelDescriptor::lull_t *)send_data[j],
-                     send_size[j]/sizeof(ParallelDescriptor::lull_t),
-                     rank, SeqNum, comm).req();
-            } else {
-                amrex::Abort("TODO: message size is too big");
-            }
+            send_reqs[j] = ParallelDescriptor::Asend
+                (send_data[j], send_size[j], rank, SeqNum, comm).req();
         }
     }
 }
@@ -715,25 +698,8 @@ FabArray<FAB>::PostRcvs (const MapOfCopyComTagContainers&  RcvTags,
             if (recv_size[i] > 0)
             {
                 const int rank = ParallelContext::global_to_local_rank(recv_from[i]);
-                const int comm_data_type = ParallelDescriptor::select_comm_data_type(recv_size[i]);
-                if (comm_data_type == 1) {
-                    recv_reqs[i] = ParallelDescriptor::Arecv
-                        (recv_data[i],
-                         recv_size[i],
-                         rank, SeqNum, comm).req();
-                } else if (comm_data_type == 2) {
-                    recv_reqs[i] = ParallelDescriptor::Arecv
-                        ((unsigned long long *)recv_data[i],
-                         recv_size[i]/sizeof(unsigned long long),
-                         rank, SeqNum, comm).req();
-                } else if (comm_data_type == 3) {
-                    recv_reqs[i] = ParallelDescriptor::Arecv
-                        ((ParallelDescriptor::lull_t *)recv_data[i],
-                         recv_size[i]/sizeof(ParallelDescriptor::lull_t),
-                         rank, SeqNum, comm).req();
-                } else {
-                    amrex::Abort("TODO: message size is too big");
-                }
+                recv_reqs[i] = ParallelDescriptor::Arecv
+                    (recv_data[i], recv_size[i], rank, SeqNum, comm).req();
             }
         }
     }

--- a/Src/Base/AMReX_ParallelDescriptor.H
+++ b/Src/Base/AMReX_ParallelDescriptor.H
@@ -592,34 +592,22 @@ namespace amrex {
 #ifdef BL_USE_MPI
 template <class T>
 ParallelDescriptor::Message
-ParallelDescriptor::Asend (const T* buf,
-                           size_t   n,
-                           int      dst_pid,
-                           int      tag)
+ParallelDescriptor::Asend (const T* buf, size_t n, int dst_pid, int tag)
 {
-    BL_PROFILE_T_S("ParallelDescriptor::Asend(Tsii)", T);
-    BL_COMM_PROFILE(BLProfiler::AsendTsii, n * sizeof(T), dst_pid, tag);
-
-    MPI_Request req;
-    BL_MPI_REQUIRE( MPI_Isend(const_cast<T*>(buf),
-                              n,
-                              Mpi_typemap<T>::type(),
-                              dst_pid,
-                              tag,
-                              Communicator(),
-                              &req) );
-    BL_COMM_PROFILE(BLProfiler::AsendTsii, BLProfiler::AfterCall(), dst_pid, tag);
-    return Message(req, Mpi_typemap<T>::type());
+    return Asend(buf, n, dst_pid, tag, Communicator());
 }
 
+namespace ParallelDescriptor {  // Have to use namespace here to work around a gcc bug
+template <>
+Message
+Asend<char> (const char* buf, size_t n, int dst_pid, int tag, MPI_Comm comm);
+
 template <class T>
-ParallelDescriptor::Message
-ParallelDescriptor::Asend (const T* buf,
-                           size_t   n,
-                           int      dst_pid,
-                           int      tag,
-                           MPI_Comm comm)
+Message
+Asend (const T* buf, size_t n, int dst_pid, int tag, MPI_Comm comm)
 {
+    static_assert(!std::is_same<char,T>::value, "Asend: char version has been specialized");
+
     BL_PROFILE_T_S("ParallelDescriptor::Asend(TsiiM)", T);
     BL_COMM_PROFILE(BLProfiler::AsendTsiiM, n * sizeof(T), dst_pid, tag);
 
@@ -634,56 +622,33 @@ ParallelDescriptor::Asend (const T* buf,
     BL_COMM_PROFILE(BLProfiler::AsendTsiiM, BLProfiler::AfterCall(), dst_pid, tag);
     return Message(req, Mpi_typemap<T>::type());
 }
-
-template <class T>
-ParallelDescriptor::Message
-ParallelDescriptor::Asend (const std::vector<T>& buf,
-                           int                   dst_pid,
-                           int                   tag)
-{
-    BL_PROFILE_T_S("ParallelDescriptor::Asend(vTii)", T);
-    BL_COMM_PROFILE(BLProfiler::AsendvTii, buf.size() * sizeof(T), dst_pid, tag);
-
-    MPI_Request req;
-    BL_MPI_REQUIRE( MPI_Isend(const_cast<T*>(&buf[0]),
-                              buf.size(),
-                              Mpi_typemap<T>::type(),
-                              dst_pid,
-                              tag,
-                              Communicator(),
-                              &req) );
-    BL_COMM_PROFILE(BLProfiler::AsendvTii, BLProfiler::AfterCall(), dst_pid, tag);
-    return Message(req, Mpi_typemap<T>::type());
 }
 
 template <class T>
 ParallelDescriptor::Message
-ParallelDescriptor::Send (const T* buf,
-                          size_t   n,
-                          int      dst_pid,
-                          int      tag)
+ParallelDescriptor::Asend (const std::vector<T>& buf, int dst_pid, int tag)
 {
-    BL_PROFILE_T_S("ParallelDescriptor::Send(Tsii)", T);
-    BL_COMM_PROFILE(BLProfiler::SendTsii, n * sizeof(T), dst_pid, tag);
-
-    BL_MPI_REQUIRE( MPI_Send(const_cast<T*>(buf),
-                             n,
-                             Mpi_typemap<T>::type(),
-                             dst_pid,
-                             tag,
-                             Communicator()) );
-    BL_COMM_PROFILE(BLProfiler::SendTsii, BLProfiler::AfterCall(), dst_pid, tag);
-    return Message();
+    return Asend(buf.data(), buf.size(), dst_pid, tag, Communicator());
 }
 
 template <class T>
 ParallelDescriptor::Message
-ParallelDescriptor::Send (const T* buf,
-                          size_t   n,
-                          int      dst_pid,
-                          int      tag,
-			  MPI_Comm comm)
+ParallelDescriptor::Send (const T* buf, size_t n, int dst_pid, int tag)
 {
+    return Send(buf, n, dst_pid, tag, Communicator());
+}
+
+namespace ParallelDescriptor {  // Have to use namespace here to work around a gcc bug
+template <>
+Message
+Send<char> (const char* buf, size_t n, int dst_pid, int tag, MPI_Comm comm);
+
+template <class T>
+Message
+Send (const T* buf, size_t n, int dst_pid, int tag, MPI_Comm comm)
+{
+    static_assert(!std::is_same<char,T>::value, "Send: char version has been specialized");
+
     BL_PROFILE_T_S("ParallelDescriptor::Send(Tsii)", T);
 
 #ifdef BL_COMM_PROFILING
@@ -705,57 +670,33 @@ ParallelDescriptor::Send (const T* buf,
     BL_COMM_PROFILE(BLProfiler::SendTsii, BLProfiler::AfterCall(), dst_pid, tag);
     return Message();
 }
-
-template <class T>
-ParallelDescriptor::Message
-ParallelDescriptor::Send (const std::vector<T>& buf,
-                          int                   dst_pid,
-                          int                   tag)
-{
-    BL_PROFILE_T_S("ParallelDescriptor::Send(vTii)", T);
-    BL_COMM_PROFILE(BLProfiler::SendvTii, buf.size() * sizeof(T), dst_pid, tag);
-
-    BL_MPI_REQUIRE( MPI_Send(const_cast<T*>(&buf[0]),
-                             buf.size(),
-                             Mpi_typemap<T>::type(),
-                             dst_pid,
-                             tag,
-                             Communicator()) );
-    BL_COMM_PROFILE(BLProfiler::SendvTii, BLProfiler::AfterCall(), dst_pid, tag);
-    return Message();
 }
 
 template <class T>
 ParallelDescriptor::Message
-ParallelDescriptor::Arecv (T*       buf,
-                           size_t   n,
-                           int      src_pid,
-                           int      tag)
+ParallelDescriptor::Send (const std::vector<T>& buf, int dst_pid, int tag)
 {
-    BL_PROFILE_T_S("ParallelDescriptor::Arecv(Tsii)", T);
-    BL_COMM_PROFILE(BLProfiler::ArecvTsii, n * sizeof(T), src_pid, tag);
-
-    MPI_Request req;
-    BL_MPI_REQUIRE( MPI_Irecv(buf,
-                              n,
-                              Mpi_typemap<T>::type(),
-                              src_pid,
-                              tag,
-                              Communicator(),
-                              &req) );
-    BL_COMM_PROFILE(BLProfiler::ArecvTsii, BLProfiler::AfterCall(), src_pid, tag);
-
-    return Message(req, Mpi_typemap<T>::type());
+    return Send(buf.data(), buf.size(), dst_pid, tag, Communicator());
 }
 
 template <class T>
 ParallelDescriptor::Message
-ParallelDescriptor::Arecv (T*       buf,
-                           size_t   n,
-                           int      src_pid,
-                           int      tag,
-                           MPI_Comm comm)
+ParallelDescriptor::Arecv (T* buf, size_t n, int src_pid, int tag)
 {
+    return Arecv(buf, n, src_pid, tag, Communicator());
+}
+
+namespace ParallelDescriptor {  // Have to use namespace here to work around a gcc bug
+template <>
+Message
+Arecv<char> (char* buf, size_t n, int src_pid, int tag, MPI_Comm comm);
+
+template <class T>
+Message
+Arecv (T* buf, size_t n, int src_pid, int tag, MPI_Comm comm)
+{
+    static_assert(!std::is_same<char,T>::value, "Arecv: char version has been specialized");
+
     BL_PROFILE_T_S("ParallelDescriptor::Arecv(TsiiM)", T);
     BL_COMM_PROFILE(BLProfiler::ArecvTsiiM, n * sizeof(T), src_pid, tag);
 
@@ -770,58 +711,33 @@ ParallelDescriptor::Arecv (T*       buf,
     BL_COMM_PROFILE(BLProfiler::ArecvTsiiM, BLProfiler::AfterCall(), src_pid, tag);
     return Message(req, Mpi_typemap<T>::type());
 }
-
-template <class T>
-ParallelDescriptor::Message
-ParallelDescriptor::Arecv (std::vector<T>& buf,
-                           int             src_pid,
-                           int             tag)
-{
-    BL_PROFILE_T_S("ParallelDescriptor::Arecv(vTii)", T);
-    BL_COMM_PROFILE(BLProfiler::ArecvvTii, buf.size() * sizeof(T), src_pid, tag);
-
-    MPI_Request req;
-    BL_MPI_REQUIRE( MPI_Irecv(&buf[0],
-                              buf.size(),
-                              Mpi_typemap<T>::type(),
-                              src_pid,
-                              tag,
-                              Communicator(),
-                              &req) );
-    BL_COMM_PROFILE(BLProfiler::ArecvvTii, BLProfiler::AfterCall(), src_pid, tag);
-    return Message(req, Mpi_typemap<T>::type());
 }
 
 template <class T>
 ParallelDescriptor::Message
-ParallelDescriptor::Recv (T*     buf,
-                          size_t n,
-                          int    src_pid,
-                          int    tag)
+ParallelDescriptor::Arecv (std::vector<T>& buf, int src_pid, int tag)
 {
-    BL_PROFILE_T_S("ParallelDescriptor::Recv(Tsii)", T);
-    BL_COMM_PROFILE(BLProfiler::RecvTsii, BLProfiler::BeforeCall(), src_pid, tag);
-
-    MPI_Status stat;
-    BL_MPI_REQUIRE( MPI_Recv(buf,
-                             n,
-                             Mpi_typemap<T>::type(),
-                             src_pid,
-                             tag,
-                             Communicator(),
-                             &stat) );
-    BL_COMM_PROFILE(BLProfiler::RecvTsii, n * sizeof(T), stat.MPI_SOURCE, stat.MPI_TAG);
-    return Message(stat, Mpi_typemap<T>::type());
+    return Arecv(buf.data(), buf.size(), src_pid, tag, Communicator());
 }
 
 template <class T>
 ParallelDescriptor::Message
-ParallelDescriptor::Recv (T*     buf,
-                          size_t n,
-                          int    src_pid,
-                          int    tag,
-			  MPI_Comm comm)
+ParallelDescriptor::Recv (T* buf, size_t n, int src_pid, int tag)
 {
+    return Recv(buf, n, src_pid, tag, Communicator());
+}
+
+namespace ParallelDescriptor {  // Have to use namespace here to work around a gcc bug
+template <>
+Message
+Recv<char> (char* buf, size_t n, int src_pid, int tag, MPI_Comm comm);
+
+template <class T>
+Message
+Recv (T* buf, size_t n, int src_pid, int tag, MPI_Comm comm)
+{
+    static_assert(!std::is_same<char,T>::value, "Recv: char version has been specialized");
+
     BL_PROFILE_T_S("ParallelDescriptor::Recv(Tsii)", T);
     BL_COMM_PROFILE(BLProfiler::RecvTsii, BLProfiler::BeforeCall(), src_pid, tag);
 
@@ -847,26 +763,13 @@ ParallelDescriptor::Recv (T*     buf,
 #endif
     return Message(stat, Mpi_typemap<T>::type());
 }
+}
 
 template <class T>
 ParallelDescriptor::Message
-ParallelDescriptor::Recv (std::vector<T>& buf,
-                          int             src_pid,
-                          int             tag)
+ParallelDescriptor::Recv (std::vector<T>& buf, int src_pid, int tag)
 {
-    BL_PROFILE_T_S("ParallelDescriptor::Recv(vTii)", T);
-    BL_COMM_PROFILE(BLProfiler::RecvvTii, BLProfiler::BeforeCall(), src_pid, tag);
-
-    MPI_Status stat;
-    BL_MPI_REQUIRE( MPI_Recv(&buf[0],
-                             buf.size(),
-                             Mpi_typemap<T>::type(),
-                             src_pid,
-                             tag,
-                             Communicator(),
-                             &stat) );
-    BL_COMM_PROFILE(BLProfiler::RecvvTii, buf.size() * sizeof(T), stat.MPI_SOURCE, stat.MPI_TAG);
-    return Message(stat, Mpi_typemap<T>::type());
+    return Recv(buf.data(), buf.size(), src_pid, tag, Communicator());
 }
 
 template <class T>

--- a/Src/Base/AMReX_ParallelDescriptor.cpp
+++ b/Src/Base/AMReX_ParallelDescriptor.cpp
@@ -47,10 +47,8 @@ namespace
 }
 #endif
 
-namespace amrex {
+namespace amrex { namespace ParallelDescriptor {
 
-namespace ParallelDescriptor
-{
 #ifdef AMREX_USE_MPI
     template <> MPI_Datatype Mpi_typemap<IntVect>::type();
     template <> MPI_Datatype Mpi_typemap<IndexType>::type();
@@ -189,8 +187,6 @@ namespace ParallelDescriptor
       amrex::Print() << "# of unique groups: " << std::distance(PMI_z_meshcoord.begin(), last) << std::endl;
     }
 #endif
-}
-
 
 #ifdef BL_USE_MPI
 
@@ -219,17 +215,14 @@ namespace
 
 }
 
-namespace ParallelDescriptor
+void
+MPI_Error (const char* file, int line, const char* str, int rc)
 {
-    void
-    MPI_Error (const char* file, int line, const char* str, int rc)
-    {
-	amrex::Error(the_message_string(file, line, str, rc));
-    }
+    amrex::Error(the_message_string(file, line, str, rc));
 }
 
 void
-ParallelDescriptor::Abort (int errorcode, bool backtrace)
+Abort (int errorcode, bool backtrace)
 {
     if (backtrace && amrex::system::signal_handling) {
 	BLBackTrace::handler(errorcode);
@@ -239,7 +232,7 @@ ParallelDescriptor::Abort (int errorcode, bool backtrace)
 }
 
 const char*
-ParallelDescriptor::ErrorString (int errorcode)
+ErrorString (int errorcode)
 {
     BL_ASSERT(errorcode > 0 && errorcode <= MPI_ERR_LASTCODE);
 
@@ -255,7 +248,7 @@ ParallelDescriptor::ErrorString (int errorcode)
 }
 
 void
-ParallelDescriptor::Message::wait ()
+Message::wait ()
 {
     BL_PROFILE_S("ParallelDescriptor::Message::wait()");
 
@@ -265,7 +258,7 @@ ParallelDescriptor::Message::wait ()
 }
 
 bool
-ParallelDescriptor::Message::test ()
+Message::test ()
 {
     int flag;
     BL_PROFILE_S("ParallelDescriptor::Message::test()");
@@ -277,21 +270,21 @@ ParallelDescriptor::Message::test ()
 }
 
 int
-ParallelDescriptor::Message::tag () const
+Message::tag () const
 {
     if ( !m_finished ) amrex::Error("Message::tag: Not Finished!");
     return m_stat.MPI_TAG;
 }
 
 int
-ParallelDescriptor::Message::pid () const
+Message::pid () const
 {
     if ( !m_finished ) amrex::Error("Message::pid: Not Finished!");
     return m_stat.MPI_SOURCE;
 }
 
 size_t
-ParallelDescriptor::Message::count () const
+Message::count () const
 {
     if ( m_type == MPI_DATATYPE_NULL ) amrex::Error("Message::count: Bad Type!");
     if ( !m_finished ) amrex::Error("Message::count: Not Finished!");
@@ -301,9 +294,7 @@ ParallelDescriptor::Message::count () const
 }
 
 void
-ParallelDescriptor::StartParallel (int*    argc,
-                                   char*** argv,
-                                   MPI_Comm a_mpi_comm)
+StartParallel (int* argc, char*** argv, MPI_Comm a_mpi_comm)
 {
     int sflag(0);
     MPI_Initialized(&sflag);
@@ -380,7 +371,7 @@ ParallelDescriptor::StartParallel (int*    argc,
 }
 
 void
-ParallelDescriptor::EndParallel ()
+EndParallel ()
 {
     --num_startparallel_called;
     if (num_startparallel_called == 0) {
@@ -407,13 +398,13 @@ ParallelDescriptor::EndParallel ()
 }
 
 double
-ParallelDescriptor::second () noexcept
+second () noexcept
 {
     return MPI_Wtime();
 }
 
 void
-ParallelDescriptor::Barrier (const std::string &message)
+Barrier (const std::string &message)
 {
     amrex::ignore_unused(message);
 
@@ -430,7 +421,7 @@ ParallelDescriptor::Barrier (const std::string &message)
 }
 
 void
-ParallelDescriptor::Barrier (const MPI_Comm &comm, const std::string &message)
+Barrier (const MPI_Comm &comm, const std::string &message)
 {
     amrex::ignore_unused(message);
 
@@ -450,8 +441,8 @@ ParallelDescriptor::Barrier (const MPI_Comm &comm, const std::string &message)
 }
 
 
-ParallelDescriptor::Message
-ParallelDescriptor::Abarrier ()
+Message
+Abarrier ()
 {
     MPI_Request req;
     BL_MPI_REQUIRE( MPI_Ibarrier(ParallelDescriptor::Communicator(), &req) );
@@ -459,8 +450,8 @@ ParallelDescriptor::Abarrier ()
     return Message(req, MPI_DATATYPE_NULL);
 }
 
-ParallelDescriptor::Message
-ParallelDescriptor::Abarrier (const MPI_Comm & comm)
+Message
+Abarrier (const MPI_Comm & comm)
 {
     MPI_Request req;
     BL_MPI_REQUIRE( MPI_Ibarrier(comm, &req) );
@@ -470,7 +461,7 @@ ParallelDescriptor::Abarrier (const MPI_Comm & comm)
 
 
 void
-ParallelDescriptor::Test (MPI_Request& request, int& flag, MPI_Status& status)
+Test (MPI_Request& request, int& flag, MPI_Status& status)
 {
     BL_PROFILE_S("ParallelDescriptor::Test()");
     BL_COMM_PROFILE(BLProfiler::Test, sizeof(char), status.MPI_SOURCE, status.MPI_TAG);
@@ -481,7 +472,7 @@ ParallelDescriptor::Test (MPI_Request& request, int& flag, MPI_Status& status)
 }
 
 void
-ParallelDescriptor::IProbe (int src_pid, int tag, int& flag, MPI_Status& status)
+IProbe (int src_pid, int tag, int& flag, MPI_Status& status)
 {
     BL_PROFILE_S("ParallelDescriptor::Iprobe()");
     BL_COMM_PROFILE(BLProfiler::Iprobe, sizeof(char), src_pid, tag);
@@ -493,7 +484,7 @@ ParallelDescriptor::IProbe (int src_pid, int tag, int& flag, MPI_Status& status)
 }
 
 void
-ParallelDescriptor::IProbe (int src_pid, int tag, MPI_Comm comm, int& flag, MPI_Status& status)
+IProbe (int src_pid, int tag, MPI_Comm comm, int& flag, MPI_Status& status)
 {
     BL_PROFILE_S("ParallelDescriptor::Iprobe(comm)");
     BL_COMM_PROFILE(BLProfiler::Iprobe, sizeof(char), src_pid, tag);
@@ -505,14 +496,14 @@ ParallelDescriptor::IProbe (int src_pid, int tag, MPI_Comm comm, int& flag, MPI_
 }
 
 void
-ParallelDescriptor::Comm_dup (MPI_Comm comm, MPI_Comm& newcomm)
+Comm_dup (MPI_Comm comm, MPI_Comm& newcomm)
 {
     BL_PROFILE_S("ParallelDescriptor::Comm_dup()");
     BL_MPI_REQUIRE( MPI_Comm_dup(comm, &newcomm) );
 }
 
 void
-ParallelDescriptor::ReduceBoolAnd (bool& r)
+ReduceBoolAnd (bool& r)
 {
     int src = r; // src is either 0 or 1.
 
@@ -522,7 +513,7 @@ ParallelDescriptor::ReduceBoolAnd (bool& r)
 }
 
 void
-ParallelDescriptor::ReduceBoolAnd (bool& r, int cpu)
+ReduceBoolAnd (bool& r, int cpu)
 {
     int src = r; // src is either 0 or 1.
 
@@ -533,7 +524,7 @@ ParallelDescriptor::ReduceBoolAnd (bool& r, int cpu)
 }
 
 void
-ParallelDescriptor::ReduceBoolOr (bool& r)
+ReduceBoolOr (bool& r)
 {
     int src = r; // src is either 0 or 1.
 
@@ -543,7 +534,7 @@ ParallelDescriptor::ReduceBoolOr (bool& r)
 }
 
 void
-ParallelDescriptor::ReduceBoolOr (bool& r, int cpu)
+ReduceBoolOr (bool& r, int cpu)
 {
     int src = r; // src is either 0 or 1.
 
@@ -554,19 +545,19 @@ ParallelDescriptor::ReduceBoolOr (bool& r, int cpu)
 }
 
 void
-ParallelDescriptor::ReduceRealSum (Real& r)
+ReduceRealSum (Real& r)
 {
     util::DoAllReduceReal(r,MPI_SUM);
 }
 
 void
-ParallelDescriptor::ReduceRealSum (Real* r, int cnt)
+ReduceRealSum (Real* r, int cnt)
 {
     util::DoAllReduceReal(r,MPI_SUM,cnt);
 }
 
 void
-ParallelDescriptor::ReduceRealSum (Vector<std::reference_wrapper<Real> >&& rvar)
+ReduceRealSum (Vector<std::reference_wrapper<Real> >&& rvar)
 {
     int cnt = rvar.size();
     Vector<Real> tmp{std::begin(rvar), std::end(rvar)};
@@ -577,19 +568,19 @@ ParallelDescriptor::ReduceRealSum (Vector<std::reference_wrapper<Real> >&& rvar)
 }
 
 void
-ParallelDescriptor::ReduceRealSum (Real& r, int cpu)
+ReduceRealSum (Real& r, int cpu)
 {
     util::DoReduceReal(r,MPI_SUM,cpu);
 }
 
 void
-ParallelDescriptor::ReduceRealSum (Real* r, int cnt, int cpu)
+ReduceRealSum (Real* r, int cnt, int cpu)
 {
     util::DoReduceReal(r,MPI_SUM,cnt,cpu);
 }
 
 void
-ParallelDescriptor::ReduceRealSum (Vector<std::reference_wrapper<Real> >&& rvar, int cpu)
+ReduceRealSum (Vector<std::reference_wrapper<Real> >&& rvar, int cpu)
 {
     int cnt = rvar.size();
     Vector<Real> tmp{std::begin(rvar), std::end(rvar)};
@@ -600,19 +591,19 @@ ParallelDescriptor::ReduceRealSum (Vector<std::reference_wrapper<Real> >&& rvar,
 }
 
 void
-ParallelDescriptor::ReduceRealMax (Real& r)
+ReduceRealMax (Real& r)
 {
     util::DoAllReduceReal(r,MPI_MAX);
 }
 
 void
-ParallelDescriptor::ReduceRealMax (Real* r, int cnt)
+ReduceRealMax (Real* r, int cnt)
 {
     util::DoAllReduceReal(r,MPI_MAX,cnt);
 }
 
 void
-ParallelDescriptor::ReduceRealMax (Vector<std::reference_wrapper<Real> >&& rvar)
+ReduceRealMax (Vector<std::reference_wrapper<Real> >&& rvar)
 {
     int cnt = rvar.size();
     Vector<Real> tmp{std::begin(rvar), std::end(rvar)};
@@ -623,19 +614,19 @@ ParallelDescriptor::ReduceRealMax (Vector<std::reference_wrapper<Real> >&& rvar)
 }
 
 void
-ParallelDescriptor::ReduceRealMax (Real& r, int cpu)
+ReduceRealMax (Real& r, int cpu)
 {
     util::DoReduceReal(r,MPI_MAX,cpu);
 }
 
 void
-ParallelDescriptor::ReduceRealMax (Real* r, int cnt, int cpu)
+ReduceRealMax (Real* r, int cnt, int cpu)
 {
     util::DoReduceReal(r,MPI_MAX,cnt,cpu);
 }
 
 void
-ParallelDescriptor::ReduceRealMax (Vector<std::reference_wrapper<Real> >&& rvar, int cpu)
+ReduceRealMax (Vector<std::reference_wrapper<Real> >&& rvar, int cpu)
 {
     int cnt = rvar.size();
     Vector<Real> tmp{std::begin(rvar), std::end(rvar)};
@@ -646,19 +637,19 @@ ParallelDescriptor::ReduceRealMax (Vector<std::reference_wrapper<Real> >&& rvar,
 }
 
 void
-ParallelDescriptor::ReduceRealMin (Real& r)
+ReduceRealMin (Real& r)
 {
     util::DoAllReduceReal(r,MPI_MIN);
 }
 
 void
-ParallelDescriptor::ReduceRealMin (Real* r, int cnt)
+ReduceRealMin (Real* r, int cnt)
 {
     util::DoAllReduceReal(r,MPI_MIN,cnt);
 }
 
 void
-ParallelDescriptor::ReduceRealMin (Vector<std::reference_wrapper<Real> >&& rvar)
+ReduceRealMin (Vector<std::reference_wrapper<Real> >&& rvar)
 {
     int cnt = rvar.size();
     Vector<Real> tmp{std::begin(rvar), std::end(rvar)};
@@ -669,19 +660,19 @@ ParallelDescriptor::ReduceRealMin (Vector<std::reference_wrapper<Real> >&& rvar)
 }
 
 void
-ParallelDescriptor::ReduceRealMin (Real& r, int cpu)
+ReduceRealMin (Real& r, int cpu)
 {
     util::DoReduceReal(r,MPI_MIN,cpu);
 }
 
 void
-ParallelDescriptor::ReduceRealMin (Real* r, int cnt, int cpu)
+ReduceRealMin (Real* r, int cnt, int cpu)
 {
     util::DoReduceReal(r,MPI_MIN,cnt,cpu);
 }
 
 void
-ParallelDescriptor::ReduceRealMin (Vector<std::reference_wrapper<Real> >&& rvar, int cpu)
+ReduceRealMin (Vector<std::reference_wrapper<Real> >&& rvar, int cpu)
 {
     int cnt = rvar.size();
     Vector<Real> tmp{std::begin(rvar), std::end(rvar)};
@@ -692,19 +683,19 @@ ParallelDescriptor::ReduceRealMin (Vector<std::reference_wrapper<Real> >&& rvar,
 }
 
 void
-ParallelDescriptor::ReduceIntSum (int& r)
+ReduceIntSum (int& r)
 {
     util::DoAllReduceInt(r,MPI_SUM);
 }
 
 void
-ParallelDescriptor::ReduceIntSum (int* r, int cnt)
+ReduceIntSum (int* r, int cnt)
 {
     util::DoAllReduceInt(r,MPI_SUM,cnt);
 }
 
 void
-ParallelDescriptor::ReduceIntSum (Vector<std::reference_wrapper<int> >&& rvar)
+ReduceIntSum (Vector<std::reference_wrapper<int> >&& rvar)
 {
     int cnt = rvar.size();
     Vector<int> tmp{std::begin(rvar), std::end(rvar)};
@@ -715,19 +706,19 @@ ParallelDescriptor::ReduceIntSum (Vector<std::reference_wrapper<int> >&& rvar)
 }
 
 void
-ParallelDescriptor::ReduceIntSum (int& r, int cpu)
+ReduceIntSum (int& r, int cpu)
 {
     util::DoReduceInt(r,MPI_SUM,cpu);
 }
 
 void
-ParallelDescriptor::ReduceIntSum (int* r, int cnt, int cpu)
+ReduceIntSum (int* r, int cnt, int cpu)
 {
     util::DoReduceInt(r,MPI_SUM,cnt,cpu);
 }
 
 void
-ParallelDescriptor::ReduceIntSum (Vector<std::reference_wrapper<int> >&& rvar, int cpu)
+ReduceIntSum (Vector<std::reference_wrapper<int> >&& rvar, int cpu)
 {
     int cnt = rvar.size();
     Vector<int> tmp{std::begin(rvar), std::end(rvar)};
@@ -738,19 +729,19 @@ ParallelDescriptor::ReduceIntSum (Vector<std::reference_wrapper<int> >&& rvar, i
 }
 
 void
-ParallelDescriptor::ReduceIntMax (int& r)
+ReduceIntMax (int& r)
 {
     util::DoAllReduceInt(r,MPI_MAX);
 }
 
 void
-ParallelDescriptor::ReduceIntMax (int* r, int cnt)
+ReduceIntMax (int* r, int cnt)
 {
     util::DoAllReduceInt(r,MPI_MAX,cnt);
 }
 
 void
-ParallelDescriptor::ReduceIntMax (Vector<std::reference_wrapper<int> >&& rvar)
+ReduceIntMax (Vector<std::reference_wrapper<int> >&& rvar)
 {
     int cnt = rvar.size();
     Vector<int> tmp{std::begin(rvar), std::end(rvar)};
@@ -761,19 +752,19 @@ ParallelDescriptor::ReduceIntMax (Vector<std::reference_wrapper<int> >&& rvar)
 }
 
 void
-ParallelDescriptor::ReduceIntMax (int& r, int cpu)
+ReduceIntMax (int& r, int cpu)
 {
     util::DoReduceInt(r,MPI_MAX,cpu);
 }
 
 void
-ParallelDescriptor::ReduceIntMax (int* r, int cnt, int cpu)
+ReduceIntMax (int* r, int cnt, int cpu)
 {
     util::DoReduceInt(r,MPI_MAX,cnt,cpu);
 }
 
 void
-ParallelDescriptor::ReduceIntMax (Vector<std::reference_wrapper<int> >&& rvar, int cpu)
+ReduceIntMax (Vector<std::reference_wrapper<int> >&& rvar, int cpu)
 {
     int cnt = rvar.size();
     Vector<int> tmp{std::begin(rvar), std::end(rvar)};
@@ -784,19 +775,19 @@ ParallelDescriptor::ReduceIntMax (Vector<std::reference_wrapper<int> >&& rvar, i
 }
 
 void
-ParallelDescriptor::ReduceIntMin (int& r)
+ReduceIntMin (int& r)
 {
     util::DoAllReduceInt(r,MPI_MIN);
 }
 
 void
-ParallelDescriptor::ReduceIntMin (int* r, int cnt)
+ReduceIntMin (int* r, int cnt)
 {
     util::DoAllReduceInt(r,MPI_MIN,cnt);
 }
 
 void
-ParallelDescriptor::ReduceIntMin (Vector<std::reference_wrapper<int> >&& rvar)
+ReduceIntMin (Vector<std::reference_wrapper<int> >&& rvar)
 {
     int cnt = rvar.size();
     Vector<int> tmp{std::begin(rvar), std::end(rvar)};
@@ -807,19 +798,19 @@ ParallelDescriptor::ReduceIntMin (Vector<std::reference_wrapper<int> >&& rvar)
 }
 
 void
-ParallelDescriptor::ReduceIntMin (int& r, int cpu)
+ReduceIntMin (int& r, int cpu)
 {
     util::DoReduceInt(r,MPI_MIN,cpu);
 }
 
 void
-ParallelDescriptor::ReduceIntMin (int* r, int cnt, int cpu)
+ReduceIntMin (int* r, int cnt, int cpu)
 {
     util::DoReduceInt(r,MPI_MIN,cnt,cpu);
 }
 
 void
-ParallelDescriptor::ReduceIntMin (Vector<std::reference_wrapper<int> >&& rvar, int cpu)
+ReduceIntMin (Vector<std::reference_wrapper<int> >&& rvar, int cpu)
 {
     int cnt = rvar.size();
     Vector<int> tmp{std::begin(rvar), std::end(rvar)};
@@ -830,19 +821,19 @@ ParallelDescriptor::ReduceIntMin (Vector<std::reference_wrapper<int> >&& rvar, i
 }
 
 void
-ParallelDescriptor::ReduceLongSum (Long& r)
+ReduceLongSum (Long& r)
 {
     util::DoAllReduceLong(r,MPI_SUM);
 }
 
 void
-ParallelDescriptor::ReduceLongSum (Long* r, int cnt)
+ReduceLongSum (Long* r, int cnt)
 {
     util::DoAllReduceLong(r,MPI_SUM,cnt);
 }
 
 void
-ParallelDescriptor::ReduceLongSum (Vector<std::reference_wrapper<Long> >&& rvar)
+ReduceLongSum (Vector<std::reference_wrapper<Long> >&& rvar)
 {
     int cnt = rvar.size();
     Vector<Long> tmp{std::begin(rvar), std::end(rvar)};
@@ -853,19 +844,19 @@ ParallelDescriptor::ReduceLongSum (Vector<std::reference_wrapper<Long> >&& rvar)
 }
 
 void
-ParallelDescriptor::ReduceLongSum (Long& r, int cpu)
+ReduceLongSum (Long& r, int cpu)
 {
     util::DoReduceLong(r,MPI_SUM,cpu);
 }
 
 void
-ParallelDescriptor::ReduceLongSum (Long* r, int cnt, int cpu)
+ReduceLongSum (Long* r, int cnt, int cpu)
 {
     util::DoReduceLong(r,MPI_SUM,cnt,cpu);
 }
 
 void
-ParallelDescriptor::ReduceLongSum (Vector<std::reference_wrapper<Long> >&& rvar, int cpu)
+ReduceLongSum (Vector<std::reference_wrapper<Long> >&& rvar, int cpu)
 {
     int cnt = rvar.size();
     Vector<Long> tmp{std::begin(rvar), std::end(rvar)};
@@ -876,19 +867,19 @@ ParallelDescriptor::ReduceLongSum (Vector<std::reference_wrapper<Long> >&& rvar,
 }
 
 void
-ParallelDescriptor::ReduceLongMax (Long& r)
+ReduceLongMax (Long& r)
 {
     util::DoAllReduceLong(r,MPI_MAX);
 }
 
 void
-ParallelDescriptor::ReduceLongMax (Long* r, int cnt)
+ReduceLongMax (Long* r, int cnt)
 {
     util::DoAllReduceLong(r,MPI_MAX,cnt);
 }
 
 void
-ParallelDescriptor::ReduceLongMax (Vector<std::reference_wrapper<Long> >&& rvar)
+ReduceLongMax (Vector<std::reference_wrapper<Long> >&& rvar)
 {
     int cnt = rvar.size();
     Vector<Long> tmp{std::begin(rvar), std::end(rvar)};
@@ -899,19 +890,19 @@ ParallelDescriptor::ReduceLongMax (Vector<std::reference_wrapper<Long> >&& rvar)
 }
 
 void
-ParallelDescriptor::ReduceLongMax (Long& r, int cpu)
+ReduceLongMax (Long& r, int cpu)
 {
     util::DoReduceLong(r,MPI_MAX,cpu);
 }
 
 void
-ParallelDescriptor::ReduceLongMax (Long* r, int cnt, int cpu)
+ReduceLongMax (Long* r, int cnt, int cpu)
 {
     util::DoReduceLong(r,MPI_MAX,cnt,cpu);
 }
 
 void
-ParallelDescriptor::ReduceLongMax (Vector<std::reference_wrapper<Long> >&& rvar, int cpu)
+ReduceLongMax (Vector<std::reference_wrapper<Long> >&& rvar, int cpu)
 {
     int cnt = rvar.size();
     Vector<Long> tmp{std::begin(rvar), std::end(rvar)};
@@ -922,19 +913,19 @@ ParallelDescriptor::ReduceLongMax (Vector<std::reference_wrapper<Long> >&& rvar,
 }
 
 void
-ParallelDescriptor::ReduceLongMin (Long& r)
+ReduceLongMin (Long& r)
 {
     util::DoAllReduceLong(r,MPI_MIN);
 }
 
 void
-ParallelDescriptor::ReduceLongMin (Long* r, int cnt)
+ReduceLongMin (Long* r, int cnt)
 {
     util::DoAllReduceLong(r,MPI_MIN,cnt);
 }
 
 void
-ParallelDescriptor::ReduceLongMin (Vector<std::reference_wrapper<Long> >&& rvar)
+ReduceLongMin (Vector<std::reference_wrapper<Long> >&& rvar)
 {
     int cnt = rvar.size();
     Vector<Long> tmp{std::begin(rvar), std::end(rvar)};
@@ -945,19 +936,19 @@ ParallelDescriptor::ReduceLongMin (Vector<std::reference_wrapper<Long> >&& rvar)
 }
 
 void
-ParallelDescriptor::ReduceLongMin (Long& r, int cpu)
+ReduceLongMin (Long& r, int cpu)
 {
     util::DoReduceLong(r,MPI_MIN,cpu);
 }
 
 void
-ParallelDescriptor::ReduceLongMin (Long* r, int cnt, int cpu)
+ReduceLongMin (Long* r, int cnt, int cpu)
 {
     util::DoReduceLong(r,MPI_MIN,cnt,cpu);
 }
 
 void
-ParallelDescriptor::ReduceLongMin (Vector<std::reference_wrapper<Long> >&& rvar, int cpu)
+ReduceLongMin (Vector<std::reference_wrapper<Long> >&& rvar, int cpu)
 {
     int cnt = rvar.size();
     Vector<Long> tmp{std::begin(rvar), std::end(rvar)};
@@ -968,19 +959,19 @@ ParallelDescriptor::ReduceLongMin (Vector<std::reference_wrapper<Long> >&& rvar,
 }
 
 void
-ParallelDescriptor::ReduceLongAnd (Long& r)
+ReduceLongAnd (Long& r)
 {
     util::DoAllReduceLong(r,MPI_LAND);
 }
 
 void
-ParallelDescriptor::ReduceLongAnd (Long* r, int cnt)
+ReduceLongAnd (Long* r, int cnt)
 {
     util::DoAllReduceLong(r,MPI_LAND,cnt);
 }
 
 void
-ParallelDescriptor::ReduceLongAnd (Vector<std::reference_wrapper<Long> >&& rvar)
+ReduceLongAnd (Vector<std::reference_wrapper<Long> >&& rvar)
 {
     int cnt = rvar.size();
     Vector<Long> tmp{std::begin(rvar), std::end(rvar)};
@@ -991,19 +982,19 @@ ParallelDescriptor::ReduceLongAnd (Vector<std::reference_wrapper<Long> >&& rvar)
 }
 
 void
-ParallelDescriptor::ReduceLongAnd (Long& r, int cpu)
+ReduceLongAnd (Long& r, int cpu)
 {
     util::DoReduceLong(r,MPI_LAND,cpu);
 }
 
 void
-ParallelDescriptor::ReduceLongAnd (Long* r, int cnt, int cpu)
+ReduceLongAnd (Long* r, int cnt, int cpu)
 {
     util::DoReduceLong(r,MPI_LAND,cnt,cpu);
 }
 
 void
-ParallelDescriptor::ReduceLongAnd (Vector<std::reference_wrapper<Long> >&& rvar,int cpu)
+ReduceLongAnd (Vector<std::reference_wrapper<Long> >&& rvar,int cpu)
 {
     int cnt = rvar.size();
     Vector<Long> tmp{std::begin(rvar), std::end(rvar)};
@@ -1014,8 +1005,7 @@ ParallelDescriptor::ReduceLongAnd (Vector<std::reference_wrapper<Long> >&& rvar,
 }
 
 void
-ParallelDescriptor::util::DoAllReduceReal (Real&  r,
-                                           MPI_Op op)
+util::DoAllReduceReal (Real& r, MPI_Op op)
 {
 #ifdef BL_LAZY
     Lazy::EvalReduction();
@@ -1053,9 +1043,7 @@ ParallelDescriptor::util::DoAllReduceReal (Real&  r,
 }
 
 void
-ParallelDescriptor::util::DoAllReduceReal (Real*  r,
-                                           MPI_Op op,
-                                           int    cnt)
+util::DoAllReduceReal (Real* r, MPI_Op op, int cnt)
 {
 #ifdef BL_LAZY
     Lazy::EvalReduction();
@@ -1097,9 +1085,7 @@ ParallelDescriptor::util::DoAllReduceReal (Real*  r,
 }
 
 void
-ParallelDescriptor::util::DoReduceReal (Real&  r,
-                                        MPI_Op op,
-                                        int    cpu)
+util::DoReduceReal (Real& r, MPI_Op op, int cpu)
 {
 #ifdef BL_LAZY
     Lazy::EvalReduction();
@@ -1143,10 +1129,7 @@ ParallelDescriptor::util::DoReduceReal (Real&  r,
 }
 
 void
-ParallelDescriptor::util::DoReduceReal (Real*  r,
-                                        MPI_Op op,
-                                        int    cnt,
-                                        int    cpu)
+util::DoReduceReal (Real* r, MPI_Op op, int cnt, int cpu)
 {
 #ifdef BL_LAZY
     Lazy::EvalReduction();
@@ -1195,8 +1178,7 @@ ParallelDescriptor::util::DoReduceReal (Real*  r,
 }
 
 void
-ParallelDescriptor::util::DoAllReduceLong (Long&  r,
-                                           MPI_Op op)
+util::DoAllReduceLong (Long& r, MPI_Op op)
 {
 #ifdef BL_LAZY
     Lazy::EvalReduction();
@@ -1234,9 +1216,7 @@ ParallelDescriptor::util::DoAllReduceLong (Long&  r,
 }
 
 void
-ParallelDescriptor::util::DoAllReduceLong (Long*  r,
-                                           MPI_Op op,
-                                           int    cnt)
+util::DoAllReduceLong (Long* r, MPI_Op op, int cnt)
 {
 #ifdef BL_LAZY
     Lazy::EvalReduction();
@@ -1278,9 +1258,7 @@ ParallelDescriptor::util::DoAllReduceLong (Long*  r,
 }
 
 void
-ParallelDescriptor::util::DoReduceLong (Long&  r,
-                                        MPI_Op op,
-                                        int    cpu)
+util::DoReduceLong (Long& r, MPI_Op op, int cpu)
 {
 #ifdef BL_LAZY
     Lazy::EvalReduction();
@@ -1324,10 +1302,7 @@ ParallelDescriptor::util::DoReduceLong (Long&  r,
 }
 
 void
-ParallelDescriptor::util::DoReduceLong (Long*  r,
-                                        MPI_Op op,
-                                        int    cnt,
-                                        int    cpu)
+util::DoReduceLong (Long* r, MPI_Op op, int cnt, int cpu)
 {
 #ifdef BL_LAZY
     Lazy::EvalReduction();
@@ -1376,8 +1351,7 @@ ParallelDescriptor::util::DoReduceLong (Long*  r,
 }
 
 void
-ParallelDescriptor::util::DoAllReduceInt (int&   r,
-                                          MPI_Op op)
+util::DoAllReduceInt (int& r, MPI_Op op)
 {
 #ifdef BL_LAZY
     Lazy::EvalReduction();
@@ -1415,9 +1389,7 @@ ParallelDescriptor::util::DoAllReduceInt (int&   r,
 }
 
 void
-ParallelDescriptor::util::DoAllReduceInt (int*   r,
-                                          MPI_Op op,
-                                          int    cnt)
+util::DoAllReduceInt (int* r, MPI_Op op, int cnt)
 {
 #ifdef BL_LAZY
     Lazy::EvalReduction();
@@ -1459,9 +1431,7 @@ ParallelDescriptor::util::DoAllReduceInt (int*   r,
 }
 
 void
-ParallelDescriptor::util::DoReduceInt (int&   r,
-                                       MPI_Op op,
-                                       int    cpu)
+util::DoReduceInt (int& r, MPI_Op op, int cpu)
 {
 #ifdef BL_LAZY
     Lazy::EvalReduction();
@@ -1505,10 +1475,7 @@ ParallelDescriptor::util::DoReduceInt (int&   r,
 }
 
 void
-ParallelDescriptor::util::DoReduceInt (int*   r,
-                                       MPI_Op op,
-                                       int    cnt,
-                                       int    cpu)
+util::DoReduceInt (int* r, MPI_Op op, int cnt, int cpu)
 {
 #ifdef BL_LAZY
     Lazy::EvalReduction();
@@ -1557,10 +1524,7 @@ ParallelDescriptor::util::DoReduceInt (int*   r,
 }
 
 void
-ParallelDescriptor::Gather (Real* sendbuf,
-                            int   nsend,
-                            Real* recvbuf,
-                            int   root)
+Gather (Real* sendbuf, int nsend, Real* recvbuf, int root)
 {
     BL_PROFILE_S("ParallelDescriptor::Gather()");
     BL_COMM_PROFILE(BLProfiler::GatherRiRi, BLProfiler::BeforeCall(), root, BLProfiler::NoTag());
@@ -1585,91 +1549,91 @@ ParallelDescriptor::Gather (Real* sendbuf,
 
 template <>
 MPI_Datatype
-ParallelDescriptor::Mpi_typemap<char>::type ()
+Mpi_typemap<char>::type ()
 {
     return  MPI_CHAR;
 }
 
 template <>
 MPI_Datatype
-ParallelDescriptor::Mpi_typemap<short>::type ()
+Mpi_typemap<short>::type ()
 {
     return  MPI_SHORT;
 }
 
 template <>
 MPI_Datatype
-ParallelDescriptor::Mpi_typemap<int>::type ()
+Mpi_typemap<int>::type ()
 {
     return  MPI_INT;
 }
 
 template <>
 MPI_Datatype
-ParallelDescriptor::Mpi_typemap<long>::type ()
+Mpi_typemap<long>::type ()
 {
     return  MPI_LONG;
 }
 
 template <>
 MPI_Datatype
-ParallelDescriptor::Mpi_typemap<long long>::type ()
+Mpi_typemap<long long>::type ()
 {
     return  MPI_LONG_LONG;
 }
 
 template <>
 MPI_Datatype
-ParallelDescriptor::Mpi_typemap<unsigned char>::type ()
+Mpi_typemap<unsigned char>::type ()
 {
     return  MPI_UNSIGNED_CHAR;
 }
 
 template <>
 MPI_Datatype
-ParallelDescriptor::Mpi_typemap<unsigned short>::type ()
+Mpi_typemap<unsigned short>::type ()
 {
     return  MPI_UNSIGNED_SHORT;
 }
 
 template <>
 MPI_Datatype
-ParallelDescriptor::Mpi_typemap<unsigned int>::type ()
+Mpi_typemap<unsigned int>::type ()
 {
     return  MPI_UNSIGNED;
 }
 
 template <>
 MPI_Datatype
-ParallelDescriptor::Mpi_typemap<unsigned long>::type ()
+Mpi_typemap<unsigned long>::type ()
 {
     return  MPI_UNSIGNED_LONG;
 }
 
 template <>
 MPI_Datatype
-ParallelDescriptor::Mpi_typemap<unsigned long long>::type ()
+Mpi_typemap<unsigned long long>::type ()
 {
     return  MPI_UNSIGNED_LONG_LONG;
 }
 
 template <>
 MPI_Datatype
-ParallelDescriptor::Mpi_typemap<float>::type ()
+Mpi_typemap<float>::type ()
 {
     return  MPI_FLOAT;
 }
 
 template <>
 MPI_Datatype
-ParallelDescriptor::Mpi_typemap<double>::type ()
+Mpi_typemap<double>::type ()
 {
     return  MPI_DOUBLE;
 }
 
 template <>
 MPI_Datatype
-ParallelDescriptor::Mpi_typemap<ParallelDescriptor::lull_t>::type ()
+Mpi_typemap<ParallelDescriptor::lull_t>::type ()
 {
     if (mpi_type_lull_t == MPI_DATATYPE_NULL)
     {
@@ -1680,8 +1644,7 @@ ParallelDescriptor::Mpi_typemap<ParallelDescriptor::lull_t>::type ()
 }
 
 void
-ParallelDescriptor::Wait (MPI_Request& req,
-                          MPI_Status& status)
+Wait (MPI_Request& req, MPI_Status& status)
 {
     BL_PROFILE_S("ParallelDescriptor::Wait()");
     BL_COMM_PROFILE_WAIT(BLProfiler::Wait, req, status, true);
@@ -1690,8 +1653,7 @@ ParallelDescriptor::Wait (MPI_Request& req,
 }
 
 void
-ParallelDescriptor::Waitall (Vector<MPI_Request>& reqs,
-                             Vector<MPI_Status>& status)
+Waitall (Vector<MPI_Request>& reqs, Vector<MPI_Status>& status)
 {
     BL_ASSERT(status.size() >= reqs.size());
 
@@ -1704,9 +1666,7 @@ ParallelDescriptor::Waitall (Vector<MPI_Request>& reqs,
 }
 
 void
-ParallelDescriptor::Waitany (Vector<MPI_Request>& reqs,
-                             int &index,
-                             MPI_Status& status)
+Waitany (Vector<MPI_Request>& reqs, int &index, MPI_Status& status)
 {
     BL_PROFILE_S("ParallelDescriptor::Waitany()");
     BL_COMM_PROFILE_WAIT(BLProfiler::Waitany, reqs[0], status, true);
@@ -1718,10 +1678,8 @@ ParallelDescriptor::Waitany (Vector<MPI_Request>& reqs,
 }
 
 void
-ParallelDescriptor::Waitsome (Vector<MPI_Request>& reqs,
-                              int&                completed,
-                              Vector<int>&         indx,
-                              Vector<MPI_Status>&  status)
+Waitsome (Vector<MPI_Request>& reqs, int& completed,
+          Vector<int>& indx, Vector<MPI_Status>& status)
 {
     BL_ASSERT(status.size() >= reqs.size());
     BL_ASSERT(indx.size() >= reqs.size());
@@ -1737,11 +1695,7 @@ ParallelDescriptor::Waitsome (Vector<MPI_Request>& reqs,
 }
 
 void
-ParallelDescriptor::Bcast(void *buf,
-                          int count,
-                          MPI_Datatype datatype,
-                          int root,
-                          MPI_Comm comm)
+Bcast(void *buf, int count, MPI_Datatype datatype, int root, MPI_Comm comm)
 {
 #ifdef BL_LAZY
     int r;
@@ -1767,9 +1721,7 @@ ParallelDescriptor::Bcast(void *buf,
 #else /*!BL_USE_MPI*/
 
 void
-ParallelDescriptor::StartParallel (int*    /*argc*/,
-                                   char*** /*argv*/,
-                                   MPI_Comm)
+StartParallel (int* /*argc*/, char*** /*argv*/, MPI_Comm)
 {
     m_comm = 0;
     m_MaxTag = 9000;
@@ -1777,10 +1729,7 @@ ParallelDescriptor::StartParallel (int*    /*argc*/,
 }
 
 void
-ParallelDescriptor::Gather (Real* sendbuf,
-			    int   nsend,
-			    Real* recvbuf,
-			    int   root)
+Gather (Real* sendbuf, int nsend, Real* recvbuf, int root)
 {
     amrex::ignore_unused(root);
     BL_ASSERT(root == 0);
@@ -1793,21 +1742,23 @@ ParallelDescriptor::Gather (Real* sendbuf,
 }
 
 void
-ParallelDescriptor::Message::wait ()
+Message::wait ()
 {}
 
 bool
-ParallelDescriptor::Message::test ()
+Message::test ()
 {
     return m_finished;
 }
 
-void ParallelDescriptor::EndParallel ()
+void
+EndParallel ()
 {
     ParallelContext::pop();
 }
 
-void ParallelDescriptor::Abort (int s, bool backtrace)
+void
+Abort (int s, bool backtrace)
 {
     if (backtrace && amrex::system::signal_handling) {
 	BLBackTrace::handler(s);
@@ -1816,132 +1767,126 @@ void ParallelDescriptor::Abort (int s, bool backtrace)
     }
 }
 
-const char* ParallelDescriptor::ErrorString (int) { return ""; }
+const char* ErrorString (int) { return ""; }
 
-void ParallelDescriptor::Barrier (const std::string &/*message*/) {}
-void ParallelDescriptor::Barrier (const MPI_Comm &/*comm*/, const std::string &/*message*/) {}
-ParallelDescriptor::Message ParallelDescriptor::Abarrier () { return ParallelDescriptor::Message(); }
-ParallelDescriptor::Message ParallelDescriptor::Abarrier (const MPI_Comm &/*comm*/) { return ParallelDescriptor::Message(); }
+void Barrier (const std::string &/*message*/) {}
+void Barrier (const MPI_Comm &/*comm*/, const std::string &/*message*/) {}
+Message Abarrier () { return Message(); }
+Message Abarrier (const MPI_Comm &/*comm*/) { return Message(); }
 
-void ParallelDescriptor::Test (MPI_Request&, int&, MPI_Status&) {}
-void ParallelDescriptor::IProbe (int, int, int&, MPI_Status&) {}
-void ParallelDescriptor::IProbe (int, int, MPI_Comm, int&, MPI_Status&) {}
+void Test (MPI_Request&, int&, MPI_Status&) {}
+void IProbe (int, int, int&, MPI_Status&) {}
+void IProbe (int, int, MPI_Comm, int&, MPI_Status&) {}
 
-void ParallelDescriptor::Comm_dup (MPI_Comm, MPI_Comm&) {}
+void Comm_dup (MPI_Comm, MPI_Comm&) {}
 
-void ParallelDescriptor::ReduceRealMax (Real&) {}
-void ParallelDescriptor::ReduceRealMin (Real&) {}
-void ParallelDescriptor::ReduceRealSum (Real&) {}
+void ReduceRealMax (Real&) {}
+void ReduceRealMin (Real&) {}
+void ReduceRealSum (Real&) {}
 
-void ParallelDescriptor::ReduceRealMax (Real&,int) {}
-void ParallelDescriptor::ReduceRealMin (Real&,int) {}
-void ParallelDescriptor::ReduceRealSum (Real&,int) {}
+void ReduceRealMax (Real&,int) {}
+void ReduceRealMin (Real&,int) {}
+void ReduceRealSum (Real&,int) {}
 
-void ParallelDescriptor::ReduceRealMax (Real*,int) {}
-void ParallelDescriptor::ReduceRealMin (Real*,int) {}
-void ParallelDescriptor::ReduceRealSum (Real*,int) {}
+void ReduceRealMax (Real*,int) {}
+void ReduceRealMin (Real*,int) {}
+void ReduceRealSum (Real*,int) {}
 
-void ParallelDescriptor::ReduceRealMax (Real*,int,int) {}
-void ParallelDescriptor::ReduceRealMin (Real*,int,int) {}
-void ParallelDescriptor::ReduceRealSum (Real*,int,int) {}
+void ReduceRealMax (Real*,int,int) {}
+void ReduceRealMin (Real*,int,int) {}
+void ReduceRealSum (Real*,int,int) {}
 
-void ParallelDescriptor::ReduceRealSum (Vector<std::reference_wrapper<Real> >&& /*rvar*/) {}
-void ParallelDescriptor::ReduceRealMax (Vector<std::reference_wrapper<Real> >&& /*rvar*/) {}
-void ParallelDescriptor::ReduceRealMin (Vector<std::reference_wrapper<Real> >&& /*rvar*/) {}
+void ReduceRealSum (Vector<std::reference_wrapper<Real> >&& /*rvar*/) {}
+void ReduceRealMax (Vector<std::reference_wrapper<Real> >&& /*rvar*/) {}
+void ReduceRealMin (Vector<std::reference_wrapper<Real> >&& /*rvar*/) {}
 
-void ParallelDescriptor::ReduceRealSum (Vector<std::reference_wrapper<Real> >&& /*rvar*/, int /*cpu*/) {}
-void ParallelDescriptor::ReduceRealMax (Vector<std::reference_wrapper<Real> >&& /*rvar*/, int /*cpu*/) {}
-void ParallelDescriptor::ReduceRealMin (Vector<std::reference_wrapper<Real> >&& /*rvar*/, int /*cpu*/) {}
+void ReduceRealSum (Vector<std::reference_wrapper<Real> >&& /*rvar*/, int /*cpu*/) {}
+void ReduceRealMax (Vector<std::reference_wrapper<Real> >&& /*rvar*/, int /*cpu*/) {}
+void ReduceRealMin (Vector<std::reference_wrapper<Real> >&& /*rvar*/, int /*cpu*/) {}
 
-void ParallelDescriptor::ReduceLongAnd (Long&) {}
-void ParallelDescriptor::ReduceLongSum (Long&) {}
-void ParallelDescriptor::ReduceLongMax (Long&) {}
-void ParallelDescriptor::ReduceLongMin (Long&) {}
+void ReduceLongAnd (Long&) {}
+void ReduceLongSum (Long&) {}
+void ReduceLongMax (Long&) {}
+void ReduceLongMin (Long&) {}
 
-void ParallelDescriptor::ReduceLongAnd (Long&,int) {}
-void ParallelDescriptor::ReduceLongSum (Long&,int) {}
-void ParallelDescriptor::ReduceLongMax (Long&,int) {}
-void ParallelDescriptor::ReduceLongMin (Long&,int) {}
+void ReduceLongAnd (Long&,int) {}
+void ReduceLongSum (Long&,int) {}
+void ReduceLongMax (Long&,int) {}
+void ReduceLongMin (Long&,int) {}
 
-void ParallelDescriptor::ReduceLongAnd (Long*,int) {}
-void ParallelDescriptor::ReduceLongSum (Long*,int) {}
-void ParallelDescriptor::ReduceLongMax (Long*,int) {}
-void ParallelDescriptor::ReduceLongMin (Long*,int) {}
+void ReduceLongAnd (Long*,int) {}
+void ReduceLongSum (Long*,int) {}
+void ReduceLongMax (Long*,int) {}
+void ReduceLongMin (Long*,int) {}
 
-void ParallelDescriptor::ReduceLongAnd (Long*,int,int) {}
-void ParallelDescriptor::ReduceLongSum (Long*,int,int) {}
-void ParallelDescriptor::ReduceLongMax (Long*,int,int) {}
-void ParallelDescriptor::ReduceLongMin (Long*,int,int) {}
+void ReduceLongAnd (Long*,int,int) {}
+void ReduceLongSum (Long*,int,int) {}
+void ReduceLongMax (Long*,int,int) {}
+void ReduceLongMin (Long*,int,int) {}
 
-void ParallelDescriptor::ReduceLongAnd (Vector<std::reference_wrapper<Long> >&& /*rvar*/) {}
-void ParallelDescriptor::ReduceLongSum (Vector<std::reference_wrapper<Long> >&& /*rvar*/) {}
-void ParallelDescriptor::ReduceLongMax (Vector<std::reference_wrapper<Long> >&& /*rvar*/) {}
-void ParallelDescriptor::ReduceLongMin (Vector<std::reference_wrapper<Long> >&& /*rvar*/) {}
+void ReduceLongAnd (Vector<std::reference_wrapper<Long> >&& /*rvar*/) {}
+void ReduceLongSum (Vector<std::reference_wrapper<Long> >&& /*rvar*/) {}
+void ReduceLongMax (Vector<std::reference_wrapper<Long> >&& /*rvar*/) {}
+void ReduceLongMin (Vector<std::reference_wrapper<Long> >&& /*rvar*/) {}
 
-void ParallelDescriptor::ReduceLongAnd (Vector<std::reference_wrapper<Long> >&& /*rvar*/, int /*cpu*/) {}
-void ParallelDescriptor::ReduceLongSum (Vector<std::reference_wrapper<Long> >&& /*rvar*/, int /*cpu*/) {}
-void ParallelDescriptor::ReduceLongMax (Vector<std::reference_wrapper<Long> >&& /*rvar*/, int /*cpu*/) {}
-void ParallelDescriptor::ReduceLongMin (Vector<std::reference_wrapper<Long> >&& /*rvar*/, int /*cpu*/) {}
+void ReduceLongAnd (Vector<std::reference_wrapper<Long> >&& /*rvar*/, int /*cpu*/) {}
+void ReduceLongSum (Vector<std::reference_wrapper<Long> >&& /*rvar*/, int /*cpu*/) {}
+void ReduceLongMax (Vector<std::reference_wrapper<Long> >&& /*rvar*/, int /*cpu*/) {}
+void ReduceLongMin (Vector<std::reference_wrapper<Long> >&& /*rvar*/, int /*cpu*/) {}
 
-void ParallelDescriptor::ReduceIntSum (int&) {}
-void ParallelDescriptor::ReduceIntMax (int&) {}
-void ParallelDescriptor::ReduceIntMin (int&) {}
+void ReduceIntSum (int&) {}
+void ReduceIntMax (int&) {}
+void ReduceIntMin (int&) {}
 
-void ParallelDescriptor::ReduceIntSum (int&,int) {}
-void ParallelDescriptor::ReduceIntMax (int&,int) {}
-void ParallelDescriptor::ReduceIntMin (int&,int) {}
+void ReduceIntSum (int&,int) {}
+void ReduceIntMax (int&,int) {}
+void ReduceIntMin (int&,int) {}
 
-void ParallelDescriptor::ReduceIntSum (int*,int) {}
-void ParallelDescriptor::ReduceIntMax (int*,int) {}
-void ParallelDescriptor::ReduceIntMin (int*,int) {}
+void ReduceIntSum (int*,int) {}
+void ReduceIntMax (int*,int) {}
+void ReduceIntMin (int*,int) {}
 
-void ParallelDescriptor::ReduceIntSum (int*,int,int) {}
-void ParallelDescriptor::ReduceIntMax (int*,int,int) {}
-void ParallelDescriptor::ReduceIntMin (int*,int,int) {}
+void ReduceIntSum (int*,int,int) {}
+void ReduceIntMax (int*,int,int) {}
+void ReduceIntMin (int*,int,int) {}
 
-void ParallelDescriptor::ReduceIntSum (Vector<std::reference_wrapper<int> >&& /*rvar*/) {}
-void ParallelDescriptor::ReduceIntMax (Vector<std::reference_wrapper<int> >&& /*rvar*/) {}
-void ParallelDescriptor::ReduceIntMin (Vector<std::reference_wrapper<int> >&& /*rvar*/) {}
+void ReduceIntSum (Vector<std::reference_wrapper<int> >&& /*rvar*/) {}
+void ReduceIntMax (Vector<std::reference_wrapper<int> >&& /*rvar*/) {}
+void ReduceIntMin (Vector<std::reference_wrapper<int> >&& /*rvar*/) {}
 
-void ParallelDescriptor::ReduceIntSum (Vector<std::reference_wrapper<int> >&& /*rvar*/, int /*cpu*/) {}
-void ParallelDescriptor::ReduceIntMax (Vector<std::reference_wrapper<int> >&& /*rvar*/, int /*cpu*/) {}
-void ParallelDescriptor::ReduceIntMin (Vector<std::reference_wrapper<int> >&& /*rvar*/, int /*cpu*/) {}
+void ReduceIntSum (Vector<std::reference_wrapper<int> >&& /*rvar*/, int /*cpu*/) {}
+void ReduceIntMax (Vector<std::reference_wrapper<int> >&& /*rvar*/, int /*cpu*/) {}
+void ReduceIntMin (Vector<std::reference_wrapper<int> >&& /*rvar*/, int /*cpu*/) {}
 
-void ParallelDescriptor::ReduceBoolAnd (bool&) {}
-void ParallelDescriptor::ReduceBoolOr  (bool&) {}
+void ReduceBoolAnd (bool&) {}
+void ReduceBoolOr  (bool&) {}
 
-void ParallelDescriptor::ReduceBoolAnd (bool&,int) {}
-void ParallelDescriptor::ReduceBoolOr  (bool&,int) {}
+void ReduceBoolAnd (bool&,int) {}
+void ReduceBoolOr  (bool&,int) {}
 
-void ParallelDescriptor::Bcast(void *, int, MPI_Datatype, int, MPI_Comm) {}
+void Bcast(void *, int, MPI_Datatype, int, MPI_Comm) {}
 
 double
-ParallelDescriptor::second () noexcept
+second () noexcept
 {
     return amrex::second();
 }
 
 void
-ParallelDescriptor::Wait (MPI_Request& /*req*/,
-                          MPI_Status& /*status*/)
+Wait (MPI_Request& /*req*/, MPI_Status& /*status*/)
 {}
 
 void
-ParallelDescriptor::Waitall (Vector<MPI_Request>& /*reqs*/,
-                             Vector<MPI_Status>& /*status*/)
+Waitall (Vector<MPI_Request>& /*reqs*/, Vector<MPI_Status>& /*status*/)
 {}
 
 void
-ParallelDescriptor::Waitany (Vector<MPI_Request>& /*reqs*/,
-                             int &/*index*/,
-                             MPI_Status& /*status*/)
+Waitany (Vector<MPI_Request>& /*reqs*/, int &/*index*/, MPI_Status& /*status*/)
 {}
 
 void
-ParallelDescriptor::Waitsome (Vector<MPI_Request>& /*reqs*/,
-                              int&                 /*completed*/,
-                              Vector<int>&         /*indx*/,
-                              Vector<MPI_Status>&  /*status*/)
+Waitsome (Vector<MPI_Request>& /*reqs*/, int& /*completed*/,
+          Vector<int>& /*indx*/, Vector<MPI_Status>& /*status*/)
 {}
 
 #endif
@@ -2014,10 +1959,7 @@ BL_FORT_PROC_DECL(BL_PD_ABORT,bl_pd_abort)()
 
 #endif
 
-#ifdef BL_USE_MPI
-namespace ParallelDescriptor
-{
-#ifndef BL_AMRPROF
+#if defined(BL_USE_MPI) && !defined(BL_AMRPROF)
 template <> MPI_Datatype Mpi_typemap<IntVect>::type()
 {
     static_assert(AMREX_IS_TRIVIALLY_COPYABLE(IntVect), "IntVect must be trivially copyable");
@@ -2098,14 +2040,10 @@ template <> MPI_Datatype Mpi_typemap<Box>::type()
     return mpi_type_box;
 }
 #endif
-}
-#endif
 
 void
-ParallelDescriptor::ReadAndBcastFile (const std::string& filename,
-                                      Vector<char>&       charBuf,
-				      bool               bExitOnError,
-				      const MPI_Comm    &comm)
+ReadAndBcastFile (const std::string& filename, Vector<char>& charBuf,
+                  bool bExitOnError, const MPI_Comm&comm)
 {
     enum { IO_Buffer_Size = 262144 * 8 };
 
@@ -2156,7 +2094,7 @@ ParallelDescriptor::ReadAndBcastFile (const std::string& filename,
 }
 
 void
-ParallelDescriptor::Initialize ()
+Initialize ()
 {
 #ifndef BL_AMRPROF
     ParmParse pp("amrex");
@@ -2167,7 +2105,7 @@ ParallelDescriptor::Initialize ()
 }
 
 void
-ParallelDescriptor::Finalize ()
+Finalize ()
 {
 #ifndef BL_AMRPROF
     EndTeams();
@@ -2176,7 +2114,7 @@ ParallelDescriptor::Finalize ()
 
 #ifndef BL_AMRPROF
 void
-ParallelDescriptor::StartTeams ()
+StartTeams ()
 {
     int team_size = 1;
     int do_team_reduce = 0;
@@ -2230,13 +2168,13 @@ ParallelDescriptor::StartTeams ()
 #endif
 
 void
-ParallelDescriptor::EndTeams ()
+EndTeams ()
 {
     m_Team.clear();
 }
 
 std::string
-ParallelDescriptor::mpi_level_to_string (int mtlev)
+mpi_level_to_string (int mtlev)
 {
     switch (mtlev) {
 #ifdef AMREX_USE_MPI
@@ -2257,7 +2195,7 @@ ParallelDescriptor::mpi_level_to_string (int mtlev)
 #ifdef BL_USE_MPI
 
 int
-ParallelDescriptor::select_comm_data_type (std::size_t nbytes)
+select_comm_data_type (std::size_t nbytes)
 {
     if (nbytes <= std::size_t(std::numeric_limits<int>::max()))
     {
@@ -2279,7 +2217,7 @@ ParallelDescriptor::select_comm_data_type (std::size_t nbytes)
 }
 
 std::size_t
-ParallelDescriptor::alignof_comm_data (std::size_t nbytes)
+alignof_comm_data (std::size_t nbytes)
 {
     const int t = select_comm_data_type(nbytes);
     if (t == 1) {
@@ -2294,9 +2232,184 @@ ParallelDescriptor::alignof_comm_data (std::size_t nbytes)
     }
 }
 
+template <>
+Message
+Asend<char> (const char* buf, size_t n, int pid, int tag, MPI_Comm comm)
+{
+    BL_PROFILE_T_S("ParallelDescriptor::Asend(TsiiM)", char);
+    BL_COMM_PROFILE(BLProfiler::AsendTsiiM, n * sizeof(char), pid, tag);
+
+    MPI_Request req;
+    Message msg;
+    const int comm_data_type = ParallelDescriptor::select_comm_data_type(n);
+    if (comm_data_type == 1) {
+        BL_MPI_REQUIRE( MPI_Isend(const_cast<char*>(buf),
+                                  n,
+                                  Mpi_typemap<char>::type(),
+                                  pid, tag, comm, &req) );
+        msg = Message(req, Mpi_typemap<char>::type());
+    } else if (comm_data_type == 2) {
+        if (!amrex::is_aligned(buf, alignof(unsigned long long))
+            or (n % sizeof(unsigned long long)) != 0) {
+            amrex::Abort("Message size is too big as char, and it cannot be sent as unsigned long long.");
+        }
+        BL_MPI_REQUIRE( MPI_Isend(const_cast<unsigned long long*>
+                                     (reinterpret_cast<unsigned long long const*>(buf)),
+                                  n/sizeof(unsigned long long),
+                                  Mpi_typemap<unsigned long long>::type(),
+                                  pid, tag, comm, &req) );
+        msg = Message(req, Mpi_typemap<unsigned long long>::type());
+    } else if (comm_data_type == 3) {
+        if (!amrex::is_aligned(buf, alignof(ParallelDescriptor::lull_t))
+            or (n % sizeof(ParallelDescriptor::lull_t)) != 0) {
+            amrex::Abort("Message size is too big as char or unsigned long long, and it cannot be sent as ParallelDescriptor::lull_t");
+        }
+        BL_MPI_REQUIRE( MPI_Isend(const_cast<ParallelDescriptor::lull_t*>
+                                     (reinterpret_cast<ParallelDescriptor::lull_t const*>(buf)),
+                                  n/sizeof(ParallelDescriptor::lull_t),
+                                  Mpi_typemap<ParallelDescriptor::lull_t>::type(),
+                                  pid, tag, comm, &req) );
+        msg = Message(req, Mpi_typemap<ParallelDescriptor::lull_t>::type());
+    } else {
+        amrex::Abort("TODO: message size is too big");
+    }
+
+    BL_COMM_PROFILE(BLProfiler::AsendTsiiM, BLProfiler::AfterCall(), pid, tag);
+    return msg;
+}
+
+template <>
+Message
+Send<char> (const char* buf, size_t n, int pid, int tag, MPI_Comm comm)
+{
+    BL_PROFILE_T_S("ParallelDescriptor::Send(Tsii)", char);
+    BL_COMM_PROFILE(BLProfiler::SendTsii, n * sizeof(char), pid, tag);
+
+    const int comm_data_type = ParallelDescriptor::select_comm_data_type(n);
+    if (comm_data_type == 1) {
+        BL_MPI_REQUIRE( MPI_Send(const_cast<char*>(buf),
+                                 n,
+                                 Mpi_typemap<char>::type(),
+                                 pid, tag, comm) );
+    } else if (comm_data_type == 2) {
+        if (!amrex::is_aligned(buf, alignof(unsigned long long))
+            or (n % sizeof(unsigned long long)) != 0) {
+            amrex::Abort("Message size is too big as char, and it cannot be sent as unsigned long long.");
+        }
+        BL_MPI_REQUIRE( MPI_Send(const_cast<unsigned long long*>
+                                     (reinterpret_cast<unsigned long long const*>(buf)),
+                                 n/sizeof(unsigned long long),
+                                 Mpi_typemap<unsigned long long>::type(),
+                                 pid, tag, comm) );
+    } else if (comm_data_type == 3) {
+        if (!amrex::is_aligned(buf, alignof(ParallelDescriptor::lull_t))
+            or (n % sizeof(ParallelDescriptor::lull_t)) != 0) {
+            amrex::Abort("Message size is too big as char or unsigned long long, and it cannot be sent as ParallelDescriptor::lull_t");
+        }
+        BL_MPI_REQUIRE( MPI_Send(const_cast<ParallelDescriptor::lull_t*>
+                                     (reinterpret_cast<ParallelDescriptor::lull_t const*>(buf)),
+                                 n/sizeof(ParallelDescriptor::lull_t),
+                                 Mpi_typemap<ParallelDescriptor::lull_t>::type(),
+                                 pid, tag, comm) );
+    } else {
+        amrex::Abort("TODO: message size is too big");
+    }
+
+    BL_COMM_PROFILE(BLProfiler::SendTsii, BLProfiler::AfterCall(), pid, tag);
+    return Message();
+}
+
+template <>
+Message
+Arecv<char> (char* buf, size_t n, int pid, int tag, MPI_Comm comm)
+{
+    BL_PROFILE_T_S("ParallelDescriptor::Arecv(TsiiM)", char);
+    BL_COMM_PROFILE(BLProfiler::ArecvTsiiM, n * sizeof(char), pid, tag);
+
+    MPI_Request req;
+    Message msg;
+    const int comm_data_type = ParallelDescriptor::select_comm_data_type(n);
+    if (comm_data_type == 1) {
+        BL_MPI_REQUIRE( MPI_Irecv(buf,
+                                  n,
+                                  Mpi_typemap<char>::type(),
+                                  pid, tag, comm, &req) );
+        msg = Message(req, Mpi_typemap<char>::type());
+    } else if (comm_data_type == 2) {
+        if (!amrex::is_aligned(buf, alignof(unsigned long long))
+            or (n % sizeof(unsigned long long)) != 0) {
+            amrex::Abort("Message size is too big as char, and it cannot be received as unsigned long long.");
+        }
+        BL_MPI_REQUIRE( MPI_Irecv((unsigned long long *)buf,
+                                  n/sizeof(unsigned long long),
+                                  Mpi_typemap<unsigned long long>::type(),
+                                  pid, tag, comm, &req) );
+        msg = Message(req, Mpi_typemap<unsigned long long>::type());
+    } else if (comm_data_type == 3) {
+        if (!amrex::is_aligned(buf, alignof(ParallelDescriptor::lull_t))
+            or (n % sizeof(ParallelDescriptor::lull_t)) != 0) {
+            amrex::Abort("Message size is too big as char or unsigned long long, and it cannot be received as ParallelDescriptor::lull_t");
+        }
+        BL_MPI_REQUIRE( MPI_Irecv((ParallelDescriptor::lull_t *)buf,
+                                  n/sizeof(ParallelDescriptor::lull_t),
+                                  Mpi_typemap<ParallelDescriptor::lull_t>::type(),
+                                  pid, tag, comm, &req) );
+        msg = Message(req, Mpi_typemap<ParallelDescriptor::lull_t>::type());
+    } else {
+        amrex::Abort("Message size is too big");
+    }
+
+    BL_COMM_PROFILE(BLProfiler::ArecvTsiiM, BLProfiler::AfterCall(), pid, tag);
+    return msg;
+}
+
+template <>
+Message
+Recv<char> (char* buf, size_t n, int pid, int tag, MPI_Comm comm)
+{
+    BL_PROFILE_T_S("ParallelDescriptor::Recv(Tsii)", char);
+    BL_COMM_PROFILE(BLProfiler::RecvTsii, BLProfiler::BeforeCall(), pid, tag);
+
+    MPI_Status stat;
+    Message msg;
+    const int comm_data_type = ParallelDescriptor::select_comm_data_type(n);
+    if (comm_data_type == 1) {
+        BL_MPI_REQUIRE( MPI_Recv(buf,
+                                 n,
+                                 Mpi_typemap<char>::type(),
+                                 pid, tag, comm, &stat) );
+        msg = Message(stat, Mpi_typemap<char>::type());
+    } else if (comm_data_type == 2) {
+        if (!amrex::is_aligned(buf, alignof(unsigned long long))
+            or (n % sizeof(unsigned long long)) != 0) {
+            amrex::Abort("Message size is too big as char, and it cannot be received as unsigned long long.");
+        }
+        BL_MPI_REQUIRE( MPI_Recv((unsigned long long *)buf,
+                                 n/sizeof(unsigned long long),
+                                 Mpi_typemap<unsigned long long>::type(),
+                                 pid, tag, comm, &stat) );
+        msg = Message(stat, Mpi_typemap<unsigned long long>::type());
+    } else if (comm_data_type == 3) {
+        if (!amrex::is_aligned(buf, alignof(ParallelDescriptor::lull_t))
+            or (n % sizeof(ParallelDescriptor::lull_t)) != 0) {
+            amrex::Abort("Message size is too big as char or unsigned long long, and it cannot be received as ParallelDescriptor::lull_t");
+        }
+        BL_MPI_REQUIRE( MPI_Recv((ParallelDescriptor::lull_t *)buf,
+                                 n/sizeof(ParallelDescriptor::lull_t),
+                                 Mpi_typemap<ParallelDescriptor::lull_t>::type(),
+                                 pid, tag, comm, &stat) );
+        msg = Message(stat, Mpi_typemap<ParallelDescriptor::lull_t>::type());
+    } else {
+        amrex::Abort("Message size is too big");
+    }
+
+    BL_COMM_PROFILE(BLProfiler::RecvTsii, n * sizeof(char), pid, stat.MPI_TAG);
+    return msg;
+}
+
 #endif
 
-}
+}}
 
 
 using namespace amrex;

--- a/Src/Particle/AMReX_ParticleCommunication.H
+++ b/Src/Particle/AMReX_ParticleCommunication.H
@@ -463,19 +463,8 @@ void communicateParticlesStart (const PC& pc, ParticleCopyPlan& plan, const Buff
         AMREX_ASSERT(Who >= 0 && Who < NProcs);
         AMREX_ASSERT(amrex::aligned_size(acd, nbytes) % acd == 0);
 
-        const int comm_data_type = ParallelDescriptor::select_comm_data_type(nbytes);
-        if (comm_data_type == 1) {
-            plan.m_particle_rreqs[i] =
-                ParallelDescriptor::Arecv((char*) (rcv_buffer.dataPtr() + offset), Cnt, Who, SeqNum, ParallelContext::CommunicatorSub()).req();
-        } else if (comm_data_type == 2) {
-            plan.m_particle_rreqs[i] =
-                ParallelDescriptor::Arecv((unsigned long long*) (rcv_buffer.dataPtr() + offset), Cnt, Who, SeqNum, ParallelContext::CommunicatorSub()).req();
-        } else if (comm_data_type == 3) {
-            plan.m_particle_rreqs[i] =
-                ParallelDescriptor::Arecv((ParallelDescriptor::lull_t *) (rcv_buffer.dataPtr() + offset), Cnt, Who, SeqNum, ParallelContext::CommunicatorSub()).req();
-        } else {
-            amrex::Abort("TODO: message size is too big");
-        }
+        plan.m_particle_rreqs[i] =
+            ParallelDescriptor::Arecv((char*) (rcv_buffer.dataPtr() + offset), Cnt, Who, SeqNum, ParallelContext::CommunicatorSub()).req();
     }
 
     if (plan.m_NumSnds == 0) return;
@@ -496,17 +485,8 @@ void communicateParticlesStart (const PC& pc, ParticleCopyPlan& plan, const Buff
         AMREX_ASSERT(Cnt < std::numeric_limits<int>::max());
         AMREX_ASSERT(snd_offset % acd == 0);
 
-        const int comm_data_type = ParallelDescriptor::select_comm_data_type(nbytes);
-        if (comm_data_type == 1) {
-            ParallelDescriptor::Send((char*)(snd_buffer.dataPtr()+snd_offset), Cnt, Who, SeqNum,
-                                     ParallelContext::CommunicatorSub());
-        } else if (comm_data_type == 2) {
-            ParallelDescriptor::Send((unsigned long long*)(snd_buffer.dataPtr()+snd_offset), Cnt, Who, SeqNum, ParallelContext::CommunicatorSub());
-        } else if (comm_data_type == 3) {
-            ParallelDescriptor::Send((ParallelDescriptor::lull_t *)(snd_buffer.dataPtr()+snd_offset), Cnt, Who, SeqNum, ParallelContext::CommunicatorSub());
-        } else {
-            amrex::Abort("TODO: message size is too big");
-        }
+        ParallelDescriptor::Send((char const*)(snd_buffer.dataPtr()+snd_offset), Cnt, Who, SeqNum,
+                                 ParallelContext::CommunicatorSub());
     }
 #else
     amrex::ignore_unused(pc,plan,snd_buffer,rcv_buffer);


### PR DESCRIPTION
## Summary

* Add template specialization of MPI communication functions for char.
  Select a proper data type according to the size.

* Use the new functions in FabArray and Particle communication. And this
  also fixes a bug in Particle communication.  (The counts should be divided
  by the size of data type.)

* Due to a gcc bug on explicit specialization in a namespace, workaround was
  implemented in AMReX_ParallelDescriptor.H and .cpp.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
