### PR TITLE
Deprecate FabArray::copy()

### DIFF
--- a/Src/Amr/AMReX_AuxBoundaryData.cpp
+++ b/Src/Amr/AMReX_AuxBoundaryData.cpp
@@ -39,7 +39,7 @@ AuxBoundaryData::copy (const AuxBoundaryData& src,
     BL_ASSERT(src_comp + num_comp <= src.m_fabs.nComp());
     BL_ASSERT(dst_comp + num_comp <= m_fabs.nComp());
 
-    m_fabs.copy(src.m_fabs,src_comp,dst_comp,num_comp);
+    m_fabs.ParallelCopy(src.m_fabs,src_comp,dst_comp,num_comp);
 }
 
 AuxBoundaryData::AuxBoundaryData (const AuxBoundaryData& rhs)
@@ -48,7 +48,7 @@ AuxBoundaryData::AuxBoundaryData (const AuxBoundaryData& rhs)
            MFInfo(), FArrayBoxFactory()),
     m_ngrow(rhs.m_ngrow)
 {
-    m_fabs.copy(rhs.m_fabs,0,0,rhs.m_fabs.nComp());
+    m_fabs.ParallelCopy(rhs.m_fabs,0,0,rhs.m_fabs.nComp());
     m_empty = false;
     m_initialized = true;
 }
@@ -134,7 +134,7 @@ AuxBoundaryData::copyTo (MultiFab& mf,
 
     if (!m_empty && mf.size() > 0)
     {
-        mf.copy(m_fabs,src_comp,dst_comp,num_comp,0,mf.nGrow());
+        mf.ParallelCopy(m_fabs,src_comp,dst_comp,num_comp,0,mf.nGrow());
     }
 }
 
@@ -149,7 +149,7 @@ AuxBoundaryData::copyFrom (const MultiFab& mf,
 
     if (!m_empty && mf.size() > 0)
     {
-        m_fabs.copy(mf,src_comp,dst_comp,num_comp,src_ng,0);
+        m_fabs.ParallelCopy(mf,src_comp,dst_comp,num_comp,src_ng,0);
     }
 }
 

--- a/Src/AmrCore/AMReX_FillPatchUtil.cpp
+++ b/Src/AmrCore/AMReX_FillPatchUtil.cpp
@@ -60,7 +60,7 @@ namespace amrex
 
                 cmf[idim].define(cba, dm, 1, 1, MFInfo(), crse[0]->Factory());
 
-                cmf[idim].copy(*crse[idim], 0, 0, 1, 0, 1, cgeom.periodicity());
+                cmf[idim].ParallelCopy(*crse[idim], 0, 0, 1, 0, 1, cgeom.periodicity());
             }
 
             const Real* dx = cgeom.CellSize();

--- a/Src/AmrCore/AMReX_FillPatchUtil_I.H
+++ b/Src/AmrCore/AMReX_FillPatchUtil_I.H
@@ -785,7 +785,7 @@ InterpFromCoarseLevel (MF& mf, IntVect const& nghost, Real time,
     }
     mf_set_domain_bndry (mf_crse_patch, cgeom);
 
-    mf_crse_patch.copy(cmf, scomp, 0, ncomp, cgeom.periodicity());
+    mf_crse_patch.ParallelCopy(cmf, scomp, 0, ncomp, cgeom.periodicity());
 
     cbc(mf_crse_patch, 0, ncomp, mf_crse_patch.nGrowVect(), time, cbccomp);
 
@@ -919,7 +919,7 @@ InterpFromCoarseLevel (Array<MF*, AMREX_SPACEDIM> const& mf, IntVect const& ngho
 #endif
         mf_set_domain_bndry(mf_crse_patch[d], cgeom);
 
-        mf_crse_patch[d].copy(*(cmf[d]), scomp, 0, ncomp, cgeom.periodicity());
+        mf_crse_patch[d].ParallelCopy(*(cmf[d]), scomp, 0, ncomp, cgeom.periodicity());
         cbc[d](mf_crse_patch[d], 0, ncomp, mf_crse_patch[d].nGrowVect(), time, cbccomp);
     }
 

