### PR TITLE
unsigned long long iMultiFab sum.

### DIFF
--- a/Src/Base/AMReX_iMultiFab.cpp
+++ b/Src/Base/AMReX_iMultiFab.cpp
@@ -325,10 +325,14 @@ iMultiFab::sum (int comp, int nghost, bool local) const
     Long sm = 0;
 
 #ifdef AMREX_USE_GPU
+    // If on GPUs, cast to unsigned long long to take advantage of hardware support.
     if (Gpu::inLaunchRegion())
     {
+        unsigned long long ulsm = 0;
+        unsigned long long points = 0;
+        const unsigned long long imax = static_cast<unsigned long long>(INT_MAX);
         ReduceOps<ReduceOpSum> reduce_op;
-        ReduceData<Long> reduce_data(reduce_op);
+        ReduceData<unsigned long long> reduce_data(reduce_op);
         using ReduceTuple = typename decltype(reduce_data)::Type;
 
         for (MFIter mfi(*this); mfi.isValid(); ++mfi)
@@ -338,12 +342,14 @@ iMultiFab::sum (int comp, int nghost, bool local) const
             reduce_op.eval(bx, reduce_data,
             [=] AMREX_GPU_DEVICE (int i, int j, int k) -> ReduceTuple
             {
-                return { static_cast<Long>(arr(i,j,k,comp)) };
+                return { static_cast<unsigned long long>(arr(i,j,k,comp))+imax };
             });
+            points += bx.numPts();
         }
 
         ReduceTuple hv = reduce_data.value();
-        sm = amrex::get<0>(hv);
+        ulsm = amrex::get<0>(hv) - points*imax;
+        sm = static_cast<Long>(ulsm);
     }
     else
 #endif

--- a/Src/Base/AMReX_iMultiFab.cpp
+++ b/Src/Base/AMReX_iMultiFab.cpp
@@ -341,7 +341,7 @@ iMultiFab::sum (int comp, int nghost, bool local) const
             [=] AMREX_GPU_DEVICE (int i, int j, int k) -> ReduceTuple
             {
                 return { static_cast<unsigned long long>(arr(i,j,k,comp)) -
-                         static_cast<unsigned long long>(INT_MIN)) };
+                         static_cast<unsigned long long>(INT_MIN) };
             });
             points += bx.numPts();
         }


### PR DESCRIPTION
## Summary
Changes iMultiFab sum to use hardware supported unsigned long long.

## Additional background
Using ParallelReduce, this changes sum time on Cori (default CUDA, 10.1) from 0.07546 to 0.001185, 63x increase.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
