### PR TITLE
CI: Split Linux Workflows

### DIFF
--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -1,0 +1,82 @@
+name: cuda
+
+on: [push, pull_request]
+
+jobs:
+  # Build libamrex and all tests with CUDA 9.2
+  tests-cuda9:
+    name: CUDA@9.2 GNU@6.5.0 C++14 Release [tests]
+    runs-on: ubuntu-18.04
+    env: {CXXFLAGS: "-fno-operator-names"}
+    steps:
+    - uses: actions/checkout@v2
+    - name: Dependencies
+      run: .github/workflows/dependencies/dependencies_nvcc9.sh
+    - name: Build & Install
+      run: |
+        export PATH=/usr/local/nvidia/bin:/usr/local/cuda/bin:${PATH}
+        export LD_LIBRARY_PATH=/usr/local/nvidia/lib:/usr/local/nvidia/lib64:/usr/local/cuda/lib64:${LD_LIBRARY_PATH}
+        which nvcc || echo "nvcc not in PATH!"
+        mkdir build
+        cd build
+        cmake ..                                           \
+            -DCMAKE_VERBOSE_MAKEFILE=ON                    \
+            -DAMReX_ENABLE_TESTS=ON                        \
+            -DAMReX_FORTRAN=OFF                            \
+            -DAMReX_PARTICLES=ON                           \
+            -DAMReX_GPU_BACKEND=CUDA                       \
+            -DCMAKE_C_COMPILER=$(which gcc-6)              \
+            -DCMAKE_CXX_COMPILER=$(which g++-6)            \
+            -DCMAKE_CUDA_HOST_COMPILER=$(which g++-6)      \
+            -DCMAKE_Fortran_COMPILER=$(which gfortran-6)   \
+            -DAMReX_CUDA_ARCH=6.0 \
+            -DAMReX_CUDA_ERROR_CROSS_EXECUTION_SPACE_CALL=ON
+        make -j 2
+
+  # Build libamrex and all tests with CUDA 11.0.2 (recent supported)
+  tests-cuda11:
+    name: CUDA@11.2 GNU@9.3.0 C++17 Release [tests]
+    runs-on: ubuntu-20.04
+    env: {CXXFLAGS: "-fno-operator-names"}
+    steps:
+    - uses: actions/checkout@v2
+    - name: Dependencies
+      run: .github/workflows/dependencies/dependencies_nvcc11.sh
+    - name: Build & Install
+      run: |
+        export PATH=/usr/local/nvidia/bin:/usr/local/cuda/bin:${PATH}
+        export LD_LIBRARY_PATH=/usr/local/nvidia/lib:/usr/local/nvidia/lib64:/usr/local/cuda/lib64:${LD_LIBRARY_PATH}
+        which nvcc || echo "nvcc not in PATH!"
+
+        cmake -S . -B build                              \
+            -DCMAKE_VERBOSE_MAKEFILE=ON                  \
+            -DAMReX_ENABLE_TESTS=ON                      \
+            -DAMReX_FORTRAN=OFF                          \
+            -DAMReX_PARTICLES=ON                         \
+            -DAMReX_GPU_BACKEND=CUDA                     \
+            -DCMAKE_C_COMPILER=$(which gcc)              \
+            -DCMAKE_CXX_COMPILER=$(which g++)            \
+            -DCMAKE_CUDA_HOST_COMPILER=$(which g++)      \
+            -DCMAKE_Fortran_COMPILER=$(which gfortran)   \
+            -DCMAKE_CUDA_STANDARD=17                     \
+            -DCMAKE_CXX_STANDARD=17                      \
+            -DAMReX_CUDA_ARCH=8.0                        \
+            -DAMReX_CUDA_ERROR_CROSS_EXECUTION_SPACE_CALL=ON \
+            -DAMReX_CUDA_ERROR_CAPTURE_THIS=ON
+
+        cmake --build build -j 2
+
+  # Build 3D libamrex cuda build with configure
+  configure-3d-cuda:
+    name: CUDA@11.2 GNU@9.3.0 [configure 3D]
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v2
+    - name: Dependencies
+      run: .github/workflows/dependencies/dependencies_nvcc11.sh
+    - name: Build & Install
+      run: |
+        export PATH=/usr/local/nvidia/bin:/usr/local/cuda/bin:${PATH}
+        ./configure --dim 3 --with-cuda yes --enable-eb yes --enable-xsdk-defaults yes --with-fortran no
+        make -j2 WARN_ALL=TRUE WARN_ERROR=TRUE XTRA_CXXFLAGS=-fno-operator-names CXXSTD=c++17
+        make install

