### PR TITLE
Fix mismatched tag warning

### DIFF
--- a/Src/AmrCore/AMReX_AmrCoreFwd.H
+++ b/Src/AmrCore/AMReX_AmrCoreFwd.H
@@ -4,7 +4,7 @@
 namespace amrex {
 
 class AmrCore;
-class AmrInfo;
+struct AmrInfo;
 class AmrMesh;
 
 class FluxRegister;


### PR DESCRIPTION
AmrInfo is defined as a struct, and it was declared as class in forward
declaration.  This is valid C++.  But the Intel oneAPI compiler gives a
warning that this may result in linker errors under the Microsoft C++ ABI.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
