### PR TITLE
CMake: implement logic to support compiler ID IntelLLVM (new in CMake 3.20)

### DIFF
--- a/Tools/CMake/AMReXFlagsTargets.cmake
+++ b/Tools/CMake/AMReXFlagsTargets.cmake
@@ -27,7 +27,7 @@ foreach (_language CXX Fortran )
    set(_comp_lang   "$<COMPILE_LANGUAGE:${_language}>")
    string(TOLOWER "${_language}" _lang)
 
-   foreach (_comp GNU Intel PGI Cray Clang AppleClang MSVC )
+   foreach (_comp GNU Intel PGI Cray Clang AppleClang IntelLLVM MSVC )
       string(TOLOWER "${_comp}" _id)
       # Define variables
       set(_comp_id              "$<${_language}_COMPILER_ID:${_comp}>")
@@ -70,6 +70,9 @@ target_compile_options( Flags_CXX
    $<${_cxx_appleclang_dbg}:-O0 -Wall -Wextra -Wno-sign-compare -Wno-unused-parameter -Wno-unused-variable -Wno-pass-failed>
    $<${_cxx_appleclang_rwdbg}:-Wno-pass-failed>
    $<${_cxx_appleclang_rel}:-Wno-pass-failed>
+   $<${_cxx_intelllvm_dbg}:-O0 -Wall -Wextra -Wno-sign-compare -Wno-unused-parameter -Wno-unused-variable -Wno-pass-failed>
+   $<${_cxx_intelllvm_rwdbg}:-Wno-pass-failed>
+   $<${_cxx_intelllvm_rel}:-Wno-pass-failed>
    )
 
 #

--- a/Tools/CMake/AMReXGenerateConfigHeader.cmake
+++ b/Tools/CMake/AMReXGenerateConfigHeader.cmake
@@ -41,9 +41,9 @@ function ( generate_config_header )
            set(COMPILER_ID_MACRO  __CRAYC)
        elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "PGI" )
            set(COMPILER_ID_MACRO  __PGI)
-       elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" )
-           set(COMPILER_ID_MACRO  __llvm__)
-       elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "AppleClang" )
+       elseif ( ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" )       OR
+                ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "AppleClang" )  OR
+                ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "IntelLLVM" )   )
            set(COMPILER_ID_MACRO  __llvm__)
        elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC" )
            set(COMPILER_ID_MACRO  _MSC_VER)

--- a/Tools/CMake/AMReXOptions.cmake
+++ b/Tools/CMake/AMReXOptions.cmake
@@ -136,7 +136,7 @@ endif ()
 
 # --- SYCL ---
 if (AMReX_DPCPP)
-   set(_valid_dpcpp_compiler_ids Clang IntelClang IntelDPCPP)
+   set(_valid_dpcpp_compiler_ids Clang IntelClang IntelDPCPP IntelLLVM)
    if (NOT (CMAKE_CXX_COMPILER_ID IN_LIST _valid_dpcpp_compiler_ids) )
       message(WARNING "\nAMReX_GPU_BACKEND=${AMReX_GPU_BACKEND} is tested with "
          "DPCPP. Verify '${CMAKE_CXX_COMPILER_ID}' is correct and potentially "

--- a/Tools/CMake/AMReXSYCL.cmake
+++ b/Tools/CMake/AMReXSYCL.cmake
@@ -28,7 +28,7 @@ if (DPCPP_BETA_VERSION LESS "09")
 endif ()
 
 
-set(_cxx_dpcpp "$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:IntelClang>,$<CXX_COMPILER_ID:IntelDPCPP>>")
+set(_cxx_dpcpp "$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:IntelClang>,$<CXX_COMPILER_ID:IntelDPCPP>,$<CXX_COMPILER_ID:IntelLLVM>")
 set(_cxx_dpcpp "$<AND:$<COMPILE_LANGUAGE:CXX>,${_cxx_dpcpp}>")
 
 #

--- a/Tools/CMake/AMReXSYCL.cmake
+++ b/Tools/CMake/AMReXSYCL.cmake
@@ -28,7 +28,7 @@ if (DPCPP_BETA_VERSION LESS "09")
 endif ()
 
 
-set(_cxx_dpcpp "$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:IntelClang>,$<CXX_COMPILER_ID:IntelDPCPP>,$<CXX_COMPILER_ID:IntelLLVM>")
+set(_cxx_dpcpp "$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:IntelClang>,$<CXX_COMPILER_ID:IntelDPCPP>,$<CXX_COMPILER_ID:IntelLLVM>>")
 set(_cxx_dpcpp "$<AND:$<COMPILE_LANGUAGE:CXX>,${_cxx_dpcpp}>")
 
 #


### PR DESCRIPTION
## Summary

## Additional background

CMake 3.20+ has its own compiler identification for the new oneAPI LLVM-ICX/DPCXX implementation.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
