### PR TITLE
Allow user to opt out of renaming MTMPI suffix

### DIFF
--- a/Tools/GNUMake/Make.defs
+++ b/Tools/GNUMake/Make.defs
@@ -200,6 +200,7 @@ endif
 
 ifdef MPI_THREAD_MULTIPLE
   MPI_THREAD_MULTIPLE := $(strip $(MPI_THREAD_MULTIPLE))
+  MPI_THREAD_MULTIPLE_UPDATE_SUFFIX ?= TRUE
   ifeq ($(MPI_THREAD_MULTIPLE),TRUE)
     USE_MPI := TRUE
   endif
@@ -588,7 +589,11 @@ ifeq ($(USE_MPI),TRUE)
     CPPFLAGS += -DBL_USE_MPI -DAMREX_USE_MPI
 
     ifeq ($(MPI_THREAD_MULTIPLE),TRUE)
-        MPISuffix := .MTMPI
+        ifeq ($(MPI_THREAD_MULTIPLE_UPDATE_SUFFIX),TRUE)
+            MPISuffix := .MTMPI
+        else
+            MPISuffix := .MPI
+        endif
         CPPFLAGS += -DAMREX_MPI_THREAD_MULTIPLE
     else
         MPISuffix := .MPI


### PR DESCRIPTION
## Summary

If MPI_THREAD_MULTIPLE is going to be on by default in an application, might as well not need to rename the suffix, so this gives the application the ability to just keep the suffix MPI.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
