### PR TITLE
Reimplementation of ReduceOps

### DIFF
--- a/Src/AmrCore/AMReX_TagBox.cpp
+++ b/Src/AmrCore/AMReX_TagBox.cpp
@@ -759,7 +759,7 @@ TagBoxArray::hasTags (Box const& a_bx) const
             }
         }
 
-        ReduceTuple hv = reduce_data.value();
+        ReduceTuple hv = reduce_data.value(reduce_op);
         has_tags = static_cast<bool>(amrex::get<0>(hv));
     } else
 #endif

--- a/Src/Base/AMReX_BaseFab.H
+++ b/Src/Base/AMReX_BaseFab.H
@@ -2293,7 +2293,7 @@ BaseFab<T>::norminfmask (const Box& subbox, const BaseFab<int>& mask,
             }
             return {t};
         });
-        ReduceTuple hv = reduce_data.value();
+        ReduceTuple hv = reduce_data.value(reduce_op);
         r = amrex::get<0>(hv);
     } else
 #endif
@@ -2342,7 +2342,7 @@ BaseFab<T>::norm (const Box& subbox, int p, int comp, int numcomp) const noexcep
                 }
                 return {t};
             });
-            ReduceTuple hv = reduce_data.value();
+            ReduceTuple hv = reduce_data.value(reduce_op);
             nrm = amrex::get<0>(hv);
         } else if (p == 1) {
             ReduceOps<ReduceOpSum> reduce_op;
@@ -2357,7 +2357,7 @@ BaseFab<T>::norm (const Box& subbox, int p, int comp, int numcomp) const noexcep
                 }
                 return {t};
             });
-            ReduceTuple hv = reduce_data.value();
+            ReduceTuple hv = reduce_data.value(reduce_op);
             nrm = amrex::get<0>(hv);
         } else if (p == 2) {
             ReduceOps<ReduceOpSum> reduce_op;
@@ -2372,7 +2372,7 @@ BaseFab<T>::norm (const Box& subbox, int p, int comp, int numcomp) const noexcep
                 }
                 return {t};
             });
-            ReduceTuple hv = reduce_data.value();
+            ReduceTuple hv = reduce_data.value(reduce_op);
             nrm = amrex::get<0>(hv);
         } else {
             amrex::Error("BaseFab<T>::norm: wrong p");
@@ -2428,7 +2428,7 @@ BaseFab<T>::min (const Box& subbox, int comp) const noexcept
         {
             return { a(i,j,k) };
         });
-        ReduceTuple hv = reduce_data.value();
+        ReduceTuple hv = reduce_data.value(reduce_op);
         return amrex::get<0>(hv);
     } else
 #endif
@@ -2466,7 +2466,7 @@ BaseFab<T>::max (const Box& subbox, int comp) const noexcept
         {
             return { a(i,j,k) };
         });
-        ReduceTuple hv = reduce_data.value();
+        ReduceTuple hv = reduce_data.value(reduce_op);
         return amrex::get<0>(hv);
     } else
 #endif
@@ -2505,7 +2505,7 @@ BaseFab<T>::minmax (const Box& subbox, int comp) const noexcept
             auto const x = a(i,j,k);
             return { x, x };
         });
-        ReduceTuple hv = reduce_data.value();
+        ReduceTuple hv = reduce_data.value(reduce_op);
         return std::make_pair(amrex::get<0>(hv), amrex::get<1>(hv));
     } else
 #endif
@@ -2546,7 +2546,7 @@ BaseFab<T>::maxabs (const Box& subbox, int comp) const noexcept
         {
             return { amrex::Math::abs(a(i,j,k)) };
         });
-        ReduceTuple hv = reduce_data.value();
+        ReduceTuple hv = reduce_data.value(reduce_op);
         return amrex::get<0>(hv);
     } else
 #endif
@@ -2679,7 +2679,7 @@ BaseFab<T>::maskLT (BaseFab<int>& mask, T const& val, int comp) const noexcept
             }
             return {t};
         });
-        ReduceTuple hv = reduce_data.value();
+        ReduceTuple hv = reduce_data.value(reduce_op);
         cnt = amrex::get<0>(hv);
     } else
 #endif
@@ -2725,7 +2725,7 @@ BaseFab<T>::maskLE (BaseFab<int>& mask, T const& val, int comp) const noexcept
             }
             return {t};
         });
-        ReduceTuple hv = reduce_data.value();
+        ReduceTuple hv = reduce_data.value(reduce_op);
         cnt = amrex::get<0>(hv);
     } else
 #endif
@@ -2771,7 +2771,7 @@ BaseFab<T>::maskEQ (BaseFab<int>& mask, T const& val, int comp) const noexcept
             }
             return {t};
         });
-        ReduceTuple hv = reduce_data.value();
+        ReduceTuple hv = reduce_data.value(reduce_op);
         cnt = amrex::get<0>(hv);
     } else
 #endif
@@ -2817,7 +2817,7 @@ BaseFab<T>::maskGT (BaseFab<int>& mask, T const& val, int comp) const noexcept
             }
             return {t};
         });
-        ReduceTuple hv = reduce_data.value();
+        ReduceTuple hv = reduce_data.value(reduce_op);
         cnt = amrex::get<0>(hv);
     } else
 #endif
@@ -2863,7 +2863,7 @@ BaseFab<T>::maskGE (BaseFab<int>& mask, T const& val, int comp) const noexcept
             }
             return {t};
         });
-        ReduceTuple hv = reduce_data.value();
+        ReduceTuple hv = reduce_data.value(reduce_op);
         cnt = amrex::get<0>(hv);
     } else
 #endif
@@ -3054,7 +3054,7 @@ BaseFab<T>::dot (const Box& xbx, int xcomp,
             }
             return {t};
         });
-        ReduceTuple hv = reduce_data.value();
+        ReduceTuple hv = reduce_data.value(reduce_op);
         r = amrex::get<0>(hv);
     } else
 #endif
@@ -3107,7 +3107,7 @@ BaseFab<T>::dotmask (const BaseFab<int>& mask, const Box& xbx, int xcomp,
             }
             return {t};
         });
-        ReduceTuple hv = reduce_data.value();
+        ReduceTuple hv = reduce_data.value(reduce_op);
         r = amrex::get<0>(hv);
     } else
 #endif
@@ -4022,7 +4022,7 @@ BaseFab<T>::sum (const Box& bx, DestComp dcomp, NumComps ncomp) const noexcept
             }
             return { t };
         });
-        ReduceTuple hv = reduce_data.value();
+        ReduceTuple hv = reduce_data.value(reduce_op);
         r = amrex::get<0>(hv);
     } else
 #endif
@@ -4062,7 +4062,7 @@ BaseFab<T>::dot (const BaseFab<T>& src, const Box& bx, SrcComp scomp, DestComp d
             }
             return { t };
         });
-        ReduceTuple hv = reduce_data.value();
+        ReduceTuple hv = reduce_data.value(reduce_op);
         r = amrex::get<0>(hv);
     } else
 #endif
@@ -4108,7 +4108,7 @@ BaseFab<T>::dot (const Box& bx, DestComp dcomp, NumComps ncomp) const noexcept
             }
             return { t };
         });
-        ReduceTuple hv = reduce_data.value();
+        ReduceTuple hv = reduce_data.value(reduce_op);
         r = amrex::get<0>(hv);
     } else
 #endif
@@ -4152,7 +4152,7 @@ BaseFab<T>::dotmask (const BaseFab<T>& src, const Box& bx, const BaseFab<int>& m
             }
             return { t };
         });
-        ReduceTuple hv = reduce_data.value();
+        ReduceTuple hv = reduce_data.value(reduce_op);
         r = amrex::get<0>(hv);
     } else
 #endif

--- a/Src/Base/AMReX_FArrayBox.H
+++ b/Src/Base/AMReX_FArrayBox.H
@@ -519,7 +519,7 @@ FArrayBox::contains_nan () const noexcept
         {
             return { static_cast<int>(amrex::isnan(dp[i])) };
         });
-        ReduceTuple hv = reduce_data.value();
+        ReduceTuple hv = reduce_data.value(reduce_op);
         return amrex::get<0>(hv);
     } else
 #endif
@@ -559,7 +559,7 @@ FArrayBox::contains_nan (const Box& bx, int scomp, int ncomp) const noexcept
             }
             return { static_cast<int>(t) };
         });
-        ReduceTuple hv = reduce_data.value();
+        ReduceTuple hv = reduce_data.value(reduce_op);
         return amrex::get<0>(hv);
     } else
 #endif
@@ -663,7 +663,7 @@ FArrayBox::contains_inf () const noexcept
         {
             return { static_cast<int>(amrex::isinf(dp[i])) };
         });
-        ReduceTuple hv = reduce_data.value();
+        ReduceTuple hv = reduce_data.value(reduce_op);
         return amrex::get<0>(hv);
     } else
 #endif
@@ -703,7 +703,7 @@ FArrayBox::contains_inf (const Box& bx, int scomp, int ncomp) const noexcept
             }
             return { static_cast<int>(t) };
         });
-        ReduceTuple hv = reduce_data.value();
+        ReduceTuple hv = reduce_data.value(reduce_op);
         return amrex::get<0>(hv);
     } else
 #endif

--- a/Src/Base/AMReX_FabArrayUtility.H
+++ b/Src/Base/AMReX_FabArrayUtility.H
@@ -65,7 +65,7 @@ ReduceSum_device (FabArray<FAB> const& fa, IntVect const& nghost, F&& f)
             });
         }
 
-        ReduceTuple hv = reduce_data.value();
+        ReduceTuple hv = reduce_data.value(reduce_op);
         sm = amrex::get<0>(hv);
     }
 
@@ -173,7 +173,7 @@ ReduceSum_device (FabArray<FAB1> const& fa1, FabArray<FAB2> const& fa2,
             });
         }
 
-        ReduceTuple hv = reduce_data.value();
+        ReduceTuple hv = reduce_data.value(reduce_op);
         sm = amrex::get<0>(hv);
     }
 
@@ -286,7 +286,7 @@ ReduceSum_device (FabArray<FAB1> const& fa1, FabArray<FAB2> const& fa2,
             });
         }
 
-        ReduceTuple hv = reduce_data.value();
+        ReduceTuple hv = reduce_data.value(reduce_op);
         sm = amrex::get<0>(hv);
     }
 
@@ -393,7 +393,7 @@ ReduceMin_device (FabArray<FAB> const& fa, IntVect const& nghost, F&& f)
             });
         }
 
-        ReduceTuple hv = reduce_data.value();
+        ReduceTuple hv = reduce_data.value(reduce_op);
         r = amrex::get<0>(hv);
     }
 
@@ -501,7 +501,7 @@ ReduceMin_device (FabArray<FAB1> const& fa1, FabArray<FAB2> const& fa2,
             });
         }
 
-        ReduceTuple hv = reduce_data.value();
+        ReduceTuple hv = reduce_data.value(reduce_op);
         r = amrex::get<0>(hv);
     }
 
@@ -616,7 +616,7 @@ ReduceMin_device (FabArray<FAB1> const& fa1, FabArray<FAB2> const& fa2,
             });
         }
 
-        ReduceTuple hv = reduce_data.value();
+        ReduceTuple hv = reduce_data.value(reduce_op);
         r = amrex::get<0>(hv);
     }
 
@@ -724,7 +724,7 @@ ReduceMax_device (FabArray<FAB> const& fa, IntVect const& nghost, F&& f)
             });
         }
 
-        ReduceTuple hv = reduce_data.value();
+        ReduceTuple hv = reduce_data.value(reduce_op);
         r = amrex::get<0>(hv);
     }
 
@@ -832,7 +832,7 @@ ReduceMax_device (FabArray<FAB1> const& fa1, FabArray<FAB2> const& fa2,
             });
         }
 
-        ReduceTuple hv = reduce_data.value();
+        ReduceTuple hv = reduce_data.value(reduce_op);
         r = amrex::get<0>(hv);
     }
 
@@ -947,7 +947,7 @@ ReduceMax_device (FabArray<FAB1> const& fa1, FabArray<FAB2> const& fa2,
             });
         }
 
-        ReduceTuple hv = reduce_data.value();
+        ReduceTuple hv = reduce_data.value(reduce_op);
         r = amrex::get<0>(hv);
     }
 
@@ -1052,7 +1052,7 @@ ReduceLogicalAnd_device (FabArray<FAB> const& fa, IntVect const& nghost, F&& f)
             });
         }
 