--- a/.github/workflows/hip.yml
+++ b/.github/workflows/hip.yml
@@ -1,0 +1,58 @@
+name: hip
+
+on: [push, pull_request]
+
+jobs:
+  # MPI_C is broken since HIP 4.1
+  # https://gitlab.kitware.com/cmake/cmake/-/issues/21968
+  # https://github.com/ROCm-Developer-Tools/HIP/issues/2246
+  tests-hip:
+    name: HIP ROCm GFortran@9.3 C++17 [tests]
+    runs-on: ubuntu-20.04
+    env: {CXXFLAGS: "-fno-operator-names"}
+    steps:
+    - uses: actions/checkout@v2
+    - name: Dependencies
+      run: .github/workflows/dependencies/dependencies_hip.sh
+    - name: Build & Install
+      run: |
+        source /etc/profile.d/rocm.sh
+        hipcc --version
+        cmake -S . -B build_full                          \
+            -DCMAKE_VERBOSE_MAKEFILE=ON                   \
+            -DAMReX_ENABLE_TESTS=ON                       \
+            -DAMReX_PARTICLES=ON                          \
+            -DAMReX_FORTRAN=ON                            \
+            -DAMReX_LINEAR_SOLVERS=ON                     \
+            -DAMReX_GPU_BACKEND=HIP                       \
+            -DAMReX_AMD_ARCH=gfx908                       \
+            -DCMAKE_C_COMPILER=$(which clang)             \
+            -DCMAKE_CXX_COMPILER=$(which hipcc)           \
+            -DCMAKE_Fortran_COMPILER=$(which gfortran)
+        cmake --build build_full -j 2
+        cmake -S . -B build_nofortran                     \
+            -DCMAKE_VERBOSE_MAKEFILE=ON                   \
+            -DAMReX_ENABLE_TESTS=ON                       \
+            -DAMReX_PARTICLES=ON                          \
+            -DAMReX_FORTRAN=OFF                           \
+            -DAMReX_LINEAR_SOLVERS=ON                     \
+            -DAMReX_GPU_BACKEND=HIP                       \
+            -DAMReX_AMD_ARCH=gfx908                       \
+            -DCMAKE_C_COMPILER=$(which clang)             \
+            -DCMAKE_CXX_COMPILER=$(which hipcc)           \
+            -DCMAKE_Fortran_COMPILER=$(which gfortran)
+        cmake --build build_nofortran -j 2
+
+  # Build 2D libamrex hip build with configure
+  configure-2d-single-hip:
+    name: HIP EB [configure 2D]
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v2
+    - name: Dependencies
+      run: .github/workflows/dependencies/dependencies_hip.sh
+    - name: Build & Install
+      run: |
+        ./configure --dim 2 --with-hip yes --enable-eb yes --enable-xsdk-defaults yes --with-mpi no --with-omp no --single-precision yes --single-precision-particles yes
+        make -j2 WARN_ALL=TRUE XTRA_CXXFLAGS="-fno-operator-names -Wno-c++17-extensions"
+        make install

