### PR TITLE
Default values for members of ParserExecutor

### DIFF
--- a/Src/Base/Parser/AMReX_Parser.H
+++ b/Src/Base/Parser/AMReX_Parser.H
@@ -50,9 +50,18 @@ struct ParserExecutor
 #endif
     }
 
-    char* m_host_executor;
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    explicit operator bool () const {
+#if AMREX_DEVICE_COMPILE
+        return m_device_executor != nullptr;
+#else
+        return m_host_executor != nullptr;
+#endif
+    }
+
+    char* m_host_executor = nullptr;
 #ifdef AMREX_USE_GPU
-    char* m_device_executor;
+    char* m_device_executor = nullptr;
 #endif
 };
 


### PR DESCRIPTION
Set the default values of pointers inside ParserExecutor to nullptr and add
a conversion operator so that it can be tested for null.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
