### PR TITLE
CI: HIPCC as C Compiler

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -280,14 +280,13 @@ jobs:
         cd build
         cmake ..                                          \
             -DCMAKE_VERBOSE_MAKEFILE=ON                   \
-            -DAMReX_MPI=OFF                               \
             -DAMReX_ENABLE_TESTS=ON                       \
             -DAMReX_PARTICLES=ON                          \
             -DAMReX_FORTRAN=ON                            \
             -DAMReX_LINEAR_SOLVERS=ON                     \
             -DAMReX_GPU_BACKEND=HIP                       \
             -DAMReX_AMD_ARCH=gfx900                       \
-            -DCMAKE_C_COMPILER=$(which hipcc)             \
+            -DCMAKE_C_COMPILER=$(which clang)             \
             -DCMAKE_CXX_COMPILER=$(which hipcc)           \
             -DCMAKE_Fortran_COMPILER=$(which gfortran)
         make -j 2


### PR DESCRIPTION
## Summary

Since `hipcc` is a C++ compiler, we should assign it with `-x c` if used as C compiler.

Or... we just use the corresponding `clang` for C files.

## Additional background

Follow-up to #1896

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
