### PR TITLE
Workaround argument mismatch in MPI reduce for gfortran >= 10

### DIFF
--- a/Src/F_Interfaces/Base/AMReX_fi_mpi_mod.F90
+++ b/Src/F_Interfaces/Base/AMReX_fi_mpi_mod.F90
@@ -1,0 +1,4 @@
+module amrex_fi_mpi
+  use mpi
+  implicit none
+end module amrex_fi_mpi

--- a/Src/F_Interfaces/Base/AMReX_mpi_reduce_int.F90
+++ b/Src/F_Interfaces/Base/AMReX_mpi_reduce_int.F90
@@ -1,0 +1,62 @@
+! Starting from gfortran 10, mismatches between actual and dummy argument
+! lists in a single file have been rejected with an error.  This causes
+! issues for mpich. https://lists.mpich.org/pipermail/discuss/2020-January/005863.html
+! This is a workaroung by splitting calls to int and real into two files.
+
+module amrex_mpi_reduce_int_module
+  use amrex_fi_mpi
+  implicit none
+  private
+  public :: amrex_mpi_reduce_int, amrex_mpi_allreduce_int
+
+  interface amrex_mpi_reduce_int
+     module procedure amrex_mpi_reduce_int_s
+     module procedure amrex_mpi_reduce_int_v
+  end interface amrex_mpi_reduce_int
+
+  interface amrex_mpi_allreduce_int
+     module procedure amrex_mpi_allreduce_int_s
+     module procedure amrex_mpi_allreduce_int_v
+  end interface amrex_mpi_allreduce_int
+
+contains
+
+  subroutine amrex_mpi_reduce_int_s (sendbuf, recvbuf, count, datatype, op, root, comm, ierror)
+    integer, intent(in) :: sendbuf
+    integer, intent(out) :: recvbuf
+    integer, intent(in) :: count, datatype, op, root, comm
+    integer, intent(out) :: ierror
+    integer :: src(1), dst(1)
+    src(1) = sendbuf
+    call MPI_Reduce(src, dst, 1, datatype, op, root, comm, ierror)
+    recvbuf = dst(1)
+  end subroutine amrex_mpi_reduce_int_s
+
+  subroutine amrex_mpi_reduce_int_v (sendbuf, recvbuf, count, datatype, op, root, comm, ierror)
+    integer, intent(in) :: sendbuf(*)
+    integer :: recvbuf(*)
+    integer, intent(in) :: count, datatype, op, root, comm
+    integer, intent(out) :: ierror
+    call MPI_Reduce(sendbuf, recvbuf, count, datatype, op, root, comm, ierror)
+  end subroutine amrex_mpi_reduce_int_v
+
+  subroutine amrex_mpi_allreduce_int_s (sendbuf, recvbuf, count, datatype, op, comm, ierror)
+    integer, intent(in) :: sendbuf
+    integer, intent(out) :: recvbuf
+    integer, intent(in) :: count, datatype, op, comm
+    integer, intent(out) :: ierror
+    integer :: src(1), dst(1)
+    src(1) = sendbuf
+    call MPI_Allreduce(src, dst, 1, datatype, op, comm, ierror)
+    recvbuf = dst(1)
+  end subroutine amrex_mpi_allreduce_int_s
+
+  subroutine amrex_mpi_allreduce_int_v (sendbuf, recvbuf, count, datatype, op, comm, ierror)
+    integer, intent(in) :: sendbuf(*)
+    integer :: recvbuf(*)
+    integer, intent(in) :: count, datatype, op, comm
+    integer, intent(out) :: ierror
+    call MPI_Allreduce(sendbuf, recvbuf, count, datatype, op, comm, ierror)
+  end subroutine amrex_mpi_allreduce_int_v
+
+end module amrex_mpi_reduce_int_module

