### PR TITLE
Fix precision issue in ParmParse::add

### DIFF
--- a/Src/Base/AMReX_ParmParse.cpp
+++ b/Src/Base/AMReX_ParmParse.cpp
@@ -842,30 +842,30 @@ sgetarr (const ParmParse::Table& table,
 template <class T>
 void
 saddval (const std::string&      name,
-	 const T&                ptr)
+         const T&                ptr)
 {
-	std::stringstream val;
-	val << ptr;
-	ParmParse::PP_entry entry(name,val.str());
-	entry.m_queried=true;
-	g_table.push_back(entry);
+    std::stringstream val;
+    val << std::setprecision(17) << ptr;
+    ParmParse::PP_entry entry(name,val.str());
+    entry.m_queried=true;
+    g_table.push_back(entry);
 }
 
 
 template <class T>
 void
 saddarr (const std::string&      name,
-	 const std::vector<T>&   ptr)
+         const std::vector<T>&   ptr)
 {
-	std::list<std::string> arr;
-	for(int i = 0; i < ptr.size(); i++) {
-		std::stringstream val;
-		val << ptr[i];
-		arr.push_back(val.str());
-	}
-	ParmParse::PP_entry entry(name,arr);
-	entry.m_queried=true;
-	g_table.push_back(entry);
+    std::list<std::string> arr;
+    for(int i = 0; i < ptr.size(); i++) {
+        std::stringstream val;
+        val << std::setprecision(17) << ptr[i];
+        arr.push_back(val.str());
+    }
+    ParmParse::PP_entry entry(name,arr);
+    entry.m_queried=true;
+    g_table.push_back(entry);
 }
 
 }


### PR DESCRIPTION
## Summary

When adding values to ParmParse, we need to call `std::setprecision` so as
not to lose precision.

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
