### PR TITLE
For FillPatchTwoLevels, BCs should be set on the coarse box, since th…

### DIFF
--- a/Src/AmrCore/AMReX_FillPatchUtil_I.H
+++ b/Src/AmrCore/AMReX_FillPatchUtil_I.H
@@ -504,7 +504,7 @@ namespace {
                         {
                             Vector<BCRec> bcr_d(ncomp);
 
-                            amrex::setBC(dfab[d]->box(), amrex::convert(fgeom.Domain(), mf[d]->boxArray().ixType()),
+                            amrex::setBC(sfab[d]->box(), amrex::convert(cgeom.Domain(), mf[d]->ixType()),
                                          bcscomp,0,ncomp,bcs[d],bcr_d);
 
                             for (int n=0; n<ncomp; ++n)
@@ -753,10 +753,10 @@ InterpFromCoarseLevel (MF& mf, IntVect const& nghost, Real time,
 
     BL_ASSERT(typ == cmf.boxArray().ixType());
 
-    Box fdomain = fgeom.Domain();
-    fdomain.convert(typ);
+    Box cdomain = cgeom.Domain();
+    cdomain.convert(typ);
 
-    Box fdomain_g(fdomain);
+    Box fdomain_g( amrex::convert(fgeom.Domain(),mf.ixType()) );
     for (int i = 0; i < AMREX_SPACEDIM; ++i) {
         if (fgeom.isPeriodic(i)) {
             fdomain_g.grow(i,nghost[i]);
@@ -799,13 +799,14 @@ InterpFromCoarseLevel (MF& mf, IntVect const& nghost, Real time,
 
         for (MFIter mfi(mf_crse_patch); mfi.isValid(); ++mfi)
         {
-            FAB& sfab = mf_crse_patch[mfi];
-            FAB& dfab = mf[mfi];
+            FAB& sfab   = mf_crse_patch[mfi];
+            Box  sbx    = sfab.box();
+            FAB& dfab   = mf[mfi];
             Box dfab_bx = dfab.box();
             dfab_bx.grow(nghost-mf.nGrowVect());
             const Box& dbx = dfab_bx & fdomain_g;
 
-            amrex::setBC(dbx,fdomain,bcscomp,0,ncomp,bcs,bcr);
+	    amrex::setBC(sbx,cdomain,bcscomp,0,ncomp,bcs,bcr);
 
             pre_interp(sfab, sfab.box(), 0, ncomp);
 
@@ -948,7 +949,8 @@ InterpFromCoarseLevel (Array<MF*, AMREX_SPACEDIM> const& mf, IntVect const& ngho
             {
                 Vector<BCRec> bcr_d(ncomp);
 
-                amrex::setBC(dfab[d]->box(), amrex::convert(fdomain, dfab[d]->box().ixType()),
+                amrex::setBC(sfab[d]->box(),
+			     amrex::convert(cgeom.Domain(), sfab[d]->box().ixType()),
                              bcscomp,0,ncomp,bcs[d],bcr_d);
 
                 for (int n=0; n<ncomp; ++n)

--- a/Src/AmrCore/AMReX_FillPatchUtil_I.H
+++ b/Src/AmrCore/AMReX_FillPatchUtil_I.H
@@ -345,7 +345,7 @@ namespace {
 
                 MF mf_fine_patch = make_mf_fine_patch<MF>(fpc, ncomp);
 
-                Box const& fdomain = amrex::convert(fgeom.Domain(),mf.ixType());
+                Box const& cdomain = amrex::convert(cgeom.Domain(),mf.ixType());
                 int idummy=0;
 #ifdef AMREX_USE_OMP
                 bool cc = fpc.ba_crse_patch.ixType().cellCentered();
@@ -358,10 +358,11 @@ namespace {
                         FAB& sfab = mf_crse_patch[mfi];
                         FAB& dfab = mf_fine_patch[mfi];
                         const Box& dbx = dfab.box();
+			const Box& sbx = sfab.box();
 
-                        amrex::setBC(dbx,fdomain,bcscomp,0,ncomp,bcs,bcr);
+                        amrex::setBC(sbx,cdomain,bcscomp,0,ncomp,bcs,bcr);
 
-                        pre_interp(sfab, sfab.box(), 0, ncomp);
+                        pre_interp(sfab, sbx, 0, ncomp);
 
                         mapper->interp(sfab, 0, dfab, 0, ncomp, dbx, ratio,
                                        cgeom, fgeom, bcr, dcomp, idummy, RunOn::Gpu);


### PR DESCRIPTION
…ey are only used on the coarse level (when computing slopes).

## Summary
This corrects certain cases where a level of refinement is very close to, but not actually touching an ext_dir or hoextrap boundary.

## Additional background

## Checklist

The proposed changes:
- [ x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
