### PR TITLE
Tests: replace D_DECL with AMREX_D_DECL

### DIFF
--- a/Tests/HDF5Benchmark/main.cpp
+++ b/Tests/HDF5Benchmark/main.cpp
@@ -264,8 +264,8 @@ void set_grids_nested (Vector<Box>& domains,
     // Now we make the refined level be the center eighth of the domain
     if (nlevs > 1) {
         int n_fine = ncells*ref_ratio[0][0];
-        IntVect refined_lo(D_DECL(n_fine/4,n_fine/4,n_fine/4));
-        IntVect refined_hi(D_DECL(3*n_fine/4-1,3*n_fine/4-1,3*n_fine/4-1));
+        IntVect refined_lo(AMREX_D_DECL(n_fine/4,n_fine/4,n_fine/4));
+        IntVect refined_hi(AMREX_D_DECL(3*n_fine/4-1,3*n_fine/4-1,3*n_fine/4-1));
 
         // Build a box for the level 1 domain
         Box refined_patch(refined_lo, refined_hi);

--- a/Tests/Particles/AssignMultiLevelDensity/main.cpp
+++ b/Tests/Particles/AssignMultiLevelDensity/main.cpp
@@ -36,8 +36,8 @@ void test_assign_density(TestParams& parms)
        fine_box.setHi(n,0.75);
     }
     
-    IntVect domain_lo(D_DECL(0 , 0, 0)); 
-    IntVect domain_hi(D_DECL(parms.nx - 1, parms.ny - 1, parms.nz-1)); 
+    IntVect domain_lo(AMREX_D_DECL(0 , 0, 0)); 
+    IntVect domain_hi(AMREX_D_DECL(parms.nx - 1, parms.ny - 1, parms.nz-1)); 
     const Box domain(domain_lo, domain_hi);
 
     // Define the refinement ratio
@@ -63,8 +63,8 @@ void test_assign_density(TestParams& parms)
     
     if (nlevs > 1) {
         int n_fine = parms.nx*rr[0];
-        IntVect refined_lo(D_DECL(n_fine/4,n_fine/4,n_fine/4)); 
-        IntVect refined_hi(D_DECL(3*n_fine/4-1,3*n_fine/4-1,3*n_fine/4-1));
+        IntVect refined_lo(AMREX_D_DECL(n_fine/4,n_fine/4,n_fine/4)); 
+        IntVect refined_hi(AMREX_D_DECL(3*n_fine/4-1,3*n_fine/4-1,3*n_fine/4-1));
 
         // Build a box for the level 1 domain
         Box refined_patch(refined_lo, refined_hi);
@@ -127,7 +127,7 @@ void test_assign_density(TestParams& parms)
     Vector<IntVect> outputRR(output_levs);
     for (int lev = 0; lev < output_levs; ++lev) {
         outputMF[lev] = density[lev].get();
-        outputRR[lev] = IntVect(D_DECL(2, 2, 2));
+        outputRR[lev] = IntVect(AMREX_D_DECL(2, 2, 2));
     }
     
     WriteMultiLevelPlotfile("plt00000", output_levs, outputMF, 

--- a/Tests/Particles/AsyncIO/main.cpp
+++ b/Tests/Particles/AsyncIO/main.cpp
@@ -182,8 +182,8 @@ void test_async_io(TestParams& parms)
        fine_box.setHi(n,0.75);
     }
 
-    IntVect domain_lo(D_DECL(0 , 0, 0));
-    IntVect domain_hi(D_DECL(parms.nx - 1, parms.ny - 1, parms.nz-1));
+    IntVect domain_lo(AMREX_D_DECL(0 , 0, 0));
+    IntVect domain_hi(AMREX_D_DECL(parms.nx - 1, parms.ny - 1, parms.nz-1));
     const Box domain(domain_lo, domain_hi);
 
     // Define the refinement ratio
@@ -209,8 +209,8 @@ void test_async_io(TestParams& parms)
 
     if (nlevs > 1) {
         int n_fine = parms.nx*rr[0][0];
-        IntVect refined_lo(D_DECL(n_fine/4,n_fine/4,n_fine/4));
-        IntVect refined_hi(D_DECL(3*n_fine/4-1,3*n_fine/4-1,3*n_fine/4-1));
+        IntVect refined_lo(AMREX_D_DECL(n_fine/4,n_fine/4,n_fine/4));
+        IntVect refined_hi(AMREX_D_DECL(3*n_fine/4-1,3*n_fine/4-1,3*n_fine/4-1));
 
         // Build a box for the level 1 domain
         Box refined_patch(refined_lo, refined_hi);
@@ -265,7 +265,7 @@ void test_async_io(TestParams& parms)
             Vector<IntVect> outputRR(output_levs);
             for (int lev = 0; lev < output_levs; ++lev) {
                 outputMF[lev] = density[lev].get();
-                outputRR[lev] = IntVect(D_DECL(2, 2, 2));
+                outputRR[lev] = IntVect(AMREX_D_DECL(2, 2, 2));
             }
 
             std::string fn = amrex::Concatenate("plt", step, 5);

--- a/Tests/Particles/GhostsAndVirtuals/main.cpp
+++ b/Tests/Particles/GhostsAndVirtuals/main.cpp
@@ -35,8 +35,8 @@ void test_ghosts_and_virtuals (TestParams& parms)
        fine_box.setHi(n,0.75);
     }
 
-    IntVect domain_lo(D_DECL(0 , 0, 0));
-    IntVect domain_hi(D_DECL(parms.nx - 1, parms.ny - 1, parms.nz-1));
+    IntVect domain_lo(AMREX_D_DECL(0 , 0, 0));
+    IntVect domain_hi(AMREX_D_DECL(parms.nx - 1, parms.ny - 1, parms.nz-1));
     const Box domain(domain_lo, domain_hi);
 
     // Define the refinement ratio
@@ -62,8 +62,8 @@ void test_ghosts_and_virtuals (TestParams& parms)
 
     if (nlevs > 1) {
         int n_fine = parms.nx*rr[0];
-        IntVect refined_lo(D_DECL(n_fine/4,n_fine/4,n_fine/4));
-        IntVect refined_hi(D_DECL(3*n_fine/4-1,3*n_fine/4-1,3*n_fine/4-1));
+        IntVect refined_lo(AMREX_D_DECL(n_fine/4,n_fine/4,n_fine/4));
+        IntVect refined_hi(AMREX_D_DECL(3*n_fine/4-1,3*n_fine/4-1,3*n_fine/4-1));
 
         // Build a box for the level 1 domain
         Box refined_patch(refined_lo, refined_hi);

--- a/Tests/Particles/Intersection/main.cpp
+++ b/Tests/Particles/Intersection/main.cpp
@@ -33,7 +33,7 @@ void testIntersection()
     
     Vector<IntVect> rr(params.nlevs-1);
     for (int lev = 1; lev < params.nlevs; lev++)
-        rr[lev-1] = IntVect(D_DECL(2,2,2));
+        rr[lev-1] = IntVect(AMREX_D_DECL(2,2,2));
     
     RealBox real_box;
     for (int n = 0; n < AMREX_SPACEDIM; n++)
@@ -42,8 +42,8 @@ void testIntersection()
         real_box.setHi(n, 1.0);
     }
 
-    IntVect domain_lo(D_DECL(0 , 0, 0));
-    IntVect domain_hi(D_DECL(params.size[0]-1, params.size[1]-1, params.size[2]-1));
+    IntVect domain_lo(AMREX_D_DECL(0 , 0, 0));
+    IntVect domain_hi(AMREX_D_DECL(params.size[0]-1, params.size[1]-1, params.size[2]-1));
     const Box base_domain(domain_lo, domain_hi);
     
     Vector<Geometry> geom(params.nlevs);
@@ -54,7 +54,7 @@ void testIntersection()
     }
     
     Vector<BoxArray> ba(params.nlevs);
-    IntVect lo = IntVect(D_DECL(0, 0, 0));
+    IntVect lo = IntVect(AMREX_D_DECL(0, 0, 0));
     IntVect size = params.size;
     for (int lev = 0; lev < params.nlevs; ++lev)
     {

--- a/Tests/Particles/Redistribute/main.cpp
+++ b/Tests/Particles/Redistribute/main.cpp
@@ -340,7 +340,7 @@ void testRedistribute ()
 
     Vector<IntVect> rr(params.nlevs-1);
     for (int lev = 1; lev < params.nlevs; lev++)
-        rr[lev-1] = IntVect(D_DECL(2,2,2));
+        rr[lev-1] = IntVect(AMREX_D_DECL(2,2,2));
 
     RealBox real_box;
     for (int n = 0; n < BL_SPACEDIM; n++)
@@ -362,7 +362,7 @@ void testRedistribute ()
 
     Vector<BoxArray> ba(params.nlevs);
     Vector<DistributionMapping> dm(params.nlevs);
-    IntVect lo = IntVect(D_DECL(0, 0, 0));
+    IntVect lo = IntVect(AMREX_D_DECL(0, 0, 0));
     IntVect size = params.size;
     for (int lev = 0; lev < params.nlevs; ++lev)
     {

--- a/Tests/Particles/SparseBins/main.cpp
+++ b/Tests/Particles/SparseBins/main.cpp
@@ -33,7 +33,7 @@ void testIntersection()
     
     Vector<IntVect> rr(params.nlevs-1);
     for (int lev = 1; lev < params.nlevs; lev++)
-        rr[lev-1] = IntVect(D_DECL(2,2,2));
+        rr[lev-1] = IntVect(AMREX_D_DECL(2,2,2));
     
     RealBox real_box;
     for (int n = 0; n < AMREX_SPACEDIM; n++)
@@ -42,8 +42,8 @@ void testIntersection()
         real_box.setHi(n, 1.0);
     }
 
-    IntVect domain_lo(D_DECL(0 , 0, 0));
-    IntVect domain_hi(D_DECL(params.size[0]-1, params.size[1]-1, params.size[2]-1));
+    IntVect domain_lo(AMREX_D_DECL(0 , 0, 0));
+    IntVect domain_hi(AMREX_D_DECL(params.size[0]-1, params.size[1]-1, params.size[2]-1));
     const Box base_domain(domain_lo, domain_hi);
     
     Vector<Geometry> geom(params.nlevs);
@@ -54,7 +54,7 @@ void testIntersection()
     }
     
     Vector<BoxArray> ba(params.nlevs);
-    IntVect lo = IntVect(D_DECL(0, 0, 0));
+    IntVect lo = IntVect(AMREX_D_DECL(0, 0, 0));
     IntVect size = params.size;
     for (int lev = 0; lev < params.nlevs; ++lev)
     {


### PR DESCRIPTION
## Summary
Not all the executables in the `Tests` directory build when in xSDK mode. This PR fixes that.

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
