### PR TITLE
Fix the previous correction where we zero'ed out the center coefficient

### DIFF
--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLap_2D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLap_2D_K.H
@@ -1585,12 +1585,6 @@ void mlndlap_set_stencil_s0 (int i, int j, int k, Array4<Real> const& sten) noex
                     + sten(i  ,j-1,k,2) + sten(i  ,j  ,k,2)
                     + sten(i-1,j-1,k,3) + sten(i  ,j-1,k,3)
                     + sten(i-1,j  ,k,3) + sten(i  ,j  ,k,3));
-
-    // It is possible that at a coarser level, the center coefficient can flip sign, which can
-    // make BiCG fail.   Here if the center coefficient flips sign we simply set it to 0, which
-    // takes it out of play for the solver.
-    sten(i,j,k,0) = amrex::min(sten(i,j,k,0),Real(0.));
-
     sten(i,j,k,4) = Real(1.0) / (amrex::Math::abs(sten(i-1,j  ,k,1)) + amrex::Math::abs(sten(i,j  ,k,1))
                                + amrex::Math::abs(sten(i  ,j-1,k,2)) + amrex::Math::abs(sten(i,j  ,k,2))
                                + amrex::Math::abs(sten(i-1,j-1,k,3)) + amrex::Math::abs(sten(i,j-1,k,3))

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLap_3D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLap_3D_K.H
@@ -2840,12 +2840,6 @@ void mlndlap_set_stencil_s0 (int i, int j, int k, Array4<Real> const& sten) noex
                           + sten(i-1,j,k-1,ist_ppp) + sten(i,j,k-1,ist_ppp)
                           + sten(i-1,j-1,k,ist_ppp) + sten(i,j-1,k,ist_ppp)
                           + sten(i-1,j,k,ist_ppp) + sten(i,j,k,ist_ppp));
-
-    // It is possible that at a coarser level, the center coefficient can flip sign, which can
-    // make BiCG fail.   Here if the center coefficient flips sign we simply set it to 0, which
-    // takes it out of play for the solver.
-    sten(i,j,k,ist_000) = amrex::min(sten(i,j,k,ist_000),Real(0.));
-
     sten(i,j,k,ist_inv) = Real(1.0) /
         (  amrex::Math::abs(sten(i-1,j,k,ist_p00)) + amrex::Math::abs(sten(i,j,k,ist_p00))
          + amrex::Math::abs(sten(i,j-1,k,ist_0p0)) + amrex::Math::abs(sten(i,j,k,ist_0p0))

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian.cpp
@@ -1197,11 +1197,14 @@ MLNodeLaplacian::buildStencil ()
                 {
                     mlndlap_set_stencil_s0(i,j,k,starr);
 
-                    // It is possible that at a coarser level, the center
+#if (AMREX_SPACEDIM ==3)
+                    // It is possible that at a coarse level, the center
                     // coefficient can flip sign, which can make BiCG fail.
                     // Here if the center coefficient flips sign we simply
                     // set it to 0, which takes it out of play for the solver.
-                    starr(i,j,k,ist_000) = amrex::min(starr(i,j,k,ist_000),Real(0.));
+                    if (amrlev == 0 && mglev == NMGLevels(0)-1)
+                        starr(i,j,k,0) = amrex::min(starr(i,j,k,0),Real(0.));
+#endif
                 });
             }
 

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian.cpp
@@ -1186,6 +1186,12 @@ MLNodeLaplacian::buildStencil ()
                 });
             }
 
+#if (AMREX_SPACEDIM == 3)
+                bool fix_starr_if_positive = (amrlev == 0 && mglev == NMGLevels(0)-1);
+#else
+                bool fix_starr_if_positive = false;
+#endif
+
 #ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
@@ -1197,14 +1203,12 @@ MLNodeLaplacian::buildStencil ()
                 {
                     mlndlap_set_stencil_s0(i,j,k,starr);
 
-#if (AMREX_SPACEDIM ==3)
                     // It is possible that at a coarse level, the center
                     // coefficient can flip sign, which can make BiCG fail.
                     // Here if the center coefficient flips sign we simply
                     // set it to 0, which takes it out of play for the solver.
-                    if (amrlev == 0 && mglev == NMGLevels(0)-1)
+                    if (fix_starr_if_positive)
                         starr(i,j,k,0) = amrex::min(starr(i,j,k,0),Real(0.));
-#endif
                 });
             }
 

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian.cpp
@@ -1196,6 +1196,12 @@ MLNodeLaplacian::buildStencil ()
                 AMREX_HOST_DEVICE_PARALLEL_FOR_3D(bx, i, j, k,
                 {
                     mlndlap_set_stencil_s0(i,j,k,starr);
+
+                    // It is possible that at a coarser level, the center 
+                    // coefficient can flip sign, which can make BiCG fail.
+                    // Here if the center coefficient flips sign we simply 
+                    // set it to 0, which takes it out of play for the solver.
+                    starr(i,j,k,ist_000) = amrex::min(starr(i,j,k,ist_000),Real(0.));
                 });
             }
 

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian.cpp
@@ -1197,9 +1197,9 @@ MLNodeLaplacian::buildStencil ()
                 {
                     mlndlap_set_stencil_s0(i,j,k,starr);
 
-                    // It is possible that at a coarser level, the center 
+                    // It is possible that at a coarser level, the center
                     // coefficient can flip sign, which can make BiCG fail.
-                    // Here if the center coefficient flips sign we simply 
+                    // Here if the center coefficient flips sign we simply
                     // set it to 0, which takes it out of play for the solver.
                     starr(i,j,k,ist_000) = amrex::min(starr(i,j,k,ist_000),Real(0.));
                 });


### PR DESCRIPTION
of the nodal stencil if it had the wrong sign.  Now we only zero it
if mglev > 0.

## Summary

## Additional background

## Checklist

The proposed changes:
- [X] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
