### PR TITLE
CMake: HIP Modernizing & RDC

### DIFF
--- a/.github/workflows/hip.yml
+++ b/.github/workflows/hip.yml
@@ -49,6 +49,7 @@ jobs:
             -DAMReX_ENABLE_TESTS=ON                       \
             -DAMReX_PARTICLES=ON                          \
             -DAMReX_FORTRAN=ON                            \
+            -DAMReX_GPU_RDC=OFF                           \
             -DAMReX_LINEAR_SOLVERS=ON                     \
             -DAMReX_GPU_BACKEND=HIP                       \
             -DAMReX_AMD_ARCH=gfx908                       \

--- a/.github/workflows/hip.yml
+++ b/.github/workflows/hip.yml
@@ -19,7 +19,7 @@ jobs:
     #                                                                          ^
     #    /opt/rocm-4.1.1/hip/include/hip/hcc_detail/hip_runtime.h:176:9: note: macro 'select_impl_' defined here
     #    #define select_impl_(_1, _2, impl_, ...) impl_
-    env: {CXXFLAGS: "-fno-operator-names -Werror -Wall -Wextra -Wpedantic -Wnull-dereference -Wfloat-conversion -Wshadow -Woverloaded-virtual -Wextra-semi -Wunreachable-code -Wno-deprecated-declarations -Wno-gnu-zero-variadic-macro-arguments"}
+    env: {CXXFLAGS: "-fno-operator-names -Werror -Wall -Wextra -Wpedantic -Wnull-dereference -Wfloat-conversion -Wshadow -Woverloaded-virtual -Wextra-semi -Wunreachable-code -Wno-deprecated-declarations -Wno-gnu-zero-variadic-macro-arguments -Wno-pass-failed"}
     steps:
     - uses: actions/checkout@v2
     - name: Dependencies
@@ -27,8 +27,24 @@ jobs:
     - name: Build & Install
       run: |
         source /etc/profile.d/rocm.sh
+        export PATH=/opt/rocm-4.1.1/llvm/bin:$PATH
         hipcc --version
-        cmake -S . -B build_full                          \
+        which clang
+        which clang++
+
+        cmake -S . -B build_nofortran                     \
+            -DCMAKE_VERBOSE_MAKEFILE=ON                   \
+            -DAMReX_ENABLE_TESTS=ON                       \
+            -DAMReX_PARTICLES=ON                          \
+            -DAMReX_FORTRAN=OFF                           \
+            -DAMReX_LINEAR_SOLVERS=ON                     \
+            -DAMReX_GPU_BACKEND=HIP                       \
+            -DAMReX_AMD_ARCH=gfx908                       \
+            -DCMAKE_C_COMPILER=$(which clang)             \
+            -DCMAKE_CXX_COMPILER=$(which clang++)         \
+            -DCMAKE_CXX_STANDARD=17
+        cmake --build build_nofortran -j 2
+        cmake -S . -B build_full_legacywrapper            \
             -DCMAKE_VERBOSE_MAKEFILE=ON                   \
             -DAMReX_ENABLE_TESTS=ON                       \
             -DAMReX_PARTICLES=ON                          \
@@ -40,20 +56,7 @@ jobs:
             -DCMAKE_CXX_COMPILER=$(which hipcc)           \
             -DCMAKE_Fortran_COMPILER=$(which gfortran)    \
             -DCMAKE_CXX_STANDARD=17
-        cmake --build build_full -j 2
-        cmake -S . -B build_nofortran                     \
-            -DCMAKE_VERBOSE_MAKEFILE=ON                   \
-            -DAMReX_ENABLE_TESTS=ON                       \
-            -DAMReX_PARTICLES=ON                          \
-            -DAMReX_FORTRAN=OFF                           \
-            -DAMReX_LINEAR_SOLVERS=ON                     \
-            -DAMReX_GPU_BACKEND=HIP                       \
-            -DAMReX_AMD_ARCH=gfx908                       \
-            -DCMAKE_C_COMPILER=$(which clang)             \
-            -DCMAKE_CXX_COMPILER=$(which hipcc)           \
-            -DCMAKE_Fortran_COMPILER=$(which gfortran)    \
-            -DCMAKE_CXX_STANDARD=17
-        cmake --build build_nofortran -j 2
+        cmake --build build_full_legacywrapper -j 2
 
   # Build 2D libamrex hip build with configure
   configure-2d-single-hip:

