### PR TITLE
CI: Cover Fortran

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -17,6 +17,7 @@ jobs:
         mkdir build
         cd build
         cmake ..                                  \
+            -DAMReX_FORTRAN=ON                    \
             -DAMReX_PLOTFILE_TOOLS=ON             \
             -DCMAKE_VERBOSE_MAKEFILE=ON           \
             -DCMAKE_INSTALL_PREFIX=/tmp/my-amrex  \
@@ -44,6 +45,7 @@ jobs:
             -DCMAKE_BUILD_TYPE=Debug    \
             -DCMAKE_VERBOSE_MAKEFILE=ON \
             -DCMAKE_INSTALL_PREFIX=/tmp/my-amrex      \
+            -DAMReX_FORTRAN=ON                        \
             -DAMReX_MPI=OFF                           \
             -DAMReX_PARTICLES=ON                      \
             -DAMReX_PLOTFILE_TOOLS=ON                 \
@@ -76,7 +78,8 @@ jobs:
         cmake ..                        \
             -DCMAKE_BUILD_TYPE=Debug    \
             -DCMAKE_VERBOSE_MAKEFILE=ON \
-            -DAMReX_ENABLE_TESTS=ON  \
+            -DAMReX_ENABLE_TESTS=ON     \
+            -DAMReX_FORTRAN=ON          \
             -DAMReX_PARTICLES=ON
         make -j 2
 
@@ -97,6 +100,7 @@ jobs:
             -DCMAKE_BUILD_TYPE=Debug    \
             -DCMAKE_VERBOSE_MAKEFILE=ON \
             -DAMReX_ENABLE_TESTS=ON     \
+            -DAMReX_FORTRAN=ON          \
             -DAMReX_OMP=ON              \
             -DAMReX_PARTICLES=ON        \
             -DCMAKE_CXX_STANDARD=20     \
@@ -121,6 +125,7 @@ jobs:
             -DCMAKE_BUILD_TYPE=Debug                  \
             -DCMAKE_VERBOSE_MAKEFILE=ON               \
             -DAMReX_ENABLE_TESTS=ON                   \
+            -DAMReX_FORTRAN=ON                        \
             -DAMReX_MPI=OFF                           \
             -DAMReX_PARTICLES=ON                      \
             -DAMReX_PRECISION=DOUBLE                  \
@@ -148,6 +153,7 @@ jobs:
             -DCMAKE_BUILD_TYPE=Debug    \
             -DCMAKE_VERBOSE_MAKEFILE=ON \
             -DAMReX_ENABLE_TESTS=ON     \
+            -DAMReX_FORTRAN=ON          \
             -DAMReX_MPI=OFF             \
             -DAMReX_PARTICLES=ON
         make -j 2
@@ -168,8 +174,9 @@ jobs:
         cmake ..                        \
             -DCMAKE_BUILD_TYPE=Debug    \
             -DCMAKE_VERBOSE_MAKEFILE=ON \
-            -DAMReX_ENABLE_TESTS=ON    \
-            -DAMReX_PARTICLES=ON       \
+            -DAMReX_ENABLE_TESTS=ON     \
+            -DAMReX_FORTRAN=OFF         \
+            -DAMReX_PARTICLES=ON        \
             -DAMReX_FORTRAN=OFF
         make -j 2
 
@@ -192,6 +199,7 @@ jobs:
         cmake ..                                           \
             -DCMAKE_VERBOSE_MAKEFILE=ON                    \
             -DAMReX_ENABLE_TESTS=ON                        \
+            -DAMReX_FORTRAN=OFF                            \
             -DAMReX_PARTICLES=ON                           \
             -DAMReX_GPU_BACKEND=CUDA                       \
             -DCMAKE_C_COMPILER=$(which gcc-6)              \
@@ -220,6 +228,7 @@ jobs:
         cmake -S . -B build                              \
             -DCMAKE_VERBOSE_MAKEFILE=ON                  \
             -DAMReX_ENABLE_TESTS=ON                      \
+            -DAMReX_FORTRAN=OFF                          \
             -DAMReX_PARTICLES=ON                         \
             -DAMReX_GPU_BACKEND=CUDA                     \
             -DCMAKE_C_COMPILER=$(which gcc)              \
@@ -253,6 +262,7 @@ jobs:
             -DCMAKE_CXX_STANDARD_COMPUTED_DEFAULT="17"     \
             -DCMAKE_VERBOSE_MAKEFILE=ON                    \
             -DAMReX_ENABLE_TESTS=ON                        \
+            -DAMReX_FORTRAN=OFF                            \
             -DAMReX_PARTICLES=ON                           \
             -DAMReX_GPU_BACKEND=SYCL                       \
             -DCMAKE_C_COMPILER=$(which clang)              \

--- a/Tests/CMakeTestInstall/CMakeLists.txt
+++ b/Tests/CMakeTestInstall/CMakeLists.txt
@@ -7,6 +7,10 @@ cmake_minimum_required(VERSION 3.14)
 
 project(amrex-test-install)
 
+if(DEFINED CMAKE_Fortran_COMPILER)
+    enable_language(Fortran)
+endif()
+
 get_filename_component(_base_dir ${CMAKE_CURRENT_LIST_DIR} DIRECTORY)
 
 set(_base_dir  ${_base_dir}/Amr/Advection_AmrCore)

--- a/Tools/CMake/AMReXInstallHelpers.cmake
+++ b/Tools/CMake/AMReXInstallHelpers.cmake
@@ -109,6 +109,10 @@ macro( add_test_install_target _dir _amrex_root )
 
    get_filename_component( _dirname ${_dir} NAME )
    set(_builddir  ${CMAKE_CURRENT_BINARY_DIR}/${_dirname})
+   set(_enable_fortran)
+   if(AMReX_FORTRAN)
+      set(_enable_fortran -DCMAKE_Fortran_COMPILER=${CMAKE_Fortran_COMPILER})
+   endif()
    add_custom_target(test_install
       COMMAND ${CMAKE_COMMAND} -E echo ""
       COMMAND ${CMAKE_COMMAND} -E echo "------------------------------------"
@@ -117,7 +121,7 @@ macro( add_test_install_target _dir _amrex_root )
       COMMAND ${CMAKE_COMMAND} -E echo ""
       COMMAND ${CMAKE_COMMAND} -E make_directory ${_builddir}
       COMMAND ${CMAKE_COMMAND} -E echo "Configuring test project"
-      COMMAND ${CMAKE_COMMAND} -S ${_dir} -B ${_builddir} -DAMReX_ROOT=${_amrex_root} -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
+      COMMAND ${CMAKE_COMMAND} -S ${_dir} -B ${_builddir} -DAMReX_ROOT=${_amrex_root} -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER} ${_enable_fortran}
       COMMAND ${CMAKE_COMMAND} -E echo "Building test project"
       COMMAND ${CMAKE_COMMAND} --build ${_builddir}
       COMMAND ${CMAKE_COMMAND} -E echo ""


### PR DESCRIPTION
## Summary

It looks like at some point we changed the `AMReX_Fortran` default from ON to OFF and forgot to adjust CI. This re-enables Fortran compile tests.

We still have at least one entry that makes sure we can compile in pure C/C++ on Linux.

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
