### PR TITLE
Undeprecate ReduceData::value()

### DIFF
--- a/Src/Base/AMReX_Reduce.H
+++ b/Src/Base/AMReX_Reduce.H
@@ -249,7 +249,6 @@ public:
     void operator= (ReduceData<Ts...> const&) = delete;
     void operator= (ReduceData<Ts...> &&) = delete;
 
-    [[deprecated("Use value (ReduceOps<Ps...>&) instead.")]]
     Type value ()
     {
         return m_fn_value();
@@ -906,7 +905,6 @@ public:
     void operator= (ReduceData<Ts...> const&) = delete;
     void operator= (ReduceData<Ts...> &&) = delete;
 
-    [[deprecated("Use value (ReduceOps<Ps...>&) instead.")]]
     Type value () { return m_fn_value(); }
 
     template <typename... Ps>


### PR DESCRIPTION
ReduceData::value() with no argument was recently marked as a depracated
function because it involves calling a std::function.  However, the call is
never made inside a loop like MFIter.  So there is no practical difference
in performance between ReduceData::vaule and ReduceData::value(ReduceOps&).
It is hereby undeprecated to avoid warning messages for a lot of
applications.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
