### PR TITLE
Fix several warnings related to double-->float conversions

### DIFF
--- a/Src/Base/AMReX_FilCC_3D_C.H
+++ b/Src/Base/AMReX_FilCC_3D_C.H
@@ -52,17 +52,17 @@ filcc_cell (const IntVect& iv, Array4<Real> const& q,
                 // i == ilo-1
                 else if (ilo+2 <= amrex::min(q.end.x-1,ihi))
                 {
-                    q(i,j,k,n) = 0.125*(15.*q(i+1,j,k,n) - 10.*q(i+2,j,k,n) + 3.*q(i+3,j,k,n));
+                    q(i,j,k,n) = Real(0.125)*(Real(15.)*q(i+1,j,k,n) - Real(10.)*q(i+2,j,k,n) + Real(3.)*q(i+3,j,k,n));
                 }
                 else
                 {
-                    q(i,j,k,n) = 0.5*(3.*q(i+1,j,k,n) - q(i+2,j,k,n));
+                    q(i,j,k,n) = Real(0.5)*(Real(3.)*q(i+1,j,k,n) - q(i+2,j,k,n));
                 }
                 break;
             }
             case (BCType::hoextrapcc):
             {
-                q(i,j,k,n) = 2.*q(i+1,j,k,n) - q(i+2,j,k,n);
+                q(i,j,k,n) = Real(2.)*q(i+1,j,k,n) - q(i+2,j,k,n);
                 break;
             }
             case (BCType::reflect_even):
@@ -94,17 +94,17 @@ filcc_cell (const IntVect& iv, Array4<Real> const& q,
                 // i == ihi+1
                 else if (ihi-2 >= amrex::max(q.begin.x,ilo))
                 {
-                    q(i,j,k,n) = 0.125*(15.*q(i-1,j,k,n) - 10.*q(i-2,j,k,n) + 3.*q(i-3,j,k,n));
+                    q(i,j,k,n) = Real(0.125)*(Real(15.)*q(i-1,j,k,n) - Real(10.)*q(i-2,j,k,n) + Real(3.)*q(i-3,j,k,n));
                 }
                 else
                 {
-                    q(i,j,k,n) = 0.5*(3.*q(i-1,j,k,n) - q(i-2,j,k,n));
+                    q(i,j,k,n) = Real(0.5)*(Real(3.)*q(i-1,j,k,n) - q(i-2,j,k,n));
                 }
                 break;
             }
             case (BCType::hoextrapcc):
             {
-                q(i,j,k,n) = 2.*q(i-1,j,k,n) - q(i-2,j,k,n);
+                q(i,j,k,n) = Real(2.)*q(i-1,j,k,n) - q(i-2,j,k,n);
                 break;
             }
             case (BCType::reflect_even):
@@ -137,17 +137,17 @@ filcc_cell (const IntVect& iv, Array4<Real> const& q,
                 // j == jlo-1
                 else if (jlo+2 <= amrex::min(q.end.y-1,jhi))
                 {
-                    q(i,j,k,n) = 0.125*(15.*q(i,j+1,k,n) - 10.*q(i,j+2,k,n) + 3.*q(i,j+3,k,n));
+                    q(i,j,k,n) = Real(0.125)*(Real(15.)*q(i,j+1,k,n) - Real(10.)*q(i,j+2,k,n) + Real(3.)*q(i,j+3,k,n));
                 }
                 else
                 {
-                    q(i,j,k,n) = 0.5*(3.*q(i,j+1,k,n) - q(i,j+2,k,n));
+                    q(i,j,k,n) = Real(0.5)*(Real(3.)*q(i,j+1,k,n) - q(i,j+2,k,n));
                 }
                 break;
             }
             case (BCType::hoextrapcc):
             {
-                q(i,j,k,n) = 2.*q(i,j+1,k,n) - q(i,j+2,k,n);
+                q(i,j,k,n) = Real(2.)*q(i,j+1,k,n) - q(i,j+2,k,n);
                 break;
             }
             case (BCType::reflect_even):
