### PR TITLE
Avoid AMREX_NO_UNIQUE_ADDRESS

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -318,7 +318,7 @@ jobs:
     - name: Build & Install
       run: |
         ./configure --dim 2 --with-fortran no --comp llvm --with-mpi no
-        make -j2 WARN_ALL=TRUE WARN_ERROR=TRUE XTRA_CXXFLAGS=-fno-operator-names
+        make -j2 WARN_ALL=TRUE WARN_ERROR=TRUE XTRA_CXXFLAGS="-fno-operator-names -Wno-error=c++17-extensions"
         make install
 
   # Build 3D libamrex with configure

--- a/Src/Base/AMReX_Extension.H
+++ b/Src/Base/AMReX_Extension.H
@@ -159,7 +159,7 @@
 #include <ciso646>
 #endif
 
-#if (__cplusplus >= 201703L)
+#if defined(__has_cpp_attribute) && __has_cpp_attribute(fallthrough) >= 201603L
 #define AMREX_FALLTHROUGH [[fallthrough]]
 #elif defined(__clang__)
 #define AMREX_FALLTHROUGH [[clang::fallthrough]]
@@ -170,7 +170,7 @@
 #endif
 
 // CI uses -Werror -Wc++17-extension, thus we need to add the __cplusplus clause
-#if !defined(AMREX_NO_NODISCARD) && defined(__has_cpp_attribute) && __has_cpp_attribute(nodiscard) && __cplusplus >= 201603L
+#if !defined(AMREX_NO_NODISCARD) && defined(__has_cpp_attribute) && __has_cpp_attribute(nodiscard) >= 201603L
 #   define AMREX_NODISCARD [[nodiscard]]
 #else
 #   define AMREX_NODISCARD
@@ -181,11 +181,17 @@
 //   - GCC >= 9.0
 //   - MSVC >= 19.26
 // Using no unique address makes empty base class optimization for multiple policies much easier
-#if !defined(AMREX_NO_NO_UNIQUE_ADDRESS) && defined(__has_cpp_attribute) && __has_cpp_attribute(no_unique_address) && __cpluspus >= 201803L
+#if !defined(AMREX_NO_NO_UNIQUE_ADDRESS) && defined(__has_cpp_attribute) && __has_cpp_attribute(no_unique_address) >= 201803L
 #   define AMREX_NO_UNIQUE_ADDRESS [[no_unique_address]]
 #   define AMREX_HAS_NO_UNIQUE_ADDRESS 1
 #else
 #   define AMREX_NO_UNIQUE_ADDRESS
+#endif
+
+#if defined(__cpp_if_constexpr) && __cpp_if_constexpr >= 201606L
+#   define AMREX_IF_CONSTEXPR if constexpr
+#else
+#   define AMREX_IF_CONSTEXPR if
 #endif
 
 #endif /* !BL_LANG_FORT */

--- a/Src/Base/AMReX_NonLocalBC.H
+++ b/Src/Base/AMReX_NonLocalBC.H
@@ -317,8 +317,8 @@ template <typename Base, typename Map = Identity> struct MapComponents {
     static_assert(IsCallableR<int, Map, int>::value,
                   "Map needs to be a callable function: int -> int.");
 
-    AMREX_NO_UNIQUE_ADDRESS Base base;
-    AMREX_NO_UNIQUE_ADDRESS Map map;
+    Base base;
+    Map map;
 
     template <typename T,
               typename = std::enable_if_t<IsCallable<Base, Array4<const T>, Dim3, int>::value>,
@@ -329,9 +329,6 @@ template <typename Base, typename Map = Identity> struct MapComponents {
     }
 };
 
-#ifdef AMREX_HAS_NO_UNIQUE_ADDRESS
-static_assert(sizeof(MapComponents<Identity, Identity>) == 1, "");
-#endif
 static_assert(std::is_trivially_copy_assignable<MapComponents<Identity>>(), "");
 static_assert(std::is_trivially_copy_constructible<MapComponents<Identity>>(), "");
 static_assert(IsFabProjection<MapComponents<Identity>, FArrayBox>(), "");
@@ -393,9 +390,6 @@ static_assert(sizeof(SwapComponents<0, 1>) == 1, "");
 static_assert(sizeof(DynamicSwapComponents) == 2 * sizeof(int), "");
 static_assert(sizeof(SwapComponents<0, -1>) == sizeof(int), "");
 static_assert(sizeof(SwapComponents<-1, 1>) == sizeof(int), "");
-#ifdef AMREX_HAS_NO_UNIQUE_ADDRESS
-static_assert(sizeof(MapComponents<Identity, SwapComponents<0, 1>>) == sizeof(SwapComponents<0, 1>), "");
-#endif
 static_assert(std::is_trivially_default_constructible<MapComponents<Identity, SwapComponents<0, 1>>>(), "");
 static_assert(std::is_trivially_copy_assignable<MapComponents<Identity, SwapComponents<0, 1>>>(), "");
 static_assert(std::is_trivially_copy_constructible<MapComponents<Identity, SwapComponents<0, 1>>>(), "");
@@ -622,8 +616,8 @@ struct ApplyDtosAndProjectionOnReciever : PackComponents {
     constexpr ApplyDtosAndProjectionOnReciever(const PackComponents& components, DTOS dtos_ = DTOS{}, FabProj proj_ = FabProj{})
         : PackComponents(components), dtos(std::move(dtos_)), proj(std::move(proj_)) {}
 
-    AMREX_NO_UNIQUE_ADDRESS DTOS dtos;
-    AMREX_NO_UNIQUE_ADDRESS FabProj proj;
+    DTOS dtos;
+    FabProj proj;
 
     static_assert(IsCallableR<Dim3, DTOS, Dim3>(), "DTOS needs to be a callable: Dim3 -> Dim3");
     static_assert(IsFabProjection<FabProj, FArrayBox>(), "FabProj needs to be at least a projection on FArrayBox.");


### PR DESCRIPTION
* Avoid AMREX_NO_UNIQUE_ADDRESS because it causes gcc 9.3 to crash.

* Fix AMREX_NO_UNIQUE_ADDRESS and AMREX_NODISCARD macros.

* Adjust compiler flag in CI to allow for C++17 extension when compiling with C++14.

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
