### PR TITLE
DPCPP MPI wrapper

### DIFF
--- a/Tools/CMake/AMReXOptions.cmake
+++ b/Tools/CMake/AMReXOptions.cmake
@@ -126,10 +126,12 @@ endif ()
 
 # --- SYCL ---
 if (AMReX_DPCPP)
-   if (NOT (CMAKE_CXX_COMPILER_ID IN_LIST "Clang;IntelClang;IntelDPCPP") )
+   set(_valid_dpcpp_compiler_ids Clang IntelClang IntelDPCPP)
+   if (NOT (CMAKE_CXX_COMPILER_ID IN_LIST _valid_dpcpp_compiler_ids) )
       message(WARNING "\nAMReX_GPU_BACKEND=${AMReX_GPU_BACKEND} is tested with DPCPP."
          "Verify '${CMAKE_CXX_COMPILER_ID}' is correct and potentially set CMAKE_CXX_COMPILER=dpccp.")
    endif ()
+   unset(_valid_dpcpp_compiler_ids)
 endif ()
 
 cmake_dependent_option( AMReX_DPCPP_AOT  "Enable DPCPP ahead-of-time compilation (WIP)"  OFF

--- a/Tools/CMake/AMReXOptions.cmake
+++ b/Tools/CMake/AMReXOptions.cmake
@@ -161,7 +161,7 @@ endif ()
 #
 # Parallel backends    ========================================================
 #
-cmake_dependent_option( AMReX_MPI  "Enable MPI"  ON "NOT AMReX_GPU_BACKEND STREQUAL SYCL" OFF)
+option( AMReX_MPI  "Enable MPI"  ON )
 print_option( AMReX_MPI )
 
 cmake_dependent_option( AMReX_MPI_THREAD_MULTIPLE

--- a/Tools/CMake/AMReXOptions.cmake
+++ b/Tools/CMake/AMReXOptions.cmake
@@ -128,7 +128,7 @@ endif ()
 if (AMReX_DPCPP)
    if (NOT (CMAKE_CXX_COMPILER_ID IN_LIST "Clang;IntelClang;IntelDPCPP") )
       message(WARNING "\nAMReX_GPU_BACKEND=${AMReX_GPU_BACKEND} is tested with DPCPP."
-         "Verify '${CMAKE_CXX_COMPILER_ID}' is correct and potentially set CMAKE_CXX_COMPILER=dpccp or mpiicpc.")
+         "Verify '${CMAKE_CXX_COMPILER_ID}' is correct and potentially set CMAKE_CXX_COMPILER=dpccp.")
    endif ()
 endif ()
 

--- a/Tools/CMake/AMReXOptions.cmake
+++ b/Tools/CMake/AMReXOptions.cmake
@@ -128,7 +128,7 @@ endif ()
 if (AMReX_DPCPP)
    if (NOT (CMAKE_CXX_COMPILER_ID IN_LIST "Clang;IntelClang;IntelDPCPP") )
       message(WARNING "\nAMReX_GPU_BACKEND=${AMReX_GPU_BACKEND} is tested with DPCPP."
-         "Verify '${CMAKE_CXX_COMPILER_ID}' is correct and potentially set CMAKE_CXX_COMPILER=dpccp or mpiicpx.")
+         "Verify '${CMAKE_CXX_COMPILER_ID}' is correct and potentially set CMAKE_CXX_COMPILER=dpccp or mpiicpc.")
    endif ()
 endif ()
 

--- a/Tools/CMake/AMReXSYCL.cmake
+++ b/Tools/CMake/AMReXSYCL.cmake
@@ -65,7 +65,7 @@ target_compile_options( SYCL
 if (AMReX_MPI)
   target_compile_options( SYCL
     INTERFACE
-    $<${_cxx_clang}:-cxx=dpcpp>)
+    $<${_cxx_clang}:-fsycl-unnamed-lambda>)
 endif ()
 
 #

