### PR TITLE
Add FabArray::release and Make BaseFab virtual

### DIFF
--- a/Src/AmrCore/AMReX_TagBox.H
+++ b/Src/AmrCore/AMReX_TagBox.H
@@ -46,7 +46,7 @@ public:
 
     TagBox (const TagBox& rhs, MakeType make_type, int scomp, int ncomp);
 
-    ~TagBox () = default;
+    virtual ~TagBox () noexcept override final = default;
 
     TagBox (TagBox&& rhs) noexcept = default;
 

--- a/Src/Base/AMReX_BaseFab.H
+++ b/Src/Base/AMReX_BaseFab.H
@@ -245,7 +245,7 @@ public:
     explicit BaseFab (Array4<T const> const& a, IndexType t) noexcept;
 
     //! The destructor deletes the array memory.
-    ~BaseFab () noexcept;
+    virtual ~BaseFab () noexcept;
 
     BaseFab (const BaseFab<T>& rhs) = delete;
     BaseFab<T>& operator= (const BaseFab<T>& rhs) = delete;

--- a/Src/Base/AMReX_FArrayBox.H
+++ b/Src/Base/AMReX_FArrayBox.H
@@ -269,7 +269,7 @@ public:
     explicit FArrayBox (Array4<Real const> const& a, IndexType t) noexcept : BaseFab<Real>(a,t) {}
 
     //!  The destructor.
-    ~FArrayBox () noexcept {}
+    virtual ~FArrayBox () noexcept override {}
 
     FArrayBox (FArrayBox&& rhs) noexcept = default;
 

--- a/Src/Base/AMReX_FabArray.H
+++ b/Src/Base/AMReX_FabArray.H
@@ -356,6 +356,14 @@ public:
     //! Explicitly set the FAB associated with mfi in the FabArray to point to elem.
     void setFab (const MFIter&mfi, FAB* elem, bool assertion=true);
 
+    //! Release ownership of the FAB. This function is not thread safe.
+    AMREX_NODISCARD
+    FAB* release (int K);
+
+    //! Release ownership of the FAB. This function is not thread safe.
+    AMREX_NODISCARD
+    FAB* release (const MFIter& mfi);
+
     //! Releases FAB memory in the FabArray.
     void clear ();
 
@@ -1163,6 +1171,44 @@ Array4<typename FabArray<FAB>::value_type const>
 FabArray<FAB>::const_array (int K, int start_comp) const noexcept
 {
     return fabPtr(K)->const_array(start_comp);
+}
+
+template <class FAB>
+AMREX_NODISCARD
+FAB*
+FabArray<FAB>::release (int K)
+{
+    const int li = localindex(K);
+    if (li >= 0 && li < static_cast<int>(m_fabs_v.size()) && m_fabs_v[li] != nullptr) {
+        Long nbytes = amrex::nBytesOwned(*m_fabs_v[li]);
+        if (nbytes > 0) {
+            for (auto const& t : m_tags) {
+                updateMemUsage(t, -nbytes, nullptr);
+            }
+        }
+        return std::exchange(m_fabs_v[li], nullptr);
+    } else {
+        return nullptr;
+    }
+}
+
+template <class FAB>
+AMREX_NODISCARD
+FAB*
+FabArray<FAB>::release (const MFIter& mfi)
+{
+    const int li = mfi.LocalIndex();
+    if (li >= 0 && li < static_cast<int>(m_fabs_v.size()) && m_fabs_v[li] != nullptr) {
+        Long nbytes = amrex::nBytesOwned(*m_fabs_v[li]);
+        if (nbytes > 0) {
+            for (auto const& t : m_tags) {
+                updateMemUsage(t, -nbytes, nullptr);
+            }
+        }
+        return std::exchange(m_fabs_v[li], nullptr);
+    } else {
+        return nullptr;
+    }
 }
 
 template <class FAB>

--- a/Src/Base/AMReX_FabFactory.H
+++ b/Src/Base/AMReX_FabFactory.H
@@ -49,9 +49,12 @@ class FabFactory
 {
 public:
     virtual ~FabFactory () {}
+    AMREX_NODISCARD
     virtual FAB* create (const Box& box, int ncomps, const FabInfo& info, int box_index) const = 0;
+    AMREX_NODISCARD
     virtual FAB* create_alias (FAB const& /*rhs*/, int /*scomp*/, int /*ncomp*/) const { return nullptr; }
     virtual void destroy (FAB* fab) const = 0;
+    AMREX_NODISCARD
     virtual FabFactory<FAB>* clone () const = 0;
 };
 