@@ -179,17 +179,17 @@ filcc_cell (const IntVect& iv, Array4<Real> const& q,
                 // j == jhi+1
                 else if (jhi-2 >= amrex::max(q.begin.y,jlo))
                 {
-                    q(i,j,k,n) = 0.125*(15.*q(i,j-1,k,n) - 10.*q(i,j-2,k,n) + 3.*q(i,j-3,k,n));
+                    q(i,j,k,n) = Real(0.125)*(Real(15.)*q(i,j-1,k,n) - Real(10.)*q(i,j-2,k,n) + Real(3.)*q(i,j-3,k,n));
                 }
                 else
                 {
-                    q(i,j,k,n) = 0.5*(3.*q(i,j-1,k,n) - q(i,j-2,k,n));
+                    q(i,j,k,n) = Real(0.5)*(Real(3.)*q(i,j-1,k,n) - q(i,j-2,k,n));
                 }
                 break;
             }
             case (BCType::hoextrapcc):
             {
-                q(i,j,k,n) = 2.*q(i,j-1,k,n) - q(i,j-2,k,n);
+                q(i,j,k,n) = Real(2.)*q(i,j-1,k,n) - q(i,j-2,k,n);
                 break;
             }
             case (BCType::reflect_even):
@@ -222,17 +222,17 @@ filcc_cell (const IntVect& iv, Array4<Real> const& q,
                 // k == klo-1
                 else if (klo+2 <= amrex::min(q.end.z-1,khi))
                 {
-                    q(i,j,k,n) = 0.125*(15.*q(i,j,k+1,n) - 10.*q(i,j,k+2,n) + 3.*q(i,j,k+3,n));
+                    q(i,j,k,n) = Real(0.125)*(Real(15.)*q(i,j,k+1,n) - Real(10.)*q(i,j,k+2,n) + Real(3.)*q(i,j,k+3,n));
                 }
                 else
                 {
-                    q(i,j,k,n) = 0.5*(3.*q(i,j,k+1,n) - q(i,j,k+2,n));
+                    q(i,j,k,n) = Real(0.5)*(Real(3.)*q(i,j,k+1,n) - q(i,j,k+2,n));
                 }
                 break;
             }
             case (BCType::hoextrapcc):
             {
-                q(i,j,k,n) = 2.*q(i,j,k+1,n) - q(i,j,k+2,n);
+                q(i,j,k,n) = Real(2.)*q(i,j,k+1,n) - q(i,j,k+2,n);
                 break;
             }
             case (BCType::reflect_even):
@@ -264,17 +264,17 @@ filcc_cell (const IntVect& iv, Array4<Real> const& q,
                 // k == khi+1
                 else if (khi-2 >= amrex::max(q.begin.z,klo))
                 {
-                    q(i,j,k,n) = 0.125*(15.*q(i,j,k-1,n) - 10.*q(i,j,k-2,n) + 3.*q(i,j,k-3,n));
+                    q(i,j,k,n) = Real(0.125)*(Real(15.)*q(i,j,k-1,n) - Real(10.)*q(i,j,k-2,n) + Real(3.)*q(i,j,k-3,n));
                 }
                 else
                 {
-                    q(i,j,k,n) = 0.5*(3.*q(i,j,k-1,n) - q(i,j,k-2,n));
+                    q(i,j,k,n) = Real(0.5)*(Real(3.)*q(i,j,k-1,n) - q(i,j,k-2,n));
                 }
                 break;
             }
             case (BCType::hoextrapcc):
             {
-                q(i,j,k,n) = 2.*q(i,j,k-1,n) - q(i,j,k-2,n);
+                q(i,j,k,n) = Real(2.)*q(i,j,k-1,n) - q(i,j,k-2,n);
                 break;
             }
             case (BCType::reflect_even):

