### PR TITLE
Fix warning in algoim

### DIFF
--- a/Src/EB/AMReX_algoim_K.H
+++ b/Src/EB/AMReX_algoim_K.H
@@ -433,6 +433,7 @@ struct ImplicitIntegral
 
     // Main calling engine; parameters with underscores are copied
     // upon entry but modified internally in the ctor
+    template <int K = M, std::enable_if_t<K==1,int> = 0>
     AMREX_GPU_HOST_DEVICE
     ImplicitIntegral (const Phi& phi_, F& f_, const GpuArray<bool,N>& free_,
                       const GpuArray<PsiCode<N>,1 << (N-1)>& psi_,
@@ -442,17 +443,24 @@ struct ImplicitIntegral
     {
         // For the one-dimensional base case, evaluate the
         // bottom-level integral.
-        if (M == 1)
-        {
-            for (int dim = 0; dim < N; ++dim) {
-                if (free[dim]) {
-                    e0 = dim;
-                }
+        for (int dim = 0; dim < N; ++dim) {
+            if (free[dim]) {
+                e0 = dim;
             }
-            evalIntegrand(GpuArray<Real,N>{}, 1.0);
-            return;
         }
+        evalIntegrand(GpuArray<Real,N>{}, 1.0);
+    }
 
+    // Main calling engine; parameters with underscores are copied
+    // upon entry but modified internally in the ctor
+    template <int K = M, std::enable_if_t<(K>1),int> = 0>
+    AMREX_GPU_HOST_DEVICE
+    ImplicitIntegral (const Phi& phi_, F& f_, const GpuArray<bool,N>& free_,
+                      const GpuArray<PsiCode<N>,1 << (N-1)>& psi_,
+                      int psiCount_) noexcept
+        : phi(phi_), f(f_), free(free_), psi(psi_), psiCount(psiCount_),
+          xrange()
+    {
         // Establish interval bounds for prune() and remaining part of ctor.
         for (int dim = 0; dim < N; ++dim)
         {

--- a/Src/LinearSolvers/MLMG/AMReX_MLPoisson.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLPoisson.cpp
@@ -109,6 +109,7 @@ MLPoisson::Fapply (int amrlev, int mglev, MultiFab& out, const MultiFab& in) con
             const auto& osm = m_overset_mask[amrlev][mglev]->const_array(mfi);
             AMREX_HOST_DEVICE_PARALLEL_FOR_3D_FUSIBLE ( bx, i, j, k,
             {
+                amrex::ignore_unused(j,k);
                 mlpoisson_adotx_os(AMREX_D_DECL(i,j,k), yfab, xfab, osm,
                                    AMREX_D_DECL(dhx,dhy,dhz));
             });
@@ -133,11 +134,13 @@ MLPoisson::Fapply (int amrlev, int mglev, MultiFab& out, const MultiFab& in) con
             if (m_has_metric_term) {
                 AMREX_HOST_DEVICE_PARALLEL_FOR_3D_FUSIBLE (bx, i, j, k,
                 {
+                    amrex::ignore_unused(k);
                     mlpoisson_adotx_m(i, j, yfab, xfab, dhx, dhy, dx, probxlo);
                 });
             } else {
                 AMREX_HOST_DEVICE_PARALLEL_FOR_3D_FUSIBLE (bx, i, j, k,
                 {
+                    amrex::ignore_unused(k);
                     mlpoisson_adotx(i, j, yfab, xfab, dhx, dhy);
                 });
             }
@@ -145,11 +148,13 @@ MLPoisson::Fapply (int amrlev, int mglev, MultiFab& out, const MultiFab& in) con
             if (m_has_metric_term) {
                 AMREX_HOST_DEVICE_PARALLEL_FOR_3D_FUSIBLE (bx, i, j, k,
                 {
+                    amrex::ignore_unused(j,k);
                     mlpoisson_adotx_m(i, yfab, xfab, dhx, dx, probxlo);
                 });
             } else {
                 AMREX_HOST_DEVICE_PARALLEL_FOR_3D_FUSIBLE (bx, i, j, k,
                 {
+                    amrex::ignore_unused(j,k);
                     mlpoisson_adotx(i, yfab, xfab, dhx);
                 });
             }

--- a/Tools/GNUMake/Make.defs
+++ b/Tools/GNUMake/Make.defs
@@ -686,10 +686,6 @@ ifeq ($(USE_CUPTI),TRUE)
   endif
 endif
 
-ifeq ($(USE_GPU_RDC),TRUE)
-    DEFINES += -DAMREX_USE_GPU_RDC
-endif
-
 ifeq ($(USE_HIP),TRUE)
 
     USE_GPU := TRUE
@@ -770,6 +766,9 @@ ifeq ($(USE_GPU),TRUE)
     DEFINES += -DAMREX_USE_GPU -DBL_COALESCE_FABS
     ifeq ($(GPU_ERROR_CHECK),FALSE)
         DEFINES += -DAMREX_GPU_NO_ERROR_CHECK
+    endif
+    ifeq ($(USE_GPU_RDC),TRUE)
+        DEFINES += -DAMREX_USE_GPU_RDC
     endif
 endif
 


### PR DESCRIPTION
Split the constructor of ImplicitIntegral into two templates to avoid an
unreachable loop warning.

## Summary

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
