### PR TITLE
No need for AMREX_IS_TRIVIALLY_COPYABLE && AMREX_IS_TRIVIALLY_DEFAULT

### DIFF
--- a/Src/Base/AMReX_BaseFab.H
+++ b/Src/Base/AMReX_BaseFab.H
@@ -144,7 +144,8 @@ placementNew (T* const /*ptr*/, Long /*n*/)
 {}
 
 template <typename T>
-typename std::enable_if< AMREX_IS_TRIVIALLY_DEFAULT_CONSTRUCTIBLE(T) && !std::is_arithmetic<T>::value >::type
+std::enable_if_t<std::is_trivially_default_constructible<T>::value
+                 && !std::is_arithmetic<T>::value>
 placementNew (T* const ptr, Long n)
 {
     for (Long i = 0; i < n; ++i) {
@@ -153,7 +154,7 @@ placementNew (T* const ptr, Long n)
 }
 
 template <typename T>
-typename std::enable_if<!AMREX_IS_TRIVIALLY_DEFAULT_CONSTRUCTIBLE(T)>::type
+std::enable_if_t<!std::is_trivially_default_constructible<T>::value>
 placementNew (T* const ptr, Long n)
 {
     AMREX_HOST_DEVICE_FOR_1D ( n, i,

--- a/Src/Base/AMReX_CudaGraph.H
+++ b/Src/Base/AMReX_CudaGraph.H
@@ -65,12 +65,12 @@ struct CudaGraph
     CudaGraph()
         : m_parms(0)
     {
-        static_assert(AMREX_IS_TRIVIALLY_COPYABLE(T), "CudaGraph's T must be trivially copyable");
+        static_assert(std::is_trivially_copyable<T>::value, "CudaGraph's T must be trivially copyable");
     }
     CudaGraph(int num)
         : m_parms(num)
     {
-        static_assert(AMREX_IS_TRIVIALLY_COPYABLE(T), "CudaGraph's T must be trivially copyable");
+        static_assert(std::is_trivially_copyable<T>::value, "CudaGraph's T must be trivially copyable");
         m_parms_d = static_cast<T*>( The_Arena()->alloc(sizeof(T)*m_parms.size()) );
     }
     ~CudaGraph() {

--- a/Src/Base/AMReX_GpuAsyncArray.H
+++ b/Src/Base/AMReX_GpuAsyncArray.H
@@ -26,7 +26,7 @@ extern "C" {
 namespace amrex {
 namespace Gpu {
 
-template <typename T, typename std::enable_if<AMREX_IS_TRIVIALLY_COPYABLE(T),int>::type = 0>
+template <typename T, std::enable_if_t<std::is_trivially_copyable<T>::value,int> = 0>
 class AsyncArray
 {
 public:

--- a/Src/Base/AMReX_GpuBuffer.H
+++ b/Src/Base/AMReX_GpuBuffer.H
@@ -13,7 +13,7 @@
 namespace amrex {
 namespace Gpu {
 
-template <typename T, typename std::enable_if<AMREX_IS_TRIVIALLY_COPYABLE(T),int>::type = 0>
+template <typename T, std::enable_if_t<std::is_trivially_copyable<T>::value,int> = 0>
 class Buffer
 {
 public:

--- a/Src/Base/AMReX_GpuContainers.H
+++ b/Src/Base/AMReX_GpuContainers.H
@@ -115,7 +115,7 @@ namespace Gpu {
     void copy (HostToDevice, InIter begin, InIter end, OutIter result) noexcept
     {
         using value_type = typename std::iterator_traits<InIter>::value_type;
-        static_assert(AMREX_IS_TRIVIALLY_COPYABLE(value_type),
+        static_assert(std::is_trivially_copyable<value_type>(),
                       "Can only copy trivially copyable types");
         auto size = std::distance(begin, end);
         if (size == 0) return;
@@ -148,7 +148,7 @@ namespace Gpu {
     void copy (DeviceToHost, InIter begin, InIter end, OutIter result) noexcept
     {
         using value_type = typename std::iterator_traits<InIter>::value_type;
-        static_assert(AMREX_IS_TRIVIALLY_COPYABLE(value_type),
+        static_assert(std::is_trivially_copyable<value_type>(),
                       "Can only copy trivially copyable types");
         auto size = std::distance(begin, end);
         if (size == 0) return;
@@ -181,7 +181,7 @@ namespace Gpu {
     void copy (DeviceToDevice, InIter begin, InIter end, OutIter result) noexcept
     {
         using value_type = typename std::iterator_traits<InIter>::value_type;
-        static_assert(AMREX_IS_TRIVIALLY_COPYABLE(value_type),
+        static_assert(std::is_trivially_copyable<value_type>(),
                       "Can only copy trivially copyable types");
         auto size = std::distance(begin, end);
         if (size == 0) return;
@@ -215,7 +215,7 @@ namespace Gpu {
     void copyAsync (HostToDevice, InIter begin, InIter end, OutIter result) noexcept
     {
         using value_type = typename std::iterator_traits<InIter>::value_type;
-        static_assert(AMREX_IS_TRIVIALLY_COPYABLE(value_type),
+        static_assert(std::is_trivially_copyable<value_type>(),
                       "Can only copy trivially copyable types");
         auto size = std::distance(begin, end);
         if (size == 0) return;
@@ -249,7 +249,7 @@ namespace Gpu {
     void copyAsync (DeviceToHost, InIter begin, InIter end, OutIter result) noexcept
     {
         using value_type = typename std::iterator_traits<InIter>::value_type;
-        static_assert(AMREX_IS_TRIVIALLY_COPYABLE(value_type),
+        static_assert(std::is_trivially_copyable<value_type>(),
                       "Can only copy trivially copyable types");
         auto size = std::distance(begin, end);
         if (size == 0) return;
@@ -283,7 +283,7 @@ namespace Gpu {
     void copyAsync (DeviceToDevice, InIter begin, InIter end, OutIter result) noexcept
     {
         using value_type = typename std::iterator_traits<InIter>::value_type;
-        static_assert(AMREX_IS_TRIVIALLY_COPYABLE(value_type),
+        static_assert(std::is_trivially_copyable<value_type>(),
                       "Can only copy trivially copyable types");
         auto size = std::distance(begin, end);
         if (size == 0) return;

--- a/Src/Base/AMReX_GpuFuse.H
+++ b/Src/Base/AMReX_GpuFuse.H
@@ -36,7 +36,7 @@ struct FuseHelper {
     int m_N;
 };
 
-static_assert(AMREX_IS_TRIVIALLY_COPYABLE(FuseHelper),"FuseHelper is not trivially copyable");
+static_assert(std::is_trivially_copyable<FuseHelper>(),"FuseHelper is not trivially copyable");
 
 template <typename Lambda>
 AMREX_GPU_DEVICE

--- a/Src/Base/AMReX_GpuMemory.H
+++ b/Src/Base/AMReX_GpuMemory.H
@@ -52,7 +52,7 @@ struct Deleter {
     void operator() (void* pt) const noexcept { m_arena->free(pt); }
 };
 
-template <class T, typename std::enable_if<AMREX_IS_TRIVIALLY_COPYABLE(T),int>::type = 0>
+template <class T, std::enable_if_t<std::is_trivially_copyable<T>::value,int> = 0>
 struct DeviceScalar
 {
     DeviceScalar (DeviceScalar const&) = delete;

--- a/Src/Base/AMReX_PODVector.H
+++ b/Src/Base/AMReX_PODVector.H
@@ -101,7 +101,7 @@ namespace amrex
     class PODVector : public Allocator
     {
         //        static_assert(std::is_standard_layout<T>(), "PODVector can only hold standard layout types");
-        static_assert(AMREX_IS_TRIVIALLY_COPYABLE(T), "PODVector can only hold trivially copyable types");
+        static_assert(std::is_trivially_copyable<T>(), "PODVector can only hold trivially copyable types");
         //        static_assert(std::is_trivially_default_constructible<T>(), "PODVector can only hold trivial dc types");
 
 

--- a/Src/Base/AMReX_ParallelDescriptor.cpp
+++ b/Src/Base/AMReX_ParallelDescriptor.cpp
@@ -1310,7 +1310,7 @@ BL_FORT_PROC_DECL(BL_PD_ABORT,bl_pd_abort)()
 #if defined(BL_USE_MPI) && !defined(BL_AMRPROF)
 template <> MPI_Datatype Mpi_typemap<IntVect>::type()
 {
-    static_assert(AMREX_IS_TRIVIALLY_COPYABLE(IntVect), "IntVect must be trivially copyable");
+    static_assert(std::is_trivially_copyable<IntVect>::value, "IntVect must be trivially copyable");
     static_assert(std::is_standard_layout<IntVect>::value, "IntVect must be standard layout");
 
     if ( mpi_type_intvect == MPI_DATATYPE_NULL )
@@ -1333,7 +1333,7 @@ template <> MPI_Datatype Mpi_typemap<IntVect>::type()
 
 template <> MPI_Datatype Mpi_typemap<IndexType>::type()
 {
-    static_assert(AMREX_IS_TRIVIALLY_COPYABLE(IndexType), "IndexType must be trivially copyable");
+    static_assert(std::is_trivially_copyable<IndexType>::value, "IndexType must be trivially copyable");
     static_assert(std::is_standard_layout<IndexType>::value, "IndexType must be standard layout");
 
     if ( mpi_type_indextype == MPI_DATATYPE_NULL )
@@ -1356,7 +1356,7 @@ template <> MPI_Datatype Mpi_typemap<IndexType>::type()
 
 template <> MPI_Datatype Mpi_typemap<Box>::type()
 {
-    static_assert(AMREX_IS_TRIVIALLY_COPYABLE(Box), "Box must be trivially copyable");
+    static_assert(std::is_trivially_copyable<Box>::value, "Box must be trivially copyable");
     static_assert(std::is_standard_layout<Box>::value, "Box must be standard layout");
 
     if ( mpi_type_box == MPI_DATATYPE_NULL )

--- a/Src/Base/AMReX_Reduce.H
+++ b/Src/Base/AMReX_Reduce.H
@@ -219,9 +219,9 @@ public:
         : m_host_tuple(),
           m_device_tuple((Type*)(The_Arena()->alloc(2*sizeof(m_host_tuple))))
     {
-        static_assert(AMREX_IS_TRIVIALLY_COPYABLE(Type),
+        static_assert(std::is_trivially_copyable<Type>(),
                       "ReduceData::Type must be trivially copyable");
-        static_assert(std::is_trivially_destructible<Type>::value,
+        static_assert(std::is_trivially_destructible<Type>(),
                       "ReduceData::Type must be trivially destructible");
 
         Reduce::detail::for_each_init<0, Type, Ps...>(m_host_tuple);

--- a/Src/Base/AMReX_TypeTraits.H
+++ b/Src/Base/AMReX_TypeTraits.H
@@ -5,14 +5,9 @@
 #include <AMReX_Extension.H>
 #include <type_traits>
 
-// workaround missing "is_trivially_copyable" in g++ < 5.0
-#if defined(__GNUG__) && __GNUC__ < 5 && !defined(AMREX_CXX_CLANG)
-#define AMREX_IS_TRIVIALLY_COPYABLE(T) __has_trivial_copy(T)
-#define AMREX_IS_TRIVIALLY_DEFAULT_CONSTRUCTIBLE(T) std::has_trivial_default_constructor<T>::value
-#else
+// In case they are still used by applications
 #define AMREX_IS_TRIVIALLY_COPYABLE(T) std::is_trivially_copyable<T>::value
 #define AMREX_IS_TRIVIALLY_DEFAULT_CONSTRUCTIBLE(T) std::is_trivially_default_constructible<T>::value
-#endif
 
 namespace amrex
 {


### PR DESCRIPTION
They are not needed because gcc 4 is no longer supported.