### PR TITLE
When building neighbor masks, perform setVal on device so it will work without managed memory.

### DIFF
--- a/Src/Particle/AMReX_NeighborParticlesGPUImpl.H
+++ b/Src/Particle/AMReX_NeighborParticlesGPUImpl.H
@@ -118,7 +118,7 @@ buildNeighborMask ()
                 const bool first_only = false;
                 auto isecs = isec_ba.intersections(box, first_only, nGrow);
 
-                if (! isecs.empty() ) (*m_neighbor_mask_ptr)[mfi].setVal<RunOn::Host>(i, box);
+                if (! isecs.empty() ) (*m_neighbor_mask_ptr)[mfi].setVal<RunOn::Device>(i, box);
 
                 for (auto& isec : isecs)
                 {

--- a/Src/Particle/AMReX_NeighborParticlesGPUImpl.H
+++ b/Src/Particle/AMReX_NeighborParticlesGPUImpl.H
@@ -45,6 +45,16 @@ namespace detail
     }
 }
 
+template <class T>
+struct Array4BoxValTag {
+    Array4<T> dfab;
+    Box       dbox;
+    T          val;
+
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    Box const& box () const noexcept { return dbox; }
+};
+
 template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt>
 void
 NeighborParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>::
@@ -69,6 +79,8 @@ buildNeighborMask ()
 
         const Periodicity& periodicity = geom.periodicity();
         const std::vector<IntVect>& pshifts = periodicity.shiftIntVect();
+
+        Vector<Array4BoxValTag<int> > tags;
 
         for (MFIter mfi(ba, dmap); mfi.isValid(); ++mfi)
         {
@@ -118,7 +130,9 @@ buildNeighborMask ()
                 const bool first_only = false;
                 auto isecs = isec_ba.intersections(box, first_only, nGrow);
 
-                if (! isecs.empty() ) (*m_neighbor_mask_ptr)[mfi].setVal<RunOn::Device>(i, box);
+                if (! isecs.empty() ) {
+                    tags.push_back({(*m_neighbor_mask_ptr)[mfi].array(), box, i});
+                }
 
                 for (auto& isec : isecs)
                 {
@@ -144,6 +158,13 @@ buildNeighborMask ()
 
             Gpu::Device::synchronize();
         }
+
+        amrex::ParallelFor(tags, 1,
+            [=] AMREX_GPU_DEVICE (int i, int j, int k, int n, const Array4BoxValTag<int>& tag) noexcept
+            {
+                tag.dfab(i,j,k,n) = tag.val;
+            });
+
         RemoveDuplicates(neighbor_procs);
     }
 }


### PR DESCRIPTION
This fixes an issue reported by Chris Lishka from Intel re: mfix. 

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
