### PR TITLE
Add wrapper for memcpy.

### DIFF
--- a/Src/Base/AMReX_GpuUtility.H
+++ b/Src/Base/AMReX_GpuUtility.H
@@ -12,6 +12,7 @@
 #include <AMReX_Array4.H>
 #include <iostream>
 #include <cmath>
+#include <cstring>
 
 #ifdef AMREX_USE_CUDA
 #include <cuda.h>
@@ -210,6 +211,16 @@ std::ostream& operator<< (std::ostream& os, const dim3& d);
 
 using Gpu::isnan;
 using Gpu::isinf;
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void* memcpy (void* dest, const void* src, std::size_t count)
+{
+#ifdef __HIP_DEVICE_COMPILE__
+    return ::memcpy(dest, src, count);
+#else
+    return std::memcpy(dest, src, count);
+#endif
+}
 
 } // namespace amrex
 


### PR DESCRIPTION
`std::memcpy` does not seem to work in device code in our HIP CI. 

This adds a wrapper that reverts to the global namespace `memcpy` in HIP device code.  

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
