### PR TITLE
Build: Windows with Shared Libs (.dll)

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -13,12 +13,30 @@ jobs:
       run: |
         cmake -S . -B build   `
               -DCMAKE_BUILD_TYPE=Debug      `
+              -DBUILD_SHARED_LIBS=ON        `
               -DCMAKE_VERBOSE_MAKEFILE=ON   `
               -DAMReX_BUILD_TUTORIALS=ON    `
               -DAMReX_FORTRAN=OFF           `
               -DAMReX_MPI=OFF               `
               -DAMReX_PARTICLES=ON
         cmake --build build --config Debug -j 2
+
+  # Build libamrex and all tutorials (static)
+  tutorials_msvc_static:
+    name: MSVC C++17 w/o Fortran w/o MPI static
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build & Install
+      run: |
+        cmake -S . -B build   `
+              -DCMAKE_BUILD_TYPE=RelWithDebInfo `
+              -DCMAKE_VERBOSE_MAKEFILE=ON   `
+              -DAMReX_BUILD_TUTORIALS=ON    `
+              -DAMReX_FORTRAN=OFF           `
+              -DAMReX_MPI=OFF               `
+              -DAMReX_PARTICLES=ON
+        cmake --build build --config RelWithDebInfo -j 2
 
   # Build libamrex and all tutorials
   tutorials_clang:
@@ -34,6 +52,7 @@ jobs:
         cmake -S . -B build   ^
               -T "ClangCl"    ^
               -DCMAKE_BUILD_TYPE=Release    ^
+              -DBUILD_SHARED_LIBS=ON        ^
               -DCMAKE_VERBOSE_MAKEFILE=ON   ^
               -DAMReX_BUILD_TUTORIALS=ON    ^
               -DAMReX_FORTRAN=OFF           ^

--- a/Src/AmrCore/AMReX_Interpolater.H
+++ b/Src/AmrCore/AMReX_Interpolater.H
@@ -4,6 +4,7 @@
 
 #include <AMReX_BoxArray.H>
 #include <AMReX_BCRec.H>
+#include <AMReX_Extension.H>
 #include <AMReX_REAL.H>
 #include <AMReX_GpuControl.H>
 
@@ -888,18 +889,18 @@ public:
 
 
 //! CONSTRUCT A GLOBAL OBJECT OF EACH VERSION.
-extern PCInterp                  pc_interp;
-extern NodeBilinear              node_bilinear_interp;
-extern FaceDivFree               face_divfree_interp;
-extern FaceLinear                face_linear_interp;
-extern CellConservativeLinear    lincc_interp;
-extern CellConservativeLinear    cell_cons_interp;
+extern AMREX_EXPORT PCInterp                  pc_interp;
+extern AMREX_EXPORT NodeBilinear              node_bilinear_interp;
+extern AMREX_EXPORT FaceDivFree               face_divfree_interp;
+extern AMREX_EXPORT FaceLinear                face_linear_interp;
+extern AMREX_EXPORT CellConservativeLinear    lincc_interp;
+extern AMREX_EXPORT CellConservativeLinear    cell_cons_interp;
 
 #ifndef BL_NO_FORT
-extern CellBilinear              cell_bilinear_interp;
-extern CellQuadratic             quadratic_interp;
-extern CellConservativeProtected protected_interp;
-extern CellConservativeQuartic   quartic_interp;
+extern AMREX_EXPORT CellBilinear              cell_bilinear_interp;
+extern AMREX_EXPORT CellQuadratic             quadratic_interp;
+extern AMREX_EXPORT CellConservativeProtected protected_interp;
+extern AMREX_EXPORT CellConservativeQuartic   quartic_interp;
 #endif
 
 class InterpolaterBoxCoarsener

--- a/Src/Base/AMReX.H
+++ b/Src/Base/AMReX.H
@@ -47,21 +47,21 @@ namespace amrex
         constexpr bool  Debug = true;
 #endif
 
-        extern std::string exename;
+        extern AMREX_EXPORT std::string exename;
 
-        extern int verbose;
+        extern AMREX_EXPORT int verbose;
 
-        extern int signal_handling;
-        extern int call_addr2line;
-        extern int throw_exception;
+        extern AMREX_EXPORT int signal_handling;
+        extern AMREX_EXPORT int call_addr2line;
+        extern AMREX_EXPORT int throw_exception;
 
-        extern int regtest_reduction;
+        extern AMREX_EXPORT int regtest_reduction;
 
-        extern std::ostream* osout;
-        extern std::ostream* oserr;
+        extern AMREX_EXPORT std::ostream* osout;
+        extern AMREX_EXPORT std::ostream* oserr;
 
-        extern ErrorHandler error_handler;
-        extern int abort_on_unused_inputs;
+        extern AMREX_EXPORT ErrorHandler error_handler;
+        extern AMREX_EXPORT int abort_on_unused_inputs;
     }
 
     std::string Version ();

--- a/Src/Base/AMReX_Extension.H
+++ b/Src/Base/AMReX_Extension.H
@@ -139,6 +139,22 @@
 #define AMREX_ATTRIBUTE_WEAK __attribute__((weak))
 #endif
 
+// public globals
+// https://stackoverflow.com/questions/54560832/cmake-windows-export-all-symbols-does-not-cover-global-variables/54568678#54568678
+#if defined(_MSC_VER)
+#   if defined(AMREX_IS_DLL)
+#       if defined(AMREX_IS_DLL_BUILDING)
+#           define AMREX_EXPORT __declspec(dllexport)
+#       else
+#           define AMREX_EXPORT __declspec(dllimport)
+#       endif
+#   else
+#       define AMREX_EXPORT
+#   endif
+#else
+#   define AMREX_EXPORT
+#endif
+
 #if defined(__cplusplus) && defined(_WIN32)
 #include <ciso646>
 #endif

--- a/Src/Base/AMReX_MFIter.H
+++ b/Src/Base/AMReX_MFIter.H
@@ -5,6 +5,7 @@
 #include <memory>
 
 #include <AMReX_Arena.H>
+#include <AMReX_Extension.H>
 #include <AMReX_FabArrayBase.H>
 #include <AMReX_IntVect.H>
 #include <AMReX_FArrayBox.H>
@@ -204,9 +205,9 @@ protected:
     std::unique_ptr<Gpu::FuseSafeGuard> gpu_fsg;
 #endif
 
-    static int nextDynamicIndex;
-    static int depth;
-    static int allow_multiple_mfiters;
+    static AMREX_EXPORT int nextDynamicIndex;
+    static AMREX_EXPORT int depth;
+    static AMREX_EXPORT int allow_multiple_mfiters;
 
     void Initialize ();
 };

--- a/Src/Base/AMReX_ParallelContext.H
+++ b/Src/Base/AMReX_ParallelContext.H
@@ -2,11 +2,12 @@
 #define AMREX_PARALLELCONTEXT_H
 #include <AMReX_Config.H>
 
-#include <memory>
-#include <fstream>
-
+#include <AMReX_Extension.H>
 #include <AMReX_Vector.H>
 #include <AMReX_ccse-mpi.H>
+
+#include <memory>
+#include <fstream>
 
 namespace amrex {
 namespace ParallelContext {
@@ -47,7 +48,7 @@ private:
     std::unique_ptr<std::ofstream> m_out;
 };
 
-extern Vector<Frame> frames; //!< stack of communicator frames
+extern AMREX_EXPORT Vector<Frame> frames; //!< stack of communicator frames
 
 //! world communicator
 inline MPI_Comm CommunicatorAll () noexcept { return frames[0].comm; }

--- a/Src/Base/AMReX_ParallelDescriptor.H
+++ b/Src/Base/AMReX_ParallelDescriptor.H
@@ -7,6 +7,7 @@
 #include <AMReX_BLBackTrace.H>
 #include <AMReX_BLProfiler.H>
 #include <AMReX_BLassert.H>
+#include <AMReX_Extension.H>
 #include <AMReX_INT.H>
 #include <AMReX_REAL.H>
 #include <AMReX_Array.H>
@@ -112,7 +113,7 @@ while ( false )
     void Initialize ();
     void Finalize ();
 
-    extern int use_gpu_aware_mpi;
+    extern AMREX_EXPORT int use_gpu_aware_mpi;
     inline bool UseGpuAwareMpi () { return use_gpu_aware_mpi; }
 
     //! Split the process pool into teams
@@ -205,13 +206,13 @@ while ( false )
         MPI_Comm  m_lead_comm;
     };
 
-    extern ProcessTeam m_Team;
+    extern AMREX_EXPORT ProcessTeam m_Team;
 
-    extern int m_MinTag, m_MaxTag;
+    extern AMREX_EXPORT int m_MinTag, m_MaxTag;
     inline int MinTag () noexcept { return m_MinTag; }
     inline int MaxTag () noexcept { return m_MaxTag; }
 
-    extern MPI_Comm m_comm;
+    extern AMREX_EXPORT MPI_Comm m_comm;
     inline MPI_Comm Communicator () noexcept { return m_comm; }
 
     //! return the number of MPI ranks local to the current Parallel Context
@@ -237,7 +238,7 @@ while ( false )
     * \brief The MPI rank number of the I/O Processor (probably rank 0).
     * This rank is usually used to write to stdout.
     */
-    extern const int ioProcessor;
+    extern AMREX_EXPORT const int ioProcessor;
     inline int
     IOProcessorNumber () noexcept
     {

--- a/Src/Base/AMReX_VisMF.H
+++ b/Src/Base/AMReX_VisMF.H
@@ -11,6 +11,7 @@
 #include <cstdint>
 #include <queue>
 
+#include <AMReX_Extension.H>
 #include <AMReX_REAL.H>
 #include <AMReX_FabArray.H>
 #include <AMReX_FArrayBox.H>
@@ -347,24 +348,24 @@ private:
     * be closed when not needed with CloseAllStreams.
     * ~VisMF also closes them.  [filename, pifs]
     */
-    static std::map<std::string, VisMF::PersistentIFStream> persistentIFStreams;
+    static AMREX_EXPORT std::map<std::string, VisMF::PersistentIFStream> persistentIFStreams;
     //! The number of files to write for a FabArray<FArrayBox>.
-    static int nOutFiles;
-    static int nMFFileInStreams;
+    static AMREX_EXPORT int nOutFiles;
+    static AMREX_EXPORT int nMFFileInStreams;
 
-    static int verbose;
-    static VisMF::Header::Version currentVersion;
-    static bool groupSets;
-    static bool setBuf;
-    static bool useSingleRead;
-    static bool useSingleWrite;
-    static bool checkFilePositions;
-    static bool usePersistentIFStreams;
-    static bool useSynchronousReads;
-    static bool useDynamicSetSelection;
-    static bool allowSparseWrites;
+    static AMREX_EXPORT int verbose;
+    static AMREX_EXPORT VisMF::Header::Version currentVersion;
+    static AMREX_EXPORT bool groupSets;
+    static AMREX_EXPORT bool setBuf;
+    static AMREX_EXPORT bool useSingleRead;
+    static AMREX_EXPORT bool useSingleWrite;
+    static AMREX_EXPORT bool checkFilePositions;
+    static AMREX_EXPORT bool usePersistentIFStreams;
+    static AMREX_EXPORT bool useSynchronousReads;
+    static AMREX_EXPORT bool useDynamicSetSelection;
+    static AMREX_EXPORT bool allowSparseWrites;
 
-    static Long ioBufferSize;   //!< ---- the settable buffer size
+    static AMREX_EXPORT Long ioBufferSize;   //!< ---- the settable buffer size
 };
 
 //! Write a FabOnDisk to an ostream in ASCII.

--- a/Src/EB/AMReX_EBInterpolater.H
+++ b/Src/EB/AMReX_EBInterpolater.H
@@ -2,6 +2,7 @@
 #define AMREX_EBINTERPOLATER_H_
 #include <AMReX_Config.H>
 
+#include <AMReX_Extension.H>
 #include <AMReX_Interpolater.H>
 
 namespace amrex {
@@ -30,8 +31,8 @@ public:
                          RunOn            gpu_or_cpu) override;
 };
 
-extern EBCellConservativeLinear  eb_lincc_interp;
-extern EBCellConservativeLinear  eb_cell_cons_interp;
+extern AMREX_EXPORT EBCellConservativeLinear  eb_lincc_interp;
+extern AMREX_EXPORT EBCellConservativeLinear  eb_cell_cons_interp;
 
 }
 

--- a/Src/Particle/AMReX_ParticleContainerBase.H
+++ b/Src/Particle/AMReX_ParticleContainerBase.H
@@ -2,8 +2,7 @@
 #define AMREX_PARTICLECONTAINERBASE_H_
 #include <AMReX_Config.H>
 
-#include <string>
-
+#include <AMReX_Extension.H>
 #include <AMReX_INT.H>
 #include <AMReX_IntVect.H>
 #include <AMReX_ParGDB.H>
@@ -15,6 +14,8 @@
 #include <AMReX_MultiFab.H>
 #include <AMReX_ParticleLocator.H>
 #include <AMReX_DenseBins.H>
+
+#include <string>
 
 namespace amrex {
 
@@ -196,8 +197,8 @@ public:
     static const std::string& AggregationType ();
     static int AggregationBuffer ();
 
-    static bool do_tiling;
-    static IntVect tile_size;
+    static AMREX_EXPORT bool do_tiling;
+    static AMREX_EXPORT IntVect tile_size;
 
 protected:
 

--- a/Tools/CMake/AMReXSetDefines.cmake
+++ b/Tools/CMake/AMReXSetDefines.cmake
@@ -154,3 +154,12 @@ add_amrex_define(AMREX_USE_HDF5_ASYNC NO_LEGACY IF AMReX_HDF5_ASYNC)
 # Miscellaneous
 #
 add_amrex_define( AMREX_NO_PROBINIT NO_LEGACY IF_NOT AMReX_PROBINIT)
+
+#
+# Windows DLLs and Global Symbols
+# https://stackoverflow.com/questions/54560832/cmake-windows-export-all-symbols-does-not-cover-global-variables/54568678#54568678
+#
+if(WIN32 AND BUILD_SHARED_LIBS)
+  add_amrex_define(AMREX_IS_DLL NO_LEGACY)
+  target_compile_definitions( amrex PRIVATE AMREX_IS_DLL_BUILDING)
+endif()

--- a/Tools/CMake/AMReXTypecheck.cmake
+++ b/Tools/CMake/AMReXTypecheck.cmake
@@ -179,6 +179,7 @@ function( add_typecheck_target _target)
       Fortran_MODULE_DIRECTORY  "${_typecheck_dir}"
       COMPILE_DEFINITIONS       "${_defines}"
       COMPILE_OPTIONS           "${_amrex_flags}"
+      WINDOWS_EXPORT_ALL_SYMBOLS ON
       )
 
    # >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>

--- a/Tools/CMake/AMReX_Config.H.in
+++ b/Tools/CMake/AMReX_Config.H.in
@@ -47,6 +47,7 @@
 #cmakedefine AMREX_USE_HYPRE
 #cmakedefine AMREX_USE_PETSC
 #cmakedefine AMREX_NO_PROBINIT
+#cmakedefine AMREX_IS_DLL
 #ifdef __cplusplus@COMP_DECLS@
 @OMP_DECLS@
 #endif

--- a/Tools/CMake/AMReX_Config.cmake
+++ b/Tools/CMake/AMReX_Config.cmake
@@ -148,30 +148,6 @@ function (configure_amrex)
         WINDOWS_EXPORT_ALL_SYMBOLS ON )
    endif ()
 
-   if ( BUILD_SHARED_LIBS OR AMReX_CUDA )
-      set(host_link_supported OLD)
-      if(CMP0105)
-        cmake_policy(GET CMP0105 host_link_supported)
-      endif()
-
-      if(CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
-        if( host_link_supported STREQUAL "NEW" ) # CMake 3.18+
-          target_link_options(amrex PUBLIC "LINKER:-undefined,dynamic_lookup")
-        else()
-          target_link_options(amrex PUBLIC "-Wl,-undefined,dynamic_lookup")
-        endif()
-      elseif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC" OR
-             CMAKE_CXX_SIMULATE_ID STREQUAL "MSVC")
-        # nothing
-      else()
-        if( host_link_supported STREQUAL "NEW" ) # CMake 3.18+
-          target_link_options(amrex PUBLIC "$<HOST_LINK:LINKER:--warn-unresolved-symbols>")
-        else()
-          target_link_options(amrex PUBLIC "-Wl,--warn-unresolved-symbols")
-        endif()
-      endif()
-   endif()
-
    #
    # Setup third-party profilers
    #

--- a/Tools/GNUMake/tools/Make.sensei
+++ b/Tools/GNUMake/tools/Make.sensei
@@ -1,14 +1,6 @@
 # enable the SENSEI bridge and data adaptor in AMReX
 DEFINES += -DBL_USE_SENSEI_INSITU
 
-# in the GNU Make build system linking error ensue when
-# only using AmrCore because of the externs referenced from
-# Amr. User is expected to provide those functions when using
-# Amr. They will not be found when the user is using AmrCore.
-# tell the linker to treat these missing functions as a warning
-# rather than an error
-CXXFLAGS += -Wl,--warn-unresolved-symbols
-
 # the following environment variables which tell AMReX how
 # to compile and link with SENSEI can be set by running
 #   source sensei_config


### PR DESCRIPTION
## Summary

Add build support, link support and CI coverage for `.dll` builds on Windows.
Remove linker tinkering for weak symbols on Linux & macOS.

## Additional background

- [x] Apply changes from #1852 (remove weak symbols)
- [x] Remove work-around for weak-symbols on macOS #1836
- [x] rebase after #1852 was merged
- [x] add macro to export globals on Windows [[SO]](https://stackoverflow.com/questions/54560832/cmake-windows-export-all-symbols-does-not-cover-global-variables/54568678#54568678)

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
