### PR TITLE
Make FabArray::setFab safer

### DIFF
--- a/Src/Base/AMReX_FArrayBox.H
+++ b/Src/Base/AMReX_FArrayBox.H
@@ -262,7 +262,7 @@ public:
 
     explicit FArrayBox (Array4<Real> const& a) noexcept : BaseFab<Real>(a) {}
 
-    explicit FArrayBox (Array4<Real> const& a, IndexType t) noexcept : BaseFab<Real>(a,t) {}
+    FArrayBox (Array4<Real> const& a, IndexType t) noexcept : BaseFab<Real>(a,t) {}
 
     explicit FArrayBox (Array4<Real const> const& a) noexcept : BaseFab<Real>(a) {}
 

--- a/Src/Base/AMReX_FabArray.H
+++ b/Src/Base/AMReX_FabArray.H
@@ -351,10 +351,18 @@ public:
     Array4<typename FabArray<FAB>::value_type const> const_array (int K, int start_comp) const noexcept;
 
     //! Explicitly set the Kth FAB in the FabArray to point to elem.
-    void setFab (int K, FAB* elem);
+    void setFab (int K, std::unique_ptr<FAB> elem);
+
+    //! Explicitly set the Kth FAB in the FabArray to point to elem.
+    template <class F=FAB, std::enable_if_t<std::is_move_constructible<F>::value,int> = 0>
+    void setFab (int K, FAB&& elem);
 
     //! Explicitly set the FAB associated with mfi in the FabArray to point to elem.
-    void setFab (const MFIter&mfi, FAB* elem, bool assertion=true);
+    void setFab (const MFIter&mfi, std::unique_ptr<FAB> elem);
+
+    //! Explicitly set the FAB associated with mfi in the FabArray to point to elem.
+    template <class F=FAB, std::enable_if_t<std::is_move_constructible<F>::value,int> = 0>
+    void setFab (const MFIter&mfi, FAB&& elem);
 
     //! Release ownership of the FAB. This function is not thread safe.
     AMREX_NODISCARD
@@ -898,6 +906,8 @@ private:
     void AllocFabs (const FabFactory<FAB>& factory, Arena* ar,
                     const Vector<std::string>& tags);
 
+    void setFab_assert (int K, FAB const& fab) const;
+
 public:
 
 #ifdef BL_USE_MPI
@@ -1223,8 +1233,10 @@ FabArray<FAB>::clear ()
 
     Long nbytes = 0L;
     for (auto x : m_fabs_v) {
-        if (x) nbytes += amrex::nBytesOwned(*x);
-        m_factory->destroy(x);
+        if (x) {
+            nbytes += amrex::nBytesOwned(*x);
+            m_factory->destroy(x);
+        }
     }
     m_fabs_v.clear();
     m_factory.reset();
