### PR TITLE
Fix some macro issues in CMake Fortran build

### DIFF
--- a/Src/AmrCore/AMReX_INTERP_2D.F90
+++ b/Src/AmrCore/AMReX_INTERP_2D.F90
@@ -331,7 +331,7 @@ contains
       integer icase
 
       if (MAX(lratiox,lratioy).gt.rMAX) then
-#ifdef AMREX_DEBUG
+#if 0
          print *,'rMAX in INTERP_2D::AMREX_PROTECT_INTERP must be >= ',MAX(lratiox,lratioy)
 #endif
          call bl_abort("rMAX in INTERP_2D")
@@ -551,7 +551,7 @@ contains
                enddo
                enddo
 
-#ifdef AMREX_DEBUG
+#if 0
                if (abs(crseTotnew - crseTot)/cvol .gt. 1.e-8) then
                   print *,' '
                   print *,'BLEW CONSERVATION with ICASE = ',icase

--- a/Src/AmrCore/AMReX_INTERP_3D.F90
+++ b/Src/AmrCore/AMReX_INTERP_3D.F90
@@ -437,7 +437,7 @@ contains
                enddo
                enddo
 
-#ifdef AMREX_DEBUG
+#if 0
                if (abs(sum_fine_new - sum_fine_old) .gt. 1.e-8) then
                   print *,' '
                   print *, &

--- a/Src/Base/AMReX_FILCC_1D.F90
+++ b/Src/Base/AMReX_FILCC_1D.F90
@@ -1,3 +1,4 @@
+#include <AMReX_Config.H>
 
 ! -----------------------------------------------------------
 !> This routine is intended to be a generic fill function

--- a/Src/Base/AMReX_FILCC_2D.F90
+++ b/Src/Base/AMReX_FILCC_2D.F90
@@ -1,3 +1,4 @@
+#include <AMReX_Config.H>
 
 #ifndef AMREX_XSDK
 

--- a/Src/Base/AMReX_FILCC_3D.F90
+++ b/Src/Base/AMReX_FILCC_3D.F90
@@ -1,3 +1,4 @@
+#include <AMReX_Config.H>
 
 #ifndef AMREX_XSDK
 

--- a/Src/Base/AMReX_acc_mod.F90
+++ b/Src/Base/AMReX_acc_mod.F90
@@ -1,3 +1,4 @@
+#include <AMReX_Config.H>
 
 module amrex_acc_module
 

--- a/Src/Base/AMReX_filcc_mod.F90
+++ b/Src/Base/AMReX_filcc_mod.F90
@@ -1,3 +1,4 @@
+#include <AMReX_Config.H>
 
 module amrex_filcc_module
 

--- a/Src/Base/AMReX_fort_mod.F90
+++ b/Src/Base/AMReX_fort_mod.F90
@@ -1,3 +1,5 @@
+#include <AMReX_Config.H>
+
 module amrex_fort_module
 
   use iso_c_binding, only : c_char, c_short, c_int, c_long, c_long_long, c_float, c_double, c_size_t, c_ptr
@@ -7,7 +9,7 @@ module amrex_fort_module
   integer, parameter ::    bl_spacedim = AMREX_SPACEDIM
   integer, parameter :: amrex_spacedim = AMREX_SPACEDIM
 
-#ifdef BL_USE_FLOAT
+#ifdef AMREX_USE_FLOAT
   integer, parameter :: amrex_real = c_float
   ! We could/should use Fortran 2008 c_sizeof here.
   integer (kind=c_size_t), parameter :: amrex_real_size = 4_c_size_t

--- a/Src/Base/AMReX_omp_mod.F90
+++ b/Src/Base/AMReX_omp_mod.F90
@@ -1,14 +1,12 @@
-#ifdef BL_USE_OMP
+#include <AMReX_Config.H>
+
+#ifdef AMREX_USE_OMP
 
 module amrex_omp_module
 
   implicit none
 
