### PR TITLE
Prefetch not supported on Windows

### DIFF
--- a/Src/Base/AMReX_BaseFab.H
+++ b/Src/Base/AMReX_BaseFab.H
@@ -1684,7 +1684,7 @@ BaseFab<T>::prefetchToHost () const noexcept
         // std::size_t s = sizeof(T)*this->nvar*this->domain.numPts();
         // auto& q = Gpu::Device::streamQueue();
         // q.submit([&] (sycl::handler& h) { h.prefetch(this->dptr, s); });
-#elif defined(AMREX_USE_CUDA)
+#elif defined(AMREX_USE_CUDA) && !defined(_WIN32)
         if (Gpu::Device::devicePropMajor() >= 6) {
             std::size_t s = sizeof(T)*this->nvar*this->domain.numPts();
             AMREX_CUDA_SAFE_CALL(cudaMemPrefetchAsync(this->dptr, s,
@@ -1709,7 +1709,7 @@ BaseFab<T>::prefetchToDevice () const noexcept
         std::size_t s = sizeof(T)*this->nvar*this->domain.numPts();
         auto& q = Gpu::Device::streamQueue();
         q.submit([&] (sycl::handler& h) { h.prefetch(this->dptr, s); });
-#elif defined(AMREX_USE_CUDA)
+#elif defined(AMREX_USE_CUDA) && !defined(_WIN32)
         if (Gpu::Device::devicePropMajor() >= 6) {
             std::size_t s = sizeof(T)*this->nvar*this->domain.numPts();
             AMREX_CUDA_SAFE_CALL(cudaMemPrefetchAsync(this->dptr, s,


### PR DESCRIPTION
## Summary

On-demand page migration is not supported on Windows.

## Additional background

https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#um-requirements

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