--- a/Docs/sphinx_documentation/source/GPU.rst
+++ b/Docs/sphinx_documentation/source/GPU.rst
@@ -347,7 +347,7 @@ Below is an example configuration for HIP on Tulip:
 
 ::
 
-   cmake -S . -B build -DAMReX_GPU_BACKEND=HIP -DCMAKE_CXX_COMPILER=$(which clang++) -DAMReX_AMD_ARCH="gfx906,gfx908"  # [other options]
+   cmake -S . -B build -DAMReX_GPU_BACKEND=HIP -DCMAKE_CXX_COMPILER=$(which clang++) -DAMReX_AMD_ARCH="gfx906;gfx908"  # [other options]
    cmake --build build -j 6
 
 

--- a/Docs/sphinx_documentation/source/GPU.rst
+++ b/Docs/sphinx_documentation/source/GPU.rst
@@ -326,6 +326,10 @@ Enabling HIP support (experimental)
 To build AMReX with HIP support in CMake, add
 ``-DAMReX_GPU_BACKEND=HIP -DAMReX_AMD_ARCH=<target-arch> -DCMAKE_CXX_COMPILER=<your-hip-compiler>``
 to the ``cmake`` invocation.
+If you don't need Fortran features (``AMReX_FORTRAN=OFF``), it is recomended to use AMD's ``clang++`` as the HIP compiler.
+(Please see these issues for reference in rocm/HIP <= 4.2.0
+`[1] <https://github.com/ROCm-Developer-Tools/HIP/issues/2275>`__
+`[2] <https://github.com/AMReX-Codes/amrex/pull/2031>`__.)
 
 In AMReX CMake, the HIP compiler is treated as a special C++ compiler and therefore
 the standard CMake variables used to customize the compilation process for C++,
@@ -333,17 +337,18 @@ for example ``CMAKE_CXX_FLAGS``, can be used for HIP as well.
 
 
 Since CMake does not support autodetection of HIP compilers/target architectures
-yet, ``CMAKE_CXX_COMPILER`` must be set to a valid HIP compiler, i.e. ``hipcc`` or ``nvcc``,
+yet, ``CMAKE_CXX_COMPILER`` must be set to a valid HIP compiler, i.e. ``clang++`` or ``hipcc`` or ``nvcc``,
 and ``AMReX_AMD_ARCH`` to the target architecture you are building for.
 Thus **AMReX_AMD_ARCH and CMAKE_CXX_COMPILER are required user-inputs when AMReX_GPU_BACKEND=HIP**.
-We again read also an *environment variable*: ``AMREX_AMD_ARCH`` (note: all caps).
+We again read also an *environment variable*: ``AMREX_AMD_ARCH`` (note: all caps) and the C++ compiler can be hinted as always, e.g. with ``export CXX=$(which clang++)``.
 Below is an example configuration for HIP on Tulip:
 
 .. highlight:: console
 
 ::
 
-   cmake -DAMReX_GPU_BACKEND=HIP -DCMAKE_CXX_COMPILER=$(which hipcc) -DAMReX_AMD_ARCH="gfx906,gfx908"  [other options] /path/to/amrex/source
+   cmake -S . -B build -DAMReX_GPU_BACKEND=HIP -DCMAKE_CXX_COMPILER=$(which clang++) -DAMReX_AMD_ARCH="gfx906,gfx908"  # [other options]
+   cmake --build build -j 6
 
 
 Enabling SYCL support (experimental)

--- a/Tools/CMake/AMReXParallelBackends.cmake
+++ b/Tools/CMake/AMReXParallelBackends.cmake
@@ -258,9 +258,6 @@ if (AMReX_HIP)
                        "See https://github.com/ROCm-Developer-Tools/HIP/issues/2275 "
                        "and https://github.com/AMReX-Codes/amrex/pull/2031 "
                        "for details.")
