### PR TITLE
AssignDensity and AssignCellDensitySingleLevel copy -> ParallelCopy

### DIFF
--- a/Src/AmrCore/AMReX_AmrParticles.H
+++ b/Src/AmrCore/AMReX_AmrParticles.H
@@ -82,7 +82,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>::AssignDensity
         //
         auto ng = IntVect(AMREX_D_DECL(ngrow,ngrow,ngrow));
         if ( ! all_grids_the_same) {
-            mf_to_be_filled[0]->ParallelCopy(*mf[0],0,0,ncomp,ng,ng);
+            mf_to_be_filled[0]->ParallelCopy(*mf[0],0,0,ncomp,0,0);
         }
         return;
     }
@@ -135,7 +135,10 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>::AssignDensity
     
     if (!all_grids_the_same) {
         for (int lev = lev_min; lev <= finest_level; lev++) {
-            mf_to_be_filled[lev]->copy(*mf_part[lev],0,0,ncomp);
+        //
+        // We haven't interpolated the ghost cells so we can't copy them
+        //
+            mf_to_be_filled[lev]->ParallelCopy(*mf_part[lev],0,0,ncomp,0,0);
         }
     }
     if (lev_min > 0) {

--- a/Src/AmrCore/AMReX_AmrParticles.H
+++ b/Src/AmrCore/AMReX_AmrParticles.H
@@ -78,10 +78,11 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>::AssignDensity
         //
         this->AssignCellDensitySingleLevel(rho_index, *mf[0], 0, ncomp);
         //
-        // I believe that we don't need any information in ghost cells so we don't copy those.
+        // We may not need any information in ghost cells but maybe we should copy them anyways.
         //
+        auto ng = IntVect(AMREX_D_DECL(ngrow,ngrow,ngrow));
         if ( ! all_grids_the_same) {
-            mf_to_be_filled[0]->copy(*mf[0],0,0,ncomp);
+            mf_to_be_filled[0]->ParallelCopy(*mf[0],0,0,ncomp,ng,ng);
         }
         return;
     }

--- a/Src/AmrCore/AMReX_AmrParticles.H
+++ b/Src/AmrCore/AMReX_AmrParticles.H
@@ -77,10 +77,6 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>::AssignDensity
         // Just use the far simpler single-level version.
         //
         this->AssignCellDensitySingleLevel(rho_index, *mf[0], 0, ncomp);
-        //
-        // We may not need any information in ghost cells but maybe we should copy them anyways.
-        //
-        auto ng = IntVect(AMREX_D_DECL(ngrow,ngrow,ngrow));
         if ( ! all_grids_the_same) {
             mf_to_be_filled[0]->ParallelCopy(*mf[0],0,0,ncomp,0,0);
         }

--- a/Src/Particle/AMReX_ParticleContainerI.H
+++ b/Src/Particle/AMReX_ParticleContainerI.H
@@ -2150,7 +2150,7 @@ AssignCellDensitySingleLevel (int rho_index,
         // We may not need any information in ghost cells but maybe we should copy them anyways.
         //
         auto ng = mf_to_be_filled.nGrow();
-        mf_to_be_filled.ParallelCopy(*mf_pointer,0,0,ncomp,ng,ng);
+        mf_to_be_filled.ParallelCopy(*mf_pointer,0,0,ncomp,0,0);
         delete mf_pointer;
     }
 

--- a/Src/Particle/AMReX_ParticleContainerI.H
+++ b/Src/Particle/AMReX_ParticleContainerI.H
@@ -2143,11 +2143,14 @@ AssignCellDensitySingleLevel (int rho_index,
     mf_pointer->mult(1.0/vol, 0, 1, mf_pointer->nGrow());
 
     // If mf_to_be_filled is not defined on the particle_box_array, then we need
-    // to copy here from mf_pointer into mf_to_be_filled. I believe that we don't
-    // need any information in ghost cells so we don't copy those.
+    // to copy here from mf_pointer into mf_to_be_filled.
     if (mf_pointer != &mf_to_be_filled)
     {
-        mf_to_be_filled.copy(*mf_pointer,0,0,ncomp);
+        //
+        // We may not need any information in ghost cells but maybe we should copy them anyways.
+        //
+        auto ng = mf_to_be_filled.nGrow();
+        mf_to_be_filled.ParallelCopy(*mf_pointer,0,0,ncomp,ng,ng);
         delete mf_pointer;
     }
 

--- a/Src/Particle/AMReX_ParticleContainerI.H
+++ b/Src/Particle/AMReX_ParticleContainerI.H
@@ -2146,10 +2146,6 @@ AssignCellDensitySingleLevel (int rho_index,
     // to copy here from mf_pointer into mf_to_be_filled.
     if (mf_pointer != &mf_to_be_filled)
     {
-        //
-        // We may not need any information in ghost cells but maybe we should copy them anyways.
-        //
-        auto ng = mf_to_be_filled.nGrow();
         mf_to_be_filled.ParallelCopy(*mf_pointer,0,0,ncomp,0,0);
         delete mf_pointer;
     }


### PR DESCRIPTION
## Summary

"ParallelCopy" should be preferred over "copy" because the name is more explicit that it works even if the ba and dm are different.

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