--- a/Src/Base/AMReX_FACopyDescriptor.H
+++ b/Src/Base/AMReX_FACopyDescriptor.H
@@ -836,12 +836,12 @@ FabArrayCopyDescriptor<FAB>::FillFab (FabArrayId       faid,
 
     BL_ASSERT(fcdp->subBox.sameSize(destBox));
 
-    destFab.copy(*fcdp->localFabSource,
-                 fcdp->subBox,
-                 fcdp->fillType == FillLocally ? fcdp->srcComp : 0,
-                 destBox,
-                 fcdp->destComp,
-                 fcdp->nComp);
+    destFab.ParallelCopy(*fcdp->localFabSource,
+                         fcdp->subBox,
+                         fcdp->fillType == FillLocally ? fcdp->srcComp : 0,
+                         destBox,
+                         fcdp->destComp,
+                         fcdp->nComp);
 
     BL_ASSERT(++fmi == fabCopyDescList[faid.Id()].upper_bound(fillboxid.Id()));
 }

--- a/Src/Base/AMReX_FabArray.H
+++ b/Src/Base/AMReX_FabArray.H
@@ -493,7 +493,7 @@ public:
                        CpOp                 op = FabArrayBase::COPY)
        { ParallelCopy(fa,0,0,nComp(),0,0,period,op); }
 
-    [[deprecated("Use FabArray::ParallelCopy instead.")]]
+    [[deprecated("Use FabArray::ParallelCopy() instead.")]]
     void copy (const FabArray<FAB>& fa,
                const Periodicity&   period = Periodicity::NonPeriodic(),
                CpOp                 op = FabArrayBase::COPY)
@@ -529,7 +529,7 @@ public:
                        CpOp                 op = FabArrayBase::COPY)
        { ParallelCopy(src,src_comp,dest_comp,num_comp,0,0,period,op); }
 
-    [[deprecated("Use FabArray::ParallelCopy instead.")]]
+    [[deprecated("Use FabArray::ParallelCopy() instead.")]]
     void copy (const FabArray<FAB>& src,
                int                  src_comp,
                int                  dest_comp,
@@ -629,7 +629,7 @@ public:
 
     void ParallelCopy_finish ();
 
-    [[deprecated("Use FabArray::ParallelCopy instead.")]]
+    [[deprecated("Use FabArray::ParallelCopy() instead.")]]
     void copy (const FabArray<FAB>& src,
                int                  src_comp,
                int                  dest_comp,
@@ -640,7 +640,7 @@ public:
                CpOp                 op = FabArrayBase::COPY)
        { ParallelCopy(src,src_comp,dest_comp,num_comp,IntVect(src_nghost),IntVect(dst_nghost),period,op); }
 
-    [[deprecated("Use FabArray::ParallelCopy instead.")]]
+    [[deprecated("Use FabArray::ParallelCopy() instead.")]]
     void copy (const FabArray<FAB>& src,
                int                  src_comp,
                int                  dest_comp,

--- a/Src/Base/AMReX_FabArray.H
+++ b/Src/Base/AMReX_FabArray.H
@@ -492,6 +492,8 @@ public:
                        const Periodicity&   period = Periodicity::NonPeriodic(),
                        CpOp                 op = FabArrayBase::COPY)
        { ParallelCopy(fa,0,0,nComp(),0,0,period,op); }
+
+    [[deprecated("Use FabArray::ParallelCopy instead.")]]
     void copy (const FabArray<FAB>& fa,
                const Periodicity&   period = Periodicity::NonPeriodic(),
                CpOp                 op = FabArrayBase::COPY)
@@ -526,6 +528,8 @@ public:
                        const Periodicity&   period = Periodicity::NonPeriodic(),
                        CpOp                 op = FabArrayBase::COPY)
        { ParallelCopy(src,src_comp,dest_comp,num_comp,0,0,period,op); }
