### PR TITLE
Remove incorrect call to coarsen.

### DIFF
--- a/Src/Particle/AMReX_NeighborParticlesI.H
+++ b/Src/Particle/AMReX_NeighborParticlesI.H
@@ -687,7 +687,6 @@ buildNeighborList (CheckPair&& check_pair, bool /*sort*/)
         }
 #endif
 
-        IntVect ref_fac = computeRefFac(0, lev);
               auto& plev = this->GetParticles(lev);
         const auto& geom = this->Geom(lev);
 
@@ -705,7 +704,6 @@ buildNeighborList (CheckPair&& check_pair, bool /*sort*/)
             if (ptile.numParticles() == 0) continue;
 
             Box bx = pti.tilebox();
-            bx.coarsen(ref_fac);
             bx.grow(m_num_neighbor_cells);
 
             m_neighbor_list[lev][index].build(ptile, bx, geom,


### PR DESCRIPTION
This call to coarsen in the multi-level neighbor list generation dates back to an early version which assumed the particle binning would always take place with the coarse level cell spacing. This is not the case any more, so this is call is wrong and should be removed.

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
