### PR TITLE
ParallelFor for MultiFab/FabArray

### DIFF
--- a/Src/Base/AMReX_CArena.cpp
+++ b/Src/Base/AMReX_CArena.cpp
@@ -115,13 +115,15 @@ CArena::alloc (std::size_t nbytes)
 void
 CArena::free (void* vp)
 {
-    std::lock_guard<std::mutex> lock(carena_mutex);
-
-    if (vp == 0)
+    if (vp == 0) {
         //
         // Allow calls with NULL as allowed by C++ delete.
         //
         return;
+    }
+
+    std::lock_guard<std::mutex> lock(carena_mutex);
+
     //
     // `vp' had better be in the busy list.
     //

--- a/Src/Base/AMReX_FabArray.H
+++ b/Src/Base/AMReX_FabArray.H
@@ -25,6 +25,11 @@
 #include <AMReX_TypeTraits.H>
 #include <AMReX_LayoutData.H>
 #include <AMReX_BaseFabUtility.H>
+#ifdef AMREX_USE_GPU
+#include <AMReX_MFParallelForG.H>
+#else
+#include <AMReX_MFParallelForC.H>
+#endif
 
 #include <AMReX_Gpu.H>
 
@@ -193,6 +198,24 @@ struct PCData {
     Vector<MPI_Request> recv_reqs;
     Vector<MPI_Request> send_reqs;
 
+};
+
+template <typename T>
+struct MultiArray4
+{
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    Array4<T> const& operator[] (int li) const noexcept {
+#if AMREX_DEVICE_COMPILE
+        return dp[li];
+#else
+        return hp[li];
+#endif
+    }
+
+#ifdef AMREX_USE_GPU
+    Array4<T>* dp = nullptr;
+#endif
+    Array4<T>* hp = nullptr;
 };
 
 template <class FAB>
@@ -399,6 +422,15 @@ public:
     //
     template <class F=FAB, typename std::enable_if<IsBaseFab<F>::value,int>::type = 0>
     Array4<typename FabArray<FAB>::value_type const> const_array (int K, int start_comp) const noexcept;
+
+    template <class F=FAB, typename std::enable_if<IsBaseFab<F>::value,int>::type = 0>
+    MultiArray4<typename FabArray<FAB>::value_type> arrays () noexcept;
+
+    template <class F=FAB, typename std::enable_if<IsBaseFab<F>::value,int>::type = 0>
+    MultiArray4<typename FabArray<FAB>::value_type const> arrays () const noexcept;
+
+    template <class F=FAB, typename std::enable_if<IsBaseFab<F>::value,int>::type = 0>
+    MultiArray4<typename FabArray<FAB>::value_type const> const_arrays () const noexcept;
 
     //! Explicitly set the Kth FAB in the FabArray to point to elem.
     void setFab (int K, std::unique_ptr<FAB> elem);
@@ -903,6 +935,13 @@ protected:
     //! The data.
     std::vector<FAB*> m_fabs_v;
 
+#ifdef AMREX_USE_GPU
+    mutable void* m_dp_arrays = nullptr;
+#endif
+    mutable void* m_hp_arrays = nullptr;
+    mutable MultiArray4<value_type> m_arrays;
+    mutable MultiArray4<value_type const> m_const_arrays;
+
     Vector<std::string> m_tags;
 
     //! for shared memory
@@ -966,6 +1005,9 @@ private:
                     const Vector<std::string>& tags);
 
     void setFab_assert (int K, FAB const& fab) const;
+
+    template <class F=FAB, typename std::enable_if<IsBaseFab<F>::value,int>::type = 0>
+    void build_arrays () const;
 
 public:
 
@@ -1207,6 +1249,63 @@ FabArray<FAB>::const_array (int K, int start_comp) const noexcept
 }
 
 template <class FAB>
