### PR TITLE
ParmParse::hasUnusedInputs & getUnusedInputs

### DIFF
--- a/Src/Base/AMReX_ParmParse.H
+++ b/Src/Base/AMReX_ParmParse.H
@@ -3,13 +3,14 @@
 #define BL_PARMPARSE_H
 #include <AMReX_Config.H>
 
+#include <AMReX_BLassert.H>
+
 #include <stack>
 #include <string>
 #include <iosfwd>
 #include <vector>
 #include <list>
 #include <array>
-#include <AMReX_BLassert.H>
 
 namespace amrex {
 
@@ -927,7 +928,13 @@ public:
     static void Finalize();
 
     static bool QueryUnusedInputs ();
-    
+
+    //! Any unused [prefix.]* parameters?
+    static bool hasUnusedInputs (const std::string& prefix = std::string());
+
+    //! Returns unused [prefix.]* parameters.
+    static std::vector<std::string> getUnusedInputs (const std::string& prefix = std::string());
+
     struct PP_entry;
     typedef std::list<PP_entry> Table;
     static void appendTable(ParmParse::Table& tab);

--- a/Src/Base/AMReX_ParmParse.cpp
+++ b/Src/Base/AMReX_ParmParse.cpp
@@ -1,3 +1,10 @@
+#include <AMReX.H>
+#include <AMReX_ParmParse.H>
+#include <AMReX_ParallelDescriptor.H>
+#include <AMReX_Box.H>
+#include <AMReX_IntVect.H>
+#include <AMReX_BLFort.H>
+#include <AMReX_Print.H>
 
 #include <algorithm>
 #include <iterator>
@@ -12,15 +19,6 @@
 #include <cctype>
 #include <vector>
 #include <list>
-#include <map>
-
-#include <AMReX.H>
-#include <AMReX_ParmParse.H>
-#include <AMReX_ParallelDescriptor.H>
-#include <AMReX_Box.H>
-#include <AMReX_IntVect.H>
-#include <AMReX_BLFort.H>
-#include <AMReX_Print.H>
 
 extern "C" void amrex_init_namelist (const char*);
 extern "C" void amrex_finalize_namelist ();
@@ -1014,7 +1012,7 @@ ParmParse::appendTable(ParmParse::Table& tab)
 
 static
 bool
-unused_table_entries_q (const ParmParse::Table& table)
+unused_table_entries_q (const ParmParse::Table& table, const std::string& prefix = std::string())
 {
     for ( const_list_iterator li = table.begin(), End = table.end(); li != End; ++li )
     {
@@ -1022,16 +1020,28 @@ unused_table_entries_q (const ParmParse::Table& table)
 	{
 	    if ( !li->m_queried )
 	    {
-		return true;
+                if (prefix.empty()) {
+                    return true;
+                } else {
+                    if (li->m_name.substr(0,prefix.size()+1) == prefix+".") {
+                        return true;
+                    }
+                }
 	    }
 	    else
 	    {
-		return unused_table_entries_q(*li->m_table);
+		if (unused_table_entries_q(*li->m_table, prefix)) return true;
 	    }
 	}
 	else if ( !li->m_queried )
 	{
-	    return true;
+            if (prefix.empty()) {
+                return true;
+            } else {
+                if (li->m_name.substr(0,prefix.size()+1) == prefix+".") {
+                    return true;
+                }
+            }
 	}
     }
     return false;
@@ -1092,6 +1102,43 @@ ParmParse::QueryUnusedInputs ()
       return true;
     }
     return false;
+}
+
+bool
+ParmParse::hasUnusedInputs (const std::string& prefix)
+{
+    return unused_table_entries_q(g_table, prefix);
+}
+
+static
+void
+get_unused_inputs(std::vector<std::string>& unused, const ParmParse::Table& table,
+                  const std::string& prefix)
+{
+    const std::string prefixdot = prefix.empty() ? std::string() : prefix+".";
+    for (auto const& entry : table) {
+        if (! entry.m_queried) {
+            if (entry.m_name.substr(0,prefixdot.size()) == prefixdot) {
+                std::string tmp(entry.m_name + " =");
+                for (auto const& v : entry.m_vals) {
+                    tmp += " " + v;
+                }
+                unused.emplace_back(std::move(tmp));
+            }
+        }
+
+        if (entry.m_table) {
+            get_unused_inputs(unused, table, prefix);
+        }
+    }
+}
+
+std::vector<std::string>
+ParmParse::getUnusedInputs (const std::string& prefix)
+{
+    std::vector<std::string> r;
+    get_unused_inputs(r, g_table, prefix);
+    return r;
 }
     
 void


### PR DESCRIPTION
## Summary

Add functions to find if there are unused `ParmParse` parameters starting
with `prefix.`.  If `prefix` is empty, all unused `ParmParse` parameters are
included.

For example,
```
if (amrex::ParmParse::hasUnusedInputs("algorithm") {
    amrex::Abort("There are unused algorithm.* runtime parameters");
}

auto const& used = amrex::ParmParse::getUnusedInputs("warpx");
for (auto const& u : used) {
    amrex::Print() << "Parameter " << u << " is unused.\n";
}
```

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
