### PR TITLE
Multilevel version of ParticleToMesh

### DIFF
--- a/Src/AmrCore/AMReX_AmrParticles.H
+++ b/Src/AmrCore/AMReX_AmrParticles.H
@@ -151,6 +151,88 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>
     }
 }
 
+template <class PC, class F, std::enable_if_t<IsParticleContainer<PC>::value, int> foo = 0>
+void
+ParticleToMesh (PC const& pc, const Vector<MultiFab*>& mf,
+                int lev_min, int lev_max, F&& f, bool zero_out_input=true)
+{
+    BL_PROFILE("amrex::ParticleToMesh");
+
+    if (lev_max == -1) { lev_max = pc.finestLevel(); }
+    while (!pc.GetParGDB()->LevelDefined(lev_max)) { lev_max--; }
+
+    if (lev_max == 0)
+    {
+        return ParticleToMesh(pc, *mf[0], 0, std::forward<F>(f), zero_out_input);
+    }
+
+    if (zero_out_input)
+    {
+        for (int lev = lev_min; lev <= lev_max; ++lev)
+        {
+            mf[lev]->setVal(0.0);
+        }
+    }
+
+    Vector<MultiFab> mf_part(lev_max+1);
+    Vector<MultiFab> mf_tmp( lev_max+1);
+    for (int lev = lev_min; lev <= lev_max; ++lev)
+    {
+        mf_part[lev].define(pc.ParticleBoxArray(lev),
+                           pc.ParticleDistributionMap(lev),
+                           mf[lev]->nComp(), mf[lev]->nGrowVect());
+        mf_tmp[lev].define( pc.ParticleBoxArray(lev),
+                            pc.ParticleDistributionMap(lev),
+                            mf[lev]->nComp(), mf[lev]->nGrowVect());
+        mf_part[lev].setVal(0.0);
+        mf_tmp[lev].setVal( 0.0);
+    }
+
+    // configure this to do a no-op at the physical boundaries.
+    int lo_bc[] = {BCType::int_dir, BCType::int_dir, BCType::int_dir};
+    int hi_bc[] = {BCType::int_dir, BCType::int_dir, BCType::int_dir};
+    Vector<BCRec> bcs(1, BCRec(lo_bc, hi_bc));
+    PCInterp mapper;
+
+    for (int lev = lev_min; lev <= lev_max; ++lev)
+    {
+        ParticleToMesh(pc, mf_part[lev], lev, std::forward<F>(f), zero_out_input);
+
+        if (lev < lev_max) {
+            PhysBCFunctNoOp cphysbc, fphysbc;
+            amrex::InterpFromCoarseLevel(mf_tmp[lev+1], 0.0, mf_part[lev],
+                                         0, 0, mf_part[lev].nComp(),
+                                         pc.GetParGDB()->Geom(lev),
+                                         pc.GetParGDB()->Geom(lev+1),
+                                         cphysbc, 0, fphysbc, 0,
+                                         pc.GetParGDB()->refRatio(lev), &mapper,
+                                         bcs, 0);
+        }
+
+        if (lev > lev_min) {
+            // Note - this will double count the mass on the coarse level in
+            // regions covered by the fine level, but this will be corrected
+            // below in the call to average_down.
+            amrex::sum_fine_to_coarse(mf_part[lev], mf_part[lev-1], 0, mf_part[lev].nComp(),
+                                      pc.GetParGDB()->refRatio(lev-1),
+                                      pc.GetParGDB()->Geom(lev-1),
+                                      pc.GetParGDB()->Geom(lev));
+        }
+
+        mf_part[lev].plus(mf_tmp[lev], 0, mf_part[lev].nComp(), 0);
+    }
+
+    for (int lev = lev_max-1; lev >= lev_min; --lev) {
+        amrex::average_down(mf_part[lev+1], mf_part[lev], 0, mf_part[lev].nComp(),
+                            pc.GetParGDB()->refRatio(lev));
+    }
+
+    for (int lev = lev_min; lev <= lev_max; lev++)
+    {
+        mf[lev]->ParallelCopy(mf_part[lev],0,0,mf_part[lev].nComp(),0,0);
+    }
+}
+
 template <int NStructReal, int NStructInt=0, int NArrayReal=0, int NArrayInt=0,
           template<class> class Allocator=DefaultAllocator>
 class AmrParticleContainer

