### PR TITLE
EB Implicit Function using Parser

### DIFF
--- a/Docs/sphinx_documentation/source/Basics.rst
+++ b/Docs/sphinx_documentation/source/Basics.rst
@@ -312,7 +312,7 @@ can still be over-written by setting a value in the inputs file.
 Parser
 ======
 
-AMReX provides a parser that can be used at runtime to evaluate mathematical
+AMReX provides a parser in ``AMReX_Parser.H`` that can be used at runtime to evaluate mathematical
 expressions given in the form of string.  It supports ``+``, ``-``, ``*``,
 ``/``, ``**`` (power), ``^`` (power), ``sqrt``, ``exp``, ``log``, ``log10``,
 ``sin``, ``cos``, ``tan``, ``asin``, ``acos``, ``atan``, ``sinh``, ``cosh``,

--- a/Src/Base/Parser/AMReX_Parser.H
+++ b/Src/Base/Parser/AMReX_Parser.H
@@ -7,6 +7,7 @@
 #include <AMReX_Parser_Exe.H>
 #include <AMReX_Vector.H>
 
+#include <memory>
 #include <string>
 #include <set>
 
@@ -79,54 +80,58 @@ public:
     template <int N> ParserExecutor<N> compile () const;
 
 private:
-    void clear ();
 
