### PR TITLE
CMake CUDA: Filter out SM Before Pascal

### DIFF
--- a/Tools/CMake/AMReXUtils.cmake
+++ b/Tools/CMake/AMReXUtils.cmake
@@ -239,7 +239,7 @@ function (set_cuda_architectures _cuda_archs)
    include(FindCUDA/select_compute_arch)
    cuda_select_nvcc_arch_flags(_nvcc_arch_flags ${_archs})
 
-   # Extract architecture number: anything less than 3.5 must go
+   # Extract architecture number: anything less than 6.0 must go
    string(REPLACE "-gencode;" "-gencode=" _nvcc_arch_flags "${_nvcc_arch_flags}")
 
    foreach (_item IN LISTS _nvcc_arch_flags)
@@ -247,7 +247,7 @@ function (set_cuda_architectures _cuda_archs)
       # [0-9]+ means any number between 0 and 9 will be matched one or more times (option +)
       string(REGEX MATCH "[0-9]+" _cuda_compute_capability "${_item}")
 
-      if (_cuda_compute_capability LESS 35)
+      if (_cuda_compute_capability LESS 60)
          message(STATUS "Ignoring unsupported CUDA architecture ${_cuda_compute_capability}")
       else ()
          list(APPEND _tmp ${_cuda_compute_capability})


### PR DESCRIPTION
## Summary

Filter out unsupported CUDA architectures in CMake, for both legacy and CMake 3.20+ logic.

## Additional background

It looks like we fallback and include SM 5.3 at the moment if no local GPU is found (tested with CUDA 11.3), which causes ptxas errors.
https://github.com/AMReX-Codes/amrex/pull/2012#issuecomment-853312177

I think we could also set `CUDA_LIMIT_GPU_ARCHITECTURE` if it were a cache variable:
https://gitlab.kitware.com/cmake/cmake/-/blob/v3.20.3/Modules/FindCUDA/select_compute_arch.cmake

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
