### PR TITLE
CMake: Fix Typos in SYCL Warnings

### DIFF
--- a/Tools/CMake/AMReXOptions.cmake
+++ b/Tools/CMake/AMReXOptions.cmake
@@ -128,8 +128,9 @@ endif ()
 if (AMReX_DPCPP)
    set(_valid_dpcpp_compiler_ids Clang IntelClang IntelDPCPP)
    if (NOT (CMAKE_CXX_COMPILER_ID IN_LIST _valid_dpcpp_compiler_ids) )
-      message(WARNING "\nAMReX_GPU_BACKEND=${AMReX_GPU_BACKEND} is tested with DPCPP."
-         "Verify '${CMAKE_CXX_COMPILER_ID}' is correct and potentially set CMAKE_CXX_COMPILER=dpccp.")
+      message(WARNING "\nAMReX_GPU_BACKEND=${AMReX_GPU_BACKEND} is tested with "
+         "DPCPP. Verify '${CMAKE_CXX_COMPILER_ID}' is correct and potentially "
+         "set CMAKE_CXX_COMPILER=dpcpp.")
    endif ()
    unset(_valid_dpcpp_compiler_ids)
 endif ()


### PR DESCRIPTION
## Summary

Just a typo and a missing space in a warning.

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
