### PR TITLE
Option to allow multiple active MFIters

### DIFF
--- a/Docs/sphinx_documentation/source/Basics.rst
+++ b/Docs/sphinx_documentation/source/Basics.rst
@@ -1893,6 +1893,44 @@ But :cpp:`Box& bx = mfi.validbox()` is not legal and will not compile.
 Finally it should be emphasized that tiling should not be used when
 running on GPUs because of kernel launch overhead.
 
+Multiple MFIters
+----------------
+
+To avoid some common bugs, it is not allowed to have multiple active
+:cpp:`MFIter` objects like below by default.
+
+.. highlight:: c++
+
+::
+
+    for (MFIter mfi1(...); ...) {
+        for (MFIter mfi2(...); ...) {
+        }
+    }
+
+.. highlight:: fortran
+
+::
+
+    call amrex_mfiter_build(mf1, ...)
+    call amrex_mfiter_build(mf2, ...)
+
+The will results in an assertion failure at runtime.  To disable the
+assertion, one could call
+
+.. highlight:: c++
+
+::
+
+    int old_flag = amrex::MFIter::allowMultipleMFIters(true);
+
+.. highlight:: fortran
+
+::
+
+    logical :: old_flag
+    old_flag = amrex_mfiter_allow_multiple(.true.)
+
 .. _sec:basics:fortran:
 
 Fortran and C++ Kernels

--- a/Src/Base/AMReX_MFIter.H
+++ b/Src/Base/AMReX_MFIter.H
@@ -189,6 +189,8 @@ public:
 
     const DistributionMapping& DistributionMap () const noexcept { return fabArray.DistributionMap(); }
 
+    static int allowMultipleMFIters (int allow);
+
 protected:
 
     std::unique_ptr<FabArrayBase> m_fa;  //!< This must be the first memeber!
@@ -229,6 +231,7 @@ protected:
 
     static int nextDynamicIndex;
     static int depth;
+    static int allow_multiple_mfiters;
 
     void Initialize ();
 };

--- a/Src/Base/AMReX_MFIter.cpp
+++ b/Src/Base/AMReX_MFIter.cpp
@@ -8,6 +8,14 @@ namespace amrex {
 
 int MFIter::nextDynamicIndex = std::numeric_limits<int>::min();
 int MFIter::depth = 0;
+int MFIter::allow_multiple_mfiters = 0;
+
+int
+MFIter::allowMultipleMFIters (int allow)
+{
+    std::swap(allow, allow_multiple_mfiters);
+    return allow;
+}
 
 MFIter::MFIter (const FabArrayBase& fabarray_, 
 		unsigned char       flags_)
@@ -255,7 +263,8 @@ MFIter::Initialize ()
 #endif
     {
         ++depth;
-        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(depth == 1, "Nested MFIter is not supported");
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(depth == 1 || MFIter::allow_multiple_mfiters,
+            "Nested or multiple active MFIters is not supported by default.  This can be changed by calling MFIter::allowMultipleMFIters(true)".);
     }
 
     if (flags & SkipInit) {

--- a/Src/F_Interfaces/Base/AMReX_multifab_fi.cpp
+++ b/Src/F_Interfaces/Base/AMReX_multifab_fi.cpp
@@ -255,6 +255,11 @@ extern "C" {
 
     // MFIter routines
 
+    int amrex_fi_mfiter_allow_multiple (int allow)
+    {
+        return MFIter::allowMultipleMFIters(allow);
+    }
+
     void amrex_fi_new_mfiter_r (MFIter*& mfi, MultiFab* mf, int tiling, int dynamic)
     {
         if (tiling) {

--- a/Src/F_Interfaces/Base/AMReX_multifab_mod.F90
+++ b/Src/F_Interfaces/Base/AMReX_multifab_mod.F90
@@ -21,7 +21,7 @@ module amrex_multifab_module
   public :: amrex_multifab_build_alias, amrex_imultifab_build_alias
   public :: amrex_imultifab_build_owner_mask
   public :: amrex_imultifab_build, amrex_imultifab_destroy
-  public :: amrex_mfiter_build, amrex_mfiter_destroy
+  public :: amrex_mfiter_build, amrex_mfiter_destroy, amrex_mfiter_allow_multiple
 
   type, public   :: amrex_multifab
      logical               :: owner = .false.
@@ -471,6 +471,13 @@ module amrex_multifab_module
   end interface
 
   interface
+     function amrex_fi_mfiter_allow_multiple (allow) bind(c)
+       import
+       implicit none
+       integer(c_int) :: amrex_fi_mfiter_allow_multiple
+       integer(c_int), value :: allow
+     end function amrex_fi_mfiter_allow_multiple
+
      subroutine amrex_fi_new_mfiter_r (mfi, mf, tiling, dynamic) bind(c)
        import
        implicit none
@@ -1222,6 +1229,23 @@ contains
   end subroutine amrex_imultifab_setval
 
 !------ MFIter routines ------!
+
+  function amrex_mfiter_allow_multiple (allow) result(old)
+    logical :: old
+    logical, intent(in) :: allow
+    integer :: old_flag, new_flag
+    if (allow) then
+       new_flag = 1
+    else
+       new_flag = 0
+    end if
+    old_flag = amrex_fi_mfiter_allow_multiple(new_flag)
+    if (old_flag .ne. 0) then
+       old = .true.
+    else
+       old = .false.
+    end if
+  end function amrex_mfiter_allow_multiple
 
   subroutine amrex_mfiter_build_r (mfi, mf, tiling, dynamic)
     type(amrex_mfiter) :: mfi


### PR DESCRIPTION
## Summary

Add MFIter::allowMultipleMFIters(bool) so that users can disable assertion
on the number of active MFIters.  This is needed by FLASH because multiple
MFIters (one for each level) are built in its iterator.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
