### PR TITLE
Fix InitNRandomPerCell for single precision particles

### DIFF
--- a/Src/Particle/AMReX_ParticleInit.H
+++ b/Src/Particle/AMReX_ParticleInit.H
@@ -1442,7 +1442,7 @@ InitNRandomPerCell (int n_per_cell, const ParticleInitData& pdata)
                         r = amrex::Random();
                         p.pos(i) = grid_box.lo(i) + (r + cell[i]-beg[i])*dx[i];
                         if (p.pos(i) < grid_box.hi(i)) break;
-                        iter++
+                        iter++;
                     }
                     AMREX_ASSERT(p.pos(i) < grid_box.hi(i));
                 }

--- a/Src/Particle/AMReX_ParticleInit.H
+++ b/Src/Particle/AMReX_ParticleInit.H
@@ -1436,8 +1436,14 @@ InitNRandomPerCell (int n_per_cell, const ParticleInitData& pdata)
             {
                 // the real struct data
                 for (int i = 0; i < AMREX_SPACEDIM; i++) {
-                    r = amrex::Random();
-                    p.pos(i) = grid_box.lo(i) + (r + cell[i]-beg[i])*dx[i];
+                    constexpr int max_iter = 10;
+                    int iter = 0;
+                    while (iter < max_iter) {
+                        r = amrex::Random();
+                        p.pos(i) = grid_box.lo(i) + (r + cell[i]-beg[i])*dx[i];
+                        if (p.pos(i) < grid_box.hi(i)) break;
+                        iter++
+                    }
                     AMREX_ASSERT(p.pos(i) < grid_box.hi(i));
                 }
 


### PR DESCRIPTION
Occasionally on very big problems, this assertion will fail due to roundoff errors when single precision particles are used. This draws another random number if that happens. 

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
