### PR TITLE
RoundRobin: option to not sort processes

### DIFF
--- a/Src/Base/AMReX_DistributionMapping.H
+++ b/Src/Base/AMReX_DistributionMapping.H
@@ -141,8 +141,8 @@ class DistributionMapping
                               bool do_full_knapsack=true,
                               int nmax=std::numeric_limits<int>::max(),
                               bool sort=true);
-    void RoundRobinProcessorMap(int nboxes, int nprocs);
-    void RoundRobinProcessorMap(const std::vector<Long>& wgts, int nprocs);
+    void RoundRobinProcessorMap(int nboxes, int nprocs, bool sort=true);
+    void RoundRobinProcessorMap(const std::vector<Long>& wgts, int nprocs, bool sort=true);
 
     /**
     * \brief Initializes distribution strategy from ParmParse.
@@ -287,7 +287,8 @@ private:
 
     void RoundRobinDoIt (int                  nboxes,
                          int                  nprocs,
-                         std::vector<LIpair>* LIpairV = 0);
+                         std::vector<LIpair>* LIpairV = 0,
+                         bool                 sort = true);
 
     void KnapSackDoIt (const std::vector<Long>& wgts,
                        int                      nprocs,


### PR DESCRIPTION
## Summary

Add an optional parameter `sort` to RoundRobin constructors.  This makes it
consistent with other DistributionMapping strategies.  And this fixes an
incorrect behavior when RoundRobin is used by KnapSack that has been given
`sort=false`.  This should be able to fix the hanging issue observed in
WarpX simulations with load balancing enabled and more MPI processes than
the number of boxes.

## Additional background

https://github.com/ECP-WarpX/WarpX/issues/1614

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
