### PR TITLE
Only issue prefetch if arena uses managed memory

### DIFF
--- a/Src/Base/AMReX_BaseFab.H
+++ b/Src/Base/AMReX_BaseFab.H
@@ -1657,7 +1657,8 @@ void
 BaseFab<T>::prefetchToHost () const noexcept
 {
 #ifdef AMREX_USE_GPU
-    if (this->arena() == The_Arena() || this->arena() == The_Managed_Arena()) {
+    if ((this->arena() == The_Arena() && this->arena()->arenaInfo().device_use_managed_memory) ||
+        this->arena() == The_Managed_Arena()) {
 #if defined(AMREX_USE_DPCPP)
         // xxxxx DPCPP todo: prefetchToHost
         // std::size_t s = sizeof(T)*this->nvar*this->domain.numPts();
@@ -1682,7 +1683,8 @@ void
 BaseFab<T>::prefetchToDevice () const noexcept
 {
 #ifdef AMREX_USE_GPU
-    if (this->arena() == The_Arena() || this->arena() == The_Managed_Arena()) {
+    if ((this->arena() == The_Arena() && this->arena()->arenaInfo().device_use_managed_memory) ||
+        this->arena() == The_Managed_Arena()) {
 #if defined(AMREX_USE_DPCPP)
         std::size_t s = sizeof(T)*this->nvar*this->domain.numPts();
         auto& q = Gpu::Device::streamQueue();

--- a/Src/Base/AMReX_FabArrayUtility.H
+++ b/Src/Base/AMReX_FabArrayUtility.H
@@ -1641,7 +1641,8 @@ void
 prefetchToHost (FabArray<FAB> const& fa, const bool synchronous = true)
 {
 #ifdef AMREX_USE_GPU
-    if (fa.arena() == The_Arena() || fa.arena() == The_Managed_Arena()) {
+    if ((fa.arena() == The_Arena() && fa.arena()->arenaInfo().device_use_managed_memory) ||
+        fa.arena() == The_Managed_Arena()) {
         for (MFIter mfi(fa, MFItInfo().SetDeviceSync(synchronous)); mfi.isValid(); ++mfi) {
             fa.prefetchToHost(mfi);
         }
@@ -1656,7 +1657,8 @@ void
 prefetchToDevice (FabArray<FAB> const& fa, const bool synchronous = true)
 {
 #ifdef AMREX_USE_GPU
-    if (fa.arena() == The_Arena() || fa.arena() == The_Managed_Arena()) {
+    if ((fa.arena() == The_Arena() && fa.arena()->arenaInfo().device_use_managed_memory) ||
+        fa.arena() == The_Managed_Arena()) {
         for (MFIter mfi(fa, MFItInfo().SetDeviceSync(synchronous)); mfi.isValid(); ++mfi) {
             fa.prefetchToDevice(mfi);
         }


### PR DESCRIPTION
## Summary

Before issuing a managed memory prefetch we check that the arena uses managed memory. This allows the CUDA implementation to still work with `amrex.the_arena_is_managed=0` while calling this API.

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
