### PR TITLE
Hypre Bottom Solver Parameter Mods

### DIFF
--- a/Src/Extern/HYPRE/AMReX_HypreIJIface.cpp
+++ b/Src/Extern/HYPRE/AMReX_HypreIJIface.cpp
@@ -39,6 +39,14 @@ struct HypreOptParse
         func(solver, val);
     }
 
+    template <typename F, typename T>
+    void operator()(const std::string& key, F&& func, T default_val, int index)
+    {
+        T val = default_val;
+        pp.query(key.c_str(), val);
+        func(solver, val, index);
+    }
+
     template <typename T, typename F>
     void set(const std::string& key, F&& func)
     {
@@ -228,9 +236,24 @@ void HypreIJIface::boomeramg_precond_configure(const std::string& prefix)
     hpp("bamg_precond_tolerance", HYPRE_BoomerAMGSetTol, 0.0);
     hpp("bamg_coarsen_type", HYPRE_BoomerAMGSetCoarsenType, 6);
     hpp("bamg_cycle_type", HYPRE_BoomerAMGSetCycleType, 1);
-    hpp("bamg_relax_type", HYPRE_BoomerAMGSetRelaxType, 6);
     hpp("bamg_relax_order", HYPRE_BoomerAMGSetRelaxOrder, 1);
-    hpp("bamg_num_sweeps", HYPRE_BoomerAMGSetNumSweeps, 2);
+
+    if (hpp.pp.contains("bamg_down_relax_type") && hpp.pp.contains("bamg_up_relax_type") && hpp.pp.contains("bamg_coarse_relax_type")) {
+        hpp("bamg_down_relax_type", HYPRE_BoomerAMGSetCycleRelaxType, 11, 1);
+        hpp("bamg_up_relax_type", HYPRE_BoomerAMGSetCycleRelaxType, 11, 2);
+        hpp("bamg_coarse_relax_type", HYPRE_BoomerAMGSetCycleRelaxType, 11, 3);
+    } else {
+        hpp("bamg_relax_type", HYPRE_BoomerAMGSetRelaxType, 11);
+    }
+
+    if (hpp.pp.contains("bamg_num_down_sweeps") && hpp.pp.contains("bamg_num_up_sweeps") && hpp.pp.contains("bamg_num_coarse_sweeps")) {
+        hpp("bamg_num_down_sweeps", HYPRE_BoomerAMGSetCycleNumSweeps, 2, 1);
+        hpp("bamg_num_up_sweeps", HYPRE_BoomerAMGSetCycleNumSweeps, 2, 2);
+        hpp("bamg_num_coarse_sweeps", HYPRE_BoomerAMGSetCycleNumSweeps, 1, 3);
+    } else {
+        hpp("bamg_num_sweeps", HYPRE_BoomerAMGSetNumSweeps, 2);
+    }
+
     hpp("bamg_max_levels", HYPRE_BoomerAMGSetMaxLevels, 20);
     hpp("bamg_strong_threshold", HYPRE_BoomerAMGSetStrongThreshold,
         (AMREX_SPACEDIM == 3) ? 0.57 : 0.25);
@@ -332,10 +355,24 @@ void HypreIJIface::boomeramg_solver_configure(const std::string& prefix)
     HypreOptParse hpp(prefix, m_solver);
     hpp("verbose", HYPRE_BoomerAMGSetPrintLevel);
     hpp("logging", HYPRE_BoomerAMGSetLogging);
-
-    hpp("bamg_relax_type", HYPRE_BoomerAMGSetRelaxType, 6);
     hpp("bamg_relax_order", HYPRE_BoomerAMGSetRelaxOrder, 1);
-    hpp("bamg_num_sweeps", HYPRE_BoomerAMGSetNumSweeps, 2);
+
+    if (hpp.pp.contains("bamg_down_relax_type") && hpp.pp.contains("bamg_up_relax_type") && hpp.pp.contains("bamg_coarse_relax_type")) {
+        hpp("bamg_down_relax_type", HYPRE_BoomerAMGSetCycleRelaxType, 11, 1);
+        hpp("bamg_up_relax_type", HYPRE_BoomerAMGSetCycleRelaxType, 11, 2);
+        hpp("bamg_coarse_relax_type", HYPRE_BoomerAMGSetCycleRelaxType, 11, 3);
+    } else {
+        hpp("bamg_relax_type", HYPRE_BoomerAMGSetRelaxType, 11);
+    }
+
+    if (hpp.pp.contains("bamg_num_down_sweeps") && hpp.pp.contains("bamg_num_up_sweeps") && hpp.pp.contains("bamg_num_coarse_sweeps")) {
+        hpp("bamg_num_down_sweeps", HYPRE_BoomerAMGSetCycleNumSweeps, 2, 1);
+        hpp("bamg_num_up_sweeps", HYPRE_BoomerAMGSetCycleNumSweeps, 2, 2);
+        hpp("bamg_num_coarse_sweeps", HYPRE_BoomerAMGSetCycleNumSweeps, 1, 3);
+    } else {
+        hpp("bamg_num_sweeps", HYPRE_BoomerAMGSetNumSweeps, 2);
+    }
+
     hpp("bamg_strong_threshold", HYPRE_BoomerAMGSetStrongThreshold,
         (AMREX_SPACEDIM == 3) ? 0.57 : 0.25);
     hpp("bamg_coarsen_type", HYPRE_BoomerAMGSetCoarsenType);


### PR DESCRIPTION
I've added a few more parameters to control the Hypre Boomer AMG cycle. This includes the number of up/down/coarse sweeps and smoother used in up/down/coarse levels.

I've also changed the default relax_type to 11 (2 stage Gauss Seidel) rather than 6 (Symmetric Gauss Seidel). 11 seems equally effective as 6. Moreover it is far more efficient for GPU builds.

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
