### PR TITLE
Include missing library 'pthread' for linking to amrex library

### DIFF
--- a/Tutorials/Basic/Build_with_libamrex/GNUmakefile
+++ b/Tutorials/Basic/Build_with_libamrex/GNUmakefile
@@ -13,6 +13,7 @@ LDFLAGS = -L$(AMREX_INSTALL_DIR)/lib
 
 LIBRARIES = -lamrex
 
+LIBRARIES += -lpthread
 LIBRARIES += -lgfortran
 #LIBRARIES += -lifcore
 


### PR DESCRIPTION
- [HOTFIX ] Include missing library 'pthread' for linking to amrex library in the tutorial 'Basic/Build_with_libamrex'