+
+    [[deprecated("Use FabArray::ParallelCopy instead.")]]
     void copy (const FabArray<FAB>& src,
                int                  src_comp,
                int                  dest_comp,
@@ -625,7 +629,7 @@ public:
 
     void ParallelCopy_finish ();
 
-
+    [[deprecated("Use FabArray::ParallelCopy instead.")]]
     void copy (const FabArray<FAB>& src,
                int                  src_comp,
                int                  dest_comp,
@@ -635,6 +639,8 @@ public:
                const Periodicity&   period = Periodicity::NonPeriodic(),
                CpOp                 op = FabArrayBase::COPY)
        { ParallelCopy(src,src_comp,dest_comp,num_comp,IntVect(src_nghost),IntVect(dst_nghost),period,op); }
+
+    [[deprecated("Use FabArray::ParallelCopy instead.")]]
     void copy (const FabArray<FAB>& src,
                int                  src_comp,
                int                  dest_comp,

--- a/Src/Base/AMReX_MultiFab.cpp
+++ b/Src/Base/AMReX_MultiFab.cpp
@@ -1197,7 +1197,7 @@ MultiFab::SumBoundary (int scomp, int ncomp, IntVect const& nghost, const Period
     MultiFab tmp(boxArray(), DistributionMap(), ncomp, n_grow, MFInfo(), Factory());
     MultiFab::Copy(tmp, *this, scomp, 0, ncomp, n_grow);
     this->setVal(0.0, scomp, ncomp, nghost);
-    this->copy(tmp,0,scomp,ncomp,n_grow,nghost,period,FabArrayBase::ADD);
+    this->ParallelCopy(tmp,0,scomp,ncomp,n_grow,nghost,period,FabArrayBase::ADD);
 }
 
 void

--- a/Src/Base/AMReX_MultiFabUtil.cpp
+++ b/Src/Base/AMReX_MultiFabUtil.cpp
@@ -306,7 +306,7 @@ namespace amrex
             });
         }
 
-        S_crse.copy(crse_S_fine,0,scomp,ncomp);
+        S_crse.ParallelCopy(crse_S_fine,0,scomp,ncomp);
 #endif
    }
 
@@ -354,8 +354,8 @@ namespace amrex
             });
         }
 
-        S_crse.copy(crse_S_fine, 0, scomp, ncomp, nGrow, 0,
-                    cgeom.periodicity(), FabArrayBase::ADD);
+        S_crse.ParallelCopy(crse_S_fine, 0, scomp, ncomp, nGrow, 0,
+                            cgeom.periodicity(), FabArrayBase::ADD);
     }
 
     void average_down (const MultiFab& S_fine, MultiFab& S_crse,
@@ -429,7 +429,7 @@ namespace amrex
                 }
             }
 
-            S_crse.copy(crse_S_fine,0,scomp,ncomp);
+            S_crse.ParallelCopy(crse_S_fine,0,scomp,ncomp);
         }
    }
 

--- a/Src/Base/AMReX_MultiFabUtilI.H
+++ b/Src/Base/AMReX_MultiFabUtilI.H
@@ -12,7 +12,7 @@ namespace amrex {
         template<typename T>
         struct SymmetricGhost {
             static void copy (T & target, const T & source, int nc, int ng) {
-                target.copy(source, 0, 0, nc, ng, ng);
+                target.ParallelCopy(source, 0, 0, nc, ng, ng);
             }
         };
 
@@ -23,7 +23,7 @@ namespace amrex {
         template<typename T> // T can be either MultiFab or iMultiFab
         struct AsymmetricGhost {
             static void copy (T & target, const T & source, int nc, int ng) {
-                target.copy(source, 0, 0, nc, 0, ng);
+                target.ParallelCopy(source, 0, 0, nc, 0, ng);
             }
         };
 

--- a/Src/Base/AMReX_VisMF.cpp
+++ b/Src/Base/AMReX_VisMF.cpp
@@ -1809,7 +1809,7 @@ VisMF::Read (FabArray<FArrayBox> &mf,
 
     if( ! inFileOrder) {
       faCopyTime = amrex::second();
-      mf.copy(fafabFileOrder);
+      mf.ParallelCopy(fafabFileOrder);
       faCopyTime = amrex::second() - faCopyTime;
     }
 

--- a/Src/Boundary/AMReX_FabSet.cpp
+++ b/Src/Boundary/AMReX_FabSet.cpp
@@ -40,7 +40,7 @@ FabSet::copyFrom (const FabSet& src, int scomp, int dcomp, int ncomp)
             });
         }
     } else {
-        m_mf.copy(src.m_mf,scomp,dcomp,ncomp);
+        m_mf.ParallelCopy(src.m_mf,scomp,dcomp,ncomp);
     }
     return *this;
 }
