### PR TITLE
Fix warnings for DPCPP

### DIFF
--- a/Src/Base/AMReX_FBI.H
+++ b/Src/Base/AMReX_FBI.H
@@ -215,7 +215,7 @@ fab_to_fab (Vector<Array4CopyTag<T> > const& copy_tags, int scomp, int dcomp, in
     detail::ParallelFor_doit(copy_tags,
         [=] AMREX_GPU_DEVICE (
 #ifdef AMREX_USE_DPCPP
-            sycl::nd_item<1> const& item,
+            sycl::nd_item<1> const& /*item*/,
 #endif
             int icell, int ncells, int i, int j, int k, Array4CopyTag<T> const tag) noexcept
         {

--- a/Tools/GNUMake/Make.defs
+++ b/Tools/GNUMake/Make.defs
@@ -969,7 +969,7 @@ ifeq ($(USE_DPCPP),TRUE)
         FC  = mpiifx
         F90 = mpiifx
         # current version of mpiicpx does not have this on by default
-        CXXFLAGS += -fsycl-unnamed-lambda
+        EXTRACXXFLAGS += -fsycl-unnamed-lambda
     endif
 
 else ifeq ($(USE_HIP),TRUE)

--- a/Tools/GNUMake/Make.rules
+++ b/Tools/GNUMake/Make.rules
@@ -25,6 +25,7 @@ ifndef LINKFLAGS
 ifeq ($(LINK_WITH_FORTRAN_COMPILER),TRUE)
   LINKFLAGS = $(F90FLAGS) $(FMODULES)
 else
+  # $(EXTRACXXFLAGS) does not go into LINKFLAGS
   LINKFLAGS = $(CXXFLAGS)
 endif
 endif

--- a/Tutorials/GPU/CNS/Source/CNS.H
+++ b/Tutorials/GPU/CNS/Source/CNS.H
@@ -106,7 +106,7 @@ public:
     // Cleanup data descriptors at end of run.
     static void variableCleanUp ();
 
-    static int numGrow() { return NUM_GROW; };
+    static int numGrow() { return NUM_GROW; }
 
 #if !defined(AMREX_USE_CUDA)
 protected:


### PR DESCRIPTION
Fix unused variable.  Do not pass `-fsycl-unnamed-lambda` to `mpiicpx` for linking to get rid of warning on unknown argument.
