### PR TITLE
fixing assert

### DIFF
--- a/Src/Extern/Conduit/AMReX_Conduit_Blueprint.cpp
+++ b/Src/Extern/Conduit/AMReX_Conduit_Blueprint.cpp
@@ -287,7 +287,7 @@ void FabToBlueprintFields (const FArrayBox& fab,
                            Node &res)
 {
     // make sure we are not asking for more components than exist.
-    BL_ASSERT(varnames.size() <= fab->nComp());
+    BL_ASSERT(varnames.size() <= fab.nComp());
 
     Node &n_fields = res["fields"];
     for(int i=0; i < varnames.size(); i++)


### PR DESCRIPTION
## Summary
Fixes a assert that used a pointer instead of a dot.
## Additional background

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
