### PR TITLE
HIP: Increase to C++17

### DIFF
--- a/.github/workflows/hip.yml
+++ b/.github/workflows/hip.yml
@@ -66,5 +66,5 @@ jobs:
     - name: Build & Install
       run: |
         ./configure --dim 2 --with-hip yes --enable-eb yes --enable-xsdk-defaults yes --with-mpi no --with-omp no --single-precision yes --single-precision-particles yes
-        make -j2 WARN_ALL=TRUE XTRA_CXXFLAGS="-fno-operator-names -Wno-c++17-extensions"
+        make -j2 WARN_ALL=TRUE XTRA_CXXFLAGS="-fno-operator-names"
         make install

--- a/Docs/sphinx_documentation/source/BuildingAMReX.rst
+++ b/Docs/sphinx_documentation/source/BuildingAMReX.rst
@@ -117,6 +117,7 @@ MPI with support for concurrent MPI calls from multiple threads.
 Variables ``USE_CUDA``, ``USE_HIP`` and ``USE_DPCPP`` are used for
 targeting Nvidia, AMD and Intel GPUs, respectively.  At most one of
 the three can be TRUE.
+For HIP and DPC++/SYCL builds, we do only test against C++17 builds at the moment.
 
 The variable ``USE_RPATH`` controls the link mechanism to dependent libraries.
 If enabled, the library path at link time will be saved as a
@@ -428,7 +429,7 @@ The list of available options is reported in the :ref:`table <tab:cmakevar>` bel
    +------------------------------+-------------------------------------------------+-------------------------+-----------------------+
    | CMAKE_CXX_FLAGS              |  User-defined C++ flags                         |                         | user-defined          |
    +------------------------------+-------------------------------------------------+-------------------------+-----------------------+
-   | CMAKE_CXX_STANDARD           |  C++ standard                                   | compiler/11             | 11, 14, 17, 20        |
+   | CMAKE_CXX_STANDARD           |  C++ standard                                   | compiler/14             | 14, 17, 20            |
    +------------------------------+-------------------------------------------------+-------------------------+-----------------------+
    | AMReX_SPACEDIM               |  Dimension of AMReX build                       | 3                       | 1, 2, 3               |
    +------------------------------+-------------------------------------------------+-------------------------+-----------------------+

--- a/Tools/CMake/AMReX_Config.cmake
+++ b/Tools/CMake/AMReX_Config.cmake
@@ -42,8 +42,8 @@ function (configure_amrex)
    # Moreover, it will also enforce such standard on all the consuming targets
    #
    set_target_properties(amrex PROPERTIES CXX_EXTENSIONS OFF)
-   # minimum: C++14 on Linux, C++17 on Windows, C++17 for dpc++
-   if (AMReX_DPCPP)
+   # minimum: C++14 on Linux, C++17 on Windows, C++17 for dpc++ and hip
+   if (AMReX_DPCPP OR AMReX_HIP)
       target_compile_features(amrex PUBLIC cxx_std_17)
    else ()
       target_compile_features(amrex PUBLIC $<IF:$<STREQUAL:$<PLATFORM_ID>,Windows>,cxx_std_17,cxx_std_14>)

--- a/Tools/GNUMake/comps/hip.mak
+++ b/Tools/GNUMake/comps/hip.mak
@@ -18,7 +18,7 @@ F90 = gfortran
 ifdef CXXSTD
   CXXSTD := $(strip $(CXXSTD))
 else
-  CXXSTD := c++14
+  CXXSTD := c++17
 endif
 
 # Generic flags, always used


### PR DESCRIPTION
## Summary

Bump HIP requirements to C++17 or newer (like DPC++).
At the moment, we only test against AMD's clang++/hipcc, which supports C++17 anyway.

## Additional background

- https://github.com/AMReX-Codes/amrex/pull/2104#discussion_r650602105
- https://github.com/ROCm-Developer-Tools/HIP/issues/2278

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
