### PR TITLE
Arena Release Threshold

### DIFF
--- a/Src/Base/AMReX_Arena.H
+++ b/Src/Base/AMReX_Arena.H
@@ -5,6 +5,7 @@
 #include <AMReX_BLassert.H>
 #include <cstddef>
 #include <cstdlib>
+#include <limits>
 
 namespace amrex {
 
@@ -33,11 +34,16 @@ Arena* The_Cpu_Arena ();
 
 struct ArenaInfo
 {
+    Long release_threshold = std::numeric_limits<Long>::max();
     bool use_cpu_memory = false;
     bool device_use_managed_memory = true;
     bool device_set_readonly = false;
     bool device_set_preferred = false;
     bool device_use_hostalloc = false;
+    ArenaInfo& SetReleaseThreshold (Long rt) noexcept {
+        release_threshold = rt;
+        return *this;
+    }
     ArenaInfo& SetDeviceMemory () noexcept {
         device_use_managed_memory = false;
         device_use_hostalloc = false;
@@ -64,14 +70,14 @@ struct ArenaInfo
         device_set_readonly = false;
         device_set_preferred = false;
         device_use_hostalloc = false;
-        return *this; 
+        return *this;
     }
 };
 
 /**
-* \brief 
+* \brief
 * A virtual base class for objects that manage their own dynamic
-* memory allocation.  
+* memory allocation.
 */
 
 class Arena

--- a/Src/Base/AMReX_Arena.cpp
+++ b/Src/Base/AMReX_Arena.cpp
@@ -39,7 +39,11 @@ namespace {
     bool use_buddy_allocator = false;
     Long buddy_allocator_size = 0L;
     Long the_arena_init_size = 0L;
-    Long the_async_arena_release_threshold = -1L;
+    Long the_arena_release_threshold = std::numeric_limits<Long>::max();
+    Long the_device_arena_release_threshold = std::numeric_limits<Long>::max();
+    Long the_managed_arena_release_threshold = std::numeric_limits<Long>::max();
+    Long the_pinned_arena_release_threshold = std::numeric_limits<Long>::max();
+    Long the_async_arena_release_threshold = std::numeric_limits<Long>::max();
 #ifdef AMREX_USE_HIP
     bool the_arena_is_managed = false; // xxxxx HIP FIX HERE
 #else
@@ -216,25 +220,33 @@ Arena::Initialize ()
     BL_ASSERT(the_pinned_arena == nullptr);
     BL_ASSERT(the_cpu_arena == nullptr);
 
+#ifdef AMREX_USE_GPU
+#ifdef AMREX_USE_DPCPP
+    the_arena_init_size = 1024L*1024L*1024L; // xxxxx DPCPP: todo
+    buddy_allocator_size = 1024L*1024L*1024L; // xxxxx DPCPP: todo
+#else
+    the_arena_init_size = Gpu::Device::totalGlobalMem() / 4L * 3L;
+    buddy_allocator_size = Gpu::Device::totalGlobalMem() / 4L * 3L;
+#endif
+
+    the_pinned_arena_release_threshold = Gpu::Device::totalGlobalMem();
+#endif
+
     ParmParse pp("amrex");
     pp.query("use_buddy_allocator", use_buddy_allocator);
     pp.query("buddy_allocator_size", buddy_allocator_size);
     pp.query("the_arena_init_size", the_arena_init_size);
-    pp.query("the_async_arena_release_threshold", the_async_arena_release_threshold);
+    pp.query(       "the_arena_release_threshold" ,         the_arena_release_threshold);
+    pp.query( "the_device_arena_release_threshold",  the_device_arena_release_threshold);
+    pp.query("the_managed_arena_release_threshold", the_managed_arena_release_threshold);
+    pp.query( "the_pinned_arena_release_threshold",  the_pinned_arena_release_threshold);
+    pp.query(  "the_async_arena_release_threshold",   the_async_arena_release_threshold);
     pp.query("the_arena_is_managed", the_arena_is_managed);
     pp.query("abort_on_out_of_gpu_memory", abort_on_out_of_gpu_memory);
 
 #ifdef AMREX_USE_GPU
     if (use_buddy_allocator)
     {
-        if (buddy_allocator_size <= 0) {
-#ifdef AMREX_USE_DPCPP
-            // buddy_allocator_size = Gpu::Device::maxMemAllocSize() / 4L * 3L;
-            buddy_allocator_size = 1024L*1024L*1024L; // xxxxx DPCPP: todo
-#else
-            buddy_allocator_size = Gpu::Device::totalGlobalMem() / 4L * 3L;
-#endif
-        }
         std::size_t chunk = 512*1024*1024;
         buddy_allocator_size = (buddy_allocator_size/chunk) * chunk;
         if (the_arena_is_managed) {
@@ -247,20 +259,14 @@ Arena::Initialize ()
 #endif
     {
 #if defined(BL_COALESCE_FABS) || defined(AMREX_USE_GPU)
+        ArenaInfo ai{};
+        ai.SetReleaseThreshold(the_arena_release_threshold);
         if (the_arena_is_managed) {
-            the_arena = new CArena(0, ArenaInfo().SetPreferred());
+            the_arena = new CArena(0, ai.SetPreferred());
         } else {
-            the_arena = new CArena(0, ArenaInfo().SetDeviceMemory());
+            the_arena = new CArena(0, ai.SetDeviceMemory());
         }
 #ifdef AMREX_USE_GPU
-        if (the_arena_init_size <= 0) {
-#ifdef AMREX_USE_DPCPP
-//            the_arena_init_size = Gpu::Device::maxMemAllocSize() / 4L * 3L;
-            the_arena_init_size = 1024L*1024L*1024L; // xxxxx DPCPP: todo
-#else
-            the_arena_init_size = Gpu::Device::totalGlobalMem() / 4L * 3L;
-#endif
-        }
         void *p = the_arena->alloc(static_cast<std::size_t>(the_arena_init_size));
         the_arena->free(p);
 #endif
@@ -269,27 +275,23 @@ Arena::Initialize ()
 #endif
     }
 
-    if (the_async_arena_release_threshold < 0) {
-        the_async_arena_release_threshold = std::numeric_limits<Long>::max();
-    }
-
     the_async_arena = new PArena(the_async_arena_release_threshold);
 
 #ifdef AMREX_USE_GPU
-    the_device_arena = new CArena(0, ArenaInfo().SetDeviceMemory());
+    the_device_arena = new CArena(0, ArenaInfo().SetDeviceMemory().SetReleaseThreshold(the_device_arena_release_threshold));
 #else
     the_device_arena = new BArena;
 #endif
 
 #ifdef AMREX_USE_GPU
-    the_managed_arena = new CArena;
+    the_managed_arena = new CArena(0, ArenaInfo().SetReleaseThreshold(the_managed_arena_release_threshold));
 #else
     the_managed_arena = new BArena;
 #endif
 
     // When USE_CUDA=FALSE, we call mlock to pin the cpu memory.
     // When USE_CUDA=TRUE, we call cudaHostAlloc to pin the host memory.
-    the_pinned_arena = new CArena(0, ArenaInfo().SetHostAlloc());
+    the_pinned_arena = new CArena(0, ArenaInfo().SetHostAlloc().SetReleaseThreshold(the_pinned_arena_release_threshold));
 
     std::size_t N = 1024UL*1024UL*8UL;
 
@@ -360,7 +362,7 @@ Arena::PrintUsage ()
         }
     }
 }
-    
+
 void
 Arena::Finalize ()
 {
@@ -371,28 +373,28 @@ Arena::Finalize ()
 #endif
         PrintUsage();
     }
-    
+
     initialized = false;
-    
+
     delete the_arena;
     the_arena = nullptr;
-    
+
     delete the_async_arena;
     the_async_arena = nullptr;
 
     delete the_device_arena;
     the_device_arena = nullptr;
-    
+
     delete the_managed_arena;
     the_managed_arena = nullptr;
-    
+
     delete the_pinned_arena;
     the_pinned_arena = nullptr;
 
     delete the_cpu_arena;
     the_cpu_arena = nullptr;
 }
