### PR TITLE
Fix a bug in BaseFab::resize.

### DIFF
--- a/Src/Base/AMReX_BaseFab.H
+++ b/Src/Base/AMReX_BaseFab.H
@@ -273,6 +273,8 @@ public:
     * space which must be a different size whenever it is used.
     * Resizing is typically faster than re-allocating a
     * BaseFab because memory allocation can often be avoided.
+    * If a nullptr is provided as Arena*, the Arena already in BaseFab will
+    * be used. Otherwise, the Arena argument will be used.
     */
     void resize (const Box& b, int N = 1, Arena* ar = nullptr);
 
@@ -2044,6 +2046,10 @@ BaseFab<T>::resize (const Box& b, int n, Arena* ar)
 {
     this->nvar   = n;
     this->domain = b;
+
+    if (ar == nullptr) {
+        ar = m_arena;
+    }
 
     if (arena() != DataAllocator(ar).arena()) {
         clear();


### PR DESCRIPTION
Previously if `BaseFab::resize`'s optional `Arena*` argument is `nullptr` (which
is the default) while `BaseFab`'s `Arena*` member is a different `Arena`, the
`nullptr` will be interpreted as the default `Arena`, `The_Arena`, ignoring the
`BaseFab`'s `Arena` has already been set.  This causes the following code to
allocate data using `The_Arena`, not `The_Cpu_Arena`.

    BaseFab fab(The_Cpu_Arena());
    fab.resize(box);

This PR fixes the bug.

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
