### PR TITLE
Template copy/add particles based on src type.

### DIFF
--- a/Src/Particle/AMReX_ParticleContainerI.H
+++ b/Src/Particle/AMReX_ParticleContainerI.H
@@ -987,9 +987,10 @@ clearParticles ()
 
 template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt,
           template<class> class Allocator>
+template <class PCType, amrex::EnableIf_t<IsParticleContainer<PCType>::value, int> foo>
 void
 ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>::
-copyParticles (const ParticleContainerType& other, bool local)
+copyParticles (const PCType& other, bool local)
 {
     using PData = ConstParticleTileData<NStructReal, NStructInt, NArrayReal, NArrayInt>;
     copyParticles(other, [=] AMREX_GPU_HOST_DEVICE (const PData& /*data*/, int /*i*/) { return 1; }, local);
@@ -997,9 +998,10 @@ copyParticles (const ParticleContainerType& other, bool local)
 
 template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt,
           template<class> class Allocator>
+template <class PCType, amrex::EnableIf_t<IsParticleContainer<PCType>::value, int> foo>
 void
 ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>::
-addParticles (const ParticleContainerType& other, bool local)
+addParticles (const PCType& other, bool local)
 {
     using PData = ConstParticleTileData<NStructReal, NStructInt, NArrayReal, NArrayInt>;
     addParticles(other, [=] AMREX_GPU_HOST_DEVICE (const PData& /*data*/, int /*i*/) { return 1; }, local);
@@ -1007,11 +1009,12 @@ addParticles (const ParticleContainerType& other, bool local)
 
 template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt,
           template<class> class Allocator>
-template <class F,
-          amrex::EnableIf_t<! std::is_integral<F>::value, int> foo>
+template <class F, class PCType,
+          amrex::EnableIf_t<IsParticleContainer<PCType>::value, int> foo,
+          amrex::EnableIf_t<! std::is_integral<F>::value, int> bar>
 void
 ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>::
-copyParticles (const ParticleContainerType& other, F&& f, bool local)
+copyParticles (const PCType& other, F&& f, bool local)
 {
     BL_PROFILE("ParticleContainer::copyParticles");
     clearParticles();
@@ -1020,11 +1023,12 @@ copyParticles (const ParticleContainerType& other, F&& f, bool local)
 
 template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt,
           template<class> class Allocator>
-template <class F,
-          amrex::EnableIf_t<! std::is_integral<F>::value, int> foo>
+template <class F, class PCType,
+          amrex::EnableIf_t<IsParticleContainer<PCType>::value, int> foo,
+          amrex::EnableIf_t<! std::is_integral<F>::value, int> bar>
 void
 ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>::
-addParticles (const ParticleContainerType& other, F&& f, bool local)
+addParticles (const PCType& other, F&& f, bool local)
 {
     BL_PROFILE("ParticleContainer::addParticles");
 

--- a/Src/Particle/AMReX_ParticleTile.H
+++ b/Src/Particle/AMReX_ParticleTile.H
@@ -472,7 +472,7 @@ struct ParticleTile
         return nbytes;
     }
 
-    void swap (ParticleTile<NStructReal, NStructInt, NArrayReal, NArrayInt>& other)
+    void swap (ParticleTile<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>& other)
     {
         m_aos_tile().swap(other.GetArrayOfStructs()());
         for (int j = 0; j < NumRealComps(); ++j)

--- a/Src/Particle/AMReX_Particles.H
+++ b/Src/Particle/AMReX_Particles.H
@@ -710,7 +710,9 @@ public:
     * \param other the other pc to copy from
     * \param local whether to call redistribute after
     */
-    void copyParticles (const ParticleContainerType& other, bool local=false);
+    template <class PCType,
+              amrex::EnableIf_t<IsParticleContainer<PCType>::value, int> foo = 0>
+    void copyParticles (const PCType& other, bool local=false);
 
     /**
     * \brief Add particles from other to this ParticleContainer. local controls
@@ -719,7 +721,9 @@ public:
     * \param other the other pc to copy from
     * \param local whether to call redistribute after
     */
-    void addParticles (const ParticleContainerType& other, bool local=false);
+    template <class PCType,
+              amrex::EnableIf_t<IsParticleContainer<PCType>::value, int> foo = 0>
+    void addParticles (const PCType& other, bool local=false);
 
     /**
     * \brief Copy particles from other to this ParticleContainer. Will clear all the
@@ -735,8 +739,10 @@ public:
     * \param f function to apply to each particle as a filter
     * \param local whether to call redistribute after
     */
-    template <class F, amrex::EnableIf_t<! std::is_integral<F>::value, int> foo = 0>
-    void copyParticles (const ParticleContainerType& other, F&&f, bool local=false);
+    template <class F, class PCType,
+              amrex::EnableIf_t<IsParticleContainer<PCType>::value, int> foo = 0,
+              amrex::EnableIf_t<! std::is_integral<F>::value, int> bar = 0>
+    void copyParticles (const PCType& other, F&&f, bool local=false);
 
     /**
     * \brief Add particles from other to this ParticleContainer. local controls
@@ -751,8 +757,10 @@ public:
     * \param f function to apply to each particle as a filter
     * \param local whether to call redistribute after
     */
-    template <class F, amrex::EnableIf_t<! std::is_integral<F>::value, int> foo = 0>
-    void addParticles (const ParticleContainerType& other, F&& f, bool local=false);
+    template <class F, class PCType,
+              amrex::EnableIf_t<IsParticleContainer<PCType>::value, int> foo = 0,
+              amrex::EnableIf_t<! std::is_integral<F>::value, int> bar = 0>
+    void addParticles (const PCType& other, F&& f, bool local=false);
 
     /**
     * \brief Write a contiguous chunk of real particle data to an ostream.


### PR DESCRIPTION
This is needed so that that they can used between PCs that have different memory allocators, for example from device to pinned memory particle containers.

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
