### PR TITLE
CMake: More Particle Tests

### DIFF
--- a/Tests/Particles/AssignDensity/CMakeLists.txt
+++ b/Tests/Particles/AssignDensity/CMakeLists.txt
@@ -1,0 +1,7 @@
+set(_sources     main.cpp)
+set(_input_files inputs  )
+
+setup_test(_sources _input_files)
+
+unset(_sources)
+unset(_input_files)

--- a/Tests/Particles/AssignMultiLevelDensity/CMakeLists.txt
+++ b/Tests/Particles/AssignMultiLevelDensity/CMakeLists.txt
@@ -1,0 +1,7 @@
+set(_sources     main.cpp)
+set(_input_files inputs  )
+
+setup_test(_sources _input_files)
+
+unset(_sources)
+unset(_input_files)

--- a/Tests/Particles/AsyncIO/CMakeLists.txt
+++ b/Tests/Particles/AsyncIO/CMakeLists.txt
@@ -1,0 +1,7 @@
+set(_sources     main.cpp)
+set(_input_files inputs  )
+
+setup_test(_sources _input_files)
+
+unset(_sources)
+unset(_input_files)

--- a/Tests/Particles/AsyncIO/inputs
+++ b/Tests/Particles/AsyncIO/inputs
@@ -1,17 +1,17 @@
 
 # Domain size
 
-#nx = 32 # number of grid points along the x axis
-#ny = 32 # number of grid points along the y axis 
-#nz = 32 # number of grid points along the z axis
+nx = 32 # number of grid points along the x axis
+ny = 32 # number of grid points along the y axis 
+nz = 32 # number of grid points along the z axis
 
 #nx = 64 # number of grid points along the x axis
 #ny = 64 # number of grid points along the y axis 
 #nz = 64 # number of grid points along the z axis
 
-nx = 128 # number of grid points along the x axis
-ny = 128 # number of grid points along the y axis 
-nz = 128 # number of grid points along the z axis
+#nx = 128 # number of grid points along the x axis
+#ny = 128 # number of grid points along the y axis 
+#nz = 128 # number of grid points along the z axis
 
 # Maximum allowable size of each subdomain in the problem domain; 
 #    this is used to decompose the domain for parallel calculations.

--- a/Tests/Particles/GhostsAndVirtuals/CMakeLists.txt
+++ b/Tests/Particles/GhostsAndVirtuals/CMakeLists.txt
@@ -1,0 +1,7 @@
+set(_sources     main.cpp)
+set(_input_files inputs  )
+
+setup_test(_sources _input_files)
+
+unset(_sources)
+unset(_input_files)

--- a/Tests/Particles/GhostsAndVirtuals/main.cpp
+++ b/Tests/Particles/GhostsAndVirtuals/main.cpp
@@ -88,7 +88,7 @@ void test_ghosts_and_virtuals (TestParams& parms)
     bool serialize = true;
     int iseed = 451;
     Real mass = 10.0;
-    MyParticleContainer::ParticleInitData pdata = {mass};
+    MyParticleContainer::ParticleInitData pdata = {{},{}, mass};
 
     myPC.InitRandom(num_particles, iseed, pdata, serialize);
 

--- a/Tests/Particles/InitFromAscii/CMakeLists.txt
+++ b/Tests/Particles/InitFromAscii/CMakeLists.txt
@@ -1,0 +1,7 @@
+set(_sources     main.cpp)
+set(_input_files inputs  )
+
+setup_test(_sources _input_files)
+
+unset(_sources)
+unset(_input_files)

--- a/Tests/Particles/InitFromAscii/CMakeLists.txt
+++ b/Tests/Particles/InitFromAscii/CMakeLists.txt
@@ -1,5 +1,5 @@
 set(_sources     main.cpp)
-set(_input_files inputs  )
+set(_input_files inputs particles.txt  )
 
 setup_test(_sources _input_files)
 

--- a/Tests/Particles/InitFromAscii/CMakeLists.txt
+++ b/Tests/Particles/InitFromAscii/CMakeLists.txt
@@ -1,7 +1,9 @@
 set(_sources     main.cpp)
-set(_input_files inputs particles.txt  )
+set(_input_files inputs  )
 
 setup_test(_sources _input_files)
