### PR TITLE
Use ParticleReal for particle interpolation

### DIFF
--- a/Src/Particle/AMReX_TracerParticles.cpp
+++ b/Src/Particle/AMReX_TracerParticles.cpp
@@ -284,7 +284,7 @@ TracerParticleContainer::Timestamp (const std::string&      basename,
                 const int       M  = indices.size();
                 const BoxArray& ba = mf.boxArray();
 
-                std::vector<Real> vals(M);
+                std::vector<ParticleReal> vals(M);
 
 		for (auto& kv : pmap) {
 		  int grid = kv.first.first;


### PR DESCRIPTION
## Summary
Use ParticleReal so ParticleReal * matches function prototype for cic_interpolate

## Additional background

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
