### PR TITLE
No casting to unsigned long long needed in iMultiFab::sum

### DIFF
--- a/.github/workflows/dependencies/documentation.sh
+++ b/.github/workflows/dependencies/documentation.sh
@@ -16,5 +16,6 @@ sudo apt-get install -y --no-install-recommends\
     texlive \
     texlive-latex-extra \
     texlive-lang-cjk \
+    tex-gyre \
     latexmk
 

--- a/Src/Base/AMReX_iMultiFab.cpp
+++ b/Src/Base/AMReX_iMultiFab.cpp
@@ -325,12 +325,10 @@ iMultiFab::sum (int comp, int nghost, bool local) const
     Long sm = 0;
 
 #ifdef AMREX_USE_GPU
-    // If on GPUs, cast to unsigned long long to take advantage of hardware support.
     if (Gpu::inLaunchRegion())
     {
-        long long points = 0;
         ReduceOps<ReduceOpSum> reduce_op;
-        ReduceData<unsigned long long> reduce_data(reduce_op);
+        ReduceData<Long> reduce_data(reduce_op);
         using ReduceTuple = typename decltype(reduce_data)::Type;
 
         for (MFIter mfi(*this); mfi.isValid(); ++mfi)
@@ -340,15 +338,12 @@ iMultiFab::sum (int comp, int nghost, bool local) const
             reduce_op.eval(bx, reduce_data,
             [=] AMREX_GPU_DEVICE (int i, int j, int k) -> ReduceTuple
             {
-                return { static_cast<unsigned long long>(arr(i,j,k,comp)) -
-                         static_cast<unsigned long long>(INT_MIN) };
+                return { static_cast<Long>(arr(i,j,k,comp)) };
             });
-            points += bx.numPts();
         }
 
         ReduceTuple hv = reduce_data.value(reduce_op);
-        sm = static_cast<Long>( static_cast<long long>(amrex::get<0>(hv))
-                              + static_cast<long long>(INT_MIN)*points);
+        sm = amrex::get<0>(hv);
     }
     else
 #endif


### PR DESCRIPTION
Because we no longer use atomics in reduction, we do not need to cast to
unsigned long long in iMultiFab::sum anymore.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
