### PR TITLE
Only add Hypre interfaces to MLMG in 2D/3D

### DIFF
--- a/Src/LinearSolvers/MLMG/AMReX_MLCellABecLap.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLCellABecLap.H
@@ -63,7 +63,7 @@ public:
 
     virtual void applyOverset (int amlev, MultiFab& rhs) const override;
 
-#ifdef AMREX_USE_HYPRE
+#if defined(AMREX_USE_HYPRE) && (AMREX_SPACEDIM > 1)
     virtual std::unique_ptr<Hypre> makeHypre (Hypre::Interface hypre_interface) const override;
 #endif
 

--- a/Src/LinearSolvers/MLMG/AMReX_MLCellABecLap.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLCellABecLap.cpp
@@ -342,7 +342,7 @@ MLCellABecLap::applyOverset (int amrlev, MultiFab& rhs) const
     }
 }
 
-#ifdef AMREX_USE_HYPRE
+#if defined(AMREX_USE_HYPRE) && (AMREX_SPACEDIM > 1)
 std::unique_ptr<Hypre>
 MLCellABecLap::makeHypre (Hypre::Interface hypre_interface) const
 {

--- a/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap.H
@@ -113,7 +113,7 @@ public:
     virtual void getEBFluxes (const Vector<MultiFab*>& a_flux,
                               const Vector<MultiFab*>& a_sol) const override;
 
-#ifdef AMREX_USE_HYPRE
+#if defined(AMREX_USE_HYPRE) && (AMREX_SPACEDIM > 1)
     virtual std::unique_ptr<Hypre> makeHypre (Hypre::Interface hypre_interface) const override;
 #endif
 

--- a/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap.cpp
@@ -9,7 +9,7 @@
 #include <AMReX_MLEBABecLap_K.H>
 #include <AMReX_MLLinOp_K.H>
 
-#ifdef AMREX_USE_HYPRE
+#if defined(AMREX_USE_HYPRE) && (AMREX_SPACEDIM > 1)
 #include <AMReX_HypreABecLap3.H>
 #endif
 
@@ -1607,7 +1607,7 @@ MLEBABecLap::getEBFluxes (const Vector<MultiFab*>& a_flux, const Vector<MultiFab
     }
 }
 
-#ifdef AMREX_USE_HYPRE
+#if defined(AMREX_USE_HYPRE) && (AMREX_SPACEDIM > 1)
 std::unique_ptr<Hypre>
 MLEBABecLap::makeHypre (Hypre::Interface hypre_interface) const
 {

--- a/Src/LinearSolvers/MLMG/AMReX_MLLinOp.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLLinOp.H
@@ -14,7 +14,7 @@
 #include <AMReX_MultiCutFab.H>
 #endif
 
-#ifdef AMREX_USE_HYPRE
+#if defined(AMREX_USE_HYPRE) && (AMREX_SPACEDIM > 1)
 #include <AMReX_Hypre.H>
 #include <AMReX_HypreNodeLap.H>
 #endif
@@ -246,7 +246,7 @@ public:
     }
 #endif
 
