### PR TITLE
DPCPP: fix atomicAdd for float

### DIFF
--- a/Src/Base/AMReX_GpuAtomic.H
+++ b/Src/Base/AMReX_GpuAtomic.H
@@ -82,7 +82,7 @@ namespace detail {
         constexpr auto mo = sycl::memory_order::relaxed;
         constexpr auto as = sycl::access::address_space::global_space;
         sycl::atomic<T,as> a{sycl::multi_ptr<T,as>(sum)};
-        return sycl::atomic_fetch_add(a, value, mo);
+        return a.fetch_add(value, mo);
 #else
         amrex::ignore_unused(sum, value);
         return T(); // should never get here, but have to return something
@@ -98,6 +98,12 @@ namespace detail {
     double Add_device (double* const sum, double const value) noexcept
     {
         return detail::atomic_op<double, unsigned long long>(sum, value, amrex::Plus<double>());
+    }
+
+    AMREX_GPU_DEVICE AMREX_FORCE_INLINE
+    float Add_device (float* const sum, float const value) noexcept
+    {
+        return detail::atomic_op<float, unsigned int>(sum, value, amrex::Plus<float>());
     }
 
 #elif defined(AMREX_USE_CUDA) || defined(AMREX_USE_HIP)
@@ -182,7 +188,7 @@ namespace detail {
         constexpr auto mo = sycl::memory_order::relaxed;
         constexpr auto as = sycl::access::address_space::global_space;
         sycl::atomic<T,as> a{sycl::multi_ptr<T,as>(m)};
-        return sycl::atomic_fetch_min(a, value, mo);
+        return a.fetch_min(value, mo);
 #else
         amrex::ignore_unused(m,value);
         return T(); // should never get here, but have to return something
@@ -242,7 +248,7 @@ namespace detail {
         constexpr auto mo = sycl::memory_order::relaxed;
         constexpr auto as = sycl::access::address_space::global_space;
         sycl::atomic<T,as> a{sycl::multi_ptr<T,as>(m)};
-        return sycl::atomic_fetch_max(a, value, mo);
+        return a.fetch_max(value, mo);
 #else
         amrex::ignore_unused(m,value);
         return T(); // should never get here, but have to return something
@@ -299,7 +305,7 @@ namespace detail {
         constexpr auto mo = sycl::memory_order::relaxed;
         constexpr auto as = sycl::access::address_space::global_space;
         sycl::atomic<int,as> a{sycl::multi_ptr<int,as>(m)};
-        return sycl::atomic_fetch_or(a, value, mo);
+        return a.fetch_or(value, mo);
 #else
         int const old = *m;
         *m = (*m) || value;
@@ -320,7 +326,7 @@ namespace detail {
         constexpr auto mo = sycl::memory_order::relaxed;
         constexpr auto as = sycl::access::address_space::global_space;
         sycl::atomic<int,as> a{sycl::multi_ptr<int,as>(m)};
-        return sycl::atomic_fetch_and(a, value ? ~0x0 : 0, mo);
+        return a.fetch_and(value ? ~0x0 : 0, mo);
 #else
         int const old = *m;
         *m = (*m) && value;

--- a/Tests/Amr/Advection_AmrCore/Source/Src_K/slope_K.H
+++ b/Tests/Amr/Advection_AmrCore/Source/Src_K/slope_K.H
@@ -21,11 +21,11 @@ void slopex2(amrex::Box const& bx,
             for (int i = lo.x; i <= hi.x; ++i) {
                 Real dlft = q(i,j,k) - q(i-1,j,k);
                 Real drgt = q(i+1,j,k) - q(i,j,k);
-                Real dcen = 0.5*(dlft+drgt);
-                Real dsgn = amrex::Math::copysign(1.0, dcen);
-                Real dslop = 2.0 * ((amrex::Math::abs(dlft) < amrex::Math::abs(drgt)) ?
-                                     amrex::Math::abs(dlft) : amrex::Math::abs(drgt));
-                Real dlim = (dlft*drgt >= 0.0) ? dslop : 0.0;
+                Real dcen = Real(0.5)*(dlft+drgt);
+                Real dsgn = amrex::Math::copysign(Real(1.0), dcen);
+                Real dslop = Real(2.0) * ((amrex::Math::abs(dlft) < amrex::Math::abs(drgt)) ?
+                                           amrex::Math::abs(dlft) : amrex::Math::abs(drgt));
+                Real dlim = (dlft*drgt >= Real(0.0)) ? dslop : Real(0.0);
                 dq(i,j,k) = dsgn*amrex::min(dlim, amrex::Math::abs(dcen));
             }
         }
@@ -49,12 +49,12 @@ void slopex4(amrex::Box const& bx,
             for (int i = lo.x; i <= hi.x; ++i) {
                 Real dlft = q(i,j,k) - q(i-1,j,k);
                 Real drgt = q(i+1,j,k) - q(i,j,k);
-                Real dcen = 0.5*(dlft+drgt);
-                Real dsgn = amrex::Math::copysign(1.0, dcen);
-                Real dslop = 2.0 * ((amrex::Math::abs(dlft) < amrex::Math::abs(drgt)) ?
-                                     amrex::Math::abs(dlft) : amrex::Math::abs(drgt));
-                Real dlim = (dlft*drgt >= 0.0) ? dslop : 0.0;
-                Real dq1 = 4.0/3.0*dcen - (1.0/6.0)*(dq(i+1,j,k) + dq(i-1,j,k));
+                Real dcen = Real(0.5)*(dlft+drgt);
+                Real dsgn = amrex::Math::copysign(Real(1.0), dcen);
+                Real dslop = Real(2.0) * ((amrex::Math::abs(dlft) < amrex::Math::abs(drgt)) ?
+                                           amrex::Math::abs(dlft) : amrex::Math::abs(drgt));
+                Real dlim = (dlft*drgt >= Real(0.0)) ? dslop : Real(0.0);
+                Real dq1 = Real(4.0/3.0)*dcen - Real(1.0/6.0)*(dq(i+1,j,k) + dq(i-1,j,k));
                 dq4(i,j,k) = dsgn*amrex::min(dlim, amrex::Math::abs(dq1));
             }
         }
@@ -79,11 +79,11 @@ void slopey2(amrex::Box const& bx,
             for (int i = lo.x; i <= hi.x; ++i) {
                 Real dlft = q(i,j,k) - q(i,j-1,k);
                 Real drgt = q(i,j+1,k) - q(i,j,k);
-                Real dcen = 0.5*(dlft+drgt);
-                Real dsgn = amrex::Math::copysign(1.0, dcen);
-                Real dslop = 2.0 * ((amrex::Math::abs(dlft) < amrex::Math::abs(drgt)) ?
-                                     amrex::Math::abs(dlft) : amrex::Math::abs(drgt));
-                Real dlim = (dlft*drgt >= 0.0) ? dslop : 0.0;
+                Real dcen = Real(0.5)*(dlft+drgt);
+                Real dsgn = amrex::Math::copysign(Real(1.0), dcen);
+                Real dslop = Real(2.0) * ((amrex::Math::abs(dlft) < amrex::Math::abs(drgt)) ?
+                                           amrex::Math::abs(dlft) : amrex::Math::abs(drgt));
+                Real dlim = (dlft*drgt >= Real(0.0)) ? dslop : Real(0.0);
                 dq(i,j,k) = dsgn*amrex::min(dlim, amrex::Math::abs(dcen));
             }
         }
@@ -107,12 +107,12 @@ void slopey4(amrex::Box const& bx,
             for (int i = lo.x; i <= hi.x; ++i) {
                 Real dlft = q(i,j,k) - q(i,j-1,k);
                 Real drgt = q(i,j+1,k) - q(i,j,k);
-                Real dcen = 0.5*(dlft+drgt);
-                Real dsgn = amrex::Math::copysign(1.0, dcen);
-                Real dslop = 2.0 * ((amrex::Math::abs(dlft) < amrex::Math::abs(drgt)) ?
-                                     amrex::Math::abs(dlft) : amrex::Math::abs(drgt));
-                Real dlim = (dlft*drgt >= 0.0) ? dslop : 0.0;
-                Real dq1 = 4.0/3.0*dcen - (1.0/6.0)*(dq(i,j+1,k) + dq(i,j-1,k));
+                Real dcen = Real(0.5)*(dlft+drgt);
+                Real dsgn = amrex::Math::copysign(Real(1.0), dcen);
+                Real dslop = Real(2.0) * ((amrex::Math::abs(dlft) < amrex::Math::abs(drgt)) ?
+                                           amrex::Math::abs(dlft) : amrex::Math::abs(drgt));
+                Real dlim = (dlft*drgt >= Real(0.0)) ? dslop : Real(0.0);
+                Real dq1 = Real(4.0/3.0)*dcen - Real(1.0/6.0)*(dq(i,j+1,k) + dq(i,j-1,k));
                 dq4(i,j,k) = dsgn*amrex::min(dlim, amrex::Math::abs(dq1));
             }
         }
@@ -137,11 +137,11 @@ void slopez2(amrex::Box const& bx,
             for (int i = lo.x; i <= hi.x; ++i) {
                 Real dlft = q(i,j,k) - q(i,j,k-1);
                 Real drgt = q(i,j,k+1) - q(i,j,k);
-                Real dcen = 0.5*(dlft+drgt);
-                Real dsgn = amrex::Math::copysign(1.0, dcen);
-                Real dslop = 2.0 * ((amrex::Math::abs(dlft) < amrex::Math::abs(drgt)) ?
-                                     amrex::Math::abs(dlft) : amrex::Math::abs(drgt));
-                Real dlim = (dlft*drgt >= 0.0) ? dslop : 0.0;
+                Real dcen = Real(0.5)*(dlft+drgt);
+                Real dsgn = amrex::Math::copysign(Real(1.0), dcen);
+                Real dslop = Real(2.0) * ((amrex::Math::abs(dlft) < amrex::Math::abs(drgt)) ?
+                                           amrex::Math::abs(dlft) : amrex::Math::abs(drgt));
+                Real dlim = (dlft*drgt >= Real(0.0)) ? dslop : Real(0.0);
                 dq(i,j,k) = dsgn*amrex::min(dlim, amrex::Math::abs(dcen));
             }
         }
@@ -165,12 +165,12 @@ void slopez4(amrex::Box const& bx,
             for (int i = lo.x; i <= hi.x; ++i) {
                 Real dlft = q(i,j,k) - q(i,j,k-1);
                 Real drgt = q(i,j,k+1) - q(i,j,k);
-                Real dcen = 0.5*(dlft+drgt);
-                Real dsgn = amrex::Math::copysign(1.0, dcen);
-                Real dslop = 2.0 * ((amrex::Math::abs(dlft) < amrex::Math::abs(drgt)) ?
-                                     amrex::Math::abs(dlft) : amrex::Math::abs(drgt));
-                Real dlim = (dlft*drgt >= 0.0) ? dslop : 0.0;
-                Real dq1 = 4.0/3.0*dcen - (1.0/6.0)*(dq(i,j,k+1) + dq(i,j,k-1));
+                Real dcen = Real(0.5)*(dlft+drgt);
+                Real dsgn = amrex::Math::copysign(Real(1.0), dcen);
+                Real dslop = Real(2.0) * ((amrex::Math::abs(dlft) < amrex::Math::abs(drgt)) ?
+                                           amrex::Math::abs(dlft) : amrex::Math::abs(drgt));
+                Real dlim = (dlft*drgt >= Real(0.0)) ? dslop : Real(0.0);
+                Real dq1 = Real(4.0/3.0)*dcen - Real(1.0/6.0)*(dq(i,j,k+1) + dq(i,j,k-1));
                 dq4(i,j,k) = dsgn*amrex::min(dlim, amrex::Math::abs(dq1));
             }
         }


### PR DESCRIPTION
We recently removed the template specialization for atomicAdd of float in
the DPC++ backend.  That was a mistake because SYCL does not support
atomicAdd for float, and we have to use atomicCAS to implement it.

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
