### PR TITLE
Optimizing away temporary BoxArrays in AmrMesh::MakeNewGrids

### DIFF
--- a/Src/Amr/AMReX_Amr.H
+++ b/Src/Amr/AMReX_Amr.H
@@ -19,7 +19,6 @@ namespace amrex {
 
 class AmrLevel;
 class LevelBld;
-class BoxDomain;
 #if defined(BL_USE_SENSEI_INSITU)
 class AmrInSituBridge;
 #endif

--- a/Src/Amr/AMReX_Amr.cpp
+++ b/Src/Amr/AMReX_Amr.cpp
@@ -4,7 +4,6 @@
 #include <AMReX_Vector.H>
 #include <AMReX_CoordSys.H>
 #include <AMReX_ParmParse.H>
-#include <AMReX_BoxDomain.H>
 #include <AMReX_Cluster.H>
 #include <AMReX_LevelBld.H>
 #include <AMReX_AmrLevel.H>
@@ -3338,4 +3337,3 @@ Amr::RedistributeParticles ()
 #endif
 
 }
-

--- a/Src/AmrCore/AMReX_Cluster.H
+++ b/Src/AmrCore/AMReX_Cluster.H
@@ -3,11 +3,7 @@
 #define AMREX_Cluster_H_
 #include <AMReX_Config.H>
 
-#include <AMReX_IntVect.H>
-#include <AMReX_Box.H>
-#include <AMReX_Array.H>
-#include <AMReX_Vector.H>
-#include <AMReX_BoxArray.H>
+#include <AMReX_BoxList.H>
 #include <AMReX_REAL.H>
 
 #include <list>
@@ -15,6 +11,7 @@
 namespace amrex {
 
 class BoxDomain;
+class BoxArray;
 class ClusterList;
 
 
@@ -220,12 +217,13 @@ public:
     void new_chop (Real eff);
 
     /**
-    * \brief Intersect clusters with BoxDomain to insure cluster
-    * boxes are interior to domain.
+    * \brief Intersect clusters with BoxArray to insure cluster
+    * boxes are interior to the domain of BoxArray.  Note that
+    * ba is modified during the process.
     *
-    * \param dom
+    * \param ba
     */
-    void intersect (const BoxDomain& dom);
+    void intersect (BoxArray& ba);
 
 private:
 

--- a/Src/AmrCore/AMReX_Cluster.cpp
+++ b/Src/AmrCore/AMReX_Cluster.cpp
@@ -1,5 +1,6 @@
 
 #include <AMReX_Cluster.H>
+#include <AMReX_BoxArray.H>
 #include <AMReX_BoxDomain.H>
 #include <AMReX_Vector.H>
 #include <AMReX_Array.H>
@@ -562,15 +563,13 @@ ClusterList::new_chop (Real eff)
 }
 
 void
-ClusterList::intersect (const BoxDomain& dom)
+ClusterList::intersect (BoxArray& domba)
 {
     BL_PROFILE("ClusterList::intersect()");
 
-    //
-    // Make a BoxArray covering dom.
-    // We'll use this to speed up the contains() test below.
-    //
-    BoxArray domba(dom.boxList());
+    domba.removeOverlap();
+
+    BoxDomain dom(domba.boxList());
 
     for (std::list<Cluster*>::iterator cli = lst.begin(); cli != lst.end(); )
     {
@@ -601,6 +600,8 @@ ClusterList::intersect (const BoxDomain& dom)
             lst.erase(cli++);
         }
     }
+
+    domba.clear();
 }
 
 }

--- a/Src/AmrCore/AMReX_TagBox.H
+++ b/Src/AmrCore/AMReX_TagBox.H
@@ -21,8 +21,6 @@ namespace amrex {
 * This class is used to tag cells in a Box that need addition refinement.
 */
 
-class BoxDomain;
-
 class TagBox final
     :
     public BaseFab<char>
@@ -189,22 +187,6 @@ public:
     * \param geom
     */
     void mapPeriodicRemoveDuplicates (const Geometry& geom);
-
-    /**
-    * \brief Set values in bl to val.
-    *
-    * \param bl
-    * \param val
-    */
-    void setVal (const BoxList& bl, TagBox::TagVal val);
-
-    /**
-    * \brief Set values in bd to val.
-    *
-    * \param bd
-    * \param val
-    */
-    void setVal (const BoxDomain& bd, TagBox::TagVal val);
 
     /**
     * \brief Set values in ba to val.

--- a/Src/AmrCore/AMReX_TagBox.cpp
+++ b/Src/AmrCore/AMReX_TagBox.cpp
@@ -661,19 +661,6 @@ TagBoxArray::collate (Gpu::PinnedVector<IntVect>& TheGlobalCollateSpace) const
 }
 
 void
-TagBoxArray::setVal (const BoxList& bl, TagBox::TagVal val)
-{
-    BoxArray ba(bl);
-    setVal(ba,val);
-}
-
-void
-TagBoxArray::setVal (const BoxDomain& bd, TagBox::TagVal val)
-{
-    setVal(bd.boxList(),val);
-}
-
-void
 TagBoxArray::setVal (const BoxArray& ba, TagBox::TagVal val)
 {
     Vector<Array4BoxTag<char> > tags;

--- a/Src/Base/AMReX_BoxDomain.H
+++ b/Src/Base/AMReX_BoxDomain.H
@@ -13,6 +13,7 @@
 namespace amrex
 {
     class BoxDomain;
+    class BoxArray;
 
     //! Returns the complement of BoxDomain bl in Box b.
     BoxDomain complementIn (const Box& b, const BoxDomain& bl);
@@ -67,6 +68,7 @@ class BoxDomain
     protected BoxList
 {
 public:
+    friend class ClusterList;
 
     typedef BoxList::const_iterator const_iterator;
     //! Construct an empty BoxDomain of IndexType::TheCellType().
@@ -158,6 +160,10 @@ public:
     //! Creates the complement of BoxDomain bl in Box b.
     BoxDomain& complementIn (const Box&       b,
                              const BoxDomain& bl);
+
+private:
+    //! Construct from a BoxList that has no overlap
+    explicit BoxDomain (BoxList&& bl);
 };
 
 }

--- a/Src/Base/AMReX_BoxDomain.cpp
+++ b/Src/Base/AMReX_BoxDomain.cpp
@@ -112,6 +112,11 @@ BoxDomain::BoxDomain (const Box& bx)
 {
 }
 
+//! Construct from a BoxList that has no overlap
+BoxDomain::BoxDomain (BoxList&& bl)
+    : BoxList(std::move(bl))
+{}
+
 void
 BoxDomain::add (const Box& b)
 {


### PR DESCRIPTION
Previously, we stored the information needed for proper nesting in BoxList.
Then when they were used, they were repeatedly converted to BoxArray for
hash based fast intersection.  In this commit, we store them directly in
BoxArray, thus removing those hidden temporaries.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
