### PR TITLE
Replace is_pod with is_standard_layout && is_trivial

### DIFF
--- a/Src/Base/AMReX_GpuAsyncArray.H
+++ b/Src/Base/AMReX_GpuAsyncArray.H
@@ -44,7 +44,7 @@ public:
 #endif
     }
 
-    template <typename U = T, typename std::enable_if<std::is_pod<U>::value,int>::type = 0>
+    template <typename U = T, typename std::enable_if<std::is_standard_layout<U>::value && std::is_trivial<U>::value,int>::type = 0>
     explicit AsyncArray (const std::size_t n)
     {
         if (n == 0) return;


### PR DESCRIPTION
## Summary

[`std::is_pod`](https://en.cppreference.com/w/cpp/types/is_pod) is deprecated in C++20 and should be replaced by `std::is_standard_layout && std::is_trivial`.
This is the only occurence of `std::is_pod` that I found in AMReX.

If unchanged, this will trigger warnings in future compilers.

## Additional background

This triggered a warning in our internal CI when using gcc 10.2 and the `-std=c++20` option.

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
