### PR TITLE
Generalize elemwiseMin and elemwiseMax.

### DIFF
--- a/Src/Base/AMReX_Algorithm.H
+++ b/Src/Base/AMReX_Algorithm.H
@@ -42,14 +42,30 @@ namespace amrex
         return max(max(a,b),c...);
     }
 
+    template <class T>
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE constexpr
-    Dim3 elemwiseMin (Dim3 const& a, Dim3 const& b) noexcept {
-        return Dim3{amrex::min(a.x,b.x),amrex::min(a.y,b.y),amrex::min(a.z,b.z)};
+    T elemwiseMin (T const& a, T const& b) noexcept {
+        return T{amrex::min(a.x,b.x),amrex::min(a.y,b.y),amrex::min(a.z,b.z)};
     }
 
+    template <class T, class ... Ts>
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE constexpr
-    Dim3 elemwiseMax (Dim3 const& a, Dim3 const& b) noexcept {
-        return Dim3{amrex::max(a.x,b.x),amrex::max(a.y,b.y),amrex::max(a.z,b.z)};
+    T elemwiseMin (const T& a, const T& b, const Ts& ... c) noexcept
+    {
+        return elemwiseMin(elemwiseMin(a,b),c...);
+    }
+
+    template <class T>
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE constexpr
+    T elemwiseMax (T const& a, T const& b) noexcept {
+        return T{amrex::max(a.x,b.x),amrex::max(a.y,b.y),amrex::max(a.z,b.z)};
+    }
+
+    template <class T, class ... Ts>
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE constexpr
+    T elemwiseMax (const T& a, const T& b, const Ts& ... c) noexcept
+    {
+        return elemwiseMax(elemwiseMax(a,b),c...);
     }
 
     template<typename T>


### PR DESCRIPTION
This allows these functions to be called on `XDim3` objects, as well as any other object that has `x`, `y`, and `z` data members, instead of just `Dim3`. Additionally, it makes them variadic so they work on any number of objects, instead of just two.

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
