### PR TITLE
Restore reproducibility of solutions with MacProjector reuse

### DIFF
--- a/Src/LinearSolvers/Projections/AMReX_MacProjector.cpp
+++ b/Src/LinearSolvers/Projections/AMReX_MacProjector.cpp
@@ -248,6 +248,10 @@ MacProjector::project (Real reltol, Real atol)
         {
             MultiFab::Add(m_rhs[ilev],m_divu[ilev],0,0,1,0);
         }
+
+        // Always reset initial phi to be zero. This is needed to handle the
+        // situation where the MacProjector is being reused.
+        m_phi[ilev].setVal(0.0);
     }
 
     m_mlmg->solve(amrex::GetVecOfPtrs(m_phi), amrex::GetVecOfConstPtrs(m_rhs), reltol, atol);


### PR DESCRIPTION
## Summary

This PR resets the initial `phi` used in `MacProjector::project` call to zero before the linear solve. This is necessary in situations where the application might reuse the MacProjector operator and the `phi` MultiFabs have the previous solution. This caused small differences in solutions when the application reused MacProjector compared recreating it from scratch before the projection step.

## Additional background

See #1574 

## Checklist

The proposed changes:
- [X] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
