### PR TITLE
GNU Make: -MMD -MP

### DIFF
--- a/Tools/GNUMake/Make.defs
+++ b/Tools/GNUMake/Make.defs
@@ -362,9 +362,7 @@ else
   LOG_BUILD_TIME := FALSE
 endif
 
-ifeq ($(LOG_BUILD_TIME),TRUE)
-  build_time_begin := $(shell date +"%s")
-endif
+build_time_begin := $(shell date +"%s")
 
 ALLOW_DIFFERENT_COMP ?= TRUE
 SKIP_LINKING ?= FALSE
@@ -386,7 +384,9 @@ MKCONFIG        = $(AMREX_HOME)/Tools/libamrex/mkconfig.py
 MKPKGCONFIG     = $(AMREX_HOME)/Tools/libamrex/mkpkgconfig.py
 GATHERBUILDTIME = $(AMREX_HOME)/Tools/C_scripts/gatherbuildtime.py
 
-DEPFLAGS        = -MM
+USE_LEGACY_DEPFLAGS = FALSE
+DEPFLAGS = -MMD -MP
+LEGACY_DEPFLAGS = -MM
 
 RANLIB          = ranlib
 

--- a/Tools/GNUMake/Make.rules
+++ b/Tools/GNUMake/Make.rules
@@ -40,8 +40,8 @@ else
 endif
 endif
 
-CXXDEPFLAGS = $(DEPFLAGS) $(filter-out -dc,$(CXXFLAGS)) $(CPPFLAGS) $(includes)
-CDEPFLAGS = $(DEPFLAGS) $(filter-out -dc,$(CFLAGS)) -DBL_LANG_C -DAMREX_LANG_C $(CPPFLAGS) $(includes)
+CXXDEPFLAGS = $(LEGACY_DEPFLAGS) $(filter-out -dc,$(CXXFLAGS)) $(CPPFLAGS) $(includes)
+CDEPFLAGS = $(LEGACY_DEPFLAGS) $(filter-out -dc,$(CFLAGS)) -DBL_LANG_C -DAMREX_LANG_C $(CPPFLAGS) $(includes)
 
 #
 # Rules for building executable.
@@ -74,7 +74,7 @@ else
 
 # multiple executables
 %.$(machineSuffix).ex:%.cpp $(objForExecs)
-	$(SLIENT) $(CCACHE) $(CXX) $(CXXFLAGS) $(EXTRACXXFLAGS) $(CPPFLAGS) $(includes) -c $< -o $(objEXETempDir)/$(subst /,_,$<).o
+	$(SLIENT) $(CCACHE) $(CXX) $(DEPFLAGS) $(CXXFLAGS) $(EXTRACXXFLAGS) $(CPPFLAGS) $(includes) -c $< -o $(objEXETempDir)/$(subst /,_,$<).o
 	@echo "Linking $@ ..."
 	$(SLIENT) $(AMREX_LINKER) $(LINKFLAGS) $(CPPFLAGS) $(includes) $(LDFLAGS) -o $@ $(objEXETempDir)/$(subst /,_,$<).o $(objForExecs) $(FINAL_LIBS)
 
@@ -194,26 +194,26 @@ FORCE:
 #
 # Rules for objects.
 #
-$(objEXETempDir)/%.o: %.cpp
+$(objEXETempDir)/%.o: %.cpp AMReX_Config.H
 	@echo Compiling $*.cpp ...
 	@if [ ! -d $(objEXETempDir) ]; then mkdir -p $(objEXETempDir); fi
 ifeq ($(LOG_BUILD_TIME),TRUE)
 	@if [ ! -d $(tmpEXETempDir) ]; then mkdir -p $(tmpEXETempDir); fi
 	@date +"%s" > $(tmpEXETempDir)/$(notdir $<).log
 endif
-	$(SILENT) $(CCACHE) $(CXX) $(CXXFLAGS) $(EXTRACXXFLAGS) $(CPPFLAGS) $(includes) -c $< $(EXE_OUTPUT_OPTION)
+	$(SILENT) $(CCACHE) $(CXX) $(DEPFLAGS) $(CXXFLAGS) $(EXTRACXXFLAGS) $(CPPFLAGS) $(includes) -c $< $(EXE_OUTPUT_OPTION)
 ifeq ($(LOG_BUILD_TIME),TRUE)
 	@date +"%s" >> $(tmpEXETempDir)/$(notdir $<).log
 endif
 
-$(objEXETempDir)/%.o: %.c
+$(objEXETempDir)/%.o: %.c AMReX_Config.H
 	@echo Compiling $*.c ...
 	@if [ ! -d $(objEXETempDir) ]; then mkdir -p $(objEXETempDir); fi
 ifeq ($(LOG_BUILD_TIME),TRUE)
 	@if [ ! -d $(tmpEXETempDir) ]; then mkdir -p $(tmpEXETempDir); fi
 	@date +"%s" > $(tmpEXETempDir)/$(notdir $<).log
 endif
-	$(SILENT) $(CCACHE) $(CC) $(CFLAGS) -DBL_LANG_C -DAMREX_LANG_C $(CPPFLAGS) $(includes) -c $< $(EXE_OUTPUT_OPTION)
+	$(SILENT) $(CCACHE) $(CC) $(DEPFLAGS) $(CFLAGS) -DBL_LANG_C -DAMREX_LANG_C $(CPPFLAGS) $(includes) -c $< $(EXE_OUTPUT_OPTION)
 ifeq ($(LOG_BUILD_TIME),TRUE)
 	@date +"%s" >> $(tmpEXETempDir)/$(notdir $<).log
 endif
