### PR TITLE
Fused FillBoundary

### DIFF
--- a/Src/Base/AMReX_Array4.H
+++ b/Src/Base/AMReX_Array4.H
@@ -59,6 +59,21 @@ namespace amrex {
               ncomp(rhs.ncomp-start_comp)
         {}
 
+        template <class U,
+                  typename std::enable_if
+                  <std::is_same<typename std::remove_const<T>::type,
+                                typename std::remove_const<U>::type>::value,int>::type = 0>
+        AMREX_GPU_HOST_DEVICE
+        constexpr Array4 (Array4<U> const& rhs, int start_comp, int num_comps) noexcept
+            : p((T*)(rhs.p+start_comp*rhs.nstride)),
+              jstride(rhs.jstride),
+              kstride(rhs.kstride),
+              nstride(rhs.nstride),
+              begin(rhs.begin),
+              end(rhs.end),
+              ncomp(num_comps)
+        {}
+
         AMREX_GPU_HOST_DEVICE
         explicit operator bool() const noexcept { return p != nullptr; }
 

--- a/Src/Base/AMReX_BaseFab.H
+++ b/Src/Base/AMReX_BaseFab.H
@@ -400,6 +400,12 @@ public:
     }
 
     AMREX_FORCE_INLINE
+    Array4<T const> array (int start_comp, int num_comps) const noexcept
+    {
+        return Array4<T const>(makeArray4<T const>(this->dptr, this->domain, this->nvar), start_comp, num_comps);
+    }
+
+    AMREX_FORCE_INLINE
     Array4<T> array () noexcept
     {
         return makeArray4<T>(this->dptr, this->domain, this->nvar);
@@ -412,6 +418,12 @@ public:
     }
 
     AMREX_FORCE_INLINE
+    Array4<T> array (int start_comp, int num_comps) noexcept
+    {
+        return Array4<T>(makeArray4<T>(this->dptr, this->domain, this->nvar), start_comp, num_comps);
+    }
+
+    AMREX_FORCE_INLINE
     Array4<T const> const_array () const noexcept
     {
         return makeArray4<T const>(this->dptr, this->domain, this->nvar);
@@ -421,6 +433,12 @@ public:
     Array4<T const> const_array (int start_comp) const noexcept
     {
         return Array4<T const>(makeArray4<T const>(this->dptr, this->domain, this->nvar),start_comp);
+    }
+
+    AMREX_FORCE_INLINE
+    Array4<T const> const_array (int start_comp, int num_comps) const noexcept
+    {
+        return Array4<T const>(makeArray4<T const>(this->dptr, this->domain, this->nvar), start_comp, num_comps);
     }
 
     //! Returns true if the data for the FAB has been allocated.

--- a/Src/Base/AMReX_Box.H
+++ b/Src/Base/AMReX_Box.H
@@ -213,6 +213,14 @@ public:
     AMREX_GPU_HOST_DEVICE
     bool contains (const IntVect& p) const noexcept { return p.allGE(smallend) && p.allLE(bigend); }
 
+    //! Returns true if argument is contained within Box.
+    AMREX_GPU_HOST_DEVICE
+    bool contains (const Dim3& p) const noexcept {
+        return AMREX_D_TERM(p.x >= smallend[0] && p.x <= bigend[0],
+                         && p.y >= smallend[1] && p.y <= bigend[1],
+                         && p.z >= smallend[2] && p.z <= bigend[2]);
+    }
+
     /** \brief Returns true if argument is contained within Box.
     * It is an error if the Boxes have different types.
     */

--- a/Src/Base/AMReX_FabArrayBase.H
+++ b/Src/Base/AMReX_FabArrayBase.H
@@ -405,12 +405,6 @@ public:
 
     const TileArray* getTileArray (const IntVect& tilesize) const;
 
-    //! Block until all send requests complete
-    static void WaitForAsyncSends (int                 N_snds,
-                                   Vector<MPI_Request>& send_reqs,
-                                   Vector<char*>&       send_data,
-                                   Vector<MPI_Status>&  stats);
-
     // Memory Usage Tags
     struct meminfo {
         Long nbytes = 0L;

--- a/Src/Base/AMReX_FabArrayBase.cpp
+++ b/Src/Base/AMReX_FabArrayBase.cpp
@@ -2337,29 +2337,6 @@ FabArrayBase::updateBDKey ()
     }
 }
 
