### PR TITLE
CMake: HIP Compiler - don't fail

### DIFF
--- a/Tools/CMake/AMReXParallelBackends.cmake
+++ b/Tools/CMake/AMReXParallelBackends.cmake
@@ -171,12 +171,13 @@ endif ()
 #
 if (AMReX_HIP)
 
-   set(_valid_hip_compilers hipcc nvcc)
+   set(_valid_hip_compilers hipcc nvcc)  # later: CC, clang++
    get_filename_component(_this_comp ${CMAKE_CXX_COMPILER} NAME)
 
    if (NOT (_this_comp IN_LIST _valid_hip_compilers) )
-      message(FATAL_ERROR "\nCMAKE_CXX_COMPILER=${_this_comp} is incompatible with HIP.\n"
-         "Set CMAKE_CXX_COMPILER to either hipcc or nvcc for HIP builds.\n")
+      message(WARNING "\nCMAKE_CXX_COMPILER=${_this_comp} is potentially "
+         "not a valid HIP device compiler.\n"
+         "For now, set CMAKE_CXX_COMPILER to hipcc for HIP builds.\n")
    endif ()
 
    unset(_hip_compiler)


### PR DESCRIPTION
## Summary

Potentially, users might use `CC` (Cray Prg Envs) and later `clang++` (underlying compiler #2031) ) as compilers. Only warn if not met.

ROCm/Cray environments are currently being developed and we want to keep things flexible for codes trying to use the compiler wrapper instead of `hpcc`.

cc @mwm126 @jmsexton03 

## Additional background

That said, the working mode to build for now is to build on Cray with AMD's `clang`/`hipcc` and pass MPI flags manually.
See e.g.: https://warpx.readthedocs.io/en/latest/install/hpc/spock.html

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