@@ -50,7 +50,7 @@ FabSet::copyFrom (const MultiFab& src, int ngrow, int scomp, int dcomp, int ncom
                   const Periodicity& period)
 {
     BL_ASSERT(boxArray() != src.boxArray());
-    m_mf.copy(src,scomp,dcomp,ncomp,ngrow,0,period);
+    m_mf.ParallelCopy(src,scomp,dcomp,ncomp,ngrow,0,period);
     return *this;
 }
 
@@ -81,7 +81,7 @@ FabSet::plusFrom (const MultiFab& src, int ngrow, int scomp, int dcomp, int ncom
                   const Periodicity& period)
 {
     BL_ASSERT(boxArray() != src.boxArray());
-    m_mf.copy(src,scomp,dcomp,ncomp,ngrow,0,period,FabArrayBase::ADD);
+    m_mf.ParallelCopy(src,scomp,dcomp,ncomp,ngrow,0,period,FabArrayBase::ADD);
     return *this;
 }
 
@@ -90,7 +90,7 @@ FabSet::copyTo (MultiFab& dest, int ngrow, int scomp, int dcomp, int ncomp,
                 const Periodicity& period) const
 {
     BL_ASSERT(boxArray() != dest.boxArray());
-    dest.copy(m_mf,scomp,dcomp,ncomp,0,ngrow,period);
+    dest.ParallelCopy(m_mf,scomp,dcomp,ncomp,0,ngrow,period);
 }
 
 void
@@ -98,7 +98,7 @@ FabSet::plusTo (MultiFab& dest, int ngrow, int scomp, int dcomp, int ncomp,
                 const Periodicity& period) const
 {
     BL_ASSERT(boxArray() != dest.boxArray());
-    dest.copy(m_mf,scomp,dcomp,ncomp,0,ngrow,period,FabArrayBase::ADD);
+    dest.ParallelCopy(m_mf,scomp,dcomp,ncomp,0,ngrow,period,FabArrayBase::ADD);
 }
 
 void
@@ -193,8 +193,8 @@ FabSet::linComb (Real a, const MultiFab& mfa, int a_comp,
         });
     }
 
-    bdrya.copy(mfa,a_comp,0,ncomp,ngrow,0);
-    bdryb.copy(mfb,b_comp,0,ncomp,ngrow,0);
+    bdrya.ParallelCopy(mfa,a_comp,0,ncomp,ngrow,0);
+    bdryb.ParallelCopy(mfb,b_comp,0,ncomp,ngrow,0);
 
 #ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())

--- a/Src/EB/AMReX_EBMultiFabUtil.cpp
+++ b/Src/EB/AMReX_EBMultiFabUtil.cpp
@@ -386,7 +386,7 @@ EB_average_down (const MultiFab& S_fine, MultiFab& S_crse, const MultiFab& vol_f
         }
     }
 
-    S_crse.copy(crse_S_fine,0,scomp,ncomp);
+    S_crse.ParallelCopy(crse_S_fine,0,scomp,ncomp);
 }
 
 
@@ -491,7 +491,7 @@ EB_average_down (const MultiFab& S_fine, MultiFab& S_crse, int scomp, int ncomp,
                 }
             }
 
-            S_crse.copy(crse_S_fine,0,scomp,ncomp);
+            S_crse.ParallelCopy(crse_S_fine,0,scomp,ncomp);
         }
     }
 }

--- a/Src/Extern/ProfParser/AMReX_BLProfUtilities.cpp
+++ b/Src/Extern/ProfParser/AMReX_BLProfUtilities.cpp
@@ -150,7 +150,7 @@ void amrex::avgDown(MultiFab &S_crse, MultiFab &S_fine, int scomp, int dcomp,
       avgDown_doit(S_fine[i], crse_S_fine[i], crse_S_fine_BA[i],
                    scomp, 0, ncomp, ratio);
     }
-    S_crse.copy(crse_S_fine, 0, dcomp, ncomp);
+    S_crse.ParallelCopy(crse_S_fine, 0, dcomp, ncomp);
 }
 
 