-#ifdef AMREX_USE_OMP
   integer, parameter :: amrex_omp_support = (_OPENMP)
-#else
-  integer, parameter :: amrex_omp_support = 0 ! Should this be allowed??
-#endif
 
   integer, external :: omp_get_num_threads
   integer, external :: omp_get_max_threads

--- a/Src/Boundary/AMReX_LO_UTIL.F90
+++ b/Src/Boundary/AMReX_LO_UTIL.F90
@@ -37,7 +37,7 @@ contains
             num = num*(xInt - x(i))
             den = den*(x(j) - x(i))
          end do
-#ifdef AMREX_DEBUG
+#if 0
          if (den .eq. zero) STOP 'polyInterpCoeff::invalid data'
 #endif
          c(j) = num/den

--- a/Src/EB/AMReX_ebcellflag_mod.F90
+++ b/Src/EB/AMReX_ebcellflag_mod.F90
@@ -1,3 +1,4 @@
+#include <AMReX_Config.H>
 
 module amrex_ebcellflag_module
   use amrex_fort_module, only : amrex_real

--- a/Src/F_Interfaces/AmrCore/AMReX_fillpatch_mod.F90
+++ b/Src/F_Interfaces/AmrCore/AMReX_fillpatch_mod.F90
@@ -1,3 +1,4 @@
+#include <AMReX_Config.H>
 
 module amrex_fillpatch_module
 

--- a/Src/F_Interfaces/Base/AMReX_fab_mod.F90
+++ b/Src/F_Interfaces/Base/AMReX_fab_mod.F90
@@ -1,3 +1,4 @@
+#include <AMReX_Config.H>
 
 module amrex_fab_module
 

--- a/Src/F_Interfaces/Base/AMReX_parallel_mod.F90
+++ b/Src/F_Interfaces/Base/AMReX_parallel_mod.F90
@@ -1,7 +1,9 @@
+#include <AMReX_Config.H>
+
 module amrex_parallel_module
 
   use iso_c_binding
-#ifdef BL_USE_MPI
+#ifdef AMREX_USE_MPI
   use amrex_fi_mpi
   use amrex_mpi_reduce_int_module, only : amrex_mpi_reduce_int, amrex_mpi_allreduce_int
   use amrex_mpi_reduce_real_module, only : amrex_mpi_reduce_real, amrex_mpi_allreduce_real
@@ -24,7 +26,7 @@ module amrex_parallel_module
   public :: amrex_parallel_reduce_max
   public :: amrex_parallel_reduce_min
 
-#ifdef BL_USE_MPI
+#ifdef AMREX_USE_MPI
   integer, public :: amrex_mpi_real = MPI_DATATYPE_NULL
   integer :: m_nprocs = -1
   integer :: m_myproc = -1
@@ -62,7 +64,7 @@ contains
 
   subroutine amrex_parallel_init (comm)
     integer, intent(in), optional :: comm
-#ifdef BL_USE_MPI
+#ifdef AMREX_USE_MPI
     integer :: ierr
     logical :: flag
     call MPI_Initialized(flag, ierr)
@@ -99,7 +101,7 @@ contains
   end subroutine amrex_parallel_init
 
   subroutine amrex_parallel_finalize ()
-#ifdef BL_USE_MPI
+#ifdef AMREX_USE_MPI
     integer :: ierr
     call MPI_Comm_Free(m_comm, ierr)
     m_comm = MPI_COMM_NULL
@@ -131,7 +133,7 @@ contains
   subroutine amrex_parallel_reduce_sum_is (i, rank)
     integer, intent(inout) :: i
     integer, intent(in), optional :: rank
-#ifdef BL_USE_MPI
+#ifdef AMREX_USE_MPI
     integer :: tmp, ierr
     tmp = i
     if (present(rank)) then
@@ -146,7 +148,7 @@ contains
     integer, intent(inout) :: i(*)
     integer, intent(in) :: n
     integer, intent(in), optional :: rank
