### PR TITLE
DPCPP: Use codeplay_host_task

### DIFF
--- a/Src/Base/AMReX_GpuAsyncArray.H
+++ b/Src/Base/AMReX_GpuAsyncArray.H
@@ -91,10 +91,19 @@ public:
 #endif
                 Gpu::callbackAdded();
 #else
-                // xxxxx DPCPP todo
-                Gpu::streamSynchronize();
-                The_Arena()->free(d_data);
-                std::free(h_data);
+                auto pd = d_data;
+                auto ph = h_data;
+                auto& q = *(Gpu::gpuStream().queue);
+                try {
+                    q.submit([&] (sycl::handler& h) {
+                        h.codeplay_host_task([=] () {
+                            The_Arena()->free(pd);
+                            std::free(ph);
+                        });
+                    });
+                } catch (sycl::exception const& ex) {
+                    amrex::Abort(std::string("host_task: ")+ex.what()+"!!!!!");
+                }
 #endif
             }
         }

--- a/Src/Base/AMReX_GpuElixir.cpp
+++ b/Src/Base/AMReX_GpuElixir.cpp
@@ -57,9 +57,18 @@ Elixir::clear () noexcept
 #endif
             Gpu::callbackAdded();
 #elif defined(AMREX_USE_DPCPP)
-            // xxxxx DPCPP todo
-            Gpu::streamSynchronize();
-            if (m_p != nullptr) m_arena->free(m_p);
+            auto p = m_p;
+            auto a = m_arena;
+            auto& q = *(Gpu::gpuStream().queue);
+            try {
+                q.submit([&] (sycl::handler& h) {
+                    h.codeplay_host_task([=] () {
+                        a->free(p);
+                    });
+                });
+            } catch (sycl::exception const& ex) {
+                amrex::Abort(std::string("host_task: ")+ex.what()+"!!!!!");
+            }
 #endif
         }
     }


### PR DESCRIPTION
In AsyncArray and Elixir, replace streamSynchronize with SYCL 2020's
host_task.  Note that the function name in the current oneAPI release is
codeplay_host_task, because it started as a Codeplay extension.  This will
probably change in the future, since the extension has been accepted into
the standard.