### PR TITLE
CMake 3.20+ CUDA: Policy & Include

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,14 +88,18 @@ endif ()
 # Enable CUDA if requested
 #
 if (AMReX_CUDA)
-    # CMake 3.18+: CMAKE_CUDA_ARCHITECTURES
-    # https://cmake.org/cmake/help/latest/policy/CMP0104.html
-    if(POLICY CMP0104)
-        cmake_policy(SET CMP0104 OLD)
+    if(CMAKE_VERSION VERSION_LESS 3.20)
+        # CMake 3.18+: CMAKE_CUDA_ARCHITECTURES
+        # https://cmake.org/cmake/help/latest/policy/CMP0104.html
+        if(POLICY CMP0104)
+            cmake_policy(SET CMP0104 OLD)
+        endif()
     endif()
 
     enable_language(CUDA)
-    include(AMReX_SetupCUDA)
+    if(CMAKE_VERSION VERSION_LESS 3.20)
+        include(AMReX_SetupCUDA)
+    endif()
 endif ()
 
 #

--- a/Tools/CMake/AMReXParallelBackends.cmake
+++ b/Tools/CMake/AMReXParallelBackends.cmake
@@ -74,7 +74,7 @@ if (  AMReX_GPU_BACKEND STREQUAL "CUDA"
    set_cuda_architectures(AMReX_CUDA_ARCH)
    set_target_properties( amrex
       PROPERTIES
-      CUDA_ARCHITECTURES ${AMREX_CUDA_ARCHS}
+      CUDA_ARCHITECTURES "${AMREX_CUDA_ARCHS}"
       )
 
    #

--- a/Tools/CMake/AMReXTargetHelpers.cmake
+++ b/Tools/CMake/AMReXTargetHelpers.cmake
@@ -123,7 +123,7 @@ function (setup_target_for_cuda_compilation _target)
    if (CMAKE_VERSION VERSION_GREATER_EQUAL 3.20)
       set_target_properties( ${_target}
          PROPERTIES
-         CUDA_ARCHITECTURES ${AMREX_CUDA_ARCHS}
+         CUDA_ARCHITECTURES "${AMREX_CUDA_ARCHS}"
          )
    endif ()
 endfunction ()


### PR DESCRIPTION
## Summary

Do not include the deprecated CUDA setup with CMake 3.20+ and support new policy for CUDA_ARCHITECTURES.

Also fix errors of the kind:
```
ERROR: set_target_properties called with incorrect number of arguments.
Value in AMREX_CUDA_ARCHS is 53;60;61;70;75;80;86;86
```
by quoting the semicolon-separated list.

## Additional background

Those are regressions to #2012 that appear with our modernized logic in CMake 3.20+ with CUDA.

I saw those regressions with [HiPACE++](https://github.com/Hi-PACE/hipace).

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
