### PR TITLE
CMake 3.20+ CUDA: Fast Math

### DIFF
--- a/Tools/CMake/AMReXParallelBackends.cmake
+++ b/Tools/CMake/AMReXParallelBackends.cmake
@@ -100,6 +100,11 @@ if (  AMReX_GPU_BACKEND STREQUAL "CUDA"
       list(APPEND _cuda_flags --forward-unknown-to-host-compiler)
    endif()
 
+   # fast math
+   if (AMReX_CUDA_FASTMATH)
+      list(APPEND _cuda_flags --use_fast_math)
+   endif ()
+
    #
    # Code generation
    #


### PR DESCRIPTION
## Summary

Honor CUDA fast math option `AMReX_CUDA_FASTMATH` (default: ON) in
modernized CUDA CMake logic.

## Additional background

- Regression of #2012
- Related to #1769

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