-       if(AMReX_GPU_RDC)
-           message(FATAL_ERROR "ROCm/HIP <= 4.2.0 cannot build Fortran + AMReX_GPU_RDC.")
-       endif()
    elseif(${_this_comp} STREQUAL hipcc)
        target_link_libraries(amrex PUBLIC ${HIP_LIBRARIES})
        # ARCH flags -- these must be PUBLIC for all downstream targets to use,
@@ -276,7 +273,7 @@ if (AMReX_HIP)
    # device variable support (for codes that use global variables on device)
    # as well as our kernel fusion in AMReX, e.g. happening likely in amr regrid
    # As of ROCm 4.1, we cannot enable this with hipcc, as it looks...
-   if(AMReX_GPU_RDC AND NOT ${_this_comp} STREQUAL hipcc)
+   if(AMReX_GPU_RDC)
        target_compile_options(amrex PUBLIC
           $<$<COMPILE_LANGUAGE:CXX>:-fgpu-rdc> )
        if(CMAKE_VERSION VERSION_LESS 3.18)

--- a/Tools/CMake/AMReXParallelBackends.cmake
+++ b/Tools/CMake/AMReXParallelBackends.cmake
@@ -199,6 +199,15 @@ if (AMReX_HIP)
 
    set(CMAKE_MODULE_PATH "${HIP_PATH}/cmake" ${CMAKE_MODULE_PATH})
 
+
+   if(DEFINED AMReX_AMD_ARCH)
+      # Set the GPU to compile for: semicolon-separated list
+      set(GPU_TARGETS "${AMReX_AMD_ARCH}" CACHE STRING "GPU targets to compile for" FORCE)
+      set(AMDGPU_TARGETS "${AMReX_AMD_ARCH}" CACHE STRING "GPU targets to compile for" FORCE)
+      mark_as_advanced(AMDGPU_TARGETS)
+      mark_as_advanced(GPU_TARGETS)
+   endif()
+
    find_package(hip)
 
    if("${HIP_COMPILER}" STREQUAL "hcc")
@@ -259,12 +268,15 @@ if (AMReX_HIP)
                        "and https://github.com/AMReX-Codes/amrex/pull/2031 "
                        "for details.")
    elseif(${_this_comp} STREQUAL hipcc)
+       # hipcc expects a comma-separeted list
+       string(REPLACE ";" "," AMReX_AMD_ARCH_HIPCC "${AMReX_AMD_ARCH}")
+
        target_link_libraries(amrex PUBLIC ${HIP_LIBRARIES})
        # ARCH flags -- these must be PUBLIC for all downstream targets to use,
        # else there will be a runtime issue (cannot find
        # missing gpu devices)
        target_compile_options(amrex PUBLIC
-          $<$<COMPILE_LANGUAGE:CXX>:--amdgpu-target=${AMReX_AMD_ARCH} -Wno-pass-failed>)
+          $<$<COMPILE_LANGUAGE:CXX>:--amdgpu-target=${AMReX_AMD_ARCH_HIPCC} -Wno-pass-failed>)
    endif()
 
    target_compile_options(amrex PUBLIC $<$<COMPILE_LANGUAGE:CXX>:-m64>)

--- a/Tools/CMake/AMReXParallelBackends.cmake
+++ b/Tools/CMake/AMReXParallelBackends.cmake
@@ -176,13 +176,14 @@ endif ()
 #
 if (AMReX_HIP)
 
-   set(_valid_hip_compilers hipcc nvcc)  # later: CC, clang++
+   set(_valid_hip_compilers clang++ hipcc nvcc CC)
    get_filename_component(_this_comp ${CMAKE_CXX_COMPILER} NAME)
 
    if (NOT (_this_comp IN_LIST _valid_hip_compilers) )
