### PR TITLE
Change default for Amr::probin_file -> ""

### DIFF
--- a/Src/Amr/AMReX_Amr.cpp
+++ b/Src/Amr/AMReX_Amr.cpp
@@ -302,7 +302,7 @@ Amr::InitAmr ()
         setRecordDataInfo(i,datalogname[i]);
     }
 
-    probin_file = "probin";  // Make "probin" the default
+    probin_file = "";
 
     if (pp.contains("probin_file"))
     {


### PR DESCRIPTION
## Summary
This sets default behavior to skip attempting to read a probin_file. 

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
