### PR TITLE
Fix bug with face-centroid slopes when using multigrid

### DIFF
--- a/Src/EB/AMReX_EB_LeastSquares_2D_K.H
+++ b/Src/EB/AMReX_EB_LeastSquares_2D_K.H
@@ -498,6 +498,9 @@ Real grad_x_of_phi_on_centroids_extdir(int i,int j,int k,int n,
               continue;
             }
 
+            if (ii == phi.end.x || jj == phi.end.y)
+               continue;
+
             if (!flag(ii,jj,k).isCovered())
             {
 
@@ -556,6 +559,9 @@ Real grad_x_of_phi_on_centroids_extdir(int i,int j,int k,int n,
         for (int ii = i-im; ii <= i+ip; ii++)  // Normal to face
             for (int jj = j-1; jj <= j+1; jj++)  // Tangential to face
             {
+                if (ii == phi.end.x || jj == phi.end.y)
+                   continue;
+
                 if (!flag(ii,jj,k).isCovered())
                 {
                     int a_ind  = (jj-(j-1)) + 3*(ii-(i-im));
@@ -617,6 +623,9 @@ Real grad_y_of_phi_on_centroids_extdir(int i,int j,int k,int n,
               continue;
             }
 
+            if (ii == phi.end.x || jj == phi.end.y)
+               continue;
+
             if (!flag(ii,jj,k).isCovered())
             {
                 int a_ind  = (ii-(i-1)) + 3*(jj-(j-jm));
@@ -671,7 +680,9 @@ Real grad_y_of_phi_on_centroids_extdir(int i,int j,int k,int n,
         rhs(irow) = 0.; // Only non-zero when inhomogeneous Dirichlet
 
         for (int jj = j-jm; jj <= j+jp; jj++) // Normal to face
-            for (int ii = i-1; ii <= i+1; ii++) // Tangential to face
+            for (int ii = i-1; ii <= i+1; ii++) {// Tangential to face
+                if (ii == phi.end.x || jj == phi.end.y)
+                   continue;
                 if (!flag(ii,jj,k).isCovered())
                 {
                     int a_ind  = (ii-(i-1)) + 3*(jj-(j-jm));
@@ -686,6 +697,7 @@ Real grad_y_of_phi_on_centroids_extdir(int i,int j,int k,int n,
                       rhs(irow) += Amatrix(a_ind+9,irow)*phieb(ii,jj,k,n);
                     }
                 }
+            }
 
     }
 

--- a/Src/EB/AMReX_EB_LeastSquares_2D_K.H
+++ b/Src/EB/AMReX_EB_LeastSquares_2D_K.H
@@ -498,7 +498,7 @@ Real grad_x_of_phi_on_centroids_extdir(int i,int j,int k,int n,
               continue;
             }
 
-            if (ii == phi.end.x || jj == phi.end.y)
+            if ( !phi.contains(ii,jj,k) )
                continue;
 
             if (!flag(ii,jj,k).isCovered())
@@ -559,7 +559,7 @@ Real grad_x_of_phi_on_centroids_extdir(int i,int j,int k,int n,
         for (int ii = i-im; ii <= i+ip; ii++)  // Normal to face
             for (int jj = j-1; jj <= j+1; jj++)  // Tangential to face
             {
-                if (ii == phi.end.x || jj == phi.end.y)
+                if ( !phi.contains(ii,jj,k) )
                    continue;
 
                 if (!flag(ii,jj,k).isCovered())
@@ -623,7 +623,7 @@ Real grad_y_of_phi_on_centroids_extdir(int i,int j,int k,int n,
               continue;
             }
 
-            if (ii == phi.end.x || jj == phi.end.y)
+            if ( !phi.contains(ii,jj,k) )
                continue;
 
             if (!flag(ii,jj,k).isCovered())
@@ -681,7 +681,7 @@ Real grad_y_of_phi_on_centroids_extdir(int i,int j,int k,int n,
 
         for (int jj = j-jm; jj <= j+jp; jj++) // Normal to face
             for (int ii = i-1; ii <= i+1; ii++) {// Tangential to face
-                if (ii == phi.end.x || jj == phi.end.y)
+                if ( !phi.contains(ii,jj,k) )
                    continue;
                 if (!flag(ii,jj,k).isCovered())
                 {
@@ -797,7 +797,9 @@ Real grad_eb_of_phi_on_centroids_extdir(int i,int j,int k,int n,
         rhs(irow) = 0.;
 
         for (int ii = i-1; ii <= i+1; ii++)
-            for (int jj = j-1; jj <= j+1; jj++)
+            for (int jj = j-1; jj <= j+1; jj++) {
+                if ( !phi.contains(ii,jj,k) )
+                   continue;
                 if (!flag(ii,jj,k).isCovered())
                 {
                     int a_ind  = (jj-(j-1)) + 3*(ii-(i-1));
@@ -811,6 +813,7 @@ Real grad_eb_of_phi_on_centroids_extdir(int i,int j,int k,int n,
                     if (flag(ii,jj,k).isSingleValued() && is_eb_inhomog && Amatrix(a_ind+9,irow) != 0.0)
                         rhs(irow) += Amatrix(a_ind+9,irow)*phieb(ii,jj,k,n);
                 }
+            }
     }
 
     cholsol_for_eb(Amatrix, rhs);

--- a/Src/EB/AMReX_EB_LeastSquares_3D_K.H
+++ b/Src/EB/AMReX_EB_LeastSquares_3D_K.H
@@ -692,6 +692,9 @@ Real grad_x_of_phi_on_centroids_extdir(int i,int j,int k,int n,
               continue;
             }
 
+            if (ii == phi.end.x || jj == phi.end.y || kk == phi.end.z)
+               continue;
+
             if (!flag(ii,jj,kk).isCovered())
             {
 
@@ -760,7 +763,9 @@ Real grad_x_of_phi_on_centroids_extdir(int i,int j,int k,int n,
 
         for (int ii = i-im; ii <= i+ip; ii++)  // Normal to face
           for (int kk = k-1; kk <= k+1; kk++)  // Tangential to face
-           for (int jj = j-1; jj <= j+1; jj++) // Tangential to face
+           for (int jj = j-1; jj <= j+1; jj++) { // Tangential to face
+               if (ii == phi.end.x || jj == phi.end.y)
+                  continue;
                if (!flag(ii,jj,kk).isCovered())
                {
                     int a_ind  = (jj-(j-1)) + 3*(kk-(k-1)) + 9*(ii-(i-im));
@@ -771,6 +776,7 @@ Real grad_x_of_phi_on_centroids_extdir(int i,int j,int k,int n,
                     if (flag(ii,jj,kk).isSingleValued() && is_eb_inhomog && Amatrix(a_ind+27,irow) != 0.0)
                         rhs(irow) += Amatrix(a_ind+27,irow)*phieb(ii,jj,kk,n);
                }
+            }
     }
 
     cholsol_for_eb(Amatrix, rhs);
@@ -826,6 +832,9 @@ Real grad_y_of_phi_on_centroids_extdir(int i,int j,int k,int n,
                 ((on_x_face && ii > domhi_x) && (on_z_face && kk > domhi_z))) {
               continue;
             }
+
+            if (ii == phi.end.x || jj == phi.end.y || kk == phi.end.z)
+               continue;
 
             if (!flag(ii,jj,kk).isCovered())
             {
@@ -894,7 +903,9 @@ Real grad_y_of_phi_on_centroids_extdir(int i,int j,int k,int n,
 
         for (int jj = j-jm; jj <= j+jp; jj++) // Normal to face
            for (int kk = k-1; kk <= k+1; kk++)  // Tangential to face
-             for (int ii = i-1; ii <= i+1; ii++) // Tangential to face
+             for (int ii = i-1; ii <= i+1; ii++) {// Tangential to face
+                if (ii == phi.end.x || jj == phi.end.y || kk == phi.end.z)
+                   continue;
                 if (!flag(ii,jj,kk).isCovered())
                 {
                     int a_ind  = (ii-(i-1)) + 3*(kk-(k-1)) + 9*(jj-(j-jm));
@@ -905,6 +916,7 @@ Real grad_y_of_phi_on_centroids_extdir(int i,int j,int k,int n,
                     if (flag(ii,jj,kk).isSingleValued() && is_eb_inhomog && Amatrix(a_ind+27,irow) != 0.0)
                         rhs(irow) += Amatrix(a_ind+27,irow)*phieb(ii,jj,kk,n);
                 }
+             }
     }
 
     cholsol_for_eb(Amatrix, rhs);
@@ -961,6 +973,9 @@ Real grad_z_of_phi_on_centroids_extdir(int i,int j,int k,int n,
                 ((on_x_face && ii > domhi_x) && (on_z_face && kk > domhi_z))) {
               continue;
             }
+
+            if (ii == phi.end.x || jj == phi.end.y || kk == phi.end.z)
+               continue;
 
             if (!flag(ii,jj,kk).isCovered())
             {
@@ -1030,7 +1045,9 @@ Real grad_z_of_phi_on_centroids_extdir(int i,int j,int k,int n,
 
         for (int kk = k-km; kk <= k+kp; kk++) // Normal to face
           for (int jj = j-1; jj <= j+1; jj++)  // Tangential to face
-             for (int ii = i-1; ii <= i+1; ii++) // Tangential to face
+             for (int ii = i-1; ii <= i+1; ii++) {// Tangential to face
+                if (ii == phi.end.x || jj == phi.end.y || kk == phi.end.z)
+                   continue;
                 if (!flag(ii,jj,kk).isCovered())
                 {
                     int a_ind  = (ii-(i-1)) + 3*(jj-(j-1)) + 9*(kk-(k-km));
@@ -1041,6 +1058,7 @@ Real grad_z_of_phi_on_centroids_extdir(int i,int j,int k,int n,
                     if (flag(ii,jj,kk).isSingleValued() && is_eb_inhomog && Amatrix(a_ind+27,irow) != 0.0)
                         rhs(irow) += Amatrix(a_ind+27,irow)*phieb(ii,jj,kk,n);
                 }
+             }
     }
 
     cholsol_for_eb(Amatrix, rhs);

--- a/Src/EB/AMReX_EB_LeastSquares_3D_K.H
+++ b/Src/EB/AMReX_EB_LeastSquares_3D_K.H
@@ -692,7 +692,7 @@ Real grad_x_of_phi_on_centroids_extdir(int i,int j,int k,int n,
               continue;
             }
 
-            if (ii == phi.end.x || jj == phi.end.y || kk == phi.end.z)
+            if ( !phi.contains(ii,jj,kk) )
                continue;
 
             if (!flag(ii,jj,kk).isCovered())
@@ -764,8 +764,9 @@ Real grad_x_of_phi_on_centroids_extdir(int i,int j,int k,int n,
         for (int ii = i-im; ii <= i+ip; ii++)  // Normal to face
           for (int kk = k-1; kk <= k+1; kk++)  // Tangential to face
            for (int jj = j-1; jj <= j+1; jj++) { // Tangential to face
-               if (ii == phi.end.x || jj == phi.end.y)
+               if ( !phi.contains(ii,jj,kk) )
                   continue;
+
                if (!flag(ii,jj,kk).isCovered())
                {
                     int a_ind  = (jj-(j-1)) + 3*(kk-(k-1)) + 9*(ii-(i-im));
@@ -833,7 +834,7 @@ Real grad_y_of_phi_on_centroids_extdir(int i,int j,int k,int n,
               continue;
             }
 
-            if (ii == phi.end.x || jj == phi.end.y || kk == phi.end.z)
+            if ( !phi.contains(ii,jj,kk) )
                continue;
 
             if (!flag(ii,jj,kk).isCovered())
@@ -904,8 +905,9 @@ Real grad_y_of_phi_on_centroids_extdir(int i,int j,int k,int n,
         for (int jj = j-jm; jj <= j+jp; jj++) // Normal to face
            for (int kk = k-1; kk <= k+1; kk++)  // Tangential to face
              for (int ii = i-1; ii <= i+1; ii++) {// Tangential to face
-                if (ii == phi.end.x || jj == phi.end.y || kk == phi.end.z)
+                if ( !phi.contains(ii,jj,kk) )
                    continue;
+
                 if (!flag(ii,jj,kk).isCovered())
                 {
                     int a_ind  = (ii-(i-1)) + 3*(kk-(k-1)) + 9*(jj-(j-jm));
@@ -974,7 +976,7 @@ Real grad_z_of_phi_on_centroids_extdir(int i,int j,int k,int n,
               continue;
             }
 
-            if (ii == phi.end.x || jj == phi.end.y || kk == phi.end.z)
+            if (!phi.contains(ii,jj,kk))
                continue;
 
             if (!flag(ii,jj,kk).isCovered())
@@ -1046,8 +1048,9 @@ Real grad_z_of_phi_on_centroids_extdir(int i,int j,int k,int n,
         for (int kk = k-km; kk <= k+kp; kk++) // Normal to face
           for (int jj = j-1; jj <= j+1; jj++)  // Tangential to face
              for (int ii = i-1; ii <= i+1; ii++) {// Tangential to face
-                if (ii == phi.end.x || jj == phi.end.y || kk == phi.end.z)
+                if ( !phi.contains(ii,jj,kk) )
                    continue;
+
                 if (!flag(ii,jj,kk).isCovered())
                 {
                     int a_ind  = (ii-(i-1)) + 3*(jj-(j-1)) + 9*(kk-(k-km));
@@ -1111,6 +1114,9 @@ Real grad_eb_of_phi_on_centroids_extdir(int i,int j,int k,int n,
                 ((on_x_face && ii > domhi_x) && (on_z_face && kk > domhi_z))) {
               continue;
             }
+
+            if ( !phi.contains(ii,jj,kk) )
+               continue;
 
             if (!flag(ii,jj,kk).isCovered())
             {
@@ -1177,7 +1183,10 @@ Real grad_eb_of_phi_on_centroids_extdir(int i,int j,int k,int n,
 
         for (int kk = k-1; kk <= k+1; kk++)
           for (int jj = j-1; jj <= j+1; jj++)
-             for (int ii = i-1; ii <= i+1; ii++)
+             for (int ii = i-1; ii <= i+1; ii++) {
+                if ( !phi.contains(ii,jj,kk) )
+                  continue;
+
                 if (!flag(ii,jj,kk).isCovered())
                 {
                     int a_ind  = (ii-(i-1)) + 3*(jj-(j-1)) + 9*(kk-(k-1));
@@ -1189,6 +1198,7 @@ Real grad_eb_of_phi_on_centroids_extdir(int i,int j,int k,int n,
                     if (flag(ii,jj,kk).isSingleValued() && is_eb_inhomog && Amatrix(a_ind+27,irow) != 0.0)
                         rhs(irow) += Amatrix(a_ind+27,irow)*phieb(ii,jj,kk,n);
                 }
+             }
     }
 
     cholsol_for_eb(Amatrix, rhs);

--- a/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap.cpp
@@ -187,12 +187,14 @@ MLEBABecLap::setEBDirichlet (int amrlev, const MultiFab& phi, const MultiFab& be
 {
     const int ncomp = getNComp();
     const int beta_ncomp = beta.nComp();
+    bool phi_on_centroid = (m_phi_loc == Location::CellCentroid);
     AMREX_ALWAYS_ASSERT(beta_ncomp == 1 || beta_ncomp == ncomp);
 
     if (m_eb_phi[amrlev] == nullptr) {
         const int mglev = 0;
+        const int ngrow = phi_on_centroid ? 1 : 0;
         m_eb_phi[amrlev].reset(new MultiFab(m_grids[amrlev][mglev], m_dmap[amrlev][mglev],
-                                            ncomp, 0, MFInfo(), *m_factory[amrlev][mglev]));
+                                            ncomp, ngrow, MFInfo(), *m_factory[amrlev][mglev]));
     }
     if (m_eb_b_coeffs[amrlev][0] == nullptr) {
         for (int mglev = 0; mglev < m_num_mg_levels[amrlev]; ++mglev) {
@@ -252,16 +254,21 @@ MLEBABecLap::setEBDirichlet (int amrlev, const MultiFab& phi, const MultiFab& be
             }
         }
     }
+
+    if (phi_on_centroid) 
+      m_eb_phi[amrlev]->FillBoundary(m_geom[amrlev][0].periodicity());
 }
 
 void
 MLEBABecLap::setEBDirichlet (int amrlev, const MultiFab& phi, Real beta)
 {
     const int ncomp = getNComp();
+    bool phi_on_centroid = (m_phi_loc == Location::CellCentroid);
     if (m_eb_phi[amrlev] == nullptr) {
         const int mglev = 0;
+        const int ngrow = phi_on_centroid ? 1 : 0;
         m_eb_phi[amrlev].reset(new MultiFab(m_grids[amrlev][mglev], m_dmap[amrlev][mglev],
-                                            ncomp, 0, MFInfo(), *m_factory[amrlev][mglev]));
+                                            ncomp, ngrow, MFInfo(), *m_factory[amrlev][mglev]));
     }
     if (m_eb_b_coeffs[amrlev][0] == nullptr) {
         for (int mglev = 0; mglev < m_num_mg_levels[amrlev]; ++mglev) {
@@ -307,16 +314,21 @@ MLEBABecLap::setEBDirichlet (int amrlev, const MultiFab& phi, Real beta)
             });
         }
     }
+
+    if (phi_on_centroid) 
+      m_eb_phi[amrlev]->FillBoundary(m_geom[amrlev][0].periodicity());
 }
 
 void
 MLEBABecLap::setEBDirichlet (int amrlev, const MultiFab& phi, Vector<Real> const& hv_beta)
 {
     const int ncomp = getNComp();
+    bool phi_on_centroid = (m_phi_loc == Location::CellCentroid);
     if (m_eb_phi[amrlev] == nullptr) {
         const int mglev = 0;
+        const int ngrow = phi_on_centroid ? 1 : 0;
         m_eb_phi[amrlev].reset(new MultiFab(m_grids[amrlev][mglev], m_dmap[amrlev][mglev],
-                                            ncomp, 0, MFInfo(), *m_factory[amrlev][mglev]));
+                                            ncomp, ngrow, MFInfo(), *m_factory[amrlev][mglev]));
     }
     if (m_eb_b_coeffs[amrlev][0] == nullptr) {
         for (int mglev = 0; mglev < m_num_mg_levels[amrlev]; ++mglev) {
@@ -366,6 +378,9 @@ MLEBABecLap::setEBDirichlet (int amrlev, const MultiFab& phi, Vector<Real> const
             });
         }
     }
+
+    if (phi_on_centroid) 
+      m_eb_phi[amrlev]->FillBoundary(m_geom[amrlev][0].periodicity());
 }
 
 void
@@ -373,11 +388,13 @@ MLEBABecLap::setEBHomogDirichlet (int amrlev, const MultiFab& beta)
 {
     const int ncomp = getNComp();
     const int beta_ncomp = beta.nComp();
+    bool phi_on_centroid = (m_phi_loc == Location::CellCentroid);
     AMREX_ALWAYS_ASSERT(beta_ncomp == 1 || beta_ncomp == ncomp);
     if (m_eb_phi[amrlev] == nullptr) {
         const int mglev = 0;
+        const int ngrow = phi_on_centroid ? 1 : 0;
         m_eb_phi[amrlev].reset(new MultiFab(m_grids[amrlev][mglev], m_dmap[amrlev][mglev],
-                                            ncomp, 0, MFInfo(), *m_factory[amrlev][mglev]));
+                                            ncomp, ngrow, MFInfo(), *m_factory[amrlev][mglev]));
     }
     if (m_eb_b_coeffs[amrlev][0] == nullptr) {
         for (int mglev = 0; mglev < m_num_mg_levels[amrlev]; ++mglev) {
@@ -435,16 +452,21 @@ MLEBABecLap::setEBHomogDirichlet (int amrlev, const MultiFab& beta)
             }
         }
     }
+
+    if (phi_on_centroid) 
+      m_eb_phi[amrlev]->FillBoundary(m_geom[amrlev][0].periodicity());
 }
 
 void
 MLEBABecLap::setEBHomogDirichlet (int amrlev, Real beta)
 {
     const int ncomp = getNComp();
+    bool phi_on_centroid = (m_phi_loc == Location::CellCentroid);
     if (m_eb_phi[amrlev] == nullptr) {
         const int mglev = 0;
+        const int ngrow = phi_on_centroid ? 1 : 0;
         m_eb_phi[amrlev].reset(new MultiFab(m_grids[amrlev][mglev], m_dmap[amrlev][mglev],
-                                            ncomp, 0, MFInfo(), *m_factory[amrlev][mglev]));
+                                            ncomp, ngrow, MFInfo(), *m_factory[amrlev][mglev]));
     }
     if (m_eb_b_coeffs[amrlev][0] == nullptr) {
         for (int mglev = 0; mglev < m_num_mg_levels[amrlev]; ++mglev) {
@@ -490,16 +512,21 @@ MLEBABecLap::setEBHomogDirichlet (int amrlev, Real beta)
             });
         }
     }
+
+    if (phi_on_centroid) 
+      m_eb_phi[amrlev]->FillBoundary(m_geom[amrlev][0].periodicity());
 }
 
 void
 MLEBABecLap::setEBHomogDirichlet (int amrlev, Vector<Real> const& hv_beta)
 {
     const int ncomp = getNComp();
+    bool phi_on_centroid = (m_phi_loc == Location::CellCentroid);
     if (m_eb_phi[amrlev] == nullptr) {
         const int mglev = 0;
+        const int ngrow = phi_on_centroid ? 1 : 0;
         m_eb_phi[amrlev].reset(new MultiFab(m_grids[amrlev][mglev], m_dmap[amrlev][mglev],
-                                            ncomp, 0, MFInfo(), *m_factory[amrlev][mglev]));
+                                            ncomp, ngrow, MFInfo(), *m_factory[amrlev][mglev]));
     }
     if (m_eb_b_coeffs[amrlev][0] == nullptr) {
         for (int mglev = 0; mglev < m_num_mg_levels[amrlev]; ++mglev) {
@@ -549,6 +576,9 @@ MLEBABecLap::setEBHomogDirichlet (int amrlev, Vector<Real> const& hv_beta)
             });
         }
     }
+
+    if (phi_on_centroid) 
+      m_eb_phi[amrlev]->FillBoundary(m_geom[amrlev][0].periodicity());
 }
 
 void

--- a/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap.cpp
@@ -255,7 +255,7 @@ MLEBABecLap::setEBDirichlet (int amrlev, const MultiFab& phi, const MultiFab& be
         }
     }
 
-    if (phi_on_centroid) 
+    if (phi_on_centroid)
       m_eb_phi[amrlev]->FillBoundary(m_geom[amrlev][0].periodicity());
 }
 
@@ -315,7 +315,7 @@ MLEBABecLap::setEBDirichlet (int amrlev, const MultiFab& phi, Real beta)
         }
     }
 
-    if (phi_on_centroid) 
+    if (phi_on_centroid)
       m_eb_phi[amrlev]->FillBoundary(m_geom[amrlev][0].periodicity());
 }
 
@@ -379,7 +379,7 @@ MLEBABecLap::setEBDirichlet (int amrlev, const MultiFab& phi, Vector<Real> const
         }
     }
 
-    if (phi_on_centroid) 
+    if (phi_on_centroid)
       m_eb_phi[amrlev]->FillBoundary(m_geom[amrlev][0].periodicity());
 }
 
@@ -453,7 +453,7 @@ MLEBABecLap::setEBHomogDirichlet (int amrlev, const MultiFab& beta)
         }
     }
 
