### PR TITLE
BoxArray::simplified() & simplified_list()

### DIFF
--- a/Src/Base/AMReX_BoxArray.H
+++ b/Src/Base/AMReX_BoxArray.H
@@ -804,15 +804,15 @@ public:
     //! Make ourselves unique.
     void uniqify ();
 
+    BoxList const& simplified_list () const; // For regular AMR grids only!!!
+    BoxArray simplified () const; // For regular AMR grids only!!!
+
     friend class AmrMesh;
     friend class FabArrayBase;
 
 private:
     //!  Update BoxArray index type according the box type, and then convert boxes to cell-centered.
     void type_update ();
-
-    BoxList const& simplified_list () const; // For regular AMR grids only
-    BoxArray simplified () const;
 
     BARef::HashType& getHashMap () const;
 


### PR DESCRIPTION
Make them public so that they can be used by application codes to regenerate
grids covering exactly the same region but with a different max grid size.
However, it should be emphasized that they only work with regular BoxArrays
without anything like coarsening.