### PR TITLE
Fix some warnings related to double-->float conversions

### DIFF
--- a/Src/AmrCore/AMReX_AmrMesh.H
+++ b/Src/AmrCore/AMReX_AmrMesh.H
@@ -25,7 +25,7 @@ struct AmrInfo {
     // Buffer cells around each tagged cell.
     Vector<IntVect> n_error_buf {{IntVect(1)}};
     // Grid efficiency.
-    Real grid_eff = 0.7;
+    Real grid_eff = static_cast<Real>(0.7);
     // Cells required for proper nesting.
     int n_proper = 1;
     int use_fixed_upto_level = 0;

--- a/Src/Base/AMReX_CoordSys.H
+++ b/Src/Base/AMReX_CoordSys.H
@@ -99,7 +99,7 @@ public:
     //! Returns location of cell center in specified direction.
     Real CellCenter (int point, int dir) const noexcept
     {
-        BL_ASSERT(ok); return offset[dir] + dx[dir]*(0.5+ (Real)point);
+        BL_ASSERT(ok); return offset[dir] + dx[dir]*((Real)0.5+ (Real)point);
     }
 
     //! Return location of cell center.

--- a/Src/Base/AMReX_FilCC_2D_C.H
+++ b/Src/Base/AMReX_FilCC_2D_C.H
@@ -52,17 +52,17 @@ filcc_cell (const IntVect& iv, Array4<Real> const& q,
                 // i == ilo-1
                 else if (ilo+2 <= ie)
                 {
-                    q(i,j,0,n) = 0.125*(15.*q(i+1,j,0,n) - 10.*q(i+2,j,0,n) + 3.*q(i+3,j,0,n));
+                    q(i,j,0,n) = Real(0.125)*(Real(15.)*q(i+1,j,0,n) - Real(10.)*q(i+2,j,0,n) + Real(3.)*q(i+3,j,0,n));
                 }
                 else
                 {
-                    q(i,j,0,n) = 0.5*(3.*q(i+1,j,0,n) - q(i+2,j,0,n));
+                    q(i,j,0,n) = Real(0.5)*(Real(3.)*q(i+1,j,0,n) - q(i+2,j,0,n));
                 }
                 break;
             }
             case (BCType::hoextrapcc):
             {
-                q(i,j,0,n) = 2.*q(i+1,j,0,n) - q(i+2,j,0,n);
+                q(i,j,0,n) = Real(2.)*q(i+1,j,0,n) - q(i+2,j,0,n);
                 break;
             }
             case (BCType::reflect_even):
@@ -94,17 +94,17 @@ filcc_cell (const IntVect& iv, Array4<Real> const& q,
                 // i == ihi+1
                 else if (ihi-2 >= is)
                 {
-                    q(i,j,0,n) = 0.125*(15.*q(i-1,j,0,n) - 10.*q(i-2,j,0,n) + 3.*q(i-3,j,0,n));
+                    q(i,j,0,n) = Real(0.125)*(Real(15.)*q(i-1,j,0,n) - Real(10.)*q(i-2,j,0,n) + Real(3.)*q(i-3,j,0,n));
                 }
                 else
                 {
-                    q(i,j,0,n) = 0.5*(3.*q(i-1,j,0,n) - q(i-2,j,0,n));
+                    q(i,j,0,n) = Real(0.5)*(Real(3.)*q(i-1,j,0,n) - q(i-2,j,0,n));
                 }
                 break;
             }
             case (BCType::hoextrapcc):
             {
-                q(i,j,0,n) = 2.*q(i-1,j,0,n) - q(i-2,j,0,n);
+                q(i,j,0,n) = Real(2.)*q(i-1,j,0,n) - q(i-2,j,0,n);
                 break;
             }
             case (BCType::reflect_even):
@@ -137,17 +137,17 @@ filcc_cell (const IntVect& iv, Array4<Real> const& q,
                 // j == jlo-1
                 else if (jlo+2 <= je)
                 {
-                    q(i,j,0,n) = 0.125*(15.*q(i,j+1,0,n) - 10.*q(i,j+2,0,n) + 3.*q(i,j+3,0,n));
+                    q(i,j,0,n) = Real(0.125)*(Real(15.)*q(i,j+1,0,n) - Real(10.)*q(i,j+2,0,n) + Real(3.)*q(i,j+3,0,n));
                 }
                 else
                 {
-                    q(i,j,0,n) = 0.5*(3.*q(i,j+1,0,n) - q(i,j+2,0,n));
+                    q(i,j,0,n) = Real(0.5)*(Real(3.)*q(i,j+1,0,n) - q(i,j+2,0,n));
                 }
                 break;
             }
             case (BCType::hoextrapcc):
             {
-                q(i,j,0,n) = 2.*q(i,j+1,0,n) - q(i,j+2,0,n);
+                q(i,j,0,n) = Real(2.)*q(i,j+1,0,n) - q(i,j+2,0,n);
                 break;
             }
             case (BCType::reflect_even):
@@ -162,7 +162,7 @@ filcc_cell (const IntVect& iv, Array4<Real> const& q,
             }
             }
         }
