### PR TITLE
Robin BC in Linear Solver

### DIFF
--- a/Docs/sphinx_documentation/source/LinearSolvers.rst
+++ b/Docs/sphinx_documentation/source/LinearSolvers.rst
@@ -200,10 +200,13 @@ before the solve one must always call the :cpp:`MLLinOp` member function
 
 ::
 
-    virtual void setLevelBC (int amrlev, const MultiFab* levelbcdata) = 0;
+    virtual void setLevelBC (int amrlev, const MultiFab* levelbcdata,
+                             const MultiFab* robinbc_a,
+                             const MultiFab* robinbc_b,
+                             const MultiFab* robinbc_f) = 0;
 
-If we want to supply any inhomogeneous Dirichlet or Neumann boundary
-conditions at the domain boundaries, we must supply those values
+If we want to supply an inhomogeneous Dirichlet, inhomogeneous Neumann, or
+Robin boundary conditions at the domain boundaries, we must supply those values
 in ``MultiFab* levelbcdata``, which must have at least one ghost cell.
 Note that the argument :cpp:`amrlev` is relative to the solve, not
 necessarily the full AMR hierarchy; amrlev = 0 refers to the coarsest

--- a/Src/Boundary/AMReX_LO_BCTYPES.H
+++ b/Src/Boundary/AMReX_LO_BCTYPES.H
@@ -19,6 +19,7 @@
 #define AMREX_LO_SANCHEZ_POMRANING 105
 #define AMREX_LO_INFLOW   106
 #define AMREX_LO_INHOMOG_NEUMANN 107
+#define AMREX_LO_ROBIN 108
 #define AMREX_LO_PERIODIC 200
 #define AMREX_LO_BOGUS    1729
 
@@ -36,6 +37,7 @@ namespace amrex {
         SanchezPomraning = AMREX_LO_SANCHEZ_POMRANING,
         inflow           = AMREX_LO_INFLOW,
         inhomogNeumann   = AMREX_LO_INHOMOG_NEUMANN,
+        Robin            = AMREX_LO_ROBIN,
         Periodic         = AMREX_LO_PERIODIC,
         bogus            = AMREX_LO_BOGUS
     };

--- a/Src/Boundary/AMReX_LO_BCTYPES.cpp
+++ b/Src/Boundary/AMReX_LO_BCTYPES.cpp
@@ -47,6 +47,11 @@ std::ostream& operator<< (std::ostream& os, const LinOpBCType& t)
             os << "inhomogeneous Neumann";
             break;
         }