+template <class F, typename std::enable_if<IsBaseFab<F>::value,int>::type>
+MultiArray4<typename FabArray<FAB>::value_type>
+FabArray<FAB>::arrays () noexcept
+{
+    build_arrays();
+    return m_arrays;
+}
+
+template <class FAB>
+template <class F, typename std::enable_if<IsBaseFab<F>::value,int>::type>
+MultiArray4<typename FabArray<FAB>::value_type const>
+FabArray<FAB>::arrays () const noexcept
+{
+    build_arrays();
+    return m_const_arrays;
+}
+
+template <class FAB>
+template <class F, typename std::enable_if<IsBaseFab<F>::value,int>::type>
+MultiArray4<typename FabArray<FAB>::value_type const>
+FabArray<FAB>::const_arrays () const noexcept
+{
+    build_arrays();
+    return m_const_arrays;
+}
+
+template <class FAB>
+template <class F, typename std::enable_if<IsBaseFab<F>::value,int>::type>
+void
+FabArray<FAB>::build_arrays () const
+{
+    using A = Array4<value_type>;
+    using AC = Array4<value_type const>;
+    static_assert(sizeof(A) == sizeof(AC), "sizeof(Array4<T>) != sizeof(Array4<T const>)");
+    if (!m_hp_arrays && local_size() > 0) {
+        const int n = local_size();
+#ifdef AMREX_USE_GPU
+        m_hp_arrays = (void*)The_Pinned_Arena()->alloc(n*2*sizeof(A));
+        m_dp_arrays = (void*)The_Arena()->alloc(n*2*sizeof(A));
+#else
+        m_hp_arrays = (void*)std::malloc(n*2*sizeof(A));
+#endif
+        for (int li = 0; li < n; ++li) {
+            new ((A*)m_hp_arrays+li) A(m_fabs_v[li]->array());
+            new ((AC*)m_hp_arrays+li+n) AC(m_fabs_v[li]->const_array());
+        }
+        m_arrays.hp = (A*)m_hp_arrays;
+        m_const_arrays.hp = (AC*)m_hp_arrays + n;
+#ifdef AMREX_USE_GPU
+        m_arrays.dp = (A*)m_dp_arrays;
+        m_const_arrays.dp = (AC*)m_dp_arrays + n;
+        Gpu::htod_memcpy(m_dp_arrays, m_hp_arrays, n*2*sizeof(A));
+#endif
+    }
+}
+
+template <class FAB>
 AMREX_NODISCARD
 FAB*
 FabArray<FAB>::release (int K)
@@ -1262,6 +1361,14 @@ FabArray<FAB>::clear ()
         }
     }
     m_fabs_v.clear();
+#ifdef AMREX_USE_GPU
+    The_Pinned_Arena()->free(m_hp_arrays);
+    The_Arena()->free(m_dp_arrays);
+    m_dp_arrays = nullptr;
+#else
+    std::free(m_hp_arrays);
+#endif
+    m_hp_arrays = nullptr;
     m_factory.reset();
     m_dallocator.m_arena = nullptr;
     // no need to clear the non-blocking fillboundary stuff
@@ -1368,6 +1475,10 @@ FabArray<FAB>::FabArray (FabArray<FAB>&& rhs) noexcept
     , m_dallocator (std::move(rhs.m_dallocator))
     , define_function_called(rhs.define_function_called)
     , m_fabs_v     (std::move(rhs.m_fabs_v))
+#ifdef AMREX_USE_GPU
+    , m_dp_arrays  (std::exchange(rhs.m_dp_arrays, nullptr))
+#endif
+    , m_hp_arrays  (std::exchange(rhs.m_hp_arrays, nullptr))
     , m_tags       (std::move(rhs.m_tags))
     , shmem        (std::move(rhs.shmem))
     // no need to worry about the data used in non-blocking FillBoundary.
@@ -1391,6 +1502,10 @@ FabArray<FAB>::operator= (FabArray<FAB>&& rhs) noexcept
         m_dallocator = std::move(rhs.m_dallocator);
         define_function_called = rhs.define_function_called;
         std::swap(m_fabs_v, rhs.m_fabs_v);
+#ifdef AMREX_USE_GPU
+        std::swap(m_dp_arrays, rhs.m_dp_arrays);
+#endif
+        std::swap(m_hp_arrays, rhs.m_hp_arrays);
         std::swap(m_tags, rhs.m_tags);
         shmem = std::move(rhs.shmem);
 

--- a/Src/Base/AMReX_FabArrayBase.H
+++ b/Src/Base/AMReX_FabArrayBase.H
@@ -16,6 +16,7 @@
 #endif
 
 #include <string>
