### PR TITLE
std::isfinite/inf for SYCL

### DIFF
--- a/Src/Base/AMReX_Math.H
+++ b/Src/Base/AMReX_Math.H
@@ -43,6 +43,8 @@ using sycl::ceil;
 using sycl::copysign;
 using sycl::floor;
 using sycl::round;
+using sycl::isfinite;
+using sycl::isinf;
 
 #else
 
@@ -51,6 +53,8 @@ using std::ceil;
 using std::copysign;
 using std::floor;
 using std::round;
+using std::isfinite;
+using std::isinf;
 
 #endif
 


### PR DESCRIPTION
## Summary

Wrappity wrap the non-constexpr functions:
https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/C-CXX-StandardLibrary/C-CXX-StandardLibrary.rst

Note that `std::nan` works by accident/virtue of being constexpr.

## Additional background

Used in WarpX for parser value checks: https://github.com/ECP-WarpX/WarpX/pull/1872

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
