### PR TITLE
Wrappers for builtin clz extensions and tests thereof.

### DIFF
--- a/Src/Base/AMReX_Algorithm.H
+++ b/Src/Base/AMReX_Algorithm.H
@@ -11,6 +11,8 @@
 #include <algorithm>
 #include <limits>
 #include <type_traits>
+#include <cstdint>
+#include <climits>
 
 namespace amrex
 {
@@ -134,6 +136,117 @@ namespace amrex
 
         return mi;
     }
+
+namespace detail {
+
+// in gcc and clang, there are three versions of __builtin_clz taking unsigned int,
+// unsigned long, and unsigned long long inputs. Because the sizes of these data types
+// vary on different platforms, we work with fixed-width integer types.
+// these tags and overloads select the smallest version of __builtin_clz that will hold the input type
+struct clzll_tag_host {};
+struct clzl_tag_host : clzll_tag_host {};
+struct clz_tag_host : clzl_tag_host {};
+
+template <typename T, typename = typename std::enable_if<sizeof(T) <= sizeof(unsigned int)>::type>
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+unsigned builtin_clz_wrapper (clz_tag_host, T x) noexcept
+{
+    return __builtin_clz(x) - (sizeof(unsigned int) * CHAR_BIT - sizeof(T) * CHAR_BIT);
+}
+
+template <typename T, typename = typename std::enable_if<sizeof(T) <= sizeof(unsigned long)>::type>
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+unsigned builtin_clz_wrapper (clzl_tag_host, T x) noexcept
+{
+    return __builtin_clzl(x) - (sizeof(unsigned long) * CHAR_BIT - sizeof(T) * CHAR_BIT);
+}
+
+template <typename T, typename = typename std::enable_if<sizeof(T) <= sizeof(unsigned long long)>::type>
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+unsigned builtin_clz_wrapper (clzll_tag_host, T x) noexcept
+{
+    return __builtin_clzll(x) - (sizeof(unsigned long long) * CHAR_BIT - sizeof(T) * CHAR_BIT);
+}
+
+#if AMREX_USE_CUDA
+// likewise with CUDA, there are __clz functions that take (signed) int and long long int
+struct clzll_tag_device {};
+struct clz_tag_device : clzll_tag_device {};
+
+template <typename T, typename = typename std::enable_if<sizeof(T) <= sizeof(int)>::type>
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE
+int clz_wrapper (clz_tag_device, T x) noexcept
+{
+    return __clz((int) x) - (sizeof(int) * CHAR_BIT - sizeof(T) * CHAR_BIT);
+}
+
+template <typename T, typename = typename std::enable_if<sizeof(T) <= sizeof(long long int)>::type>
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE
+int clz_wrapper (clzll_tag_device, T x) noexcept
+{
+    return __clzll((long long int) x) - (sizeof(long long int) * CHAR_BIT - sizeof(T) * CHAR_BIT);
+}
+#endif
+
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+int clz (std::uint8_t x) noexcept
+{
+#if (AMREX_DEVICE_COMPILE && AMREX_USE_CUDA) // all supported cuda versions have __clz
+    return detail::clz_wrapper(detail::clz_tag_device{}, x);
+#elif (!AMREX_DEVICE_COMPILE && AMREX_HAS_BUILTIN_CLZ)
+    return detail::builtin_clz_wrapper(detail::clz_tag_host{}, x);
+#else
+    static constexpr std::uint8_t clz_lookup[16] = { 4, 3, 2, 2, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0 };
+    auto upper = x >> 4;
+    auto lower = x & 0xF;
+    return upper ? clz_lookup[upper] : 4 + clz_lookup[lower];
+#endif
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+int clz (std::uint16_t x) noexcept
+{
+#if (AMREX_DEVICE_COMPILE && AMREX_USE_CUDA) // all supported cuda versions have __clz
+    return detail::clz_wrapper(detail::clz_tag_device{}, x);
+#elif (!AMREX_DEVICE_COMPILE && AMREX_HAS_BUILTIN_CLZ)
+    return detail::builtin_clz_wrapper(detail::clz_tag_host{}, x);
+#else
+    auto upper = std::uint8_t(x >> 8);
+    auto lower = std::uint8_t(x & 0xFF);
+    return upper ? clz(upper) : 8 + clz(lower);
+#endif
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+int clz (std::uint32_t x) noexcept
+{
+#if (AMREX_DEVICE_COMPILE && AMREX_USE_CUDA) // all supported cuda versions have __clz
+    return detail::clz_wrapper(detail::clz_tag_device{}, x);
+#elif (!AMREX_DEVICE_COMPILE && AMREX_HAS_BUILTIN_CLZ)
+    return detail::builtin_clz_wrapper(detail::clz_tag_host{}, x);
+#else
+    auto upper = std::uint16_t(x >> 16);
+    auto lower = std::uint16_t(x & 0xFFFF);
+    return upper ? clz(upper) : 16 + clz(lower);
+#endif
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+int clz (std::uint64_t x) noexcept
+{
+#if (AMREX_DEVICE_COMPILE && AMREX_USE_CUDA) // all supported cuda versions have __clz
+    return detail::clz_wrapper(detail::clz_tag_device{}, x);
+#elif (!AMREX_DEVICE_COMPILE && AMREX_HAS_BUILTIN_CLZ)
+    return detail::builtin_clz_wrapper(detail::clz_tag_host{}, x);
+#else
+    auto upper = std::uint32_t(x >> 32);
+    auto lower = std::uint32_t(x & 0xFFFFFFFF);
+    return upper ? clz(upper) : 32 + clz(lower);
+#endif
+}
+
 }
 
 #endif

--- a/Src/Base/AMReX_Algorithm.H
+++ b/Src/Base/AMReX_Algorithm.H
@@ -168,7 +168,7 @@ unsigned builtin_clz_wrapper (clzll_tag_host, T x) noexcept
     return __builtin_clzll(x) - (sizeof(unsigned long long) * CHAR_BIT - sizeof(T) * CHAR_BIT);
 }
 
-#if AMREX_USE_CUDA
+#ifdef AMREX_USE_CUDA
 // likewise with CUDA, there are __clz functions that take (signed) int and long long int
 struct clzll_tag_device {};
 struct clz_tag_device : clzll_tag_device {};
@@ -193,7 +193,7 @@ int clz_wrapper (clzll_tag_device, T x) noexcept
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 int clz (std::uint8_t x) noexcept
 {
-#if (AMREX_DEVICE_COMPILE && AMREX_USE_CUDA) // all supported cuda versions have __clz
+#if (AMREX_DEVICE_COMPILE && defined(AMREX_USE_CUDA)) // all supported cuda versions have __clz
     return detail::clz_wrapper(detail::clz_tag_device{}, x);
 #elif (!AMREX_DEVICE_COMPILE && AMREX_HAS_BUILTIN_CLZ)
     return detail::builtin_clz_wrapper(detail::clz_tag_host{}, x);
@@ -208,7 +208,7 @@ int clz (std::uint8_t x) noexcept
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 int clz (std::uint16_t x) noexcept
 {
-#if (AMREX_DEVICE_COMPILE && AMREX_USE_CUDA) // all supported cuda versions have __clz
+#if (AMREX_DEVICE_COMPILE && defined(AMREX_USE_CUDA)) // all supported cuda versions have __clz
     return detail::clz_wrapper(detail::clz_tag_device{}, x);
 #elif (!AMREX_DEVICE_COMPILE && AMREX_HAS_BUILTIN_CLZ)
     return detail::builtin_clz_wrapper(detail::clz_tag_host{}, x);
@@ -222,7 +222,7 @@ int clz (std::uint16_t x) noexcept
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 int clz (std::uint32_t x) noexcept
 {
-#if (AMREX_DEVICE_COMPILE && AMREX_USE_CUDA) // all supported cuda versions have __clz
+#if (AMREX_DEVICE_COMPILE && defined(AMREX_USE_CUDA)) // all supported cuda versions have __clz
     return detail::clz_wrapper(detail::clz_tag_device{}, x);
 #elif (!AMREX_DEVICE_COMPILE && AMREX_HAS_BUILTIN_CLZ)
     return detail::builtin_clz_wrapper(detail::clz_tag_host{}, x);
@@ -236,7 +236,7 @@ int clz (std::uint32_t x) noexcept
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 int clz (std::uint64_t x) noexcept
 {
-#if (AMREX_DEVICE_COMPILE && AMREX_USE_CUDA) // all supported cuda versions have __clz
+#if (AMREX_DEVICE_COMPILE && defined(AMREX_USE_CUDA)) // all supported cuda versions have __clz
     return detail::clz_wrapper(detail::clz_tag_device{}, x);
 #elif (!AMREX_DEVICE_COMPILE && AMREX_HAS_BUILTIN_CLZ)
     return detail::builtin_clz_wrapper(detail::clz_tag_host{}, x);

--- a/Src/Base/AMReX_Algorithm.H
+++ b/Src/Base/AMReX_Algorithm.H
@@ -148,21 +148,21 @@ struct clzl_tag_host : clzll_tag_host {};
 struct clz_tag_host : clzl_tag_host {};
 
 template <typename T, typename = typename std::enable_if<sizeof(T) <= sizeof(unsigned int)>::type>
-AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+AMREX_FORCE_INLINE
 unsigned builtin_clz_wrapper (clz_tag_host, T x) noexcept
 {
     return __builtin_clz(x) - (sizeof(unsigned int) * CHAR_BIT - sizeof(T) * CHAR_BIT);
 }
 
 template <typename T, typename = typename std::enable_if<sizeof(T) <= sizeof(unsigned long)>::type>
-AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+AMREX_FORCE_INLINE
 unsigned builtin_clz_wrapper (clzl_tag_host, T x) noexcept
 {
     return __builtin_clzl(x) - (sizeof(unsigned long) * CHAR_BIT - sizeof(T) * CHAR_BIT);
 }
 
 template <typename T, typename = typename std::enable_if<sizeof(T) <= sizeof(unsigned long long)>::type>
-AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+AMREX_FORCE_INLINE
 unsigned builtin_clz_wrapper (clzll_tag_host, T x) noexcept
 {
     return __builtin_clzll(x) - (sizeof(unsigned long long) * CHAR_BIT - sizeof(T) * CHAR_BIT);

--- a/Src/Base/AMReX_Algorithm.H
+++ b/Src/Base/AMReX_Algorithm.H
@@ -139,50 +139,48 @@ namespace amrex
 
 namespace detail {
 
+struct clzll_tag {};
+struct clzl_tag : clzll_tag {};
+struct clz_tag : clzl_tag {};
+
 // in gcc and clang, there are three versions of __builtin_clz taking unsigned int,
 // unsigned long, and unsigned long long inputs. Because the sizes of these data types
 // vary on different platforms, we work with fixed-width integer types.
 // these tags and overloads select the smallest version of __builtin_clz that will hold the input type
-struct clzll_tag_host {};
-struct clzl_tag_host : clzll_tag_host {};
-struct clz_tag_host : clzl_tag_host {};
-
 template <typename T, typename = typename std::enable_if<sizeof(T) <= sizeof(unsigned int)>::type>
 AMREX_FORCE_INLINE
-unsigned builtin_clz_wrapper (clz_tag_host, T x) noexcept
+unsigned builtin_clz_wrapper (clz_tag, T x) noexcept
 {
     return __builtin_clz(x) - (sizeof(unsigned int) * CHAR_BIT - sizeof(T) * CHAR_BIT);
 }
 
 template <typename T, typename = typename std::enable_if<sizeof(T) <= sizeof(unsigned long)>::type>
 AMREX_FORCE_INLINE
-unsigned builtin_clz_wrapper (clzl_tag_host, T x) noexcept
+unsigned builtin_clz_wrapper (clzl_tag, T x) noexcept
 {
     return __builtin_clzl(x) - (sizeof(unsigned long) * CHAR_BIT - sizeof(T) * CHAR_BIT);
 }
 
 template <typename T, typename = typename std::enable_if<sizeof(T) <= sizeof(unsigned long long)>::type>
 AMREX_FORCE_INLINE
-unsigned builtin_clz_wrapper (clzll_tag_host, T x) noexcept
+unsigned builtin_clz_wrapper (clzll_tag, T x) noexcept
 {
     return __builtin_clzll(x) - (sizeof(unsigned long long) * CHAR_BIT - sizeof(T) * CHAR_BIT);
 }
 
 #ifdef AMREX_USE_CUDA
-// likewise with CUDA, there are __clz functions that take (signed) int and long long int
-struct clzll_tag_device {};
-struct clz_tag_device : clzll_tag_device {};
 
+// likewise with CUDA, there are __clz functions that take (signed) int and long long int
 template <typename T, typename = typename std::enable_if<sizeof(T) <= sizeof(int)>::type>
 AMREX_GPU_DEVICE AMREX_FORCE_INLINE
-int clz_wrapper (clz_tag_device, T x) noexcept
+int clz_wrapper (clz_tag, T x) noexcept
 {
     return __clz((int) x) - (sizeof(int) * CHAR_BIT - sizeof(T) * CHAR_BIT);
 }
 
 template <typename T, typename = typename std::enable_if<sizeof(T) <= sizeof(long long int)>::type>
 AMREX_GPU_DEVICE AMREX_FORCE_INLINE
-int clz_wrapper (clzll_tag_device, T x) noexcept
+int clz_wrapper (clzll_tag, T x) noexcept
 {
     return __clzll((long long int) x) - (sizeof(long long int) * CHAR_BIT - sizeof(T) * CHAR_BIT);
 }
@@ -194,9 +192,9 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 int clz (std::uint8_t x) noexcept
 {
 #if (AMREX_DEVICE_COMPILE && defined(AMREX_USE_CUDA)) // all supported cuda versions have __clz
-    return detail::clz_wrapper(detail::clz_tag_device{}, x);
+    return detail::clz_wrapper(detail::clz_tag{}, x);
 #elif (!AMREX_DEVICE_COMPILE && AMREX_HAS_BUILTIN_CLZ)
-    return detail::builtin_clz_wrapper(detail::clz_tag_host{}, x);
+    return detail::builtin_clz_wrapper(detail::clz_tag{}, x);
 #else
     static constexpr std::uint8_t clz_lookup[16] = { 4, 3, 2, 2, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0 };
     auto upper = x >> 4;
@@ -209,9 +207,9 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 int clz (std::uint16_t x) noexcept
 {
 #if (AMREX_DEVICE_COMPILE && defined(AMREX_USE_CUDA)) // all supported cuda versions have __clz
-    return detail::clz_wrapper(detail::clz_tag_device{}, x);
+    return detail::clz_wrapper(detail::clz_tag{}, x);
 #elif (!AMREX_DEVICE_COMPILE && AMREX_HAS_BUILTIN_CLZ)
-    return detail::builtin_clz_wrapper(detail::clz_tag_host{}, x);
+    return detail::builtin_clz_wrapper(detail::clz_tag{}, x);
 #else
     auto upper = std::uint8_t(x >> 8);
     auto lower = std::uint8_t(x & 0xFF);
@@ -223,9 +221,9 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 int clz (std::uint32_t x) noexcept
 {
 #if (AMREX_DEVICE_COMPILE && defined(AMREX_USE_CUDA)) // all supported cuda versions have __clz
-    return detail::clz_wrapper(detail::clz_tag_device{}, x);
+    return detail::clz_wrapper(detail::clz_tag{}, x);
 #elif (!AMREX_DEVICE_COMPILE && AMREX_HAS_BUILTIN_CLZ)
-    return detail::builtin_clz_wrapper(detail::clz_tag_host{}, x);
+    return detail::builtin_clz_wrapper(detail::clz_tag{}, x);
 #else
     auto upper = std::uint16_t(x >> 16);
     auto lower = std::uint16_t(x & 0xFFFF);
@@ -237,9 +235,9 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 int clz (std::uint64_t x) noexcept
 {
 #if (AMREX_DEVICE_COMPILE && defined(AMREX_USE_CUDA)) // all supported cuda versions have __clz
-    return detail::clz_wrapper(detail::clz_tag_device{}, x);
+    return detail::clz_wrapper(detail::clz_tag{}, x);
 #elif (!AMREX_DEVICE_COMPILE && AMREX_HAS_BUILTIN_CLZ)
-    return detail::builtin_clz_wrapper(detail::clz_tag_host{}, x);
+    return detail::builtin_clz_wrapper(detail::clz_tag{}, x);
 #else
     auto upper = std::uint32_t(x >> 32);
     auto lower = std::uint32_t(x & 0xFFFFFFFF);

--- a/Src/Base/AMReX_Extension.H
+++ b/Src/Base/AMReX_Extension.H
@@ -194,6 +194,13 @@
 #   define AMREX_IF_CONSTEXPR if
 #endif
 
+#if !defined(AMREX_NO_BUILTIN_CLZ)
+#   if defined(__clang__) || defined(__GNUC__)
+#      define AMREX_HAS_BUILTIN_CLZ 1
+#   endif
+#endif
+
+
 #endif /* !BL_LANG_FORT */
 
 #endif

--- a/Tests/CLZ/CMakeLists.txt
+++ b/Tests/CLZ/CMakeLists.txt
@@ -1,0 +1,7 @@
+set(_sources     main.cpp)
+set(_input_files)
+
+setup_test(_sources _input_files)
+
+unset(_sources)
+unset(_input_files)

--- a/Tests/CLZ/GNUmakefile
+++ b/Tests/CLZ/GNUmakefile
@@ -1,0 +1,18 @@
+AMREX_HOME = ../../
+
+DEBUG	= FALSE
+DIM	= 3
+COMP    = gcc
+
+USE_MPI   = TRUE
+USE_OMP   = FALSE
+USE_CUDA  = FALSE
+
+TINY_PROFILE = TRUE
+
+include $(AMREX_HOME)/Tools/GNUMake/Make.defs
+
+include ./Make.package
+include $(AMREX_HOME)/Src/Base/Make.package
+
+include $(AMREX_HOME)/Tools/GNUMake/Make.rules

--- a/Tests/CLZ/Make.package
+++ b/Tests/CLZ/Make.package
@@ -1,0 +1,4 @@
+CEXE_sources += main.cpp
+
+
+

--- a/Tests/CLZ/main.cpp
+++ b/Tests/CLZ/main.cpp
@@ -1,0 +1,40 @@
+#include <AMReX.H>
+#include <AMReX_Gpu.H>
+#include <AMReX_Algorithm.H>
+
+void testCLZ ();
+
+int main (int argc, char* argv[])
+{
+    amrex::Initialize(argc,argv);
+
+    amrex::Print() << "Running CLZ test. \n";
+    testCLZ();
+
+    amrex::Finalize();
+}
+
+void testCLZ ()
+{
+    AMREX_ALWAYS_ASSERT(amrex::clz(std::uint8_t(10) ) == 4 );
+    AMREX_ALWAYS_ASSERT(amrex::clz(std::uint16_t(10)) == 12);
+    AMREX_ALWAYS_ASSERT(amrex::clz(std::uint32_t(10)) == 28);
+    AMREX_ALWAYS_ASSERT(amrex::clz(std::uint64_t(10)) == 60);
+
+    AMREX_ALWAYS_ASSERT(amrex::clz(std::uint8_t (1 << 7  )) == 0);
+    AMREX_ALWAYS_ASSERT(amrex::clz(std::uint16_t(1 << 15 )) == 0);
+    AMREX_ALWAYS_ASSERT(amrex::clz(std::uint32_t(1 << 31 )) == 0);
+    AMREX_ALWAYS_ASSERT(amrex::clz(std::uint64_t(1L << 63)) == 0);
+
+    amrex::ParallelFor(1, [=] AMREX_GPU_DEVICE (int i) noexcept {
+            AMREX_ALWAYS_ASSERT(amrex::clz(std::uint8_t(10) ) == 4 );
+            AMREX_ALWAYS_ASSERT(amrex::clz(std::uint16_t(10)) == 12);
+            AMREX_ALWAYS_ASSERT(amrex::clz(std::uint32_t(10)) == 28);
+            AMREX_ALWAYS_ASSERT(amrex::clz(std::uint64_t(10)) == 60);
+
+            AMREX_ALWAYS_ASSERT(amrex::clz(std::uint8_t (1 << 7  )) == 0);
+            AMREX_ALWAYS_ASSERT(amrex::clz(std::uint16_t(1 << 15 )) == 0);
+            AMREX_ALWAYS_ASSERT(amrex::clz(std::uint32_t(1 << 31 )) == 0);
+            AMREX_ALWAYS_ASSERT(amrex::clz(std::uint64_t(1L << 63)) == 0);
+        });
+}

--- a/Tests/CLZ/main.cpp
+++ b/Tests/CLZ/main.cpp
@@ -26,7 +26,7 @@ void testCLZ ()
     AMREX_ALWAYS_ASSERT(amrex::clz(std::uint32_t(1 << 31 )) == 0);
     AMREX_ALWAYS_ASSERT(amrex::clz(std::uint64_t(1L << 63)) == 0);
 
-    amrex::ParallelFor(1, [=] AMREX_GPU_DEVICE (int i) noexcept {
+    amrex::ParallelFor(1, [=] AMREX_GPU_DEVICE (int /*i*/) noexcept {
             AMREX_ALWAYS_ASSERT(amrex::clz(std::uint8_t(10) ) == 4 );
             AMREX_ALWAYS_ASSERT(amrex::clz(std::uint16_t(10)) == 12);
             AMREX_ALWAYS_ASSERT(amrex::clz(std::uint32_t(10)) == 28);

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -1,7 +1,7 @@
 #
 # List of subdirectories to search for CMakeLists.
 #
-set( AMREX_TESTS_SUBDIRS AsyncOut MultiBlock Amr)
+set( AMREX_TESTS_SUBDIRS AsyncOut MultiBlock Amr CLZ)
 
 if (AMReX_PARTICLES)
    list(APPEND AMREX_TESTS_SUBDIRS Particles)


### PR DESCRIPTION
Counting the number of leading zeros in an integer is useful for a number of bit-fiddling tasks. GCC, clang, and CUDA all provide builtin functions to do this. However, the results are platform-dependent, because the size of many integer types can vary, and also the CUDA interface is slightly different. 

This:

1) Wraps the builtin versions to work with unsigned, fixed-width types, which should behave the same anywhere they are present. 
2) Provides a backup implementation for when the extension is not available.
3) Adds a test.

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
