### PR TITLE
GPU RDC Support

### DIFF
--- a/Docs/sphinx_documentation/source/BuildingAMReX.rst
+++ b/Docs/sphinx_documentation/source/BuildingAMReX.rst
@@ -65,7 +65,7 @@ list of important variables.
    | AMREX_AMD_ARCH  | AMD GPU arch such as gfx908         | none if the        |
    |    or AMD_ARCH  |                                     | machine is unknown |
    +-----------------+-------------------------------------+--------------------+
-   | USE_GPU_RDC     | TRUE or FALSE                       | FALSE              |
+   | USE_GPU_RDC     | TRUE or FALSE                       | TRUE               |
    +-----------------+-------------------------------------+--------------------+
 
 
@@ -448,7 +448,7 @@ The list of available options is reported in the :ref:`table <tab:cmakevar>` bel
    +------------------------------+-------------------------------------------------+-------------------------+-----------------------+
    | AMReX_GPU_BACKEND            |  Build with on-node, accelerated GPU backend    | NONE                    | NONE, SYCL, HIP, CUDA |
    +------------------------------+-------------------------------------------------+-------------------------+-----------------------+
-   | AMReX_GPU_RDC                |  Build with GPU RDC support                     | NO                      | YES, NO               |
+   | AMReX_GPU_RDC                |  Build with GPU RDC support                     | YES                     | YES, NO               |
    +------------------------------+-------------------------------------------------+-------------------------+-----------------------+
    | AMReX_FORTRAN_INTERFACES     |  Build Fortran API                              | NO                      | YES, NO               |
    +------------------------------+-------------------------------------------------+-------------------------+-----------------------+

--- a/Docs/sphinx_documentation/source/BuildingAMReX.rst
+++ b/Docs/sphinx_documentation/source/BuildingAMReX.rst
@@ -65,6 +65,9 @@ list of important variables.
    | AMREX_AMD_ARCH  | AMD GPU arch such as gfx908         | none if the        |
    |    or AMD_ARCH  |                                     | machine is unknown |
    +-----------------+-------------------------------------+--------------------+
+   | USE_GPU_RDC     | TRUE or FALSE                       | FALSE              |
+   +-----------------+-------------------------------------+--------------------+
+
 
 .. raw:: latex
 
@@ -444,6 +447,8 @@ The list of available options is reported in the :ref:`table <tab:cmakevar>` bel
    | AMReX_OMP                    |  Build with OpenMP support                      | NO                      | YES, NO               |
    +------------------------------+-------------------------------------------------+-------------------------+-----------------------+
    | AMReX_GPU_BACKEND            |  Build with on-node, accelerated GPU backend    | NONE                    | NONE, SYCL, HIP, CUDA |
+   +------------------------------+-------------------------------------------------+-------------------------+-----------------------+
+   | AMReX_GPU_RDC                |  Build with GPU RDC support                     | NO                      | YES, NO               |
    +------------------------------+-------------------------------------------------+-------------------------+-----------------------+
    | AMReX_FORTRAN_INTERFACES     |  Build Fortran API                              | NO                      | YES, NO               |
    +------------------------------+-------------------------------------------------+-------------------------+-----------------------+

--- a/Src/Base/AMReX.H
+++ b/Src/Base/AMReX.H
@@ -9,11 +9,7 @@
 #include <AMReX_ccse-mpi.H>
 #include <AMReX_Exception.H>
 #include <AMReX_Extension.H>
-#include <AMReX_INT.H>
-#include <AMReX_REAL.H>
-#include <AMReX_Math.H>
 
-#include <cstdio>
 #include <functional>
 #include <iostream>
 #include <memory>
@@ -101,21 +97,14 @@ namespace amrex
 
     void Error_host (const char* msg);
 
