### PR TITLE
Link with HIP_LIBRARIES

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -278,20 +278,30 @@ jobs:
       run: |
         source /etc/profile.d/rocm.sh
         hipcc --version
-        mkdir build
-        cd build
-        cmake ..                                          \
+        cmake -S . -B build_full                          \
             -DCMAKE_VERBOSE_MAKEFILE=ON                   \
             -DAMReX_ENABLE_TESTS=ON                       \
             -DAMReX_PARTICLES=ON                          \
             -DAMReX_FORTRAN=ON                            \
             -DAMReX_LINEAR_SOLVERS=ON                     \
             -DAMReX_GPU_BACKEND=HIP                       \
-            -DAMReX_AMD_ARCH=gfx900                       \
+            -DAMReX_AMD_ARCH=gfx908                       \
             -DCMAKE_C_COMPILER=$(which clang)             \
             -DCMAKE_CXX_COMPILER=$(which hipcc)           \
             -DCMAKE_Fortran_COMPILER=$(which gfortran)
-        make -j 2
+        cmake --build build_full -j 2
+        cmake -S . -B build_nofortran                     \
+            -DCMAKE_VERBOSE_MAKEFILE=ON                   \
+            -DAMReX_ENABLE_TESTS=ON                       \
+            -DAMReX_PARTICLES=ON                          \
+            -DAMReX_FORTRAN=OFF                           \
+            -DAMReX_LINEAR_SOLVERS=ON                     \
+            -DAMReX_GPU_BACKEND=HIP                       \
+            -DAMReX_AMD_ARCH=gfx908                       \
+            -DCMAKE_C_COMPILER=$(which clang)             \
+            -DCMAKE_CXX_COMPILER=$(which hipcc)           \
+            -DCMAKE_Fortran_COMPILER=$(which gfortran)
+        cmake --build build_nofortran -j 2
 
   # Build 1D libamrex with configure
   configure-1d:

--- a/Tools/CMake/AMReXParallelBackends.cmake
+++ b/Tools/CMake/AMReXParallelBackends.cmake
@@ -211,7 +211,7 @@ if (AMReX_HIP)
    find_package(rocprim REQUIRED CONFIG)
    find_package(hiprand REQUIRED CONFIG)
    target_link_libraries(amrex PUBLIC hip::hiprand roc::rocrand roc::rocprim)
-   target_link_libraries(amrex PUBLIC $<$<COMPILE_LANGUAGE:CXX>:${HIP_LIBRARIES}>)
+   target_link_libraries(amrex PUBLIC $<$<LINK_LANGUAGE:CXX>:${HIP_LIBRARIES}>)
 
    # ARCH flags -- these must be PUBLIC for all downstream targets to use,
    # else there will be a runtime issue (cannot find

--- a/Tools/CMake/AMReXParallelBackends.cmake
+++ b/Tools/CMake/AMReXParallelBackends.cmake
@@ -209,7 +209,7 @@ if (AMReX_HIP)
    # avoid forcing the rocm LLVM flags on a gfortran
    # https://github.com/ROCm-Developer-Tools/HIP/issues/2275
    if(AMReX_FORTRAN)
