### PR TITLE
Particle plotfile/checkpoint without managed memory.

### DIFF
--- a/Src/Particle/AMReX_NeighborList.H
+++ b/Src/Particle/AMReX_NeighborList.H
@@ -68,7 +68,7 @@ struct Neighbors
         void operator++ () { ++m_index;; }
 
         AMREX_GPU_HOST_DEVICE
-        bool operator!= (const_iterator const& rhs) const { return m_index < m_stop; }
+        bool operator!= (const_iterator const& /*rhs*/) const { return m_index < m_stop; }
 
         AMREX_GPU_HOST_DEVICE
         const ParticleType& operator* () const { return m_pstruct[m_nbor_list_ptr[m_index]];  }

--- a/Src/Particle/AMReX_ParticleIO.H
+++ b/Src/Particle/AMReX_ParticleIO.H
@@ -572,7 +572,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>
                   Vector<int>& which, Vector<int>& count, Vector<Long>& where,
                   const Vector<int>& write_real_comp,
                   const Vector<int>& write_int_comp,
-                  const Vector<std::map<std::pair<int, int>, Gpu::DeviceVector<int>>>& particle_io_flags) const
+                  const Vector<std::map<std::pair<int, int>, IntVector>>& particle_io_flags) const
 {
     BL_PROFILE("ParticleContainer::WriteParticles()");
 
@@ -588,11 +588,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>
 
         // Only write out valid particles.
         int cnt = 0;
-        for (int k = 0; k < kv.second.GetArrayOfStructs().numParticles(); ++k)
-        {
-            if (pflags[k]) cnt++;
-        }
-
+        particle_detail::countFlags(pflags, cnt);
         count[grid] += cnt;
     }
 
@@ -609,98 +605,14 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>
 
         if (count[grid] == 0) continue;
 
-        // First write out the integer data in binary.
-        int num_output_int = 0;
-        for (int i = 0; i < NumIntComps() + NStructInt; ++i)
-            if (write_int_comp[i]) ++num_output_int;
-
-        const int iChunkSize = 2 + num_output_int;
-        Vector<int> istuff(count[grid]*iChunkSize);
-        int* iptr = istuff.dataPtr();
-
-        for (unsigned i = 0; i < tile_map[grid].size(); i++) {
-            auto ptile_index = std::make_pair(grid, tile_map[grid][i]);
-            const auto& pbox = m_particles[lev].at(ptile_index);
-            const auto& pflags = particle_io_flags[lev].at(ptile_index);
-            for (int pindex = 0; pindex < pbox.GetArrayOfStructs().numParticles(); ++pindex) {
-                const auto& aos = pbox.GetArrayOfStructs();
-                const auto& p = aos[pindex];
-                if (pflags[pindex])
-                {
-                    // always write these
-                    *iptr = p.id(); ++iptr;
-                    *iptr = p.cpu(); ++iptr;
-
-                    // optionally write these
-                    for (int j = 0; j < NStructInt; j++)
-                    {
-                        if (write_int_comp[j])
-                        {
-                            *iptr = p.idata(j);
-                            ++iptr;
-                        }
-                    }
-
-                    const auto& soa  = pbox.GetStructOfArrays();
-                    for (int j = 0; j < NumIntComps(); j++)
-                    {
-                        if (write_int_comp[NStructInt+j])
-                        {
-                            *iptr = soa.GetIntData(j)[pindex];
-                            ++iptr;
-                        }
-                    }
-                }
-            }
-        }
+        Vector<int> istuff;
+        Vector<ParticleReal> rstuff;
+        particle_detail::packIOData(istuff, rstuff, *this, lev, grid,
+                                    write_real_comp, write_int_comp,
+                                    particle_io_flags, tile_map[grid], count[grid]);
 
         writeIntData(istuff.dataPtr(), istuff.size(), ofs);
         ofs.flush();  // Some systems require this flush() (probably due to a bug)
