### PR TITLE
CI: Windows + CUDA

### DIFF
--- a/.github/workflows/dependencies/windows_install_cuda.ps1
+++ b/.github/workflows/dependencies/windows_install_cuda.ps1
@@ -36,7 +36,6 @@ $CudaFeatures = " nvcc_${cuda_version_short} " + `
 " cuxxfilt_${cuda_version_short} " + `
 " npp_${cuda_version_short} " + `
 " npp_dev_${cuda_version_short} " + `
-" nsight_vse_${cuda_version_short} " + `
 " nvdisasm_${cuda_version_short} " + `
 " nvjitlink_${cuda_version_short} " + `
 " nvjpeg_${cuda_version_short} " + `

--- a/.github/workflows/dependencies/windows_install_cuda.ps1
+++ b/.github/workflows/dependencies/windows_install_cuda.ps1
@@ -15,7 +15,8 @@ $cuda_version_short = '12.4'
 # download
 New-item -ItemType directory -Name cuda
 Set-Location -Path cuda -PassThru
-Invoke-WebRequest -Uri "https://developer.download.nvidia.com/compute/cuda/${cuda_version_long}/network_installers/cuda_${cuda_version_long}_windows_network.exe" -OutFile "cuda_install.exe"
+# Invoke-WebRequest -Uri "https://developer.download.nvidia.com/compute/cuda/${cuda_version_long}/network_installers/cuda_${cuda_version_long}_windows_network.exe" -OutFile "cuda_install.exe"
+Invoke-WebRequest -Uri "https://developer.download.nvidia.com/compute/cuda/${cuda_version_long}/local_installers/cuda_${cuda_version_long}_551.61_windows.exe" -OutFile "cuda_install.exe"
 
 # install
 $CudaFeatures = " nvcc_${cuda_version_short} " + `
@@ -49,8 +50,9 @@ $CudaFeatures = " nvcc_${cuda_version_short} " + `
 " sanitizer_${cuda_version_short} " + `
 " thrust_${cuda_version_short} "
 
-$SilentFlag = '-s '
-Start-Process -FilePath '.\cuda_install.exe' -ArgumentList @($SilentFlag + $CudaFeatures) -Wait -NoNewWindow
+#$SilentFlag = '-s '
+#Start-Process -FilePath '.\cuda_install.exe' -ArgumentList @($SilentFlag + $CudaFeatures) -Wait -NoNewWindow
+Start-Process -FilePath '.\cuda_install.exe' -ArgumentList "-s" -Wait -NoNewWindow
 
 # cleanup
 Remove-Item cuda_install.exe

--- a/.github/workflows/dependencies/windows_install_cuda.ps1
+++ b/.github/workflows/dependencies/windows_install_cuda.ps1
@@ -15,7 +15,7 @@ $cuda_version_short = '12.4'
 # download
 New-item -ItemType directory -Name cuda
 Set-Location -Path cuda -PassThru
-Invoke-WebRequest -Uri 'https://developer.download.nvidia.com/compute/cuda/${cuda_version_long}/network_installers/cuda_${cuda_version_long}_windows_network.exe' -OutFile 'cuda_install.exe'
+Invoke-WebRequest -Uri "https://developer.download.nvidia.com/compute/cuda/${cuda_version_long}/network_installers/cuda_${cuda_version_long}_windows_network.exe" -OutFile "cuda_install.exe"
 
 # install
 $CudaFeatures = " nvcc_${cuda_version_short} " + `

--- a/.github/workflows/dependencies/windows_install_cuda.ps1
+++ b/.github/workflows/dependencies/windows_install_cuda.ps1
@@ -15,8 +15,7 @@ $cuda_version_short = '12.4'
 # download
 New-item -ItemType directory -Name cuda
 Set-Location -Path cuda -PassThru