-#if defined(AMREX_USE_GPU)
-    AMREX_GPU_EXTERNAL AMREX_GPU_DEVICE AMREX_NO_INLINE
-    void Error_device (const char * msg);
-#endif
-
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     void Error (const char* msg = 0) {
 #if AMREX_DEVICE_COMPILE
-#if defined(NDEBUG) || defined(AMREX_USE_HIP)
+#if defined(NDEBUG)
         amrex::ignore_unused(msg);
-//#elif defined(AMREX_USE_HIP)
-//        if (msg) { AMREX_DEVICE_PRINTF("%s", msg); }
-//        assert(0);
 #else
-        Error_device(msg);
+        if (msg) AMREX_DEVICE_PRINTF("Error %s\n", msg);
+        AMREX_DEVICE_ASSERT(0);
 #endif
 #else
         Error_host(msg);
@@ -127,20 +116,13 @@ namespace amrex
 
     void Warning_host (const char * msg);
 
-#if defined(AMREX_USE_GPU)
-    AMREX_GPU_EXTERNAL AMREX_GPU_DEVICE AMREX_NO_INLINE
-    void Warning_device (const char * msg);
-#endif
-
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     void Warning (const char * msg) {
 #if AMREX_DEVICE_COMPILE
-#if defined(NDEBUG) || defined(AMREX_USE_HIP)
+#if defined(NDEBUG)
         amrex::ignore_unused(msg);
-//#elif defined(AMREX_USE_HIP)
-//        if (msg) { AMREX_DEVICE_PRINTF("%s", msg); }
 #else
-        Warning_device(msg);
+        if (msg) AMREX_DEVICE_PRINTF("Warning %s\n", msg);
 #endif
 #else
         Warning_host(msg);
@@ -152,21 +134,14 @@ namespace amrex
 
     void Abort_host (const char * msg);
 
-#if defined(AMREX_USE_GPU)
-    AMREX_GPU_EXTERNAL AMREX_GPU_DEVICE AMREX_NO_INLINE
-    void Abort_device (const char * msg);
-#endif
-
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     void Abort (const char * msg = 0) {
 #if AMREX_DEVICE_COMPILE
-#if defined(NDEBUG) || defined(AMREX_USE_HIP)
+#if defined(NDEBUG)
         amrex::ignore_unused(msg);
-//#elif defined(AMREX_USE_HIP)
-//        if (msg) { AMREX_DEVICE_PRINTF("%s", msg); }
-//        assert(0);
 #else
-        Abort_device(msg);
+        if (msg) AMREX_DEVICE_PRINTF("Abort %s\n", msg);
+        AMREX_DEVICE_ASSERT(0);
 #endif
 #else
         Abort_host(msg);
@@ -181,27 +156,20 @@ namespace amrex
 
     void Assert_host (const char* EX, const char* file, int line, const char* msg);
 
-#if defined(AMREX_USE_GPU)
-    AMREX_GPU_EXTERNAL AMREX_GPU_DEVICE AMREX_NO_INLINE
-    void Assert_device (const char* EX, const char* file, int line, const char* msg);
-#endif
-
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     void Assert (const char* EX, const char* file, int line, const char* msg = nullptr) {
 #if AMREX_DEVICE_COMPILE
-#if defined(NDEBUG) || defined(AMREX_USE_HIP)
+#if defined(NDEBUG)
         amrex::ignore_unused(EX,file,line,msg);
-//#elif defined(AMREX_USE_HIP)
-//        if (msg) {
-//            AMREX_DEVICE_PRINTF("Assertion `%s' failed, file \"%s\", line %d, Msg: %s",
-//                                EX, file, line, msg);
-//        } else {
-//            AMREX_DEVICE_PRINTF("Assertion `%s' failed, file \"%s\", line %d",
-//                                EX, file, line);
-//        }
-//        assert(0);
 #else
-        Assert_device(EX,file,line,msg);
+        if (msg) {
+            AMREX_DEVICE_PRINTF("Assertion `%s' failed, file \"%s\", line %d, Msg: %s",
+                                EX, file, line, msg);
+        } else {
+            AMREX_DEVICE_PRINTF("Assertion `%s' failed, file \"%s\", line %d",
+                                EX, file, line);
+        }
+        AMREX_DEVICE_ASSERT(0);
 #endif
 #else
         Assert_host(EX,file,line,msg);

--- a/Src/Base/AMReX.cpp
+++ b/Src/Base/AMReX.cpp
@@ -216,18 +216,6 @@ amrex::Error_host (const char * msg)
     }
 }
 
-#if defined(AMREX_USE_GPU)
-#if AMREX_DEVICE_COMPILE
-AMREX_GPU_DEVICE
-void
-amrex::Error_device (const char * msg)
-{
-    if (msg) AMREX_DEVICE_PRINTF("Error %s\n", msg);
-    AMREX_DEVICE_ASSERT(0);
-}
-#endif
-#endif
-
 void
 amrex::Warning_host (const char * msg)
 {
@@ -235,17 +223,6 @@ amrex::Warning_host (const char * msg)
         amrex::Print(Print::AllProcs,amrex::ErrorStream()) << msg << '!' << '\n';
     }
 }
-
-#if defined(AMREX_USE_GPU)
-#if AMREX_DEVICE_COMPILE
-AMREX_GPU_DEVICE
-void
-amrex::Warning_device (const char * msg)
-{
-    if (msg) AMREX_DEVICE_PRINTF("Warning %s\n", msg);
-}
-#endif
-#endif
 
 void
 amrex::Abort_host (const char * msg)
@@ -263,18 +240,6 @@ amrex::Abort_host (const char * msg)
        ParallelDescriptor::Abort();
    }
 }
