### PR TITLE
EditorConfig and trailing whitespaces

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,7 +12,7 @@ indent_style = space
 indent_size = 4
 
 # setting it to true would result in too many white changes to amrex
-trim_trailing_whitespace = false
+trim_trailing_whitespace = true
 
 # unix-style newlines
 end_of_line = lf

--- a/.github/workflows/style/check_trailing_whitespaces.sh
+++ b/.github/workflows/style/check_trailing_whitespaces.sh
@@ -11,7 +11,7 @@ find . -type d \( -name .git \
                   -o -name "*.c" -o -name "*.cc" -o -name "*.cpp" -o -name "*.cxx" \
                   -o -name "*.f" -o -name "*.F" -o -name "*.f90" -o -name "*.F90" \
                   -o -name "*.py" \
-                  -o -name "*.md" -o -name "*.rst" \
+                  -o -name "*.rst" \
                   -o -name "*.sh" \
                   -o -name "*.tex" \
                   -o -name "*.txt" \


### PR DESCRIPTION
Trim trailing whitespaces in editorconfig for C/C++ codes and others.

Allow md file to have trailing whitespaces because they are syntactically
significant.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
