### PR TITLE
CMake 3.20+ CUDA: Shell-Escape --Werror

### DIFF
--- a/Tools/CMake/AMReXParallelBackends.cmake
+++ b/Tools/CMake/AMReXParallelBackends.cmake
@@ -110,13 +110,13 @@ if (  AMReX_GPU_BACKEND STREQUAL "CUDA"
    # keep intermediately generated files
    if (AMReX_CUDA_KEEP_FILES)
       make_directory("${PROJECT_BINARY_DIR}/nvcc_tmp")
-      list(APPEND _cuda_flags --keep --keep-dir ${PROJECT_BINARY_DIR}/nvcc_tmp)
+      list(APPEND _cuda_flags --keep "SHELL:--keep-dir ${PROJECT_BINARY_DIR}/nvcc_tmp")
    endif ()
 
    # compilation timings
    if (AMReX_CUDA_COMPILATION_TIMER)
       file(REMOVE "${PROJECT_BINARY_DIR}/nvcc_timings.csv")
-      list(APPEND _cuda_flags --time ${PROJECT_BINARY_DIR}/nvcc_timings.csv)
+      list(APPEND _cuda_flags "SHELL:--time ${PROJECT_BINARY_DIR}/nvcc_timings.csv")
    endif ()
 
    #
@@ -146,7 +146,7 @@ if (  AMReX_GPU_BACKEND STREQUAL "CUDA"
    # Flags to make it an error to write a device variable in
    # a host function.
    if (CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL 11.2)
-      list(APPEND _cuda_flag --display-error-number --diag-error 20092)
+      list(APPEND _cuda_flag --display-error-number "SHELL:--diag-error 20092")
    endif ()
 
    target_compile_options( amrex PUBLIC $<${_genex}:${_cuda_flags}> )

--- a/Tools/CMake/AMReXParallelBackends.cmake
+++ b/Tools/CMake/AMReXParallelBackends.cmake
@@ -87,10 +87,10 @@ if (  AMReX_GPU_BACKEND STREQUAL "CUDA"
    if (AMReX_CUDA_ERROR_CAPTURE_THIS)
       # note: prefer double-dash --Werror!
       # https://github.com/ccache/ccache/issues/598
-      list(APPEND _cuda_flags --Werror ext-lambda-captures-this)
+      list(APPEND _cuda_flags "SHELL:--Werror ext-lambda-captures-this")
    endif()
    if (AMReX_CUDA_ERROR_CROSS_EXECUTION_SPACE_CALL)
-      list(APPEND _cuda_flags --Werror cross-execution-space-call)
+      list(APPEND _cuda_flags "SHELL:--Werror cross-execution-space-call")
    endif()
 
    #


### PR DESCRIPTION
## Summary

When adding a list of flags to CMake targets, duplicated flags get by default deduplicated. This caused with our new CMake 3.20+ CUDA logic #2012 that this gets passed to the linker: `--Werror ext-lambda-captures-this cross-execution-space-call`.

The CMake `SHELL:` prefix is exactly made for this instance, keeping flags that belong together also over transformations like this together: https://cmake.org/cmake/help/latest/command/target_compile_options.html#arguments

Since we injected directly into the global `CMAKE_CUDA_FLAGS` flags for earlier CMake versions, this deduplication logic does not apply and thus we have not experienced it earlier.

## Additional background

Seen first with CI in AMReX Tutorials (e.g. https://github.com/AMReX-Codes/amrex-tutorials/pull/12).

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
