### PR TITLE
HIP indirect function and kernel fusing

### DIFF
--- a/Src/Base/AMReX_GpuFuse.H
+++ b/Src/Base/AMReX_GpuFuse.H
@@ -16,7 +16,7 @@ namespace Gpu {
 
 #ifdef AMREX_USE_GPU
 
-#ifdef AMREX_USE_CUDA
+#if defined(AMREX_USE_CUDA) || (defined(AMREX_USE_HIP) && defined(AMREX_HIP_INDIRECT_FUNCTION))
 
 typedef void (*Lambda1DLauncher)(char*,int);
 typedef void (*Lambda3DLauncher)(char*,int,int,int);

--- a/Src/Base/AMReX_GpuFuse.cpp
+++ b/Src/Base/AMReX_GpuFuse.cpp
@@ -19,7 +19,7 @@ namespace {
 
 std::unique_ptr<Fuser> Fuser::m_instance = nullptr;
 
-#ifdef AMREX_USE_CUDA
+#if defined(AMREX_USE_CUDA) || (defined(AMREX_USE_HIP) && defined(AMREX_HIP_INDIRECT_FUNCTION))
 
 Fuser::Fuser ()
 {

--- a/Src/Base/AMReX_GpuLaunch.H
+++ b/Src/Base/AMReX_GpuLaunch.H
@@ -190,7 +190,7 @@ namespace Gpu {
                                                         AMREX_WRONG_NUM_ARGS, \
                                                         AMREX_WRONG_NUM_ARGS)(__VA_ARGS__)
 
-#ifdef AMREX_USE_CUDA
+#if defined(AMREX_USE_CUDA) || (defined(AMREX_USE_HIP) && defined(AMREX_HIP_INDIRECT_FUNCTION))
 #define AMREX_LAUNCH_HOST_DEVICE_FUSIBLE_LAMBDA(...) AMREX_GET_MACRO(__VA_ARGS__,\
                                                         AMREX_GPU_LAUNCH_HOST_DEVICE_FUSIBLE_LAMBDA_RANGE_3, \
                                                         AMREX_WRONG_NUM_ARGS, \
@@ -235,7 +235,7 @@ namespace Gpu {
 #define AMREX_HOST_DEVICE_PARALLEL_FOR_3D(...) AMREX_GPU_HOST_DEVICE_PARALLEL_FOR_3D(__VA_ARGS__)
 #define AMREX_HOST_DEVICE_PARALLEL_FOR_4D(...) AMREX_GPU_HOST_DEVICE_PARALLEL_FOR_4D(__VA_ARGS__)
 
-#ifdef AMREX_USE_CUDA
+#if defined(AMREX_USE_CUDA) || (defined(AMREX_USE_HIP) && defined(AMREX_HIP_INDIRECT_FUNCTION))
 #define AMREX_HOST_DEVICE_PARALLEL_FOR_1D_FUSIBLE(...) AMREX_GPU_HOST_DEVICE_FOR_1D_FUSIBLE(__VA_ARGS__)
 #define AMREX_HOST_DEVICE_PARALLEL_FOR_3D_FUSIBLE(...) AMREX_GPU_HOST_DEVICE_FOR_3D_FUSIBLE(__VA_ARGS__)
 #define AMREX_HOST_DEVICE_PARALLEL_FOR_4D_FUSIBLE(...) AMREX_GPU_HOST_DEVICE_FOR_4D_FUSIBLE(__VA_ARGS__)

--- a/Src/Base/AMReX_GpuLaunchFunctsG.H
+++ b/Src/Base/AMReX_GpuLaunchFunctsG.H
@@ -912,7 +912,7 @@ amrex::EnableIf_t<MaybeDeviceRunnable<L>::value>
 ParallelFor (Gpu::KernelInfo const& info, T n, L&& f) noexcept
 {
     if (amrex::isEmpty(n)) return;
-#ifdef AMREX_USE_CUDA
+#if defined(AMREX_USE_CUDA) || (defined(AMREX_USE_HIP) && defined(AMREX_HIP_INDIRECT_FUNCTION))
     if (!info.hasReduction() && Gpu::inFuseRegion() && info.isFusible() && n <= Gpu::getFuseSizeThreshold()) {
         Gpu::Register(n, f);
     } else
@@ -938,7 +938,7 @@ ParallelFor (Gpu::KernelInfo const& info, Box const& box, L&& f) noexcept
 {
     if (amrex::isEmpty(box)) return;
     int ncells = box.numPts();
-#ifdef AMREX_USE_CUDA
+#if defined(AMREX_USE_CUDA) || (defined(AMREX_USE_HIP) && defined(AMREX_HIP_INDIRECT_FUNCTION))
     if (!info.hasReduction() && Gpu::inFuseRegion() && info.isFusible() && ncells <= Gpu::getFuseSizeThreshold()) {
         Gpu::Register(box, f);
     } else
@@ -973,7 +973,7 @@ ParallelFor (Gpu::KernelInfo const& info, Box const& box, T ncomp, L&& f) noexce
 {
     if (amrex::isEmpty(box)) return;
     int ncells = box.numPts();
-#ifdef AMREX_USE_CUDA
+#if defined(AMREX_USE_CUDA) || (defined(AMREX_USE_HIP) && defined(AMREX_HIP_INDIRECT_FUNCTION))
     if (!info.hasReduction() && Gpu::inFuseRegion() && info.isFusible() && ncells <= Gpu::getFuseSizeThreshold()) {
         Gpu::Register(box, ncomp, f);
     } else
@@ -1087,7 +1087,7 @@ ParallelFor (Gpu::KernelInfo const& info,
     int ncells1 = box1.numPts();
     int ncells2 = box2.numPts();
     int ncells = amrex::max(ncells1, ncells2);
-#ifdef AMREX_USE_CUDA
+#if defined(AMREX_USE_CUDA) || (defined(AMREX_USE_HIP) && defined(AMREX_HIP_INDIRECT_FUNCTION))
     if (Gpu::inFuseRegion() && info.isFusible() && ncells <= Gpu::getFuseSizeThreshold()) {
         Gpu::Register(box1, f1);
         Gpu::Register(box2, f2);
@@ -1139,7 +1139,7 @@ ParallelFor (Gpu::KernelInfo const& info,
     int ncells2 = box2.numPts();
     int ncells3 = box3.numPts();
     int ncells = amrex::max(ncells1, ncells2, ncells3);
-#ifdef AMREX_USE_CUDA
+#if defined(AMREX_USE_CUDA) || (defined(AMREX_USE_HIP) && defined(AMREX_HIP_INDIRECT_FUNCTION))
     if (Gpu::inFuseRegion() && info.isFusible() && ncells <= Gpu::getFuseSizeThreshold()) {
         Gpu::Register(box1, f1);
         Gpu::Register(box2, f2);
@@ -1204,7 +1204,7 @@ ParallelFor (Gpu::KernelInfo const& info,
     int ncells1 = box1.numPts();
     int ncells2 = box2.numPts();
     int ncells = amrex::max(ncells1, ncells2);
-#ifdef AMREX_USE_CUDA
+#if defined(AMREX_USE_CUDA) || (defined(AMREX_USE_HIP) && defined(AMREX_HIP_INDIRECT_FUNCTION))
     if (Gpu::inFuseRegion() && info.isFusible() && ncells <= Gpu::getFuseSizeThreshold()) {
         Gpu::Register(box1, ncomp1, f1);
         Gpu::Register(box2, ncomp2, f2);
@@ -1264,7 +1264,7 @@ ParallelFor (Gpu::KernelInfo const& info,
     int ncells2 = box2.numPts();
     int ncells3 = box3.numPts();
     int ncells = amrex::max(ncells1, ncells2, ncells3);
-#ifdef AMREX_USE_CUDA
+#if defined(AMREX_USE_CUDA) || (defined(AMREX_USE_HIP) && defined(AMREX_HIP_INDIRECT_FUNCTION))
     if (Gpu::inFuseRegion() && info.isFusible() && ncells <= Gpu::getFuseSizeThreshold()) {
         Gpu::Register(box1, ncomp1, f1);
         Gpu::Register(box2, ncomp2, f2);

--- a/Src/Base/AMReX_GpuLaunchMacrosG.H
+++ b/Src/Base/AMReX_GpuLaunchMacrosG.H
@@ -54,7 +54,7 @@
             block \
         } \
     }}}
-#ifdef AMREX_USE_CUDA
+#if defined(AMREX_USE_CUDA) || (defined(AMREX_USE_HIP) && defined(AMREX_HIP_INDIRECT_FUNCTION))
 #define AMREX_GPU_LAUNCH_HOST_DEVICE_FUSIBLE_LAMBDA_RANGE(TN,TI,block) \
     { auto const& amrex_i_tn = TN; \
     if (!amrex::isEmpty(amrex_i_tn)) { \
@@ -163,7 +163,7 @@
             block2 \
         } \
     }}}
-#ifdef AMREX_USE_CUDA
+#if defined(AMREX_USE_CUDA) || (defined(AMREX_USE_HIP) && defined(AMREX_HIP_INDIRECT_FUNCTION))
 #define AMREX_GPU_LAUNCH_HOST_DEVICE_FUSIBLE_LAMBDA_RANGE_2(TN1,TI1,block1,TN2,TI2,block2) \
     { auto const& amrex_i_tn1 = TN1; auto const& amrex_i_tn2 = TN2; \
     if (!amrex::isEmpty(amrex_i_tn1) || !amrex::isEmpty(amrex_i_tn2)) { \
@@ -307,7 +307,7 @@
             block3 \
         } \
     }}}
-#ifdef AMREX_USE_CUDA
+#if defined(AMREX_USE_CUDA) || (defined(AMREX_USE_HIP) && defined(AMREX_HIP_INDIRECT_FUNCTION))
 #define AMREX_GPU_LAUNCH_HOST_DEVICE_FUSIBLE_LAMBDA_RANGE_3(TN1,TI1,block1,TN2,TI2,block2,TN3,TI3,block3) \
     { auto const& amrex_i_tn1 = TN1; auto const& amrex_i_tn2 = TN2; auto const& amrex_i_tn3 = TN3; \
     if (!amrex::isEmpty(amrex_i_tn1) || !amrex::isEmpty(amrex_i_tn2) || !amrex::isEmpty(amrex_i_tn3)) { \

--- a/Src/Base/AMReX_Reduce.H
+++ b/Src/Base/AMReX_Reduce.H
@@ -309,7 +309,7 @@ public:
             Reduce::detail::for_each_parallel<0, ReduceTuple, Ps...>(*dp,r, gh);
         });
 #else
-#ifdef AMREX_USE_CUDA
+#if defined(AMREX_USE_CUDA) || (defined(AMREX_USE_HIP) && defined(AMREX_HIP_INDIRECT_FUNCTION))
         if (Gpu::inFuseRegion() && Gpu::inFuseReductionRegion()
             && ec.numBlocks.x*ec.numThreads.x <= Gpu::getFuseSizeThreshold())
         {

--- a/Tests/GPU/Fuse/GNUmakefile
+++ b/Tests/GPU/Fuse/GNUmakefile
@@ -3,17 +3,18 @@ AMREX_HOME = ../../..
 DEBUG	= TRUE
 DEBUG	= FALSE
 
-DIM	= 2
+DIM	= 3
 
 COMP    = gcc
 
 USE_MPI   = FALSE
 USE_OMP   = FALSE
 USE_CUDA  = TRUE
-USE_HIP   = FALSE
 USE_DPCPP = FALSE
 
-TINY_PROFILE = TRUE
+## To test HIP indirect funciton, uncomment the following
+# USE_HIP=TRUE
+# HIP_INDIRECT_FUNCTION=TRUE
 
 include $(AMREX_HOME)/Tools/GNUMake/Make.defs
 

--- a/Tests/GPU/Fuse/GNUmakefile
+++ b/Tests/GPU/Fuse/GNUmakefile
@@ -12,9 +12,11 @@ USE_OMP   = FALSE
 USE_CUDA  = TRUE
 USE_DPCPP = FALSE
 
-## To test HIP indirect funciton, uncomment the following
+## To test HIP indirect funciton, uncomment the following or run with `make -j8 USE_HIP=TRUE`
 # USE_HIP=TRUE
-# HIP_INDIRECT_FUNCTION=TRUE
+ifdef USE_HIP
+  HIP_INDIRECT_FUNCTION=$(USE_HIP)
+endif
 
 include $(AMREX_HOME)/Tools/GNUMake/Make.defs
 

--- a/Tests/GPU/Fuse/main.cpp
+++ b/Tests/GPU/Fuse/main.cpp
@@ -82,7 +82,7 @@ int main(int argc, char* argv[])
         mfc.setVal(-1);
 
         {
-            BL_PROFILE("fuesd-test1");
+            BL_PROFILE("fused-test1");
             fused_test(mfa,mfb,mfc);
         }
         r = r && verify(mfc);

--- a/Tests/GPU/Fuse/main.cpp
+++ b/Tests/GPU/Fuse/main.cpp
@@ -71,7 +71,7 @@ int main(int argc, char* argv[])
 
         Box bx(IntVect(0),IntVect(255));
         BoxArray ba(bx);
-        ba.maxSize(32);
+        ba.maxSize(16);
         DistributionMapping dm{ba};
 
         iMultiFab mfa(ba,dm,1,0);

--- a/Tests/GPU/Fuse/main.cpp
+++ b/Tests/GPU/Fuse/main.cpp
@@ -69,7 +69,7 @@ int main(int argc, char* argv[])
     {
         BL_PROFILE("main()");
 
-        Box bx(IntVect(0),IntVect(255));
+        Box bx(IntVect(0),IntVect(127));
         BoxArray ba(bx);
         ba.maxSize(16);
         DistributionMapping dm{ba};

--- a/Tests/GPU/Fuse/main.cpp
+++ b/Tests/GPU/Fuse/main.cpp
@@ -1,17 +1,17 @@
 
 #include <AMReX.H>
-#include <AMReX_MultiFab.H>
+#include <AMReX_iMultiFab.H>
 #include <AMReX_BLProfiler.H>
 
 using namespace amrex;
 
-void fused_test (MultiFab const& mfa, MultiFab const& mfb, MultiFab& mfc)
+void fused_test (iMultiFab const& mfa, iMultiFab const& mfb, iMultiFab& mfc)
 {
     Gpu::FuseSafeGuard fsg(true);
     for (MFIter mfi(mfc); mfi.isValid(); ++mfi) {
-        Array4<Real const> const& a = mfa.const_array(mfi);
-        Array4<Real const> const& b = mfb.const_array(mfi);
-        Array4<Real      > const& c = mfc.array(mfi);
+        Array4<int const> const& a = mfa.const_array(mfi);
+        Array4<int const> const& b = mfb.const_array(mfi);
+        Array4<int      > const& c = mfc.array(mfi);
         Box const& vbx = mfi.validbox();
         amrex::Gpu::Register(vbx, [=] AMREX_GPU_DEVICE (int i, int j, int k)
         {
@@ -25,12 +25,12 @@ void fused_test (MultiFab const& mfa, MultiFab const& mfb, MultiFab& mfc)
     amrex::Gpu::LaunchFusedKernels();
 }
 
-void unfused_test (MultiFab const& mfa, MultiFab const& mfb, MultiFab& mfc)
+void unfused_test (iMultiFab const& mfa, iMultiFab const& mfb, iMultiFab& mfc)
 {
     for (MFIter mfi(mfc); mfi.isValid(); ++mfi) {
-        Array4<Real const> const& a = mfa.const_array(mfi);
-        Array4<Real const> const& b = mfb.const_array(mfi);
-        Array4<Real      > const& c = mfc.array(mfi);
+        Array4<int const> const& a = mfa.const_array(mfi);
+        Array4<int const> const& b = mfb.const_array(mfi);
+        Array4<int      > const& c = mfc.array(mfi);
         Box const& vbx = mfi.validbox();
         amrex::ParallelFor(vbx, [=] AMREX_GPU_DEVICE (int i, int j, int k)
         {
@@ -43,56 +43,75 @@ void unfused_test (MultiFab const& mfa, MultiFab const& mfb, MultiFab& mfc)
     }
 }
 
-void verify (MultiFab& mfc)
+int verify (iMultiFab& mfc)
 {
-    Real min0 = mfc.min(0);
-    Real min1 = mfc.min(1);
-    Real max0 = mfc.max(0);
-    Real max1 = mfc.max(1);
-    if (min0 != 4.0 || max0 != min0 || min1 != -2.0 || max1 != min1) {
+    int min0 = mfc.min(0);
+    int min1 = mfc.min(1);
+    int max0 = mfc.max(0);
+    int max1 = mfc.max(1);
+    bool r;
+    if (min0 != 4 || max0 != min0 || min1 != -2 || max1 != min1) {
         amrex::Print() << "Failed!" << std::endl;
+        r = false;
     } else {
         amrex::Print() << "Success" << std::endl;
+        r = true;
     }
-    mfc.setVal(-1.);
+    mfc.setVal(-1);
+    return r;
 }
 
 int main(int argc, char* argv[])
 {
+    bool r = true;
+    Real tf, tuf;
     amrex::Initialize(argc,argv);
     {
         BL_PROFILE("main()");
 
-        Box bx(IntVect(0),IntVect(127));
+        Box bx(IntVect(0),IntVect(255));
         BoxArray ba(bx);
-        ba.maxSize(16);
+        ba.maxSize(32);
         DistributionMapping dm{ba};
 
-        MultiFab mfa(ba,dm,1,0);
-        MultiFab mfb(ba,dm,1,0);
-        MultiFab mfc(ba,dm,2,0);
-        mfa.setVal(1.0);
-        mfb.setVal(3.0);
-        mfc.setVal(-1.0);
+        iMultiFab mfa(ba,dm,1,0);
+        iMultiFab mfb(ba,dm,1,0);
+        iMultiFab mfc(ba,dm,2,0);
+        mfa.setVal(1);
+        mfb.setVal(3);
+        mfc.setVal(-1);
 
         {
             BL_PROFILE("fuesd-test1");
             fused_test(mfa,mfb,mfc);
         }
-        verify(mfc);
+        r = r && verify(mfc);
         
         {
             BL_PROFILE("fused-test2");
+            Real t = amrex::second();
             fused_test(mfa,mfb,mfc);
+            tf = amrex::second() - t;
         }
-        verify(mfc);
+        r = r && verify(mfc);
 
         {
             BL_PROFILE("unfused-test");
+            Real t = amrex::second();
             unfused_test(mfa,mfb,mfc);
+            tuf = amrex::second() - t;
         }
-        verify(mfc);
+        r = r && verify(mfc);
     }
     amrex::Finalize();
-}
 
+    if (r) {
+        std::cout << "\nTest passes.\n";
+    } else {
+        std::cout << "\nTest fails.\n";
+    }
+    std::cout << "Unfused kernels take " << tuf << " seconds.\n"
+              << "Fused   kernels take " << tf  << " seconds." << std::endl;
+
+    return r ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/Tools/GNUMake/Make.defs
+++ b/Tools/GNUMake/Make.defs
@@ -652,6 +652,10 @@ ifeq ($(USE_HIP),TRUE)
 
     GPUSuffix := .HIP
 
+    ifeq ($(HIP_INDIRECT_FUNCTION),TRUE)
+      DEFINES += -DAMREX_HIP_INDIRECT_FUNCTION
+    endif
+
 else ifeq ($(USE_CUDA),TRUE)
 
     USE_GPU := TRUE


### PR DESCRIPTION
Add a GNU Make flag, HIP_INDIRECT_FUNCTION=[TRUE|FALSE], and modify the Gpu
kernel fusing test.

Currently HIP does not support indirect function calls via device function
pointers, which our GPU fusing implementation depends on.