### PR TITLE
eval_genex correctly replaces the matching compiler version

### DIFF
--- a/Tools/CMake/AMReXGenexHelpers.cmake
+++ b/Tools/CMake/AMReXGenexHelpers.cmake
@@ -246,7 +246,7 @@ function ( eval_genex _list _lang _comp )
 
       # Genex in the form $<*_COMPILER_VERSION>
       if (ARG_COMP_VERSION)
-         string(REGEX REPLACE "\\$<${_lang}_COMPILER_VERSION>" "${ARG_COMP_VERSION}>" "1"  _in "${_in}")
+         string(REGEX REPLACE "\\$<${_lang}_COMPILER_VERSION>" "${ARG_COMP_VERSION}"  _in "${_in}")
       endif ()
       string(REGEX REPLACE "\\$<[A-Za-z]*_COMPILER_VERSION>" "0"  _in "${_in}")
 


### PR DESCRIPTION

## Summary

Previously it would place the resulting output in the variable
`1` instead of `_in`. Additionally it would try to add an extra `>`.

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
