### PR TITLE
Bump minimum C++ standard from 11 to 14.

### DIFF
--- a/.github/workflows/dependencies/dependencies_nvcc9.sh
+++ b/.github/workflows/dependencies/dependencies_nvcc9.sh
@@ -15,8 +15,8 @@ sudo apt-get update
 
 sudo apt-get install -y --no-install-recommends\
     build-essential     \
-    g++-4.8             \
-    gfortran-4.8        \
+    g++-5.5             \
+    gfortran-5.5        \
     libopenmpi-dev      \
     openmpi-bin         \
     nvidia-cuda-dev     \

--- a/.github/workflows/dependencies/dependencies_nvcc9.sh
+++ b/.github/workflows/dependencies/dependencies_nvcc9.sh
@@ -28,11 +28,10 @@ sudo apt-get update
 sudo apt-get install -y \
     cuda-command-line-tools-9-2 \
     cuda-compiler-9-2           \
-    cuda-cupti-dev-9-2          \
     cuda-minimal-build-9-2      \
     cuda-nvml-dev-9-2           \
-    cuda-nvtx-9-2               \
-    libcurand-dev-9-2
+    cuda-nvtx-9-2
+
 sudo ln -s cuda-9.2 /usr/local/cuda
 
 

--- a/.github/workflows/dependencies/dependencies_nvcc9.sh
+++ b/.github/workflows/dependencies/dependencies_nvcc9.sh
@@ -20,9 +20,9 @@ sudo apt-get install -y --no-install-recommends\
     libopenmpi-dev      \
     openmpi-bin
 
-sudo wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/7fa2af80.pub
+sudo wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/x86_64/7fa2af80.pub
 sudo apt-key add 7fa2af80.pub
-echo "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64 /" \
+echo "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/x86_64 /" \
     | sudo tee /etc/apt/sources.list.d/cuda.list
 sudo apt-get update
 sudo apt-get install -y \

--- a/.github/workflows/dependencies/dependencies_nvcc9.sh
+++ b/.github/workflows/dependencies/dependencies_nvcc9.sh
@@ -30,7 +30,8 @@ sudo apt-get install -y \
     cuda-compiler-9-2           \
     cuda-minimal-build-9-2      \
     cuda-nvml-dev-9-2           \
-    cuda-nvtx-9-2
+    cuda-nvtx-9-2               \
+    cuda-curand-9.2
 
 sudo ln -s cuda-9.2 /usr/local/cuda
 

--- a/.github/workflows/dependencies/dependencies_nvcc9.sh
+++ b/.github/workflows/dependencies/dependencies_nvcc9.sh
@@ -18,8 +18,21 @@ sudo apt-get install -y --no-install-recommends\
     g++-7               \
     gfortran-7          \
     libopenmpi-dev      \
-    openmpi-bin         \
-    nvidia-cuda-dev     \
-    nvidia-cuda-toolkit
+    openmpi-bin
+
+sudo wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/7fa2af80.pub
+sudo apt-key add 7fa2af80.pub
+echo "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64 /" \
+    | sudo tee /etc/apt/sources.list.d/cuda.list
+sudo apt-get update
+sudo apt-get install -y \
+    cuda-command-line-tools-9-2 \
+    cuda-compiler-9-2           \
+    cuda-cupti-dev-9-2          \
+    cuda-minimal-build-9-2      \
+    cuda-nvml-dev-9-2           \
+    cuda-nvtx-9-2               \
+    libcurand-dev-9-2
+sudo ln -s cuda-9.2 /usr/local/cuda
 
 

--- a/.github/workflows/dependencies/dependencies_nvcc9.sh
+++ b/.github/workflows/dependencies/dependencies_nvcc9.sh
@@ -15,8 +15,8 @@ sudo apt-get update
 
 sudo apt-get install -y --no-install-recommends\
     build-essential     \
-    g++-7               \
-    gfortran-7          \
+    g++-6               \
+    gfortran-6          \
     libopenmpi-dev      \
     openmpi-bin
 

--- a/.github/workflows/dependencies/dependencies_nvcc9.sh
+++ b/.github/workflows/dependencies/dependencies_nvcc9.sh
@@ -15,8 +15,8 @@ sudo apt-get update
 
 sudo apt-get install -y --no-install-recommends\
     build-essential     \
