### PR TITLE
Remove an expensive assertion in BoxArray::contains

### DIFF
--- a/Src/Base/AMReX_BoxArray.cpp
+++ b/Src/Base/AMReX_BoxArray.cpp
@@ -982,7 +982,6 @@ BoxArray::contains (const Box& b, bool assume_disjoint_ba) const
         if (isects.size() > 0)
         {
             if (assume_disjoint_ba) {
-                BL_ASSERT(isDisjoint());
                 Long nbx = b.numPts(), nisects = 0L;
                 for (int i = 0, N = isects.size(); i < N; i++) {
                     nisects += isects[i].second.numPts();


### PR DESCRIPTION
The assertion gets extremely expensive for large runs with long skinny
patches when it's used by ClusterList::intersect.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
