### PR TITLE
Launch bounds

### DIFF
--- a/Src/Base/AMReX_GpuLaunch.H
+++ b/Src/Base/AMReX_GpuLaunch.H
@@ -32,10 +32,10 @@
 
 #ifdef AMREX_USE_CUDA
 #  define AMREX_LAUNCH_KERNEL(blocks, threads, sharedMem, stream, ... ) \
-        amrex::launch_global<<<blocks, threads, sharedMem, stream>>>(__VA_ARGS__);
+        amrex::launch_global<AMREX_GPU_MAX_THREADS><<<blocks, threads, sharedMem, stream>>>(__VA_ARGS__);
 #elif defined(AMREX_USE_HIP)
 #  define AMREX_LAUNCH_KERNEL(blocks, threads, sharedMem, stream, ... ) \
-        hipLaunchKernelGGL(launch_global, blocks, threads, sharedMem, stream, __VA_ARGS__);
+        hipLaunchKernelGGL(launch_global<AMREX_GPU_MAX_THREADS>, blocks, threads, sharedMem, stream, __VA_ARGS__);
 #endif
 
 

--- a/Src/Base/AMReX_GpuReduce.H
+++ b/Src/Base/AMReX_GpuReduce.H
@@ -554,8 +554,6 @@ void deviceReduceSum (T * dest, T source, Gpu::Handler const& handler) noexcept
             deviceReduceSum_full<128,T>(dest, source);
         } else if (blockDim.x == 256) {
             deviceReduceSum_full<256,T>(dest, source);
-        } else if (blockDim.x == 512) {
-            deviceReduceSum_full<512,T>(dest, source);
         } else {
             deviceReduceSum_full<T>(dest, source);
         }
@@ -575,8 +573,6 @@ void deviceReduceMin (T * dest, T source, Gpu::Handler const& handler) noexcept
             deviceReduceMin_full<128,T>(dest, source);
         } else if (blockDim.x == 256) {
             deviceReduceMin_full<256,T>(dest, source);
-        } else if (blockDim.x == 512) {
-            deviceReduceMin_full<512,T>(dest, source);
         } else {
             deviceReduceMin_full<T>(dest, source);
         }
@@ -596,8 +592,6 @@ void deviceReduceMax (T * dest, T source, Gpu::Handler const& handler) noexcept
             deviceReduceMax_full<128,T>(dest, source);
         } else if (blockDim.x == 256) {
             deviceReduceMax_full<256,T>(dest, source);
-        } else if (blockDim.x == 512) {
-            deviceReduceMax_full<512,T>(dest, source);
         } else {
             deviceReduceMax_full<T>(dest, source);
         }
@@ -616,8 +610,6 @@ void deviceReduceLogicalAnd (int * dest, int source, Gpu::Handler const& handler
             deviceReduceLogicalAnd_full<128>(dest, source);
         } else if (blockDim.x == 256) {
             deviceReduceLogicalAnd_full<256>(dest, source);
-        } else if (blockDim.x == 512) {
-            deviceReduceLogicalAnd_full<512>(dest, source);
         } else {
             deviceReduceLogicalAnd_full(dest, source);
         }
@@ -636,8 +628,6 @@ void deviceReduceLogicalOr (int * dest, int source, Gpu::Handler const& handler)
             deviceReduceLogicalOr_full<128>(dest, source);
         } else if (blockDim.x == 256) {
             deviceReduceLogicalOr_full<256>(dest, source);
-        } else if (blockDim.x == 512) {
-            deviceReduceLogicalOr_full<512>(dest, source);
         } else {
             deviceReduceLogicalOr_full(dest, source);
         }


### PR DESCRIPTION
Set launch bounds to AMREX_GPU_MAX_THREADS (256 by default) for all kernel
launches.  This helps resolve some HIP compiler issues we have had recently.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