--- a/Src/F_Interfaces/Base/AMReX_mpi_reduce_real.F90
+++ b/Src/F_Interfaces/Base/AMReX_mpi_reduce_real.F90
@@ -1,0 +1,63 @@
+! Starting from gfortran 10, mismatches between actual and dummy argument
+! lists in a single file have been rejected with an error.  This causes
+! issues for mpich. https://lists.mpich.org/pipermail/discuss/2020-January/005863.html
+! This is a workaroung by splitting calls to int and real into two files.
+
+module amrex_mpi_reduce_real_module
+  use amrex_fi_mpi
+  use amrex_fort_module, only : amrex_real
+  implicit none
+  private
+  public :: amrex_mpi_reduce_real, amrex_mpi_allreduce_real
+
+  interface amrex_mpi_reduce_real
+     module procedure amrex_mpi_reduce_real_s
+     module procedure amrex_mpi_reduce_real_v
+  end interface amrex_mpi_reduce_real
+
+  interface amrex_mpi_allreduce_real
+     module procedure amrex_mpi_allreduce_real_s
+     module procedure amrex_mpi_allreduce_real_v
+  end interface amrex_mpi_allreduce_real
+
+contains
+
+  subroutine amrex_mpi_reduce_real_s (sendbuf, recvbuf, count, datatype, op, root, comm, ierror)
+    real(amrex_real), intent(in) :: sendbuf
+    real(amrex_real), intent(out) :: recvbuf
+    integer, intent(in) :: count, datatype, op, root, comm
+    integer, intent(out) :: ierror
+    real(amrex_real) :: src(1), dst(1)
+    src(1) = sendbuf
+    call MPI_Reduce(src, dst, 1, datatype, op, root, comm, ierror)
+    recvbuf = dst(1)
+  end subroutine amrex_mpi_reduce_real_s
+
+  subroutine amrex_mpi_reduce_real_v (sendbuf, recvbuf, count, datatype, op, root, comm, ierror)
+    real(amrex_real), intent(in) :: sendbuf(*)
+    real(amrex_real) :: recvbuf(*)
+    integer, intent(in) :: count, datatype, op, root, comm
+    integer, intent(out) :: ierror
+    call MPI_Reduce(sendbuf, recvbuf, count, datatype, op, root, comm, ierror)
+  end subroutine amrex_mpi_reduce_real_v
+
+  subroutine amrex_mpi_allreduce_real_s (sendbuf, recvbuf, count, datatype, op, comm, ierror)
+    real(amrex_real), intent(in) :: sendbuf
+    real(amrex_real), intent(out) :: recvbuf
+    integer, intent(in) :: count, datatype, op, comm
+    integer, intent(out) :: ierror
+    real(amrex_real) :: src(1), dst(1)
+    src(1) = sendbuf
+    call MPI_Allreduce(src, dst, 1, datatype, op, comm, ierror)
+    recvbuf = dst(1)
+  end subroutine amrex_mpi_allreduce_real_s
+
+  subroutine amrex_mpi_allreduce_real_v (sendbuf, recvbuf, count, datatype, op, comm, ierror)
+    real(amrex_real), intent(in) :: sendbuf(*)
+    real(amrex_real) :: recvbuf(*)
+    integer, intent(in) :: count, datatype, op, comm
+    integer, intent(out) :: ierror
+    call MPI_Allreduce(sendbuf, recvbuf, count, datatype, op, comm, ierror)
+  end subroutine amrex_mpi_allreduce_real_v
+
+end module amrex_mpi_reduce_real_module

--- a/Src/F_Interfaces/Base/AMReX_parallel_mod.F90
+++ b/Src/F_Interfaces/Base/AMReX_parallel_mod.F90
@@ -1,16 +1,10 @@
-
-#ifdef BL_USE_MPI
-module amrex_fi_mpi
-  use mpi
-  implicit none
-end module amrex_fi_mpi
-#endif
-
 module amrex_parallel_module
 
   use iso_c_binding
 #ifdef BL_USE_MPI
   use amrex_fi_mpi
+  use amrex_mpi_reduce_int_module, only : amrex_mpi_reduce_int, amrex_mpi_allreduce_int
+  use amrex_mpi_reduce_real_module, only : amrex_mpi_reduce_real, amrex_mpi_allreduce_real
 #endif
 
   use amrex_error_module
@@ -141,9 +135,9 @@ contains
     integer :: tmp, ierr
     tmp = i
     if (present(rank)) then
-       call MPI_Reduce(tmp, i, 1, MPI_INTEGER, MPI_SUM, rank, m_comm, ierr)
+       call amrex_mpi_reduce_int(tmp, i, 1, MPI_INTEGER, MPI_SUM, rank, m_comm, ierr)
     else
