### PR TITLE
CMake: add test_install

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -23,6 +23,7 @@ jobs:
             -DCMAKE_CXX_STANDARD=17
         make -j 2
         make install
+        make test_install
 
         export PATH=/tmp/my-amrex/bin:$PATH
         which fcompare
@@ -54,6 +55,7 @@ jobs:
             -DCMAKE_Fortran_COMPILER=$(which gfortran)
         make -j 2
         make install
+        make test_install
 
         export PATH=/tmp/my-amrex/bin:$PATH
         which fcompare

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,8 +136,13 @@ endif ()
 if(AMReX_INSTALL)
     include(AMReXInstallHelpers)
     install_amrex_targets(${_amrex_targets})
-endif()
 
+    # Add a test_install target to smoke-test
+    # the installation
+    add_test_install_target(
+       ${CMAKE_CURRENT_LIST_DIR}/Tests/CMakeTestInstall
+       ${CMAKE_INSTALL_PREFIX})
+endif()
 
 #
 # Enable CTests

--- a/Docs/sphinx_documentation/source/BuildingAMReX.rst
+++ b/Docs/sphinx_documentation/source/BuildingAMReX.rst
@@ -369,6 +369,7 @@ The CMake build process is summarized as follows:
     cd    /path/to/builddir
     cmake [options] -DCMAKE_BUILD_TYPE=[Debug|Release|RelWithDebInfo|MinSizeRel] -DCMAKE_INSTALL_PREFIX=/path/to/installdir  /path/to/amrex
     make  install
+    make  test_install  # optional step to test if the installation is working
 
 In the above snippet, ``[options]`` indicates one or more options for the
 customization of the build, as described in the subsection on

--- a/Tests/CMakeTestInstall/CMakeLists.txt
+++ b/Tests/CMakeTestInstall/CMakeLists.txt
@@ -1,0 +1,63 @@
+#
+# Test the amrex installation by
+# building and running the code
+# in Tests/Amr/Advection_AmrCore/
+#
+cmake_minimum_required(VERSION 3.14)
+
+project(amrex-test-install)
+
+get_filename_component(_base_dir ${CMAKE_CURRENT_LIST_DIR} DIRECTORY)
+
+set(_base_dir  ${_base_dir}/Amr/Advection_AmrCore)
+set(_src_dir   ${_base_dir}/Source)
+set(_input_dir ${_base_dir}/Exec)
+
+
+find_package(AMReX REQUIRED)
+
+if (AMReX_3D_FOUND)
+   set(_dim 3)
+elseif (AMReX_2D_FOUND)
+   set(_dim 2)
+else ()
+   message(FATAL_ERROR "Cannot find a 2D or 3D version of AMReX")
+endif ()
+
+
+add_executable(install_test)
+
+target_link_libraries(install_test PUBLIC AMReX::amrex)
+
+target_include_directories(install_test
+   PUBLIC
+   ${_src_dir}
+   ${_src_dir}/Src_K/
+   ${_input_dir}
+   )
+
+target_sources(install_test
+   PRIVATE
+   ${_src_dir}/AdvancePhiAllLevels.cpp
+   ${_src_dir}/AdvancePhiAtLevel.cpp
+   ${_src_dir}/AmrCoreAdv.cpp
+   ${_src_dir}/AmrCoreAdv.H
+   ${_src_dir}/bc_fill.H
+   ${_src_dir}/DefineVelocity.cpp
+   ${_src_dir}/face_velocity.H
+   ${_src_dir}/Kernels.H
+   ${_src_dir}/main.cpp
+   ${_src_dir}/Tagging.H
+   ${_src_dir}/Src_K/Adv_K.H
+   ${_src_dir}/Src_K/compute_flux_2D_K.H
+   ${_src_dir}/Src_K/slope_K.H
+   ${_input_dir}/Prob.H
+   )
+
+add_custom_command(
+   TARGET install_test
+   POST_BUILD
+   COMMAND ${CMAKE_COMMAND} -E echo "Running test project"
+   COMMAND ${PROJECT_BINARY_DIR}/install_test ${_input_dir}/inputs max_step=1 > out.txt
+   WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
+   )

--- a/Tools/CMake/AMReXInstallHelpers.cmake
+++ b/Tools/CMake/AMReXInstallHelpers.cmake
@@ -117,7 +117,7 @@ macro( add_test_install_target _dir _amrex_root )
       COMMAND ${CMAKE_COMMAND} -E echo ""
       COMMAND ${CMAKE_COMMAND} -E make_directory ${_builddir}
       COMMAND ${CMAKE_COMMAND} -E echo "Configuring test project"
-      COMMAND ${CMAKE_COMMAND} -S ${_dir} -B ${_builddir} -DAMReX_ROOT=${_amrex_root}
+      COMMAND ${CMAKE_COMMAND} -S ${_dir} -B ${_builddir} -DAMReX_ROOT=${_amrex_root} -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
       COMMAND ${CMAKE_COMMAND} -E echo "Building test project"
       COMMAND ${CMAKE_COMMAND} --build ${_builddir}
       COMMAND ${CMAKE_COMMAND} -E echo ""

--- a/Tools/CMake/AMReXInstallHelpers.cmake
+++ b/Tools/CMake/AMReXInstallHelpers.cmake
@@ -97,3 +97,36 @@ function (install_amrex_targets)
 
 
 endfunction ()
+
+
+#
+# Create a test_install target
+#
+# _dir        is the project directory
+# _amrex_root is the amrex installation dir
+#
+macro( add_test_install_target _dir _amrex_root )
+
+   get_filename_component( _dirname ${_dir} NAME )
+   set(_builddir  ${CMAKE_CURRENT_BINARY_DIR}/${_dirname})
+   add_custom_target(test_install
+      COMMAND ${CMAKE_COMMAND} -E echo ""
+      COMMAND ${CMAKE_COMMAND} -E echo "------------------------------------"
+      COMMAND ${CMAKE_COMMAND} -E echo "     Testing AMReX installation     "
+      COMMAND ${CMAKE_COMMAND} -E echo "------------------------------------"
+      COMMAND ${CMAKE_COMMAND} -E echo ""
+      COMMAND ${CMAKE_COMMAND} -E make_directory ${_builddir}
+      COMMAND ${CMAKE_COMMAND} -E echo "Configuring test project"
+      COMMAND ${CMAKE_COMMAND} -S ${_dir} -B ${_builddir} -DAMReX_ROOT=${_amrex_root}
+      COMMAND ${CMAKE_COMMAND} -E echo "Building test project"
+      COMMAND ${CMAKE_COMMAND} --build ${_builddir}
+      COMMAND ${CMAKE_COMMAND} -E echo ""
+      COMMAND ${CMAKE_COMMAND} -E echo "------------------------------------"
+      COMMAND ${CMAKE_COMMAND} -E echo "   AMReX is installed correctly"
+      COMMAND ${CMAKE_COMMAND} -E echo "              Enjoy!           "
+      COMMAND ${CMAKE_COMMAND} -E echo "------------------------------------"
+      COMMAND ${CMAKE_COMMAND} -E echo ""
+      COMMAND ${CMAKE_COMMAND} -E remove_directory ${_builddir} # So we can run it again from scratch
+      )
+
+endmacro()


### PR DESCRIPTION
## Summary
Add a ``test_install`` target to test the amrex installation by configuring and building a simple CMake project that consumes amrex as a library. 
## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