--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -1,0 +1,34 @@
+name: intel
+
+on: [push, pull_request]
+
+jobs:
+  tests-dpcpp:
+    name: DPCPP GFortran@7.5 C++17 [tests]
+    runs-on: ubuntu-20.04
+    env: {CXXFLAGS: "-fno-operator-names"}
+    steps:
+    - uses: actions/checkout@v2
+    - name: Dependencies
+      run: .github/workflows/dependencies/dependencies_dpcpp.sh
+    - name: Build & Install
+      run: |
+        set +e
+        source /opt/intel/oneapi/setvars.sh
+        set -e
+        cmake -S . -B build                                \
+            -DCMAKE_CXX_COMPILER_ID="Clang"                \
+            -DCMAKE_CXX_COMPILER_VERSION=12.0              \
+            -DCMAKE_CXX_STANDARD_COMPUTED_DEFAULT="17"     \
+            -DCMAKE_VERBOSE_MAKEFILE=ON                    \
+            -DAMReX_ENABLE_TESTS=ON                        \
+            -DAMReX_FORTRAN=OFF                            \
+            -DAMReX_PARTICLES=ON                           \
+            -DAMReX_GPU_BACKEND=SYCL                       \
+            -DCMAKE_C_COMPILER=$(which clang)              \
+            -DCMAKE_CXX_COMPILER=$(which dpcpp)            \
+            -DCMAKE_Fortran_COMPILER=$(which gfortran)
+        cmake --build build --parallel 2
+    # note: setting the CXX compiler ID is a work-around for
+    # the 2021.1 DPC++ release / CMake 3.19.0-3.19.1
+    # https://gitlab.kitware.com/cmake/cmake/-/issues/21551#note_869580

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -180,139 +180,6 @@ jobs:
             -DAMReX_FORTRAN=OFF
         make -j 2
 