-       call MPI_Allreduce(tmp, i, 1, MPI_INTEGER, MPI_SUM, m_comm, ierr)
+       call amrex_mpi_allreduce_int(tmp, i, 1, MPI_INTEGER, MPI_SUM, m_comm, ierr)
     end if
 #endif
   end subroutine amrex_parallel_reduce_sum_is
@@ -156,9 +150,9 @@ contains
     integer :: tmp(n), ierr
     tmp = i(1:n)
     if (present(rank)) then
-       call MPI_Reduce(tmp, i, n, MPI_INTEGER, MPI_SUM, rank, m_comm, ierr)
+       call amrex_mpi_reduce_int(tmp, i, n, MPI_INTEGER, MPI_SUM, rank, m_comm, ierr)
     else
-       call MPI_Allreduce(tmp, i, n, MPI_INTEGER, MPI_SUM, m_comm, ierr)
+       call amrex_mpi_allreduce_int(tmp, i, n, MPI_INTEGER, MPI_SUM, m_comm, ierr)
     end if
 #endif
   end subroutine amrex_parallel_reduce_sum_iv
@@ -171,9 +165,9 @@ contains
     integer :: ierr
     tmp = r
     if (present(rank)) then
-       call MPI_Reduce(tmp, r, 1, amrex_mpi_real, MPI_SUM, rank, m_comm, ierr)
+       call amrex_mpi_reduce_real(tmp, r, 1, amrex_mpi_real, MPI_SUM, rank, m_comm, ierr)
     else
-       call MPI_Allreduce(tmp, r, 1, amrex_mpi_real, MPI_SUM, m_comm, ierr)
+       call amrex_mpi_allreduce_real(tmp, r, 1, amrex_mpi_real, MPI_SUM, m_comm, ierr)
     end if
 #endif
   end subroutine amrex_parallel_reduce_sum_rs
@@ -187,9 +181,9 @@ contains
     integer :: ierr
     tmp = r(1:n)
     if (present(rank)) then
-       call MPI_Reduce(tmp, r, n, amrex_mpi_real, MPI_SUM, rank, m_comm, ierr)
+       call amrex_mpi_reduce_real(tmp, r, n, amrex_mpi_real, MPI_SUM, rank, m_comm, ierr)
     else
-       call MPI_Allreduce(tmp, r, n, amrex_mpi_real, MPI_SUM, m_comm, ierr)
+       call amrex_mpi_allreduce_real(tmp, r, n, amrex_mpi_real, MPI_SUM, m_comm, ierr)
     end if
 #endif
   end subroutine amrex_parallel_reduce_sum_rv
@@ -201,9 +195,9 @@ contains
     integer :: tmp, ierr
     tmp = i
     if (present(rank)) then
-       call MPI_Reduce(tmp, i, 1, MPI_INTEGER, MPI_MAX, rank, m_comm, ierr)
+       call amrex_mpi_reduce_int(tmp, i, 1, MPI_INTEGER, MPI_MAX, rank, m_comm, ierr)
     else
-       call MPI_Allreduce(tmp, i, 1, MPI_INTEGER, MPI_MAX, m_comm, ierr)
+       call amrex_mpi_allreduce_int(tmp, i, 1, MPI_INTEGER, MPI_MAX, m_comm, ierr)
     end if
 #endif
   end subroutine amrex_parallel_reduce_max_is
@@ -216,9 +210,9 @@ contains
     integer :: tmp(n), ierr
     tmp = i(1:n)
     if (present(rank)) then
-       call MPI_Reduce(tmp, i, n, MPI_INTEGER, MPI_MAX, rank, m_comm, ierr)
+       call amrex_mpi_reduce_int(tmp, i, n, MPI_INTEGER, MPI_MAX, rank, m_comm, ierr)
     else
-       call MPI_Allreduce(tmp, i, n, MPI_INTEGER, MPI_MAX, m_comm, ierr)
+       call amrex_mpi_allreduce_int(tmp, i, n, MPI_INTEGER, MPI_MAX, m_comm, ierr)
     end if
 #endif
   end subroutine amrex_parallel_reduce_max_iv
@@ -231,9 +225,9 @@ contains
     integer :: ierr
     tmp = r
     if (present(rank)) then
-       call MPI_Reduce(tmp, r, 1, amrex_mpi_real, MPI_MAX, rank, m_comm, ierr)
+       call amrex_mpi_reduce_real(tmp, r, 1, amrex_mpi_real, MPI_MAX, rank, m_comm, ierr)
     else
