### PR TITLE
Use CUB for block reduction

### DIFF
--- a/Src/Base/AMReX_GpuFuse.cpp
+++ b/Src/Base/AMReX_GpuFuse.cpp
@@ -85,7 +85,7 @@ void Fuser::Launch ()
         auto d_lambda_helper = reinterpret_cast<FuseHelper*>(d_buffer+offset_helpers);
         auto d_lambda_object = reinterpret_cast<char*>(d_buffer+offset_objects);
 
-        constexpr int nthreads = 256;
+        constexpr int nthreads = AMREX_GPU_MAX_THREADS;
         constexpr int nwarps_per_block = nthreads/Gpu::Device::warp_size;
         int nblocks = (ntotwarps + nwarps_per_block-1) / nwarps_per_block;
 

--- a/Src/Base/AMReX_GpuLaunchFunctsG.H
+++ b/Src/Base/AMReX_GpuLaunchFunctsG.H
@@ -1390,6 +1390,7 @@ VecReduce (N n, T const& init_val, L1&& f1, L2&& f2) noexcept
     if (amrex::isEmpty(n)) return;
     auto ec = Gpu::ExecutionConfig(n);
     ec.numBlocks.x = std::min(ec.numBlocks.x, Gpu::Device::maxBlocksPerLaunch());