-#ifdef AMREX_USE_HYPRE
+#if defined(AMREX_USE_HYPRE) && (AMREX_SPACEDIM > 1)
     virtual std::unique_ptr<Hypre> makeHypre (Hypre::Interface /*hypre_interface*/) const {
         amrex::Abort("MLLinOp::makeHypre: How did we get here?");
         return {nullptr};

--- a/Src/LinearSolvers/MLMG/AMReX_MLMG.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLMG.H
@@ -6,7 +6,7 @@
 #include <AMReX_iMultiFab.H>
 #include <AMReX_MLCGSolver.H>
 
-#ifdef AMREX_USE_HYPRE
+#if defined(AMREX_USE_HYPRE) && (AMREX_SPACEDIM > 1)
 #include <AMReX_Hypre.H>
 #include <AMReX_HypreNodeLap.H>
 #endif
@@ -98,7 +98,7 @@ public:
     void setNSolve (int flag) noexcept { do_nsolve = flag; }
     void setNSolveGridSize (int s) noexcept { nsolve_grid_size = s; }
 
-#ifdef AMREX_USE_HYPRE
+#if defined(AMREX_USE_HYPRE) && (AMREX_SPACEDIM > 1)
     void setHypreInterface (Hypre::Interface f) noexcept {
         // must use ij interface for EB
 #ifndef AMREX_USE_EB
@@ -158,7 +158,9 @@ public:
     void makeSolvable (int amrlev, int mglev, MultiFab& mf);
     Real getNodalSum (int amrlev, int mglev, MultiFab& mf) const;
 
+#if defined(AMREX_USE_HYPRE) && (AMREX_SPACEDIM > 1)
     void bottomSolveWithHypre (MultiFab& x, const MultiFab& b);
+#endif
 
     void bottomSolveWithPETSc (MultiFab& x, const MultiFab& b);
 
@@ -214,7 +216,7 @@ private:
     std::unique_ptr<MultiFab> ns_rhs;
 
     //! Hypre
-#ifdef AMREX_USE_HYPRE
+#if defined(AMREX_USE_HYPRE) && (AMREX_SPACEDIM > 1)
     // Hypre::Interface hypre_interface = Hypre::Interface::structed;
     // Hypre::Interface hypre_interface = Hypre::Interface::semi_structed;
     Hypre::Interface hypre_interface = Hypre::Interface::ij;

--- a/Src/LinearSolvers/MLMG/AMReX_MLMG.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLMG.cpp
@@ -941,7 +941,9 @@ MLMG::actualBottomSolve ()
 
         if (bottom_solver == BottomSolver::hypre)
         {
+#if defined(AMREX_USE_HYPRE) && (AMREX_SPACEDIM > 1)
             bottomSolveWithHypre(x, *bottom_b);
+#endif
         }
         else if (bottom_solver == BottomSolver::petsc)
         {
@@ -1143,7 +1145,7 @@ MLMG::prepareForSolve (const Vector<MultiFab*>& a_sol, const Vector<MultiFab con
     } else if (linop.needsUpdate()) {
         linop.update();
 
-#ifdef AMREX_USE_HYPRE
+#if defined(AMREX_USE_HYPRE) && (AMREX_SPACEDIM > 1)
         hypre_solver.reset();
         hypre_bndry.reset();
         hypre_node_solver.reset();
@@ -1823,14 +1825,10 @@ MLMG::getNodalSum (int amrlev, int mglev, MultiFab& mf) const
     return s1/s2;
 }
 
+#if defined(AMREX_USE_HYPRE) && (AMREX_SPACEDIM > 1)
 void
 MLMG::bottomSolveWithHypre (MultiFab& x, const MultiFab& b)
 {
-#if !defined(AMREX_USE_HYPRE)
-    amrex::ignore_unused(x,b);
-    amrex::Abort("bottomSolveWithHypre is called without building with Hypre");
-#else
-
     const int amrlev = 0;
     const int mglev  = linop.NMGLevels(amrlev) - 1;
 
@@ -1892,8 +1890,8 @@ MLMG::bottomSolveWithHypre (MultiFab& x, const MultiFab& b)
     {
         makeSolvable(amrlev, mglev, x);
     }
-#endif
 }
+#endif
 
 void
 MLMG::bottomSolveWithPETSc (MultiFab& x, const MultiFab& b)

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian.H
@@ -132,7 +132,7 @@ public :
     void buildIntegral ();
 #endif
 
-#ifdef AMREX_USE_HYPRE
+#if defined(AMREX_USE_HYPRE) && (AMREX_SPACEDIM > 1)
     virtual void fillIJMatrix (MFIter const& mfi, Array4<HypreNodeLap::Int const> const& nid,
                                Array4<int const> const& owner,
                                Vector<HypreNodeLap::Int>& ncols, Vector<HypreNodeLap::Int>& rows,

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian.cpp
@@ -2882,7 +2882,7 @@ MLNodeLaplacian::checkPoint (std::string const& file_name) const
     }
 }
 
-#ifdef AMREX_USE_HYPRE
+#if defined(AMREX_USE_HYPRE) && (AMREX_SPACEDIM > 1)
 
 #if (AMREX_SPACEDIM == 2)
 void

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLinOp.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLinOp.H
@@ -5,7 +5,7 @@
 #include <AMReX_MLLinOp.H>
 #include <AMReX_iMultiFab.H>
 
-#ifdef AMREX_USE_HYPRE
+#if defined(AMREX_USE_HYPRE) && (AMREX_SPACEDIM > 1)
 #include <AMReX_HypreNodeLap.H>
 #endif
 
@@ -96,7 +96,7 @@ public:
     // omask is either 0 or 1. 1 means the node is an unknown. 0 means it's known.
     void setOversetMask (int amrlev, const iMultiFab& a_omask);
 
-#ifdef AMREX_USE_HYPRE
+#if defined(AMREX_USE_HYPRE) && (AMREX_SPACEDIM > 1)
     virtual std::unique_ptr<HypreNodeLap> makeHypreNodeLap(
         int bottom_verbose,
         const std::string& options_namespace) const override;

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLinOp.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLinOp.cpp
@@ -23,7 +23,7 @@ MLNodeLinOp::define (const Vector<Geometry>& a_geom,
                      const LPInfo& a_info,
                      const Vector<FabFactory<FArrayBox> const*>& a_factory)
 {
-#ifdef AMREX_USE_HYPRE
+#if defined(AMREX_USE_HYPRE) && (AMREX_SPACEDIM > 1)
     bool eb_limit_coarsening = true;
 #else
     bool eb_limit_coarsening = false;
@@ -377,7 +377,7 @@ MLNodeLinOp::applyBC (int amrlev, int mglev, MultiFab& phi, BCMode/* bc_mode*/, 
     }
 }
 
-#ifdef AMREX_USE_HYPRE
+#if defined(AMREX_USE_HYPRE) && (AMREX_SPACEDIM > 1)
 std::unique_ptr<HypreNodeLap>
 MLNodeLinOp::makeHypreNodeLap (int bottom_verbose, const std::string& options_namespace) const
 {

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeTensorLap_2D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeTensorLap_2D_K.H
@@ -120,7 +120,7 @@ void mlndtslap_normalize (Box const& b, Array4<Real> const& phi,
     });
 }
 
-#ifdef AMREX_USE_HYPRE
+#if defined(AMREX_USE_HYPRE) && (AMREX_SPACEDIM > 1)
 
 AMREX_FORCE_INLINE
 void mlndtslap_fill_ijmatrix (Box const& ndbx, Array4<HypreNodeLap::Int const> const& nid,

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeTensorLap_3D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeTensorLap_3D_K.H
@@ -214,7 +214,7 @@ void mlndtslap_normalize (Box const& b, Array4<Real> const& phi,
     });
 }
 
