### PR TITLE
[CMake] Fix path to tests inputs file

### DIFF
--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -80,7 +80,8 @@ function (setup_test _srcs  _inputs)
 
    if (${_inputs})
       file( COPY ${${_inputs}} DESTINATION ${_exe_dir} )
-      get_filename_component( _inputs_filename ${${_inputs}} NAME )
+      list(GET ${_inputs} 0 _first_inputs)
+      get_filename_component( _inputs_filename ${_first_inputs} NAME )
       list(APPEND _cmd ${_inputs_filename})
    endif ()
 

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -80,7 +80,8 @@ function (setup_test _srcs  _inputs)
 
    if (${_inputs})
       file( COPY ${${_inputs}} DESTINATION ${_exe_dir} )
-      list(APPEND _cmd ${${_inputs}})
+      get_filename_component( _inputs_filename ${${_inputs}} NAME )
+      list(APPEND _cmd ${_inputs_filename})
    endif ()
 
    #


### PR DESCRIPTION
The inputs file gets copied to the test run directory from a location that sometimes includes a subdirectory, for example `Exec/inputs`. But, then the run command will also include the sub-directory. This makes it so that the directory is stripped out, so that the run command will be `./<exe> inputs` instead of `./<exe> Exec/inputs`.  

Furthermore, in the event that multiple files are passed in as _`inputs`, so that e.g. `probin` can be copied, we should only actually run the test with the first inputs file. 

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
