### PR TITLE
Move the memcpy wrapper into amrex::Gpu

### DIFF
--- a/Src/Base/AMReX_GpuUtility.H
+++ b/Src/Base/AMReX_GpuUtility.H
@@ -204,15 +204,6 @@ namespace Gpu {
         bool m_sync;
     };
 
-} // namespace Gpu
-
-#ifdef AMREX_USE_GPU
-std::ostream& operator<< (std::ostream& os, const dim3& d);
-#endif
-
-using Gpu::isnan;
-using Gpu::isinf;
-
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 void* memcpy (void* dest, const void* src, std::size_t count)
 {
@@ -222,6 +213,15 @@ void* memcpy (void* dest, const void* src, std::size_t count)
     return std::memcpy(dest, src, count);
 #endif
 }
+
+} // namespace Gpu
+
+#ifdef AMREX_USE_GPU
+std::ostream& operator<< (std::ostream& os, const dim3& d);
+#endif
+
+using Gpu::isnan;
+using Gpu::isinf;
 
 } // namespace amrex
 


### PR DESCRIPTION
PR #1597 introduced a problem with Cuda builds - this fixes by putting the wrapper inside the `amrex::Gpu` namespace.

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
