### PR TITLE
ParamParse: Find Entries under Prefix

### DIFF
--- a/Src/Base/AMReX_ParmParse.H
+++ b/Src/Base/AMReX_ParmParse.H
@@ -5,6 +5,7 @@
 
 #include <AMReX_BLassert.H>
 
+#include <set>
 #include <stack>
 #include <string>
 #include <iosfwd>
@@ -936,7 +937,7 @@ public:
     static std::vector<std::string> getUnusedInputs (const std::string& prefix = std::string());
 
     //! Returns [prefix.]* parameters.
-    static std::vector<std::string> getEntries (const std::string& prefix = std::string());
+    static std::set<std::string> getEntries (const std::string& prefix = std::string());
 
     struct PP_entry;
     typedef std::list<PP_entry> Table;

--- a/Src/Base/AMReX_ParmParse.H
+++ b/Src/Base/AMReX_ParmParse.H
@@ -935,6 +935,9 @@ public:
     //! Returns unused [prefix.]* parameters.
     static std::vector<std::string> getUnusedInputs (const std::string& prefix = std::string());
 
+    //! Returns [prefix.]* parameters.
+    static std::vector<std::string> getEntries (const std::string& prefix = std::string());
+
     struct PP_entry;
     typedef std::list<PP_entry> Table;
     static void appendTable(ParmParse::Table& tab);

--- a/Src/Base/AMReX_ParmParse.cpp
+++ b/Src/Base/AMReX_ParmParse.cpp
@@ -19,6 +19,8 @@
 #include <cctype>
 #include <vector>
 #include <list>
+#include <set>
+#include <string>
 
 extern "C" void amrex_init_namelist (const char*);
 extern "C" void amrex_finalize_namelist ();
@@ -1148,12 +1150,12 @@ ParmParse::getUnusedInputs (const std::string& prefix)
     return r;
 }
 
-std::vector<std::string>
+std::set<std::string>
 ParmParse::getEntries (const std::string& prefix)
 {
     std::vector<std::string> r;
     get_entries_under_prefix(r, g_table, prefix, false, false);
-    return r;
+    return std::set<std::string>(r.begin(), r.end());
 }
 
 void


### PR DESCRIPTION
## Summary

Extend the "unused params" checks to find generally parameters under a given inputs prefix.

## Additional background

Demonstrator & test in: https://github.com/AMReX-Codes/amrex-tutorials/pull/7

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