+
+file(COPY particles.txt DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 
 unset(_sources)
 unset(_input_files)

--- a/Tests/Particles/InitFromAscii/main.cpp
+++ b/Tests/Particles/InitFromAscii/main.cpp
@@ -46,21 +46,22 @@ void test_init_ascii (TestParams& parms)
     myPC.InitFromAsciiFile("particles.txt", 1 + AMREX_SPACEDIM);
 
     // should be 8
-    amrex::Print() << myPC.TotalNumberOfParticles() << "\n";
+    AMREX_ALWAYS_ASSERT(myPC.TotalNumberOfParticles() == 8);
 
     // should be 8010.0
     using PType = MyParticleContainer::SuperParticleType;
-    amrex::Print() << amrex::ReduceSum(myPC,
-                                       [=] AMREX_GPU_HOST_DEVICE (const PType& p) -> Real
-                                       {
-                                           Real total = 0.0;
-                                           for (int i = 0; i < 1 + AMREX_SPACEDIM; ++i)
-                                           {
-                                               total += p.rdata(i);
-                                           }
-                                           return total;
-                                       })
-                   << "\n";
+    auto tot = amrex::ReduceSum(myPC,
+                                [=] AMREX_GPU_HOST_DEVICE (const PType& p) -> Real
+                                {
+                                    Real total = 0.0;
+                                    for (int i = 0; i < 1 + AMREX_SPACEDIM; ++i)
+                                    {
+                                        total += p.rdata(i);
+                                    }
+                                    return total;
+                                });
+
+    AMREX_ALWAYS_ASSERT(tot == 8010);
 }
 
 int main(int argc, char* argv[])

--- a/Tests/Particles/Intersection/CMakeLists.txt
+++ b/Tests/Particles/Intersection/CMakeLists.txt
@@ -1,0 +1,7 @@
+set(_sources     main.cpp)
+set(_input_files inputs  )
+
+setup_test(_sources _input_files)
+
+unset(_sources)
+unset(_input_files)

--- a/Tests/Particles/Intersection/main.cpp
+++ b/Tests/Particles/Intersection/main.cpp
@@ -64,7 +64,7 @@ void testIntersection()
         size *= 2;
     }
 
-    Vector<ParticleLocator> ploc(params.nlevs);
+    Vector<ParticleLocator<DenseBins<Box>>> ploc(params.nlevs);
 
     for (int lev = 0; lev < params.nlevs; ++lev)
     {

--- a/Tests/Particles/ParallelContext/CMakeLists.txt
+++ b/Tests/Particles/ParallelContext/CMakeLists.txt
@@ -1,0 +1,7 @@
+set(_sources     main.cpp)
+set(_input_files inputs.rt)
+
+setup_test(_sources _input_files)
+
+unset(_sources)
+unset(_input_files)

--- a/Tests/Particles/ParticleArray/CMakeLists.txt
+++ b/Tests/Particles/ParticleArray/CMakeLists.txt
@@ -1,0 +1,5 @@
+set(_sources main.cpp)
+
+setup_test(_sources FALSE)
+
+unset(_sources)

--- a/Tests/Particles/ParticleIterator/CMakeLists.txt
+++ b/Tests/Particles/ParticleIterator/CMakeLists.txt
@@ -1,0 +1,5 @@
+set(_sources main.cpp)
+
+setup_test(_sources FALSE)
+
+unset(_sources)

--- a/Tests/Particles/SparseBins/CMakeLists.txt
+++ b/Tests/Particles/SparseBins/CMakeLists.txt
@@ -1,0 +1,7 @@
+set(_sources     main.cpp)
+set(_input_files inputs  )
+
+setup_test(_sources _input_files)
+
+unset(_sources)
+unset(_input_files)

--- a/Tests/Particles/TypeDescriptor/CMakeLists.txt
+++ b/Tests/Particles/TypeDescriptor/CMakeLists.txt
@@ -1,0 +1,5 @@
+set(_sources main.cpp)
+
+setup_test(_sources FALSE)
+
+unset(_sources)


### PR DESCRIPTION
## Summary

Add CMake support to more particle tests :)

Updates a few particle test details that were using outdated syntax and did not compile anymore.

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
