### PR TITLE
Fix NodalProjector::getGradPhi for multilevel case

### DIFF
--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLap_2D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLap_2D_K.H
@@ -2057,6 +2057,24 @@ void mlndlap_mknewu_eb (int i, int j, int, Array4<Real> const& u, Array4<Real co
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void mlndlap_mknewu_eb_c (int i, int j, int, Array4<Real> const& u, Array4<Real const> const& p,
+			  Real sig, Array4<Real const> const& vfrac,
+			  Array4<Real const> const& intg, GpuArray<Real,AMREX_SPACEDIM> const& dxinv) noexcept
+{
+    Real facx = Real(0.5)*dxinv[0];
+    Real facy = Real(0.5)*dxinv[1];
+    if (vfrac(i,j,0) == Real(0.)) {
+        u(i,j,0,0) = u(i,j,0,1) = Real(0.);
+    } else {
+        Real dpdx = facx*(-p(i,j,0)+p(i+1,j,0)-p(i,j+1,0)+p(i+1,j+1,0));
+        Real dpdy = facy*(-p(i,j,0)-p(i+1,j,0)+p(i,j+1,0)+p(i+1,j+1,0));
+        Real dpp = (p(i,j,0)+p(i+1,j+1,0)-p(i+1,j,0)-p(i,j+1,0))/vfrac(i,j,0);
+        u(i,j,0,0) -= sig*(dpdx + dxinv[0]*intg(i,j,0,1)*dpp);
+        u(i,j,0,1) -= sig*(dpdy + dxinv[1]*intg(i,j,0,0)*dpp);
+    }
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 Real mlndlap_rhcc_eb (int i, int j, int, Array4<Real const> const& rhcc,
                       Array4<Real const> const& vfrac, Array4<Real const> const& intg,
                       Array4<int const> const& msk) noexcept

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLap_3D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLap_3D_K.H
@@ -6913,6 +6913,45 @@ void mlndlap_mknewu_eb (int i, int j, int k, Array4<Real> const& u, Array4<Real 
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void mlndlap_mknewu_eb_c (int i, int j, int k, Array4<Real> const& u, Array4<Real const> const& p,
+                        Real sig, Array4<Real const> const& vfrac,
+                        Array4<Real const> const& intg, GpuArray<Real,AMREX_SPACEDIM> const& dxinv) noexcept
+{
+    if (vfrac(i,j,k) == Real(0.)) {
+        u(i,j,k,0) = u(i,j,k,1) = u(i,j,k,2) = Real(0.);
+    } else {
+        Real dpdx = Real(0.25)*(-p(i,j,k  )+p(i+1,j,k  )-p(i,j+1,k  )+p(i+1,j+1,k  )
+                                -p(i,j,k+1)+p(i+1,j,k+1)-p(i,j+1,k+1)+p(i+1,j+1,k+1));
+        Real dpdy = Real(0.25)*(-p(i,j,k  )-p(i+1,j,k  )+p(i,j+1,k  )+p(i+1,j+1,k  )
+                                -p(i,j,k+1)-p(i+1,j,k+1)+p(i,j+1,k+1)+p(i+1,j+1,k+1));
+        Real dpdz = Real(0.25)*(-p(i,j,k  )-p(i+1,j,k  )-p(i,j+1,k  )-p(i+1,j+1,k  )
+                                +p(i,j,k+1)+p(i+1,j,k+1)+p(i,j+1,k+1)+p(i+1,j+1,k+1));
+
+        Real dpp_xy = (p(i+1,j+1,k+1) - p(i,j+1,k+1) - p(i+1,j,k+1) + p(i,j,k+1)
+                      +p(i+1,j+1,k  ) - p(i,j+1,k  ) - p(i+1,j,k  ) + p(i,j,k  ) ) / vfrac(i,j,k);
+
+        Real dpp_xz = (p(i+1,j+1,k+1) - p(i,j+1,k+1) + p(i+1,j,k+1) - p(i,j,k+1)
+                      -p(i+1,j+1,k  ) + p(i,j+1,k  ) - p(i+1,j,k  ) + p(i,j,k  ) ) / vfrac(i,j,k);
+
+        Real dpp_yz = (p(i+1,j+1,k+1) + p(i,j+1,k+1) - p(i+1,j,k+1) - p(i,j,k+1)
+                      -p(i+1,j+1,k  ) - p(i,j+1,k  ) + p(i+1,j,k  ) + p(i,j,k  ) ) / vfrac(i,j,k);
+
+        Real dpp_xyz = (p(i+1,j+1,k+1) - p(i,j+1,k+1) - p(i+1,j,k+1) + p(i,j,k+1)
+                       -p(i+1,j+1,k  ) + p(i,j+1,k  ) + p(i+1,j,k  ) - p(i,j,k  ) ) / vfrac(i,j,k);
+
+        u(i,j,k,0) -= sig*dxinv[0]*(dpdx + Real(0.5)*intg(i,j,k,i_S_y  )*dpp_xy +
+                                           Real(0.5)*intg(i,j,k,i_S_z  )*dpp_xz +
+                                                     intg(i,j,k,i_S_y_z)*dpp_xyz );
+        u(i,j,k,1) -= sig*dxinv[1]*(dpdy + Real(0.5)*intg(i,j,k,i_S_x  )*dpp_xy +
+                                           Real(0.5)*intg(i,j,k,i_S_z  )*dpp_yz +
+                                                     intg(i,j,k,i_S_x_z)*dpp_xyz );
+        u(i,j,k,2) -= sig*dxinv[2]*(dpdz + Real(0.5)*intg(i,j,k,i_S_x  )*dpp_xz +
+				           Real(0.5)*intg(i,j,k,i_S_y  )*dpp_yz +
+                                                     intg(i,j,k,i_S_x_y)*dpp_xyz );
+    }
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 Real mlndlap_rhcc_eb (int i, int j, int k, Array4<Real const> const& rhcc,
                       Array4<Real const> const& vfrac, Array4<Real const> const& intg,
                       Array4<int const> const& msk) noexcept

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian.H
@@ -106,12 +106,17 @@ public :
     virtual void getFluxes (const Vector<Array<MultiFab*,AMREX_SPACEDIM> >& /*a_flux*/,
                             const Vector<MultiFab*>& /*a_sol*/,
                             Location /*a_loc*/) const final override {
-        amrex::Abort("MLLinOp::getFluxes: How did we get here?");
+        amrex::Abort("MLNodeLaplacian::getFluxes: How did we get here?");
     }
     virtual void getFluxes (const Vector<MultiFab*>& a_flux,
                             const Vector<MultiFab*>& a_sol) const final override;
-
     virtual void unimposeNeumannBC (int amrlev, MultiFab& rhs) const final override;
+
+    virtual void compGrad (int /*amrlev*/, const Array<MultiFab*,AMREX_SPACEDIM>& /*grad*/,
+			   MultiFab& /*sol*/, Location /*loc*/) const final override {
+        amrex::Abort("MLNodeLaplacian::compGrad: How did we get here?");
+    }
+    void compGrad (int amrlev, MultiFab& grad, MultiFab& sol) const;
 
     void averageDownCoeffs ();
     void averageDownCoeffsToCoarseAmrLevel (int flev);

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian.cpp
@@ -608,6 +608,79 @@ MLNodeLaplacian::updateVelocity (const Vector<MultiFab*>& vel, const Vector<Mult
 }
 
 void
+MLNodeLaplacian::compGrad (int amrlev, MultiFab& grad, MultiFab& sol) const
+{
+#if (AMREX_SPACEDIM == 2)
+    bool is_rz = m_is_rz;
+#endif
+
+    Real sigma = -1.0;
+
+    AMREX_ASSERT(grad.nComp() >= AMREX_SPACEDIM);
+
+    const auto dxinv = m_geom[amrlev][0].InvCellSizeArray();
+#ifdef AMREX_USE_EB
+    auto factory = dynamic_cast<EBFArrayBoxFactory const*>(m_factory[amrlev][0].get());
+    const FabArray<EBCellFlagFab>* flags = (factory) ? &(factory->getMultiEBCellFlagFab()) : nullptr;
+    const MultiFab* vfrac = (factory) ? &(factory->getVolFrac()) : nullptr;
+    const MultiFab* intg = m_integral[amrlev].get();
+#endif
+
+#ifdef _OPENMP
+#pragma omp parallel if (Gpu::notInLaunchRegion())
+#endif
+    for (MFIter mfi(grad, TilingIfNotGPU()); mfi.isValid(); ++mfi)
+    {
+        const Box& bx = mfi.tilebox();
+	Array4<Real> const& garr = grad.array(mfi);
+	Array4<Real const> const& solarr = sol.const_array(mfi);
+
+	AMREX_HOST_DEVICE_PARALLEL_FOR_4D ( bx, AMREX_SPACEDIM, i, j, k, n,
+        {
+            garr(i,j,k,n) = 0.0;
+        });
+
+#ifdef AMREX_USE_EB
+	bool regular = !factory;
+	if (factory)
+	{
+	    auto type = (*flags)[mfi].getType(bx);
+	    Array4<Real const> const& vfracarr = vfrac->const_array(mfi);
+	    Array4<Real const> const& intgarr = intg->const_array(mfi);
+	    if (type == FabType::covered)
+	    { }
+	    else if (type == FabType::singlevalued)
+	    {
+	      AMREX_HOST_DEVICE_FOR_3D(bx, i, j, k,
+              {
+		  mlndlap_mknewu_eb_c(i,j,k, garr, solarr, sigma, vfracarr, intgarr, dxinv);
+              });
+	    }
+	    else
+	    {
+	        regular = true;
+	    }
+	}
+	if (regular)
+#endif
+	{
+
+#if (AMREX_SPACEDIM == 2)
+	    AMREX_HOST_DEVICE_PARALLEL_FOR_3D (bx, i, j, k,
+	    {
+	        mlndlap_mknewu_c(i,j,k,garr,solarr,sigma,dxinv,is_rz);
+	    });
+#else
+	    AMREX_HOST_DEVICE_PARALLEL_FOR_3D (bx, i, j, k,
+            {
+	        mlndlap_mknewu_c(i,j,k,garr,solarr,sigma,dxinv);
+	    });
+#endif
+	}
+    }
+}
+
+void
 MLNodeLaplacian::getFluxes (const Vector<MultiFab*> & a_flux, const Vector<MultiFab*>& a_sol) const
 {
 #if (AMREX_SPACEDIM == 2)

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLinOp.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLinOp.H
@@ -52,7 +52,7 @@ public:
         amrex::Abort("AMReX_MLNodeLinOp::compFlux::How did we get here?");
     }
     virtual void compGrad (int /*amrlev*/, const Array<MultiFab*,AMREX_SPACEDIM>& /*grad*/,
-                           MultiFab& /*sol*/, Location /*loc*/) const final override {
+                           MultiFab& /*sol*/, Location /*loc*/) const override {
         amrex::Abort("AMReX_MLNodeLinOp::compGrad::How did we get here?");
     }
     

--- a/Src/LinearSolvers/Projections/AMReX_NodalProjector.cpp
+++ b/Src/LinearSolvers/Projections/AMReX_NodalProjector.cpp
@@ -272,12 +272,6 @@ NodalProjector::project ( Real a_rtol, Real a_atol )
     // Get fluxes -- fluxes = - sigma * grad(phi)
     m_mlmg -> getFluxes( GetVecOfPtrs(m_fluxes) );
 
-    // At this time, the fluxes are "correct" only on regions not covered by finer grids.
-    // We average the fluxes down so that they are "correct" everywhere in each level.
-    // This is necessary because the caller can access grad(phi) and may use it for
-    // computations involving the whole level.
-    averageDown(GetVecOfPtrs(m_fluxes));
-
     // Compute sync residual BEFORE performing projection
     computeSyncResidual();
 
@@ -296,30 +290,19 @@ NodalProjector::project ( Real a_rtol, Real a_atol )
         //
         // vel = vel + fluxes = vel - ( sigma / alpha ) * grad(phi)
         //
-        // Since we already averaged-down the velocity field and -grad(phi),
-        // we perform the projection by simply adding the two of them.
-        // In virtue of the linearity of the operations involved, this is equivalent
-        // to averaging down the velocity only once AFTER summing -grad(phi)
-        //
         MultiFab::Add( *m_vel[lev], m_fluxes[lev], 0, 0, AMREX_SPACEDIM, 0);
 
         // set m_fluxes = grad(phi)
-        m_fluxes[lev].mult(-1.0);
-        for (int n = 0; n < AMREX_SPACEDIM; ++n)
-        {
-            if (m_has_alpha)
-            {
-                MultiFab::Multiply(m_fluxes[lev], *m_alpha[lev], 0, n, 1, 0);
-            }
-            if (m_sigma.empty()) {
-                AMREX_ASSERT(m_const_sigma != Real(0.));
-                m_fluxes[lev].mult(Real(1.)/m_const_sigma, n, 1, 0);
-            } else {
-                MultiFab::Divide(m_fluxes[lev], *m_sigma[lev], 0, n, 1, 0);
-            }
-        }
-
+	m_linop->compGrad(lev,m_fluxes[lev],m_phi[lev]);
     }
+
+    //
+    // At this time, results are "correct" only on regions not covered by finer grids.
+    // We average them down so that they are "correct" everywhere in each level.
+    //
+    averageDown(GetVecOfPtrs(m_fluxes));
+    averageDown(m_vel);
+
 
     // Print diagnostics
     if ( (m_verbose > 0) && (!m_has_rhs))


### PR DESCRIPTION
## Summary
    Two bug fixes for multilevel in NodalProjector:
    
    1. Ensure NodalProjector::getGradPhi() returns the correct result. Previously could return \sum{sigma grad phi} / (2**dim sigma_coarse).
    2. Average down the complete projected velocity at the end. For alpha!=1, this ensures the projected velocity is averaged down correctly.

This could change the results of multilevel regression tests. If the application uses the affected outputs from NodalProjector as is, then changes are expected. If the application subsequently averages down the outputs, then changes greater than roundoff level are not expected.   

## Additional background

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
