### PR TITLE
Fix missing Real()

### DIFF
--- a/Src/EB/AMReX_EB2_3D_C.H
+++ b/Src/EB/AMReX_EB2_3D_C.H
@@ -448,7 +448,7 @@ Real coarsen_edge_cent (Real f1, Real f2)
             f2 = Real(0.5)*f2 + Real(0.25);
         }
         Real r = (f2*f2-f1*f1)/(f2-f1+Real(1.e-30));
-        return amrex::min(Real(0.5),amrex::max(-0.5,r));
+        return amrex::min(Real(0.5),amrex::max(Real(-0.5),r));
     }
 }
 }


### PR DESCRIPTION
## Summary
This PR fixes a missing `Real()`. Currently `coarsen_edge_cent` fails to compile in single precision.

## Additional background

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
