### PR TITLE
DPC++: Re-Enable with Work-around.

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -163,12 +163,9 @@ jobs:
             -DAMReX_CUDA_ARCH=6.0
         make -j 2
 
-# disabled since Intel patched a new CMake Compiler ID in with incomplete support
-# for dpcpp
   tutorials-dpcpp:
-    if: false
-    name: DPCPP@PubBeta GFortran@7.5 C++17 [tutorials]
-    runs-on: ubuntu-latest
+    name: DPCPP GFortran@7.5 C++17 [tutorials]
+    runs-on: ubuntu-20.04
     env: {CXXFLAGS: "-fno-operator-names"}
     steps:
     - uses: actions/checkout@v2
@@ -180,6 +177,9 @@ jobs:
         source /opt/intel/oneapi/setvars.sh
         set -e
         cmake -S . -B build                                \
+            -DCMAKE_CXX_COMPILER_ID="Clang"                \
+            -DCMAKE_CXX_COMPILER_VERSION=12.0              \
+            -DCMAKE_CXX_STANDARD_COMPUTED_DEFAULT="17"     \
             -DCMAKE_VERBOSE_MAKEFILE=ON                    \
             -DAMReX_BUILD_TUTORIALS=ON                     \
             -DAMReX_PARTICLES=ON                           \
@@ -188,6 +188,9 @@ jobs:
             -DCMAKE_CXX_COMPILER=$(which dpcpp)            \
             -DCMAKE_Fortran_COMPILER=$(which gfortran)
         cmake --build build --parallel 2
+    # note: setting the CXX compiler ID is a work-around for
+    # the 2021.1 DPC++ release / CMake 3.19.0-3.19.1
+    # https://gitlab.kitware.com/cmake/cmake/-/issues/21551#note_869580
 
   tutorials-hip:
     name: HIP ROCm@3.8 GFortran@9.3 C++17 [tutorials]


### PR DESCRIPTION
## Summary

My former colleagues shared a work-around that we can use to overwrite the compiler identification:
  https://gitlab.kitware.com/cmake/cmake/-/issues/21551#note_869580

This regression will also be fixed in CMake 3.19.2

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