-    
+
 Arena*
 The_Arena ()
 {

--- a/Src/Base/AMReX_CArena.H
+++ b/Src/Base/AMReX_CArena.H
@@ -2,6 +2,8 @@
 #define BL_CARENA_H
 #include <AMReX_Config.H>
 
+#include <AMReX_Arena.H>
+
 #include <cstddef>
 #include <set>
 #include <vector>
@@ -9,8 +11,6 @@
 #include <unordered_set>
 #include <functional>
 #include <string>
-
-#include <AMReX_Arena.H>
 
 namespace amrex {
 
@@ -35,7 +35,7 @@ public:
 
     CArena (const CArena& rhs) = delete;
     CArena& operator= (const CArena& rhs) = delete;
-    
+
     //! The destructor.
     virtual ~CArena () override;
 
@@ -77,7 +77,7 @@ protected:
             return m_block < rhs.m_block;
         }
 
-        //! The equality operator. 
+        //! The equality operator.
         bool operator== (const Node& rhs) const noexcept
         {
             return m_block == rhs.m_block;

--- a/Src/Base/AMReX_DArena.H
+++ b/Src/Base/AMReX_DArena.H
@@ -2,13 +2,13 @@
 #define AMREX_D_ARENA_H_
 #include <AMReX_Config.H>
 
+#include <AMReX_Arena.H>
+
 #include <cstddef>
 #include <unordered_set>
 #include <unordered_map>
 #include <array>
 #include <mutex>
-
-#include <AMReX_Arena.H>
 
 namespace amrex {
 

--- a/Src/Base/AMReX_DArena.cpp
+++ b/Src/Base/AMReX_DArena.cpp
@@ -1,12 +1,12 @@
 
-#include <cstdlib>
-#include <cmath>
-
 #include <AMReX_DArena.H>
 #include <AMReX_BLassert.H>
 #include <AMReX_Gpu.H>
 #include <AMReX_Print.H>
 #include <AMReX.H>
+
+#include <cstdlib>
+#include <cmath>
 
 namespace amrex {
 

--- a/Src/Base/AMReX_EArena.H
+++ b/Src/Base/AMReX_EArena.H
@@ -2,6 +2,8 @@
 #define AMREX_EARENA_H_
 #include <AMReX_Config.H>
 
+#include <AMReX_Arena.H>
+
 #include <cstddef>
 #include <cstdint>
 #include <limits>
@@ -11,12 +13,10 @@
 #include <unordered_set>
 #include <functional>
 
-#include <AMReX_Arena.H>
-
 namespace amrex {
 
 /**
-* \brief A Concrete Class for Dynamic Memory Management using best fit. 
+* \brief A Concrete Class for Dynamic Memory Management using best fit.
 * This is a coalescing memory manager.  It allocates (possibly) large
 * chunks of heap space and apportions it out as requested.  It merges
 * together neighboring chunks on each free().

--- a/Src/Base/AMReX_EArena.cpp
+++ b/Src/Base/AMReX_EArena.cpp
@@ -1,10 +1,10 @@
 
-#include <utility>
-#include <cstring>
-
 #include <AMReX_EArena.H>
 #include <AMReX_BLassert.H>
 #include <AMReX_Gpu.H>
+
+#include <utility>
+#include <cstring>
 
 namespace amrex {
 
@@ -119,7 +119,7 @@ EArena::free (void* vp)
             }
         }
     }
-    
+
     auto hi_it = mit;
     ++hi_it;
     if (hi_it != m_mergelist.end() && mit->m_owner == hi_it->m_owner)

--- a/Src/Base/AMReX_PArena.cpp
+++ b/Src/Base/AMReX_PArena.cpp
@@ -64,6 +64,8 @@ PArena::alloc (std::size_t nbytes)
 void
 PArena::free (void* p)
 {
+    if (p == nullptr) return;
+
 #if defined(AMREX_USE_GPU)
 
 #ifdef AMREX_CUDA_GE_11_2


### PR DESCRIPTION
## Summary

Release memory from Arena back to the system if it's above a threshold.  For
the pinned arena, the release threshold is set to the size of the global
memory.  For others, it's set to a huge number.  These can be controlled
with ParmParse parameters, `amrex.the_arena_release_threshold` and
`the_[device|pinned|managed|async]_release_threshold`.  The reason for
setting the pinned arena's release threshold to the size of the global
memory is that we received a report in the past that the pinned arena used
by the communication functions wasted a huge amount of memory in the case
that more and more grids were added over the run time.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