-
-        // Write the Real data in binary.
-        int num_output_real = 0;
-        for (int i = 0; i < NumRealComps() + NStructReal; ++i)
-            if (write_real_comp[i]) ++num_output_real;
-
-        const int rChunkSize = AMREX_SPACEDIM + num_output_real;
-        Vector<typename ParticleType::RealType> rstuff(count[grid]*rChunkSize);
-        typename ParticleType::RealType* rptr = rstuff.dataPtr();
-
-        for (unsigned i = 0; i < tile_map[grid].size(); i++) {
-                        auto ptile_index = std::make_pair(grid, tile_map[grid][i]);
-            const auto& pbox = m_particles[lev].at(ptile_index);
-                        const auto& pflags = particle_io_flags[lev].at(ptile_index);
-            for (int pindex = 0; pindex < pbox.GetArrayOfStructs().numParticles(); ++pindex) {
-                const auto& aos = pbox.GetArrayOfStructs();
-                const auto& p = aos[pindex];
-                if (pflags[pindex])
-                {
-                    // always write these
-                    for (int j = 0; j < AMREX_SPACEDIM; j++) rptr[j] = p.pos(j);
-                    rptr += AMREX_SPACEDIM;
-
-                    // optionally write these
-                    for (int j = 0; j < NStructReal; j++)
-                    {
-                        if (write_real_comp[j])
-                        {
-                            *rptr = p.rdata(j);
-                            ++rptr;
-                        }
-                    }
-
-                    const auto& soa  = pbox.GetStructOfArrays();
-                    for (int j = 0; j < NumRealComps(); j++)
-                    {
-                        if (write_real_comp[NStructReal+j])
-                        {
-                            *rptr = (typename ParticleType::RealType) soa.GetRealData(j)[pindex];
-                            ++rptr;
-                        }
-                    }
-                }
-            }
-        }
 
         WriteParticleRealData(rstuff.dataPtr(), rstuff.size(), ofs);
         ofs.flush();  // Some systems require this flush() (probably due to a bug)

--- a/Src/Particle/AMReX_ParticleIO.H
+++ b/Src/Particle/AMReX_ParticleIO.H
@@ -587,9 +587,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>
         const auto& pflags = particle_io_flags[lev].at(kv.first);
 
         // Only write out valid particles.
-        int cnt = 0;
-        particle_detail::countFlags(pflags, cnt);
-        count[grid] += cnt;
+        count[grid] += particle_detail::countFlags(pflags);
     }
 
     MFInfo info;

--- a/Src/Particle/AMReX_ParticleTile.H
+++ b/Src/Particle/AMReX_ParticleTile.H
@@ -237,6 +237,9 @@ template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt,
           template<class> class Allocator=DefaultAllocator>
 struct ParticleTile
 {
+    template <typename T>
+    using AllocatorType = Allocator<T>;
+
     using ParticleType = Particle<NStructReal, NStructInt>;
     static constexpr int NAR = NArrayReal;
     static constexpr int NAI = NArrayInt;

--- a/Src/Particle/AMReX_Particles.H
+++ b/Src/Particle/AMReX_Particles.H
@@ -154,6 +154,9 @@ private:
     friend class ParIterBase<false,NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>;
 
 public:
+    //! \brief The memory allocator in use.
+    template <typename T>
+    using AllocatorType = Allocator<T>;
     //! \brief The type of Particles we hold.
     using ParticleType = Particle<NStructReal, NStructInt>;
     //! \brief The type of the "SuperParticle" which stored all components in AoS form
@@ -1151,7 +1154,7 @@ public:
     WriteParticles (int level, std::ofstream& ofs, int fnum,
                     Vector<int>& which, Vector<int>& count, Vector<Long>& where,
                     const Vector<int>& write_real_comp, const Vector<int>& write_int_comp,
-                    const Vector<std::map<std::pair<int, int>, Gpu::DeviceVector<int>>>& particle_io_flags) const;
+                    const Vector<std::map<std::pair<int, int>,IntVector>>& particle_io_flags) const;
 protected:
 
 #ifdef AMREX_USE_HDF5

--- a/Src/Particle/AMReX_WriteBinaryParticleData.H
+++ b/Src/Particle/AMReX_WriteBinaryParticleData.H
@@ -137,7 +137,7 @@ countFlags (const Container<int,Allocator>& pflags, amrex::Long& nparticles)
 }
 
 template <class PC>
