### PR TITLE
Fix CNS tutorial for HIP

### DIFF
--- a/Tutorials/GPU/CNS/Source/CNS.cpp
+++ b/Tutorials/GPU/CNS/Source/CNS.cpp
@@ -398,7 +398,7 @@ CNS::estTimeStep ()
     Parm const* lparm = parm.get();
 
     Real estdt = amrex::ReduceMin(S, 0,
-    [=] AMREX_GPU_DEVICE (Box const& bx, Array4<Real const> const& fab) noexcept -> Real
+    [=] AMREX_GPU_HOST_DEVICE (Box const& bx, Array4<Real const> const& fab) -> Real
     {
         return cns_estdt(bx, fab, dx, *lparm);
     });


### PR DESCRIPTION
## Summary

Use AMREX_GPU_HOST_DEVICE instead of AMREX_GPU_DEVICE because of we cannot
detect the lambda type in HIP.

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