@@ -60,11 +63,13 @@ class DefaultFabFactory
     : public FabFactory<FAB>
 {
 public:
+    AMREX_NODISCARD
     virtual FAB* create (const Box& box, int ncomps, const FabInfo& info, int /*box_index*/) const override
     {
         return new FAB(box, ncomps, info.alloc, info.shared, info.arena);
     }
 
+    AMREX_NODISCARD
     virtual FAB* create_alias (FAB const& rhs, int scomp, int ncomp) const override
     {
         return new FAB(rhs, amrex::make_alias, scomp, ncomp);
@@ -75,6 +80,7 @@ public:
         delete fab;
     }
 
+    AMREX_NODISCARD
     virtual DefaultFabFactory<FAB>* clone () const override {
         return new DefaultFabFactory<FAB>();
     }

--- a/Src/Base/AMReX_IArrayBox.H
+++ b/Src/Base/AMReX_IArrayBox.H
@@ -65,7 +65,7 @@ public:
     explicit IArrayBox (Array4<int const> const& a, IndexType t) noexcept : BaseFab<int>(a,t) {}
 
     //!  The destructor.
-    ~IArrayBox () noexcept {}
+    virtual ~IArrayBox () noexcept override {}
 
     IArrayBox (IArrayBox&& rhs) noexcept = default;
 

--- a/Src/Boundary/AMReX_Mask.H
+++ b/Src/Boundary/AMReX_Mask.H
@@ -54,7 +54,7 @@ public:
 
     explicit Mask (Array4<int const> const& a, IndexType t) noexcept : BaseFab<int>(a,t) {}
 
-    ~Mask () noexcept {}
+    virtual ~Mask () noexcept override final {}
 
     Mask (Mask&& rhs) noexcept = default;
 

--- a/Src/EB/AMReX_EBCellFlag.H
+++ b/Src/EB/AMReX_EBCellFlag.H
@@ -302,7 +302,7 @@ public:
 
     EBCellFlagFab () = default;
     EBCellFlagFab (EBCellFlagFab&& rhs) = default;
-    ~EBCellFlagFab () = default;
+    virtual ~EBCellFlagFab () override final = default;
 
     EBCellFlagFab (const EBCellFlagFab&) = delete;
     EBCellFlagFab& operator= (const EBCellFlagFab&) = delete;

--- a/Src/EB/AMReX_EBFabFactory.H
+++ b/Src/EB/AMReX_EBFabFactory.H
@@ -34,12 +34,15 @@ public:
     EBFArrayBoxFactory& operator= (const EBFArrayBoxFactory&) = delete;
     EBFArrayBoxFactory& operator= (EBFArrayBoxFactory&&) = delete;
 
+    AMREX_NODISCARD
     virtual FArrayBox* create (const Box& box, int ncomps, const FabInfo& info, int box_index) const final;
 
+    AMREX_NODISCARD
     virtual FArrayBox* create_alias (FArrayBox const& rhs, int scomp, int ncomp) const final;
 
     virtual void destroy (FArrayBox* fab) const final;
 
+    AMREX_NODISCARD
     virtual EBFArrayBoxFactory* clone () const final;
 
     const FabArray<EBCellFlagFab>& getMultiEBCellFlagFab () const noexcept

--- a/Src/EB/AMReX_EBFabFactory.cpp
+++ b/Src/EB/AMReX_EBFabFactory.cpp
@@ -22,6 +22,7 @@ EBFArrayBoxFactory::EBFArrayBoxFactory (const EB2::Level& a_level,
       m_parent(&a_level)
 {}
 
+AMREX_NODISCARD
 FArrayBox*
 EBFArrayBoxFactory::create (const Box& box, int ncomps,
                             const FabInfo& info, int box_index) const
@@ -37,6 +38,7 @@ EBFArrayBoxFactory::create (const Box& box, int ncomps,
     }
 }
 
+AMREX_NODISCARD
 FArrayBox*
 EBFArrayBoxFactory::create_alias (FArrayBox const& rhs, int scomp, int ncomp) const
 {
@@ -65,6 +67,7 @@ EBFArrayBoxFactory::destroy (FArrayBox* fab) const
     }
 }
 
