### PR TITLE
Update the preferred short name of NVIDIA HPC SDK to nvhpc

### DIFF
--- a/Tools/GNUMake/Make.defs
+++ b/Tools/GNUMake/Make.defs
@@ -401,8 +401,8 @@ ifdef AMREX_CCOMP
     AMREX_CCOMP = cray
   else ifeq ($(lowercase_amrex_comp),pgi)
     AMREX_CCOMP = pgi
-  else ifeq ($(lowercase_amrex_comp),hpcsdk)
-    AMREX_CCOMP = hpcsdk
+  else ifeq ($(lowercase_amrex_comp),nvhpc)
+    AMREX_CCOMP = nvhpc
   else ifeq ($(lowercase_amrex_comp),ibm)
     AMREX_CCOMP = ibm
   else ifeq ($(lowercase_amrex_comp),$(filter $(lowercase_amrex_comp),llvm clang clang++))
@@ -414,7 +414,7 @@ ifdef AMREX_CCOMP
   else ifeq ($(lowercase_amrex_comp),nec)
     AMREX_CCOMP = nec
   else
-    $(error Unknown compiler $(AMREX_CCOMP). Supported compilers are gnu, intel, dpcpp, cray, pgi, hpcsdk, ibm, llvm, nag, and nec)
+    $(error Unknown compiler $(AMREX_CCOMP). Supported compilers are gnu, intel, dpcpp, cray, pgi, nvhpc, ibm, llvm, nag, and nec)
   endif
 endif
 
@@ -446,11 +446,11 @@ else ifeq ($(lowercase_comp),pgi)
   AMREX_CCOMP ?= pgi
   $(info Loading $(AMREX_HOME)/Tools/GNUMake/comps/pgi.mak...)
   include        $(AMREX_HOME)/Tools/GNUMake/comps/pgi.mak
-else ifeq ($(lowercase_comp),hpcsdk)
-  AMREX_FCOMP ?= hpcsdk
-  AMREX_CCOMP ?= hpcsdk
-  $(info Loading $(AMREX_HOME)/Tools/GNUMake/comps/hpcsdk.mak...)
-  include        $(AMREX_HOME)/Tools/GNUMake/comps/hpcsdk.mak
+else ifeq ($(lowercase_comp),nvhpc)
+  AMREX_FCOMP ?= nvhpc
+  AMREX_CCOMP ?= nvhpc
+  $(info Loading $(AMREX_HOME)/Tools/GNUMake/comps/nvhpc.mak...)
+  include        $(AMREX_HOME)/Tools/GNUMake/comps/nvhpc.mak
 else ifeq ($(lowercase_comp),ibm)
   AMREX_FCOMP ?= ibm
   AMREX_CCOMP ?= ibm
@@ -484,7 +484,7 @@ else ifeq ($(lowercase_comp),hip)
   $(info Loading $(AMREX_HOME)/Tools/GNUMake/comps/hip.mak...)
   include        $(AMREX_HOME)/Tools/GNUMake/comps/hip.mak
 else
-  $(error Unknown compiler $(COMP). Supported compilers are gnu, intel, dpcpp, cray, pgi, hpcsdk, ibm, llvm, nag, and nec)
+  $(error Unknown compiler $(COMP). Supported compilers are gnu, intel, dpcpp, cray, pgi, nvhpc, ibm, llvm, nag, and nec)
 endif
 
 CXXFLAGS += $(XTRA_CXXFLAGS)
@@ -662,13 +662,13 @@ else ifeq ($(USE_CUDA),TRUE)
 
     ifeq ($(lowercase_comp),pgi)
         LINK_WITH_FORTRAN_COMPILER=TRUE
-    else ifeq ($(lowercase_comp),hpcsdk)
+    else ifeq ($(lowercase_comp),nvhpc)
         LINK_WITH_FORTRAN_COMPILER=TRUE
     else ifeq ($(lowercase_comp),ibm)
         LINK_WITH_FORTRAN_COMPILER=TRUE
     else ifeq ($(lowercase_comp),gnu)
     else
-        $(error CUDA can only be used with COMP=pgi or hpcsdk or ibm or gnu)
+        $(error CUDA can only be used with COMP=pgi or nvhpc or ibm or gnu)
     endif
 
     include $(AMREX_HOME)/Tools/GNUMake/comps/nvcc.mak