+        case LinOpBCType::Robin:
+        {
+            os << "Robin";
+            break;
+        }
         case LinOpBCType::Periodic:
         {
             os << "Periodic";

--- a/Src/LinearSolvers/MLMG/AMReX_MLABecLaplacian.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLABecLaplacian.H
@@ -95,6 +95,8 @@ public:
 
     void applyMetricTermsCoeffs ();
 
+    void applyRobinBCTermsCoeffs ();
+
     static void FFlux (Box const& box, Real const* dxinv, Real bscalar,
                        Array<FArrayBox const*, AMREX_SPACEDIM> const& bcoef,
                        Array<FArrayBox*,AMREX_SPACEDIM> const& flux,
@@ -110,6 +112,8 @@ protected:
     Vector<Vector<Array<MultiFab,AMREX_SPACEDIM> > > m_b_coeffs;
 
     Vector<int> m_is_singular;
+
+    virtual bool supportRobinBC () const noexcept override { return true; }
 
 private:
 

--- a/Src/LinearSolvers/MLMG/AMReX_MLABecLaplacian.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLABecLaplacian.cpp
@@ -269,6 +269,33 @@ MLABecLaplacian::applyMetricTermsCoeffs ()
 #endif
 }
 
+//
+// Suppose we are solving `alpha u - del (beta grad u) = rhs` (Scalar
+// coefficients can be easily added back in the end) and there is Robin BC
+// `a u + b du/dn = f` at the upper end of the x-direction.  The 1D
+// discretization at the last cell i is
+//
+//    alpha u_i + (beta_{i-1/2} (du/dx)_{i-1/2} - beta_{i+1/2} (du/dx)_{i+1/2}) / h = rhs_i
+//
+// where h is the cell size.  At `i+1/2` (i.e., the boundary), we have
+//
+//    a (u_i + u_{i+1})/2 + b (u_{i+1}-u_i)/h = f,
+//
+// according to the Robin BC.  This gives
+//
+//    u_{i+1} = A + B u_i,
+//
+// where `A = f/(b/h + a/2)` and `B = (b/h - a/2) / (b/h + a/2).  We then
+// use `u_i` and `u_{i+1}` to compute `(du/dx)_{i+1/2}`.  The discretization
+// at cell i then becomes
+//
+//    \tilde{alpha}_i u_i + (beta_{i-1/2} (du/dx)_{i-1/2} - 0) / h = \tilde{rhs}_i
+//
+// This is equivalent to having homogeneous Neumann BC with modified alpha and rhs.
+//
+//    \tilde{alpha}_i = alpha_i + (1-B) beta_{i+1/2} / h^2
+//    \tilde{rhs}_i = rhs_i + A beta_{i+1/2} / h^2
+//
 void
 MLABecLaplacian::applyRobinBCTermsCoeffs ()
 {

--- a/Src/LinearSolvers/MLMG/AMReX_MLCellABecLap.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLCellABecLap.H
@@ -73,6 +73,8 @@ public:
 
 protected:
     Vector<Vector<std::unique_ptr<iMultiFab> > > m_overset_mask;
+
+    virtual bool supportInhomogNeumannBC () const noexcept override { return true; }
 };
 
 }

