### PR TITLE
Cell-Centered Overset Solver Coarsening

### DIFF
--- a/Src/LinearSolvers/MLMG/AMReX_MLABecLaplacian.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLABecLaplacian.H
@@ -83,10 +83,11 @@ public:
     virtual Array<MultiFab const*,AMREX_SPACEDIM> getBCoeffs (int amrlev, int mglev) const final override
         { return amrex::GetArrOfConstPtrs(m_b_coeffs[amrlev][mglev]); }
 
-    virtual std::unique_ptr<MLLinOp> makeNLinOp (int /*grid_size*/) const final override {
-        amrex::Abort("MLABecLaplacian::makeNLinOp: Not implmented");
-        return std::unique_ptr<MLLinOp>{};
-    }
+    virtual std::unique_ptr<MLLinOp> makeNLinOp (int /*grid_size*/) const final override;
+
+    virtual bool supportNSolve () const final override;
+
+    virtual void copyNSolveSolution (MultiFab& dst, MultiFab const& src) const final override;
 
     void averageDownCoeffsSameAmrLevel (int amrlev, Vector<MultiFab>& a,
                                         Vector<Array<MultiFab,AMREX_SPACEDIM> >& b);

--- a/Src/LinearSolvers/MLMG/AMReX_MLCellABecLap.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLCellABecLap.H
@@ -74,6 +74,8 @@ public:
 protected:
     Vector<Vector<std::unique_ptr<iMultiFab> > > m_overset_mask;
 
+    LPInfo m_lpinfo_arg;
+
     virtual bool supportInhomogNeumannBC () const noexcept override { return true; }
 };
 

--- a/Src/LinearSolvers/MLMG/AMReX_MLCellABecLap.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLCellABecLap.cpp
@@ -43,6 +43,8 @@ MLCellABecLap::define (const Vector<Geometry>& a_geom,
 
     AMREX_ALWAYS_ASSERT(!hasHiddenDimension());
 
+    m_lpinfo_arg = a_info;
+
     int namrlevs = a_geom.size();
     m_overset_mask.resize(namrlevs);
     for (int amrlev = 0; amrlev < namrlevs; ++amrlev)

--- a/Src/LinearSolvers/MLMG/AMReX_MLLinOp.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLLinOp.H
@@ -274,6 +274,10 @@ public:
     virtual std::unique_ptr<PETScABecLap> makePETSc () const;
 #endif
 
+    virtual bool supportNSolve () const { return false; }
+
+    virtual void copyNSolveSolution (MultiFab&, MultiFab const&) const {}
+
 protected:
 
     static constexpr int mg_coarsen_ratio = 2;

--- a/Src/LinearSolvers/MLMG/AMReX_MLPoisson.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLPoisson.H
@@ -66,6 +66,10 @@ public:
 
     virtual std::unique_ptr<MLLinOp> makeNLinOp (int grid_size) const final override;
 
+    virtual bool supportNSolve () const final override;
+
+    virtual void copyNSolveSolution (MultiFab& dst, MultiFab const& src) const final override;
+
 private:
 
     Vector<int> m_is_singular;

--- a/Src/LinearSolvers/MLMG/AMReX_MLPoisson.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLPoisson.cpp
@@ -560,6 +560,16 @@ MLPoisson::FFlux (int amrlev, const MFIter& mfi,
 #endif
 }
 
+bool
+MLPoisson::supportNSolve () const
+{
+    bool support = true;
+    if (m_domain_covered[0]) support = false;
+    if (doAgglomeration()) support = false;
+    if (AMREX_SPACEDIM != 3) support = false;
+    return support;
+}
+
 std::unique_ptr<MLLinOp>
 MLPoisson::makeNLinOp (int grid_size) const
 {
@@ -624,6 +634,12 @@ MLPoisson::makeNLinOp (int grid_size) const
     nop->setACoeffs(0, alpha);
 
     return r;
+}
+
+void
+MLPoisson::copyNSolveSolution (MultiFab& dst, MultiFab const& src) const
+{
+    dst.ParallelCopy(src);
 }
 
 }


### PR DESCRIPTION
Currently for the cell-centered overset multigrid solver, coarsening stops
when a coarsened cell would contain both regular and masked-out cells.
Here, we further coarsen the grids by ignoring the overset mask and giving
the masked-out cells a huge value of alpha so that their values are
essentially frozen.

To use the new capability, call `MLMG::setNSolve(true)`.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
