### PR TITLE
Disable HIP device assertion

### DIFF
--- a/Src/Base/AMReX.H
+++ b/Src/Base/AMReX.H
@@ -109,8 +109,11 @@ namespace amrex
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     void Error (const char* msg = 0) {
 #if AMREX_DEVICE_COMPILE
-#ifdef NDEBUG
+#if defined(NDEBUG) || defined(AMREX_USE_HIP)
         amrex::ignore_unused(msg);
+//#elif defined(AMREX_USE_HIP)
+//        if (msg) { AMREX_DEVICE_PRINTF("%s", msg); }
+//        assert(0);
 #else
         Error_device(msg);
 #endif
@@ -132,8 +135,10 @@ namespace amrex
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     void Warning (const char * msg) {
 #if AMREX_DEVICE_COMPILE
-#ifdef NDEBUG
+#if defined(NDEBUG) || defined(AMREX_USE_HIP)
         amrex::ignore_unused(msg);
+//#elif defined(AMREX_USE_HIP)
+//        if (msg) { AMREX_DEVICE_PRINTF("%s", msg); }
 #else
         Warning_device(msg);
 #endif
@@ -155,8 +160,11 @@ namespace amrex
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     void Abort (const char * msg = 0) {
 #if AMREX_DEVICE_COMPILE
-#ifdef NDEBUG
+#if defined(NDEBUG) || defined(AMREX_USE_HIP)
         amrex::ignore_unused(msg);
+//#elif defined(AMREX_USE_HIP)
+//        if (msg) { AMREX_DEVICE_PRINTF("%s", msg); }
+//        assert(0);
 #else
         Abort_device(msg);
 #endif
@@ -181,8 +189,17 @@ namespace amrex
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     void Assert (const char* EX, const char* file, int line, const char* msg = nullptr) {
 #if AMREX_DEVICE_COMPILE
-#ifdef NDEBUG
+#if defined(NDEBUG) || defined(AMREX_USE_HIP)
         amrex::ignore_unused(EX,file,line,msg);
+//#elif defined(AMREX_USE_HIP)
+//        if (msg) {
+//            AMREX_DEVICE_PRINTF("Assertion `%s' failed, file \"%s\", line %d, Msg: %s",
+//                                EX, file, line, msg);
+//        } else {
+//            AMREX_DEVICE_PRINTF("Assertion `%s' failed, file \"%s\", line %d",
+//                                EX, file, line);
+//        }
+//        assert(0);
 #else
         Assert_device(EX,file,line,msg);
 #endif

--- a/Src/Base/AMReX_GpuQualifiers.H
+++ b/Src/Base/AMReX_GpuQualifiers.H
@@ -13,15 +13,14 @@
 #define AMREX_GPU_GLOBAL __global__
 #define AMREX_GPU_HOST_DEVICE __host__ __device__
 #define AMREX_GPU_CONSTANT __constant__
+#define AMREX_GPU_EXTERNAL
 
 #if defined(AMREX_USE_HIP) && !defined(AMREX_USE_CUDA)
 #define AMREX_GPU_MANAGED __device__
 #define AMREX_GPU_DEVICE_MANAGED __device__
-#define AMREX_GPU_EXTERNAL __attribute__((weak))
 #else
 #define AMREX_GPU_MANAGED __managed__
 #define AMREX_GPU_DEVICE_MANAGED __device__ __managed__
-#define AMREX_GPU_EXTERNAL
 #endif
 
 #else


### PR DESCRIPTION
It makes the compliation very slow and it does not currently work.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
