### PR TITLE
DPCPP: Update CMake options to allow building with MPI+DPCPP

### DIFF
--- a/Tools/CMake/AMReXOptions.cmake
+++ b/Tools/CMake/AMReXOptions.cmake
@@ -126,10 +126,17 @@ endif ()
 
 # --- SYCL ---
 if (AMReX_DPCPP)
+  if (AMReX_MPI)
+    if (NOT (CMAKE_CXX_COMPILER MATCHES "mpiicpx") )
+       message(FATAL_ERROR "\nAMReX_GPU_BACKEND=${AMReX_GPU_BACKEND} only supports mpiicpx compiler when AMReX_MPI=ON"
+         "Set CMAKE_CXX_COMPILER=mpiicpx and try again.")
+    endif ()
+  else ()
    if (NOT (CMAKE_CXX_COMPILER MATCHES "dpcpp") )
       message(FATAL_ERROR "\nAMReX_GPU_BACKEND=${AMReX_GPU_BACKEND} supports dpcpp compiler only."
          "Set CMAKE_CXX_COMPILER=dpccp and try again.")
    endif ()
+ endif ()
 endif ()
 
 cmake_dependent_option( AMReX_DPCPP_AOT  "Enable DPCPP ahead-of-time compilation (WIP)"  OFF

--- a/Tools/CMake/AMReXSYCL.cmake
+++ b/Tools/CMake/AMReXSYCL.cmake
@@ -42,6 +42,7 @@ target_compile_features(SYCL INTERFACE cxx_std_17)
 #
 # Compiler options
 #
+
 target_compile_options( SYCL
    INTERFACE
    $<${_cxx_clang}:-Wno-error=sycl-strict -fsycl>
@@ -60,6 +61,12 @@ target_compile_options( SYCL
    INTERFACE
    $<${_cxx_clang}:-fno-sycl-early-optimizations>)
 
+# Need this option to compile with mpiicpx
+if (AMReX_MPI)
+  target_compile_options( SYCL
+    INTERFACE
+    $<${_cxx_clang}:-fsycl-unnamed-lambda>)
+endif ()
 
 #
 # Link options


### PR DESCRIPTION
## Summary

This PR updates the CMake rules to allow compilation with `-DAMReX_MPI=ON -DAMReX_GPU_BACKEND=SYCL`. Changes are based on #1556 

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [X] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
