### PR TITLE
Return const& in rdata and idata and disallow returning copies for rvalues.

### DIFF
--- a/Src/Particle/AMReX_Particle.H
+++ b/Src/Particle/AMReX_Particle.H
@@ -242,18 +242,24 @@ struct Particle
     }
 
     template <int U = T_NReal, typename std::enable_if<U != 0, int>::type = 0>
-    AMREX_GPU_HOST_DEVICE RealType  rdata (int index) const &
+    AMREX_GPU_HOST_DEVICE const RealType& rdata (int index) const &
     {
         AMREX_ASSERT(index < NReal);
         return this->m_rdata[index];
     }
 
     template <int U = T_NReal, typename std::enable_if<U == 0, int>::type = 0>
-    AMREX_GPU_HOST_DEVICE RealType  rdata (int /*index*/) const &
+    AMREX_GPU_HOST_DEVICE const RealType& rdata (int /*index*/) const &
     {
         AMREX_ALWAYS_ASSERT(false);
         return this->pos(0);  // because we must return something
     }
+
+    template <int U = T_NReal, typename std::enable_if<U != 0, int>::type = 0>
+    AMREX_GPU_HOST_DEVICE RealType rdata (int /*index*/) && = delete;
+
+    template <int U = T_NReal, typename std::enable_if<U == 0, int>::type = 0>
+    AMREX_GPU_HOST_DEVICE RealType rdata (int /*index*/) && = delete;
 
     template <int U = T_NReal, typename std::enable_if<U != 0, int>::type = 0>
     AMREX_GPU_HOST_DEVICE RealVect  rvec (AMREX_D_DECL(int indx, int indy, int indz)) const &
@@ -302,18 +308,24 @@ struct Particle
     }
 
     template <int U = T_NInt, typename std::enable_if<U != 0, int>::type = 0>
-    AMREX_GPU_HOST_DEVICE int  idata (int index) const &
+    AMREX_GPU_HOST_DEVICE const int& idata (int index) const &
     {
         AMREX_ASSERT(index < NInt);
         return this->m_idata[index];
     }
 
     template <int U = T_NInt, typename std::enable_if<U == 0, int>::type = 0>
-    AMREX_GPU_HOST_DEVICE int idata (int /*index*/) const &
+    AMREX_GPU_HOST_DEVICE const int& idata (int /*index*/) const &
     {
         AMREX_ALWAYS_ASSERT(false);
         return this->m_idcpu;  //bc we must return something
     }
+
+    template <int U = T_NReal, typename std::enable_if<U != 0, int>::type = 0>
+    AMREX_GPU_HOST_DEVICE RealType idata (int /*index*/) && = delete;
+
+    template <int U = T_NReal, typename std::enable_if<U == 0, int>::type = 0>
+    AMREX_GPU_HOST_DEVICE RealType idata (int /*index*/) && = delete;
 
     /**
     * \brief Returns the next particle ID for this processor.

--- a/Src/Particle/AMReX_Particle.H
+++ b/Src/Particle/AMReX_Particle.H
@@ -249,7 +249,7 @@ struct Particle
     }
 
     template <int U = T_NReal, typename std::enable_if<U == 0, int>::type = 0>
-    AMREX_GPU_HOST_DEVICE const RealType& rdata (int /*index*/) const &
+    AMREX_GPU_HOST_DEVICE RealType rdata (int /*index*/) const &
     {
         AMREX_ALWAYS_ASSERT(false);
         return this->pos(0);  // because we must return something

--- a/Src/Particle/AMReX_Particle.H
+++ b/Src/Particle/AMReX_Particle.H
@@ -255,10 +255,6 @@ struct Particle
         return this->pos(0);  // because we must return something
     }
 
-    template <int U = T_NReal, typename std::enable_if<U != 0, int>::type = 0>
-    AMREX_GPU_HOST_DEVICE RealType rdata (int /*index*/) && = delete;
-
-    template <int U = T_NReal, typename std::enable_if<U == 0, int>::type = 0>
     AMREX_GPU_HOST_DEVICE RealType rdata (int /*index*/) && = delete;
 
     template <int U = T_NReal, typename std::enable_if<U != 0, int>::type = 0>
@@ -321,10 +317,6 @@ struct Particle
         return this->m_idcpu;  //bc we must return something
     }
 
-    template <int U = T_NReal, typename std::enable_if<U != 0, int>::type = 0>
-    AMREX_GPU_HOST_DEVICE RealType idata (int /*index*/) && = delete;
-
-    template <int U = T_NReal, typename std::enable_if<U == 0, int>::type = 0>
     AMREX_GPU_HOST_DEVICE RealType idata (int /*index*/) && = delete;
 
     /**

--- a/Src/Particle/AMReX_Particle.H
+++ b/Src/Particle/AMReX_Particle.H
@@ -315,7 +315,7 @@ struct Particle
     }
 
     template <int U = T_NInt, typename std::enable_if<U == 0, int>::type = 0>
-    AMREX_GPU_HOST_DEVICE const int& idata (int /*index*/) const &
+    AMREX_GPU_HOST_DEVICE int idata (int /*index*/) const &
     {
         AMREX_ALWAYS_ASSERT(false);
         return this->m_idcpu;  //bc we must return something


### PR DESCRIPTION
This should allow constructs like:

```
const ParticleType& p = pstructs[ip];
const amrex::ParticleReal* p_vals = &p.rdata(0);
// use p_vals[0], p_vals[1], etc...
```

while not allowing 

```
const amrex::ParticleReal& x = ParticleType().rdata(0);
```

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
