### PR TITLE
Make bisect more robust

### DIFF
--- a/Src/Base/AMReX_Algorithm.H
+++ b/Src/Base/AMReX_Algorithm.H
@@ -68,7 +68,21 @@ namespace amrex
         return (v < lo) ? lo : (hi < v) ? hi : v;
     }
 
-    template <class T, class F>
+    // Reference: https://en.cppreference.com/w/cpp/types/numeric_limits/epsilon
+    template <typename T>
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    typename std::enable_if<std::is_floating_point<T>::value,bool>::type
+    almostEqual (T x, T y, int ulp = 2)
+    {
+        // the machine epsilon has to be scaled to the magnitude of the values used
+        // and multiplied by the desired precision in ULPs (units in the last place)
+        return amrex::Math::abs(x-y) <= std::numeric_limits<T>::epsilon() * amrex::Math::abs(x+y) * ulp
+        // unless the result is subnormal
+        || amrex::Math::abs(x-y) < std::numeric_limits<T>::min();
+    }
+
+    template <class T, class F,
+              typename std::enable_if<std::is_floating_point<T>::value,int>::type FOO = 0>
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     T bisect (T lo, T hi, F f, T tol=1e-12, int max_iter=100)
     {
@@ -85,11 +99,11 @@ namespace amrex
             "Error - calling bisect but lo and hi don't bracket a root.");
 
         T mi = (lo + hi) / T(2);
-        T fmi = 0.0;
+        T fmi = T(0);
         int n = 1;
         while (n <= max_iter)
         {
-            if (hi - lo < tol) break;
+            if (hi - lo < tol || almostEqual(lo,hi)) break;
             mi = (lo + hi) / T(2);
             fmi = f(mi);
             if (fmi == T(0)) break;
@@ -103,19 +117,6 @@ namespace amrex
             "Error - maximum number of iterations reached in bisect.");
 
         return mi;
-    }
-
-    // Reference: https://en.cppreference.com/w/cpp/types/numeric_limits/epsilon
-    template <typename T>
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-    typename std::enable_if<std::is_floating_point<T>::value,bool>::type
-    almostEqual (T x, T y, int ulp = 2)
-    {
-        // the machine epsilon has to be scaled to the magnitude of the values used
-        // and multiplied by the desired precision in ULPs (units in the last place)
-        return amrex::Math::abs(x-y) <= std::numeric_limits<T>::epsilon() * amrex::Math::abs(x+y) * ulp
-        // unless the result is subnormal
-        || amrex::Math::abs(x-y) < std::numeric_limits<T>::min();
     }
 }
 

--- a/Src/Base/AMReX_Geometry.cpp
+++ b/Src/Base/AMReX_Geometry.cpp
@@ -414,7 +414,7 @@ Geometry::computeRoundoffDomain ()
         Real deltax = CellSize(idim);
 
 #ifdef AMREX_SINGLE_PRECISION_PARTICLES
-        Real tolerance = std::max(1.e-4_rt*deltax, 1.e-10_rt*phi);
+        Real tolerance = std::max(1.e-4_rt*deltax, 2.e-7_rt*phi);
 #else
         Real tolerance = std::max(1.e-8_rt*deltax, 1.e-14_rt*phi);
 #endif


### PR DESCRIPTION
## Summary

If the lower and upper bounds are almost equal, break out of the bisect
iteration.

## Additional background

The following code breaks the development branch in single precision debug mode.
```
Box domain(IntVect(0), IntVect(335,63,47));
RealBox probdomain({-0.7099999785_rt, -0.02305299975_rt, -0.0480009988_rt},
                   {0.1299999952_rt, 0.1369469911_rt, 0.07199899852_rt});
Geometry geom(domain, probdomain, 0, Array<int,3>{0,0,0});
```

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