-        ReduceTuple hv = reduce_data.value();
+        ReduceTuple hv = reduce_data.value(reduce_op);
         r = amrex::get<0>(hv);
     }
 
@@ -1158,7 +1158,7 @@ ReduceLogicalAnd_device (FabArray<FAB1> const& fa1, FabArray<FAB2> const& fa2,
             });
         }
 
-        ReduceTuple hv = reduce_data.value();
+        ReduceTuple hv = reduce_data.value(reduce_op);
         r = amrex::get<0>(hv);
     }
 
@@ -1263,7 +1263,7 @@ ReduceLogicalOr_device (FabArray<FAB> const& fa, IntVect const& nghost, F&& f)
             });
         }
 
-        ReduceTuple hv = reduce_data.value();
+        ReduceTuple hv = reduce_data.value(reduce_op);
         r = amrex::get<0>(hv);
     }
 
@@ -1369,7 +1369,7 @@ ReduceLogicalOr_device (FabArray<FAB1> const& fa1, FabArray<FAB2> const& fa2,
             });
         }
 
-        ReduceTuple hv = reduce_data.value();
+        ReduceTuple hv = reduce_data.value(reduce_op);
         r = amrex::get<0>(hv);
     }
 

--- a/Src/Base/AMReX_GpuDevice.H
+++ b/Src/Base/AMReX_GpuDevice.H
@@ -10,9 +10,12 @@
 #include <AMReX_OpenMP.H>
 #include <AMReX_Vector.H>
 
+#include <algorithm>
+#include <array>
 #include <cstdlib>
 #include <memory>
-#include <array>
+
+#define AMREX_GPU_MAX_STREAMS 8
 
 namespace amrex {
 
@@ -65,10 +68,14 @@ public:
 #endif
 
     static int numGpuStreams () noexcept { return max_gpu_streams; }
+
     static void setStreamIndex (const int idx) noexcept;
     static void resetStreamIndex () noexcept { setStreamIndex(-1); }
 
 #ifdef AMREX_USE_GPU
+    // For Index, the null stream is -1, and the other streams are 0, 1, 2, ...
+    static int streamIndex (gpuStream_t s = gpuStream()) noexcept;
+
     static gpuStream_t setStream (gpuStream_t s) noexcept;
     static gpuStream_t resetStream () noexcept;
 #endif

--- a/Src/Base/AMReX_GpuDevice.cpp
+++ b/Src/Base/AMReX_GpuDevice.cpp
@@ -125,6 +125,7 @@ Device::Initialize ()
 
     ParmParse ppamrex("amrex");
     ppamrex.query("max_gpu_streams", max_gpu_streams);
+    max_gpu_streams = std::min(max_gpu_streams, AMREX_GPU_MAX_STREAMS);
 
     ParmParse pp("device");
 
@@ -550,6 +551,19 @@ Device::numDevicesUsed () noexcept
 {
     return num_devices_used;
 }
+
+#ifdef AMREX_USE_GPU
+int
+Device::streamIndex (gpuStream_t s) noexcept
+{
+    if (s == nullStream()) {
+        return -1;
+    } else {
+        auto it = std::find(std::begin(gpu_stream_pool), std::end(gpu_stream_pool), s);
+        return static_cast<int>(std::distance(std::begin(gpu_stream_pool), it));
+    }
+}
+#endif
 
 void
 Device::setStreamIndex (const int idx) noexcept

--- a/Src/Base/AMReX_GpuReduce.H
+++ b/Src/Base/AMReX_GpuReduce.H
@@ -13,8 +13,10 @@
 #define AMREX_USE_CUB 1
 #endif
 
-#ifdef AMREX_USE_CUB
+#if defined(AMREX_USE_CUB)
 #include <cub/cub.cuh>
+#elif defined(AMREX_USE_HIP)
+#include <rocprim/rocprim.hpp>
 #endif
 
 //
@@ -101,47 +103,85 @@ void blockReduce_partial (T* dest, T x, WARPREDUCE && warp_reduce, ATOMICOP && a
    }
 }
 
+// block-wide reduction for thread0
+template <typename T>
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE
+T blockReduceSum (T source, Gpu::Handler const& h) noexcept
+{
+    return Gpu::blockReduce<Gpu::Device::warp_size>
+        (source, Gpu::warpReduce<Gpu::Device::warp_size,T,amrex::Plus<T> >(), (T)0, h);
+}
+
 template <typename T>
 AMREX_GPU_DEVICE AMREX_FORCE_INLINE
 void deviceReduceSum_full (T * dest, T source, Gpu::Handler const& h) noexcept
 {
-    source = Gpu::blockReduce<Gpu::Device::warp_size>
-        (source, Gpu::warpReduce<Gpu::Device::warp_size,T,amrex::Plus<T> >(), (T)0, h);
-    if (h.item->get_local_id(0) == 0) { Gpu::Atomic::AddNoRet(dest, source); }
+    T aggregate = blockReduceSum(source, h);
+    if (h.item->get_local_id(0) == 0) { Gpu::Atomic::AddNoRet(dest, aggregate); }
+}
+
+// block-wide reduction for thread0
+template <typename T>
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE
+T blockReduceMin (T source, Gpu::Handler const& h) noexcept
+{
+    return Gpu::blockReduce<Gpu::Device::warp_size>
+        (source, Gpu::warpReduce<Gpu::Device::warp_size,T,amrex::Less<T> >(), source, h);
 }
 
 template <typename T>
 AMREX_GPU_DEVICE AMREX_FORCE_INLINE
 void deviceReduceMin_full (T * dest, T source, Gpu::Handler const& h) noexcept
 {
-    source = Gpu::blockReduce<Gpu::Device::warp_size>
-        (source, Gpu::warpReduce<Gpu::Device::warp_size,T,amrex::Less<T> >(), source, h);
-    if (h.item->get_local_id(0) == 0) { Gpu::Atomic::Min(dest, source); }
+    T aggregate = blockReduceMin(source, h);
+    if (h.item->get_local_id(0) == 0) { Gpu::Atomic::Min(dest, aggregate); }
+}
+
+// block-wide reduction for thread0
+template <typename T>
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE
+T blockReduceMax (T source, Gpu::Handler const& h) noexcept
+{
+    return Gpu::blockReduce<Gpu::Device::warp_size>
+        (source, Gpu::warpReduce<Gpu::Device::warp_size,T,amrex::Greater<T> >(), source, h);
 }
 
 template <typename T>
 AMREX_GPU_DEVICE AMREX_FORCE_INLINE
 void deviceReduceMax_full (T * dest, T source, Gpu::Handler const& h) noexcept
 {
-    source = Gpu::blockReduce<Gpu::Device::warp_size>
-        (source, Gpu::warpReduce<Gpu::Device::warp_size,T,amrex::Greater<T> >(), source, h);
-    if (h.item->get_local_id(0) == 0) { Gpu::Atomic::Max(dest, source); }
+    T aggregate = blockReduceMax(source, h);
+    if (h.item->get_local_id(0) == 0) { Gpu::Atomic::Max(dest, aggregate); }
+}
+
+// block-wide reduction for thread0
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE
+int blockReduceLogicalAnd (int source, Gpu::Handler const& h) noexcept
+{
+    return Gpu::blockReduce<Gpu::Device::warp_size>
+        (source, Gpu::warpReduce<Gpu::Device::warp_size,int,amrex::LogicalAnd<int> >(), 1, h);
 }
 
 AMREX_GPU_DEVICE AMREX_FORCE_INLINE
 void deviceReduceLogicalAnd_full (int * dest, int source, Gpu::Handler const& h) noexcept
 {
-    source = Gpu::blockReduce<Gpu::Device::warp_size>
-        (source, Gpu::warpReduce<Gpu::Device::warp_size,int,amrex::LogicalAnd<int> >(), 1, h);
-    if (h.item->get_local_id(0) == 0) { Gpu::Atomic::LogicalAnd(dest, source); }
+    int aggregate = blockReduceLogicalAnd(source, h);
+    if (h.item->get_local_id(0) == 0) { Gpu::Atomic::LogicalAnd(dest, aggregate); }
+}
+
+// block-wide reduction for thread0
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE
+int blockReduceLogicalOr (int source, Gpu::Handler const& h) noexcept
+{
+    return Gpu::blockReduce<Gpu::Device::warp_size>
+        (source, Gpu::warpReduce<Gpu::Device::warp_size,int,amrex::LogicalOr<int> >(), 0, h);
 }
 
 AMREX_GPU_DEVICE AMREX_FORCE_INLINE
 void deviceReduceLogicalOr_full (int * dest, int source, Gpu::Handler const& h) noexcept
 {
-    source = Gpu::blockReduce<Gpu::Device::warp_size>
-        (source, Gpu::warpReduce<Gpu::Device::warp_size,int,amrex::LogicalOr<int> >(), 0, h);
-    if (h.item->get_local_id(0) == 0) { Gpu::Atomic::LogicalOr(dest, source); }
+    int aggregate = blockReduceLogicalOr(source, h);
+    if (h.item->get_local_id(0) == 0) { Gpu::Atomic::LogicalOr(dest, aggregate); }
 }
 
 template <typename T>
@@ -259,65 +299,79 @@ void blockReduce_partial (T* dest, T x, WARPREDUCE && warp_reduce, ATOMICOP && a
     }
 }
 
-#if defined(AMREX_USE_CUB)
-template <int BLOCKDIMX, typename T>
+// Compute the block-wide reduction for thread0
+template <typename T>
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE
+T blockReduceSum (T source) noexcept
+{
+    return Gpu::blockReduce<Gpu::Device::warp_size>
+        (source, Gpu::warpReduce<Gpu::Device::warp_size,T,amrex::Plus<T> >(), (T)0);
+}
+
+template <typename T>
 AMREX_GPU_DEVICE AMREX_FORCE_INLINE
 void deviceReduceSum_full (T * dest, T source) noexcept
 {
-    typedef cub::BlockReduce<T,BLOCKDIMX> BlockReduce;
-    __shared__ typename BlockReduce::TempStorage temp_storage;
-    // __syncthreads() prior to writing to shared memory is necessary
-    // if this reduction call is occurring multiple times in a kernel,
-    // and since we don't know how many times the user is calling it,
-    // we do it always to be safe.
-    __syncthreads();
-    // Compute the block-wide reduction for thread0
-    T aggregate = BlockReduce(temp_storage).Sum(source);
+    T aggregate = blockReduceSum(source);
     if (threadIdx.x == 0) { Gpu::Atomic::AddNoRet(dest, aggregate); }
 }
-#endif
 
-template <typename T>
+// Compute the block-wide reduction for thread0
+template <int BLOCKDIMX, typename T>
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE
+T blockReduceSum (T source) noexcept
+{
+#if defined(AMREX_USE_CUB)
+    typedef cub::BlockReduce<T,BLOCKDIMX> BlockReduce;
+    __shared__ typename BlockReduce::TempStorage temp_storage;
+    // __syncthreads() prior to writing to shared memory is necessary
+    // if this reduction call is occurring multiple times in a kernel,
+    // and since we don't know how many times the user is calling it,
+    // we do it always to be safe.
+    __syncthreads();
+    return BlockReduce(temp_storage).Sum(source);
+#elif defined(AMREX_USE_HIP)
+    typedef rocprim::block_reduce<T,BLOCKDIMX> BlockReduce;
+    __shared__ typename BlockReduce::storage_type temp_storage;
+    __syncthreads();
+    BlockReduce().reduce(source, source, temp_storage, rocprim::plus<T>());
+    return source;
+#else
+    return blockReduceSum(source);
+#endif
+}
+
+template <int BLOCKDIMX, typename T>
 AMREX_GPU_DEVICE AMREX_FORCE_INLINE
 void deviceReduceSum_full (T * dest, T source) noexcept
 {
-    source = Gpu::blockReduce<Gpu::Device::warp_size>
-        (source, Gpu::warpReduce<Gpu::Device::warp_size,T,amrex::Plus<T> >(), (T)0);
-    if (threadIdx.x == 0) { Gpu::Atomic::AddNoRet(dest, source); }
+    T aggregate = blockReduceSum<BLOCKDIMX>(source);
+    if (threadIdx.x == 0) { Gpu::Atomic::AddNoRet(dest, aggregate); }
 }
 
