### PR TITLE
CI: Brew Returns Non-Zero If Already Installed

### DIFF
--- a/.github/workflows/dependencies/dependencies_mac.sh
+++ b/.github/workflows/dependencies/dependencies_mac.sh
@@ -8,6 +8,6 @@
 set -eu -o pipefail
 
 brew update
-brew install gfortran
-brew install libomp
-brew install open-mpi
+brew install gfortran || true
+brew install libomp || true
+brew install open-mpi || true


### PR DESCRIPTION
## Summary

Homebrew has the unusual behavior to return a non-zero error code in `brew install` if the package is already installed. Since the base image in CI is somewhat fluid and also the status that `brew update` leaves is very dynamic, we just change this ourselves now to be a non-error.

## Additional background

https://twitter.com/axccl/status/1340013303280541696

The brew maintainer basically said: "yes, it's odd. but dang it's too late to change [in brew] now." (me paraphrasing the time-purged answer)

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