--- a/Src/AmrCore/AMReX_AmrParticles.H
+++ b/Src/AmrCore/AMReX_AmrParticles.H
@@ -14,9 +14,9 @@ template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt,
           template<class> class Allocator>
 void
 ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>
-::AssignDensity(int rho_index,
-                Vector<std::unique_ptr<MultiFab> >& mf_to_be_filled,
-                int lev_min, int ncomp, int finest_level, int ngrow) const
+::AssignDensity (int rho_index,
+                 Vector<std::unique_ptr<MultiFab> >& mf_to_be_filled,
+                 int lev_min, int ncomp, int finest_level, int ngrow) const
 {
 
     BL_PROFILE("ParticleContainer::AssignDensity()");
@@ -154,7 +154,8 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>
 template <class PC, class F, std::enable_if_t<IsParticleContainer<PC>::value, int> foo = 0>
 void
 ParticleToMesh (PC const& pc, const Vector<MultiFab*>& mf,
-                int lev_min, int lev_max, F&& f, bool zero_out_input=true)
+                int lev_min, int lev_max, F&& f,
+                bool zero_out_input=true, bool vol_weight=true)
 {
     BL_PROFILE("amrex::ParticleToMesh");
 
@@ -163,7 +164,13 @@ ParticleToMesh (PC const& pc, const Vector<MultiFab*>& mf,
 
     if (lev_max == 0)
     {
-        return ParticleToMesh(pc, *mf[0], 0, std::forward<F>(f), zero_out_input);
+        ParticleToMesh(pc, *mf[0], 0, std::forward<F>(f), zero_out_input);
+        if (vol_weight) {
+            const Real* dx = pc.Geom(0).CellSize();
+            const Real vol = AMREX_D_TERM(dx[0], *dx[1], *dx[2]);
+            mf[0]->mult(1.0/vol, 0, mf[0]->nComp(), mf[0]->nGrow());
+        }
+        return;
     }
 
     if (zero_out_input)
@@ -197,6 +204,11 @@ ParticleToMesh (PC const& pc, const Vector<MultiFab*>& mf,
     for (int lev = lev_min; lev <= lev_max; ++lev)
     {
         ParticleToMesh(pc, mf_part[lev], lev, std::forward<F>(f), zero_out_input);
+        if (vol_weight) {
+            const Real* dx = pc.Geom(lev).CellSize();
+            const Real vol = AMREX_D_TERM(dx[0], *dx[1], *dx[2]);
+            mf_part[lev].mult(1.0/vol, 0, mf_part[lev].nComp(), mf_part[lev].nGrow());
+        }
 
         if (lev < lev_max) {
             PhysBCFunctNoOp cphysbc, fphysbc;

--- a/Src/Particle/AMReX_ParticleMesh.H
+++ b/Src/Particle/AMReX_ParticleMesh.H
@@ -4,6 +4,7 @@
 
 #include <AMReX_TypeTraits.H>
 #include <AMReX_MultiFab.H>
+#include <AMReX_ParticleUtil.H>
 
 namespace amrex
 {
@@ -22,7 +23,6 @@ ParticleToMesh (PC const& pc, MF& mf, int lev, F&& f, bool zero_out_input=true)
     mf_tmp.setVal(0.0);
 
     using ParIter = typename PC::ParConstIterType;
-    const auto& plevel = pc.GetParticles(lev);
 #ifdef AMREX_USE_GPU
     if (Gpu::inLaunchRegion())
     {
@@ -38,7 +38,7 @@ ParticleToMesh (PC const& pc, MF& mf, int lev, F&& f, bool zero_out_input=true)
 
             AMREX_FOR_1D( np, i,
             {
-                f(pstruct[i], fabarr);
+                particle_detail::call_f(f, pstruct[i], fabarr);
             });
         }
     }
@@ -67,7 +67,7 @@ ParticleToMesh (PC const& pc, MF& mf, int lev, F&& f, bool zero_out_input=true)
 
                 AMREX_FOR_1D( np, i,
                 {
-                    f(pstruct[i], fabarr);
+                    particle_detail::call_f(f, pstruct[i], fabarr);
                 });
 
                 fab.atomicAdd<RunOn::Host>(local_fab, tile_box, tile_box, 0, 0, mf_tmp.nComp());
@@ -91,7 +91,6 @@ MeshToParticle (PC& pc, MF const& mf, int lev, F&& f)
 
     if (mf_pointer != &mf) mf_pointer->copy(mf,0,0,mf.nComp(),mf.nGrowVect(),mf.nGrowVect());
 
-    auto& plevel = pc.GetParticles(lev);
     using ParIter = typename PC::ParIterType;
 #ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
@@ -108,7 +107,7 @@ MeshToParticle (PC& pc, MF const& mf, int lev, F&& f)
 
         AMREX_FOR_1D( np, i,
         {
-            f(pstruct[i], fabarr);
+            particle_detail::call_f(f, pstruct[i], fabarr);
         });
     }
 

--- a/Src/Particle/AMReX_ParticleMesh.H
+++ b/Src/Particle/AMReX_ParticleMesh.H
@@ -22,6 +22,9 @@ ParticleToMesh (PC const& pc, MF& mf, int lev, F&& f, bool zero_out_input=true)
                     mf.nComp(), mf.nGrowVect());
     mf_tmp.setVal(0.0);
 
+    const auto plo = pc.Geom(lev).ProbLoArray();
+    const auto dxi = pc.Geom(lev).InvCellSizeArray();
+
     using ParIter = typename PC::ParConstIterType;
 #ifdef AMREX_USE_GPU
     if (Gpu::inLaunchRegion())
@@ -38,7 +41,7 @@ ParticleToMesh (PC const& pc, MF& mf, int lev, F&& f, bool zero_out_input=true)
 
             AMREX_FOR_1D( np, i,
             {
-                particle_detail::call_f(f, pstruct[i], fabarr);
+                particle_detail::call_f(f, pstruct[i], fabarr, plo, dxi);
             });
         }
     }
@@ -67,7 +70,7 @@ ParticleToMesh (PC const& pc, MF& mf, int lev, F&& f, bool zero_out_input=true)
 
                 AMREX_FOR_1D( np, i,
                 {
-                    particle_detail::call_f(f, pstruct[i], fabarr);
+                    particle_detail::call_f(f, pstruct[i], fabarr, plo, dxi);
                 });
 
                 fab.atomicAdd<RunOn::Host>(local_fab, tile_box, tile_box, 0, 0, mf_tmp.nComp());
@@ -91,6 +94,9 @@ MeshToParticle (PC& pc, MF const& mf, int lev, F&& f)
 
     if (mf_pointer != &mf) mf_pointer->copy(mf,0,0,mf.nComp(),mf.nGrowVect(),mf.nGrowVect());
 
+    const auto plo = pc.Geom(lev).ProbLoArray();
+    const auto dxi = pc.Geom(lev).InvCellSizeArray();
+
     using ParIter = typename PC::ParIterType;
 #ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
@@ -107,7 +113,7 @@ MeshToParticle (PC& pc, MF const& mf, int lev, F&& f)
 
         AMREX_FOR_1D( np, i,
         {
-            particle_detail::call_f(f, pstruct[i], fabarr);
+            particle_detail::call_f(f, pstruct[i], fabarr, plo, dxi);
         });
     }
 

