### PR TITLE
Improve the interpolation from cell centroids to face centroids:

### DIFF
--- a/Src/EB/AMReX_EBMultiFabUtil_2D_C.H
+++ b/Src/EB/AMReX_EBMultiFabUtil_2D_C.H
@@ -395,7 +395,7 @@ void eb_interp_centroid2facecent_x (Box const& ubx,
   const Dim3 domlo = amrex::lbound(domain);
   const Dim3 domhi = amrex::ubound(domain);
   amrex::Loop(ubx, ncomp, [=] (int i, int j, int k, int n) noexcept
-    {
+  {
       if (apx(i,j,k) == 0)
       {
           edg_x(i,j,k,n) = 1e40;
@@ -408,22 +408,32 @@ void eb_interp_centroid2facecent_x (Box const& ubx,
       {
           edg_x(i,j,k,n) = phi(domhi.x+1,j,k,n);
       }
-      else if (apx(i,j,k) == 1 && cvol(i,j,k) == 1 && cvol(i-1,j,k) == 1)
+      else if ( apx(i,j,k) == 1 && (cvol(i,j,k) == 1 && cvol(i-1,j,k) == 1) )
       {
           edg_x(i,j,k,n) = 0.5 * ( phi(i,j,k,n) + phi(i-1,j,k,n) );
+      } 
+      else if (apx(i,j,k) == 1 && (amrex::Math::abs(ccent(i,j,k,1)-ccent(i-1,j,k,1)) < 1.e-8) )
+      {
+          Real d0 = 0.5 + ccent(i  ,j,k,0);                               // distance in x-dir from centroid(i  ,j) to face(i,j)
+          Real d1 = 0.5 - ccent(i-1,j,k,0);                               // distance in x-dir from centroid(i-1,j) to face(i,j)
+          Real a0 = d1 / (d0 + d1);                                       // coefficient of phi(i  ,j,k,n)
+          Real a1 = d0 / (d0 + d1);                                       // coefficient of phi(i-1,j,k,n)
+          edg_x(i,j,k,n) = a0*phi(i,j,k,n) + a1*phi(i-1,j,k,n);           // interpolation of phi in x-direction
       } 
       else 
       {
           int ii = i - 1;
-          // We must add an additional test to avoid the case where fcx is very close to zero, but (j-1) or (j+1)
-          //    might be covered cells -- this can happen when the EB is exactly aligned with the horizontal grid lines
           int jj;
-          if (amrex::Math::abs(fcx(i,j,k)) > 1.e-8)
+          if (amrex::Math::abs(fcx(i,j,k)) > 1.e-8) {
               jj = (fcx(i,j,k) < 0.0) ? j - 1 : j + 1;
-          else if (apx(i,j-1,k) > 0.)
-              jj = j-1;
-          else 
-              jj = j+1;
+          } else {
+
+              // We must add an additional test to avoid the case where fcx is very close to zero,
+              //     but the cells at (j-1) or (j+1) might be covered or very small cells
+              Real min_vol_lo = std::min(cvol(i,j-1,k),cvol(ii,j-1,k));
+              Real min_vol_hi = std::min(cvol(i,j+1,k),cvol(ii,j+1,k));
+              jj = (min_vol_lo > min_vol_hi) ? j - 1 : j + 1;
+          }
 
           Real d0    = 0.5 + ccent( i,j,k,0);                                 // distance in x-dir from centroid(i  ,j) to face(i,j)
           Real d1    = 0.5 - ccent(ii,j,k,0);                                 // distance in x-dir from centroid(i-1,j) to face(i,j)
@@ -446,7 +456,7 @@ void eb_interp_centroid2facecent_x (Box const& ubx,
           edg_x(i,j,k,n) = ( (     fcx(i,j,k) - y01   ) * phi01_jj + 
                              (1. - fcx(i,j,k) + y01_jj) * phi01    ) / (1. - y01 + y01_jj);
       }
-    });
+  });
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
@@ -464,36 +474,47 @@ void eb_interp_centroid2facecent_y (Box const& vbx,
   const Dim3 domlo = amrex::lbound(domain);
   const Dim3 domhi = amrex::ubound(domain);
   amrex::Loop(vbx, ncomp, [=] (int i, int j, int k, int n) noexcept
-    {
-        if (apy(i,j,k) == 0)
-        {
-            edg_y(i,j,k,n) = 1e40;
-        }
-        else if ( (j == domlo.y) && (bc[n].lo(1) == BCType::ext_dir) )
-        {
-            edg_y(i,j,k,n) = phi(i,domlo.y-1,k,n);
-        }
-        else if ( (j == domhi.y+1) && (bc[n].hi(1) == BCType::ext_dir) )
-        {
-            edg_y(i,j,k,n) = phi(i,domhi.y+1,k,n);
-        }
-        else if (apy(i,j,k) == 1 && cvol(i,j,k) == 1 && cvol(i,j-1,k) == 1)
-        {
-            edg_y(i,j,k,n) = 0.5 * (phi(i,j  ,k,n) + phi(i,j-1,k,n));
-        }
-        else 
-        {
+   {
+      if (apy(i,j,k) == 0)
+      {
+          edg_y(i,j,k,n) = 1e40;
+      }
+      else if ( (j == domlo.y) && (bc[n].lo(1) == BCType::ext_dir) )
+      {
+          edg_y(i,j,k,n) = phi(i,domlo.y-1,k,n);
+      }
+      else if ( (j == domhi.y+1) && (bc[n].hi(1) == BCType::ext_dir) )
+      {
+          edg_y(i,j,k,n) = phi(i,domhi.y+1,k,n);
+      }
+      else if (apy(i,j,k) == 1. && cvol(i,j,k) == 1 && cvol(i,j-1,k) == 1)
+      {
+          edg_y(i,j,k,n) = 0.5 * (phi(i,j  ,k,n) + phi(i,j-1,k,n));
+      }
+      else if (apy(i,j,k) == 1. && (amrex::Math::abs(ccent(i,j,k,0)-ccent(i,j-1,k,0)) < 1.e-8) )
+      {
+          Real d0 = 0.5 + ccent(i,j  ,k,1);                                // distance in y-dir from centroid(i,j  ) to face(i,j)
+          Real d1 = 0.5 - ccent(i,j-1,k,1);                                // distance in y-dir from centroid(i,j-1) to face(i,j)
+          Real a0 = d1 / (d0 + d1);                                        // coefficient of phi(i,j  ,k,n)
+          Real a1 = d0 / (d0 + d1);                                        // coefficient of phi(i,j-1,k,n)
+          edg_y(i,j,k,n) = a0*phi(i,j,k,n) + a1*phi(i,j-1,k,n);            // interpolation of phi in y-direction
+      } 
+      else 
+      {
           int jj = j - 1;
+          int ii;
 
           // We must add an additional test to avoid the case where fcy is very close to zero, but (i-1) or (i+1)
           //    might be covered cells -- this can happen when the EB is exactly aligned with the horizontal grid lines
-          int ii;
-          if (amrex::Math::abs(fcy(i,j,k)) > 1.e-8)
+          if (amrex::Math::abs(fcy(i,j,k)) > 1.e-8) {
               ii = (fcy(i,j,k) < 0.0) ? i - 1 : i + 1;
-          else if (apy(i-1,j,k) > 0.)
-              ii = i-1;
-          else 
-              ii = i+1;
+          } else {
+              // We must add an additional test to avoid the case where fcx is very close to zero,
+              //     but the cells at (i-1) or (i+1) might be covered or very small cells
+              Real min_vol_lo = std::min(cvol(i-1,j,k),cvol(i-1,jj,k));
+              Real min_vol_hi = std::min(cvol(i+1,j,k),cvol(i+1,jj,k));
+              ii = (min_vol_lo > min_vol_hi) ? i - 1 : i + 1;
+          }
 
           Real d0    = 0.5 + ccent(i, j,k,1);                                 // distance in y-dir from centroid(i,j  ) to face(i,j)
           Real d1    = 0.5 - ccent(i,jj,k,1);                                 // distance in y-dir from centroid(i,j-1) to face(i,j)

--- a/Src/EB/AMReX_EBMultiFabUtil_3D_C.H
+++ b/Src/EB/AMReX_EBMultiFabUtil_3D_C.H
@@ -640,6 +640,15 @@ void eb_interp_centroid2facecent_x (Box const& ubx,
       {
           phi_x(i,j,k,n) = 0.5 * ( phi(i,j,k,n) + phi(i-1,j,k,n) );
       } 
+      else if ( apx(i,j,k) == 1 && (amrex::Math::abs(ccent(i,j,k,1)-ccent(i-1,j,k,1)) < 1.e-8) && 
+                                   (amrex::Math::abs(ccent(i,j,k,2)-ccent(i-1,j,k,2)) < 1.e-8) )
+      {
+          Real d0 = 0.5 + ccent(i  ,j,k,0);                               // distance in x-dir from centroid(i  ,j) to face(i,j)
+          Real d1 = 0.5 - ccent(i-1,j,k,0);                               // distance in x-dir from centroid(i-1,j) to face(i,j)
+          Real a0 = d1 / (d0 + d1);                                       // coefficient of phi(i  ,j,k,n)
+          Real a1 = d0 / (d0 + d1);                                       // coefficient of phi(i-1,j,k,n)
+          phi_x(i,j,k,n) = a0*phi(i,j,k,n) + a1*phi(i-1,j,k,n);           // interpolation of phi in x-direction
+      }
       else 
       {
           // We must add additional tests to avoid the case where fcx is very close to zero, but j-1/j+1 or k-1/k+1
@@ -654,7 +663,7 @@ void eb_interp_centroid2facecent_x (Box const& ubx,
 
           if (amrex::Math::abs(fcx(i,j,k,1)) > 1.e-8)
               kk = (fcx(i,j,k,1) < 0.0) ? k - 1 : k + 1;
-          else if (apx(i,j-1,k) > 0.)
+          else if (apx(i,j,k-1) > 0.)
               kk = k-1;
           else
               kk = k+1;
@@ -844,6 +853,15 @@ void eb_interp_centroid2facecent_y (Box const& vbx,
         {
             phi_y(i,j,k,n) = 0.5 * (phi(i,j  ,k,n) + phi(i,j-1,k,n));
         }
+        else if ( apy(i,j,k) == 1. && (amrex::Math::abs(ccent(i,j,k,0)-ccent(i,j-1,k,0)) < 1.e-8) &&
+                                      (amrex::Math::abs(ccent(i,j,k,2)-ccent(i,j-1,k,2)) < 1.e-8) )
+        {
+            Real d0 = 0.5 + ccent(i,j  ,k,1);                                // distance in y-dir from centroid(i,j  ,k) to face(i,j,k)
+            Real d1 = 0.5 - ccent(i,j-1,k,1);                                // distance in y-dir from centroid(i,j-1,k) to face(i,j,k)
+            Real a0 = d1 / (d0 + d1);                                        // coefficient of phi(i,j  ,k,n)
+            Real a1 = d0 / (d0 + d1);                                        // coefficient of phi(i,j-1,k,n)
+            phi_y(i,j,k,n) = a0*phi(i,j,k,n) + a1*phi(i,j-1,k,n);            // interpolation of phi in y-direction
+        }
         else 
         {
 
@@ -852,14 +870,14 @@ void eb_interp_centroid2facecent_y (Box const& vbx,
           int ii,kk;
           if (amrex::Math::abs(fcy(i,j,k,0)) > 1.e-8)
               ii = (fcy(i,j,k,0) < 0.0) ? i - 1 : i + 1;
-          else if (apy(i,j-1,k) > 0.)
+          else if (apy(i-1,j,k) > 0.)
               ii = i-1;
           else
               ii = i+1;
 
           if (amrex::Math::abs(fcy(i,j,k,1)) > 1.e-8)
               kk = (fcy(i,j,k,1) < 0.0) ? k - 1 : k + 1;
-          else if (apy(i,j-1,k) > 0.)
+          else if (apy(i,j,k-1) > 0.)
               kk = k-1;
           else
               kk = k+1;
@@ -1046,6 +1064,15 @@ void eb_interp_centroid2facecent_z (Box const& wbx,
         {
             phi_z(i,j,k,n) = 0.5 * (phi(i,j,k,n) + phi(i,j,k-1,n));
         }
+        else if ( apz(i,j,k) == 1. && (amrex::Math::abs(ccent(i,j,k,0)-ccent(i,j,k-1,0)) < 1.e-8) &&
+                                      (amrex::Math::abs(ccent(i,j,k,1)-ccent(i,j,k-1,1)) < 1.e-8) )
+        {
+            Real d0 = 0.5 + ccent(i,j,k  ,2);                                // distance in z-dir from centroid(i,j,k  ) to face(i,j,k)
+            Real d1 = 0.5 - ccent(i,j,k-1,2);                                // distance in z-dir from centroid(i,j,k-1) to face(i,j,k)
+            Real a0 = d1 / (d0 + d1);                                        // coefficient of phi(i,j,k  ,n)
+            Real a1 = d0 / (d0 + d1);                                        // coefficient of phi(i,j,k-1,n)
+            phi_z(i,j,k,n) = a0*phi(i,j,k,n) + a1*phi(i,j,k-1,n);            // interpolation of phi in z-direction
+        }
         else 
         {
           // We must add additional tests to avoid the case where fcz is very close to zero, but i-1/i+1 or j-1/j+1
@@ -1053,7 +1080,7 @@ void eb_interp_centroid2facecent_z (Box const& wbx,
           int ii,jj;
           if (amrex::Math::abs(fcz(i,j,k,0)) > 1.e-8)
               ii = (fcz(i,j,k,0) < 0.0) ? i - 1 : i + 1;
-          else if (apz(i,j-1,k) > 0.)
+          else if (apz(i-1,j,k) > 0.)
               ii = i-1;
           else
               ii = i+1;


### PR DESCRIPTION
1) if the centroids are aligned tangentially to the face but not at
equal distance to the face, use just those two cells for interpolation
2) in the case where the face centroid is at 0 but the cell
centroids are not aligned, instead of testing on an area fraction
tangential to the face to decide which way to go, in 2d, now test
on the minimum volume for each option and choose the option with
the larger minimum volume -- this should avoid using covered or
very small cells.   (3D already has logic to avoid using covered cells)

## Summary

## Additional background

## Checklist

The proposed changes:
- [X] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [X] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