-typename std::enable_if<RunOnGpu<typename PC::AllocatorType<int>>::value>::type
+typename std::enable_if<RunOnGpu<typename PC::template AllocatorType<int>>::value>::type
 packIOData (Vector<int>& idata, Vector<ParticleReal>& rdata, const PC& pc, int lev, int grid,
             const Vector<int>& write_real_comp, const Vector<int>& write_int_comp,
             const Vector<std::map<std::pair<int, int>, typename PC::IntVector>>& particle_io_flags,
@@ -231,7 +231,7 @@ packIOData (Vector<int>& idata, Vector<ParticleReal>& rdata, const PC& pc, int l
 }
 
 template <class PC>
-typename std::enable_if<!RunOnGpu<typename PC::AllocatorType<int>>::value>::type
+typename std::enable_if<!RunOnGpu<typename PC::template AllocatorType<int>>::value>::type
 packIOData (Vector<int>& idata, Vector<ParticleReal>& rdata, const PC& pc, int lev, int grid,
             const Vector<int>& write_real_comp, const Vector<int>& write_int_comp,
             const Vector<std::map<std::pair<int, int>, typename PC::IntVector>>& particle_io_flags,

--- a/Src/Particle/AMReX_WriteBinaryParticleData.H
+++ b/Src/Particle/AMReX_WriteBinaryParticleData.H
@@ -5,6 +5,7 @@
 #include <AMReX_TypeTraits.H>
 #include <AMReX_Particles.H>
 #include <AMReX_ParticleUtil.H>
+#include <AMReX_GpuDevice.H>
 
 struct KeepValidFilter
 {

--- a/Src/Particle/AMReX_WriteBinaryParticleData.H
+++ b/Src/Particle/AMReX_WriteBinaryParticleData.H
@@ -64,9 +64,8 @@ fillFlags (Container<int, Allocator>& pflags, const PTile& ptile, F&& f)
 }
 
 template <template <class, class> class Container, class Allocator, class PC>
-typename std::enable_if<RunOnGpu<typename Container<int, Allocator>::allocator_type>::value>::type
-countFlags (const Vector<std::map<std::pair<int,int>,Container<int,Allocator>>>& particle_io_flags,
-            const PC& pc, amrex::Long& nparticles)
+typename std::enable_if<RunOnGpu<typename Container<int, Allocator>::allocator_type>::value, amrex::Long>::type
+countFlags (const Vector<std::map<std::pair<int,int>,Container<int,Allocator>>>& particle_io_flags, const PC& pc)
 {
     ReduceOps<ReduceOpSum> reduce_op;
     ReduceData<Long> reduce_data(reduce_op);
@@ -87,12 +86,12 @@ countFlags (const Vector<std::map<std::pair<int,int>,Container<int,Allocator>>>&
         }
     }
     ReduceTuple hv = reduce_data.value(reduce_op);
-    nparticles += amrex::get<0>(hv);
+    return amrex::get<0>(hv);
 }
 
 template <template <class, class> class Container, class Allocator>
-typename std::enable_if<RunOnGpu<typename Container<int, Allocator>::allocator_type>::value>::type
-countFlags (const Container<int,Allocator>& pflags, int& nparticles)
+typename std::enable_if<RunOnGpu<typename Container<int, Allocator>::allocator_type>::value, int>::type
+countFlags (const Container<int,Allocator>& pflags)
 {
     ReduceOps<ReduceOpSum> reduce_op;
     ReduceData<Long> reduce_data(reduce_op);
@@ -105,14 +104,14 @@ countFlags (const Container<int,Allocator>& pflags, int& nparticles)
             return flag_ptr[i] ? 1 : 0;
         });
     ReduceTuple hv = reduce_data.value(reduce_op);
-    nparticles += amrex::get<0>(hv);
+    return amrex::get<0>(hv);
 }
 
 template <template <class, class> class Container, class Allocator, class PC>
-typename std::enable_if<!RunOnGpu<typename Container<int, Allocator>::allocator_type>::value>::type
-countFlags (const Vector<std::map<std::pair<int,int>,Container<int,Allocator>>>& particle_io_flags,
-            const PC& pc, amrex::Long& nparticles)
+typename std::enable_if<!RunOnGpu<typename Container<int, Allocator>::allocator_type>::value, amrex::Long>::type
+countFlags (const Vector<std::map<std::pair<int,int>,Container<int,Allocator>>>& particle_io_flags, const PC& pc)
 {
+    amrex::Long nparticles = 0;
     for (int lev = 0; lev < pc.GetParticles().size();  lev++)
     {
         const auto& pmap = pc.GetParticles(lev);
@@ -125,16 +124,19 @@ countFlags (const Vector<std::map<std::pair<int,int>,Container<int,Allocator>>>&
             }
         }
     }
+    return nparticles;
 }
 
 template <template <class, class> class Container, class Allocator>
-typename std::enable_if<!RunOnGpu<typename Container<int, Allocator>::allocator_type>::value>::type
-countFlags (const Container<int,Allocator>& pflags, int& nparticles)
+typename std::enable_if<!RunOnGpu<typename Container<int, Allocator>::allocator_type>::value, int>::type
+countFlags (const Container<int,Allocator>& pflags)
 {
+    int nparticles = 0;
     for (std::size_t k = 0; k < pflags.size(); ++k)
     {
         if (pflags[k]) nparticles++;
     }
+    return nparticles;
 }
 
 template <class PC>
