### PR TITLE
remove deprecated usage of `atomicAddNoRet` with HIP 4.1+

### DIFF
--- a/Src/Base/AMReX_GpuAtomic.H
+++ b/Src/Base/AMReX_GpuAtomic.H
@@ -156,8 +156,10 @@ namespace detail {
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     void AddNoRet (float* const sum, float const value) noexcept
     {
-#if AMREX_DEVICE_COMPILE
+#if AMREX_DEVICE_COMPILE && (HIP_VERSION_MAJOR * 100 + HIP_VERSION_MINOR) < 401
         atomicAddNoRet(sum, value);
+#elif AMREX_DEVICE_COMPILE
+        atomicAdd(sum, value);
 #else
         *sum += value;
 #endif


### PR DESCRIPTION
## Summary

`atomicAddNoRet` is deprecated with HIP 4.1

## Additional background

https://github.com/ROCm-Developer-Tools/HIP/commit/019c556c7d5e90c248767b8b4fa897ca08f85616

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX (I assume using a deprecated function is counted as a bug)
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
