### PR TITLE
Header file order and iosfwd

### DIFF
--- a/Src/Amr/AMReX_Amr.H
+++ b/Src/Amr/AMReX_Amr.H
@@ -3,18 +3,17 @@
 #define AMREX_Amr_H_
 #include <AMReX_Config.H>
 
-#include <fstream>
-#include <memory>
-#include <list>
-
 #include <AMReX_Box.H>
 #include <AMReX_Geometry.H>
 #include <AMReX_BoxArray.H>
 #include <AMReX_Array.H>
 #include <AMReX_Vector.H>
 #include <AMReX_BCRec.H>
-
 #include <AMReX_AmrCore.H>
+
+#include <iosfwd>
+#include <list>
+#include <memory>
 
 namespace amrex {
 

--- a/Src/Amr/AMReX_Amr.cpp
+++ b/Src/Amr/AMReX_Amr.cpp
@@ -1,17 +1,3 @@
-#include <algorithm>
-#include <cstdio>
-#include <list>
-#include <iostream>
-#include <iomanip>
-#include <sstream>
-#include <iomanip>
-#include <limits>
-#include <cmath>
-
-#ifdef AMREX_USE_OMP
-#include <omp.h>
-#endif
-
 #include <AMReX_Geometry.H>
 #include <AMReX_TagBox.H>
 #include <AMReX_Array.H>
@@ -47,6 +33,19 @@
 #ifdef BL_USE_SENSEI_INSITU
 #include <AMReX_AmrInSituBridge.H>
 #endif
+
+#ifdef AMREX_USE_OMP
+#include <omp.h>
+#endif
+
+#include <algorithm>
+#include <cmath>
+#include <cstdio>
+#include <iostream>
+#include <iomanip>
+#include <limits>
+#include <list>
+#include <sstream>
 
 namespace amrex {
 

--- a/Src/Amr/AMReX_AmrLevel.cpp
+++ b/Src/Amr/AMReX_AmrLevel.cpp
@@ -1,9 +1,4 @@
 
-#include <sstream>
-
-#include <memory>
-#include <limits>
-
 #include <AMReX_AmrLevel.H>
 #include <AMReX_Derive.H>
 #include <AMReX_ParallelDescriptor.H>
@@ -19,6 +14,10 @@
 #include <AMReX_EBMultiFabUtil.H>
 #include <AMReX_EB2.H>
 #endif
+
+#include <sstream>
+#include <memory>
+#include <limits>
 
 namespace amrex {
 

--- a/Src/Amr/AMReX_Derive.H
+++ b/Src/Amr/AMReX_Derive.H
@@ -2,13 +2,13 @@
 #define AMREX_Derive_H_
 #include <AMReX_Config.H>
 
-#include <list>
-#include <string>
-
 #include <AMReX_ArrayLim.H>
 #include <AMReX_REAL.H>
 #include <AMReX_Box.H>
 #include <AMReX_Interpolater.H>
+
+#include <list>
+#include <string>
 
 namespace amrex {
 

--- a/Src/Amr/AMReX_Derive.cpp
+++ b/Src/Amr/AMReX_Derive.cpp
@@ -1,8 +1,8 @@
 
-#include <cstring>
-
 #include <AMReX_Derive.H>
 #include <AMReX_StateDescriptor.H>
+
+#include <cstring>
 
 namespace amrex {
 

--- a/Src/Amr/AMReX_StateData.H
+++ b/Src/Amr/AMReX_StateData.H
@@ -3,8 +3,6 @@
 #define AMREX_StateData_H_
 #include <AMReX_Config.H>
 
-#include <memory>
-
 #include <AMReX_Box.H>
 #include <AMReX_BoxArray.H>
 #include <AMReX_MultiFab.H>
@@ -18,6 +16,8 @@
 #include <AMReX_Geometry.H>
 #include <AMReX_RealBox.H>
 #include <AMReX_StateDescriptor.H>
+
+#include <memory>
 
 namespace amrex {
 

--- a/Src/Amr/AMReX_StateData.cpp
+++ b/Src/Amr/AMReX_StateData.cpp
@@ -1,8 +1,4 @@
 
-#include <iostream>
-#include <limits>
-#include <algorithm>
-
 #include <AMReX_RealBox.H>
 #include <AMReX_StateData.H>
 #include <AMReX_StateDescriptor.H>
@@ -12,6 +8,10 @@
 #ifdef AMREX_USE_OMP
 #include <omp.h>
 #endif
+
+#include <iostream>
+#include <limits>
+#include <algorithm>
 
 namespace amrex {
 

--- a/Src/Amr/AMReX_StateDescriptor.H
+++ b/Src/Amr/AMReX_StateDescriptor.H
@@ -3,14 +3,14 @@
 #define AMREX_StateDescriptor_H_
 #include <AMReX_Config.H>
 
-#include <utility>
-#include <memory>
-
 #include <AMReX_Array.H>
 #include <AMReX_Vector.H>
 #include <AMReX_REAL.H>
 #include <AMReX_Box.H>
 #include <AMReX_PhysBCFunct.H>
+
+#include <utility>
+#include <memory>
 
 namespace amrex {
 

--- a/Src/Amr/AMReX_StateDescriptor.cpp
+++ b/Src/Amr/AMReX_StateDescriptor.cpp
@@ -1,11 +1,11 @@
 
-#include <algorithm>
-#include <string>
-#include <iostream>
-
 #include <AMReX_StateDescriptor.H>
 #include <AMReX_Interpolater.H>
 #include <AMReX_BCRec.H>
+
+#include <algorithm>
+#include <string>
+#include <iostream>
 
 namespace amrex {
 

--- a/Src/AmrCore/AMReX_AmrCore.H
+++ b/Src/AmrCore/AMReX_AmrCore.H
@@ -2,10 +2,10 @@
 #define BL_AMRCORE_H_
 #include <AMReX_Config.H>
 
-#include <ostream>
-#include <memory>
-
 #include <AMReX_AmrMesh.H>
+
+#include <iosfwd>
+#include <memory>
 
 namespace amrex {
 

--- a/Src/AmrCore/AMReX_AmrCore.cpp
+++ b/Src/AmrCore/AMReX_AmrCore.cpp
@@ -1,6 +1,4 @@
 
-#include <algorithm>
-
 #include <AMReX_AmrCore.H>
 #include <AMReX_Print.H>
 
@@ -11,6 +9,9 @@
 #ifdef AMREX_USE_OMP
 #include <omp.h>
 #endif
+
+#include <algorithm>
+#include <ostream>
 
 namespace amrex {
 

--- a/Src/AmrCore/AMReX_Cluster.H
+++ b/Src/AmrCore/AMReX_Cluster.H
@@ -3,13 +3,14 @@
 #define AMREX_Cluster_H_
 #include <AMReX_Config.H>
 
-#include <list>
 #include <AMReX_IntVect.H>
 #include <AMReX_Box.H>
 #include <AMReX_Array.H>
 #include <AMReX_Vector.H>
 #include <AMReX_BoxArray.H>
 #include <AMReX_REAL.H>
+
+#include <list>
 
 namespace amrex {
 

--- a/Src/AmrCore/AMReX_Cluster.cpp
+++ b/Src/AmrCore/AMReX_Cluster.cpp
@@ -1,11 +1,12 @@
 
-#include <algorithm>
-#include <cmath>
 #include <AMReX_Cluster.H>
 #include <AMReX_BoxDomain.H>
 #include <AMReX_Vector.H>
 #include <AMReX_Array.H>
 #include <AMReX_BLProfiler.H>
+
+#include <algorithm>
+#include <cmath>
 
 namespace amrex {
 

--- a/Src/AmrCore/AMReX_ErrorList.H
+++ b/Src/AmrCore/AMReX_ErrorList.H
@@ -2,9 +2,6 @@
 #define AMREX_ErrorList_H_
 #include <AMReX_Config.H>
 
-#include <string>
-#include <memory>
-
 #include <AMReX_Array.H>
 #include <AMReX_Vector.H>
 #include <AMReX_REAL.H>
@@ -12,6 +9,9 @@
 #include <AMReX_MultiFab.H>
 #include <AMReX_TagBox.H>
 #include <AMReX_Geometry.H>
+
+#include <string>
+#include <memory>
 
 namespace amrex {
 

--- a/Src/AmrCore/AMReX_ErrorList.cpp
+++ b/Src/AmrCore/AMReX_ErrorList.cpp
@@ -1,8 +1,9 @@
 
-#include <iostream>
 #include <AMReX_BLassert.H>
 #include <AMReX_ErrorList.H>
 #include <AMReX_SPACE.H>
+
+#include <iostream>
 
 namespace amrex {
 

--- a/Src/AmrCore/AMReX_FillPatchUtil.H
+++ b/Src/AmrCore/AMReX_FillPatchUtil.H
@@ -14,12 +14,12 @@
 #include <AMReX_EBFabFactory.H>
 #endif
 
-#include <cmath>
-#include <limits>
-
 #ifdef AMREX_USE_OMP
 #include <omp.h>
 #endif
+
+#include <cmath>
+#include <limits>
 
 namespace amrex
 {

--- a/Src/AmrCore/AMReX_Interpolater.cpp
+++ b/Src/AmrCore/AMReX_Interpolater.cpp
@@ -1,6 +1,4 @@
 
-#include <climits>
-
 #include <AMReX_FArrayBox.H>
 #include <AMReX_IArrayBox.H>
 #include <AMReX_Geometry.H>
@@ -10,6 +8,8 @@
 #ifndef BL_NO_FORT
 #include <AMReX_INTERP_F.H>
 #endif
+
+#include <climits>
 
 namespace amrex {
 

--- a/Src/AmrCore/AMReX_TagBox.cpp
+++ b/Src/AmrCore/AMReX_TagBox.cpp
@@ -1,8 +1,3 @@
-#include <algorithm>
-#include <cstdlib>
-#include <cmath>
-#include <climits>
-
 #include <AMReX_TagBox.H>
 #include <AMReX_Geometry.H>
 #include <AMReX_ParallelDescriptor.H>
@@ -10,6 +5,11 @@
 #include <AMReX_ccse-mpi.H>
 #include <AMReX_iMultiFab.H>
 #include <AMReX_MultiFabUtil.H>
+
+#include <algorithm>
+#include <cstdlib>
+#include <cmath>
+#include <climits>
 
 namespace amrex {
 

--- a/Src/Base/AMReX.H
+++ b/Src/Base/AMReX.H
@@ -13,12 +13,12 @@
 #include <AMReX_REAL.H>
 #include <AMReX_Math.H>
 
-#include <iostream>
-#include <functional>
-#include <string>
 #include <cstdio>
-#include <vector>
+#include <functional>
+#include <iostream>
 #include <memory>
+#include <string>
+#include <vector>
 
 //
 // Initialize, Finalize, Error Reporting, and Version String Functions

--- a/Src/Base/AMReX_Array.H
+++ b/Src/Base/AMReX_Array.H
@@ -2,14 +2,6 @@
 #define AMREX_ARRAY_H_
 #include <AMReX_Config.H>
 
-#include <array>
-#include <memory>
-#include <utility>
-#include <string>
-#include <iostream>
-#include <sstream>
-#include <cstdio>
-#include <type_traits>
 #include <AMReX.H>
 #include <AMReX_GpuQualifiers.H>
 #include <AMReX_GpuControl.H>
@@ -18,6 +10,12 @@
 #include <AMReX_REAL.H>
 #include <AMReX_Algorithm.H>
 #include <AMReX_Dim3.H>
+
+#include <array>
+#include <memory>
+#include <utility>
+#include <string>
+#include <type_traits>
 
 namespace amrex {
 

--- a/Src/Base/AMReX_Array4.H
+++ b/Src/Base/AMReX_Array4.H
@@ -6,6 +6,9 @@
 #include <AMReX_IntVect.H>
 #include <AMReX_GpuPrint.H>
 
+#include <iostream>
+#include <sstream>
+
 namespace amrex {
 
     template <typename T>

--- a/Src/Base/AMReX_BCRec.cpp
+++ b/Src/Base/AMReX_BCRec.cpp
@@ -1,7 +1,6 @@
 
-#include <iostream>
-
 #include <AMReX_BCRec.H>
+#include <iostream>
 
 namespace amrex {
 

--- a/Src/Base/AMReX_BLBackTrace.H
+++ b/Src/Base/AMReX_BLBackTrace.H
@@ -2,16 +2,14 @@
 #define AMREX_BL_BACKTRACE_H_
 #include <AMReX_Config.H>
 
-#include <stack>
-#include <string>
-#include <utility>
-#include <sstream>
-#include <cstdio>
-#include <cstdlib>
-
 #ifdef AMREX_USE_OMP
 #include <omp.h>
 #endif
+
+#include <stack>
+#include <string>
+#include <utility>
+#include <cstdlib>
 
 #define BL_PASTE2(x, y) x##y
 #define BL_PASTE(x, y) BL_PASTE2(x, y)

--- a/Src/Base/AMReX_BLProfiler.H
+++ b/Src/Base/AMReX_BLProfiler.H
@@ -15,15 +15,14 @@
 #include <AMReX_Box.H>
 #endif
 
-#include <iostream>
-#include <ostream>
+#include <list>
+#include <map>
+#include <iosfwd>
 #include <string>
 #include <stack>
 #include <set>
-#include <map>
-#include <list>
-#include <utility>
 #include <typeinfo>
+#include <utility>
 
 namespace amrex {
 
@@ -333,12 +332,7 @@ namespace BLProfilerUtils {
 }
 
 
-inline std::ostream &operator<< (std::ostream &os, const BLProfiler::CommStats &cs) {
-  os << BLProfiler::CommStats::CFTToString(cs.cfType) << "   " << cs.size
-     << "  " << cs.commpid << "  " << cs.tag << "  " << cs.timeStamp;
-  return os;
-}
-
+std::ostream &operator<< (std::ostream &os, const BLProfiler::CommStats &cs);
 
 
 inline std::string BLProfiler::CommStats::CFTToString(CommFuncType cft) {

--- a/Src/Base/AMReX_BLProfiler.cpp
+++ b/Src/Base/AMReX_BLProfiler.cpp
@@ -769,8 +769,13 @@ void WriteStats(std::ostream &ios,
 #endif
 }
 
-
 }  // end namespace BLProfilerUtils
+
+std::ostream &operator<< (std::ostream &os, const BLProfiler::CommStats &cs) {
+  os << BLProfiler::CommStats::CFTToString(cs.cfType) << "   " << cs.size
+     << "  " << cs.commpid << "  " << cs.tag << "  " << cs.timeStamp;
+  return os;
+}
 
 void BLProfiler::WriteBaseProfile(bool bFlushing, bool memCheck) {   // ---- write basic profiling data
   amrex::ignore_unused(memCheck);

--- a/Src/Base/AMReX_BaseFab.cpp
+++ b/Src/Base/AMReX_BaseFab.cpp
@@ -1,12 +1,12 @@
-#include <cstring>
-#include <cstdlib>
-
 #include <AMReX_BaseFab.H>
 #include <AMReX_BLFort.H>
 
 #ifdef AMREX_MEM_PROFILING
 #include <AMReX_MemProfiler.H>
 #endif
+
+#include <cstring>
+#include <cstdlib>
 
 namespace amrex {
 

--- a/Src/Base/AMReX_BaseUmap.H
+++ b/Src/Base/AMReX_BaseUmap.H
@@ -2,15 +2,6 @@
 #define BL_BASEUMAP_H
 #include <AMReX_Config.H>
 
-#include <cmath>
-#include <cstdlib>
-#include <algorithm>
-#include <limits>
-
-#ifdef AMREX_USE_OMP
-#include <omp.h>
-#endif
-
 #include <AMReX_BLassert.H>
 #include <AMReX_Box.H>
 #include <AMReX_BoxList.H>
@@ -20,6 +11,14 @@
 #include <AMReX_MakeType.H>
 #include <unordered_map>
 
+#ifdef AMREX_USE_OMP
+#include <omp.h>
+#endif
+
+#include <cmath>
+#include <cstdlib>
+#include <algorithm>
+#include <limits>
 
 // iv - IntVect in absolute coordiantes
 // m - variable / component

--- a/Src/Base/AMReX_BoxArray.H
+++ b/Src/Base/AMReX_BoxArray.H
@@ -8,7 +8,7 @@
 #include <AMReX_Array.H>
 #include <AMReX_Vector.H>
 
-#include <iostream>
+#include <iosfwd>
 #include <cstddef>
 #include <map>
 #include <unordered_map>

--- a/Src/Base/AMReX_BoxArray.cpp
+++ b/Src/Base/AMReX_BoxArray.cpp
@@ -12,6 +12,8 @@
 
 #include <AMReX_OpenMP.H>
 
+#include <iostream>
+
 namespace amrex {
 
 #ifdef AMREX_MEM_PROFILING

--- a/Src/Base/AMReX_BoxDomain.H
+++ b/Src/Base/AMReX_BoxDomain.H
@@ -3,12 +3,12 @@
 #define BL_BOXDOMAIN_H
 #include <AMReX_Config.H>
 
-#include <iosfwd>
-
 #include <AMReX_IndexType.H>
 #include <AMReX_Box.H>
 #include <AMReX_IntVect.H>
 #include <AMReX_BoxList.H>
+
+#include <iosfwd>
 
 namespace amrex
 {

--- a/Src/Base/AMReX_BoxDomain.cpp
+++ b/Src/Base/AMReX_BoxDomain.cpp
@@ -1,9 +1,9 @@
 
-#include <iostream>
-
 #include <AMReX_BoxDomain.H>
 #include <AMReX_BLProfiler.H>
 #include <AMReX_Print.H>
+
+#include <iostream>
 
 namespace amrex {
 

--- a/Src/Base/AMReX_BoxIterator.H
+++ b/Src/Base/AMReX_BoxIterator.H
@@ -2,12 +2,13 @@
 #define AMREX_BOXITERATOR_H_
 #include <AMReX_Config.H>
 
+#include <AMReX_BLassert.H>
+#include <AMReX_Box.H>
+#include <AMReX_REAL.H>
+#include <AMReX_SPACE.H>
+#include <AMReX_IntVect.H>
+
 #include <cstdlib>
-#include "AMReX_BLassert.H"
-#include "AMReX_Box.H"
-#include "AMReX_REAL.H"
-#include "AMReX_SPACE.H"
-#include "AMReX_IntVect.H"
 
 namespace amrex
 {

--- a/Src/Base/AMReX_BoxIterator.cpp
+++ b/Src/Base/AMReX_BoxIterator.cpp
@@ -1,4 +1,4 @@
-#include "AMReX_BoxIterator.H"
+#include <AMReX_BoxIterator.H>
 
 namespace amrex
 {

--- a/Src/Base/AMReX_BoxList.H
+++ b/Src/Base/AMReX_BoxList.H
@@ -3,13 +3,13 @@
 #define BL_BOXLIST_H
 #include <AMReX_Config.H>
 
-#include <iosfwd>
-
 #include <AMReX_IntVect.H>
 #include <AMReX_IndexType.H>
 #include <AMReX_Box.H>
 #include <AMReX_Array.H>
 #include <AMReX_Vector.H>
+
+#include <iosfwd>
 
 namespace amrex
 {

--- a/Src/Base/AMReX_BoxList.cpp
+++ b/Src/Base/AMReX_BoxList.cpp
@@ -1,8 +1,4 @@
 
-#include <algorithm>
-#include <iostream>
-#include <cmath>
-
 #include <AMReX_Print.H>
 #include <AMReX_BoxArray.H>
 #include <AMReX_BoxList.H>
@@ -12,6 +8,10 @@
 #ifdef AMREX_USE_OMP
 #include <omp.h>
 #endif
+
+#include <algorithm>
+#include <iostream>
+#include <cmath>
 
 namespace amrex {
 

--- a/Src/Base/AMReX_CoordSys.H
+++ b/Src/Base/AMReX_CoordSys.H
@@ -3,12 +3,13 @@
 #define AMREX_COORDSYS_H_
 #include <AMReX_Config.H>
 
-#include <limits>
 #include <AMReX.H>
 #include <AMReX_REAL.H>
 #include <AMReX_Array.H>
 #include <AMReX_Vector.H>
 #include <AMReX_Box.H>
+
+#include <limits>
 
 namespace amrex {
 

--- a/Src/Base/AMReX_CoordSys.cpp
+++ b/Src/Base/AMReX_CoordSys.cpp
@@ -1,10 +1,10 @@
 
-#include <iostream>
-
 #include <AMReX_CoordSys.H>
 #include <AMReX_COORDSYS_C.H>
 #include <AMReX_FArrayBox.H>
 #include <AMReX_ParallelDescriptor.H>
+
+#include <iostream>
 
 namespace {
 #if (AMREX_SPACEDIM == 2)

--- a/Src/Base/AMReX_Dim3.H
+++ b/Src/Base/AMReX_Dim3.H
@@ -2,19 +2,17 @@
 #define AMREX_DIM3_H_
 #include <AMReX_Config.H>
 
-#include <iostream>
 #include <AMReX_REAL.H>
 #include <AMReX_GpuQualifiers.H>
+
+#include <iosfwd>
 
 namespace amrex {
 
 struct Dim3 { int x; int y; int z; };
 struct XDim3 { Real x; Real y; Real z; };
 
-inline std::ostream& operator<< (std::ostream& os, const Dim3& d) {
-    os << '(' << d.x << ',' << d.y << ',' << d.z << ')';
-    return os;
-}
+std::ostream& operator<< (std::ostream& os, const Dim3& d);
 
 }
 

--- a/Src/Base/AMReX_Dim3.cpp
+++ b/Src/Base/AMReX_Dim3.cpp
@@ -1,0 +1,13 @@
+
+#include <AMReX_Dim3.H>
+#include <iostream>
+
+namespace amrex {
+
+std::ostream& operator<< (std::ostream& os, const Dim3& d)
+{
+    os << '(' << d.x << ',' << d.y << ',' << d.z << ')';
+    return os;
+}
+
+}

--- a/Src/Base/AMReX_DistributionMapping.H
+++ b/Src/Base/AMReX_DistributionMapping.H
@@ -2,18 +2,18 @@
 #define BL_DISTRIBUTIONMAPPING_H
 #include <AMReX_Config.H>
 
-#include <map>
-#include <limits>
-#include <memory>
-#include <cstddef>
-#include <iostream>
-
 #include <AMReX.H>
 #include <AMReX_Array.H>
 #include <AMReX_Vector.H>
 #include <AMReX_Box.H>
 #include <AMReX_REAL.H>
 #include <AMReX_ParallelDescriptor.H>
+
+#include <map>
+#include <limits>
+#include <memory>
+#include <cstddef>
+#include <iosfwd>
 
 namespace amrex {
 

--- a/Src/Base/AMReX_FACopyDescriptor.H
+++ b/Src/Base/AMReX_FACopyDescriptor.H
@@ -4,7 +4,7 @@
 #include <AMReX_Config.H>
 
 #include <AMReX_FabArray.H>
-#include <sstream>
+#include <string>
 
 namespace amrex {
 
@@ -271,10 +271,11 @@ FabArrayCopyDescriptor<FAB>::AddBoxDoIt (FabArrayId fabarrayid,
 
         int remoteProc     = fabArray->DistributionMap()[faindex];
         if(remoteProc >= ParallelDescriptor::NProcs()) {
-            std::ostringstream ss;
-            ss << ParallelDescriptor::MyProc() << ":: _in AddBoxDoIt:  nProcs remoteProc = "
-               << ParallelDescriptor::NProcs() << "  " << remoteProc << "\n";
-            amrex::Abort("Bad remoteProc: "+ss.str());
+            amrex::Abort("Bad remoteProc: "
+                         + std::to_string(ParallelDescriptor::MyProc())
+                         + ":: _in AddBoxDoIt:  nProcs remoteProc = "
+                         + std::to_string(ParallelDescriptor::NProcs())
+                         + "  " + std::to_string(remoteProc) + "\n");
         }
         fcd->fillBoxId     = nextFillBoxId;
         fcd->subBox        = intersect;

--- a/Src/Base/AMReX_FArrayBox.cpp
+++ b/Src/Base/AMReX_FArrayBox.cpp
@@ -1,14 +1,4 @@
 
-#include <cstdint>
-#include <cstdlib>
-#include <iostream>
-#include <iomanip>
-#include <cfloat>
-#include <cmath>
-#include <cstring>
-#include <limits>
-#include <memory>
-
 #include <AMReX_FArrayBox.H>
 #include <AMReX_FabConv.H>
 #include <AMReX_ParmParse.H>
@@ -19,6 +9,16 @@
 #include <AMReX.H>
 #include <AMReX_Utility.H>
 #include <AMReX_MemPool.H>
+
+#include <cstdint>
+#include <cstdlib>
+#include <iostream>
+#include <iomanip>
+#include <cfloat>
+#include <cmath>
+#include <cstring>
+#include <limits>
+#include <memory>
 
 namespace amrex {
 

--- a/Src/Base/AMReX_FabArray.H
+++ b/Src/Base/AMReX_FabArray.H
@@ -3,20 +3,6 @@
 #define BL_FABARRAY_H
 #include <AMReX_Config.H>
 
-#include <iostream>
-#include <cstring>
-#include <limits>
-#include <map>
-#include <utility>
-#include <vector>
-#include <algorithm>
-#include <set>
-#include <string>
-
-#ifdef AMREX_USE_OMP
-#include <omp.h>
-#endif
-
 #include <AMReX_BLassert.H>
 #include <AMReX_Array.H>
 #include <AMReX_Vector.H>
@@ -45,6 +31,19 @@
 #ifdef AMREX_USE_EB
 #include <AMReX_EBFabFactory.H>
 #endif
+
+#ifdef AMREX_USE_OMP
+#include <omp.h>
+#endif
+
+#include <cstring>
+#include <limits>
+#include <map>
+#include <utility>
+#include <vector>
+#include <algorithm>
+#include <set>
+#include <string>
 
 namespace amrex {
 

--- a/Src/Base/AMReX_FabArrayBase.H
+++ b/Src/Base/AMReX_FabArrayBase.H
@@ -2,11 +2,6 @@
 #define BL_FABARRAYBASE_H_
 #include <AMReX_Config.H>
 
-#ifdef AMREX_USE_OMP
-#include <omp.h>
-#endif
-
-#include <string>
 #include <AMReX_BoxArray.H>
 #include <AMReX_DistributionMapping.H>
 #include <AMReX_ParallelDescriptor.H>
@@ -15,6 +10,12 @@
 #include <AMReX_Print.H>
 #include <AMReX_Arena.H>
 #include <AMReX_Gpu.H>
+
+#ifdef AMREX_USE_OMP
+#include <omp.h>
+#endif
+
+#include <string>
 
 namespace amrex {
 

--- a/Src/Base/AMReX_FabArrayBase.cpp
+++ b/Src/Base/AMReX_FabArrayBase.cpp
@@ -1,5 +1,4 @@
 
-#include <algorithm>
 #include <AMReX_FabArrayBase.H>
 #include <AMReX_ParmParse.H>
 #include <AMReX_Utility.H>
@@ -18,6 +17,8 @@
 #include <AMReX_EB2.H>
 #include <AMReX_EBFabFactory.H>
 #endif
+
+#include <algorithm>
 
 namespace amrex {
 

--- a/Src/Base/AMReX_FabConv.H
+++ b/Src/Base/AMReX_FabConv.H
@@ -3,13 +3,13 @@
 #define BL_FABCONV_H
 #include <AMReX_Config.H>
 
-#include <iosfwd>
-
 #include <AMReX_Array.H>
 #include <AMReX_Vector.H>
 #include <AMReX_BLassert.H>
 #include <AMReX_REAL.H>
 #include <AMReX_INT.H>
+
+#include <iosfwd>
 
 namespace amrex {
 

--- a/Src/Base/AMReX_Geometry.H
+++ b/Src/Base/AMReX_Geometry.H
@@ -2,18 +2,18 @@
 #define AMREX_GEOMETRY_H_
 #include <AMReX_Config.H>
 
-#include <iosfwd>
-#include <map>
-
-#ifdef AMREX_USE_OMP
-#include <omp.h>
-#endif
-
 #include <AMReX_Array.H>
 #include <AMReX_CoordSys.H>
 #include <AMReX_ParallelDescriptor.H>
 #include <AMReX_RealBox.H>
 #include <AMReX_Periodicity.H>
+
+#ifdef AMREX_USE_OMP
+#include <omp.h>
+#endif
+
+#include <iosfwd>
+#include <map>
 
 namespace amrex {
 /**

--- a/Src/Base/AMReX_Geometry.cpp
+++ b/Src/Base/AMReX_Geometry.cpp
@@ -1,7 +1,4 @@
 
-
-#include <iostream>
-
 #include <AMReX_Algorithm.H>
 #include <AMReX_BoxArray.H>
 #include <AMReX_Geometry.H>
@@ -11,6 +8,8 @@
 #include <AMReX_SPACE.H>
 
 #include <AMReX_OpenMP.H>
+
+#include <iostream>
 
 namespace amrex {
 

--- a/Src/Base/AMReX_GpuAllocators.H
+++ b/Src/Base/AMReX_GpuAllocators.H
@@ -2,12 +2,6 @@
 #define AMREX_GPUALLOCATORS_H_
 #include <AMReX_Config.H>
 
-#include <map>
-#include <memory>
-#include <limits>
-#include <memory>
-#include <type_traits>
-
 #include <AMReX_Print.H>
 #include <AMReX_Arena.H>
 #include <AMReX_GpuDevice.H>
@@ -17,6 +11,12 @@
 #include <driver_types.h>
 #include <cuda_runtime.h>
 #endif // AMREX_USE_CUDA
+
+#include <map>
+#include <memory>
+#include <limits>
+#include <memory>
+#include <type_traits>
 
 namespace amrex {
 

--- a/Src/Base/AMReX_GpuAsyncArray.H
+++ b/Src/Base/AMReX_GpuAsyncArray.H
@@ -2,13 +2,14 @@
 #define AMREX_GPU_ASYNC_ARRAY_H_
 #include <AMReX_Config.H>
 
+#include <AMReX_Arena.H>
+#include <AMReX_TypeTraits.H>
+#include <AMReX_GpuDevice.H>
+
 #include <cstddef>
 #include <cstring>
 #include <cstdlib>
 #include <memory>
-#include <AMReX_Arena.H>
-#include <AMReX_TypeTraits.H>
-#include <AMReX_GpuDevice.H>
 
 #if defined(AMREX_USE_CUDA) || defined(AMREX_USE_HIP)
 extern "C" {

--- a/Src/Base/AMReX_GpuComplex.H
+++ b/Src/Base/AMReX_GpuComplex.H
@@ -2,9 +2,9 @@
 #define AMREX_GPUCOMPLEX_H_
 #include <AMReX_Config.H>
 
+#include <AMReX_Math.H>
 #include <cmath>
 #include <iostream>
-#include <AMReX_Math.H>
 
 namespace amrex {
 

--- a/Src/Base/AMReX_GpuContainers.H
+++ b/Src/Base/AMReX_GpuContainers.H
@@ -2,14 +2,14 @@
 #define AMREX_GPU_CONTAINERS_H_
 #include <AMReX_Config.H>
 
-#include <numeric>
-#include <iterator>
-
 #include <AMReX_Vector.H>
 #include <AMReX_PODVector.H>
 #include <AMReX_GpuAllocators.H>
 #include <AMReX_Scan.H>
 #include <type_traits>
+
+#include <numeric>
+#include <iterator>
 
 namespace amrex {
 

--- a/Src/Base/AMReX_GpuDevice.cpp
+++ b/Src/Base/AMReX_GpuDevice.cpp
@@ -1,15 +1,16 @@
 
+#include <AMReX_GpuDevice.H>
+#include <AMReX_ParallelDescriptor.H>
+#include <AMReX_ParmParse.H>
+#include <AMReX_Print.H>
+#include <AMReX_GpuLaunch.H>
+
 #include <iostream>
 #include <map>
 #include <algorithm>
 #include <string>
 #include <unordered_set>
 #include <exception>
-#include <AMReX_GpuDevice.H>
-#include <AMReX_ParallelDescriptor.H>
-#include <AMReX_ParmParse.H>
-#include <AMReX_Print.H>
-#include <AMReX_GpuLaunch.H>
 
 #if defined(AMREX_USE_CUDA)
 #include <cuda_profiler_api.h>

--- a/Src/Base/AMReX_GpuUtility.H
+++ b/Src/Base/AMReX_GpuUtility.H
@@ -11,7 +11,7 @@
 #include <AMReX_INT.H>
 #include <AMReX_Array.H>
 #include <AMReX_Array4.H>
-#include <iostream>
+#include <iosfwd>
 #include <cmath>
 #include <cstring>
 

--- a/Src/Base/AMReX_IndexType.H
+++ b/Src/Base/AMReX_IndexType.H
@@ -3,11 +3,11 @@
 #define BL_INDEXTYPE_H
 #include <AMReX_Config.H>
 
-#include <iosfwd>
-
 #include <AMReX_ccse-mpi.H>
 #include <AMReX_IntVect.H>
 #include <AMReX_SPACE.H>
+
+#include <iosfwd>
 
 namespace amrex {
 

--- a/Src/Base/AMReX_IndexType.cpp
+++ b/Src/Base/AMReX_IndexType.cpp
@@ -1,8 +1,8 @@
 
+#include <AMReX_IndexType.H>
+
 #include <iostream>
 #include <iomanip>
-
-#include <AMReX_IndexType.H>
 
 namespace amrex {
 

--- a/Src/Base/AMReX_IntConv.H
+++ b/Src/Base/AMReX_IntConv.H
@@ -2,12 +2,12 @@
 #define AMREX_INTCONV_H_
 #include <AMReX_Config.H>
 
+#include <AMReX_FPC.H>
+#include <AMReX_FabConv.H>
+
 #include <iostream>
 #include <cstring>
 #include <cstdint>
-
-#include "AMReX_FPC.H"
-#include "AMReX_FabConv.H"
 
 namespace amrex {
 

--- a/Src/Base/AMReX_IntVect.cpp
+++ b/Src/Base/AMReX_IntVect.cpp
@@ -1,11 +1,11 @@
 
-#include <iostream>
-
 #include <AMReX_IntVect.H>
 #include <AMReX_BLassert.H>
 #include <AMReX.H>
 #include <AMReX_Utility.H>
 #include <AMReX_IndexType.H>
+
+#include <iostream>
 
 namespace amrex {
 

--- a/Src/Base/AMReX_MFIter.H
+++ b/Src/Base/AMReX_MFIter.H
@@ -2,8 +2,6 @@
 #define BL_MFITER_H_
 #include <AMReX_Config.H>
 
-#include <memory>
-
 #include <AMReX_Arena.H>
 #include <AMReX_Extension.H>
 #include <AMReX_FabArrayBase.H>
@@ -16,6 +14,8 @@
 #ifdef AMREX_USE_OMP
 #include <omp.h>
 #endif
+
+#include <memory>
 
 namespace amrex {
 

--- a/Src/Base/AMReX_MemPool.cpp
+++ b/Src/Base/AMReX_MemPool.cpp
@@ -1,11 +1,3 @@
-#include <iostream>
-#include <limits>
-#include <algorithm>
-#include <new>
-#include <memory>
-#include <cstring>
-#include <cstdint>
-
 #include <AMReX_CArena.H>
 #include <AMReX_MemPool.H>
 #include <AMReX_Vector.H>
@@ -16,6 +8,14 @@
 #endif
 
 #include <AMReX_ParmParse.H>
+
+#include <iostream>
+#include <limits>
+#include <algorithm>
+#include <new>
+#include <memory>
+#include <cstring>
+#include <cstdint>
 
 using namespace amrex;
 

--- a/Src/Base/AMReX_MemProfiler.H
+++ b/Src/Base/AMReX_MemProfiler.H
@@ -4,12 +4,13 @@
 #include <AMReX_Config.H>
 
 #include <AMReX_INT.H>
+
 #include <stack>
 #include <functional>
 #include <string>
 #include <vector>
 #include <map>
-#include <iostream>
+#include <iosfwd>
 #include <memory>
 
 namespace amrex {

--- a/Src/Base/AMReX_MemProfiler.cpp
+++ b/Src/Base/AMReX_MemProfiler.cpp
@@ -1,8 +1,14 @@
 
+#include <AMReX_MemProfiler.H>
+#include <AMReX_ParallelDescriptor.H>
+#include <AMReX.H>
+#include <AMReX_ParmParse.H>
+
 #include <limits>
 #include <numeric>
 #include <algorithm>
 #include <iomanip>
+#include <iostream>
 #include <fstream>
 
 #ifdef __linux__
@@ -10,11 +16,6 @@
 #include <sys/types.h>
 #include <sys/sysinfo.h>
 #endif
-
-#include <AMReX_MemProfiler.H>
-#include <AMReX_ParallelDescriptor.H>
-#include <AMReX.H>
-#include <AMReX_ParmParse.H>
 
 namespace amrex {
 

--- a/Src/Base/AMReX_MultiFab.H
+++ b/Src/Base/AMReX_MultiFab.H
@@ -3,9 +3,6 @@
 #define BL_MULTIFAB_H
 #include <AMReX_Config.H>
 
-
-#include <cstdint>
-
 #include <AMReX_BLassert.H>
 #include <AMReX_FArrayBox.H>
 #include <AMReX_FabArray.H>
@@ -15,6 +12,8 @@
 #ifdef AMREX_USE_EB
 #include <AMReX_EBMultiFabUtil.H>
 #endif
+
+#include <cstdint>
 
 namespace amrex
 {

--- a/Src/Base/AMReX_MultiFab.cpp
+++ b/Src/Base/AMReX_MultiFab.cpp
@@ -1,11 +1,4 @@
 
-#include <algorithm>
-#include <cfloat>
-#include <iostream>
-#include <iomanip>
-#include <map>
-#include <limits>
-
 #include <AMReX_BLassert.H>
 #include <AMReX_MultiFab.H>
 #include <AMReX_ParallelDescriptor.H>
@@ -20,6 +13,13 @@
 #ifdef AMREX_USE_EB
 #include <AMReX_EBMultiFabUtil.H>
 #endif
+
+#include <algorithm>
+#include <cfloat>
+#include <iostream>
+#include <iomanip>
+#include <map>
+#include <limits>
 
 namespace amrex {
 

--- a/Src/Base/AMReX_NFiles.H
+++ b/Src/Base/AMReX_NFiles.H
@@ -3,11 +3,11 @@
 #define BL_NFILES_H
 #include <AMReX_Config.H>
 
-#include <string>
-#include <fstream>
-
 #include <AMReX_ParallelDescriptor.H>
 #include <AMReX_VisMF.H>
+
+#include <string>
+#include <iosfwd>
 
 namespace amrex {
 

--- a/Src/Base/AMReX_NFiles.cpp
+++ b/Src/Base/AMReX_NFiles.cpp
@@ -2,6 +2,7 @@
 #include <AMReX_Utility.H>
 #include <AMReX_NFiles.H>
 #include <deque>
+#include <fstream>
 
 namespace amrex {
 

--- a/Src/Base/AMReX_Orientation.H
+++ b/Src/Base/AMReX_Orientation.H
@@ -3,11 +3,11 @@
 #define BL_ORIENTATION_H
 #include <AMReX_Config.H>
 
-#include <iosfwd>
-
 #include <AMReX_BLassert.H>
 #include <AMReX_SPACE.H>
 #include <AMReX_GpuQualifiers.H>
+
+#include <iosfwd>
 
 namespace amrex {
 

--- a/Src/Base/AMReX_Orientation.cpp
+++ b/Src/Base/AMReX_Orientation.cpp
@@ -1,8 +1,8 @@
 
-#include <iostream>
-
 #include <AMReX.H>
 #include <AMReX_Orientation.H>
+
+#include <iostream>
 
 namespace amrex {
 

--- a/Src/Base/AMReX_ParallelContext.H
+++ b/Src/Base/AMReX_ParallelContext.H
@@ -6,8 +6,8 @@
 #include <AMReX_Vector.H>
 #include <AMReX_ccse-mpi.H>
 
+#include <iosfwd>
 #include <memory>
-#include <fstream>
 
 namespace amrex {
 namespace ParallelContext {

--- a/Src/Base/AMReX_ParallelContext.cpp
+++ b/Src/Base/AMReX_ParallelContext.cpp
@@ -1,7 +1,8 @@
-#include <sstream>
-
 #include <AMReX_ParallelContext.H>
 #include <AMReX_ParallelDescriptor.H>
+
+#include <sstream>
+#include <fstream>
 
 namespace amrex {
 namespace ParallelContext {

--- a/Src/Base/AMReX_ParallelDescriptor.H
+++ b/Src/Base/AMReX_ParallelDescriptor.H
@@ -12,16 +12,9 @@
 #include <AMReX_REAL.H>
 #include <AMReX_Array.H>
 #include <AMReX_Vector.H>
+
 #ifndef BL_AMRPROF
 #include <AMReX_Box.H>
-#endif
-
-#ifdef BL_USE_MPI3
-#include <atomic>
-#endif
-
-#ifdef AMREX_USE_OMP
-#include <omp.h>
 #endif
 
 #ifdef BL_LAZY
@@ -32,16 +25,19 @@
 #include <pmi.h>
 #endif
 
-#include <iostream>
-#include <vector>
-#include <string>
-#include <typeinfo>
+#ifdef AMREX_USE_OMP
+#include <omp.h>
+#endif
+
 #include <algorithm>
+#include <atomic>
+#include <csignal>
 #include <functional>
-#include <iostream>
 #include <limits>
 #include <numeric>
-#include <csignal>
+#include <string>
+#include <typeinfo>
+#include <vector>
 
 namespace amrex {
 

--- a/Src/Base/AMReX_ParallelDescriptor.cpp
+++ b/Src/Base/AMReX_ParallelDescriptor.cpp
@@ -1,14 +1,4 @@
 
-#include <cstdio>
-#include <cstddef>
-#include <cstdlib>
-#include <iostream>
-#include <fstream>
-#include <sstream>
-#include <stack>
-#include <list>
-#include <chrono>
-
 #include <AMReX.H>
 #include <AMReX_Utility.H>
 #include <AMReX_BLProfiler.H>
@@ -34,6 +24,16 @@
 #ifdef AMREX_USE_OMP
 #include <omp.h>
 #endif
+
+#include <cstdio>
+#include <cstddef>
+#include <cstdlib>
+#include <iostream>
+#include <fstream>
+#include <sstream>
+#include <stack>
+#include <list>
+#include <chrono>
 
 #ifdef BL_USE_MPI
 namespace

--- a/Src/Base/AMReX_Periodicity.cpp
+++ b/Src/Base/AMReX_Periodicity.cpp
@@ -1,6 +1,6 @@
 
-#include <limits>
 #include <AMReX_Periodicity.H>
+#include <limits>
 
 namespace amrex {
 

--- a/Src/Base/AMReX_PlotFileDataImpl.H
+++ b/Src/Base/AMReX_PlotFileDataImpl.H
@@ -2,9 +2,9 @@
 #define AMREX_PLOT_FILE_DATA_IMPL_H_
 #include <AMReX_Config.H>
 
-#include <string>
 #include <AMReX_MultiFab.H>
 #include <AMReX_VisMF.H>
+#include <string>
 
 namespace amrex {
 

--- a/Src/Base/AMReX_PlotFileDataImpl.cpp
+++ b/Src/Base/AMReX_PlotFileDataImpl.cpp
@@ -1,7 +1,7 @@
-#include <algorithm>
 #include <AMReX_PlotFileDataImpl.H>
 #include <AMReX_ParallelDescriptor.H>
 #include <AMReX_VisMF.H>
+#include <algorithm>
 
 namespace amrex {
 

--- a/Src/Base/AMReX_PlotFileUtil.H
+++ b/Src/Base/AMReX_PlotFileUtil.H
@@ -2,9 +2,6 @@
 #define AMREX_PLOTFILEUTIL_H_
 #include <AMReX_Config.H>
 
-#include <string>
-#include <memory>
-
 #include <AMReX_Geometry.H>
 #include <AMReX_MultiFab.H>
 #include <AMReX_PlotFileDataImpl.H>
@@ -12,6 +9,9 @@
 #ifdef AMREX_USE_HDF5
 #include <hdf5.h>
 #endif
+
+#include <string>
+#include <memory>
 
 namespace amrex
 {

--- a/Src/Base/AMReX_PlotFileUtil.cpp
+++ b/Src/Base/AMReX_PlotFileUtil.cpp
@@ -1,7 +1,4 @@
 
-#include <fstream>
-#include <iomanip>
-
 #include <AMReX_VisMF.H>
 #include <AMReX_AsyncOut.H>
 #include <AMReX_PlotFileUtil.H>
@@ -20,6 +17,9 @@
 #endif
 
 #endif
+
+#include <fstream>
+#include <iomanip>
 
 namespace amrex {
 

--- a/Src/Base/AMReX_Print.H
+++ b/Src/Base/AMReX_Print.H
@@ -2,14 +2,14 @@
 #define AMREX_PRINT_H_
 #include <AMReX_Config.H>
 
+#include <AMReX.H>
+#include <AMReX_ParallelContext.H>
+#include <AMReX_ParallelDescriptor.H>
+
 #include <sstream>
 #include <fstream>
 #include <iomanip>
 #include <utility>
-
-#include <AMReX.H>
-#include <AMReX_ParallelContext.H>
-#include <AMReX_ParallelDescriptor.H>
 
 namespace amrex
 {

--- a/Src/Base/AMReX_Random.cpp
+++ b/Src/Base/AMReX_Random.cpp
@@ -1,6 +1,3 @@
-#include <set>
-#include <random>
-#include <limits>
 #include <AMReX_Arena.H>
 #include <AMReX_BLFort.H>
 #include <AMReX_Print.H>
@@ -8,6 +5,10 @@
 #include <AMReX_BlockMutex.H>
 #include <AMReX_Gpu.H>
 #include <AMReX_OpenMP.H>
+
+#include <set>
+#include <random>
+#include <limits>
 
 namespace
 {

--- a/Src/Base/AMReX_RealVect.H
+++ b/Src/Base/AMReX_RealVect.H
@@ -2,19 +2,19 @@
 #define AMREX_REALVECT_H_
 #include <AMReX_Config.H>
 
-#include <cstddef>
-#include <cstdlib>
-#include <cstring>
-#include <iostream>
-#include <cmath>
-
 #include <AMReX_Box.H>
 #include <AMReX_REAL.H>
 #include <AMReX_SPACE.H>
-#include <vector>
 #include <AMReX_IntVect.H>
 #include <AMReX_Utility.H>
 #include <AMReX_Math.H>
+
+#include <cmath>
+#include <cstddef>
+#include <cstdlib>
+#include <cstring>
+#include <iosfwd>
+#include <vector>
 
 namespace amrex
 {

--- a/Src/Base/AMReX_RealVect.cpp
+++ b/Src/Base/AMReX_RealVect.cpp
@@ -1,4 +1,5 @@
 #include <AMReX_RealVect.H>
+#include <iostream>
 
 namespace amrex
 {

--- a/Src/Base/AMReX_TinyProfiler.H
+++ b/Src/Base/AMReX_TinyProfiler.H
@@ -2,21 +2,21 @@
 #define AMREX_TINY_PROFILER_H_
 #include <AMReX_Config.H>
 
-#include <string>
-#include <deque>
-#include <map>
-#include <vector>
-#include <tuple>
-#include <utility>
-#include <limits>
-#include <iostream>
-
 #include <AMReX_INT.H>
 #include <AMReX_REAL.H>
 
 #ifdef AMREX_USE_CUDA
 #include "nvToolsExt.h"
 #endif
+
+#include <deque>
+#include <iosfwd>
+#include <limits>
+#include <map>
+#include <string>
+#include <tuple>
+#include <utility>
+#include <vector>
 
 namespace amrex {
 

--- a/Src/Base/AMReX_TinyProfiler.cpp
+++ b/Src/Base/AMReX_TinyProfiler.cpp
@@ -1,12 +1,6 @@
 // We only support BL_PROFILE, BL_PROFILE_VAR, BL_PROFILE_VAR_STOP, BL_PROFILE_VAR_START,
 // BL_PROFILE_VAR_NS, and BL_PROFILE_REGION.
 
-#include <algorithm>
-#include <iostream>
-#include <iomanip>
-#include <cmath>
-#include <set>
-
 #include <AMReX_TinyProfiler.H>
 #include <AMReX_ParallelDescriptor.H>
 #include <AMReX_ParallelReduce.H>
@@ -26,6 +20,11 @@
 #include <omp.h>
 #endif
 
+#include <algorithm>
+#include <cmath>
+#include <iostream>
+#include <iomanip>
+#include <set>
 
 namespace amrex {
 

--- a/Src/Base/AMReX_Tuple.H
+++ b/Src/Base/AMReX_Tuple.H
@@ -3,16 +3,16 @@
 #define AMREX_TUPLE_H_
 #include <AMReX_Config.H>
 
-#include <array>
-
-#include <tuple>
-#include <functional>
-#include <type_traits>
-#include <utility>
 #include <AMReX_TypeTraits.H>
 #include <AMReX_IndexSequence.H>
 #include <AMReX_Functional.H>
 #include <AMReX_GpuQualifiers.H>
+
+#include <array>
+#include <tuple>
+#include <functional>
+#include <type_traits>
+#include <utility>
 
 namespace amrex {
     template <class... Ts>

--- a/Src/Base/AMReX_TypeTraits.H
+++ b/Src/Base/AMReX_TypeTraits.H
@@ -2,8 +2,8 @@
 #define BL_TYPETRAITS_H_
 #include <AMReX_Config.H>
 
-#include <type_traits>
 #include <AMReX_Extension.H>
+#include <type_traits>
 
 // workaround missing "is_trivially_copyable" in g++ < 5.0
 #if defined(__GNUG__) && __GNUC__ < 5 && !defined(AMREX_CXX_CLANG)

--- a/Src/Base/AMReX_Utility.H
+++ b/Src/Base/AMReX_Utility.H
@@ -2,17 +2,6 @@
 #define BL_UTILITY_H
 #include <AMReX_Config.H>
 
-#include <cstdlib>
-#include <iostream>
-#include <sstream>
-#include <string>
-#include <map>
-#include <chrono>
-#include <type_traits>
-#include <climits>
-#include <limits>
-#include <cfloat>
-
 #include <AMReX_BLassert.H>
 #include <AMReX_REAL.H>
 #include <AMReX_INT.H>
@@ -25,6 +14,17 @@
 #include <AMReX_Random.H>
 #include <AMReX_GpuQualifiers.H>
 #include <AMReX_FileSystem.H>
+
+#include <cfloat>
+#include <chrono>
+#include <climits>
+#include <cstdlib>
+#include <iostream>
+#include <limits>
+#include <map>
+#include <sstream>
+#include <string>
+#include <type_traits>
 
 namespace amrex
 {

--- a/Src/Base/AMReX_Vector.H
+++ b/Src/Base/AMReX_Vector.H
@@ -2,9 +2,6 @@
 #define AMREX_VECTOR_H_
 #include <AMReX_Config.H>
 
-#include <algorithm>
-#include <vector>
-#include <memory>
 #include <AMReX_BLassert.H>
 #include <AMReX_Extension.H>
 #include <AMReX_INT.H>
@@ -12,6 +9,10 @@
 #include <AMReX_Array.H>
 #include <AMReX_TypeTraits.H>
 #endif
+
+#include <algorithm>
+#include <memory>
+#include <vector>
 
 namespace amrex {
 /**

--- a/Src/Base/AMReX_VectorIO.H
+++ b/Src/Base/AMReX_VectorIO.H
@@ -2,11 +2,11 @@
 #define AMREX_VECTORIO_H_
 #include <AMReX_Config.H>
 
-#include <iostream>
+#include <AMReX_FPC.H>
+#include <AMReX_FabConv.H>
+#include <AMReX_IntConv.H>
 
-#include "AMReX_FPC.H"
-#include "AMReX_FabConv.H"
-#include "AMReX_IntConv.H"
+#include <iosfwd>
 
 namespace amrex {
 

--- a/Src/Base/AMReX_VectorIO.cpp
+++ b/Src/Base/AMReX_VectorIO.cpp
@@ -1,4 +1,5 @@
-#include "AMReX_VectorIO.H"
+#include <AMReX_VectorIO.H>
+#include <iostream>
 
 using namespace amrex;
 

--- a/Src/Base/AMReX_VisMF.H
+++ b/Src/Base/AMReX_VisMF.H
@@ -3,20 +3,19 @@
 #define BL_VISMF_H
 #include <AMReX_Config.H>
 
-#include <iosfwd>
-#include <string>
-#include <fstream>
-#include <thread>
-#include <utility>
-#include <cstdint>
-#include <queue>
-
 #include <AMReX_Extension.H>
 #include <AMReX_REAL.H>
 #include <AMReX_FabArray.H>
 #include <AMReX_FArrayBox.H>
 #include <AMReX_FabConv.H>
 #include <AMReX_AsyncOut.H>
+
+#include <cstdint>
+#include <iosfwd>
+#include <queue>
+#include <string>
+#include <thread>
+#include <utility>
 
 namespace amrex {
 

--- a/Src/Base/AMReX_VisMF.cpp
+++ b/Src/Base/AMReX_VisMF.cpp
@@ -1,16 +1,3 @@
-#include <fstream>
-#include <iostream>
-#include <sstream>
-#include <vector>
-#include <deque>
-#include <cerrno>
-#include <atomic>
-#include <cstdio>
-#include <limits>
-#include <array>
-#include <memory>
-#include <numeric>
-
 #include <AMReX_ccse-mpi.H>
 #include <AMReX_Utility.H>
 #include <AMReX_VisMF.H>
@@ -19,6 +6,19 @@
 #include <AMReX_FPC.H>
 #include <AMReX_FabArrayUtility.H>
 #include <AMReX_AsyncOut.H>
+
+#include <array>
+#include <atomic>
+#include <cerrno>
+#include <cstdio>
+#include <deque>
+#include <fstream>
+#include <iostream>
+#include <limits>
+#include <memory>
+#include <numeric>
+#include <sstream>
+#include <vector>
 
 namespace amrex {
 

--- a/Src/Base/AMReX_iMultiFab.cpp
+++ b/Src/Base/AMReX_iMultiFab.cpp
@@ -1,4 +1,11 @@
 
+#include <AMReX_BLassert.H>
+#include <AMReX_iMultiFab.H>
+#include <AMReX_MultiFabUtil.H>
+#include <AMReX_ParallelDescriptor.H>
+#include <AMReX_BLProfiler.H>
+#include <AMReX_ParmParse.H>
+
 #include <algorithm>
 #include <cfloat>
 #include <iostream>
@@ -6,13 +13,6 @@
 #include <map>
 #include <limits>
 #include <climits>
-
-#include <AMReX_BLassert.H>
-#include <AMReX_iMultiFab.H>
-#include <AMReX_MultiFabUtil.H>
-#include <AMReX_ParallelDescriptor.H>
-#include <AMReX_BLProfiler.H>
-#include <AMReX_ParmParse.H>
 
 namespace amrex {
 

--- a/Src/Base/AMReX_parmparse_fi.cpp
+++ b/Src/Base/AMReX_parmparse_fi.cpp
@@ -1,9 +1,10 @@
-#include <cstring>
 #include <AMReX_ParmParse.H>
 #include <AMReX_Array.H>
 #include <AMReX_Vector.H>
 #include <AMReX_REAL.H>
 #include <AMReX_Print.H>
+
+#include <cstring>
 
 using namespace amrex;
 

--- a/Src/Base/AMReX_parstream.H
+++ b/Src/Base/AMReX_parstream.H
@@ -2,7 +2,7 @@
 #define AMREX_PARSTREAM_H_
 #include <AMReX_Config.H>
 
-#include <iostream>
+#include <iosfwd>
 #include <string>
 namespace amrex
 {

--- a/Src/Base/AMReX_parstream.cpp
+++ b/Src/Base/AMReX_parstream.cpp
@@ -1,8 +1,9 @@
-#include <cstdio>
-#include <fstream>
 #include <AMReX_parstream.H>
 #include <AMReX_ParmParse.H>
 #include <AMReX_ParallelDescriptor.H>
+
+#include <cstdio>
+#include <fstream>
 
 namespace amrex
 {

--- a/Src/Base/CMakeLists.txt
+++ b/Src/Base/CMakeLists.txt
@@ -91,6 +91,7 @@ target_sources( amrex
    AMReX_BoxIterator.H
    AMReX_BoxIterator.cpp
    AMReX_Dim3.H
+   AMReX_Dim3.cpp
    AMReX_IntVect.H
    AMReX_IntVect.cpp
    AMReX_IndexType.H

--- a/Src/Base/Make.package
+++ b/Src/Base/Make.package
@@ -109,6 +109,7 @@ C${AMREX_BASE}_sources += AMReX_FabConv.cpp AMReX_FPC.cpp AMReX_IntConv.cpp AMRe
 C$(AMREX_BASE)_sources += AMReX_Box.cpp AMReX_BoxIterator.cpp AMReX_IntVect.cpp AMReX_IndexType.cpp AMReX_Orientation.cpp AMReX_Periodicity.cpp
 C$(AMREX_BASE)_headers += AMReX_Box.H AMReX_BoxIterator.H AMReX_IntVect.H AMReX_IndexType.H AMReX_Orientation.H AMReX_Periodicity.H
 
+C$(AMREX_BASE)_sources += AMReX_Dim3.cpp
 C$(AMREX_BASE)_headers += AMReX_Dim3.H AMReX_Loop.H
 
 #

--- a/Src/Boundary/AMReX_Mask.cpp
+++ b/Src/Boundary/AMReX_Mask.cpp
@@ -1,7 +1,7 @@
 
-#include <cstdlib>
 #include <AMReX_Mask.H>
 #include <AMReX_Utility.H>
+#include <cstdlib>
 
 namespace amrex {
 

--- a/Src/EB/AMReX_EB2_IF_Base.H
+++ b/Src/EB/AMReX_EB2_IF_Base.H
@@ -2,9 +2,9 @@
 #define AMREX_EB2_IF_BASE_H_
 #include <AMReX_Config.H>
 
-#include <type_traits>
 #include <AMReX_Gpu.H>
 #include <AMReX_Utility.H>
+#include <type_traits>
 
 namespace amrex {
 

--- a/Src/EB/AMReX_EB2_IF_Spline.H
+++ b/Src/EB/AMReX_EB2_IF_Spline.H
@@ -3,13 +3,12 @@
 #define AMREX_EB2_IF_SPLINE_H_
 #include <AMReX_Config.H>
 
-#include <vector>
 #include <AMReX_EB2_IF_Base.H>
-#include "AMReX_RealVect.H"
-#include "AMReX.H"
-#include "AMReX_Vector.H"
-#include "AMReX_Array.H"
-#include "AMReX_distFcnElement.H"
+#include <AMReX_RealVect.H>
+#include <AMReX.H>
+#include <AMReX_Vector.H>
+#include <AMReX_Array.H>
+#include <AMReX_distFcnElement.H>
 
 namespace amrex { namespace EB2 {
 

--- a/Src/EB/AMReX_EB2_Level.H
+++ b/Src/EB/AMReX_EB2_Level.H
@@ -14,14 +14,14 @@
 #include <AMReX_EB2_C.H>
 #include <AMReX_EB2_IF_AllRegular.H>
 
+#ifdef AMREX_USE_OMP
+#include <omp.h>
+#endif
+
 #include <unordered_map>
 #include <limits>
 #include <cmath>
 #include <type_traits>
-
-#ifdef AMREX_USE_OMP
-#include <omp.h>
-#endif
 
 namespace amrex { namespace EB2 {
 

--- a/Src/EB/AMReX_EBCellFlag.H
+++ b/Src/EB/AMReX_EBCellFlag.H
@@ -2,13 +2,14 @@
 #define AMREX_EBCELLFLAG_H_
 #include <AMReX_Config.H>
 
-#include <cstdint>
-#include <iostream>
-#include <map>
 #include <AMReX_Array.H>
 #include <AMReX_IntVect.H>
 #include <AMReX_BaseFab.H>
 #include <AMReX_FabFactory.H>
+
+#include <cstdint>
+#include <map>
+#include <iosfwd>
 
 namespace amrex {
 

--- a/Src/EB/AMReX_EBCellFlag.cpp
+++ b/Src/EB/AMReX_EBCellFlag.cpp
@@ -1,5 +1,6 @@
 #include <AMReX_EBCellFlag.H>
 #include <AMReX_Reduce.H>
+#include <iostream>
 
 namespace amrex {
 

--- a/Src/EB/AMReX_EBToPVD.H
+++ b/Src/EB/AMReX_EBToPVD.H
@@ -7,7 +7,7 @@
 
 #include <vector>
 #include <array>
-#include <fstream>
+#include <iosfwd>
 
 namespace amrex {
 

--- a/Src/EB/AMReX_EB_STL_utils.H
+++ b/Src/EB/AMReX_EB_STL_utils.H
@@ -5,8 +5,8 @@
 #include <AMReX.H>
 #include <AMReX_ParmParse.H>
 #include <AMReX_MultiFab.H>
-#include<AMReX_REAL.H>
-#include<AMReX_Vector.H>
+#include <AMReX_REAL.H>
+#include <AMReX_Vector.H>
 #include <AMReX_Geometry.H>
 #include <AMReX_FArrayBox.H>
 #include <AMReX_Box.H>

--- a/Src/EB/AMReX_distFcnElement.H
+++ b/Src/EB/AMReX_distFcnElement.H
@@ -2,10 +2,9 @@
 #define AMREX_DISTFCNELEMENT_H_
 #include <AMReX_Config.H>
 
-#include <vector>
-#include "AMReX_RealVect.H"
-#include "AMReX.H"
-#include "AMReX_Vector.H"
+#include <AMReX_RealVect.H>
+#include <AMReX.H>
+#include <AMReX_Vector.H>
 
 namespace amrex {
 

--- a/Src/Extern/HYPRE/AMReX_Hypre.H
+++ b/Src/Extern/HYPRE/AMReX_Hypre.H
@@ -2,14 +2,14 @@
 #define AMREX_HYPRE_H_
 #include <AMReX_Config.H>
 
-#include <memory>
-
 #include <AMReX_Geometry.H>
 #include <AMReX_MultiFab.H>
 #include <AMReX_BndryData.H>
 
 #include "HYPRE.h"
 #include "_hypre_utilities.h"
+
+#include <memory>
 
 namespace amrex
 {

--- a/Src/Extern/HYPRE/AMReX_HypreABecLap.H
+++ b/Src/Extern/HYPRE/AMReX_HypreABecLap.H
@@ -2,10 +2,6 @@
 #define AMREX_HypreABecLap_H_
 #include <AMReX_Config.H>
 
-#include <iomanip>
-#include <iostream>
-#include <memory>
-
 #include <AMReX_Hypre.H>
 #include <AMReX_Array.H>
 #include <AMReX_Geometry.H>
@@ -15,6 +11,8 @@
 #include <AMReX_LO_BCTYPES.H>
 
 #include <HYPRE_struct_ls.h>
+
+#include <memory>
 
 namespace amrex {
 

--- a/Src/Extern/HYPRE/AMReX_HypreABecLap.cpp
+++ b/Src/Extern/HYPRE/AMReX_HypreABecLap.cpp
@@ -1,11 +1,11 @@
 
 #include <AMReX_HypreABecLap.H>
-#include <string>
-#include <algorithm>
-
 #include <AMReX_Habec_K.H>
 
 #include <_hypre_struct_mv.h>
+
+#include <string>
+#include <algorithm>
 
 namespace amrex {
 

--- a/Src/Extern/HYPRE/AMReX_HypreIJIface.H
+++ b/Src/Extern/HYPRE/AMReX_HypreIJIface.H
@@ -2,13 +2,13 @@
 #define AMREX_HYPREIJIFACE_H
 #include <AMReX_Config.H>
 
-#include <memory>
-
 #include <AMReX_MultiFab.H>
 
 #include <HYPRE.h>
 #include <HYPRE_parcsr_ls.h>
 #include <HYPRE_parcsr_mv.h>
+
+#include <memory>
 
 namespace amrex {
 

--- a/Src/Extern/HYPRE/AMReX_HypreNodeLap.H
+++ b/Src/Extern/HYPRE/AMReX_HypreNodeLap.H
@@ -2,9 +2,6 @@
 #define AMREX_HYPRE_NODE_LAP_H_
 #include <AMReX_Config.H>
 
-#include <memory>
-#include <algorithm>
-
 #include <AMReX_Geometry.H>
 #include <AMReX_MultiFab.H>
 #include <AMReX_iMultiFab.H>
@@ -13,6 +10,8 @@
 #include <AMReX_MultiFabUtil.H>
 #include <AMReX_HypreIJIface.H>
 
+#include <memory>
+#include <algorithm>
 
 namespace amrex {
 

--- a/Src/F_Interfaces/AmrCore/AMReX_FAmrCore.H
+++ b/Src/F_Interfaces/AmrCore/AMReX_FAmrCore.H
@@ -2,10 +2,9 @@
 #define AMREX_FAMRCORE_H_
 #include <AMReX_Config.H>
 
-#include <functional>
-
 #include <AMReX_AmrCore.H>
 #include <AMReX_MultiFab.H>
+#include <functional>
 
 namespace amrex {
 

--- a/Src/Particle/AMReX_Particle.H
+++ b/Src/Particle/AMReX_Particle.H
@@ -2,15 +2,14 @@
 #define AMREX_PARTICLE_H_
 #include <AMReX_Config.H>
 
-#include <string>
-
 #include <AMReX_REAL.H>
 #include <AMReX_FArrayBox.H>
 #include <AMReX_IntVect.H>
 #include <AMReX_RealVect.H>
-
 #include <AMReX_ParmParse.H>
 #include <AMReX_Geometry.H>
+
+#include <string>
 
 namespace amrex {
 

--- a/Src/Particle/AMReX_ParticleMPIUtil.H
+++ b/Src/Particle/AMReX_ParticleMPIUtil.H
@@ -2,9 +2,8 @@
 #define AMREX_PARTICLEMPIUTIL_H_
 #include <AMReX_Config.H>
 
-#include <map>
-
 #include <AMReX_Vector.H>
+#include <map>
 
 namespace amrex {
 

--- a/Src/Particle/AMReX_Particles.H
+++ b/Src/Particle/AMReX_Particles.H
@@ -2,22 +2,6 @@
 #define AMREX_PARTICLES_H_
 #include <AMReX_Config.H>
 
-#include <cstring>
-#include <map>
-#include <deque>
-#include <vector>
-#include <fstream>
-#include <iostream>
-#include <numeric>
-#include <algorithm>
-#include <array>
-#include <memory>
-#include <limits>
-#include <utility>
-#include <tuple>
-#include <type_traits>
-#include <random>
-
 #include <AMReX_ParticleContainerBase.H>
 #include <AMReX_ParmParse.H>
 #include <AMReX_ParGDB.H>
@@ -64,6 +48,21 @@
 #ifdef AMREX_USE_HDF5
 #include <hdf5.h>
 #endif
+
+#include <algorithm>
+#include <array>
+#include <cstring>
+#include <fstream>
+#include <iostream>
+#include <limits>
+#include <map>
+#include <memory>
+#include <numeric>
+#include <random>
+#include <tuple>
+#include <type_traits>
+#include <utility>
+#include <vector>
 
 namespace amrex {
 

--- a/Src/Particle/AMReX_TracerParticle_mod_K.H
+++ b/Src/Particle/AMReX_TracerParticle_mod_K.H
@@ -6,11 +6,11 @@
 #include <AMReX_Box.H>
 #include <AMReX_Gpu.H>
 #include <AMReX_Geometry.H>
-#include <cmath>
 #include <AMReX_REAL.H>
 #include <AMReX_IntVect.H>
-#include "AMReX_TracerParticles.H"
+#include <AMReX_TracerParticles.H>
 
+#include <cmath>
 
 namespace amrex{
 

--- a/Src/Particle/AMReX_TracerParticles.cpp
+++ b/Src/Particle/AMReX_TracerParticles.cpp
@@ -1,7 +1,7 @@
 #include <AMReX_TracerParticle_mod_K.H>
 #include <AMReX_TracerParticles.H>
-#include "AMReX_TracerParticles.H"
-#include "AMReX_TracerParticle_mod_K.H"
+#include <AMReX_TracerParticles.H>
+#include <AMReX_TracerParticle_mod_K.H>
 #include <AMReX_Print.H>
 namespace amrex {
 


### PR DESCRIPTION
Include amrex headers before standard C++ headers.

Use iosfwd instead of iostream if we can.