-# Invoke-WebRequest -Uri "https://developer.download.nvidia.com/compute/cuda/${cuda_version_long}/network_installers/cuda_${cuda_version_long}_windows_network.exe" -OutFile "cuda_install.exe"
-Invoke-WebRequest -Uri "https://developer.download.nvidia.com/compute/cuda/${cuda_version_long}/local_installers/cuda_${cuda_version_long}_551.61_windows.exe" -OutFile "cuda_install.exe"
+Invoke-WebRequest -Uri "https://developer.download.nvidia.com/compute/cuda/${cuda_version_long}/network_installers/cuda_${cuda_version_long}_windows_network.exe" -OutFile "cuda_install.exe"
 
 # install
 $CudaFeatures = " nvcc_${cuda_version_short} " + `
@@ -50,9 +49,8 @@ $CudaFeatures = " nvcc_${cuda_version_short} " + `
 " sanitizer_${cuda_version_short} " + `
 " thrust_${cuda_version_short} "
 
-#$SilentFlag = '-s '
-#Start-Process -FilePath '.\cuda_install.exe' -ArgumentList @($SilentFlag + $CudaFeatures) -Wait -NoNewWindow
-Start-Process -FilePath '.\cuda_install.exe' -ArgumentList "-s" -Wait -NoNewWindow
+$SilentFlag = '-s '
+Start-Process -FilePath '.\cuda_install.exe' -ArgumentList @($SilentFlag + $CudaFeatures) -Wait -NoNewWindow
 
 # cleanup
 Remove-Item cuda_install.exe

--- a/.github/workflows/dependencies/windows_install_cuda.ps1
+++ b/.github/workflows/dependencies/windows_install_cuda.ps1
@@ -5,6 +5,9 @@
 # License: BSD-3-Clause-LBNL
 # Authors: Axel Huebl
 
+# fail on first error
+$ErrorActionPreference = "Stop"
+
 # skip if already installed
 if (Test-Path "C:\Program Files\NVIDIA GPU Computing Toolkit\") { exit }
 
@@ -47,17 +50,14 @@ $CudaFeatures = " nvcc_${cuda_version_short} " + `
 " nvrtc_dev_${cuda_version_short} " + `
 " nvtx_${cuda_version_short} " + `
 " sanitizer_${cuda_version_short} " + `
-" thrust_${cuda_version_short} "
+" thrust_${cuda_version_short} " + `
+" visual_studio_integration_${cuda_version_short} "
 
 $SilentFlag = '-s '
 Start-Process -FilePath '.\cuda_install.exe' -ArgumentList @($SilentFlag + $CudaFeatures) -Wait -NoNewWindow
 
 # cleanup
 Remove-Item cuda_install.exe