-       message(WARNING "As of rocM/HIP <= 4.2.0, Fortran support might be flaky.\n"
+       message(WARNING "As of ROCm/HIP <= 4.2.0, Fortran support might be flaky.\n"
                        "Especially, we cannot yet support reloctable device code (RDC)."
                        "See https://github.com/ROCm-Developer-Tools/HIP/issues/2275 "
                        "and https://github.com/AMReX-Codes/amrex/pull/2031 "

--- a/Tools/CMake/AMReXParallelBackends.cmake
+++ b/Tools/CMake/AMReXParallelBackends.cmake
@@ -211,8 +211,10 @@ if (AMReX_HIP)
    find_package(rocprim REQUIRED CONFIG)
    find_package(hiprand REQUIRED CONFIG)
    target_link_libraries(amrex PUBLIC hip::hiprand roc::rocrand roc::rocprim)
-   target_link_libraries(amrex PUBLIC $<$<LINK_LANGUAGE:CXX>:${HIP_LIBRARIES}>)
-
+   if(NOT ${AMReX_FORTRAN)
+     target_link_libraries(amrex PUBLIC $<$<LINK_LANGUAGE:CXX>:${HIP_LIBRARIES}>)
+   endif()
+   
    # ARCH flags -- these must be PUBLIC for all downstream targets to use,
    # else there will be a runtime issue (cannot find
    # missing gpu devices)

--- a/Tools/CMake/AMReXParallelBackends.cmake
+++ b/Tools/CMake/AMReXParallelBackends.cmake
@@ -211,6 +211,7 @@ if (AMReX_HIP)
    find_package(rocprim REQUIRED CONFIG)
    find_package(hiprand REQUIRED CONFIG)
    target_link_libraries(amrex PUBLIC hip::hiprand roc::rocrand roc::rocprim)
+   target_link_libraries(amrex PUBLIC $<$<COMPILE_LANGUAGE:CXX>:${HIP_LIBRARIES}>)
 
    # ARCH flags -- these must be PUBLIC for all downstream targets to use,
    # else there will be a runtime issue (cannot find

--- a/Tools/CMake/AMReXParallelBackends.cmake
+++ b/Tools/CMake/AMReXParallelBackends.cmake
@@ -211,7 +211,7 @@ if (AMReX_HIP)
    find_package(rocprim REQUIRED CONFIG)
    find_package(hiprand REQUIRED CONFIG)
    target_link_libraries(amrex PUBLIC hip::hiprand roc::rocrand roc::rocprim)
-   if(NOT ${AMReX_FORTRAN)
+   if(NOT AMReX_FORTRAN)
      target_link_libraries(amrex PUBLIC $<$<LINK_LANGUAGE:CXX>:${HIP_LIBRARIES}>)
    endif()
    

--- a/Tools/CMake/AMReXParallelBackends.cmake
+++ b/Tools/CMake/AMReXParallelBackends.cmake
@@ -206,15 +206,24 @@ if (AMReX_HIP)
          " Ensure that HIP is either installed in /opt/rocm/hip or the variable HIP_PATH is set to point to the right location.")
    endif()
 
+   # avoid forcing the rocm LLVM flags on a gfortran
+   # https://github.com/ROCm-Developer-Tools/HIP/issues/2275
+   if(AMReX_FORTRAN)
+       message(WARNING "As of rocM/HIP <= 4.2.0, Fortran support might be flaky.\n"
+                       "Especially, we cannot yet support reloctable device code (RDC)."
+                       "See https://github.com/ROCm-Developer-Tools/HIP/issues/2275 "
+                       "and https://github.com/AMReX-Codes/amrex/pull/2031 "
+                       "for details.")
+   else()
+       target_link_libraries(amrex PUBLIC ${HIP_LIBRARIES})
+   endif()
+
    # Link to hiprand -- must include rocrand too
    find_package(rocrand REQUIRED CONFIG)
    find_package(rocprim REQUIRED CONFIG)
    find_package(hiprand REQUIRED CONFIG)
    target_link_libraries(amrex PUBLIC hip::hiprand roc::rocrand roc::rocprim)
-   if(NOT AMReX_FORTRAN)
-     target_link_libraries(amrex PUBLIC $<$<LINK_LANGUAGE:CXX>:${HIP_LIBRARIES}>)
-   endif()
-   
+
    # ARCH flags -- these must be PUBLIC for all downstream targets to use,
    # else there will be a runtime issue (cannot find
    # missing gpu devices)


### PR DESCRIPTION
## Summary

Find error building MFiX with CMake for HIP

## Additional background

Following errors occurs when building MFiX with CMake for HIP

```
error: ("Must define exactly one of __HIP_PLATFORM_HCC__ or __HIP_PLATFORM_NVCC__");
```

Linking with `HIP_LIBRARIES` fixes it.

## Checklist

The proposed changes:
- [X] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