--- a/Src/LinearSolvers/MLMG/AMReX_MLCellABecLap.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLCellABecLap.cpp
@@ -326,6 +326,8 @@ MLCellABecLap::applyInhomogNeumannTerm (int amrlev, MultiFab& rhs) const
                 }
 
                 if (has_robin) {
+                    // For Robin BC, see comments in AMReX_MLABecLaplacian.cpp above
+                    // function applyRobinBCTermsCoeffs.
                     Array4<Real const> const& rbc = (*m_robin_bcval[amrlev])[mfi].const_array(icomp*3);
                     if (m_lobc_orig[icomp][idim] == LinOpBCType::Robin && outside_domain_lo)
                     {

--- a/Src/LinearSolvers/MLMG/AMReX_MLCellABecLap.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLCellABecLap.cpp
@@ -174,23 +174,12 @@ MLCellABecLap::getFluxes (const Vector<Array<MultiFab*,AMREX_SPACEDIM> >& a_flux
 void
 MLCellABecLap::applyInhomogNeumannTerm (int amrlev, MultiFab& rhs) const
 {
-    int ncomp = rhs.nComp();
-    bool has_inhomog_neumann = false;
-    for (int n = 0; n < ncomp; ++n)
-    {
-        auto itlo = std::find(m_lo_inhomog_neumann[n].begin(),
-                              m_lo_inhomog_neumann[n].end(),   1);
-        auto ithi = std::find(m_hi_inhomog_neumann[n].begin(),
-                              m_hi_inhomog_neumann[n].end(),   1);
-        if (itlo != m_lo_inhomog_neumann[n].end() ||
-            ithi != m_hi_inhomog_neumann[n].end())
-        {
-            has_inhomog_neumann = true;
-        }
-    }
+    bool has_inhomog_neumann = hasInhomogNeumannBC();
+    bool has_robin = hasRobinBC();
 
-    if (!has_inhomog_neumann) return;
+    if (!has_inhomog_neumann && !has_robin) return;
 
+    int ncomp = getNComp();
     const int mglev = 0;
 
     const auto problo = m_geom[amrlev][mglev].ProbLoArray();
@@ -228,7 +217,8 @@ MLCellABecLap::applyInhomogNeumannTerm (int amrlev, MultiFab& rhs) const
 
         for (int idim = 0; idim < AMREX_SPACEDIM; ++idim)
         {
-            Array4<Real const> const bfab = (has_bcoef) ? bcoef[idim]->array(mfi) : foo.array();
+            Array4<Real const> const bfab = (has_bcoef)
+                ? bcoef[idim]->const_array(mfi) : foo.const_array();
             const Orientation olo(idim,Orientation::low);
             const Orientation ohi(idim,Orientation::high);
             const Box blo = amrex::adjCellLo(vbx, idim);
@@ -245,7 +235,7 @@ MLCellABecLap::applyInhomogNeumannTerm (int amrlev, MultiFab& rhs) const
                 const BoundCond bcthi = bdcv[icomp][ohi];
                 const Real bcllo = bdlv[icomp][olo];
                 const Real bclhi = bdlv[icomp][ohi];
-                if (m_lo_inhomog_neumann[icomp][idim] && outside_domain_lo)
+                if (m_lobc_orig[icomp][idim] == LinOpBCType::inhomogNeumann && outside_domain_lo)
                 {
                     if (idim == 0) {
                         Real fac = beta*dxi;
@@ -290,7 +280,7 @@ MLCellABecLap::applyInhomogNeumannTerm (int amrlev, MultiFab& rhs) const
                         });
                     }
                 }
-                if (m_hi_inhomog_neumann[icomp][idim] && outside_domain_hi)
+                if (m_hibc_orig[icomp][idim] == LinOpBCType::inhomogNeumann && outside_domain_hi)
                 {
                     if (idim == 0) {
                         Real fac = beta*dxi;
@@ -335,6 +325,65 @@ MLCellABecLap::applyInhomogNeumannTerm (int amrlev, MultiFab& rhs) const
                     }
                 }
 
+                if (has_robin) {
+                    Array4<Real const> const& rbc = (*m_robin_bcval[amrlev])[mfi].const_array(icomp*3);
+                    if (m_lobc_orig[icomp][idim] == LinOpBCType::Robin && outside_domain_lo)
+                    {
+                        if (idim == 0) {
+                            Real fac = beta*dxi*dxi;
+                            AMREX_HOST_DEVICE_FOR_3D(blo, i, j, k,
+                            {
+                                Real A = rbc(i,j,k,2)
+                                    / (rbc(i,j,k,1)*dxi + rbc(i,j,k,0)*Real(0.5));
+                                rhsfab(i+1,j,k,icomp) += fac*bfab(i+1,j,k,icomp)*A;
+                            });
+                        } else if (idim == 1) {
+                            Real fac = beta*dyi*dyi;
+                            AMREX_HOST_DEVICE_FOR_3D(blo, i, j, k,
+                            {
+                                Real A = rbc(i,j,k,2)
+                                    / (rbc(i,j,k,1)*dyi + rbc(i,j,k,0)*Real(0.5));
+                                rhsfab(i,j+1,k,icomp) += fac*bfab(i,j+1,k,icomp)*A;
+                            });
+                        } else {
+                            Real fac = beta*dzi*dzi;
+                            AMREX_HOST_DEVICE_FOR_3D(blo, i, j, k,
+                            {
+                                Real A = rbc(i,j,k,2)
+                                    / (rbc(i,j,k,1)*dzi + rbc(i,j,k,0)*Real(0.5));
+                                rhsfab(i,j,k+1,icomp) += fac*bfab(i,j,k+1,icomp)*A;
+                            });
+                        }
+                    }
+                    if (m_hibc_orig[icomp][idim] == LinOpBCType::Robin && outside_domain_hi)
+                    {
+                        if (idim == 0) {
+                            Real fac = beta*dxi*dxi;
+                            AMREX_HOST_DEVICE_FOR_3D(bhi, i, j, k,
+                            {
+                                Real A = rbc(i,j,k,2)
+                                    / (rbc(i,j,k,1)*dxi + rbc(i,j,k,0)*Real(0.5));
+                                rhsfab(i-1,j,k,icomp) += fac*bfab(i,j,k,icomp)*A;
+                            });
+                        } else if (idim == 1) {
+                            Real fac = beta*dyi*dyi;
+                            AMREX_HOST_DEVICE_FOR_3D(bhi, i, j, k,
+                            {
+                                Real A = rbc(i,j,k,2)
+                                    / (rbc(i,j,k,1)*dyi + rbc(i,j,k,0)*Real(0.5));
+                                rhsfab(i,j-1,k,icomp) += fac*bfab(i,j,k,icomp)*A;
+                            });
+                        } else {
+                            Real fac = beta*dzi*dzi;
+                            AMREX_HOST_DEVICE_FOR_3D(bhi, i, j, k,
+                            {
+                                Real A = rbc(i,j,k,2)
+                                    / (rbc(i,j,k,1)*dzi + rbc(i,j,k,0)*Real(0.5));
+                                rhsfab(i,j,k-1,icomp) += fac*bfab(i,j,k,icomp)*A;
+                            });
+                        }
+                    }
+                }
             }
         }
 

--- a/Src/LinearSolvers/MLMG/AMReX_MLCellLinOp.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLCellLinOp.H
@@ -28,7 +28,10 @@ public:
                  const LPInfo& a_info = LPInfo(),
                  const Vector<FabFactory<FArrayBox> const*>& a_factory = {});
 