+#include <utility>
 
 namespace amrex {
 
@@ -645,6 +646,36 @@ public:
     //
     void flushPolarB (bool no_assertion=false) const; //!< This flushes its own PolarB.
     static void flushPolarBCache (); //!< This flushes the entire cache.
+
+#ifdef AMREX_USE_GPU
+    //
+    //! For ParalleFor(FabArray)
+    struct ParForInfo
+    {
+        ParForInfo (const FabArrayBase& fa, const IntVect& nghost);
+        ~ParForInfo ();
+
+        std::pair<int*,int*> const& getBlocks () const { return m_nblocks_x; }
+
+        ParForInfo () = delete;
+        ParForInfo (ParForInfo const&) = delete;
+        ParForInfo (ParForInfo &&) = delete;
+        void operator= (ParForInfo const&) = delete;
+        void operator= (ParForInfo &&) = delete;
+
+        IndexType m_typ;
+        IntVect m_crse_ratio;
+        std::pair<int*,int*> m_nblocks_x;
+    };
+
+    ParForInfo const& getParForInfo (const IntVect& nghost) const;
+
+    static std::multimap<BDKey,ParForInfo*> m_TheParForCache;
+
+    void flushParForInfo (bool no_assertion=false) const; // flushes its own cache
+    static void flushParForCache (); // flushes the entire cache
+
+#endif
 
     //
     //! Keep track of how many FabArrays are built with the same BDKey.

--- a/Src/Base/AMReX_MFIter.H
+++ b/Src/Base/AMReX_MFIter.H
@@ -2,18 +2,7 @@
 #define BL_MFITER_H_
 #include <AMReX_Config.H>
 
-#include <AMReX_Arena.H>
-#include <AMReX_Extension.H>
 #include <AMReX_FabArrayBase.H>
-#include <AMReX_IntVect.H>
-#include <AMReX_FArrayBox.H>
-#include <AMReX_RealBox.H>
-
-#include <AMReX_Gpu.H>
-
-#ifdef AMREX_USE_OMP
-#include <omp.h>
-#endif
 
 #include <memory>
 
@@ -193,7 +182,15 @@ protected:
     IndexType     typ;
 
     bool          dynamic;
-    bool          device_sync = true;
+
+    struct DeviceSync {
+        DeviceSync () = default;
+        DeviceSync (bool f) : flag(f) {}
+        DeviceSync (DeviceSync&& rhs) : flag(std::exchange(rhs.flag,false)) {}
+        explicit operator bool() const noexcept { return flag; }
+        bool flag = true;
+    };
+    DeviceSync device_sync;
 
     const Vector<int>* index_map;
     const Vector<int>* local_index_map;

--- a/Src/Base/AMReX_MFParallelForC.H
+++ b/Src/Base/AMReX_MFParallelForC.H
@@ -1,0 +1,43 @@
+#ifndef AMREX_MF_PARALLEL_FOR_C_H_
+#define AMREX_MF_PARALLEL_FOR_C_H_
+#include <AMReX_Config.H>
+
+#include <AMReX_MFIter.H>
+
+namespace amrex {
+namespace experimental {
+
+template <typename MF, typename F>
+std::enable_if_t<IsFabArray<MF>::value>
+ParallelFor (MF const& mf, IntVect const& nghost, F&& f)
+{
+#ifdef AMREX_USE_OMP
+#pragma omp parallel
+#endif
+    for (MFIter mfi(mf); mfi.isValid(); ++mfi) {
+        Box const& bx = amrex::grow(mfi.validbox(), nghost);
+        int const lidx = mfi.LocalIndex();
+        const auto lo = amrex::lbound(bx);
+        const auto hi = amrex::ubound(bx);
+        for (        int k = lo.z; k <= hi.z; ++k) {
+            for (    int j = lo.y; j <= hi.y; ++j) {
+                AMREX_PRAGMA_SIMD
+                for (int i = lo.x; i <= hi.x; ++i) {
+                    f(lidx,i,j,k);
+                }
+            }
+        }
+    }
+}
+
+template <typename MF, typename F>
+std::enable_if_t<IsFabArray<MF>::value>
+ParallelFor (MF const& mf, F&& f)
+{
+    ParallelFor(mf, IntVect(0), std::forward<F>(f));
+}
+
+}
+}
+
+#endif

--- a/Src/Base/AMReX_MFParallelForG.H
+++ b/Src/Base/AMReX_MFParallelForG.H
@@ -1,0 +1,151 @@
+#ifndef AMREX_MF_PARALLEL_FOR_G_H_
+#define AMREX_MF_PARALLEL_FOR_G_H_
+#include <AMReX_Config.H>
+
+#ifdef AMREX_USE_GPU
+
+#include <AMReX_FabArrayBase.H>
+#include <AMReX_TypeTraits.H>
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+
+namespace amrex {
+
+namespace detail {
+    template <typename MF, typename F>
+    std::enable_if_t<IsFabArray<MF>::value>
+    ParallelFor_doit (MF const&, IntVect const&, F&&);
+}
+
+
+namespace experimental {
+
+template <typename MF, typename F>
+std::enable_if_t<IsFabArray<MF>::value>
+ParallelFor (MF const& mf, F&& f)
+{
+    detail::ParallelFor_doit(mf, IntVect(0), std::forward<F>(f));
+}
+
+template <typename MF, typename F>
+std::enable_if_t<IsFabArray<MF>::value>
+ParallelFor (MF const& mf, IntVect const& nghost, F&& f)
+{
+    detail::ParallelFor_doit(mf, nghost, std::forward<F>(f));
+}
+
+}
+
+namespace detail {
+
+inline
+std::pair<int*,int*> build_par_for_nblocks (Vector<Long> const& ncells)
+{
+    int* hp = nullptr;
+    int* dp = nullptr;
+    if (!ncells.empty()) {
+        const int nboxes = ncells.size();
+        const std::size_t nbytes = (nboxes+1) * sizeof(int);
+        hp = (int*)The_Pinned_Arena()->alloc(nbytes);
+        hp[0] = 0;
+        Long ntot = 0;
+        bool same_size = true;
+        for (int i = 0; i < nboxes; ++i) {
+            Long nblocks = (ncells[i] + AMREX_GPU_MAX_THREADS-1) / AMREX_GPU_MAX_THREADS;
+            hp[i+1] = hp[i] + static_cast<int>(nblocks);
+            ntot += nblocks;
+            same_size = same_size && (ncells[i] == ncells[0]);
+        }
+        amrex::ignore_unused(ntot);
+        AMREX_ASSERT(static_cast<Long>(hp[nboxes]) == ntot); // no overflow
+        if (!same_size) {
+            dp = (int*) The_Arena()->alloc(nbytes);
+            Gpu::htod_memcpy(dp, hp, nbytes);
+        }
+    }
+    return std::make_pair(hp,dp);
+}
+
+inline
+void destroy_par_for_nblocks (std::pair<int*,int*> const& pp)
+{
+    The_Pinned_Arena()->free(pp.first);
+    The_Arena()->free(pp.second);
+}
+
+template <typename MF, typename F>
+std::enable_if_t<IsFabArray<MF>::value>
+ParallelFor_doit (MF const& mf, IntVect const& nghost, F&& f)
+{
+    const auto& index_array = mf.IndexArray();
+    const int nboxes = index_array.size();
+    if (nboxes == 0) return;
+
+    AMREX_ASSERT(nghost.allLE(mf.nGrowVect()) && nghost.allGE(IntVect(0)));
+    IntVect ngrow = nghost - mf.nGrowVect(); // We use this to go from fabbox to valid+nghost.
+    auto ma = mf.arrays();
+
+    auto par_for_blocks = mf.getParForInfo(nghost).getBlocks();
+    const int nblocks = par_for_blocks.first[nboxes];
+    const int block_0_size = par_for_blocks.first[1];
+    const int* dp_nblocks = par_for_blocks.second;
+
+#if defined(AMREX_USE_CUDA) || defined(AMREX_USE_HIP)
+
+    amrex::launch_global<AMREX_GPU_MAX_THREADS>
+        <<<nblocks, AMREX_GPU_MAX_THREADS, 0, Gpu::gpuStream()>>>
+        ([=] AMREX_GPU_DEVICE () noexcept
+         {
+             int ibox, icell;
+             if (dp_nblocks) {
+                 int blo = 0;
+                 int bhi = nboxes;
+                 int bid = blockIdx.x;
+                 while (blo <= bhi) {
+                     int mid = (blo+bhi)/2;
+                     if (bid >= dp_nblocks[mid] && bid < dp_nblocks[mid+1]) {
+                         ibox = mid;
+                         break;
+                     } else if (bid < dp_nblocks[mid]) {
+                         bhi = mid-1;
+                     } else {
+                         blo = mid+1;
+                     }
+                 };
+                 icell = (blockIdx.x-dp_nblocks[ibox])*AMREX_GPU_MAX_THREADS + threadIdx.x;
+             } else {
+                 ibox = blockIdx.x / block_0_size;
+                 icell = (blockIdx.x-ibox*block_0_size)*AMREX_GPU_MAX_THREADS + threadIdx.x;
+             }
+
+             Box b(ma[ibox]);
+             b.grow(ngrow);
+             int ncells = b.numPts();
+             if (icell < ncells) {
+                 const auto len = amrex::length(b);
+                 int k =  icell /   (len.x*len.y);
+                 int j = (icell - k*(len.x*len.y)) /   len.x;
+                 int i = (icell - k*(len.x*len.y)) - j*len.x;
+                 AMREX_D_TERM(i += b.smallEnd(0);,
+                              j += b.smallEnd(1);,
+                              k += b.smallEnd(2);)
+                 f(ibox, i, j, k);
+             }
+         });
+
+#elif defined(AMREX_USE_DPCPP)
+    // xxxxx dpcpp TODO: ParallelFor(MF)
+#endif
+
+    AMREX_GPU_ERROR_CHECK();
+}
+
+}
+
+}
+
+#endif
+
+#endif

--- a/Src/Base/AMReX_NonLocalBC.H
+++ b/Src/Base/AMReX_NonLocalBC.H
@@ -3,6 +3,7 @@
 #include <AMReX_Config.H>
 #include <AMReX_TypeTraits.H>
 #include <AMReX_FabArray.H>
+#include <AMReX_FArrayBox.H>
 
 namespace amrex { namespace NonLocalBC {
 

--- a/Src/Base/AMReX_TypeTraits.H
+++ b/Src/Base/AMReX_TypeTraits.H
@@ -43,6 +43,10 @@ namespace amrex
     template <> struct HasAtomicAdd<float> : std::true_type {};
     template <> struct HasAtomicAdd<double> : std::true_type {};
 
+    class MFIter;
+    template <typename T>
+    struct IsMultiFabIterator : public std::is_base_of<MFIter, T>::type {};
+
 #ifdef AMREX_PARTICLES
     template <bool is_const, int NStructReal, int NStructInt, int NArrayReal, int NArrayInt,
               template<class> class Allocator>
@@ -56,11 +60,10 @@ namespace amrex
               template<class> class Allocator>
     class ParConstIter;
 
-    class MFIter;
     class ParticleContainerBase;
 
     template <typename T>
-    struct IsParticleIterator : public std::is_base_of<MFIter, T>::type {};
+    struct IsParticleIterator : public std::is_base_of<MFIter, T>::type {}; // not exactly right
 
     template <typename T>
     struct IsParticleContainer : public std::is_base_of<ParticleContainerBase, T>::type {};

--- a/Src/Base/CMakeLists.txt
+++ b/Src/Base/CMakeLists.txt
@@ -210,6 +210,8 @@ target_sources( amrex
    AMReX_GpuReduce.H
    AMReX_GpuAllocators.H
    AMReX_GpuContainers.H
+   AMReX_MFParallelForC.H
+   AMReX_MFParallelForG.H
    # CUDA --------------------------------------------------------------------
    AMReX_CudaGraph.H
    # Machine model -----------------------------------------------------------

--- a/Src/Base/Make.package
+++ b/Src/Base/Make.package
@@ -96,6 +96,9 @@ C$(AMREX_BASE)_headers += AMReX_CudaGraph.H AMReX_GpuContainers.H
 
 C$(AMREX_BASE)_headers += AMReX_GpuAllocators.H
 
+C$(AMREX_BASE)_headers += AMReX_MFParallelForC.H
+C$(AMREX_BASE)_headers += AMReX_MFParallelForG.H
+
 #
 # I/O stuff.
 #

--- a/Src/EB/AMReX_MultiCutFab.H
+++ b/Src/EB/AMReX_MultiCutFab.H
@@ -3,6 +3,7 @@
 #include <AMReX_Config.H>
 
 #include <AMReX_FabArray.H>
+#include <AMReX_FArrayBox.H>
 #include <AMReX_EBCellFlag.H>
 
 namespace amrex {


### PR DESCRIPTION
## Summary

Add an experimental feature that can be used to launch a single kernel to
work on MultiFabs or FabArrays.  An example is shown below, where `mf` is a
MultiFab.
```
        auto ma = mf.arrays();
        amrex::ParallelFor(mf,
                           [=] AMREX_GPU_DEVICE (int box_no, int i, int j, int k)
        {
            ma[box_no](i,j,k) = 1.0;
        });
        Gpu::synchronize();
```

It's still unclear how we handle tiling and OpenMP and how it performs on CPU.  However, there is strong evidence that this improves performance for GPU runs when there are small boxes.  The purpose of this PR is to get the feature into the AMReX repo first and do further tuning later.  Since the new function is  not used at all, it should not affect any codes.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