-
-# VisualStudio integration
-Copy-item -Force -Recurse -Verbose "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v${cuda_version_short}\extras\visual_studio_integration\MSBuildExtensions" -Destination "C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\MSBuild\Microsoft\VC\v170\BuildCustomizations"
-Copy-item -Force -Recurse -Verbose "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v${cuda_version_short}\extras\visual_studio_integration\MSBuildExtensions" -Destination "C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Microsoft\VC\v170\BuildCustomizations"
 
 # GitHub actions env updates
 if (Test-Path "env:GITHUB_ACTIONS") {

--- a/.github/workflows/dependencies/windows_install_cuda.ps1
+++ b/.github/workflows/dependencies/windows_install_cuda.ps1
@@ -1,0 +1,57 @@
+#!/usr/bin/env pwsh
+#
+# Copyright 2024 The AMReX Community
+#
+# License: BSD-3-Clause-LBNL
+# Authors: Axel Huebl
+
+# skip if already installed
+if (Test-Path "C:\Program Files\NVIDIA GPU Computing Toolkit\") { exit }
+
+# configure
+$cuda_version_long = '12.4.0'
+$cuda_version_short = '12.4'
+
+# download
+New-item -ItemType directory -Name cuda
+Set-Location -Path cuda -PassThru
+Invoke-WebRequest -Uri 'https://developer.download.nvidia.com/compute/cuda/${cuda_version_long}/network_installers/cuda_${cuda_version_long}_windows_network.exe' -OutFile 'cuda_install.exe'
+
+# install
+$CudaFeatures = " nvcc_${cuda_version_short} " + `
+" cublas_${cuda_version_short} " + `
+" cublas_dev_${cuda_version_short} " + `
+" cuda_profiler_api_${cuda_version_short} " + `
+" cudart_${cuda_version_short} " + `
+" cufft_${cuda_version_short} " + `
+" cufft_dev_${cuda_version_short} " + `
+" cuobjdump_${cuda_version_short} " + `
+" cupti_${cuda_version_short} " + `
+" curand_${cuda_version_short} " + `
+" curand_dev_${cuda_version_short} " + `
+" cusolver_${cuda_version_short} " + `
+" cusolver_dev_${cuda_version_short} " + `
+" cusparse_${cuda_version_short} " + `
+" cusparse_dev_${cuda_version_short} " + `
+" cuxxfilt_${cuda_version_short} " + `
+" npp_${cuda_version_short} " + `
+" npp_dev_${cuda_version_short} " + `
+" nsight_vse_${cuda_version_short} " + `
+" nvdisasm_${cuda_version_short} " + `
+" nvjitlink_${cuda_version_short} " + `
+" nvjpeg_${cuda_version_short} " + `
+" nvjpeg_dev_${cuda_version_short} " + `
+" nvml_dev_${cuda_version_short} " + `
+" nvprof_${cuda_version_short} " + `
+" nvprune_${cuda_version_short} " + `
+" nvrtc_${cuda_version_short} " + `
+" nvrtc_dev_${cuda_version_short} " + `
+" nvtx_${cuda_version_short} " + `
+" sanitizer_${cuda_version_short} " + `
+" thrust_${cuda_version_short} "
+
+$SilentFlag = '-s '
+Start-Process -FilePath '.\cuda_install.exe' -ArgumentList @($SilentFlag + $CudaFeatures) -Wait -NoNewWindow
+
+# cleanup
+Remove-Item cuda_install.exe

--- a/.github/workflows/dependencies/windows_install_cuda.ps1
+++ b/.github/workflows/dependencies/windows_install_cuda.ps1
@@ -54,3 +54,15 @@ Start-Process -FilePath '.\cuda_install.exe' -ArgumentList @($SilentFlag + $Cuda
 
 # cleanup
 Remove-Item cuda_install.exe
+
+# VisualStudio integration
+Copy-item -Force -Recurse -Verbose "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v${cuda_version_short}\extras\visual_studio_integration\MSBuildExtensions" -Destination "C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\MSBuild\Microsoft\VC\v170\BuildCustomizations"
+Copy-item -Force -Recurse -Verbose "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v${cuda_version_short}\extras\visual_studio_integration\MSBuildExtensions" -Destination "C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Microsoft\VC\v170\BuildCustomizations"
+
+# GitHub actions env updates
+if (Test-Path "env:GITHUB_ACTIONS") {
+    echo "Adding CUDA to CUDA_PATH and PATH"
+    $env:CUDA_PATH = "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v${cuda_version_short}"
+    echo "CUDA_PATH=$env:CUDA_PATH" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+    echo "$env:CUDA_PATH/bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -159,6 +159,8 @@ jobs:
         SET "CMAKE_PREFIX_PATH=%CUDA_PATH%;%CMAKE_PREFIX_PATH%"
         SET "PATH=%CUDA_PATH%\bin\;%PATH%"
         SET "PATH=%CUDA_PATH%\libnvvp\;%PATH%"
+        SET "CUDACXX=%CUDA_PATH%\bin\nvcc.exe"
+
         cmake -S . -B build ^
               -A x64        ^
               -DCUDAToolkit_ROOT="%CUDA_PATH%"  ^

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -151,8 +151,43 @@ jobs:
         if (Test-Path "C:\Program Files\NVIDIA GPU Computing Toolkit\") { exit }
         New-item -ItemType directory -Name cuda
         Set-Location -Path cuda -PassThru
+        $cuda_version_short = '12.4'
         Invoke-WebRequest -Uri 'https://developer.download.nvidia.com/compute/cuda/12.4.0/network_installers/cuda_12.4.0_windows_network.exe' -OutFile 'cuda_install.exe'
-        Start-Process -FilePath '.\cuda_install.exe' -ArgumentList '-s nvcc cudart cublas cufft curand' -Wait -NoNewWindow
+
+        $CudaFeatures = " nvcc_${cuda_version_short} " + `
+  " cublas_${cuda_version_short} " + `
+  " cublas_dev_${cuda_version_short} " + `
+  " cuda_profiler_api_${cuda_version_short} " + `
+  " cudart_${cuda_version_short} " + `
+  " cufft_${cuda_version_short} " + `
+  " cufft_dev_${cuda_version_short} " + `
+  " cuobjdump_${cuda_version_short} " + `
+  " cupti_${cuda_version_short} " + `
+  " curand_${cuda_version_short} " + `
+  " curand_dev_${cuda_version_short} " + `
+  " cusolver_${cuda_version_short} " + `
+  " cusolver_dev_${cuda_version_short} " + `
+  " cusparse_${cuda_version_short} " + `
+  " cusparse_dev_${cuda_version_short} " + `
+  " cuxxfilt_${cuda_version_short} " + `
+  " npp_${cuda_version_short} " + `
+  " npp_dev_${cuda_version_short} " + `
+  " nsight_vse_${cuda_version_short} " + `
+  " nvdisasm_${cuda_version_short} " + `
+  " nvjitlink_${cuda_version_short} " + `
+  " nvjpeg_${cuda_version_short} " + `
+  " nvjpeg_dev_${cuda_version_short} " + `
+  " nvml_dev_${cuda_version_short} " + `
+  " nvprof_${cuda_version_short} " + `
+  " nvprune_${cuda_version_short} " + `
+  " nvrtc_${cuda_version_short} " + `
+  " nvrtc_dev_${cuda_version_short} " + `
+  " nvtx_${cuda_version_short} " + `
+  " sanitizer_${cuda_version_short} " + `
+  " thrust_${cuda_version_short} "
+
+        $SilentFlag = '-s '
+        Start-Process -FilePath '.\cuda_install.exe' -ArgumentList @($SilentFlag + $CudaFeatures) -Wait -NoNewWindow
         Remove-Item cuda_install.exe
     - name: Build & Install
       shell: cmd

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -155,6 +155,7 @@ jobs:
         call "C:\Program Files (x86)\Microsoft Visual Studio\2022\Enterprise\vc\Auxiliary\build\vcvarsall.bat" x64
         SET "CUDA_PATH=C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.4"
         SET "CUDA_HOME=%CUDA_PATH%"
+        SET "CUDA_TOOLKIT_ROOT_DIR=%CUDA_PATH%"
         SET "CMAKE_PREFIX_PATH=%CUDA_PATH%;%CMAKE_PREFIX_PATH%"
         SET "PATH=%CUDA_PATH%\bin\;%PATH%"
         SET "PATH=%CUDA_PATH%\libnvvp\;%PATH%"

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -159,6 +159,7 @@ jobs:
         SET "PATH=%CUDA_PATH%\bin\;%PATH%"
         SET "PATH=%CUDA_PATH%\libnvvp\;%PATH%"
         cmake -S . -B build ^
+              -A x64        ^
               -DCUDAToolkit_ROOT="%CUDA_PATH%"  ^
               -DCMAKE_BUILD_TYPE=Release ^
               -DAMReX_CUDA_ARCH=8.0      ^

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -139,3 +139,38 @@ jobs:
   #        name: pr_number
   #        path: pr_number.txt
   #        retention-days: 1
+
+  # Build libamrex and all tutorials with CUDA
+  tutorials-cuda:
+    name: MSVC C++17 w/ CUDA@11.1.1 w/o Fortran w/o MPI
+    runs-on: windows-2019
+    steps:
+    - uses: actions/checkout@v2
+    - uses: seanmiddleditch/gha-setup-ninja@master
+    - name: Windows CUDA Cache
+      uses: actions/cache@v2
+      with:
+        path: "C:/Program Files/NVIDIA GPU Computing Toolkit/"
+        key: msvc_cxx17_cuda111
+    - name: Download CUDA
+      run: |
+        if (Test-Path "C:\Program Files\NVIDIA GPU Computing Toolkit\") { exit }
+        New-item -ItemType directory -Name cuda
+        Set-Location -Path cuda -PassThru
+        Invoke-WebRequest -Uri 'https://developer.download.nvidia.com/compute/cuda/11.1.1/network_installers/cuda_11.1.1_win10_network.exe' -OutFile 'cuda_install.exe'
+        Start-Process -FilePath '.\cuda_install.exe' -ArgumentList '-s' -Wait -NoNewWindow
+    - name: Build & Install
+      run: |
+        cmake -S . -B build `
+              -G "Ninja"    `
+              -DAMReX_BUILD_TUTORIALS=ON `
+              -DAMReX_FORTRAN=OFF        `
+              -DAMReX_MPI=OFF            `
+              -DAMReX_GPU_BACKEND=CUDA   `
+              -DCMAKE_CXX_STANDARD=17    `
+              -DCMAKE_CUDA_STANDARD=17   `
+              -DAMReX_CUDA_ARCH=6.0      `
+              -DCMAKE_CUDA_COMPILER="C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v11.1/bin/nvcc.exe"
+        cmake --build build -j 2
+    # use "cmd", see https://gitlab.kitware.com/cmake/cmake/-/issues/20281
+    # -DAMReX_PARTICLES=ON

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -142,7 +142,7 @@ jobs:
 
   # Build libamrex and all tutorials with CUDA
   tutorials-cuda:
-    name: MSVC C++17 w/ CUDA@11.1.1 w/o Fortran w/o MPI
+    name: MSVC C++14 w/ CUDA@11.1.1 w/o Fortran w/o MPI
     runs-on: windows-2019
     steps:
     - uses: actions/checkout@v2
@@ -167,8 +167,8 @@ jobs:
               -DAMReX_FORTRAN=OFF        `
               -DAMReX_MPI=OFF            `
               -DAMReX_GPU_BACKEND=CUDA   `
-              -DCMAKE_CXX_STANDARD=17    `
-              -DCMAKE_CUDA_STANDARD=17   `
+              -DCMAKE_CXX_STANDARD=14    `
+              -DCMAKE_CUDA_STANDARD=14   `
               -DAMReX_CUDA_ARCH=6.0      `
               -DCMAKE_CUDA_COMPILER="C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v11.1/bin/nvcc.exe"
         cmake --build build -j 2

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -146,49 +146,9 @@ jobs:
     runs-on: windows-2022
     steps:
     - uses: actions/checkout@v4
-    - name: Download CUDA
-      run: |
-        if (Test-Path "C:\Program Files\NVIDIA GPU Computing Toolkit\") { exit }
-        New-item -ItemType directory -Name cuda
-        Set-Location -Path cuda -PassThru
-        $cuda_version_short = '12.4'
-        Invoke-WebRequest -Uri 'https://developer.download.nvidia.com/compute/cuda/12.4.0/network_installers/cuda_12.4.0_windows_network.exe' -OutFile 'cuda_install.exe'
-
-        $CudaFeatures = " nvcc_${cuda_version_short} " + `
-  " cublas_${cuda_version_short} " + `
-  " cublas_dev_${cuda_version_short} " + `
-  " cuda_profiler_api_${cuda_version_short} " + `
-  " cudart_${cuda_version_short} " + `
-  " cufft_${cuda_version_short} " + `
-  " cufft_dev_${cuda_version_short} " + `
-  " cuobjdump_${cuda_version_short} " + `
-  " cupti_${cuda_version_short} " + `
-  " curand_${cuda_version_short} " + `
-  " curand_dev_${cuda_version_short} " + `
-  " cusolver_${cuda_version_short} " + `
-  " cusolver_dev_${cuda_version_short} " + `
-  " cusparse_${cuda_version_short} " + `
-  " cusparse_dev_${cuda_version_short} " + `
-  " cuxxfilt_${cuda_version_short} " + `
-  " npp_${cuda_version_short} " + `
-  " npp_dev_${cuda_version_short} " + `
-  " nsight_vse_${cuda_version_short} " + `
-  " nvdisasm_${cuda_version_short} " + `
-  " nvjitlink_${cuda_version_short} " + `
-  " nvjpeg_${cuda_version_short} " + `
-  " nvjpeg_dev_${cuda_version_short} " + `
-  " nvml_dev_${cuda_version_short} " + `
-  " nvprof_${cuda_version_short} " + `
-  " nvprune_${cuda_version_short} " + `
-  " nvrtc_${cuda_version_short} " + `
-  " nvrtc_dev_${cuda_version_short} " + `
-  " nvtx_${cuda_version_short} " + `
-  " sanitizer_${cuda_version_short} " + `
-  " thrust_${cuda_version_short} "
-
-        $SilentFlag = '-s '
-        Start-Process -FilePath '.\cuda_install.exe' -ArgumentList @($SilentFlag + $CudaFeatures) -Wait -NoNewWindow
-        Remove-Item cuda_install.exe
+    - name: Install CUDA
+      shell: powershell
+      run: .\dependencies\windows_install_cuda.ps1
     - name: Build & Install
       shell: cmd
       run: |

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -148,7 +148,7 @@ jobs:
     - uses: actions/checkout@v4
     - name: Install CUDA
       shell: powershell
-      run: .\dependencies\windows_install_cuda.ps1
+      run: .github\workflows\dependencies\windows_install_cuda.ps1
     - name: Build & Install
       shell: cmd
       run: |

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -163,7 +163,8 @@ jobs:
 
         cmake -S . -B build ^
               -A x64        ^
-              -DCMAKE_GENERATOR_TOOLSET="cuda=%CUDA_PATH%"  ^
+              -DCMAKE_VS_PLATFORM_TOOLSET_CUDA="cuda=12.4"  ^
+              -DCUDA_TOOLKIT_ROOT_DIR="%CUDA_PATH%"  ^
               -DCUDAToolkit_ROOT="%CUDA_PATH%"  ^
               -DCMAKE_BUILD_TYPE=Release ^
               -DAMReX_CUDA_ARCH=8.0      ^

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -163,6 +163,7 @@ jobs:
       shell: cmd
       run: |
         call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\vc\Auxiliary\build\vcvarsall.bat" x64
+        SET "PATH=C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.1\bin\;%PATH%"
         cmake -S . -B build ^
               -G Ninja      ^
               -DCMAKE_BUILD_TYPE=Release ^
@@ -172,7 +173,8 @@ jobs:
               -DAMReX_GPU_BACKEND=CUDA   ^
               -DCMAKE_CXX_STANDARD=14    ^
               -DCMAKE_CUDA_STANDARD=14   ^
-              -DAMReX_CUDA_ARCH=6.0
+              -DAMReX_CUDA_ARCH=6.0      ^
+              -DCUDAToolkit_ROOT="C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.1"
         cmake --build build -j 2
     # use "cmd", see https://gitlab.kitware.com/cmake/cmake/-/issues/20281
     # -DAMReX_PARTICLES=ON

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -160,17 +160,19 @@ jobs:
         Invoke-WebRequest -Uri 'https://developer.download.nvidia.com/compute/cuda/11.1.1/network_installers/cuda_11.1.1_win10_network.exe' -OutFile 'cuda_install.exe'
         Start-Process -FilePath '.\cuda_install.exe' -ArgumentList '-s' -Wait -NoNewWindow
     - name: Build & Install
+      shell: cmd
       run: |
-        cmake -S . -B build `
-              -G "Ninja"    `
-              -DAMReX_BUILD_TUTORIALS=ON `
-              -DAMReX_FORTRAN=OFF        `
-              -DAMReX_MPI=OFF            `
-              -DAMReX_GPU_BACKEND=CUDA   `
-              -DCMAKE_CXX_STANDARD=14    `
-              -DCMAKE_CUDA_STANDARD=14   `
-              -DAMReX_CUDA_ARCH=6.0      `
+        call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\vc\Auxiliary\build\vcvarsall.bat" x64
+        cmake -S . -B build ^
+              -DCMAKE_BUILD_TYPE=Release ^
+              -DAMReX_BUILD_TUTORIALS=ON ^
+              -DAMReX_FORTRAN=OFF        ^
+              -DAMReX_MPI=OFF            ^
+              -DAMReX_GPU_BACKEND=CUDA   ^
+              -DCMAKE_CXX_STANDARD=14    ^
+              -DCMAKE_CUDA_STANDARD=14   ^
+              -DAMReX_CUDA_ARCH=6.0      ^
               -DCMAKE_CUDA_COMPILER="C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v11.1/bin/nvcc.exe"
-        cmake --build build -j 2
+        cmake --build build --config Release -j 2
     # use "cmd", see https://gitlab.kitware.com/cmake/cmake/-/issues/20281
     # -DAMReX_PARTICLES=ON

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -142,37 +142,36 @@ jobs:
 
   # Build libamrex and all tutorials with CUDA
   tutorials-cuda:
-    name: MSVC C++17 w/ CUDA@11.1.1 w/o Fortran w/o MPI
-    runs-on: windows-2019
+    name: MSVC C++17 w/ CUDA@12.4 w/o Fortran w/o MPI
+    runs-on: windows-2022
     steps:
-    - uses: actions/checkout@v2
-    - uses: seanmiddleditch/gha-setup-ninja@master
-    - name: Windows CUDA Cache
-      uses: actions/cache@v2
-      with:
-        path: "C:/Program Files/NVIDIA GPU Computing Toolkit/"
-        key: msvc_cxx17_cuda111
+    - uses: actions/checkout@v4
     - name: Download CUDA
       run: |
         if (Test-Path "C:\Program Files\NVIDIA GPU Computing Toolkit\") { exit }
         New-item -ItemType directory -Name cuda
         Set-Location -Path cuda -PassThru
-        Invoke-WebRequest -Uri 'https://developer.download.nvidia.com/compute/cuda/11.1.1/network_installers/cuda_11.1.1_win10_network.exe' -OutFile 'cuda_install.exe'
+        Invoke-WebRequest -Uri 'https://developer.download.nvidia.com/compute/cuda/12.4.0/network_installers/cuda_12.4.0_windows_network.exe' -OutFile 'cuda_install.exe'
         Start-Process -FilePath '.\cuda_install.exe' -ArgumentList '-s' -Wait -NoNewWindow
     - name: Build & Install
       shell: cmd
       run: |
-        call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\vc\Auxiliary\build\vcvarsall.bat" x64
-        SET "PATH=C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.1\bin\;%PATH%"
+        call "C:\Program Files (x86)\Microsoft Visual Studio\2022\Enterprise\vc\Auxiliary\build\vcvarsall.bat" x64
+        SET "CUDA_PATH=C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.4"
+        SET "CMAKE_PREFIX_PATH=%CUDA_PATH%;%CMAKE_PREFIX_PATH%"
+        SET "PATH=%CUDA_PATH%\bin\;%PATH%"
+        SET "PATH=%CUDA_PATH%\libnvvp\;%PATH%"
         cmake -S . -B build ^
-              -G Ninja      ^
+              -DCUDAToolkit_ROOT="%CUDA_PATH%"  ^
               -DCMAKE_BUILD_TYPE=Release ^
+              -DAMReX_CUDA_ARCH=8.0      ^
               -DAMReX_FORTRAN=OFF        ^
-              -DAMReX_MPI=OFF            ^
               -DAMReX_GPU_BACKEND=CUDA   ^
-              -DCMAKE_CXX_STANDARD=17    ^
-              -DCMAKE_CUDA_STANDARD=17   ^
-              -DAMReX_CUDA_ARCH=6.0
-        cmake --build build -j 2
+              -DAMReX_MPI=OFF            ^
+              -DAMReX_PARTICLES=ON
+
+        cmake --build build --config Release -j 4
+
+        cmake --build build --config Release --target install
+
     # use "cmd", see https://gitlab.kitware.com/cmake/cmake/-/issues/20281
-    # -DAMReX_PARTICLES=ON

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -171,8 +171,7 @@ jobs:
               -DAMReX_GPU_BACKEND=CUDA   ^
               -DCMAKE_CXX_STANDARD=14    ^
               -DCMAKE_CUDA_STANDARD=14   ^
-              -DAMReX_CUDA_ARCH=6.0      ^
-              -DCMAKE_CUDA_COMPILER="C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v11.1/bin/nvcc.exe"
+              -DAMReX_CUDA_ARCH=6.0
         cmake --build build --config Release -j 2
     # use "cmd", see https://gitlab.kitware.com/cmake/cmake/-/issues/20281
     # -DAMReX_PARTICLES=ON

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -167,7 +167,6 @@ jobs:
         cmake -S . -B build ^
               -G Ninja      ^
               -DCMAKE_BUILD_TYPE=Release ^
-              -DAMReX_BUILD_TUTORIALS=ON ^
               -DAMReX_FORTRAN=OFF        ^
               -DAMReX_MPI=OFF            ^
               -DAMReX_GPU_BACKEND=CUDA   ^

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -152,7 +152,8 @@ jobs:
         New-item -ItemType directory -Name cuda
         Set-Location -Path cuda -PassThru
         Invoke-WebRequest -Uri 'https://developer.download.nvidia.com/compute/cuda/12.4.0/network_installers/cuda_12.4.0_windows_network.exe' -OutFile 'cuda_install.exe'
-        Start-Process -FilePath '.\cuda_install.exe' -ArgumentList '-s' -Wait -NoNewWindow
+        Start-Process -FilePath '.\cuda_install.exe' -ArgumentList '-s nvcc cudart cublas cufft curand' -Wait -NoNewWindow
+        Remove-Item cuda_install.exe
     - name: Build & Install
       shell: cmd
       run: |

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -163,6 +163,7 @@ jobs:
 
         cmake -S . -B build ^
               -A x64        ^
+              -DCMAKE_GENERATOR_TOOLSET="cuda=%CUDA_PATH%"  ^
               -DCUDAToolkit_ROOT="%CUDA_PATH%"  ^
               -DCMAKE_BUILD_TYPE=Release ^
               -DAMReX_CUDA_ARCH=8.0      ^

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -163,7 +163,7 @@ jobs:
 
         cmake -S . -B build ^
               -A x64        ^
-              -DCMAKE_VS_PLATFORM_TOOLSET_CUDA="cuda=12.4"  ^
+              -DCMAKE_GENERATOR_TOOLSET="cuda=12.4"  ^
               -DCUDA_TOOLKIT_ROOT_DIR="%CUDA_PATH%"  ^
               -DCUDAToolkit_ROOT="%CUDA_PATH%"  ^
               -DCMAKE_BUILD_TYPE=Release ^

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -154,6 +154,7 @@ jobs:
       run: |
         call "C:\Program Files (x86)\Microsoft Visual Studio\2022\Enterprise\vc\Auxiliary\build\vcvarsall.bat" x64
         SET "CUDA_PATH=C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.4"
+        SET "CUDA_HOME=%CUDA_PATH%"
         SET "CMAKE_PREFIX_PATH=%CUDA_PATH%;%CMAKE_PREFIX_PATH%"
         SET "PATH=%CUDA_PATH%\bin\;%PATH%"
         SET "PATH=%CUDA_PATH%\libnvvp\;%PATH%"

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -142,7 +142,7 @@ jobs:
 
   # Build libamrex and all tutorials with CUDA
   tutorials-cuda:
-    name: MSVC C++14 w/ CUDA@11.1.1 w/o Fortran w/o MPI
+    name: MSVC C++17 w/ CUDA@11.1.1 w/o Fortran w/o MPI
     runs-on: windows-2019
     steps:
     - uses: actions/checkout@v2
@@ -171,10 +171,9 @@ jobs:
               -DAMReX_FORTRAN=OFF        ^
               -DAMReX_MPI=OFF            ^
               -DAMReX_GPU_BACKEND=CUDA   ^
-              -DCMAKE_CXX_STANDARD=14    ^
-              -DCMAKE_CUDA_STANDARD=14   ^
-              -DAMReX_CUDA_ARCH=6.0      ^
-              -DCUDAToolkit_ROOT="C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.1"
+              -DCMAKE_CXX_STANDARD=17    ^
+              -DCMAKE_CUDA_STANDARD=17   ^
+              -DAMReX_CUDA_ARCH=6.0
         cmake --build build -j 2
     # use "cmd", see https://gitlab.kitware.com/cmake/cmake/-/issues/20281
     # -DAMReX_PARTICLES=ON

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -164,6 +164,7 @@ jobs:
       run: |
         call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\vc\Auxiliary\build\vcvarsall.bat" x64
         cmake -S . -B build ^
+              -G Ninja      ^
               -DCMAKE_BUILD_TYPE=Release ^
               -DAMReX_BUILD_TUTORIALS=ON ^
               -DAMReX_FORTRAN=OFF        ^
@@ -172,6 +173,6 @@ jobs:
               -DCMAKE_CXX_STANDARD=14    ^
               -DCMAKE_CUDA_STANDARD=14   ^
               -DAMReX_CUDA_ARCH=6.0
-        cmake --build build --config Release -j 2
+        cmake --build build -j 2
     # use "cmd", see https://gitlab.kitware.com/cmake/cmake/-/issues/20281
     # -DAMReX_PARTICLES=ON


### PR DESCRIPTION
## Summary

This a CI entry for Windows MSVC + CUDA.

@robertmaynard @WeiqunZhang @mic84 

## Additional background

The install of CUDA takes about 10min, but we cache its install after the first run (this cache will be [evicted after 7 days of inactivity](https://docs.github.com/en/free-pro-team@latest/actions/guides/caching-dependencies-to-speed-up-workflows#usage-limits-and-eviction-policy)).

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
