### PR TITLE
changing blueprint ghost type to int

### DIFF
--- a/Src/Extern/Conduit/AMReX_Conduit_Blueprint.cpp
+++ b/Src/Extern/Conduit/AMReX_Conduit_Blueprint.cpp
@@ -234,8 +234,8 @@ void AddFabGhostIndicatorField (const FArrayBox& fab,
     Node &n_field = res["fields/ascent_ghosts"];
     n_field["association"] = "element";
     n_field["topology"] = "topo";
-    n_field["values"].set(DataType::float64(fab.box().numPts()));
-    float64_array vals_array = n_field["values"].value();
+    n_field["values"].set(DataType::int32(fab.box().numPts()));
+    int32_array vals_array = n_field["values"].value();
 
     int dims = BL_SPACEDIM;
 


### PR DESCRIPTION
## Summary

## Additional background
This MR changes the type of the ghost field used by conduit blueprint from `double` to `int`. Ascent expects integers, and this reduces the storage space required for the field.

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
