### PR TITLE
FaceLinear fused interpolater variation (with performance comparison!)

### DIFF
--- a/Src/AmrCore/AMReX_Interpolater.H
+++ b/Src/AmrCore/AMReX_Interpolater.H
@@ -734,6 +734,7 @@ public:
     * \param bcr
     * \param actual_comp
     * \param actual_state
+    * \param runon
     */
     virtual void interp (const FArrayBox& crse,
                          int              crse_comp,
@@ -758,14 +759,14 @@ public:
     * \param fine_comp
     * \param ncomp
     * \param fine_region
-    * \param fine_values
-    * \param fine_known
     * \param ratio
+    * \param solve_mask
     * \param crse_geom
     * \param fine_geom
     * \param bcr
     * \param actual_comp
     * \param actual_state
+    * \param runon
     */
     virtual void interp_arr (Array<FArrayBox*, AMREX_SPACEDIM> const& crse,
                              const int         crse_comp,
@@ -848,6 +849,41 @@ public:
                          int              actual_comp,
                          int              actual_state,
                          RunOn            gpu_or_cpu) override;
+
+/**
+    * \brief Coarse to fine interpolation in space.
+    *
+    * \param crse
+    * \param crse_comp
+    * \param fine
+    * \param fine_comp
+    * \param ncomp
+    * \param fine_region
+    * \param fine_values
+    * \param fine_known
+    * \param ratio
+    * \param crse_geom
+    * \param fine_geom
+    * \param bcr
+    * \param actual_comp
+    * \param actual_state
+    */
+    virtual void interp_arr (Array<FArrayBox*, AMREX_SPACEDIM> const& crse,
+                             const int         crse_comp,
+                             Array<FArrayBox*, AMREX_SPACEDIM> const& fine,
+                             const int         fine_comp,
+                             const int         ncomp,
+                             const Box&        fine_region,
+                             const IntVect&    ratio,
+                             Array<IArrayBox*, AMREX_SPACEDIM> const& /*solve_mask*/,
+                             const Geometry&   /*crse_geom*/,
+                             const Geometry&   /*fine_geom*/,
+                             Vector<Array<BCRec, AMREX_SPACEDIM> > const& /*bcr*/,
+                             const int         /*actual_comp*/,
+                             const int         /*actual_state*/,
+                             const RunOn       runon) override;
+
+
 };
 
 


