### PR TITLE
Remove alternative operators from AMReX

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -142,6 +142,7 @@ jobs:
   tutorials-cuda:
     name: CUDA@9.1.85 GNU@4.8.5 C++11 Release [tutorials]
     runs-on: ubuntu-latest
+    env: {CXXFLAGS: "-fno-operator-names"}
     steps:
     - uses: actions/checkout@v2
     - name: Dependencies
@@ -165,6 +166,7 @@ jobs:
   tutorials-dpcpp:
     name: DPCPP@PubBeta GFortran@7.5 C++17 [tutorials]
     runs-on: ubuntu-latest
+        env: {CXXFLAGS: "-fno-operator-names"}
     steps:
     - uses: actions/checkout@v2
     - name: Dependencies
@@ -187,6 +189,7 @@ jobs:
   tutorials-hip:
     name: HIP ROCm@3.8 GFortran@9.3 C++17 [tutorials]
     runs-on: ubuntu-20.04
+    env: {CXXFLAGS: "-fno-operator-names"}
     steps:
     - uses: actions/checkout@v2
     - name: Dependencies

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -166,7 +166,7 @@ jobs:
   tutorials-dpcpp:
     name: DPCPP@PubBeta GFortran@7.5 C++17 [tutorials]
     runs-on: ubuntu-latest
-        env: {CXXFLAGS: "-fno-operator-names"}
+    env: {CXXFLAGS: "-fno-operator-names"}
     steps:
     - uses: actions/checkout@v2
     - name: Dependencies

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -227,7 +227,7 @@ jobs:
     - name: Build & Install
       run: |
         ./configure --dim 1
-        make -j2
+        make -j2 XTRA_CXXFLAGS=-fno-operator-names
         make install
 
   # Build 2D libamrex with configure
@@ -241,7 +241,7 @@ jobs:
     - name: Build & Install
       run: |
         ./configure --dim 2 --with-fortran no --comp llvm --with-mpi no
-        make -j2 WARN_ALL=TRUE WARN_ERROR=TRUE
+        make -j2 WARN_ALL=TRUE WARN_ERROR=TRUE XTRA_CXXFLAGS=-fno-operator-names
         make install
 
   # Build 3D libamrex with configure
@@ -255,7 +255,7 @@ jobs:
     - name: Build & Install
       run: |
         ./configure --dim 3 --enable-eb yes --enable-xsdk-defaults yes
-        make -j2 WARN_ALL=TRUE WARN_ERROR=TRUE
+        make -j2 WARN_ALL=TRUE WARN_ERROR=TRUE XTRA_CXXFLAGS=-fno-operator-names
         make install
 
   # Build 3D libamrex debug omp build with configure
@@ -269,7 +269,7 @@ jobs:
     - name: Build & Install
       run: |
         ./configure --dim 3 --enable-eb yes --enable-xsdk-defaults yes --with-omp yes --debug yes
-        make -j2 WARN_ALL=TRUE WARN_ERROR=TRUE
+        make -j2 WARN_ALL=TRUE WARN_ERROR=TRUE XTRA_CXXFLAGS=-fno-operator-names
         make install
 
   # Build libamrex and run all tests

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -7,7 +7,7 @@ jobs:
   library:
     name: GNU@7.5 C++17 Release [lib]
     runs-on: ubuntu-latest
-    env: {CXXFLAGS: "-Werror -Wshadow -Woverloaded-virtual -Wunreachable-code"}
+    env: {CXXFLAGS: "-Werror -Wshadow -Woverloaded-virtual -Wunreachable-code -fno-operator-names"}
     steps:
     - uses: actions/checkout@v2
     - name: Dependencies
@@ -26,7 +26,7 @@ jobs:
   library_clang:
     name: Clang@6.0 C++14 SP NOMPI Debug [lib]
     runs-on: ubuntu-latest
-    env: {CXXFLAGS: "-Werror -Wshadow -Woverloaded-virtual -Wextra-semi -Wunreachable-code"}
+    env: {CXXFLAGS: "-Werror -Wshadow -Woverloaded-virtual -Wextra-semi -Wunreachable-code -fno-operator-names"}
     steps:
     - uses: actions/checkout@v2
     - name: Dependencies
@@ -54,7 +54,7 @@ jobs:
   tutorials:
     name: GNU@7.5 C++14 [tutorials]
     runs-on: ubuntu-latest
-    env: {CXXFLAGS: "-Werror -Wshadow -Woverloaded-virtual -Wunreachable-code"}
+    env: {CXXFLAGS: "-Werror -Wshadow -Woverloaded-virtual -Wunreachable-code -fno-operator-names"}
     steps:
     - uses: actions/checkout@v2
     - name: Dependencies
@@ -74,7 +74,7 @@ jobs:
   tutorials_cxx20:
     name: GNU@10.1 C++20 OMP [tutorials]
     runs-on: ubuntu-latest
-    env: {CXXFLAGS: "-Werror -Wno-error=deprecated-declarations -Wshadow -Woverloaded-virtual -Wunreachable-code"}
+    env: {CXXFLAGS: "-Werror -Wno-error=deprecated-declarations -Wshadow -Woverloaded-virtual -Wunreachable-code -fno-operator-names"}
     steps:
     - uses: actions/checkout@v2
     - name: Dependencies
@@ -99,7 +99,7 @@ jobs:
   tutorials-nonmpi:
     name: GNU@7.5 C++14 NOMPI [tutorials]
     runs-on: ubuntu-latest
-    env: {CXXFLAGS: "-Werror -Wshadow -Woverloaded-virtual -Wunreachable-code"}
+    env: {CXXFLAGS: "-Werror -Wshadow -Woverloaded-virtual -Wunreachable-code -fno-operator-names"}
     steps:
     - uses: actions/checkout@v2
     - name: Dependencies
@@ -120,7 +120,7 @@ jobs:
   tutorials-nofortran:
     name: GNU@7.5 C++11 w/o Fortran [tutorials]
     runs-on: ubuntu-latest
-    env: {CXXFLAGS: "-Werror -Wshadow -Woverloaded-virtual -Wunreachable-code"}
+    env: {CXXFLAGS: "-Werror -Wshadow -Woverloaded-virtual -Wunreachable-code -fno-operator-names"}
     steps:
     - uses: actions/checkout@v2
     - name: Dependencies
@@ -270,7 +270,7 @@ jobs:
   tests:
     name: GNU@7.5 C++14 [tests]
     runs-on: ubuntu-latest
-    env: {CXXFLAGS: "-Werror -Wshadow -Woverloaded-virtual -Wunreachable-code"}
+    env: {CXXFLAGS: "-Werror -Wshadow -Woverloaded-virtual -Wunreachable-code -fno-operator-names"}
     steps:
     - uses: actions/checkout@v2
     - name: Dependencies

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -3,7 +3,7 @@ name: macos
 on: [push, pull_request]
 
 env:
-  CXXFLAGS: "-Werror -Wshadow -Woverloaded-virtual -Wextra-semi -Wunreachable-code"
+  CXXFLAGS: "-Werror -Wshadow -Woverloaded-virtual -Wextra-semi -Wunreachable-code -fno-operator-names"
 
 jobs:
   # Build libamrex and all tutorials

--- a/Src/AmrCore/AMReX_AmrCore.cpp
+++ b/Src/AmrCore/AMReX_AmrCore.cpp
@@ -80,7 +80,7 @@ AmrCore::regrid (int lbase, Real time, bool)
         if (lev <= finest_level) // an old level
         {
             bool ba_changed = (new_grids[lev] != grids[lev]);
-	    if (ba_changed or coarse_ba_changed) {
+	    if (ba_changed || coarse_ba_changed) {
                 BoxArray level_grids = grids[lev];
                 DistributionMapping level_dmap = dmap[lev];
                 if (ba_changed) {

--- a/Src/AmrCore/AMReX_AmrParGDB.H
+++ b/Src/AmrCore/AMReX_AmrParGDB.H
@@ -70,7 +70,7 @@ inline
 const Geometry&
 AmrParGDB::ParticleGeom (int level) const
 {
-    if (not m_has_geom[level]) {
+    if (! m_has_geom[level]) {
         return m_amrcore->Geom(level);
     } else {
         return m_geom[level];
@@ -88,7 +88,7 @@ inline
 const Vector<Geometry>&
 AmrParGDB::ParticleGeom () const
 {
-    if (not m_has_geom[0]) {
+    if (! m_has_geom[0]) {
         return m_amrcore->Geom();
     } else {
         return m_geom;

--- a/Src/AmrCore/AMReX_Cluster.cpp
+++ b/Src/AmrCore/AMReX_Cluster.cpp
@@ -405,7 +405,7 @@ Cluster::new_chop ()
            nlo += hist[dir][i-lo[dir]];
        }
 
-       if (nlo <= 0 or nlo >= m_len) return chop();
+       if (nlo <= 0 || nlo >= m_len) return chop();
 
        int nhi = m_len - nlo;
 

--- a/Src/AmrCore/AMReX_FillPatchUtil_I.H
+++ b/Src/AmrCore/AMReX_FillPatchUtil_I.H
@@ -61,7 +61,7 @@ FillPatchSingleLevel (MF& mf, IntVect const& nghost, Real time,
 
     if (smf.size() == 1)
     {
-        if (&mf == smf[0] and scomp == dcomp) {
+        if (&mf == smf[0] && scomp == dcomp) {
             mf.FillBoundary(dcomp, ncomp, nghost, geom.periodicity());
         } else {
             mf.ParallelCopy(*smf[0], scomp, dcomp, ncomp, IntVect{0}, nghost, geom.periodicity());
@@ -74,7 +74,7 @@ FillPatchSingleLevel (MF& mf, IntVect const& nghost, Real time,
         MF * dmf;
         int destcomp;
         bool sameba;
-        if (mf.boxArray() == smf[0]->boxArray() and
+        if (mf.boxArray() == smf[0]->boxArray() &&
             mf.DistributionMap() == smf[0]->DistributionMap())
         {
             dmf = &mf;
@@ -89,7 +89,7 @@ FillPatchSingleLevel (MF& mf, IntVect const& nghost, Real time,
             sameba = false;
         }
 
-        if ((dmf != smf[0] and dmf != smf[1]) or scomp != dcomp)
+        if ((dmf != smf[0] && dmf != smf[1]) || scomp != dcomp)
         {
 #ifdef _OPENMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())

--- a/Src/Base/AMReX_Array4.H
+++ b/Src/Base/AMReX_Array4.H
@@ -161,7 +161,7 @@ namespace amrex {
 
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         bool contains (int i, int j, int k) const noexcept {
-            return (i>=begin.x and i<end.x and j>=begin.y and j<end.y and k>=begin.z and k<end.z);
+            return (i>=begin.x && i<end.x && j>=begin.y && j<end.y && k>=begin.z && k<end.z);
         }
 
 #if defined(AMREX_DEBUG) || defined(AMREX_BOUND_CHECK)

--- a/Src/Base/AMReX_AsyncOut.cpp
+++ b/Src/Base/AMReX_AsyncOut.cpp
@@ -39,7 +39,7 @@ void Initialize ()
     s_noutfiles = std::min(s_noutfiles, nprocs);
 
 #ifdef AMREX_USE_MPI
-    if (s_asyncout and s_noutfiles < nprocs)
+    if (s_asyncout && s_noutfiles < nprocs)
     {
         int provided = -1;
         MPI_Query_thread(&provided);

--- a/Src/Base/AMReX_BaseFab.H
+++ b/Src/Base/AMReX_BaseFab.H
@@ -1639,7 +1639,7 @@ void
 BaseFab<T>::prefetchToHost () const noexcept
 {
 #ifdef AMREX_USE_GPU
-    if (this->arena() == The_Arena() or this->arena() == The_Managed_Arena()) {
+    if (this->arena() == The_Arena() || this->arena() == The_Managed_Arena()) {
 #if defined(AMREX_USE_DPCPP)
         // xxxxx DPCPP todo: prefetchToHost
         // std::size_t s = sizeof(T)*this->nvar*this->domain.numPts();
@@ -1664,7 +1664,7 @@ void
 BaseFab<T>::prefetchToDevice () const noexcept
 {
 #ifdef AMREX_USE_GPU
-    if (this->arena() == The_Arena() or this->arena() == The_Managed_Arena()) {
+    if (this->arena() == The_Arena() || this->arena() == The_Managed_Arena()) {
 #if defined(AMREX_USE_DPCPP)
         std::size_t s = sizeof(T)*this->nvar*this->domain.numPts();
         auto& q = Gpu::Device::streamQueue();
@@ -2229,7 +2229,7 @@ BaseFab<T>::norminfmask (const Box& subbox, const BaseFab<int>& mask,
     Array4<int const> const& m = mask.const_array();
     Real r = 0.0;
 #ifdef AMREX_USE_GPU
-    if (run_on == RunOn::Device and Gpu::inLaunchRegion()) {
+    if (run_on == RunOn::Device && Gpu::inLaunchRegion()) {
         ReduceOps<ReduceOpMax> reduce_op;
         ReduceData<Real> reduce_data(reduce_op);
         using ReduceTuple = ReduceData<Real>::Type;
@@ -2279,7 +2279,7 @@ BaseFab<T>::norm (const Box& subbox, int p, int comp, int numcomp) const noexcep
     Array4<T const> const& a = this->const_array();
     Real nrm = 0.;
 #ifdef AMREX_USE_GPU
-    if (run_on == RunOn::Device and Gpu::inLaunchRegion()) {
+    if (run_on == RunOn::Device && Gpu::inLaunchRegion()) {
         if (p == 0) {
             ReduceOps<ReduceOpMax> reduce_op;
             ReduceData<Real> reduce_data(reduce_op);
@@ -2370,7 +2370,7 @@ BaseFab<T>::min (const Box& subbox, int comp) const noexcept
 {
     Array4<T const> const& a = this->const_array(comp);
 #ifdef AMREX_USE_GPU
-    if (run_on == RunOn::Device and Gpu::inLaunchRegion()) {
+    if (run_on == RunOn::Device && Gpu::inLaunchRegion()) {
         ReduceOps<ReduceOpMin> reduce_op;
         ReduceData<T> reduce_data(reduce_op);
         using ReduceTuple = typename decltype(reduce_data)::Type;
@@ -2408,7 +2408,7 @@ BaseFab<T>::max (const Box& subbox, int comp) const noexcept
 {
     Array4<T const> const& a = this->const_array(comp);
 #ifdef AMREX_USE_GPU
-    if (run_on == RunOn::Device and Gpu::inLaunchRegion()) {
+    if (run_on == RunOn::Device && Gpu::inLaunchRegion()) {
         ReduceOps<ReduceOpMax> reduce_op;
         ReduceData<T> reduce_data(reduce_op);
         using ReduceTuple = typename decltype(reduce_data)::Type;
@@ -2446,7 +2446,7 @@ BaseFab<T>::maxabs (const Box& subbox, int comp) const noexcept
 {
     Array4<T const> const& a = this->const_array(comp);
 #ifdef AMREX_USE_GPU
-    if (run_on == RunOn::Device and Gpu::inLaunchRegion()) {
+    if (run_on == RunOn::Device && Gpu::inLaunchRegion()) {
         ReduceOps<ReduceOpMax> reduce_op;
         ReduceData<T> reduce_data(reduce_op);
         using ReduceTuple = typename decltype(reduce_data)::Type;
@@ -2477,7 +2477,7 @@ BaseFab<T>::indexFromValue (Box const& subbox, int comp, T const& value) const n
 {
     Array4<T const> const& a = this->const_array(comp);
 #ifdef AMREX_USE_GPU
-    if (run_on == RunOn::Device and Gpu::inLaunchRegion()) {
+    if (run_on == RunOn::Device && Gpu::inLaunchRegion()) {
         Array<int,1+AMREX_SPACEDIM> ha{0,AMREX_D_DECL(std::numeric_limits<int>::lowest(),
                                                       std::numeric_limits<int>::lowest(),
                                                       std::numeric_limits<int>::lowest())};
@@ -2487,7 +2487,7 @@ BaseFab<T>::indexFromValue (Box const& subbox, int comp, T const& value) const n
         amrex::ParallelFor(subbox, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
             int* flag = p;
-            if ((*flag == 0) and (a(i,j,k) == value)) {
+            if ((*flag == 0) && (a(i,j,k) == value)) {
                 if (Gpu::Atomic::Exch(flag,1) == 0) {
                     AMREX_D_TERM(p[1] = i;,
                                  p[2] = j;,
@@ -2571,7 +2571,7 @@ BaseFab<T>::maskLT (BaseFab<int>& mask, T const& val, int comp) const noexcept
     Array4<int> const& m = mask.array();
     Array4<T const> const& a = this->const_array(comp);
 #ifdef AMREX_USE_GPU
-    if (run_on == RunOn::Device and Gpu::inLaunchRegion()) {
+    if (run_on == RunOn::Device && Gpu::inLaunchRegion()) {
         ReduceOps<ReduceOpSum> reduce_op;
         ReduceData<int> reduce_data(reduce_op);
         using ReduceTuple = typename decltype(reduce_data)::Type;
@@ -2617,7 +2617,7 @@ BaseFab<T>::maskLE (BaseFab<int>& mask, T const& val, int comp) const noexcept
     Array4<int> const& m = mask.array();
     Array4<T const> const& a = this->const_array(comp);
 #ifdef AMREX_USE_GPU
-    if (run_on == RunOn::Device and Gpu::inLaunchRegion()) {
+    if (run_on == RunOn::Device && Gpu::inLaunchRegion()) {
         ReduceOps<ReduceOpSum> reduce_op;
         ReduceData<int> reduce_data(reduce_op);
         using ReduceTuple = typename decltype(reduce_data)::Type;
@@ -2663,7 +2663,7 @@ BaseFab<T>::maskEQ (BaseFab<int>& mask, T const& val, int comp) const noexcept
     Array4<int> const& m = mask.array();
     Array4<T const> const& a = this->const_array(comp);
 #ifdef AMREX_USE_GPU
-    if (run_on == RunOn::Device and Gpu::inLaunchRegion()) {
+    if (run_on == RunOn::Device && Gpu::inLaunchRegion()) {
         ReduceOps<ReduceOpSum> reduce_op;
         ReduceData<int> reduce_data(reduce_op);
         using ReduceTuple = typename decltype(reduce_data)::Type;
@@ -2709,7 +2709,7 @@ BaseFab<T>::maskGT (BaseFab<int>& mask, T const& val, int comp) const noexcept
     Array4<int> const& m = mask.array();
     Array4<T const> const& a = this->const_array(comp);
 #ifdef AMREX_USE_GPU
-    if (run_on == RunOn::Device and Gpu::inLaunchRegion()) {
+    if (run_on == RunOn::Device && Gpu::inLaunchRegion()) {
         ReduceOps<ReduceOpSum> reduce_op;
         ReduceData<int> reduce_data(reduce_op);
         using ReduceTuple = typename decltype(reduce_data)::Type;
@@ -2755,7 +2755,7 @@ BaseFab<T>::maskGE (BaseFab<int>& mask, T const& val, int comp) const noexcept
     Array4<int> const& m = mask.array();
     Array4<T const> const& a = this->const_array(comp);
 #ifdef AMREX_USE_GPU
-    if (run_on == RunOn::Device and Gpu::inLaunchRegion()) {
+    if (run_on == RunOn::Device && Gpu::inLaunchRegion()) {
         ReduceOps<ReduceOpSum> reduce_op;
         ReduceData<int> reduce_data(reduce_op);
         using ReduceTuple = typename decltype(reduce_data)::Type;
@@ -2950,7 +2950,7 @@ BaseFab<T>::dot (const Box& xbx, int xcomp,
     Array4<T const> const& ya = y.const_array();
 
 #ifdef AMREX_USE_GPU
-    if (run_on == RunOn::Device and Gpu::inLaunchRegion()) {
+    if (run_on == RunOn::Device && Gpu::inLaunchRegion()) {
         ReduceOps<ReduceOpSum> reduce_op;
         ReduceData<T> reduce_data(reduce_op);
         using ReduceTuple = typename decltype(reduce_data)::Type;
@@ -3002,7 +3002,7 @@ BaseFab<T>::dotmask (const BaseFab<int>& mask, const Box& xbx, int xcomp,
     Array4<int const> const& ma = mask.const_array();
 
 #ifdef AMREX_USE_GPU
-    if (run_on == RunOn::Device and Gpu::inLaunchRegion()) {
+    if (run_on == RunOn::Device && Gpu::inLaunchRegion()) {
         ReduceOps<ReduceOpSum> reduce_op;
         ReduceData<T> reduce_data(reduce_op);
         using ReduceTuple = typename decltype(reduce_data)::Type;
@@ -3527,11 +3527,11 @@ void
 BaseFab<T>::setComplement (T const& x, const Box& bx, DestComp dcomp, NumComps ncomp) noexcept
 {
 #ifdef AMREX_USE_GPU
-    if (run_on == RunOn::Device and Gpu::inLaunchRegion()) {
+    if (run_on == RunOn::Device && Gpu::inLaunchRegion()) {
         Array4<T> const& a = this->array();
         amrex::ParallelFor(this->domain, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
-            if (not bx.contains(IntVect(AMREX_D_DECL(i,j,k)))) {
+            if (! bx.contains(IntVect(AMREX_D_DECL(i,j,k)))) {
                 for (int n = dcomp.i; n < ncomp.n+dcomp.i; ++n) {
                     a(i,j,k,n) = x;
                 }
@@ -3916,7 +3916,7 @@ BaseFab<T>::sum (const Box& bx, DestComp dcomp, NumComps ncomp) const noexcept
     T r = 0;
     Array4<T const> const& a = this->const_array();
 #ifdef AMREX_USE_GPU
-    if (run_on == RunOn::Device and Gpu::inLaunchRegion()) {
+    if (run_on == RunOn::Device && Gpu::inLaunchRegion()) {
         ReduceOps<ReduceOpSum> reduce_op;
         ReduceData<T> reduce_data(reduce_op);
         using ReduceTuple = typename decltype(reduce_data)::Type;
@@ -3956,7 +3956,7 @@ BaseFab<T>::dot (const BaseFab<T>& src, const Box& bx, SrcComp scomp, DestComp d
     Array4<T const> const& d = this->const_array();
     Array4<T const> const& s = src.const_array();
 #ifdef AMREX_USE_GPU
-    if (run_on == RunOn::Device and Gpu::inLaunchRegion()) {
+    if (run_on == RunOn::Device && Gpu::inLaunchRegion()) {
         ReduceOps<ReduceOpSum> reduce_op;
         ReduceData<T> reduce_data(reduce_op);
         using ReduceTuple = typename decltype(reduce_data)::Type;
@@ -4002,7 +4002,7 @@ BaseFab<T>::dot (const Box& bx, DestComp dcomp, NumComps ncomp) const noexcept
     T r = 0;
     Array4<T const> const& a = this->const_array();
 #ifdef AMREX_USE_GPU
-    if (run_on == RunOn::Device and Gpu::inLaunchRegion()) {
+    if (run_on == RunOn::Device && Gpu::inLaunchRegion()) {
         ReduceOps<ReduceOpSum> reduce_op;
         ReduceData<T> reduce_data(reduce_op);
         using ReduceTuple = typename decltype(reduce_data)::Type;
@@ -4045,7 +4045,7 @@ BaseFab<T>::dotmask (const BaseFab<T>& src, const Box& bx, const BaseFab<int>& m
     Array4<T const> const& s = src.const_array();
     Array4<int const> const& m = mask.const_array();
 #ifdef AMREX_USE_GPU
-    if (run_on == RunOn::Device and Gpu::inLaunchRegion()) {
+    if (run_on == RunOn::Device && Gpu::inLaunchRegion()) {
         ReduceOps<ReduceOpSum> reduce_op;
         ReduceData<T> reduce_data(reduce_op);
         using ReduceTuple = typename decltype(reduce_data)::Type;

--- a/Src/Base/AMReX_BlockMutex.cpp
+++ b/Src/Base/AMReX_BlockMutex.cpp
@@ -21,7 +21,7 @@ void BlockMutex::init_states (state_t* state, int N) noexcept {
 BlockMutex::BlockMutex (int N) noexcept
     : m_nstates(N)
 {
-    static_assert(sizeof(unsigned long long) == 2*sizeof(int) and
+    static_assert(sizeof(unsigned long long) == 2*sizeof(int) &&
                   sizeof(unsigned long long) == sizeof(state_t),
                   "BlockMutex: wrong size");
     // The first 4 bytes of unsigned long stores blockIdx.

--- a/Src/Base/AMReX_BoxArray.H
+++ b/Src/Base/AMReX_BoxArray.H
@@ -219,9 +219,9 @@ struct BATbndryReg
     IntVect coarsen_ratio () const noexcept { return m_crse_ratio; }
 
     friend bool operator== (BATbndryReg const& a, BATbndryReg const& b) noexcept {
-        return a.m_face == b.m_face and a.m_typ == b.m_typ and a.m_crse_ratio == b.m_crse_ratio
-            and a.m_loshft == b.m_loshft and a.m_hishft == b.m_hishft
-            and a.m_doilo == b.m_doilo and a.m_doihi == b.m_doihi;
+        return a.m_face == b.m_face && a.m_typ == b.m_typ && a.m_crse_ratio == b.m_crse_ratio
+            && a.m_loshft == b.m_loshft && a.m_hishft == b.m_hishft
+            && a.m_doilo == b.m_doilo && a.m_doihi == b.m_doihi;
     }
 
     Orientation m_face;
@@ -498,7 +498,7 @@ struct BATransformer
                 return false;
             default:
                 return a.index_type() == b.index_type()
-                    and a.coarsen_ratio() == b.coarsen_ratio();
+                    && a.coarsen_ratio() == b.coarsen_ratio();
             }
         }
     }

--- a/Src/Base/AMReX_BoxArray.cpp
+++ b/Src/Base/AMReX_BoxArray.cpp
@@ -466,7 +466,7 @@ BoxArray::readFrom (std::istream& is)
     clear();
     int ndims;
     m_ref->define(is, ndims);
-    if (not m_ref->m_abox.empty()) {
+    if (! m_ref->m_abox.empty()) {
         m_bat = BATransformer(m_ref->m_abox[0].ixType());
         type_update();
     }
@@ -510,7 +510,7 @@ BoxArray::writeOn (std::ostream& os) const
 bool
 BoxArray::operator== (const BoxArray& rhs) const noexcept
 {
-    return m_bat == rhs.m_bat and
+    return m_bat == rhs.m_bat &&
         (m_ref == rhs.m_ref || m_ref->m_abox == rhs.m_ref->m_abox);
 }
 
@@ -552,7 +552,7 @@ BoxArray::maxSize (int block_size)
 BoxArray&
 BoxArray::maxSize (const IntVect& block_size)
 {
-    if ((not m_bat.is_simple()) or (crseRatio() != IntVect::TheUnitVector())) {
+    if ((! m_bat.is_simple()) || (crseRatio() != IntVect::TheUnitVector())) {
         uniqify();
     }
     BoxList blst(*this);
@@ -872,17 +872,17 @@ BoxArray::ok () const
         auto const& bxs = this->m_ref->m_abox;
         if (m_bat.is_null()) {
             for (int i = 0; i < N; ++i) {
-                if (not bxs[i].ok()) return false;
+                if (! bxs[i].ok()) return false;
             }
         } else if (m_bat.is_simple()) {
             IndexType t = ixType();
             IntVect cr = crseRatio();
             for (int i = 0; i < N; ++i) {
-                if (not amrex::convert(amrex::coarsen(bxs[i],cr),t).ok()) return false;
+                if (! amrex::convert(amrex::coarsen(bxs[i],cr),t).ok()) return false;
             }
         } else {
             for (int i = 0; i < N; ++i) {
-                if (not m_bat.m_op.m_bndryReg(bxs[i]).ok()) return false;
+                if (! m_bat.m_op.m_bndryReg(bxs[i]).ok()) return false;
             }
         }
     }
@@ -1461,7 +1461,7 @@ BoxArray::type_update ()
 {
     if (!empty())
     {
-	if (not ixType().cellCentered())
+	if (! ixType().cellCentered())
 	{
             for (auto& bx : m_ref->m_abox) {
 		bx.enclosedCells();

--- a/Src/Base/AMReX_CuptiTrace.cpp
+++ b/Src/Base/AMReX_CuptiTrace.cpp
@@ -90,7 +90,7 @@ bfrCompleteCallback (CUcontext ctx, uint32_t streamId, uint8_t* bfr,
 
         size_t dropped;
         cuptiActivityGetNumDroppedRecords(ctx, streamId, &dropped);
-        if (dropped != 0 and amrex::Verbose() > 1) {
+        if (dropped != 0 && amrex::Verbose() > 1) {
             amrex::AllPrint() << (unsigned int) dropped
                               << " activity records were dropped due to insufficient buffer space\n";
         }

--- a/Src/Base/AMReX_FArrayBox.H
+++ b/Src/Base/AMReX_FArrayBox.H
@@ -510,7 +510,7 @@ FArrayBox::contains_nan () const noexcept
     const Real* dp = dptr;
     const Long n = numPts()*nvar;
 #ifdef AMREX_USE_GPU
-    if (run_on == RunOn::Device and Gpu::inLaunchRegion()) {
+    if (run_on == RunOn::Device && Gpu::inLaunchRegion()) {
         ReduceOps<ReduceOpLogicalOr> reduce_op;
         ReduceData<int> reduce_data(reduce_op);
         using ReduceTuple = ReduceData<int>::Type;
@@ -546,7 +546,7 @@ FArrayBox::contains_nan (const Box& bx, int scomp, int ncomp) const noexcept
     const auto& a = this->array();
 
 #ifdef AMREX_USE_GPU
-    if (run_on == RunOn::Device and Gpu::inLaunchRegion()) {
+    if (run_on == RunOn::Device && Gpu::inLaunchRegion()) {
         ReduceOps<ReduceOpLogicalOr> reduce_op;
         ReduceData<int> reduce_data(reduce_op);
         using ReduceTuple = ReduceData<int>::Type;
@@ -555,7 +555,7 @@ FArrayBox::contains_nan (const Box& bx, int scomp, int ncomp) const noexcept
         {
             bool t = false;
             for (int n = scomp; n < scomp+ncomp; ++n) {
-                t = t or amrex::isnan(a(i,j,k,n));
+                t = t || amrex::isnan(a(i,j,k,n));
             }
             return { static_cast<int>(t) };
         });
@@ -600,7 +600,7 @@ FArrayBox::contains_nan (const Box& bx, int scomp, int ncomp, IntVect& where) co
 
     const auto& a = this->array();
 #ifdef AMREX_USE_GPU
-    if (run_on == RunOn::Device and Gpu::inLaunchRegion()) {
+    if (run_on == RunOn::Device && Gpu::inLaunchRegion()) {
         Array<int,1+AMREX_SPACEDIM> ha{0,AMREX_D_DECL(std::numeric_limits<int>::lowest(),
                                                       std::numeric_limits<int>::lowest(),
                                                       std::numeric_limits<int>::lowest())};
@@ -612,9 +612,9 @@ FArrayBox::contains_nan (const Box& bx, int scomp, int ncomp, IntVect& where) co
             int* flag = p;
             bool t = false;
             for (int n = scomp; n < scomp+ncomp; ++n) {
-                t = t or amrex::isnan(a(i,j,k,n));
+                t = t || amrex::isnan(a(i,j,k,n));
             }
-            if (t and (*flag == 0)) {
+            if (t && (*flag == 0)) {
                 if (Gpu::Atomic::Exch(flag,1) == 0) {
                     AMREX_D_TERM(p[1] = i;,
                                  p[2] = j;,
@@ -654,7 +654,7 @@ FArrayBox::contains_inf () const noexcept
     const Real* dp = dptr;
     const Long n = numPts()*nvar;
 #ifdef AMREX_USE_GPU
-    if (run_on == RunOn::Device and Gpu::inLaunchRegion()) {
+    if (run_on == RunOn::Device && Gpu::inLaunchRegion()) {
         ReduceOps<ReduceOpLogicalOr> reduce_op;
         ReduceData<int> reduce_data(reduce_op);
         using ReduceTuple = ReduceData<int>::Type;
@@ -690,7 +690,7 @@ FArrayBox::contains_inf (const Box& bx, int scomp, int ncomp) const noexcept
     const auto& a = this->array();
 
 #ifdef AMREX_USE_GPU
-    if (run_on == RunOn::Device and Gpu::inLaunchRegion()) {
+    if (run_on == RunOn::Device && Gpu::inLaunchRegion()) {
         ReduceOps<ReduceOpLogicalOr> reduce_op;
         ReduceData<int> reduce_data(reduce_op);
         using ReduceTuple = ReduceData<int>::Type;
@@ -699,7 +699,7 @@ FArrayBox::contains_inf (const Box& bx, int scomp, int ncomp) const noexcept
         {
             bool t = false;
             for (int n = scomp; n < scomp+ncomp; ++n) {
-                t = t or amrex::isinf(a(i,j,k,n));
+                t = t || amrex::isinf(a(i,j,k,n));
             }
             return { static_cast<int>(t) };
         });
@@ -744,7 +744,7 @@ FArrayBox::contains_inf (const Box& bx, int scomp, int ncomp, IntVect& where) co
 
     const auto& a = this->array();
 #ifdef AMREX_USE_GPU
-    if (run_on == RunOn::Device and Gpu::inLaunchRegion()) {
+    if (run_on == RunOn::Device && Gpu::inLaunchRegion()) {
         Array<int,1+AMREX_SPACEDIM> ha{0,AMREX_D_DECL(std::numeric_limits<int>::lowest(),
                                                       std::numeric_limits<int>::lowest(),
                                                       std::numeric_limits<int>::lowest())};
@@ -756,9 +756,9 @@ FArrayBox::contains_inf (const Box& bx, int scomp, int ncomp, IntVect& where) co
             int* flag = p;
             bool t = false;
             for (int n = scomp; n < scomp+ncomp; ++n) {
-                t = t or amrex::isinf(a(i,j,k,n));
+                t = t || amrex::isinf(a(i,j,k,n));
             }
-            if (t and (*flag == 0)) {
+            if (t && (*flag == 0)) {
                 if (Gpu::Atomic::Exch(flag,1) == 0) {
                     AMREX_D_TERM(p[1] = i;,
                                  p[2] = j;,

--- a/Src/Base/AMReX_FArrayBox.cpp
+++ b/Src/Base/AMReX_FArrayBox.cpp
@@ -156,7 +156,7 @@ FArrayBox::initVal () noexcept
 {
     Real * p = dataPtr();
     Long s = size();
-    if (p and s > 0) {
+    if (p && s > 0) {
         RunOn runon;
 #if defined(AMREX_USE_GPU)
         if ( Gpu::inLaunchRegion() && 

--- a/Src/Base/AMReX_FBI.H
+++ b/Src/Base/AMReX_FBI.H
@@ -107,7 +107,7 @@ ParallelFor_doit (Vector<TagType> const& tags, F && f)
             while (lo <= hi)
             {
                 int mid = (lo+hi)/2;
-                if (g_wid >= d_nwarps[mid] and g_wid < d_nwarps[mid+1]) {
+                if (g_wid >= d_nwarps[mid] && g_wid < d_nwarps[mid+1]) {
                     tag_id = mid;
                     break;
                 } else if (g_wid < d_nwarps[mid]) {
@@ -439,7 +439,7 @@ FabArray<FAB>::FB_local_copy_gpu (const FB& TheFB, int scomp, int ncomp)
 
     Vector<BaseFab<int> > maskfabs;
     Vector<Array4<int> > masks;
-    if (!amrex::IsStoreAtomic<value_type>::value and !is_thread_safe)
+    if (!amrex::IsStoreAtomic<value_type>::value && !is_thread_safe)
     {
         maskfabs.resize(this->local_size());
         masks.reserve(N_locs);
@@ -504,7 +504,7 @@ FabArray<FAB>::CMD_local_setVal_gpu (typename FabArray<FAB>::value_type x,
     Vector<TagType> loc_setval_tags;
     loc_setval_tags.reserve(N_locs);
 
-    AMREX_ALWAYS_ASSERT(amrex::IsStoreAtomic<value_type>::value or is_thread_safe);
+    AMREX_ALWAYS_ASSERT(amrex::IsStoreAtomic<value_type>::value || is_thread_safe);
 
     for (int i = 0; i < N_locs; ++i)
     {
@@ -539,7 +539,7 @@ FabArray<FAB>::CMD_remote_setVal_gpu (typename FabArray<FAB>::value_type x,
 
     if (rcv_setval_tags.empty()) return;
 
-    AMREX_ALWAYS_ASSERT(amrex::IsStoreAtomic<value_type>::value or is_thread_safe);
+    AMREX_ALWAYS_ASSERT(amrex::IsStoreAtomic<value_type>::value || is_thread_safe);
 
     amrex::ParallelFor(rcv_setval_tags, ncomp,
     [x,scomp] AMREX_GPU_DEVICE (int i, int j, int k, int n, TagType const& tag) noexcept
@@ -904,7 +904,7 @@ FabArray<FAB>::pack_send_buffer_gpu (FabArray<FAB> const& src, int scomp, int nc
 #if 0
     // For linear solver test on summit, this is slower than writing to
     // pinned memory directly on device.
-    if (not ParallelDescriptor::UseGpuAwareMpi()) {
+    if (! ParallelDescriptor::UseGpuAwareMpi()) {
         // Memory in send_data is pinned.
         szbuffer = (send_data[N_snds-1]-send_data[0]) + send_size[N_snds-1];
         pbuffer = (char*)The_Arena()->alloc(szbuffer);
@@ -964,7 +964,7 @@ FabArray<FAB>::unpack_recv_buffer_gpu (FabArray<FAB>& dst, int dcomp, int ncomp,
     std::size_t szbuffer = 0;
     // For linear solver test on summit, this is slower than writing to
     // pinned memory directly on device.
-    if (not ParallelDescriptor::UseGpuAwareMpi()) {
+    if (! ParallelDescriptor::UseGpuAwareMpi()) {
         // Memory in recv_data is pinned.
         szbuffer = (recv_data[N_rcvs-1]-recv_data[0]) + recv_size[N_rcvs-1];
         pbuffer = (char*)The_Arena()->alloc(szbuffer);
@@ -981,8 +981,8 @@ FabArray<FAB>::unpack_recv_buffer_gpu (FabArray<FAB>& dst, int dcomp, int ncomp,
     Vector<Array4<int> > masks;
     if (!is_thread_safe)
     {
-        if ((op == FabArrayBase::COPY and !amrex::IsStoreAtomic<value_type>::value) or
-            (op == FabArrayBase::ADD  and !amrex::HasAtomicAdd <value_type>::value))
+        if ((op == FabArrayBase::COPY && !amrex::IsStoreAtomic<value_type>::value) ||
+            (op == FabArrayBase::ADD  && !amrex::HasAtomicAdd <value_type>::value))
         {
             maskfabs.resize(dst.local_size());
         }

--- a/Src/Base/AMReX_FabArray.H
+++ b/Src/Base/AMReX_FabArray.H
@@ -1512,7 +1512,7 @@ FabArray<FAB>::setDomainBndry (value_type val,
     for (MFIter fai(*this); fai.isValid(); ++fai)
     {
         const Box& gbx = fai.fabbox();
-        if (not domain_box.contains(gbx))
+        if (! domain_box.contains(gbx))
         {
             get(fai).template setComplement<RunOn::Device>(val, domain_box, strt_comp, ncomp);
         }

--- a/Src/Base/AMReX_FabArrayBase.cpp
+++ b/Src/Base/AMReX_FabArrayBase.cpp
@@ -399,8 +399,8 @@ FabArrayBase::CPC::define (const BoxArray& ba_dst, const DistributionMapping& dm
 	    check_local = true;
 	}
 
-        m_threadsafe_loc = not check_local;
-        m_threadsafe_rcv = not check_remote;
+        m_threadsafe_loc = ! check_local;
+        m_threadsafe_rcv = ! check_remote;
 
 	for (int i = 0; i < nlocal_dst; ++i)
 	{
@@ -733,8 +733,8 @@ FabArrayBase::FB::define_fb (const FabArrayBase& fa)
         check_local = true;
     }
 
-    m_threadsafe_loc = not check_local;
-    m_threadsafe_rcv = not check_remote;
+    m_threadsafe_loc = ! check_local;
+    m_threadsafe_rcv = ! check_remote;
 
     for (int i = 0; i < nlocal; ++i)
     {
@@ -953,8 +953,8 @@ FabArrayBase::FB::define_epo (const FabArrayBase& fa)
 	check_local = true;
     }
 
-    m_threadsafe_loc = not check_local;
-    m_threadsafe_rcv = not check_remote;
+    m_threadsafe_loc = ! check_local;
+    m_threadsafe_rcv = ! check_remote;
 
     for (int i = 0; i < nlocal; ++i)
     {

--- a/Src/Base/AMReX_FabArrayUtility.H
+++ b/Src/Base/AMReX_FabArrayUtility.H
@@ -1641,7 +1641,7 @@ void
 prefetchToHost (FabArray<FAB> const& fa, const bool synchronous = true)
 {
 #ifdef AMREX_USE_GPU
-    if (fa.arena() == The_Arena() or fa.arena() == The_Managed_Arena()) {
+    if (fa.arena() == The_Arena() || fa.arena() == The_Managed_Arena()) {
         for (MFIter mfi(fa, MFItInfo().SetDeviceSync(synchronous)); mfi.isValid(); ++mfi) {
             fa.prefetchToHost(mfi);
         }
@@ -1656,7 +1656,7 @@ void
 prefetchToDevice (FabArray<FAB> const& fa, const bool synchronous = true)
 {
 #ifdef AMREX_USE_GPU
-    if (fa.arena() == The_Arena() or fa.arena() == The_Managed_Arena()) {
+    if (fa.arena() == The_Arena() || fa.arena() == The_Managed_Arena()) {
         for (MFIter mfi(fa, MFItInfo().SetDeviceSync(synchronous)); mfi.isValid(); ++mfi) {
             fa.prefetchToDevice(mfi);
         }

--- a/Src/Base/AMReX_FilCC_C.cpp
+++ b/Src/Base/AMReX_FilCC_C.cpp
@@ -327,15 +327,15 @@ void fab_filcc (Box const& bx, Array4<Real> const& qn, int ncomp,
         //
         // First correct the i-j edges and all corners
         //
-        if (bc.lo(0) == BCType::hoextrap and bc.lo(1) == BCType::hoextrap) {
-            if (lo.x < ilo and lo.y < jlo) {
+        if (bc.lo(0) == BCType::hoextrap && bc.lo(1) == BCType::hoextrap) {
+            if (lo.x < ilo && lo.y < jlo) {
                 const int imin = lo.x;
                 const int imax = std::min(hi.x,ilo-1);
                 const int jmin = lo.y;
                 const int jmax = std::min(hi.y,jlo-1);
                 const int i = ilo-1;
                 const int j = jlo-1;
-                if (i>=imin and i<=imax and j>=jmin and j<=jmax) {
+                if (i>=imin && i<=imax && j>=jmin && j<=jmax) {
                     for (int k = lo.z; k <= hi.z; ++k) {
                         if (jlo+2 <= je) {
                             q(i,j,k) = 0.5 * (1./8.) * (15.*q(ilo-1,jlo,k) - 10.*q(ilo-1,jlo+1,k) + 3.*q(ilo-1,jlo+2,k));
@@ -352,7 +352,7 @@ void fab_filcc (Box const& bx, Array4<Real> const& qn, int ncomp,
 
 #if AMREX_SPACEDIM == 3
 
-                        if (k == klo-1 and bc.lo(2) == BCType::hoextrap) {
+                        if (k == klo-1 && bc.lo(2) == BCType::hoextrap) {
                             if (klo+2 <= ke) {
                                 q(i,j,k) = (1./8.) * ( (15.*q(ilo-1,jlo-1,klo) - 10.*q(ilo-1,jlo-1,klo+1) +
                                                           3.*q(ilo-1,jlo-1,klo+2)) );
@@ -361,7 +361,7 @@ void fab_filcc (Box const& bx, Array4<Real> const& qn, int ncomp,
                             }
                         }
 
-                        if (k == khi+1 and bc.hi(2) == BCType::hoextrap) {
+                        if (k == khi+1 && bc.hi(2) == BCType::hoextrap) {
                             if (khi-2 >= ks) {
                                 q(i,j,k) = (1./8.) * ( (15.*q(ilo-1,jlo-1,khi) - 10.*q(ilo-1,jlo-1,khi-1) +
                                                           3.*q(ilo-1,jlo-1,khi-2)) );
@@ -379,15 +379,15 @@ void fab_filcc (Box const& bx, Array4<Real> const& qn, int ncomp,
         // *********************************************************************
         //
 
-        if (bc.lo(0) == BCType::hoextrap and bc.hi(1) == BCType::hoextrap) {
-            if (lo.x < ilo and hi.y > jhi) {
+        if (bc.lo(0) == BCType::hoextrap && bc.hi(1) == BCType::hoextrap) {
+            if (lo.x < ilo && hi.y > jhi) {
                 const int imin = lo.x;
                 const int imax = std::min(hi.x,ilo-1);
                 const int jmin = std::max(lo.y,jhi+1);
                 const int jmax = hi.y;
                 const int i = ilo-1;
                 const int j = jhi+1;
-                if (i>=imin and i<=imax and j>=jmin and j<=jmax) {
+                if (i>=imin && i<=imax && j>=jmin && j<=jmax) {
                     for (int k = lo.z; k <= hi.z; ++k) {
                         if (jhi-2 >= js) {
                             q(i,j,k) = 0.5 * (1./8.) * (15.*q(ilo-1,jhi,k) - 10.*q(ilo-1,jhi-1,k) + 3.*q(ilo-1,jhi-2,k));
@@ -403,7 +403,7 @@ void fab_filcc (Box const& bx, Array4<Real> const& qn, int ncomp,
                    }
 
 #if (AMREX_SPACEDIM == 3)
-                        if (k == klo-1 and bc.lo(2) == BCType::hoextrap) {
+                        if (k == klo-1 && bc.lo(2) == BCType::hoextrap) {
                             if (klo+2 <= ke) {
                                 q(i,j,k) = (1./8.) * ( (15.*q(ilo-1,jhi+1,klo) - 10.*q(ilo-1,jhi+1,klo+1) +
                                                           3.*q(ilo-1,jhi+1,klo+2)) );
@@ -412,7 +412,7 @@ void fab_filcc (Box const& bx, Array4<Real> const& qn, int ncomp,
                             }
                         }
 
-                        if (k == khi+1 and bc.hi(2) == BCType::hoextrap) {
+                        if (k == khi+1 && bc.hi(2) == BCType::hoextrap) {
                             if (khi-2 >= ks) {
                                 q(i,j,k) = (1./8.) * ( (15.*q(ilo-1,jhi+1,khi) - 10.*q(ilo-1,jhi+1,khi-1) +
                                                           3.*q(ilo-1,jhi+1,khi-2)) );
@@ -430,15 +430,15 @@ void fab_filcc (Box const& bx, Array4<Real> const& qn, int ncomp,
         // **********************************************************************
         //
 
-        if (bc.hi(0) == BCType::hoextrap and bc.lo(1) == BCType::hoextrap) {
-            if (hi.x > ihi and lo.y < jlo) {
+        if (bc.hi(0) == BCType::hoextrap && bc.lo(1) == BCType::hoextrap) {
+            if (hi.x > ihi && lo.y < jlo) {
                 const int imin = std::max(lo.x,ihi+1);
                 const int imax = hi.x;
                 const int jmin = lo.y;
                 const int jmax = std::min(hi.y,jlo-1);
                 const int i = ihi+1;
                 const int j = jlo-1;
-                if (i>=imin and i<=imax and j>=jmin and j<=jmax) {
+                if (i>=imin && i<=imax && j>=jmin && j<=jmax) {
                     for (int k = lo.z; k <= hi.z; ++k) {
                         if (jlo+2 <= je) {
                             q(i,j,k) = 0.5 * (1./8.) * (15.*q(ihi+1,jlo,k) - 10.*q(ihi+1,jlo+1,k) + 3.*q(ihi+1,jlo+2,k));
@@ -454,7 +454,7 @@ void fab_filcc (Box const& bx, Array4<Real> const& qn, int ncomp,
                         }
 
 #if (AMREX_SPACEDIM == 3)
-                        if (k == klo-1 and bc.lo(2) == BCType::hoextrap) {
+                        if (k == klo-1 && bc.lo(2) == BCType::hoextrap) {
                             if (klo+2 <= ke) {
                                 q(i,j,k) = (1./8.) * (15.*q(ihi+1,jlo-1,klo) - 10.*q(ihi+1,jlo-1,klo+1) + 3.*q(ihi+1,jlo-1,klo+2));
                             } else {
@@ -462,7 +462,7 @@ void fab_filcc (Box const& bx, Array4<Real> const& qn, int ncomp,
                             }
                         }
 
-                        if (k == khi+1 and bc.hi(2) == BCType::hoextrap) {
+                        if (k == khi+1 && bc.hi(2) == BCType::hoextrap) {
                             if (khi-2 >= ks) {
                                 q(i,j,k) = (1./8.) * (15.*q(ihi+1,jlo-1,khi) - 10.*q(ihi+1,jlo-1,khi-1) + 3.*q(ihi+1,jlo-1,khi-2));
                             } else {
@@ -479,15 +479,15 @@ void fab_filcc (Box const& bx, Array4<Real> const& qn, int ncomp,
         // **********************************************************************
         //
 
-        if (bc.hi(0) == BCType::hoextrap and bc.hi(1) == BCType::hoextrap) {
-            if (hi.x > ihi and hi.y > jhi) {
+        if (bc.hi(0) == BCType::hoextrap && bc.hi(1) == BCType::hoextrap) {
+            if (hi.x > ihi && hi.y > jhi) {
                 const int imin = std::max(lo.x,ihi+1);
                 const int imax = hi.x;
                 const int jmin = std::max(lo.y,jhi+1);
                 const int jmax = hi.y;
                 const int i = ihi+1;
                 const int j = jhi+1;
-                if (i>=imin and i<=imax and j>=jmin and j<=jmax) {
+                if (i>=imin && i<=imax && j>=jmin && j<=jmax) {
                     for (int k = lo.z; k <= hi.z; ++k) {
                         if (jhi-2 >= js) {
                             q(i,j,k) = 0.5 * (1./8.) * (15.*q(ihi+1,jhi,k) - 10.*q(ihi+1,jhi-1,k) + 3.*q(ihi+1,jhi-2,k));
@@ -503,7 +503,7 @@ void fab_filcc (Box const& bx, Array4<Real> const& qn, int ncomp,
                         }
 
 #if (AMREX_SPACEDIM == 3)
-                        if (k == klo-1 and bc.lo(2) == BCType::hoextrap) {
+                        if (k == klo-1 && bc.lo(2) == BCType::hoextrap) {
                             if (klo+2 <= ke) {
                                 q(i,j,k) = (1./8.) * (15.*q(ihi+1,jhi+1,klo) - 10.*q(ihi+1,jhi+1,klo+1) + 3.*q(ihi+1,jhi+1,klo+2));
                             } else {
@@ -511,7 +511,7 @@ void fab_filcc (Box const& bx, Array4<Real> const& qn, int ncomp,
                             }
                         }
 
-                        if (k == khi+1 and bc.hi(2) == BCType::hoextrap) {
+                        if (k == khi+1 && bc.hi(2) == BCType::hoextrap) {
                             if (khi-2 >= ks) {
                                 q(i,j,k) = (1./8.) * (15.*q(ihi+1,jhi+1,khi) - 10.*q(ihi+1,jhi+1,khi-1) + 3.*q(ihi+1,jhi+1,khi-2));
                             } else {
@@ -530,15 +530,15 @@ void fab_filcc (Box const& bx, Array4<Real> const& qn, int ncomp,
         // Next correct the i-k edges
         //
 
-        if (bc.lo(0) == BCType::hoextrap and bc.lo(2) == BCType::hoextrap) {
-            if (lo.x < ilo and lo.z < klo) {
+        if (bc.lo(0) == BCType::hoextrap && bc.lo(2) == BCType::hoextrap) {
+            if (lo.x < ilo && lo.z < klo) {
                 const int imin = lo.x;
                 const int imax = std::min(hi.x,ilo-1);
                 const int kmin = lo.z;
                 const int kmax = std::min(hi.z,klo-1);
                 const int i = ilo-1;
                 const int k = klo-1;
-                if (i>=imin and i<=imax and k>=kmin and k<=kmax) {
+                if (i>=imin && i<=imax && k>=kmin && k<=kmax) {
                     for (int j = lo.y; j <= hi.y; ++j) {
                         if (klo+2 <= ke) {
                             q(i,j,k) = 0.5 * (1./8.) * (15.*q(ilo-1,j,klo) - 10.*q(ilo-1,j,klo+1) + 3.*q(ilo-1,j,klo+2));
@@ -561,15 +561,15 @@ void fab_filcc (Box const& bx, Array4<Real> const& qn, int ncomp,
         // **********************************************************************
         //
 
-        if (bc.lo(0) == BCType::hoextrap and bc.hi(2) == BCType::hoextrap) {
-            if (lo.x < ilo and hi.z > khi) {
+        if (bc.lo(0) == BCType::hoextrap && bc.hi(2) == BCType::hoextrap) {
+            if (lo.x < ilo && hi.z > khi) {
                 const int imin = lo.x;
                 const int imax = std::min(hi.x,ilo-1);
                 const int kmin = std::max(lo.z,khi+1);
                 const int kmax = hi.z;
                 const int i = ilo-1;
                 const int k = khi+1;
-                if (i>=imin and i<=imax and k>=kmin and k<=kmax) {
+                if (i>=imin && i<=imax && k>=kmin && k<=kmax) {
                     for (int j = lo.y; j <= hi.y; ++j) {
                         if (khi-2 >= ks) {
                             q(i,j,k) = 0.5 * (1./8.) * (15.*q(ilo-1,j,khi) - 10.*q(ilo-1,j,khi-1) + 3.*q(ilo-1,j,khi-2));
@@ -592,15 +592,15 @@ void fab_filcc (Box const& bx, Array4<Real> const& qn, int ncomp,
         // **********************************************************************
         //
 
-        if (bc.hi(0) == BCType::hoextrap and bc.lo(2) == BCType::hoextrap) {
-            if (hi.x > ihi and lo.z < klo) {
+        if (bc.hi(0) == BCType::hoextrap && bc.lo(2) == BCType::hoextrap) {
+            if (hi.x > ihi && lo.z < klo) {
                 const int imin = std::max(lo.x,ihi+1);
                 const int imax = hi.x;
                 const int kmin = lo.z;
                 const int kmax = std::min(hi.z,klo-1);
                 const int i = ihi+1;
                 const int k = klo-1;
-                if (i>=imin and i<=imax and k>=kmin and k<=kmax) {
+                if (i>=imin && i<=imax && k>=kmin && k<=kmax) {
                     for (int j = lo.y; j <= hi.y; ++j) {
                         if (klo+2 <= ke) {
                             q(i,j,k) = 0.5 * (1./8.) * (15.*q(ihi+1,j,klo) - 10.*q(ihi+1,j,klo+1) + 3.*q(ihi+1,j,klo+2));
@@ -623,15 +623,15 @@ void fab_filcc (Box const& bx, Array4<Real> const& qn, int ncomp,
         // **********************************************************************
         //
 
-        if (bc.hi(0) == BCType::hoextrap and bc.hi(2) == BCType::hoextrap) {
-            if (hi.x > ihi and hi.z > khi) {
+        if (bc.hi(0) == BCType::hoextrap && bc.hi(2) == BCType::hoextrap) {
+            if (hi.x > ihi && hi.z > khi) {
                 const int imin = std::max(lo.x,ihi+1);
                 const int imax = hi.x;
                 const int kmin = std::max(lo.z,khi+1);
                 const int kmax = hi.z;
                 const int i = ihi+1;
                 const int k = khi+1;
-                if (i>=imin and i<=imax and k>=kmin and k<=kmax) {
+                if (i>=imin && i<=imax && k>=kmin && k<=kmax) {
                     for (int j = lo.y; j <= hi.y; ++j) {
                         if (khi-2 >= ks) {
                             q(i,j,k) = 0.5 * (1./8.) * (15.*q(ihi+1,j,khi) - 10.*q(ihi+1,j,khi-1) + 3.*q(ihi+1,j,khi-2));
@@ -654,15 +654,15 @@ void fab_filcc (Box const& bx, Array4<Real> const& qn, int ncomp,
         // Next correct the j-k edges
         //
 
-        if (bc.lo(1) == BCType::hoextrap and bc.lo(2) == BCType::hoextrap) {
-            if (lo.y < jlo and lo.z < klo) {
+        if (bc.lo(1) == BCType::hoextrap && bc.lo(2) == BCType::hoextrap) {
+            if (lo.y < jlo && lo.z < klo) {
                 const int jmin = lo.y;
                 const int jmax = std::min(hi.y,jlo-1);
                 const int kmin = lo.z;
                 const int kmax = std::min(hi.z,klo-1);
                 const int j = jlo-1;
                 const int k = klo-1;
-                if (j>=jmin and j<=jmax and k>=kmin and k<=kmax) {
+                if (j>=jmin && j<=jmax && k>=kmin && k<=kmax) {
                     for (int i = lo.x; i <= hi.x; ++i) {
                         if (klo+2 <= ke) {
                             q(i,j,k) = 0.5 * (1./8.) * (15.*q(i,jlo-1,klo) - 10.*q(i,jlo-1,klo+1) + 3.*q(i,jlo-1,klo+2));
@@ -685,15 +685,15 @@ void fab_filcc (Box const& bx, Array4<Real> const& qn, int ncomp,
         // **********************************************************************
         //
 
-        if (bc.lo(1) == BCType::hoextrap and bc.hi(2) == BCType::hoextrap) {
-            if (lo.y < jlo and hi.z > khi) {
+        if (bc.lo(1) == BCType::hoextrap && bc.hi(2) == BCType::hoextrap) {
+            if (lo.y < jlo && hi.z > khi) {
                 const int jmin = lo.y;
                 const int jmax = std::min(hi.y,jlo-1);
                 const int kmin = std::max(lo.z,khi+1);
                 const int kmax = hi.z;
                 const int j = jlo-1;
                 const int k = khi+1;
-                if (j>=jmin and j<=jmax and k>=kmin and k<=kmax) {
+                if (j>=jmin && j<=jmax && k>=kmin && k<=kmax) {
                     for (int i = lo.x; i <= hi.x; ++i) {
                         if (khi-2 >= ks) {
                             q(i,j,k) = 0.5 * (1./8.) * (15.*q(i,jlo-1,khi) - 10.*q(i,jlo-1,khi-1) + 3.*q(i,jlo-1,khi-2));
@@ -716,15 +716,15 @@ void fab_filcc (Box const& bx, Array4<Real> const& qn, int ncomp,
         // **********************************************************************
         //
 
-        if (bc.hi(1) == BCType::hoextrap and bc.lo(2) == BCType::hoextrap) {
-            if (hi.y > jhi and lo.z < klo) {
+        if (bc.hi(1) == BCType::hoextrap && bc.lo(2) == BCType::hoextrap) {
+            if (hi.y > jhi && lo.z < klo) {
                 const int jmin = std::max(lo.y,jhi+1);
                 const int jmax = hi.y;
                 const int kmin = lo.z;
                 const int kmax = std::min(hi.z,klo-1);
                 const int j = jhi+1;
                 const int k = klo-1;
-                if (j>=jmin and j<=jmax and k>=kmin and k<=kmax) {
+                if (j>=jmin && j<=jmax && k>=kmin && k<=kmax) {
                     for (int i = lo.x; i <= hi.x; ++i) {
                         if (klo+2 <= ke) {
                             q(i,j,k) = 0.5 * (1./8.) * (15.*q(i,jhi+1,klo) - 10.*q(i,jhi+1,klo+1) + 3.*q(i,jhi+1,klo+2));
@@ -747,15 +747,15 @@ void fab_filcc (Box const& bx, Array4<Real> const& qn, int ncomp,
         // **********************************************************************
         //
 
-        if (bc.hi(1) == BCType::hoextrap and bc.hi(2) == BCType::hoextrap) {
-            if (hi.y > jhi and hi.z > khi) {
+        if (bc.hi(1) == BCType::hoextrap && bc.hi(2) == BCType::hoextrap) {
+            if (hi.y > jhi && hi.z > khi) {
                 const int jmin = std::max(lo.y,jhi+1);
                 const int jmax = hi.y;
                 const int kmin = std::max(lo.z,khi+1);
                 const int kmax = hi.z;
                 const int j = jhi+1;
                 const int k = khi+1;
-                if (j>=jmin and j<=jmax and k>=kmin and k<=kmax) {
+                if (j>=jmin && j<=jmax && k>=kmin && k<=kmax) {
                     for (int i = lo.x; i <= hi.x; ++i) {
                         if (khi-2 >= ks) {
                             q(i,j,k) = 0.5 * (1./8.) * (15.*q(i,jhi+1,khi) - 10.*q(i,jhi+1,khi-1) + 3.*q(i,jhi+1,khi-2));

--- a/Src/Base/AMReX_FileSystem.cpp
+++ b/Src/Base/AMReX_FileSystem.cpp
@@ -16,7 +16,7 @@ CreateDirectories (std::string const& p, mode_t /*mode*/, bool verbose)
 {
     std::error_code ec;
     std::filesystem::create_directories(std::filesystem::path{p}, ec);
-    if (ec and verbose) {
+    if (ec && verbose) {
         amrex::AllPrint() << "amrex::UtilCreateDirectory failed to create "
                           << p << ": " << ec.message() << std::endl;
     }
@@ -28,7 +28,7 @@ Exists (std::string const& filename)
 {
     std::error_code ec;
     bool r = std::filesystem::exists(std::filesystem::path{filename}, ec);
-    if (ec and amrex::Verbose() > 0) {
+    if (ec && amrex::Verbose() > 0) {
         amrex::AllPrint() << "amrex::FileSystem::Exists failed. " << ec.message() << std::endl;
     }
     return r;
@@ -39,7 +39,7 @@ CurrentPath ()
 {
     std::error_code ec;
     auto path = std::filesystem::current_path(ec);
-    if (ec and amrex::Verbose() > 0) {
+    if (ec && amrex::Verbose() > 0) {
         amrex::AllPrint() << "amrex::FileSystem::CurrentPath failed. " << ec.message() << std::endl;
     }
     return path.string();

--- a/Src/Base/AMReX_Geometry.cpp
+++ b/Src/Base/AMReX_Geometry.cpp
@@ -426,7 +426,7 @@ Geometry::computeRoundoffDomain ()
                           [=] AMREX_GPU_HOST_DEVICE (Real x) -> Real
                           {
                               int i = int(Math::floor((x - plo)*idx)) + ilo;
-                              bool inside = i >= ilo and i <= ihi;
+                              bool inside = i >= ilo && i <= ihi;
                               return static_cast<Real>(inside) - Real(0.5);
                           }, tolerance);
         roundoff_domain.setHi(idim, mid - tolerance);

--- a/Src/Base/AMReX_GpuAtomic.H
+++ b/Src/Base/AMReX_GpuAtomic.H
@@ -35,7 +35,7 @@ namespace detail {
         do {
             R const new_R = f(*(reinterpret_cast<R const*>(&old_I)), val);
             new_I = *(reinterpret_cast<I const*>(&new_R));
-        } while (not a.compare_exchange_strong(old_I, new_I, mo));
+        } while (! a.compare_exchange_strong(old_I, new_I, mo));
         return *(reinterpret_cast<R const*>(&old_I));
 #else
         R old = *address;
@@ -341,7 +341,7 @@ namespace detail {
         unsigned int oldi = a.load(mo), newi;
         do {
             newi = (oldi >= value) ? 0u : (oldi+1u);
-        } while (not a.compare_exchange_strong(oldi, newi, mo));
+        } while (! a.compare_exchange_strong(oldi, newi, mo));
         return oldi;
 #else
         auto const old = *m;
@@ -379,7 +379,7 @@ namespace detail {
         unsigned int oldi = a.load(mo), newi;
         do {
             newi = ((oldi == 0u) || (oldi > value)) ? value : (oldi-1u);
-        } while (not a.compare_exchange_strong(oldi, newi, mo));
+        } while (! a.compare_exchange_strong(oldi, newi, mo));
         return oldi;
 #else
         auto const old = *m;

--- a/Src/Base/AMReX_GpuLaunchFunctsG.H
+++ b/Src/Base/AMReX_GpuLaunchFunctsG.H
@@ -329,7 +329,7 @@ void ParallelFor (Gpu::KernelInfo const& /*info*/, Box const& box1, Box const& b
     ParallelFor(box1, std::forward<L1>(f1));
     ParallelFor(box2, std::forward<L2>(f2));
 #if 0
-    if (amrex::isEmpty(box1) and amrex::isEmpty(box2)) return;
+    if (amrex::isEmpty(box1) && amrex::isEmpty(box2)) return;
     int ncells1 = box1.numPts();
     int ncells2 = box2.numPts();
     int ncells = amrex::max(ncells1, ncells2);
@@ -389,7 +389,7 @@ void ParallelFor (Gpu::KernelInfo const& /*info*/,
     ParallelFor(box2, std::forward<L2>(f2));
     ParallelFor(box3, std::forward<L3>(f3));
 #if 0
-    if (amrex::isEmpty(box1) and amrex::isEmpty(box2) and amrex::isEmpty(box3)) return;
+    if (amrex::isEmpty(box1) && amrex::isEmpty(box2) && amrex::isEmpty(box3)) return;
     int ncells1 = box1.numPts();
     int ncells2 = box2.numPts();
     int ncells3 = box3.numPts();
@@ -462,7 +462,7 @@ void ParallelFor (Gpu::KernelInfo const& /*info*/,
     ParallelFor(box1, ncomp1, std::forward<L1>(f1));
     ParallelFor(box2, ncomp2, std::forward<L2>(f2));
 #if 0
-    if (amrex::isEmpty(box1) and amrex::isEmpty(box2)) return;
+    if (amrex::isEmpty(box1) && amrex::isEmpty(box2)) return;
     int ncells1 = box1.numPts();
     int ncells2 = box2.numPts();
     int ncells = amrex::max(ncells1, ncells2);
@@ -530,7 +530,7 @@ void ParallelFor (Gpu::KernelInfo const& /*info*/,
     ParallelFor(box2, ncomp2, std::forward<L2>(f2));
     ParallelFor(box3, ncomp3, std::forward<L3>(f3));
 #if 0
-    if (amrex::isEmpty(box1) and amrex::isEmpty(box2) and amrex::isEmpty(box3)) return;
+    if (amrex::isEmpty(box1) && amrex::isEmpty(box2) && amrex::isEmpty(box3)) return;
     int ncells1 = box1.numPts();
     int ncells2 = box2.numPts();
     int ncells3 = box3.numPts();
@@ -925,11 +925,11 @@ ParallelForRNG (Box const& box, T ncomp, L&& f) noexcept
 }
 
 template <typename L1, typename L2>
-amrex::EnableIf_t<MaybeDeviceRunnable<L1>::value and MaybeDeviceRunnable<L2>::value>
+amrex::EnableIf_t<MaybeDeviceRunnable<L1>::value && MaybeDeviceRunnable<L2>::value>
 ParallelFor (Gpu::KernelInfo const& info,
              Box const& box1, Box const& box2, L1&& f1, L2&& f2) noexcept
 {
-    if (amrex::isEmpty(box1) and amrex::isEmpty(box2)) return;
+    if (amrex::isEmpty(box1) && amrex::isEmpty(box2)) return;
     int ncells1 = box1.numPts();
     int ncells2 = box2.numPts();
     int ncells = amrex::max(ncells1, ncells2);
@@ -975,12 +975,12 @@ ParallelFor (Gpu::KernelInfo const& info,
 }
 
 template <typename L1, typename L2, typename L3>
-amrex::EnableIf_t<MaybeDeviceRunnable<L1>::value and MaybeDeviceRunnable<L2>::value and MaybeDeviceRunnable<L3>::value>
+amrex::EnableIf_t<MaybeDeviceRunnable<L1>::value && MaybeDeviceRunnable<L2>::value && MaybeDeviceRunnable<L3>::value>
 ParallelFor (Gpu::KernelInfo const& info,
              Box const& box1, Box const& box2, Box const& box3,
              L1&& f1, L2&& f2, L3&& f3) noexcept
 {
-    if (amrex::isEmpty(box1) and amrex::isEmpty(box2) and amrex::isEmpty(box3)) return;
+    if (amrex::isEmpty(box1) && amrex::isEmpty(box2) && amrex::isEmpty(box3)) return;
     int ncells1 = box1.numPts();
     int ncells2 = box2.numPts();
     int ncells3 = box3.numPts();
@@ -1041,12 +1041,12 @@ ParallelFor (Gpu::KernelInfo const& info,
 template <typename T1, typename T2, typename L1, typename L2,
           typename M1=amrex::EnableIf_t<std::is_integral<T1>::value>,
           typename M2=amrex::EnableIf_t<std::is_integral<T2>::value> >
-amrex::EnableIf_t<MaybeDeviceRunnable<L1>::value and MaybeDeviceRunnable<L2>::value>
+amrex::EnableIf_t<MaybeDeviceRunnable<L1>::value && MaybeDeviceRunnable<L2>::value>
 ParallelFor (Gpu::KernelInfo const& info,
              Box const& box1, T1 ncomp1, L1&& f1,
              Box const& box2, T2 ncomp2, L2&& f2) noexcept
 {
-    if (amrex::isEmpty(box1) and amrex::isEmpty(box2)) return;
+    if (amrex::isEmpty(box1) && amrex::isEmpty(box2)) return;
     int ncells1 = box1.numPts();
     int ncells2 = box2.numPts();
     int ncells = amrex::max(ncells1, ncells2);
@@ -1099,13 +1099,13 @@ template <typename T1, typename T2, typename T3, typename L1, typename L2, typen
           typename M1=amrex::EnableIf_t<std::is_integral<T1>::value>,
           typename M2=amrex::EnableIf_t<std::is_integral<T2>::value>,
           typename M3=amrex::EnableIf_t<std::is_integral<T3>::value> >
-amrex::EnableIf_t<MaybeDeviceRunnable<L1>::value and MaybeDeviceRunnable<L2>::value and MaybeDeviceRunnable<L3>::value>
+amrex::EnableIf_t<MaybeDeviceRunnable<L1>::value && MaybeDeviceRunnable<L2>::value && MaybeDeviceRunnable<L3>::value>
 ParallelFor (Gpu::KernelInfo const& info,
              Box const& box1, T1 ncomp1, L1&& f1,
              Box const& box2, T2 ncomp2, L2&& f2,
              Box const& box3, T3 ncomp3, L3&& f3) noexcept
 {
-    if (amrex::isEmpty(box1) and amrex::isEmpty(box2) and amrex::isEmpty(box3)) return;
+    if (amrex::isEmpty(box1) && amrex::isEmpty(box2) && amrex::isEmpty(box3)) return;
     int ncells1 = box1.numPts();
     int ncells2 = box2.numPts();
     int ncells3 = box3.numPts();
@@ -1170,7 +1170,7 @@ ParallelFor (Gpu::KernelInfo const& info,
 }
 
 template <typename T, typename L1, typename L2>
-amrex::EnableIf_t<MaybeDeviceRunnable<L1>::value and MaybeDeviceRunnable<L2>::value>
+amrex::EnableIf_t<MaybeDeviceRunnable<L1>::value && MaybeDeviceRunnable<L2>::value>
 FabReduce (Box const& box, T const& init_val, L1&& f1, L2&& f2) noexcept
 {
     if (amrex::isEmpty(box)) return;
@@ -1199,7 +1199,7 @@ FabReduce (Box const& box, T const& init_val, L1&& f1, L2&& f2) noexcept
 
 template <typename N, typename T, typename L1, typename L2,
           typename M=amrex::EnableIf_t<std::is_integral<N>::value> >
-amrex::EnableIf_t<MaybeDeviceRunnable<L1>::value and MaybeDeviceRunnable<L2>::value>
+amrex::EnableIf_t<MaybeDeviceRunnable<L1>::value && MaybeDeviceRunnable<L2>::value>
 FabReduce (Box const& box, N ncomp, T const& init_val, L1&& f1, L2&& f2) noexcept
 {
     if (amrex::isEmpty(box)) return;
@@ -1230,7 +1230,7 @@ FabReduce (Box const& box, N ncomp, T const& init_val, L1&& f1, L2&& f2) noexcep
 
 template <typename N, typename T, typename L1, typename L2,
           typename M=amrex::EnableIf_t<std::is_integral<N>::value> >
-amrex::EnableIf_t<MaybeDeviceRunnable<L1>::value and MaybeDeviceRunnable<L2>::value>
+amrex::EnableIf_t<MaybeDeviceRunnable<L1>::value && MaybeDeviceRunnable<L2>::value>
 VecReduce (N n, T const& init_val, L1&& f1, L2&& f2) noexcept
 {
     if (amrex::isEmpty(n)) return;
@@ -1464,7 +1464,7 @@ HostDeviceParallelFor (Gpu::KernelInfo const& info, Box const& box, T ncomp, L&&
 }
 
 template <typename L1, typename L2>
-amrex::EnableIf_t<MaybeHostDeviceRunnable<L1>::value and MaybeHostDeviceRunnable<L2>::value>
+amrex::EnableIf_t<MaybeHostDeviceRunnable<L1>::value && MaybeHostDeviceRunnable<L2>::value>
 HostDeviceParallelFor (Gpu::KernelInfo const& info,
                        Box const& box1, Box const& box2, L1&& f1, L2&& f2) noexcept
 {
@@ -1477,7 +1477,7 @@ HostDeviceParallelFor (Gpu::KernelInfo const& info,
 }
 
 template <typename L1, typename L2, typename L3>
-amrex::EnableIf_t<MaybeHostDeviceRunnable<L1>::value and MaybeHostDeviceRunnable<L2>::value and MaybeHostDeviceRunnable<L3>::value>
+amrex::EnableIf_t<MaybeHostDeviceRunnable<L1>::value && MaybeHostDeviceRunnable<L2>::value && MaybeHostDeviceRunnable<L3>::value>
 HostDeviceParallelFor (Gpu::KernelInfo const& info,
                        Box const& box1, Box const& box2, Box const& box3,
                        L1&& f1, L2&& f2, L3&& f3) noexcept
@@ -1495,7 +1495,7 @@ HostDeviceParallelFor (Gpu::KernelInfo const& info,
 template <typename T1, typename T2, typename L1, typename L2,
           typename M1=amrex::EnableIf_t<std::is_integral<T1>::value>,
           typename M2=amrex::EnableIf_t<std::is_integral<T2>::value> >
-amrex::EnableIf_t<MaybeHostDeviceRunnable<L1>::value and MaybeHostDeviceRunnable<L2>::value>
+amrex::EnableIf_t<MaybeHostDeviceRunnable<L1>::value && MaybeHostDeviceRunnable<L2>::value>
 HostDeviceParallelFor (Gpu::KernelInfo const& info,
                        Box const& box1, T1 ncomp1, L1&& f1,
                        Box const& box2, T2 ncomp2, L2&& f2) noexcept
@@ -1512,7 +1512,7 @@ template <typename T1, typename T2, typename T3, typename L1, typename L2, typen
           typename M1=amrex::EnableIf_t<std::is_integral<T1>::value>,
           typename M2=amrex::EnableIf_t<std::is_integral<T2>::value>,
           typename M3=amrex::EnableIf_t<std::is_integral<T3>::value> >
-amrex::EnableIf_t<MaybeHostDeviceRunnable<L1>::value and MaybeHostDeviceRunnable<L2>::value and MaybeHostDeviceRunnable<L3>::value>
+amrex::EnableIf_t<MaybeHostDeviceRunnable<L1>::value && MaybeHostDeviceRunnable<L2>::value && MaybeHostDeviceRunnable<L3>::value>
 HostDeviceParallelFor (Gpu::KernelInfo const& info,
                        Box const& box1, T1 ncomp1, L1&& f1,
                        Box const& box2, T2 ncomp2, L2&& f2,

--- a/Src/Base/AMReX_GpuLaunchMacrosG.H
+++ b/Src/Base/AMReX_GpuLaunchMacrosG.H
@@ -88,7 +88,7 @@
 #ifdef AMREX_USE_DPCPP
 #define AMREX_GPU_LAUNCH_HOST_DEVICE_LAMBDA_RANGE_2(TN1,TI1,block1,TN2,TI2,block2) \
     { auto const& amrex_i_tn1 = TN1; auto const& amrex_i_tn2 = TN2; \
-    if (!amrex::isEmpty(amrex_i_tn1) or !amrex::isEmpty(amrex_i_tn2)) { \
+    if (!amrex::isEmpty(amrex_i_tn1) || !amrex::isEmpty(amrex_i_tn2)) { \
     if (amrex::Gpu::inLaunchRegion()) \
     { \
         const auto amrex_i_ec1 = amrex::Gpu::ExecutionConfig(amrex_i_tn1); \
@@ -133,7 +133,7 @@
 #else
 #define AMREX_GPU_LAUNCH_HOST_DEVICE_LAMBDA_RANGE_2(TN1,TI1,block1,TN2,TI2,block2) \
     { auto const& amrex_i_tn1 = TN1; auto const& amrex_i_tn2 = TN2; \
-    if (!amrex::isEmpty(amrex_i_tn1) or !amrex::isEmpty(amrex_i_tn2)) { \
+    if (!amrex::isEmpty(amrex_i_tn1) || !amrex::isEmpty(amrex_i_tn2)) { \
     if (amrex::Gpu::inLaunchRegion()) \
     { \
         const auto amrex_i_ec1 = amrex::Gpu::ExecutionConfig(amrex_i_tn1); \
@@ -166,7 +166,7 @@
 #ifdef AMREX_USE_CUDA
 #define AMREX_GPU_LAUNCH_HOST_DEVICE_FUSIBLE_LAMBDA_RANGE_2(TN1,TI1,block1,TN2,TI2,block2) \
     { auto const& amrex_i_tn1 = TN1; auto const& amrex_i_tn2 = TN2; \
-    if (!amrex::isEmpty(amrex_i_tn1) or !amrex::isEmpty(amrex_i_tn2)) { \
+    if (!amrex::isEmpty(amrex_i_tn1) || !amrex::isEmpty(amrex_i_tn2)) { \
     if (amrex::Gpu::inLaunchRegion()) \
     { \
       const auto amrex_i_ec1 = amrex::Gpu::ExecutionConfig(amrex_i_tn1); \
@@ -214,7 +214,7 @@
 #ifdef AMREX_USE_DPCPP
 #define AMREX_GPU_LAUNCH_HOST_DEVICE_LAMBDA_RANGE_3(TN1,TI1,block1,TN2,TI2,block2,TN3,TI3,block3) \
     { auto const& amrex_i_tn1 = TN1; auto const& amrex_i_tn2 = TN2; auto const& amrex_i_tn3 = TN3; \
-    if (!amrex::isEmpty(amrex_i_tn1) or !amrex::isEmpty(amrex_i_tn2) or !amrex::isEmpty(amrex_i_tn3)) { \
+    if (!amrex::isEmpty(amrex_i_tn1) || !amrex::isEmpty(amrex_i_tn2) || !amrex::isEmpty(amrex_i_tn3)) { \
     if (amrex::Gpu::inLaunchRegion()) \
     { \
         const auto amrex_i_ec1 = amrex::Gpu::ExecutionConfig(amrex_i_tn1); \
@@ -268,7 +268,7 @@
 #else
 #define AMREX_GPU_LAUNCH_HOST_DEVICE_LAMBDA_RANGE_3(TN1,TI1,block1,TN2,TI2,block2,TN3,TI3,block3) \
     { auto const& amrex_i_tn1 = TN1; auto const& amrex_i_tn2 = TN2; auto const& amrex_i_tn3 = TN3; \
-    if (!amrex::isEmpty(amrex_i_tn1) or !amrex::isEmpty(amrex_i_tn2) or !amrex::isEmpty(amrex_i_tn3)) { \
+    if (!amrex::isEmpty(amrex_i_tn1) || !amrex::isEmpty(amrex_i_tn2) || !amrex::isEmpty(amrex_i_tn3)) { \
     if (amrex::Gpu::inLaunchRegion()) \
     { \
         const auto amrex_i_ec1 = amrex::Gpu::ExecutionConfig(amrex_i_tn1); \
@@ -310,7 +310,7 @@
 #ifdef AMREX_USE_CUDA
 #define AMREX_GPU_LAUNCH_HOST_DEVICE_FUSIBLE_LAMBDA_RANGE_3(TN1,TI1,block1,TN2,TI2,block2,TN3,TI3,block3) \
     { auto const& amrex_i_tn1 = TN1; auto const& amrex_i_tn2 = TN2; auto const& amrex_i_tn3 = TN3; \
-    if (!amrex::isEmpty(amrex_i_tn1) or !amrex::isEmpty(amrex_i_tn2) or !amrex::isEmpty(amrex_i_tn3)) { \
+    if (!amrex::isEmpty(amrex_i_tn1) || !amrex::isEmpty(amrex_i_tn2) || !amrex::isEmpty(amrex_i_tn3)) { \
     if (amrex::Gpu::inLaunchRegion()) \
     { \
       const auto amrex_i_ec1 = amrex::Gpu::ExecutionConfig(amrex_i_tn1); \
@@ -421,7 +421,7 @@
 #ifdef AMREX_USE_DPCPP
 #define AMREX_GPU_LAUNCH_DEVICE_LAMBDA_RANGE_2(TN1,TI1,block1,TN2,TI2,block2) \
     { auto const& amrex_i_tn1 = TN1; auto const& amrex_i_tn2 = TN2; \
-    if (!amrex::isEmpty(amrex_i_tn1) or !amrex::isEmpty(amrex_i_tn2)) { \
+    if (!amrex::isEmpty(amrex_i_tn1) || !amrex::isEmpty(amrex_i_tn2)) { \
     if (amrex::Gpu::inLaunchRegion()) \
     { \
         const auto amrex_i_ec1 = amrex::Gpu::ExecutionConfig(amrex_i_tn1); \
@@ -461,7 +461,7 @@
 #else
 #define AMREX_GPU_LAUNCH_DEVICE_LAMBDA_RANGE_2(TN1,TI1,block1,TN2,TI2,block2) \
     { auto const& amrex_i_tn1 = TN1; auto const& amrex_i_tn2 = TN2; \
-    if (!amrex::isEmpty(amrex_i_tn1) or !amrex::isEmpty(amrex_i_tn2)) { \
+    if (!amrex::isEmpty(amrex_i_tn1) || !amrex::isEmpty(amrex_i_tn2)) { \
     if (amrex::Gpu::inLaunchRegion()) \
     { \
         const auto amrex_i_ec1 = amrex::Gpu::ExecutionConfig(amrex_i_tn1); \
@@ -492,7 +492,7 @@
 #ifdef AMREX_USE_DPCPP
 #define AMREX_GPU_LAUNCH_DEVICE_LAMBDA_RANGE_3(TN1,TI1,block1,TN2,TI2,block2,TN3,TI3,block3) \
     { auto const& amrex_i_tn1 = TN1; auto const& amrex_i_tn2 = TN2; auto const& amrex_i_tn3 = TN3; \
-    if (!amrex::isEmpty(amrex_i_tn1) or !amrex::isEmpty(amrex_i_tn2) or !amrex::isEmpty(amrex_i_tn3)) { \
+    if (!amrex::isEmpty(amrex_i_tn1) || !amrex::isEmpty(amrex_i_tn2) || !amrex::isEmpty(amrex_i_tn3)) { \
     if (amrex::Gpu::inLaunchRegion()) \
     { \
         const auto amrex_i_ec1 = amrex::Gpu::ExecutionConfig(amrex_i_tn1); \
@@ -537,7 +537,7 @@
 #else
 #define AMREX_GPU_LAUNCH_DEVICE_LAMBDA_RANGE_3(TN1,TI1,block1,TN2,TI2,block2,TN3,TI3,block3) \
     { auto const& amrex_i_tn1 = TN1; auto const& amrex_i_tn2 = TN2; auto const& amrex_i_tn3 = TN3; \
-    if (!amrex::isEmpty(amrex_i_tn1) or !amrex::isEmpty(amrex_i_tn2) or !amrex::isEmpty(amrex_i_tn3)) { \
+    if (!amrex::isEmpty(amrex_i_tn1) || !amrex::isEmpty(amrex_i_tn2) || !amrex::isEmpty(amrex_i_tn3)) { \
     if (amrex::Gpu::inLaunchRegion()) \
     { \
         const auto amrex_i_ec1 = amrex::Gpu::ExecutionConfig(amrex_i_tn1); \

--- a/Src/Base/AMReX_GpuReduce.H
+++ b/Src/Base/AMReX_GpuReduce.H
@@ -61,7 +61,7 @@ T blockReduce (T x, WARPREDUCE && warp_reduce, T x0, Gpu::Handler const& h)
     h.item.barrier(sycl::access::fence_space::local_space);
     if (lane == 0) shared[wid] = x;
     h.item.barrier(sycl::access::fence_space::local_space);
-    bool b = (tid == 0) or (tid < numwarps);
+    bool b = (tid == 0) || (tid < numwarps);
     x =  b ? shared[lane] : x0;
     if (wid == 0) x = warp_reduce(x, sg);
     return x;
@@ -142,7 +142,7 @@ T blockReduce (T x, WARPREDUCE && warp_reduce, T x0)
     __syncthreads();
     if (lane == 0) shared[wid] = x;
     __syncthreads();
-    bool b = (threadIdx.x == 0) or (threadIdx.x < blockDim.x / warpSize);
+    bool b = (threadIdx.x == 0) || (threadIdx.x < blockDim.x / warpSize);
     x =  b ? shared[lane] : x0;
     if (wid == 0) x = warp_reduce(x);
     return x;

--- a/Src/Base/AMReX_IArrayBox.cpp
+++ b/Src/Base/AMReX_IArrayBox.cpp
@@ -83,7 +83,7 @@ IArrayBox::resize (const Box& b, int N)
     // For debugging purposes
     if ( do_initval ) {
 #if defined(AMREX_USE_GPU)
-        bool run_on_device = Gpu::inLaunchRegion() and
+        bool run_on_device = Gpu::inLaunchRegion() &&
             (arena() == The_Arena() ||
              arena() == The_Device_Arena() ||
              arena() == The_Managed_Arena());

--- a/Src/Base/AMReX_MultiFab.cpp
+++ b/Src/Base/AMReX_MultiFab.cpp
@@ -39,7 +39,7 @@ MultiFab::Dot (const MultiFab& x, int xcomp,
 {
     BL_ASSERT(x.boxArray() == y.boxArray());
     BL_ASSERT(x.DistributionMap() == y.DistributionMap());
-    BL_ASSERT(x.nGrow() >= nghost and y.nGrow() >= nghost);
+    BL_ASSERT(x.nGrow() >= nghost && y.nGrow() >= nghost);
 
     BL_PROFILE("MultiFab::Dot()");
 
@@ -112,7 +112,7 @@ MultiFab::Dot (const iMultiFab& mask,
     BL_ASSERT(x.boxArray() == mask.boxArray());
     BL_ASSERT(x.DistributionMap() == y.DistributionMap());
     BL_ASSERT(x.DistributionMap() == mask.DistributionMap());
-    BL_ASSERT(x.nGrow() >= nghost and y.nGrow() >= nghost);
+    BL_ASSERT(x.nGrow() >= nghost && y.nGrow() >= nghost);
     BL_ASSERT(mask.nGrow() >= nghost);
 
     Real sm = amrex::ReduceSum(x, y, mask, nghost,
@@ -148,7 +148,7 @@ MultiFab::Add (MultiFab& dst, const MultiFab& src,
 {
     BL_ASSERT(dst.boxArray() == src.boxArray());
     BL_ASSERT(dst.distributionMap == src.distributionMap);
-    BL_ASSERT(dst.nGrowVect().allGE(nghost) and src.nGrowVect().allGE(nghost));
+    BL_ASSERT(dst.nGrowVect().allGE(nghost) && src.nGrowVect().allGE(nghost));
 
     BL_PROFILE("MultiFab::Add()");
 
@@ -188,7 +188,7 @@ MultiFab::Swap (MultiFab& dst, MultiFab& src,
 {
     BL_ASSERT(dst.boxArray() == src.boxArray());
     BL_ASSERT(dst.distributionMap == src.distributionMap);
-    BL_ASSERT(dst.nGrowVect().allGE(nghost) and src.nGrowVect().allGE(nghost));
+    BL_ASSERT(dst.nGrowVect().allGE(nghost) && src.nGrowVect().allGE(nghost));
 
     BL_PROFILE("MultiFab::Swap()");
 
@@ -244,7 +244,7 @@ MultiFab::Subtract (MultiFab& dst, const MultiFab& src,
 {
     BL_ASSERT(dst.boxArray() == src.boxArray());
     BL_ASSERT(dst.distributionMap == src.distributionMap);
-    BL_ASSERT(dst.nGrowVect().allGE(nghost) and src.nGrowVect().allGE(nghost));
+    BL_ASSERT(dst.nGrowVect().allGE(nghost) && src.nGrowVect().allGE(nghost));
 
     BL_PROFILE("MultiFab::Subtract()");
 
@@ -264,7 +264,7 @@ MultiFab::Multiply (MultiFab& dst, const MultiFab& src,
 {
     BL_ASSERT(dst.boxArray() == src.boxArray());
     BL_ASSERT(dst.distributionMap == src.distributionMap);
-    BL_ASSERT(dst.nGrowVect().allGE(nghost) and src.nGrowVect().allGE(nghost));
+    BL_ASSERT(dst.nGrowVect().allGE(nghost) && src.nGrowVect().allGE(nghost));
 
     BL_PROFILE("MultiFab::Multiply()");
 
@@ -284,7 +284,7 @@ MultiFab::Divide (MultiFab& dst, const MultiFab& src,
 {
     BL_ASSERT(dst.boxArray() == src.boxArray());
     BL_ASSERT(dst.distributionMap == src.distributionMap);
-    BL_ASSERT(dst.nGrowVect().allGE(nghost) and src.nGrowVect().allGE(nghost));
+    BL_ASSERT(dst.nGrowVect().allGE(nghost) && src.nGrowVect().allGE(nghost));
 
     BL_PROFILE("MultiFab::Divide()");
 
@@ -304,7 +304,7 @@ MultiFab::Saxpy (MultiFab& dst, Real a, const MultiFab& src,
 {
     BL_ASSERT(dst.boxArray() == src.boxArray());
     BL_ASSERT(dst.distributionMap == src.distributionMap);
-    BL_ASSERT(dst.nGrowVect().allGE(nghost) and src.nGrowVect().allGE(nghost));
+    BL_ASSERT(dst.nGrowVect().allGE(nghost) && src.nGrowVect().allGE(nghost));
 
     BL_PROFILE("MultiFab::Saxpy()");
 
@@ -339,7 +339,7 @@ MultiFab::Xpay (MultiFab& dst, Real a, const MultiFab& src,
 {
     BL_ASSERT(dst.boxArray() == src.boxArray());
     BL_ASSERT(dst.distributionMap == src.distributionMap);
-    BL_ASSERT(dst.nGrowVect().allGE(nghost) and src.nGrowVect().allGE(nghost));
+    BL_ASSERT(dst.nGrowVect().allGE(nghost) && src.nGrowVect().allGE(nghost));
 
     BL_PROFILE("MultiFab::Xpay()");
 
@@ -379,7 +379,7 @@ MultiFab::LinComb (MultiFab& dst,
     BL_ASSERT(dst.distributionMap == x.distributionMap);
     BL_ASSERT(dst.boxArray() == y.boxArray());
     BL_ASSERT(dst.distributionMap == y.distributionMap);
-    BL_ASSERT(dst.nGrowVect().allGE(nghost) and x.nGrowVect().allGE(nghost) and y.nGrowVect().allGE(nghost));
+    BL_ASSERT(dst.nGrowVect().allGE(nghost) && x.nGrowVect().allGE(nghost) && y.nGrowVect().allGE(nghost));
 
     BL_PROFILE("MultiFab::LinComb()");
 
@@ -421,7 +421,7 @@ MultiFab::AddProduct (MultiFab& dst,
     BL_ASSERT(dst.distributionMap == src1.distributionMap);
     BL_ASSERT(dst.boxArray() == src2.boxArray());
     BL_ASSERT(dst.distributionMap == src2.distributionMap);
-    BL_ASSERT(dst.nGrowVect().allGE(nghost) and src1.nGrowVect().allGE(nghost) and src2.nGrowVect().allGE(nghost));
+    BL_ASSERT(dst.nGrowVect().allGE(nghost) && src1.nGrowVect().allGE(nghost) && src2.nGrowVect().allGE(nghost));
 
     BL_PROFILE("MultiFab::AddProduct()");
 
@@ -539,7 +539,7 @@ MultiFab::MultiFab (const BoxArray&            bxs,
     :
     FabArray<FArrayBox>(bxs,dm,ncomp,ngrow,info,factory)
 {
-    if (SharedMemory() and info.alloc) initVal();  // else already done in FArrayBox
+    if (SharedMemory() && info.alloc) initVal();  // else already done in FArrayBox
 #ifdef AMREX_MEM_PROFILING
     ++num_multifabs;
     num_multifabs_hwm = std::max(num_multifabs_hwm, num_multifabs);
@@ -587,7 +587,7 @@ MultiFab::define (const BoxArray&            bxs,
                   const FabFactory<FArrayBox>& factory)
 {
     define(bxs, dm, nvar, IntVect(ngrow), info, factory);
-    if (SharedMemory() and info.alloc) initVal();  // else already done in FArrayBox
+    if (SharedMemory() && info.alloc) initVal();  // else already done in FArrayBox
 }
 
 void
@@ -599,7 +599,7 @@ MultiFab::define (const BoxArray&            bxs,
                   const FabFactory<FArrayBox>& factory)
 {
     this->FabArray<FArrayBox>::define(bxs,dm,nvar,ngrow,info,factory);
-    if (SharedMemory() and info.alloc) initVal();  // else already done in FArrayBox
+    if (SharedMemory() && info.alloc) initVal();  // else already done in FArrayBox
 }
 
 void
@@ -632,8 +632,8 @@ MultiFab::contains_nan (int scomp,
 {
     BL_ASSERT(scomp >= 0);
     BL_ASSERT(scomp + ncomp <= nComp());
-    BL_ASSERT(ncomp >  0 and ncomp <= nComp());
-    BL_ASSERT(IntVect::TheZeroVector().allLE(ngrow) and ngrow.allLE(nGrowVect()));
+    BL_ASSERT(ncomp >  0 && ncomp <= nComp());
+    BL_ASSERT(IntVect::TheZeroVector().allLE(ngrow) && ngrow.allLE(nGrowVect()));
 
     bool r = amrex::ReduceLogicalOr(*this, ngrow,
     [=] AMREX_GPU_HOST_DEVICE (Box const& bx, Array4<Real const> const& fab) -> bool
@@ -663,8 +663,8 @@ MultiFab::contains_inf (int scomp, int ncomp, IntVect const& ngrow, bool local) 
 {
     BL_ASSERT(scomp >= 0);
     BL_ASSERT(scomp + ncomp <= nComp());
-    BL_ASSERT(ncomp >  0 and ncomp <= nComp());
-    BL_ASSERT(IntVect::TheZeroVector().allLE(ngrow) and ngrow.allLE(nGrowVect()));
+    BL_ASSERT(ncomp >  0 && ncomp <= nComp());
+    BL_ASSERT(IntVect::TheZeroVector().allLE(ngrow) && ngrow.allLE(nGrowVect()));
 
     bool r = amrex::ReduceLogicalOr(*this, ngrow,
     [=] AMREX_GPU_HOST_DEVICE (Box const& bx, Array4<Real const> const& fab) -> bool
@@ -697,7 +697,7 @@ MultiFab::contains_inf (bool local) const
 Real
 MultiFab::min (int comp, int nghost, bool local) const
 {
-    BL_ASSERT(nghost >= 0 and nghost <= n_grow.min());
+    BL_ASSERT(nghost >= 0 && nghost <= n_grow.min());
 
     Real mn;
 
@@ -742,7 +742,7 @@ MultiFab::min (int comp, int nghost, bool local) const
 Real
 MultiFab::min (const Box& region, int comp, int nghost, bool local) const
 {
-    BL_ASSERT(nghost >= 0 and nghost <= n_grow.min());
+    BL_ASSERT(nghost >= 0 && nghost <= n_grow.min());
 
     Real mn = amrex::ReduceMin(*this, nghost,
     [=] AMREX_GPU_HOST_DEVICE (Box const& bx, Array4<Real const> const& fab) -> Real
@@ -766,7 +766,7 @@ MultiFab::min (const Box& region, int comp, int nghost, bool local) const
 Real
 MultiFab::max (int comp, int nghost, bool local) const
 {
-    BL_ASSERT(nghost >= 0 and nghost <= n_grow.min());
+    BL_ASSERT(nghost >= 0 && nghost <= n_grow.min());
 
     Real mx;
 
@@ -811,7 +811,7 @@ MultiFab::max (int comp, int nghost, bool local) const
 Real
 MultiFab::max (const Box& region, int comp, int nghost, bool local) const
 {
-    BL_ASSERT(nghost >= 0 and nghost <= n_grow.min());
+    BL_ASSERT(nghost >= 0 && nghost <= n_grow.min());
 
     Real mx = amrex::ReduceMax(*this, nghost,
     [=] AMREX_GPU_HOST_DEVICE (Box const& bx, Array4<Real const> const& fab) -> Real
@@ -866,7 +866,7 @@ indexFromValue (MultiFab const& mf, int comp, int nghost, Real value, MPI_Op mml
 IntVect
 MultiFab::minIndex (int comp, int nghost) const
 {
-    BL_ASSERT(nghost >= 0 and nghost <= n_grow.min());
+    BL_ASSERT(nghost >= 0 && nghost <= n_grow.min());
     Real mn = this->min(comp, nghost, true);
     return indexFromValue(*this, comp, nghost, mn, MPI_MINLOC);
 }
@@ -874,7 +874,7 @@ MultiFab::minIndex (int comp, int nghost) const
 IntVect
 MultiFab::maxIndex (int comp, int nghost) const
 {
-    BL_ASSERT(nghost >= 0 and nghost <= n_grow.min());
+    BL_ASSERT(nghost >= 0 && nghost <= n_grow.min());
     Real mx = this->max(comp, nghost, true);
     return indexFromValue(*this, comp, nghost, mx, MPI_MAXLOC);
 }
@@ -907,7 +907,7 @@ MultiFab::norm0 (int comp, int nghost, bool local, bool ignore_covered ) const
     Real nm0;
 
 #ifdef AMREX_USE_EB
-    if ( this -> hasEBFabFactory() and ignore_covered )
+    if ( this -> hasEBFabFactory() && ignore_covered )
     {
         const auto& ebfactory = dynamic_cast<EBFArrayBoxFactory const&>(this->Factory());
         auto const& flags = ebfactory.getMultiEBCellFlagFab();
@@ -1020,7 +1020,7 @@ MultiFab::norm1 (int comp, const Periodicity& period, bool ignore_covered ) cons
     MultiFab::Copy(tmpmf, *this, comp, 0, 1, 0);
 
 #ifdef AMREX_USE_EB
-    if ( this -> hasEBFabFactory() and ignore_covered )
+    if ( this -> hasEBFabFactory() && ignore_covered )
         EB_set_covered( tmpmf, 0.0 );
 #endif
 
@@ -1106,7 +1106,7 @@ void
 MultiFab::plus (Real val, int comp, int num_comp, int nghost)
 {
 
-    BL_ASSERT(nghost >= 0 and nghost <= n_grow.min());
+    BL_ASSERT(nghost >= 0 && nghost <= n_grow.min());
     BL_ASSERT(comp+num_comp <= n_comp);
     BL_ASSERT(num_comp > 0);
 
@@ -1116,7 +1116,7 @@ MultiFab::plus (Real val, int comp, int num_comp, int nghost)
 void
 MultiFab::plus (Real val, const Box& region, int comp, int num_comp, int nghost)
 {
-    BL_ASSERT(nghost >= 0 and nghost <= n_grow.min());
+    BL_ASSERT(nghost >= 0 && nghost <= n_grow.min());
     BL_ASSERT(comp+num_comp <= n_comp);
     BL_ASSERT(num_comp > 0);
 
@@ -1132,7 +1132,7 @@ MultiFab::plus (const MultiFab& mf, int strt_comp, int num_comp, int nghost)
 void
 MultiFab::mult (Real val, int comp, int num_comp, int  nghost)
 {
-    BL_ASSERT(nghost >= 0 and nghost <= n_grow.min());
+    BL_ASSERT(nghost >= 0 && nghost <= n_grow.min());
     BL_ASSERT(comp+num_comp <= n_comp);
     BL_ASSERT(num_comp > 0);
 
@@ -1142,7 +1142,7 @@ MultiFab::mult (Real val, int comp, int num_comp, int  nghost)
 void
 MultiFab::mult (Real val, const Box& region, int comp, int num_comp, int nghost)
 {
-    BL_ASSERT(nghost >= 0 and nghost <= n_grow.min());
+    BL_ASSERT(nghost >= 0 && nghost <= n_grow.min());
     BL_ASSERT(comp+num_comp <= n_comp);
     BL_ASSERT(num_comp > 0);
 
@@ -1152,7 +1152,7 @@ MultiFab::mult (Real val, const Box& region, int comp, int num_comp, int nghost)
 void
 MultiFab::invert (Real numerator, int comp, int num_comp, int nghost)
 {
-    BL_ASSERT(nghost >= 0 and nghost <= n_grow.min());
+    BL_ASSERT(nghost >= 0 && nghost <= n_grow.min());
     BL_ASSERT(comp+num_comp <= n_comp);
     BL_ASSERT(num_comp > 0);
 
@@ -1162,7 +1162,7 @@ MultiFab::invert (Real numerator, int comp, int num_comp, int nghost)
 void
 MultiFab::invert (Real numerator, const Box& region, int comp, int num_comp, int nghost)
 {
-    BL_ASSERT(nghost >= 0 and nghost <= n_grow.min());
+    BL_ASSERT(nghost >= 0 && nghost <= n_grow.min());
     BL_ASSERT(comp+num_comp <= n_comp);
     BL_ASSERT(num_comp > 0);
 
@@ -1172,7 +1172,7 @@ MultiFab::invert (Real numerator, const Box& region, int comp, int num_comp, int
 void
 MultiFab::negate (int comp, int num_comp, int nghost)
 {
-    BL_ASSERT(nghost >= 0 and nghost <= n_grow.min());
+    BL_ASSERT(nghost >= 0 && nghost <= n_grow.min());
     BL_ASSERT(comp+num_comp <= n_comp);
 
     FabArray<FArrayBox>::mult(-1., comp, num_comp, nghost);
@@ -1181,7 +1181,7 @@ MultiFab::negate (int comp, int num_comp, int nghost)
 void
 MultiFab::negate (const Box& region, int comp, int num_comp, int nghost)
 {
-    BL_ASSERT(nghost >= 0 and nghost <= n_grow.min());
+    BL_ASSERT(nghost >= 0 && nghost <= n_grow.min());
     BL_ASSERT(comp+num_comp <= n_comp);
 
     FabArray<FArrayBox>::mult(-1.,region,comp,num_comp,nghost);
@@ -1192,7 +1192,7 @@ MultiFab::SumBoundary (int scomp, int ncomp, IntVect const& nghost, const Period
 {
     BL_PROFILE("MultiFab::SumBoundary()");
 
-    if ( n_grow == IntVect::TheZeroVector() and boxArray().ixType().cellCentered()) return;
+    if ( n_grow == IntVect::TheZeroVector() && boxArray().ixType().cellCentered()) return;
 
     MultiFab tmp(boxArray(), DistributionMap(), ncomp, n_grow, MFInfo(), Factory());
     MultiFab::Copy(tmp, *this, scomp, 0, ncomp, n_grow);

--- a/Src/Base/AMReX_MultiFabUtil.cpp
+++ b/Src/Base/AMReX_MultiFabUtil.cpp
@@ -362,7 +362,7 @@ namespace amrex
         //
         BoxArray crse_S_fine_BA = S_fine.boxArray(); crse_S_fine_BA.coarsen(ratio);
 
-        if (crse_S_fine_BA == S_crse.boxArray() and S_fine.DistributionMap() == S_crse.DistributionMap())
+        if (crse_S_fine_BA == S_crse.boxArray() && S_fine.DistributionMap() == S_crse.DistributionMap())
         {
 #ifdef _OPENMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
@@ -471,7 +471,7 @@ namespace amrex
         }
         auto tmptype = type;
         tmptype.unset(dir);
-        if (dir >= AMREX_SPACEDIM or !tmptype.cellCentered()) {
+        if (dir >= AMREX_SPACEDIM || !tmptype.cellCentered()) {
             amrex::Abort("average_down_faces: not face index type");
         }
         const int ncomp = crse.nComp();
@@ -553,7 +553,7 @@ namespace amrex
         }
         auto tmptype = type;
         tmptype.set(dir);
-        if (dir >= AMREX_SPACEDIM or !tmptype.nodeCentered()) {
+        if (dir >= AMREX_SPACEDIM || !tmptype.nodeCentered()) {
             amrex::Abort("average_down_edges: not face index type");
         }
         const int ncomp = crse.nComp();

--- a/Src/Base/AMReX_PCI.H
+++ b/Src/Base/AMReX_PCI.H
@@ -100,8 +100,8 @@ FabArray<FAB>::PC_local_gpu (const CPC& thecpc, FabArray<FAB> const& src,
     Vector<Array4<int> > masks;
     if (!is_thread_safe)
     {
-        if ((op == FabArrayBase::COPY and !amrex::IsStoreAtomic<value_type>::value) or
-            (op == FabArrayBase::ADD  and !amrex::HasAtomicAdd <value_type>::value))
+        if ((op == FabArrayBase::COPY && !amrex::IsStoreAtomic<value_type>::value) ||
+            (op == FabArrayBase::ADD  && !amrex::HasAtomicAdd <value_type>::value))
         {
             maskfabs.resize(this->local_size());
             masks.reserve(N_locs);

--- a/Src/Base/AMReX_ParallelDescriptor.cpp
+++ b/Src/Base/AMReX_ParallelDescriptor.cpp
@@ -2250,7 +2250,7 @@ Asend<char> (const char* buf, size_t n, int pid, int tag, MPI_Comm comm)
         msg = Message(req, Mpi_typemap<char>::type());
     } else if (comm_data_type == 2) {
         if (!amrex::is_aligned(buf, alignof(unsigned long long))
-            or (n % sizeof(unsigned long long)) != 0) {
+            || (n % sizeof(unsigned long long)) != 0) {
             amrex::Abort("Message size is too big as char, and it cannot be sent as unsigned long long.");
         }
         BL_MPI_REQUIRE( MPI_Isend(const_cast<unsigned long long*>
@@ -2261,7 +2261,7 @@ Asend<char> (const char* buf, size_t n, int pid, int tag, MPI_Comm comm)
         msg = Message(req, Mpi_typemap<unsigned long long>::type());
     } else if (comm_data_type == 3) {
         if (!amrex::is_aligned(buf, alignof(ParallelDescriptor::lull_t))
-            or (n % sizeof(ParallelDescriptor::lull_t)) != 0) {
+            || (n % sizeof(ParallelDescriptor::lull_t)) != 0) {
             amrex::Abort("Message size is too big as char or unsigned long long, and it cannot be sent as ParallelDescriptor::lull_t");
         }
         BL_MPI_REQUIRE( MPI_Isend(const_cast<ParallelDescriptor::lull_t*>
@@ -2293,7 +2293,7 @@ Send<char> (const char* buf, size_t n, int pid, int tag, MPI_Comm comm)
                                  pid, tag, comm) );
     } else if (comm_data_type == 2) {
         if (!amrex::is_aligned(buf, alignof(unsigned long long))
-            or (n % sizeof(unsigned long long)) != 0) {
+            || (n % sizeof(unsigned long long)) != 0) {
             amrex::Abort("Message size is too big as char, and it cannot be sent as unsigned long long.");
         }
         BL_MPI_REQUIRE( MPI_Send(const_cast<unsigned long long*>
@@ -2303,7 +2303,7 @@ Send<char> (const char* buf, size_t n, int pid, int tag, MPI_Comm comm)
                                  pid, tag, comm) );
     } else if (comm_data_type == 3) {
         if (!amrex::is_aligned(buf, alignof(ParallelDescriptor::lull_t))
-            or (n % sizeof(ParallelDescriptor::lull_t)) != 0) {
+            || (n % sizeof(ParallelDescriptor::lull_t)) != 0) {
             amrex::Abort("Message size is too big as char or unsigned long long, and it cannot be sent as ParallelDescriptor::lull_t");
         }
         BL_MPI_REQUIRE( MPI_Send(const_cast<ParallelDescriptor::lull_t*>
@@ -2337,7 +2337,7 @@ Arecv<char> (char* buf, size_t n, int pid, int tag, MPI_Comm comm)
         msg = Message(req, Mpi_typemap<char>::type());
     } else if (comm_data_type == 2) {
         if (!amrex::is_aligned(buf, alignof(unsigned long long))
-            or (n % sizeof(unsigned long long)) != 0) {
+            || (n % sizeof(unsigned long long)) != 0) {
             amrex::Abort("Message size is too big as char, and it cannot be received as unsigned long long.");
         }
         BL_MPI_REQUIRE( MPI_Irecv((unsigned long long *)buf,
@@ -2347,7 +2347,7 @@ Arecv<char> (char* buf, size_t n, int pid, int tag, MPI_Comm comm)
         msg = Message(req, Mpi_typemap<unsigned long long>::type());
     } else if (comm_data_type == 3) {
         if (!amrex::is_aligned(buf, alignof(ParallelDescriptor::lull_t))
-            or (n % sizeof(ParallelDescriptor::lull_t)) != 0) {
+            || (n % sizeof(ParallelDescriptor::lull_t)) != 0) {
             amrex::Abort("Message size is too big as char or unsigned long long, and it cannot be received as ParallelDescriptor::lull_t");
         }
         BL_MPI_REQUIRE( MPI_Irecv((ParallelDescriptor::lull_t *)buf,
@@ -2381,7 +2381,7 @@ Recv<char> (char* buf, size_t n, int pid, int tag, MPI_Comm comm)
         msg = Message(stat, Mpi_typemap<char>::type());
     } else if (comm_data_type == 2) {
         if (!amrex::is_aligned(buf, alignof(unsigned long long))
-            or (n % sizeof(unsigned long long)) != 0) {
+            || (n % sizeof(unsigned long long)) != 0) {
             amrex::Abort("Message size is too big as char, and it cannot be received as unsigned long long.");
         }
         BL_MPI_REQUIRE( MPI_Recv((unsigned long long *)buf,
@@ -2391,7 +2391,7 @@ Recv<char> (char* buf, size_t n, int pid, int tag, MPI_Comm comm)
         msg = Message(stat, Mpi_typemap<unsigned long long>::type());
     } else if (comm_data_type == 3) {
         if (!amrex::is_aligned(buf, alignof(ParallelDescriptor::lull_t))
-            or (n % sizeof(ParallelDescriptor::lull_t)) != 0) {
+            || (n % sizeof(ParallelDescriptor::lull_t)) != 0) {
             amrex::Abort("Message size is too big as char or unsigned long long, and it cannot be received as ParallelDescriptor::lull_t");
         }
         BL_MPI_REQUIRE( MPI_Recv((ParallelDescriptor::lull_t *)buf,

--- a/Src/Base/AMReX_PlotFileDataImpl.cpp
+++ b/Src/Base/AMReX_PlotFileDataImpl.cpp
@@ -110,7 +110,7 @@ PlotFileDataImpl::syncDistributionMap (PlotFileDataImpl const& src) noexcept
 void
 PlotFileDataImpl::syncDistributionMap (int level, PlotFileDataImpl const& src) noexcept
 {
-    if (level <= src.finestLevel() and m_dmap[level].size() == src.DistributionMap(level).size()) {
+    if (level <= src.finestLevel() && m_dmap[level].size() == src.DistributionMap(level).size()) {
         m_dmap[level] = src.DistributionMap(level);
     }
 }

--- a/Src/Base/AMReX_Reduce.H
+++ b/Src/Base/AMReX_Reduce.H
@@ -607,13 +607,13 @@ bool AnyOf (N n, T const* v, P&& pred)
         {
             int r = false;
             for (N i = blockDim.x*blockIdx.x+threadIdx.x, stride = blockDim.x*gridDim.x;
-                 i < n and !r; i += stride)
+                 i < n && !r; i += stride)
             {
                 r = pred(v[i]) ? 1 : 0;
             }
             r = Gpu::blockReduce<Gpu::Device::warp_size>
                 (r, Gpu::warpReduce<Gpu::Device::warp_size,int,amrex::Plus<int> >(), 0);
-            if (threadIdx.x == 0 and r) *dp = 1;
+            if (threadIdx.x == 0 && r) *dp = 1;
         }
     });
 #endif
@@ -649,7 +649,7 @@ bool AnyOf (Box const& box, P&& pred)
         {
             int r = false;
             for (int icell = blockDim.x*blockIdx.x+threadIdx.x, stride = blockDim.x*gridDim.x;
-                 icell < ncells and !r; icell += stride) {
+                 icell < ncells && !r; icell += stride) {
                 int k =  icell /   (len.x*len.y);
                 int j = (icell - k*(len.x*len.y)) /   len.x;
                 int i = (icell - k*(len.x*len.y)) - j*len.x;
@@ -660,7 +660,7 @@ bool AnyOf (Box const& box, P&& pred)
             }
             r = Gpu::blockReduce<Gpu::Device::warp_size>
                 (r, Gpu::warpReduce<Gpu::Device::warp_size,int,amrex::Plus<int> >(), 0);
-            if (threadIdx.x == 0 and r) *dp = 1;
+            if (threadIdx.x == 0 && r) *dp = 1;
         }
     });
 #endif

--- a/Src/Base/AMReX_Slopes_K.H
+++ b/Src/Base/AMReX_Slopes_K.H
@@ -67,9 +67,9 @@ amrex::Real amrex_calc_xslope_extdir (int i, int j, int k, int n, int order,
         amrex::Real dr = 2.0*(q(i+1,j,k,n) - q(i  ,j,k,n));
         amrex::Real dc = 0.5*(q(i+1,j,k,n) - q(i-1,j,k,n));
 
-        if (edlo and i == domlo) {
+        if (edlo && i == domlo) {
             dc = (q(i+1,j,k,n)+3.0*q(i,j,k,n)-4.0*q(i-1,j,k,n))/3.0;
-        } else if (edhi and i == domhi) {
+        } else if (edhi && i == domhi) {
             dc = (4.0*q(i+1,j,k,n)-3.0*q(i,j,k,n)-q(i-1,j,k,n))/3.0;
         }
 
@@ -107,13 +107,13 @@ amrex::Real amrex_calc_xslope_extdir (int i, int j, int k, int n, int order,
 
         dtemp  = 4.0/3.0*dcen - 1.0/6.0*(dfp + dfm);
 
-        if (edlo and i == domlo) {
+        if (edlo && i == domlo) {
            dtemp  = -16./15.*q(i-1,j,k,n) + .5*q(i,j,k,n) + 2./3.*q(i+1,j,k,n) -  0.1*q(i+2,j,k,n);
            dlft = 2.*(q(i  ,j,k,n)-q(i-1,j,k,n));
            drgt = 2.*(q(i+1,j,k,n)-q(i  ,j,k,n));
            dlim = (dlft*drgt >= 0.0) ? amrex::min(amrex::Math::abs(dlft), amrex::Math::abs(drgt)) : 0.0;
            dsgn = amrex::Math::copysign(1.e0, dtemp);
-        } else if (edlo and i == domlo+1) {
+        } else if (edlo && i == domlo+1) {
            dfm  = -16./15.*q(domlo-1,j,k,n) + .5*q(domlo,j,k,n) + 2./3.*q(domlo+1,j,k,n) -  0.1*q(domlo+2,j,k,n);
            dlft = 2.*(q(domlo  ,j,k,n)-q(domlo-1,j,k,n));
            drgt = 2.*(q(domlo+1,j,k,n)-q(domlo  ,j,k,n));
@@ -123,13 +123,13 @@ amrex::Real amrex_calc_xslope_extdir (int i, int j, int k, int n, int order,
            dtemp  = 4.0/3.0*dcen - 1.0/6.0*(dfp + dfm);
         }
 
-        if (edhi and i == domhi) {
+        if (edhi && i == domhi) {
            dtemp  = 16./15.*q(i+1,j,k,n) - .5*q(i,j,k,n) - 2./3.*q(i-1,j,k,n) +  0.1*q(i-2,j,k,n);
            dlft = 2.*(q(i  ,j,k,n)-q(i-1,j,k,n));
            drgt = 2.*(q(i+1,j,k,n)-q(i  ,j,k,n));
            dlim = (dlft*drgt >= 0.0) ? amrex::min(amrex::Math::abs(dlft), amrex::Math::abs(drgt)) : 0.0;
            dsgn = amrex::Math::copysign(1.e0, dtemp);
-        } else if (edhi and i == domhi-1) {
+        } else if (edhi && i == domhi-1) {
            dfp  = 16./15.*q(domhi+1,j,k,n) - .5*q(domhi,j,k,n) - 2./3.*q(domhi-1,j,k,n) +  0.1*q(domhi-2,j,k,n);
            dlft = 2.*(q(domhi  ,j,k,n)-q(domhi-1,j,k,n));
            drgt = 2.*(q(domhi+1,j,k,n)-q(domhi  ,j,k,n));
@@ -206,9 +206,9 @@ amrex::Real amrex_calc_yslope_extdir (int i, int j, int k, int n, int order,
         amrex::Real dl = 2.0*(q(i,j  ,k,n) - q(i,j-1,k,n));
         amrex::Real dr = 2.0*(q(i,j+1,k,n) - q(i,j  ,k,n));
         amrex::Real dc = 0.5*(q(i,j+1,k,n) - q(i,j-1,k,n));
-        if (edlo and j == domlo) {
+        if (edlo && j == domlo) {
             dc = (q(i,j+1,k,n)+3.0*q(i,j,k,n)-4.0*q(i,j-1,k,n))/3.0;
-        } else if (edhi and j == domhi) {
+        } else if (edhi && j == domhi) {
             dc = (4.0*q(i,j+1,k,n)-3.0*q(i,j,k,n)-q(i,j-1,k,n))/3.0;
         }
         amrex::Real slope = amrex::min(amrex::Math::abs(dl),amrex::Math::abs(dc),amrex::Math::abs(dr));
@@ -245,13 +245,13 @@ amrex::Real amrex_calc_yslope_extdir (int i, int j, int k, int n, int order,
 
         dtemp  = 4.0/3.0*dcen - 1.0/6.0*(dfp + dfm);
 
-        if (edlo and j == domlo) {
+        if (edlo && j == domlo) {
            dtemp  = -16./15.*q(i,j-1,k,n) + .5*q(i,j,k,n) + 2./3.*q(i,j+1,k,n) -  0.1*q(i,j+2,k,n);
            dlft = 2.*(q(i  ,j,k,n)-q(i,j-1,k,n));
            drgt = 2.*(q(i,j+1,k,n)-q(i  ,j,k,n));
            dlim = (dlft*drgt >= 0.0) ? amrex::min(amrex::Math::abs(dlft), amrex::Math::abs(drgt)) : 0.0;
            dsgn = amrex::Math::copysign(1.e0, dtemp);
-        } else if (edlo and j == domlo+1) {
+        } else if (edlo && j == domlo+1) {
            dfm  = -16./15.*q(i,domlo-1,k,n) + .5*q(i,domlo,k,n) + 2./3.*q(i,domlo+1,k,n) -  0.1*q(i,domlo+2,k,n);
            dlft = 2.*(q(i  ,domlo,k,n)-q(i,domlo-1,k,n));
            drgt = 2.*(q(i,domlo+1,k,n)-q(i  ,domlo,k,n));
@@ -261,13 +261,13 @@ amrex::Real amrex_calc_yslope_extdir (int i, int j, int k, int n, int order,
            dtemp  = 4.0/3.0*dcen - 1.0/6.0*(dfp + dfm);
         }
 
-        if (edhi and j == domhi) {
+        if (edhi && j == domhi) {
            dtemp  = 16./15.*q(i,j+1,k,n) - .5*q(i,j,k,n) - 2./3.*q(i,j-1,k,n) +  0.1*q(i,j-2,k,n);
            dlft = 2.*(q(i  ,j,k,n)-q(i,j-1,k,n));
            drgt = 2.*(q(i,j+1,k,n)-q(i  ,j,k,n));
            dlim = (dlft*drgt >= 0.0) ? amrex::min(amrex::Math::abs(dlft), amrex::Math::abs(drgt)) : 0.0;
            dsgn = amrex::Math::copysign(1.e0, dtemp);
-        } else if (edhi and j == domhi-1) {
+        } else if (edhi && j == domhi-1) {
            dfp  = 16./15.*q(i,domhi+1,k,n) - .5*q(i,domhi,k,n) - 2./3.*q(i,domhi-1,k,n) +  0.1*q(i,domhi-2,k,n);
            dlft = 2.*(q(i  ,domhi,k,n)-q(i,domhi-1,k,n));
            drgt = 2.*(q(i,domhi+1,k,n)-q(i  ,domhi,k,n));
@@ -345,9 +345,9 @@ amrex::Real amrex_calc_zslope_extdir (int i, int j, int k, int n, int order,
         amrex::Real dl = 2.0*(q(i,j,k  ,n) - q(i,j,k-1,n));
         amrex::Real dr = 2.0*(q(i,j,k+1,n) - q(i,j,k  ,n));
         amrex::Real dc = 0.5*(q(i,j,k+1,n) - q(i,j,k-1,n));
-        if (edlo and k == domlo) {
+        if (edlo && k == domlo) {
             dc = (q(i,j,k+1,n)+3.0*q(i,j,k,n)-4.0*q(i,j,k-1,n))/3.0;
-        } else if (edhi and k == domhi) {
+        } else if (edhi && k == domhi) {
             dc = (4.0*q(i,j,k+1,n)-3.0*q(i,j,k,n)-q(i,j,k-1,n))/3.0;
         }
         amrex::Real slope = amrex::min(amrex::Math::abs(dl),amrex::Math::abs(dc),amrex::Math::abs(dr));
@@ -384,13 +384,13 @@ amrex::Real amrex_calc_zslope_extdir (int i, int j, int k, int n, int order,
 
         dtemp  = 4.0/3.0*dcen - 1.0/6.0*(dfp + dfm);
 
-        if (edlo and k == domlo) {
+        if (edlo && k == domlo) {
            dtemp  = -16./15.*q(i,j,k-1,n) + .5*q(i,j,k,n) + 2./3.*q(i,j,k+1,n) -  0.1*q(i,j,k+2,n);
            dlft = 2.*(q(i  ,j,k,n)-q(i,j,k-1,n));
            drgt = 2.*(q(i,j,k+1,n)-q(i  ,j,k,n));
            dlim = (dlft*drgt >= 0.0) ? amrex::min(amrex::Math::abs(dlft), amrex::Math::abs(drgt)) : 0.0;
            dsgn = amrex::Math::copysign(1.e0, dtemp);
-        } else if (edlo and k == domlo+1) {
+        } else if (edlo && k == domlo+1) {
            dfm  = -16./15.*q(i,j,domlo-1,n) + .5*q(i,j,domlo,n) + 2./3.*q(i,j,domlo+1,n) -  0.1*q(i,j,domlo+2,n);
            dlft = 2.*(q(i  ,j,domlo,n)-q(i,j,domlo-1,n));
            drgt = 2.*(q(i,j,domlo+1,n)-q(i  ,j,domlo,n));
@@ -400,13 +400,13 @@ amrex::Real amrex_calc_zslope_extdir (int i, int j, int k, int n, int order,
            dtemp  = 4.0/3.0*dcen - 1.0/6.0*(dfp + dfm);
         }
 
-        if (edhi and k == domhi) {
+        if (edhi && k == domhi) {
            dtemp  = 16./15.*q(i,j,k+1,n) - .5*q(i,j,k,n) - 2./3.*q(i,j,k-1,n) +  0.1*q(i,j,k-2,n);
            dlft = 2.*(q(i  ,j,k,n)-q(i,j,k-1,n));
            drgt = 2.*(q(i,j,k+1,n)-q(i  ,j,k,n));
            dlim = (dlft*drgt >= 0.0) ? amrex::min(amrex::Math::abs(dlft), amrex::Math::abs(drgt)) : 0.0;
            dsgn = amrex::Math::copysign(1.e0, dtemp);
-        } else if (edhi and k == domhi-1) {
+        } else if (edhi && k == domhi-1) {
            dfp  = 16./15.*q(i,j,domhi+1,n) - .5*q(i,j,domhi,n) - 2./3.*q(i,j,domhi-1,n) +  0.1*q(i,j,domhi-2,n);
            dlft = 2.*(q(i  ,j,domhi,n)-q(i,j,domhi-1,n));
            drgt = 2.*(q(i,j,domhi+1,n)-q(i  ,j,domhi,n));

--- a/Src/Base/AMReX_TypeTraits.H
+++ b/Src/Base/AMReX_TypeTraits.H
@@ -119,7 +119,7 @@ namespace amrex
     template <typename T, typename U1, typename... Us>
     struct Same
     {
-        static constexpr bool value = std::is_same<T,U1>::value and Same<T,Us...>::value;
+        static constexpr bool value = std::is_same<T,U1>::value && Same<T,Us...>::value;
     };
 }
 

--- a/Src/Base/AMReX_Vector.H
+++ b/Src/Base/AMReX_Vector.H
@@ -254,7 +254,7 @@ namespace amrex
             std::size_t swapPos = 0;
             for (std::size_t i = 0; i < N; ++i) {
                 // move type 2 to the beginning pointed to by swapPos
-                if (data[i] != sentinel and i == hasher(data[i]) % N) {
+                if (data[i] != sentinel && i == hasher(data[i]) % N) {
                     std::swap(data[i], data[swapPos++]);
                 }
             }

--- a/Src/Base/AMReX_VisMF.cpp
+++ b/Src/Base/AMReX_VisMF.cpp
@@ -669,8 +669,8 @@ VisMF::Header::Header (const FabArray<FArrayBox>& mf,
     }
 
     bool run_on_device = Gpu::inLaunchRegion()
-        and (mf.arena() == The_Arena() or
-             mf.arena() == The_Device_Arena() or
+        && (mf.arena() == The_Arena() ||
+             mf.arena() == The_Device_Arena() ||
              mf.arena() == The_Managed_Arena());
 
     if(version == NoFabHeaderFAMinMax_v1) {
@@ -715,8 +715,8 @@ VisMF::Header::CalculateMinMax (const FabArray<FArrayBox>& mf,
     m_max.resize(m_ba.size());
 
     bool run_on_device = Gpu::inLaunchRegion()
-        and (mf.arena() == The_Arena() or
-             mf.arena() == The_Device_Arena() or
+        && (mf.arena() == The_Arena() ||
+             mf.arena() == The_Device_Arena() ||
              mf.arena() == The_Managed_Arena());
 
 #ifdef BL_USE_MPI
@@ -963,12 +963,12 @@ VisMF::Write (const FabArray<FArrayBox>&    mf,
     }
     bool doConvert(*whichRD != FPC::NativeRealDescriptor());
 
-    if(set_ghost and mf.nGrowVect() != 0) {
+    if(set_ghost && mf.nGrowVect() != 0) {
         FabArray<FArrayBox>* the_mf = const_cast<FabArray<FArrayBox>*>(&mf);
 
         bool run_on_device = Gpu::inLaunchRegion()
-            and (mf.arena() == The_Arena() or
-                 mf.arena() == The_Device_Arena() or
+            && (mf.arena() == The_Arena() ||
+                 mf.arena() == The_Device_Arena() ||
                  mf.arena() == The_Managed_Arena());
 
         for(MFIter mfi(*the_mf); mfi.isValid(); ++mfi) {
@@ -2183,7 +2183,7 @@ VisMF::AsyncWrite (const FabArray<FArrayBox>& mf, const std::string& mf_name, bo
     if (AsyncOut::UseAsyncOut()) {
         AsyncWriteDoit(mf, mf_name, false, valid_cells_only);
     } else {
-        if (valid_cells_only and mf.nGrowVect() != 0) {
+        if (valid_cells_only && mf.nGrowVect() != 0) {
             FabArray<FArrayBox> mf_tmp(mf.boxArray(), mf.DistributionMap(), mf.nComp(), 0);
             amrex::Copy(mf_tmp, mf, 0, 0, mf.nComp(), 0);
             Write(mf_tmp, mf_name);
@@ -2199,7 +2199,7 @@ VisMF::AsyncWrite (FabArray<FArrayBox>&& mf, const std::string& mf_name, bool va
     if (AsyncOut::UseAsyncOut()) {
         AsyncWriteDoit(mf, mf_name, true, valid_cells_only);
     } else {
-        if (valid_cells_only and mf.nGrowVect() != 0) {
+        if (valid_cells_only && mf.nGrowVect() != 0) {
             FabArray<FArrayBox> mf_tmp(mf.boxArray(), mf.DistributionMap(), mf.nComp(), 0);
             amrex::Copy(mf_tmp, mf, 0, 0, mf.nComp(), 0);
             Write(mf_tmp, mf_name);
@@ -2216,7 +2216,7 @@ VisMF::AsyncWriteDoit (const FabArray<FArrayBox>& mf, const std::string& mf_name
     BL_PROFILE("VisMF::AsyncWrite()");
 
     AMREX_ASSERT(mf_name[mf_name.length() - 1] != '/');
-    static_assert(sizeof(int64_t) == sizeof(Real)*2 or sizeof(int64_t) == sizeof(Real),
+    static_assert(sizeof(int64_t) == sizeof(Real)*2 || sizeof(int64_t) == sizeof(Real),
                   "AsyncWrite: unsupported Real size");
 
     const DistributionMapping& dm = mf.DistributionMap();
@@ -2240,12 +2240,12 @@ VisMF::AsyncWriteDoit (const FabArray<FArrayBox>& mf, const std::string& mf_name
     const Long n_local_nums = n_fab_nums * n_local_fabs + 1;
     Vector<int64_t> localdata(n_local_nums);
 
-    bool data_on_device = (mf.arena() == The_Arena() or
-                           mf.arena() == The_Device_Arena() or
+    bool data_on_device = (mf.arena() == The_Arena() ||
+                           mf.arena() == The_Device_Arena() ||
                            mf.arena() == The_Managed_Arena());
-    bool run_on_device = Gpu::inLaunchRegion() and data_on_device;
+    bool run_on_device = Gpu::inLaunchRegion() && data_on_device;
 
-    bool strip_ghost = valid_cells_only and mf.nGrowVect() != 0;
+    bool strip_ghost = valid_cells_only && mf.nGrowVect() != 0;
 
     int64_t total_bytes = 0;
     auto pld = (char*)(&(localdata[1]));
@@ -2327,7 +2327,7 @@ VisMF::AsyncWriteDoit (const FabArray<FArrayBox>& mf, const std::string& mf_name
         } else
 #endif
         {
-            if (is_rvalue and not strip_ghost) {
+            if (is_rvalue && ! strip_ghost) {
                 myfabs->emplace_back(std::move(const_cast<FArrayBox&>(mf[mfi])));
             } else {
                 myfabs->emplace_back(bx, mf.nComp(), The_Cpu_Arena());

--- a/Src/Boundary/AMReX_InterpBndryData_2D_K.H
+++ b/Src/Boundary/AMReX_InterpBndryData_2D_K.H
@@ -36,8 +36,8 @@ void interpbndrydata_x_o3 (int i, int j, int /*k*/, int n,
         x[NN] = -1.0;
         y[NN] = crse(ic,jc-1,0,n+nc);
         ++NN;
-    } else if (mask.contains(i,(jc+2)*r.y,0) and
-               mask         (i,(jc+2)*r.y,0) == not_covered and crse.contains(ic,jc+2,0)) {
+    } else if (mask.contains(i,(jc+2)*r.y,0) &&
+               mask         (i,(jc+2)*r.y,0) == not_covered && crse.contains(ic,jc+2,0)) {
         x[NN] = 2.0;
         y[NN] = crse(ic,jc+2,0,n+nc);
         ++NN;
@@ -47,14 +47,14 @@ void interpbndrydata_x_o3 (int i, int j, int /*k*/, int n,
         x[NN] = 1.0;
         y[NN] = crse(ic,jc+1,0,n+nc);
         ++NN;
-    } else if (mask.contains(i,jc*r.y-r.y-1,0) and
-               mask         (i,jc*r.y-r.y-1,0) == not_covered and crse.contains(ic,jc-2,0)) {
+    } else if (mask.contains(i,jc*r.y-r.y-1,0) &&
+               mask         (i,jc*r.y-r.y-1,0) == not_covered && crse.contains(ic,jc-2,0)) {
         x[NN] = -2.0;
         y[NN] = crse(ic,jc-2,0,n+nc);
         ++NN;
     }
 
-    if ( (mask(i,j-r.y,0) != not_covered) and (mask(i,j+r.y,0) != not_covered) ) {
+    if ( (mask(i,j-r.y,0) != not_covered) && (mask(i,j+r.y,0) != not_covered) ) {
         NN = 1;
     }
 
@@ -85,8 +85,8 @@ void interpbndrydata_y_o3 (int i, int j, int /*k*/, int n,
         x[NN] = -1.0;
         y[NN] = crse(ic-1,jc,0,n+nc);
         ++NN;
-    } else if (mask.contains((ic+2)*r.x,j,0) and
-               mask         ((ic+2)*r.x,j,0) == not_covered and crse.contains(ic+2,jc,0)) {
+    } else if (mask.contains((ic+2)*r.x,j,0) &&
+               mask         ((ic+2)*r.x,j,0) == not_covered && crse.contains(ic+2,jc,0)) {
         x[NN] = 2.0;
         y[NN] = crse(ic+2,jc,0,n+nc);
         ++NN;
@@ -96,14 +96,14 @@ void interpbndrydata_y_o3 (int i, int j, int /*k*/, int n,
         x[NN] = 1.0;
         y[NN] = crse(ic+1,jc,0,n+nc);
         ++NN;
-    } else if (mask.contains(ic*r.x-r.x-1,j,0) and
-               mask         (ic*r.x-r.x-1,j,0) == not_covered and crse.contains(ic-2,jc,0)) {
+    } else if (mask.contains(ic*r.x-r.x-1,j,0) &&
+               mask         (ic*r.x-r.x-1,j,0) == not_covered && crse.contains(ic-2,jc,0)) {
         x[NN] = -2.0;
         y[NN] = crse(ic-2,jc,0,n+nc);
         ++NN;
     }
 
-    if ( (mask(i-r.x,j,0) != not_covered) and (mask(i+r.x,j,0) != not_covered) ) {
+    if ( (mask(i-r.x,j,0) != not_covered) && (mask(i+r.x,j,0) != not_covered) ) {
         NN = 1;
     }
 

--- a/Src/Boundary/AMReX_InterpBndryData_3D_K.H
+++ b/Src/Boundary/AMReX_InterpBndryData_3D_K.H
@@ -40,8 +40,8 @@ void interpbndrydata_x_o3 (int i, int j, int k, int n,
     Real dz = fac*(crse(ic,jc,hi,n+nc)-crse(ic,jc,lo,n+nc));
     Real dz2 = (hi==lo+2) ? Real(0.5)*(crse(ic,jc,kc+1,n+nc) - Real(2.)*crse(ic,jc,kc,n+nc) + crse(ic,jc,kc-1,n+nc)) : Real(0.);
 
-    Real dyz = (mask(i,j-r.y,k-r.z) == not_covered and mask(i,j+r.y,k-r.z) == not_covered and
-                mask(i,j-r.y,k+r.z) == not_covered and mask(i,j+r.y,k+r.z) == not_covered)
+    Real dyz = (mask(i,j-r.y,k-r.z) == not_covered && mask(i,j+r.y,k-r.z) == not_covered &&
+                mask(i,j-r.y,k+r.z) == not_covered && mask(i,j+r.y,k+r.z) == not_covered)
         ? Real(0.25)*(crse(ic,jc+1,kc+1,n+nc)-crse(ic,jc-1,kc+1,n+nc)+crse(ic,jc-1,kc-1,n+nc)-crse(ic,jc+1,kc-1,n+nc))
         : 0.0;
 
@@ -72,8 +72,8 @@ void interpbndrydata_y_o3 (int i, int j, int k, int n,
     Real dz = fac*(crse(ic,jc,hi,n+nc)-crse(ic,jc,lo,n+nc));
     Real dz2 = (hi==lo+2) ? Real(0.5)*(crse(ic,jc,kc+1,n+nc) - Real(2.)*crse(ic,jc,kc,n+nc) + crse(ic,jc,kc-1,n+nc)) : Real(0.);
 
-    Real dxz = (mask(i-r.x,j,k-r.z) == not_covered and mask(i+r.x,j,k-r.z) == not_covered and
-                mask(i-r.x,j,k+r.z) == not_covered and mask(i+r.x,j,k+r.z) == not_covered)
+    Real dxz = (mask(i-r.x,j,k-r.z) == not_covered && mask(i+r.x,j,k-r.z) == not_covered &&
+                mask(i-r.x,j,k+r.z) == not_covered && mask(i+r.x,j,k+r.z) == not_covered)
         ? Real(0.25)*(crse(ic+1,jc,kc+1,n+nc)-crse(ic-1,jc,kc+1,n+nc)+crse(ic-1,jc,kc-1,n+nc)-crse(ic+1,jc,kc-1,n+nc))
         : 0.0;
 
@@ -105,8 +105,8 @@ void interpbndrydata_z_o3 (int i, int j, int k, int n,
     Real dy = fac*(crse(ic,hi,kc,n+nc)-crse(ic,lo,kc,n+nc));
     Real dy2 = (hi==lo+2) ? Real(0.5)*(crse(ic,jc+1,kc,n+nc) - Real(2.)*crse(ic,jc,kc,n+nc) + crse(ic,jc-1,kc,n+nc)) : Real(0.);
 
-    Real dxy = (mask(i-r.x,j-r.y,k) == not_covered and mask(i+r.x,j-r.y,k) == not_covered and
-                mask(i-r.x,j+r.y,k) == not_covered and mask(i+r.x,j+r.y,k) == not_covered)
+    Real dxy = (mask(i-r.x,j-r.y,k) == not_covered && mask(i+r.x,j-r.y,k) == not_covered &&
+                mask(i-r.x,j+r.y,k) == not_covered && mask(i+r.x,j+r.y,k) == not_covered)
         ? Real(0.25)*(crse(ic+1,jc+1,kc,n+nc)-crse(ic-1,jc+1,kc,n+nc)+crse(ic-1,jc-1,kc,n+nc)-crse(ic+1,jc-1,kc,n+nc))
         : 0.0;
 

--- a/Src/EB/AMReX_EB2_2D_C.H
+++ b/Src/EB/AMReX_EB2_2D_C.H
@@ -17,13 +17,13 @@ amrex_eb2_build_types (Box const& tbx, Box const& bxg2,
     amrex::Loop(lo, hi,
     [=] (int i, int j, int k) noexcept
     {
-        if (    s(i,j  ,k) < 0.0 and s(i+1,j  ,k) < 0.0
-            and s(i,j+1,k) < 0.0 and s(i+1,j+1,k) < 0.0)
+        if (    s(i,j  ,k) < 0.0 && s(i+1,j  ,k) < 0.0
+            && s(i,j+1,k) < 0.0 && s(i+1,j+1,k) < 0.0)
         {
             cell(i,j,k).setRegular();
         }
-        else if (s(i,j  ,k) >= 0.0 and s(i+1,j  ,k) >= 0.0
-            and  s(i,j+1,k) >= 0.0 and s(i+1,j+1,k) >= 0.0)
+        else if (s(i,j  ,k) >= 0.0 && s(i+1,j  ,k) >= 0.0
+            &&  s(i,j+1,k) >= 0.0 && s(i+1,j+1,k) >= 0.0)
         {
             cell(i,j,k).setCovered();
         }
@@ -40,9 +40,9 @@ amrex_eb2_build_types (Box const& tbx, Box const& bxg2,
     amrex::Loop(lo, hi,
     [=] (int i, int j, int k) noexcept
     {
-        if (s(i,j,k) < 0.0 and s(i,j+1,k) < 0.0) {
+        if (s(i,j,k) < 0.0 && s(i,j+1,k) < 0.0) {
             fx(i,j,k) = Type::regular;
-        } else if (s(i,j,k) >= 0.0 and s(i,j+1,k) >= 0.0) {
+        } else if (s(i,j,k) >= 0.0 && s(i,j+1,k) >= 0.0) {
             fx(i,j,k) = Type::covered;
         } else {
             fx(i,j,k) = Type::irregular;
@@ -56,9 +56,9 @@ amrex_eb2_build_types (Box const& tbx, Box const& bxg2,
     amrex::Loop(lo, hi,
     [=] (int i, int j, int k) noexcept
     {
-        if (s(i,j,k) < 0.0 and s(i+1,j,k) < 0.0) {
+        if (s(i,j,k) < 0.0 && s(i+1,j,k) < 0.0) {
             fy(i,j,k) = Type::regular;
-        } else if (s(i,j,k) >= 0.0 and s(i+1,j,k) >= 0.0) {
+        } else if (s(i,j,k) >= 0.0 && s(i+1,j,k) >= 0.0) {
             fy(i,j,k) = Type::covered;
         } else {
             fy(i,j,k) = Type::irregular;
@@ -69,7 +69,7 @@ amrex_eb2_build_types (Box const& tbx, Box const& bxg2,
 namespace {
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     int num_cuts (Real a, Real b) noexcept {
-        return (a >= 0.0 and b < 0.0) or (b >= 0.0 and a < 0.0);
+        return (a >= 0.0 && b < 0.0) || (b >= 0.0 && a < 0.0);
     }
 }
 
@@ -87,7 +87,7 @@ int check_mvmc (int i, int j, int, Array4<Real const> const& fine)
         +       num_cuts(fine(i  ,j+1,k),fine(i  ,j+2,k))
         +       num_cuts(fine(i+2,j  ,k),fine(i+2,j+1,k))
         +       num_cuts(fine(i+2,j+1,k),fine(i+2,j+2,k));
-    return (ncuts != 0 and ncuts != 2);
+    return (ncuts != 0 && ncuts != 2);
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
@@ -183,13 +183,13 @@ int coarsen_from_fine (int i, int j, Box const& bx, Box const& gbx,
              Real nfac = 1.0/std::sqrt(nx*nx+ny*ny+1.e-50);
              cbn(i,j,k,0) = nx*nfac;
              cbn(i,j,k,1) = ny*nfac;
-             ierr = (nx == 0.0 and ny == 0.0)
+             ierr = (nx == 0.0 && ny == 0.0)
                  // we must check the enclosing surface to make sure the coarse cell does not
                  // fully contains the geometry object.
-                 or ( fapx(ii,jj  ,k)==1.0 and fapx(ii+2,jj  ,k)==1.0
-                  and fapx(ii,jj+1,k)==1.0 and fapx(ii+2,jj+1,k)==1.0
-                  and fapy(ii,jj  ,k)==1.0 and fapy(ii+1,jj  ,k)==1.0
-                  and fapy(ii,jj+2,k)==1.0 and fapy(ii+1,jj+2,k)==1.0);
+                 || ( fapx(ii,jj  ,k)==1.0 && fapx(ii+2,jj  ,k)==1.0
+                  && fapx(ii,jj+1,k)==1.0 && fapx(ii+2,jj+1,k)==1.0
+                  && fapy(ii,jj  ,k)==1.0 && fapy(ii+1,jj  ,k)==1.0
+                  && fapy(ii,jj+2,k)==1.0 && fapy(ii+1,jj+2,k)==1.0);
         }
     }
     else if (gbx.contains(iv))
@@ -256,26 +256,26 @@ void build_cellflag_from_ap (int i, int j, Array4<EBCellFlag> const& cflag,
     if (apy(i  ,j  ,k) == 0.0) flg.setDisconnected( 0,-1, 0);
     if (apy(i  ,j+1,k) == 0.0) flg.setDisconnected( 0, 1, 0);
 
-    if ((apx(i,j  ,k) == 0.0 or apy(i-1,j,k) == 0.0) and
-        (apx(i,j-1,k) == 0.0 or apy(i  ,j,k) == 0.0))
+    if ((apx(i,j  ,k) == 0.0 || apy(i-1,j,k) == 0.0) &&
+        (apx(i,j-1,k) == 0.0 || apy(i  ,j,k) == 0.0))
     {
         flg.setDisconnected(-1,-1,0);
     }
 
-    if ((apx(i+1,j  ,k) == 0.0 or apy(i+1,j,k) == 0.0) and
-        (apx(i+1,j-1,k) == 0.0 or apy(i  ,j,k) == 0.0))
+    if ((apx(i+1,j  ,k) == 0.0 || apy(i+1,j,k) == 0.0) &&
+        (apx(i+1,j-1,k) == 0.0 || apy(i  ,j,k) == 0.0))
     {
         flg.setDisconnected(1,-1,0);
     }
 
-    if ((apx(i,j  ,k) == 0.0 or apy(i-1,j+1,k) == 0.0) and
-        (apx(i,j+1,k) == 0.0 or apy(i  ,j+1,k) == 0.0))
+    if ((apx(i,j  ,k) == 0.0 || apy(i-1,j+1,k) == 0.0) &&
+        (apx(i,j+1,k) == 0.0 || apy(i  ,j+1,k) == 0.0))
     {
         flg.setDisconnected(-1,1,0);
     }
 
-    if ((apx(i+1,j  ,k) == 0.0 or apy(i+1,j+1,k) == 0.0) and
-        (apx(i+1,j+1,k) == 0.0 or apy(i  ,j+1,k) == 0.0))
+    if ((apx(i+1,j  ,k) == 0.0 || apy(i+1,j+1,k) == 0.0) &&
+        (apx(i+1,j+1,k) == 0.0 || apy(i  ,j+1,k) == 0.0))
     {
         flg.setDisconnected(1,1,0);
     }

--- a/Src/EB/AMReX_EB2_2D_C.cpp
+++ b/Src/EB/AMReX_EB2_2D_C.cpp
@@ -57,7 +57,7 @@ void set_eb_data (const int i, const int j,
     bnorm(i,j,0,0) = nx;
     bnorm(i,j,0,1) = ny;
 
-    if (nxabs < tiny or nyabs > almostone) {
+    if (nxabs < tiny || nyabs > almostone) {
         barea(i,j,0) = 1.0;
         bcent(i,j,0,0) = 0.0;
         bnorm(i,j,0,0) = 0.0;
@@ -65,7 +65,7 @@ void set_eb_data (const int i, const int j,
         vfrac(i,j,0) = 0.5*(axm+axp);
         vcent(i,j,0,0) = 0.0;
         vcent(i,j,0,1) = (0.125*(ayp-aym) + ny*0.5*bcent(i,j,0,1)*bcent(i,j,0,1)) / (vfrac(i,j,0) + 1.e-30);
-    } else if (nyabs < tiny or nxabs > almostone) {
+    } else if (nyabs < tiny || nxabs > almostone) {
         barea(i,j,0) = 1.0;
         bcent(i,j,0,1) = 0.0;
         bnorm(i,j,0,0) = signx;
@@ -212,13 +212,13 @@ void build_faces (Box const& bx, Array4<EBCellFlag> const& cell,
     AMREX_HOST_DEVICE_FOR_3D ( bxg1, i, j, k,
     {
         if (cell(i,j,0).isSingleValued()) {
-            if (fx(i,j,0) == Type::regular and fx(i+1,j,0) == Type::regular and
-                fy(i,j,0) == Type::regular and fy(i,j+1,0) == Type::regular)
+            if (fx(i,j,0) == Type::regular && fx(i+1,j,0) == Type::regular &&
+                fy(i,j,0) == Type::regular && fy(i,j+1,0) == Type::regular)
             {
                 cell(i,j,0).setRegular();
             }
-            else if (fx(i,j,0) == Type::covered and fx(i+1,j,0) == Type::covered and
-                     fy(i,j,0) == Type::covered and fy(i,j+1,0) == Type::covered)
+            else if (fx(i,j,0) == Type::covered && fx(i+1,j,0) == Type::covered &&
+                     fy(i,j,0) == Type::covered && fy(i,j+1,0) == Type::covered)
             {
                 cell(i,j,0).setCovered();
             }
@@ -289,7 +289,7 @@ void build_cells (Box const& bx, Array4<EBCellFlag> const& cell,
            }
        }
 
-       if (not gdomain.contains(bxg1)) {
+       if (! gdomain.contains(bxg1)) {
        AMREX_HOST_DEVICE_FOR_3D ( bxg1, i, j, k,
        {
               const auto & dlo = gdomain.loVect();
@@ -320,8 +320,8 @@ void build_cells (Box const& bx, Array4<EBCellFlag> const& cell,
               }
 
               // set cell in extendable region to covered if necessary
-              if( in_extended_domain and (not cell(i,j,k).isCovered()) 
-                  and cell(ii,jj,kk).isCovered() ) 
+              if( in_extended_domain && (! cell(i,j,k).isCovered()) 
+                  && cell(ii,jj,kk).isCovered() ) 
               {
                   set_covered(i,j,cell,vfrac,vcent,barea,bcent,bnorm);
               }
@@ -334,16 +334,16 @@ void build_cells (Box const& bx, Array4<EBCellFlag> const& cell,
     const Box xbx = Box(bx).surroundingNodes(0).grow(1,1);
     AMREX_HOST_DEVICE_FOR_3D ( xbx, i, j, k,
     {
-        if (vfrac(i-1,j,0) == 0._rt or vfrac(i,j,0) == 0._rt) {
+        if (vfrac(i-1,j,0) == 0._rt || vfrac(i,j,0) == 0._rt) {
             fx(i,j,0) = Type::covered;
             apx(i,j,0) = 0.0;
             // race conditions do not happeen because multiple cuts are not allowed
-            if (not cell(i,j,0).isCovered())
+            if (! cell(i,j,0).isCovered())
             {
                 cell(i,j,0).setSingleValued();
                 set_eb_data(i,j,apx,apy,vfrac,vcent,barea,bcent,bnorm);
             }
-            if (not cell(i-1,j,0).isCovered())
+            if (! cell(i-1,j,0).isCovered())
             {
                 cell(i-1,j,0).setSingleValued();
                 set_eb_data(i-1,j,apx,apy,vfrac,vcent,barea,bcent,bnorm);
@@ -354,15 +354,15 @@ void build_cells (Box const& bx, Array4<EBCellFlag> const& cell,
     const Box ybx = Box(bx).surroundingNodes(1).grow(0,1);
     AMREX_HOST_DEVICE_FOR_3D ( ybx, i, j, k,
     {
-        if (vfrac(i,j-1,0) == 0._rt or vfrac(i,j,0) == 0._rt) {
+        if (vfrac(i,j-1,0) == 0._rt || vfrac(i,j,0) == 0._rt) {
             fy(i,j,0) = Type::covered;
             apy(i,j,0) = 0.0;
-            if (not cell(i,j,0).isCovered())
+            if (! cell(i,j,0).isCovered())
             {
                 cell(i,j,0).setSingleValued();
                 set_eb_data(i,j,apx,apy,vfrac,vcent,barea,bcent,bnorm);
             }
-            if (not cell(i,j-1,0).isCovered())
+            if (! cell(i,j-1,0).isCovered())
             {
                 cell(i,j-1,0).setSingleValued();
                 set_eb_data(i,j-1,apx,apy,vfrac,vcent,barea,bcent,bnorm);
@@ -380,26 +380,26 @@ void build_cells (Box const& bx, Array4<EBCellFlag> const& cell,
         if (fy(i  ,j  ,0) == Type::covered) flg.setDisconnected(IntVect( 0,-1));
         if (fy(i  ,j+1,0) == Type::covered) flg.setDisconnected(IntVect( 0, 1));
 
-        if (((fx(i,j,0) == Type::covered) or fy(i-1,j,0) == Type::covered) and
-            ((fx(i,j-1,0) == Type::covered) or fy(i,j,0) == Type::covered))
+        if (((fx(i,j,0) == Type::covered) || fy(i-1,j,0) == Type::covered) &&
+            ((fx(i,j-1,0) == Type::covered) || fy(i,j,0) == Type::covered))
         {
             flg.setDisconnected(IntVect(-1,-1));
         }
 
-        if (((fx(i+1,j,0) == Type::covered) or fy(i+1,j,0) == Type::covered) and
-            ((fx(i+1,j-1,0) == Type::covered) or fy(i,j,0) == Type::covered))
+        if (((fx(i+1,j,0) == Type::covered) || fy(i+1,j,0) == Type::covered) &&
+            ((fx(i+1,j-1,0) == Type::covered) || fy(i,j,0) == Type::covered))
         {
             flg.setDisconnected(IntVect(1,-1));
         }
 
-        if (((fx(i,j,0) == Type::covered) or fy(i-1,j+1,0) == Type::covered) and
-            ((fx(i,j+1,0) == Type::covered) or fy(i,j+1,0) == Type::covered))
+        if (((fx(i,j,0) == Type::covered) || fy(i-1,j+1,0) == Type::covered) &&
+            ((fx(i,j+1,0) == Type::covered) || fy(i,j+1,0) == Type::covered))
         {
             flg.setDisconnected(IntVect(-1,1));
         }
 
-        if (((fx(i+1,j,0) == Type::covered) or fy(i+1,j+1,0) == Type::covered) and
-            ((fx(i+1,j+1,0) == Type::covered) or fy(i,j+1,0) == Type::covered))
+        if (((fx(i+1,j,0) == Type::covered) || fy(i+1,j+1,0) == Type::covered) &&
+            ((fx(i+1,j+1,0) == Type::covered) || fy(i,j+1,0) == Type::covered))
         {
             flg.setDisconnected(IntVect(1,1));
         }

--- a/Src/EB/AMReX_EB2_3D_C.H
+++ b/Src/EB/AMReX_EB2_3D_C.H
@@ -21,17 +21,17 @@ amrex_eb2_build_types (Box const& tbx, Box const& bxg2,
     amrex::Loop(lo, hi,
     [=] (int i, int j, int k) noexcept
     {
-        if (    s(i,j  ,k  ) < 0.0 and s(i+1,j  ,k  ) < 0.0
-            and s(i,j+1,k  ) < 0.0 and s(i+1,j+1,k  ) < 0.0
-            and s(i,j  ,k+1) < 0.0 and s(i+1,j  ,k+1) < 0.0
-            and s(i,j+1,k+1) < 0.0 and s(i+1,j+1,k+1) < 0.0)
+        if (    s(i,j  ,k  ) < 0.0 && s(i+1,j  ,k  ) < 0.0
+            && s(i,j+1,k  ) < 0.0 && s(i+1,j+1,k  ) < 0.0
+            && s(i,j  ,k+1) < 0.0 && s(i+1,j  ,k+1) < 0.0
+            && s(i,j+1,k+1) < 0.0 && s(i+1,j+1,k+1) < 0.0)
         {
             cell(i,j,k).setRegular();
         }
-        else if (s(i,j  ,k  ) >= 0.0 and s(i+1,j  ,k  ) >= 0.0
-            and  s(i,j+1,k  ) >= 0.0 and s(i+1,j+1,k  ) >= 0.0
-            and  s(i,j  ,k+1) >= 0.0 and s(i+1,j  ,k+1) >= 0.0
-            and  s(i,j+1,k+1) >= 0.0 and s(i+1,j+1,k+1) >= 0.0)
+        else if (s(i,j  ,k  ) >= 0.0 && s(i+1,j  ,k  ) >= 0.0
+            &&  s(i,j+1,k  ) >= 0.0 && s(i+1,j+1,k  ) >= 0.0
+            &&  s(i,j  ,k+1) >= 0.0 && s(i+1,j  ,k+1) >= 0.0
+            &&  s(i,j+1,k+1) >= 0.0 && s(i+1,j+1,k+1) >= 0.0)
         {
             cell(i,j,k).setCovered();
         }
@@ -48,13 +48,13 @@ amrex_eb2_build_types (Box const& tbx, Box const& bxg2,
     amrex::Loop(lo, hi,
     [=] (int i, int j, int k) noexcept
     {
-        if (    s(i,j,k  ) < 0.0 and s(i,j+1,k  ) < 0.0
-            and s(i,j,k+1) < 0.0 and s(i,j+1,k+1) < 0.0 )
+        if (    s(i,j,k  ) < 0.0 && s(i,j+1,k  ) < 0.0
+            && s(i,j,k+1) < 0.0 && s(i,j+1,k+1) < 0.0 )
         {
             fx(i,j,k) = Type::regular;
         }
-        else if (s(i,j,k  ) >= 0.0 and s(i,j+1,k  ) >= 0.0
-            and  s(i,j,k+1) >= 0.0 and s(i,j+1,k+1) >= 0.0 )
+        else if (s(i,j,k  ) >= 0.0 && s(i,j+1,k  ) >= 0.0
+            &&  s(i,j,k+1) >= 0.0 && s(i,j+1,k+1) >= 0.0 )
         {
             fx(i,j,k) = Type::covered;
         }
@@ -71,13 +71,13 @@ amrex_eb2_build_types (Box const& tbx, Box const& bxg2,
     amrex::Loop(lo, hi,
     [=] (int i, int j, int k) noexcept
     {
-        if (    s(i,j,k  ) < 0.0 and s(i+1,j,k  ) < 0.0
-            and s(i,j,k+1) < 0.0 and s(i+1,j,k+1) < 0.0 )
+        if (    s(i,j,k  ) < 0.0 && s(i+1,j,k  ) < 0.0
+            && s(i,j,k+1) < 0.0 && s(i+1,j,k+1) < 0.0 )
         {
             fy(i,j,k) = Type::regular;
         }
-        else if (s(i,j,k  ) >= 0.0 and s(i+1,j,k  ) >= 0.0
-            and  s(i,j,k+1) >= 0.0 and s(i+1,j,k+1) >= 0.0 )
+        else if (s(i,j,k  ) >= 0.0 && s(i+1,j,k  ) >= 0.0
+            &&  s(i,j,k+1) >= 0.0 && s(i+1,j,k+1) >= 0.0 )
         {
             fy(i,j,k) = Type::covered;
         }
@@ -94,13 +94,13 @@ amrex_eb2_build_types (Box const& tbx, Box const& bxg2,
     amrex::Loop(lo, hi,
     [=] (int i, int j, int k) noexcept
     {
-        if (    s(i,j  ,k) < 0.0 and s(i+1,j  ,k) < 0.0
-            and s(i,j+1,k) < 0.0 and s(i+1,j+1,k) < 0.0)
+        if (    s(i,j  ,k) < 0.0 && s(i+1,j  ,k) < 0.0
+            && s(i,j+1,k) < 0.0 && s(i+1,j+1,k) < 0.0)
         {
             fz(i,j,k) = Type::regular;
         }
-        else if (s(i,j  ,k) >= 0.0 and s(i+1,j  ,k) >= 0.0
-            and  s(i,j+1,k) >= 0.0 and s(i+1,j+1,k) >= 0.0)
+        else if (s(i,j  ,k) >= 0.0 && s(i+1,j  ,k) >= 0.0
+            &&  s(i,j+1,k) >= 0.0 && s(i+1,j+1,k) >= 0.0)
         {
             fz(i,j,k) = Type::covered;
         }
@@ -117,9 +117,9 @@ amrex_eb2_build_types (Box const& tbx, Box const& bxg2,
     amrex::Loop(lo, hi,
     [=] (int i, int j, int k) noexcept
     {
-        if (s(i,j,k) < 0.0 and s(i+1,j,k) < 0.0) {
+        if (s(i,j,k) < 0.0 && s(i+1,j,k) < 0.0) {
             ex(i,j,k) = Type::regular;
-        } else if (s(i,j,k) >= 0.0 and s(i+1,j,k) >= 0.0) {
+        } else if (s(i,j,k) >= 0.0 && s(i+1,j,k) >= 0.0) {
             ex(i,j,k) = Type::covered;
         } else {
             ex(i,j,k) = Type::irregular;
@@ -133,9 +133,9 @@ amrex_eb2_build_types (Box const& tbx, Box const& bxg2,
     amrex::Loop(lo, hi,
     [=] (int i, int j, int k) noexcept
     {
-        if (s(i,j,k) < 0.0 and s(i,j+1,k) < 0.0) {
+        if (s(i,j,k) < 0.0 && s(i,j+1,k) < 0.0) {
             ey(i,j,k) = Type::regular;
-        } else if (s(i,j,k) >= 0.0 and s(i,j+1,k) >= 0.0) {
+        } else if (s(i,j,k) >= 0.0 && s(i,j+1,k) >= 0.0) {
             ey(i,j,k) = Type::covered;
         } else {
             ey(i,j,k) = Type::irregular;
@@ -149,9 +149,9 @@ amrex_eb2_build_types (Box const& tbx, Box const& bxg2,
     amrex::Loop(lo, hi,
     [=] (int i, int j, int k) noexcept
     {
-        if (s(i,j,k) < 0.0 and s(i,j,k+1) < 0.0) {
+        if (s(i,j,k) < 0.0 && s(i,j,k+1) < 0.0) {
             ez(i,j,k) = Type::regular;
-        } else if (s(i,j,k) >= 0.0 and s(i,j,k+1) >= 0.0) {
+        } else if (s(i,j,k) >= 0.0 && s(i,j,k+1) >= 0.0) {
             ez(i,j,k) = Type::covered;
         } else {
             ez(i,j,k) = Type::irregular;
@@ -162,7 +162,7 @@ amrex_eb2_build_types (Box const& tbx, Box const& bxg2,
 namespace {
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     int num_cuts (Real a, Real b) noexcept {
-        return (a >= 0.0 and b < 0.0) or (b >= 0.0 and a < 0.0);
+        return (a >= 0.0 && b < 0.0) || (b >= 0.0 && a < 0.0);
     }
 }
 
@@ -274,12 +274,12 @@ int check_mvmc (int i, int j, int k, Array4<Real const> const& fine)
         amrex::Abort("amrex::check_mvmc: how did this happen? wrong number of cuts on zhi-face");
     }
 
-    if (nxm == 1 and nym == 1 and nzm == 1 and nxp == 1 and nyp == 1 and nzp == 1) {
+    if (nxm == 1 && nym == 1 && nzm == 1 && nxp == 1 && nyp == 1 && nzp == 1) {
         n = (fine(i  ,j  ,k  ) < 0.0) + (fine(i+2,j  ,k  ) < 0.0) +
             (fine(i  ,j+2,k  ) < 0.0) + (fine(i+2,j+2,k  ) < 0.0) +
             (fine(i  ,j  ,k+2) < 0.0) + (fine(i+2,j  ,k+2) < 0.0) +
             (fine(i  ,j+2,k+2) < 0.0) + (fine(i+2,j+2,k+2) < 0.0);
-        if (n == 2 or n == 6) {
+        if (n == 2 || n == 6) {
             ierr = 1;
         } else if (n != 4) {
             ierr = 1;
@@ -451,21 +451,21 @@ int coarsen_from_fine (int i, int j, int k, Box const& bx, Box const& gbx,
             cbn(i,j,k,0) = nx*nfac;
             cbn(i,j,k,1) = ny*nfac;
             cbn(i,j,k,2) = nz*nfac;
-            ierr = (nx == 0.0 and ny == 0.0 and nz == 0.0)
+            ierr = (nx == 0.0 && ny == 0.0 && nz == 0.0)
                 // we must check the enclosing surface to make sure the coarse cell does not
                 // fully contains the geometry object.
-                or ( fapx(ii,jj  ,kk  )==1.0 and fapx(ii+2,jj  ,kk  )==1.0
-                 and fapx(ii,jj+1,kk  )==1.0 and fapx(ii+2,jj+1,kk  )==1.0
-                 and fapx(ii,jj  ,kk+1)==1.0 and fapx(ii+2,jj  ,kk+1)==1.0
-                 and fapx(ii,jj+1,kk+1)==1.0 and fapx(ii+2,jj+1,kk+1)==1.0
-                 and fapy(ii,jj  ,kk  )==1.0 and fapy(ii+1,jj  ,kk  )==1.0
-                 and fapy(ii,jj+2,kk  )==1.0 and fapy(ii+1,jj+2,kk  )==1.0
-                 and fapy(ii,jj  ,kk+1)==1.0 and fapy(ii+1,jj  ,kk+1)==1.0
-                 and fapy(ii,jj+2,kk+1)==1.0 and fapy(ii+1,jj+2,kk+1)==1.0
-                 and fapz(ii,jj  ,kk  )==1.0 and fapz(ii+1,jj  ,kk  )==1.0
-                 and fapz(ii,jj+1,kk  )==1.0 and fapz(ii+1,jj+1,kk  )==1.0
-                 and fapz(ii,jj  ,kk+2)==1.0 and fapz(ii+1,jj  ,kk+2)==1.0
-                 and fapz(ii,jj+1,kk+2)==1.0 and fapz(ii+1,jj+1,kk+2)==1.0);
+                || ( fapx(ii,jj  ,kk  )==1.0 && fapx(ii+2,jj  ,kk  )==1.0
+                 && fapx(ii,jj+1,kk  )==1.0 && fapx(ii+2,jj+1,kk  )==1.0
+                 && fapx(ii,jj  ,kk+1)==1.0 && fapx(ii+2,jj  ,kk+1)==1.0
+                 && fapx(ii,jj+1,kk+1)==1.0 && fapx(ii+2,jj+1,kk+1)==1.0
+                 && fapy(ii,jj  ,kk  )==1.0 && fapy(ii+1,jj  ,kk  )==1.0
+                 && fapy(ii,jj+2,kk  )==1.0 && fapy(ii+1,jj+2,kk  )==1.0
+                 && fapy(ii,jj  ,kk+1)==1.0 && fapy(ii+1,jj  ,kk+1)==1.0
+                 && fapy(ii,jj+2,kk+1)==1.0 && fapy(ii+1,jj+2,kk+1)==1.0
+                 && fapz(ii,jj  ,kk  )==1.0 && fapz(ii+1,jj  ,kk  )==1.0
+                 && fapz(ii,jj+1,kk  )==1.0 && fapz(ii+1,jj+1,kk  )==1.0
+                 && fapz(ii,jj  ,kk+2)==1.0 && fapz(ii+1,jj  ,kk+2)==1.0
+                 && fapz(ii,jj+1,kk+2)==1.0 && fapz(ii+1,jj+1,kk+2)==1.0);
 
         }
     }
@@ -590,96 +590,96 @@ void build_cellflag_from_ap (int i, int j, int k, Array4<EBCellFlag> const& cfla
         if (apz(i,j,k  ) != 0.0) flg.setConnected( 0,  0, -1);
         if (apz(i,j,k+1) != 0.0) flg.setConnected( 0,  0,  1);
 
-        if ( (apx(i,j,k) != 0.0 and apy(i-1,j,k) != 0.0) or
-             (apy(i,j,k) != 0.0 and apx(i,j-1,k) != 0.0) )
+        if ( (apx(i,j,k) != 0.0 && apy(i-1,j,k) != 0.0) ||
+             (apy(i,j,k) != 0.0 && apx(i,j-1,k) != 0.0) )
         {
             flg.setConnected(-1, -1, 0);
             if (apz(i-1,j-1,k  ) != 0.0) flg.setConnected(-1,-1,-1);
             if (apz(i-1,j-1,k+1) != 0.0) flg.setConnected(-1,-1, 1);
         }
 
-        if ( (apx(i+1,j,k) != 0.0 and apy(i+1,j  ,k) != 0.0) or
-             (apy(i  ,j,k) != 0.0 and apx(i+1,j-1,k) != 0.0) )
+        if ( (apx(i+1,j,k) != 0.0 && apy(i+1,j  ,k) != 0.0) ||
+             (apy(i  ,j,k) != 0.0 && apx(i+1,j-1,k) != 0.0) )
         {
             flg.setConnected(1, -1, 0);
             if (apz(i+1,j-1,k  ) != 0.0) flg.setConnected(1,-1,-1);
             if (apz(i+1,j-1,k+1) != 0.0) flg.setConnected(1,-1, 1);
         }
 
-        if ( (apx(i,j  ,k) != 0.0 and apy(i-1,j+1,k) != 0.0) or
-             (apy(i,j+1,k) != 0.0 and apx(i  ,j+1,k) != 0.0) )
+        if ( (apx(i,j  ,k) != 0.0 && apy(i-1,j+1,k) != 0.0) ||
+             (apy(i,j+1,k) != 0.0 && apx(i  ,j+1,k) != 0.0) )
         {
             flg.setConnected(-1, 1, 0);
             if (apz(i-1,j+1,k  ) != 0.0) flg.setConnected(-1, 1,-1);
             if (apz(i-1,j+1,k+1) != 0.0) flg.setConnected(-1, 1, 1);
         }
 
-        if ( (apx(i+1,j  ,k) != 0.0 and apy(i+1,j+1,k) != 0.0) or
-             (apy(i  ,j+1,k) != 0.0 and apx(i+1,j+1,k) != 0.0) )
+        if ( (apx(i+1,j  ,k) != 0.0 && apy(i+1,j+1,k) != 0.0) ||
+             (apy(i  ,j+1,k) != 0.0 && apx(i+1,j+1,k) != 0.0) )
         {
             flg.setConnected(1, 1, 0);
             if (apz(i+1,j+1,k  ) != 0.0) flg.setConnected(1, 1,-1);
             if (apz(i+1,j+1,k+1) != 0.0) flg.setConnected(1, 1, 1);
         }
 
-        if ( (apx(i,j,k) != 0.0 and apz(i-1,j,k  ) != 0.0) or
-             (apz(i,j,k) != 0.0 and apx(i  ,j,k-1) != 0.0) )
+        if ( (apx(i,j,k) != 0.0 && apz(i-1,j,k  ) != 0.0) ||
+             (apz(i,j,k) != 0.0 && apx(i  ,j,k-1) != 0.0) )
         {
             flg.setConnected(-1, 0, -1);
             if (apy(i-1,j  ,k-1) != 0.0) flg.setConnected(-1,-1,-1);
             if (apy(i-1,j+1,k-1) != 0.0) flg.setConnected(-1, 1,-1);
         }
 
-        if ( (apx(i+1,j,k) != 0.0 and apz(i+1,j,k  ) != 0.0) or
-             (apz(i  ,j,k) != 0.0 and apx(i+1,j,k-1) != 0.0) )
+        if ( (apx(i+1,j,k) != 0.0 && apz(i+1,j,k  ) != 0.0) ||
+             (apz(i  ,j,k) != 0.0 && apx(i+1,j,k-1) != 0.0) )
         {
             flg.setConnected(1, 0, -1);
             if (apy(i+1,j  ,k-1) != 0.0) flg.setConnected(1,-1,-1);
             if (apy(i+1,j+1,k-1) != 0.0) flg.setConnected(1, 1,-1);
         }
 
-        if ( (apx(i,j,k  ) != 0.0 and apz(i-1,j,k+1) != 0.0) or
-             (apz(i,j,k+1) != 0.0 and apx(i  ,j,k+1) != 0.0) )
+        if ( (apx(i,j,k  ) != 0.0 && apz(i-1,j,k+1) != 0.0) ||
+             (apz(i,j,k+1) != 0.0 && apx(i  ,j,k+1) != 0.0) )
         {
             flg.setConnected(-1, 0, 1);
             if (apy(i-1,j  ,k+1) != 0.0) flg.setConnected(-1,-1, 1);
             if (apy(i-1,j+1,k+1) != 0.0) flg.setConnected(-1, 1, 1);
         }
 
-        if ( (apx(i+1,j,k  ) != 0.0 and apz(i+1,j,k+1) != 0.0) or
-             (apz(i  ,j,k+1) != 0.0 and apx(i+1,j,k+1) != 0.0) )
+        if ( (apx(i+1,j,k  ) != 0.0 && apz(i+1,j,k+1) != 0.0) ||
+             (apz(i  ,j,k+1) != 0.0 && apx(i+1,j,k+1) != 0.0) )
         {
             flg.setConnected(1, 0, 1);
             if (apy(i+1,j  ,k+1) != 0.0) flg.setConnected(1,-1, 1);
             if (apy(i+1,j+1,k+1) != 0.0) flg.setConnected(1, 1, 1);
         }
 
-        if ( (apy(i,j,k) != 0.0 and apz(i,j-1,k  ) != 0.0) or
-             (apz(i,j,k) != 0.0 and apy(i,j  ,k-1) != 0.0) )
+        if ( (apy(i,j,k) != 0.0 && apz(i,j-1,k  ) != 0.0) ||
+             (apz(i,j,k) != 0.0 && apy(i,j  ,k-1) != 0.0) )
         {
             flg.setConnected(0, -1, -1);
             if (apx(i  ,j-1,k-1) != 0.0) flg.setConnected(-1,-1,-1);
             if (apx(i+1,j-1,k-1) != 0.0) flg.setConnected( 1,-1,-1);
         }
 
-        if ( (apy(i,j+1,k) != 0.0 and apz(i,j+1,k  ) != 0.0) or
-             (apz(i,j  ,k) != 0.0 and apy(i,j+1,k-1) != 0.0) )
+        if ( (apy(i,j+1,k) != 0.0 && apz(i,j+1,k  ) != 0.0) ||
+             (apz(i,j  ,k) != 0.0 && apy(i,j+1,k-1) != 0.0) )
         {
             flg.setConnected(0, 1, -1);
             if (apx(i  ,j+1,k-1) != 0.0) flg.setConnected(-1, 1,-1);
             if (apx(i+1,j+1,k-1) != 0.0) flg.setConnected( 1, 1,-1);
         }
 
-        if ( (apy(i,j,k  ) != 0.0 and apz(i,j-1,k+1) != 0.0) or
-             (apz(i,j,k+1) != 0.0 and apy(i,j  ,k+1) != 0.0) )
+        if ( (apy(i,j,k  ) != 0.0 && apz(i,j-1,k+1) != 0.0) ||
+             (apz(i,j,k+1) != 0.0 && apy(i,j  ,k+1) != 0.0) )
         {
             flg.setConnected(0, -1, 1);
             if (apx(i  ,j-1,k+1) != 0.0) flg.setConnected(-1,-1, 1);
             if (apx(i+1,j-1,k+1) != 0.0) flg.setConnected( 1,-1, 1);
         }
 
-        if ( (apy(i,j+1,k  ) != 0.0 and apz(i,j+1,k+1) != 0.0) or
-             (apz(i,j  ,k+1) != 0.0 and apy(i,j+1,k+1) != 0.0) )
+        if ( (apy(i,j+1,k  ) != 0.0 && apz(i,j+1,k+1) != 0.0) ||
+             (apz(i,j  ,k+1) != 0.0 && apy(i,j+1,k+1) != 0.0) )
         {
             flg.setConnected(0, 1, 1);
             if (apx(i  ,j+1,k+1) != 0.0) flg.setConnected(-1, 1, 1);

--- a/Src/EB/AMReX_EB2_3D_C.cpp
+++ b/Src/EB/AMReX_EB2_3D_C.cpp
@@ -25,12 +25,12 @@ void set_eb_data (const int i, const int j, const int k,
     // We know there are no multiple cuts on faces by now.
     // So we only need to check the case that there are two cuts
     // at the opposite corners.
-    bool multi_cuts = (axm >= 0.5 and axm < 1.0 and
-                       axp >= 0.5 and axp < 1.0 and
-                       aym >= 0.5 and aym < 1.0 and
-                       ayp >= 0.5 and ayp < 1.0 and
-                       azm >= 0.5 and azm < 1.0 and
-                       azp >= 0.5 and azp < 1.0);
+    bool multi_cuts = (axm >= 0.5 && axm < 1.0 &&
+                       axp >= 0.5 && axp < 1.0 &&
+                       aym >= 0.5 && aym < 1.0 &&
+                       ayp >= 0.5 && ayp < 1.0 &&
+                       azm >= 0.5 && azm < 1.0 &&
+                       azp >= 0.5 && azp < 1.0);
     AMREX_ALWAYS_ASSERT_WITH_MESSAGE(!multi_cuts,
                                      "amrex::EB2::build_cells: multi-cuts not supported");
 
@@ -138,7 +138,7 @@ void cut_face_2d (Real& areafrac, Real& centx, Real& centy,
     Real nxabs = amrex::Math::abs(nx);
     Real nyabs = amrex::Math::abs(ny);
 
-    if (nxabs < tiny or nyabs > 1.0-tiny) {
+    if (nxabs < tiny || nyabs > 1.0-tiny) {
         areafrac = 0.5*(axm+axp);
         if (areafrac > 1.0-small) {
             areafrac = 1.0;
@@ -160,7 +160,7 @@ void cut_face_2d (Real& areafrac, Real& centx, Real& centy,
             Sy2 = (1./24.)*(ayp+aym) + ny*(1./3.)*(bcy*bcy*bcy);
             Sxy = 0.0;
         }
-    } else if (nyabs < tiny or nxabs > 1.0-tiny) {
+    } else if (nyabs < tiny || nxabs > 1.0-tiny) {
         areafrac = 0.5*(aym+ayp);
         if (areafrac > 1.0-small) {
             areafrac = 1.0;
@@ -356,14 +356,14 @@ void build_faces (Box const& bx, Array4<EBCellFlag> const& cell,
             AMREX_ALWAYS_ASSERT_WITH_MESSAGE(ncuts <= 2,
                                              "amrex::EB2::build_faces: more than 2 cuts not supported");
 
-            if (lym <= small and lyp <= small and lzm <= small and lzp <= small) {
+            if (lym <= small && lyp <= small && lzm <= small && lzp <= small) {
                 apx(i,j,k) = 0.0;
                 fcx(i,j,k,0) = 0.0;
                 fcx(i,j,k,1) = 0.0;
                 m2x(i,j,k,0) = 0.0;
                 m2x(i,j,k,1) = 0.0;
                 m2x(i,j,k,2) = 0.0;
-            } else if (lym == lyp and lzm == lzp) {
+            } else if (lym == lyp && lzm == lzp) {
                 apx(i,j,k) = 1.0;
                 fcx(i,j,k,0) = 0.0;
                 fcx(i,j,k,1) = 0.0;
@@ -463,14 +463,14 @@ void build_faces (Box const& bx, Array4<EBCellFlag> const& cell,
             AMREX_ALWAYS_ASSERT_WITH_MESSAGE(ncuts <= 2,
                                              "amrex::EB2::build_faces: more than 2 cuts not supported");
 
-            if (lxm <= small and lxp <= small and lzm <= small and lzp <= small) {
+            if (lxm <= small && lxp <= small && lzm <= small && lzp <= small) {
                 apy(i,j,k) = 0.0;
                 fcy(i,j,k,0) = 0.0;
                 fcy(i,j,k,1) = 0.0;
                 m2y(i,j,k,0) = 0.0;
                 m2y(i,j,k,1) = 0.0;
                 m2y(i,j,k,2) = 0.0;
-            } else if (lxm == lxp and lzm == lzp) {
+            } else if (lxm == lxp && lzm == lzp) {
                 apy(i,j,k) = 1.0;
                 fcy(i,j,k,0) = 0.0;
                 fcy(i,j,k,1) = 0.0;
@@ -570,14 +570,14 @@ void build_faces (Box const& bx, Array4<EBCellFlag> const& cell,
             AMREX_ALWAYS_ASSERT_WITH_MESSAGE(ncuts <= 2,
                                              "amrex::EB2::build_faces: more than 2 cuts not supported");
 
-            if (lxm <= small and lxp <= small and lym <= small and lyp <= small) {
+            if (lxm <= small && lxp <= small && lym <= small && lyp <= small) {
                 apz(i,j,k) = 0.0;
                 fcz(i,j,k,0) = 0.0;
                 fcz(i,j,k,1) = 0.0;
                 m2z(i,j,k,0) = 0.0;
                 m2z(i,j,k,1) = 0.0;
                 m2z(i,j,k,2) = 0.0;
-            } else if (lxm == lxp and lym == lyp) {
+            } else if (lxm == lxp && lym == lyp) {
                 apz(i,j,k) = 1.0;
                 fcz(i,j,k,0) = 0.0;
                 fcz(i,j,k,1) = 0.0;
@@ -604,15 +604,15 @@ void build_faces (Box const& bx, Array4<EBCellFlag> const& cell,
     AMREX_HOST_DEVICE_FOR_3D ( bxg1, i, j, k,
     {
         if (cell(i,j,k).isSingleValued()) {
-            if (fx(i,j,k) == Type::covered and fx(i+1,j,k) == Type::covered and
-                fy(i,j,k) == Type::covered and fy(i,j+1,k) == Type::covered and
-                fz(i,j,k) == Type::covered and fz(i,j,k+1) == Type::covered)
+            if (fx(i,j,k) == Type::covered && fx(i+1,j,k) == Type::covered &&
+                fy(i,j,k) == Type::covered && fy(i,j+1,k) == Type::covered &&
+                fz(i,j,k) == Type::covered && fz(i,j,k+1) == Type::covered)
             {
                 cell(i,j,k).setCovered();
             }
-            else if (fx(i,j,k) == Type::regular and fx(i+1,j,k) == Type::regular and
-                     fy(i,j,k) == Type::regular and fy(i,j+1,k) == Type::regular and
-                     fz(i,j,k) == Type::regular and fz(i,j,k+1) == Type::regular)
+            else if (fx(i,j,k) == Type::regular && fx(i+1,j,k) == Type::regular &&
+                     fy(i,j,k) == Type::regular && fy(i,j+1,k) == Type::regular &&
+                     fz(i,j,k) == Type::regular && fz(i,j,k+1) == Type::regular)
             {
                 cell(i,j,k).setRegular();
             }
@@ -685,7 +685,7 @@ void build_cells (Box const& bx, Array4<EBCellFlag> const& cell,
            }
        }
 
-       if (not gdomain.contains(bxg1)) {
+       if (! gdomain.contains(bxg1)) {
           AMREX_HOST_DEVICE_FOR_3D ( bxg1, i, j, k,
           {
               const auto & dlo = gdomain.loVect();
@@ -725,8 +725,8 @@ void build_cells (Box const& bx, Array4<EBCellFlag> const& cell,
               }
 
               // set cell in extendable region to covered if necessary
-              if( in_extended_domain and (not cell(i,j,k).isCovered()) 
-                  and cell(ii,jj,kk).isCovered() ) 
+              if( in_extended_domain && (! cell(i,j,k).isCovered()) 
+                  && cell(ii,jj,kk).isCovered() ) 
               {
                   set_covered(i,j,k,cell,vfrac,vcent,barea,bcent,bnorm);
               }
@@ -745,7 +745,7 @@ void build_cells (Box const& bx, Array4<EBCellFlag> const& cell,
     const Box xbx = Box(bx).surroundingNodes(0).grow(1,1).grow(2,1);
     AMREX_HOST_DEVICE_FOR_3D ( xbx, i, j, k,
     {
-        if (vfrac(i-1,j,k) == 0._rt or vfrac(i,j,k) == 0._rt) {
+        if (vfrac(i-1,j,k) == 0._rt || vfrac(i,j,k) == 0._rt) {
             AMREX_DPCPP_ONLY(auto fcx = ptmp[0]);
             AMREX_DPCPP_ONLY(auto fcy = ptmp[1]);
             AMREX_DPCPP_ONLY(auto fcz = ptmp[2]);
@@ -754,14 +754,14 @@ void build_cells (Box const& bx, Array4<EBCellFlag> const& cell,
             AMREX_DPCPP_ONLY(auto m2z = ptmp[5]);
             fx(i,j,k) = Type::covered;
             apx(i,j,k) = 0.0;
-            if (not cell(i  ,j,k).isCovered())
+            if (! cell(i  ,j,k).isCovered())
             {
                 cell(i  ,j,k).setSingleValued();
                 set_eb_data(i,j,k,apx,apy,apz,
                             fcx,fcy,fcz,m2x,m2y,m2z,vfrac,vcent,
                             barea,bcent,bnorm);
             }
-            if (not cell(i-1,j,k).isCovered())
+            if (! cell(i-1,j,k).isCovered())
             {
                 cell(i-1,j,k).setSingleValued();
                 set_eb_data(i-1,j,k,apx,apy,apz,
@@ -774,7 +774,7 @@ void build_cells (Box const& bx, Array4<EBCellFlag> const& cell,
     const Box ybx = Box(bx).surroundingNodes(1).grow(0,1).grow(2,1);
     AMREX_HOST_DEVICE_FOR_3D ( ybx, i, j, k,
     {
-        if (vfrac(i,j-1,k) == 0._rt or vfrac(i,j,k) == 0._rt) {
+        if (vfrac(i,j-1,k) == 0._rt || vfrac(i,j,k) == 0._rt) {
             AMREX_DPCPP_ONLY(auto fcx = ptmp[0]);
             AMREX_DPCPP_ONLY(auto fcy = ptmp[1]);
             AMREX_DPCPP_ONLY(auto fcz = ptmp[2]);
@@ -783,14 +783,14 @@ void build_cells (Box const& bx, Array4<EBCellFlag> const& cell,
             AMREX_DPCPP_ONLY(auto m2z = ptmp[5]);
             fy(i,j,k) = Type::covered;
             apy(i,j,k) = 0.0;
-            if (not cell(i,j  ,k).isCovered())
+            if (! cell(i,j  ,k).isCovered())
             {
                 cell(i,j  ,k).setSingleValued();
                 set_eb_data(i,j,k,apx,apy,apz,
                             fcx,fcy,fcz,m2x,m2y,m2z,vfrac,vcent,
                             barea,bcent,bnorm);
             }
-            if (not cell(i,j-1,k).isCovered())
+            if (! cell(i,j-1,k).isCovered())
             {
                 cell(i,j-1,k).setSingleValued();
                 set_eb_data(i,j-1,k,apx,apy,apz,
@@ -803,7 +803,7 @@ void build_cells (Box const& bx, Array4<EBCellFlag> const& cell,
     const Box zbx = Box(bx).surroundingNodes(2).grow(0,1).grow(1,1);
     AMREX_HOST_DEVICE_FOR_3D ( zbx, i, j, k,
     {
-        if (vfrac(i,j,k-1) == 0._rt or vfrac(i,j,k) == 0._rt) {
+        if (vfrac(i,j,k-1) == 0._rt || vfrac(i,j,k) == 0._rt) {
             AMREX_DPCPP_ONLY(auto fcx = ptmp[0]);
             AMREX_DPCPP_ONLY(auto fcy = ptmp[1]);
             AMREX_DPCPP_ONLY(auto fcz = ptmp[2]);
@@ -812,14 +812,14 @@ void build_cells (Box const& bx, Array4<EBCellFlag> const& cell,
             AMREX_DPCPP_ONLY(auto m2z = ptmp[5]);
             fz(i,j,k) = Type::covered;
             apz(i,j,k) = 0.0;
-            if (not cell(i,j,k  ).isCovered())
+            if (! cell(i,j,k  ).isCovered())
             {
                 cell(i,j,k  ).setSingleValued();
                 set_eb_data(i,j,k,apx,apy,apz,
                             fcx,fcy,fcz,m2x,m2y,m2z,vfrac,vcent,
                             barea,bcent,bnorm);
             }
-            if (not cell(i,j,k-1).isCovered())
+            if (! cell(i,j,k-1).isCovered())
             {
                 cell(i,j,k-1).setSingleValued();
                 set_eb_data(i,j,k-1,apx,apy,apz,
@@ -857,76 +857,76 @@ void build_cells (Box const& bx, Array4<EBCellFlag> const& cell,
             }
 
             // x-y
-            if ((fx(i,j,k) == Type::covered or fy(i-1,j,k) == Type::covered) and
-                (fx(i,j-1,k) == Type::covered or fy(i,j,k) == Type::covered))
+            if ((fx(i,j,k) == Type::covered || fy(i-1,j,k) == Type::covered) &&
+                (fx(i,j-1,k) == Type::covered || fy(i,j,k) == Type::covered))
             {
                 flg.setDisconnected(-1,-1,0);
             }
 
-            if ((fx(i+1,j,k) == Type::covered or fy(i+1,j,k) == Type::covered) and
-                (fx(i+1,j-1,k) == Type::covered or fy(i,j,k) == Type::covered))
+            if ((fx(i+1,j,k) == Type::covered || fy(i+1,j,k) == Type::covered) &&
+                (fx(i+1,j-1,k) == Type::covered || fy(i,j,k) == Type::covered))
             {
                 flg.setDisconnected(1,-1,0);
             }
 
-            if ((fx(i,j,k) == Type::covered or fy(i-1,j+1,k) == Type::covered) and
-                (fx(i,j+1,k) == Type::covered or fy(i,j+1,k) == Type::covered))
+            if ((fx(i,j,k) == Type::covered || fy(i-1,j+1,k) == Type::covered) &&
+                (fx(i,j+1,k) == Type::covered || fy(i,j+1,k) == Type::covered))
             {
                 flg.setDisconnected(-1,1,0);
             }
 
-            if ((fx(i+1,j,k) == Type::covered or fy(i+1,j+1,k) == Type::covered) and
-                (fx(i+1,j+1,k) == Type::covered or fy(i,j+1,k) == Type::covered))
+            if ((fx(i+1,j,k) == Type::covered || fy(i+1,j+1,k) == Type::covered) &&
+                (fx(i+1,j+1,k) == Type::covered || fy(i,j+1,k) == Type::covered))
             {
                 flg.setDisconnected(1,1,0);
             }
 
             // x-z
-            if ((fx(i,j,k) == Type::covered or fz(i-1,j,k) == Type::covered) and
-                (fx(i,j,k-1) == Type::covered or fz(i,j,k) == Type::covered))
+            if ((fx(i,j,k) == Type::covered || fz(i-1,j,k) == Type::covered) &&
+                (fx(i,j,k-1) == Type::covered || fz(i,j,k) == Type::covered))
             {
                 flg.setDisconnected(-1,0,-1);
             }
 
-            if ((fx(i+1,j,k) == Type::covered or fz(i+1,j,k) == Type::covered) and
-                (fx(i+1,j,k-1) == Type::covered or fz(i,j,k) == Type::covered))
+            if ((fx(i+1,j,k) == Type::covered || fz(i+1,j,k) == Type::covered) &&
+                (fx(i+1,j,k-1) == Type::covered || fz(i,j,k) == Type::covered))
             {
                 flg.setDisconnected(1,0,-1);
             }
 
-            if ((fx(i,j,k) == Type::covered or fz(i-1,j,k+1) == Type::covered) and
-                (fx(i,j,k+1) == Type::covered or fz(i,j,k+1) == Type::covered))
+            if ((fx(i,j,k) == Type::covered || fz(i-1,j,k+1) == Type::covered) &&
+                (fx(i,j,k+1) == Type::covered || fz(i,j,k+1) == Type::covered))
             {
                 flg.setDisconnected(-1,0,1);
             }
 
-            if ((fx(i+1,j,k) == Type::covered or fz(i+1,j,k+1) == Type::covered) and
-                (fx(i+1,j,k+1) == Type::covered or fz(i,j,k+1) == Type::covered))
+            if ((fx(i+1,j,k) == Type::covered || fz(i+1,j,k+1) == Type::covered) &&
+                (fx(i+1,j,k+1) == Type::covered || fz(i,j,k+1) == Type::covered))
             {
                 flg.setDisconnected(1,0,1);
             }
 
             // y-z
-            if ((fy(i,j,k) == Type::covered or fz(i,j-1,k) == Type::covered) and
-                (fy(i,j,k-1) == Type::covered or fz(i,j,k) == Type::covered))
+            if ((fy(i,j,k) == Type::covered || fz(i,j-1,k) == Type::covered) &&
+                (fy(i,j,k-1) == Type::covered || fz(i,j,k) == Type::covered))
             {
                 flg.setDisconnected(0,-1,-1);
             }
 
-            if ((fy(i,j+1,k) == Type::covered or fz(i,j+1,k) == Type::covered) and
-                (fy(i,j+1,k-1) == Type::covered or fz(i,j,k) == Type::covered))
+            if ((fy(i,j+1,k) == Type::covered || fz(i,j+1,k) == Type::covered) &&
+                (fy(i,j+1,k-1) == Type::covered || fz(i,j,k) == Type::covered))
             {
                 flg.setDisconnected(0,1,-1);
             }
 
-            if ((fy(i,j,k) == Type::covered or fz(i,j-1,k+1) == Type::covered) and
-                (fy(i,j,k+1) == Type::covered or fz(i,j,k+1) == Type::covered))
+            if ((fy(i,j,k) == Type::covered || fz(i,j-1,k+1) == Type::covered) &&
+                (fy(i,j,k+1) == Type::covered || fz(i,j,k+1) == Type::covered))
             {
                 flg.setDisconnected(0,-1,1);
             }
 
-            if ((fy(i,j+1,k) == Type::covered or fz(i,j+1,k+1) == Type::covered) and
-                (fy(i,j+1,k+1) == Type::covered or fz(i,j,k+1) == Type::covered))
+            if ((fy(i,j+1,k) == Type::covered || fz(i,j+1,k+1) == Type::covered) &&
+                (fy(i,j+1,k+1) == Type::covered || fz(i,j,k+1) == Type::covered))
             {
                 flg.setDisconnected(0,1,1);
             }
@@ -944,65 +944,65 @@ void build_cells (Box const& bx, Array4<EBCellFlag> const& cell,
             auto newflg = tmpflg;
 
             // -1, -1, -1 corner
-            if ((tmpflg.isDisconnected(-1, 0, 0) or ctmp(i-1,j  ,k  ).isDisconnected( 0,-1,-1)) and
-                (tmpflg.isDisconnected( 0,-1, 0) or ctmp(i  ,j-1,k  ).isDisconnected(-1, 0,-1)) and
-                (tmpflg.isDisconnected( 0, 0,-1) or ctmp(i  ,j  ,k-1).isDisconnected(-1,-1, 0)))
+            if ((tmpflg.isDisconnected(-1, 0, 0) || ctmp(i-1,j  ,k  ).isDisconnected( 0,-1,-1)) &&
+                (tmpflg.isDisconnected( 0,-1, 0) || ctmp(i  ,j-1,k  ).isDisconnected(-1, 0,-1)) &&
+                (tmpflg.isDisconnected( 0, 0,-1) || ctmp(i  ,j  ,k-1).isDisconnected(-1,-1, 0)))
             {
                 newflg.setDisconnected(-1,-1,-1);
             }
 
             // 1, -1, -1 corner
-            if ((tmpflg.isDisconnected( 1, 0, 0) or ctmp(i+1,j  ,k  ).isDisconnected( 0,-1,-1)) and
-                (tmpflg.isDisconnected( 0,-1, 0) or ctmp(i  ,j-1,k  ).isDisconnected( 1, 0,-1)) and
-                (tmpflg.isDisconnected( 0, 0,-1) or ctmp(i  ,j  ,k-1).isDisconnected( 1,-1, 0)))
+            if ((tmpflg.isDisconnected( 1, 0, 0) || ctmp(i+1,j  ,k  ).isDisconnected( 0,-1,-1)) &&
+                (tmpflg.isDisconnected( 0,-1, 0) || ctmp(i  ,j-1,k  ).isDisconnected( 1, 0,-1)) &&
+                (tmpflg.isDisconnected( 0, 0,-1) || ctmp(i  ,j  ,k-1).isDisconnected( 1,-1, 0)))
             {
                 newflg.setDisconnected(1,-1,-1);
             }
 
             // -1, 1, -1 corner
-            if ((tmpflg.isDisconnected(-1, 0, 0) or ctmp(i-1,j  ,k  ).isDisconnected( 0, 1,-1)) and
-                (tmpflg.isDisconnected( 0, 1, 0) or ctmp(i  ,j+1,k  ).isDisconnected(-1, 0,-1)) and
-                (tmpflg.isDisconnected( 0, 0,-1) or ctmp(i  ,j  ,k-1).isDisconnected(-1, 1, 0)))
+            if ((tmpflg.isDisconnected(-1, 0, 0) || ctmp(i-1,j  ,k  ).isDisconnected( 0, 1,-1)) &&
+                (tmpflg.isDisconnected( 0, 1, 0) || ctmp(i  ,j+1,k  ).isDisconnected(-1, 0,-1)) &&
+                (tmpflg.isDisconnected( 0, 0,-1) || ctmp(i  ,j  ,k-1).isDisconnected(-1, 1, 0)))
             {
                 newflg.setDisconnected(-1, 1,-1);
             }
 
             // 1, 1, -1 corner
-            if ((tmpflg.isDisconnected( 1, 0, 0) or ctmp(i+1,j  ,k  ).isDisconnected( 0, 1,-1)) and
-                (tmpflg.isDisconnected( 0, 1, 0) or ctmp(i  ,j+1,k  ).isDisconnected( 1, 0,-1)) and
-                (tmpflg.isDisconnected( 0, 0,-1) or ctmp(i  ,j  ,k-1).isDisconnected( 1, 1, 0)))
+            if ((tmpflg.isDisconnected( 1, 0, 0) || ctmp(i+1,j  ,k  ).isDisconnected( 0, 1,-1)) &&
+                (tmpflg.isDisconnected( 0, 1, 0) || ctmp(i  ,j+1,k  ).isDisconnected( 1, 0,-1)) &&
+                (tmpflg.isDisconnected( 0, 0,-1) || ctmp(i  ,j  ,k-1).isDisconnected( 1, 1, 0)))
             {
                 newflg.setDisconnected(1, 1,-1);
             }
 
             // -1, -1, 1 corner
-            if ((tmpflg.isDisconnected(-1, 0, 0) or ctmp(i-1,j  ,k  ).isDisconnected( 0,-1, 1)) and
-                (tmpflg.isDisconnected( 0,-1, 0) or ctmp(i  ,j-1,k  ).isDisconnected(-1, 0, 1)) and
-                (tmpflg.isDisconnected( 0, 0, 1) or ctmp(i  ,j  ,k+1).isDisconnected(-1,-1, 0)))
+            if ((tmpflg.isDisconnected(-1, 0, 0) || ctmp(i-1,j  ,k  ).isDisconnected( 0,-1, 1)) &&
+                (tmpflg.isDisconnected( 0,-1, 0) || ctmp(i  ,j-1,k  ).isDisconnected(-1, 0, 1)) &&
+                (tmpflg.isDisconnected( 0, 0, 1) || ctmp(i  ,j  ,k+1).isDisconnected(-1,-1, 0)))
             {
                 newflg.setDisconnected(-1,-1, 1);
             }
 
             // 1, -1, 1 corner
-            if ((tmpflg.isDisconnected( 1, 0, 0) or ctmp(i+1,j  ,k  ).isDisconnected( 0,-1, 1)) and
-                (tmpflg.isDisconnected( 0,-1, 0) or ctmp(i  ,j-1,k  ).isDisconnected( 1, 0, 1)) and
-                (tmpflg.isDisconnected( 0, 0, 1) or ctmp(i  ,j  ,k+1).isDisconnected( 1,-1, 0)))
+            if ((tmpflg.isDisconnected( 1, 0, 0) || ctmp(i+1,j  ,k  ).isDisconnected( 0,-1, 1)) &&
+                (tmpflg.isDisconnected( 0,-1, 0) || ctmp(i  ,j-1,k  ).isDisconnected( 1, 0, 1)) &&
+                (tmpflg.isDisconnected( 0, 0, 1) || ctmp(i  ,j  ,k+1).isDisconnected( 1,-1, 0)))
             {
                 newflg.setDisconnected(1,-1, 1);
             }
 
             // -1, 1, 1 corner
-            if ((tmpflg.isDisconnected(-1, 0, 0) or ctmp(i-1,j  ,k  ).isDisconnected( 0, 1, 1)) and
-                (tmpflg.isDisconnected( 0, 1, 0) or ctmp(i  ,j+1,k  ).isDisconnected(-1, 0, 1)) and
-                (tmpflg.isDisconnected( 0, 0, 1) or ctmp(i  ,j  ,k+1).isDisconnected(-1, 1, 0)))
+            if ((tmpflg.isDisconnected(-1, 0, 0) || ctmp(i-1,j  ,k  ).isDisconnected( 0, 1, 1)) &&
+                (tmpflg.isDisconnected( 0, 1, 0) || ctmp(i  ,j+1,k  ).isDisconnected(-1, 0, 1)) &&
+                (tmpflg.isDisconnected( 0, 0, 1) || ctmp(i  ,j  ,k+1).isDisconnected(-1, 1, 0)))
             {
                 newflg.setDisconnected(-1,1,1);
             }
 
             // 1, 1, 1 corner
-            if ((tmpflg.isDisconnected( 1, 0, 0) or ctmp(i+1,j  ,k  ).isDisconnected( 0, 1, 1)) and
-                (tmpflg.isDisconnected( 0, 1, 0) or ctmp(i  ,j+1,k  ).isDisconnected( 1, 0, 1)) and
-                (tmpflg.isDisconnected( 0, 0, 1) or ctmp(i  ,j  ,k+1).isDisconnected( 1, 1, 0)))
+            if ((tmpflg.isDisconnected( 1, 0, 0) || ctmp(i+1,j  ,k  ).isDisconnected( 0, 1, 1)) &&
+                (tmpflg.isDisconnected( 0, 1, 0) || ctmp(i  ,j+1,k  ).isDisconnected( 1, 0, 1)) &&
+                (tmpflg.isDisconnected( 0, 0, 1) || ctmp(i  ,j  ,k+1).isDisconnected( 1, 1, 0)))
             {
                 newflg.setDisconnected(1,1,1);
             }

--- a/Src/EB/AMReX_EB2_Level.H
+++ b/Src/EB/AMReX_EB2_Level.H
@@ -229,7 +229,7 @@ GShopLevel<G>::GShopLevel (IndexSpace const* is, G const& gshop, const Geometry&
     RunOn gshop_run_on = (Gpu::inLaunchRegion() && gshop.isGPUable())
         ? RunOn::Gpu : RunOn::Cpu;
 
-    bool hybrid = Gpu::inLaunchRegion() and (gshop_run_on == RunOn::Cpu);
+    bool hybrid = Gpu::inLaunchRegion() && (gshop_run_on == RunOn::Cpu);
 
 #ifdef _OPENMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())

--- a/Src/EB/AMReX_EBAmrUtil.cpp
+++ b/Src/EB/AMReX_EBAmrUtil.cpp
@@ -60,7 +60,7 @@ TagVolfrac (TagBoxArray& tags, const MultiFab& volfrac, Real tol)
         Array4<Real const> const& volarr = volfrac.const_array(mfi);
         AMREX_HOST_DEVICE_FOR_3D ( bx, i, j, k,
         {
-            if (volarr(i,j,k) <= (1.-tol) and volarr(i,j,k) >= tol) {
+            if (volarr(i,j,k) <= (1.-tol) && volarr(i,j,k) >= tol) {
                 tagarr(i,j,k) = tagval;
             }
         });

--- a/Src/EB/AMReX_EBFluxRegister_2D_C.H
+++ b/Src/EB/AMReX_EBFluxRegister_2D_C.H
@@ -12,7 +12,7 @@ void eb_flux_reg_crseadd_va(int i, int j, int k, Array4<Real> const& d,
                             Real dtdx, Real dtdy)
 {
     if (flag(i,j,k) == amrex_yafluxreg_crse_fine_boundary_cell
-        and vfrac(i,j,k) > 1.e-14)
+        && vfrac(i,j,k) > 1.e-14)
     {
         int ncomp = d.nComp();
         Real volinv = 1.0/vfrac(i,j,k);
@@ -175,7 +175,7 @@ void eb_rereflux_from_crse (int i, int j, int k, int n, Box const& bx, Array4<Re
             Real wtot = 0.0;
             for (int jj = -1; jj <= 1; ++jj) {
             for (int ii = -1; ii <= 1; ++ii) {
-                if ((ii != 0 or jj != 0) and flag.isConnected(ii,jj,0)) {
+                if ((ii != 0 || jj != 0) && flag.isConnected(ii,jj,0)) {
                     wtot += vfrac(i+ii,j+jj,k);
                 }
             }}
@@ -183,7 +183,7 @@ void eb_rereflux_from_crse (int i, int j, int k, int n, Box const& bx, Array4<Re
             Real drho = dm * ((1.0-vfrac(i,j,k))/wtot);
             for (int jj = -1; jj <= 1; ++jj) {
             for (int ii = -1; ii <= 1; ++ii) {
-                if ((ii != 0 or jj != 0) and flag.isConnected(ii,jj,0)) {
+                if ((ii != 0 || jj != 0) && flag.isConnected(ii,jj,0)) {
                     if (bx.contains(IntVect(i+ii,j+jj))) {
                         HostDevice::Atomic::Add(d.ptr(i+ii,j+jj,k,n), drho);
                     }

--- a/Src/EB/AMReX_EBFluxRegister_3D_C.H
+++ b/Src/EB/AMReX_EBFluxRegister_3D_C.H
@@ -13,7 +13,7 @@ void eb_flux_reg_crseadd_va(int i, int j, int k, Array4<Real> const& d,
                             Real dtdx, Real dtdy, Real dtdz)
 {
     if (flag(i,j,k) == amrex_yafluxreg_crse_fine_boundary_cell
-        and vfrac(i,j,k) > 1.e-14)
+        && vfrac(i,j,k) > 1.e-14)
     {
         int ncomp = d.nComp();
         Real volinv = 1.0/vfrac(i,j,k);
@@ -233,7 +233,7 @@ void eb_rereflux_from_crse (int i, int j, int k, int n, Box const& bx, Array4<Re
             for (int kk = -1; kk <= 1; ++kk) {
             for (int jj = -1; jj <= 1; ++jj) {
             for (int ii = -1; ii <= 1; ++ii) {
-                if ((ii != 0 or jj != 0 or kk != 0) and flag.isConnected(ii,jj,kk)) {
+                if ((ii != 0 or jj != 0 or kk != 0) && flag.isConnected(ii,jj,kk)) {
                     wtot += vfrac(i+ii,j+jj,k+kk);
                 }
             }}}
@@ -242,7 +242,7 @@ void eb_rereflux_from_crse (int i, int j, int k, int n, Box const& bx, Array4<Re
             for (int kk = -1; kk <= 1; ++kk) {
             for (int jj = -1; jj <= 1; ++jj) {
             for (int ii = -1; ii <= 1; ++ii) {
-                if ((ii != 0 or jj != 0 or kk != 0) and flag.isConnected(ii,jj,kk)) {
+                if ((ii != 0 or jj != 0 or kk != 0) && flag.isConnected(ii,jj,kk)) {
                     if (bx.contains(IntVect(i+ii,j+jj,k+kk))) {
                         HostDevice::Atomic::Add(d.ptr(i+ii,j+jj,k+kk,n), drho);
                     }

--- a/Src/EB/AMReX_EBFluxRegister_3D_C.H
+++ b/Src/EB/AMReX_EBFluxRegister_3D_C.H
@@ -233,7 +233,7 @@ void eb_rereflux_from_crse (int i, int j, int k, int n, Box const& bx, Array4<Re
             for (int kk = -1; kk <= 1; ++kk) {
             for (int jj = -1; jj <= 1; ++jj) {
             for (int ii = -1; ii <= 1; ++ii) {
-                if ((ii != 0 or jj != 0 or kk != 0) && flag.isConnected(ii,jj,kk)) {
+                if ((ii != 0 || jj != 0 || kk != 0) && flag.isConnected(ii,jj,kk)) {
                     wtot += vfrac(i+ii,j+jj,k+kk);
                 }
             }}}
@@ -242,7 +242,7 @@ void eb_rereflux_from_crse (int i, int j, int k, int n, Box const& bx, Array4<Re
             for (int kk = -1; kk <= 1; ++kk) {
             for (int jj = -1; jj <= 1; ++jj) {
             for (int ii = -1; ii <= 1; ++ii) {
-                if ((ii != 0 or jj != 0 or kk != 0) && flag.isConnected(ii,jj,kk)) {
+                if ((ii != 0 || jj != 0 || kk != 0) && flag.isConnected(ii,jj,kk)) {
                     if (bx.contains(IntVect(i+ii,j+jj,k+kk))) {
                         HostDevice::Atomic::Add(d.ptr(i+ii,j+jj,k+kk,n), drho);
                     }

--- a/Src/EB/AMReX_EBMultiFabUtil.cpp
+++ b/Src/EB/AMReX_EBMultiFabUtil.cpp
@@ -416,7 +416,7 @@ EB_average_down (const MultiFab& S_fine, MultiFab& S_crse, int scomp, int ncomp,
         BoxArray crse_S_fine_BA = S_fine.boxArray(); crse_S_fine_BA.coarsen(ratio);
 
         if (crse_S_fine_BA == S_crse.boxArray()
-            and S_fine.DistributionMap() == S_crse.DistributionMap())
+            && S_fine.DistributionMap() == S_crse.DistributionMap())
         {
 #ifdef _OPENMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())

--- a/Src/EB/AMReX_EBMultiFabUtil_2D_C.H
+++ b/Src/EB/AMReX_EBMultiFabUtil_2D_C.H
@@ -8,8 +8,8 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 void eb_set_covered_nodes (int i, int j, int k, int n, int icomp, Array4<Real> const& d,
                            Array4<EBCellFlag const> const& f, Real v)
 {
-    if (f(i-1,j-1,k).isCovered() and f(i  ,j-1,k).isCovered() and
-        f(i-1,j  ,k).isCovered() and f(i  ,j  ,k).isCovered())
+    if (f(i-1,j-1,k).isCovered() && f(i  ,j-1,k).isCovered() &&
+        f(i-1,j  ,k).isCovered() && f(i  ,j  ,k).isCovered())
     {
         d(i,j,k,n+icomp) = v;
     }
@@ -19,8 +19,8 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 void eb_set_covered_nodes (int i, int j, int k, int n, int icomp, Array4<Real> const& d,
                            Array4<EBCellFlag const> const& f, Real const * AMREX_RESTRICT v)
 {
-    if (f(i-1,j-1,k).isCovered() and f(i  ,j-1,k).isCovered() and
-        f(i-1,j  ,k).isCovered() and f(i  ,j  ,k).isCovered())
+    if (f(i-1,j-1,k).isCovered() && f(i  ,j-1,k).isCovered() &&
+        f(i-1,j  ,k).isCovered() && f(i  ,j  ,k).isCovered())
     {
         d(i,j,k,n+icomp) = v[n];
     }
@@ -178,28 +178,28 @@ void eb_compute_divergence (int i, int j, int k, int n, Array4<Real> const& divu
     else
     {
         Real fxm = u(i,j,k,n);
-        if (apx(i,j,k) != 0.0 and apx(i,j,k) != 1.0) {
+        if (apx(i,j,k) != 0.0 && apx(i,j,k) != 1.0) {
             int jj = j + static_cast<int>(amrex::Math::copysign(1.0,fcx(i,j,k)));
             Real fracy = (ccm(i-1,jj,k) || ccm(i,jj,k)) ? amrex::Math::abs(fcx(i,j,k)) : 0.0;
             fxm = (1.0-fracy)*fxm + fracy*u(i,jj,k,n);
         }
 
         Real fxp = u(i+1,j,k,n);
-        if (apx(i+1,j,k) != 0.0 and apx(i+1,j,k) != 1.0) {
+        if (apx(i+1,j,k) != 0.0 && apx(i+1,j,k) != 1.0) {
             int jj = j + static_cast<int>(amrex::Math::copysign(1.0,fcx(i+1,j,k)));
             Real fracy = (ccm(i,jj,k) || ccm(i+1,jj,k)) ? amrex::Math::abs(fcx(i+1,j,k)) : 0.0;
             fxp = (1.0-fracy)*fxp + fracy*u(i+1,jj,k,n);
         }
 
         Real fym = v(i,j,k,n);
-        if (apy(i,j,k) != 0.0 and apy(i,j,k) != 1.0) {
+        if (apy(i,j,k) != 0.0 && apy(i,j,k) != 1.0) {
             int ii = i + static_cast<int>(amrex::Math::copysign(1.0,fcy(i,j,k)));
             Real fracx = (ccm(ii,j-1,k) || ccm(ii,j,k)) ? amrex::Math::abs(fcy(i,j,k)) : 0.0;
             fym = (1.0-fracx)*fym + fracx*v(ii,j,k,n);
         }
 
         Real fyp = v(i,j+1,k,n);
-        if (apy(i,j+1,k) != 0.0 and apy(i,j+1,k) != 1.0) {
+        if (apy(i,j+1,k) != 0.0 && apy(i,j+1,k) != 1.0) {
             int ii = i + static_cast<int>(amrex::Math::copysign(1.0,fcy(i,j+1,k)));
             Real fracx = (ccm(ii,j,k) || ccm(ii,j+1,k)) ? amrex::Math::abs(fcy(i,j+1,k)) : 0.0;
             fyp = (1.0-fracx)*fyp + fracx*v(ii,j+1,k,n);
@@ -300,11 +300,11 @@ void eb_interp_cc2facecent_x (Box const& ubx,
       {
         if (apx(i,j,k) == 1)
         {
-          if ( (i == domlo.x) and (bc[n].lo(0) == BCType::ext_dir) )
+          if ( (i == domlo.x) && (bc[n].lo(0) == BCType::ext_dir) )
           {
             edg_x(i,j,k,n) = phi(domlo.x-1,j,k,n);
           }
-          else if ( (i == domhi.x+1) and (bc[n].hi(0) == BCType::ext_dir) )
+          else if ( (i == domhi.x+1) && (bc[n].hi(0) == BCType::ext_dir) )
           {
             edg_x(i,j,k,n) = phi(domhi.x+1,j,k,n);
           }
@@ -351,11 +351,11 @@ void eb_interp_cc2facecent_y (Box const& vbx,
       {
         if (apy(i,j,k) == 1)
         {
-          if ( (j == domlo.y) and (bc[n].lo(1) == BCType::ext_dir) )
+          if ( (j == domlo.y) && (bc[n].lo(1) == BCType::ext_dir) )
           {
             edg_y(i,j,k,n) = phi(i,domlo.y-1,k,n);
           }
-          else if ( (j == domhi.y+1) and (bc[n].hi(1) == BCType::ext_dir) )
+          else if ( (j == domhi.y+1) && (bc[n].hi(1) == BCType::ext_dir) )
           {
             edg_y(i,j,k,n) = phi(i,domhi.y+1,k,n);
           }
@@ -400,11 +400,11 @@ void eb_interp_centroid2facecent_x (Box const& ubx,
       {
           edg_x(i,j,k,n) = 1e40;
       }
-      else if ( (i == domlo.x) and (bc[n].lo(0) == BCType::ext_dir) )
+      else if ( (i == domlo.x) && (bc[n].lo(0) == BCType::ext_dir) )
       {
           edg_x(i,j,k,n) = phi(domlo.x-1,j,k,n);
       }
-      else if ( (i == domhi.x+1) and (bc[n].hi(0) == BCType::ext_dir) )
+      else if ( (i == domhi.x+1) && (bc[n].hi(0) == BCType::ext_dir) )
       {
           edg_x(i,j,k,n) = phi(domhi.x+1,j,k,n);
       }
@@ -461,11 +461,11 @@ void eb_interp_centroid2facecent_y (Box const& vbx,
         {
             edg_y(i,j,k,n) = 1e40;
         }
-        else if ( (j == domlo.y) and (bc[n].lo(1) == BCType::ext_dir) )
+        else if ( (j == domlo.y) && (bc[n].lo(1) == BCType::ext_dir) )
         {
             edg_y(i,j,k,n) = phi(i,domlo.y-1,k,n);
         }
-        else if ( (j == domhi.y+1) and (bc[n].hi(1) == BCType::ext_dir) )
+        else if ( (j == domhi.y+1) && (bc[n].hi(1) == BCType::ext_dir) )
         {
             edg_y(i,j,k,n) = phi(i,domhi.y+1,k,n);
         }
@@ -514,11 +514,11 @@ void eb_interp_cc2face_x (Box const& ubx,
   const Dim3 domhi = amrex::ubound(domain);
   amrex::Loop(ubx, ncomp, [=] (int i, int j, int k, int n) noexcept
     {
-        if ( (i == domlo.x) and (bc[n].lo(0) == BCType::ext_dir) )
+        if ( (i == domlo.x) && (bc[n].lo(0) == BCType::ext_dir) )
         {
           edg_x(i,j,k,n) = phi(domlo.x-1,j,k,n);
         }
-        else if ( (i == domhi.x+1) and (bc[n].hi(0) == BCType::ext_dir) )
+        else if ( (i == domhi.x+1) && (bc[n].hi(0) == BCType::ext_dir) )
         {
           edg_x(i,j,k,n) = phi(domhi.x+1,j,k,n);
         }
@@ -541,11 +541,11 @@ void eb_interp_cc2face_y (Box const& vbx,
   const Dim3 domhi = amrex::ubound(domain);
   amrex::Loop(vbx, ncomp, [=] (int i, int j, int k, int n) noexcept
     {
-        if ( (j == domlo.y) and (bc[n].lo(1) == BCType::ext_dir) )
+        if ( (j == domlo.y) && (bc[n].lo(1) == BCType::ext_dir) )
         {
           edg_y(i,j,k,n) = phi(i,domlo.y-1,k,n);
         }
-        else if ( (j == domhi.y+1) and (bc[n].hi(1) == BCType::ext_dir) )
+        else if ( (j == domhi.y+1) && (bc[n].hi(1) == BCType::ext_dir) )
         {
           edg_y(i,j,k,n) = phi(i,domhi.y+1,k,n);
         }

--- a/Src/EB/AMReX_EBMultiFabUtil_3D_C.H
+++ b/Src/EB/AMReX_EBMultiFabUtil_3D_C.H
@@ -50,10 +50,10 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 void eb_set_covered_nodes (int i, int j, int k, int n, int icomp, Array4<Real> const& d,
                            Array4<EBCellFlag const> const& f, Real v)
 {
-    if (f(i-1,j-1,k-1).isCovered() and f(i  ,j-1,k-1).isCovered() and
-        f(i-1,j  ,k-1).isCovered() and f(i  ,j  ,k-1).isCovered() and
-        f(i-1,j-1,k  ).isCovered() and f(i  ,j-1,k  ).isCovered() and
-        f(i-1,j  ,k  ).isCovered() and f(i  ,j  ,k  ).isCovered())
+    if (f(i-1,j-1,k-1).isCovered() && f(i  ,j-1,k-1).isCovered() &&
+        f(i-1,j  ,k-1).isCovered() && f(i  ,j  ,k-1).isCovered() &&
+        f(i-1,j-1,k  ).isCovered() && f(i  ,j-1,k  ).isCovered() &&
+        f(i-1,j  ,k  ).isCovered() && f(i  ,j  ,k  ).isCovered())
     {
         d(i,j,k,n+icomp) = v;
     }
@@ -63,10 +63,10 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 void eb_set_covered_nodes (int i, int j, int k, int n, int icomp, Array4<Real> const& d,
                            Array4<EBCellFlag const> const& f, Real const * AMREX_RESTRICT v)
 {
-    if (f(i-1,j-1,k-1).isCovered() and f(i  ,j-1,k-1).isCovered() and
-        f(i-1,j  ,k-1).isCovered() and f(i  ,j  ,k-1).isCovered() and
-        f(i-1,j-1,k  ).isCovered() and f(i  ,j-1,k  ).isCovered() and
-        f(i-1,j  ,k  ).isCovered() and f(i  ,j  ,k  ).isCovered())
+    if (f(i-1,j-1,k-1).isCovered() && f(i  ,j-1,k-1).isCovered() &&
+        f(i-1,j  ,k-1).isCovered() && f(i  ,j  ,k-1).isCovered() &&
+        f(i-1,j-1,k  ).isCovered() && f(i  ,j-1,k  ).isCovered() &&
+        f(i-1,j  ,k  ).isCovered() && f(i  ,j  ,k  ).isCovered())
     {
         d(i,j,k,n+icomp) = v[n];
     }
@@ -252,7 +252,7 @@ void eb_compute_divergence (int i, int j, int k, int n, Array4<Real> const& divu
     else
     {
         Real fxm = u(i,j,k,n);
-        if (apx(i,j,k) != 0.0 and apx(i,j,k) != 1.0) {
+        if (apx(i,j,k) != 0.0 && apx(i,j,k) != 1.0) {
             int jj = j + static_cast<int>(amrex::Math::copysign(1.0, fcx(i,j,k,0)));
             int kk = k + static_cast<int>(amrex::Math::copysign(1.0, fcx(i,j,k,1)));
             Real fracy = (ccm(i-1,jj,k) || ccm(i,jj,k)) ? amrex::Math::abs(fcx(i,j,k,0)) : 0.0;
@@ -264,7 +264,7 @@ void eb_compute_divergence (int i, int j, int k, int n, Array4<Real> const& divu
         }
 
         Real fxp = u(i+1,j,k,n);
-        if (apx(i+1,j,k) != 0.0 and apx(i+1,j,k) != 1.0) {
+        if (apx(i+1,j,k) != 0.0 && apx(i+1,j,k) != 1.0) {
             int jj = j + static_cast<int>(amrex::Math::copysign(1.0,fcx(i+1,j,k,0)));
             int kk = k + static_cast<int>(amrex::Math::copysign(1.0,fcx(i+1,j,k,1)));
             Real fracy = (ccm(i,jj,k) || ccm(i+1,jj,k)) ? amrex::Math::abs(fcx(i+1,j,k,0)) : 0.0;
@@ -276,7 +276,7 @@ void eb_compute_divergence (int i, int j, int k, int n, Array4<Real> const& divu
         }
 
         Real fym = v(i,j,k,n);
-        if (apy(i,j,k) != 0.0 and apy(i,j,k) != 1.0) {
+        if (apy(i,j,k) != 0.0 && apy(i,j,k) != 1.0) {
             int ii = i + static_cast<int>(amrex::Math::copysign(1.0,fcy(i,j,k,0)));
             int kk = k + static_cast<int>(amrex::Math::copysign(1.0,fcy(i,j,k,1)));
             Real fracx = (ccm(ii,j-1,k) || ccm(ii,j,k)) ? amrex::Math::abs(fcy(i,j,k,0)) : 0.0;
@@ -288,7 +288,7 @@ void eb_compute_divergence (int i, int j, int k, int n, Array4<Real> const& divu
         }
 
         Real fyp = v(i,j+1,k,n);
-        if (apy(i,j+1,k) != 0.0 and apy(i,j+1,k) != 1.0) {
+        if (apy(i,j+1,k) != 0.0 && apy(i,j+1,k) != 1.0) {
             int ii = i + static_cast<int>(amrex::Math::copysign(1.0,fcy(i,j+1,k,0)));
             int kk = k + static_cast<int>(amrex::Math::copysign(1.0,fcy(i,j+1,k,1)));
             Real fracx = (ccm(ii,j,k) || ccm(ii,j+1,k)) ? amrex::Math::abs(fcy(i,j+1,k,0)) : 0.0;
@@ -300,7 +300,7 @@ void eb_compute_divergence (int i, int j, int k, int n, Array4<Real> const& divu
         }
 
         Real fzm = w(i,j,k,n);
-        if (apz(i,j,k) != 0.0 and apz(i,j,k) != 1.0) {
+        if (apz(i,j,k) != 0.0 && apz(i,j,k) != 1.0) {
             int ii = i + static_cast<int>(amrex::Math::copysign(1.0,fcz(i,j,k,0)));
             int jj = j + static_cast<int>(amrex::Math::copysign(1.0,fcz(i,j,k,1)));
             Real fracx = (ccm(ii,j,k-1) || ccm(ii,j,k)) ? amrex::Math::abs(fcz(i,j,k,0)) : 0.0;
@@ -312,7 +312,7 @@ void eb_compute_divergence (int i, int j, int k, int n, Array4<Real> const& divu
         }
 
         Real fzp = w(i,j,k+1,n);
-        if (apz(i,j,k+1) != 0.0 and apz(i,j,k+1) != 1.0) {
+        if (apz(i,j,k+1) != 0.0 && apz(i,j,k+1) != 1.0) {
             int ii = i + static_cast<int>(amrex::Math::copysign(1.0,fcz(i,j,k+1,0)));
             int jj = j + static_cast<int>(amrex::Math::copysign(1.0,fcz(i,j,k+1,1)));
             Real fracx = (ccm(ii,j,k) || ccm(ii,j,k+1)) ? amrex::Math::abs(fcz(i,j,k+1,0)) : 0.0;
@@ -439,11 +439,11 @@ void eb_interp_cc2facecent_x (Box const& ubx,
     {
       if (apx(i,j,k) == 1)
       {
-        if ( (i == domlo.x) and (bc[n].lo(0) == BCType::ext_dir) )
+        if ( (i == domlo.x) && (bc[n].lo(0) == BCType::ext_dir) )
         {
           edg_x(i,j,k,n) = phi(domlo.x-1,j,k,n);
         }
-        else if ( (i == domhi.x+1) and (bc[n].hi(0) == BCType::ext_dir) )
+        else if ( (i == domhi.x+1) && (bc[n].hi(0) == BCType::ext_dir) )
         {
           edg_x(i,j,k,n) = phi(domhi.x+1,j,k,n);
         }
@@ -502,11 +502,11 @@ void eb_interp_cc2facecent_y (Box const& vbx,
     {
       if (apy(i,j,k) == 1)
       {
-        if ( (j == domlo.y) and (bc[n].lo(1) == BCType::ext_dir) )
+        if ( (j == domlo.y) && (bc[n].lo(1) == BCType::ext_dir) )
         {
           edg_y(i,j,k,n) = phi(i,domlo.y-1,k,n);
         }
-        else if ( (j == domhi.y+1) and (bc[n].hi(1) == BCType::ext_dir) )
+        else if ( (j == domhi.y+1) && (bc[n].hi(1) == BCType::ext_dir) )
         {
           edg_y(i,j,k,n) = phi(i,domhi.y+1,k,n);
         }
@@ -565,11 +565,11 @@ void eb_interp_cc2facecent_z (Box const& wbx,
     {
       if (apz(i,j,k) == 1)
       {
-        if ( (k == domlo.z) and (bc[n].lo(2) == BCType::ext_dir) )
+        if ( (k == domlo.z) && (bc[n].lo(2) == BCType::ext_dir) )
         {
           edg_z(i,j,k,n) = phi(i,j,domlo.z-1,n);
         }
-        else if ( (k == domhi.z+1) and (bc[n].hi(2) == BCType::ext_dir) )
+        else if ( (k == domhi.z+1) && (bc[n].hi(2) == BCType::ext_dir) )
         {
           edg_z(i,j,k,n) = phi(i,j,domhi.z+1,n);
         }
@@ -628,11 +628,11 @@ void eb_interp_centroid2facecent_x (Box const& ubx,
       {
           phi_x(i,j,k,n) = 1e40;
       }
-      else if ( (i == domlo.x) and (bc[n].lo(0) == BCType::ext_dir) )
+      else if ( (i == domlo.x) && (bc[n].lo(0) == BCType::ext_dir) )
       {
           phi_x(i,j,k,n) = phi(domlo.x-1,j,k,n);
       }
-      else if ( (i == domhi.x+1) and (bc[n].hi(0) == BCType::ext_dir) )
+      else if ( (i == domhi.x+1) && (bc[n].hi(0) == BCType::ext_dir) )
       {
           phi_x(i,j,k,n) = phi(domhi.x+1,j,k,n);
       }
@@ -818,11 +818,11 @@ void eb_interp_centroid2facecent_y (Box const& vbx,
         {
             phi_y(i,j,k,n) = 1e40;
         }
-        else if ( (j == domlo.y) and (bc[n].lo(1) == BCType::ext_dir) )
+        else if ( (j == domlo.y) && (bc[n].lo(1) == BCType::ext_dir) )
         {
             phi_y(i,j,k,n) = phi(i,domlo.y-1,k,n);
         }
-        else if ( (j == domhi.y+1) and (bc[n].hi(1) == BCType::ext_dir) )
+        else if ( (j == domhi.y+1) && (bc[n].hi(1) == BCType::ext_dir) )
         {
             phi_y(i,j,k,n) = phi(i,domhi.y+1,k,n);
         }
@@ -1005,11 +1005,11 @@ void eb_interp_centroid2facecent_z (Box const& wbx,
         {
             phi_z(i,j,k,n) = 1e40;
         }
-        else if ( (k == domlo.z) and (bc[n].lo(2) == BCType::ext_dir) )
+        else if ( (k == domlo.z) && (bc[n].lo(2) == BCType::ext_dir) )
         {
             phi_z(i,j,k,n) = phi(i,j,domlo.z-1,n);
         }
-        else if ( (k == domhi.z+1) and (bc[n].hi(2) == BCType::ext_dir) )
+        else if ( (k == domhi.z+1) && (bc[n].hi(2) == BCType::ext_dir) )
         {
             phi_z(i,j,k,n) = phi(i,j,domhi.z+1,n);
         }
@@ -1182,11 +1182,11 @@ void eb_interp_cc2face_x (Box const& ubx,
   const Dim3 domhi = amrex::ubound(domain);
   amrex::Loop(ubx, ncomp, [=] (int i, int j, int k, int n) noexcept
   {
-    if ( (i == domlo.x) and (bc[n].lo(0) == BCType::ext_dir) )
+    if ( (i == domlo.x) && (bc[n].lo(0) == BCType::ext_dir) )
     {
       edg_x(i,j,k,n) = phi(domlo.x-1,j,k,n);
     }
-    else if ( (i == domhi.x+1) and (bc[n].hi(0) == BCType::ext_dir) )
+    else if ( (i == domhi.x+1) && (bc[n].hi(0) == BCType::ext_dir) )
     {
       edg_x(i,j,k,n) = phi(domhi.x+1,j,k,n);
     }
@@ -1209,11 +1209,11 @@ void eb_interp_cc2face_y (Box const& vbx,
   const Dim3 domhi = amrex::ubound(domain);
   amrex::Loop(vbx, ncomp, [=] (int i, int j, int k, int n) noexcept
   {
-    if ( (j == domlo.y) and (bc[n].lo(1) == BCType::ext_dir) )
+    if ( (j == domlo.y) && (bc[n].lo(1) == BCType::ext_dir) )
     {
       edg_y(i,j,k,n) = phi(i,domlo.y-1,k,n);
     }
-    else if ( (j == domhi.y+1) and (bc[n].hi(1) == BCType::ext_dir) )
+    else if ( (j == domhi.y+1) && (bc[n].hi(1) == BCType::ext_dir) )
     {
       edg_y(i,j,k,n) = phi(i,domhi.y+1,k,n);
     }
@@ -1236,11 +1236,11 @@ void eb_interp_cc2face_z (Box const& wbx,
   const Dim3 domhi = amrex::ubound(domain);
   amrex::Loop(wbx, ncomp, [=] (int i, int j, int k, int n) noexcept
   {
-    if ( (k == domlo.z) and (bc[n].lo(2) == BCType::ext_dir) )
+    if ( (k == domlo.z) && (bc[n].lo(2) == BCType::ext_dir) )
     {
       edg_z(i,j,k,n) = phi(i,j,domlo.z-1,n);
     }
-    else if ( (k == domhi.z+1) and (bc[n].hi(2) == BCType::ext_dir) )
+    else if ( (k == domhi.z+1) && (bc[n].hi(2) == BCType::ext_dir) )
     {
       edg_z(i,j,k,n) = phi(i,j,domhi.z+1,n);
     }

--- a/Src/EB/AMReX_EB_slopes_K.H
+++ b/Src/EB/AMReX_EB_slopes_K.H
@@ -41,8 +41,8 @@ amrex_calc_slopes_eb_given_A (int i, int j, int k, int n,
         for(int jj(-1); jj<=1; jj++){
           for(int ii(-1); ii<=1; ii++){
 
-            if( flag(i,j,0).isConnected(ii,jj,0) and
-                not (ii==0 and jj==0)) {
+            if( flag(i,j,0).isConnected(ii,jj,0) &&
+                ! (ii==0 && jj==0)) {
 
               du[lc] = state(i+ii,j+jj,0,n) - state(i,j,0,n);
 
@@ -115,8 +115,8 @@ amrex_calc_slopes_eb_given_A (int i, int j, int k, int n,
         for(int jj(-1); jj<=1; jj++){
           for(int ii(-1); ii<=1; ii++){
 
-            if( flag(i,j,k).isConnected(ii,jj,kk) and
-                not (ii==0 and jj==0 and kk==0)) {
+            if( flag(i,j,k).isConnected(ii,jj,kk) &&
+                ! (ii==0 && jj==0 && kk==0)) {
 
               du[lc] = state(i+ii,j+jj,k+kk,n) - state(i,j,k,n);
 
@@ -228,8 +228,8 @@ amrex_calc_slopes_eb (int i, int j, int k, int n,
         for(int jj(-1); jj<=1; jj++){
           for(int ii(-1); ii<=1; ii++){
 
-            if( flag(i,j,k).isConnected(ii,jj,kk) and
-                not (ii==0 and jj==0 and kk==0)) {
+            if( flag(i,j,k).isConnected(ii,jj,kk) &&
+                ! (ii==0 && jj==0 && kk==0)) {
 
             // Not multplying by dx to be consistent with how the
             // slope is stored. Also not including the global shift
@@ -265,14 +265,14 @@ amrex_calc_slopes_eb (int i, int j, int k, int n,
     // 
 
     // X direction
-    if (flag(i,j,k).isRegular() and flag(i-1,j,k).isRegular() and flag(i+1,j,k).isRegular()) 
+    if (flag(i,j,k).isRegular() && flag(i-1,j,k).isRegular() && flag(i+1,j,k).isRegular()) 
     {
         int order = 2;
         xslope = amrex_calc_xslope(i,j,k,n,order,state);
     }
 
     // Y direction
-    if (flag(i,j,k).isRegular() and flag(i,j-1,k).isRegular() and flag(i,j+1,k).isRegular()) 
+    if (flag(i,j,k).isRegular() && flag(i,j-1,k).isRegular() && flag(i,j+1,k).isRegular()) 
     {
         int order = 2;
         yslope = amrex_calc_yslope(i,j,k,n,order,state);
@@ -280,7 +280,7 @@ amrex_calc_slopes_eb (int i, int j, int k, int n,
 
 #if (AMREX_SPACEDIM == 3)
     // Z direction
-    if (flag(i,j,k).isRegular() and flag(i,j,k-1).isRegular() and flag(i,j,k+1).isRegular()) 
+    if (flag(i,j,k).isRegular() && flag(i,j,k-1).isRegular() && flag(i,j,k+1).isRegular()) 
     {
         int order = 2;
         zslope = amrex_calc_zslope(i,j,k,n,order,state);
@@ -328,11 +328,11 @@ amrex_calc_slopes_extdir_eb (int i, int j, int k, int n,
                  amrex::Real zslope = 0.0;);
 
     // First get EB-aware slope that doesn't know about extdir
-    bool needs_bdry_stencil = (edlo_x and i <= domlo_x) or (edhi_x and i >= domhi_x) or
-                              (edlo_y and j <= domlo_y) or (edhi_y and j >= domhi_y);
+    bool needs_bdry_stencil = (edlo_x && i <= domlo_x) || (edhi_x && i >= domhi_x) ||
+                              (edlo_y && j <= domlo_y) || (edhi_y && j >= domhi_y);
 #if (AMREX_SPACEDIM == 3)
-         needs_bdry_stencil = needs_bdry_stencil or 
-                              (edlo_z and k <= domlo_z) or (edhi_z and k >= domhi_z);
+         needs_bdry_stencil = needs_bdry_stencil || 
+                              (edlo_z && k <= domlo_z) || (edhi_z && k >= domhi_z);
 #endif
 
     //
@@ -355,7 +355,7 @@ amrex_calc_slopes_extdir_eb (int i, int j, int k, int n,
     //    1) Here if any of the cells are not regular we use the face and cell centroids
     //
 
-    if ( (edlo_x and i == domlo_x) or (edhi_x and i == domhi_x) )
+    if ( (edlo_x && i == domlo_x) || (edhi_x && i == domhi_x) )
     {
         int lc=0;
 #if (AMREX_SPACEDIM == 3)
@@ -367,21 +367,21 @@ amrex_calc_slopes_extdir_eb (int i, int j, int k, int n,
             for(int jj(-1); jj<=1; jj++){
               for(int ii(-1); ii<=1; ii++){
 
-                if( flag(i,j,k).isConnected(ii,jj,kk) and
-                    not (ii==0 and jj==0 and kk==0)) {
+                if( flag(i,j,k).isConnected(ii,jj,kk) &&
+                    ! (ii==0 && jj==0 && kk==0)) {
     
                     // Not multplying by dx to be consistent with how the
                     // slope is stored. Also not including the global shift
                     // wrt plo or i,j,k. We only need relative distance.
 
-                    if ( (edlo_x and i == domlo_x) and ii == -1) {
+                    if ( (edlo_x && i == domlo_x) && ii == -1) {
                         A[lc][0] = -0.5                       - ccent(i,j,k,0);
                         A[lc][1] = jj + fcx(i   ,j+jj,k+kk,0) - ccent(i,j,k,1);
 #if (AMREX_SPACEDIM == 3)
                         A[lc][2] = kk + fcx(i   ,j+jj,k+kk,1) - ccent(i,j,k,2);
 #endif
                     } 
-                    else if ( (edhi_x and i == domhi_x) and ii == 1) 
+                    else if ( (edhi_x && i == domhi_x) && ii == 1) 
                     {
                         A[lc][0] = 0.5                        - ccent(i,j,k,0);
                         A[lc][1] = jj + fcx(i+ii,j+jj,k+kk,0) - ccent(i,j,k,1);
@@ -411,7 +411,7 @@ amrex_calc_slopes_extdir_eb (int i, int j, int k, int n,
                      zslope = slopes[2];);
     }
 
-    if ( (edlo_y and j == domlo_y) or (edhi_y and j == domhi_y) )
+    if ( (edlo_y && j == domlo_y) || (edhi_y && j == domhi_y) )
     {
         int lc=0;
 #if (AMREX_SPACEDIM == 3)
@@ -423,21 +423,21 @@ amrex_calc_slopes_extdir_eb (int i, int j, int k, int n,
             for(int jj(-1); jj<=1; jj++){
               for(int ii(-1); ii<=1; ii++){
 
-                if( flag(i,j,k).isConnected(ii,jj,kk) and
-                    not (ii==0 and jj==0 and kk==0)) {
+                if( flag(i,j,k).isConnected(ii,jj,kk) &&
+                    ! (ii==0 && jj==0 && kk==0)) {
     
                     // Not multplying by dx to be consistent with how the
                     // slope is stored. Also not including the global shift
                     // wrt plo or i,j,k. We only need relative distance.
 
-                    if (edlo_y and j == domlo_y and jj == -1) {
+                    if (edlo_y && j == domlo_y && jj == -1) {
                         A[lc][0] = ii + fcy(i+ii,j   ,k+kk,0) - ccent(i,j,k,0);
                         A[lc][1] = -0.5                       - ccent(i,j,k,1);
 #if (AMREX_SPACEDIM == 3)
                         A[lc][2] = kk + fcy(i+ii,j   ,k+kk,1) - ccent(i,j,k,2);
 #endif
                     } 
-                    else if (edhi_y and j == domhi_y and jj == 1) 
+                    else if (edhi_y && j == domhi_y && jj == 1) 
                     {
                         A[lc][0] = ii + fcy(i+ii,j+jj,k+kk,0) - ccent(i,j,k,0);
                         A[lc][1] = 0.5                        - ccent(i,j,k,1);
@@ -470,26 +470,26 @@ amrex_calc_slopes_extdir_eb (int i, int j, int k, int n,
     }
 
 #if (AMREX_SPACEDIM == 3)
-    if ( (edlo_z and k == domlo_z) or (edhi_z and k == domhi_z) )
+    if ( (edlo_z && k == domlo_z) || (edhi_z && k == domhi_z) )
     {
         int lc=0;
         for(int kk(-1); kk<=1; kk++) {
             for(int jj(-1); jj<=1; jj++){
               for(int ii(-1); ii<=1; ii++){
 
-                if( flag(i,j,k).isConnected(ii,jj,kk) and
-                    not (ii==0 and jj==0 and kk==0)) 
+                if( flag(i,j,k).isConnected(ii,jj,kk) &&
+                    ! (ii==0 && jj==0 && kk==0)) 
                 {
                     // Not multplying by dx to be consistent with how the
                     // slope is stored. Also not including the global shift
                     // wrt plo or i,j,k. We only need relative distance.
 
-                    if (edlo_z and k == domlo_z and kk == -1) {
+                    if (edlo_z && k == domlo_z && kk == -1) {
                         A[lc][0] = ii + fcz(i+ii,j+jj,k   ,0) - ccent(i,j,k,0);
                         A[lc][1] = jj + fcz(i+ii,j+jj,k   ,1) - ccent(i,j,k,1);
                         A[lc][2] = -0.5                       - ccent(i,j,k,2);
                     } 
-                    else if (edhi_z and k == domhi_z and kk == 1) 
+                    else if (edhi_z && k == domhi_z && kk == 1) 
                     {
                         A[lc][0] = ii + fcz(i+ii,j+jj,k+kk,0) - ccent(i,j,k,0);
                         A[lc][1] = jj + fcz(i+ii,j+jj,k+kk,1) - ccent(i,j,k,1);
@@ -526,14 +526,14 @@ amrex_calc_slopes_extdir_eb (int i, int j, int k, int n,
     int order = 2;
 
     // Overwrite the tangential slope with the regular stencils if we can compute from non-EB cells
-    if ( flag(i,j,k).isRegular() and flag(i-1,j,k).isRegular() and flag(i+1,j,k).isRegular() )
+    if ( flag(i,j,k).isRegular() && flag(i-1,j,k).isRegular() && flag(i+1,j,k).isRegular() )
       xslope = amrex_calc_xslope_extdir(i,j,k,n,order,state,edlo_x,edhi_x,domlo_x,domhi_x);
 
-    if ( flag(i,j,k).isRegular() and flag(i,j-1,k).isRegular() and flag(i,j+1,k).isRegular() ) 
+    if ( flag(i,j,k).isRegular() && flag(i,j-1,k).isRegular() && flag(i,j+1,k).isRegular() ) 
       yslope = amrex_calc_yslope_extdir(i,j,k,n,order,state,edlo_y,edhi_y,domlo_y,domhi_y);
 
 #if (AMREX_SPACEDIM == 3)
-    if ( flag(i,j,k).isRegular() and flag(i,j,k-1).isRegular() and flag(i,j,k+1).isRegular() ) 
+    if ( flag(i,j,k).isRegular() && flag(i,j,k-1).isRegular() && flag(i,j,k+1).isRegular() ) 
       zslope = amrex_calc_zslope_extdir(i,j,k,n,order,state,edlo_z,edhi_z,domlo_z,domhi_z);
 #endif
     }
@@ -541,17 +541,17 @@ amrex_calc_slopes_extdir_eb (int i, int j, int k, int n,
     // Zero out slopes outside of an extdir (or hoextrap) boundary
     // TODO:  is this the right thing to do at a HOEXTRAP boundary??
 #if (AMREX_SPACEDIM == 2)
-    if ( (edlo_x and i < domlo_x) or (edhi_x and i > domhi_x)   or
-         (edlo_y and j < domlo_y) or (edhi_y and j > domhi_y) )  
+    if ( (edlo_x && i < domlo_x) || (edhi_x && i > domhi_x)   ||
+         (edlo_y && j < domlo_y) || (edhi_y && j > domhi_y) )  
     { 
           AMREX_D_TERM(xslope = 0.;,  
                        xslope = 0.; yslope = 0.;, 
                        xslope = 0.; yslope = 0.; zslope = 0.;);
     } 
 #elif (AMREX_SPACEDIM == 3)
-    if ( (edlo_x and i < domlo_x) or (edhi_x and i > domhi_x) or
-         (edlo_y and j < domlo_y) or (edhi_y and j > domhi_y) or
-         (edlo_z and k < domlo_z) or (edhi_z and k > domhi_z) )
+    if ( (edlo_x && i < domlo_x) || (edhi_x && i > domhi_x) ||
+         (edlo_y && j < domlo_y) || (edhi_y && j > domhi_y) ||
+         (edlo_z && k < domlo_z) || (edhi_z && k > domhi_z) )
     {
           AMREX_D_TERM(xslope = 0.;,  
                        xslope = 0.; yslope = 0.;, 

--- a/Src/EB/AMReX_EB_triGeomOps_K.H
+++ b/Src/EB/AMReX_EB_triGeomOps_K.H
@@ -182,7 +182,7 @@ namespace amrex
                     //or error: p1,midp and p2 are on the same side 
                     //which is not what this function is meant for
                 {
-                    if(plane_eq_mid*plane_eq1 > 0.0 and plane_eq_mid*plane_eq2 > 0.0)
+                    if(plane_eq_mid*plane_eq1 > 0.0 && plane_eq_mid*plane_eq2 > 0.0)
                     {
                         all_ok=false;
                     }
@@ -215,7 +215,7 @@ namespace amrex
             Real eps = std::numeric_limits<Real>::epsilon();
 
             //coplanar (S1,S2,S3 = 0)
-            if(Math::abs(S1) < eps and Math::abs(S2) < eps and Math::abs(S3) < eps) 
+            if(Math::abs(S1) < eps && Math::abs(S2) < eps && Math::abs(S3) < eps)
             {
                 //Print()<<"line segment and triangle are in the same plane\t"<<S1<<"\t"<<S2<<"\t"<<S3<<"\n";
                 tri_area=triangle_area(t1,t2,t3);
@@ -227,17 +227,17 @@ namespace amrex
                 area1=(triangle_area(t1,t2,v1)+triangle_area(t2,t3,v1)+triangle_area(t3,t1,v1));
                 area2=(triangle_area(t1,t2,v2)+triangle_area(t2,t3,v2)+triangle_area(t3,t1,v2));
 
-                if( Math::abs(area1-tri_area)>eps or Math::abs(area2-tri_area)>eps )
+                if( Math::abs(area1-tri_area)>eps || Math::abs(area2-tri_area)>eps )
                 {
                     no_intersections = 0;
                 }
             }
             //proper and edge intersection
-            else if( (S1 < 0.0 and S2 < 0.0 and S3 < 0.0) or 
-                    (S1 > 0.0 and S2 > 0.0 and S3 > 0.0) or
-                    (Math::abs(S1) < eps and S2*S3 > 0.0) or     //S1=0
-                    (Math::abs(S2) < eps and S3*S1 > 0.0) or     //S2=0
-                    (Math::abs(S3) < eps and S1*S2 > 0.0) )      //S3=0
+            else if( (S1 < 0.0 && S2 < 0.0 && S3 < 0.0) ||
+                    (S1 > 0.0 && S2 > 0.0 && S3 > 0.0) ||
+                    (Math::abs(S1) < eps && S2*S3 > 0.0) ||     //S1=0
+                    (Math::abs(S2) < eps && S3*S1 > 0.0) ||     //S2=0
+                    (Math::abs(S3) < eps && S1*S2 > 0.0) )      //S3=0
             {
 
                 get_plucker_coords(v1,t1,L2);
@@ -259,8 +259,8 @@ namespace amrex
                 }
             }
             //vertex intersection
-            else if( (Math::abs(S1) < eps and Math::abs(S2) < eps) or  //S1,S2=0
-                    (Math::abs(S2) < eps and Math::abs(S3) < eps) )   //S2,S3=0
+            else if( (Math::abs(S1) < eps && Math::abs(S2) < eps) ||  //S1,S2=0
+                    (Math::abs(S2) < eps && Math::abs(S3) < eps) )   //S2,S3=0
             {
 
                 //Print()<<"vertex intersection type 1\n";   
@@ -277,7 +277,7 @@ namespace amrex
                     no_intersections = 0;
                 }
             }
-            else if(Math::abs(S3) < eps and Math::abs(S1) < eps) //S3,S1=0
+            else if(Math::abs(S3) < eps && Math::abs(S1) < eps) //S3,S1=0
             {
 
                 //Print()<<"vertex intersection type 2\n";

--- a/Src/EB/AMReX_EB_utils.cpp
+++ b/Src/EB/AMReX_EB_utils.cpp
@@ -98,8 +98,8 @@ namespace amrex {
             for (int kk(ks); kk <= ke; ++kk) {
               for (int jj(-1); jj <= 1; ++jj) {
                 for (int ii(-1); ii <= 1; ++ii) {
-		        if( (ii != 0 or jj != 0 or kk != 0) and
-			    flags(i,j,k).isConnected(ii,jj,kk) and
+		        if( (ii != 0 or jj != 0 or kk != 0) &&
+			    flags(i,j,k).isConnected(ii,jj,kk) &&
 			    dbox.contains(IntVect(AMREX_D_DECL(i+ii,j+jj,k+kk))))
                         {
 
@@ -141,7 +141,7 @@ namespace amrex {
               for (int jj(-1); jj <= 1; ++jj) {
                 for (int ii(-1); ii <= 1; ++ii) {         
             
-                        if( (ii != 0 or jj != 0 or kk != 0) and
+                        if( (ii != 0 or jj != 0 or kk != 0) &&
                             (flags(i,j,k).isConnected(ii,jj,kk)) )
                         {
                             wtot += wt(i+ii,j+jj,k+kk) * vfrac(i+ii,j+jj,k+kk) * mask(i+ii,j+jj,k+kk);
@@ -155,8 +155,8 @@ namespace amrex {
               for (int jj(-1); jj <= 1; ++jj) {
                 for (int ii(-1); ii <= 1; ++ii) {       
             
-                        if( (ii != 0 or jj != 0 or kk != 0) and
-                            (flags(i,j,k).isConnected(ii,jj,kk)) and
+                        if( (ii != 0 or jj != 0 or kk != 0) &&
+                            (flags(i,j,k).isConnected(ii,jj,kk)) &&
                             bx.contains(IntVect(AMREX_D_DECL(i+ii,j+jj,k+kk))) )
                         {
                             Gpu::Atomic::AddNoRet(&optmp(i+ii,j+jj,k+kk,n),

--- a/Src/EB/AMReX_EB_utils.cpp
+++ b/Src/EB/AMReX_EB_utils.cpp
@@ -33,8 +33,8 @@ namespace amrex {
         if (std::abs(dx[0] - dx[1]) > tolerance)
             amrex::Abort("apply_eb_redistribution(): grid spacing must be uniform");
 #elif (AMREX_SPACEDIM == 3)
-        if( (std::abs(dx[0] - dx[1]) > tolerance) or
-            (std::abs(dx[0] - dx[2]) > tolerance) or
+        if( (std::abs(dx[0] - dx[1]) > tolerance) ||
+            (std::abs(dx[0] - dx[2]) > tolerance) ||
             (std::abs(dx[1] - dx[2]) > tolerance) )
             amrex::Abort("apply_eb_redistribution(): grid spacing must be uniform");
 #endif
@@ -98,7 +98,7 @@ namespace amrex {
             for (int kk(ks); kk <= ke; ++kk) {
               for (int jj(-1); jj <= 1; ++jj) {
                 for (int ii(-1); ii <= 1; ++ii) {
-		        if( (ii != 0 or jj != 0 or kk != 0) &&
+		        if( (ii != 0 || jj != 0 || kk != 0) &&
 			    flags(i,j,k).isConnected(ii,jj,kk) &&
 			    dbox.contains(IntVect(AMREX_D_DECL(i+ii,j+jj,k+kk))))
                         {
@@ -141,7 +141,7 @@ namespace amrex {
               for (int jj(-1); jj <= 1; ++jj) {
                 for (int ii(-1); ii <= 1; ++ii) {         
             
-                        if( (ii != 0 or jj != 0 or kk != 0) &&
+                        if( (ii != 0 || jj != 0 || kk != 0) &&
                             (flags(i,j,k).isConnected(ii,jj,kk)) )
                         {
                             wtot += wt(i+ii,j+jj,k+kk) * vfrac(i+ii,j+jj,k+kk) * mask(i+ii,j+jj,k+kk);
@@ -155,7 +155,7 @@ namespace amrex {
               for (int jj(-1); jj <= 1; ++jj) {
                 for (int ii(-1); ii <= 1; ++ii) {       
             
-                        if( (ii != 0 or jj != 0 or kk != 0) &&
+                        if( (ii != 0 || jj != 0 || kk != 0) &&
                             (flags(i,j,k).isConnected(ii,jj,kk)) &&
                             bx.contains(IntVect(AMREX_D_DECL(i+ii,j+jj,k+kk))) )
                         {

--- a/Src/EB/AMReX_WriteEBSurface.cpp
+++ b/Src/EB/AMReX_WriteEBSurface.cpp
@@ -25,7 +25,7 @@ void WriteEBSurface (const BoxArray & ba, const DistributionMapping & dmap, cons
 
         const Box & bx = mfi.validbox();
 
-        if (my_flag.getType(bx) == FabType::covered or
+        if (my_flag.getType(bx) == FabType::covered ||
             my_flag.getType(bx) == FabType::regular) continue;
 
         std::array<const MultiCutFab *, AMREX_SPACEDIM> areafrac;
@@ -57,7 +57,7 @@ void WriteEBSurface (const BoxArray & ba, const DistributionMapping & dmap, cons
 
         const Box & bx = mfi.validbox();
 
-        if (my_flag.getType(bx) == FabType::covered or
+        if (my_flag.getType(bx) == FabType::covered ||
             my_flag.getType(bx) == FabType::regular) continue;
 
         amrex_eb_grid_coverage(& cpu, problo, dx, BL_TO_FORTRAN_BOX(bx), BL_TO_FORTRAN_3D(my_flag));

--- a/Src/EB/AMReX_algoim_K.H
+++ b/Src/EB/AMReX_algoim_K.H
@@ -282,8 +282,8 @@ struct ImplicitIntegral
             bool uniform_sign = (phi_0 > dphi_max) or (phi_0 < -dphi_max);
             if (uniform_sign)
             {
-                if ((phi_0 >= 0.0 and psi[i].sign() >= 0) or
-                    (phi_0 <= 0.0 and psi[i].sign() <= 0) )
+                if ((phi_0 >= 0.0 && psi[i].sign() >= 0) ||
+                    (phi_0 <= 0.0 && psi[i].sign() <= 0) )
                 {
                     --psiCount;
                     detail::swap(psi[i], psi[psiCount]);
@@ -383,13 +383,13 @@ struct ImplicitIntegral
                 x[e0] = x_min;
                 Real phi_lo = phi(x);
                 Real xroot = x[e0] - phi_lo / phi.grad(e0);
-                if (xroot > x_min and xroot < x_max) {
+                if (xroot > x_min && xroot < x_max) {
                     roots[nroots++] = xroot;
                 }
             }
             AMREX_ASSERT(nroots <= 3);
         }
-        if (nroots == 3 and roots[1] > roots[2]) {
+        if (nroots == 3 && roots[1] > roots[2]) {
             detail::swap(roots[1],roots[2]);
         }
         roots[nroots++] = x_max;
@@ -418,7 +418,7 @@ struct ImplicitIntegral
                     }
                 }
                 bool new_ok = (phi(x) > 0.0) ? (psi[j].sign() >= 0) : (psi[j].sign() <= 0);
-                okay = okay and new_ok;
+                okay = okay && new_ok;
             }
             if (!okay) continue;
 

--- a/Src/EB/AMReX_algoim_K.H
+++ b/Src/EB/AMReX_algoim_K.H
@@ -279,7 +279,7 @@ struct ImplicitIntegral
             }
             dphi_max *= 0.5*almostone;
             const Real phi_0 = phi(mid);
-            bool uniform_sign = (phi_0 > dphi_max) or (phi_0 < -dphi_max);
+            bool uniform_sign = (phi_0 > dphi_max) || (phi_0 < -dphi_max);
             if (uniform_sign)
             {
                 if ((phi_0 >= 0.0 && psi[i].sign() >= 0) ||

--- a/Src/Extern/HYPRE/AMReX_Habec_2D_K.H
+++ b/Src/Extern/HYPRE/AMReX_Habec_2D_K.H
@@ -216,7 +216,7 @@ void amrex_hpijmatrix (Box const& box,
         rows[irow]  = cell_id_arr(i,j,k);
         ncols[irow] = 0;
 
-        if (!osm or osm(i,j,k) != 0) {
+        if (!osm || osm(i,j,k) != 0) {
             cols_tmpPtr[0] = cell_id_arr(i,j,k);
             mat_tmpPtr[0]  = sa*a_arr(i,j,k) + fac[0]*(bx_arr(i,j,k)+bx_arr(i+1,j,k))
                                              + fac[1]*(by_arr(i,j,k)+by_arr(i,j+1,k));

--- a/Src/Extern/HYPRE/AMReX_Habec_3D_K.H
+++ b/Src/Extern/HYPRE/AMReX_Habec_3D_K.H
@@ -250,7 +250,7 @@ void amrex_hpijmatrix (Box const& box,
         rows[irow]  = cell_id_arr(i,j,k);
         ncols[irow] = 0;
 
-        if (!osm or osm(i,j,k) != 0) {
+        if (!osm || osm(i,j,k) != 0) {
             cols_tmpPtr[0] = cell_id_arr(i,j,k);
             mat_tmpPtr[0]  = sa*a_arr(i,j,k) + fac[0]*(bx_arr(i,j,k)+bx_arr(i+1,j,k))
                                              + fac[1]*(by_arr(i,j,k)+by_arr(i,j+1,k))

--- a/Src/Extern/HYPRE/AMReX_HypreNodeLap.cpp
+++ b/Src/Extern/HYPRE/AMReX_HypreNodeLap.cpp
@@ -75,24 +75,24 @@ HypreNodeLap::HypreNodeLap (const BoxArray& grids_, const DistributionMapping& d
             for         (int k = lo.z; k <= hi.z; ++k) {
                 for     (int j = lo.y; j <= hi.y; ++j) {
                     for (int i = lo.x; i <= hi.x; ++i) {
-                        if (!owner(i,j,k) or dirichlet(i,j,k))
+                        if (!owner(i,j,k) || dirichlet(i,j,k))
                         {
                             nid(i,j,k) = std::numeric_limits<Int>::lowest();
                         }
 #if (AMREX_SPACEDIM == 2)
-                        else if (flag(i-1,j-1,k).isCovered() and
-                                 flag(i  ,j-1,k).isCovered() and
-                                 flag(i-1,j  ,k).isCovered() and
+                        else if (flag(i-1,j-1,k).isCovered() &&
+                                 flag(i  ,j-1,k).isCovered() &&
+                                 flag(i-1,j  ,k).isCovered() &&
                                  flag(i  ,j  ,k).isCovered())
 #endif
 #if (AMREX_SPACEDIM == 3)
-                        else if (flag(i-1,j-1,k-1).isCovered() and
-                                 flag(i  ,j-1,k-1).isCovered() and
-                                 flag(i-1,j  ,k-1).isCovered() and
-                                 flag(i  ,j  ,k-1).isCovered() and
-                                 flag(i-1,j-1,k  ).isCovered() and
-                                 flag(i  ,j-1,k  ).isCovered() and
-                                 flag(i-1,j  ,k  ).isCovered() and
+                        else if (flag(i-1,j-1,k-1).isCovered() &&
+                                 flag(i  ,j-1,k-1).isCovered() &&
+                                 flag(i-1,j  ,k-1).isCovered() &&
+                                 flag(i  ,j  ,k-1).isCovered() &&
+                                 flag(i-1,j-1,k  ).isCovered() &&
+                                 flag(i  ,j-1,k  ).isCovered() &&
+                                 flag(i-1,j  ,k  ).isCovered() &&
                                  flag(i  ,j  ,k  ).isCovered())
 #endif
                         {
@@ -127,7 +127,7 @@ HypreNodeLap::HypreNodeLap (const BoxArray& grids_, const DistributionMapping& d
             for         (int k = lo.z; k <= hi.z; ++k) {
                 for     (int j = lo.y; j <= hi.y; ++j) {
                     for (int i = lo.x; i <= hi.x; ++i) {
-                        if (!owner(i,j,k) or dirichlet(i,j,k))
+                        if (!owner(i,j,k) || dirichlet(i,j,k))
                         {
                             nid(i,j,k) = std::numeric_limits<Int>::lowest();
                         }

--- a/Src/F_Interfaces/AmrCore/AMReX_FlashFluxRegister.cpp
+++ b/Src/F_Interfaces/AmrCore/AMReX_FlashFluxRegister.cpp
@@ -333,7 +333,7 @@ void FlashFluxRegister::store (int fine_global_index, int dir, FArrayBox const& 
                 allsame = false;
                 d_ifd.resize(m_ncomp);
             }
-            if (not allsame) {
+            if (! allsame) {
                 Gpu::copyAsync(Gpu::HostToDevice(), h_ifd.begin(), h_ifd.end(), d_ifd.begin());
             }
 
@@ -549,7 +549,7 @@ void FlashFluxRegister::load (int crse_global_index, int dir, FArrayBox& crse_fl
         int d_ifd_ready = false;
         for (int index = dir; index < 2*AMREX_SPACEDIM; index += AMREX_SPACEDIM) {
             if (fab_a[index]) {
-                if (not d_ifd_ready) {
+                if (! d_ifd_ready) {
                     d_ifd_ready = true;
                     bool allsame = true;
                     for (int n = 0; n < m_ncomp; ++n) {
@@ -562,7 +562,7 @@ void FlashFluxRegister::load (int crse_global_index, int dir, FArrayBox& crse_fl
                         allsame = false;
                         d_ifd.resize(m_ncomp);
                     }
-                    if (not allsame) {
+                    if (! allsame) {
                         Gpu::copyAsync(Gpu::HostToDevice(), h_ifd.begin(), h_ifd.end(),
                                        d_ifd.begin());
                     }

--- a/Src/LinearSolvers/MLMG/AMReX_MLABecLap_1D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLABecLap_1D_K.H
@@ -125,9 +125,9 @@ void abec_gsrb (Box const& box, Array4<Real> const& phi, Array4<Real const> cons
         AMREX_PRAGMA_SIMD
         for (int i = lo.x; i <= hi.x; ++i) {
             if ((i+redblack)%2 == 0) {
-                Real cf0 = (i == vlo.x and m0(vlo.x-1,0,0) > 0)
+                Real cf0 = (i == vlo.x && m0(vlo.x-1,0,0) > 0)
                     ? f0(vlo.x,0,0,n) : 0.0;
-                Real cf1 = (i == vhi.x and m1(vhi.x+1,0,0) > 0)
+                Real cf1 = (i == vhi.x && m1(vhi.x+1,0,0) > 0)
                     ? f1(vhi.x,0,0,n) : 0.0;
 
                 Real delta = dhx*(bX(i,0,0)*cf0 + bX(i+1,0,0)*cf1);
@@ -169,9 +169,9 @@ void abec_gsrb_os (Box const& box, Array4<Real> const& phi, Array4<Real const> c
                 if (osm(i,0,0) == 0) {
                     phi(i,0,0) = 0.0;
                 } else {
-                    Real cf0 = (i == vlo.x and m0(vlo.x-1,0,0) > 0)
+                    Real cf0 = (i == vlo.x && m0(vlo.x-1,0,0) > 0)
                         ? f0(vlo.x,0,0,n) : 0.0;
-                    Real cf1 = (i == vhi.x and m1(vhi.x+1,0,0) > 0)
+                    Real cf1 = (i == vhi.x && m1(vhi.x+1,0,0) > 0)
                         ? f1(vhi.x,0,0,n) : 0.0;
 
                     Real delta = dhx*(bX(i,0,0)*cf0 + bX(i+1,0,0)*cf1);

--- a/Src/LinearSolvers/MLMG/AMReX_MLABecLap_2D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLABecLap_2D_K.H
@@ -186,13 +186,13 @@ void abec_gsrb (Box const& box, Array4<Real> const& phi, Array4<Real const> cons
             AMREX_PRAGMA_SIMD
             for (int i = lo.x; i <= hi.x; ++i) {
                 if ((i+j+redblack)%2 == 0) {
-                    Real cf0 = (i == vlo.x and m0(vlo.x-1,j,0) > 0)
+                    Real cf0 = (i == vlo.x && m0(vlo.x-1,j,0) > 0)
                         ? f0(vlo.x,j,0,n) : 0.0;
-                    Real cf1 = (j == vlo.y and m1(i,vlo.y-1,0) > 0)
+                    Real cf1 = (j == vlo.y && m1(i,vlo.y-1,0) > 0)
                         ? f1(i,vlo.y,0,n) : 0.0;
-                    Real cf2 = (i == vhi.x and m2(vhi.x+1,j,0) > 0)
+                    Real cf2 = (i == vhi.x && m2(vhi.x+1,j,0) > 0)
                         ? f2(vhi.x,j,0,n) : 0.0;
-                    Real cf3 = (j == vhi.y and m3(i,vhi.y+1,0) > 0)
+                    Real cf3 = (j == vhi.y && m3(i,vhi.y+1,0) > 0)
                         ? f3(i,vhi.y,0,n) : 0.0;
 
                     Real delta = dhx*(bX(i,j,0,n)*cf0 + bX(i+1,j,0,n)*cf2)
@@ -240,13 +240,13 @@ void abec_gsrb_os (Box const& box, Array4<Real> const& phi, Array4<Real const> c
                     if (osm(i,j,0) == 0) {
                         phi(i,j,0,n) = 0.0;
                     } else {
-                        Real cf0 = (i == vlo.x and m0(vlo.x-1,j,0) > 0)
+                        Real cf0 = (i == vlo.x && m0(vlo.x-1,j,0) > 0)
                             ? f0(vlo.x,j,0,n) : 0.0;
-                        Real cf1 = (j == vlo.y and m1(i,vlo.y-1,0) > 0)
+                        Real cf1 = (j == vlo.y && m1(i,vlo.y-1,0) > 0)
                             ? f1(i,vlo.y,0,n) : 0.0;
-                        Real cf2 = (i == vhi.x and m2(vhi.x+1,j,0) > 0)
+                        Real cf2 = (i == vhi.x && m2(vhi.x+1,j,0) > 0)
                             ? f2(vhi.x,j,0,n) : 0.0;
-                        Real cf3 = (j == vhi.y and m3(i,vhi.y+1,0) > 0)
+                        Real cf3 = (j == vhi.y && m3(i,vhi.y+1,0) > 0)
                             ? f3(i,vhi.y,0,n) : 0.0;
 
                         Real delta = dhx*(bX(i,j,0,n)*cf0 + bX(i+1,j,0,n)*cf2)
@@ -319,13 +319,13 @@ void abec_gsrb_with_line_solve (
                         +   dhx*(bX(i,j,0,n)+bX(i+1,j,0,n))
                         +   dhy*(bY(i,j,0,n)+bY(i,j+1,0,n));
 
-                    Real cf0 = (i == vlo.x and m0(vlo.x-1,j,0) > 0)
+                    Real cf0 = (i == vlo.x && m0(vlo.x-1,j,0) > 0)
                         ? f0(vlo.x,j,0,n) : 0.0;
-                    Real cf1 = (j == vlo.y and m1(i,vlo.y-1,0) > 0)
+                    Real cf1 = (j == vlo.y && m1(i,vlo.y-1,0) > 0)
                         ? f1(i,vlo.y,0,n) : 0.0;
-                    Real cf2 = (i == vhi.x and m2(vhi.x+1,j,0) > 0)
+                    Real cf2 = (i == vhi.x && m2(vhi.x+1,j,0) > 0)
                         ? f2(vhi.x,j,0,n) : 0.0;
-                    Real cf3 = (j == vhi.y and m3(i,vhi.y+1,0) > 0)
+                    Real cf3 = (j == vhi.y && m3(i,vhi.y+1,0) > 0)
                         ? f3(i,vhi.y,0,n) : 0.0;
 
                     Real g_m_d = gamma
@@ -336,9 +336,9 @@ void abec_gsrb_with_line_solve (
                               +       bX(i+1,j,0,n)*phi(i+1,j,0,n) );
 
                     // We have already accounted for this external boundary in the coefficient of phi(i,j,k,n)
-                    if (i == vlo.x and m0(vlo.x-1,j,0) > 0)
+                    if (i == vlo.x && m0(vlo.x-1,j,0) > 0)
                         rho -= dhx*bX(i  ,j,0,n)*phi(i-1,j,0,n);
-                    if (i == vhi.x and m3(vhi.x+1,j,0) > 0)
+                    if (i == vhi.x && m3(vhi.x+1,j,0) > 0)
                         rho -= dhx*bX(i+1,j,0,n)*phi(i+1,j,0,n);
 
                     a_ls(j-lo.y) = -dhy*bY(i,j,0,n);

--- a/Src/LinearSolvers/MLMG/AMReX_MLABecLap_3D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLABecLap_3D_K.H
@@ -264,17 +264,17 @@ void abec_gsrb (Box const& box, Array4<Real> const& phi, Array4<Real const> cons
                 AMREX_PRAGMA_SIMD
                 for (int i = lo.x; i <= hi.x; ++i) {
                     if ((i+j+k+redblack)%2 == 0) {
-                        Real cf0 = (i == vlo.x and m0(vlo.x-1,j,k) > 0)
+                        Real cf0 = (i == vlo.x && m0(vlo.x-1,j,k) > 0)
                             ? f0(vlo.x,j,k,n) : 0.0;
-                        Real cf1 = (j == vlo.y and m1(i,vlo.y-1,k) > 0)
+                        Real cf1 = (j == vlo.y && m1(i,vlo.y-1,k) > 0)
                             ? f1(i,vlo.y,k,n) : 0.0;
-                        Real cf2 = (k == vlo.z and m2(i,j,vlo.z-1) > 0)
+                        Real cf2 = (k == vlo.z && m2(i,j,vlo.z-1) > 0)
                             ? f2(i,j,vlo.z,n) : 0.0;
-                        Real cf3 = (i == vhi.x and m3(vhi.x+1,j,k) > 0)
+                        Real cf3 = (i == vhi.x && m3(vhi.x+1,j,k) > 0)
                             ? f3(vhi.x,j,k,n) : 0.0;
-                        Real cf4 = (j == vhi.y and m4(i,vhi.y+1,k) > 0)
+                        Real cf4 = (j == vhi.y && m4(i,vhi.y+1,k) > 0)
                             ? f4(i,vhi.y,k,n) : 0.0;
-                        Real cf5 = (k == vhi.z and m5(i,j,vhi.z+1) > 0)
+                        Real cf5 = (k == vhi.z && m5(i,j,vhi.z+1) > 0)
                             ? f5(i,j,vhi.z,n) : 0.0;
 
                         Real gamma = alpha*a(i,j,k)
@@ -336,17 +336,17 @@ void abec_gsrb_os (Box const& box, Array4<Real> const& phi, Array4<Real const> c
                         if (osm(i,j,k) == 0) {
                             phi(i,j,k,n) = 0.0;
                         } else {
-                            Real cf0 = (i == vlo.x and m0(vlo.x-1,j,k) > 0)
+                            Real cf0 = (i == vlo.x && m0(vlo.x-1,j,k) > 0)
                                 ? f0(vlo.x,j,k,n) : 0.0;
-                            Real cf1 = (j == vlo.y and m1(i,vlo.y-1,k) > 0)
+                            Real cf1 = (j == vlo.y && m1(i,vlo.y-1,k) > 0)
                                 ? f1(i,vlo.y,k,n) : 0.0;
-                            Real cf2 = (k == vlo.z and m2(i,j,vlo.z-1) > 0)
+                            Real cf2 = (k == vlo.z && m2(i,j,vlo.z-1) > 0)
                                 ? f2(i,j,vlo.z,n) : 0.0;
-                            Real cf3 = (i == vhi.x and m3(vhi.x+1,j,k) > 0)
+                            Real cf3 = (i == vhi.x && m3(vhi.x+1,j,k) > 0)
                                 ? f3(vhi.x,j,k,n) : 0.0;
-                            Real cf4 = (j == vhi.y and m4(i,vhi.y+1,k) > 0)
+                            Real cf4 = (j == vhi.y && m4(i,vhi.y+1,k) > 0)
                                 ? f4(i,vhi.y,k,n) : 0.0;
-                            Real cf5 = (k == vhi.z and m5(i,j,vhi.z+1) > 0)
+                            Real cf5 = (k == vhi.z && m5(i,j,vhi.z+1) > 0)
                                 ? f5(i,j,vhi.z,n) : 0.0;
 
                             Real gamma = alpha*a(i,j,k)
@@ -425,11 +425,11 @@ void abec_gsrb_with_line_solve (
     int idir = 2;
     int ilen = hi.z - lo.z + 1;
 	
-    if ( (dhx <= dhy) and (dhz <= dhy) ) {
+    if ( (dhx <= dhy) && (dhz <= dhy) ) {
 	idir = 1;
 	ilen = hi.y - lo.y + 1;
     }	
-    if ( (dhy <= dhx) and (dhz <= dhx) ) {
+    if ( (dhy <= dhx) && (dhz <= dhx) ) {
 	idir = 0;
 	ilen = hi.x - lo.x + 1;
     } 
@@ -458,17 +458,17 @@ void abec_gsrb_with_line_solve (
                                 +   dhy*(bY(i,j,k,n)+bY(i,j+1,k,n))
                                 +   dhz*(bZ(i,j,k,n)+bZ(i,j,k+1,n));
 
-                            Real cf0 = (i == vlo.x and m0(vlo.x-1,j,k) > 0)
+                            Real cf0 = (i == vlo.x && m0(vlo.x-1,j,k) > 0)
                                 ? f0(vlo.x,j,k,n) : 0.0;
-                            Real cf1 = (j == vlo.y and m1(i,vlo.y-1,k) > 0)
+                            Real cf1 = (j == vlo.y && m1(i,vlo.y-1,k) > 0)
                                 ? f1(i,vlo.y,k,n) : 0.0;
-                            Real cf2 = (k == vlo.z and m2(i,j,vlo.z-1) > 0)
+                            Real cf2 = (k == vlo.z && m2(i,j,vlo.z-1) > 0)
                                 ? f2(i,j,vlo.z,n) : 0.0;
-                            Real cf3 = (i == vhi.x and m3(vhi.x+1,j,k) > 0)
+                            Real cf3 = (i == vhi.x && m3(vhi.x+1,j,k) > 0)
                                 ? f3(vhi.x,j,k,n) : 0.0;
-                            Real cf4 = (j == vhi.y and m4(i,vhi.y+1,k) > 0)
+                            Real cf4 = (j == vhi.y && m4(i,vhi.y+1,k) > 0)
                                 ? f4(i,vhi.y,k,n) : 0.0;
-                            Real cf5 = (k == vhi.z and m5(i,j,vhi.z+1) > 0)
+                            Real cf5 = (k == vhi.z && m5(i,j,vhi.z+1) > 0)
                                 ? f5(i,j,vhi.z,n) : 0.0;
 
                             Real g_m_d = gamma
@@ -482,13 +482,13 @@ void abec_gsrb_with_line_solve (
                                       +       bY(i,j+1,k,n)*phi(i,j+1,k,n) );
 
                             // We have already accounted for this external boundary in the coefficient of phi(i,j,k,n)
-                            if (i == vlo.x and m0(vlo.x-1,j,k) > 0)
+                            if (i == vlo.x && m0(vlo.x-1,j,k) > 0)
                                 rho -= dhx*bX(i  ,j,k,n)*phi(i-1,j,k,n);
-                            if (i == vhi.x and m3(vhi.x+1,j,k) > 0)
+                            if (i == vhi.x && m3(vhi.x+1,j,k) > 0)
                                 rho -= dhx*bX(i+1,j,k,n)*phi(i+1,j,k,n);
-                            if (j == vlo.y and m1(i,vlo.y-1,k) > 0)
+                            if (j == vlo.y && m1(i,vlo.y-1,k) > 0)
                                 rho -= dhy*bY(i,j  ,k,n)*phi(i,j-1,k,n);
-                            if (j == vhi.y and m4(i,vhi.y+1,k) > 0)
+                            if (j == vhi.y && m4(i,vhi.y+1,k) > 0)
                                 rho -= dhy*bY(i,j+1,k,n)*phi(i,j+1,k,n);
 
                             a_ls(k-lo.z) = -dhz*bZ(i,j,k,n);
@@ -534,17 +534,17 @@ void abec_gsrb_with_line_solve (
                                 +   dhy*(bY(i,j,k,n)+bY(i,j+1,k,n))
                                 +   dhz*(bZ(i,j,k,n)+bZ(i,j,k+1,n));
 
-                            Real cf0 = (i == vlo.x and m0(vlo.x-1,j,k) > 0)
+                            Real cf0 = (i == vlo.x && m0(vlo.x-1,j,k) > 0)
                                 ? f0(vlo.x,j,k,n) : 0.0;
-                            Real cf1 = (j == vlo.y and m1(i,vlo.y-1,k) > 0)
+                            Real cf1 = (j == vlo.y && m1(i,vlo.y-1,k) > 0)
                                 ? f1(i,vlo.y,k,n) : 0.0;
-                            Real cf2 = (k == vlo.z and m2(i,j,vlo.z-1) > 0)
+                            Real cf2 = (k == vlo.z && m2(i,j,vlo.z-1) > 0)
                                 ? f2(i,j,vlo.z,n) : 0.0;
-                            Real cf3 = (i == vhi.x and m3(vhi.x+1,j,k) > 0)
+                            Real cf3 = (i == vhi.x && m3(vhi.x+1,j,k) > 0)
                                 ? f3(vhi.x,j,k,n) : 0.0;
-                            Real cf4 = (j == vhi.y and m4(i,vhi.y+1,k) > 0)
+                            Real cf4 = (j == vhi.y && m4(i,vhi.y+1,k) > 0)
                                 ? f4(i,vhi.y,k,n) : 0.0;
-                            Real cf5 = (k == vhi.z and m5(i,j,vhi.z+1) > 0)
+                            Real cf5 = (k == vhi.z && m5(i,j,vhi.z+1) > 0)
                                 ? f5(i,j,vhi.z,n) : 0.0;
 
                             Real g_m_d = gamma
@@ -558,13 +558,13 @@ void abec_gsrb_with_line_solve (
                                       +       bZ(i,j,k+1,n)*phi(i,j,k+1,n) );
 
                             // We have already accounted for this external boundary in the coefficient of phi(i,j,k,n)
-                            if (i == vlo.x and m0(vlo.x-1,j,k) > 0)
+                            if (i == vlo.x && m0(vlo.x-1,j,k) > 0)
                                 rho -= dhx*bX(i  ,j,k,n)*phi(i-1,j,k,n);
-                            if (i == vhi.x and m3(vhi.x+1,j,k) > 0)
+                            if (i == vhi.x && m3(vhi.x+1,j,k) > 0)
                                 rho -= dhx*bX(i+1,j,k,n)*phi(i+1,j,k,n);
-                            if (k == vlo.z and m2(i,j,vlo.z-1) > 0)
+                            if (k == vlo.z && m2(i,j,vlo.z-1) > 0)
                                 rho -= dhz*bZ(i,j  ,k,n)*phi(i,j,k-1,n);
-                            if (k == vhi.z and m5(i,j,vhi.z+1) > 0)
+                            if (k == vhi.z && m5(i,j,vhi.z+1) > 0)
                                 rho -= dhz*bZ(i,j,k+1,n)*phi(i,j,k+1,n);
 
                             a_ls(j-lo.y) = -dhy*bY(i,j,k,n);
@@ -609,17 +609,17 @@ void abec_gsrb_with_line_solve (
                                 +   dhy*(bY(i,j,k,n)+bY(i,j+1,k,n))
                                 +   dhz*(bZ(i,j,k,n)+bZ(i,j,k+1,n));
 
-                            Real cf0 = (i == vlo.x and m0(vlo.x-1,j,k) > 0)
+                            Real cf0 = (i == vlo.x && m0(vlo.x-1,j,k) > 0)
                                 ? f0(vlo.x,j,k,n) : 0.0;
-                            Real cf1 = (j == vlo.y and m1(i,vlo.y-1,k) > 0)
+                            Real cf1 = (j == vlo.y && m1(i,vlo.y-1,k) > 0)
                                 ? f1(i,vlo.y,k,n) : 0.0;
-                            Real cf2 = (k == vlo.z and m2(i,j,vlo.z-1) > 0)
+                            Real cf2 = (k == vlo.z && m2(i,j,vlo.z-1) > 0)
                                 ? f2(i,j,vlo.z,n) : 0.0;
-                            Real cf3 = (i == vhi.x and m3(vhi.x+1,j,k) > 0)
+                            Real cf3 = (i == vhi.x && m3(vhi.x+1,j,k) > 0)
                                 ? f3(vhi.x,j,k,n) : 0.0;
-                            Real cf4 = (j == vhi.y and m4(i,vhi.y+1,k) > 0)
+                            Real cf4 = (j == vhi.y && m4(i,vhi.y+1,k) > 0)
                                 ? f4(i,vhi.y,k,n) : 0.0;
-                            Real cf5 = (k == vhi.z and m5(i,j,vhi.z+1) > 0)
+                            Real cf5 = (k == vhi.z && m5(i,j,vhi.z+1) > 0)
                                 ? f5(i,j,vhi.z,n) : 0.0;
 
                             Real g_m_d = gamma
@@ -633,13 +633,13 @@ void abec_gsrb_with_line_solve (
                                       +       bZ(i,j,k+1,n)*phi(i,j,k+1,n) );
 
                             // We have already accounted for this external boundary in the coefficient of phi(i,j,k,n)
-                            if (j == vlo.y and m1(i,vlo.y-1,k) > 0)
+                            if (j == vlo.y && m1(i,vlo.y-1,k) > 0)
                                 rho -= dhy*bY(i,j  ,k,n)*phi(i,j-1,k,n);
-                            if (j == vhi.y and m4(i,vhi.y+1,k) > 0)
+                            if (j == vhi.y && m4(i,vhi.y+1,k) > 0)
                                 rho -= dhy*bY(i,j+1,k,n)*phi(i,j+1,k,n);
-                            if (k == vlo.z and m2(i,j,vlo.z-1) > 0)
+                            if (k == vlo.z && m2(i,j,vlo.z-1) > 0)
                                 rho -= dhz*bZ(i,j  ,k,n)*phi(i,j,k-1,n);
-                            if (k == vhi.z and m5(i,j,vhi.z+1) > 0)
+                            if (k == vhi.z && m5(i,j,vhi.z+1) > 0)
                                 rho -= dhz*bZ(i,j,k+1,n)*phi(i,j,k+1,n);
 
                             a_ls(i-lo.x) = -dhx*bX(i,j,k,n);

--- a/Src/LinearSolvers/MLMG/AMReX_MLABecLaplacian.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLABecLaplacian.cpp
@@ -91,7 +91,7 @@ MLABecLaplacian::define (const Vector<Geometry>& a_geom,
     {
         AMREX_ALWAYS_ASSERT(mg_coarsen_ratio == 2);
         iMultiFab const& fine = *m_overset_mask[amrlev][mglev-1];
-        if (dom.coarsenable(2) and fine.boxArray().coarsenable(2)) {
+        if (dom.coarsenable(2) && fine.boxArray().coarsenable(2)) {
             dom.coarsen(2);
             std::unique_ptr<iMultiFab> crse(new iMultiFab(amrex::coarsen(fine.boxArray(),2),
                                                           fine.DistributionMap(), 1, 1));
@@ -185,7 +185,7 @@ MLABecLaplacian::setBCoeffs (int amrlev,
                              const Array<MultiFab const*,AMREX_SPACEDIM>& beta)
 {
     const int ncomp = getNComp();
-    AMREX_ALWAYS_ASSERT(beta[0]->nComp() == 1 or beta[0]->nComp() == ncomp);
+    AMREX_ALWAYS_ASSERT(beta[0]->nComp() == 1 || beta[0]->nComp() == ncomp);
     if (beta[0]->nComp() == ncomp)
         for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
             for (int icomp = 0; icomp < ncomp; ++icomp) {
@@ -468,7 +468,7 @@ MLABecLaplacian::Fsmooth (int amrlev, int mglev, MultiFab& sol, const MultiFab& 
     BL_PROFILE("MLABecLaplacian::Fsmooth()");
 
     bool regular_coarsening = true;
-    if (amrlev == 0 and mglev > 0) {
+    if (amrlev == 0 && mglev > 0) {
         regular_coarsening = mg_coarsen_ratio_vec[mglev-1] == mg_coarsen_ratio;
     }
 

--- a/Src/LinearSolvers/MLMG/AMReX_MLALap_1D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLALap_1D_K.H
@@ -157,9 +157,9 @@ void mlalap_gsrb (Box const& box, Array4<Real> const& phi,
     AMREX_PRAGMA_SIMD
     for (int i = lo.x; i <= hi.x; ++i) {
         if ((i+redblack)%2 == 0) {
-            Real cf0 = (i == vlo.x and m0(vlo.x-1,0,0) > 0)
+            Real cf0 = (i == vlo.x && m0(vlo.x-1,0,0) > 0)
                 ? f0(vlo.x,0,0) : 0.0;
-            Real cf1 = (i == vhi.x and m1(vhi.x+1,0,0) > 0)
+            Real cf1 = (i == vhi.x && m1(vhi.x+1,0,0) > 0)
                 ? f1(vhi.x,0,0) : 0.0;
             
             Real delta = dhx*(cf0+cf1);
@@ -191,9 +191,9 @@ void mlalap_gsrb_m (Box const& box, Array4<Real> const& phi,
     AMREX_PRAGMA_SIMD
     for (int i = lo.x; i <= hi.x; ++i) {
         if ((i+redblack)%2 == 0) {
-            Real cf0 = (i == vlo.x and m0(vlo.x-1,0,0) > 0)
+            Real cf0 = (i == vlo.x && m0(vlo.x-1,0,0) > 0)
                 ? f0(vlo.x,0,0) : 0.0;
-            Real cf1 = (i == vhi.x and m1(vhi.x+1,0,0) > 0)
+            Real cf1 = (i == vhi.x && m1(vhi.x+1,0,0) > 0)
                 ? f1(vhi.x,0,0) : 0.0;
 
             Real rel = (probxlo + i   *dx) * (probxlo + i   *dx);

--- a/Src/LinearSolvers/MLMG/AMReX_MLALap_2D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLALap_2D_K.H
@@ -256,13 +256,13 @@ void mlalap_gsrb (Box const& box, Array4<Real> const& phi,
         AMREX_PRAGMA_SIMD
         for (int i = lo.x; i <= hi.x; ++i) {
             if ((i+j+redblack)%2 == 0) {
-                Real cf0 = (i == vlo.x and m0(vlo.x-1,j,0) > 0)
+                Real cf0 = (i == vlo.x && m0(vlo.x-1,j,0) > 0)
                     ? f0(vlo.x,j,0) : 0.0;
-                Real cf1 = (j == vlo.y and m1(i,vlo.y-1,0) > 0)
+                Real cf1 = (j == vlo.y && m1(i,vlo.y-1,0) > 0)
                     ? f1(i,vlo.y,0) : 0.0;
-                Real cf2 = (i == vhi.x and m2(vhi.x+1,j,0) > 0)
+                Real cf2 = (i == vhi.x && m2(vhi.x+1,j,0) > 0)
                     ? f2(vhi.x,j,0) : 0.0;
-                Real cf3 = (j == vhi.y and m3(i,vhi.y+1,0) > 0)
+                Real cf3 = (j == vhi.y && m3(i,vhi.y+1,0) > 0)
                     ? f3(i,vhi.y,0) : 0.0;
 
                 Real delta = dhx*(cf0 + cf2) + dhy*(cf1 + cf3);
@@ -299,13 +299,13 @@ void mlalap_gsrb_m (Box const& box, Array4<Real> const& phi,
         AMREX_PRAGMA_SIMD
         for (int i = lo.x; i <= hi.x; ++i) {
             if ((i+j+redblack)%2 == 0) {
-                Real cf0 = (i == vlo.x and m0(vlo.x-1,j,0) > 0)
+                Real cf0 = (i == vlo.x && m0(vlo.x-1,j,0) > 0)
                     ? f0(vlo.x,j,0) : 0.0;
-                Real cf1 = (j == vlo.y and m1(i,vlo.y-1,0) > 0)
+                Real cf1 = (j == vlo.y && m1(i,vlo.y-1,0) > 0)
                     ? f1(i,vlo.y,0) : 0.0;
-                Real cf2 = (i == vhi.x and m2(vhi.x+1,j,0) > 0)
+                Real cf2 = (i == vhi.x && m2(vhi.x+1,j,0) > 0)
                     ? f2(vhi.x,j,0) : 0.0;
-                Real cf3 = (j == vhi.y and m3(i,vhi.y+1,0) > 0)
+                Real cf3 = (j == vhi.y && m3(i,vhi.y+1,0) > 0)
                     ? f3(i,vhi.y,0) : 0.0;
 
                 Real rel = probxlo + i*dx;

--- a/Src/LinearSolvers/MLMG/AMReX_MLALap_3D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLALap_3D_K.H
@@ -192,17 +192,17 @@ void mlalap_gsrb (Box const& box, Array4<Real> const& phi,
             AMREX_PRAGMA_SIMD
             for (int i = lo.x; i <= hi.x; ++i) {
                 if ((i+j+k+redblack)%2 == 0) {
-                    Real cf0 = (i == vlo.x and m0(vlo.x-1,j,k) > 0)
+                    Real cf0 = (i == vlo.x && m0(vlo.x-1,j,k) > 0)
                         ? f0(vlo.x,j,k) : 0.0;
-                    Real cf1 = (j == vlo.y and m1(i,vlo.y-1,k) > 0)
+                    Real cf1 = (j == vlo.y && m1(i,vlo.y-1,k) > 0)
                         ? f1(i,vlo.y,k) : 0.0;
-                    Real cf2 = (k == vlo.z and m2(i,j,vlo.z-1) > 0)
+                    Real cf2 = (k == vlo.z && m2(i,j,vlo.z-1) > 0)
                         ? f2(i,j,vlo.z) : 0.0;
-                    Real cf3 = (i == vhi.x and m3(vhi.x+1,j,k) > 0)
+                    Real cf3 = (i == vhi.x && m3(vhi.x+1,j,k) > 0)
                         ? f3(vhi.x,j,k) : 0.0;
-                    Real cf4 = (j == vhi.y and m4(i,vhi.y+1,k) > 0)
+                    Real cf4 = (j == vhi.y && m4(i,vhi.y+1,k) > 0)
                         ? f4(i,vhi.y,k) : 0.0;
-                    Real cf5 = (k == vhi.z and m5(i,j,vhi.z+1) > 0)
+                    Real cf5 = (k == vhi.z && m5(i,j,vhi.z+1) > 0)
                         ? f5(i,j,vhi.z) : 0.0;
 
                     Real gamma = alpha*a(i,j,k) + dhfac;

--- a/Src/LinearSolvers/MLMG/AMReX_MLCellABecLap.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLCellABecLap.cpp
@@ -68,7 +68,7 @@ MLCellABecLap::applyInhomogNeumannTerm (int amrlev, MultiFab& rhs) const
                               m_lo_inhomog_neumann[n].end(),   1);
         auto ithi = std::find(m_hi_inhomog_neumann[n].begin(),
                               m_hi_inhomog_neumann[n].end(),   1);
-        if (itlo != m_lo_inhomog_neumann[n].end() or
+        if (itlo != m_lo_inhomog_neumann[n].end() ||
             ithi != m_hi_inhomog_neumann[n].end())
         {
             has_inhomog_neumann = true;
@@ -125,17 +125,17 @@ MLCellABecLap::applyInhomogNeumannTerm (int amrlev, MultiFab& rhs) const
             const auto& bvhi = bndry.bndryValues(ohi).array(mfi);
             bool outside_domain_lo = !(domain.contains(blo));
             bool outside_domain_hi = !(domain.contains(bhi));
-            if ((!outside_domain_lo) and (!outside_domain_hi)) continue;
+            if ((!outside_domain_lo) && (!outside_domain_hi)) continue;
             for (int icomp = 0; icomp < ncomp; ++icomp) {
                 const BoundCond bctlo = bdcv[icomp][olo];
                 const BoundCond bcthi = bdcv[icomp][ohi];
                 const Real bcllo = bdlv[icomp][olo];
                 const Real bclhi = bdlv[icomp][ohi];
-                if (m_lo_inhomog_neumann[icomp][idim] and outside_domain_lo)
+                if (m_lo_inhomog_neumann[icomp][idim] && outside_domain_lo)
                 {
                     if (idim == 0) {
                         Real fac = beta*dxi;
-                        if (m_has_metric_term and !has_bcoef) {
+                        if (m_has_metric_term && !has_bcoef) {
 #if (AMREX_SPACEDIM == 1)
                             fac *= problo[0]*problo[0];
 #elif (AMREX_SPACEDIM == 2)
@@ -150,7 +150,7 @@ MLCellABecLap::applyInhomogNeumannTerm (int amrlev, MultiFab& rhs) const
                         });
                     } else if (idim == 1) {
                         Real fac = beta*dyi;
-                        if (m_has_metric_term and !has_bcoef) {
+                        if (m_has_metric_term && !has_bcoef) {
                             AMREX_HOST_DEVICE_FOR_3D(blo, i, j, k,
                             {
                                 mllinop_apply_innu_ylo_m(i,j,k, rhsfab, mlo,
@@ -176,11 +176,11 @@ MLCellABecLap::applyInhomogNeumannTerm (int amrlev, MultiFab& rhs) const
                         });
                     }
                 }
-                if (m_hi_inhomog_neumann[icomp][idim] and outside_domain_hi)
+                if (m_hi_inhomog_neumann[icomp][idim] && outside_domain_hi)
                 {
                     if (idim == 0) {
                         Real fac = beta*dxi;
-                        if (m_has_metric_term and !has_bcoef) {
+                        if (m_has_metric_term && !has_bcoef) {
 #if (AMREX_SPACEDIM == 1)
                             fac *= probhi[0]*probhi[0];
 #elif (AMREX_SPACEDIM == 2)
@@ -195,7 +195,7 @@ MLCellABecLap::applyInhomogNeumannTerm (int amrlev, MultiFab& rhs) const
                         });
                     } else if (idim == 1) {
                         Real fac = beta*dyi;
-                        if (m_has_metric_term and !has_bcoef) {
+                        if (m_has_metric_term && !has_bcoef) {
                             AMREX_HOST_DEVICE_FOR_3D(bhi, i, j, k,
                             {
                                 mllinop_apply_innu_yhi_m(i,j,k, rhsfab, mhi,

--- a/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap.cpp
@@ -142,7 +142,7 @@ MLEBABecLap::setBCoeffs (int amrlev, const Array<MultiFab const*,AMREX_SPACEDIM>
 
     m_beta_loc     = a_beta_loc;
 
-    AMREX_ALWAYS_ASSERT(beta_ncomp == 1 or beta_ncomp == ncomp);
+    AMREX_ALWAYS_ASSERT(beta_ncomp == 1 || beta_ncomp == ncomp);
     if (beta[0]->nComp() == ncomp) {
         for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
             for (int icomp = 0; icomp < ncomp; ++icomp) {
@@ -187,7 +187,7 @@ MLEBABecLap::setEBDirichlet (int amrlev, const MultiFab& phi, const MultiFab& be
 {
     const int ncomp = getNComp();
     const int beta_ncomp = beta.nComp();
-    AMREX_ALWAYS_ASSERT(beta_ncomp == 1 or beta_ncomp == ncomp);
+    AMREX_ALWAYS_ASSERT(beta_ncomp == 1 || beta_ncomp == ncomp);
 
     if (m_eb_phi[amrlev] == nullptr) {
         const int mglev = 0;
@@ -217,7 +217,7 @@ MLEBABecLap::setEBDirichlet (int amrlev, const MultiFab& phi, const MultiFab& be
         Array4<Real> const& phiout = m_eb_phi[amrlev]->array(mfi);
         Array4<Real> const& betaout = m_eb_b_coeffs[amrlev][0]->array(mfi);
         FabType t = (flags) ? (*flags)[mfi].getType(bx) : FabType::regular;
-        if (FabType::regular == t or FabType::covered == t) {
+        if (FabType::regular == t || FabType::covered == t) {
             AMREX_HOST_DEVICE_PARALLEL_FOR_4D ( bx, ncomp, i, j, k, n,
             {
                 phiout(i,j,k,n) = 0.0;
@@ -286,7 +286,7 @@ MLEBABecLap::setEBDirichlet (int amrlev, const MultiFab& phi, Real beta)
         Array4<Real> const& phiout = m_eb_phi[amrlev]->array(mfi);
         Array4<Real> const& betaout = m_eb_b_coeffs[amrlev][0]->array(mfi);
         FabType t = (flags) ? (*flags)[mfi].getType(bx) : FabType::regular;
-        if (FabType::regular == t or FabType::covered == t) {
+        if (FabType::regular == t || FabType::covered == t) {
             AMREX_HOST_DEVICE_PARALLEL_FOR_4D ( bx, ncomp, i, j, k, n,
             {
                 phiout(i,j,k,n) = 0.0;
@@ -345,7 +345,7 @@ MLEBABecLap::setEBDirichlet (int amrlev, const MultiFab& phi, Vector<Real> const
         Array4<Real> const& phiout = m_eb_phi[amrlev]->array(mfi);
         Array4<Real> const& betaout = m_eb_b_coeffs[amrlev][0]->array(mfi);
         FabType t = (flags) ? (*flags)[mfi].getType(bx) : FabType::regular;
-        if (FabType::regular == t or FabType::covered == t) {
+        if (FabType::regular == t || FabType::covered == t) {
             AMREX_HOST_DEVICE_PARALLEL_FOR_4D ( bx, ncomp, i, j, k, n,
             {
                 phiout(i,j,k,n) = 0.0;
@@ -373,7 +373,7 @@ MLEBABecLap::setEBHomogDirichlet (int amrlev, const MultiFab& beta)
 {
     const int ncomp = getNComp();
     const int beta_ncomp = beta.nComp();
-    AMREX_ALWAYS_ASSERT(beta_ncomp == 1 or beta_ncomp == ncomp);
+    AMREX_ALWAYS_ASSERT(beta_ncomp == 1 || beta_ncomp == ncomp);
     if (m_eb_phi[amrlev] == nullptr) {
         const int mglev = 0;
         m_eb_phi[amrlev].reset(new MultiFab(m_grids[amrlev][mglev], m_dmap[amrlev][mglev],
@@ -406,7 +406,7 @@ MLEBABecLap::setEBHomogDirichlet (int amrlev, const MultiFab& beta)
         {
             phifab(i,j,k,n) = 0.0;
         });
-        if (FabType::regular == t or FabType::covered == t) {
+        if (FabType::regular == t || FabType::covered == t) {
             AMREX_HOST_DEVICE_PARALLEL_FOR_4D ( bx, ncomp, i, j, k, n,
             {
                 betaout(i,j,k,n) = 0.0;
@@ -473,7 +473,7 @@ MLEBABecLap::setEBHomogDirichlet (int amrlev, Real beta)
         {
             phifab(i,j,k,n) = 0.0;
         });
-        if (FabType::regular == t or FabType::covered == t) {
+        if (FabType::regular == t || FabType::covered == t) {
             AMREX_HOST_DEVICE_PARALLEL_FOR_4D ( bx, ncomp, i, j, k, n,
             {
                 betaout(i,j,k,n) = 0.0;
@@ -532,7 +532,7 @@ MLEBABecLap::setEBHomogDirichlet (int amrlev, Vector<Real> const& hv_beta)
         {
             phifab(i,j,k,n) = 0.0;
         });
-        if (FabType::regular == t or FabType::covered == t) {
+        if (FabType::regular == t || FabType::covered == t) {
             AMREX_HOST_DEVICE_PARALLEL_FOR_4D ( bx, ncomp, i, j, k, n,
             {
                 betaout(i,j,k,n) = 0.0;
@@ -1714,7 +1714,7 @@ MLEBABecLap::getEBFluxes (const Vector<MultiFab*>& a_flux, const Vector<MultiFab
 
                 auto fabtyp = (flags) ? (*flags)[mfi].getType(bx) : FabType::regular;
 
-                if (fabtyp == FabType::covered or fabtyp == FabType::regular) {
+                if (fabtyp == FabType::covered || fabtyp == FabType::regular) {
                     AMREX_HOST_DEVICE_PARALLEL_FOR_4D( bx, ncomp, i, j, k, n,
                     {
                         febfab(i,j,k,n) = 0.0;

--- a/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap_2D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap_2D_K.H
@@ -47,45 +47,45 @@ void mlebabeclap_adotx (Box const& box, Array4<Real> const& y,
             Real apyp = apy(i,j+1,k);
 
             Real fxm = bX(i,j,k,n) * (x(i,j,k,n)-x(i-1,j,k,n));
-            if (apxm != 0.0 and apxm != 1.0) {
+            if (apxm != 0.0 && apxm != 1.0) {
                 int jj = j + static_cast<int>(amrex::Math::copysign(1.0,fcx(i,j,k)));
                 Real fracy = (ccm(i-1,jj,k) || ccm(i,jj,k)) ? amrex::Math::abs(fcx(i,j,k)) : 0.0;
-                if (beta_on_center and phi_on_center) 
+                if (beta_on_center && phi_on_center) 
                    fxm = (1.0-fracy)*fxm + fracy*bX(i,jj,k,n)*(x(i,jj,k,n)-x(i-1,jj,k,n));
-                else if (beta_on_centroid and phi_on_center) 
+                else if (beta_on_centroid && phi_on_center) 
                    fxm = bX(i,j,k,n) * ( (1.0-fracy)*(x(i, j,k,n)-x(i-1, j,k,n))
                                            + fracy  *(x(i,jj,k,n)-x(i-1,jj,k,n)) );
             }
 
             Real fxp = bX(i+1,j,k,n)*(x(i+1,j,k,n)-x(i,j,k,n));
-            if (apxp != 0.0 and apxp != 1.0) {
+            if (apxp != 0.0 && apxp != 1.0) {
                 int jj = j + static_cast<int>(amrex::Math::copysign(1.0,fcx(i+1,j,k)));
                 Real fracy = (ccm(i,jj,k) || ccm(i+1,jj,k)) ? amrex::Math::abs(fcx(i+1,j,k)) : 0.0;
-                if (beta_on_center and phi_on_center) 
+                if (beta_on_center && phi_on_center) 
                     fxp = (1.0-fracy)*fxp + fracy*bX(i+1,jj,k,n)*(x(i+1,jj,k,n)-x(i,jj,k,n));
-                else if (beta_on_centroid and phi_on_center) 
+                else if (beta_on_centroid && phi_on_center) 
                     fxp = bX(i+1,j,k,n) * ( (1.0-fracy)*(x(i+1, j,k,n)-x(i, j,k,n))
                                                + fracy *(x(i+1,jj,k,n)-x(i,jj,k,n)) );
             }
 
             Real fym = bY(i,j,k,n)*(x(i,j,k,n)-x(i,j-1,k,n));
-            if (apym != 0.0 and apym != 1.0) {
+            if (apym != 0.0 && apym != 1.0) {
                 int ii = i + static_cast<int>(amrex::Math::copysign(1.0,fcy(i,j,k)));
                 Real fracx = (ccm(ii,j-1,k) || ccm(ii,j,k)) ? amrex::Math::abs(fcy(i,j,k)) : 0.0;
-                if (beta_on_center and phi_on_center) 
+                if (beta_on_center && phi_on_center) 
                     fym = (1.0-fracx)*fym + fracx*bY(ii,j,k,n)*(x(ii,j,k,n)-x(ii,j-1,k,n));
-                else if (beta_on_centroid and phi_on_center) 
+                else if (beta_on_centroid && phi_on_center) 
                     fym = bY(i,j,k,n) * ( (1.0-fracx)*(x( i,j,k,n)-x( i,j-1,k,n))
                                              + fracx *(x(ii,j,k,n)-x(ii,j-1,k,n)) );
             }
 
             Real fyp = bY(i,j+1,k,n)*(x(i,j+1,k,n)-x(i,j,k,n));
-            if (apyp != 0.0 and apyp != 1.0) {
+            if (apyp != 0.0 && apyp != 1.0) {
                 int ii = i + static_cast<int>(amrex::Math::copysign(1.0,fcy(i,j+1,k)));
                 Real fracx = (ccm(ii,j,k) || ccm(ii,j+1,k)) ? amrex::Math::abs(fcy(i,j+1,k)) : 0.0;
-                if (beta_on_center and phi_on_center) 
+                if (beta_on_center && phi_on_center) 
                     fyp = (1.0-fracx)*fyp + fracx*bY(ii,j+1,k,n)*(x(ii,j+1,k,n)-x(ii,j,k,n));
-                else if (beta_on_centroid and phi_on_center) 
+                else if (beta_on_centroid && phi_on_center) 
                     fyp = bY(i,j+1,k,n) * ( (1.0-fracx)*(x( i,j+1,k,n)-x( i,j,k,n))
                                                + fracx *(x(ii,j+1,k,n)-x(ii,j,k,n)) );
             }
@@ -241,13 +241,13 @@ void mlebabeclap_gsrb (Box const& box,
             }
             else
             {
-                Real cf0 = (i == vlo.x and m0(vlo.x-1,j,k) > 0)
+                Real cf0 = (i == vlo.x && m0(vlo.x-1,j,k) > 0)
                     ? f0(vlo.x,j,k,n) : 0.0;
-                Real cf1 = (j == vlo.y and m1(i,vlo.y-1,k) > 0)
+                Real cf1 = (j == vlo.y && m1(i,vlo.y-1,k) > 0)
                     ? f1(i,vlo.y,k,n) : 0.0;
-                Real cf2 = (i == vhi.x and m2(vhi.x+1,j,k) > 0)
+                Real cf2 = (i == vhi.x && m2(vhi.x+1,j,k) > 0)
                     ? f2(vhi.x,j,k,n) : 0.0;
-                Real cf3 = (j == vhi.y and m3(i,vhi.y+1,k) > 0)
+                Real cf3 = (j == vhi.y && m3(i,vhi.y+1,k) > 0)
                     ? f3(i,vhi.y,k,n) : 0.0;
 
                 if (flag(i,j,k).isRegular())
@@ -278,16 +278,16 @@ void mlebabeclap_gsrb (Box const& box,
                     Real fxm = -bX(i,j,k,n)*phi(i-1,j,k,n);
                     Real oxm = -bX(i,j,k,n)*cf0;
                     Real sxm =  bX(i,j,k,n);
-                    if (apxm != 0.0 and apxm != 1.0) {
+                    if (apxm != 0.0 && apxm != 1.0) {
                         int jj = j + static_cast<int>(amrex::Math::copysign(1.0,fcx(i,j,k)));
                         Real fracy = (ccm(i-1,jj,k) || ccm(i,jj,k))
                             ? amrex::Math::abs(fcx(i,j,k)) : 0.0;
-                        if (!beta_on_centroid and !phi_on_centroid)
+                        if (!beta_on_centroid && !phi_on_centroid)
                         {
                             fxm = (1.0-fracy)*fxm + 
                                        fracy *bX(i,jj,k,n)*(phi(i,jj,k,n)-phi(i-1,jj,k,n));
                         } 
-                        else if (beta_on_centroid and !phi_on_centroid)
+                        else if (beta_on_centroid && !phi_on_centroid)
                         {
                             fxm = (1.0-fracy)*(             -phi(i-1,j,k,n)) +
                                        fracy *(phi(i,jj,k,n)-phi(i-1,jj,k,n));
@@ -300,16 +300,16 @@ void mlebabeclap_gsrb (Box const& box,
                     Real fxp =  bX(i+1,j,k,n)*phi(i+1,j,k,n);
                     Real oxp =  bX(i+1,j,k,n)*cf2;
                     Real sxp = -bX(i+1,j,k,n);
-                    if (apxp != 0.0 and apxp != 1.0) {
+                    if (apxp != 0.0 && apxp != 1.0) {
                         int jj = j + static_cast<int>(amrex::Math::copysign(1.0,fcx(i+1,j,k)));
                         Real fracy = (ccm(i,jj,k) || ccm(i+1,jj,k))
                             ? amrex::Math::abs(fcx(i+1,j,k)) : 0.0;
-                        if (!beta_on_centroid and !phi_on_centroid)
+                        if (!beta_on_centroid && !phi_on_centroid)
                         {
                             fxp = (1.0-fracy)*fxp + 
                                        fracy *bX(i+1,jj,k,n)*(phi(i+1,jj,k,n)-phi(i,jj,k,n));
                         } 
-                        else if (beta_on_centroid and !phi_on_centroid)
+                        else if (beta_on_centroid && !phi_on_centroid)
                         {
                             fxp = (1.0-fracy)*(phi(i+1,j,k,n)               ) +
                                        fracy *(phi(i+1,jj,k,n)-phi(i,jj,k,n));
@@ -322,16 +322,16 @@ void mlebabeclap_gsrb (Box const& box,
                     Real fym = -bY(i,j,k,n)*phi(i,j-1,k,n);
                     Real oym = -bY(i,j,k,n)*cf1;
                     Real sym =  bY(i,j,k,n);
-                    if (apym != 0.0 and apym != 1.0) {
+                    if (apym != 0.0 && apym != 1.0) {
                         int ii = i + static_cast<int>(amrex::Math::copysign(1.0,fcy(i,j,k)));
                         Real fracx = (ccm(ii,j-1,k) || ccm(ii,j,k))
                             ? amrex::Math::abs(fcy(i,j,k)) : 0.0;
-                        if (!beta_on_centroid and !phi_on_centroid)
+                        if (!beta_on_centroid && !phi_on_centroid)
                         {
                             fym = (1.0-fracx)*fym + 
                                        fracx *bY(ii,j,k,n)*(phi(ii,j,k,n)-phi(ii,j-1,k,n));
                         } 
-                        else if (beta_on_centroid and !phi_on_centroid)
+                        else if (beta_on_centroid && !phi_on_centroid)
                         {
                             fym = (1.0-fracx)*(             -phi( i,j-1,k,n)) +
                                        fracx *(phi(ii,j,k,n)-phi(ii,j-1,k,n));
@@ -345,16 +345,16 @@ void mlebabeclap_gsrb (Box const& box,
                     Real fyp =  bY(i,j+1,k,n)*phi(i,j+1,k,n);
                     Real oyp =  bY(i,j+1,k,n)*cf3;
                     Real syp = -bY(i,j+1,k,n);
-                    if (apyp != 0.0 and apyp != 1.0) {
+                    if (apyp != 0.0 && apyp != 1.0) {
                         int ii = i + static_cast<int>(amrex::Math::copysign(1.0,fcy(i,j+1,k)));
                         Real fracx = (ccm(ii,j,k) || ccm(ii,j+1,k))
                             ? amrex::Math::abs(fcy(i,j+1,k)) : 0.0;
-                        if (!beta_on_centroid and !phi_on_centroid)
+                        if (!beta_on_centroid && !phi_on_centroid)
                         {
                             fyp = (1.0-fracx)*fyp + 
                                        fracx*bY(ii,j+1,k,n)*(phi(ii,j+1,k,n)-phi(ii,j,k,n));
                         } 
-                        else if (beta_on_centroid and !phi_on_centroid)
+                        else if (beta_on_centroid && !phi_on_centroid)
                         {
                             fyp = (1.0-fracx)*(phi(i,j+1,k,n)               )+
                                        fracx *(phi(ii,j+1,k,n)-phi(ii,j,k,n));
@@ -440,7 +440,7 @@ void mlebabeclap_flux_x (Box const& box, Array4<Real> const& fx, Array4<Real con
     int hif = xbox.bigEnd(0);
     amrex::LoopConcurrent(box, ncomp, [=] (int i, int j, int k, int n) noexcept
     {
-        if (!face_only or lof == i or hif == i) {
+        if (!face_only || lof == i || hif == i) {
             if (apx(i,j,k) == 0.0) {
                 fx(i,j,k,n) = 0.0;
             } else if (apx(i,j,k) == 1.0) {
@@ -449,10 +449,10 @@ void mlebabeclap_flux_x (Box const& box, Array4<Real> const& fx, Array4<Real con
                 Real fxm = bX(i,j,k,n)*(sol(i,j,k,n)-sol(i-1,j,k,n));
                 int jj = j + static_cast<int>(amrex::Math::copysign(1.0,fcx(i,j,k)));
                 Real fracy = (ccm(i-1,jj,k) || ccm(i,jj,k)) ? amrex::Math::abs(fcx(i,j,k)) : 0.0;
-                if (!beta_on_centroid and !phi_on_centroid)
+                if (!beta_on_centroid && !phi_on_centroid)
                 {
                     fxm = (1.0-fracy)*fxm + fracy*bX(i,jj,k,n)*(sol(i,jj,k,n)-sol(i-1,jj,k,n));
-                } else if (beta_on_centroid and !phi_on_centroid)
+                } else if (beta_on_centroid && !phi_on_centroid)
                     fxm = bX(i,j,k,n) * ( (1.0-fracy)*(sol(i, j,k,n)-sol(i-1, j,k,n)) +
                                                fracy *(sol(i,jj,k,n)-sol(i-1,jj,k,n)) );
                 fx(i,j,k,n) = -fxm*dhx;
@@ -472,7 +472,7 @@ void mlebabeclap_flux_y (Box const& box, Array4<Real> const& fy, Array4<Real con
     int hif = ybox.bigEnd(1);
     amrex::LoopConcurrent(box, ncomp, [=] (int i, int j, int k, int n) noexcept
     {
-        if (!face_only or lof == j or hif == j) {
+        if (!face_only || lof == j || hif == j) {
             if (apy(i,j,k) == 0.0) {
                 fy(i,j,k,n) = 0.0;
             } else if (apy(i,j,k) == 1.0) {
@@ -481,10 +481,10 @@ void mlebabeclap_flux_y (Box const& box, Array4<Real> const& fy, Array4<Real con
                 Real fym = bY(i,j,k,n)*(sol(i,j,k,n)-sol(i,j-1,k,n));
                 int ii = i + static_cast<int>(amrex::Math::copysign(1.0,fcy(i,j,k)));
                 Real fracx = (ccm(ii,j-1,k) || ccm(ii,j,k)) ? amrex::Math::abs(fcy(i,j,k)) : 0.0;
-                if (!beta_on_centroid and !phi_on_centroid)
+                if (!beta_on_centroid && !phi_on_centroid)
                 {
                     fym = (1.0-fracx)*fym + fracx*bY(ii,j,k,n)*(sol(ii,j,k,n)-sol(ii,j-1,k,n));
-                } else if (beta_on_centroid and !phi_on_centroid)
+                } else if (beta_on_centroid && !phi_on_centroid)
                     fym = bY(i,j,k,n) * ( (1.0-fracx)*(sol( i,j,k,n)-sol( i,j-1,k,n)) +
                                                fracx *(sol(ii,j,k,n)-sol(ii,j-1,k,n)) );
                 fy(i,j,k,n) = -fym*dhy;
@@ -502,7 +502,7 @@ void mlebabeclap_flux_x_0 (Box const& box, Array4<Real> const& fx, Array4<Real c
     int hif = xbox.bigEnd(0);
     amrex::LoopConcurrent(box, ncomp, [=] (int i, int j, int k, int n) noexcept
     {
-        if (!face_only or lof == i or hif == i) {
+        if (!face_only || lof == i || hif == i) {
             if (apx(i,j,k) == 0.0) {
                 fx(i,j,k,n) = 0.0;
             } else {
@@ -521,7 +521,7 @@ void mlebabeclap_flux_y_0 (Box const& box, Array4<Real> const& fy, Array4<Real c
     int hif = ybox.bigEnd(1);
     amrex::LoopConcurrent(box, ncomp, [=] (int i, int j, int k, int n) noexcept
     {
-        if (!face_only or lof == j or hif == j) {
+        if (!face_only || lof == j || hif == j) {
             if (apy(i,j,k) == 0.0) {
                 fy(i,j,k,n) = 0.0;
             } else {
@@ -634,7 +634,7 @@ void mlebabeclap_normalize (Box const& box, Array4<Real> const& phi,
             Real apyp = apy(i,j+1,k);
 
             Real sxm =  bX(i,j,k,n);
-            if (apxm != 0.0 and apxm != 1.0 && !beta_on_centroid) {
+            if (apxm != 0.0 && apxm != 1.0 && !beta_on_centroid) {
                 int jj = j + static_cast<int>(amrex::Math::copysign(1.0,fcx(i,j,k)));
                 Real fracy = (ccm(i-1,jj,k) || ccm(i,jj,k))
                     ? amrex::Math::abs(fcx(i,j,k)) : 0.0;
@@ -642,7 +642,7 @@ void mlebabeclap_normalize (Box const& box, Array4<Real> const& phi,
             }
 
             Real sxp = -bX(i+1,j,k,n);
-            if (apxp != 0.0 and apxp != 1.0 && !beta_on_centroid) {
+            if (apxp != 0.0 && apxp != 1.0 && !beta_on_centroid) {
                 int jj = j + static_cast<int>(amrex::Math::copysign(1.0,fcx(i+1,j,k)));
                 Real fracy = (ccm(i,jj,k) || ccm(i+1,jj,k))
                     ? amrex::Math::abs(fcx(i+1,j,k)) : 0.0;
@@ -650,7 +650,7 @@ void mlebabeclap_normalize (Box const& box, Array4<Real> const& phi,
             }
 
             Real sym =  bY(i,j,k,n);
-            if (apym != 0.0 and apym != 1.0 && !beta_on_centroid) {
+            if (apym != 0.0 && apym != 1.0 && !beta_on_centroid) {
                 int ii = i + static_cast<int>(amrex::Math::copysign(1.0,fcy(i,j,k)));
                 Real fracx = (ccm(ii,j-1,k) || ccm(ii,j,k))
                     ? amrex::Math::abs(fcy(i,j,k)) : 0.0;
@@ -658,7 +658,7 @@ void mlebabeclap_normalize (Box const& box, Array4<Real> const& phi,
             }
 
             Real syp = -bY(i,j+1,k,n);
-            if (apyp != 0.0 and apyp != 1.0 && !beta_on_centroid) {
+            if (apyp != 0.0 && apyp != 1.0 && !beta_on_centroid) {
                 int ii = i + static_cast<int>(amrex::Math::copysign(1.0,fcy(i,j+1,k)));
                 Real fracx = (ccm(ii,j,k) || ccm(ii,j+1,k))
                     ? amrex::Math::abs(fcy(i,j+1,k)) : 0.0;

--- a/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap_3D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap_3D_K.H
@@ -54,19 +54,19 @@ void mlebabeclap_adotx (Box const& box, Array4<Real> const& y,
             Real apzp = apz(i,j,k+1);
 
             Real fxm = bX(i,j,k,n)*(x(i,j,k,n) - x(i-1,j,k,n));
-            if (apxm != 0.0 and apxm != 1.0) {
+            if (apxm != 0.0 && apxm != 1.0) {
                 int jj = j + static_cast<int>(amrex::Math::copysign(1.0, fcx(i,j,k,0)));
                 int kk = k + static_cast<int>(amrex::Math::copysign(1.0, fcx(i,j,k,1)));
                 Real fracy = (ccm(i-1,jj,k) || ccm(i,jj,k)) ? amrex::Math::abs(fcx(i,j,k,0)) : 0.0;
                 Real fracz = (ccm(i-1,j,kk) || ccm(i,j,kk)) ? amrex::Math::abs(fcx(i,j,k,1)) : 0.0;
-                if (beta_on_center and phi_on_center)
+                if (beta_on_center && phi_on_center)
                 {
                     fxm = (1.0-fracy)*(1.0-fracz)*fxm +
                         fracy*(1.0-fracz)*bX(i,jj,k ,n)*(x(i,jj,k ,n)-x(i-1,jj,k ,n)) +
                         fracz*(1.0-fracy)*bX(i,j ,kk,n)*(x(i,j ,kk,n)-x(i-1,j ,kk,n)) +
                         fracy*     fracz *bX(i,jj,kk,n)*(x(i,jj,kk,n)-x(i-1,jj,kk,n));
                 }
-                else if (beta_on_centroid and phi_on_center)
+                else if (beta_on_centroid && phi_on_center)
                 {
                     fxm = (1.0-fracy)*(1.0-fracz)*(x(i, j, k,n)-x(i-1, j, k,n)) +
                                fracy *(1.0-fracz)*(x(i,jj, k,n)-x(i-1,jj, k,n)) +
@@ -77,19 +77,19 @@ void mlebabeclap_adotx (Box const& box, Array4<Real> const& y,
             }
 
             Real fxp = bX(i+1,j,k,n)*(x(i+1,j,k,n) - x(i,j,k,n));
-            if (apxp != 0.0 and apxp != 1.0) {
+            if (apxp != 0.0 && apxp != 1.0) {
                 int jj = j + static_cast<int>(amrex::Math::copysign(1.0,fcx(i+1,j,k,0)));
                 int kk = k + static_cast<int>(amrex::Math::copysign(1.0,fcx(i+1,j,k,1)));
                 Real fracy = (ccm(i,jj,k) || ccm(i+1,jj,k)) ? amrex::Math::abs(fcx(i+1,j,k,0)) : 0.0;
                 Real fracz = (ccm(i,j,kk) || ccm(i+1,j,kk)) ? amrex::Math::abs(fcx(i+1,j,k,1)) : 0.0;
-                if (beta_on_center and phi_on_center)
+                if (beta_on_center && phi_on_center)
                 {
                     fxp = (1.0-fracy)*(1.0-fracz)*fxp +
                         fracy*(1.0-fracz)*bX(i+1,jj,k ,n)*(x(i+1,jj,k ,n)-x(i,jj,k ,n)) +
                         fracz*(1.0-fracy)*bX(i+1,j ,kk,n)*(x(i+1,j ,kk,n)-x(i,j ,kk,n)) +
                         fracy*     fracz *bX(i+1,jj,kk,n)*(x(i+1,jj,kk,n)-x(i,jj,kk,n));
                 }
-                else if (beta_on_centroid and phi_on_center)
+                else if (beta_on_centroid && phi_on_center)
                 {
                     fxp = (1.0-fracy)*(1.0-fracz)*(x(i+1, j, k,n)-x(i, j, k,n)) +
                                fracy *(1.0-fracz)*(x(i+1,jj, k,n)-x(i,jj, k,n)) +
@@ -101,19 +101,19 @@ void mlebabeclap_adotx (Box const& box, Array4<Real> const& y,
             }
 
             Real fym = bY(i,j,k,n)*(x(i,j,k,n) - x(i,j-1,k,n));
-            if (apym != 0.0 and apym != 1.0) {
+            if (apym != 0.0 && apym != 1.0) {
                 int ii = i + static_cast<int>(amrex::Math::copysign(1.0,fcy(i,j,k,0)));
                 int kk = k + static_cast<int>(amrex::Math::copysign(1.0,fcy(i,j,k,1)));
                 Real fracx = (ccm(ii,j-1,k) || ccm(ii,j,k)) ? amrex::Math::abs(fcy(i,j,k,0)) : 0.0;
                 Real fracz = (ccm(i,j-1,kk) || ccm(i,j,kk)) ? amrex::Math::abs(fcy(i,j,k,1)) : 0.0;
-                if (beta_on_center and phi_on_center)
+                if (beta_on_center && phi_on_center)
                 {
                     fym = (1.0-fracx)*(1.0-fracz)*fym +
                         fracx*(1.0-fracz)*bY(ii,j,k ,n)*(x(ii,j,k ,n)-x(ii,j-1,k ,n)) +
                         fracz*(1.0-fracx)*bY(i ,j,kk,n)*(x(i ,j,kk,n)-x(i ,j-1,kk,n)) +
                         fracx*     fracz *bY(ii,j,kk,n)*(x(ii,j,kk,n)-x(ii,j-1,kk,n));
                 }
-                else if (beta_on_centroid and phi_on_center)
+                else if (beta_on_centroid && phi_on_center)
                 {
                     fym = (1.0-fracx)*(1.0-fracz)*(x( i,j, k,n)-x( i,j-1, k,n)) +
                                fracx *(1.0-fracz)*(x(ii,j, k,n)-x(ii,j-1, k,n)) +
@@ -125,19 +125,19 @@ void mlebabeclap_adotx (Box const& box, Array4<Real> const& y,
             }
 
             Real fyp = bY(i,j+1,k,n)*(x(i,j+1,k,n) - x(i,j,k,n));
-            if (apyp != 0.0 and apyp != 1.0) {
+            if (apyp != 0.0 && apyp != 1.0) {
                 int ii = i + static_cast<int>(amrex::Math::copysign(1.0,fcy(i,j+1,k,0)));
                 int kk = k + static_cast<int>(amrex::Math::copysign(1.0,fcy(i,j+1,k,1)));
                 Real fracx = (ccm(ii,j,k) || ccm(ii,j+1,k)) ? amrex::Math::abs(fcy(i,j+1,k,0)) : 0.0;
                 Real fracz = (ccm(i,j,kk) || ccm(i,j+1,kk)) ? amrex::Math::abs(fcy(i,j+1,k,1)) : 0.0;
-                if (beta_on_center and phi_on_center)
+                if (beta_on_center && phi_on_center)
                 {
                     fyp = (1.0-fracx)*(1.0-fracz)*fyp +
                         fracx*(1.0-fracz)*bY(ii,j+1,k ,n)*(x(ii,j+1,k ,n)-x(ii,j,k ,n)) +
                         fracz*(1.0-fracx)*bY(i ,j+1,kk,n)*(x(i ,j+1,kk,n)-x(i ,j,kk,n)) +
                         fracx*     fracz *bY(ii,j+1,kk,n)*(x(ii,j+1,kk,n)-x(ii,j,kk,n));
                 }
-                else if (beta_on_centroid and phi_on_center)
+                else if (beta_on_centroid && phi_on_center)
                 {
                     fyp = (1.0-fracx)*(1.0-fracz)*(x( i,j+1, k,n)-x( i,j, k,n)) +
                                fracx *(1.0-fracz)*(x(ii,j+1, k,n)-x(ii,j, k,n)) +
@@ -149,19 +149,19 @@ void mlebabeclap_adotx (Box const& box, Array4<Real> const& y,
             }
 
             Real fzm = bZ(i,j,k,n)*(x(i,j,k,n) - x(i,j,k-1,n));
-            if (apzm != 0.0 and apzm != 1.0) {
+            if (apzm != 0.0 && apzm != 1.0) {
                 int ii = i + static_cast<int>(amrex::Math::copysign(1.0,fcz(i,j,k,0)));
                 int jj = j + static_cast<int>(amrex::Math::copysign(1.0,fcz(i,j,k,1)));
                 Real fracx = (ccm(ii,j,k-1) || ccm(ii,j,k)) ? amrex::Math::abs(fcz(i,j,k,0)) : 0.0;
                 Real fracy = (ccm(i,jj,k-1) || ccm(i,jj,k)) ? amrex::Math::abs(fcz(i,j,k,1)) : 0.0;
-                if (beta_on_center and phi_on_center)
+                if (beta_on_center && phi_on_center)
                 {
                     fzm = (1.0-fracx)*(1.0-fracy)*fzm +
                         fracx*(1.0-fracy)*bZ(ii,j ,k,n)*(x(ii,j ,k,n)-x(ii,j ,k-1,n)) +
                         fracy*(1.0-fracx)*bZ(i ,jj,k,n)*(x(i ,jj,k,n)-x(i ,jj,k-1,n)) +
                         fracx*     fracy *bZ(ii,jj,k,n)*(x(ii,jj,k,n)-x(ii,jj,k-1,n));
                 }
-                else if (beta_on_centroid and phi_on_center)
+                else if (beta_on_centroid && phi_on_center)
                 {
                     fzm = (1.0-fracx)*(1.0-fracy)*(x( i, j,k,n)-x( i, j,k-1,n)) +
                                fracx *(1.0-fracy)*(x(ii, j,k,n)-x(ii, j,k-1,n)) +
@@ -173,19 +173,19 @@ void mlebabeclap_adotx (Box const& box, Array4<Real> const& y,
             }
 
             Real fzp = bZ(i,j,k+1,n)*(x(i,j,k+1,n) - x(i,j,k,n));
-            if (apzp != 0.0 and apzp != 1.0) {
+            if (apzp != 0.0 && apzp != 1.0) {
                 int ii = i + static_cast<int>(amrex::Math::copysign(1.0,fcz(i,j,k+1,0)));
                 int jj = j + static_cast<int>(amrex::Math::copysign(1.0,fcz(i,j,k+1,1)));
                 Real fracx = (ccm(ii,j,k) || ccm(ii,j,k+1)) ? amrex::Math::abs(fcz(i,j,k+1,0)) : 0.0;
                 Real fracy = (ccm(i,jj,k) || ccm(i,jj,k+1)) ? amrex::Math::abs(fcz(i,j,k+1,1)) : 0.0;
-                if (beta_on_center and phi_on_center)
+                if (beta_on_center && phi_on_center)
                 {
                     fzp = (1.0-fracx)*(1.0-fracy)*fzp +
                         fracx*(1.0-fracy)*bZ(ii,j ,k+1,n)*(x(ii,j ,k+1,n)-x(ii,j ,k,n)) +
                         fracy*(1.0-fracx)*bZ(i ,jj,k+1,n)*(x(i ,jj,k+1,n)-x(i ,jj,k,n)) +
                         fracx*     fracy *bZ(ii,jj,k+1,n)*(x(ii,jj,k+1,n)-x(ii,jj,k,n));
                 }
-                else if (beta_on_centroid and phi_on_center)
+                else if (beta_on_centroid && phi_on_center)
                 {
                     fzp = (1.0-fracx)*(1.0-fracy)*(x( i, j,k+1,n)-x( i, j,k,n)) +
                                fracx *(1.0-fracy)*(x(ii, j,k+1,n)-x(ii, j,k,n)) +
@@ -382,17 +382,17 @@ void mlebabeclap_gsrb (Box const& box,
             }
             else
             {
-                Real cf0 = (i == vlo.x and m0(vlo.x-1,j,k) > 0)
+                Real cf0 = (i == vlo.x && m0(vlo.x-1,j,k) > 0)
                     ? f0(vlo.x,j,k,n) : 0.0;
-                Real cf1 = (j == vlo.y and m1(i,vlo.y-1,k) > 0) 
+                Real cf1 = (j == vlo.y && m1(i,vlo.y-1,k) > 0) 
                     ? f1(i,vlo.y,k,n) : 0.0;
-                Real cf2 = (k == vlo.z and m2(i,j,vlo.z-1) > 0)
+                Real cf2 = (k == vlo.z && m2(i,j,vlo.z-1) > 0)
                     ? f2(i,j,vlo.z,n) : 0.0;
-                Real cf3 = (i == vhi.x and m3(vhi.x+1,j,k) > 0)
+                Real cf3 = (i == vhi.x && m3(vhi.x+1,j,k) > 0)
                     ? f3(vhi.x,j,k,n) : 0.0;
-                Real cf4 = (j == vhi.y and m4(i,vhi.y+1,k) > 0)
+                Real cf4 = (j == vhi.y && m4(i,vhi.y+1,k) > 0)
                     ? f4(i,vhi.y,k,n) : 0.0;
-                Real cf5 = (k == vhi.z and m5(i,j,vhi.z+1) > 0)
+                Real cf5 = (k == vhi.z && m5(i,j,vhi.z+1) > 0)
                     ? f5(i,j,vhi.z,n) : 0.0;
 
                 if (flag(i,j,k).isRegular())
@@ -429,21 +429,21 @@ void mlebabeclap_gsrb (Box const& box,
                     Real fxm = -bX(i,j,k,n)*phi(i-1,j,k,n);
                     Real oxm = -bX(i,j,k,n)*cf0;
                     Real sxm =  bX(i,j,k,n);
-                    if (apxm != 0.0 and apxm != 1.0) {
+                    if (apxm != 0.0 && apxm != 1.0) {
                         int jj = j + static_cast<int>(amrex::Math::copysign(1.0, fcx(i,j,k,0)));
                         int kk = k + static_cast<int>(amrex::Math::copysign(1.0, fcx(i,j,k,1)));
                         Real fracy = (ccm(i-1,jj,k) || ccm(i,jj,k))
                             ? amrex::Math::abs(fcx(i,j,k,0)) : 0.0;
                         Real fracz = (ccm(i-1,j,kk) || ccm(i,j,kk))
                             ? amrex::Math::abs(fcx(i,j,k,1)) : 0.0;
-                        if (!beta_on_centroid and !phi_on_centroid)
+                        if (!beta_on_centroid && !phi_on_centroid)
                         {
                             fxm = (1.0-fracy)*(1.0-fracz)*fxm
                                  +     fracy *(1.0-fracz)*bX(i,jj,k ,n)*(phi(i,jj,k ,n)-phi(i-1,jj,k ,n))
                                  +(1.0-fracy)*     fracz *bX(i,j ,kk,n)*(phi(i,j ,kk,n)-phi(i-1,j ,kk,n))
                                  +     fracy *     fracz *bX(i,jj,kk,n)*(phi(i,jj,kk,n)-phi(i-1,jj,kk,n));
                         }
-                        else if (beta_on_centroid and !phi_on_centroid)
+                        else if (beta_on_centroid && !phi_on_centroid)
                         {
                             fxm = (1.0-fracy)*(1.0-fracz)*(              -phi(i-1, j, k,n)) 
                                  +     fracy *(1.0-fracz)*(phi(i,jj,k ,n)-phi(i-1,jj, k,n))
@@ -459,21 +459,21 @@ void mlebabeclap_gsrb (Box const& box,
                     Real fxp =  bX(i+1,j,k,n)*phi(i+1,j,k,n);
                     Real oxp =  bX(i+1,j,k,n)*cf3;
                     Real sxp = -bX(i+1,j,k,n);
-                    if (apxp != 0.0 and apxp != 1.0) {
+                    if (apxp != 0.0 && apxp != 1.0) {
                         int jj = j + static_cast<int>(amrex::Math::copysign(1.0,fcx(i+1,j,k,0)));
                         int kk = k + static_cast<int>(amrex::Math::copysign(1.0,fcx(i+1,j,k,1)));
                         Real fracy = (ccm(i,jj,k) || ccm(i+1,jj,k))
                             ? amrex::Math::abs(fcx(i+1,j,k,0)) : 0.0;
                         Real fracz = (ccm(i,j,kk) || ccm(i+1,j,kk))
                             ? amrex::Math::abs(fcx(i+1,j,k,1)) : 0.0;
-                        if (!beta_on_centroid and !phi_on_centroid)
+                        if (!beta_on_centroid && !phi_on_centroid)
                         {
                             fxp = (1.0-fracy)*(1.0-fracz)*fxp
                                   +    fracy *(1.0-fracz)*bX(i+1,jj,k ,n)*(phi(i+1,jj,k ,n)-phi(i,jj,k ,n))
                                  +(1.0-fracy)*     fracz *bX(i+1,j ,kk,n)*(phi(i+1,j ,kk,n)-phi(i,j ,kk,n))
                                  +     fracy *     fracz *bX(i+1,jj,kk,n)*(phi(i+1,jj,kk,n)-phi(i,jj,kk,n));
                         }
-                        else if (beta_on_centroid and !phi_on_centroid)
+                        else if (beta_on_centroid && !phi_on_centroid)
                         {
                             fxp = (1.0-fracy)*(1.0-fracz)*(phi(i+1, j, k,n)               ) +
                                        fracy *(1.0-fracz)*(phi(i+1,jj, k,n)-phi(i,jj, k,n)) +
@@ -490,21 +490,21 @@ void mlebabeclap_gsrb (Box const& box,
                     Real fym = -bY(i,j,k,n)*phi(i,j-1,k,n);
                     Real oym = -bY(i,j,k,n)*cf1;
                     Real sym =  bY(i,j,k,n);
-                    if (apym != 0.0 and apym != 1.0) {
+                    if (apym != 0.0 && apym != 1.0) {
                         int ii = i + static_cast<int>(amrex::Math::copysign(1.0,fcy(i,j,k,0)));
                         int kk = k + static_cast<int>(amrex::Math::copysign(1.0,fcy(i,j,k,1)));
                         Real fracx = (ccm(ii,j-1,k) || ccm(ii,j,k))
                             ? amrex::Math::abs(fcy(i,j,k,0)) : 0.0;
                         Real fracz = (ccm(i,j-1,kk) || ccm(i,j,kk))
                             ? amrex::Math::abs(fcy(i,j,k,1)) : 0.0;
-                        if (!beta_on_centroid and !phi_on_centroid)
+                        if (!beta_on_centroid && !phi_on_centroid)
                         {
                             fym = (1.0-fracx)*(1.0-fracz)*fym
                                 +      fracx *(1.0-fracz)*bY(ii,j,k ,n)*(phi(ii,j,k ,n)-phi(ii,j-1,k ,n))
                                 + (1.0-fracx)*     fracz *bY(i ,j,kk,n)*(phi(i ,j,kk,n)-phi(i ,j-1,kk,n))
                                 +      fracx *     fracz *bY(ii,j,kk,n)*(phi(ii,j,kk,n)-phi(ii,j-1,kk,n));
                         }
-                        else if (beta_on_centroid and !phi_on_centroid)
+                        else if (beta_on_centroid && !phi_on_centroid)
                         {
                             fym = (1.0-fracx)*(1.0-fracz)*(              -phi( i,j-1, k,n))
                                 +      fracx *(1.0-fracz)*(phi(ii,j,k ,n)-phi(ii,j-1, k,n))
@@ -520,21 +520,21 @@ void mlebabeclap_gsrb (Box const& box,
                     Real fyp =  bY(i,j+1,k,n)*phi(i,j+1,k,n);
                     Real oyp =  bY(i,j+1,k,n)*cf4;
                     Real syp = -bY(i,j+1,k,n);
-                    if (apyp != 0.0 and apyp != 1.0) {
+                    if (apyp != 0.0 && apyp != 1.0) {
                         int ii = i + static_cast<int>(amrex::Math::copysign(1.0,fcy(i,j+1,k,0)));
                         int kk = k + static_cast<int>(amrex::Math::copysign(1.0,fcy(i,j+1,k,1)));
                         Real fracx = (ccm(ii,j,k) || ccm(ii,j+1,k))
                             ? amrex::Math::abs(fcy(i,j+1,k,0)) : 0.0;
                         Real fracz = (ccm(i,j,kk) || ccm(i,j+1,kk))
                             ? amrex::Math::abs(fcy(i,j+1,k,1)) : 0.0;
-                        if (!beta_on_centroid and !phi_on_centroid)
+                        if (!beta_on_centroid && !phi_on_centroid)
                         {
                             fyp = (1.0-fracx)*(1.0-fracz)*fyp 
                                 +      fracx *(1.0-fracz)*bY(ii,j+1,k ,n)*(phi(ii,j+1,k ,n)-phi(ii,j,k ,n))
                                 + (1.0-fracx)*     fracz *bY(i ,j+1,kk,n)*(phi(i ,j+1,kk,n)-phi(i ,j,kk,n))
                                 +      fracx *     fracz *bY(ii,j+1,kk,n)*(phi(ii,j+1,kk,n)-phi(ii,j,kk,n));
                         }
-                        else if (beta_on_centroid and !phi_on_centroid)
+                        else if (beta_on_centroid && !phi_on_centroid)
                         {
                             fyp = (1.0-fracx)*(1.0-fracz)*(phi( i,j+1, k,n)               ) 
                                 +      fracx *(1.0-fracz)*(phi(ii,j+1, k,n)-phi(ii,j, k,n))
@@ -550,21 +550,21 @@ void mlebabeclap_gsrb (Box const& box,
                     Real fzm = -bZ(i,j,k,n)*phi(i,j,k-1,n);
                     Real ozm = -bZ(i,j,k,n)*cf2;
                     Real szm =  bZ(i,j,k,n);
-                    if (apzm != 0.0 and apzm != 1.0) {
+                    if (apzm != 0.0 && apzm != 1.0) {
                         int ii = i + static_cast<int>(amrex::Math::copysign(1.0,fcz(i,j,k,0)));
                         int jj = j + static_cast<int>(amrex::Math::copysign(1.0,fcz(i,j,k,1)));
                         Real fracx = (ccm(ii,j,k-1) || ccm(ii,j,k))
                             ? amrex::Math::abs(fcz(i,j,k,0)) : 0.0;
                         Real fracy = (ccm(i,jj,k-1) || ccm(i,jj,k))
                             ? amrex::Math::abs(fcz(i,j,k,1)) : 0.0;
-                        if (!beta_on_centroid and !phi_on_centroid)
+                        if (!beta_on_centroid && !phi_on_centroid)
                         {
                             fzm = (1.0-fracx)*(1.0-fracy)*fzm
                                  +     fracx *(1.0-fracy)*bZ(ii, j,k,n)*(phi(ii, j,k,n)-phi(ii, j,k-1,n))
                                  +(1.0-fracx)*     fracy *bZ( i,jj,k,n)*(phi( i,jj,k,n)-phi( i,jj,k-1,n))
                                  +     fracx *     fracy *bZ(ii,jj,k,n)*(phi(ii,jj,k,n)-phi(ii,jj,k-1,n));
                         }
-                        else if (beta_on_centroid and !phi_on_centroid)
+                        else if (beta_on_centroid && !phi_on_centroid)
                         {
                             fzm = (1.0-fracx)*(1.0-fracy)*(              -phi( i, j,k-1,n))
                                 +      fracx *(1.0-fracy)*(phi(ii, j,k,n)-phi(ii, j,k-1,n))
@@ -580,21 +580,21 @@ void mlebabeclap_gsrb (Box const& box,
                     Real fzp =  bZ(i,j,k+1,n)*phi(i,j,k+1,n);
                     Real ozp =  bZ(i,j,k+1,n)*cf5;
                     Real szp = -bZ(i,j,k+1,n);
-                    if (apzp != 0.0 and apzp != 1.0) {
+                    if (apzp != 0.0 && apzp != 1.0) {
                         int ii = i + static_cast<int>(amrex::Math::copysign(1.0,fcz(i,j,k+1,0)));
                         int jj = j + static_cast<int>(amrex::Math::copysign(1.0,fcz(i,j,k+1,1)));
                         Real fracx = (ccm(ii,j,k) || ccm(ii,j,k+1))
                             ? amrex::Math::abs(fcz(i,j,k+1,0)) : 0.0;
                         Real fracy = (ccm(i,jj,k) || ccm(i,jj,k+1))
                             ? amrex::Math::abs(fcz(i,j,k+1,1)) : 0.0;
-                        if (!beta_on_centroid and !phi_on_centroid)
+                        if (!beta_on_centroid && !phi_on_centroid)
                         {
                             fzp = (1.0-fracx)*(1.0-fracy)*fzp 
                                 +      fracx *(1.0-fracy)*bZ(ii,j ,k+1,n)*(phi(ii,j ,k+1,n)-phi(ii,j ,k,n))
                                 + (1.0-fracx)*     fracy *bZ(i ,jj,k+1,n)*(phi(i ,jj,k+1,n)-phi(i ,jj,k,n))
                                 +      fracx *     fracy *bZ(ii,jj,k+1,n)*(phi(ii,jj,k+1,n)-phi(ii,jj,k,n));
                         }
-                        else if (beta_on_centroid and !phi_on_centroid)
+                        else if (beta_on_centroid && !phi_on_centroid)
                         {
                             fzp = (1.0-fracx)*(1.0-fracy)*(phi( i, j,k+1,n)               )
                                 +      fracx *(1.0-fracy)*(phi(ii, j,k+1,n)-phi(ii, j,k,n))
@@ -693,7 +693,7 @@ void mlebabeclap_flux_x (Box const& box, Array4<Real> const& fx, Array4<Real con
     int hif = xbox.bigEnd(0);
     amrex::LoopConcurrent(box, ncomp, [=] (int i, int j, int k, int n) noexcept
     {
-        if (!face_only or lof == i or hif == i) {
+        if (!face_only || lof == i || hif == i) {
             if (apx(i,j,k) == 0.0) {
                 fx(i,j,k,n) = 0.0;
             } else if (apx(i,j,k) == 1.0) {
@@ -704,14 +704,14 @@ void mlebabeclap_flux_x (Box const& box, Array4<Real> const& fx, Array4<Real con
                 int kk = k + static_cast<int>(amrex::Math::copysign(1.0, fcx(i,j,k,1)));
                 Real fracy = (ccm(i-1,jj,k) || ccm(i,jj,k)) ? amrex::Math::abs(fcx(i,j,k,0)) : 0.0;
                 Real fracz = (ccm(i-1,j,kk) || ccm(i,j,kk)) ? amrex::Math::abs(fcx(i,j,k,1)) : 0.0;
-                if (!beta_on_centroid and !phi_on_centroid)
+                if (!beta_on_centroid && !phi_on_centroid)
                 {
                     fxm = (1.0-fracy)*(1.0-fracz)*fxm +
                                fracy *(1.0-fracz)*bX(i,jj,k ,n)*(sol(i,jj,k ,n)-sol(i-1,jj,k ,n)) +
                                fracz *(1.0-fracy)*bX(i,j ,kk,n)*(sol(i,j ,kk,n)-sol(i-1,j ,kk,n)) +
                                fracy*      fracz *bX(i,jj,kk,n)*(sol(i,jj,kk,n)-sol(i-1,jj,kk,n));
                 } 
-                else if (beta_on_centroid and !phi_on_centroid)
+                else if (beta_on_centroid && !phi_on_centroid)
                 {
                     fxm = (1.0-fracy)*(1.0-fracz)*(sol(i, j, k,n)-sol(i-1, j, k,n)) +
                                fracy *(1.0-fracz)*(sol(i,jj, k,n)-sol(i-1,jj, k,n)) +
@@ -737,7 +737,7 @@ void mlebabeclap_flux_y (Box const& box, Array4<Real> const& fy, Array4<Real con
     int hif = ybox.bigEnd(1);
     amrex::LoopConcurrent(box, ncomp, [=] (int i, int j, int k, int n) noexcept
     {
-        if (!face_only or lof == j or hif == j) {
+        if (!face_only || lof == j || hif == j) {
             if (apy(i,j,k) == 0.0) {
                 fy(i,j,k,n) = 0.0;
             } else if (apy(i,j,k) == 1.0) {
@@ -748,14 +748,14 @@ void mlebabeclap_flux_y (Box const& box, Array4<Real> const& fy, Array4<Real con
                 int kk = k + static_cast<int>(amrex::Math::copysign(1.0,fcy(i,j,k,1)));
                 Real fracx = (ccm(ii,j-1,k) || ccm(ii,j,k)) ? amrex::Math::abs(fcy(i,j,k,0)) : 0.0;
                 Real fracz = (ccm(i,j-1,kk) || ccm(i,j,kk)) ? amrex::Math::abs(fcy(i,j,k,1)) : 0.0;
-                if (!beta_on_centroid and !phi_on_centroid)
+                if (!beta_on_centroid && !phi_on_centroid)
                 {
                     fym = (1.0-fracx)*(1.0-fracz)*fym +
                                fracx *(1.0-fracz)*bY(ii,j,k ,n)*(sol(ii,j,k ,n)-sol(ii,j-1,k ,n)) +
                                fracz *(1.0-fracx)*bY(i ,j,kk,n)*(sol(i ,j,kk,n)-sol(i ,j-1,kk,n)) +
                                fracx *     fracz *bY(ii,j,kk,n)*(sol(ii,j,kk,n)-sol(ii,j-1,kk,n));
                 } 
-                else if (beta_on_centroid and !phi_on_centroid)
+                else if (beta_on_centroid && !phi_on_centroid)
                 {
                     fym = (1.0-fracx)*(1.0-fracz)*(sol( i,j, k,n)-sol( i,j-1, k,n)) +
                                fracx *(1.0-fracz)*(sol(ii,j, k,n)-sol(ii,j-1, k,n)) +
@@ -781,7 +781,7 @@ void mlebabeclap_flux_z (Box const& box, Array4<Real> const& fz, Array4<Real con
     int hif = zbox.bigEnd(2);
     amrex::LoopConcurrent(box, ncomp, [=] (int i, int j, int k, int n) noexcept
     {
-        if (!face_only or lof == k or hif == k) {
+        if (!face_only || lof == k || hif == k) {
             if (apz(i,j,k) == 0.0) {
                 fz(i,j,k,n) = 0.0;
             } else if (apz(i,j,k) == 1.0) {
@@ -792,14 +792,14 @@ void mlebabeclap_flux_z (Box const& box, Array4<Real> const& fz, Array4<Real con
                 int jj = j + static_cast<int>(amrex::Math::copysign(1.0,fcz(i,j,k,1)));
                 Real fracx = (ccm(ii,j,k-1) || ccm(ii,j,k)) ? amrex::Math::abs(fcz(i,j,k,0)) : 0.0;
                 Real fracy = (ccm(i,jj,k-1) || ccm(i,jj,k)) ? amrex::Math::abs(fcz(i,j,k,1)) : 0.0;
-                if (!beta_on_centroid and !phi_on_centroid)
+                if (!beta_on_centroid && !phi_on_centroid)
                 {
                     fzm = (1.0-fracx)*(1.0-fracy)*fzm +
                         fracx*(1.0-fracy)*bZ(ii,j ,k,n)*(sol(ii,j ,k,n)-sol(ii,j ,k-1,n)) +
                         fracy*(1.0-fracx)*bZ(i ,jj,k,n)*(sol(i ,jj,k,n)-sol(i ,jj,k-1,n)) +
                         fracx*     fracy *bZ(ii,jj,k,n)*(sol(ii,jj,k,n)-sol(ii,jj,k-1,n));
                 } 
-                else if (beta_on_centroid and !phi_on_centroid)
+                else if (beta_on_centroid && !phi_on_centroid)
                 {
                     fzm = (1.0-fracx)*(1.0-fracy)*(sol( i, j,k,n)-sol( i, j,k-1,n)) +
                                fracx *(1.0-fracy)*(sol(ii, j,k,n)-sol(ii, j,k-1,n)) +
@@ -824,7 +824,7 @@ void mlebabeclap_flux_x_0 (Box const& box, Array4<Real> const& fx, Array4<Real c
     int hif = xbox.bigEnd(0);
     amrex::LoopConcurrent(box, ncomp, [=] (int i, int j, int k, int n) noexcept
     {
-        if (!face_only or lof == i or hif == i) {
+        if (!face_only || lof == i || hif == i) {
             if (apx(i,j,k) == 0.0) {
                 fx(i,j,k,n) = 0.0;
             } else {
@@ -843,7 +843,7 @@ void mlebabeclap_flux_y_0 (Box const& box, Array4<Real> const& fy, Array4<Real c
     int hif = ybox.bigEnd(1);
     amrex::LoopConcurrent(box, ncomp, [=] (int i, int j, int k, int n) noexcept
     {
-        if (!face_only or lof == j or hif == j) {
+        if (!face_only || lof == j || hif == j) {
             if (apy(i,j,k) == 0.0) {
                 fy(i,j,k,n) = 0.0;
             } else {
@@ -862,7 +862,7 @@ void mlebabeclap_flux_z_0 (Box const& box, Array4<Real> const& fz, Array4<Real c
     int hif = zbox.bigEnd(2);
     amrex::LoopConcurrent(box, ncomp, [=] (int i, int j, int k, int n) noexcept
     {
-        if (!face_only or lof == k or hif == k) {
+        if (!face_only || lof == k || hif == k) {
             if (apz(i,j,k) == 0.0) {
                 fz(i,j,k,n) = 0.0;
             } else {
@@ -1039,7 +1039,7 @@ void mlebabeclap_normalize (Box const& box, Array4<Real> const& phi,
             Real apzp = apz(i,j,k+1);
 
             Real sxm =  bX(i,j,k,n);
-            if (apxm != 0.0 and apxm != 1.0 && !beta_on_centroid) {
+            if (apxm != 0.0 && apxm != 1.0 && !beta_on_centroid) {
                 int jj = j + static_cast<int>(amrex::Math::copysign(1.0, fcx(i,j,k,0)));
                 int kk = k + static_cast<int>(amrex::Math::copysign(1.0, fcx(i,j,k,1)));
                 Real fracy = (ccm(i-1,jj,k) || ccm(i,jj,k))
@@ -1050,7 +1050,7 @@ void mlebabeclap_normalize (Box const& box, Array4<Real> const& phi,
             }
 
             Real sxp = -bX(i+1,j,k,n);
-            if (apxp != 0.0 and apxp != 1.0 && !beta_on_centroid) {
+            if (apxp != 0.0 && apxp != 1.0 && !beta_on_centroid) {
                 int jj = j + static_cast<int>(amrex::Math::copysign(1.0,fcx(i+1,j,k,0)));
                 int kk = k + static_cast<int>(amrex::Math::copysign(1.0,fcx(i+1,j,k,1)));
                 Real fracy = (ccm(i,jj,k) || ccm(i+1,jj,k))
@@ -1061,7 +1061,7 @@ void mlebabeclap_normalize (Box const& box, Array4<Real> const& phi,
             }
 
             Real sym =  bY(i,j,k,n);
-            if (apym != 0.0 and apym != 1.0 && !beta_on_centroid) {
+            if (apym != 0.0 && apym != 1.0 && !beta_on_centroid) {
                 int ii = i + static_cast<int>(amrex::Math::copysign(1.0,fcy(i,j,k,0)));
                 int kk = k + static_cast<int>(amrex::Math::copysign(1.0,fcy(i,j,k,1)));
                 Real fracx = (ccm(ii,j-1,k) || ccm(ii,j,k))
@@ -1072,7 +1072,7 @@ void mlebabeclap_normalize (Box const& box, Array4<Real> const& phi,
             }
 
             Real syp = -bY(i,j+1,k,n);
-            if (apyp != 0.0 and apyp != 1.0 && !beta_on_centroid) {
+            if (apyp != 0.0 && apyp != 1.0 && !beta_on_centroid) {
                 int ii = i + static_cast<int>(amrex::Math::copysign(1.0,fcy(i,j+1,k,0)));
                 int kk = k + static_cast<int>(amrex::Math::copysign(1.0,fcy(i,j+1,k,1)));
                 Real fracx = (ccm(ii,j,k) || ccm(ii,j+1,k))
@@ -1083,7 +1083,7 @@ void mlebabeclap_normalize (Box const& box, Array4<Real> const& phi,
             }
 
             Real szm =  bZ(i,j,k,n);
-            if (apzm != 0.0 and apzm != 1.0 && !beta_on_centroid) {
+            if (apzm != 0.0 && apzm != 1.0 && !beta_on_centroid) {
                 int ii = i + static_cast<int>(amrex::Math::copysign(1.0,fcz(i,j,k,0)));
                 int jj = j + static_cast<int>(amrex::Math::copysign(1.0,fcz(i,j,k,1)));
                 Real fracx = (ccm(ii,j,k-1) || ccm(ii,j,k))
@@ -1094,7 +1094,7 @@ void mlebabeclap_normalize (Box const& box, Array4<Real> const& phi,
             }
 
             Real szp = -bZ(i,j,k+1,n);
-            if (apzp != 0.0 and apzp != 1.0 && !beta_on_centroid) {
+            if (apzp != 0.0 && apzp != 1.0 && !beta_on_centroid) {
                 int ii = i + static_cast<int>(amrex::Math::copysign(1.0,fcz(i,j,k+1,0)));
                 int jj = j + static_cast<int>(amrex::Math::copysign(1.0,fcz(i,j,k+1,1)));
                 Real fracx = (ccm(ii,j,k) || ccm(ii,j,k+1))

--- a/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap_K.H
@@ -42,7 +42,7 @@ void mlebabeclap_apply_bc_x (int side, Box const& box, int blen,
     {
         for     (int k = lo.z; k <= hi.z; ++k) {
             for (int j = lo.y; j <= hi.y; ++j) {
-                if (mask(i,j,k) == 0 and mask(i+s,j,k) == 1) {
+                if (mask(i,j,k) == 0 && mask(i+s,j,k) == 1) {
                     phi(i,j,k,icomp) = phi(i+s,j,k,icomp);
                 }
             }
@@ -53,7 +53,7 @@ void mlebabeclap_apply_bc_x (int side, Box const& box, int blen,
     {
         for     (int k = lo.z; k <= hi.z; ++k) {
             for (int j = lo.y; j <= hi.y; ++j) {
-                if (mask(i,j,k) == 0 and mask(i+s,j,k) == 1) {
+                if (mask(i,j,k) == 0 && mask(i+s,j,k) == 1) {
                     phi(i,j,k,icomp) = -phi(i+s,j,k,icomp);
                 }
             }
@@ -70,7 +70,7 @@ void mlebabeclap_apply_bc_x (int side, Box const& box, int blen,
         }
         for     (int k = lo.z; k <= hi.z; ++k) {
             for (int j = lo.y; j <= hi.y; ++j) {
-                if (mask(i,j,k) == 0 and mask(i+s,j,k) == 1) {
+                if (mask(i,j,k) == 0 && mask(i+s,j,k) == 1) {
                     int order = 1;
                     bool has_cutfaces = false;
                     for (int r = 0; r <= NX-2; ++r) {
@@ -128,7 +128,7 @@ void mlebabeclap_apply_bc_y (int side, Box const& box, int blen,
     {
         for     (int k = lo.z; k <= hi.z; ++k) {
             for (int i = lo.x; i <= hi.x; ++i) {
-                if (mask(i,j,k) == 0 and mask(i,j+s,k) == 1) {
+                if (mask(i,j,k) == 0 && mask(i,j+s,k) == 1) {
                     phi(i,j,k,icomp) = phi(i,j+s,k,icomp);
                 }
             }
@@ -139,7 +139,7 @@ void mlebabeclap_apply_bc_y (int side, Box const& box, int blen,
     {
         for     (int k = lo.z; k <= hi.z; ++k) {
             for (int i = lo.x; i <= hi.x; ++i) {
-                if (mask(i,j,k) == 0 and mask(i,j+s,k) == 1) {
+                if (mask(i,j,k) == 0 && mask(i,j+s,k) == 1) {
                     phi(i,j,k,icomp) = -phi(i,j+s,k,icomp);
                 }
             }
@@ -156,7 +156,7 @@ void mlebabeclap_apply_bc_y (int side, Box const& box, int blen,
         }
         for     (int k = lo.z; k <= hi.z; ++k) {
             for (int i = lo.x; i <= hi.x; ++i) {
-                if (mask(i,j,k) == 0 and mask(i,j+s,k) == 1) {
+                if (mask(i,j,k) == 0 && mask(i,j+s,k) == 1) {
                     int order = 1;
                     bool has_cutfaces = false;
                     for (int r = 0; r <= NX-2; ++r) {
@@ -214,7 +214,7 @@ void mlebabeclap_apply_bc_z (int side, Box const& box, int blen,
     {
         for     (int j = lo.y; j <= hi.y; ++j) {
             for (int i = lo.x; i <= hi.x; ++i) {
-                if (mask(i,j,k) == 0 and mask(i,j,k+s) == 1) {
+                if (mask(i,j,k) == 0 && mask(i,j,k+s) == 1) {
                     phi(i,j,k,icomp) = phi(i,j,k+s,icomp);
                 }
             }
@@ -225,7 +225,7 @@ void mlebabeclap_apply_bc_z (int side, Box const& box, int blen,
     {
         for     (int j = lo.y; j <= hi.y; ++j) {
             for (int i = lo.x; i <= hi.x; ++i) {
-                if (mask(i,j,k) == 0 and mask(i,j,k+s) == 1) {
+                if (mask(i,j,k) == 0 && mask(i,j,k+s) == 1) {
                     phi(i,j,k,icomp) = -phi(i,j,k+s,icomp);
                 }
             }
@@ -242,7 +242,7 @@ void mlebabeclap_apply_bc_z (int side, Box const& box, int blen,
         }
         for     (int j = lo.y; j <= hi.y; ++j) {
             for (int i = lo.x; i <= hi.x; ++i) {
-                if (mask(i,j,k) == 0 and mask(i,j,k+s) == 1) {
+                if (mask(i,j,k) == 0 && mask(i,j,k+s) == 1) {
                     int order = 1;
                     bool has_cutfaces = false;
                     for (int r = 0; r <= NX-2; ++r) {

--- a/Src/LinearSolvers/MLMG/AMReX_MLEBTensor_2D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBTensor_2D_K.H
@@ -143,36 +143,36 @@ void mlebtensor_cross_terms (Box const& box, Array4<Real> const& Ax,
             {
                 Real fxm_0 = fx(i,j,0,0);
                 Real fxm_1 = fx(i,j,0,1);
-                if (apx(i,j,0) > 0.0 and apx(i,j,0) < 1.0) {
+                if (apx(i,j,0) > 0.0 && apx(i,j,0) < 1.0) {
                     int jj = j + (fcx(i,j,0,0) >= 0.0 ? 1 : -1);
-                    Real fracy = (ccm(i-1,jj,0) or ccm(i,jj,0)) ? amrex::Math::abs(fcx(i,j,0,0)) : 0.0;
+                    Real fracy = (ccm(i-1,jj,0) || ccm(i,jj,0)) ? amrex::Math::abs(fcx(i,j,0,0)) : 0.0;
                     fxm_0 = (1.0-fracy)*fxm_0 + fracy*fx(i,jj,0,0);
                     fxm_1 = (1.0-fracy)*fxm_1 + fracy*fx(i,jj,0,1);
                 }
 
                 Real fxp_0 = fx(i+1,j,0,0);
                 Real fxp_1 = fx(i+1,j,0,1);
-                if (apx(i+1,j,0) > 0.0 and apx(i+1,j,0) < 1.0) {
+                if (apx(i+1,j,0) > 0.0 && apx(i+1,j,0) < 1.0) {
                     int jj = j + (fcx(i+1,j,0,0) >= 0.0 ? 1 : -1);
-                    Real fracy = (ccm(i,jj,0) or ccm(i+1,jj,0)) ? amrex::Math::abs(fcx(i+1,j,0,0)) : 0.0;
+                    Real fracy = (ccm(i,jj,0) || ccm(i+1,jj,0)) ? amrex::Math::abs(fcx(i+1,j,0,0)) : 0.0;
                     fxp_0 = (1.0-fracy)*fxp_0 + fracy*fx(i+1,jj,0,0);
                     fxp_1 = (1.0-fracy)*fxp_1 + fracy*fx(i+1,jj,0,1);
                 }
 
                 Real fym_0 = fy(i,j,0,0);
                 Real fym_1 = fy(i,j,0,1);
-                if (apy(i,j,0) > 0.0 and apy(i,j,0) < 1.0) {
+                if (apy(i,j,0) > 0.0 && apy(i,j,0) < 1.0) {
                     int ii = i + (fcy(i,j,0,0) >= 0.0 ? 1 : -1);
-                    Real fracx = (ccm(ii,j-1,0) or ccm(ii,j,0)) ? amrex::Math::abs(fcy(i,j,0,0)) : 0.0;
+                    Real fracx = (ccm(ii,j-1,0) || ccm(ii,j,0)) ? amrex::Math::abs(fcy(i,j,0,0)) : 0.0;
                     fym_0 = (1.0-fracx)*fym_0 + fracx*fy(ii,j,0,0);
                     fym_1 = (1.0-fracx)*fym_1 + fracx*fy(ii,j,0,1);
                 }
 
                 Real fyp_0 = fy(i,j+1,0,0);
                 Real fyp_1 = fy(i,j+1,0,1);
-                if (apy(i,j+1,0) > 0.0 and apy(i,j+1,0) < 1.0) {
+                if (apy(i,j+1,0) > 0.0 && apy(i,j+1,0) < 1.0) {
                     int ii = i + (fcy(i,j+1,0,0) >= 0.0 ? 1 : -1);
-                    Real fracx = (ccm(ii,j,0) or ccm(ii,j+1,0)) ? amrex::Math::abs(fcy(i,j+1,0,0)) : 0.0;
+                    Real fracx = (ccm(ii,j,0) || ccm(ii,j+1,0)) ? amrex::Math::abs(fcy(i,j+1,0,0)) : 0.0;
                     fyp_0 = (1.0-fracx)*fyp_0 + fracx*fy(ii,j+1,0,0);
                     fyp_1 = (1.0-fracx)*fyp_1 + fracx*fy(ii,j+1,0,1);
                 }
@@ -290,7 +290,7 @@ void mlebtensor_flux_x (Box const& box, Array4<Real> const& Ax,
     int hif = xbox.bigEnd(0);
     amrex::LoopConcurrent(box, [=] (int i, int j, int k) noexcept
     {
-        if (!face_only or lof == i or hif == i) {
+        if (!face_only || lof == i || hif == i) {
 	  if (apx(i,j,k) == 1.0) {
 	    for (int n=0; n<AMREX_SPACEDIM; n++)
 	        Ax(i,j,k,n) += bscalar*fx(i,j,k,n);
@@ -300,7 +300,7 @@ void mlebtensor_flux_x (Box const& box, Array4<Real> const& Ax,
                 Real fxm_1 = fx(i,j,0,1);
 
 		int jj = j + (fcx(i,j,0,0) >= 0.0 ? 1 : -1);
-		Real fracy = (ccm(i-1,jj,0) or ccm(i,jj,0)) ? amrex::Math::abs(fcx(i,j,0,0)) : 0.0;
+		Real fracy = (ccm(i-1,jj,0) || ccm(i,jj,0)) ? amrex::Math::abs(fcx(i,j,0,0)) : 0.0;
 		fxm_0 = (1.0-fracy)*fxm_0 + fracy*fx(i,jj,0,0);
 		fxm_1 = (1.0-fracy)*fxm_1 + fracy*fx(i,jj,0,1);
 
@@ -323,7 +323,7 @@ void mlebtensor_flux_y (Box const& box, Array4<Real> const& Ay,
     int hif = ybox.bigEnd(1);
     amrex::LoopConcurrent(box, [=] (int i, int j, int k) noexcept
     {
-        if (!face_only or lof == j or hif == j) {
+        if (!face_only || lof == j || hif == j) {
 	  if (apy(i,j,k) == 1.0) {
 	    for (int n=0; n<AMREX_SPACEDIM; n++)
 	        Ay(i,j,k,n) += bscalar*fy(i,j,k,n);
@@ -333,7 +333,7 @@ void mlebtensor_flux_y (Box const& box, Array4<Real> const& Ay,
                 Real fym_1 = fy(i,j,0,1);
 
 		int ii = i + (fcy(i,j,0,0) >= 0.0 ? 1 : -1);
-		Real fracx = (ccm(ii,j-1,0) or ccm(ii,j,0)) ? amrex::Math::abs(fcy(i,j,0,0)) : 0.0;
+		Real fracx = (ccm(ii,j-1,0) || ccm(ii,j,0)) ? amrex::Math::abs(fcy(i,j,0,0)) : 0.0;
 		fym_0 = (1.0-fracx)*fym_0 + fracx*fy(ii,j,0,0);
 		fym_1 = (1.0-fracx)*fym_1 + fracx*fy(ii,j,0,1);
 

--- a/Src/LinearSolvers/MLMG/AMReX_MLEBTensor_3D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBTensor_3D_K.H
@@ -251,11 +251,11 @@ void mlebtensor_cross_terms (Box const& box, Array4<Real> const& Ax,
                     Real fxm_0 = fx(i,j,k,0);
                     Real fxm_1 = fx(i,j,k,1);
                     Real fxm_2 = fx(i,j,k,2);
-                    if (apx(i,j,k) > 0.0 and apx(i,j,k) < 1.0) {
+                    if (apx(i,j,k) > 0.0 && apx(i,j,k) < 1.0) {
                         int jj = j + (fcx(i,j,k,0) >= 0.0 ? 1 : -1);
                         int kk = k + (fcx(i,j,k,1) >= 0.0 ? 1 : -1);
-                        Real fracy = (ccm(i-1,jj,k) or ccm(i,jj,k)) ? amrex::Math::abs(fcx(i,j,k,0)) : 0.0;
-                        Real fracz = (ccm(i-1,j,kk) or ccm(i,j,kk)) ? amrex::Math::abs(fcx(i,j,k,1)) : 0.0;
+                        Real fracy = (ccm(i-1,jj,k) || ccm(i,jj,k)) ? amrex::Math::abs(fcx(i,j,k,0)) : 0.0;
+                        Real fracz = (ccm(i-1,j,kk) || ccm(i,j,kk)) ? amrex::Math::abs(fcx(i,j,k,1)) : 0.0;
                         fxm_0 = (1.0-fracy)*(1.0-fracz) *fxm_0
                             + fracy*(1.0-fracz) * fx(i,jj,k ,0)
                             + fracz*(1.0-fracy) * fx(i,j ,kk,0)
@@ -273,11 +273,11 @@ void mlebtensor_cross_terms (Box const& box, Array4<Real> const& Ax,
                     Real fxp_0 = fx(i+1,j,k,0);
                     Real fxp_1 = fx(i+1,j,k,1);
                     Real fxp_2 = fx(i+1,j,k,2);
-                    if (apx(i+1,j,k) > 0.0 and apx(i+1,j,k) < 1.0) {
+                    if (apx(i+1,j,k) > 0.0 && apx(i+1,j,k) < 1.0) {
                         int jj = j + (fcx(i+1,j,k,0) >= 0.0 ? 1 : -1);
                         int kk = k + (fcx(i+1,j,k,1) >= 0.0 ? 1 : -1);
-                        Real fracy = (ccm(i,jj,k) or ccm(i+1,jj,k)) ? amrex::Math::abs(fcx(i+1,j,k,0)) : 0.0;
-                        Real fracz = (ccm(i,j,kk) or ccm(i+1,j,kk)) ? amrex::Math::abs(fcx(i+1,j,k,1)) : 0.0;
+                        Real fracy = (ccm(i,jj,k) || ccm(i+1,jj,k)) ? amrex::Math::abs(fcx(i+1,j,k,0)) : 0.0;
+                        Real fracz = (ccm(i,j,kk) || ccm(i+1,j,kk)) ? amrex::Math::abs(fcx(i+1,j,k,1)) : 0.0;
                         fxp_0 = (1.0-fracy)*(1.0-fracz) *  fxp_0
                             + fracy*(1.0-fracz) * fx(i+1,jj,k ,0)
                             + fracz*(1.0-fracy) * fx(i+1,j ,kk,0)
@@ -295,11 +295,11 @@ void mlebtensor_cross_terms (Box const& box, Array4<Real> const& Ax,
                     Real fym_0 = fy(i,j,k,0);
                     Real fym_1 = fy(i,j,k,1);
                     Real fym_2 = fy(i,j,k,2);
-                    if (apy(i,j,k) > 0.0 and apy(i,j,k) < 1.0) {
+                    if (apy(i,j,k) > 0.0 && apy(i,j,k) < 1.0) {
                         int ii = i + (fcy(i,j,k,0) >= 0.0 ? 1 : -1);
                         int kk = k + (fcy(i,j,k,1) >= 0.0 ? 1 : -1);
-                        Real fracx = (ccm(ii,j-1,k) or ccm(ii,j,k)) ? amrex::Math::abs(fcy(i,j,k,0)) : 0.0;
-                        Real fracz = (ccm(i,j-1,kk) or ccm(i,j,kk)) ? amrex::Math::abs(fcy(i,j,k,1)) : 0.0;
+                        Real fracx = (ccm(ii,j-1,k) || ccm(ii,j,k)) ? amrex::Math::abs(fcy(i,j,k,0)) : 0.0;
+                        Real fracz = (ccm(i,j-1,kk) || ccm(i,j,kk)) ? amrex::Math::abs(fcy(i,j,k,1)) : 0.0;
                         fym_0 = (1.0-fracx)*(1.0-fracz) *fym_0
                             + fracx*(1.0-fracz) * fy(ii,j,k ,0)
                             + fracz*(1.0-fracx) * fy(i ,j,kk,0)
@@ -317,11 +317,11 @@ void mlebtensor_cross_terms (Box const& box, Array4<Real> const& Ax,
                     Real fyp_0 = fy(i,j+1,k,0);
                     Real fyp_1 = fy(i,j+1,k,1);
                     Real fyp_2 = fy(i,j+1,k,2);
-                    if (apy(i,j+1,k) > 0.0 and apy(i,j+1,k) < 1.0) {
+                    if (apy(i,j+1,k) > 0.0 && apy(i,j+1,k) < 1.0) {
                         int ii = i + (fcy(i,j+1,k,0) >= 0.0 ? 1 : -1);
                         int kk = k + (fcy(i,j+1,k,1) >= 0.0 ? 1 : -1);
-                        Real fracx = (ccm(ii,j,k) or ccm(ii,j+1,k)) ? amrex::Math::abs(fcy(i,j+1,k,0)) : 0.0;
-                        Real fracz = (ccm(i,j,kk) or ccm(i,j+1,kk)) ? amrex::Math::abs(fcy(i,j+1,k,1)) : 0.0;
+                        Real fracx = (ccm(ii,j,k) || ccm(ii,j+1,k)) ? amrex::Math::abs(fcy(i,j+1,k,0)) : 0.0;
+                        Real fracz = (ccm(i,j,kk) || ccm(i,j+1,kk)) ? amrex::Math::abs(fcy(i,j+1,k,1)) : 0.0;
                         fyp_0 = (1.0-fracx)*(1.0-fracz) *  fyp_0
                             + fracx*(1.0-fracz) * fy(ii,j+1,k ,0)
                             + fracz*(1.0-fracx) * fy(i ,j+1,kk,0)
@@ -339,11 +339,11 @@ void mlebtensor_cross_terms (Box const& box, Array4<Real> const& Ax,
                     Real fzm_0 = fz(i,j,k,0);
                     Real fzm_1 = fz(i,j,k,1);
                     Real fzm_2 = fz(i,j,k,2);
-                    if (apz(i,j,k) > 0.0 and apz(i,j,k) < 1.0) {
+                    if (apz(i,j,k) > 0.0 && apz(i,j,k) < 1.0) {
                         int ii = i + (fcz(i,j,k,0) >= 0.0 ? 1 : -1);
                         int jj = j + (fcz(i,j,k,1) >= 0.0 ? 1 : -1);
-                        Real fracx = (ccm(ii,j,k-1) or ccm(ii,j,k)) ? amrex::Math::abs(fcz(i,j,k,0)) : 0.0;
-                        Real fracy = (ccm(i,jj,k-1) or ccm(i,jj,k)) ? amrex::Math::abs(fcz(i,j,k,1)) : 0.0;
+                        Real fracx = (ccm(ii,j,k-1) || ccm(ii,j,k)) ? amrex::Math::abs(fcz(i,j,k,0)) : 0.0;
+                        Real fracy = (ccm(i,jj,k-1) || ccm(i,jj,k)) ? amrex::Math::abs(fcz(i,j,k,1)) : 0.0;
                         fzm_0 = (1.0-fracx)*(1.0-fracy) *fzm_0
                             + fracx*(1.0-fracy) * fz(ii,j ,k,0)
                             + fracy*(1.0-fracx) * fz(i ,jj,k,0)
@@ -361,11 +361,11 @@ void mlebtensor_cross_terms (Box const& box, Array4<Real> const& Ax,
                     Real fzp_0 = fz(i,j,k+1,0);
                     Real fzp_1 = fz(i,j,k+1,1);
                     Real fzp_2 = fz(i,j,k+1,2);
-                    if (apz(i,j,k+1) > 0.0 and apz(i,j,k+1) < 1.0) {
+                    if (apz(i,j,k+1) > 0.0 && apz(i,j,k+1) < 1.0) {
                         int ii = i + (fcz(i,j,k+1,0) >= 0.0 ? 1 : -1);
                         int jj = j + (fcz(i,j,k+1,1) >= 0.0 ? 1 : -1);
-                        Real fracx = (ccm(ii,j,k) or ccm(ii,j,k)) ? amrex::Math::abs(fcz(i,j,k+1,0)) : 0.0;
-                        Real fracy = (ccm(i,jj,k) or ccm(i,jj,k)) ? amrex::Math::abs(fcz(i,j,k+1,1)) : 0.0;
+                        Real fracx = (ccm(ii,j,k) || ccm(ii,j,k)) ? amrex::Math::abs(fcz(i,j,k+1,0)) : 0.0;
+                        Real fracy = (ccm(i,jj,k) || ccm(i,jj,k)) ? amrex::Math::abs(fcz(i,j,k+1,1)) : 0.0;
                         fzp_0 = (1.0-fracx)*(1.0-fracy) *  fzp_0
                             + fracx*(1.0-fracy) * fz(ii,j ,k+1,0)
                             + fracy*(1.0-fracx) * fz(i ,jj,k+1,0)
@@ -542,7 +542,7 @@ void mlebtensor_flux_x (Box const& box, Array4<Real> const& Ax,
     int hif = xbox.bigEnd(0);
     amrex::LoopConcurrent(box, [=] (int i, int j, int k) noexcept
     {
-        if (!face_only or lof == i or hif == i) {
+        if (!face_only || lof == i || hif == i) {
 	  if (apx(i,j,k) == 1.0) {
 	    for (int n=0; n<AMREX_SPACEDIM; n++)
 	        Ax(i,j,k,n) += bscalar*fx(i,j,k,n);
@@ -554,8 +554,8 @@ void mlebtensor_flux_x (Box const& box, Array4<Real> const& Ax,
 
 		int jj = j + (fcx(i,j,k,0) >= 0.0 ? 1 : -1);
 		int kk = k + (fcx(i,j,k,1) >= 0.0 ? 1 : -1);
-		Real fracy = (ccm(i-1,jj,k) or ccm(i,jj,k)) ? amrex::Math::abs(fcx(i,j,k,0)) : 0.0;
-		Real fracz = (ccm(i-1,j,kk) or ccm(i,j,kk)) ? amrex::Math::abs(fcx(i,j,k,1)) : 0.0;
+		Real fracy = (ccm(i-1,jj,k) || ccm(i,jj,k)) ? amrex::Math::abs(fcx(i,j,k,0)) : 0.0;
+		Real fracz = (ccm(i-1,j,kk) || ccm(i,j,kk)) ? amrex::Math::abs(fcx(i,j,k,1)) : 0.0;
 		fxm_0 = (1.0-fracy)*(1.0-fracz) *fxm_0
 		        + fracy*(1.0-fracz) * fx(i,jj,k ,0)
 		        + fracz*(1.0-fracy) * fx(i,j ,kk,0)
@@ -588,7 +588,7 @@ void mlebtensor_flux_y (Box const& box, Array4<Real> const& Ay,
     int hif = ybox.bigEnd(1);
     amrex::LoopConcurrent(box, [=] (int i, int j, int k) noexcept
     {
-        if (!face_only or lof == j or hif == j) {
+        if (!face_only || lof == j || hif == j) {
 	  if (apy(i,j,k) == 1.0) {
 	    for (int n=0; n<AMREX_SPACEDIM; n++)
 	          Ay(i,j,k,n) += bscalar*fy(i,j,k,n);
@@ -599,8 +599,8 @@ void mlebtensor_flux_y (Box const& box, Array4<Real> const& Ay,
 
 		  int ii = i + (fcy(i,j,k,0) >= 0.0 ? 1 : -1);
 		  int kk = k + (fcy(i,j,k,1) >= 0.0 ? 1 : -1);
-		  Real fracx = (ccm(ii,j-1,k) or ccm(ii,j,k)) ? amrex::Math::abs(fcy(i,j,k,0)) : 0.0;
-		  Real fracz = (ccm(i,j-1,kk) or ccm(i,j,kk)) ? amrex::Math::abs(fcy(i,j,k,1)) : 0.0;
+		  Real fracx = (ccm(ii,j-1,k) || ccm(ii,j,k)) ? amrex::Math::abs(fcy(i,j,k,0)) : 0.0;
+		  Real fracz = (ccm(i,j-1,kk) || ccm(i,j,kk)) ? amrex::Math::abs(fcy(i,j,k,1)) : 0.0;
 		  fym_0 = (1.0-fracx)*(1.0-fracz) *fym_0
                           + fracx*(1.0-fracz) * fy(ii,j,k ,0)
                           + fracz*(1.0-fracx) * fy(i ,j,kk,0)
@@ -634,7 +634,7 @@ void mlebtensor_flux_z (Box const& box, Array4<Real> const& Az,
     int hif = zbox.bigEnd(2);
     amrex::LoopConcurrent(box, [=] (int i, int j, int k) noexcept
     {
-        if (!face_only or lof == k or hif == k) {
+        if (!face_only || lof == k || hif == k) {
 	  if (apz(i,j,k) == 1.0) {
 	    for (int n=0; n<AMREX_SPACEDIM; n++)
 	          Az(i,j,k,n) += bscalar*fz(i,j,k,n);
@@ -646,8 +646,8 @@ void mlebtensor_flux_z (Box const& box, Array4<Real> const& Az,
 
 		  int ii = i + (fcz(i,j,k,0) >= 0.0 ? 1 : -1);
 		  int jj = j + (fcz(i,j,k,1) >= 0.0 ? 1 : -1);
-		  Real fracx = (ccm(ii,j,k-1) or ccm(ii,j,k)) ? amrex::Math::abs(fcz(i,j,k,0)) : 0.0;
-		  Real fracy = (ccm(i,jj,k-1) or ccm(i,jj,k)) ? amrex::Math::abs(fcz(i,j,k,1)) : 0.0;
+		  Real fracx = (ccm(ii,j,k-1) || ccm(ii,j,k)) ? amrex::Math::abs(fcz(i,j,k,0)) : 0.0;
+		  Real fracy = (ccm(i,jj,k-1) || ccm(i,jj,k)) ? amrex::Math::abs(fcz(i,j,k,1)) : 0.0;
 		  fzm_0 = (1.0-fracx)*(1.0-fracy) *fzm_0
                           + fracx*(1.0-fracy) * fz(ii,j ,k,0)
                           + fracy*(1.0-fracx) * fz(i ,jj,k,0)

--- a/Src/LinearSolvers/MLMG/AMReX_MLLinOp.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLLinOp.cpp
@@ -157,7 +157,7 @@ MLLinOp::define (const Vector<Geometry>& a_geom,
     }
 
 #ifdef AMREX_USE_EB
-    if (!a_factory.empty() and eb_limit_coarsening) {
+    if (!a_factory.empty() && eb_limit_coarsening) {
         auto f = dynamic_cast<EBFArrayBoxFactory const*>(a_factory[0]);
         if (f) {
             info.max_coarsening_level = std::min(info.max_coarsening_level,
@@ -293,22 +293,22 @@ MLLinOp::defineGrids (const Vector<Geometry>& a_geom,
 	{   
 	    int num_semicoarsening_level = 0;
             IntVect rr_0(AMREX_D_DECL(mg_coarsen_ratio,1,1));
-            bool is_coarsenable_x = ( dbx.coarsenable(rr_0, mg_domain_min_width) and
+            bool is_coarsenable_x = ( dbx.coarsenable(rr_0, mg_domain_min_width) &&
                                       bbx.coarsenable(rr_0, mg_box_min_width));
             IntVect rr_1(AMREX_D_DECL(1,mg_coarsen_ratio,1));
-            bool is_coarsenable_y = ( dbx.coarsenable(rr_1, mg_domain_min_width) and
+            bool is_coarsenable_y = ( dbx.coarsenable(rr_1, mg_domain_min_width) &&
                                       bbx.coarsenable(rr_1, mg_box_min_width));
 #if (AMREX_SPACEDIM == 3)
             IntVect rr_2(AMREX_D_DECL(1,1,mg_coarsen_ratio));
-            bool is_coarsenable_z = ( dbx.coarsenable(rr_2, mg_domain_min_width) and
+            bool is_coarsenable_z = ( dbx.coarsenable(rr_2, mg_domain_min_width) &&
                                       bbx.coarsenable(rr_2, mg_box_min_width));
 #endif
 	    IntVect rr_vec(mg_coarsen_ratio);
 #if (AMREX_SPACEDIM == 2)
-            while ( is_coarsenable_x or is_coarsenable_y )
+            while ( is_coarsenable_x || is_coarsenable_y )
 #endif
 #if (AMREX_SPACEDIM == 3)
-            while ( is_coarsenable_x or is_coarsenable_y or is_coarsenable_z )
+            while ( is_coarsenable_x || is_coarsenable_y || is_coarsenable_z )
 #endif
 	    {
 #if (AMREX_SPACEDIM >= 2)
@@ -328,21 +328,21 @@ MLLinOp::defineGrids (const Vector<Geometry>& a_geom,
                 bool to_agg = (bbx.d_numPts() / nbxs) < 0.999*threshold_npts;
                 agg_flag.push_back(to_agg);
 
-                is_coarsenable_x = ( dbx.coarsenable(rr_0, mg_domain_min_width) and
+                is_coarsenable_x = ( dbx.coarsenable(rr_0, mg_domain_min_width) &&
                                      bbx.coarsenable(rr_0, mg_box_min_width));
 #if (AMREX_SPACEDIM >= 2)
-                is_coarsenable_y = ( dbx.coarsenable(rr_1, mg_domain_min_width) and
+                is_coarsenable_y = ( dbx.coarsenable(rr_1, mg_domain_min_width) &&
                                      bbx.coarsenable(rr_1, mg_box_min_width));
 #if (AMREX_SPACEDIM == 3)
-                is_coarsenable_z = ( dbx.coarsenable(rr_2, mg_domain_min_width) and
+                is_coarsenable_z = ( dbx.coarsenable(rr_2, mg_domain_min_width) &&
                                      bbx.coarsenable(rr_2, mg_box_min_width));
 #endif
 #endif
 #if (AMREX_SPACEDIM == 2)
-		if (!(is_coarsenable_x and is_coarsenable_y))
+		if (!(is_coarsenable_x && is_coarsenable_y))
 #endif
 #if (AMREX_SPACEDIM == 3)
-                if (!(is_coarsenable_x and is_coarsenable_y and is_coarsenable_z))
+                if (!(is_coarsenable_x && is_coarsenable_y && is_coarsenable_z))
 #endif
 		{
 		    num_semicoarsening_level++;    
@@ -355,7 +355,7 @@ MLLinOp::defineGrids (const Vector<Geometry>& a_geom,
 #endif
 	{
             while (    dbx.coarsenable(mg_coarsen_ratio,mg_domain_min_width)
-                   and bbx.coarsenable(mg_coarsen_ratio,mg_box_min_width))
+                   && bbx.coarsenable(mg_coarsen_ratio,mg_box_min_width))
             {
                 dbx.coarsen(mg_coarsen_ratio);
                 domainboxes.push_back(dbx);
@@ -440,8 +440,8 @@ MLLinOp::defineGrids (const Vector<Geometry>& a_geom,
 
         // Regular coarsening
         while (m_num_mg_levels[0] < info.max_coarsening_level + 1
-               and a_geom[0].Domain().coarsenable(rr, mg_domain_min_width)
-               and a_grids[0].coarsenable(rr, mg_box_min_width))
+               && a_geom[0].Domain().coarsenable(rr, mg_domain_min_width)
+               && a_grids[0].coarsenable(rr, mg_box_min_width))
         {
             m_geom[0].emplace_back(amrex::coarsen(a_geom[0].Domain(),rr),rb,coord,is_per);
 
@@ -475,36 +475,36 @@ MLLinOp::defineGrids (const Vector<Geometry>& a_geom,
             int num_semicoarsening_level = 1;
             // Semi-coarsening  -- by the time we get here we know we can't coarsen isotropically any more
             IntVect rr_0(AMREX_D_DECL(rr,1,1));
-            bool is_coarsenable_x = ( a_geom[0].Domain().coarsenable(rr_0, mg_domain_min_width) and
+            bool is_coarsenable_x = ( a_geom[0].Domain().coarsenable(rr_0, mg_domain_min_width) &&
                                       a_grids[0].coarsenable(rr_0, mg_box_min_width));
 #if (AMREX_SPACEDIM >= 2)
             IntVect rr_1(AMREX_D_DECL(1,rr,1));
-            bool is_coarsenable_y = ( a_geom[0].Domain().coarsenable(rr_1, mg_domain_min_width) and
+            bool is_coarsenable_y = ( a_geom[0].Domain().coarsenable(rr_1, mg_domain_min_width) &&
                                       a_grids[0].coarsenable(rr_1, mg_box_min_width));
 #endif
 #if (AMREX_SPACEDIM == 3)
             IntVect rr_2(AMREX_D_DECL(1,1,rr));
-            bool is_coarsenable_z = ( a_geom[0].Domain().coarsenable(rr_2, mg_domain_min_width) and
+            bool is_coarsenable_z = ( a_geom[0].Domain().coarsenable(rr_2, mg_domain_min_width) &&
                                       a_grids[0].coarsenable(rr_2, mg_box_min_width));
 #endif
 
 #if (AMREX_SPACEDIM == 2)
-            if (is_coarsenable_x or is_coarsenable_y)
+            if (is_coarsenable_x || is_coarsenable_y)
 #endif
 #if (AMREX_SPACEDIM == 3)
-            if (is_coarsenable_x or is_coarsenable_y or is_coarsenable_z)
+            if (is_coarsenable_x || is_coarsenable_y || is_coarsenable_z)
 #endif
             {
                 IntVect rr_vec(rr/mg_coarsen_ratio);
 #if (AMREX_SPACEDIM == 2)
-                while ( (num_semicoarsening_level < info.max_semicoarsening_level + 1) and
-			(m_num_mg_levels[0] < info.max_coarsening_level + 1) and
-                        (is_coarsenable_x or is_coarsenable_y ) )
+                while ( (num_semicoarsening_level < info.max_semicoarsening_level + 1) &&
+			(m_num_mg_levels[0] < info.max_coarsening_level + 1) &&
+                        (is_coarsenable_x || is_coarsenable_y ) )
 #endif
 #if (AMREX_SPACEDIM == 3)
-                while ( (num_semicoarsening_level < info.max_semicoarsening_level + 1) and
-		        (m_num_mg_levels[0] < info.max_coarsening_level + 1) and
-                        (is_coarsenable_x or is_coarsenable_y or is_coarsenable_z) )
+                while ( (num_semicoarsening_level < info.max_semicoarsening_level + 1) &&
+		        (m_num_mg_levels[0] < info.max_coarsening_level + 1) &&
+                        (is_coarsenable_x || is_coarsenable_y || is_coarsenable_z) )
 #endif
                 {
                     int r0 = (is_coarsenable_x) ? rr_vec[0]*mg_coarsen_ratio : rr_vec[0];
@@ -542,16 +542,16 @@ MLLinOp::defineGrids (const Vector<Geometry>& a_geom,
                     ++num_semicoarsening_level;
 
                     IntVect rrr_0(AMREX_D_DECL(rr_vec[0]*mg_coarsen_ratio, 1, 1));
-                    is_coarsenable_x = ( a_geom[0].Domain().coarsenable(rrr_0, mg_domain_min_width) and
+                    is_coarsenable_x = ( a_geom[0].Domain().coarsenable(rrr_0, mg_domain_min_width) &&
                                          a_grids[0].coarsenable(rrr_0, mg_box_min_width));
 #if (AMREX_SPACEDIM >= 2)
                     IntVect rrr_1(AMREX_D_DECL(1, rr_vec[1]*mg_coarsen_ratio, 1));
-                    is_coarsenable_y = ( a_geom[0].Domain().coarsenable(rrr_1, mg_domain_min_width) and
+                    is_coarsenable_y = ( a_geom[0].Domain().coarsenable(rrr_1, mg_domain_min_width) &&
                                          a_grids[0].coarsenable(rrr_1, mg_box_min_width));
 
 #if (AMREX_SPACEDIM == 3)
                     IntVect rrr_2(AMREX_D_DECL(1,1,rr_vec[2]*mg_coarsen_ratio));
-                    is_coarsenable_z = ( a_geom[0].Domain().coarsenable(rrr_2, mg_domain_min_width) and
+                    is_coarsenable_z = ( a_geom[0].Domain().coarsenable(rrr_2, mg_domain_min_width) &&
                                          a_grids[0].coarsenable(rrr_2, mg_box_min_width));
 #endif
 #endif
@@ -662,7 +662,7 @@ MLLinOp::setDomainBC (const Array<BCType,AMREX_SPACEDIM>& a_lobc,
             AMREX_ALWAYS_ASSERT(a_lobc[idim] == BCType::Periodic);
             AMREX_ALWAYS_ASSERT(a_hibc[idim] == BCType::Periodic);
         }
-        if (a_lobc[idim] == BCType::Periodic or
+        if (a_lobc[idim] == BCType::Periodic ||
             a_hibc[idim] == BCType::Periodic) {
             AMREX_ALWAYS_ASSERT(m_geom[0][0].isPeriodic(idim));
         }
@@ -704,7 +704,7 @@ MLLinOp::setDomainBC (const Vector<Array<BCType,AMREX_SPACEDIM> >& a_lobc,
                 AMREX_ALWAYS_ASSERT(m_lobc[icomp][idim] == BCType::Periodic);
                 AMREX_ALWAYS_ASSERT(m_hibc[icomp][idim] == BCType::Periodic);
             }
-            if (m_lobc[icomp][idim] == BCType::Periodic or
+            if (m_lobc[icomp][idim] == BCType::Periodic ||
                 m_hibc[icomp][idim] == BCType::Periodic) {
                 AMREX_ALWAYS_ASSERT(m_geom[0][0].isPeriodic(idim));
             }

--- a/Src/LinearSolvers/MLMG/AMReX_MLLinOp_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLLinOp_K.H
@@ -546,7 +546,7 @@ void mllinop_apply_innu_xlo (int i, int j, int k,
                              Array4<Real const> const& bcval,
                              Real fac, bool has_bcoef, int icomp) noexcept
 {
-    if (bct == AMREX_LO_NEUMANN and mask(i,j,k) == 2) {
+    if (bct == AMREX_LO_NEUMANN && mask(i,j,k) == 2) {
         Real b = (has_bcoef) ? bcoef(i+1,j,k,icomp) : Real(1.0);
         rhs(i+1,j,k,icomp) -= fac*b*bcval(i,j,k,icomp);
     }
@@ -561,7 +561,7 @@ void mllinop_apply_innu_xhi (int i, int j, int k,
                              Array4<Real const> const& bcval,
                              Real fac, bool has_bcoef, int icomp) noexcept
 {
-    if (bct == AMREX_LO_NEUMANN and mask(i,j,k) == 2) {
+    if (bct == AMREX_LO_NEUMANN && mask(i,j,k) == 2) {
         Real b = (has_bcoef) ? bcoef(i,j,k,icomp) : Real(1.0);
         rhs(i-1,j,k,icomp) += fac*b*bcval(i,j,k,icomp);
     }
@@ -576,7 +576,7 @@ void mllinop_apply_innu_ylo (int i, int j, int k,
                              Array4<Real const> const& bcval,
                              Real fac, bool has_bcoef, int icomp) noexcept
 {
-    if (bct == AMREX_LO_NEUMANN and mask(i,j,k) == 2) {
+    if (bct == AMREX_LO_NEUMANN && mask(i,j,k) == 2) {
         Real b = (has_bcoef) ? bcoef(i,j+1,k,icomp) : Real(1.0);
         rhs(i,j+1,k,icomp) -= fac*b*bcval(i,j,k,icomp);
     }
@@ -590,7 +590,7 @@ void mllinop_apply_innu_ylo_m (int i, int j, int k,
                                Array4<Real const> const& bcval,
                                Real fac, Real xlo, Real dx, int icomp) noexcept
 {
-    if (bct == AMREX_LO_NEUMANN and mask(i,j,k) == 2) {
+    if (bct == AMREX_LO_NEUMANN && mask(i,j,k) == 2) {
         Real b = xlo + (i+0.5)*dx;
         rhs(i,j+1,k,icomp) -= fac*b*bcval(i,j,k,icomp);
     }
@@ -605,7 +605,7 @@ void mllinop_apply_innu_yhi (int i, int j, int k,
                              Array4<Real const> const& bcval,
                              Real fac, bool has_bcoef, int icomp) noexcept
 {
-    if (bct == AMREX_LO_NEUMANN and mask(i,j,k) == 2) {
+    if (bct == AMREX_LO_NEUMANN && mask(i,j,k) == 2) {
         Real b = (has_bcoef) ? bcoef(i,j,k,icomp) : Real(1.0);
         rhs(i,j-1,k,icomp) += fac*b*bcval(i,j,k,icomp);
     }
@@ -619,7 +619,7 @@ void mllinop_apply_innu_yhi_m (int i, int j, int k,
                                Array4<Real const> const& bcval,
                                Real fac, Real xlo, Real dx, int icomp) noexcept
 {
-    if (bct == AMREX_LO_NEUMANN and mask(i,j,k) == 2) {
+    if (bct == AMREX_LO_NEUMANN && mask(i,j,k) == 2) {
         Real b = xlo + (i+0.5)*dx;
         rhs(i,j-1,k,icomp) += fac*b*bcval(i,j,k,icomp);
     }
@@ -634,7 +634,7 @@ void mllinop_apply_innu_zlo (int i, int j, int k,
                              Array4<Real const> const& bcval,
                              Real fac, bool has_bcoef, int icomp) noexcept
 {
-    if (bct == AMREX_LO_NEUMANN and mask(i,j,k) == 2) {
+    if (bct == AMREX_LO_NEUMANN && mask(i,j,k) == 2) {
         Real b = (has_bcoef) ? bcoef(i,j,k+1,icomp) : Real(1.0);
         rhs(i,j,k+1,icomp) -= fac*b*bcval(i,j,k,icomp);
     }
@@ -649,7 +649,7 @@ void mllinop_apply_innu_zhi (int i, int j, int k,
                              Array4<Real const> const& bcval,
                              Real fac, bool has_bcoef, int icomp) noexcept
 {
-    if (bct == AMREX_LO_NEUMANN and mask(i,j,k) == 2) {
+    if (bct == AMREX_LO_NEUMANN && mask(i,j,k) == 2) {
         Real b = (has_bcoef) ? bcoef(i,j,k,icomp) : Real(1.0);
         rhs(i,j,k-1,icomp) += fac*b*bcval(i,j,k,icomp);
     }

--- a/Src/LinearSolvers/MLMG/AMReX_MLMG.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLMG.cpp
@@ -104,7 +104,7 @@ MLMG::solve (const Vector<MultiFab*>& a_sol, const Vector<MultiFab const*>& a_rh
 
     Real max_norm;
     std::string norm_name;
-    if (always_use_bnorm or rhsnorm0 >= resnorm0) {
+    if (always_use_bnorm || rhsnorm0 >= resnorm0) {
         norm_name = "bnorm";
         max_norm = rhsnorm0;
     } else {
@@ -143,7 +143,7 @@ MLMG::solve (const Vector<MultiFab*>& a_sol, const Vector<MultiFab const*>& a_rh
             }
             bool fine_converged = (fine_norminf <= res_target);
 
-            if (namrlevs == 1 and fine_converged) {
+            if (namrlevs == 1 && fine_converged) {
                 converged = true;
             } else if (fine_converged) {
                 // finest level is converged, but we still need to test the coarse levels
@@ -696,7 +696,7 @@ MLMG::interpCorrection (int alev)
         for (MFIter mfi(fine_cor, TilingIfNotGPU()); mfi.isValid(); ++mfi)
         {
             Box fbx = mfi.tilebox();
-            if (cf_strategy == CFStrategy::ghostnodes and nghost >1) fbx.grow(2);
+            if (cf_strategy == CFStrategy::ghostnodes && nghost >1) fbx.grow(2);
             Array4<Real> const& ffab = fine_cor.array(mfi);
             Array4<Real const> const& cfab = cfine.const_array(mfi);
 

--- a/Src/LinearSolvers/MLMG/AMReX_MLMG_2D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLMG_2D_K.H
@@ -82,7 +82,7 @@ void mlmg_lin_nd_interp (int i, int j, int, int n, Array4<Real> const& fine,
     int jc = amrex::coarsen(j,2);
     bool i_is_odd = (ic*2 != i);
     bool j_is_odd = (jc*2 != j);
-    if (i_is_odd and j_is_odd) {
+    if (i_is_odd && j_is_odd) {
         // Fine node at center of cell
         fine(i,j,0,n) = 0.25*(crse(ic,jc,0,n) + crse(ic+1,jc,0,n) +
                               crse(ic,jc+1,0,n) + crse(ic+1,jc+1,0,n));

--- a/Src/LinearSolvers/MLMG/AMReX_MLMG_3D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLMG_3D_K.H
@@ -97,21 +97,21 @@ void mlmg_lin_nd_interp (int i, int j, int k, int n, Array4<Real> const& fine,
     bool i_is_odd = (ic*2 != i);
     bool j_is_odd = (jc*2 != j);
     bool k_is_odd = (kc*2 != k);
-    if (i_is_odd and j_is_odd and k_is_odd) {
+    if (i_is_odd && j_is_odd && k_is_odd) {
         // Fine node at center of cell
         fine(i,j,k,n) = 0.125*(crse(ic,  jc,  kc,n) + crse(ic,  jc,  kc+1,n) +
                                crse(ic,  jc+1,kc,n) + crse(ic,  jc+1,kc+1,n) +
                                crse(ic+1,jc,  kc,n) + crse(ic+1,jc,  kc+1,n) +
                                crse(ic+1,jc+1,kc,n) + crse(ic+1,jc+1,kc+1,n));
-    } else if (j_is_odd and k_is_odd) {
+    } else if (j_is_odd && k_is_odd) {
         // Node on a Y-Z face
         fine(i,j,k,n) = 0.25*(crse(ic,  jc,  kc,n) + crse(ic,  jc,  kc+1,n) +
                               crse(ic,  jc+1,kc,n) + crse(ic,  jc+1,kc+1,n));
-    } else if (i_is_odd and k_is_odd) {
+    } else if (i_is_odd && k_is_odd) {
         // Node on a Z-X face
         fine(i,j,k,n) = 0.25*(crse(ic,  jc,kc,n) + crse(ic,  jc,kc+1,n) +
                               crse(ic+1,jc,kc,n) + crse(ic+1,jc,kc+1,n));
-    } else if (i_is_odd and j_is_odd) {
+    } else if (i_is_odd && j_is_odd) {
         // Node on a X-Y face
         fine(i,j,k,n) = 0.25*(crse(ic  ,jc,kc,n) + crse(ic  ,jc+1,kc,n) +
                               crse(ic+1,jc,kc,n) + crse(ic+1,jc+1,kc,n));

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLap_2D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLap_2D_K.H
@@ -36,34 +36,34 @@ void mlndlap_set_dirichlet_mask (Box const& bx, Array4<int> const& dmsk,
     AMREX_PRAGMA_SIMD
     for (int i = lo.x; i <= hi.x; ++i) {
         if (!dmsk(i,j,0)) {
-            dmsk(i,j,0) = (omsk(i-1,j-1,0) == 1 or omsk(i,j-1,0) == 1 or
-                           omsk(i-1,j  ,0) == 1 or omsk(i,j  ,0) == 1);
+            dmsk(i,j,0) = (omsk(i-1,j-1,0) == 1 || omsk(i,j-1,0) == 1 ||
+                           omsk(i-1,j  ,0) == 1 || omsk(i,j  ,0) == 1);
         }
     }}
 
     const auto domlo = amrex::lbound(dom);
     const auto domhi = amrex::ubound(dom);
 
-    if (bclo[0] == LinOpBCType::Dirichlet and lo.x == domlo.x) {
+    if (bclo[0] == LinOpBCType::Dirichlet && lo.x == domlo.x) {
         for (int j = lo.y; j <= hi.y; ++j) {
             dmsk(lo.x,j,0) = 1;
         }
     }
 
-    if (bchi[0] == LinOpBCType::Dirichlet and hi.x == domhi.x) {
+    if (bchi[0] == LinOpBCType::Dirichlet && hi.x == domhi.x) {
         for (int j = lo.y; j <= hi.y; ++j) {
             dmsk(hi.x,j,0) = 1;
         }
     }
 
-    if (bclo[1] == LinOpBCType::Dirichlet and lo.y == domlo.y) {
+    if (bclo[1] == LinOpBCType::Dirichlet && lo.y == domlo.y) {
         AMREX_PRAGMA_SIMD
         for (int i = lo.x; i <= hi.x; ++i) {
             dmsk(i,lo.y,0) = 1;
         }
     }
 
-    if (bchi[1] == LinOpBCType::Dirichlet and hi.y == domhi.y) {
+    if (bchi[1] == LinOpBCType::Dirichlet && hi.y == domhi.y) {
         AMREX_PRAGMA_SIMD
         for (int i = lo.x; i <= hi.x; ++i) {
             dmsk(i,hi.y,0) = 1;
@@ -88,24 +88,24 @@ void mlndlap_set_dot_mask (Box const& bx, Array4<Real> const& dmsk,
     const auto domlo = amrex::lbound(dom);
     const auto domhi = amrex::ubound(dom);
 
-    if ((bclo[0] == LinOpBCType::Neumann or bclo[0] == LinOpBCType::inflow)
-        and lo.x == domlo.x)
+    if ((bclo[0] == LinOpBCType::Neumann || bclo[0] == LinOpBCType::inflow)
+        && lo.x == domlo.x)
     {
         for (int j = lo.y; j <= hi.y; ++j) {
             dmsk(lo.x,j,0) *= 0.5;
         }
     }
 
-    if ((bchi[0] == LinOpBCType::Neumann or bchi[0] == LinOpBCType::inflow)
-        and hi.x == domhi.x)
+    if ((bchi[0] == LinOpBCType::Neumann || bchi[0] == LinOpBCType::inflow)
+        && hi.x == domhi.x)
     {
         for (int j = lo.y; j <= hi.y; ++j) {
             dmsk(hi.x,j,0) *= 0.5;
         }
     }
 
-    if ((bclo[1] == LinOpBCType::Neumann or bclo[1] == LinOpBCType::inflow)
-        and lo.y == domlo.y)
+    if ((bclo[1] == LinOpBCType::Neumann || bclo[1] == LinOpBCType::inflow)
+        && lo.y == domlo.y)
     {
         AMREX_PRAGMA_SIMD
         for (int i = lo.x; i <= hi.x; ++i) {
@@ -113,8 +113,8 @@ void mlndlap_set_dot_mask (Box const& bx, Array4<Real> const& dmsk,
         }
     }
 
-    if ((bchi[1] == LinOpBCType::Neumann or bchi[1] == LinOpBCType::inflow)
-        and hi.y == domhi.y)
+    if ((bchi[1] == LinOpBCType::Neumann || bchi[1] == LinOpBCType::inflow)
+        && hi.y == domhi.y)
     {
         AMREX_PRAGMA_SIMD
         for (int i = lo.x; i <= hi.x; ++i) {
@@ -129,9 +129,9 @@ void mlndlap_zero_fine (int i, int j, int, Array4<Real> const& phi,
 {
     // Testing if the node is covered by a fine level in computing
     // coarse sync residual
-    if (msk(i-1,j-1,0) == fine_flag and
-        msk(i  ,j-1,0) == fine_flag and
-        msk(i-1,j  ,0) == fine_flag and
+    if (msk(i-1,j-1,0) == fine_flag &&
+        msk(i  ,j-1,0) == fine_flag &&
+        msk(i-1,j  ,0) == fine_flag &&
         msk(i  ,j  ,0) == fine_flag)
     {
         phi(i,j,0) = Real(0.0);
@@ -186,8 +186,8 @@ void mlndlap_bc_doit (Box const& vbx, Array4<T> const& a, Box const& domain,
 {
     Box gdomain = domain;
     for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-        if (not bflo[idim]) gdomain.growLo(idim,1);
-        if (not bfhi[idim]) gdomain.growHi(idim,1);
+        if (! bflo[idim]) gdomain.growLo(idim,1);
+        if (! bfhi[idim]) gdomain.growHi(idim,1);
     }
 
     if (gdomain.strictly_contains(vbx)) return;
@@ -200,11 +200,11 @@ void mlndlap_bc_doit (Box const& vbx, Array4<T> const& a, Box const& domain,
     Box const& sbox = amrex::grow(vbx,1);
     AMREX_HOST_DEVICE_FOR_3D(sbox, i, j, k,
     {
-        if (not gdomain.contains(IntVect(i,j))) {
+        if (! gdomain.contains(IntVect(i,j))) {
             // xlo & ylo
-            if (i == dlo.x-1 and j == dlo.y-1 and (bflo[0] or bflo[1]))
+            if (i == dlo.x-1 && j == dlo.y-1 && (bflo[0] || bflo[1]))
             {
-                if (bflo[0] and bflo[1])
+                if (bflo[0] && bflo[1])
                 {
                     a(i,j,k) = a(i+1+offset, j+1+offset, k);
                 }
@@ -218,9 +218,9 @@ void mlndlap_bc_doit (Box const& vbx, Array4<T> const& a, Box const& domain,
                 }
             }
             // xhi & ylo
-            else if (i == dhi.x+1 and j == dlo.y-1 and (bfhi[0] or bflo[1]))
+            else if (i == dhi.x+1 && j == dlo.y-1 && (bfhi[0] || bflo[1]))
             {
-                if (bfhi[0] and bflo[1])
+                if (bfhi[0] && bflo[1])
                 {
                     a(i,j,k) = a(i-1-offset, j+1+offset, k);
                 }
@@ -234,9 +234,9 @@ void mlndlap_bc_doit (Box const& vbx, Array4<T> const& a, Box const& domain,
                 }
             }
             // xlo & yhi
-            else if (i == dlo.x-1 and j == dhi.y+1 and (bflo[0] or bfhi[1]))
+            else if (i == dlo.x-1 && j == dhi.y+1 && (bflo[0] || bfhi[1]))
             {
-                if (bflo[0] and bfhi[1])
+                if (bflo[0] && bfhi[1])
                 {
                     a(i,j,k) = a(i+1+offset, j-1-offset, k);
                 }
@@ -250,9 +250,9 @@ void mlndlap_bc_doit (Box const& vbx, Array4<T> const& a, Box const& domain,
                 }
             }
             // xhi & yhi
-            else if (i == dhi.x+1 and j == dhi.y+1 and (bfhi[0] or bfhi[1]))
+            else if (i == dhi.x+1 && j == dhi.y+1 && (bfhi[0] || bfhi[1]))
             {
-                if (bfhi[0] and bfhi[1])
+                if (bfhi[0] && bfhi[1])
                 {
                     a(i,j,k) = a(i-1-offset, j-1-offset, k);
                 }
@@ -265,19 +265,19 @@ void mlndlap_bc_doit (Box const& vbx, Array4<T> const& a, Box const& domain,
                     a(i,j,k) = a(i, j-1-offset, k);
                 }
             }
-            else if (i == dlo.x-1 and bflo[0])
+            else if (i == dlo.x-1 && bflo[0])
             {
                 a(i,j,k) = a(i+1+offset, j, k);
             }
-            else if (i == dhi.x+1 and bfhi[0])
+            else if (i == dhi.x+1 && bfhi[0])
             {
                 a(i,j,k) = a(i-1-offset, j, k);
             }
-            else if (j == dlo.y-1 and bflo[1])
+            else if (j == dlo.y-1 && bflo[1])
             {
                 a(i,j,k) = a(i, j+1+offset, k);
             }
-            else if (j == dhi.y+1 and bfhi[1])
+            else if (j == dhi.y+1 && bfhi[1])
             {
                 a(i,j,k) = a(i, j-1-offset, k);
             }
@@ -747,7 +747,7 @@ void mlndlap_interpadd_aa (int i, int j, int, Array4<Real> const& fine,
         int jc = amrex::coarsen(j,2);
         bool i_is_odd = (ic*2 != i);
         bool j_is_odd = (jc*2 != j);
-        if (i_is_odd and j_is_odd) {
+        if (i_is_odd && j_is_odd) {
             // Node on a X-Y face
             fine(i,j,0) += aa_interp_face_xy(crse,sig,i,j,ic,jc);
         } else if (i_is_odd) {
@@ -825,7 +825,7 @@ void mlndlap_interpadd_ha (int i, int j, int,
         int jc = amrex::coarsen(j,2);
         bool i_is_odd = (ic*2 != i);
         bool j_is_odd = (jc*2 != j);
-        if (i_is_odd and j_is_odd) {
+        if (i_is_odd && j_is_odd) {
             // Node on a X-Y face
             fine(i,j,0) += ha_interp_face_xy(crse,sigx,sigy,i,j,ic,jc);
         } else if (i_is_odd) {
@@ -870,14 +870,14 @@ void mlndlap_divu (int i, int j, int k, Array4<Real> const& rhs, Array4<Real con
 
         // The nodal divergence operator should not see the tangential velocity
         //     at an inflow face
-        if ((bclo[0] == LinOpBCType::Neumann or bclo[0] == LinOpBCType::inflow)
-            and i == domlo.x) zero_ilo = 0.0;
-        if ((bchi[0] == LinOpBCType::Neumann or bchi[0] == LinOpBCType::inflow)
-            and i == domhi.x) zero_ihi = 0.0;
-        if ((bclo[1] == LinOpBCType::Neumann or bclo[1] == LinOpBCType::inflow)
-            and j == domlo.y) zero_jlo = 0.0;
-        if ((bchi[1] == LinOpBCType::Neumann or bchi[1] == LinOpBCType::inflow)
-            and j == domhi.y) zero_jhi = 0.0; 
+        if ((bclo[0] == LinOpBCType::Neumann || bclo[0] == LinOpBCType::inflow)
+            && i == domlo.x) zero_ilo = 0.0;
+        if ((bchi[0] == LinOpBCType::Neumann || bchi[0] == LinOpBCType::inflow)
+            && i == domhi.x) zero_ihi = 0.0;
+        if ((bclo[1] == LinOpBCType::Neumann || bclo[1] == LinOpBCType::inflow)
+            && j == domlo.y) zero_jlo = 0.0;
+        if ((bchi[1] == LinOpBCType::Neumann || bchi[1] == LinOpBCType::inflow)
+            && j == domhi.y) zero_jhi = 0.0; 
 
         rhs(i,j,k) = facx*(-vel(i-1,j-1,k,0)*zero_jlo + vel(i,j-1,k,0)*zero_jlo
                            -vel(i-1,j  ,k,0)*zero_jhi + vel(i,j  ,k,0)*zero_jhi)
@@ -934,7 +934,7 @@ void mlndlap_divu_compute_fine_contrib (int i, int j, int, Box const& fvbx,
     const auto domhi = amrex::ubound(nodal_domain);
 
     IntVect iv(i,j);
-    if (fvbx.contains(iv) and !fvbx.strictly_contains(iv))
+    if (fvbx.contains(iv) && !fvbx.strictly_contains(iv))
     {
         Real zero_ilo = 1.0;
         Real zero_ihi = 1.0;
@@ -943,14 +943,14 @@ void mlndlap_divu_compute_fine_contrib (int i, int j, int, Box const& fvbx,
 
         // The nodal divergence operator should not see the tangential velocity
         //     at an inflow face
-        if ((bclo[0] == LinOpBCType::Neumann or bclo[0] == LinOpBCType::inflow)
-            and i == domlo.x) zero_ilo = 0.0;
-        if ((bchi[0] == LinOpBCType::Neumann or bchi[0] == LinOpBCType::inflow)
-            and i == domhi.x) zero_ihi = 0.0;
-        if ((bclo[1] == LinOpBCType::Neumann or bclo[1] == LinOpBCType::inflow)
-            and j == domlo.y) zero_jlo = 0.0;
-        if ((bchi[1] == LinOpBCType::Neumann or bchi[1] == LinOpBCType::inflow)
-            and j == domhi.y) zero_jhi = 0.0; 
+        if ((bclo[0] == LinOpBCType::Neumann || bclo[0] == LinOpBCType::inflow)
+            && i == domlo.x) zero_ilo = 0.0;
+        if ((bchi[0] == LinOpBCType::Neumann || bchi[0] == LinOpBCType::inflow)
+            && i == domhi.x) zero_ihi = 0.0;
+        if ((bclo[1] == LinOpBCType::Neumann || bclo[1] == LinOpBCType::inflow)
+            && j == domlo.y) zero_jlo = 0.0;
+        if ((bchi[1] == LinOpBCType::Neumann || bchi[1] == LinOpBCType::inflow)
+            && j == domhi.y) zero_jhi = 0.0; 
 
         Real facx = Real(0.5)*dxinv[0];
         Real facy = Real(0.5)*dxinv[1];
@@ -980,7 +980,7 @@ void mlndlap_divu_add_fine_contrib (int i, int j, int /*k*/, Box const& fvbx,
     int ii = 2*i;
     int jj = 2*j;
     IntVect iv(ii,jj);
-    if (fvbx.contains(iv) and !fvbx.strictly_contains(iv) and msk(ii,jj,0))
+    if (fvbx.contains(iv) && !fvbx.strictly_contains(iv) && msk(ii,jj,0))
     {
         rhs(i,j,0) +=
             rfd*(frh(ii,jj,0)
@@ -1001,7 +1001,7 @@ void mlndlap_rhcc_fine_contrib (int i, int j, int, Box const& fvbx,
     int ii = 2*i;
     int jj = 2*j;
     IntVect iv(ii,jj);
-    if (fvbx.contains(iv) and !fvbx.strictly_contains(iv) and msk(ii,jj,0))
+    if (fvbx.contains(iv) && !fvbx.strictly_contains(iv) && msk(ii,jj,0))
     {
         rhs(i,j,0) += w1*(cc(ii-1,jj-1,0)+cc(ii  ,jj-1,0)+cc(ii-1,jj  ,0)+cc(ii  ,jj  ,0))
                     + w2*(cc(ii-2,jj-1,0)+cc(ii+1,jj-1,0)+cc(ii-2,jj  ,0)+cc(ii+1,jj  ,0)
@@ -1020,7 +1020,7 @@ void mlndlap_divu_cf_contrib (int i, int j, int, Array4<Real> const& rhs,
                               GpuArray<LinOpBCType,AMREX_SPACEDIM> const& bchi,
                               bool neumann_doubling) noexcept
 {
-    if (!dmsk(i,j,0) and ndmsk(i,j,0) == crse_fine_node) {
+    if (!dmsk(i,j,0) && ndmsk(i,j,0) == crse_fine_node) {
         Real facx = Real(0.5) * dxinv[0];
         Real facy = Real(0.5) * dxinv[1];
         Real r = fc(i,j,0);
@@ -1046,18 +1046,18 @@ void mlndlap_divu_cf_contrib (int i, int j, int, Array4<Real> const& rhs,
         if (neumann_doubling) {
             const auto ndlo = amrex::lbound(nddom);
             const auto ndhi = amrex::ubound(nddom);
-            if (i == ndlo.x and ( bclo[0] == LinOpBCType::Neumann or
+            if (i == ndlo.x && ( bclo[0] == LinOpBCType::Neumann ||
                                   bclo[0] == LinOpBCType::inflow)) {
                 r *= Real(2.);
-            } else if (i== ndhi.x and ( bchi[0] == LinOpBCType::Neumann or
+            } else if (i== ndhi.x && ( bchi[0] == LinOpBCType::Neumann ||
                                         bchi[0] == LinOpBCType::inflow)) {
                 r *= Real(2.);
             }
 
-            if (j == ndlo.y and ( bclo[1] == LinOpBCType::Neumann or
+            if (j == ndlo.y && ( bclo[1] == LinOpBCType::Neumann ||
                                   bclo[1] == LinOpBCType::inflow)) {
                 r *= Real(2.);
-            } else if (j == ndhi.y and ( bchi[1] == LinOpBCType::Neumann or
+            } else if (j == ndhi.y && ( bchi[1] == LinOpBCType::Neumann ||
                                          bchi[1] == LinOpBCType::inflow)) {
                 r *= Real(2.);
             }
@@ -1078,30 +1078,30 @@ void mlndlap_crse_resid (int i, int j, int k, Array4<Real> const& resid,
                          GpuArray<LinOpBCType,AMREX_SPACEDIM> const& bchi,
                          bool neumann_doubling) noexcept
 {
-    if ((msk(i-1,j-1,k  ) == 0 or
-         msk(i  ,j-1,k  ) == 0 or
-         msk(i-1,j  ,k  ) == 0 or
-         msk(i  ,j  ,k  ) == 0) and
-        (msk(i-1,j-1,k  ) == 0 or
-         msk(i  ,j-1,k  ) == 0 or
-         msk(i-1,j  ,k  ) == 0 or
+    if ((msk(i-1,j-1,k  ) == 0 ||
+         msk(i  ,j-1,k  ) == 0 ||
+         msk(i-1,j  ,k  ) == 0 ||
+         msk(i  ,j  ,k  ) == 0) &&
+        (msk(i-1,j-1,k  ) == 0 ||
+         msk(i  ,j-1,k  ) == 0 ||
+         msk(i-1,j  ,k  ) == 0 ||
          msk(i  ,j  ,k  ) == 0))
     {
         Real fac = Real(1.0);
         if (neumann_doubling) {
             const auto ndlo = amrex::lbound(nddom);
             const auto ndhi = amrex::ubound(nddom);
-            if (i == ndlo.x and ( bclo[0] == LinOpBCType::Neumann or
+            if (i == ndlo.x && ( bclo[0] == LinOpBCType::Neumann ||
                                   bclo[0] == LinOpBCType::inflow)) {
                 fac *= Real(2.);
-            } else if (i== ndhi.x and ( bchi[0] == LinOpBCType::Neumann or
+            } else if (i== ndhi.x && ( bchi[0] == LinOpBCType::Neumann ||
                                         bchi[0] == LinOpBCType::inflow)) {
                 fac *= Real(2.);
             }
-            if (j == ndlo.y and ( bclo[1] == LinOpBCType::Neumann or
+            if (j == ndlo.y && ( bclo[1] == LinOpBCType::Neumann ||
                                   bclo[1] == LinOpBCType::inflow)) {
                 fac *= Real(2.);
-            } else if (j == ndhi.y and ( bchi[1] == LinOpBCType::Neumann or
+            } else if (j == ndhi.y && ( bchi[1] == LinOpBCType::Neumann ||
                                          bchi[1] == LinOpBCType::inflow)) {
                 fac *= Real(2.);
             }
@@ -1124,7 +1124,7 @@ void mlndlap_res_fine_Ax (int i, int j, int, Box const& fvbx, Array4<Real> const
                           GpuArray<Real,AMREX_SPACEDIM> const& dxinv) noexcept
 {
     IntVect iv(i,j);
-    if (fvbx.contains(iv) and !fvbx.strictly_contains(iv)) {
+    if (fvbx.contains(iv) && !fvbx.strictly_contains(iv)) {
         Real facx = Real(1./6.)*dxinv[0]*dxinv[0];
         Real facy = Real(1./6.)*dxinv[1]*dxinv[1];
         Real fxy = facx + facy;
@@ -1180,7 +1180,7 @@ void mlndlap_res_cf_contrib (int i, int j, int, Array4<Real> const& res,
                              GpuArray<LinOpBCType, AMREX_SPACEDIM> const& bchi,
                              bool neumann_doubling) noexcept
 {
-    if (!dmsk(i,j,0) and ndmsk(i,j,0) == crse_fine_node) {
+    if (!dmsk(i,j,0) && ndmsk(i,j,0) == crse_fine_node) {
         Real facx = Real(1./6.)*dxinv[0]*dxinv[0];
         Real facy = Real(1./6.)*dxinv[1]*dxinv[1];
 
@@ -1233,18 +1233,18 @@ void mlndlap_res_cf_contrib (int i, int j, int, Array4<Real> const& res,
             const auto ndlo = amrex::lbound(nddom);
             const auto ndhi = amrex::ubound(nddom);
 
-            if (i == ndlo.x and (bclo[0] == LinOpBCType::Neumann or
+            if (i == ndlo.x && (bclo[0] == LinOpBCType::Neumann ||
                                  bclo[0] == LinOpBCType::inflow)) {
                 Axf *= Real(2.);
-            } else if (i== ndhi.x and (bchi[0] == LinOpBCType::Neumann or
+            } else if (i== ndhi.x && (bchi[0] == LinOpBCType::Neumann ||
                                        bchi[0] == LinOpBCType::inflow)) {
                 Axf *= Real(2.);
             }
 
-            if (j == ndlo.y and (bclo[1] == LinOpBCType::Neumann or
+            if (j == ndlo.y && (bclo[1] == LinOpBCType::Neumann ||
                                  bclo[1] == LinOpBCType::inflow)) {
                 Axf *= Real(2.);
-            } else if (j == ndhi.y and (bchi[1] == LinOpBCType::Neumann or
+            } else if (j == ndhi.y && (bchi[1] == LinOpBCType::Neumann ||
                                         bchi[1] == LinOpBCType::inflow)) {
                 Axf *= Real(2.);
             }
@@ -1566,13 +1566,13 @@ void mlndlap_interpadd_rap (int i, int j, int, Array4<Real> const& fine,
                             Array4<Real const> const& crse, Array4<Real const> const& sten,
                             Array4<int const> const& msk) noexcept
 {
-    if (!msk(i,j,0) and sten(i,j,0,0) != 0.0) {
+    if (!msk(i,j,0) && sten(i,j,0,0) != 0.0) {
         int ic = amrex::coarsen(i,2);
         int jc = amrex::coarsen(j,2);
         bool ieven = ic*2 == i;
         bool jeven = jc*2 == j;
         Real fv;
-        if (ieven and jeven) {
+        if (ieven && jeven) {
             fv = crse(ic,jc,0);
         } else if (ieven) {
             Real wym = amrex::Math::abs(sten(i,j-1,0,2));
@@ -1687,7 +1687,7 @@ void mlndlap_set_connection (int i, int j, int, Array4<Real> const& conn,
 {
     if (flag(i,j,0).isCovered()) {
         for (int n = 0; n < 6; ++n) conn(i,j,0,n) = Real(0.);
-    } else if (flag(i,j,0).isRegular() or vol(i,j,0) >= almostone) {
+    } else if (flag(i,j,0).isRegular() || vol(i,j,0) >= almostone) {
         for (int n = 0; n < 6; ++n) conn(i,j,0,n) = Real(1.);
     } else {
         // Note that these are normalized so that they equal 1 in the case of a regular cell
@@ -1741,14 +1741,14 @@ void mlndlap_divu_eb (int i, int j, int, Array4<Real> const& rhs, Array4<Real co
 
         // The nodal divergence operator should not see the tangential velocity
         //     at an inflow face
-        if ((bclo[0] == LinOpBCType::Neumann or bclo[0] == LinOpBCType::inflow)
-            and i == domlo.x) zero_ilo = 0.0;
-        if ((bchi[0] == LinOpBCType::Neumann or bchi[0] == LinOpBCType::inflow)
-            and i == domhi.x) zero_ihi = 0.0;
-        if ((bclo[1] == LinOpBCType::Neumann or bclo[1] == LinOpBCType::inflow)
-            and j == domlo.y) zero_jlo = 0.0;
-        if ((bchi[1] == LinOpBCType::Neumann or bchi[1] == LinOpBCType::inflow)
-            and j == domhi.y) zero_jhi = 0.0; 
+        if ((bclo[0] == LinOpBCType::Neumann || bclo[0] == LinOpBCType::inflow)
+            && i == domlo.x) zero_ilo = 0.0;
+        if ((bchi[0] == LinOpBCType::Neumann || bchi[0] == LinOpBCType::inflow)
+            && i == domhi.x) zero_ihi = 0.0;
+        if ((bclo[1] == LinOpBCType::Neumann || bclo[1] == LinOpBCType::inflow)
+            && j == domlo.y) zero_jlo = 0.0;
+        if ((bchi[1] == LinOpBCType::Neumann || bchi[1] == LinOpBCType::inflow)
+            && j == domhi.y) zero_jhi = 0.0; 
 
         rhs(i,j,0) = facx*(-vel(i-1,j-1,0,0)*(vfrac(i-1,j-1,0)+Real(2.)*intg(i-1,j-1,0,1))*zero_jlo
                            +vel(i  ,j-1,0,0)*(vfrac(i  ,j-1,0)+Real(2.)*intg(i  ,j-1,0,1))*zero_jlo
@@ -1819,7 +1819,7 @@ void mlndlap_set_integral_eb (int i, int j, int, Array4<Real> const& intg,
         intg(i,j,0,i_S_x2) = Real(0.);
         intg(i,j,0,i_S_y2) = Real(0.);
         intg(i,j,0,i_S_xy) = Real(0.);
-    } else if (flag(i,j,0).isRegular() or vol(i,j,0) >= almostone) {
+    } else if (flag(i,j,0).isRegular() || vol(i,j,0) >= almostone) {
         intg(i,j,0,i_S_x ) = Real(0.);
         intg(i,j,0,i_S_y ) = Real(0.);
         intg(i,j,0,i_S_x2) = Real(1./12.);

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLap_3D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLap_3D_K.H
@@ -39,31 +39,31 @@ void mlndlap_set_dirichlet_mask (Box const& bx, Array4<int> const& dmsk,
     AMREX_PRAGMA_SIMD
     for (int i = lo.x; i <= hi.x; ++i) {
         if (!dmsk(i,j,k)) {
-            dmsk(i,j,k) = (omsk(i-1,j-1,k-1) == 1 or omsk(i,j-1,k-1) == 1 or
-                           omsk(i-1,j  ,k-1) == 1 or omsk(i,j  ,k-1) == 1 or
-                           omsk(i-1,j-1,k  ) == 1 or omsk(i,j-1,k  ) == 1 or
-                           omsk(i-1,j  ,k  ) == 1 or omsk(i,j  ,k  ) == 1);
+            dmsk(i,j,k) = (omsk(i-1,j-1,k-1) == 1 || omsk(i,j-1,k-1) == 1 ||
+                           omsk(i-1,j  ,k-1) == 1 || omsk(i,j  ,k-1) == 1 ||
+                           omsk(i-1,j-1,k  ) == 1 || omsk(i,j-1,k  ) == 1 ||
+                           omsk(i-1,j  ,k  ) == 1 || omsk(i,j  ,k  ) == 1);
         }
     }}}
 
     const auto domlo = amrex::lbound(dom);
     const auto domhi = amrex::ubound(dom);
 
-    if (bclo[0] == LinOpBCType::Dirichlet and lo.x == domlo.x) {
+    if (bclo[0] == LinOpBCType::Dirichlet && lo.x == domlo.x) {
         for (int k = lo.z; k <= hi.z; ++k) {
         for (int j = lo.y; j <= hi.y; ++j) {
             dmsk(lo.x,j,k) = 1;
         }}
     }
 
-    if (bchi[0] == LinOpBCType::Dirichlet and hi.x == domhi.x) {
+    if (bchi[0] == LinOpBCType::Dirichlet && hi.x == domhi.x) {
         for (int k = lo.z; k <= hi.z; ++k) {
         for (int j = lo.y; j <= hi.y; ++j) {
             dmsk(hi.x,j,k) = 1;
         }}
     }
 
-    if (bclo[1] == LinOpBCType::Dirichlet and lo.y == domlo.y) {
+    if (bclo[1] == LinOpBCType::Dirichlet && lo.y == domlo.y) {
         for (int k = lo.z; k <= hi.z; ++k) {
         AMREX_PRAGMA_SIMD
         for (int i = lo.x; i <= hi.x; ++i) {
@@ -71,7 +71,7 @@ void mlndlap_set_dirichlet_mask (Box const& bx, Array4<int> const& dmsk,
         }}
     }
 
-    if (bchi[1] == LinOpBCType::Dirichlet and hi.y == domhi.y) {
+    if (bchi[1] == LinOpBCType::Dirichlet && hi.y == domhi.y) {
         for (int k = lo.z; k <= hi.z; ++k) {
         AMREX_PRAGMA_SIMD
         for (int i = lo.x; i <= hi.x; ++i) {
@@ -79,7 +79,7 @@ void mlndlap_set_dirichlet_mask (Box const& bx, Array4<int> const& dmsk,
         }}
     }
 
-    if (bclo[2] == LinOpBCType::Dirichlet and lo.z == domlo.z) {
+    if (bclo[2] == LinOpBCType::Dirichlet && lo.z == domlo.z) {
         for (int j = lo.y; j <= hi.y; ++j) {
         AMREX_PRAGMA_SIMD
         for (int i = lo.x; i <= hi.x; ++i) {
@@ -87,7 +87,7 @@ void mlndlap_set_dirichlet_mask (Box const& bx, Array4<int> const& dmsk,
         }}
     }
 
-    if (bchi[2] == LinOpBCType::Dirichlet and hi.z == domhi.z) {
+    if (bchi[2] == LinOpBCType::Dirichlet && hi.z == domhi.z) {
         for (int j = lo.y; j <= hi.y; ++j) {
         AMREX_PRAGMA_SIMD
         for (int i = lo.x; i <= hi.x; ++i) {
@@ -114,8 +114,8 @@ void mlndlap_set_dot_mask (Box const& bx, Array4<Real> const& dmsk,
     const auto domlo = amrex::lbound(dom);
     const auto domhi = amrex::ubound(dom);
 
-    if ((bclo[0] == LinOpBCType::Neumann or bclo[0] == LinOpBCType::inflow)
-        and lo.x == domlo.x)
+    if ((bclo[0] == LinOpBCType::Neumann || bclo[0] == LinOpBCType::inflow)
+        && lo.x == domlo.x)
     {
         for (int k = lo.z; k <= hi.z; ++k) {
         for (int j = lo.y; j <= hi.y; ++j) {
@@ -123,8 +123,8 @@ void mlndlap_set_dot_mask (Box const& bx, Array4<Real> const& dmsk,
         }}
     }
 
-    if ((bchi[0] == LinOpBCType::Neumann or bchi[0] == LinOpBCType::inflow)
-        and hi.x == domhi.x)
+    if ((bchi[0] == LinOpBCType::Neumann || bchi[0] == LinOpBCType::inflow)
+        && hi.x == domhi.x)
     {
         for (int k = lo.z; k <= hi.z; ++k) {
         for (int j = lo.y; j <= hi.y; ++j) {
@@ -132,8 +132,8 @@ void mlndlap_set_dot_mask (Box const& bx, Array4<Real> const& dmsk,
         }}
     }
 
-    if ((bclo[1] == LinOpBCType::Neumann or bclo[1] == LinOpBCType::inflow)
-        and lo.y == domlo.y)
+    if ((bclo[1] == LinOpBCType::Neumann || bclo[1] == LinOpBCType::inflow)
+        && lo.y == domlo.y)
     {
         for (int k = lo.z; k <= hi.z; ++k) {
         AMREX_PRAGMA_SIMD
@@ -142,8 +142,8 @@ void mlndlap_set_dot_mask (Box const& bx, Array4<Real> const& dmsk,
         }}
     }
 
-    if ((bchi[1] == LinOpBCType::Neumann or bchi[1] == LinOpBCType::inflow)
-        and hi.y == domhi.y)
+    if ((bchi[1] == LinOpBCType::Neumann || bchi[1] == LinOpBCType::inflow)
+        && hi.y == domhi.y)
     {
         for (int k = lo.z; k <= hi.z; ++k) {
         AMREX_PRAGMA_SIMD
@@ -152,8 +152,8 @@ void mlndlap_set_dot_mask (Box const& bx, Array4<Real> const& dmsk,
         }}
     }
 
-    if ((bclo[2] == LinOpBCType::Neumann or bclo[2] == LinOpBCType::inflow)
-        and lo.z == domlo.z)
+    if ((bclo[2] == LinOpBCType::Neumann || bclo[2] == LinOpBCType::inflow)
+        && lo.z == domlo.z)
     {
         for (int j = lo.y; j <= hi.y; ++j) {
         AMREX_PRAGMA_SIMD
@@ -162,8 +162,8 @@ void mlndlap_set_dot_mask (Box const& bx, Array4<Real> const& dmsk,
         }}
     }
 
-    if ((bchi[2] == LinOpBCType::Neumann or bchi[2] == LinOpBCType::inflow)
-        and hi.z == domhi.z)
+    if ((bchi[2] == LinOpBCType::Neumann || bchi[2] == LinOpBCType::inflow)
+        && hi.z == domhi.z)
     {
         for (int j = lo.y; j <= hi.y; ++j) {
         AMREX_PRAGMA_SIMD
@@ -179,13 +179,13 @@ void mlndlap_zero_fine (int i, int j, int k, Array4<Real> const& phi,
 {
     // Testing if the node is covered by a fine level in computing
     // coarse sync residual
-    if (msk(i-1,j-1,k-1) == fine_flag and
-        msk(i  ,j-1,k-1) == fine_flag and
-        msk(i-1,j  ,k-1) == fine_flag and
-        msk(i  ,j  ,k-1) == fine_flag and
-        msk(i-1,j-1,k  ) == fine_flag and
-        msk(i  ,j-1,k  ) == fine_flag and
-        msk(i-1,j  ,k  ) == fine_flag and
+    if (msk(i-1,j-1,k-1) == fine_flag &&
+        msk(i  ,j-1,k-1) == fine_flag &&
+        msk(i-1,j  ,k-1) == fine_flag &&
+        msk(i  ,j  ,k-1) == fine_flag &&
+        msk(i-1,j-1,k  ) == fine_flag &&
+        msk(i  ,j-1,k  ) == fine_flag &&
+        msk(i-1,j  ,k  ) == fine_flag &&
         msk(i  ,j  ,k  ) == fine_flag)
     {
         phi(i,j,k) = 0.0;
@@ -258,8 +258,8 @@ inline void mlndlap_bc_doit (Box const& vbx, Array4<T> const& a, Box const& doma
 {
     Box gdomain = domain;
     for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-        if (not bflo[idim]) gdomain.growLo(idim,1);
-        if (not bfhi[idim]) gdomain.growHi(idim,1);
+        if (! bflo[idim]) gdomain.growLo(idim,1);
+        if (! bfhi[idim]) gdomain.growHi(idim,1);
     }
 
     if (gdomain.strictly_contains(vbx)) return;
@@ -272,23 +272,23 @@ inline void mlndlap_bc_doit (Box const& vbx, Array4<T> const& a, Box const& doma
     Box const& sbox = amrex::grow(vbx,1);
     AMREX_HOST_DEVICE_FOR_3D(sbox, i, j, k,
     {
-        if (not gdomain.contains(IntVect(i,j,k))) {
+        if (! gdomain.contains(IntVect(i,j,k))) {
             // xlo & ylo & zlo
-            if (i == dlo.x-1 and j == dlo.y-1 and k == dlo.z-1 and (bflo[0] or bflo[1] or bflo[2]))
+            if (i == dlo.x-1 && j == dlo.y-1 && k == dlo.z-1 && (bflo[0] || bflo[1] || bflo[2]))
             {
-                if (bflo[0] and bflo[1] and bflo[2])
+                if (bflo[0] && bflo[1] && bflo[2])
                 {
                     a(i,j,k) = a(i+1+offset, j+1+offset, k+1+offset);
                 }
-                else if (bflo[0] and bflo[1])
+                else if (bflo[0] && bflo[1])
                 {
                     a(i,j,k) = a(i+1+offset, j+1+offset, k);
                 }
-                else if (bflo[0] and bflo[2])
+                else if (bflo[0] && bflo[2])
                 {
                     a(i,j,k) = a(i+1+offset, j, k+1+offset);
                 }
-                else if (bflo[1] and bflo[2])
+                else if (bflo[1] && bflo[2])
                 {
                     a(i,j,k) = a(i, j+1+offset, k+1+offset);
                 }
@@ -306,21 +306,21 @@ inline void mlndlap_bc_doit (Box const& vbx, Array4<T> const& a, Box const& doma
                 }
             }
             // xhi & ylo & zlo
-            else if (i == dhi.x+1 and j == dlo.y-1 and k == dlo.z-1 and (bfhi[0] or bflo[1] or bflo[2]))
+            else if (i == dhi.x+1 && j == dlo.y-1 && k == dlo.z-1 && (bfhi[0] || bflo[1] || bflo[2]))
             {
-                if (bfhi[0] and bflo[1] and bflo[2])
+                if (bfhi[0] && bflo[1] && bflo[2])
                 {
                     a(i,j,k) = a(i-1-offset, j+1+offset, k+1+offset);
                 }
-                else if (bfhi[0] and bflo[1])
+                else if (bfhi[0] && bflo[1])
                 {
                     a(i,j,k) = a(i-1-offset, j+1+offset, k);
                 }
-                else if (bfhi[0] and bflo[2])
+                else if (bfhi[0] && bflo[2])
                 {
                     a(i,j,k) = a(i-1-offset, j, k+1+offset);
                 }
-                else if (bflo[1] and bflo[2])
+                else if (bflo[1] && bflo[2])
                 {
                     a(i,j,k) = a(i, j+1+offset, k+1+offset);
                 }
@@ -338,21 +338,21 @@ inline void mlndlap_bc_doit (Box const& vbx, Array4<T> const& a, Box const& doma
                 }
             }
             // xlo & yhi & zlo
-            else if (i == dlo.x-1 and j == dhi.y+1 and k == dlo.z-1 and (bflo[0] or bfhi[1] or bflo[2]))
+            else if (i == dlo.x-1 && j == dhi.y+1 && k == dlo.z-1 && (bflo[0] || bfhi[1] || bflo[2]))
             {
-                if (bflo[0] and bfhi[1] and bflo[2])
+                if (bflo[0] && bfhi[1] && bflo[2])
                 {
                     a(i,j,k) = a(i+1+offset, j-1-offset, k+1+offset);
                 }
-                else if (bflo[0] and bfhi[1])
+                else if (bflo[0] && bfhi[1])
                 {
                     a(i,j,k) = a(i+1+offset, j-1-offset, k);
                 }
-                else if (bflo[0] and bflo[2])
+                else if (bflo[0] && bflo[2])
                 {
                     a(i,j,k) = a(i+1+offset, j, k+1+offset);
                 }
-                else if (bfhi[1] and bflo[2])
+                else if (bfhi[1] && bflo[2])
                 {
                     a(i,j,k) = a(i, j-1-offset, k+1+offset);
                 }
@@ -370,21 +370,21 @@ inline void mlndlap_bc_doit (Box const& vbx, Array4<T> const& a, Box const& doma
                 }
             }
             // xhi & yhi & zlo
-            else if (i == dhi.x+1 and j == dhi.y+1 and k == dlo.z-1 and (bfhi[0] or bfhi[1] or bflo[2]))
+            else if (i == dhi.x+1 && j == dhi.y+1 && k == dlo.z-1 && (bfhi[0] || bfhi[1] || bflo[2]))
             {
-                if (bfhi[0] and bfhi[1] and bflo[2])
+                if (bfhi[0] && bfhi[1] && bflo[2])
                 {
                     a(i,j,k) = a(i-1-offset, j-1-offset, k+1+offset);
                 }
-                else if (bfhi[0] and bfhi[1])
+                else if (bfhi[0] && bfhi[1])
                 {
                     a(i,j,k) = a(i-1-offset, j-1-offset, k);
                 }
-                else if (bfhi[0] and bflo[2])
+                else if (bfhi[0] && bflo[2])
                 {
                     a(i,j,k) = a(i-1-offset, j, k+1+offset);
                 }
-                else if (bfhi[1] and bflo[2])
+                else if (bfhi[1] && bflo[2])
                 {
                     a(i,j,k) = a(i, j-1-offset, k+1+offset);
                 }
@@ -402,21 +402,21 @@ inline void mlndlap_bc_doit (Box const& vbx, Array4<T> const& a, Box const& doma
                 }
             }
             // xlo & ylo & zhi
-            else if (i == dlo.x-1 and j == dlo.y-1 and k == dhi.z+1 and (bflo[0] or bflo[1] or bfhi[2]))
+            else if (i == dlo.x-1 && j == dlo.y-1 && k == dhi.z+1 && (bflo[0] || bflo[1] || bfhi[2]))
             {
-                if (bflo[0] and bflo[1] and bfhi[2])
+                if (bflo[0] && bflo[1] && bfhi[2])
                 {
                     a(i,j,k) = a(i+1+offset, j+1+offset, k-1-offset);
                 }
-                else if (bflo[0] and bflo[1])
+                else if (bflo[0] && bflo[1])
                 {
                     a(i,j,k) = a(i+1+offset, j+1+offset, k);
                 }
-                else if (bflo[0] and bfhi[2])
+                else if (bflo[0] && bfhi[2])
                 {
                     a(i,j,k) = a(i+1+offset, j, k-1-offset);
                 }
-                else if (bflo[1] and bfhi[2])
+                else if (bflo[1] && bfhi[2])
                 {
                     a(i,j,k) = a(i, j+1+offset, k-1-offset);
                 }
@@ -434,21 +434,21 @@ inline void mlndlap_bc_doit (Box const& vbx, Array4<T> const& a, Box const& doma
                 }
             }
             // xhi & ylo & zhi
-            else if (i == dhi.x+1 and j == dlo.y-1 and k == dhi.z+1 and (bfhi[0] or bflo[1] or bfhi[2]))
+            else if (i == dhi.x+1 && j == dlo.y-1 && k == dhi.z+1 && (bfhi[0] || bflo[1] || bfhi[2]))
             {
-                if (bfhi[0] and bflo[1] and bfhi[2])
+                if (bfhi[0] && bflo[1] && bfhi[2])
                 {
                     a(i,j,k) = a(i-1-offset, j+1+offset, k-1-offset);
                 }
-                else if (bfhi[0] and bflo[1])
+                else if (bfhi[0] && bflo[1])
                 {
                     a(i,j,k) = a(i-1-offset, j+1+offset, k);
                 }
-                else if (bfhi[0] and bfhi[2])
+                else if (bfhi[0] && bfhi[2])
                 {
                     a(i,j,k) = a(i-1-offset, j, k-1-offset);
                 }
-                else if (bflo[1] and bfhi[2])
+                else if (bflo[1] && bfhi[2])
                 {
                     a(i,j,k) = a(i, j+1+offset, k-1-offset);
                 }
@@ -466,21 +466,21 @@ inline void mlndlap_bc_doit (Box const& vbx, Array4<T> const& a, Box const& doma
                 }
             }
             // xlo & yhi & zhi
-            else if (i == dlo.x-1 and j == dhi.y+1 and k == dhi.z+1 and (bflo[0] or bfhi[1] or bfhi[2]))
+            else if (i == dlo.x-1 && j == dhi.y+1 && k == dhi.z+1 && (bflo[0] || bfhi[1] || bfhi[2]))
             {
-                if (bflo[0] and bfhi[1] and bfhi[2])
+                if (bflo[0] && bfhi[1] && bfhi[2])
                 {
                     a(i,j,k) = a(i+1+offset, j-1-offset, k-1-offset);
                 }
-                else if (bflo[0] and bfhi[1])
+                else if (bflo[0] && bfhi[1])
                 {
                     a(i,j,k) = a(i+1+offset, j-1-offset, k);
                 }
-                else if (bflo[0] and bfhi[2])
+                else if (bflo[0] && bfhi[2])
                 {
                     a(i,j,k) = a(i+1+offset, j, k-1-offset);
                 }
-                else if (bfhi[1] and bfhi[2])
+                else if (bfhi[1] && bfhi[2])
                 {
                     a(i,j,k) = a(i, j-1-offset, k-1-offset);
                 }
@@ -498,21 +498,21 @@ inline void mlndlap_bc_doit (Box const& vbx, Array4<T> const& a, Box const& doma
                 }
             }
             // xhi & yhi & zhi
-            else if (i == dhi.x+1 and j == dhi.y+1 and k == dhi.z+1 and (bfhi[0] or bfhi[1] or bfhi[2]))
+            else if (i == dhi.x+1 && j == dhi.y+1 && k == dhi.z+1 && (bfhi[0] || bfhi[1] || bfhi[2]))
             {
-                if (bfhi[0] and bfhi[1] and bfhi[2])
+                if (bfhi[0] && bfhi[1] && bfhi[2])
                 {
                     a(i,j,k) = a(i-1-offset, j-1-offset, k-1-offset);
                 }
-                else if (bfhi[0] and bfhi[1])
+                else if (bfhi[0] && bfhi[1])
                 {
                     a(i,j,k) = a(i-1-offset, j-1-offset, k);
                 }
-                else if (bfhi[0] and bfhi[2])
+                else if (bfhi[0] && bfhi[2])
                 {
                     a(i,j,k) = a(i-1-offset, j, k-1-offset);
                 }
-                else if (bfhi[1] and bfhi[2])
+                else if (bfhi[1] && bfhi[2])
                 {
                     a(i,j,k) = a(i, j-1-offset, k-1-offset);
                 }
@@ -530,9 +530,9 @@ inline void mlndlap_bc_doit (Box const& vbx, Array4<T> const& a, Box const& doma
                 }
             }
             // xlo & ylo
-            else if (i == dlo.x-1 and j == dlo.y-1 and (bflo[0] or bflo[1]))
+            else if (i == dlo.x-1 && j == dlo.y-1 && (bflo[0] || bflo[1]))
             {
-                if (bflo[0] and bflo[1])
+                if (bflo[0] && bflo[1])
                 {
                     a(i,j,k) = a(i+1+offset, j+1+offset, k);
                 }
@@ -546,9 +546,9 @@ inline void mlndlap_bc_doit (Box const& vbx, Array4<T> const& a, Box const& doma
                 }
             }
             // xhi & ylo
-            else if (i == dhi.x+1 and j == dlo.y-1 and (bfhi[0] or bflo[1]))
+            else if (i == dhi.x+1 && j == dlo.y-1 && (bfhi[0] || bflo[1]))
             {
-                if (bfhi[0] and bflo[1])
+                if (bfhi[0] && bflo[1])
                 {
                     a(i,j,k) = a(i-1-offset, j+1+offset, k);
                 }
@@ -562,9 +562,9 @@ inline void mlndlap_bc_doit (Box const& vbx, Array4<T> const& a, Box const& doma
                 }
             }
             // xlo & yhi
-            else if (i == dlo.x-1 and j == dhi.y+1 and (bflo[0] or bfhi[1]))
+            else if (i == dlo.x-1 && j == dhi.y+1 && (bflo[0] || bfhi[1]))
             {
-                if (bflo[0] and bfhi[1])
+                if (bflo[0] && bfhi[1])
                 {
                     a(i,j,k) = a(i+1+offset, j-1-offset, k);
                 }
@@ -578,9 +578,9 @@ inline void mlndlap_bc_doit (Box const& vbx, Array4<T> const& a, Box const& doma
                 }
             }
             // xhi & yhi
-            else if (i == dhi.x+1 and j == dhi.y+1 and (bfhi[0] or bfhi[1]))
+            else if (i == dhi.x+1 && j == dhi.y+1 && (bfhi[0] || bfhi[1]))
             {
-                if (bfhi[0] and bfhi[1])
+                if (bfhi[0] && bfhi[1])
                 {
                     a(i,j,k) = a(i-1-offset, j-1-offset, k);
                 }
@@ -594,9 +594,9 @@ inline void mlndlap_bc_doit (Box const& vbx, Array4<T> const& a, Box const& doma
                 }
             }
             // xlo & zlo
-            else if (i == dlo.x-1 and k == dlo.z-1 and (bflo[0] or bflo[2]))
+            else if (i == dlo.x-1 && k == dlo.z-1 && (bflo[0] || bflo[2]))
             {
-                if (bflo[0] and bflo[2])
+                if (bflo[0] && bflo[2])
                 {
                     a(i,j,k) = a(i+1+offset, j, k+1+offset);
                 }
@@ -610,9 +610,9 @@ inline void mlndlap_bc_doit (Box const& vbx, Array4<T> const& a, Box const& doma
                 }
             }
             // xhi & zlo
-            else if (i == dhi.x+1 and k == dlo.z-1 and (bfhi[0] or bflo[2]))
+            else if (i == dhi.x+1 && k == dlo.z-1 && (bfhi[0] || bflo[2]))
             {
-                if (bfhi[0] and bflo[2])
+                if (bfhi[0] && bflo[2])
                 {
                     a(i,j,k) = a(i-1-offset, j, k+1+offset);
                 }
@@ -626,9 +626,9 @@ inline void mlndlap_bc_doit (Box const& vbx, Array4<T> const& a, Box const& doma
                 }
             }
             // xlo & zhi
-            else if (i == dlo.x-1 and k == dhi.z+1 and (bflo[0] or bfhi[2]))
+            else if (i == dlo.x-1 && k == dhi.z+1 && (bflo[0] || bfhi[2]))
             {
-                if (bflo[0] and bfhi[2])
+                if (bflo[0] && bfhi[2])
                 {
                     a(i,j,k) = a(i+1+offset, j, k-1-offset);
                 }
@@ -642,9 +642,9 @@ inline void mlndlap_bc_doit (Box const& vbx, Array4<T> const& a, Box const& doma
                 }
             }
             // xhi & zhi
-            else if (i == dhi.x+1 and k == dhi.z+1 and (bfhi[0] or bfhi[2]))
+            else if (i == dhi.x+1 && k == dhi.z+1 && (bfhi[0] || bfhi[2]))
             {
-                if (bfhi[0] and bfhi[2])
+                if (bfhi[0] && bfhi[2])
                 {
                     a(i,j,k) = a(i-1-offset, j, k-1-offset);
                 }
@@ -658,9 +658,9 @@ inline void mlndlap_bc_doit (Box const& vbx, Array4<T> const& a, Box const& doma
                 }
             }
             // ylo & zlo
-            else if (j == dlo.y-1 and k == dlo.z-1 and (bflo[1] or bflo[2]))
+            else if (j == dlo.y-1 && k == dlo.z-1 && (bflo[1] || bflo[2]))
             {
-                if (bflo[1] and bflo[2])
+                if (bflo[1] && bflo[2])
                 {
                     a(i,j,k) = a(i, j+1+offset, k+1+offset);
                 }
@@ -674,9 +674,9 @@ inline void mlndlap_bc_doit (Box const& vbx, Array4<T> const& a, Box const& doma
                 }
             }
             // yhi & zlo
-            else if (j == dhi.y+1 and k == dlo.z-1 and (bfhi[1] or bflo[2]))
+            else if (j == dhi.y+1 && k == dlo.z-1 && (bfhi[1] || bflo[2]))
             {
-                if (bfhi[1] and bflo[2])
+                if (bfhi[1] && bflo[2])
                 {
                     a(i,j,k) = a(i, j-1-offset, k+1+offset);
                 }
@@ -690,9 +690,9 @@ inline void mlndlap_bc_doit (Box const& vbx, Array4<T> const& a, Box const& doma
                 }
             }
             // ylo & zhi
-            else if (j == dlo.y-1 and k == dhi.z+1 and (bflo[1] or bfhi[2]))
+            else if (j == dlo.y-1 && k == dhi.z+1 && (bflo[1] || bfhi[2]))
             {
-                if (bflo[1] and bfhi[2])
+                if (bflo[1] && bfhi[2])
                 {
                     a(i,j,k) = a(i, j+1+offset, k-1-offset);
                 }
@@ -706,9 +706,9 @@ inline void mlndlap_bc_doit (Box const& vbx, Array4<T> const& a, Box const& doma
                 }
             }
             // yhi & zhi
-            else if (j == dhi.y+1 and k == dhi.z+1 and (bfhi[1] or bfhi[2]))
+            else if (j == dhi.y+1 && k == dhi.z+1 && (bfhi[1] || bfhi[2]))
             {
-                if (bfhi[1] and bfhi[2])
+                if (bfhi[1] && bfhi[2])
                 {
                     a(i,j,k) = a(i, j-1-offset, k-1-offset);
                 }
@@ -721,27 +721,27 @@ inline void mlndlap_bc_doit (Box const& vbx, Array4<T> const& a, Box const& doma
                     a(i,j,k) = a(i, j, k-1-offset);
                 }
             }
-            else if (i == dlo.x-1 and bflo[0])
+            else if (i == dlo.x-1 && bflo[0])
             {
                 a(i,j,k) = a(i+1+offset, j, k);
             }
-            else if (i == dhi.x+1 and bfhi[0])
+            else if (i == dhi.x+1 && bfhi[0])
             {
                 a(i,j,k) = a(i-1-offset, j, k);
             }
-            else if (j == dlo.y-1 and bflo[1])
+            else if (j == dlo.y-1 && bflo[1])
             {
                 a(i,j,k) = a(i, j+1+offset, k);
             }
-            else if (j == dhi.y+1 and bfhi[1])
+            else if (j == dhi.y+1 && bfhi[1])
             {
                 a(i,j,k) = a(i, j-1-offset, k);
             }
-            else if (k == dlo.z-1 and bflo[2])
+            else if (k == dlo.z-1 && bflo[2])
             {
                 a(i,j,k) = a(i, j, k+1+offset);
             }
-            else if (k == dhi.z+1 and bfhi[2])
+            else if (k == dhi.z+1 && bfhi[2])
             {
                 a(i,j,k) = a(i, j, k-1-offset);
             }
@@ -1196,15 +1196,15 @@ void mlndlap_gauss_seidel_with_line_solve_aa (Box const& bx, Array4<Real> const&
     int idir = -1;
     int ilen = 33;
 
-    if ( (dxinv[0] <= dxinv[2]) and (dxinv[1] <= dxinv[2]) ) {
+    if ( (dxinv[0] <= dxinv[2]) && (dxinv[1] <= dxinv[2]) ) {
         idir = 2;
         ilen = hi.z - lo.z + 1;
     }
-    if ( (dxinv[0] <= dxinv[1]) and (dxinv[2] <= dxinv[1]) ) {
+    if ( (dxinv[0] <= dxinv[1]) && (dxinv[2] <= dxinv[1]) ) {
         idir = 1;
         ilen = hi.y - lo.y + 1;
     }
-    if ( (dxinv[1] <= dxinv[0]) and (dxinv[2] <= dxinv[0]) ) {
+    if ( (dxinv[1] <= dxinv[0]) && (dxinv[2] <= dxinv[0]) ) {
         idir = 0;
         ilen = hi.x - lo.x + 1;
     }
@@ -1574,7 +1574,7 @@ void mlndlap_interpadd_aa (int i, int j, int k, Array4<Real> const& fine,
         bool i_is_odd = (ic*2 != i);
         bool j_is_odd = (jc*2 != j);
         bool k_is_odd = (kc*2 != k);
-        if (i_is_odd and j_is_odd and k_is_odd) {
+        if (i_is_odd && j_is_odd && k_is_odd) {
             // Fine node at center of cell
             Real w1 = sig(i-1,j-1,k-1) + sig(i-1,j,k-1) + sig(i-1,j-1,k) + sig(i-1,j,k);
             Real w2 = sig(i  ,j-1,k-1) + sig(i  ,j,k-1) + sig(i  ,j-1,k) + sig(i  ,j,k);
@@ -1589,13 +1589,13 @@ void mlndlap_interpadd_aa (int i, int j, int k, Array4<Real> const& fine,
                             w5 * aa_interp_face_xy(crse,sig,i  ,j  ,k-1,ic  ,jc  ,kc  ) +
                             w6 * aa_interp_face_xy(crse,sig,i  ,j  ,k+1,ic  ,jc  ,kc+1))
                 / (w1+w2+w3+w4+w5+w6);
-        } else if (j_is_odd and k_is_odd) {
+        } else if (j_is_odd && k_is_odd) {
             // Node on a Y-Z face
             fine(i,j,k) += aa_interp_face_yz(crse,sig,i,j,k,ic,jc,kc);
-        } else if (i_is_odd and k_is_odd) {
+        } else if (i_is_odd && k_is_odd) {
             // Node on a Z-X face
             fine(i,j,k) += aa_interp_face_xz(crse,sig,i,j,k,ic,jc,kc);
-        } else if (i_is_odd and j_is_odd) {
+        } else if (i_is_odd && j_is_odd) {
             // Node on a X-Y face
             fine(i,j,k) += aa_interp_face_xy(crse,sig,i,j,k,ic,jc,kc);
         } else if (i_is_odd) {
@@ -1628,7 +1628,7 @@ void mlndlap_semi_interpadd_aa (int i, int j, int k, Array4<Real> const& fine,
             bool i_is_odd = (ic*2 != i);
             bool j_is_odd = (jc*2 != j);
 
-            if (i_is_odd and j_is_odd) {
+            if (i_is_odd && j_is_odd) {
                 // Node on a X-Y face
                 fine(i,j,k) += aa_interp_face_xy(crse,sig,i,j,k,ic,jc,kc);
             } else if (i_is_odd) {
@@ -1650,7 +1650,7 @@ void mlndlap_semi_interpadd_aa (int i, int j, int k, Array4<Real> const& fine,
             bool i_is_odd = (ic*2 != i);
             bool k_is_odd = (kc*2 != k);
 
-            if (i_is_odd and k_is_odd) {
+            if (i_is_odd && k_is_odd) {
                 // Node on a X-Z face
 	        fine(i,j,k) += aa_interp_face_xz(crse,sig,i,j,k,ic,jc,kc);
             } else if (i_is_odd) {
@@ -1672,7 +1672,7 @@ void mlndlap_semi_interpadd_aa (int i, int j, int k, Array4<Real> const& fine,
             bool j_is_odd = (jc*2 != j);
             bool k_is_odd = (kc*2 != k);
 
-            if (j_is_odd and k_is_odd) {
+            if (j_is_odd && k_is_odd) {
                 // Node on a Y-Z face
                 fine(i,j,k) += aa_interp_face_yz(crse,sig,i,j,k,ic,jc,kc);
             } else if (j_is_odd) {
@@ -1751,7 +1751,7 @@ void mlndlap_interpadd_ha (int i, int j, int k, Array4<Real> const& fine,
         bool i_is_odd = (ic*2 != i);
         bool j_is_odd = (jc*2 != j);
         bool k_is_odd = (kc*2 != k);
-        if (i_is_odd and j_is_odd and k_is_odd) {
+        if (i_is_odd && j_is_odd && k_is_odd) {
             // Fine node at center of cell
             Real w1 = sigx(i-1,j-1,k-1) + sigx(i-1,j,k-1) + sigx(i-1,j-1,k) + sigx(i-1,j,k);
             Real w2 = sigx(i  ,j-1,k-1) + sigx(i  ,j,k-1) + sigx(i  ,j-1,k) + sigx(i  ,j,k);
@@ -1766,13 +1766,13 @@ void mlndlap_interpadd_ha (int i, int j, int k, Array4<Real> const& fine,
                             w5 * ha_interp_face_xy(crse,sigx,sigy,i  ,j  ,k-1,ic  ,jc  ,kc  ) +
                             w6 * ha_interp_face_xy(crse,sigx,sigy,i  ,j  ,k+1,ic  ,jc  ,kc+1))
                 / (w1+w2+w3+w4+w5+w6);
-        } else if (j_is_odd and k_is_odd) {
+        } else if (j_is_odd && k_is_odd) {
             // Node on a Y-Z face
             fine(i,j,k) += ha_interp_face_yz(crse,sigy,sigz,i,j,k,ic,jc,kc);
-        } else if (i_is_odd and k_is_odd) {
+        } else if (i_is_odd && k_is_odd) {
             // Node on a Z-X face
             fine(i,j,k) += ha_interp_face_xz(crse,sigx,sigz,i,j,k,ic,jc,kc);
-        } else if (i_is_odd and j_is_odd) {
+        } else if (i_is_odd && j_is_odd) {
             // Node on a X-Y face
             fine(i,j,k) += ha_interp_face_xy(crse,sigx,sigy,i,j,k,ic,jc,kc);
         } else if (i_is_odd) {
@@ -1823,18 +1823,18 @@ void mlndlap_divu (int i, int j, int k, Array4<Real> const& rhs, Array4<Real con
 
         // The nodal divergence operator should not see the tangential velocity
         //     at an inflow face
-        if ((bclo[0] == LinOpBCType::Neumann or bclo[0] == LinOpBCType::inflow)
-            and i == domlo.x) zero_ilo = 0.0;
-        if ((bchi[0] == LinOpBCType::Neumann or bchi[0] == LinOpBCType::inflow)
-            and i == domhi.x) zero_ihi = 0.0;
-        if ((bclo[1] == LinOpBCType::Neumann or bclo[1] == LinOpBCType::inflow)
-            and j == domlo.y) zero_jlo = 0.0;
-        if ((bchi[1] == LinOpBCType::Neumann or bchi[1] == LinOpBCType::inflow)
-            and j == domhi.y) zero_jhi = 0.0;
-        if ((bclo[2] == LinOpBCType::Neumann or bclo[2] == LinOpBCType::inflow)
-            and k == domlo.z) zero_klo = 0.0;
-        if ((bchi[2] == LinOpBCType::Neumann or bchi[2] == LinOpBCType::inflow)
-            and k == domhi.z) zero_khi = 0.0;
+        if ((bclo[0] == LinOpBCType::Neumann || bclo[0] == LinOpBCType::inflow)
+            && i == domlo.x) zero_ilo = 0.0;
+        if ((bchi[0] == LinOpBCType::Neumann || bchi[0] == LinOpBCType::inflow)
+            && i == domhi.x) zero_ihi = 0.0;
+        if ((bclo[1] == LinOpBCType::Neumann || bclo[1] == LinOpBCType::inflow)
+            && j == domlo.y) zero_jlo = 0.0;
+        if ((bchi[1] == LinOpBCType::Neumann || bchi[1] == LinOpBCType::inflow)
+            && j == domhi.y) zero_jhi = 0.0;
+        if ((bclo[2] == LinOpBCType::Neumann || bclo[2] == LinOpBCType::inflow)
+            && k == domlo.z) zero_klo = 0.0;
+        if ((bchi[2] == LinOpBCType::Neumann || bchi[2] == LinOpBCType::inflow)
+            && k == domhi.z) zero_khi = 0.0;
 
         rhs(i,j,k) = facx*(-vel(i-1,j-1,k-1,0)*zero_jlo*zero_klo+vel(i,j-1,k-1,0)*zero_jlo*zero_klo
                            -vel(i-1,j  ,k-1,0)*zero_jhi*zero_klo+vel(i,j  ,k-1,0)*zero_jhi*zero_klo
@@ -1897,7 +1897,7 @@ void mlndlap_divu_compute_fine_contrib (int i, int j, int k, Box const& fvbx,
     const auto domhi = amrex::ubound(nodal_domain);
 
     IntVect iv(i,j,k);
-    if (fvbx.contains(iv) and !fvbx.strictly_contains(iv))
+    if (fvbx.contains(iv) && !fvbx.strictly_contains(iv))
     {
         Real zero_ilo = 1.0;
         Real zero_ihi = 1.0;
@@ -1908,18 +1908,18 @@ void mlndlap_divu_compute_fine_contrib (int i, int j, int k, Box const& fvbx,
 
         // The nodal divergence operator should not see the tangential velocity
         //     at an inflow face
-        if ((bclo[0] == LinOpBCType::Neumann or bclo[0] == LinOpBCType::inflow)
-            and i == domlo.x) zero_ilo = 0.0;
-        if ((bchi[0] == LinOpBCType::Neumann or bchi[0] == LinOpBCType::inflow)
-            and i == domhi.x) zero_ihi = 0.0;
-        if ((bclo[1] == LinOpBCType::Neumann or bclo[1] == LinOpBCType::inflow)
-            and j == domlo.y) zero_jlo = 0.0;
-        if ((bchi[1] == LinOpBCType::Neumann or bchi[1] == LinOpBCType::inflow)
-            and j == domhi.y) zero_jhi = 0.0;
-        if ((bclo[2] == LinOpBCType::Neumann or bclo[2] == LinOpBCType::inflow)
-            and k == domlo.z) zero_klo = 0.0;
-        if ((bchi[2] == LinOpBCType::Neumann or bchi[2] == LinOpBCType::inflow)
-            and k == domhi.z) zero_khi = 0.0;
+        if ((bclo[0] == LinOpBCType::Neumann || bclo[0] == LinOpBCType::inflow)
+            && i == domlo.x) zero_ilo = 0.0;
+        if ((bchi[0] == LinOpBCType::Neumann || bchi[0] == LinOpBCType::inflow)
+            && i == domhi.x) zero_ihi = 0.0;
+        if ((bclo[1] == LinOpBCType::Neumann || bclo[1] == LinOpBCType::inflow)
+            && j == domlo.y) zero_jlo = 0.0;
+        if ((bchi[1] == LinOpBCType::Neumann || bchi[1] == LinOpBCType::inflow)
+            && j == domhi.y) zero_jhi = 0.0;
+        if ((bclo[2] == LinOpBCType::Neumann || bclo[2] == LinOpBCType::inflow)
+            && k == domlo.z) zero_klo = 0.0;
+        if ((bchi[2] == LinOpBCType::Neumann || bchi[2] == LinOpBCType::inflow)
+            && k == domhi.z) zero_khi = 0.0;
 
         frh(i,j,k) = 0.25*dxinv[0]*(-vel(i-1,j-1,k-1,0)*zero_jlo*zero_klo+vel(i,j-1,k-1,0)*zero_jlo*zero_klo
                                     -vel(i-1,j  ,k-1,0)*zero_jhi*zero_klo+vel(i,j  ,k-1,0)*zero_jhi*zero_klo
@@ -1950,7 +1950,7 @@ void mlndlap_divu_add_fine_contrib (int i, int j, int k, Box const& fvbx,
     int jj = 2*j;
     int kk = 2*k;
     IntVect iv(ii,jj,kk);
-    if (fvbx.contains(iv) and !fvbx.strictly_contains(iv) and msk(ii,jj,kk))
+    if (fvbx.contains(iv) && !fvbx.strictly_contains(iv) && msk(ii,jj,kk))
     {
         rhs(i,j,k) +=
             rfd*(frh(ii,jj,kk)
@@ -1977,7 +1977,7 @@ void mlndlap_rhcc_fine_contrib (int i, int j, int k, Box const& fvbx,
     int jj = 2*j;
     int kk = 2*k;
     IntVect iv(ii,jj,kk);
-    if (fvbx.contains(iv) and !fvbx.strictly_contains(iv) and msk(ii,jj,kk))
+    if (fvbx.contains(iv) && !fvbx.strictly_contains(iv) && msk(ii,jj,kk))
     {
         Real r = 0.0;
         for (int koff = -2; koff <= 1; ++koff) {
@@ -1999,7 +1999,7 @@ void mlndlap_divu_cf_contrib (int i, int j, int k, Array4<Real> const& rhs,
                               GpuArray<LinOpBCType,AMREX_SPACEDIM> const& bchi,
                               bool neumann_doubling) noexcept
 {
-    if (!dmsk(i,j,k) and ndmsk(i,j,k) == crse_fine_node) {
+    if (!dmsk(i,j,k) && ndmsk(i,j,k) == crse_fine_node) {
         Real facx = Real(0.25) * dxinv[0];
         Real facy = Real(0.25) * dxinv[1];
         Real facz = Real(0.25) * dxinv[2];
@@ -2058,26 +2058,26 @@ void mlndlap_divu_cf_contrib (int i, int j, int k, Array4<Real> const& rhs,
         if (neumann_doubling) {
             const auto ndlo = amrex::lbound(nddom);
             const auto ndhi = amrex::ubound(nddom);
-            if (i == ndlo.x and ( bclo[0] == LinOpBCType::Neumann or
+            if (i == ndlo.x && ( bclo[0] == LinOpBCType::Neumann ||
                                   bclo[0] == LinOpBCType::inflow)) {
                 r *= Real(2.);
-            } else if (i== ndhi.x and ( bchi[0] == LinOpBCType::Neumann or
+            } else if (i== ndhi.x && ( bchi[0] == LinOpBCType::Neumann ||
                                         bchi[0] == LinOpBCType::inflow)) {
                 r *= Real(2.);
             }
 
-            if (j == ndlo.y and ( bclo[1] == LinOpBCType::Neumann or
+            if (j == ndlo.y && ( bclo[1] == LinOpBCType::Neumann ||
                                   bclo[1] == LinOpBCType::inflow)) {
                 r *= Real(2.);
-            } else if (j == ndhi.y and ( bchi[1] == LinOpBCType::Neumann or
+            } else if (j == ndhi.y && ( bchi[1] == LinOpBCType::Neumann ||
                                          bchi[1] == LinOpBCType::inflow)) {
                 r *= Real(2.);
             }
 
-            if (k == ndlo.z and ( bclo[2] == LinOpBCType::Neumann or
+            if (k == ndlo.z && ( bclo[2] == LinOpBCType::Neumann ||
                                   bclo[2] == LinOpBCType::inflow)) {
                 r *= Real(2.);
-            } else if (k == ndhi.z and ( bchi[2] == LinOpBCType::Neumann or
+            } else if (k == ndhi.z && ( bchi[2] == LinOpBCType::Neumann ||
                                          bchi[2] == LinOpBCType::inflow)) {
                 r *= Real(2.);
             }
@@ -2098,45 +2098,45 @@ void mlndlap_crse_resid (int i, int j, int k, Array4<Real> const& resid,
                          GpuArray<LinOpBCType,AMREX_SPACEDIM> const& bchi,
                          bool neumann_doubling) noexcept
 {
-    if ((msk(i-1,j-1,k-1) == 0 or
-         msk(i  ,j-1,k-1) == 0 or
-         msk(i-1,j  ,k-1) == 0 or
-         msk(i  ,j  ,k-1) == 0 or
-         msk(i-1,j-1,k  ) == 0 or
-         msk(i  ,j-1,k  ) == 0 or
-         msk(i-1,j  ,k  ) == 0 or
-         msk(i  ,j  ,k  ) == 0) and
-        (msk(i-1,j-1,k-1) == 0 or
-         msk(i  ,j-1,k-1) == 0 or
-         msk(i-1,j  ,k-1) == 0 or
-         msk(i  ,j  ,k-1) == 0 or
-         msk(i-1,j-1,k  ) == 0 or
-         msk(i  ,j-1,k  ) == 0 or
-         msk(i-1,j  ,k  ) == 0 or
+    if ((msk(i-1,j-1,k-1) == 0 ||
+         msk(i  ,j-1,k-1) == 0 ||
+         msk(i-1,j  ,k-1) == 0 ||
+         msk(i  ,j  ,k-1) == 0 ||
+         msk(i-1,j-1,k  ) == 0 ||
+         msk(i  ,j-1,k  ) == 0 ||
+         msk(i-1,j  ,k  ) == 0 ||
+         msk(i  ,j  ,k  ) == 0) &&
+        (msk(i-1,j-1,k-1) == 0 ||
+         msk(i  ,j-1,k-1) == 0 ||
+         msk(i-1,j  ,k-1) == 0 ||
+         msk(i  ,j  ,k-1) == 0 ||
+         msk(i-1,j-1,k  ) == 0 ||
+         msk(i  ,j-1,k  ) == 0 ||
+         msk(i-1,j  ,k  ) == 0 ||
          msk(i  ,j  ,k  ) == 0))
     {
         Real fac = Real(1.0);
         if (neumann_doubling) {
             const auto ndlo = amrex::lbound(nddom);
             const auto ndhi = amrex::ubound(nddom);
-            if (i == ndlo.x and ( bclo[0] == LinOpBCType::Neumann or
+            if (i == ndlo.x && ( bclo[0] == LinOpBCType::Neumann ||
                                   bclo[0] == LinOpBCType::inflow)) {
                 fac *= Real(2.);
-            } else if (i== ndhi.x and ( bchi[0] == LinOpBCType::Neumann or
+            } else if (i== ndhi.x && ( bchi[0] == LinOpBCType::Neumann ||
                                         bchi[0] == LinOpBCType::inflow)) {
                 fac *= Real(2.);
             }
-            if (j == ndlo.y and ( bclo[1] == LinOpBCType::Neumann or
+            if (j == ndlo.y && ( bclo[1] == LinOpBCType::Neumann ||
                                   bclo[1] == LinOpBCType::inflow)) {
                 fac *= Real(2.);
-            } else if (j == ndhi.y and ( bchi[1] == LinOpBCType::Neumann or
+            } else if (j == ndhi.y && ( bchi[1] == LinOpBCType::Neumann ||
                                          bchi[1] == LinOpBCType::inflow)) {
                 fac *= Real(2.);
             }
-            if (k == ndlo.z and ( bclo[2] == LinOpBCType::Neumann or
+            if (k == ndlo.z && ( bclo[2] == LinOpBCType::Neumann ||
                                   bclo[2] == LinOpBCType::inflow)) {
                 fac *= Real(2.);
-            } else if (k == ndhi.z and ( bchi[2] == LinOpBCType::Neumann or
+            } else if (k == ndhi.z && ( bchi[2] == LinOpBCType::Neumann ||
                                          bchi[2] == LinOpBCType::inflow)) {
                 fac *= Real(2.);
             }
@@ -2157,7 +2157,7 @@ void mlndlap_res_fine_Ax (int i, int j, int k, Box const& fvbx, Array4<Real> con
                           GpuArray<Real,AMREX_SPACEDIM> const& dxinv) noexcept
 {
     IntVect iv(i,j,k);
-    if (fvbx.contains(iv) and !fvbx.strictly_contains(iv)) {
+    if (fvbx.contains(iv) && !fvbx.strictly_contains(iv)) {
         Real facx = Real(1./36.)*dxinv[0]*dxinv[0];
         Real facy = Real(1./36.)*dxinv[1]*dxinv[1];
         Real facz = Real(1./36.)*dxinv[2]*dxinv[2];
@@ -2240,7 +2240,7 @@ void mlndlap_res_cf_contrib (int i, int j, int k, Array4<Real> const& res,
                              GpuArray<LinOpBCType, AMREX_SPACEDIM> const& bchi,
                              bool neumann_doubling) noexcept
 {
-    if (!dmsk(i,j,k) and ndmsk(i,j,k) == crse_fine_node) {
+    if (!dmsk(i,j,k) && ndmsk(i,j,k) == crse_fine_node) {
 
         Real facx = Real(1./36.)*dxinv[0]*dxinv[0];
         Real facy = Real(1./36.)*dxinv[1]*dxinv[1];
@@ -2365,26 +2365,26 @@ void mlndlap_res_cf_contrib (int i, int j, int k, Array4<Real> const& res,
             const auto ndlo = amrex::lbound(nddom);
             const auto ndhi = amrex::ubound(nddom);
 
-            if (i == ndlo.x and (bclo[0] == LinOpBCType::Neumann or
+            if (i == ndlo.x && (bclo[0] == LinOpBCType::Neumann ||
                                  bclo[0] == LinOpBCType::inflow)) {
                 Axf *= Real(2.);
-            } else if (i== ndhi.x and (bchi[0] == LinOpBCType::Neumann or
+            } else if (i== ndhi.x && (bchi[0] == LinOpBCType::Neumann ||
                                        bchi[0] == LinOpBCType::inflow)) {
                 Axf *= Real(2.);
             }
 
-            if (j == ndlo.y and ( bclo[1] == LinOpBCType::Neumann or
+            if (j == ndlo.y && ( bclo[1] == LinOpBCType::Neumann ||
                                   bclo[1] == LinOpBCType::inflow)) {
                 Axf *= Real(2.);
-            } else if (j == ndhi.y and (bchi[1] == LinOpBCType::Neumann or
+            } else if (j == ndhi.y && (bchi[1] == LinOpBCType::Neumann ||
                                         bchi[1] == LinOpBCType::inflow)) {
                 Axf *= Real(2.);
             }
 
-            if (k == ndlo.z and (bclo[2] == LinOpBCType::Neumann or
+            if (k == ndlo.z && (bclo[2] == LinOpBCType::Neumann ||
                                  bclo[2] == LinOpBCType::inflow)) {
                 Axf *= Real(2.);
-            } else if (k == ndhi.z and (bchi[2] == LinOpBCType::Neumann or
+            } else if (k == ndhi.z && (bchi[2] == LinOpBCType::Neumann ||
                                         bchi[2] == LinOpBCType::inflow)) {
                 Axf *= Real(2.);
             }
@@ -2944,7 +2944,7 @@ void mlndlap_stencil_rap (int i, int j, int k, Array4<Real> const& csten,
     auto interp_from_00m_to = [&fsten] (int i_, int j_, int k_) -> Real {
         Real w1 = amrex::Math::abs(fsten(i_  ,j_  ,k_-1,ist_00p));
         Real w2 = amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_00p));
-        if (w1 == Real(0.) and w2 == Real(0.)) {
+        if (w1 == Real(0.) && w2 == Real(0.)) {
             return Real(0.5);
         } else {
             return w1 / (w1+w2);
@@ -2954,7 +2954,7 @@ void mlndlap_stencil_rap (int i, int j, int k, Array4<Real> const& csten,
     auto interp_from_00p_to = [&fsten] (int i_, int j_, int k_) -> Real {
         Real w1 = amrex::Math::abs(fsten(i_  ,j_  ,k_-1,ist_00p));
         Real w2 = amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_00p));
-        if (w1 == Real(0.) and w2 == Real(0.)) {
+        if (w1 == Real(0.) && w2 == Real(0.)) {
             return Real(0.5);
         } else {
             return w2 / (w1+w2);
@@ -2964,7 +2964,7 @@ void mlndlap_stencil_rap (int i, int j, int k, Array4<Real> const& csten,
     auto interp_from_0m0_to = [&fsten] (int i_, int j_, int k_) -> Real {
         Real w1 = amrex::Math::abs(fsten(i_  ,j_-1,k_  ,ist_0p0));
         Real w2 = amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_0p0));
-        if (w1 == Real(0.) and w2 == Real(0.)) {
+        if (w1 == Real(0.) && w2 == Real(0.)) {
             return Real(0.5);
         } else {
             return w1 / (w1+w2);
@@ -2974,7 +2974,7 @@ void mlndlap_stencil_rap (int i, int j, int k, Array4<Real> const& csten,
     auto interp_from_0p0_to = [&fsten] (int i_, int j_, int k_) -> Real {
         Real w1 = amrex::Math::abs(fsten(i_  ,j_-1,k_  ,ist_0p0));
         Real w2 = amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_0p0));
-        if (w1 == Real(0.) and w2 == Real(0.)) {
+        if (w1 == Real(0.) && w2 == Real(0.)) {
             return Real(0.5);
         } else {
             return w2 / (w1+w2);
@@ -2984,7 +2984,7 @@ void mlndlap_stencil_rap (int i, int j, int k, Array4<Real> const& csten,
     auto interp_from_m00_to = [&fsten] (int i_, int j_, int k_) -> Real {
         Real w1 = amrex::Math::abs(fsten(i_-1,j_  ,k_  ,ist_p00));
         Real w2 = amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_p00));
-        if (w1 == Real(0.) and w2 == Real(0.)) {
+        if (w1 == Real(0.) && w2 == Real(0.)) {
             return Real(0.5);
         } else {
             return w1 / (w1+w2);
@@ -2994,7 +2994,7 @@ void mlndlap_stencil_rap (int i, int j, int k, Array4<Real> const& csten,
     auto interp_from_p00_to = [&fsten] (int i_, int j_, int k_) -> Real {
         Real w1 = amrex::Math::abs(fsten(i_-1,j_  ,k_  ,ist_p00));
         Real w2 = amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_p00));
-        if (w1 == Real(0.) and w2 == Real(0.)) {
+        if (w1 == Real(0.) && w2 == Real(0.)) {
             return Real(0.5);
         } else {
             return w2 / (w1+w2);
@@ -3206,7 +3206,7 @@ void mlndlap_stencil_rap (int i, int j, int k, Array4<Real> const& csten,
     auto restrict_from_00m_to = [&fsten] (int ii_, int jj_, int kk_) -> Real {
         Real w1 = amrex::Math::abs(fsten(ii_,jj_,kk_-2,ist_00p));
         Real w2 = amrex::Math::abs(fsten(ii_,jj_,kk_-1,ist_00p));
-        if (w1 == Real(0.) and w2 == Real(0.)) {
+        if (w1 == Real(0.) && w2 == Real(0.)) {
             return Real(0.5);
         } else {
             return w2 / (w1+w2);
@@ -3324,7 +3324,7 @@ void mlndlap_stencil_rap (int i, int j, int k, Array4<Real> const& csten,
     auto restrict_from_0m0_to = [&fsten] (int ii_, int jj_, int kk_) -> Real {
         Real w1 = amrex::Math::abs(fsten(ii_,jj_-2,kk_,ist_0p0));
         Real w2 = amrex::Math::abs(fsten(ii_,jj_-1,kk_,ist_0p0));
-        if (w1 == Real(0.) and w2 == Real(0.)) {
+        if (w1 == Real(0.) && w2 == Real(0.)) {
             return Real(0.5);
         } else {
             return w2 / (w1+w2);
@@ -3350,7 +3350,7 @@ void mlndlap_stencil_rap (int i, int j, int k, Array4<Real> const& csten,
     auto restrict_from_m00_to = [&fsten] (int ii_, int jj_, int kk_) -> Real {
         Real w1 = amrex::Math::abs(fsten(ii_-2,jj_,kk_,ist_p00));
         Real w2 = amrex::Math::abs(fsten(ii_-1,jj_,kk_,ist_p00));
-        if (w1 == Real(0.) and w2 == Real(0.)) {
+        if (w1 == Real(0.) && w2 == Real(0.)) {
             return Real(0.5);
         } else {
             return w2 / (w1+w2);
@@ -3364,7 +3364,7 @@ void mlndlap_stencil_rap (int i, int j, int k, Array4<Real> const& csten,
     auto restrict_from_p00_to = [&fsten] (int ii_, int jj_, int kk_) -> Real {
         Real w1 = amrex::Math::abs(fsten(ii_  ,jj_,kk_,ist_p00));
         Real w2 = amrex::Math::abs(fsten(ii_+1,jj_,kk_,ist_p00));
-        if (w1 == Real(0.) and w2 == Real(0.)) {
+        if (w1 == Real(0.) && w2 == Real(0.)) {
             return Real(0.5);
         } else {
             return w1 / (w1+w2);
@@ -3390,7 +3390,7 @@ void mlndlap_stencil_rap (int i, int j, int k, Array4<Real> const& csten,
     auto restrict_from_0p0_to = [&fsten] (int ii_, int jj_, int kk_) -> Real {
         Real w1 = amrex::Math::abs(fsten(ii_,jj_  ,kk_,ist_0p0));
         Real w2 = amrex::Math::abs(fsten(ii_,jj_+1,kk_,ist_0p0));
-        if (w1 == Real(0.) and w2 == Real(0.)) {
+        if (w1 == Real(0.) && w2 == Real(0.)) {
             return Real(0.5);
         } else {
             return w1 / (w1+w2);
@@ -3508,7 +3508,7 @@ void mlndlap_stencil_rap (int i, int j, int k, Array4<Real> const& csten,
     auto restrict_from_00p_to = [&fsten] (int ii_, int jj_, int kk_) -> Real {
         Real w1 = amrex::Math::abs(fsten(ii_,jj_,kk_  ,ist_00p));
         Real w2 = amrex::Math::abs(fsten(ii_,jj_,kk_+1,ist_00p));
-        if (w1 == Real(0.) and w2 == Real(0.)) {
+        if (w1 == Real(0.) && w2 == Real(0.)) {
             return Real(0.5);
         } else {
             return w1 / (w1+w2);
@@ -5203,7 +5203,7 @@ void mlndlap_interpadd_rap (int i, int j, int k, Array4<Real> const& fine,
                             Array4<Real const> const& crse, Array4<Real const> const& sten,
                             Array4<int const> const& msk) noexcept
 {
-    if (!msk(i,j,k) and sten(i,j,k,ist_000) != 0.0) {
+    if (!msk(i,j,k) && sten(i,j,k,ist_000) != 0.0) {
         int ic = amrex::coarsen(i,2);
         int jc = amrex::coarsen(j,2);
         int kc = amrex::coarsen(k,2);
@@ -5211,28 +5211,28 @@ void mlndlap_interpadd_rap (int i, int j, int k, Array4<Real> const& fine,
         bool jeven = jc*2 == j;
         bool keven = kc*2 == k;
         Real fv;
-        if (ieven and jeven and keven) {
+        if (ieven && jeven && keven) {
             fv = crse(ic,jc,kc);
-        } else if (ieven and jeven) {
+        } else if (ieven && jeven) {
             Real w1 = amrex::Math::abs(sten(i,j,k-1,ist_00p));
             Real w2 = amrex::Math::abs(sten(i,j,k  ,ist_00p));
-            if (w1 == 0.0 and w2 == 0.0) {
+            if (w1 == 0.0 && w2 == 0.0) {
                 fv = 0.5*(crse(ic,jc,kc)+crse(ic,jc,kc+1));
             } else {
                 fv = (w1*crse(ic,jc,kc) + w2*crse(ic,jc,kc+1)) / (w1+w2);
             }
-        } else if (ieven and keven) {
+        } else if (ieven && keven) {
             Real w1 = amrex::Math::abs(sten(i,j-1,k,ist_0p0));
             Real w2 = amrex::Math::abs(sten(i,j  ,k,ist_0p0));
-            if (w1 == 0.0 and w2 == 0.0) {
+            if (w1 == 0.0 && w2 == 0.0) {
                 fv = 0.5*(crse(ic,jc,kc)+crse(ic,jc+1,kc));
             } else {
                 fv = (w1*crse(ic,jc,kc) + w2*crse(ic,jc+1,kc)) / (w1+w2);
             }
-        } else if (jeven and keven) {
+        } else if (jeven && keven) {
             Real w1 = amrex::Math::abs(sten(i-1,j,k,ist_p00));
             Real w2 = amrex::Math::abs(sten(i  ,j,k,ist_p00));
-            if (w1 == 0.0 and w2 == 0.0) {
+            if (w1 == 0.0 && w2 == 0.0) {
                 fv = 0.5*(crse(ic,jc,kc)+crse(ic+1,jc,kc));
             } else {
                 fv = (w1*crse(ic,jc,kc) + w2*crse(ic+1,jc,kc)) / (w1+w2);
@@ -5467,7 +5467,7 @@ void mlndlap_restriction_rap (int i, int j, int k, Array4<Real> const& crse,
         Real sten_lo = amrex::Math::abs(sten(ii-2,jj,kk,ist_p00));
         Real sten_hi = amrex::Math::abs(sten(ii-1,jj,kk,ist_p00));
 
-        if (sten_lo == 0.0 and sten_hi == 0.0) {
+        if (sten_lo == 0.0 && sten_hi == 0.0) {
             cv += 0.5*fine(ii-1,jj,kk);
         } else {
             cv += fine(ii-1,jj,kk) * sten_hi / (sten_lo + sten_hi);
@@ -5480,7 +5480,7 @@ void mlndlap_restriction_rap (int i, int j, int k, Array4<Real> const& crse,
         sten_lo = amrex::Math::abs(sten(ii  ,jj,kk,ist_p00));
         sten_hi = amrex::Math::abs(sten(ii+1,jj,kk,ist_p00));
 
-        if (sten_lo == 0.0 and sten_hi == 0.0) {
+        if (sten_lo == 0.0 && sten_hi == 0.0) {
             cv += 0.5*fine(ii+1,jj,kk);
         } else {
             cv += fine(ii+1,jj,kk) * sten_lo / (sten_lo + sten_hi);
@@ -5493,7 +5493,7 @@ void mlndlap_restriction_rap (int i, int j, int k, Array4<Real> const& crse,
         sten_lo = amrex::Math::abs(sten(ii,jj-2,kk,ist_0p0));
         sten_hi = amrex::Math::abs(sten(ii,jj-1,kk,ist_0p0));
 
-        if (sten_lo == 0.0 and sten_hi == 0.0) {
+        if (sten_lo == 0.0 && sten_hi == 0.0) {
             cv += 0.5*fine(ii,jj-1,kk);
         } else {
             cv += fine(ii,jj-1,kk) * sten_hi / (sten_lo + sten_hi);
@@ -5506,7 +5506,7 @@ void mlndlap_restriction_rap (int i, int j, int k, Array4<Real> const& crse,
         sten_lo = amrex::Math::abs(sten(ii,jj  ,kk,ist_0p0));
         sten_hi = amrex::Math::abs(sten(ii,jj+1,kk,ist_0p0));
 
-        if (sten_lo == 0.0 and sten_hi == 0.0) {
+        if (sten_lo == 0.0 && sten_hi == 0.0) {
             cv += 0.5*fine(ii,jj+1,kk);
         } else {
             cv += fine(ii,jj+1,kk) * sten_lo / (sten_lo + sten_hi);
@@ -5519,7 +5519,7 @@ void mlndlap_restriction_rap (int i, int j, int k, Array4<Real> const& crse,
         sten_lo = amrex::Math::abs(sten(ii,jj,kk-2,ist_00p));
         sten_hi = amrex::Math::abs(sten(ii,jj,kk-1,ist_00p));
 
-        if (sten_lo == 0.0 and sten_hi == 0.0) {
+        if (sten_lo == 0.0 && sten_hi == 0.0) {
             cv += 0.5*fine(ii,jj,kk-1);
         } else {
             cv += fine(ii,jj,kk-1)*sten_hi / (sten_lo + sten_hi);
@@ -5532,7 +5532,7 @@ void mlndlap_restriction_rap (int i, int j, int k, Array4<Real> const& crse,
         sten_lo = amrex::Math::abs(sten(ii,jj,kk  ,ist_00p));
         sten_hi = amrex::Math::abs(sten(ii,jj,kk+1,ist_00p));
 
-        if (sten_lo == 0.0 and sten_hi == 0.0) {
+        if (sten_lo == 0.0 && sten_hi == 0.0) {
             cv += 0.5*fine(ii,jj,kk+1);
         } else {
             cv += fine(ii,jj,kk+1)*sten_lo  / (sten_lo + sten_hi);
@@ -6100,7 +6100,7 @@ void mlndlap_set_connection (int i, int j, int k, Array4<Real> const& conn,
 {
     if (flag(i,j,k).isCovered()) {
         for (int n = 0; n < n_conn; ++n) conn(i,j,k,n) = Real(0.);
-    } else if (flag(i,j,k).isRegular() or vol(i,j,k) >= almostone) {
+    } else if (flag(i,j,k).isRegular() || vol(i,j,k) >= almostone) {
         for (int n = 0; n < n_conn; ++n) conn(i,j,k,n) = Real(1.);
     } else {
         // Scaled by 9
@@ -6339,18 +6339,18 @@ void mlndlap_divu_eb (int i, int j, int k, Array4<Real> const& rhs, Array4<Real 
 
         // The nodal divergence operator should not see the tangential velocity
         //     at an inflow face
-        if ((bclo[0] == LinOpBCType::Neumann or bclo[0] == LinOpBCType::inflow)
-            and i == domlo.x) zero_ilo = 0.0;
-        if ((bchi[0] == LinOpBCType::Neumann or bchi[0] == LinOpBCType::inflow)
-            and i == domhi.x) zero_ihi = 0.0;
-        if ((bclo[1] == LinOpBCType::Neumann or bclo[1] == LinOpBCType::inflow)
-            and j == domlo.y) zero_jlo = 0.0;
-        if ((bchi[1] == LinOpBCType::Neumann or bchi[1] == LinOpBCType::inflow)
-            and j == domhi.y) zero_jhi = 0.0;
-        if ((bclo[2] == LinOpBCType::Neumann or bclo[2] == LinOpBCType::inflow)
-            and k == domlo.z) zero_klo = 0.0;
-        if ((bchi[2] == LinOpBCType::Neumann or bchi[2] == LinOpBCType::inflow)
-            and k == domhi.z) zero_khi = 0.0;
+        if ((bclo[0] == LinOpBCType::Neumann || bclo[0] == LinOpBCType::inflow)
+            && i == domlo.x) zero_ilo = 0.0;
+        if ((bchi[0] == LinOpBCType::Neumann || bchi[0] == LinOpBCType::inflow)
+            && i == domhi.x) zero_ihi = 0.0;
+        if ((bclo[1] == LinOpBCType::Neumann || bclo[1] == LinOpBCType::inflow)
+            && j == domlo.y) zero_jlo = 0.0;
+        if ((bchi[1] == LinOpBCType::Neumann || bchi[1] == LinOpBCType::inflow)
+            && j == domhi.y) zero_jhi = 0.0;
+        if ((bclo[2] == LinOpBCType::Neumann || bclo[2] == LinOpBCType::inflow)
+            && k == domlo.z) zero_klo = 0.0;
+        if ((bchi[2] == LinOpBCType::Neumann || bchi[2] == LinOpBCType::inflow)
+            && k == domhi.z) zero_khi = 0.0;
 
         rhs(i,j,k) = facx*(
             vel(i-1,j-1,k  ,0)*(    -vfrac(i-1,j-1,k  )

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLap_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLap_K.H
@@ -32,7 +32,7 @@ mlndlap_scale_neumann_bc (Real s, Box const& bx, Array4<Real> const& rhs, Box co
                           GpuArray<LinOpBCType,AMREX_SPACEDIM> const& hibc) noexcept
 {
     for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-        if (lobc[idim] == LinOpBCType::Neumann or lobc[idim] == LinOpBCType::inflow) {
+        if (lobc[idim] == LinOpBCType::Neumann || lobc[idim] == LinOpBCType::inflow) {
             Box const& blo = amrex::bdryLo(bx, idim);
             if (blo.smallEnd(idim) == nddom.smallEnd(idim)) {
                 AMREX_HOST_DEVICE_PARALLEL_FOR_3D (blo, i, j, k,
@@ -41,7 +41,7 @@ mlndlap_scale_neumann_bc (Real s, Box const& bx, Array4<Real> const& rhs, Box co
                 });
             }
         }
-        if (hibc[idim] == LinOpBCType::Neumann or hibc[idim] == LinOpBCType::inflow) {
+        if (hibc[idim] == LinOpBCType::Neumann || hibc[idim] == LinOpBCType::inflow) {
             Box const& bhi = amrex::bdryHi(bx, idim);
             if (bhi.bigEnd(idim) == nddom.bigEnd(idim)) {
                 AMREX_HOST_DEVICE_PARALLEL_FOR_3D (bhi, i, j, k,
@@ -101,17 +101,17 @@ void mlndlap_applybc (Box const& vbx, Array4<T> const& phi, Box const& domain,
                       GpuArray<LinOpBCType, AMREX_SPACEDIM> bclo,
                       GpuArray<LinOpBCType, AMREX_SPACEDIM> bchi) noexcept
 {
-    GpuArray<bool,AMREX_SPACEDIM> bflo{{AMREX_D_DECL(bclo[0] == LinOpBCType::Neumann or
+    GpuArray<bool,AMREX_SPACEDIM> bflo{{AMREX_D_DECL(bclo[0] == LinOpBCType::Neumann ||
                                                      bclo[0] == LinOpBCType::inflow,
-                                                     bclo[1] == LinOpBCType::Neumann or
+                                                     bclo[1] == LinOpBCType::Neumann ||
                                                      bclo[1] == LinOpBCType::inflow,
-                                                     bclo[2] == LinOpBCType::Neumann or
+                                                     bclo[2] == LinOpBCType::Neumann ||
                                                      bclo[2] == LinOpBCType::inflow)}};
-    GpuArray<bool,AMREX_SPACEDIM> bfhi{{AMREX_D_DECL(bchi[0] == LinOpBCType::Neumann or
+    GpuArray<bool,AMREX_SPACEDIM> bfhi{{AMREX_D_DECL(bchi[0] == LinOpBCType::Neumann ||
                                                      bchi[0] == LinOpBCType::inflow,
-                                                     bchi[1] == LinOpBCType::Neumann or
+                                                     bchi[1] == LinOpBCType::Neumann ||
                                                      bchi[1] == LinOpBCType::inflow,
-                                                     bchi[2] == LinOpBCType::Neumann or
+                                                     bchi[2] == LinOpBCType::Neumann ||
                                                      bchi[2] == LinOpBCType::inflow)}};
     mlndlap_bc_doit(vbx, phi, domain, bflo, bfhi);
 }
@@ -123,7 +123,7 @@ void mlndlap_normalize_sten (Box const& bx, Array4<Real> const& x,
 {
     amrex::LoopConcurrent(bx, [=] (int i, int j, int k) noexcept
     {
-        if (!msk(i,j,k) and amrex::Math::abs(sten(i,j,k,0)) > s0_norm0) {
+        if (!msk(i,j,k) && amrex::Math::abs(sten(i,j,k,0)) > s0_norm0) {
             x(i,j,k) /= sten(i,j,k,0);
         }
     });

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian.cpp
@@ -1523,7 +1523,7 @@ MLNodeLaplacian::Fsmooth (int amrlev, int mglev, MultiFab& sol, const MultiFab& 
 #endif
     {
 	bool regular_coarsening = true;
-	if (amrlev == 0 and mglev > 0) 
+	if (amrlev == 0 && mglev > 0) 
     	{
             regular_coarsening = mg_coarsen_ratio_vec[mglev-1] == mg_coarsen_ratio;
         }
@@ -1870,7 +1870,7 @@ MLNodeLaplacian::compSyncResidualCoarse (MultiFab& sync_resid, const MultiFab& a
                     Array4<Real const> const& voarr = vold.const_array(mfi);
                     AMREX_HOST_DEVICE_FOR_3D(ccbxg1, i, j, k,
                     {
-		        if (b.contains(IntVect(AMREX_D_DECL(i,j,k))) and cccmsk(i,j,k)){
+		        if (b.contains(IntVect(AMREX_D_DECL(i,j,k))) && cccmsk(i,j,k)){
                             AMREX_D_TERM(uarr(i,j,k,0) = voarr(i,j,k,0);,
                                          uarr(i,j,k,1) = voarr(i,j,k,1);,
                                          uarr(i,j,k,2) = voarr(i,j,k,2););
@@ -1919,7 +1919,7 @@ MLNodeLaplacian::compSyncResidualCoarse (MultiFab& sync_resid, const MultiFab& a
                         const Box& b2 = ccbxg1 & ccvbx;
                         AMREX_HOST_DEVICE_FOR_3D(ccbxg1, i, j, k,
                         {
- 			    if (b2.contains(IntVect(AMREX_D_DECL(i,j,k))) and cccmsk(i,j,k)){
+ 			    if (b2.contains(IntVect(AMREX_D_DECL(i,j,k))) && cccmsk(i,j,k)){
                                 rhccarr(i,j,k) = rhccarr_orig(i,j,k);
                             } else {
                                 rhccarr(i,j,k) = 0.0;
@@ -1976,7 +1976,7 @@ MLNodeLaplacian::compSyncResidualCoarse (MultiFab& sync_resid, const MultiFab& a
                         const Box& ibx = sgbx & amrex::enclosedCells(mfi.validbox());
                         AMREX_HOST_DEVICE_FOR_3D(sgbx, i, j, k,
                         {
-                            if (ibx.contains(IntVect(AMREX_D_DECL(i,j,k))) and cccmsk(i,j,k)) {
+                            if (ibx.contains(IntVect(AMREX_D_DECL(i,j,k))) && cccmsk(i,j,k)) {
                                 mlndlap_set_connection(i,j,k,cnarr,intgarr,vfracarr,flagarr);
                                 sgarr(i,j,k) = sigmaarr_orig(i,j,k);
                             } else {
@@ -2006,7 +2006,7 @@ MLNodeLaplacian::compSyncResidualCoarse (MultiFab& sync_resid, const MultiFab& a
                         const Box& ibx = ccbxg1 & amrex::enclosedCells(mfi.validbox());
                         AMREX_HOST_DEVICE_FOR_3D(ccbxg1, i, j, k,
                         {
-                            if (ibx.contains(IntVect(AMREX_D_DECL(i,j,k))) and cccmsk(i,j,k)) {
+                            if (ibx.contains(IntVect(AMREX_D_DECL(i,j,k))) && cccmsk(i,j,k)) {
                                 sigmaarr(i,j,k) = sigmaarr_orig(i,j,k);
                             } else {
                                 sigmaarr(i,j,k) = 0.0;

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLinOp.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLinOp.cpp
@@ -169,7 +169,7 @@ MLNodeLinOp::applyInhomogNeumannTerm (int amrlev, MultiFab& rhs) const
                               m_lo_inhomog_neumann[n].end(),   1);
         auto ithi = std::find(m_hi_inhomog_neumann[n].begin(),
                               m_hi_inhomog_neumann[n].end(),   1);
-        if (itlo != m_lo_inhomog_neumann[n].end() or
+        if (itlo != m_lo_inhomog_neumann[n].end() ||
             ithi != m_hi_inhomog_neumann[n].end())
         {
             amrex::Abort("Inhomogeneous Neumann not supported for nodal solver");
@@ -244,7 +244,7 @@ MLNodeLinOp::buildMasks ()
             MFItInfo mfi_info;
             if (Gpu::notInLaunchRegion()) mfi_info.SetDynamic(true);
 
-            if (m_overset_dirichlet_mask and mglev > 0) {
+            if (m_overset_dirichlet_mask && mglev > 0) {
                 const auto& dmask_fine = *m_dirichlet_mask[amrlev][mglev-1];
                 amrex::average_down_nodal(dmask_fine, dmask, IntVect(2));
             }

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeTensorLap_2D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeTensorLap_2D_K.H
@@ -37,7 +37,7 @@ void mlndtslap_interpadd (int i, int j, int, Array4<Real> const& fine,
         int jc = amrex::coarsen(j,2);
         bool i_is_odd = (ic*2 != i);
         bool j_is_odd = (jc*2 != j);
-        if (i_is_odd and j_is_odd) {
+        if (i_is_odd && j_is_odd) {
             // Node on a X-Y face
             fine(i,j,0) += ts_interp_face_xy(crse,ic,jc);
         } else if (i_is_odd) {
@@ -139,7 +139,7 @@ void mlndtslap_fill_ijmatrix (Box const& ndbx, Array4<HypreNodeLap::Int const> c
     for (int k = lo.z; k <= hi.z; ++k) {
     for (int j = lo.y; j <= hi.y; ++j) {
     for (int i = lo.x; i <= hi.x; ++i) {
-        if (nid(i,j,k) >= 0 and owner(i,j,k))
+        if (nid(i,j,k) >= 0 && owner(i,j,k))
         {
             rows.push_back(nid(i,j,k));
             cols.push_back(nid(i,j,k));

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeTensorLap_3D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeTensorLap_3D_K.H
@@ -69,7 +69,7 @@ void mlndtslap_interpadd (int i, int j, int k, Array4<Real> const& fine,
         bool i_is_odd = (ic*2 != i);
         bool j_is_odd = (jc*2 != j);
         bool k_is_odd = (kc*2 != k);
-        if (i_is_odd and j_is_odd and k_is_odd) {
+        if (i_is_odd && j_is_odd && k_is_odd) {
             // Fine node at center of cell
             fine(i,j,k) += (ts_interp_face_yz(crse,ic  ,jc  ,kc  ) +
                             ts_interp_face_yz(crse,ic+1,jc  ,kc  ) +
@@ -77,13 +77,13 @@ void mlndtslap_interpadd (int i, int j, int k, Array4<Real> const& fine,
                             ts_interp_face_xz(crse,ic  ,jc+1,kc  ) +
                             ts_interp_face_xy(crse,ic  ,jc  ,kc  ) +
                             ts_interp_face_xy(crse,ic  ,jc  ,kc+1)) * Real(1./6.);
-        } else if (j_is_odd and k_is_odd) {
+        } else if (j_is_odd && k_is_odd) {
             // Node on a Y-Z face
             fine(i,j,k) += ts_interp_face_yz(crse,ic,jc,kc);
-        } else if (i_is_odd and k_is_odd) {
+        } else if (i_is_odd && k_is_odd) {
             // Node on a Z-X face
             fine(i,j,k) += ts_interp_face_xz(crse,ic,jc,kc);
-        } else if (i_is_odd and j_is_odd) {
+        } else if (i_is_odd && j_is_odd) {
             // Node on a X-Y face
             fine(i,j,k) += ts_interp_face_xy(crse,ic,jc,kc);
         } else if (i_is_odd) {
@@ -236,7 +236,7 @@ void mlndtslap_fill_ijmatrix (Box const& ndbx, Array4<HypreNodeLap::Int const> c
     for (int k = lo.z; k <= hi.z; ++k) {
     for (int j = lo.y; j <= hi.y; ++j) {
     for (int i = lo.x; i <= hi.x; ++i) {
-        if (nid(i,j,k) >= 0 and owner(i,j,k))
+        if (nid(i,j,k) >= 0 && owner(i,j,k))
         {
             rows.push_back(nid(i,j,k));
             cols.push_back(nid(i,j,k));

--- a/Src/LinearSolvers/MLMG/AMReX_MLPoisson_1D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLPoisson_1D_K.H
@@ -96,9 +96,9 @@ void mlpoisson_gsrb (Box const& box, Array4<Real> const& phi, Array4<Real const>
     AMREX_PRAGMA_SIMD
     for (int i = lo.x; i <= hi.x; ++i) {
         if ((i+redblack)%2 == 0) {
-            Real cf0 = (i == vlo.x and m0(vlo.x-1,0,0) > 0)
+            Real cf0 = (i == vlo.x && m0(vlo.x-1,0,0) > 0)
                 ? f0(vlo.x,0,0) : 0.0;
-            Real cf1 = (i == vhi.x and m1(vhi.x+1,0,0) > 0)
+            Real cf1 = (i == vhi.x && m1(vhi.x+1,0,0) > 0)
                 ? f1(vhi.x,0,0) : 0.0;
 
             Real g_m_d = gamma + dhx*(cf0+cf1);
@@ -126,9 +126,9 @@ void mlpoisson_gsrb_m (Box const& box, Array4<Real> const& phi, Array4<Real cons
     AMREX_PRAGMA_SIMD
     for (int i = lo.x; i <= hi.x; ++i) {
         if ((i+redblack)%2 == 0) {
-            Real cf0 = (i == vlo.x and m0(vlo.x-1,0,0) > 0)
+            Real cf0 = (i == vlo.x && m0(vlo.x-1,0,0) > 0)
                 ? f0(vlo.x,0,0) : 0.0;
-            Real cf1 = (i == vhi.x and m1(vhi.x+1,0,0) > 0)
+            Real cf1 = (i == vhi.x && m1(vhi.x+1,0,0) > 0)
                 ? f1(vhi.x,0,0) : 0.0;
 
             Real rel = (probxlo + i   *dx) * (probxlo + i   *dx);

--- a/Src/LinearSolvers/MLMG/AMReX_MLPoisson_2D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLPoisson_2D_K.H
@@ -183,13 +183,13 @@ void mlpoisson_gsrb (Box const& box, Array4<Real> const& phi, Array4<Real const>
         AMREX_PRAGMA_SIMD
         for (int i = lo.x; i <= hi.x; ++i) {
             if ((i+j+redblack)%2 == 0) {
-                Real cf0 = (i == vlo.x and m0(vlo.x-1,j,0) > 0)
+                Real cf0 = (i == vlo.x && m0(vlo.x-1,j,0) > 0)
                     ? f0(vlo.x,j,0) : 0.0;
-                Real cf1 = (j == vlo.y and m1(i,vlo.y-1,0) > 0)
+                Real cf1 = (j == vlo.y && m1(i,vlo.y-1,0) > 0)
                     ? f1(i,vlo.y,0) : 0.0;
-                Real cf2 = (i == vhi.x and m2(vhi.x+1,j,0) > 0)
+                Real cf2 = (i == vhi.x && m2(vhi.x+1,j,0) > 0)
                     ? f2(vhi.x,j,0) : 0.0;
-                Real cf3 = (j == vhi.y and m3(i,vhi.y+1,0) > 0)
+                Real cf3 = (j == vhi.y && m3(i,vhi.y+1,0) > 0)
                     ? f3(i,vhi.y,0) : 0.0;
 
                 Real g_m_d = gamma + dhx*(cf0+cf2) + dhy*(cf1+cf3);
@@ -222,13 +222,13 @@ void mlpoisson_gsrb_m (Box const& box, Array4<Real> const& phi, Array4<Real cons
         AMREX_PRAGMA_SIMD
         for (int i = lo.x; i <= hi.x; ++i) {
             if ((i+j+redblack)%2 == 0) {
-                Real cf0 = (i == vlo.x and m0(vlo.x-1,j,0) > 0)
+                Real cf0 = (i == vlo.x && m0(vlo.x-1,j,0) > 0)
                     ? f0(vlo.x,j,0) : 0.0;
-                Real cf1 = (j == vlo.y and m1(i,vlo.y-1,0) > 0)
+                Real cf1 = (j == vlo.y && m1(i,vlo.y-1,0) > 0)
                     ? f1(i,vlo.y,0) : 0.0;
-                Real cf2 = (i == vhi.x and m2(vhi.x+1,j,0) > 0)
+                Real cf2 = (i == vhi.x && m2(vhi.x+1,j,0) > 0)
                     ? f2(vhi.x,j,0) : 0.0;
-                Real cf3 = (j == vhi.y and m3(i,vhi.y+1,0) > 0)
+                Real cf3 = (j == vhi.y && m3(i,vhi.y+1,0) > 0)
                     ? f3(i,vhi.y,0) : 0.0;
 
                 Real rel = probxlo + i*dx;

--- a/Src/LinearSolvers/MLMG/AMReX_MLPoisson_3D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLPoisson_3D_K.H
@@ -153,17 +153,17 @@ void mlpoisson_gsrb (Box const& box, Array4<Real> const& phi,
             AMREX_PRAGMA_SIMD
             for (int i = lo.x; i <= hi.x; ++i) {
                 if ((i+j+k+redblack)%2 == 0) {
-                    Real cf0 = (i == vlo.x and m0(vlo.x-1,j,k) > 0)
+                    Real cf0 = (i == vlo.x && m0(vlo.x-1,j,k) > 0)
                         ? f0(vlo.x,j,k) : 0.0;
-                    Real cf1 = (j == vlo.y and m1(i,vlo.y-1,k) > 0)
+                    Real cf1 = (j == vlo.y && m1(i,vlo.y-1,k) > 0)
                         ? f1(i,vlo.y,k) : 0.0;
-                    Real cf2 = (k == vlo.z and m2(i,j,vlo.z-1) > 0)
+                    Real cf2 = (k == vlo.z && m2(i,j,vlo.z-1) > 0)
                         ? f2(i,j,vlo.z) : 0.0;
-                    Real cf3 = (i == vhi.x and m3(vhi.x+1,j,k) > 0)
+                    Real cf3 = (i == vhi.x && m3(vhi.x+1,j,k) > 0)
                         ? f3(vhi.x,j,k) : 0.0;
-                    Real cf4 = (j == vhi.y and m4(i,vhi.y+1,k) > 0)
+                    Real cf4 = (j == vhi.y && m4(i,vhi.y+1,k) > 0)
                         ? f4(i,vhi.y,k) : 0.0;
-                    Real cf5 = (k == vhi.z and m5(i,j,vhi.z+1) > 0)
+                    Real cf5 = (k == vhi.z && m5(i,j,vhi.z+1) > 0)
                         ? f5(i,j,vhi.z) : 0.0;
 
                     Real g_m_d = gamma + dhx*(cf0+cf3) + dhy*(cf1+cf4) + dhz*(cf2+cf5);

--- a/Src/LinearSolvers/MLMG/AMReX_MLTensorOp.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLTensorOp.cpp
@@ -163,7 +163,7 @@ MLTensorOp::prepareForSolve ()
 
     for (int amrlev = NAMRLevels()-1; amrlev >= 0; --amrlev) {
         for (int mglev = 1; mglev < m_kappa[amrlev].size(); ++mglev) {
-            if (m_has_kappa and m_overset_mask[amrlev][mglev]) {
+            if (m_has_kappa && m_overset_mask[amrlev][mglev]) {
                 const Real fac = static_cast<Real>(1 << mglev); // 2**mglev
                 const Real osfac = 2.0*fac/(fac+1.0);
 #ifdef _OPENMP

--- a/Src/LinearSolvers/MLMG/AMReX_MLTensor_2D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLTensor_2D_K.H
@@ -40,10 +40,10 @@ void mltensor_fill_corners (int icorner, Box const& vbox, // vbox: the valid box
             // xlo & ylo
             if (mxlo(vlo.x-1,vlo.y-1,0) != BndryData::covered) {
                 Box bx = amrex::adjCellLo(amrex::adjCellLo(vbox,xdir,1),ydir,1);
-                if (vlo.x == dlo.x and vlo.y == dlo.y) {
+                if (vlo.x == dlo.x && vlo.y == dlo.y) {
                     vel(vlo.x-1,vlo.y-1,0,icomp) = vel(vlo.x-1,vlo.y,0,icomp)
                         + vel(vlo.x,vlo.y-1,0,icomp) - vel(vlo.x,vlo.y,0,icomp);
-                } else if (vlo.x == dlo.x or mylo(vlo.x,vlo.y-1,0) == BndryData::covered) {
+                } else if (vlo.x == dlo.x || mylo(vlo.x,vlo.y-1,0) == BndryData::covered) {
                     int offset = AMREX_SPACEDIM * oxlo;
                     mllinop_apply_bc_x(Orientation::low, bx, blen.x,
                                        vel, mxlo, bct[offset+icomp], bcl[offset+icomp],
@@ -61,10 +61,10 @@ void mltensor_fill_corners (int icorner, Box const& vbox, // vbox: the valid box
             // xhi & ylo
             if (mxhi(vhi.x+1,vlo.y-1,0) != BndryData::covered) {
                 Box bx = amrex::adjCellLo(amrex::adjCellHi(vbox,xdir,1),ydir,1);
-                if (vhi.x == dhi.x and vlo.y == dlo.y) {
+                if (vhi.x == dhi.x && vlo.y == dlo.y) {
                     vel(vhi.x+1,vlo.y-1,0,icomp) = vel(vhi.x+1,vlo.y,0,icomp)
                         + vel(vhi.x,vlo.y-1,0,icomp) - vel(vhi.x,vlo.y,0,icomp);
-                } else if (vhi.x == dhi.x or mylo(vhi.x,vlo.y-1,0) == BndryData::covered) {
+                } else if (vhi.x == dhi.x || mylo(vhi.x,vlo.y-1,0) == BndryData::covered) {
                     int offset = AMREX_SPACEDIM * oxhi;
                     mllinop_apply_bc_x(Orientation::high, bx, blen.x,
                                        vel, mxhi, bct[offset+icomp], bcl[offset+icomp],
@@ -82,10 +82,10 @@ void mltensor_fill_corners (int icorner, Box const& vbox, // vbox: the valid box
             // xlo & yhi
             if (mxlo(vlo.x-1,vhi.y+1,0) != BndryData::covered) {
                 Box bx = amrex::adjCellHi(amrex::adjCellLo(vbox,xdir,1),ydir,1);
-                if (vlo.x == dlo.x and vhi.y == dhi.y) {
+                if (vlo.x == dlo.x && vhi.y == dhi.y) {
                     vel(vlo.x-1,vhi.y+1,0,icomp) = vel(vlo.x-1,vhi.y,0,icomp)
                         + vel(vlo.x,vhi.y+1,0,icomp) - vel(vlo.x,vhi.y,0,icomp);
-                } else if (vlo.x == dlo.x or myhi(vlo.x,vhi.y+1,0) == BndryData::covered) {
+                } else if (vlo.x == dlo.x || myhi(vlo.x,vhi.y+1,0) == BndryData::covered) {
                     int offset = AMREX_SPACEDIM * oxlo;
                     mllinop_apply_bc_x(Orientation::low, bx, blen.x,
                                        vel, mxlo, bct[offset+icomp], bcl[offset+icomp],
@@ -103,10 +103,10 @@ void mltensor_fill_corners (int icorner, Box const& vbox, // vbox: the valid box
             // xhi & yhi
             if (mxhi(vhi.x+1,vhi.y+1,0) != BndryData::covered) {
                 Box bx = amrex::adjCellHi(amrex::adjCellHi(vbox,xdir,1),ydir,1);
-                if (vhi.x == dhi.x and vhi.y == dhi.y) {
+                if (vhi.x == dhi.x && vhi.y == dhi.y) {
                     vel(vhi.x+1,vhi.y+1,0,icomp) = vel(vhi.x+1,vhi.y,0,icomp)
                         + vel(vhi.x,vhi.y+1,0,icomp) - vel(vhi.x,vhi.y,0,icomp);
-                } else if (vhi.x == dhi.x or myhi(vhi.x,vhi.y+1,0) == BndryData::covered) {
+                } else if (vhi.x == dhi.x || myhi(vhi.x,vhi.y+1,0) == BndryData::covered) {
                     int offset = AMREX_SPACEDIM * oxhi;
                     mllinop_apply_bc_x(Orientation::high, bx, blen.x,
                                        vel, mxhi, bct[offset+icomp], bcl[offset+icomp],

--- a/Src/LinearSolvers/MLMG/AMReX_MLTensor_3D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLTensor_3D_K.H
@@ -45,23 +45,23 @@ void mltensor_fill_corners (int icorner, Box const& vbox, // vbox: the valid box
         case 0: {
             // xlo & ylo & zlo
             Box bx = amrex::adjCellLo(amrex::adjCellLo(amrex::adjCellLo(vbox,xdir,1),ydir,1),zdir,1);
-            if (vlo.x == dlo.x and vlo.y == dlo.y and vlo.z == dlo.z) {
+            if (vlo.x == dlo.x && vlo.y == dlo.y && vlo.z == dlo.z) {
                 vel      (vlo.x-1,vlo.y-1,vlo.z-1,icomp)
                     = vel(vlo.x-1,vlo.y  ,vlo.z  ,icomp)
                     + vel(vlo.x  ,vlo.y-1,vlo.z  ,icomp)
                     + vel(vlo.x  ,vlo.y  ,vlo.z-1,icomp)
                     - vel(vlo.x  ,vlo.y  ,vlo.z  ,icomp) * 2.0;
-            } else if (vlo.x == dlo.x and vlo.y == dlo.y) {
+            } else if (vlo.x == dlo.x && vlo.y == dlo.y) {
                 vel      (vlo.x-1,vlo.y-1,vlo.z-1,icomp)
                     = vel(vlo.x-1,vlo.y  ,vlo.z-1,icomp)
                     + vel(vlo.x  ,vlo.y-1,vlo.z-1,icomp)
                     - vel(vlo.x  ,vlo.y  ,vlo.z-1,icomp);
-            } else if (vlo.x == dlo.x and vlo.z == dlo.z) {
+            } else if (vlo.x == dlo.x && vlo.z == dlo.z) {
                 vel      (vlo.x-1,vlo.y-1,vlo.z-1,icomp)
                     = vel(vlo.x-1,vlo.y-1,vlo.z  ,icomp)
                     + vel(vlo.x  ,vlo.y-1,vlo.z-1,icomp)
                     - vel(vlo.x  ,vlo.y-1,vlo.z  ,icomp);
-            } else if (vlo.y == dlo.y and vlo.z == dlo.z) {
+            } else if (vlo.y == dlo.y && vlo.z == dlo.z) {
                 vel      (vlo.x-1,vlo.y-1,vlo.z-1,icomp)
                     = vel(vlo.x-1,vlo.y-1,vlo.z  ,icomp)
                     + vel(vlo.x-1,vlo.y  ,vlo.z-1,icomp)
@@ -104,23 +104,23 @@ void mltensor_fill_corners (int icorner, Box const& vbox, // vbox: the valid box
         case 1: {
             // xhi & ylo & zlo
             Box bx = amrex::adjCellLo(amrex::adjCellLo(amrex::adjCellHi(vbox,xdir,1),ydir,1),zdir,1);
-            if (vhi.x == dhi.x and vlo.y == dlo.y and vlo.z == dlo.z) {
+            if (vhi.x == dhi.x && vlo.y == dlo.y && vlo.z == dlo.z) {
                 vel      (vhi.x+1,vlo.y-1,vlo.z-1,icomp)
                     = vel(vhi.x+1,vlo.y  ,vlo.z  ,icomp)
                     + vel(vhi.x  ,vlo.y-1,vlo.z  ,icomp)
                     + vel(vhi.x  ,vlo.y  ,vlo.z-1,icomp)
                     - vel(vhi.x  ,vlo.y  ,vlo.z  ,icomp) * 2.0;
-            } else if (vhi.x == dhi.x and vlo.y == dlo.y) {
+            } else if (vhi.x == dhi.x && vlo.y == dlo.y) {
                 vel      (vhi.x+1,vlo.y-1,vlo.z-1,icomp)
                     = vel(vhi.x+1,vlo.y  ,vlo.z-1,icomp)
                     + vel(vhi.x  ,vlo.y-1,vlo.z-1,icomp)
                     - vel(vhi.x  ,vlo.y  ,vlo.z-1,icomp);
-            } else if (vhi.x == dhi.x and vlo.z == dlo.z) {
+            } else if (vhi.x == dhi.x && vlo.z == dlo.z) {
                 vel      (vhi.x+1,vlo.y-1,vlo.z-1,icomp)
                     = vel(vhi.x+1,vlo.y-1,vlo.z  ,icomp)
                     + vel(vhi.x  ,vlo.y-1,vlo.z-1,icomp)
                     - vel(vhi.x  ,vlo.y-1,vlo.z  ,icomp);
-            } else if (vlo.y == dlo.y and vlo.z == dlo.z) {
+            } else if (vlo.y == dlo.y && vlo.z == dlo.z) {
                 vel      (vhi.x+1,vlo.y-1,vlo.z-1,icomp)
                     = vel(vhi.x+1,vlo.y-1,vlo.z  ,icomp)
                     + vel(vhi.x+1,vlo.y  ,vlo.z-1,icomp)
@@ -163,23 +163,23 @@ void mltensor_fill_corners (int icorner, Box const& vbox, // vbox: the valid box
         case 2: {
             // xlo & yhi & zlo
             Box bx = amrex::adjCellLo(amrex::adjCellHi(amrex::adjCellLo(vbox,xdir,1),ydir,1),zdir,1);
-            if (vlo.x == dlo.x and vhi.y == dhi.y and vlo.z == dlo.z) {
+            if (vlo.x == dlo.x && vhi.y == dhi.y && vlo.z == dlo.z) {
                 vel      (vlo.x-1,vhi.y+1,vlo.z-1,icomp)
                     = vel(vlo.x-1,vhi.y  ,vlo.z  ,icomp)
                     + vel(vlo.x  ,vhi.y+1,vlo.z  ,icomp)
                     + vel(vlo.x  ,vhi.y  ,vlo.z-1,icomp)
                     - vel(vlo.x  ,vhi.y  ,vlo.z  ,icomp) * 2.0;
-            } else if (vlo.x == dlo.x and vhi.y == dhi.y) {
+            } else if (vlo.x == dlo.x && vhi.y == dhi.y) {
                 vel      (vlo.x-1,vhi.y+1,vlo.z-1,icomp)
                     = vel(vlo.x-1,vhi.y  ,vlo.z-1,icomp)
                     + vel(vlo.x  ,vhi.y+1,vlo.z-1,icomp)
                     - vel(vlo.x  ,vhi.y  ,vlo.z-1,icomp);
-            } else if (vlo.x == dlo.x and vlo.z == dlo.z) {
+            } else if (vlo.x == dlo.x && vlo.z == dlo.z) {
                 vel      (vlo.x-1,vhi.y+1,vlo.z-1,icomp)
                     = vel(vlo.x-1,vhi.y+1,vlo.z  ,icomp)
                     + vel(vlo.x  ,vhi.y+1,vlo.z-1,icomp)
                     - vel(vlo.x  ,vhi.y+1,vlo.z  ,icomp);
-            } else if (vhi.y == dhi.y and vlo.z == dlo.z) {
+            } else if (vhi.y == dhi.y && vlo.z == dlo.z) {
                 vel      (vlo.x-1,vhi.y+1,vlo.z-1,icomp)
                     = vel(vlo.x-1,vhi.y+1,vlo.z  ,icomp)
                     + vel(vlo.x-1,vhi.y  ,vlo.z-1,icomp)
@@ -222,23 +222,23 @@ void mltensor_fill_corners (int icorner, Box const& vbox, // vbox: the valid box
         case 3: {
             // xhi & yhi & zlo
             Box bx = amrex::adjCellLo(amrex::adjCellHi(amrex::adjCellHi(vbox,xdir,1),ydir,1),zdir,1);
-            if (vhi.x == dhi.x and vhi.y == dhi.y and vlo.z == dlo.z) {
+            if (vhi.x == dhi.x && vhi.y == dhi.y && vlo.z == dlo.z) {
                 vel      (vhi.x+1,vhi.y+1,vlo.z-1,icomp)
                     = vel(vhi.x+1,vhi.y  ,vlo.z  ,icomp)
                     + vel(vhi.x  ,vhi.y+1,vlo.z  ,icomp)
                     + vel(vhi.x  ,vhi.y  ,vlo.z-1,icomp)
                     - vel(vhi.x  ,vhi.y  ,vlo.z  ,icomp) * 2.0;
-            } else if (vhi.x == dhi.x and vhi.y == dhi.y) {
+            } else if (vhi.x == dhi.x && vhi.y == dhi.y) {
                 vel      (vhi.x+1,vhi.y+1,vlo.z-1,icomp)
                     = vel(vhi.x+1,vhi.y  ,vlo.z-1,icomp)
                     + vel(vhi.x  ,vhi.y+1,vlo.z-1,icomp)
                     - vel(vhi.x  ,vhi.y  ,vlo.z-1,icomp);
-            } else if (vhi.x == dhi.x and vlo.z == dlo.z) {
+            } else if (vhi.x == dhi.x && vlo.z == dlo.z) {
                 vel      (vhi.x+1,vhi.y+1,vlo.z-1,icomp)
                     = vel(vhi.x+1,vhi.y+1,vlo.z  ,icomp)
                     + vel(vhi.x  ,vhi.y+1,vlo.z-1,icomp)
                     - vel(vhi.x  ,vhi.y+1,vlo.z  ,icomp);
-            } else if (vhi.y == dhi.y and vlo.z == dlo.z) {
+            } else if (vhi.y == dhi.y && vlo.z == dlo.z) {
                 vel      (vhi.x+1,vhi.y+1,vlo.z-1,icomp)
                     = vel(vhi.x+1,vhi.y+1,vlo.z  ,icomp)
                     + vel(vhi.x+1,vhi.y  ,vlo.z-1,icomp)
@@ -281,23 +281,23 @@ void mltensor_fill_corners (int icorner, Box const& vbox, // vbox: the valid box
         case 4: {
             // xlo & ylo & zhi
             Box bx = amrex::adjCellHi(amrex::adjCellLo(amrex::adjCellLo(vbox,xdir,1),ydir,1),zdir,1);
-            if (vlo.x == dlo.x and vlo.y == dlo.y and vhi.z == dhi.z) {
+            if (vlo.x == dlo.x && vlo.y == dlo.y && vhi.z == dhi.z) {
                 vel      (vlo.x-1, vlo.y-1, vhi.z+1,icomp)
                     = vel(vlo.x-1, vlo.y  , vhi.z  ,icomp)
                     + vel(vlo.x  , vlo.y-1, vhi.z  ,icomp)
                     + vel(vlo.x  , vlo.y  , vhi.z+1,icomp)
                     - vel(vlo.x  , vlo.y  , vhi.z  ,icomp) * 2.0;
-            } else if (vlo.x == dlo.x and vlo.y == dlo.y) {
+            } else if (vlo.x == dlo.x && vlo.y == dlo.y) {
                 vel      (vlo.x-1, vlo.y-1, vhi.z+1,icomp)
                     = vel(vlo.x-1, vlo.y  , vhi.z+1,icomp)
                     + vel(vlo.x  , vlo.y-1, vhi.z+1,icomp)
                     - vel(vlo.x  , vlo.y  , vhi.z+1,icomp);
-            } else if (vlo.x == dlo.x and vhi.z == dhi.z) {
+            } else if (vlo.x == dlo.x && vhi.z == dhi.z) {
                 vel      (vlo.x-1, vlo.y-1, vhi.z+1,icomp)
                     = vel(vlo.x-1, vlo.y-1, vhi.z  ,icomp)
                     + vel(vlo.x  , vlo.y-1, vhi.z+1,icomp)
                     - vel(vlo.x  , vlo.y-1, vhi.z  ,icomp);
-            } else if (vlo.y == dlo.y and vhi.z == dhi.z) {
+            } else if (vlo.y == dlo.y && vhi.z == dhi.z) {
                 vel      (vlo.x-1, vlo.y-1, vhi.z+1,icomp)
                     = vel(vlo.x-1, vlo.y-1, vhi.z  ,icomp)
                     + vel(vlo.x-1, vlo.y  , vhi.z+1,icomp)
@@ -340,23 +340,23 @@ void mltensor_fill_corners (int icorner, Box const& vbox, // vbox: the valid box
         case 5: {
             // xhi & ylo & zhi
             Box bx = amrex::adjCellHi(amrex::adjCellLo(amrex::adjCellHi(vbox,xdir,1),ydir,1),zdir,1);
-            if (vhi.x == dhi.x and vlo.y == dlo.y and vhi.z == dhi.z) {
+            if (vhi.x == dhi.x && vlo.y == dlo.y && vhi.z == dhi.z) {
                 vel      (vhi.x+1,vlo.y-1,vhi.z+1,icomp)
                     = vel(vhi.x+1,vlo.y  ,vhi.z  ,icomp)
                     + vel(vhi.x  ,vlo.y-1,vhi.z  ,icomp)
                     + vel(vhi.x  ,vlo.y  ,vhi.z+1,icomp)
                     - vel(vhi.x  ,vlo.y  ,vhi.z  ,icomp) * 2.0;
-            } else if (vhi.x == dhi.x and vlo.y == dlo.y) {
+            } else if (vhi.x == dhi.x && vlo.y == dlo.y) {
                 vel      (vhi.x+1,vlo.y-1,vhi.z+1,icomp)
                     = vel(vhi.x+1,vlo.y  ,vhi.z+1,icomp)
                     + vel(vhi.x  ,vlo.y-1,vhi.z+1,icomp)
                     - vel(vhi.x  ,vlo.y  ,vhi.z+1,icomp);
-            } else if (vhi.x == dhi.x and vhi.z == dhi.z) {
+            } else if (vhi.x == dhi.x && vhi.z == dhi.z) {
                 vel      (vhi.x+1,vlo.y-1,vhi.z+1,icomp)
                     = vel(vhi.x+1,vlo.y-1,vhi.z  ,icomp)
                     + vel(vhi.x  ,vlo.y-1,vhi.z+1,icomp)
                     - vel(vhi.x  ,vlo.y-1,vhi.z  ,icomp);
-            } else if (vlo.y == dlo.y and vhi.z == dhi.z) {
+            } else if (vlo.y == dlo.y && vhi.z == dhi.z) {
                 vel      (vhi.x+1,vlo.y-1,vhi.z+1,icomp)
                     = vel(vhi.x+1,vlo.y-1,vhi.z  ,icomp)
                     + vel(vhi.x+1,vlo.y  ,vhi.z+1,icomp)
@@ -399,23 +399,23 @@ void mltensor_fill_corners (int icorner, Box const& vbox, // vbox: the valid box
         case 6: {
             // xlo & yhi & zhi
             Box bx = amrex::adjCellHi(amrex::adjCellHi(amrex::adjCellLo(vbox,xdir,1),ydir,1),zdir,1);
-            if (vlo.x == dlo.x and vhi.y == dhi.y and vhi.z == dhi.z) {
+            if (vlo.x == dlo.x && vhi.y == dhi.y && vhi.z == dhi.z) {
                 vel      (vlo.x-1,vhi.y+1,vhi.z+1,icomp)
                     = vel(vlo.x-1,vhi.y  ,vhi.z  ,icomp)
                     + vel(vlo.x  ,vhi.y+1,vhi.z  ,icomp)
                     + vel(vlo.x  ,vhi.y  ,vhi.z+1,icomp)
                     - vel(vlo.x  ,vhi.y  ,vhi.z  ,icomp) * 2.0;
-            } else if (vlo.x == dlo.x and vhi.y == dhi.y) {
+            } else if (vlo.x == dlo.x && vhi.y == dhi.y) {
                 vel      (vlo.x-1,vhi.y+1,vhi.z+1,icomp)
                     = vel(vlo.x-1,vhi.y  ,vhi.z+1,icomp)
                     + vel(vlo.x  ,vhi.y+1,vhi.z+1,icomp)
                     - vel(vlo.x  ,vhi.y  ,vhi.z+1,icomp);
-            } else if (vlo.x == dlo.x and vhi.z == dhi.z) {
+            } else if (vlo.x == dlo.x && vhi.z == dhi.z) {
                 vel      (vlo.x-1,vhi.y+1,vhi.z+1,icomp)
                     = vel(vlo.x-1,vhi.y+1,vhi.z  ,icomp)
                     + vel(vlo.x  ,vhi.y+1,vhi.z+1,icomp)
                     - vel(vlo.x  ,vhi.y+1,vhi.z  ,icomp);
-            } else if (vhi.y == dhi.y and vhi.z == dhi.z) {
+            } else if (vhi.y == dhi.y && vhi.z == dhi.z) {
                 vel      (vlo.x-1,vhi.y+1,vhi.z+1,icomp)
                     = vel(vlo.x-1,vhi.y+1,vhi.z  ,icomp)
                     + vel(vlo.x-1,vhi.y  ,vhi.z+1,icomp)
@@ -458,23 +458,23 @@ void mltensor_fill_corners (int icorner, Box const& vbox, // vbox: the valid box
         case 7: {
             // xhi & yhi & zhi
             Box bx = amrex::adjCellHi(amrex::adjCellHi(amrex::adjCellHi(vbox,xdir,1),ydir,1),zdir,1);
-            if (vhi.x == dhi.x and vhi.y == dhi.y and vhi.z == dhi.z) {
+            if (vhi.x == dhi.x && vhi.y == dhi.y && vhi.z == dhi.z) {
                 vel      (vhi.x+1,vhi.y+1,vhi.z+1,icomp)
                     = vel(vhi.x+1,vhi.y  ,vhi.z  ,icomp)
                     + vel(vhi.x  ,vhi.y+1,vhi.z  ,icomp)
                     + vel(vhi.x  ,vhi.y  ,vhi.z+1,icomp)
                     - vel(vhi.x  ,vhi.y  ,vhi.z  ,icomp) * 2.0;
-            } else if (vhi.x == dhi.x and vhi.y == dhi.y) {
+            } else if (vhi.x == dhi.x && vhi.y == dhi.y) {
                 vel      (vhi.x+1,vhi.y+1,vhi.z+1,icomp)
                     = vel(vhi.x+1,vhi.y  ,vhi.z+1,icomp)
                     + vel(vhi.x  ,vhi.y+1,vhi.z+1,icomp)
                     - vel(vhi.x  ,vhi.y  ,vhi.z+1,icomp);
-            } else if (vhi.x == dhi.x and vhi.z == dhi.z) {
+            } else if (vhi.x == dhi.x && vhi.z == dhi.z) {
                 vel      (vhi.x+1,vhi.y+1,vhi.z+1,icomp)
                     = vel(vhi.x+1,vhi.y+1,vhi.z  ,icomp)
                     + vel(vhi.x  ,vhi.y+1,vhi.z+1,icomp)
                     - vel(vhi.x  ,vhi.y+1,vhi.z  ,icomp);
-            } else if (vhi.y == dhi.y and vhi.z == dhi.z) {
+            } else if (vhi.y == dhi.y && vhi.z == dhi.z) {
                 vel      (vhi.x+1,vhi.y+1,vhi.z+1,icomp)
                     = vel(vhi.x+1,vhi.y+1,vhi.z  ,icomp)
                     + vel(vhi.x+1,vhi.y  ,vhi.z+1,icomp)
@@ -557,7 +557,7 @@ void mltensor_fill_edges (int iedge, Box const& vbox, // vbox: the valid box
         switch (iedge) {
         case 0: {
             // xlo & ylo
-            if (vlo.x == dlo.x and vlo.y == dlo.y) {
+            if (vlo.x == dlo.x && vlo.y == dlo.y) {
                 for (int k = vlo.z; k <= vhi.z; ++k) {
                     vel      (vlo.x-1,vlo.y-1,k,icomp)
                         = vel(vlo.x  ,vlo.y-1,k,icomp)
@@ -598,7 +598,7 @@ void mltensor_fill_edges (int iedge, Box const& vbox, // vbox: the valid box
         }
         case 1: {
             // xhi & ylo
-            if (vhi.x == dhi.x and vlo.y == dlo.y) {
+            if (vhi.x == dhi.x && vlo.y == dlo.y) {
                 for (int k = vlo.z; k <= vhi.z; ++k) {
                     vel      (vhi.x+1,vlo.y-1,k,icomp)
                         = vel(vhi.x  ,vlo.y-1,k,icomp)
@@ -639,7 +639,7 @@ void mltensor_fill_edges (int iedge, Box const& vbox, // vbox: the valid box
         }
         case 2: {
             // xlo & yhi
-            if (vlo.x == dlo.x and vhi.y == dhi.y) {
+            if (vlo.x == dlo.x && vhi.y == dhi.y) {
                 for (int k = vlo.z; k <= vhi.z; ++k) {
                     vel      (vlo.x-1,vhi.y+1,k,icomp)
                         = vel(vlo.x  ,vhi.y+1,k,icomp)
@@ -680,7 +680,7 @@ void mltensor_fill_edges (int iedge, Box const& vbox, // vbox: the valid box
         }
         case 3: {
             // xhi & yhi
-            if (vhi.x == dhi.x and vhi.y == dhi.y) {
+            if (vhi.x == dhi.x && vhi.y == dhi.y) {
                 for (int k = vlo.z; k <= vhi.z; ++k) {
                     vel      (vhi.x+1,vhi.y+1,k,icomp)
                         = vel(vhi.x  ,vhi.y+1,k,icomp)
@@ -721,7 +721,7 @@ void mltensor_fill_edges (int iedge, Box const& vbox, // vbox: the valid box
         }
         case 4: {
             // xlo & zlo
-            if (vlo.x == dlo.x and vlo.z == dlo.z) {
+            if (vlo.x == dlo.x && vlo.z == dlo.z) {
                 for (int j = vlo.y; j <= vhi.y; ++j) {
                     vel      (vlo.x-1,j,vlo.z-1,icomp)
                         = vel(vlo.x  ,j,vlo.z-1,icomp)
@@ -762,7 +762,7 @@ void mltensor_fill_edges (int iedge, Box const& vbox, // vbox: the valid box
         }
         case 5: {
             // xhi & zlo
-            if (vhi.x == dhi.x and vlo.z == dlo.z) {
+            if (vhi.x == dhi.x && vlo.z == dlo.z) {
                 for (int j = vlo.y; j <= vhi.y; ++j) {
                     vel      (vhi.x+1,j,vlo.z-1,icomp)
                         = vel(vhi.x  ,j,vlo.z-1,icomp)
@@ -803,7 +803,7 @@ void mltensor_fill_edges (int iedge, Box const& vbox, // vbox: the valid box
         }
         case 6: {
             // xlo & zhi
-            if (vlo.x == dlo.x and vhi.z == dhi.z) {
+            if (vlo.x == dlo.x && vhi.z == dhi.z) {
                 for (int j = vlo.y; j <= vhi.y; ++j) {
                     vel      (vlo.x-1,j,vhi.z+1,icomp)
                         = vel(vlo.x  ,j,vhi.z+1,icomp)
@@ -844,7 +844,7 @@ void mltensor_fill_edges (int iedge, Box const& vbox, // vbox: the valid box
         }
         case 7: {
             // xhi & zhi
-            if (vhi.x == dhi.x and vhi.z == dhi.z) {
+            if (vhi.x == dhi.x && vhi.z == dhi.z) {
                 for (int j = vlo.y; j <= vhi.y; ++j) {
                     vel      (vhi.x+1,j,vhi.z+1,icomp)
                         = vel(vhi.x  ,j,vhi.z+1,icomp)
@@ -885,7 +885,7 @@ void mltensor_fill_edges (int iedge, Box const& vbox, // vbox: the valid box
         }
         case 8: {
             // ylo & zlo
-            if (vlo.y == dlo.y and vlo.z == dlo.z) {
+            if (vlo.y == dlo.y && vlo.z == dlo.z) {
                 for (int i = vlo.x; i <= vhi.x; ++i) {
                     vel      (i,vlo.y-1,vlo.z-1,icomp)
                         = vel(i,vlo.y  ,vlo.z-1,icomp)
@@ -926,7 +926,7 @@ void mltensor_fill_edges (int iedge, Box const& vbox, // vbox: the valid box
         }
         case 9: {
             // yhi & zlo
-            if (vhi.y == dhi.y and vlo.z == dlo.z) {
+            if (vhi.y == dhi.y && vlo.z == dlo.z) {
                 for (int i = vlo.x; i <= vhi.x; ++i) {
                     vel      (i,vhi.y+1,vlo.z-1,icomp)
                         = vel(i,vhi.y  ,vlo.z-1,icomp)
@@ -967,7 +967,7 @@ void mltensor_fill_edges (int iedge, Box const& vbox, // vbox: the valid box
         }
         case 10: {
             // ylo & zhi
-            if (vlo.y == dlo.y and vhi.z == dhi.z) {
+            if (vlo.y == dlo.y && vhi.z == dhi.z) {
                 for (int i = vlo.x; i <= vhi.x; ++i) {
                     vel      (i,vlo.y-1,vhi.z+1,icomp)
                         = vel(i,vlo.y  ,vhi.z+1,icomp)
@@ -1008,7 +1008,7 @@ void mltensor_fill_edges (int iedge, Box const& vbox, // vbox: the valid box
         }
         case 11: {
             // yhi & zhi
-            if (vhi.y == dhi.y and vhi.z == dhi.z) {
+            if (vhi.y == dhi.y && vhi.z == dhi.z) {
                 for (int i = vlo.x; i <= vhi.x; ++i) {
                     vel      (i,vhi.y+1,vhi.z+1,icomp)
                         = vel(i,vhi.y  ,vhi.z+1,icomp)

--- a/Src/Particle/AMReX_NeighborParticles.H
+++ b/Src/Particle/AMReX_NeighborParticles.H
@@ -106,11 +106,11 @@ private:
         }
 
         bool operator== (const NeighborCopyTag& other) const {
-            return (level == other.level) and (grid == other.grid) and (tile == other.tile)
+            return (level == other.level) && (grid == other.grid) && (tile == other.tile)
                 AMREX_D_TERM(
-                    and (periodic_shift[0] == other.periodic_shift[0]),
-                    and (periodic_shift[1] == other.periodic_shift[1]),
-                    and (periodic_shift[2] == other.periodic_shift[2])
+                    && (periodic_shift[0] == other.periodic_shift[0]),
+                    && (periodic_shift[1] == other.periodic_shift[1]),
+                    && (periodic_shift[2] == other.periodic_shift[2])
                     );
         }
 
@@ -169,9 +169,9 @@ private:
         }
 
         bool operator== (const NeighborCommTag& other) const {
-            return ( (proc_id == other.proc_id) and
-                     (grid_id == other.grid_id) and
-                     (tile_id == other.tile_id) and
+            return ( (proc_id == other.proc_id) &&
+                     (grid_id == other.grid_id) &&
+                     (tile_id == other.tile_id) &&
                      (level_id == other.level_id));
         }
 

--- a/Src/Particle/AMReX_NeighborParticlesCPUImpl.H
+++ b/Src/Particle/AMReX_NeighborParticlesCPUImpl.H
@@ -21,7 +21,7 @@ NeighborParticleContainer<NStructReal, NStructInt>
 {
     BL_PROFILE("NeighborParticleContainer::sumNeighborsCPU");
 
-    if ( not enableInverse() )
+    if ( ! enableInverse() )
     {
         amrex::Abort("Need to enable inverse to true to use sumNeighbors. \n");
     }
@@ -294,7 +294,7 @@ NeighborParticleContainer<NStructReal, NStructInt>
                     ParticleType p = particles[tag.src_index];  // copy
                     if (periodicity.isAnyPeriodic()) {
                         for (int dir = 0; dir < AMREX_SPACEDIM; ++dir) {
-                            if (not periodicity.isPeriodic(dir)) continue;
+                            if (! periodicity.isPeriodic(dir)) continue;
                             if (tag.periodic_shift[dir] < 0)
                                 p.pos(dir) += prob_domain.length(dir);
                             else if (tag.periodic_shift[dir] > 0)

--- a/Src/Particle/AMReX_NeighborParticlesGPUImpl.H
+++ b/Src/Particle/AMReX_NeighborParticlesGPUImpl.H
@@ -29,7 +29,7 @@ namespace detail
                     edge_boxes.push_back(lo_edge_box); bl.push_back(lo_edge_box);
                     for (auto edge_box : edge_boxes) {                    
                         for (int k = 0; k < AMREX_SPACEDIM; ++k) {
-                            if ((j == k) or (i == k)) continue;
+                            if ((j == k) || (i == k)) continue;
                             Box hi_corner_box = adjCellHi(edge_box, k, ncells);
                             Box lo_corner_box = adjCellLo(edge_box, k, ncells);
                             bl.push_back(hi_corner_box);
@@ -58,7 +58,7 @@ buildNeighborMask ()
     const BoxArray& ba = this->ParticleBoxArray(lev);
     const DistributionMapping& dmap = this->ParticleDistributionMap(lev);
 
-    if (ba.size() == 1 and (not geom.isAnyPeriodic()) ) return;
+    if (ba.size() == 1 && (! geom.isAnyPeriodic()) ) return;
 
     if (m_neighbor_mask_ptr == nullptr ||
         ! BoxArray::SameRefs(m_neighbor_mask_ptr->boxArray(), ba) ||
@@ -87,7 +87,7 @@ buildNeighborMask ()
                 {
                     int nbor_grid = isec.first;
                     const Box isec_box = isec.second - *pit;
-                    if ( (grid == nbor_grid) and (*pit == IntVect(AMREX_D_DECL(0, 0, 0)))) continue;
+                    if ( (grid == nbor_grid) && (*pit == IntVect(AMREX_D_DECL(0, 0, 0)))) continue;
                     neighbor_grids.insert(NeighborTask(nbor_grid, isec_box, *pit));
                 }
             }
@@ -154,7 +154,7 @@ buildNeighborCopyOp ()
     auto& plev  = this->GetParticles(lev);
     auto& ba = this->ParticleBoxArray(lev);
 
-    if (ba.size() == 1 and (not geom.isAnyPeriodic()) ) return;
+    if (ba.size() == 1 && (! geom.isAnyPeriodic()) ) return;
 
     for(MFIter mfi = this->MakeMFIter(lev); mfi.isValid(); ++mfi)
     {

--- a/Src/Particle/AMReX_NeighborParticlesI.H
+++ b/Src/Particle/AMReX_NeighborParticlesI.H
@@ -540,7 +540,7 @@ getNeighborTags (Vector<NeighborCopyTag>& tags, const ParticleType& p,
                  for (int ii = -nGrow[0]; ii < nGrow[0] + 1; ii += nGrow[0]) {,
                      for (int jj = -nGrow[1]; jj < nGrow[1] + 1; jj += nGrow[1]) {,
                          for (int kk = -nGrow[2]; kk < nGrow[2] + 1; kk += nGrow[2]) {)
-                             if (AMREX_D_TERM((ii == 0), and (jj == 0), and (kk == 0))) continue;
+                             if (AMREX_D_TERM((ii == 0), && (jj == 0), && (kk == 0))) continue;
                              IntVect shift(AMREX_D_DECL(ii, jj, kk));
                              IntVect neighbor_cell = iv + shift;
 
@@ -550,7 +550,7 @@ getNeighborTags (Vector<NeighborCopyTag>& tags, const ParticleType& p,
                              tag.level = mask(neighbor_cell, MaskComps::level);
                              if (periodicity.isAnyPeriodic()) {
                                  for (int dir = 0; dir < AMREX_SPACEDIM; ++dir) {
-                                     if (not periodicity.isPeriodic(dir)) continue;
+                                     if (! periodicity.isPeriodic(dir)) continue;
                                      if (neighbor_cell[dir] < lo[dir])
                                          tag.periodic_shift[dir] = -1;
                                      else if (neighbor_cell[dir] > hi[dir])
@@ -764,6 +764,6 @@ resizeContainers (const int num_levels)
         if ( enableInverse() ) inverse_tags.resize(num_levels);
     }
 
-    AMREX_ASSERT((neighbors.size() == m_neighbor_list.size()) and
+    AMREX_ASSERT((neighbors.size() == m_neighbor_list.size()) &&
                  (neighbors.size() == mask_ptr.size()     )    );
 }

--- a/Src/Particle/AMReX_Particle.H
+++ b/Src/Particle/AMReX_Particle.H
@@ -259,7 +259,7 @@ struct Particle
     template <int U = T_NReal, typename std::enable_if<U != 0, int>::type = 0>
     AMREX_GPU_HOST_DEVICE RealVect  rvec (AMREX_D_DECL(int indx, int indy, int indz)) const &
     {
-        AMREX_ASSERT(AMREX_D_TERM(indx < NReal, and indy < NReal, and indz < NReal));
+        AMREX_ASSERT(AMREX_D_TERM(indx < NReal, && indy < NReal, && indz < NReal));
         return RealVect(AMREX_D_DECL(this->m_rdata[indx],
                                      this->m_rdata[indy],
                                      this->m_rdata[indz]));

--- a/Src/Particle/AMReX_ParticleCommunication.H
+++ b/Src/Particle/AMReX_ParticleCommunication.H
@@ -321,7 +321,7 @@ void packBuffer (const PC& pc, const ParticleCopyOp& op, const ParticleCopyPlan&
                     const IntVect& pshift = p_periodic_shift[i];
                     for (int idim = 0; idim < AMREX_SPACEDIM; ++idim)
                     {
-                        if (not is_per[idim]) continue;
+                        if (! is_per[idim]) continue;
                         if (pshift[idim] > 0)
                             p->pos(idim) += phi[idim] - plo[idim];
                         else if (pshift[idim] < 0)

--- a/Src/Particle/AMReX_ParticleCommunication.cpp
+++ b/Src/Particle/AMReX_ParticleCommunication.cpp
@@ -113,7 +113,7 @@ void ParticleCopyPlan::buildMPIStart (const ParticleBufferMap& map, Long psize)
         }
     }
 
-    if ( (tot_snds_this_proc == 0) and (tot_rcvs_this_proc == 0) )
+    if ( (tot_snds_this_proc == 0) && (tot_rcvs_this_proc == 0) )
     {
         m_nrcvs = 0;
         m_NumSnds = 0;

--- a/Src/Particle/AMReX_ParticleContainerI.H
+++ b/Src/Particle/AMReX_ParticleContainerI.H
@@ -1354,8 +1354,8 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
           int tile = grid_tile_ids[pmap_it].second;
           auto& aos = ptile_ptrs[pmap_it]->GetArrayOfStructs();
           auto& soa = ptile_ptrs[pmap_it]->GetStructOfArrays();
-          AMREX_ASSERT_WITH_MESSAGE((NumRealComps() == 0 and NumIntComps() == 0)
-                                    or aos.size() == soa.size(),
+          AMREX_ASSERT_WITH_MESSAGE((NumRealComps() == 0 && NumIntComps() == 0)
+                                    || aos.size() == soa.size(),
               "The AoS and SoA data on this tile are different sizes - "
               "perhaps particles have not been initialized correctly?");
           unsigned npart = aos.numParticles();

--- a/Src/Particle/AMReX_ParticleContainerI.H
+++ b/Src/Particle/AMReX_ParticleContainerI.H
@@ -23,7 +23,7 @@ template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt>
 void
 ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt> :: SetParticleSize ()
 {
-    if (NumRealComps() > 0 or NumIntComps() > 0) {
+    if (NumRealComps() > 0 || NumIntComps() > 0) {
         if (NumRealComps() > 0) {
             d_communicate_real_comp.resize(NumRealComps());
             Gpu::copyAsync(Gpu::hostToDevice,
@@ -343,7 +343,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>::locateParticl
                              || p.pos(2) <  Geom(0).ProbLo(2)
                              || p.pos(2) >= Geom(0).ProbHi(2));
 
-    if (not outside)
+    if (! outside)
     {
         if (Geom(0).outsideRoundoffDomain(AMREX_D_DECL(p.pos(0), p.pos(1), p.pos(2))))
         {
@@ -358,7 +358,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>::locateParticl
                 }
             }
 
-            AMREX_ASSERT(not Geom(0).outsideRoundoffDomain(AMREX_D_DECL(p.pos(0), p.pos(1), p.pos(2))));
+            AMREX_ASSERT(! Geom(0).outsideRoundoffDomain(AMREX_D_DECL(p.pos(0), p.pos(1), p.pos(2))));
         }
     }
 
@@ -467,7 +467,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>::NumberOfParti
 {
     Long nparticles = 0;
 
-    if (lev < 0 or lev >= int(m_particles.size())) return nparticles;
+    if (lev < 0 || lev >= int(m_particles.size())) return nparticles;
 
     if (only_valid) {
         ReduceOps<ReduceOpSum> reduce_op;
@@ -1015,7 +1015,7 @@ addParticles (const ParticleContainerType& other, F&& f, bool local)
         }
     }
 
-    if (not local) Redistribute();
+    if (! local) Redistribute();
 }
 
 //
@@ -1117,7 +1117,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
 
     this->defineBufferMap();
 
-    if (not m_particle_locator.isValid(GetParGDB())) m_particle_locator.build(GetParGDB());
+    if (! m_particle_locator.isValid(GetParGDB())) m_particle_locator.build(GetParGDB());
     m_particle_locator.setGeometry(GetParGDB());
     auto assign_grid = m_particle_locator.getGridAssignor();
 
@@ -1605,7 +1605,7 @@ defineBufferMap () const
 {
     BL_PROFILE("ParticleContainer::defineBufferMap");
 
-    if (not m_buffer_map.isValid(GetParGDB()))
+    if (! m_buffer_map.isValid(GetParGDB()))
     {
         m_buffer_map.define(GetParGDB());
     }
@@ -1711,7 +1711,7 @@ RedistributeMPI (std::map<int, Vector<char> >& not_ours,
 
     const int SeqNum = ParallelDescriptor::SeqNum();
 
-    if ((not local) and NumSnds == 0)
+    if ((! local) && NumSnds == 0)
         return;  // There's no parallel work to do.
 
     if (local)
@@ -1722,7 +1722,7 @@ RedistributeMPI (std::map<int, Vector<char> >& not_ours,
             tot_snds_this_proc += Snds[neighbor_procs[i]];
             tot_rcvs_this_proc += Rcvs[neighbor_procs[i]];
         }
-        if ( (tot_snds_this_proc == 0) and (tot_rcvs_this_proc == 0) ) {
+        if ( (tot_snds_this_proc == 0) && (tot_rcvs_this_proc == 0) ) {
             return; // There's no parallel work to do.
         }
     }

--- a/Src/Particle/AMReX_ParticleContainerI.H
+++ b/Src/Particle/AMReX_ParticleContainerI.H
@@ -1141,7 +1141,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
             auto& aos = src_tile.GetArrayOfStructs();
             const size_t np = aos.numParticles();
 
-            AMREX_ASSERT_WITH_MESSAGE((NumRealComps() == 0 and NumIntComps() == 0) or
+            AMREX_ASSERT_WITH_MESSAGE((NumRealComps() == 0 && NumIntComps() == 0) ||
                                       aos.size() == src_tile.GetStructOfArrays().size(),
                 "The AoS and SoA data on this tile are different sizes - "
                 "perhaps particles have not been initialized correctly?");

--- a/Src/Particle/AMReX_ParticleHDF5.H
+++ b/Src/Particle/AMReX_ParticleHDF5.H
@@ -327,7 +327,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
     AMREX_ALWAYS_ASSERT( int_comp_names.size() == NumIntComps() + NStructInt);
 
     std::string pdir = dir;
-    if ( not pdir.empty() and pdir[pdir.size()-1] != '/') pdir += '/';
+    if ( ! pdir.empty() && pdir[pdir.size()-1] != '/') pdir += '/';
     if ( ! levelDirectoriesCreated) {
         if (ParallelDescriptor::IOProcessor()) {
             if ( ! amrex::UtilCreateDirectory(pdir, 0755))
@@ -944,7 +944,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
     if (version.find("Version_One_Dot_Zero") != std::string::npos) {
         how = "double";
     }
-    else if (version.find("Version_One_Dot_One")  != std::string::npos or
+    else if (version.find("Version_One_Dot_One")  != std::string::npos ||
              version.find("Version_Two_Dot_Zero") != std::string::npos) {
         if (version.find("_single") != std::string::npos) {
             how = "single";
@@ -1096,7 +1096,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
             particle_box_arrays[lev][i] = tmp;
         }
 
-        if (not particle_box_arrays[lev].CellEqual(ParticleBoxArray(lev))) 
+        if (! particle_box_arrays[lev].CellEqual(ParticleBoxArray(lev))) 
             dual_grid = true;
     }
     if (dual_grid) {

--- a/Src/Particle/AMReX_ParticleIO.H
+++ b/Src/Particle/AMReX_ParticleIO.H
@@ -739,7 +739,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
     if (version.find("Version_One_Dot_Zero") != std::string::npos) {
         how = "double";
     }
-    else if (version.find("Version_One_Dot_One")  != std::string::npos or
+    else if (version.find("Version_One_Dot_One")  != std::string::npos ||
              version.find("Version_Two_Dot_Zero") != std::string::npos) {
         if (version.find("_single") != std::string::npos) {
             how = "single";
@@ -822,7 +822,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
             phdr_name = amrex::Concatenate(phdr_name + "/Level_", lev, 1);
             phdr_name += "/Particle_H";
 
-            if (not amrex::FileExists(phdr_name)) continue;
+            if (! amrex::FileExists(phdr_name)) continue;
 
             Vector<char> phdr_chars;
             ParallelDescriptor::ReadAndBcastFile(phdr_name, phdr_chars);
@@ -836,7 +836,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
             }
 
             particle_box_arrays[lev].readFrom(phdr_file);
-            if (not particle_box_arrays[lev].CellEqual(ParticleBoxArray(lev))) dual_grid = true;
+            if (! particle_box_arrays[lev].CellEqual(ParticleBoxArray(lev))) dual_grid = true;
         }
     } else // if no particle box array information exists in the file, we assume a single grid restart
     {

--- a/Src/Particle/AMReX_ParticleLocator.H
+++ b/Src/Particle/AMReX_ParticleLocator.H
@@ -285,7 +285,7 @@ public:
 
     bool isValid (const Vector<BoxArray>& a_ba) const
     {
-        if ( !m_defined or (m_locators.size() == 0) or
+        if ( !m_defined || (m_locators.size() == 0) ||
              (m_locators.size() != a_ba.size()) ) return false;
         bool all_valid = true;
         int num_levels = m_locators.size();

--- a/Src/Particle/AMReX_ParticleTile.H
+++ b/Src/Particle/AMReX_ParticleTile.H
@@ -333,7 +333,7 @@ struct ParticleTile
     /// Add one particle to this tile.
     ///
     template < int NR = NArrayReal, int NI = NArrayInt,
-               EnableIf_t<NR != 0 or NI != 0, int> foo = 0>
+               EnableIf_t<NR != 0 || NI != 0, int> foo = 0>
     void push_back (const SuperParticleType& sp)
     {
         auto np = numParticles();

--- a/Src/Particle/AMReX_ParticleTile.H
+++ b/Src/Particle/AMReX_ParticleTile.H
@@ -535,7 +535,7 @@ struct ParticleTile
         ptd.m_runtime_idata = m_runtime_i_ptrs.dataPtr();
 
 #ifdef AMREX_USE_GPU
-        if ((h_runtime_r_ptrs.size() > 0) or (h_runtime_i_ptrs.size() > 0)) {
+        if ((h_runtime_r_ptrs.size() > 0) || (h_runtime_i_ptrs.size() > 0)) {
             Gpu::synchronize();
         }
 #endif
@@ -590,7 +590,7 @@ struct ParticleTile
         ptd.m_runtime_idata = m_runtime_i_cptrs.dataPtr();
 
 #ifdef AMREX_USE_GPU
-        if ((h_runtime_r_cptrs.size() > 0) or (h_runtime_i_cptrs.size() > 0)) {
+        if ((h_runtime_r_cptrs.size() > 0) || (h_runtime_i_cptrs.size() > 0)) {
             Gpu::synchronize();
         }
 #endif

--- a/Src/Particle/AMReX_ParticleUtil.H
+++ b/Src/Particle/AMReX_ParticleUtil.H
@@ -271,7 +271,7 @@ bool enforcePeriodic (P& p,
     bool shifted = false;
     for (int idim = 0; idim < AMREX_SPACEDIM; ++idim)
     {
-        if (not is_per[idim]) continue;
+        if (! is_per[idim]) continue;
         if (p.pos(idim) >= phi[idim]) {
             while (p.pos(idim) >= phi[idim]) {
                 p.pos(idim) -= static_cast<ParticleReal>(phi[idim] - plo[idim]);
@@ -289,7 +289,7 @@ bool enforcePeriodic (P& p,
             if (p.pos(idim) > phi[idim]) p.pos(idim) = std::nextafter( (amrex::ParticleReal) phi[idim], (amrex::ParticleReal) plo[idim]);
             shifted = true;
         }
-        AMREX_ASSERT( (p.pos(idim) >= plo[idim] ) and ( p.pos(idim) < phi[idim] ));
+        AMREX_ASSERT( (p.pos(idim) >= plo[idim] ) && ( p.pos(idim) < phi[idim] ));
     }
 
     return shifted;

--- a/Src/Particle/AMReX_ParticleUtil.H
+++ b/Src/Particle/AMReX_ParticleUtil.H
@@ -148,7 +148,7 @@ numParticlesOutOfRange (PC const& pc, int lev_min, int lev_max, int nGrow)
     for (int lev = lev_min; lev <= lev_max; ++lev)
     {
 #ifdef _OPENMP
-#pragma omp parallel if (Gpu::notInLaunchRegion() and !system::regtest_reduction) reduction(+:num_wrong)
+#pragma omp parallel if (Gpu::notInLaunchRegion() && !system::regtest_reduction) reduction(+:num_wrong)
 #endif
         for(ParIter pti(pc, lev); pti.isValid(); ++pti)
         {

--- a/Src/Particle/AMReX_WriteBinaryParticleData.H
+++ b/Src/Particle/AMReX_WriteBinaryParticleData.H
@@ -49,7 +49,7 @@ void WriteBinaryParticleDataSync (PC const& pc,
     AMREX_ALWAYS_ASSERT( int_comp_names.size() == pc.NumIntComps() + NStructInt);
 
     std::string pdir = dir;
-    if ( not pdir.empty() and pdir[pdir.size()-1] != '/') pdir += '/';
+    if ( ! pdir.empty() && pdir[pdir.size()-1] != '/') pdir += '/';
     pdir += name;
 
     if ( ! pc.GetLevelDirectoriesCreated()) {
@@ -230,7 +230,7 @@ void WriteBinaryParticleDataSync (PC const& pc,
         }
 
         // Write out the header for each particle
-        if (gotsome and ParallelDescriptor::IOProcessor()) {
+        if (gotsome && ParallelDescriptor::IOProcessor()) {
             std::string HeaderFileName = LevelDir;
             HeaderFileName += "/Particle_H";
             std::ofstream ParticleHeader(HeaderFileName);
@@ -393,7 +393,7 @@ void WriteBinaryParticleDataAsync (PC const& pc,
     }
 
     std::string pdir = dir;
-    if ( not pdir.empty() and pdir[pdir.size()-1] != '/') pdir += '/';
+    if ( ! pdir.empty() && pdir[pdir.size()-1] != '/') pdir += '/';
     pdir += name;
 
     if (MyProc == IOProcNumber)

--- a/Tests/LinearSolvers/CellOverset/MyTest.cpp
+++ b/Tests/LinearSolvers/CellOverset/MyTest.cpp
@@ -216,7 +216,7 @@ MyTest::initData ()
                                               + pi*std::cos(fpi*x) * std::cos(fpi*y) * std::sin(fpi*z)))
                                             + a * (std::cos(tpi*x) * std::cos(tpi*y) * std::cos(tpi*z)
                                           + 0.25 * std::cos(fpi*x) * std::cos(fpi*y) * std::cos(fpi*z));
-                if (loverset and overset_box.contains(IntVect(AMREX_D_DECL(i,j,k)))) {
+                if (loverset && overset_box.contains(IntVect(AMREX_D_DECL(i,j,k)))) {
                     mask(i,j,k) = 0;
                     phifab(i,j,k) = exact(i,j,k);
                 } else {

--- a/Tests/LinearSolvers/EBTensor/MyTest.cpp
+++ b/Tests/LinearSolvers/EBTensor/MyTest.cpp
@@ -220,12 +220,12 @@ MyTest::initData ()
                     etafab(i,j,k) = seta;
 
 #if (AMREX_SPACEDIM == 2)
-                    if (x < -1.0 or x > 1.0 or
-                        y < -1.0 or y > 1.0)
+                    if (x < -1.0 || x > 1.0 ||
+                        y < -1.0 || y > 1.0)
 #elif (AMREX_SPACEDIM == 3)
-                    if (x < -1.0 or x > 1.0 or
-                        y < -1.0 or y > 1.0 or
-                        z < -1.0 or z > 1.0)
+                    if (x < -1.0 || x > 1.0 ||
+                        y < -1.0 || y > 1.0 ||
+                        z < -1.0 || z > 1.0)
 #endif
                     {
                         AMREX_D_TERM(x = std::max(-1.0,std::min(1.0,x));,

--- a/Tests/LinearSolvers/NodalOverset/MyTest.cpp
+++ b/Tests/LinearSolvers/NodalOverset/MyTest.cpp
@@ -58,7 +58,7 @@ MyTest::solve ()
         amrex::ParallelFor(bx,
         [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
-            if (domain.strictly_contains(IntVect(AMREX_D_DECL(i,j,k))) and
+            if (domain.strictly_contains(IntVect(AMREX_D_DECL(i,j,k))) &&
                 ma(i,j,k) == 1)
             {  // Let's set phi = 0 for unknown nodes
                 pa(i,j,k) = 0.0;

--- a/Tests/LinearSolvers/TensorOverset/MyTest.cpp
+++ b/Tests/LinearSolvers/TensorOverset/MyTest.cpp
@@ -167,7 +167,7 @@ MyTest::initData ()
             rhsfab(i,j,k,1) = vrhs;
             rhsfab(i,j,k,2) = wrhs;
             etafab(i,j,k) = seta;
-            if (vbx.contains(IntVect(i,j,k)) and overset_box.contains(IntVect(i,j,k))) {
+            if (vbx.contains(IntVect(i,j,k)) && overset_box.contains(IntVect(i,j,k))) {
                 solnfab(i,j,k,0) = u;
                 solnfab(i,j,k,1) = v;
                 solnfab(i,j,k,2) = w;

--- a/Tools/GNUMake/comps/gnu.mak
+++ b/Tools/GNUMake/comps/gnu.mak
@@ -30,7 +30,7 @@ COMP_VERSION = $(gcc_version)
 
 ########################################################################
 
-GENERIC_GNU_FLAGS = -fno-operator-names
+GENERIC_GNU_FLAGS =
 
 ifeq ($(EXPORT_DYNAMIC),TRUE)
   CPPFLAGS += -DAMREX_EXPORT_DYNAMIC

--- a/Tools/GNUMake/comps/gnu.mak
+++ b/Tools/GNUMake/comps/gnu.mak
@@ -30,7 +30,7 @@ COMP_VERSION = $(gcc_version)
 
 ########################################################################
 
-GENERIC_GNU_FLAGS =
+GENERIC_GNU_FLAGS = -fno-operator-names
 
 ifeq ($(EXPORT_DYNAMIC),TRUE)
   CPPFLAGS += -DAMREX_EXPORT_DYNAMIC

--- a/Tools/Plotfile/fcompare.cpp
+++ b/Tools/Plotfile/fcompare.cpp
@@ -46,17 +46,17 @@ int main_main()
             plotfile_a = amrex::get_command_argument(++farg);
         } else if (fname == "--infile2") {
             plotfile_b = amrex::get_command_argument(++farg);
-        } else if (fname == "-n" or fname == "--norm") {
+        } else if (fname == "-n" || fname == "--norm") {
             norm = std::stoi(amrex::get_command_argument(++farg));
-        } else if (fname == "-z" or fname == "--zone_info") {
+        } else if (fname == "-z" || fname == "--zone_info") {
             zone_info_var_name = amrex::get_command_argument(++farg);
             zone_info = true;
-        } else if (fname == "-d" or fname == "--diffvar") {
+        } else if (fname == "-d" || fname == "--diffvar") {
             diffvar = amrex::get_command_argument(++farg);
             plot_names[0] = diffvar;
-        } else if (fname == "-a" or fname == "--allow_diff_grids") {
+        } else if (fname == "-a" || fname == "--allow_diff_grids") {
             allow_diff_grids = true;
-        } else if (fname == "-r" or fname == "--rel_tol") {
+        } else if (fname == "-r" || fname == "--rel_tol") {
             rtol = std::stod(amrex::get_command_argument(++farg));
         } else if (fname == "--abs_tol") {
             atol = std::stod(amrex::get_command_argument(++farg));
@@ -75,7 +75,7 @@ int main_main()
         plotfile_b = amrex::get_command_argument(farg++);
     }
 
-    if (plotfile_a.empty() and plotfile_b.empty()) {
+    if (plotfile_a.empty() && plotfile_b.empty()) {
         amrex::Print()
             << "\n"
             << " Compare two plotfiles, zone by zone, to machine precision\n"
@@ -245,7 +245,7 @@ int main_main()
                     rerror[icomp_a] = rerror[icomp_a]/rerror_denom[icomp_a];
                 }
 
-                if (icomp_a == save_var_a or icomp_a == zone_info_var_a) {
+                if (icomp_a == save_var_a || icomp_a == zone_info_var_a) {
                     mf_b.abs(0,1);
                 }
 
@@ -272,7 +272,7 @@ int main_main()
                 amrex::Print() << " " << std::setw(24) << std::left << names_a[icomp_a]
                                << "  " << std::setw(50)
                                << "< variable not present in both files > \n";
-            } else if (has_nan_a[icomp_a] and has_nan_b[icomp_a]) {
+            } else if (has_nan_a[icomp_a] && has_nan_b[icomp_a]) {
                 amrex::Print() << " " << std::setw(24) << std::left << names_a[icomp_a]
                                << "  " << std::setw(50)
                                << "< NaN present in both A and B > \n";
@@ -314,7 +314,7 @@ int main_main()
         abserr_for_global_rerror = std::max(
             abserr_for_global_rerror, aerror[idx]);
         for (int icomp_a = 0; icomp_a < ncomp_a; ++icomp_a) {
-            any_nans = any_nans or has_nan_a[icomp_a] or has_nan_b[icomp_a];
+            any_nans = any_nans || has_nan_a[icomp_a] || has_nan_b[icomp_a];
         }
     }
 
@@ -365,7 +365,7 @@ int main_main()
         if (abort_if_not_all_found) return EXIT_FAILURE;
     }
 
-    if (global_error == 0.0 and !any_nans) {
+    if (global_error == 0.0 && !any_nans) {
         amrex::Print() << " PLOTFILE AGREE" << std::endl;
         return EXIT_SUCCESS;
     } else if ((abserr_for_global_rerror <= atol) ||

--- a/Tools/Plotfile/fsnapshot.cpp
+++ b/Tools/Plotfile/fsnapshot.cpp
@@ -38,25 +38,25 @@ void main_main()
     int farg = 1;
     while (farg <= narg) {
         const std::string& name = amrex::get_command_argument(farg);
-        if (name == "-n" or name == "--normaldir") {
+        if (name == "-n" || name == "--normaldir") {
             ndir_pass = std::stoi(amrex::get_command_argument(++farg));
-        } else if (name == "-p" or name == "--palette") {
+        } else if (name == "-p" || name == "--palette") {
             pfname[0] = amrex::get_command_argument(++farg);
-        } else if (name == "-v" or name == "--variable") {
+        } else if (name == "-v" || name == "--variable") {
             compname = amrex::get_command_argument(++farg);
-        } else if (name == "-M" or name == "--max") {
+        } else if (name == "-M" || name == "--max") {
             def_mx = std::stod(amrex::get_command_argument(++farg));
             ldef_mx = true;
-        } else if (name == "-m" or name == "--min") {
+        } else if (name == "-m" || name == "--min") {
             def_mn = std::stod(amrex::get_command_argument(++farg));
             ldef_mn = true;
-        } else if (name == "-L" or name == "--max_level") {
+        } else if (name == "-L" || name == "--max_level") {
             max_level = std::stoi(amrex::get_command_argument(++farg));
-        } else if (name == "-l" or name == "--log") {
+        } else if (name == "-l" || name == "--log") {
             do_log = true;
-        } else if (name == "-g" or name == "--origin") {
-            origin = true;
-        } else if (name == "-c" or name == "--coordinates") {
+        } else if (name == "-g" || name == "--origin") {
+            ||igin = true;
+        } else if (name == "-c" || name == "--coordinates") {
             location[0] = std::stod(amrex::get_command_argument(++farg));
             location[1] = std::stod(amrex::get_command_argument(++farg));
             location[2] = std::stod(amrex::get_command_argument(++farg));
@@ -66,11 +66,11 @@ void main_main()
         ++farg;
     }
 
-    if (pltfile.empty() and farg <= narg) {
+    if (pltfile.empty() && farg <= narg) {
         pltfile = amrex::get_command_argument(farg);
     }
 
-    if (pltfile.empty() or compname.empty()) {
+    if (pltfile.empty() || compname.empty()) {
         amrex::Print()
             << "\n"
             << " produce an image of 2-d plotfile or slice of 3-d plotfile\n"
@@ -97,8 +97,8 @@ void main_main()
 
     // make sure we have valid options set
     if (do_log) {
-        if (ldef_mx and def_mx < 0.) amrex::Abort("ERROR: log plot specified with negative maximum");
-        if (ldef_mn and def_mn < 0.) amrex::Abort("ERROR: log plot specified with negative minimum");
+        if (ldef_mx && def_mx < 0.) amrex::Abort("ERROR: log plot specified with negative maximum");
+        if (ldef_mn && def_mn < 0.) amrex::Abort("ERROR: log plot specified with negative minimum");
     }
 
     // get the palette
@@ -129,7 +129,7 @@ void main_main()
     if (max_level < 0) {
         max_level = pf.finestLevel();
     } else {
-        if (max_level < 0 or max_level > pf.finestLevel()) {
+        if (max_level < 0 || max_level > pf.finestLevel()) {
             amrex::Abort("ERROR: specified level not allowed");
         }
     }
@@ -153,7 +153,7 @@ void main_main()
         iloc[2] = (fhi.z-flo.z+1)/2 + flo.z;
     }
 
-    if (location[0] > -1.e36 or location[1] > -1.e36 or location[2] > -1.e36) {
+    if (location[0] > -1.e36 || location[1] > -1.e36 || location[2] > -1.e36) {
         Array<Real,AMREX_SPACEDIM> problo = pf.probLo();
         Array<Real,AMREX_SPACEDIM> dx = pf.cellSize(max_level);
         for (int idim = 0; idim < dim; ++idim) {

--- a/Tools/Postprocessing/C_Src/particle_compare.cpp
+++ b/Tools/Postprocessing/C_Src/particle_compare.cpp
@@ -57,7 +57,7 @@ struct ParticleHeader {
         hdr_file_name = par_file_name + "/Header";
 
         std::ifstream file(hdr_file_name.c_str());
-        if ( not file.is_open() ) {
+        if ( ! file.is_open() ) {
 #ifdef BL_USE_MPI
             int myproc;
             MPI_Comm_rank(MPI_COMM_WORLD, &myproc);
@@ -74,7 +74,7 @@ struct ParticleHeader {
         }
 
         file >> *this;
-        if (not file.is_open() ) {
+        if (! file.is_open() ) {
 #ifdef BL_USE_MPI
             int myproc;
             MPI_Comm_rank(MPI_COMM_WORLD, &myproc);
@@ -178,7 +178,7 @@ bool operator==(const ParticleHeader& lhs, const ParticleHeader& rhs) {
 }
 
 bool operator!=(const ParticleHeader& lhs, const ParticleHeader& rhs) {
-    return not (lhs == rhs);
+    return ! (lhs == rhs);
 }
 
 std::ostream& operator<< (std::ostream& stream, const ParticleHeader& header) {
@@ -442,7 +442,7 @@ int main_main()
     int farg=1;
     while (farg <= narg) {
         const std::string fname = amrex::get_command_argument(farg);
-        if (fname == "-r" or fname == "--rel_tol") {
+        if (fname == "-r" || fname == "--rel_tol") {
             rtol = std::stod(amrex::get_command_argument(++farg));
         } else {
             break;
@@ -460,7 +460,7 @@ int main_main()
         pt = amrex::get_command_argument(farg++);
     }
 
-    if (fn1.empty() or fn2.empty() or pt.empty()) {
+    if (fn1.empty() || fn2.empty() || pt.empty()) {
         amrex::Print()
             << "\n"
             << " Compare the particles in two plotfiles, grid by grid,\n"

--- a/Tutorials/Amr/Advection_AmrLevel/Source/AmrLevelAdv.cpp
+++ b/Tutorials/Amr/Advection_AmrLevel/Source/AmrLevelAdv.cpp
@@ -75,7 +75,7 @@ AmrLevelAdv::checkPoint (const std::string& dir,
 {
   AmrLevel::checkPoint(dir, os, how, dump_old);
 #ifdef AMREX_PARTICLES
-  if (do_tracers and level == 0) {
+  if (do_tracers && level == 0) {
     TracerPC->Checkpoint(dir, "Tracer", true);
   }
 #endif
@@ -93,7 +93,7 @@ AmrLevelAdv::writePlotFile (const std::string& dir,
     AmrLevel::writePlotFile (dir,os,how);
 
 #ifdef AMREX_PARTICLES
-    if (do_tracers and level == 0) {
+    if (do_tracers && level == 0) {
       TracerPC->Checkpoint(dir, "Tracer", true);
     }
 #endif
@@ -587,7 +587,7 @@ void
 AmrLevelAdv::post_restart() 
 {
 #ifdef AMREX_PARTICLES
-    if (do_tracers and level == 0) {
+    if (do_tracers && level == 0) {
       BL_ASSERT(TracerPC == 0);
       TracerPC.reset(new AmrTracerParticleContainer(parent));
       TracerPC->Restart(parent->theRestartFile(), "Tracer");
@@ -760,7 +760,7 @@ AmrLevelAdv::avgDown (int state_indx)
 void
 AmrLevelAdv::init_particles ()
 {
-  if (do_tracers and level == 0)
+  if (do_tracers && level == 0)
     {
       BL_ASSERT(TracerPC == nullptr);
       

--- a/Tutorials/LinearSolvers/ABecLaplacian_C/MyTest.cpp
+++ b/Tutorials/LinearSolvers/ABecLaplacian_C/MyTest.cpp
@@ -463,7 +463,7 @@ MyTest::initData ()
     rhs.resize(nlevels);
     exact_solution.resize(nlevels);
     
-    if (prob_type == 2 or prob_type == 3) {
+    if (prob_type == 2 || prob_type == 3) {
         acoef.resize(nlevels);
         bcoef.resize(nlevels);
     }

--- a/Tutorials/Particles/CellSortedParticles/CellSortedPC.cpp
+++ b/Tutorials/Particles/CellSortedParticles/CellSortedPC.cpp
@@ -110,13 +110,13 @@ CellSortedParticleContainer::UpdateCellVectors()
     const int lev = 0;
 
     bool needs_update = false;
-    if (not m_vectors_initialized)
+    if (! m_vectors_initialized)
     {
         // this is the first call, so we must update
         m_vectors_initialized = true;
         needs_update = true;
     }
-    else if ((m_BARef != this->ParticleBoxArray(lev).getRefID()) or 
+    else if ((m_BARef != this->ParticleBoxArray(lev).getRefID()) ||
              (m_DMRef != this->ParticleDistributionMap(lev).getRefID()))
     {
         // the grids have changed, so we must update
@@ -125,7 +125,7 @@ CellSortedParticleContainer::UpdateCellVectors()
         needs_update = true;
     }
     
-    if (not needs_update) return;
+    if (! needs_update) return;
 
     // clear old data
     m_cell_vectors.clear();
@@ -269,7 +269,7 @@ void
 CellSortedParticleContainer::correctCellVectors(int old_index, int new_index, 
 						int grid, const ParticleType& p)
 {
-    if (not p.idata(IntData::sorted)) return;
+    if (! p.idata(IntData::sorted)) return;
     IntVect iv(p.idata(IntData::i), p.idata(IntData::j), p.idata(IntData::k));
     auto& cell_vector = m_cell_vectors[grid](iv);
     for (int i = 0; i < static_cast<int>(cell_vector.size()); ++i) {
@@ -283,7 +283,7 @@ CellSortedParticleContainer::correctCellVectors(int old_index, int new_index,
 int
 CellSortedParticleContainer::SumCellVectors()
 {
-  if (not m_vectors_initialized) return 0;
+  if (! m_vectors_initialized) return 0;
 
   const int lev = 0;
   int np = 0;
@@ -345,7 +345,7 @@ CellSortedParticleContainer::numWrongCell()
         for(int pindex = 0; pindex < np; ++pindex) {
             const ParticleType& p = particles[pindex];
             const IntVect& iv = this->Index(p, lev);
-            if ((iv[0] != p.idata(IntData::i)) or (iv[1] != p.idata(IntData::j)) or (iv[2] != p.idata(IntData::k))) {
+            if ((iv[0] != p.idata(IntData::i)) || (iv[1] != p.idata(IntData::j)) || (iv[2] != p.idata(IntData::k))) {
                 num_wrong += 1;
             }
         }
@@ -360,7 +360,7 @@ CellSortedParticleContainer::visitAllParticles()
 {
     const int lev = 0;
 
-    if (not m_vectors_initialized) return;
+    if (! m_vectors_initialized) return;
     
     for (MyParIter pti(*this, lev); pti.isValid(); ++pti)
     {

--- a/Tutorials/Particles/NeighborList/MDParticleContainer.cpp
+++ b/Tutorials/Particles/NeighborList/MDParticleContainer.cpp
@@ -240,7 +240,7 @@ void MDParticleContainer::moveParticles(const amrex::Real& dt)
             p.pos(2) += p.rdata(PIdx::vz) * dt;
 
             for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-                while ( (p.pos(idim) < plo[idim]) or (p.pos(idim) > phi[idim]) ) {
+                while ( (p.pos(idim) < plo[idim]) || (p.pos(idim) > phi[idim]) ) {
                     if ( p.pos(idim) < plo[idim] ) {
                         p.pos(idim) = 2*plo[idim] - p.pos(idim);
                     } else {


### PR DESCRIPTION
Operators like `and`, `or`, and `not` are allowed in the C++ standard; however, they cause problems on Windows and with our clang CI. This PR removes them from AMReX in favor of `&&`, `||`, and `!`, and also configures the CI to throw a compilation error if they are re-introduced into the codebase.

Application codes are still free to use these if they want.

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
