### PR TITLE
Fix indexes bug for particles output in GPU version of packIOData

### DIFF
--- a/Src/Particle/AMReX_WriteBinaryParticleData.H
+++ b/Src/Particle/AMReX_WriteBinaryParticleData.H
@@ -199,19 +199,25 @@ packIOData (Vector<int>& idata, Vector<ParticleReal>& rdata, const PC& pc, int l
                 std::size_t iout_index = (pindex+poffset)*iChunkSize;
                 idata_d_ptr[iout_index] = p.id();
                 idata_d_ptr[iout_index+1] = p.cpu();
+                iout_index += 2;
 
                 std::size_t rout_index = (pindex+poffset)*rChunkSize;
-                for (int j = 0; j < AMREX_SPACEDIM; j++) rdata_d_ptr[rout_index+j] = p.pos(j);
+                for (int j = 0; j < AMREX_SPACEDIM; j++) {
+                  rdata_d_ptr[rout_index] = p.pos(j);
+                  rout_index++;
+                }
 
                 for (int j = 0; j < PC::SuperParticleType::NInt; j++) {
                     if (write_int_comp_d_ptr[j]) {
-                        idata_d_ptr[iout_index+2+j] = p.idata(j);
+                        idata_d_ptr[iout_index] = p.idata(j);
+                        iout_index++;
                     }
                 }
 
                 for (int j = 0; j < PC::SuperParticleType::NReal; j++) {
                     if (write_real_comp_d_ptr[j]) {
-                        rdata_d_ptr[rout_index+AMREX_SPACEDIM+j] = p.rdata(j);
+                        rdata_d_ptr[rout_index] = p.rdata(j);
+                        rout_index++;
                     }
                 }
             }


### PR DESCRIPTION
## Summary
This PR seems to fix an indexing issue in packIOData for GPU runs. The issue should actually produce illegal memory access (out of boundary) on idata_d_ptr and rdata_d_ptr.

## Additional background

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
