### PR TITLE
The_Async_Arena and Elixir::append

### DIFF
--- a/Src/Base/AMReX_Arena.H
+++ b/Src/Base/AMReX_Arena.H
@@ -25,6 +25,7 @@ inline bool is_aligned (const void* p, std::size_t alignment) noexcept
 class Arena;
 
 Arena* The_Arena ();
+Arena* The_Async_Arena ();
 Arena* The_Device_Arena ();
 Arena* The_Managed_Arena ();
 Arena* The_Pinned_Arena ();

--- a/Src/Base/AMReX_Arena.cpp
+++ b/Src/Base/AMReX_Arena.cpp
@@ -4,6 +4,7 @@
 #include <AMReX_CArena.H>
 #include <AMReX_DArena.H>
 #include <AMReX_EArena.H>
+#include <AMReX_PArena.H>
 
 #include <AMReX.H>
 #include <AMReX_Print.H>
@@ -29,6 +30,7 @@ namespace {
     bool initialized = false;
 
     Arena* the_arena = nullptr;
+    Arena* the_async_arena = nullptr;
     Arena* the_device_arena = nullptr;
     Arena* the_managed_arena = nullptr;
     Arena* the_pinned_arena = nullptr;
@@ -37,6 +39,7 @@ namespace {
     bool use_buddy_allocator = false;
     Long buddy_allocator_size = 0L;
     Long the_arena_init_size = 0L;
+    Long the_async_arena_release_threshold = -1L;
 #ifdef AMREX_USE_HIP
     bool the_arena_is_managed = false; // xxxxx HIP FIX HERE
 #else
@@ -150,6 +153,7 @@ Arena::Initialize ()
     initialized = true;
 
     BL_ASSERT(the_arena == nullptr);
+    BL_ASSERT(the_async_arena == nullptr);
     BL_ASSERT(the_device_arena == nullptr);
     BL_ASSERT(the_managed_arena == nullptr);
     BL_ASSERT(the_pinned_arena == nullptr);
@@ -159,6 +163,7 @@ Arena::Initialize ()
     pp.query("use_buddy_allocator", use_buddy_allocator);
     pp.query("buddy_allocator_size", buddy_allocator_size);
     pp.query("the_arena_init_size", the_arena_init_size);
+    pp.query("the_async_arena_release_threshold", the_async_arena_release_threshold);
     pp.query("the_arena_is_managed", the_arena_is_managed);
     pp.query("abort_on_out_of_gpu_memory", abort_on_out_of_gpu_memory);
 
@@ -206,6 +211,12 @@ Arena::Initialize ()
         the_arena = new BArena;
 #endif
     }
+
+    if (the_async_arena_release_threshold < 0) {
+        the_async_arena_release_threshold = std::numeric_limits<Long>::max();
+    }
+
+    the_async_arena = new PArena(the_async_arena_release_threshold);
 
 #ifdef AMREX_USE_GPU
     the_device_arena = new CArena(0, ArenaInfo().SetDeviceMemory());
@@ -309,6 +320,9 @@ Arena::Finalize ()
     delete the_arena;
     the_arena = nullptr;
     
+    delete the_async_arena;
+    the_async_arena = nullptr;
+
     delete the_device_arena;
     the_device_arena = nullptr;
     
@@ -327,6 +341,13 @@ The_Arena ()
 {
     BL_ASSERT(the_arena != nullptr);
     return the_arena;
+}
+
+Arena*
+The_Async_Arena ()
+{
+    BL_ASSERT(the_async_arena != nullptr);
+    return the_async_arena;
 }
 
 Arena*

--- a/Src/Base/AMReX_BaseFab.H
+++ b/Src/Base/AMReX_BaseFab.H
@@ -274,7 +274,7 @@ public:
     * Resizing is typically faster than re-allocating a
     * BaseFab because memory allocation can often be avoided.
     */
-    void resize (const Box& b, int N = 1);
+    void resize (const Box& b, int N = 1, Arena* ar = nullptr);
 
     template <class U=T, typename std::enable_if<std::is_trivially_destructible<U>::value,int>::type = 0>
     Elixir elixir () noexcept;
@@ -2042,12 +2042,17 @@ BaseFab<T>::operator= (T const& t) noexcept
 
 template <class T>
 void
-BaseFab<T>::resize (const Box& b, int n)
+BaseFab<T>::resize (const Box& b, int n, Arena* ar)
 {
     this->nvar   = n;
     this->domain = b;
 
-    if (this->dptr == 0 || !this->ptr_owner)
+    if (arena() != DataAllocator(ar).arena()) {
+        clear();
+        m_arena = ar;
+        define();
+    }
+    else if (this->dptr == 0 || !this->ptr_owner)
     {
 	if (this->shared_memory)
 	    amrex::Abort("BaseFab::resize: BaseFab in shared memory cannot increase size");

--- a/Src/Base/AMReX_FArrayBox.H
+++ b/Src/Base/AMReX_FArrayBox.H
@@ -357,7 +357,7 @@ public:
     bool contains_inf (const Box& bx, int scomp, int ncomp, IntVect& where) const noexcept;
 
     //! For debugging purposes we hide BaseFab version and do some extra work.
-    void resize (const Box& b, int N = 1);
+    void resize (const Box& b, int N = 1, Arena* ar = nullptr);
 
     FabType getType () const noexcept { return m_type; }
 

--- a/Src/Base/AMReX_FArrayBox.cpp
+++ b/Src/Base/AMReX_FArrayBox.cpp
@@ -201,9 +201,9 @@ FArrayBox::initVal () noexcept
 }
 
 void
-FArrayBox::resize (const Box& b, int N)
+FArrayBox::resize (const Box& b, int N, Arena* ar)
 {
-    BaseFab<Real>::resize(b,N);
+    BaseFab<Real>::resize(b,N,ar);
     initVal();
 }
 

--- a/Src/Base/AMReX_GpuDevice.H
+++ b/Src/Base/AMReX_GpuDevice.H
@@ -124,6 +124,8 @@ public:
 
 #ifdef AMREX_USE_GPU
 
+    static int memoryPoolsSupported () noexcept { return memory_pools_supported; }
+
 #   if defined(AMREX_USE_HIP) && (HIP_VERSION_MAJOR >= 4)
     // definition: https://github.com/llvm/llvm-project/blob/62ec4ac90738a5f2d209ed28c822223e58aaaeb7/clang/lib/Basic/Targets/AMDGPU.cpp#L400
     // overview wavefront size: https://github.com/llvm/llvm-project/blob/efc063b621ea0c4d1e452bcade62f7fc7e1cc937/clang/test/Driver/amdgpu-macros.cl#L70-L115
@@ -159,6 +161,7 @@ private:
     static Vector<gpuStream_t> gpu_stream_pool;
     static Vector<gpuStream_t> gpu_stream;
     static gpuDeviceProp_t device_prop;
+    static int memory_pools_supported;
     static unsigned int max_blocks_per_launch;
 
 #ifdef AMREX_USE_DPCPP

--- a/Src/Base/AMReX_GpuDevice.cpp
+++ b/Src/Base/AMReX_GpuDevice.cpp
@@ -64,6 +64,7 @@ gpuStream_t         Device::gpu_default_stream;
 Vector<gpuStream_t> Device::gpu_stream_pool;
 Vector<gpuStream_t> Device::gpu_stream;
 gpuDeviceProp_t     Device::device_prop;
+int                 Device::memory_pools_supported = 0;
 
 constexpr int Device::warp_size;
 
@@ -407,6 +408,10 @@ Device::initialize_gpu ()
 
     AMREX_ALWAYS_ASSERT_WITH_MESSAGE(device_prop.major >= 4 || (device_prop.major == 3 && device_prop.minor >= 5),
                                      "Compute capability must be >= 3.5");
+
+#if (__CUDACC_VER_MAJOR__ > 11 || ((__CUDACC_VER_MAJOR__ == 11) && (__CUDACC_VER_MINOR__ >= 2)) )
+    cudaDeviceGetAttribute(&memory_pools_supported, cudaDevAttrMemoryPoolsSupported, device_id);
+#endif
 
     if (sizeof(Real) == 8) {
         AMREX_CUDA_SAFE_CALL(cudaDeviceSetSharedMemConfig(cudaSharedMemBankSizeEightByte));

--- a/Src/Base/AMReX_GpuElixir.H
+++ b/Src/Base/AMReX_GpuElixir.H
@@ -3,6 +3,8 @@
 #include <AMReX_Config.H>
 
 #include <AMReX_Arena.H>
+#include <AMReX_Vector.H>
+#include <utility>
 
 namespace amrex {
 namespace Gpu {
@@ -11,27 +13,30 @@ class Elixir
 {
 public:
 
-    Elixir () noexcept : m_p(nullptr), m_arena(nullptr) {}
+    Elixir () noexcept {}
 
-    Elixir (void* p, Arena* arena) noexcept : m_p(p), m_arena(arena) {}
+    Elixir (void* p, Arena* arena) noexcept : m_pa({std::make_pair(p,arena)}) {}
 
     Elixir (Elixir const&) = delete;
     void operator= (Elixir const&) = delete;
 
     Elixir (Elixir && rhs) noexcept
-        : m_p(rhs.m_p), m_arena(rhs.m_arena)
+        : m_pa(std::move(rhs.m_pa))
     {
-        rhs.m_p = nullptr;
-        rhs.m_arena = nullptr;
+        rhs.m_pa.clear();
     }
 
     void operator= (Elixir && rhs) noexcept
     {
         clear();
-        m_p = rhs.m_p;
-        m_arena = rhs.m_arena;
-        rhs.m_p = nullptr;
-        rhs.m_arena = nullptr;
+        m_pa = std::move(rhs.m_pa);
+        rhs.m_pa.clear();
+    }
+
+    void append (Elixir && rhs) noexcept
+    {
+        m_pa.insert(m_pa.end(), rhs.m_pa.begin(), rhs.m_pa.end());
+        rhs.m_pa.clear();
     }
 
     ~Elixir () { clear(); }
@@ -39,8 +44,7 @@ public:
     void clear () noexcept;
 
 private:
-    void* m_p;
-    Arena* m_arena;
+    Vector<std::pair<void*,Arena*> > m_pa;
 };
 
 }

--- a/Src/Base/AMReX_GpuElixir.cpp
+++ b/Src/Base/AMReX_GpuElixir.cpp
@@ -1,10 +1,10 @@
 
 #include <AMReX_GpuElixir.H>
+#include <AMReX_GpuDevice.H>
 #include <cstddef>
 #include <cstring>
 #include <cstdlib>
 #include <memory>
-#include <AMReX_GpuDevice.H>
 
 namespace amrex {
 namespace Gpu {
@@ -22,11 +22,11 @@ extern "C" {
     void CUDART_CB amrex_elixir_delete (cudaStream_t /*stream*/, cudaError_t /*error*/, void* p)
 #endif
     {
-        void** pp = (void**)p;
-        void* d = pp[0];
-        Arena* arena = (Arena*)(pp[1]);
-        std::free(p);
-        arena->free(d);
+        auto p_pa = reinterpret_cast<Vector<std::pair<void*,Arena*> >*>(p);
+        for (auto const& pa : *p_pa) {
+            pa.second->free(pa.first);
+        }
+        delete p_pa;
     }
 }
 
@@ -40,29 +40,28 @@ Elixir::clear () noexcept
 #if defined(AMREX_USE_GPU)
     if (Gpu::inLaunchRegion())
     {
-        if (m_p != nullptr) {
+        if (!m_pa.empty()) {
 #if defined(AMREX_USE_CUDA) || defined(AMREX_USE_HIP)
-            void** p = static_cast<void**>(std::malloc(2*sizeof(void*)));
-            p[0] = m_p;
-            p[1] = (void*)m_arena;
+            auto p = new Vector<std::pair<void*,Arena*> >(std::move(m_pa));
 #if defined(AMREX_USE_HIP)
             AMREX_HIP_SAFE_CALL ( hipStreamAddCallback(Gpu::gpuStream(),
-                                                       amrex_elixir_delete, p, 0));
+                                                       amrex_elixir_delete, (void*)p, 0));
 #elif defined(__CUDACC__) && (__CUDACC_VER_MAJOR__ >= 10)
             AMREX_CUDA_SAFE_CALL(cudaLaunchHostFunc(Gpu::gpuStream(),
-                                                    amrex_elixir_delete, p));
+                                                    amrex_elixir_delete, (void*)p));
 #elif defined(AMREX_USE_CUDA)
             AMREX_CUDA_SAFE_CALL(cudaStreamAddCallback(Gpu::gpuStream(),
-                                                       amrex_elixir_delete, p, 0));
+                                                       amrex_elixir_delete, (void*)p, 0));
 #endif
 #elif defined(AMREX_USE_DPCPP)
-            auto p = m_p;
-            auto a = m_arena;
+            auto lpa = std::move(m_pa);
             auto& q = *(Gpu::gpuStream().queue);
             try {
                 q.submit([&] (sycl::handler& h) {
                     h.codeplay_host_task([=] () {
-                        a->free(p);
+                        for (auto const& pa : lpa) {
+                            pa.second->free(pa.first);
+                        }
                     });
                 });
             } catch (sycl::exception const& ex) {
@@ -74,10 +73,11 @@ Elixir::clear () noexcept
     else
 #endif
     {
-        if (m_p != nullptr) m_arena->free(m_p);
+        for (auto const& pa : m_pa) {
+            pa.second->free(pa.first);
+        }
     }
-    m_p = nullptr;
-    m_arena = nullptr;
+    m_pa.clear();
 }
 
 }

--- a/Src/Base/AMReX_IArrayBox.H
+++ b/Src/Base/AMReX_IArrayBox.H
@@ -78,7 +78,7 @@ public:
     IArrayBox& operator= (int r) noexcept;
 
     //! For debugging purposes we hide BaseFab version and do some extra work.
-    void resize (const Box& b, int N = 1);
+    void resize (const Box& b, int N = 1, Arena* ar = nullptr);
 
     //! Initialize from ParmParse with "fab" prefix.
     static void Initialize ();

--- a/Src/Base/AMReX_IArrayBox.cpp
+++ b/Src/Base/AMReX_IArrayBox.cpp
@@ -77,9 +77,9 @@ IArrayBox::IArrayBox (const IArrayBox& rhs, MakeType make_type, int scomp, int n
 }
 
 void
-IArrayBox::resize (const Box& b, int N)
+IArrayBox::resize (const Box& b, int N, Arena* ar)
 {
-    BaseFab<int>::resize(b,N);
+    BaseFab<int>::resize(b,N,ar);
     // For debugging purposes
     if ( do_initval ) {
 #if defined(AMREX_USE_GPU)

--- a/Src/Base/AMReX_PArena.H
+++ b/Src/Base/AMReX_PArena.H
@@ -1,0 +1,39 @@
+#ifndef AMREX_PARENA_H_
+#define AMREX_PARENA_H_
+#include <AMReX_Config.H>
+
+#include <AMReX_Arena.H>
+
+#ifdef AMREX_USE_CUDA
+#include <cuda.h>
+#endif
+
+namespace amrex {
+
+/**
+* \brief This arena uses CUDA stream-ordered memory allocator if available.
+* If not, use The_Arena().
+*/
+
+class PArena
+    :
+    public Arena
+{
+public:
+    PArena (Long release_threshold);
+    PArena (const PArena& rhs) = delete;
+    PArena& operator= (const PArena& rhs) = delete;
+    virtual ~PArena () override;
+
+    virtual void* alloc (std::size_t nbytes) override final;
+    virtual void free (void* p) override final;
+
+#if (__CUDACC_VER_MAJOR__ > 11 || ((__CUDACC_VER_MAJOR__ == 11) && (__CUDACC_VER_MINOR__ >= 2)))
+private:
+    cudaMemPool_t m_pool;
+    cuuint64_t m_old_release_threshold;
+#endif
+};
+
+}
+#endif

--- a/Src/Base/AMReX_PArena.cpp
+++ b/Src/Base/AMReX_PArena.cpp
@@ -1,0 +1,93 @@
+#include <AMReX_PArena.H>
+#include <AMReX_GpuDevice.H>
+#include <AMReX_GpuElixir.H>
+#include <AMReX_MemPool.H>
+
+#ifdef AMREX_USE_OMP
+#include <omp.h>
+#endif
+
+namespace amrex {
+
+PArena::PArena (Long release_threshold)
+{
+#if (__CUDACC_VER_MAJOR__ > 11 || ((__CUDACC_VER_MAJOR__ == 11) && (__CUDACC_VER_MINOR__ >= 2)))
+    AMREX_CUDA_SAFE_CALL(cudaDeviceGetMemPool(&m_pool, Gpu::Device::deviceId()));
+    AMREX_CUDA_SAFE_CALL(cudaMemPoolGetAttribute(m_pool, cudaMemPoolAttrReleaseThreshold,
+                                                 &m_old_release_threshold));
+    cuuint64_t value = release_threshold;
+    AMREX_CUDA_SAFE_CALL(cudaMemPoolSetAttribute(m_pool, cudaMemPoolAttrReleaseThreshold, &value));
+#else
+    amrex::ignore_unused(release_threshold);
+#endif
+}
+
+PArena::~PArena ()
+{
+#if (__CUDACC_VER_MAJOR__ > 11 || ((__CUDACC_VER_MAJOR__ == 11) && (__CUDACC_VER_MINOR__ >= 2)))
+    AMREX_CUDA_SAFE_CALL(cudaMemPoolSetAttribute(m_pool, cudaMemPoolAttrReleaseThreshold,
+                                                 &m_old_release_threshold));
+#endif
+}
+
+void*
+PArena::alloc (std::size_t nbytes)
+{
+#if defined(AMREX_USE_GPU)
+
+#if (__CUDACC_VER_MAJOR__ > 11 || ((__CUDACC_VER_MAJOR__ == 11) && (__CUDACC_VER_MINOR__ >= 2)))
+    if (Gpu::Device::memoryPoolsSupported()) {
+        void* p;
+        AMREX_CUDA_SAFE_CALL(cudaMallocAsync(&p, nbytes, m_pool, Gpu::gpuStream()));
+        return p;
+    } else
+#endif
+    {
+        return The_Arena()->alloc(nbytes);
+    }
+
+#elif defined(AMREX_USE_OMP)
+
+    if (omp_in_parallel()) {
+        return amrex_mempool_alloc(nbytes);
+    } else {
+        return The_Arena()->alloc(nbytes);
+    }
+
+#else
+
+    return The_Arena()->alloc(nbytes);
+
+#endif
+}
+
+void
+PArena::free (void* p)
+{
+#if defined(AMREX_USE_GPU)
+
+#if (__CUDACC_VER_MAJOR__ > 11 || ((__CUDACC_VER_MAJOR__ == 11) && (__CUDACC_VER_MINOR__ >= 2)) )
+    if (Gpu::Device::memoryPoolsSupported()) {
+        AMREX_CUDA_SAFE_CALL(cudaFreeAsync(p, Gpu::gpuStream()));
+    } else
+#endif
+    {
+        Elixir eli(p, The_Arena());
+    }
+
+#elif defined(AMREX_USE_OMP)
+
+    if (omp_in_parallel()) {
+        amrex_mempool_free(p);
+    } else {
+        The_Arena()->free(p);
+    }
+
+#else
+
+    The_Arena()->free(p);
+
+#endif
+}
+
+}

--- a/Src/Base/CMakeLists.txt
+++ b/Src/Base/CMakeLists.txt
@@ -66,6 +66,8 @@ target_sources( amrex
    AMReX_DArena.cpp
    AMReX_EArena.H
    AMReX_EArena.cpp
+   AMReX_PArena.H
+   AMReX_PArena.cpp
    AMReX_BLProfiler.H
    AMReX_BLBackTrace.H
    AMReX_BLFort.H

--- a/Src/Base/Make.package
+++ b/Src/Base/Make.package
@@ -43,8 +43,8 @@ C$(AMREX_BASE)_headers += AMReX_ParallelReduce.H
 C$(AMREX_BASE)_headers += AMReX_ForkJoin.H AMReX_ParallelContext.H
 C$(AMREX_BASE)_sources += AMReX_ForkJoin.cpp AMReX_ParallelContext.cpp
 
-C$(AMREX_BASE)_sources += AMReX_VisMF.cpp AMReX_Arena.cpp AMReX_BArena.cpp AMReX_CArena.cpp AMReX_DArena.cpp AMReX_EArena.cpp
-C$(AMREX_BASE)_headers += AMReX_VisMF.H AMReX_Arena.H AMReX_BArena.H AMReX_CArena.H AMReX_DArena.H AMReX_EArena.H
+C$(AMREX_BASE)_sources += AMReX_VisMF.cpp AMReX_Arena.cpp AMReX_BArena.cpp AMReX_CArena.cpp AMReX_DArena.cpp AMReX_EArena.cpp AMReX_PArena.cpp
+C$(AMREX_BASE)_headers += AMReX_VisMF.H AMReX_Arena.H AMReX_BArena.H AMReX_CArena.H AMReX_DArena.H AMReX_EArena.H AMReX_PArena.H
 
 C$(AMREX_BASE)_sources += AMReX_AsyncOut.cpp
 C$(AMREX_BASE)_headers += AMReX_AsyncOut.H


### PR DESCRIPTION
## Summary

Add The_Async_Arena that uses CUDA steam-ordered memory allocator, if available.  If the
feature is not available, use The_Arena to allocate and free memory and the free is done
with a host callback function.  The purpose of this Arena is to be used by a temporary
FArrayBox inside an MFIter loop.

Add Elixir::append that appends an rvalue Elixir to an existing one to reduce the number of
host callback calls.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [x] are described in the proposed changes to the AMReX documentation, if appropriate
