### PR TITLE
Remove __attribute__((warn_unused_result)) from AMREX_NODISCARD

### DIFF
--- a/Src/Base/AMReX_Extension.H
+++ b/Src/Base/AMReX_Extension.H
@@ -169,11 +169,9 @@
 #define AMREX_FALLTHROUGH ((void)0)
 #endif
 
-// CI uses -Werror -Wc++17-extentsion, thus we need to add the __cplusplus clause
+// CI uses -Werror -Wc++17-extension, thus we need to add the __cplusplus clause
 #if !defined(AMREX_NO_NODISCARD) && defined(__has_cpp_attribute) && __has_cpp_attribute(nodiscard) && __cplusplus >= 201603L
 #   define AMREX_NODISCARD [[nodiscard]]
-#elif !defined(AMREX_NO_NODISCARD) && (defined(__GNUC__) || defined(__clang__))
-#   define AMREX_NODISCARD __attribute__ ((warn_unused_result))
 #else
 #   define AMREX_NODISCARD
 #endif


### PR DESCRIPTION
This appears to be buggy in our CI, for example: https://github.com/AMReX-Codes/amrex/pull/1876/checks?check_run_id=2146238004

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