--- a/Src/Particle/AMReX_ParticleUtil.H
+++ b/Src/Particle/AMReX_ParticleUtil.H
@@ -55,15 +55,39 @@ auto call_f (F const& f, SrcData const& src, N i, amrex::RandomEngine const&) no
 
 template <typename F, typename P, typename T>
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-auto call_f (F const& f, P const& p, Array4<T> const& fabarr) noexcept
-    -> decltype(f(P{}, Array4<T>{}))
+auto call_f (F const& f, P const& p, Array4<T> const& fabarr,
+             GpuArray<Real,AMREX_SPACEDIM> const& plo,
+             GpuArray<Real,AMREX_SPACEDIM> const& dxi) noexcept
+    -> decltype(f(p, fabarr, plo, dxi))
+{
+    return f(p, fabarr, plo, dxi);
+}
+
+template <typename F, typename P, typename T>
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+auto call_f (F const& f, P const& p, Array4<T> const& fabarr,
+             GpuArray<Real,AMREX_SPACEDIM> const&,
+             GpuArray<Real,AMREX_SPACEDIM> const&) noexcept
+    -> decltype(f(p, fabarr))
 {
     return f(p, fabarr);
 }
 
 template <typename F, typename P, typename T>
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-auto call_f (F const& f, P& p, Array4<const T> const& fabarr) noexcept
+auto call_f (F const& f, P& p, Array4<const T> const& fabarr,
+             GpuArray<Real,AMREX_SPACEDIM> const& plo,
+             GpuArray<Real,AMREX_SPACEDIM> const& dxi) noexcept
+    -> decltype(f(p, fabarr, plo, dxi))
+{
+    return f(p, fabarr, plo, dxi);
+}
+
+template <typename F, typename P, typename T>
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+auto call_f (F const& f, P& p, Array4<const T> const& fabarr,
+             GpuArray<Real,AMREX_SPACEDIM> const& plo,
+             GpuArray<Real,AMREX_SPACEDIM> const& dxi) noexcept
     -> decltype(f(p, fabarr))
 {
     return f(p, fabarr);

--- a/Src/Particle/AMReX_ParticleUtil.H
+++ b/Src/Particle/AMReX_ParticleUtil.H
@@ -53,6 +53,22 @@ auto call_f (F const& f, SrcData const& src, N i, amrex::RandomEngine const&) no
     return f(src,i);
 }
 
