### PR TITLE
LevelBld

### DIFF
--- a/Src/Amr/AMReX_Amr.H
+++ b/Src/Amr/AMReX_Amr.H
@@ -40,9 +40,10 @@ class Amr
 
 public:
     //! The constructor.
-    Amr ();
+    Amr (LevelBld* a_levelbld /* One must pass LevelBld* as an argument now*/);
 
-    Amr (const RealBox* rb, int max_level_in, const Vector<int>& n_cell_in, int coord);
+    Amr (const RealBox* rb, int max_level_in, const Vector<int>& n_cell_in, int coord,
+        LevelBld* a_levelbld /* One must pass LevelBld* as an argument now*/);
 
     Amr (const Amr& rhs) = delete;
     Amr& operator= (const Amr& rhs) = delete;

--- a/Src/Amr/AMReX_Amr.cpp
+++ b/Src/Amr/AMReX_Amr.cpp
@@ -204,17 +204,20 @@ Amr::derive (const std::string& name,
     return amr_level[lev]->derive(name,time,ngrow);
 }
 
-Amr::Amr ()
+Amr::Amr (LevelBld* a_levelbld)
     :
-    AmrCore()
+    AmrCore(),
+    levelbld(a_levelbld)
 {
     Initialize();
     InitAmr();
 }
 
-Amr::Amr (const RealBox* rb, int max_level_in, const Vector<int>& n_cell_in, int coord)
+Amr::Amr (const RealBox* rb, int max_level_in, const Vector<int>& n_cell_in, int coord,
+          LevelBld* a_levelbld)
     :
-    AmrCore(rb,max_level_in,n_cell_in,coord)
+    AmrCore(rb,max_level_in,n_cell_in,coord),
+    levelbld(a_levelbld)
 {
     Initialize();
     InitAmr();
@@ -224,10 +227,8 @@ void
 Amr::InitAmr ()
 {
     BL_PROFILE("Amr::InitAmr()");
-    //
-    // Determine physics class.
-    //
-    levelbld = getLevelBld();
+
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(levelbld != nullptr, "ERROR: levelbld is nullptr");
     //
     // Global function that define state variables.
     //

--- a/Src/Amr/AMReX_LevelBld.H
+++ b/Src/Amr/AMReX_LevelBld.H
@@ -74,6 +74,4 @@ public:
 
 }
 
-extern amrex::LevelBld* getLevelBld () AMREX_ATTRIBUTE_WEAK;
-
 #endif /*_LEVELBLD_H_*/

--- a/Tutorials/Amr/Advection_AmrLevel/Source/main.cpp
+++ b/Tutorials/Amr/Advection_AmrLevel/Source/main.cpp
@@ -10,6 +10,8 @@
 
 using namespace amrex;
 
+amrex::LevelBld* getLevelBld ();
+
 int
 main (int   argc,
       char* argv[])
@@ -43,7 +45,7 @@ main (int   argc,
     }
 
     {
-        Amr amr;
+        Amr amr(getLevelBld());
 
         amr.init(strt_time,stop_time);
 

--- a/Tutorials/EB/CNS/Source/main.cpp
+++ b/Tutorials/EB/CNS/Source/main.cpp
@@ -9,6 +9,7 @@
 
 using namespace amrex;
 
+amrex::LevelBld* getLevelBld ();
 void initialize_EB2 (const Geometry& geom, const int required_level, const int max_level);
 
 int main (int argc, char* argv[])
@@ -48,7 +49,7 @@ int main (int argc, char* argv[])
     {
         timer_init = amrex::second();
 
-        Amr amr;
+        Amr amr(getLevelBld());
         AmrLevel::SetEBSupportLevel(EBSupport::full);
         AmrLevel::SetEBMaxGrowCells(CNS::numGrow(),4,2);
 

--- a/Tutorials/GPU/CNS/Source/main.cpp
+++ b/Tutorials/GPU/CNS/Source/main.cpp
@@ -8,6 +8,8 @@
 
 using namespace amrex;
 
+amrex::LevelBld* getLevelBld ();
+
 int main (int argc, char* argv[])
 {
     amrex::Initialize(argc,argv);
@@ -45,7 +47,7 @@ int main (int argc, char* argv[])
     {
         timer_init = amrex::second();
 
-        Amr amr;
+        Amr amr(getLevelBld());
         amr.init(strt_time,stop_time);
 
         timer_init = amrex::second() - timer_init;

--- a/Tutorials/GPU/EBCNS/Source/main.cpp
+++ b/Tutorials/GPU/EBCNS/Source/main.cpp
@@ -9,6 +9,7 @@
 
 using namespace amrex;
 
+amrex::LevelBld* getLevelBld ();
 void initialize_EB2 (const Geometry& geom, const int required_level, const int max_level);
 
 int main (int argc, char* argv[])
@@ -48,7 +49,7 @@ int main (int argc, char* argv[])
     {
         timer_init = amrex::second();
 
-        Amr amr;
+        Amr amr(getLevelBld());
         AmrLevel::SetEBSupportLevel(EBSupport::full);
         AmrLevel::SetEBMaxGrowCells(CNS::numGrow(),4,2);
 


### PR DESCRIPTION
In Amr class, we need to get LevelBld* and use it to build AmrLevels.
Previously, Amr called a function `LevelBld* getLevelBld()` to get that.
The problem was that `getLevelBld` was not defined by amrex but it was being
called by amrex.  This caused issues in building amrex as a shared library
on Mac and Windows, because they do not support weak symbols.

In this PR, the constructors of Amr now take `LevelBld*` as an argument.
This is unfortunately a breaking change.  However, it's a compile time
failure and it's easy to fix.

The following codes need updates:
- [x] IAMR
- [x] PeleC
- [x] Castro
- [x] Nyx