### PR TITLE
Use pinned memory for data transfer between host and device

### DIFF
--- a/Src/AmrCore/AMReX_AmrMesh.cpp
+++ b/Src/AmrCore/AMReX_AmrMesh.cpp
@@ -691,7 +691,7 @@ AmrMesh::MakeNewGrids (int lbase, Real time, int& new_finest, Vector<BoxArray>& 
         //
         // Create initial cluster containing all tagged points.
         //
-        Vector<IntVect> tagvec;
+        Gpu::PinnedVector<IntVect> tagvec;
         tags.collate(tagvec);
         tags.clear();
 

--- a/Src/AmrCore/AMReX_TagBox.H
+++ b/Src/AmrCore/AMReX_TagBox.H
@@ -224,14 +224,14 @@ public:
     *
     * \param TheGlobalCollateSpace
     */
-    void collate (Vector<IntVect>& TheGlobalCollateSpace) const;
+    void collate (Gpu::PinnedVector<IntVect>& TheGlobalCollateSpace) const;
 
     // \brief Are there tags in the region defined by bx?
     bool hasTags (Box const& bx) const;
 
-    void local_collate_cpu (Vector<IntVect>& v) const;
+    void local_collate_cpu (Gpu::PinnedVector<IntVect>& v) const;
 #ifdef AMREX_USE_GPU
-    void local_collate_gpu (Vector<IntVect>& v) const;
+    void local_collate_gpu (Gpu::PinnedVector<IntVect>& v) const;
 #endif
 };
 

--- a/Src/AmrCore/AMReX_TagBox.cpp
+++ b/Src/AmrCore/AMReX_TagBox.cpp
@@ -359,7 +359,7 @@ TagBoxArray::mapPeriodicRemoveDuplicates (const Geometry& geom)
 }
 
 void
-TagBoxArray::local_collate_cpu (Vector<IntVect>& v) const
+TagBoxArray::local_collate_cpu (Gpu::PinnedVector<IntVect>& v) const
 {
     if (this->local_size() == 0) return;
 
@@ -408,7 +408,7 @@ TagBoxArray::local_collate_cpu (Vector<IntVect>& v) const
 
 #ifdef AMREX_USE_GPU
 void
-TagBoxArray::local_collate_gpu (Vector<IntVect>& v) const
+TagBoxArray::local_collate_gpu (Gpu::PinnedVector<IntVect>& v) const
 {
     const int nfabs = this->local_size();
     if (nfabs == 0) return;
@@ -575,11 +575,11 @@ TagBoxArray::local_collate_gpu (Vector<IntVect>& v) const
 #endif
 
 void
-TagBoxArray::collate (Vector<IntVect>& TheGlobalCollateSpace) const
+TagBoxArray::collate (Gpu::PinnedVector<IntVect>& TheGlobalCollateSpace) const
 {
     BL_PROFILE("TagBoxArray::collate()");
 
-    Vector<IntVect> TheLocalCollateSpace;
+    Gpu::PinnedVector<IntVect> TheLocalCollateSpace;
 #ifdef AMREX_USE_GPU
     if (Gpu::inLaunchRegion()) {
         local_collate_gpu(TheLocalCollateSpace);
@@ -764,4 +764,3 @@ TagBoxArray::hasTags (Box const& a_bx) const
 }
 
 }
-

--- a/Src/Base/AMReX_GpuAsyncArray.H
+++ b/Src/Base/AMReX_GpuAsyncArray.H
@@ -34,7 +34,7 @@ public:
     AsyncArray (T const* h_p, const std::size_t n)
     {
         if (n == 0) return;
-        h_data = static_cast<T*>(std::malloc(n*sizeof(T)));
+        h_data = static_cast<T*>(The_Pinned_Arena()->alloc(n*sizeof(T)));
         std::memcpy(h_data, h_p, n*sizeof(T));
 #ifdef AMREX_USE_GPU
         if (Gpu::inLaunchRegion())
@@ -57,7 +57,7 @@ public:
         else
 #endif
         {
-            h_data = static_cast<T*>(std::malloc(n*sizeof(T)));
+            h_data = static_cast<T*>(The_Pinned_Arena()->alloc(n*sizeof(T)));
         }
     }
 
@@ -99,7 +99,7 @@ public:
                     q.submit([&] (sycl::handler& h) {
                         h.codeplay_host_task([=] () {
                             The_Arena()->free(pd);
-                            std::free(ph);
+                            The_Pinned_Arena()->free(ph);
                         });
                     });
                 } catch (sycl::exception const& ex) {
@@ -109,7 +109,7 @@ public:
                 // xxxxx DPCPP todo
                 Gpu::streamSynchronize();
                 The_Arena()->free(d_data);
-                std::free(h_data);
+                The_Pinned_Arena()->free(h_data);
 #endif
 #endif
             }
@@ -117,7 +117,7 @@ public:
         else
 #endif
         {
-            std::free(h_data);
+            The_Pinned_Arena()->free(h_data);
         }
         d_data = nullptr;
         h_data = nullptr;

--- a/Src/Base/AMReX_GpuAsyncArray.cpp
+++ b/Src/Base/AMReX_GpuAsyncArray.cpp
@@ -15,9 +15,9 @@ extern "C" {
         void** pp = (void**)p;
         void* dp = pp[0];
         void* hp = pp[1];
-        std::free(hp);
         std::free(p);
         amrex::The_Arena()->free(dp);
+        amrex::The_Pinned_Arena()->free(hp);
     }
 }
 #endif

--- a/Src/EB/AMReX_EB_STL_utils.H
+++ b/Src/EB/AMReX_EB_STL_utils.H
@@ -18,8 +18,8 @@ namespace amrex
         private:
 
             //host vectors
-            Vector<Real> m_tri_pts_h;
-            Vector<Real> m_tri_normals_h;
+            Gpu::PinnedVector<Real> m_tri_pts_h;
+            Gpu::PinnedVector<Real> m_tri_normals_h;
 
             //device vectors
             Gpu::DeviceVector<amrex::Real> m_tri_pts_d;


### PR DESCRIPTION
The amount of data to be transferred in TagBox and STLtools is likely to be
big.  So pinned memory is used instead of pageable.

AsyncArray is sometimes used to transfer a large amount of data.  So pinned
memory is used.
