### PR TITLE
Fix sign-compare and shadow warnings

### DIFF
--- a/Src/Base/AMReX_NonLocalBC.H
+++ b/Src/Base/AMReX_NonLocalBC.H
@@ -140,7 +140,7 @@ EnableIf_t<IsCallableR<Dim3, DTOS, Dim3>::value && IsCallableR<IndexType, DTOS, 
 Image(DTOS dtos, const Box& box)
 {
     // "Forget" the index type mapping and invoke Image without changing the index type.
-    Box srcbox = Image([&dtos](Dim3 i) { return dtos(i); }, box);
+    Box srcbox = Image([&dtos](Dim3 d) { return dtos(d); }, box);
     // Fix the index type of the resulting box
     srcbox.setType(dtos(box.ixType()));
     return srcbox;

--- a/Src/Particle/AMReX_ParticleCommunication.H
+++ b/Src/Particle/AMReX_ParticleCommunication.H
@@ -528,8 +528,8 @@ void unpackRemotes (PC& pc, const ParticleCopyPlan& plan, Buffer& rcv_buffer, Un
 
         std::vector<int> sizes;
         std::vector<PTile*> tiles;
-        for (int i = 0; i < plan.m_rcv_box_counts.size(); ++i)
-          {
+        for (int i = 0, N = plan.m_rcv_box_counts.size(); i < N; ++i)
+        {
             int copy_size = plan.m_rcv_box_counts[i];
             int lev = plan.m_rcv_box_levs[i];
             int gid = plan.m_rcv_box_ids[i];
@@ -544,8 +544,8 @@ void unpackRemotes (PC& pc, const ParticleCopyPlan& plan, Buffer& rcv_buffer, Un
         Gpu::Device::synchronize();
         int uindex = 0;
         int procindex = 0, rproc = plan.m_rcv_box_pids[0];
-        for (int i = 0; i < plan.m_rcv_box_counts.size(); ++i)
-          {
+        for (int i = 0, N = plan.m_rcv_box_counts.size(); i < N; ++i)
+        {
             int lev = plan.m_rcv_box_levs[i];
             int gid = plan.m_rcv_box_ids[i];
             int tid = 0;
@@ -574,7 +574,7 @@ void unpackRemotes (PC& pc, const ParticleCopyPlan& plan, Buffer& rcv_buffer, Un
               });
 
             Gpu::synchronize();
-          }
+        }
     }
 #else
     amrex::ignore_unused(pc,plan,rcv_buffer,policy);

--- a/Src/Particle/AMReX_ParticleContainerI.H
+++ b/Src/Particle/AMReX_ParticleContainerI.H
@@ -1737,7 +1737,7 @@ RedistributeMPI (std::map<int, Vector<char> >& not_ours,
             const auto offset = rOffset[i];
             const auto Who    = RcvProc[i];
             const auto Cnt = Rcvs[Who] / superparticle_size;
-            for (int j = 0; j < Cnt; ++j)
+            for (auto j = decltype(Cnt)(0); j < Cnt; ++j)
             {
                 int lev = rcv_levs[ipart];
                 std::pair<int, int> ind(std::make_pair(rcv_grid[ipart], rcv_tile[ipart]));


### PR DESCRIPTION
The warning about shadowed varaible in AMReX_NonLocalBC.H seems a compiler
bug.  Nevertheless, the source is modified to get rid of the warning.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