-    g++-6               \
-    gfortran-6          \
+    g++-7               \
+    gfortran-7          \
     libopenmpi-dev      \
     openmpi-bin         \
     nvidia-cuda-dev     \

--- a/.github/workflows/dependencies/dependencies_nvcc9.sh
+++ b/.github/workflows/dependencies/dependencies_nvcc9.sh
@@ -15,8 +15,8 @@ sudo apt-get update
 
 sudo apt-get install -y --no-install-recommends\
     build-essential     \
-    g++-5               \
-    gfortran-5          \
+    g++-6               \
+    gfortran-6          \
     libopenmpi-dev      \
     openmpi-bin         \
     nvidia-cuda-dev     \

--- a/.github/workflows/dependencies/dependencies_nvcc9.sh
+++ b/.github/workflows/dependencies/dependencies_nvcc9.sh
@@ -31,7 +31,7 @@ sudo apt-get install -y \
     cuda-minimal-build-9-2      \
     cuda-nvml-dev-9-2           \
     cuda-nvtx-9-2               \
-    cuda-curand-9.2
+    cuda-curand-dev-9.2
 
 sudo ln -s cuda-9.2 /usr/local/cuda
 

--- a/.github/workflows/dependencies/dependencies_nvcc9.sh
+++ b/.github/workflows/dependencies/dependencies_nvcc9.sh
@@ -15,8 +15,8 @@ sudo apt-get update
 
 sudo apt-get install -y --no-install-recommends\
     build-essential     \
-    g++-5.5             \
-    gfortran-5.5        \
+    g++-5               \
+    gfortran-5          \
     libopenmpi-dev      \
     openmpi-bin         \
     nvidia-cuda-dev     \

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -173,7 +173,7 @@ jobs:
 
   # Build libamrex and all tutorials with CUDA 9.1 (oldest supported)
   tutorials-cuda9:
-    name: CUDA@9.1.85 GNU@5.5.0 C++14 Release [tutorials]
+    name: CUDA@9.1.85 GNU@6.4.0 C++14 Release [tutorials]
     runs-on: ubuntu-18.04
     env: {CXXFLAGS: "-fno-operator-names"}
     steps:
@@ -189,10 +189,10 @@ jobs:
             -DAMReX_BUILD_TUTORIALS=ON                   \
             -DAMReX_PARTICLES=ON                        \
             -DAMReX_GPU_BACKEND=CUDA                         \
-            -DCMAKE_C_COMPILER=$(which gcc-5)              \
-            -DCMAKE_CXX_COMPILER=$(which g++-5)            \
-            -DCMAKE_CUDA_HOST_COMPILER=$(which g++-5)      \
-            -DCMAKE_Fortran_COMPILER=$(which gfortran-5)   \
+            -DCMAKE_C_COMPILER=$(which gcc-6)              \
+            -DCMAKE_CXX_COMPILER=$(which g++-6)            \
+            -DCMAKE_CUDA_HOST_COMPILER=$(which g++-6)      \
+            -DCMAKE_Fortran_COMPILER=$(which gfortran-6)   \
             -DAMReX_CUDA_ARCH=6.0 \
             -DAMReX_CUDA_ERROR_CROSS_EXECUTION_SPACE_CALL=ON
         make -j 2

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -173,7 +173,7 @@ jobs:
 
   # Build libamrex and all tutorials with CUDA 9.1 (oldest supported)
   tutorials-cuda9:
-    name: CUDA@9.1.85 GNU@6.4.0 C++14 Release [tutorials]
+    name: CUDA@9.1.85 GNU@7.5.0 C++14 Release [tutorials]
     runs-on: ubuntu-18.04
     env: {CXXFLAGS: "-fno-operator-names"}
     steps:
@@ -189,10 +189,10 @@ jobs:
             -DAMReX_BUILD_TUTORIALS=ON                   \
             -DAMReX_PARTICLES=ON                        \
             -DAMReX_GPU_BACKEND=CUDA                         \