-    std::string m_expression;
-    struct amrex_parser* m_parser = nullptr;
-    int m_nvars = 0;
-    mutable char* m_host_executor = nullptr;
+    struct Data {
+        std::string m_expression;
+        struct amrex_parser* m_parser = nullptr;
+        int m_nvars = 0;
+        mutable char* m_host_executor = nullptr;
 #ifdef AMREX_USE_GPU
-    mutable char* m_device_executor = nullptr;
+        mutable char* m_device_executor = nullptr;
 #endif
-    mutable int m_max_stack_size = 0;
+        mutable int m_max_stack_size = 0;
+        ~Data ();
+    };
+
+    std::shared_ptr<Data> m_data;
 };
 
 template <int N>
 ParserExecutor<N>
 Parser::compile () const
 {
-    AMREX_ASSERT(N == m_nvars);
+    AMREX_ASSERT(N == m_data->m_nvars);
 
-    if (!m_host_executor) {
+    if (!(m_data->m_host_executor)) {
         int stack_size;
-        int exe_size = parser_exe_size(m_parser, m_max_stack_size, stack_size);
+        int exe_size = parser_exe_size(m_data->m_parser, m_data->m_max_stack_size, stack_size);
 
-        if (m_max_stack_size > AMREX_PARSER_STACK_SIZE) {
+        if (m_data->m_max_stack_size > AMREX_PARSER_STACK_SIZE) {
             amrex::Abort("amrex::Parser: AMREX_PARSER_STACK_SIZE, "
                          + std::to_string(AMREX_PARSER_STACK_SIZE) + ", is too small for "
-                         + m_expression);
+                         + m_data->m_expression);
         }
         if (stack_size != 0) {
             amrex::Abort("amrex::Parser: something went wrong with parser stack! "
                          + std::to_string(stack_size));
         }
 
-        m_host_executor = (char*)The_Pinned_Arena()->alloc(exe_size);
+        m_data->m_host_executor = (char*)The_Pinned_Arena()->alloc(exe_size);
 
-        parser_compile(m_parser, m_host_executor);
+        parser_compile(m_data->m_parser, m_data->m_host_executor);
 
 #ifdef AMREX_USE_GPU
-        m_device_executor = (char*)The_Arena()->alloc(exe_size);
-        Gpu::htod_memcpy_async(m_device_executor, m_host_executor, exe_size);
+        m_data->m_device_executor = (char*)The_Arena()->alloc(exe_size);
+        Gpu::htod_memcpy_async(m_data->m_device_executor, m_data->m_host_executor, exe_size);
         Gpu::streamSynchronize();
 #endif
     }
 
 
 #ifdef AMREX_USE_GPU
-    return ParserExecutor<N>{m_host_executor, m_device_executor};
+    return ParserExecutor<N>{m_data->m_host_executor, m_data->m_device_executor};
 #else
-    return ParserExecutor<N>{m_host_executor};
+    return ParserExecutor<N>{m_data->m_host_executor};
 #endif
 }
 

--- a/Src/Base/Parser/AMReX_Parser.cpp
+++ b/Src/Base/Parser/AMReX_Parser.cpp
@@ -17,26 +17,24 @@ Parser::Parser (std::string const& func_body)
 void
 Parser::define (std::string const& func_body)
 {
-    clear();
+    m_data = std::make_shared<Data>();
 
-    m_expression = func_body;
-    m_expression.erase(std::remove(m_expression.begin(),m_expression.end(),'\n'),
-                       m_expression.end());
-    std::string f = m_expression + "\n";
+    m_data->m_expression = func_body;
+    m_data->m_expression.erase(std::remove(m_data->m_expression.begin(),
+                                           m_data->m_expression.end(),'\n'),
+                               m_data->m_expression.end());
+    std::string f = m_data->m_expression + "\n";
 
     YY_BUFFER_STATE buffer = amrex_parser_scan_string(f.c_str());
     amrex_parserparse();
-    m_parser = amrex_parser_new();
+    m_data->m_parser = amrex_parser_new();
     amrex_parser_delete_buffer(buffer);
 }
 
 Parser::~Parser ()
-{
-    clear();
-}
+{}
 
-void
-Parser::clear ()
+Parser::Data::~Data ()
 {
     m_expression.clear();
     if (m_parser) { amrex_parser_delete(m_parser); }
@@ -52,46 +50,46 @@ Parser::clear ()
 void
 Parser::setConstant (std::string const& name, amrex::Real c)
 {
-    parser_setconst(m_parser, name.c_str(), c);
+    parser_setconst(m_data->m_parser, name.c_str(), c);
 }
 
 void
 Parser::registerVariables (Vector<std::string> const& vars)
 {
-    m_nvars = vars.size();
-    for (int i = 0; i < m_nvars; ++i) {
-        parser_regvar(m_parser, vars[i].c_str(), i);
+    m_data->m_nvars = vars.size();
+    for (int i = 0; i < m_data->m_nvars; ++i) {
+        parser_regvar(m_data->m_parser, vars[i].c_str(), i);
     }
 }
 
 void
 Parser::print () const
 {
-    parser_print(m_parser);
+    parser_print(m_data->m_parser);
 }
 
 int
 Parser::depth () const
 {
-    return parser_depth(m_parser);
+    return parser_depth(m_data->m_parser);
 }
 
 int
 Parser::maxStackSize () const
 {
-    return m_max_stack_size;
+    return m_data->m_max_stack_size;
 }
 
 std::string const&
 Parser::expr () const
 {
-    return m_expression;
+    return m_data->m_expression;
 }
 
 std::set<std::string>
 Parser::symbols () const
 {
-    return parser_get_symbols(m_parser);
+    return parser_get_symbols(m_data->m_parser);
 }
 
 }

--- a/Src/EB/AMReX_EB2.cpp
+++ b/Src/EB/AMReX_EB2.cpp
@@ -7,6 +7,7 @@
 #include <AMReX_EB2_IF_Sphere.H>
 #include <AMReX_EB2_IF_Torus.H>
 #include <AMReX_EB2_IF_Spline.H>
+#include <AMReX_EB2_IF_Parser.H>
 #include <AMReX_EB2_GeometryShop.H>
 #include <AMReX_EB2.H>
 #include <AMReX_ParmParse.H>
@@ -174,6 +175,17 @@ Build (const Geometry& geom, int required_coarsening_level,
         EB2::TorusIF sf(large_radius, small_radius, center, has_fluid_inside);
 
         EB2::GeometryShop<EB2::TorusIF> gshop(sf);
+        EB2::Build(gshop, geom, required_coarsening_level,
+                   max_coarsening_level, ngrow, build_coarse_level_by_coarsening);
+    }
+    else if (geom_type == "parser")
+    {
+        std::string fn_string;
+        pp.get("parser_function", fn_string);
+        Parser parser(fn_string);
+        parser.registerVariables({"x","y","z"});
+        EB2::ParserIF pif(parser.compile<3>());
+        EB2::GeometryShop<EB2::ParserIF,Parser> gshop(pif,parser);
         EB2::Build(gshop, geom, required_coarsening_level,
                    max_coarsening_level, ngrow, build_coarse_level_by_coarsening);
     }

--- a/Src/EB/AMReX_EB2_GeometryShop.H
+++ b/Src/EB/AMReX_EB2_GeometryShop.H
@@ -167,7 +167,7 @@ BrentRootFinder (GpuArray<Real,AMREX_SPACEDIM> const& lo,
     return bPt[rangedir];
 }
 
-template <class F>
+template <class F, class R = int>
 class GeometryShop
 {
 public:
@@ -183,21 +183,29 @@ public:
     using FunctionType = F;
 
     explicit GeometryShop (F const& f)
-        : m_f(f)
+        : m_f(f), m_resource()
         {}
 
     explicit GeometryShop (F && f)
-        : m_f(std::move(f))
+        : m_f(std::move(f)), m_resource()
+        {}
+
+    GeometryShop (F const& f, R const& r)
+        : m_f(f), m_resource(r)
+        {}
+
+    GeometryShop (F && f, R && r)
+        : m_f(std::move(f)), m_resource(std::move(r))
         {}
 
     ~GeometryShop() {}
 
     GeometryShop (GeometryShop<F> const& rhs)
-        : m_f(rhs.m_f)
+        : m_f(rhs.m_f), m_resource(rhs.m_resource)
         {}
 
     GeometryShop (GeometryShop<F> && rhs)
-        : m_f(std::move(rhs.m_f))
+        : m_f(std::move(rhs.m_f)), m_resource(std::move(rhs.m_resource))
         {}
 
     GeometryShop<F>& operator= (GeometryShop<F> const& rhs) = delete;
@@ -411,7 +419,8 @@ public:
 private:
 
     F m_f;
-
+    R m_resource;  // We use this to hold the ownership of resource for F if needed,
+                   // because F needs to be a simply type suitable for GPU.
 };
 
 template <class F>
@@ -419,6 +428,15 @@ GeometryShop<typename std::decay<F>::type>
 makeShop (F&& f)
 {
     return GeometryShop<typename std::decay<F>::type>(std::forward<F>(f));
+}
+
+template <class F, class R>
+GeometryShop<typename std::decay<F>::type, typename std::decay<R>::type>
+makeShop (F&& f, R&& r)
+{
+    return GeometryShop<typename std::decay<F>::type,
+                        typename std::decay<R>::type>
+        (std::forward<F>(f), std::forward<R>(r));
 }
 
 }}