-      message(WARNING "\nCMAKE_CXX_COMPILER=${_this_comp} is potentially "
-         "not a valid HIP device compiler.\n"
-         "For now, set CMAKE_CXX_COMPILER to hipcc for HIP builds.\n")
+      message(WARNING "\nCMAKE_CXX_COMPILER (${_this_comp}) is likely "
+         "incompatible with HIP.\n"
+         "Set CMAKE_CXX_COMPILER to either AMD's clang++ (preferred) or "
+         "hipcc or nvcc for HIP builds.\n")
    endif ()
 
    unset(_hip_compiler)
@@ -198,25 +199,50 @@ if (AMReX_HIP)
 
    set(CMAKE_MODULE_PATH "${HIP_PATH}/cmake" ${CMAKE_MODULE_PATH})
 
-   find_package(HIP REQUIRED)
+   find_package(hip)
 
    if("${HIP_COMPILER}" STREQUAL "hcc")
       message(FATAL_ERROR "Using (deprecated) HCC compiler: please update ROCm")
    endif()
 
-   if(HIP_FOUND)
+   if(hip_FOUND)
       message(STATUS "Found HIP: ${HIP_VERSION}")
-      message(STATUS "HIP: Platform=${HIP_PLATFORM} Compiler=${HIP_COMPILER} Path=${HIP_PATH}")
+      message(STATUS "HIP: Runtime=${HIP_RUNTIME} Compiler=${HIP_COMPILER} Path=${HIP_PATH}")
    else()
       message(FATAL_ERROR "Could not find HIP."
          " Ensure that HIP is either installed in /opt/rocm/hip or the variable HIP_PATH is set to point to the right location.")
+   endif()
+
+   if(${_this_comp} STREQUAL hipcc AND NOT AMReX_FORTRAN)
+       message(WARNING "You are using the legacy wrapper 'hipcc' as the HIP compiler.\n"
+           "This is only needed when building with Fortran support and with ROCm/HIP <=4.2.0. "
+           "Use AMD's 'clang++' compiler instead.")
+   endif()
+   # AMD's or mainline clang++ with support for "-x hip"
+   # Cray's CC wrapper that points to AMD's clang++ underneath
+   if(NOT ${_this_comp} STREQUAL hipcc)
+       target_link_libraries(amrex PUBLIC hip::device)
+
+       # work-around for https://github.com/ROCm-Developer-Tools/HIP/issues/2278
+       # CXX_STANDARD always adds -std=c++XX, even if the compiler default fulfills it
+       #set_property(TARGET amrex PROPERTY CXX_STANDARD 17)
+       # note: already bumped to C++17 (cxx_std_17) or newer in AMReX_Config.cmake
+
+       # work-around for ROCm <=4.2
+       # https://github.com/ROCm-Developer-Tools/HIP/pull/2190
+       target_compile_options(amrex PUBLIC
+          "$<$<COMPILE_LANGUAGE:CXX>:SHELL:-mllvm;-amdgpu-early-inline-all=true;-mllvm;-amdgpu-function-calls=false>"
+       )
+       target_compile_options(amrex PUBLIC
+          "$<$<COMPILE_LANGUAGE:CXX>:SHELL:-x hip>"
+       )
    endif()
 
    # Link to hiprand -- must include rocrand too
    find_package(rocrand REQUIRED CONFIG)
    find_package(rocprim REQUIRED CONFIG)
    find_package(hiprand REQUIRED CONFIG)
-   if (AMReX_ROCTX)
+   if(AMReX_ROCTX)
        # To be modernized in the future, please see:
        # https://github.com/ROCm-Developer-Tools/roctracer/issues/56
        target_include_directories(amrex PUBLIC ${HIP_PATH}/../roctracer/include ${HIP_PATH}/../rocprofiler/include)
@@ -232,16 +258,34 @@ if (AMReX_HIP)
                        "See https://github.com/ROCm-Developer-Tools/HIP/issues/2275 "
                        "and https://github.com/AMReX-Codes/amrex/pull/2031 "
                        "for details.")
-   else()
+       if(AMReX_GPU_RDC)
+           message(FATAL_ERROR "ROCm/HIP <= 4.2.0 cannot build Fortran + AMReX_GPU_RDC.")
+       endif()
+   elseif(${_this_comp} STREQUAL hipcc)
        target_link_libraries(amrex PUBLIC ${HIP_LIBRARIES})