-       call MPI_Allreduce(tmp, r, 1, amrex_mpi_real, MPI_MAX, m_comm, ierr)
+       call amrex_mpi_allreduce_real(tmp, r, 1, amrex_mpi_real, MPI_MAX, m_comm, ierr)
     end if
 #endif
   end subroutine amrex_parallel_reduce_max_rs
@@ -247,9 +241,9 @@ contains
     integer :: ierr
     tmp = r(1:n)
     if (present(rank)) then
-       call MPI_Reduce(tmp, r, n, amrex_mpi_real, MPI_MAX, rank, m_comm, ierr)
+       call amrex_mpi_reduce_real(tmp, r, n, amrex_mpi_real, MPI_MAX, rank, m_comm, ierr)
     else
-       call MPI_Allreduce(tmp, r, n, amrex_mpi_real, MPI_MAX, m_comm, ierr)
+       call amrex_mpi_allreduce_real(tmp, r, n, amrex_mpi_real, MPI_MAX, m_comm, ierr)
     end if
 #endif
   end subroutine amrex_parallel_reduce_max_rv
@@ -261,9 +255,9 @@ contains
     integer :: tmp, ierr
     tmp = i
     if (present(rank)) then
-       call MPI_Reduce(tmp, i, 1, MPI_INTEGER, MPI_MIN, rank, m_comm, ierr)
+       call amrex_mpi_reduce_int(tmp, i, 1, MPI_INTEGER, MPI_MIN, rank, m_comm, ierr)
     else
-       call MPI_Allreduce(tmp, i, 1, MPI_INTEGER, MPI_MIN, m_comm, ierr)
+       call amrex_mpi_allreduce_int(tmp, i, 1, MPI_INTEGER, MPI_MIN, m_comm, ierr)
     end if
 #endif
   end subroutine amrex_parallel_reduce_min_is
@@ -276,9 +270,9 @@ contains
     integer :: tmp(n), ierr
     tmp = i(1:n)
     if (present(rank)) then
-       call MPI_Reduce(tmp, i, n, MPI_INTEGER, MPI_MIN, rank, m_comm, ierr)
+       call amrex_mpi_reduce_int(tmp, i, n, MPI_INTEGER, MPI_MIN, rank, m_comm, ierr)
     else
-       call MPI_Allreduce(tmp, i, n, MPI_INTEGER, MPI_MIN, m_comm, ierr)
+       call amrex_mpi_allreduce_int(tmp, i, n, MPI_INTEGER, MPI_MIN, m_comm, ierr)
     end if
 #endif
   end subroutine amrex_parallel_reduce_min_iv
@@ -291,9 +285,9 @@ contains
     integer :: ierr
     tmp = r
     if (present(rank)) then
-       call MPI_Reduce(tmp, r, 1, amrex_mpi_real, MPI_MIN, rank, m_comm, ierr)
+       call amrex_mpi_reduce_real(tmp, r, 1, amrex_mpi_real, MPI_MIN, rank, m_comm, ierr)
     else
-       call MPI_Allreduce(tmp, r, 1, amrex_mpi_real, MPI_MIN, m_comm, ierr)
+       call amrex_mpi_allreduce_real(tmp, r, 1, amrex_mpi_real, MPI_MIN, m_comm, ierr)
     end if
 #endif
   end subroutine amrex_parallel_reduce_min_rs
@@ -307,9 +301,9 @@ contains
     integer :: ierr
     tmp = r(1:n)
     if (present(rank)) then
-       call MPI_Reduce(tmp, r, n, amrex_mpi_real, MPI_MIN, rank, m_comm, ierr)
+       call amrex_mpi_reduce_real(tmp, r, n, amrex_mpi_real, MPI_MIN, rank, m_comm, ierr)
     else
-       call MPI_Allreduce(tmp, r, n, amrex_mpi_real, MPI_MIN, m_comm, ierr)
+       call amrex_mpi_allreduce_real(tmp, r, n, amrex_mpi_real, MPI_MIN, m_comm, ierr)
     end if
 #endif
   end subroutine amrex_parallel_reduce_min_rv