-#ifdef BL_USE_MPI
+#ifdef AMREX_USE_MPI
     integer :: tmp(n), ierr
     tmp = i(1:n)
     if (present(rank)) then
@@ -160,7 +162,7 @@ contains
   subroutine amrex_parallel_reduce_sum_rs (r, rank)
     real(amrex_real), intent(inout) :: r
     integer, intent(in), optional :: rank
-#ifdef BL_USE_MPI
+#ifdef AMREX_USE_MPI
     real(amrex_real) :: tmp
     integer :: ierr
     tmp = r
@@ -176,7 +178,7 @@ contains
     real(amrex_real), intent(inout) :: r(*)
     integer, intent(in) :: n
     integer, intent(in), optional :: rank
-#ifdef BL_USE_MPI
+#ifdef AMREX_USE_MPI
     real(amrex_real) :: tmp(n)
     integer :: ierr
     tmp = r(1:n)
@@ -191,7 +193,7 @@ contains
   subroutine amrex_parallel_reduce_max_is (i, rank)
     integer, intent(inout) :: i
     integer, intent(in), optional :: rank
-#ifdef BL_USE_MPI
+#ifdef AMREX_USE_MPI
     integer :: tmp, ierr
     tmp = i
     if (present(rank)) then
@@ -206,7 +208,7 @@ contains
     integer, intent(inout) :: i(*)
     integer, intent(in) :: n
     integer, intent(in), optional :: rank
-#ifdef BL_USE_MPI
+#ifdef AMREX_USE_MPI
     integer :: tmp(n), ierr
     tmp = i(1:n)
     if (present(rank)) then
@@ -220,7 +222,7 @@ contains
   subroutine amrex_parallel_reduce_max_rs (r, rank)
     real(amrex_real), intent(inout) :: r
     integer, intent(in), optional :: rank
-#ifdef BL_USE_MPI
+#ifdef AMREX_USE_MPI
     real(amrex_real) :: tmp
     integer :: ierr
     tmp = r
@@ -236,7 +238,7 @@ contains
     real(amrex_real), intent(inout) :: r(*)
     integer, intent(in) :: n
     integer, intent(in), optional :: rank
-#ifdef BL_USE_MPI
+#ifdef AMREX_USE_MPI
     real(amrex_real) :: tmp(n)
     integer :: ierr
     tmp = r(1:n)
@@ -251,7 +253,7 @@ contains
   subroutine amrex_parallel_reduce_min_is (i, rank)
     integer, intent(inout) :: i
     integer, intent(in), optional :: rank
-#ifdef BL_USE_MPI
+#ifdef AMREX_USE_MPI
     integer :: tmp, ierr
     tmp = i
     if (present(rank)) then
@@ -266,7 +268,7 @@ contains
     integer, intent(inout) :: i(*)
     integer, intent(in) :: n
     integer, intent(in), optional :: rank
-#ifdef BL_USE_MPI
+#ifdef AMREX_USE_MPI
     integer :: tmp(n), ierr
     tmp = i(1:n)
     if (present(rank)) then
@@ -280,7 +282,7 @@ contains
   subroutine amrex_parallel_reduce_min_rs (r, rank)
     real(amrex_real), intent(inout) :: r
     integer, intent(in), optional :: rank
-#ifdef BL_USE_MPI
+#ifdef AMREX_USE_MPI
     real(amrex_real) :: tmp
     integer :: ierr
     tmp = r
@@ -296,7 +298,7 @@ contains
     real(amrex_real), intent(inout) :: r(*)
     integer, intent(in) :: n
     integer, intent(in), optional :: rank
-#ifdef BL_USE_MPI
+#ifdef AMREX_USE_MPI
     real(amrex_real) :: tmp(n)
     integer :: ierr
     tmp = r(1:n)