-            -DCMAKE_C_COMPILER=$(which gcc-6)              \
-            -DCMAKE_CXX_COMPILER=$(which g++-6)            \
-            -DCMAKE_CUDA_HOST_COMPILER=$(which g++-6)      \
-            -DCMAKE_Fortran_COMPILER=$(which gfortran-6)   \
+            -DCMAKE_C_COMPILER=$(which gcc-7)              \
+            -DCMAKE_CXX_COMPILER=$(which g++-7)            \
+            -DCMAKE_CUDA_HOST_COMPILER=$(which g++-7)      \
+            -DCMAKE_Fortran_COMPILER=$(which gfortran-7)   \
             -DAMReX_CUDA_ARCH=6.0 \
             -DAMReX_CUDA_ERROR_CROSS_EXECUTION_SPACE_CALL=ON
         make -j 2

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -182,6 +182,9 @@ jobs:
       run: .github/workflows/dependencies/dependencies_nvcc9.sh
     - name: Build & Install
       run: |
+        export PATH=/usr/local/nvidia/bin:/usr/local/cuda/bin:${PATH}
+        export LD_LIBRARY_PATH=/usr/local/nvidia/lib:/usr/local/nvidia/lib64:/usr/local/cuda/lib64:${LD_LIBRARY_PATH}
+        which nvcc || echo "nvcc not in PATH!"
         mkdir build
         cd build
         cmake ..                                         \

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -171,9 +171,9 @@ jobs:
             -DAMReX_FORTRAN=OFF
         make -j 2
 
-  # Build libamrex and all tutorials with CUDA 9.1 (oldest supported)
+  # Build libamrex and all tutorials with CUDA 9.2
   tutorials-cuda9:
-    name: CUDA@9.1.85 GNU@7.5.0 C++14 Release [tutorials]
+    name: CUDA@9.2 GNU@6.5.0 C++14 Release [tutorials]
     runs-on: ubuntu-18.04
     env: {CXXFLAGS: "-fno-operator-names"}
     steps:
@@ -189,10 +189,10 @@ jobs:
             -DAMReX_BUILD_TUTORIALS=ON                   \
             -DAMReX_PARTICLES=ON                        \
             -DAMReX_GPU_BACKEND=CUDA                         \
-            -DCMAKE_C_COMPILER=$(which gcc-7)              \
-            -DCMAKE_CXX_COMPILER=$(which g++-7)            \
-            -DCMAKE_CUDA_HOST_COMPILER=$(which g++-7)      \
-            -DCMAKE_Fortran_COMPILER=$(which gfortran-7)   \
+            -DCMAKE_C_COMPILER=$(which gcc-6)              \
+            -DCMAKE_CXX_COMPILER=$(which g++-6)            \
+            -DCMAKE_CUDA_HOST_COMPILER=$(which g++-6)      \
+            -DCMAKE_Fortran_COMPILER=$(which gfortran-6)   \
             -DAMReX_CUDA_ARCH=6.0 \
             -DAMReX_CUDA_ERROR_CROSS_EXECUTION_SPACE_CALL=ON
         make -j 2

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -152,7 +152,7 @@ jobs:
 
   # Build libamrex and all tutorials
   tutorials-nofortran:
-    name: GNU@7.5 C++11 w/o Fortran [tutorials]
+    name: GNU@7.5 C++14 w/o Fortran [tutorials]
     runs-on: ubuntu-18.04
     env: {CXXFLAGS: "-Werror -Wshadow -Woverloaded-virtual -Wunreachable-code -fno-operator-names"}
     steps:
@@ -168,13 +168,12 @@ jobs:
             -DCMAKE_VERBOSE_MAKEFILE=ON \
             -DAMReX_BUILD_TUTORIALS=ON  \
             -DAMReX_PARTICLES=ON       \
-            -DAMReX_FORTRAN=OFF        \
-            -DCMAKE_CXX_STANDARD=11
+            -DAMReX_FORTRAN=OFF
         make -j 2
 
   # Build libamrex and all tutorials with CUDA 9.1 (oldest supported)
   tutorials-cuda9:
-    name: CUDA@9.1.85 GNU@4.8.5 C++11 Release [tutorials]
+    name: CUDA@9.1.85 GNU@5.5.0 C++14 Release [tutorials]
     runs-on: ubuntu-18.04
     env: {CXXFLAGS: "-fno-operator-names"}
     steps:
@@ -190,10 +189,10 @@ jobs:
             -DAMReX_BUILD_TUTORIALS=ON                   \
             -DAMReX_PARTICLES=ON                        \
             -DAMReX_GPU_BACKEND=CUDA                         \