--- a/Tools/CMake/AMReXSYCL.cmake
+++ b/Tools/CMake/AMReXSYCL.cmake
@@ -28,7 +28,8 @@ if (DPCPP_BETA_VERSION LESS "09")
 endif ()
 
 
-set(_cxx_clang "$<AND:$<COMPILE_LANGUAGE:CXX>,$<CXX_COMPILER_ID:Clang>>") # Only Clang for now
+set(_cxx_dpcpp "$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:IntelClang>,$<CXX_COMPILER_ID:IntelDPCPP>>")
+set(_cxx_dpcpp "$<AND:$<COMPILE_LANGUAGE:CXX>,${_cxx_dpcpp}>")
 
 #
 # SYCL and AMReX::SYCL targets
@@ -45,27 +46,27 @@ target_compile_features(SYCL INTERFACE cxx_std_17)
 
 target_compile_options( SYCL
    INTERFACE
-   $<${_cxx_clang}:-Wno-error=sycl-strict -fsycl>
-   $<${_cxx_clang}:$<$<BOOL:${AMReX_DPCPP_SPLIT_KERNEL}>:-fsycl-device-code-split=per_kernel>>)
+   $<${_cxx_dpcpp}:-Wno-error=sycl-strict -fsycl>
+   $<${_cxx_dpcpp}:$<$<BOOL:${AMReX_DPCPP_SPLIT_KERNEL}>:-fsycl-device-code-split=per_kernel>>)
 
 # temporary work-around for DPC++ beta08 bug
 #   define "long double" as 64bit for C++ user-defined literals
 #   https://github.com/intel/llvm/issues/2187
 target_compile_options( SYCL
    INTERFACE
-   $<${_cxx_clang}:-mlong-double-64 "SHELL:-Xclang -mlong-double-64">)
+   $<${_cxx_dpcpp}:-mlong-double-64 "SHELL:-Xclang -mlong-double-64">)
 
 # Beta09 has enabled eary optimizations by default.  But this causes many
 # tests to crash.  So we disable it.
 target_compile_options( SYCL
    INTERFACE
-   $<${_cxx_clang}:-fno-sycl-early-optimizations>)
+   $<${_cxx_dpcpp}:-fno-sycl-early-optimizations>)
 
 # Need this option to compile with mpiicpc
 if (AMReX_MPI)
   target_compile_options( SYCL
     INTERFACE
-    $<${_cxx_clang}:-fsycl-unnamed-lambda>)
+    $<${_cxx_dpcpp}:-fsycl-unnamed-lambda>)
 endif ()
 
 #
@@ -82,13 +83,13 @@ if (DPCPP_BETA_VERSION LESS "10")   # If beta < 10
 
    target_link_options( SYCL
       INTERFACE
-      $<${_cxx_clang}:-fsycl -device-math-lib=fp32,fp64> )
+      $<${_cxx_dpcpp}:-fsycl -device-math-lib=fp32,fp64> )
 
 else ()  # for beta >= 10
 
    target_link_options( SYCL
       INTERFACE
-      $<${_cxx_clang}:-fsycl -fsycl-device-lib=libc,libm-fp32,libm-fp64> )
+      $<${_cxx_dpcpp}:-fsycl -fsycl-device-lib=libc,libm-fp32,libm-fp64> )
 
 endif ()
 
@@ -97,7 +98,7 @@ endif ()
 # TODO: use $<LINK_LANG_AND_ID:> genex for CMake >=3.17
 target_link_options( SYCL
    INTERFACE
-   $<${_cxx_clang}:$<$<BOOL:${AMReX_DPCPP_SPLIT_KERNEL}>:-fsycl-device-code-split=per_kernel>>)
+   $<${_cxx_dpcpp}:$<$<BOOL:${AMReX_DPCPP_SPLIT_KERNEL}>:-fsycl-device-code-split=per_kernel>>)
 
 
 if (AMReX_DPCPP_AOT)
@@ -136,4 +137,4 @@ if (AMReX_DPCPP_AOT)
 endif ()
 
 
-unset(_cxx_clang)
+unset(_cxx_dpcpp)

