### PR TITLE
fix -Werror=sign-compare

### DIFF
--- a/Src/Particle/AMReX_NeighborParticlesCPUImpl.H
+++ b/Src/Particle/AMReX_NeighborParticlesCPUImpl.H
@@ -579,7 +579,7 @@ fillNeighborsMPI (bool reuse_rcv_counts) {
                 if ( enableInverse() )
                 {
                     AMREX_ASSERT(neighbors[lev][dst_index].size() ==
-                                 inverse_tags[lev][dst_index].size());
+                                 size_t(inverse_tags[lev][dst_index].size()));
                     inverse_tags[lev][dst_index].resize(new_size);
                 }
                 neighbors[lev][dst_index].resize(new_size);

--- a/Src/Particle/AMReX_NeighborParticlesI.H
+++ b/Src/Particle/AMReX_NeighborParticlesI.H
@@ -450,7 +450,7 @@ NeighborParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
                 Vector<NeighborCopyTag>& tags = buffer_tag_cache[nim.src_level][src_index][nim.thread_num];
                 AMREX_ASSERT(nim.src_index < tags.size());
                 tags[nim.src_index].dst_index = i;
-                AMREX_ASSERT(tags[nim.src_index].dst_index < neighbors[nim.dst_level][dst_index].size());
+                AMREX_ASSERT(size_t(tags[nim.src_index].dst_index) < neighbors[nim.dst_level][dst_index].size());
             }
         }
     }

--- a/Src/Particle/AMReX_StructOfArrays.H
+++ b/Src/Particle/AMReX_StructOfArrays.H
@@ -10,7 +10,7 @@
 
 namespace amrex {
 
-template <int NReal, int NInt,
+template <size_t NReal, size_t NInt,
           template<class> class Allocator=DefaultAllocator>
 struct StructOfArrays {
 
@@ -39,16 +39,7 @@ struct StructOfArrays {
     const std::array<RealVector, NReal>& GetRealData () const { return m_rdata; }
     const std::array< IntVector,  NInt>& GetIntData  () const { return m_idata; }
 
-    RealVector& GetRealData (const int index) {
-        AMREX_ASSERT(size_t(index) < NReal + m_runtime_rdata.size());
-        if (index < NReal) return m_rdata[index];
-        else {
-            AMREX_ASSERT(m_defined);
-            return m_runtime_rdata[index - NReal];
-        }
-    }
-
-    const RealVector& GetRealData (const int index) const {
+    RealVector& GetRealData (const size_t index) {
         AMREX_ASSERT(index < NReal + m_runtime_rdata.size());
         if (index < NReal) return m_rdata[index];
         else {
@@ -57,8 +48,17 @@ struct StructOfArrays {
         }
     }
 
-    IntVector& GetIntData (const int index) {
-        AMREX_ASSERT(size_t(index) < NInt + m_runtime_idata.size());
+    const RealVector& GetRealData (const size_t index) const {
+        AMREX_ASSERT(index < NReal + m_runtime_rdata.size());
+        if (index < NReal) return m_rdata[index];
+        else {
+            AMREX_ASSERT(m_defined);
+            return m_runtime_rdata[index - NReal];
+        }
+    }
+
+    IntVector& GetIntData (const size_t index) {
+        AMREX_ASSERT(index < NInt + m_runtime_idata.size());
         if (index < NInt) return m_idata[index];
         else {
             AMREX_ASSERT(m_defined);
@@ -66,8 +66,8 @@ struct StructOfArrays {
         }
    }
 
-    const IntVector& GetIntData (const int index) const {
-        AMREX_ASSERT(size_t(index) < NInt + m_runtime_idata.size());
+    const IntVector& GetIntData (const size_t index) const {
+        AMREX_ASSERT(index < NInt + m_runtime_idata.size());
         if (index < NInt) return m_idata[index];
         else {
             AMREX_ASSERT(m_defined);
@@ -128,10 +128,10 @@ struct StructOfArrays {
 
     void resize (size_t count)
     {
-        for (int i = 0; i < NReal; ++i) m_rdata[i].resize(count);
-        for (int i = 0; i < NInt;  ++i) m_idata[i].resize(count);
-        for (int i = 0; i < (int) m_runtime_rdata.size(); ++i) m_runtime_rdata[i].resize(count);
-        for (int i = 0; i < (int) m_runtime_idata.size(); ++i) m_runtime_idata[i].resize(count);
+        for (size_t i = 0; i < NReal; ++i) m_rdata[i].resize(count);
+        for (size_t i = 0; i < NInt;  ++i) m_idata[i].resize(count);
+        for (size_t i = 0; i < m_runtime_rdata.size(); ++i) m_runtime_rdata[i].resize(count);
+        for (size_t i = 0; i < m_runtime_idata.size(); ++i) m_runtime_idata[i].resize(count);
     }
 
     GpuArray<ParticleReal*, NReal> realarray ()

--- a/Src/Particle/AMReX_StructOfArrays.H
+++ b/Src/Particle/AMReX_StructOfArrays.H
@@ -10,7 +10,7 @@
 
 namespace amrex {
 
-template <size_t NReal, size_t NInt,
+template <int NReal, int NInt,
           template<class> class Allocator=DefaultAllocator>
 struct StructOfArrays {
 


### PR DESCRIPTION
## Summary

Use size_t for index variables to avoid sign-compare warnings and casting to size_t

## Checklist

The proposed changes:
- [X] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