--- a/Src/Extern/amrdata/AMReX_DataServices.cpp
+++ b/Src/Extern/amrdata/AMReX_DataServices.cpp
@@ -2196,7 +2196,7 @@ void DataServices::RunSendsPF(std::string &plotfileName,
       b.setBig(XDIR, iX);
       BoxArray bA(b);
       MultiFab mfLine(bA, dmapOneProc, 1, 0);
-      mfLine.copy(sendMF);
+      mfLine.ParallelCopy(sendMF);
       Real value(0.0);
       if(bIOP) {
         for(int iLine(0); iLine < b.length(YDIR); ++iLine) {
@@ -2258,7 +2258,7 @@ void DataServices::RunSendsPF(std::string &plotfileName,
       const DistributionMapping sqDM(sqBA);
       sqState[i].define(sqBA, sqDM, numState, nGrow);
       sqState[i].setVal(0.0);
-      sqState[i].copy(state[i]);
+      sqState[i].ParallelCopy(state[i]);
     }
 
 
@@ -2533,7 +2533,7 @@ void DataServices::RunTimelinePF(std::map<int, string> &mpiFuncNames,
       const DistributionMapping sqDM(sqBA);
       sqState[i].define(sqBA, sqDM, numState, nGrow);
       sqState[i].setVal(0.0);
-      sqState[i].copy(state[i]);
+      sqState[i].ParallelCopy(state[i]);
     }
 
 
@@ -2894,7 +2894,7 @@ void DataServices::RunACTPF(std::string &plotfileName,
     state[finestLevel].define(dnpBoxArray, dnpDM, numState, nGrow);
     MultiFab &fLMF = state[finestLevel];
     fLMF.setVal(0.0);
-    fLMF.copy(mfWFN);
+    fLMF.ParallelCopy(mfWFN);
 
     // ---- make an xgraph of coefficient of variation for each call
     Vector<Real> coeffVar(whichFuncNCalls, 0.0);
@@ -2976,7 +2976,7 @@ void DataServices::RunACTPF(std::string &plotfileName,
       sqBA.maxSize(sqMG);
       sqState[i].define(sqBA, sqDM, numState, nGrow);
       sqState[i].setVal(0.0);
-      sqState[i].copy(state[i]);
+      sqState[i].ParallelCopy(state[i]);
     }
 
 

--- a/Src/Particle/AMReX_ParticleMesh.H
+++ b/Src/Particle/AMReX_ParticleMesh.H
@@ -107,7 +107,7 @@ MeshToParticle (PC& pc, MF const& mf, int lev, F&& f)
                                                   pc.ParticleDistributionMap(lev),
                                                   mf.nComp(), mf.nGrowVect());
 
-    if (mf_pointer != &mf) mf_pointer->copy(mf,0,0,mf.nComp(),mf.nGrowVect(),mf.nGrowVect());
+    if (mf_pointer != &mf) mf_pointer->ParallelCopy(mf,0,0,mf.nComp(),mf.nGrowVect(),mf.nGrowVect());
 
     const auto plo = pc.Geom(lev).ProbLoArray();
     const auto dxi = pc.Geom(lev).InvCellSizeArray();

--- a/Src/Particle/AMReX_TracerParticles.cpp
+++ b/Src/Particle/AMReX_TracerParticles.cpp
@@ -45,7 +45,7 @@ TracerParticleContainer::AdvectWithUmac (MultiFab* umac, int lev, Real dt)
                 (amrex::convert(m_gdb->ParticleBoxArray(lev), IntVect::TheDimensionVector(i)),
                  m_gdb->ParticleDistributionMap(lev), umac[i].nComp(), ng);
             umac_pointer[i] = raii_umac[i].get();
-            umac_pointer[i]->copy(umac[i],0,0,umac[i].nComp(),ng,ng);
+            umac_pointer[i]->ParallelCopy(umac[i],0,0,umac[i].nComp(),ng,ng);
         }
     }
 


### PR DESCRIPTION
## Summary

This deprecates the legacy `FabArray::copy()` in favor of the better named `FabArray::ParallelCopy()` functions. This should help alleviate the problem of confusion between `FabArray::copy()` and `MultiFab::Copy()`, which is a local copy.

Also removes "copy" calls from the rest of the repo (at least according to my greps and the CI tests. Is there anything those tests don't reach?)

Should we also change the names of the `SymmetricGhost` and `AsymmetricGhost` calls to `ParallelCopy` to be consistent as well? (AMReX_MultiFabUtilI.H)

Crazy Thought: Should we change `MultiFab::Copy()` to `MultiFab::LocalCopy()` and deprecate `Copy` for a blatant and direct function name that'll remove all confusion or questions about what the call does? Would also be easy to read for new users, and thinking about all copies in terms of `Parallel` and `Local` might avoid a lot of bugs as well.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
