### PR TITLE
Remove DPCPP hacks

### DIFF
--- a/Src/Base/AMReX_GpuLaunchFunctsG.H
+++ b/Src/Base/AMReX_GpuLaunchFunctsG.H
@@ -325,10 +325,6 @@ void ParallelForRNG (Box const& box, T ncomp, L&& f) noexcept
 template <typename L1, typename L2>
 void ParallelFor (Gpu::KernelInfo const& /*info*/, Box const& box1, Box const& box2, L1&& f1, L2&& f2) noexcept
 {
-    // xxxxx DPCPP todo: launch separate kernel to reduce kernel size
-    ParallelFor(box1, std::forward<L1>(f1));
-    ParallelFor(box2, std::forward<L2>(f2));
-#if 0
     if (amrex::isEmpty(box1) and amrex::isEmpty(box2)) return;
     int ncells1 = box1.numPts();
     int ncells2 = box2.numPts();
@@ -376,7 +372,6 @@ void ParallelFor (Gpu::KernelInfo const& /*info*/, Box const& box1, Box const& b
     } catch (sycl::exception const& ex) {
         amrex::Abort(std::string("ParallelFor: ")+ex.what()+"!!!!!");
     }
-#endif
 }
 
 template <typename L1, typename L2, typename L3>
@@ -384,11 +379,6 @@ void ParallelFor (Gpu::KernelInfo const& /*info*/,
                   Box const& box1, Box const& box2, Box const& box3,
                   L1&& f1, L2&& f2, L3&& f3) noexcept
 {
-    // xxxxx DPCPP todo: launch separate kernel to reduce kernel size
-    ParallelFor(box1, std::forward<L1>(f1));
-    ParallelFor(box2, std::forward<L2>(f2));
-    ParallelFor(box3, std::forward<L3>(f3));
-#if 0
     if (amrex::isEmpty(box1) and amrex::isEmpty(box2) and amrex::isEmpty(box3)) return;
     int ncells1 = box1.numPts();
     int ncells2 = box2.numPts();
@@ -448,7 +438,6 @@ void ParallelFor (Gpu::KernelInfo const& /*info*/,
     } catch (sycl::exception const& ex) {
         amrex::Abort(std::string("ParallelFor: ")+ex.what()+"!!!!!");
     }
-#endif
 }
 
 template <typename T1, typename T2, typename L1, typename L2,
@@ -458,10 +447,6 @@ void ParallelFor (Gpu::KernelInfo const& /*info*/,
                   Box const& box1, T1 ncomp1, L1&& f1,
                   Box const& box2, T2 ncomp2, L2&& f2) noexcept
 {
-    // xxxxx DPCPP todo: launch separate kernel to reduce kernel size
-    ParallelFor(box1, ncomp1, std::forward<L1>(f1));
-    ParallelFor(box2, ncomp2, std::forward<L2>(f2));
-#if 0
     if (amrex::isEmpty(box1) and amrex::isEmpty(box2)) return;
     int ncells1 = box1.numPts();
     int ncells2 = box2.numPts();
@@ -513,7 +498,6 @@ void ParallelFor (Gpu::KernelInfo const& /*info*/,
     } catch (sycl::exception const& ex) {
         amrex::Abort(std::string("ParallelFor: ")+ex.what()+"!!!!!");
     }
-#endif
 }
 
 template <typename T1, typename T2, typename T3, typename L1, typename L2, typename L3,
@@ -525,11 +509,6 @@ void ParallelFor (Gpu::KernelInfo const& /*info*/,
                   Box const& box2, T2 ncomp2, L2&& f2,
                   Box const& box3, T3 ncomp3, L3&& f3) noexcept
 {
-    // xxxxx DPCPP todo: launch separate kernel to reduce kernel size
-    ParallelFor(box1, ncomp1, std::forward<L1>(f1));
-    ParallelFor(box2, ncomp2, std::forward<L2>(f2));
-    ParallelFor(box3, ncomp3, std::forward<L3>(f3));
-#if 0
     if (amrex::isEmpty(box1) and amrex::isEmpty(box2) and amrex::isEmpty(box3)) return;
     int ncells1 = box1.numPts();
     int ncells2 = box2.numPts();
@@ -595,7 +574,6 @@ void ParallelFor (Gpu::KernelInfo const& /*info*/,
     } catch (sycl::exception const& ex) {
         amrex::Abort(std::string("ParallelFor: ")+ex.what()+"!!!!!");
     }
-#endif
 }
 
 template <typename T, typename L1, typename L2>

