### PR TITLE
Fix up neighbor list for 1D/2D

### DIFF
--- a/Src/Particle/AMReX_NeighborList.H
+++ b/Src/Particle/AMReX_NeighborList.H
@@ -203,16 +203,21 @@ public:
 
         AMREX_FOR_1D ( np_real, i,
         {
-            int ix = static_cast<int>(amrex::Math::floor((pstruct_ptr[i].pos(0)-plo[0])*dxi[0])) - lo.x;
-            int iy = static_cast<int>(amrex::Math::floor((pstruct_ptr[i].pos(1)-plo[1])*dxi[1])) - lo.y;
-            int iz = static_cast<int>(amrex::Math::floor((pstruct_ptr[i].pos(2)-plo[2])*dxi[2])) - lo.z;
+            IntVect iv(AMREX_D_DECL(
+                static_cast<int>(amrex::Math::floor((pstruct_ptr[i].pos(0)-plo[0])*dxi[0])) - lo.x,
+                static_cast<int>(amrex::Math::floor((pstruct_ptr[i].pos(1)-plo[1])*dxi[1])) - lo.y,
+                static_cast<int>(amrex::Math::floor((pstruct_ptr[i].pos(2)-plo[2])*dxi[2])) - lo.z));
+            auto iv3 = iv.dim3();
+
+            int ix = iv3.x;
+            int iy = iv3.y;
+            int iz = iv3.z;
 
             int nx = hi.x-lo.x+1;
             int ny = hi.y-lo.y+1;
             int nz = hi.z-lo.z+1;
 
             int count = 0;
-
             for (int ii = amrex::max(ix-num_cells, 0); ii <= amrex::min(ix+num_cells, nx-1); ++ii) {
                 for (int jj = amrex::max(iy-num_cells, 0); jj <= amrex::min(iy+num_cells, ny-1); ++jj) {
                     for (int kk = amrex::max(iz-num_cells, 0); kk <= amrex::min(iz+num_cells, nz-1); ++kk) {
@@ -246,9 +251,15 @@ public:
 
         AMREX_FOR_1D ( np_real, i,
         {
-            int ix = static_cast<int>(amrex::Math::floor((pstruct_ptr[i].pos(0)-plo[0])*dxi[0])) - lo.x;
-            int iy = static_cast<int>(amrex::Math::floor((pstruct_ptr[i].pos(1)-plo[1])*dxi[1])) - lo.y;
-            int iz = static_cast<int>(amrex::Math::floor((pstruct_ptr[i].pos(2)-plo[2])*dxi[2])) - lo.z;
+            IntVect iv(AMREX_D_DECL(
+                static_cast<int>(amrex::Math::floor((pstruct_ptr[i].pos(0)-plo[0])*dxi[0])) - lo.x,
+                static_cast<int>(amrex::Math::floor((pstruct_ptr[i].pos(1)-plo[1])*dxi[1])) - lo.y,
+                static_cast<int>(amrex::Math::floor((pstruct_ptr[i].pos(2)-plo[2])*dxi[2])) - lo.z));
+            auto iv3 = iv.dim3();
+
+            int ix = iv3.x;
+            int iy = iv3.y;
+            int iz = iv3.z;
 
             int nx = hi.x-lo.x+1;
             int ny = hi.y-lo.y+1;


### PR DESCRIPTION
Neighbor list construction currently gives an assertion failure AMREX_SPACEDIM < 3;

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
