### PR TITLE
Unsigned long long for counting number of particles on GPU

### DIFF
--- a/Src/Particle/AMReX_ParticleContainerI.H
+++ b/Src/Particle/AMReX_ParticleContainerI.H
@@ -471,7 +471,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>::NumberOfParti
 
     if (only_valid) {
         ReduceOps<ReduceOpSum> reduce_op;
-        ReduceData<Long> reduce_data(reduce_op);
+        ReduceData<unsigned long long> reduce_data(reduce_op);
         using ReduceTuple = typename decltype(reduce_data)::Type;
 
         for (const auto& kv : GetParticles(lev)) {
@@ -485,7 +485,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>::NumberOfParti
                                return (pp[i].id() > 0) ? 1 : 0;
                            });
         }
-        nparticles  = amrex::get<0>(reduce_data.value());
+        nparticles = static_cast<Long>(amrex::get<0>(reduce_data.value()));
     }
     else {
         for (const auto& kv : GetParticles(lev)) {


### PR DESCRIPTION
## Summary

Because long does not have native atomicAdd support, it's much slower than
doing reduction using unsigned long long.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
