### PR TITLE
Sanitize the input of mkconfig

### DIFF
--- a/Tools/libamrex/mkconfig.py
+++ b/Tools/libamrex/mkconfig.py
@@ -2,7 +2,7 @@
 
 from __future__ import print_function
 
-import sys
+import sys, re
 
 if sys.version_info < (2, 7):
     sys.exit("ERROR: need python 2.7 or later for mkconfig.py")
@@ -12,6 +12,9 @@ import argparse
 def doit(defines, undefines, comp, allow_diff_comp):
     print("#ifndef AMREX_HAVE_NO_CONFIG_H")
     print("#define AMREX_HAVE_NO_CONFIG_H")
+
+    # Remove -I from input
+    defines = re.sub(r'-I.*?(-D|$)', r'\1', defines)
 
     defs = defines.split("-D")
     for d in defs:


### PR DESCRIPTION
## Summary

The mkconfig.py script takes CPPFLAGS and generates AMReX_Config.H.  If
CPPFLAGS contains -I flags (as advised by homebrew) and the input is not
santized, it would generate ill-formed code.

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