### PR DESCRIPTION
## Summary
Add a `interp_arr` version of `FaceLinear` to test generality of the new API (and performance comparison, as `FaceDivFree `stencil can't be used in regular API for comparison). Also includes a bit of `interp_arr` cleanup.

## Additional background
* Based on summit tests (1 rank/GPU), new "fused" `FillPatchTwoLevels` is always equal or better than the old "reg" (~15-30%) [final column].
* `InterpFromCoarse` is equivalent or better (with enough boxes), if `ratio=nghost` (and work can be done in place), but new "fused" `InterpFromCoarse` is generally slower otherwise. [5th column]
* Test can be added to PR if desired. It's a slight variation on DivFree test in previous PR, so for now avoiding unnecessary code clutter.

```
----------------------------
ratio = 2,2,2; nghost = 2,2,2
----------------------------
ncell  | mgs || Interp Reg | Interp Fused | Fused/Reg || FillPatch Reg | FillPatch Fused | Fused/Reg |
       |     || (secs)     | (secs)       |           || (secs)        | (secs)          |           |
-------+-----++------------+--------------+-----------++---------------+-----------------+-----------|
256    | 256 || 0.144      | 0.1485       |  1.03     || 1.139         | 1.159           | 1.02      |
256    | 128 || 0.08125    | 0.08456      |  1.04     || 1.005         | 0.654           | 0.651     |
256    | 64  || 0.09196    | 0.09253      |  1.01     || 1.157         | 0.8091          | 0.699     |
256    | 32  || 0.2319     | 0.1895       |  0.817    || 1.335         | 0.929           | 0.696     |
-------+-----++------------+--------------+-----------++---------------+-----------------+-----------+
128    | 128 || 0.01358    | 0.01345      |  0.990    || 0.1318        | 0.1321          | 1.002     |
128    | 64  || 0.01105    | 0.01124      |  1.01     || 0.1283        | 0.09295         | 0.724     |
128    | 32  || 0.02141    | 0.01703      |  0.795    || 0.1464        | 0.1056          | 0.721     |
128    | 16  || 0.117      | 0.08385      |  0.717    || 0.248         | 0.1908          | 0.769     |
-------+-----++------------+--------------+-----------++---------------+-----------------+-----------+
64     | 64  || 0.001408   | 0.001387     |  0.985    || 0.01286       | 0.01305         | 1.01      |
64     | 32  || 0.002094   | 0.001677     |  0.801    || 0.01359       | 0.0112          | 0.824     |
64     | 16  || 0.009103   | 0.006466     |  0.710    || 0.02122       | 0.01728         | 0.8143    |


----------------------------
ratio = 3,3,3; nghost = 2,2,2
----------------------------
ncell  | mgs || Interp Reg | Interp Fused | Fused/Reg || FillPatch Reg | FillPatch Fused | Fused/Reg |
       |     || (secs)     | (secs)       |           || (secs)        | (secs)          |           |
-------+-----++------------+--------------+-----------++---------------+-----------------+-----------|
256    | 256 || 3.627      | 140.3(out of device mem) || 2.207         | 3.181           |    ---    |
-------+-----++------------+--------------+-----------++---------------+-----------------+-----------+
128    | 128 || 0.01898    | 0.02324      | 1.22      || 0.36          | 0.2481          | 0.689     |
128    | 64  || 0.01786    | 0.02383      | 1.33      || 0.4209        | 0.298           | 0.708     |
128    | 32  || 0.05352    | 0.06316      | 1.18      || 0.4709        | 0.3391          | 0.720     |
128    | 16  || 0.2928     | 0.2516       | 0.859     || 0.8428        | 0.6419          | 0.762     |
-------+-----++------------+--------------+-----------++---------------+-----------------+-----------+
64     | 64  || 0.00215    | 0.002602     | 1.21      || 0.03505       | 0.02869         | 0.818     |
64     | 32  || 0.005222   | 0.005735     | 1.10      || 0.04228       | 0.03283         | 0.776     |
64     | 16  || 0.01907    | 0.02314      | 1.21      || 0.06719       | 0.05308         | 0.790     |


----------------------------
ratio = 2,2,2; nghost = 1,1,1
--------------------------
ncell  | mgs || Interp Reg | Interp Fused | Fused/Reg || FillPatch Reg | FillPatch Fused | Fused/Reg |
       |     || (secs)     | (secs)       |           || (secs)        | (secs)          |           |
-------+-----++------------+--------------+-----------++---------------+-----------------+-----------|
256    | 256 || 0.145      | 0.1541       | 1.06      || 1.123         | 1.16            | 1.03      |
256    | 128 || 0.08329    | 0.09592      | 1.15      || 0.9566        | 0.6316          | 0.660     |
256    | 64  || 0.116      | 0.1338       | 1.15      || 1.075         | 0.7526          | 0.700     |
256    | 32  || 0.2416     | 0.3285       | 1.35      || 1.454         | 1.051           | 0.723     |
-------+-----++------------+--------------+-----------++---------------+-----------------+-----------+
128    | 128 || 0.01317    | 0.01416      | 1.07      || 0.1213        | 0.1282          | 1.06      |
128    | 64  || 0.01315    | 0.01435      | 1.09      || 0.1155        | 0.08692         | 0.752     |
128    | 32  || 0.02435    | 0.02582      | 1.06      || 0.1498        | 0.1162          | 0.776     |
128    | 16  || 0.1202     | 0.1029       | 0.856     || 0.2373        | 0.185           | 0.780     |
-------+-----++------------+--------------+-----------++---------------+-----------------+-----------+
64     | 64  || 0.001564   | 0.001668     | 1.07      || 0.01102       | 0.01273         | 1.15      |
64     | 32  || 0.002355   | 0.002421     | 1.03      || 0.01271       | 0.0114          | 0.897     |
64     | 16  || 0.007996   | 0.009382     | 1.17      || 0.01934       | 0.01634         | 0.845     |
```
*Note: All ncell=256 cases with ratio=2, nghost=2 fit into device memory (first test group). The remaining ncell=256 cases (ratio != nghost) do not.


## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
