### PR TITLE
Don't include Hypre files in GNU make for 1D

### DIFF
--- a/Src/Extern/HYPRE/Make.package
+++ b/Src/Extern/HYPRE/Make.package
@@ -1,4 +1,6 @@
 
+ifneq ($(DIM), 1)
+
 CEXE_sources += AMReX_HypreABecLap.cpp AMReX_HypreABecLap2.cpp AMReX_HypreABecLap3.cpp AMReX_Hypre.cpp
 
 CEXE_headers += AMReX_HypreABecLap.H AMReX_HypreABecLap2.H AMReX_HypreABecLap3.H AMReX_Hypre.H
@@ -10,3 +12,5 @@ CEXE_sources += AMReX_HypreNodeLap.cpp AMReX_HypreIJIface.cpp
 
 VPATH_LOCATIONS += $(AMREX_HOME)/Src/Extern/HYPRE
 INCLUDE_LOCATIONS += $(AMREX_HOME)/Src/Extern/HYPRE
+
+endif


### PR DESCRIPTION
## Summary

These files cannot be compiled in 1D, so there is no point in adding them.

## Additional background

CMake treats this as fatal, but for Castro we would like to use the AMReX Hypre GNU make package even without the actual interfaces.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
