### PR TITLE
CI: macOS Shared Lib

### DIFF
--- a/.github/workflows/dependencies/dependencies_mac.sh
+++ b/.github/workflows/dependencies/dependencies_mac.sh
@@ -11,3 +11,4 @@ brew update
 brew install gfortran || true
 brew install libomp || true
 brew install open-mpi || true
+brew install ccache || true

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -17,6 +17,7 @@ jobs:
     - name: Build & Install
       run: |
         cmake -S . -B build             \
+            -DBUILD_SHARED_LIBS=ON      \
             -DCMAKE_BUILD_TYPE=Debug    \
             -DCMAKE_VERBOSE_MAKEFILE=ON \
             -DAMReX_BUILD_TUTORIALS=ON  \
@@ -25,7 +26,6 @@ jobs:
         cmake --build build --parallel 2
 
         cmake -S . -B build             \
-            -DBUILD_SHARED_LIBS=ON      \
             -DCMAKE_BUILD_TYPE=Debug    \
             -DCMAKE_VERBOSE_MAKEFILE=ON \
             -DAMReX_BUILD_TUTORIALS=ON  \

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -16,11 +16,19 @@ jobs:
       run: .github/workflows/dependencies/dependencies_mac.sh
     - name: Build & Install
       run: |
-        mkdir build
-        cd build
-        cmake ..                        \
+        cmake -S . -B build             \
             -DCMAKE_BUILD_TYPE=Debug    \
             -DCMAKE_VERBOSE_MAKEFILE=ON \
             -DAMReX_BUILD_TUTORIALS=ON  \
             -DAMReX_PARTICLES=ON
-        make -j 2
+        cmake --build build --parallel 2
+
+        cmake -S . -B build             \
+            -DBUILD_SHARED_LIBS=ON      \
+            -DCMAKE_BUILD_TYPE=Debug    \
+            -DCMAKE_VERBOSE_MAKEFILE=ON \
+            -DAMReX_BUILD_TUTORIALS=ON  \
+            -DAMReX_PARTICLES=ON
+        cmake --build build --parallel 2
+
+        cmake --build build --target install

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -20,7 +20,8 @@ jobs:
             -DCMAKE_BUILD_TYPE=Debug    \
             -DCMAKE_VERBOSE_MAKEFILE=ON \
             -DAMReX_BUILD_TUTORIALS=ON  \
-            -DAMReX_PARTICLES=ON
+            -DAMReX_PARTICLES=ON        \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=$(which ccache)
         cmake --build build --parallel 2
 
         cmake -S . -B build             \
@@ -28,7 +29,8 @@ jobs:
             -DCMAKE_BUILD_TYPE=Debug    \
             -DCMAKE_VERBOSE_MAKEFILE=ON \
             -DAMReX_BUILD_TUTORIALS=ON  \
-            -DAMReX_PARTICLES=ON
+            -DAMReX_PARTICLES=ON        \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=$(which ccache)
         cmake --build build --parallel 2
 
         cmake --build build --target install

--- a/Src/Amr/AMReX_LevelBld.H
+++ b/Src/Amr/AMReX_LevelBld.H
@@ -74,6 +74,13 @@ public:
 
 }
 
-extern amrex::LevelBld* getLevelBld () AMREX_ATTRIBUTE_WEAK;
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+    amrex::LevelBld* getLevelBld () AMREX_ATTRIBUTE_WEAK;
+#ifdef __cplusplus
+}
+#endif
 
 #endif /*_LEVELBLD_H_*/

--- a/Src/Amr/AMReX_LevelBld.H
+++ b/Src/Amr/AMReX_LevelBld.H
@@ -74,6 +74,6 @@ public:
 
 }
 
-extern AMREX_ATTRIBUTE_WEAK amrex::LevelBld* getLevelBld ();
+extern amrex::LevelBld* getLevelBld () AMREX_ATTRIBUTE_WEAK;
 
 #endif /*_LEVELBLD_H_*/