-
-#if defined(AMREX_USE_GPU)
-#if AMREX_DEVICE_COMPILE
-AMREX_GPU_DEVICE
-void
-amrex::Abort_device (const char * msg)
-{
-    if (msg) AMREX_DEVICE_PRINTF("Abort %s\n", msg);
-    AMREX_DEVICE_ASSERT(0);
-}
-#endif
-#endif
 
 void
 amrex::Assert_host (const char* EX, const char* file, int line, const char* msg)
@@ -312,24 +277,6 @@ amrex::Assert_host (const char* EX, const char* file, int line, const char* msg)
        ParallelDescriptor::Abort();
    }
 }
-
-#if defined(AMREX_USE_GPU)
-#if AMREX_DEVICE_COMPILE
-AMREX_GPU_DEVICE
-void
-amrex::Assert_device (const char* EX, const char* file, int line, const char* msg)
-{
-    if (msg) {
-        AMREX_DEVICE_PRINTF("Assertion `%s' failed, file \"%s\", line %d, Msg: %s",
-                            EX, file, line, msg);
-    } else {
-        AMREX_DEVICE_PRINTF("Assertion `%s' failed, file \"%s\", line %d",
-                            EX, file, line);
-    }
-    AMREX_DEVICE_ASSERT(0);
-}
-#endif
-#endif
 
 namespace
 {

--- a/Src/Base/AMReX_Arena.H
+++ b/Src/Base/AMReX_Arena.H
@@ -3,6 +3,7 @@
 #include <AMReX_Config.H>
 
 #include <AMReX_BLassert.H>
+#include <AMReX_INT.H>
 #include <cstddef>
 #include <cstdlib>
 #include <limits>

--- a/Src/Base/AMReX_Random.H
+++ b/Src/Base/AMReX_Random.H
@@ -18,11 +18,7 @@ namespace amrex
     *  distribution between 0.0 and 1.0 (0.0 included, 1.0 excluded)
     *
     */
-#ifdef AMREX_USE_CUDA
-    AMREX_GPU_HOST_DEVICE Real Random ();
-#else
     Real Random ();
-#endif
 
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     Real Random (RandomEngine const& random_engine)
@@ -55,11 +51,7 @@ namespace amrex
     *  distribution with mean 'mean' and standard deviation 'stddev'.
     *
     */
-#ifdef AMREX_USE_CUDA
-    AMREX_GPU_HOST_DEVICE Real RandomNormal (Real mean, Real stddev);
-#else
     Real RandomNormal (Real mean, Real stddev);
-#endif
 
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     Real RandomNormal (Real mean, Real stddev, RandomEngine const& random_engine)
@@ -94,11 +86,7 @@ namespace amrex
     *  The GPU version of this function relies on the cuRAND library
     *
     */
-#ifdef AMREX_USE_CUDA
-    AMREX_GPU_HOST_DEVICE unsigned int RandomPoisson (Real lambda);
-#else
     unsigned int RandomPoisson (Real lambda);
-#endif
 
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     unsigned int RandomPoisson (Real lambda, RandomEngine const& random_engine)
@@ -123,11 +111,7 @@ namespace amrex
     * The CPU version of this function uses C++11's mt19937.
     * The GPU version uses CURAND's XORWOW generator.
     */
-#ifdef AMREX_USE_CUDA
-    AMREX_GPU_HOST_DEVICE unsigned int Random_int (unsigned int n); // [0,n-1]
-#else
     unsigned int Random_int (unsigned int n); // [0,n-1]
-#endif
 
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     unsigned int Random_int (unsigned int n, RandomEngine const& random_engine)
@@ -151,12 +135,6 @@ namespace amrex
 #endif
     }
 
