### PR TITLE
Fix missing Real() in AMReX_EB2_2D_C.cpp

### DIFF
--- a/Src/EB/AMReX_EB2_2D_C.cpp
+++ b/Src/EB/AMReX_EB2_2D_C.cpp
@@ -100,8 +100,8 @@ void set_eb_data (const int i, const int j,
         } else {
             vcent(i,j,0,0) *= (1.0/vfrac(i,j,0));
             vcent(i,j,0,1) *= (1.0/vfrac(i,j,0));
-            vcent(i,j,0,0) = amrex::min(amrex::max(vcent(i,j,0,0),-0.5),0.5);
-            vcent(i,j,0,1) = amrex::min(amrex::max(vcent(i,j,0,1),-0.5),0.5);
+            vcent(i,j,0,0) = amrex::min(amrex::max(vcent(i,j,0,0),Real(-0.5)),Real(0.5));
+            vcent(i,j,0,1) = amrex::min(amrex::max(vcent(i,j,0,1),Real(-0.5)),Real(0.5));
         }
     }
 }


### PR DESCRIPTION
## Summary

This PR fixes few missing `Real()` in `AMReX_EB2_2D_C.cpp`, which currently prevent the compilation of a function in single precision.

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
