### PR TITLE
Cover multiple cuts

### DIFF
--- a/Src/EB/AMReX_EB2_3D_C.H
+++ b/Src/EB/AMReX_EB2_3D_C.H
@@ -16,6 +16,8 @@ amrex_eb2_build_types (Box const& tbx, Box const& bxg2,
                        Array4<Type_t> const& ey,
                        Array4<Type_t> const& ez)
 {
+    bool handle_multiple_cuts = true;
+
     auto lo = amrex::max_lbound(tbx, bxg2);
     auto hi = amrex::min_ubound(tbx, bxg2);
     amrex::Loop(lo, hi,
@@ -157,6 +159,206 @@ amrex_eb2_build_types (Box const& tbx, Box const& bxg2,
             ez(i,j,k) = Type::irregular;
         }
     });
+
+    if (handle_multiple_cuts) {
+       b = amrex::surroundingNodes(bxg2,0);
+       lo = amrex::max_lbound(tbx, b);
+       hi = amrex::min_ubound(tbx, b);
+       amrex::Loop(lo, hi,
+       [=] (int i, int j, int k) noexcept
+       {
+           // If only opposite corners of face are inside fluid
+           if ( (   s(i,j,k  ) <  0.0 && s(i,j+1,k  ) >= 0.0
+                 && s(i,j,k+1) >= 0.0 && s(i,j+1,k+1) <  0.0 )
+              || (  s(i,j,k  ) >= 0.0 && s(i,j+1,k  ) <  0.0
+                 && s(i,j,k+1) <  0.0 && s(i,j+1,k+1) >= 0.0 )
+              )
+           {
+               // Cover the face
+               fx(i,j,k) = Type::covered;
+
+               // Cover the 4 edges of the face
+               ey(i,j,k) = Type::covered;
+               ey(i,j,k+1) = Type::covered;
+               ez(i,j,k) = Type::covered;
+               ez(i,j+1,k) = Type::covered;
+
+               // Cover additional edges for faces that are not at the boundary
+               if (i > fx.begin.x && i < fx.end.x-1) {
+                  // Cover the other ey that touch the corners if necessary
+                  if (ey(i,j-1,k  ) == Type::irregular && s(i  ,j,k  ) < 0.0)
+                     ey(i,j-1,k) = Type::covered;
+                  if (ey(i,j-1,k+1) == Type::irregular && s(i  ,j,k+1) < 0.0)
+                     ey(i,j-1,k+1) = Type::covered;
+                  if (ey(i,j+1,k  ) == Type::irregular && s(i,j+1,k  ) < 0.0)
+                     ey(i,j+1,k) = Type::covered;
+                  if (ey(i,j+1,k+1) == Type::irregular && s(i,j+1,k+1) < 0.0)
+                     ey(i,j+1,k+1) = Type::covered;
+
+                  // Cover the other ez that touch the corners if necessary
+                  if (ez(i  ,j,k-1) == Type::irregular && s(i  ,j,k  ) < 0.0)
+                     ez(i,j,k-1) = Type::covered;
+                  if (ez(i  ,j,k+1) == Type::irregular && s(i  ,j,k+1) < 0.0)
+                     ez(i,j,k+1) = Type::covered;
+                  if (ez(i,j+1,k-1) == Type::irregular && s(i,j+1,k  ) < 0.0)
+                     ez(i,j+1,k-1) = Type::covered;
+                  if (ez(i,j+1,k+1) == Type::irregular && s(i,j+1,k+1) < 0.0)
+                     ez(i,j+1,k+1) = Type::covered;
+
+                  // Cover the ex that touch the corners if necessary
+                  if (ex(i-1,j  ,k  ) == Type::irregular && s(i  ,j,k  ) < 0.0)
+                     ex(i-1,j,k) = Type::covered;
+                  if (ex(i  ,j  ,k  ) == Type::irregular && s(i  ,j,k  ) < 0.0)
+                     ex(i,j,k) = Type::covered;
+                  if (ex(i-1,j  ,k+1) == Type::irregular && s(i  ,j,k+1) < 0.0)
+                     ex(i-1,j,k+1) = Type::covered;
+                  if (ex(i  ,j  ,k+1) == Type::irregular && s(i  ,j,k+1) < 0.0)
+                     ex(i,j,k+1) = Type::covered;
+                  if (ex(i-1,j+1,k+1) == Type::irregular && s(i,j+1,k+1) < 0.0)
+                     ex(i-1,j+1,k+1) = Type::covered;
+                  if (ex(i  ,j+1,k+1) == Type::irregular && s(i,j+1,k+1) < 0.0)
+                     ex(i,j+1,k+1) = Type::covered;
+                  if (ex(i-1,j+1,k  ) == Type::irregular && s(i,j+1,k  ) < 0.0)
+                     ex(i-1,j+1,k) = Type::covered;
+                  if (ex(i  ,j+1,k  ) == Type::irregular && s(i,j+1,k  ) < 0.0)
+                     ex(i,j+1,k) = Type::covered;
+               }
+
+           }
+       });
+
+       b = amrex::surroundingNodes(bxg2,1);
+       lo = amrex::max_lbound(tbx, b);
+       hi = amrex::min_ubound(tbx, b);
+       amrex::Loop(lo, hi,
+       [=] (int i, int j, int k) noexcept
+       {
+           // If only opposite corners of face are inside fluid
+           if ( (   s(i,j,k  ) <  0.0 && s(i+1,j,k  ) >= 0.0
+                 && s(i,j,k+1) >= 0.0 && s(i+1,j,k+1) <  0.0 )
+              || (  s(i,j,k  ) >= 0.0 && s(i+1,j,k  ) <  0.0
+                 && s(i,j,k+1) <  0.0 && s(i+1,j,k+1) >= 0.0 )
+              )
+           {
+               // Cover the face
+               fy(i,j,k) = Type::covered;
+
+               // Cover the 4 edges of the face
+               ex(i,j,k) = Type::covered;
+               ex(i,j,k+1) = Type::covered;
+               ez(i,j,k) = Type::covered;
+               ez(i+1,j,k) = Type::covered;
+
+               // Cover additional edges for faces that are not at the boundary
+               if (j > fy.begin.y && j < fy.end.y-1) {
+                  //Cover the other ex that touch the corners if necessary
+                  if (ex(i-1,j,k  ) == Type::irregular && s(i  ,j,k  ) < 0.0)
+                     ex(i-1,j,k) = Type::covered;
+                  if (ex(i-1,j,k+1) == Type::irregular && s(i  ,j,k+1) < 0.0)
+                     ex(i-1,j,k+1) = Type::covered;
+                  if (ex(i+1,j,k  ) == Type::irregular && s(i+1,j,k  ) < 0.0)
+                     ex(i+1,j,k) = Type::covered;
+                  if (ex(i+1,j,k+1) == Type::irregular && s(i+1,j,k+1) < 0.0)
+                     ex(i+1,j,k+1) = Type::covered;
+
+                  // Cover the other ez that touch the corners if necessary
+                  if (ez(i  ,j,k-1) == Type::irregular && s(i  ,j,k  ) < 0.0)
+                     ez(i,j,k-1) = Type::covered;
+                  if (ez(i  ,j,k+1) == Type::irregular && s(i  ,j,k+1) < 0.0)
+                     ez(i,j,k+1) = Type::covered;
+                  if (ez(i+1,j,k-1) == Type::irregular && s(i+1,j,k  ) < 0.0)
+                     ez(i+1,j,k-1) = Type::covered;
+                  if (ez(i+1,j,k+1) == Type::irregular && s(i+1,j,k+1) < 0.0)
+                     ez(i+1,j,k+1) = Type::covered;
+
+                  // Cover the ey that touch the corners if necessary
+                  if (ey(i  ,j-1,k  ) == Type::irregular && s(i  ,j,k  ) < 0.0)
+                     ey(i,j-1,k) = Type::covered;
+                  if (ey(i  ,j  ,k  ) == Type::irregular && s(i  ,j,k  ) < 0.0)
+                     ey(i,j,k) = Type::covered;
+                  if (ey(i  ,j-1,k+1) == Type::irregular && s(i  ,j,k+1) < 0.0)
+                     ey(i,j-1,k+1) = Type::covered;
+                  if (ey(i  ,j  ,k+1) == Type::irregular && s(i  ,j,k+1) < 0.0)
+                     ey(i,j,k+1) = Type::covered;
+                  if (ey(i+1,j-1,k+1) == Type::irregular && s(i+1,j,k+1) < 0.0)
+                     ey(i+1,j-1,k+1) = Type::covered;
+                  if (ey(i+1,j  ,k+1) == Type::irregular && s(i+1,j,k+1) < 0.0)
+                     ey(i+1,j,k+1) = Type::covered;
+                  if (ey(i+1,j-1,k  ) == Type::irregular && s(i+1,j,k  ) < 0.0)
+                     ey(i+1,j-1,k) = Type::covered;
+                  if (ey(i+1,j  ,k  ) == Type::irregular && s(i+1,j,k  ) < 0.0)
+                     ey(i+1,j,k) = Type::covered;
+               }
+
+           }
+       });
+
+       b = amrex::surroundingNodes(bxg2,2);
+       lo = amrex::max_lbound(tbx, b);
+       hi = amrex::min_ubound(tbx, b);
+       amrex::Loop(lo, hi,
+       [=] (int i, int j, int k) noexcept
+       {
+           // If only opposite corners of face are inside fluid
+           if ( (   s(i,j,k  ) <  0.0 && s(i+1,j,k  ) >= 0.0
+                 && s(i,j+1,k) >= 0.0 && s(i+1,j+1,k) <  0.0 )
+              || (  s(i,j,k  ) >= 0.0 && s(i+1,j,k  ) <  0.0
+                 && s(i,j+1,k) <  0.0 && s(i+1,j+1,k) >= 0.0 )
+              )
+           {
+               // Cover the face
+               fz(i,j,k) = Type::covered;
+
+               // Cover the 4 edges of the face
+               ex(i,j,k) = Type::covered;
+               ex(i,j+1,k) = Type::covered;
+               ey(i,j,k) = Type::covered;
+               ey(i+1,j,k) = Type::covered;
+
+               // Cover additional edges for faces that are not at the boundary
+               if (k > fz.begin.z && k < fz.end.z-1) {
+                  //Cover the other ex that touch the corners if necessary
+                  if (ex(i-1,j,k  ) == Type::irregular && s(i  ,j,k  ) < 0.0)
+                     ex(i-1,j,k) = Type::covered;
+                  if (ex(i-1,j+1,k) == Type::irregular && s(i  ,j+1,k) < 0.0)
+                     ex(i-1,j+1,k) = Type::covered;
+                  if (ex(i+1,j,k  ) == Type::irregular && s(i+1,j,k  ) < 0.0)
+                     ex(i+1,j,k) = Type::covered;
+                  if (ex(i+1,j+1,k) == Type::irregular && s(i+1,j+1,k) < 0.0)
+                     ex(i+1,j+1,k) = Type::covered;
+
+                  // Cover the other ey that touch the corners if necessary
+                  if (ey(i  ,j-1,k) == Type::irregular && s(i  ,j,k  ) < 0.0)
+                     ey(i,j-1,k) = Type::covered;
+                  if (ey(i  ,j+1,k) == Type::irregular && s(i  ,j+1,k) < 0.0)
+                     ey(i,j+1,k) = Type::covered;
+                  if (ey(i+1,j-1,k) == Type::irregular && s(i+1,j,k  ) < 0.0)
+                     ey(i+1,j-1,k) = Type::covered;
+                  if (ey(i+1,j+1,k) == Type::irregular && s(i+1,j+1,k) < 0.0)
+                     ey(i+1,j+1,k) = Type::covered;
+
+                  // Cover the ez that touch the corners if necessary
+                  if (ez(i  ,j  ,k-1) == Type::irregular && s(i  ,j,k  ) < 0.0)
+                     ez(i,j,k-1) = Type::covered;
+                  if (ez(i  ,j  ,k  ) == Type::irregular && s(i  ,j,k  ) < 0.0)
+                     ez(i,j,k) = Type::covered;
+                  if (ez(i  ,j+1,k-1) == Type::irregular && s(i  ,j+1,k) < 0.0)
+                     ez(i,j+1,k-1) = Type::covered;
+                  if (ez(i  ,j+1,k  ) == Type::irregular && s(i  ,j+1,k) < 0.0)
+                     ez(i,j+1,k) = Type::covered;
+                  if (ez(i+1,j+1,k-1) == Type::irregular && s(i+1,j+1,k) < 0.0)
+                     ez(i+1,j+1,k-1) = Type::covered;
+                  if (ez(i+1,j+1,k  ) == Type::irregular && s(i+1,j+1,k) < 0.0)
+                     ez(i+1,j+1,k) = Type::covered;
+                  if (ez(i+1,j  ,k-1) == Type::irregular && s(i+1,j,k  ) < 0.0)
+                     ez(i+1,j,k-1) = Type::covered;
+                  if (ez(i+1,j  ,k  ) == Type::irregular && s(i+1,j,k  ) < 0.0)
+                     ez(i+1,j,k) = Type::covered;
+               }
+
+           }
+       });
+    }
 }
 
 namespace {

--- a/Src/EB/AMReX_EB2_3D_C.H
+++ b/Src/EB/AMReX_EB2_3D_C.H
@@ -5,6 +5,34 @@
 
 namespace amrex { namespace EB2 {
 
+namespace {
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    void cover_cut_edges_given_corner (
+                       int i, int j, int k,
+                       Array4<Type_t> const& ex,
+                       Array4<Type_t> const& ey,
+                       Array4<Type_t> const& ez)
+   {
+      //x edges
+      if (i > ex.begin.x && ex(i-1,j,k) == Type::irregular)
+         ex(i-1,j,k) = Type::covered;
+      if (ex(i,j,k) == Type::irregular)
+         ex(i,j,k) = Type::covered;
+
+      //y edges
+      if (j > ey.begin.y && ey(i,j-1,k) == Type::irregular)
+         ey(i,j-1,k) = Type::covered;
+      if (ey(i,j,k) == Type::irregular)
+         ey(i,j,k) = Type::covered;
+
+      //z edges
+      if (k > ez.begin.z && ez(i,j,k-1) == Type::irregular)
+         ez(i,j,k-1) = Type::covered;
+      if (ez(i,j,k) == Type::irregular)
+         ez(i,j,k) = Type::covered;
+   }
+}
+
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 void
 amrex_eb2_build_types (Box const& tbx, Box const& bxg2,
@@ -167,8 +195,8 @@ amrex_eb2_build_types (Box const& tbx, Box const& bxg2,
        amrex::Loop(lo, hi,
        [=] (int i, int j, int k) noexcept
        {
-           // If only opposite corners of face are inside fluid, it
-           // will result in mutilple cut edges, so cover them
+           // If only opposite corners of face are regular, it
+           // will result in a face with 4 cuts, so cover them
            if ( (   s(i,j,k  ) <  0.0 && s(i,j+1,k  ) >= 0.0
                  && s(i,j,k+1) >= 0.0 && s(i,j+1,k+1) <  0.0 )
               || (  s(i,j,k  ) >= 0.0 && s(i,j+1,k  ) <  0.0
@@ -178,62 +206,15 @@ amrex_eb2_build_types (Box const& tbx, Box const& bxg2,
                // Cover the face
                fx(i,j,k) = Type::covered;
 
-               // Cover the 4 edges of the face
-               ey(i,j,k) = Type::covered;
-               ey(i,j,k+1) = Type::covered;
-               ez(i,j,k) = Type::covered;
-               ez(i,j+1,k) = Type::covered;
-
-               // Cover the other ey that touch the corners if necessary
-               if (j > ey.begin.y) {
-                  if (s(i,j-1,k  ) >= 0.0 && s(i  ,j,k  ) < 0.0)
-                     ey(i,j-1,k) = Type::covered;
-                  if (s(i,j-1,k+1) >= 0.0 && s(i  ,j,k+1) < 0.0)
-                     ey(i,j-1,k+1) = Type::covered;
-               }
-               if (j < ey.end.y-1) {
-                  if (s(i,j+2,k  ) >= 0.0 && s(i,j+1,k  ) < 0.0)
-                     ey(i,j+1,k) = Type::covered;
-                  if (s(i,j+2,k+1) >= 0.0 && s(i,j+1,k+1) < 0.0)
-                     ey(i,j+1,k+1) = Type::covered;
-               }
-
-               // Cover the other ez that touch the corners if necessary
-               if (k > ez.begin.z) {
-                  if (s(i  ,j,k-1) >= 0.0 && s(i  ,j,k  ) < 0.0)
-                     ez(i,j,k-1) = Type::covered;
-                  if (s(i,j+1,k-1) >= 0.0 && s(i,j+1,k  ) < 0.0)
-                     ez(i,j+1,k-1) = Type::covered;
-               }
-               if (k < ez.end.z-1) {
-                  if (s(i  ,j,k+2) >= 0.0 && s(i  ,j,k+1) < 0.0)
-                     ez(i,j,k+1) = Type::covered;
-                  if (s(i,j+1,k+2) >= 0.0 && s(i,j+1,k+1) < 0.0)
-                     ez(i,j+1,k+1) = Type::covered;
-               }
-
-               // Cover the ex that touch the corners if necessary
-               if (i > ex.begin.x) {
-                  if (s(i-1,j  ,k  ) >= 0.0 && s(i  ,j,k  ) < 0.0)
-                     ex(i-1,j,k) = Type::covered;
-                  if (s(i-1,j+1,k  ) >= 0.0 && s(i,j+1,k  ) < 0.0)
-                     ex(i-1,j+1,k) = Type::covered;
-                  if (s(i-1,j  ,k+1) >= 0.0 && s(i  ,j,k+1) < 0.0)
-                     ex(i-1,j,k+1) = Type::covered;
-                  if (s(i-1,j+1,k+1) >= 0.0 && s(i,j+1,k+1) < 0.0)
-                     ex(i-1,j+1,k+1) = Type::covered;
-                }
-               if (i <= ex.end.x-1) {
-                  if (s(i+1,j  ,k  ) >= 0.0 && s(i  ,j,k  ) < 0.0)
-                     ex(i,j,k) = Type::covered;
-                  if (s(i+1,j  ,k+1) >= 0.0 && s(i  ,j,k+1) < 0.0)
-                     ex(i,j,k+1) = Type::covered;
-                  if (s(i+1,j+1,k+1) >= 0.0 && s(i,j+1,k+1) < 0.0)
-                     ex(i,j+1,k+1) = Type::covered;
-                  if (s(i+1,j+1,k  ) >= 0.0 && s(i,j+1,k  ) < 0.0)
-                     ex(i,j+1,k) = Type::covered;
-               }
-
+               // Cover the cut edges containing any regular corner
+               if (s(i,j  ,k  ) < 0.0) 
+                  cover_cut_edges_given_corner(i,j  ,k  ,ex,ey,ez);
+               if (s(i,j+1,k  ) < 0.0) 
+                  cover_cut_edges_given_corner(i,j+1,k  ,ex,ey,ez);
+               if (s(i,j  ,k+1) < 0.0) 
+                  cover_cut_edges_given_corner(i,j  ,k+1,ex,ey,ez);
+               if (s(i,j+1,k+1) < 0.0) 
+                  cover_cut_edges_given_corner(i,j+1,k+1,ex,ey,ez);
            }
        });
 
@@ -243,8 +224,8 @@ amrex_eb2_build_types (Box const& tbx, Box const& bxg2,
        amrex::Loop(lo, hi,
        [=] (int i, int j, int k) noexcept
        {
-           // If only opposite corners of face are inside fluid, it
-           // will result in mutilple cut edges, so cover them
+           // If only opposite corners of face are regular, it
+           // will result in a face with 4 cuts, so cover them
            if ( (   s(i,j,k  ) <  0.0 && s(i+1,j,k  ) >= 0.0
                  && s(i,j,k+1) >= 0.0 && s(i+1,j,k+1) <  0.0 )
               || (  s(i,j,k  ) >= 0.0 && s(i+1,j,k  ) <  0.0
@@ -254,62 +235,15 @@ amrex_eb2_build_types (Box const& tbx, Box const& bxg2,
                // Cover the face
                fy(i,j,k) = Type::covered;
 
-               // Cover the 4 edges of the face
-               ex(i,j,k) = Type::covered;
-               ex(i,j,k+1) = Type::covered;
-               ez(i,j,k) = Type::covered;
-               ez(i+1,j,k) = Type::covered;
-
-               //Cover the other ex that touch the corners if necessary
-               if (i > ex.begin.x) {
-                  if (s(i-1,j,k  ) >= 0.0 && s(i  ,j,k  ) < 0.0)
-                     ex(i-1,j,k) = Type::covered;
-                  if (s(i-1,j,k+1) >= 0.0 && s(i  ,j,k+1) < 0.0)
-                     ex(i-1,j,k+1) = Type::covered;
-               }
-               if (i < ex.end.x-1) {
-                  if (s(i+2,j,k  ) >= 0.0 && s(i+1,j,k  ) < 0.0)
-                     ex(i+1,j,k) = Type::covered;
-                  if (s(i+2,j,k+1) >= 0.0 && s(i+1,j,k+1) < 0.0)
-                     ex(i+1,j,k+1) = Type::covered;
-               }
-
-               // Cover the other ez that touch the corners if necessary
-               if (k > ez.begin.z) {
-                  if (s(i  ,j,k-1) >= 0.0 && s(i  ,j,k  ) < 0.0)
-                     ez(i,j,k-1) = Type::covered;
-                  if (s(i+1,j,k-1) >= 0.0 && s(i+1,j,k  ) < 0.0)
-                     ez(i+1,j,k-1) = Type::covered;
-               }
-               if (k < ez.end.z-1) {
-                  if (s(i  ,j,k+2) >= 0.0 && s(i  ,j,k+1) < 0.0)
-                     ez(i,j,k+1) = Type::covered;
-                  if (s(i+1,j,k+2) >= 0.0 && s(i+1,j,k+1) < 0.0)
-                     ez(i+1,j,k+1) = Type::covered;
-               }
-
-               // Cover the ey that touch the corners if necessary
-               if (j > ey.begin.y) {
-                  if (s(i  ,j-1,k  ) >= 0.0 && s(i  ,j,k  ) < 0.0)
-                     ey(i,j-1,k) = Type::covered;
-                  if (s(i+1,j-1,k  ) >= 0.0 && s(i+1,j,k  ) < 0.0)
-                     ey(i+1,j-1,k) = Type::covered;
-                  if (s(i+1,j-1,k+1) >= 0.0 && s(i+1,j,k+1) < 0.0)
-                     ey(i+1,j-1,k+1) = Type::covered;
-                  if (s(i  ,j-1,k+1) >= 0.0 && s(i  ,j,k+1) < 0.0)
-                     ey(i,j-1,k+1) = Type::covered;
-               }
-               if (j <= ey.end.y-1) {
-                  if (s(i  ,j+1,k  ) >= 0.0 && s(i  ,j,k  ) < 0.0)
-                     ey(i,j,k) = Type::covered;
-                  if (s(i  ,j+1,k+1) >= 0.0 && s(i  ,j,k+1) < 0.0)
-                     ey(i,j,k+1) = Type::covered;
-                  if (s(i+1,j+1,k+1) >= 0.0 && s(i+1,j,k+1) < 0.0)
-                     ey(i+1,j,k+1) = Type::covered;
-                  if (s(i+1,j+1,k  ) >= 0.0 && s(i+1,j,k  ) < 0.0)
-                     ey(i+1,j,k) = Type::covered;
-               }
-
+               // Cover the cut edges containing any regular corner
+               if (s(i  ,j,k  ) < 0.0) 
+                  cover_cut_edges_given_corner(i  ,j,k  ,ex,ey,ez);
+               if (s(i+1,j,k  ) < 0.0) 
+                  cover_cut_edges_given_corner(i+1,j,k  ,ex,ey,ez);
+               if (s(i  ,j,k+1) < 0.0) 
+                  cover_cut_edges_given_corner(i  ,j,k+1,ex,ey,ez);
+               if (s(i+1,j,k+1) < 0.0) 
+                  cover_cut_edges_given_corner(i+1,j,k+1,ex,ey,ez);
            }
        });
 
@@ -319,8 +253,8 @@ amrex_eb2_build_types (Box const& tbx, Box const& bxg2,
        amrex::Loop(lo, hi,
        [=] (int i, int j, int k) noexcept
        {
-           // If only opposite corners of face are inside fluid, it
-           // will result in mutilple cut edges, so cover them
+           // If only opposite corners of face are regular, it
+           // will result in a face with 4 cuts, so cover them
            if ( (   s(i,j,k  ) <  0.0 && s(i+1,j,k  ) >= 0.0
                  && s(i,j+1,k) >= 0.0 && s(i+1,j+1,k) <  0.0 )
               || (  s(i,j,k  ) >= 0.0 && s(i+1,j,k  ) <  0.0
@@ -329,62 +263,15 @@ amrex_eb2_build_types (Box const& tbx, Box const& bxg2,
                // Cover the face
                fz(i,j,k) = Type::covered;
 
-               // Cover the 4 edges of the face
-               ex(i,j,k) = Type::covered;
-               ex(i,j+1,k) = Type::covered;
-               ey(i,j,k) = Type::covered;
-               ey(i+1,j,k) = Type::covered;
-
-               //Cover the other ex that touch the corners if necessary
-               if (i > ex.begin.x) {
-                  if (s(i-1,j,k  ) >= 0.0 && s(i  ,j,k  ) < 0.0)
-                     ex(i-1,j,k) = Type::covered;
-                  if (s(i-1,j+1,k) >= 0.0 && s(i  ,j+1,k) < 0.0)
-                     ex(i-1,j+1,k) = Type::covered;
-               }
-               if (i < ex.end.x-1) {
-                  if (s(i+2,j,k  ) >= 0.0 && s(i+1,j,k  ) < 0.0)
-                     ex(i+1,j,k) = Type::covered;
-                  if (s(i+2,j+1,k) >= 0.0 && s(i+1,j+1,k) < 0.0)
-                     ex(i+1,j+1,k) = Type::covered;
-               }
-
-               // Cover the other ey that touch the corners if necessary
-               if (j > ey.begin.y) {
-                  if (s(i  ,j-1,k) >= 0.0 && s(i  ,j,k  ) < 0.0)
-                     ey(i,j-1,k) = Type::covered;
-                  if (s(i+1,j-1,k) >= 0.0 && s(i+1,j,k  ) < 0.0)
-                     ey(i+1,j-1,k) = Type::covered;
-               }
-               if (j < ey.end.y-1) {
-                  if (s(i  ,j+2,k) >= 0.0 && s(i  ,j+1,k) < 0.0)
-                     ey(i,j+1,k) = Type::covered;
-                  if (s(i+1,j+2,k) >= 0.0 && s(i+1,j+1,k) < 0.0)
-                     ey(i+1,j+1,k) = Type::covered;
-               }
-
-               // Cover the ez that touch the corners if necessary
-               if (k > ez.begin.z) {
-                  if (s(i  ,j  ,k-1) >= 0.0 && s(i  ,j,k  ) < 0.0)
-                     ez(i,j,k-1) = Type::covered;
-                  if (s(i  ,j+1,k-1) >= 0.0 && s(i  ,j+1,k) < 0.0)
-                     ez(i,j+1,k-1) = Type::covered;
-                  if (s(i+1,j+1,k-1) >= 0.0 && s(i+1,j+1,k) < 0.0)
-                     ez(i+1,j+1,k-1) = Type::covered;
-                  if (s(i+1,j  ,k-1) >= 0.0 && s(i+1,j,k  ) < 0.0)
-                     ez(i+1,j,k-1) = Type::covered;
-               }
-               if (k <= ez.end.z-1) {
-                  if (s(i  ,j  ,k+1) >= 0.0 && s(i  ,j,k  ) < 0.0)
-                     ez(i,j,k) = Type::covered;
-                  if (s(i  ,j+1,k+1) >= 0.0 && s(i  ,j+1,k) < 0.0)
-                     ez(i,j+1,k) = Type::covered;
-                  if (s(i+1,j+1,k+1) >= 0.0 && s(i+1,j+1,k) < 0.0)
-                     ez(i+1,j+1,k) = Type::covered;
-                  if (s(i+1,j  ,k+1) >= 0.0 && s(i+1,j,k  ) < 0.0)
-                     ez(i+1,j,k) = Type::covered;
-               }
-
+               // Cover the cut edges containing any regular corner
+               if (s(i  ,j  ,k) < 0.0) 
+                  cover_cut_edges_given_corner(i  ,j  ,k,ex,ey,ez);
+               if (s(i+1,j  ,k) < 0.0) 
+                  cover_cut_edges_given_corner(i+1,j  ,k,ex,ey,ez);
+               if (s(i  ,j+1,k) < 0.0) 
+                  cover_cut_edges_given_corner(i  ,j+1,k,ex,ey,ez);
+               if (s(i+1,j+1,k) < 0.0) 
+                  cover_cut_edges_given_corner(i+1,j+1,k,ex,ey,ez);
            }
        });
     }

--- a/Src/EB/AMReX_EB2_3D_C.H
+++ b/Src/EB/AMReX_EB2_3D_C.H
@@ -14,22 +14,28 @@ namespace {
                        Array4<Type_t> const& ez)
    {
       //x edges
-      if (i > ex.begin.x && ex(i-1,j,k) == Type::irregular)
-         ex(i-1,j,k) = Type::covered;
-      if (ex(i,j,k) == Type::irregular)
-         ex(i,j,k) = Type::covered;
+      if (j >= ex.begin.y && j < ex.end.y && k >= ex.begin.z && k < ex.end.z) {
+         if (i > ex.begin.x && i <= ex.end.x && ex(i-1,j,k) == Type::irregular)
+            ex(i-1,j,k) = Type::covered;
+         if (i >= ex.begin.x && i < ex.end.x && ex(i  ,j,k) == Type::irregular)
+            ex(i,j,k) = Type::covered;
+      }
 
       //y edges
-      if (j > ey.begin.y && ey(i,j-1,k) == Type::irregular)
-         ey(i,j-1,k) = Type::covered;
-      if (ey(i,j,k) == Type::irregular)
-         ey(i,j,k) = Type::covered;
+      if (i >= ey.begin.x && i < ey.end.x && k >= ey.begin.z && k < ey.end.z) {
+         if (j > ey.begin.y && j <= ey.end.y && ey(i,j-1,k) == Type::irregular)
+            ey(i,j-1,k) = Type::covered;
+         if (j >= ey.begin.y && j < ey.end.y && ey(i,j  ,k) == Type::irregular)
+            ey(i,j,k) = Type::covered;
+      }
 
       //z edges
-      if (k > ez.begin.z && ez(i,j,k-1) == Type::irregular)
-         ez(i,j,k-1) = Type::covered;
-      if (ez(i,j,k) == Type::irregular)
-         ez(i,j,k) = Type::covered;
+      if (i >= ez.begin.x && i < ez.end.x && j >= ez.begin.y && j < ez.end.y) {
+         if (k > ez.begin.z && k <= ez.end.z && ez(i,j,k-1) == Type::irregular)
+            ez(i,j,k-1) = Type::covered;
+         if (k >= ez.begin.z && k < ez.end.z && ez(i,j,k  ) == Type::irregular)
+            ez(i,j,k) = Type::covered;
+      }
    }
 }
 

--- a/Src/EB/AMReX_EB2_3D_C.H
+++ b/Src/EB/AMReX_EB2_3D_C.H
@@ -183,43 +183,52 @@ amrex_eb2_build_types (Box const& tbx, Box const& bxg2,
                ez(i,j,k) = Type::covered;
                ez(i,j+1,k) = Type::covered;
 
-               // Cover additional edges for faces that are not at the boundary
-               if (i > fx.begin.x && i < fx.end.x-1) {
-                  // Cover the other ey that touch the corners if necessary
+               // Cover the other ey that touch the corners if necessary
+               if (j > ey.begin.y) {
                   if (ey(i,j-1,k  ) == Type::irregular && s(i  ,j,k  ) < 0.0)
                      ey(i,j-1,k) = Type::covered;
                   if (ey(i,j-1,k+1) == Type::irregular && s(i  ,j,k+1) < 0.0)
                      ey(i,j-1,k+1) = Type::covered;
+               }
+               if (j < ey.end.y-1) {
                   if (ey(i,j+1,k  ) == Type::irregular && s(i,j+1,k  ) < 0.0)
                      ey(i,j+1,k) = Type::covered;
                   if (ey(i,j+1,k+1) == Type::irregular && s(i,j+1,k+1) < 0.0)
                      ey(i,j+1,k+1) = Type::covered;
+               }
 
-                  // Cover the other ez that touch the corners if necessary
+               // Cover the other ez that touch the corners if necessary
+               if (k > ez.begin.z) {
                   if (ez(i  ,j,k-1) == Type::irregular && s(i  ,j,k  ) < 0.0)
                      ez(i,j,k-1) = Type::covered;
-                  if (ez(i  ,j,k+1) == Type::irregular && s(i  ,j,k+1) < 0.0)
-                     ez(i,j,k+1) = Type::covered;
                   if (ez(i,j+1,k-1) == Type::irregular && s(i,j+1,k  ) < 0.0)
                      ez(i,j+1,k-1) = Type::covered;
+               }
+               if (k < ez.end.z-1) {
+                  if (ez(i  ,j,k+1) == Type::irregular && s(i  ,j,k+1) < 0.0)
+                     ez(i,j,k+1) = Type::covered;
                   if (ez(i,j+1,k+1) == Type::irregular && s(i,j+1,k+1) < 0.0)
                      ez(i,j+1,k+1) = Type::covered;
+               }
 
-                  // Cover the ex that touch the corners if necessary
+               // Cover the ex that touch the corners if necessary
+               if (i > ex.begin.x) {
                   if (ex(i-1,j  ,k  ) == Type::irregular && s(i  ,j,k  ) < 0.0)
                      ex(i-1,j,k) = Type::covered;
-                  if (ex(i  ,j  ,k  ) == Type::irregular && s(i  ,j,k  ) < 0.0)
-                     ex(i,j,k) = Type::covered;
-                  if (ex(i-1,j  ,k+1) == Type::irregular && s(i  ,j,k+1) < 0.0)
-                     ex(i-1,j,k+1) = Type::covered;
-                  if (ex(i  ,j  ,k+1) == Type::irregular && s(i  ,j,k+1) < 0.0)
-                     ex(i,j,k+1) = Type::covered;
-                  if (ex(i-1,j+1,k+1) == Type::irregular && s(i,j+1,k+1) < 0.0)
-                     ex(i-1,j+1,k+1) = Type::covered;
-                  if (ex(i  ,j+1,k+1) == Type::irregular && s(i,j+1,k+1) < 0.0)
-                     ex(i,j+1,k+1) = Type::covered;
                   if (ex(i-1,j+1,k  ) == Type::irregular && s(i,j+1,k  ) < 0.0)
                      ex(i-1,j+1,k) = Type::covered;
+                  if (ex(i-1,j  ,k+1) == Type::irregular && s(i  ,j,k+1) < 0.0)
+                     ex(i-1,j,k+1) = Type::covered;
+                  if (ex(i-1,j+1,k+1) == Type::irregular && s(i,j+1,k+1) < 0.0)
+                     ex(i-1,j+1,k+1) = Type::covered;
+                }
+               if (i <= ex.end.x-1) {
+                  if (ex(i  ,j  ,k  ) == Type::irregular && s(i  ,j,k  ) < 0.0)
+                     ex(i,j,k) = Type::covered;
+                  if (ex(i  ,j  ,k+1) == Type::irregular && s(i  ,j,k+1) < 0.0)
+                     ex(i,j,k+1) = Type::covered;
+                  if (ex(i  ,j+1,k+1) == Type::irregular && s(i,j+1,k+1) < 0.0)
+                     ex(i,j+1,k+1) = Type::covered;
                   if (ex(i  ,j+1,k  ) == Type::irregular && s(i,j+1,k  ) < 0.0)
                      ex(i,j+1,k) = Type::covered;
                }
@@ -249,43 +258,52 @@ amrex_eb2_build_types (Box const& tbx, Box const& bxg2,
                ez(i,j,k) = Type::covered;
                ez(i+1,j,k) = Type::covered;
 
-               // Cover additional edges for faces that are not at the boundary
-               if (j > fy.begin.y && j < fy.end.y-1) {
-                  //Cover the other ex that touch the corners if necessary
+               //Cover the other ex that touch the corners if necessary
+               if (i > ex.begin.x) {
                   if (ex(i-1,j,k  ) == Type::irregular && s(i  ,j,k  ) < 0.0)
                      ex(i-1,j,k) = Type::covered;
                   if (ex(i-1,j,k+1) == Type::irregular && s(i  ,j,k+1) < 0.0)
                      ex(i-1,j,k+1) = Type::covered;
+               }
+               if (i < ex.end.x-1) {
                   if (ex(i+1,j,k  ) == Type::irregular && s(i+1,j,k  ) < 0.0)
                      ex(i+1,j,k) = Type::covered;
                   if (ex(i+1,j,k+1) == Type::irregular && s(i+1,j,k+1) < 0.0)
                      ex(i+1,j,k+1) = Type::covered;
+               }
 
-                  // Cover the other ez that touch the corners if necessary
+               // Cover the other ez that touch the corners if necessary
+               if (k > ez.begin.z) {
                   if (ez(i  ,j,k-1) == Type::irregular && s(i  ,j,k  ) < 0.0)
                      ez(i,j,k-1) = Type::covered;
-                  if (ez(i  ,j,k+1) == Type::irregular && s(i  ,j,k+1) < 0.0)
-                     ez(i,j,k+1) = Type::covered;
                   if (ez(i+1,j,k-1) == Type::irregular && s(i+1,j,k  ) < 0.0)
                      ez(i+1,j,k-1) = Type::covered;
+               }
+               if (k < ez.end.z-1) {
+                  if (ez(i  ,j,k+1) == Type::irregular && s(i  ,j,k+1) < 0.0)
+                     ez(i,j,k+1) = Type::covered;
                   if (ez(i+1,j,k+1) == Type::irregular && s(i+1,j,k+1) < 0.0)
                      ez(i+1,j,k+1) = Type::covered;
+               }
 
-                  // Cover the ey that touch the corners if necessary
+               // Cover the ey that touch the corners if necessary
+               if (j > ey.begin.y) {
                   if (ey(i  ,j-1,k  ) == Type::irregular && s(i  ,j,k  ) < 0.0)
                      ey(i,j-1,k) = Type::covered;
-                  if (ey(i  ,j  ,k  ) == Type::irregular && s(i  ,j,k  ) < 0.0)
-                     ey(i,j,k) = Type::covered;
-                  if (ey(i  ,j-1,k+1) == Type::irregular && s(i  ,j,k+1) < 0.0)
-                     ey(i,j-1,k+1) = Type::covered;
-                  if (ey(i  ,j  ,k+1) == Type::irregular && s(i  ,j,k+1) < 0.0)
-                     ey(i,j,k+1) = Type::covered;
-                  if (ey(i+1,j-1,k+1) == Type::irregular && s(i+1,j,k+1) < 0.0)
-                     ey(i+1,j-1,k+1) = Type::covered;
-                  if (ey(i+1,j  ,k+1) == Type::irregular && s(i+1,j,k+1) < 0.0)
-                     ey(i+1,j,k+1) = Type::covered;
                   if (ey(i+1,j-1,k  ) == Type::irregular && s(i+1,j,k  ) < 0.0)
                      ey(i+1,j-1,k) = Type::covered;
+                  if (ey(i+1,j-1,k+1) == Type::irregular && s(i+1,j,k+1) < 0.0)
+                     ey(i+1,j-1,k+1) = Type::covered;
+                  if (ey(i  ,j-1,k+1) == Type::irregular && s(i  ,j,k+1) < 0.0)
+                     ey(i,j-1,k+1) = Type::covered;
+               }
+               if (j <= ey.end.y-1) {
+                  if (ey(i  ,j  ,k  ) == Type::irregular && s(i  ,j,k  ) < 0.0)
+                     ey(i,j,k) = Type::covered;
+                  if (ey(i  ,j  ,k+1) == Type::irregular && s(i  ,j,k+1) < 0.0)
+                     ey(i,j,k+1) = Type::covered;
+                  if (ey(i+1,j  ,k+1) == Type::irregular && s(i+1,j,k+1) < 0.0)
+                     ey(i+1,j,k+1) = Type::covered;
                   if (ey(i+1,j  ,k  ) == Type::irregular && s(i+1,j,k  ) < 0.0)
                      ey(i+1,j,k) = Type::covered;
                }
@@ -315,43 +333,52 @@ amrex_eb2_build_types (Box const& tbx, Box const& bxg2,
                ey(i,j,k) = Type::covered;
                ey(i+1,j,k) = Type::covered;
 
-               // Cover additional edges for faces that are not at the boundary
-               if (k > fz.begin.z && k < fz.end.z-1) {
-                  //Cover the other ex that touch the corners if necessary
+               //Cover the other ex that touch the corners if necessary
+               if (i > ex.begin.x) {
                   if (ex(i-1,j,k  ) == Type::irregular && s(i  ,j,k  ) < 0.0)
                      ex(i-1,j,k) = Type::covered;
                   if (ex(i-1,j+1,k) == Type::irregular && s(i  ,j+1,k) < 0.0)
                      ex(i-1,j+1,k) = Type::covered;
+               }
+               if (i < ex.end.x-1) {
                   if (ex(i+1,j,k  ) == Type::irregular && s(i+1,j,k  ) < 0.0)
                      ex(i+1,j,k) = Type::covered;
                   if (ex(i+1,j+1,k) == Type::irregular && s(i+1,j+1,k) < 0.0)
                      ex(i+1,j+1,k) = Type::covered;
+               }
 
-                  // Cover the other ey that touch the corners if necessary
+               // Cover the other ey that touch the corners if necessary
+               if (j > ey.begin.y) {
                   if (ey(i  ,j-1,k) == Type::irregular && s(i  ,j,k  ) < 0.0)
                      ey(i,j-1,k) = Type::covered;
-                  if (ey(i  ,j+1,k) == Type::irregular && s(i  ,j+1,k) < 0.0)
-                     ey(i,j+1,k) = Type::covered;
                   if (ey(i+1,j-1,k) == Type::irregular && s(i+1,j,k  ) < 0.0)
                      ey(i+1,j-1,k) = Type::covered;
+               }
+               if (j < ey.end.y-1) {
+                  if (ey(i  ,j+1,k) == Type::irregular && s(i  ,j+1,k) < 0.0)
+                     ey(i,j+1,k) = Type::covered;
                   if (ey(i+1,j+1,k) == Type::irregular && s(i+1,j+1,k) < 0.0)
                      ey(i+1,j+1,k) = Type::covered;
+               }
 
-                  // Cover the ez that touch the corners if necessary
+               // Cover the ez that touch the corners if necessary
+               if (k > ez.begin.z) {
                   if (ez(i  ,j  ,k-1) == Type::irregular && s(i  ,j,k  ) < 0.0)
                      ez(i,j,k-1) = Type::covered;
-                  if (ez(i  ,j  ,k  ) == Type::irregular && s(i  ,j,k  ) < 0.0)
-                     ez(i,j,k) = Type::covered;
                   if (ez(i  ,j+1,k-1) == Type::irregular && s(i  ,j+1,k) < 0.0)
                      ez(i,j+1,k-1) = Type::covered;
-                  if (ez(i  ,j+1,k  ) == Type::irregular && s(i  ,j+1,k) < 0.0)
-                     ez(i,j+1,k) = Type::covered;
                   if (ez(i+1,j+1,k-1) == Type::irregular && s(i+1,j+1,k) < 0.0)
                      ez(i+1,j+1,k-1) = Type::covered;
-                  if (ez(i+1,j+1,k  ) == Type::irregular && s(i+1,j+1,k) < 0.0)
-                     ez(i+1,j+1,k) = Type::covered;
                   if (ez(i+1,j  ,k-1) == Type::irregular && s(i+1,j,k  ) < 0.0)
                      ez(i+1,j,k-1) = Type::covered;
+               }
+               if (k <= ez.end.z-1) {
+                  if (ez(i  ,j  ,k  ) == Type::irregular && s(i  ,j,k  ) < 0.0)
+                     ez(i,j,k) = Type::covered;
+                  if (ez(i  ,j+1,k  ) == Type::irregular && s(i  ,j+1,k) < 0.0)
+                     ez(i,j+1,k) = Type::covered;
+                  if (ez(i+1,j+1,k  ) == Type::irregular && s(i+1,j+1,k) < 0.0)
+                     ez(i+1,j+1,k) = Type::covered;
                   if (ez(i+1,j  ,k  ) == Type::irregular && s(i+1,j,k  ) < 0.0)
                      ez(i+1,j,k) = Type::covered;
                }

--- a/Src/EB/AMReX_EB2_3D_C.H
+++ b/Src/EB/AMReX_EB2_3D_C.H
@@ -15,7 +15,8 @@ amrex_eb2_build_types (Box const& tbx, Box const& bxg2,
                        Array4<Type_t> const& fz,
                        Array4<Type_t> const& ex,
                        Array4<Type_t> const& ey,
-                       Array4<Type_t> const& ez)
+                       Array4<Type_t> const& ez,
+                       bool cover_multiple_cuts)
 {
     auto lo = amrex::max_lbound(tbx, bxg2);
     auto hi = amrex::min_ubound(tbx, bxg2);
@@ -158,12 +159,6 @@ amrex_eb2_build_types (Box const& tbx, Box const& bxg2,
             ez(i,j,k) = Type::irregular;
         }
     });
-
-    bool cover_multiple_cuts = false;
-    {
-        ParmParse pp("eb2");
-        pp.query("cover_multiple_cuts", cover_multiple_cuts);
-    }
 
     if (cover_multiple_cuts) {
        b = amrex::surroundingNodes(bxg2,0);

--- a/Src/EB/AMReX_EB2_3D_C.H
+++ b/Src/EB/AMReX_EB2_3D_C.H
@@ -15,6 +15,8 @@ namespace {
       //x edges
       if (j >= ex.begin.y && j < ex.end.y && k >= ex.begin.z && k < ex.end.z) {
          if (i > ex.begin.x && i <= ex.end.x && ex(i-1,j,k) == Type::irregular)
+            // In principle, there could be race conditions here.  But if the EB is in a configuration
+            // that that could happen, we are in trouble anyway.
             ex(i-1,j,k) = Type::covered;
          if (i >= ex.begin.x && i < ex.end.x && ex(i  ,j,k) == Type::irregular)
             ex(i,j,k) = Type::covered;

--- a/Src/EB/AMReX_EB2_3D_C.H
+++ b/Src/EB/AMReX_EB2_3D_C.H
@@ -15,8 +15,6 @@ namespace {
       //x edges
       if (j >= ex.begin.y && j < ex.end.y && k >= ex.begin.z && k < ex.end.z) {
          if (i > ex.begin.x && i <= ex.end.x && ex(i-1,j,k) == Type::irregular)
-            // In principle, there could be race conditions here.  But if the EB is in a configuration
-            // that that could happen, we are in trouble anyway.
             ex(i-1,j,k) = Type::covered;
          if (i >= ex.begin.x && i < ex.end.x && ex(i  ,j,k) == Type::irregular)
             ex(i,j,k) = Type::covered;

--- a/Src/EB/AMReX_EB2_3D_C.H
+++ b/Src/EB/AMReX_EB2_3D_C.H
@@ -209,7 +209,7 @@ amrex_eb2_build_types (Box const& tbx, Box const& bxg2,
                  && s(i,j,k+1) >= 0.0 && s(i,j+1,k+1) <  0.0 )
               || (  s(i,j,k  ) >= 0.0 && s(i,j+1,k  ) <  0.0
                  && s(i,j,k+1) <  0.0 && s(i,j+1,k+1) >= 0.0 )) {
-               printf("AMReX WARNING: covering multiple cuts\n");
+  //             printf("AMReX WARNING: covering multiple cuts\n");
 
                // Cover the face
                fx(i,j,k) = Type::covered;
@@ -239,7 +239,7 @@ amrex_eb2_build_types (Box const& tbx, Box const& bxg2,
                  && s(i,j,k+1) >= 0.0 && s(i+1,j,k+1) <  0.0 )
               || (  s(i,j,k  ) >= 0.0 && s(i+1,j,k  ) <  0.0
                  && s(i,j,k+1) <  0.0 && s(i+1,j,k+1) >= 0.0 )) {
-               printf("AMReX WARNING: covering multiple cuts\n");
+      //         printf("AMReX WARNING: covering multiple cuts\n");
 
                // Cover the face
                fy(i,j,k) = Type::covered;
@@ -269,7 +269,7 @@ amrex_eb2_build_types (Box const& tbx, Box const& bxg2,
                  && s(i,j+1,k) >= 0.0 && s(i+1,j+1,k) <  0.0 )
               || (  s(i,j,k  ) >= 0.0 && s(i+1,j,k  ) <  0.0
                  && s(i,j+1,k) <  0.0 && s(i+1,j+1,k) >= 0.0 )) {
-               printf("AMReX WARNING: covering multiple cuts\n");
+   //            printf("AMReX WARNING: covering multiple cuts\n");
                // Cover the face
                fz(i,j,k) = Type::covered;
 

--- a/Src/EB/AMReX_EB2_3D_C.H
+++ b/Src/EB/AMReX_EB2_3D_C.H
@@ -4,40 +4,6 @@
 
 namespace amrex { namespace EB2 {
 
-namespace {
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-    void cover_cut_edges_given_corner (
-                       int i, int j, int k,
-                       Array4<Type_t> const& ex,
-                       Array4<Type_t> const& ey,
-                       Array4<Type_t> const& ez)
-   {
-      //x edges
-      if (j >= ex.begin.y && j < ex.end.y && k >= ex.begin.z && k < ex.end.z) {
-         if (i > ex.begin.x && i <= ex.end.x && ex(i-1,j,k) == Type::irregular)
-            ex(i-1,j,k) = Type::covered;
-         if (i >= ex.begin.x && i < ex.end.x && ex(i  ,j,k) == Type::irregular)
-            ex(i,j,k) = Type::covered;
-      }
-
-      //y edges
-      if (i >= ey.begin.x && i < ey.end.x && k >= ey.begin.z && k < ey.end.z) {
-         if (j > ey.begin.y && j <= ey.end.y && ey(i,j-1,k) == Type::irregular)
-            ey(i,j-1,k) = Type::covered;
-         if (j >= ey.begin.y && j < ey.end.y && ey(i,j  ,k) == Type::irregular)
-            ey(i,j,k) = Type::covered;
-      }
-
-      //z edges
-      if (i >= ez.begin.x && i < ez.end.x && j >= ez.begin.y && j < ez.end.y) {
-         if (k > ez.begin.z && k <= ez.end.z && ez(i,j,k-1) == Type::irregular)
-            ez(i,j,k-1) = Type::covered;
-         if (k >= ez.begin.z && k < ez.end.z && ez(i,j,k  ) == Type::irregular)
-            ez(i,j,k) = Type::covered;
-      }
-   }
-}
-
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 void
 amrex_eb2_build_types (Box const& tbx, Box const& bxg2,
@@ -48,8 +14,7 @@ amrex_eb2_build_types (Box const& tbx, Box const& bxg2,
                        Array4<Type_t> const& fz,
                        Array4<Type_t> const& ex,
                        Array4<Type_t> const& ey,
-                       Array4<Type_t> const& ez,
-                       bool cover_multiple_cuts)
+                       Array4<Type_t> const& ez)
 {
     auto lo = amrex::max_lbound(tbx, bxg2);
     auto hi = amrex::min_ubound(tbx, bxg2);
@@ -192,97 +157,140 @@ amrex_eb2_build_types (Box const& tbx, Box const& bxg2,
             ez(i,j,k) = Type::irregular;
         }
     });
+}
 
-    if (cover_multiple_cuts) {
-       // x faces
-       b = amrex::surroundingNodes(bxg2,0);
-       lo = amrex::max_lbound(tbx, b);
-       hi = amrex::min_ubound(tbx, b);
-       amrex::Loop(lo, hi,
-       [=] (int i, int j, int k) noexcept
-       {
-           // If only opposite corners of face are regular, it
-           // will result in a face with 4 cuts, so cover them
-           if ( (   s(i,j,k  ) <  0.0 && s(i,j+1,k  ) >= 0.0
-                 && s(i,j,k+1) >= 0.0 && s(i,j+1,k+1) <  0.0 )
-              || (  s(i,j,k  ) >= 0.0 && s(i,j+1,k  ) <  0.0
-                 && s(i,j,k+1) <  0.0 && s(i,j+1,k+1) >= 0.0 )) {
-  //             printf("AMReX WARNING: covering multiple cuts\n");
+namespace {
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    void cover_cut_edges_given_corner (
+                       int i, int j, int k,
+                       Array4<Type_t> const& ex,
+                       Array4<Type_t> const& ey,
+                       Array4<Type_t> const& ez)
+   {
+      //x edges
+      if (j >= ex.begin.y && j < ex.end.y && k >= ex.begin.z && k < ex.end.z) {
+         if (i > ex.begin.x && i <= ex.end.x && ex(i-1,j,k) == Type::irregular)
+            ex(i-1,j,k) = Type::covered;
+         if (i >= ex.begin.x && i < ex.end.x && ex(i  ,j,k) == Type::irregular)
+            ex(i,j,k) = Type::covered;
+      }
 
-               // Cover the face
-               fx(i,j,k) = Type::covered;
+      //y edges
+      if (i >= ey.begin.x && i < ey.end.x && k >= ey.begin.z && k < ey.end.z) {
+         if (j > ey.begin.y && j <= ey.end.y && ey(i,j-1,k) == Type::irregular)
+            ey(i,j-1,k) = Type::covered;
+         if (j >= ey.begin.y && j < ey.end.y && ey(i,j  ,k) == Type::irregular)
+            ey(i,j,k) = Type::covered;
+      }
 
-               // Cover the cut edges containing any regular corner
-               if (s(i,j  ,k  ) < 0.0) 
-                  cover_cut_edges_given_corner(i,j  ,k  ,ex,ey,ez);
-               if (s(i,j+1,k  ) < 0.0) 
-                  cover_cut_edges_given_corner(i,j+1,k  ,ex,ey,ez);
-               if (s(i,j  ,k+1) < 0.0) 
-                  cover_cut_edges_given_corner(i,j  ,k+1,ex,ey,ez);
-               if (s(i,j+1,k+1) < 0.0) 
-                  cover_cut_edges_given_corner(i,j+1,k+1,ex,ey,ez);
-           }
-       });
+      //z edges
+      if (i >= ez.begin.x && i < ez.end.x && j >= ez.begin.y && j < ez.end.y) {
+         if (k > ez.begin.z && k <= ez.end.z && ez(i,j,k-1) == Type::irregular)
+            ez(i,j,k-1) = Type::covered;
+         if (k >= ez.begin.z && k < ez.end.z && ez(i,j,k  ) == Type::irregular)
+            ez(i,j,k) = Type::covered;
+      }
+   }
+}
 
-       // y faces
-       b = amrex::surroundingNodes(bxg2,1);
-       lo = amrex::max_lbound(tbx, b);
-       hi = amrex::min_ubound(tbx, b);
-       amrex::Loop(lo, hi,
-       [=] (int i, int j, int k) noexcept
-       {
-           // If only opposite corners of face are regular, it
-           // will result in a face with 4 cuts, so cover them
-           if ( (   s(i,j,k  ) <  0.0 && s(i+1,j,k  ) >= 0.0
-                 && s(i,j,k+1) >= 0.0 && s(i+1,j,k+1) <  0.0 )
-              || (  s(i,j,k  ) >= 0.0 && s(i+1,j,k  ) <  0.0
-                 && s(i,j,k+1) <  0.0 && s(i+1,j,k+1) >= 0.0 )) {
-      //         printf("AMReX WARNING: covering multiple cuts\n");
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void amrex_eb2_cover_multiple_cuts (Box const& tbx, Box const& bxg2,
+                       Array4<Real const> const& s,
+                       Array4<Type_t> const& fx,
+                       Array4<Type_t> const& fy,
+                       Array4<Type_t> const& fz,
+                       Array4<Type_t> const& ex,
+                       Array4<Type_t> const& ey,
+                       Array4<Type_t> const& ez)
+{
+    // x faces
+    Box b = amrex::surroundingNodes(bxg2,0);
+    auto lo = amrex::max_lbound(tbx, b);
+    auto hi = amrex::min_ubound(tbx, b);
+    amrex::Loop(lo, hi,
+    [=] (int i, int j, int k) noexcept
+    {
+        // If only opposite corners of face are regular, it
+        // will result in a face with 4 cuts, so cover them
+        if ( (   s(i,j,k  ) <  0.0 && s(i,j+1,k  ) >= 0.0
+              && s(i,j,k+1) >= 0.0 && s(i,j+1,k+1) <  0.0 )
+           || (  s(i,j,k  ) >= 0.0 && s(i,j+1,k  ) <  0.0
+              && s(i,j,k+1) <  0.0 && s(i,j+1,k+1) >= 0.0 )) {
+//             printf("AMReX WARNING: covering multiple cuts\n");
 
-               // Cover the face
-               fy(i,j,k) = Type::covered;
+            // Cover the face
+            fx(i,j,k) = Type::covered;
 
-               // Cover the cut edges containing any regular corner
-               if (s(i  ,j,k  ) < 0.0) 
-                  cover_cut_edges_given_corner(i  ,j,k  ,ex,ey,ez);
-               if (s(i+1,j,k  ) < 0.0) 
-                  cover_cut_edges_given_corner(i+1,j,k  ,ex,ey,ez);
-               if (s(i  ,j,k+1) < 0.0) 
-                  cover_cut_edges_given_corner(i  ,j,k+1,ex,ey,ez);
-               if (s(i+1,j,k+1) < 0.0) 
-                  cover_cut_edges_given_corner(i+1,j,k+1,ex,ey,ez);
-           }
-       });
+            // Cover the cut edges containing any regular corner
+            if (s(i,j  ,k  ) < 0.0) 
+               cover_cut_edges_given_corner(i,j  ,k  ,ex,ey,ez);
+            if (s(i,j+1,k  ) < 0.0) 
+               cover_cut_edges_given_corner(i,j+1,k  ,ex,ey,ez);
+            if (s(i,j  ,k+1) < 0.0) 
+               cover_cut_edges_given_corner(i,j  ,k+1,ex,ey,ez);
+            if (s(i,j+1,k+1) < 0.0) 
+               cover_cut_edges_given_corner(i,j+1,k+1,ex,ey,ez);
+        }
+    });
 
-       // z faces
-       b = amrex::surroundingNodes(bxg2,2);
-       lo = amrex::max_lbound(tbx, b);
-       hi = amrex::min_ubound(tbx, b);
-       amrex::Loop(lo, hi,
-       [=] (int i, int j, int k) noexcept
-       {
-           // If only opposite corners of face are regular, it
-           // will result in a face with 4 cuts, so cover them
-           if ( (   s(i,j,k  ) <  0.0 && s(i+1,j,k  ) >= 0.0
-                 && s(i,j+1,k) >= 0.0 && s(i+1,j+1,k) <  0.0 )
-              || (  s(i,j,k  ) >= 0.0 && s(i+1,j,k  ) <  0.0
-                 && s(i,j+1,k) <  0.0 && s(i+1,j+1,k) >= 0.0 )) {
-   //            printf("AMReX WARNING: covering multiple cuts\n");
-               // Cover the face
-               fz(i,j,k) = Type::covered;
+    // y faces
+    b = amrex::surroundingNodes(bxg2,1);
+    lo = amrex::max_lbound(tbx, b);
+    hi = amrex::min_ubound(tbx, b);
+    amrex::Loop(lo, hi,
+    [=] (int i, int j, int k) noexcept
+    {
+        // If only opposite corners of face are regular, it
+        // will result in a face with 4 cuts, so cover them
+        if ( (   s(i,j,k  ) <  0.0 && s(i+1,j,k  ) >= 0.0
+              && s(i,j,k+1) >= 0.0 && s(i+1,j,k+1) <  0.0 )
+           || (  s(i,j,k  ) >= 0.0 && s(i+1,j,k  ) <  0.0
+              && s(i,j,k+1) <  0.0 && s(i+1,j,k+1) >= 0.0 )) {
+   //         printf("AMReX WARNING: covering multiple cuts\n");
 
-               // Cover the cut edges containing any regular corner
-               if (s(i  ,j  ,k) < 0.0) 
-                  cover_cut_edges_given_corner(i  ,j  ,k,ex,ey,ez);
-               if (s(i+1,j  ,k) < 0.0) 
-                  cover_cut_edges_given_corner(i+1,j  ,k,ex,ey,ez);
-               if (s(i  ,j+1,k) < 0.0) 
-                  cover_cut_edges_given_corner(i  ,j+1,k,ex,ey,ez);
-               if (s(i+1,j+1,k) < 0.0) 
-                  cover_cut_edges_given_corner(i+1,j+1,k,ex,ey,ez);
-           }
-       });
-    }
+            // Cover the face
+            fy(i,j,k) = Type::covered;
+
+            // Cover the cut edges containing any regular corner
+            if (s(i  ,j,k  ) < 0.0) 
+               cover_cut_edges_given_corner(i  ,j,k  ,ex,ey,ez);
+            if (s(i+1,j,k  ) < 0.0) 
+               cover_cut_edges_given_corner(i+1,j,k  ,ex,ey,ez);
+            if (s(i  ,j,k+1) < 0.0) 
+               cover_cut_edges_given_corner(i  ,j,k+1,ex,ey,ez);
+            if (s(i+1,j,k+1) < 0.0) 
+               cover_cut_edges_given_corner(i+1,j,k+1,ex,ey,ez);
+        }
+    });
+
+    // z faces
+    b = amrex::surroundingNodes(bxg2,2);
+    lo = amrex::max_lbound(tbx, b);
+    hi = amrex::min_ubound(tbx, b);
+    amrex::Loop(lo, hi,
+    [=] (int i, int j, int k) noexcept
+    {
+        // If only opposite corners of face are regular, it
+        // will result in a face with 4 cuts, so cover them
+        if ( (   s(i,j,k  ) <  0.0 && s(i+1,j,k  ) >= 0.0
+              && s(i,j+1,k) >= 0.0 && s(i+1,j+1,k) <  0.0 )
+           || (  s(i,j,k  ) >= 0.0 && s(i+1,j,k  ) <  0.0
+              && s(i,j+1,k) <  0.0 && s(i+1,j+1,k) >= 0.0 )) {
+//            printf("AMReX WARNING: covering multiple cuts\n");
+            // Cover the face
+            fz(i,j,k) = Type::covered;
+
+            // Cover the cut edges containing any regular corner
+            if (s(i  ,j  ,k) < 0.0) 
+               cover_cut_edges_given_corner(i  ,j  ,k,ex,ey,ez);
+            if (s(i+1,j  ,k) < 0.0) 
+               cover_cut_edges_given_corner(i+1,j  ,k,ex,ey,ez);
+            if (s(i  ,j+1,k) < 0.0) 
+               cover_cut_edges_given_corner(i  ,j+1,k,ex,ey,ez);
+            if (s(i+1,j+1,k) < 0.0) 
+               cover_cut_edges_given_corner(i+1,j+1,k,ex,ey,ez);
+        }
+    });
 }
 
 namespace {

--- a/Src/EB/AMReX_EB2_3D_C.H
+++ b/Src/EB/AMReX_EB2_3D_C.H
@@ -172,15 +172,12 @@ amrex_eb2_build_types (Box const& tbx, Box const& bxg2,
        amrex::Loop(lo, hi,
        [=] (int i, int j, int k) noexcept
        {
-           int ncuts = 0;
-           if (fx(i,j,k) == Type::irregular) {
-              if (ey(i,j,k) == Type::irregular) ++ncuts;
-              if (ey(i,j,k+1) == Type::irregular) ++ncuts;
-              if (ez(i,j,k) == Type::irregular) ++ncuts;
-              if (ez(i,j+1,k) == Type::irregular) ++ncuts;
-           }
-            
-           if (ncuts > 2) {
+           // If only opposite corners of face are inside fluid, it
+           // will result in mutilple cut edges, so cover them
+           if ( (   s(i,j,k  ) <  0.0 && s(i,j+1,k  ) >= 0.0
+                 && s(i,j,k+1) >= 0.0 && s(i,j+1,k+1) <  0.0 )
+              || (  s(i,j,k  ) >= 0.0 && s(i,j+1,k  ) <  0.0
+                 && s(i,j,k+1) <  0.0 && s(i,j+1,k+1) >= 0.0 )) {
                amrex::Print() << "AMReX WARNING: covering multiple cuts\n";
 
                // Cover the face
@@ -194,51 +191,51 @@ amrex_eb2_build_types (Box const& tbx, Box const& bxg2,
 
                // Cover the other ey that touch the corners if necessary
                if (j > ey.begin.y) {
-                  if (ey(i,j-1,k  ) == Type::irregular && s(i  ,j,k  ) < 0.0)
+                  if (s(i,j-1,k  ) == Type::irregular && s(i  ,j,k  ) < 0.0)
                      ey(i,j-1,k) = Type::covered;
-                  if (ey(i,j-1,k+1) == Type::irregular && s(i  ,j,k+1) < 0.0)
+                  if (s(i,j-1,k+1) == Type::irregular && s(i  ,j,k+1) < 0.0)
                      ey(i,j-1,k+1) = Type::covered;
                }
                if (j < ey.end.y-1) {
-                  if (ey(i,j+1,k  ) == Type::irregular && s(i,j+1,k  ) < 0.0)
+                  if (s(i,j+1,k  ) == Type::irregular && s(i,j+1,k  ) < 0.0)
                      ey(i,j+1,k) = Type::covered;
-                  if (ey(i,j+1,k+1) == Type::irregular && s(i,j+1,k+1) < 0.0)
+                  if (s(i,j+1,k+1) == Type::irregular && s(i,j+1,k+1) < 0.0)
                      ey(i,j+1,k+1) = Type::covered;
                }
 
                // Cover the other ez that touch the corners if necessary
                if (k > ez.begin.z) {
-                  if (ez(i  ,j,k-1) == Type::irregular && s(i  ,j,k  ) < 0.0)
+                  if (s(i  ,j,k-1) == Type::irregular && s(i  ,j,k  ) < 0.0)
                      ez(i,j,k-1) = Type::covered;
-                  if (ez(i,j+1,k-1) == Type::irregular && s(i,j+1,k  ) < 0.0)
+                  if (s(i,j+1,k-1) == Type::irregular && s(i,j+1,k  ) < 0.0)
                      ez(i,j+1,k-1) = Type::covered;
                }
                if (k < ez.end.z-1) {
-                  if (ez(i  ,j,k+1) == Type::irregular && s(i  ,j,k+1) < 0.0)
+                  if (s(i  ,j,k+1) == Type::irregular && s(i  ,j,k+1) < 0.0)
                      ez(i,j,k+1) = Type::covered;
-                  if (ez(i,j+1,k+1) == Type::irregular && s(i,j+1,k+1) < 0.0)
+                  if (s(i,j+1,k+1) == Type::irregular && s(i,j+1,k+1) < 0.0)
                      ez(i,j+1,k+1) = Type::covered;
                }
 
                // Cover the ex that touch the corners if necessary
                if (i > ex.begin.x) {
-                  if (ex(i-1,j  ,k  ) == Type::irregular && s(i  ,j,k  ) < 0.0)
+                  if (s(i-1,j  ,k  ) == Type::irregular && s(i  ,j,k  ) < 0.0)
                      ex(i-1,j,k) = Type::covered;
-                  if (ex(i-1,j+1,k  ) == Type::irregular && s(i,j+1,k  ) < 0.0)
+                  if (s(i-1,j+1,k  ) == Type::irregular && s(i,j+1,k  ) < 0.0)
                      ex(i-1,j+1,k) = Type::covered;
-                  if (ex(i-1,j  ,k+1) == Type::irregular && s(i  ,j,k+1) < 0.0)
+                  if (s(i-1,j  ,k+1) == Type::irregular && s(i  ,j,k+1) < 0.0)
                      ex(i-1,j,k+1) = Type::covered;
-                  if (ex(i-1,j+1,k+1) == Type::irregular && s(i,j+1,k+1) < 0.0)
+                  if (s(i-1,j+1,k+1) == Type::irregular && s(i,j+1,k+1) < 0.0)
                      ex(i-1,j+1,k+1) = Type::covered;
                 }
                if (i <= ex.end.x-1) {
-                  if (ex(i  ,j  ,k  ) == Type::irregular && s(i  ,j,k  ) < 0.0)
+                  if (s(i  ,j  ,k  ) == Type::irregular && s(i  ,j,k  ) < 0.0)
                      ex(i,j,k) = Type::covered;
-                  if (ex(i  ,j  ,k+1) == Type::irregular && s(i  ,j,k+1) < 0.0)
+                  if (s(i  ,j  ,k+1) == Type::irregular && s(i  ,j,k+1) < 0.0)
                      ex(i,j,k+1) = Type::covered;
-                  if (ex(i  ,j+1,k+1) == Type::irregular && s(i,j+1,k+1) < 0.0)
+                  if (s(i  ,j+1,k+1) == Type::irregular && s(i,j+1,k+1) < 0.0)
                      ex(i,j+1,k+1) = Type::covered;
-                  if (ex(i  ,j+1,k  ) == Type::irregular && s(i,j+1,k  ) < 0.0)
+                  if (s(i  ,j+1,k  ) == Type::irregular && s(i,j+1,k  ) < 0.0)
                      ex(i,j+1,k) = Type::covered;
                }
 
@@ -251,15 +248,12 @@ amrex_eb2_build_types (Box const& tbx, Box const& bxg2,
        amrex::Loop(lo, hi,
        [=] (int i, int j, int k) noexcept
        {
-           int ncuts = 0;
-           if (fy(i,j,k) == Type::irregular) {
-              if (ex(i,j,k) == Type::irregular) ++ncuts;
-              if (ex(i,j,k+1) == Type::irregular) ++ncuts;
-              if (ez(i,j,k) == Type::irregular) ++ncuts;
-              if (ez(i+1,j,k) == Type::irregular) ++ncuts;
-           }
-
-           if (ncuts > 2) {
+           // If only opposite corners of face are inside fluid, it
+           // will result in mutilple cut edges, so cover them
+           if ( (   s(i,j,k  ) <  0.0 && s(i+1,j,k  ) >= 0.0
+                 && s(i,j,k+1) >= 0.0 && s(i+1,j,k+1) <  0.0 )
+              || (  s(i,j,k  ) >= 0.0 && s(i+1,j,k  ) <  0.0
+                 && s(i,j,k+1) <  0.0 && s(i+1,j,k+1) >= 0.0 )) {
                amrex::Print() << "AMReX WARNING: covering multiple cuts\n";
 
                // Cover the face
@@ -273,51 +267,51 @@ amrex_eb2_build_types (Box const& tbx, Box const& bxg2,
 
                //Cover the other ex that touch the corners if necessary
                if (i > ex.begin.x) {
-                  if (ex(i-1,j,k  ) == Type::irregular && s(i  ,j,k  ) < 0.0)
+                  if (s(i-1,j,k  ) == Type::irregular && s(i  ,j,k  ) < 0.0)
                      ex(i-1,j,k) = Type::covered;
-                  if (ex(i-1,j,k+1) == Type::irregular && s(i  ,j,k+1) < 0.0)
+                  if (s(i-1,j,k+1) == Type::irregular && s(i  ,j,k+1) < 0.0)
                      ex(i-1,j,k+1) = Type::covered;
                }
                if (i < ex.end.x-1) {
-                  if (ex(i+1,j,k  ) == Type::irregular && s(i+1,j,k  ) < 0.0)
+                  if (s(i+1,j,k  ) == Type::irregular && s(i+1,j,k  ) < 0.0)
                      ex(i+1,j,k) = Type::covered;
-                  if (ex(i+1,j,k+1) == Type::irregular && s(i+1,j,k+1) < 0.0)
+                  if (s(i+1,j,k+1) == Type::irregular && s(i+1,j,k+1) < 0.0)
                      ex(i+1,j,k+1) = Type::covered;
                }
 
                // Cover the other ez that touch the corners if necessary
                if (k > ez.begin.z) {
-                  if (ez(i  ,j,k-1) == Type::irregular && s(i  ,j,k  ) < 0.0)
+                  if (s(i  ,j,k-1) == Type::irregular && s(i  ,j,k  ) < 0.0)
                      ez(i,j,k-1) = Type::covered;
-                  if (ez(i+1,j,k-1) == Type::irregular && s(i+1,j,k  ) < 0.0)
+                  if (s(i+1,j,k-1) == Type::irregular && s(i+1,j,k  ) < 0.0)
                      ez(i+1,j,k-1) = Type::covered;
                }
                if (k < ez.end.z-1) {
-                  if (ez(i  ,j,k+1) == Type::irregular && s(i  ,j,k+1) < 0.0)
+                  if (s(i  ,j,k+1) == Type::irregular && s(i  ,j,k+1) < 0.0)
                      ez(i,j,k+1) = Type::covered;
-                  if (ez(i+1,j,k+1) == Type::irregular && s(i+1,j,k+1) < 0.0)
+                  if (s(i+1,j,k+1) == Type::irregular && s(i+1,j,k+1) < 0.0)
                      ez(i+1,j,k+1) = Type::covered;
                }
 
                // Cover the ey that touch the corners if necessary
                if (j > ey.begin.y) {
-                  if (ey(i  ,j-1,k  ) == Type::irregular && s(i  ,j,k  ) < 0.0)
+                  if (s(i  ,j-1,k  ) == Type::irregular && s(i  ,j,k  ) < 0.0)
                      ey(i,j-1,k) = Type::covered;
-                  if (ey(i+1,j-1,k  ) == Type::irregular && s(i+1,j,k  ) < 0.0)
+                  if (s(i+1,j-1,k  ) == Type::irregular && s(i+1,j,k  ) < 0.0)
                      ey(i+1,j-1,k) = Type::covered;
-                  if (ey(i+1,j-1,k+1) == Type::irregular && s(i+1,j,k+1) < 0.0)
+                  if (s(i+1,j-1,k+1) == Type::irregular && s(i+1,j,k+1) < 0.0)
                      ey(i+1,j-1,k+1) = Type::covered;
-                  if (ey(i  ,j-1,k+1) == Type::irregular && s(i  ,j,k+1) < 0.0)
+                  if (s(i  ,j-1,k+1) == Type::irregular && s(i  ,j,k+1) < 0.0)
                      ey(i,j-1,k+1) = Type::covered;
                }
                if (j <= ey.end.y-1) {
-                  if (ey(i  ,j  ,k  ) == Type::irregular && s(i  ,j,k  ) < 0.0)
+                  if (s(i  ,j  ,k  ) == Type::irregular && s(i  ,j,k  ) < 0.0)
                      ey(i,j,k) = Type::covered;
-                  if (ey(i  ,j  ,k+1) == Type::irregular && s(i  ,j,k+1) < 0.0)
+                  if (s(i  ,j  ,k+1) == Type::irregular && s(i  ,j,k+1) < 0.0)
                      ey(i,j,k+1) = Type::covered;
-                  if (ey(i+1,j  ,k+1) == Type::irregular && s(i+1,j,k+1) < 0.0)
+                  if (s(i+1,j  ,k+1) == Type::irregular && s(i+1,j,k+1) < 0.0)
                      ey(i+1,j,k+1) = Type::covered;
-                  if (ey(i+1,j  ,k  ) == Type::irregular && s(i+1,j,k  ) < 0.0)
+                  if (s(i+1,j  ,k  ) == Type::irregular && s(i+1,j,k  ) < 0.0)
                      ey(i+1,j,k) = Type::covered;
                }
 
@@ -330,16 +324,12 @@ amrex_eb2_build_types (Box const& tbx, Box const& bxg2,
        amrex::Loop(lo, hi,
        [=] (int i, int j, int k) noexcept
        {
-           int ncuts = 0;
-           if (fz(i,j,k) == Type::irregular) {
-              if (ex(i,j,k) == Type::irregular) ++ncuts;
-              if (ex(i,j+1,k) == Type::irregular) ++ncuts;
-              if (ey(i,j,k) == Type::irregular) ++ncuts;
-              if (ey(i+1,j,k) == Type::irregular) ++ncuts;
-           }
-
-           if (ncuts > 2)
-           {
+           // If only opposite corners of face are inside fluid, it
+           // will result in mutilple cut edges, so cover them
+           if ( (   s(i,j,k  ) <  0.0 && s(i+1,j,k  ) >= 0.0
+                 && s(i,j+1,k) >= 0.0 && s(i+1,j+1,k) <  0.0 )
+              || (  s(i,j,k  ) >= 0.0 && s(i+1,j,k  ) <  0.0
+                 && s(i,j+1,k) <  0.0 && s(i+1,j+1,k) >= 0.0 )) {
                amrex::Print() << "AMReX WARNING: covering multiple cuts\n";
                // Cover the face
                fz(i,j,k) = Type::covered;
@@ -352,51 +342,51 @@ amrex_eb2_build_types (Box const& tbx, Box const& bxg2,
 
                //Cover the other ex that touch the corners if necessary
                if (i > ex.begin.x) {
-                  if (ex(i-1,j,k  ) == Type::irregular && s(i  ,j,k  ) < 0.0)
+                  if (s(i-1,j,k  ) == Type::irregular && s(i  ,j,k  ) < 0.0)
                      ex(i-1,j,k) = Type::covered;
-                  if (ex(i-1,j+1,k) == Type::irregular && s(i  ,j+1,k) < 0.0)
+                  if (s(i-1,j+1,k) == Type::irregular && s(i  ,j+1,k) < 0.0)
                      ex(i-1,j+1,k) = Type::covered;
                }
                if (i < ex.end.x-1) {
-                  if (ex(i+1,j,k  ) == Type::irregular && s(i+1,j,k  ) < 0.0)
+                  if (s(i+1,j,k  ) == Type::irregular && s(i+1,j,k  ) < 0.0)
                      ex(i+1,j,k) = Type::covered;
-                  if (ex(i+1,j+1,k) == Type::irregular && s(i+1,j+1,k) < 0.0)
+                  if (s(i+1,j+1,k) == Type::irregular && s(i+1,j+1,k) < 0.0)
                      ex(i+1,j+1,k) = Type::covered;
                }
 
                // Cover the other ey that touch the corners if necessary
                if (j > ey.begin.y) {
-                  if (ey(i  ,j-1,k) == Type::irregular && s(i  ,j,k  ) < 0.0)
+                  if (s(i  ,j-1,k) == Type::irregular && s(i  ,j,k  ) < 0.0)
                      ey(i,j-1,k) = Type::covered;
-                  if (ey(i+1,j-1,k) == Type::irregular && s(i+1,j,k  ) < 0.0)
+                  if (s(i+1,j-1,k) == Type::irregular && s(i+1,j,k  ) < 0.0)
                      ey(i+1,j-1,k) = Type::covered;
                }
                if (j < ey.end.y-1) {
-                  if (ey(i  ,j+1,k) == Type::irregular && s(i  ,j+1,k) < 0.0)
+                  if (s(i  ,j+1,k) == Type::irregular && s(i  ,j+1,k) < 0.0)
                      ey(i,j+1,k) = Type::covered;
-                  if (ey(i+1,j+1,k) == Type::irregular && s(i+1,j+1,k) < 0.0)
+                  if (s(i+1,j+1,k) == Type::irregular && s(i+1,j+1,k) < 0.0)
                      ey(i+1,j+1,k) = Type::covered;
                }
 
                // Cover the ez that touch the corners if necessary
                if (k > ez.begin.z) {
-                  if (ez(i  ,j  ,k-1) == Type::irregular && s(i  ,j,k  ) < 0.0)
+                  if (s(i  ,j  ,k-1) == Type::irregular && s(i  ,j,k  ) < 0.0)
                      ez(i,j,k-1) = Type::covered;
-                  if (ez(i  ,j+1,k-1) == Type::irregular && s(i  ,j+1,k) < 0.0)
+                  if (s(i  ,j+1,k-1) == Type::irregular && s(i  ,j+1,k) < 0.0)
                      ez(i,j+1,k-1) = Type::covered;
-                  if (ez(i+1,j+1,k-1) == Type::irregular && s(i+1,j+1,k) < 0.0)
+                  if (s(i+1,j+1,k-1) == Type::irregular && s(i+1,j+1,k) < 0.0)
                      ez(i+1,j+1,k-1) = Type::covered;
-                  if (ez(i+1,j  ,k-1) == Type::irregular && s(i+1,j,k  ) < 0.0)
+                  if (s(i+1,j  ,k-1) == Type::irregular && s(i+1,j,k  ) < 0.0)
                      ez(i+1,j,k-1) = Type::covered;
                }
                if (k <= ez.end.z-1) {
-                  if (ez(i  ,j  ,k  ) == Type::irregular && s(i  ,j,k  ) < 0.0)
+                  if (s(i  ,j  ,k  ) == Type::irregular && s(i  ,j,k  ) < 0.0)
                      ez(i,j,k) = Type::covered;
-                  if (ez(i  ,j+1,k  ) == Type::irregular && s(i  ,j+1,k) < 0.0)
+                  if (s(i  ,j+1,k  ) == Type::irregular && s(i  ,j+1,k) < 0.0)
                      ez(i,j+1,k) = Type::covered;
-                  if (ez(i+1,j+1,k  ) == Type::irregular && s(i+1,j+1,k) < 0.0)
+                  if (s(i+1,j+1,k  ) == Type::irregular && s(i+1,j+1,k) < 0.0)
                      ez(i+1,j+1,k) = Type::covered;
-                  if (ez(i+1,j  ,k  ) == Type::irregular && s(i+1,j,k  ) < 0.0)
+                  if (s(i+1,j  ,k  ) == Type::irregular && s(i+1,j,k  ) < 0.0)
                      ez(i+1,j,k) = Type::covered;
                }
 

--- a/Src/EB/AMReX_EB2_3D_C.H
+++ b/Src/EB/AMReX_EB2_3D_C.H
@@ -1,6 +1,7 @@
 #ifndef AMREX_EB2_3D_C_H_
 #define AMREX_EB2_3D_C_H_
 #include <AMReX_Config.H>
+#include <AMReX_ParmParse.H>
 
 namespace amrex { namespace EB2 {
 
@@ -16,8 +17,6 @@ amrex_eb2_build_types (Box const& tbx, Box const& bxg2,
                        Array4<Type_t> const& ey,
                        Array4<Type_t> const& ez)
 {
-    bool handle_multiple_cuts = true;
-
     auto lo = amrex::max_lbound(tbx, bxg2);
     auto hi = amrex::min_ubound(tbx, bxg2);
     amrex::Loop(lo, hi,
@@ -160,20 +159,30 @@ amrex_eb2_build_types (Box const& tbx, Box const& bxg2,
         }
     });
 
-    if (handle_multiple_cuts) {
+    bool cover_multiple_cuts = false;
+    {
+        ParmParse pp("eb2");
+        pp.query("cover_multiple_cuts", cover_multiple_cuts);
+    }
+
+    if (cover_multiple_cuts) {
        b = amrex::surroundingNodes(bxg2,0);
        lo = amrex::max_lbound(tbx, b);
        hi = amrex::min_ubound(tbx, b);
        amrex::Loop(lo, hi,
        [=] (int i, int j, int k) noexcept
        {
-           // If only opposite corners of face are inside fluid
-           if ( (   s(i,j,k  ) <  0.0 && s(i,j+1,k  ) >= 0.0
-                 && s(i,j,k+1) >= 0.0 && s(i,j+1,k+1) <  0.0 )
-              || (  s(i,j,k  ) >= 0.0 && s(i,j+1,k  ) <  0.0
-                 && s(i,j,k+1) <  0.0 && s(i,j+1,k+1) >= 0.0 )
-              )
-           {
+           int ncuts = 0;
+           if (fx(i,j,k) == Type::irregular) {
+              if (ey(i,j,k) == Type::irregular) ++ncuts;
+              if (ey(i,j,k+1) == Type::irregular) ++ncuts;
+              if (ez(i,j,k) == Type::irregular) ++ncuts;
+              if (ez(i,j+1,k) == Type::irregular) ++ncuts;
+           }
+            
+           if (ncuts > 2) {
+               amrex::Print() << "AMReX WARNING: covering multiple cuts\n";
+
                // Cover the face
                fx(i,j,k) = Type::covered;
 
@@ -242,13 +251,17 @@ amrex_eb2_build_types (Box const& tbx, Box const& bxg2,
        amrex::Loop(lo, hi,
        [=] (int i, int j, int k) noexcept
        {
-           // If only opposite corners of face are inside fluid
-           if ( (   s(i,j,k  ) <  0.0 && s(i+1,j,k  ) >= 0.0
-                 && s(i,j,k+1) >= 0.0 && s(i+1,j,k+1) <  0.0 )
-              || (  s(i,j,k  ) >= 0.0 && s(i+1,j,k  ) <  0.0
-                 && s(i,j,k+1) <  0.0 && s(i+1,j,k+1) >= 0.0 )
-              )
-           {
+           int ncuts = 0;
+           if (fy(i,j,k) == Type::irregular) {
+              if (ex(i,j,k) == Type::irregular) ++ncuts;
+              if (ex(i,j,k+1) == Type::irregular) ++ncuts;
+              if (ez(i,j,k) == Type::irregular) ++ncuts;
+              if (ez(i+1,j,k) == Type::irregular) ++ncuts;
+           }
+
+           if (ncuts > 2) {
+               amrex::Print() << "AMReX WARNING: covering multiple cuts\n";
+
                // Cover the face
                fy(i,j,k) = Type::covered;
 
@@ -317,13 +330,17 @@ amrex_eb2_build_types (Box const& tbx, Box const& bxg2,
        amrex::Loop(lo, hi,
        [=] (int i, int j, int k) noexcept
        {
-           // If only opposite corners of face are inside fluid
-           if ( (   s(i,j,k  ) <  0.0 && s(i+1,j,k  ) >= 0.0
-                 && s(i,j+1,k) >= 0.0 && s(i+1,j+1,k) <  0.0 )
-              || (  s(i,j,k  ) >= 0.0 && s(i+1,j,k  ) <  0.0
-                 && s(i,j+1,k) <  0.0 && s(i+1,j+1,k) >= 0.0 )
-              )
+           int ncuts = 0;
+           if (fz(i,j,k) == Type::irregular) {
+              if (ex(i,j,k) == Type::irregular) ++ncuts;
+              if (ex(i,j+1,k) == Type::irregular) ++ncuts;
+              if (ey(i,j,k) == Type::irregular) ++ncuts;
+              if (ey(i+1,j,k) == Type::irregular) ++ncuts;
+           }
+
+           if (ncuts > 2)
            {
+               amrex::Print() << "AMReX WARNING: covering multiple cuts\n";
                // Cover the face
                fz(i,j,k) = Type::covered;
 

--- a/Src/EB/AMReX_EB2_3D_C.H
+++ b/Src/EB/AMReX_EB2_3D_C.H
@@ -1,7 +1,6 @@
 #ifndef AMREX_EB2_3D_C_H_
 #define AMREX_EB2_3D_C_H_
 #include <AMReX_Config.H>
-#include <AMReX_ParmParse.H>
 
 namespace amrex { namespace EB2 {
 
@@ -195,6 +194,7 @@ amrex_eb2_build_types (Box const& tbx, Box const& bxg2,
     });
 
     if (cover_multiple_cuts) {
+       // x faces
        b = amrex::surroundingNodes(bxg2,0);
        lo = amrex::max_lbound(tbx, b);
        hi = amrex::min_ubound(tbx, b);
@@ -224,6 +224,7 @@ amrex_eb2_build_types (Box const& tbx, Box const& bxg2,
            }
        });
 
+       // y faces
        b = amrex::surroundingNodes(bxg2,1);
        lo = amrex::max_lbound(tbx, b);
        hi = amrex::min_ubound(tbx, b);
@@ -253,6 +254,7 @@ amrex_eb2_build_types (Box const& tbx, Box const& bxg2,
            }
        });
 
+       // z faces
        b = amrex::surroundingNodes(bxg2,2);
        lo = amrex::max_lbound(tbx, b);
        hi = amrex::min_ubound(tbx, b);

--- a/Src/EB/AMReX_EB2_3D_C.H
+++ b/Src/EB/AMReX_EB2_3D_C.H
@@ -178,7 +178,7 @@ amrex_eb2_build_types (Box const& tbx, Box const& bxg2,
                  && s(i,j,k+1) >= 0.0 && s(i,j+1,k+1) <  0.0 )
               || (  s(i,j,k  ) >= 0.0 && s(i,j+1,k  ) <  0.0
                  && s(i,j,k+1) <  0.0 && s(i,j+1,k+1) >= 0.0 )) {
-               amrex::Print() << "AMReX WARNING: covering multiple cuts\n";
+               printf("AMReX WARNING: covering multiple cuts\n");
 
                // Cover the face
                fx(i,j,k) = Type::covered;
@@ -254,7 +254,7 @@ amrex_eb2_build_types (Box const& tbx, Box const& bxg2,
                  && s(i,j,k+1) >= 0.0 && s(i+1,j,k+1) <  0.0 )
               || (  s(i,j,k  ) >= 0.0 && s(i+1,j,k  ) <  0.0
                  && s(i,j,k+1) <  0.0 && s(i+1,j,k+1) >= 0.0 )) {
-               amrex::Print() << "AMReX WARNING: covering multiple cuts\n";
+               printf("AMReX WARNING: covering multiple cuts\n");
 
                // Cover the face
                fy(i,j,k) = Type::covered;
@@ -330,7 +330,7 @@ amrex_eb2_build_types (Box const& tbx, Box const& bxg2,
                  && s(i,j+1,k) >= 0.0 && s(i+1,j+1,k) <  0.0 )
               || (  s(i,j,k  ) >= 0.0 && s(i+1,j,k  ) <  0.0
                  && s(i,j+1,k) <  0.0 && s(i+1,j+1,k) >= 0.0 )) {
-               amrex::Print() << "AMReX WARNING: covering multiple cuts\n";
+               printf("AMReX WARNING: covering multiple cuts\n");
                // Cover the face
                fz(i,j,k) = Type::covered;
 

--- a/Src/EB/AMReX_EB2_3D_C.H
+++ b/Src/EB/AMReX_EB2_3D_C.H
@@ -186,51 +186,51 @@ amrex_eb2_build_types (Box const& tbx, Box const& bxg2,
 
                // Cover the other ey that touch the corners if necessary
                if (j > ey.begin.y) {
-                  if (s(i,j-1,k  ) == Type::irregular && s(i  ,j,k  ) < 0.0)
+                  if (s(i,j-1,k  ) >= 0.0 && s(i  ,j,k  ) < 0.0)
                      ey(i,j-1,k) = Type::covered;
-                  if (s(i,j-1,k+1) == Type::irregular && s(i  ,j,k+1) < 0.0)
+                  if (s(i,j-1,k+1) >= 0.0 && s(i  ,j,k+1) < 0.0)
                      ey(i,j-1,k+1) = Type::covered;
                }
                if (j < ey.end.y-1) {
-                  if (s(i,j+1,k  ) == Type::irregular && s(i,j+1,k  ) < 0.0)
+                  if (s(i,j+2,k  ) >= 0.0 && s(i,j+1,k  ) < 0.0)
                      ey(i,j+1,k) = Type::covered;
-                  if (s(i,j+1,k+1) == Type::irregular && s(i,j+1,k+1) < 0.0)
+                  if (s(i,j+2,k+1) >= 0.0 && s(i,j+1,k+1) < 0.0)
                      ey(i,j+1,k+1) = Type::covered;
                }
 
                // Cover the other ez that touch the corners if necessary
                if (k > ez.begin.z) {
-                  if (s(i  ,j,k-1) == Type::irregular && s(i  ,j,k  ) < 0.0)
+                  if (s(i  ,j,k-1) >= 0.0 && s(i  ,j,k  ) < 0.0)
                      ez(i,j,k-1) = Type::covered;
-                  if (s(i,j+1,k-1) == Type::irregular && s(i,j+1,k  ) < 0.0)
+                  if (s(i,j+1,k-1) >= 0.0 && s(i,j+1,k  ) < 0.0)
                      ez(i,j+1,k-1) = Type::covered;
                }
                if (k < ez.end.z-1) {
-                  if (s(i  ,j,k+1) == Type::irregular && s(i  ,j,k+1) < 0.0)
+                  if (s(i  ,j,k+2) >= 0.0 && s(i  ,j,k+1) < 0.0)
                      ez(i,j,k+1) = Type::covered;
-                  if (s(i,j+1,k+1) == Type::irregular && s(i,j+1,k+1) < 0.0)
+                  if (s(i,j+1,k+2) >= 0.0 && s(i,j+1,k+1) < 0.0)
                      ez(i,j+1,k+1) = Type::covered;
                }
 
                // Cover the ex that touch the corners if necessary
                if (i > ex.begin.x) {
-                  if (s(i-1,j  ,k  ) == Type::irregular && s(i  ,j,k  ) < 0.0)
+                  if (s(i-1,j  ,k  ) >= 0.0 && s(i  ,j,k  ) < 0.0)
                      ex(i-1,j,k) = Type::covered;
-                  if (s(i-1,j+1,k  ) == Type::irregular && s(i,j+1,k  ) < 0.0)
+                  if (s(i-1,j+1,k  ) >= 0.0 && s(i,j+1,k  ) < 0.0)
                      ex(i-1,j+1,k) = Type::covered;
-                  if (s(i-1,j  ,k+1) == Type::irregular && s(i  ,j,k+1) < 0.0)
+                  if (s(i-1,j  ,k+1) >= 0.0 && s(i  ,j,k+1) < 0.0)
                      ex(i-1,j,k+1) = Type::covered;
-                  if (s(i-1,j+1,k+1) == Type::irregular && s(i,j+1,k+1) < 0.0)
+                  if (s(i-1,j+1,k+1) >= 0.0 && s(i,j+1,k+1) < 0.0)
                      ex(i-1,j+1,k+1) = Type::covered;
                 }
                if (i <= ex.end.x-1) {
-                  if (s(i  ,j  ,k  ) == Type::irregular && s(i  ,j,k  ) < 0.0)
+                  if (s(i+1,j  ,k  ) >= 0.0 && s(i  ,j,k  ) < 0.0)
                      ex(i,j,k) = Type::covered;
-                  if (s(i  ,j  ,k+1) == Type::irregular && s(i  ,j,k+1) < 0.0)
+                  if (s(i+1,j  ,k+1) >= 0.0 && s(i  ,j,k+1) < 0.0)
                      ex(i,j,k+1) = Type::covered;
-                  if (s(i  ,j+1,k+1) == Type::irregular && s(i,j+1,k+1) < 0.0)
+                  if (s(i+1,j+1,k+1) >= 0.0 && s(i,j+1,k+1) < 0.0)
                      ex(i,j+1,k+1) = Type::covered;
-                  if (s(i  ,j+1,k  ) == Type::irregular && s(i,j+1,k  ) < 0.0)
+                  if (s(i+1,j+1,k  ) >= 0.0 && s(i,j+1,k  ) < 0.0)
                      ex(i,j+1,k) = Type::covered;
                }
 
@@ -262,51 +262,51 @@ amrex_eb2_build_types (Box const& tbx, Box const& bxg2,
 
                //Cover the other ex that touch the corners if necessary
                if (i > ex.begin.x) {
-                  if (s(i-1,j,k  ) == Type::irregular && s(i  ,j,k  ) < 0.0)
+                  if (s(i-1,j,k  ) >= 0.0 && s(i  ,j,k  ) < 0.0)
                      ex(i-1,j,k) = Type::covered;
-                  if (s(i-1,j,k+1) == Type::irregular && s(i  ,j,k+1) < 0.0)
+                  if (s(i-1,j,k+1) >= 0.0 && s(i  ,j,k+1) < 0.0)
                      ex(i-1,j,k+1) = Type::covered;
                }
                if (i < ex.end.x-1) {
-                  if (s(i+1,j,k  ) == Type::irregular && s(i+1,j,k  ) < 0.0)
+                  if (s(i+2,j,k  ) >= 0.0 && s(i+1,j,k  ) < 0.0)
                      ex(i+1,j,k) = Type::covered;
-                  if (s(i+1,j,k+1) == Type::irregular && s(i+1,j,k+1) < 0.0)
+                  if (s(i+2,j,k+1) >= 0.0 && s(i+1,j,k+1) < 0.0)
                      ex(i+1,j,k+1) = Type::covered;
                }
 
                // Cover the other ez that touch the corners if necessary
                if (k > ez.begin.z) {
-                  if (s(i  ,j,k-1) == Type::irregular && s(i  ,j,k  ) < 0.0)
+                  if (s(i  ,j,k-1) >= 0.0 && s(i  ,j,k  ) < 0.0)
                      ez(i,j,k-1) = Type::covered;
-                  if (s(i+1,j,k-1) == Type::irregular && s(i+1,j,k  ) < 0.0)
+                  if (s(i+1,j,k-1) >= 0.0 && s(i+1,j,k  ) < 0.0)
                      ez(i+1,j,k-1) = Type::covered;
                }
                if (k < ez.end.z-1) {
-                  if (s(i  ,j,k+1) == Type::irregular && s(i  ,j,k+1) < 0.0)
+                  if (s(i  ,j,k+2) >= 0.0 && s(i  ,j,k+1) < 0.0)
                      ez(i,j,k+1) = Type::covered;
-                  if (s(i+1,j,k+1) == Type::irregular && s(i+1,j,k+1) < 0.0)
+                  if (s(i+1,j,k+2) >= 0.0 && s(i+1,j,k+1) < 0.0)
                      ez(i+1,j,k+1) = Type::covered;
                }
 
                // Cover the ey that touch the corners if necessary
                if (j > ey.begin.y) {
-                  if (s(i  ,j-1,k  ) == Type::irregular && s(i  ,j,k  ) < 0.0)
+                  if (s(i  ,j-1,k  ) >= 0.0 && s(i  ,j,k  ) < 0.0)
                      ey(i,j-1,k) = Type::covered;
-                  if (s(i+1,j-1,k  ) == Type::irregular && s(i+1,j,k  ) < 0.0)
+                  if (s(i+1,j-1,k  ) >= 0.0 && s(i+1,j,k  ) < 0.0)
                      ey(i+1,j-1,k) = Type::covered;
-                  if (s(i+1,j-1,k+1) == Type::irregular && s(i+1,j,k+1) < 0.0)
+                  if (s(i+1,j-1,k+1) >= 0.0 && s(i+1,j,k+1) < 0.0)
                      ey(i+1,j-1,k+1) = Type::covered;
-                  if (s(i  ,j-1,k+1) == Type::irregular && s(i  ,j,k+1) < 0.0)
+                  if (s(i  ,j-1,k+1) >= 0.0 && s(i  ,j,k+1) < 0.0)
                      ey(i,j-1,k+1) = Type::covered;
                }
                if (j <= ey.end.y-1) {
-                  if (s(i  ,j  ,k  ) == Type::irregular && s(i  ,j,k  ) < 0.0)
+                  if (s(i  ,j+1,k  ) >= 0.0 && s(i  ,j,k  ) < 0.0)
                      ey(i,j,k) = Type::covered;
-                  if (s(i  ,j  ,k+1) == Type::irregular && s(i  ,j,k+1) < 0.0)
+                  if (s(i  ,j+1,k+1) >= 0.0 && s(i  ,j,k+1) < 0.0)
                      ey(i,j,k+1) = Type::covered;
-                  if (s(i+1,j  ,k+1) == Type::irregular && s(i+1,j,k+1) < 0.0)
+                  if (s(i+1,j+1,k+1) >= 0.0 && s(i+1,j,k+1) < 0.0)
                      ey(i+1,j,k+1) = Type::covered;
-                  if (s(i+1,j  ,k  ) == Type::irregular && s(i+1,j,k  ) < 0.0)
+                  if (s(i+1,j+1,k  ) >= 0.0 && s(i+1,j,k  ) < 0.0)
                      ey(i+1,j,k) = Type::covered;
                }
 
@@ -337,51 +337,51 @@ amrex_eb2_build_types (Box const& tbx, Box const& bxg2,
 
                //Cover the other ex that touch the corners if necessary
                if (i > ex.begin.x) {
-                  if (s(i-1,j,k  ) == Type::irregular && s(i  ,j,k  ) < 0.0)
+                  if (s(i-1,j,k  ) >= 0.0 && s(i  ,j,k  ) < 0.0)
                      ex(i-1,j,k) = Type::covered;
-                  if (s(i-1,j+1,k) == Type::irregular && s(i  ,j+1,k) < 0.0)
+                  if (s(i-1,j+1,k) >= 0.0 && s(i  ,j+1,k) < 0.0)
                      ex(i-1,j+1,k) = Type::covered;
                }
                if (i < ex.end.x-1) {
-                  if (s(i+1,j,k  ) == Type::irregular && s(i+1,j,k  ) < 0.0)
+                  if (s(i+2,j,k  ) >= 0.0 && s(i+1,j,k  ) < 0.0)
                      ex(i+1,j,k) = Type::covered;
-                  if (s(i+1,j+1,k) == Type::irregular && s(i+1,j+1,k) < 0.0)
+                  if (s(i+2,j+1,k) >= 0.0 && s(i+1,j+1,k) < 0.0)
                      ex(i+1,j+1,k) = Type::covered;
                }
 
                // Cover the other ey that touch the corners if necessary
                if (j > ey.begin.y) {
-                  if (s(i  ,j-1,k) == Type::irregular && s(i  ,j,k  ) < 0.0)
+                  if (s(i  ,j-1,k) >= 0.0 && s(i  ,j,k  ) < 0.0)
                      ey(i,j-1,k) = Type::covered;
-                  if (s(i+1,j-1,k) == Type::irregular && s(i+1,j,k  ) < 0.0)
+                  if (s(i+1,j-1,k) >= 0.0 && s(i+1,j,k  ) < 0.0)
                      ey(i+1,j-1,k) = Type::covered;
                }
                if (j < ey.end.y-1) {
-                  if (s(i  ,j+1,k) == Type::irregular && s(i  ,j+1,k) < 0.0)
+                  if (s(i  ,j+2,k) >= 0.0 && s(i  ,j+1,k) < 0.0)
                      ey(i,j+1,k) = Type::covered;
-                  if (s(i+1,j+1,k) == Type::irregular && s(i+1,j+1,k) < 0.0)
+                  if (s(i+1,j+2,k) >= 0.0 && s(i+1,j+1,k) < 0.0)
                      ey(i+1,j+1,k) = Type::covered;
                }
 
                // Cover the ez that touch the corners if necessary
                if (k > ez.begin.z) {
-                  if (s(i  ,j  ,k-1) == Type::irregular && s(i  ,j,k  ) < 0.0)
+                  if (s(i  ,j  ,k-1) >= 0.0 && s(i  ,j,k  ) < 0.0)
                      ez(i,j,k-1) = Type::covered;
-                  if (s(i  ,j+1,k-1) == Type::irregular && s(i  ,j+1,k) < 0.0)
+                  if (s(i  ,j+1,k-1) >= 0.0 && s(i  ,j+1,k) < 0.0)
                      ez(i,j+1,k-1) = Type::covered;
-                  if (s(i+1,j+1,k-1) == Type::irregular && s(i+1,j+1,k) < 0.0)
+                  if (s(i+1,j+1,k-1) >= 0.0 && s(i+1,j+1,k) < 0.0)
                      ez(i+1,j+1,k-1) = Type::covered;
-                  if (s(i+1,j  ,k-1) == Type::irregular && s(i+1,j,k  ) < 0.0)
+                  if (s(i+1,j  ,k-1) >= 0.0 && s(i+1,j,k  ) < 0.0)
                      ez(i+1,j,k-1) = Type::covered;
                }
                if (k <= ez.end.z-1) {
-                  if (s(i  ,j  ,k  ) == Type::irregular && s(i  ,j,k  ) < 0.0)
+                  if (s(i  ,j  ,k+1) >= 0.0 && s(i  ,j,k  ) < 0.0)
                      ez(i,j,k) = Type::covered;
-                  if (s(i  ,j+1,k  ) == Type::irregular && s(i  ,j+1,k) < 0.0)
+                  if (s(i  ,j+1,k+1) >= 0.0 && s(i  ,j+1,k) < 0.0)
                      ez(i,j+1,k) = Type::covered;
-                  if (s(i+1,j+1,k  ) == Type::irregular && s(i+1,j+1,k) < 0.0)
+                  if (s(i+1,j+1,k+1) >= 0.0 && s(i+1,j+1,k) < 0.0)
                      ez(i+1,j+1,k) = Type::covered;
-                  if (s(i+1,j  ,k  ) == Type::irregular && s(i+1,j,k  ) < 0.0)
+                  if (s(i+1,j  ,k+1) >= 0.0 && s(i+1,j,k  ) < 0.0)
                      ez(i+1,j,k) = Type::covered;
                }
 

--- a/Src/EB/AMReX_EB2_Level.H
+++ b/Src/EB/AMReX_EB2_Level.H
@@ -121,9 +121,11 @@ GShopLevel<G>::GShopLevel (IndexSpace const* is, G const& gshop, const Geometry&
     BL_PROFILE("EB2::GShopLevel()-fine");
 
     Real small_volfrac = 1.e-14;
+    bool cover_multiple_cuts = false;
     {
         ParmParse pp("eb2");
         pp.query("small_volfrac", small_volfrac);
+        pp.query("cover_multiple_cuts", cover_multiple_cuts);
     }
 
     // make sure ngrow is multiple of 16
@@ -255,7 +257,7 @@ GShopLevel<G>::GShopLevel (IndexSpace const* is, G const& gshop, const Geometry&
 
             auto& cellflag = m_cellflag[mfi];
 
-            gfab.buildTypes(cellflag);
+            gfab.buildTypes(cellflag, cover_multiple_cuts);
 
             Array4<Real const> const& lst = levelset.const_array();
             Array4<EBCellFlag> const& cfg = m_cellflag.array(mfi);

--- a/Src/EB/AMReX_EB2_MultiGFab.H
+++ b/Src/EB/AMReX_EB2_MultiGFab.H
@@ -47,7 +47,7 @@ public:
     const Graph& getGraph () const { return m_graph; }
     Graph& getGraph () { return m_graph; }
 
-    void buildTypes (EBCellFlagFab& celltype);
+    void buildTypes (EBCellFlagFab& celltype, bool cover_multiple_cuts = false);
 
 private:
 

--- a/Src/EB/AMReX_EB2_MultiGFab.cpp
+++ b/Src/EB/AMReX_EB2_MultiGFab.cpp
@@ -1,6 +1,7 @@
 
 #include <AMReX_EB2_MultiGFab.H>
 #include <AMReX_EB2_C.H>
+#include <AMReX_ParmParse.H>
 
 namespace amrex { namespace EB2 {
 

--- a/Src/EB/AMReX_EB2_MultiGFab.cpp
+++ b/Src/EB/AMReX_EB2_MultiGFab.cpp
@@ -25,13 +25,19 @@ GFab::buildTypes (EBCellFlagFab& celltype)
 
 #elif (AMREX_SPACEDIM == 3)
 
+    bool cover_multiple_cuts = false;
+    {
+        ParmParse pp("eb2");
+        pp.query("cover_multiple_cuts", cover_multiple_cuts);
+    }
+
     Array4<Type_t> const& ex = m_edgetype[0].array();
     Array4<Type_t> const& ey = m_edgetype[1].array();
     Array4<Type_t> const& ez = m_edgetype[2].array();
 
     AMREX_LAUNCH_HOST_DEVICE_LAMBDA ( nodal_box, tbx,
     {
-        amrex_eb2_build_types(tbx, bxg2, s, cell, fx, fy, fz, ex, ey, ez);
+        amrex_eb2_build_types(tbx, bxg2, s, cell, fx, fy, fz, ex, ey, ez, cover_multiple_cuts);
     });
 
 #endif

--- a/Src/EB/AMReX_EB2_MultiGFab.cpp
+++ b/Src/EB/AMReX_EB2_MultiGFab.cpp
@@ -33,8 +33,15 @@ GFab::buildTypes (EBCellFlagFab& celltype, bool cover_multiple_cuts)
 
     AMREX_LAUNCH_HOST_DEVICE_LAMBDA ( nodal_box, tbx,
     {
-        amrex_eb2_build_types(tbx, bxg2, s, cell, fx, fy, fz, ex, ey, ez, cover_multiple_cuts);
+        amrex_eb2_build_types(tbx, bxg2, s, cell, fx, fy, fz, ex, ey, ez);
     });
+
+    if (cover_multiple_cuts) {
+       AMREX_LAUNCH_HOST_DEVICE_LAMBDA ( nodal_box, tbx,
+       {
+           amrex_eb2_cover_multiple_cuts(tbx, bxg2, s, fx, fy, fz, ex, ey, ez);
+       });
+    }
 
 #endif
 }

--- a/Src/EB/AMReX_EB2_MultiGFab.cpp
+++ b/Src/EB/AMReX_EB2_MultiGFab.cpp
@@ -6,7 +6,7 @@
 namespace amrex { namespace EB2 {
 
 void
-GFab::buildTypes (EBCellFlagFab& celltype)
+GFab::buildTypes (EBCellFlagFab& celltype, bool cover_multiple_cuts)
 {
     Array4<Real const> const& s = m_levelset.const_array();
     Array4<EBCellFlag> const& cell = celltype.array();
@@ -18,6 +18,7 @@ GFab::buildTypes (EBCellFlagFab& celltype)
     const Box& nodal_box = amrex::surroundingNodes(bxg2);
 
 #if (AMREX_SPACEDIM == 2)
+    amrex::ignore_unused(cover_multiple_cuts);
 
     AMREX_LAUNCH_HOST_DEVICE_LAMBDA ( nodal_box, tbx,
     {
@@ -25,12 +26,6 @@ GFab::buildTypes (EBCellFlagFab& celltype)
     });
 
 #elif (AMREX_SPACEDIM == 3)
-
-    bool cover_multiple_cuts = false;
-    {
-        ParmParse pp("eb2");
-        pp.query("cover_multiple_cuts", cover_multiple_cuts);
-    }
 
     Array4<Type_t> const& ex = m_edgetype[0].array();
     Array4<Type_t> const& ey = m_edgetype[1].array();


### PR DESCRIPTION
## Summary
When building the edge types, cover the cut edges that touch opposite regular corners in order to prevent the `too many cuts in a face error`. Logic is only enabled when flag is set to true in inputs file (default is false).

## Additional background
When trying to resolve complex geometries with sharp edges one can run into cases where there are multiple EB cuts on a face. In this change, when the flag `cover_multiple_cuts` is set, we cover appropriate edges in order to avoid this error. Manually tested geometry generation on some complex geometries that were previously failing to resolve. 

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
