### PR TITLE
MacProjector: Update setDomainBC API

### DIFF
--- a/Src/LinearSolvers/Projections/AMReX_MacProjector.cpp
+++ b/Src/LinearSolvers/Projections/AMReX_MacProjector.cpp
@@ -187,8 +187,12 @@ void
 MacProjector::setDomainBC (const Array<LinOpBCType,AMREX_SPACEDIM>& lobc,
                            const Array<LinOpBCType,AMREX_SPACEDIM>& hibc)
 {
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+        m_linop != nullptr,
+        "MacProjector::setDomainBC: initProjector must be called before calling this method");
+
     m_linop->setDomainBC(lobc, hibc);
-    for (int ilev = 0, N = m_umac.size(); ilev < N; ++ilev) {
+    for (int ilev = 0, N = m_geom.size(); ilev < N; ++ilev) {
         m_linop->setLevelBC(ilev, nullptr);
     }
 


### PR DESCRIPTION
## Summary

Allow `setDomainBC` to be called before `setUMAC` has been called. 

#1574 introduced the ability to reuse MacProjector instance. However, the implementation of `setDomainBC` was not updated and depended on existence of proper `MacProjector::m_umac` instance for BC logic to work


## Checklist

The proposed changes:
- [X] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