--- a/Src/F_Interfaces/Particle/AMReX_particlecontainer_mod.F90
+++ b/Src/F_Interfaces/Particle/AMReX_particlecontainer_mod.F90
@@ -16,8 +16,8 @@ module amrex_particlecontainer_module
   public :: amrex_get_particle_cpu, amrex_set_particle_cpu
 
   type, bind(C), public :: amrex_particle
-     real(amrex_particle_real)    :: pos(AMREX_SPACEDIM) !< Position
-     real(amrex_particle_real)    :: vel(AMREX_SPACEDIM) !< Particle velocity
+     real(amrex_particle_real)    :: pos(amrex_spacedim) !< Position
+     real(amrex_particle_real)    :: vel(amrex_spacedim) !< Particle velocity
      integer(c_int), private      :: id
      integer(c_int), private      :: cpu
   end type amrex_particle

--- a/Src/LinearSolvers/MLMG/AMReX_MLLinOp_nd.F90
+++ b/Src/LinearSolvers/MLMG/AMReX_MLLinOp_nd.F90
@@ -1,3 +1,4 @@
+#include <AMReX_Config.H>
 
 module amrex_mllinop_nd_module
 

--- a/Tests/FortranInterface/Advection_F/Source/compute_dt_mod.F90
+++ b/Tests/FortranInterface/Advection_F/Source/compute_dt_mod.F90
@@ -1,3 +1,5 @@
+#include <AMReX_Config.H>
+
 module compute_dt_module
 
   use amrex_amr_module

--- a/Tests/FortranInterface/Advection_F/Source/evolve_mod.F90
+++ b/Tests/FortranInterface/Advection_F/Source/evolve_mod.F90
@@ -1,3 +1,5 @@
+#include <AMReX_Config.H>
+
 module evolve_module
 
   use amrex_amr_module

--- a/Tests/FortranInterface/Advection_octree_F/Source/compute_dt_mod.F90
+++ b/Tests/FortranInterface/Advection_octree_F/Source/compute_dt_mod.F90
@@ -1,3 +1,5 @@
+#include <AMReX_Config.H>
+
 module compute_dt_module
 
   use amrex_amr_module

--- a/Tests/FortranInterface/Advection_octree_F/Source/evolve_mod.F90
+++ b/Tests/FortranInterface/Advection_octree_F/Source/evolve_mod.F90
@@ -1,3 +1,5 @@
+#include <AMReX_Config.H>
+
 module evolve_module
 
   use amrex_amr_module

--- a/Tools/CMake/AMReXSetDefines.cmake
+++ b/Tools/CMake/AMReXSetDefines.cmake
@@ -70,22 +70,13 @@ add_amrex_define( AMREX_USE_ASSERTION NO_LEGACY IF AMReX_ASSERTIONS )
 # Bound checking
 add_amrex_define( AMREX_BOUND_CHECK NO_LEGACY IF AMReX_BOUND_CHECK )
 
-#
-# Fortran-specific defines: BL_LANG_FORT and AMREX_LANG_FORT
-#
 if (AMReX_FORTRAN)
 
-   # These defines are needed only by AMReX source files
+   # Fortran-specific defines, BL_LANG_FORT and AMREX_LANG_FORT do not get
+   # stored in AMReX_Config.H
    target_compile_definitions( amrex PRIVATE
-      $<$<COMPILE_LANGUAGE:Fortran>:AMREX_SPACEDIM=${AMReX_SPACEDIM}>
       $<$<COMPILE_LANGUAGE:Fortran>:BL_LANG_FORT AMREX_LANG_FORT>
       )
-
-    if (AMReX_MPI)
-      target_compile_definitions( amrex PRIVATE
-        $<$<COMPILE_LANGUAGE:Fortran>:BL_USE_MPI>
-        )
-    endif()
 
    #
    # Fortran/C mangling scheme


### PR DESCRIPTION
Include AMReX_Config.H in Fortran files that need preprocessing.  Do not
pass those definitions already defined in AMReX_Config.H to the Fortran
compiler in the cmake build.  This fixes the warnings about redefined macros.

Fix #2071

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
