### PR TITLE
Define BL_USE_MPI compilation flag when MPI and Fortran are enabled

### DIFF
--- a/Tools/CMake/AMReXSetDefines.cmake
+++ b/Tools/CMake/AMReXSetDefines.cmake
@@ -79,6 +79,12 @@ if (AMReX_FORTRAN)
       $<$<COMPILE_LANGUAGE:Fortran>:BL_LANG_FORT AMREX_LANG_FORT>
       )
 
+    if (AMReX_MPI)
+      target_compile_definitions( amrex PRIVATE
+        $<$<COMPILE_LANGUAGE:Fortran>:BL_USE_MPI>
+        )
+    endif()
+
    #
    # Fortran/C mangling scheme
    #


### PR DESCRIPTION
## Summary
Resolves #1989 

## Additional background

## Checklist

The proposed changes:
- [X] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
