### PR TITLE
GNU Make: Fix the library flags

### DIFF
--- a/Tools/GNUMake/Make.defs
+++ b/Tools/GNUMake/Make.defs
@@ -958,6 +958,8 @@ ifneq ("$(wildcard $(AMREX_HOME)/Tools/GNUMake/Make.local)","")
   include        $(AMREX_HOME)/Tools/GNUMake/Make.local
 endif
 
+FINAL_LIBS = $(libraries)
+
 ifeq ($(USE_DPCPP),TRUE)
 
     ifeq ($(USE_MPI),TRUE)
@@ -1065,9 +1067,10 @@ else ifeq ($(USE_CUDA),TRUE)
       space +=
 
       ifeq ($(AMREX_LINKER),nvcc)
-        libraries := $(subst -Wl$(comm),-Xlinker=,$(libraries))
         ifeq ($(FIX_NVCC_PTHREAD),TRUE)
-          libraries := $(subst -pthread,-Xcompiler$(space)-pthread,$(libraries))
+          FINAL_LIBS = $(subst -pthread,-Xcompiler$(space)-pthread,$(subst -Wl$(comm),-Xlinker=,$(libraries)))
+        else
+          FINAL_LIBS = $(subst -Wl$(comm),-Xlinker=,$(libraries))
         endif
       endif
 

--- a/Tools/GNUMake/Make.rules
+++ b/Tools/GNUMake/Make.rules
@@ -53,9 +53,9 @@ $(executable): $(objForExecs)
 ifneq ($(SKIP_LINKING),TRUE)
 	@echo Linking $@ ...
 ifeq ($(LINK_WITH_FORTRAN_COMPILER),TRUE)
-	$(SILENT) $(AMREX_LINKER) $(LINKFLAGS) $(FCPPFLAGS) $(fincludes) $(LDFLAGS) -o $@ $^ $(libraries)
+	$(SILENT) $(AMREX_LINKER) $(LINKFLAGS) $(FCPPFLAGS) $(fincludes) $(LDFLAGS) -o $@ $^ $(FINAL_LIBS)
 else
-	$(SILENT) $(AMREX_LINKER) $(LINKFLAGS) $(CPPFLAGS) $(includes) $(LDFLAGS) -o $@ $^ $(libraries)
+	$(SILENT) $(AMREX_LINKER) $(LINKFLAGS) $(CPPFLAGS) $(includes) $(LDFLAGS) -o $@ $^ $(FINAL_LIBS)
 endif
 #	@echo SUCCESS
 endif
@@ -69,7 +69,7 @@ else
 %.$(machineSuffix).ex:%.cpp $(objForExecs)
 	$(SLIENT) $(CCACHE) $(CXX) $(CXXFLAGS) $(EXTRACXXFLAGS) $(CPPFLAGS) $(includes) -c $< -o $(objEXETempDir)/$(subst /,_,$<).o
 	@echo "Linking $@ ..."
-	$(SLIENT) $(AMREX_LINKER) $(LINKFLAGS) $(CPPFLAGS) $(includes) $(LDFLAGS) -o $@ $(objEXETempDir)/$(subst /,_,$<).o $(objForExecs) $(libraries)
+	$(SLIENT) $(AMREX_LINKER) $(LINKFLAGS) $(CPPFLAGS) $(includes) $(LDFLAGS) -o $@ $(objEXETempDir)/$(subst /,_,$<).o $(objForExecs) $(FINAL_LIBS)
 
 endif
 
@@ -131,7 +131,7 @@ $(objEXETempDir)/amrex.pc: FORCE
 	@ $(MKPKGCONFIG) --prefix="$(abspath $(AMREX_INSTALL_DIR))" \
 	                 --version="$(AMREX_GIT_VERSION)" \
 	                 --cflags="$(CXXFLAGS) $(EXTRACXXFLAGS)" \
-	                 --libs="$(filter-out -L.,$(LDFLAGS)) $(libraries)" \
+	                 --libs="$(filter-out -L.,$(LDFLAGS)) $(FINAL_LIBS)" \
 	                 --libpriv="" \
 	                 --fflags="$(F90FLAGS)" \
                          > $@
@@ -507,9 +507,9 @@ help:
 	@echo "The rule for compiling foo.[fF] is: \$$(FC) \$$(FFLAGS) \$$(FMODULES) \$$(fincludes) -c foo.o foo.f"
 	@echo "    Note that .F files are preprocessed with cpp into .f files before being compiled."
 ifeq ($(LINK_WITH_FORTRAN_COMPILER),TRUE)
-	@echo "The rule for linking            is: \$$(F90) \$$(LINKFLAGS) \$$(FCPPFLAGS) \$$(fincludes) \$$(LDFLAGS) -o \$$(executable) *.o \$$(libraries)"
+	@echo "The rule for linking            is: \$$(F90) \$$(LINKFLAGS) \$$(FCPPFLAGS) \$$(fincludes) \$$(LDFLAGS) -o \$$(executable) *.o \$$(FINAL_LIBS)"
 else
-	@echo "The rule for linking            is: \$$(CXX) \$$(LINKFLAGS) \$$(CPPFLAGS) \$$(includes) \$$(LDFLAGS) -o \$$(executable) *.o \$$(libraries)"
+	@echo "The rule for linking            is: \$$(CXX) \$$(LINKFLAGS) \$$(CPPFLAGS) \$$(includes) \$$(LDFLAGS) -o \$$(executable) *.o \$$(FINAL_LIBS)"
 endif
 	@echo ""
 	@echo "Here the variables are set to:"
@@ -529,7 +529,7 @@ endif
 	@echo "    FMODULES      = $(FMODULES)"
 	@echo "    fincludes     = $(fincludes)"
 	@echo "    LDFLAGS       = $(LDFLAGS)"
-	@echo "    libraries     = $(libraries)"
+	@echo "    FINAL_LIBS    = $(FINAL_LIBS)"
 	@echo "    executable    = $(executable)"
 	@echo ""
 	@echo "Read Tools/GNUMake/README.md for details on tweaking the make system."


### PR DESCRIPTION
## Summary

Previously for GPU build, the GNU Make system was very sensitive on which
variable to use for adding extra `libraries`.  Before a certain location,
`LIBRARIES` should be used, but after that `libraries` should be used.  This
is very error prone.  This PR tries to fix this.  Now the user should be
able to use `LIBRARIES` anywhere.  The use of `libraries` should be avoided
because it is still the case that it can only be used after a certain
location in the make file.  Nevertheless, this PR is backward compatible and
it does not force the use of `LIBRARIES`.

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
