### PR TITLE
Non-blocking SumBoundary

### DIFF
--- a/Src/Base/AMReX_MultiFab.H
+++ b/Src/Base/AMReX_MultiFab.H
@@ -650,11 +650,20 @@ public:
 
     void SumBoundary (int scomp, int ncomp, const Periodicity& period = Periodicity::NonPeriodic());
 
+    void SumBoundary_nowait (const Periodicity& period = Periodicity::NonPeriodic());
+
+    void SumBoundary_nowait (int scomp, int ncomp, const Periodicity& period = Periodicity::NonPeriodic());
+
     /**
     * \brief Sum values in overlapped cells.  The destination is limited to valid + ngrow cells.
     */
     void SumBoundary (int scomp, int ncomp, IntVect const& ngrow,
                       const Periodicity& period = Periodicity::NonPeriodic());
+
+    void SumBoundary_nowait (int scomp, int ncomp, IntVect const& ngrow,
+                             const Periodicity& period = Periodicity::NonPeriodic());
+
+    void SumBoundary_finish ();
 
     /**
      * \brief Return a mask indicating how many duplicates are in each point.

--- a/Src/Base/AMReX_MultiFab.cpp
+++ b/Src/Base/AMReX_MultiFab.cpp
@@ -1238,7 +1238,8 @@ MultiFab::SumBoundary_finish ()
 {
     BL_PROFILE("MultiFab::SumBoundary_finish()");
 
-    if ( n_grow == IntVect::TheZeroVector() && boxArray().ixType().cellCentered()) return;
+    // If pcd doesn't exist, was all local and operation was fully completed in "SumBoundary_nowait".
+    if ( (n_grow == IntVect::TheZeroVector() && boxArray().ixType().cellCentered()) || !(this->pcd) ) return;
 
     FabArray<FArrayBox>* tmp = const_cast<FabArray<FArrayBox>*> (this->pcd->src);
     this->ParallelCopy_finish();

--- a/Src/Base/AMReX_MultiFab.cpp
+++ b/Src/Base/AMReX_MultiFab.cpp
@@ -1231,6 +1231,9 @@ MultiFab::SumBoundary_nowait (int scomp, int ncomp, IntVect const& nghost, const
     MultiFab::Copy(*tmp, *this, scomp, 0, ncomp, n_grow);
     this->setVal(0.0, scomp, ncomp, nghost);
     this->ParallelCopy_nowait(*tmp,0,scomp,ncomp,n_grow,nghost,period,FabArrayBase::ADD);
+
+    // All local. Operation complete.
+    if (!this->pcd) { delete tmp; }
 }
 
 void
@@ -1238,12 +1241,12 @@ MultiFab::SumBoundary_finish ()
 {
     BL_PROFILE("MultiFab::SumBoundary_finish()");
 
-    // If pcd doesn't exist, was all local and operation was fully completed in "SumBoundary_nowait".
+    // If pcd doesn't exist, ParallelCopy was all local and operation was fully completed in "SumBoundary_nowait".
     if ( (n_grow == IntVect::TheZeroVector() && boxArray().ixType().cellCentered()) || !(this->pcd) ) return;
 
     FabArray<FArrayBox>* tmp = const_cast<FabArray<FArrayBox>*> (this->pcd->src);
     this->ParallelCopy_finish();
-    tmp->clear();
+    delete tmp;
 }
 
 std::unique_ptr<MultiFab>

--- a/Src/Base/AMReX_MultiFab.cpp
+++ b/Src/Base/AMReX_MultiFab.cpp
@@ -1188,16 +1188,9 @@ MultiFab::negate (const Box& region, int comp, int num_comp, int nghost)
 }
 
 void
-MultiFab::SumBoundary (int scomp, int ncomp, IntVect const& nghost, const Periodicity& period)
+MultiFab::SumBoundary (const Periodicity& period)
 {
-    BL_PROFILE("MultiFab::SumBoundary()");
-
-    if ( n_grow == IntVect::TheZeroVector() && boxArray().ixType().cellCentered()) return;
-
-    MultiFab tmp(boxArray(), DistributionMap(), ncomp, n_grow, MFInfo(), Factory());
-    MultiFab::Copy(tmp, *this, scomp, 0, ncomp, n_grow);
-    this->setVal(0.0, scomp, ncomp, nghost);
-    this->copy(tmp,0,scomp,ncomp,n_grow,nghost,period,FabArrayBase::ADD);
+    SumBoundary(0, n_comp, IntVect(0), period);
 }
 
 void
@@ -1207,9 +1200,49 @@ MultiFab::SumBoundary (int scomp, int ncomp, const Periodicity& period)
 }
 
 void
-MultiFab::SumBoundary (const Periodicity& period)
+MultiFab::SumBoundary (int scomp, int ncomp, IntVect const& nghost, const Periodicity& period)
 {
-    SumBoundary(0, n_comp, IntVect(0), period);
+    BL_PROFILE("MultiFab::SumBoundary()");
+
+    SumBoundary_nowait(scomp, ncomp, nghost, period);
+    SumBoundary_finish();
+}
+
+void
+MultiFab::SumBoundary_nowait (const Periodicity& period)
+{
+    SumBoundary_nowait(0, n_comp, IntVect(0), period);
+}
+
+void
+MultiFab::SumBoundary_nowait (int scomp, int ncomp, const Periodicity& period)
+{
+    SumBoundary_nowait(scomp, ncomp, IntVect(0), period);
+}
+
+void
+MultiFab::SumBoundary_nowait (int scomp, int ncomp, IntVect const& nghost, const Periodicity& period)
+{
+    BL_PROFILE("MultiFab::SumBoundary_nowait()");
+
+    if ( n_grow == IntVect::TheZeroVector() && boxArray().ixType().cellCentered()) return;
+
+    MultiFab* tmp = new MultiFab( boxArray(), DistributionMap(), ncomp, n_grow, MFInfo(), Factory() );
+    MultiFab::Copy(*tmp, *this, scomp, 0, ncomp, n_grow);
+    this->setVal(0.0, scomp, ncomp, nghost);
+    this->ParallelCopy_nowait(*tmp,0,scomp,ncomp,n_grow,nghost,period,FabArrayBase::ADD);
+}
+
+void
+MultiFab::SumBoundary_finish ()
+{
+    BL_PROFILE("MultiFab::SumBoundary_finish()");
+
+    if ( n_grow == IntVect::TheZeroVector() && boxArray().ixType().cellCentered()) return;
+
+    FabArray<FArrayBox>* tmp = const_cast<FabArray<FArrayBox>*> (this->pc_src);
+    this->ParallelCopy_finish();
+    tmp->clear();
 }
 
 std::unique_ptr<MultiFab>


### PR DESCRIPTION
## Summary

Non-blocking SumBoundary, using the stored MF pointer in PCData. 

Could use a double-check that this is the preferred, non-memory leak way to do this. Feels a bit unsafe, as is.

## Additional background

SumBoundary isn't described in the docs anywhere, so we'd have to add SumBoundary before adding this.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