--- a/Tools/GNUMake/comps/nvhpc.mak
+++ b/Tools/GNUMake/comps/nvhpc.mak
@@ -1,34 +1,34 @@
 
 ifndef AMREX_CCOMP
-  AMREX_CCOMP = hpcsdk
+  AMREX_CCOMP = nvhpc
 endif
 
 ifndef AMREX_FCOMP
-  AMREX_FCOMP = hpcsdk
+  AMREX_FCOMP = nvhpc
 endif
 
 ########################################################################
 
-hpcsdk_version = $(shell $(CXX) -V 2>&1 | grep 'target' | sed 's|.*$(CXX) \([0-9\.]*\).*|\1|')
-hpcsdk_major_version = $(shell echo $(hpcsdk_version) | cut -f1 -d.)
-hpcsdk_minor_version = $(shell echo $(hpcsdk_version) | cut -f2 -d.)
+nvhpc_version = $(shell $(CXX) -V 2>&1 | grep 'target' | sed 's|.*$(CXX) \([0-9\.]*\).*|\1|')
+nvhpc_major_version = $(shell echo $(nvhpc_version) | cut -f1 -d.)
+nvhpc_minor_version = $(shell echo $(nvhpc_version) | cut -f2 -d.)
 
 gcc_version       = $(shell g++ -dumpfullversion -dumpversion | head -1 | sed -e 's;.*  *;;')
 gcc_major_version = $(shell g++ -dumpfullversion -dumpversion | head -1 | sed -e 's;.*  *;;' | sed -e 's;\..*;;')
 gcc_minor_version = $(shell g++ -dumpfullversion -dumpversion | head -1 | sed -e 's;.*  *;;' | sed -e 's;[^.]*\.;;' | sed -e 's;\..*;;')
 
-COMP_VERSION = $(hpcsdk_version)
+COMP_VERSION = $(nvhpc_version)
 
 ########################################################################
 
-GENERIC_HPCSDK_FLAGS =
+GENERIC_NVHPC_FLAGS =
 
 ifeq ($(USE_OMP),TRUE)
-  GENERIC_HPCSDK_FLAGS += -mp -Minfo=mp
+  GENERIC_NVHPC_FLAGS += -mp -Minfo=mp
 endif
 
 ifeq ($(USE_ACC),TRUE)
-  GENERIC_HPCSDK_FLAGS += -acc=gpu -Minfo=accel -mcmodel=medium
+  GENERIC_NVHPC_FLAGS += -acc=gpu -Minfo=accel -mcmodel=medium
   ifneq ($(CUDA_ARCH),)
     # We use 10.1 because nvcc defaults to 10.1 if it can't detect a GPU
     # driver. And in Cori GPU interactive jobs, nvcc can't see the GPU driver
@@ -37,21 +37,21 @@ ifeq ($(USE_ACC),TRUE)
     # get link errors between nvcc and the HPC SDK if we don't do something
     # about this. The easiest fix is to simply force HPC SDK to use CUDA 10.1
     # to match the blind nvcc.
-    GENERIC_HPCSDK_FLAGS += -acc=gpu -gpu=cc$(CUDA_ARCH),cuda10.1
+    GENERIC_NVHPC_FLAGS += -acc=gpu -gpu=cc$(CUDA_ARCH),cuda10.1
   else
-    GENERIC_HPCSDK_FLAGS += -acc=gpu
+    GENERIC_NVHPC_FLAGS += -acc=gpu
   endif
 endif
 
-# Note that -O2 is the default optimization level for HPCSDK
+# Note that -O2 is the default optimization level for NVHPC
 
-HPCSDK_OPT := -O2 -fast
+NVHPC_OPT := -O2 -fast
 
 ########################################################################
 ########################################################################
 ########################################################################
 
-ifeq ($(AMREX_CCOMP),hpcsdk)
+ifeq ($(AMREX_CCOMP),nvhpc)
 
 CXX = nvc++
 CC  = nvc
@@ -63,7 +63,7 @@ CFLAGS   =
 
 # Allow -gopt to be disabled to work around a compiler bug on P9.
 
