### PR TITLE
Fix the return of MLPoisson::makeNLinOp

### DIFF
--- a/Src/LinearSolvers/MLMG/AMReX_MLPoisson.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLPoisson.cpp
@@ -593,10 +593,11 @@ MLPoisson::makeNLinOp (int grid_size) const
     LPInfo minfo{};
     minfo.has_metric_term = info.has_metric_term;
 
-    auto r = std::make_unique<MLALaplacian>(Vector<Geometry>{geom},
-                                            Vector<BoxArray>{ba},
-                                            Vector<DistributionMapping>{dm}, minfo);
-    MLALaplacian* nop = r.get();
+    std::unique_ptr<MLLinOp> r{new MLALaplacian({geom}, {ba}, {dm}, minfo)};
+    auto nop = dynamic_cast<MLALaplacian*>(r.get());
+    if (!nop) {
+        return nullptr;
+    }
 
     nop->m_parent = this;
 
@@ -633,9 +634,7 @@ MLPoisson::makeNLinOp (int grid_size) const
 
     nop->setACoeffs(0, alpha);
 
-    // Some versions of gcc require std::move, because r does not match the
-    // return type.
-    return std::move(r);
+    return r;
 }
 
 void

--- a/Src/LinearSolvers/MLMG/AMReX_MLPoisson.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLPoisson.cpp
@@ -633,7 +633,9 @@ MLPoisson::makeNLinOp (int grid_size) const
 
     nop->setACoeffs(0, alpha);
 
-    return r;
+    // Some versions of gcc require std::move, because r does not match the
+    // return type.
+    return std::move(r);
 }
 
 void


### PR DESCRIPTION
The return type of MLPoisson::makeNLinOp is std::unique_ptr<MLLinOp>,
whereas the return statement is `return r;`, where r is
std::unique_ptr<MLPoisson>.  Some compilers do not like this unless we do
`return std::move(r)`.

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
