### PR TITLE
Update Make.nrel to accomodate MPT MPI with CUDA enabled

### DIFF
--- a/Tools/GNUMake/Make.defs
+++ b/Tools/GNUMake/Make.defs
@@ -672,7 +672,7 @@ else ifeq ($(USE_CUDA),TRUE)
     ifeq ($(USE_MPI),TRUE)
       # Make sure that the C/C++ MPI
       # wrappers are calling nvcc to compile the code.
-      # Right now we handle OpenMPI/Spectrum MPI and MPICH.
+      # Right now we handle OpenMPI/Spectrum MPI, MPICH, and HPE MPT.
       # Other MPI implementations could be added later.
 
       export OMPI_CC := nvcc
@@ -684,6 +684,10 @@ else ifeq ($(USE_CUDA),TRUE)
       export MPICH_CXX := nvcc
       export MPICH_F77 := $(FC)
       export MPICH_FC  := $(F90)
+
+      export MPICXX_CXX := nvcc
+      export MPICC_CC   := nvcc
+      export MPIF90_F90 := $(F90)
     endif
 
     DEFINES += -DAMREX_USE_CUDA

--- a/Tools/GNUMake/sites/Make.nrel
+++ b/Tools/GNUMake/sites/Make.nrel
@@ -40,7 +40,7 @@ else ifeq ($(which_computer), rhodes)
   endif
 endif
 
-# Account for Intel-MPI, MPICH, OpenMPI, and MPT
+# Account for Intel-MPI, MPICH, OpenMPI, and HPE MPT
 ifeq ($(USE_MPI),TRUE)
   ifeq ($(COMP), intel)
     CXX := mpiicpc
@@ -58,6 +58,14 @@ ifeq ($(USE_MPI),TRUE)
     else ifneq ($(findstring Open MPI, $(shell $(F90) -showme:version 2>&1)),)
       mpif90_link_flags := $(shell $(F90) -showme:link)
       LIBRARIES += $(mpif90_link_flags)
+    else
+      # MPT case (no option available to query link flags)
+      LIBRARIES += -lmpi
+      ifeq ($(USE_CUDA),TRUE)
+        export MPICXX_CXX := nvcc
+        export MPICC_CC   := nvcc
+        export MPIF90_F90 := $(F90)
+      endif
     endif
   endif
 endif

--- a/Tools/GNUMake/sites/Make.nrel
+++ b/Tools/GNUMake/sites/Make.nrel
@@ -61,11 +61,6 @@ ifeq ($(USE_MPI),TRUE)
     else
       # MPT case (no option available to query link flags)
       LIBRARIES += -lmpi
-      ifeq ($(USE_CUDA),TRUE)
-        export MPICXX_CXX := nvcc
-        export MPICC_CC   := nvcc
-        export MPIF90_F90 := $(F90)
-      endif
     endif
   endif
 endif


### PR DESCRIPTION
## Summary

For our main computer at NREL, Eagle, we mostly use HPE's MPT for MPI. Until these changes, CUDA did not work with MPT when using the GNU makefiles.

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
