### PR TITLE
Clean up some unused variables.

### DIFF
--- a/Src/LinearSolvers/MLMG/AMReX_MLMG.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLMG.cpp
@@ -395,25 +395,6 @@ MLMG::miniCycle (int amrlev)
     mgVcycle(amrlev, mglev);
 }
 
-namespace {
-
-void make_str_helper (std::ostringstream & /*oss*/) { }
-
-template <class T, class... Ts>
-void make_str_helper (std::ostringstream & oss, T x, Ts... xs) {
-    oss << x;
-    make_str_helper(oss, xs...);
-}
-
-template <class... Ts>
-std::string make_str (Ts... xs) {
-    std::ostringstream oss;
-    make_str_helper(oss, xs...);
-    return oss.str();
-}
-
-}
-
 // in   : Residual (res)
 // out  : Correction (cor) from bottom to this function's local top
 void
@@ -425,8 +406,7 @@ MLMG::mgVcycle (int amrlev, int mglev_top)
 
     for (int mglev = mglev_top; mglev < mglev_bottom; ++mglev)
     {
-        std::string blp_mgv_down_lev_str = make_str("MLMG::mgVcycle_down::", mglev);
-        BL_PROFILE_VAR(blp_mgv_down_lev_str, blp_mgv_down_lev);
+        BL_PROFILE_VAR("MLMG::mgVcycle_down::"+std::to_string(mglev), blp_mgv_down_lev);
 
         if (verbose >= 4)
         {
@@ -504,8 +484,7 @@ MLMG::mgVcycle (int amrlev, int mglev_top)
 
     for (int mglev = mglev_bottom-1; mglev >= mglev_top; --mglev)
     {
-        std::string blp_mgv_up_lev_str = make_str("MLMG::mgVcycle_up::", mglev);
-        BL_PROFILE_VAR(blp_mgv_up_lev_str, blp_mgv_up_lev);
+        BL_PROFILE_VAR("MLMG::mgVcycle_up::"+std::to_string(mglev), blp_mgv_up_lev);
         // cor_fine += I(cor_crse)
         addInterpCorrection(amrlev, mglev);
         if (verbose >= 4)

--- a/Tests/MultiBlock/IndexType/main.cpp
+++ b/Tests/MultiBlock/IndexType/main.cpp
@@ -56,7 +56,7 @@ bool ParallelCopyWithItselfIsCorrect(amrex::iMultiFab& mf, const amrex::Box& dom
         amrex::LoopOnCpu(section, [&](int i, int j, int k)
         {
             amrex::Dim3 si = dtos(amrex::Dim3{i,j,k});
-            int value = si.x + si.y*nx + si.z*nx*xy;
+            int value = si.x + si.y*nx + si.z*nx*ny;
             fails += (array(i,j,k) != value);
 
             AMREX_ASSERT(fails);  // If DEBUG, crash on first error.

--- a/Tests/MultiBlock/IndexType/main.cpp
+++ b/Tests/MultiBlock/IndexType/main.cpp
@@ -56,7 +56,10 @@ bool ParallelCopyWithItselfIsCorrect(amrex::iMultiFab& mf, const amrex::Box& dom
         amrex::LoopOnCpu(section, [&](int i, int j, int k)
         {
             amrex::Dim3 si = dtos(amrex::Dim3{i,j,k});
-            AMREX_ASSERT(array(i,j,k) == (si.x + si.y*nx + si.z*nx*ny));
+            int value = si.x + si.y*nx + si.z*nx*xy;
+            fails += (array(i,j,k) != value);
+
+            AMREX_ASSERT(fails);  // If DEBUG, crash on first error.
         });
     }
     return fails == 0;
@@ -116,8 +119,8 @@ bool ParallelCopyFaceToFace(amrex::iMultiFab& dest, const amrex::Box& domain_des
         amrex::LoopOnCpu(section, [&](int i, int j, int k)
         {
             amrex::Dim3 si = dtos(amrex::Dim3{i,j,k});
-	    int value = si.x + si.y*nx + si.z*nx*ny;
-	    fails += (darray(i,j,k) != value);
+            int value = si.x + si.y*nx + si.z*nx*ny;
+            fails += (darray(i,j,k) != value);
 
             AMREX_ASSERT(fails); // If in debug, crash on first error.
         });

--- a/Tests/MultiBlock/IndexType/main.cpp
+++ b/Tests/MultiBlock/IndexType/main.cpp
@@ -116,7 +116,10 @@ bool ParallelCopyFaceToFace(amrex::iMultiFab& dest, const amrex::Box& domain_des
         amrex::LoopOnCpu(section, [&](int i, int j, int k)
         {
             amrex::Dim3 si = dtos(amrex::Dim3{i,j,k});
-            AMREX_ASSERT(darray(i,j,k) == si.x + si.y*nx + si.z*nx*ny);
+	    int value = si.x + si.y*nx + si.z*nx*ny;
+	    fails += (darray(i,j,k) != value);
+
+            AMREX_ASSERT(fails); // If in debug, crash on first error.
         });
     }
     return fails == 0;

--- a/Tests/MultiBlock/IndexType/main.cpp
+++ b/Tests/MultiBlock/IndexType/main.cpp
@@ -59,7 +59,7 @@ bool ParallelCopyWithItselfIsCorrect(amrex::iMultiFab& mf, const amrex::Box& dom
             int value = si.x + si.y*nx + si.z*nx*ny;
             fails += (array(i,j,k) != value);
 
-            AMREX_ASSERT(fails);  // If DEBUG, crash on first error.
+            AMREX_ASSERT(fails==0);  // If DEBUG, crash on first error.
         });
     }
     return fails == 0;
@@ -122,7 +122,7 @@ bool ParallelCopyFaceToFace(amrex::iMultiFab& dest, const amrex::Box& domain_des
             int value = si.x + si.y*nx + si.z*nx*ny;
             fails += (darray(i,j,k) != value);
 
-            AMREX_ASSERT(fails); // If in debug, crash on first error.
+            AMREX_ASSERT(fails==0); // If in debug, crash on first error.
         });
     }
     return fails == 0;

--- a/Tests/MultiBlock/IndexType/main.cpp
+++ b/Tests/MultiBlock/IndexType/main.cpp
@@ -56,8 +56,7 @@ bool ParallelCopyWithItselfIsCorrect(amrex::iMultiFab& mf, const amrex::Box& dom
         amrex::LoopOnCpu(section, [&](int i, int j, int k)
         {
             amrex::Dim3 si = dtos(amrex::Dim3{i,j,k});
-            int value = si.x + si.y*nx + si.z*nx*ny;
-            AMREX_ASSERT(array(i,j,k) == value);
+            AMREX_ASSERT(array(i,j,k) == (si.x + si.y*nx + si.z*nx*ny));
         });
     }
     return fails == 0;

--- a/Tests/Particles/GhostsAndVirtuals/main.cpp
+++ b/Tests/Particles/GhostsAndVirtuals/main.cpp
@@ -93,8 +93,6 @@ void test_ghosts_and_virtuals (TestParams& parms)
     myPC.InitRandom(num_particles, iseed, pdata, serialize);
 
     {
-        const int src_lev = 1;
-        const int dst_lev = 0;
         MyParticleContainer virtPC(geom, dmap, ba, rr);
         MyParticleContainer::ParticleTileType virts;
         myPC.CreateVirtualParticles(1, virts);


### PR DESCRIPTION
## Summary

Found during the Perlmutter CMake testing.

- Alternatively, in MultiBlock tests, am I correct that the `ParallelCopyWithItselfIsCorrect` function doesn't do anything if DEBUG is off? Would it be cleaner to wrap the entire function or the call in `#ifdef DEBUG` to make it a no-op?

- Also found:
`/global/homes/k/kngott/amrex/Src/LinearSolvers/MLMG/AMReX_MLMG.cpp(409): warning #177-D: parameter "xs" was declared but never referenced
          detected during instantiation of "std::string amrex::<unnamed>::make_str(Ts...) [with Ts=<const char *, int>]" 
(428): here`

    Do we have anything to quiet an unused parameter pack?

## Additional background

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
