### PR TITLE
Reimplementation of PrefixSum with cub

### DIFF
--- a/Src/Base/AMReX_Reduce.H
+++ b/Src/Base/AMReX_Reduce.H
@@ -477,7 +477,7 @@ T Sum (N n, F&& f, T init_val = 0)
     ReduceOps<ReduceOpSum> reduce_op;
     ReduceData<T> reduce_data(reduce_op);
     using ReduceTuple = typename decltype(reduce_data)::Type;
-    reduce_op.eval(n, [=] AMREX_GPU_DEVICE (N i) -> ReduceTuple { return {f(i)}; });
+    reduce_op.eval(n, reduce_data, [=] AMREX_GPU_DEVICE (N i) -> ReduceTuple { return {f(i)}; });
     return amrex::get<0>(reduce_data.value()) + init_val;
 }
 
@@ -519,7 +519,7 @@ T Min (N n, F&& f, T init_val = std::numeric_limits<T>::max())
     ReduceOps<ReduceOpMin> reduce_op;
     ReduceData<T> reduce_data(reduce_op);
     using ReduceTuple = typename decltype(reduce_data)::Type;
-    reduce_op.eval(n, [=] AMREX_GPU_DEVICE (N i) -> ReduceTuple { return {f(i)}; });
+    reduce_op.eval(n, reduce_data, [=] AMREX_GPU_DEVICE (N i) -> ReduceTuple { return {f(i)}; });
     T tmp = amrex::get<0>(reduce_data.value());
     return std::min(tmp,init_val);
 }
@@ -562,7 +562,7 @@ T Max (N n, F&& f, T init_val = std::numeric_limits<T>::lowest())
     ReduceOps<ReduceOpMax> reduce_op;
     ReduceData<T> reduce_data(reduce_op);
     using ReduceTuple = typename decltype(reduce_data)::Type;
-    reduce_op.eval(n, [=] AMREX_GPU_DEVICE (N i) -> ReduceTuple { return {f(i)}; });
+    reduce_op.eval(n, reduce_data, [=] AMREX_GPU_DEVICE (N i) -> ReduceTuple { return {f(i)}; });
     T tmp = amrex::get<0>(reduce_data.value());
     return std::max(tmp,init_val);
 }
@@ -612,7 +612,7 @@ std::pair<T,T> MinMax (N n, F&& f)
     ReduceOps<ReduceOpMin,ReduceOpMax> reduce_op;
     ReduceData<T,T> reduce_data(reduce_op);
     using ReduceTuple = typename decltype(reduce_data)::Type;
