### PR TITLE
When using CMake 3.15+ allow for MSVC runtime library changes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,13 @@
 cmake_minimum_required(VERSION 3.14)
 
 #
+# Allow for MSVC Runtime library controls
+#
+if(POLICY CMP0091)
+  cmake_policy(SET CMP0091 NEW)
+endif()
+
+#
 # Prevent in-source builds
 #
 if (CMAKE_BINARY_DIR STREQUAL CMAKE_SOURCE_DIR)

--- a/Tools/CMake/AMReX_Config.cmake
+++ b/Tools/CMake/AMReX_Config.cmake
@@ -56,14 +56,6 @@ function (configure_amrex)
    endif()
 
    #
-   # Allow for MSVC Runtime library controls
-   #
-   if(POLICY CMP0091)
-      cmake_policy(SET CMP0091 NEW)
-   endif()
-
-
-   #
    # Special flags for MSVC compiler
    #
    set(_cxx_msvc   "$<AND:$<COMPILE_LANGUAGE:CXX>,$<CXX_COMPILER_ID:MSVC>>")


### PR DESCRIPTION
Enabling of CMP0091 needs to go before the first `project` call as that computes if MSVC_RUNTIME_LIBRARY information is used

## Summary
Fixes a bug in https://github.com/AMReX-Codes/amrex/pull/1724 where we didn't set CMP0091 early enough

## Additional background

## Checklist

The proposed changes:
- [X] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
