### PR TITLE
HIP ROCTX: USE_RPATH Control

### DIFF
--- a/Tools/GNUMake/comps/hip.mak
+++ b/Tools/GNUMake/comps/hip.mak
@@ -121,7 +121,7 @@ ifeq ($(HIP_COMPILER),clang)
   HIPCC_FLAGS += -DAMREX_USE_ROCTX
   SYSTEM_INCLUDE_LOCATIONS += $(ROC_PATH)/roctracer/include $(ROC_PATH)/rocprofiler/include
   LIBRARY_LOCATIONS += $(ROC_PATH)/roctracer/lib $(ROC_PATH)/rocprofiler/lib
-  LIBRARIES +=  -Wl,--rpath=${ROC_PATH}/roctracer/lib -lroctracer64 -lroctx64
+  LIBRARIES += -lroctracer64 -lroctx64
   endif
 
   # hipcc passes a lot of unused arguments to clang


### PR DESCRIPTION
## Summary

Just rely on USE_RPATH instead for GNUmake. Follow-up to #2057

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
