### PR TITLE
When we create a new level of refinement, we need to set the "level_s…

### DIFF
--- a/Src/Amr/AMReX_Amr.cpp
+++ b/Src/Amr/AMReX_Amr.cpp
@@ -2615,6 +2615,8 @@ Amr::regrid (int  lbase,
         {
             a->init();
             amr_level[lev].reset(a);
+            if (lev > 0)
+                level_steps[lev] = level_steps[lev-1] * n_cycle[lev-1];
 	    this->SetBoxArray(lev, amr_level[lev]->boxArray());
 	    this->SetDistributionMap(lev, amr_level[lev]->DistributionMap());
         }


### PR DESCRIPTION
…teps" of that

new level appropriately.

## Summary

## Additional background

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