+       # ARCH flags -- these must be PUBLIC for all downstream targets to use,
+       # else there will be a runtime issue (cannot find
+       # missing gpu devices)
+       target_compile_options(amrex PUBLIC
+          $<$<COMPILE_LANGUAGE:CXX>:--amdgpu-target=${AMReX_AMD_ARCH} -Wno-pass-failed>)
    endif()
 
-   # ARCH flags -- these must be PUBLIC for all downstream targets to use,
-   # else there will be a runtime issue (cannot find
-   # missing gpu devices)
-   target_compile_options(amrex
-      PUBLIC
-      # There are a lot of warnings due to #define AMREX_PRAGMA_SIMD _Pragma("clang loop vectorize(enable)")
-      $<$<COMPILE_LANGUAGE:CXX>:-m64 --amdgpu-target=${AMReX_AMD_ARCH} -Wno-pass-failed> )
+   target_compile_options(amrex PUBLIC $<$<COMPILE_LANGUAGE:CXX>:-m64>)
+
+   # Equivalently, relocatable-device-code (RDC) flags are needed for `extern`
+   # device variable support (for codes that use global variables on device)
+   # as well as our kernel fusion in AMReX, e.g. happening likely in amr regrid
+   # As of ROCm 4.1, we cannot enable this with hipcc, as it looks...
+   if(AMReX_GPU_RDC AND NOT ${_this_comp} STREQUAL hipcc)
+       target_compile_options(amrex PUBLIC
+          $<$<COMPILE_LANGUAGE:CXX>:-fgpu-rdc> )
+       if(CMAKE_VERSION VERSION_LESS 3.18)
+           target_link_options(amrex PUBLIC
+              -fgpu-rdc)
+       else()
+           target_link_options(amrex PUBLIC
+              "$<$<LINK_LANGUAGE:CXX>:-fgpu-rdc>")
+       endif()
+   endif()
 
 endif ()


### PR DESCRIPTION
## Summary

Add `-fgpu-rdc` flags to HIP if requested via `AMReX_GPU_RDC`.

Modernize HIP logic with recommended targets that avoid the flaky `hipcc` compiler scripts: https://rocmdocs.amd.com/en/latest/Installation_Guide/Using-CMake-with-AMD-ROCm.html#using-hip-in-cmake
Add support for AMDs `clang++`/`clang` compiler for HIP instead of using the legacy `hipcc` perl wrapper as C++ compiler.
This also increases support towards Cray compiler wrappers, which also refer to `clang++`/`clang` underneath (Spock/OLCF).

Close #1688

## Additional background

Relocatable-device-code (RDC) flags are needed for `extern` device variable support (for codes that use global variables on device). Also needed when linking with Ascent.

Follow-up to  #2029

With HIP GPU RDC, static libs emitting & linking does get more fancy:
https://github.com/ROCmSoftwarePlatform/rccl/pull/260

## Tests

