### PR TITLE
Ensure center coefficient in an EB nodal solve has correct sign

### DIFF
--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLap_2D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLap_2D_K.H
@@ -1585,6 +1585,12 @@ void mlndlap_set_stencil_s0 (int i, int j, int k, Array4<Real> const& sten) noex
                     + sten(i  ,j-1,k,2) + sten(i  ,j  ,k,2)
                     + sten(i-1,j-1,k,3) + sten(i  ,j-1,k,3)
                     + sten(i-1,j  ,k,3) + sten(i  ,j  ,k,3));
+
+    // It is possible that at a coarser level, the center coefficient can flip sign, which can
+    // make BiCG fail.   Here if the center coefficient flips sign we simply set it to 0, which
+    // takes it out of play for the solver.
+    sten(i,j,k,0) = std::min(sten(i,j,k,0),0.);
+
     sten(i,j,k,4) = Real(1.0) / (amrex::Math::abs(sten(i-1,j  ,k,1)) + amrex::Math::abs(sten(i,j  ,k,1))
                                + amrex::Math::abs(sten(i  ,j-1,k,2)) + amrex::Math::abs(sten(i,j  ,k,2))
                                + amrex::Math::abs(sten(i-1,j-1,k,3)) + amrex::Math::abs(sten(i,j-1,k,3))

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLap_2D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLap_2D_K.H
@@ -1589,7 +1589,7 @@ void mlndlap_set_stencil_s0 (int i, int j, int k, Array4<Real> const& sten) noex
     // It is possible that at a coarser level, the center coefficient can flip sign, which can
     // make BiCG fail.   Here if the center coefficient flips sign we simply set it to 0, which
     // takes it out of play for the solver.
-    sten(i,j,k,0) = std::min(sten(i,j,k,0),0.);
+    sten(i,j,k,0) = amrex::min(sten(i,j,k,0),Real(0.));
 
     sten(i,j,k,4) = Real(1.0) / (amrex::Math::abs(sten(i-1,j  ,k,1)) + amrex::Math::abs(sten(i,j  ,k,1))
                                + amrex::Math::abs(sten(i  ,j-1,k,2)) + amrex::Math::abs(sten(i,j  ,k,2))

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLap_3D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLap_3D_K.H
@@ -2844,7 +2844,7 @@ void mlndlap_set_stencil_s0 (int i, int j, int k, Array4<Real> const& sten) noex
     // It is possible that at a coarser level, the center coefficient can flip sign, which can
     // make BiCG fail.   Here if the center coefficient flips sign we simply set it to 0, which
     // takes it out of play for the solver.
-    sten(i,j,k,ist_000) = std::min(sten(i,j,k,ist_000),0.);
+    sten(i,j,k,ist_000) = amrex::min(sten(i,j,k,ist_000),Real(0.));
 
     sten(i,j,k,ist_inv) = Real(1.0) /
         (  amrex::Math::abs(sten(i-1,j,k,ist_p00)) + amrex::Math::abs(sten(i,j,k,ist_p00))

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLap_3D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLap_3D_K.H
@@ -2840,6 +2840,12 @@ void mlndlap_set_stencil_s0 (int i, int j, int k, Array4<Real> const& sten) noex
                           + sten(i-1,j,k-1,ist_ppp) + sten(i,j,k-1,ist_ppp)
                           + sten(i-1,j-1,k,ist_ppp) + sten(i,j-1,k,ist_ppp)
                           + sten(i-1,j,k,ist_ppp) + sten(i,j,k,ist_ppp));
+
+    // It is possible that at a coarser level, the center coefficient can flip sign, which can
+    // make BiCG fail.   Here if the center coefficient flips sign we simply set it to 0, which
+    // takes it out of play for the solver.
+    sten(i,j,k,ist_000) = std::min(sten(i,j,k,ist_000),0.);
+
     sten(i,j,k,ist_inv) = Real(1.0) /
         (  amrex::Math::abs(sten(i-1,j,k,ist_p00)) + amrex::Math::abs(sten(i,j,k,ist_p00))
          + amrex::Math::abs(sten(i,j-1,k,ist_0p0)) + amrex::Math::abs(sten(i,j,k,ist_0p0))


### PR DESCRIPTION
It is possible for the center coefficient in an EB nodal solve to
have the incorrect sign after coarsening -- here we protect against that by
setting s0 to the max of (s0,0) -- this enables the BiCG to converge

## Summary

## Additional background

## Checklist

The proposed changes:
- [X] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
