### PR TITLE
Free unused memory

### DIFF
--- a/Src/Base/AMReX_Arena.H
+++ b/Src/Base/AMReX_Arena.H
@@ -96,6 +96,12 @@ public:
     */
     virtual void free (void* pt) = 0;
 
+    /**
+    * \brief Free unused memory back to the sytem.  Return value is the
+    * amount memory freed.
+    */
+    virtual std::size_t freeUnused () { return 0; }
+
     // isDeviceAccessible and isHostAccessible can both be true.
     virtual bool isDeviceAccessible () const;
     virtual bool isHostAccessible () const;
@@ -139,6 +145,7 @@ protected:
 
     ArenaInfo arena_info;
 
+    virtual std::size_t freeUnused_protected () { return 0; }
     void* allocate_system (std::size_t nbytes);
     void deallocate_system (void* p, std::size_t nbytes);
 };

--- a/Src/Base/AMReX_Arena.cpp
+++ b/Src/Base/AMReX_Arena.cpp
@@ -138,9 +138,10 @@ Arena::allocate_system (std::size_t nbytes)
     }
     else
     {
-        if (abort_on_out_of_gpu_memory) {
-            std::size_t free_mem_avail = Gpu::Device::freeMemAvailable();
-            if (nbytes >= free_mem_avail) {
+        std::size_t free_mem_avail = Gpu::Device::freeMemAvailable();
+        if (nbytes >= free_mem_avail) {
+            free_mem_avail += freeUnused_protected(); // For CArena, mutex has already acquired
+            if (abort_on_out_of_gpu_memory && nbytes >= free_mem_avail) {
                 amrex::Abort("Out of gpu memory. Free: " + std::to_string(free_mem_avail)
                              + " Asked: " + std::to_string(nbytes));
             }

--- a/Src/Base/AMReX_CArena.H
+++ b/Src/Base/AMReX_CArena.H
@@ -48,6 +48,8 @@ public:
     */
     virtual void free (void* ap) override final;
 
+    virtual std::size_t freeUnused () override final;
+
     //! The current amount of heap space used by the CArena object.
     std::size_t heap_space_used () const noexcept;
 
@@ -63,6 +65,9 @@ public:
     constexpr static std::size_t DefaultHunkSize = 1024*1024*8;
 
 protected:
+
+    virtual std::size_t freeUnused_protected () override final;
+
     //! The nodes in our free list and block list.
     class Node
     {


### PR DESCRIPTION
If Arena is asked to allocate more than what's available in the system, try
to free unused memory first.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
