### PR TITLE
Skip temporary in ParticleToMesh when it is not needed.

### DIFF
--- a/Src/AmrCore/AMReX_AmrParticles.H
+++ b/Src/AmrCore/AMReX_AmrParticles.H
@@ -173,6 +173,10 @@ ParticleToMesh (PC const& pc, const Vector<MultiFab*>& mf,
         return;
     }
 
+    int ngrow = amrex::max(AMREX_D_DECL(mf[0]->nGrow(0),
+                                        mf[0]->nGrow(1),
+                                        mf[0]->nGrow(2)), 2);
+
     if (zero_out_input)
     {
         for (int lev = lev_min; lev <= lev_max; ++lev)
@@ -186,11 +190,11 @@ ParticleToMesh (PC const& pc, const Vector<MultiFab*>& mf,
     for (int lev = lev_min; lev <= lev_max; ++lev)
     {
         mf_part[lev].define(pc.ParticleBoxArray(lev),
-                           pc.ParticleDistributionMap(lev),
-                           mf[lev]->nComp(), mf[lev]->nGrowVect());
+                            pc.ParticleDistributionMap(lev),
+                            mf[lev]->nComp(), ngrow);
         mf_tmp[lev].define( pc.ParticleBoxArray(lev),
                             pc.ParticleDistributionMap(lev),
-                            mf[lev]->nComp(), mf[lev]->nGrowVect());
+                            mf[lev]->nComp(), 0);
         mf_part[lev].setVal(0.0);
         mf_tmp[lev].setVal( 0.0);
     }

--- a/Src/Particle/AMReX_ParticleMesh.H
+++ b/Src/Particle/AMReX_ParticleMesh.H
@@ -19,7 +19,7 @@ ParticleToMesh (PC const& pc, MF& mf, int lev, F&& f, bool zero_out_input=true)
 
     MultiFab* mf_pointer;
 
-    if (pc.OnSameGrids(lev, mf) and zero_out_input)
+    if (pc.OnSameGrids(lev, mf) && zero_out_input)
     {
         mf_pointer = &mf;
     } else {

--- a/Src/Particle/AMReX_ParticleMesh.H
+++ b/Src/Particle/AMReX_ParticleMesh.H
@@ -17,10 +17,17 @@ ParticleToMesh (PC const& pc, MF& mf, int lev, F&& f, bool zero_out_input=true)
 
     if (zero_out_input) { mf.setVal(0.0); }
 
-    MultiFab mf_tmp(pc.ParticleBoxArray(lev),
-                    pc.ParticleDistributionMap(lev),
-                    mf.nComp(), mf.nGrowVect());
-    mf_tmp.setVal(0.0);
+    MultiFab* mf_pointer;
+
+    if (pc.OnSameGrids(lev, mf) and zero_out_input)
+    {
+        mf_pointer = &mf;
+    } else {
+        mf_pointer = new MultiFab(pc.ParticleBoxArray(lev),
+                                  pc.ParticleDistributionMap(lev),
+                                  mf.nComp(), mf.nGrowVect());
+        mf_pointer->setVal(0.0);
+    }
 
     const auto plo = pc.Geom(lev).ProbLoArray();
     const auto dxi = pc.Geom(lev).InvCellSizeArray();
@@ -36,7 +43,7 @@ ParticleToMesh (PC const& pc, MF& mf, int lev, F&& f, bool zero_out_input=true)
             const auto& aos = tile.GetArrayOfStructs();
             const auto pstruct = aos().dataPtr();
 
-            FArrayBox& fab = mf_tmp[pti];
+            FArrayBox& fab = (*mf_pointer)[pti];
             auto fabarr = fab.array();
 
             AMREX_FOR_1D( np, i,
@@ -60,11 +67,11 @@ ParticleToMesh (PC const& pc, MF& mf, int lev, F&& f, bool zero_out_input=true)
                 const auto& aos = tile.GetArrayOfStructs();
                 const auto pstruct = aos().dataPtr();
 
-                FArrayBox& fab = mf_tmp[pti];
+                FArrayBox& fab = (*mf_pointer)[pti];
 
                 Box tile_box = pti.tilebox();
-                tile_box.grow(mf_tmp.nGrowVect());
-                local_fab.resize(tile_box,mf_tmp.nComp());
+                tile_box.grow(mf_pointer->nGrowVect());
+                local_fab.resize(tile_box,mf_pointer->nComp());
                 local_fab.setVal<RunOn::Host>(0.0);
                 auto fabarr = local_fab.array();
 
@@ -73,12 +80,20 @@ ParticleToMesh (PC const& pc, MF& mf, int lev, F&& f, bool zero_out_input=true)
                     particle_detail::call_f(f, pstruct[i], fabarr, plo, dxi);
                 });
 
-                fab.atomicAdd<RunOn::Host>(local_fab, tile_box, tile_box, 0, 0, mf_tmp.nComp());
+                fab.atomicAdd<RunOn::Host>(local_fab, tile_box, tile_box,
+                                           0, 0, mf_pointer->nComp());
             }
         }
     }
 
-    mf.ParallelAdd(mf_tmp, 0, 0, mf_tmp.nComp(), mf_tmp.nGrowVect(), IntVect(0), pc.Geom(lev).periodicity());
+    if (mf_pointer != &mf)
+    {
+        mf.ParallelAdd(*mf_pointer, 0, 0, mf_pointer->nComp(),
+                       mf_pointer->nGrowVect(), IntVect(0), pc.Geom(lev).periodicity());
+        delete mf_pointer;
+    } else {
+        mf_pointer->SumBoundary(pc.Geom(lev).periodicity());
+    }
 }
 
 template <class PC, class MF, class F, std::enable_if_t<IsParticleContainer<PC>::value, int> foo = 0>


### PR DESCRIPTION
Also fix a bug where not enough grow cells are used in the multilevel version.

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