@@ -358,11 +360,8 @@ void WriteBinaryParticleDataSync (PC const& pc,
     }
     else
     {
-        nparticles = 0;
+        nparticles = particle_detail::countFlags(particle_io_flags, pc);
         maxnextid  = PC::ParticleType::NextID();
-
-        particle_detail::countFlags(particle_io_flags, pc, nparticles);
-
         ParallelDescriptor::ReduceLongSum(nparticles, IOProcNumber);
         PC::ParticleType::NextID(maxnextid);
         ParallelDescriptor::ReduceLongMax(maxnextid, IOProcNumber);

--- a/Src/Particle/AMReX_WriteBinaryParticleData.H
+++ b/Src/Particle/AMReX_WriteBinaryParticleData.H
@@ -16,12 +16,287 @@ struct KeepValidFilter
     }
 };
 
+namespace particle_detail {
+
 template <typename ParticleReal>
 std::size_t PSizeInFile (const Vector<int>& wrc, const Vector<int>& wic)
 {
     std::size_t rsize = sizeof(ParticleReal)*std::accumulate(wrc.begin(), wrc.end(), 0);
     std::size_t isize = sizeof(int)*std::accumulate(wic.begin(), wic.end(), 0);
     return rsize + isize + AMREX_SPACEDIM*sizeof(ParticleReal) + 2*sizeof(int);
+}
+
+template <template <class, class> class Container,
+          class Allocator,
+          class PTile,
+          class F>
+typename std::enable_if<RunOnGpu<typename Container<int, Allocator>::allocator_type>::value>::type
+fillFlags (Container<int, Allocator>& pflags, const PTile& ptile, F&& f)
+{
+    const auto ptd = ptile.getConstParticleTileData();
+    const auto np = ptile.numParticles();
+    pflags.resize(np, 0);
+    auto flag_ptr = pflags.data();
+    amrex::ParallelForRNG(np,
+        [=] AMREX_GPU_DEVICE (int k, amrex::RandomEngine const& engine) noexcept
+        {
+            const auto p = ptd.getSuperParticle(k);
+            flag_ptr[k] = particle_detail::call_f(f,p,engine);
+        });
+}
+
+template <template <class, class> class Container,
+          class Allocator,
+          class PTile,
+          class F>
+typename std::enable_if<!RunOnGpu<typename Container<int, Allocator>::allocator_type>::value>::type
+fillFlags (Container<int, Allocator>& pflags, const PTile& ptile, F&& f)
+{
+    const auto ptd = ptile.getConstParticleTileData();
+    const auto np = ptile.numParticles();
+    pflags.resize(np, 0);
+    auto flag_ptr = pflags.data();
+    for (int k = 0; k < np; ++k) {
+        const auto p = ptd.getSuperParticle(k);
+        flag_ptr[k] = particle_detail::call_f(f,p,RandomEngine{});
+    }
+}
+
+template <template <class, class> class Container, class Allocator, class PC>
+typename std::enable_if<RunOnGpu<typename Container<int, Allocator>::allocator_type>::value>::type
+countFlags (const Vector<std::map<std::pair<int,int>,Container<int,Allocator>>>& particle_io_flags,
+            const PC& pc, amrex::Long& nparticles)
+{
+    ReduceOps<ReduceOpSum> reduce_op;
+    ReduceData<Long> reduce_data(reduce_op);
+    using ReduceTuple = typename decltype(reduce_data)::Type;
+
+    for (int lev = 0; lev < pc.GetParticles().size();  lev++)
+    {
+        const auto& pmap = pc.GetParticles(lev);
+        for (const auto& kv : pmap)
+        {
+            const auto& pflags = particle_io_flags[lev].at(kv.first);
+            const auto flag_ptr = pflags.data();
+            reduce_op.eval(pflags.size(), reduce_data,
+                [=] AMREX_GPU_DEVICE (const int i) -> ReduceTuple
+                {
+                    return flag_ptr[i] ? 1 : 0;
+                });
+        }
+    }
+    ReduceTuple hv = reduce_data.value(reduce_op);
+    nparticles += amrex::get<0>(hv);
+}
+
+template <template <class, class> class Container, class Allocator>
+typename std::enable_if<RunOnGpu<typename Container<int, Allocator>::allocator_type>::value>::type
+countFlags (const Container<int,Allocator>& pflags, int& nparticles)
+{
+    ReduceOps<ReduceOpSum> reduce_op;
+    ReduceData<Long> reduce_data(reduce_op);
+    using ReduceTuple = typename decltype(reduce_data)::Type;
+
+    const auto flag_ptr = pflags.data();
+    reduce_op.eval(pflags.size(), reduce_data,
+        [=] AMREX_GPU_DEVICE (const int i) -> ReduceTuple
+        {
+            return flag_ptr[i] ? 1 : 0;
+        });
+    ReduceTuple hv = reduce_data.value(reduce_op);
+    nparticles += amrex::get<0>(hv);
+}
+
+template <template <class, class> class Container, class Allocator, class PC>
+typename std::enable_if<!RunOnGpu<typename Container<int, Allocator>::allocator_type>::value>::type
+countFlags (const Vector<std::map<std::pair<int,int>,Container<int,Allocator>>>& particle_io_flags,
+            const PC& pc, int& nparticles)
+{
+    for (int lev = 0; lev < pc.GetParticles().size();  lev++)
+    {
+        const auto& pmap = pc.GetParticles(lev);
+        for (const auto& kv : pmap)
+        {
+            const auto& pflags = particle_io_flags[lev].at(kv.first);
+            for (int k = 0; k < kv.second.numParticles(); ++k)
+            {
+                if (pflags[k]) nparticles++;
+            }
+        }
+    }
+}
+
+template <template <class, class> class Container, class Allocator>
+typename std::enable_if<!RunOnGpu<typename Container<int, Allocator>::allocator_type>::value>::type
+countFlags (const Container<int,Allocator>& pflags, amrex::Long& nparticles)
+{
+    for (std::size_t k = 0; k < pflags.size(); ++k)
+    {
+        if (pflags[k]) nparticles++;
+    }
+}
+
+template <class PC>
+typename std::enable_if<RunOnGpu<typename PC::AllocatorType<int>>::value>::type
+packIOData (Vector<int>& idata, Vector<ParticleReal>& rdata, const PC& pc, int lev, int grid,
+            const Vector<int>& write_real_comp, const Vector<int>& write_int_comp,
+            const Vector<std::map<std::pair<int, int>, typename PC::IntVector>>& particle_io_flags,
+            const Vector<int>& tiles, int np)
+{
+    int num_output_int = 0;
+    for (int i = 0; i < pc.NumIntComps() + PC::NStructInt; ++i)
+        if (write_int_comp[i]) ++num_output_int;
+
+    const int iChunkSize = 2 + num_output_int;
+    idata.resize(np*iChunkSize);
+
+    int num_output_real = 0;
+    for (int i = 0; i < pc.NumRealComps() + PC::NStructReal; ++i)
+        if (write_real_comp[i]) ++num_output_real;
+
+    const int rChunkSize = AMREX_SPACEDIM + num_output_real;
+    rdata.resize(np*rChunkSize);
+
+    typename PC::IntVector  idata_d(idata.size());
+    typename PC::RealVector rdata_d(rdata.size());
+
+    typename PC::IntVector write_int_comp_d(write_int_comp.size());
+    typename PC::IntVector write_real_comp_d(write_real_comp.size());
+    Gpu::copy(Gpu::hostToDevice, write_int_comp.begin(), write_int_comp.end(),
+              write_int_comp_d.begin());
+    Gpu::copy(Gpu::hostToDevice, write_real_comp.begin(), write_real_comp.end(),
+              write_real_comp_d.begin());
+    Gpu::Device::synchronize();
+
+    const auto write_int_comp_d_ptr = write_int_comp_d.data();
+    const auto write_real_comp_d_ptr = write_real_comp_d.data();
+
+    std::size_t poffset = 0;
+    for (std::size_t i = 0; i < tiles.size(); i++) {
+        const auto& ptile = pc.ParticlesAt(lev, grid, tiles[i]);
+        const auto& pflags = particle_io_flags[lev].at(std::make_pair(grid, tiles[i]));
+
+        int np_tile = ptile.GetArrayOfStructs().numParticles();
+        typename PC::IntVector offsets(np_tile);
+        Gpu::exclusive_scan(pflags.begin(), pflags.end(), offsets.begin());
+
+        int num_copies;
+        {
+            int last_flag;
+            Gpu::dtoh_memcpy(&num_copies, offsets.dataPtr()+np_tile-1, sizeof(int));
+            Gpu::dtoh_memcpy(&last_flag, pflags.dataPtr()+np_tile-1, sizeof(int));
+            num_copies += last_flag;
+        }
+
+        const auto flag_ptr = pflags.data();
+        const auto offsets_ptr = offsets.data();
+
+        auto idata_d_ptr = idata_d.data();
+        auto rdata_d_ptr = rdata_d.data();
+
+        const auto ptd = ptile.getConstParticleTileData();
+        amrex::ParallelFor(num_copies,
+        [=] AMREX_GPU_DEVICE (int pindex) noexcept
+        {
+            // might be worth using shared memory here
+            const auto p = ptd.getSuperParticle(pindex);
+
+            if (flag_ptr[pindex]) {
+                std::size_t out_index = (pindex+poffset)*iChunkSize;
+                idata_d_ptr[out_index] = p.id();
+                idata_d_ptr[out_index+1] = p.cpu();
+
+                for (int j = 0; j < AMREX_SPACEDIM; j++) rdata_d_ptr[out_index+j] = p.pos(j);
+
+                for (int j = 0; j < PC::SuperParticleType::NInt; j++) {
+                    if (write_int_comp_d_ptr[j]) {
+                        idata_d_ptr[out_index+2+j] = p.idata(j);
+                    }
+                }
+
+                for (int j = 0; j < PC::SuperParticleType::NReal; j++) {
+                    if (write_real_comp_d_ptr[j]) {
+                        rdata_d_ptr[out_index+AMREX_SPACEDIM+j] = p.rdata(j);
+                    }
+                }
+            }
+        });
+
+        poffset += num_copies;
+    }
+
+    Gpu::copy(Gpu::deviceToHost, idata_d.begin(), idata_d.end(), idata.begin());
+    Gpu::copy(Gpu::deviceToHost, rdata_d.begin(), rdata_d.end(), rdata.begin());
+    Gpu::Device::synchronize();
+}
+
+template <class PC>
+typename std::enable_if<!RunOnGpu<typename PC::AllocatorType<int>>::value>::type
+packIOData (Vector<int>& idata, Vector<ParticleReal>& rdata, const PC& pc, int lev, int grid,
+            const Vector<int>& write_real_comp, const Vector<int>& write_int_comp,
+            const Vector<std::map<std::pair<int, int>, typename PC::IntVector>>& particle_io_flags,
+            const Vector<int>& tiles, int np)
+{
+    int num_output_int = 0;
+    for (int i = 0; i < pc.NumIntComps() + PC::NStructInt; ++i)
+        if (write_int_comp[i]) ++num_output_int;
+
+    const int iChunkSize = 2 + num_output_int;
+    idata.resize(np*iChunkSize);
+
+    int num_output_real = 0;
+    for (int i = 0; i < pc.NumRealComps() + PC::NStructReal; ++i)
+        if (write_real_comp[i]) ++num_output_real;
+
+    const int rChunkSize = AMREX_SPACEDIM + num_output_real;
+    rdata.resize(np*rChunkSize);
+
+    int* iptr = idata.dataPtr();
+    ParticleReal* rptr = rdata.dataPtr();
+    for (unsigned i = 0; i < tiles.size(); i++) {
+        const auto& ptile = pc.ParticlesAt(lev, grid, tiles[i]);
+        const auto& pflags = particle_io_flags[lev].at(std::make_pair(grid, tiles[i]));
+        for (int pindex = 0; pindex < ptile.GetArrayOfStructs().numParticles(); ++pindex) {
+            const auto& aos = ptile.GetArrayOfStructs();
+            const auto& p = aos[pindex];
+            if (pflags[pindex]) {
+                *iptr = p.id(); ++iptr;
+                *iptr = p.cpu(); ++iptr;
+                for (int j = 0; j < AMREX_SPACEDIM; j++) rptr[j] = p.pos(j);
+                rptr += AMREX_SPACEDIM;
+
+                for (int j = 0; j < PC::NStructInt; j++) {
+                    if (write_int_comp[j]) {
+                        *iptr = p.idata(j);
+                        ++iptr;
+                    }
+                }
+
+                const auto& soa  = ptile.GetStructOfArrays();
+                for (int j = 0; j < pc.NumIntComps(); j++) {
+                    if (write_int_comp[PC::NStructInt+j]) {
+                        *iptr = soa.GetIntData(j)[pindex];
+                        ++iptr;
+                    }
+                }
+
+                for (int j = 0; j < PC::NStructReal; j++) {
+                    if (write_real_comp[j]) {
+                        *rptr = p.rdata(j);
+                        ++rptr;
+                    }
+                }
+
+                for (int j = 0; j < pc.NumRealComps(); j++) {
+                    if (write_real_comp[PC::NStructReal+j]) {
+                        *rptr = (ParticleReal) soa.GetRealData(j)[pindex];
+                        ++rptr;
+                    }
+                }
+            }
+        }
+    }
+}
 }
 
 template <class PC, class F, std::enable_if_t<IsParticleContainer<PC>::value, int> foo = 0>