-            -DCMAKE_C_COMPILER=$(which gcc-4.8)              \
-            -DCMAKE_CXX_COMPILER=$(which g++-4.8)            \
-            -DCMAKE_CUDA_HOST_COMPILER=$(which g++-4.8)      \
-            -DCMAKE_Fortran_COMPILER=$(which gfortran-4.8)   \
+            -DCMAKE_C_COMPILER=$(which gcc-5.5)              \
+            -DCMAKE_CXX_COMPILER=$(which g++-5.5)            \
+            -DCMAKE_CUDA_HOST_COMPILER=$(which g++-5.5)      \
+            -DCMAKE_Fortran_COMPILER=$(which gfortran-5.5)   \
             -DAMReX_CUDA_ARCH=6.0 \
             -DAMReX_CUDA_ERROR_CROSS_EXECUTION_SPACE_CALL=ON
         make -j 2

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -187,11 +187,11 @@ jobs:
         which nvcc || echo "nvcc not in PATH!"
         mkdir build
         cd build
-        cmake ..                                         \
-            -DCMAKE_VERBOSE_MAKEFILE=ON                  \
-            -DAMReX_BUILD_TUTORIALS=ON                   \
-            -DAMReX_PARTICLES=ON                        \
-            -DAMReX_GPU_BACKEND=CUDA                         \
+        cmake ..                                           \
+            -DCMAKE_VERBOSE_MAKEFILE=ON                    \
+            -DAMReX_BUILD_TUTORIALS=ON                     \
+            -DAMReX_PARTICLES=ON                           \
+            -DAMReX_GPU_BACKEND=CUDA                       \
             -DCMAKE_C_COMPILER=$(which gcc-6)              \
             -DCMAKE_CXX_COMPILER=$(which g++-6)            \
             -DCMAKE_CUDA_HOST_COMPILER=$(which g++-6)      \

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -189,10 +189,10 @@ jobs:
             -DAMReX_BUILD_TUTORIALS=ON                   \
             -DAMReX_PARTICLES=ON                        \
             -DAMReX_GPU_BACKEND=CUDA                         \
-            -DCMAKE_C_COMPILER=$(which gcc-5.5)              \
-            -DCMAKE_CXX_COMPILER=$(which g++-5.5)            \
-            -DCMAKE_CUDA_HOST_COMPILER=$(which g++-5.5)      \
-            -DCMAKE_Fortran_COMPILER=$(which gfortran-5.5)   \
+            -DCMAKE_C_COMPILER=$(which gcc-5)              \
+            -DCMAKE_CXX_COMPILER=$(which g++-5)            \
+            -DCMAKE_CUDA_HOST_COMPILER=$(which g++-5)      \
+            -DCMAKE_Fortran_COMPILER=$(which gfortran-5)   \
             -DAMReX_CUDA_ARCH=6.0 \
             -DAMReX_CUDA_ERROR_CROSS_EXECUTION_SPACE_CALL=ON
         make -j 2

--- a/Docs/sphinx_documentation/source/BuildingAMReX.rst
+++ b/Docs/sphinx_documentation/source/BuildingAMReX.rst
@@ -35,8 +35,8 @@ list of important variables.
    +-----------------+-------------------------------------+--------------------+
    | COMP            | gnu, cray, ibm, intel, llvm, or pgi | none               |
    +-----------------+-------------------------------------+--------------------+
-   | CXXSTD          | C++ standard (``c++11``, ``c++14``, | compiler default,  |
-   |                 | ``c++17``, ``c++20``)               | at least ``c++11`` |
+   | CXXSTD          | C++ standard (``c++14``, ``c++17``, | compiler default,  |
+   |                 | ``c++20``)                          | at least ``c++14`` |
    +-----------------+-------------------------------------+--------------------+
    | DEBUG           | TRUE or FALSE                       | FALSE              |
    +-----------------+-------------------------------------+--------------------+
@@ -736,7 +736,7 @@ The AMReX team does development on Linux machines, from laptops to supercomputer
 We do not officially support AMReX on Windows, and many of us do not have access to any Windows
 machines.  However, we believe there are no fundamental issues for it to work on Windows.
 
