### PR TITLE
CI: IntelLLVM known to CMake

### DIFF
--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -18,21 +18,15 @@ jobs:
         source /opt/intel/oneapi/setvars.sh
         set -e
         cmake -S . -B build                                \
-            -DCMAKE_CXX_COMPILER_ID="Clang"                \
-            -DCMAKE_CXX_COMPILER_VERSION=12.0              \
-            -DCMAKE_CXX_STANDARD_COMPUTED_DEFAULT="17"     \
             -DCMAKE_VERBOSE_MAKEFILE=ON                    \
             -DAMReX_ENABLE_TESTS=ON                        \
-            -DAMReX_FORTRAN=OFF                            \
+            -DAMReX_FORTRAN=ON                             \
             -DAMReX_PARTICLES=ON                           \
             -DAMReX_GPU_BACKEND=SYCL                       \
             -DCMAKE_C_COMPILER=$(which clang)              \
             -DCMAKE_CXX_COMPILER=$(which dpcpp)            \
             -DCMAKE_Fortran_COMPILER=$(which gfortran)
         cmake --build build --parallel 2
-    # note: setting the CXX compiler ID is a work-around for
-    # the 2021.1 DPC++ release / CMake 3.19.0-3.19.1
-    # https://gitlab.kitware.com/cmake/cmake/-/issues/21551#note_869580
 
 # "Classic" EDG Intel Compiler
 # Ref.: https://github.com/rscohn2/oneapi-ci

--- a/Tools/CMake/AMReXSYCL.cmake
+++ b/Tools/CMake/AMReXSYCL.cmake
@@ -53,7 +53,8 @@ target_compile_options( SYCL
 #   https://github.com/intel/llvm/issues/2187
 target_compile_options( SYCL
    INTERFACE
-   $<${_cxx_dpcpp}:-mlong-double-64 "SHELL:-Xclang -mlong-double-64">)
+     "$<${_cxx_dpcpp}:-mlong-double-64>"
+     "$<${_cxx_dpcpp}:SHELL:-Xclang -mlong-double-64>")
 
 # Beta09 has enabled eary optimizations by default.  But this causes many
 # tests to crash.  So we disable it.


### PR DESCRIPTION
## Summary

`IntelLLVM` is now a recognized CMake compiler, so we don't need to add a Clang-ish identification anymore.

Also fix a CMake -Wdev warning (DPC++/SYCL)

-  beta08 work-around: `-mlong-double-64` (https://github.com/intel/llvm/issues/2187) -> still needed!
- beta09 work-around: `-fno-sycl-early-optimizations` (link to upstream issue?) -> keep for now, RT tests pending to verify fix

## Additional background

setting the CXX compiler ID was a work-around for the 2021.1 DPC++ release / CMake 3.19.0-3.19.1
  https://gitlab.kitware.com/cmake/cmake/-/issues/21551#note_869580

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
