### PR TITLE
Remove Warnings in DEBUG in AssignParticle Test

### DIFF
--- a/Tests/Particles/AssignDensity/main.cpp
+++ b/Tests/Particles/AssignDensity/main.cpp
@@ -30,9 +30,6 @@ void test_assign_density(TestParams& parms)
   IntVect domain_hi(AMREX_D_DECL(parms.nx - 1, parms.ny - 1, parms.nz-1));
   const Box domain(domain_lo, domain_hi);
 
-  // This says we are using Cartesian coordinates
-  int coord = 0;
-
   // This sets the boundary conditions to be doubly or triply periodic
   int is_per[BL_SPACEDIM];
   for (int i = 0; i < BL_SPACEDIM; i++)
@@ -68,7 +65,7 @@ void test_assign_density(TestParams& parms)
   int iseed = 451;
   Real mass = 10.0;
 
-  MyParticleContainer::ParticleInitData pdata = {mass, AMREX_D_DECL(1.0, 2.0, 3.0)};
+  MyParticleContainer::ParticleInitData pdata = {mass, AMREX_D_DECL(1.0, 2.0, 3.0), {}, {}, {}};
   myPC.InitRandom(num_particles, iseed, pdata, serialize);
   myPC.AssignCellDensitySingleLevel(0, partMF, 0, 4, 0);
 

--- a/Tests/Particles/AssignDensity/main.cpp
+++ b/Tests/Particles/AssignDensity/main.cpp
@@ -65,7 +65,7 @@ void test_assign_density(TestParams& parms)
   int iseed = 451;
   Real mass = 10.0;
 
-  MyParticleContainer::ParticleInitData pdata = {mass, AMREX_D_DECL(1.0, 2.0, 3.0), {}, {}, {}};
+  MyParticleContainer::ParticleInitData pdata = {{mass, AMREX_D_DECL(1.0, 2.0, 3.0)}, {}, {}, {}};
   myPC.InitRandom(num_particles, iseed, pdata, serialize);
   myPC.AssignCellDensitySingleLevel(0, partMF, 0, 4, 0);
 


### PR DESCRIPTION
## Summary

Removing a un-used variable (replaced with `CoordSys::cartesian`) and avoiding this warning (below).

If there's a different, preferred way, just let me know.

```
main.cpp: In function ‘void test_assign_density(TestParams&)’:
main.cpp:68:83: warning: missing initializer for member ‘amrex::ParticleInitType<4, 0, 0, 0>::int_struct_data’ [-Wmissing-field-initializers]
   MyParticleContainer::ParticleInitData pdata = {mass, AMREX_D_DECL(1.0, 2.0, 3.0)};
                                                                                   ^
main.cpp:68:83: warning: missing initializer for member ‘amrex::ParticleInitType<4, 0, 0, 0>::real_array_data’ [-Wmissing-field-initializers]
main.cpp:68:83: warning: missing initializer for member ‘amrex::ParticleInitType<4, 0, 0, 0>::int_array_data’ [-Wmissing-field-initializers]

```