### PR TITLE
The_Device_Arena -> The_Arena

### DIFF
--- a/Src/Base/AMReX_BlockMutex.cpp
+++ b/Src/Base/AMReX_BlockMutex.cpp
@@ -27,12 +27,12 @@ BlockMutex::BlockMutex (int N) noexcept
     // The first 4 bytes of unsigned long stores blockIdx.
     // The second 4 bytes, count.
     // The initial values are -1 and 0.
-    m_state = static_cast<state_t*>(The_Device_Arena()->alloc(sizeof(state_t)*m_nstates));
+    m_state = static_cast<state_t*>(The_Arena()->alloc(sizeof(state_t)*m_nstates));
     init_states(m_state, m_nstates);
 }
 
 BlockMutex::~BlockMutex () {
-    The_Device_Arena()->free(m_state);
+    The_Arena()->free(m_state);
 }
 
 #endif

--- a/Src/Base/AMReX_CudaGraph.H
+++ b/Src/Base/AMReX_CudaGraph.H
@@ -71,10 +71,10 @@ struct CudaGraph
         : m_parms(num)
     {
         static_assert(AMREX_IS_TRIVIALLY_COPYABLE(T), "CudaGraph's T must be trivially copyable");
-        m_parms_d = static_cast<T*>( The_Device_Arena()->alloc(sizeof(T)*m_parms.size()) );
+        m_parms_d = static_cast<T*>( The_Arena()->alloc(sizeof(T)*m_parms.size()) );
     }
     ~CudaGraph() {
-        The_Device_Arena()->free(m_parms_d);
+        The_Arena()->free(m_parms_d);
 
         if (graph_is_ready)
         {
@@ -86,9 +86,9 @@ struct CudaGraph
         m_parms.resize(num);
         if (m_parms_d != nullptr)
         {
-            The_Device_Arena()->free(m_parms_d);
+            The_Arena()->free(m_parms_d);
         }
-        m_parms_d = static_cast<T*>( The_Device_Arena()->alloc(sizeof(T)*m_parms.size()) );
+        m_parms_d = static_cast<T*>( The_Arena()->alloc(sizeof(T)*m_parms.size()) );
     }
     void setGraph(cudaGraphExec_t const& graph) { 
         m_graph = graph;

--- a/Src/Base/AMReX_GpuAllocators.H
+++ b/Src/Base/AMReX_GpuAllocators.H
@@ -128,7 +128,7 @@ namespace amrex {
 	    value_type* result = nullptr;
             if (m_use_gpu_aware_mpi)
             {
-                result = (value_type*) The_Device_Arena()->alloc(n * sizeof(T));
+                result = (value_type*) The_Arena()->alloc(n * sizeof(T));
             }
             else
             {
@@ -141,7 +141,7 @@ namespace amrex {
         {
             if (m_use_gpu_aware_mpi)
             {
-                The_Device_Arena()->free(ptr);
+                The_Arena()->free(ptr);
             }
             else
             {

--- a/Src/Base/AMReX_GpuFuse.cpp
+++ b/Src/Base/AMReX_GpuFuse.cpp
@@ -74,7 +74,7 @@ void Fuser::Launch ()
         std::size_t total_buf_size = offset_objects + sizeof_objects;
 
         char* h_buffer = (char*)The_Pinned_Arena()->alloc(total_buf_size);
-        char* d_buffer = (char*)The_Device_Arena()->alloc(total_buf_size);
+        char* d_buffer = (char*)The_Arena()->alloc(total_buf_size);
 
         std::memcpy(h_buffer, nwarps, sizeof_nwarps);
         std::memcpy(h_buffer+offset_helpers, m_helper_buf, sizeof_helpers);
@@ -178,7 +178,7 @@ void Fuser::Launch ()
         Gpu::synchronize();
         The_Pinned_Arena()->free(nwarps);
         The_Pinned_Arena()->free(h_buffer);
-        The_Device_Arena()->free(d_buffer);
+        The_Arena()->free(d_buffer);
 
         for (int i = 0; i < nlambdas; ++i) {
             char* p = m_lambda_buf + m_helper_buf[i].m_offset;

--- a/Src/Base/AMReX_GpuMemory.H
+++ b/Src/Base/AMReX_GpuMemory.H
@@ -64,7 +64,7 @@ struct DeviceScalar
 
     DeviceScalar () {
         if (Gpu::inLaunchRegion()) {
-            dp = (T*)(The_Device_Arena()->alloc(sizeof(T)));
+            dp = (T*)(The_Arena()->alloc(sizeof(T)));
         } else {
             dp = (T*)(std::malloc(sizeof(T)));
         }
@@ -72,7 +72,7 @@ struct DeviceScalar
 
     explicit DeviceScalar (T init_val) {
         if (Gpu::inLaunchRegion()) {
-            dp = (T*)(The_Device_Arena()->alloc(sizeof(T)));
+            dp = (T*)(The_Arena()->alloc(sizeof(T)));
             Gpu::htod_memcpy(dp, &init_val, sizeof(T));
         } else {
             dp = (T*)(std::malloc(sizeof(T)));
@@ -82,7 +82,7 @@ struct DeviceScalar
 
     ~DeviceScalar () {
         if (Gpu::inLaunchRegion()) {
-            The_Device_Arena()->free(dp);
+            The_Arena()->free(dp);
         } else {
             std::free(dp);
         }

--- a/Src/Base/AMReX_MFIter.H
+++ b/Src/Base/AMReX_MFIter.H
@@ -230,8 +230,6 @@ inline bool isMFIterSafe (const FabArrayBase& x, const FabArrayBase& y) {
         && BoxArray::SameRefs(x.boxArray(), y.boxArray());
 }
 
-inline Arena* The_MFIter_Arena () noexcept { return The_Device_Arena(); }
-
 }
 
 #endif

--- a/Src/Base/AMReX_Reduce.H
+++ b/Src/Base/AMReX_Reduce.H
@@ -217,7 +217,7 @@ public:
     template <typename... Ps>
     explicit ReduceData (ReduceOps<Ps...> const&)
         : m_host_tuple(),
-          m_device_tuple((Type*)(The_Device_Arena()->alloc(2*sizeof(m_host_tuple))))
+          m_device_tuple((Type*)(The_Arena()->alloc(2*sizeof(m_host_tuple))))
     {
         static_assert(AMREX_IS_TRIVIALLY_COPYABLE(Type),
                       "ReduceData::Type must be trivially copyable");
@@ -229,7 +229,7 @@ public:
         Gpu::synchronize();
     }
 
-    ~ReduceData () { The_Device_Arena()->free(m_device_tuple); }
+    ~ReduceData () { The_Arena()->free(m_device_tuple); }
 
     ReduceData (ReduceData<Ts...> const&) = delete;
     ReduceData (ReduceData<Ts...> &&) = delete;
@@ -572,7 +572,7 @@ std::pair<T,T> MinMax (N n, U const* v, MINOP minop, MAXOP maxop)
 {
     Gpu::LaunchSafeGuard lsg(true);
     Array<T,2> hv{std::numeric_limits<T>::max(), std::numeric_limits<T>::lowest()};
-    T* dp = (T*)(The_Device_Arena()->alloc(2*sizeof(T)));
+    T* dp = (T*)(The_Arena()->alloc(2*sizeof(T)));
     Gpu::htod_memcpy_async(dp, hv.data(), 2*sizeof(T));
     typedef GpuArray<T,2> Real2;
     amrex::VecReduce(n, Real2{hv[0],hv[1]},
@@ -595,7 +595,7 @@ std::pair<T,T> MinMax (N n, U const* v, MINOP minop, MAXOP maxop)
     });
 #endif
     Gpu::dtoh_memcpy(hv.data(), dp, 2*sizeof(T));
-    The_Device_Arena()->free(dp);
+    The_Arena()->free(dp);
     return std::make_pair(hv[0],hv[1]);
 }
 

--- a/Src/Base/AMReX_Scan.H
+++ b/Src/Base/AMReX_Scan.H
@@ -180,7 +180,7 @@ T PrefixSum (N n, FIN && fin, FOUT && fout, Type type)
     std::size_t nbytes_blockstatus = Arena::align(sizeof(BlockStatusT)*nblocks);
     std::size_t nbytes_blockid = Arena::align(sizeof(unsigned int));
     std::size_t nbytes_totalsum = Arena::align(sizeof(T));
-    auto dp = (char*)(The_Device_Arena()->alloc(  nbytes_blockstatus
+    auto dp = (char*)(The_Arena()->alloc(  nbytes_blockstatus
                                                 + nbytes_blockid
                                                 + nbytes_totalsum));
     BlockStatusT* AMREX_RESTRICT block_status_p = (BlockStatusT*)dp;
@@ -379,7 +379,7 @@ T PrefixSum (N n, FIN && fin, FOUT && fout, Type type)
     Gpu::dtoh_memcpy_async(&totalsum, totalsum_p, sizeof(T));
     Gpu::streamSynchronize();
 
-    The_Device_Arena()->free(dp);
+    The_Arena()->free(dp);
 
     AMREX_GPU_ERROR_CHECK();
 
@@ -408,7 +408,7 @@ T PrefixSum (N n, FIN && fin, FOUT && fout, Type type)
     std::size_t nbytes_blockstatus = Arena::align(sizeof(BlockStatusT)*nblocks);
     std::size_t nbytes_blockid = Arena::align(sizeof(unsigned int));
     std::size_t nbytes_totalsum = Arena::align(sizeof(T));
-    auto dp = (char*)(The_Device_Arena()->alloc(  nbytes_blockstatus
+    auto dp = (char*)(The_Arena()->alloc(  nbytes_blockstatus
                                                 + nbytes_blockid
                                                 + nbytes_totalsum));
     BlockStatusT* AMREX_RESTRICT block_status_p = (BlockStatusT*)dp;
@@ -618,7 +618,7 @@ T PrefixSum (N n, FIN && fin, FOUT && fout, Type type)
     Gpu::dtoh_memcpy_async(&totalsum, totalsum_p, sizeof(T));
     Gpu::streamSynchronize();
 
-    The_Device_Arena()->free(dp);
+    The_Arena()->free(dp);
 
     AMREX_GPU_ERROR_CHECK();
 


### PR DESCRIPTION
Replace The_Device_Arena with The_Arena in various places.  Using The_Arena
should help reduce the memory footprint.  We used The_Device_Arena in the
early days to avoid the penalty of page fault caused by touching managed
memory on CPU.  We are much better in that regard now.  In fact, AMReX
itself no longer depends on managed memory.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