-(1) AMReX mostly uses standard C++11, but for Windows C++17 is required.  This is because we use
+(1) AMReX mostly uses standard C++14, but for Windows C++17 is required.  This is because we use
     C++17 to support file system operations when POSIX I/O is not available.
 
 (2) We use POSIX signal handling when floating point exceptions, segmentation faults, etc. happen.

--- a/Docs/sphinx_documentation/source/BuildingAMReX_Chapter.rst
+++ b/Docs/sphinx_documentation/source/BuildingAMReX_Chapter.rst
@@ -17,7 +17,7 @@ an application code then uses its own build system and links to AMReX as an exte
 
 Finally, AMReX can also be built with CMake, as detailed in the section on :ref:`sec:build:cmake`.
 
-AMReX requires a C++ compiler that supports the C++11 standard, a
+AMReX requires a C++ compiler that supports the C++14 standard, a
 Fortran compiler that supports the Fortran 2003 standard, and a C
 compiler that supports the C99 standard.  Prerequisites for building
 with GNU Make include Python (>= 2.7, including 3) and standard tools

--- a/INSTALL
+++ b/INSTALL
@@ -10,7 +10,7 @@ There are three ways to use AMReX.
     Fortran modules via `./configure` followed by `make` and `make
     install`.  Type `./configure -h` to show help message.  An
     application code uses its build system to compile and link to the
-    AMReX library.  Because AMReX uses C++11 and Fortran, the linker
+    AMReX library.  Because AMReX uses C++14 and Fortran, the linker
     needs to link the libraries.  See
     `Tutorials/Basic/Build_with_libamrex` for an example of this
     approach.  Note that this approach relies the make system in

--- a/Tools/CMake/AMReX_Config.cmake
+++ b/Tools/CMake/AMReX_Config.cmake
@@ -42,17 +42,17 @@ function (configure_amrex)
    # Moreover, it will also enforce such standard on all the consuming targets
    #
    set_target_properties(amrex PROPERTIES CXX_EXTENSIONS OFF)
-   # minimum: C++11 on Linux, C++17 on Windows, C++17 for dpc++
+   # minimum: C++14 on Linux, C++17 on Windows, C++17 for dpc++
    if (AMReX_DPCPP)
       target_compile_features(amrex PUBLIC cxx_std_17)
    else ()
-      target_compile_features(amrex PUBLIC $<IF:$<STREQUAL:$<PLATFORM_ID>,Windows>,cxx_std_17,cxx_std_11>)
+      target_compile_features(amrex PUBLIC $<IF:$<STREQUAL:$<PLATFORM_ID>,Windows>,cxx_std_17,cxx_std_14>)
    endif ()
 
    if (AMReX_CUDA AND (CMAKE_VERSION VERSION_GREATER_EQUAL 3.17) )
       set_target_properties(amrex PROPERTIES CUDA_EXTENSIONS OFF)
-      # minimum: C++11 on Linux, C++17 on Windows
-      target_compile_features(amrex PUBLIC $<IF:$<STREQUAL:$<PLATFORM_ID>,Windows>,cuda_std_17,cuda_std_11>)
+      # minimum: C++14 on Linux, C++17 on Windows
+      target_compile_features(amrex PUBLIC $<IF:$<STREQUAL:$<PLATFORM_ID>,Windows>,cuda_std_17,cuda_std_14>)
    endif()
 
    #

--- a/Tools/GNUMake/comps/cray.mak
+++ b/Tools/GNUMake/comps/cray.mak
@@ -76,7 +76,7 @@ endif
 ifdef CXXSTD
   CXXSTD := $(strip $(CXXSTD))
 else
-  CXXSTD := c++11
+  CXXSTD := c++14
 endif
 
 ifeq ($(CCE_GE_V9),TRUE)

--- a/Tools/GNUMake/comps/gnu.mak
+++ b/Tools/GNUMake/comps/gnu.mak
@@ -147,7 +147,9 @@ ifdef CXXSTD
   endif
   CXXFLAGS += -std=$(CXXSTD)
 else
-  CXXFLAGS += -std=c++14
+  ifeq ($(gcc_major_version),5)
+    CXXFLAGS += -std=c++14
+  endif
 endif
 
 CFLAGS   += -std=gnu99

