### PR TITLE
DPCPP: run stencil rap on device

### DIFF
--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian.cpp
@@ -1021,12 +1021,7 @@ MLNodeLaplacian::buildStencil ()
                 bx &= vbx;
                 Array4<Real> const& csten = pcrse->array(mfi);
                 Array4<Real const> const& fsten = fine.const_array(mfi);
-#ifdef AMREX_USE_DPCPP
-                // xxxxx DPCPP todo: this kernel hangs at JIT compilation
-#ifndef AMREX_DPCPP_STENCIL_RAP_ON_GPU
-                Gpu::LaunchSafeGuard lsg(false);
-#endif
-#endif
+
                 AMREX_HOST_DEVICE_FOR_3D(bx, i, j, k,
                 {
                     mlndlap_stencil_rap(i,j,k,csten,fsten);


### PR DESCRIPTION
An earlier compiler bug has been fixed.  The stencil rap kernel can run on
GPU now.
