### PR TITLE
Add new parameter to BoxArray::contains(BoxArray)

### DIFF
--- a/Src/Base/AMReX_BoxArray.H
+++ b/Src/Base/AMReX_BoxArray.H
@@ -726,13 +726,17 @@ public:
     bool contains (const IntVect& v) const;
 
     /**
-    * \brief True if the Box is within any of the Boxes in the List.
+    * \brief True if the Box is contained in this BoxArray(+ng).
     * The Box must also have the same IndexType as those in this BoxArray.
     */
-    bool contains (const Box& b, bool assume_disjoint_ba = false) const;
+    bool contains (const Box& b, bool assume_disjoint_ba = false,
+                   const IntVect& ng = IntVect(0)) const;
 
-    //! True if all Boxes in bl are contained in this BoxArray.
-    bool contains (const BoxArray& bl, bool assume_disjoint_ba = false) const;
+    /**
+     * \brief True if all Boxes in ba are contained in this BoxArray(+ng).
+     */
+    bool contains (const BoxArray& ba, bool assume_disjoint_ba = false,
+                   const IntVect& ng = IntVect(0)) const;
 
     //! Return smallest Box that contains all Boxes in this BoxArray.
     Box minimalBox () const;


### PR DESCRIPTION
In regrid, we need to figure out how many cells we need to grow the current
coarse level grids in order for the fine grids to be properly nested.  We
used BoxArray::contains(BoxArray) in a loop and grew the coarse BoxArray in
the loop.  In this commit, we add a new parameter to
BoxArray::contains(BoxArray) to specify the number of grow cells without
having to actually grow the BoxArray.  This is better than the previous
version because growing BoxArray would invalidate the hash data in BoxArray.
We also modify the implementation of BoxArray::contains(Box) in this commit.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
