### PR TITLE
CMake: move AMReX_INSTALL option to AMReXOptions.cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,7 +143,6 @@ endif ()
 #
 # Install amrex  -- Export
 #
-option(AMReX_INSTALL "Generate Install Targets" YES)
 if(AMReX_INSTALL)
     include(AMReXInstallHelpers)
     install_amrex_targets(${_amrex_targets})

--- a/Tools/CMake/AMReXOptions.cmake
+++ b/Tools/CMake/AMReXOptions.cmake
@@ -61,6 +61,11 @@ else ()
 endif ()
 print_option( BUILD_SHARED_LIBS )
 
+#
+# Option to control generation of install targets
+#
+option(AMReX_INSTALL "Generate Install Targets" ON)
+
 
 #
 # Option to control if Fortran must be enabled  ==============================


### PR DESCRIPTION
## Summary
Option to control generation of install target must be loaded at the beginning of execution.
Follow-up to #1831 and #1833
## Additional background

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