-    if (phi_on_centroid) 
+    if (phi_on_centroid)
       m_eb_phi[amrlev]->FillBoundary(m_geom[amrlev][0].periodicity());
 }
 
@@ -513,7 +513,7 @@ MLEBABecLap::setEBHomogDirichlet (int amrlev, Real beta)
         }
     }
 
-    if (phi_on_centroid) 
+    if (phi_on_centroid)
       m_eb_phi[amrlev]->FillBoundary(m_geom[amrlev][0].periodicity());
 }
 
@@ -577,7 +577,7 @@ MLEBABecLap::setEBHomogDirichlet (int amrlev, Vector<Real> const& hv_beta)
         }
     }
 
-    if (phi_on_centroid) 
+    if (phi_on_centroid)
       m_eb_phi[amrlev]->FillBoundary(m_geom[amrlev][0].periodicity());
 }
 

--- a/Tests/LinearSolvers/LeastSquares/inputs.2d.askew-x.mg
+++ b/Tests/LinearSolvers/LeastSquares/inputs.2d.askew-x.mg
@@ -1,0 +1,27 @@
+amrex.fpe_trap_invalid = 1
+eb_is_dirichlet = 0
+eb_is_homog_dirichlet = 1
+
+eb2.geom_type = channel
+
+eb2.channel_pt_on_top_wall = 0.0  1.8  0.0
+eb2.channel_height = 1.0
+eb2.channel_rotation = -30.
+eb2.channel_has_fluid_inside = 1
+
+max_level = 0
+ref_ratio = 2
+n_cell = 20
+max_grid_size = 10
+max_coarsening_level = 0
+prob_lo =  0.   0.   0.
+prob_hi = 2.0  2.0   0.
+is_periodic = 0  0  0
+scalars = 0  1
+
+use_poiseuille = 1
+poiseuille_pt_on_top_wall = 0.0  1.8  0.0
+poiseuille_height = 1.0
+poiseuille_rotation = -30.
+
+plot_file = "plot-askew-x-mg"

