### PR TITLE
Tools/Plotfile: Fix build errors in single precision mode

### DIFF
--- a/Tools/Plotfile/fcompare.cpp
+++ b/Tools/Plotfile/fcompare.cpp
@@ -287,10 +287,14 @@ int main_main()
             } else {
                 Real aerr = 0., rerr = 0.;
                 if (aerror[icomp_a] > 0.) {
-                    aerr = std::min(std::max(aerror[icomp_a], 1.e-99), 1.e98);
+                    aerr = std::min(
+                        std::max(aerror[icomp_a], std::numeric_limits<Real>::min()),
+                        std::numeric_limits<Real>::max());
                 }
                 if (rerror[icomp_a] > 0.) {
-                    rerr = std::min(std::max(rerror[icomp_a], 1.e-99), 1.e98);
+                    rerr = std::min(
+                        std::max(rerror[icomp_a], std::numeric_limits<Real>::min()),
+                        std::numeric_limits<Real>::max());
                 }
                 amrex::Print() << " " << std::setw(24) << std::left << names_a[icomp_a]
                                << std::right

--- a/Tools/Plotfile/fextract.cpp
+++ b/Tools/Plotfile/fextract.cpp
@@ -192,9 +192,9 @@ void main_main()
                                     if (m(i,j,k) == 0) { // not covered by fine
                                         if (pos.size() == data[ivar].size()) {
                                             Array<Real,AMREX_SPACEDIM> p
-                                                = {AMREX_D_DECL(problo[0]+(i+0.5)*dx[0],
-                                                                problo[1]+(j+0.5)*dx[1],
-                                                                problo[2]+(k+0.5)*dx[2])};
+                                                = {AMREX_D_DECL(problo[0]+static_cast<Real>(i+0.5)*dx[0],
+                                                                problo[1]+static_cast<Real>(j+0.5)*dx[1],
+                                                                problo[2]+static_cast<Real>(k+0.5)*dx[2])};
                                             pos.push_back(p[idir]);
                                         }
                                         data[ivar].push_back(fab(i,j,k));
@@ -220,9 +220,9 @@ void main_main()
                                 for (int i = lo.x; i <= hi.x; ++i) {
                                     if (pos.size() == data[ivar].size()) {
                                         Array<Real,AMREX_SPACEDIM> p
-                                            = {AMREX_D_DECL(problo[0]+(i+0.5)*dx[0],
-                                                            problo[1]+(j+0.5)*dx[1],
-                                                            problo[2]+(k+0.5)*dx[2])};
+                                            = {AMREX_D_DECL(problo[0]+static_cast<Real>(i+0.5)*dx[0],
+                                                            problo[1]+static_cast<Real>(j+0.5)*dx[1],
+                                                            problo[2]+static_cast<Real>(k+0.5)*dx[2])};
                                         pos.push_back(p[idir]);
                                     }
                                     data[ivar].push_back(fab(i,j,k));


### PR DESCRIPTION
## Summary

This PR fixes one build error and one warning observed when compiling `Tools/Plotfile` utilities with `-DAMREX_USE_FLOAT` 

## Additional background

```
/opt/hpe/hpc/mpt/mpt-2.22/bin/mpicxx  -DAMREX_GIT_VERSION=\"20.11-43-gb329cfe0bc40\" -DAMREX_Linux -DAMREX_PARTICLES -DAMREX_SINGLE_PRECISION_PARTICLES -DAMREX_SPACEDIM=3 -DAMREX_USE_FLOAT -DAMREX_USE_MPI -DBL_Linux -DBL_NO_FORT -DBL_SPACEDIM=3 -DBL_USE_FLOAT -DBL_USE_MPI -I../submods/amrex/Src/Base -I../submods/amrex/Src/Boundary -I../submods/amrex/Src/AmrCore -I../submods/amrex/Src/Amr -I../submods/amrex/Src/LinearSolvers/MLMG -I../submods/amrex/Src/LinearSolvers/Projections -I../submods/amrex/Src/Particle -march=skylake -mtune=skylake -O3 -DNDEBUG   -std=c++14 -MD -MT submods/amrex/Tools/Plotfile/CMakeFiles/fcompare.dir/fcompare.cpp.o -MF submods/amrex/Tools/Plotfile/CMakeFiles/fcompare.dir/fcompare.cpp.o.d -o submods/amrex/Tools/Plotfile/CMakeFiles/fcompare.dir/fcompare.cpp.o -c ../submods/amrex/Tools/Plotfile/fcompare.cpp
../submods/amrex/Tools/Plotfile/fcompare.cpp: In function 'int main_main()':
../submods/amrex/Tools/Plotfile/fcompare.cpp:290:69: error: no matching function for call to 'max(float&, double)'
                     aerr = std::min(std::max(aerror[icomp_a], 1.e-99), 1.e98);
                                                                     ^
```

```
[7/9] Building CXX object submods/amrex/Tools/Plotfile/CMakeFiles/fextract.dir/fextract.cpp.o
In file included from ../submods/amrex/Src/Base/AMReX_Array.H:16,
                 from ../submods/amrex/Src/Base/AMReX_Vector.H:10,
                 from ../submods/amrex/Src/Base/AMReX_ParallelContext.H:7,
                 from ../submods/amrex/Src/Base/AMReX_Print.H:10,
                 from ../submods/amrex/Tools/Plotfile/fextract.cpp:2:
../submods/amrex/Tools/Plotfile/fextract.cpp: In function 'void main_main()':
../submods/amrex/Tools/Plotfile/fextract.cpp:195:74: warning: narrowing conversion of '(((double)problo.std::array<float, 3>::operator[](0)) + (((double)i + 5.0e-1) * ((double)dx.std::array<float, 3>::operator[](0))))' from 'double' to 'float' inside { } [-Wnarrowing]
                                                 = {AMREX_D_DECL(problo[0]+(i+0.5)*dx[0],
../submods/amrex/Src/Base/AMReX_SPACE.H:150:31: note: in definition of macro 'AMREX_D_DECL'
 #  define AMREX_D_DECL(a,b,c) a,b,c
                               ^
```

## Checklist

The proposed changes:
- [X] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