--- a/Src/Base/AMReX_MultiFabUtil_3D_C.H
+++ b/Src/Base/AMReX_MultiFabUtil_3D_C.H
@@ -24,10 +24,10 @@ void amrex_avg_nd_to_cc (Box const& bx,
         for (int j = lo.y; j <= hi.y; ++j) {
         AMREX_PRAGMA_SIMD
         for (int i = lo.x; i <= hi.x; ++i) {
-            cc(i,j,k,n+cccomp) = 0.125*( nd(i,j  ,k  ,n+ndcomp) + nd(i+1,j  ,k  ,n+ndcomp)
-                                       + nd(i,j+1,k  ,n+ndcomp) + nd(i+1,j+1,k  ,n+ndcomp)
-                                       + nd(i,j  ,k+1,n+ndcomp) + nd(i+1,j  ,k+1,n+ndcomp)
-                                       + nd(i,j+1,k+1,n+ndcomp) + nd(i+1,j+1,k+1,n+ndcomp));
+            cc(i,j,k,n+cccomp) = Real(0.125)*( nd(i,j  ,k  ,n+ndcomp) + nd(i+1,j  ,k  ,n+ndcomp)
+                                             + nd(i,j+1,k  ,n+ndcomp) + nd(i+1,j+1,k  ,n+ndcomp)
+                                             + nd(i,j  ,k+1,n+ndcomp) + nd(i+1,j  ,k+1,n+ndcomp)
+                                             + nd(i,j+1,k+1,n+ndcomp) + nd(i+1,j+1,k+1,n+ndcomp));
         }}}
     }
 }
@@ -48,9 +48,9 @@ void amrex_avg_eg_to_cc (Box const& bx,
     for (int j = lo.y; j <= hi.y; ++j) {
     AMREX_PRAGMA_SIMD
     for (int i = lo.x; i <= hi.x; ++i) {
-        cc(i,j,k,0+cccomp) = 0.25 * ( Ex(i,j,k) + Ex(i,j+1,k) + Ex(i,j,k+1) + Ex(i,j+1,k+1) );
-        cc(i,j,k,1+cccomp) = 0.25 * ( Ey(i,j,k) + Ey(i+1,j,k) + Ey(i,j,k+1) + Ey(i+1,j,k+1) );
-        cc(i,j,k,2+cccomp) = 0.25 * ( Ez(i,j,k) + Ez(i+1,j,k) + Ez(i,j+1,k) + Ez(i+1,j+1,k) );
+        cc(i,j,k,0+cccomp) = Real(0.25) * ( Ex(i,j,k) + Ex(i,j+1,k) + Ex(i,j,k+1) + Ex(i,j+1,k+1) );
+        cc(i,j,k,1+cccomp) = Real(0.25) * ( Ey(i,j,k) + Ey(i+1,j,k) + Ey(i,j,k+1) + Ey(i+1,j,k+1) );
+        cc(i,j,k,2+cccomp) = Real(0.25) * ( Ez(i,j,k) + Ez(i+1,j,k) + Ez(i,j+1,k) + Ez(i+1,j+1,k) );
     }}}
 }
 
@@ -70,9 +70,9 @@ void amrex_avg_fc_to_cc (Box const& bx,
     for (int j = lo.y; j <= hi.y; ++j) {
     AMREX_PRAGMA_SIMD
     for (int i = lo.x; i <= hi.x; ++i) {
-        cc(i,j,k,0+cccomp) = 0.5 * ( fx(i,j,k) + fx(i+1,j,k) );
-        cc(i,j,k,1+cccomp) = 0.5 * ( fy(i,j,k) + fy(i,j+1,k) );
-        cc(i,j,k,2+cccomp) = 0.5 * ( fz(i,j,k) + fz(i,j,k+1) );
+        cc(i,j,k,0+cccomp) = Real(0.5) * ( fx(i,j,k) + fx(i+1,j,k) );
+        cc(i,j,k,1+cccomp) = Real(0.5) * ( fy(i,j,k) + fy(i,j+1,k) );
+        cc(i,j,k,2+cccomp) = Real(0.5) * ( fz(i,j,k) + fz(i,j,k+1) );
     }}}
 }
 