-
-void
-FabArrayBase::WaitForAsyncSends (int                 N_snds,
-                                 Vector<MPI_Request>& send_reqs,
-                                 Vector<char*>&       send_data,
-                                 Vector<MPI_Status>&  stats)
-{
-    amrex::ignore_unused(send_data);
-#ifdef BL_USE_MPI
-    BL_ASSERT(N_snds > 0);
-
-    stats.resize(N_snds);
-
-    BL_ASSERT(send_reqs.size() == N_snds);
-    BL_ASSERT(send_data.size() == N_snds);
-
-    ParallelDescriptor::Waitall(send_reqs, stats);
-#else
-    amrex::ignore_unused(N_snds,send_reqs,stats);
-#endif /*BL_USE_MPI*/
-}
-
-
 #ifdef BL_USE_MPI
 
 bool

--- a/Src/Base/AMReX_FabArrayCommI.H
+++ b/Src/Base/AMReX_FabArrayCommI.H
@@ -150,9 +150,10 @@ FabArray<FAB>::FBEP_nowait (int scomp, int ncomp, const IntVect& nghost,
         {
             FB_local_copy_cpu(TheFB, scomp, ncomp);
 	}
+
+        FillBoundary_test();
     }
 
-    FillBoundary_test();
 #endif /*BL_USE_MPI*/
 }
 
@@ -232,8 +233,8 @@ FabArray<FAB>::FillBoundary_finish ()
 
     const int N_snds = TheFB.m_SndTags->size();
     if (N_snds > 0) {
-        Vector<MPI_Status> stats;
-        FabArrayBase::WaitForAsyncSends(N_snds,fb_send_reqs,fb_send_data,stats);
+        Vector<MPI_Status> stats(fb_send_reqs.size());
+        ParallelDescriptor::Waitall(fb_send_reqs, stats);
         amrex::The_FA_Arena()->free(fb_the_send_data);
         fb_the_send_data = nullptr;
     }
