### PR TITLE
Device profilerStart and profilerStop APIs

### DIFF
--- a/Src/Base/AMReX_GpuDevice.H
+++ b/Src/Base/AMReX_GpuDevice.H
@@ -129,6 +129,8 @@ public:
 #endif
 
     static std::size_t freeMemAvailable ();
+    static void profilerStart ();
+    static void profilerStop ();
 
 #ifdef AMREX_USE_GPU
 

--- a/Src/Base/AMReX_GpuDevice.cpp
+++ b/Src/Base/AMReX_GpuDevice.cpp
@@ -311,7 +311,7 @@ Device::Initialize ()
 #if (defined(AMREX_PROFILING) || defined(AMREX_TINY_PROFILING))
     nvtxRangeEnd(nvtx_init);
 #endif
-    cudaProfilerStart();
+    profilerStart();
 
     if (amrex::Verbose()) {
 #if defined(AMREX_USE_MPI) && (__CUDACC_VER_MAJOR__ >= 10)
@@ -330,7 +330,7 @@ Device::Initialize ()
 #endif // AMREX_USE_MPI && NVCC >= 10
     }
 
-    cudaProfilerStart();
+    profilerStart();
 
 #elif defined(AMREX_USE_HIP)
     if (amrex::Verbose()) {
@@ -988,6 +988,22 @@ Device::freeMemAvailable ()
     return f;
 #else
     return 0;
+#endif
+}
+
+void
+Device::profilerStart ()
+{
+#ifdef AMREX_USE_CUDA
+    AMREX_GPU_SAFE_CALL(cudaProfilerStart());
+#endif
+}
+
+void
+Device::profilerStop ()
+{
+#ifdef AMREX_USE_CUDA
+    AMREX_GPU_SAFE_CALL(cudaProfilerStop());
 #endif
 }
 


### PR DESCRIPTION
## Summary

Add a Gpu::Device interface to cudaProfilerStart and cudaProfilerStop so that the application can use this without CUDA-specific code. Similar hooks for HIP and DPC++ could be added later as needed.

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