--- a/Tools/CMake/AMReXSYCL.cmake
+++ b/Tools/CMake/AMReXSYCL.cmake
@@ -61,7 +61,7 @@ target_compile_options( SYCL
    INTERFACE
    $<${_cxx_clang}:-fno-sycl-early-optimizations>)
 
-# Need this option to compile with mpiicpx
+# Need this option to compile with mpiicpc
 if (AMReX_MPI)
   target_compile_options( SYCL
     INTERFACE

--- a/Tools/CMake/AMReXSYCL.cmake
+++ b/Tools/CMake/AMReXSYCL.cmake
@@ -65,7 +65,7 @@ target_compile_options( SYCL
 if (AMReX_MPI)
   target_compile_options( SYCL
     INTERFACE
-    $<${_cxx_clang}:-fsycl-unnamed-lambda>)
+    $<${_cxx_clang}:-cxx=dpcpp>)
 endif ()
 
 #

--- a/Tools/GNUMake/Make.defs
+++ b/Tools/GNUMake/Make.defs
@@ -35,7 +35,7 @@ ifeq ($(USE_DPCPP),TRUE)
   USE_HIP := FALSE
   # disable ccache for now
   USE_CCACHE := FALSE
-  # Make.unknown's mpi checking does not work with mpiipx
+  # Make.unknown's mpi checking does not work with mpiicpc
   NO_MPI_CHECKING := TRUE
 endif
 
@@ -961,12 +961,11 @@ endif
 ifeq ($(USE_DPCPP),TRUE)
 
     ifeq ($(USE_MPI),TRUE)
-        CC  = mpiicx
-        CXX = mpiicpx
-        FC  = mpiifx
-        F90 = mpiifx
-        # current version of mpiicpx does not have this on by default
-        EXTRACXXFLAGS += -fsycl-unnamed-lambda
+        CC  = mpiicc
+        CXX = mpiicpc
+        FC  = mpiifort
+        F90 = mpiifort
+        CXXFLAGS += -cxx=dpcpp
     endif
 
 else ifeq ($(USE_HIP),TRUE)

--- a/Tutorials/GPU/CNS/Source/CNS_bcfill.cpp
+++ b/Tutorials/GPU/CNS/Source/CNS_bcfill.cpp
@@ -8,11 +8,11 @@ using namespace amrex;
 struct CnsFillExtDir
 {
     AMREX_GPU_DEVICE
-    void operator() (const IntVect& iv, Array4<Real> const& dest,
-                     const int dcomp, const int numcomp,
-                     GeometryData const& geom, const Real time,
-                     const BCRec* bcr, const int bcomp,
-                     const int orig_comp) const
+    void operator() (const IntVect& /*iv*/, Array4<Real> const& /*dest*/,
+                     const int /*dcomp*/, const int /*numcomp*/,
+                     GeometryData const& /*geom*/, const Real /*time*/,
+                     const BCRec* /*bcr*/, const int /*bcomp*/,
+                     const int /*orig_comp*/) const
         {
             // do something for external Dirichlet (BCType::ext_dir)
         }

--- a/Tutorials/GPU/CNS/Source/hydro/CNS_hydro_K.H
+++ b/Tutorials/GPU/CNS/Source/hydro/CNS_hydro_K.H
@@ -184,7 +184,7 @@ namespace {
 AMREX_GPU_DEVICE
 inline
 void
-riemann (const amrex::Real gamma, const amrex::Real smallp, const amrex::Real smallr,
+riemann (const amrex::Real gamma, const amrex::Real smallp, const amrex::Real /*smallr*/,
          const amrex::Real rl, const amrex::Real ul, const amrex::Real pl,
          const amrex::Real ut1l, const amrex::Real ut2l,
          const amrex::Real rr, const amrex::Real ur, const amrex::Real pr,


### PR DESCRIPTION
## Summary

Replace mpiicpx with mpiicpc because mpiicpc is shipped by Intel, whereas
mpiicpx is a script that is only available on JLSE testbeds.

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
