### PR TITLE
Arena: Add accessor to query Arena attributes through info object

### DIFF
--- a/Src/Base/AMReX_Arena.H
+++ b/Src/Base/AMReX_Arena.H
@@ -105,7 +105,7 @@ public:
     /**
      *  \brief Return the ArenaInfo object for querying
      */
-    const ArenaInfo& the_arena_info() const { return arena_info; }
+    const ArenaInfo& arenaInfo () const { return arena_info; }
 
 protected:
 

--- a/Src/Base/AMReX_Arena.H
+++ b/Src/Base/AMReX_Arena.H
@@ -102,6 +102,11 @@ public:
 
     static const std::size_t align_size = 16;
 
+    /**
+     *  \brief Return the ArenaInfo object for querying
+     */
+    const ArenaInfo& the_arena_info() const { return arena_info; }
+
 protected:
 
     ArenaInfo arena_info;


### PR DESCRIPTION
## Summary

This PR adds an accessor to the `Arena` class that can be used to query the attributes of the Arena (e.g., `device_use_managed_memory` flag) from the application codes.

## Additional background

Currently, there is no easy way to determine if `amrex::The_Arena()` is using managed memory. Applications would have to use a combination of `AMREX_USE_HIP` compile-time definition and `amrex.the_arena_is_managed` ParmParse variable to determine this. Testing individual pointers with `amrex::Gpu::isManaged()` is possible only on CUDA/HIP but not DPC++. Also it is costly compared to just querying the `Arena` object. Allowing read-only access to `ArenaInfo` object will allow a wide variety of checks in application code. 

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [X] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