-#ifdef AMREX_USE_GPU
-    // Locking mechanism functions for locking and unlocking
-    AMREX_GPU_DEVICE int get_state (int tid);
-    AMREX_GPU_DEVICE void free_state (int tid);
-#endif
-
     /**
     * \brief Generates one pseudorandom unsigned long which is
     *  uniformly distributed on [0,n-1]-interval for each call.
@@ -164,7 +142,7 @@ namespace amrex
     * The CPU version of this function uses C++11's mt19937.
     * There is no GPU version.
     */
-    AMREX_GPU_HOST ULong Random_long (ULong n); // [0,n-1]
+    ULong Random_long (ULong n); // [0,n-1]
 
     /** \brief Set the seed of the random number generator.
     *

--- a/Tools/CMake/AMReXOptions.cmake
+++ b/Tools/CMake/AMReXOptions.cmake
@@ -183,7 +183,13 @@ endif ()
 #
 # GPU RDC support
 #
-cmake_dependent_option( AMReX_GPU_RDC "Enable GPU RDC" OFF
+# https://cmake.org/cmake/help/latest/variable/CMAKE_CUDA_SEPARABLE_COMPILATION.html
+set(_GPU_RDC_default OFF)
+if(AMReX_CUDA AND DEFINED CMAKE_CUDA_SEPARABLE_COMPILATION)
+    set(_GPU_RDC_default "${CMAKE_CUDA_SEPARABLE_COMPILATION}")
+endif()
+cmake_dependent_option( AMReX_GPU_RDC "Enable GPU RDC" ${_GPU_RDC_default} )
+unset(_GPU_RDC_default)
    "AMReX_CUDA OR AMReX_HIP" OFF)
 print_option(AMReX_GPU_RDC)
 

--- a/Tools/CMake/AMReXOptions.cmake
+++ b/Tools/CMake/AMReXOptions.cmake
@@ -180,6 +180,12 @@ if (AMReX_CUDA OR AMReX_HIP)
    print_option(GPUS_PER_NODE)
 endif ()
 
+#
+# GPU RDC support
+#
+cmake_dependent_option( AMReX_GPU_RDC "Enable GPU RDC" OFF
+   "AMReX_CUDA OR AMReX_HIP" OFF)
+print_option(AMReX_GPU_RDC)
 
 #
 # Parallel backends    ========================================================

--- a/Tools/CMake/AMReXOptions.cmake
+++ b/Tools/CMake/AMReXOptions.cmake
@@ -188,9 +188,9 @@ set(_GPU_RDC_default OFF)
 if(AMReX_CUDA AND DEFINED CMAKE_CUDA_SEPARABLE_COMPILATION)
     set(_GPU_RDC_default "${CMAKE_CUDA_SEPARABLE_COMPILATION}")
 endif()
-cmake_dependent_option( AMReX_GPU_RDC "Enable GPU RDC" ${_GPU_RDC_default} )
-unset(_GPU_RDC_default)
+cmake_dependent_option( AMReX_GPU_RDC "Enable GPU RDC" ${_GPU_RDC_default}
    "AMReX_CUDA OR AMReX_HIP" OFF)
+unset(_GPU_RDC_default)
 print_option(AMReX_GPU_RDC)
 
 #

--- a/Tools/CMake/AMReXOptions.cmake
+++ b/Tools/CMake/AMReXOptions.cmake
@@ -184,7 +184,7 @@ endif ()
 # GPU RDC support
 #
 # https://cmake.org/cmake/help/latest/variable/CMAKE_CUDA_SEPARABLE_COMPILATION.html
-set(_GPU_RDC_default OFF)
+set(_GPU_RDC_default ON)
 if(AMReX_CUDA AND DEFINED CMAKE_CUDA_SEPARABLE_COMPILATION)
     set(_GPU_RDC_default "${CMAKE_CUDA_SEPARABLE_COMPILATION}")
 endif()

--- a/Tools/CMake/AMReXTargetHelpers.cmake
+++ b/Tools/CMake/AMReXTargetHelpers.cmake
@@ -114,12 +114,10 @@ endfunction ()
 # is compatible with amrex CUDA build.
 #
 function (setup_target_for_cuda_compilation _target)
-   if (AMReX_GPU_RDC)
-      set_target_properties( ${_target}
-         PROPERTIES
-         CUDA_SEPARABLE_COMPILATION ON      # This adds -dc
-         )
-   endif ()
+   set_target_properties( ${_target}
+      PROPERTIES
+      CUDA_SEPARABLE_COMPILATION ${AMReX_GPU_RDC}      # This adds -dc
+   )
    set_cpp_sources_to_cuda_language(${_target})
 
    if (CMAKE_VERSION VERSION_GREATER_EQUAL 3.20)

--- a/Tools/CMake/AMReXTargetHelpers.cmake
+++ b/Tools/CMake/AMReXTargetHelpers.cmake
@@ -114,12 +114,12 @@ endfunction ()
 # is compatible with amrex CUDA build.
 #
 function (setup_target_for_cuda_compilation _target)
-   # separable compilation:
-   #   mainly due to amrex::Random which uses global device variables
-   set_target_properties( ${_target}
-      PROPERTIES
-      CUDA_SEPARABLE_COMPILATION ON      # This adds -dc
-      )
+   if (AMReX_GPU_RDC)
+      set_target_properties( ${_target}
+         PROPERTIES
+         CUDA_SEPARABLE_COMPILATION ON      # This adds -dc
+         )
+   endif ()
    set_cpp_sources_to_cuda_language(${_target})
 
    if (CMAKE_VERSION VERSION_GREATER_EQUAL 3.20)

--- a/Tools/GNUMake/Make.defs
+++ b/Tools/GNUMake/Make.defs
@@ -370,7 +370,7 @@ endif
 ifdef USE_GPU_RDC
   USE_GPU_RDC := $(strip $(USE_GPU_RDC))
 else
-  USE_GPU_RDC := FALSE
+  USE_GPU_RDC := TRUE
 endif
 
 build_time_begin := $(shell date +"%s")

--- a/Tools/GNUMake/Make.defs
+++ b/Tools/GNUMake/Make.defs
@@ -367,6 +367,12 @@ else
   LOG_BUILD_TIME := FALSE
 endif
 
+ifdef USE_GPU_RDC
+  USE_GPU_RDC := $(strip $(USE_GPU_RDC))
+else
+  USE_GPU_RDC := FALSE
+endif
+
 build_time_begin := $(shell date +"%s")
 
 ALLOW_DIFFERENT_COMP ?= TRUE

--- a/Tools/GNUMake/comps/hip.mak
+++ b/Tools/GNUMake/comps/hip.mak
@@ -30,7 +30,9 @@ F90FLAGS = -ffree-line-length-none -fno-range-check -fno-second-underscore -fimp
 FMODULES =  -J$(fmoddir) -I $(fmoddir)
 
 # rdc support
-HIPCC_FLAGS += -fgpu-rdc
+ifeq ($(USE_GPU_RDC),TRUE)
+  HIPCC_FLAGS += -fgpu-rdc
+endif
 
 # amd gpu target
 HIPCC_FLAGS += --amdgpu-target=$(AMD_ARCH)

--- a/Tools/GNUMake/comps/nvcc.mak
+++ b/Tools/GNUMake/comps/nvcc.mak
@@ -183,8 +183,16 @@ ifeq ($(nvcc_diag_error),1)
   NVCC_FLAGS += --display-error-number --diag-error 20092
 endif
 
-CXXFLAGS = $(CXXFLAGS_FROM_HOST) $(NVCC_FLAGS) -dc -x cu
-CFLAGS   =   $(CFLAGS_FROM_HOST) $(NVCC_FLAGS) -dc -x cu
+CXXFLAGS = $(CXXFLAGS_FROM_HOST) $(NVCC_FLAGS) -x cu
+CFLAGS   =   $(CFLAGS_FROM_HOST) $(NVCC_FLAGS) -x cu
+
+ifeq ($(USE_GPU_RDC),TRUE)
+  CXXFLAGS += -dc
+  CFLAGS   += -dc
+else
+  CXXFLAGS += -c
+  CFLAGS   += -c
+endif
 
 ifeq ($(nvcc_version),9.2)
   # relaxed constexpr not supported

--- a/Tools/Plotfile/AMReX_PPMUtil.cpp
+++ b/Tools/Plotfile/AMReX_PPMUtil.cpp
@@ -1,5 +1,6 @@
 
 #include <AMReX_PPMUtil.H>
+#include <AMReX_INT.H>
 #include <cstdio>
 #include <cstdlib>
 


### PR DESCRIPTION
Make GPU RDC configurable, but still on by default.  The user can disable it by `USE_GPU_RDC=FALSE` in
gnu make and `-DAMReX_GPU_RDC=OFF` in cmake.

Remove CUDA specific random number functions that rely on rdc.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
