### PR TITLE
Implement overset mask for MLPoisson too

### DIFF
--- a/Src/LinearSolvers/CMakeLists.txt
+++ b/Src/LinearSolvers/CMakeLists.txt
@@ -21,6 +21,8 @@ target_sources(amrex
    MLMG/AMReX_MLNodeLinOp.cpp
    MLMG/AMReX_MLCellABecLap.H
    MLMG/AMReX_MLCellABecLap.cpp
+   MLMG/AMReX_MLCellABecLap_K.H
+   MLMG/AMReX_MLCellABecLap_${AMReX_SPACEDIM}D_K.H
    MLMG/AMReX_MLCGSolver.H
    MLMG/AMReX_MLCGSolver.cpp
    MLMG/AMReX_MLABecLaplacian.H

--- a/Src/LinearSolvers/MLMG/AMReX_MLABecLap_1D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLABecLap_1D_K.H
@@ -45,7 +45,7 @@ void mlabeclap_adotx_os (Box const& box, Array4<Real> const& y,
     AMREX_PRAGMA_SIMD
     for (int i = lo.x; i <= hi.x; ++i) {
         if (osm(i,0,0) == 0) {
-            y(i,0,0,n) = 0.0;
+            y(i,0,0,n) = Real(0.0);
         } else {
             y(i,0,0,n) = alpha*a(i,0,0)*x(i,0,0,n)
                 - dhx * (bX(i+1,0,0)*(x(i+1,0,0,n) - x(i  ,0,0,n))
@@ -126,9 +126,9 @@ void abec_gsrb (Box const& box, Array4<Real> const& phi, Array4<Real const> cons
         for (int i = lo.x; i <= hi.x; ++i) {
             if ((i+redblack)%2 == 0) {
                 Real cf0 = (i == vlo.x && m0(vlo.x-1,0,0) > 0)
-                    ? f0(vlo.x,0,0,n) : 0.0;
+                    ? f0(vlo.x,0,0,n) : Real(0.0);
                 Real cf1 = (i == vhi.x && m1(vhi.x+1,0,0) > 0)
-                    ? f1(vhi.x,0,0,n) : 0.0;
+                    ? f1(vhi.x,0,0,n) : Real(0.0);
 
                 Real delta = dhx*(bX(i,0,0)*cf0 + bX(i+1,0,0)*cf1);
 
@@ -167,12 +167,12 @@ void abec_gsrb_os (Box const& box, Array4<Real> const& phi, Array4<Real const> c
         for (int i = lo.x; i <= hi.x; ++i) {
             if ((i+redblack)%2 == 0) {
                 if (osm(i,0,0) == 0) {
-                    phi(i,0,0) = 0.0;
+                    phi(i,0,0) = Real(0.0);
                 } else {
                     Real cf0 = (i == vlo.x && m0(vlo.x-1,0,0) > 0)
-                        ? f0(vlo.x,0,0,n) : 0.0;
+                        ? f0(vlo.x,0,0,n) : Real(0.0);
                     Real cf1 = (i == vhi.x && m1(vhi.x+1,0,0) > 0)
-                        ? f1(vhi.x,0,0,n) : 0.0;
+                        ? f1(vhi.x,0,0,n) : Real(0.0);
 
                     Real delta = dhx*(bX(i,0,0)*cf0 + bX(i+1,0,0)*cf1);
 
@@ -203,25 +203,6 @@ void abec_gsrb_with_line_solve (
                 Box const& vbox, int redblack, int nc) noexcept
 {
     amrex::Abort("abec_gsrb_with_line_solve not implemented in 1D");
-}
-
-AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-int coarsen_overset_mask (Box const& bx, Array4<int> const& cmsk, Array4<int const> const& fmsk)
-    noexcept
-{
-    int nerrors = 0;
-    const auto lo = amrex::lbound(bx);
-    const auto hi = amrex::ubound(bx);
-    for (int i = lo.x; i <= hi.x; ++i) {
-        int ii = 2*i;
-        cmsk(i,0,0) = fmsk(ii,0,0) + fmsk(ii+1,0,0);
-        if (cmsk(i,0,0) == 2) {
-            cmsk(i,0,0) = 1;
-        } else if (cmsk(i,0,0) != 0) {
-            ++nerrors;
-        }
-    }
-    return nerrors;
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE

--- a/Src/LinearSolvers/MLMG/AMReX_MLABecLap_2D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLABecLap_2D_K.H
@@ -54,7 +54,7 @@ void mlabeclap_adotx_os (Box const& box, Array4<Real> const& y,
         AMREX_PRAGMA_SIMD
         for (int i = lo.x; i <= hi.x; ++i) {
             if (osm(i,j,0) == 0) {
-                y(i,j,0,n) = 0.0;
+                y(i,j,0,n) = Real(0.0);
             } else {
                 y(i,j,0,n) = alpha*a(i,j,0)*x(i,j,0,n)
                     - dhx * (bX(i+1,j,0,n)*(x(i+1,j,0,n) - x(i  ,j,0,n))
@@ -187,13 +187,13 @@ void abec_gsrb (Box const& box, Array4<Real> const& phi, Array4<Real const> cons
             for (int i = lo.x; i <= hi.x; ++i) {
                 if ((i+j+redblack)%2 == 0) {
                     Real cf0 = (i == vlo.x && m0(vlo.x-1,j,0) > 0)
-                        ? f0(vlo.x,j,0,n) : 0.0;
+                        ? f0(vlo.x,j,0,n) : Real(0.0);
                     Real cf1 = (j == vlo.y && m1(i,vlo.y-1,0) > 0)
-                        ? f1(i,vlo.y,0,n) : 0.0;
+                        ? f1(i,vlo.y,0,n) : Real(0.0);
                     Real cf2 = (i == vhi.x && m2(vhi.x+1,j,0) > 0)
-                        ? f2(vhi.x,j,0,n) : 0.0;
+                        ? f2(vhi.x,j,0,n) : Real(0.0);
                     Real cf3 = (j == vhi.y && m3(i,vhi.y+1,0) > 0)
-                        ? f3(i,vhi.y,0,n) : 0.0;
+                        ? f3(i,vhi.y,0,n) : Real(0.0);
 
                     Real delta = dhx*(bX(i,j,0,n)*cf0 + bX(i+1,j,0,n)*cf2)
                               +  dhy*(bY(i,j,0,n)*cf1 + bY(i,j+1,0,n)*cf3);
@@ -238,16 +238,16 @@ void abec_gsrb_os (Box const& box, Array4<Real> const& phi, Array4<Real const> c
             for (int i = lo.x; i <= hi.x; ++i) {
                 if ((i+j+redblack)%2 == 0) {
                     if (osm(i,j,0) == 0) {
-                        phi(i,j,0,n) = 0.0;
+                        phi(i,j,0,n) = Real(0.0);
                     } else {
                         Real cf0 = (i == vlo.x && m0(vlo.x-1,j,0) > 0)
-                            ? f0(vlo.x,j,0,n) : 0.0;
+                            ? f0(vlo.x,j,0,n) : Real(0.0);
                         Real cf1 = (j == vlo.y && m1(i,vlo.y-1,0) > 0)
-                            ? f1(i,vlo.y,0,n) : 0.0;
+                            ? f1(i,vlo.y,0,n) : Real(0.0);
                         Real cf2 = (i == vhi.x && m2(vhi.x+1,j,0) > 0)
-                            ? f2(vhi.x,j,0,n) : 0.0;
+                            ? f2(vhi.x,j,0,n) : Real(0.0);
                         Real cf3 = (j == vhi.y && m3(i,vhi.y+1,0) > 0)
-                            ? f3(i,vhi.y,0,n) : 0.0;
+                            ? f3(i,vhi.y,0,n) : Real(0.0);
 
                         Real delta = dhx*(bX(i,j,0,n)*cf0 + bX(i+1,j,0,n)*cf2)
                                   +  dhy*(bY(i,j,0,n)*cf1 + bY(i,j+1,0,n)*cf3);
@@ -320,13 +320,13 @@ void abec_gsrb_with_line_solve (
                         +   dhy*(bY(i,j,0,n)+bY(i,j+1,0,n));
 
                     Real cf0 = (i == vlo.x && m0(vlo.x-1,j,0) > 0)
-                        ? f0(vlo.x,j,0,n) : 0.0;
+                        ? f0(vlo.x,j,0,n) : Real(0.0);
                     Real cf1 = (j == vlo.y && m1(i,vlo.y-1,0) > 0)
-                        ? f1(i,vlo.y,0,n) : 0.0;
+                        ? f1(i,vlo.y,0,n) : Real(0.0);
                     Real cf2 = (i == vhi.x && m2(vhi.x+1,j,0) > 0)
-                        ? f2(vhi.x,j,0,n) : 0.0;
+                        ? f2(vhi.x,j,0,n) : Real(0.0);
                     Real cf3 = (j == vhi.y && m3(i,vhi.y+1,0) > 0)
-                        ? f3(i,vhi.y,0,n) : 0.0;
+                        ? f3(i,vhi.y,0,n) : Real(0.0);
 
                     Real g_m_d = gamma
                         - (dhx*(bX(i,j,0,n)*cf0 + bX(i+1,j,0,n)*cf2)
@@ -344,15 +344,15 @@ void abec_gsrb_with_line_solve (
                     a_ls(j-lo.y) = -dhy*bY(i,j,0,n);
                     b_ls(j-lo.y) =  g_m_d;
                     c_ls(j-lo.y) = -dhy*bY(i,j+1,0,n);
-                    u_ls(j-lo.y) = 0.;
+                    u_ls(j-lo.y) = Real(0.);
                     r_ls(j-lo.y) = rhs(i,j,0,n) + rho;
 
                     if (j == lo.y) {
-                        a_ls(j-lo.y) = 0.;
+                        a_ls(j-lo.y) = Real(0.);
                         if (!(m1(i,vlo.y-1,0) > 0)) r_ls(j-lo.y) += dhy*bY(i,j,0,n)*phi(i,j-1,0,n);
                     }
                     if (j == hi.y) {
-                        c_ls(j-lo.y) = 0.;
+                        c_ls(j-lo.y) = Real(0.);
                         if (!(m3(i,vhi.y+1,0) > 0)) r_ls(j-lo.y) += dhy*bY(i,j+1,0,n)*phi(i,j+1,0,n);
                     }
                 }
@@ -379,27 +379,6 @@ void abec_gsrb_with_line_solve (
             }
 	}
     }
-}
-
-AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-int coarsen_overset_mask (Box const& bx, Array4<int> const& cmsk, Array4<int const> const& fmsk)
-    noexcept
-{
-    int nerrors = 0;
-    const auto lo = amrex::lbound(bx);
-    const auto hi = amrex::ubound(bx);
-    for (int j = lo.y; j <= hi.y; ++j) {
-    for (int i = lo.x; i <= hi.x; ++i) {
-        int ii = 2*i;
-        int jj = 2*j;
-        cmsk(i,j,0) = fmsk(ii,jj,0) + fmsk(ii+1,jj,0) + fmsk(ii,jj+1,0) + fmsk(ii+1,jj+1,0);
-        if (cmsk(i,j,0) == 4) {
-            cmsk(i,j,0) = 1;
-        } else if (cmsk(i,j,0) != 0) {
-            ++nerrors;
-        }
-    }}
-    return nerrors;
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE

--- a/Src/LinearSolvers/MLMG/AMReX_MLABecLap_3D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLABecLap_3D_K.H
@@ -63,7 +63,7 @@ void mlabeclap_adotx_os (Box const& box, Array4<Real> const& y,
             AMREX_PRAGMA_SIMD
             for (int i = lo.x; i <= hi.x; ++i) {
                 if (osm(i,j,k) == 0) {
-                    y(i,j,k,n) = 0.0;
+                    y(i,j,k,n) = Real(0.0);
                 } else {
                     y(i,j,k,n) = alpha*a(i,j,k)*x(i,j,k,n)
                         - dhx * (bX(i+1,j,k,n)*(x(i+1,j,k,n) - x(i  ,j,k,n))
@@ -256,7 +256,7 @@ void abec_gsrb (Box const& box, Array4<Real> const& phi, Array4<Real const> cons
     const auto vlo = amrex::lbound(vbox);
     const auto vhi = amrex::ubound(vbox);
 
-    constexpr Real omega = 1.15;
+    constexpr Real omega = Real(1.15);
 
     for (int n = 0; n < nc; ++n) {
         for         (int k = lo.z; k <= hi.z; ++k) {
@@ -265,17 +265,17 @@ void abec_gsrb (Box const& box, Array4<Real> const& phi, Array4<Real const> cons
                 for (int i = lo.x; i <= hi.x; ++i) {
                     if ((i+j+k+redblack)%2 == 0) {
                         Real cf0 = (i == vlo.x && m0(vlo.x-1,j,k) > 0)
-                            ? f0(vlo.x,j,k,n) : 0.0;
+                            ? f0(vlo.x,j,k,n) : Real(0.0);
                         Real cf1 = (j == vlo.y && m1(i,vlo.y-1,k) > 0)
-                            ? f1(i,vlo.y,k,n) : 0.0;
+                            ? f1(i,vlo.y,k,n) : Real(0.0);
                         Real cf2 = (k == vlo.z && m2(i,j,vlo.z-1) > 0)
-                            ? f2(i,j,vlo.z,n) : 0.0;
+                            ? f2(i,j,vlo.z,n) : Real(0.0);
                         Real cf3 = (i == vhi.x && m3(vhi.x+1,j,k) > 0)
-                            ? f3(vhi.x,j,k,n) : 0.0;
+                            ? f3(vhi.x,j,k,n) : Real(0.0);
                         Real cf4 = (j == vhi.y && m4(i,vhi.y+1,k) > 0)
-                            ? f4(i,vhi.y,k,n) : 0.0;
+                            ? f4(i,vhi.y,k,n) : Real(0.0);
                         Real cf5 = (k == vhi.z && m5(i,j,vhi.z+1) > 0)
-                            ? f5(i,j,vhi.z,n) : 0.0;
+                            ? f5(i,j,vhi.z,n) : Real(0.0);
 
                         Real gamma = alpha*a(i,j,k)
                             +   dhx*(bX(i,j,k,n)+bX(i+1,j,k,n))
@@ -325,7 +325,7 @@ void abec_gsrb_os (Box const& box, Array4<Real> const& phi, Array4<Real const> c
     const auto vlo = amrex::lbound(vbox);
     const auto vhi = amrex::ubound(vbox);
 
-    constexpr Real omega = 1.15;
+    constexpr Real omega = Real(1.15);
 
     for (int n = 0; n < nc; ++n) {
         for         (int k = lo.z; k <= hi.z; ++k) {
@@ -334,20 +334,20 @@ void abec_gsrb_os (Box const& box, Array4<Real> const& phi, Array4<Real const> c
                 for (int i = lo.x; i <= hi.x; ++i) {
                     if ((i+j+k+redblack)%2 == 0) {
                         if (osm(i,j,k) == 0) {
-                            phi(i,j,k,n) = 0.0;
+                            phi(i,j,k,n) = Real(0.0);
                         } else {
                             Real cf0 = (i == vlo.x && m0(vlo.x-1,j,k) > 0)
-                                ? f0(vlo.x,j,k,n) : 0.0;
+                                ? f0(vlo.x,j,k,n) : Real(0.0);
                             Real cf1 = (j == vlo.y && m1(i,vlo.y-1,k) > 0)
-                                ? f1(i,vlo.y,k,n) : 0.0;
+                                ? f1(i,vlo.y,k,n) : Real(0.0);
                             Real cf2 = (k == vlo.z && m2(i,j,vlo.z-1) > 0)
-                                ? f2(i,j,vlo.z,n) : 0.0;
+                                ? f2(i,j,vlo.z,n) : Real(0.0);
                             Real cf3 = (i == vhi.x && m3(vhi.x+1,j,k) > 0)
-                                ? f3(vhi.x,j,k,n) : 0.0;
+                                ? f3(vhi.x,j,k,n) : Real(0.0);
                             Real cf4 = (j == vhi.y && m4(i,vhi.y+1,k) > 0)
-                                ? f4(i,vhi.y,k,n) : 0.0;
+                                ? f4(i,vhi.y,k,n) : Real(0.0);
                             Real cf5 = (k == vhi.z && m5(i,j,vhi.z+1) > 0)
-                                ? f5(i,j,vhi.z,n) : 0.0;
+                                ? f5(i,j,vhi.z,n) : Real(0.0);
 
                             Real gamma = alpha*a(i,j,k)
                                 +   dhx*(bX(i,j,k,n)+bX(i+1,j,k,n))
@@ -459,17 +459,17 @@ void abec_gsrb_with_line_solve (
                                 +   dhz*(bZ(i,j,k,n)+bZ(i,j,k+1,n));
 
                             Real cf0 = (i == vlo.x && m0(vlo.x-1,j,k) > 0)
-                                ? f0(vlo.x,j,k,n) : 0.0;
+                                ? f0(vlo.x,j,k,n) : Real(0.0);
                             Real cf1 = (j == vlo.y && m1(i,vlo.y-1,k) > 0)
-                                ? f1(i,vlo.y,k,n) : 0.0;
+                                ? f1(i,vlo.y,k,n) : Real(0.0);
                             Real cf2 = (k == vlo.z && m2(i,j,vlo.z-1) > 0)
-                                ? f2(i,j,vlo.z,n) : 0.0;
+                                ? f2(i,j,vlo.z,n) : Real(0.0);
                             Real cf3 = (i == vhi.x && m3(vhi.x+1,j,k) > 0)
-                                ? f3(vhi.x,j,k,n) : 0.0;
+                                ? f3(vhi.x,j,k,n) : Real(0.0);
                             Real cf4 = (j == vhi.y && m4(i,vhi.y+1,k) > 0)
-                                ? f4(i,vhi.y,k,n) : 0.0;
+                                ? f4(i,vhi.y,k,n) : Real(0.0);
                             Real cf5 = (k == vhi.z && m5(i,j,vhi.z+1) > 0)
-                                ? f5(i,j,vhi.z,n) : 0.0;
+                                ? f5(i,j,vhi.z,n) : Real(0.0);
 
                             Real g_m_d = gamma
                                 - (dhx*(bX(i,j,k,n)*cf0 + bX(i+1,j,k,n)*cf3)
@@ -494,18 +494,18 @@ void abec_gsrb_with_line_solve (
                             a_ls(k-lo.z) = -dhz*bZ(i,j,k,n);
                             b_ls(k-lo.z) =  g_m_d;
                             c_ls(k-lo.z) = -dhz*bZ(i,j,k+1,n);
-                            u_ls(k-lo.z) = 0.;
+                            u_ls(k-lo.z) = Real(0.);
                             r_ls(k-lo.z) = rhs(i,j,k,n) + rho;
                             // r_ls(k-lo.z) = g_m_d*phi(i,j,k,n) -gamma*phi(i,j,k,n) + rhs(i,j,k,n) + rho;
 
                             if (k == lo.z)
                             {
-                                a_ls(k-lo.z) = 0.;
+                                a_ls(k-lo.z) = Real(0.);
                                 if (!(m2(i,j,vlo.z-1) > 0)) r_ls(k-lo.z) += dhz*bZ(i,j,k,n)*phi(i,j,k-1,n);
                             }
                             if (k == hi.z)
                             {
-                                c_ls(k-lo.z) = 0.;
+                                c_ls(k-lo.z) = Real(0.);
                                 if (!(m5(i,j,vhi.z+1) > 0)) r_ls(k-lo.z) += dhz*bZ(i,j,k+1,n)*phi(i,j,k+1,n);
                             }
                         }
@@ -535,17 +535,17 @@ void abec_gsrb_with_line_solve (
                                 +   dhz*(bZ(i,j,k,n)+bZ(i,j,k+1,n));
 
                             Real cf0 = (i == vlo.x && m0(vlo.x-1,j,k) > 0)
-                                ? f0(vlo.x,j,k,n) : 0.0;
+                                ? f0(vlo.x,j,k,n) : Real(0.0);
                             Real cf1 = (j == vlo.y && m1(i,vlo.y-1,k) > 0)
-                                ? f1(i,vlo.y,k,n) : 0.0;
+                                ? f1(i,vlo.y,k,n) : Real(0.0);
                             Real cf2 = (k == vlo.z && m2(i,j,vlo.z-1) > 0)
-                                ? f2(i,j,vlo.z,n) : 0.0;
+                                ? f2(i,j,vlo.z,n) : Real(0.0);
                             Real cf3 = (i == vhi.x && m3(vhi.x+1,j,k) > 0)
-                                ? f3(vhi.x,j,k,n) : 0.0;
+                                ? f3(vhi.x,j,k,n) : Real(0.0);
                             Real cf4 = (j == vhi.y && m4(i,vhi.y+1,k) > 0)
-                                ? f4(i,vhi.y,k,n) : 0.0;
+                                ? f4(i,vhi.y,k,n) : Real(0.0);
                             Real cf5 = (k == vhi.z && m5(i,j,vhi.z+1) > 0)
-                                ? f5(i,j,vhi.z,n) : 0.0;
+                                ? f5(i,j,vhi.z,n) : Real(0.0);
 
                             Real g_m_d = gamma
                                 - (dhx*(bX(i,j,k,n)*cf0 + bX(i+1,j,k,n)*cf3)
@@ -570,17 +570,17 @@ void abec_gsrb_with_line_solve (
                             a_ls(j-lo.y) = -dhy*bY(i,j,k,n);
                             b_ls(j-lo.y) =  g_m_d;
                             c_ls(j-lo.y) = -dhy*bY(i,j+1,k,n);
-                            u_ls(j-lo.y) = 0.;
+                            u_ls(j-lo.y) = Real(0.);
                             r_ls(j-lo.y) = rhs(i,j,k,n) + rho;
 
                             if (j == lo.y)
                             {
-                                a_ls(j-lo.y) = 0.;
+                                a_ls(j-lo.y) = Real(0.);
                                 if (!(m1(i,vlo.y-1,k) > 0)) r_ls(j-lo.y) += dhy*bY(i,j,k,n)*phi(i,j-1,k,n);
                             }
                             if (j == hi.y)
                             {
-                                c_ls(j-lo.y) = 0.;
+                                c_ls(j-lo.y) = Real(0.);
                                 if (!(m4(i,vhi.y+1,k) > 0)) r_ls(j-lo.y) += dhy*bY(i,j+1,k,n)*phi(i,j+1,k,n);
                             }
                         }
@@ -610,17 +610,17 @@ void abec_gsrb_with_line_solve (
                                 +   dhz*(bZ(i,j,k,n)+bZ(i,j,k+1,n));
 
                             Real cf0 = (i == vlo.x && m0(vlo.x-1,j,k) > 0)
-                                ? f0(vlo.x,j,k,n) : 0.0;
+                                ? f0(vlo.x,j,k,n) : Real(0.0);
                             Real cf1 = (j == vlo.y && m1(i,vlo.y-1,k) > 0)
-                                ? f1(i,vlo.y,k,n) : 0.0;
+                                ? f1(i,vlo.y,k,n) : Real(0.0);
                             Real cf2 = (k == vlo.z && m2(i,j,vlo.z-1) > 0)
-                                ? f2(i,j,vlo.z,n) : 0.0;
+                                ? f2(i,j,vlo.z,n) : Real(0.0);
                             Real cf3 = (i == vhi.x && m3(vhi.x+1,j,k) > 0)
-                                ? f3(vhi.x,j,k,n) : 0.0;
+                                ? f3(vhi.x,j,k,n) : Real(0.0);
                             Real cf4 = (j == vhi.y && m4(i,vhi.y+1,k) > 0)
-                                ? f4(i,vhi.y,k,n) : 0.0;
+                                ? f4(i,vhi.y,k,n) : Real(0.0);
                             Real cf5 = (k == vhi.z && m5(i,j,vhi.z+1) > 0)
-                                ? f5(i,j,vhi.z,n) : 0.0;
+                                ? f5(i,j,vhi.z,n) : Real(0.0);
 
                             Real g_m_d = gamma
                                 - (dhx*(bX(i,j,k,n)*cf0 + bX(i+1,j,k,n)*cf3)
@@ -645,17 +645,17 @@ void abec_gsrb_with_line_solve (
                             a_ls(i-lo.x) = -dhx*bX(i,j,k,n);
                             b_ls(i-lo.x) =  g_m_d;
                             c_ls(i-lo.x) = -dhx*bX(i+1,j,k,n);
-                            u_ls(i-lo.x) = 0.;
+                            u_ls(i-lo.x) = Real(0.);
                             r_ls(i-lo.x) = rhs(i,j,k,n) + rho;
 
                             if (i == lo.x)
                             {
-                                a_ls(i-lo.x) = 0.;
+                                a_ls(i-lo.x) = Real(0.);
                                 if (!(m0(vlo.x-1,j,k) > 0)) r_ls(i-lo.x) += dhx*bX(i,j,k,n)*phi(i-1,j,k,n);
                             }
                             if (i == hi.x)
                             {
-                                c_ls(i-lo.x) = 0.;
+                                c_ls(i-lo.x) = Real(0.);
                                 if (!(m3(vhi.x+1,j,k) > 0)) r_ls(i-lo.x) += dhx*bX(i+1,j,k,n)*phi(i+1,j,k,n);
                             }
                         }
@@ -671,32 +671,6 @@ void abec_gsrb_with_line_solve (
             }
 	}
     }	
-}
-
-AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-int coarsen_overset_mask (Box const& bx, Array4<int> const& cmsk, Array4<int const> const& fmsk)
-    noexcept
-{
-    int nerrors = 0;
-    const auto lo = amrex::lbound(bx);
-    const auto hi = amrex::ubound(bx);
-    for (int k = lo.z; k <= hi.z; ++k) {
-    for (int j = lo.y; j <= hi.y; ++j) {
-    for (int i = lo.x; i <= hi.x; ++i) {
-        int ii = 2*i;
-        int jj = 2*j;
-        int kk = 2*k;
-        cmsk(i,j,k) = fmsk(ii,jj  ,kk  ) + fmsk(ii+1,jj  ,kk  )
-            +         fmsk(ii,jj+1,kk  ) + fmsk(ii+1,jj+1,kk  )
-            +         fmsk(ii,jj  ,kk+1) + fmsk(ii+1,jj  ,kk+1)
-            +         fmsk(ii,jj+1,kk+1) + fmsk(ii+1,jj+1,kk+1);
-        if (cmsk(i,j,k) == 8) {
-            cmsk(i,j,k) = 1;
-        } else if (cmsk(i,j,k) != 0) {
-            ++nerrors;
-        }
-    }}}
-    return nerrors;
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE

--- a/Src/LinearSolvers/MLMG/AMReX_MLABecLaplacian.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLABecLaplacian.H
@@ -83,12 +83,6 @@ public:
         return std::unique_ptr<MLLinOp>{};
     }
 
-    virtual iMultiFab const* getOversetMask (int amrlev, int mglev) const override {
-        return m_overset_mask[amrlev][mglev].get();
-    }
-
-    virtual void applyOverset (int amlev, MultiFab& rhs) const override;
-
     void averageDownCoeffsSameAmrLevel (int amrlev, Vector<MultiFab>& a,
                                         Vector<Array<MultiFab,AMREX_SPACEDIM> >& b);
     void averageDownCoeffs ();
@@ -110,9 +104,10 @@ protected:
     Vector<Vector<MultiFab> > m_a_coeffs;
     Vector<Vector<Array<MultiFab,AMREX_SPACEDIM> > > m_b_coeffs;
 
-    Vector<Vector<std::unique_ptr<iMultiFab> > > m_overset_mask;
-
     Vector<int> m_is_singular;
+
+private:
+    void define_ab_coeffs ();
 };
 
 }

--- a/Src/LinearSolvers/MLMG/AMReX_MLABecLaplacian.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLABecLaplacian.cpp
@@ -33,19 +33,34 @@ MLABecLaplacian::define (const Vector<Geometry>& a_geom,
                          const Vector<FabFactory<FArrayBox> const*>& a_factory)
 {
     BL_PROFILE("MLABecLaplacian::define()");
-
     MLCellABecLap::define(a_geom, a_grids, a_dmap, a_info, a_factory);
+    define_ab_coeffs();
+}
 
+void
+MLABecLaplacian::define (const Vector<Geometry>& a_geom,
+                         const Vector<BoxArray>& a_grids,
+                         const Vector<DistributionMapping>& a_dmap,
+                         const Vector<iMultiFab const*>& a_overset_mask,
+                         const LPInfo& a_info,
+                         const Vector<FabFactory<FArrayBox> const*>& a_factory)
+{
+    BL_PROFILE("MLABecLaplacian::define(overset)");
+    MLCellABecLap::define(a_geom, a_grids, a_dmap, a_overset_mask, a_info, a_factory);
+    define_ab_coeffs();
+}
+
+void
+MLABecLaplacian::define_ab_coeffs ()
+{
     const int ncomp = getNComp();
 
     m_a_coeffs.resize(m_num_amr_levels);
     m_b_coeffs.resize(m_num_amr_levels);
-    m_overset_mask.resize(m_num_amr_levels);
     for (int amrlev = 0; amrlev < m_num_amr_levels; ++amrlev)
     {
         m_a_coeffs[amrlev].resize(m_num_mg_levels[amrlev]);
         m_b_coeffs[amrlev].resize(m_num_mg_levels[amrlev]);
-        m_overset_mask[amrlev].resize(m_num_mg_levels[amrlev]);
         for (int mglev = 0; mglev < m_num_mg_levels[amrlev]; ++mglev)
         {
             m_a_coeffs[amrlev][mglev].define(m_grids[amrlev][mglev],
@@ -59,92 +74,6 @@ MLABecLaplacian::define (const Vector<Geometry>& a_geom,
                                                        m_dmap[amrlev][mglev],
                                                        ncomp, 0, MFInfo(), *m_factory[amrlev][mglev]);
             }
-        }
-    }
-}
-
-void
-MLABecLaplacian::define (const Vector<Geometry>& a_geom,
-                         const Vector<BoxArray>& a_grids,
-                         const Vector<DistributionMapping>& a_dmap,
-                         const Vector<iMultiFab const*>& a_overset_mask,
-                         const LPInfo& a_info,
-                         const Vector<FabFactory<FArrayBox> const*>& a_factory)
-{
-    BL_PROFILE("MLABecLaplacian::define(overset)");
-
-    int namrlevs = a_geom.size();
-    m_overset_mask.resize(namrlevs);
-    for (int amrlev = 0; amrlev < namrlevs; ++amrlev)
-    {
-        m_overset_mask[amrlev].emplace_back(new iMultiFab(a_grids[amrlev], a_dmap[amrlev], 1, 1));
-        iMultiFab::Copy(*m_overset_mask[amrlev][0], *a_overset_mask[amrlev], 0, 0, 1, 0);
-        if (amrlev > 1) {
-            AMREX_ALWAYS_ASSERT(amrex::refine(a_geom[amrlev-1].Domain(),2)
-                                == a_geom[amrlev].Domain());
-        }
-    }
-
-    int amrlev = 0;
-    Box dom = a_geom[0].Domain();
-    for (int mglev = 1; mglev <= a_info.max_coarsening_level; ++mglev)
-    {
-        AMREX_ALWAYS_ASSERT(mg_coarsen_ratio == 2);
-        iMultiFab const& fine = *m_overset_mask[amrlev][mglev-1];
-        if (dom.coarsenable(2) && fine.boxArray().coarsenable(2)) {
-            dom.coarsen(2);
-            std::unique_ptr<iMultiFab> crse(new iMultiFab(amrex::coarsen(fine.boxArray(),2),
-                                                          fine.DistributionMap(), 1, 1));
-            ReduceOps<ReduceOpSum> reduce_op;
-            ReduceData<int> reduce_data(reduce_op);
-            using ReduceTuple = typename decltype(reduce_data)::Type;
-#ifdef _OPENMP
-#pragma omp parallel if (Gpu::notInLaunchRegion())
-#endif
-            for (MFIter mfi(*crse, TilingIfNotGPU()); mfi.isValid(); ++mfi)
-            {
-                const Box& bx = mfi.tilebox();
-                Array4<int const> const& fmsk = fine.const_array(mfi);
-                Array4<int> const& cmsk = crse->array(mfi);
-                reduce_op.eval(bx, reduce_data,
-                [=] AMREX_GPU_HOST_DEVICE (Box const& b) -> ReduceTuple
-                {
-                    return { coarsen_overset_mask(b, cmsk, fmsk) };
-                });
-            }
-            ReduceTuple hv = reduce_data.value();
-            if (amrex::get<0>(hv) == 0) {
-                m_overset_mask[amrlev].push_back(std::move(crse));
-            } else {
-                break;
-            }
-        } else {
-            break;
-        }
-    }
-    int max_overset_mask_coarsening_level = m_overset_mask[amrlev].size()-1;
-    ParallelAllReduce::Min(max_overset_mask_coarsening_level, ParallelContext::CommunicatorSub());
-    m_overset_mask[amrlev].resize(max_overset_mask_coarsening_level+1);
-
-    LPInfo linfo = a_info;
-    linfo.max_coarsening_level = std::min(a_info.max_coarsening_level,
-                                          max_overset_mask_coarsening_level);
-    define(a_geom, a_grids, a_dmap, linfo, a_factory);
-
-    amrlev = 0;
-    for (int mglev = 1; mglev < m_num_mg_levels[amrlev]; ++mglev) {
-        if (! isMFIterSafe(*m_overset_mask[amrlev][mglev], m_a_coeffs[amrlev][mglev])) {
-            std::unique_ptr<iMultiFab> osm(new iMultiFab(m_grids[amrlev][mglev],
-                                                         m_dmap[amrlev][mglev], 1, 1));
-            osm->ParallelCopy(*m_overset_mask[amrlev][mglev]);
-            std::swap(osm, m_overset_mask[amrlev][mglev]);
-        }
-    }
-
-    for (amrlev = 0; amrlev < m_num_amr_levels; ++amrlev) {
-        for (int mglev = 0; mglev < m_num_mg_levels[amrlev]; ++mglev) {
-            m_overset_mask[amrlev][mglev]->setBndry(1);
-            m_overset_mask[amrlev][mglev]->FillBoundary(m_geom[amrlev][mglev].periodicity());
         }
     }
 }
@@ -409,7 +338,7 @@ MLABecLaplacian::Fapply (int amrlev, int mglev, MultiFab& out, const MultiFab& i
                      const auto& byfab = bycoef.array(mfi);,
                      const auto& bzfab = bzcoef.array(mfi););
         if (m_overset_mask[amrlev][mglev]) {
-            const auto& osm = m_overset_mask[amrlev][mglev]->array(mfi);
+            const auto& osm = m_overset_mask[amrlev][mglev]->const_array(mfi);
             AMREX_LAUNCH_HOST_DEVICE_FUSIBLE_LAMBDA ( bx, tbx,
             {
                 mlabeclap_adotx_os(tbx, yfab, xfab, afab, AMREX_D_DECL(bxfab,byfab,bzfab),
@@ -717,27 +646,6 @@ MLABecLaplacian::update ()
     }
 
     m_needs_update = false;
-}
-
-void
-MLABecLaplacian::applyOverset (int amrlev, MultiFab& rhs) const
-{
-    if (m_overset_mask[amrlev][0]) {
-        const int ncomp = getNComp();
-#ifdef _OPENMP
-#pragma omp parallel if (Gpu::notInLaunchRegion())
-#endif
-        for (MFIter mfi(*m_overset_mask[amrlev][0],TilingIfNotGPU()); mfi.isValid(); ++mfi)
-        {
-            const Box& bx = mfi.tilebox();
-            Array4<Real> const& rfab = rhs.array(mfi);
-            Array4<int const> const& osm = m_overset_mask[amrlev][0]->const_array(mfi);
-            AMREX_HOST_DEVICE_PARALLEL_FOR_4D(bx, ncomp, i, j, k, n,
-            {
-                if (osm(i,j,k) == 0) rfab(i,j,k,n) = 0.0;
-            });
-        }
-    }
 }
 
 }

--- a/Src/LinearSolvers/MLMG/AMReX_MLCellABecLap.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLCellABecLap.H
@@ -28,6 +28,17 @@ public:
                  const LPInfo& a_info = LPInfo(),
                  const Vector<FabFactory<FArrayBox> const*>& a_factory = {});
 
+    void define (const Vector<Geometry>& a_geom,
+                 const Vector<BoxArray>& a_grids,
+                 const Vector<DistributionMapping>& a_dmap,
+                 const Vector<iMultiFab const*>& a_overset_mask,
+                 const LPInfo& a_info = LPInfo(),
+                 const Vector<FabFactory<FArrayBox> const*>& a_factory = {});
+
+    iMultiFab const* getOversetMask (int amrlev, int mglev) const {
+        return m_overset_mask[amrlev][mglev].get();
+    }
+
     virtual bool needsUpdate () const override {
         return MLCellLinOp::needsUpdate();
     }
@@ -48,9 +59,9 @@ public:
     virtual MultiFab const* getACoeffs (int amrlev, int mglev) const = 0;
     virtual Array<MultiFab const*,AMREX_SPACEDIM> getBCoeffs (int amrlev, int mglev) const = 0;
 
-    virtual iMultiFab const* getOversetMask (int /*amrlev*/, int /*mglev*/) const { return nullptr; }
-
     virtual void applyInhomogNeumannTerm (int amrlev, MultiFab& rhs) const final override;
+
+    virtual void applyOverset (int amlev, MultiFab& rhs) const override;
 
 #ifdef AMREX_USE_HYPRE
     virtual std::unique_ptr<Hypre> makeHypre (Hypre::Interface hypre_interface) const override;
@@ -59,6 +70,9 @@ public:
 #ifdef AMREX_USE_PETSC
     virtual std::unique_ptr<PETScABecLap> makePETSc () const override;
 #endif
+
+protected:
+    Vector<Vector<std::unique_ptr<iMultiFab> > > m_overset_mask;
 };
 
 }

--- a/Src/LinearSolvers/MLMG/AMReX_MLCellABecLap.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLCellABecLap.cpp
@@ -1,6 +1,7 @@
 
 #include <AMReX_MLCellABecLap.H>
 #include <AMReX_MLLinOp_K.H>
+#include <AMReX_MLCellABecLap_K.H>
 
 #ifdef AMREX_USE_PETSC
 #include <petscksp.h>
@@ -23,6 +24,99 @@ MLCellABecLap::define (const Vector<Geometry>& a_geom,
                        const Vector<FabFactory<FArrayBox> const*>& a_factory)
 {
     MLCellLinOp::define(a_geom, a_grids, a_dmap, a_info, a_factory);
+
+    m_overset_mask.resize(m_num_amr_levels);
+    for (int amrlev = 0; amrlev < m_num_amr_levels; ++amrlev) {
+        m_overset_mask[amrlev].resize(m_num_mg_levels[amrlev]);
+    }
+}
+
+void
+MLCellABecLap::define (const Vector<Geometry>& a_geom,
+                       const Vector<BoxArray>& a_grids,
+                       const Vector<DistributionMapping>& a_dmap,
+                       const Vector<iMultiFab const*>& a_overset_mask,
+                       const LPInfo& a_info,
+                       const Vector<FabFactory<FArrayBox> const*>& a_factory)
+{
+    BL_PROFILE("MLCellABecLap::define(overset)");
+
+    int namrlevs = a_geom.size();
+    m_overset_mask.resize(namrlevs);
+    for (int amrlev = 0; amrlev < namrlevs; ++amrlev)
+    {
+        m_overset_mask[amrlev].emplace_back(new iMultiFab(a_grids[amrlev], a_dmap[amrlev], 1, 1));
+        iMultiFab::Copy(*m_overset_mask[amrlev][0], *a_overset_mask[amrlev], 0, 0, 1, 0);
+        if (amrlev > 1) {
+            AMREX_ALWAYS_ASSERT(amrex::refine(a_geom[amrlev-1].Domain(),2)
+                                == a_geom[amrlev].Domain());
+        }
+    }
+
+    int amrlev = 0;
+    Box dom = a_geom[0].Domain();
+    for (int mglev = 1; mglev <= a_info.max_coarsening_level; ++mglev)
+    {
+        AMREX_ALWAYS_ASSERT(mg_coarsen_ratio == 2);
+        iMultiFab const& fine = *m_overset_mask[amrlev][mglev-1];
+        if (dom.coarsenable(2) && fine.boxArray().coarsenable(2)) {
+            dom.coarsen(2);
+            std::unique_ptr<iMultiFab> crse(new iMultiFab(amrex::coarsen(fine.boxArray(),2),
+                                                          fine.DistributionMap(), 1, 1));
+            ReduceOps<ReduceOpSum> reduce_op;
+            ReduceData<int> reduce_data(reduce_op);
+            using ReduceTuple = typename decltype(reduce_data)::Type;
+#ifdef _OPENMP
+#pragma omp parallel if (Gpu::notInLaunchRegion())
+#endif
+            for (MFIter mfi(*crse, TilingIfNotGPU()); mfi.isValid(); ++mfi)
+            {
+                const Box& bx = mfi.tilebox();
+                Array4<int const> const& fmsk = fine.const_array(mfi);
+                Array4<int> const& cmsk = crse->array(mfi);
+                reduce_op.eval(bx, reduce_data,
+                [=] AMREX_GPU_HOST_DEVICE (Box const& b) -> ReduceTuple
+                {
+                    return { coarsen_overset_mask(b, cmsk, fmsk) };
+                });
+            }
+            ReduceTuple hv = reduce_data.value();
+            if (amrex::get<0>(hv) == 0) {
+                m_overset_mask[amrlev].push_back(std::move(crse));
+            } else {
+                break;
+            }
+        } else {
+            break;
+        }
+    }
+    int max_overset_mask_coarsening_level = m_overset_mask[amrlev].size()-1;
+    ParallelAllReduce::Min(max_overset_mask_coarsening_level, ParallelContext::CommunicatorSub());
+    m_overset_mask[amrlev].resize(max_overset_mask_coarsening_level+1);
+
+    LPInfo linfo = a_info;
+    linfo.max_coarsening_level = std::min(a_info.max_coarsening_level,
+                                          max_overset_mask_coarsening_level);
+
+    MLCellLinOp::define(a_geom, a_grids, a_dmap, linfo, a_factory);
+
+    amrlev = 0;
+    for (int mglev = 1; mglev < m_num_mg_levels[amrlev]; ++mglev) {
+        MultiFab foo(m_grids[amrlev][mglev], m_dmap[amrlev][mglev], 1, 0, MFInfo().SetAlloc(false));
+        if (! isMFIterSafe(*m_overset_mask[amrlev][mglev], foo)) {
+            std::unique_ptr<iMultiFab> osm(new iMultiFab(m_grids[amrlev][mglev],
+                                                         m_dmap[amrlev][mglev], 1, 1));
+            osm->ParallelCopy(*m_overset_mask[amrlev][mglev]);
+            std::swap(osm, m_overset_mask[amrlev][mglev]);
+        }
+    }
+
+    for (amrlev = 0; amrlev < m_num_amr_levels; ++amrlev) {
+        for (int mglev = 0; mglev < m_num_mg_levels[amrlev]; ++mglev) {
+            m_overset_mask[amrlev][mglev]->setBndry(1);
+            m_overset_mask[amrlev][mglev]->FillBoundary(m_geom[amrlev][mglev].periodicity());
+        }
+    }
 }
 
 void
@@ -224,6 +318,27 @@ MLCellABecLap::applyInhomogNeumannTerm (int amrlev, MultiFab& rhs) const
             }
         }
 
+    }
+}
+
+void
+MLCellABecLap::applyOverset (int amrlev, MultiFab& rhs) const
+{
+    if (m_overset_mask[amrlev][0]) {
+        const int ncomp = getNComp();
+#ifdef _OPENMP
+#pragma omp parallel if (Gpu::notInLaunchRegion())
+#endif
+        for (MFIter mfi(*m_overset_mask[amrlev][0],TilingIfNotGPU()); mfi.isValid(); ++mfi)
+        {
+            const Box& bx = mfi.tilebox();
+            Array4<Real> const& rfab = rhs.array(mfi);
+            Array4<int const> const& osm = m_overset_mask[amrlev][0]->const_array(mfi);
+            AMREX_HOST_DEVICE_PARALLEL_FOR_4D(bx, ncomp, i, j, k, n,
+            {
+                if (osm(i,j,k) == 0) rfab(i,j,k,n) = 0.0;
+            });
+        }
     }
 }
 

--- a/Src/LinearSolvers/MLMG/AMReX_MLCellABecLap_1D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLCellABecLap_1D_K.H
@@ -1,0 +1,28 @@
+#ifndef AMREX_MLCELLABECLAP_1D_K_H_
+#define AMREX_MLCELLABECLAP_1D_K_H_
+#include <AMReX_Config.H>
+
+namespace amrex {
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+int coarsen_overset_mask (Box const& bx, Array4<int> const& cmsk, Array4<int const> const& fmsk)
+    noexcept
+{
+    int nerrors = 0;
+    const auto lo = amrex::lbound(bx);
+    const auto hi = amrex::ubound(bx);
+    for (int i = lo.x; i <= hi.x; ++i) {
+        int ii = 2*i;
+        cmsk(i,0,0) = fmsk(ii,0,0) + fmsk(ii+1,0,0);
+        if (cmsk(i,0,0) == 2) {
+            cmsk(i,0,0) = 1;
+        } else if (cmsk(i,0,0) != 0) {
+            ++nerrors;
+        }
+    }
+    return nerrors;
+}
+
+}
+
+#endif

--- a/Src/LinearSolvers/MLMG/AMReX_MLCellABecLap_2D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLCellABecLap_2D_K.H
@@ -1,0 +1,30 @@
+#ifndef AMREX_MLCELLABECLAP_2D_K_H_
+#define AMREX_MLCELLABECLAP_2D_K_H_
+#include <AMReX_Config.H>
+
+namespace amrex {
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+int coarsen_overset_mask (Box const& bx, Array4<int> const& cmsk, Array4<int const> const& fmsk)
+    noexcept
+{
+    int nerrors = 0;
+    const auto lo = amrex::lbound(bx);
+    const auto hi = amrex::ubound(bx);
+    for (int j = lo.y; j <= hi.y; ++j) {
+    for (int i = lo.x; i <= hi.x; ++i) {
+        int ii = 2*i;
+        int jj = 2*j;
+        cmsk(i,j,0) = fmsk(ii,jj,0) + fmsk(ii+1,jj,0) + fmsk(ii,jj+1,0) + fmsk(ii+1,jj+1,0);
+        if (cmsk(i,j,0) == 4) {
+            cmsk(i,j,0) = 1;
+        } else if (cmsk(i,j,0) != 0) {
+            ++nerrors;
+        }
+    }}
+    return nerrors;
+}
+
+}
+
+#endif

--- a/Src/LinearSolvers/MLMG/AMReX_MLCellABecLap_3D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLCellABecLap_3D_K.H
@@ -1,0 +1,35 @@
+#ifndef AMREX_MLCELLABECLAP_3D_K_H_
+#define AMREX_MLCELLABECLAP_3D_K_H_
+#include <AMReX_Config.H>
+
+namespace amrex {
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+int coarsen_overset_mask (Box const& bx, Array4<int> const& cmsk, Array4<int const> const& fmsk)
+    noexcept
+{
+    int nerrors = 0;
+    const auto lo = amrex::lbound(bx);
+    const auto hi = amrex::ubound(bx);
+    for (int k = lo.z; k <= hi.z; ++k) {
+    for (int j = lo.y; j <= hi.y; ++j) {
+    for (int i = lo.x; i <= hi.x; ++i) {
+        int ii = 2*i;
+        int jj = 2*j;
+        int kk = 2*k;
+        cmsk(i,j,k) = fmsk(ii,jj  ,kk  ) + fmsk(ii+1,jj  ,kk  )
+            +         fmsk(ii,jj+1,kk  ) + fmsk(ii+1,jj+1,kk  )
+            +         fmsk(ii,jj  ,kk+1) + fmsk(ii+1,jj  ,kk+1)
+            +         fmsk(ii,jj+1,kk+1) + fmsk(ii+1,jj+1,kk+1);
+        if (cmsk(i,j,k) == 8) {
+            cmsk(i,j,k) = 1;
+        } else if (cmsk(i,j,k) != 0) {
+            ++nerrors;
+        }
+    }}}
+    return nerrors;
+}
+
+}
+
+#endif

--- a/Src/LinearSolvers/MLMG/AMReX_MLCellABecLap_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLCellABecLap_K.H
@@ -1,0 +1,15 @@
+#ifndef AMREX_MLCELLABECLAP_K_H_
+#define AMREX_MLCELLABECLAP_K_H_
+#include <AMReX_Config.H>
+
+#include <AMReX_FArrayBox.H>
+
+#if (AMREX_SPACEDIM == 1)
+#include <AMReX_MLCellABecLap_1D_K.H>
+#elif (AMREX_SPACEDIM == 2)
+#include <AMReX_MLCellABecLap_2D_K.H>
+#else
+#include <AMReX_MLCellABecLap_3D_K.H>
+#endif
+
+#endif

--- a/Src/LinearSolvers/MLMG/AMReX_MLPoisson.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLPoisson.H
@@ -21,6 +21,12 @@ public:
                const Vector<DistributionMapping>& a_dmap,
                const LPInfo& a_info = LPInfo(),
                const Vector<FabFactory<FArrayBox> const*>& a_factory = {});
+    MLPoisson (const Vector<Geometry>& a_geom,
+               const Vector<BoxArray>& a_grids,
+               const Vector<DistributionMapping>& a_dmap,
+               const Vector<iMultiFab const*>& a_overset_mask, // 1: unknown, 0: known
+               const LPInfo& a_info = LPInfo(),
+               const Vector<FabFactory<FArrayBox> const*>& a_factory = {});
     virtual ~MLPoisson ();
 
     MLPoisson (const MLPoisson&) = delete;
@@ -31,6 +37,13 @@ public:
     void define (const Vector<Geometry>& a_geom,
                  const Vector<BoxArray>& a_grids,
                  const Vector<DistributionMapping>& a_dmap,
+                 const LPInfo& a_info = LPInfo(),
+                 const Vector<FabFactory<FArrayBox> const*>& a_factory = {});
+
+    void define (const Vector<Geometry>& a_geom,
+                 const Vector<BoxArray>& a_grids,
+                 const Vector<DistributionMapping>& a_dmap,
+                 const Vector<iMultiFab const*>& a_overset_mask,
                  const LPInfo& a_info = LPInfo(),
                  const Vector<FabFactory<FArrayBox> const*>& a_factory = {});
 

--- a/Src/LinearSolvers/MLMG/AMReX_MLPoisson_1D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLPoisson_1D_K.H
@@ -9,7 +9,20 @@ void mlpoisson_adotx (int i, Array4<Real> const& y,
                       Array4<Real const> const& x,
                       Real dhx) noexcept
 {
-    y(i,0,0) = dhx * (x(i-1,0,0) - 2.0*x(i,0,0) + x(i+1,0,0));
+    y(i,0,0) = dhx * (x(i-1,0,0) - Real(2.0)*x(i,0,0) + x(i+1,0,0));
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void mlpoisson_adotx_os (int i, Array4<Real> const& y,
+                         Array4<Real const> const& x,
+                         Array4<int const> const& osm,
+                         Real dhx) noexcept
+{
+    if (osm(i,0,0) == 0) {
+        y(i,0,0) = Real(0.0);
+    } else {
+        y(i,0,0) = dhx * (x(i-1,0,0) - Real(2.0)*x(i,0,0) + x(i+1,0,0));
+    }
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
@@ -91,15 +104,15 @@ void mlpoisson_gsrb (Box const& box, Array4<Real> const& phi, Array4<Real const>
     const auto vlo = amrex::lbound(vbox);
     const auto vhi = amrex::ubound(vbox);
 
-    Real gamma = -dhx*2.0;
+    Real gamma = -dhx*Real(2.0);
 
     AMREX_PRAGMA_SIMD
     for (int i = lo.x; i <= hi.x; ++i) {
         if ((i+redblack)%2 == 0) {
             Real cf0 = (i == vlo.x && m0(vlo.x-1,0,0) > 0)
-                ? f0(vlo.x,0,0) : 0.0;
+                ? f0(vlo.x,0,0) : Real(0.0);
             Real cf1 = (i == vhi.x && m1(vhi.x+1,0,0) > 0)
-                ? f1(vhi.x,0,0) : 0.0;
+                ? f1(vhi.x,0,0) : Real(0.0);
 
             Real g_m_d = gamma + dhx*(cf0+cf1);
 
@@ -107,6 +120,42 @@ void mlpoisson_gsrb (Box const& box, Array4<Real> const& phi, Array4<Real const>
                 - dhx*(phi(i-1,0,0) + phi(i+1,0,0));
 
             phi(i,0,0) = phi(i,0,0) + res /g_m_d;
+        }
+    }
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void mlpoisson_gsrb_os (Box const& box, Array4<Real> const& phi, Array4<Real const> const& rhs,
+                        Array4<int const> const& osm, Real dhx,
+                        Array4<Real const> const& f0, Array4<int const> const& m0,
+                        Array4<Real const> const& f1, Array4<int const> const& m1,
+                        Box const& vbox, int redblack) noexcept
+{
+    const auto lo = amrex::lbound(box);
+    const auto hi = amrex::ubound(box);
+    const auto vlo = amrex::lbound(vbox);
+    const auto vhi = amrex::ubound(vbox);
+
+    Real gamma = -dhx*Real(2.0);
+
+    AMREX_PRAGMA_SIMD
+    for (int i = lo.x; i <= hi.x; ++i) {
+        if ((i+redblack)%2 == 0) {
+            if (osm(i,0,0) == 0) {
+                phi(i,0,0) = Real(0.0);
+            } else {
+                Real cf0 = (i == vlo.x && m0(vlo.x-1,0,0) > 0)
+                    ? f0(vlo.x,0,0) : Real(0.0);
+                Real cf1 = (i == vhi.x && m1(vhi.x+1,0,0) > 0)
+                    ? f1(vhi.x,0,0) : Real(0.0);
+
+                Real g_m_d = gamma + dhx*(cf0+cf1);
+
+                Real res = rhs(i,0,0) - gamma*phi(i,0,0)
+                    - dhx*(phi(i-1,0,0) + phi(i+1,0,0));
+
+                phi(i,0,0) = phi(i,0,0) + res /g_m_d;
+            }
         }
     }
 }
@@ -127,9 +176,9 @@ void mlpoisson_gsrb_m (Box const& box, Array4<Real> const& phi, Array4<Real cons
     for (int i = lo.x; i <= hi.x; ++i) {
         if ((i+redblack)%2 == 0) {
             Real cf0 = (i == vlo.x && m0(vlo.x-1,0,0) > 0)
-                ? f0(vlo.x,0,0) : 0.0;
+                ? f0(vlo.x,0,0) : Real(0.0);
             Real cf1 = (i == vhi.x && m1(vhi.x+1,0,0) > 0)
-                ? f1(vhi.x,0,0) : 0.0;
+                ? f1(vhi.x,0,0) : Real(0.0);
 
             Real rel = (probxlo + i   *dx) * (probxlo + i   *dx);
             Real rer = (probxlo +(i+1)*dx) * (probxlo +(i+1)*dx);

--- a/Src/LinearSolvers/MLMG/AMReX_MLPoisson_2D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLPoisson_2D_K.H
@@ -9,8 +9,22 @@ void mlpoisson_adotx (int i, int j, Array4<Real> const& y,
                       Array4<Real const> const& x,
                       Real dhx, Real dhy) noexcept
 {
-    y(i,j,0) = dhx * (x(i-1,j,0) - 2.*x(i,j,0) + x(i+1,j,0))
-        +      dhy * (x(i,j-1,0) - 2.*x(i,j,0) + x(i,j+1,0));
+    y(i,j,0) = dhx * (x(i-1,j,0) - Real(2.)*x(i,j,0) + x(i+1,j,0))
+        +      dhy * (x(i,j-1,0) - Real(2.)*x(i,j,0) + x(i,j+1,0));
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void mlpoisson_adotx_os (int i, int j, Array4<Real> const& y,
+                         Array4<Real const> const& x,
+                         Array4<int const> const& osm,
+                         Real dhx, Real dhy) noexcept
+{
+    if (osm(i,j,0) == 0) {
+        y(i,j,0) = Real(0.0);
+    } else {
+        y(i,j,0) = dhx * (x(i-1,j,0) - Real(2.)*x(i,j,0) + x(i+1,j,0))
+            +      dhy * (x(i,j-1,0) - Real(2.)*x(i,j,0) + x(i,j+1,0));
+    }
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
@@ -22,7 +36,7 @@ void mlpoisson_adotx_m (int i, int j, Array4<Real> const& y,
     Real rer = probxlo +(i+1)*dx;
     Real rc = probxlo + (i+0.5)*dx;
     y(i,j,0) = dhx * (rel*x(i-1,j,0) - (rel+rer)*x(i,j,0) + rer*x(i+1,j,0))
-        +      dhy * rc *(x(i,j-1,0) -        2.*x(i,j,0) +     x(i,j+1,0));
+        +      dhy * rc *(x(i,j-1,0) -  Real(2.)*x(i,j,0) +     x(i,j+1,0));
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
@@ -177,20 +191,20 @@ void mlpoisson_gsrb (Box const& box, Array4<Real> const& phi, Array4<Real const>
     const auto vlo = amrex::lbound(vbox);
     const auto vhi = amrex::ubound(vbox);
 
-    Real gamma = -2.0*dhx - 2.0*dhy;
+    Real gamma = Real(-2.0)*(dhx+dhy);
 
     for     (int j = lo.y; j <= hi.y; ++j) {
         AMREX_PRAGMA_SIMD
         for (int i = lo.x; i <= hi.x; ++i) {
             if ((i+j+redblack)%2 == 0) {
                 Real cf0 = (i == vlo.x && m0(vlo.x-1,j,0) > 0)
-                    ? f0(vlo.x,j,0) : 0.0;
+                    ? f0(vlo.x,j,0) : Real(0.0);
                 Real cf1 = (j == vlo.y && m1(i,vlo.y-1,0) > 0)
-                    ? f1(i,vlo.y,0) : 0.0;
+                    ? f1(i,vlo.y,0) : Real(0.0);
                 Real cf2 = (i == vhi.x && m2(vhi.x+1,j,0) > 0)
-                    ? f2(vhi.x,j,0) : 0.0;
+                    ? f2(vhi.x,j,0) : Real(0.0);
                 Real cf3 = (j == vhi.y && m3(i,vhi.y+1,0) > 0)
-                    ? f3(i,vhi.y,0) : 0.0;
+                    ? f3(i,vhi.y,0) : Real(0.0);
 
                 Real g_m_d = gamma + dhx*(cf0+cf2) + dhy*(cf1+cf3);
 
@@ -199,6 +213,51 @@ void mlpoisson_gsrb (Box const& box, Array4<Real> const& phi, Array4<Real const>
                     - dhy*(phi(i,j-1,0) + phi(i,j+1,0));
 
                 phi(i,j,0) = phi(i,j,0) + res /g_m_d;
+            }
+        }
+    }
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void mlpoisson_gsrb_os (Box const& box, Array4<Real> const& phi, Array4<Real const> const& rhs,
+                        Array4<int const> const& osm, Real dhx, Real dhy,
+                        Array4<Real const> const& f0, Array4<int const> const& m0,
+                        Array4<Real const> const& f1, Array4<int const> const& m1,
+                        Array4<Real const> const& f2, Array4<int const> const& m2,
+                        Array4<Real const> const& f3, Array4<int const> const& m3,
+                        Box const& vbox, int redblack) noexcept
+{
+    const auto lo = amrex::lbound(box);
+    const auto hi = amrex::ubound(box);
+    const auto vlo = amrex::lbound(vbox);
+    const auto vhi = amrex::ubound(vbox);
+
+    Real gamma = Real(-2.0)*(dhx+dhy);
+
+    for     (int j = lo.y; j <= hi.y; ++j) {
+        AMREX_PRAGMA_SIMD
+        for (int i = lo.x; i <= hi.x; ++i) {
+            if ((i+j+redblack)%2 == 0) {
+                if (osm(i,j,0) == 0) {
+                    phi(i,j,0) = Real(0.0);
+                } else {
+                    Real cf0 = (i == vlo.x && m0(vlo.x-1,j,0) > 0)
+                        ? f0(vlo.x,j,0) : Real(0.0);
+                    Real cf1 = (j == vlo.y && m1(i,vlo.y-1,0) > 0)
+                        ? f1(i,vlo.y,0) : Real(0.0);
+                    Real cf2 = (i == vhi.x && m2(vhi.x+1,j,0) > 0)
+                        ? f2(vhi.x,j,0) : Real(0.0);
+                    Real cf3 = (j == vhi.y && m3(i,vhi.y+1,0) > 0)
+                        ? f3(i,vhi.y,0) : Real(0.0);
+
+                    Real g_m_d = gamma + dhx*(cf0+cf2) + dhy*(cf1+cf3);
+
+                    Real res = rhs(i,j,0) - gamma*phi(i,j,0)
+                        - dhx*(phi(i-1,j,0) + phi(i+1,j,0))
+                        - dhy*(phi(i,j-1,0) + phi(i,j+1,0));
+
+                    phi(i,j,0) = phi(i,j,0) + res /g_m_d;
+                }
             }
         }
     }
@@ -223,19 +282,19 @@ void mlpoisson_gsrb_m (Box const& box, Array4<Real> const& phi, Array4<Real cons
         for (int i = lo.x; i <= hi.x; ++i) {
             if ((i+j+redblack)%2 == 0) {
                 Real cf0 = (i == vlo.x && m0(vlo.x-1,j,0) > 0)
-                    ? f0(vlo.x,j,0) : 0.0;
+                    ? f0(vlo.x,j,0) : Real(0.0);
                 Real cf1 = (j == vlo.y && m1(i,vlo.y-1,0) > 0)
-                    ? f1(i,vlo.y,0) : 0.0;
+                    ? f1(i,vlo.y,0) : Real(0.0);
                 Real cf2 = (i == vhi.x && m2(vhi.x+1,j,0) > 0)
-                    ? f2(vhi.x,j,0) : 0.0;
+                    ? f2(vhi.x,j,0) : Real(0.0);
                 Real cf3 = (j == vhi.y && m3(i,vhi.y+1,0) > 0)
-                    ? f3(i,vhi.y,0) : 0.0;
+                    ? f3(i,vhi.y,0) : Real(0.0);
 
                 Real rel = probxlo + i*dx;
                 Real rer = probxlo +(i+1)*dx;
                 Real rc = probxlo + (i+0.5)*dx;
 
-                Real gamma = -dhx*(rel+rer) - 2.0*dhy*rc;
+                Real gamma = -dhx*(rel+rer) - Real(2.0)*dhy*rc;
 
                 Real g_m_d = gamma + dhx*(rel*cf0+rer*cf2) + dhy*rc*(cf1+cf3);
 
@@ -262,7 +321,7 @@ void mlpoisson_normalize (Box const& box, Array4<Real> const& x,
             Real rel = probxlo + i*dx;
             Real rer = probxlo +(i+1)*dx;
             Real rc = probxlo + (i+0.5)*dx;
-            x(i,j,0) /= (-dhx*(rel+rer) - dhy*rc*2.0);
+            x(i,j,0) /= (-dhx*(rel+rer) - dhy*rc*Real(2.0));
         }
     }
 }

--- a/Src/LinearSolvers/MLMG/AMReX_MLPoisson_3D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLPoisson_3D_K.H
@@ -9,9 +9,24 @@ void mlpoisson_adotx (int i, int j, int k, Array4<Real> const& y,
                       Array4<Real const> const& x,
                       Real dhx, Real dhy, Real dhz) noexcept
 {
-    y(i,j,k) = dhx * (x(i-1,j,k) - 2.0*x(i,j,k) + x(i+1,j,k))
-        +      dhy * (x(i,j-1,k) - 2.0*x(i,j,k) + x(i,j+1,k))
-        +      dhz * (x(i,j,k-1) - 2.0*x(i,j,k) + x(i,j,k+1));
+    y(i,j,k) = dhx * (x(i-1,j,k) - Real(2.0)*x(i,j,k) + x(i+1,j,k))
+        +      dhy * (x(i,j-1,k) - Real(2.0)*x(i,j,k) + x(i,j+1,k))
+        +      dhz * (x(i,j,k-1) - Real(2.0)*x(i,j,k) + x(i,j,k+1));
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void mlpoisson_adotx_os (int i, int j, int k, Array4<Real> const& y,
+                         Array4<Real const> const& x,
+                         Array4<int const> const& osm,
+                         Real dhx, Real dhy, Real dhz) noexcept
+{
+    if (osm(i,j,k) == 0) {
+        y(i,j,k) = Real(0.0);
+    } else {
+        y(i,j,k) = dhx * (x(i-1,j,k) - Real(2.0)*x(i,j,k) + x(i+1,j,k))
+            +      dhy * (x(i,j-1,k) - Real(2.0)*x(i,j,k) + x(i,j+1,k))
+            +      dhz * (x(i,j,k-1) - Real(2.0)*x(i,j,k) + x(i,j,k+1));
+    }
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
@@ -144,9 +159,9 @@ void mlpoisson_gsrb (Box const& box, Array4<Real> const& phi,
     const auto vlo = amrex::lbound(vbox);
     const auto vhi = amrex::ubound(vbox);
 
-    constexpr Real omega = 1.15;
+    constexpr Real omega = Real(1.15);
 
-    const Real gamma = -2.*(dhx+dhy+dhz);
+    const Real gamma = Real(-2.)*(dhx+dhy+dhz);
 
     for         (int k = lo.z; k <= hi.z; ++k) {
         for     (int j = lo.y; j <= hi.y; ++j) {
@@ -154,17 +169,17 @@ void mlpoisson_gsrb (Box const& box, Array4<Real> const& phi,
             for (int i = lo.x; i <= hi.x; ++i) {
                 if ((i+j+k+redblack)%2 == 0) {
                     Real cf0 = (i == vlo.x && m0(vlo.x-1,j,k) > 0)
-                        ? f0(vlo.x,j,k) : 0.0;
+                        ? f0(vlo.x,j,k) : Real(0.0);
                     Real cf1 = (j == vlo.y && m1(i,vlo.y-1,k) > 0)
-                        ? f1(i,vlo.y,k) : 0.0;
+                        ? f1(i,vlo.y,k) : Real(0.0);
                     Real cf2 = (k == vlo.z && m2(i,j,vlo.z-1) > 0)
-                        ? f2(i,j,vlo.z) : 0.0;
+                        ? f2(i,j,vlo.z) : Real(0.0);
                     Real cf3 = (i == vhi.x && m3(vhi.x+1,j,k) > 0)
-                        ? f3(vhi.x,j,k) : 0.0;
+                        ? f3(vhi.x,j,k) : Real(0.0);
                     Real cf4 = (j == vhi.y && m4(i,vhi.y+1,k) > 0)
-                        ? f4(i,vhi.y,k) : 0.0;
+                        ? f4(i,vhi.y,k) : Real(0.0);
                     Real cf5 = (k == vhi.z && m5(i,j,vhi.z+1) > 0)
-                        ? f5(i,j,vhi.z) : 0.0;
+                        ? f5(i,j,vhi.z) : Real(0.0);
 
                     Real g_m_d = gamma + dhx*(cf0+cf3) + dhy*(cf1+cf4) + dhz*(cf2+cf5);
 
@@ -174,6 +189,64 @@ void mlpoisson_gsrb (Box const& box, Array4<Real> const& phi,
                         - dhz*(phi(i,j,k-1) + phi(i,j,k+1));
 
                     phi(i,j,k) = phi(i,j,k) + omega/g_m_d * res;
+                }
+            }
+        }
+    }
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void mlpoisson_gsrb_os (Box const& box, Array4<Real> const& phi,
+                        Array4<Real const> const& rhs,
+                        Array4<int const> const& osm,
+                        Real dhx, Real dhy, Real dhz,
+                        Array4<Real const> const& f0, Array4<int const> const& m0,
+                        Array4<Real const> const& f1, Array4<int const> const& m1,
+                        Array4<Real const> const& f2, Array4<int const> const& m2,
+                        Array4<Real const> const& f3, Array4<int const> const& m3,
+                        Array4<Real const> const& f4, Array4<int const> const& m4,
+                        Array4<Real const> const& f5, Array4<int const> const& m5,
+                        Box const& vbox, int redblack) noexcept
+{
+    const auto lo = amrex::lbound(box);
+    const auto hi = amrex::ubound(box);
+    const auto vlo = amrex::lbound(vbox);
+    const auto vhi = amrex::ubound(vbox);
+
+    constexpr Real omega = Real(1.15);
+
+    const Real gamma = Real(-2.)*(dhx+dhy+dhz);
+
+    for         (int k = lo.z; k <= hi.z; ++k) {
+        for     (int j = lo.y; j <= hi.y; ++j) {
+            AMREX_PRAGMA_SIMD
+            for (int i = lo.x; i <= hi.x; ++i) {
+                if ((i+j+k+redblack)%2 == 0) {
+                    if (osm(i,j,k) == 0) {
+                        phi(i,j,k) = Real(0.0);
+                    } else {
+                        Real cf0 = (i == vlo.x && m0(vlo.x-1,j,k) > 0)
+                            ? f0(vlo.x,j,k) : Real(0.0);
+                        Real cf1 = (j == vlo.y && m1(i,vlo.y-1,k) > 0)
+                            ? f1(i,vlo.y,k) : Real(0.0);
+                        Real cf2 = (k == vlo.z && m2(i,j,vlo.z-1) > 0)
+                            ? f2(i,j,vlo.z) : Real(0.0);
+                        Real cf3 = (i == vhi.x && m3(vhi.x+1,j,k) > 0)
+                            ? f3(vhi.x,j,k) : Real(0.0);
+                        Real cf4 = (j == vhi.y && m4(i,vhi.y+1,k) > 0)
+                            ? f4(i,vhi.y,k) : Real(0.0);
+                        Real cf5 = (k == vhi.z && m5(i,j,vhi.z+1) > 0)
+                            ? f5(i,j,vhi.z) : Real(0.0);
+
+                        Real g_m_d = gamma + dhx*(cf0+cf3) + dhy*(cf1+cf4) + dhz*(cf2+cf5);
+
+                        Real res = rhs(i,j,k) - gamma*phi(i,j,k)
+                            - dhx*(phi(i-1,j,k) + phi(i+1,j,k))
+                            - dhy*(phi(i,j-1,k) + phi(i,j+1,k))
+                            - dhz*(phi(i,j,k-1) + phi(i,j,k+1));
+
+                        phi(i,j,k) = phi(i,j,k) + omega/g_m_d * res;
+                    }
                 }
             }
         }

--- a/Src/LinearSolvers/MLMG/Make.package
+++ b/Src/LinearSolvers/MLMG/Make.package
@@ -20,6 +20,7 @@ CEXE_sources   += AMReX_MLNodeLinOp.cpp
 
 CEXE_headers   += AMReX_MLCellABecLap.H
 CEXE_sources   += AMReX_MLCellABecLap.cpp
+CEXE_headers   += AMReX_MLCellABecLap_K.H AMReX_MLCellABecLap_$(DIM)D_K.H
 
 CEXE_headers   += AMReX_MLCGSolver.H
 CEXE_sources   += AMReX_MLCGSolver.cpp


### PR DESCRIPTION
## Summary
Move overset mask to MLCellABecLap so that both MLABecLaplacian and MLPoisson can use it.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
