### PR TITLE
Hypre Default Params 

### DIFF
--- a/Src/Extern/HYPRE/AMReX_HypreIJIface.cpp
+++ b/Src/Extern/HYPRE/AMReX_HypreIJIface.cpp
@@ -243,7 +243,7 @@ void HypreIJIface::boomeramg_precond_configure(const std::string& prefix)
         hpp("bamg_up_relax_type", HYPRE_BoomerAMGSetCycleRelaxType, 11, 2);
         hpp("bamg_coarse_relax_type", HYPRE_BoomerAMGSetCycleRelaxType, 11, 3);
     } else {
-        hpp("bamg_relax_type", HYPRE_BoomerAMGSetRelaxType, 11);
+        hpp("bamg_relax_type", HYPRE_BoomerAMGSetRelaxType, 6);
     }
 
     if (hpp.pp.contains("bamg_num_down_sweeps") && hpp.pp.contains("bamg_num_up_sweeps") && hpp.pp.contains("bamg_num_coarse_sweeps")) {
@@ -362,7 +362,7 @@ void HypreIJIface::boomeramg_solver_configure(const std::string& prefix)
         hpp("bamg_up_relax_type", HYPRE_BoomerAMGSetCycleRelaxType, 11, 2);
         hpp("bamg_coarse_relax_type", HYPRE_BoomerAMGSetCycleRelaxType, 11, 3);
     } else {
-        hpp("bamg_relax_type", HYPRE_BoomerAMGSetRelaxType, 11);
+        hpp("bamg_relax_type", HYPRE_BoomerAMGSetRelaxType, 6);
     }
 
     if (hpp.pp.contains("bamg_num_down_sweeps") && hpp.pp.contains("bamg_num_up_sweeps") && hpp.pp.contains("bamg_num_coarse_sweeps")) {


### PR DESCRIPTION
This PR reverts the default values for bamg_relax_type back to 6 (Symmetric Gauss Seidel). This appears to be more robust than 11 (2 stage Gauss Seidel).

## Additional background

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
