### PR TITLE
CPU version of TagBox::buffer

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -318,7 +318,7 @@ jobs:
     - name: Build & Install
       run: |
         ./configure --dim 2 --with-fortran no --comp llvm --with-mpi no
-        make -j2 WARN_ALL=TRUE WARN_ERROR=TRUE XTRA_CXXFLAGS="-fno-operator-names -Wno-error=c++17-extensions"
+        make -j2 WARN_ALL=TRUE WARN_ERROR=TRUE XTRA_CXXFLAGS="-fno-operator-names -Wno-c++17-extensions"
         make install
 
   # Build 3D libamrex with configure

--- a/Src/AmrCore/AMReX_TagBox.H
+++ b/Src/AmrCore/AMReX_TagBox.H
@@ -63,10 +63,13 @@ public:
 
     /**
     * \brief Mark neighbors of every tagged cell a distance nbuff away
+    * only search interior for initial tagged points where nwid
+    * is given as the width of the bndry region.
     *
     * \param nbuff
+    * \param nwid
     */
-    void buffer (const IntVect& nbuf) noexcept;
+    void buffer (const IntVect& nbuf, const IntVect& nwid) noexcept;
 
     /**
     * \brief Returns Vector\<int\> of size domain.numPts() suitable for calling


### PR DESCRIPTION
Add a CPU version of TagBox::buffer.  @MSABuschman reported in #1951 that
TagBox::buffer has been very slow since commit #1258 if the error buffer
size is large.  The function was rewritten in #1258 to do the work on GPU.
In this PR, the old version is reintroduced for CPU.

Note that the current implementation is expected to have poor performance on
GPU if it has a very large error buffer.  It's still not clear how we should
implement this function for GPU if a large error buffer is used.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
