### PR TITLE
HIP: AMREX_AMD_ARCH Env Variable

### DIFF
--- a/Docs/sphinx_documentation/source/GPU.rst
+++ b/Docs/sphinx_documentation/source/GPU.rst
@@ -333,6 +333,7 @@ Since CMake does not support autodetection of HIP compilers/target architectures
 yet, ``CMAKE_CXX_COMPILER`` must be set to a valid HIP compiler, i.e. ``hipcc`` or ``nvcc``,
 and ``AMReX_AMD_ARCH`` to the target architecture you are building for.
 Thus **AMReX_AMD_ARCH and CMAKE_CXX_COMPILER are required user-inputs when AMReX_GPU_BACKEND=HIP**.
+We again read also an *environment variable*: ``AMREX_AMD_ARCH`` (note: all caps).
 Below is an example configuration for HIP on Tulip:
 
 .. highlight:: console

--- a/Tools/CMake/AMReXOptions.cmake
+++ b/Tools/CMake/AMReXOptions.cmake
@@ -155,8 +155,14 @@ print_option(  AMReX_DPCPP_SPLIT_KERNEL )
 
 # --- HIP ----
 if (AMReX_HIP)
-   set(AMReX_AMD_ARCH "IGNORE" CACHE STRING
+   set(AMReX_AMD_ARCH_DEFAULT "IGNORE")
+   if(DEFINED ENV{AMREX_AMD_ARCH})
+      set(AMReX_AMD_ARCH_DEFAULT "$ENV{AMREX_AMD_ARCH}")
+   endif()
+
+   set(AMReX_AMD_ARCH ${AMReX_AMD_ARCH_DEFAULT} CACHE STRING
       "AMD GPU architecture (Must be provided if AMReX_HIP=ON)")
+
    if (NOT AMReX_AMD_ARCH)
       message(FATAL_ERROR "\nMust specify AMReX_AMD_ARCH if AMReX_HIP=ON\n")
    endif ()


### PR DESCRIPTION
## Summary

Adding an AMREX_AMD_ARCH env variable to control the AMD GPU arch from user environments & profiles.

## Additional background

Same as #1507 / #1522, but for HIP.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
