### PR TITLE
IntVect::toArray()

### DIFF
--- a/Src/Base/AMReX_IntVect.H
+++ b/Src/Base/AMReX_IntVect.H
@@ -135,6 +135,17 @@ public:
 #endif
     }
 
+#if __cplusplus >= 201402L
+    template< typename T = int >
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    Array<T, AMREX_SPACEDIM>
+    toArray () const noexcept {
+        return Array<T, AMREX_SPACEDIM>{
+            AMREX_D_DECL(T(vect[0]), T(vect[1]), T(vect[2]))
+        };
+    }
+#endif
+
   ///
   /**
      Sum of all components of this IntVect.


### PR DESCRIPTION
## Summary

Add a ::toArray() conversion member to IntVect that can be used to convert back to an array type and cast the result on the way, e.g. to unsigned.

## Additional background

Functions in https://github.com/ECP-WarpX/WarpX/pull/1660

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
