### PR TITLE
Option to set amd gpu targets

### DIFF
--- a/Docs/sphinx_documentation/source/BuildingAMReX.rst
+++ b/Docs/sphinx_documentation/source/BuildingAMReX.rst
@@ -62,6 +62,9 @@ list of important variables.
    | AMREX_CUDA_ARCH | CUDA arch such as 70                | 70 if not set      |
    |    or CUDA_ARCH |                                     | or detected        |
    +-----------------+-------------------------------------+--------------------+
+   | AMREX_AMD_ARCH  | AMD GPU arch such as gfx908         | none if the        |
+   |    or AMD_ARCH  |                                     | machine is unknown |
+   +-----------------+-------------------------------------+--------------------+
 
 .. raw:: latex
 

--- a/Tools/GNUMake/Make.defs
+++ b/Tools/GNUMake/Make.defs
@@ -692,6 +692,27 @@ ifeq ($(USE_HIP),TRUE)
       DEFINES += -DAMREX_HIP_INDIRECT_FUNCTION
     endif
 
+    ifeq ($(USE_MPI),TRUE)
+      # Make sure that the C/C++ MPI
+      # wrappers are calling hipcc to compile the code.
+      # Right now we handle OpenMPI, MPICH, and HPE MPT.
+      # Other MPI implementations could be added later.
+
+      export OMPI_CC := $(CXX)
+      export OMPI_CXX := $(CC)
+      export OMPI_F77 := $(FC)
+      export OMPI_FC  := $(F90)
+
+      export MPICH_CC  := $(CXX)
+      export MPICH_CXX := $(CC)
+      export MPICH_F77 := $(FC)
+      export MPICH_FC  := $(F90)
+
+      export MPICXX_CXX := $(CXX)
+      export MPICC_CC   := $(CXX)
+      export MPIF90_F90 := $(F90)
+    endif
+
 else ifeq ($(USE_CUDA),TRUE)
 
     USE_GPU := TRUE
@@ -988,6 +1009,10 @@ else ifeq ($(USE_HIP),TRUE)
 
     LINKFLAGS = $(HIPCC_FLAGS)
     AMREX_LINKER = hipcc
+
+    ifdef AMREX_AMD_ARCH
+      AMD_ARCH = $(AMREX_AMD_ARCH)
+    endif
 
     ifeq ($(HIP_SAVE_TEMPS),TRUE)
       # Issue: hipcc does not seem to respect the arg to --save-temps

--- a/Tools/GNUMake/comps/hip.mak
+++ b/Tools/GNUMake/comps/hip.mak
@@ -21,17 +21,21 @@ endif
 #if less than a given version, throw error.
 
 # Generic flags, always used
-CXXFLAGS := -std=$(CXXSTD) -m64
-CFLAGS   := -std=c99 -m64
+CXXFLAGS = -std=$(CXXSTD) -m64
+CFLAGS   = -std=c99 -m64
 
-FFLAGS   := -ffixed-line-length-none -fno-range-check -fno-second-underscore
-F90FLAGS := -ffree-line-length-none -fno-range-check -fno-second-underscore -fimplicit-none
+FFLAGS   = -ffixed-line-length-none -fno-range-check -fno-second-underscore
+F90FLAGS = -ffree-line-length-none -fno-range-check -fno-second-underscore -fimplicit-none
 
 FMODULES =  -J$(fmoddir) -I $(fmoddir)
 
 # rdc support
-CXXFLAGS += -fgpu-rdc
-HIPCC_FLAGS += -fgpu-rdc # This will be added to link flags
+HIPCC_FLAGS += -fgpu-rdc
+
+# amd gpu target
+HIPCC_FLAGS += --amdgpu-target=$(AMD_ARCH)
+
+CXXFLAGS += $(HIPCC_FLAGS)
 
 # =============================================================================================
 

--- a/Tools/GNUMake/sites/Make.frontier-coe
+++ b/Tools/GNUMake/sites/Make.frontier-coe
@@ -2,8 +2,7 @@ ifeq (,$(filter $(which_computer),poplar redwood tulip))
   $(error Unknown Frontier CoE computer, $(which_computer))
 else
   ifeq ($(USE_HIP),TRUE)
-    CXXFLAGS += --amdgpu-target=gfx906,gfx908
-    HIPCC_FLAGS += --amdgpu-target=gfx906,gfx908
+    AMD_ARCH=gfx906,gfx908
   endif
 
   ifeq ($(USE_MPI),TRUE)

--- a/Tools/GNUMake/sites/Make.olcf
+++ b/Tools/GNUMake/sites/Make.olcf
@@ -48,8 +48,7 @@ endif
 ifeq ($(which_computer),spock)
   ifeq ($(USE_HIP),TRUE)
     # MI100
-    CXXFLAGS += --amdgpu-target=gfx908
-    HIPCC_FLAGS += --amdgpu-target=gfx908
+    AMD_ARCH=gfx908
   endif
 
   ifeq ($(USE_MPI),TRUE)


### PR DESCRIPTION
In GNU make, one can set amd gpu targets with make argument AMD_ARCH or
environment variable AMREX_AMD_ARCH.

Also set MPI wrapper's underlying compiler to hipcc.  This is needed if the
machine is unknown.  For machines known to the gnu make build system, we
could either use mpicxx or hipcc -Ipath/to/mpi/include.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
