### PR TITLE
Always have Abort_device etc. defined for GPU build

### DIFF
--- a/Src/Base/AMReX.H
+++ b/Src/Base/AMReX.H
@@ -101,7 +101,7 @@ namespace amrex
 
     void Error_host (const char* msg);
 
-#if defined(AMREX_USE_GPU) && !defined(NDEBUG)
+#if defined(AMREX_USE_GPU)
     AMREX_GPU_EXTERNAL AMREX_GPU_DEVICE AMREX_NO_INLINE
     void Error_device (const char * msg);
 #endif
@@ -124,7 +124,7 @@ namespace amrex
 
     void Warning_host (const char * msg);
 
-#if defined(AMREX_USE_GPU) && !defined(NDEBUG)
+#if defined(AMREX_USE_GPU)
     AMREX_GPU_EXTERNAL AMREX_GPU_DEVICE AMREX_NO_INLINE
     void Warning_device (const char * msg);
 #endif
@@ -147,7 +147,7 @@ namespace amrex
 
     void Abort_host (const char * msg);
 
-#if defined(AMREX_USE_GPU) && !defined(NDEBUG)
+#if defined(AMREX_USE_GPU)
     AMREX_GPU_EXTERNAL AMREX_GPU_DEVICE AMREX_NO_INLINE
     void Abort_device (const char * msg);
 #endif
@@ -173,7 +173,7 @@ namespace amrex
 
     void Assert_host (const char* EX, const char* file, int line, const char* msg);
 
-#if defined(AMREX_USE_GPU) && !defined(NDEBUG)
+#if defined(AMREX_USE_GPU)
     AMREX_GPU_EXTERNAL AMREX_GPU_DEVICE AMREX_NO_INLINE
     void Assert_device (const char* EX, const char* file, int line, const char* msg);
 #endif

--- a/Src/Base/AMReX.cpp
+++ b/Src/Base/AMReX.cpp
@@ -203,7 +203,7 @@ amrex::Error_host (const char * msg)
     }
 }
 
-#if defined(AMREX_USE_GPU) && !defined(NDEBUG)
+#if defined(AMREX_USE_GPU)
 #if AMREX_DEVICE_COMPILE
 AMREX_GPU_DEVICE
 void
@@ -223,7 +223,7 @@ amrex::Warning_host (const char * msg)
     }
 }
 
-#if defined(AMREX_USE_GPU) && !defined(NDEBUG)
+#if defined(AMREX_USE_GPU)
 #if AMREX_DEVICE_COMPILE
 AMREX_GPU_DEVICE
 void
@@ -251,7 +251,7 @@ amrex::Abort_host (const char * msg)
    }
 }
 
-#if defined(AMREX_USE_GPU) && !defined(NDEBUG)
+#if defined(AMREX_USE_GPU)
 #if AMREX_DEVICE_COMPILE
 AMREX_GPU_DEVICE
 void
@@ -300,7 +300,7 @@ amrex::Assert_host (const char* EX, const char* file, int line, const char* msg)
    }
 }
 
-#if defined(AMREX_USE_GPU) && !defined(NDEBUG)
+#if defined(AMREX_USE_GPU)
 #if AMREX_DEVICE_COMPILE
 AMREX_GPU_DEVICE
 void


### PR DESCRIPTION
## Summary

It used to be these functions are defined only if NDEBUG is defined.
However, the cmake build system does not store `NDEBUG` in `AMReX_Config.H.
It's possible that AMReX is built with `NDEBUG` and `Abort_device` is not
defined, but the user's code may be built without `NDEBUG`.  Then
`amrex::Abort` defined in `AMReX.H` would fail to compile.  Always having
these device functions defined can solve the issue.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
