### PR TITLE
Fix parallel add bug when both USE_GPU and USE_OMP are defined.

### DIFF
--- a/Src/Base/AMReX_FabArrayBase.cpp
+++ b/Src/Base/AMReX_FabArrayBase.cpp
@@ -385,16 +385,16 @@ FabArrayBase::CPC::define (const BoxArray& ba_dst, const DistributionMapping& dm
 
 	BaseFab<int> localtouch(The_Cpu_Arena()), remotetouch(The_Cpu_Arena());
 	bool check_local = false, check_remote = false;
-#if defined(_OPENMP)
+#if defined(AMREX_USE_GPU)
+        check_local = true;
+        check_remote = true;
+#elif defined(_OPENMP)
 	if (omp_get_max_threads() > 1) {
 	    check_local = true;
 	    check_remote = true;
 	}
-#elif defined(AMREX_USE_GPU)
-        check_local = true;
-        check_remote = true;
-#endif    
-	
+#endif
+
 	if (ParallelDescriptor::TeamSize() > 1) {
 	    check_local = true;
 	}


### PR DESCRIPTION
We cannot assume copies are thread safe any time AMREX_USE_GPU is defined, whether or not USE_OMP is also on.

Note that this only would have been an issue when compiling with OMP but running on only one thread.

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