--- a/Tests/LinearSolvers/LeastSquares/inputs.2d.askew-y.mg
+++ b/Tests/LinearSolvers/LeastSquares/inputs.2d.askew-y.mg
@@ -1,0 +1,35 @@
+amrex.fpe_trap_invalid = 1
+eb_is_dirichlet = 0
+eb_is_homog_dirichlet = 1
+
+eb2.geom_type = channel
+
+eb2.channel_pt_on_top_wall = 0.2  0.0  0.0
+eb2.channel_height = 1.0
+eb2.channel_rotation = 60.
+eb2.channel_has_fluid_inside = 1
+
+max_level = 0
+ref_ratio = 2
+n_cell = 20
+max_grid_size = 10
+max_coarsening_level = 0
+prob_lo =  0.   0.   0.
+prob_hi = 2.0  2.0   0.
+is_periodic = 0  0  0
+scalars = 0  1
+
+use_poiseuille = 1
+poiseuille_pt_on_top_wall = 0.2  0.0  0.0
+poiseuille_height = 1.0
+poiseuille_rotation = 60.
+
+plot_file = "plot-askew-y-mg"
+
+verbose        = 2
+bottom_verbose = 0
+max_iter = 1000
+max_bottom_iter = 1000
+reltol = 1e-5
+bottom_reltol = 1e-5
+abstol = 0.