-        else if (j > jhi) 
+        else if (j > jhi)
         {
             switch (bc.hi(1)) {
             case (BCType::foextrap):
@@ -179,17 +179,17 @@ filcc_cell (const IntVect& iv, Array4<Real> const& q,
                 // j == jhi+1
                 else if (jhi-2 >= js)
                 {
-                    q(i,j,0,n) = 0.125*(15.*q(i,j-1,0,n) - 10.*q(i,j-2,0,n) + 3.*q(i,j-3,0,n));
+                    q(i,j,0,n) = Real(0.125)*(Real(15.)*q(i,j-1,0,n) - Real(10.)*q(i,j-2,0,n) + Real(3.)*q(i,j-3,0,n));
                 }
                 else
                 {
-                    q(i,j,0,n) = 0.5*(3.*q(i,j-1,0,n) - q(i,j-2,0,n));
+                    q(i,j,0,n) = Real(0.5)*(Real(3.)*q(i,j-1,0,n) - q(i,j-2,0,n));
                 }
                 break;
             }
             case (BCType::hoextrapcc):
             {
-                q(i,j,0,n) = 2.*q(i,j-1,0,n) - q(i,j-2,0,n);
+                q(i,j,0,n) = Real(2.)*q(i,j-1,0,n) - q(i,j-2,0,n);
                 break;
             }
             case (BCType::reflect_even):

--- a/Src/Base/AMReX_Geometry.H
+++ b/Src/Base/AMReX_Geometry.H
@@ -256,7 +256,7 @@ public:
         domain.coarsen(rr);
         for (int i = 0; i < AMREX_SPACEDIM; ++i) {
             dx[i] = (ProbHi(i) - ProbLo(i)) / domain.length(i);
-            inv_dx[i] = 1./dx[i];
+            inv_dx[i] = static_cast<Real>(1.)/dx[i];
         }
     }
 
@@ -264,7 +264,7 @@ public:
         domain.refine(rr);
         for (int i = 0; i < AMREX_SPACEDIM; ++i) {
             dx[i] = (ProbHi(i) - ProbLo(i)) / domain.length(i);
-            inv_dx[i] = 1./dx[i];
+            inv_dx[i] = static_cast<Real>(1.)/dx[i];
         }
     }
 