+    AMREX_ASSERT(ec.numThreads.x == AMREX_GPU_MAX_THREADS);
     AMREX_LAUNCH_KERNEL(ec.numBlocks, ec.numThreads, 0, Gpu::gpuStream(),
     [=] AMREX_GPU_DEVICE () noexcept {
         auto r = init_val;

--- a/Src/Base/AMReX_GpuReduce.H
+++ b/Src/Base/AMReX_GpuReduce.H
@@ -9,6 +9,14 @@
 #include <AMReX_GpuUtility.H>
 #include <AMReX_Functional.H>
 
+#if !defined(AMREX_USE_CUB) && defined(AMREX_USE_CUDA) && defined(__CUDACC__) && (__CUDACC_VER_MAJOR__ >= 11)
+#define AMREX_USE_CUB 1
+#endif
+
+#ifdef AMREX_USE_CUB
+#include <cub/cub.cuh>
+#endif
+
 //
 // Public interface
 //
@@ -70,11 +78,11 @@ T blockReduce (T x, WARPREDUCE && warp_reduce, T x0, Gpu::Handler const& h)
     // and since we don't know how many times the user is calling it,
     // we do it always to be safe.
     h.item->barrier(sycl::access::fence_space::local_space);
-    if (lane == 0) shared[wid] = x;
+    if (lane == 0) { shared[wid] = x; }
     h.item->barrier(sycl::access::fence_space::local_space);
     bool b = (tid == 0) || (tid < numwarps);
     x =  b ? shared[lane] : x0;
-    if (wid == 0) x = warp_reduce(x, sg);
+    if (wid == 0) { x = warp_reduce(x, sg); }
     return x;
 }
 
@@ -87,7 +95,7 @@ void blockReduce_partial (T* dest, T x, WARPREDUCE && warp_reduce, ATOMICOP && a
    int wid = sg.get_group_id()[0];
    if ((wid+1)*warpSize <= handler.numActiveThreads) {
        x = warp_reduce(x, sg); // full warp
-       if (sg.get_local_id()[0] == 0) atomic_op(dest, x);
+       if (sg.get_local_id()[0] == 0) { atomic_op(dest, x); }
    } else {
        atomic_op(dest, x);
    }
@@ -99,7 +107,7 @@ void deviceReduceSum_full (T * dest, T source, Gpu::Handler const& h) noexcept
 {
     source = Gpu::blockReduce<Gpu::Device::warp_size>
         (source, Gpu::warpReduce<Gpu::Device::warp_size,T,amrex::Plus<T> >(), (T)0, h);
-    if (h.item->get_local_id(0) == 0) Gpu::Atomic::AddNoRet(dest, source);
+    if (h.item->get_local_id(0) == 0) { Gpu::Atomic::AddNoRet(dest, source); }
 }
 
 template <typename T>
@@ -108,7 +116,7 @@ void deviceReduceMin_full (T * dest, T source, Gpu::Handler const& h) noexcept
 {
     source = Gpu::blockReduce<Gpu::Device::warp_size>
         (source, Gpu::warpReduce<Gpu::Device::warp_size,T,amrex::Less<T> >(), source, h);
-    if (h.item->get_local_id(0) == 0) Gpu::Atomic::Min(dest, source);
+    if (h.item->get_local_id(0) == 0) { Gpu::Atomic::Min(dest, source); }
 }
 
 template <typename T>
@@ -117,7 +125,7 @@ void deviceReduceMax_full (T * dest, T source, Gpu::Handler const& h) noexcept
 {
     source = Gpu::blockReduce<Gpu::Device::warp_size>
         (source, Gpu::warpReduce<Gpu::Device::warp_size,T,amrex::Greater<T> >(), source, h);
-    if (h.item->get_local_id(0) == 0) Gpu::Atomic::Max(dest, source);
+    if (h.item->get_local_id(0) == 0) { Gpu::Atomic::Max(dest, source); }
 }
 
 AMREX_GPU_DEVICE AMREX_FORCE_INLINE
@@ -125,7 +133,7 @@ void deviceReduceLogicalAnd_full (int * dest, int source, Gpu::Handler const& h)
 {
     source = Gpu::blockReduce<Gpu::Device::warp_size>
         (source, Gpu::warpReduce<Gpu::Device::warp_size,int,amrex::LogicalAnd<int> >(), 1, h);
-    if (h.item->get_local_id(0) == 0) Gpu::Atomic::LogicalAnd(dest, source);
+    if (h.item->get_local_id(0) == 0) { Gpu::Atomic::LogicalAnd(dest, source); }
 }
 
 AMREX_GPU_DEVICE AMREX_FORCE_INLINE
@@ -133,7 +141,7 @@ void deviceReduceLogicalOr_full (int * dest, int source, Gpu::Handler const& h) 
 {
     source = Gpu::blockReduce<Gpu::Device::warp_size>
         (source, Gpu::warpReduce<Gpu::Device::warp_size,int,amrex::LogicalOr<int> >(), 0, h);
-    if (h.item->get_local_id(0) == 0) Gpu::Atomic::LogicalOr(dest, source);
+    if (h.item->get_local_id(0) == 0) { Gpu::Atomic::LogicalOr(dest, source); }
 }
 
 template <typename T>
@@ -229,11 +237,11 @@ T blockReduce (T x, WARPREDUCE && warp_reduce, T x0)
     // and since we don't know how many times the user is calling it,
     // we do it always to be safe.
     __syncthreads();
-    if (lane == 0) shared[wid] = x;
+    if (lane == 0) { shared[wid] = x; }
     __syncthreads();
     bool b = (threadIdx.x == 0) || (threadIdx.x < blockDim.x / warpSize);
     x =  b ? shared[lane] : x0;
-    if (wid == 0) x = warp_reduce(x);
+    if (wid == 0) { x = warp_reduce(x); }
     return x;
 }
 
@@ -245,11 +253,29 @@ void blockReduce_partial (T* dest, T x, WARPREDUCE && warp_reduce, ATOMICOP && a
     int warp = (int)threadIdx.x / warpSize;
     if ((warp+1)*warpSize <= handler.numActiveThreads) {
         x = warp_reduce(x); // full warp
-        if (threadIdx.x % warpSize == 0) atomic_op(dest, x);
+        if (threadIdx.x % warpSize == 0) { atomic_op(dest, x); }
     } else {
         atomic_op(dest,x);
     }
 }
+
+#if defined(AMREX_USE_CUB)
+template <int BLOCKDIMX, typename T>
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE
+void deviceReduceSum_full (T * dest, T source) noexcept
+{
+    typedef cub::BlockReduce<T,BLOCKDIMX> BlockReduce;
+    __shared__ typename BlockReduce::TempStorage temp_storage;
+    // __syncthreads() prior to writing to shared memory is necessary
+    // if this reduction call is occurring multiple times in a kernel,
+    // and since we don't know how many times the user is calling it,
+    // we do it always to be safe.
+    __syncthreads();
+    // Compute the block-wide reduction for thread0
+    T aggregate = BlockReduce(temp_storage).Sum(source);
+    if (threadIdx.x == 0) { Gpu::Atomic::AddNoRet(dest, aggregate); }
+}
+#endif
 
 template <typename T>
 AMREX_GPU_DEVICE AMREX_FORCE_INLINE
@@ -257,8 +283,26 @@ void deviceReduceSum_full (T * dest, T source) noexcept
 {
     source = Gpu::blockReduce<Gpu::Device::warp_size>
         (source, Gpu::warpReduce<Gpu::Device::warp_size,T,amrex::Plus<T> >(), (T)0);
-    if (threadIdx.x == 0) Gpu::Atomic::AddNoRet(dest, source);
+    if (threadIdx.x == 0) { Gpu::Atomic::AddNoRet(dest, source); }
 }
+
+#if defined(AMREX_USE_CUB)
+template <int BLOCKDIMX, typename T>
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE
+void deviceReduceMin_full (T * dest, T source) noexcept
+{
+    typedef cub::BlockReduce<T,BLOCKDIMX> BlockReduce;
+    __shared__ typename BlockReduce::TempStorage temp_storage;
+    // __syncthreads() prior to writing to shared memory is necessary
+    // if this reduction call is occurring multiple times in a kernel,
+    // and since we don't know how many times the user is calling it,
+    // we do it always to be safe.
+    __syncthreads();
+    // Compute the block-wide reduction for thread0
+    T aggregate = BlockReduce(temp_storage).Reduce(source, cub::Min());
+    if (threadIdx.x == 0) { Gpu::Atomic::Min(dest, aggregate); }
+}
+#endif
 
 template <typename T>
 AMREX_GPU_DEVICE AMREX_FORCE_INLINE
@@ -266,8 +310,26 @@ void deviceReduceMin_full (T * dest, T source) noexcept
 {
     source = Gpu::blockReduce<Gpu::Device::warp_size>
         (source, Gpu::warpReduce<Gpu::Device::warp_size,T,amrex::Less<T> >(), source);
-    if (threadIdx.x == 0) Gpu::Atomic::Min(dest, source);
+    if (threadIdx.x == 0) { Gpu::Atomic::Min(dest, source); }
 }
+
+#if defined(AMREX_USE_CUB)
+template <int BLOCKDIMX, typename T>
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE
+void deviceReduceMax_full (T * dest, T source) noexcept
+{
+    typedef cub::BlockReduce<T,BLOCKDIMX> BlockReduce;
+    __shared__ typename BlockReduce::TempStorage temp_storage;
+    // __syncthreads() prior to writing to shared memory is necessary
+    // if this reduction call is occurring multiple times in a kernel,
+    // and since we don't know how many times the user is calling it,
+    // we do it always to be safe.
+    __syncthreads();
+    // Compute the block-wide reduction for thread0
+    T aggregate = BlockReduce(temp_storage).Reduce(source, cub::Max());
+    if (threadIdx.x == 0) { Gpu::Atomic::Max(dest, aggregate); }
+}
+#endif
 
 template <typename T>
 AMREX_GPU_DEVICE AMREX_FORCE_INLINE
@@ -275,23 +337,59 @@ void deviceReduceMax_full (T * dest, T source) noexcept
 {
     source = Gpu::blockReduce<Gpu::Device::warp_size>
         (source, Gpu::warpReduce<Gpu::Device::warp_size,T,amrex::Greater<T> >(), source);
-    if (threadIdx.x == 0) Gpu::Atomic::Max(dest, source);
+    if (threadIdx.x == 0) { Gpu::Atomic::Max(dest, source); }
 }
+
+#if defined(AMREX_USE_CUB)
+template <int BLOCKDIMX>
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE
+void deviceReduceLogicalAnd_full (int * dest, int source) noexcept
+{
+    typedef cub::BlockReduce<int,BLOCKDIMX> BlockReduce;
+    __shared__ typename BlockReduce::TempStorage temp_storage;
+    // __syncthreads() prior to writing to shared memory is necessary
+    // if this reduction call is occurring multiple times in a kernel,
+    // and since we don't know how many times the user is calling it,
+    // we do it always to be safe.
+    __syncthreads();
+    // Compute the block-wide reduction for thread0
+    int aggregate = BlockReduce(temp_storage).Reduce(source, amrex::LogicalAnd<int>());
+    if (threadIdx.x == 0) { Gpu::Atomic::LogicalAnd(dest, aggregate); }
+}
+#endif
 
 AMREX_GPU_DEVICE AMREX_FORCE_INLINE
 void deviceReduceLogicalAnd_full (int * dest, int source) noexcept
 {
     source = Gpu::blockReduce<Gpu::Device::warp_size>
         (source, Gpu::warpReduce<Gpu::Device::warp_size,int,amrex::LogicalAnd<int> >(), 1);
-    if (threadIdx.x == 0) Gpu::Atomic::LogicalAnd(dest, source);
+    if (threadIdx.x == 0) { Gpu::Atomic::LogicalAnd(dest, source); }
 }
+
+#if defined(AMREX_USE_CUB)
+template <int BLOCKDIMX>
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE
+void deviceReduceLogicalOr_full (int * dest, int source) noexcept
+{
+    typedef cub::BlockReduce<int,BLOCKDIMX> BlockReduce;
+    __shared__ typename BlockReduce::TempStorage temp_storage;
+    // __syncthreads() prior to writing to shared memory is necessary
+    // if this reduction call is occurring multiple times in a kernel,
+    // and since we don't know how many times the user is calling it,
+    // we do it always to be safe.
+    __syncthreads();
+    // Compute the block-wide reduction for thread0
+    int aggregate = BlockReduce(temp_storage).Reduce(source, amrex::LogicalOr<int>());
+    if (threadIdx.x == 0) { Gpu::Atomic::LogicalOr(dest, aggregate); }
+}
+#endif
 
 AMREX_GPU_DEVICE AMREX_FORCE_INLINE
 void deviceReduceLogicalOr_full (int * dest, int source) noexcept
 {
     source = Gpu::blockReduce<Gpu::Device::warp_size>
         (source, Gpu::warpReduce<Gpu::Device::warp_size,int,amrex::LogicalOr<int> >(), 0);
-    if (threadIdx.x == 0) Gpu::Atomic::LogicalOr(dest, source);
+    if (threadIdx.x == 0) { Gpu::Atomic::LogicalOr(dest, source); }
 }
 
 template <typename T>
@@ -299,7 +397,18 @@ AMREX_GPU_DEVICE AMREX_FORCE_INLINE
 void deviceReduceSum (T * dest, T source, Gpu::Handler const& handler) noexcept
 {
     if (handler.isFullBlock()) {
-        deviceReduceSum_full(dest, source);
+#if defined(AMREX_USE_CUB)
+        if (blockDim.x == 128) {
+            deviceReduceSum_full<128,T>(dest, source);
+        } else if (blockDim.x == 256) {
+            deviceReduceSum_full<256,T>(dest, source);
+        } else if (blockDim.x == 512) {
+            deviceReduceSum_full<512,T>(dest, source);
+        } else
+#endif
+        {
+            deviceReduceSum_full<T>(dest, source);
+        }
     } else {
         Gpu::blockReduce_partial<Gpu::Device::warp_size>
             (dest, source, Gpu::warpReduce<Gpu::Device::warp_size,T,amrex::Plus<T> >(),
@@ -312,7 +421,18 @@ AMREX_GPU_DEVICE AMREX_FORCE_INLINE
 void deviceReduceMin (T * dest, T source, Gpu::Handler const& handler) noexcept
 {
     if (handler.isFullBlock()) {
-        deviceReduceMin_full(dest, source);
+#if defined(AMREX_USE_CUB)
+        if (blockDim.x == 128) {
+            deviceReduceMin_full<128,T>(dest, source);
+        } else if (blockDim.x == 256) {
+            deviceReduceMin_full<256,T>(dest, source);
+        } else if (blockDim.x == 512) {
+            deviceReduceMin_full<512,T>(dest, source);
+        } else
+#endif
+        {
+            deviceReduceMin_full<T>(dest, source);
+        }
     } else {
         Gpu::blockReduce_partial<Gpu::Device::warp_size>
             (dest, source, Gpu::warpReduce<Gpu::Device::warp_size,T,amrex::Less<T> >(),
@@ -325,7 +445,18 @@ AMREX_GPU_DEVICE AMREX_FORCE_INLINE
 void deviceReduceMax (T * dest, T source, Gpu::Handler const& handler) noexcept
 {
     if (handler.isFullBlock()) {
-        deviceReduceMax_full(dest, source);
+#if defined(AMREX_USE_CUB)
+        if (blockDim.x == 128) {
+            deviceReduceMax_full<128,T>(dest, source);
+        } else if (blockDim.x == 256) {
+            deviceReduceMax_full<256,T>(dest, source);
+        } else if (blockDim.x == 512) {
+            deviceReduceMax_full<512,T>(dest, source);
+        } else
+#endif
+        {
+            deviceReduceMax_full<T>(dest, source);
+        }
     } else {
         Gpu::blockReduce_partial<Gpu::Device::warp_size>
             (dest, source, Gpu::warpReduce<Gpu::Device::warp_size,T,amrex::Greater<T> >(),
@@ -337,7 +468,18 @@ AMREX_GPU_DEVICE AMREX_FORCE_INLINE
 void deviceReduceLogicalAnd (int * dest, int source, Gpu::Handler const& handler) noexcept
 {
     if (handler.isFullBlock()) {
-        deviceReduceLogicalAnd_full(dest, source);
+#if defined(AMREX_USE_CUB)
+        if (blockDim.x == 128) {
+            deviceReduceLogicalAnd_full<128>(dest, source);
+        } else if (blockDim.x == 256) {
+            deviceReduceLogicalAnd_full<256>(dest, source);
+        } else if (blockDim.x == 512) {
+            deviceReduceLogicalAnd_full<512>(dest, source);
+        } else
+#endif
+        {
+            deviceReduceLogicalAnd_full(dest, source);
+        }
     } else {
         Gpu::blockReduce_partial<Gpu::Device::warp_size>
             (dest, source, Gpu::warpReduce<Gpu::Device::warp_size,int,amrex::LogicalAnd<int> >(),
@@ -349,7 +491,18 @@ AMREX_GPU_DEVICE AMREX_FORCE_INLINE
 void deviceReduceLogicalOr (int * dest, int source, Gpu::Handler const& handler) noexcept
 {
     if (handler.isFullBlock()) {
-        deviceReduceLogicalOr_full(dest, source);
+#if defined(AMREX_USE_CUB)
+        if (blockDim.x == 128) {
+            deviceReduceLogicalOr_full<128>(dest, source);
+        } else if (blockDim.x == 256) {
+            deviceReduceLogicalOr_full<256>(dest, source);
+        } else if (blockDim.x == 512) {
+            deviceReduceLogicalOr_full<512>(dest, source);
+        } else
+#endif
+        {
+            deviceReduceLogicalOr_full(dest, source);
+        }
     } else {
         Gpu::blockReduce_partial<Gpu::Device::warp_size>
             (dest, source, Gpu::warpReduce<Gpu::Device::warp_size,int,amrex::LogicalOr<int> >(),
@@ -442,445 +595,5 @@ void deviceReduceLogicalOr (int * dest, int source, Gpu::Handler const&) noexcep
 
 #endif
 }}
-
-namespace amrex {
-namespace Gpu {
-#if defined(AMREX_USE_GPU) && !defined(AMREX_USE_DPCPP)
-
-// Based on https://developer.download.nvidia.com/assets/cuda/files/reduction.pdf by Mark Harris
-
-// sum
-
-template <unsigned int blockSize, typename T>
-AMREX_GPU_DEVICE AMREX_FORCE_INLINE
-void amdWarpReduceSum (volatile T* data, int tid) noexcept
-{
-#ifdef __HIP_DEVICE_COMPILE__
-    if (blockSize >= 128) data[tid] += data[tid + 64];
-    if (blockSize >= 64) data[tid] += data[tid + 32];
-    if (blockSize >= 32) data[tid] += data[tid + 16];
-    if (blockSize >= 16) data[tid] += data[tid + 8];
-    if (blockSize >=  8) data[tid] += data[tid + 4];
-    if (blockSize >=  4) data[tid] += data[tid + 2];
-    if (blockSize >=  2) data[tid] += data[tid + 1];
-#else
-    amrex::ignore_unused(data,tid);
-#endif
-}
-
-template <unsigned int blockSize, typename T>
-AMREX_GPU_DEVICE AMREX_FORCE_INLINE
-void cudaWarpReduceSum_lt7 (volatile T* data, int tid) noexcept
-{
-#if __CUDA_ARCH__ < 700
-    if (blockSize >= 64) data[tid] += data[tid + 32];
-    if (blockSize >= 32) data[tid] += data[tid + 16];
-    if (blockSize >= 16) data[tid] += data[tid + 8];
-    if (blockSize >=  8) data[tid] += data[tid + 4];
-    if (blockSize >=  4) data[tid] += data[tid + 2];
-    if (blockSize >=  2) data[tid] += data[tid + 1];
-#else
-    amrex::ignore_unused(data,tid);
-#endif
-}
-
-template <unsigned int blockSize, typename T>
-AMREX_GPU_DEVICE AMREX_FORCE_INLINE
-void cudaWarpReduceSum_ge7 (T* data, int tid) noexcept
-{
-#if __CUDA_ARCH__ >= 700
-    if (blockSize >= 64) { if (tid < 32) { data[tid] += data[tid + 32]; } __syncwarp(); }
-    if (blockSize >= 32) { if (tid < 16) { data[tid] += data[tid + 16]; } __syncwarp(); }
-    if (blockSize >= 16) { if (tid <  8) { data[tid] += data[tid +  8]; } __syncwarp(); }
-    if (blockSize >=  8) { if (tid <  4) { data[tid] += data[tid +  4]; } __syncwarp(); }
-    if (blockSize >=  4) { if (tid <  2) { data[tid] += data[tid +  2]; } __syncwarp(); }
-    if (blockSize >=  2) { if (tid <  1) { data[tid] += data[tid +  1]; } __syncwarp(); }
-#else
-    amrex::ignore_unused(data,tid);
-#endif
-}
-
-template <unsigned int blockSize, typename T>
-AMREX_GPU_DEVICE AMREX_FORCE_INLINE
-void cudaWarpReduceSum (T* data, int tid) noexcept
-{
-#if __CUDA_ARCH__ >= 700
-    cudaWarpReduceSum_ge7<blockSize>(data, tid);
-#else
-    cudaWarpReduceSum_lt7<blockSize>(data, tid);
-#endif
-}
-
-template <unsigned int blockSize, int warpSize, typename T>
-AMREX_GPU_DEVICE AMREX_FORCE_INLINE
-void blockReduceSum (T* data, T& sum) noexcept
-{
-    int tid = threadIdx.x;
-    if (blockSize >= 1024) {
-        if (tid < 512) {
-            for (int n = tid+512; n < blockSize; n += 512) {
-                data[tid] += data[n];
-            }
-        }
-        __syncthreads();
-    }
-    if (blockSize >= 512) { if (tid < 256) { data[tid] += data[tid+256]; } __syncthreads(); }
-    if (blockSize >= 256) { if (tid < 128) { data[tid] += data[tid+128]; } __syncthreads(); }
-    if (warpSize >= 64) {
-        if (tid < 64) amdWarpReduceSum<blockSize>(data, tid);
-    } else {
-        if (blockSize >= 128) { if (tid <  64) { data[tid] += data[tid+ 64]; } __syncthreads(); }
-        if (tid < 32) cudaWarpReduceSum<blockSize>(data, tid);
-    }
-    if (tid == 0) sum = data[0];
-}
-
-// min
-
-template <unsigned int blockSize, typename T>
-AMREX_GPU_DEVICE AMREX_FORCE_INLINE
-void amdWarpReduceMin (volatile T* data, int tid) noexcept
-{
-#ifdef __HIP_DEVICE_COMPILE__
-    if (blockSize >= 128) data[tid] = amrex::min(data[tid],data[tid + 64]);
-    if (blockSize >= 64) data[tid] = amrex::min(data[tid],data[tid + 32]);
-    if (blockSize >= 32) data[tid] = amrex::min(data[tid],data[tid + 16]);
-    if (blockSize >= 16) data[tid] = amrex::min(data[tid],data[tid +  8]);
-    if (blockSize >=  8) data[tid] = amrex::min(data[tid],data[tid +  4]);
-    if (blockSize >=  4) data[tid] = amrex::min(data[tid],data[tid +  2]);
-    if (blockSize >=  2) data[tid] = amrex::min(data[tid],data[tid +  1]);
-#else
-    amrex::ignore_unused(data,tid);
-#endif
-}
-
-template <unsigned int blockSize, typename T>
-AMREX_GPU_DEVICE AMREX_FORCE_INLINE
-void cudaWarpReduceMin_lt7 (volatile T* data, int tid) noexcept
-{
-#if __CUDA_ARCH__ < 700
-    if (blockSize >= 64) data[tid] = amrex::min(data[tid],data[tid + 32]);
-    if (blockSize >= 32) data[tid] = amrex::min(data[tid],data[tid + 16]);
-    if (blockSize >= 16) data[tid] = amrex::min(data[tid],data[tid +  8]);
-    if (blockSize >=  8) data[tid] = amrex::min(data[tid],data[tid +  4]);
-    if (blockSize >=  4) data[tid] = amrex::min(data[tid],data[tid +  2]);
-    if (blockSize >=  2) data[tid] = amrex::min(data[tid],data[tid +  1]);
-#else
-    amrex::ignore_unused(data,tid);
-#endif
-}
-
-template <unsigned int blockSize, typename T>
-AMREX_GPU_DEVICE AMREX_FORCE_INLINE
-void cudaWarpReduceMin_ge7 (T* data, int tid) noexcept
-{
-#if __CUDA_ARCH__ >= 700
-    if (blockSize >= 64) { if (tid < 32) { data[tid] = amrex::min(data[tid],data[tid + 32]); } __syncwarp(); }
-    if (blockSize >= 32) { if (tid < 16) { data[tid] = amrex::min(data[tid],data[tid + 16]); } __syncwarp(); }
-    if (blockSize >= 16) { if (tid <  8) { data[tid] = amrex::min(data[tid],data[tid +  8]); } __syncwarp(); }
-    if (blockSize >=  8) { if (tid <  4) { data[tid] = amrex::min(data[tid],data[tid +  4]); } __syncwarp(); }
-    if (blockSize >=  4) { if (tid <  2) { data[tid] = amrex::min(data[tid],data[tid +  2]); } __syncwarp(); }
-    if (blockSize >=  2) { if (tid <  1) { data[tid] = amrex::min(data[tid],data[tid +  1]); } __syncwarp(); }
-#else
-    amrex::ignore_unused(data,tid);
-#endif
-}
-
-template <unsigned int blockSize, typename T>
-AMREX_GPU_DEVICE AMREX_FORCE_INLINE
-void cudaWarpReduceMin (T* data, int tid) noexcept
-{
-#if __CUDA_ARCH__ >= 700
-    cudaWarpReduceMin_ge7<blockSize>(data, tid);
-#else
-    cudaWarpReduceMin_lt7<blockSize>(data, tid);
-#endif
-}
-
-template <unsigned int blockSize, int warpSize, typename T>
-AMREX_GPU_DEVICE AMREX_FORCE_INLINE
-void blockReduceMin (T* data, T& dmin) noexcept
-{
-    int tid = threadIdx.x;
-    if (blockSize >= 1024) {
-        if (tid < 512) {
-            for (int n = tid+512; n < blockSize; n += 512) {
-                data[tid] = amrex::min(data[tid],data[n]);
-            }
-        }
-        __syncthreads();
-    }
-    if (blockSize >= 512) { if (tid < 256) { data[tid] = amrex::min(data[tid],data[tid+256]); } __syncthreads(); }
-    if (blockSize >= 256) { if (tid < 128) { data[tid] = amrex::min(data[tid],data[tid+128]); } __syncthreads(); }
-    if (warpSize >= 64) {
-        if (tid < 64) amdWarpReduceMin<blockSize>(data, tid);
-    } else {
-        if (blockSize >= 128) { if (tid <  64) { data[tid] = amrex::min(data[tid],data[tid+ 64]); } __syncthreads(); }
-        if (tid < 32) cudaWarpReduceMin<blockSize>(data, tid);
-    }
-    if (tid == 0) dmin = data[0];
-}
-
-// max
-
-template <unsigned int blockSize, typename T>
-AMREX_GPU_DEVICE AMREX_FORCE_INLINE
-void amdWarpReduceMax (volatile T* data, int tid) noexcept
-{
-#ifdef __HIP_DEVICE_COMPILE__
-    if (blockSize >= 128) data[tid] = amrex::max(data[tid],data[tid + 64]);
-    if (blockSize >= 64) data[tid] = amrex::max(data[tid],data[tid + 32]);
-    if (blockSize >= 32) data[tid] = amrex::max(data[tid],data[tid + 16]);
-    if (blockSize >= 16) data[tid] = amrex::max(data[tid],data[tid +  8]);
-    if (blockSize >=  8) data[tid] = amrex::max(data[tid],data[tid +  4]);
-    if (blockSize >=  4) data[tid] = amrex::max(data[tid],data[tid +  2]);
-    if (blockSize >=  2) data[tid] = amrex::max(data[tid],data[tid +  1]);
-#else
-    amrex::ignore_unused(data,tid);
-#endif
-}
-
-template <unsigned int blockSize, typename T>
-AMREX_GPU_DEVICE AMREX_FORCE_INLINE
-void cudaWarpReduceMax_lt7 (volatile T* data, int tid) noexcept
-{
-#if __CUDA_ARCH__ < 700
-    if (blockSize >= 64) data[tid] = amrex::max(data[tid],data[tid + 32]);
-    if (blockSize >= 32) data[tid] = amrex::max(data[tid],data[tid + 16]);
-    if (blockSize >= 16) data[tid] = amrex::max(data[tid],data[tid +  8]);
-    if (blockSize >=  8) data[tid] = amrex::max(data[tid],data[tid +  4]);
-    if (blockSize >=  4) data[tid] = amrex::max(data[tid],data[tid +  2]);
-    if (blockSize >=  2) data[tid] = amrex::max(data[tid],data[tid +  1]);
-#else
-    amrex::ignore_unused(data,tid);
-#endif
-}
-
-template <unsigned int blockSize, typename T>
-AMREX_GPU_DEVICE AMREX_FORCE_INLINE
-void cudaWarpReduceMax_ge7 (T* data, int tid) noexcept
-{
-#if __CUDA_ARCH__ >= 700
-    if (blockSize >= 64) { if (tid < 32) { data[tid] = amrex::max(data[tid],data[tid + 32]); } __syncwarp(); }
-    if (blockSize >= 32) { if (tid < 16) { data[tid] = amrex::max(data[tid],data[tid + 16]); } __syncwarp(); }
-    if (blockSize >= 16) { if (tid <  8) { data[tid] = amrex::max(data[tid],data[tid +  8]); } __syncwarp(); }
-    if (blockSize >=  8) { if (tid <  4) { data[tid] = amrex::max(data[tid],data[tid +  4]); } __syncwarp(); }
-    if (blockSize >=  4) { if (tid <  2) { data[tid] = amrex::max(data[tid],data[tid +  2]); } __syncwarp(); }
-    if (blockSize >=  2) { if (tid <  1) { data[tid] = amrex::max(data[tid],data[tid +  1]); } __syncwarp(); }
-#else
-    amrex::ignore_unused(data,tid);
-#endif
-}
-
-template <unsigned int blockSize, typename T>
-AMREX_GPU_DEVICE AMREX_FORCE_INLINE
-void cudaWarpReduceMax (T* data, int tid) noexcept
-{
-#if __CUDA_ARCH__ >= 700
-    cudaWarpReduceMax_ge7<blockSize>(data, tid);
-#else
-    cudaWarpReduceMax_lt7<blockSize>(data, tid);
-#endif
-}
-
-template <unsigned int blockSize, int warpSize, typename T>
-AMREX_GPU_DEVICE AMREX_FORCE_INLINE
-void blockReduceMax (T* data, T& dmax) noexcept
-{
-    int tid = threadIdx.x;
-    if (blockSize >= 1024) {
-        if (tid < 512) {
-            for (int n = tid+512; n < blockSize; n += 512) {
-                data[tid] = amrex::max(data[tid],data[n]);
-            }
-        }
-        __syncthreads();
-    }
-    if (blockSize >= 512) { if (tid < 256) { data[tid] = amrex::max(data[tid],data[tid+256]); } __syncthreads(); }
-    if (blockSize >= 256) { if (tid < 128) { data[tid] = amrex::max(data[tid],data[tid+128]); } __syncthreads(); }
-    if (warpSize >= 64) {
-        if (tid < 64) amdWarpReduceMax<blockSize>(data, tid);
-    } else {
-        if (blockSize >= 128) { if (tid <  64) { data[tid] = amrex::max(data[tid],data[tid+ 64]); } __syncthreads(); }
-        if (tid < 32) cudaWarpReduceMax<blockSize>(data, tid);
-    }
-    if (tid == 0) dmax = data[0];
-}
-
-// and
-
-template <unsigned int blockSize, typename T>
-AMREX_GPU_DEVICE AMREX_FORCE_INLINE
-void amdWarpReduceAnd (volatile T* data, int tid) noexcept
-{
-#ifdef __HIP_DEVICE_COMPILE__
-    if (blockSize >= 128) data[tid] = data[tid] && data[tid + 64];
-    if (blockSize >= 64) data[tid] = data[tid] && data[tid + 32];
-    if (blockSize >= 32) data[tid] = data[tid] && data[tid + 16];
-    if (blockSize >= 16) data[tid] = data[tid] && data[tid +  8];
-    if (blockSize >=  8) data[tid] = data[tid] && data[tid +  4];
-    if (blockSize >=  4) data[tid] = data[tid] && data[tid +  2];
-    if (blockSize >=  2) data[tid] = data[tid] && data[tid +  1];
-#else
-    amrex::ignore_unused(data,tid);
-#endif
-}
-
-template <unsigned int blockSize, typename T>
-AMREX_GPU_DEVICE AMREX_FORCE_INLINE
-void cudaWarpReduceAnd_lt7 (volatile T* data, int tid) noexcept
-{
-#if __CUDA_ARCH__ < 700
-    if (blockSize >= 64) data[tid] = data[tid] && data[tid + 32];
-    if (blockSize >= 32) data[tid] = data[tid] && data[tid + 16];
-    if (blockSize >= 16) data[tid] = data[tid] && data[tid +  8];
-    if (blockSize >=  8) data[tid] = data[tid] && data[tid +  4];
-    if (blockSize >=  4) data[tid] = data[tid] && data[tid +  2];
-    if (blockSize >=  2) data[tid] = data[tid] && data[tid +  1];
-#else
-    amrex::ignore_unused(data,tid);
-#endif
-}
-
-template <unsigned int blockSize, typename T>
-AMREX_GPU_DEVICE AMREX_FORCE_INLINE
-void cudaWarpReduceAnd_ge7 (T* data, int tid) noexcept
-{
-#if __CUDA_ARCH__ >= 700
-    if (blockSize >= 64) { if (tid < 32) { data[tid] = data[tid] && data[tid + 32]; } __syncwarp(); }
-    if (blockSize >= 32) { if (tid < 16) { data[tid] = data[tid] && data[tid + 16]; } __syncwarp(); }
-    if (blockSize >= 16) { if (tid <  8) { data[tid] = data[tid] && data[tid +  8]; } __syncwarp(); }
-    if (blockSize >=  8) { if (tid <  4) { data[tid] = data[tid] && data[tid +  4]; } __syncwarp(); }
-    if (blockSize >=  4) { if (tid <  2) { data[tid] = data[tid] && data[tid +  2]; } __syncwarp(); }
-    if (blockSize >=  2) { if (tid <  1) { data[tid] = data[tid] && data[tid +  1]; } __syncwarp(); }
-#else
-    amrex::ignore_unused(data,tid);
-#endif
-}
-
-template <unsigned int blockSize, typename T>
-AMREX_GPU_DEVICE AMREX_FORCE_INLINE
-void cudaWarpReduceAnd (T* data, int tid) noexcept
-{
-#if __CUDA_ARCH__ >= 700
-    cudaWarpReduceAnd_ge7<blockSize>(data, tid);
-#else
-    cudaWarpReduceAnd_lt7<blockSize>(data, tid);
-#endif
-}
-
-template <unsigned int blockSize, int warpSize, typename T>
-AMREX_GPU_DEVICE AMREX_FORCE_INLINE
-void blockReduceAnd (T* data, T& r) noexcept
-{
-    int tid = threadIdx.x;
-    if (blockSize >= 1024) {
-        if (tid < 512) {
-            for (int n = tid+512; n < blockSize; n += 512) {
-                data[tid] = data[tid] && data[n];
-            }
-        }
-        __syncthreads();
-    }
-    if (blockSize >= 512) { if (tid < 256) { data[tid] = data[tid] && data[tid+256]; } __syncthreads(); }
-    if (blockSize >= 256) { if (tid < 128) { data[tid] = data[tid] && data[tid+128]; } __syncthreads(); }
-    if (warpSize >= 64) {
-        if (tid < 64) amdWarpReduceAnd<blockSize>(data, tid);
-    } else {
-        if (blockSize >= 128) { if (tid <  64) { data[tid] = data[tid] && data[tid+ 64]; } __syncthreads(); }
-        if (tid < 32) cudaWarpReduceAnd<blockSize>(data, tid);
-    }
-    if (tid == 0) r = data[0];
-}
-
-// or
-
-template <unsigned int blockSize, typename T>
-AMREX_GPU_DEVICE AMREX_FORCE_INLINE
-void amdWarpReduceOr (volatile T* data, int tid) noexcept
-{
-#ifdef __HIP_DEVICE_COMPILE__
-    if (blockSize >= 128) data[tid] = data[tid] || data[tid + 64];
-    if (blockSize >= 64) data[tid] = data[tid] || data[tid + 32];
-    if (blockSize >= 32) data[tid] = data[tid] || data[tid + 16];
-    if (blockSize >= 16) data[tid] = data[tid] || data[tid +  8];
-    if (blockSize >=  8) data[tid] = data[tid] || data[tid +  4];
-    if (blockSize >=  4) data[tid] = data[tid] || data[tid +  2];
-    if (blockSize >=  2) data[tid] = data[tid] || data[tid +  1];
-#else
-    amrex::ignore_unused(data,tid);
-#endif
-}
-
-template <unsigned int blockSize, typename T>
-AMREX_GPU_DEVICE AMREX_FORCE_INLINE
-void cudaWarpReduceOr_lt7 (volatile T* data, int tid) noexcept
-{
-#if __CUDA_ARCH__ < 700
-    if (blockSize >= 64) data[tid] = data[tid] || data[tid + 32];
-    if (blockSize >= 32) data[tid] = data[tid] || data[tid + 16];
-    if (blockSize >= 16) data[tid] = data[tid] || data[tid +  8];
-    if (blockSize >=  8) data[tid] = data[tid] || data[tid +  4];
-    if (blockSize >=  4) data[tid] = data[tid] || data[tid +  2];
-    if (blockSize >=  2) data[tid] = data[tid] || data[tid +  1];
-#else
-    amrex::ignore_unused(data,tid);
-#endif
-}
-
-template <unsigned int blockSize, typename T>
-AMREX_GPU_DEVICE AMREX_FORCE_INLINE
-void cudaWarpReduceOr_ge7 (T* data, int tid) noexcept
-{
-#if __CUDA_ARCH__ >= 700
-    if (blockSize >= 64) { if (tid < 32) { data[tid] = data[tid] || data[tid + 32]; } __syncwarp(); }
-    if (blockSize >= 32) { if (tid < 16) { data[tid] = data[tid] || data[tid + 16]; } __syncwarp(); }
-    if (blockSize >= 16) { if (tid <  8) { data[tid] = data[tid] || data[tid +  8]; } __syncwarp(); }
-    if (blockSize >=  8) { if (tid <  4) { data[tid] = data[tid] || data[tid +  4]; } __syncwarp(); }
-    if (blockSize >=  4) { if (tid <  2) { data[tid] = data[tid] || data[tid +  2]; } __syncwarp(); }
-    if (blockSize >=  2) { if (tid <  1) { data[tid] = data[tid] || data[tid +  1]; } __syncwarp(); }
-#else
-    amrex::ignore_unused(data,tid);
-#endif
-}
-
-template <unsigned int blockSize, typename T>
-AMREX_GPU_DEVICE AMREX_FORCE_INLINE
-void cudaWarpReduceOr (T* data, int tid) noexcept
-{
-#if __CUDA_ARCH__ >= 700
-    cudaWarpReduceOr_ge7<blockSize>(data, tid);
-#else
-    cudaWarpReduceOr_lt7<blockSize>(data, tid);
-#endif
-}
-
-template <unsigned int blockSize, int warpSize, typename T>
-AMREX_GPU_DEVICE AMREX_FORCE_INLINE
-void blockReduceOr (T* data, T& r) noexcept
-{
-    int tid = threadIdx.x;
-    if (blockSize >= 1024) {
-        if (tid < 512) {
-            for (int n = tid+512; n < blockSize; n += 512) {
-                data[tid] = data[tid] || data[n];
-            }
-        }
-        __syncthreads();
-    }
-    if (blockSize >= 512) { if (tid < 256) { data[tid] = data[tid] || data[tid+256]; } __syncthreads(); }
-    if (blockSize >= 256) { if (tid < 128) { data[tid] = data[tid] || data[tid+128]; } __syncthreads(); }
-    if (warpSize >= 64) {
-        if (tid < 64) amdWarpReduceOr<blockSize>(data, tid);
-    } else {
-        if (blockSize >= 128) { if (tid <  64) { data[tid] = data[tid] || data[tid+ 64]; } __syncthreads(); }
-        if (tid < 32) cudaWarpReduceOr<blockSize>(data, tid);
-    }
-    if (tid == 0) r = data[0];
-}
-
-#endif
-}
-}
 
 #endif

--- a/Src/Base/AMReX_Reduce.H
+++ b/Src/Base/AMReX_Reduce.H
@@ -82,7 +82,13 @@ struct ReduceOpSum
 #else
     template <typename T>
     AMREX_GPU_DEVICE AMREX_FORCE_INLINE
-    void parallel_update (T& d, T const& s) const noexcept { Gpu::deviceReduceSum_full(&d,s); }
+    void parallel_update (T& d, T const& s) const noexcept {
+#if defined(AMREX_USE_CUB)
+        Gpu::deviceReduceSum_full<AMREX_GPU_MAX_THREADS>(&d,s);
+#else
+        Gpu::deviceReduceSum_full(&d,s);
+#endif
+    }
 #endif
 
     template <typename T>
@@ -104,7 +110,13 @@ struct ReduceOpMin
 #else
     template <typename T>
     AMREX_GPU_DEVICE AMREX_FORCE_INLINE
-    void parallel_update (T& d, T const& s) const noexcept { Gpu::deviceReduceMin_full(&d,s); }
+    void parallel_update (T& d, T const& s) const noexcept {
+#if defined(AMREX_USE_CUB)
+        Gpu::deviceReduceMin_full<AMREX_GPU_MAX_THREADS>(&d,s);
+#else
+        Gpu::deviceReduceMin_full(&d,s);
+#endif
+    }
 #endif
 
     template <typename T>
@@ -126,7 +138,13 @@ struct ReduceOpMax
 #else
     template <typename T>
     AMREX_GPU_DEVICE AMREX_FORCE_INLINE
-    void parallel_update (T& d, T const& s) const noexcept { Gpu::deviceReduceMax_full(&d,s); }
+    void parallel_update (T& d, T const& s) const noexcept {
+#if defined(AMREX_USE_CUB)
+        Gpu::deviceReduceMax_full<AMREX_GPU_MAX_THREADS>(&d,s);
+#else
+        Gpu::deviceReduceMax_full(&d,s);
+#endif
+    }
 #endif
 
     template <typename T>
@@ -146,7 +164,13 @@ struct ReduceOpLogicalAnd
     }
 #else
     AMREX_GPU_DEVICE AMREX_FORCE_INLINE
-    void parallel_update (int& d, int s) const noexcept { Gpu::deviceReduceLogicalAnd_full(&d,s); }
+    void parallel_update (int& d, int s) const noexcept {
+#if defined(AMREX_USE_CUB)
+        Gpu::deviceReduceLogicalAnd_full<AMREX_GPU_MAX_THREADS>(&d,s);
+#else
+        Gpu::deviceReduceLogicalAnd_full(&d,s);
+#endif
+    }
 #endif
 
     AMREX_GPU_DEVICE AMREX_FORCE_INLINE
@@ -164,7 +188,13 @@ struct ReduceOpLogicalOr
     }
 #else
     AMREX_GPU_DEVICE AMREX_FORCE_INLINE
-    void parallel_update (int& d, int s) const noexcept { Gpu::deviceReduceLogicalOr_full(&d,s); }
+    void parallel_update (int& d, int s) const noexcept {
+#if defined(AMREX_USE_CUB)
+        Gpu::deviceReduceLogicalOr_full<AMREX_GPU_MAX_THREADS>(&d,s);
+#else
+        Gpu::deviceReduceLogicalOr_full(&d,s);
+#endif
+    }
 #endif
 
     AMREX_GPU_DEVICE AMREX_FORCE_INLINE
@@ -287,6 +317,7 @@ public:
         const auto len = amrex::length(box);
         IndexType ixtype = box.ixType();
         auto ec = Gpu::ExecutionConfig(ncells);
+        AMREX_ASSERT(ec.numThreads.x == AMREX_GPU_MAX_THREADS);
         ec.numBlocks.x = std::min(ec.numBlocks.x, Gpu::Device::maxBlocksPerLaunch());
 #ifdef AMREX_USE_DPCPP
         // device reduce needs local(i.e., shared) memory
@@ -355,6 +386,7 @@ public:
         const auto lo  = amrex::lbound(box);
         const auto len = amrex::length(box);
         auto ec = Gpu::ExecutionConfig(ncells);
+        AMREX_ASSERT(ec.numThreads.x == AMREX_GPU_MAX_THREADS);
         ec.numBlocks.x = std::min(ec.numBlocks.x, Gpu::Device::maxBlocksPerLaunch());
 #ifdef AMREX_USE_DPCPP
         // device reduce needs local(i.e., shared) memory
@@ -407,6 +439,7 @@ public:
         using ReduceTuple = typename D::Type;
         auto dp = reduce_data.devicePtr();
         auto ec = Gpu::ExecutionConfig(n);
+        AMREX_ASSERT(ec.numThreads.x == AMREX_GPU_MAX_THREADS);
         ec.numBlocks.x = std::min(ec.numBlocks.x, Gpu::Device::maxBlocksPerLaunch());
 #ifdef AMREX_USE_DPCPP
         // device reduce needs local(i.e., shared) memory
@@ -458,7 +491,11 @@ T Sum (N n, U const* v, T init_val, BOP bop)
 #else
     [=] AMREX_GPU_DEVICE (T const& r) noexcept
     {
+#if defined(AMREX_USE_CUB)
+        Gpu::deviceReduceSum_full<AMREX_GPU_MAX_THREADS>(dp, r);
+#else
         Gpu::deviceReduceSum_full(dp, r);
+#endif
     });
 #endif
     return ds.dataValue();
@@ -500,7 +537,11 @@ T Min (N n, U const* v, T init_val, BOP bop)
 #else
     [=] AMREX_GPU_DEVICE (T const& r) noexcept
     {
+#if defined(AMREX_USE_CUB)
+        Gpu::deviceReduceMin_full<AMREX_GPU_MAX_THREADS>(dp, r);
+#else
         Gpu::deviceReduceMin_full(dp, r);
+#endif
     });
 #endif
     return ds.dataValue();
@@ -543,7 +584,11 @@ T Max (N n, U const* v, T init_val, BOP bop)
 #else
     [=] AMREX_GPU_DEVICE (T const& r) noexcept
     {
+#if defined(AMREX_USE_CUB)
+        Gpu::deviceReduceMax_full<AMREX_GPU_MAX_THREADS>(dp, r);
+#else
         Gpu::deviceReduceMax_full(dp, r);
+#endif
     });
 #endif
     return ds.dataValue();
@@ -590,8 +635,13 @@ std::pair<T,T> MinMax (N n, U const* v, MINOP minop, MAXOP maxop)
 #else
     [=] AMREX_GPU_DEVICE (Real2 const& r) noexcept
     {
+#if defined(AMREX_USE_CUB)
+        Gpu::deviceReduceMin_full<AMREX_GPU_MAX_THREADS>(dp  , r[0]);
+        Gpu::deviceReduceMax_full<AMREX_GPU_MAX_THREADS>(dp+1, r[1]);
+#else
         Gpu::deviceReduceMin_full(dp  , r[0]);
         Gpu::deviceReduceMax_full(dp+1, r[1]);
+#endif
     });
 #endif
     Gpu::dtoh_memcpy(hv.data(), dp, 2*sizeof(T));


### PR DESCRIPTION
Also removed some reduction functions that have been deprecated long ago.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