-#ifdef AMREX_USE_HYPRE
+#if defined(AMREX_USE_HYPRE) && (AMREX_SPACEDIM > 1)
 
 AMREX_FORCE_INLINE
 void mlndtslap_fill_ijmatrix (Box const& ndbx, Array4<HypreNodeLap::Int const> const& nid,

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeTensorLaplacian.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeTensorLaplacian.H
@@ -63,7 +63,7 @@ public:
 
     virtual void fixUpResidualMask (int amrlev, iMultiFab& resmsk) final override;
 
-#ifdef AMREX_USE_HYPRE
+#if defined(AMREX_USE_HYPRE) && (AMREX_SPACEDIM > 1)
     virtual void fillIJMatrix (MFIter const& mfi, Array4<HypreNodeLap::Int const> const& nid,
                                Array4<int const> const& owner,
                                Vector<HypreNodeLap::Int>& ncols, Vector<HypreNodeLap::Int>& rows,

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeTensorLaplacian.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeTensorLaplacian.cpp
@@ -248,7 +248,7 @@ MLNodeTensorLaplacian::fixUpResidualMask (int /*amrlev*/, iMultiFab& /*resmsk*/)
     amrex::Abort("MLNodeTensorLaplacian::fixUpResidualMask: TODO");
 }
 
-#ifdef AMREX_USE_HYPRE
+#if defined(AMREX_USE_HYPRE) && (AMREX_SPACEDIM > 1)
 void
 MLNodeTensorLaplacian::fillIJMatrix (MFIter const& mfi, Array4<HypreNodeLap::Int const> const& nid,
                                      Array4<int const> const& owner,


### PR DESCRIPTION
## Summary

This is necessary for compiling with both Hypre and MLMG in 1D.

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