-  # Build libamrex and all tests with CUDA 9.2
-  tests-cuda9:
-    name: CUDA@9.2 GNU@6.5.0 C++14 Release [tests]
-    runs-on: ubuntu-18.04
-    env: {CXXFLAGS: "-fno-operator-names"}
-    steps:
-    - uses: actions/checkout@v2
-    - name: Dependencies
-      run: .github/workflows/dependencies/dependencies_nvcc9.sh
-    - name: Build & Install
-      run: |
-        export PATH=/usr/local/nvidia/bin:/usr/local/cuda/bin:${PATH}
-        export LD_LIBRARY_PATH=/usr/local/nvidia/lib:/usr/local/nvidia/lib64:/usr/local/cuda/lib64:${LD_LIBRARY_PATH}
-        which nvcc || echo "nvcc not in PATH!"
-        mkdir build
-        cd build
-        cmake ..                                           \
-            -DCMAKE_VERBOSE_MAKEFILE=ON                    \
-            -DAMReX_ENABLE_TESTS=ON                        \
-            -DAMReX_FORTRAN=OFF                            \
-            -DAMReX_PARTICLES=ON                           \
-            -DAMReX_GPU_BACKEND=CUDA                       \
-            -DCMAKE_C_COMPILER=$(which gcc-6)              \
-            -DCMAKE_CXX_COMPILER=$(which g++-6)            \
-            -DCMAKE_CUDA_HOST_COMPILER=$(which g++-6)      \
-            -DCMAKE_Fortran_COMPILER=$(which gfortran-6)   \
-            -DAMReX_CUDA_ARCH=6.0 \
-            -DAMReX_CUDA_ERROR_CROSS_EXECUTION_SPACE_CALL=ON
-        make -j 2
-
-  # Build libamrex and all tests with CUDA 11.0.2 (recent supported)
-  tests-cuda11:
-    name: CUDA@11.2 GNU@9.3.0 C++17 Release [tests]
-    runs-on: ubuntu-20.04
-    env: {CXXFLAGS: "-fno-operator-names"}
-    steps:
-    - uses: actions/checkout@v2
-    - name: Dependencies
-      run: .github/workflows/dependencies/dependencies_nvcc11.sh
-    - name: Build & Install
-      run: |
-        export PATH=/usr/local/nvidia/bin:/usr/local/cuda/bin:${PATH}
-        export LD_LIBRARY_PATH=/usr/local/nvidia/lib:/usr/local/nvidia/lib64:/usr/local/cuda/lib64:${LD_LIBRARY_PATH}
-        which nvcc || echo "nvcc not in PATH!"
-
-        cmake -S . -B build                              \
-            -DCMAKE_VERBOSE_MAKEFILE=ON                  \
-            -DAMReX_ENABLE_TESTS=ON                      \
-            -DAMReX_FORTRAN=OFF                          \
-            -DAMReX_PARTICLES=ON                         \
-            -DAMReX_GPU_BACKEND=CUDA                     \
-            -DCMAKE_C_COMPILER=$(which gcc)              \
-            -DCMAKE_CXX_COMPILER=$(which g++)            \
-            -DCMAKE_CUDA_HOST_COMPILER=$(which g++)      \
-            -DCMAKE_Fortran_COMPILER=$(which gfortran)   \
-            -DCMAKE_CUDA_STANDARD=17                     \
-            -DCMAKE_CXX_STANDARD=17                      \
-            -DAMReX_CUDA_ARCH=8.0                        \
-            -DAMReX_CUDA_ERROR_CROSS_EXECUTION_SPACE_CALL=ON \
-            -DAMReX_CUDA_ERROR_CAPTURE_THIS=ON
-
-        cmake --build build -j 2
-
-  tests-dpcpp:
-    name: DPCPP GFortran@7.5 C++17 [tests]
-    runs-on: ubuntu-20.04
-    env: {CXXFLAGS: "-fno-operator-names"}
-    steps:
-    - uses: actions/checkout@v2
-    - name: Dependencies
-      run: .github/workflows/dependencies/dependencies_dpcpp.sh
-    - name: Build & Install
-      run: |
-        set +e
-        source /opt/intel/oneapi/setvars.sh
-        set -e
-        cmake -S . -B build                                \
-            -DCMAKE_CXX_COMPILER_ID="Clang"                \
-            -DCMAKE_CXX_COMPILER_VERSION=12.0              \
-            -DCMAKE_CXX_STANDARD_COMPUTED_DEFAULT="17"     \
-            -DCMAKE_VERBOSE_MAKEFILE=ON                    \
-            -DAMReX_ENABLE_TESTS=ON                        \
-            -DAMReX_FORTRAN=OFF                            \
-            -DAMReX_PARTICLES=ON                           \
-            -DAMReX_GPU_BACKEND=SYCL                       \
-            -DCMAKE_C_COMPILER=$(which clang)              \
-            -DCMAKE_CXX_COMPILER=$(which dpcpp)            \
-            -DCMAKE_Fortran_COMPILER=$(which gfortran)
-        cmake --build build --parallel 2
-    # note: setting the CXX compiler ID is a work-around for
-    # the 2021.1 DPC++ release / CMake 3.19.0-3.19.1
-    # https://gitlab.kitware.com/cmake/cmake/-/issues/21551#note_869580
-
-  # MPI_C is broken since HIP 4.1
-  # https://gitlab.kitware.com/cmake/cmake/-/issues/21968
-  # https://github.com/ROCm-Developer-Tools/HIP/issues/2246
-  tests-hip:
-    name: HIP ROCm GFortran@9.3 C++17 [tests]
-    runs-on: ubuntu-20.04
-    env: {CXXFLAGS: "-fno-operator-names"}
-    steps:
-    - uses: actions/checkout@v2
-    - name: Dependencies
-      run: .github/workflows/dependencies/dependencies_hip.sh
-    - name: Build & Install
-      run: |
-        source /etc/profile.d/rocm.sh
-        hipcc --version
-        cmake -S . -B build_full                          \
-            -DCMAKE_VERBOSE_MAKEFILE=ON                   \
-            -DAMReX_ENABLE_TESTS=ON                       \
-            -DAMReX_PARTICLES=ON                          \
-            -DAMReX_FORTRAN=ON                            \
-            -DAMReX_LINEAR_SOLVERS=ON                     \
-            -DAMReX_GPU_BACKEND=HIP                       \
-            -DAMReX_AMD_ARCH=gfx908                       \
-            -DCMAKE_C_COMPILER=$(which clang)             \
-            -DCMAKE_CXX_COMPILER=$(which hipcc)           \
-            -DCMAKE_Fortran_COMPILER=$(which gfortran)
-        cmake --build build_full -j 2
-        cmake -S . -B build_nofortran                     \
-            -DCMAKE_VERBOSE_MAKEFILE=ON                   \
-            -DAMReX_ENABLE_TESTS=ON                       \
-            -DAMReX_PARTICLES=ON                          \
-            -DAMReX_FORTRAN=OFF                           \
-            -DAMReX_LINEAR_SOLVERS=ON                     \
-            -DAMReX_GPU_BACKEND=HIP                       \
-            -DAMReX_AMD_ARCH=gfx908                       \
-            -DCMAKE_C_COMPILER=$(which clang)             \
-            -DCMAKE_CXX_COMPILER=$(which hipcc)           \
-            -DCMAKE_Fortran_COMPILER=$(which gfortran)
-        cmake --build build_nofortran -j 2
-
   # Build 1D libamrex with configure
   configure-1d:
     name: GNU@7.5 Release [configure 1D]