--- a/Src/Amr/AMReX_LevelBld.H
+++ b/Src/Amr/AMReX_LevelBld.H
@@ -74,13 +74,6 @@ public:
 
 }
 
-#ifdef __cplusplus
-extern "C"
-{
-#endif
-    amrex::LevelBld* getLevelBld () AMREX_ATTRIBUTE_WEAK;
-#ifdef __cplusplus
-}
-#endif
+extern amrex::LevelBld* getLevelBld () AMREX_ATTRIBUTE_WEAK;
 
 #endif /*_LEVELBLD_H_*/

--- a/Src/Amr/AMReX_PROB_AMR_F.H
+++ b/Src/Amr/AMReX_PROB_AMR_F.H
@@ -9,11 +9,11 @@
 extern "C"
 {
 #endif
-     void AMREX_ATTRIBUTE_WEAK amrex_probinit (const int* init,
-                                               const int* name,
-                                               const int* namelen,
-                                               const amrex_real* problo,
-                                               const amrex_real* probhi);
+     void amrex_probinit (const int* init,
+                          const int* name,
+                          const int* namelen,
+                          const amrex_real* problo,
+                          const amrex_real* probhi) AMREX_ATTRIBUTE_WEAK;
 #ifdef __cplusplus
 }
 #endif

--- a/Src/Base/AMReX_Extension.H
+++ b/Src/Base/AMReX_Extension.H
@@ -133,6 +133,8 @@
 #define AMREX_ATTRIBUTE_WEAK 
 #elif defined(_WIN32)
 #define AMREX_ATTRIBUTE_WEAK
+#elif defined(__clang__) && defined(__apple_build_version__)
+#define AMREX_ATTRIBUTE_WEAK __attribute__((weak_import))
 #else
 #define AMREX_ATTRIBUTE_WEAK __attribute__((weak))
 #endif

--- a/Tools/CMake/AMReX_Config.cmake
+++ b/Tools/CMake/AMReX_Config.cmake
@@ -156,11 +156,9 @@ function (configure_amrex)
 
       if(CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
         if( host_link_supported STREQUAL "NEW" ) # CMake 3.18+
-          target_link_options(amrex PUBLIC "LINKER:-U,_amrex_probinit")
-          target_link_options(amrex PUBLIC "LINKER:-U,_Z11getLevelBldv")
+          target_link_options(amrex PUBLIC "LINKER:-undefined,dynamic_lookup")
         else()
-          target_link_options(amrex PUBLIC "-Wl,-U,_amrex_probinit")
-          target_link_options(amrex PUBLIC "-Wl,-U,_Z11getLevelBldv")
+          target_link_options(amrex PUBLIC "-Wl,-undefined,dynamic_lookup")
         endif()
       elseif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC" OR
              CMAKE_CXX_SIMULATE_ID STREQUAL "MSVC")

--- a/Tools/CMake/AMReX_Config.cmake
+++ b/Tools/CMake/AMReX_Config.cmake
@@ -157,10 +157,10 @@ function (configure_amrex)
       if(CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
         if( host_link_supported STREQUAL "NEW" ) # CMake 3.18+
           target_link_options(amrex PUBLIC "LINKER:-U,_amrex_probinit")
-          target_link_options(amrex PUBLIC "LINKER:-U,_getLevelBld")
+          target_link_options(amrex PUBLIC "LINKER:-U,_Z11getLevelBldv")
         else()
           target_link_options(amrex PUBLIC "-Wl,-U,_amrex_probinit")
-          target_link_options(amrex PUBLIC "-Wl,-U,_getLevelBld")
+          target_link_options(amrex PUBLIC "-Wl,-U,_Z11getLevelBldv")
         endif()
       elseif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC" OR
              CMAKE_CXX_SIMULATE_ID STREQUAL "MSVC")