-HPCSDK_GOPT ?= TRUE
+NVHPC_GOPT ?= TRUE
 
 ifeq ($(DEBUG),TRUE)
 
@@ -72,10 +72,10 @@ ifeq ($(DEBUG),TRUE)
 
 else
 
-  CXXFLAGS += $(HPCSDK_OPT)
-  CFLAGS   += $(HPCSDK_OPT)
+  CXXFLAGS += $(NVHPC_OPT)
+  CFLAGS   += $(NVHPC_OPT)
 
-  ifeq ($(HPCSDK_GOPT),TRUE)
+  ifeq ($(NVHPC_GOPT),TRUE)
 
     CXXFLAGS += -gopt
     CFLAGS   += -gopt
@@ -103,28 +103,28 @@ endif
 
 CFLAGS   += -c99
 
-CXXFLAGS += $(GENERIC_HPCSDK_FLAGS)
-CFLAGS   += $(GENERIC_HPCSDK_FLAGS)
+CXXFLAGS += $(GENERIC_NVHPC_FLAGS)
+CFLAGS   += $(GENERIC_NVHPC_FLAGS)
 
-else # AMREX_CCOMP == hpcsdk
+else # AMREX_CCOMP == nvhpc
 
 # If we're using OpenACC but also CUDA, then nvcc will be the C++ compiler. If
 # we want to call the OpenACC API from C++ then we need to make sure we have
-# the includes for it, because HPCSDK may not be the host compiler for nvcc.
+# the includes for it, because NVHPC may not be the host compiler for nvcc.
 
 ifeq ($(USE_ACC),TRUE)
-  HPCSDK_BIN_LOCATION := $(shell nvc++ -show 2>&1 | grep CPPCOMPDIR | awk '{print $$7}' | cut -c2-)
-  HPCSDK_LOCATION := $(shell dirname $(HPCSDK_BIN_LOCATION))
-  INCLUDE_LOCATIONS += $(HPCSDK_LOCATION)/etc/include_acc
+  NVHPC_BIN_LOCATION := $(shell nvc++ -show 2>&1 | grep CPPCOMPDIR | awk '{print $$7}' | cut -c2-)
+  NVHPC_LOCATION := $(shell dirname $(NVHPC_BIN_LOCATION))
+  INCLUDE_LOCATIONS += $(NVHPC_LOCATION)/etc/include_acc
 endif
 
-endif # AMREX_CCOMP == hpcsdk
+endif # AMREX_CCOMP == nvhpc
 
 ########################################################################
 ########################################################################
 ########################################################################
 
-ifeq ($(AMREX_FCOMP),hpcsdk)
+ifeq ($(AMREX_FCOMP),nvhpc)
 
 #
 # Now set the Fortran flags. Since this is done after the GNU include
@@ -144,10 +144,10 @@ ifeq ($(DEBUG),TRUE)
 
 else
 
-  FFLAGS   += $(HPCSDK_OPT)
-  F90FLAGS += $(HPCSDK_OPT)
+  FFLAGS   += $(NVHPC_OPT)
+  F90FLAGS += $(NVHPC_OPT)
 
-  ifeq ($(HPCSDK_GOPT),TRUE)
+  ifeq ($(NVHPC_GOPT),TRUE)
 
     FFLAGS   += -gopt
     F90FLAGS += -gopt
@@ -205,8 +205,8 @@ FMODULES = -module $(fmoddir) -I$(fmoddir)
 
 ########################################################################
 
-FFLAGS   += $(GENERIC_HPCSDK_FLAGS)
-F90FLAGS += $(GENERIC_HPCSDK_FLAGS)
+FFLAGS   += $(GENERIC_NVHPC_FLAGS)
+F90FLAGS += $(GENERIC_NVHPC_FLAGS)
 
 ########################################################################
 
@@ -214,4 +214,4 @@ override XTRALIBS += -lstdc++ -latomic -lnvf
 
 LINK_WITH_FORTRAN_COMPILER ?= $(USE_F_INTERFACES)
 
-endif # AMREX_FCOMP == hpcsdk
+endif # AMREX_FCOMP == nvhpc


### PR DESCRIPTION
## Summary

`nvhpc` is the preferred short name of the NVIDIA HPC SDK (for example when used in modules).

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