--- a/Tools/GNUMake/comps/gnu.mak
+++ b/Tools/GNUMake/comps/gnu.mak
@@ -147,11 +147,7 @@ ifdef CXXSTD
   endif
   CXXFLAGS += -std=$(CXXSTD)
 else
-  ifeq ($(gcc_major_version),4)
-    CXXFLAGS += -std=c++11
-  else ifeq ($(gcc_major_version),5)
-    CXXFLAGS += -std=c++14
-  endif
+  CXXFLAGS += -std=c++14
 endif
 
 CFLAGS   += -std=gnu99

--- a/Tools/GNUMake/comps/hpcsdk.mak
+++ b/Tools/GNUMake/comps/hpcsdk.mak
@@ -94,7 +94,9 @@ ifdef CXXSTD
   endif
   CXXFLAGS += -std=$(CXXSTD)
 else
-  CXXFLAGS += -std=c++14
+  ifeq ($(gcc_major_version),5)
+    CXXFLAGS += -std=c++14
+  endif
 endif
 
 CFLAGS   += -c99

--- a/Tools/GNUMake/comps/hpcsdk.mak
+++ b/Tools/GNUMake/comps/hpcsdk.mak
@@ -94,11 +94,7 @@ ifdef CXXSTD
   endif
   CXXFLAGS += -std=$(CXXSTD)
 else
-  ifeq ($(gcc_major_version),4)
-    CXXFLAGS += -std=c++11
-  else ifeq ($(gcc_major_version),5)
-    CXXFLAGS += -std=c++14
-  endif
+  CXXFLAGS += -std=c++14
 endif
 
 CFLAGS   += -c99

--- a/Tools/GNUMake/comps/intel.mak
+++ b/Tools/GNUMake/comps/intel.mak
@@ -49,7 +49,7 @@ else
   ifeq ($(firstword $(sort 17.0 $(intel_version))), 17.0)
     CXXFLAGS += -std=c++14
   else
-    CXXFLAGS += -std=c++11
+    $(error Intel icpc 17.0 or newer is required.)
   endif
 endif
 

--- a/Tools/GNUMake/comps/llvm-flang.mak
+++ b/Tools/GNUMake/comps/llvm-flang.mak
@@ -43,7 +43,7 @@ endif
 ifdef CXXSTD
   CXXSTD := $(strip $(CXXSTD))
 else
-  CXXSTD := c++11
+  CXXSTD := c++14
 endif
 
 CXXFLAGS += -std=$(CXXSTD)

--- a/Tools/GNUMake/comps/nag.mak
+++ b/Tools/GNUMake/comps/nag.mak
@@ -59,11 +59,7 @@ ifdef CXXSTD
   endif
   CXXFLAGS += -std=$(CXXSTD)
 else
-  ifeq ($(gcc_major_version),4)
-    CXXFLAGS += -std=c++11
-  else ifeq ($(gcc_major_version),5)
-    CXXFLAGS += -std=c++14
-  endif
+  CXXFLAGS += -std=c++14
 endif
 
 CFLAGS   += -std=gnu99

--- a/Tools/GNUMake/comps/nvcc.mak
+++ b/Tools/GNUMake/comps/nvcc.mak
@@ -65,11 +65,12 @@ ifeq ($(lowercase_nvcc_host_comp),gnu)
 
   ifdef CXXSTD
     CXXSTD := $(strip $(CXXSTD))
+    CXXFLAGS += -std=$(CXXSTD)
   else
-    CXXSTD := c++14
+    ifeq ($(gcc_major_version),5)
+      CXXFLAGS += -std=c++14
+    endif
   endif
-
-  CXXFLAGS += -std=$(CXXSTD)
 
   NVCC_CCBIN ?= g++
 