@@ -411,11 +411,19 @@ ifneq ($(findstring print-,$(MAKECMDGOALS)),print-)
 ifneq ($(MAKECMDGOALS),help)
 
 ifdef CEXE_sources
--include $(CEXE_sources:%.cpp=$(depEXETempDir)/%.d)
+ifeq ($(USE_LEGACY_DEPFLAGS),TRUE)
+  -include $(CEXE_sources:%.cpp=$(depEXETempDir)/%.d)
+else
+  -include $(CEXE_sources:%.cpp=$(objEXETempDir)/%.d)
+endif
 endif
 
 ifdef cEXE_sources
--include $(cEXE_sources:%.c=$(depEXETempDir)/%.d)
+ifeq ($(USE_LEGACY_DEPFLAGS),TRUE)
+  -include $(cEXE_sources:%.c=$(depEXETempDir)/%.d)
+else
+  -include $(cEXE_sources:%.c=$(objEXETempDir)/%.d)
+endif
 endif
 
 ifdef fEXE_sources

--- a/Tools/GNUMake/comps/cray.mak
+++ b/Tools/GNUMake/comps/cray.mak
@@ -32,6 +32,13 @@ ifeq ($(CRAY_CC_VERSION),10.0.1)
   endif
 endif
 
+ifeq ($(CCE_GE_V9),FALSE)
+  # -MMD -MP not supprted
+  USE_LEGACY_DEPFLAGS = TRUE
+  DEPFLAGS =
+  LEGACY_DEPFLAGS = -M
+endif
+
 ########################################################################
 
 ifeq ($(DEBUG),TRUE)
@@ -120,6 +127,10 @@ else
   ifeq ($(CCE_GE_V9),FALSE)
     GENERIC_COMP_FLAGS += -h noacc
   endif
+endif
+
+ifeq ($(CCE_GE_V9),TRUE)
+  CXXFLAGS += -Wno-pass-failed -Wno-c++17-extensions
 endif
 
 CXXFLAGS += $(GENERIC_COMP_FLAGS)

--- a/Tools/GNUMake/comps/hip.mak
+++ b/Tools/GNUMake/comps/hip.mak
@@ -107,7 +107,7 @@ ifeq ($(HIP_COMPILER),clang)
   # SYSTEM_INCLUDE_LOCATIONS += $(ROC_PATH)/rocthrust/include
 
   # hipcc passes a lot of unused arguments to clang
-  DEPFLAGS += -Wno-unused-command-line-argument
+  LEGACY_DEPFLAGS += -Wno-unused-command-line-argument
 
 # =============================================================================================
 

--- a/Tools/GNUMake/comps/llvm.mak
+++ b/Tools/GNUMake/comps/llvm.mak
@@ -38,8 +38,6 @@ else
 
 endif
 
-CXXFLAGS += -Wno-pass-failed  # disable this warning
-
 ifeq ($(WARN_ALL),TRUE)
   warning_flags = -Wall -Wextra -Wno-sign-compare -Wunreachable-code -Wnull-dereference
   warning_flags += -Wfloat-conversion -Wextra-semi
@@ -60,6 +58,9 @@ ifeq ($(WARN_ERROR),TRUE)
   CXXFLAGS += -Werror
   CFLAGS += -Werror
 endif
+
+# disable some warnings
+CXXFLAGS += -Wno-pass-failed -Wno-c++17-extensions
 
 ########################################################################
 

--- a/Tools/GNUMake/comps/nvcc.mak
+++ b/Tools/GNUMake/comps/nvcc.mak
@@ -27,13 +27,21 @@ ifeq ($(shell expr $(nvcc_major_version) \>= 11),1)
   nvcc_forward_unknowns = 1
 endif
 
+ifeq ($(shell expr $(nvcc_major_version) \< 11),1)
+  # -MMD -MP not supprted in < 11
+  USE_LEGACY_DEPFLAGS = TRUE
+  DEPFLAGS =
+endif
+
 ifeq ($(shell expr $(nvcc_major_version) \< 10),1)
-  DEPFLAGS = -M  # -MM not supported in < 10
+  # -MM not supported in < 10
+  LEGACY_DEPFLAGS = -M
 endif
 
 ifeq ($(shell expr $(nvcc_major_version) \= 10),1)
 ifeq ($(shell expr $(nvcc_minor_version) \= 0),1)
-  DEPFLAGS = -M  # -MM not supported in 10.0
+  # -MM not supported in 10.0
+  LEGACY_DEPFLAGS = -M
 endif
 endif
 

--- a/Tools/GNUMake/comps/pgi.mak
+++ b/Tools/GNUMake/comps/pgi.mak
@@ -19,6 +19,10 @@ gcc_minor_version = $(shell g++ -dumpfullversion -dumpversion | head -1 | sed -e
 
 COMP_VERSION = $(pgi_version)
 
+# -MP not supported by pgi and -MMD's output is put in the wrong directory
+USE_LEGACY_DEPFLAGS = TRUE
+DEPFLAGS =
+
 ########################################################################
 
 GENERIC_PGI_FLAGS =


### PR DESCRIPTION
Use -MMD -MP instead of -M to generate dependency unless it is not supported
by the compiler.  In the new approach, the dependencies are generated during
compilation without a separate step.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