-#if defined(AMREX_USE_CUB)
-template <int BLOCKDIMX, typename T>
+// Compute the block-wide reduction for thread0
+template <typename T>
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE
+T blockReduceMin (T source) noexcept
+{
+    return Gpu::blockReduce<Gpu::Device::warp_size>
+        (source, Gpu::warpReduce<Gpu::Device::warp_size,T,amrex::Less<T> >(), source);
+}
+
+template <typename T>
 AMREX_GPU_DEVICE AMREX_FORCE_INLINE
 void deviceReduceMin_full (T * dest, T source) noexcept
 {
-    typedef cub::BlockReduce<T,BLOCKDIMX> BlockReduce;
-    __shared__ typename BlockReduce::TempStorage temp_storage;
-    // __syncthreads() prior to writing to shared memory is necessary
-    // if this reduction call is occurring multiple times in a kernel,
-    // and since we don't know how many times the user is calling it,
-    // we do it always to be safe.
-    __syncthreads();
-    // Compute the block-wide reduction for thread0
-    T aggregate = BlockReduce(temp_storage).Reduce(source, cub::Min());
+    T aggregate = blockReduceMin(source);
     if (threadIdx.x == 0) { Gpu::Atomic::Min(dest, aggregate); }
 }
-#endif
 
-template <typename T>
-AMREX_GPU_DEVICE AMREX_FORCE_INLINE
-void deviceReduceMin_full (T * dest, T source) noexcept
-{
-    source = Gpu::blockReduce<Gpu::Device::warp_size>
-        (source, Gpu::warpReduce<Gpu::Device::warp_size,T,amrex::Less<T> >(), source);
-    if (threadIdx.x == 0) { Gpu::Atomic::Min(dest, source); }
-}
-
-#if defined(AMREX_USE_CUB)
+// Compute the block-wide reduction for thread0
 template <int BLOCKDIMX, typename T>
 AMREX_GPU_DEVICE AMREX_FORCE_INLINE
-void deviceReduceMax_full (T * dest, T source) noexcept
+T blockReduceMin (T source) noexcept
 {
+#if defined(AMREX_USE_CUB)
     typedef cub::BlockReduce<T,BLOCKDIMX> BlockReduce;
     __shared__ typename BlockReduce::TempStorage temp_storage;
     // __syncthreads() prior to writing to shared memory is necessary
@@ -325,52 +379,97 @@ void deviceReduceMax_full (T * dest, T source) noexcept
     // and since we don't know how many times the user is calling it,
     // we do it always to be safe.
     __syncthreads();
-    // Compute the block-wide reduction for thread0
-    T aggregate = BlockReduce(temp_storage).Reduce(source, cub::Max());
-    if (threadIdx.x == 0) { Gpu::Atomic::Max(dest, aggregate); }
-}
+    return BlockReduce(temp_storage).Reduce(source, cub::Min());
+#elif defined(AMREX_USE_HIP)
+    typedef rocprim::block_reduce<T,BLOCKDIMX> BlockReduce;
+    __shared__ typename BlockReduce::storage_type temp_storage;
+    __syncthreads();
+    BlockReduce().reduce(source, source, temp_storage, rocprim::minimum<T>());
+    return source;
+#else
+    return blockReduceMin(source);
 #endif
+}
+
+template <int BLOCKDIMX, typename T>
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE
+void deviceReduceMin_full (T * dest, T source) noexcept
+{
+    T aggregate = blockReduceMin<BLOCKDIMX>(source);
+    if (threadIdx.x == 0) { Gpu::Atomic::Min(dest, aggregate); }
+}
+
+// Compute the block-wide reduction for thread0
+template <typename T>
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE
+T blockReduceMax (T source) noexcept
+{
+    return Gpu::blockReduce<Gpu::Device::warp_size>
+        (source, Gpu::warpReduce<Gpu::Device::warp_size,T,amrex::Greater<T> >(), source);
+}
 
 template <typename T>
 AMREX_GPU_DEVICE AMREX_FORCE_INLINE
 void deviceReduceMax_full (T * dest, T source) noexcept
 {
-    source = Gpu::blockReduce<Gpu::Device::warp_size>
-        (source, Gpu::warpReduce<Gpu::Device::warp_size,T,amrex::Greater<T> >(), source);
-    if (threadIdx.x == 0) { Gpu::Atomic::Max(dest, source); }
+    T aggregate = blockReduceMax(source);
+    if (threadIdx.x == 0) { Gpu::Atomic::Max(dest, aggregate); }
 }
 
-#if defined(AMREX_USE_CUB)
-template <int BLOCKDIMX>
+// Compute the block-wide reduction for thread0
+template <int BLOCKDIMX, typename T>
 AMREX_GPU_DEVICE AMREX_FORCE_INLINE
-void deviceReduceLogicalAnd_full (int * dest, int source) noexcept
+T blockReduceMax (T source) noexcept
 {
-    typedef cub::BlockReduce<int,BLOCKDIMX> BlockReduce;
+#if defined(AMREX_USE_CUB)
+    typedef cub::BlockReduce<T,BLOCKDIMX> BlockReduce;
     __shared__ typename BlockReduce::TempStorage temp_storage;
     // __syncthreads() prior to writing to shared memory is necessary
     // if this reduction call is occurring multiple times in a kernel,
     // and since we don't know how many times the user is calling it,
     // we do it always to be safe.
     __syncthreads();
-    // Compute the block-wide reduction for thread0
-    int aggregate = BlockReduce(temp_storage).Reduce(source, amrex::LogicalAnd<int>());
+    return BlockReduce(temp_storage).Reduce(source, cub::Max());
+#elif defined(AMREX_USE_HIP)
+    typedef rocprim::block_reduce<T,BLOCKDIMX> BlockReduce;
+    __shared__ typename BlockReduce::storage_type temp_storage;
+    __syncthreads();
+    BlockReduce().reduce(source, source, temp_storage, rocprim::maximum<T>());
+    return source;
+#else
+    return blockReduceMax(source);
+#endif
+}
+
+template <int BLOCKDIMX, typename T>
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE
+void deviceReduceMax_full (T * dest, T source) noexcept
+{
+    T aggregate = blockReduceMax<BLOCKDIMX>(source);
+    if (threadIdx.x == 0) { Gpu::Atomic::Max(dest, aggregate); }
+}
+
+// Compute the block-wide reduction for thread0
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE
+int blockReduceLogicalAnd (int source) noexcept
+{
+    return Gpu::blockReduce<Gpu::Device::warp_size>
+        (source, Gpu::warpReduce<Gpu::Device::warp_size,int,amrex::LogicalAnd<int> >(), 1);
+}
+
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE
+void deviceReduceLogicalAnd_full (int * dest, int source) noexcept
+{
+    int aggregate = blockReduceLogicalAnd(source);
     if (threadIdx.x == 0) { Gpu::Atomic::LogicalAnd(dest, aggregate); }
 }
-#endif
 
-AMREX_GPU_DEVICE AMREX_FORCE_INLINE
-void deviceReduceLogicalAnd_full (int * dest, int source) noexcept
-{
-    source = Gpu::blockReduce<Gpu::Device::warp_size>
-        (source, Gpu::warpReduce<Gpu::Device::warp_size,int,amrex::LogicalAnd<int> >(), 1);
-    if (threadIdx.x == 0) { Gpu::Atomic::LogicalAnd(dest, source); }
-}
-
-#if defined(AMREX_USE_CUB)
+// Compute the block-wide reduction for thread0
 template <int BLOCKDIMX>
 AMREX_GPU_DEVICE AMREX_FORCE_INLINE
-void deviceReduceLogicalOr_full (int * dest, int source) noexcept
+int blockReduceLogicalAnd (int source) noexcept
 {
+#if defined(AMREX_USE_CUB)
     typedef cub::BlockReduce<int,BLOCKDIMX> BlockReduce;
     __shared__ typename BlockReduce::TempStorage temp_storage;
     // __syncthreads() prior to writing to shared memory is necessary
@@ -378,18 +477,72 @@ void deviceReduceLogicalOr_full (int * dest, int source) noexcept
     // and since we don't know how many times the user is calling it,
     // we do it always to be safe.
     __syncthreads();
-    // Compute the block-wide reduction for thread0
-    int aggregate = BlockReduce(temp_storage).Reduce(source, amrex::LogicalOr<int>());
-    if (threadIdx.x == 0) { Gpu::Atomic::LogicalOr(dest, aggregate); }
-}
+    return BlockReduce(temp_storage).Reduce(source, amrex::LogicalAnd<int>());
+#elif defined(AMREX_USE_HIP)
+    typedef rocprim::block_reduce<int,BLOCKDIMX> BlockReduce;
+    __shared__ typename BlockReduce::storage_type temp_storage;
+    __syncthreads();
+    BlockReduce().reduce(source, source, temp_storage, amrex::LogicalAnd<int>());
+    return source;
+#else
+    return blockReduceLogicalAnd(source);
 #endif
+}
+
+template <int BLOCKDIMX>
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE
+void deviceReduceLogicalAnd_full (int * dest, int source) noexcept
+{
+    int aggregate = blockReduceLogicalAnd<BLOCKDIMX>(source);
+    if (threadIdx.x == 0) { Gpu::Atomic::LogicalAnd(dest, aggregate); }
+}
+
+// Compute the block-wide reduction for thread0
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE
+int blockReduceLogicalOr (int source) noexcept
+{
+    return Gpu::blockReduce<Gpu::Device::warp_size>
+        (source, Gpu::warpReduce<Gpu::Device::warp_size,int,amrex::LogicalOr<int> >(), 0);
+}
 
 AMREX_GPU_DEVICE AMREX_FORCE_INLINE
 void deviceReduceLogicalOr_full (int * dest, int source) noexcept
 {
-    source = Gpu::blockReduce<Gpu::Device::warp_size>
-        (source, Gpu::warpReduce<Gpu::Device::warp_size,int,amrex::LogicalOr<int> >(), 0);
-    if (threadIdx.x == 0) { Gpu::Atomic::LogicalOr(dest, source); }
+    int aggregate = blockReduceLogicalOr(source);
+    if (threadIdx.x == 0) { Gpu::Atomic::LogicalOr(dest, aggregate); }
+}
+
+// Compute the block-wide reduction for thread0
+template <int BLOCKDIMX>
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE
+int blockReduceLogicalOr (int source) noexcept
+{
+#if defined(AMREX_USE_CUB)
+    typedef cub::BlockReduce<int,BLOCKDIMX> BlockReduce;
+    __shared__ typename BlockReduce::TempStorage temp_storage;
+    // __syncthreads() prior to writing to shared memory is necessary
+    // if this reduction call is occurring multiple times in a kernel,
+    // and since we don't know how many times the user is calling it,
+    // we do it always to be safe.
+    __syncthreads();
+    return BlockReduce(temp_storage).Reduce(source, amrex::LogicalOr<int>());
+#elif defined(AMREX_USE_HIP)
+    typedef rocprim::block_reduce<int,BLOCKDIMX> BlockReduce;
+    __shared__ typename BlockReduce::storage_type temp_storage;
+    __syncthreads();
+    BlockReduce().reduce(source, source, temp_storage, amrex::LogicalOr<int>());
+    return source;
+#else
+    return blockReduceLogicalOr(source);
+#endif
+}
+
+template <int BLOCKDIMX>
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE
+void deviceReduceLogicalOr_full (int * dest, int source) noexcept
+{
+    int aggregate = blockReduceLogicalOr<BLOCKDIMX>(source);
+    if (threadIdx.x == 0) { Gpu::Atomic::LogicalOr(dest, aggregate); }
 }
 
 template <typename T>