-    reduce_op.eval(n, [=] AMREX_GPU_DEVICE (N i) -> ReduceTuple {
+    reduce_op.eval(n, reduce_data, [=] AMREX_GPU_DEVICE (N i) -> ReduceTuple {
             T tmp = f(i);
             return {tmp,tmp};
         });

--- a/Src/Base/AMReX_Scan.H
+++ b/Src/Base/AMReX_Scan.H
@@ -24,7 +24,10 @@ struct RetSum {
 static constexpr RetSum   retSum{true};
 static constexpr RetSum noRetSum{false};
 
-enum class Type { inclusive, exclusive };
+namespace Type {
+    static constexpr struct Inclusive {} inclusive{};
+    static constexpr struct Exclusive {} exclusive{};
+}
 
 #if defined(AMREX_USE_GPU)
 
@@ -174,9 +177,11 @@ struct BlockStatus<T, false>
 
 #if defined(AMREX_USE_DPCPP)
 
-template <typename T, typename N, typename FIN, typename FOUT,
-          typename M=std::enable_if_t<std::is_integral<N>::value> >
-T PrefixSum (N n, FIN && fin, FOUT && fout, Type type, RetSum a_ret_sum = retSum)
+template <typename T, typename N, typename FIN, typename FOUT, typename TYPE,
+          typename M=std::enable_if_t<std::is_integral<N>::value &&
+                                      (std::is_same<std::decay_t<TYPE>,Type::Inclusive>::value ||
+                                       std::is_same<std::decay_t<TYPE>,Type::Exclusive>::value)> >
+T PrefixSum (N n, FIN && fin, FOUT && fout, TYPE, RetSum a_ret_sum = retSum)
 {
     if (n <= 0) return 0;
     constexpr int nwarps_per_block = 8;
@@ -262,7 +267,7 @@ T PrefixSum (N n, FIN && fin, FOUT && fout, Type type, RetSum a_ret_sum = retSum
 
             offset += threadIdxx;
             T x0 = (offset < iend) ? fin(offset) : 0;
-            if  (type == Type::exclusive && offset == n-1) {
+            if  (std::is_same<std::decay_t<TYPE>,Type::Exclusive>::value && offset == n-1) {
                 *totalsum_p += x0;
             }
             T x = x0;
@@ -302,7 +307,7 @@ T PrefixSum (N n, FIN && fin, FOUT && fout, Type type, RetSum a_ret_sum = retSum
             // sum within this chunk.
             T sum_prev_warp = (warp == 0) ? 0 : shared2[warp-1];
             tmp_out[ichunk] = sum_prev_warp + sum_prev_chunk +
-                ((type == Type::inclusive) ? x : x-x0);
+                (std::is_same<std::decay_t<TYPE>,Type::Inclusive>::value ? x : x-x0);
             sum_prev_chunk += shared2[nwarps-1];
         }
 
@@ -401,11 +406,159 @@ T PrefixSum (N n, FIN && fin, FOUT && fout, Type type, RetSum a_ret_sum = retSum
     return totalsum;
 }
 
+#elif defined(AMREX_USE_CUDA) && defined(__CUDACC__) && (__CUDACC_VER_MAJOR__ >= 11)
+
+template <typename T, typename N, typename FIN, typename FOUT, typename TYPE,
+          typename M=std::enable_if_t<std::is_integral<N>::value &&
+                                      (std::is_same<std::decay_t<TYPE>,Type::Inclusive>::value ||
+                                       std::is_same<std::decay_t<TYPE>,Type::Exclusive>::value)> >
+T PrefixSum (N n, FIN && fin, FOUT && fout, TYPE, RetSum a_ret_sum = retSum)
+{
+    if (n <= 0) return 0;
+    constexpr int nwarps_per_block = AMREX_HIP_OR_CUDA_OR_DPCPP(4,4,8);
+    constexpr int nthreads = nwarps_per_block*Gpu::Device::warp_size; // # of threads per block
+    constexpr int nelms_per_thread = 15;
+    constexpr int nelms_per_block = nthreads * nelms_per_thread;
+    int nblocks = (n + nelms_per_block - 1) / nelms_per_block;
+    std::size_t sm = 0;
+    auto stream = Gpu::gpuStream();
+
+    typedef cub::ScanTileState<T> ScanTileState;
+    std::size_t tile_state_size = 0;
+    ScanTileState::AllocationSize(nblocks, tile_state_size);
+
+    std::size_t nbytes_tile_state = Arena::align(tile_state_size);
+    std::size_t nbytes_block_id = Arena::align(sizeof(unsigned int));
+    auto dp = (char*)(The_Arena()->alloc(nbytes_tile_state+nbytes_block_id));
+    auto tile_state_p = dp;
+
+    ScanTileState tile_state;
+    tile_state.Init(nblocks, tile_state_p, tile_state_size); // Init ScanTileState on host
+
+    // Init ScanTileState on device
+    amrex::launch((nblocks+nthreads-1)/nthreads, nthreads, 0, stream, [=] AMREX_GPU_DEVICE ()
+    {
+        const_cast<ScanTileState&>(tile_state).InitializeStatus(nblocks);
+    });
+
+    struct InputIterator {
+        InputIterator (FIN const& a_fin, N a_offset)
+            : m_fin(a_fin), m_offset(a_offset) {}
+
+        AMREX_GPU_DEVICE AMREX_FORCE_INLINE
+        T operator[] (N i) const { return m_fin(i+m_offset); }
+
+    private:
+        FIN m_fin;
+        N m_offset;
+    };
+
+    T* totalsum_p = (a_ret_sum) ? (T*)(The_Pinned_Arena()->alloc(sizeof(T))) : nullptr;
+
+    amrex::launch(nblocks, nthreads, sm, stream,
+    [=] AMREX_GPU_DEVICE () noexcept
+    {
+        typedef cub::BlockLoad<T, nthreads, nelms_per_thread, cub::BLOCK_LOAD_WARP_TRANSPOSE>
+            BlockLoad;
+        typedef cub::BlockScan<T, nthreads, cub::BLOCK_SCAN_WARP_SCANS> BlockScan;
+        typedef cub::BlockExchange<T, nthreads, nelms_per_thread>       BlockExchange;
+        typedef cub::TilePrefixCallbackOp<T, cub::Sum, ScanTileState>   TilePrefixCallbackOp;
+
+        __shared__ union TempStorage
+        {
+            typename BlockLoad::TempStorage     load;
+            typename BlockExchange::TempStorage exchange;
+            struct ScanStorage {
+                typename BlockScan::TempStorage            scan;
+                typename TilePrefixCallbackOp::TempStorage prefix;
+            } scan_storeage;
+        } temp_storage;
+
+        // Lambda captured tile_state is const.  We have to cast the const away.
+        auto& scan_tile_state = const_cast<ScanTileState&>(tile_state);
+
+        int virtual_block_id = blockIdx.x;
+
+        // Each block processes [ibegin,iend).
+        N ibegin = nelms_per_block * virtual_block_id;
+        N iend = amrex::min(static_cast<N>(ibegin+nelms_per_block), n);
+
+        T data[nelms_per_thread];
+        if (static_cast<int>(iend-ibegin) == nelms_per_block) {
+            BlockLoad(temp_storage.load).Load(InputIterator(fin, ibegin), data);
+        } else {
+            BlockLoad(temp_storage.load).Load(InputIterator(fin, ibegin), data,
+                                              iend-ibegin, 0);
+        }
+
+        __syncthreads();
+
+        constexpr bool is_exclusive = std::is_same<std::decay_t<TYPE>,Type::Exclusive>::value;
+
+        if (virtual_block_id == 0) {
+            T block_agg;
+            AMREX_IF_CONSTEXPR(is_exclusive) {
+                BlockScan(temp_storage.scan_storeage.scan).ExclusiveSum(data, data, block_agg);
+            } else {
+                BlockScan(temp_storage.scan_storeage.scan).InclusiveSum(data, data, block_agg);
+            }
+            if (threadIdx.x == 0) {
+                if (nblocks > 1) {
+                    scan_tile_state.SetInclusive(0, block_agg);
+                } else if (nblocks == 1 && totalsum_p) {
+                    *totalsum_p = block_agg;
+                }
+            }
+        } else {
+            TilePrefixCallbackOp prefix_op(scan_tile_state, temp_storage.scan_storeage.prefix,
+                                           cub::Sum{}, virtual_block_id);
+            AMREX_IF_CONSTEXPR(is_exclusive) {
+                BlockScan(temp_storage.scan_storeage.scan).ExclusiveSum(data, data, prefix_op);
+            } else {
+                BlockScan(temp_storage.scan_storeage.scan).InclusiveSum(data, data, prefix_op);
+            }
+            if (totalsum_p) {
+                if (iend == n && threadIdx.x == blockDim.x-1) { // last thread of last block
+                    T tsum = data[nelms_per_thread-1];
+                    AMREX_IF_CONSTEXPR(is_exclusive) {
+                        if (static_cast<N>(ibegin+nelms_per_block) == n) {
+                            tsum += fin(n-1);
+                        } // else tsum is already the inclusive total sum
+                    }
+                    *totalsum_p = tsum;
+                }
+            }
+        }
+
+        __syncthreads();
+
+        BlockExchange(temp_storage.exchange).BlockedToStriped(data);
+
+        for (int i = 0; i < nelms_per_thread; ++i) {
+            N offset = ibegin + i*blockDim.x + threadIdx.x;
+            if (offset >= iend) break;
+            fout(offset, data[i]);
+        }
+    });
+
+    Gpu::streamSynchronize();
+    AMREX_GPU_ERROR_CHECK();
+
+    The_Arena()->free(dp);
+
+    T ret = (a_ret_sum) ? *totalsum_p : T(0);
+    if (totalsum_p) { The_Pinned_Arena()->free(totalsum_p); }
+
+    return ret;
+}
+
 #else
 
-template <typename T, typename N, typename FIN, typename FOUT,
-          typename M=std::enable_if_t<std::is_integral<N>::value> >
-T PrefixSum (N n, FIN && fin, FOUT && fout, Type type, RetSum a_ret_sum = retSum)
+template <typename T, typename N, typename FIN, typename FOUT, typename TYPE,
+          typename M=std::enable_if_t<std::is_integral<N>::value &&
+                                      (std::is_same<std::decay_t<TYPE>,Type::Inclusive>::value ||
+                                       std::is_same<std::decay_t<TYPE>,Type::Exclusive>::value)> >
+T PrefixSum (N n, FIN && fin, FOUT && fout, TYPE, RetSum a_ret_sum = retSum)
 {
     if (n <= 0) return 0;
     constexpr int nwarps_per_block = 4;
@@ -424,8 +577,8 @@ T PrefixSum (N n, FIN && fin, FOUT && fout, Type type, RetSum a_ret_sum = retSum
     std::size_t nbytes_blockid = Arena::align(sizeof(unsigned int));
     std::size_t nbytes_totalsum = Arena::align(sizeof(T));
     auto dp = (char*)(The_Arena()->alloc(  nbytes_blockstatus
-                                                + nbytes_blockid
-                                                + nbytes_totalsum));
+                                         + nbytes_blockid
+                                         + nbytes_totalsum));
     BlockStatusT* AMREX_RESTRICT block_status_p = (BlockStatusT*)dp;
     unsigned int* AMREX_RESTRICT virtual_block_id_p = (unsigned int*)(dp + nbytes_blockstatus);
     T* AMREX_RESTRICT totalsum_p = (T*)(dp + nbytes_blockstatus + nbytes_blockid);
@@ -486,7 +639,7 @@ T PrefixSum (N n, FIN && fin, FOUT && fout, Type type, RetSum a_ret_sum = retSum
 
             offset += threadIdx.x;
             T x0 = (offset < iend) ? fin(offset) : 0;
-            if  (type == Type::exclusive && offset == n-1) {
+            if  (std::is_same<std::decay_t<TYPE>,Type::Exclusive>::value && offset == n-1) {
                 *totalsum_p += x0;
             }
             T x = x0;
@@ -544,7 +697,7 @@ T PrefixSum (N n, FIN && fin, FOUT && fout, Type type, RetSum a_ret_sum = retSum
             // sum within this chunk.
             T sum_prev_warp = (warp == 0) ? 0 : shared2[warp-1];
             tmp_out[ichunk] = sum_prev_warp + sum_prev_chunk +
-                ((type == Type::inclusive) ? x : x-x0);
+                (std::is_same<std::decay_t<TYPE>,Type::Inclusive>::value ? x : x-x0);
             sum_prev_chunk += shared2[nwarps-1];
         }
 
@@ -749,9 +902,11 @@ T ExclusiveSum (N n, T const* in, T * out, RetSum a_ret_sum = retSum)
 
 #else
 //  !defined(AMREX_USE_GPU)
-template <typename T, typename N, typename FIN, typename FOUT,
-          typename M=std::enable_if_t<std::is_integral<N>::value> >
-T PrefixSum (N n, FIN && fin, FOUT && fout, Type type)
+template <typename T, typename N, typename FIN, typename FOUT, typename TYPE,
+          typename M=std::enable_if_t<std::is_integral<N>::value &&
+                                      (std::is_same<std::decay_t<TYPE>,Type::Inclusive>::value ||
+                                       std::is_same<std::decay_t<TYPE>,Type::Exclusive>::value)> >
+T PrefixSum (N n, FIN && fin, FOUT && fout, TYPE)
 {
     if (n <= 0) return 0;
     T totalsum = 0;
@@ -759,7 +914,7 @@ T PrefixSum (N n, FIN && fin, FOUT && fout, Type type)
         T x = fin(i);
         T y = totalsum;
         totalsum += x;
-        if (type == Type::inclusive) {
+        AMREX_IF_CONSTEXPR (std::is_same<std::decay_t<TYPE>,Type::Inclusive>::value) {
             y += x;
         }
         fout(i, y);

--- a/Src/Base/AMReX_Scan.H
+++ b/Src/Base/AMReX_Scan.H
@@ -488,7 +488,7 @@ T PrefixSum (N n, FIN && fin, FOUT && fout, TYPE, RetSum a_ret_sum = retSum)
             BlockLoad(temp_storage.load).Load(InputIterator(fin, ibegin), data);
         } else {
             BlockLoad(temp_storage.load).Load(InputIterator(fin, ibegin), data,
-                                              iend-ibegin, 0);
+                                              iend-ibegin, 0); // padding with 0
         }
 
         __syncthreads();
@@ -510,6 +510,8 @@ T PrefixSum (N n, FIN && fin, FOUT && fout, TYPE, RetSum a_ret_sum = retSum)
                 }
             }
         } else {
+            T last = data[nelms_per_thread-1]; // Need this for the total sum in exclusive case
+
             TilePrefixCallbackOp prefix_op(scan_tile_state, temp_storage.scan_storeage.prefix,
                                            cub::Sum{}, virtual_block_id);
             AMREX_IF_CONSTEXPR(is_exclusive) {
@@ -520,11 +522,7 @@ T PrefixSum (N n, FIN && fin, FOUT && fout, TYPE, RetSum a_ret_sum = retSum)
             if (totalsum_p) {
                 if (iend == n && threadIdx.x == blockDim.x-1) { // last thread of last block
                     T tsum = data[nelms_per_thread-1];
-                    AMREX_IF_CONSTEXPR(is_exclusive) {
-                        if (static_cast<N>(ibegin+nelms_per_block) == n) {
-                            tsum += fin(n-1);
-                        } // else tsum is already the inclusive total sum
-                    }
+                    AMREX_IF_CONSTEXPR(is_exclusive) { tsum += last; }
                     *totalsum_p = tsum;
                 }
             }


### PR DESCRIPTION
For CUDA >= 11, use cub to reimplement PrefixSum that can take two lambda funcitons.  Both
cub and thrust only provide scan functions that take iterators.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
