### PR TITLE
CMake link with roc::rocprim for HIP

### DIFF
--- a/Tools/CMake/AMReXParallelBackends.cmake
+++ b/Tools/CMake/AMReXParallelBackends.cmake
@@ -208,8 +208,9 @@ if (AMReX_HIP)
 
    # Link to hiprand -- must include rocrand too
    find_package(rocrand REQUIRED CONFIG)
+   find_package(rocprim REQUIRED CONFIG)
    find_package(hiprand REQUIRED CONFIG)
-   target_link_libraries(amrex PUBLIC hip::hiprand roc::rocrand)
+   target_link_libraries(amrex PUBLIC hip::hiprand roc::rocrand roc::rocprim)
 
    # ARCH flags -- these must be PUBLIC for all downstream targets to use,
    # else there will be a runtime issue (cannot find

--- a/Tools/CMake/AMReXParallelBackends.cmake
+++ b/Tools/CMake/AMReXParallelBackends.cmake
@@ -210,7 +210,7 @@ if (AMReX_HIP)
    find_package(rocrand REQUIRED CONFIG)
    find_package(rocprim REQUIRED CONFIG)
    find_package(hiprand REQUIRED CONFIG)
-   target_link_libraries(amrex PUBLIC hip::hiprand roc::rocrand roc::rocprim)
+   target_link_libraries(amrex PUBLIC hip::hiprand roc::rocrand roc::rocprim ${HIP_LIBRARIES})
 
    # ARCH flags -- these must be PUBLIC for all downstream targets to use,
    # else there will be a runtime issue (cannot find

--- a/Tools/CMake/AMReXParallelBackends.cmake
+++ b/Tools/CMake/AMReXParallelBackends.cmake
@@ -210,7 +210,7 @@ if (AMReX_HIP)
    find_package(rocrand REQUIRED CONFIG)
    find_package(rocprim REQUIRED CONFIG)
    find_package(hiprand REQUIRED CONFIG)
-   target_link_libraries(amrex PUBLIC hip::hiprand roc::rocrand roc::rocprim ${HIP_LIBRARIES})
+   target_link_libraries(amrex PUBLIC hip::hiprand roc::rocrand roc::rocprim)
 
    # ARCH flags -- these must be PUBLIC for all downstream targets to use,
    # else there will be a runtime issue (cannot find


### PR DESCRIPTION
## Summary

Fix error when building MFiX with HIP ROCm

## Additional background

When building MFiX with CMake and HIP enabled, the build error

```
In file included from ../subprojects/amrex/Src/Base/AMReX_GpuLaunch.H:13:
../subprojects/amrex/Src/Base/AMReX_GpuReduce.H:19:10: fatal error: 'rocprim/rocprim.hpp' file not found
#include <rocprim/rocprim.hpp>
         ^~~~~~~~~~~~~~~~~~~~~
```

is resolved by linking with `rocprim`

## Checklist

The proposed changes:
- [X] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
