### PR TITLE
Refinement Ratio of 4 Support in Nodal Solver

### DIFF
--- a/Src/Base/AMReX_Box.H
+++ b/Src/Base/AMReX_Box.H
@@ -259,6 +259,21 @@ public:
 	BL_ASSERT(sameType(b));
 	return b.smallend.allGT(smallend) && b.bigend.allLT(bigend);
     }
+
+    //! Returns true if argument is strictly contained within Box.
+    AMREX_GPU_HOST_DEVICE
+#if (AMREX_SPACEDIM == 1)
+    bool strictly_contains (int i, int, int) const noexcept {
+#elif (AMREX_SPACEDIM == 2)
+    bool strictly_contains (int i, int j, int) const noexcept {
+#else
+    bool strictly_contains (int i, int j, int k) const noexcept {
+#endif
+        return AMREX_D_TERM(i > smallend[0] && i < bigend[0],
+                         && j > smallend[1] && j < bigend[1],
+                         && k > smallend[2] && k < bigend[2]);
+    }
+
     /**
     * \brief Returns true if Boxes have non-null intersections.
     * It is an error if the Boxes have different types.

--- a/Src/LinearSolvers/MLMG/AMReX_MLLinOp.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLLinOp.cpp
@@ -567,6 +567,12 @@ MLLinOp::defineGrids (const Vector<Geometry>& a_geom,
         mg_coarsen_ratio_vec.push_back(fine_domain.length()/crse_domain.length());
     }
 
+    for (int amrlev = 0; amrlev < m_num_amr_levels; ++amrlev) {
+        if (AMRRefRatio(amrlev) == 4 && mg_coarsen_ratio_vec.size() == 0) {
+            mg_coarsen_ratio_vec.push_back(IntVect(2));
+        }
+    }
+
     if (agged)
     {
         makeAgglomeratedDMap(m_grids[0], m_dmap[0]);

--- a/Src/LinearSolvers/MLMG/AMReX_MLMG.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLMG.cpp
@@ -70,7 +70,7 @@ MLMG::solve (const Vector<MultiFab*>& a_sol, const Vector<MultiFab const*>& a_rh
             linop.setMaxOrder(std::min(3,mo));  // maxorder = 4 not supported
         }
     }
-    
+
     bool is_nsolve = linop.m_parent;
 
     auto solve_start_time = amrex::second();
@@ -87,8 +87,8 @@ MLMG::solve (const Vector<MultiFab*>& a_sol, const Vector<MultiFab const*>& a_rh
     int ncomp = linop.getNComp();
 
     bool local = true;
-    Real resnorm0 = MLResNormInf(finest_amr_lev, local); 
-    Real rhsnorm0 = MLRhsNormInf(local); 
+    Real resnorm0 = MLResNormInf(finest_amr_lev, local);
+    Real rhsnorm0 = MLRhsNormInf(local);
     if (!is_nsolve) {
         ParallelAllReduce::Max<Real>({resnorm0, rhsnorm0}, ParallelContext::CommunicatorSub());
 
@@ -169,7 +169,7 @@ MLMG::solve (const Vector<MultiFab*>& a_sol, const Vector<MultiFab const*>& a_rh
                 }
                 break;
             } else {
-              if (composite_norminf > Real(1.e20)*max_norm) 
+              if (composite_norminf > Real(1.e20)*max_norm)
               {
                   if (verbose > 0) {
                       amrex::Print() << "MLMG: Failing to converge after " << iter+1 << " iterations."
@@ -269,7 +269,7 @@ void MLMG::oneIter (int iter)
         MultiFab::Add(*sol[alev], *cor[alev][0], 0, 0, ncomp, nghost);
 
         if (alev != finest_amr_lev) {
-	  MultiFab::Add(*cor_hold[alev][0], *cor[alev][0], 0, 0, ncomp, nghost);
+            MultiFab::Add(*cor_hold[alev][0], *cor[alev][0], 0, 0, ncomp, nghost);
         }
 
         // Update fine AMR level correction
@@ -280,7 +280,7 @@ void MLMG::oneIter (int iter)
         MultiFab::Add(*sol[alev], *cor[alev][0], 0, 0, ncomp, nghost);
 
         if (alev != finest_amr_lev) {
-	  MultiFab::Add(*cor[alev][0], *cor_hold[alev][0], 0, 0, ncomp, nghost);
+            MultiFab::Add(*cor[alev][0], *cor_hold[alev][0], 0, 0, ncomp, nghost);
         }
     }
 
@@ -340,7 +340,7 @@ MLMG::computeResWithCrseSolFineCor (int calev, int falev)
     MultiFab& fine_cor = *cor[falev][0];
     MultiFab& fine_res = res[falev][0];
     MultiFab& fine_rescor = rescor[falev][0];
-    
+
     const MultiFab* crse_bcdata = nullptr;
     if (calev > 0) {
         crse_bcdata = sol[calev-1];
@@ -411,7 +411,7 @@ std::string make_str (Ts... xs) {
 
 }
 
-// in   : Residual (res) 
+// in   : Residual (res)
 // out  : Correction (cor) from bottom to this function's local top
 void
 MLMG::mgVcycle (int amrlev, int mglev_top)
@@ -469,7 +469,7 @@ MLMG::mgVcycle (int amrlev, int mglev_top)
         {
             computeResOfCorrection(amrlev, mglev_bottom);
             Real norm = rescor[amrlev][mglev_bottom].norm0();
-            
+
             amrex::Print() << "AT LEVEL "  << amrlev << " " << mglev_bottom
                            << "   UP: Norm after  bottom " << norm << "\n";
         }
@@ -479,7 +479,7 @@ MLMG::mgVcycle (int amrlev, int mglev_top)
         if (verbose >= 4)
         {
             Real norm = res[amrlev][mglev_bottom].norm0();
-            amrex::Print() << "AT LEVEL "  << amrlev << " " << mglev_bottom 
+            amrex::Print() << "AT LEVEL "  << amrlev << " " << mglev_bottom
                            << "       Norm before smooth " << norm << "\n";
         }
         cor[amrlev][mglev_bottom]->setVal(0.0);
@@ -491,9 +491,9 @@ MLMG::mgVcycle (int amrlev, int mglev_top)
         }
         if (verbose >= 4)
         {
-	    computeResOfCorrection(amrlev, mglev_bottom);
+            computeResOfCorrection(amrlev, mglev_bottom);
             Real norm = rescor[amrlev][mglev_bottom].norm0();
-            amrex::Print() << "AT LEVEL "  << amrlev  << " " << mglev_bottom 
+            amrex::Print() << "AT LEVEL "  << amrlev  << " " << mglev_bottom
                            << "       Norm after  smooth " << norm << "\n";
         }
     }
@@ -507,7 +507,7 @@ MLMG::mgVcycle (int amrlev, int mglev_top)
         addInterpCorrection(amrlev, mglev);
         if (verbose >= 4)
         {
-	    computeResOfCorrection(amrlev, mglev);
+            computeResOfCorrection(amrlev, mglev);
             Real norm = rescor[amrlev][mglev].norm0();
             amrex::Print() << "AT LEVEL "  << amrlev << " " << mglev
                            << "   UP: Norm before smooth " << norm << "\n";
@@ -516,11 +516,11 @@ MLMG::mgVcycle (int amrlev, int mglev_top)
             linop.smooth(amrlev, mglev, *cor[amrlev][mglev], res[amrlev][mglev]);
         }
 
-	if (cf_strategy == CFStrategy::ghostnodes) computeResOfCorrection(amrlev, mglev);
+        if (cf_strategy == CFStrategy::ghostnodes) computeResOfCorrection(amrlev, mglev);
 
         if (verbose >= 4)
         {
-	    computeResOfCorrection(amrlev, mglev);
+            computeResOfCorrection(amrlev, mglev);
             Real norm = rescor[amrlev][mglev].norm0();
             amrex::Print() << "AT LEVEL "  << amrlev << " " << mglev
                            << "   UP: Norm after  smooth " << norm << "\n";
@@ -593,7 +593,7 @@ MLMG::interpCorrection (int alev)
 
     int ng_src = 0;
     int ng_dst = linop.isCellCentered() ? 1 : 0;
-    if (cf_strategy == CFStrategy::ghostnodes) 
+    if (cf_strategy == CFStrategy::ghostnodes)
     {
         ng_src = nghost;
         ng_dst = nghost;
@@ -689,7 +689,7 @@ MLMG::interpCorrection (int alev)
     }
     else
     {
-        AMREX_ALWAYS_ASSERT(amrrr == 2);
+        AMREX_ALWAYS_ASSERT(amrrr == 2 || amrrr == 4);
 #ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
@@ -700,10 +700,17 @@ MLMG::interpCorrection (int alev)
             Array4<Real> const& ffab = fine_cor.array(mfi);
             Array4<Real const> const& cfab = cfine.const_array(mfi);
 
-            AMREX_HOST_DEVICE_FOR_4D ( fbx, ncomp, i, j, k, n,
-            {
-                mlmg_lin_nd_interp(i,j,k,n,ffab,cfab);
-            });
+            if (amrrr == 2) {
+                AMREX_HOST_DEVICE_FOR_4D ( fbx, ncomp, i, j, k, n,
+                {
+                    mlmg_lin_nd_interp_r2(i,j,k,n,ffab,cfab);
+                });
+            } else {
+                AMREX_HOST_DEVICE_FOR_4D ( fbx, ncomp, i, j, k, n,
+                {
+                    mlmg_lin_nd_interp_r4(i,j,k,n,ffab,cfab);
+                });
+            }
         }
     }
 }
@@ -728,7 +735,7 @@ MLMG::interpCorrection (int alev, int mglev)
 
     MultiFab cfine;
     const MultiFab* cmf;
-    
+
     if (amrex::isMFIterSafe(crse_cor, fine_cor))
     {
         crse_cor.FillBoundary(crse_geom.periodicity());
@@ -812,7 +819,7 @@ MLMG::interpCorrection (int alev, int mglev)
 
             AMREX_HOST_DEVICE_FOR_4D ( fbx, ncomp, i, j, k, n,
             {
-                mlmg_lin_nd_interp(i,j,k,n,ffab,cfab);
+                mlmg_lin_nd_interp_r2(i,j,k,n,ffab,cfab);
             });
         }
     }
@@ -959,7 +966,7 @@ MLMG::actualBottomSolve ()
                 cg_type = MLCGSolver::Type::BiCGStab;
             }
             int ret = bottomSolveWithCG(x, *bottom_b, cg_type);
-            // If the MLMG solve failed then set the correction to zero 
+            // If the MLMG solve failed then set the correction to zero
             if (ret != 0) {
                 cor[amrlev][mglev]->setVal(0.0);
                 if (bottom_solver == BottomSolver::cgbicg ||
@@ -1036,12 +1043,12 @@ MLMG::ResNormInf (int alev, bool local)
 #endif
     for (int n = 0; n < ncomp; n++)
     {
-	Real newnorm = 0.0;
-	if (fine_mask[alev]) {
+        Real newnorm = 0.0;
+        if (fine_mask[alev]) {
             newnorm = pmf->norm0(*fine_mask[alev],n,0,true);
-	} else {
+        } else {
             newnorm = pmf->norm0(n,0,true);
-	}
+        }
         norm = std::max(norm, newnorm);
     }
     if (!local) ParallelAllReduce::Max(norm, ParallelContext::CommunicatorSub());
@@ -1109,7 +1116,7 @@ MLMG::buildFineMask ()
 
     fine_mask.clear();
     fine_mask.resize(namrlevs);
-    
+
     const auto& amrrr = linop.AMRRefRatio();
     for (int alev = 0; alev < finest_amr_lev; ++alev)
     {
@@ -1152,8 +1159,8 @@ MLMG::prepareForSolve (const Vector<MultiFab*>& a_sol, const Vector<MultiFab con
 #endif
 
 #ifdef AMREX_USE_PETSC
-        petsc_solver.reset(); 
-        petsc_bndry.reset(); 
+        petsc_solver.reset();
+        petsc_bndry.reset();
 #endif
     }
 
@@ -1182,7 +1189,7 @@ MLMG::prepareForSolve (const Vector<MultiFab*>& a_sol, const Vector<MultiFab con
             sol[alev] = sol_raii[alev].get();
         }
     }
-    
+
     rhs.resize(namrlevs);
     for (int alev = 0; alev < namrlevs; ++alev)
     {
@@ -1210,7 +1217,7 @@ MLMG::prepareForSolve (const Vector<MultiFab*>& a_sol, const Vector<MultiFab con
     {
         linop.averageDownSolutionRHS(falev-1, *sol[falev-1], rhs[falev-1], *sol[falev], rhs[falev]);
     }
-    
+
     // enforce solvability if appropriate
     if (linop.isSingular(0) && linop.getEnforceSingularSolvable())
     {
@@ -1329,7 +1336,7 @@ MLMG::prepareForNSolve ()
     if (cf_strategy == CFStrategy::ghostnodes) nghost = linop.getNGrow();
 
     const BoxArray& ba = (*ns_linop).m_grids[0][0];
-    const DistributionMapping& dm =(*ns_linop).m_dmap[0][0]; 
+    const DistributionMapping& dm =(*ns_linop).m_dmap[0][0];
 
     int ng = 1;
     if (cf_strategy == CFStrategy::ghostnodes) ng = nghost;
@@ -1341,7 +1348,7 @@ MLMG::prepareForNSolve ()
     ns_rhs->setVal(0.0);
 
     ns_linop->setLevelBC(0, ns_sol.get());
-    
+
     ns_mlmg.reset(new MLMG(*ns_linop));
     ns_mlmg->setVerbose(0);
     ns_mlmg->setFixedIter(1);
@@ -1423,7 +1430,7 @@ MLMG::getFluxes (const Vector<MultiFab*> & a_flux, const Vector<MultiFab*>& a_so
 
     } else {
         linop.getFluxes(a_flux, a_sol);
-    } 
+    }
 }
 
 #ifdef AMREX_USE_EB
@@ -1461,7 +1468,7 @@ MLMG::compResidual (const Vector<MultiFab*>& a_res, const Vector<MultiFab*>& a_s
     int nghost = 0;
     if (cf_strategy == CFStrategy::ghostnodes) nghost = linop.getNGrow();
     amrex::ignore_unused(nghost);
-   
+
     sol.resize(namrlevs);
     sol_raii.resize(namrlevs);
     for (int alev = 0; alev < namrlevs; ++alev)
@@ -1493,7 +1500,7 @@ MLMG::compResidual (const Vector<MultiFab*>& a_res, const Vector<MultiFab*>& a_s
     } else if (linop.needsUpdate()) {
         linop.update();
     }
-    
+
     const auto& amrrr = linop.AMRRefRatio();
 
     for (int alev = finest_amr_lev; alev >= 0; --alev) {
@@ -1652,7 +1659,7 @@ MLMG::computeVolInv ()
     if (solve_called) return;
 
     if (linop.isCellCentered())
-    { 
+    {
         volinv.resize(namrlevs);
         for (int amrlev = 0; amrlev < namrlevs; ++amrlev) {
             volinv[amrlev].resize(linop.NMGLevels(amrlev));
@@ -1692,11 +1699,11 @@ MLMG::computeVolInv ()
         }
         else
         {
-            temp1 = volinv[0][0]; 
-            temp2 = volinv[0][mgbottom]; 
+            temp1 = volinv[0][0];
+            temp2 = volinv[0][mgbottom];
         }
-        volinv[0][0] = temp1; 
-        volinv[0][mgbottom] = temp2; 
+        volinv[0][0] = temp1;
+        volinv[0][mgbottom] = temp2;
 #endif
     }
 }
@@ -1716,7 +1723,7 @@ MLMG::makeSolvable ()
             const MultiFab& vfrac = factory->getVolFrac();
             for (int c = 0; c < ncomp; ++c) {
                 offset[c] = MultiFab::Dot(rhs[0], c, vfrac, 0, 1, 0, true) * volinv[0][0];
-            }            
+            }
         }
         else
 #endif
@@ -1728,7 +1735,7 @@ MLMG::makeSolvable ()
         ParallelAllReduce::Sum(offset.data(), ncomp, ParallelContext::CommunicatorSub());
         if (verbose >= 4) {
             for (int c = 0; c < ncomp; ++c) {
-                amrex::Print() << "MLMG: Subtracting " << offset[c] 
+                amrex::Print() << "MLMG: Subtracting " << offset[c]
                                << " from rhs component " << c << "\n";
             }
         }
@@ -1761,7 +1768,7 @@ void
 MLMG::makeSolvable (int amrlev, int mglev, MultiFab& mf)
 {
     const int ncomp = linop.getNComp();
-    
+
     if (linop.isCellCentered())
     {
         Vector<Real> offset(ncomp);
@@ -1772,7 +1779,7 @@ MLMG::makeSolvable (int amrlev, int mglev, MultiFab& mf)
             const MultiFab& vfrac = factory->getVolFrac();
             for (int c = 0; c < ncomp; ++c) {
                 offset[c] = MultiFab::Dot(mf, c, vfrac, 0, 1, 0, true) * volinv[amrlev][mglev];
-            }            
+            }
         }
         else
 #endif
@@ -1786,7 +1793,7 @@ MLMG::makeSolvable (int amrlev, int mglev, MultiFab& mf)
 
         if (verbose >= 4) {
             for (int c = 0; c < ncomp; ++c) {
-                amrex::Print() << "MLMG: Subtracting " << offset[c] 
+                amrex::Print() << "MLMG: Subtracting " << offset[c]
                                << " from mf component c = " << c << "\n";
             }
         }
@@ -1905,7 +1912,7 @@ MLMG::bottomSolveWithPETSc (MultiFab& x, const MultiFab& b)
     AMREX_ALWAYS_ASSERT_WITH_MESSAGE(ncomp == 1, "bottomSolveWithPETSc doesn't work with ncomp > 1");
 
     if(petsc_solver == nullptr)
-    { 
+    {
         petsc_solver = linop.makePETSc();
         petsc_solver->setVerbose(bottom_verbose);
 
@@ -1945,7 +1952,7 @@ MLMG::checkPoint (const Vector<MultiFab*>& a_sol, const Vector<MultiFab const*>&
         }
 
         HeaderFile.precision(17);
-        
+
         HeaderFile << linop.name() << "\n"
                    << "a_tol_rel = " << a_tol_rel << "\n"
                    << "a_tol_abs = " << a_tol_abs << "\n"
@@ -1965,7 +1972,7 @@ MLMG::checkPoint (const Vector<MultiFab*>& a_sol, const Vector<MultiFab const*>&
                    << "finest_amr_lev = " << finest_amr_lev << "\n"
                    << "linop_prepared = " << linop_prepared << "\n"
                    << "solve_called = " << solve_called << "\n";
-        
+
         for (int ilev = 0; ilev <= finest_amr_lev; ++ilev) {
             UtilCreateCleanDirectory(file_name+"/Level_"+std::to_string(ilev), false);
         }
@@ -1980,5 +1987,5 @@ MLMG::checkPoint (const Vector<MultiFab*>& a_sol, const Vector<MultiFab const*>&
 
     linop.checkPoint(file_name+"/linop");
 }
-    
+
 }

--- a/Src/LinearSolvers/MLMG/AMReX_MLMG_1D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLMG_1D_K.H
@@ -38,8 +38,8 @@ void mlmg_lin_cc_interp_r4 (Box const& bx, Array4<Real> const& ff,
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-void mlmg_lin_nd_interp (int i, int, int, int n, Array4<Real> const& fine,
-                         Array4<Real const> const& crse) noexcept
+void mlmg_lin_nd_interp_r2 (int i, int, int, int n, Array4<Real> const& fine,
+                            Array4<Real const> const& crse) noexcept
 {
     int ic = amrex::coarsen(i,2);
     bool i_is_odd = (ic*2 != i);
@@ -49,6 +49,20 @@ void mlmg_lin_nd_interp (int i, int, int, int n, Array4<Real> const& fine,
     } else {
         // Fine node coincident with coarse node
         fine(i,0,0,n) = crse(ic,0,0,n);
+    }
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void mlmg_lin_nd_interp_r4 (int i, int, int, int n, Array4<Real> const& fine,
+                            Array4<Real const> const& crse) noexcept
+{
+    int ic = amrex::coarsen(i,4);
+    bool i_injection = (ic*4 == i);
+    if (i_injection) {
+        fine(i,0,0,n) = crse(ic,0,0,n);
+    } else {
+        fine(i,0,0,n) = Real(0.25)*(crse(ic  ,0,0,n)*Real(4*(ic+1)-i)
+                                  + crse(ic+1,0,0,n)*Real(i-4*ic));
     }
 }
 

--- a/Src/LinearSolvers/MLMG/AMReX_MLMG_2D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLMG_2D_K.H
@@ -75,8 +75,8 @@ void mlmg_eb_cc_interp_r (Box const& bx, Array4<Real> const& ff, Array4<Real con
 #endif
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-void mlmg_lin_nd_interp (int i, int j, int, int n, Array4<Real> const& fine,
-                         Array4<Real const> const& crse) noexcept
+void mlmg_lin_nd_interp_r2 (int i, int j, int, int n, Array4<Real> const& fine,
+                            Array4<Real const> const& crse) noexcept
 {
     int ic = amrex::coarsen(i,2);
     int jc = amrex::coarsen(j,2);
@@ -96,6 +96,41 @@ void mlmg_lin_nd_interp (int i, int j, int, int n, Array4<Real> const& fine,
         // Fine node coincident with coarse node
         fine(i,j,0,n) = crse(ic,jc,0,n);
     }
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void mlmg_lin_nd_interp_r4 (int i, int j, int, int n, Array4<Real> const& fine,
+                            Array4<Real const> const& crse) noexcept
+{
+    int ic = amrex::coarsen(i,4);
+    int jc = amrex::coarsen(j,4);
+    bool i_injection = (ic*4 == i);
+    bool j_injection = (jc*4 == j);
+
+#define I_LO (4*(ic+1)-i)
+#define J_LO (4*(jc+1)-j)
+#define I_HI (i-4*ic)
+#define J_HI (j-4*jc)
+
+    if (i_injection && j_injection) {
+        fine(i,j,0,n) = crse(ic,jc,0,n);
+    } else if (i_injection) {
+        fine(i,j,0,n) = Real(0.25)*(crse(ic,jc  ,0,n)*Real(J_LO)
+                                  + crse(ic,jc+1,0,n)*Real(J_HI));
+    } else if (j_injection) {
+        fine(i,j,0,n) = Real(0.25)*(crse(ic  ,jc,0,n)*Real(I_LO)
+                                  + crse(ic+1,jc,0,n)*Real(I_HI));
+    } else {
+        fine(i,j,0,n) = Real(0.0625)*(crse(ic  ,jc  ,0,n)*Real(I_LO*J_LO)
+                                    + crse(ic+1,jc  ,0,n)*Real(I_HI*J_LO)
+                                    + crse(ic  ,jc+1,0,n)*Real(I_LO*J_HI)
+                                    + crse(ic+1,jc+1,0,n)*Real(I_HI*J_HI));
+    }
+
+#undef I_LO
+#undef J_LO
+#undef I_HI
+#undef J_HI
 }
 
 }

--- a/Src/LinearSolvers/MLMG/AMReX_MLMG_3D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLMG_3D_K.H
@@ -88,8 +88,8 @@ void mlmg_eb_cc_interp_r (Box const& bx, Array4<Real> const& ff, Array4<Real con
 #endif
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-void mlmg_lin_nd_interp (int i, int j, int k, int n, Array4<Real> const& fine,
-                         Array4<Real const> const& crse) noexcept
+void mlmg_lin_nd_interp_r2 (int i, int j, int k, int n, Array4<Real> const& fine,
+                            Array4<Real const> const& crse) noexcept
 {
     int ic = amrex::coarsen(i,2);
     int jc = amrex::coarsen(j,2);
@@ -128,6 +128,83 @@ void mlmg_lin_nd_interp (int i, int j, int k, int n, Array4<Real> const& fine,
         // Node coincident with coarse node
         fine(i,j,k,n) = crse(ic,jc,kc,n);
     }
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void mlmg_lin_nd_interp_r4 (int i, int j, int k, int n, Array4<Real> const& fine,
+                            Array4<Real const> const& crse) noexcept
+{
+    int ic = amrex::coarsen(i,4);
+    int jc = amrex::coarsen(j,4);
+    int kc = amrex::coarsen(k,4);
+    bool i_injection = (ic*4 == i);
+    bool j_injection = (jc*4 == j);
+    bool k_injection = (kc*4 == k);
+
+#define I_LO (4*(ic+1)-i)
+#define J_LO (4*(jc+1)-j)
+#define K_LO (4*(kc+1)-k)
+#define I_HI (i-4*ic)
+#define J_HI (j-4*jc)
+#define K_HI (k-4*kc)
+
+    if (i_injection && j_injection && k_injection)
+    {
+        fine(i,j,k,n) = crse(ic,jc,kc,n);
+    }
+    else if (i_injection && j_injection)
+    {
+        fine(i,j,k,n) = Real(0.25)*(crse(ic,jc,kc  ,n)*Real(K_LO)
+                                  + crse(ic,jc,kc+1,n)*Real(K_HI));
+    }
+    else if (i_injection && k_injection)
+    {
+        fine(i,j,k,n) = Real(0.25)*(crse(ic,jc  ,kc,n)*Real(J_LO)
+                                  + crse(ic,jc+1,kc,n)*Real(J_HI));
+    }
+    else if (j_injection && k_injection)
+    {
+        fine(i,j,k,n) = Real(0.25)*(crse(ic  ,jc,kc,n)*Real(I_LO)
+                                  + crse(ic+1,jc,kc,n)*Real(I_HI));
+    }
+    else if (i_injection)
+    {
+        fine(i,j,k,n) = Real(0.0625)*(crse(ic,jc  ,kc  ,n)*Real(J_LO*K_LO)
+                                    + crse(ic,jc+1,kc  ,n)*Real(J_HI*K_LO)
+                                    + crse(ic,jc  ,kc+1,n)*Real(J_LO*K_HI)
+                                    + crse(ic,jc+1,kc+1,n)*Real(J_HI*K_HI));
+    }
+    else if (j_injection)
+    {
+        fine(i,j,k,n) = Real(0.0625)*(crse(ic  ,jc,kc  ,n)*Real(I_LO*K_LO)
+                                    + crse(ic+1,jc,kc  ,n)*Real(I_HI*K_LO)
+                                    + crse(ic  ,jc,kc+1,n)*Real(I_LO*K_HI)
+                                    + crse(ic+1,jc,kc+1,n)*Real(I_HI*K_HI));
+
+    } else if (k_injection) {
+        fine(i,j,k,n) = Real(0.0625)*(crse(ic  ,jc  ,kc,n)*Real(I_LO*J_LO)
+                                    + crse(ic+1,jc  ,kc,n)*Real(I_HI*J_LO)
+                                    + crse(ic  ,jc+1,kc,n)*Real(I_LO*J_HI)
+                                    + crse(ic+1,jc+1,kc,n)*Real(I_HI*J_HI));
+    }
+    else
+    {
+        fine(i,j,k,n) = Real(0.015625)*(crse(ic  ,jc  ,kc  ,n)*Real(I_LO*J_LO*K_LO)
+                                      + crse(ic+1,jc  ,kc  ,n)*Real(I_HI*J_LO*K_LO)
+                                      + crse(ic  ,jc+1,kc  ,n)*Real(I_LO*J_HI*K_LO)
+                                      + crse(ic+1,jc+1,kc  ,n)*Real(I_HI*J_HI*K_LO)
+                                      + crse(ic  ,jc  ,kc+1,n)*Real(I_LO*J_LO*K_HI)
+                                      + crse(ic+1,jc  ,kc+1,n)*Real(I_HI*J_LO*K_HI)
+                                      + crse(ic  ,jc+1,kc+1,n)*Real(I_LO*J_HI*K_HI)
+                                      + crse(ic+1,jc+1,kc+1,n)*Real(I_HI*J_HI*K_HI));
+    }
+
+#undef I_LO
+#undef J_LO
+#undef K_LO
+#undef I_HI
+#undef J_HI
+#undef K_HI
 }
 
 }

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLap_1D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLap_1D_K.H
@@ -138,6 +138,15 @@ void mlndlap_restriction (int /*i*/, int /*j*/, int /*k*/, Array4<Real> const&,
                           Array4<Real const> const&, Array4<int const> const&) noexcept
 {}
 
+template <int rr>
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void mlndlap_restriction (int /*i*/, int /*j*/, int /*k*/, Array4<Real> const&,
+                          Array4<Real const> const&, Array4<int const> const&,
+                          Box const&,
+                          GpuArray<LinOpBCType, AMREX_SPACEDIM> const&,
+                          GpuArray<LinOpBCType, AMREX_SPACEDIM> const&) noexcept
+{}
+
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 void mlndlap_semi_restriction (int /*i*/, int /*j*/, int /*k*/, Array4<Real> const&,
                           Array4<Real const> const&, Array4<int const> const&, int) noexcept
@@ -191,21 +200,7 @@ void mlndlap_mknewu_c (int /*i*/, int /*j*/, int /*k*/, Array4<Real> const&, Arr
                      Real, GpuArray<Real,AMREX_SPACEDIM> const&) noexcept
 {}
 
-AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-void mlndlap_divu_compute_fine_contrib (int /*i*/, int /*j*/, int /*k*/, Box const&,
-                                        Array4<Real> const&, Array4<Real const> const&,
-                                        GpuArray<Real,AMREX_SPACEDIM> const&,
-                                        Box const&,
-                                        GpuArray<LinOpBCType, AMREX_SPACEDIM> const&,
-                                        GpuArray<LinOpBCType, AMREX_SPACEDIM> const&) noexcept
-{}
-
-AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-void mlndlap_divu_add_fine_contrib (int /*i*/, int /*j*/, int /*k*/, Box const&,
-                                    Array4<Real> const&, Array4<Real const> const&,
-                                    Array4<int const> const&) noexcept
-{}
-
+template <int rr>
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 void mlndlap_rhcc_fine_contrib (int /*i*/, int /*j*/, int /*k*/, Box const&,
                                 Array4<Real> const&, Array4<Real const> const&,
@@ -229,17 +224,6 @@ void mlndlap_crse_resid (int /*i*/, int /*j*/, int /*k*/, Array4<Real> const&,
                          Box const&, GpuArray<LinOpBCType,AMREX_SPACEDIM> const&,
                          GpuArray<LinOpBCType,AMREX_SPACEDIM> const&,
                          bool) noexcept
-{}
-
-AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-void mlndlap_res_fine_Ax (int /*i*/, int /*j*/, int /*k*/, Box const&, Array4<Real> const&,
-                          Array4<Real const> const&, Array4<Real const> const&,
-                          GpuArray<Real,AMREX_SPACEDIM> const&) noexcept
-{}
-
-AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-void mlndlap_res_fine_contrib (int /*i*/, int /*j*/, int /*k*/, Array4<Real> const&,
-                               Array4<Real const> const&, Array4<int const> const&) noexcept
 {}
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLap_2D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLap_2D_K.H
@@ -818,6 +818,47 @@ void mlndlap_restriction (int i, int j, int k, Array4<Real> const& crse,
     }
 }
 
+template <int rr>
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void mlndlap_restriction (int i, int j, int k, Array4<Real> const& crse,
+                          Array4<Real const> const& fine, Array4<int const> const& msk,
+                          Box const& fdom,
+                          GpuArray<LinOpBCType, AMREX_SPACEDIM> const& bclo,
+                          GpuArray<LinOpBCType, AMREX_SPACEDIM> const& bchi) noexcept
+{
+    const int ii = i*rr;
+    const int jj = j*rr;
+    if (msk(ii,jj,0)) {
+        crse(i,j,k) = Real(0.0);
+    } else {
+        const auto ndlo = amrex::lbound(fdom);
+        const auto ndhi = amrex::ubound(fdom);
+        Real tmp = Real(0.0);
+        for (int joff = -rr+1; joff <= rr-1; ++joff) {
+            Real wy = rr - amrex::Math::abs(joff);
+            for (int ioff = -rr+1; ioff <= rr-1; ++ioff) {
+                Real wx = rr - amrex::Math::abs(ioff);
+                int itmp = ii + ioff;
+                int jtmp = jj + joff;
+                if ((itmp < ndlo.x && (bclo[0] == LinOpBCType::Neumann ||
+                                       bclo[0] == LinOpBCType::inflow)) ||
+                    (itmp > ndhi.x && (bchi[0] == LinOpBCType::Neumann ||
+                                       bchi[0] == LinOpBCType::inflow))) {
+                    itmp = ii - ioff;
+                }
+                if ((jtmp < ndlo.y && (bclo[1] == LinOpBCType::Neumann ||
+                                       bclo[1] == LinOpBCType::inflow)) ||
+                    (jtmp > ndhi.y && (bchi[1] == LinOpBCType::Neumann ||
+                                       bchi[1] == LinOpBCType::inflow))) {
+                    jtmp = jj - joff;
+                }
+                tmp += wx*wy*fine(itmp,jtmp,0);
+            }
+        }
+        crse(i,j,k) = tmp*(Real(1.0)/Real(rr*rr*rr*rr));
+    }
+}
+
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 void mlndlap_semi_restriction (int i, int j, int k, Array4<Real> const& crse,
                           Array4<Real const> const& fine, Array4<int const> const& msk, int idir) noexcept
@@ -1109,92 +1150,123 @@ void mlndlap_mknewu_c (int i, int j, int k, Array4<Real> const& u, Array4<Real c
     }
 }
 
-AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-void mlndlap_divu_compute_fine_contrib (int i, int j, int, Box const& fvbx,
-                                        Array4<Real> const& frh, Array4<Real const> const& vel,
-                                        GpuArray<Real,AMREX_SPACEDIM> const& dxinv,
-                                        Box const& nodal_domain,
-                                        GpuArray<LinOpBCType, AMREX_SPACEDIM> const& bclo,
-                                        GpuArray<LinOpBCType, AMREX_SPACEDIM> const& bchi,
-                                        bool is_rz) noexcept
-{
-    const auto domlo = amrex::lbound(nodal_domain);
-    const auto domhi = amrex::ubound(nodal_domain);
-
-    IntVect iv(i,j);
-    if (fvbx.contains(iv) && !fvbx.strictly_contains(iv))
+namespace {
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    Real mlndlap_sum_Df (int ii, int jj, Real facx, Real facy,
+                         Array4<Real const> const& vel, Box const& velbx, bool is_rz) noexcept
     {
-        Real zero_ilo = Real(1.0);
-        Real zero_ihi = Real(1.0);
-        Real zero_jlo = Real(1.0);
-        Real zero_jhi = Real(1.0);
+        Real fm = is_rz ? facy / static_cast<Real>(6*ii-3) : Real(0.0);
+        Real fp = is_rz ? facy / static_cast<Real>(6*ii+3) : Real(0.0);
 
-        // The nodal divergence operator should not see the tangential velocity
-        //     at an inflow face
-        if ((bclo[0] == LinOpBCType::Neumann || bclo[0] == LinOpBCType::inflow)
-            && i == domlo.x) zero_ilo = Real(0.0);
-        if ((bchi[0] == LinOpBCType::Neumann || bchi[0] == LinOpBCType::inflow)
-            && i == domhi.x) zero_ihi = Real(0.0);
-        if ((bclo[1] == LinOpBCType::Neumann || bclo[1] == LinOpBCType::inflow)
-            && j == domlo.y) zero_jlo = Real(0.0);
-        if ((bchi[1] == LinOpBCType::Neumann || bchi[1] == LinOpBCType::inflow)
-            && j == domhi.y) zero_jhi = Real(0.0);
-
-        Real facx = Real(0.5)*dxinv[0];
-        Real facy = Real(0.5)*dxinv[1];
-
-        frh(i,j,0) = facx*(-vel(i-1,j-1,0,0)*zero_jlo+vel(i,j-1,0,0)*zero_jlo-vel(i-1,j,0,0)*zero_jhi+vel(i,j,0,0)*zero_jhi)
-            +        facy*(-vel(i-1,j-1,0,1)*zero_ilo-vel(i,j-1,0,1)*zero_ihi+vel(i-1,j,0,1)*zero_ilo+vel(i,j,0,1)*zero_ihi);
-
-        if (is_rz) {
-            // Here we assume we can't have inflow in the radial direction
-            Real fm = facy / static_cast<Real>(6*i-3);
-            Real fp = facy / static_cast<Real>(6*i+3);
-            frh(i,j,0) += fm*(vel(i-1,j,0,1)-vel(i-1,j-1,0,1))
-                        - fp*(vel(i  ,j,0,1)-vel(i  ,j-1,0,1));
+        Real Df = Real(0.0);
+        if (velbx.contains(ii-1,jj-1,0)) {
+            Df += -facx*vel(ii-1,jj-1,0,0) - (facy+fm)*vel(ii-1,jj-1,0,1);
         }
+        if (velbx.contains(ii,jj-1,0)) {
+            Df += facx*vel(ii,jj-1,0,0) - (facy-fp)*vel(ii,jj-1,0,1);
+        }
+        if (velbx.contains(ii-1,jj,0)) {
+            Df += -facx*vel(ii-1,jj,0,0) + (facy+fm)*vel(ii-1,jj,0,1);
+        }
+        if (velbx.contains(ii,jj,0)) {
+            Df += facx*vel(ii,jj,0,0) + (facy-fp)*vel(ii,jj,0,1);
+        }
+        return Df;
     }
 }
 
+template <int rr>
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-void mlndlap_divu_add_fine_contrib (int i, int j, int /*k*/, Box const& fvbx,
-                                    Array4<Real> const& rhs, Array4<Real const> const& frh,
-                                    Array4<int const> const& msk) noexcept
+void mlndlap_divu_fine_contrib (int i, int j, int /*k*/, Box const& fvbx, Box const& velbx,
+                                Array4<Real> const& rhs, Array4<Real const> const& vel,
+                                Array4<Real const> const& frhs, Array4<int const> const& msk,
+                                GpuArray<Real,AMREX_SPACEDIM> const& dxinv, bool is_rz) noexcept
 {
-    constexpr Real rfd = Real(0.25);
-    constexpr Real chip = Real(0.5);
-    constexpr Real chip2 = Real(0.25);
+    const int ii = rr*i;
+    const int jj = rr*j;
+    if (msk(ii,jj,0)) {
+        const Real facx = Real(0.5)*dxinv[0];
+        const Real facy = Real(0.5)*dxinv[1];
 
-    int ii = 2*i;
-    int jj = 2*j;
-    IntVect iv(ii,jj);
-    if (fvbx.contains(iv) && !fvbx.strictly_contains(iv) && msk(ii,jj,0))
-    {
-        rhs(i,j,0) +=
-            rfd*(frh(ii,jj,0)
-                 + chip*(frh(ii-1,jj,0)+frh(ii+1,jj,0)+frh(ii,jj-1,0)+frh(ii,jj+1,0))
-                 + chip2*(frh(ii-1,jj-1,0)+frh(ii+1,jj-1,0)+frh(ii-1,jj+1,0)+frh(ii+1,jj+1,0)));
+        Real Df = Real(0.0);
+
+        const int ilo = amrex::max(ii-rr+1, fvbx.smallEnd(0));
+        const int ihi = amrex::min(ii+rr-1, fvbx.bigEnd  (0));
+        const int jlo = amrex::max(jj-rr+1, fvbx.smallEnd(1));
+        const int jhi = amrex::min(jj+rr-1, fvbx.bigEnd  (1));
+
+        for (int joff = jlo; joff <= jhi; ++joff) {
+        for (int ioff = ilo; ioff <= ihi; ++ioff) {
+            Real scale = static_cast<Real>((rr-amrex::Math::abs(ii-ioff)) *
+                                           (rr-amrex::Math::abs(jj-joff)));
+            if (fvbx.strictly_contains(ioff,joff,0)) {
+                Df += scale * frhs(ioff,joff,0);
+            } else {
+                Df += scale * mlndlap_sum_Df(ioff, joff, facx, facy, vel, velbx, is_rz);
+            }
+        }}
+
+        rhs(i,j,0) = Df * (Real(1.0)/static_cast<Real>(rr*rr*rr*rr));
+    } else {
+        rhs(i,j,0) = Real(0.0);
     }
 }
 
+template <int rr>
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-void mlndlap_rhcc_fine_contrib (int i, int j, int, Box const& fvbx,
+void mlndlap_rhcc_fine_contrib (int i, int j, int, Box const& ccbx,
                                 Array4<Real> const& rhs, Array4<Real const> const& cc,
                                 Array4<int const> const& msk) noexcept
 {
-    constexpr Real w1 = Real(9./64.);
-    constexpr Real w2 = Real(3./64.);
-    constexpr Real w3 = Real(1./64.);
+    const int ii = rr*i;
+    const int jj = rr*j;
+    if (msk(ii,jj,0)) {
+        Real tmp = Real(0.0);
 
-    int ii = 2*i;
-    int jj = 2*j;
-    IntVect iv(ii,jj);
-    if (fvbx.contains(iv) && !fvbx.strictly_contains(iv) && msk(ii,jj,0))
+        const int ilo = amrex::max(ii-rr  , ccbx.smallEnd(0));
+        const int ihi = amrex::min(ii+rr-1, ccbx.bigEnd  (0));
+        const int jlo = amrex::max(jj-rr  , ccbx.smallEnd(1));
+        const int jhi = amrex::min(jj+rr-1, ccbx.bigEnd  (1));
+
+        for (int joff = jlo; joff <= jhi; ++joff) {
+        for (int ioff = ilo; ioff <= ihi; ++ioff) {
+            Real scale = (Real(2.0)-amrex::Math::abs(static_cast<Real>(ioff)+Real(0.5)))
+                *        (Real(2.0)-amrex::Math::abs(static_cast<Real>(joff)+Real(0.5)));
+            tmp += cc(ioff,joff,0) * scale;
+        }}
+
+        rhs(i,j,0) += tmp * (Real(1.0)/Real(4*rr*rr));
+    }
+}
+
+namespace {
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    Real neumann_scale (int i, int j, Box const& nddom,
+                        GpuArray<LinOpBCType,AMREX_SPACEDIM> const& bclo,
+                        GpuArray<LinOpBCType,AMREX_SPACEDIM> const& bchi) noexcept
     {
-        rhs(i,j,0) += w1*(cc(ii-1,jj-1,0)+cc(ii  ,jj-1,0)+cc(ii-1,jj  ,0)+cc(ii  ,jj  ,0))
-                    + w2*(cc(ii-2,jj-1,0)+cc(ii+1,jj-1,0)+cc(ii-2,jj  ,0)+cc(ii+1,jj  ,0)
-                         +cc(ii-1,jj-2,0)+cc(ii  ,jj-2,0)+cc(ii-1,jj+1,0)+cc(ii  ,jj+1,0))
-                    + w3*(cc(ii-2,jj-2,0)+cc(ii+1,jj-2,0)+cc(ii-2,jj+1,0)+cc(ii+1,jj+1,0));
+        Real val = Real(1.0);
+
+        const auto ndlo = amrex::lbound(nddom);
+        const auto ndhi = amrex::ubound(nddom);
+
+        if (i == ndlo.x && ( bclo[0] == LinOpBCType::Neumann ||
+                             bclo[0] == LinOpBCType::inflow)) {
+            val *= Real(2.0);
+        } else if (i== ndhi.x && ( bchi[0] == LinOpBCType::Neumann ||
+                                   bchi[0] == LinOpBCType::inflow)) {
+            val *= Real(2.0);
+        }
+
+        if (j == ndlo.y && ( bclo[1] == LinOpBCType::Neumann ||
+                             bclo[1] == LinOpBCType::inflow)) {
+            val *= Real(2.0);
+        } else if (j == ndhi.y && ( bchi[1] == LinOpBCType::Neumann ||
+                                    bchi[1] == LinOpBCType::inflow)) {
+            val *= Real(2.0);
+        }
+
+        return val;
     }
 }
 
@@ -1204,54 +1276,50 @@ void mlndlap_divu_cf_contrib (int i, int j, int, Array4<Real> const& rhs,
                               Array4<Real const> const& rhcc, Array4<int const> const& dmsk,
                               Array4<int const> const& ndmsk, Array4<int const> const& ccmsk,
                               bool is_rz, GpuArray<Real,AMREX_SPACEDIM> const& dxinv,
-                              Box const& nddom, GpuArray<LinOpBCType,AMREX_SPACEDIM> const& bclo,
-                              GpuArray<LinOpBCType,AMREX_SPACEDIM> const& bchi,
-                              bool neumann_doubling) noexcept
+                              Box const& ccdom_p, Box const& veldom, Box const& nddom,
+                              GpuArray<LinOpBCType,AMREX_SPACEDIM> const& bclo,
+                              GpuArray<LinOpBCType,AMREX_SPACEDIM> const& bchi) noexcept
 {
     if (!dmsk(i,j,0) && ndmsk(i,j,0) == crse_fine_node) {
         Real facx = Real(0.5) * dxinv[0];
         Real facy = Real(0.5) * dxinv[1];
-        Real r = fc(i,j,0);
-        if (rhcc) {
-            r += Real(0.25)*( (Real(1.)-ccmsk(i-1,j-1,0)) * rhcc(i-1,j-1,0)
-                            + (Real(1.)-ccmsk(i  ,j-1,0)) * rhcc(i  ,j-1,0)
-                            + (Real(1.)-ccmsk(i-1,j  ,0)) * rhcc(i-1,j  ,0)
-                            + (Real(1.)-ccmsk(i  ,j  ,0)) * rhcc(i  ,j  ,0));
-        }
-        r += (Real(1.)-ccmsk(i-1,j-1,0)) * (-facx*vel(i-1,j-1,0,0) - facy*vel(i-1,j-1,0,1))
-           + (Real(1.)-ccmsk(i  ,j-1,0)) * ( facx*vel(i  ,j-1,0,0) - facy*vel(i  ,j-1,0,1))
-           + (Real(1.)-ccmsk(i-1,j  ,0)) * (-facx*vel(i-1,j  ,0,0) + facy*vel(i-1,j  ,0,1))
-           + (Real(1.)-ccmsk(i  ,j  ,0)) * ( facx*vel(i  ,j  ,0,0) + facy*vel(i  ,j  ,0,1));
-        if (is_rz) {
-            Real fm = facy / static_cast<Real>(6*i-3);
-            Real fp = facy / static_cast<Real>(6*i+3);
-            r += fm*((Real(1.)-ccmsk(i-1,j  ,0))*vel(i-1,j  ,0,1)
-                    -(Real(1.)-ccmsk(i-1,j-1,0))*vel(i-1,j-1,0,1))
-               - fp*((Real(1.)-ccmsk(i  ,j  ,0))*vel(i  ,j  ,0,1)
-                    -(Real(1.)-ccmsk(i  ,j-1,0))*vel(i  ,j-1,0,1));
-        }
+        Real tmp = fc(i,j,0);
 
-        if (neumann_doubling) {
-            const auto ndlo = amrex::lbound(nddom);
-            const auto ndhi = amrex::ubound(nddom);
-            if (i == ndlo.x && ( bclo[0] == LinOpBCType::Neumann ||
-                                  bclo[0] == LinOpBCType::inflow)) {
-                r *= Real(2.);
-            } else if (i== ndhi.x && ( bchi[0] == LinOpBCType::Neumann ||
-                                        bchi[0] == LinOpBCType::inflow)) {
-                r *= Real(2.);
-            }
+        Real fm = is_rz ? facy / static_cast<Real>(6*i-3) : Real(0.0);
+        Real fp = is_rz ? facy / static_cast<Real>(6*i+3) : Real(0.0);
 
-            if (j == ndlo.y && ( bclo[1] == LinOpBCType::Neumann ||
-                                  bclo[1] == LinOpBCType::inflow)) {
-                r *= Real(2.);
-            } else if (j == ndhi.y && ( bchi[1] == LinOpBCType::Neumann ||
-                                         bchi[1] == LinOpBCType::inflow)) {
-                r *= Real(2.);
+        // Where there is inflow, veldom there is bigger than ccdom_p by one cell.
+        // ccdom_p is cc domain grown at periodic boundaries.
+
+        if (ccmsk(i-1,j-1,0) == crse_cell && veldom.contains(i-1,j-1,0)) {
+            tmp += -facx*vel(i-1,j-1,0,0) - (facy+fm)*vel(i-1,j-1,0,1);
+            if (rhcc && ccdom_p.contains(i-1,j-1,0)) {
+                tmp += Real(0.25) * rhcc(i-1,j-1,0);
             }
         }
 
-        rhs(i,j,0) = r;
+        if (ccmsk(i,j-1,0) == crse_cell && veldom.contains(i,j-1,0)) {
+            tmp += facx*vel(i,j-1,0,0) - (facy-fp)*vel(i,j-1,0,1);
+            if (rhcc && ccdom_p.contains(i,j-1,0)) {
+                tmp += Real(0.25) * rhcc(i,j-1,0);
+            }
+        }
+
+        if (ccmsk(i-1,j,0) == crse_cell && veldom.contains(i-1,j,0)) {
+            tmp += -facx*vel(i-1,j,0,0) + (facy+fm)*vel(i-1,j,0,1);
+            if (rhcc && ccdom_p.contains(i-1,j,0)) {
+                tmp += Real(0.25) * rhcc(i-1,j,0);
+            }
+        }
+
+        if (ccmsk(i,j,0) == crse_cell && veldom.contains(i,j,0)) {
+            tmp += facx*vel(i,j,0,0) + (facy-fp)*vel(i,j,0,1);
+            if (rhcc && ccdom_p.contains(i,j,0)) {
+                tmp += Real(0.25) * rhcc(i,j,0);
+            }
+        }
+
+        rhs(i,j,0) = tmp * neumann_scale(i, j, nddom, bclo, bchi);
     }
 }
 
@@ -1305,55 +1373,120 @@ void mlndlap_crse_resid (int i, int j, int k, Array4<Real> const& resid,
 // sync residual
 //
 
-AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-void mlndlap_res_fine_Ax (int i, int j, int, Box const& fvbx, Array4<Real> const& Ax,
-                          Array4<Real const> const& x, Array4<Real const> const& sig,
-                          bool is_rz,
-                          GpuArray<Real,AMREX_SPACEDIM> const& dxinv) noexcept
-{
-    IntVect iv(i,j);
-    if (fvbx.contains(iv) && !fvbx.strictly_contains(iv)) {
-        Real facx = Real(1./6.)*dxinv[0]*dxinv[0];
-        Real facy = Real(1./6.)*dxinv[1]*dxinv[1];
-        Real fxy = facx + facy;
-        Real f2xmy = Real(2.)*facx - facy;
-        Real fmx2y = Real(2.)*facy - facx;
-        Ax(i,j,0) = x(i-1,j-1,0)*fxy*sig(i-1,j-1,0)
-            +       x(i+1,j-1,0)*fxy*sig(i  ,j-1,0)
-            +       x(i-1,j+1,0)*fxy*sig(i-1,j  ,0)
-            +       x(i+1,j+1,0)*fxy*sig(i  ,j  ,0)
-            +       x(i-1,j,0)*f2xmy*(sig(i-1,j-1,0)+sig(i-1,j  ,0))
-            +       x(i+1,j,0)*f2xmy*(sig(i  ,j-1,0)+sig(i  ,j  ,0))
-            +       x(i,j-1,0)*fmx2y*(sig(i-1,j-1,0)+sig(i  ,j-1,0))
-            +       x(i,j+1,0)*fmx2y*(sig(i-1,j  ,0)+sig(i  ,j  ,0))
-            +       x(i,j,0)*Real(-2.)*fxy*(sig(i-1,j-1,0)+sig(i,j-1,0)
-                                           +sig(i-1,j,0)+sig(i,j,0));
+namespace {
+    template <typename P, typename S>
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    Real mlndlap_sum_Ax (P && pred, S && sig, int i, int j, Real facx, Real facy,
+                         Array4<Real const> const& phi, bool is_rz) noexcept
+    {
+        Real Ax = Real(0.0);
+        Real fp = Real(0.0), fm = Real(0.0);
         if (is_rz) {
-            Real fp = facy / static_cast<Real>(2*i+1);
-            Real fm = facy / static_cast<Real>(2*i-1);
-            Ax(i,j,0) += (fm*sig(i-1,j  ,0)-fp*sig(i,j  ,0))*(x(i,j+1,0)-x(i,j,0))
-                       + (fm*sig(i-1,j-1,0)-fp*sig(i,j-1,0))*(x(i,j-1,0)-x(i,j,0));
+            fp = facy / static_cast<Real>(2*i+1);
+            fm = facy / static_cast<Real>(2*i-1);
+        }
+        if (pred(i-1,j-1)) {
+            Ax += sig(i-1,j-1,0)*(facx*(Real(2.)*(phi(i-1,j  ,0)-phi(i  ,j  ,0))
+                                           +     (phi(i-1,j-1,0)-phi(i  ,j-1,0)))
+                                + facy*(Real(2.)*(phi(i  ,j-1,0)-phi(i  ,j  ,0))
+                                           +     (phi(i-1,j-1,0)-phi(i-1,j  ,0)))
+                                + fm  *          (phi(i  ,j-1,0)-phi(i  ,j  ,0)));
+        }
+        if (pred(i,j-1)) {
+            Ax += sig(i,j-1,0)*(facx*(Real(2.)*(phi(i+1,j  ,0)-phi(i  ,j  ,0))
+                                         +     (phi(i+1,j-1,0)-phi(i  ,j-1,0)))
+                              + facy*(Real(2.)*(phi(i  ,j-1,0)-phi(i  ,j  ,0))
+                                         +     (phi(i+1,j-1,0)-phi(i+1,j  ,0)))
+                              - fp  *          (phi(i  ,j-1,0)-phi(i  ,j  ,0)));
+        }
+        if (pred(i-1,j)) {
+            Ax += sig(i-1,j,0)*(facx*(Real(2.)*(phi(i-1,j  ,0)-phi(i  ,j  ,0))
+                                         +     (phi(i-1,j+1,0)-phi(i  ,j+1,0)))
+                              + facy*(Real(2.)*(phi(i  ,j+1,0)-phi(i  ,j  ,0))
+                                         +     (phi(i-1,j+1,0)-phi(i-1,j  ,0)))
+                              + fm  *          (phi(i  ,j+1,0)-phi(i  ,j  ,0)));
+        }
+        if (pred(i,j)) {
+            Ax += sig(i,j,0)*(facx*(Real(2.)*(phi(i+1,j  ,0)-phi(i  ,j  ,0))
+                                      +      (phi(i+1,j+1,0)-phi(i  ,j+1,0)))
+                            + facy*(Real(2.)*(phi(i  ,j+1,0)-phi(i  ,j  ,0))
+                                      +      (phi(i+1,j+1,0)-phi(i+1,j  ,0)))
+                            - fp  *          (phi(i  ,j+1,0)-phi(i  ,j  ,0)));
+        }
+        return Ax;
+    }
+
+    template <int rr, typename S>
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    void mlndlap_Ax_fine_contrib_doit (S&& sig, int i, int j, Box const& ndbx, Box const& ccbx,
+                                       Array4<Real> const& f, Array4<Real const> const& res,
+                                       Array4<Real const> const& rhs,
+                                       Array4<Real const> const& phi,
+                                       Array4<int const> const& msk, bool is_rz,
+                                       GpuArray<Real,AMREX_SPACEDIM> const& dxinv) noexcept
+    {
+        const int ii = rr*i;
+        const int jj = rr*j;
+        if (msk(ii,jj,0)) {
+            Real facx = Real(1./6.)*dxinv[0]*dxinv[0];
+            Real facy = Real(1./6.)*dxinv[1]*dxinv[1];
+
+            auto is_fine = [&ccbx] (int ix, int iy) -> bool {
+                return ccbx.contains(ix,iy,0);
+            };
+
+            Real Df = Real(0.0);
+
+            const int ilo = amrex::max(ii-rr+1, ndbx.smallEnd(0));
+            const int ihi = amrex::min(ii+rr-1, ndbx.bigEnd  (0));
+            const int jlo = amrex::max(jj-rr+1, ndbx.smallEnd(1));
+            const int jhi = amrex::min(jj+rr-1, ndbx.bigEnd  (1));
+
+            for (int joff = jlo; joff <= jhi; ++joff) {
+            for (int ioff = ilo; ioff <= ihi; ++ioff) {
+                Real scale = static_cast<Real>((rr-amrex::Math::abs(ii-ioff)) *
+                                               (rr-amrex::Math::abs(jj-joff)));
+                if (ndbx.strictly_contains(ioff,joff,0)) {
+                    Df += scale * (rhs(ioff,joff,0)-res(ioff,joff,0));
+                } else {
+                    Df += scale * mlndlap_sum_Ax
+                        (is_fine, sig, ioff, joff, facx, facy, phi, is_rz);
+                }
+            }}
+
+            f(i,j,0) = Df * (Real(1.0)/static_cast<Real>(rr*rr*rr*rr));
+        } else {
+            f(i,j,0) = Real(0.0);
         }
     }
 }
 
+template <int rr>
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-void mlndlap_res_fine_contrib (int i, int j, int k, Array4<Real> const& f,
-                               Array4<Real const> const& Ax,
-                               Array4<int const> const& msk) noexcept
+void mlndlap_Ax_fine_contrib (int i, int j, int /*k*/, Box const& ndbx, Box const& ccbx,
+                              Array4<Real> const& f, Array4<Real const> const& res,
+                              Array4<Real const> const& rhs, Array4<Real const> const& phi,
+                              Array4<Real const> const& sig, Array4<int const> const& msk,
+                              bool is_rz,
+                              GpuArray<Real,AMREX_SPACEDIM> const& dxinv) noexcept
 {
-    constexpr Real rfd = Real(0.25);
-    constexpr Real chip = Real(0.5);
-    constexpr Real chip2 = Real(0.25);
+    mlndlap_Ax_fine_contrib_doit<rr>
+        ([&sig] (int ix, int iy, int) -> Real const& { return sig(ix,iy,0); },
+         i,j,ndbx,ccbx,f,res,rhs,phi,msk,is_rz,dxinv);
+}
 
-    int ii = 2*i;
-    int jj = 2*j;
-    int kk = 2*k;
-    if (msk(ii,jj,kk)) {
-        f(i,j,0) += rfd*(Ax(ii,jj,0)
-                 + chip*(Ax(ii-1,jj,0)+Ax(ii+1,jj,0)+Ax(ii,jj-1,0)+Ax(ii,jj+1,0))
-                 + chip2*(Ax(ii-1,jj-1,0)+Ax(ii+1,jj-1,0)+Ax(ii-1,jj+1,0)+Ax(ii+1,jj+1,0)));
-    }
+template <int rr>
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void mlndlap_Ax_fine_contrib_cs (int i, int j, int /*k*/, Box const& ndbx, Box const& ccbx,
+                                 Array4<Real> const& f, Array4<Real const> const& res,
+                                 Array4<Real const> const& rhs, Array4<Real const> const& phi,
+                                 Real const sig, Array4<int const> const& msk,
+                                 bool is_rz,
+                                 GpuArray<Real,AMREX_SPACEDIM> const& dxinv) noexcept
+{
+    mlndlap_Ax_fine_contrib_doit<rr>
+        ([&sig] (int, int, int) -> Real const& { return sig; },
+         i,j,ndbx,ccbx,f,res,rhs,phi,msk,is_rz,dxinv);
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
@@ -1362,7 +1495,8 @@ void mlndlap_res_cf_contrib (int i, int j, int, Array4<Real> const& res,
                              Array4<Real const> const& sig, Array4<int const> const& dmsk,
                              Array4<int const> const& ndmsk, Array4<int const> const& ccmsk,
                              Array4<Real const> const& fc,
-                             GpuArray<Real,AMREX_SPACEDIM> const& dxinv, Box const& nddom,
+                             GpuArray<Real,AMREX_SPACEDIM> const& dxinv,
+                             Box const& ccdom_p, Box const& nddom,
                              bool is_rz,
                              GpuArray<LinOpBCType, AMREX_SPACEDIM> const& bclo,
                              GpuArray<LinOpBCType, AMREX_SPACEDIM> const& bchi,
@@ -1372,83 +1506,30 @@ void mlndlap_res_cf_contrib (int i, int j, int, Array4<Real> const& res,
         Real facx = Real(1./6.)*dxinv[0]*dxinv[0];
         Real facy = Real(1./6.)*dxinv[1]*dxinv[1];
 
-        Real fp, fm;
-        if (is_rz) {
-            fp = facy / static_cast<Real>(2*i+1);
-            fm = facy / static_cast<Real>(2*i-1);
-        }
-
-        Real Ax = Real(0.);
-        if (ccmsk(i-1,j-1,0) == crse_cell) {
-            Ax += sig(i-1,j-1,0)*(facx*(Real(2.)*(phi(i-1,j  ,0)-phi(i  ,j  ,0))
-                                           +     (phi(i-1,j-1,0)-phi(i  ,j-1,0)))
-                                + facy*(Real(2.)*(phi(i  ,j-1,0)-phi(i  ,j  ,0))
-                                           +     (phi(i-1,j-1,0)-phi(i-1,j  ,0))));
-            if (is_rz) {
-                Ax += fm*sig(i-1,j-1,0)*(phi(i,j-1,0)-phi(i,j,0));
-            }
-        }
-        if (ccmsk(i,j-1,0) == crse_cell) {
-            Ax += sig(i,j-1,0)*(facx*(Real(2.)*(phi(i+1,j  ,0)-phi(i  ,j  ,0))
-                                         +     (phi(i+1,j-1,0)-phi(i  ,j-1,0)))
-                              + facy*(Real(2.)*(phi(i  ,j-1,0)-phi(i  ,j  ,0))
-                                         +     (phi(i+1,j-1,0)-phi(i+1,j  ,0))));
-            if (is_rz) {
-                Ax -= fp*sig(i,j-1,0)*(phi(i,j-1,0)-phi(i,j,0));
-            }
-        }
-        if (ccmsk(i-1,j,0) == crse_cell) {
-            Ax += sig(i-1,j,0)*(facx*(Real(2.)*(phi(i-1,j  ,0)-phi(i  ,j  ,0))
-                                         +     (phi(i-1,j+1,0)-phi(i  ,j+1,0)))
-                              + facy*(Real(2.)*(phi(i  ,j+1,0)-phi(i  ,j  ,0))
-                                         +     (phi(i-1,j+1,0)-phi(i-1,j  ,0))));
-            if (is_rz) {
-                Ax += fm*sig(i-1,j,0)*(phi(i,j+1,0)-phi(i,j,0));
-            }
-        }
-        if (ccmsk(i,j,0) == crse_cell) {
-            Ax += sig(i,j,0)*(facx*(Real(2.)*(phi(i+1,j  ,0)-phi(i  ,j  ,0))
-                                      +      (phi(i+1,j+1,0)-phi(i  ,j+1,0)))
-                            + facy*(Real(2.)*(phi(i  ,j+1,0)-phi(i  ,j  ,0))
-                                      +      (phi(i+1,j+1,0)-phi(i+1,j  ,0))));
-            if (is_rz) {
-                Ax -= fp*sig(i,j,0)*(phi(i,j+1,0)-phi(i,j,0));
-            }
-        }
-
-        Real Axf = fc(i,j,0);
-        if (neumann_doubling) {
-            const auto ndlo = amrex::lbound(nddom);
-            const auto ndhi = amrex::ubound(nddom);
-
-            if (i == ndlo.x && (bclo[0] == LinOpBCType::Neumann ||
-                                 bclo[0] == LinOpBCType::inflow)) {
-                Axf *= Real(2.);
-            } else if (i== ndhi.x && (bchi[0] == LinOpBCType::Neumann ||
-                                       bchi[0] == LinOpBCType::inflow)) {
-                Axf *= Real(2.);
-            }
-
-            if (j == ndlo.y && (bclo[1] == LinOpBCType::Neumann ||
-                                 bclo[1] == LinOpBCType::inflow)) {
-                Axf *= Real(2.);
-            } else if (j == ndhi.y && (bchi[1] == LinOpBCType::Neumann ||
-                                        bchi[1] == LinOpBCType::inflow)) {
-                Axf *= Real(2.);
-            }
-        }
-
-        res(i,j,0) = rhs(i,j,0) - (Ax + Axf);
+        Real Ax = mlndlap_sum_Ax([&ccmsk, &ccdom_p] (int ix, int iy) -> bool
+                                 {
+                                     return ccdom_p.contains(ix,iy,0)
+                                         && (ccmsk(ix,iy,0) == crse_cell);
+                                 },
+                                 [&sig] (int ix, int iy, int) -> Real const&
+                                 {
+                                     return sig(ix,iy,0);
+                                 },
+                                 i, j, facx, facy, phi, is_rz);
+        Ax += fc(i,j,0);
+        Real const ns = (neumann_doubling) ? neumann_scale(i,j,nddom,bclo,bchi) : Real(1.0);
+        res(i,j,0) = rhs(i,j,0) - Ax*ns;
     }
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 void mlndlap_res_cf_contrib_cs (int i, int j, int, Array4<Real> const& res,
                                 Array4<Real const> const& phi, Array4<Real const> const& rhs,
-                                Real sig, Array4<int const> const& dmsk,
+                                Real const sig, Array4<int const> const& dmsk,
                                 Array4<int const> const& ndmsk, Array4<int const> const& ccmsk,
                                 Array4<Real const> const& fc,
-                                GpuArray<Real,AMREX_SPACEDIM> const& dxinv, Box const& nddom,
+                                GpuArray<Real,AMREX_SPACEDIM> const& dxinv,
+                                Box const& ccdom_p, Box const& nddom,
                                 bool is_rz,
                                 GpuArray<LinOpBCType, AMREX_SPACEDIM> const& bclo,
                                 GpuArray<LinOpBCType, AMREX_SPACEDIM> const& bchi,
@@ -1458,74 +1539,19 @@ void mlndlap_res_cf_contrib_cs (int i, int j, int, Array4<Real> const& res,
         Real facx = Real(1./6.)*dxinv[0]*dxinv[0];
         Real facy = Real(1./6.)*dxinv[1]*dxinv[1];
 
-        Real fp, fm;
-        if (is_rz) {
-            fp = facy / static_cast<Real>(2*i+1);
-            fm = facy / static_cast<Real>(2*i-1);
-        }
-
-        Real Ax = Real(0.);
-        if (ccmsk(i-1,j-1,0) == crse_cell) {
-            Ax += facx*(Real(2.)*(phi(i-1,j  ,0)-phi(i  ,j  ,0))
-                           +     (phi(i-1,j-1,0)-phi(i  ,j-1,0)))
-                + facy*(Real(2.)*(phi(i  ,j-1,0)-phi(i  ,j  ,0))
-                           +     (phi(i-1,j-1,0)-phi(i-1,j  ,0)));
-            if (is_rz) {
-                Ax += fm*(phi(i,j-1,0)-phi(i,j,0));
-            }
-        }
-        if (ccmsk(i,j-1,0) == crse_cell) {
-            Ax += facx*(Real(2.)*(phi(i+1,j  ,0)-phi(i  ,j  ,0))
-                           +     (phi(i+1,j-1,0)-phi(i  ,j-1,0)))
-                + facy*(Real(2.)*(phi(i  ,j-1,0)-phi(i  ,j  ,0))
-                           +     (phi(i+1,j-1,0)-phi(i+1,j  ,0)));
-            if (is_rz) {
-                Ax -= fp*(phi(i,j-1,0)-phi(i,j,0));
-            }
-        }
-        if (ccmsk(i-1,j,0) == crse_cell) {
-            Ax += facx*(Real(2.)*(phi(i-1,j  ,0)-phi(i  ,j  ,0))
-                           +     (phi(i-1,j+1,0)-phi(i  ,j+1,0)))
-                + facy*(Real(2.)*(phi(i  ,j+1,0)-phi(i  ,j  ,0))
-                           +     (phi(i-1,j+1,0)-phi(i-1,j  ,0)));
-            if (is_rz) {
-                Ax += fm*(phi(i,j+1,0)-phi(i,j,0));
-            }
-        }
-        if (ccmsk(i,j,0) == crse_cell) {
-            Ax += facx*(Real(2.)*(phi(i+1,j  ,0)-phi(i  ,j  ,0))
-                          +      (phi(i+1,j+1,0)-phi(i  ,j+1,0)))
-                + facy*(Real(2.)*(phi(i  ,j+1,0)-phi(i  ,j  ,0))
-                          +      (phi(i+1,j+1,0)-phi(i+1,j  ,0)));
-            if (is_rz) {
-                Ax -= fp*(phi(i,j+1,0)-phi(i,j,0));
-            }
-        }
-        Ax *= sig;
-
-        Real Axf = fc(i,j,0);
-        if (neumann_doubling) {
-            const auto ndlo = amrex::lbound(nddom);
-            const auto ndhi = amrex::ubound(nddom);
-
-            if (i == ndlo.x && (bclo[0] == LinOpBCType::Neumann ||
-                                 bclo[0] == LinOpBCType::inflow)) {
-                Axf *= Real(2.);
-            } else if (i== ndhi.x && (bchi[0] == LinOpBCType::Neumann ||
-                                       bchi[0] == LinOpBCType::inflow)) {
-                Axf *= Real(2.);
-            }
-
-            if (j == ndlo.y && (bclo[1] == LinOpBCType::Neumann ||
-                                 bclo[1] == LinOpBCType::inflow)) {
-                Axf *= Real(2.);
-            } else if (j == ndhi.y && (bchi[1] == LinOpBCType::Neumann ||
-                                        bchi[1] == LinOpBCType::inflow)) {
-                Axf *= Real(2.);
-            }
-        }
-
-        res(i,j,0) = rhs(i,j,0) - (Ax + Axf);
+        Real Ax = mlndlap_sum_Ax([&ccmsk, &ccdom_p] (int ix, int iy) -> bool
+                                 {
+                                     return ccdom_p.contains(ix,iy,0)
+                                         && (ccmsk(ix,iy,0) == crse_cell);
+                                 },
+                                 [&sig] (int, int, int) -> Real const&
+                                 {
+                                     return sig;
+                                 },
+                                 i, j, facx, facy, phi, is_rz);
+        Ax += fc(i,j,0);
+        Real const ns = (neumann_doubling) ? neumann_scale(i,j,nddom,bclo,bchi) : Real(1.0);
+        res(i,j,0) = rhs(i,j,0) - Ax*ns;
     }
 }
 

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLap_3D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLap_3D_K.H
@@ -1620,6 +1620,58 @@ void mlndlap_restriction (int i, int j, int k, Array4<Real> const& crse,
     }
 }
 
+template <int rr>
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void mlndlap_restriction (int i, int j, int k, Array4<Real> const& crse,
+                          Array4<Real const> const& fine, Array4<int const> const& msk,
+                          Box const& fdom,
+                          GpuArray<LinOpBCType, AMREX_SPACEDIM> const& bclo,
+                          GpuArray<LinOpBCType, AMREX_SPACEDIM> const& bchi) noexcept
+{
+    const int ii = i*rr;
+    const int jj = j*rr;
+    const int kk = k*rr;
+    if (msk(ii,jj,kk)) {
+        crse(i,j,k) = Real(0.0);
+    } else {
+        const auto ndlo = amrex::lbound(fdom);
+        const auto ndhi = amrex::ubound(fdom);
+        Real tmp = Real(0.0);
+        for (int koff = -rr+1; koff <= rr-1; ++koff) {
+            Real wz = rr - amrex::Math::abs(koff);
+            for (int joff = -rr+1; joff <= rr-1; ++joff) {
+                Real wy = rr - amrex::Math::abs(joff);
+                for (int ioff = -rr+1; ioff <= rr-1; ++ioff) {
+                    Real wx = rr - amrex::Math::abs(ioff);
+                    int itmp = ii + ioff;
+                    int jtmp = jj + joff;
+                    int ktmp = kk + koff;
+                    if ((itmp < ndlo.x && (bclo[0] == LinOpBCType::Neumann ||
+                                           bclo[0] == LinOpBCType::inflow)) ||
+                        (itmp > ndhi.x && (bchi[0] == LinOpBCType::Neumann ||
+                                           bchi[0] == LinOpBCType::inflow))) {
+                        itmp = ii - ioff;
+                    }
+                    if ((jtmp < ndlo.y && (bclo[1] == LinOpBCType::Neumann ||
+                                           bclo[1] == LinOpBCType::inflow)) ||
+                        (jtmp > ndhi.y && (bchi[1] == LinOpBCType::Neumann ||
+                                           bchi[1] == LinOpBCType::inflow))) {
+                        jtmp = jj - joff;
+                    }
+                    if ((ktmp < ndlo.z && (bclo[2] == LinOpBCType::Neumann ||
+                                           bclo[2] == LinOpBCType::inflow)) ||
+                        (ktmp > ndhi.z && (bchi[2] == LinOpBCType::Neumann ||
+                                           bchi[2] == LinOpBCType::inflow))) {
+                        ktmp = kk - koff;
+                    }
+                    tmp += wx*wy*wz*fine(itmp,jtmp,ktmp);
+                }
+            }
+        }
+        crse(i,j,k) = tmp/Real(rr*rr*rr*rr*rr*rr);
+    }
+}
+
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 void mlndlap_semi_restriction (int i, int j, int k, Array4<Real> const& crse,
                                Array4<Real const> const& fine, Array4<int const> const& msk, int idir) noexcept
@@ -2136,107 +2188,151 @@ void mlndlap_mknewu_c (int i, int j, int k, Array4<Real> const& u, Array4<Real c
            +p(i,j,k+1)+p(i+1,j,k+1)+p(i,j+1,k+1)+p(i+1,j+1,k+1));
 }
 
-AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-void mlndlap_divu_compute_fine_contrib (int i, int j, int k, Box const& fvbx,
-                                        Array4<Real> const& frh, Array4<Real const> const& vel,
-                                        GpuArray<Real,AMREX_SPACEDIM> const& dxinv,
-                                        Box const& nodal_domain,
-                                        GpuArray<LinOpBCType, AMREX_SPACEDIM> const& bclo,
-                                        GpuArray<LinOpBCType, AMREX_SPACEDIM> const& bchi) noexcept
-{
-    const auto domlo = amrex::lbound(nodal_domain);
-    const auto domhi = amrex::ubound(nodal_domain);
-
-    IntVect iv(i,j,k);
-    if (fvbx.contains(iv) && !fvbx.strictly_contains(iv))
+namespace {
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    Real mlndlap_sum_Df (int ii, int jj, int kk, Real facx, Real facy, Real facz,
+                         Array4<Real const> const& vel, Box const& velbx) noexcept
     {
-        Real zero_ilo = Real(1.0);
-        Real zero_ihi = Real(1.0);
-        Real zero_jlo = Real(1.0);
-        Real zero_jhi = Real(1.0);
-        Real zero_klo = Real(1.0);
-        Real zero_khi = Real(1.0);
-
-        // The nodal divergence operator should not see the tangential velocity
-        //     at an inflow face
-        if ((bclo[0] == LinOpBCType::Neumann || bclo[0] == LinOpBCType::inflow)
-            && i == domlo.x) zero_ilo = Real(0.0);
-        if ((bchi[0] == LinOpBCType::Neumann || bchi[0] == LinOpBCType::inflow)
-            && i == domhi.x) zero_ihi = Real(0.0);
-        if ((bclo[1] == LinOpBCType::Neumann || bclo[1] == LinOpBCType::inflow)
-            && j == domlo.y) zero_jlo = Real(0.0);
-        if ((bchi[1] == LinOpBCType::Neumann || bchi[1] == LinOpBCType::inflow)
-            && j == domhi.y) zero_jhi = Real(0.0);
-        if ((bclo[2] == LinOpBCType::Neumann || bclo[2] == LinOpBCType::inflow)
-            && k == domlo.z) zero_klo = Real(0.0);
-        if ((bchi[2] == LinOpBCType::Neumann || bchi[2] == LinOpBCType::inflow)
-            && k == domhi.z) zero_khi = Real(0.0);
-
-        frh(i,j,k) = Real(0.25)*dxinv[0]*(-vel(i-1,j-1,k-1,0)*zero_jlo*zero_klo+vel(i,j-1,k-1,0)*zero_jlo*zero_klo
-                                          -vel(i-1,j  ,k-1,0)*zero_jhi*zero_klo+vel(i,j  ,k-1,0)*zero_jhi*zero_klo
-                                          -vel(i-1,j-1,k  ,0)*zero_jlo*zero_khi+vel(i,j-1,k  ,0)*zero_jlo*zero_khi
-                                          -vel(i-1,j  ,k  ,0)*zero_jhi*zero_khi+vel(i,j  ,k  ,0)*zero_jhi*zero_khi)
-                   + Real(0.25)*dxinv[1]*(-vel(i-1,j-1,k-1,1)*zero_ilo*zero_klo-vel(i,j-1,k-1,1)*zero_ihi*zero_klo
-                                          +vel(i-1,j  ,k-1,1)*zero_ilo*zero_klo+vel(i,j  ,k-1,1)*zero_ihi*zero_klo
-                                          -vel(i-1,j-1,k  ,1)*zero_ilo*zero_khi-vel(i,j-1,k  ,1)*zero_ihi*zero_khi
-                                          +vel(i-1,j  ,k  ,1)*zero_ilo*zero_khi+vel(i,j  ,k  ,1)*zero_ihi*zero_khi)
-                   + Real(0.25)*dxinv[2]*(-vel(i-1,j-1,k-1,2)*zero_ilo*zero_jlo-vel(i,j-1,k-1,2)*zero_ihi*zero_jlo
-                                          -vel(i-1,j  ,k-1,2)*zero_ilo*zero_jhi-vel(i,j  ,k-1,2)*zero_ihi*zero_jhi
-                                          +vel(i-1,j-1,k  ,2)*zero_ilo*zero_jlo+vel(i,j-1,k  ,2)*zero_ihi*zero_jlo
-                                          +vel(i-1,j  ,k  ,2)*zero_ilo*zero_jhi+vel(i,j  ,k  ,2)*zero_ihi*zero_jhi);
+        Real Df = Real(0.0);
+        if (velbx.contains(ii-1,jj-1,kk-1)) {
+            Df += -facx*vel(ii-1,jj-1,kk-1,0) - facy*vel(ii-1,jj-1,kk-1,1) - facz*vel(ii-1,jj-1,kk-1,2);
+        }
+        if (velbx.contains(ii,jj-1,kk-1)) {
+            Df += facx*vel(ii,jj-1,kk-1,0) - facy*vel(ii,jj-1,kk-1,1) - facz*vel(ii,jj-1,kk-1,2);
+        }
+        if (velbx.contains(ii-1,jj,kk-1)) {
+            Df += -facx*vel(ii-1,jj,kk-1,0) + facy*vel(ii-1,jj,kk-1,1) - facz*vel(ii-1,jj,kk-1,2);
+        }
+        if (velbx.contains(ii,jj,kk-1)) {
+            Df += facx*vel(ii,jj,kk-1,0) + facy*vel(ii,jj,kk-1,1) - facz*vel(ii,jj,kk-1,2);
+        }
+        if (velbx.contains(ii-1,jj-1,kk)) {
+            Df += -facx*vel(ii-1,jj-1,kk,0) - facy*vel(ii-1,jj-1,kk,1) + facz*vel(ii-1,jj-1,kk,2);
+        }
+        if (velbx.contains(ii,jj-1,kk)) {
+            Df += facx*vel(ii,jj-1,kk,0) - facy*vel(ii,jj-1,kk,1) + facz*vel(ii,jj-1,kk,2);
+        }
+        if (velbx.contains(ii-1,jj,kk)) {
+            Df += -facx*vel(ii-1,jj,kk,0) + facy*vel(ii-1,jj,kk,1) + facz*vel(ii-1,jj,kk,2);
+        }
+        if (velbx.contains(ii,jj,kk)) {
+            Df += facx*vel(ii,jj,kk,0) + facy*vel(ii,jj,kk,1) + facz*vel(ii,jj,kk,2);
+        }
+        return Df;
     }
 }
 
+template <int rr>
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-void mlndlap_divu_add_fine_contrib (int i, int j, int k, Box const& fvbx,
-                                    Array4<Real> const& rhs, Array4<Real const> const& frh,
-                                    Array4<int const> const& msk) noexcept
+void mlndlap_divu_fine_contrib (int i, int j, int k, Box const& fvbx, Box const& velbx,
+                                Array4<Real> const& rhs, Array4<Real const> const& vel,
+                                Array4<Real const> const& frhs, Array4<int const> const& msk,
+                                GpuArray<Real,AMREX_SPACEDIM> const& dxinv) noexcept
 {
-    constexpr Real rfd = Real(0.125);
-    constexpr Real chip = Real(0.5);
-    constexpr Real chip2 = Real(0.25);
-    constexpr Real chip3 = Real(0.125);
+    const int ii = rr*i;
+    const int jj = rr*j;
+    const int kk = rr*k;
+    if (msk(ii,jj,kk)) {
+        const Real facx = Real(0.25)*dxinv[0];
+        const Real facy = Real(0.25)*dxinv[1];
+        const Real facz = Real(0.25)*dxinv[2];
 
-    int ii = 2*i;
-    int jj = 2*j;
-    int kk = 2*k;
-    IntVect iv(ii,jj,kk);
-    if (fvbx.contains(iv) && !fvbx.strictly_contains(iv) && msk(ii,jj,kk))
-    {
-        rhs(i,j,k) +=
-            rfd*(frh(ii,jj,kk)
-                 + chip*(frh(ii,jj,kk-1)+frh(ii,jj,kk+1)
-                         +frh(ii,jj-1,kk)+frh(ii,jj+1,kk)
-                         +frh(ii-1,jj,kk)+frh(ii+1,jj,kk))
-                 + chip2*(frh(ii,jj-1,kk-1)+frh(ii,jj+1,kk-1)+frh(ii,jj-1,kk+1)+frh(ii,jj+1,kk+1)
-                          +frh(ii-1,jj,kk-1)+frh(ii+1,jj,kk-1)+frh(ii-1,jj,kk+1)+frh(ii+1,jj,kk+1)
-                          +frh(ii-1,jj-1,kk)+frh(ii+1,jj-1,kk)+frh(ii-1,jj+1,kk)+frh(ii+1,jj+1,kk))
-                 + chip3*(frh(ii-1,jj-1,kk-1)+frh(ii+1,jj-1,kk-1)
-                          +frh(ii-1,jj+1,kk-1)+frh(ii+1,jj+1,kk-1)
-                          +frh(ii-1,jj-1,kk+1)+frh(ii+1,jj-1,kk+1)
-                          +frh(ii-1,jj+1,kk+1)+frh(ii+1,jj+1,kk+1)));
+        Real Df = Real(0.0);
+
+        const int ilo = amrex::max(ii-rr+1, fvbx.smallEnd(0));
+        const int ihi = amrex::min(ii+rr-1, fvbx.bigEnd  (0));
+        const int jlo = amrex::max(jj-rr+1, fvbx.smallEnd(1));
+        const int jhi = amrex::min(jj+rr-1, fvbx.bigEnd  (1));
+        const int klo = amrex::max(kk-rr+1, fvbx.smallEnd(2));
+        const int khi = amrex::min(kk+rr-1, fvbx.bigEnd  (2));
+
+        for (int koff = klo; koff <= khi; ++koff) {
+        for (int joff = jlo; joff <= jhi; ++joff) {
+        for (int ioff = ilo; ioff <= ihi; ++ioff) {
+            Real scale = static_cast<Real>((rr-amrex::Math::abs(ii-ioff)) *
+                                           (rr-amrex::Math::abs(jj-joff)) *
+                                           (rr-amrex::Math::abs(kk-koff)));
+            if (fvbx.strictly_contains(ioff,joff,koff)) {
+                Df += scale * frhs(ioff,joff,koff);
+            } else {
+                Df += scale * mlndlap_sum_Df(ioff, joff, koff, facx, facy, facz, vel, velbx);
+            }
+        }}}
+
+        rhs(i,j,k) = Df * (Real(1.0)/static_cast<Real>(rr*rr*rr*rr*rr*rr));
+    } else {
+        rhs(i,j,k) = Real(0.0);
     }
 }
 
+template<int rr>
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-void mlndlap_rhcc_fine_contrib (int i, int j, int k, Box const& fvbx,
+void mlndlap_rhcc_fine_contrib (int i, int j, int k, Box const& ccbx,
                                 Array4<Real> const& rhs, Array4<Real const> const& cc,
                                 Array4<int const> const& msk) noexcept
 {
-    constexpr Real fac[] = {Real(0.125), Real(0.375), Real(0.375), Real(0.125)};
-    int ii = 2*i;
-    int jj = 2*j;
-    int kk = 2*k;
-    IntVect iv(ii,jj,kk);
-    if (fvbx.contains(iv) && !fvbx.strictly_contains(iv) && msk(ii,jj,kk))
-    {
-        Real r = Real(0.0);
-        for (int koff = -2; koff <= 1; ++koff) {
-        for (int joff = -2; joff <= 1; ++joff) {
-        for (int ioff = -2; ioff <= 1; ++ioff) {
-            r += cc(ii+ioff,jj+joff,kk+koff) * fac[ioff+2]*fac[joff+2]*fac[koff+2];
+    const int ii = rr*i;
+    const int jj = rr*j;
+    const int kk = rr*k;
+    if (msk(ii,jj,kk)) {
+        Real tmp = Real(0.0);
+
+        const int ilo = amrex::max(ii-rr  , ccbx.smallEnd(0));
+        const int ihi = amrex::min(ii+rr-1, ccbx.bigEnd  (0));
+        const int jlo = amrex::max(jj-rr  , ccbx.smallEnd(1));
+        const int jhi = amrex::min(jj+rr-1, ccbx.bigEnd  (1));
+        const int klo = amrex::max(kk-rr  , ccbx.smallEnd(2));
+        const int khi = amrex::min(kk+rr-1, ccbx.bigEnd (2));
+
+        for (int koff = klo; koff <= khi; ++koff) {
+        for (int joff = jlo; joff <= jhi; ++joff) {
+        for (int ioff = ilo; ioff <= ihi; ++ioff) {
+            Real scale = (Real(2.0)-amrex::Math::abs(static_cast<Real>(ioff)+Real(0.5)))
+                *        (Real(2.0)-amrex::Math::abs(static_cast<Real>(joff)+Real(0.5)))
+                *        (Real(2.0)-amrex::Math::abs(static_cast<Real>(koff)+Real(0.5)));
+            tmp += cc(ioff,joff,koff) * scale;
         }}}
-        rhs(i,j,k) += r;
+
+        rhs(i,j,k) += tmp * (Real(1.0)/Real(8*rr*rr*rr));
+    }
+}
+
+namespace {
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    Real neumann_scale (int i, int j, int k, Box const& nddom,
+                        GpuArray<LinOpBCType,AMREX_SPACEDIM> const& bclo,
+                        GpuArray<LinOpBCType,AMREX_SPACEDIM> const& bchi) noexcept
+    {
+        Real val = Real(1.0);
+
+        const auto ndlo = amrex::lbound(nddom);
+        const auto ndhi = amrex::ubound(nddom);
+
+        if (i == ndlo.x && ( bclo[0] == LinOpBCType::Neumann ||
+                             bclo[0] == LinOpBCType::inflow)) {
+            val *= Real(2.);
+        } else if (i== ndhi.x && ( bchi[0] == LinOpBCType::Neumann ||
+                                   bchi[0] == LinOpBCType::inflow)) {
+            val *= Real(2.);
+        }
+
+        if (j == ndlo.y && ( bclo[1] == LinOpBCType::Neumann ||
+                             bclo[1] == LinOpBCType::inflow)) {
+            val *= Real(2.);
+        } else if (j == ndhi.y && ( bchi[1] == LinOpBCType::Neumann ||
+                                    bchi[1] == LinOpBCType::inflow)) {
+            val *= Real(2.);
+        }
+
+        if (k == ndlo.z && ( bclo[2] == LinOpBCType::Neumann ||
+                             bclo[2] == LinOpBCType::inflow)) {
+            val *= Real(2.);
+        } else if (k == ndhi.z && ( bchi[2] == LinOpBCType::Neumann ||
+                                    bchi[2] == LinOpBCType::inflow)) {
+            val *= Real(2.);
+        }
+
+        return val;
     }
 }
 
@@ -2246,95 +2342,76 @@ void mlndlap_divu_cf_contrib (int i, int j, int k, Array4<Real> const& rhs,
                               Array4<Real const> const& rhcc, Array4<int const> const& dmsk,
                               Array4<int const> const& ndmsk, Array4<int const> const& ccmsk,
                               GpuArray<Real,AMREX_SPACEDIM> const& dxinv,
-                              Box const& nddom, GpuArray<LinOpBCType,AMREX_SPACEDIM> const& bclo,
-                              GpuArray<LinOpBCType,AMREX_SPACEDIM> const& bchi,
-                              bool neumann_doubling) noexcept
+                              Box const& ccdom_p, Box const& veldom, Box const& nddom,
+                              GpuArray<LinOpBCType,AMREX_SPACEDIM> const& bclo,
+                              GpuArray<LinOpBCType,AMREX_SPACEDIM> const& bchi) noexcept
 {
     if (!dmsk(i,j,k) && ndmsk(i,j,k) == crse_fine_node) {
         Real facx = Real(0.25) * dxinv[0];
         Real facy = Real(0.25) * dxinv[1];
         Real facz = Real(0.25) * dxinv[2];
-        Real r = fc(i,j,k);
-        if (rhcc) {
-            r += Real(0.125)*((Real(1.)-ccmsk(i-1,j-1,k-1)) * rhcc(i-1,j-1,k-1)
-                            + (Real(1.)-ccmsk(i  ,j-1,k-1)) * rhcc(i  ,j-1,k-1)
-                            + (Real(1.)-ccmsk(i-1,j  ,k-1)) * rhcc(i-1,j  ,k-1)
-                            + (Real(1.)-ccmsk(i  ,j  ,k-1)) * rhcc(i  ,j  ,k-1)
-                            + (Real(1.)-ccmsk(i-1,j-1,k  )) * rhcc(i-1,j-1,k  )
-                            + (Real(1.)-ccmsk(i  ,j-1,k  )) * rhcc(i  ,j-1,k  )
-                            + (Real(1.)-ccmsk(i-1,j  ,k  )) * rhcc(i-1,j  ,k  )
-                            + (Real(1.)-ccmsk(i  ,j  ,k  )) * rhcc(i  ,j  ,k  ));
-        }
-        if (ccmsk(i-1,j-1,k-1) == crse_cell) {
-            r += - facx*vel(i-1,j-1,k-1,0)
-                 - facy*vel(i-1,j-1,k-1,1)
-                 - facz*vel(i-1,j-1,k-1,2);
-        }
-        if (ccmsk(i,j-1,k-1) == crse_cell) {
-            r += + facx*vel(i  ,j-1,k-1,0)
-                 - facy*vel(i  ,j-1,k-1,1)
-                 - facz*vel(i  ,j-1,k-1,2);
-        }
-        if (ccmsk(i-1,j,k-1) == crse_cell) {
-            r += - facx*vel(i-1,j  ,k-1,0)
-                 + facy*vel(i-1,j  ,k-1,1)
-                 - facz*vel(i-1,j  ,k-1,2);
-        }
-        if (ccmsk(i,j,k-1) == crse_cell) {
-            r += + facx*vel(i  ,j  ,k-1,0)
-                 + facy*vel(i  ,j  ,k-1,1)
-                 - facz*vel(i  ,j  ,k-1,2);
-        }
-        if (ccmsk(i-1,j-1,k) == crse_cell) {
-            r += - facx*vel(i-1,j-1,k  ,0)
-                 - facy*vel(i-1,j-1,k  ,1)
-                 + facz*vel(i-1,j-1,k  ,2);
-        }
-        if (ccmsk(i,j-1,k) == crse_cell) {
-            r += + facx*vel(i  ,j-1,k  ,0)
-                 - facy*vel(i  ,j-1,k  ,1)
-                 + facz*vel(i  ,j-1,k  ,2);
-        }
-        if (ccmsk(i-1,j,k) == crse_cell) {
-            r += - facx*vel(i-1,j  ,k  ,0)
-                 + facy*vel(i-1,j  ,k  ,1)
-                 + facz*vel(i-1,j  ,k  ,2);
-        }
-        if (ccmsk(i,j,k) == crse_cell) {
-            r += + facx*vel(i  ,j  ,k  ,0)
-                 + facy*vel(i  ,j  ,k  ,1)
-                 + facz*vel(i  ,j  ,k  ,2);
-        }
+        Real tmp = fc(i,j,k);
 
-        if (neumann_doubling) {
-            const auto ndlo = amrex::lbound(nddom);
-            const auto ndhi = amrex::ubound(nddom);
-            if (i == ndlo.x && ( bclo[0] == LinOpBCType::Neumann ||
-                                  bclo[0] == LinOpBCType::inflow)) {
-                r *= Real(2.);
-            } else if (i== ndhi.x && ( bchi[0] == LinOpBCType::Neumann ||
-                                        bchi[0] == LinOpBCType::inflow)) {
-                r *= Real(2.);
-            }
+        // Where there is inflow, veldom there is bigger than ccdom_p by one cell.
+        // ccdom_p is cc domain grown at periodic boundaries.
 
-            if (j == ndlo.y && ( bclo[1] == LinOpBCType::Neumann ||
-                                  bclo[1] == LinOpBCType::inflow)) {
-                r *= Real(2.);
-            } else if (j == ndhi.y && ( bchi[1] == LinOpBCType::Neumann ||
-                                         bchi[1] == LinOpBCType::inflow)) {
-                r *= Real(2.);
-            }
-
-            if (k == ndlo.z && ( bclo[2] == LinOpBCType::Neumann ||
-                                  bclo[2] == LinOpBCType::inflow)) {
-                r *= Real(2.);
-            } else if (k == ndhi.z && ( bchi[2] == LinOpBCType::Neumann ||
-                                         bchi[2] == LinOpBCType::inflow)) {
-                r *= Real(2.);
+        if (ccmsk(i-1,j-1,k-1) == crse_cell && veldom.contains(i-1,j-1,k-1)) {
+            tmp += -facx*vel(i-1,j-1,k-1,0) - facy*vel(i-1,j-1,k-1,1) - facz*vel(i-1,j-1,k-1,2);
+            if (rhcc && ccdom_p.contains(i-1,j-1,k-1)) {
+                tmp += Real(0.125) * rhcc(i-1,j-1,k-1);
             }
         }
 
-        rhs(i,j,k) = r;
+        if (ccmsk(i,j-1,k-1) == crse_cell && veldom.contains(i,j-1,k-1)) {
+            tmp += facx*vel(i,j-1,k-1,0) - facy*vel(i,j-1,k-1,1) - facz*vel(i,j-1,k-1,2);
+            if (rhcc && ccdom_p.contains(i,j-1,k-1)) {
+                tmp += Real(0.125) * rhcc(i,j-1,k-1);
+            }
+        }
+
+        if (ccmsk(i-1,j,k-1) == crse_cell && veldom.contains(i-1,j,k-1)) {
+            tmp += -facx*vel(i-1,j,k-1,0) + facy*vel(i-1,j,k-1,1) - facz*vel(i-1,j,k-1,2);
+            if (rhcc && ccdom_p.contains(i-1,j,k-1)) {
+                tmp += Real(0.125) * rhcc(i-1,j,k-1);
+            }
+        }
+
+        if (ccmsk(i,j,k-1) == crse_cell && veldom.contains(i,j,k-1)) {
+            tmp += facx*vel(i,j,k-1,0) + facy*vel(i,j,k-1,1) - facz*vel(i,j,k-1,2);
+            if (rhcc && ccdom_p.contains(i,j,k-1)) {
+                tmp += Real(0.125) * rhcc(i,j,k-1);
+            }
+        }
+
+        if (ccmsk(i-1,j-1,k) == crse_cell && veldom.contains(i-1,j-1,k)) {
+            tmp += -facx*vel(i-1,j-1,k,0) - facy*vel(i-1,j-1,k,1) + facz*vel(i-1,j-1,k,2);
+            if (rhcc && ccdom_p.contains(i-1,j-1,k)) {
+                tmp += Real(0.125) * rhcc(i-1,j-1,k);
+            }
+        }
+
+        if (ccmsk(i,j-1,k) == crse_cell && veldom.contains(i,j-1,k)) {
+            tmp += facx*vel(i,j-1,k,0) - facy*vel(i,j-1,k,1) + facz*vel(i,j-1,k,2);
+            if (rhcc && ccdom_p.contains(i,j-1,k)) {
+                tmp += Real(0.125) * rhcc(i,j-1,k);
+            }
+        }
+
+        if (ccmsk(i-1,j,k) == crse_cell && veldom.contains(i-1,j,k)) {
+            tmp += -facx*vel(i-1,j,k,0) + facy*vel(i-1,j,k,1) + facz*vel(i-1,j,k,2);
+            if (rhcc && ccdom_p.contains(i-1,j,k)) {
+                tmp += Real(0.125) * rhcc(i-1,j,k);
+            }
+        }
+
+        if (ccmsk(i,j,k) == crse_cell && veldom.contains(i,j,k)) {
+            tmp += facx*vel(i,j,k,0) + facy*vel(i,j,k,1) + facz*vel(i,j,k,2);
+            if (rhcc && ccdom_p.contains(i,j,k)) {
+                tmp += Real(0.125) * rhcc(i,j,k);
+            }
+        }
+
+        rhs(i,j,k) = tmp * neumann_scale(i, j, k, nddom, bclo, bchi);
     }
 }
 
@@ -2402,103 +2479,15 @@ void mlndlap_crse_resid (int i, int j, int k, Array4<Real> const& resid,
 // sync residual
 //
 
-AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-void mlndlap_res_fine_Ax (int i, int j, int k, Box const& fvbx, Array4<Real> const& Ax,
-                          Array4<Real const> const& x, Array4<Real const> const& sig,
-                          GpuArray<Real,AMREX_SPACEDIM> const& dxinv) noexcept
-{
-    IntVect iv(i,j,k);
-    if (fvbx.contains(iv) && !fvbx.strictly_contains(iv)) {
-        Real facx = Real(1./36.)*dxinv[0]*dxinv[0];
-        Real facy = Real(1./36.)*dxinv[1]*dxinv[1];
-        Real facz = Real(1./36.)*dxinv[2]*dxinv[2];
-        Real fxyz = facx + facy + facz;
-        Real fmx2y2z = -facx + Real(2.)*facy + Real(2.)*facz;
-        Real f2xmy2z = Real(2.)*facx - facy + Real(2.)*facz;
-        Real f2x2ymz = Real(2.)*facx + Real(2.)*facy - facz;
-        Real f4xm2ym2z = Real(4.)*facx - Real(2.)*facy - Real(2.)*facz;
-        Real fm2x4ym2z = -Real(2.)*facx + Real(4.)*facy - Real(2.)*facz;
-        Real fm2xm2y4z = -Real(2.)*facx - Real(2.)*facy + Real(4.)*facz;
-        Ax(i,j,k) = x(i,j,k)*Real(-4.)*fxyz*
-            (sig(i-1,j-1,k-1)+sig(i,j-1,k-1)+sig(i-1,j,k-1)+sig(i,j,k-1)
-            +sig(i-1,j-1,k  )+sig(i,j-1,k  )+sig(i-1,j,k  )+sig(i,j,k  ))
-            //
-            + fxyz*(x(i-1,j-1,k-1)*sig(i-1,j-1,k-1)
-                  + x(i+1,j-1,k-1)*sig(i  ,j-1,k-1)
-                  + x(i-1,j+1,k-1)*sig(i-1,j  ,k-1)
-                  + x(i+1,j+1,k-1)*sig(i  ,j  ,k-1)
-                  + x(i-1,j-1,k+1)*sig(i-1,j-1,k  )
-                  + x(i+1,j-1,k+1)*sig(i  ,j-1,k  )
-                  + x(i-1,j+1,k+1)*sig(i-1,j  ,k  )
-                  + x(i+1,j+1,k+1)*sig(i  ,j  ,k  ))
-            + fmx2y2z*(x(i  ,j-1,k-1)*(sig(i-1,j-1,k-1)+sig(i,j-1,k-1))
-                     + x(i  ,j+1,k-1)*(sig(i-1,j  ,k-1)+sig(i,j  ,k-1))
-                     + x(i  ,j-1,k+1)*(sig(i-1,j-1,k  )+sig(i,j-1,k  ))
-                     + x(i  ,j+1,k+1)*(sig(i-1,j  ,k  )+sig(i,j  ,k  )))
-            + f2xmy2z*(x(i-1,j  ,k-1)*(sig(i-1,j-1,k-1)+sig(i-1,j,k-1))
-                     + x(i+1,j  ,k-1)*(sig(i  ,j-1,k-1)+sig(i  ,j,k-1))
-                     + x(i-1,j  ,k+1)*(sig(i-1,j-1,k  )+sig(i-1,j,k  ))
-                     + x(i+1,j  ,k+1)*(sig(i  ,j-1,k  )+sig(i  ,j,k  )))
-            + f2x2ymz*(x(i-1,j-1,k  )*(sig(i-1,j-1,k-1)+sig(i-1,j-1,k))
-                     + x(i+1,j-1,k  )*(sig(i  ,j-1,k-1)+sig(i  ,j-1,k))
-                     + x(i-1,j+1,k  )*(sig(i-1,j  ,k-1)+sig(i-1,j  ,k))
-                     + x(i+1,j+1,k  )*(sig(i  ,j  ,k-1)+sig(i  ,j  ,k)))
-            + f4xm2ym2z*(x(i-1,j,k)*(sig(i-1,j-1,k-1)+sig(i-1,j,k-1)+sig(i-1,j-1,k)+sig(i-1,j,k))
-                       + x(i+1,j,k)*(sig(i  ,j-1,k-1)+sig(i  ,j,k-1)+sig(i  ,j-1,k)+sig(i  ,j,k)))
-            + fm2x4ym2z*(x(i,j-1,k)*(sig(i-1,j-1,k-1)+sig(i,j-1,k-1)+sig(i-1,j-1,k)+sig(i,j-1,k))
-                       + x(i,j+1,k)*(sig(i-1,j  ,k-1)+sig(i,j  ,k-1)+sig(i-1,j  ,k)+sig(i,j  ,k)))
-            + fm2xm2y4z*(x(i,j,k-1)*(sig(i-1,j-1,k-1)+sig(i,j-1,k-1)+sig(i-1,j,k-1)+sig(i,j,k-1))
-                       + x(i,j,k+1)*(sig(i-1,j-1,k  )+sig(i,j-1,k  )+sig(i-1,j,k  )+sig(i,j,k  )));
-    }
-}
-
-AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-void mlndlap_res_fine_contrib (int i, int j, int k, Array4<Real> const& f,
-                               Array4<Real const> const& Ax, Array4<int const> const& msk) noexcept
-{
-    constexpr Real rfd = Real(0.125);
-    constexpr Real chip = Real(0.5);
-    constexpr Real chip2 = Real(0.25);
-    constexpr Real chip3 = Real(0.125);
-
-    int ii = 2*i;
-    int jj = 2*j;
-    int kk = 2*k;
-    if (msk(ii,jj,kk)) {
-        f(i,j,k) += rfd*
-            (Ax(ii,jj,kk)
-             + chip*(Ax(ii,jj,kk-1)+Ax(ii,jj,kk+1)
-                     +Ax(ii,jj-1,kk)+Ax(ii,jj+1,kk)
-                     +Ax(ii-1,jj,kk)+Ax(ii+1,jj,kk))
-             + chip2*(Ax(ii,jj-1,kk-1)+Ax(ii,jj+1,kk-1)+Ax(ii,jj-1,kk+1)+Ax(ii,jj+1,kk+1)
-                      +Ax(ii-1,jj,kk-1)+Ax(ii+1,jj,kk-1)+Ax(ii-1,jj,kk+1)+Ax(ii+1,jj,kk+1)
-                      +Ax(ii-1,jj-1,kk)+Ax(ii+1,jj-1,kk)+Ax(ii-1,jj+1,kk)+Ax(ii+1,jj+1,kk))
-             + chip3*(Ax(ii-1,jj-1,kk-1)+Ax(ii+1,jj-1,kk-1)
-                      +Ax(ii-1,jj+1,kk-1)+Ax(ii+1,jj+1,kk-1)
-                      +Ax(ii-1,jj-1,kk+1)+Ax(ii+1,jj-1,kk+1)
-                      +Ax(ii-1,jj+1,kk+1)+Ax(ii+1,jj+1,kk+1)));
-    }
-}
-
-AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-void mlndlap_res_cf_contrib (int i, int j, int k, Array4<Real> const& res,
-                             Array4<Real const> const& phi, Array4<Real const> const& rhs,
-                             Array4<Real const> const& sig, Array4<int const> const& dmsk,
-                             Array4<int const> const& ndmsk, Array4<int const> const& ccmsk,
-                             Array4<Real const> const& fc,
-                             GpuArray<Real,AMREX_SPACEDIM> const& dxinv, Box const& nddom,
-                             GpuArray<LinOpBCType, AMREX_SPACEDIM> const& bclo,
-                             GpuArray<LinOpBCType, AMREX_SPACEDIM> const& bchi,
-                             bool neumann_doubling) noexcept
-{
-    if (!dmsk(i,j,k) && ndmsk(i,j,k) == crse_fine_node) {
-
-        Real facx = Real(1./36.)*dxinv[0]*dxinv[0];
-        Real facy = Real(1./36.)*dxinv[1]*dxinv[1];
-        Real facz = Real(1./36.)*dxinv[2]*dxinv[2];
-
-        Real Ax = Real(0.);
-        if (ccmsk(i-1,j-1,k-1) == crse_cell) {
+namespace {
+    template <typename P, typename S>
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    Real mlndlap_sum_Ax (P && pred, S && sig,
+                         int i, int j, int k, Real facx, Real facy, Real facz,
+                         Array4<Real const> const& phi) noexcept
+    {
+        Real Ax = Real(0.0);
+        if (pred(i-1,j-1,k-1)) {
             Ax += sig(i-1,j-1,k-1)*(facx*(Real(4.)*(phi(i-1,j  ,k  )-phi(i  ,j  ,k  ))
                                          +Real(2.)*(phi(i-1,j-1,k  )-phi(i  ,j-1,k  ))
                                          +Real(2.)*(phi(i-1,j  ,k-1)-phi(i  ,j  ,k-1))
@@ -2512,7 +2501,7 @@ void mlndlap_res_cf_contrib (int i, int j, int k, Array4<Real> const& res,
                                          +Real(2.)*(phi(i  ,j-1,k-1)-phi(i  ,j-1,k  ))
                                          +         (phi(i-1,j-1,k-1)-phi(i-1,j-1,k  ))));
         }
-        if (ccmsk(i,j-1,k-1) == crse_cell) {
+        if (pred(i,j-1,k-1)) {
             Ax += sig(i,j-1,k-1)*(facx*(Real(4.)*(phi(i+1,j  ,k  )-phi(i  ,j  ,k  ))
                                        +Real(2.)*(phi(i+1,j-1,k  )-phi(i  ,j-1,k  ))
                                        +Real(2.)*(phi(i+1,j  ,k-1)-phi(i  ,j  ,k-1))
@@ -2526,7 +2515,7 @@ void mlndlap_res_cf_contrib (int i, int j, int k, Array4<Real> const& res,
                                        +Real(2.)*(phi(i  ,j-1,k-1)-phi(i  ,j-1,k  ))
                                        +         (phi(i+1,j-1,k-1)-phi(i+1,j-1,k  ))));
         }
-        if (ccmsk(i-1,j,k-1) == crse_cell) {
+        if (pred(i-1,j,k-1)) {
             Ax += sig(i-1,j,k-1)*(facx*(Real(4.)*(phi(i-1,j  ,k  )-phi(i  ,j  ,k  ))
                                        +Real(2.)*(phi(i-1,j+1,k  )-phi(i  ,j+1,k  ))
                                        +Real(2.)*(phi(i-1,j  ,k-1)-phi(i  ,j  ,k-1))
@@ -2540,7 +2529,7 @@ void mlndlap_res_cf_contrib (int i, int j, int k, Array4<Real> const& res,
                                         +Real(2.)*(phi(i  ,j+1,k-1)-phi(i  ,j+1,k  ))
                                         +         (phi(i-1,j+1,k-1)-phi(i-1,j+1,k  ))));
         }
-        if (ccmsk(i,j,k-1) == crse_cell) {
+        if (pred(i,j,k-1)) {
             Ax += sig(i,j,k-1)*(facx*(Real(4.)*(phi(i+1,j  ,k  )-phi(i  ,j  ,k  ))
                                      +Real(2.)*(phi(i+1,j+1,k  )-phi(i  ,j+1,k  ))
                                      +Real(2.)*(phi(i+1,j  ,k-1)-phi(i  ,j  ,k-1))
@@ -2554,7 +2543,7 @@ void mlndlap_res_cf_contrib (int i, int j, int k, Array4<Real> const& res,
                                      +Real(2.)*(phi(i  ,j+1,k-1)-phi(i  ,j+1,k  ))
                                      +         (phi(i+1,j+1,k-1)-phi(i+1,j+1,k  ))));
         }
-        if (ccmsk(i-1,j-1,k) == crse_cell) {
+        if (pred(i-1,j-1,k)) {
             Ax += sig(i-1,j-1,k)*(facx*(Real(4.)*(phi(i-1,j  ,k  )-phi(i  ,j  ,k  ))
                                        +Real(2.)*(phi(i-1,j-1,k  )-phi(i  ,j-1,k  ))
                                        +Real(2.)*(phi(i-1,j  ,k+1)-phi(i  ,j  ,k+1))
@@ -2568,7 +2557,7 @@ void mlndlap_res_cf_contrib (int i, int j, int k, Array4<Real> const& res,
                                        +Real(2.)*(phi(i  ,j-1,k+1)-phi(i  ,j-1,k  ))
                                        +         (phi(i-1,j-1,k+1)-phi(i-1,j-1,k  ))));
         }
-        if (ccmsk(i,j-1,k) == crse_cell) {
+        if (pred(i,j-1,k)) {
             Ax += sig(i,j-1,k)*(facx*(Real(4.)*(phi(i+1,j  ,k  )-phi(i  ,j  ,k  ))
                                      +Real(2.)*(phi(i+1,j-1,k  )-phi(i  ,j-1,k  ))
                                      +Real(2.)*(phi(i+1,j  ,k+1)-phi(i  ,j  ,k+1))
@@ -2582,7 +2571,7 @@ void mlndlap_res_cf_contrib (int i, int j, int k, Array4<Real> const& res,
                                      +Real(2.)*(phi(i  ,j-1,k+1)-phi(i  ,j-1,k  ))
                                      +         (phi(i+1,j-1,k+1)-phi(i+1,j-1,k  ))));
         }
-        if (ccmsk(i-1,j,k) == crse_cell) {
+        if (pred(i-1,j,k)) {
             Ax += sig(i-1,j,k)*(facx*(Real(4.)*(phi(i-1,j  ,k  )-phi(i  ,j  ,k  ))
                                      +Real(2.)*(phi(i-1,j+1,k  )-phi(i  ,j+1,k  ))
                                      +Real(2.)*(phi(i-1,j  ,k+1)-phi(i  ,j  ,k+1))
@@ -2596,7 +2585,7 @@ void mlndlap_res_cf_contrib (int i, int j, int k, Array4<Real> const& res,
                                      +Real(2.)*(phi(i  ,j+1,k+1)-phi(i  ,j+1,k  ))
                                      +         (phi(i-1,j+1,k+1)-phi(i-1,j+1,k  ))));
         }
-        if (ccmsk(i,j,k) == crse_cell) {
+        if (pred(i,j,k)) {
             Ax += sig(i,j,k)*(facx*(Real(4.)*(phi(i+1,j  ,k  )-phi(i  ,j  ,k  ))
                                    +Real(2.)*(phi(i+1,j+1,k  )-phi(i  ,j+1,k  ))
                                    +Real(2.)*(phi(i+1,j  ,k+1)-phi(i  ,j  ,k+1))
@@ -2610,204 +2599,150 @@ void mlndlap_res_cf_contrib (int i, int j, int k, Array4<Real> const& res,
                                    +Real(2.)*(phi(i  ,j+1,k+1)-phi(i  ,j+1,k  ))
                                    +         (phi(i+1,j+1,k+1)-phi(i+1,j+1,k  ))));
         }
+        return Ax;
+    }
 
-        Real Axf = fc(i,j,k);
-        if (neumann_doubling) {
-            const auto ndlo = amrex::lbound(nddom);
-            const auto ndhi = amrex::ubound(nddom);
+    template <int rr, typename S>
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    void mlndlap_Ax_fine_contrib_doit (S&& sig,
+                                       int i, int j, int k, Box const& ndbx, Box const& ccbx,
+                                       Array4<Real> const& f, Array4<Real const> const& res,
+                                       Array4<Real const> const& rhs,
+                                       Array4<Real const> const& phi,
+                                       Array4<int const> const& msk,
+                                       GpuArray<Real,AMREX_SPACEDIM> const& dxinv) noexcept
+    {
+        const int ii = rr*i;
+        const int jj = rr*j;
+        const int kk = rr*k;
+        if (msk(ii,jj,kk)) {
+            Real facx = Real(1./36.)*dxinv[0]*dxinv[0];
+            Real facy = Real(1./36.)*dxinv[1]*dxinv[1];
+            Real facz = Real(1./36.)*dxinv[1]*dxinv[1];
 
-            if (i == ndlo.x && (bclo[0] == LinOpBCType::Neumann ||
-                                 bclo[0] == LinOpBCType::inflow)) {
-                Axf *= Real(2.);
-            } else if (i== ndhi.x && (bchi[0] == LinOpBCType::Neumann ||
-                                       bchi[0] == LinOpBCType::inflow)) {
-                Axf *= Real(2.);
-            }
+            auto is_fine = [&ccbx] (int ix, int iy, int iz) -> bool {
+                return ccbx.contains(ix,iy,iz);
+            };
 
-            if (j == ndlo.y && ( bclo[1] == LinOpBCType::Neumann ||
-                                  bclo[1] == LinOpBCType::inflow)) {
-                Axf *= Real(2.);
-            } else if (j == ndhi.y && (bchi[1] == LinOpBCType::Neumann ||
-                                        bchi[1] == LinOpBCType::inflow)) {
-                Axf *= Real(2.);
-            }
+            Real Df = Real(0.0);
 
-            if (k == ndlo.z && (bclo[2] == LinOpBCType::Neumann ||
-                                 bclo[2] == LinOpBCType::inflow)) {
-                Axf *= Real(2.);
-            } else if (k == ndhi.z && (bchi[2] == LinOpBCType::Neumann ||
-                                        bchi[2] == LinOpBCType::inflow)) {
-                Axf *= Real(2.);
-            }
+            const int ilo = amrex::max(ii-rr+1, ndbx.smallEnd(0));
+            const int ihi = amrex::min(ii+rr-1, ndbx.bigEnd  (0));
+            const int jlo = amrex::max(jj-rr+1, ndbx.smallEnd(1));
+            const int jhi = amrex::min(jj+rr-1, ndbx.bigEnd  (1));
+            const int klo = amrex::max(kk-rr+1, ndbx.smallEnd(2));
+            const int khi = amrex::min(kk+rr-1, ndbx.bigEnd  (2));
+
+            for (int koff = klo; koff <= khi; ++koff) {
+            for (int joff = jlo; joff <= jhi; ++joff) {
+            for (int ioff = ilo; ioff <= ihi; ++ioff) {
+                Real scale = static_cast<Real>((rr-amrex::Math::abs(ii-ioff)) *
+                                               (rr-amrex::Math::abs(jj-joff)) *
+                                               (rr-amrex::Math::abs(kk-koff)));
+                if (ndbx.strictly_contains(ioff,joff,koff)) {
+                    Df += scale * (rhs(ioff,joff,koff)-res(ioff,joff,koff));
+                } else {
+                    Df += scale * mlndlap_sum_Ax
+                        (is_fine, sig, ioff, joff, koff, facx, facy, facz, phi);
+                }
+            }}}
+
+            f(i,j,k) = Df * (Real(1.0)/static_cast<Real>(rr*rr*rr*rr*rr*rr));
+        } else {
+            f(i,j,k) = Real(0.0);
         }
+    }
+}
 
-        res(i,j,k) = rhs(i,j,k) - (Ax + Axf);
+template <int rr>
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void mlndlap_Ax_fine_contrib (int i, int j, int k, Box const& ndbx, Box const& ccbx,
+                              Array4<Real> const& f, Array4<Real const> const& res,
+                              Array4<Real const> const& rhs, Array4<Real const> const& phi,
+                              Array4<Real const> const& sig, Array4<int const> const& msk,
+                              GpuArray<Real,AMREX_SPACEDIM> const& dxinv) noexcept
+{
+    mlndlap_Ax_fine_contrib_doit<rr>
+        ([&sig] (int ix, int iy, int iz) -> Real const& { return sig(ix,iy,iz); },
+         i,j,k,ndbx,ccbx,f,res,rhs,phi,msk,dxinv);
+}
+
+template <int rr>
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void mlndlap_Ax_fine_contrib_cs (int i, int j, int k, Box const& ndbx, Box const& ccbx,
+                                 Array4<Real> const& f, Array4<Real const> const& res,
+                                 Array4<Real const> const& rhs, Array4<Real const> const& phi,
+                                 Real const sig, Array4<int const> const& msk,
+                                 GpuArray<Real,AMREX_SPACEDIM> const& dxinv) noexcept
+{
+    mlndlap_Ax_fine_contrib_doit<rr>
+        ([&sig] (int, int, int) -> Real const& { return sig; },
+         i,j,k,ndbx,ccbx,f,res,rhs,phi,msk,dxinv);
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void mlndlap_res_cf_contrib (int i, int j, int k, Array4<Real> const& res,
+                             Array4<Real const> const& phi, Array4<Real const> const& rhs,
+                             Array4<Real const> const& sig, Array4<int const> const& dmsk,
+                             Array4<int const> const& ndmsk, Array4<int const> const& ccmsk,
+                             Array4<Real const> const& fc,
+                             GpuArray<Real,AMREX_SPACEDIM> const& dxinv,
+                             Box const& ccdom_p, Box const& nddom,
+                             GpuArray<LinOpBCType, AMREX_SPACEDIM> const& bclo,
+                             GpuArray<LinOpBCType, AMREX_SPACEDIM> const& bchi,
+                             bool neumann_doubling) noexcept
+{
+    if (!dmsk(i,j,k) && ndmsk(i,j,k) == crse_fine_node) {
+        Real facx = Real(1./36.)*dxinv[0]*dxinv[0];
+        Real facy = Real(1./36.)*dxinv[1]*dxinv[1];
+        Real facz = Real(1./36.)*dxinv[2]*dxinv[2];
+
+        Real Ax = mlndlap_sum_Ax([&ccmsk, &ccdom_p] (int ix, int iy, int iz) -> bool
+                                 {
+                                     return ccdom_p.contains(ix,iy,iz)
+                                         && (ccmsk(ix,iy,iz) == crse_cell);
+                                 },
+                                 [&sig] (int ix, int iy, int iz) -> Real const&
+                                 {
+                                     return sig(ix,iy,iz);
+                                 },
+                                 i, j, k, facx, facy, facz, phi);
+        Ax += fc(i,j,k);
+        Real const ns = (neumann_doubling) ? neumann_scale(i,j,k,nddom,bclo,bchi) : Real(1.0);
+        res(i,j,k) = rhs(i,j,k) - Ax*ns;
     }
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 void mlndlap_res_cf_contrib_cs (int i, int j, int k, Array4<Real> const& res,
                                 Array4<Real const> const& phi, Array4<Real const> const& rhs,
-                                Real sig, Array4<int const> const& dmsk,
+                                Real const sig, Array4<int const> const& dmsk,
                                 Array4<int const> const& ndmsk, Array4<int const> const& ccmsk,
                                 Array4<Real const> const& fc,
-                                GpuArray<Real,AMREX_SPACEDIM> const& dxinv, Box const& nddom,
+                                GpuArray<Real,AMREX_SPACEDIM> const& dxinv,
+                                Box const& ccdom_p, Box const& nddom,
                                 GpuArray<LinOpBCType, AMREX_SPACEDIM> const& bclo,
                                 GpuArray<LinOpBCType, AMREX_SPACEDIM> const& bchi,
                                 bool neumann_doubling) noexcept
 {
     if (!dmsk(i,j,k) && ndmsk(i,j,k) == crse_fine_node) {
-
         Real facx = Real(1./36.)*dxinv[0]*dxinv[0];
         Real facy = Real(1./36.)*dxinv[1]*dxinv[1];
         Real facz = Real(1./36.)*dxinv[2]*dxinv[2];
 
-        Real Ax = Real(0.);
-        if (ccmsk(i-1,j-1,k-1) == crse_cell) {
-            Ax += facx*(Real(4.)*(phi(i-1,j  ,k  )-phi(i  ,j  ,k  ))
-                       +Real(2.)*(phi(i-1,j-1,k  )-phi(i  ,j-1,k  ))
-                       +Real(2.)*(phi(i-1,j  ,k-1)-phi(i  ,j  ,k-1))
-                       +         (phi(i-1,j-1,k-1)-phi(i  ,j-1,k-1)))
-                + facy*(Real(4.)*(phi(i  ,j-1,k  )-phi(i  ,j  ,k  ))
-                       +Real(2.)*(phi(i-1,j-1,k  )-phi(i-1,j  ,k  ))
-                       +Real(2.)*(phi(i  ,j-1,k-1)-phi(i  ,j  ,k-1))
-                       +         (phi(i-1,j-1,k-1)-phi(i-1,j  ,k-1)))
-                + facz*(Real(4.)*(phi(i  ,j  ,k-1)-phi(i  ,j  ,k  ))
-                       +Real(2.)*(phi(i-1,j  ,k-1)-phi(i-1,j  ,k  ))
-                       +Real(2.)*(phi(i  ,j-1,k-1)-phi(i  ,j-1,k  ))
-                       +         (phi(i-1,j-1,k-1)-phi(i-1,j-1,k  )));
-        }
-        if (ccmsk(i,j-1,k-1) == crse_cell) {
-            Ax += facx*(Real(4.)*(phi(i+1,j  ,k  )-phi(i  ,j  ,k  ))
-                       +Real(2.)*(phi(i+1,j-1,k  )-phi(i  ,j-1,k  ))
-                       +Real(2.)*(phi(i+1,j  ,k-1)-phi(i  ,j  ,k-1))
-                       +         (phi(i+1,j-1,k-1)-phi(i  ,j-1,k-1)))
-                + facy*(Real(4.)*(phi(i  ,j-1,k  )-phi(i  ,j  ,k  ))
-                       +Real(2.)*(phi(i+1,j-1,k  )-phi(i+1,j  ,k  ))
-                       +Real(2.)*(phi(i  ,j-1,k-1)-phi(i  ,j  ,k-1))
-                       +         (phi(i+1,j-1,k-1)-phi(i+1,j  ,k-1)))
-                + facz*(Real(4.)*(phi(i  ,j  ,k-1)-phi(i  ,j  ,k  ))
-                       +Real(2.)*(phi(i+1,j  ,k-1)-phi(i+1,j  ,k  ))
-                       +Real(2.)*(phi(i  ,j-1,k-1)-phi(i  ,j-1,k  ))
-                       +         (phi(i+1,j-1,k-1)-phi(i+1,j-1,k  )));
-        }
-        if (ccmsk(i-1,j,k-1) == crse_cell) {
-            Ax += facx*(Real(4.)*(phi(i-1,j  ,k  )-phi(i  ,j  ,k  ))
-                       +Real(2.)*(phi(i-1,j+1,k  )-phi(i  ,j+1,k  ))
-                       +Real(2.)*(phi(i-1,j  ,k-1)-phi(i  ,j  ,k-1))
-                       +         (phi(i-1,j+1,k-1)-phi(i  ,j+1,k-1)))
-                + facy*(Real(4.)*(phi(i  ,j+1,k  )-phi(i  ,j  ,k  ))
-                       +Real(2.)*(phi(i-1,j+1,k  )-phi(i-1,j  ,k  ))
-                       +Real(2.)*(phi(i  ,j+1,k-1)-phi(i  ,j  ,k-1))
-                       +         (phi(i-1,j+1,k-1)-phi(i-1,j  ,k-1)))
-                + facz*(Real(4.)*(phi(i  ,j  ,k-1)-phi(i  ,j  ,k  ))
-                       +Real(2.)*(phi(i-1,j  ,k-1)-phi(i-1,j  ,k  ))
-                       +Real(2.)*(phi(i  ,j+1,k-1)-phi(i  ,j+1,k  ))
-                       +         (phi(i-1,j+1,k-1)-phi(i-1,j+1,k  )));
-        }
-        if (ccmsk(i,j,k-1) == crse_cell) {
-            Ax += facx*(Real(4.)*(phi(i+1,j  ,k  )-phi(i  ,j  ,k  ))
-                       +Real(2.)*(phi(i+1,j+1,k  )-phi(i  ,j+1,k  ))
-                       +Real(2.)*(phi(i+1,j  ,k-1)-phi(i  ,j  ,k-1))
-                       +         (phi(i+1,j+1,k-1)-phi(i  ,j+1,k-1)))
-                + facy*(Real(4.)*(phi(i  ,j+1,k  )-phi(i  ,j  ,k  ))
-                       +Real(2.)*(phi(i+1,j+1,k  )-phi(i+1,j  ,k  ))
-                       +Real(2.)*(phi(i  ,j+1,k-1)-phi(i  ,j  ,k-1))
-                       +         (phi(i+1,j+1,k-1)-phi(i+1,j  ,k-1)))
-                + facz*(Real(4.)*(phi(i  ,j  ,k-1)-phi(i  ,j  ,k  ))
-                       +Real(2.)*(phi(i+1,j  ,k-1)-phi(i+1,j  ,k  ))
-                       +Real(2.)*(phi(i  ,j+1,k-1)-phi(i  ,j+1,k  ))
-                       +         (phi(i+1,j+1,k-1)-phi(i+1,j+1,k  )));
-        }
-        if (ccmsk(i-1,j-1,k) == crse_cell) {
-            Ax += facx*(Real(4.)*(phi(i-1,j  ,k  )-phi(i  ,j  ,k  ))
-                       +Real(2.)*(phi(i-1,j-1,k  )-phi(i  ,j-1,k  ))
-                       +Real(2.)*(phi(i-1,j  ,k+1)-phi(i  ,j  ,k+1))
-                       +         (phi(i-1,j-1,k+1)-phi(i  ,j-1,k+1)))
-                + facy*(Real(4.)*(phi(i  ,j-1,k  )-phi(i  ,j  ,k  ))
-                       +Real(2.)*(phi(i-1,j-1,k  )-phi(i-1,j  ,k  ))
-                       +Real(2.)*(phi(i  ,j-1,k+1)-phi(i  ,j  ,k+1))
-                       +         (phi(i-1,j-1,k+1)-phi(i-1,j  ,k+1)))
-                + facz*(Real(4.)*(phi(i  ,j  ,k+1)-phi(i  ,j  ,k  ))
-                       +Real(2.)*(phi(i-1,j  ,k+1)-phi(i-1,j  ,k  ))
-                       +Real(2.)*(phi(i  ,j-1,k+1)-phi(i  ,j-1,k  ))
-                       +         (phi(i-1,j-1,k+1)-phi(i-1,j-1,k  )));
-        }
-        if (ccmsk(i,j-1,k) == crse_cell) {
-            Ax += facx*(Real(4.)*(phi(i+1,j  ,k  )-phi(i  ,j  ,k  ))
-                       +Real(2.)*(phi(i+1,j-1,k  )-phi(i  ,j-1,k  ))
-                       +Real(2.)*(phi(i+1,j  ,k+1)-phi(i  ,j  ,k+1))
-                       +         (phi(i+1,j-1,k+1)-phi(i  ,j-1,k+1)))
-                + facy*(Real(4.)*(phi(i  ,j-1,k  )-phi(i  ,j  ,k  ))
-                       +Real(2.)*(phi(i+1,j-1,k  )-phi(i+1,j  ,k  ))
-                       +Real(2.)*(phi(i  ,j-1,k+1)-phi(i  ,j  ,k+1))
-                       +         (phi(i+1,j-1,k+1)-phi(i+1,j  ,k+1)))
-                + facz*(Real(4.)*(phi(i  ,j  ,k+1)-phi(i  ,j  ,k  ))
-                       +Real(2.)*(phi(i+1,j  ,k+1)-phi(i+1,j  ,k  ))
-                       +Real(2.)*(phi(i  ,j-1,k+1)-phi(i  ,j-1,k  ))
-                       +         (phi(i+1,j-1,k+1)-phi(i+1,j-1,k  )));
-        }
-        if (ccmsk(i-1,j,k) == crse_cell) {
-            Ax += facx*(Real(4.)*(phi(i-1,j  ,k  )-phi(i  ,j  ,k  ))
-                       +Real(2.)*(phi(i-1,j+1,k  )-phi(i  ,j+1,k  ))
-                       +Real(2.)*(phi(i-1,j  ,k+1)-phi(i  ,j  ,k+1))
-                       +         (phi(i-1,j+1,k+1)-phi(i  ,j+1,k+1)))
-                + facy*(Real(4.)*(phi(i  ,j+1,k  )-phi(i  ,j  ,k  ))
-                       +Real(2.)*(phi(i-1,j+1,k  )-phi(i-1,j  ,k  ))
-                       +Real(2.)*(phi(i  ,j+1,k+1)-phi(i  ,j  ,k+1))
-                       +         (phi(i-1,j+1,k+1)-phi(i-1,j  ,k+1)))
-                + facz*(Real(4.)*(phi(i  ,j  ,k+1)-phi(i  ,j  ,k  ))
-                       +Real(2.)*(phi(i-1,j  ,k+1)-phi(i-1,j  ,k  ))
-                       +Real(2.)*(phi(i  ,j+1,k+1)-phi(i  ,j+1,k  ))
-                       +         (phi(i-1,j+1,k+1)-phi(i-1,j+1,k  )));
-        }
-        if (ccmsk(i,j,k) == crse_cell) {
-            Ax += facx*(Real(4.)*(phi(i+1,j  ,k  )-phi(i  ,j  ,k  ))
-                       +Real(2.)*(phi(i+1,j+1,k  )-phi(i  ,j+1,k  ))
-                       +Real(2.)*(phi(i+1,j  ,k+1)-phi(i  ,j  ,k+1))
-                       +         (phi(i+1,j+1,k+1)-phi(i  ,j+1,k+1)))
-                + facy*(Real(4.)*(phi(i  ,j+1,k  )-phi(i  ,j  ,k  ))
-                       +Real(2.)*(phi(i+1,j+1,k  )-phi(i+1,j  ,k  ))
-                       +Real(2.)*(phi(i  ,j+1,k+1)-phi(i  ,j  ,k+1))
-                       +         (phi(i+1,j+1,k+1)-phi(i+1,j  ,k+1)))
-                + facz*(Real(4.)*(phi(i  ,j  ,k+1)-phi(i  ,j  ,k  ))
-                       +Real(2.)*(phi(i+1,j  ,k+1)-phi(i+1,j  ,k  ))
-                       +Real(2.)*(phi(i  ,j+1,k+1)-phi(i  ,j+1,k  ))
-                       +         (phi(i+1,j+1,k+1)-phi(i+1,j+1,k  )));
-        }
-        Ax *= sig;
-
-        Real Axf = fc(i,j,k);
-        if (neumann_doubling) {
-            const auto ndlo = amrex::lbound(nddom);
-            const auto ndhi = amrex::ubound(nddom);
-
-            if (i == ndlo.x && (bclo[0] == LinOpBCType::Neumann ||
-                                 bclo[0] == LinOpBCType::inflow)) {
-                Axf *= Real(2.);
-            } else if (i== ndhi.x && (bchi[0] == LinOpBCType::Neumann ||
-                                       bchi[0] == LinOpBCType::inflow)) {
-                Axf *= Real(2.);
-            }
-
-            if (j == ndlo.y && ( bclo[1] == LinOpBCType::Neumann ||
-                                  bclo[1] == LinOpBCType::inflow)) {
-                Axf *= Real(2.);
-            } else if (j == ndhi.y && (bchi[1] == LinOpBCType::Neumann ||
-                                        bchi[1] == LinOpBCType::inflow)) {
-                Axf *= Real(2.);
-            }
-
-            if (k == ndlo.z && (bclo[2] == LinOpBCType::Neumann ||
-                                 bclo[2] == LinOpBCType::inflow)) {
-                Axf *= Real(2.);
-            } else if (k == ndhi.z && (bchi[2] == LinOpBCType::Neumann ||
-                                        bchi[2] == LinOpBCType::inflow)) {
-                Axf *= Real(2.);
-            }
-        }
-
-        res(i,j,k) = rhs(i,j,k) - (Ax + Axf);
+        Real Ax = mlndlap_sum_Ax([&ccmsk, &ccdom_p] (int ix, int iy, int iz) -> bool
+                                 {
+                                     return ccdom_p.contains(ix,iy,iz)
+                                         && (ccmsk(ix,iy,iz) == crse_cell);
+                                 },
+                                 [&sig] (int, int, int) -> Real const&
+                                 {
+                                     return sig;
+                                 },
+                                 i, j, k, facx, facy, facz, phi);
+        Ax += fc(i,j,k);
+        Real const ns = (neumann_doubling) ? neumann_scale(i,j,k,nddom,bclo,bchi) : Real(1.0);
+        res(i,j,k) = rhs(i,j,k) - Ax*ns;
     }
 }
 

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLap_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLap_K.H
@@ -11,7 +11,7 @@
 namespace amrex {
 namespace {
 
-    constexpr int crse_cell = 0;
+    constexpr int crse_cell = 0; // Do NOT change the values
     constexpr int fine_cell = 1;
     constexpr int crse_node = 0;
     constexpr int crse_fine_node = 1;

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian.H
@@ -113,7 +113,7 @@ public :
     virtual void unimposeNeumannBC (int amrlev, MultiFab& rhs) const final override;
 
     virtual void compGrad (int /*amrlev*/, const Array<MultiFab*,AMREX_SPACEDIM>& /*grad*/,
-			   MultiFab& /*sol*/, Location /*loc*/) const final override {
+                           MultiFab& /*sol*/, Location /*loc*/) const final override {
         amrex::Abort("MLNodeLaplacian::compGrad: How did we get here?");
     }
     void compGrad (int amrlev, MultiFab& grad, MultiFab& sol) const;

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian.cpp
@@ -165,6 +165,16 @@ MLNodeLaplacian::compRHS (const Vector<MultiFab*>& rhs, const Vector<MultiFab*>&
                           const Vector<const MultiFab*>& rhnd,
                           const Vector<MultiFab*>& a_rhcc)
 {
+    //
+    // Note that div vel we copmute on a coarse/fine nodes is not a
+    // composite divergence.  It has been restricted so that it is suitable
+    // as RHS for our geometric mulitgrid solver with a MG hirerachy
+    // including multiple AMR levels.
+    //
+    // Also note that even for RAP, we do doubling at Nuemann boundary,
+    // because unimposeNeumannBC will be called on rhs for RAP.
+    //
+
     BL_PROFILE("MLNodeLaplacian::compRHS()");
 
     if (!m_masks_built) buildMasks();
@@ -180,6 +190,12 @@ MLNodeLaplacian::compRHS (const Vector<MultiFab*>& rhs, const Vector<MultiFab*>&
     const auto lobc = LoBC();
     const auto hibc = HiBC();
 
+    bool has_inflow = false;
+    for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+        has_inflow = has_inflow || (lobc[idim] == LinOpBCType::inflow ||
+                                    hibc[idim] == LinOpBCType::inflow);
+    }
+
     Vector<std::unique_ptr<MultiFab> > rhcc(m_num_amr_levels);
     Vector<std::unique_ptr<MultiFab> > rhs_cc(m_num_amr_levels);
 
@@ -188,6 +204,44 @@ MLNodeLaplacian::compRHS (const Vector<MultiFab*>& rhs, const Vector<MultiFab*>&
         const Geometry& geom = m_geom[ilev][0];
         AMREX_ASSERT(vel[ilev]->nComp() >= AMREX_SPACEDIM);
         AMREX_ASSERT(vel[ilev]->nGrow() >= 1);
+
+        if (has_inflow) { // Zero out transverse velocity so that it's not seen.
+            Box domain = geom.Domain();
+            for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+                if (lobc[idim] != LinOpBCType::inflow) {
+                    domain.growLo(idim,1);
+                }
+                if (hibc[idim] != LinOpBCType::inflow) {
+                    domain.growHi(idim,1);
+                }
+            }
+            const auto dlo = domain.smallEnd();
+            const auto dhi = domain.bigEnd();
+#ifdef AMREX_USE_OMP
+#pragma omp parallel if (Gpu::notInLaunchRegion())
+#endif
+            for (MFIter mfi(*vel[ilev],TilingIfNotGPU()); mfi.isValid(); ++mfi)
+            {
+                const Box& bx = mfi.growntilebox(1);
+                Array4<Real> const& vfab = vel[ilev]->array(mfi);
+                if ( ! domain.contains(bx) ) {
+                    AMREX_HOST_DEVICE_PARALLEL_FOR_3D(bx, i, j, k,
+                    {
+                        IntVect cell(AMREX_D_DECL(i,j,k));
+                        for (int in = 0; in < AMREX_SPACEDIM; ++in) {
+                            for (int it = 0; it < AMREX_SPACEDIM; ++it) {
+                                if (it != in) {
+                                    if (cell[in] < dlo[in] || cell[in] > dhi[in]) {
+                                        vfab(i,j,k,it) = Real(0.0);
+                                    }
+                                }
+                            }
+                        }
+                    });
+                }
+            }
+        }
+
         vel[ilev]->FillBoundary(0, AMREX_SPACEDIM, IntVect(1), geom.periodicity());
 
         if (ilev < a_rhcc.size() && a_rhcc[ilev])
@@ -212,6 +266,9 @@ MLNodeLaplacian::compRHS (const Vector<MultiFab*>& rhs, const Vector<MultiFab*>&
         const FabArray<EBCellFlagFab>* flags = (factory) ? &(factory->getMultiEBCellFlagFab()) : nullptr;
         const MultiFab* vfrac = (factory) ? &(factory->getVolFrac()) : nullptr;
         const MultiFab* intg = m_integral[ilev].get();
+
+        AMREX_ALWAYS_ASSERT(ilev == m_num_amr_levels-1 || AMRRefRatio(ilev) == 2
+                            || factory == nullptr || factory->isAllRegular());
 #endif
 
         MFItInfo mfi_info;
@@ -314,15 +371,14 @@ MLNodeLaplacian::compRHS (const Vector<MultiFab*>& rhs, const Vector<MultiFab*>&
 
     for (int ilev = 0; ilev < m_num_amr_levels-1; ++ilev)
     {
-        const Geometry& cgeom = m_geom[ilev  ][0];
+        const int amrrr = AMRRefRatio(ilev);
         const Geometry& fgeom = m_geom[ilev+1][0];
+        AMREX_ALWAYS_ASSERT(amrrr == 2 || amrrr == 4);
 
-        frhs[ilev].reset(new MultiFab(amrex::coarsen(rhs[ilev+1]->boxArray(),2),
+        frhs[ilev].reset(new MultiFab(amrex::coarsen(rhs[ilev+1]->boxArray(),amrrr),
                                       rhs[ilev+1]->DistributionMap(), 1, 0));
-        frhs[ilev]->setVal(0.0);
 
-        const Box& cccdom = cgeom.Domain();
-        const Box& nddom = amrex::surroundingNodes(fgeom.Domain());
+        const Box& ccfdom = fgeom.Domain();
         const auto fdxinv = fgeom.InvCellSizeArray();
         const iMultiFab& fdmsk = *m_dirichlet_mask[ilev+1][0];
 
@@ -331,110 +387,76 @@ MLNodeLaplacian::compRHS (const Vector<MultiFab*>& rhs, const Vector<MultiFab*>&
 #ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
+        for (MFIter mfi(*frhs[ilev],mfi_info); mfi.isValid(); ++mfi)
         {
-            FArrayBox vfab, rfab, rhccfab;
-            for (MFIter mfi(*frhs[ilev],mfi_info); mfi.isValid(); ++mfi)
+            const Box& cbx = mfi.tilebox();
+            const Box& fvbx = amrex::refine(mfi.validbox(),amrrr);
+            const Box& cc_fvbx = amrex::enclosedCells(fvbx);
+
+            Box bx_vel = cc_fvbx;
+            for (int idim = 0; idim < AMREX_SPACEDIM; ++idim)
             {
-                const Box& cvbx = mfi.validbox();
-                const Box& fvbx = amrex::refine(cvbx,2);
-                const Box& cbx = mfi.tilebox();
-                const Box& fbx = amrex::refine(cbx,2);
-
-                const Box& cc_fbx = amrex::enclosedCells(fbx);
-                const Box& cc_fvbx = amrex::enclosedCells(fvbx);
-
-                const Box& bx_vel = amrex::grow(cc_fbx,2) & amrex::grow(cc_fvbx,1);
-                Box b = bx_vel & cc_fvbx;
-                for (int idim = 0; idim < AMREX_SPACEDIM; ++idim)
+                if (m_lobc[0][idim] == LinOpBCType::inflow)
                 {
-                    if (m_lobc[0][idim] == LinOpBCType::inflow)
-                    {
-                        if (b.smallEnd(idim) == cccdom.smallEnd(idim)) {
-                            b.growLo(idim, 1);
-                        }
-                    }
-                    if (m_hibc[0][idim] == LinOpBCType::inflow)
-                    {
-                        if (b.bigEnd(idim) == cccdom.bigEnd(idim)) {
-                            b.growHi(idim, 1);
-                        }
+                    if (bx_vel.smallEnd(idim) == ccfdom.smallEnd(idim)) {
+                        bx_vel.growLo(idim, 1);
                     }
                 }
-
-                vfab.resize(bx_vel, AMREX_SPACEDIM);
-                Elixir veli = vfab.elixir();
-                Array4<Real> const& varr = vfab.array();
-
-                const Box& bx_rhs = amrex::grow(fbx,1);
-                const Box& b2 = bx_rhs & amrex::grow(fvbx,-1);
-                rfab.resize(bx_rhs);
-                Elixir reli = rfab.elixir();
-                Array4<Real> const& rarr = rfab.array();
-
-                Array4<Real const> const& varr_orig = vel[ilev+1]->const_array(mfi);
-                AMREX_HOST_DEVICE_FOR_4D(bx_vel, AMREX_SPACEDIM, i, j, k, n,
+                if (m_hibc[0][idim] == LinOpBCType::inflow)
                 {
-                    if (b.contains(IntVect(AMREX_D_DECL(i,j,k)))) {
-                        varr(i,j,k,n) = varr_orig(i,j,k,n);
-                    } else {
-                        varr(i,j,k,n) = 0.0;
+                    if (bx_vel.bigEnd(idim) == ccfdom.bigEnd(idim)) {
+                        bx_vel.growHi(idim, 1);
                     }
-                });
+                }
+            }
 
-                Array4<Real const> const& rarr_orig = rhs[ilev+1]->const_array(mfi);
+            Array4<Real> const& rhsarr = frhs[ilev]->array(mfi);
+            Array4<Real const> const& velarr = vel[ilev+1]->const_array(mfi);
+            Array4<Real const> const& rhsarr_fine = rhs[ilev+1]->const_array(mfi);
+            Array4<int const> const& mskarr = fdmsk.const_array(mfi);
 #if (AMREX_SPACEDIM == 2)
-                AMREX_HOST_DEVICE_FOR_3D(bx_rhs, i, j, k,
+            if (amrrr == 2) {
+                AMREX_HOST_DEVICE_PARALLEL_FOR_3D(cbx, i, j, k,
                 {
-                    if (b2.contains(IntVect(AMREX_D_DECL(i,j,k)))) {
-                        rarr(i,j,k) = rarr_orig(i,j,k);
-                    } else {
-                        rarr(i,j,k) = 0.0;
-                    }
-                    mlndlap_divu_compute_fine_contrib(i,j,k,fvbx,rarr,varr,fdxinv,
-                                                      nddom,lobc,hibc,is_rz);
+                    mlndlap_divu_fine_contrib<2>(i,j,k,fvbx,bx_vel,rhsarr,velarr,rhsarr_fine,
+                                                 mskarr,fdxinv,is_rz);
                 });
-#else
-                AMREX_HOST_DEVICE_FOR_3D(bx_rhs, i, j, k,
+            } else {
+                AMREX_HOST_DEVICE_PARALLEL_FOR_3D(cbx, i, j, k,
                 {
-                    if (b2.contains(IntVect(AMREX_D_DECL(i,j,k)))) {
-                        rarr(i,j,k) = rarr_orig(i,j,k);
-                    } else {
-                        rarr(i,j,k) = 0.0;
-                    }
-                    mlndlap_divu_compute_fine_contrib(i,j,k,fvbx,rarr,varr,fdxinv,
-                                                      nddom,lobc,hibc);
+                    mlndlap_divu_fine_contrib<4>(i,j,k,fvbx,bx_vel,rhsarr,velarr,rhsarr_fine,
+                                                 mskarr,fdxinv,is_rz);
                 });
+            }
+#elif (AMREX_SPACEDIM == 3)
+            if (amrrr == 2) {
+                AMREX_HOST_DEVICE_PARALLEL_FOR_3D(cbx, i, j, k,
+                {
+                    mlndlap_divu_fine_contrib<2>(i,j,k,fvbx,bx_vel,rhsarr,velarr,rhsarr_fine,
+                                                 mskarr,fdxinv);
+                });
+            } else {
+                AMREX_HOST_DEVICE_PARALLEL_FOR_3D(cbx, i, j, k,
+                {
+                    mlndlap_divu_fine_contrib<4>(i,j,k,fvbx,bx_vel,rhsarr,velarr,rhsarr_fine,
+                                                 mskarr,fdxinv);
+                });
+            }
 #endif
 
-                Array4<Real> const& rhsarr = frhs[ilev]->array(mfi);
-                Array4<int const> const& mskarr = fdmsk.const_array(mfi);
-                AMREX_HOST_DEVICE_FOR_3D(cbx, i, j, k,
-                {
-                    mlndlap_divu_add_fine_contrib(i,j,k,fvbx,rhsarr,rarr,mskarr);
-                });
-
-                if (rhcc[ilev+1])
-                {
-                    const Box& bx_rhcc = amrex::grow(cc_fbx,2);
-                    const Box& b3 = bx_rhcc & cc_fvbx;
-
-                    rhccfab.resize(bx_rhcc);
-                    Elixir rhcceli = rhccfab.elixir();
-                    Array4<Real> const& rhccarr = rhccfab.array();
-
-                    Array4<Real const> const& rhccarr_orig = rhcc[ilev+1]->const_array(mfi);
-                    AMREX_HOST_DEVICE_FOR_3D(bx_rhcc, i, j, k,
-                    {
-                        if (b3.contains(IntVect(AMREX_D_DECL(i,j,k)))) {
-                            rhccarr(i,j,k) = rhccarr_orig(i,j,k);
-                        } else {
-                            rhccarr(i,j,k) = 0.0;
-                        }
-                    });
-
+            if (rhcc[ilev+1])
+            {
+                // xxxxx TODO: incorrect if cut cells are too close to coarse/fine boundary
+                Array4<Real const> const& rhccarr = rhcc[ilev+1]->const_array(mfi);
+                if (amrrr == 2) {
                     AMREX_HOST_DEVICE_FOR_3D(cbx, i, j, k,
                     {
-                        mlndlap_rhcc_fine_contrib(i,j,k,fvbx,rhsarr,rhccarr,mskarr);
+                        mlndlap_rhcc_fine_contrib<2>(i,j,k,cc_fvbx,rhsarr,rhccarr,mskarr);
+                    });
+                } else {
+                    AMREX_HOST_DEVICE_FOR_3D(cbx, i, j, k,
+                    {
+                        mlndlap_rhcc_fine_contrib<4>(i,j,k,cc_fvbx,rhsarr,rhccarr,mskarr);
                     });
                 }
             }
@@ -457,6 +479,16 @@ MLNodeLaplacian::compRHS (const Vector<MultiFab*>& rhs, const Vector<MultiFab*>&
         crhs.ParallelAdd(*frhs[ilev], cgeom.periodicity());
 
         const Box& cccdom = cgeom.Domain();
+        const Box& cccdom_p = cgeom.growPeriodicDomain(1);
+        Box cccdom_pi = cccdom_p;
+        for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+            if (lobc[idim] == LinOpBCType::inflow) {
+                cccdom_pi.growLo(idim,1);
+            }
+            if (hibc[idim] == LinOpBCType::inflow) {
+                cccdom_pi.growHi(idim,1);
+            }
+        }
         const Box& cnddom = amrex::surroundingNodes(cccdom);
         const auto cdxinv = cgeom.InvCellSizeArray();
         const iMultiFab& cdmsk = *m_dirichlet_mask[ilev][0];
@@ -464,14 +496,12 @@ MLNodeLaplacian::compRHS (const Vector<MultiFab*>& rhs, const Vector<MultiFab*>&
         const iMultiFab& c_cc_mask = *m_cc_fine_mask[ilev];
         const auto& has_fine_bndry = *m_has_fine_bndry[ilev];
 
-        bool neumann_doubling = true; // yes even for RAP, because unimposeNeumannBC will be called on rhs
-
         MFItInfo mfi_info;
         if (Gpu::notInLaunchRegion()) mfi_info.EnableTiling().SetDynamic(true);
 #ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
-        for (MFIter mfi(*rhs[ilev]); mfi.isValid(); ++mfi)
+        for (MFIter mfi(*rhs[ilev],mfi_info); mfi.isValid(); ++mfi)
         {
             if (has_fine_bndry[mfi])
             {
@@ -492,14 +522,14 @@ MLNodeLaplacian::compRHS (const Vector<MultiFab*>& rhs, const Vector<MultiFab*>&
                     mlndlap_divu_cf_contrib(i,j,k,rhsarr,velarr,crhsarr,rhccarr,
                                             cdmskarr,ndmskarr,ccmskarr,
                                             is_rz,
-                                            cdxinv,cnddom,lobc,hibc, neumann_doubling);
+                                            cdxinv,cccdom_p,cccdom_pi,cnddom,lobc,hibc);
                 });
-#else
+#elif (AMREX_SPACEDIM == 3)
                 AMREX_HOST_DEVICE_FOR_3D(bx, i, j, k,
                 {
                     mlndlap_divu_cf_contrib(i,j,k,rhsarr,velarr,crhsarr,rhccarr,
                                             cdmskarr,ndmskarr,ccmskarr,
-                                            cdxinv,cnddom,lobc,hibc, neumann_doubling);
+                                            cdxinv,cccdom_p,cccdom_pi,cnddom,lobc,hibc);
                 });
 #endif
             }
@@ -724,7 +754,7 @@ MLNodeLaplacian::getFluxes (const Vector<MultiFab*> & a_flux, const Vector<Multi
                 auto type = (*flags)[mfi].getType(bx);
                 Array4<Real const> const& vfracarr = vfrac->const_array(mfi);
                 Array4<Real const> const& intgarr = intg->const_array(mfi);
-                if (type == FabType::covered) 
+                if (type == FabType::covered)
                 { }
                 else if (type == FabType::singlevalued)
                 {
@@ -884,7 +914,7 @@ MLNodeLaplacian::averageDownCoeffsSameAmrLevel (int amrlev)
             }
 
             MultiFab* pcrse = (need_parallel_copy) ? &cfine : &crse;
-            
+
             if (regular_coarsening) {
 #ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
@@ -973,7 +1003,7 @@ MLNodeLaplacian::buildStencil ()
         m_stencil[amrlev].resize(m_num_mg_levels[amrlev]);
         m_s0_norm0[amrlev].resize(m_num_mg_levels[amrlev],0.0);
     }
-    
+
     if (m_coarsening_strategy != CoarseningStrategy::RAP) return;
 
     const int ncomp_s = (AMREX_SPACEDIM == 2) ? 5 : 9;
@@ -984,6 +1014,7 @@ MLNodeLaplacian::buildStencil ()
 
     for (int amrlev = 0; amrlev < m_num_amr_levels; ++amrlev)
     {
+        AMREX_ALWAYS_ASSERT(amrlev == m_num_amr_levels-1 || AMRRefRatio(amrlev) == 2);
         for (int mglev = 0; mglev < m_num_mg_levels[amrlev]; ++mglev)
         {
             const int nghost = (0 == amrlev && mglev+1 == m_num_mg_levels[amrlev]) ? 1 : 4;
@@ -1176,7 +1207,6 @@ MLNodeLaplacian::buildStencil ()
         }
     }
 
-
     // This is only needed at the bottom.
     m_s0_norm0[0].back() = m_stencil[0].back()->norm0(0,0) * m_normalization_threshold;
 }
@@ -1262,20 +1292,20 @@ MLNodeLaplacian::restriction (int amrlev, int cmglev, MultiFab& crse, MultiFab& 
         Array4<int const> const& mfab = dmsk.const_array(mfi);
         if (m_coarsening_strategy == CoarseningStrategy::Sigma)
         {
-	    if (regular_coarsening) 
-	    {
-            	AMREX_HOST_DEVICE_PARALLEL_FOR_3D(bx, i, j, k,
-            	{
-               	    mlndlap_restriction(i,j,k,cfab,ffab,mfab);
-            	});
-	    }
-	    else
-	    {
+            if (regular_coarsening)
+            {
+                AMREX_HOST_DEVICE_PARALLEL_FOR_3D(bx, i, j, k,
+                {
+                    mlndlap_restriction(i,j,k,cfab,ffab,mfab);
+                });
+            }
+            else
+            {
                 AMREX_HOST_DEVICE_PARALLEL_FOR_3D(bx, i, j, k,
                 {
                     mlndlap_semi_restriction(i,j,k,cfab,ffab,mfab,idir);
                 });
-	    }
+            }
         }
         else
         {
@@ -1316,10 +1346,10 @@ MLNodeLaplacian::interpolation (int amrlev, int fmglev, MultiFab& fine, const Mu
     if (fmglev > 0) {
         regular_coarsening = mg_coarsen_ratio_vec[fmglev] == mg_coarsen_ratio;
         IntVect ratio = mg_coarsen_ratio_vec[fmglev];
-	if (ratio[1] == 1) {
-	    idir = 1;
+        if (ratio[1] == 1) {
+            idir = 1;
         } else if (ratio[0] == 1) {
- 	    idir = 0;
+            idir = 0;
         }
     }
     if (sigma[0] == nullptr) {
@@ -1362,21 +1392,21 @@ MLNodeLaplacian::interpolation (int amrlev, int fmglev, MultiFab& fine, const Mu
         }
         else
         { 
-	    Array4<Real const> const& sfab = sigma[0]->const_array(mfi);
-	    if (regular_coarsening)
-	    {
-            	AMREX_HOST_DEVICE_PARALLEL_FOR_3D(bx, i, j, k,
-            	{
+            Array4<Real const> const& sfab = sigma[0]->const_array(mfi);
+            if (regular_coarsening)
+            {
+                AMREX_HOST_DEVICE_PARALLEL_FOR_3D(bx, i, j, k,
+                {
                     mlndlap_interpadd_aa(i,j,k,ffab,cfab,sfab,mfab);
                 });
-	    } 
-	    else
-	    {
+            }
+            else
+            {
                 AMREX_HOST_DEVICE_PARALLEL_FOR_3D(bx, i, j, k,
                 {
                     mlndlap_semi_interpadd_aa(i,j,k,ffab,cfab,sfab,mfab,idir);
                 });
-	    } 
+            }
         }
     }
 }
@@ -1390,7 +1420,7 @@ MLNodeLaplacian::averageDownSolutionRHS (int camrlev, MultiFab& crse_sol, MultiF
 
     if (isSingular(0))
     {
-        MultiFab frhs(fine_rhs.boxArray(), fine_rhs.DistributionMap(), 1, 1);
+        MultiFab frhs(fine_rhs.boxArray(), fine_rhs.DistributionMap(), 1, amrrr-1);
         MultiFab::Copy(frhs, fine_rhs, 0, 0, 1, 0);
         restrictInteriorNodes(camrlev, crse_rhs, frhs);
     }
@@ -1401,30 +1431,36 @@ MLNodeLaplacian::restrictInteriorNodes (int camrlev, MultiFab& crhs, MultiFab& a
 {
     const BoxArray& fba = a_frhs.boxArray();
     const DistributionMapping& fdm = a_frhs.DistributionMap();
+    const int amrrr = AMRRefRatio(camrlev);
 
     MultiFab* frhs = nullptr;
     std::unique_ptr<MultiFab> mf;
-    if (a_frhs.nGrow() == 1)
+    if (a_frhs.nGrowVect().allGE(IntVect(amrrr-1)))
     {
         frhs = &a_frhs;
     }
     else
     {
-        mf.reset(new MultiFab(fba, fdm, 1, 1));
+        mf.reset(new MultiFab(fba, fdm, 1, amrrr-1));
         frhs = mf.get();
         MultiFab::Copy(*frhs, a_frhs, 0, 0, 1, 0);
     }
 
     const Geometry& cgeom = m_geom[camrlev  ][0];
+    const Geometry& fgeom = m_geom[camrlev+1][0];
+
+    const Box& f_nd_domain = amrex::surroundingNodes(fgeom.Domain());
+
+    const auto lobc = LoBC();
+    const auto hibc = HiBC();
 
     const iMultiFab& fdmsk = *m_dirichlet_mask[camrlev+1][0];
     const auto& stencil    =  m_stencil[camrlev+1][0];
 
-    MultiFab cfine(amrex::coarsen(fba, 2), fdm, 1, 0);
+    MultiFab cfine(amrex::coarsen(fba, amrrr), fdm, 1, 0);
 
     frhs->setBndry(0.0);
-
-    applyBC(camrlev+1, 0, *frhs, BCMode::Inhomogeneous, StateMode::Solution);
+    frhs->FillBoundary(fgeom.periodicity());
 
 #ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
@@ -1436,10 +1472,17 @@ MLNodeLaplacian::restrictInteriorNodes (int camrlev, MultiFab& crhs, MultiFab& a
         Array4<Real const> const& ffab = frhs->const_array(mfi);
         Array4<int const> const& mfab = fdmsk.const_array(mfi);
         if (m_coarsening_strategy == CoarseningStrategy::Sigma) {
-            AMREX_HOST_DEVICE_PARALLEL_FOR_3D(bx, i, j, k,
-            {
-                mlndlap_restriction(i,j,k,cfab,ffab,mfab);
-            });
+            if (amrrr == 2) {
+                AMREX_HOST_DEVICE_PARALLEL_FOR_3D(bx, i, j, k,
+                {
+                    mlndlap_restriction<2>(i,j,k,cfab,ffab,mfab,f_nd_domain,lobc,hibc);
+                });
+            } else {
+                AMREX_HOST_DEVICE_PARALLEL_FOR_3D(bx, i, j, k,
+                {
+                    mlndlap_restriction<4>(i,j,k,cfab,ffab,mfab,f_nd_domain,lobc,hibc);
+                });
+            }
         } else {
             Array4<Real const> const& stfab = stencil->const_array(mfi);
             AMREX_HOST_DEVICE_PARALLEL_FOR_3D(bx, i, j, k,
@@ -1654,9 +1697,9 @@ MLNodeLaplacian::Fsmooth (int amrlev, int mglev, MultiFab& sol, const MultiFab& 
     else // cpu
 #endif
     {
-	bool regular_coarsening = true;
-	if (amrlev == 0 && mglev > 0) 
-    	{
+        bool regular_coarsening = true;
+        if (amrlev == 0 && mglev > 0)
+        {
             regular_coarsening = mg_coarsen_ratio_vec[mglev-1] == mg_coarsen_ratio;
         }
         if (sigma[0] == nullptr) {
@@ -1747,8 +1790,8 @@ MLNodeLaplacian::Fsmooth (int amrlev, int mglev, MultiFab& sol, const MultiFab& 
                     Array4<Real const> const& rhsarr = rhs.const_array(mfi);
                     Array4<int const> const& dmskarr = dmsk.const_array(mfi);
 
-		    if ( regular_coarsening ) 
-		    {
+                    if ( regular_coarsening )
+                    {
                         for (int ns = 0; ns < nsweeps; ++ns) {
                             mlndlap_gauss_seidel_aa(bx, solarr, rhsarr,
                                                     sarr, dmskarr, dxinvarr
@@ -1757,16 +1800,16 @@ MLNodeLaplacian::Fsmooth (int amrlev, int mglev, MultiFab& sol, const MultiFab& 
 #endif
                                  );
                         }
-		    } else {
-			for (int ns = 0; ns < nsweeps; ++ns) {
+                    } else {
+                        for (int ns = 0; ns < nsweeps; ++ns) {
                             mlndlap_gauss_seidel_with_line_solve_aa(bx, solarr, rhsarr,
                                                                     sarr, dmskarr, dxinvarr
 #if (AMREX_SPACEDIM == 2)
                                                                    ,is_rz
 #endif
-                                 );
-			}
-		    }
+                                );
+                        }
+                    }
                 }
             }
 
@@ -2048,7 +2091,7 @@ MLNodeLaplacian::compSyncResidualCoarse (MultiFab& sync_resid, const MultiFab& a
                     Array4<Real const> const& voarr = vold.const_array(mfi);
                     AMREX_HOST_DEVICE_FOR_3D(ccbxg1, i, j, k,
                     {
-		        if (b.contains(IntVect(AMREX_D_DECL(i,j,k))) && cccmsk(i,j,k)){
+                        if (b.contains(IntVect(AMREX_D_DECL(i,j,k))) && cccmsk(i,j,k)){
                             AMREX_D_TERM(uarr(i,j,k,0) = voarr(i,j,k,0);,
                                          uarr(i,j,k,1) = voarr(i,j,k,1);,
                                          uarr(i,j,k,2) = voarr(i,j,k,2););
@@ -2097,7 +2140,7 @@ MLNodeLaplacian::compSyncResidualCoarse (MultiFab& sync_resid, const MultiFab& a
                         const Box& b2 = ccbxg1 & ccvbx;
                         AMREX_HOST_DEVICE_FOR_3D(ccbxg1, i, j, k,
                         {
- 			    if (b2.contains(IntVect(AMREX_D_DECL(i,j,k))) && cccmsk(i,j,k)){
+                            if (b2.contains(IntVect(AMREX_D_DECL(i,j,k))) && cccmsk(i,j,k)){
                                 rhccarr(i,j,k) = rhccarr_orig(i,j,k);
                             } else {
                                 rhccarr(i,j,k) = 0.0;
@@ -2507,18 +2550,41 @@ MLNodeLaplacian::compSyncResidualFine (MultiFab& sync_resid, const MultiFab& phi
 void
 MLNodeLaplacian::reflux (int crse_amrlev,
                          MultiFab& res, const MultiFab& crse_sol, const MultiFab& crse_rhs,
-                         MultiFab& fine_res, MultiFab& fine_sol, const MultiFab& fine_rhs) const
+                         MultiFab& a_fine_res, MultiFab& fine_sol, const MultiFab& fine_rhs) const
 {
+    //
+    //  Note that the residue we copmute on a coarse/fine node is not a
+    //  composite divergence.  It has been restricted so that it is suitable
+    //  as RHS for our geometric mulitgrid solver with a MG hirerachy
+    //  including multiple AMR levels.
+    //
+
     BL_PROFILE("MLNodeLaplacian::reflux()");
+
+    const int amrrr = AMRRefRatio(crse_amrlev);
+    AMREX_ALWAYS_ASSERT(amrrr == 2 || m_coarsening_strategy == CoarseningStrategy::Sigma);
 
     const Geometry& cgeom = m_geom[crse_amrlev  ][0];
     const Geometry& fgeom = m_geom[crse_amrlev+1][0];
     const auto cdxinv = cgeom.InvCellSizeArray();
     const auto fdxinv = fgeom.InvCellSizeArray();
     const Box& c_cc_domain = cgeom.Domain();
-    Box c_nd_domain = amrex::surroundingNodes(c_cc_domain);
+    const Box& c_cc_domain_p = cgeom.growPeriodicDomain(1);
+    const Box& c_nd_domain = amrex::surroundingNodes(c_cc_domain);
+    const Box& f_nd_domain = amrex::surroundingNodes(fgeom.Domain());
 
-    bool neumann_doubling = m_coarsening_strategy == CoarseningStrategy::Sigma;
+    const auto lobc = LoBC();
+    const auto hibc = HiBC();
+
+    bool neumann_doubling = false;
+    if (m_coarsening_strategy == CoarseningStrategy::Sigma) {
+        for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+            neumann_doubling = neumann_doubling || (lobc[idim] == LinOpBCType::inflow  ||
+                                                    lobc[idim] == LinOpBCType::Neumann ||
+                                                    hibc[idim] == LinOpBCType::inflow  ||
+                                                    hibc[idim] == LinOpBCType::Neumann);
+        }
+    }
 
 #if (AMREX_SPACEDIM == 2)
     bool is_rz = m_is_rz;
@@ -2530,9 +2596,16 @@ MLNodeLaplacian::reflux (int crse_amrlev,
     const iMultiFab& fdmsk = *m_dirichlet_mask[crse_amrlev+1][0];
     const auto& stencil    =  m_stencil[crse_amrlev+1][0];
 
-    MultiFab fine_res_for_coarse(amrex::coarsen(fba, 2), fdm, 1, 0);
+    MultiFab fine_res_for_coarse(amrex::coarsen(fba, amrrr), fdm, 1, 0);
 
-    applyBC(crse_amrlev+1, 0, fine_res, BCMode::Inhomogeneous, StateMode::Solution);
+    std::unique_ptr<MultiFab> tmp_fine_res;
+    if (amrrr == 4 && !a_fine_res.nGrowVect().allGE(IntVect(3))) {
+        tmp_fine_res.reset(new MultiFab(a_fine_res.boxArray(), a_fine_res.DistributionMap(), 1, 3));
+        MultiFab::Copy(*tmp_fine_res, a_fine_res, 0, 0, 1, 0);
+    }
+    MultiFab& fine_res = (tmp_fine_res) ? *tmp_fine_res :  a_fine_res;
+
+    fine_res.FillBoundary(fgeom.periodicity());
 
 #ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
@@ -2544,10 +2617,17 @@ MLNodeLaplacian::reflux (int crse_amrlev,
         Array4<Real const> const& ffab = fine_res.const_array(mfi);
         Array4<int const> const& mfab = fdmsk.const_array(mfi);
         if (m_coarsening_strategy == CoarseningStrategy::Sigma) {
-            AMREX_HOST_DEVICE_PARALLEL_FOR_3D(bx, i, j, k,
-            {
-                mlndlap_restriction(i,j,k,cfab,ffab,mfab);
-            });
+            if (amrrr == 2) {
+                AMREX_HOST_DEVICE_PARALLEL_FOR_3D(bx, i, j, k,
+                {
+                    mlndlap_restriction<2>(i,j,k,cfab,ffab,mfab,f_nd_domain,lobc,hibc);
+                });
+            } else {
+                AMREX_HOST_DEVICE_PARALLEL_FOR_3D(bx, i, j, k,
+                {
+                    mlndlap_restriction<4>(i,j,k,cfab,ffab,mfab,f_nd_domain,lobc,hibc);
+                });
+            }
         } else {
             Array4<Real const> const& stfab = stencil->const_array(mfi);
             AMREX_HOST_DEVICE_PARALLEL_FOR_3D(bx, i, j, k,
@@ -2558,8 +2638,7 @@ MLNodeLaplacian::reflux (int crse_amrlev,
     }
     res.ParallelCopy(fine_res_for_coarse, cgeom.periodicity());
 
-    MultiFab fine_contrib(amrex::coarsen(fba, 2), fdm, 1, 0);
-    fine_contrib.setVal(0.0);
+    MultiFab fine_contrib(amrex::coarsen(fba, amrrr), fdm, 1, 0);
 
     const auto& fsigma = m_sigma[crse_amrlev+1][0][0];
 
@@ -2568,81 +2647,80 @@ MLNodeLaplacian::reflux (int crse_amrlev,
 #ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
+    for (MFIter mfi(fine_contrib,mfi_info); mfi.isValid(); ++mfi)
     {
-        FArrayBox sigfab;
-        FArrayBox Axfab;
-        for (MFIter mfi(fine_contrib,mfi_info); mfi.isValid(); ++mfi)
-        {
-            const Box& cvbx = mfi.validbox();
-            const Box& fvbx = amrex::refine(cvbx,2);
-            const Box& cbx = mfi.tilebox();
-            const Box& fbx = amrex::refine(cbx,2);
+        const Box& cbx = mfi.tilebox();
+        const Box& fvbx = amrex::refine(mfi.validbox(),amrrr);
+        const Box& cc_fvbx = amrex::enclosedCells(fvbx);
 
-            const Box& cc_fbx = amrex::enclosedCells(fbx);
-            const Box& cc_fvbx = amrex::enclosedCells(fvbx);
-            const Box& bx_sig = amrex::grow(cc_fbx,2) & amrex::grow(cc_fvbx,1);
-            const Box& b = bx_sig & cc_fvbx;
+        Array4<Real> const& farr = fine_contrib.array(mfi);
+        Array4<Real const> const& resarr = fine_res.const_array(mfi);
+        Array4<Real const> const& rhsarr = fine_rhs.const_array(mfi);
+        Array4<Real const> const& solarr = fine_sol.const_array(mfi);
+        Array4<int const> const& marr = fdmsk.const_array(mfi);
 
-            sigfab.resize(bx_sig, 1);
-            Elixir sigeli = sigfab.elixir();
-            Array4<Real> const& sigarr = sigfab.array();
-            if (fsigma) {
-                Array4<Real const> const& sigarr_orig = fsigma->const_array(mfi);
-                AMREX_HOST_DEVICE_FOR_3D(bx_sig, i, j, k,
+        if (fsigma) {
+            Array4<Real const> const& sigarr = fsigma->const_array(mfi);
+#if (AMREX_SPACEDIM == 2)
+            if (amrrr == 2) {
+                AMREX_HOST_DEVICE_FOR_3D(cbx, i, j, k,
                 {
-                    if (b.contains(IntVect(AMREX_D_DECL(i,j,k)))) {
-                        sigarr(i,j,k) = sigarr_orig(i,j,k);
-                    } else {
-                        sigarr(i,j,k) = 0.0;
-                    }
+                    mlndlap_Ax_fine_contrib<2>(i,j,k,fvbx,cc_fvbx,farr,resarr,rhsarr,solarr,
+                                               sigarr,marr,is_rz,fdxinv);
                 });
             } else {
-                Real const_sigma = m_const_sigma;
-                AMREX_HOST_DEVICE_FOR_3D(bx_sig, i, j, k,
+                AMREX_HOST_DEVICE_FOR_3D(cbx, i, j, k,
                 {
-                    if (b.contains(IntVect(AMREX_D_DECL(i,j,k)))) {
-                        sigarr(i,j,k) = const_sigma;
-                    } else {
-                        sigarr(i,j,k) = 0.0;
-                    }
+                    mlndlap_Ax_fine_contrib<4>(i,j,k,fvbx,cc_fvbx,farr,resarr,rhsarr,solarr,
+                                               sigarr,marr,is_rz,fdxinv);
                 });
             }
-
-            const Box& bx_Ax = amrex::grow(fbx,1);
-            const Box& b2 = bx_Ax & amrex::grow(fvbx,-1);
-            Axfab.resize(bx_Ax);
-            Elixir Axeli = Axfab.elixir();
-            Array4<Real> const& Axarr = Axfab.array();
-            Array4<Real const> const& rhsarr = fine_rhs.const_array(mfi);
-            Array4<Real const> const& resarr = fine_res.const_array(mfi);
-            Array4<Real const> const& solarr = fine_sol.const_array(mfi);
-#if (AMREX_SPACEDIM == 2)
-            AMREX_HOST_DEVICE_FOR_3D(bx_Ax, i, j, k,
-            {
-                if (b2.contains(IntVect(AMREX_D_DECL(i,j,k)))) {
-                    Axarr(i,j,k) = rhsarr(i,j,k) - resarr(i,j,k);
-                } else {
-                    Axarr(i,j,k) = 0.0;
-                }
-                mlndlap_res_fine_Ax(i,j,k, fvbx, Axarr, solarr, sigarr, is_rz, fdxinv);
-            });
-#else
-            AMREX_HOST_DEVICE_FOR_3D(bx_Ax, i, j, k,
-            {
-                if (b2.contains(IntVect(AMREX_D_DECL(i,j,k)))) {
-                    Axarr(i,j,k) = rhsarr(i,j,k) - resarr(i,j,k);
-                } else {
-                    Axarr(i,j,k) = 0.0;
-                }
-                mlndlap_res_fine_Ax(i,j,k, fvbx, Axarr, solarr, sigarr, fdxinv);
-            });
+#elif (AMREX_SPACEDIM == 3)
+            if (amrrr == 2) {
+                AMREX_HOST_DEVICE_FOR_3D(cbx, i, j, k,
+                {
+                    mlndlap_Ax_fine_contrib<2>(i,j,k,fvbx,cc_fvbx,farr,resarr,rhsarr,solarr,
+                                               sigarr,marr,fdxinv);
+                });
+            } else {
+                AMREX_HOST_DEVICE_FOR_3D(cbx, i, j, k,
+                {
+                    mlndlap_Ax_fine_contrib<4>(i,j,k,fvbx,cc_fvbx,farr,resarr,rhsarr,solarr,
+                                               sigarr,marr,fdxinv);
+                });
+            }
 #endif
-            Array4<Real> const& farr = fine_contrib.array(mfi);
-            Array4<int const> const& marr = fdmsk.const_array(mfi);
-            AMREX_HOST_DEVICE_FOR_3D(cbx, i, j, k,
-            {
-                mlndlap_res_fine_contrib(i,j,k,farr,Axarr,marr);
-            });
+        } else {
+            Real const_sigma = m_const_sigma;
+#if (AMREX_SPACEDIM == 2)
+            if (amrrr == 2) {
+                AMREX_HOST_DEVICE_FOR_3D(cbx, i, j, k,
+                {
+                    mlndlap_Ax_fine_contrib_cs<2>(i,j,k,fvbx,cc_fvbx,farr,resarr,rhsarr,solarr,
+                                                  const_sigma,marr,is_rz,fdxinv);
+                });
+            } else {
+                AMREX_HOST_DEVICE_FOR_3D(cbx, i, j, k,
+                {
+                    mlndlap_Ax_fine_contrib_cs<4>(i,j,k,fvbx,cc_fvbx,farr,resarr,rhsarr,solarr,
+                                                  const_sigma,marr,is_rz,fdxinv);
+                });
+            }
+#elif (AMREX_SPACEDIM == 3)
+            if (amrrr == 2) {
+                AMREX_HOST_DEVICE_FOR_3D(cbx, i, j, k,
+                {
+                    mlndlap_Ax_fine_contrib_cs<2>(i,j,k,fvbx,cc_fvbx,farr,resarr,rhsarr,solarr,
+                                                  const_sigma,marr,fdxinv);
+                });
+            } else {
+                AMREX_HOST_DEVICE_FOR_3D(cbx, i, j, k,
+                {
+                    mlndlap_Ax_fine_contrib_cs<4>(i,j,k,fvbx,cc_fvbx,farr,resarr,rhsarr,solarr,
+                                                  const_sigma,marr,fdxinv);
+                });
+            }
+#endif
         }
     }
 
@@ -2654,9 +2732,6 @@ MLNodeLaplacian::reflux (int crse_amrlev,
     const auto& nd_mask     = m_nd_fine_mask[crse_amrlev];
     const auto& cc_mask     = m_cc_fine_mask[crse_amrlev];
     const auto& has_fine_bndry = m_has_fine_bndry[crse_amrlev];
-
-    const auto lobc = LoBC();
-    const auto hibc = HiBC();
 
     const auto& csigma = m_sigma[crse_amrlev][0][0];
 
@@ -2683,16 +2758,16 @@ MLNodeLaplacian::reflux (int crse_amrlev,
                 {
                     mlndlap_res_cf_contrib(i,j,k,resarr,csolarr,crhsarr,csigarr,
                                            cdmskarr,ndmskarr,ccmskarr,fcocarr,
-                                           cdxinv,c_nd_domain,
+                                           cdxinv,c_cc_domain_p,c_nd_domain,
                                            is_rz,
                                            lobc,hibc, neumann_doubling);
                 });
-#else
+#elif (AMREX_SPACEDIM == 3)
                 AMREX_HOST_DEVICE_FOR_3D(bx, i, j, k,
                 {
                     mlndlap_res_cf_contrib(i,j,k,resarr,csolarr,crhsarr,csigarr,
                                            cdmskarr,ndmskarr,ccmskarr,fcocarr,
-                                           cdxinv,c_nd_domain,
+                                           cdxinv,c_cc_domain_p,c_nd_domain,
                                            lobc,hibc, neumann_doubling);
                 });
 #endif
@@ -2703,16 +2778,16 @@ MLNodeLaplacian::reflux (int crse_amrlev,
                 {
                     mlndlap_res_cf_contrib_cs(i,j,k,resarr,csolarr,crhsarr,const_sigma,
                                               cdmskarr,ndmskarr,ccmskarr,fcocarr,
-                                              cdxinv,c_nd_domain,
+                                              cdxinv,c_cc_domain_p,c_nd_domain,
                                               is_rz,
                                               lobc,hibc, neumann_doubling);
                 });
-#else
+#elif (AMREX_SPACEDIM == 3)
                 AMREX_HOST_DEVICE_FOR_3D(bx, i, j, k,
                 {
                     mlndlap_res_cf_contrib_cs(i,j,k,resarr,csolarr,crhsarr,const_sigma,
                                               cdmskarr,ndmskarr,ccmskarr,fcocarr,
-                                              cdxinv,c_nd_domain,
+                                              cdxinv,c_cc_domain_p,c_nd_domain,
                                               lobc,hibc, neumann_doubling);
                 });
 #endif
@@ -2760,7 +2835,7 @@ MLNodeLaplacian::buildIntegral ()
                 Array4<Real> const& garr = intg->array(mfi);
                 const auto& flag = flags[mfi];
                 auto typ = flag.getType(bx);
-                
+
                 if (typ == FabType::covered) {
                     AMREX_HOST_DEVICE_PARALLEL_FOR_4D(bx, ncomp, i, j, k, n,
                     {
@@ -2809,7 +2884,7 @@ MLNodeLaplacian::checkPoint (std::string const& file_name) const
             if( ! HeaderFile.good()) {
                 FileOpenFailed(HeaderFileName);
             }
-            
+
             HeaderFile.precision(17);
 
             // MLLinop stuff
@@ -2864,7 +2939,7 @@ MLNodeLaplacian::checkPoint (std::string const& file_name) const
             if( ! HeaderFile.good()) {
                 FileOpenFailed(HeaderFileName);
             }
-            
+
             HeaderFile.precision(17);
 
             HeaderFile << Geom(ilev) << "\n";
@@ -2914,7 +2989,7 @@ MLNodeLaplacian::fillIJMatrix (MFIter const& mfi, Array4<HypreNodeLap::Int const
                 HypreNodeLap::Int nc = 1;
 
                 if                (nid(i-1,j-1,k) >= 0) {
-                    cols.push_back(nid(i-1,j-1,k));                  
+                    cols.push_back(nid(i-1,j-1,k));
                     mat.push_back(sten(i-1,j-1,k,3));
                     ++nc;
                 }
@@ -3005,7 +3080,7 @@ MLNodeLaplacian::fillIJMatrix (MFIter const& mfi, Array4<HypreNodeLap::Int const
                     HypreNodeLap::Int nc = 1;
 
                     if                (nid(i-1,j-1,k-1) >= 0) {
-                        cols.push_back(nid(i-1,j-1,k-1));                  
+                        cols.push_back(nid(i-1,j-1,k-1));
                         mat.push_back(sten(i-1,j-1,k-1,ist_ppp));
                         ++nc;
                     }

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLinOp.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLinOp.H
@@ -55,7 +55,7 @@ public:
                            MultiFab& /*sol*/, Location /*loc*/) const override {
         amrex::Abort("AMReX_MLNodeLinOp::compGrad::How did we get here?");
     }
-    
+
     virtual void applyMetricTerm (int /*amrlev*/, int /*mglev*/, MultiFab& /*rhs*/) const final override {}
     virtual void unapplyMetricTerm (int /*amrlev*/, int /*mglev*/, MultiFab& /*rhs*/) const final override {}
 

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLinOp.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLinOp.cpp
@@ -271,7 +271,8 @@ MLNodeLinOp::buildMasks ()
         LayoutData<int>& has_cf = *m_has_fine_bndry[amrlev];
         const Box& ccdom = m_geom[amrlev][0].Domain();
 
-        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(AMRRefRatio(amrlev) == 2, "ref_ratio != 0 not supported");
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(AMRRefRatio(amrlev) == 2 || AMRRefRatio(amrlev) == 4,
+                                         "ref_ratio != 2 and 4 not supported");
 
         cc_mask = amrex::makeFineMask(cc_mask, *m_cc_fine_mask[amrlev+1], cc_mask.nGrowVect(),
                                       IntVect(AMRRefRatio(amrlev)), m_geom[amrlev][0].periodicity(),

--- a/Src/LinearSolvers/Projections/AMReX_MacProjector.H
+++ b/Src/LinearSolvers/Projections/AMReX_MacProjector.H
@@ -175,6 +175,7 @@ private:
     int m_verbose = 0;
 
     bool m_needs_domain_bcs = true;
+    Vector<int> m_needs_level_bcs;
 
     // Location of umac -- face center vs face centroid
     MLMG::Location m_umac_loc;

--- a/Tutorials/LinearSolvers/NodalPoisson/MyTest.H
+++ b/Tutorials/LinearSolvers/NodalPoisson/MyTest.H
@@ -41,8 +41,8 @@ private:
     bool agglomeration = false;
     bool consolidation = false;
     bool semicoarsening = false;
+    int max_coarsening_level = 30;
     int max_semicoarsening_level = 0;
-
 
     amrex::Vector<amrex::Geometry> geom;
     amrex::Vector<amrex::BoxArray> grids;

--- a/Tutorials/LinearSolvers/NodalPoisson/MyTest.cpp
+++ b/Tutorials/LinearSolvers/NodalPoisson/MyTest.cpp
@@ -16,14 +16,15 @@ MyTest::MyTest ()
 void
 MyTest::solve ()
 {
+    LPInfo info;
+    info.setAgglomeration(agglomeration);
+    info.setConsolidation(consolidation);
+    info.setSemicoarsening(semicoarsening);
+    info.setMaxCoarseningLevel(max_coarsening_level);
+    info.setMaxSemicoarseningLevel(max_semicoarsening_level);
+
     if (composite_solve)
     {
-        LPInfo info;
-        info.setAgglomeration(agglomeration);
-        info.setConsolidation(consolidation);
-        info.setSemicoarsening(semicoarsening);
-        info.setMaxSemicoarseningLevel(max_semicoarsening_level);
-
         MLNodeLaplacian linop(geom, grids, dmap, info);
 
         linop.setDomainBC({AMREX_D_DECL(LinOpBCType::Dirichlet,
@@ -60,8 +61,9 @@ MyTest::solve ()
     }
     else // solve level by level
     {
-        for (int ilev = 0; ilev <= max_level; ++ilev) {
-            MLNodeLaplacian linop({geom[ilev]}, {grids[ilev]}, {dmap[ilev]});
+        for (int ilev = 0; ilev <= max_level; ++ilev)
+        {
+            MLNodeLaplacian linop({geom[ilev]}, {grids[ilev]}, {dmap[ilev]}, info);
 
             linop.setDomainBC({AMREX_D_DECL(LinOpBCType::Dirichlet,
                                             LinOpBCType::Dirichlet,
@@ -147,7 +149,9 @@ MyTest::readParameters ()
     pp.query("gpu_regtest", gpu_regtest);
 
     pp.query("agglomeration", agglomeration);
+    pp.query("consolidation", consolidation);
     pp.query("semicoarsening", semicoarsening);
+    pp.query("max_coarsening_level", max_coarsening_level);
     pp.query("max_semicoarsening_level", max_semicoarsening_level);
 }
 


### PR DESCRIPTION
This adds refinement ratio of 4 support in non-EB nodal linear solver.
Roundoff errors are expected for multi-level solves with a refinement ratio
of 2.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
