### PR TITLE
 Use device warp size instead of defaulting to 32

### DIFF
--- a/Src/Base/AMReX_GpuDevice.cpp
+++ b/Src/Base/AMReX_GpuDevice.cpp
@@ -905,7 +905,7 @@ Device::grid_stride_threads_and_blocks (dim3& numBlocks, dim3& numThreads) noexc
 {
     int num_SMs = device_prop.multiProcessorCount;
 
-    int SM_mult_factor = 32;
+    int SM_mult_factor = device_prop.warp_size;
 
     if (num_SMs > 0) {
 

--- a/Src/Base/AMReX_GpuDevice.cpp
+++ b/Src/Base/AMReX_GpuDevice.cpp
@@ -905,7 +905,7 @@ Device::grid_stride_threads_and_blocks (dim3& numBlocks, dim3& numThreads) noexc
 {
     int num_SMs = device_prop.multiProcessorCount;
 
-    int SM_mult_factor = device_prop.warp_size;
+    int SM_mult_factor = device_prop.warpSize;
 
     if (num_SMs > 0) {
 


### PR DESCRIPTION
## Summary

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
