### PR TITLE
HIP: New Warp Size Macro

### DIFF
--- a/Src/Base/AMReX_GpuDevice.H
+++ b/Src/Base/AMReX_GpuDevice.H
@@ -123,7 +123,15 @@ public:
     static std::size_t freeMemAvailable ();
 
 #ifdef AMREX_USE_GPU
+
+#   if defined(AMREX_USE_HIP) && (HIP_VERSION_MAJOR >= 4)
+    // definition: https://github.com/llvm/llvm-project/blob/62ec4ac90738a5f2d209ed28c822223e58aaaeb7/clang/lib/Basic/Targets/AMDGPU.cpp#L400
+    // overview wavefront size: https://github.com/llvm/llvm-project/blob/efc063b621ea0c4d1e452bcade62f7fc7e1cc937/clang/test/Driver/amdgpu-macros.cl#L70-L115
+    // gfx10XX has 32 threads per wavefront else 64
+    static constexpr int warp_size = __AMDGCN_WAVEFRONT_SIZE;
+#   else
     static constexpr int warp_size = AMREX_HIP_OR_CUDA_OR_DPCPP(64,32,16);
+#   endif
 
     static unsigned int maxBlocksPerLaunch () noexcept { return max_blocks_per_launch; }
 


### PR DESCRIPTION
## Summary

Use new the HIP macro for the warp size on various AMD devices.

## Additional background

Credits to @psychocoderHPC and the mallocMC developers (https://github.com/alpaka-group/mallocMC/pull/204)

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
