### PR TITLE
Hypre BAMG parameter fix

### DIFF
--- a/Src/Extern/HYPRE/AMReX_HypreIJIface.cpp
+++ b/Src/Extern/HYPRE/AMReX_HypreIJIface.cpp
@@ -267,7 +267,7 @@ void HypreIJIface::boomeramg_precond_configure(const std::string& prefix)
     hpp("bamg_agg_num_levels", HYPRE_BoomerAMGSetAggNumLevels);
     hpp("bamg_agg_interp_type", HYPRE_BoomerAMGSetAggInterpType);
     hpp("bamg_agg_pmax_elmts", HYPRE_BoomerAMGSetAggPMaxElmts);
-    hpp("bamg_set_trunc_factor", HYPRE_BoomerAMGSetTruncFactor);
+    hpp("bamg_trunc_factor", HYPRE_BoomerAMGSetTruncFactor, 0.1);
 
     if (hpp.pp.contains("bamg_non_galerkin_tol")) {
         hpp("bamg_non_galerkin_tol", HYPRE_BoomerAMGSetNonGalerkinTol);


### PR DESCRIPTION
This parameter needs to be a double. We give it a sensible initial value which the Hypre team recommends.

## Additional background

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