--- a/Src/EB/AMReX_EB2_IF.H
+++ b/Src/EB/AMReX_EB2_IF.H
@@ -12,6 +12,7 @@
 #include <AMReX_EB2_IF_Extrusion.H>
 #include <AMReX_EB2_IF_Intersection.H>
 #include <AMReX_EB2_IF_Lathe.H>
+#include <AMReX_EB2_IF_Parser.H>
 #include <AMReX_EB2_IF_Plane.H>
 #include <AMReX_EB2_IF_Polynomial.H>
 #include <AMReX_EB2_IF_Rotation.H>

--- a/Src/EB/AMReX_EB2_IF_Parser.H
+++ b/Src/EB/AMReX_EB2_IF_Parser.H
@@ -1,0 +1,45 @@
+#ifndef AMREX_EB2_IF_PARSER_H_
+#define AMREX_EB2_IF_PARSER_H_
+#include <AMReX_Config.H>
+
+#include <AMReX_EB2_IF_Base.H>
+#include <AMReX_Parser.H>
+
+// For all implicit functions, >0: body; =0: boundary; <0: fluid
+
+namespace amrex { namespace EB2 {
+
+class ParserIF
+    : public amrex::GPUable
+{
+public:
+    ParserIF (const ParserExecutor<3>& a_parser)
+        : m_parser(a_parser)
+        {}
+
+    ParserIF (const ParserIF& rhs) noexcept = default;
+    ParserIF (ParserIF&& rhs) noexcept = default;
+    ParserIF& operator= (const ParserIF& rhs) = delete;
+    ParserIF& operator= (ParserIF&& rhs) = delete;
+
+    AMREX_GPU_HOST_DEVICE inline
+    amrex::Real operator() (AMREX_D_DECL(amrex::Real x, amrex::Real y,
+                                         amrex::Real z)) const noexcept {
+#if (AMREX_SPACEDIM == 2)
+        return m_parser({x,y,Real(0.0)});
+#else
+        return m_parser({x,y,z});
+#endif
+    }
+
+    inline amrex::Real operator() (const amrex::RealArray& p) const noexcept {
+        return this->operator()(AMREX_D_DECL(p[0],p[1],p[2]));
+    }
+
+private:
+    ParserExecutor<3> m_parser;
+};
+
+}}
+
+#endif

--- a/Src/EB/CMakeLists.txt
+++ b/Src/EB/CMakeLists.txt
@@ -50,6 +50,7 @@ target_sources(amrex
    AMReX_EB2_IF_Union.H
    AMReX_EB2_IF_Extrusion.H
    AMReX_EB2_IF_Difference.H
+   AMReX_EB2_IF_Parser.H
    AMReX_EB2_IF.H
    AMReX_EB2_IF_Base.H
    AMReX_distFcnElement.cpp

--- a/Src/EB/Make.package
+++ b/Src/EB/Make.package
@@ -57,6 +57,7 @@ CEXE_headers += AMReX_EB2_IF_Translation.H
 CEXE_headers += AMReX_EB2_IF_Union.H
 CEXE_headers += AMReX_EB2_IF_Extrusion.H
 CEXE_headers += AMReX_EB2_IF_Difference.H
+CEXE_headers += AMReX_EB2_IF_Parser.H
 CEXE_headers += AMReX_EB2_IF.H
 CEXE_headers += AMReX_EB2_IF_Base.H
 


### PR DESCRIPTION
Add ParserIF to EB.  One can use a parser function to generate geometry.
For example, the following ParmParse parameters can be used in 3D to
place two cylinders with a radius of 0.1 at (-0.5,0,) and (0.5,0,).
```
eb2.geom_type = parser
eb2.parser_function = "max(0.01-(x+0.5)^2-y^2, 0.01-(x-0.5)^2-y^2)"
```

Put the internal data of Parser in a shared_ptr for memory safety.

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