--- a/Tools/CMake/AMReX_Config.cmake
+++ b/Tools/CMake/AMReX_Config.cmake
@@ -157,10 +157,10 @@ function (configure_amrex)
       if(CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
         if( host_link_supported STREQUAL "NEW" ) # CMake 3.18+
           target_link_options(amrex PUBLIC "LINKER:-U,_amrex_probinit")
-          target_link_options(amrex PUBLIC "LINKER:-U,getLevelBld()")
+          target_link_options(amrex PUBLIC "LINKER:-U,getLevelBld")
         else()
           target_link_options(amrex PUBLIC "-Wl,-U,_amrex_probinit")
-          target_link_options(amrex PUBLIC "-Wl,-U,getLevelBld()")
+          target_link_options(amrex PUBLIC "-Wl,-U,getLevelBld")
         endif()
       elseif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC" OR
              CMAKE_CXX_SIMULATE_ID STREQUAL "MSVC")

--- a/Tools/CMake/AMReX_Config.cmake
+++ b/Tools/CMake/AMReX_Config.cmake
@@ -154,11 +154,11 @@ function (configure_amrex)
         cmake_policy(GET CMP0105 host_link_supported)
       endif()
 
-      if(APPLE)
+      if(CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
         if( host_link_supported STREQUAL "NEW" ) # CMake 3.18+
-          target_link_options(amrex PUBLIC "LINKER:-undefined,warning")
+          target_link_options(amrex PUBLIC "LINKER:-undefined,dynamic_lookup")
         else()
-          target_link_options(amrex PUBLIC "-Wl,-undefined,warning")
+          target_link_options(amrex PUBLIC "-Wl,-undefined,dynamic_lookup")
         endif()
       elseif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC" OR
              CMAKE_CXX_SIMULATE_ID STREQUAL "MSVC")

--- a/Tools/CMake/AMReX_Config.cmake
+++ b/Tools/CMake/AMReX_Config.cmake
@@ -157,10 +157,10 @@ function (configure_amrex)
       if(CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
         if( host_link_supported STREQUAL "NEW" ) # CMake 3.18+
           target_link_options(amrex PUBLIC "LINKER:-U,_amrex_probinit")
-          target_link_options(amrex PUBLIC "LINKER:-U,getLevelBld")
+          target_link_options(amrex PUBLIC "LINKER:-U,_getLevelBld")
         else()
           target_link_options(amrex PUBLIC "-Wl,-U,_amrex_probinit")
-          target_link_options(amrex PUBLIC "-Wl,-U,getLevelBld")
+          target_link_options(amrex PUBLIC "-Wl,-U,_getLevelBld")
         endif()
       elseif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC" OR
              CMAKE_CXX_SIMULATE_ID STREQUAL "MSVC")

--- a/Tools/CMake/AMReX_Config.cmake
+++ b/Tools/CMake/AMReX_Config.cmake
@@ -156,9 +156,11 @@ function (configure_amrex)
 
       if(CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
         if( host_link_supported STREQUAL "NEW" ) # CMake 3.18+
-          target_link_options(amrex PUBLIC "LINKER:-undefined,dynamic_lookup")
+          target_link_options(amrex PUBLIC "LINKER:-U,_amrex_probinit")
+          target_link_options(amrex PUBLIC "LINKER:-U,getLevelBld()")
         else()
-          target_link_options(amrex PUBLIC "-Wl,-undefined,dynamic_lookup")
+          target_link_options(amrex PUBLIC "-Wl,-U,_amrex_probinit")
+          target_link_options(amrex PUBLIC "-Wl,-U,getLevelBld()")
         endif()
       elseif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC" OR
              CMAKE_CXX_SIMULATE_ID STREQUAL "MSVC")


### PR DESCRIPTION
## Summary

CI for macOS: Build a shared library. This is the default in Spack.

I see issues with AppleClang 12.0 raising:
```
ld: can't use -undefined warning or suppress with -twolevel_namespace
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

@RemiLehe reported this again here: https://github.com/AMReX-Codes/amrex/issues/425#issuecomment-473153152

- [x] reproduce issue
- [x] add fix

## Additional background

Introduced in 1b6af3cb630 to fix #425

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
