### PR TITLE
Perlmutter Make: CUDA_PATH

### DIFF
--- a/Tools/GNUMake/sites/Make.nersc
+++ b/Tools/GNUMake/sites/Make.nersc
@@ -44,7 +44,20 @@ ifeq ($(which_computer),$(filter $(which_computer),perlmutter))
     endif
   endif
 
-  CUDA_ARCH = 80
+  ifeq ($(USE_CUDA),TRUE)
+    CUDA_ARCH = 80
+
+    ifneq ($(CUDA_ROOT),)
+        SYSTEM_CUDA_PATH := $(CUDA_ROOT)
+        COMPILE_CUDA_PATH := $(CUDA_ROOT)
+    else ifneq ($(CUDA_HOME),)
+        SYSTEM_CUDA_PATH := $(CUDA_HOME)
+        COMPILE_CUDA_PATH := $(CUDA_HOME)
+    else
+        $(error No CUDA_ROOT or CUDA_PATH found. Please load a cuda module.)
+    endif
+
+  endif
 
 endif
 

--- a/Tools/GNUMake/sites/Make.nersc
+++ b/Tools/GNUMake/sites/Make.nersc
@@ -53,8 +53,11 @@ ifeq ($(which_computer),$(filter $(which_computer),perlmutter))
     else ifneq ($(CUDA_HOME),)
         SYSTEM_CUDA_PATH := $(CUDA_HOME)
         COMPILE_CUDA_PATH := $(CUDA_HOME)
+    else ifneq ($(CUDA_PATH),)
+        SYSTEM_CUDA_PATH := $(CUDA_PATH)
+        COMPILE_CUDA_PATH := $(CUDA_PATH)
     else
-        $(error No CUDA_ROOT or CUDA_PATH found. Please load a cuda module.)
+        $(error No CUDA_ROOT nor CUDA_HOME nor CUDA_PATH found. Please load a cuda module.)
     endif
 
   endif


### PR DESCRIPTION
## Summary
Copy CUDA_ROOT/CUDA_PATH logic from cgpu. Required for TINY_PROFILE, among other things.

For now, force users to load a Cuda module (defining a version they're using). Probably good practice anyway, instead of running the default.

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