@@ -397,16 +550,13 @@ AMREX_GPU_DEVICE AMREX_FORCE_INLINE
 void deviceReduceSum (T * dest, T source, Gpu::Handler const& handler) noexcept
 {
     if (handler.isFullBlock()) {
-#if defined(AMREX_USE_CUB)
         if (blockDim.x == 128) {
             deviceReduceSum_full<128,T>(dest, source);
         } else if (blockDim.x == 256) {
             deviceReduceSum_full<256,T>(dest, source);
         } else if (blockDim.x == 512) {
             deviceReduceSum_full<512,T>(dest, source);
-        } else
-#endif
-        {
+        } else {
             deviceReduceSum_full<T>(dest, source);
         }
     } else {
@@ -421,16 +571,13 @@ AMREX_GPU_DEVICE AMREX_FORCE_INLINE
 void deviceReduceMin (T * dest, T source, Gpu::Handler const& handler) noexcept
 {
     if (handler.isFullBlock()) {
-#if defined(AMREX_USE_CUB)
         if (blockDim.x == 128) {
             deviceReduceMin_full<128,T>(dest, source);
         } else if (blockDim.x == 256) {
             deviceReduceMin_full<256,T>(dest, source);
         } else if (blockDim.x == 512) {
             deviceReduceMin_full<512,T>(dest, source);
-        } else
-#endif
-        {
+        } else {
             deviceReduceMin_full<T>(dest, source);
         }
     } else {
@@ -445,16 +592,13 @@ AMREX_GPU_DEVICE AMREX_FORCE_INLINE
 void deviceReduceMax (T * dest, T source, Gpu::Handler const& handler) noexcept
 {
     if (handler.isFullBlock()) {
-#if defined(AMREX_USE_CUB)
         if (blockDim.x == 128) {
             deviceReduceMax_full<128,T>(dest, source);
         } else if (blockDim.x == 256) {
             deviceReduceMax_full<256,T>(dest, source);
         } else if (blockDim.x == 512) {
             deviceReduceMax_full<512,T>(dest, source);
-        } else
-#endif
-        {
+        } else {
             deviceReduceMax_full<T>(dest, source);
         }
     } else {
@@ -468,16 +612,13 @@ AMREX_GPU_DEVICE AMREX_FORCE_INLINE
 void deviceReduceLogicalAnd (int * dest, int source, Gpu::Handler const& handler) noexcept
 {
     if (handler.isFullBlock()) {
-#if defined(AMREX_USE_CUB)
         if (blockDim.x == 128) {
             deviceReduceLogicalAnd_full<128>(dest, source);
         } else if (blockDim.x == 256) {
             deviceReduceLogicalAnd_full<256>(dest, source);
         } else if (blockDim.x == 512) {
             deviceReduceLogicalAnd_full<512>(dest, source);
-        } else
-#endif
-        {
+        } else {
             deviceReduceLogicalAnd_full(dest, source);
         }
     } else {
@@ -491,16 +632,13 @@ AMREX_GPU_DEVICE AMREX_FORCE_INLINE
 void deviceReduceLogicalOr (int * dest, int source, Gpu::Handler const& handler) noexcept
 {
     if (handler.isFullBlock()) {
-#if defined(AMREX_USE_CUB)
         if (blockDim.x == 128) {
             deviceReduceLogicalOr_full<128>(dest, source);
         } else if (blockDim.x == 256) {
             deviceReduceLogicalOr_full<256>(dest, source);
         } else if (blockDim.x == 512) {
             deviceReduceLogicalOr_full<512>(dest, source);
-        } else
-#endif
-        {
+        } else {
             deviceReduceLogicalOr_full(dest, source);
         }
     } else {

--- a/Src/Base/AMReX_Reduce.H
+++ b/Src/Base/AMReX_Reduce.H
@@ -508,7 +508,7 @@ public:
 #ifdef AMREX_USE_DPCPP
 #if 0
         // xxxxx DPCPP todo: There is a bug in either the compiler or amrex
-        // that makes this fail on the latest hardware, but not on DG1.
+        // that makes this fail on the new hardwares, but not on Gen9.
         amrex::launch(1, AMREX_GPU_MAX_THREADS, 0, Gpu::gpuStream(),
         [=] AMREX_GPU_DEVICE (Gpu::Handler const& gh) noexcept
         {
@@ -522,6 +522,7 @@ public:
                     Reduce::detail::for_each_local<0, ReduceTuple, Ps...>(r, dp_stream[i]);
                 }
             }
+            // xxxxx DPCPP todo: The following for_each_parallel fails!
             Reduce::detail::for_each_parallel<0, ReduceTuple, Ps...>(dst, r, gh);
             if (gh.threadIdx() == 0) { *hp = dst; }
         });

--- a/Src/Base/AMReX_Reduce.H
+++ b/Src/Base/AMReX_Reduce.H
@@ -506,10 +506,9 @@ public:
         auto const& nblocks = reduce_data.nBlocks();
         int maxblocks = reduce_data.maxBlocks();
 #ifdef AMREX_USE_DPCPP
-#if 0
-        // xxxxx DPCPP todo: There is a bug in either the compiler or amrex
-        // that makes this fail on the new hardwares, but not on Gen9.
-        amrex::launch(1, AMREX_GPU_MAX_THREADS, 0, Gpu::gpuStream(),
+        // device reduce needs local(i.e., shared) memory
+        constexpr std::size_t shared_mem_bytes = sizeof(unsigned long long)*Gpu::Device::warp_size;
+        amrex::launch(1, AMREX_GPU_MAX_THREADS, shared_mem_bytes, Gpu::gpuStream(),
         [=] AMREX_GPU_DEVICE (Gpu::Handler const& gh) noexcept
         {
             ReduceTuple r;
@@ -522,25 +521,9 @@ public:
                     Reduce::detail::for_each_local<0, ReduceTuple, Ps...>(r, dp_stream[i]);
                 }
             }
-            // xxxxx DPCPP todo: The following for_each_parallel fails!
             Reduce::detail::for_each_parallel<0, ReduceTuple, Ps...>(dst, r, gh);
             if (gh.threadIdx() == 0) { *hp = dst; }
         });
-#else
-        Reduce::detail::for_each_init<0, ReduceTuple, Ps...>(*hp);
-        for (int istream = 0, nstreams = nblocks.size(); istream < nstreams; ++istream) {
-            auto dp_stream = dp+istream*maxblocks;
-            int nb = nblocks[istream];
-            if (nb > 0) {
-                Gpu::PinnedVector<ReduceTuple> hv(nb);
-                Gpu::htod_memcpy_async(hv.data(), dp_stream, nb*sizeof(ReduceTuple));
-                Gpu::streamSynchronize();
-                for (int i = 0; i < nb; ++i) {
-                    Reduce::detail::for_each_local<0, ReduceTuple, Ps...>(*hp, hv[i]);
-                }
-            }
-        }
-#endif
 #else
         amrex::launch(1, AMREX_GPU_MAX_THREADS, 0, Gpu::gpuStream(),
         [=] AMREX_GPU_DEVICE () noexcept

--- a/Src/Base/AMReX_Reduce.H
+++ b/Src/Base/AMReX_Reduce.H
@@ -4,13 +4,16 @@
 
 #include <AMReX_Gpu.H>
 #include <AMReX_Arena.H>
+#include <AMReX_OpenMP.H>
 
 #include <algorithm>
+#include <functional>
 
 namespace amrex {
 
 namespace Reduce { namespace detail {
 
+#ifdef AMREX_USE_GPU
 #ifdef AMREX_USE_DPCPP
     template <std::size_t I, typename T, typename P>
     AMREX_GPU_DEVICE
@@ -42,15 +45,17 @@ namespace Reduce { namespace detail {
         for_each_parallel<I+1,T,P1,Ps...>(d, s);
     }
 #endif
+#endif
+
     template <std::size_t I, typename T, typename P>
-    AMREX_GPU_DEVICE
+    AMREX_GPU_HOST_DEVICE
     void for_each_local (T& d, T const& s)
     {
         P().local_update(amrex::get<I>(d), amrex::get<I>(s));
     }
 
     template <std::size_t I, typename T, typename P, typename P1, typename... Ps>
-    AMREX_GPU_DEVICE
+    AMREX_GPU_HOST_DEVICE
     void for_each_local (T& d, T const& s)
     {
         P().local_update(amrex::get<I>(d), amrex::get<I>(s));
@@ -58,12 +63,14 @@ namespace Reduce { namespace detail {
     }
 
     template <std::size_t I, typename T, typename P>
+    AMREX_GPU_HOST_DEVICE
     void for_each_init (T& t)
     {
         P().init(amrex::get<I>(t));
     }
 
     template <std::size_t I, typename T, typename P, typename P1, typename... Ps>
+    AMREX_GPU_HOST_DEVICE
     void for_each_init (T& t)
     {
         P().init(amrex::get<I>(t));
@@ -73,22 +80,23 @@ namespace Reduce { namespace detail {
 
 struct ReduceOpSum
 {
+
+#ifdef AMREX_USE_GPU
 #ifdef AMREX_USE_DPCPP
     template <typename T>
     AMREX_GPU_DEVICE AMREX_FORCE_INLINE
     void parallel_update (T& d, T const& s, Gpu::Handler const& h) const noexcept {
-        Gpu::deviceReduceSum_full(&d,s,h);
+        T r = Gpu::blockReduceSum(s,h);
+        if (h.threadIdx() == 0) { d += r; }
     }
 #else
     template <typename T>
     AMREX_GPU_DEVICE AMREX_FORCE_INLINE
     void parallel_update (T& d, T const& s) const noexcept {
-#if defined(AMREX_USE_CUB)
-        Gpu::deviceReduceSum_full<AMREX_GPU_MAX_THREADS>(&d,s);
-#else
-        Gpu::deviceReduceSum_full(&d,s);
-#endif
+        T r = Gpu::blockReduceSum<AMREX_GPU_MAX_THREADS>(s);
+        if (threadIdx.x == 0) { d += r; }
     }
+#endif
 #endif
 
     template <typename T>
@@ -96,27 +104,27 @@ struct ReduceOpSum
     void local_update (T& d, T const& s) const noexcept { d += s; }
 
     template <typename T>
-    void init (T& t) const noexcept { t = 0; }
+    constexpr void init (T& t) const noexcept { t = 0; }
 };
 
 struct ReduceOpMin
 {
+#ifdef AMREX_USE_GPU
 #ifdef AMREX_USE_DPCPP
     template <typename T>
     AMREX_GPU_DEVICE AMREX_FORCE_INLINE
     void parallel_update (T& d, T const& s, Gpu::Handler const& h) const noexcept {
-        Gpu::deviceReduceMin_full(&d,s,h);
+        T r = Gpu::blockReduceMin(s,h);
+        if (h.threadIdx() == 0) { d = amrex::min(d,r); }
     }
 #else
     template <typename T>
     AMREX_GPU_DEVICE AMREX_FORCE_INLINE
     void parallel_update (T& d, T const& s) const noexcept {
-#if defined(AMREX_USE_CUB)
-        Gpu::deviceReduceMin_full<AMREX_GPU_MAX_THREADS>(&d,s);
-#else
-        Gpu::deviceReduceMin_full(&d,s);
-#endif
+        T r = Gpu::blockReduceMin<AMREX_GPU_MAX_THREADS>(s);
+        if (threadIdx.x == 0) { d = amrex::min(d,r); }
     }
+#endif
 #endif
 
     template <typename T>
@@ -124,27 +132,27 @@ struct ReduceOpMin
     void local_update (T& d, T const& s) const noexcept { d = amrex::min(d,s); }
 
     template <typename T>
-    void init (T& t) const noexcept { t = std::numeric_limits<T>::max(); }
+    constexpr void init (T& t) const noexcept { t = std::numeric_limits<T>::max(); }
 };
 
 struct ReduceOpMax
 {
+#ifdef AMREX_USE_GPU
 #ifdef AMREX_USE_DPCPP
     template <typename T>
     AMREX_GPU_DEVICE AMREX_FORCE_INLINE
     void parallel_update (T& d, T const& s, Gpu::Handler const& h) const noexcept {
-        Gpu::deviceReduceMax_full(&d,s,h);
+        T r = Gpu::blockReduceMax(s,h);
+        if (h.threadIdx() == 0) { d = amrex::max(d,r); }
     }
 #else
     template <typename T>
     AMREX_GPU_DEVICE AMREX_FORCE_INLINE
     void parallel_update (T& d, T const& s) const noexcept {
-#if defined(AMREX_USE_CUB)
-        Gpu::deviceReduceMax_full<AMREX_GPU_MAX_THREADS>(&d,s);
-#else
-        Gpu::deviceReduceMax_full(&d,s);
-#endif
+        T r = Gpu::blockReduceMax<AMREX_GPU_MAX_THREADS>(s);
+        if (threadIdx.x == 0) { d = amrex::max(d,r); }
     }
+#endif
 #endif
 
     template <typename T>
@@ -152,91 +160,60 @@ struct ReduceOpMax
     void local_update (T& d, T const& s) const noexcept { d = amrex::max(d,s); }
 
     template <typename T>
-    void init (T& t) const noexcept { t = std::numeric_limits<T>::lowest(); }
+    constexpr void init (T& t) const noexcept { t = std::numeric_limits<T>::lowest(); }
 };
 
 struct ReduceOpLogicalAnd
 {
+#ifdef AMREX_USE_GPU
 #ifdef AMREX_USE_DPCPP
     AMREX_GPU_DEVICE AMREX_FORCE_INLINE
     void parallel_update (int& d, int s, Gpu::Handler const& h) const noexcept {
-        Gpu::deviceReduceLogicalAnd_full(&d,s,h);
+        int r = Gpu::blockReduceLogicalAnd(s,h);
+        if (h.threadIdx() == 0) { d = d && r; }
     }
 #else
     AMREX_GPU_DEVICE AMREX_FORCE_INLINE
     void parallel_update (int& d, int s) const noexcept {
-#if defined(AMREX_USE_CUB)
-        Gpu::deviceReduceLogicalAnd_full<AMREX_GPU_MAX_THREADS>(&d,s);
-#else
-        Gpu::deviceReduceLogicalAnd_full(&d,s);
-#endif
+        int r = Gpu::blockReduceLogicalAnd<AMREX_GPU_MAX_THREADS>(s);
+        if (threadIdx.x == 0) { d = d && r; }
     }
+#endif
 #endif
 
     AMREX_GPU_DEVICE AMREX_FORCE_INLINE
     void local_update (int& d, int s) const noexcept { d = d && s; }
 
-    void init (int& t) const noexcept { t = true; }
+    constexpr void init (int& t) const noexcept { t = true; }
 };
 
 struct ReduceOpLogicalOr
 {
+#ifdef AMREX_USE_GPU
 #ifdef AMREX_USE_DPCPP
     AMREX_GPU_DEVICE AMREX_FORCE_INLINE
     void parallel_update (int& d, int s, Gpu::Handler const& h) const noexcept {
-        Gpu::deviceReduceLogicalOr_full(&d,s,h);
+        int r = Gpu::blockReduceLogicalOr(s,h);
+        if (h.threadIdx() == 0) { d = d || r; }
     }
 #else
     AMREX_GPU_DEVICE AMREX_FORCE_INLINE
     void parallel_update (int& d, int s) const noexcept {
-#if defined(AMREX_USE_CUB)
-        Gpu::deviceReduceLogicalOr_full<AMREX_GPU_MAX_THREADS>(&d,s);
-#else
-        Gpu::deviceReduceLogicalOr_full(&d,s);
-#endif
+        int r = Gpu::blockReduceLogicalOr<AMREX_GPU_MAX_THREADS>(s);
+        if (threadIdx.x == 0) { d = d || r; }
     }
+#endif
 #endif
 
     AMREX_GPU_DEVICE AMREX_FORCE_INLINE
     void local_update (int& d, int s) const noexcept { d = d || s; }
 
-    void init (int& t) const noexcept { t = false; }
+    constexpr void init (int& t) const noexcept { t = false; }
 };
 
 template <typename... Ps> class ReduceOps;
 
 #ifdef AMREX_USE_GPU
-
-namespace Reduce {
-namespace detail {
-#ifdef AMREX_USE_DPCPP
-    // xxxxx DPCPP todo: the compiler seems to have a bug.  It cannot capture
-    //                   GpuTuple<T> correctly even if it's standard layout.
-    template <typename T>
-    void
-    init_tuple_on_device (T* p, T const& v)
-    {
-        amrex::single_task(Gpu::nullStream(), [=] AMREX_GPU_DEVICE () noexcept
-        {
-            new (p) T();
-            new (p+1) T();
-        });
-        Array<T,2> tmp{v,v};
-        Gpu::htod_memcpy(p, tmp.data(), sizeof(T)*2);
-    }
-#else
-    template <typename T>
-    void
-    init_tuple_on_device (T* p, T const& v)
-    {
-        amrex::single_task(Gpu::nullStream(), [=] AMREX_GPU_DEVICE () noexcept
-        {
-            new (p) T(v);
-            new (p+1) T(v);
-        });
-    }
-#endif
-}}
 
 template <typename... Ts>
 class ReduceData
@@ -245,40 +222,63 @@ public:
     using Type = GpuTuple<Ts...>;
 
     template <typename... Ps>
-    explicit ReduceData (ReduceOps<Ps...> const&)
-        : m_host_tuple(),
-          m_device_tuple((Type*)(The_Arena()->alloc(2*sizeof(m_host_tuple))))
+    explicit ReduceData (ReduceOps<Ps...>& reduce_op)
+        : m_host_tuple((Type*)(The_Pinned_Arena()->alloc(sizeof(Type)))),
+          m_device_tuple((Type*)(The_Arena()->alloc((AMREX_GPU_MAX_STREAMS+1)
+                                                    *Gpu::Device::maxBlocksPerLaunch()
+                                                    *sizeof(Type)))),
+          m_max_blocks(Gpu::Device::maxBlocksPerLaunch()),
+          m_fn_value([&reduce_op,this] () -> Type { return this->value(reduce_op); })
     {
         static_assert(std::is_trivially_copyable<Type>(),
                       "ReduceData::Type must be trivially copyable");
         static_assert(std::is_trivially_destructible<Type>(),
                       "ReduceData::Type must be trivially destructible");
 
-        Reduce::detail::for_each_init<0, Type, Ps...>(m_host_tuple);
-        Reduce::detail::init_tuple_on_device(m_device_tuple, m_host_tuple);
-        Gpu::synchronize();
+        new (m_host_tuple) Type();
+        m_nblocks.fill(0);
     }
 
-    ~ReduceData () { The_Arena()->free(m_device_tuple); }
+    ~ReduceData () {
+        The_Pinned_Arena()->free(m_host_tuple);
+        The_Arena()->free(m_device_tuple);
+    }
 
     ReduceData (ReduceData<Ts...> const&) = delete;
     ReduceData (ReduceData<Ts...> &&) = delete;
     void operator= (ReduceData<Ts...> const&) = delete;
     void operator= (ReduceData<Ts...> &&) = delete;
 
+    [[deprecated("Use value (ReduceOps<Ps...>&) instead.")]]
     Type value ()
     {
-        Gpu::dtoh_memcpy(&m_host_tuple, m_device_tuple, sizeof(m_host_tuple));
-        return m_host_tuple;
+        return m_fn_value();
+    }
+
+    template <typename... Ps>
+    Type value (ReduceOps<Ps...> & reduce_op)
+    {
+        return reduce_op.value(*this);
     }
 
     Type* devicePtr () { return m_device_tuple; }
+    Type* devicePtr (gpuStream_t const& s) {
+        return m_device_tuple+(Gpu::Device::streamIndex(s)+1)*m_max_blocks;
+    }
 
-    Type& hostRef () { return m_host_tuple; }
+    Type* hostPtr () { return m_host_tuple; }
+
+    GpuArray<int,AMREX_GPU_MAX_STREAMS+1>& nBlocks () { return m_nblocks; }
+    int& nBlocks (gpuStream_t const& s) { return m_nblocks[Gpu::Device::streamIndex(s)+1]; }
+
+    int maxBlocks () const { return m_max_blocks; }
 
 private:
-    Type m_host_tuple;
-    Type* m_device_tuple;
+    Type* m_host_tuple = nullptr;
+    Type* m_device_tuple = nullptr;
+    int m_max_blocks;
+    GpuArray<int,AMREX_GPU_MAX_STREAMS+1> m_nblocks;
+    std::function<Type()> m_fn_value;
 };
 
 namespace Reduce { namespace detail {
@@ -311,21 +311,29 @@ public:
     void eval (Box const& box, D & reduce_data, F&& f)
     {
         using ReduceTuple = typename D::Type;
-        auto dp = reduce_data.devicePtr();
+        auto const& stream = Gpu::gpuStream();
+        auto dp = reduce_data.devicePtr(stream);
+        int& nblocks = reduce_data.nBlocks(stream);
         int ncells = box.numPts();
         const auto lo  = amrex::lbound(box);
         const auto len = amrex::length(box);
         IndexType ixtype = box.ixType();
-        auto ec = Gpu::ExecutionConfig(ncells);
-        AMREX_ASSERT(ec.numThreads.x == AMREX_GPU_MAX_THREADS);
-        ec.numBlocks.x = std::min(ec.numBlocks.x, Gpu::Device::maxBlocksPerLaunch());
+        constexpr int nitems_per_thread = 4;
+        int nblocks_ec = (ncells + nitems_per_thread*AMREX_GPU_MAX_THREADS-1)
+            / (nitems_per_thread*AMREX_GPU_MAX_THREADS);
+        nblocks_ec = std::min(nblocks_ec, static_cast<int>(Gpu::Device::maxBlocksPerLaunch()));
 #ifdef AMREX_USE_DPCPP
         // device reduce needs local(i.e., shared) memory
         constexpr std::size_t shared_mem_bytes = sizeof(unsigned long long)*Gpu::Device::warp_size;
-        amrex::launch(ec.numBlocks.x, ec.numThreads.x, shared_mem_bytes, Gpu::gpuStream(),
+        amrex::launch(nblocks_ec, AMREX_GPU_MAX_THREADS, shared_mem_bytes, stream,
         [=] AMREX_GPU_DEVICE (Gpu::Handler const& gh) noexcept
         {
-            ReduceTuple r = *(dp+1);
+            ReduceTuple r;
+            Reduce::detail::for_each_init<0, ReduceTuple, Ps...>(r);
+            ReduceTuple& dst = *(dp+gh.blockIdx());
+            if (gh.threadIdx() == 0 && gh.blockIdx() >= nblocks) {
+                dst = r;
+            }
             for (int icell = gh.item->get_global_id(0), stride = gh.item->get_global_range(0);
                  icell < ncells; icell += stride) {
                 int k =  icell /   (len.x*len.y);
@@ -337,28 +345,18 @@ public:
                 auto pr = Reduce::detail::call_f(f,i,j,k,ixtype);
                 Reduce::detail::for_each_local<0, ReduceTuple, Ps...>(r, pr);
             }
-            Reduce::detail::for_each_parallel<0, ReduceTuple, Ps...>(*dp,r, gh);
+            Reduce::detail::for_each_parallel<0, ReduceTuple, Ps...>(dst, r, gh);
         });
 #else
-#if defined(AMREX_USE_CUDA) || (defined(AMREX_USE_HIP) && defined(AMREX_HIP_INDIRECT_FUNCTION))
-        if (Gpu::inFuseRegion() && Gpu::inFuseReductionRegion()
-            && ec.numBlocks.x*ec.numThreads.x <= Gpu::getFuseSizeThreshold())
+        amrex::launch(nblocks_ec, AMREX_GPU_MAX_THREADS, 0, stream,
+        [=] AMREX_GPU_DEVICE () noexcept
         {
-            Gpu::Register(box, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
-            {
-                ReduceTuple r = *(dp+1);
-                if (box.contains(IntVect(AMREX_D_DECL(i,j,k)))) {
-                    auto pr = Reduce::detail::call_f(f,i,j,k,ixtype);
-                    Reduce::detail::for_each_local<0, ReduceTuple, Ps...>(r, pr);
-                }
-                Reduce::detail::for_each_parallel<0, ReduceTuple, Ps...>(*dp,r);
-            });
-        } else
-#endif
-        {
-        amrex::launch(ec.numBlocks.x, ec.numThreads.x, 0, Gpu::gpuStream(),
-        [=] AMREX_GPU_DEVICE () noexcept {
-            ReduceTuple r = *(dp+1);
+            ReduceTuple r;
+            Reduce::detail::for_each_init<0, ReduceTuple, Ps...>(r);
+            ReduceTuple& dst = *(dp+blockIdx.x);
+            if (threadIdx.x == 0 && blockIdx.x >= nblocks) {
+                dst = r;
+            }
             for (int icell = blockDim.x*blockIdx.x+threadIdx.x, stride = blockDim.x*gridDim.x;
                  icell < ncells; icell += stride) {
                 int k =  icell /   (len.x*len.y);
@@ -370,10 +368,10 @@ public:
                 auto pr = Reduce::detail::call_f(f,i,j,k,ixtype);
                 Reduce::detail::for_each_local<0, ReduceTuple, Ps...>(r, pr);
             }
-            Reduce::detail::for_each_parallel<0, ReduceTuple, Ps...>(*dp,r);
+            Reduce::detail::for_each_parallel<0, ReduceTuple, Ps...>(dst, r);
         });
-        }
 #endif
+        nblocks = std::max(nblocks, nblocks_ec);
     }
 
     template <typename N, typename D, typename F,
@@ -381,20 +379,28 @@ public:
     void eval (Box const& box, N ncomp, D & reduce_data, F&& f)
     {
         using ReduceTuple = typename D::Type;
-        auto dp = reduce_data.devicePtr();
+        auto const& stream = Gpu::gpuStream();
+        auto dp = reduce_data.devicePtr(stream);
+        int& nblocks = reduce_data.nBlocks(stream);
         int ncells = box.numPts();
         const auto lo  = amrex::lbound(box);
         const auto len = amrex::length(box);
-        auto ec = Gpu::ExecutionConfig(ncells);
-        AMREX_ASSERT(ec.numThreads.x == AMREX_GPU_MAX_THREADS);
-        ec.numBlocks.x = std::min(ec.numBlocks.x, Gpu::Device::maxBlocksPerLaunch());
+        constexpr int nitems_per_thread = 4;
+        int nblocks_ec = (ncells + nitems_per_thread*AMREX_GPU_MAX_THREADS-1)
+            / (nitems_per_thread*AMREX_GPU_MAX_THREADS);
+        nblocks_ec = std::min(nblocks_ec, static_cast<int>(Gpu::Device::maxBlocksPerLaunch()));
 #ifdef AMREX_USE_DPCPP
         // device reduce needs local(i.e., shared) memory
         constexpr std::size_t shared_mem_bytes = sizeof(unsigned long long)*Gpu::Device::warp_size;
-        amrex::launch(ec.numBlocks.x, ec.numThreads.x, shared_mem_bytes, Gpu::gpuStream(),
+        amrex::launch(nblocks_ec, AMREX_GPU_MAX_THREADS, shared_mem_bytes, stream,
         [=] AMREX_GPU_DEVICE (Gpu::Handler const& gh) noexcept
         {
-            ReduceTuple r = *(dp+1);
+            ReduceTuple r;
+            Reduce::detail::for_each_init<0, ReduceTuple, Ps...>(r);
+            ReduceTuple& dst = *(dp+gh.blockIdx());
+            if (gh.threadIdx() == 0 && gh.blockIdx() >= nblocks) {
+                dst = r;
+            }
             for (int icell = gh.item->get_global_id(0), stride = gh.item->get_global_range(0);
                  icell < ncells; icell += stride) {
                 int k =  icell /   (len.x*len.y);
@@ -408,12 +414,17 @@ public:
                     Reduce::detail::for_each_local<0, ReduceTuple, Ps...>(r, pr);
                 }
             }
-            Reduce::detail::for_each_parallel<0, ReduceTuple, Ps...>(*dp,r, gh);
+            Reduce::detail::for_each_parallel<0, ReduceTuple, Ps...>(dst, r, gh);
         });
 #else
-        amrex::launch(ec.numBlocks.x, ec.numThreads.x, 0, Gpu::gpuStream(),
+        amrex::launch(nblocks_ec, AMREX_GPU_MAX_THREADS, 0, stream,
         [=] AMREX_GPU_DEVICE () noexcept {
-            ReduceTuple r = *(dp+1);
+            ReduceTuple r;
+            Reduce::detail::for_each_init<0, ReduceTuple, Ps...>(r);
+            ReduceTuple& dst = *(dp+blockIdx.x);
+            if (threadIdx.x == 0 && blockIdx.x >= nblocks) {
+                dst = r;
+            }
             for (int icell = blockDim.x*blockIdx.x+threadIdx.x, stride = blockDim.x*gridDim.x;
                  icell < ncells; icell += stride) {
                 int k =  icell /   (len.x*len.y);
@@ -427,52 +438,135 @@ public:
                     Reduce::detail::for_each_local<0, ReduceTuple, Ps...>(r, pr);
                 }
             }
-            Reduce::detail::for_each_parallel<0, ReduceTuple, Ps...>(*dp,r);
+            Reduce::detail::for_each_parallel<0, ReduceTuple, Ps...>(dst, r);
         });
 #endif
+        nblocks = std::max(nblocks, nblocks_ec);
     }
 
     template <typename N, typename D, typename F,
               typename M=std::enable_if_t<std::is_integral<N>::value> >
     void eval (N n, D & reduce_data, F&& f)
     {
+        if (n <= 0) return;
         using ReduceTuple = typename D::Type;
-        auto dp = reduce_data.devicePtr();
-        auto ec = Gpu::ExecutionConfig(n);
-        AMREX_ASSERT(ec.numThreads.x == AMREX_GPU_MAX_THREADS);
-        ec.numBlocks.x = std::min(ec.numBlocks.x, Gpu::Device::maxBlocksPerLaunch());
+        auto const& stream = Gpu::gpuStream();
+        auto dp = reduce_data.devicePtr(stream);
+        int& nblocks = reduce_data.nBlocks(stream);
+        constexpr int nitems_per_thread = 4;
+        int nblocks_ec = (n + nitems_per_thread*AMREX_GPU_MAX_THREADS-1)
+            / (nitems_per_thread*AMREX_GPU_MAX_THREADS);
+        nblocks_ec = std::min(nblocks_ec, static_cast<int>(Gpu::Device::maxBlocksPerLaunch()));
 #ifdef AMREX_USE_DPCPP
         // device reduce needs local(i.e., shared) memory
         constexpr std::size_t shared_mem_bytes = sizeof(unsigned long long)*Gpu::Device::warp_size;
-        amrex::launch(ec.numBlocks.x, ec.numThreads.x, shared_mem_bytes, Gpu::gpuStream(),
+        amrex::launch(nblocks_ec, AMREX_GPU_MAX_THREADS, shared_mem_bytes, stream,
         [=] AMREX_GPU_DEVICE (Gpu::Handler const& gh) noexcept
         {
-            ReduceTuple r = *(dp+1);
+            ReduceTuple r;
+            Reduce::detail::for_each_init<0, ReduceTuple, Ps...>(r);
+            ReduceTuple& dst = *(dp+gh.blockIdx());
+            if (gh.threadIdx() == 0 && gh.blockIdx() >= nblocks) {
+                dst = r;
+            }
             for (N i = gh.item->get_global_id(0), stride = gh.item->get_global_range(0);
                  i < n; i += stride) {
                 auto pr = f(i);
                 Reduce::detail::for_each_local<0, ReduceTuple, Ps...>(r,pr);
             }
-            Reduce::detail::for_each_parallel<0, ReduceTuple, Ps...>(*dp,r, gh);
+            Reduce::detail::for_each_parallel<0, ReduceTuple, Ps...>(dst, r, gh);
         });
 #else
-        amrex::launch(ec.numBlocks.x, ec.numThreads.x, 0, Gpu::gpuStream(),
+        amrex::launch(nblocks_ec, AMREX_GPU_MAX_THREADS, 0, stream,
         [=] AMREX_GPU_DEVICE () noexcept {
-            auto r = *(dp+1);
+            ReduceTuple r;
+            Reduce::detail::for_each_init<0, ReduceTuple, Ps...>(r);
+            ReduceTuple& dst = *(dp+blockIdx.x);
+            if (threadIdx.x == 0 && blockIdx.x >= nblocks) {
+                dst = r;
+            }
             for (N i = blockDim.x*blockIdx.x+threadIdx.x, stride = blockDim.x*gridDim.x;
                  i < n; i += stride) {
                 auto pr = f(i);
                 Reduce::detail::for_each_local<0, ReduceTuple, Ps...>(r,pr);
             }
-            Reduce::detail::for_each_parallel<0, ReduceTuple, Ps...>(*dp,r);
+            Reduce::detail::for_each_parallel<0, ReduceTuple, Ps...>(dst, r);
         });
 #endif
+        nblocks = amrex::max(nblocks, nblocks_ec);
+    }
+
+    template <typename D>
+    typename D::Type value (D & reduce_data)
+    {
+        using ReduceTuple = typename D::Type;
+        auto const& stream = Gpu::gpuStream();
+        auto hp = reduce_data.hostPtr();
+        auto dp = reduce_data.devicePtr();
+        auto const& nblocks = reduce_data.nBlocks();
+        int maxblocks = reduce_data.maxBlocks();
+#ifdef AMREX_USE_DPCPP
+#if 0
+        // xxxxx DPCPP todo: There is a bug in either the compiler or amrex
+        // that makes this fail on the latest hardware, but not on DG1.
+        amrex::launch(1, AMREX_GPU_MAX_THREADS, 0, Gpu::gpuStream(),
+        [=] AMREX_GPU_DEVICE (Gpu::Handler const& gh) noexcept
+        {
+            ReduceTuple r;
+            Reduce::detail::for_each_init<0, ReduceTuple, Ps...>(r);
+            ReduceTuple dst = r;
+            for (int istream = 0, nstreams = nblocks.size(); istream < nstreams; ++istream) {
+                auto dp_stream = dp+istream*maxblocks;
+                for (int i = gh.item->get_global_id(0), stride = gh.item->get_global_range(0);
+                     i < nblocks[istream]; i += stride) {
+                    Reduce::detail::for_each_local<0, ReduceTuple, Ps...>(r, dp_stream[i]);
+                }
+            }
+            Reduce::detail::for_each_parallel<0, ReduceTuple, Ps...>(dst, r, gh);
+            if (gh.threadIdx() == 0) { *hp = dst; }
+        });
+#else
+        Reduce::detail::for_each_init<0, ReduceTuple, Ps...>(*hp);
+        for (int istream = 0, nstreams = nblocks.size(); istream < nstreams; ++istream) {
+            auto dp_stream = dp+istream*maxblocks;
+            int nb = nblocks[istream];
+            if (nb > 0) {
+                Gpu::PinnedVector<ReduceTuple> hv(nb);
+                Gpu::htod_memcpy_async(hv.data(), dp_stream, nb*sizeof(ReduceTuple));
+                Gpu::streamSynchronize();
+                for (int i = 0; i < nb; ++i) {
+                    Reduce::detail::for_each_local<0, ReduceTuple, Ps...>(*hp, hv[i]);
+                }
+            }
+        }
+#endif
+#else
+        amrex::launch(1, AMREX_GPU_MAX_THREADS, 0, Gpu::gpuStream(),
+        [=] AMREX_GPU_DEVICE () noexcept
+        {
+            ReduceTuple r;
+            Reduce::detail::for_each_init<0, ReduceTuple, Ps...>(r);
+            ReduceTuple dst = r;
+            for (int istream = 0, nstreams = nblocks.size(); istream < nstreams; ++istream) {
+                auto dp_stream = dp+istream*maxblocks;
+                for (int i = blockDim.x*blockIdx.x+threadIdx.x, stride = blockDim.x*gridDim.x;
+                     i < nblocks[istream]; i += stride) {
+                    Reduce::detail::for_each_local<0, ReduceTuple, Ps...>(r, dp_stream[i]);
+                }
+            }
+            Reduce::detail::for_each_parallel<0, ReduceTuple, Ps...>(dst, r);
+            if (threadIdx.x == 0) { *hp = dst; }
+        });
+#endif
+        Gpu::streamSynchronize();
+        return *hp;
     }
 };
 
 namespace Reduce {
 
 template <typename T, typename N, typename U, typename BOP, typename M=std::enable_if_t<std::is_integral<N>::value> >
+[[deprecated]]
 T Sum (N n, U const* v, T init_val, BOP bop)
 {
     Gpu::LaunchSafeGuard lsg(true);
@@ -491,11 +585,7 @@ T Sum (N n, U const* v, T init_val, BOP bop)
 #else
     [=] AMREX_GPU_DEVICE (T const& r) noexcept
     {
-#if defined(AMREX_USE_CUB)
         Gpu::deviceReduceSum_full<AMREX_GPU_MAX_THREADS>(dp, r);
-#else
-        Gpu::deviceReduceSum_full(dp, r);
-#endif
     });
 #endif
     return ds.dataValue();
@@ -504,7 +594,12 @@ T Sum (N n, U const* v, T init_val, BOP bop)
 template <typename T, typename N, typename M=std::enable_if_t<std::is_integral<N>::value> >
 T Sum (N n, T const* v, T init_val = 0)
 {
-    return Reduce::Sum(n, v, init_val, amrex::Plus<T>());
+    ReduceOps<ReduceOpSum> reduce_op;
+    ReduceData<T> reduce_data(reduce_op);
+    using ReduceTuple = typename decltype(reduce_data)::Type;
+    reduce_op.eval(n, reduce_data, [=] AMREX_GPU_DEVICE (N i) -> ReduceTuple { return {v[i]}; });
+    ReduceTuple hv = reduce_data.value(reduce_op);
+    return amrex::get<0>(hv) + init_val;
 }
 
 template <typename T, typename N, typename F,
@@ -515,10 +610,12 @@ T Sum (N n, F&& f, T init_val = 0)
     ReduceData<T> reduce_data(reduce_op);
     using ReduceTuple = typename decltype(reduce_data)::Type;
     reduce_op.eval(n, reduce_data, [=] AMREX_GPU_DEVICE (N i) -> ReduceTuple { return {f(i)}; });
-    return amrex::get<0>(reduce_data.value()) + init_val;
+    ReduceTuple hv = reduce_data.value(reduce_op);
+    return amrex::get<0>(hv) + init_val;
 }
 
 template <typename T, typename N, typename U, typename BOP, typename M=std::enable_if_t<std::is_integral<N>::value> >
+[[deprecated]]
 T Min (N n, U const* v, T init_val, BOP bop)
 {
     Gpu::LaunchSafeGuard lsg(true);
@@ -537,11 +634,7 @@ T Min (N n, U const* v, T init_val, BOP bop)
 #else
     [=] AMREX_GPU_DEVICE (T const& r) noexcept
     {
-#if defined(AMREX_USE_CUB)
         Gpu::deviceReduceMin_full<AMREX_GPU_MAX_THREADS>(dp, r);
-#else
-        Gpu::deviceReduceMin_full(dp, r);
-#endif
     });
 #endif
     return ds.dataValue();
@@ -550,7 +643,12 @@ T Min (N n, U const* v, T init_val, BOP bop)
 template <typename T, typename N, typename M=std::enable_if_t<std::is_integral<N>::value> >
 T Min (N n, T const* v, T init_val = std::numeric_limits<T>::max())
 {
-    return Reduce::Min(n, v, init_val, amrex::Less<T>());
+    ReduceOps<ReduceOpMin> reduce_op;
+    ReduceData<T> reduce_data(reduce_op);
+    using ReduceTuple = typename decltype(reduce_data)::Type;
+    reduce_op.eval(n, reduce_data, [=] AMREX_GPU_DEVICE (N i) -> ReduceTuple { return {v[i]}; });
+    ReduceTuple hv = reduce_data.value(reduce_op);
+    return std::min(amrex::get<0>(hv),init_val);
 }
 
 template <typename T, typename N, typename F,
@@ -561,11 +659,12 @@ T Min (N n, F&& f, T init_val = std::numeric_limits<T>::max())
     ReduceData<T> reduce_data(reduce_op);
     using ReduceTuple = typename decltype(reduce_data)::Type;
     reduce_op.eval(n, reduce_data, [=] AMREX_GPU_DEVICE (N i) -> ReduceTuple { return {f(i)}; });
-    T tmp = amrex::get<0>(reduce_data.value());
-    return std::min(tmp,init_val);
+    ReduceTuple hv = reduce_data.value(reduce_op);
+    return std::min(amrex::get<0>(hv),init_val);
 }
 
 template <typename T, typename N, typename U, typename BOP, typename M=std::enable_if_t<std::is_integral<N>::value> >
+[[deprecated]]
 T Max (N n, U const* v, T init_val, BOP bop)
 {
     Gpu::LaunchSafeGuard lsg(true);
@@ -584,11 +683,7 @@ T Max (N n, U const* v, T init_val, BOP bop)
 #else
     [=] AMREX_GPU_DEVICE (T const& r) noexcept
     {
-#if defined(AMREX_USE_CUB)
         Gpu::deviceReduceMax_full<AMREX_GPU_MAX_THREADS>(dp, r);
-#else
-        Gpu::deviceReduceMax_full(dp, r);
-#endif
     });
 #endif
     return ds.dataValue();
@@ -597,7 +692,12 @@ T Max (N n, U const* v, T init_val, BOP bop)
 template <typename T, typename N, typename M=std::enable_if_t<std::is_integral<N>::value> >
 T Max (N n, T const* v, T init_val = std::numeric_limits<T>::lowest())
 {
-    return Reduce::Max(n, v, init_val, amrex::Greater<T>());
+    ReduceOps<ReduceOpMax> reduce_op;
+    ReduceData<T> reduce_data(reduce_op);
+    using ReduceTuple = typename decltype(reduce_data)::Type;
+    reduce_op.eval(n, reduce_data, [=] AMREX_GPU_DEVICE (N i) -> ReduceTuple { return {v[i]}; });
+    ReduceTuple hv = reduce_data.value(reduce_op);
+    return std::max(amrex::get<0>(hv),init_val);
 }
 
 template <typename T, typename N, typename F,
@@ -608,11 +708,12 @@ T Max (N n, F&& f, T init_val = std::numeric_limits<T>::lowest())
     ReduceData<T> reduce_data(reduce_op);
     using ReduceTuple = typename decltype(reduce_data)::Type;
     reduce_op.eval(n, reduce_data, [=] AMREX_GPU_DEVICE (N i) -> ReduceTuple { return {f(i)}; });
-    T tmp = amrex::get<0>(reduce_data.value());
-    return std::max(tmp,init_val);
+    ReduceTuple hv = reduce_data.value(reduce_op);
+    return std::max(amrex::get<0>(hv),init_val);
 }
 
 template <typename T, typename N, typename U, typename MINOP, typename MAXOP, typename M=std::enable_if_t<std::is_integral<N>::value> >
+[[deprecated]]
 std::pair<T,T> MinMax (N n, U const* v, MINOP minop, MAXOP maxop)
 {
     Gpu::LaunchSafeGuard lsg(true);
@@ -635,13 +736,8 @@ std::pair<T,T> MinMax (N n, U const* v, MINOP minop, MAXOP maxop)
 #else
     [=] AMREX_GPU_DEVICE (Real2 const& r) noexcept
     {
-#if defined(AMREX_USE_CUB)
         Gpu::deviceReduceMin_full<AMREX_GPU_MAX_THREADS>(dp  , r[0]);
         Gpu::deviceReduceMax_full<AMREX_GPU_MAX_THREADS>(dp+1, r[1]);
-#else
-        Gpu::deviceReduceMin_full(dp  , r[0]);
-        Gpu::deviceReduceMax_full(dp+1, r[1]);
-#endif
     });
 #endif
     Gpu::dtoh_memcpy(hv.data(), dp, 2*sizeof(T));
@@ -652,7 +748,14 @@ std::pair<T,T> MinMax (N n, U const* v, MINOP minop, MAXOP maxop)
 template <typename T, typename N, typename M=std::enable_if_t<std::is_integral<N>::value> >
 std::pair<T,T> MinMax (N n, T const* v)
 {
-    return Reduce::MinMax<T>(n, v, amrex::Less<T>(), amrex::Greater<T>());
+    ReduceOps<ReduceOpMin,ReduceOpMax> reduce_op;
+    ReduceData<T,T> reduce_data(reduce_op);
+    using ReduceTuple = typename decltype(reduce_data)::Type;
+    reduce_op.eval(n, reduce_data, [=] AMREX_GPU_DEVICE (N i) -> ReduceTuple {
+            return {v[i],v[i]};
+        });
+    auto hv = reduce_data.value(reduce_op);
+    return std::make_pair(amrex::get<0>(hv), amrex::get<1>(hv));
 }
 
 template <typename T, typename N, typename F,
@@ -666,7 +769,7 @@ std::pair<T,T> MinMax (N n, F&& f)
             T tmp = f(i);
             return {tmp,tmp};
         });
-    auto hv = reduce_data.value();
+    auto hv = reduce_data.value(reduce_op);
     return std::make_pair(amrex::get<0>(hv), amrex::get<1>(hv));
 }
 
@@ -805,10 +908,13 @@ public:
     using Type = GpuTuple<Ts...>;
 
     template <typename... Ps>
-    explicit ReduceData (ReduceOps<Ps...> const&)
-        : m_tuple()
+    explicit ReduceData (ReduceOps<Ps...>& reduce_op)
+        : m_tuple(OpenMP::in_parallel() ? 1 : OpenMP::get_max_threads()),
+          m_fn_value([&reduce_op,this] () -> Type { return this->value(reduce_op); })
     {
-        Reduce::detail::for_each_init<0, Type, Ps...>(m_tuple);
+        for (auto& t : m_tuple) {
+            Reduce::detail::for_each_init<0, Type, Ps...>(t);
+        }
     }
 
     ReduceData (ReduceData<Ts...> const&) = delete;
@@ -816,15 +922,30 @@ public:
     void operator= (ReduceData<Ts...> const&) = delete;
     void operator= (ReduceData<Ts...> &&) = delete;
 
-    Type value () const
+    [[deprecated("Use value (ReduceOps<Ps...>&) instead.")]]
+    Type value () { return m_fn_value(); }
+
+    template <typename... Ps>
+    Type value (ReduceOps<Ps...>& reduce_op)
     {
-        return m_tuple;
+        return reduce_op.value(*this);
     }
 
-    Type& reference () { return m_tuple; }
+    Vector<Type>& reference () { return m_tuple; }
+
+    Type& reference (int tid)
+    {
+        if (m_tuple.size() == 1) {
+            // No OpenMP or already inside OpenMP parallel when reduce_data is constructed
+            return m_tuple[0];
+        } else {
+            return m_tuple[tid];
+        }
+    }
 
 private:
-    Type m_tuple;
+    Vector<Type> m_tuple;
+    std::function<Type()> m_fn_value;
 };
 
 template <typename... Ps>
@@ -834,29 +955,28 @@ private:
 
     template <typename D, typename F>
     AMREX_FORCE_INLINE
-    static auto call_f (Box const& box, D & /*reduce_data*/, F const& f)
-        noexcept -> decltype(f(0,0,0))
+    static auto call_f (Box const& box, typename D::Type & r, F const& f)
+        noexcept -> std::enable_if_t<std::is_same<std::decay_t<decltype(f(0,0,0))>,
+                                                  typename D::Type>::value>
     {
         using ReduceTuple = typename D::Type;
-        ReduceTuple r;
-        Reduce::detail::for_each_init<0, ReduceTuple, Ps...>(r);
         const auto lo = amrex::lbound(box);
         const auto hi = amrex::ubound(box);
         for (int k = lo.z; k <= hi.z; ++k) {
         for (int j = lo.y; j <= hi.y; ++j) {
         for (int i = lo.x; i <= hi.x; ++i) {
-            auto pr = f(i,j,k);
-            Reduce::detail::for_each_local<0, ReduceTuple, Ps...>(r, pr);
+            Reduce::detail::for_each_local<0, ReduceTuple, Ps...>(r, f(i,j,k));
         }}}
-        return r;
     }
 
     template <typename D, typename F>
     AMREX_FORCE_INLINE
-    static auto call_f (Box const& box, D&, F const& f)
-        noexcept -> decltype(f(Box()))
+    static auto call_f (Box const& box, typename D::Type & r, F const& f)
+        noexcept -> std::enable_if_t<std::is_same<std::decay_t<decltype(f(Box()))>,
+                                                  typename D::Type>::value>
     {
-        return f(box);
+        using ReduceTuple = typename D::Type;
+        Reduce::detail::for_each_local<0, ReduceTuple, Ps...>(r, f(box));
     }
 
 public:
@@ -864,10 +984,8 @@ public:
     template <typename D, typename F>
     void eval (Box const& box, D & reduce_data, F&& f)
     {
-        using ReduceTuple = typename D::Type;
-        ReduceTuple& rr = reduce_data.reference();
-        auto r = call_f(box, reduce_data, f);
-        Reduce::detail::for_each_parallel<0, ReduceTuple, Ps...>(rr,r);
+        auto& rr = reduce_data.reference(OpenMP::get_thread_num());
+        call_f<D>(box, rr, f);
     }
 
     template <typename N, typename D, typename F,
@@ -875,19 +993,15 @@ public:
     void eval (Box const& box, N ncomp, D & reduce_data, F&& f)
     {
         using ReduceTuple = typename D::Type;
-        ReduceTuple r;
-        Reduce::detail::for_each_init<0, ReduceTuple, Ps...>(r);
-        ReduceTuple& rr = reduce_data.reference();
+        auto& rr = reduce_data.reference(OpenMP::get_thread_num());
         const auto lo = amrex::lbound(box);
         const auto hi = amrex::ubound(box);
         for (N n = 0; n < ncomp; ++n) {
         for (int k = lo.z; k <= hi.z; ++k) {
         for (int j = lo.y; j <= hi.y; ++j) {
         for (int i = lo.x; i <= hi.x; ++i) {
-            auto pr = f(i,j,k,n);
-            Reduce::detail::for_each_local<0, ReduceTuple, Ps...>(r, pr);
+            Reduce::detail::for_each_local<0, ReduceTuple, Ps...>(rr, f(i,j,k,n));
         }}}}
-        Reduce::detail::for_each_parallel<0, ReduceTuple, Ps...>(rr,r);
     }
 
     template <typename N, typename D, typename F,
@@ -895,20 +1009,30 @@ public:
     void eval (N n, D & reduce_data, F&& f)
     {
         using ReduceTuple = typename D::Type;
-        ReduceTuple r;
-        Reduce::detail::for_each_init<0, ReduceTuple, Ps...>(r);
-        ReduceTuple& rr = reduce_data.reference();
+        auto& rr = reduce_data.reference(OpenMP::get_thread_num());
         for (N i = 0; i < n; ++i) {
-            auto pr = f(i);
-            Reduce::detail::for_each_local<0, ReduceTuple, Ps...>(r, pr);
+            Reduce::detail::for_each_local<0, ReduceTuple, Ps...>(rr, f(i));
         }
-        Reduce::detail::for_each_parallel<0, ReduceTuple, Ps...>(rr,r);
+    }
+
+    template <typename D>
+    typename D::Type value (D & reduce_data)
+    {
+        using ReduceTuple = typename D::Type;
+        auto& rrv = reduce_data.reference();
+        if (rrv.size() > 1) {
+            for (int i = 1, N = rrv.size(); i < N; ++i) {
+                Reduce::detail::for_each_local<0, ReduceTuple, Ps...>(rrv[0], rrv[i]);
+            }
+        }
+        return rrv[0];
     }
 };
 
 namespace Reduce {
 
 template <typename T, typename N, typename U, typename BOP, typename M=std::enable_if_t<std::is_integral<N>::value> >
+[[deprecated]]
 T Sum (N n, U const* v, T init_val, BOP bop)
 {
     T sum = init_val;
@@ -946,6 +1070,7 @@ T Sum (N n, T const* v, T init_val = 0)
 }
 
 template <typename T, typename N, typename U, typename BOP, typename M=std::enable_if_t<std::is_integral<N>::value> >
+[[deprecated]]
 T Min (N n, U const* v, T init_val, BOP bop)
 {
     T mn = init_val;
@@ -983,6 +1108,7 @@ T Min (N n, T const* v, T init_val = std::numeric_limits<T>::max())
 }
 
 template <typename T, typename N, typename U, typename BOP, typename M=std::enable_if_t<std::is_integral<N>::value> >
+[[deprecated]]
 T Max (N n, U const* v, T init_val, BOP bop)
 {
     T mx = init_val;
@@ -1020,6 +1146,7 @@ T Max (N n, T const* v, T init_val = std::numeric_limits<T>::lowest())
 }
 
 template <typename T, typename N, typename U, typename MINOP, typename MAXOP, typename M=std::enable_if_t<std::is_integral<N>::value> >
+[[deprecated]]
 std::pair<T,T> MinMax (N n, U const* v, MINOP minop, MAXOP maxop)
 {
     Array<T,2> hv{std::numeric_limits<T>::max(), std::numeric_limits<T>::lowest()};

--- a/Src/Base/AMReX_Tuple.H
+++ b/Src/Base/AMReX_Tuple.H
@@ -93,6 +93,7 @@ class GpuTuple
     : public detail::gpu_tuple_impl<0, Ts...>
 {
 public:
+    AMREX_GPU_HOST_DEVICE // Some versions of nvcc require this in debug build
     constexpr GpuTuple () = default;
 
     constexpr GpuTuple (Ts const&... args)

--- a/Src/Base/AMReX_iMultiFab.cpp
+++ b/Src/Base/AMReX_iMultiFab.cpp
@@ -346,7 +346,7 @@ iMultiFab::sum (int comp, int nghost, bool local) const
             points += bx.numPts();
         }
 
-        ReduceTuple hv = reduce_data.value();
+        ReduceTuple hv = reduce_data.value(reduce_op);
         sm = static_cast<Long>( static_cast<long long>(amrex::get<0>(hv))
                               + static_cast<long long>(INT_MIN)*points);
     }

--- a/Src/EB/AMReX_EB2_GeometryShop.H
+++ b/Src/EB/AMReX_EB2_GeometryShop.H
@@ -269,7 +269,7 @@ public:
                 }
                 return {nbody,nzero,nfluid};
             });
-            ReduceTuple hv = reduce_data.value();
+            ReduceTuple hv = reduce_data.value(reduce_op);
             int nbody = amrex::get<0>(hv);
             // int nzero = amrex::get<1>(hv);
             int nfluid = amrex::get<2>(hv);

--- a/Src/EB/AMReX_EB2_Level.cpp
+++ b/Src/EB/AMReX_EB2_Level.cpp
@@ -152,7 +152,7 @@ Level::coarsenFromFine (Level& fineLevel, bool fill_boundary)
                 return {ierror};
             });
         }
-        ReduceTuple rv = reduce_data.value();
+        ReduceTuple rv = reduce_data.value(reduce_op);
         mvmc_error = amrex::max(0, amrex::get<0>(rv));
     }
 
@@ -378,7 +378,7 @@ Level::coarsenFromFine (Level& fineLevel, bool fill_boundary)
             });
         }
 
-        ReduceTuple rv = reduce_data.value();
+        ReduceTuple rv = reduce_data.value(reduce_op);
         error = amrex::max(0, amrex::get<0>(rv));
     }
 

--- a/Src/EB/AMReX_EBCellFlag.cpp
+++ b/Src/EB/AMReX_EBCellFlag.cpp
@@ -72,7 +72,7 @@ EBCellFlagFab::getType (const Box& bx_in) const noexcept
                     }
                     return {nr, ns, nm, nc};
                 });
-                ReduceTuple hv = reduce_data.value();
+                ReduceTuple hv = reduce_data.value(reduce_op);
                 nregular = amrex::get<0>(hv);
                 nsingle  = amrex::get<1>(hv);
                 nmulti   = amrex::get<2>(hv);

--- a/Src/LinearSolvers/MLMG/AMReX_MLCellABecLap.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLCellABecLap.cpp
@@ -85,7 +85,7 @@ MLCellABecLap::define (const Vector<Geometry>& a_geom,
                     return { coarsen_overset_mask(b, cmsk, fmsk) };
                 });
             }
