### PR TITLE
GpuArray template parameter

### DIFF
--- a/Src/Base/AMReX_Array.H
+++ b/Src/Base/AMReX_Array.H
@@ -28,7 +28,7 @@ namespace amrex {
 }
 
 namespace amrex {
-    template <class T, std::size_t N>
+    template <class T, unsigned int N>
     struct GpuArray
     {
         using value_type = T;
@@ -47,7 +47,7 @@ namespace amrex {
         T* data () noexcept { return arr; }
 
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-        constexpr std::size_t size() const noexcept { return N; }
+        constexpr unsigned int size() const noexcept { return N; }
 
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         const T* begin() const noexcept { return arr; }
@@ -63,9 +63,9 @@ namespace amrex {
 
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         void fill( const T& value ) noexcept
-        { for (std::size_t i = 0; i < N; ++i) arr[i] = value; }
+        { for (unsigned int i = 0; i < N; ++i) arr[i] = value; }
 
-        T arr[amrex::max(N,std::size_t{1})];
+        T arr[amrex::max(N,1u)];
     };
 }
 

--- a/Src/Base/AMReX_BaseFwd.H
+++ b/Src/Base/AMReX_BaseFwd.H
@@ -14,7 +14,7 @@ class IArrayBox;
 template <class T> class BaseFab;
 template <typename T> struct Array4;
 
-template <class T, std::size_t N> struct GpuArray;
+template <class T, unsigned int N> struct GpuArray;
 
 class BoxArray;
 class BoxList;


### PR DESCRIPTION
Use unsigned int as the type for size instead of std::size_t so that the
forward declaration does not need to include another header.

## Summary

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
