### PR TITLE
CI: Disable DPC++ oneAPI 2020-11

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -162,7 +162,10 @@ jobs:
             -DAMReX_CUDA_ARCH=6.0
         make -j 2
 
+# disabled since Intel patched a new CMake Compiler ID in with incomplete support
+# for dpcpp
   tutorials-dpcpp:
+    if: false
     name: DPCPP@PubBeta GFortran@7.5 C++17 [tutorials]
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary

Someone patched in a dedicated CMake compiler ID for Intel DPC++
but did not add full compiler support.

Release: 2021.1.1

Ref.: https://gitlab.kitware.com/cmake/cmake/-/issues/21551

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