--- a/Src/EB/AMReX_EB2_3D_C.cpp
+++ b/Src/EB/AMReX_EB2_3D_C.cpp
@@ -735,23 +735,10 @@ void build_cells (Box const& bx, Array4<EBCellFlag> const& cell,
     }
 
     // fix faces for small cells whose vfrac has been set to zero
-#ifdef AMREX_USE_DPCPP
-    // xxxxx DPCPP todo: kernel parameter size
-    Vector<Array4<Real const> > htmp = {fcx,fcy,fcz,m2x,m2y,m2z};
-    std::unique_ptr<Gpu::AsyncArray<Array4<Real const> > > dtmp;
-    if (Gpu::inLaunchRegion()) dtmp.reset(new Gpu::AsyncArray<Array4<Real const> >(htmp.data(), 6));
-    Array4<Real const>* ptmp = (Gpu::inLaunchRegion()) ? dtmp->data() : htmp.data();
-#endif
     const Box xbx = Box(bx).surroundingNodes(0).grow(1,1).grow(2,1);
     AMREX_HOST_DEVICE_FOR_3D ( xbx, i, j, k,
     {
         if (vfrac(i-1,j,k) == 0._rt or vfrac(i,j,k) == 0._rt) {
-            AMREX_DPCPP_ONLY(auto fcx = ptmp[0]);
-            AMREX_DPCPP_ONLY(auto fcy = ptmp[1]);
-            AMREX_DPCPP_ONLY(auto fcz = ptmp[2]);
-            AMREX_DPCPP_ONLY(auto m2x = ptmp[3]);
-            AMREX_DPCPP_ONLY(auto m2y = ptmp[4]);
-            AMREX_DPCPP_ONLY(auto m2z = ptmp[5]);
             fx(i,j,k) = Type::covered;
             apx(i,j,k) = 0.0;
             if (not cell(i  ,j,k).isCovered())
@@ -775,12 +762,6 @@ void build_cells (Box const& bx, Array4<EBCellFlag> const& cell,
     AMREX_HOST_DEVICE_FOR_3D ( ybx, i, j, k,
     {
         if (vfrac(i,j-1,k) == 0._rt or vfrac(i,j,k) == 0._rt) {
-            AMREX_DPCPP_ONLY(auto fcx = ptmp[0]);
-            AMREX_DPCPP_ONLY(auto fcy = ptmp[1]);
-            AMREX_DPCPP_ONLY(auto fcz = ptmp[2]);
-            AMREX_DPCPP_ONLY(auto m2x = ptmp[3]);
-            AMREX_DPCPP_ONLY(auto m2y = ptmp[4]);
-            AMREX_DPCPP_ONLY(auto m2z = ptmp[5]);
             fy(i,j,k) = Type::covered;
             apy(i,j,k) = 0.0;
             if (not cell(i,j  ,k).isCovered())
@@ -804,12 +785,6 @@ void build_cells (Box const& bx, Array4<EBCellFlag> const& cell,
     AMREX_HOST_DEVICE_FOR_3D ( zbx, i, j, k,
     {
         if (vfrac(i,j,k-1) == 0._rt or vfrac(i,j,k) == 0._rt) {
-            AMREX_DPCPP_ONLY(auto fcx = ptmp[0]);
-            AMREX_DPCPP_ONLY(auto fcy = ptmp[1]);
-            AMREX_DPCPP_ONLY(auto fcz = ptmp[2]);
-            AMREX_DPCPP_ONLY(auto m2x = ptmp[3]);
-            AMREX_DPCPP_ONLY(auto m2y = ptmp[4]);
-            AMREX_DPCPP_ONLY(auto m2z = ptmp[5]);
             fz(i,j,k) = Type::covered;
             apz(i,j,k) = 0.0;
             if (not cell(i,j,k  ).isCovered())

--- a/Src/EB/AMReX_EB2_Level.cpp
+++ b/Src/EB/AMReX_EB2_Level.cpp
@@ -357,18 +357,6 @@ Level::coarsenFromFine (Level& fineLevel, bool fill_boundary)
                          Box const& zgbx = amrex::surroundingNodes(gbx,2););
             Box const& ndgbx = amrex::surroundingNodes(gbx);
 
-#ifdef AMREX_USE_DPCPP
-            // xxxxx DPCPP todo: kernel size
-            Vector<Array4<Real const> > htmp = {fvol, fcent, fba, fbc, fbn,
-                                                AMREX_D_DECL(fapx,fapy,fapz),
-                                                AMREX_D_DECL(ffcx,ffcy,ffcz)};
-            Vector<Array4<Real> > htmp2 = {AMREX_D_DECL(capx,capy,capz)};
-            Gpu::AsyncArray<Array4<Real const> > dtmp(htmp.data(), 5+2*AMREX_SPACEDIM);
-            Gpu::AsyncArray<Array4<Real> > dtmp2(htmp2.data(), AMREX_SPACEDIM);
-            auto dp = dtmp.data();
-            auto dp2 = dtmp2.data();
-#endif
-
             reduce_op.eval(ndgbx, reduce_data,
             [=] AMREX_GPU_DEVICE (int i, int j, int k) -> ReduceTuple
             {
@@ -378,24 +366,11 @@ Level::coarsenFromFine (Level& fineLevel, bool fill_boundary)
                                              AMREX_D_DECL(xbx,ybx,zbx),
                                              AMREX_D_DECL(xgbx,ygbx,zgbx),
                                              cvol,ccent,cba,cbc,cbn,
-#ifdef AMREX_USE_DPCPP
-                                             AMREX_D_DECL(dp2[0],dp2[1],dp2[2]),
-#else
                                              AMREX_D_DECL(capx,capy,capz),
-#endif
                                              AMREX_D_DECL(cfcx,cfcy,cfcz),
-                                             cflag,
-#ifdef AMREX_USE_DPCPP
-                                             dp[0], dp[1], dp[2], dp[3], dp[4],
-                                             dp[5], dp[6], dp[7], dp[8],
-#if (AMREX_SPACEDIM == 3)
-                                             dp[9], dp[10],
-#endif
-#else
-                                             fvol,fcent,fba,fbc,fbn,
+                                             cflag,fvol,fcent,fba,fbc,fbn,
                                              AMREX_D_DECL(fapx,fapy,fapz),
                                              AMREX_D_DECL(ffcx,ffcy,ffcz),
-#endif
                                              fflag);
                 return {ierr};
             });

--- a/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap.cpp
@@ -757,33 +757,8 @@ MLEBABecLap::Fapply (int amrlev, int mglev, MultiFab& out, const MultiFab& in) c
 
             if (phi_on_centroid) amrex::Abort("phi_on_centroid is still a WIP");
 
-#ifdef AMREX_USE_DPCPP
-            // xxxxx DPCPP todo: kernel size
-            Vector<Array4<Real const> > htmp = {bafab,bcfab,bebfab,phiebfab,
-                                                AMREX_D_DECL(apxfab,apyfab,apzfab),
-                                                AMREX_D_DECL(fcxfab,fcyfab,fczfab)};
-            Gpu::AsyncArray<Array4<Real const> > dtmp(htmp.data(), 4+2*AMREX_SPACEDIM);
-            auto dp = dtmp.data();
-#endif
             AMREX_LAUNCH_HOST_DEVICE_LAMBDA ( bx, tbx,
             {
-                AMREX_DPCPP_ONLY(auto bafab    = dp[0]);
-                AMREX_DPCPP_ONLY(auto bcfab    = dp[1]);
-                AMREX_DPCPP_ONLY(auto bebfab   = dp[2]);
-                AMREX_DPCPP_ONLY(auto phiebfab = dp[3]);
-
-                AMREX_DPCPP_2D_ONLY(auto apxfab = dp[4]);
-                AMREX_DPCPP_2D_ONLY(auto apyfab = dp[5]);
-                AMREX_DPCPP_2D_ONLY(auto fcxfab = dp[6]);
-                AMREX_DPCPP_2D_ONLY(auto fcyfab = dp[7]);
-
-                AMREX_DPCPP_3D_ONLY(auto apxfab = dp[4]);
-                AMREX_DPCPP_3D_ONLY(auto apyfab = dp[5]);
-                AMREX_DPCPP_3D_ONLY(auto apzfab = dp[6]);
-                AMREX_DPCPP_3D_ONLY(auto fcxfab = dp[7]);
-                AMREX_DPCPP_3D_ONLY(auto fcyfab = dp[8]);
-                AMREX_DPCPP_3D_ONLY(auto fczfab = dp[9]);
-
                 mlebabeclap_adotx(tbx, yfab, xfab, afab, AMREX_D_DECL(bxfab,byfab,bzfab),
                                   ccmfab, flagfab, vfracfab,
                                   AMREX_D_DECL(apxfab,apyfab,apzfab),
@@ -905,28 +880,8 @@ MLEBABecLap::Fsmooth (int amrlev, int mglev, MultiFab& sol, const MultiFab& rhs,
         }
         else if (fabtyp == FabType::regular)
         {
-#ifdef AMREX_USE_DPCPP
-            // xxxxx DPCPP todo: kernel size
-            Vector<Array4<Real const> > htmp = {AMREX_D_DECL(f0fab,f2fab,f4fab),
-                                                AMREX_D_DECL(f1fab,f3fab,f5fab)};
-            Gpu::AsyncArray<Array4<Real const> > dtmp(htmp.data(), 2*AMREX_SPACEDIM);
-            auto dp = dtmp.data();
-#endif
-
             AMREX_LAUNCH_HOST_DEVICE_LAMBDA ( vbx, thread_box,
             {
-                AMREX_DPCPP_2D_ONLY(auto f0fab = dp[0]);
-                AMREX_DPCPP_2D_ONLY(auto f2fab = dp[1]);
-                AMREX_DPCPP_2D_ONLY(auto f1fab = dp[2]);
-                AMREX_DPCPP_2D_ONLY(auto f3fab = dp[3]);
-
-                AMREX_DPCPP_3D_ONLY(auto f0fab = dp[0]);
-                AMREX_DPCPP_3D_ONLY(auto f2fab = dp[1]);
-                AMREX_DPCPP_3D_ONLY(auto f4fab = dp[2]);
-                AMREX_DPCPP_3D_ONLY(auto f1fab = dp[3]);
-                AMREX_DPCPP_3D_ONLY(auto f3fab = dp[4]);
-                AMREX_DPCPP_3D_ONLY(auto f5fab = dp[5]);
-
                 abec_gsrb(thread_box, solnfab, rhsfab, alpha, afab,
                           AMREX_D_DECL(dhx, dhy, dhz),
                           AMREX_D_DECL(bxfab, byfab, bzfab),
@@ -958,53 +913,8 @@ MLEBABecLap::Fsmooth (int amrlev, int mglev, MultiFab& sol, const MultiFab& rhs,
 
             if (phi_on_centroid) amrex::Abort("phi_on_centroid is still a WIP");
 
-#ifdef AMREX_USE_DPCPP
-            // xxxxx DPCPP todo: kernel size
-            Vector<Array4<Real const> > htmp = {rhsfab,afab,
-                                                AMREX_D_DECL(bxfab,byfab,bzfab),
-                                                AMREX_D_DECL(f0fab,f2fab,f4fab),
-                                                AMREX_D_DECL(f1fab,f3fab,f5fab)};
-            Vector<Array4<int const> > htmp2 = {AMREX_D_DECL(m0,m2,m4),
-                                                AMREX_D_DECL(m1,m3,m5)};
-            Gpu::AsyncArray<Array4<Real const> > dtmp(htmp.data(), 2+3*AMREX_SPACEDIM);
-            Gpu::AsyncArray<Array4<int const> > dtmp2(htmp2.data(), 2*AMREX_SPACEDIM);
-            auto dp = dtmp.data();
-            auto dp2 = dtmp2.data();
-#endif
             AMREX_LAUNCH_HOST_DEVICE_LAMBDA ( vbx, thread_box,
             {
-                AMREX_DPCPP_ONLY(auto rhsfab = dp[0]);
-                AMREX_DPCPP_ONLY(auto afab   = dp[1]);
-
-                AMREX_DPCPP_2D_ONLY(auto bxfab = dp[2]);
-                AMREX_DPCPP_2D_ONLY(auto byfab = dp[3]);
-                AMREX_DPCPP_2D_ONLY(auto f0fab = dp[4]);
-                AMREX_DPCPP_2D_ONLY(auto f2fab = dp[5]);
-                AMREX_DPCPP_2D_ONLY(auto f1fab = dp[6]);
-                AMREX_DPCPP_2D_ONLY(auto f3fab = dp[7]);
-
-                AMREX_DPCPP_3D_ONLY(auto bxfab = dp[2]);
-                AMREX_DPCPP_3D_ONLY(auto byfab = dp[3]);
-                AMREX_DPCPP_3D_ONLY(auto bzfab = dp[4]);
-                AMREX_DPCPP_3D_ONLY(auto f0fab = dp[5]);
-                AMREX_DPCPP_3D_ONLY(auto f2fab = dp[6]);
-                AMREX_DPCPP_3D_ONLY(auto f4fab = dp[7]);
-                AMREX_DPCPP_3D_ONLY(auto f1fab = dp[8]);
-                AMREX_DPCPP_3D_ONLY(auto f3fab = dp[9]);
-                AMREX_DPCPP_3D_ONLY(auto f5fab = dp[10]);
-
-                AMREX_DPCPP_2D_ONLY(auto m0 = dp2[0]);
-                AMREX_DPCPP_2D_ONLY(auto m2 = dp2[1]);
-                AMREX_DPCPP_2D_ONLY(auto m1 = dp2[2]);
-                AMREX_DPCPP_2D_ONLY(auto m3 = dp2[3]);
-
-                AMREX_DPCPP_3D_ONLY(auto m0 = dp2[0]);
-                AMREX_DPCPP_3D_ONLY(auto m2 = dp2[1]);
-                AMREX_DPCPP_3D_ONLY(auto m4 = dp2[2]);
-                AMREX_DPCPP_3D_ONLY(auto m1 = dp2[3]);
-                AMREX_DPCPP_3D_ONLY(auto m3 = dp2[4]);
-                AMREX_DPCPP_3D_ONLY(auto m5 = dp2[5]);
-
                 mlebabeclap_gsrb(thread_box, solnfab, rhsfab, alpha, afab,
                                  AMREX_D_DECL(dhx, dhy, dhz),
                                  AMREX_D_DECL(bxfab,byfab,bzfab),
@@ -1092,39 +1002,19 @@ MLEBABecLap::FFlux (int amrlev, const MFIter& mfi, const Array<FArrayBox*,AMREX_
 
         if (phi_on_centroid) amrex::Abort("phi_on_centroid is still a WIP");
 
-#ifdef AMREX_USE_DPCPP
-        // xxxxx DPCPP todo: kernel size
-#if (AMREX_SPACEDIM == 2)
-        Vector<Array4<Real const> > htmp = {apx, fcx, bxcoef, apy, fcy, bycoef};
-#elif (AMREX_SPACEDIM == 3)
-        Vector<Array4<Real const> > htmp = {apx, fcx, bxcoef, apy, fcy, bycoef, apz, fcz, bzcoef};
-#endif
-        Gpu::AsyncArray<Array4<Real const> > dtmp(htmp.data(), htmp.size());
-        auto dp = dtmp.data();
-#endif
-
         AMREX_LAUNCH_HOST_DEVICE_LAMBDA_DIM (
             xbx, txbx,
             {
-                AMREX_DPCPP_ONLY(auto apx    = dp[0]);
-                AMREX_DPCPP_ONLY(auto fcx    = dp[1]);
-                AMREX_DPCPP_ONLY(auto bxcoef = dp[2]);
                 mlebabeclap_flux_x(txbx, fx, apx, fcx, phi, bxcoef, msk, dhx, face_only, ncomp, xbx,
                                    beta_on_centroid, phi_on_centroid);
             }
             , ybx, tybx,
             {
-                AMREX_DPCPP_ONLY(auto apy    = dp[3]);
-                AMREX_DPCPP_ONLY(auto fcy    = dp[4]);
-                AMREX_DPCPP_ONLY(auto bycoef = dp[5]);
                 mlebabeclap_flux_y(tybx, fy, apy, fcy, phi, bycoef, msk, dhy, face_only, ncomp, ybx,
                                    beta_on_centroid, phi_on_centroid);
             }
             , zbx, tzbx,
             {
-                AMREX_DPCPP_3D_ONLY(auto apz    = dp[6]);
-                AMREX_DPCPP_3D_ONLY(auto fcz    = dp[7]);
-                AMREX_DPCPP_3D_ONLY(auto bzcoef = dp[8]);
                 mlebabeclap_flux_z(tzbx, fz, apz, fcz, phi, bzcoef, msk, dhz, face_only, ncomp, zbx,
                                    beta_on_centroid, phi_on_centroid);
             }
@@ -1142,34 +1032,17 @@ MLEBABecLap::FFlux (int amrlev, const MFIter& mfi, const Array<FArrayBox*,AMREX_
                      Real dhy = m_b_scalar*dxinv[1];,
                      Real dhz = m_b_scalar*dxinv[2];);
 
-#ifdef AMREX_USE_DPCPP
-        // xxxxx DPCPP todo: kernel size
-#if (AMREX_SPACEDIM == 2)
-        Vector<Array4<Real const> > htmp = {apx, bxcoef, apy, bycoef};
-#elif (AMREX_SPACEDIM == 3)
-        Vector<Array4<Real const> > htmp = {apx, bxcoef, apy, bycoef, apz, bzcoef};
-#endif
-        Gpu::AsyncArray<Array4<Real const> > dtmp(htmp.data(), htmp.size());
-        auto dp = dtmp.data();
-#endif
-
         AMREX_LAUNCH_HOST_DEVICE_LAMBDA_DIM (
             xbx, txbx,
             {
-                AMREX_DPCPP_ONLY(auto apx    = dp[0]);
-                AMREX_DPCPP_ONLY(auto bxcoef = dp[1]);
                 mlebabeclap_flux_x_0(txbx, fx, apx, phi, bxcoef, dhx, face_only, ncomp, xbx);
             }
             , ybx, tybx,
             {
-                AMREX_DPCPP_ONLY(auto apy    = dp[2]);
-                AMREX_DPCPP_ONLY(auto bycoef = dp[3]);
                 mlebabeclap_flux_y_0(tybx, fy, apy, phi, bycoef, dhy, face_only, ncomp, ybx);
             }
             , zbx, tzbx,
             {
-                AMREX_DPCPP_3D_ONLY(auto apz    = dp[4]);
-                AMREX_DPCPP_3D_ONLY(auto bzcoef = dp[5]);
                 mlebabeclap_flux_z_0(tzbx, fz, apz, phi, bzcoef, dhz, face_only, ncomp, zbx);
             }
         );
@@ -1374,18 +1247,8 @@ MLEBABecLap::normalize (int amrlev, int mglev, MultiFab& mf) const
 
             bool beta_on_centroid = (m_beta_loc == Location::FaceCentroid);
 
-#ifdef AMREX_USE_DPCPP
-            // xxxxx DPCPP todo: kernel size
-            Vector<Array4<Real const> > htmp = {AMREX_D_DECL(fcxfab,fcyfab,fczfab)};
-            Gpu::AsyncArray<Array4<Real const> > dtmp(htmp.data(), AMREX_SPACEDIM);
-            auto dp = dtmp.data();
-#endif
-
             AMREX_LAUNCH_HOST_DEVICE_LAMBDA ( bx, tbx,
             {
-                AMREX_DPCPP_ONLY(   auto fcxfab = dp[0]);
-                AMREX_DPCPP_ONLY(   auto fcyfab = dp[1]);
-                AMREX_DPCPP_3D_ONLY(auto fczfab = dp[2]);
                 mlebabeclap_normalize(tbx, fab, ascalar, afab,
                                       AMREX_D_DECL(dhx, dhy, dhz),
                                       AMREX_D_DECL(bxfab, byfab, bzfab),

--- a/Src/LinearSolvers/MLMG/AMReX_MLEBTensorOp.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBTensorOp.cpp
@@ -261,17 +261,9 @@ MLEBTensorOp::apply (int amrlev, int mglev, MultiFab& out, MultiFab& in, BCMode 
                          Array4<Real const> const& fcy = fcent[1]->const_array(mfi);,
                          Array4<Real const> const& fcz = fcent[2]->const_array(mfi););
             Array4<Real const> const& bc = bcent->const_array(mfi);
-#ifdef AMREX_USE_DPCPP
-            // xxxxx DPCPP todo: kernel size
-            Vector<Array4<Real const> > htmp = {AMREX_D_DECL(fcx,fcy,fcz)};
-            Gpu::AsyncArray<Array4<Real const> > dtmp(htmp.data(), htmp.size());
-            auto dp = dtmp.data();
-#endif
+
             AMREX_LAUNCH_HOST_DEVICE_LAMBDA ( bx, tbx,
             {
-                AMREX_DPCPP_ONLY(   auto fcx = dp[0]);
-                AMREX_DPCPP_ONLY(   auto fcy = dp[1]);
-                AMREX_DPCPP_3D_ONLY(auto fcz = dp[2]);
                 mlebtensor_cross_terms(tbx, axfab,
                                        AMREX_D_DECL(fxfab,fyfab,fzfab),
                                        vfab, etab, kapb, ccm, flag, vol,
@@ -362,21 +354,8 @@ MLEBTensorOp::applyBCTensor (int amrlev, int mglev, MultiFab& vel,
             const auto& bvzhi = (bndry != nullptr) ?
                 (*bndry)[Orientation(2,Orientation::high)].array(mfi) : foo;
 
-#ifdef AMREX_USE_DPCPP
-            // xxxxx DPCPP todo: kernel size
-            Vector<Array4<int const> > htmp = {mxlo,mylo,mzlo,mxhi,myhi,mzhi};
-            Gpu::AsyncArray<Array4<int const> > dtmp(htmp.data(), htmp.size());
-            auto dp = dtmp.data();
-#endif
-
             AMREX_HOST_DEVICE_FOR_1D ( 12, iedge,
             {
-                AMREX_DPCPP_ONLY(auto mxlo = dp[0]);
-                AMREX_DPCPP_ONLY(auto mylo = dp[1]);
-                AMREX_DPCPP_ONLY(auto mzlo = dp[2]);
-                AMREX_DPCPP_ONLY(auto mxhi = dp[3]);
-                AMREX_DPCPP_ONLY(auto myhi = dp[4]);
-                AMREX_DPCPP_ONLY(auto mzhi = dp[5]);
                 mltensor_fill_edges(iedge, vbx, velfab,
                                     mxlo, mylo, mzlo, mxhi, myhi, mzhi,
                                     bvxlo, bvylo, bvzlo, bvxhi, bvyhi, bvzhi,
@@ -386,12 +365,6 @@ MLEBTensorOp::applyBCTensor (int amrlev, int mglev, MultiFab& vel,
 
             AMREX_HOST_DEVICE_FOR_1D ( 8, icorner,
             {
-                AMREX_DPCPP_ONLY(auto mxlo = dp[0]);
-                AMREX_DPCPP_ONLY(auto mylo = dp[1]);
-                AMREX_DPCPP_ONLY(auto mzlo = dp[2]);
-                AMREX_DPCPP_ONLY(auto mxhi = dp[3]);
-                AMREX_DPCPP_ONLY(auto myhi = dp[4]);
-                AMREX_DPCPP_ONLY(auto mzhi = dp[5]);
                 mltensor_fill_corners(icorner, vbx, velfab,
                                       mxlo, mylo, mzlo, mxhi, myhi, mzhi,
                                       bvxlo, bvylo, bvzlo, bvxhi, bvyhi, bvzhi,

--- a/Src/LinearSolvers/MLMG/AMReX_MLTensorOp.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLTensorOp.cpp
@@ -357,20 +357,6 @@ MLTensorOp::applyBCTensor (int amrlev, int mglev, MultiFab& vel,
 	  (*bndry)[Orientation(2,Orientation::high)].array(mfi) : foo;
 
 	// only edge vals used in 3D stencil
-#ifdef AMREX_USE_DPCPP
-        // xxxxx DPCPP todo: kernel size
-        Vector<Array4<int const> > htmp = {mxlo,mylo,mzlo,mxhi,myhi,mzhi};
-        Gpu::AsyncArray<Array4<int const> > dtmp(htmp.data(), 6);
-        auto dp = dtmp.data();
-        AMREX_HOST_DEVICE_FOR_1D ( 12, iedge,
-        {
-            mltensor_fill_edges(iedge, vbx, velfab,
-                                dp[0],dp[1],dp[2],dp[3],dp[4],dp[5],
-                                bvxlo, bvylo, bvzlo, bvxhi, bvyhi, bvzhi,
-                                bct, bcl, inhomog, imaxorder,
-                                dxinv, domain);
-        });
-#else
         AMREX_HOST_DEVICE_FOR_1D ( 12, iedge,
         {
             mltensor_fill_edges(iedge, vbx, velfab,
@@ -379,8 +365,6 @@ MLTensorOp::applyBCTensor (int amrlev, int mglev, MultiFab& vel,
                                 bct, bcl, inhomog, imaxorder,
                                 dxinv, domain);
         });
-#endif
-
 #endif
     }
 


### PR DESCRIPTION
Because the Intel graphics driver has increased the kernel parameters to 2K
by default, these hacks are no longer needed.
