### PR TITLE
Remove unnecessary abort.

### DIFF
--- a/Src/EB/AMReX_distFcnElement.cpp
+++ b/Src/EB/AMReX_distFcnElement.cpp
@@ -400,7 +400,6 @@ amrex::Real LineDistFcnElement2d::cpside(amrex::RealVect pt,
     }
     */
   }
-  amrex::Abort("Should not get here");
 }
 
 void LineDistFcnElement2d::set_control_points


### PR DESCRIPTION
It is logically impossible to reach this abort, and in fact it is an error in some of our CI because we use `-Wunreachable-code`.

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