--- a/Src/Base/AMReX_MultiFabUtil_2D_C.H
+++ b/Src/Base/AMReX_MultiFabUtil_2D_C.H
@@ -22,7 +22,7 @@ void amrex_avg_nd_to_cc (Box const& bx,
         for (int j = lo.y; j <= hi.y; ++j) {
         AMREX_PRAGMA_SIMD
         for (int i = lo.x; i <= hi.x; ++i) {
-            cc(i,j,0,n+cccomp) = 0.25*( nd(i,j  ,0,n+ndcomp) + nd(i+1,j  ,0,n+ndcomp)
+            cc(i,j,0,n+cccomp) = Real(0.25)*( nd(i,j  ,0,n+ndcomp) + nd(i+1,j  ,0,n+ndcomp)
                                       + nd(i,j+1,0,n+ndcomp) + nd(i+1,j+1,0,n+ndcomp));
         }}
     }
@@ -42,8 +42,8 @@ void amrex_avg_eg_to_cc (Box const& bx,
     for (int j = lo.y; j <= hi.y; ++j) {
     AMREX_PRAGMA_SIMD
     for (int i = lo.x; i <= hi.x; ++i) {
-        cc(i,j,0,0+cccomp) = 0.5 * ( Ex(i,j,0) + Ex(i,j+1,0) );
-        cc(i,j,0,1+cccomp) = 0.5 * ( Ey(i,j,0) + Ey(i+1,j,0) );
+        cc(i,j,0,0+cccomp) = Real(0.5) * ( Ex(i,j,0) + Ex(i,j+1,0) );
+        cc(i,j,0,1+cccomp) = Real(0.5) * ( Ey(i,j,0) + Ey(i+1,j,0) );
     }}
 }
 
@@ -61,8 +61,8 @@ void amrex_avg_fc_to_cc (Box const& bx,
     for (int j = lo.y; j <= hi.y; ++j) {
     AMREX_PRAGMA_SIMD
     for (int i = lo.x; i <= hi.x; ++i) {
-        cc(i,j,0,0+cccomp) = 0.5 * ( fx(i,j,0) + fx(i+1,j,0) );
-        cc(i,j,0,1+cccomp) = 0.5 * ( fy(i,j,0) + fy(i,j+1,0) );
+        cc(i,j,0,0+cccomp) = Real(0.5) * ( fx(i,j,0) + fx(i+1,j,0) );
+        cc(i,j,0,1+cccomp) = Real(0.5) * ( fy(i,j,0) + fy(i,j+1,0) );
     }}
 }
 
@@ -82,14 +82,14 @@ void amrex_avg_cc_to_fc (Box const& ndbx, Box const& xbx, Box const& ybx,
     for     (int j = xlo.y; j <= xhi.y; ++j) {
         AMREX_PRAGMA_SIMD
         for (int i = xlo.x; i <= xhi.x; ++i) {
-            fx(i,j,0) = 0.5*(cc(i-1,j,0) + cc(i,j,0));
+            fx(i,j,0) = Real(0.5)*(cc(i-1,j,0) + cc(i,j,0));
         }
     }
 
     for     (int j = ylo.y; j <= yhi.y; ++j) {
         AMREX_PRAGMA_SIMD
         for (int i = ylo.x; i <= yhi.x; ++i) {
-            fy(i,j,0) = 0.5*(cc(i,j-1,0) + cc(i,j,0));
+            fy(i,j,0) = Real(0.5)*(cc(i,j-1,0) + cc(i,j,0));
         }
     }
 }
@@ -109,7 +109,7 @@ void amrex_avgdown_faces (Box const& bx, Array4<Real> const& crse,
     switch (idir) {
     case 0:
     {
-        Real facInv = 1.0 / facy;
+        Real facInv =  Real(1.0) / facy;
         for (int n = 0; n < ncomp; ++n) {
             for (int j = clo.y; j <= chi.y; ++j) {
             for (int i = clo.x; i <= chi.x; ++i) {
@@ -126,7 +126,7 @@ void amrex_avgdown_faces (Box const& bx, Array4<Real> const& crse,
     }
     case 1:
     {
-        Real facInv = 1.0 / facx;
+        Real facInv = Real(1.0) / facx;
         for (int n = 0; n < ncomp; ++n) {
             for (int j = clo.y; j <= chi.y; ++j) {
             for (int i = clo.x; i <= chi.x; ++i) {
@@ -159,7 +159,7 @@ void amrex_avgdown_edges (Box const& bx, Array4<Real> const& crse,
     switch (idir) {
     case 0:
     {
-        Real facInv = 1.0 / facx;
+        Real facInv = Real(1.0) / facx;
         for (int n = 0; n < ncomp; ++n) {
             for (int j = clo.y; j <= chi.y; ++j) {
             for (int i = clo.x; i <= chi.x; ++i) {
@@ -176,7 +176,7 @@ void amrex_avgdown_edges (Box const& bx, Array4<Real> const& crse,
     }
     case 1:
     {
-        Real facInv = 1.0 / facy;
+        Real facInv = Real(1.0) / facy;
         for (int n = 0; n < ncomp; ++n) {
             for (int j = clo.y; j <= chi.y; ++j) {
             for (int i = clo.x; i <= chi.x; ++i) {
@@ -205,7 +205,7 @@ void amrex_avgdown (Box const& bx, Array4<Real> const& crse,
     const auto chi = ubound(bx);
     const int facx = ratio[0];
     const int facy = ratio[1];
-    const Real volfrac = 1.0/static_cast<Real>(facx*facy);
+    const Real volfrac = static_cast<Real>(1.0)/static_cast<Real>(facx*facy);
 
     for (int n = 0; n < ncomp; ++n) {
         for (int j = clo.y; j <= chi.y; ++j) {
@@ -338,9 +338,9 @@ void amrex_compute_convective_difference (Box const& bx, Array4<amrex::Real> con
         for     (int j = lo.y; j <= hi.y; ++j) {
             AMREX_PRAGMA_SIMD
                 for (int i = lo.x; i <= hi.x; ++i) {
-                    diff(i,j,n) = 0.5*dxi * (u_face(i+1,j,0,0)+u_face(i,j,0,0)) * 
+                    diff(i,j,n) = Real(0.5)*dxi * (u_face(i+1,j,0,0)+u_face(i,j,0,0)) *
                                             (s_on_x_face(i+1,j,0,n)-s_on_x_face(i,j,0,n))
-                        +         0.5*dyi * (v_face(i,j+1,0,0)+v_face(i,j,0,0)) * 
+                        +         Real(0.5)*dyi * (v_face(i,j+1,0,0)+v_face(i,j,0,0)) *
                                             (s_on_y_face(i,j+1,0,n)-s_on_y_face(i,j,0,n));
                 }
         }

--- a/Src/Base/AMReX_MultiFabUtil_nd_C.H
+++ b/Src/Base/AMReX_MultiFabUtil_nd_C.H
@@ -60,7 +60,7 @@ void amrex_fill_slice_interp (Box const& bx, Array4<Real> slice,
             for     (int j = lo.y; j <= hi.y; ++j) {
                 AMREX_PRAGMA_SIMD
                 for (int i = lo.x; i <= hi.x; ++i) {
-                    slice(i,j,k,ns) = (1.0-weight)*full(i+ilo,j+jlo,k+klo,nf)
+                    slice(i,j,k,ns) = (Real(1.0)-weight)*full(i+ilo,j+jlo,k+klo,nf)
                         +                  weight *full(i+ihi,j+jhi,k+khi,nf);
                 }
             }


### PR DESCRIPTION
## Summary
I tried to compile  `WarpX` in single precision and I noticed several warnings related to casts from `double` to `float` in `AMReX`.
This PR should fix some of these warnings. I plan to continue in the next days with other PRs, if you agree.

I don't know if you have a strong preference between C-style `Real(1.0)` and the C++-style `static_cast<Real>(1.0)`

## Additional background

I compiled `WarpX` with `make DIM=2 QED=TRUE PRECISION=FLOAT USE_SINGLE_PRECISION_PARTICLES=TRUE`
using the compiler `g++ (Ubuntu 10.2.0-13ubuntu1) 10.2.0` 

## Checklist

The proposed changes:
- [X] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