@@ -95,7 +95,7 @@ void amrex_avg_cc_to_fc (Box const& ndbx, Box const& xbx, Box const& ybx, Box co
         for     (int j = xlo.y; j <= xhi.y; ++j) {
             AMREX_PRAGMA_SIMD
             for (int i = xlo.x; i <= xhi.x; ++i) {
-                fx(i,j,k) = 0.5*(cc(i-1,j,k) + cc(i,j,k));
+                fx(i,j,k) = Real(0.5)*(cc(i-1,j,k) + cc(i,j,k));
             }
         }
     }
@@ -104,7 +104,7 @@ void amrex_avg_cc_to_fc (Box const& ndbx, Box const& xbx, Box const& ybx, Box co
         for     (int j = ylo.y; j <= yhi.y; ++j) {
             AMREX_PRAGMA_SIMD
             for (int i = ylo.x; i <= yhi.x; ++i) {
-                fy(i,j,k) = 0.5*(cc(i,j-1,k) + cc(i,j,k));
+                fy(i,j,k) = Real(0.5)*(cc(i,j-1,k) + cc(i,j,k));
             }
         }
     }
@@ -113,7 +113,7 @@ void amrex_avg_cc_to_fc (Box const& ndbx, Box const& xbx, Box const& ybx, Box co
         for     (int j = zlo.y; j <= zhi.y; ++j) {
             AMREX_PRAGMA_SIMD
             for (int i = zlo.x; i <= zhi.x; ++i) {
-                fz(i,j,k) = 0.5*(cc(i,j,k-1) + cc(i,j,k));
+                fz(i,j,k) = Real(0.5)*(cc(i,j,k-1) + cc(i,j,k));
             }
         }
     }
