### PR TITLE
Fix a new bug in GNU Make

### DIFF
--- a/Tools/GNUMake/comps/nvcc.mak
+++ b/Tools/GNUMake/comps/nvcc.mak
@@ -65,12 +65,10 @@ ifeq ($(lowercase_nvcc_host_comp),gnu)
 
   ifdef CXXSTD
     CXXSTD := $(strip $(CXXSTD))
-    CXXFLAGS += -std=$(CXXSTD)
   else
-    ifeq ($(gcc_major_version),5)
-      CXXFLAGS += -std=c++14
-    endif
+    CXXSTD = c++14
   endif
+  CXXFLAGS += -std=$(CXXSTD)
 
   NVCC_CCBIN ?= g++
 


### PR DESCRIPTION
## Summary

Must set CXXSTD for nvcc because we need to use it later.

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