--- a/Src/F_Interfaces/Base/Make.package
+++ b/Src/F_Interfaces/Base/Make.package
@@ -17,5 +17,9 @@ CEXE_sources += AMReX_multifabutil_fi.cpp AMReX_physbc_fi.cpp
 CEXE_headers += AMReX_FPhysBC.H
 CEXE_sources += AMReX_FPhysBC.cpp
 
+ifeq ($(USE_MPI),TRUE)
+  F90EXE_sources += AMReX_fi_mpi_mod.F90 AMReX_mpi_reduce_int.F90 AMReX_mpi_reduce_real.F90
+endif
+
 VPATH_LOCATIONS += $(AMREX_HOME)/Src/F_Interfaces/Base
 INCLUDE_LOCATIONS += $(AMREX_HOME)/Src/F_Interfaces/Base

--- a/Src/F_Interfaces/CMakeLists.txt
+++ b/Src/F_Interfaces/CMakeLists.txt
@@ -38,6 +38,14 @@ target_sources( amrex PRIVATE
    Base/AMReX_FPhysBC.cpp
    )
 
+if (AMReX_MPI)
+  target_sources( amrex PRIVATE
+    Base/AMReX_fi_mpi_mod.F90
+    Base/AMReX_mpi_reduce_int.F90
+    Base/AMReX_mpi_reduce_real.F90
+    )
+endif ()
+
 #
 # AMRCORE subdir
 #

--- a/Tools/GNUMake/comps/gnu.mak
+++ b/Tools/GNUMake/comps/gnu.mak
@@ -212,15 +212,6 @@ F90FLAGS += -ffree-line-length-none -fno-range-check -fno-second-underscore -fim
 
 FMODULES =  -J$(fmoddir) -I $(fmoddir)
 
-# gcc 10 has treated mismatches between actuall and dummy argument lists
-# in a single file as errors. This is a workaround.
-ifeq ($(USE_MPI),TRUE)
-ifeq ($(gcc_major_ge_10),1)
-  F90FLAGS += -fallow-argument-mismatch
-  FFLAGS   += -fallow-argument-mismatch
-endif
-endif
-
 ########################################################################
 
 ifneq ($(BL_NO_FORT),TRUE)

--- a/Tools/GNUMake/comps/hip.mak
+++ b/Tools/GNUMake/comps/hip.mak
@@ -29,15 +29,6 @@ F90FLAGS := -ffree-line-length-none -fno-range-check -fno-second-underscore -fim
 
 FMODULES =  -J$(fmoddir) -I $(fmoddir)
 
-ifeq ($(USE_MPI),TRUE)
-gfortran_major_version = $(shell gfortran -dumpfullversion -dumpversion | head -1 | sed -e 's;.*  *;;' | sed -e 's;\..*;;')
-gfortran_major_ge_10 = $(shell expr $(gfortran_major_version) \>= 10)
-ifeq ($(gfortran_major_ge_10),1)
-  F90FLAGS += -fallow-argument-mismatch
-  FFLAGS   += -fallow-argument-mismatch
-endif
-endif
-
 # rdc support
 CXXFLAGS += -fgpu-rdc
 HIPCC_FLAGS += -fgpu-rdc # This will be added to link flags

--- a/Tools/GNUMake/comps/llvm.mak
+++ b/Tools/GNUMake/comps/llvm.mak
@@ -78,15 +78,6 @@ F90FLAGS += -ffree-line-length-none -fno-range-check -fno-second-underscore -fim
 
 FMODULES =  -J$(fmoddir) -I $(fmoddir)
 
-ifeq ($(USE_MPI),TRUE)
-gfortran_major_version = $(shell gfortran -dumpfullversion -dumpversion | head -1 | sed -e 's;.*  *;;' | sed -e 's;\..*;;')
-gfortran_major_ge_10 = $(shell expr $(gfortran_major_version) \>= 10)
-ifeq ($(gfortran_major_ge_10),1)
-  F90FLAGS += -fallow-argument-mismatch
-  FFLAGS   += -fallow-argument-mismatch
-endif
-endif
-
 ########################################################################
 
 GENERIC_COMP_FLAGS =


### PR DESCRIPTION
In #2040, we added -fallow-argument-mismatch as a workaround.  This commit
reverts the change and implements an alternative approach that does not
require that compiler compiler.  We just need to make sure that there are no
argument mismatches in the same file.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