--- a/Tools/GNUMake/comps/nvcc.mak
+++ b/Tools/GNUMake/comps/nvcc.mak
@@ -56,23 +56,17 @@ ifeq ($(lowercase_nvcc_host_comp),$(filter $(lowercase_nvcc_host_comp),gcc gnu g
 endif
 
 ifeq ($(lowercase_nvcc_host_comp),gnu)
+
+  ifeq ($(shell expr $(gcc_major_version) \< 5),1)
+    ifneq ($(NO_CONFIG_CHECKING),TRUE)
+      $(error C++14 support requires GCC 5 or newer.)
+    endif
+  endif
+
   ifdef CXXSTD
     CXXSTD := $(strip $(CXXSTD))
-    ifeq ($(shell expr $(gcc_major_version) \< 5),1)
-      ifneq ($(NO_CONFIG_CHECKING),TRUE)
-        ifeq ($(CXXSTD),c++14)
-          $(error C++14 support requires GCC 5 or newer.)
-        endif
-      endif
-    endif
   else
-    ifeq ($(gcc_major_version),4)
-      CXXSTD := c++11
-    else ifeq ($(gcc_major_version),5)
-      CXXSTD := c++14
-    else
-      CXXSTD := c++14
-    endif
+    CXXSTD := c++14
   endif
 
   CXXFLAGS += -std=$(CXXSTD)
@@ -93,27 +87,21 @@ else ifeq ($(lowercase_nvcc_host_comp),pgi)
       endif
     endif
   else
-    ifeq ($(gcc_major_version),4)
-      CXXSTD := c++11
-    else ifeq ($(gcc_major_version),5)
-      CXXSTD := c++14
-    else
-      CXXSTD := c++14
-    endif
+    CXXSTD := c++14
   endif
 
   CXXFLAGS += -std=$(CXXSTD)
 
   NVCC_CCBIN ?= pgc++
 
-  # In pgi.make, we use gcc_major_version to handle c++11/c++14 flag.
+  # In pgi.make, we use gcc_major_version to handle c++14 flag.
   CXXFLAGS_FROM_HOST := -ccbin=$(NVCC_CCBIN) -Xcompiler='$(CXXFLAGS)' --std=$(CXXSTD)
   CFLAGS_FROM_HOST := $(CXXFLAGS_FROM_HOST)
 else
   ifdef CXXSTD
     CXXSTD := $(strip $(CXXSTD))
   else
-    CXXSTD := c++11
+    CXXSTD := c++14
   endif
 
   NVCC_CCBIN ?= $(CXX)

--- a/Tools/GNUMake/comps/pgi.mak
+++ b/Tools/GNUMake/comps/pgi.mak
@@ -91,7 +91,9 @@ ifdef CXXSTD
   CXXSTD := $(strip $(CXXSTD))
   CXXFLAGS += -std=$(CXXSTD)
 else
-  CXXFLAGS += -std=c++14
+  ifeq ($(gcc_major_version),5)
+    CXXFLAGS += -std=c++14
+  endif
 endif
 
 CFLAGS   += -c99

--- a/Tools/GNUMake/comps/pgi.mak
+++ b/Tools/GNUMake/comps/pgi.mak
@@ -82,20 +82,16 @@ else
 endif
 
 # The logic here should be consistent with what's in nvcc.mak
+
+ifeq ($(shell expr $(gcc_major_version) \< 5),1)
+  $(error C++14 support requires GCC 5 or newer.)
+endif
+
 ifdef CXXSTD
   CXXSTD := $(strip $(CXXSTD))
-  ifeq ($(shell expr $(gcc_major_version) \< 5),1)
-    ifeq ($(CXXSTD),c++14)
-      $(error C++14 support requires GCC 5 or newer.)
-    endif
-  endif
   CXXFLAGS += -std=$(CXXSTD)
 else
-  ifeq ($(gcc_major_version),4)
-    CXXFLAGS += -std=c++11
-  else ifeq ($(gcc_major_version),5)
-    CXXFLAGS += -std=c++14
-  endif
+  CXXFLAGS += -std=c++14
 endif
 
 CFLAGS   += -c99

--- a/Tutorials/Basic/Build_with_libamrex/GNUmakefile
+++ b/Tutorials/Basic/Build_with_libamrex/GNUmakefile
@@ -7,7 +7,7 @@ CXX = mpicxx
 FC = gfortran
 
 CPPFLAGS = -I. -I$(AMREX_INSTALL_DIR)/include
-CXXFLAGS = -O2 -std=c++11
+CXXFLAGS = -O2 -std=c++14
 FFLAGS = -O2
 LDFLAGS = -L$(AMREX_INSTALL_DIR)/lib
 


### PR DESCRIPTION
This is well-supported now and will allow a lot of the code in amrex to be simplified. 

I have also bumped the version on the Cuda 9 CI test to Cuda 9.2 and GCC 6.5.0, since the old combination did not work with C++14. 

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
