### PR TITLE
Remove functions about the number of host callbacks

### DIFF
--- a/Src/Base/AMReX_GpuAsyncArray.H
+++ b/Src/Base/AMReX_GpuAsyncArray.H
@@ -89,7 +89,6 @@ public:
                 AMREX_CUDA_SAFE_CALL(cudaStreamAddCallback(Gpu::gpuStream(),
                                                            amrex_asyncarray_delete, p, 0));
 #endif
-                Gpu::callbackAdded();
 #else
                 // xxxxx DPCPP todo
                 Gpu::streamSynchronize();

--- a/Src/Base/AMReX_GpuDevice.H
+++ b/Src/Base/AMReX_GpuDevice.H
@@ -335,12 +335,6 @@ onNullStream (gpuStream_t stream)
 }
 #endif
 
-#ifdef AMREX_USE_GPU
-void callbackAdded ();
-void resetNumCallbacks ();
-int getNumCallbacks ();
-#endif
-
 }}
 
 #endif

--- a/Src/Base/AMReX_GpuDevice.cpp
+++ b/Src/Base/AMReX_GpuDevice.cpp
@@ -971,25 +971,4 @@ Device::freeMemAvailable ()
 #endif
 }
 
-#ifdef AMREX_USE_GPU
-namespace {
-    static int ncallbacks = 0;
-}
-
-void callbackAdded ()
-{
-    ++ncallbacks;
-}
-
-void resetNumCallbacks ()
-{
-    ncallbacks = 0;
-}
-
-int getNumCallbacks ()
-{
-    return ncallbacks;
-}
-#endif
-
 }}

--- a/Src/Base/AMReX_GpuElixir.cpp
+++ b/Src/Base/AMReX_GpuElixir.cpp
@@ -55,7 +55,6 @@ Elixir::clear () noexcept
             AMREX_CUDA_SAFE_CALL(cudaStreamAddCallback(Gpu::gpuStream(),
                                                        amrex_elixir_delete, p, 0));
 #endif
-            Gpu::callbackAdded();
 #elif defined(AMREX_USE_DPCPP)
             // xxxxx DPCPP todo
             Gpu::streamSynchronize();

--- a/Src/Base/AMReX_MFIter.cpp
+++ b/Src/Base/AMReX_MFIter.cpp
@@ -228,7 +228,6 @@ MFIter::~MFIter ()
 #ifdef AMREX_USE_GPU
     AMREX_GPU_ERROR_CHECK();
     Gpu::Device::resetStreamIndex();
-    Gpu::resetNumCallbacks();
     if (!OpenMP::in_parallel() && Gpu::inFuseRegion()) {
         Gpu::LaunchFusedKernels();
     }
@@ -342,7 +341,6 @@ MFIter::Initialize ()
 
 #ifdef AMREX_USE_GPU
 	Gpu::Device::setStreamIndex((streams > 0) ? currentIndex%streams : -1);
-        Gpu::resetNumCallbacks();
         if (!OpenMP::in_parallel()) {
             if (index_map->size() >= Gpu::getFuseNumKernelsThreshold()) {
                 gpu_fsg.reset(new Gpu::FuseSafeGuard(true));


### PR DESCRIPTION
## Summary

We used to use the number of host callbacks to limit the number of GPU
streams.  But we no longer do that anymore, and the default number of
streams has been reduced to 4.  So the functions keeping track of the number
of host callbacks can now be removed.

## Summary

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
