### PR TITLE
Ensure that Particle is 8-byte aligned, even in single precision.

### DIFF
--- a/Src/F_Interfaces/Particle/AMReX_particlecontainer_mod.F90
+++ b/Src/F_Interfaces/Particle/AMReX_particlecontainer_mod.F90
@@ -16,10 +16,9 @@ module amrex_particlecontainer_module
   public :: amrex_get_particle_cpu, amrex_set_particle_cpu
 
   type, bind(C), public :: amrex_particle
+     integer(c_int64_t), private  :: idcpu
      real(amrex_particle_real)    :: pos(AMREX_SPACEDIM) !< Position
      real(amrex_particle_real)    :: vel(AMREX_SPACEDIM) !< Particle velocity
-     integer(c_int), private      :: id
-     integer(c_int), private      :: cpu
   end type amrex_particle
 
   type, public :: amrex_particlecontainer

--- a/Src/Particle/AMReX_ArrayOfStructs.H
+++ b/Src/Particle/AMReX_ArrayOfStructs.H
@@ -69,8 +69,8 @@ public:
 
     bool empty () const { return m_data.empty(); }
 
-    const RealType* data () const { return &(m_data[0].m_pos[0]); }
-    RealType* data () { return &(m_data[0].pos(0)); }
+    const RealType* data () const { return (RealType*)&(m_data[0]); }
+    RealType* data () { return (RealType*)&(m_data[0]); }
 
     const RealType* dataPtr () const { return data(); }
     RealType*       dataPtr ()       { return data(); }

--- a/Src/Particle/AMReX_ArrayOfStructs.H
+++ b/Src/Particle/AMReX_ArrayOfStructs.H
@@ -69,8 +69,8 @@ public:
 
     bool empty () const { return m_data.empty(); }
 
-    const RealType* data () const { return (RealType*)&(m_data[0]); }
-    RealType* data () { return (RealType*)&(m_data[0]); }
+    const RealType* data () const { return (RealType*) m_data.data(); }
+    RealType* data () { return (RealType*) m_data.data(); }
 
     const RealType* dataPtr () const { return data(); }
     RealType*       dataPtr ()       { return data(); }

--- a/Src/Particle/AMReX_Particle.H
+++ b/Src/Particle/AMReX_Particle.H
@@ -159,33 +159,33 @@ struct ConstParticleCPUWrapper
 template <typename T, int NReal, int NInt>
 struct ParticleBase
 {
+    uint64_t m_idcpu = 0;
     T m_pos[AMREX_SPACEDIM];
     T m_rdata[NReal];
-    uint64_t m_idcpu = 0;
     int m_idata[NInt];
 };
 
 template <typename T, int NInt>
 struct ParticleBase<T,0,NInt>
 {
-    T m_pos[AMREX_SPACEDIM];
     uint64_t m_idcpu = 0;
+    T m_pos[AMREX_SPACEDIM];
     int m_idata[NInt];
 };
 
 template <typename T, int NReal>
 struct ParticleBase<T,NReal,0>
 {
+    uint64_t m_idcpu = 0;
     T m_pos[AMREX_SPACEDIM];
     T m_rdata[NReal];
-    uint64_t m_idcpu = 0;
 };
 
 template <typename T>
 struct ParticleBase<T,0,0>
 {
-    T m_pos[AMREX_SPACEDIM];
     uint64_t m_idcpu = 0;
+    T m_pos[AMREX_SPACEDIM];
 };
 
 


### PR DESCRIPTION
This will allow us to load particles as a bunch of `uint64_t`s into shared memory.
