### PR TITLE
Fix missing "class" in forward declaration header

### DIFF
--- a/Src/Base/AMReX_BaseFwd.H
+++ b/Src/Base/AMReX_BaseFwd.H
@@ -5,7 +5,7 @@ namespace amrex {
 
 class MultiFab;
 class iMultiFab;
-template <class FAB> FabArray;
+template <class FAB> class FabArray;
 template <typename T> class LayoutData;
 class FabArrayBase;
 


### PR DESCRIPTION
## Summary

If I am not mistaken, there should be a `class` before `FabArray` in this forward declaration header...

## Additional background

## Checklist

The proposed changes:
- [X] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
