### PR TITLE
Fix proper nesting issue for large error buffer

### DIFF
--- a/Src/AmrCore/AMReX_TagBox.cpp
+++ b/Src/AmrCore/AMReX_TagBox.cpp
@@ -77,14 +77,15 @@ TagBox::coarsen (const IntVect& ratio, const Box& cbox) noexcept
 void
 TagBox::buffer (const IntVect& a_nbuff, const IntVect& a_nwid) noexcept
 {
-    amrex::ignore_unused(a_nbuff, a_nwid);
+    Box const& interior = amrex::grow(domain, -a_nwid);
+    Dim3 nbuf = a_nbuff.dim3();
     Array4<char> const& a = this->array();
 #ifdef AMREX_USE_GPU
     if (Gpu::inLaunchRegion()) {
-        Dim3 nbuf = a_nbuff.dim3();
-        const auto lo = amrex::lbound(domain);
-        const auto hi = amrex::ubound(domain);
-        AMREX_HOST_DEVICE_FOR_3D(domain, i, j, k,
+        Box const& interiorplusbuf = amrex::grow(interior, a_nbuff);
+        const auto lo = amrex::lbound(interiorplusbuf);
+        const auto hi = amrex::ubound(interiorplusbuf);
+        AMREX_HOST_DEVICE_FOR_3D(interiorplusbuf, i, j, k,
         {
             if (a(i,j,k) == TagBox::CLEAR) {
                 bool to_buf = false;
@@ -107,14 +108,12 @@ TagBox::buffer (const IntVect& a_nbuff, const IntVect& a_nwid) noexcept
     } else
 #endif
     {
-        Dim3 nwid = a_nwid.dim3();
-        Box const& interior = amrex::grow(domain, -a_nwid);
         AMREX_LOOP_3D(interior, i, j, k,
         {
             if (a(i,j,k) == TagBox::SET) {
-                for (int kk = k-nwid.z; kk <= k+nwid.z; ++kk) {
-                for (int jj = j-nwid.y; jj <= j+nwid.y; ++jj) {
-                for (int ii = i-nwid.x; ii <= i+nwid.x; ++ii) {
+                for (int kk = k-nbuf.z; kk <= k+nbuf.z; ++kk) {
+                for (int jj = j-nbuf.y; jj <= j+nbuf.y; ++jj) {
+                for (int ii = i-nbuf.x; ii <= i+nbuf.x; ++ii) {
                     if (a(ii,jj,kk) == TagBox::CLEAR) { a(ii,jj,kk) = TagBox::BUF; }
                 }}}
             }


### PR DESCRIPTION
Reimplement the code that ensures proper nesting by projecting the fine
grids onto the coarse.  The previous implementation has a bug that causes it
to fail when the error buffer is very large.

In the very beginning of BoxLib, the enforcement of proper nesting was
actually done in a similar way as the approach in this commit (i.e., calling
TagBoxArray::setVal(BoxArray,TagBox::CLEAR) with projected down BoxArray).
However, it had the issue of buffering the buffer cells, creating
unnecessarily big refinement patches.  That issue was fixed in a block of
very complicated code that was hard to reason, also in the very beginning of
BoxLib days.  Since it worked, the code had not been touched at all.
However, it was reported recently it failed when a very large error buffet
was used.  In this commit, we switched back to the original setVal approach
and it is performed after the tagged cells are buffered already, thus
avoiding the issue of buffering the buffer cells.  Furthermore, it is
performed after the tags are coarsened, thus performing less work.

This also adds a check to make sure that blocking factors do not vary too
much between levels.  Otherwise regrid will break.

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