-            ReduceTuple hv = reduce_data.value();
+            ReduceTuple hv = reduce_data.value(reduce_op);
             if (amrex::get<0>(hv) == 0) {
                 m_overset_mask[amrlev].push_back(std::move(crse));
             } else {

--- a/Src/Particle/AMReX_ParticleContainerI.H
+++ b/Src/Particle/AMReX_ParticleContainerI.H
@@ -404,7 +404,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>::Nu
                                return (pstruct[i].id() > 0) ? 1 : 0;
                            });
 
-            int np_valid = amrex::get<0>(reduce_data.value());
+            int np_valid = amrex::get<0>(reduce_data.value(reduce_op));
             np_per_grid_local[gid] += np_valid;
         } else
         {
@@ -456,7 +456,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>::Nu
                                return (pp[i].id() > 0) ? 1 : 0;
                            });
         }
-        nparticles = static_cast<Long>(amrex::get<0>(reduce_data.value()));
+        nparticles = static_cast<Long>(amrex::get<0>(reduce_data.value(reduce_op)));
     }
     else {
         for (const auto& kv : GetParticles(lev)) {

--- a/Src/Particle/AMReX_ParticleInit.H
+++ b/Src/Particle/AMReX_ParticleInit.H
@@ -545,9 +545,9 @@ InitFromBinaryFile (const std::string& file,
 
                 readers.insert(n);
             }
-            while (readers.size() < NReaders);
+            while (static_cast<int>(readers.size()) < NReaders);
 
-            AMREX_ASSERT(readers.size() == rprocs.size());
+            AMREX_ASSERT(static_cast<Long>(readers.size()) == rprocs.size());
 
             int i = 0;
 
@@ -569,7 +569,7 @@ InitFromBinaryFile (const std::string& file,
         //
         readers.insert(rprocs.begin(), rprocs.end());
 
-        AMREX_ASSERT(readers.size() == rprocs.size());
+        AMREX_ASSERT(static_cast<Long>(readers.size()) == rprocs.size());
 
         AMREX_ASSERT(rprocs.size() == NReaders);
     }

--- a/Src/Particle/AMReX_ParticleLocator.H
+++ b/Src/Particle/AMReX_ParticleLocator.H
@@ -124,7 +124,7 @@ public:
                     AMREX_D_DECL(si[0], si[1], si[2])};
         });
 
