### PR TITLE
Reimplement partitionParticlesByDest

### DIFF
--- a/Src/Particle/AMReX_ParticleUtil.H
+++ b/Src/Particle/AMReX_ParticleUtil.H
@@ -497,14 +497,9 @@ partitionParticlesByDest (PTile& ptile, const PLocator& ploc, const ParticleBuff
                           },
                           [=] AMREX_GPU_DEVICE (int i, int const& s)
                           {
-                              if ( particle_stays(i) )
-                              {
-                                  copyParticle(dst_data, src_data, i + this_offset, s);
-                              }
-                              else
-                              {
-                                  copyParticle(dst_data, src_data, i + this_offset, this_chunk_size-1-(i-s));
-                              }
+                              int src_i = i + this_offset;
+                              int dst_i = particle_stays(i) ? s : this_chunk_size-1-(i-s);
+                              copyParticle(dst_data, src_data, src_i, dst_i);
                           },
                           Scan::Type::exclusive);
         }


### PR DESCRIPTION
Note - I did not see a timing difference when I tested this on either Summit or Spock. However, in principle this could be easier for some compiler to optimize, so let's make this change. 

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
