### PR TITLE
Support single precision build with configure

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -317,6 +317,20 @@ jobs:
         make -j2 WARN_ALL=TRUE WARN_ERROR=TRUE XTRA_CXXFLAGS=-fno-operator-names CXXSTD=c++17
         make install
 
+  # Build 3D libamrex with single precision and tiny profiler
+  configure-3d-single-tprof:
+    name: GNU@7.5 Release [configure 3D]
+    runs-on: ubuntu-18.04
+    steps:
+    - uses: actions/checkout@v2
+    - name: Dependencies
+      run: .github/workflows/dependencies/dependencies.sh
+    - name: Build & Install
+      run: |
+        ./configure --dim 3 --enable-eb no --enable-xsdk-defaults no --single-precision yes --single-precision-particles yes --enable-tiny-profile yes
+        make -j2 WARN_ALL=TRUE WARN_ERROR=TRUE XTRA_CXXFLAGS=-fno-operator-names
+        make install
+
   # Build 3D libamrex debug omp build with configure
   configure-3d-omp-debug:
     name: GNU@7.5 OMP Debug [configure 3D]

--- a/Src/Amr/AMReX_Amr.cpp
+++ b/Src/Amr/AMReX_Amr.cpp
@@ -920,7 +920,7 @@ Amr::writeSmallPlotFile ()
 void
 Amr::writePlotFileDoit (std::string const& pltfile, bool regular)
 {
-    Real dPlotFileTime0 = amrex::second();
+    auto dPlotFileTime0 = amrex::second();
 
     VisMF::SetNOutFiles(plot_nfiles);
     VisMF::Header::Version currentVersion(VisMF::GetHeaderVersion());
@@ -1009,7 +1009,7 @@ Amr::writePlotFileDoit (std::string const& pltfile, bool regular)
 
         if (verbose > 0) {
             const int IOProc        = ParallelDescriptor::IOProcessorNumber();
-            Real      dPlotFileTime = amrex::second() - dPlotFileTime0;
+            auto      dPlotFileTime = amrex::second() - dPlotFileTime0;
             ParallelDescriptor::ReduceRealMax(dPlotFileTime,IOProc);
             if (regular) {
                 amrex::Print() << "Write plotfile time = " << dPlotFileTime << "  seconds" << "\n\n";
@@ -1168,7 +1168,7 @@ Amr::readProbinFile (int& a_init)
     const int NSets   = (NProcs + (nAtOnce - 1)) / nAtOnce;
     const int MySet   = MyProc/nAtOnce;
 
-    Real piStart = 0, piEnd = 0, piStartAll = amrex::second();
+    double piStart = 0, piEnd = 0, piStartAll = amrex::second();
 
     for (int iSet = 0; iSet < NSets; ++iSet)
     {
@@ -1218,8 +1218,8 @@ Amr::readProbinFile (int& a_init)
     if (verbose > 1)
     {
         const int IOProc     = ParallelDescriptor::IOProcessorNumber();
-        Real      piTotal    = piEnd - piStart;
-        Real      piTotalAll = amrex::second() - piStartAll;
+        auto      piTotal    = piEnd - piStart;
+        auto      piTotalAll = amrex::second() - piStartAll;
 
         ParallelDescriptor::ReduceRealMax(piTotal,    IOProc);
         ParallelDescriptor::ReduceRealMax(piTotalAll, IOProc);
@@ -1361,7 +1361,7 @@ Amr::restart (const std::string& filename)
 
     which_level_being_advanced = -1;
 
-    Real dRestartTime0 = amrex::second();
+    auto dRestartTime0 = amrex::second();
 
     VisMF::SetMFFileInStreams(mffile_nstreams);
 
@@ -1662,7 +1662,7 @@ Amr::restart (const std::string& filename)
 
     if (verbose > 0)
     {
-        Real dRestartTime = amrex::second() - dRestartTime0;
+        auto dRestartTime = amrex::second() - dRestartTime0;
 
         ParallelDescriptor::ReduceRealMax(dRestartTime,ParallelDescriptor::IOProcessorNumber());
 
@@ -1692,7 +1692,7 @@ Amr::checkPoint ()
     VisMF::Header::Version currentVersion(VisMF::GetHeaderVersion());
     VisMF::SetHeaderVersion(checkpoint_headerversion);
 
-    Real dCheckPointTime0 = amrex::second();
+    auto dCheckPointTime0 = amrex::second();
 
     const std::string& ckfile = amrex::Concatenate(check_file_root,level_steps[0],file_name_digits);
 
@@ -1824,7 +1824,7 @@ Amr::checkPoint ()
 
     if (verbose > 0)
     {
-        Real dCheckPointTime = amrex::second() - dCheckPointTime0;
+        auto dCheckPointTime = amrex::second() - dCheckPointTime0;
 
         ParallelDescriptor::ReduceRealMax(dCheckPointTime,
 	                            ParallelDescriptor::IOProcessorNumber());
@@ -2048,8 +2048,8 @@ Amr::coarseTimeStepDt (Real stop_time)
 void
 Amr::coarseTimeStep (Real stop_time)
 {
-    Real      run_stop;
-    Real run_strt;
+    double run_stop;
+    double run_strt;
     BL_PROFILE_REGION_START("Amr::coarseTimeStep()");
     BL_PROFILE("Amr::coarseTimeStep()");
     std::stringstream stepName;
@@ -2173,7 +2173,7 @@ Amr::coarseTimeStep (Real stop_time)
         // the counter, because we have indeed reached the next check_per interval
         // at this point.
 
-        const Real eps = std::numeric_limits<Real>::epsilon() * 10.0 * std::abs(cumtime);
+        const Real eps = std::numeric_limits<Real>::epsilon() * 10.0_rt * std::abs(cumtime);
         const Real next_chk_time = (num_per_old + 1) * check_per;
 
         if ((num_per_new == num_per_old) && std::abs(cumtime - next_chk_time) <= eps)
@@ -2317,7 +2317,7 @@ Amr::writePlotNow() noexcept
         // the counter, because we have indeed reached the next plot_per interval
         // at this point.
 
-        const Real eps = std::numeric_limits<Real>::epsilon() * 10.0 * std::abs(cumtime);
+        const Real eps = std::numeric_limits<Real>::epsilon() * 10.0_rt * std::abs(cumtime);
         const Real next_plot_time = (num_per_old + 1) * plot_per;
 
         if ((num_per_new == num_per_old) && std::abs(cumtime - next_plot_time) <= eps)
@@ -2390,7 +2390,7 @@ Amr::writeSmallPlotNow() noexcept
         // the counter, because we have indeed reached the next small_plot_per interval
         // at this point.
 
-        const Real eps = std::numeric_limits<Real>::epsilon() * 10.0 * std::abs(cumtime);
+        const Real eps = std::numeric_limits<Real>::epsilon() * 10.0_rt * std::abs(cumtime);
         const Real next_plot_time = (num_per_old + 1) * small_plot_per;
 
         if ((num_per_new == num_per_old) && std::abs(cumtime - next_plot_time) <= eps)
@@ -2816,7 +2816,7 @@ Amr::printGridInfo (std::ostream& os,
         int                       numgrid = bs.size();
         Long                      ncells  = amr_level[lev]->countCells();
         double                    ntot    = Geom(lev).Domain().d_numPts();
-        Real                      frac    = Real(100.0)*(Real(ncells) / ntot);
+        Real                      frac    = Real(100.0 * double(ncells) / ntot);
         const DistributionMapping& map    = amr_level[lev]->get_new_data(0).DistributionMap();
 
         os << "  Level "
@@ -2856,7 +2856,7 @@ Amr::grid_places (int              lbase,
 {
     BL_PROFILE("Amr::grid_places()");
 
-    const Real strttime = amrex::second();
+    const auto strttime = amrex::second();
 
     if (lbase == 0)
     {
@@ -2931,7 +2931,7 @@ Amr::grid_places (int              lbase,
 
     if (verbose > 0)
     {
-        Real stoptime = amrex::second() - strttime;
+        auto stoptime = amrex::second() - strttime;
 
 #ifdef BL_LAZY
 	Lazy::QueueReduction( [=] () mutable {

--- a/Src/Amr/AMReX_AmrLevel.cpp
+++ b/Src/Amr/AMReX_AmrLevel.cpp
@@ -598,7 +598,7 @@ AmrLevel::get_data (int  state_indx, Real time) noexcept
 {
     const Real old_time = state[state_indx].prevTime();
     const Real new_time = state[state_indx].curTime();
-    const Real eps = 0.001*(new_time - old_time);
+    const Real eps = Real(0.001)*(new_time - old_time);
 
     if (time > old_time-eps && time < old_time+eps)
     {
@@ -2098,10 +2098,10 @@ AmrLevel::which_time (int  indx, Real time) const noexcept
 {
     const Real oldtime = state[indx].prevTime();
     const Real newtime = state[indx].curTime();
-    const Real haftime = .5 * (oldtime + newtime);
-    const Real qtime = oldtime + 0.25*(newtime-oldtime);
-    const Real tqtime = oldtime + 0.75*(newtime-oldtime);
-    const Real epsilon = 0.001 * (newtime - oldtime);
+    const Real haftime = .5_rt * (oldtime + newtime);
+    const Real qtime = oldtime + 0.25_rt*(newtime-oldtime);
+    const Real tqtime = oldtime + 0.75_rt*(newtime-oldtime);
+    const Real epsilon = 0.001_rt * (newtime - oldtime);
 
     BL_ASSERT(time >= oldtime-epsilon && time <= newtime+epsilon);
     
@@ -2131,7 +2131,7 @@ AmrLevel::which_time (int  indx, Real time) const noexcept
 Real
 AmrLevel::estimateWork ()
 {
-    return 1.0*countCells();
+    return static_cast<Real>(countCells());
 }
 
 bool

--- a/Src/Amr/AMReX_AuxBoundaryData.cpp
+++ b/Src/Amr/AMReX_AuxBoundaryData.cpp
@@ -63,7 +63,7 @@ AuxBoundaryData::initialize (const BoxArray& ba,
 
     const bool verbose   = false;
     const int  NProcs    = ParallelDescriptor::NProcs();
-    const Real strt_time = amrex::second();
+    const auto strt_time = amrex::second();
 
     m_ngrow = n_grow;
 
@@ -108,7 +108,7 @@ AuxBoundaryData::initialize (const BoxArray& ba,
     if (verbose)
     {
         const int IOProc   = ParallelDescriptor::IOProcessorNumber();
-        Real      run_time = amrex::second() - strt_time;
+        auto      run_time = amrex::second() - strt_time;
 	const int sz       = nba.size();
 
 #ifdef BL_LAZY

--- a/Src/Amr/AMReX_StateData.H
+++ b/Src/Amr/AMReX_StateData.H
@@ -314,7 +314,7 @@ public:
     */
     Real curTime () const noexcept {
 	return (desc->timeType() == StateDescriptor::Point) ?
-	    new_time.stop : 0.5*(new_time.start + new_time.stop);
+	    new_time.stop : 0.5_rt*(new_time.start + new_time.stop);
     }
 
     /**
@@ -322,7 +322,7 @@ public:
     */
     Real prevTime () const noexcept {
 	return (desc->timeType() == StateDescriptor::Point) ?
-	    old_time.stop : 0.5*(old_time.start + old_time.stop);
+	    old_time.stop : 0.5_rt*(old_time.start + old_time.stop);
     }
 
     /**

--- a/Src/Amr/AMReX_StateData.cpp
+++ b/Src/Amr/AMReX_StateData.cpp
@@ -16,9 +16,9 @@
 namespace amrex {
 
 #ifdef AMREX_USE_FLOAT
-static constexpr Real INVALID_TIME = -1.0e30;
+static constexpr Real INVALID_TIME = -1.0e30_rt;
 #else
-static constexpr Real INVALID_TIME = -1.0e200; 
+static constexpr Real INVALID_TIME = -1.0e200_rt;
 #endif
 
 static constexpr int MFNEWDATA = 0;
@@ -235,7 +235,7 @@ StateData::restartDoit (std::istream& is, const std::string& chkfile)
     // We set it to zero in case a compiler complains about uninitialized data.
     //
     if (nsets == 0) {
-       new_data->setVal(0.0);
+       new_data->setVal(0.0_rt);
     }
 
     std::string mf_name;
@@ -293,7 +293,7 @@ StateData::restart (const StateDescriptor& d,
     new_data.reset(new MultiFab(grids,dmap,desc->nComp(),desc->nExtra(),
                                 MFInfo().SetTag("StateData").SetArena(arena),
                                 *m_factory));
-    new_data->setVal(0.);
+    new_data->setVal(0._rt);
 }
 
 StateData::~StateData()
@@ -349,7 +349,7 @@ StateData::setNewTimeLevel (Real time)
 void
 StateData::syncNewTimeLevel (Real time)
 {
-    Real teps = (new_time.stop - old_time.stop)*1.e-3;
+    Real teps = (new_time.stop - old_time.stop)*1.e-3_rt;
     if (time > new_time.stop-teps && time < new_time.stop+teps)
     {
 	if (desc->timeType() == StateDescriptor::Point)
@@ -624,7 +624,7 @@ StateData::InterpAddBox (MultiFabCopyDescriptor& multiFabCopyDesc,
     }
     else
     {
-        const Real teps = (new_time.start - old_time.start)*1.e-3;
+        const Real teps = (new_time.start - old_time.start)*1.e-3_rt;
 
         if (time > new_time.start-teps && time < new_time.stop+teps)
         {
@@ -691,7 +691,7 @@ StateData::InterpFillFab (MultiFabCopyDescriptor&  multiFabCopyDesc,
     }
     else
     {
-        const Real teps = (new_time.start - old_time.start)*1.e-3;
+        const Real teps = (new_time.start - old_time.start)*1.e-3_rt;
 
         if (time > new_time.start-teps && time < new_time.stop+teps)
         {
@@ -728,7 +728,7 @@ StateData::getData (Vector<MultiFab*>& data,
         }
         else
         {
-	    const Real teps = (new_time.start - old_time.start)*1.e-3;
+	    const Real teps = (new_time.start - old_time.start)*1.e-3_rt;
 	    if (time > new_time.start-teps && time < new_time.start+teps) {
 		data.push_back(new_data.get());
 		datatime.push_back(new_time.start);
@@ -745,7 +745,7 @@ StateData::getData (Vector<MultiFab*>& data,
     }
     else
     {
-        const Real teps = (new_time.start - old_time.start)*1.e-3;
+        const Real teps = (new_time.start - old_time.start)*1.e-3_rt;
 
         if (time > new_time.start-teps && time < new_time.stop+teps)
         {

--- a/Src/Amr/AMReX_extrapolater_3D_K.H
+++ b/Src/Amr/AMReX_extrapolater_3D_K.H
@@ -254,7 +254,7 @@ amrex_first_order_extrap_cpu(amrex::Box const& bx,
                                    + mask(i+1,j,k+1) * data(i+1,j,k+1,n)
                                    + mask(i,j+1,k-1) * data(i,j+1,k-1,n)
                                    + mask(i,j+1,k+1) * data(i,j+1,k+1,n) )
-                                 / ( 1.0 + mask(i+1,j,k-1) + mask(i+1,j,k+1) + mask(i,j+1,k-1) + mask(i,j+1,k+1) );
+                                 / ( 1 + mask(i+1,j,k-1) + mask(i+1,j,k+1) + mask(i,j+1,k-1) + mask(i,j+1,k+1) );
                }
             }
          }
@@ -280,7 +280,7 @@ amrex_first_order_extrap_cpu(amrex::Box const& bx,
                                    + mask(i+1,j,k+1) * data(i+1,j,k+1,n)
                                    + mask(i,j-1,k-1) * data(i,j-1,k-1,n)
                                    + mask(i,j-1,k+1) * data(i,j-1,k+1,n) )
-                                 / ( 1.0 + mask(i+1,j,k-1) + mask(i+1,j,k+1) + mask(i,j-1,k-1) + mask(i,j-1,k+1) );
+                                 / ( 1 + mask(i+1,j,k-1) + mask(i+1,j,k+1) + mask(i,j-1,k-1) + mask(i,j-1,k+1) );
                }
             }
          }
@@ -306,7 +306,7 @@ amrex_first_order_extrap_cpu(amrex::Box const& bx,
                                    + mask(i-1,j,k+1) * data(i-1,j,k+1,n)
                                    + mask(i,j+1,k-1) * data(i,j+1,k-1,n)
                                    + mask(i,j+1,k+1) * data(i,j+1,k+1,n) )
-                                 / ( 1.0 + mask(i-1,j,k-1) + mask(i-1,j,k+1) + mask(i,j+1,k-1) + mask(i,j+1,k+1) );
+                                 / ( 1 + mask(i-1,j,k-1) + mask(i-1,j,k+1) + mask(i,j+1,k-1) + mask(i,j+1,k+1) );
                }
             }
          }
@@ -332,7 +332,7 @@ amrex_first_order_extrap_cpu(amrex::Box const& bx,
                                    + mask(i-1,j,k+1) * data(i-1,j,k+1,n)
                                    + mask(i,j-1,k-1) * data(i,j-1,k-1,n)
                                    + mask(i,j-1,k+1) * data(i,j-1,k+1,n) )
-                                 / ( 1.0 + mask(i-1,j,k-1) + mask(i-1,j,k+1) + mask(i,j-1,k-1) + mask(i,j-1,k+1) );
+                                 / ( 1 + mask(i-1,j,k-1) + mask(i-1,j,k+1) + mask(i,j-1,k-1) + mask(i,j-1,k+1) );
                }
             }
          }
@@ -358,7 +358,7 @@ amrex_first_order_extrap_cpu(amrex::Box const& bx,
                                    +                   data(i+1,j,k+1,n)
                                    + mask(i,j-1,k+1) * data(i,j-1,k+1,n)
                                    + mask(i,j+1,k+1) * data(i,j+1,k+1,n) )
-                                 / ( mask(i+1,j-1,k) + mask(i+1,j+1,k) + 1.0 + mask(i,j-1,k+1) + mask(i,j+1,k+1) );
+                                 / ( mask(i+1,j-1,k) + mask(i+1,j+1,k) + 1 + mask(i,j-1,k+1) + mask(i,j+1,k+1) );
                }
             }
          }
@@ -384,7 +384,7 @@ amrex_first_order_extrap_cpu(amrex::Box const& bx,
                                    +                   data(i+1,j,k-1,n)
                                    + mask(i,j-1,k-1) * data(i,j-1,k-1,n)
                                    + mask(i,j+1,k-1) * data(i,j+1,k-1,n) )
-                                 / ( mask(i+1,j-1,k) + mask(i+1,j+1,k) + 1.0 + mask(i,j-1,k-1) + mask(i,j+1,k-1) );
+                                 / ( mask(i+1,j-1,k) + mask(i+1,j+1,k) + 1 + mask(i,j-1,k-1) + mask(i,j+1,k-1) );
                }
             }
          }
@@ -410,7 +410,7 @@ amrex_first_order_extrap_cpu(amrex::Box const& bx,
                                    +                   data(i-1,j,k+1,n)
                                    + mask(i,j-1,k+1) * data(i,j-1,k+1,n)
                                    + mask(i,j+1,k+1) * data(i,j+1,k+1,n) )
-                                 / ( mask(i-1,j-1,k) + mask(i-1,j+1,k) + 1.0 + mask(i,j-1,k+1) + mask(i,j+1,k+1) );
+                                 / ( mask(i-1,j-1,k) + mask(i-1,j+1,k) + 1 + mask(i,j-1,k+1) + mask(i,j+1,k+1) );
                }
             }
          }
@@ -436,7 +436,7 @@ amrex_first_order_extrap_cpu(amrex::Box const& bx,
                                    +                   data(i-1,j,k-1,n)
                                    + mask(i,j-1,k-1) * data(i,j-1,k-1,n)
                                    + mask(i,j+1,k-1) * data(i,j+1,k-1,n) )
-                                 / ( mask(i-1,j-1,k) + mask(i-1,j+1,k) + 1.0 + mask(i,j-1,k-1) + mask(i,j+1,k-1) );
+                                 / ( mask(i-1,j-1,k) + mask(i-1,j+1,k) + 1 + mask(i,j-1,k-1) + mask(i,j+1,k-1) );
                }
             }
          }
@@ -462,7 +462,7 @@ amrex_first_order_extrap_cpu(amrex::Box const& bx,
                                    + mask(i-1,j,k+1) * data(i-1,j,k+1,n)
                                    + mask(i+1,j,k+1) * data(i+1,j,k+1,n)
                                    +                   data(i,j+1,k+1,n) )
-                                 / ( mask(i-1,j+1,k) + mask(i+1,j+1,k) + mask(i-1,j,k+1) + mask(i+1,j,k+1) + 1.0 );
+                                 / ( mask(i-1,j+1,k) + mask(i+1,j+1,k) + mask(i-1,j,k+1) + mask(i+1,j,k+1) + 1 );
                }
             }
          }
@@ -488,7 +488,7 @@ amrex_first_order_extrap_cpu(amrex::Box const& bx,
                                    + mask(i-1,j,k-1) * data(i-1,j,k-1,n)
                                    + mask(i+1,j,k-1) * data(i+1,j,k-1,n)
                                    +                   data(i,j+1,k-1,n) )
-                                 / ( mask(i-1,j+1,k) + mask(i+1,j+1,k) + mask(i-1,j,k-1) + mask(i+1,j,k-1) + 1.0 );
+                                 / ( mask(i-1,j+1,k) + mask(i+1,j+1,k) + mask(i-1,j,k-1) + mask(i+1,j,k-1) + 1 );
                }
             }
          }
@@ -514,7 +514,7 @@ amrex_first_order_extrap_cpu(amrex::Box const& bx,
                                    + mask(i-1,j,k+1) * data(i-1,j,k+1,n)
                                    + mask(i+1,j,k+1) * data(i+1,j,k+1,n)
                                    +                   data(i,j-1,k+1,n) )
-                                 / ( mask(i-1,j-1,k) + mask(i+1,j-1,k) + mask(i-1,j,k+1) + mask(i+1,j,k+1) + 1.0 );
+                                 / ( mask(i-1,j-1,k) + mask(i+1,j-1,k) + mask(i-1,j,k+1) + mask(i+1,j,k+1) + 1 );
                }
             }
          }
@@ -540,7 +540,7 @@ amrex_first_order_extrap_cpu(amrex::Box const& bx,
                                    + mask(i-1,j,k-1) * data(i-1,j,k-1,n)
                                    + mask(i+1,j,k-1) * data(i+1,j,k-1,n)
                                    +                   data(i,j-1,k-1,n) )
-                                 / ( mask(i-1,j-1,k) + mask(i+1,j-1,k) + mask(i-1,j,k-1) + mask(i+1,j,k-1) + 1.0 );
+                                 / ( mask(i-1,j-1,k) + mask(i+1,j-1,k) + mask(i-1,j,k-1) + mask(i+1,j,k-1) + 1 );
                }
             }
          }
@@ -557,7 +557,7 @@ amrex_first_order_extrap_cpu(amrex::Box const& bx,
                                    + mask(i,j+1,k) * data(i,j+1,k,n)
                                    + mask(i,j,k-1) * data(i,j,k-1,n)
                                    + mask(i,j,k+1) * data(i,j,k+1,n) )
-                                 / ( 1.0 + mask(i,j-1,k) + mask(i,j+1,k) + mask(i,j,k-1) + mask(i,j,k+1) );
+                                 / ( 1 + mask(i,j-1,k) + mask(i,j+1,k) + mask(i,j,k-1) + mask(i,j,k+1) );
                }
             }
          }
@@ -573,7 +573,7 @@ amrex_first_order_extrap_cpu(amrex::Box const& bx,
                                    + mask(i,j+1,k) * data(i,j+1,k,n)
                                    + mask(i,j,k-1) * data(i,j,k-1,n)
                                    + mask(i,j,k+1) * data(i,j,k+1,n) )
-                                 / ( 1.0 + mask(i,j-1,k) + mask(i,j+1,k) + mask(i,j,k-1) + mask(i,j,k+1) );
+                                 / ( 1 + mask(i,j-1,k) + mask(i,j+1,k) + mask(i,j,k-1) + mask(i,j,k+1) );
                }
             }
          }
@@ -589,7 +589,7 @@ amrex_first_order_extrap_cpu(amrex::Box const& bx,
                                    +                 data(i,j+1,k,n)
                                    + mask(i,j,k-1) * data(i,j,k-1,n)
                                    + mask(i,j,k+1) * data(i,j,k+1,n) )
-                                 / ( mask(i-1,j,k) + mask(i+1,j,k) + 1.0 + mask(i,j,k-1) + mask(i,j,k+1) );
+                                 / ( mask(i-1,j,k) + mask(i+1,j,k) + 1 + mask(i,j,k-1) + mask(i,j,k+1) );
                }
             }
          }
@@ -605,7 +605,7 @@ amrex_first_order_extrap_cpu(amrex::Box const& bx,
                                    +                 data(i,j-1,k,n)
                                    + mask(i,j,k-1) * data(i,j,k-1,n)
                                    + mask(i,j,k+1) * data(i,j,k+1,n) )
-                                 / ( mask(i-1,j,k) + mask(i+1,j,k) + 1.0 + mask(i,j,k-1) + mask(i,j,k+1) );
+                                 / ( mask(i-1,j,k) + mask(i+1,j,k) + 1 + mask(i,j,k-1) + mask(i,j,k+1) );
                }
             }
          }
@@ -621,7 +621,7 @@ amrex_first_order_extrap_cpu(amrex::Box const& bx,
                                    + mask(i,j-1,k) * data(i,j-1,k,n)
                                    + mask(i,j+1,k) * data(i,j+1,k,n)
                                    +                 data(i,j,k+1,n) )
-                                 / ( mask(i-1,j,k) + mask(i+1,j,k) + mask(i,j-1,k) + mask(i,j+1,k) + 1.0 );
+                                 / ( mask(i-1,j,k) + mask(i+1,j,k) + mask(i,j-1,k) + mask(i,j+1,k) + 1 );
                }
             }
          }
@@ -637,7 +637,7 @@ amrex_first_order_extrap_cpu(amrex::Box const& bx,
                                    + mask(i,j-1,k) * data(i,j-1,k,n)
                                    + mask(i,j+1,k) * data(i,j+1,k,n)
                                    +                 data(i,j,k-1,n) )
-                                 / ( mask(i-1,j,k) + mask(i+1,j,k) + mask(i,j-1,k) + mask(i,j+1,k) + 1.0 );
+                                 / ( mask(i-1,j,k) + mask(i+1,j,k) + mask(i,j-1,k) + mask(i,j+1,k) + 1 );
                }
             }
          }
@@ -834,7 +834,7 @@ amrex_first_order_extrap_gpu(int i, int j, int k, int n,
                              + mask(i+1,j,k+1) * data(i+1,j,k+1,n)
                              + mask(i,j+1,k-1) * data(i,j+1,k-1,n)
                              + mask(i,j+1,k+1) * data(i,j+1,k+1,n) )
-                           / ( 1.0 + mask(i+1,j,k-1) + mask(i+1,j,k+1) + mask(i,j+1,k-1) + mask(i,j+1,k+1) );
+                           / ( 1 + mask(i+1,j,k-1) + mask(i+1,j,k+1) + mask(i,j+1,k-1) + mask(i,j+1,k+1) );
          }
       // xlo, yhi, z-valid
       } else if ( ( i == lo.x-1) && ( j == hi.y+1 ) && 
@@ -854,7 +854,7 @@ amrex_first_order_extrap_gpu(int i, int j, int k, int n,
                              + mask(i+1,j,k+1) * data(i+1,j,k+1,n)
                              + mask(i,j-1,k-1) * data(i,j-1,k-1,n)
                              + mask(i,j-1,k+1) * data(i,j-1,k+1,n) )
-                           / ( 1.0 + mask(i+1,j,k-1) + mask(i+1,j,k+1) + mask(i,j-1,k-1) + mask(i,j-1,k+1) );
+                           / ( 1 + mask(i+1,j,k-1) + mask(i+1,j,k+1) + mask(i,j-1,k-1) + mask(i,j-1,k+1) );
          }
       // xhi, ylo, z-valid
       } else if ( ( i == hi.x+1) && ( j == lo.y-1 ) && 
@@ -874,7 +874,7 @@ amrex_first_order_extrap_gpu(int i, int j, int k, int n,
                              + mask(i-1,j,k+1) * data(i-1,j,k+1,n)
                              + mask(i,j+1,k-1) * data(i,j+1,k-1,n)
                              + mask(i,j+1,k+1) * data(i,j+1,k+1,n) )
-                           / ( 1.0 + mask(i-1,j,k-1) + mask(i-1,j,k+1) + mask(i,j+1,k-1) + mask(i,j+1,k+1) );
+                           / ( 1 + mask(i-1,j,k-1) + mask(i-1,j,k+1) + mask(i,j+1,k-1) + mask(i,j+1,k+1) );
          }
       // xhi, yhi, z-valid
       } else if ( ( i == hi.x+1) && ( j == hi.y+1 ) && 
@@ -894,7 +894,7 @@ amrex_first_order_extrap_gpu(int i, int j, int k, int n,
                              + mask(i-1,j,k+1) * data(i-1,j,k+1,n)
                              + mask(i,j-1,k-1) * data(i,j-1,k-1,n)
                              + mask(i,j-1,k+1) * data(i,j-1,k+1,n) )
-                           / ( 1.0 + mask(i-1,j,k-1) + mask(i-1,j,k+1) + mask(i,j-1,k-1) + mask(i,j-1,k+1) );
+                           / ( 1 + mask(i-1,j,k-1) + mask(i-1,j,k+1) + mask(i,j-1,k-1) + mask(i,j-1,k+1) );
          }
       // xlo, y-valid, zlo
       } else if ( ( i == lo.x-1) && ( j >= lo.y ) && 
@@ -914,7 +914,7 @@ amrex_first_order_extrap_gpu(int i, int j, int k, int n,
                              +                   data(i+1,j,k+1,n)
                              + mask(i,j-1,k+1) * data(i,j-1,k+1,n)
                              + mask(i,j+1,k+1) * data(i,j+1,k+1,n) )
-                           / ( mask(i+1,j-1,k) + mask(i+1,j+1,k) + 1.0 + mask(i,j-1,k+1) + mask(i,j+1,k+1) );
+                           / ( mask(i+1,j-1,k) + mask(i+1,j+1,k) + 1 + mask(i,j-1,k+1) + mask(i,j+1,k+1) );
          }
       // xlo, y-valid, zhi
       } else if ( ( i == lo.x-1) && ( j >= lo.y ) && 
@@ -934,7 +934,7 @@ amrex_first_order_extrap_gpu(int i, int j, int k, int n,
                              +                   data(i+1,j,k-1,n)
                              + mask(i,j-1,k-1) * data(i,j-1,k-1,n)
                              + mask(i,j+1,k-1) * data(i,j+1,k-1,n) )
-                           / ( mask(i+1,j-1,k) + mask(i+1,j+1,k) + 1.0 + mask(i,j-1,k-1) + mask(i,j+1,k-1) );
+                           / ( mask(i+1,j-1,k) + mask(i+1,j+1,k) + 1 + mask(i,j-1,k-1) + mask(i,j+1,k-1) );
          }
       // xhi, y-valid, zlo
       } else if ( ( i == hi.x+1) && ( j >= lo.y ) && 
@@ -954,7 +954,7 @@ amrex_first_order_extrap_gpu(int i, int j, int k, int n,
                              +                   data(i-1,j,k+1,n)
                              + mask(i,j-1,k+1) * data(i,j-1,k+1,n)
                              + mask(i,j+1,k+1) * data(i,j+1,k+1,n) )
-                           / ( mask(i-1,j-1,k) + mask(i-1,j+1,k) + 1.0 + mask(i,j-1,k+1) + mask(i,j+1,k+1) );
+                           / ( mask(i-1,j-1,k) + mask(i-1,j+1,k) + 1 + mask(i,j-1,k+1) + mask(i,j+1,k+1) );
          }
       // xhi, y-valid, zhi
       } else if ( ( i == hi.x+1) && ( j >= lo.y ) && 
@@ -974,7 +974,7 @@ amrex_first_order_extrap_gpu(int i, int j, int k, int n,
                              +                   data(i-1,j,k-1,n)
                              + mask(i,j-1,k-1) * data(i,j-1,k-1,n)
                              + mask(i,j+1,k-1) * data(i,j+1,k-1,n) )
-                           / ( mask(i-1,j-1,k) + mask(i-1,j+1,k) + 1.0 + mask(i,j-1,k-1) + mask(i,j+1,k-1) );
+                           / ( mask(i-1,j-1,k) + mask(i-1,j+1,k) + 1 + mask(i,j-1,k-1) + mask(i,j+1,k-1) );
          }
       // x-valid, ylo, zlo
       } else if ( ( i >= lo.x) && ( i <= hi.x ) && 
@@ -994,7 +994,7 @@ amrex_first_order_extrap_gpu(int i, int j, int k, int n,
                              + mask(i-1,j,k+1) * data(i-1,j,k+1,n)
                              + mask(i+1,j,k+1) * data(i+1,j,k+1,n)
                              +                   data(i,j+1,k+1,n) )
-                           / ( mask(i-1,j+1,k) + mask(i+1,j+1,k) + mask(i-1,j,k+1) + mask(i+1,j,k+1) + 1.0 );
+                           / ( mask(i-1,j+1,k) + mask(i+1,j+1,k) + mask(i-1,j,k+1) + mask(i+1,j,k+1) + 1 );
          }
       // x-valid, ylo, zhi
       } else if ( ( i >= lo.x) && ( i <= hi.x ) && 
@@ -1014,7 +1014,7 @@ amrex_first_order_extrap_gpu(int i, int j, int k, int n,
                              + mask(i-1,j,k-1) * data(i-1,j,k-1,n)
                              + mask(i+1,j,k-1) * data(i+1,j,k-1,n)
                              +                   data(i,j+1,k-1,n) )
-                           / ( mask(i-1,j+1,k) + mask(i+1,j+1,k) + mask(i-1,j,k-1) + mask(i+1,j,k-1) + 1.0 );
+                           / ( mask(i-1,j+1,k) + mask(i+1,j+1,k) + mask(i-1,j,k-1) + mask(i+1,j,k-1) + 1 );
          }
       // x-valid, yhi, zlo
       } else if ( ( i >= lo.x) && ( i <= hi.x ) && 
@@ -1034,7 +1034,7 @@ amrex_first_order_extrap_gpu(int i, int j, int k, int n,
                              + mask(i-1,j,k+1) * data(i-1,j,k+1,n)
                              + mask(i+1,j,k+1) * data(i+1,j,k+1,n)
                              +                   data(i,j-1,k+1,n) )
-                           / ( mask(i-1,j-1,k) + mask(i+1,j-1,k) + mask(i-1,j,k+1) + mask(i+1,j,k+1) + 1.0 );
+                           / ( mask(i-1,j-1,k) + mask(i+1,j-1,k) + mask(i-1,j,k+1) + mask(i+1,j,k+1) + 1 );
          }
       // x-valid, yhi, zhi
       } else if ( ( i >= lo.x) && ( i <= hi.x ) && 
@@ -1054,7 +1054,7 @@ amrex_first_order_extrap_gpu(int i, int j, int k, int n,
                              + mask(i-1,j,k-1) * data(i-1,j,k-1,n)
                              + mask(i+1,j,k-1) * data(i+1,j,k-1,n)
                              +                   data(i,j-1,k-1,n) )
-                           / ( mask(i-1,j-1,k) + mask(i+1,j-1,k) + mask(i-1,j,k-1) + mask(i+1,j,k-1) + 1.0 );
+                           / ( mask(i-1,j-1,k) + mask(i+1,j-1,k) + mask(i-1,j,k-1) + mask(i+1,j,k-1) + 1 );
          }
       // Faces
       // xlo, y-valid, z-valid
@@ -1066,7 +1066,7 @@ amrex_first_order_extrap_gpu(int i, int j, int k, int n,
                           + mask(i,j+1,k) * data(i,j+1,k,n)
                           + mask(i,j,k-1) * data(i,j,k-1,n)
                           + mask(i,j,k+1) * data(i,j,k+1,n) )
-                        / ( 1.0 + mask(i,j-1,k) + mask(i,j+1,k) + mask(i,j,k-1) + mask(i,j,k+1) );
+                        / ( 1 + mask(i,j-1,k) + mask(i,j+1,k) + mask(i,j,k-1) + mask(i,j,k+1) );
       // xhi, y-valid, z-valid
       } else if ( ( i == hi.x+1) &&
                   ( j >= lo.y )  && ( j <= hi.y ) &&
@@ -1076,7 +1076,7 @@ amrex_first_order_extrap_gpu(int i, int j, int k, int n,
                           + mask(i,j+1,k) * data(i,j+1,k,n)
                           + mask(i,j,k-1) * data(i,j,k-1,n)
                           + mask(i,j,k+1) * data(i,j,k+1,n) )
-                        / ( 1.0 + mask(i,j-1,k) + mask(i,j+1,k) + mask(i,j,k-1) + mask(i,j,k+1) );
+                        / ( 1 + mask(i,j-1,k) + mask(i,j+1,k) + mask(i,j,k-1) + mask(i,j,k+1) );
       // x-valid, ylo, z-valid
       } else if ( ( i >= lo.x )  && ( i <= hi.x ) &&
                   ( j == lo.y-1) &&
@@ -1086,7 +1086,7 @@ amrex_first_order_extrap_gpu(int i, int j, int k, int n,
                           +                 data(i,j+1,k,n)
                           + mask(i,j,k-1) * data(i,j,k-1,n)
                           + mask(i,j,k+1) * data(i,j,k+1,n) )
-                        / ( mask(i-1,j,k) + mask(i+1,j,k) + 1.0 + mask(i,j,k-1) + mask(i,j,k+1) );
+                        / ( mask(i-1,j,k) + mask(i+1,j,k) + 1 + mask(i,j,k-1) + mask(i,j,k+1) );
       // x-valid, yhi, z-valid
       } else if ( ( i >= lo.x )  && ( i <= hi.x ) &&
                   ( j == hi.y+1) &&
@@ -1096,7 +1096,7 @@ amrex_first_order_extrap_gpu(int i, int j, int k, int n,
                           +                 data(i,j-1,k,n)
                           + mask(i,j,k-1) * data(i,j,k-1,n)
                           + mask(i,j,k+1) * data(i,j,k+1,n) )
-                        / ( mask(i-1,j,k) + mask(i+1,j,k) + 1.0 + mask(i,j,k-1) + mask(i,j,k+1) );
+                        / ( mask(i-1,j,k) + mask(i+1,j,k) + 1 + mask(i,j,k-1) + mask(i,j,k+1) );
       // x-valid, y-valid, zlo
       } else if ( ( i >= lo.x )  && ( i <= hi.x ) &&
                   ( j >= lo.y )  && ( j <= hi.y ) &&
@@ -1106,7 +1106,7 @@ amrex_first_order_extrap_gpu(int i, int j, int k, int n,
                           + mask(i,j-1,k) * data(i,j-1,k,n)
                           + mask(i,j+1,k) * data(i,j+1,k,n)
                           +                 data(i,j,k+1,n) )
-                        / ( mask(i-1,j,k) + mask(i+1,j,k) + mask(i,j-1,k) + mask(i,j+1,k) + 1.0 );
+                        / ( mask(i-1,j,k) + mask(i+1,j,k) + mask(i,j-1,k) + mask(i,j+1,k) + 1 );
       // x-valid, y-valid, zhi
       } else if ( ( i >= lo.x )  && ( i <= hi.x ) &&
                   ( j >= lo.y )  && ( j <= hi.y ) &&
@@ -1116,7 +1116,7 @@ amrex_first_order_extrap_gpu(int i, int j, int k, int n,
                           + mask(i,j-1,k) * data(i,j-1,k,n)
                           + mask(i,j+1,k) * data(i,j+1,k,n)
                           +                 data(i,j,k-1,n) )
-                        / ( mask(i-1,j,k) + mask(i+1,j,k) + mask(i,j-1,k) + mask(i,j+1,k) + 1.0 );
+                        / ( mask(i-1,j,k) + mask(i+1,j,k) + mask(i,j-1,k) + mask(i,j+1,k) + 1 );
       }
    }
 }

--- a/Src/AmrCore/AMReX_AmrCore.cpp
+++ b/Src/AmrCore/AMReX_AmrCore.cpp
@@ -127,7 +127,7 @@ AmrCore::printGridSummary (std::ostream& os, int min_lev, int max_lev) const noe
         int                       numgrid = bs.size();
         Long                      ncells  = bs.numPts();
         double                    ntot    = Geom(lev).Domain().d_numPts();
-        Real                      frac    = Real(100.0)*(Real(ncells) / ntot);
+        Real                      frac    = Real(100.0*double(ncells) / ntot);
 
         os << "  Level "
            << lev

--- a/Src/AmrCore/AMReX_Cluster.H
+++ b/Src/AmrCore/AMReX_Cluster.H
@@ -116,7 +116,7 @@ public:
     /**
     * \brief Compute ratio of tagged to total number of points in cluster.
     */
-    Real eff () const noexcept { BL_ASSERT(ok()); return numTag()/m_bx.d_numPts(); }
+    Real eff () const noexcept { BL_ASSERT(ok()); return Real(numTag()/m_bx.d_numPts()); }
 
 private:
 

--- a/Src/AmrCore/AMReX_ErrorList.cpp
+++ b/Src/AmrCore/AMReX_ErrorList.cpp
@@ -334,7 +334,7 @@ operator << (std::ostream&    os,
                    Real                      threshold,
                    char                      tagval) noexcept
   {
-    const Real fac = threshold * std::pow(2,level);
+    const Real fac = threshold * Real(std::pow(2,level));
     amrex::ParallelFor(bx,
     [=] AMREX_GPU_HOST_DEVICE (int i, int j, int k)
     {

--- a/Src/Base/AMReX_Algorithm.H
+++ b/Src/Base/AMReX_Algorithm.H
@@ -2,12 +2,15 @@
 #define AMREX_ALGORITHM_H_
 #include <AMReX_Config.H>
 
-#include <algorithm>
-
 #include <AMReX_GpuQualifiers.H>
 #include <AMReX_Extension.H>
 #include <AMReX_Dim3.H>
 #include <AMReX_BLassert.H>
+#include <AMReX_Math.H>
+
+#include <algorithm>
+#include <limits>
+#include <type_traits>
 
 namespace amrex
 {
@@ -100,6 +103,19 @@ namespace amrex
             "Error - maximum number of iterations reached in bisect.");
 
         return mi;
+    }
+
+    // Reference: https://en.cppreference.com/w/cpp/types/numeric_limits/epsilon
+    template <typename T>
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    typename std::enable_if<std::is_floating_point<T>::value,bool>::type
+    almostEqual (T x, T y, int ulp = 2)
+    {
+        // the machine epsilon has to be scaled to the magnitude of the values used
+        // and multiplied by the desired precision in ULPs (units in the last place)
+        return amrex::Math::abs(x-y) <= std::numeric_limits<T>::epsilon() * amrex::Math::abs(x+y) * ulp
+        // unless the result is subnormal
+        || amrex::Math::abs(x-y) < std::numeric_limits<T>::min();
     }
 }
 

--- a/Src/Base/AMReX_BaseFab.H
+++ b/Src/Base/AMReX_BaseFab.H
@@ -2,6 +2,7 @@
 #define AMREX_BASEFAB_H_
 #include <AMReX_Config.H>
 
+#include <AMReX_Algorithm.H>
 #include <AMReX_Extension.H>
 #include <AMReX_BLassert.H>
 #include <AMReX_Array.H>
@@ -3505,9 +3506,15 @@ BaseFab<T>::linInterp (const BaseFab<T>& f1, const Box& b1, int comp1,
                        Real t1, Real t2, Real t,
                        const Box& b, int comp, int numcomp) noexcept
 {
-    Real alpha = (t2-t)/(t2-t1);
-    Real beta = (t-t1)/(t2-t1);
-    return linComb<run_on>(f1,b1,comp1,f2,b2,comp2,alpha,beta,b,comp,numcomp);
+    if (amrex::almostEqual(t1,t2) || amrex::almostEqual(t1,t)) {
+        return copy<run_on>(f1,b1,comp1,b,comp,numcomp);
+    } else if (amrex::almostEqual(t2,t)) {
+        return copy<run_on>(f2,b2,comp2,b,comp,numcomp);
+    } else {
+        Real alpha = (t2-t)/(t2-t1);
+        Real beta = (t-t1)/(t2-t1);
+        return linComb<run_on>(f1,b1,comp1,f2,b2,comp2,alpha,beta,b,comp,numcomp);
+    }
 }
 
 template <class T>
@@ -3518,19 +3525,15 @@ BaseFab<T>::linInterp (const BaseFab<T>& f1, int comp1,
                        Real t1, Real t2, Real t,
                        const Box& b, int comp, int numcomp) noexcept
 {
-    Real tol = 1.0e-16;
-    if(amrex::Math::abs(t2-t1) > tol)
-    {
+    if (amrex::almostEqual(t1,t2) || amrex::almostEqual(t1,t)) {
+        return copy<run_on>(f1,b,comp1,b,comp,numcomp);
+    } else if (amrex::almostEqual(t2,t)) {
+        return copy<run_on>(f2,b,comp2,b,comp,numcomp);
+    } else {
         Real alpha = (t2-t)/(t2-t1);
         Real beta = (t-t1)/(t2-t1);
-
         return linComb<run_on>(f1,b,comp1,f2,b,comp2,alpha,beta,b,comp,numcomp);
     }
-    else
-    {
-        copy<run_on>(f1,b,comp1,b,comp,numcomp);
-    }
-    return *this;
 }
 
 //

--- a/Src/Base/AMReX_BoxList.cpp
+++ b/Src/Base/AMReX_BoxList.cpp
@@ -346,11 +346,11 @@ BoxList::complementIn (const Box& b, const BoxArray& ba)
         BoxList bl_mesh(mbox & b);
 
 #if (AMREX_SPACEDIM == 1)
-        Real s_avgbox = npts_avgbox;
+        Real s_avgbox = static_cast<Real>(npts_avgbox);
 #elif (AMREX_SPACEDIM == 2)
-        Real s_avgbox = std::sqrt(npts_avgbox);
+        Real s_avgbox = static_cast<Real>(std::sqrt(npts_avgbox));
 #elif (AMREX_SPACEDIM == 3)
-        Real s_avgbox = std::cbrt(npts_avgbox);
+        Real s_avgbox = static_cast<Real>(std::cbrt(npts_avgbox));
 #endif
 
         const int block_size = 4 * std::max(1,static_cast<int>(std::ceil(s_avgbox/4.))*4);
@@ -435,11 +435,11 @@ BoxList::parallelComplementIn (const Box& b, BoxArray const& ba)
         BoxList bl_mesh(mbox & b);
 
 #if (AMREX_SPACEDIM == 1)
-        Real s_avgbox = npts_avgbox;
+        Real s_avgbox = static_cast<Real>(npts_avgbox);
 #elif (AMREX_SPACEDIM == 2)
-        Real s_avgbox = std::sqrt(npts_avgbox);
+        Real s_avgbox = static_cast<Real>(std::sqrt(npts_avgbox));
 #elif (AMREX_SPACEDIM == 3)
-        Real s_avgbox = std::cbrt(npts_avgbox);
+        Real s_avgbox = static_cast<Real>(std::cbrt(npts_avgbox));
 #endif
 
         const int block_size = 4 * std::max(1,static_cast<int>(std::ceil(s_avgbox/4.))*4);

--- a/Src/Base/AMReX_COORDSYS_2D_C.H
+++ b/Src/Base/AMReX_COORDSYS_2D_C.H
@@ -31,7 +31,7 @@ amrex_setvol (Box const& bx, Array4<Real> const& vol,
     }
     else if (coord == 1) // r-z
     {
-        const Real pi = 3.1415926535897932;
+        const Real pi = Real(3.1415926535897932);
         for     (int j = lo.y; j <= hi.y; ++j) {
             AMREX_PRAGMA_SIMD
             for (int i = lo.x; i <= hi.x; ++i) {
@@ -44,11 +44,11 @@ amrex_setvol (Box const& bx, Array4<Real> const& vol,
     }
     else // r-theta
     {
-        const Real pi = 3.1415926535897932;
+        const Real pi = Real(3.1415926535897932);
         for     (int j = lo.y; j <= hi.y; ++j) {
             Real ti = offset[1] + dx[1]*(j);
             Real to = ti + dx[1];
-            Real tmp = (2.*pi)*(std::cos(ti)-std::cos(to))/3.0;
+            Real tmp = (Real(2.)*pi)*(std::cos(ti)-std::cos(to))/Real(3.0);
             AMREX_PRAGMA_SIMD
             for (int i = lo.x; i <= hi.x; ++i) {
                 Real ri = offset[0] + dx[0]*(i);
@@ -82,14 +82,14 @@ amrex_setarea (Box const& bx, Array4<Real> const& area,
     }
     else if (coord == 1)
     {
-        const Real pi = 3.1415926535897932;
+        const Real pi = Real(3.1415926535897932);
         if (dir == 0)
         {
             for     (int j = lo.y; j <= hi.y; ++j) {
                 AMREX_PRAGMA_SIMD
                 for (int i = lo.x; i <= hi.x; ++i) {
                     Real ri = offset[0] + dx[0]*(i);
-                    Real a = amrex::Math::abs((2.*pi)*ri*dx[1]);
+                    Real a = amrex::Math::abs((Real(2.)*pi)*ri*dx[1]);
                     area(i,j,0) = a;
                 }
             }
@@ -99,8 +99,8 @@ amrex_setarea (Box const& bx, Array4<Real> const& area,
             for     (int j = lo.y; j <= hi.y; ++j) {
                 AMREX_PRAGMA_SIMD
                 for (int i = lo.x; i <= hi.x; ++i) {
-                    Real rc = offset[0] + dx[0]*(i+0.5);
-                    Real a = amrex::Math::abs(dx[0]*(2.*pi)*rc);
+                    Real rc = offset[0] + dx[0]*(i+Real(0.5));
+                    Real a = amrex::Math::abs(dx[0]*(Real(2.)*pi)*rc);
                     area(i,j,0) = a;
                 }
             }
@@ -108,13 +108,13 @@ amrex_setarea (Box const& bx, Array4<Real> const& area,
     }
     else
     {
-        const Real pi = 3.1415926535897932;
+        const Real pi = Real(3.1415926535897932);
         if (dir == 0)
         {
             for     (int j = lo.y; j <= hi.y; ++j) {
                 Real ti = offset[1] + dx[1]*(j);
                 Real to = ti + dx[1];
-                Real tmp = (2.*pi)*(std::cos(ti)-std::cos(to));
+                Real tmp = (Real(2.)*pi)*(std::cos(ti)-std::cos(to));
                 AMREX_PRAGMA_SIMD 
                 for (int i = lo.x; i <= hi.x; ++i) {
                     Real ri = offset[0] + dx[0]*(i);
@@ -155,7 +155,7 @@ amrex_setdloga (Box const& bx, Array4<Real> const& dloga,
         for     (int j = lo.y; j <= hi.y; ++j) {
             AMREX_PRAGMA_SIMD
             for (int i = lo.x; i <= hi.x; ++i) {
-                dloga(i,j,0) = 0.0;
+                dloga(i,j,0) = Real(0.0);
             }
         }
     }
@@ -166,8 +166,8 @@ amrex_setdloga (Box const& bx, Array4<Real> const& dloga,
             for     (int j = lo.y; j <= hi.y; ++j) {
                 AMREX_PRAGMA_SIMD
                 for (int i = lo.x; i <= hi.x; ++i) {
-                    Real rc = offset[0] + dx[0]*(i+0.5);
-                    dloga(i,j,0) = 1.0/rc;
+                    Real rc = offset[0] + dx[0]*(i+Real(0.5));
+                    dloga(i,j,0) = Real(1.0)/rc;
                 }
             }
         }
@@ -176,7 +176,7 @@ amrex_setdloga (Box const& bx, Array4<Real> const& dloga,
             for     (int j = lo.y; j <= hi.y; ++j) {
                 AMREX_PRAGMA_SIMD
                 for (int i = lo.x; i <= hi.x; ++i) {
-                    dloga(i,j,0) = 0.0;
+                    dloga(i,j,0) = Real(0.0);
                 }
             }
         }
@@ -188,8 +188,8 @@ amrex_setdloga (Box const& bx, Array4<Real> const& dloga,
             for     (int j = lo.y; j <= hi.y; ++j) {
                 AMREX_PRAGMA_SIMD
                 for (int i = lo.x; i <= hi.x; ++i) {
-                    Real rc = offset[0] + dx[0]*(i+0.5);
-                    dloga(i,j,0) = 2.0/rc;
+                    Real rc = offset[0] + dx[0]*(i+Real(0.5));
+                    dloga(i,j,0) = Real(2.0)/rc;
                 }
             }
         }
@@ -198,10 +198,10 @@ amrex_setdloga (Box const& bx, Array4<Real> const& dloga,
             for     (int j = lo.y; j <= hi.y; ++j) {
                 Real ti = offset[1] + dx[1]*(j);
                 Real to = ti + dx[1];
-                Real tmp = 1.0/std::tan(0.5*(ti+to));
+                Real tmp = Real(1.0)/std::tan(Real(0.5)*(ti+to));
                 AMREX_PRAGMA_SIMD
                 for (int i = lo.x; i <= hi.x; ++i) {
-                    Real rc = offset[0] + dx[0]*(i+0.5);
+                    Real rc = offset[0] + dx[0]*(i+Real(0.5) );
                     dloga(i,j,0) = tmp/rc;
                 }
             }

--- a/Src/Base/AMReX_CoordSys.cpp
+++ b/Src/Base/AMReX_CoordSys.cpp
@@ -53,7 +53,7 @@ CoordSys::CellCenter (const IntVect& point, Real* loc) const noexcept
     AMREX_ASSERT(loc != 0);
     for (int k = 0; k < AMREX_SPACEDIM; k++)
     {
-        loc[k] = offset[k] + dx[k]*(0.5+ (Real)point[k]);
+        loc[k] = offset[k] + dx[k]*(0.5_rt+ (Real)point[k]);
     }
 }
 
@@ -74,7 +74,7 @@ CoordSys::LoFace (const IntVect& point,
     AMREX_ASSERT(loc != 0);
     for (int k = 0; k < AMREX_SPACEDIM; k++)
     {
-        Real off = (k == dir) ? 0.0 : 0.5;
+        Real off = (k == dir) ? 0.0_rt : 0.5_rt;
         loc[k] = offset[k] + dx[k]*(off + (Real)point[k]);
     }
 }
@@ -97,7 +97,7 @@ CoordSys::HiFace (const IntVect& point,
     AMREX_ASSERT(loc != 0);
     for (int k = 0; k < AMREX_SPACEDIM; k++)
     {
-        Real off = (k == dir) ? 1.0 : 0.5;
+        Real off = (k == dir) ? 1.0_rt : 0.5_rt;
         loc[k] = offset[k] + dx[k]*(off + (Real)point[k]);
     }
 }
@@ -250,7 +250,7 @@ CoordSys::SetDLogA (FArrayBox& a_dlogafab,
     AMREX_ASSERT(IsCartesian());
     AMREX_HOST_DEVICE_PARALLEL_FOR_3D ( region, i, j, k,
     {
-        dloga(i,j,k) = 0.;
+        dloga(i,j,k) = 0._rt;
     });
 #else
     GpuArray<Real,AMREX_SPACEDIM> a_offset{AMREX_D_DECL(offset[0],offset[1],offset[2])};
@@ -330,7 +330,7 @@ CoordSys::GetCellLoc (Vector<Real>& loc,
     const int* lo = region.loVect();
     const int* hi = region.hiVect();
     int len       = hi[dir] - lo[dir] + 1;
-    Real off = offset[dir] + dx[dir]*(0.5 + (Real)lo[dir]);
+    Real off = offset[dir] + dx[dir]*(0.5_rt + (Real)lo[dir]);
     loc.resize(len);
     AMREX_PRAGMA_SIMD
     for (int i = 0; i < len; i++)
@@ -360,7 +360,7 @@ CoordSys::GetEdgeVolCoord (Vector<Real>& vc,
         for (int i = 0; i < len; i++)
         {
             Real r = vc[i];
-            vc[i] = 0.5*r*r;
+            vc[i] = 0.5_rt*r*r;
         }
     }
 #elif (AMREX_SPACEDIM == 1)
@@ -370,7 +370,7 @@ CoordSys::GetEdgeVolCoord (Vector<Real>& vc,
         AMREX_PRAGMA_SIMD
         for (int i = 0; i < len; i++) {
             Real r = vc[i];
-            vc[i] = FOURPI/3.*r*r*r;
+            vc[i] = static_cast<Real>(FOURPI/3.)*r*r*r;
         }
     }
 #endif    
@@ -397,7 +397,7 @@ CoordSys::GetCellVolCoord (Vector<Real>& vc,
         for (int i = 0; i < len; i++)
         {
             Real r = vc[i];
-            vc[i] = 0.5*r*r;
+            vc[i] = 0.5_rt*r*r;
         }
     }
 #elif (AMREX_SPACEDIM == 1)
@@ -406,7 +406,7 @@ CoordSys::GetCellVolCoord (Vector<Real>& vc,
         AMREX_PRAGMA_SIMD
         for (int i = 0; i < len; i++) {
             Real r = vc[i];
-            vc[i] = FOURPI/3.*r*r*r;
+            vc[i] = static_cast<Real>(FOURPI/3.)*r*r*r;
         }
     }
 #endif    
@@ -455,7 +455,7 @@ operator>> (std::istream& is,
     for (int k = 0; k < AMREX_SPACEDIM; k++)
     {
         c.dx[k] = cellsize[k];
- 	c.inv_dx[k] = 1.0/cellsize[k];
+        c.inv_dx[k] = 1.0_rt/cellsize[k];
     }
     return is;
 }
@@ -482,7 +482,7 @@ CoordSys::Volume (const Real xlo[AMREX_SPACEDIM],
                             *(xhi[2]-xlo[2]));
 #if (AMREX_SPACEDIM==2)
     case RZ:
-        return (0.5*TWOPI)*(xhi[1]-xlo[1])*(xhi[0]*xhi[0]-xlo[0]*xlo[0]);
+        return static_cast<Real>(0.5*TWOPI)*(xhi[1]-xlo[1])*(xhi[0]*xhi[0]-xlo[0]*xlo[0]);
 #endif
     default:
         AMREX_ASSERT(0);
@@ -504,15 +504,15 @@ CoordSys::AreaLo (const IntVect& point, int dir) const noexcept
         case 0: return dx[1];
         case 1: return dx[0];
         }
-        return 0.; // to silent compiler warning
+        return 0._rt; // to silent compiler warning
     case RZ:
         LoNode(point,xlo);
         switch (dir)
         {
-        case 0: return TWOPI*dx[1]*xlo[0];
-        case 1: return ((xlo[0]+dx[0])*(xlo[0]+dx[0])-xlo[0]*xlo[0])*(0.5*TWOPI);
+        case 0: return Real(TWOPI)*dx[1]*xlo[0];
+        case 1: return ((xlo[0]+dx[0])*(xlo[0]+dx[0])-xlo[0]*xlo[0])*static_cast<Real>(0.5*TWOPI);
         }
-        return 0.; // to silent compiler warning
+        return 0._rt; // to silent compiler warning
     default:
         AMREX_ASSERT(0);
     }
@@ -542,15 +542,15 @@ CoordSys::AreaHi (const IntVect& point, int dir) const noexcept
         case 0: return dx[1];
         case 1: return dx[0];
         }
-        return 0.; // to silent compiler warning
+        return 0._rt; // to silent compiler warning
     case RZ:
         HiNode(point,xhi);
         switch (dir)
         {
-        case 0: return TWOPI*dx[1]*xhi[0];
-        case 1: return (xhi[0]*xhi[0]-(xhi[0]-dx[0])*(xhi[0]-dx[0]))*(TWOPI*0.5);
+        case 0: return Real(TWOPI)*dx[1]*xhi[0];
+        case 1: return (xhi[0]*xhi[0]-(xhi[0]-dx[0])*(xhi[0]-dx[0]))*static_cast<Real>(TWOPI*0.5);
         }
-        return 0.; // to silent compiler warning
+        return 0._rt; // to silent compiler warning
     default:
         AMREX_ASSERT(0);
     }
@@ -563,7 +563,7 @@ CoordSys::AreaHi (const IntVect& point, int dir) const noexcept
     case 2: return dx[1]*dx[0];
     }
 #endif
-    return 0;
+    return 0._rt;
 }
 
 }

--- a/Src/Base/AMReX_DistributionMapping.cpp
+++ b/Src/Base/AMReX_DistributionMapping.cpp
@@ -111,7 +111,7 @@ DistributionMapping::Initialize ()
     //
     verbose          = 0;
     sfc_threshold    = 0;
-    max_efficiency   = 0.9;
+    max_efficiency   = 0.9_rt;
     node_size        = 0;
     flag_verbose_mapper = 0;
 
@@ -1445,7 +1445,7 @@ DistributionMapping::makeKnapSack (const Vector<Real>& rcost, int nmax)
     Vector<Long> cost(rcost.size());
 
     Real wmax = *std::max_element(rcost.begin(), rcost.end());
-    Real scale = (wmax == 0) ? 1.e9 : 1.e9/wmax;
+    Real scale = (wmax == 0) ? 1.e9_rt : 1.e9_rt/wmax;
 
     for (int i = 0; i < rcost.size(); ++i) {
         cost[i] = Long(rcost[i]*scale) + 1L;
@@ -1469,7 +1469,7 @@ DistributionMapping::makeKnapSack (const Vector<Real>& rcost, Real& eff, int nma
     Vector<Long> cost(rcost.size());
 
     Real wmax = *std::max_element(rcost.begin(), rcost.end());
-    Real scale = (wmax == 0) ? 1.e9 : 1.e9/wmax;
+    Real scale = (wmax == 0) ? 1.e9_rt : 1.e9_rt/wmax;
 
     for (int i = 0; i < rcost.size(); ++i) {
         cost[i] = Long(rcost[i]*scale) + 1L;
@@ -1507,7 +1507,7 @@ DistributionMapping::makeKnapSack (const LayoutData<Real>& rcost_local,
         Vector<Long> cost(rcost.size());
 
         Real wmax = *std::max_element(rcost.begin(), rcost.end());
-        Real scale = (wmax == 0) ? 1.e9 : 1.e9/wmax;
+        Real scale = (wmax == 0) ? 1.e9_rt : 1.e9_rt/wmax;
 
         for (int i = 0; i < rcost.size(); ++i) {
             cost[i] = Long(rcost[i]*scale) + 1L;
@@ -1584,7 +1584,7 @@ DistributionMapping::ComputeDistributionMappingEfficiency (const DistributionMap
     for (int i=0; i<nprocs; ++i)
     {
         const Real rwSum = std::accumulate(rankToCosts[i].begin(),
-                                           rankToCosts[i].end(), 0.0);
+                                           rankToCosts[i].end(), 0.0_rt);
         rankToCost[i] = rwSum;
         maxCost = std::max(maxCost, rwSum);
     }
@@ -1592,7 +1592,7 @@ DistributionMapping::ComputeDistributionMappingEfficiency (const DistributionMap
     // Write `efficiency` (number between 0 and 1), the mean cost per processor
     // (normalized to the max cost)
     *efficiency = (std::accumulate(rankToCost.begin(),
-                                   rankToCost.end(), 0.0) / (nprocs*maxCost));
+                                   rankToCost.end(), 0.0_rt) / (nprocs*maxCost));
 }
 
 namespace {
@@ -1612,7 +1612,7 @@ gather_weights (const MultiFab& weight)
                                                  ParallelContext::IOProcessorNumberSub());
     ParallelDescriptor::Bcast(rcost.data(), rcost.size(), ParallelContext::IOProcessorNumberSub());
     Real wmax = *std::max_element(rcost.begin(), rcost.end());
-    Real scale = (wmax == 0) ? 1.e9 : 1.e9/wmax;
+    Real scale = (wmax == 0) ? 1.e9_rt : 1.e9_rt/wmax;
     Vector<Long> lcost(rcost.size());
     for (int i = 0; i < rcost.size(); ++i) {
         lcost[i] = static_cast<Long>(rcost[i]*scale) + 1L;
@@ -1690,7 +1690,7 @@ DistributionMapping::makeSFC (const Vector<Real>& rcost, const BoxArray& ba, boo
     Vector<Long> cost(rcost.size());
     
     Real wmax = *std::max_element(rcost.begin(), rcost.end());
-    Real scale = (wmax == 0) ? 1.e9 : 1.e9/wmax;
+    Real scale = (wmax == 0) ? 1.e9_rt : 1.e9_rt/wmax;
 
     for (int i = 0; i < rcost.size(); ++i) {
         cost[i] = Long(rcost[i]*scale) + 1L;
@@ -1713,7 +1713,7 @@ DistributionMapping::makeSFC (const Vector<Real>& rcost, const BoxArray& ba, Rea
     Vector<Long> cost(rcost.size());
     
     Real wmax = *std::max_element(rcost.begin(), rcost.end());
-    Real scale = (wmax == 0) ? 1.e9 : 1.e9/wmax;
+    Real scale = (wmax == 0) ? 1.e9_rt : 1.e9_rt/wmax;
 
     for (int i = 0; i < rcost.size(); ++i) {
         cost[i] = Long(rcost[i]*scale) + 1L;
@@ -1751,7 +1751,7 @@ DistributionMapping::makeSFC (const LayoutData<Real>& rcost_local,
         Vector<Long> cost(rcost.size());
 
         Real wmax = *std::max_element(rcost.begin(), rcost.end());
-        Real scale = (wmax == 0) ? 1.e9 : 1.e9/wmax;
+        Real scale = (wmax == 0) ? 1.e9_rt : 1.e9_rt/wmax;
 
         for (int i = 0; i < rcost.size(); ++i) {
             cost[i] = Long(rcost[i]*scale) + 1L;

--- a/Src/Base/AMReX_FArrayBox.cpp
+++ b/Src/Base/AMReX_FArrayBox.cpp
@@ -748,7 +748,7 @@ FABio_8bit::write (std::ostream&    os,
 {
     BL_ASSERT(comp >= 0 && num_comp >= 1 && (comp+num_comp) <= f.nComp());
 
-    const Real eps = 1.0e-8; // FIXME - whats a better value?
+    const Real eps = 1.0e-8_rt; // FIXME - whats a better value?
     const Long siz = f.box().numPts();
 
     unsigned char *c = new unsigned char[siz];
@@ -758,7 +758,7 @@ FABio_8bit::write (std::ostream&    os,
         const Real mx   = f.max<RunOn::Host>(k+comp);
         const Real* dat = f.dataPtr(k+comp);
         Real rng = std::fabs(mx-mn);
-        rng = (rng < eps) ? 0.0 : 255.0/(mx-mn);
+        rng = (rng < eps) ? 0.0_rt : 255.0_rt/(mx-mn);
         for(Long i(0); i < siz; ++i) {
             Real v = rng*(dat[i]-mn);
             int iv = (int) v;
@@ -791,7 +791,7 @@ FABio_8bit::read (std::istream& is,
 	}
         is.read((char*)c,siz);
         Real* dat       = f.dataPtr(k);
-        const Real rng  = (mx-mn)/255.0;
+        const Real rng  = (mx-mn)/255.0_rt;
         for (Long i = 0; i < siz; i++)
         {
             int iv = (int) c[i];

--- a/Src/Base/AMReX_FilCC_C.cpp
+++ b/Src/Base/AMReX_FilCC_C.cpp
@@ -57,9 +57,9 @@ void fab_filcc (Box const& bx, Array4<Real> const& qn, int ncomp,
                        q(i,j,k) = q(ilo,j,k);
                    } else if (i == ilo - 1) {
                        if (ilo+2 <= ie) {
-                           q(i,j,k) = (1./8.) * (15.*q(ilo,j,k) - 10.*q(ilo+1,j,k) + 3.*q(ilo+2,j,k));
+                           q(i,j,k) = Real(1./8.) * (Real(15.)*q(ilo,j,k) - Real(10.)*q(ilo+1,j,k) + Real(3.)*q(ilo+2,j,k));
                        } else {
-                           q(i,j,k) = 0.5 * (3.*q(ilo,j,k) - q(ilo+1,j,k));
+                           q(i,j,k) = Real(0.5) * (Real(3.)*q(ilo,j,k) - q(ilo+1,j,k));
                        }
                    }
                }}}
@@ -67,7 +67,7 @@ void fab_filcc (Box const& bx, Array4<Real> const& qn, int ncomp,
                for (int k = lo.z; k <= hi.z; ++k) {
                for (int j = lo.y; j <= hi.y; ++j) {
                for (int i = imin; i <= imax; ++i) {
-                   q(i,j,k) = 2.*q(ilo,j,k) - q(ilo+1,j,k);
+                   q(i,j,k) = Real(2.)*q(ilo,j,k) - q(ilo+1,j,k);
                }}}
            } else if (bc.lo(0) == BCType::reflect_even) {
                for (int k = lo.z; k <= hi.z; ++k) {
@@ -104,9 +104,9 @@ void fab_filcc (Box const& bx, Array4<Real> const& qn, int ncomp,
                         q(i,j,k) = q(ihi,j,k);
                     } else if (i == ihi + 1) {
                         if (ihi-2 >= is) {
-                            q(i,j,k) = (1./8.) * (15.*q(ihi,j,k) - 10.*q(ihi-1,j,k) + 3.*q(ihi-2,j,k));
+                            q(i,j,k) = Real(1./8.) * (Real(15.)*q(ihi,j,k) - Real(10.)*q(ihi-1,j,k) + Real(3.)*q(ihi-2,j,k));
                         } else {
-                            q(i,j,k) = 0.5 * (3.*q(ihi,j,k) - q(ihi-1,j,k));
+                            q(i,j,k) = Real(0.5) * (Real(3.)*q(ihi,j,k) - q(ihi-1,j,k));
                         }
                     }
                 }}}
@@ -114,7 +114,7 @@ void fab_filcc (Box const& bx, Array4<Real> const& qn, int ncomp,
                 for (int k = lo.z; k <= hi.z; ++k) {
                 for (int j = lo.y; j <= hi.y; ++j) {
                 for (int i = imin; i <= imax; ++i) {
-                    q(i,j,k) = 2.*q(ihi,j,k) - q(ihi-1,j,k);
+                    q(i,j,k) = Real(2.)*q(ihi,j,k) - q(ihi-1,j,k);
                 }}}
             } else if (bc.hi(0) == BCType::reflect_even) {
                 for (int k = lo.z; k <= hi.z; ++k) {
@@ -152,9 +152,9 @@ void fab_filcc (Box const& bx, Array4<Real> const& qn, int ncomp,
                         q(i,j,k) = q(i,jlo,k);
                     } else if (j == jlo - 1) {
                         if (jlo+2 <= je) {
-                            q(i,j,k) = (1./8.) * (15.*q(i,jlo,k) - 10.*q(i,jlo+1,k) + 3.*q(i,jlo+2,k));
+                            q(i,j,k) = Real(1./8.) * (Real(15.)*q(i,jlo,k) - Real(10.)*q(i,jlo+1,k) + Real(3.)*q(i,jlo+2,k));
                         } else {
-                            q(i,j,k) = 0.5 * (3.*q(i,jlo,k) - q(i,jlo+1,k));
+                            q(i,j,k) = Real(0.5) * (Real(3.)*q(i,jlo,k) - q(i,jlo+1,k));
                         }
                     }
                 }}}
@@ -162,7 +162,7 @@ void fab_filcc (Box const& bx, Array4<Real> const& qn, int ncomp,
                 for (int k = lo.z; k <= hi.z; ++k) {
                 for (int j = jmin; j <= jmax; ++j) {
                 for (int i = lo.x; i <= hi.x; ++i) {
-                    q(i,j,k) = 2.*q(i,jlo,k) - q(i,jlo+1,k);
+                    q(i,j,k) = Real(2.)*q(i,jlo,k) - q(i,jlo+1,k);
                 }}}
             } else if (bc.lo(1) == BCType::reflect_even) {
                 for (int k = lo.z; k <= hi.z; ++k) {
@@ -198,9 +198,9 @@ void fab_filcc (Box const& bx, Array4<Real> const& qn, int ncomp,
                         q(i,j,k) = q(i,jhi,k);
                     } else if (j == jhi + 1) {
                         if (jhi-2 >= js) {
-                            q(i,j,k) = (1./8.) * (15.*q(i,jhi,k) - 10.*q(i,jhi-1,k) + 3.*q(i,jhi-2,k));
+                            q(i,j,k) = Real(1./8.) * (Real(15.)*q(i,jhi,k) - Real(10.)*q(i,jhi-1,k) + Real(3.)*q(i,jhi-2,k));
                         } else {
-                            q(i,j,k) = 0.5 * (3.*q(i,jhi,k) - q(i,jhi-1,k));
+                            q(i,j,k) = Real(0.5) * (Real(3.)*q(i,jhi,k) - q(i,jhi-1,k));
                         }
                     }
                 }}}
@@ -208,7 +208,7 @@ void fab_filcc (Box const& bx, Array4<Real> const& qn, int ncomp,
                 for (int k = lo.z; k <= hi.z; ++k) {
                 for (int j = jmin; j <= jmax; ++j) {
                 for (int i = lo.x; i <= hi.x; ++i) {
-                    q(i,j,k) = 2.*q(i,jhi,k) - q(i,jhi-1,k);
+                    q(i,j,k) = Real(2.)*q(i,jhi,k) - q(i,jhi-1,k);
                 }}}
             } else if (bc.hi(1) == BCType::reflect_even) {
                 for (int k = lo.z; k <= hi.z; ++k) {
@@ -247,9 +247,9 @@ void fab_filcc (Box const& bx, Array4<Real> const& qn, int ncomp,
                         q(i,j,k) = q(i,j,klo);
                     } else if (k == klo - 1) {
                         if (klo+2 <= ke) {
-                            q(i,j,k) = (1./8.) * (15.*q(i,j,klo) - 10.*q(i,j,klo+1) + 3.*q(i,j,klo+2));
+                            q(i,j,k) = Real(1./8.) * (Real(15.)*q(i,j,klo) - Real(10.)*q(i,j,klo+1) + Real(3.)*q(i,j,klo+2));
                         } else {
-                            q(i,j,k) = 0.5 * (3.*q(i,j,klo) - q(i,j,klo+1));
+                            q(i,j,k) = Real(0.5) * (Real(3.)*q(i,j,klo) - q(i,j,klo+1));
                         }
                     }
                 }}}
@@ -257,7 +257,7 @@ void fab_filcc (Box const& bx, Array4<Real> const& qn, int ncomp,
                 for (int k = kmin; k <= kmax; ++k) {
                 for (int j = lo.y; j <= hi.y; ++j) {
                 for (int i = lo.x; i <= hi.x; ++i) {
-                    q(i,j,k) = 2.*q(i,j,klo) - q(i,j,klo+1);
+                    q(i,j,k) = Real(2.)*q(i,j,klo) - q(i,j,klo+1);
                 }}}
             } else if (bc.lo(2) == BCType::reflect_even) {
                 for (int k = kmin; k <= kmax; ++k) {
@@ -293,9 +293,9 @@ void fab_filcc (Box const& bx, Array4<Real> const& qn, int ncomp,
                         q(i,j,k) = q(i,j,khi);
                     } else if (k == khi + 1) {
                         if (khi-2 >= ks) {
-                            q(i,j,k) = (1./8.) * (15.*q(i,j,khi) - 10.*q(i,j,khi-1) + 3.*q(i,j,khi-2));
+                            q(i,j,k) = Real(1./8.) * (Real(15.)*q(i,j,khi) - Real(10.)*q(i,j,khi-1) + Real(3.)*q(i,j,khi-2));
                         } else {
-                            q(i,j,k) = 0.5 * (3.*q(i,j,khi) - q(i,j,khi-1));
+                            q(i,j,k) = Real(0.5) * (Real(3.)*q(i,j,khi) - q(i,j,khi-1));
                         }
                     }
                 }}}
@@ -303,7 +303,7 @@ void fab_filcc (Box const& bx, Array4<Real> const& qn, int ncomp,
                 for (int k = kmin; k <= kmax; ++k) {
                 for (int j = lo.y; j <= hi.y; ++j) {
                 for (int i = lo.x; i <= hi.x; ++i) {
-                    q(i,j,k) = 2.*q(i,j,khi) - q(i,j,khi-1);
+                    q(i,j,k) = Real(2.)*q(i,j,khi) - q(i,j,khi-1);
                 }}}
             } else if (bc.hi(2) == BCType::reflect_even) {
                 for (int k = kmin; k <= kmax; ++k) {
@@ -338,35 +338,35 @@ void fab_filcc (Box const& bx, Array4<Real> const& qn, int ncomp,
                 if (i>=imin && i<=imax && j>=jmin && j<=jmax) {
                     for (int k = lo.z; k <= hi.z; ++k) {
                         if (jlo+2 <= je) {
-                            q(i,j,k) = 0.5 * (1./8.) * (15.*q(ilo-1,jlo,k) - 10.*q(ilo-1,jlo+1,k) + 3.*q(ilo-1,jlo+2,k));
+                            q(i,j,k) = Real(1./16.) * (Real(15.)*q(ilo-1,jlo,k) - Real(10.)*q(ilo-1,jlo+1,k) + Real(3.)*q(ilo-1,jlo+2,k));
                         } else {
-                            q(i,j,k) = 0.5 * 0.5 * (3.*q(ilo-1,jlo,k) - q(ilo-1,jlo+1,k));
+                            q(i,j,k) = Real(0.25) * (Real(3.)*q(ilo-1,jlo,k) - q(ilo-1,jlo+1,k));
                         }
 
                         if (ilo+2 <= ie) {
                             q(i,j,k) = q(ilo-1,jlo-1,k) +
-                                0.5 * (1./8.) * (15.*q(ilo,jlo-1,k) - 10.*q(ilo+1,jlo-1,k) + 3.*q(ilo+2,jlo-1,k));
+                                Real(1./16.) * (Real(15.)*q(ilo,jlo-1,k) - Real(10.)*q(ilo+1,jlo-1,k) + Real(3.)*q(ilo+2,jlo-1,k));
                         } else {
-                            q(i,j,k) = q(ilo-1,jlo-1,k) + 0.5 * 0.5 * (3.*q(ilo,jlo-1,k) - q(ilo+1,jlo-1,k));
+                            q(i,j,k) = q(ilo-1,jlo-1,k) + Real(0.25) * (Real(3.)*q(ilo,jlo-1,k) - q(ilo+1,jlo-1,k));
                         }
 
 #if AMREX_SPACEDIM == 3
 
                         if (k == klo-1 && bc.lo(2) == BCType::hoextrap) {
                             if (klo+2 <= ke) {
-                                q(i,j,k) = (1./8.) * ( (15.*q(ilo-1,jlo-1,klo) - 10.*q(ilo-1,jlo-1,klo+1) +
-                                                          3.*q(ilo-1,jlo-1,klo+2)) );
+                                q(i,j,k) = Real(1./8.) * ( (Real(15.)*q(ilo-1,jlo-1,klo) - Real(10.)*q(ilo-1,jlo-1,klo+1) +
+                                                          Real(3.)*q(ilo-1,jlo-1,klo+2)) );
                             } else {
-                                q(i,j,k) = 0.5 * (3.*q(ilo-1,jlo-1,klo) - q(ilo-1,jlo-1,klo+1));
+                                q(i,j,k) = Real(0.5) * (Real(3.)*q(ilo-1,jlo-1,klo) - q(ilo-1,jlo-1,klo+1));
                             }
                         }
 
                         if (k == khi+1 && bc.hi(2) == BCType::hoextrap) {
                             if (khi-2 >= ks) {
-                                q(i,j,k) = (1./8.) * ( (15.*q(ilo-1,jlo-1,khi) - 10.*q(ilo-1,jlo-1,khi-1) +
-                                                          3.*q(ilo-1,jlo-1,khi-2)) );
+                                q(i,j,k) = Real(1./8.) * ( (Real(15.)*q(ilo-1,jlo-1,khi) - Real(10.)*q(ilo-1,jlo-1,khi-1) +
+                                                          Real(3.)*q(ilo-1,jlo-1,khi-2)) );
                             } else {
-                                q(i,j,k) = 0.5 * (3.*q(ilo-1,jlo-1,khi) - q(ilo-1,jlo-1,khi-1));
+                                q(i,j,k) = Real(0.5) * (Real(3.)*q(ilo-1,jlo-1,khi) - q(ilo-1,jlo-1,khi-1));
                             }
                         }
 #endif
@@ -390,34 +390,34 @@ void fab_filcc (Box const& bx, Array4<Real> const& qn, int ncomp,
                 if (i>=imin && i<=imax && j>=jmin && j<=jmax) {
                     for (int k = lo.z; k <= hi.z; ++k) {
                         if (jhi-2 >= js) {
-                            q(i,j,k) = 0.5 * (1./8.) * (15.*q(ilo-1,jhi,k) - 10.*q(ilo-1,jhi-1,k) + 3.*q(ilo-1,jhi-2,k));
+                            q(i,j,k) = Real(1./16.) * (Real(15.)*q(ilo-1,jhi,k) - Real(10.)*q(ilo-1,jhi-1,k) + Real(3.)*q(ilo-1,jhi-2,k));
                         } else {
-                            q(i,j,k) = 0.5 * 0.5 * (3.*q(ilo-1,jhi,k) - q(ilo-1,jhi-1,k));
+                            q(i,j,k) = Real(0.25) * (Real(3.)*q(ilo-1,jhi,k) - q(ilo-1,jhi-1,k));
                         }
 
                         if (ilo+2 <= ie) {
                             q(i,j,k) = q(ilo-1,jhi+1,k) +
-                                0.5 * (1./8.) * (15.*q(ilo,jhi+1,k) - 10.*q(ilo+1,jhi+1,k) + 3.*q(ilo+2,jhi+1,k));
+                                Real(1./16.) * (Real(15.)*q(ilo,jhi+1,k) - Real(10.)*q(ilo+1,jhi+1,k) + Real(3.)*q(ilo+2,jhi+1,k));
                         } else {
-                            q(i,j,k) = q(ilo-1,jhi+1,k) + 0.5 * 0.5 * (3.*q(ilo,jhi+1,k) - q(ilo+1,jhi+1,k));
+                            q(i,j,k) = q(ilo-1,jhi+1,k) + Real(0.25) * (Real(3.)*q(ilo,jhi+1,k) - q(ilo+1,jhi+1,k));
                    }
 
 #if (AMREX_SPACEDIM == 3)
                         if (k == klo-1 && bc.lo(2) == BCType::hoextrap) {
                             if (klo+2 <= ke) {
-                                q(i,j,k) = (1./8.) * ( (15.*q(ilo-1,jhi+1,klo) - 10.*q(ilo-1,jhi+1,klo+1) +
-                                                          3.*q(ilo-1,jhi+1,klo+2)) );
+                                q(i,j,k) = Real(1./8.) * ( (Real(15.)*q(ilo-1,jhi+1,klo) - Real(10.)*q(ilo-1,jhi+1,klo+1) +
+                                                          Real(3.)*q(ilo-1,jhi+1,klo+2)) );
                             } else {
-                                q(i,j,k) = 0.5 * (3.*q(ilo-1,jhi+1,klo) - q(ilo-1,jhi+1,klo+1));
+                                q(i,j,k) = Real(0.5) * (Real(3.)*q(ilo-1,jhi+1,klo) - q(ilo-1,jhi+1,klo+1));
                             }
                         }
 
                         if (k == khi+1 && bc.hi(2) == BCType::hoextrap) {
                             if (khi-2 >= ks) {
-                                q(i,j,k) = (1./8.) * ( (15.*q(ilo-1,jhi+1,khi) - 10.*q(ilo-1,jhi+1,khi-1) +
-                                                          3.*q(ilo-1,jhi+1,khi-2)) );
+                                q(i,j,k) = Real(1./8.) * ( (Real(15.)*q(ilo-1,jhi+1,khi) - Real(10.)*q(ilo-1,jhi+1,khi-1) +
+                                                          Real(3.)*q(ilo-1,jhi+1,khi-2)) );
                             } else {
-                                q(i,j,k) = 0.5 * (3.*q(ilo-1,jhi+1,khi) - q(ilo-1,jhi+1,khi-1));
+                                q(i,j,k) = Real(0.5) * (Real(3.)*q(ilo-1,jhi+1,khi) - q(ilo-1,jhi+1,khi-1));
                             }
                         }
 #endif
@@ -441,32 +441,32 @@ void fab_filcc (Box const& bx, Array4<Real> const& qn, int ncomp,
                 if (i>=imin && i<=imax && j>=jmin && j<=jmax) {
                     for (int k = lo.z; k <= hi.z; ++k) {
                         if (jlo+2 <= je) {
-                            q(i,j,k) = 0.5 * (1./8.) * (15.*q(ihi+1,jlo,k) - 10.*q(ihi+1,jlo+1,k) + 3.*q(ihi+1,jlo+2,k));
+                            q(i,j,k) = Real(1./16.) * (Real(15.)*q(ihi+1,jlo,k) - Real(10.)*q(ihi+1,jlo+1,k) + Real(3.)*q(ihi+1,jlo+2,k));
                         } else {
-                            q(i,j,k) = 0.5 * 0.5 * (3.*q(ihi+1,jlo,k) - q(ihi+1,jlo+1,k));
+                            q(i,j,k) = Real(0.25) * (Real(3.)*q(ihi+1,jlo,k) - q(ihi+1,jlo+1,k));
                         }
 
                         if (ihi-2 >= is) {
                             q(i,j,k) = q(ihi+1,jlo-1,k) +
-                                0.5 * (1./8.) * (15.*q(ihi,jlo-1,k) - 10.*q(ihi-1,jlo-1,k) + 3.*q(ihi-2,jlo-1,k));
+                                Real(1./16.) * (Real(15.)*q(ihi,jlo-1,k) - Real(10.)*q(ihi-1,jlo-1,k) + Real(3.)*q(ihi-2,jlo-1,k));
                         } else {
-                            q(i,j,k) = q(ihi+1,jlo-1,k) + 0.5 * 0.5 * (3.*q(ihi,jlo-1,k) - q(ihi-1,jlo-1,k));
+                            q(i,j,k) = q(ihi+1,jlo-1,k) + Real(0.25) * (Real(3.)*q(ihi,jlo-1,k) - q(ihi-1,jlo-1,k));
                         }
 
 #if (AMREX_SPACEDIM == 3)
                         if (k == klo-1 && bc.lo(2) == BCType::hoextrap) {
                             if (klo+2 <= ke) {
-                                q(i,j,k) = (1./8.) * (15.*q(ihi+1,jlo-1,klo) - 10.*q(ihi+1,jlo-1,klo+1) + 3.*q(ihi+1,jlo-1,klo+2));
+                                q(i,j,k) = Real(1./8.) * (Real(15.)*q(ihi+1,jlo-1,klo) - Real(10.)*q(ihi+1,jlo-1,klo+1) + Real(3.)*q(ihi+1,jlo-1,klo+2));
                             } else {
-                                q(i,j,k) = 0.5 * (3.*q(ihi+1,jlo-1,klo) - q(ihi+1,jlo-1,klo+1));
+                                q(i,j,k) = Real(0.5) * (Real(3.)*q(ihi+1,jlo-1,klo) - q(ihi+1,jlo-1,klo+1));
                             }
                         }
 
                         if (k == khi+1 && bc.hi(2) == BCType::hoextrap) {
                             if (khi-2 >= ks) {
-                                q(i,j,k) = (1./8.) * (15.*q(ihi+1,jlo-1,khi) - 10.*q(ihi+1,jlo-1,khi-1) + 3.*q(ihi+1,jlo-1,khi-2));
+                                q(i,j,k) = Real(1./8.) * (Real(15.)*q(ihi+1,jlo-1,khi) - Real(10.)*q(ihi+1,jlo-1,khi-1) + Real(3.)*q(ihi+1,jlo-1,khi-2));
                             } else {
-                                q(i,j,k) = 0.5 * (3.*q(ihi+1,jlo-1,khi) - q(ihi+1,jlo-1,khi-1));
+                                q(i,j,k) = Real(0.5) * (Real(3.)*q(ihi+1,jlo-1,khi) - q(ihi+1,jlo-1,khi-1));
                             }
                         }
 #endif
@@ -490,32 +490,32 @@ void fab_filcc (Box const& bx, Array4<Real> const& qn, int ncomp,
                 if (i>=imin && i<=imax && j>=jmin && j<=jmax) {
                     for (int k = lo.z; k <= hi.z; ++k) {
                         if (jhi-2 >= js) {
-                            q(i,j,k) = 0.5 * (1./8.) * (15.*q(ihi+1,jhi,k) - 10.*q(ihi+1,jhi-1,k) + 3.*q(ihi+1,jhi-2,k));
+                            q(i,j,k) = Real(1./16.) * (Real(15.)*q(ihi+1,jhi,k) - Real(10.)*q(ihi+1,jhi-1,k) + Real(3.)*q(ihi+1,jhi-2,k));
                         } else {
-                            q(i,j,k) = 0.5 * 0.5 * (3.*q(ihi+1,jhi,k) - q(ihi+1,jhi-1,k));
+                            q(i,j,k) = Real(0.25) * (Real(3.)*q(ihi+1,jhi,k) - q(ihi+1,jhi-1,k));
                         }
 
                         if (ihi-2 >= is) {
                             q(i,j,k) = q(ihi+1,jhi+1,k) +
-                                0.5 * (1./8.) * (15.*q(ihi,jhi+1,k) - 10.*q(ihi-1,jhi+1,k) + 3.*q(ihi-2,jhi+1,k));
+                                Real(1./16.) * (Real(15.)*q(ihi,jhi+1,k) - Real(10.)*q(ihi-1,jhi+1,k) + Real(3.)*q(ihi-2,jhi+1,k));
                         } else {
-                            q(i,j,k) = q(ihi+1,jhi+1,k) + 0.5 * 0.5 * (3.*q(ihi,jhi+1,k) - q(ihi-1,jhi+1,k));
+                            q(i,j,k) = q(ihi+1,jhi+1,k) + Real(0.25) * (Real(3.)*q(ihi,jhi+1,k) - q(ihi-1,jhi+1,k));
                         }
 
 #if (AMREX_SPACEDIM == 3)
                         if (k == klo-1 && bc.lo(2) == BCType::hoextrap) {
                             if (klo+2 <= ke) {
-                                q(i,j,k) = (1./8.) * (15.*q(ihi+1,jhi+1,klo) - 10.*q(ihi+1,jhi+1,klo+1) + 3.*q(ihi+1,jhi+1,klo+2));
+                                q(i,j,k) = Real(1./8.) * (Real(15.)*q(ihi+1,jhi+1,klo) - Real(10.)*q(ihi+1,jhi+1,klo+1) + Real(3.)*q(ihi+1,jhi+1,klo+2));
                             } else {
-                                q(i,j,k) = 0.5 * (3.*q(ihi+1,jhi+1,klo) - q(ihi+1,jhi+1,klo+1));
+                                q(i,j,k) = Real(0.5) * (Real(3.)*q(ihi+1,jhi+1,klo) - q(ihi+1,jhi+1,klo+1));
                             }
                         }
 
                         if (k == khi+1 && bc.hi(2) == BCType::hoextrap) {
                             if (khi-2 >= ks) {
-                                q(i,j,k) = (1./8.) * (15.*q(ihi+1,jhi+1,khi) - 10.*q(ihi+1,jhi+1,khi-1) + 3.*q(ihi+1,jhi+1,khi-2));
+                                q(i,j,k) = Real(1./8.) * (Real(15.)*q(ihi+1,jhi+1,khi) - Real(10.)*q(ihi+1,jhi+1,khi-1) + Real(3.)*q(ihi+1,jhi+1,khi-2));
                             } else {
-                                q(i,j,k) = 0.5 * (3.*q(ihi+1,jhi+1,khi) - q(ihi+1,jhi+1,khi-1));
+                                q(i,j,k) = Real(0.5) * (Real(3.)*q(ihi+1,jhi+1,khi) - q(ihi+1,jhi+1,khi-1));
                             }
                         }
 #endif
@@ -541,16 +541,16 @@ void fab_filcc (Box const& bx, Array4<Real> const& qn, int ncomp,
                 if (i>=imin && i<=imax && k>=kmin && k<=kmax) {
                     for (int j = lo.y; j <= hi.y; ++j) {
                         if (klo+2 <= ke) {
-                            q(i,j,k) = 0.5 * (1./8.) * (15.*q(ilo-1,j,klo) - 10.*q(ilo-1,j,klo+1) + 3.*q(ilo-1,j,klo+2));
+                            q(i,j,k) = Real(1./16.) * (Real(15.)*q(ilo-1,j,klo) - Real(10.)*q(ilo-1,j,klo+1) + Real(3.)*q(ilo-1,j,klo+2));
                         } else {
-                            q(i,j,k) = 0.5 * 0.5 * (3.*q(ilo-1,j,klo) - q(ilo-1,j,klo+1));
+                            q(i,j,k) = Real(0.25) * (Real(3.)*q(ilo-1,j,klo) - q(ilo-1,j,klo+1));
                         }
 
                         if (ilo+2 <= ie) {
                             q(i,j,k) = q(ilo-1,j,klo-1) +
-                                0.5 * (1./8.) * (15.*q(ilo,j,klo-1) - 10.*q(ilo+1,j,klo-1) + 3.*q(ilo+2,j,klo-1));
+                                Real(1./16.) * (Real(15.)*q(ilo,j,klo-1) - Real(10.)*q(ilo+1,j,klo-1) + Real(3.)*q(ilo+2,j,klo-1));
                         } else {
-                            q(i,j,k) = q(ilo-1,j,klo-1) + 0.5 * 0.5 * (3.*q(ilo,j,klo-1) - q(ilo+1,j,klo-1));
+                            q(i,j,k) = q(ilo-1,j,klo-1) + Real(0.25) * (Real(3.)*q(ilo,j,klo-1) - q(ilo+1,j,klo-1));
                         }
                     }
                 }
@@ -572,16 +572,16 @@ void fab_filcc (Box const& bx, Array4<Real> const& qn, int ncomp,
                 if (i>=imin && i<=imax && k>=kmin && k<=kmax) {
                     for (int j = lo.y; j <= hi.y; ++j) {
                         if (khi-2 >= ks) {
-                            q(i,j,k) = 0.5 * (1./8.) * (15.*q(ilo-1,j,khi) - 10.*q(ilo-1,j,khi-1) + 3.*q(ilo-1,j,khi-2));
+                            q(i,j,k) = Real(1./16.) * (Real(15.)*q(ilo-1,j,khi) - Real(10.)*q(ilo-1,j,khi-1) + Real(3.)*q(ilo-1,j,khi-2));
                         } else {
-                            q(i,j,k) = 0.5 * 0.5 * (3.*q(ilo-1,j,khi) - q(ilo-1,j,khi-1));
+                            q(i,j,k) = Real(0.25) * (Real(3.)*q(ilo-1,j,khi) - q(ilo-1,j,khi-1));
                         }
 
                         if (ilo+2 <= ie) {
                             q(i,j,k) = q(ilo-1,j,khi+1) +
-                                0.5 * (1./8.) * (15.*q(ilo,j,khi+1) - 10.*q(ilo+1,j,khi+1) + 3.*q(ilo+2,j,khi+1));
+                                Real(1./16.) * (Real(15.)*q(ilo,j,khi+1) - Real(10.)*q(ilo+1,j,khi+1) + Real(3.)*q(ilo+2,j,khi+1));
                         } else {
-                            q(i,j,k) = q(ilo-1,j,khi+1) + 0.5 * 0.5 * (3.*q(ilo,j,khi+1) - q(ilo+1,j,khi+1));
+                            q(i,j,k) = q(ilo-1,j,khi+1) + Real(0.25) * (Real(3.)*q(ilo,j,khi+1) - q(ilo+1,j,khi+1));
                         }
                     }
                 }
@@ -603,16 +603,16 @@ void fab_filcc (Box const& bx, Array4<Real> const& qn, int ncomp,
                 if (i>=imin && i<=imax && k>=kmin && k<=kmax) {
                     for (int j = lo.y; j <= hi.y; ++j) {
                         if (klo+2 <= ke) {
-                            q(i,j,k) = 0.5 * (1./8.) * (15.*q(ihi+1,j,klo) - 10.*q(ihi+1,j,klo+1) + 3.*q(ihi+1,j,klo+2));
+                            q(i,j,k) = Real(1./16.) * (Real(15.)*q(ihi+1,j,klo) - Real(10.)*q(ihi+1,j,klo+1) + Real(3.)*q(ihi+1,j,klo+2));
                         } else {
-                            q(i,j,k) = 0.5 * 0.5 * (3.*q(ihi+1,j,klo) - q(ihi+1,j,klo+1));
+                            q(i,j,k) = Real(0.25) * (Real(3.)*q(ihi+1,j,klo) - q(ihi+1,j,klo+1));
                         }
 
                         if (ihi-2 >= is) {
                             q(i,j,k) = q(ihi+1,j,klo-1) +
-                                0.5 * (1./8.) * (15.*q(ihi,j,klo-1) - 10.*q(ihi-1,j,klo-1) + 3.*q(ihi-2,j,klo-1));
+                                Real(1./16.) * (Real(15.)*q(ihi,j,klo-1) - Real(10.)*q(ihi-1,j,klo-1) + Real(3.)*q(ihi-2,j,klo-1));
                         } else {
-                            q(i,j,k) = q(ihi+1,j,klo-1) + 0.5 * 0.5 * (3.*q(ihi,j,klo-1) - q(ihi-1,j,klo-1));
+                            q(i,j,k) = q(ihi+1,j,klo-1) + Real(0.25) * (Real(3.)*q(ihi,j,klo-1) - q(ihi-1,j,klo-1));
                         }
                     }
                 }
@@ -634,16 +634,16 @@ void fab_filcc (Box const& bx, Array4<Real> const& qn, int ncomp,
                 if (i>=imin && i<=imax && k>=kmin && k<=kmax) {
                     for (int j = lo.y; j <= hi.y; ++j) {
                         if (khi-2 >= ks) {
-                            q(i,j,k) = 0.5 * (1./8.) * (15.*q(ihi+1,j,khi) - 10.*q(ihi+1,j,khi-1) + 3.*q(ihi+1,j,khi-2));
+                            q(i,j,k) = Real(1./16.) * (Real(15.)*q(ihi+1,j,khi) - Real(10.)*q(ihi+1,j,khi-1) + Real(3.)*q(ihi+1,j,khi-2));
                         } else {
-                            q(i,j,k) = 0.5 * 0.5 * (3.*q(ihi+1,j,khi) - q(ihi+1,j,khi-1));
+                            q(i,j,k) = Real(0.25) * (Real(3.)*q(ihi+1,j,khi) - q(ihi+1,j,khi-1));
                         }
 
                         if (ihi-2 >= is) {
                             q(i,j,k) = q(ihi+1,j,khi+1) +
-                                0.5 * (1./8.) * (15.*q(ihi,j,khi+1) - 10.*q(ihi-1,j,khi+1) + 3.*q(ihi-2,j,khi+1));
+                                Real(1./16.) * (Real(15.)*q(ihi,j,khi+1) - Real(10.)*q(ihi-1,j,khi+1) + Real(3.)*q(ihi-2,j,khi+1));
                         } else {
-                            q(i,j,k) = q(ihi+1,j,khi+1) + 0.5 * 0.5 * (3.*q(ihi,j,khi+1) - q(ihi-1,j,khi+1));
+                            q(i,j,k) = q(ihi+1,j,khi+1) + Real(0.25) * (Real(3.)*q(ihi,j,khi+1) - q(ihi-1,j,khi+1));
                         }
                     }
                 }
@@ -665,16 +665,16 @@ void fab_filcc (Box const& bx, Array4<Real> const& qn, int ncomp,
                 if (j>=jmin && j<=jmax && k>=kmin && k<=kmax) {
                     for (int i = lo.x; i <= hi.x; ++i) {
                         if (klo+2 <= ke) {
-                            q(i,j,k) = 0.5 * (1./8.) * (15.*q(i,jlo-1,klo) - 10.*q(i,jlo-1,klo+1) + 3.*q(i,jlo-1,klo+2));
+                            q(i,j,k) = Real(1./16.) * (Real(15.)*q(i,jlo-1,klo) - Real(10.)*q(i,jlo-1,klo+1) + Real(3.)*q(i,jlo-1,klo+2));
                         } else {
-                            q(i,j,k) = 0.5 * 0.5 * (3.*q(i,jlo-1,klo) - q(i,jlo-1,klo+1));
+                            q(i,j,k) = Real(0.25) * (Real(3.)*q(i,jlo-1,klo) - q(i,jlo-1,klo+1));
                         }
 
                         if (jlo+2 <= je) {
                             q(i,j,k) = q(i,jlo-1,klo-1) +
-                                0.5 * (1./8.) * (15.*q(i,jlo,klo-1) - 10.*q(i,jlo+1,klo-1) + 3.*q(i,jlo+2,klo-1));
+                                Real(1./16.) * (Real(15.)*q(i,jlo,klo-1) - Real(10.)*q(i,jlo+1,klo-1) + Real(3.)*q(i,jlo+2,klo-1));
                         } else {
-                            q(i,j,k) = q(i,jlo-1,klo-1) + 0.5 * 0.5 * (3.*q(i,jlo,klo-1) - q(i,jlo+1,klo-1));
+                            q(i,j,k) = q(i,jlo-1,klo-1) + Real(0.25) * (Real(3.)*q(i,jlo,klo-1) - q(i,jlo+1,klo-1));
                         }
                     }
                 }
@@ -696,16 +696,16 @@ void fab_filcc (Box const& bx, Array4<Real> const& qn, int ncomp,
                 if (j>=jmin && j<=jmax && k>=kmin && k<=kmax) {
                     for (int i = lo.x; i <= hi.x; ++i) {
                         if (khi-2 >= ks) {
-                            q(i,j,k) = 0.5 * (1./8.) * (15.*q(i,jlo-1,khi) - 10.*q(i,jlo-1,khi-1) + 3.*q(i,jlo-1,khi-2));
+                            q(i,j,k) = Real(1./16.) * (Real(15.)*q(i,jlo-1,khi) - Real(10.)*q(i,jlo-1,khi-1) + Real(3.)*q(i,jlo-1,khi-2));
                         } else {
-                            q(i,j,k) = 0.5 * 0.5 * (3.*q(i,jlo-1,khi) - q(i,jlo-1,khi-1));
+                            q(i,j,k) = Real(0.25) * (Real(3.)*q(i,jlo-1,khi) - q(i,jlo-1,khi-1));
                         }
 
                         if (jlo+2 <= je) {
                             q(i,j,k) = q(i,jlo-1,khi+1) +
-                                0.5 * (1./8.) * (15.*q(i,jlo,khi+1) - 10.*q(i,jlo+1,khi+1) + 3.*q(i,jlo+2,khi+1));
+                                Real(1./16.) * (Real(15.)*q(i,jlo,khi+1) - Real(10.)*q(i,jlo+1,khi+1) + Real(3.)*q(i,jlo+2,khi+1));
                         } else {
-                            q(i,j,k) = q(i,jlo-1,khi+1) + 0.5 * 0.5 * (3.*q(i,jlo,khi+1) - q(i,jlo+1,khi+1));
+                            q(i,j,k) = q(i,jlo-1,khi+1) + Real(0.25) * (Real(3.)*q(i,jlo,khi+1) - q(i,jlo+1,khi+1));
                         }
                     }
                 }
@@ -727,16 +727,16 @@ void fab_filcc (Box const& bx, Array4<Real> const& qn, int ncomp,
                 if (j>=jmin && j<=jmax && k>=kmin && k<=kmax) {
                     for (int i = lo.x; i <= hi.x; ++i) {
                         if (klo+2 <= ke) {
-                            q(i,j,k) = 0.5 * (1./8.) * (15.*q(i,jhi+1,klo) - 10.*q(i,jhi+1,klo+1) + 3.*q(i,jhi+1,klo+2));
+                            q(i,j,k) = Real(1./16.) * (Real(15.)*q(i,jhi+1,klo) - Real(10.)*q(i,jhi+1,klo+1) + Real(3.)*q(i,jhi+1,klo+2));
                         } else {
-                            q(i,j,k) = 0.5 * 0.5 * (3.*q(i,jhi+1,klo) - q(i,jhi+1,klo+1));
+                            q(i,j,k) = Real(0.25) * (Real(3.)*q(i,jhi+1,klo) - q(i,jhi+1,klo+1));
                         }
 
                         if (jhi-2 >= js) {
                             q(i,j,k) = q(i,jhi+1,klo-1) +
-                                0.5 * (1./8.) * (15.*q(i,jhi,klo-1) - 10.*q(i,jhi-1,klo-1) + 3.*q(i,jhi-2,klo-1));
+                                Real(1./16.) * (Real(15.)*q(i,jhi,klo-1) - Real(10.)*q(i,jhi-1,klo-1) + Real(3.)*q(i,jhi-2,klo-1));
                         } else {
-                            q(i,j,k) = q(i,jhi+1,klo-1) + 0.5 * 0.5 * (3.*q(i,jhi,klo-1) - q(i,jhi-1,klo-1));
+                            q(i,j,k) = q(i,jhi+1,klo-1) + Real(0.25) * (Real(3.)*q(i,jhi,klo-1) - q(i,jhi-1,klo-1));
                         }
                     }
                 }
@@ -758,16 +758,16 @@ void fab_filcc (Box const& bx, Array4<Real> const& qn, int ncomp,
                 if (j>=jmin && j<=jmax && k>=kmin && k<=kmax) {
                     for (int i = lo.x; i <= hi.x; ++i) {
                         if (khi-2 >= ks) {
-                            q(i,j,k) = 0.5 * (1./8.) * (15.*q(i,jhi+1,khi) - 10.*q(i,jhi+1,khi-1) + 3.*q(i,jhi+1,khi-2));
+                            q(i,j,k) = Real(1./16.) * (Real(15.)*q(i,jhi+1,khi) - Real(10.)*q(i,jhi+1,khi-1) + Real(3.)*q(i,jhi+1,khi-2));
                         } else {
-                            q(i,j,k) = 0.5 * 0.5 * (3.*q(i,jhi+1,khi) - q(i,jhi+1,khi-1));
+                            q(i,j,k) = Real(0.25) * (Real(3.)*q(i,jhi+1,khi) - q(i,jhi+1,khi-1));
                         }
 
                         if (jhi-2 >= js) {
                             q(i,j,k) = q(i,jhi+1,khi+1) +
-                                0.5 * (1./8.) * (15.*q(i,jhi,khi+1) - 10.*q(i,jhi-1,khi+1) + 3.*q(i,jhi-2,khi+1));
+                                Real(1./16.) * (Real(15.)*q(i,jhi,khi+1) - Real(10.)*q(i,jhi-1,khi+1) + Real(3.)*q(i,jhi-2,khi+1));
                         } else {
-                            q(i,j,k) = q(i,jhi+1,khi+1) + 0.5 * 0.5 * (3.*q(i,jhi,khi+1) - q(i,jhi-1,khi+1));
+                            q(i,j,k) = q(i,jhi+1,khi+1) + Real(0.25) * (Real(3.)*q(i,jhi,khi+1) - q(i,jhi-1,khi+1));
                         }
                     }
                 }

--- a/Src/Base/AMReX_Geometry.cpp
+++ b/Src/Base/AMReX_Geometry.cpp
@@ -400,7 +400,7 @@ Geometry::computeRoundoffDomain ()
     {
         offset[k] = prob_domain.lo(k);
         dx[k] = prob_domain.length(k)/(Real(domain.length(k)));
-        inv_dx[k] = 1.0/dx[k];
+        inv_dx[k] = 1.0_rt/dx[k];
     }
 
     roundoff_domain = prob_domain;
@@ -414,9 +414,9 @@ Geometry::computeRoundoffDomain ()
         Real deltax = CellSize(idim);
 
 #ifdef AMREX_SINGLE_PRECISION_PARTICLES
-        Real tolerance = std::max(1.e-4*deltax, 1.e-10*phi);
+        Real tolerance = std::max(1.e-4_rt*deltax, 1.e-10_rt*phi);
 #else
-        Real tolerance = std::max(1.e-8*deltax, 1.e-14*phi);
+        Real tolerance = std::max(1.e-8_rt*deltax, 1.e-14_rt*phi);
 #endif
         // bisect the point at which the cell no longer maps to inside the domain
         Real lo = static_cast<Real>(phi) - Real(0.5)*static_cast<Real>(deltax);

--- a/Src/Base/AMReX_MFCopyDescriptor.cpp
+++ b/Src/Base/AMReX_MFCopyDescriptor.cpp
@@ -26,7 +26,7 @@ InterpAddBox (MultiFabCopyDescriptor& fabCopyDesc,
 {
     amrex::ignore_unused(extrap);
 
-    const Real teps = (t2-t1)/1000.0;
+    const Real teps = (t2-t1)/1000.0_rt;
 
     BL_ASSERT(extrap || ( (t>=t1-teps) && (t <= t2+teps) ) );
 
@@ -89,7 +89,7 @@ InterpFillFab (MultiFabCopyDescriptor& fabCopyDesc,
 {
     amrex::ignore_unused(extrap);
 
-    const Real teps = (t2-t1)/1000.0;
+    const Real teps = (t2-t1)/1000.0_rt;
 
     BL_ASSERT(extrap || ( (t>=t1-teps) && (t <= t2+teps) ) );
 

--- a/Src/Base/AMReX_MultiFab.cpp
+++ b/Src/Base/AMReX_MultiFab.cpp
@@ -1254,7 +1254,7 @@ MultiFab::OverlapMask (const Periodicity& period) const
                     } else {
                         amrex::LoopConcurrentOnCpu(b, [=] (int i, int j, int k) noexcept
                         {
-                            arr(i,j,k) += 1.0;
+                            arr(i,j,k) += Real(1.0);
                         });
                     }
                 }

--- a/Src/Base/AMReX_ParallelDescriptor.cpp
+++ b/Src/Base/AMReX_ParallelDescriptor.cpp
@@ -1786,6 +1786,6 @@ extern "C" {
 
     Real amrex_fi_pd_wtime ()
     {
-        return ParallelDescriptor::second();
+        return static_cast<Real>(ParallelDescriptor::second());
     }
 }

--- a/Src/Base/AMReX_RealBox.cpp
+++ b/Src/Base/AMReX_RealBox.cpp
@@ -63,8 +63,8 @@ operator >> (std::istream &is, RealBox& b)
     double dlotemp, dhitemp;
     for (int i = 0; i < AMREX_SPACEDIM; i++) {
         is >> dlotemp >> dhitemp;
-        lo[i] = dlotemp;
-        hi[i] = dhitemp;
+        lo[i] = static_cast<Real>(dlotemp);
+        hi[i] = static_cast<Real>(dhitemp);
     }
 #else
     for (int i = 0; i < AMREX_SPACEDIM; i++)

--- a/Src/Base/AMReX_VisMF.cpp
+++ b/Src/Base/AMReX_VisMF.cpp
@@ -968,7 +968,7 @@ VisMF::Write (const FabArray<FArrayBox>&    mf,
             for(int j(0); j < mf.nComp(); ++j) {
                 auto mm = (run_on_device) ? mf[mfi].minmax<RunOn::Device>(mf.box(idx),j)
                                           : mf[mfi].minmax<RunOn::Host  >(mf.box(idx),j);
-                const Real val = (mm.first + mm.second) / 2.0;
+                const Real val = (mm.first + mm.second) / 2.0_rt;
                 if (run_on_device) {
                     the_mf->get(mfi).setComplement<RunOn::Device>(val, mf.box(idx), j, 1);
                 } else {
@@ -1481,9 +1481,9 @@ VisMF::Read (FabArray<FArrayBox> &mf,
     BL_PROFILE("VisMF::Read()");
 
     VisMF::Header hdr;
-    Real hEndTime, hStartTime, faCopyTime(0.0);
-    Real startTime(amrex::second());
-    static Real totalTime(0.0);
+    double hEndTime, hStartTime, faCopyTime(0.0);
+    double startTime(amrex::second());
+    static double totalTime(0.0);
     int myProc(ParallelDescriptor::MyProc());
     int messTotal(0);
 
@@ -1916,7 +1916,7 @@ VisMF::Read (FabArray<FArrayBox> &mf,
     }
 
     if(myProc == coordinatorProc && verbose) {
-      Real mfReadTime = amrex::second() - startTime;
+      auto mfReadTime = amrex::second() - startTime;
       totalTime += mfReadTime;
       amrex::AllPrint() << "FARead ::  nBoxes = " << hdr.m_ba.size()
                         << "  nMessages = " << messTotal << '\n'

--- a/Src/Boundary/AMReX_InterpBndryData_3D_K.H
+++ b/Src/Boundary/AMReX_InterpBndryData_3D_K.H
@@ -43,7 +43,7 @@ void interpbndrydata_x_o3 (int i, int j, int k, int n,
     Real dyz = (mask(i,j-r.y,k-r.z) == not_covered && mask(i,j+r.y,k-r.z) == not_covered &&
                 mask(i,j-r.y,k+r.z) == not_covered && mask(i,j+r.y,k+r.z) == not_covered)
         ? Real(0.25)*(crse(ic,jc+1,kc+1,n+nc)-crse(ic,jc-1,kc+1,n+nc)+crse(ic,jc-1,kc-1,n+nc)-crse(ic,jc+1,kc-1,n+nc))
-        : 0.0;
+        : Real(0.0);
 
     Real y = -Real(0.5) + (j-jc*r.y+Real(0.5))/r.y;
     Real z = -Real(0.5) + (k-kc*r.z+Real(0.5))/r.z;
@@ -75,7 +75,7 @@ void interpbndrydata_y_o3 (int i, int j, int k, int n,
     Real dxz = (mask(i-r.x,j,k-r.z) == not_covered && mask(i+r.x,j,k-r.z) == not_covered &&
                 mask(i-r.x,j,k+r.z) == not_covered && mask(i+r.x,j,k+r.z) == not_covered)
         ? Real(0.25)*(crse(ic+1,jc,kc+1,n+nc)-crse(ic-1,jc,kc+1,n+nc)+crse(ic-1,jc,kc-1,n+nc)-crse(ic+1,jc,kc-1,n+nc))
-        : 0.0;
+        : Real(0.0);
 
 
     Real x = -Real(0.5) + (i-ic*r.x+Real(0.5))/r.x;
@@ -108,7 +108,7 @@ void interpbndrydata_z_o3 (int i, int j, int k, int n,
     Real dxy = (mask(i-r.x,j-r.y,k) == not_covered && mask(i+r.x,j-r.y,k) == not_covered &&
                 mask(i-r.x,j+r.y,k) == not_covered && mask(i+r.x,j+r.y,k) == not_covered)
         ? Real(0.25)*(crse(ic+1,jc+1,kc,n+nc)-crse(ic-1,jc+1,kc,n+nc)+crse(ic-1,jc-1,kc,n+nc)-crse(ic+1,jc-1,kc,n+nc))
-        : 0.0;
+        : Real(0.0);
 
     Real x = -Real(0.5) + (i-ic*r.x+Real(0.5))/r.x;
     Real y = -Real(0.5) + (j-jc*r.y+Real(0.5))/r.y;

--- a/Src/Boundary/AMReX_MacBndry.cpp
+++ b/Src/Boundary/AMReX_MacBndry.cpp
@@ -78,7 +78,7 @@ MacBndry::setBndryConds (const BCRec&   phys_bc,
                 const Real delta = dx[dir]*ratio[dir];
 
                 bctag[face][comp] = AMREX_LO_DIRICHLET;
-		bloc[face]        = 0.5*delta;
+		bloc[face]        = 0.5_rt*delta;
             }
         }
     }

--- a/Src/F_Interfaces/AmrCore/AMReX_FlashFluxRegister.cpp
+++ b/Src/F_Interfaces/AmrCore/AMReX_FlashFluxRegister.cpp
@@ -198,7 +198,7 @@ void FlashFluxRegister::store (int fine_global_index, int dir, FArrayBox const& 
                 AMREX_HOST_DEVICE_PARALLEL_FOR_4D (b, ncomp, i, j, k, n,
                 {
                     dest(i,j,0,n) = (src(2*i,2*j  ,0,n) +
-                                     src(2*i,2*j+1,0,n)) * (0.5*sf);
+                                     src(2*i,2*j+1,0,n)) * (Real(0.5)*sf);
                 });
 #endif
 #if (AMREX_SPACEDIM == 3)
@@ -207,7 +207,7 @@ void FlashFluxRegister::store (int fine_global_index, int dir, FArrayBox const& 
                     dest(i,j,k,n) = (src(2*i,2*j  ,2*k  ,n) +
                                      src(2*i,2*j+1,2*k  ,n) +
                                      src(2*i,2*j  ,2*k+1,n) +
-                                     src(2*i,2*j+1,2*k+1,n)) * (0.25*sf);
+                                     src(2*i,2*j+1,2*k+1,n)) * (Real(0.25)*sf);
                 });
 #endif
             } else if (dir == 1) {
@@ -215,7 +215,7 @@ void FlashFluxRegister::store (int fine_global_index, int dir, FArrayBox const& 
                 AMREX_HOST_DEVICE_PARALLEL_FOR_4D (b, ncomp, i, j, k, n,
                 {
                     dest(i,j,0,n) = (src(2*i  ,2*j,0,n) +
-                                     src(2*i+1,2*j,0,n)) * (0.5*sf);
+                                     src(2*i+1,2*j,0,n)) * (Real(0.5)*sf);
                 });
 #endif
 #if (AMREX_SPACEDIM == 3)
@@ -224,7 +224,7 @@ void FlashFluxRegister::store (int fine_global_index, int dir, FArrayBox const& 
                     dest(i,j,k,n) = (src(2*i  ,2*j,2*k  ,n) +
                                      src(2*i+1,2*j,2*k  ,n) +
                                      src(2*i  ,2*j,2*k+1,n) +
-                                     src(2*i+1,2*j,2*k+1,n)) * (0.25*sf);
+                                     src(2*i+1,2*j,2*k+1,n)) * (Real(0.25)*sf);
                 });
 #endif
             } else {
@@ -234,7 +234,7 @@ void FlashFluxRegister::store (int fine_global_index, int dir, FArrayBox const& 
                     dest(i,j,k,n) = (src(2*i  ,2*j  ,2*k,n) +
                                      src(2*i+1,2*j  ,2*k,n) +
                                      src(2*i  ,2*j+1,2*k,n) +
-                                     src(2*i+1,2*j+1,2*k,n)) * (0.25*sf);
+                                     src(2*i+1,2*j+1,2*k,n)) * (Real(0.25)*sf);
                 });
 #endif
             }

--- a/Src/LinearSolvers/MLMG/AMReX_MLABecLaplacian.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLABecLaplacian.cpp
@@ -200,7 +200,7 @@ MLABecLaplacian::averageDownCoeffsSameAmrLevel (int amrlev, Vector<MultiFab>& a,
     {
         if (m_overset_mask[amrlev][mglev]) {
             const Real fac = static_cast<Real>(1 << mglev); // 2**mglev
-            const Real osfac = 2.0*fac/(fac+1.0);
+            const Real osfac = Real(2.0)*fac/(fac+Real(1.0));
             const int ncomp = getNComp();
 #ifdef _OPENMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())

--- a/Src/LinearSolvers/MLMG/AMReX_MLALap_1D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLALap_1D_K.H
@@ -19,7 +19,7 @@ void mlalap_adotx (Box const& box, Array4<Real> const& y,
     AMREX_PRAGMA_SIMD
     for (int i = lo.x; i <= hi.x; ++i) {
         y(i,0,0) = alpha*a(i,0,0)*x(i,0,0)
-            - dhx * (x(i+1,0,0) - 2.*x(i,0,0) + x(i-1,0,0));
+            - dhx * (x(i+1,0,0) - Real(2.)*x(i,0,0) + x(i-1,0,0));
     }
 }
 
@@ -40,7 +40,7 @@ void mlalap_adotx_m (Box const& box, Array4<Real> const& y,
     for (int i = lo.x; i <= hi.x; ++i) {
         Real rel = (probxlo + i   *dx) * (probxlo + i   *dx);
         Real rer = (probxlo +(i+1)*dx) * (probxlo +(i+1)*dx);
-        Real rc  = (probxlo +(i+.5)*dx) * (probxlo +(i+.5)*dx);
+        Real rc  = (probxlo +(i+Real(.5))*dx) * (probxlo +(i+Real(.5))*dx);
         y(i,0,0) = alpha*a(i,0,0)*x(i,0,0)*rc
             - dhx * (rer*(x(i+1,0,0) - x(i  ,0,0))
                    - rel*(x(i  ,0,0) - x(i-1,0,0)));
@@ -60,7 +60,7 @@ void mlalap_normalize (Box const& box, Array4<Real> const& x,
 
     AMREX_PRAGMA_SIMD
     for (int i = lo.x; i <= hi.x; ++i) {
-        x(i,0,0) /= alpha*a(i,0,0) + dhx*2.0;
+        x(i,0,0) /= alpha*a(i,0,0) + dhx*Real(2.0);
     }
 }
 
@@ -79,7 +79,7 @@ void mlalap_normalize_m (Box const& box, Array4<Real> const& x,
     for (int i = lo.x; i <= hi.x; ++i) {
         Real rel = (probxlo + i   *dx) * (probxlo + i   *dx);
         Real rer = (probxlo +(i+1)*dx) * (probxlo +(i+1)*dx);
-        Real rc  = (probxlo +(i+.5)*dx) * (probxlo +(i+.5)*dx);
+        Real rc  = (probxlo +(i+Real(.5))*dx) * (probxlo +(i+Real(.5))*dx);
         x(i,0,0) /= alpha*a(i,0,0)*rc + dhx*(rel+rer);
     }
 }
@@ -156,13 +156,13 @@ void mlalap_gsrb (Box const& box, Array4<Real> const& phi,
     for (int i = lo.x; i <= hi.x; ++i) {
         if ((i+redblack)%2 == 0) {
             Real cf0 = (i == vlo.x && m0(vlo.x-1,0,0) > 0)
-                ? f0(vlo.x,0,0) : 0.0;
+                ? f0(vlo.x,0,0) : Real(0.0);
             Real cf1 = (i == vhi.x && m1(vhi.x+1,0,0) > 0)
-                ? f1(vhi.x,0,0) : 0.0;
+                ? f1(vhi.x,0,0) : Real(0.0);
             
             Real delta = dhx*(cf0+cf1);
             
-            Real gamma = alpha*a(i,0,0) + dhx*2.0;
+            Real gamma = alpha*a(i,0,0) + dhx*Real(2.0);
             
             Real rho = dhx*(phi(i-1,0,0) + phi(i+1,0,0));
 
@@ -190,13 +190,13 @@ void mlalap_gsrb_m (Box const& box, Array4<Real> const& phi,
     for (int i = lo.x; i <= hi.x; ++i) {
         if ((i+redblack)%2 == 0) {
             Real cf0 = (i == vlo.x && m0(vlo.x-1,0,0) > 0)
-                ? f0(vlo.x,0,0) : 0.0;
+                ? f0(vlo.x,0,0) : Real(0.0);
             Real cf1 = (i == vhi.x && m1(vhi.x+1,0,0) > 0)
-                ? f1(vhi.x,0,0) : 0.0;
+                ? f1(vhi.x,0,0) : Real(0.0);
 
             Real rel = (probxlo + i   *dx) * (probxlo + i   *dx);
             Real rer = (probxlo +(i+1)*dx) * (probxlo +(i+1)*dx);
-            Real rc  = (probxlo +(i+.5)*dx) * (probxlo +(i+.5)*dx);
+            Real rc  = (probxlo +(i+Real(.5))*dx) * (probxlo +(i+Real(.5))*dx);
             
             Real delta = dhx*(rel*cf0 + rer*cf1);
             

--- a/Src/LinearSolvers/MLMG/AMReX_MLALap_2D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLALap_2D_K.H
@@ -21,8 +21,8 @@ void mlalap_adotx (Box const& box, Array4<Real> const& y,
         AMREX_PRAGMA_SIMD
         for (int i = lo.x; i <= hi.x; ++i) {
             y(i,j,0) = alpha*a(i,j,0)*x(i,j,0)
-                - dhx * (x(i-1,j,0) - 2.*x(i,j,0) + x(i+1,j,0))
-                - dhy * (x(i,j-1,0) - 2.*x(i,j,0) + x(i,j+1,0));
+                - dhx * (x(i-1,j,0) - Real(2.)*x(i,j,0) + x(i+1,j,0))
+                - dhy * (x(i,j-1,0) - Real(2.)*x(i,j,0) + x(i,j+1,0));
         }
     }
 }
@@ -45,11 +45,11 @@ void mlalap_adotx_m (Box const& box, Array4<Real> const& y,
         for (int i = lo.x; i <= hi.x; ++i) {
             Real rel = probxlo + i*dx;
             Real rer = probxlo +(i+1)*dx;
-            Real rc = probxlo + (i+0.5)*dx;
+            Real rc = probxlo + (i+Real(0.5))*dx;
             y(i,j,0) = alpha*a(i,j,0)*x(i,j,0)*rc
                 - dhx * (rer*(x(i+1,j,0) - x(i  ,j,0))
                        - rel*(x(i  ,j,0) - x(i-1,j,0)))
-                - dhy * rc * (x(i,j-1,0) - 2.*x(i,j,0) + x(i,j+1,0));
+                - dhy * rc * (x(i,j-1,0) - Real(2.)*x(i,j,0) + x(i,j+1,0));
         }
     }
 }
@@ -69,7 +69,7 @@ void mlalap_normalize (Box const& box, Array4<Real> const& x,
     for     (int j = lo.y; j <= hi.y; ++j) {
         AMREX_PRAGMA_SIMD
         for (int i = lo.x; i <= hi.x; ++i) {
-            x(i,j,0) /= alpha*a(i,j,0) + 2.0*(dhx + dhy);
+            x(i,j,0) /= alpha*a(i,j,0) + Real(2.0)*(dhx + dhy);
         }
     }
 }
@@ -92,9 +92,9 @@ void mlalap_normalize_m (Box const& box, Array4<Real> const& x,
         for (int i = lo.x; i <= hi.x; ++i) {
             Real rel = probxlo + i*dx;
             Real rer = probxlo +(i+1)*dx;
-            Real rc = probxlo + (i+0.5)*dx;
+            Real rc = probxlo + (i+Real(0.5))*dx;
             x(i,j,0) /= alpha*a(i,j,0)*rc
-                + dhx*(rel+rer) + dhy*(rc*2.0);
+                + dhx*(rel+rer) + dhy*(rc*Real(2.0));
         }
     }
 }
@@ -190,7 +190,7 @@ void mlalap_flux_y_m (Box const& box, Array4<Real> const& fy,
     for     (int j = lo.y; j <= hi.y; ++j) {
         AMREX_PRAGMA_SIMD
         for (int i = lo.x; i <= hi.x; ++i) {
-            Real rc = probxlo + (i+0.5)*dx;
+            Real rc = probxlo + (i+Real(0.5))*dx;
             fy(i,j,0) = -fac*rc*(sol(i,j,0)-sol(i,j-1,0));
         }
     }
@@ -226,13 +226,13 @@ void mlalap_flux_yface_m (Box const& box, Array4<Real> const& fy,
     int j = lo.y;
     AMREX_PRAGMA_SIMD
     for (int i = lo.x; i <= hi.x; ++i) {
-        Real rc = probxlo + (i+0.5)*dx;
+        Real rc = probxlo + (i+Real(0.5))*dx;
         fy(i,j,0) = -fac*rc*(sol(i,j,0)-sol(i,j-1,0));
     }
     j += ylen;
     AMREX_PRAGMA_SIMD
     for (int i = lo.x; i <= hi.x; ++i) {
-        Real rc = probxlo + (i+0.5)*dx;
+        Real rc = probxlo + (i+Real(0.5))*dx;
         fy(i,j,0) = -fac*rc*(sol(i,j,0)-sol(i,j-1,0));
     }
 }
@@ -257,17 +257,17 @@ void mlalap_gsrb (Box const& box, Array4<Real> const& phi,
         for (int i = lo.x; i <= hi.x; ++i) {
             if ((i+j+redblack)%2 == 0) {
                 Real cf0 = (i == vlo.x && m0(vlo.x-1,j,0) > 0)
-                    ? f0(vlo.x,j,0) : 0.0;
+                    ? f0(vlo.x,j,0) : Real(0.0);
                 Real cf1 = (j == vlo.y && m1(i,vlo.y-1,0) > 0)
-                    ? f1(i,vlo.y,0) : 0.0;
+                    ? f1(i,vlo.y,0) : Real(0.0);
                 Real cf2 = (i == vhi.x && m2(vhi.x+1,j,0) > 0)
-                    ? f2(vhi.x,j,0) : 0.0;
+                    ? f2(vhi.x,j,0) : Real(0.0);
                 Real cf3 = (j == vhi.y && m3(i,vhi.y+1,0) > 0)
-                    ? f3(i,vhi.y,0) : 0.0;
+                    ? f3(i,vhi.y,0) : Real(0.0);
 
                 Real delta = dhx*(cf0 + cf2) + dhy*(cf1 + cf3);
 
-                Real gamma = alpha*a(i,j,0) + 2.0*(dhx + dhy);
+                Real gamma = alpha*a(i,j,0) + Real(2.0)*(dhx + dhy);
 
                 Real rho = dhx*(phi(i-1,j,0) + phi(i+1,j,0))
                     +      dhy*(phi(i,j-1,0) + phi(i,j+1,0));
@@ -300,21 +300,21 @@ void mlalap_gsrb_m (Box const& box, Array4<Real> const& phi,
         for (int i = lo.x; i <= hi.x; ++i) {
             if ((i+j+redblack)%2 == 0) {
                 Real cf0 = (i == vlo.x && m0(vlo.x-1,j,0) > 0)
-                    ? f0(vlo.x,j,0) : 0.0;
+                    ? f0(vlo.x,j,0) : Real(0.0);
                 Real cf1 = (j == vlo.y && m1(i,vlo.y-1,0) > 0)
-                    ? f1(i,vlo.y,0) : 0.0;
+                    ? f1(i,vlo.y,0) : Real(0.0);
                 Real cf2 = (i == vhi.x && m2(vhi.x+1,j,0) > 0)
-                    ? f2(vhi.x,j,0) : 0.0;
+                    ? f2(vhi.x,j,0) : Real(0.0);
                 Real cf3 = (j == vhi.y && m3(i,vhi.y+1,0) > 0)
-                    ? f3(i,vhi.y,0) : 0.0;
+                    ? f3(i,vhi.y,0) : Real(0.0);
 
                 Real rel = probxlo + i*dx;
                 Real rer = probxlo +(i+1)*dx;
-                Real rc = probxlo + (i+0.5)*dx;
+                Real rc = probxlo + (i+Real(0.5))*dx;
 
                 Real delta = dhx*(rel*cf0 + rer*cf2) + dhy*rc*(cf1 + cf3);
 
-                Real gamma = alpha*a(i,j,0)*rc + dhx*(rel+rer) + dhy*(2.*rc);
+                Real gamma = alpha*a(i,j,0)*rc + dhx*(rel+rer) + dhy*(Real(2.)*rc);
 
                 Real rho = dhx*(rel*phi(i-1,j,0) + rer*phi(i+1,j,0))
                     +      dhy* rc*(phi(i,j-1,0) +     phi(i,j+1,0));

--- a/Src/LinearSolvers/MLMG/AMReX_MLALap_3D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLALap_3D_K.H
@@ -23,9 +23,9 @@ void mlalap_adotx (Box const& box, Array4<Real> const& y,
             AMREX_PRAGMA_SIMD
             for (int i = lo.x; i <= hi.x; ++i) {
                 y(i,j,k) = alpha*a(i,j,k)*x(i,j,k)
-                    - dhx * (x(i-1,j,k) - 2.0*x(i,j,k) + x(i+1,j,k))
-                    - dhy * (x(i,j-1,k) - 2.0*x(i,j,k) + x(i,j+1,k))
-                    - dhz * (x(i,j,k-1) - 2.0*x(i,j,k) + x(i,j,k+1));
+                    - dhx * (x(i-1,j,k) - Real(2.0)*x(i,j,k) + x(i+1,j,k))
+                    - dhy * (x(i,j-1,k) - Real(2.0)*x(i,j,k) + x(i,j+1,k))
+                    - dhz * (x(i,j,k-1) - Real(2.0)*x(i,j,k) + x(i,j,k+1));
             }
         }
     }
@@ -40,7 +40,7 @@ void mlalap_normalize (Box const& box, Array4<Real> const& x,
     const Real dhx = beta*dxinv[0]*dxinv[0];
     const Real dhy = beta*dxinv[1]*dxinv[1];
     const Real dhz = beta*dxinv[2]*dxinv[2];
-    const Real fac = 2.0*(dhx+dhy+dhz);
+    const Real fac = Real(2.0)*(dhx+dhy+dhz);
 
     const auto lo = amrex::lbound(box);
     const auto hi = amrex::ubound(box);
@@ -183,9 +183,9 @@ void mlalap_gsrb (Box const& box, Array4<Real> const& phi,
     const auto vlo = amrex::lbound(vbox);
     const auto vhi = amrex::ubound(vbox);
 
-    constexpr Real omega = 1.15;
+    constexpr Real omega = Real(1.15);
 
-    const Real dhfac = 2.*(dhx+dhy+dhz);
+    const Real dhfac = Real(2.)*(dhx+dhy+dhz);
 
     for         (int k = lo.z; k <= hi.z; ++k) {
         for     (int j = lo.y; j <= hi.y; ++j) {
@@ -193,17 +193,17 @@ void mlalap_gsrb (Box const& box, Array4<Real> const& phi,
             for (int i = lo.x; i <= hi.x; ++i) {
                 if ((i+j+k+redblack)%2 == 0) {
                     Real cf0 = (i == vlo.x && m0(vlo.x-1,j,k) > 0)
-                        ? f0(vlo.x,j,k) : 0.0;
+                        ? f0(vlo.x,j,k) : Real(0.0);
                     Real cf1 = (j == vlo.y && m1(i,vlo.y-1,k) > 0)
-                        ? f1(i,vlo.y,k) : 0.0;
+                        ? f1(i,vlo.y,k) : Real(0.0);
                     Real cf2 = (k == vlo.z && m2(i,j,vlo.z-1) > 0)
-                        ? f2(i,j,vlo.z) : 0.0;
+                        ? f2(i,j,vlo.z) : Real(0.0);
                     Real cf3 = (i == vhi.x && m3(vhi.x+1,j,k) > 0)
-                        ? f3(vhi.x,j,k) : 0.0;
+                        ? f3(vhi.x,j,k) : Real(0.0);
                     Real cf4 = (j == vhi.y && m4(i,vhi.y+1,k) > 0)
-                        ? f4(i,vhi.y,k) : 0.0;
+                        ? f4(i,vhi.y,k) : Real(0.0);
                     Real cf5 = (k == vhi.z && m5(i,j,vhi.z+1) > 0)
-                        ? f5(i,j,vhi.z) : 0.0;
+                        ? f5(i,j,vhi.z) : Real(0.0);
 
                     Real gamma = alpha*a(i,j,k) + dhfac;
 

--- a/Src/LinearSolvers/MLMG/AMReX_MLCellABecLap.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLCellABecLap.cpp
@@ -138,7 +138,7 @@ MLCellABecLap::getFluxes (const Vector<Array<MultiFab*,AMREX_SPACEDIM> >& a_flux
 {
     BL_PROFILE("MLMG::getFluxes()");
 
-    const Real betainv = 1.0 / getBScalar();
+    const Real betainv = Real(1.0) / getBScalar();
     const int nlevs = NAMRLevels();
     for (int alev = 0; alev < nlevs; ++alev) {
         compFlux(alev, a_flux[alev], *a_sol[alev], a_loc);
@@ -177,8 +177,8 @@ MLCellABecLap::applyInhomogNeumannTerm (int amrlev, MultiFab& rhs) const
     const auto probhi = m_geom[amrlev][mglev].ProbHiArray();
     amrex::ignore_unused(probhi);
     const Real dxi = m_geom[amrlev][mglev].InvCellSize(0);
-    const Real dyi = (AMREX_SPACEDIM >= 2) ? m_geom[amrlev][mglev].InvCellSize(1) : 1.0;
-    const Real dzi = (AMREX_SPACEDIM == 3) ? m_geom[amrlev][mglev].InvCellSize(2) : 1.0;
+    const Real dyi = (AMREX_SPACEDIM >= 2) ? m_geom[amrlev][mglev].InvCellSize(1) : Real(1.0);
+    const Real dzi = (AMREX_SPACEDIM == 3) ? m_geom[amrlev][mglev].InvCellSize(2) : Real(1.0);
     const Real xlo = problo[0];
     const Real dx = m_geom[amrlev][mglev].CellSize(0);
     const Box& domain = m_geom[amrlev][mglev].Domain();

--- a/Src/LinearSolvers/MLMG/AMReX_MLCellLinOp.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLCellLinOp.cpp
@@ -398,7 +398,7 @@ MLCellLinOp::solutionResidual (int amrlev, MultiFab& resid, MultiFab& x, const M
           m_bndry_sol[amrlev].get());
 
     AMREX_ALWAYS_ASSERT(resid.nComp() == b.nComp());
-    MultiFab::Xpay(resid, -1.0, b, 0, 0, ncomp, 0);
+    MultiFab::Xpay(resid, Real(-1.0), b, 0, 0, ncomp, 0);
 }
 
 void
@@ -436,7 +436,7 @@ MLCellLinOp::correctionResidual (int amrlev, int mglev, MultiFab& resid, MultiFa
         apply(amrlev, mglev, resid, x, BCMode::Homogeneous, StateMode::Correction, nullptr);
     }
 
-    MultiFab::Xpay(resid, -1.0, b, 0, 0, ncomp, 0);
+    MultiFab::Xpay(resid, Real(-1.0), b, 0, 0, ncomp, 0);
 }
 
 void
@@ -460,8 +460,8 @@ MLCellLinOp::applyBC (int amrlev, int mglev, MultiFab& in, BCMode bc_mode, State
 
     const Real* dxinv = m_geom[amrlev][mglev].InvCellSize();
     const Real dxi = dxinv[0];
-    const Real dyi = (AMREX_SPACEDIM >= 2) ? dxinv[1] : 1.0;
-    const Real dzi = (AMREX_SPACEDIM == 3) ? dxinv[2] : 1.0;
+    const Real dyi = (AMREX_SPACEDIM >= 2) ? dxinv[1] : Real(1.0);
+    const Real dzi = (AMREX_SPACEDIM == 3) ? dxinv[2] : Real(1.0);
 
     const auto& maskvals = m_maskvals[amrlev][mglev];
     const auto& bcondloc = *m_bcondloc[amrlev][mglev];
@@ -666,7 +666,7 @@ MLCellLinOp::reflux (int crse_amrlev,
 
     const int fine_amrlev = crse_amrlev+1;
 
-    Real dt = 1.0;
+    Real dt = Real(1.0);
     const Real* crse_dx = m_geom[crse_amrlev][0].CellSize();
     const Real* fine_dx = m_geom[fine_amrlev][0].CellSize();
 
@@ -837,8 +837,8 @@ MLCellLinOp::prepareForSolve ()
             const auto& maskvals = m_maskvals[amrlev][mglev];
 
             const Real dxi = m_geom[amrlev][mglev].InvCellSize(0);
-            const Real dyi = (AMREX_SPACEDIM >= 2) ? m_geom[amrlev][mglev].InvCellSize(1) : 1.0;
-            const Real dzi = (AMREX_SPACEDIM == 3) ? m_geom[amrlev][mglev].InvCellSize(2) : 1.0;
+            const Real dyi = (AMREX_SPACEDIM >= 2) ? m_geom[amrlev][mglev].InvCellSize(1) : Real(1.0);
+            const Real dzi = (AMREX_SPACEDIM == 3) ? m_geom[amrlev][mglev].InvCellSize(2) : Real(1.0);
 
             BndryRegister& undrrelxr = m_undrrelxr[amrlev][mglev];
             MultiFab foo(m_grids[amrlev][mglev], m_dmap[amrlev][mglev], ncomp, 0, MFInfo().SetAlloc(false));
@@ -1221,7 +1221,7 @@ MLCellLinOp::applyMetricTerm (int amrlev, int mglev, MultiFab& rhs) const
         if (cc) {
             AMREX_HOST_DEVICE_PARALLEL_FOR_4D ( tbx, ncomp, i, j, k, n,
             {
-                Real rc = probxlo + (i+0.5)*dx;
+                Real rc = probxlo + (i+Real(0.5))*dx;
                 rhsarr(i,j,k,n) *= rc*rc;
             });
         } else {
@@ -1235,7 +1235,7 @@ MLCellLinOp::applyMetricTerm (int amrlev, int mglev, MultiFab& rhs) const
         if (cc) {
             AMREX_HOST_DEVICE_PARALLEL_FOR_4D ( tbx, ncomp, i, j, k, n,
             {
-                Real rc = probxlo + (i+0.5)*dx;
+                Real rc = probxlo + (i+Real(0.5))*dx;
                 rhsarr(i,j,k,n) *= rc;
             });
         } else {
@@ -1277,14 +1277,14 @@ MLCellLinOp::unapplyMetricTerm (int amrlev, int mglev, MultiFab& rhs) const
         if (cc) {
             AMREX_HOST_DEVICE_PARALLEL_FOR_4D ( tbx, ncomp, i, j, k, n,
             {
-                Real rcinv = 1.0/(probxlo + (i+0.5)*dx);
+                Real rcinv = Real(1.0)/(probxlo + (i+Real(0.5))*dx);
                 rhsarr(i,j,k,n) *= rcinv*rcinv;
             });
         } else {
             AMREX_HOST_DEVICE_PARALLEL_FOR_4D ( tbx, ncomp, i, j, k, n,
             {
                 Real re = probxlo + i*dx;
-                Real reinv = (re==0.0) ? 0.0 : 1./re;
+                Real reinv = (re==Real(0.0)) ? Real(0.0) : Real(1.)/re;
                 rhsarr(i,j,k,n) *= reinv*reinv;
             });
         }
@@ -1292,14 +1292,14 @@ MLCellLinOp::unapplyMetricTerm (int amrlev, int mglev, MultiFab& rhs) const
         if (cc) {
             AMREX_HOST_DEVICE_PARALLEL_FOR_4D ( tbx, ncomp, i, j, k, n,
             {
-                Real rcinv = 1.0/(probxlo + (i+0.5)*dx);
+                Real rcinv = Real(1.0)/(probxlo + (i+Real(0.5))*dx);
                 rhsarr(i,j,k,n) *= rcinv;
             });
         } else {
             AMREX_HOST_DEVICE_PARALLEL_FOR_4D ( tbx, ncomp, i, j, k, n,
             {
                 Real re = probxlo + i*dx;
-                Real reinv = (re==0.0) ? 0.0 : 1./re;
+                Real reinv = (re==Real(0.0)) ? Real(0.0) : Real(1.)/re;
                 rhsarr(i,j,k,n) *= reinv;
             });
         }

--- a/Src/LinearSolvers/MLMG/AMReX_MLLinOp_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLLinOp_K.H
@@ -591,7 +591,7 @@ void mllinop_apply_innu_ylo_m (int i, int j, int k,
                                Real fac, Real xlo, Real dx, int icomp) noexcept
 {
     if (bct == AMREX_LO_NEUMANN && mask(i,j,k) == 2) {
-        Real b = xlo + (i+0.5)*dx;
+        Real b = xlo + (i+Real(0.5))*dx;
         rhs(i,j+1,k,icomp) -= fac*b*bcval(i,j,k,icomp);
     }
 }
@@ -620,7 +620,7 @@ void mllinop_apply_innu_yhi_m (int i, int j, int k,
                                Real fac, Real xlo, Real dx, int icomp) noexcept
 {
     if (bct == AMREX_LO_NEUMANN && mask(i,j,k) == 2) {
-        Real b = xlo + (i+0.5)*dx;
+        Real b = xlo + (i+Real(0.5))*dx;
         rhs(i,j-1,k,icomp) += fac*b*bcval(i,j,k,icomp);
     }
 }

--- a/Src/LinearSolvers/MLMG/AMReX_MLMG.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLMG.H
@@ -261,7 +261,7 @@ private:
     Vector<std::unique_ptr<MultiFab> > scratch;
 
     enum timer_types { solve_time=0, iter_time, bottom_time, ntimers };
-    Vector<Real> timer;
+    Vector<double> timer;
 
     Real m_rhsnorm0 = -1.0;
     Real m_init_resnorm0 = -1.0;

--- a/Src/LinearSolvers/MLMG/AMReX_MLMG.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLMG.cpp
@@ -73,7 +73,7 @@ MLMG::solve (const Vector<MultiFab*>& a_sol, const Vector<MultiFab const*>& a_rh
     
     bool is_nsolve = linop.m_parent;
 
-    Real solve_start_time = amrex::second();
+    auto solve_start_time = amrex::second();
 
     Real& composite_norminf = m_final_resnorm0;
 
@@ -119,7 +119,7 @@ MLMG::solve (const Vector<MultiFab*>& a_sol, const Vector<MultiFab const*>& a_rh
             amrex::Print() << "MLMG: No iterations needed\n";
         }
     } else {
-        Real iter_start_time = amrex::second();
+        auto iter_start_time = amrex::second();
         bool converged = false;
 
         const int niters = do_fixed_number_of_iters ? do_fixed_number_of_iters : max_iters;
@@ -169,7 +169,7 @@ MLMG::solve (const Vector<MultiFab*>& a_sol, const Vector<MultiFab const*>& a_rh
                 }
                 break;
             } else {
-              if (composite_norminf > 1.e20*max_norm) 
+              if (composite_norminf > Real(1.e20)*max_norm) 
               {
                   if (verbose > 0) {
                       amrex::Print() << "MLMG: Failing to converge after " << iter+1 << " iterations."
@@ -205,8 +205,8 @@ MLMG::solve (const Vector<MultiFab*>& a_sol, const Vector<MultiFab const*>& a_rh
 
     timer[solve_time] = amrex::second() - solve_start_time;
     if (verbose >= 1) {
-        ParallelReduce::Max<Real>(timer.data(), timer.size(), 0,
-                                  ParallelContext::CommunicatorSub());
+        ParallelReduce::Max<double>(timer.data(), timer.size(), 0,
+                                    ParallelContext::CommunicatorSub());
         if (ParallelContext::MyProcSub() == 0)
         {
             amrex::AllPrint() << "MLMG: Timers: Solve = " << timer[solve_time]
@@ -891,7 +891,7 @@ MLMG::NSolve (MLMG& a_solver, MultiFab& a_sol, MultiFab& a_rhs)
     a_rhs.setVal(0.0);
     a_rhs.ParallelCopy(res[0].back());
 
-    a_solver.solve({&a_sol}, {&a_rhs}, -1.0, -1.0);
+    a_solver.solve({&a_sol}, {&a_rhs}, Real(-1.0), Real(-1.0));
 
     cor[0].back()->ParallelCopy(a_sol);
 }
@@ -905,7 +905,7 @@ MLMG::actualBottomSolve ()
 
     if (!linop.isBottomActive()) return;
 
-    Real bottom_start_time = amrex::second();
+    auto bottom_start_time = amrex::second();
 
     ParallelContext::push(linop.BottomCommunicator());
 
@@ -1669,7 +1669,7 @@ MLMG::computeVolInv ()
             else
 #endif
             {
-                volinv[amrlev][mglev] = 1.0 / linop.Geom(amrlev,mglev).Domain().d_numPts();
+                volinv[amrlev][mglev] = Real(1.0 / linop.Geom(amrlev,mglev).Domain().d_numPts());
             }
         };
 
@@ -1685,8 +1685,8 @@ MLMG::computeVolInv ()
         {
             ParallelAllReduce::Sum<Real>({volinv[0][0], volinv[0][mgbottom]},
                                          ParallelContext::CommunicatorSub());
-            temp1 = 1.0/volinv[0][0];
-            temp2 = 1.0/volinv[0][mgbottom];
+            temp1 = Real(1.0)/volinv[0][0];
+            temp2 = Real(1.0)/volinv[0][mgbottom];
         }
         else
         {
@@ -1815,7 +1815,7 @@ Real
 MLMG::getNodalSum (int amrlev, int mglev, MultiFab& mf) const
 {
     MultiFab one(mf.boxArray(), mf.DistributionMap(), 1, 0, MFInfo(), mf.Factory());
-    one.setVal(1.0);
+    one.setVal(Real(1.0));
     const bool local = true;
     Real s1 = linop.xdoty(amrlev, mglev, mf, one, local);
     Real s2 = linop.xdoty(amrlev, mglev, one, one, local);
@@ -1871,7 +1871,7 @@ MLMG::bottomSolveWithHypre (MultiFab& x, const MultiFab& b)
         // IJ interface understands absolute tolerance API of hypre
         amrex::Real hypre_abstol =
             (hypre_interface == amrex::Hypre::Interface::ij)
-            ? bottom_abstol : -1.0;
+            ? bottom_abstol : Real(-1.0);
         hypre_solver->solve(
             x, b, bottom_reltol, hypre_abstol, bottom_maxiter, *hypre_bndry,
             linop.getMaxOrder());
@@ -1924,7 +1924,7 @@ MLMG::bottomSolveWithPETSc (MultiFab& x, const MultiFab& b)
                                          0.5*dx[2]*crse_ratio));
         petsc_bndry->setLOBndryConds(linop.m_lobc, linop.m_hibc, -1, bclocation);
     }
-    petsc_solver->solve(x, b, bottom_reltol, -1., bottom_maxiter, *petsc_bndry, linop.getMaxOrder());
+    petsc_solver->solve(x, b, bottom_reltol, Real(-1.), bottom_maxiter, *petsc_bndry, linop.getMaxOrder());
 #endif
 }
 

--- a/Src/LinearSolvers/MLMG/AMReX_MLMGBndry.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLMGBndry.cpp
@@ -78,7 +78,7 @@ MLMGBndry::setBoxBC (RealTuple& bloc, BCTuple& bctag, const Box& bx, const Box& 
         {
             // Internal bndry.
             bctag[face] = AMREX_LO_DIRICHLET;
-            bloc[face]  = ratio > 0 ? 0.5*ratio*dx[dir] : interior_bloc[dir];
+            bloc[face]  = ratio > 0 ? Real(0.5)*ratio*dx[dir] : interior_bloc[dir];
             // If this is next to another same level box, bloc is
             // wrong.  But it doesn't matter, because we also have
             // mask.  It is used only if mask says it is next to

--- a/Src/LinearSolvers/MLMG/AMReX_MLMG_1D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLMG_1D_K.H
@@ -16,7 +16,7 @@ void mlmg_lin_cc_interp_r2 (Box const& bx, Array4<Real> const& ff,
         for (int i = lo.x; i <= hi.x; ++i) {
             const int ic = i/2;
             const int ioff = 2*(i-ic*2)-1;
-            ff(i,0,0,n) = 0.75*cc(ic,0,0,n) + 0.25*cc(ic+ioff,0,0,n);
+            ff(i,0,0,n) = Real(0.75)*cc(ic,0,0,n) + Real(0.25)*cc(ic+ioff,0,0,n);
         }
     }
 }
@@ -45,7 +45,7 @@ void mlmg_lin_nd_interp (int i, int, int, int n, Array4<Real> const& fine,
     bool i_is_odd = (ic*2 != i);
     if (i_is_odd) {
         // Fine node along a horizontal cell edge
-        fine(i,0,0,n) = 0.5*(crse(ic,0,0,n) + crse(ic+1,0,0,n));
+        fine(i,0,0,n) = Real(0.5)*(crse(ic,0,0,n) + crse(ic+1,0,0,n));
     } else {
         // Fine node coincident with coarse node
         fine(i,0,0,n) = crse(ic,0,0,n);

--- a/Src/LinearSolvers/MLMG/AMReX_MLMG_2D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLMG_2D_K.H
@@ -19,10 +19,10 @@ void mlmg_lin_cc_interp_r2 (Box const& bx, Array4<Real> const& ff,
             for (int i = lo.x; i <= hi.x; ++i) {
                 const int ic = i/2;
                 const int ioff = 2*(i-ic*2)-1;
-                ff(i,j,0,n) = 0.5625*cc(ic     ,jc     ,0,n)
-                    +         0.1875*cc(ic+ioff,jc     ,0,n)
-                    +         0.1875*cc(ic     ,jc+joff,0,n)
-                    +         0.0625*cc(ic+ioff,jc+joff,0,n);
+                ff(i,j,0,n) = Real(0.5625)*cc(ic     ,jc     ,0,n)
+                    +         Real(0.1875)*cc(ic+ioff,jc     ,0,n)
+                    +         Real(0.1875)*cc(ic     ,jc+joff,0,n)
+                    +         Real(0.0625)*cc(ic+ioff,jc+joff,0,n);
 
             }
         }
@@ -64,7 +64,7 @@ void mlmg_eb_cc_interp_r (Box const& bx, Array4<Real> const& ff, Array4<Real con
             for (int i = lo.x; i <= hi.x; ++i) {
                 const int ic = i/R;
                 if (flag(i,j,0).isCovered()) {
-                    ff(i,j,0,n) = 0.0;
+                    ff(i,j,0,n) = Real(0.0);
                 } else {
                     ff(i,j,0,n) = cc(ic,jc,0,n);
                 }
@@ -84,14 +84,14 @@ void mlmg_lin_nd_interp (int i, int j, int, int n, Array4<Real> const& fine,
     bool j_is_odd = (jc*2 != j);
     if (i_is_odd && j_is_odd) {
         // Fine node at center of cell
-        fine(i,j,0,n) = 0.25*(crse(ic,jc,0,n) + crse(ic+1,jc,0,n) +
+        fine(i,j,0,n) = Real(0.25)*(crse(ic,jc,0,n) + crse(ic+1,jc,0,n) +
                               crse(ic,jc+1,0,n) + crse(ic+1,jc+1,0,n));
     } else if (j_is_odd) {
         // Fine node along a vertical cell edge
-        fine(i,j,0,n) = 0.5*(crse(ic,jc,0,n) + crse(ic,jc+1,0,n));
+        fine(i,j,0,n) = Real(0.5)*(crse(ic,jc,0,n) + crse(ic,jc+1,0,n));
     } else if (i_is_odd) {
         // Fine node along a horizontal cell edge
-        fine(i,j,0,n) = 0.5*(crse(ic,jc,0,n) + crse(ic+1,jc,0,n));
+        fine(i,j,0,n) = Real(0.5)*(crse(ic,jc,0,n) + crse(ic+1,jc,0,n));
     } else {
         // Fine node coincident with coarse node
         fine(i,j,0,n) = crse(ic,jc,0,n);

--- a/Src/LinearSolvers/MLMG/AMReX_MLMG_3D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLMG_3D_K.H
@@ -22,14 +22,14 @@ void mlmg_lin_cc_interp_r2 (Box const& bx, Array4<Real> const& ff,
                 for (int i = lo.x; i <= hi.x; ++i) {
                     const int ic = i/2;
                     const int ioff = 2*(i-ic*2)-1;
-                    ff(i,j,k,n) = 0.421875*cc(ic     ,jc     ,kc     ,n)
-                        +         0.140625*cc(ic+ioff,jc     ,kc     ,n)
-                        +         0.140625*cc(ic     ,jc+joff,kc     ,n)
-                        +         0.140625*cc(ic     ,jc     ,kc+koff,n)
-                        +         0.046875*cc(ic     ,jc+joff,kc+koff,n)
-                        +         0.046875*cc(ic+ioff,jc     ,kc+koff,n)
-                        +         0.046875*cc(ic+ioff,jc+joff,kc     ,n)
-                        +         0.015625*cc(ic+ioff,jc+joff,kc+koff,n);
+                    ff(i,j,k,n) = Real(0.421875)*cc(ic     ,jc     ,kc     ,n)
+                        +         Real(0.140625)*cc(ic+ioff,jc     ,kc     ,n)
+                        +         Real(0.140625)*cc(ic     ,jc+joff,kc     ,n)
+                        +         Real(0.140625)*cc(ic     ,jc     ,kc+koff,n)
+                        +         Real(0.046875)*cc(ic     ,jc+joff,kc+koff,n)
+                        +         Real(0.046875)*cc(ic+ioff,jc     ,kc+koff,n)
+                        +         Real(0.046875)*cc(ic+ioff,jc+joff,kc     ,n)
+                        +         Real(0.015625)*cc(ic+ioff,jc+joff,kc+koff,n);
                 }
             }
         }
@@ -76,7 +76,7 @@ void mlmg_eb_cc_interp_r (Box const& bx, Array4<Real> const& ff, Array4<Real con
                 for (int i = lo.x; i <= hi.x; ++i) {
                     const int ic = i/R;
                     if (flag(i,j,k).isCovered()) {
-                        ff(i,j,k,n) = 0.0;
+                        ff(i,j,k,n) = Real(0.0);
                     } else {
                         ff(i,j,k,n) = cc(ic,jc,kc,n);
                     }
@@ -99,31 +99,31 @@ void mlmg_lin_nd_interp (int i, int j, int k, int n, Array4<Real> const& fine,
     bool k_is_odd = (kc*2 != k);
     if (i_is_odd && j_is_odd && k_is_odd) {
         // Fine node at center of cell
-        fine(i,j,k,n) = 0.125*(crse(ic,  jc,  kc,n) + crse(ic,  jc,  kc+1,n) +
-                               crse(ic,  jc+1,kc,n) + crse(ic,  jc+1,kc+1,n) +
-                               crse(ic+1,jc,  kc,n) + crse(ic+1,jc,  kc+1,n) +
-                               crse(ic+1,jc+1,kc,n) + crse(ic+1,jc+1,kc+1,n));
+        fine(i,j,k,n) = Real(0.125)*(crse(ic,  jc,  kc,n) + crse(ic,  jc,  kc+1,n) +
+                                     crse(ic,  jc+1,kc,n) + crse(ic,  jc+1,kc+1,n) +
+                                     crse(ic+1,jc,  kc,n) + crse(ic+1,jc,  kc+1,n) +
+                                     crse(ic+1,jc+1,kc,n) + crse(ic+1,jc+1,kc+1,n));
     } else if (j_is_odd && k_is_odd) {
         // Node on a Y-Z face
-        fine(i,j,k,n) = 0.25*(crse(ic,  jc,  kc,n) + crse(ic,  jc,  kc+1,n) +
-                              crse(ic,  jc+1,kc,n) + crse(ic,  jc+1,kc+1,n));
+        fine(i,j,k,n) = Real(0.25)*(crse(ic,  jc,  kc,n) + crse(ic,  jc,  kc+1,n) +
+                                    crse(ic,  jc+1,kc,n) + crse(ic,  jc+1,kc+1,n));
     } else if (i_is_odd && k_is_odd) {
         // Node on a Z-X face
-        fine(i,j,k,n) = 0.25*(crse(ic,  jc,kc,n) + crse(ic,  jc,kc+1,n) +
-                              crse(ic+1,jc,kc,n) + crse(ic+1,jc,kc+1,n));
+        fine(i,j,k,n) = Real(0.25)*(crse(ic,  jc,kc,n) + crse(ic,  jc,kc+1,n) +
+                                    crse(ic+1,jc,kc,n) + crse(ic+1,jc,kc+1,n));
     } else if (i_is_odd && j_is_odd) {
         // Node on a X-Y face
-        fine(i,j,k,n) = 0.25*(crse(ic  ,jc,kc,n) + crse(ic  ,jc+1,kc,n) +
-                              crse(ic+1,jc,kc,n) + crse(ic+1,jc+1,kc,n));
+        fine(i,j,k,n) = Real(0.25)*(crse(ic  ,jc,kc,n) + crse(ic  ,jc+1,kc,n) +
+                                    crse(ic+1,jc,kc,n) + crse(ic+1,jc+1,kc,n));
     } else if (i_is_odd) {
         // Node on X line
-        fine(i,j,k,n) = 0.5*(crse(ic,jc,kc,n) + crse(ic+1,jc,kc,n));
+        fine(i,j,k,n) = Real(0.5)*(crse(ic,jc,kc,n) + crse(ic+1,jc,kc,n));
     } else if (j_is_odd) {
         // Node on Y line
-        fine(i,j,k,n) = 0.5*(crse(ic,jc,kc,n) + crse(ic,jc+1,kc,n));
+        fine(i,j,k,n) = Real(0.5)*(crse(ic,jc,kc,n) + crse(ic,jc+1,kc,n));
     } else if (k_is_odd) {
         // Node on Z line
-        fine(i,j,k,n) = 0.5*(crse(ic,jc,kc,n) + crse(ic,jc,kc+1,n));
+        fine(i,j,k,n) = Real(0.5)*(crse(ic,jc,kc,n) + crse(ic,jc,kc+1,n));
     } else {
         // Node coincident with coarse node
         fine(i,j,k,n) = crse(ic,jc,kc,n);

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLap_2D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLap_2D_K.H
@@ -92,7 +92,7 @@ void mlndlap_set_dot_mask (Box const& bx, Array4<Real> const& dmsk,
         && lo.x == domlo.x)
     {
         for (int j = lo.y; j <= hi.y; ++j) {
-            dmsk(lo.x,j,0) *= 0.5;
+            dmsk(lo.x,j,0) *= Real(0.5);
         }
     }
 
@@ -100,7 +100,7 @@ void mlndlap_set_dot_mask (Box const& bx, Array4<Real> const& dmsk,
         && hi.x == domhi.x)
     {
         for (int j = lo.y; j <= hi.y; ++j) {
-            dmsk(hi.x,j,0) *= 0.5;
+            dmsk(hi.x,j,0) *= Real(0.5);
         }
     }
 
@@ -109,7 +109,7 @@ void mlndlap_set_dot_mask (Box const& bx, Array4<Real> const& dmsk,
     {
         AMREX_PRAGMA_SIMD
         for (int i = lo.x; i <= hi.x; ++i) {
-            dmsk(i,lo.y,0) *= 0.5;
+            dmsk(i,lo.y,0) *= Real(0.5);
         }
     }
 
@@ -118,7 +118,7 @@ void mlndlap_set_dot_mask (Box const& bx, Array4<Real> const& dmsk,
     {
         AMREX_PRAGMA_SIMD
         for (int i = lo.x; i <= hi.x; ++i) {
-            dmsk(i,hi.y,0) *= 0.5;
+            dmsk(i,hi.y,0) *= Real(0.5);
         }
     }
 }
@@ -167,11 +167,11 @@ void mlndlap_semi_avgdown_coeff (int i, int j, int k, Array4<Real> const& crse,
     if (idir == 1) {
         Real a = fine(2*i  ,j,k);
         Real b = fine(2*i+1,j,k);
-        crse(i,j,k) = 2.0*a*b/(a+b);
+        crse(i,j,k) = Real(2.0)*a*b/(a+b);
     } else {
         Real a = fine(i,2*j  ,k);
         Real b = fine(i,2*j+1,k);
-        crse(i,j,k) = 2.0*a*b/(a+b);
+        crse(i,j,k) = Real(2.0)*a*b/(a+b);
     }
 }
 
@@ -298,22 +298,22 @@ Real mlndlap_adotx_ha (int i, int j, int k, Array4<Real const> const& x,
     if (msk(i,j,k)) {
         return Real(0.0);
     } else {
-        Real facx = (1./6.)*dxinv[0]*dxinv[0];
-        Real facy = (1./6.)*dxinv[1]*dxinv[1];
+        Real facx = Real(1./6.)*dxinv[0]*dxinv[0];
+        Real facy = Real(1./6.)*dxinv[1]*dxinv[1];
         Real y   = x(i-1,j-1,k)*(facx*sx(i-1,j-1,k)+facy*sy(i-1,j-1,k))
                +   x(i+1,j-1,k)*(facx*sx(i  ,j-1,k)+facy*sy(i  ,j-1,k))
                +   x(i-1,j+1,k)*(facx*sx(i-1,j  ,k)+facy*sy(i-1,j  ,k))
                +   x(i+1,j+1,k)*(facx*sx(i  ,j  ,k)+facy*sy(i  ,j  ,k))
-               +   x(i-1,j,k)*(2.0*facx*(sx(i-1,j-1,k)+sx(i-1,j,k))
-                             -     facy*(sy(i-1,j-1,k)+sx(i-1,j,k)))
-               +   x(i+1,j,k)*(2.0*facx*(sx(i  ,j-1,k)+sx(i  ,j,k))
-                             -     facy*(sy(i  ,j-1,k)+sx(i  ,j,k)))
+               +   x(i-1,j,k)*(Real(2.0)*facx*(sx(i-1,j-1,k)+sx(i-1,j,k))
+                                   -     facy*(sy(i-1,j-1,k)+sx(i-1,j,k)))
+               +   x(i+1,j,k)*(Real(2.0)*facx*(sx(i  ,j-1,k)+sx(i  ,j,k))
+                                   -     facy*(sy(i  ,j-1,k)+sx(i  ,j,k)))
                +   x(i,j-1,k)*(   -facx*(sx(i-1,j-1,k)+sx(i,j-1,k))
-                              +2.0*facy*(sy(i-1,j-1,k)+sy(i,j-1,k)))
+                        +Real(2.0)*facy*(sy(i-1,j-1,k)+sy(i,j-1,k)))
                +   x(i,j+1,k)*(   -facx*(sx(i-1,j  ,k)+sx(i,j  ,k))
-                              +2.0*facy*(sy(i-1,j  ,k)+sy(i,j  ,k)))
-               +   x(i,j,k)*(-2.0)*(facx*(sx(i-1,j-1,k)+sx(i,j-1,k)+sx(i-1,j,k)+sx(i,j,k))
-                                   +facy*(sy(i-1,j-1,k)+sy(i,j-1,k)+sy(i-1,j,k)+sy(i,j,k)));
+                        +Real(2.0)*facy*(sy(i-1,j  ,k)+sy(i,j  ,k)))
+               +   x(i,j,k)*(-Real(2.0))*(facx*(sx(i-1,j-1,k)+sx(i,j-1,k)+sx(i-1,j,k)+sx(i,j,k))
+                                         +facy*(sy(i-1,j-1,k)+sy(i,j-1,k)+sy(i-1,j,k)+sy(i,j,k)));
         if (is_rz) {
             Real fp = facy / static_cast<Real>(2*i+1);
             Real fm = facy / static_cast<Real>(2*i-1);
@@ -332,11 +332,11 @@ Real mlndlap_adotx_aa (int i, int j, int k, Array4<Real const> const& x,
     if (msk(i,j,k)) {
         return Real(0.0);
     } else {
-        Real facx = (1.0/6.0)*dxinv[0]*dxinv[0];
-        Real facy = (1.0/6.0)*dxinv[1]*dxinv[1];
+        Real facx = Real(1.0/6.0)*dxinv[0]*dxinv[0];
+        Real facy = Real(1.0/6.0)*dxinv[1]*dxinv[1];
         Real fxy = facx + facy;
-        Real f2xmy = 2.0*facx - facy;
-        Real fmx2y = 2.0*facy - facx;
+        Real f2xmy = Real(2.0)*facx - facy;
+        Real fmx2y = Real(2.0)*facy - facx;
         Real y   = x(i-1,j-1,k)*fxy*sig(i-1,j-1,k)
                +   x(i+1,j-1,k)*fxy*sig(i  ,j-1,k)
                +   x(i-1,j+1,k)*fxy*sig(i-1,j  ,k)
@@ -345,8 +345,8 @@ Real mlndlap_adotx_aa (int i, int j, int k, Array4<Real const> const& x,
                +   x(i+1,j,k)*f2xmy*(sig(i  ,j-1,k)+sig(i  ,j,k))
                +   x(i,j-1,k)*fmx2y*(sig(i-1,j-1,k)+sig(i,j-1,k))
                +   x(i,j+1,k)*fmx2y*(sig(i-1,j  ,k)+sig(i,j  ,k))
-               +   x(i,j,k)*(-2.0)*fxy*(sig(i-1,j-1,k)+sig(i,j-1,k)
-                                        +sig(i-1,j,k)+sig(i,j,k));
+               +   x(i,j,k)*(-Real(2.0))*fxy*(sig(i-1,j-1,k)+sig(i,j-1,k)
+                                             +sig(i-1,j,k)+sig(i,j,k));
         if (is_rz) {
             Real fp = facy / static_cast<Real>(2*i+1);
             Real fm = facy / static_cast<Real>(2*i-1);
@@ -365,11 +365,11 @@ Real mlndlap_adotx_c (int i, int j, int k, Array4<Real const> const& x,
     if (msk(i,j,k)) {
         return Real(0.0);
     } else {
-        Real facx = (1.0/6.0)*dxinv[0]*dxinv[0];
-        Real facy = (1.0/6.0)*dxinv[1]*dxinv[1];
+        Real facx = Real(1.0/6.0)*dxinv[0]*dxinv[0];
+        Real facy = Real(1.0/6.0)*dxinv[1]*dxinv[1];
         Real fxy = facx + facy;
-        Real f2xmy = 2.0*facx - facy;
-        Real fmx2y = 2.0*facy - facx;
+        Real f2xmy = Real(2.0)*facx - facy;
+        Real fmx2y = Real(2.0)*facy - facx;
         Real y  = (x(i-1,j-1,k)*fxy
                +   x(i+1,j-1,k)*fxy
                +   x(i-1,j+1,k)*fxy
@@ -378,7 +378,7 @@ Real mlndlap_adotx_c (int i, int j, int k, Array4<Real const> const& x,
                +   x(i+1,j,k)*f2xmy*Real(2.)
                +   x(i,j-1,k)*fmx2y*Real(2.)
                +   x(i,j+1,k)*fmx2y*Real(2.)
-               +   x(i,j,k)*(-2.0)*fxy*Real(4.));
+               +   x(i,j,k)*(-Real(2.0))*fxy*Real(4.));
         if (is_rz) {
             Real fp = facy / static_cast<Real>(2*i+1);
             Real fm = facy / static_cast<Real>(2*i-1);
@@ -394,14 +394,14 @@ void mlndlap_normalize_ha (Box const& bx, Array4<Real> const& x, Array4<Real con
                            Array4<Real const> const& sy, Array4<int const> const& msk,
                            GpuArray<Real,AMREX_SPACEDIM> const& dxinv) noexcept
 {
-    Real facx = (1.0/6.0)*dxinv[0]*dxinv[0];
-    Real facy = (1.0/6.0)*dxinv[1]*dxinv[1];
+    Real facx = Real(1.0/6.0)*dxinv[0]*dxinv[0];
+    Real facy = Real(1.0/6.0)*dxinv[1]*dxinv[1];
 
     amrex::LoopConcurrent(bx, [=] (int i, int j, int k) noexcept
     {
         if (!msk(i,j,k)) {
-            x(i,j,k) /= (-2.0)*(facx*(sx(i-1,j-1,k)+sx(i,j-1,k)+sx(i-1,j,k)+sx(i,j,k))
-                               +facy*(sy(i-1,j-1,k)+sy(i,j-1,k)+sy(i-1,j,k)+sy(i,j,k)));
+            x(i,j,k) /= (-Real(2.0))*(facx*(sx(i-1,j-1,k)+sx(i,j-1,k)+sx(i-1,j,k)+sx(i,j,k))
+                                     +facy*(sy(i-1,j-1,k)+sy(i,j-1,k)+sy(i-1,j,k)+sy(i,j,k)));
         }
     });
 }
@@ -410,14 +410,14 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 void mlndlap_normalize_aa (Box const& bx, Array4<Real> const& x, Array4<Real const> const& sig,
                            Array4<int const> const& msk, GpuArray<Real,AMREX_SPACEDIM> const& dxinv) noexcept
 {
-    Real facx = (1.0/6.0)*dxinv[0]*dxinv[0];
-    Real facy = (1.0/6.0)*dxinv[1]*dxinv[1];
+    Real facx = Real(1.0/6.0)*dxinv[0]*dxinv[0];
+    Real facy = Real(1.0/6.0)*dxinv[1]*dxinv[1];
     Real fxy = facx + facy;
 
     amrex::LoopConcurrent(bx, [=] (int i, int j, int k) noexcept
     {
         if (!msk(i,j,k)) {
-            x(i,j,k) /= (-2.0)*fxy*(sig(i-1,j-1,k)+sig(i,j-1,k)+sig(i-1,j,k)+sig(i,j,k));
+            x(i,j,k) /= (-Real(2.0))*fxy*(sig(i-1,j-1,k)+sig(i,j-1,k)+sig(i-1,j,k)+sig(i,j,k));
         }
     });
 }
@@ -428,8 +428,8 @@ void mlndlap_jacobi_ha (int i, int j, int k, Array4<Real> const& sol, Real Ax,
                         Array4<Real const> const& sy, Array4<int const> const& msk,
                         GpuArray<Real,AMREX_SPACEDIM> const& dxinv) noexcept
 {
-    Real facx = -Real(2.0 * (1.0/6.0))*dxinv[0]*dxinv[0];
-    Real facy = -Real(2.0 * (1.0/6.0))*dxinv[1]*dxinv[1];
+    Real facx = -Real(2.0/6.0)*dxinv[0]*dxinv[0];
+    Real facy = -Real(2.0/6.0)*dxinv[1]*dxinv[1];
 
     if (msk(i,j,k)) {
         sol(i,j,k) = Real(0.0);
@@ -446,8 +446,8 @@ void mlndlap_jacobi_ha (Box const& bx, Array4<Real> const& sol, Array4<Real cons
                         Array4<Real const> const& sy, Array4<int const> const& msk,
                         GpuArray<Real,AMREX_SPACEDIM> const& dxinv) noexcept
 {
-    Real facx = -Real(2.0 * (1.0/6.0))*dxinv[0]*dxinv[0];
-    Real facy = -Real(2.0 * (1.0/6.0))*dxinv[1]*dxinv[1];
+    Real facx = -Real(2.0/6.0)*dxinv[0]*dxinv[0];
+    Real facy = -Real(2.0/6.0)*dxinv[1]*dxinv[1];
 
     amrex::LoopConcurrent(bx, [=] (int i, int j, int k) noexcept
     {
@@ -466,7 +466,7 @@ void mlndlap_jacobi_aa (int i, int j, int k, Array4<Real> const& sol, Real Ax,
                         Array4<Real const> const& rhs, Array4<Real const> const& sig,
                         Array4<int const> const& msk, GpuArray<Real,AMREX_SPACEDIM> const& dxinv) noexcept
 {
-    Real fac = -Real(2.0 * (1.0/6.0))*(dxinv[0]*dxinv[0] + dxinv[1]*dxinv[1]);
+    Real fac = -Real(2.0/6.0)*(dxinv[0]*dxinv[0] + dxinv[1]*dxinv[1]);
 
     if (msk(i,j,k)) {
         sol(i,j,k) = Real(0.0);
@@ -481,7 +481,7 @@ void mlndlap_jacobi_c (int i, int j, int k, Array4<Real> const& sol, Real Ax,
                        Array4<Real const> const& rhs, Real sig,
                        Array4<int const> const& msk, GpuArray<Real,AMREX_SPACEDIM> const& dxinv) noexcept
 {
-    Real fac = -Real(2.0 * (1.0/6.0))*(dxinv[0]*dxinv[0] + dxinv[1]*dxinv[1]);
+    Real fac = -Real(2.0/6.0)*(dxinv[0]*dxinv[0] + dxinv[1]*dxinv[1]);
 
     if (msk(i,j,k)) {
         sol(i,j,k) = Real(0.0);
@@ -496,7 +496,7 @@ void mlndlap_jacobi_aa (Box const& bx, Array4<Real> const& sol, Array4<Real cons
                         Array4<Real const> const& rhs, Array4<Real const> const& sig,
                         Array4<int const> const& msk, GpuArray<Real,AMREX_SPACEDIM> const& dxinv) noexcept
 {
-    Real fac = -Real(2.0 * (1.0/6.0))*(dxinv[0]*dxinv[0] + dxinv[1]*dxinv[1]);
+    Real fac = -Real(2.0/6.0)*(dxinv[0]*dxinv[0] + dxinv[1]*dxinv[1]);
 
     amrex::LoopConcurrent(bx, [=] (int i, int j, int k) noexcept
     {
@@ -514,7 +514,7 @@ void mlndlap_jacobi_c (Box const& bx, Array4<Real> const& sol, Array4<Real const
                        Array4<Real const> const& rhs, Real sig,
                        Array4<int const> const& msk, GpuArray<Real,AMREX_SPACEDIM> const& dxinv) noexcept
 {
-    Real fac = -Real(2.0 * (1.0/6.0))*(dxinv[0]*dxinv[0] + dxinv[1]*dxinv[1]);
+    Real fac = -Real(2.0/6.0)*(dxinv[0]*dxinv[0] + dxinv[1]*dxinv[1]);
 
     amrex::LoopConcurrent(bx, [=] (int i, int j, int k) noexcept
     {
@@ -581,18 +581,18 @@ void mlndlap_gauss_seidel_aa (Box const& bx, Array4<Real> const& sol,
                               GpuArray<Real,AMREX_SPACEDIM> const& dxinv,
                               bool is_rz) noexcept
 {
-    Real facx = (1.0/6.0)*dxinv[0]*dxinv[0];
-    Real facy = (1.0/6.0)*dxinv[1]*dxinv[1];
+    Real facx = Real(1.0/6.0)*dxinv[0]*dxinv[0];
+    Real facy = Real(1.0/6.0)*dxinv[1]*dxinv[1];
     Real fxy = facx + facy;
-    Real f2xmy = 2.0*facx - facy;
-    Real fmx2y = 2.0*facy - facx;
+    Real f2xmy = Real(2.0)*facx - facy;
+    Real fmx2y = Real(2.0)*facy - facx;
 
     amrex::Loop(bx, [=] (int i, int j, int k) noexcept
     {
         if (msk(i,j,k)) {
-            sol(i,j,k) = 0.0;
+            sol(i,j,k) = Real(0.0);
         } else {
-            Real s0 = (-2.0)*fxy*(sig(i-1,j-1,k)+sig(i,j-1,k)+sig(i-1,j,k)+sig(i,j,k));
+            Real s0 = (-Real(2.0))*fxy*(sig(i-1,j-1,k)+sig(i,j-1,k)+sig(i-1,j,k)+sig(i,j,k));
             Real Ax =   sol(i-1,j-1,k)*fxy*sig(i-1,j-1,k)
                       + sol(i+1,j-1,k)*fxy*sig(i  ,j-1,k)
                       + sol(i-1,j+1,k)*fxy*sig(i-1,j  ,k)
@@ -625,18 +625,18 @@ void mlndlap_gauss_seidel_c (Box const& bx, Array4<Real> const& sol,
                              GpuArray<Real,AMREX_SPACEDIM> const& dxinv,
                              bool is_rz) noexcept
 {
-    Real facx = (1.0/6.0)*dxinv[0]*dxinv[0];
-    Real facy = (1.0/6.0)*dxinv[1]*dxinv[1];
+    Real facx = Real(1.0/6.0)*dxinv[0]*dxinv[0];
+    Real facy = Real(1.0/6.0)*dxinv[1]*dxinv[1];
     Real fxy = facx + facy;
-    Real f2xmy = 2.0*facx - facy;
-    Real fmx2y = 2.0*facy - facx;
+    Real f2xmy = Real(2.0)*facx - facy;
+    Real fmx2y = Real(2.0)*facy - facx;
 
     amrex::Loop(bx, [=] (int i, int j, int k) noexcept
     {
         if (msk(i,j,k)) {
-            sol(i,j,k) = 0.0;
+            sol(i,j,k) = Real(0.0);
         } else {
-            Real s0 = (-2.0)*fxy*Real(4.);
+            Real s0 = (-Real(2.0))*fxy*Real(4.);
             Real Ax =   sol(i-1,j-1,k)*fxy
                       + sol(i+1,j-1,k)*fxy
                       + sol(i-1,j+1,k)*fxy
@@ -688,11 +688,11 @@ void mlndlap_gauss_seidel_with_line_solve_aa (Box const& bx, Array4<Real> const&
                               GpuArray<Real,AMREX_SPACEDIM> const& dxinv,
                               bool is_rz) noexcept
 {
-    Real facx = (1.0/6.0)*dxinv[0]*dxinv[0];
-    Real facy = (1.0/6.0)*dxinv[1]*dxinv[1];
+    Real facx = Real(1.0/6.0)*dxinv[0]*dxinv[0];
+    Real facy = Real(1.0/6.0)*dxinv[1]*dxinv[1];
     Real fxy = facx + facy;
-    Real f2xmy = 2.0*facx - facy;
-    Real fmx2y = 2.0*facy - facx;
+    Real f2xmy = Real(2.0)*facx - facy;
+    Real fmx2y = Real(2.0)*facy - facx;
 
     if (is_rz) {
 	amrex::Abort("mlndlap_gauss_seidel_with_line_solve_aa is not implemented in r-z 2D ");
@@ -731,7 +731,7 @@ void mlndlap_gauss_seidel_with_line_solve_aa (Box const& bx, Array4<Real> const&
                 }
                 else
                 {
-                    Real s0 = (-2.0)*fxy*(sig(i-1,j-1,k)+sig(i,j-1,k)+sig(i-1,j,k)+sig(i,j,k));
+                    Real s0 = (-Real(2.0))*fxy*(sig(i-1,j-1,k)+sig(i,j-1,k)+sig(i-1,j,k)+sig(i,j,k));
 
                     Real Ax = sol(i-1,j-1,k)*fxy*sig(i-1,j-1,k)
                             + sol(i+1,j-1,k)*fxy*sig(i  ,j-1,k)
@@ -768,7 +768,7 @@ void mlndlap_gauss_seidel_with_line_solve_aa (Box const& bx, Array4<Real> const&
                 }
                 else
                 {
-                    Real s0 = (-2.0)*fxy*(sig(i-1,j-1,k)+sig(i,j-1,k)+sig(i-1,j,k)+sig(i,j,k));
+                    Real s0 = (-Real(2.0))*fxy*(sig(i-1,j-1,k)+sig(i,j-1,k)+sig(i-1,j,k)+sig(i,j,k));
 
                     Real Ax = sol(i-1,j-1,k)*fxy*sig(i-1,j-1,k)
                             + sol(i+1,j-1,k)*fxy*sig(i  ,j-1,k)
@@ -810,11 +810,11 @@ void mlndlap_restriction (int i, int j, int k, Array4<Real> const& crse,
     int jj = j*2;
     int kk = 0;
     if (msk(ii,jj,kk)) {
-        crse(i,j,k) = 0.0;
+        crse(i,j,k) = Real(0.0);
     } else {
-        crse(i,j,k) = (1./16.)*(fine(ii-1,jj-1,kk) + 2.*fine(ii  ,jj-1,kk) +    fine(ii+1,jj-1,kk)
-                           + 2.*fine(ii-1,jj  ,kk) + 4.*fine(ii  ,jj  ,kk) + 2.*fine(ii+1,jj  ,kk)
-                              + fine(ii-1,jj+1,kk) + 2.*fine(ii  ,jj+1,kk) +    fine(ii+1,jj+1,kk));
+        crse(i,j,k) = Real(1./16.)*(fine(ii-1,jj-1,kk) + Real(2.)*fine(ii  ,jj-1,kk) +          fine(ii+1,jj-1,kk)
+                         + Real(2.)*fine(ii-1,jj  ,kk) + Real(4.)*fine(ii  ,jj  ,kk) + Real(2.)*fine(ii+1,jj  ,kk)
+                                  + fine(ii-1,jj+1,kk) + Real(2.)*fine(ii  ,jj+1,kk) +          fine(ii+1,jj+1,kk));
     }
 }
 
@@ -827,17 +827,17 @@ void mlndlap_semi_restriction (int i, int j, int k, Array4<Real> const& crse,
         int ii = i*2;
         int jj = j;
         if (msk(ii,jj,kk)) {
-            crse(i,j,k) = 0.0;
+            crse(i,j,k) = Real(0.0);
         } else {
-            crse(i,j,k) = (1./4.)*(fine(ii-1,jj,kk) + 2.*fine(ii,jj,kk) + fine(ii+1,jj,kk));
+            crse(i,j,k) = Real(1./4.)*(fine(ii-1,jj,kk) + Real(2.)*fine(ii,jj,kk) + fine(ii+1,jj,kk));
         }
     } else if (idir == 0) {
         int ii = i;
         int jj = j*2;
         if (msk(ii,jj,kk)) {
-            crse(i,j,k) = 0.0;
+            crse(i,j,k) = Real(0.0);
         } else {
-            crse(i,j,k) = (1./4.)*(fine(ii,jj-1,kk) + 2.*fine(ii,jj,kk) + fine(ii,jj+1,kk));
+            crse(i,j,k) = Real(1./4.)*(fine(ii,jj-1,kk) + Real(2.)*fine(ii,jj,kk) + fine(ii,jj+1,kk));
         }
     }
 }
@@ -1026,31 +1026,31 @@ void mlndlap_divu (int i, int j, int k, Array4<Real> const& rhs, Array4<Real con
                    GpuArray<LinOpBCType, AMREX_SPACEDIM> const& bchi,
                    bool is_rz) noexcept
 {
-    Real facx = 0.5*dxinv[0];
-    Real facy = 0.5*dxinv[1];
+    Real facx = Real(0.5)*dxinv[0];
+    Real facy = Real(0.5)*dxinv[1];
 
     const auto domlo = amrex::lbound(nodal_domain);
     const auto domhi = amrex::ubound(nodal_domain);
 
     if (msk(i,j,k)) {
-        rhs(i,j,k) = 0.0;
+        rhs(i,j,k) = Real(0.0);
     } else {
 
-        Real zero_ilo = 1.0;
-        Real zero_ihi = 1.0;
-        Real zero_jlo = 1.0;
-        Real zero_jhi = 1.0;
+        Real zero_ilo = Real(1.0);
+        Real zero_ihi = Real(1.0);
+        Real zero_jlo = Real(1.0);
+        Real zero_jhi = Real(1.0);
 
         // The nodal divergence operator should not see the tangential velocity
         //     at an inflow face
         if ((bclo[0] == LinOpBCType::Neumann || bclo[0] == LinOpBCType::inflow)
-            && i == domlo.x) zero_ilo = 0.0;
+            && i == domlo.x) zero_ilo = Real(0.0);
         if ((bchi[0] == LinOpBCType::Neumann || bchi[0] == LinOpBCType::inflow)
-            && i == domhi.x) zero_ihi = 0.0;
+            && i == domhi.x) zero_ihi = Real(0.0);
         if ((bclo[1] == LinOpBCType::Neumann || bclo[1] == LinOpBCType::inflow)
-            && j == domlo.y) zero_jlo = 0.0;
+            && j == domlo.y) zero_jlo = Real(0.0);
         if ((bchi[1] == LinOpBCType::Neumann || bchi[1] == LinOpBCType::inflow)
-            && j == domhi.y) zero_jhi = 0.0; 
+            && j == domhi.y) zero_jhi = Real(0.0);
 
         rhs(i,j,k) = facx*(-vel(i-1,j-1,k,0)*zero_jlo + vel(i,j-1,k,0)*zero_jlo
                            -vel(i-1,j  ,k,0)*zero_jhi + vel(i,j  ,k,0)*zero_jhi)
@@ -1072,9 +1072,9 @@ Real mlndlap_rhcc (int i, int j, int k, Array4<Real const> const& rhcc,
 {
     Real r;
     if (msk(i,j,k)) {
-        r = 0.0;
+        r = Real(0.0);
     } else {
-        r = 0.25 * (rhcc(i-1,j-1,k)+rhcc(i,j-1,k)+rhcc(i-1,j,k)+rhcc(i,j,k));
+        r = Real(0.25) * (rhcc(i-1,j-1,k)+rhcc(i,j-1,k)+rhcc(i-1,j,k)+rhcc(i,j,k));
     }
     return r;
 }
@@ -1084,8 +1084,8 @@ void mlndlap_mknewu (int i, int j, int k, Array4<Real> const& u, Array4<Real con
                      Array4<Real const> const& sig,  GpuArray<Real,AMREX_SPACEDIM> const& dxinv,
                      bool is_rz) noexcept
 {
-    Real facx = 0.5*dxinv[0];
-    Real facy = 0.5*dxinv[1];
+    Real facx = Real(0.5)*dxinv[0];
+    Real facy = Real(0.5)*dxinv[1];
     u(i,j,k,0) -= sig(i,j,k)*facx*(-p(i,j,k)+p(i+1,j,k)-p(i,j+1,k)+p(i+1,j+1,k));
     u(i,j,k,1) -= sig(i,j,k)*facy*(-p(i,j,k)-p(i+1,j,k)+p(i,j+1,k)+p(i+1,j+1,k));
     if (is_rz) {
@@ -1099,8 +1099,8 @@ void mlndlap_mknewu_c (int i, int j, int k, Array4<Real> const& u, Array4<Real c
                        Real sig,  GpuArray<Real,AMREX_SPACEDIM> const& dxinv,
                        bool is_rz) noexcept
 {
-    Real facx = 0.5*dxinv[0];
-    Real facy = 0.5*dxinv[1];
+    Real facx = Real(0.5)*dxinv[0];
+    Real facy = Real(0.5)*dxinv[1];
     u(i,j,k,0) -= sig*facx*(-p(i,j,k)+p(i+1,j,k)-p(i,j+1,k)+p(i+1,j+1,k));
     u(i,j,k,1) -= sig*facy*(-p(i,j,k)-p(i+1,j,k)+p(i,j+1,k)+p(i+1,j+1,k));
     if (is_rz) {
@@ -1124,21 +1124,21 @@ void mlndlap_divu_compute_fine_contrib (int i, int j, int, Box const& fvbx,
     IntVect iv(i,j);
     if (fvbx.contains(iv) && !fvbx.strictly_contains(iv))
     {
-        Real zero_ilo = 1.0;
-        Real zero_ihi = 1.0;
-        Real zero_jlo = 1.0;
-        Real zero_jhi = 1.0;
+        Real zero_ilo = Real(1.0);
+        Real zero_ihi = Real(1.0);
+        Real zero_jlo = Real(1.0);
+        Real zero_jhi = Real(1.0);
 
         // The nodal divergence operator should not see the tangential velocity
         //     at an inflow face
         if ((bclo[0] == LinOpBCType::Neumann || bclo[0] == LinOpBCType::inflow)
-            && i == domlo.x) zero_ilo = 0.0;
+            && i == domlo.x) zero_ilo = Real(0.0);
         if ((bchi[0] == LinOpBCType::Neumann || bchi[0] == LinOpBCType::inflow)
-            && i == domhi.x) zero_ihi = 0.0;
+            && i == domhi.x) zero_ihi = Real(0.0);
         if ((bclo[1] == LinOpBCType::Neumann || bclo[1] == LinOpBCType::inflow)
-            && j == domlo.y) zero_jlo = 0.0;
+            && j == domlo.y) zero_jlo = Real(0.0);
         if ((bchi[1] == LinOpBCType::Neumann || bchi[1] == LinOpBCType::inflow)
-            && j == domhi.y) zero_jhi = 0.0; 
+            && j == domhi.y) zero_jhi = Real(0.0);
 
         Real facx = Real(0.5)*dxinv[0];
         Real facy = Real(0.5)*dxinv[1];
@@ -1538,11 +1538,11 @@ void mlndlap_set_stencil (Box const& bx, Array4<Real> const& sten,
                           Array4<Real const> const& sigma,
                           GpuArray<Real,AMREX_SPACEDIM> const& dxinv) noexcept
 {
-    Real facx = (1.0/6.0)*dxinv[0]*dxinv[0];
-    Real facy = (1.0/6.0)*dxinv[1]*dxinv[1];
+    Real facx = Real(1.0/6.0)*dxinv[0]*dxinv[0];
+    Real facy = Real(1.0/6.0)*dxinv[1]*dxinv[1];
     Real fxy = facx + facy;
-    Real f2xmy = 2.0*facx - facy;
-    Real fmx2y = 2.0*facy - facx;
+    Real f2xmy = Real(2.0)*facx - facy;
+    Real fmx2y = Real(2.0)*facy - facx;
 
     amrex::LoopConcurrent(bx, [=] (int i, int j, int k) noexcept
     {
@@ -1559,10 +1559,10 @@ void mlndlap_set_stencil_s0 (int i, int j, int k, Array4<Real> const& sten) noex
                     + sten(i  ,j-1,k,2) + sten(i  ,j  ,k,2)
                     + sten(i-1,j-1,k,3) + sten(i  ,j-1,k,3)
                     + sten(i-1,j  ,k,3) + sten(i  ,j  ,k,3));
-    sten(i,j,k,4) = 1.0 / (amrex::Math::abs(sten(i-1,j  ,k,1)) + amrex::Math::abs(sten(i,j  ,k,1))
-                         + amrex::Math::abs(sten(i  ,j-1,k,2)) + amrex::Math::abs(sten(i,j  ,k,2))
-                         + amrex::Math::abs(sten(i-1,j-1,k,3)) + amrex::Math::abs(sten(i,j-1,k,3))
-                         + amrex::Math::abs(sten(i-1,j  ,k,3)) + amrex::Math::abs(sten(i,j  ,k,3)) + eps);
+    sten(i,j,k,4) = Real(1.0) / (amrex::Math::abs(sten(i-1,j  ,k,1)) + amrex::Math::abs(sten(i,j  ,k,1))
+                               + amrex::Math::abs(sten(i  ,j-1,k,2)) + amrex::Math::abs(sten(i,j  ,k,2))
+                               + amrex::Math::abs(sten(i-1,j-1,k,3)) + amrex::Math::abs(sten(i,j-1,k,3))
+                               + amrex::Math::abs(sten(i-1,j  ,k,3)) + amrex::Math::abs(sten(i,j  ,k,3)) + eps);
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
@@ -1725,11 +1725,11 @@ void mlndlap_stencil_rap (int i, int j, int, Array4<Real> const& csten,
         +     A00(ii+1,jj+1)*p(-1,1) + Ap0(ii+1,jj+1)*p(0,1);
 
     csten(i,j,k,1) = Real(0.25)*(restrict_from_0m_to(ii,jj)*ap(0,-1)
-                            + restrict_from_pm_to(ii,jj)*ap(1,-1)
-                            + ap(0,0)
-                            + restrict_from_p0_to(ii,jj)*ap(1,0)
-                            + restrict_from_0p_to(ii,jj)*ap(0,1)
-                            + restrict_from_pp_to(ii,jj)*ap(1,1));
+                               + restrict_from_pm_to(ii,jj)*ap(1,-1)
+                               + ap(0,0)
+                               + restrict_from_p0_to(ii,jj)*ap(1,0)
+                               + restrict_from_0p_to(ii,jj)*ap(0,1)
+                               + restrict_from_pp_to(ii,jj)*ap(1,1));
 
     // csten(i,j,k,2)
     p(-1,-1) = interp_from_pp_to(ii-1,jj+1);
@@ -1820,8 +1820,8 @@ void mlndlap_gauss_seidel_sten (Box const& bx, Array4<Real> const& sol,
     amrex::LoopConcurrent(bx, [=] (int i, int j, int k) noexcept
     {
         if (msk(i,j,k)) {
-            sol(i,j,k) = 0.0;
-        } else if (sten(i,j,k,0) != 0.0) {
+            sol(i,j,k) = Real(0.0);
+        } else if (sten(i,j,k,0) != Real(0.0)) {
             Real Ax = sol(i-1,j-1,k)*sten(i-1,j-1,k,3)
                 +     sol(i  ,j-1,k)*sten(i  ,j-1,k,2)
                 +     sol(i+1,j-1,k)*sten(i  ,j-1,k,3)
@@ -1841,7 +1841,7 @@ void mlndlap_interpadd_rap (int i, int j, int, Array4<Real> const& fine,
                             Array4<Real const> const& crse, Array4<Real const> const& sten,
                             Array4<int const> const& msk) noexcept
 {
-    if (!msk(i,j,0) && sten(i,j,0,0) != 0.0) {
+    if (!msk(i,j,0) && sten(i,j,0,0) != Real(0.0)) {
         int ic = amrex::coarsen(i,2);
         int jc = amrex::coarsen(j,2);
         bool ieven = ic*2 == i;
@@ -1866,10 +1866,10 @@ void mlndlap_interpadd_rap (int i, int j, int, Array4<Real> const& fine,
                 (amrex::Math::abs(sten(i-1,j-1,0,3))+amrex::Math::abs(sten(i  ,j-1,0,3))+eps);
             Real wyp = amrex::Math::abs(sten(i  ,j  ,0,2)) /
                 (amrex::Math::abs(sten(i-1,j  ,0,3))+amrex::Math::abs(sten(i  ,j  ,0,3))+eps);
-            Real wmm = amrex::Math::abs(sten(i-1,j-1,0,3)) * (1.0 + wxm + wym);
-            Real wpm = amrex::Math::abs(sten(i,j-1,0,3)) * (1.0 + wxp + wym);
-            Real wmp = amrex::Math::abs(sten(i-1,j,0,3)) *(1.0 + wxm + wyp);
-            Real wpp = amrex::Math::abs(sten(i,j,0,3)) * (1.0 + wxp + wyp);
+            Real wmm = amrex::Math::abs(sten(i-1,j-1,0,3)) * (Real(1.0) + wxm + wym);
+            Real wpm = amrex::Math::abs(sten(i,j-1,0,3)) * (Real(1.0) + wxp + wym);
+            Real wmp = amrex::Math::abs(sten(i-1,j,0,3)) *(Real(1.0) + wxm + wyp);
+            Real wpp = amrex::Math::abs(sten(i,j,0,3)) * (Real(1.0) + wxp + wyp);
             fv = (wmm*crse(ic,jc,0) + wpm*crse(ic+1,jc,0)
                   + wmp*crse(ic,jc+1,0) + wpp*crse(ic+1,jc+1,0))
                 / (wmm+wpm+wmp+wpp+eps);
@@ -1887,7 +1887,7 @@ void mlndlap_restriction_rap (int i, int j, int /*k*/, Array4<Real> const& crse,
     int ii = i*2;
     int jj = j*2;
     if (msk(ii,jj,0)) {
-        crse(i,j,0) = 0.0;
+        crse(i,j,0) = Real(0.0);
     } else {
 
         Real cv = fine(ii,jj,0)
@@ -1910,7 +1910,7 @@ void mlndlap_restriction_rap (int i, int j, int /*k*/, Array4<Real> const& crse,
         Real wyp = amrex::Math::abs(sten(ii-1,jj-1,0,2))
             /     (amrex::Math::abs(sten(ii-2,jj-1,0,3))
                   +amrex::Math::abs(sten(ii-1,jj-1,0,3))+eps);
-        Real wpp = amrex::Math::abs(sten(ii-1,jj-1,0,3))*(1.0+wxp+wyp);
+        Real wpp = amrex::Math::abs(sten(ii-1,jj-1,0,3))*(Real(1.0) + wxp + wyp);
         cv +=           wpp*sten(ii-1,jj-1,0,4)*fine(ii-1,jj-1,0);
 
         Real wxm = amrex::Math::abs(sten(ii  ,jj-1,0,1))
@@ -1919,7 +1919,7 @@ void mlndlap_restriction_rap (int i, int j, int /*k*/, Array4<Real> const& crse,
         wyp      = amrex::Math::abs(sten(ii+1,jj-1,0,2))
             /     (amrex::Math::abs(sten(ii  ,jj-1,0,3))
                   +amrex::Math::abs(sten(ii+1,jj-1,0,3))+eps);
-        Real wmp = amrex::Math::abs(sten(ii  ,jj-1,0,3))*(1.0 + wxm + wyp);
+        Real wmp = amrex::Math::abs(sten(ii  ,jj-1,0,3))*(Real(1.0) + wxm + wyp);
         cv +=           wmp*sten(ii+1,jj-1,0,4)*fine(ii+1,jj-1,0);
 
         wxp      = amrex::Math::abs(sten(ii-1,jj+1,0,1))
@@ -1928,7 +1928,7 @@ void mlndlap_restriction_rap (int i, int j, int /*k*/, Array4<Real> const& crse,
         Real wym = amrex::Math::abs(sten(ii-1,jj  ,0,2))
             /     (amrex::Math::abs(sten(ii-2,jj  ,0,3))
                   +amrex::Math::abs(sten(ii-1,jj  ,0,3))+eps);
-        Real wpm = amrex::Math::abs(sten(ii-1,jj  ,0,3)) * (1.0 + wxp + wym);
+        Real wpm = amrex::Math::abs(sten(ii-1,jj  ,0,3)) * (Real(1.0) + wxp + wym);
         cv +=           wpm*sten(ii-1,jj+1,0,4)*fine(ii-1,jj+1,0);
 
         wxm      = amrex::Math::abs(sten(ii  ,jj+1,0,1))
@@ -1937,10 +1937,10 @@ void mlndlap_restriction_rap (int i, int j, int /*k*/, Array4<Real> const& crse,
         wym      = amrex::Math::abs(sten(ii+1,jj  ,0,2))
             /     (amrex::Math::abs(sten(ii  ,jj  ,0,3))
                   +amrex::Math::abs(sten(ii+1,jj  ,0,3))+eps);
-        Real wmm = amrex::Math::abs(sten(ii  ,jj  ,0,3)) * (1.0 + wxm + wym);
+        Real wmm = amrex::Math::abs(sten(ii  ,jj  ,0,3)) * (Real(1.0) + wxm + wym);
         cv +=           wmm*sten(ii+1,jj+1,0,4)*fine(ii+1,jj+1,0);
 
-        crse(i,j,0) = cv * 0.25;
+        crse(i,j,0) = cv * Real(0.25);
     }
 }
 
@@ -2009,21 +2009,21 @@ void mlndlap_divu_eb (int i, int j, int, Array4<Real> const& rhs, Array4<Real co
 
     if (!msk(i,j,0)) {
 
-        Real zero_ilo = 1.0;
-        Real zero_ihi = 1.0;
-        Real zero_jlo = 1.0;
-        Real zero_jhi = 1.0;
+        Real zero_ilo = Real(1.0);
+        Real zero_ihi = Real(1.0);
+        Real zero_jlo = Real(1.0);
+        Real zero_jhi = Real(1.0);
 
         // The nodal divergence operator should not see the tangential velocity
         //     at an inflow face
         if ((bclo[0] == LinOpBCType::Neumann || bclo[0] == LinOpBCType::inflow)
-            && i == domlo.x) zero_ilo = 0.0;
+            && i == domlo.x) zero_ilo = Real(0.0);
         if ((bchi[0] == LinOpBCType::Neumann || bchi[0] == LinOpBCType::inflow)
-            && i == domhi.x) zero_ihi = 0.0;
+            && i == domhi.x) zero_ihi = Real(0.0);
         if ((bclo[1] == LinOpBCType::Neumann || bclo[1] == LinOpBCType::inflow)
-            && j == domlo.y) zero_jlo = 0.0;
+            && j == domlo.y) zero_jlo = Real(0.0);
         if ((bchi[1] == LinOpBCType::Neumann || bchi[1] == LinOpBCType::inflow)
-            && j == domhi.y) zero_jhi = 0.0; 
+            && j == domhi.y) zero_jhi = Real(0.0);
 
         rhs(i,j,0) = facx*(-vel(i-1,j-1,0,0)*(vfrac(i-1,j-1,0)+Real(2.)*intg(i-1,j-1,0,1))*zero_jlo
                            +vel(i  ,j-1,0,0)*(vfrac(i  ,j-1,0)+Real(2.)*intg(i  ,j-1,0,1))*zero_jlo

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLap_3D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLap_3D_K.H
@@ -119,7 +119,7 @@ void mlndlap_set_dot_mask (Box const& bx, Array4<Real> const& dmsk,
     {
         for (int k = lo.z; k <= hi.z; ++k) {
         for (int j = lo.y; j <= hi.y; ++j) {
-            dmsk(lo.x,j,k) *= 0.5;
+            dmsk(lo.x,j,k) *= Real(0.5);
         }}
     }
 
@@ -128,7 +128,7 @@ void mlndlap_set_dot_mask (Box const& bx, Array4<Real> const& dmsk,
     {
         for (int k = lo.z; k <= hi.z; ++k) {
         for (int j = lo.y; j <= hi.y; ++j) {
-            dmsk(hi.x,j,k) *= 0.5;
+            dmsk(hi.x,j,k) *= Real(0.5);
         }}
     }
 
@@ -138,7 +138,7 @@ void mlndlap_set_dot_mask (Box const& bx, Array4<Real> const& dmsk,
         for (int k = lo.z; k <= hi.z; ++k) {
         AMREX_PRAGMA_SIMD
         for (int i = lo.x; i <= hi.x; ++i) {
-            dmsk(i,lo.y,k) *= 0.5;
+            dmsk(i,lo.y,k) *= Real(0.5);
         }}
     }
 
@@ -148,7 +148,7 @@ void mlndlap_set_dot_mask (Box const& bx, Array4<Real> const& dmsk,
         for (int k = lo.z; k <= hi.z; ++k) {
         AMREX_PRAGMA_SIMD
         for (int i = lo.x; i <= hi.x; ++i) {
-            dmsk(i,hi.y,k) *= 0.5;
+            dmsk(i,hi.y,k) *= Real(0.5);
         }}
     }
 
@@ -158,7 +158,7 @@ void mlndlap_set_dot_mask (Box const& bx, Array4<Real> const& dmsk,
         for (int j = lo.y; j <= hi.y; ++j) {
         AMREX_PRAGMA_SIMD
         for (int i = lo.x; i <= hi.x; ++i) {
-            dmsk(i,j,lo.z) *= 0.5;
+            dmsk(i,j,lo.z) *= Real(0.5);
         }}
     }
 
@@ -168,7 +168,7 @@ void mlndlap_set_dot_mask (Box const& bx, Array4<Real> const& dmsk,
         for (int j = lo.y; j <= hi.y; ++j) {
         AMREX_PRAGMA_SIMD
         for (int i = lo.x; i <= hi.x; ++i) {
-            dmsk(i,j,hi.z) *= 0.5;
+            dmsk(i,j,hi.z) *= Real(0.5);
         }}
     }
 }
@@ -188,7 +188,7 @@ void mlndlap_zero_fine (int i, int j, int k, Array4<Real> const& phi,
         msk(i-1,j  ,k  ) == fine_flag &&
         msk(i  ,j  ,k  ) == fine_flag)
     {
-        phi(i,j,k) = 0.0;
+        phi(i,j,k) = Real(0.0);
     }
 }
 
@@ -204,7 +204,7 @@ void mlndlap_avgdown_coeff_x (int i, int j, int k, Array4<Real> const& crse,
               fine(2*i  ,2*j,2*k+1)+fine(2*i  ,2*j+1,2*k+1);
     Real cr = fine(2*i+1,2*j,2*k  )+fine(2*i+1,2*j+1,2*k  )+
               fine(2*i+1,2*j,2*k+1)+fine(2*i+1,2*j+1,2*k+1);
-    crse(i,j,k) = 0.5*cl*cr/(cl+cr);
+    crse(i,j,k) = Real(0.5)*cl*cr/(cl+cr);
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
@@ -215,7 +215,7 @@ void mlndlap_avgdown_coeff_y (int i, int j, int k, Array4<Real> const& crse,
               fine(2*i,2*j  ,2*k+1)+fine(2*i+1,2*j  ,2*k+1);
     Real cr = fine(2*i,2*j+1,2*k  )+fine(2*i+1,2*j+1,2*k  )+
               fine(2*i,2*j+1,2*k+1)+fine(2*i+1,2*j+1,2*k+1);
-    crse(i,j,k) = 0.5*cl*cr/(cl+cr);
+    crse(i,j,k) = Real(0.5)*cl*cr/(cl+cr);
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
@@ -226,7 +226,7 @@ void mlndlap_avgdown_coeff_z (int i, int j, int k, Array4<Real> const& crse,
               fine(2*i,2*j+1,2*k  )+fine(2*i+1,2*j+1,2*k  );
     Real cr = fine(2*i,2*j  ,2*k+1)+fine(2*i+1,2*j  ,2*k+1)+
               fine(2*i,2*j+1,2*k+1)+fine(2*i+1,2*j+1,2*k+1);
-    crse(i,j,k) = 0.5*cl*cr/(cl+cr);
+    crse(i,j,k) = Real(0.5)*cl*cr/(cl+cr);
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
@@ -762,15 +762,15 @@ Real mlndlap_adotx_ha (int i, int j, int k, Array4<Real const> const& x,
     if (msk(i,j,k)) {
         return Real(0.0);
     } else {
-        Real facx = (1./36.)*dxinv[0]*dxinv[0];
-        Real facy = (1./36.)*dxinv[1]*dxinv[1];
-        Real facz = (1./36.)*dxinv[2]*dxinv[2];
-        Real y   = x(i,j,k)*(-4.0)*(facx*(sx(i-1,j-1,k-1)+sx(i,j-1,k-1)+sx(i-1,j,k-1)+sx(i,j,k-1)
-                                         +sx(i-1,j-1,k  )+sx(i,j-1,k  )+sx(i-1,j,k  )+sx(i,j,k  ))
-                                   +facy*(sy(i-1,j-1,k-1)+sy(i,j-1,k-1)+sy(i-1,j,k-1)+sy(i,j,k-1)
-                                         +sy(i-1,j-1,k  )+sy(i,j-1,k  )+sy(i-1,j,k  )+sy(i,j,k  ))
-                                   +facz*(sz(i-1,j-1,k-1)+sz(i,j-1,k-1)+sz(i-1,j,k-1)+sz(i,j,k-1)
-                                         +sz(i-1,j-1,k  )+sz(i,j-1,k  )+sz(i-1,j,k  )+sz(i,j,k  )));
+        Real facx = Real(1./36.)*dxinv[0]*dxinv[0];
+        Real facy = Real(1./36.)*dxinv[1]*dxinv[1];
+        Real facz = Real(1./36.)*dxinv[2]*dxinv[2];
+        Real y   = x(i,j,k)*Real(-4.0)*(facx*(sx(i-1,j-1,k-1)+sx(i,j-1,k-1)+sx(i-1,j,k-1)+sx(i,j,k-1)
+                                             +sx(i-1,j-1,k  )+sx(i,j-1,k  )+sx(i-1,j,k  )+sx(i,j,k  ))
+                                       +facy*(sy(i-1,j-1,k-1)+sy(i,j-1,k-1)+sy(i-1,j,k-1)+sy(i,j,k-1)
+                                             +sy(i-1,j-1,k  )+sy(i,j-1,k  )+sy(i-1,j,k  )+sy(i,j,k  ))
+                                       +facz*(sz(i-1,j-1,k-1)+sz(i,j-1,k-1)+sz(i-1,j,k-1)+sz(i,j,k-1)
+                                             +sz(i-1,j-1,k  )+sz(i,j-1,k  )+sz(i-1,j,k  )+sz(i,j,k  )));
         y        += x(i-1,j-1,k-1)*(facx*sx(i-1,j-1,k-1)
                                    +facy*sy(i-1,j-1,k-1)
                                    +facz*sz(i-1,j-1,k-1))
@@ -795,60 +795,60 @@ Real mlndlap_adotx_ha (int i, int j, int k, Array4<Real const> const& x,
                   + x(i+1,j+1,k+1)*(facx*sx(i  ,j  ,k  )
                                    +facy*sy(i  ,j  ,k  )
                                    +facz*sz(i  ,j  ,k  ));
-        y        += x(i  ,j-1,k-1)*(    -facx*(sx(i-1,j-1,k-1)+sx(i,j-1,k-1))
-                                    +2.0*facy*(sy(i-1,j-1,k-1)+sy(i,j-1,k-1))
-                                    +2.0*facz*(sz(i-1,j-1,k-1)+sz(i,j-1,k-1)))
-                  + x(i  ,j+1,k-1)*(    -facx*(sx(i-1,j  ,k-1)+sx(i,j  ,k-1))
-                                    +2.0*facy*(sy(i-1,j  ,k-1)+sy(i,j  ,k-1))
-                                    +2.0*facz*(sz(i-1,j  ,k-1)+sz(i,j  ,k-1)))
-                  + x(i  ,j-1,k+1)*(    -facx*(sx(i-1,j-1,k  )+sx(i,j-1,k  ))
-                                    +2.0*facy*(sy(i-1,j-1,k  )+sy(i,j-1,k  ))
-                                    +2.0*facz*(sz(i-1,j-1,k  )+sz(i,j-1,k  )))
-                  + x(i  ,j+1,k+1)*(    -facx*(sx(i-1,j  ,k  )+sx(i,j  ,k  ))
-                                    +2.0*facy*(sy(i-1,j  ,k  )+sy(i,j  ,k  ))
-                                    +2.0*facz*(sz(i-1,j  ,k  )+sz(i,j  ,k  )))
-                  + x(i-1,j  ,k-1)*( 2.0*facx*(sx(i-1,j-1,k-1)+sx(i-1,j,k-1))
-                                        -facy*(sy(i-1,j-1,k-1)+sy(i-1,j,k-1))
-                                    +2.0*facz*(sz(i-1,j-1,k-1)+sz(i-1,j,k-1)))
-                  + x(i+1,j  ,k-1)*( 2.0*facx*(sx(i  ,j-1,k-1)+sx(i  ,j,k-1))
-                                        -facy*(sy(i  ,j-1,k-1)+sy(i  ,j,k-1))
-                                    +2.0*facz*(sz(i  ,j-1,k-1)+sz(i  ,j,k-1)))
-                  + x(i-1,j  ,k+1)*( 2.0*facx*(sx(i-1,j-1,k  )+sx(i-1,j,k  ))
-                                        -facy*(sy(i-1,j-1,k  )+sy(i-1,j,k  ))
-                                    +2.0*facz*(sz(i-1,j-1,k  )+sz(i-1,j,k  )))
-                  + x(i+1,j  ,k+1)*( 2.0*facx*(sx(i  ,j-1,k  )+sx(i  ,j,k  ))
-                                        -facy*(sy(i  ,j-1,k  )+sy(i  ,j,k  ))
-                                    +2.0*facz*(sz(i  ,j-1,k  )+sz(i  ,j,k  )))
-                  + x(i-1,j-1,k  )*( 2.0*facx*(sx(i-1,j-1,k-1)+sx(i-1,j-1,k))
-                                    +2.0*facy*(sy(i-1,j-1,k-1)+sy(i-1,j-1,k))
-                                        -facz*(sz(i-1,j-1,k-1)+sz(i-1,j-1,k)))
-                  + x(i+1,j-1,k  )*( 2.0*facx*(sx(i  ,j-1,k-1)+sx(i  ,j-1,k))
-                                    +2.0*facy*(sy(i  ,j-1,k-1)+sy(i  ,j-1,k))
-                                        -facz*(sz(i  ,j-1,k-1)+sz(i  ,j-1,k)))
-                  + x(i-1,j+1,k  )*( 2.0*facx*(sx(i-1,j  ,k-1)+sx(i-1,j  ,k))
-                                    +2.0*facy*(sy(i-1,j  ,k-1)+sy(i-1,j  ,k))
-                                        -facz*(sz(i-1,j  ,k-1)+sz(i-1,j  ,k)))
-                  + x(i+1,j+1,k  )*( 2.0*facx*(sx(i  ,j  ,k-1)+sx(i  ,j  ,k))
-                                    +2.0*facy*(sy(i  ,j  ,k-1)+sy(i  ,j  ,k))
-                                        -facz*(sz(i  ,j  ,k-1)+sz(i  ,j  ,k)));
-        y            += 2.0*x(i-1,j,k)*( 2.0*facx*(sx(i-1,j-1,k-1)+sx(i-1,j,k-1)+sx(i-1,j-1,k)+sx(i-1,j,k))
-                                            -facy*(sy(i-1,j-1,k-1)+sy(i-1,j,k-1)+sy(i-1,j-1,k)+sy(i-1,j,k))
-                                            -facz*(sz(i-1,j-1,k-1)+sz(i-1,j,k-1)+sz(i-1,j-1,k)+sz(i-1,j,k)))
-                      + 2.0*x(i+1,j,k)*( 2.0*facx*(sx(i  ,j-1,k-1)+sx(i  ,j,k-1)+sx(i  ,j-1,k)+sx(i  ,j,k))
-                                            -facy*(sy(i  ,j-1,k-1)+sy(i  ,j,k-1)+sy(i  ,j-1,k)+sy(i  ,j,k))
-                                            -facz*(sz(i  ,j-1,k-1)+sz(i  ,j,k-1)+sz(i  ,j-1,k)+sz(i  ,j,k)))
-                      + 2.0*x(i,j-1,k)*(    -facx*(sx(i-1,j-1,k-1)+sx(i,j-1,k-1)+sx(i-1,j-1,k)+sx(i,j-1,k))
-                                        +2.0*facy*(sy(i-1,j-1,k-1)+sy(i,j-1,k-1)+sy(i-1,j-1,k)+sy(i,j-1,k))
-                                            -facz*(sz(i-1,j-1,k-1)+sz(i,j-1,k-1)+sz(i-1,j-1,k)+sz(i,j-1,k)))
-                      + 2.0*x(i,j+1,k)*(    -facx*(sx(i-1,j  ,k-1)+sx(i,j  ,k-1)+sx(i-1,j  ,k)+sx(i,j  ,k))
-                                        +2.0*facy*(sy(i-1,j  ,k-1)+sy(i,j  ,k-1)+sy(i-1,j  ,k)+sy(i,j  ,k))
-                                            -facz*(sz(i-1,j  ,k-1)+sz(i,j  ,k-1)+sz(i-1,j  ,k)+sz(i,j  ,k)))
-                      + 2.0*x(i,j,k-1)*(    -facx*(sx(i-1,j-1,k-1)+sx(i,j-1,k-1)+sx(i-1,j,k-1)+sx(i,j,k-1))
-                                            -facy*(sy(i-1,j-1,k-1)+sy(i,j-1,k-1)+sy(i-1,j,k-1)+sy(i,j,k-1))
-                                        +2.0*facz*(sz(i-1,j-1,k-1)+sz(i,j-1,k-1)+sz(i-1,j,k-1)+sz(i,j,k-1)))
-                      + 2.0*x(i,j,k+1)*(    -facx*(sx(i-1,j-1,k  )+sx(i,j-1,k  )+sx(i-1,j,k  )+sx(i,j,k  ))
-                                            -facy*(sy(i-1,j-1,k  )+sy(i,j-1,k  )+sy(i-1,j,k  )+sy(i,j,k  ))
-                                        +2.0*facz*(sz(i-1,j-1,k  )+sz(i,j-1,k  )+sz(i-1,j,k  )+sz(i,j,k  )));
+        y        += x(i  ,j-1,k-1)*(          -facx*(sx(i-1,j-1,k-1)+sx(i,j-1,k-1))
+                                    +Real(2.0)*facy*(sy(i-1,j-1,k-1)+sy(i,j-1,k-1))
+                                    +Real(2.0)*facz*(sz(i-1,j-1,k-1)+sz(i,j-1,k-1)))
+                  + x(i  ,j+1,k-1)*(          -facx*(sx(i-1,j  ,k-1)+sx(i,j  ,k-1))
+                                    +Real(2.0)*facy*(sy(i-1,j  ,k-1)+sy(i,j  ,k-1))
+                                    +Real(2.0)*facz*(sz(i-1,j  ,k-1)+sz(i,j  ,k-1)))
+                  + x(i  ,j-1,k+1)*(          -facx*(sx(i-1,j-1,k  )+sx(i,j-1,k  ))
+                                    +Real(2.0)*facy*(sy(i-1,j-1,k  )+sy(i,j-1,k  ))
+                                    +Real(2.0)*facz*(sz(i-1,j-1,k  )+sz(i,j-1,k  )))
+                  + x(i  ,j+1,k+1)*(          -facx*(sx(i-1,j  ,k  )+sx(i,j  ,k  ))
+                                    +Real(2.0)*facy*(sy(i-1,j  ,k  )+sy(i,j  ,k  ))
+                                    +Real(2.0)*facz*(sz(i-1,j  ,k  )+sz(i,j  ,k  )))
+                  + x(i-1,j  ,k-1)*( Real(2.0)*facx*(sx(i-1,j-1,k-1)+sx(i-1,j,k-1))
+                                              -facy*(sy(i-1,j-1,k-1)+sy(i-1,j,k-1))
+                                    +Real(2.0)*facz*(sz(i-1,j-1,k-1)+sz(i-1,j,k-1)))
+                  + x(i+1,j  ,k-1)*( Real(2.0)*facx*(sx(i  ,j-1,k-1)+sx(i  ,j,k-1))
+                                              -facy*(sy(i  ,j-1,k-1)+sy(i  ,j,k-1))
+                                    +Real(2.0)*facz*(sz(i  ,j-1,k-1)+sz(i  ,j,k-1)))
+                  + x(i-1,j  ,k+1)*( Real(2.0)*facx*(sx(i-1,j-1,k  )+sx(i-1,j,k  ))
+                                              -facy*(sy(i-1,j-1,k  )+sy(i-1,j,k  ))
+                                    +Real(2.0)*facz*(sz(i-1,j-1,k  )+sz(i-1,j,k  )))
+                  + x(i+1,j  ,k+1)*( Real(2.0)*facx*(sx(i  ,j-1,k  )+sx(i  ,j,k  ))
+                                              -facy*(sy(i  ,j-1,k  )+sy(i  ,j,k  ))
+                                    +Real(2.0)*facz*(sz(i  ,j-1,k  )+sz(i  ,j,k  )))
+                  + x(i-1,j-1,k  )*( Real(2.0)*facx*(sx(i-1,j-1,k-1)+sx(i-1,j-1,k))
+                                    +Real(2.0)*facy*(sy(i-1,j-1,k-1)+sy(i-1,j-1,k))
+                                              -facz*(sz(i-1,j-1,k-1)+sz(i-1,j-1,k)))
+                  + x(i+1,j-1,k  )*( Real(2.0)*facx*(sx(i  ,j-1,k-1)+sx(i  ,j-1,k))
+                                    +Real(2.0)*facy*(sy(i  ,j-1,k-1)+sy(i  ,j-1,k))
+                                              -facz*(sz(i  ,j-1,k-1)+sz(i  ,j-1,k)))
+                  + x(i-1,j+1,k  )*( Real(2.0)*facx*(sx(i-1,j  ,k-1)+sx(i-1,j  ,k))
+                                    +Real(2.0)*facy*(sy(i-1,j  ,k-1)+sy(i-1,j  ,k))
+                                              -facz*(sz(i-1,j  ,k-1)+sz(i-1,j  ,k)))
+                  + x(i+1,j+1,k  )*( Real(2.0)*facx*(sx(i  ,j  ,k-1)+sx(i  ,j  ,k))
+                                    +Real(2.0)*facy*(sy(i  ,j  ,k-1)+sy(i  ,j  ,k))
+                                              -facz*(sz(i  ,j  ,k-1)+sz(i  ,j  ,k)));
+        y            += Real(2.0)*x(i-1,j,k)*( Real(2.0)*facx*(sx(i-1,j-1,k-1)+sx(i-1,j,k-1)+sx(i-1,j-1,k)+sx(i-1,j,k))
+                                                        -facy*(sy(i-1,j-1,k-1)+sy(i-1,j,k-1)+sy(i-1,j-1,k)+sy(i-1,j,k))
+                                                        -facz*(sz(i-1,j-1,k-1)+sz(i-1,j,k-1)+sz(i-1,j-1,k)+sz(i-1,j,k)))
+                      + Real(2.0)*x(i+1,j,k)*( Real(2.0)*facx*(sx(i  ,j-1,k-1)+sx(i  ,j,k-1)+sx(i  ,j-1,k)+sx(i  ,j,k))
+                                                        -facy*(sy(i  ,j-1,k-1)+sy(i  ,j,k-1)+sy(i  ,j-1,k)+sy(i  ,j,k))
+                                                        -facz*(sz(i  ,j-1,k-1)+sz(i  ,j,k-1)+sz(i  ,j-1,k)+sz(i  ,j,k)))
+                      + Real(2.0)*x(i,j-1,k)*(    -facx*(sx(i-1,j-1,k-1)+sx(i,j-1,k-1)+sx(i-1,j-1,k)+sx(i,j-1,k))
+                                        +Real(2.0)*facy*(sy(i-1,j-1,k-1)+sy(i,j-1,k-1)+sy(i-1,j-1,k)+sy(i,j-1,k))
+                                                  -facz*(sz(i-1,j-1,k-1)+sz(i,j-1,k-1)+sz(i-1,j-1,k)+sz(i,j-1,k)))
+                      + Real(2.0)*x(i,j+1,k)*(    -facx*(sx(i-1,j  ,k-1)+sx(i,j  ,k-1)+sx(i-1,j  ,k)+sx(i,j  ,k))
+                                        +Real(2.0)*facy*(sy(i-1,j  ,k-1)+sy(i,j  ,k-1)+sy(i-1,j  ,k)+sy(i,j  ,k))
+                                                  -facz*(sz(i-1,j  ,k-1)+sz(i,j  ,k-1)+sz(i-1,j  ,k)+sz(i,j  ,k)))
+                      + Real(2.0)*x(i,j,k-1)*(    -facx*(sx(i-1,j-1,k-1)+sx(i,j-1,k-1)+sx(i-1,j,k-1)+sx(i,j,k-1))
+                                                  -facy*(sy(i-1,j-1,k-1)+sy(i,j-1,k-1)+sy(i-1,j,k-1)+sy(i,j,k-1))
+                                        +Real(2.0)*facz*(sz(i-1,j-1,k-1)+sz(i,j-1,k-1)+sz(i-1,j,k-1)+sz(i,j,k-1)))
+                      + Real(2.0)*x(i,j,k+1)*(    -facx*(sx(i-1,j-1,k  )+sx(i,j-1,k  )+sx(i-1,j,k  )+sx(i,j,k  ))
+                                                  -facy*(sy(i-1,j-1,k  )+sy(i,j-1,k  )+sy(i-1,j,k  )+sy(i,j,k  ))
+                                        +Real(2.0)*facz*(sz(i-1,j-1,k  )+sz(i,j-1,k  )+sz(i-1,j,k  )+sz(i,j,k  )));
         return y;
     }
 }
@@ -861,17 +861,17 @@ Real mlndlap_adotx_aa (int i, int j, int k, Array4<Real const> const& x,
     if (msk(i,j,k)) {
         return Real(0.0);
     } else {
-        Real facx = (1.0/36.0)*dxinv[0]*dxinv[0];
-        Real facy = (1.0/36.0)*dxinv[1]*dxinv[1];
-        Real facz = (1.0/36.0)*dxinv[2]*dxinv[2];
+        Real facx = Real(1.0/36.0)*dxinv[0]*dxinv[0];
+        Real facy = Real(1.0/36.0)*dxinv[1]*dxinv[1];
+        Real facz = Real(1.0/36.0)*dxinv[2]*dxinv[2];
         Real fxyz = facx + facy + facz;
-        Real fmx2y2z = -facx + 2.0*facy + 2.0*facz;
-        Real f2xmy2z = 2.0*facx - facy + 2.0*facz;
-        Real f2x2ymz = 2.0*facx + 2.0*facy - facz;
-        Real f4xm2ym2z = 4.0*facx - 2.0*facy - 2.0*facz;
-        Real fm2x4ym2z = -2.0*facx + 4.0*facy - 2.0*facz;
-        Real fm2xm2y4z = -2.0*facx - 2.0*facy + 4.0*facz;
-        return x(i,j,k)*(-4.0)*fxyz*
+        Real fmx2y2z = -facx + Real(2.0)*facy + Real(2.0)*facz;
+        Real f2xmy2z = Real(2.0)*facx - facy + Real(2.0)*facz;
+        Real f2x2ymz = Real(2.0)*facx + Real(2.0)*facy - facz;
+        Real f4xm2ym2z = Real(4.0)*facx - Real(2.0)*facy - Real(2.0)*facz;
+        Real fm2x4ym2z = -Real(2.0)*facx + Real(4.0)*facy - Real(2.0)*facz;
+        Real fm2xm2y4z = -Real(2.0)*facx - Real(2.0)*facy + Real(4.0)*facz;
+        return x(i,j,k)*Real(-4.0)*fxyz*
             (sig(i-1,j-1,k-1)+sig(i,j-1,k-1)+sig(i-1,j,k-1)+sig(i,j,k-1)
             +sig(i-1,j-1,k  )+sig(i,j-1,k  )+sig(i-1,j,k  )+sig(i,j,k  ))
             + fxyz*(x(i-1,j-1,k-1)*sig(i-1,j-1,k-1)
@@ -911,16 +911,16 @@ Real mlndlap_adotx_c (int i, int j, int k, Array4<Real const> const& x,
     if (msk(i,j,k)) {
         return Real(0.0);
     } else {
-        Real facx = (1.0/36.0)*dxinv[0]*dxinv[0];
-        Real facy = (1.0/36.0)*dxinv[1]*dxinv[1];
-        Real facz = (1.0/36.0)*dxinv[2]*dxinv[2];
+        Real facx = Real(1.0/36.0)*dxinv[0]*dxinv[0];
+        Real facy = Real(1.0/36.0)*dxinv[1]*dxinv[1];
+        Real facz = Real(1.0/36.0)*dxinv[2]*dxinv[2];
         Real fxyz = facx + facy + facz;
-        Real fmx2y2z = -facx + 2.0*facy + 2.0*facz;
-        Real f2xmy2z = 2.0*facx - facy + 2.0*facz;
-        Real f2x2ymz = 2.0*facx + 2.0*facy - facz;
-        Real f4xm2ym2z = 4.0*facx - 2.0*facy - 2.0*facz;
-        Real fm2x4ym2z = -2.0*facx + 4.0*facy - 2.0*facz;
-        Real fm2xm2y4z = -2.0*facx - 2.0*facy + 4.0*facz;
+        Real fmx2y2z = -facx + Real(2.0)*facy + Real(2.0)*facz;
+        Real f2xmy2z = Real(2.0)*facx - facy + Real(2.0)*facz;
+        Real f2x2ymz = Real(2.0)*facx + Real(2.0)*facy - facz;
+        Real f4xm2ym2z = Real(4.0)*facx - Real(2.0)*facy - Real(2.0)*facz;
+        Real fm2x4ym2z = -Real(2.0)*facx + Real(4.0)*facy - Real(2.0)*facz;
+        Real fm2xm2y4z = -Real(2.0)*facx - Real(2.0)*facy + Real(4.0)*facz;
         return sig * (x(i,j,k)*Real(-4.0)*fxyz*Real(8.)
             + fxyz*(x(i-1,j-1,k-1)
                   + x(i+1,j-1,k-1)
@@ -956,19 +956,19 @@ void mlndlap_normalize_ha (Box const& bx, Array4<Real> const& x, Array4<Real con
                            Array4<Real const> const& sy, Array4<Real const> const& sz,
                            Array4<int const> const& msk, GpuArray<Real,AMREX_SPACEDIM> const& dxinv) noexcept
 {
-    Real facx = (1.0/36.0)*dxinv[0]*dxinv[0];
-    Real facy = (1.0/36.0)*dxinv[1]*dxinv[1];
-    Real facz = (1.0/36.0)*dxinv[2]*dxinv[2];
+    Real facx = Real(1.0/36.0)*dxinv[0]*dxinv[0];
+    Real facy = Real(1.0/36.0)*dxinv[1]*dxinv[1];
+    Real facz = Real(1.0/36.0)*dxinv[2]*dxinv[2];
 
     amrex::LoopConcurrent(bx, [=] (int i, int j, int k) noexcept
     {
         if (!msk(i,j,k)) {
-            x(i,j,k) = x(i,j,k)/((-4.0)*(facx*(sx(i-1,j-1,k-1)+sx(i,j-1,k-1)+sx(i-1,j,k-1)+sx(i,j,k-1)
-                                              +sx(i-1,j-1,k  )+sx(i,j-1,k  )+sx(i-1,j,k  )+sx(i,j,k  ))
-                                        +facy*(sy(i-1,j-1,k-1)+sy(i,j-1,k-1)+sy(i-1,j,k-1)+sy(i,j,k-1)
-                                              +sy(i-1,j-1,k  )+sy(i,j-1,k  )+sy(i-1,j,k  )+sy(i,j,k  ))
-                                        +facz*(sz(i-1,j-1,k-1)+sz(i,j-1,k-1)+sz(i-1,j,k-1)+sz(i,j,k-1)
-                                              +sz(i-1,j-1,k  )+sz(i,j-1,k  )+sz(i-1,j,k  )+sz(i,j,k  ))));
+            x(i,j,k) = x(i,j,k)/(Real(-4.0)*(facx*(sx(i-1,j-1,k-1)+sx(i,j-1,k-1)+sx(i-1,j,k-1)+sx(i,j,k-1)
+                                                  +sx(i-1,j-1,k  )+sx(i,j-1,k  )+sx(i-1,j,k  )+sx(i,j,k  ))
+                                            +facy*(sy(i-1,j-1,k-1)+sy(i,j-1,k-1)+sy(i-1,j,k-1)+sy(i,j,k-1)
+                                                  +sy(i-1,j-1,k  )+sy(i,j-1,k  )+sy(i-1,j,k  )+sy(i,j,k  ))
+                                            +facz*(sz(i-1,j-1,k-1)+sz(i,j-1,k-1)+sz(i-1,j,k-1)+sz(i,j,k-1)
+                                                  +sz(i-1,j-1,k  )+sz(i,j-1,k  )+sz(i-1,j,k  )+sz(i,j,k  ))));
         }
     });
 }
@@ -977,17 +977,17 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 void mlndlap_normalize_aa (Box const& bx, Array4<Real> const& x, Array4<Real const> const& sig,
                            Array4<int const> const& msk, GpuArray<Real,AMREX_SPACEDIM> const& dxinv) noexcept
 {
-    Real facx = (1.0/36.0)*dxinv[0]*dxinv[0];
-    Real facy = (1.0/36.0)*dxinv[1]*dxinv[1];
-    Real facz = (1.0/36.0)*dxinv[2]*dxinv[2];
+    Real facx = Real(1.0/36.0)*dxinv[0]*dxinv[0];
+    Real facy = Real(1.0/36.0)*dxinv[1]*dxinv[1];
+    Real facz = Real(1.0/36.0)*dxinv[2]*dxinv[2];
     Real fxyz = facx + facy + facz;
 
     amrex::LoopConcurrent(bx, [=] (int i, int j, int k) noexcept
     {
         if (!msk(i,j,k)) {
             x(i,j,k) = x(i,j,k) /
-                ((-4.0)*fxyz*(sig(i-1,j-1,k-1)+sig(i,j-1,k-1)+sig(i-1,j,k-1)+sig(i,j,k-1)
-                             +sig(i-1,j-1,k  )+sig(i,j-1,k  )+sig(i-1,j,k  )+sig(i,j,k  )));
+                (Real(-4.0)*fxyz*(sig(i-1,j-1,k-1)+sig(i,j-1,k-1)+sig(i-1,j,k-1)+sig(i,j,k-1)
+                                 +sig(i-1,j-1,k  )+sig(i,j-1,k  )+sig(i-1,j,k  )+sig(i,j,k  )));
         }
     });
 }
@@ -998,14 +998,14 @@ void mlndlap_jacobi_ha (int i, int j, int k, Array4<Real> const& sol, Real Ax,
                         Array4<Real const> const& sy, Array4<Real const> const& sz,
                         Array4<int const> const& msk, GpuArray<Real,AMREX_SPACEDIM> const& dxinv) noexcept
 {
-    Real facx = -4.0 * (1.0/36.0)*dxinv[0]*dxinv[0];
-    Real facy = -4.0 * (1.0/36.0)*dxinv[1]*dxinv[1];
-    Real facz = -4.0 * (1.0/36.0)*dxinv[2]*dxinv[2];
+    Real facx = Real(-4.0 / 36.0)*dxinv[0]*dxinv[0];
+    Real facy = Real(-4.0 / 36.0)*dxinv[1]*dxinv[1];
+    Real facz = Real(-4.0 / 36.0)*dxinv[2]*dxinv[2];
 
     if (msk(i,j,k)) {
-        sol(i,j,k) = 0.0;
+        sol(i,j,k) = Real(0.0);
     } else {
-        sol(i,j,k) += (2.0/3.0) * (rhs(i,j,k) - Ax)
+        sol(i,j,k) += Real(2.0/3.0) * (rhs(i,j,k) - Ax)
             / (facx*(sx(i-1,j-1,k-1)+sx(i,j-1,k-1)+sx(i-1,j,k-1)+sx(i,j,k-1)
                     +sx(i-1,j-1,k  )+sx(i,j-1,k  )+sx(i-1,j,k  )+sx(i,j,k  ))
               +facy*(sy(i-1,j-1,k-1)+sy(i,j-1,k-1)+sy(i-1,j,k-1)+sy(i,j,k-1)
@@ -1021,16 +1021,16 @@ void mlndlap_jacobi_ha (Box const& bx, Array4<Real> const& sol, Array4<Real cons
                         Array4<Real const> const& sy, Array4<Real const> const& sz,
                         Array4<int const> const& msk, GpuArray<Real,AMREX_SPACEDIM> const& dxinv) noexcept
 {
-    Real facx = -4.0 * (1.0/36.0)*dxinv[0]*dxinv[0];
-    Real facy = -4.0 * (1.0/36.0)*dxinv[1]*dxinv[1];
-    Real facz = -4.0 * (1.0/36.0)*dxinv[2]*dxinv[2];
+    Real facx = Real(-4.0 / 36.0)*dxinv[0]*dxinv[0];
+    Real facy = Real(-4.0 / 36.0)*dxinv[1]*dxinv[1];
+    Real facz = Real(-4.0 / 36.0)*dxinv[2]*dxinv[2];
 
     amrex::LoopConcurrent(bx, [=] (int i, int j, int k) noexcept
     {
         if (msk(i,j,k)) {
-            sol(i,j,k) = 0.0;
+            sol(i,j,k) = Real(0.0);
         } else {
-            sol(i,j,k) += (2.0/3.0) * (rhs(i,j,k) - Ax(i,j,k))
+            sol(i,j,k) += Real(2.0/3.0) * (rhs(i,j,k) - Ax(i,j,k))
                 / (facx*(sx(i-1,j-1,k-1)+sx(i,j-1,k-1)+sx(i-1,j,k-1)+sx(i,j,k-1)
                         +sx(i-1,j-1,k  )+sx(i,j-1,k  )+sx(i-1,j,k  )+sx(i,j,k  ))
                   +facy*(sy(i-1,j-1,k-1)+sy(i,j-1,k-1)+sy(i-1,j,k-1)+sy(i,j,k-1)
@@ -1046,14 +1046,14 @@ void mlndlap_jacobi_aa (int i, int j, int k, Array4<Real> const& sol, Real Ax,
                         Array4<Real const> const& rhs, Array4<Real const> const& sig,
                         Array4<int const> const& msk, GpuArray<Real,AMREX_SPACEDIM> const& dxinv) noexcept
 {
-    Real fxyz = -4.0 * (1.0/36.0)*(dxinv[0]*dxinv[0] +
+    Real fxyz = Real(-4.0 / 36.0)*(dxinv[0]*dxinv[0] +
                                    dxinv[1]*dxinv[1] +
                                    dxinv[2]*dxinv[2]);
 
     if (msk(i,j,k)) {
-        sol(i,j,k) = 0.0;
+        sol(i,j,k) = Real(0.0);
     } else {
-        sol(i,j,k) += (2.0/3.0) * (rhs(i,j,k) - Ax)
+        sol(i,j,k) += Real(2.0/3.0) * (rhs(i,j,k) - Ax)
             / (fxyz*(sig(i-1,j-1,k-1)+sig(i,j-1,k-1)+sig(i-1,j,k-1)+sig(i,j,k-1)
                     +sig(i-1,j-1,k  )+sig(i,j-1,k  )+sig(i-1,j,k  )+sig(i,j,k  )));
     }
@@ -1064,14 +1064,14 @@ void mlndlap_jacobi_c (int i, int j, int k, Array4<Real> const& sol, Real Ax,
                        Array4<Real const> const& rhs, Real sig,
                        Array4<int const> const& msk, GpuArray<Real,AMREX_SPACEDIM> const& dxinv) noexcept
 {
-    Real fxyz = -4.0 * (1.0/36.0)*(dxinv[0]*dxinv[0] +
+    Real fxyz = Real(-4.0 / 36.0)*(dxinv[0]*dxinv[0] +
                                    dxinv[1]*dxinv[1] +
                                    dxinv[2]*dxinv[2]);
 
     if (msk(i,j,k)) {
-        sol(i,j,k) = 0.0;
+        sol(i,j,k) = Real(0.0);
     } else {
-        sol(i,j,k) += (2.0/3.0) * (rhs(i,j,k) - Ax)
+        sol(i,j,k) += Real(2.0/3.0) * (rhs(i,j,k) - Ax)
             / (fxyz*Real(8.)*sig);
     }
 }
@@ -1081,16 +1081,16 @@ void mlndlap_jacobi_aa (Box const& bx, Array4<Real> const& sol, Array4<Real cons
                         Array4<Real const> const& rhs, Array4<Real const> const& sig,
                         Array4<int const> const& msk, GpuArray<Real,AMREX_SPACEDIM> const& dxinv) noexcept
 {
-    Real fxyz = -4.0 * (1.0/36.0)*(dxinv[0]*dxinv[0] +
+    Real fxyz = Real(-4.0 / 36.0)*(dxinv[0]*dxinv[0] +
                                    dxinv[1]*dxinv[1] +
                                    dxinv[2]*dxinv[2]);
 
     amrex::LoopConcurrent(bx, [=] (int i, int j, int k) noexcept
     {
         if (msk(i,j,k)) {
-            sol(i,j,k) = 0.0;
+            sol(i,j,k) = Real(0.0);
         } else {
-            sol(i,j,k) += (2.0/3.0) * (rhs(i,j,k) - Ax(i,j,k))
+            sol(i,j,k) += Real(2.0/3.0) * (rhs(i,j,k) - Ax(i,j,k))
                 / (fxyz*(sig(i-1,j-1,k-1)+sig(i,j-1,k-1)+sig(i-1,j,k-1)+sig(i,j,k-1)
                         +sig(i-1,j-1,k  )+sig(i,j-1,k  )+sig(i-1,j,k  )+sig(i,j,k  )));
         }
@@ -1102,16 +1102,16 @@ void mlndlap_jacobi_c (Box const& bx, Array4<Real> const& sol, Array4<Real const
                        Array4<Real const> const& rhs, Real sig,
                        Array4<int const> const& msk, GpuArray<Real,AMREX_SPACEDIM> const& dxinv) noexcept
 {
-    Real fxyz = -4.0 * (1.0/36.0)*(dxinv[0]*dxinv[0] +
+    Real fxyz = Real(-4.0 / 36.0)*(dxinv[0]*dxinv[0] +
                                    dxinv[1]*dxinv[1] +
                                    dxinv[2]*dxinv[2]);
 
     amrex::LoopConcurrent(bx, [=] (int i, int j, int k) noexcept
     {
         if (msk(i,j,k)) {
-            sol(i,j,k) = 0.0;
+            sol(i,j,k) = Real(0.0);
         } else {
-            sol(i,j,k) += (2.0/3.0) * (rhs(i,j,k) - Ax(i,j,k))
+            sol(i,j,k) += Real(2.0/3.0) * (rhs(i,j,k) - Ax(i,j,k))
                 / (fxyz*Real(8.)*sig);
         }
     });
@@ -1124,21 +1124,21 @@ void mlndlap_gauss_seidel_ha (Box const& bx, Array4<Real> const& sol,
                               Array4<int const> const& msk,
                               GpuArray<Real,AMREX_SPACEDIM> const& dxinv) noexcept
 {
-    Real facx = (1.0/36.0)*dxinv[0]*dxinv[0];
-    Real facy = (1.0/36.0)*dxinv[1]*dxinv[1];
-    Real facz = (1.0/36.0)*dxinv[2]*dxinv[2];
+    Real facx = Real(1.0/36.0)*dxinv[0]*dxinv[0];
+    Real facy = Real(1.0/36.0)*dxinv[1]*dxinv[1];
+    Real facz = Real(1.0/36.0)*dxinv[2]*dxinv[2];
 
     amrex::Loop(bx, [=] (int i, int j, int k) noexcept
     {
         if (msk(i,j,k)) {
-            sol(i,j,k) = 0.0;
+            sol(i,j,k) = Real(0.0);
         } else {
-            Real s0 = (-4.0)*(facx*(sx(i-1,j-1,k-1)+sx(i,j-1,k-1)+sx(i-1,j,k-1)+sx(i,j,k-1)
-                                   +sx(i-1,j-1,k  )+sx(i,j-1,k  )+sx(i-1,j,k  )+sx(i,j,k  ))
-                             +facy*(sy(i-1,j-1,k-1)+sy(i,j-1,k-1)+sy(i-1,j,k-1)+sy(i,j,k-1)
-                                   +sy(i-1,j-1,k  )+sy(i,j-1,k  )+sy(i-1,j,k  )+sy(i,j,k  ))
-                             +facz*(sz(i-1,j-1,k-1)+sz(i,j-1,k-1)+sz(i-1,j,k-1)+sz(i,j,k-1)
-                                   +sz(i-1,j-1,k  )+sz(i,j-1,k  )+sz(i-1,j,k  )+sz(i,j,k  )));
+            Real s0 = Real(-4.0)*(facx*(sx(i-1,j-1,k-1)+sx(i,j-1,k-1)+sx(i-1,j,k-1)+sx(i,j,k-1)
+                                       +sx(i-1,j-1,k  )+sx(i,j-1,k  )+sx(i-1,j,k  )+sx(i,j,k  ))
+                                 +facy*(sy(i-1,j-1,k-1)+sy(i,j-1,k-1)+sy(i-1,j,k-1)+sy(i,j,k-1)
+                                       +sy(i-1,j-1,k  )+sy(i,j-1,k  )+sy(i-1,j,k  )+sy(i,j,k  ))
+                                 +facz*(sz(i-1,j-1,k-1)+sz(i,j-1,k-1)+sz(i-1,j,k-1)+sz(i,j,k-1)
+                                       +sz(i-1,j-1,k  )+sz(i,j-1,k  )+sz(i-1,j,k  )+sz(i,j,k  )));
             Real Ax = sol(i,j,k)*s0
                      + sol(i-1,j-1,k-1)*(facx*sx(i-1,j-1,k-1)
                                         +facy*sy(i-1,j-1,k-1)
@@ -1164,60 +1164,60 @@ void mlndlap_gauss_seidel_ha (Box const& bx, Array4<Real> const& sol,
                      + sol(i+1,j+1,k+1)*(facx*sx(i  ,j  ,k  )
                                         +facy*sy(i  ,j  ,k  )
                                         +facz*sz(i  ,j  ,k  ))
-                     +sol(i  ,j-1,k-1)*(    -facx*(sx(i-1,j-1,k-1)+sx(i,j-1,k-1))
-                                        +2.0*facy*(sy(i-1,j-1,k-1)+sy(i,j-1,k-1))
-                                        +2.0*facz*(sz(i-1,j-1,k-1)+sz(i,j-1,k-1)))
-                     +sol(i  ,j+1,k-1)*(    -facx*(sx(i-1,j  ,k-1)+sx(i,j  ,k-1))
-                                        +2.0*facy*(sy(i-1,j  ,k-1)+sy(i,j  ,k-1))
-                                        +2.0*facz*(sz(i-1,j  ,k-1)+sz(i,j  ,k-1)))
-                     +sol(i  ,j-1,k+1)*(    -facx*(sx(i-1,j-1,k  )+sx(i,j-1,k  ))
-                                        +2.0*facy*(sy(i-1,j-1,k  )+sy(i,j-1,k  ))
-                                        +2.0*facz*(sz(i-1,j-1,k  )+sz(i,j-1,k  )))
-                     +sol(i  ,j+1,k+1)*(    -facx*(sx(i-1,j  ,k  )+sx(i,j  ,k  ))
-                                        +2.0*facy*(sy(i-1,j  ,k  )+sy(i,j  ,k  ))
-                                        +2.0*facz*(sz(i-1,j  ,k  )+sz(i,j  ,k  )))
-                     +sol(i-1,j  ,k-1)*( 2.0*facx*(sx(i-1,j-1,k-1)+sx(i-1,j,k-1))
-                                            -facy*(sy(i-1,j-1,k-1)+sy(i-1,j,k-1))
-                                        +2.0*facz*(sz(i-1,j-1,k-1)+sz(i-1,j,k-1)))
-                     +sol(i+1,j  ,k-1)*( 2.0*facx*(sx(i  ,j-1,k-1)+sx(i  ,j,k-1))
-                                            -facy*(sy(i  ,j-1,k-1)+sy(i  ,j,k-1))
-                                        +2.0*facz*(sz(i  ,j-1,k-1)+sz(i  ,j,k-1)))
-                     +sol(i-1,j  ,k+1)*( 2.0*facx*(sx(i-1,j-1,k  )+sx(i-1,j,k  ))
-                                            -facy*(sy(i-1,j-1,k  )+sy(i-1,j,k  ))
-                                        +2.0*facz*(sz(i-1,j-1,k  )+sz(i-1,j,k  )))
-                     +sol(i+1,j  ,k+1)*( 2.0*facx*(sx(i  ,j-1,k  )+sx(i  ,j,k  ))
-                                            -facy*(sy(i  ,j-1,k  )+sy(i  ,j,k  ))
-                                        +2.0*facz*(sz(i  ,j-1,k  )+sz(i  ,j,k  )))
-                     +sol(i-1,j-1,k  )*( 2.0*facx*(sx(i-1,j-1,k-1)+sx(i-1,j-1,k))
-                                        +2.0*facy*(sy(i-1,j-1,k-1)+sy(i-1,j-1,k))
-                                            -facz*(sz(i-1,j-1,k-1)+sz(i-1,j-1,k)))
-                     +sol(i+1,j-1,k  )*( 2.0*facx*(sx(i  ,j-1,k-1)+sx(i  ,j-1,k))
-                                        +2.0*facy*(sy(i  ,j-1,k-1)+sy(i  ,j-1,k))
-                                            -facz*(sz(i  ,j-1,k-1)+sz(i  ,j-1,k)))
-                     +sol(i-1,j+1,k  )*( 2.0*facx*(sx(i-1,j  ,k-1)+sx(i-1,j  ,k))
-                                        +2.0*facy*(sy(i-1,j  ,k-1)+sy(i-1,j  ,k))
-                                            -facz*(sz(i-1,j  ,k-1)+sz(i-1,j  ,k)))
-                     +sol(i+1,j+1,k  )*( 2.0*facx*(sx(i  ,j  ,k-1)+sx(i  ,j  ,k))
-                                        +2.0*facy*(sy(i  ,j  ,k-1)+sy(i  ,j  ,k))
-                                            -facz*(sz(i  ,j  ,k-1)+sz(i  ,j  ,k)))
-                     + 2.0*sol(i-1,j,k)*(2.0*facx*(sx(i-1,j-1,k-1)+sx(i-1,j,k-1)+sx(i-1,j-1,k)+sx(i-1,j,k))
-                                            -facy*(sy(i-1,j-1,k-1)+sy(i-1,j,k-1)+sy(i-1,j-1,k)+sy(i-1,j,k))
-                                            -facz*(sz(i-1,j-1,k-1)+sz(i-1,j,k-1)+sz(i-1,j-1,k)+sz(i-1,j,k)))
-                     + 2.0*sol(i+1,j,k)*(2.0*facx*(sx(i  ,j-1,k-1)+sx(i  ,j,k-1)+sx(i  ,j-1,k)+sx(i  ,j,k))
-                                            -facy*(sy(i  ,j-1,k-1)+sy(i  ,j,k-1)+sy(i  ,j-1,k)+sy(i  ,j,k))
-                                            -facz*(sz(i  ,j-1,k-1)+sz(i  ,j,k-1)+sz(i  ,j-1,k)+sz(i  ,j,k)))
-                     + 2.0*sol(i,j-1,k)*(   -facx*(sx(i-1,j-1,k-1)+sx(i,j-1,k-1)+sx(i-1,j-1,k)+sx(i,j-1,k))
-                                        +2.0*facy*(sy(i-1,j-1,k-1)+sy(i,j-1,k-1)+sy(i-1,j-1,k)+sy(i,j-1,k))
-                                            -facz*(sz(i-1,j-1,k-1)+sz(i,j-1,k-1)+sz(i-1,j-1,k)+sz(i,j-1,k)))
-                     + 2.0*sol(i,j+1,k)*(   -facx*(sx(i-1,j  ,k-1)+sx(i,j  ,k-1)+sx(i-1,j  ,k)+sx(i,j  ,k))
-                                        +2.0*facy*(sy(i-1,j  ,k-1)+sy(i,j  ,k-1)+sy(i-1,j  ,k)+sy(i,j  ,k))
-                                            -facz*(sz(i-1,j  ,k-1)+sz(i,j  ,k-1)+sz(i-1,j  ,k)+sz(i,j  ,k)))
-                     + 2.0*sol(i,j,k-1)*(   -facx*(sx(i-1,j-1,k-1)+sx(i,j-1,k-1)+sx(i-1,j,k-1)+sx(i,j,k-1))
-                                            -facy*(sy(i-1,j-1,k-1)+sy(i,j-1,k-1)+sy(i-1,j,k-1)+sy(i,j,k-1))
-                                        +2.0*facz*(sz(i-1,j-1,k-1)+sz(i,j-1,k-1)+sz(i-1,j,k-1)+sz(i,j,k-1)))
-                     + 2.0*sol(i,j,k+1)*(   -facx*(sx(i-1,j-1,k  )+sx(i,j-1,k  )+sx(i-1,j,k  )+sx(i,j,k  ))
-                                            -facy*(sy(i-1,j-1,k  )+sy(i,j-1,k  )+sy(i-1,j,k  )+sy(i,j,k  ))
-                                        +2.0*facz*(sz(i-1,j-1,k  )+sz(i,j-1,k  )+sz(i-1,j,k  )+sz(i,j,k  )));
+                     +sol(i  ,j-1,k-1)*(          -facx*(sx(i-1,j-1,k-1)+sx(i,j-1,k-1))
+                                        +Real(2.0)*facy*(sy(i-1,j-1,k-1)+sy(i,j-1,k-1))
+                                        +Real(2.0)*facz*(sz(i-1,j-1,k-1)+sz(i,j-1,k-1)))
+                     +sol(i  ,j+1,k-1)*(          -facx*(sx(i-1,j  ,k-1)+sx(i,j  ,k-1))
+                                        +Real(2.0)*facy*(sy(i-1,j  ,k-1)+sy(i,j  ,k-1))
+                                        +Real(2.0)*facz*(sz(i-1,j  ,k-1)+sz(i,j  ,k-1)))
+                     +sol(i  ,j-1,k+1)*(          -facx*(sx(i-1,j-1,k  )+sx(i,j-1,k  ))
+                                        +Real(2.0)*facy*(sy(i-1,j-1,k  )+sy(i,j-1,k  ))
+                                        +Real(2.0)*facz*(sz(i-1,j-1,k  )+sz(i,j-1,k  )))
+                     +sol(i  ,j+1,k+1)*(          -facx*(sx(i-1,j  ,k  )+sx(i,j  ,k  ))
+                                        +Real(2.0)*facy*(sy(i-1,j  ,k  )+sy(i,j  ,k  ))
+                                        +Real(2.0)*facz*(sz(i-1,j  ,k  )+sz(i,j  ,k  )))
+                     +sol(i-1,j  ,k-1)*( Real(2.0)*facx*(sx(i-1,j-1,k-1)+sx(i-1,j,k-1))
+                                                  -facy*(sy(i-1,j-1,k-1)+sy(i-1,j,k-1))
+                                        +Real(2.0)*facz*(sz(i-1,j-1,k-1)+sz(i-1,j,k-1)))
+                     +sol(i+1,j  ,k-1)*( Real(2.0)*facx*(sx(i  ,j-1,k-1)+sx(i  ,j,k-1))
+                                                  -facy*(sy(i  ,j-1,k-1)+sy(i  ,j,k-1))
+                                        +Real(2.0)*facz*(sz(i  ,j-1,k-1)+sz(i  ,j,k-1)))
+                     +sol(i-1,j  ,k+1)*( Real(2.0)*facx*(sx(i-1,j-1,k  )+sx(i-1,j,k  ))
+                                                  -facy*(sy(i-1,j-1,k  )+sy(i-1,j,k  ))
+                                        +Real(2.0)*facz*(sz(i-1,j-1,k  )+sz(i-1,j,k  )))
+                     +sol(i+1,j  ,k+1)*( Real(2.0)*facx*(sx(i  ,j-1,k  )+sx(i  ,j,k  ))
+                                                  -facy*(sy(i  ,j-1,k  )+sy(i  ,j,k  ))
+                                        +Real(2.0)*facz*(sz(i  ,j-1,k  )+sz(i  ,j,k  )))
+                     +sol(i-1,j-1,k  )*( Real(2.0)*facx*(sx(i-1,j-1,k-1)+sx(i-1,j-1,k))
+                                        +Real(2.0)*facy*(sy(i-1,j-1,k-1)+sy(i-1,j-1,k))
+                                                  -facz*(sz(i-1,j-1,k-1)+sz(i-1,j-1,k)))
+                     +sol(i+1,j-1,k  )*( Real(2.0)*facx*(sx(i  ,j-1,k-1)+sx(i  ,j-1,k))
+                                        +Real(2.0)*facy*(sy(i  ,j-1,k-1)+sy(i  ,j-1,k))
+                                                  -facz*(sz(i  ,j-1,k-1)+sz(i  ,j-1,k)))
+                     +sol(i-1,j+1,k  )*( Real(2.0)*facx*(sx(i-1,j  ,k-1)+sx(i-1,j  ,k))
+                                        +Real(2.0)*facy*(sy(i-1,j  ,k-1)+sy(i-1,j  ,k))
+                                                  -facz*(sz(i-1,j  ,k-1)+sz(i-1,j  ,k)))
+                     +sol(i+1,j+1,k  )*( Real(2.0)*facx*(sx(i  ,j  ,k-1)+sx(i  ,j  ,k))
+                                        +Real(2.0)*facy*(sy(i  ,j  ,k-1)+sy(i  ,j  ,k))
+                                                  -facz*(sz(i  ,j  ,k-1)+sz(i  ,j  ,k)))
+                     + Real(2.0)*sol(i-1,j,k)*(Real(2.0)*facx*(sx(i-1,j-1,k-1)+sx(i-1,j,k-1)+sx(i-1,j-1,k)+sx(i-1,j,k))
+                                                        -facy*(sy(i-1,j-1,k-1)+sy(i-1,j,k-1)+sy(i-1,j-1,k)+sy(i-1,j,k))
+                                                        -facz*(sz(i-1,j-1,k-1)+sz(i-1,j,k-1)+sz(i-1,j-1,k)+sz(i-1,j,k)))
+                     + Real(2.0)*sol(i+1,j,k)*(Real(2.0)*facx*(sx(i  ,j-1,k-1)+sx(i  ,j,k-1)+sx(i  ,j-1,k)+sx(i  ,j,k))
+                                                        -facy*(sy(i  ,j-1,k-1)+sy(i  ,j,k-1)+sy(i  ,j-1,k)+sy(i  ,j,k))
+                                                        -facz*(sz(i  ,j-1,k-1)+sz(i  ,j,k-1)+sz(i  ,j-1,k)+sz(i  ,j,k)))
+                     + Real(2.0)*sol(i,j-1,k)*(   -facx*(sx(i-1,j-1,k-1)+sx(i,j-1,k-1)+sx(i-1,j-1,k)+sx(i,j-1,k))
+                                        +Real(2.0)*facy*(sy(i-1,j-1,k-1)+sy(i,j-1,k-1)+sy(i-1,j-1,k)+sy(i,j-1,k))
+                                                  -facz*(sz(i-1,j-1,k-1)+sz(i,j-1,k-1)+sz(i-1,j-1,k)+sz(i,j-1,k)))
+                     + Real(2.0)*sol(i,j+1,k)*(   -facx*(sx(i-1,j  ,k-1)+sx(i,j  ,k-1)+sx(i-1,j  ,k)+sx(i,j  ,k))
+                                        +Real(2.0)*facy*(sy(i-1,j  ,k-1)+sy(i,j  ,k-1)+sy(i-1,j  ,k)+sy(i,j  ,k))
+                                                  -facz*(sz(i-1,j  ,k-1)+sz(i,j  ,k-1)+sz(i-1,j  ,k)+sz(i,j  ,k)))
+                     + Real(2.0)*sol(i,j,k-1)*(   -facx*(sx(i-1,j-1,k-1)+sx(i,j-1,k-1)+sx(i-1,j,k-1)+sx(i,j,k-1))
+                                                  -facy*(sy(i-1,j-1,k-1)+sy(i,j-1,k-1)+sy(i-1,j,k-1)+sy(i,j,k-1))
+                                        +Real(2.0)*facz*(sz(i-1,j-1,k-1)+sz(i,j-1,k-1)+sz(i-1,j,k-1)+sz(i,j,k-1)))
+                     + Real(2.0)*sol(i,j,k+1)*(   -facx*(sx(i-1,j-1,k  )+sx(i,j-1,k  )+sx(i-1,j,k  )+sx(i,j,k  ))
+                                                  -facy*(sy(i-1,j-1,k  )+sy(i,j-1,k  )+sy(i-1,j,k  )+sy(i,j,k  ))
+                                        +Real(2.0)*facz*(sz(i-1,j-1,k  )+sz(i,j-1,k  )+sz(i-1,j,k  )+sz(i,j,k  )));
 
                 sol(i,j,k) += (rhs(i,j,k) - Ax) / s0;
         }
@@ -1230,24 +1230,24 @@ void mlndlap_gauss_seidel_aa (Box const& bx, Array4<Real> const& sol,
                               Array4<int const> const& msk,
                               GpuArray<Real,AMREX_SPACEDIM> const& dxinv) noexcept
 {
-    Real facx = (1.0/36.0)*dxinv[0]*dxinv[0];
-    Real facy = (1.0/36.0)*dxinv[1]*dxinv[1];
-    Real facz = (1.0/36.0)*dxinv[2]*dxinv[2];
+    Real facx = Real(1.0/36.0)*dxinv[0]*dxinv[0];
+    Real facy = Real(1.0/36.0)*dxinv[1]*dxinv[1];
+    Real facz = Real(1.0/36.0)*dxinv[2]*dxinv[2];
     Real fxyz = facx + facy + facz;
-    Real fmx2y2z = -facx + 2.0*facy + 2.0*facz;
-    Real f2xmy2z = 2.0*facx - facy + 2.0*facz;
-    Real f2x2ymz = 2.0*facx + 2.0*facy - facz;
-    Real f4xm2ym2z = 4.0*facx - 2.0*facy - 2.0*facz;
-    Real fm2x4ym2z = -2.0*facx + 4.0*facy - 2.0*facz;
-    Real fm2xm2y4z = -2.0*facx - 2.0*facy + 4.0*facz;
+    Real fmx2y2z = -facx + Real(2.0)*facy + Real(2.0)*facz;
+    Real f2xmy2z = Real(2.0)*facx - facy + Real(2.0)*facz;
+    Real f2x2ymz = Real(2.0)*facx + Real(2.0)*facy - facz;
+    Real f4xm2ym2z = Real(4.0)*facx - Real(2.0)*facy - Real(2.0)*facz;
+    Real fm2x4ym2z = -Real(2.0)*facx + Real(4.0)*facy - Real(2.0)*facz;
+    Real fm2xm2y4z = -Real(2.0)*facx - Real(2.0)*facy + Real(4.0)*facz;
 
     amrex::Loop(bx, [=] (int i, int j, int k) noexcept
     {
         if (msk(i,j,k)) {
-            sol(i,j,k) = 0.0;
+            sol(i,j,k) = Real(0.0);
         } else {
-            Real s0 = (-4.0)*fxyz*(sig(i-1,j-1,k-1)+sig(i,j-1,k-1)+sig(i-1,j,k-1)+sig(i,j,k-1)
-                                  +sig(i-1,j-1,k  )+sig(i,j-1,k  )+sig(i-1,j,k  )+sig(i,j,k  ));
+            Real s0 = Real(-4.0)*fxyz*(sig(i-1,j-1,k-1)+sig(i,j-1,k-1)+sig(i-1,j,k-1)+sig(i,j,k-1)
+                                      +sig(i-1,j-1,k  )+sig(i,j-1,k  )+sig(i-1,j,k  )+sig(i,j,k  ));
             Real Ax = sol(i,j,k)*s0
                 + fxyz*(sol(i-1,j-1,k-1)*sig(i-1,j-1,k-1)
                       + sol(i+1,j-1,k-1)*sig(i  ,j-1,k-1)
@@ -1287,23 +1287,23 @@ void mlndlap_gauss_seidel_c (Box const& bx, Array4<Real> const& sol,
                              Array4<int const> const& msk,
                              GpuArray<Real,AMREX_SPACEDIM> const& dxinv) noexcept
 {
-    Real facx = (1.0/36.0)*dxinv[0]*dxinv[0];
-    Real facy = (1.0/36.0)*dxinv[1]*dxinv[1];
-    Real facz = (1.0/36.0)*dxinv[2]*dxinv[2];
+    Real facx = Real(1.0/36.0)*dxinv[0]*dxinv[0];
+    Real facy = Real(1.0/36.0)*dxinv[1]*dxinv[1];
+    Real facz = Real(1.0/36.0)*dxinv[2]*dxinv[2];
     Real fxyz = facx + facy + facz;
-    Real fmx2y2z = -facx + 2.0*facy + 2.0*facz;
-    Real f2xmy2z = 2.0*facx - facy + 2.0*facz;
-    Real f2x2ymz = 2.0*facx + 2.0*facy - facz;
-    Real f4xm2ym2z = 4.0*facx - 2.0*facy - 2.0*facz;
-    Real fm2x4ym2z = -2.0*facx + 4.0*facy - 2.0*facz;
-    Real fm2xm2y4z = -2.0*facx - 2.0*facy + 4.0*facz;
+    Real fmx2y2z = -facx + Real(2.0)*facy + Real(2.0)*facz;
+    Real f2xmy2z = Real(2.0)*facx - facy + Real(2.0)*facz;
+    Real f2x2ymz = Real(2.0)*facx + Real(2.0)*facy - facz;
+    Real f4xm2ym2z = Real(4.0)*facx - Real(2.0)*facy - Real(2.0)*facz;
+    Real fm2x4ym2z = -Real(2.0)*facx + Real(4.0)*facy - Real(2.0)*facz;
+    Real fm2xm2y4z = -Real(2.0)*facx - Real(2.0)*facy + Real(4.0)*facz;
 
     amrex::Loop(bx, [=] (int i, int j, int k) noexcept
     {
         if (msk(i,j,k)) {
-            sol(i,j,k) = 0.0;
+            sol(i,j,k) = Real(0.0);
         } else {
-            Real s0 = (-4.0)*fxyz*Real(8.);
+            Real s0 = Real(-4.0)*fxyz*Real(8.);
             Real Ax = sol(i,j,k)*s0
                 + fxyz*(sol(i-1,j-1,k-1)
                       + sol(i+1,j-1,k-1)
@@ -1362,16 +1362,16 @@ void mlndlap_gauss_seidel_with_line_solve_aa (Box const& bx, Array4<Real> const&
                               Array4<int const> const& msk,
                               GpuArray<Real,AMREX_SPACEDIM> const& dxinv) noexcept
 {
-    Real facx = (1.0/36.0)*dxinv[0]*dxinv[0];
-    Real facy = (1.0/36.0)*dxinv[1]*dxinv[1];
-    Real facz = (1.0/36.0)*dxinv[2]*dxinv[2];
+    Real facx = Real(1.0/36.0)*dxinv[0]*dxinv[0];
+    Real facy = Real(1.0/36.0)*dxinv[1]*dxinv[1];
+    Real facz = Real(1.0/36.0)*dxinv[2]*dxinv[2];
     Real fxyz = facx + facy + facz;
-    Real fmx2y2z = -facx + 2.0*facy + 2.0*facz;
-    Real f2xmy2z = 2.0*facx - facy + 2.0*facz;
-    Real f2x2ymz = 2.0*facx + 2.0*facy - facz;
-    Real f4xm2ym2z = 4.0*facx - 2.0*facy - 2.0*facz;
-    Real fm2x4ym2z = -2.0*facx + 4.0*facy - 2.0*facz;
-    Real fm2xm2y4z = -2.0*facx - 2.0*facy + 4.0*facz;
+    Real fmx2y2z = -facx + Real(2.0)*facy + Real(2.0)*facz;
+    Real f2xmy2z = Real(2.0)*facx - facy + Real(2.0)*facz;
+    Real f2x2ymz = Real(2.0)*facx + Real(2.0)*facy - facz;
+    Real f4xm2ym2z = Real(4.0)*facx - Real(2.0)*facy - Real(2.0)*facz;
+    Real fm2x4ym2z = -Real(2.0)*facx + Real(4.0)*facy - Real(2.0)*facz;
+    Real fm2xm2y4z = -Real(2.0)*facx - Real(2.0)*facy + Real(4.0)*facz;
  
     const auto lo = amrex::lbound(bx);
     const auto hi = amrex::ubound(bx);
@@ -1407,16 +1407,16 @@ void mlndlap_gauss_seidel_with_line_solve_aa (Box const& bx, Array4<Real> const&
                 {
                     if (msk(i,j,k)) 
                     {
-                        a_ls(k-lo.z) = 0.;
-                        b_ls(k-lo.z) = 1.;
-                        c_ls(k-lo.z) = 0.;
-                        u_ls(k-lo.z) = 0.;
-                        r_ls(k-lo.z) = 0.;
+                        a_ls(k-lo.z) = Real(0.);
+                        b_ls(k-lo.z) = Real(1.);
+                        c_ls(k-lo.z) = Real(0.);
+                        u_ls(k-lo.z) = Real(0.);
+                        r_ls(k-lo.z) = Real(0.);
                     } 
                     else 
                     {
-                        Real s0 = (-4.0)*fxyz*(sig(i-1,j-1,k-1)+sig(i,j-1,k-1)+sig(i-1,j,k-1)+sig(i,j,k-1)   
-                                             + sig(i-1,j-1,k  )+sig(i,j-1,k  )+sig(i-1,j,k  )+sig(i,j,k  ));
+                        Real s0 = Real(-4.0)*fxyz*(sig(i-1,j-1,k-1)+sig(i,j-1,k-1)+sig(i-1,j,k-1)+sig(i,j,k-1)
+                                                 + sig(i-1,j-1,k  )+sig(i,j-1,k  )+sig(i-1,j,k  )+sig(i,j,k  ));
 
                         Real Ax = fxyz*(sol(i-1,j-1,k-1)*sig(i-1,j-1,k-1)
                                       + sol(i+1,j-1,k-1)*sig(i  ,j-1,k-1)
@@ -1446,7 +1446,7 @@ void mlndlap_gauss_seidel_with_line_solve_aa (Box const& bx, Array4<Real> const&
                         a_ls(k-lo.z) = fm2xm2y4z*(sig(i-1,j-1,k-1)+sig(i,j-1,k-1)+sig(i-1,j,k-1)+sig(i,j,k-1));
                         b_ls(k-lo.z) = s0;
                         c_ls(k-lo.z) = fm2xm2y4z*(sig(i-1,j-1,k  )+sig(i,j-1,k  )+sig(i-1,j,k  )+sig(i,j,k  ));
-                        u_ls(k-lo.z) = 0.;  
+                        u_ls(k-lo.z) = Real(0.);
                         r_ls(k-lo.z) = rhs(i,j,k) - Ax;
                     }
                 }
@@ -1468,16 +1468,16 @@ void mlndlap_gauss_seidel_with_line_solve_aa (Box const& bx, Array4<Real> const&
                 for (int j = lo.y; j <= hi.y; ++j)
                 {
                     if (msk(i,j,k)) {
-                        a_ls(j-lo.y) = 0.;
-                        b_ls(j-lo.y) = 1.;
-                        c_ls(j-lo.y) = 0.;
-                        u_ls(j-lo.y) = 0.;
-                        r_ls(j-lo.y) = 0.;
+                        a_ls(j-lo.y) = Real(0.);
+                        b_ls(j-lo.y) = Real(1.);
+                        c_ls(j-lo.y) = Real(0.);
+                        u_ls(j-lo.y) = Real(0.);
+                        r_ls(j-lo.y) = Real(0.);
                     } 
                     else
                     {
-                        Real s0 = (-4.0)*fxyz*(sig(i-1,j-1,k-1)+sig(i,j-1,k-1)+sig(i-1,j,k-1)+sig(i,j,k-1)
-                                             + sig(i-1,j-1,k  )+sig(i,j-1,k  )+sig(i-1,j,k  )+sig(i,j,k  ));
+                        Real s0 = Real(-4.0)*fxyz*(sig(i-1,j-1,k-1)+sig(i,j-1,k-1)+sig(i-1,j,k-1)+sig(i,j,k-1)
+                                                 + sig(i-1,j-1,k  )+sig(i,j-1,k  )+sig(i-1,j,k  )+sig(i,j,k  ));
 
                         Real Ax = fxyz*(sol(i-1,j-1,k-1)*sig(i-1,j-1,k-1)
                                       + sol(i+1,j-1,k-1)*sig(i  ,j-1,k-1)
@@ -1507,7 +1507,7 @@ void mlndlap_gauss_seidel_with_line_solve_aa (Box const& bx, Array4<Real> const&
                         a_ls(j-lo.y) = fm2x4ym2z*(sig(i-1,j-1,k-1)+sig(i,j-1,k-1)+sig(i-1,j-1,k)+sig(i,j-1,k));
                         b_ls(j-lo.y) = s0;
                         c_ls(j-lo.y) = fm2x4ym2z*(sig(i-1,j  ,k-1)+sig(i,j  ,k-1)+sig(i-1,j  ,k)+sig(i,j  ,k));
-                        u_ls(j-lo.y) = 0.;
+                        u_ls(j-lo.y) = Real(0.);
                         r_ls(j-lo.y) = rhs(i,j,k) - Ax;
 
                     }
@@ -1531,16 +1531,16 @@ void mlndlap_gauss_seidel_with_line_solve_aa (Box const& bx, Array4<Real> const&
                 {
                     if (msk(i,j,k)) 
                     {
-                        a_ls(i-lo.x) = 0.;
-                        b_ls(i-lo.x) = 1.;
-                        c_ls(i-lo.x) = 0.;
-                        u_ls(i-lo.x) = 0.;
-                        r_ls(i-lo.x) = 0.;
+                        a_ls(i-lo.x) = Real(0.);
+                        b_ls(i-lo.x) = Real(1.);
+                        c_ls(i-lo.x) = Real(0.);
+                        u_ls(i-lo.x) = Real(0.);
+                        r_ls(i-lo.x) = Real(0.);
                     }
                     else
                     {
-                        Real s0 = (-4.0)*fxyz*(sig(i-1,j-1,k-1)+sig(i,j-1,k-1)+sig(i-1,j,k-1)+sig(i,j,k-1)
-                                             + sig(i-1,j-1,k  )+sig(i,j-1,k  )+sig(i-1,j,k  )+sig(i,j,k  ));
+                        Real s0 = Real(-4.0)*fxyz*(sig(i-1,j-1,k-1)+sig(i,j-1,k-1)+sig(i-1,j,k-1)+sig(i,j,k-1)
+                                                 + sig(i-1,j-1,k  )+sig(i,j-1,k  )+sig(i-1,j,k  )+sig(i,j,k  ));
 
                         Real Ax = fxyz*(sol(i-1,j-1,k-1)*sig(i-1,j-1,k-1)
                                       + sol(i+1,j-1,k-1)*sig(i  ,j-1,k-1)
@@ -1570,7 +1570,7 @@ void mlndlap_gauss_seidel_with_line_solve_aa (Box const& bx, Array4<Real> const&
                         a_ls(i-lo.x) = f4xm2ym2z*(sig(i-1,j-1,k-1)+sig(i-1,j,k-1)+sig(i-1,j-1,k)+sig(i-1,j,k));
                         b_ls(i-lo.x) = s0;
                         c_ls(i-lo.x) = f4xm2ym2z*(sig(i  ,j-1,k-1)+sig(i  ,j,k-1)+sig(i  ,j-1,k)+sig(i  ,j,k));
-                        u_ls(i-lo.x) = 0.;
+                        u_ls(i-lo.x) = Real(0.);
                         r_ls(i-lo.x) = rhs(i,j,k) - Ax;
               	    }
                 }
@@ -1601,22 +1601,22 @@ void mlndlap_restriction (int i, int j, int k, Array4<Real> const& crse,
     int jj = j*2;
     int kk = k*2;
     if (msk(ii,jj,kk)) {
-        crse(i,j,k) = 0.0;
+        crse(i,j,k) = Real(0.0);
     } else {
-        crse(i,j,k) = (1./64.)*(fine(ii-1,jj-1,kk-1)+fine(ii+1,jj-1,kk-1)
-                               +fine(ii-1,jj+1,kk-1)+fine(ii+1,jj+1,kk-1)
-                               +fine(ii-1,jj-1,kk+1)+fine(ii+1,jj-1,kk+1)
-                               +fine(ii-1,jj+1,kk+1)+fine(ii+1,jj+1,kk+1))
-                    + (1./32.)*(fine(ii  ,jj-1,kk-1)+fine(ii  ,jj+1,kk-1)
-                               +fine(ii  ,jj-1,kk+1)+fine(ii  ,jj+1,kk+1)
-                               +fine(ii-1,jj  ,kk-1)+fine(ii+1,jj  ,kk-1)
-                               +fine(ii-1,jj  ,kk+1)+fine(ii+1,jj  ,kk+1)
-                               +fine(ii-1,jj-1,kk  )+fine(ii+1,jj-1,kk  )
-                               +fine(ii-1,jj+1,kk  )+fine(ii+1,jj+1,kk  ))
-                    + (1./16.)*(fine(ii-1,jj,kk)+fine(ii+1,jj,kk)
-                               +fine(ii,jj-1,kk)+fine(ii,jj+1,kk)
-                               +fine(ii,jj,kk-1)+fine(ii,jj,kk+1))
-                      + (1./8.)*fine(ii,jj,kk);
+        crse(i,j,k) = Real(1./64.)*(fine(ii-1,jj-1,kk-1)+fine(ii+1,jj-1,kk-1)
+                                   +fine(ii-1,jj+1,kk-1)+fine(ii+1,jj+1,kk-1)
+                                   +fine(ii-1,jj-1,kk+1)+fine(ii+1,jj-1,kk+1)
+                                   +fine(ii-1,jj+1,kk+1)+fine(ii+1,jj+1,kk+1))
+                    + Real(1./32.)*(fine(ii  ,jj-1,kk-1)+fine(ii  ,jj+1,kk-1)
+                                   +fine(ii  ,jj-1,kk+1)+fine(ii  ,jj+1,kk+1)
+                                   +fine(ii-1,jj  ,kk-1)+fine(ii+1,jj  ,kk-1)
+                                   +fine(ii-1,jj  ,kk+1)+fine(ii+1,jj  ,kk+1)
+                                   +fine(ii-1,jj-1,kk  )+fine(ii+1,jj-1,kk  )
+                                   +fine(ii-1,jj+1,kk  )+fine(ii+1,jj+1,kk  ))
+                    + Real(1./16.)*(fine(ii-1,jj,kk)+fine(ii+1,jj,kk)
+                                   +fine(ii,jj-1,kk)+fine(ii,jj+1,kk)
+                                   +fine(ii,jj,kk-1)+fine(ii,jj,kk+1))
+                      + Real(1./8.)*fine(ii,jj,kk);
     }
 }
 
@@ -1630,11 +1630,11 @@ void mlndlap_semi_restriction (int i, int j, int k, Array4<Real> const& crse,
         int jj = j*2;
         int kk = k;
         if (msk(ii,jj,kk)) {
-            crse(i,j,k) = 0.0;
+            crse(i,j,k) = Real(0.0);
         } else { // use 2-D formula 
-            crse(i,j,k) = (1./16.)*(fine(ii-1,jj-1,kk) + 2.*fine(ii  ,jj-1,kk) +    fine(ii+1,jj-1,kk)
-                               + 2.*fine(ii-1,jj  ,kk) + 4.*fine(ii  ,jj  ,kk) + 2.*fine(ii+1,jj  ,kk)
-                                  + fine(ii-1,jj+1,kk) + 2.*fine(ii  ,jj+1,kk) +    fine(ii+1,jj+1,kk));
+            crse(i,j,k) = Real(1./16.)*(fine(ii-1,jj-1,kk) + Real(2.)*fine(ii  ,jj-1,kk) +          fine(ii+1,jj-1,kk)
+                             + Real(2.)*fine(ii-1,jj  ,kk) + Real(4.)*fine(ii  ,jj  ,kk) + Real(2.)*fine(ii+1,jj  ,kk)
+                                      + fine(ii-1,jj+1,kk) + Real(2.)*fine(ii  ,jj+1,kk) +          fine(ii+1,jj+1,kk));
         }
     } 
     else if (idir == 1) 
@@ -1643,11 +1643,11 @@ void mlndlap_semi_restriction (int i, int j, int k, Array4<Real> const& crse,
         int jj = j;
         int kk = k*2;
         if (msk(ii,jj,kk)) {
-            crse(i,j,k) = 0.0;
+            crse(i,j,k) = Real(0.0);
         } else { // use 2-D formula 
-            crse(i,j,k) = (1./16.)*(fine(ii-1,jj,kk-1) + 2.*fine(ii  ,jj,kk-1) +    fine(ii+1,jj,kk-1)
-                               + 2.*fine(ii-1,jj  ,kk) + 4.*fine(ii  ,jj,kk  ) + 2.*fine(ii+1,jj,kk  )
-                                  + fine(ii-1,jj,kk+1) + 2.*fine(ii  ,jj,kk+1) +    fine(ii+1,jj,kk+1));
+            crse(i,j,k) = Real(1./16.)*(fine(ii-1,jj,kk-1) + Real(2.)*fine(ii  ,jj,kk-1) +          fine(ii+1,jj,kk-1)
+                             + Real(2.)*fine(ii-1,jj  ,kk) + Real(4.)*fine(ii  ,jj,kk  ) + Real(2.)*fine(ii+1,jj,kk  )
+                                      + fine(ii-1,jj,kk+1) + Real(2.)*fine(ii  ,jj,kk+1) +          fine(ii+1,jj,kk+1));
         }
     }
     else if (idir == 0)
@@ -1656,11 +1656,11 @@ void mlndlap_semi_restriction (int i, int j, int k, Array4<Real> const& crse,
         int jj = j*2;
         int kk = k*2;
         if (msk(ii,jj,kk)) {
-            crse(i,j,k) = 0.0;
+            crse(i,j,k) = Real(0.0);
         } else { // use 2-D formula 
-            crse(i,j,k) = (1./16.)*(fine(ii,jj-1,kk-1) + 2.*fine(ii  ,jj,kk-1) +    fine(ii,jj+1,kk-1)
-                               + 2.*fine(ii,jj-1  ,kk) + 4.*fine(ii  ,jj,kk  ) + 2.*fine(ii,jj+1,kk  )
-                                  + fine(ii,jj-1,kk+1) + 2.*fine(ii  ,jj,kk+1) +    fine(ii,jj+1,kk+1));
+            crse(i,j,k) = Real(1./16.)*(fine(ii,jj-1,kk-1) + Real(2.)*fine(ii  ,jj,kk-1) +          fine(ii,jj+1,kk-1)
+                             + Real(2.)*fine(ii,jj-1  ,kk) + Real(4.)*fine(ii  ,jj,kk  ) + Real(2.)*fine(ii,jj+1,kk  )
+                                      + fine(ii,jj-1,kk+1) + Real(2.)*fine(ii  ,jj,kk+1) +          fine(ii,jj+1,kk+1));
         }
     }
     else 
@@ -2036,38 +2036,38 @@ void mlndlap_divu (int i, int j, int k, Array4<Real> const& rhs, Array4<Real con
                    GpuArray<LinOpBCType, AMREX_SPACEDIM> const& bclo,
                    GpuArray<LinOpBCType, AMREX_SPACEDIM> const& bchi) noexcept
 {
-    Real facx = 0.25*dxinv[0];
-    Real facy = 0.25*dxinv[1];
-    Real facz = 0.25*dxinv[2];
+    Real facx = Real(0.25)*dxinv[0];
+    Real facy = Real(0.25)*dxinv[1];
+    Real facz = Real(0.25)*dxinv[2];
 
     const auto domlo = amrex::lbound(nodal_domain);
     const auto domhi = amrex::ubound(nodal_domain);
 
     if (msk(i,j,k)) {
-        rhs(i,j,k) = 0.0;
+        rhs(i,j,k) = Real(0.0);
     } else {
 
-        Real zero_ilo = 1.0;
-        Real zero_ihi = 1.0;
-        Real zero_jlo = 1.0;
-        Real zero_jhi = 1.0;
-        Real zero_klo = 1.0;
-        Real zero_khi = 1.0;
+        Real zero_ilo = Real(1.0);
+        Real zero_ihi = Real(1.0);
+        Real zero_jlo = Real(1.0);
+        Real zero_jhi = Real(1.0);
+        Real zero_klo = Real(1.0);
+        Real zero_khi = Real(1.0);
 
         // The nodal divergence operator should not see the tangential velocity
         //     at an inflow face
         if ((bclo[0] == LinOpBCType::Neumann || bclo[0] == LinOpBCType::inflow)
-            && i == domlo.x) zero_ilo = 0.0;
+            && i == domlo.x) zero_ilo = Real(0.0);
         if ((bchi[0] == LinOpBCType::Neumann || bchi[0] == LinOpBCType::inflow)
-            && i == domhi.x) zero_ihi = 0.0;
+            && i == domhi.x) zero_ihi = Real(0.0);
         if ((bclo[1] == LinOpBCType::Neumann || bclo[1] == LinOpBCType::inflow)
-            && j == domlo.y) zero_jlo = 0.0;
+            && j == domlo.y) zero_jlo = Real(0.0);
         if ((bchi[1] == LinOpBCType::Neumann || bchi[1] == LinOpBCType::inflow)
-            && j == domhi.y) zero_jhi = 0.0;
+            && j == domhi.y) zero_jhi = Real(0.0);
         if ((bclo[2] == LinOpBCType::Neumann || bclo[2] == LinOpBCType::inflow)
-            && k == domlo.z) zero_klo = 0.0;
+            && k == domlo.z) zero_klo = Real(0.0);
         if ((bchi[2] == LinOpBCType::Neumann || bchi[2] == LinOpBCType::inflow)
-            && k == domhi.z) zero_khi = 0.0;
+            && k == domhi.z) zero_khi = Real(0.0);
 
         rhs(i,j,k) = facx*(-vel(i-1,j-1,k-1,0)*zero_jlo*zero_klo+vel(i,j-1,k-1,0)*zero_jlo*zero_klo
                            -vel(i-1,j  ,k-1,0)*zero_jhi*zero_klo+vel(i,j  ,k-1,0)*zero_jhi*zero_klo
@@ -2092,10 +2092,10 @@ Real mlndlap_rhcc (int i, int j, int k, Array4<Real const> const& rhcc,
 {
     Real r;
     if (msk(i,j,k)) {
-        r = 0.0;
+        r = Real(0.0);
     } else {
-        r = 0.125 * (rhcc(i-1,j-1,k-1)+rhcc(i,j-1,k-1)+rhcc(i-1,j,k-1)+rhcc(i,j,k-1) +
-                     rhcc(i-1,j-1,k  )+rhcc(i,j-1,k  )+rhcc(i-1,j,k  )+rhcc(i,j,k  ));
+        r = Real(0.125) * (rhcc(i-1,j-1,k-1)+rhcc(i,j-1,k-1)+rhcc(i-1,j,k-1)+rhcc(i,j,k-1) +
+                           rhcc(i-1,j-1,k  )+rhcc(i,j-1,k  )+rhcc(i-1,j,k  )+rhcc(i,j,k  ));
     }
     return r;
 }
@@ -2104,9 +2104,9 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 void mlndlap_mknewu (int i, int j, int k, Array4<Real> const& u, Array4<Real const> const& p,
                      Array4<Real const> const& sig, GpuArray<Real,AMREX_SPACEDIM> const& dxinv) noexcept
 {
-    Real facx = 0.25*dxinv[0];
-    Real facy = 0.25*dxinv[1];
-    Real facz = 0.25*dxinv[2];
+    Real facx = Real(0.25)*dxinv[0];
+    Real facy = Real(0.25)*dxinv[1];
+    Real facz = Real(0.25)*dxinv[2];
     u(i,j,k,0) -= sig(i,j,k)*facx
         * (-p(i,j,k  )+p(i+1,j,k  )-p(i,j+1,k  )+p(i+1,j+1,k  )
            -p(i,j,k+1)+p(i+1,j,k+1)-p(i,j+1,k+1)+p(i+1,j+1,k+1));
@@ -2122,9 +2122,9 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 void mlndlap_mknewu_c (int i, int j, int k, Array4<Real> const& u, Array4<Real const> const& p,
                        Real sig, GpuArray<Real,AMREX_SPACEDIM> const& dxinv) noexcept
 {
-    Real facx = 0.25*dxinv[0];
-    Real facy = 0.25*dxinv[1];
-    Real facz = 0.25*dxinv[2];
+    Real facx = Real(0.25)*dxinv[0];
+    Real facy = Real(0.25)*dxinv[1];
+    Real facz = Real(0.25)*dxinv[2];
     u(i,j,k,0) -= sig*facx
         * (-p(i,j,k  )+p(i+1,j,k  )-p(i,j+1,k  )+p(i+1,j+1,k  )
            -p(i,j,k+1)+p(i+1,j,k+1)-p(i,j+1,k+1)+p(i+1,j+1,k+1));
@@ -2150,40 +2150,40 @@ void mlndlap_divu_compute_fine_contrib (int i, int j, int k, Box const& fvbx,
     IntVect iv(i,j,k);
     if (fvbx.contains(iv) && !fvbx.strictly_contains(iv))
     {
-        Real zero_ilo = 1.0;
-        Real zero_ihi = 1.0;
-        Real zero_jlo = 1.0;
-        Real zero_jhi = 1.0;
-        Real zero_klo = 1.0;
-        Real zero_khi = 1.0;
+        Real zero_ilo = Real(1.0);
+        Real zero_ihi = Real(1.0);
+        Real zero_jlo = Real(1.0);
+        Real zero_jhi = Real(1.0);
+        Real zero_klo = Real(1.0);
+        Real zero_khi = Real(1.0);
 
         // The nodal divergence operator should not see the tangential velocity
         //     at an inflow face
         if ((bclo[0] == LinOpBCType::Neumann || bclo[0] == LinOpBCType::inflow)
-            && i == domlo.x) zero_ilo = 0.0;
+            && i == domlo.x) zero_ilo = Real(0.0);
         if ((bchi[0] == LinOpBCType::Neumann || bchi[0] == LinOpBCType::inflow)
-            && i == domhi.x) zero_ihi = 0.0;
+            && i == domhi.x) zero_ihi = Real(0.0);
         if ((bclo[1] == LinOpBCType::Neumann || bclo[1] == LinOpBCType::inflow)
-            && j == domlo.y) zero_jlo = 0.0;
+            && j == domlo.y) zero_jlo = Real(0.0);
         if ((bchi[1] == LinOpBCType::Neumann || bchi[1] == LinOpBCType::inflow)
-            && j == domhi.y) zero_jhi = 0.0;
+            && j == domhi.y) zero_jhi = Real(0.0);
         if ((bclo[2] == LinOpBCType::Neumann || bclo[2] == LinOpBCType::inflow)
-            && k == domlo.z) zero_klo = 0.0;
+            && k == domlo.z) zero_klo = Real(0.0);
         if ((bchi[2] == LinOpBCType::Neumann || bchi[2] == LinOpBCType::inflow)
-            && k == domhi.z) zero_khi = 0.0;
+            && k == domhi.z) zero_khi = Real(0.0);
 
-        frh(i,j,k) = 0.25*dxinv[0]*(-vel(i-1,j-1,k-1,0)*zero_jlo*zero_klo+vel(i,j-1,k-1,0)*zero_jlo*zero_klo
-                                    -vel(i-1,j  ,k-1,0)*zero_jhi*zero_klo+vel(i,j  ,k-1,0)*zero_jhi*zero_klo
-                                    -vel(i-1,j-1,k  ,0)*zero_jlo*zero_khi+vel(i,j-1,k  ,0)*zero_jlo*zero_khi
-                                    -vel(i-1,j  ,k  ,0)*zero_jhi*zero_khi+vel(i,j  ,k  ,0)*zero_jhi*zero_khi)
-                   + 0.25*dxinv[1]*(-vel(i-1,j-1,k-1,1)*zero_ilo*zero_klo-vel(i,j-1,k-1,1)*zero_ihi*zero_klo
-                                    +vel(i-1,j  ,k-1,1)*zero_ilo*zero_klo+vel(i,j  ,k-1,1)*zero_ihi*zero_klo
-                                    -vel(i-1,j-1,k  ,1)*zero_ilo*zero_khi-vel(i,j-1,k  ,1)*zero_ihi*zero_khi
-                                    +vel(i-1,j  ,k  ,1)*zero_ilo*zero_khi+vel(i,j  ,k  ,1)*zero_ihi*zero_khi)
-                   + 0.25*dxinv[2]*(-vel(i-1,j-1,k-1,2)*zero_ilo*zero_jlo-vel(i,j-1,k-1,2)*zero_ihi*zero_jlo
-                                    -vel(i-1,j  ,k-1,2)*zero_ilo*zero_jhi-vel(i,j  ,k-1,2)*zero_ihi*zero_jhi
-                                    +vel(i-1,j-1,k  ,2)*zero_ilo*zero_jlo+vel(i,j-1,k  ,2)*zero_ihi*zero_jlo
-                                    +vel(i-1,j  ,k  ,2)*zero_ilo*zero_jhi+vel(i,j  ,k  ,2)*zero_ihi*zero_jhi);
+        frh(i,j,k) = Real(0.25)*dxinv[0]*(-vel(i-1,j-1,k-1,0)*zero_jlo*zero_klo+vel(i,j-1,k-1,0)*zero_jlo*zero_klo
+                                          -vel(i-1,j  ,k-1,0)*zero_jhi*zero_klo+vel(i,j  ,k-1,0)*zero_jhi*zero_klo
+                                          -vel(i-1,j-1,k  ,0)*zero_jlo*zero_khi+vel(i,j-1,k  ,0)*zero_jlo*zero_khi
+                                          -vel(i-1,j  ,k  ,0)*zero_jhi*zero_khi+vel(i,j  ,k  ,0)*zero_jhi*zero_khi)
+                   + Real(0.25)*dxinv[1]*(-vel(i-1,j-1,k-1,1)*zero_ilo*zero_klo-vel(i,j-1,k-1,1)*zero_ihi*zero_klo
+                                          +vel(i-1,j  ,k-1,1)*zero_ilo*zero_klo+vel(i,j  ,k-1,1)*zero_ihi*zero_klo
+                                          -vel(i-1,j-1,k  ,1)*zero_ilo*zero_khi-vel(i,j-1,k  ,1)*zero_ihi*zero_khi
+                                          +vel(i-1,j  ,k  ,1)*zero_ilo*zero_khi+vel(i,j  ,k  ,1)*zero_ihi*zero_khi)
+                   + Real(0.25)*dxinv[2]*(-vel(i-1,j-1,k-1,2)*zero_ilo*zero_jlo-vel(i,j-1,k-1,2)*zero_ihi*zero_jlo
+                                          -vel(i-1,j  ,k-1,2)*zero_ilo*zero_jhi-vel(i,j  ,k-1,2)*zero_ihi*zero_jhi
+                                          +vel(i-1,j-1,k  ,2)*zero_ilo*zero_jlo+vel(i,j-1,k  ,2)*zero_ihi*zero_jlo
+                                          +vel(i-1,j  ,k  ,2)*zero_ilo*zero_jhi+vel(i,j  ,k  ,2)*zero_ihi*zero_jhi);
     }
 }
 
@@ -2230,7 +2230,7 @@ void mlndlap_rhcc_fine_contrib (int i, int j, int k, Box const& fvbx,
     IntVect iv(ii,jj,kk);
     if (fvbx.contains(iv) && !fvbx.strictly_contains(iv) && msk(ii,jj,kk))
     {
-        Real r = 0.0;
+        Real r = Real(0.0);
         for (int koff = -2; koff <= 1; ++koff) {
         for (int joff = -2; joff <= 1; ++joff) {
         for (int ioff = -2; ioff <= 1; ++ioff) {
@@ -2834,16 +2834,16 @@ void mlndlap_set_stencil (Box const& bx, Array4<Real> const& sten,
                           Array4<Real const> const& sig,
                           GpuArray<Real,AMREX_SPACEDIM> const& dxinv) noexcept
 {
-    Real facx = (1.0/36.0)*dxinv[0]*dxinv[0];
-    Real facy = (1.0/36.0)*dxinv[1]*dxinv[1];
-    Real facz = (1.0/36.0)*dxinv[2]*dxinv[2];
+    Real facx = Real(1.0/36.0)*dxinv[0]*dxinv[0];
+    Real facy = Real(1.0/36.0)*dxinv[1]*dxinv[1];
+    Real facz = Real(1.0/36.0)*dxinv[2]*dxinv[2];
     Real fxyz = facx + facy + facz;
-    Real fmx2y2z = -facx + 2.0*facy + 2.0*facz;
-    Real f2xmy2z = 2.0*facx - facy + 2.0*facz;
-    Real f2x2ymz = 2.0*facx + 2.0*facy - facz;
-    Real f4xm2ym2z = 4.0*facx - 2.0*facy - 2.0*facz;
-    Real fm2x4ym2z = -2.0*facx + 4.0*facy - 2.0*facz;
-    Real fm2xm2y4z = -2.0*facx - 2.0*facy + 4.0*facz;
+    Real fmx2y2z = -facx + Real(2.0)*facy + Real(2.0)*facz;
+    Real f2xmy2z = Real(2.0)*facx - facy + Real(2.0)*facz;
+    Real f2x2ymz = Real(2.0)*facx + Real(2.0)*facy - facz;
+    Real f4xm2ym2z = Real(4.0)*facx - Real(2.0)*facy - Real(2.0)*facz;
+    Real fm2x4ym2z = -Real(2.0)*facx + Real(4.0)*facy - Real(2.0)*facz;
+    Real fm2xm2y4z = -Real(2.0)*facx - Real(2.0)*facy + Real(4.0)*facz;
 
     amrex::LoopConcurrent(bx, [=] (int i, int j, int k) noexcept
     {
@@ -2905,7 +2905,7 @@ void mlndlap_set_stencil_s0 (int i, int j, int k, Array4<Real> const& sten) noex
                           + sten(i-1,j,k-1,ist_ppp) + sten(i,j,k-1,ist_ppp)
                           + sten(i-1,j-1,k,ist_ppp) + sten(i,j-1,k,ist_ppp)
                           + sten(i-1,j,k,ist_ppp) + sten(i,j,k,ist_ppp));
-    sten(i,j,k,ist_inv) = 1.0 /
+    sten(i,j,k,ist_inv) = Real(1.0) /
         (  amrex::Math::abs(sten(i-1,j,k,ist_p00)) + amrex::Math::abs(sten(i,j,k,ist_p00))
          + amrex::Math::abs(sten(i,j-1,k,ist_0p0)) + amrex::Math::abs(sten(i,j,k,ist_0p0))
          + amrex::Math::abs(sten(i,j,k-1,ist_00p)) + amrex::Math::abs(sten(i,j,k,ist_00p))
@@ -5573,8 +5573,8 @@ void mlndlap_gauss_seidel_sten (Box const& bx, Array4<Real> const& sol,
     amrex::LoopConcurrent(bx, [=] (int i, int j, int k) noexcept
     {
         if (msk(i,j,k)) {
-            sol(i,j,k) = 0.0;
-        } else if (sten(i,j,k,ist_000) != 0.0) {
+            sol(i,j,k) = Real(0.0);
+        } else if (sten(i,j,k,ist_000) != Real(0.0)) {
             Real Ax  = sol(i  ,j  ,k  ) * sten(i  ,j  ,k  ,ist_000)
                 //
                 +      sol(i-1,j  ,k  ) * sten(i-1,j  ,k  ,ist_p00)
@@ -5620,7 +5620,7 @@ void mlndlap_interpadd_rap (int i, int j, int k, Array4<Real> const& fine,
                             Array4<Real const> const& crse, Array4<Real const> const& sten,
                             Array4<int const> const& msk) noexcept
 {
-    if (!msk(i,j,k) && sten(i,j,k,ist_000) != 0.0) {
+    if (!msk(i,j,k) && sten(i,j,k,ist_000) != Real(0.0)) {
         int ic = amrex::coarsen(i,2);
         int jc = amrex::coarsen(j,2);
         int kc = amrex::coarsen(k,2);
@@ -5633,24 +5633,24 @@ void mlndlap_interpadd_rap (int i, int j, int k, Array4<Real> const& fine,
         } else if (ieven && jeven) {
             Real w1 = amrex::Math::abs(sten(i,j,k-1,ist_00p));
             Real w2 = amrex::Math::abs(sten(i,j,k  ,ist_00p));
-            if (w1 == 0.0 && w2 == 0.0) {
-                fv = 0.5*(crse(ic,jc,kc)+crse(ic,jc,kc+1));
+            if (w1 == Real(0.0) && w2 == Real(0.0)) {
+                fv = Real(0.5)*(crse(ic,jc,kc)+crse(ic,jc,kc+1));
             } else {
                 fv = (w1*crse(ic,jc,kc) + w2*crse(ic,jc,kc+1)) / (w1+w2);
             }
         } else if (ieven && keven) {
             Real w1 = amrex::Math::abs(sten(i,j-1,k,ist_0p0));
             Real w2 = amrex::Math::abs(sten(i,j  ,k,ist_0p0));
-            if (w1 == 0.0 && w2 == 0.0) {
-                fv = 0.5*(crse(ic,jc,kc)+crse(ic,jc+1,kc));
+            if (w1 == Real(0.0) && w2 == Real(0.0)) {
+                fv = Real(0.5)*(crse(ic,jc,kc)+crse(ic,jc+1,kc));
             } else {
                 fv = (w1*crse(ic,jc,kc) + w2*crse(ic,jc+1,kc)) / (w1+w2);
             }
         } else if (jeven && keven) {
             Real w1 = amrex::Math::abs(sten(i-1,j,k,ist_p00));
             Real w2 = amrex::Math::abs(sten(i  ,j,k,ist_p00));
-            if (w1 == 0.0 && w2 == 0.0) {
-                fv = 0.5*(crse(ic,jc,kc)+crse(ic+1,jc,kc));
+            if (w1 == Real(0.0) && w2 == Real(0.0)) {
+                fv = Real(0.5)*(crse(ic,jc,kc)+crse(ic+1,jc,kc));
             } else {
                 fv = (w1*crse(ic,jc,kc) + w2*crse(ic+1,jc,kc)) / (w1+w2);
             }
@@ -5663,10 +5663,10 @@ void mlndlap_interpadd_rap (int i, int j, int k, Array4<Real> const& fine,
                                                          +amrex::Math::abs(sten(i,j  ,k-1,ist_0pp)) + eps);
             Real w2p = amrex::Math::abs(sten(i,j,k  ,ist_00p)) / (amrex::Math::abs(sten(i,j-1,k  ,ist_0pp))
                                                          +amrex::Math::abs(sten(i,j  ,k  ,ist_0pp)) + eps);
-            Real wmm = amrex::Math::abs(sten(i,j-1,k-1,ist_0pp)) * (1.0 + w1m + w2m);
-            Real wpm = amrex::Math::abs(sten(i,j  ,k-1,ist_0pp)) * (1.0 + w1p + w2m);
-            Real wmp = amrex::Math::abs(sten(i,j-1,k  ,ist_0pp)) * (1.0 + w1m + w2p);
-            Real wpp = amrex::Math::abs(sten(i,j  ,k  ,ist_0pp)) * (1.0 + w1p + w2p);
+            Real wmm = amrex::Math::abs(sten(i,j-1,k-1,ist_0pp)) * (Real(1.0) + w1m + w2m);
+            Real wpm = amrex::Math::abs(sten(i,j  ,k-1,ist_0pp)) * (Real(1.0) + w1p + w2m);
+            Real wmp = amrex::Math::abs(sten(i,j-1,k  ,ist_0pp)) * (Real(1.0) + w1m + w2p);
+            Real wpp = amrex::Math::abs(sten(i,j  ,k  ,ist_0pp)) * (Real(1.0) + w1p + w2p);
             fv = (wmm*crse(ic,jc,kc) + wpm*crse(ic,jc+1,kc)
                   + wmp*crse(ic,jc,kc+1) + wpp*crse(ic,jc+1,kc+1))
                 / (wmm+wpm+wmp+wpp+eps);
@@ -5679,10 +5679,10 @@ void mlndlap_interpadd_rap (int i, int j, int k, Array4<Real> const& fine,
                                                          +amrex::Math::abs(sten(i  ,j,k-1,ist_p0p)) + eps);
             Real w2p = amrex::Math::abs(sten(i,j,k  ,ist_00p)) / (amrex::Math::abs(sten(i-1,j,k  ,ist_p0p))
                                                          +amrex::Math::abs(sten(i  ,j,k  ,ist_p0p)) + eps);
-            Real wmm = amrex::Math::abs(sten(i-1,j,k-1,ist_p0p)) * (1.0 + w1m + w2m);
-            Real wpm = amrex::Math::abs(sten(i  ,j,k-1,ist_p0p)) * (1.0 + w1p + w2m);
-            Real wmp = amrex::Math::abs(sten(i-1,j,k  ,ist_p0p)) * (1.0 + w1m + w2p);
-            Real wpp = amrex::Math::abs(sten(i  ,j,k  ,ist_p0p)) * (1.0 + w1p + w2p);
+            Real wmm = amrex::Math::abs(sten(i-1,j,k-1,ist_p0p)) * (Real(1.0) + w1m + w2m);
+            Real wpm = amrex::Math::abs(sten(i  ,j,k-1,ist_p0p)) * (Real(1.0) + w1p + w2m);
+            Real wmp = amrex::Math::abs(sten(i-1,j,k  ,ist_p0p)) * (Real(1.0) + w1m + w2p);
+            Real wpp = amrex::Math::abs(sten(i  ,j,k  ,ist_p0p)) * (Real(1.0) + w1p + w2p);
             fv = (wmm*crse(ic,jc,kc) + wpm*crse(ic+1,jc,kc)
                   + wmp*crse(ic,jc,kc+1) + wpp*crse(ic+1,jc,kc+1))
                 / (wmm+wpm+wmp+wpp+eps);
@@ -5695,22 +5695,22 @@ void mlndlap_interpadd_rap (int i, int j, int k, Array4<Real> const& fine,
                                                          +amrex::Math::abs(sten(i  ,j-1,k,ist_pp0)) + eps);
             Real w2p = amrex::Math::abs(sten(i,j  ,k,ist_0p0)) / (amrex::Math::abs(sten(i-1,j  ,k,ist_pp0))
                                                          +amrex::Math::abs(sten(i  ,j  ,k,ist_pp0)) + eps);
-            Real wmm = amrex::Math::abs(sten(i-1,j-1,k,ist_pp0)) * (1.0 + w1m + w2m);
-            Real wpm = amrex::Math::abs(sten(i  ,j-1,k,ist_pp0)) * (1.0 + w1p + w2m);
-            Real wmp = amrex::Math::abs(sten(i-1,j  ,k,ist_pp0)) * (1.0 + w1m + w2p);
-            Real wpp = amrex::Math::abs(sten(i  ,j  ,k,ist_pp0)) * (1.0 + w1p + w2p);
+            Real wmm = amrex::Math::abs(sten(i-1,j-1,k,ist_pp0)) * (Real(1.0) + w1m + w2m);
+            Real wpm = amrex::Math::abs(sten(i  ,j-1,k,ist_pp0)) * (Real(1.0) + w1p + w2m);
+            Real wmp = amrex::Math::abs(sten(i-1,j  ,k,ist_pp0)) * (Real(1.0) + w1m + w2p);
+            Real wpp = amrex::Math::abs(sten(i  ,j  ,k,ist_pp0)) * (Real(1.0) + w1p + w2p);
             fv = (wmm*crse(ic,jc,kc) + wpm*crse(ic+1,jc,kc)
                   + wmp*crse(ic,jc+1,kc) + wpp*crse(ic+1,jc+1,kc))
                 / (wmm+wpm+wmp+wpp+eps);
         } else {
-            Real wmmm = 1.0;
-            Real wpmm = 1.0;
-            Real wmpm = 1.0;
-            Real wppm = 1.0;
-            Real wmmp = 1.0;
-            Real wpmp = 1.0;
-            Real wmpp = 1.0;
-            Real wppp = 1.0;
+            Real wmmm = Real(1.0);
+            Real wpmm = Real(1.0);
+            Real wmpm = Real(1.0);
+            Real wppm = Real(1.0);
+            Real wmmp = Real(1.0);
+            Real wpmp = Real(1.0);
+            Real wmpp = Real(1.0);
+            Real wppp = Real(1.0);
 
             Real wtmp = amrex::Math::abs(sten(i-1,j,k,ist_p00)) /
                 ( amrex::Math::abs(sten(i-1,j-1,k-1,ist_ppp))
@@ -5872,7 +5872,7 @@ void mlndlap_restriction_rap (int i, int j, int k, Array4<Real> const& crse,
     int jj = j*2;
     int kk = k*2;
     if (msk(ii,jj,kk)) {
-        crse(i,j,k) = 0.0;
+        crse(i,j,k) = Real(0.0);
     } else {
 
         Real cv = fine(ii,jj,kk);
@@ -5884,8 +5884,8 @@ void mlndlap_restriction_rap (int i, int j, int k, Array4<Real> const& crse,
         Real sten_lo = amrex::Math::abs(sten(ii-2,jj,kk,ist_p00));
         Real sten_hi = amrex::Math::abs(sten(ii-1,jj,kk,ist_p00));
 
-        if (sten_lo == 0.0 && sten_hi == 0.0) {
-            cv += 0.5*fine(ii-1,jj,kk);
+        if (sten_lo == Real(0.0) && sten_hi == Real(0.0)) {
+            cv += Real(0.5)*fine(ii-1,jj,kk);
         } else {
             cv += fine(ii-1,jj,kk) * sten_hi / (sten_lo + sten_hi);
         }
@@ -5897,8 +5897,8 @@ void mlndlap_restriction_rap (int i, int j, int k, Array4<Real> const& crse,
         sten_lo = amrex::Math::abs(sten(ii  ,jj,kk,ist_p00));
         sten_hi = amrex::Math::abs(sten(ii+1,jj,kk,ist_p00));
 
-        if (sten_lo == 0.0 && sten_hi == 0.0) {
-            cv += 0.5*fine(ii+1,jj,kk);
+        if (sten_lo == Real(0.0) && sten_hi == Real(0.0)) {
+            cv += Real(0.5)*fine(ii+1,jj,kk);
         } else {
             cv += fine(ii+1,jj,kk) * sten_lo / (sten_lo + sten_hi);
         }
@@ -5910,8 +5910,8 @@ void mlndlap_restriction_rap (int i, int j, int k, Array4<Real> const& crse,
         sten_lo = amrex::Math::abs(sten(ii,jj-2,kk,ist_0p0));
         sten_hi = amrex::Math::abs(sten(ii,jj-1,kk,ist_0p0));
 
-        if (sten_lo == 0.0 && sten_hi == 0.0) {
-            cv += 0.5*fine(ii,jj-1,kk);
+        if (sten_lo == Real(0.0) && sten_hi == Real(0.0)) {
+            cv += Real(0.5)*fine(ii,jj-1,kk);
         } else {
             cv += fine(ii,jj-1,kk) * sten_hi / (sten_lo + sten_hi);
         }
@@ -5923,8 +5923,8 @@ void mlndlap_restriction_rap (int i, int j, int k, Array4<Real> const& crse,
         sten_lo = amrex::Math::abs(sten(ii,jj  ,kk,ist_0p0));
         sten_hi = amrex::Math::abs(sten(ii,jj+1,kk,ist_0p0));
 
-        if (sten_lo == 0.0 && sten_hi == 0.0) {
-            cv += 0.5*fine(ii,jj+1,kk);
+        if (sten_lo == Real(0.0) && sten_hi == Real(0.0)) {
+            cv += Real(0.5)*fine(ii,jj+1,kk);
         } else {
             cv += fine(ii,jj+1,kk) * sten_lo / (sten_lo + sten_hi);
         }
@@ -5936,8 +5936,8 @@ void mlndlap_restriction_rap (int i, int j, int k, Array4<Real> const& crse,
         sten_lo = amrex::Math::abs(sten(ii,jj,kk-2,ist_00p));
         sten_hi = amrex::Math::abs(sten(ii,jj,kk-1,ist_00p));
 
-        if (sten_lo == 0.0 && sten_hi == 0.0) {
-            cv += 0.5*fine(ii,jj,kk-1);
+        if (sten_lo == Real(0.0) && sten_hi == Real(0.0)) {
+            cv += Real(0.5)*fine(ii,jj,kk-1);
         } else {
             cv += fine(ii,jj,kk-1)*sten_hi / (sten_lo + sten_hi);
         }
@@ -5949,8 +5949,8 @@ void mlndlap_restriction_rap (int i, int j, int k, Array4<Real> const& crse,
         sten_lo = amrex::Math::abs(sten(ii,jj,kk  ,ist_00p));
         sten_hi = amrex::Math::abs(sten(ii,jj,kk+1,ist_00p));
 
-        if (sten_lo == 0.0 && sten_hi == 0.0) {
-            cv += 0.5*fine(ii,jj,kk+1);
+        if (sten_lo == Real(0.0) && sten_hi == Real(0.0)) {
+            cv += Real(0.5)*fine(ii,jj,kk+1);
         } else {
             cv += fine(ii,jj,kk+1)*sten_lo  / (sten_lo + sten_hi);
         }
@@ -5972,10 +5972,10 @@ void mlndlap_restriction_rap (int i, int j, int k, Array4<Real> const& crse,
         Real w2p = amrex::Math::abs(sten(ii-1,jj-1,kk,ist_0p0))
             / (    amrex::Math::abs(sten(ii-2,jj-1,kk,ist_pp0))
                   +amrex::Math::abs(sten(ii-1,jj-1,kk,ist_pp0)) + eps);
-        Real wmm = amrex::Math::abs(sten(ii-2,jj-2,kk,ist_pp0)) * (1.0 + w1m + w2m);
-        Real wpm = amrex::Math::abs(sten(ii-1,jj-2,kk,ist_pp0)) * (1.0 + w1p + w2m);
-        Real wmp = amrex::Math::abs(sten(ii-2,jj-1,kk,ist_pp0)) * (1.0 + w1m + w2p);
-        Real wpp = amrex::Math::abs(sten(ii-1,jj-1,kk,ist_pp0)) * (1.0 + w1p + w2p);
+        Real wmm = amrex::Math::abs(sten(ii-2,jj-2,kk,ist_pp0)) * (Real(1.0) + w1m + w2m);
+        Real wpm = amrex::Math::abs(sten(ii-1,jj-2,kk,ist_pp0)) * (Real(1.0) + w1p + w2m);
+        Real wmp = amrex::Math::abs(sten(ii-2,jj-1,kk,ist_pp0)) * (Real(1.0) + w1m + w2p);
+        Real wpp = amrex::Math::abs(sten(ii-1,jj-1,kk,ist_pp0)) * (Real(1.0) + w1p + w2p);
         cv += fine(ii-1,jj-1,kk)*wpp/(wmm+wpm+wmp+wpp+eps);
 
         // ************************************
@@ -5994,10 +5994,10 @@ void mlndlap_restriction_rap (int i, int j, int k, Array4<Real> const& crse,
         w2p = amrex::Math::abs(sten(ii+1,jj-1,kk,ist_0p0))
            / (amrex::Math::abs(sten(ii  ,jj-1,kk,ist_pp0))
              +amrex::Math::abs(sten(ii+1,jj-1,kk,ist_pp0)) + eps);
-        wmm = amrex::Math::abs(sten(ii  ,jj-2,kk,ist_pp0)) * (1.0 + w1m + w2m);
-        wpm = amrex::Math::abs(sten(ii+1,jj-2,kk,ist_pp0)) * (1.0 + w1p + w2m);
-        wmp = amrex::Math::abs(sten(ii  ,jj-1,kk,ist_pp0)) * (1.0 + w1m + w2p);
-        wpp = amrex::Math::abs(sten(ii+1,jj-1,kk,ist_pp0)) * (1.0 + w1p + w2p);
+        wmm = amrex::Math::abs(sten(ii  ,jj-2,kk,ist_pp0)) * (Real(1.0) + w1m + w2m);
+        wpm = amrex::Math::abs(sten(ii+1,jj-2,kk,ist_pp0)) * (Real(1.0) + w1p + w2m);
+        wmp = amrex::Math::abs(sten(ii  ,jj-1,kk,ist_pp0)) * (Real(1.0) + w1m + w2p);
+        wpp = amrex::Math::abs(sten(ii+1,jj-1,kk,ist_pp0)) * (Real(1.0) + w1p + w2p);
         cv += fine(ii+1,jj-1,kk)*wmp/(wmm+wpm+wmp+wpp+eps);
 
         // ************************************
@@ -6016,10 +6016,10 @@ void mlndlap_restriction_rap (int i, int j, int k, Array4<Real> const& crse,
         w2p = amrex::Math::abs(sten(ii-1,jj+1,kk,ist_0p0))
            / (amrex::Math::abs(sten(ii-2,jj+1,kk,ist_pp0))
              +amrex::Math::abs(sten(ii-1,jj+1,kk,ist_pp0)) + eps);
-        wmm = amrex::Math::abs(sten(ii-2,jj  ,kk,ist_pp0)) * (1.0 + w1m + w2m);
-        wpm = amrex::Math::abs(sten(ii-1,jj  ,kk,ist_pp0)) * (1.0 + w1p + w2m);
-        wmp = amrex::Math::abs(sten(ii-2,jj+1,kk,ist_pp0)) * (1.0 + w1m + w2p);
-        wpp = amrex::Math::abs(sten(ii-1,jj+1,kk,ist_pp0)) * (1.0 + w1p + w2p);
+        wmm = amrex::Math::abs(sten(ii-2,jj  ,kk,ist_pp0)) * (Real(1.0) + w1m + w2m);
+        wpm = amrex::Math::abs(sten(ii-1,jj  ,kk,ist_pp0)) * (Real(1.0) + w1p + w2m);
+        wmp = amrex::Math::abs(sten(ii-2,jj+1,kk,ist_pp0)) * (Real(1.0) + w1m + w2p);
+        wpp = amrex::Math::abs(sten(ii-1,jj+1,kk,ist_pp0)) * (Real(1.0) + w1p + w2p);
         cv += fine(ii-1,jj+1,kk)*wpm/(wmm+wpm+wmp+wpp+eps);
 
         // ************************************
@@ -6038,10 +6038,10 @@ void mlndlap_restriction_rap (int i, int j, int k, Array4<Real> const& crse,
         w2p = amrex::Math::abs(sten(ii+1,jj+1,kk,ist_0p0))
            / (amrex::Math::abs(sten(ii+1,jj+1,kk,ist_pp0))
              +amrex::Math::abs(sten(ii  ,jj+1,kk,ist_pp0)) + eps);
-        wmm = amrex::Math::abs(sten(ii  ,jj  ,kk,ist_pp0)) * (1.0 + w1m + w2m);
-        wpm = amrex::Math::abs(sten(ii+1,jj  ,kk,ist_pp0)) * (1.0 + w1p + w2m);
-        wmp = amrex::Math::abs(sten(ii  ,jj+1,kk,ist_pp0)) * (1.0 + w1m + w2p);
-        wpp = amrex::Math::abs(sten(ii+1,jj+1,kk,ist_pp0)) * (1.0 + w1p + w2p);
+        wmm = amrex::Math::abs(sten(ii  ,jj  ,kk,ist_pp0)) * (Real(1.0) + w1m + w2m);
+        wpm = amrex::Math::abs(sten(ii+1,jj  ,kk,ist_pp0)) * (Real(1.0) + w1p + w2m);
+        wmp = amrex::Math::abs(sten(ii  ,jj+1,kk,ist_pp0)) * (Real(1.0) + w1m + w2p);
+        wpp = amrex::Math::abs(sten(ii+1,jj+1,kk,ist_pp0)) * (Real(1.0) + w1p + w2p);
         cv += fine(ii+1,jj+1,kk)*wmm/(wmm+wpm+wmp+wpp+eps);
 
         // ************************************
@@ -6061,10 +6061,10 @@ void mlndlap_restriction_rap (int i, int j, int k, Array4<Real> const& crse,
         w2p = amrex::Math::abs(sten(ii-1,jj,kk-1,ist_00p))
            / (amrex::Math::abs(sten(ii-2,jj,kk-1,ist_p0p))
              +amrex::Math::abs(sten(ii-1,jj,kk-1,ist_p0p)) + eps);
-        wmm = amrex::Math::abs(sten(ii-2,jj,kk-2,ist_p0p)) * (1.0 + w1m + w2m);
-        wpm = amrex::Math::abs(sten(ii-1,jj,kk-2,ist_p0p)) * (1.0 + w1p + w2m);
-        wmp = amrex::Math::abs(sten(ii-2,jj,kk-1,ist_p0p)) * (1.0 + w1m + w2p);
-        wpp = amrex::Math::abs(sten(ii-1,jj,kk-1,ist_p0p)) * (1.0 + w1p + w2p);
+        wmm = amrex::Math::abs(sten(ii-2,jj,kk-2,ist_p0p)) * (Real(1.0) + w1m + w2m);
+        wpm = amrex::Math::abs(sten(ii-1,jj,kk-2,ist_p0p)) * (Real(1.0) + w1p + w2m);
+        wmp = amrex::Math::abs(sten(ii-2,jj,kk-1,ist_p0p)) * (Real(1.0) + w1m + w2p);
+        wpp = amrex::Math::abs(sten(ii-1,jj,kk-1,ist_p0p)) * (Real(1.0) + w1p + w2p);
         cv += fine(ii-1,jj,kk-1)*wpp/(wmm+wpm+wmp+wpp+eps);
 
         // ************************************
@@ -6083,10 +6083,10 @@ void mlndlap_restriction_rap (int i, int j, int k, Array4<Real> const& crse,
         w2p = amrex::Math::abs(sten(ii+1,jj,kk-1,ist_00p))
            / (amrex::Math::abs(sten(ii+1,jj,kk-1,ist_p0p))
              +amrex::Math::abs(sten(ii  ,jj,kk-1,ist_p0p)) + eps);
-        wmm = amrex::Math::abs(sten(ii  ,jj,kk-2,ist_p0p)) * (1.0 + w1m + w2m);
-        wpm = amrex::Math::abs(sten(ii+1,jj,kk-2,ist_p0p)) * (1.0 + w1p + w2m);
-        wmp = amrex::Math::abs(sten(ii  ,jj,kk-1,ist_p0p)) * (1.0 + w1m + w2p);
-        wpp = amrex::Math::abs(sten(ii+1,jj,kk-1,ist_p0p)) * (1.0 + w1p + w2p);
+        wmm = amrex::Math::abs(sten(ii  ,jj,kk-2,ist_p0p)) * (Real(1.0) + w1m + w2m);
+        wpm = amrex::Math::abs(sten(ii+1,jj,kk-2,ist_p0p)) * (Real(1.0) + w1p + w2m);
+        wmp = amrex::Math::abs(sten(ii  ,jj,kk-1,ist_p0p)) * (Real(1.0) + w1m + w2p);
+        wpp = amrex::Math::abs(sten(ii+1,jj,kk-1,ist_p0p)) * (Real(1.0) + w1p + w2p);
         cv += fine(ii+1,jj,kk-1)*wmp/(wmm+wpm+wmp+wpp+eps);
 
         // ************************************
@@ -6105,10 +6105,10 @@ void mlndlap_restriction_rap (int i, int j, int k, Array4<Real> const& crse,
         w2p = amrex::Math::abs(sten(ii-1,jj,kk+1,ist_00p))
            / (amrex::Math::abs(sten(ii-2,jj,kk+1,ist_p0p))
              +amrex::Math::abs(sten(ii-1,jj,kk+1,ist_p0p)) + eps);
-        wmm = amrex::Math::abs(sten(ii-2,jj,kk  ,ist_p0p)) * (1.0 + w1m + w2m);
-        wpm = amrex::Math::abs(sten(ii-1,jj,kk  ,ist_p0p)) * (1.0 + w1p + w2m);
-        wmp = amrex::Math::abs(sten(ii-2,jj,kk+1,ist_p0p)) * (1.0 + w1m + w2p);
-        wpp = amrex::Math::abs(sten(ii-1,jj,kk+1,ist_p0p)) * (1.0 + w1p + w2p);
+        wmm = amrex::Math::abs(sten(ii-2,jj,kk  ,ist_p0p)) * (Real(1.0) + w1m + w2m);
+        wpm = amrex::Math::abs(sten(ii-1,jj,kk  ,ist_p0p)) * (Real(1.0) + w1p + w2m);
+        wmp = amrex::Math::abs(sten(ii-2,jj,kk+1,ist_p0p)) * (Real(1.0) + w1m + w2p);
+        wpp = amrex::Math::abs(sten(ii-1,jj,kk+1,ist_p0p)) * (Real(1.0) + w1p + w2p);
         cv += fine(ii-1,jj,kk+1)*wpm/(wmm+wpm+wmp+wpp+eps);
 
         // ************************************
@@ -6127,10 +6127,10 @@ void mlndlap_restriction_rap (int i, int j, int k, Array4<Real> const& crse,
         w2p = amrex::Math::abs(sten(ii+1,jj,kk+1,ist_00p))
            / (amrex::Math::abs(sten(ii+1,jj,kk+1,ist_p0p))
              +amrex::Math::abs(sten(ii  ,jj,kk+1,ist_p0p)) + eps);
-        wmm = amrex::Math::abs(sten(ii  ,jj,kk  ,ist_p0p)) * (1.0 + w1m + w2m);
-        wpm = amrex::Math::abs(sten(ii+1,jj,kk  ,ist_p0p)) * (1.0 + w1p + w2m);
-        wmp = amrex::Math::abs(sten(ii  ,jj,kk+1,ist_p0p)) * (1.0 + w1m + w2p);
-        wpp = amrex::Math::abs(sten(ii+1,jj,kk+1,ist_p0p)) * (1.0 + w1p + w2p);
+        wmm = amrex::Math::abs(sten(ii  ,jj,kk  ,ist_p0p)) * (Real(1.0) + w1m + w2m);
+        wpm = amrex::Math::abs(sten(ii+1,jj,kk  ,ist_p0p)) * (Real(1.0) + w1p + w2m);
+        wmp = amrex::Math::abs(sten(ii  ,jj,kk+1,ist_p0p)) * (Real(1.0) + w1m + w2p);
+        wpp = amrex::Math::abs(sten(ii+1,jj,kk+1,ist_p0p)) * (Real(1.0) + w1p + w2p);
         cv += fine(ii+1,jj,kk+1)*wmm/(wmm+wpm+wmp+wpp+eps);
 
         // ************************************
@@ -6150,10 +6150,10 @@ void mlndlap_restriction_rap (int i, int j, int k, Array4<Real> const& crse,
         w2p = amrex::Math::abs(sten(ii,jj-1,kk-1,ist_00p))
            / (amrex::Math::abs(sten(ii,jj-2,kk-1,ist_0pp))
              +amrex::Math::abs(sten(ii,jj-1,kk-1,ist_0pp)) + eps);
-        wmm = amrex::Math::abs(sten(ii,jj-2,kk-2,ist_0pp)) * (1.0 + w1m + w2m);
-        wpm = amrex::Math::abs(sten(ii,jj-1,kk-2,ist_0pp)) * (1.0 + w1p + w2m);
-        wmp = amrex::Math::abs(sten(ii,jj-2,kk-1,ist_0pp)) * (1.0 + w1m + w2p);
-        wpp = amrex::Math::abs(sten(ii,jj-1,kk-1,ist_0pp)) * (1.0 + w1p + w2p);
+        wmm = amrex::Math::abs(sten(ii,jj-2,kk-2,ist_0pp)) * (Real(1.0) + w1m + w2m);
+        wpm = amrex::Math::abs(sten(ii,jj-1,kk-2,ist_0pp)) * (Real(1.0) + w1p + w2m);
+        wmp = amrex::Math::abs(sten(ii,jj-2,kk-1,ist_0pp)) * (Real(1.0) + w1m + w2p);
+        wpp = amrex::Math::abs(sten(ii,jj-1,kk-1,ist_0pp)) * (Real(1.0) + w1p + w2p);
         cv += fine(ii,jj-1,kk-1)*wpp/(wmm+wpm+wmp+wpp+eps);
 
         // ************************************
@@ -6172,10 +6172,10 @@ void mlndlap_restriction_rap (int i, int j, int k, Array4<Real> const& crse,
         w2p = amrex::Math::abs(sten(ii,jj+1,kk-1,ist_00p))
            / (amrex::Math::abs(sten(ii,jj+1,kk-1,ist_0pp))
              +amrex::Math::abs(sten(ii,jj  ,kk-1,ist_0pp)) + eps);
-        wmm = amrex::Math::abs(sten(ii,jj  ,kk-2,ist_0pp)) * (1.0 + w1m + w2m);
-        wpm = amrex::Math::abs(sten(ii,jj+1,kk-2,ist_0pp)) * (1.0 + w1p + w2m);
-        wmp = amrex::Math::abs(sten(ii,jj  ,kk-1,ist_0pp)) * (1.0 + w1m + w2p);
-        wpp = amrex::Math::abs(sten(ii,jj+1,kk-1,ist_0pp)) * (1.0 + w1p + w2p);
+        wmm = amrex::Math::abs(sten(ii,jj  ,kk-2,ist_0pp)) * (Real(1.0) + w1m + w2m);
+        wpm = amrex::Math::abs(sten(ii,jj+1,kk-2,ist_0pp)) * (Real(1.0) + w1p + w2m);
+        wmp = amrex::Math::abs(sten(ii,jj  ,kk-1,ist_0pp)) * (Real(1.0) + w1m + w2p);
+        wpp = amrex::Math::abs(sten(ii,jj+1,kk-1,ist_0pp)) * (Real(1.0) + w1p + w2p);
         cv += fine(ii,jj+1,kk-1)*wmp/(wmm+wpm+wmp+wpp+eps);
 
         // ************************************
@@ -6194,10 +6194,10 @@ void mlndlap_restriction_rap (int i, int j, int k, Array4<Real> const& crse,
         w2p = amrex::Math::abs(sten(ii,jj-1,kk+1,ist_00p))
            / (amrex::Math::abs(sten(ii,jj-2,kk+1,ist_0pp))
              +amrex::Math::abs(sten(ii,jj-1,kk+1,ist_0pp)) + eps);
-        wmm = amrex::Math::abs(sten(ii,jj-2,kk  ,ist_0pp)) * (1.0 + w1m + w2m);
-        wpm = amrex::Math::abs(sten(ii,jj-1,kk  ,ist_0pp)) * (1.0 + w1p + w2m);
-        wmp = amrex::Math::abs(sten(ii,jj-2,kk+1,ist_0pp)) * (1.0 + w1m + w2p);
-        wpp = amrex::Math::abs(sten(ii,jj-1,kk+1,ist_0pp)) * (1.0 + w1p + w2p);
+        wmm = amrex::Math::abs(sten(ii,jj-2,kk  ,ist_0pp)) * (Real(1.0) + w1m + w2m);
+        wpm = amrex::Math::abs(sten(ii,jj-1,kk  ,ist_0pp)) * (Real(1.0) + w1p + w2m);
+        wmp = amrex::Math::abs(sten(ii,jj-2,kk+1,ist_0pp)) * (Real(1.0) + w1m + w2p);
+        wpp = amrex::Math::abs(sten(ii,jj-1,kk+1,ist_0pp)) * (Real(1.0) + w1p + w2p);
         cv += fine(ii,jj-1,kk+1)*wpm/(wmm+wpm+wmp+wpp+eps);
 
         // ************************************
@@ -6216,17 +6216,17 @@ void mlndlap_restriction_rap (int i, int j, int k, Array4<Real> const& crse,
         w2p = amrex::Math::abs(sten(ii,jj+1,kk+1,ist_00p))
            / (amrex::Math::abs(sten(ii,jj+1,kk+1,ist_0pp))
              +amrex::Math::abs(sten(ii,jj  ,kk+1,ist_0pp)) + eps);
-        wmm = amrex::Math::abs(sten(ii,jj  ,kk  ,ist_0pp)) * (1.0 + w1m + w2m);
-        wpm = amrex::Math::abs(sten(ii,jj+1,kk  ,ist_0pp)) * (1.0 + w1p + w2m);
-        wmp = amrex::Math::abs(sten(ii,jj  ,kk+1,ist_0pp)) * (1.0 + w1m + w2p);
-        wpp = amrex::Math::abs(sten(ii,jj+1,kk+1,ist_0pp)) * (1.0 + w1p + w2p);
+        wmm = amrex::Math::abs(sten(ii,jj  ,kk  ,ist_0pp)) * (Real(1.0) + w1m + w2m);
+        wpm = amrex::Math::abs(sten(ii,jj+1,kk  ,ist_0pp)) * (Real(1.0) + w1p + w2m);
+        wmp = amrex::Math::abs(sten(ii,jj  ,kk+1,ist_0pp)) * (Real(1.0) + w1m + w2p);
+        wpp = amrex::Math::abs(sten(ii,jj+1,kk+1,ist_0pp)) * (Real(1.0) + w1p + w2p);
         cv += fine(ii,jj+1,kk+1)*wmm/(wmm+wpm+wmp+wpp+eps);
 
         // ************************************
         // Adding fine at corners
         // ************************************
 
-        Real wmmm = 1.0
+        Real wmmm = Real(1.0)
             + amrex::Math::abs(sten(ii  ,jj+1,kk+1,ist_p00)) /
             ( amrex::Math::abs(sten(ii  ,jj  ,kk  ,ist_ppp))
             + amrex::Math::abs(sten(ii  ,jj+1,kk  ,ist_ppp))
@@ -6254,7 +6254,7 @@ void mlndlap_restriction_rap (int i, int j, int k, Array4<Real> const& crse,
         wmmm *= amrex::Math::abs(sten(ii,jj,kk,ist_ppp));
         cv += wmmm*fine(ii+1,jj+1,kk+1)*sten(ii+1,jj+1,kk+1,ist_inv);
 
-        Real wpmm = 1.0
+        Real wpmm = Real(1.0)
             + amrex::Math::abs(sten(ii-1,jj+1,kk+1,ist_p00)) /
             ( amrex::Math::abs(sten(ii-1,jj  ,kk  ,ist_ppp))
             + amrex::Math::abs(sten(ii-1,jj+1,kk  ,ist_ppp))
@@ -6282,7 +6282,7 @@ void mlndlap_restriction_rap (int i, int j, int k, Array4<Real> const& crse,
         wpmm *= amrex::Math::abs(sten(ii-1,jj,kk,ist_ppp));
         cv += wpmm*fine(ii-1,jj+1,kk+1)*sten(ii-1,jj+1,kk+1,ist_inv);
 
-        Real wmpm = 1.0
+        Real wmpm = Real(1.0)
             + amrex::Math::abs(sten(ii  ,jj-1,kk+1,ist_p00)) /
             ( amrex::Math::abs(sten(ii  ,jj-2,kk  ,ist_ppp))
             + amrex::Math::abs(sten(ii  ,jj-1,kk  ,ist_ppp))
@@ -6310,7 +6310,7 @@ void mlndlap_restriction_rap (int i, int j, int k, Array4<Real> const& crse,
         wmpm *= amrex::Math::abs(sten(ii  ,jj-1,kk  ,ist_ppp));
         cv += wmpm*fine(ii+1,jj-1,kk+1)*sten(ii+1,jj-1,kk+1,ist_inv);
 
-        Real wppm = 1.0
+        Real wppm = Real(1.0)
             + amrex::Math::abs(sten(ii-1,jj-1,kk+1,ist_p00)) /
             ( amrex::Math::abs(sten(ii-1,jj-2,kk  ,ist_ppp))
             + amrex::Math::abs(sten(ii-1,jj-1,kk  ,ist_ppp))
@@ -6338,7 +6338,7 @@ void mlndlap_restriction_rap (int i, int j, int k, Array4<Real> const& crse,
         wppm *= amrex::Math::abs(sten(ii-1,jj-1,kk  ,ist_ppp));
         cv += wppm*fine(ii-1,jj-1,kk+1)*sten(ii-1,jj-1,kk+1,ist_inv);
 
-        Real wmmp = 1.0
+        Real wmmp = Real(1.0)
             + amrex::Math::abs(sten(ii  ,jj+1,kk-1,ist_p00)) /
             ( amrex::Math::abs(sten(ii  ,jj  ,kk-2,ist_ppp))
             + amrex::Math::abs(sten(ii  ,jj+1,kk-2,ist_ppp))
@@ -6366,7 +6366,7 @@ void mlndlap_restriction_rap (int i, int j, int k, Array4<Real> const& crse,
         wmmp *= amrex::Math::abs(sten(ii  ,jj  ,kk-1,ist_ppp));
         cv += wmmp*fine(ii+1,jj+1,kk-1)*sten(ii+1,jj+1,kk-1,ist_inv);
 
-        Real wpmp = 1.0
+        Real wpmp = Real(1.0)
             + amrex::Math::abs(sten(ii-1,jj+1,kk-1,ist_p00)) /
             ( amrex::Math::abs(sten(ii-1,jj  ,kk-2,ist_ppp))
             + amrex::Math::abs(sten(ii-1,jj+1,kk-2,ist_ppp))
@@ -6394,7 +6394,7 @@ void mlndlap_restriction_rap (int i, int j, int k, Array4<Real> const& crse,
         wpmp *= amrex::Math::abs(sten(ii-1,jj  ,kk-1,ist_ppp));
         cv += wpmp*fine(ii-1,jj+1,kk-1)*sten(ii-1,jj+1,kk-1,ist_inv);
 
-        Real wmpp = 1.0
+        Real wmpp = Real(1.0)
             + amrex::Math::abs(sten(ii  ,jj-1,kk-1,ist_p00)) /
             ( amrex::Math::abs(sten(ii  ,jj-2,kk-2,ist_ppp))
             + amrex::Math::abs(sten(ii  ,jj-1,kk-2,ist_ppp))
@@ -6422,7 +6422,7 @@ void mlndlap_restriction_rap (int i, int j, int k, Array4<Real> const& crse,
         wmpp *= amrex::Math::abs(sten(ii  ,jj-1,kk-1,ist_ppp));
         cv += wmpp*fine(ii+1,jj-1,kk-1)*sten(ii+1,jj-1,kk-1,ist_inv);
 
-        Real wppp = 1.0
+        Real wppp = Real(1.0)
             + amrex::Math::abs(sten(ii-1,jj-1,kk-1,ist_p00)) /
             ( amrex::Math::abs(sten(ii-1,jj-2,kk-2,ist_ppp))
             + amrex::Math::abs(sten(ii-1,jj-1,kk-2,ist_ppp))
@@ -6450,7 +6450,7 @@ void mlndlap_restriction_rap (int i, int j, int k, Array4<Real> const& crse,
         wppp *= amrex::Math::abs(sten(ii-1,jj-1,kk-1,ist_ppp));
         cv += wppp*fine(ii-1,jj-1,kk-1)*sten(ii-1,jj-1,kk-1,ist_inv);
 
-        crse(i,j,k) = cv * 0.125;
+        crse(i,j,k) = cv * Real(0.125);
     }
 }
 
@@ -6747,27 +6747,27 @@ void mlndlap_divu_eb (int i, int j, int k, Array4<Real> const& rhs, Array4<Real 
 
     if (!msk(i,j,k)) {
 
-        Real zero_ilo = 1.0;
-        Real zero_ihi = 1.0;
-        Real zero_jlo = 1.0;
-        Real zero_jhi = 1.0;
-        Real zero_klo = 1.0;
-        Real zero_khi = 1.0;
+        Real zero_ilo = Real(1.0);
+        Real zero_ihi = Real(1.0);
+        Real zero_jlo = Real(1.0);
+        Real zero_jhi = Real(1.0);
+        Real zero_klo = Real(1.0);
+        Real zero_khi = Real(1.0);
 
         // The nodal divergence operator should not see the tangential velocity
         //     at an inflow face
         if ((bclo[0] == LinOpBCType::Neumann || bclo[0] == LinOpBCType::inflow)
-            && i == domlo.x) zero_ilo = 0.0;
+            && i == domlo.x) zero_ilo = Real(0.0);
         if ((bchi[0] == LinOpBCType::Neumann || bchi[0] == LinOpBCType::inflow)
-            && i == domhi.x) zero_ihi = 0.0;
+            && i == domhi.x) zero_ihi = Real(0.0);
         if ((bclo[1] == LinOpBCType::Neumann || bclo[1] == LinOpBCType::inflow)
-            && j == domlo.y) zero_jlo = 0.0;
+            && j == domlo.y) zero_jlo = Real(0.0);
         if ((bchi[1] == LinOpBCType::Neumann || bchi[1] == LinOpBCType::inflow)
-            && j == domhi.y) zero_jhi = 0.0;
+            && j == domhi.y) zero_jhi = Real(0.0);
         if ((bclo[2] == LinOpBCType::Neumann || bclo[2] == LinOpBCType::inflow)
-            && k == domlo.z) zero_klo = 0.0;
+            && k == domlo.z) zero_klo = Real(0.0);
         if ((bchi[2] == LinOpBCType::Neumann || bchi[2] == LinOpBCType::inflow)
-            && k == domhi.z) zero_khi = 0.0;
+            && k == domhi.z) zero_khi = Real(0.0);
 
         rhs(i,j,k) = facx*(
             vel(i-1,j-1,k  ,0)*(    -vfrac(i-1,j-1,k  )

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLap_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLap_K.H
@@ -17,9 +17,9 @@ namespace {
     constexpr int crse_fine_node = 1;
     constexpr int fine_node = 2;
 #if (BL_USE_FLOAT)
-    constexpr float eps = 1.e-30;
+    constexpr float eps = 1.e-30_rt;
 #else
-    constexpr double eps = 1.e-100;
+    constexpr double eps = 1.e-100_rt;
 #endif
     constexpr Real almostone = Real(1.) - Real(100.)*std::numeric_limits<Real>::epsilon();
 

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian.H
@@ -20,14 +20,14 @@ public :
                      const Vector<DistributionMapping>& a_dmap,
                      const LPInfo& a_info = LPInfo(),
                      const Vector<FabFactory<FArrayBox> const*>& a_factory = {},
-                     Real  a_const_sigma = 0.0);
+                     Real  a_const_sigma = Real(0.0));
 #ifdef AMREX_USE_EB
     MLNodeLaplacian (const Vector<Geometry>& a_geom,
                      const Vector<BoxArray>& a_grids,
                      const Vector<DistributionMapping>& a_dmap,
                      const LPInfo& a_info,
                      const Vector<EBFArrayBoxFactory const*>& a_factory,
-                     Real a_const_sigma = 0.0);
+                     Real a_const_sigma = Real(0.0));
 #endif
     virtual ~MLNodeLaplacian ();
 
@@ -41,7 +41,7 @@ public :
                  const Vector<DistributionMapping>& a_dmap,
                  const LPInfo& a_info = LPInfo(),
                  const Vector<FabFactory<FArrayBox> const*>& a_factory = {},
-                 Real  a_const_sigma = 0.0);
+                 Real  a_const_sigma = Real(0.0));
 
 #ifdef AMREX_USE_EB
     void define (const Vector<Geometry>& a_geom,
@@ -49,7 +49,7 @@ public :
                  const Vector<DistributionMapping>& a_dmap,
                  const LPInfo& a_info,
                  const Vector<EBFArrayBoxFactory const*>& a_factory,
-                 Real a_const_sigma = 0.0);
+                 Real a_const_sigma = Real(0.0));
 #endif
 
     virtual std::string name () const override { return std::string("MLNodeLaplacian"); }
@@ -143,12 +143,12 @@ private:
 
     int m_is_rz = 0;
 
-    Real m_const_sigma = 0.0;
+    Real m_const_sigma = Real(0.0);
     Vector<Vector<Array<std::unique_ptr<MultiFab>,AMREX_SPACEDIM> > > m_sigma;
     Vector<Vector<std::unique_ptr<MultiFab> > > m_stencil;
     Vector<Vector<Real> > m_s0_norm0;
 
-    Real m_normalization_threshold = 1.e-10;
+    Real m_normalization_threshold = Real(1.e-10);
 
 #ifdef AMREX_USE_EB
     // they could be MultiCutFab

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian.cpp
@@ -614,7 +614,7 @@ MLNodeLaplacian::compGrad (int amrlev, MultiFab& grad, MultiFab& sol) const
     bool is_rz = m_is_rz;
 #endif
 
-    Real sigma = -1.0;
+    Real sigma = Real(-1.0);
 
     AMREX_ASSERT(grad.nComp() >= AMREX_SPACEDIM);
 

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeTensorLap_2D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeTensorLap_2D_K.H
@@ -63,15 +63,15 @@ void mlndtslap_adotx (Box const& b, Array4<Real> const& y, Array4<Real const> co
     const Real h11 = dxinv[1]*dxinv[1];
     amrex::LoopConcurrent(b, [=] (int i, int j, int k) noexcept
     {
-        y(i,j,k) = x(i-1,j-1,0) * ((1./6.)*h00*s[0] + 0.5*h01*s[1] + (1./6.)*h11*s[2])
-            +      x(i-1,j  ,0) * ((2./3.)*h00*s[0] - (1./3.)*h11*s[2])
-            +      x(i-1,j+1,0) * ((1./6.)*h00*s[0] - 0.5*h01*s[1] + (1./6.)*h11*s[2])
-            +      x(i  ,j-1,0) * ((-1./3.)*h00*s[0] + (2./3.)*h11*s[2])
-            +      x(i  ,j  ,0) * ((-4./3.)*h00*s[0] + (-4./3.)*h11*s[2])
-            +      x(i  ,j+1,0) * ((-1./3.)*h00*s[0] + (2./3.)*h11*s[2])
-            +      x(i+1,j-1,0) * ((1./6.)*h00*s[0] - 0.5*h01*s[1] + (1./6.)*h11*s[2])
-            +      x(i+1,j  ,0) * ((2./3.)*h00*s[0] - (1./3.)*h11*s[2])
-            +      x(i+1,j+1,0) * ((1./6.)*h00*s[0] + 0.5*h01*s[1] + (1./6.)*h11*s[2]);
+        y(i,j,k) = x(i-1,j-1,0) * (Real(1./6.)*h00*s[0] + Real(0.5)*h01*s[1] + Real(1./6.)*h11*s[2])
+            +      x(i-1,j  ,0) * (Real(2./3.)*h00*s[0] - Real(1./3.)*h11*s[2])
+            +      x(i-1,j+1,0) * (Real(1./6.)*h00*s[0] - Real(0.5)*h01*s[1] + Real(1./6.)*h11*s[2])
+            +      x(i  ,j-1,0) * (Real(-1./3.)*h00*s[0] + Real(2./3.)*h11*s[2])
+            +      x(i  ,j  ,0) * (Real(-4./3.)*h00*s[0] + Real(-4./3.)*h11*s[2])
+            +      x(i  ,j+1,0) * (Real(-1./3.)*h00*s[0] + Real(2./3.)*h11*s[2])
+            +      x(i+1,j-1,0) * (Real(1./6.)*h00*s[0] - Real(0.5)*h01*s[1] + Real(1./6.)*h11*s[2])
+            +      x(i+1,j  ,0) * (Real(2./3.)*h00*s[0] - Real(1./3.)*h11*s[2])
+            +      x(i+1,j+1,0) * (Real(1./6.)*h00*s[0] + Real(0.5)*h01*s[1] + Real(1./6.)*h11*s[2]);
     });
 }
 
@@ -89,16 +89,16 @@ void mlndtslap_gauss_seidel (Box const& b, Array4<Real> const& sol,
         if (msk(i,j,k)) {
             sol(i,j,k) = 0.0;
         } else {
-            Real s0 = ((-4./3.)*h00*s[0] + (-4./3.)*h11*s[2]);
-            Real Ax = sol(i-1,j-1,0) * ((1./6.)*h00*s[0] + 0.5*h01*s[1] + (1./6.)*h11*s[2])
-                +     sol(i-1,j  ,0) * ((2./3.)*h00*s[0] - (1./3.)*h11*s[2])
-                +     sol(i-1,j+1,0) * ((1./6.)*h00*s[0] - 0.5*h01*s[1] + (1./6.)*h11*s[2])
-                +     sol(i  ,j-1,0) * ((-1./3.)*h00*s[0] + (2./3.)*h11*s[2])
+            Real s0 = (Real(-4./3.)*h00*s[0] + Real(-4./3.)*h11*s[2]);
+            Real Ax = sol(i-1,j-1,0) * (Real(1./6.)*h00*s[0] + Real(0.5)*h01*s[1] + Real(1./6.)*h11*s[2])
+                +     sol(i-1,j  ,0) * (Real(2./3.)*h00*s[0] - Real(1./3.)*h11*s[2])
+                +     sol(i-1,j+1,0) * (Real(1./6.)*h00*s[0] - Real(0.5)*h01*s[1] + Real(1./6.)*h11*s[2])
+                +     sol(i  ,j-1,0) * (Real(-1./3.)*h00*s[0] + Real(2./3.)*h11*s[2])
                 +     sol(i  ,j  ,0) * s0
-                +     sol(i  ,j+1,0) * ((-1./3.)*h00*s[0] + (2./3.)*h11*s[2])
-                +     sol(i+1,j-1,0) * ((1./6.)*h00*s[0] - 0.5*h01*s[1] + (1./6.)*h11*s[2])
-                +     sol(i+1,j  ,0) * ((2./3.)*h00*s[0] - (1./3.)*h11*s[2])
-                +     sol(i+1,j+1,0) * ((1./6.)*h00*s[0] + 0.5*h01*s[1] + (1./6.)*h11*s[2]);
+                +     sol(i  ,j+1,0) * (Real(-1./3.)*h00*s[0] + Real(2./3.)*h11*s[2])
+                +     sol(i+1,j-1,0) * (Real(1./6.)*h00*s[0] - Real(0.5)*h01*s[1] + Real(1./6.)*h11*s[2])
+                +     sol(i+1,j  ,0) * (Real(2./3.)*h00*s[0] - Real(1./3.)*h11*s[2])
+                +     sol(i+1,j+1,0) * (Real(1./6.)*h00*s[0] + Real(0.5)*h01*s[1] + Real(1./6.)*h11*s[2]);
             sol(i,j,k) += (rhs(i,j,k) - Ax) / s0;
         }
     });
@@ -114,7 +114,7 @@ void mlndtslap_normalize (Box const& b, Array4<Real> const& phi,
     amrex::Loop(b, [=] (int i, int j, int k) noexcept
     {
         if (!msk(i,j,k)) {
-            Real s0 = ((-4./3.)*h00*s[0] + (-4./3.)*h11*s[2]);
+            Real s0 = (Real(-4./3.)*h00*s[0] + Real(-4./3.)*h11*s[2]);
             phi(i,j,k) /= s0;
         }
     });
@@ -143,54 +143,54 @@ void mlndtslap_fill_ijmatrix (Box const& ndbx, Array4<HypreNodeLap::Int const> c
         {
             rows.push_back(nid(i,j,k));
             cols.push_back(nid(i,j,k));
-            mat.push_back((-4./3.)*h00*s[0] + (-4./3.)*h11*s[2]);
+            mat.push_back(Real(-4./3.)*h00*s[0] + Real(-4./3.)*h11*s[2]);
             HypreNodeLap::Int nc = 1;
 
             if                (nid(i-1,j-1,k) >= 0) {
                 cols.push_back(nid(i-1,j-1,k));
-                mat.push_back((1./6.)*h00*s[0] + 0.5*h01*s[1] + (1./6.)*h11*s[2]);
+                mat.push_back(Real(1./6.)*h00*s[0] + Real(0.5)*h01*s[1] + Real(1./6.)*h11*s[2]);
                 ++nc;
             }
 
             if                (nid(i-1,j,k) >= 0) {
                 cols.push_back(nid(i-1,j,k));
-                mat.push_back((2./3.)*h00*s[0] - (1./3.)*h11*s[2]);
+                mat.push_back(Real(2./3.)*h00*s[0] - Real(1./3.)*h11*s[2]);
                 ++nc;
             }
 
             if                (nid(i-1,j+1,k) >= 0) {
                 cols.push_back(nid(i-1,j+1,k));
-                mat.push_back((1./6.)*h00*s[0] - 0.5*h01*s[1] + (1./6.)*h11*s[2]);
+                mat.push_back(Real(1./6.)*h00*s[0] - Real(0.5)*h01*s[1] + Real(1./6.)*h11*s[2]);
                 ++nc;
             }
 
             if                (nid(i,j-1,k) >= 0) {
                 cols.push_back(nid(i,j-1,k));
-                mat.push_back((-1./3.)*h00*s[0] + (2./3.)*h11*s[2]);
+                mat.push_back(Real(-1./3.)*h00*s[0] + Real(2./3.)*h11*s[2]);
                 ++nc;
             }
 
             if                (nid(i,j+1,k) >= 0) {
                 cols.push_back(nid(i,j+1,k));
-                mat.push_back((-1./3.)*h00*s[0] + (2./3.)*h11*s[2]);
+                mat.push_back(Real(-1./3.)*h00*s[0] + Real(2./3.)*h11*s[2]);
                 ++nc;
             }
 
             if                (nid(i+1,j-1,k) >= 0) {
                 cols.push_back(nid(i+1,j-1,k));
-                mat.push_back((1./6.)*h00*s[0] - 0.5*h01*s[1] + (1./6.)*h11*s[2]);
+                mat.push_back(Real(1./6.)*h00*s[0] - Real(0.5)*h01*s[1] + Real(1./6.)*h11*s[2]);
                 ++nc;
             }
 
             if                (nid(i+1,j,k) >= 0) {
                 cols.push_back(nid(i+1,j,k));
-                mat.push_back((2./3.)*h00*s[0] - (1./3.)*h11*s[2]);
+                mat.push_back(Real(2./3.)*h00*s[0] - Real(1./3.)*h11*s[2]);
                 ++nc;
             }
 
             if                (nid(i+1,j+1,k) >= 0) {
                 cols.push_back(nid(i+1,j+1,k));
-                mat.push_back((1./6.)*h00*s[0] + 0.5*h01*s[1] + (1./6.)*h11*s[2]);
+                mat.push_back(Real(1./6.)*h00*s[0] + Real(0.5)*h01*s[1] + Real(1./6.)*h11*s[2]);
                 ++nc;
             }
 

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeTensorLap_3D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeTensorLap_3D_K.H
@@ -115,34 +115,34 @@ void mlndtslap_adotx (Box const& b, Array4<Real> const& y, Array4<Real const> co
     const Real h22 = dxinv[2]*dxinv[2];
     amrex::LoopConcurrent(b, [=] (int i, int j, int k) noexcept
     {
-        y(i,j,k) = (1./36.) *
-            ( x(i-1,j-1,k-1) * ((h00*s[0]+h11*s[3]+h22*s[5])+3.*( h01*s[1]+h02*s[2]+h12*s[4]))
-            + x(i+1,j-1,k-1) * ((h00*s[0]+h11*s[3]+h22*s[5])+3.*(-h01*s[1]-h02*s[2]+h12*s[4]))
-            + x(i-1,j+1,k-1) * ((h00*s[0]+h11*s[3]+h22*s[5])+3.*(-h01*s[1]+h02*s[2]-h12*s[4]))
-            + x(i+1,j+1,k-1) * ((h00*s[0]+h11*s[3]+h22*s[5])+3.*( h01*s[1]-h02*s[2]-h12*s[4]))
-            + x(i-1,j-1,k+1) * ((h00*s[0]+h11*s[3]+h22*s[5])+3.*( h01*s[1]-h02*s[2]-h12*s[4]))
-            + x(i+1,j-1,k+1) * ((h00*s[0]+h11*s[3]+h22*s[5])+3.*(-h01*s[1]+h02*s[2]-h12*s[4]))
-            + x(i-1,j+1,k+1) * ((h00*s[0]+h11*s[3]+h22*s[5])+3.*(-h01*s[1]-h02*s[2]+h12*s[4]))
-            + x(i+1,j+1,k+1) * ((h00*s[0]+h11*s[3]+h22*s[5])+3.*( h01*s[1]+h02*s[2]+h12*s[4]))
-            + x(i-1,j-1,k  ) * (4.*(h00*s[0]+h11*s[3]-0.5*h22*s[5])+12.*h01*s[1])
-            + x(i+1,j-1,k  ) * (4.*(h00*s[0]+h11*s[3]-0.5*h22*s[5])-12.*h01*s[1])
-            + x(i-1,j+1,k  ) * (4.*(h00*s[0]+h11*s[3]-0.5*h22*s[5])-12.*h01*s[1])
-            + x(i+1,j+1,k  ) * (4.*(h00*s[0]+h11*s[3]-0.5*h22*s[5])+12.*h01*s[1])
-            + x(i-1,j  ,k-1) * (4.*(h00*s[0]+h22*s[5]-0.5*h11*s[3])+12.*h02*s[2])
-            + x(i+1,j  ,k-1) * (4.*(h00*s[0]+h22*s[5]-0.5*h11*s[3])-12.*h02*s[2])
-            + x(i-1,j  ,k+1) * (4.*(h00*s[0]+h22*s[5]-0.5*h11*s[3])-12.*h02*s[2])
-            + x(i+1,j  ,k+1) * (4.*(h00*s[0]+h22*s[5]-0.5*h11*s[3])+12.*h02*s[2])
-            + x(i  ,j-1,k-1) * (4.*(h11*s[3]+h22*s[5]-0.5*h00*s[0])+12.*h12*s[4])
-            + x(i  ,j+1,k-1) * (4.*(h11*s[3]+h22*s[5]-0.5*h00*s[0])-12.*h12*s[4])
-            + x(i  ,j-1,k+1) * (4.*(h11*s[3]+h22*s[5]-0.5*h00*s[0])-12.*h12*s[4])
-            + x(i  ,j+1,k+1) * (4.*(h11*s[3]+h22*s[5]-0.5*h00*s[0])+12.*h12*s[4])
-            + x(i-1,j  ,k  ) * (8.*(2.*h00*s[0]-h11*s[3]-h22*s[5]))
-            + x(i+1,j  ,k  ) * (8.*(2.*h00*s[0]-h11*s[3]-h22*s[5]))
-            + x(i  ,j-1,k  ) * (8.*(2.*h11*s[3]-h00*s[0]-h22*s[5]))
-            + x(i  ,j+1,k  ) * (8.*(2.*h11*s[3]-h00*s[0]-h22*s[5]))
-            + x(i  ,j  ,k-1) * (8.*(2.*h22*s[5]-h00*s[0]-h11*s[3]))
-            + x(i  ,j  ,k+1) * (8.*(2.*h22*s[5]-h00*s[0]-h11*s[3]))
-            + x(i  ,j  ,k  ) * (-32.)*(h00*s[0]+h11*s[3]+h22*s[5]) );
+        y(i,j,k) = Real(1./36.) *
+            ( x(i-1,j-1,k-1) * ((h00*s[0]+h11*s[3]+h22*s[5])+Real(3.)*( h01*s[1]+h02*s[2]+h12*s[4]))
+            + x(i+1,j-1,k-1) * ((h00*s[0]+h11*s[3]+h22*s[5])+Real(3.)*(-h01*s[1]-h02*s[2]+h12*s[4]))
+            + x(i-1,j+1,k-1) * ((h00*s[0]+h11*s[3]+h22*s[5])+Real(3.)*(-h01*s[1]+h02*s[2]-h12*s[4]))
+            + x(i+1,j+1,k-1) * ((h00*s[0]+h11*s[3]+h22*s[5])+Real(3.)*( h01*s[1]-h02*s[2]-h12*s[4]))
+            + x(i-1,j-1,k+1) * ((h00*s[0]+h11*s[3]+h22*s[5])+Real(3.)*( h01*s[1]-h02*s[2]-h12*s[4]))
+            + x(i+1,j-1,k+1) * ((h00*s[0]+h11*s[3]+h22*s[5])+Real(3.)*(-h01*s[1]+h02*s[2]-h12*s[4]))
+            + x(i-1,j+1,k+1) * ((h00*s[0]+h11*s[3]+h22*s[5])+Real(3.)*(-h01*s[1]-h02*s[2]+h12*s[4]))
+            + x(i+1,j+1,k+1) * ((h00*s[0]+h11*s[3]+h22*s[5])+Real(3.)*( h01*s[1]+h02*s[2]+h12*s[4]))
+            + x(i-1,j-1,k  ) * (Real(4.)*(h00*s[0]+h11*s[3]-Real(0.5)*h22*s[5])+Real(12.)*h01*s[1])
+            + x(i+1,j-1,k  ) * (Real(4.)*(h00*s[0]+h11*s[3]-Real(0.5)*h22*s[5])-Real(12.)*h01*s[1])
+            + x(i-1,j+1,k  ) * (Real(4.)*(h00*s[0]+h11*s[3]-Real(0.5)*h22*s[5])-Real(12.)*h01*s[1])
+            + x(i+1,j+1,k  ) * (Real(4.)*(h00*s[0]+h11*s[3]-Real(0.5)*h22*s[5])+Real(12.)*h01*s[1])
+            + x(i-1,j  ,k-1) * (Real(4.)*(h00*s[0]+h22*s[5]-Real(0.5)*h11*s[3])+Real(12.)*h02*s[2])
+            + x(i+1,j  ,k-1) * (Real(4.)*(h00*s[0]+h22*s[5]-Real(0.5)*h11*s[3])-Real(12.)*h02*s[2])
+            + x(i-1,j  ,k+1) * (Real(4.)*(h00*s[0]+h22*s[5]-Real(0.5)*h11*s[3])-Real(12.)*h02*s[2])
+            + x(i+1,j  ,k+1) * (Real(4.)*(h00*s[0]+h22*s[5]-Real(0.5)*h11*s[3])+Real(12.)*h02*s[2])
+            + x(i  ,j-1,k-1) * (Real(4.)*(h11*s[3]+h22*s[5]-Real(0.5)*h00*s[0])+Real(12.)*h12*s[4])
+            + x(i  ,j+1,k-1) * (Real(4.)*(h11*s[3]+h22*s[5]-Real(0.5)*h00*s[0])-Real(12.)*h12*s[4])
+            + x(i  ,j-1,k+1) * (Real(4.)*(h11*s[3]+h22*s[5]-Real(0.5)*h00*s[0])-Real(12.)*h12*s[4])
+            + x(i  ,j+1,k+1) * (Real(4.)*(h11*s[3]+h22*s[5]-Real(0.5)*h00*s[0])+Real(12.)*h12*s[4])
+            + x(i-1,j  ,k  ) * (Real(8.)*(Real(2.)*h00*s[0]-h11*s[3]-h22*s[5]))
+            + x(i+1,j  ,k  ) * (Real(8.)*(Real(2.)*h00*s[0]-h11*s[3]-h22*s[5]))
+            + x(i  ,j-1,k  ) * (Real(8.)*(Real(2.)*h11*s[3]-h00*s[0]-h22*s[5]))
+            + x(i  ,j+1,k  ) * (Real(8.)*(Real(2.)*h11*s[3]-h00*s[0]-h22*s[5]))
+            + x(i  ,j  ,k-1) * (Real(8.)*(Real(2.)*h22*s[5]-h00*s[0]-h11*s[3]))
+            + x(i  ,j  ,k+1) * (Real(8.)*(Real(2.)*h22*s[5]-h00*s[0]-h11*s[3]))
+            + x(i  ,j  ,k  ) * Real(-32.)*(h00*s[0]+h11*s[3]+h22*s[5]) );
     });
 }
 
@@ -163,34 +163,34 @@ void mlndtslap_gauss_seidel (Box const& b, Array4<Real> const& sol,
         if (msk(i,j,k)) {
             sol(i,j,k) = 0.0;
         } else {
-            Real s0 = (1./36.) * (-32.)*(h00*s[0]+h11*s[3]+h22*s[5]);
-            Real Ax = (1./36.) *
-                ( sol(i-1,j-1,k-1) * ((h00*s[0]+h11*s[3]+h22*s[5])+3.*( h01*s[1]+h02*s[2]+h12*s[4]))
-                + sol(i+1,j-1,k-1) * ((h00*s[0]+h11*s[3]+h22*s[5])+3.*(-h01*s[1]-h02*s[2]+h12*s[4]))
-                + sol(i-1,j+1,k-1) * ((h00*s[0]+h11*s[3]+h22*s[5])+3.*(-h01*s[1]+h02*s[2]-h12*s[4]))
-                + sol(i+1,j+1,k-1) * ((h00*s[0]+h11*s[3]+h22*s[5])+3.*( h01*s[1]-h02*s[2]-h12*s[4]))
-                + sol(i-1,j-1,k+1) * ((h00*s[0]+h11*s[3]+h22*s[5])+3.*( h01*s[1]-h02*s[2]-h12*s[4]))
-                + sol(i+1,j-1,k+1) * ((h00*s[0]+h11*s[3]+h22*s[5])+3.*(-h01*s[1]+h02*s[2]-h12*s[4]))
-                + sol(i-1,j+1,k+1) * ((h00*s[0]+h11*s[3]+h22*s[5])+3.*(-h01*s[1]-h02*s[2]+h12*s[4]))
-                + sol(i+1,j+1,k+1) * ((h00*s[0]+h11*s[3]+h22*s[5])+3.*( h01*s[1]+h02*s[2]+h12*s[4]))
-                + sol(i-1,j-1,k  ) * (4.*(h00*s[0]+h11*s[3]-0.5*h22*s[5])+12.*h01*s[1])
-                + sol(i+1,j-1,k  ) * (4.*(h00*s[0]+h11*s[3]-0.5*h22*s[5])-12.*h01*s[1])
-                + sol(i-1,j+1,k  ) * (4.*(h00*s[0]+h11*s[3]-0.5*h22*s[5])-12.*h01*s[1])
-                + sol(i+1,j+1,k  ) * (4.*(h00*s[0]+h11*s[3]-0.5*h22*s[5])+12.*h01*s[1])
-                + sol(i-1,j  ,k-1) * (4.*(h00*s[0]+h22*s[5]-0.5*h11*s[3])+12.*h02*s[2])
-                + sol(i+1,j  ,k-1) * (4.*(h00*s[0]+h22*s[5]-0.5*h11*s[3])-12.*h02*s[2])
-                + sol(i-1,j  ,k+1) * (4.*(h00*s[0]+h22*s[5]-0.5*h11*s[3])-12.*h02*s[2])
-                + sol(i+1,j  ,k+1) * (4.*(h00*s[0]+h22*s[5]-0.5*h11*s[3])+12.*h02*s[2])
-                + sol(i  ,j-1,k-1) * (4.*(h11*s[3]+h22*s[5]-0.5*h00*s[0])+12.*h12*s[4])
-                + sol(i  ,j+1,k-1) * (4.*(h11*s[3]+h22*s[5]-0.5*h00*s[0])-12.*h12*s[4])
-                + sol(i  ,j-1,k+1) * (4.*(h11*s[3]+h22*s[5]-0.5*h00*s[0])-12.*h12*s[4])
-                + sol(i  ,j+1,k+1) * (4.*(h11*s[3]+h22*s[5]-0.5*h00*s[0])+12.*h12*s[4])
-                + sol(i-1,j  ,k  ) * (8.*(2.*h00*s[0]-h11*s[3]-h22*s[5]))
-                + sol(i+1,j  ,k  ) * (8.*(2.*h00*s[0]-h11*s[3]-h22*s[5]))
-                + sol(i  ,j-1,k  ) * (8.*(2.*h11*s[3]-h00*s[0]-h22*s[5]))
-                + sol(i  ,j+1,k  ) * (8.*(2.*h11*s[3]-h00*s[0]-h22*s[5]))
-                + sol(i  ,j  ,k-1) * (8.*(2.*h22*s[5]-h00*s[0]-h11*s[3]))
-                + sol(i  ,j  ,k+1) * (8.*(2.*h22*s[5]-h00*s[0]-h11*s[3])) )
+            Real s0 = Real(1./36.) * Real(-32.)*(h00*s[0]+h11*s[3]+h22*s[5]);
+            Real Ax = Real(1./36.) *
+                ( sol(i-1,j-1,k-1) * ((h00*s[0]+h11*s[3]+h22*s[5])+Real(3.)*( h01*s[1]+h02*s[2]+h12*s[4]))
+                + sol(i+1,j-1,k-1) * ((h00*s[0]+h11*s[3]+h22*s[5])+Real(3.)*(-h01*s[1]-h02*s[2]+h12*s[4]))
+                + sol(i-1,j+1,k-1) * ((h00*s[0]+h11*s[3]+h22*s[5])+Real(3.)*(-h01*s[1]+h02*s[2]-h12*s[4]))
+                + sol(i+1,j+1,k-1) * ((h00*s[0]+h11*s[3]+h22*s[5])+Real(3.)*( h01*s[1]-h02*s[2]-h12*s[4]))
+                + sol(i-1,j-1,k+1) * ((h00*s[0]+h11*s[3]+h22*s[5])+Real(3.)*( h01*s[1]-h02*s[2]-h12*s[4]))
+                + sol(i+1,j-1,k+1) * ((h00*s[0]+h11*s[3]+h22*s[5])+Real(3.)*(-h01*s[1]+h02*s[2]-h12*s[4]))
+                + sol(i-1,j+1,k+1) * ((h00*s[0]+h11*s[3]+h22*s[5])+Real(3.)*(-h01*s[1]-h02*s[2]+h12*s[4]))
+                + sol(i+1,j+1,k+1) * ((h00*s[0]+h11*s[3]+h22*s[5])+Real(3.)*( h01*s[1]+h02*s[2]+h12*s[4]))
+                + sol(i-1,j-1,k  ) * (Real(4.)*(h00*s[0]+h11*s[3]-Real(0.5)*h22*s[5])+Real(12.)*h01*s[1])
+                + sol(i+1,j-1,k  ) * (Real(4.)*(h00*s[0]+h11*s[3]-Real(0.5)*h22*s[5])-Real(12.)*h01*s[1])
+                + sol(i-1,j+1,k  ) * (Real(4.)*(h00*s[0]+h11*s[3]-Real(0.5)*h22*s[5])-Real(12.)*h01*s[1])
+                + sol(i+1,j+1,k  ) * (Real(4.)*(h00*s[0]+h11*s[3]-Real(0.5)*h22*s[5])+Real(12.)*h01*s[1])
+                + sol(i-1,j  ,k-1) * (Real(4.)*(h00*s[0]+h22*s[5]-Real(0.5)*h11*s[3])+Real(12.)*h02*s[2])
+                + sol(i+1,j  ,k-1) * (Real(4.)*(h00*s[0]+h22*s[5]-Real(0.5)*h11*s[3])-Real(12.)*h02*s[2])
+                + sol(i-1,j  ,k+1) * (Real(4.)*(h00*s[0]+h22*s[5]-Real(0.5)*h11*s[3])-Real(12.)*h02*s[2])
+                + sol(i+1,j  ,k+1) * (Real(4.)*(h00*s[0]+h22*s[5]-Real(0.5)*h11*s[3])+Real(12.)*h02*s[2])
+                + sol(i  ,j-1,k-1) * (Real(4.)*(h11*s[3]+h22*s[5]-Real(0.5)*h00*s[0])+Real(12.)*h12*s[4])
+                + sol(i  ,j+1,k-1) * (Real(4.)*(h11*s[3]+h22*s[5]-Real(0.5)*h00*s[0])-Real(12.)*h12*s[4])
+                + sol(i  ,j-1,k+1) * (Real(4.)*(h11*s[3]+h22*s[5]-Real(0.5)*h00*s[0])-Real(12.)*h12*s[4])
+                + sol(i  ,j+1,k+1) * (Real(4.)*(h11*s[3]+h22*s[5]-Real(0.5)*h00*s[0])+Real(12.)*h12*s[4])
+                + sol(i-1,j  ,k  ) * (Real(8.)*(Real(2.)*h00*s[0]-h11*s[3]-h22*s[5]))
+                + sol(i+1,j  ,k  ) * (Real(8.)*(Real(2.)*h00*s[0]-h11*s[3]-h22*s[5]))
+                + sol(i  ,j-1,k  ) * (Real(8.)*(Real(2.)*h11*s[3]-h00*s[0]-h22*s[5]))
+                + sol(i  ,j+1,k  ) * (Real(8.)*(Real(2.)*h11*s[3]-h00*s[0]-h22*s[5]))
+                + sol(i  ,j  ,k-1) * (Real(8.)*(Real(2.)*h22*s[5]-h00*s[0]-h11*s[3]))
+                + sol(i  ,j  ,k+1) * (Real(8.)*(Real(2.)*h22*s[5]-h00*s[0]-h11*s[3])) )
                 + sol(i  ,j  ,k  ) * s0;
             sol(i,j,k) += (rhs(i,j,k) - Ax) / s0;
         }
@@ -208,7 +208,7 @@ void mlndtslap_normalize (Box const& b, Array4<Real> const& phi,
     amrex::LoopConcurrent(b, [=] (int i, int j, int k) noexcept
     {
         if (!msk(i,j,k)) {
-            Real s0 = (1./36.) * (-32.)*(h00*s[0]+h11*s[3]+h22*s[5]);
+            Real s0 = Real(1./36.) * Real(-32.)*(h00*s[0]+h11*s[3]+h22*s[5]);
             phi(i,j,k) /= s0;
         }
     });
@@ -240,187 +240,187 @@ void mlndtslap_fill_ijmatrix (Box const& ndbx, Array4<HypreNodeLap::Int const> c
         {
             rows.push_back(nid(i,j,k));
             cols.push_back(nid(i,j,k));
-            mat.push_back((1./36.) * (-32.)*(h00*s[0]+h11*s[3]+h22*s[5]));
+            mat.push_back(Real(1./36.) * Real(-32.)*(h00*s[0]+h11*s[3]+h22*s[5]));
             HypreNodeLap::Int nc = 1;
 
             if (               nid(i-1,j-1,k-1) >= 0) {
                 cols.push_back(nid(i-1,j-1,k-1));
-                Real t = (1./36.)*((h00*s[0]+h11*s[3]+h22*s[5])+3.*( h01*s[1]+h02*s[2]+h12*s[4]));
+                Real t = Real(1./36.)*((h00*s[0]+h11*s[3]+h22*s[5])+Real(3.)*( h01*s[1]+h02*s[2]+h12*s[4]));
                 mat.push_back(t);
                 ++nc;
             }
 
             if (               nid(i+1,j-1,k-1) >= 0) {
                 cols.push_back(nid(i+1,j-1,k-1));
-                Real t = (1./36.)*((h00*s[0]+h11*s[3]+h22*s[5])+3.*(-h01*s[1]-h02*s[2]+h12*s[4]));
+                Real t = Real(1./36.)*((h00*s[0]+h11*s[3]+h22*s[5])+Real(3.)*(-h01*s[1]-h02*s[2]+h12*s[4]));
                 mat.push_back(t);
                 ++nc;
             }
 
             if (               nid(i-1,j+1,k-1) >= 0) {
                 cols.push_back(nid(i-1,j+1,k-1));
-                Real t = (1./36.)*((h00*s[0]+h11*s[3]+h22*s[5])+3.*(-h01*s[1]+h02*s[2]-h12*s[4]));
+                Real t = Real(1./36.)*((h00*s[0]+h11*s[3]+h22*s[5])+Real(3.)*(-h01*s[1]+h02*s[2]-h12*s[4]));
                 mat.push_back(t);
                 ++nc;
             }
 
             if (               nid(i+1,j+1,k-1) >= 0) {
                 cols.push_back(nid(i+1,j+1,k-1));
-                Real t = (1./36.)*((h00*s[0]+h11*s[3]+h22*s[5])+3.*( h01*s[1]-h02*s[2]-h12*s[4]));
+                Real t = Real(1./36.)*((h00*s[0]+h11*s[3]+h22*s[5])+Real(3.)*( h01*s[1]-h02*s[2]-h12*s[4]));
                 mat.push_back(t);
                 ++nc;
             }
 
             if (               nid(i-1,j-1,k+1) >= 0) {
                 cols.push_back(nid(i-1,j-1,k+1));
-                Real t = (1./36.)*((h00*s[0]+h11*s[3]+h22*s[5])+3.*( h01*s[1]-h02*s[2]-h12*s[4]));
+                Real t = Real(1./36.)*((h00*s[0]+h11*s[3]+h22*s[5])+Real(3.)*( h01*s[1]-h02*s[2]-h12*s[4]));
                 mat.push_back(t);
                 ++nc;
             }
 
             if (               nid(i+1,j-1,k+1) >= 0) {
                 cols.push_back(nid(i+1,j-1,k+1));
-                Real t = (1./36.)*((h00*s[0]+h11*s[3]+h22*s[5])+3.*(-h01*s[1]+h02*s[2]-h12*s[4]));
+                Real t = Real(1./36.)*((h00*s[0]+h11*s[3]+h22*s[5])+Real(3.)*(-h01*s[1]+h02*s[2]-h12*s[4]));
                 mat.push_back(t);
                 ++nc;
             }
 
             if (               nid(i-1,j+1,k+1) >= 0) {
                 cols.push_back(nid(i-1,j+1,k+1));
-                Real t = (1./36.)*((h00*s[0]+h11*s[3]+h22*s[5])+3.*(-h01*s[1]-h02*s[2]+h12*s[4]));
+                Real t = Real(1./36.)*((h00*s[0]+h11*s[3]+h22*s[5])+Real(3.)*(-h01*s[1]-h02*s[2]+h12*s[4]));
                 mat.push_back(t);
                 ++nc;
             }
 
             if (               nid(i+1,j+1,k+1) >= 0) {
                 cols.push_back(nid(i+1,j+1,k+1));
-                Real t = (1./36.)*((h00*s[0]+h11*s[3]+h22*s[5])+3.*( h01*s[1]+h02*s[2]+h12*s[4]));
+                Real t = Real(1./36.)*((h00*s[0]+h11*s[3]+h22*s[5])+Real(3.)*( h01*s[1]+h02*s[2]+h12*s[4]));
                 mat.push_back(t);
                 ++nc;
             }
 
             if (               nid(i-1,j-1,k  ) >= 0) {
                 cols.push_back(nid(i-1,j-1,k  ));
-                Real t = (1./36.)*(4.*(h00*s[0]+h11*s[3]-0.5*h22*s[5])+12.*h01*s[1]);
+                Real t = Real(1./36.)*(Real(4.)*(h00*s[0]+h11*s[3]-Real(0.5)*h22*s[5])+Real(12.)*h01*s[1]);
                 mat.push_back(t);
                 ++nc;
             }
 
             if (               nid(i+1,j-1,k  ) >= 0) {
                 cols.push_back(nid(i+1,j-1,k  ));
-                Real t = (1./36.)*(4.*(h00*s[0]+h11*s[3]-0.5*h22*s[5])-12.*h01*s[1]);
+                Real t = Real(1./36.)*(Real(4.)*(h00*s[0]+h11*s[3]-Real(0.5)*h22*s[5])-Real(12.)*h01*s[1]);
                 mat.push_back(t);
                 ++nc;
             }
 
             if (               nid(i-1,j+1,k  ) >= 0) {
                 cols.push_back(nid(i-1,j+1,k  ));
-                Real t = (1./36.)*(4.*(h00*s[0]+h11*s[3]-0.5*h22*s[5])-12.*h01*s[1]);
+                Real t = Real(1./36.)*(Real(4.)*(h00*s[0]+h11*s[3]-Real(0.5)*h22*s[5])-Real(12.)*h01*s[1]);
                 mat.push_back(t);
                 ++nc;
             }
 
             if (               nid(i+1,j+1,k  ) >= 0) {
                 cols.push_back(nid(i+1,j+1,k  ));
-                Real t = (1./36.)*(4.*(h00*s[0]+h11*s[3]-0.5*h22*s[5])+12.*h01*s[1]);
+                Real t = Real(1./36.)*(Real(4.)*(h00*s[0]+h11*s[3]-Real(0.5)*h22*s[5])+Real(12.)*h01*s[1]);
                 mat.push_back(t);
                 ++nc;
             }
 
             if (               nid(i-1,j  ,k-1) >= 0) {
                 cols.push_back(nid(i-1,j  ,k-1));
-                Real t = (1./36.)*(4.*(h00*s[0]+h22*s[5]-0.5*h11*s[3])+12.*h02*s[2]);
+                Real t = Real(1./36.)*(Real(4.)*(h00*s[0]+h22*s[5]-Real(0.5)*h11*s[3])+Real(12.)*h02*s[2]);
                 mat.push_back(t);
                 ++nc;
             }
 
             if (               nid(i+1,j  ,k-1) >= 0) {
                 cols.push_back(nid(i+1,j  ,k-1));
-                Real t = (1./36.)*(4.*(h00*s[0]+h22*s[5]-0.5*h11*s[3])-12.*h02*s[2]);
+                Real t = Real(1./36.)*(Real(4.)*(h00*s[0]+h22*s[5]-Real(0.5)*h11*s[3])-Real(12.)*h02*s[2]);
                 mat.push_back(t);
                 ++nc;
             }
 
             if (               nid(i-1,j  ,k+1) >= 0) {
                 cols.push_back(nid(i-1,j  ,k+1));
-                Real t = (1./36.)*(4.*(h00*s[0]+h22*s[5]-0.5*h11*s[3])-12.*h02*s[2]);
+                Real t = Real(1./36.)*(Real(4.)*(h00*s[0]+h22*s[5]-Real(0.5)*h11*s[3])-Real(12.)*h02*s[2]);
                 mat.push_back(t);
                 ++nc;
             }
 
             if (               nid(i+1,j  ,k+1) >= 0) {
                 cols.push_back(nid(i+1,j  ,k+1));
-                Real t = (1./36.)*(4.*(h00*s[0]+h22*s[5]-0.5*h11*s[3])+12.*h02*s[2]);
+                Real t = Real(1./36.)*(Real(4.)*(h00*s[0]+h22*s[5]-Real(0.5)*h11*s[3])+Real(12.)*h02*s[2]);
                 mat.push_back(t);
                 ++nc;
             }
 
             if (               nid(i  ,j-1,k-1) >= 0) {
                 cols.push_back(nid(i  ,j-1,k-1));
-                Real t = (1./36.)*(4.*(h11*s[3]+h22*s[5]-0.5*h00*s[0])+12.*h12*s[4]);
+                Real t = Real(1./36.)*(Real(4.)*(h11*s[3]+h22*s[5]-Real(0.5)*h00*s[0])+Real(12.)*h12*s[4]);
                 mat.push_back(t);
                 ++nc;
             }
 
             if (               nid(i  ,j+1,k-1) >= 0) {
                 cols.push_back(nid(i  ,j+1,k-1));
-                Real t = (1./36.)*(4.*(h11*s[3]+h22*s[5]-0.5*h00*s[0])-12.*h12*s[4]);
+                Real t = Real(1./36.)*(Real(4.)*(h11*s[3]+h22*s[5]-Real(0.5)*h00*s[0])-Real(12.)*h12*s[4]);
                 mat.push_back(t);
                 ++nc;
             }
 
             if (               nid(i  ,j-1,k+1) >= 0) {
                 cols.push_back(nid(i  ,j-1,k+1));
-                Real t = (1./36.)*(4.*(h11*s[3]+h22*s[5]-0.5*h00*s[0])-12.*h12*s[4]);
+                Real t = Real(1./36.)*(Real(4.)*(h11*s[3]+h22*s[5]-Real(0.5)*h00*s[0])-Real(12.)*h12*s[4]);
                 mat.push_back(t);
                 ++nc;
             }
 
             if (               nid(i  ,j+1,k+1) >= 0) {
                 cols.push_back(nid(i  ,j+1,k+1));
-                Real t = (1./36.)*(4.*(h11*s[3]+h22*s[5]-0.5*h00*s[0])+12.*h12*s[4]);
+                Real t = Real(1./36.)*(Real(4.)*(h11*s[3]+h22*s[5]-Real(0.5)*h00*s[0])+Real(12.)*h12*s[4]);
                 mat.push_back(t);
                 ++nc;
             }
 
             if (               nid(i-1,j  ,k  ) >= 0) {
                 cols.push_back(nid(i-1,j  ,k  ));
-                Real t = (1./36.)*(8.*(2.*h00*s[0]-h11*s[3]-h22*s[5]));
+                Real t = Real(1./36.)*(Real(8.)*(Real(2.)*h00*s[0]-h11*s[3]-h22*s[5]));
                 mat.push_back(t);
                 ++nc;
             }
 
             if (               nid(i+1,j  ,k  ) >= 0) {
                 cols.push_back(nid(i+1,j  ,k  ));
-                Real t = (1./36.)*(8.*(2.*h00*s[0]-h11*s[3]-h22*s[5]));
+                Real t = Real(1./36.)*(Real(8.)*(Real(2.)*h00*s[0]-h11*s[3]-h22*s[5]));
                 mat.push_back(t);
                 ++nc;
             }
 
             if (               nid(i  ,j-1,k  ) >= 0) {
                 cols.push_back(nid(i  ,j-1,k  ));
-                Real t = (1./36.)*(8.*(2.*h11*s[3]-h00*s[0]-h22*s[5]));
+                Real t = Real(1./36.)*(Real(8.)*(Real(2.)*h11*s[3]-h00*s[0]-h22*s[5]));
                 mat.push_back(t);
                 ++nc;
             }
 
             if (               nid(i  ,j+1,k  ) >= 0) {
                 cols.push_back(nid(i  ,j+1,k  ));
-                Real t = (1./36.)*(8.*(2.*h11*s[3]-h00*s[0]-h22*s[5]));
+                Real t = Real(1./36.)*(Real(8.)*(Real(2.)*h11*s[3]-h00*s[0]-h22*s[5]));
                 mat.push_back(t);
                 ++nc;
             }
 
             if (               nid(i  ,j  ,k-1) >= 0) {
                 cols.push_back(nid(i  ,j  ,k-1));
-                Real t = (1./36.)*(8.*(2.*h22*s[5]-h00*s[0]-h11*s[3]));
+                Real t = Real(1./36.)*(Real(8.)*(Real(2.)*h22*s[5]-h00*s[0]-h11*s[3]));
                 mat.push_back(t);
                 ++nc;
             }
 
             if (               nid(i  ,j  ,k+1) >= 0) {
                 cols.push_back(nid(i  ,j  ,k+1));
-                Real t = (1./36.)*(8.*(2.*h22*s[5]-h00*s[0]-h11*s[3]));
+                Real t = Real(1./36.)*(Real(8.)*(Real(2.)*h22*s[5]-h00*s[0]-h11*s[3]));
                 mat.push_back(t);
                 ++nc;
             }

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeTensorLaplacian.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeTensorLaplacian.cpp
@@ -28,16 +28,16 @@ MLNodeTensorLaplacian::setBeta (Array<Real,AMREX_SPACEDIM> const& a_beta) noexce
 #if (AMREX_SPACEDIM == 1)
     amrex::ignore_unused(a_beta);
 #elif (AMREX_SPACEDIM == 2)
-    m_sigma[0] = 1. - a_beta[0]*a_beta[0];
-    m_sigma[1] =    - a_beta[0]*a_beta[1];
-    m_sigma[2] = 1. - a_beta[1]*a_beta[1];
+    m_sigma[0] = Real(1.) - a_beta[0]*a_beta[0];
+    m_sigma[1] =          - a_beta[0]*a_beta[1];
+    m_sigma[2] = Real(1.) - a_beta[1]*a_beta[1];
 #elif (AMREX_SPACEDIM == 3)
-    m_sigma[0] = 1. - a_beta[0]*a_beta[0];
-    m_sigma[1] =    - a_beta[0]*a_beta[1];
-    m_sigma[2] =    - a_beta[0]*a_beta[2];
-    m_sigma[3] = 1. - a_beta[1]*a_beta[1];
-    m_sigma[4] =    - a_beta[1]*a_beta[2];
-    m_sigma[5] = 1. - a_beta[2]*a_beta[2];
+    m_sigma[0] = Real(1.) - a_beta[0]*a_beta[0];
+    m_sigma[1] =          - a_beta[0]*a_beta[1];
+    m_sigma[2] =          - a_beta[0]*a_beta[2];
+    m_sigma[3] = Real(1.) - a_beta[1]*a_beta[1];
+    m_sigma[4] =          - a_beta[1]*a_beta[2];
+    m_sigma[5] = Real(1.) - a_beta[2]*a_beta[2];
 #endif
 }
 

--- a/Src/LinearSolvers/MLMG/AMReX_MLPoisson.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLPoisson.cpp
@@ -555,7 +555,7 @@ MLPoisson::makeNLinOp (int grid_size) const
     if (needsCoarseDataForBC())
     {
         const Real* dx0 = m_geom[0][0].CellSize();
-        const Real fac = 0.5*m_coarse_data_crse_ratio;
+        const Real fac = Real(0.5)*m_coarse_data_crse_ratio;
         RealVect cbloc {AMREX_D_DECL(dx0[0]*fac, dx0[1]*fac, dx0[2]*fac)};
         nop->setCoarseFineBCLocation(cbloc);
     }
@@ -572,7 +572,7 @@ MLPoisson::makeNLinOp (int grid_size) const
 #endif
 
     MultiFab alpha(ba, dm, 1, 0);
-    alpha.setVal(1.e30*dxscale*dxscale);
+    alpha.setVal(Real(1.e30)*dxscale*dxscale);
 
     MultiFab foo(m_grids[0].back(), m_dmap[0].back(), 1, 0, MFInfo().SetAlloc(false));
     const FabArrayBase::CPC& cpc = alpha.getCPC(IntVect(0),foo,IntVect(0),Periodicity::NonPeriodic());

--- a/Src/LinearSolvers/MLMG/AMReX_MLPoisson_2D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLPoisson_2D_K.H
@@ -34,7 +34,7 @@ void mlpoisson_adotx_m (int i, int j, Array4<Real> const& y,
 {
     Real rel = probxlo + i*dx;
     Real rer = probxlo +(i+1)*dx;
-    Real rc = probxlo + (i+0.5)*dx;
+    Real rc = probxlo + (i+Real(0.5))*dx;
     y(i,j,0) = dhx * (rel*x(i-1,j,0) - (rel+rer)*x(i,j,0) + rer*x(i+1,j,0))
         +      dhy * rc *(x(i,j-1,0) -  Real(2.)*x(i,j,0) +     x(i,j+1,0));
 }
@@ -130,7 +130,7 @@ void mlpoisson_flux_y_m (Box const& box, Array4<Real> const& fy,
     for     (int j = lo.y; j <= hi.y; ++j) {
         AMREX_PRAGMA_SIMD
         for (int i = lo.x; i <= hi.x; ++i) {
-            Real rc = probxlo + (i+0.5)*dx;
+            Real rc = probxlo + (i+Real(0.5))*dx;
             fy(i,j,0) = dyinv*rc*(sol(i,j,0)-sol(i,j-1,0));
         }
     }
@@ -166,13 +166,13 @@ void mlpoisson_flux_yface_m (Box const& box, Array4<Real> const& fy,
     int j = lo.y;
     AMREX_PRAGMA_SIMD
     for (int i = lo.x; i <= hi.x; ++i) {
-        Real rc = probxlo + (i+0.5)*dx;
+        Real rc = probxlo + (i+Real(0.5))*dx;
         fy(i,j,0) = dyinv*rc*(sol(i,j,0)-sol(i,j-1,0));
     }
     j += ylen;
     AMREX_PRAGMA_SIMD
     for (int i = lo.x; i <= hi.x; ++i) {
-        Real rc = probxlo + (i+0.5)*dx;
+        Real rc = probxlo + (i+Real(0.5))*dx;
         fy(i,j,0) = dyinv*rc*(sol(i,j,0)-sol(i,j-1,0));
     }
 }
@@ -292,7 +292,7 @@ void mlpoisson_gsrb_m (Box const& box, Array4<Real> const& phi, Array4<Real cons
 
                 Real rel = probxlo + i*dx;
                 Real rer = probxlo +(i+1)*dx;
-                Real rc = probxlo + (i+0.5)*dx;
+                Real rc = probxlo + (i+Real(0.5))*dx;
 
                 Real gamma = -dhx*(rel+rer) - Real(2.0)*dhy*rc;
 
@@ -320,7 +320,7 @@ void mlpoisson_normalize (Box const& box, Array4<Real> const& x,
         for (int i = lo.x; i <= hi.x; ++i) {
             Real rel = probxlo + i*dx;
             Real rer = probxlo +(i+1)*dx;
-            Real rc = probxlo + (i+0.5)*dx;
+            Real rc = probxlo + (i+Real(0.5))*dx;
             x(i,j,0) /= (-dhx*(rel+rer) - dhy*rc*Real(2.0));
         }
     }

--- a/Src/LinearSolvers/MLMG/AMReX_MLTensorOp.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLTensorOp.cpp
@@ -154,7 +154,7 @@ MLTensorOp::prepareForSolve ()
     for (int amrlev = 0; amrlev < NAMRLevels(); ++amrlev) {
         for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
             int icomp = idim;
-            MultiFab::Xpay(m_b_coeffs[amrlev][0][idim], 4./3.,
+            MultiFab::Xpay(m_b_coeffs[amrlev][0][idim], Real(4./3.),
                            m_kappa[amrlev][0][idim], 0, icomp, 1, 0);
         }
     }
@@ -165,7 +165,7 @@ MLTensorOp::prepareForSolve ()
         for (int mglev = 1; mglev < m_kappa[amrlev].size(); ++mglev) {
             if (m_has_kappa && m_overset_mask[amrlev][mglev]) {
                 const Real fac = static_cast<Real>(1 << mglev); // 2**mglev
-                const Real osfac = 2.0*fac/(fac+1.0);
+                const Real osfac = Real(2.0)*fac/(fac+Real(1.0));
 #ifdef _OPENMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif

--- a/Src/LinearSolvers/MLMG/AMReX_MLTensor_2D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLTensor_2D_K.H
@@ -135,17 +135,17 @@ void mltensor_cross_terms_fx (Box const& box, Array4<Real> const& fx,
     const Real dyi = dxinv[1];
     const auto lo = amrex::lbound(box);
     const auto hi = amrex::ubound(box);
-    constexpr Real twoThirds = 2./3.;
+    constexpr Real twoThirds = Real(2./3.);
 
     for     (int j = lo.y; j <= hi.y; ++j) {
         AMREX_PRAGMA_SIMD
         for (int i = lo.x; i <= hi.x; ++i) {
-            Real dudy = (vel(i,j+1,0,0)+vel(i-1,j+1,0,0)-vel(i,j-1,0,0)-vel(i-1,j-1,0,0))*(0.25*dyi);
-            Real dvdy = (vel(i,j+1,0,1)+vel(i-1,j+1,0,1)-vel(i,j-1,0,1)-vel(i-1,j-1,0,1))*(0.25*dyi);
+            Real dudy = (vel(i,j+1,0,0)+vel(i-1,j+1,0,0)-vel(i,j-1,0,0)-vel(i-1,j-1,0,0))*(Real(0.25)*dyi);
+            Real dvdy = (vel(i,j+1,0,1)+vel(i-1,j+1,0,1)-vel(i,j-1,0,1)-vel(i-1,j-1,0,1))*(Real(0.25)*dyi);
             Real divu = dvdy;
             Real xif = kapx(i,j,0);
-            Real mun = 0.75*(etax(i,j,0,0)-xif);  // restore the original eta
-            Real mut =       etax(i,j,0,1);
+            Real mun = Real(0.75)*(etax(i,j,0,0)-xif);  // restore the original eta
+            Real mut =             etax(i,j,0,1);
             fx(i,j,0,0) = -mun*(-twoThirds*divu) - xif*divu;
             fx(i,j,0,1) = -mut*dudy;
         }
@@ -162,17 +162,17 @@ void mltensor_cross_terms_fy (Box const& box, Array4<Real> const& fy,
     const Real dxi = dxinv[0];
     const auto lo = amrex::lbound(box);
     const auto hi = amrex::ubound(box);
-    constexpr Real twoThirds = 2./3.;
+    constexpr Real twoThirds = Real(2./3.);
 
     for     (int j = lo.y; j <= hi.y; ++j) {
         AMREX_PRAGMA_SIMD
         for (int i = lo.x; i <= hi.x; ++i) {
-            Real dudx = (vel(i+1,j,0,0)+vel(i+1,j-1,0,0)-vel(i-1,j,0,0)-vel(i-1,j-1,0,0))*(0.25*dxi);
-            Real dvdx = (vel(i+1,j,0,1)+vel(i+1,j-1,0,1)-vel(i-1,j,0,1)-vel(i-1,j-1,0,1))*(0.25*dxi);
+            Real dudx = (vel(i+1,j,0,0)+vel(i+1,j-1,0,0)-vel(i-1,j,0,0)-vel(i-1,j-1,0,0))*(Real(0.25)*dxi);
+            Real dvdx = (vel(i+1,j,0,1)+vel(i+1,j-1,0,1)-vel(i-1,j,0,1)-vel(i-1,j-1,0,1))*(Real(0.25)*dxi);
             Real divu = dudx;
             Real xif = kapy(i,j,0);
-            Real mun = 0.75*(etay(i,j,0,1)-xif);  // restore the original eta
-            Real mut =       etay(i,j,0,0);
+            Real mun = Real(0.75)*(etay(i,j,0,1)-xif);  // restore the original eta
+            Real mut =             etay(i,j,0,0);
             fy(i,j,0,0) = -mut*dvdx;
             fy(i,j,0,1) = -mun*(-twoThirds*divu) - xif*divu;
         }
@@ -246,8 +246,8 @@ void mltensor_vel_grads_fx (Box const& box, Array4<Real> const& fx,
         for (int i = lo.x; i <= hi.x; ++i) {
             Real dudx = (vel(i,j,0,0) - vel(i-1,j,0,0))*dxi;
             Real dvdx = (vel(i,j,0,1) - vel(i-1,j,0,1))*dxi;
-            Real dudy = (vel(i,j+1,0,0)+vel(i-1,j+1,0,0)-vel(i,j-1,0,0)-vel(i-1,j-1,0,0))*(0.25*dyi);
-            Real dvdy = (vel(i,j+1,0,1)+vel(i-1,j+1,0,1)-vel(i,j-1,0,1)-vel(i-1,j-1,0,1))*(0.25*dyi);
+            Real dudy = (vel(i,j+1,0,0)+vel(i-1,j+1,0,0)-vel(i,j-1,0,0)-vel(i-1,j-1,0,0))*(Real(0.25)*dyi);
+            Real dvdy = (vel(i,j+1,0,1)+vel(i-1,j+1,0,1)-vel(i,j-1,0,1)-vel(i-1,j-1,0,1))*(Real(0.25)*dyi);
             fx(i,j,0,0) = dudx;
             fx(i,j,0,1) = dvdx;
             fx(i,j,0,2) = dudy;
@@ -269,8 +269,8 @@ void mltensor_vel_grads_fy (Box const& box, Array4<Real> const& fy,
     for     (int j = lo.y; j <= hi.y; ++j) {
         AMREX_PRAGMA_SIMD
         for (int i = lo.x; i <= hi.x; ++i) {
-            Real dudx = (vel(i+1,j,0,0)+vel(i+1,j-1,0,0)-vel(i-1,j,0,0)-vel(i-1,j-1,0,0))*(0.25*dxi);
-            Real dvdx = (vel(i+1,j,0,1)+vel(i+1,j-1,0,1)-vel(i-1,j,0,1)-vel(i-1,j-1,0,1))*(0.25*dxi);
+            Real dudx = (vel(i+1,j,0,0)+vel(i+1,j-1,0,0)-vel(i-1,j,0,0)-vel(i-1,j-1,0,0))*(Real(0.25)*dxi);
+            Real dvdx = (vel(i+1,j,0,1)+vel(i+1,j-1,0,1)-vel(i-1,j,0,1)-vel(i-1,j-1,0,1))*(Real(0.25)*dxi);
             Real dudy = (vel(i,j,0,0) - vel(i,j-1,0,0))*dyi;
             Real dvdy = (vel(i,j,0,1) - vel(i,j-1,0,1))*dyi;
             fy(i,j,0,0) = dudx;

--- a/Src/LinearSolvers/MLMG/AMReX_MLTensor_3D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLTensor_3D_K.H
@@ -50,7 +50,7 @@ void mltensor_fill_corners (int icorner, Box const& vbox, // vbox: the valid box
                     = vel(vlo.x-1,vlo.y  ,vlo.z  ,icomp)
                     + vel(vlo.x  ,vlo.y-1,vlo.z  ,icomp)
                     + vel(vlo.x  ,vlo.y  ,vlo.z-1,icomp)
-                    - vel(vlo.x  ,vlo.y  ,vlo.z  ,icomp) * 2.0;
+                    - vel(vlo.x  ,vlo.y  ,vlo.z  ,icomp) * Real(2.0);
             } else if (vlo.x == dlo.x && vlo.y == dlo.y) {
                 vel      (vlo.x-1,vlo.y-1,vlo.z-1,icomp)
                     = vel(vlo.x-1,vlo.y  ,vlo.z-1,icomp)
@@ -109,7 +109,7 @@ void mltensor_fill_corners (int icorner, Box const& vbox, // vbox: the valid box
                     = vel(vhi.x+1,vlo.y  ,vlo.z  ,icomp)
                     + vel(vhi.x  ,vlo.y-1,vlo.z  ,icomp)
                     + vel(vhi.x  ,vlo.y  ,vlo.z-1,icomp)
-                    - vel(vhi.x  ,vlo.y  ,vlo.z  ,icomp) * 2.0;
+                    - vel(vhi.x  ,vlo.y  ,vlo.z  ,icomp) * Real(2.0);
             } else if (vhi.x == dhi.x && vlo.y == dlo.y) {
                 vel      (vhi.x+1,vlo.y-1,vlo.z-1,icomp)
                     = vel(vhi.x+1,vlo.y  ,vlo.z-1,icomp)
@@ -168,7 +168,7 @@ void mltensor_fill_corners (int icorner, Box const& vbox, // vbox: the valid box
                     = vel(vlo.x-1,vhi.y  ,vlo.z  ,icomp)
                     + vel(vlo.x  ,vhi.y+1,vlo.z  ,icomp)
                     + vel(vlo.x  ,vhi.y  ,vlo.z-1,icomp)
-                    - vel(vlo.x  ,vhi.y  ,vlo.z  ,icomp) * 2.0;
+                    - vel(vlo.x  ,vhi.y  ,vlo.z  ,icomp) * Real(2.0);
             } else if (vlo.x == dlo.x && vhi.y == dhi.y) {
                 vel      (vlo.x-1,vhi.y+1,vlo.z-1,icomp)
                     = vel(vlo.x-1,vhi.y  ,vlo.z-1,icomp)
@@ -227,7 +227,7 @@ void mltensor_fill_corners (int icorner, Box const& vbox, // vbox: the valid box
                     = vel(vhi.x+1,vhi.y  ,vlo.z  ,icomp)
                     + vel(vhi.x  ,vhi.y+1,vlo.z  ,icomp)
                     + vel(vhi.x  ,vhi.y  ,vlo.z-1,icomp)
-                    - vel(vhi.x  ,vhi.y  ,vlo.z  ,icomp) * 2.0;
+                    - vel(vhi.x  ,vhi.y  ,vlo.z  ,icomp) * Real(2.0);
             } else if (vhi.x == dhi.x && vhi.y == dhi.y) {
                 vel      (vhi.x+1,vhi.y+1,vlo.z-1,icomp)
                     = vel(vhi.x+1,vhi.y  ,vlo.z-1,icomp)
@@ -286,7 +286,7 @@ void mltensor_fill_corners (int icorner, Box const& vbox, // vbox: the valid box
                     = vel(vlo.x-1, vlo.y  , vhi.z  ,icomp)
                     + vel(vlo.x  , vlo.y-1, vhi.z  ,icomp)
                     + vel(vlo.x  , vlo.y  , vhi.z+1,icomp)
-                    - vel(vlo.x  , vlo.y  , vhi.z  ,icomp) * 2.0;
+                    - vel(vlo.x  , vlo.y  , vhi.z  ,icomp) * Real(2.0);
             } else if (vlo.x == dlo.x && vlo.y == dlo.y) {
                 vel      (vlo.x-1, vlo.y-1, vhi.z+1,icomp)
                     = vel(vlo.x-1, vlo.y  , vhi.z+1,icomp)
@@ -345,7 +345,7 @@ void mltensor_fill_corners (int icorner, Box const& vbox, // vbox: the valid box
                     = vel(vhi.x+1,vlo.y  ,vhi.z  ,icomp)
                     + vel(vhi.x  ,vlo.y-1,vhi.z  ,icomp)
                     + vel(vhi.x  ,vlo.y  ,vhi.z+1,icomp)
-                    - vel(vhi.x  ,vlo.y  ,vhi.z  ,icomp) * 2.0;
+                    - vel(vhi.x  ,vlo.y  ,vhi.z  ,icomp) * Real(2.0);
             } else if (vhi.x == dhi.x && vlo.y == dlo.y) {
                 vel      (vhi.x+1,vlo.y-1,vhi.z+1,icomp)
                     = vel(vhi.x+1,vlo.y  ,vhi.z+1,icomp)
@@ -404,7 +404,7 @@ void mltensor_fill_corners (int icorner, Box const& vbox, // vbox: the valid box
                     = vel(vlo.x-1,vhi.y  ,vhi.z  ,icomp)
                     + vel(vlo.x  ,vhi.y+1,vhi.z  ,icomp)
                     + vel(vlo.x  ,vhi.y  ,vhi.z+1,icomp)
-                    - vel(vlo.x  ,vhi.y  ,vhi.z  ,icomp) * 2.0;
+                    - vel(vlo.x  ,vhi.y  ,vhi.z  ,icomp) * Real(2.0);
             } else if (vlo.x == dlo.x && vhi.y == dhi.y) {
                 vel      (vlo.x-1,vhi.y+1,vhi.z+1,icomp)
                     = vel(vlo.x-1,vhi.y  ,vhi.z+1,icomp)
@@ -463,7 +463,7 @@ void mltensor_fill_corners (int icorner, Box const& vbox, // vbox: the valid box
                     = vel(vhi.x+1,vhi.y  ,vhi.z  ,icomp)
                     + vel(vhi.x  ,vhi.y+1,vhi.z  ,icomp)
                     + vel(vhi.x  ,vhi.y  ,vhi.z+1,icomp)
-                    - vel(vhi.x  ,vhi.y  ,vhi.z  ,icomp) * 2.0;
+                    - vel(vhi.x  ,vhi.y  ,vhi.z  ,icomp) * Real(2.0);
             } else if (vhi.x == dhi.x && vhi.y == dhi.y) {
                 vel      (vhi.x+1,vhi.y+1,vhi.z+1,icomp)
                     = vel(vhi.x+1,vhi.y  ,vhi.z+1,icomp)
@@ -1063,20 +1063,20 @@ void mltensor_cross_terms_fx (Box const& box, Array4<Real> const& fx,
     const Real dzi = dxinv[2];
     const auto lo = amrex::lbound(box);
     const auto hi = amrex::ubound(box);
-    constexpr Real twoThirds = 2./3.;
+    constexpr Real twoThirds = Real(2./3.);
 
     for         (int k = lo.z; k <= hi.z; ++k) {
         for     (int j = lo.y; j <= hi.y; ++j) {
             AMREX_PRAGMA_SIMD
             for (int i = lo.x; i <= hi.x; ++i) {
-                Real dudy = (vel(i,j+1,k,0)+vel(i-1,j+1,k,0)-vel(i,j-1,k,0)-vel(i-1,j-1,k,0))*(0.25*dyi);
-                Real dvdy = (vel(i,j+1,k,1)+vel(i-1,j+1,k,1)-vel(i,j-1,k,1)-vel(i-1,j-1,k,1))*(0.25*dyi);
-                Real dudz = (vel(i,j,k+1,0)+vel(i-1,j,k+1,0)-vel(i,j,k-1,0)-vel(i-1,j,k-1,0))*(0.25*dzi);
-                Real dwdz = (vel(i,j,k+1,2)+vel(i-1,j,k+1,2)-vel(i,j,k-1,2)-vel(i-1,j,k-1,2))*(0.25*dzi);
+                Real dudy = (vel(i,j+1,k,0)+vel(i-1,j+1,k,0)-vel(i,j-1,k,0)-vel(i-1,j-1,k,0))*(Real(0.25)*dyi);
+                Real dvdy = (vel(i,j+1,k,1)+vel(i-1,j+1,k,1)-vel(i,j-1,k,1)-vel(i-1,j-1,k,1))*(Real(0.25)*dyi);
+                Real dudz = (vel(i,j,k+1,0)+vel(i-1,j,k+1,0)-vel(i,j,k-1,0)-vel(i-1,j,k-1,0))*(Real(0.25)*dzi);
+                Real dwdz = (vel(i,j,k+1,2)+vel(i-1,j,k+1,2)-vel(i,j,k-1,2)-vel(i-1,j,k-1,2))*(Real(0.25)*dzi);
                 Real divu = dvdy + dwdz;
                 Real xif = kapx(i,j,k);
-                Real mun = 0.75*(etax(i,j,k,0)-xif);  // restore the original eta
-                Real mut =       etax(i,j,k,1);
+                Real mun = Real(0.75)*(etax(i,j,k,0)-xif);  // restore the original eta
+                Real mut =             etax(i,j,k,1);
                 fx(i,j,k,0) = -mun*(-twoThirds*divu) - xif*divu;
                 fx(i,j,k,1) = -mut*(dudy);
                 fx(i,j,k,2) = -mut*(dudz);
@@ -1096,20 +1096,20 @@ void mltensor_cross_terms_fy (Box const& box, Array4<Real> const& fy,
     const Real dzi = dxinv[2];
     const auto lo = amrex::lbound(box);
     const auto hi = amrex::ubound(box);
-    constexpr Real twoThirds = 2./3.;
+    constexpr Real twoThirds = Real(2./3.);
 
     for         (int k = lo.z; k <= hi.z; ++k) {
         for     (int j = lo.y; j <= hi.y; ++j) {
             AMREX_PRAGMA_SIMD
             for (int i = lo.x; i <= hi.x; ++i) {
-                Real dudx = (vel(i+1,j,k,0)+vel(i+1,j-1,k,0)-vel(i-1,j,k,0)-vel(i-1,j-1,k,0))*(0.25*dxi);
-                Real dvdx = (vel(i+1,j,k,1)+vel(i+1,j-1,k,1)-vel(i-1,j,k,1)-vel(i-1,j-1,k,1))*(0.25*dxi);
-                Real dvdz = (vel(i,j,k+1,1)+vel(i,j-1,k+1,1)-vel(i,j,k-1,1)-vel(i,j-1,k-1,1))*(0.25*dzi);
-                Real dwdz = (vel(i,j,k+1,2)+vel(i,j-1,k+1,2)-vel(i,j,k-1,2)-vel(i,j-1,k-1,2))*(0.25*dzi);
+                Real dudx = (vel(i+1,j,k,0)+vel(i+1,j-1,k,0)-vel(i-1,j,k,0)-vel(i-1,j-1,k,0))*(Real(0.25)*dxi);
+                Real dvdx = (vel(i+1,j,k,1)+vel(i+1,j-1,k,1)-vel(i-1,j,k,1)-vel(i-1,j-1,k,1))*(Real(0.25)*dxi);
+                Real dvdz = (vel(i,j,k+1,1)+vel(i,j-1,k+1,1)-vel(i,j,k-1,1)-vel(i,j-1,k-1,1))*(Real(0.25)*dzi);
+                Real dwdz = (vel(i,j,k+1,2)+vel(i,j-1,k+1,2)-vel(i,j,k-1,2)-vel(i,j-1,k-1,2))*(Real(0.25)*dzi);
                 Real divu = dudx + dwdz;
                 Real xif = kapy(i,j,k);
-                Real mun = 0.75*(etay(i,j,k,1)-xif);  // restore the original eta
-                Real mut =       etay(i,j,k,0);
+                Real mun = Real(0.75)*(etay(i,j,k,1)-xif);  // restore the original eta
+                Real mut =             etay(i,j,k,0);
                 fy(i,j,k,0) = -mut*(dvdx);
                 fy(i,j,k,1) = -mun*(-twoThirds*divu) - xif*divu;
                 fy(i,j,k,2) = -mut*(dvdz);
@@ -1129,20 +1129,20 @@ void mltensor_cross_terms_fz (Box const& box, Array4<Real> const& fz,
     const Real dyi = dxinv[1];
     const auto lo = amrex::lbound(box);
     const auto hi = amrex::ubound(box);
-    constexpr Real twoThirds = 2./3.;
+    constexpr Real twoThirds = Real(2./3.);
 
     for         (int k = lo.z; k <= hi.z; ++k) {
         for     (int j = lo.y; j <= hi.y; ++j) {
             AMREX_PRAGMA_SIMD
             for (int i = lo.x; i <= hi.x; ++i) {
-                Real dudx = (vel(i+1,j,k,0)+vel(i+1,j,k-1,0)-vel(i-1,j,k,0)-vel(i-1,j,k-1,0))*(0.25*dxi);
-                Real dwdx = (vel(i+1,j,k,2)+vel(i+1,j,k-1,2)-vel(i-1,j,k,2)-vel(i-1,j,k-1,2))*(0.25*dxi);
-                Real dvdy = (vel(i,j+1,k,1)+vel(i,j+1,k-1,1)-vel(i,j-1,k,1)-vel(i,j-1,k-1,1))*(0.25*dyi);
-                Real dwdy = (vel(i,j+1,k,2)+vel(i,j+1,k-1,2)-vel(i,j-1,k,2)-vel(i,j-1,k-1,2))*(0.25*dyi);
+                Real dudx = (vel(i+1,j,k,0)+vel(i+1,j,k-1,0)-vel(i-1,j,k,0)-vel(i-1,j,k-1,0))*(Real(0.25)*dxi);
+                Real dwdx = (vel(i+1,j,k,2)+vel(i+1,j,k-1,2)-vel(i-1,j,k,2)-vel(i-1,j,k-1,2))*(Real(0.25)*dxi);
+                Real dvdy = (vel(i,j+1,k,1)+vel(i,j+1,k-1,1)-vel(i,j-1,k,1)-vel(i,j-1,k-1,1))*(Real(0.25)*dyi);
+                Real dwdy = (vel(i,j+1,k,2)+vel(i,j+1,k-1,2)-vel(i,j-1,k,2)-vel(i,j-1,k-1,2))*(Real(0.25)*dyi);
                 Real divu = dudx + dvdy;
                 Real xif = kapz(i,j,k);
-                Real mun = 0.75*(etaz(i,j,k,2)-xif);  // restore the original eta
-                Real mut =       etaz(i,j,k,0);
+                Real mun = Real(0.75)*(etaz(i,j,k,2)-xif);  // restore the original eta
+                Real mut =             etaz(i,j,k,0);
                 fz(i,j,k,0) = -mut*(dwdx);
                 fz(i,j,k,1) = -mut*(dwdy);
                 fz(i,j,k,2) = -mun*(-twoThirds*divu) - xif*divu;
@@ -1242,13 +1242,13 @@ void mltensor_vel_grads_fx (Box const& box, Array4<Real> const& fx,
                 Real dvdx = (vel(i,j,k,1) - vel(i-1,j,k,1))*dxi;
                 Real dwdx = (vel(i,j,k,2) - vel(i-1,j,k,2))*dxi;
               
-                Real dudy = (vel(i,j+1,k,0)+vel(i-1,j+1,k,0)-vel(i,j-1,k,0)-vel(i-1,j-1,k,0))*(0.25*dyi);
-                Real dvdy = (vel(i,j+1,k,1)+vel(i-1,j+1,k,1)-vel(i,j-1,k,1)-vel(i-1,j-1,k,1))*(0.25*dyi);
-                Real dwdy = (vel(i,j+1,k,2)+vel(i-1,j+1,k,2)-vel(i,j-1,k,2)-vel(i-1,j-1,k,2))*(0.25*dyi);
+                Real dudy = (vel(i,j+1,k,0)+vel(i-1,j+1,k,0)-vel(i,j-1,k,0)-vel(i-1,j-1,k,0))*(Real(0.25)*dyi);
+                Real dvdy = (vel(i,j+1,k,1)+vel(i-1,j+1,k,1)-vel(i,j-1,k,1)-vel(i-1,j-1,k,1))*(Real(0.25)*dyi);
+                Real dwdy = (vel(i,j+1,k,2)+vel(i-1,j+1,k,2)-vel(i,j-1,k,2)-vel(i-1,j-1,k,2))*(Real(0.25)*dyi);
                 
-                Real dudz = (vel(i,j,k+1,0)+vel(i-1,j,k+1,0)-vel(i,j,k-1,0)-vel(i-1,j,k-1,0))*(0.25*dzi);
-                Real dvdz = (vel(i,j,k+1,1)+vel(i-1,j,k+1,1)-vel(i,j,k-1,1)-vel(i-1,j,k-1,1))*(0.25*dzi);
-                Real dwdz = (vel(i,j,k+1,2)+vel(i-1,j,k+1,2)-vel(i,j,k-1,2)-vel(i-1,j,k-1,2))*(0.25*dzi);
+                Real dudz = (vel(i,j,k+1,0)+vel(i-1,j,k+1,0)-vel(i,j,k-1,0)-vel(i-1,j,k-1,0))*(Real(0.25)*dzi);
+                Real dvdz = (vel(i,j,k+1,1)+vel(i-1,j,k+1,1)-vel(i,j,k-1,1)-vel(i-1,j,k-1,1))*(Real(0.25)*dzi);
+                Real dwdz = (vel(i,j,k+1,2)+vel(i-1,j,k+1,2)-vel(i,j,k-1,2)-vel(i-1,j,k-1,2))*(Real(0.25)*dzi);
                 
                 fx(i,j,k,0) = dudx;
                 fx(i,j,k,1) = dvdx;
@@ -1281,17 +1281,17 @@ void mltensor_vel_grads_fy (Box const& box, Array4<Real> const& fy,
             AMREX_PRAGMA_SIMD
             for (int i = lo.x; i <= hi.x; ++i) {
               
-                Real dudx = (vel(i+1,j,k,0)+vel(i+1,j-1,k,0)-vel(i-1,j,k,0)-vel(i-1,j-1,k,0))*(0.25*dxi);
-                Real dvdx = (vel(i+1,j,k,1)+vel(i+1,j-1,k,1)-vel(i-1,j,k,1)-vel(i-1,j-1,k,1))*(0.25*dxi);
-                Real dwdx = (vel(i+1,j,k,2)+vel(i+1,j-1,k,2)-vel(i-1,j,k,2)-vel(i-1,j-1,k,2))*(0.25*dxi);
+                Real dudx = (vel(i+1,j,k,0)+vel(i+1,j-1,k,0)-vel(i-1,j,k,0)-vel(i-1,j-1,k,0))*(Real(0.25)*dxi);
+                Real dvdx = (vel(i+1,j,k,1)+vel(i+1,j-1,k,1)-vel(i-1,j,k,1)-vel(i-1,j-1,k,1))*(Real(0.25)*dxi);
+                Real dwdx = (vel(i+1,j,k,2)+vel(i+1,j-1,k,2)-vel(i-1,j,k,2)-vel(i-1,j-1,k,2))*(Real(0.25)*dxi);
                 
                 Real dudy = (vel(i,j,k,0) - vel(i,j-1,k,0))*dyi;
                 Real dvdy = (vel(i,j,k,1) - vel(i,j-1,k,1))*dyi;
                 Real dwdy = (vel(i,j,k,2) - vel(i,j-1,k,2))*dyi;
                 
-                Real dudz = (vel(i,j,k+1,0)+vel(i,j-1,k+1,0)-vel(i,j,k-1,0)-vel(i,j-1,k-1,0))*(0.25*dzi);
-                Real dvdz = (vel(i,j,k+1,1)+vel(i,j-1,k+1,1)-vel(i,j,k-1,1)-vel(i,j-1,k-1,1))*(0.25*dzi);
-                Real dwdz = (vel(i,j,k+1,2)+vel(i,j-1,k+1,2)-vel(i,j,k-1,2)-vel(i,j-1,k-1,2))*(0.25*dzi);
+                Real dudz = (vel(i,j,k+1,0)+vel(i,j-1,k+1,0)-vel(i,j,k-1,0)-vel(i,j-1,k-1,0))*(Real(0.25)*dzi);
+                Real dvdz = (vel(i,j,k+1,1)+vel(i,j-1,k+1,1)-vel(i,j,k-1,1)-vel(i,j-1,k-1,1))*(Real(0.25)*dzi);
+                Real dwdz = (vel(i,j,k+1,2)+vel(i,j-1,k+1,2)-vel(i,j,k-1,2)-vel(i,j-1,k-1,2))*(Real(0.25)*dzi);
                 
                 fy(i,j,k,0) = dudx;
                 fy(i,j,k,1) = dvdx;
@@ -1324,13 +1324,13 @@ void mltensor_vel_grads_fz (Box const& box, Array4<Real> const& fz,
             AMREX_PRAGMA_SIMD
             for (int i = lo.x; i <= hi.x; ++i) {
               
-                Real dudx = (vel(i+1,j,k,0)+vel(i+1,j,k-1,0)-vel(i-1,j,k,0)-vel(i-1,j,k-1,0))*(0.25*dxi);
-                Real dvdx = (vel(i+1,j,k,1)+vel(i+1,j,k-1,1)-vel(i-1,j,k,1)-vel(i-1,j,k-1,1))*(0.25*dxi);
-                Real dwdx = (vel(i+1,j,k,2)+vel(i+1,j,k-1,2)-vel(i-1,j,k,2)-vel(i-1,j,k-1,2))*(0.25*dxi);
+                Real dudx = (vel(i+1,j,k,0)+vel(i+1,j,k-1,0)-vel(i-1,j,k,0)-vel(i-1,j,k-1,0))*(Real(0.25)*dxi);
+                Real dvdx = (vel(i+1,j,k,1)+vel(i+1,j,k-1,1)-vel(i-1,j,k,1)-vel(i-1,j,k-1,1))*(Real(0.25)*dxi);
+                Real dwdx = (vel(i+1,j,k,2)+vel(i+1,j,k-1,2)-vel(i-1,j,k,2)-vel(i-1,j,k-1,2))*(Real(0.25)*dxi);
                 
-                Real dudy = (vel(i,j+1,k,0)+vel(i,j+1,k-1,0)-vel(i,j-1,k,0)-vel(i,j-1,k-1,0))*(0.25*dyi);
-                Real dvdy = (vel(i,j+1,k,1)+vel(i,j+1,k-1,1)-vel(i,j-1,k,1)-vel(i,j-1,k-1,1))*(0.25*dyi);
-                Real dwdy = (vel(i,j+1,k,2)+vel(i,j+1,k-1,2)-vel(i,j-1,k,2)-vel(i,j-1,k-1,2))*(0.25*dyi);
+                Real dudy = (vel(i,j+1,k,0)+vel(i,j+1,k-1,0)-vel(i,j-1,k,0)-vel(i,j-1,k-1,0))*(Real(0.25)*dyi);
+                Real dvdy = (vel(i,j+1,k,1)+vel(i,j+1,k-1,1)-vel(i,j-1,k,1)-vel(i,j-1,k-1,1))*(Real(0.25)*dyi);
+                Real dwdy = (vel(i,j+1,k,2)+vel(i,j+1,k-1,2)-vel(i,j-1,k,2)-vel(i,j-1,k-1,2))*(Real(0.25)*dyi);
                 
                 Real dudz = (vel(i,j,k,0) - vel(i,j,k-1,0))*dzi;
                 Real dvdz = (vel(i,j,k,1) - vel(i,j,k-1,1))*dzi;

--- a/Src/LinearSolvers/Projections/AMReX_MacProjector.cpp
+++ b/Src/LinearSolvers/Projections/AMReX_MacProjector.cpp
@@ -323,8 +323,8 @@ MacProjector::setOptions ()
     int          bottom_verbose(0);
     int          maxiter(200);
     int          bottom_maxiter(200);
-    Real         bottom_rtol(1.0e-4);
-    Real         bottom_atol(-1.0);
+    Real         bottom_rtol(1.0e-4_rt);
+    Real         bottom_atol(-1.0_rt);
     std::string  bottom_solver("bicg");
 
     int num_pre_smooth(2);

--- a/Src/LinearSolvers/Projections/AMReX_NodalProjector.H
+++ b/Src/LinearSolvers/Projections/AMReX_NodalProjector.H
@@ -73,9 +73,9 @@ public:
                      const amrex::Vector<amrex::MultiFab*>&       a_S_cc = {},
                      const amrex::Vector<const amrex::MultiFab*>& a_S_nd = {} );
 
-    void project ( amrex::Real a_rtol = 1.0e-11, amrex::Real a_atol = 1.0e-14 );
-    void project ( const Vector<amrex::MultiFab*>& a_phi, amrex::Real a_rtol = 1.0e-11,
-                   amrex::Real a_atol = 1.0e-14 );
+    void project ( amrex::Real a_rtol = Real(1.0e-11), amrex::Real a_atol = Real(1.0e-14) );
+    void project ( const Vector<amrex::MultiFab*>& a_phi, amrex::Real a_rtol = Real(1.0e-11),
+                   amrex::Real a_atol = Real(1.0e-14) );
 
     Vector< const MultiFab* > getGradPhi () const {return GetVecOfConstPtrs(m_fluxes);}
     Vector< const MultiFab* > getPhi     () const {return GetVecOfConstPtrs(m_phi);}

--- a/Src/LinearSolvers/Projections/AMReX_NodalProjector.cpp
+++ b/Src/LinearSolvers/Projections/AMReX_NodalProjector.cpp
@@ -143,8 +143,8 @@ NodalProjector::setOptions ()
     int          bottom_verbose(0);
     int          maxiter(100);
     int          bottom_maxiter(100);
-    Real         bottom_rtol(1.0e-4);
-    Real         bottom_atol(-1.0);
+    Real         bottom_rtol(1.0e-4_rt);
+    Real         bottom_atol(-1.0_rt);
     std::string  bottom_solver("bicgcg");
 
     int          num_pre_smooth (2);

--- a/Src/Particle/AMReX_ParticleContainerI.H
+++ b/Src/Particle/AMReX_ParticleContainerI.H
@@ -345,7 +345,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>::locateParticl
 
     if (! outside)
     {
-        if (Geom(0).outsideRoundoffDomain(AMREX_D_DECL(p.pos(0), p.pos(1), p.pos(2))))
+        if (Geom(0).outsideRoundoffDomain(AMREX_D_DECL(Real(p.pos(0)), Real(p.pos(1)), Real(p.pos(2)))))
         {
             RealBox roundoff_domain = Geom(0).RoundoffDomain();
             for (int idim=0; idim < AMREX_SPACEDIM; ++idim)
@@ -358,7 +358,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>::locateParticl
                 }
             }
 
-            AMREX_ASSERT(! Geom(0).outsideRoundoffDomain(AMREX_D_DECL(p.pos(0), p.pos(1), p.pos(2))));
+            AMREX_ASSERT(! Geom(0).outsideRoundoffDomain(AMREX_D_DECL(Real(p.pos(0)), Real(p.pos(1)), Real(p.pos(2)))));
         }
     }
 
@@ -1264,7 +1264,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
   BL_PROFILE("ParticleContainer::RedistributeCPU()");
 
   const int MyProc    = ParallelContext::MyProcSub();
-  Real      strttime  = static_cast<Real>(amrex::second());
+  auto      strttime  = amrex::second();
 
   if (local > 0) BuildRedistributeMask(0, local);
 
@@ -1581,7 +1581,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
   AMREX_ASSERT(OK(lev_min, lev_max, nGrow));
 
   if (m_verbose > 0) {
-      Real stoptime = static_cast<Real>(amrex::second() - strttime);
+      auto stoptime = amrex::second() - strttime;
 
       ByteSpread();
 
@@ -2059,7 +2059,7 @@ AssignCellDensitySingleLevel (int rho_index,
     if (mf_pointer->nGrow() < 1)
        amrex::Error("Must have at least one ghost cell when in AssignCellDensitySingleLevel");
 
-    const Real      strttime    = amrex::second();
+    const auto strttime = amrex::second();
 
     const auto dxi              = Geom(lev).InvCellSizeArray();
     const auto plo              = Geom(lev).ProbLoArray();
@@ -2152,7 +2152,7 @@ AssignCellDensitySingleLevel (int rho_index,
 
     if (m_verbose > 1)
     {
-        Real stoptime = amrex::second() - strttime;
+        auto stoptime = amrex::second() - strttime;
 
         ParallelReduce::Max(stoptime, ParallelContext::IOProcessorNumberSub(),
                             ParallelContext::CommunicatorSub());

--- a/Src/Particle/AMReX_ParticleHDF5.H
+++ b/Src/Particle/AMReX_ParticleHDF5.H
@@ -322,7 +322,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
 
     const int NProcs = ParallelDescriptor::NProcs();
     const int IOProcNumber = ParallelDescriptor::IOProcessorNumber();
-    const Real strttime = amrex::second();
+    const auto strttime = amrex::second();
 
     AMREX_ALWAYS_ASSERT(real_comp_names.size() == NumRealComps() + NStructReal);
     AMREX_ALWAYS_ASSERT( int_comp_names.size() == NumIntComps() + NStructInt);
@@ -623,7 +623,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
    
     if (m_verbose > 1)
     {
-        Real stoptime = amrex::second() - strttime;
+        auto stoptime = amrex::second() - strttime;
         
         ParallelDescriptor::ReduceRealMax(stoptime, IOProcNumber);
         
@@ -899,7 +899,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
     AMREX_ASSERT(!dir.empty());
     AMREX_ASSERT(!file.empty());
     
-    const Real strttime = amrex::second();
+    const auto strttime = amrex::second();
     
     /* int DATA_Digits_Read(5); */
     /* ParmParse pp("particles"); */
@@ -1251,7 +1251,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
     AMREX_ASSERT(OK());
     
     if (m_verbose > 1) {
-        Real stoptime = amrex::second() - strttime;	
+        auto stoptime = amrex::second() - strttime;
         ParallelDescriptor::ReduceRealMax(stoptime, ParallelDescriptor::IOProcessorNumber());
         amrex::Print() << "ParticleContainer::Restart() time: " << stoptime << '\n';
     }

--- a/Src/Particle/AMReX_ParticleIO.H
+++ b/Src/Particle/AMReX_ParticleIO.H
@@ -705,7 +705,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
     AMREX_ASSERT(!dir.empty());
     AMREX_ASSERT(!file.empty());
 
-    const Real strttime = static_cast<Real>(amrex::second());
+    const auto strttime = amrex::second();
 
     int DATA_Digits_Read(5);
     ParmParse pp("particles");
@@ -956,7 +956,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
     AMREX_ASSERT(OK());
 
     if (m_verbose > 1) {
-        Real stoptime = static_cast<Real>(amrex::second() - strttime);
+        auto stoptime = amrex::second() - strttime;
         ParallelDescriptor::ReduceRealMax(stoptime, ParallelDescriptor::IOProcessorNumber());
         amrex::Print() << "ParticleContainer::Restart() time: " << stoptime << '\n';
     }
@@ -1096,7 +1096,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>::WriteAsciiFil
     BL_PROFILE("ParticleContainer::WriteAsciiFile()");
     AMREX_ASSERT(!filename.empty());
 
-    const Real strttime = amrex::second();
+    const auto strttime = amrex::second();
     //
     // Count # of valid particles.
     //
@@ -1230,7 +1230,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>::WriteAsciiFil
 
     if (m_verbose > 1)
     {
-        Real stoptime = amrex::second() - strttime;
+        auto stoptime = amrex::second() - strttime;
 
         ParallelDescriptor::ReduceRealMax(stoptime,ParallelDescriptor::IOProcessorNumber());
 

--- a/Src/Particle/AMReX_ParticleInit.H
+++ b/Src/Particle/AMReX_ParticleInit.H
@@ -41,7 +41,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
 
     const int  MyProc   = ParallelDescriptor::MyProc();
     const int  NProcs   = ParallelDescriptor::NProcs();
-    const Real strttime = amrex::second();
+    const auto strttime = amrex::second();
 
     int NReaders = ParticleType::MaxReaders();  // num ranks to read with
     int NRedist = 1;  // number of times to redistribute while reading
@@ -430,7 +430,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
     {
         ByteSpread();
 
-        Real runtime = amrex::second() - strttime;
+        auto runtime = amrex::second() - strttime;
         
         ParallelDescriptor::ReduceRealMax(runtime, ParallelDescriptor::IOProcessorNumber());
         
@@ -461,7 +461,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>::InitFromBinar
     const int  MyProc   = ParallelDescriptor::MyProc();
     const int  NProcs   = ParallelDescriptor::NProcs();
     const int  IOProc   = ParallelDescriptor::IOProcessorNumber();
-    const Real strttime = amrex::second();
+    const auto strttime = amrex::second();
     //
     // The number of MPI processes that read from the file.
     // We limit this to a rather small number since there's a limit
@@ -865,7 +865,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>::InitFromBinar
     {
         ByteSpread();
 
-        Real runtime = amrex::second() - strttime;
+        auto runtime = amrex::second() - strttime;
 
         ParallelDescriptor::ReduceRealMax(runtime, ParallelDescriptor::IOProcessorNumber());
 
@@ -887,7 +887,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>::InitFromBinar
                                                        int                extradata)
 {
     BL_PROFILE("ParticleContainer<NSR, NSI, NAR, NAI>::InitFromBinaryMetaFile()");
-    const Real strttime = amrex::second();
+    const auto strttime = amrex::second();
 
     std::ifstream ifs(metafile.c_str(), std::ios::in);
 
@@ -909,7 +909,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>::InitFromBinar
     {
         ByteSpread();
 
-        Real runtime = amrex::second() - strttime;
+        auto runtime = amrex::second() - strttime;
 
         ParallelDescriptor::ReduceRealMax(runtime, ParallelDescriptor::IOProcessorNumber());
 
@@ -935,7 +935,7 @@ InitRandom (Long                    icount,
     const int       MyProc   = ParallelDescriptor::MyProc();
     const int       NProcs   = ParallelDescriptor::NProcs();
     const int       IOProc   = ParallelDescriptor::IOProcessorNumber();
-    const Real      strttime = amrex::second();
+    const auto      strttime = amrex::second();
     const Geometry& geom     = Geom(0);
 
     Real r, x, len[AMREX_SPACEDIM] = { AMREX_D_DECL(geom.ProbLength(0),
@@ -1193,7 +1193,7 @@ InitRandom (Long                    icount,
 
     if (m_verbose > 1)
     {
-        Real stoptime = amrex::second() - strttime;
+        auto stoptime = amrex::second() - strttime;
 
         ParallelDescriptor::ReduceRealMax(stoptime,IOProc);
 
@@ -1217,7 +1217,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
     AMREX_ASSERT(m_gdb != 0);
 
     const int       IOProc   = ParallelDescriptor::IOProcessorNumber();
-    const Real      strttime = amrex::second();
+    const auto      strttime = amrex::second();
     const Geometry& geom     = Geom(0);
 
     ParticleLocData pld;
@@ -1292,7 +1292,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
 
     if (m_verbose > 1)
     {
-        Real stoptime = amrex::second() - strttime;
+        auto stoptime = amrex::second() - strttime;
 
         ParallelDescriptor::ReduceRealMax(stoptime,IOProc);
 
@@ -1317,7 +1317,7 @@ InitOnePerCell (Real x_off, Real y_off, Real z_off, const ParticleInitData& pdat
     AMREX_ASSERT(x_off <= 1. && y_off <= 1. && z_off <= 1.); 
 
     const int       IOProc   = ParallelDescriptor::IOProcessorNumber();
-    const Real      strttime = amrex::second();
+    const auto      strttime = amrex::second();
     const Geometry& geom     = Geom(0);
 
     // This assumes level 0 since geom = Geom(0)
@@ -1379,7 +1379,7 @@ InitOnePerCell (Real x_off, Real y_off, Real z_off, const ParticleInitData& pdat
     }
     
     if (m_verbose > 1) {
-        Real stoptime = amrex::second() - strttime;
+        auto stoptime = amrex::second() - strttime;
         
         ParallelDescriptor::ReduceRealMax(stoptime,IOProc);
 
@@ -1397,7 +1397,7 @@ InitNRandomPerCell (int n_per_cell, const ParticleInitData& pdata)
     AMREX_ASSERT(m_gdb != 0);
 
     const int       IOProc   = ParallelDescriptor::IOProcessorNumber();
-    const Real      strttime = amrex::second();
+    const auto      strttime = amrex::second();
     const Geometry& geom     = Geom(0);
 
     // This assumes level 0 since geom = Geom(0)
@@ -1519,7 +1519,7 @@ InitNRandomPerCell (int n_per_cell, const ParticleInitData& pdata)
 
     if (m_verbose > 1)
     {
-        Real stoptime = amrex::second() - strttime;
+        auto stoptime = amrex::second() - strttime;
         
         ParallelDescriptor::ReduceRealMax(stoptime,IOProc);
         

--- a/Src/Particle/AMReX_TracerParticle_mod_K.H
+++ b/Src/Particle/AMReX_TracerParticle_mod_K.H
@@ -26,7 +26,7 @@ void cic_interpolate (const P& p,
 
 #if (AMREX_SPACEDIM == 1)
 
-    amrex::Real lx = (p.pos(0) - plo[0]) * dxi[0] - 0.5; //len
+    amrex::Real lx = (Real(p.pos(0)) - plo[0]) * dxi[0] - Real(0.5); //len
 
     int const i = static_cast<int>(amrex::Math::floor(lx)); //cell
 
@@ -46,8 +46,8 @@ void cic_interpolate (const P& p,
 
 #elif (AMREX_SPACEDIM == 2)
 
-    amrex::Real lx = (p.pos(0) - plo[0]) * dxi[0] - 0.5;
-    amrex::Real ly = (p.pos(1) - plo[1]) * dxi[1] - 0.5;
+    amrex::Real lx = (Real(p.pos(0)) - plo[0]) * dxi[0] - Real(0.5);
+    amrex::Real ly = (Real(p.pos(1)) - plo[1]) * dxi[1] - Real(0.5);
 
     int const i = static_cast<int>(amrex::Math::floor(lx));
     int const j = static_cast<int>(amrex::Math::floor(ly));
@@ -73,9 +73,9 @@ void cic_interpolate (const P& p,
 
 #elif (AMREX_SPACEDIM == 3)
 
-    amrex::Real lx = (p.pos(0) - plo[0]) * dxi[0] - 0.5;
-    amrex::Real ly = (p.pos(1) - plo[1]) * dxi[1] - 0.5;
-    amrex::Real lz = (p.pos(2) - plo[2]) * dxi[2] - 0.5;
+    amrex::Real lx = (Real(p.pos(0)) - plo[0]) * dxi[0] - Real(0.5);
+    amrex::Real ly = (Real(p.pos(1)) - plo[1]) * dxi[1] - Real(0.5);
+    amrex::Real lz = (Real(p.pos(2)) - plo[2]) * dxi[2] - Real(0.5);
 
     int const i = static_cast<int>(amrex::Math::floor(lx));
     int const j = static_cast<int>(amrex::Math::floor(ly));
@@ -120,7 +120,7 @@ void mac_interpolate (const P& p,
 #if (AMREX_SPACEDIM == 1)
     for (int d=0; d < AMREX_SPACEDIM; ++d)
     {
-        amrex::Real lx = (p.pos(0)-plo[0])*dxi[0] - (d != 0)*0.5;
+        amrex::Real lx = (Real(p.pos(0))-plo[0])*dxi[0] - (d != 0)*Real(0.5);
 
         int const i = static_cast<int>(amrex::Math::floor(lx));
 
@@ -139,8 +139,8 @@ void mac_interpolate (const P& p,
 
   for (int d=0; d < AMREX_SPACEDIM; ++d)
   {
-      amrex::Real lx = (p.pos(0)-plo[0])*dxi[0] - (d != 0)*0.5;
-      amrex::Real ly = (p.pos(1)-plo[1])*dxi[1] - (d != 1)*0.5;
+      amrex::Real lx = (Real(p.pos(0))-plo[0])*dxi[0] - (d != 0)*Real(0.5);
+      amrex::Real ly = (Real(p.pos(1))-plo[1])*dxi[1] - (d != 1)*Real(0.5);
 
       int const i = static_cast<int>(amrex::Math::floor(lx));
       int const j = static_cast<int>(amrex::Math::floor(ly));
@@ -166,9 +166,9 @@ void mac_interpolate (const P& p,
 
   for (int d=0; d < AMREX_SPACEDIM; ++d)
   {
-      amrex::Real lx = (p.pos(0)-plo[0])*dxi[0] - (d != 0)*0.5;
-      amrex::Real ly = (p.pos(1)-plo[1])*dxi[1] - (d != 1)*0.5;
-      amrex::Real lz = (p.pos(2)-plo[2])*dxi[2] - (d != 2)*0.5;
+      amrex::Real lx = (Real(p.pos(0))-plo[0])*dxi[0] - (d != 0)*Real(0.5);
+      amrex::Real ly = (Real(p.pos(1))-plo[1])*dxi[1] - (d != 1)*Real(0.5);
+      amrex::Real lz = (Real(p.pos(2))-plo[2])*dxi[2] - (d != 2)*Real(0.5);
 
       int const i = static_cast<int>(amrex::Math::floor(lx));
       int const j = static_cast<int>(amrex::Math::floor(ly));

--- a/Src/Particle/AMReX_TracerParticles.cpp
+++ b/Src/Particle/AMReX_TracerParticles.cpp
@@ -23,7 +23,7 @@ TracerParticleContainer::AdvectWithUmac (MultiFab* umac, int lev, Real dt)
                  AMREX_ASSERT(!umac[1].contains_nan());,
                  AMREX_ASSERT(!umac[2].contains_nan()););
 
-    const Real      strttime = amrex::second();
+    const auto      strttime = amrex::second();
     const Geometry& geom     = m_gdb->Geom(lev);
     const auto          plo      = geom.ProbLoArray();
     const auto          dxi      = geom.InvCellSizeArray();
@@ -104,7 +104,7 @@ TracerParticleContainer::AdvectWithUmac (MultiFab* umac, int lev, Real dt)
 
     if (m_verbose > 1)
     {
-        Real stoptime = amrex::second() - strttime;
+        auto stoptime = amrex::second() - strttime;
 
 #ifdef AMREX_LAZY
 	Lazy::QueueReduction( [=] () mutable {
@@ -131,7 +131,7 @@ TracerParticleContainer::AdvectWithUcc (const MultiFab& Ucc, int lev, Real dt)
     AMREX_ASSERT(lev >= 0 && lev < GetParticles().size());
     AMREX_ASSERT(!Ucc.contains_nan());
 
-    const Real          strttime = amrex::second();
+    const auto          strttime = amrex::second();
     const Geometry&     geom     = m_gdb->Geom(lev);
     const auto          plo      = geom.ProbLoArray();
     const auto          dxi      = geom.InvCellSizeArray();
@@ -184,7 +184,7 @@ TracerParticleContainer::AdvectWithUcc (const MultiFab& Ucc, int lev, Real dt)
 
     if (m_verbose > 1)
     {
-        Real stoptime = amrex::second() - strttime;
+        auto stoptime = amrex::second() - strttime;
 
 #ifdef AMREX_LAZY
 	Lazy::QueueReduction( [=] () mutable {
@@ -219,7 +219,7 @@ TracerParticleContainer::Timestamp (const std::string&      basename,
     AMREX_ASSERT(!basename.empty());
     AMREX_ASSERT(lev <= m_gdb->finestLevel());
 
-    const Real strttime = amrex::second();
+    const auto strttime = amrex::second();
 
     const int   MyProc    = ParallelDescriptor::MyProc();
     const int   NProcs    = ParallelContext::NProcsSub();
@@ -353,7 +353,7 @@ TracerParticleContainer::Timestamp (const std::string&      basename,
 
     if (m_verbose > 1)
     {
-        Real stoptime = amrex::second() - strttime;
+        auto stoptime = amrex::second() - strttime;
 
 #ifdef AMREX_LAZY
         Lazy::QueueReduction( [=] () mutable {

--- a/Tests/FillBoundaryComparison/main.cpp
+++ b/Tests/FillBoundaryComparison/main.cpp
@@ -133,7 +133,7 @@ main (int argc, char* argv[])
     Real err = 0.0;
 
     ParallelDescriptor::Barrier();
-    Real wt0 = ParallelDescriptor::second();
+    auto wt0 = ParallelDescriptor::second();
 
     for (int iround = 0; iround < nrounds; ++iround) {
 	for (int c=0; c<2; ++c) {
@@ -152,7 +152,7 @@ main (int argc, char* argv[])
     }
 	    
     ParallelDescriptor::Barrier();
-    Real wt1 = ParallelDescriptor::second();
+    auto wt1 = ParallelDescriptor::second();
 
     if (ParallelDescriptor::IOProcessor()) {
         std::cout << "Using MPI" << std::endl;

--- a/Tools/C_util/WritePlotFile.cpp
+++ b/Tools/C_util/WritePlotFile.cpp
@@ -229,7 +229,7 @@ writePlotFile (const char*               name,
                const Vector<std::string>& names)
 {
 
-    Real dPlotFileTime0(ParallelDescriptor::second());
+    auto dPlotFileTime0 =ParallelDescriptor::second();
     //std::string pltfile = Concatenate(root, num);
     std::string pltfile(name);
 
@@ -281,8 +281,8 @@ writePlotFile (const char*               name,
             amrex::Error("Amr::writePlotFile() failed");
     }
 
-    Real dPlotFileTime1(ParallelDescriptor::second());
-    Real dPlotFileTime(dPlotFileTime1 - dPlotFileTime0);
+    auto dPlotFileTime1 = ParallelDescriptor::second();
+    auto dPlotFileTime = dPlotFileTime1 - dPlotFileTime0;
     ParallelDescriptor::ReduceRealMax(dPlotFileTime);
     if(ParallelDescriptor::IOProcessor()) {
       std::cout << "Write plotfile time = " << dPlotFileTime << "  seconds." << std::endl;

--- a/Tools/libamrex/configure.py
+++ b/Tools/libamrex/configure.py
@@ -79,6 +79,14 @@ def configure(argv):
                         help="Enable AMReX embedded boundary capability [default=no]",
                         choices=["yes","no"],
                         default="no")
+    parser.add_argument("--single-precision",
+                        help="Define amrex::Real as float [default=no (i.e., double)]",
+                        choices=["yes","no"],
+                        default="no")
+    parser.add_argument("--single-precision-particles",
+                        help="Define amrex::ParticleReal as float [default=no (i.e., double)]",
+                        choices=["yes","no"],
+                        default="no")
     parser.add_argument("--enable-xsdk-defaults",
                         help="Enable XSDK mode [default=no]",
                         choices=["yes","no"],
@@ -133,6 +141,8 @@ def configure(argv):
     f.write("USE_HYPRE = {}\n".format("TRUE" if args.enable_hypre == "yes" else "FALSE"))
     f.write("USE_PETSC = {}\n".format("TRUE" if args.enable_petsc == "yes" else "FALSE"))
     f.write("USE_EB = {}\n".format("TRUE" if args.enable_eb == "yes" else "FALSE"))
+    f.write("PRECISION = {}\n".format("FLOAT" if args.single_precision == "yes" else "DOUBLE"))
+    f.write("USE_SINGLE_PRECISION_PARTICLES = {}\n".format("TRUE" if args.single_precision_particles == "yes" else "FALSE"))
     f.write("AMREX_XSDK = {}\n".format("TRUE" if args.enable_xsdk_defaults == "yes" else "FALSE"))
     f.write("ALLOW_DIFFERENT_COMP = {}\n".format("FALSE" if args.allow_different_compiler == "no" else "TRUE"))
     f.write("USE_SENSEI_INSITU = {}\n".format("FALSE" if args.with_sensei_insitu == "no" else "TRUE"))

--- a/Tutorials/Amr/Advection_AmrCore/Source/main.cpp
+++ b/Tutorials/Amr/Advection_AmrCore/Source/main.cpp
@@ -18,7 +18,7 @@ int main(int argc, char* argv[])
         BL_PROFILE("main()");
 
         // wallclock time
-        const Real strt_total = amrex::second();
+        const auto strt_total = amrex::second();
 
         // constructor - reads in parameters from inputs file
         //             - sizes multilevel arrays and data structures
@@ -31,7 +31,7 @@ int main(int argc, char* argv[])
 	amr_core_adv.Evolve();
 	
         // wallclock time
-	Real end_total = amrex::second() - strt_total;
+	auto end_total = amrex::second() - strt_total;
 	
 	if (amr_core_adv.Verbose()) {
             // print wallclock time

--- a/Tutorials/Amr/Advection_AmrLevel/Source/AmrLevelAdv.cpp
+++ b/Tutorials/Amr/Advection_AmrLevel/Source/AmrLevelAdv.cpp
@@ -719,14 +719,14 @@ AmrLevelAdv::reflux ()
 {
     BL_ASSERT(level<parent->finestLevel());
 
-    const Real strt = amrex::second();
+    const auto strt = amrex::second();
 
     getFluxReg(level+1).Reflux(get_new_data(Phi_Type),1.0,0,0,NUM_STATE,geom);
     
     if (verbose)
     {
         const int IOProc = ParallelDescriptor::IOProcessorNumber();
-        Real      end    = amrex::second() - strt;
+        auto      end    = amrex::second() - strt;
 	
         ParallelDescriptor::ReduceRealMax(end,IOProc);
 	

--- a/Tutorials/Amr/Advection_AmrLevel/Source/main.cpp
+++ b/Tutorials/Amr/Advection_AmrLevel/Source/main.cpp
@@ -16,7 +16,7 @@ main (int   argc,
 {
     amrex::Initialize(argc,argv);
 
-    Real dRunTime1 = amrex::second();
+    auto dRunTime1 = amrex::second();
 
     int  max_step;
     Real strt_time;
@@ -69,7 +69,7 @@ main (int   argc,
 
     }
 
-    Real dRunTime2 = amrex::second() - dRunTime1;
+    auto dRunTime2 = amrex::second() - dRunTime1;
 
     ParallelDescriptor::ReduceRealMax(dRunTime2, ParallelDescriptor::IOProcessorNumber());
 

--- a/Tutorials/Basic/HeatEquation_EX1_C/Source/main.cpp
+++ b/Tutorials/Basic/HeatEquation_EX1_C/Source/main.cpp
@@ -21,7 +21,7 @@ int main (int argc, char* argv[])
 void main_main ()
 {
     // What time is it now?  We'll use this to compute total run time.
-    Real strt_time = ParallelDescriptor::second();
+    auto strt_time = ParallelDescriptor::second();
 
     // AMREX_SPACEDIM: number of dimensions
     int n_cell, max_grid_size, nsteps, plot_int;
@@ -138,7 +138,7 @@ void main_main ()
 
     // Call the timer again and compute the maximum difference between the start time and stop time
     //   over all processors
-    Real stop_time = ParallelDescriptor::second() - strt_time;
+    auto stop_time = ParallelDescriptor::second() - strt_time;
     const int IOProc = ParallelDescriptor::IOProcessorNumber();
     ParallelDescriptor::ReduceRealMax(stop_time,IOProc);
 

--- a/Tutorials/Basic/HeatEquation_EX1_CF/Source/main.cpp
+++ b/Tutorials/Basic/HeatEquation_EX1_CF/Source/main.cpp
@@ -21,7 +21,7 @@ int main (int argc, char* argv[])
 void main_main ()
 {
     // What time is it now?  We'll use this to compute total run time.
-    Real strt_time = amrex::second();
+    auto strt_time = amrex::second();
 
     // AMREX_SPACEDIM: number of dimensions
     int n_cell, max_grid_size, nsteps, plot_int;
@@ -147,7 +147,7 @@ void main_main ()
 
     // Call the timer again and compute the maximum difference between the start time and stop time
     //   over all processors
-    Real stop_time = amrex::second() - strt_time;
+    auto stop_time = amrex::second() - strt_time;
     const int IOProc = ParallelDescriptor::IOProcessorNumber();
     ParallelDescriptor::ReduceRealMax(stop_time,IOProc);
 

--- a/Tutorials/Basic/HeatEquation_EX2_C/Source/main.cpp
+++ b/Tutorials/Basic/HeatEquation_EX2_C/Source/main.cpp
@@ -23,7 +23,7 @@ int main (int argc, char* argv[])
 void main_main ()
 {
     // What time is it now?  We'll use this to compute total run time.
-    Real strt_time = ParallelDescriptor::second();
+    auto strt_time = ParallelDescriptor::second();
 
     // AMREX_SPACEDIM: number of dimensions
     int n_cell, max_grid_size, nsteps, plot_int;
@@ -192,7 +192,7 @@ void main_main ()
 
     // Call the timer again and compute the maximum difference between the start time and stop time
     //   over all processors
-    Real stop_time = ParallelDescriptor::second() - strt_time;
+    auto stop_time = ParallelDescriptor::second() - strt_time;
     const int IOProc = ParallelDescriptor::IOProcessorNumber();
     ParallelDescriptor::ReduceRealMax(stop_time,IOProc);
 

--- a/Tutorials/Basic/HeatEquation_EX2_CF/Source/main.cpp
+++ b/Tutorials/Basic/HeatEquation_EX2_CF/Source/main.cpp
@@ -21,7 +21,7 @@ int main (int argc, char* argv[])
 void main_main ()
 {
     // What time is it now?  We'll use this to compute total run time.
-    Real strt_time = amrex::second();
+    auto strt_time = amrex::second();
 
     // AMREX_SPACEDIM: number of dimensions
     int n_cell, max_grid_size, nsteps, plot_int;
@@ -195,7 +195,7 @@ void main_main ()
 
     // Call the timer again and compute the maximum difference between the start time and stop time
     //   over all processors
-    Real stop_time = amrex::second() - strt_time;
+    auto stop_time = amrex::second() - strt_time;
     const int IOProc = ParallelDescriptor::IOProcessorNumber();
     ParallelDescriptor::ReduceRealMax(stop_time,IOProc);
 

--- a/Tutorials/Basic/HeatEquation_EX3_C/Source/main.cpp
+++ b/Tutorials/Basic/HeatEquation_EX3_C/Source/main.cpp
@@ -21,7 +21,7 @@ int main (int argc, char* argv[])
 void main_main ()
 {
     // What time is it now?  We'll use this to compute total run time.
-    Real strt_time = amrex::second();
+    auto strt_time = amrex::second();
 
     // AMREX_SPACEDIM: number of dimensions
     int n_cell, max_grid_size, nsteps, plot_int;
@@ -188,7 +188,7 @@ void main_main ()
 
     // Call the timer again and compute the maximum difference between the start time and stop time
     //   over all processors
-    Real stop_time = amrex::second() - strt_time;
+    auto stop_time = amrex::second() - strt_time;
     const int IOProc = ParallelDescriptor::IOProcessorNumber();
     ParallelDescriptor::ReduceRealMax(stop_time,IOProc);
 

--- a/Tutorials/Blueprint/HeatEquation_EX1_C/Source/main.cpp
+++ b/Tutorials/Blueprint/HeatEquation_EX1_C/Source/main.cpp
@@ -34,7 +34,7 @@ int main (int argc, char* argv[])
 void main_main ()
 {
     // What time is it now?  We'll use this to compute total run time.
-    Real strt_time = ParallelDescriptor::second();
+    auto strt_time = ParallelDescriptor::second();
 
     // AMREX_SPACEDIM: number of dimensions
     int n_cell, max_grid_size, nsteps, plot_int;
@@ -256,7 +256,7 @@ void main_main ()
 
     // Call the timer again and compute the maximum difference between the start time and stop time
     //   over all processors
-    Real stop_time = ParallelDescriptor::second() - strt_time;
+    auto stop_time = ParallelDescriptor::second() - strt_time;
     const int IOProc = ParallelDescriptor::IOProcessorNumber();
     ParallelDescriptor::ReduceRealMax(stop_time,IOProc);
 

--- a/Tutorials/EB/CNS/Source/CNS_advance.cpp
+++ b/Tutorials/EB/CNS/Source/CNS_advance.cpp
@@ -90,7 +90,7 @@ CNS::compute_dSdt (const MultiFab& S, MultiFab& dSdt, Real dt,
         for (MFIter mfi(S, MFItInfo().EnableTiling(hydro_tile_size).SetDynamic(true));
                         mfi.isValid(); ++mfi)
         {
-            Real wt = amrex::second();
+            auto wt = amrex::second();
 
             const Box& bx = mfi.tilebox();
 

--- a/Tutorials/EB/CNS/Source/main.cpp
+++ b/Tutorials/EB/CNS/Source/main.cpp
@@ -17,9 +17,9 @@ int main (int argc, char* argv[])
 
     BL_PROFILE_VAR("main()", pmain);
 
-    Real timer_tot = amrex::second();
-    Real timer_init = 0.;
-    Real timer_advance = 0.;
+    double timer_tot = amrex::second();
+    double timer_init = 0.;
+    double timer_advance = 0.;
 
     int  max_step;
     Real strt_time;

--- a/Tutorials/GPU/CNS/Source/main.cpp
+++ b/Tutorials/GPU/CNS/Source/main.cpp
@@ -14,9 +14,9 @@ int main (int argc, char* argv[])
 
     BL_PROFILE_VAR("main()", pmain);
 
-    Real timer_tot = amrex::second();
-    Real timer_init = Real(0.);
-    Real timer_advance = Real(0.);
+    double timer_tot = amrex::second();
+    double timer_init = 0.;
+    double timer_advance = 0.;
 
     int  max_step;
     Real strt_time;

--- a/Tutorials/GPU/EBCNS/Source/main.cpp
+++ b/Tutorials/GPU/EBCNS/Source/main.cpp
@@ -17,9 +17,9 @@ int main (int argc, char* argv[])
 
     BL_PROFILE_VAR("main()", pmain);
 
-    Real timer_tot = amrex::second();
-    Real timer_init = 0.;
-    Real timer_advance = 0.;
+    double timer_tot = amrex::second();
+    double timer_init = 0.;
+    double timer_advance = 0.;
 
     int  max_step;
     Real strt_time;

--- a/Tutorials/LinearSolvers/MAC_Projection_EB/main.cpp
+++ b/Tutorials/LinearSolvers/MAC_Projection_EB/main.cpp
@@ -48,7 +48,7 @@ int main (int argc, char* argv[])
 
     amrex::Initialize(argc, argv);
 
-    Real strt_time = amrex::second();
+    auto strt_time = amrex::second();
 
     {
         int mg_verbose = 0;
@@ -257,7 +257,7 @@ int main (int argc, char* argv[])
         write_plotfile(geom, plotfile_mf, regtest);
     }
 
-    Real stop_time = amrex::second() - strt_time;
+    auto stop_time = amrex::second() - strt_time;
     amrex::Print() << "Total run time " << stop_time << std::endl;
 
     amrex::Finalize();

--- a/Tutorials/LinearSolvers/Nodal_Projection_EB/main.cpp
+++ b/Tutorials/LinearSolvers/Nodal_Projection_EB/main.cpp
@@ -35,7 +35,7 @@ int main (int argc, char* argv[])
 
     amrex::Initialize(argc, argv);
 
-    Real strt_time = amrex::second();
+    auto strt_time = amrex::second();
     
     {
         int mg_verbose = 0;
@@ -298,7 +298,7 @@ int main (int argc, char* argv[])
         write_plotfile(geom, plotfile_mf); 
     }
   
-    Real stop_time = amrex::second() - strt_time;
+    auto stop_time = amrex::second() - strt_time;
     amrex::Print() << "Total run time " << stop_time << std::endl;
 
     amrex::Finalize();


### PR DESCRIPTION
## Summary

* Add new arguments `--single-precision` and `--single-precision-particles`
  to `configure`.

* Add amrex::almostEqual for comparing floating point numbers.

* Fix double to float conversion warnings.

* Add CI testing single precision build

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