-    virtual void setLevelBC (int amrlev, const MultiFab* levelbcdata) final override;
+    virtual void setLevelBC (int amrlev, const MultiFab* levelbcdata,
+                             const MultiFab* robinbc_a = nullptr,
+                             const MultiFab* robinbc_b = nullptr,
+                             const MultiFab* robinbc_f = nullptr) final override;
 
     virtual bool needsUpdate () const override {
         return MLLinOp::needsUpdate();
@@ -198,6 +201,8 @@ protected:
         int m_ncomp;
     };
     Vector<Vector<std::unique_ptr<BndryCondLoc> > > m_bcondloc;
+
+    Vector<std::unique_ptr<MultiFab> > m_robin_bcval;
 
     // used to save interpolation coefficients of the first interior cells
     mutable Vector<Vector<BndryRegister> > m_undrrelxr;

--- a/Src/LinearSolvers/MLMG/AMReX_MLLinOp.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLLinOp.H
@@ -154,21 +154,25 @@ public:
     void setCoarseFineBC (const MultiFab* crse, int crse_ratio) noexcept;
 
     /**
-    * \brief For cell-centered solves only: this must be called for each level.
-    * Argument `levelbcdata` is * used to supply Dirichlet or Neumann bc at the
-    * physical domain; if those data are homogeneous we can pass nullptr instead
-    * of levelbcdata.  Regardless, this function must be called.
-    * If used, the MultiFab levelbcdata must have one ghost cell.
-    * Only the data outside the physical domain at Dirichlet or
-    * inhomogeneous Neumann boundary will be used.  It is assumed that
-    * the data in those ghost cells outside the domain live exactly on
-    * the face of the physical domain.  Argument `amrlev` is relative
-    * level such that the lowest to the solver is always 0.
-    *
-    * \param amrlev
-    * \param levelbcdata
+    * \brief For cell-centered solves only: this must be called for each
+    * level.  Argument `levelbcdata` is used to supply Dirichlet or Neumann
+    * bc at the physical domain; if those data are homogeneous we can pass
+    * nullptr instead of levelbcdata.  Regardless, this function must be
+    * called.  If used, the MultiFab levelbcdata must have one ghost cell.
+    * Only the data outside the physical domain will be used.  It is assumed
+    * that the data in those ghost cells outside the domain live exactly on
+    * the face of the physical domain.  Argument `amrlev` is relative level
+    * such that the lowest to the solver is always 0.  The optional
+    * arguments robinbc_[a|b|f] provide Robin boundary condition `a*phi +
+    * b*dphi/dn = f`.  Note that `d./dn` is `d./dx` at the upper boundary
+    * and `-d./dx` at the lower boundary, for Robin BC. However, for
+    * inhomogeneous Neumann BC, the value in leveldata is assumed to be
+    * `d./dx`.
     */
