### PR TITLE
Cray complier type detection

### DIFF
--- a/Tools/GNUMake/comps/cray.mak
+++ b/Tools/GNUMake/comps/cray.mak
@@ -13,26 +13,13 @@ F90FLAGS =
 
 ########################################################################
 
-# CRAY_CC_VERSION is defined by the 'cce' module. Starting with CCE 9, Cray
-# changed the C and C++ compilers to clang/LLVM based, so all of the
-# options/flags for those compilers changed. But the Cray Fortran compiler is
-# still based on CCE 8 and so it has the same options as before.
-COMP_VERSION = $(shell echo $(CRAY_CC_VERSION) | cut -f 1 -d .)
-
-ifeq ($(shell expr $(COMP_VERSION) \>= 9), 1)
-  CCE_GE_V9 := TRUE
+ifneq ($(shell CC --version | grep "LLVM"),)
+  CRAY_IS_CLANG_BASED = TRUE
 else
-  CCE_GE_V9 := FALSE
+  CRAY_IS_CLANG_BASED = FALSE
 endif
 
-# we need to be careful on the A64fx
-ifeq ($(CRAY_CC_VERSION),10.0.1)
-  ifeq ($(CRAY_ARCH_TARGET),aarch64)
-    CCE_GE_V9 := FALSE
-  endif
-endif
-
-ifeq ($(CCE_GE_V9),FALSE)
+ifeq ($(CRAY_IS_CLANG_BASED),FALSE)
   # -MMD -MP not supprted
   USE_LEGACY_DEPFLAGS = TRUE
   DEPFLAGS =
@@ -43,7 +30,7 @@ endif
 
 ifeq ($(DEBUG),TRUE)
 
-  ifeq ($(CCE_GE_V9),TRUE)
+  ifeq ($(CRAY_IS_CLANG_BASED),TRUE)
     CXXFLAGS += -g -O0
     CFLAGS   += -g -O0
     FFLAGS   += -g -O0 -e i -K trap=fp
@@ -58,7 +45,7 @@ ifeq ($(DEBUG),TRUE)
   endif
 
 else
-  ifeq ($(CCE_GE_V9),TRUE)
+  ifeq ($(CRAY_IS_CLANG_BASED),TRUE)
     # The LLVM optimizer is not as aggressive as the native Cray optimizer from
     # CCE <= 8. So we adjust some flags to achieve similar optimization. See
     # this page:
@@ -86,7 +73,7 @@ else
   CXXSTD := c++14
 endif
 
-ifeq ($(CCE_GE_V9),TRUE)
+ifeq ($(CRAY_IS_CLANG_BASED),TRUE)
   CXXFLAGS += -std=$(CXXSTD)
   CFLAGS   += -std=c99
 else
@@ -104,7 +91,7 @@ FMODULES = -I $(fmoddir) -J $(fmoddir)
 ifeq ($(USE_OMP),TRUE)
   # Starting in CCE 9, OpenMP is disabled by default in each of C/C++/Fortran
   # compilers.
-  ifeq ($(CCE_GE_V9),TRUE)
+  ifeq ($(CRAY_IS_CLANG_BASED),TRUE)
     CXXFLAGS += -fopenmp
     CFLAGS   += -fopenmp
     FFLAGS   += -h omp
@@ -113,23 +100,23 @@ ifeq ($(USE_OMP),TRUE)
     GENERIC_COMP_FLAGS += -h omp
   endif
 else
-  ifeq ($(CCE_GE_V9),FALSE)
+  ifeq ($(CRAY_IS_CLANG_BASED),FALSE)
     GENERIC_COMP_FLAGS += -h noomp
   endif
 endif
 
 ifeq ($(USE_ACC),TRUE)
   # OpenACC is removed from CCE altogether in CCE 9.
-  ifeq ($(CCE_GE_V9),TRUE)
+  ifeq ($(CRAY_IS_CLANG_BASED),TRUE)
     $(error OpenACC has been removed from CCE >= 9.)
   endif
 else
-  ifeq ($(CCE_GE_V9),FALSE)
+  ifeq ($(CRAY_IS_CLANG_BASED),FALSE)
     GENERIC_COMP_FLAGS += -h noacc
   endif
 endif
 
-ifeq ($(CCE_GE_V9),TRUE)
+ifeq ($(CRAY_IS_CLANG_BASED),TRUE)
   CXXFLAGS += -Wno-pass-failed -Wno-c++17-extensions
 endif
 


### PR DESCRIPTION
There are two types of Cray compilers, the classical and clang based.  The version number
is not a reliable way to determine the type.  For example, cce/9 on Cori has both
versions.  Cray compilers for aarch64 on Ookami are classical.  Thus we switch to grep
"LLVM" in `CC --version`.  This works on both Cori and Ookami.

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
