### PR TITLE
CMake: Verify DPC++ Compiler ID and at best warn

### DIFF
--- a/Tools/CMake/AMReXOptions.cmake
+++ b/Tools/CMake/AMReXOptions.cmake
@@ -126,12 +126,10 @@ endif ()
 
 # --- SYCL ---
 if (AMReX_DPCPP)
-  if (NOT AMReX_MPI)
-   if (NOT (CMAKE_CXX_COMPILER MATCHES "dpcpp") )
-      message(FATAL_ERROR "\nAMReX_GPU_BACKEND=${AMReX_GPU_BACKEND} supports dpcpp compiler only."
-         "Set CMAKE_CXX_COMPILER=dpccp and try again.")
+   if (NOT (CMAKE_CXX_COMPILER_ID IN_LIST "Clang;IntelClang;IntelDPCPP") )
+      message(WARNING "\nAMReX_GPU_BACKEND=${AMReX_GPU_BACKEND} is tested with DPCPP."
+         "Verify '${CMAKE_CXX_COMPILER_ID}' is correct and otherwise set CMAKE_CXX_COMPILER=dpccp.")
    endif ()
- endif ()
 endif ()
 
 cmake_dependent_option( AMReX_DPCPP_AOT  "Enable DPCPP ahead-of-time compilation (WIP)"  OFF

--- a/Tools/CMake/AMReXOptions.cmake
+++ b/Tools/CMake/AMReXOptions.cmake
@@ -126,12 +126,7 @@ endif ()
 
 # --- SYCL ---
 if (AMReX_DPCPP)
-  if (AMReX_MPI)
-    if (NOT (CMAKE_CXX_COMPILER MATCHES "mpiicpx") )
-       message(FATAL_ERROR "\nAMReX_GPU_BACKEND=${AMReX_GPU_BACKEND} only supports mpiicpx compiler when AMReX_MPI=ON"
-         "Set CMAKE_CXX_COMPILER=mpiicpx and try again.")
-    endif ()
-  else ()
+  if (NOT AMReX_MPI)
    if (NOT (CMAKE_CXX_COMPILER MATCHES "dpcpp") )
       message(FATAL_ERROR "\nAMReX_GPU_BACKEND=${AMReX_GPU_BACKEND} supports dpcpp compiler only."
          "Set CMAKE_CXX_COMPILER=dpccp and try again.")

--- a/Tools/CMake/AMReXOptions.cmake
+++ b/Tools/CMake/AMReXOptions.cmake
@@ -127,7 +127,7 @@ endif ()
 # --- SYCL ---
 if (AMReX_DPCPP)
    if (NOT (CMAKE_CXX_COMPILER_ID IN_LIST "Clang;IntelClang;IntelDPCPP") )
-      message(WARNING "AMReX_GPU_BACKEND=${AMReX_GPU_BACKEND} is tested with DPCPP."
+      message(WARNING "\nAMReX_GPU_BACKEND=${AMReX_GPU_BACKEND} is tested with DPCPP."
          "Verify '${CMAKE_CXX_COMPILER_ID}' is correct and potentially set CMAKE_CXX_COMPILER=dpccp or mpiicpx.")
    endif ()
 endif ()

--- a/Tools/CMake/AMReXOptions.cmake
+++ b/Tools/CMake/AMReXOptions.cmake
@@ -127,8 +127,8 @@ endif ()
 # --- SYCL ---
 if (AMReX_DPCPP)
    if (NOT (CMAKE_CXX_COMPILER_ID IN_LIST "Clang;IntelClang;IntelDPCPP") )
-      message(WARNING "\nAMReX_GPU_BACKEND=${AMReX_GPU_BACKEND} is tested with DPCPP."
-         "Verify '${CMAKE_CXX_COMPILER_ID}' is correct and otherwise set CMAKE_CXX_COMPILER=dpccp.")
+      message(WARNING "AMReX_GPU_BACKEND=${AMReX_GPU_BACKEND} is tested with DPCPP."
+         "Verify '${CMAKE_CXX_COMPILER_ID}' is correct and potentially set CMAKE_CXX_COMPILER=dpccp or mpiicpx.")
    endif ()
 endif ()
 


### PR DESCRIPTION
## Summary

Verifying a compiler binary name is hack-ish, because it does not work with:
- compiler aliases, e.g. `dpcpp-beta10` or scripts, e.g. `clang -fsycl` in my own wrappers
- absolute paths, i.e. `-DCMAKE_CXX_COMPILER=$(which dpcpp)`
- flexible configs and new experimental compilers (i.e. hipsycl experiments)

Instead, we now verify the compiler ID and if it does not match what we expect, we just warn.

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
