### PR TITLE
Change the default value of m_normalization_threshold from 1e-10 to 1…

### DIFF
--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian.H
@@ -148,7 +148,7 @@ private:
     Vector<Vector<std::unique_ptr<MultiFab> > > m_stencil;
     Vector<Vector<Real> > m_s0_norm0;
 
-    Real m_normalization_threshold = Real(1.e-10);
+    Real m_normalization_threshold = Real(1.e-8);
 
 #ifdef AMREX_USE_EB
     // they could be MultiCutFab


### PR DESCRIPTION
…e-8.

This is motivated by an EB nodal BiCG bottom solver failing to converge
with 1e-10 while converging with 1e-8.

## Summary

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
