### PR TITLE
Fix bug in #1774

### DIFF
--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLap_2D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLap_2D_K.H
@@ -1230,12 +1230,12 @@ void mlndlap_rhcc_fine_contrib (int i, int j, int, Box const& ccbx,
 
         for (int joff = jlo; joff <= jhi; ++joff) {
         for (int ioff = ilo; ioff <= ihi; ++ioff) {
-            Real scale = (Real(2.0)-amrex::Math::abs(static_cast<Real>(ioff)+Real(0.5)))
-                *        (Real(2.0)-amrex::Math::abs(static_cast<Real>(joff)+Real(0.5)));
+            Real scale = (static_cast<Real>(rr)-amrex::Math::abs(static_cast<Real>(ioff-ii)+Real(0.5)))
+                *        (static_cast<Real>(rr)-amrex::Math::abs(static_cast<Real>(joff-jj)+Real(0.5)));
             tmp += cc(ioff,joff,0) * scale;
         }}
 
-        rhs(i,j,0) += tmp * (Real(1.0)/Real(4*rr*rr));
+        rhs(i,j,0) += tmp * (Real(1.0)/Real(rr*rr*rr*rr));
     }
 }
 

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLap_3D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLap_3D_K.H
@@ -2287,13 +2287,13 @@ void mlndlap_rhcc_fine_contrib (int i, int j, int k, Box const& ccbx,
         for (int koff = klo; koff <= khi; ++koff) {
         for (int joff = jlo; joff <= jhi; ++joff) {
         for (int ioff = ilo; ioff <= ihi; ++ioff) {
-            Real scale = (Real(2.0)-amrex::Math::abs(static_cast<Real>(ioff)+Real(0.5)))
-                *        (Real(2.0)-amrex::Math::abs(static_cast<Real>(joff)+Real(0.5)))
-                *        (Real(2.0)-amrex::Math::abs(static_cast<Real>(koff)+Real(0.5)));
+            Real scale = (static_cast<Real>(rr)-amrex::Math::abs(static_cast<Real>(ioff-ii)+Real(0.5)))
+                *        (static_cast<Real>(rr)-amrex::Math::abs(static_cast<Real>(joff-jj)+Real(0.5)))
+                *        (static_cast<Real>(rr)-amrex::Math::abs(static_cast<Real>(koff-kk)+Real(0.5)));
             tmp += cc(ioff,joff,koff) * scale;
         }}}
 
-        rhs(i,j,k) += tmp * (Real(1.0)/Real(8*rr*rr*rr));
+        rhs(i,j,k) += tmp * (Real(1.0)/Real(rr*rr*rr*rr*rr*rr));
     }
 }
 


### PR DESCRIPTION
## Summary

A bug was introduced in #1774 that resulted in incorrect weights when
making nodal RHS from cell-centered RHS.

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
