### PR TITLE
the A64fx Cray 10.0.1 compilers need the old-style options

### DIFF
--- a/Tools/GNUMake/comps/cray.mak
+++ b/Tools/GNUMake/comps/cray.mak
@@ -24,6 +24,14 @@ ifeq ($(shell expr $(COMP_VERSION) \>= 9), 1)
 else
   CCE_GE_V9 := FALSE
 endif
+
+# we need to be careful on the A64fx
+ifeq ($(CRAY_CC_VERSION),10.0.1)
+  ifeq ($(CRAY_ARCH_TARGET),aarch64)
+    CCE_GE_V9 := FALSE
+  endif
+endif
+
 ########################################################################
 
 ifeq ($(DEBUG),TRUE)


### PR DESCRIPTION
## Summary

The default cray compilers on the Ookami A64fx machine use the old-style options for cray compilers.  This logic
allows us to build there.

## Additional background

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
