### PR TITLE
Generalize fextract allowing to specify coords perpendicular to slicedir

### DIFF
--- a/Tools/Plotfile/fextract.cpp
+++ b/Tools/Plotfile/fextract.cpp
@@ -148,7 +148,7 @@ void main_main()
         kloc = (hi0.z-lo0.z+1)/2 + lo0.z;
     }
 
-    if (xcoord > -1.e-36 && AMREX_SPACEDIM >= 1) {
+    if (xcoord > -1.e36 && AMREX_SPACEDIM >= 1) {
         // we specified the x value to pass through
         iloc = hi0.x;
         for (int i = lo0.x; i <= hi0.x; ++i) {
@@ -160,7 +160,7 @@ void main_main()
         }
     }
 
-    if (ycoord > -1.e-36 && AMREX_SPACEDIM >= 2) {
+    if (ycoord > -1.e36 && AMREX_SPACEDIM >= 2) {
         // we specified the y value to pass through
         jloc = hi0.y;
         for (int j = lo0.y; j <= hi0.y; ++j) {
@@ -172,7 +172,7 @@ void main_main()
         }
     }
 
-    if (zcoord > -1.e-36 && AMREX_SPACEDIM == 3) {
+    if (zcoord > -1.e36 && AMREX_SPACEDIM == 3) {
         // we specified the z value to pass through
         kloc = hi0.z;
         for (int k = lo0.z; k <= hi0.z; ++k) {

--- a/Tools/Plotfile/fextract.cpp
+++ b/Tools/Plotfile/fextract.cpp
@@ -20,7 +20,9 @@ void main_main()
     bool center = true;
     int coarse_level = 0;
     int fine_level = -1;  // This will be fixed later
+    Real xcoord = std::numeric_limits<Real>::lowest();
     Real ycoord = std::numeric_limits<Real>::lowest();
+    Real zcoord = std::numeric_limits<Real>::lowest();
     bool scientific = false;
     bool csv = false;
     int  precision = 17;
@@ -36,8 +38,12 @@ void main_main()
             idir = std::stoi(amrex::get_command_argument(++farg));
         } else if (name == "-v" || name == "--variable") {
             varnames_arg = amrex::get_command_argument(++farg);
+        } else if (name == "-x") {
+            xcoord = std::stod(amrex::get_command_argument(++farg));
         } else if (name == "-y") {
             ycoord = std::stod(amrex::get_command_argument(++farg));
+        } else if (name == "-z") {
+            zcoord = std::stod(amrex::get_command_argument(++farg));
         } else if (name == "-l" || name == "--lower_left") {
             center = false;
         } else if (name == "-c" || name == "--coarse_level") {
@@ -80,7 +86,7 @@ void main_main()
             << "                                         multiple variables)\n"
             << "      [-l|--lower_left]                : slice through lower left corner\n"
             << "                                         instead of center\n"
-            << "      [-y]                             : y-coordinate to pass through\n"
+            << "      [-x][-y][-z]                     : (x,y,z)-coordinate to pass through\n"
             << "                                         (overrides center/lower-left)\n"
             << "      [-c|--coarse_level] coarse level : coarsest level to extract from\n"
             << "      [-f|--fine_level]   fine level   : finest level to extract from\n"
@@ -105,19 +111,6 @@ void main_main()
     }
 
     PlotFileData pf(pltfile);
-    const int dim = pf.spaceDim();
-
-    if (idir < 0 || idir >= dim) {
-        amrex::Print() << " invalid direction\n";
-        return;
-    } else if (idir == 0) {
-        amrex::Print() << " slicing along x-direction and output to " << slicefile << "\n";
-    } else if (idir == 1) {
-        amrex::Print() << " slicing along y-direction and output to " << slicefile << "\n";
-    } else if (idir == 2) {
-        amrex::Print() << " slicing along z-direction and output to " << slicefile << "\n";
-    }
-
     const Vector<std::string>& var_names_pf = pf.varNames();
 
     Vector<std::string> var_names;
@@ -155,8 +148,21 @@ void main_main()
         kloc = (hi0.z-lo0.z+1)/2 + lo0.z;
     }
 
+    if (xcoord > -1.e-36 && AMREX_SPACEDIM >= 1) {
+        // we specified the x value to pass through
+        iloc = hi0.x;
+        for (int i = lo0.x; i <= hi0.x; ++i) {
+            amrex::Real xc = problo[0] + (i+0.5)*dx0[0];
+            if (xc > xcoord) {
+                iloc = i;
+                break;
+            }
+        }
+    }
+
     if (ycoord > -1.e-36 && AMREX_SPACEDIM >= 2) {
         // we specified the y value to pass through
+        jloc = hi0.y;
         for (int j = lo0.y; j <= hi0.y; ++j) {
             amrex::Real yc = problo[1] + (j+0.5)*dx0[1];
             if (yc > ycoord) {
@@ -165,6 +171,32 @@ void main_main()
             }
         }
     }
+
+    if (zcoord > -1.e-36 && AMREX_SPACEDIM == 3) {
+        // we specified the z value to pass through
+        kloc = hi0.z;
+        for (int k = lo0.z; k <= hi0.z; ++k) {
+            amrex::Real zc = problo[2] + (k+0.5)*dx0[2];
+            if (zc > zcoord) {
+                kloc = k;
+                break;
+            }
+        }
+    }
+
+    const int dim = pf.spaceDim();
+
+    if (idir < 0 || idir >= dim) {
+        amrex::Print() << " invalid direction\n";
+        return;
+    } else if (idir == 0) {
+        amrex::Print() << " slicing along x-direction at coarse grid (j,k)=(" << jloc << "," << kloc << ") and output to " << slicefile << "\n";
+    } else if (idir == 1) {
+        amrex::Print() << " slicing along y-direction at coarse grid (i,k)=(" << iloc << "," << kloc << ") and output to " << slicefile << "\n";
+    } else if (idir == 2) {
+        amrex::Print() << " slicing along z-direction at coarse grid (i,j)=(" << iloc << "," << jloc << ") and output to " << slicefile << "\n";
+    }
+
 
     const IntVect ivloc{AMREX_D_DECL(iloc,jloc,kloc)};
 


### PR DESCRIPTION
Generalize fextract.  Allow spec as coordinate + dir, so that 1D slice can be positioned as desired, within constraints of backward compatibility.

## Summary

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