-        ReduceTuple hv = reduce_data.value();
+        ReduceTuple hv = reduce_data.value(reduce_op);
 
         m_bins_lo  = IntVect(AMREX_D_DECL(amrex::get<0>(hv),
                                           amrex::get<1>(hv),

--- a/Src/Particle/AMReX_ParticleReduce.H
+++ b/Src/Particle/AMReX_ParticleReduce.H
@@ -112,7 +112,7 @@ ReduceSum (PC const& pc, int lev_min, int lev_max, F&& f) -> decltype(f(typename
             }
         }
 
-        ReduceTuple hv = reduce_data.value();
+        ReduceTuple hv = reduce_data.value(reduce_op);
         sm = amrex::get<0>(hv);
     }
     else
@@ -236,7 +236,7 @@ ReduceMax (PC const& pc, int lev_min, int lev_max, F&& f) -> decltype(f(typename
             }
         }
 
-        ReduceTuple hv = reduce_data.value();
+        ReduceTuple hv = reduce_data.value(reduce_op);
         r = amrex::get<0>(hv);
     }
     else
@@ -360,7 +360,7 @@ ReduceMin (PC const& pc, int lev_min, int lev_max, F&& f) -> decltype(f(typename
             }
         }
 
-        ReduceTuple hv = reduce_data.value();
+        ReduceTuple hv = reduce_data.value(reduce_op);
         r = amrex::get<0>(hv);
     }
     else
