### PR TITLE
PolymorphicArray4

### DIFF
--- a/Src/Base/AMReX_Array.H
+++ b/Src/Base/AMReX_Array.H
@@ -33,6 +33,9 @@ namespace amrex {
     template <class T, std::size_t N>
     struct GpuArray
     {
+        using value_type = T;
+        using reference_type = T&;
+
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         const T& operator [] (int i) const noexcept { return arr[i]; }
 
@@ -46,7 +49,7 @@ namespace amrex {
         T* data () noexcept { return arr; }
 
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-        std::size_t size() const noexcept { return N; }
+        constexpr std::size_t size() const noexcept { return N; }
 
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         const T* begin() const noexcept { return arr; }

--- a/Src/Base/AMReX_Array4.H
+++ b/Src/Base/AMReX_Array4.H
@@ -2,6 +2,7 @@
 #define AMREX_ARRAY4_H_
 #include <AMReX_Config.H>
 
+#include <AMReX_Array.H>
 #include <AMReX_IntVect.H>
 #include <AMReX_GpuPrint.H>
 
@@ -239,6 +240,53 @@ namespace amrex {
         return os;
     }
 
+    //
+    // Type traits for detecting if a class has a size() constexpr function.
+    //
+    template <class A, class Enable = void> struct HasMultiComp : std::false_type {};
+    //
+    template <class B>
+    struct HasMultiComp<B, typename std::enable_if<B().size() >= 1>::type>
+        : std::true_type {};
+
+    //
+    // PolymorphicArray4 can be used to access both AoS and SoA with
+    // (i,j,k,n).  Here SoA refers multi-component BaseFab, and AoS refers
+    // to single-component BaseFab of multi-component GpuArray.
+    //
+    template <typename T>
+    struct PolymorphicArray4
+        : public Array4<T>
+    {
+        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        PolymorphicArray4 (Array4<T> const& a)
+            : Array4<T>{a} {}
+
+        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        T& operator() (int i, int j, int k) const noexcept {
+            return this->Array4<T>::operator()(i,j,k);
+        }
+
+        template <class U=T, typename std::enable_if< amrex::HasMultiComp<U>::value,int>::type = 0>
+        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        typename U::reference_type
+        operator() (int i, int j, int k, int n) const noexcept {
+            return this->Array4<T>::operator()(i,j,k,0)[n];
+        }
+
+        template <class U=T, typename std::enable_if<!amrex::HasMultiComp<U>::value,int>::type = 0>
+        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        U& operator() (int i, int j, int k, int n) const noexcept {
+            return this->Array4<T>::operator()(i,j,k,n);
+        }
+    };
+
+    template <typename T>
+    PolymorphicArray4<T>
+    makePolymorphic (Array4<T> const& a)
+    {
+        return PolymorphicArray4<T>(a);
+    }
 }
 
 #endif


### PR DESCRIPTION
## Summary

PolymorphicArray4 is a thin layer around Array4.  It allows us to access
both AoS and SoA data with operator().  For example,

    constexpr int ncomp = 2;
    Box box(...);
    BaseFab<Real> soa_fab(box, ncomp);
    auto soa_array = makePolymorphic(soa_fab.array());
    int i = ...; int j = ...; int k = ...;
    soa_array(i,j,k,0) = 0;
    soa_array(i,j,k,1) = 1;

    BaseFab<GpuArray<Real,ncomp>> aos_fab(box,1);
    auto aos_array = makePolymorphic(aos_fab.array());
    aos_array(i,j,k,0) = 0;
    aos_array(i,j,k,1) = 1;

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
