### PR TITLE
Add relative gradient to AMRErrorTag

### DIFF
--- a/Src/AmrCore/AMReX_ErrorList.H
+++ b/Src/AmrCore/AMReX_ErrorList.H
@@ -406,7 +406,7 @@ std::ostream& operator << (std::ostream& os, const ErrorList& elst);
   {
   public:
 
-    enum TEST {GRAD=0, LESS, GREATER, VORT, BOX, USER};
+    enum TEST {GRAD=0, RELGRAD, LESS, GREATER, VORT, BOX, USER};
 
     struct UserFunc
     {


### PR DESCRIPTION
## Summary

This tagging scheme measures the gradient with respect to the size of the field in the current zone (whereas AMRErrorTag::GRAD uses the absolute value of the gradient).

## Additional background

This is needed to replace tagging functionality such as `dengrad_rel` in Castro.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