--- a/Tests/LinearSolvers/LeastSquares/inputs.3d.poiseuille.askew-all.mg
+++ b/Tests/LinearSolvers/LeastSquares/inputs.3d.poiseuille.askew-all.mg
@@ -1,0 +1,31 @@
+amrex.fpe_trap_invalid = 1
+eb_is_dirichlet = 0
+eb_is_homog_dirichlet = 1
+
+eb2.geom_type = channel
+
+eb2.channel_askew = 1
+eb2.channel_pt_on_top_wall = 2.0  0.0  0.0
+eb2.channel_height = 1.0
+eb2.channel_rotation = 10.0  60.0
+eb2.channel_has_fluid_inside = 1
+
+max_level = 0
+ref_ratio = 2
+n_cell = 80
+max_grid_size =  40
+
+max_coarsening_level = 0
+prob_lo = 0.   0.   0.
+prob_hi = 8.0  8.0  8.0
+is_periodic = 0  0  0
+scalars = 0  1
+
+use_poiseuille = 1
+poiseuille_askew = 1
+poiseuille_pt_on_top_wall = 2.0  0.0  0.0
+poiseuille_askew_rotation = 10.0  60.0
+poiseuille_height = 1.0
+poiseuille_no_flow_dir = 0
+
+plot_file = "plot-3d-askew-all-mg"


### PR DESCRIPTION
## Summary
When computing the Least Square slopes on face-centroid stencil with multigrid, we need to grow `m_eb_phi` and make additional checks.

## Additional background
This adds to the changes made in https://github.com/AMReX-Codes/amrex/pull/1707

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