@@ -1561,56 +1573,99 @@ FabArray<FAB>::AllocFabs (const FabFactory<FAB>& factory, Arena* ar,
 
 template <class FAB>
 void
-FabArray<FAB>::setFab (int  boxno,
-                       FAB* elem)
+FabArray<FAB>::setFab_assert (int K, FAB const& fab) const
 {
-    //
-    // Must check it is of the proper size.
-    //
-    if (n_comp == 0) {
-        n_comp = elem->nComp();
-    }
-
-    BL_ASSERT(n_comp == elem->nComp());
-    BL_ASSERT(boxarray.size() > 0);
-    BL_ASSERT(elem->box() == fabbox(boxno));
-    BL_ASSERT(!this->defined(boxno));
-    BL_ASSERT(distributionMap[boxno] == ParallelDescriptor::MyProc());
-
-    if (m_fabs_v.size() == 0) {
-      m_fabs_v.resize(indexArray.size(),nullptr);
-    }
-
-    const int li = localindex(boxno);
-    m_fabs_v[li] = elem;
+    amrex::ignore_unused(K,fab);
+    AMREX_ASSERT(n_comp == fab.nComp());
+    AMREX_ASSERT(boxarray.size() > 0);
+    AMREX_ASSERT(fab.box() == fabbox(K));
+    AMREX_ASSERT(distributionMap[K] == ParallelDescriptor::MyProc());
 }
 
 template <class FAB>
 void
-FabArray<FAB>::setFab (const MFIter& mfi,
-                       FAB* elem, bool assertion)
+FabArray<FAB>::setFab (int boxno, std::unique_ptr<FAB> elem)
 {
-    if (assertion)
-    {
-        //
-        // Must check it is of the proper size.
-        //
-        if (n_comp == 0)
-            n_comp = elem->nComp();
-
-        BL_ASSERT(n_comp == elem->nComp());
-        BL_ASSERT(boxarray.size() > 0);
-        BL_ASSERT(elem->box() == fabbox(mfi.index()));
-        BL_ASSERT(!this->defined(mfi));
-        BL_ASSERT(distributionMap[mfi.index()] == ParallelDescriptor::MyProc());
+    if (n_comp == 0) {
+        n_comp = elem->nComp();
     }
 
+    setFab_assert(boxno, *elem);
+
     if (m_fabs_v.size() == 0) {
-      m_fabs_v.resize(indexArray.size(),nullptr);
+        m_fabs_v.resize(indexArray.size(),nullptr);
+    }
+
+    const int li = localindex(boxno);
+    if (m_fabs_v[li]) {
+        m_factory->destroy(m_fabs_v[li]);
+    }
+    m_fabs_v[li] = elem.release();
+}
+
+template <class FAB>
+template <class F, std::enable_if_t<std::is_move_constructible<F>::value,int> >
+void
+FabArray<FAB>::setFab (int boxno, FAB&& elem)
+{
+    if (n_comp == 0) {
+        n_comp = elem.nComp();
+    }
+
+    setFab_assert(boxno, elem);
+
+    if (m_fabs_v.size() == 0) {
+        m_fabs_v.resize(indexArray.size(),nullptr);
+    }
+
+    const int li = localindex(boxno);
+    if (m_fabs_v[li]) {
+        m_factory->destroy(m_fabs_v[li]);
+    }
+    m_fabs_v[li] = new FAB(std::move(elem));
+}
+
+template <class FAB>
+void
+FabArray<FAB>::setFab (const MFIter& mfi, std::unique_ptr<FAB> elem)
+{
+    if (n_comp == 0) {
+        n_comp = elem->nComp();
+    }
+
+    setFab_assert(mfi.index(), *elem);
+
+    if (m_fabs_v.size() == 0) {
+        m_fabs_v.resize(indexArray.size(),nullptr);
     }
 
     const int li = mfi.LocalIndex();
-    m_fabs_v[li] = elem;
+    if (m_fabs_v[li]) {
+        m_factory->destroy(m_fabs_v[li]);
+    }
+    m_fabs_v[li] = elem.release();
+}
+
+template <class FAB>
+template <class F, std::enable_if_t<std::is_move_constructible<F>::value,int> >
+void
+FabArray<FAB>::setFab (const MFIter& mfi, FAB&& elem)
+{
+    if (n_comp == 0) {
+        n_comp = elem.nComp();
+    }
+
+    setFab_assert(mfi.index(), elem);
+
+    if (m_fabs_v.size() == 0) {
+        m_fabs_v.resize(indexArray.size(),nullptr);
+    }
+
+    const int li = mfi.LocalIndex();
+    if (m_fabs_v[li]) {
+        m_factory->destroy(m_fabs_v[li]);
+    }
+    m_fabs_v[li] = new FAB(std::move(elem));
 }
 
 template <class FAB>

--- a/Src/Base/AMReX_MultiFabUtil.cpp
+++ b/Src/Base/AMReX_MultiFabUtil.cpp
@@ -858,13 +858,12 @@ namespace amrex
             b.shift(offset);
         }
         BoxArray nba(std::move(bl));
-        MultiFab nmf(nba, mf.DistributionMap(), mf.nComp(), 0,
-                     MFInfo().SetAlloc(false));
+        MultiFab nmf(nba, mf.DistributionMap(), mf.nComp(), 0, MFInfo().SetAlloc(false));
 
         for (MFIter mfi(r); mfi.isValid(); ++mfi) {
             auto const& rfab = r[mfi];
-            nmf.setFab(mfi, new FArrayBox(nba[mfi.index()], rfab.nComp(),
-                                          rfab.dataPtr()), false);
+            nmf.setFab(mfi, FArrayBox(amrex::shift(rfab.box(),offset), rfab.nComp(),
+                                      rfab.dataPtr()));
         }
 
         nmf.ParallelCopy(mf, period);

--- a/Src/Base/AMReX_ParallelDescriptor.H
+++ b/Src/Base/AMReX_ParallelDescriptor.H
@@ -854,7 +854,7 @@ ParallelDescriptor::Bcast (T*     t,
     Lazy::EvalReduction();
 #endif
 
-    BL_ASSERT(n < std::numeric_limits<int>::max());
+    BL_ASSERT(n < static_cast<size_t>(std::numeric_limits<int>::max()));
 
     BL_PROFILE_T_S("ParallelDescriptor::Bcast(Tsi)", T);
     BL_COMM_PROFILE(BLProfiler::BCastTsi, BLProfiler::BeforeCall(), root, BLProfiler::NoTag());
@@ -881,7 +881,7 @@ ParallelDescriptor::Bcast (T*     t,
         Lazy::EvalReduction();
 #endif
 
-    BL_ASSERT(n < std::numeric_limits<int>::max());
+    BL_ASSERT(n < static_cast<size_t>(std::numeric_limits<int>::max()));
 
     BL_PROFILE_T_S("ParallelDescriptor::Bcast(Tsi)", T);
     BL_COMM_PROFILE(BLProfiler::BCastTsi, BLProfiler::BeforeCall(), root, BLProfiler::NoTag());
@@ -905,8 +905,8 @@ ParallelDescriptor::Gather (const T* t,
     BL_PROFILE_T_S("ParallelDescriptor::Gather(TsT1si)", T);
     BL_COMM_PROFILE(BLProfiler::GatherTsT1Si, BLProfiler::BeforeCall(), root, BLProfiler::NoTag());
 
-    BL_ASSERT(n  < std::numeric_limits<int>::max());
-    BL_ASSERT(n1 < std::numeric_limits<int>::max());
+    BL_ASSERT(n  < static_cast<size_t>(std::numeric_limits<int>::max()));
+    BL_ASSERT(n1 < static_cast<size_t>(std::numeric_limits<int>::max()));
 
     BL_MPI_REQUIRE( MPI_Gather(const_cast<T*>(t),
                                n,

--- a/Src/EB/AMReX_EB2_MultiGFab.cpp
+++ b/Src/EB/AMReX_EB2_MultiGFab.cpp
@@ -54,8 +54,7 @@ MultiGFab::getLevelSet ()
 
     for (MFIter mfi(*this); mfi.isValid(); ++mfi) {
         auto& fab = (*this)[mfi].getLevelSet();
-        FArrayBox* p = new FArrayBox(fab.box(),1,fab.dataPtr());
-        r.setFab(mfi,p);
+        r.setFab(mfi, FArrayBox(fab.box(), fab.nComp(), fab.dataPtr()));
     }
 
     return r;

--- a/Src/EB/AMReX_MultiCutFab.cpp
+++ b/Src/EB/AMReX_MultiCutFab.cpp
@@ -38,9 +38,7 @@ MultiCutFab::remove ()
     {
         if (!ok(mfi))
         {
-            CutFab* p = &(m_data[mfi]);
-            delete p;
-            m_data.setFab(mfi, new CutFab(), false);
+            delete m_data.release(mfi);
         }
     }
 }


### PR DESCRIPTION
Instead of taking a raw pointer, it takes std::unique_ptr or rvalue FAB, so
that the ownership is very clear.  It also deletes the old FAB if not null.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
