### PR TITLE
CI: Windows + Clang

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -4,14 +4,38 @@ on: [push, pull_request]
 
 jobs:
   # Build libamrex and all tutorials
-  tutorials:
+  tutorials_msvc:
     name: MSVC C++17 w/o Fortran w/o MPI
     runs-on: windows-latest
     steps:
     - uses: actions/checkout@v2
     - name: Build & Install
       run: |
-        mkdir build
-        cd build
-        cmake .. -DCMAKE_BUILD_TYPE=Debug -DCMAKE_VERBOSE_MAKEFILE=ON -DAMReX_BUILD_TUTORIALS=ON -DAMReX_FORTRAN=OFF -DAMReX_MPI=OFF
-        cmake --build . --config Debug
+        cmake -S . -B build   `
+              -T "ClangCl"    `
+              -DCMAKE_BUILD_TYPE=Debug      `
+              -DCMAKE_VERBOSE_MAKEFILE=ON   `
+              -DAMReX_BUILD_TUTORIALS=ON    `
+              -DAMReX_FORTRAN=OFF           `
+              -DAMReX_MPI=OFF               `
+              -DAMReX_PARTICLES=ON
+        cmake --build build --config Debug -j 2
+
+  # Build libamrex and all tutorials
+  tutorials_clang:
+    name: Clang C++17 w/o Fortran w/o MPI
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: seanmiddleditch/gha-setup-ninja@master
+    - name: Build & Install
+      run: |
+        cmake -S . -B build   `
+              -T "ClangCl"    `
+              -DCMAKE_BUILD_TYPE=Release    `
+              -DCMAKE_VERBOSE_MAKEFILE=ON   `
+              -DAMReX_BUILD_TUTORIALS=ON    `
+              -DAMReX_FORTRAN=OFF           `
+              -DAMReX_MPI=OFF               `
+              -DAMReX_PARTICLES=ON
+        cmake --build build --config Release -j 2


### PR DESCRIPTION
## Summary

Add Clang as Windows target.
This compiler offers potentially a route to modern OpenMP #1562 
(MSVC: 2.0 standard, LLVM/Clang: 4.5 standard)

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
