### PR TITLE
Workaround for gfortran 10

### DIFF
--- a/Tools/GNUMake/comps/gnu.mak
+++ b/Tools/GNUMake/comps/gnu.mak
@@ -212,6 +212,15 @@ F90FLAGS += -ffree-line-length-none -fno-range-check -fno-second-underscore -fim
 
 FMODULES =  -J$(fmoddir) -I $(fmoddir)
 
+# gcc 10 has treated mismatches between actuall and dummy argument lists
+# in a single file as errors. This is a workaround.
+ifeq ($(USE_MPI),TRUE)
+ifeq ($(gcc_major_ge_10),1)
+  F90FLAGS += -fallow-argument-mismatch
+  FFLAGS   += -fallow-argument-mismatch
+endif
+endif
+
 ########################################################################
 
 ifneq ($(BL_NO_FORT),TRUE)

--- a/Tools/GNUMake/comps/hip.mak
+++ b/Tools/GNUMake/comps/hip.mak
@@ -29,6 +29,15 @@ F90FLAGS := -ffree-line-length-none -fno-range-check -fno-second-underscore -fim
 
 FMODULES =  -J$(fmoddir) -I $(fmoddir)
 
+ifeq ($(USE_MPI),TRUE)
+gfortran_major_version = $(shell gfortran -dumpfullversion -dumpversion | head -1 | sed -e 's;.*  *;;' | sed -e 's;\..*;;')
+gfortran_major_ge_10 = $(shell expr $(gfortran_major_version) \>= 10)
+ifeq ($(gfortran_major_ge_10),1)
+  F90FLAGS += -fallow-argument-mismatch
+  FFLAGS   += -fallow-argument-mismatch
+endif
+endif
+
 # rdc support
 CXXFLAGS += -fgpu-rdc
 HIPCC_FLAGS += -fgpu-rdc # This will be added to link flags

--- a/Tools/GNUMake/comps/llvm.mak
+++ b/Tools/GNUMake/comps/llvm.mak
@@ -78,6 +78,15 @@ F90FLAGS += -ffree-line-length-none -fno-range-check -fno-second-underscore -fim
 
 FMODULES =  -J$(fmoddir) -I $(fmoddir)
 
+ifeq ($(USE_MPI),TRUE)
+gfortran_major_version = $(shell gfortran -dumpfullversion -dumpversion | head -1 | sed -e 's;.*  *;;' | sed -e 's;\..*;;')
+gfortran_major_ge_10 = $(shell expr $(gfortran_major_version) \>= 10)
+ifeq ($(gfortran_major_ge_10),1)
+  F90FLAGS += -fallow-argument-mismatch
+  FFLAGS   += -fallow-argument-mismatch
+endif
+endif
+
 ########################################################################
 
 GENERIC_COMP_FLAGS =


### PR DESCRIPTION
Starting from gfortran 10, mismatches between actual and dummy argument
lists in a single file have been rejected with an error.  This causes issues
for MPI calls.  This commit adds -fallow-argument-mismatch as a workaround.

## Additional background

https://gcc.gnu.org/gcc-10/changes.html
https://lists.mpich.org/pipermail/discuss/2020-January/005863.html

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