@@ -463,8 +464,8 @@ FabArray<FAB>::ParallelCopy (const FabArray<FAB>& src,
 	
         if (N_snds > 0) {
             if (! thecpc.m_SndTags->empty()) {
-                Vector<MPI_Status> stats;
-                FabArrayBase::WaitForAsyncSends(N_snds,send_reqs,send_data,stats);
+                Vector<MPI_Status> stats(send_reqs.size());
+                ParallelDescriptor::Waitall(send_reqs, stats);
 	    }
             amrex::The_FA_Arena()->free(the_send_data);
             the_send_data = nullptr;
@@ -585,7 +586,7 @@ FabArray<FAB>::PrepareSendBuffers (const MapOfCopyComTagContainers&     SndTags,
         std::size_t nbytes = 0;
         for (auto const& cct : kv.second)
         {
-                nbytes += (*this)[cct.srcIndex].nBytes(cct.sbox,ncomp);
+            nbytes += (*this)[cct.srcIndex].nBytes(cct.sbox,ncomp);
         }
 
         std::size_t acd = ParallelDescriptor::alignof_comm_data(nbytes);
@@ -750,33 +751,315 @@ template <class FAB>
 void
 FabArray<FAB>::FillBoundary_test ()
 {
-#ifdef BL_USE_MPI
-#ifndef AMREX_DEBUG
-    if (!fb_recv_reqs.empty()) {
-        int flag;
-        MPI_Testall(fb_recv_reqs.size(), fb_recv_reqs.data(), &flag,
-                    fb_recv_stat.data());
-    }
-#endif
+#if defined(AMREX_USE_MPI) && !defined(AMREX_DEBUG)
+    // We only test if no DEBUG because in DEBUG we check the status later.
+    // If Test is done here, the status check will fail.
+    int flag;
+    ParallelDescriptor::Test(fb_recv_reqs, flag, fb_recv_stat);
 #endif
 }
 
-template <class FAB>
-void
-FillBoundary (Vector<FabArray<FAB>*> const& mf, const Periodicity& period)
+namespace detail {
+template <class TagT>
+void fbv_copy (Vector<TagT> const& tags)
+{
+    const int N = tags.size();
+    if (N == 0) return;
+#ifdef AMREX_USE_GPU
+    if (Gpu::inLaunchRegion()) {
+        ParallelFor(tags, 1,
+        [=] AMREX_GPU_DEVICE (int i, int j, int k, int, TagT const& tag) noexcept
+        {
+            const int ncomp = tag.dfab.nComp();
+            for (int n = 0; n < ncomp; ++n) {
+                tag.dfab(i,j,k,n) = tag.sfab(i+tag.offset.x,j+tag.offset.y,k+tag.offset.z,n);
+            }
+        });
+    } else
+#endif
+    {
+#ifdef AMREX_USE_OMP
+#pragma omp parallel for
+#endif
+        for (int itag = 0; itag < N; ++itag) {
+            auto const& tag = tags[itag];
+            const int ncomp = tag.dfab.nComp();
+            AMREX_LOOP_4D(tag.dbox, ncomp, i, j, k, n,
+            {
+                tag.dfab(i,j,k,n) = tag.sfab(i+tag.offset.x,j+tag.offset.y,k+tag.offset.z,n);
+            });
+        }
+    }
+}
+}
+
+template <class MF>
+amrex::EnableIf_t<IsFabArray<MF>::value>
+FillBoundary (Vector<MF*> const& mf, Vector<int> const& scomp,
+              Vector<int> const& ncomp, Vector<IntVect> const& nghost,
+              Vector<Periodicity> const& period, Vector<int> const& cross = {})
 {
     BL_PROFILE("FillBoundary(Vector)");
-    const int nummfs = mf.size();
 #if 1
-    for (int imf = 0; imf < nummfs; ++imf) {
-        mf[imf]->FillBoundary(period);
+    const int N = mf.size();
+    for (int i = 0; i < N; ++i) {
+        mf[i]->FillBoundary_nowait(scomp[i], ncomp[i], nghost[i], period[i],
+                                   cross.empty() ? 0 : cross[i]);
     }
+    for (int i = 0; i < N; ++i) {
+        mf[i]->FillBoundary_finish();
+    }
+
 #else
-    for (int imf = 0; imf < nummfs; ++imf) {
-        mf[imf]->FillBoundary_nowait(period);
+    using FAB = typename MF::FABType::value_type;
+    using T   = typename FAB::value_type;
+
+    const int nmfs = mf.size();
+    Vector<FabArrayBase::CommMetaData const*> cmds;
+    int N_locs = 0;
+    int N_rcvs = 0;
+    int N_snds = 0;
+    for (int imf = 0; imf < nmfs; ++imf) {
+        if (nghost[imf].max() > 0) {
+            auto const& TheFB = mf[imf]->getFB(nghost[imf], period[imf],
+                                               cross.empty() ? 0 : cross[imf]);
+            // The FB is cached.  Therefore it's safe take its address for later use.
+            cmds.push_back(static_cast<FabArrayBase::CommMetaData const*>(&TheFB));
+            N_locs += TheFB.m_LocTags->size();
+            N_rcvs += TheFB.m_RcvTags->size();
+            N_snds += TheFB.m_SndTags->size();
+        } else {
+            cmds.push_back(nullptr);
+        }
     }
-    for (int imf = 0; imf < nummfs; ++imf) {
-        mf[imf]->FillBoundary_finish();
+
+    using TagT = Array4CopyTag<T>;
+    Vector<TagT> local_tags;
+    local_tags.reserve(N_locs);
+    static_assert(amrex::IsStoreAtomic<T>::value, "FillBoundary(Vector): storing T is not atomic");
+    for (int imf = 0; imf < nmfs; ++imf) {
+        if (cmds[imf]) {
+            auto const& tags = *(cmds[imf]->m_LocTags);
+            for (auto const& tag : tags) {
+                local_tags.push_back({(*mf[imf])[tag.dstIndex].array      (scomp[imf],ncomp[imf]),
+                                      (*mf[imf])[tag.srcIndex].const_array(scomp[imf],ncomp[imf]),
+                                      tag.dbox,
+                                      (tag.sbox.smallEnd()-tag.dbox.smallEnd()).dim3()});
+            }
+        }
     }
+
+    if (ParallelContext::NProcsSub() == 1) {
+        detail::fbv_copy(local_tags);
+        return;
+    }
+
+#ifdef AMREX_USE_MPI
+    //
+    // Do this before prematurely exiting if running in parallel.
+    // Otherwise sequence numbers will not match across MPI processes.
+    //
+    int SeqNum = ParallelDescriptor::SeqNum();
+    MPI_Comm comm = ParallelContext::CommunicatorSub();
+
+    if (N_locs == 0 && N_rcvs == 0 && N_snds == 0) return; // No work to do
+
+    char* the_recv_data = nullptr;
+    Vector<int> recv_from;
+    Vector<std::size_t> recv_size;
+    Vector<MPI_Request> recv_reqs;
+    Vector<MPI_Status> recv_stat;
+    Vector<TagT> recv_tags;
+
+    if (N_rcvs > 0) {
+
+        for (int imf = 0; imf < nmfs; ++imf) {
+            if (cmds[imf]) {
+                auto const& tags = *(cmds[imf]->m_RcvTags);
+                for (const auto& kv : tags) {
+                    recv_from.push_back(kv.first);
+                }
+            }
+        }
+        amrex::RemoveDuplicates(recv_from);
+        const int nrecv = recv_from.size();
+
+        recv_reqs.resize(nrecv, MPI_REQUEST_NULL);
+        recv_stat.resize(nrecv);
+
+        recv_tags.reserve(N_rcvs);
+
+        Vector<Vector<std::size_t> > recv_offset(nrecv);
+        Vector<std::size_t> offset;
+        recv_size.reserve(nrecv);
+        offset.reserve(nrecv);
+        std::size_t TotalRcvsVolume = 0;
+        for (int i = 0; i < nrecv; ++i) {
+            std::size_t nbytes = 0;
+            for (int imf = 0; imf < nmfs; ++imf) {
+                if (cmds[imf]) {
+                    auto const& tags = *(cmds[imf]->m_RcvTags);
+                    auto it = tags.find(recv_from[i]);
+                    if (it != tags.end()) {
+                        for (auto const& cct : it->second) {
+                            auto& dfab = (*mf[imf])[cct.dstIndex];
+                            recv_offset[i].push_back(nbytes);
+                            recv_tags.push_back({dfab.array(scomp[imf],ncomp[imf]),
+                                                 makeArray4<T const>(nullptr,cct.dbox,ncomp[imf]),
+                                                 cct.dbox, Dim3{0,0,0}});
+                            nbytes += dfab.nBytes(cct.dbox,ncomp[imf]);
+                        }
+                    }
+                }
+            }
+
+            std::size_t acd = ParallelDescriptor::alignof_comm_data(nbytes);
+            nbytes = amrex::aligned_size(acd, nbytes); // so that nbytes are aligned
+
+            // Also need to align the offset properly
+            TotalRcvsVolume = amrex::aligned_size(std::max(alignof(T),acd), TotalRcvsVolume);
+
+            offset.push_back(TotalRcvsVolume);
+            TotalRcvsVolume += nbytes;
+
+            recv_size.push_back(nbytes);
+        }
+
+        the_recv_data = static_cast<char*>(amrex::The_FA_Arena()->alloc(TotalRcvsVolume));
+
+        int k = 0;
+        for (int i = 0; i < nrecv; ++i) {
+            char* p = the_recv_data + offset[i];
+            const int rank = ParallelContext::global_to_local_rank(recv_from[i]);
+            recv_reqs[i] = ParallelDescriptor::Arecv
+                (p, recv_size[i], rank, SeqNum, comm).req();
+            for (int j = 0, nj = recv_offset[i].size(); j < nj; ++j) {
+                recv_tags[k++].sfab.p = (T const*)(p + recv_offset[i][j]);
+            }
+        }
+    }
+
+    char* the_send_data = nullptr;
+    Vector<int> send_rank;
+    Vector<char*> send_data;
+    Vector<std::size_t> send_size;
+    Vector<MPI_Request> send_reqs;
+    if (N_snds > 0) {
+        for (int imf = 0; imf < nmfs; ++imf) {
+            if (cmds[imf]) {
+                auto const& tags = *(cmds[imf]->m_SndTags);
+                for (auto const& kv : tags) {
+                    send_rank.push_back(kv.first);
+                }
+            }
+        }
+        amrex::RemoveDuplicates(send_rank);
+        const int nsend = send_rank.size();
+
+        send_data.resize(nsend, nullptr);
+        send_reqs.resize(nsend, MPI_REQUEST_NULL);
+
+        Vector<TagT> send_tags;
+        send_tags.reserve(N_snds);
+
+        Vector<Vector<std::size_t> > send_offset(nsend);
+        Vector<std::size_t> offset;
+        send_size.reserve(nsend);
+        offset.reserve(nsend);
+        std::size_t TotalSndsVolume = 0;
+        for (int i = 0; i < nsend; ++i) {
+            std::size_t nbytes = 0;
+            for (int imf = 0; imf < nmfs; ++imf) {
+                if (cmds[imf]) {
+                    auto const& tags = *(cmds[imf]->m_SndTags);
+                    auto it = tags.find(send_rank[i]);
+                    if (it != tags.end()) {
+                        for (auto const& cct : it->second) {
+                            auto const& sfab = (*mf[imf])[cct.srcIndex];
+                            send_offset[i].push_back(nbytes);
+                            send_tags.push_back({amrex::makeArray4<T>(nullptr,cct.sbox,ncomp[imf]),
+                                                 sfab.const_array(scomp[imf],ncomp[imf]),
+                                                 cct.sbox, Dim3{0,0,0}});
+                            nbytes += sfab.nBytes(cct.sbox,ncomp[imf]);
+                        }
+                    }
+                }
+            }
+
+            std::size_t acd = ParallelDescriptor::alignof_comm_data(nbytes);
+            nbytes = amrex::aligned_size(acd, nbytes); // so that bytes are aligned
+
+            // Also need to align the offset properly
+            TotalSndsVolume = amrex::aligned_size(std::max(alignof(T),acd), TotalSndsVolume);
+
+            offset.push_back(TotalSndsVolume);
+            TotalSndsVolume += nbytes;
+
+            send_size.push_back(nbytes);
+        }
+
+        the_send_data = static_cast<char*>(amrex::The_FA_Arena()->alloc(TotalSndsVolume));
+        int k = 0;
+        for (int i = 0; i < nsend; ++i) {
+            send_data[i] = the_send_data + offset[i];
+            for (int j = 0, nj = send_offset[i].size(); j < nj; ++j) {
+                send_tags[k++].dfab.p = (T*)(send_data[i] + send_offset[i][j]);
+            }
+        }
+
+        detail::fbv_copy(send_tags);
+
+        FabArray<FAB>::PostSnds(send_data, send_size, send_rank, send_reqs, SeqNum);
+    }
+
+#if !defined(AMREX_DEBUG)
+    int recv_flag;
+    ParallelDescriptor::Test(recv_reqs, recv_flag, recv_stat);
 #endif
+
+    if (N_locs > 0) {
+        detail::fbv_copy(local_tags);
+#if !defined(AMREX_DEBUG)
+        ParallelDescriptor::Test(recv_reqs, recv_flag, recv_stat);
+#endif
+    }
+
+    if (N_rcvs > 0) {
+        ParallelDescriptor::Waitall(recv_reqs, recv_stat);
+#ifdef AMREX_DEBUG
+        if (!FabArrayBase::CheckRcvStats(recv_stat, recv_size, SeqNum)) {
+            amrex::Abort("FillBoundary(vector) failed with wrong message size");
+        }
+#endif
+
+        detail::fbv_copy(recv_tags);
+
+        amrex::The_FA_Arena()->free(the_recv_data);
+    }
+
+    if (N_snds > 0) {
+        Vector<MPI_Status> stats(send_reqs.size());
+        ParallelDescriptor::Waitall(send_reqs, stats);
+        amrex::The_FA_Arena()->free(the_send_data);
+    }
+
+#endif  // #ifdef AMREX_USE_MPI
+#endif  // #if 1 #else
+}
+
+template <class MF>
+amrex::EnableIf_t<IsFabArray<MF>::value>
+FillBoundary (Vector<MF*> const& mf, const Periodicity& a_period = Periodicity::NonPeriodic())
+{
+    Vector<int> scomp(mf.size(), 0);
+    Vector<int> ncomp;
+    Vector<IntVect> nghost;
+    Vector<Periodicity> period(mf.size(), a_period);
+    ncomp.reserve(mf.size());
+    nghost.reserve(mf.size());
+    for (auto const& x : mf) {
+        ncomp.push_back(x->nComp());
+        nghost.push_back(x->nGrowVect());
+    }
+    FillBoundary(mf, scomp, ncomp, nghost, period);
 }

--- a/Src/Base/AMReX_MultiFab.H
+++ b/Src/Base/AMReX_MultiFab.H
@@ -694,9 +694,6 @@ inline void GccPlacaterMF ()
 }
 #endif
 
-//!  This is a special version of FillBoundary for warpx
-void FillBoundary (Vector<MultiFab*> const& mf, const Periodicity& period);
-
 }
 
 #endif /*BL_MULTIFAB_H*/

--- a/Src/Base/AMReX_MultiFab.cpp
+++ b/Src/Base/AMReX_MultiFab.cpp
@@ -1325,15 +1325,4 @@ MultiFab::OverrideSync (const iMultiFab& msk, const Periodicity& period)
     amrex::OverrideSync(*this, msk, period);
 }
 
-void
-FillBoundary (Vector<MultiFab*> const& mf, const Periodicity& period)
-{
-    for (auto x : mf) {
-        x->FillBoundary(period);
-    }
-// The following is actually slower on summit
-//    Vector<FabArray<FArrayBox>*> fa{mf.begin(),mf.end()};
-//    FillBoundary(fa,period);
-}
-
 }

--- a/Src/Base/AMReX_NonLocalBCImpl.H
+++ b/Src/Base/AMReX_NonLocalBCImpl.H
@@ -322,7 +322,6 @@ struct CommHandler
     Vector<std::size_t> recv_size;
     Vector<MPI_Request> recv_reqs;
     //
-    Vector<char*>       send_data;
     Vector<MPI_Request> send_reqs;
 #endif
 };
@@ -377,22 +376,23 @@ Comm_nowait (FabArray<FAB>& mf, int scomp, int ncomp, FabArrayBase::CommMetaData
     {
         Vector<std::size_t> send_size;
         Vector<int> send_rank;
+        Vector<char*> send_data;
         Vector<const FabArrayBase::CopyComTagsContainer*> send_cctc;
-        mf.PrepareSendBuffers(*cmd.m_SndTags, handler.the_send_data, handler.send_data,
+        mf.PrepareSendBuffers(*cmd.m_SndTags, handler.the_send_data, send_data,
                               send_size, send_rank, handler.send_reqs, send_cctc, ncomp);
 
 #ifdef AMREX_USE_GPU
         if (Gpu::inLaunchRegion()) {
-            FabArray<FAB>::pack_send_buffer_gpu(mf, scomp, ncomp, handler.send_data,
+            FabArray<FAB>::pack_send_buffer_gpu(mf, scomp, ncomp, send_data,
                                                 send_size, send_cctc);
         } else
 #endif
         {
-            FabArray<FAB>::pack_send_buffer_cpu(mf, scomp, ncomp, handler.send_data,
+            FabArray<FAB>::pack_send_buffer_cpu(mf, scomp, ncomp, send_data,
                                                 send_size, send_cctc);
         }
 
-        FabArray<FAB>::PostSnds(handler.send_data, send_size, send_rank, handler.send_reqs, SeqNum);
+        FabArray<FAB>::PostSnds(send_data, send_size, send_rank, handler.send_reqs, SeqNum);
     }
 
     if (N_locs > 0)
@@ -453,8 +453,8 @@ Comm_finish (FabArray<FAB>& mf, int scomp, int ncomp, FabArrayBase::CommMetaData
 
     const int N_snds = cmd.m_SndTags->size();
     if (N_snds > 0) {
-        Vector<MPI_Status> stats;
-        FabArrayBase::WaitForAsyncSends(N_snds, handler.send_reqs, handler.send_data, stats);
+        Vector<MPI_Status> stats(handler.send_reqs.size());
+        ParallelDescriptor::Waitall(handler.send_reqs, stats);
         amrex::The_FA_Arena()->free(handler.the_send_data);
     }
 }

--- a/Src/Base/AMReX_ParallelDescriptor.H
+++ b/Src/Base/AMReX_ParallelDescriptor.H
@@ -401,6 +401,7 @@ while ( false )
     Message Abarrier (const MPI_Comm &comm);
 
     void Test (MPI_Request& request, int& flag, MPI_Status& status);
+    void Test (Vector<MPI_Request>& request, int& flag, Vector<MPI_Status>& status);
 
     void Comm_dup (MPI_Comm comm, MPI_Comm& newcomm);
     //! Abort with specified error code.

--- a/Src/Base/AMReX_ParallelDescriptor.cpp
+++ b/Src/Base/AMReX_ParallelDescriptor.cpp
@@ -472,6 +472,12 @@ Test (MPI_Request& request, int& flag, MPI_Status& status)
 }
 
 void
+Test (Vector<MPI_Request>& request, int& flag, Vector<MPI_Status>& status)
+{
+    BL_MPI_REQUIRE( MPI_Testall(request.size(), request.data(), &flag, status.data()) );
+}
+
+void
 IProbe (int src_pid, int tag, int& flag, MPI_Status& status)
 {
     BL_PROFILE_S("ParallelDescriptor::Iprobe()");
@@ -1775,6 +1781,7 @@ Message Abarrier () { return Message(); }
 Message Abarrier (const MPI_Comm &/*comm*/) { return Message(); }
 
 void Test (MPI_Request&, int&, MPI_Status&) {}
+void Test (Vector<MPI_Request>&, int&, Vector<MPI_Status>&) {}
 void IProbe (int, int, int&, MPI_Status&) {}
 void IProbe (int, int, MPI_Comm, int&, MPI_Status&) {}
 


### PR DESCRIPTION
## Summary

Add a new FillBoundary function for a Vector of FabArrays.  There are two
implementations in this PR.  The one being used simply calls
`FillBoundary_nowait` and `FillBoundary_finish`.  The other version
aggregates the MPI messages from multiple FabArrays into one.  Tests on
summit shows the latter is slower.  But I don't want to lose the code, so it
is kept for future investigation.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