+AMREX_NODISCARD
 EBFArrayBoxFactory*
 EBFArrayBoxFactory::clone () const
 {

--- a/Src/EB/AMReX_MultiCutFab.H
+++ b/Src/EB/AMReX_MultiCutFab.H
@@ -26,7 +26,7 @@ public:
     CutFab (CutFab const& rhs, MakeType make_type, int scomp, int ncomp)
         : FArrayBox(rhs, make_type, scomp, ncomp) {}
 
-    ~CutFab () = default;
+    virtual ~CutFab () noexcept override final = default;
 
     CutFab (CutFab&& rhs) noexcept = default;
 

--- a/Tutorials/EB/CNS/Source/CNS.cpp
+++ b/Tutorials/EB/CNS/Source/CNS.cpp
@@ -115,12 +115,12 @@ CNS::initData ()
 }
 
 void
-CNS::computeInitialDt (int                   finest_level,
-                       int                   sub_cycle,
+CNS::computeInitialDt (int                    finest_level,
+                       int                    /*sub_cycle*/,
                        Vector<int>&           n_cycle,
-                       const Vector<IntVect>& ref_ratio,
+                       const Vector<IntVect>& /*ref_ratio*/,
                        Vector<Real>&          dt_level,
-                       Real                  stop_time)
+                       Real                   stop_time)
 {
   //
   // Grids have been constructed, compute dt for all levels.
@@ -158,9 +158,9 @@ CNS::computeInitialDt (int                   finest_level,
 
 void
 CNS::computeNewDt (int                    finest_level,
-                   int                    sub_cycle,
+                   int                    /*sub_cycle*/,
                    Vector<int>&           n_cycle,
-                   const Vector<IntVect>& ref_ratio,
+                   const Vector<IntVect>& /*ref_ratio*/,
                    Vector<Real>&          dt_min,
                    Vector<Real>&          dt_level,
                    Real                   stop_time,
@@ -232,12 +232,12 @@ CNS::computeNewDt (int                    finest_level,
 }
 
 void
-CNS::post_regrid (int lbase, int new_finest)
+CNS::post_regrid (int /*lbase*/, int /*new_finest*/)
 {
 }
 
 void
-CNS::post_timestep (int iteration)
+CNS::post_timestep (int /*iteration*/)
 {
     if (do_reflux && level < parent->finestLevel()) {
         CNS& fine_level = getLevel(level+1);
@@ -252,7 +252,7 @@ CNS::post_timestep (int iteration)
 }
 
 void
-CNS::postCoarseTimeStep (Real time)
+CNS::postCoarseTimeStep (Real /*time*/)
 {
     // This only computes sum on level 0
     if (verbose >= 2) {

--- a/Tutorials/EB/CNS/Source/CNS_advance.cpp
+++ b/Tutorials/EB/CNS/Source/CNS_advance.cpp
@@ -8,7 +8,7 @@
 using namespace amrex;
 
 Real
-CNS::advance (Real time, Real dt, int iteration, int ncycle)
+CNS::advance (Real time, Real dt, int /*iteration*/, int /*ncycle*/)
 {
     BL_PROFILE("CNS::advance()");
 

--- a/Tutorials/EB/CNS/Source/CNS_init_eb2.cpp
+++ b/Tutorials/EB/CNS/Source/CNS_init_eb2.cpp
@@ -10,7 +10,7 @@
 using namespace amrex;
 
 void
-initialize_EB2 (const Geometry& geom, const int required_coarsening_level,
+initialize_EB2 (const Geometry& geom, const int /*required_coarsening_level*/,
                 const int max_coarsening_level)
 {
     BL_PROFILE("initializeEB2");


### PR DESCRIPTION
Add FabArray::release functions that release the ownership of the FAB at
the given index and return a raw pointer to the FAB.

Make BaseFab virtual so that it's safe to use the new release functions.

Also declare a number of functions `[[nodiscard]]`.

Fix some warnings in EB/CNS example.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