@@ -69,22 +344,15 @@ void WriteBinaryParticleDataSync (PC const& pc,
     Long maxnextid;
 
     // evaluate f for every particle to determine which ones to output
-    Vector<std::map<std::pair<int, int>, Gpu::DeviceVector<int> > > particle_io_flags(pc.GetParticles().size());
+    Vector<std::map<std::pair<int, int>, typename PC::IntVector > >
+        particle_io_flags(pc.GetParticles().size());
     for (int lev = 0; lev < pc.GetParticles().size();  lev++)
     {
         const auto& pmap = pc.GetParticles(lev);
         for (const auto& kv : pmap)
         {
-            const auto ptd = kv.second.getConstParticleTileData();
-            const auto np = kv.second.numParticles();
-            particle_io_flags[lev][kv.first].resize(np, 0);
-            auto pflags = particle_io_flags[lev][kv.first].data();
-            amrex::ParallelForRNG(np,
-            [=] AMREX_GPU_DEVICE (int k, amrex::RandomEngine const& engine) noexcept
-            {
-                const auto p = ptd.getSuperParticle(k);
-                pflags[k] = particle_detail::call_f(f,p,engine);
-            });
+            Gpu::DeviceVector<int>& flags = particle_io_flags[lev][kv.first];
+            particle_detail::fillFlags(flags, kv.second, std::forward<F>(f));
         }
     }
 
@@ -100,18 +368,7 @@ void WriteBinaryParticleDataSync (PC const& pc,
         nparticles = 0;
         maxnextid  = PC::ParticleType::NextID();
 
-        for (int lev = 0; lev < pc.GetParticles().size();  lev++)
-        {
-            const auto& pmap = pc.GetParticles(lev);
-            for (const auto& kv : pmap)
-            {
-                const auto& pflags = particle_io_flags[lev][kv.first];
-                for (int k = 0; k < kv.second.numParticles(); ++k)
-                {
-                    if (pflags[k]) nparticles++;
-                }
-            }
-        }
+        particle_detail::countFlags(particle_io_flags, pc, nparticles);
 
         ParallelDescriptor::ReduceLongSum(nparticles, IOProcNumber);
         PC::ParticleType::NextID(maxnextid);
@@ -444,7 +701,7 @@ void WriteBinaryParticleDataAsync (PC const& pc,
     ParallelDescriptor::ReduceLongMax(maxnextid, IOProcNumber);
 
     Vector<Long> np_on_rank(NProcs, 0L);
-    std::size_t psize = PSizeInFile<ParticleReal>(write_real_comp, write_int_comp);
+    std::size_t psize = particle_detail::PSizeInFile<ParticleReal>(write_real_comp, write_int_comp);
     Vector<int64_t> rank_start_offset(NProcs);
     if (MyProc == IOProcNumber)
     {

--- a/Src/Particle/AMReX_WriteBinaryParticleData.H
+++ b/Src/Particle/AMReX_WriteBinaryParticleData.H
@@ -178,20 +178,7 @@ packIOData (Vector<int>& idata, Vector<ParticleReal>& rdata, const PC& pc, int l
         const auto& pflags = particle_io_flags[lev].at(std::make_pair(grid, tiles[i]));
         int np_tile = ptile.GetArrayOfStructs().numParticles();
         typename PC::IntVector offsets(np_tile);
-        Gpu::exclusive_scan(pflags.begin(), pflags.end(), offsets.begin());
-
-        int num_copies;
-        {
-            int last_flag;
-#ifdef AMREX_USE_GPU
-            Gpu::dtoh_memcpy(&num_copies, offsets.dataPtr()+np_tile-1, sizeof(int));
-            Gpu::dtoh_memcpy(&last_flag, pflags.dataPtr()+np_tile-1, sizeof(int));
-#else
-            std::memcpy(&num_copies, offsets.dataPtr()+np_tile-1, sizeof(int));
-            std::memcpy(&last_flag, pflags.dataPtr()+np_tile-1, sizeof(int));
-#endif
-            num_copies += last_flag;
-        }
+        int num_copies = Scan::ExclusiveSum(np_tile, pflags.begin(), offsets.begin(), Scan::retSum);
 
         const auto flag_ptr = pflags.data();
         const auto offsets_ptr = offsets.data();

--- a/Src/Particle/AMReX_WriteBinaryParticleData.H
+++ b/Src/Particle/AMReX_WriteBinaryParticleData.H
@@ -176,7 +176,6 @@ packIOData (Vector<int>& idata, Vector<ParticleReal>& rdata, const PC& pc, int l
     for (std::size_t i = 0; i < tiles.size(); i++) {
         const auto& ptile = pc.ParticlesAt(lev, grid, tiles[i]);
         const auto& pflags = particle_io_flags[lev].at(std::make_pair(grid, tiles[i]));
-
         int np_tile = ptile.GetArrayOfStructs().numParticles();
         typename PC::IntVector offsets(np_tile);
         Gpu::exclusive_scan(pflags.begin(), pflags.end(), offsets.begin());
@@ -208,21 +207,22 @@ packIOData (Vector<int>& idata, Vector<ParticleReal>& rdata, const PC& pc, int l
             const auto p = ptd.getSuperParticle(pindex);
 
             if (flag_ptr[pindex]) {
-                std::size_t out_index = (pindex+poffset)*iChunkSize;
-                idata_d_ptr[out_index] = p.id();
-                idata_d_ptr[out_index+1] = p.cpu();
+                std::size_t iout_index = (pindex+poffset)*iChunkSize;
+                idata_d_ptr[iout_index] = p.id();
+                idata_d_ptr[iout_index+1] = p.cpu();
 
-                for (int j = 0; j < AMREX_SPACEDIM; j++) rdata_d_ptr[out_index+j] = p.pos(j);
+                std::size_t rout_index = (pindex+poffset)*rChunkSize;
+                for (int j = 0; j < AMREX_SPACEDIM; j++) rdata_d_ptr[rout_index+j] = p.pos(j);
 
                 for (int j = 0; j < PC::SuperParticleType::NInt; j++) {
                     if (write_int_comp_d_ptr[j]) {
-                        idata_d_ptr[out_index+2+j] = p.idata(j);
+                        idata_d_ptr[iout_index+2+j] = p.idata(j);
                     }
                 }
 
                 for (int j = 0; j < PC::SuperParticleType::NReal; j++) {
                     if (write_real_comp_d_ptr[j]) {
-                        rdata_d_ptr[out_index+AMREX_SPACEDIM+j] = p.rdata(j);
+                        rdata_d_ptr[rout_index+AMREX_SPACEDIM+j] = p.rdata(j);
                     }
                 }
             }

--- a/Src/Particle/AMReX_WriteBinaryParticleData.H
+++ b/Src/Particle/AMReX_WriteBinaryParticleData.H
@@ -173,7 +173,7 @@ packIOData (Vector<int>& idata, Vector<ParticleReal>& rdata, const PC& pc, int l
     const auto write_real_comp_d_ptr = write_real_comp_d.data();
 
     std::size_t poffset = 0;
-    for (std::size_t i = 0; i < tiles.size(); i++) {
+    for (int i = 0; i < tiles.size(); i++) {
         const auto& ptile = pc.ParticlesAt(lev, grid, tiles[i]);
         const auto& pflags = particle_io_flags[lev].at(std::make_pair(grid, tiles[i]));
         int np_tile = ptile.GetArrayOfStructs().numParticles();

--- a/Src/Particle/AMReX_WriteBinaryParticleData.H
+++ b/Src/Particle/AMReX_WriteBinaryParticleData.H
@@ -111,7 +111,7 @@ countFlags (const Container<int,Allocator>& pflags, int& nparticles)
 template <template <class, class> class Container, class Allocator, class PC>
 typename std::enable_if<!RunOnGpu<typename Container<int, Allocator>::allocator_type>::value>::type
 countFlags (const Vector<std::map<std::pair<int,int>,Container<int,Allocator>>>& particle_io_flags,
-            const PC& pc, int& nparticles)
+            const PC& pc, amrex::Long& nparticles)
 {
     for (int lev = 0; lev < pc.GetParticles().size();  lev++)
     {
@@ -129,7 +129,7 @@ countFlags (const Vector<std::map<std::pair<int,int>,Container<int,Allocator>>>&
 
 template <template <class, class> class Container, class Allocator>
 typename std::enable_if<!RunOnGpu<typename Container<int, Allocator>::allocator_type>::value>::type
-countFlags (const Container<int,Allocator>& pflags, amrex::Long& nparticles)
+countFlags (const Container<int,Allocator>& pflags, int& nparticles)
 {
     for (std::size_t k = 0; k < pflags.size(); ++k)
     {
@@ -184,8 +184,13 @@ packIOData (Vector<int>& idata, Vector<ParticleReal>& rdata, const PC& pc, int l
         int num_copies;
         {
             int last_flag;
+#ifdef AMREX_USE_GPU
             Gpu::dtoh_memcpy(&num_copies, offsets.dataPtr()+np_tile-1, sizeof(int));
             Gpu::dtoh_memcpy(&last_flag, pflags.dataPtr()+np_tile-1, sizeof(int));
+#else
+            std::memcpy(&num_copies, offsets.dataPtr()+np_tile-1, sizeof(int));
+            std::memcpy(&last_flag, pflags.dataPtr()+np_tile-1, sizeof(int));
+#endif
             num_copies += last_flag;
         }
 


### PR DESCRIPTION
Currently, `ParticleContainer::WritePlotFile` and `ParticleContainer::Checkpoint` assume managed memory when compiled for GPUs. This PR extends them to work without managed memory. Operations such as particle filtering is performed on the device if the container uses managed or device memory, and on the host otherwise. 

The AMReX GPU and CPU tests all pass with the PR. 

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
