### PR TITLE
AMReX_PROBINT: Depends on AMReX_AMRLEVEL

### DIFF
--- a/Tools/CMake/AMReXOptions.cmake
+++ b/Tools/CMake/AMReXOptions.cmake
@@ -375,6 +375,7 @@ print_option(AMReX_DIFFERENT_COMPILER)
 if (BUILD_SHARED_LIBS AND NOT (CMAKE_SYSTEM_NAME STREQUAL "Linux") )
    option(AMReX_PROBINIT "Enable support for probin file" OFF)
 else ()
-   option(AMReX_PROBINIT "Enable support for probin file" ON)
+   cmake_dependent_option(AMReX_PROBINIT "Enable support for probin file" ON
+       "AMReX_AMRLEVEL" OFF)
 endif ()
 print_option(AMReX_PROBINIT)


### PR DESCRIPTION
## Summary

CMake: do not enable if `AMReX_AMRLEVEL` is off anyway.

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