@@ -482,7 +482,7 @@ ReduceLogicalAnd (PC const& pc, int lev_min, int lev_max, F&& f)
             }
         }
 
-        ReduceTuple hv = reduce_data.value();
+        ReduceTuple hv = reduce_data.value(reduce_op);
         r = amrex::get<0>(hv);
     }
     else
@@ -604,7 +604,7 @@ ReduceLogicalOr (PC const& pc, int lev_min, int lev_max, F&& f)
             }
         }
 
-        ReduceTuple hv = reduce_data.value();
+        ReduceTuple hv = reduce_data.value(reduce_op);
         r = amrex::get<0>(hv);
     }
     else

--- a/Src/Particle/AMReX_ParticleUtil.H
+++ b/Src/Particle/AMReX_ParticleUtil.H
@@ -158,7 +158,7 @@ numParticlesOutOfRange (Iterator const& pti, IntVect nGrow)
         iv += domain.smallEnd();
         return !box.contains(iv);
     });
-    int hv = amrex::get<0>(reduce_data.value());
+    int hv = amrex::get<0>(reduce_data.value(reduce_op));
     return hv;
 }
 

--- a/Src/Particle/AMReX_WriteBinaryParticleData.H
+++ b/Src/Particle/AMReX_WriteBinaryParticleData.H
@@ -374,7 +374,7 @@ void WriteBinaryParticleDataAsync (PC const& pc,
                 return (pstruct[i].id() > 0) ? 1 : 0;
             });
 
-            int np_valid = amrex::get<0>(reduce_data.value());
+            int np_valid = amrex::get<0>(reduce_data.value(reduce_op));
             np_per_grid_local[lev][gid] += np_valid;
         }
     }

--- a/Tests/Particles/Intersection/main.cpp
+++ b/Tests/Particles/Intersection/main.cpp
@@ -104,7 +104,7 @@ void testIntersection()
                 return {grids_ptr[j] != i};
             });
 
-            ReduceTuple hv = reduce_data.value();
+            ReduceTuple hv = reduce_data.value(reduce_op);
 
             int num_wrong = amrex::get<0>(hv);
             AMREX_ALWAYS_ASSERT(num_wrong == 0);


### PR DESCRIPTION
The new approach does reduction in two passes. Unlike the old approach, this
does not require atomics, and has much better performance for types that do
not have hardware support for atomics.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
