### PR TITLE
Fix GNU make for nvcc 11.0

### DIFF
--- a/Tools/GNUMake/comps/nvcc.mak
+++ b/Tools/GNUMake/comps/nvcc.mak
@@ -27,6 +27,13 @@ ifeq ($(shell expr $(nvcc_major_version) \>= 11),1)
   nvcc_forward_unknowns = 1
 endif
 
+ifeq ($(shell expr $(nvcc_major_version) \= 11),1)
+ifeq ($(shell expr $(nvcc_minor_version) \= 0),1)
+  # -MP not supprted in 11.0
+  DEPFLAGS = -MMD
+endif
+endif
+
 ifeq ($(shell expr $(nvcc_major_version) \< 11),1)
   # -MMD -MP not supprted in < 11
   USE_LEGACY_DEPFLAGS = TRUE


### PR DESCRIPTION
This fixes a bug introduced in #1967.  It turns out nvcc 11.0 does not
support -MP.

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
