### PR TITLE
Support when CMake 3.18 policy 105 is set to new

### DIFF
--- a/Tools/CMake/AMReX_Config.cmake
+++ b/Tools/CMake/AMReX_Config.cmake
@@ -141,11 +141,22 @@ function (configure_amrex)
 
    if ( BUILD_SHARED_LIBS OR AMReX_CUDA )
       if(APPLE)
-         target_link_options(amrex PUBLIC -Wl,-undefined,warning)
+        target_link_options(amrex PUBLIC "LINKER:-undefined,warning")
       elseif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC" OR
              CMAKE_CXX_SIMULATE_ID STREQUAL "MSVC")
+
       else()
-         target_link_options(amrex PUBLIC -Wl,--warn-unresolved-symbols)
+
+        set(host_link_supported OLD)
+        if(CMP0105)
+          cmake_policy(GET CMP0105 host_link_supported)
+        endif()
+
+        if( host_link_supported STREQUAL "NEW" )
+          target_link_options(amrex PUBLIC "$<HOST_LINK:LINKER:--warn-unresolved-symbols>")
+        else()
+          target_link_options(amrex PUBLIC "LINKER:--warn-unresolved-symbols")
+        endif()
       endif()
    endif()
 


### PR DESCRIPTION
## Summary
When AMReX is using a newer version of CMake (3.18+) it sets policy `105` to new, causing `target_link_options` rules to be applied to CUDA device linking. When that happens we need to make sure that host only linking flags are excluded.
 
## Additional background

## Checklist

The proposed changes:
- [X] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
