### PR TITLE
Fix ncomp bug in linear solver

### DIFF
--- a/Src/LinearSolvers/MLMG/AMReX_MLABecLaplacian.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLABecLaplacian.H
@@ -113,7 +113,7 @@ protected:
 
 private:
 
-    int m_ncomp;
+    int m_ncomp = 1;
 
     void define_ab_coeffs ();
 };

--- a/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap.H
@@ -123,7 +123,7 @@ public:
 
 protected:
 
-    int m_ncomp;
+    int m_ncomp = 1;
 
     bool m_needs_update = true;
 


### PR DESCRIPTION
Need to give m_ncomp a default value, otherwise default constructor followed
by define(...) will not work.

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
