### PR TITLE
Remove minBlocksPerMultiprocessor from launch bounds

### DIFF
--- a/Src/Base/AMReX_GpuLaunchGlobal.H
+++ b/Src/Base/AMReX_GpuLaunchGlobal.H
@@ -12,7 +12,7 @@ namespace amrex {
     AMREX_GPU_GLOBAL void launch_global (L f0) { f0(); }
 
     template<int amrex_launch_bounds_max_threads, class L>
-    __launch_bounds__(amrex_launch_bounds_max_threads,1)
+    __launch_bounds__(amrex_launch_bounds_max_threads)
     AMREX_GPU_GLOBAL void launch_global (L f0) { f0(); }
 #endif
 


### PR DESCRIPTION
After reading CUDA Programming Guide, I think we should remove
minBlocksPerMultiprocessor from launch bounds, so that it's closer to what
we had before.

https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#launch-bounds

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