@@ -355,21 +222,6 @@ jobs:
         make -j2 WARN_ALL=TRUE WARN_ERROR=TRUE XTRA_CXXFLAGS=-fno-operator-names
         make install
 
-  # Build 3D libamrex cuda build with configure
-  configure-3d-cuda:
-    name: CUDA@11.2 GNU@9.3.0 [configure 3D]
-    runs-on: ubuntu-20.04
-    steps:
-    - uses: actions/checkout@v2
-    - name: Dependencies
-      run: .github/workflows/dependencies/dependencies_nvcc11.sh
-    - name: Build & Install
-      run: |
-        export PATH=/usr/local/nvidia/bin:/usr/local/cuda/bin:${PATH}
-        ./configure --dim 3 --with-cuda yes --enable-eb yes --enable-xsdk-defaults yes --with-fortran no
-        make -j2 WARN_ALL=TRUE WARN_ERROR=TRUE XTRA_CXXFLAGS=-fno-operator-names CXXSTD=c++17
-        make install
-
   # Build 3D libamrex with single precision and tiny profiler
   configure-3d-single-tprof:
     name: GNU@7.5 Release [configure 3D]
@@ -396,20 +248,6 @@ jobs:
       run: |
         ./configure --dim 3 --enable-eb yes --enable-xsdk-defaults yes --with-omp yes --debug yes
         make -j2 WARN_ALL=TRUE WARN_ERROR=TRUE XTRA_CXXFLAGS=-fno-operator-names
-        make install
-
-  # Build 2D libamrex hip build with configure
-  configure-2d-single-hip:
-    name: HIP EB [configure 2D]
-    runs-on: ubuntu-20.04
-    steps:
-    - uses: actions/checkout@v2
-    - name: Dependencies
-      run: .github/workflows/dependencies/dependencies_hip.sh
-    - name: Build & Install
-      run: |
-        ./configure --dim 2 --with-hip yes --enable-eb yes --enable-xsdk-defaults yes --with-mpi no --with-omp no --single-precision yes --single-precision-particles yes
-        make -j2 WARN_ALL=TRUE XTRA_CXXFLAGS="-fno-operator-names -Wno-c++17-extensions"
         make install
 
   # Build Tools/Plotfile


### PR DESCRIPTION
## Summary

Split linux workflows into
- linux (CPU)
- cuda
- intel (DPC++/ICC/ICX)
- hip

workflows.

## Additional background

Individual workflows can be individually restarted, enabled/disabled and this increases order a bit as well.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
