### PR TITLE
When using CMake 3.15 allow for MSVC runtime library changes

### DIFF
--- a/Tools/CMake/AMReX_Config.cmake
+++ b/Tools/CMake/AMReX_Config.cmake
@@ -56,6 +56,14 @@ function (configure_amrex)
    endif()
 
    #
+   # Allow for MSVC Runtime library controls
+   #
+   if(POLICY CMP0091)
+      cmake_policy(SET CMP0091 NEW)
+   endif()
+
+
+   #
    # Special flags for MSVC compiler
    #
    set(_cxx_msvc   "$<AND:$<COMPILE_LANGUAGE:CXX>,$<CXX_COMPILER_ID:MSVC>>")


### PR DESCRIPTION
## Summary
Allows for users to specify the MSVC runtime library ( static | dll , threaded ) via the CMAKE_MSVC_RUNTIME_LIBRARY variable.

## Additional background

CMake 3.15 added policy `CMP0091` which allows for `CMAKE_MSVC_RUNTIME_LIBRARY` to control the MSVC runtime library

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