- [x] Compiled in CI
- [ ] Compile on Tulip (ROCm 4.1.1) with Cray Wrappers:
```bash
module unload cuda11.2
module load craype-accel-amd-gfx908
module load rocm/4.1.1
module load cmake/3.18.2
# default: cray-mvapich2/2.3.5

export CC=$(which cc)
export CXX=$(which CC)
export CXXFLAGS="--rocm-path=${ROCM_PATH}"

cmake -S . -B build -DWarpX_COMPUTE=HIP -DAMReX_AMD_ARCH=gfx908
cmake --build build -j 32
# In linking of final executable:
# error: Illegal instruction detected: VOP* instruction violates constant bus restriction
# renamable $sgpr4_sgpr5 = V_CMP_EQ_U64_e64 $exec, killed $vcc, implicit $exec, debug-location !293636; /opt/rocm-4.1.1/hip/../include/hip/hcc_detail/device_functions.h:1021:12
```
- [x] Compile on Tulip (ROCm 4.1.1) with AMD Clang:
```bash
module unload cuda11.2
module load craype-accel-amd-gfx908
module load rocm/4.1.1
module load cmake/3.18.2
# default: cray-mvapich2/2.3.5 as CUDA awareness in it and needs this at link time
module unload cray-mvapich2
module load cray-mvapich2_nogpu

export CC=$(which clang)
export CXX=$(which clang++)  # legacy works, too: export CXX=$(which hipcc)
# export CXXFLAGS="--rocm-path=${ROCM_PATH}"
export LDFLAGS="-L${CRAYLIBS_X86_64} $(CC --cray-print-opts=libs) -lmpi"

cmake -S . -B build -DWarpX_COMPUTE=HIP -DAMReX_AMD_ARCH=gfx908 -DMPI_CXX_COMPILER=$(which CC) -DMPI_C_COMPILER=$(which cc) -DMPI_COMPILER_FLAGS="--cray-print-opts=all"
cmake --build build -j 32
```
- [ ] Compile on Spock (ROCm 4.1.0) with Cray Wrappers:
```bash
# module load DefApps/alt
module switch cce cce/12.0.0
# -> `cce/11.0.4` too old clang shipped by Cray (Clang 11-based) while ROCm/4.1.0 Clang already builds on Clang 12.
# -> use `cce/12.0.0`
module load craype-accel-amd-gfx908
module load cmake
module load ninja
module load rocm/4.1.0

export CC=$(which cc)
export CXX=$(which CC)

cmake -S . -B build -DWarpX_COMPUTE=HIP -DAMReX_AMD_ARCH=gfx908
cmake --build build
# In final link of  the executable:
# error: Illegal instruction detected: VOP* instruction violates constant bus restriction
# renamable $sgpr4_sgpr5 = V_CMP_EQ_U64_e64 $exec, killed $vcc, implicit $exec, debug-location !322291; nccs-svm1_sw/spock/spack-envs/views/rocm-4.1.0/hip/include/hip/hcc_detail/device_functions.h:1021:12
# clang-12: error: linker command failed with exit code 1 (use -v to see invocation)
```

- [x] Compile on Spock (ROCm 4.1.0) with AMD Clang w/o MPI:
```bash
# module load DefApps/alt
module switch cce cce/12.0.0
module load craype-accel-amd-gfx908
module load cmake
module load ninja
module load rocm/4.1.0

export CC=$(which clang)
export CXX=$(which clang++)

cmake -S . -B build -DWarpX_COMPUTE=HIP -DAMReX_AMD_ARCH=gfx908 -DWarpX_MPI=OFF
cmake --build build -j 64
```

- [x] Compile on Spock (ROCm 4.1.0) with AMD Clang w/ MPI (2 tests: w/ and w/o RDC):
```bash
# module load DefApps/alt
module switch cce cce/12.0.0
module load craype-accel-amd-gfx908
module load cmake
module load ninja
module load rocm/4.1.0

export CC=$(which clang)
export CXX=$(which clang++)
export LDFLAGS="-L${CRAYLIBS_X86_64} $(CC --cray-print-opts=libs) -lmpi"

cmake -S . -B build -DWarpX_COMPUTE=HIP -DAMReX_AMD_ARCH=gfx908 -DMPI_CXX_COMPILER=$(which CC) -DMPI_C_COMPILER=$(which cc) -DMPI_COMPILER_FLAGS="--cray-print-opts=all"
cmake --build build -j 64
```
- [x] Compile on Spock (ROCm 4.1.0) with legacy logic (`hipcc`) w/ MPI:
```bash
# module load DefApps/alt
module switch cce cce/12.0.0
module load craype-accel-amd-gfx908
module load cmake
module load ninja
module load rocm/4.1.0

export CC=$(which clang)
export CXX=$(which hipcc)
export LDFLAGS="-L${CRAYLIBS_X86_64} $(CC --cray-print-opts=libs) -lmpi"

cmake -S . -B build -DWarpX_COMPUTE=HIP -DAMReX_AMD_ARCH=gfx908 -DMPI_CXX_COMPILER=$(which CC) -DMPI_C_COMPILER=$(which cc) -DMPI_COMPILER_FLAGS="--cray-print-opts=all"
cmake --build build
```

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
