### PR TITLE
nvcc --display-error-number --diag-error errNum

### DIFF
--- a/Tools/CMake/AMReXParallelBackends.cmake
+++ b/Tools/CMake/AMReXParallelBackends.cmake
@@ -143,6 +143,12 @@ if (  AMReX_GPU_BACKEND STREQUAL "CUDA"
       endif ()
    endif ()
 
+   # Flags to make it an error to write a device variable in
+   # a host function.
+   if (CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL)
+      list(APPEND _cuda_flag --display-error-number --diag-error 20092)
+   endif ()
+
    target_compile_options( amrex PUBLIC $<${_genex}:${_cuda_flags}> )
 
 endif ()

--- a/Tools/CMake/AMReXParallelBackends.cmake
+++ b/Tools/CMake/AMReXParallelBackends.cmake
@@ -145,7 +145,7 @@ if (  AMReX_GPU_BACKEND STREQUAL "CUDA"
 
    # Flags to make it an error to write a device variable in
    # a host function.
-   if (CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL)
+   if (CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL 11.2)
       list(APPEND _cuda_flag --display-error-number --diag-error 20092)
    endif ()
 

--- a/Tools/CMake/AMReX_SetupCUDA.cmake
+++ b/Tools/CMake/AMReX_SetupCUDA.cmake
@@ -129,3 +129,7 @@ if (AMReX_CUDA_BACKTRACE)
         string(APPEND CMAKE_CUDA_FLAGS " -Xcompiler -rdynamic")
     endif ()
 endif ()
+
+if (CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL)
+   string(APPEND CMAKE_CUDA_FLAGS " --display-error-number --diag-error 20092")
+endif ()

--- a/Tools/CMake/AMReX_SetupCUDA.cmake
+++ b/Tools/CMake/AMReX_SetupCUDA.cmake
@@ -130,6 +130,6 @@ if (AMReX_CUDA_BACKTRACE)
     endif ()
 endif ()
 
-if (CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL)
+if (CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL 11.2)
    string(APPEND CMAKE_CUDA_FLAGS " --display-error-number --diag-error 20092")
 endif ()

--- a/Tools/GNUMake/comps/nvcc.mak
+++ b/Tools/GNUMake/comps/nvcc.mak
@@ -168,6 +168,21 @@ endif
 endif
 endif
 
+nvcc_diag_error = 0
+ifeq ($(shell expr $(nvcc_major_version) \>= 12),1)
+  nvcc_diag_error = 1
+else
+ifeq ($(shell expr $(nvcc_major_version) \= 11),1)
+ifeq ($(shell expr $(nvcc_minor_version) \>= 2),1)
+  nvcc_diag_error = 1
+endif
+endif
+endif
+# warning #20092-D: a __device__ variable cannot be directly written in a host function
+ifeq ($(nvcc_diag_error),1)
+  NVCC_FLAGS += --display-error-number --diag-error 20092
+endif
+
 CXXFLAGS = $(CXXFLAGS_FROM_HOST) $(NVCC_FLAGS) -dc -x cu
 CFLAGS   =   $(CFLAGS_FROM_HOST) $(NVCC_FLAGS) -dc -x cu
 


### PR DESCRIPTION
Since 11.2, nvcc can display a diagnostic number for any warning message and
it can turn specified warnings into errors These two new flags are added to
the GNU make system, and it's now an error to write a `__device__` variable in
a host function.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
