### PR TITLE
Mask: -Wfinal-dtor-non-final-class

### DIFF
--- a/Src/AmrCore/AMReX_TagBox.H
+++ b/Src/AmrCore/AMReX_TagBox.H
@@ -23,7 +23,7 @@ namespace amrex {
 
 class BoxDomain;
 
-class TagBox
+class TagBox final
     :
     public BaseFab<char>
 {
@@ -46,7 +46,7 @@ public:
 
     TagBox (const TagBox& rhs, MakeType make_type, int scomp, int ncomp);
 
-    virtual ~TagBox () noexcept override final = default;
+    virtual ~TagBox () noexcept override = default;
 
     TagBox (TagBox&& rhs) noexcept = default;
 

--- a/Src/Boundary/AMReX_Mask.H
+++ b/Src/Boundary/AMReX_Mask.H
@@ -23,7 +23,7 @@ namespace amrex {
         This class does NOT provide a copy constructor or assignment operator.
 */
 
-class Mask
+class Mask final
     :
     public BaseFab<int>
 {
@@ -54,7 +54,7 @@ public:
 
     explicit Mask (Array4<int const> const& a, IndexType t) noexcept : BaseFab<int>(a,t) {}
 
-    virtual ~Mask () noexcept override final {}
+    virtual ~Mask () noexcept override {}
 
     Mask (Mask&& rhs) noexcept = default;
 

--- a/Src/EB/AMReX_EBCellFlag.H
+++ b/Src/EB/AMReX_EBCellFlag.H
@@ -283,7 +283,7 @@ private:
 template <>
 struct IsStoreAtomic<EBCellFlag> : std::true_type {};
 
-class EBCellFlagFab
+class EBCellFlagFab final
     : public BaseFab<EBCellFlag>
 {
 public:
@@ -302,7 +302,7 @@ public:
 
     EBCellFlagFab () = default;
     EBCellFlagFab (EBCellFlagFab&& rhs) = default;
-    virtual ~EBCellFlagFab () override final = default;
+    virtual ~EBCellFlagFab () override = default;
 
     EBCellFlagFab (const EBCellFlagFab&) = delete;
     EBCellFlagFab& operator= (const EBCellFlagFab&) = delete;

--- a/Src/EB/AMReX_MultiCutFab.H
+++ b/Src/EB/AMReX_MultiCutFab.H
@@ -7,7 +7,7 @@
 
 namespace amrex {
 
-class CutFab
+class CutFab final
     : public FArrayBox
 {
 public:
@@ -26,7 +26,7 @@ public:
     CutFab (CutFab const& rhs, MakeType make_type, int scomp, int ncomp)
         : FArrayBox(rhs, make_type, scomp, ncomp) {}
 
-    virtual ~CutFab () noexcept override final = default;
+    virtual ~CutFab () noexcept override = default;
 
     CutFab (CutFab&& rhs) noexcept = default;
 


### PR DESCRIPTION
## Summary

```
Src/Boundary/AMReX_Mask.H:57:40: warning: class with destructor marked 'final' cannot be inherited from [-Wfinal-dtor-non-final-class]
    virtual ~Mask () noexcept override final {}
                                       ^
Src/Boundary/AMReX_Mask.H:26:7: note: mark 'amrex::Mask' as 'final' to silence this warning
class Mask
```

## Additional background

Seen with Clang 10.0 on Ubuntu 20.04 LTS.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
