### PR TITLE
Remove noexcept from this functor to work around cuda 11 bug.

### DIFF
--- a/Tutorials/Particles/NeighborList/MDParticleContainer.cpp
+++ b/Tutorials/Particles/NeighborList/MDParticleContainer.cpp
@@ -266,12 +266,12 @@ Real MDParticleContainer::computeStepSize(amrex::Real& cfl)
     BL_PROFILE("MDParticleContainer::computeStepSize");
 
     Real maxVel = amrex::ReduceMax(*this, 0,
-    [=] AMREX_GPU_HOST_DEVICE (const ParticleType& p) noexcept -> Real
+    [=] AMREX_GPU_HOST_DEVICE (const ParticleType& p) -> Real
                               {
                                  Real u = std::abs(p.rdata(PIdx::vx));
                                  Real v = std::abs(p.rdata(PIdx::vy));
                                  Real w = std::abs(p.rdata(PIdx::vz));
-                                 return amrex::max(u,amrex::max(v,w));
+                                 return amrex::max(u,v,w);
                               });
 
     ParallelDescriptor::ReduceRealMax(maxVel);


### PR DESCRIPTION
Also uses variadic form of `amrex::max`.

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