@@ -135,7 +135,7 @@ void amrex_avgdown_faces (Box const& bx, Array4<Real> const& crse,
     switch (idir) {
     case 0:
     {
-        Real facInv = 1.0 / (facy*facz);
+        Real facInv = Real(1.0) / (facy*facz);
         for (int n = 0; n < ncomp; ++n) {
             for (int k = clo.z; k <= chi.z; ++k) {
             for (int j = clo.y; j <= chi.y; ++j) {
@@ -155,7 +155,7 @@ void amrex_avgdown_faces (Box const& bx, Array4<Real> const& crse,
     }
     case 1:
     {
-        Real facInv = 1.0 / (facx*facz);
+        Real facInv = Real(1.0) / (facx*facz);
         for (int n = 0; n < ncomp; ++n) {
             for (int k = clo.z; k <= chi.z; ++k) {
             for (int j = clo.y; j <= chi.y; ++j) {
@@ -175,7 +175,7 @@ void amrex_avgdown_faces (Box const& bx, Array4<Real> const& crse,
     }
     case 2:
     {
-        Real facInv = 1.0 / (facx*facy);
+        Real facInv = Real(1.0) / (facx*facy);
         for (int n = 0; n < ncomp; ++n) {
             for (int k = clo.z; k <= chi.z; ++k) {
             for (int j = clo.y; j <= chi.y; ++j) {
@@ -212,7 +212,7 @@ void amrex_avgdown_edges (Box const& bx, Array4<Real> const& crse,
     switch (idir) {
     case 0:
     {
-        Real facInv = 1.0 / facx;
+        Real facInv = Real(1.0) / facx;
         for (int n = 0; n < ncomp; ++n) {
             for (int k = clo.z; k <= chi.z; ++k) {
             for (int j = clo.y; j <= chi.y; ++j) {
@@ -231,7 +231,7 @@ void amrex_avgdown_edges (Box const& bx, Array4<Real> const& crse,
     }
     case 1:
     {
-        Real facInv = 1.0 / facy;
+        Real facInv = Real(1.0) / facy;
         for (int n = 0; n < ncomp; ++n) {
             for (int k = clo.z; k <= chi.z; ++k) {
             for (int j = clo.y; j <= chi.y; ++j) {
@@ -250,7 +250,7 @@ void amrex_avgdown_edges (Box const& bx, Array4<Real> const& crse,
     }
     case 2:
     {
-        Real facInv = 1.0 / facz;
+        Real facInv = Real(1.0) / facz;
         for (int n = 0; n < ncomp; ++n) {
             for (int k = clo.z; k <= chi.z; ++k) {
             for (int j = clo.y; j <= chi.y; ++j) {
@@ -282,7 +282,7 @@ void amrex_avgdown (Box const& bx, Array4<Real> const& crse,
     const int facx = ratio[0];
     const int facy = ratio[1];
     const int facz = ratio[2];
-    const Real volfrac = 1.0/static_cast<Real>(facx*facy*facz);
+    const Real volfrac = Real(1.0)/(facx*facy*facz);
 
     for (int n = 0; n < ncomp; ++n) {
         for (int k = clo.z; k <= chi.z; ++k) {
@@ -440,11 +440,11 @@ void amrex_compute_convective_difference (Box const& bx, Array4<Real> const& dif
             for     (int j = lo.y; j <= hi.y; ++j) {
                 AMREX_PRAGMA_SIMD
                     for (int i = lo.x; i <= hi.x; ++i) {
-                        diff(i,j,k,n) = 0.5*dxi * (u_face(i+1,j,k)+u_face(i,j,k)) * 
+                        diff(i,j,k,n) = Real(0.5)*dxi * (u_face(i+1,j,k)+u_face(i,j,k)) *
                                                   (s_on_x_face(i+1,j,k,n)-s_on_x_face(i,j,k,n))
-                            +           0.5*dyi * (v_face(i,j+1,k)+v_face(i,j,k)) * 
+                            +           Real(0.5)*dyi * (v_face(i,j+1,k)+v_face(i,j,k)) *
                                                   (s_on_y_face(i,j+1,k,n)-s_on_y_face(i,j,k,n))
-                            +           0.5*dzi * (w_face(i,j,k+1)+w_face(i,j,k)) * 
+                            +           Real(0.5)*dzi * (w_face(i,j,k+1)+w_face(i,j,k)) *
                                                   (s_on_z_face(i,j,k+1,n)-s_on_z_face(i,j,k,n));
                     }
             }

--- a/Src/LinearSolvers/MLMG/AMReX_MLMG.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLMG.H
@@ -189,8 +189,8 @@ private:
     CFStrategy cf_strategy     = CFStrategy::none;
     int  bottom_verbose        = 0;
     int  bottom_maxiter        = 200;
-    Real bottom_reltol         = 1.e-4;
-    Real bottom_abstol         = -1.0;
+    Real bottom_reltol         = Real(1.e-4);
+    Real bottom_abstol         = Real(-1.0);
 
     int always_use_bnorm = 0;
 

--- a/Src/Particle/AMReX_ParticleContainerI.H
+++ b/Src/Particle/AMReX_ParticleContainerI.H
@@ -277,11 +277,11 @@ Reset (ParticleType& p,
       PeriodicShift(p);
       ok = Where(p, pld);
     }
-    
+
     if (!ok) {
         // invalidate the particle.
 	if (verbose) {
-            amrex::AllPrint()<< "Invalidating out-of-domain particle: " << p << '\n'; 
+            amrex::AllPrint()<< "Invalidating out-of-domain particle: " << p << '\n';
 	}
 
 	AMREX_ASSERT(p.id() > 0);
@@ -613,7 +613,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>::MoveRandom (i
     BL_PROFILE("ParticleContainer::MoveRandom(lev)");
     AMREX_ASSERT(OK());
     AMREX_ASSERT(m_gdb != 0);
-    // 
+    //
     // Move particles up to FRAC*CellSize distance in each coordinate direction.
     //
     const Real FRAC = 0.25;
@@ -646,7 +646,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>::MoveRandom (i
 
 template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt>
 void
-ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>::Increment (MultiFab& mf, int lev) 
+ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>::Increment (MultiFab& mf, int lev)
 {
   IncrementWithTotal(mf,lev);
 }
@@ -657,19 +657,19 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>::IncrementWith
 {
   BL_PROFILE("ParticleContainer::IncrementWithTotal(lev)");
   AMREX_ASSERT(OK());
-  
+
   if (m_particles.empty()) return 0;
-  
+
   AMREX_ASSERT(lev >= 0 && lev < int(m_particles.size()));
-  
+
   AMREX_ASSERT(numParticlesOutOfRange(*this, 0) == 0);
 
   const auto& pmap = m_particles[lev];
-  
+
   Long num_particles_in_domain = 0;
-  
+
   MultiFab* mf_pointer;
-  
+
   if (OnSameGrids(lev, mf))
   {
       // If we are already working with the internal mf defined on the
@@ -684,7 +684,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>::IncrementWith
 				ParticleDistributionMap(lev),
 				mf.nComp(),mf.nGrow());
   }
-  
+
   ParticleLocData pld;
   for (auto& kv : pmap) {
       int gid = kv.first.first;
@@ -1264,7 +1264,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
   BL_PROFILE("ParticleContainer::RedistributeCPU()");
 
   const int MyProc    = ParallelContext::MyProcSub();
-  Real      strttime  = amrex::second();
+  Real      strttime  = static_cast<Real>(amrex::second());
 
   if (local > 0) BuildRedistributeMask(0, local);
 
@@ -1477,11 +1477,11 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
           }
       }
   }
-  
+
   // Second pass - for each tile in parallel, collect the particles we are owed from all thread's buffers.
   for (int lev = lev_min; lev <= lev_max; lev++) {
       typename std::map<std::pair<int, int>, Vector<ParticleVector > >::iterator pmap_it;
-      
+
       Vector<std::pair<int, int> > grid_tile_ids;
       Vector<Vector<ParticleVector>* > pvec_ptrs;
 
@@ -1581,7 +1581,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
   AMREX_ASSERT(OK(lev_min, lev_max, nGrow));
 
   if (m_verbose > 0) {
-      Real stoptime = amrex::second() - strttime;
+      Real stoptime = static_cast<Real>(amrex::second() - strttime);
 
       ByteSpread();
 
@@ -1888,7 +1888,7 @@ RedistributeMPI (std::map<int, Vector<char> >& not_ours,
 
                 // add the struct
                 host_particles[lev][ind].push_back(p);
-	  
+
                 // add the real...
                 for (int comp = 0; comp < NumRealComps(); ++comp) {
                     if (h_communicate_real_comp[comp]) {
@@ -1898,9 +1898,9 @@ RedistributeMPI (std::map<int, Vector<char> >& not_ours,
                         host_real_attribs[lev][ind][comp].push_back(rdata);
                     } else {
                         host_real_attribs[lev][ind][comp].push_back(0.0);
-                    }                    
+                    }
                 }
-                
+
                 // ... and int array data
                 for (int comp = 0; comp < NumIntComps(); ++comp) {
                     if (h_communicate_int_comp[comp]) {
@@ -1922,23 +1922,23 @@ RedistributeMPI (std::map<int, Vector<char> >& not_ours,
 	      auto grid = kv.first.first;
 	      auto tile = kv.first.second;
 	      const auto& src_tile = kv.second;
-	      
+
 	      auto& dst_tile = GetParticles(host_lev)[std::make_pair(grid,tile)];
 	      auto old_size = dst_tile.GetArrayOfStructs().size();
 	      auto new_size = old_size + src_tile.size();
 	      dst_tile.resize(new_size);
-	      
+
 	      Gpu::copy(Gpu::hostToDevice,
                         src_tile.begin(), src_tile.end(),
                         dst_tile.GetArrayOfStructs().begin() + old_size);
-	      
+
 	      for (int i = 0; i < NumRealComps(); ++i) {
                   Gpu::copy(Gpu::hostToDevice,
                             host_real_attribs[host_lev][std::make_pair(grid,tile)][i].begin(),
                             host_real_attribs[host_lev][std::make_pair(grid,tile)][i].end(),
                             dst_tile.GetStructOfArrays().GetRealData(i).begin() + old_size);
 	      }
-	      
+
 	      for (int i = 0; i < NumIntComps(); ++i) {
                   Gpu::copy(Gpu::hostToDevice,
                             host_int_attribs[host_lev][std::make_pair(grid,tile)][i].begin(),
@@ -1947,7 +1947,7 @@ RedistributeMPI (std::map<int, Vector<char> >& not_ours,
 	      }
 	    }
 	  }
-    
+
 	Gpu::Device::streamSynchronize();
 #endif
 

--- a/Src/Particle/AMReX_ParticleIO.H
+++ b/Src/Particle/AMReX_ParticleIO.H
@@ -705,7 +705,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
     AMREX_ASSERT(!dir.empty());
     AMREX_ASSERT(!file.empty());
 
-    const Real strttime = amrex::second();
+    const Real strttime = static_cast<Real>(amrex::second());
 
     int DATA_Digits_Read(5);
     ParmParse pp("particles");
@@ -956,7 +956,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
     AMREX_ASSERT(OK());
 
     if (m_verbose > 1) {
-        Real stoptime = amrex::second() - strttime;
+        Real stoptime = static_cast<Real>(amrex::second() - strttime);
         ParallelDescriptor::ReduceRealMax(stoptime, ParallelDescriptor::IOProcessorNumber());
         amrex::Print() << "ParticleContainer::Restart() time: " << stoptime << '\n';
     }
@@ -1020,15 +1020,15 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
 
         AMREX_ASSERT(p.id() > 0);
 
-        AMREX_D_TERM(p.pos(0) = rptr[0];,
-                     p.pos(1) = rptr[1];,
-                     p.pos(2) = rptr[2];);
+        AMREX_D_TERM(p.pos(0) = ParticleReal(rptr[0]);,
+                     p.pos(1) = ParticleReal(rptr[1]);,
+                     p.pos(2) = ParticleReal(rptr[2]););
 
         rptr += AMREX_SPACEDIM;
 
         for (int j = 0; j < NStructReal; j++)
         {
-            p.rdata(j) = *rptr;
+            p.rdata(j) = ParticleReal(*rptr);
             ++rptr;
         }
 
@@ -1044,7 +1044,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
 
 	// add the real...
 	for (int icomp = 0; icomp < NumRealComps(); icomp++) {
-            host_real_attribs[lev][ind][icomp].push_back(*rptr);
+            host_real_attribs[lev][ind][icomp].push_back(ParticleReal(*rptr));
             ++rptr;
 	}
 


### PR DESCRIPTION
## Summary
I tried to compile  `WarpX` in single precision and I noticed several warnings related to casts from `double` to `float` in `AMReX`.
This PR should fix several of these warnings. 

## Additional background
I compiled `WarpX` with `make DIM=3 PRECISION=FLOAT USE_SINGLE_PRECISION_PARTICLES=TRUE`
using the compiler `g++ (Ubuntu 10.2.0-13ubuntu1) 10.2.0` 

## Checklist

The proposed changes:
- [X] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