+template <typename F, typename P, typename T>
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+auto call_f (F const& f, P const& p, Array4<T> const& fabarr) noexcept
+    -> decltype(f(P{}, Array4<T>{}))
+{
+    return f(p, fabarr);
+}
+
+template <typename F, typename P, typename T>
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+auto call_f (F const& f, P& p, Array4<const T> const& fabarr) noexcept
+    -> decltype(f(p, fabarr))
+{
+    return f(p, fabarr);
+}
+
 }
 
 /**

--- a/Src/Particle/AMReX_ParticleUtil.H
+++ b/Src/Particle/AMReX_ParticleUtil.H
@@ -86,8 +86,8 @@ auto call_f (F const& f, P& p, Array4<const T> const& fabarr,
 template <typename F, typename P, typename T>
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 auto call_f (F const& f, P& p, Array4<const T> const& fabarr,
-             GpuArray<Real,AMREX_SPACEDIM> const& plo,
-             GpuArray<Real,AMREX_SPACEDIM> const& dxi) noexcept
+             GpuArray<Real,AMREX_SPACEDIM> const&,
+             GpuArray<Real,AMREX_SPACEDIM> const&) noexcept
     -> decltype(f(p, fabarr))
 {
     return f(p, fabarr);

--- a/Tests/Particles/ParticleMesh/main.cpp
+++ b/Tests/Particles/ParticleMesh/main.cpp
@@ -18,7 +18,7 @@ struct TestParams {
   bool verbose;
 };
 
-void testParticleMesh(TestParams& parms)
+void testParticleMesh (TestParams& parms)
 {
 
   RealBox real_box;

--- a/Tests/Particles/ParticleMeshMultiLevel/CMakeLists.txt
+++ b/Tests/Particles/ParticleMeshMultiLevel/CMakeLists.txt
@@ -1,0 +1,7 @@
+set(_sources     main.cpp)
+set(_input_files inputs  )
+
+setup_test(_sources _input_files)
+
+unset(_sources)
+unset(_input_files)

--- a/Tests/Particles/ParticleMeshMultiLevel/GNUmakefile
+++ b/Tests/Particles/ParticleMeshMultiLevel/GNUmakefile
@@ -1,0 +1,30 @@
+AMREX_HOME = ../../../
+
+DEBUG	= TRUE
+DEBUG	= FALSE
+
+DIM	= 3
+
+COMP    = gcc
+
+TINY_PROFILE = TRUE
+USE_PARTICLES = TRUE
+
+PRECISION = DOUBLE
+
+USE_MPI   = TRUE
+USE_OMP   = FALSE
+
+###################################################
+
+EBASE     = main
+
+include $(AMREX_HOME)/Tools/GNUMake/Make.defs
+
+include ./Make.package
+include $(AMREX_HOME)/Src/Base/Make.package
+include $(AMREX_HOME)/Src/Boundary/Make.package
+include $(AMREX_HOME)/Src/Particle/Make.package
+include $(AMREX_HOME)/Src/AmrCore/Make.package
+
+include $(AMREX_HOME)/Tools/GNUMake/Make.rules

--- a/Tests/Particles/ParticleMeshMultiLevel/Make.package
+++ b/Tests/Particles/ParticleMeshMultiLevel/Make.package
@@ -1,0 +1,2 @@
+CEXE_sources += main.cpp
+

--- a/Tests/Particles/ParticleMeshMultiLevel/inputs
+++ b/Tests/Particles/ParticleMeshMultiLevel/inputs
@@ -1,0 +1,26 @@
+
+# Domain size
+
+#nx = 32 # number of grid points along the x axis
+#ny = 32 # number of grid points along the y axis
+#nz = 32 # number of grid points along the z axis
+
+#nx = 64 # number of grid points along the x axis
+#ny = 64 # number of grid points along the y axis
+#nz = 64 # number of grid points along the z axis
+
+nx = 128 # number of grid points along the x axis
+ny = 128 # number of grid points along the y axis
+nz = 128 # number of grid points along the z axis
+
+# Maximum allowable size of each subdomain in the problem domain;
+#    this is used to decompose the domain for parallel calculations.
+max_grid_size = 32
+
+# Number of particles per cell
+nppc = 10
+
+# Verbosity
+verbose = true   # set to true to get more verbosity
+
+nlevs=2

--- a/Tests/Particles/ParticleMeshMultiLevel/main.cpp
+++ b/Tests/Particles/ParticleMeshMultiLevel/main.cpp
@@ -1,0 +1,171 @@
+#include <iostream>
+
+#include <AMReX.H>
+#include <AMReX_MultiFab.H>
+#include <AMReX_MultiFabUtil.H>
+#include "AMReX_Particles.H"
+#include "AMReX_PlotFileUtil.H"
+#include <AMReX_AmrParticles.H>
+
+using namespace amrex;
+
+struct TestParams {
+    int nx;
+    int ny;
+    int nz;
+    int nlevs;
+    int max_grid_size;
+    int nppc;
+    bool verbose;
+};
+
+void testParticleMesh (TestParams& parms)
+{
+    Vector<IntVect> rr(parms.nlevs-1);
+    for (int lev = 1; lev < parms.nlevs; lev++)
+        rr[lev-1] = IntVect(AMREX_D_DECL(2,2,2));
+
+    RealBox real_box;
+    for (int n = 0; n < BL_SPACEDIM; n++) {
+        real_box.setLo(n, 0.0);
+        real_box.setHi(n, 1.0);
+    }
+
+    IntVect domain_lo(AMREX_D_DECL(0, 0, 0));
+    IntVect domain_hi(AMREX_D_DECL(parms.nx - 1, parms.ny - 1, parms.nz-1));
+    const Box base_domain(domain_lo, domain_hi);
+
+    // This sets the boundary conditions to be doubly or triply periodic
+    int is_per[BL_SPACEDIM];
+    for (int i = 0; i < BL_SPACEDIM; i++)
+        is_per[i] = 1;
+
+    Vector<Geometry> geom(parms.nlevs);
+    geom[0].define(base_domain, &real_box, CoordSys::cartesian, is_per);
+    for (int lev = 1; lev < parms.nlevs; lev++) {
+        geom[lev].define(amrex::refine(geom[lev-1].Domain(), rr[lev-1]),
+                         &real_box, CoordSys::cartesian, is_per);
+    }
+
+    Vector<BoxArray> ba(parms.nlevs);
+    Vector<DistributionMapping> dm(parms.nlevs);
+
+    Box domain = base_domain;
+    IntVect size = IntVect(AMREX_D_DECL(parms.nx, parms.ny, parms.nz));
+    for (int lev = 0; lev < parms.nlevs; ++lev)
+    {
+        ba[lev].define(domain);
+        ba[lev].maxSize(parms.max_grid_size);
+        dm[lev].define(ba[lev]);
+        domain.grow(-size/4);   // fine level cover the middle of the coarse domain
+        domain.refine(2);
+    }
+
+    Vector<MultiFab> density(parms.nlevs);
+    for (int lev = 0; lev < parms.nlevs; lev++) {
+        density[lev].define(ba[lev], dm[lev], 1, 1);
+        density[lev].setVal(0.0);
+    }
+
+    typedef ParticleContainer<1> MyParticleContainer;
+    MyParticleContainer myPC(geom, dm, ba, rr);
+    myPC.SetVerbose(false);
+
+    int num_particles = parms.nppc * parms.nx * parms.ny * parms.nz;
+    amrex::Print() << "Total number of particles    : " << num_particles << '\n' << '\n';
+
+    bool serialize = true;
+    int iseed = 451;
+    Real mass = 10.0;
+
+    MyParticleContainer::ParticleInitData pdata = {{mass}, {}, {}, {}};
+    myPC.InitRandom(num_particles, iseed, pdata, serialize);
+
+    amrex::ParticleToMesh(myPC, GetVecOfPtrs(density), 0, parms.nlevs-1,
+        [=] AMREX_GPU_DEVICE (const MyParticleContainer::ParticleType& p,
+                              amrex::Array4<amrex::Real> const& rho,
+                              amrex::GpuArray<amrex::Real,AMREX_SPACEDIM> const& plo,
+                              amrex::GpuArray<amrex::Real,AMREX_SPACEDIM> const& dxi) noexcept
+        {
+          amrex::Real lx = (p.pos(0) - plo[0]) * dxi[0] + 0.5;
+          amrex::Real ly = (p.pos(1) - plo[1]) * dxi[1] + 0.5;
+          amrex::Real lz = (p.pos(2) - plo[2]) * dxi[2] + 0.5;
+
+          int i = static_cast<int>(amrex::Math::floor(lx));
+          int j = static_cast<int>(amrex::Math::floor(ly));
+          int k = static_cast<int>(amrex::Math::floor(lz));
+
+          amrex::Real xint = lx - i;
+          amrex::Real yint = ly - j;
+          amrex::Real zint = lz - k;
+
+          amrex::Real sx[] = {1.-xint, xint};
+          amrex::Real sy[] = {1.-yint, yint};
+          amrex::Real sz[] = {1.-zint, zint};
+
+          for (int kk = 0; kk <= 1; ++kk) {
+              for (int jj = 0; jj <= 1; ++jj) {
+                  for (int ii = 0; ii <= 1; ++ii) {
+                      amrex::Gpu::Atomic::AddNoRet(&rho(i+ii-1, j+jj-1, k+kk-1, 0),
+                                                   sx[ii]*sy[jj]*sz[kk]*p.rdata(0));
+                  }
+              }
+          }
+      });
+
+    Vector<std::string> varnames;
+    varnames.push_back("density");
+
+    Vector<std::string> particle_varnames;
+    particle_varnames.push_back("mass");
+
+    Vector<int> level_steps;
+    level_steps.push_back(0);
+    level_steps.push_back(0);
+
+    int output_levs = parms.nlevs;
+
+    Vector<const MultiFab*> outputMF(output_levs);
+    Vector<IntVect> outputRR(output_levs);
+    for (int lev = 0; lev < output_levs; ++lev) {
+        outputMF[lev] = &density[lev];
+        outputRR[lev] = IntVect(AMREX_D_DECL(2, 2, 2));
+    }
+
+    WriteMultiLevelPlotfile("plt00000", output_levs, outputMF,
+                            varnames, geom, 0.0, level_steps, outputRR);
+    myPC.Checkpoint("plt00000", "particle0", true, particle_varnames);
+}
+
+int main(int argc, char* argv[])
+{
+  amrex::Initialize(argc,argv);
+
+  ParmParse pp;
+
+  TestParams parms;
+
+  pp.get("nx", parms.nx);
+  pp.get("ny", parms.ny);
+  pp.get("nz", parms.nz);
+  pp.get("max_grid_size", parms.max_grid_size);
+  pp.get("nppc", parms.nppc);
+  pp.get("nlevs", parms.nlevs);
+  if (parms.nppc < 1 && ParallelDescriptor::IOProcessor())
+    amrex::Abort("Must specify at least one particle per cell");
+
+  parms.verbose = false;
+  pp.query("verbose", parms.verbose);
+
+  if (parms.verbose && ParallelDescriptor::IOProcessor()) {
+    std::cout << std::endl;
+    std::cout << "Number of particles per cell : ";
+    std::cout << parms.nppc  << std::endl;
+    std::cout << "Size of domain               : ";
+    std::cout << parms.nx << " " << parms.ny << " " << parms.nz << std::endl;
+  }
+
+  testParticleMesh(parms);
+
+  amrex::Finalize();
+}


### PR DESCRIPTION
This uses the same algorithm as the AssignDensity method in `AmrCore/AMReX_AmrParticles.H` to handle the coarse / fine boundaries. However, it allows a user-specified lambda function to define the interpolation operation, as in the single-level `ParticleToMesh` routine.   

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
