### PR TITLE
Clang Cray can also show up with explicit Clang identifier

### DIFF
--- a/Tools/GNUMake/comps/cray.mak
+++ b/Tools/GNUMake/comps/cray.mak
@@ -13,7 +13,7 @@ F90FLAGS =
 
 ########################################################################
 
-ifneq ($(shell CC --version | grep "LLVM"),)
+ifneq ($(shell CC --version | grep -E "LLVM|clang"),)
   CRAY_IS_CLANG_BASED = TRUE
 else
   CRAY_IS_CLANG_BASED = FALSE


### PR DESCRIPTION
## Summary

This supplements #2001 with an additional way that the Clang-based Cray compiler can present.

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