-    virtual void setLevelBC (int amrlev, const MultiFab* levelbcdata) = 0;
+    virtual void setLevelBC (int amrlev, const MultiFab* levelbcdata,
+                             const MultiFab* robinbc_a = nullptr,
+                             const MultiFab* robinbc_b = nullptr,
+                             const MultiFab* robinbc_f = nullptr) = 0;
 
     void setVerbose (int v) noexcept { verbose = v; }
 
@@ -323,8 +327,10 @@ protected:
     // BC
     Vector<Array<BCType, AMREX_SPACEDIM> > m_lobc;
     Vector<Array<BCType, AMREX_SPACEDIM> > m_hibc;
-    Vector<Array<int, AMREX_SPACEDIM> > m_lo_inhomog_neumann;
-    Vector<Array<int, AMREX_SPACEDIM> > m_hi_inhomog_neumann;
+    // Need to save the original copy because we change the BC type to
+    // Neumann for inhomogeneous Neumann and Robin.
+    Vector<Array<BCType, AMREX_SPACEDIM> > m_lobc_orig;
+    Vector<Array<BCType, AMREX_SPACEDIM> > m_hibc_orig;
 
     Array<Real, AMREX_SPACEDIM> m_domain_bloc_lo {{AMREX_D_DECL(0.,0.,0.)}};
     Array<Real, AMREX_SPACEDIM> m_domain_bloc_hi {{AMREX_D_DECL(0.,0.,0.)}};
@@ -357,6 +363,12 @@ protected:
                                                              m_hibc[icomp][1],
                                                              m_hibc[icomp][2])}};
     }
+
+    bool hasInhomogNeumannBC () const noexcept;
+    bool hasRobinBC () const noexcept;
+
+    virtual bool supportRobinBC () const noexcept { return false; }
+    virtual bool supportInhomogNeumannBC () const noexcept { return false; }
 
 #ifdef BL_USE_MPI
     bool isBottomActive () const noexcept { return m_bottom_comm != MPI_COMM_NULL; }

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLinOp.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLinOp.H
@@ -35,7 +35,9 @@ public:
                  const LPInfo& a_info = LPInfo(),
                  const Vector<FabFactory<FArrayBox> const*>& a_factory = {});
 
-    virtual void setLevelBC (int /*amrlev*/, const MultiFab* /*levelbcdata*/) final override {}
+    virtual void setLevelBC (int /*amrlev*/, const MultiFab* /*levelbcdata*/,
+                             const MultiFab* = nullptr, const MultiFab* = nullptr,
+                             const MultiFab* = nullptr) final override {}
 
     virtual void apply (int amrlev, int mglev, MultiFab& out, MultiFab& in, BCMode bc_mode,
                         StateMode s_mode, const MLMGBndry* bndry=nullptr) const final override;

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLinOp.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLinOp.cpp
@@ -159,22 +159,8 @@ MLNodeLinOp::xdoty (int amrlev, int mglev, const MultiFab& x, const MultiFab& y,
 }
 
 void
-MLNodeLinOp::applyInhomogNeumannTerm (int amrlev, MultiFab& rhs) const
+MLNodeLinOp::applyInhomogNeumannTerm (int /*amrlev*/, MultiFab& /*rhs*/) const
 {
-    amrex::ignore_unused(amrlev);
-    int ncomp = rhs.nComp();
-    for (int n = 0; n < ncomp; ++n)
-    {
-        auto itlo = std::find(m_lo_inhomog_neumann[n].begin(),
-                              m_lo_inhomog_neumann[n].end(),   1);
-        auto ithi = std::find(m_hi_inhomog_neumann[n].begin(),
-                              m_hi_inhomog_neumann[n].end(),   1);
-        if (itlo != m_lo_inhomog_neumann[n].end() ||
-            ithi != m_hi_inhomog_neumann[n].end())
-        {
-            amrex::Abort("Inhomogeneous Neumann not supported for nodal solver");
-        }
-    }
 }
 
 namespace {


### PR DESCRIPTION
## Summary

Add Robin BC to MLABecLaplacian.  There are two steps for setting up Robin
BC.  The first step is to call setDomainBC, and the second step is to call
setLevelBC, which has been modified to take a, b and f in Robin BC, `a*phi +
b*dphi/dn = f`.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
