### PR TITLE
Windows: WINDOWS_EXPORT_ALL_SYMBOLS

### DIFF
--- a/Tools/CMake/AMReXBuildInfo.cmake
+++ b/Tools/CMake/AMReXBuildInfo.cmake
@@ -221,8 +221,9 @@ function (generate_buildinfo _target _git_dir)
 
    # Set PIC property to be consistent with AMReX'
    get_target_property(_pic AMReX::amrex POSITION_INDEPENDENT_CODE)
-   set_target_properties(buildInfo${_target}
-      PROPERTIES
-      POSITION_INDEPENDENT_CODE ${_pic} )
+   get_target_property(_sym AMReX::amrex WINDOWS_EXPORT_ALL_SYMBOLS)
+   set_target_properties(buildInfo${_target} PROPERTIES
+      POSITION_INDEPENDENT_CODE ${_pic}
+      WINDOWS_EXPORT_ALL_SYMBOLS ${_sym} )
 
 endfunction ()

--- a/Tools/CMake/AMReX_Config.cmake
+++ b/Tools/CMake/AMReX_Config.cmake
@@ -143,7 +143,9 @@ function (configure_amrex)
    endif ()
 
    if ( AMReX_PIC OR BUILD_SHARED_LIBS )
-      set_target_properties ( amrex PROPERTIES POSITION_INDEPENDENT_CODE True )
+      set_target_properties ( amrex PROPERTIES
+        POSITION_INDEPENDENT_CODE ON
+        WINDOWS_EXPORT_ALL_SYMBOLS ON )
    endif ()
 
    if ( BUILD_SHARED_LIBS OR AMReX_CUDA )


### PR DESCRIPTION
## Summary

I am seeing some linker issues downstream when building Python bindings with WarpX on Windows. This nice option makes sure we don't need to add dll export symbols all over the place when building a shared AMReX library (dll).

## Additional background

Kudos to the ROOT team at CERN for contributing this feature years ago to CMake.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
