### PR TITLE
Fix EB bug in #1629

### DIFF
--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian.cpp
@@ -77,6 +77,9 @@ MLNodeLaplacian::define (const Vector<Geometry>& a_geom,
                 (new MultiFab(m_grids[amrlev][mglev], m_dmap[amrlev][mglev], 1, 1,
                               MFInfo(), *m_factory[amrlev][0]));
             m_sigma[amrlev][mglev][idim]->setVal(m_const_sigma);
+#ifdef AMREX_USE_EB
+            m_sigma[amrlev][mglev][idim]->setDomainBndry(0.0, m_geom[amrlev][mglev]);
+#endif
         }
     }
 


### PR DESCRIPTION
## Summary

For EB nodal solver with constant sigma, the domain ghost cells of sigma
should be set to zero.

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
