### PR TITLE
Use CPU memory in memory pools for OpenMP threads

### DIFF
--- a/Src/Base/AMReX_MemPool.cpp
+++ b/Src/Base/AMReX_MemPool.cpp
@@ -45,14 +45,7 @@ void amrex_mempool_init ()
 
         the_memory_pool.resize(nthreads);
         for (int i=0; i<nthreads; ++i) {
-// xxxxx HIP FIX THIS - Default Arena w/o managed?
-// Default arena is currently Device on HIP where there is no managed option.
-// Need to adjust to CPU specifically in that case.
-#ifdef AMREX_USE_HIP
             the_memory_pool[i] = std::make_unique<CArena>(0, ArenaInfo().SetCpuMemory());
-#else
-            the_memory_pool[i] = std::make_unique<CArena>();
-#endif
         }
 
 #ifdef AMREX_USE_OMP


### PR DESCRIPTION
The memory pools are primarily used by Fortran functions as scratch space
inside OpenMP parallel regions.  There are no reasons to allocate them in
managed device memory.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
