### PR TITLE
Optimized function for filling BaseFab of GpuArray

### DIFF
--- a/Src/Base/AMReX_BaseFabUtility.H
+++ b/Src/Base/AMReX_BaseFabUtility.H
@@ -20,6 +20,84 @@ cast (BaseFab<Tto>& tofab, BaseFab<Tfrom> const& fromfab,
     });
 }
 
+template <int STRUCTSIZE, typename F,
+          typename std::enable_if<(STRUCTSIZE<=36),int>::type FOO = 0>
+void fill (BaseFab<GpuArray<Real,STRUCTSIZE> >& aos_fab, F && f)
+{
+    Box const& box = aos_fab.box();
+    auto const& aos = aos_fab.array();
+#ifdef AMREX_USE_GPU
+    if (Gpu::inLaunchRegion()) {
+        const auto lo  = amrex::lbound(box);
+        const auto len = amrex::length(box);
+        int ntotcells = box.numPts();
+        int nthreads_per_block = (STRUCTSIZE <= 8) ? 256 : 128;
+        int nblocks = (ntotcells+nthreads_per_block-1)/nthreads_per_block;
+        std::size_t shared_mem_bytes = nthreads_per_block * STRUCTSIZE * sizeof(Real);
+        static_assert(sizeof(GpuArray<Real,STRUCTSIZE>) == sizeof(Real)*STRUCTSIZE,
+                      "amrex::fill: sizeof(GpuArray<Real,STRUCTSIZE>) != sizeof(Real)*STRUCTSIZE");
+        Real* p = (Real*)aos_fab.dataPtr();
+#ifdef AMREX_USE_DPCPP
+        amrex::launch(nblocks, nthreads_per_block, shared_mem_bytes, Gpu::gpuStream(),
+        [=] AMREX_GPU_DEVICE (Gpu::Handler const& handler) noexcept
+        {
+            int icell = handler.globalIdx();
+            unsigned int blockDimx = handler.blockDim();
+            unsigned int threadIdxx = handler.threadIdx();
+            unsigned int blockIdxx = handler.blockIdx();
+            auto const shared = (Real*)handler.sharedMemory();
+            if (icell < ntotcells) {
+                auto ga = new(shared+threadIdxx*STRUCTSIZE) GpuArray<Real,STRUCTSIZE>;
+                int k =  icell /   (len.x*len.y);
+                int j = (icell - k*(len.x*len.y)) /   len.x;
+                int i = (icell - k*(len.x*len.y)) - j*len.x;
+                i += lo.x;
+                j += lo.y;
+                k += lo.z;
+                f(*ga, i, j, k);
+            }
+            handler.sharedBarrier();
+            for (unsigned int m = threadIdxx,
+                     mend = amrex::min<unsigned int>(blockDimx, ntotcells-blockDimx*blockIdxx) * STRUCTSIZE;
+                 m < mend; m += blockDimx) {
+                p[blockDimx*blockIdxx*STRUCTSIZE+m] = shared[m];
+            }
+        });
+#else
+        amrex::launch(nblocks, nthreads_per_block, shared_mem_bytes, Gpu::gpuStream(),
+        [=] AMREX_GPU_DEVICE () noexcept
+        {
+            int icell = blockDim.x*blockIdx.x+threadIdx.x;
+            Gpu::SharedMemory<Real> gsm;
+            Real* const shared = gsm.dataPtr();
+            if (icell < ntotcells) {
+                auto ga = new(shared+threadIdx.x*STRUCTSIZE) GpuArray<Real,STRUCTSIZE>;
+                int k =  icell /   (len.x*len.y);
+                int j = (icell - k*(len.x*len.y)) /   len.x;
+                int i = (icell - k*(len.x*len.y)) - j*len.x;
+                i += lo.x;
+                j += lo.y;
+                k += lo.z;
+                f(*ga, i, j, k);
+            }
+            __syncthreads();
+            for (unsigned int m = threadIdx.x,
+                     mend = amrex::min<unsigned int>(blockDim.x, ntotcells-blockDim.x*blockIdx.x) * STRUCTSIZE;
+                 m < mend; m += blockDim.x) {
+                p[blockDim.x*blockIdx.x*STRUCTSIZE+m] = shared[m];
+            }
+        });
+#endif
+    } else
+#endif
+    {
+        amrex::LoopOnCpu(box, [=] (int i, int j, int k) noexcept
+        {
+            f(aos(i,j,k), i, j, k);
+        });
+    }
+}
+
 }
 
 #endif

--- a/Src/Base/AMReX_FabArray.H
+++ b/Src/Base/AMReX_FabArray.H
@@ -38,7 +38,7 @@
 #include <AMReX_MakeType.H>
 #include <AMReX_TypeTraits.H>
 #include <AMReX_LayoutData.H>
-#include <AMReX_BaseFab.H>
+#include <AMReX_BaseFabUtility.H>
 
 #include <AMReX_Gpu.H>
 

--- a/Src/Base/AMReX_GpuTypes.H
+++ b/Src/Base/AMReX_GpuTypes.H
@@ -51,6 +51,26 @@ struct Handler
                 numActiveThreads <= 0);
     }
 
+    std::size_t globalIdx () const { return item->get_global_linear_id(); }
+    std::size_t blockIdx () const { return item->get_group_linear_id(); }
+    std::size_t threadIdx () const { return item->get_local_linear_id(); }
+    //
+    std::size_t gridDim () const { return item->get_group_range(0); }
+    std::size_t blockDim () const { return item->get_local_range(0); }
+
+    // warp index in block
+    std::size_t warpIdx () const { return item->get_sub_group().get_group_id()[0]; }
+    // lane index in warp
+    std::size_t laneIdx () const { return item->get_sub_group().get_local_id()[0]; }
+    // warp size
+    std::size_t warpDim () const { return item->get_sub_group().get_group_range()[0]; }
+
+    void* sharedMemory () const { return local; }
+
+    void sharedBarrier () const { item->barrier(sycl::access::fence_space::local_space); }
+    void globalBarrier () const { item->barrier(sycl::access::fence_space::global_space); }
+    void syncThreads () const { item->barrier(sycl::access::fence_space::global_and_local); }
+
     sycl::nd_item<1> const* item;
     void* local; // DPC++ local memory
     int numActiveThreads;

--- a/Src/Base/AMReX_MultiFabUtil.H
+++ b/Src/Base/AMReX_MultiFabUtil.H
@@ -2,7 +2,6 @@
 #define AMREX_MultiFabUtil_H_
 #include <AMReX_Config.H>
 
-#include <AMReX_BaseFabUtility.H>
 #include <AMReX_MultiFab.H>
 #include <AMReX_iMultiFab.H>
 #include <AMReX_LayoutData.H>


### PR DESCRIPTION
## Summary

Add amrex::fill for BaseFab of GpuArray (a.k.a. AoS).  The GPU
implementation uses shared memory.  Tests show it's more than 10x faster
than a naive implementation for GpuArray<Real,27>.

Also added are a few functions in DPC++ so that I do not have to look up the
documentation every time I need to use things like threadIdx and blockIdx.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
