### PR TITLE
Alias HostVector to PinnedVector and update documentation.

### DIFF
--- a/Src/Base/AMReX_GpuContainers.H
+++ b/Src/Base/AMReX_GpuContainers.H
@@ -42,7 +42,7 @@ namespace Gpu {
 
     /**
      * \brief A PODVector that uses pinned host memory. Same as PinnedVector.
-     * For a vector class that uses std::allocator, see amrex::Vector.
+     * For a vector class that uses std::allocator by default, see amrex::Vector.
      *
      */
     template <class T>

--- a/Src/Base/AMReX_GpuContainers.H
+++ b/Src/Base/AMReX_GpuContainers.H
@@ -27,13 +27,6 @@ namespace Gpu {
     using DeviceVector = PODVector<T, ArenaAllocator<T> >;
 
     /**
-     * \brief A PODVector that uses host memory. No Arena is used.
-     *
-     */
-    template <class T>
-    using HostVector = PODVector<T>;
-
-    /**
      * \brief A PODVector that uses the managed memory arena.
      *
      */
@@ -46,6 +39,14 @@ namespace Gpu {
      */
     template <class T>
     using PinnedVector = PODVector<T, PinnedArenaAllocator<T> >;
+
+    /**
+     * \brief A PODVector that uses pinned host memory. Same as PinnedVector.
+     * For a vector class that uses std::allocator, see amrex::Vector.
+     *
+     */
+    template <class T>
+    using HostVector = PinnedVector<T>;
 
     /**
      * \brief The behavior of PolymorphicVector changes depending on
@@ -66,7 +67,7 @@ namespace Gpu {
     using ManagedDeviceVector = PODVector<T, ManagedArenaAllocator<T> >;
 
 #else
-    //! When Cuda is off, all these containers revert to amrex::Vector.
+    //! When Cuda is off, all these containers revert to amrex::PODVector.
     template <class T>
     using DeviceVector = PODVector<T>;
 

--- a/Src/Base/AMReX_GpuContainers.H
+++ b/Src/Base/AMReX_GpuContainers.H
@@ -67,7 +67,7 @@ namespace Gpu {
     using ManagedDeviceVector = PODVector<T, ManagedArenaAllocator<T> >;
 
 #else
-    //! When Cuda is off, all these containers revert to amrex::PODVector.
+    //! When Cuda is off, all these containers revert to amrex::Gpu::PODVector.
     template <class T>
     using DeviceVector = PODVector<T>;
 


### PR DESCRIPTION
Currently, `amrex::Gpu::HostVector` uses `std::allocator`. However, the normal use case for this class is for vectors that need to be initialized on the host and then copied into a amrex::Gpu::DeviceVector. For this purpose, pinned memory is expected to perform better. Additionally, it is arguably less surprising for Gpu::HostVector to use `cudaHostAlloc` than `std::allocator`. Thus, this PR changes `amrex::Gpu::HostVector` to alias `amrex::Gpu::PinnedVector`. If a vector that uses `std::allocator` by default is desired, people can always use `amrex::Vector`.

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
