### PR TITLE
Warning in SP: large ICC float constant

### DIFF
--- a/Src/Amr/AMReX_Amr.cpp
+++ b/Src/Amr/AMReX_Amr.cpp
@@ -329,7 +329,13 @@ Amr::InitAmr ()
     //
     for (int i = 0; i < nlev; i++)
     {
-        dt_level[i]    = 1.e200; // Something nonzero so old & new will differ
+        
+        // Something nonzero so old & new will differ
+#ifdef AMREX_USE_FLOAT
+        dt_level[i]    = 1.e30f;
+#else
+        dt_level[i]    = 1.e200;
+#endif
         level_steps[i] = 0;
         level_count[i] = 0;
         n_cycle[i]     = 0;
@@ -3235,7 +3241,11 @@ Amr::computeOptimalSubcycling(int n, int* best, Real* dt_max, Real* est_work, in
     // internally these represent the total number of steps at a level, 
     // not the number of cycles
     std::vector<int> cycles(n);
+#ifdef AMREX_USE_FLOAT
+    Real best_ratio = 1e30f;
+#else
     Real best_ratio = 1e200;
+#endif
     Real best_dt = 0;
     Real ratio;
     Real dt;


### PR DESCRIPTION
## Summary

Fix an ICC warning for a too-large float constant when compiling for single precision in WarpX.

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
