### PR TITLE
Add link to "Building with CMake" page in INSTALL file

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -17,5 +17,5 @@ There are three ways to use AMReX.
     `Tools/GNUMake/`.  See `Tools/GNUMake/README.md` for more details
     on the make system.
 
-(3) CMake.
+(3) CMake. See [this page](https://amrex-codes.github.io/amrex/docs_html/BuildingAMReX.html#building-with-cmake) in the AMReX documentation for more details.
 

--- a/INSTALL
+++ b/INSTALL
@@ -17,5 +17,7 @@ There are three ways to use AMReX.
     `Tools/GNUMake/`.  See `Tools/GNUMake/README.md` for more details
     on the make system.
 
-(3) CMake. See [this page](https://amrex-codes.github.io/amrex/docs_html/BuildingAMReX.html#building-with-cmake) in the AMReX documentation for more details.
+(3) CMake. See the "Building with CMake" page in the AMReX documentation
+    page at the link below for more details.
+    https://amrex-codes.github.io/amrex/docs_html/BuildingAMReX.html#building-with-cmake
 


### PR DESCRIPTION
## Summary
Add a link to "Building with CMake" page in the AMReX documentation web page into the INSTALL file.

## Additional background
I think it is useful for people who want to build AMReX to have the link handy, and it's more descriptive than simply listing CMake as a possible way to build AMReX.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [x] are described in the proposed changes to the AMReX documentation, if appropriate
