### PR TITLE
EB nodal solver

### DIFF
--- a/Src/EB/AMReX_EBDataCollection.H
+++ b/Src/EB/AMReX_EBDataCollection.H
@@ -30,6 +30,7 @@ public:
     EBDataCollection& operator= (EBDataCollection&&) = delete;
 
     const FabArray<EBCellFlagFab>& getMultiEBCellFlagFab () const;
+    const MultiFab& getLevelSet () const;
     const MultiFab& getVolFrac () const;
     const MultiCutFab& getCentroid () const;
     const MultiCutFab& getBndryCent () const;
@@ -49,6 +50,7 @@ private:
 
     // EBSupport::basic
     FabArray<EBCellFlagFab>* m_cellflags = nullptr;
+    MultiFab* m_levelset = nullptr;
 
     // EBSupport::volume
     MultiFab* m_volfrac = nullptr;

--- a/Src/EB/AMReX_EBDataCollection.cpp
+++ b/Src/EB/AMReX_EBDataCollection.cpp
@@ -24,6 +24,9 @@ EBDataCollection::EBDataCollection (const EB2::Level& a_level,
         m_cellflags = new FabArray<EBCellFlagFab>(a_ba, a_dm, 1, m_ngrow[0], MFInfo(),
                                                   DefaultFabFactory<EBCellFlagFab>());
         a_level.fillEBCellFlag(*m_cellflags, m_geom);
+        m_levelset = new MultiFab(amrex::convert(a_ba,IntVect::TheUnitVector()), a_dm,
+                                  1, m_ngrow[0], MFInfo(), FArrayBoxFactory());
+        a_level.fillLevelSet(*m_levelset, m_geom);
     }
 
     if (m_support >= EBSupport::volume)
@@ -66,6 +69,7 @@ EBDataCollection::EBDataCollection (const EB2::Level& a_level,
 EBDataCollection::~EBDataCollection ()
 {
     delete m_cellflags;
+    delete m_levelset;
     delete m_volfrac;
     delete m_centroid;
     delete m_bndrycent;
@@ -83,6 +87,13 @@ EBDataCollection::getMultiEBCellFlagFab () const
 {
     AMREX_ASSERT(m_cellflags != nullptr);
     return *m_cellflags;
+}
+
+const MultiFab&
+EBDataCollection::getLevelSet () const
+{
+    AMREX_ASSERT(m_levelset != nullptr);
+    return *m_levelset;
 }
 
 const MultiFab&

--- a/Src/EB/AMReX_EBFabFactory.H
+++ b/Src/EB/AMReX_EBFabFactory.H
@@ -48,6 +48,8 @@ public:
     const FabArray<EBCellFlagFab>& getMultiEBCellFlagFab () const noexcept
         { return m_ebdc->getMultiEBCellFlagFab(); }
 
+    const MultiFab& getLevelSet () const noexcept { return m_ebdc->getLevelSet(); }
+
     const MultiFab& getVolFrac () const noexcept { return m_ebdc->getVolFrac(); }
 
     const MultiCutFab& getCentroid () const noexcept { return m_ebdc->getCentroid(); }

--- a/Src/LinearSolvers/CMakeLists.txt
+++ b/Src/LinearSolvers/CMakeLists.txt
@@ -77,6 +77,10 @@ if (AMReX_EB)
       MLMG/AMReX_MLEBABecLap_F.cpp
       MLMG/AMReX_MLEBABecLap_K.H
       MLMG/AMReX_MLEBABecLap_${AMReX_SPACEDIM}D_K.H
+      MLMG/AMReX_MLEBNodeFDLaplacian.H
+      MLMG/AMReX_MLEBNodeFDLaplacian.cpp
+      MLMG/AMReX_MLEBNodeFDLap_K.H
+      MLMG/AMReX_MLEBNodeFDLap_${AMReX_SPACEDIM}D_K.H
       MLMG/AMReX_MLEBTensorOp.H
       MLMG/AMReX_MLEBTensorOp.cpp
       MLMG/AMReX_MLEBTensorOp_bc.cpp

--- a/Src/LinearSolvers/MLMG/AMReX_MLEBNodeFDLap_2D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBNodeFDLap_2D_K.H
@@ -1,0 +1,182 @@
+#ifndef AMREX_MLEBNODEFDLAP_2D_K_H_
+#define AMREX_MLEBNODEFDLAP_2D_K_H_
+
+namespace amrex {
+
+template <typename F>
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void mlebndfdlap_adotx_eb_doit (int i, int j, int k, Array4<Real> const& y,
+                                Array4<Real const> const& x, Array4<int const> const& dmsk,
+                                Array4<Real const> const& ecx, Array4<Real const> const& ecy,
+                                F && xeb, Real bx, Real by) noexcept
+{
+    if (dmsk(i,j,k)) {
+        y(i,j,k) = Real(0.0);
+    } else if (!ecx) {
+        y(i,j,k) = bx * (x(i-1,j,k) + x(i+1,j,k))
+            +      by * (x(i,j-1,k) + x(i,j+1,k))
+            - Real(2.0)*(bx+by) * x(i,j,k);
+    } else {
+        Real tmp;
+        Real hp, hm;
+        if (ecx(i,j,k) == Real(1.0)) { // regular
+            hp = Real(1.0);
+            tmp = x(i+1,j,k) - x(i,j,k);
+        } else {
+            hp = Real(1.0) + Real(2.) * ecx(i,j,k);
+            tmp = (xeb(i+1,j,k) - x(i,j,k)) / hp;
+        }
+
+        if (ecx(i-1,j,k) == Real(1.0)) {
+            hm = Real(1.0);
+            tmp += x(i-1,j,k) - x(i,j,k);
+        } else {
+            hm = Real(1.0) - Real(2.) * ecx(i-1,j,k);
+            tmp += (xeb(i-1,j,k) - x(i,j,k)) / hm;
+        }
+
+        y(i,j,k) = tmp * bx * Real(2.0) / (hp+hm);
+
+        if (ecy(i,j,k) == Real(1.0)) {
+            hp = Real(1.0);
+            tmp = x(i,j+1,k) - x(i,j,k);
+        } else {
+            hp = Real(1.0) + Real(2.) * ecy(i,j,k);
+            tmp = (xeb(i,j+1,k) - x(i,j,k)) / hp;
+        }
+
+        if (ecy(i,j-1,k) == Real(1.0)) {
+            hm = Real(1.0);
+            tmp += x(i,j-1,k) - x(i,j,k);
+        } else {
+            hm = Real(1.0) - Real(2.) * ecy(i,j-1,k);
+            tmp += (xeb(i,j-1,k) - x(i,j,k)) / hm;
+        }
+
+        y(i,j,k) += tmp * by * Real(2.0) / (hp+hm);
+    }
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void mlebndfdlap_adotx_eb (int i, int j, int k, Array4<Real> const& y,
+                           Array4<Real const> const& x, Array4<int const> const& dmsk,
+                           Array4<Real const> const& ecx, Array4<Real const> const& ecy,
+                           Real xeb, Real bx, Real by) noexcept
+{
+    mlebndfdlap_adotx_eb_doit(i, j, k, y, x, dmsk, ecx, ecy,
+                              [=] (int, int, int) -> Real { return xeb; },
+                              bx, by);
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void mlebndfdlap_adotx_eb (int i, int j, int k, Array4<Real> const& y,
+                           Array4<Real const> const& x, Array4<int const> const& dmsk,
+                           Array4<Real const> const& ecx, Array4<Real const> const& ecy,
+                           Array4<Real const> const& xeb, Real bx, Real by) noexcept
+{
+    mlebndfdlap_adotx_eb_doit(i, j, k, y, x, dmsk, ecx, ecy,
+                              [=] (int i1, int i2, int i3) -> Real {
+                                  return xeb(i1,i2,i3); },
+                              bx, by);
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void mlebndfdlap_adotx (int i, int j, int k, Array4<Real> const& y,
+                        Array4<Real const> const& x, Array4<int const> const& dmsk,
+                        Array4<Real const> const& a, Real bx, Real by) noexcept
+{
+    if (dmsk(i,j,k)) {
+        y(i,j,k) = Real(0.0);
+    } else {
+        y(i,j,k) = bx * (x(i-1,j,k) + x(i+1,j,k))
+            +      by * (x(i,j-1,k) + x(i,j+1,k))
+            - (Real(2.0)*(bx+by) + a(i,j,k)) * x(i,j,k);
+    }
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void mlebndfdlap_gsrb_eb(int i, int j, int k, Array4<Real> const& x,
+                         Array4<Real const> const& rhs, Array4<int const> const& dmsk,
+                         Array4<Real const> const& ecx, Array4<Real const> const& ecy,
+                         Real bx, Real by, int redblack) noexcept
+{
+    if ((i+j+k+redblack)%2 == 0) {
+        if (dmsk(i,j,k)) {
+            x(i,j,k) = Real(0.);
+        } else if (!ecx) {
+            Real gamma = Real(-2.0)*(bx+by);
+            Real rho = bx * (x(i-1,j,k) + x(i+1,j,k))
+                +      by * (x(i,j-1,k) + x(i,j+1,k));
+            x(i,j,k) = (rhs(i,j,k) - rho) / gamma;
+        } else {
+            Real tmp0, tmp1;
+            Real hp, hm;
+            if (ecx(i,j,k) == Real(1.0)) { // regular
+                hp = Real(1.0);
+                tmp0 = Real(-1.0);
+                tmp1 = x(i+1,j,k);
+            } else {
+                hp = Real(1.0) + Real(2.) * ecx(i,j,k);
+                tmp0 = Real(-1.0) / hp;
+                tmp1 = Real(0.0);
+            }
+
+            if (ecx(i-1,j,k) == Real(1.0)) {
+                hm = Real(1.0);
+                tmp0 += Real(-1.0);
+                tmp1 += x(i-1,j,k);
+            } else {
+                hm = Real(1.0) - Real(2.) * ecx(i-1,j,k);
+                tmp0 += Real(-1.0) / hm;
+            }
+
+            Real gamma = tmp0 * (bx * Real(2.0) / (hp+hm));
+            Real rho   = tmp1 * (bx * Real(2.0) / (hp+hm));
+
+            if (ecy(i,j,k) == Real(1.0)) {
+                hp = Real(1.0);
+                tmp0 = Real(-1.0);
+                tmp1 = x(i,j+1,k);
+            } else {
+                hp = Real(1.0) + Real(2.) * ecy(i,j,k);
+                tmp0 = Real(-1.0) / hp;
+                tmp1 = Real(0.0);
+            }
+
+            if (ecy(i,j-1,k) == Real(1.0)) {
+                hm = Real(1.0);
+                tmp0 += Real(-1.0);
+                tmp1 += x(i,j-1,k);
+            } else {
+                hm = Real(1.0) - Real(2.) * ecy(i,j-1,k);
+                tmp0 += Real(-1.0) / hm;
+            }
+
+            gamma += tmp0 * (by * Real(2.0) / (hp+hm));
+            rho   += tmp1 * (by * Real(2.0) / (hp+hm));
+
+            x(i,j,k) = (rhs(i,j,k) - rho) / gamma;
+        }
+    }
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void mlebndfdlap_gsrb(int i, int j, int k, Array4<Real> const& x,
+                      Array4<Real const> const& rhs, Array4<int const> const& dmsk,
+                      Array4<Real const> const& a, Real bx, Real by, int redblack) noexcept
+{
+    if ((i+j+k+redblack)%2 == 0) {
+        if (dmsk(i,j,k)) {
+            x(i,j,k) = Real(0.);
+        } else {
+            Real gamma = Real(-2.0)*(bx+by) - a(i,j,k);
+            Real rho = bx * (x(i-1,j,k) + x(i+1,j,k))
+                +      by * (x(i,j-1,k) + x(i,j+1,k));
+            x(i,j,k) = (rhs(i,j,k) - rho) / gamma;
+        }
+    }
+}
+
+}
+
+#endif

--- a/Src/LinearSolvers/MLMG/AMReX_MLEBNodeFDLap_3D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBNodeFDLap_3D_K.H
@@ -1,0 +1,231 @@
+#ifndef AMREX_MLEBNODEFDLAP_3D_K_H_
+#define AMREX_MLEBNODEFDLAP_3D_K_H_
+
+namespace amrex {
+
+template <typename F>
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void mlebndfdlap_adotx_eb_doit (int i, int j, int k, Array4<Real> const& y,
+                                Array4<Real const> const& x, Array4<int const> const& dmsk,
+                                Array4<Real const> const& ecx, Array4<Real const> const& ecy,
+                                Array4<Real const> const& ecz, F && xeb,
+                                Real bx, Real by, Real bz) noexcept
+{
+    if (dmsk(i,j,k)) {
+        y(i,j,k) = Real(0.0);
+    } else if (!ecx) {
+        y(i,j,k) = bx * (x(i-1,j,k) + x(i+1,j,k))
+            +      by * (x(i,j-1,k) + x(i,j+1,k))
+            +      bz * (x(i,j,k-1) + x(i,j,k+1))
+            - Real(2.0)*(bx+by+bz) * x(i,j,k);
+    } else {
+        Real tmp;
+        Real hp, hm;
+        if (ecx(i,j,k) == Real(1.0)) { // regular
+            hp = Real(1.0);
+            tmp = x(i+1,j,k) - x(i,j,k);
+        } else {
+            hp = Real(1.0) + Real(2.) * ecx(i,j,k);
+            tmp = (xeb(i+1,j,k) - x(i,j,k)) / hp;
+        }
+
+        if (ecx(i-1,j,k) == Real(1.0)) {
+            hm = Real(1.0);
+            tmp += x(i-1,j,k) - x(i,j,k);
+        } else {
+            hm = Real(1.0) - Real(2.) * ecx(i-1,j,k);
+            tmp += (xeb(i-1,j,k) - x(i,j,k)) / hm;
+        }
+
+        y(i,j,k) = tmp * bx * Real(2.0) / (hp+hm);
+
+        if (ecy(i,j,k) == Real(1.0)) {
+            hp = Real(1.0);
+            tmp = x(i,j+1,k) - x(i,j,k);
+        } else {
+            hp = Real(1.0) + Real(2.) * ecy(i,j,k);
+            tmp = (xeb(i,j+1,k) - x(i,j,k)) / hp;
+        }
+
+        if (ecy(i,j-1,k) == Real(1.0)) {
+            hm = Real(1.0);
+            tmp += x(i,j-1,k) - x(i,j,k);
+        } else {
+            hm = Real(1.0) - Real(2.) * ecy(i,j-1,k);
+            tmp += (xeb(i,j-1,k) - x(i,j,k)) / hm;
+        }
+
+        y(i,j,k) += tmp * by * Real(2.0) / (hp+hm);
+
+        if (ecz(i,j,k) == Real(1.0)) {
+            hp = Real(1.0);
+            tmp = x(i,j,k+1) - x(i,j,k);
+        } else {
+            hp = Real(1.0) + Real(2.0) * ecz(i,j,k);
+            tmp = (xeb(i,j,k+1) - x(i,j,k)) / hp;
+        }
+
+        if (ecz(i,j,k-1) == Real(1.0)) {
+            hm = Real(1.0);
+            tmp += x(i,j,k-1) - x(i,j,k);
+        } else {
+            hm = Real(1.0) - Real(2.) * ecz(i,j,k-1);
+            tmp += (xeb(i,j,k-1) - x(i,j,k)) / hm;
+        }
+
+        y(i,j,k) += tmp * bz * Real(2.0) / (hp+hm);
+    }
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void mlebndfdlap_adotx_eb (int i, int j, int k, Array4<Real> const& y,
+                           Array4<Real const> const& x, Array4<int const> const& dmsk,
+                           Array4<Real const> const& ecx, Array4<Real const> const& ecy,
+                           Array4<Real const> const& ecz, Real xeb,
+                           Real bx, Real by, Real bz) noexcept
+{
+    mlebndfdlap_adotx_eb_doit(i, j, k, y, x, dmsk, ecx, ecy, ecz,
+                              [=] (int, int, int) -> Real { return xeb; },
+                              bx, by, bz);
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void mlebndfdlap_adotx_eb (int i, int j, int k, Array4<Real> const& y,
+                           Array4<Real const> const& x, Array4<int const> const& dmsk,
+                           Array4<Real const> const& ecx, Array4<Real const> const& ecy,
+                           Array4<Real const> const& ecz, Array4<Real const> const& xeb,
+                           Real bx, Real by, Real bz) noexcept
+{
+    mlebndfdlap_adotx_eb_doit(i, j, k, y, x, dmsk, ecx, ecy, ecz,
+                              [=] (int i1, int i2, int i3) -> Real {
+                                  return xeb(i1,i2,i3); },
+                              bx, by, bz);
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void mlebndfdlap_adotx (int i, int j, int k, Array4<Real> const& y,
+                        Array4<Real const> const& x, Array4<int const> const& dmsk,
+                        Array4<Real const> const& a, Real bx, Real by, Real bz) noexcept
+{
+    if (dmsk(i,j,k)) {
+        y(i,j,k) = Real(0.0);
+    } else {
+        y(i,j,k) = bx * (x(i-1,j,k) + x(i+1,j,k))
+            +      by * (x(i,j-1,k) + x(i,j+1,k))
+            +      bz * (x(i,j,k-1) + x(i,j,k+1))
+            - (Real(2.0)*(bx+by+bz) + a(i,j,k)) * x(i,j,k);
+    }
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void mlebndfdlap_gsrb_eb (int i, int j, int k, Array4<Real> const& x,
+                          Array4<Real const> const& rhs, Array4<int const> const& dmsk,
+                          Array4<Real const> const& ecx, Array4<Real const> const& ecy,
+                          Array4<Real const> const& ecz, Real bx, Real by, Real bz,
+                          int redblack) noexcept
+{
+    if ((i+j+k+redblack)%2 == 0) {
+        if (dmsk(i,j,k)) {
+            x(i,j,k) = Real(0.);
+        } else if (!ecx) {
+            Real gamma = Real(-2.0)*(bx+by+bz);
+            Real rho = bx * (x(i-1,j,k) + x(i+1,j,k))
+                +      by * (x(i,j-1,k) + x(i,j+1,k))
+                +      bz * (x(i,j,k-1) + x(i,j,k+1));
+            x(i,j,k) = (rhs(i,j,k) - rho) / gamma;
+        } else {
+            Real tmp0, tmp1;
+            Real hp, hm;
+            if (ecx(i,j,k) == Real(1.0)) { // regular
+                hp = Real(1.0);
+                tmp0 = Real(-1.0);
+                tmp1 = x(i+1,j,k);
+            } else {
+                hp = Real(1.0) + Real(2.) * ecx(i,j,k);
+                tmp0 = Real(-1.0) / hp;
+                tmp1 = Real(0.0);
+            }
+
+            if (ecx(i-1,j,k) == Real(1.0)) {
+                hm = Real(1.0);
+                tmp0 += Real(-1.0);
+                tmp1 += x(i-1,j,k);
+            } else {
+                hm = Real(1.0) - Real(2.) * ecx(i-1,j,k);
+                tmp0 += Real(-1.0) / hm;
+            }
+
+            Real gamma = tmp0 * (bx * Real(2.0) / (hp+hm));
+            Real rho   = tmp1 * (bx * Real(2.0) / (hp+hm));
+
+            if (ecy(i,j,k) == Real(1.0)) {
+                hp = Real(1.0);
+                tmp0 = Real(-1.0);
+                tmp1 = x(i,j+1,k);
+            } else {
+                hp = Real(1.0) + Real(2.) * ecy(i,j,k);
+                tmp0 = Real(-1.0) / hp;
+                tmp1 = Real(0.0);
+            }
+
+            if (ecy(i,j-1,k) == Real(1.0)) {
+                hm = Real(1.0);
+                tmp0 += Real(-1.0);
+                tmp1 += x(i,j-1,k);
+            } else {
+                hm = Real(1.0) - Real(2.) * ecy(i,j-1,k);
+                tmp0 += Real(-1.0) / hm;
+            }
+
+            gamma += tmp0 * (by * Real(2.0) / (hp+hm));
+            rho   += tmp1 * (by * Real(2.0) / (hp+hm));
+
+            if (ecz(i,j,k) == Real(1.0)) {
+                hp = Real(1.0);
+                tmp0 = Real(-1.0);
+                tmp1 = x(i,j,k+1);
+            } else {
+                hp = Real(1.0) + Real(2.) * ecz(i,j,k);
+                tmp0 = Real(-1.0) / hp;
+                tmp1 = Real(0.0);
+            }
+
+            if (ecz(i,j,k-1) == Real(1.0)) {
+                hm = Real(1.0);
+                tmp0 += Real(-1.0);
+                tmp1 += x(i,j,k-1);
+            } else {
+                hm = Real(1.0) - Real(2.) * ecz(i,j,k-1);
+                tmp0 += Real(-1.0) / hm;
+            }
+
+            gamma += tmp0 * (bz * Real(2.0) / (hp+hm));
+            rho   += tmp1 * (bz * Real(2.0) / (hp+hm));
+
+            x(i,j,k) = (rhs(i,j,k) - rho) / gamma;
+        }
+    }
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void mlebndfdlap_gsrb (int i, int j, int k, Array4<Real> const& x,
+                       Array4<Real const> const& rhs, Array4<int const> const& dmsk,
+                       Array4<Real const> const& a, Real bx, Real by, Real bz,
+                       int redblack) noexcept
+{
+    if ((i+j+k+redblack)%2 == 0) {
+        if (dmsk(i,j,k)) {
+            x(i,j,k) = Real(0.);
+        } else {
+            Real gamma = Real(-2.0)*(bx+by+bz) - a(i,j,k);
+            Real rho = bx * (x(i-1,j,k) + x(i+1,j,k))
+                +      by * (x(i,j-1,k) + x(i,j+1,k))
+                +      bz * (x(i,j,k-1) + x(i,j,k+1));
+            x(i,j,k) = (rhs(i,j,k) - rho) / gamma;
+        }
+    }
+}
+
+}
+
+#endif

--- a/Src/LinearSolvers/MLMG/AMReX_MLEBNodeFDLap_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBNodeFDLap_K.H
@@ -1,0 +1,14 @@
+#ifndef AMREX_MLEBNODEFDLAP_K_H_
+#define AMREX_MLEBNODEFDLAP_K_H_
+#include <AMReX_Config.H>
+
+#include <AMReX_MLEBNodeFDLaplacian.H>
+#include <AMReX_LO_BCTYPES.H>
+
+#if (AMREX_SPACEDIM == 2)
+#include <AMReX_MLEBNodeFDLap_2D_K.H>
+#else
+#include <AMReX_MLEBNodeFDLap_3D_K.H>
+#endif
+
+#endif

--- a/Src/LinearSolvers/MLMG/AMReX_MLEBNodeFDLaplacian.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBNodeFDLaplacian.H
@@ -1,0 +1,142 @@
+#ifndef AMREX_MLEBNODEFDLAPLACIAN_H_
+#define AMREX_MLEBNODEFDLAPLACIAN_H_
+#include <AMReX_Config.H>
+
+#include <AMReX_Array.H>
+#include <AMReX_EBFabFactory.H>
+#include <AMReX_MLNodeLinOp.H>
+
+#include <limits>
+
+namespace amrex {
+
+// del dot (sigma grad phi) = rhs
+// where phi and rhs are nodal multifab, and sigma is a tensor constant
+// with only diagonal components.  Only periodic and Dirichlet are supported
+// at domain boundaries.  The EB is assumed to be Dirichlet.
+
+class MLEBNodeFDLaplacian
+    : public MLNodeLinOp
+{
+public:
+
+    MLEBNodeFDLaplacian () noexcept {}
+    MLEBNodeFDLaplacian (const Vector<Geometry>& a_geom,
+                         const Vector<BoxArray>& a_grids,
+                         const Vector<DistributionMapping>& a_dmap,
+                         const LPInfo& a_info,
+                         const Vector<EBFArrayBoxFactory const*>& a_factory);
+
+    virtual ~MLEBNodeFDLaplacian ();
+
+    MLEBNodeFDLaplacian (const MLEBNodeFDLaplacian&) = delete;
+    MLEBNodeFDLaplacian (MLEBNodeFDLaplacian&&) = delete;
+    MLEBNodeFDLaplacian& operator= (const MLEBNodeFDLaplacian&) = delete;
+    MLEBNodeFDLaplacian& operator= (MLEBNodeFDLaplacian&&) = delete;
+
+    void setSigma (Array<Real,AMREX_SPACEDIM> const& a_sigma) noexcept;
+
+    // Phi on EB
+    void setEBDirichlet (Real a_phi_eb);
+    //
+    template <typename F>
+    std::enable_if_t<
+        std::is_same<std::decay_t<decltype(std::declval<F>()(AMREX_D_DECL(Real(0.),Real(0.),Real(0.))))>,
+                     Real>::value>
+    setEBDirichlet (F&& f);
+
+    void define (const Vector<Geometry>& a_geom,
+                 const Vector<BoxArray>& a_grids,
+                 const Vector<DistributionMapping>& a_dmap,
+                 const LPInfo& a_info,
+                 const Vector<EBFArrayBoxFactory const*>& a_factory);
+
+    virtual std::unique_ptr<FabFactory<FArrayBox> > makeFactory (int amrlev, int mglev) const final override;
+
+    virtual std::string name () const override { return std::string("MLEBNodeFDLaplacian"); }
+
+    virtual void restriction (int amrlev, int cmglev, MultiFab& crse, MultiFab& fine) const final override;
+    virtual void interpolation (int amrlev, int fmglev, MultiFab& fine, const MultiFab& crse) const final override;
+    virtual void averageDownSolutionRHS (int camrlev, MultiFab& crse_sol, MultiFab& crse_rhs,
+                                         const MultiFab& fine_sol, const MultiFab& fine_rhs) final override;
+
+    virtual void reflux (int crse_amrlev,
+                         MultiFab& res, const MultiFab& crse_sol, const MultiFab& crse_rhs,
+                         MultiFab& fine_res, MultiFab& fine_sol, const MultiFab& fine_rhs) const final override;
+
+    virtual void prepareForSolve () final override;
+    virtual void Fapply (int amrlev, int mglev, MultiFab& out, const MultiFab& in) const final override;
+    virtual void Fsmooth (int amrlev, int mglev, MultiFab& sol, const MultiFab& rhs) const final override;
+    virtual void normalize (int amrlev, int mglev, MultiFab& mf) const final override;
+
+    virtual void fixUpResidualMask (int amrlev, iMultiFab& resmsk) final override;
+
+    virtual bool isSingular (int) const final override { return false; }
+
+#if defined(AMREX_USE_HYPRE)
+    virtual void fillIJMatrix (MFIter const& mfi,
+                               Array4<HypreNodeLap::AtomicInt const> const& gid,
+                               Array4<int const> const& lid,
+                               HypreNodeLap::Int* const ncols,
+                               HypreNodeLap::Int* const cols,
+                               Real* const mat) const override;
+
+    virtual void fillRHS (MFIter const& mfi,
+                          Array4<int const> const& lid,
+                          Real* const rhs,
+                          Array4<Real const> const& bfab) const override;
+#endif
+
+private:
+    GpuArray<Real,AMREX_SPACEDIM> m_sigma;
+    Real m_s_phi_eb = std::numeric_limits<Real>::lowest();
+    Vector<MultiFab> m_phi_eb;
+    Vector<MultiFab> m_acoef;
+    Real m_a_huge = 1.0;
+};
+
+template <typename F>
+std::enable_if_t<
+    std::is_same<std::decay_t<decltype(std::declval<F>()(AMREX_D_DECL(Real(0.),Real(0.),Real(0.))))>,
+                 Real>::value>
+MLEBNodeFDLaplacian::setEBDirichlet (F&& f)
+{
+    m_phi_eb.resize(m_num_amr_levels);
+    for (int amrlev = 0; amrlev < m_num_amr_levels; ++amrlev) {
+        auto factory = dynamic_cast<EBFArrayBoxFactory const*>(m_factory[amrlev][0].get());
+        if (factory) {
+            Geometry const& geom = m_geom[amrlev][0];
+            auto const problo = geom.ProbLoArray();
+            auto const cellsize = geom.CellSizeArray();
+            m_phi_eb[amrlev].define(amrex::convert(m_grids[amrlev][0],IntVect(1)),
+                                    m_dmap[amrlev][0], 1, 1);
+            auto const& flags = factory->getMultiEBCellFlagFab();
+            auto const& levset = factory->getLevelSet();
+#ifdef AMREX_USE_OMP
+#pragma omp parallel if (Gpu::notInLaunchRegion())
+#endif
+            for (MFIter mfi(m_phi_eb[amrlev],TilingIfNotGPU()); mfi.isValid(); ++mfi)
+            {
+                const Box& ndbx = mfi.growntilebox();
+                const auto& flag = flags[mfi];
+                if (flag.getType() != FabType::regular) {
+                    Array4<Real const> const lstarr = levset.const_array(mfi);
+                    Array4<Real> const& phi = m_phi_eb[amrlev].array(mfi);
+                    AMREX_HOST_DEVICE_FOR_3D(ndbx, i, j, k,
+                    {
+                        if (lstarr(i,j,k) >= Real(0.0)) {
+                            phi(i,j,k) = f(AMREX_D_DECL(problo[0]+i*cellsize[0],
+                                                        problo[1]+j*cellsize[1],
+                                                        problo[2]+k*cellsize[2]));
+                        }
+                    });
+                }
+            }
+        }
+    }
+    return Real(0.);
+}
+
+}
+
+#endif

--- a/Src/LinearSolvers/MLMG/AMReX_MLEBNodeFDLaplacian.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBNodeFDLaplacian.cpp
@@ -1,0 +1,447 @@
+#include <AMReX_MLEBNodeFDLaplacian.H>
+#include <AMReX_MLEBNodeFDLap_K.H>
+#include <AMReX_MLNodeLap_K.H>
+#include <AMReX_MLNodeTensorLap_K.H>
+
+namespace amrex {
+
+MLEBNodeFDLaplacian::MLEBNodeFDLaplacian (
+    const Vector<Geometry>& a_geom,
+    const Vector<BoxArray>& a_grids,
+    const Vector<DistributionMapping>& a_dmap,
+    const LPInfo& a_info,
+    const Vector<EBFArrayBoxFactory const*>& a_factory)
+{
+    define(a_geom, a_grids, a_dmap, a_info, a_factory);
+}
+
+MLEBNodeFDLaplacian::~MLEBNodeFDLaplacian ()
+{}
+
+void
+MLEBNodeFDLaplacian::setSigma (Array<Real,AMREX_SPACEDIM> const& a_sigma) noexcept
+{
+    for (int i = 0; i < AMREX_SPACEDIM; ++i) {
+        m_sigma[i] = a_sigma[i];
+    }
+}
+
+void
+MLEBNodeFDLaplacian::setEBDirichlet (Real a_phi_eb)
+{
+    m_s_phi_eb = a_phi_eb;
+}
+
+void
+MLEBNodeFDLaplacian::define (const Vector<Geometry>& a_geom,
+                             const Vector<BoxArray>& a_grids,
+                             const Vector<DistributionMapping>& a_dmap,
+                             const LPInfo& a_info,
+                             const Vector<EBFArrayBoxFactory const*>& a_factory)
+{
+    static_assert(AMREX_SPACEDIM > 1, "MLEBNodeFDLaplacian: 1D not supported");
+
+    BL_PROFILE("MLEBNodeFDLaplacian::define()");
+
+    // This makes sure grids are cell-centered;
+    Vector<BoxArray> cc_grids = a_grids;
+    for (auto& ba : cc_grids) {
+        ba.enclosedCells();
+    }
+
+    if (a_grids.size() > 1) {
+        amrex::Abort("MLEBNodeFDLaplacian: multi-level not supported");
+    }
+
+    Vector<FabFactory<FArrayBox> const*> _factory;
+    for (auto x : a_factory) {
+        _factory.push_back(static_cast<FabFactory<FArrayBox> const*>(x));
+    }
+
+    int eb_limit_coarsening = false;
+    MLNodeLinOp::define(a_geom, cc_grids, a_dmap, a_info, _factory, eb_limit_coarsening);
+}
+
+std::unique_ptr<FabFactory<FArrayBox> >
+MLEBNodeFDLaplacian::makeFactory (int amrlev, int mglev) const
+{
+    if (amrlev == 0 && mglev > 0) {
+        return std::make_unique<FArrayBoxFactory>();
+    } else {
+        return makeEBFabFactory(m_geom[amrlev][mglev],
+                                m_grids[amrlev][mglev],
+                                m_dmap[amrlev][mglev],
+                                {1,1,1}, EBSupport::full);
+    }
+}
+
+void
+MLEBNodeFDLaplacian::restriction (int amrlev, int cmglev, MultiFab& crse, MultiFab& fine) const
+{
+    BL_PROFILE("MLEBNodeFDLaplacian::restriction()");
+
+    applyBC(amrlev, cmglev-1, fine, BCMode::Homogeneous, StateMode::Solution);
+
+    bool need_parallel_copy = !amrex::isMFIterSafe(crse, fine);
+    MultiFab cfine;
+    if (need_parallel_copy) {
+        const BoxArray& ba = amrex::coarsen(fine.boxArray(), 2);
+        cfine.define(ba, fine.DistributionMap(), 1, 0);
+    }
+
+    MultiFab* pcrse = (need_parallel_copy) ? &cfine : &crse;
+    const iMultiFab& dmsk = *m_dirichlet_mask[amrlev][cmglev-1];
+
+#ifdef AMREX_USE_OMP
+#pragma omp parallel if (Gpu::notInLaunchRegion())
+#endif
+    for (MFIter mfi(*pcrse, TilingIfNotGPU()); mfi.isValid(); ++mfi)
+    {
+        const Box& bx = mfi.tilebox();
+        Array4<Real> cfab = pcrse->array(mfi);
+        Array4<Real const> const& ffab = fine.const_array(mfi);
+        Array4<int const> const& mfab = dmsk.const_array(mfi);
+        AMREX_HOST_DEVICE_PARALLEL_FOR_3D(bx, i, j, k,
+        {
+            mlndlap_restriction(i,j,k,cfab,ffab,mfab);
+        });
+    }
+
+    if (need_parallel_copy) {
+        crse.ParallelCopy(cfine);
+    }
+}
+
+void
+MLEBNodeFDLaplacian::interpolation (int amrlev, int fmglev, MultiFab& fine,
+                                    const MultiFab& crse) const
+{
+    BL_PROFILE("MLEBNodeFDLaplacian::interpolation()");
+
+    bool need_parallel_copy = !amrex::isMFIterSafe(crse, fine);
+    MultiFab cfine;
+    const MultiFab* cmf = &crse;
+    if (need_parallel_copy) {
+        const BoxArray& ba = amrex::coarsen(fine.boxArray(), 2);
+        cfine.define(ba, fine.DistributionMap(), 1, 0);
+        cfine.ParallelCopy(crse);
+        cmf = &cfine;
+    }
+
+    const iMultiFab& dmsk = *m_dirichlet_mask[amrlev][fmglev];
+
+#ifdef AMREX_USE_OMP
+#pragma omp parallel if (Gpu::notInLaunchRegion())
+#endif
+    for (MFIter mfi(fine, TilingIfNotGPU()); mfi.isValid(); ++mfi)
+    {
+        Box const& bx = mfi.tilebox();
+        Array4<Real> const& ffab = fine.array(mfi);
+        Array4<Real const> const& cfab = cmf->const_array(mfi);
+        Array4<int const> const& mfab = dmsk.const_array(mfi);
+        AMREX_HOST_DEVICE_PARALLEL_FOR_3D(bx, i, j, k,
+        {
+            mlndtslap_interpadd(i,j,k,ffab,cfab,mfab);
+        });
+    }
+}
+
+void
+MLEBNodeFDLaplacian::averageDownSolutionRHS (int /*camrlev*/, MultiFab& /*crse_sol*/,
+                                             MultiFab& /*crse_rhs*/,
+                                             const MultiFab& /*fine_sol*/,
+                                             const MultiFab& /*fine_rhs*/)
+{
+    amrex::Abort("MLEBNodeFDLaplacian::averageDownSolutionRHS: todo");
+}
+
+void
+MLEBNodeFDLaplacian::reflux (int /*crse_amrlev*/, MultiFab& /*res*/,
+                             const MultiFab& /*crse_sol*/, const MultiFab& /*crse_rhs*/,
+                             MultiFab& /*fine_res*/, MultiFab& /*fine_sol*/,
+                             const MultiFab& /*fine_rhs*/) const
+{
+    amrex::Abort("MLEBNodeFDLaplacian::reflux: TODO");
+}
+
+void
+MLEBNodeFDLaplacian::prepareForSolve ()
+{
+    BL_PROFILE("MLEBNodeFDLaplacian::prepareForSolve()");
+
+    MLNodeLinOp::prepareForSolve();
+
+    buildMasks();
+
+    // Set covered nodes to Dirichlet
+    for (int amrlev = 0; amrlev < m_num_amr_levels; ++amrlev) {
+        for (int mglev = 0; mglev < m_num_mg_levels[amrlev]; ++mglev) {
+            auto factory = dynamic_cast<EBFArrayBoxFactory const*>(m_factory[amrlev][mglev].get());
+            if (factory) {
+                auto const& levset = factory->getLevelSet();
+                auto& dmask = *m_dirichlet_mask[amrlev][mglev];
+#ifdef AMREX_USE_OMP
+#pragma omp parallel if (Gpu::notInLaunchRegion())
+#endif
+                for (MFIter mfi(dmask,TilingIfNotGPU()); mfi.isValid(); ++mfi) {
+                    const Box& ndbx = mfi.tilebox();
+                    Array4<int> const& mskarr = dmask.array(mfi);
+                    Array4<Real const> const lstarr = levset.const_array(mfi);
+                    AMREX_HOST_DEVICE_FOR_3D(ndbx, i, j, k,
+                    {
+                        if (lstarr(i,j,k) >= Real(0.0)) {
+                            mskarr(i,j,k) = -1;
+                        }
+                    });
+                }
+            }
+        }
+    }
+
+    m_acoef.clear();
+    m_acoef.emplace_back(amrex::convert(m_grids[0][0],IntVect(1)),
+                         m_dmap[0][0], 1, 0);
+    const auto dxinv = m_geom[0][0].InvCellSizeArray();
+    AMREX_D_TERM(const Real bcx = m_sigma[0]*dxinv[0]*dxinv[0];,
+                 const Real bcy = m_sigma[1]*dxinv[1]*dxinv[1];,
+                 const Real bcz = m_sigma[2]*dxinv[2]*dxinv[2];)
+    m_a_huge = 1.e10 * AMREX_D_TERM(std::abs(bcx),+std::abs(bcy),+std::abs(bcz));
+    Real ahuge = m_a_huge;
+#ifdef AMREX_USE_OMP
+#pragma omp parallel if (Gpu::notInLaunchRegion())
+#endif
+    for (MFIter mfi(m_acoef[0],TilingIfNotGPU()); mfi.isValid(); ++mfi)
+    {
+        Box const& bx = mfi.tilebox();
+        auto const& acf = m_acoef[0].array(mfi);
+        auto const& msk = m_dirichlet_mask[0][0]->const_array(mfi);
+        AMREX_HOST_DEVICE_PARALLEL_FOR_3D(bx, i, j, k,
+        {
+            acf(i,j,k) = msk(i,j,k) ? ahuge : 0.0;
+        });
+    }
+
+    for (int mglev = 1; mglev < m_num_mg_levels[0]; ++mglev) {
+        m_acoef.emplace_back(amrex::convert(m_grids[0][mglev],IntVect(1)),
+                             m_dmap[0][mglev], 1, 0);
+        auto const& fine = m_acoef[mglev-1];
+        auto      & crse = m_acoef[mglev];
+
+        bool need_parallel_copy = !amrex::isMFIterSafe(crse, fine);
+        MultiFab cfine;
+        if (need_parallel_copy) {
+            const BoxArray& ba = amrex::coarsen(fine.boxArray(), 2);
+            cfine.define(ba, fine.DistributionMap(), 1, 0);
+        }
+
+        MultiFab* pcrse = (need_parallel_copy) ? &cfine : &crse;
+
+#ifdef AMREX_USE_OMP
+#pragma omp parallel if (Gpu::notInLaunchRegion())
+#endif
+        for (MFIter mfi(*pcrse, TilingIfNotGPU()); mfi.isValid(); ++mfi)
+        {
+            const Box& bx = mfi.tilebox();
+            Array4<Real> cfab = pcrse->array(mfi);
+            Array4<Real const> const& ffab = fine.const_array(mfi);
+            AMREX_HOST_DEVICE_PARALLEL_FOR_3D(bx, i, j, k,
+            {
+                cfab(i,j,k) = ffab(2*i,2*j,2*k);
+            });
+        }
+
+        if (need_parallel_copy) {
+            crse.ParallelCopy(cfine);
+        }
+    }
+}
+
+void
+MLEBNodeFDLaplacian::Fapply (int amrlev, int mglev, MultiFab& out, const MultiFab& in) const
+{
+    BL_PROFILE("MLEBNodeFDLaplacian::Fapply()");
+
+    const auto dxinv = m_geom[amrlev][mglev].InvCellSizeArray();
+    AMREX_D_TERM(const Real bx = m_sigma[0]*dxinv[0]*dxinv[0];,
+                 const Real by = m_sigma[1]*dxinv[1]*dxinv[1];,
+                 const Real bz = m_sigma[2]*dxinv[2]*dxinv[2];)
+    const auto phieb = (m_in_solution_mode) ? m_s_phi_eb : Real(0.0);
+
+    auto const& dmask = *m_dirichlet_mask[amrlev][mglev];
+
+    auto factory = dynamic_cast<EBFArrayBoxFactory const*>(m_factory[amrlev][mglev].get());
+    if (factory) {
+        auto const& edgecent = factory->getEdgeCent();
+
+#ifdef AMREX_USE_OMP
+#pragma omp parallel if (Gpu::notInLaunchRegion())
+#endif
+        for (MFIter mfi(out,TilingIfNotGPU()); mfi.isValid(); ++mfi)
+        {
+            const Box& box = mfi.tilebox();
+            Array4<Real const> const& xarr = in.const_array(mfi);
+            Array4<Real> const& yarr = out.array(mfi);
+            Array4<int const> const& dmarr = dmask.const_array(mfi);
+            bool cutfab = edgecent[0]->ok(mfi);
+            AMREX_D_TERM(Array4<Real const> const& ecx
+                             = cutfab ? edgecent[0]->const_array(mfi) : Array4<Real const>{};,
+                         Array4<Real const> const& ecy
+                             = cutfab ? edgecent[1]->const_array(mfi) : Array4<Real const>{};,
+                         Array4<Real const> const& ecz
+                             = cutfab ? edgecent[2]->const_array(mfi) : Array4<Real const>{};)
+            if (phieb == std::numeric_limits<Real>::lowest()) {
+                auto const& phiebarr = m_phi_eb[amrlev].const_array(mfi);
+                AMREX_HOST_DEVICE_FOR_3D(box, i, j, k,
+                {
+                    mlebndfdlap_adotx_eb(i,j,k,yarr,xarr,dmarr,AMREX_D_DECL(ecx,ecy,ecz),
+                                         phiebarr, AMREX_D_DECL(bx,by,bz));
+                });
+            } else {
+                AMREX_HOST_DEVICE_FOR_3D(box, i, j, k,
+                {
+                    mlebndfdlap_adotx_eb(i,j,k,yarr,xarr,dmarr,AMREX_D_DECL(ecx,ecy,ecz),
+                                         phieb, AMREX_D_DECL(bx,by,bz));
+                });
+            }
+        }
+    } else {
+        AMREX_ALWAYS_ASSERT(amrlev == 0);
+        auto const& acoef = m_acoef[mglev];
+#ifdef AMREX_USE_OMP
+#pragma omp parallel if (Gpu::notInLaunchRegion())
+#endif
+        for (MFIter mfi(out,TilingIfNotGPU()); mfi.isValid(); ++mfi)
+        {
+            const Box& box = mfi.tilebox();
+            Array4<Real const> const& xarr = in.const_array(mfi);
+            Array4<Real> const& yarr = out.array(mfi);
+            Array4<int const> const& dmarr = dmask.const_array(mfi);
+            Array4<Real const> const& acarr = acoef.const_array(mfi);
+            AMREX_HOST_DEVICE_FOR_3D(box, i, j, k,
+            {
+                mlebndfdlap_adotx(i,j,k,yarr,xarr,dmarr,acarr,AMREX_D_DECL(bx,by,bz));
+            });
+        }
+    }
+}
+
+void
+MLEBNodeFDLaplacian::Fsmooth (int amrlev, int mglev, MultiFab& sol, const MultiFab& rhs) const
+{
+    BL_PROFILE("MLEBNodeFDLaplacian::Fsmooth()");
+
+    const auto dxinv = m_geom[amrlev][mglev].InvCellSizeArray();
+    AMREX_D_TERM(const Real bx = m_sigma[0]*dxinv[0]*dxinv[0];,
+                 const Real by = m_sigma[1]*dxinv[1]*dxinv[1];,
+                 const Real bz = m_sigma[2]*dxinv[2]*dxinv[2];)
+
+    auto const& dmask = *m_dirichlet_mask[amrlev][mglev];
+
+    for (int redblack = 0; redblack < 4; ++redblack) {
+        if (redblack > 0) {
+            applyBC(amrlev, mglev, sol, BCMode::Homogeneous, StateMode::Correction);
+        }
+
+        auto factory = dynamic_cast<EBFArrayBoxFactory const*>(m_factory[amrlev][mglev].get());
+        if (factory) {
+            auto const& edgecent = factory->getEdgeCent();
+
+#ifdef AMREX_USE_OMP
+#pragma omp parallel if (Gpu::notInLaunchRegion())
+#endif
+            for (MFIter mfi(sol,TilingIfNotGPU()); mfi.isValid(); ++mfi)
+            {
+                const Box& box = mfi.tilebox();
+                Array4<Real> const& solarr = sol.array(mfi);
+                Array4<Real const> const& rhsarr = rhs.const_array(mfi);
+                Array4<int const> const& dmskarr = dmask.const_array(mfi);
+                bool cutfab = edgecent[0]->ok(mfi);
+                AMREX_D_TERM(Array4<Real const> const& ecx
+                                 = cutfab ? edgecent[0]->const_array(mfi) : Array4<Real const>{};,
+                             Array4<Real const> const& ecy
+                                 = cutfab ? edgecent[1]->const_array(mfi) : Array4<Real const>{};,
+                             Array4<Real const> const& ecz
+                                 = cutfab ? edgecent[2]->const_array(mfi) : Array4<Real const>{};)
+
+                AMREX_HOST_DEVICE_FOR_3D(box, i, j, k,
+                {
+                    mlebndfdlap_gsrb_eb(i,j,k,solarr,rhsarr,dmskarr,AMREX_D_DECL(ecx,ecy,ecz),
+                                        AMREX_D_DECL(bx,by,bz), redblack);
+                });
+            }
+        } else {
+            AMREX_ALWAYS_ASSERT(amrlev == 0);
+            auto const& acoef = m_acoef[mglev];
+#ifdef AMREX_USE_OMP
+#pragma omp parallel if (Gpu::notInLaunchRegion())
+#endif
+            for (MFIter mfi(sol,TilingIfNotGPU()); mfi.isValid(); ++mfi)
+            {
+                const Box& box = mfi.tilebox();
+                Array4<Real> const& solarr = sol.array(mfi);
+                Array4<Real const> const& rhsarr = rhs.const_array(mfi);
+                Array4<int const> const& dmskarr = dmask.const_array(mfi);
+                Array4<Real const> const& acarr = acoef.const_array(mfi);
+                AMREX_HOST_DEVICE_FOR_3D(box, i, j, k,
+                {
+                    mlebndfdlap_gsrb(i,j,k,solarr,rhsarr,dmskarr,acarr,
+                                     AMREX_D_DECL(bx,by,bz), redblack);
+                });
+            }
+        }
+    }
+
+    nodalSync(amrlev, mglev, sol);
+}
+
+void
+MLEBNodeFDLaplacian::normalize (int amrlev, int mglev, MultiFab& mf) const
+{
+    if (amrlev == 0 && mglev > 0) {
+        Real ahugeinv = Real(1.0) / m_a_huge;
+        auto const& acoef = m_acoef[mglev];
+#ifdef AMREX_USE_OMP
+#pragma omp parallel if (Gpu::notInLaunchRegion())
+#endif
+        for (MFIter mfi(mf,TilingIfNotGPU()); mfi.isValid(); ++mfi)
+        {
+            const Box& box = mfi.tilebox();
+            Array4<Real> const& fab = mf.array(mfi);
+            Array4<Real const> const& acarr = acoef.const_array(mfi);
+            AMREX_HOST_DEVICE_PARALLEL_FOR_3D(box, i, j, k,
+            {
+                if (acarr(i,j,k) > Real(0.0)) {
+                    fab(i,j,k) *= ahugeinv;
+                }
+            });
+        }
+    }
+}
+
+void
+MLEBNodeFDLaplacian::fixUpResidualMask (int /*amrlev*/, iMultiFab& /*resmsk*/)
+{
+    amrex::Abort("MLEBNodeFDLaplacian::fixUpResidualMask: TODO");
+}
+
+#if defined(AMREX_USE_HYPRE)
+void
+MLEBNodeFDLaplacian::fillIJMatrix (MFIter const& mfi,
+                                   Array4<HypreNodeLap::AtomicInt const> const& gid,
+                                   Array4<int const> const& lid,
+                                   HypreNodeLap::Int* const ncols,
+                                   HypreNodeLap::Int* const cols,
+                                   Real* const mat) const
+{
+    amrex::Abort("MLEBNodeFDLaplacian::fillIJMatrix: todo");
+}
+
+void
+MLEBNodeFDLaplacian::fillRHS (MFIter const& mfi, Array4<int const> const& lid,
+                              Real* const rhs, Array4<Real const> const& bfab) const
+{
+    amrex::Abort("MLEBNodeFDLaplacian::fillRHS: todo");
+}
+#endif
+
+}

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLinOp.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLinOp.H
@@ -33,7 +33,8 @@ public:
                  const Vector<BoxArray>& a_grids,
                  const Vector<DistributionMapping>& a_dmap,
                  const LPInfo& a_info = LPInfo(),
-                 const Vector<FabFactory<FArrayBox> const*>& a_factory = {});
+                 const Vector<FabFactory<FArrayBox> const*>& a_factory = {},
+                 int a_eb_limit_coarsening = -1);
 
     virtual void setLevelBC (int /*amrlev*/, const MultiFab* /*levelbcdata*/,
                              const MultiFab* = nullptr, const MultiFab* = nullptr,
@@ -141,6 +142,8 @@ protected:
     bool m_is_bottom_singular = false;
     bool m_masks_built = false;
     bool m_overset_dirichlet_mask = false;
+
+    mutable bool m_in_solution_mode = true;
 };
 
 }

--- a/Src/LinearSolvers/MLMG/Make.package
+++ b/Src/LinearSolvers/MLMG/Make.package
@@ -75,6 +75,11 @@ CEXE_sources   += AMReX_MLEBABecLap_F.cpp
 CEXE_headers   += AMReX_MLEBABecLap_K.H
 CEXE_headers   += AMReX_MLEBABecLap_$(DIM)D_K.H
 
+CEXE_headers   += AMReX_MLEBNodeFDLaplacian.H
+CEXE_sources   += AMReX_MLEBNodeFDLaplacian.cpp
+CEXE_headers   += AMReX_MLEBNodeFDLap_K.H
+CEXE_headers   += AMReX_MLEBNodeFDLap_$(DIM)D_K.H
+
 CEXE_headers   += AMReX_MLEBTensorOp.H
 CEXE_sources   += AMReX_MLEBTensorOp.cpp
 CEXE_sources   += AMReX_MLEBTensorOp_bc.cpp


### PR DESCRIPTION
New EB nodal solver with Dirichlet EB.  This uses a finite-difference
stencil.  It will be used by WarpX's static solver.  Currently only
Dirichlet and periodic domain BC are supported.  Support for Neumann BC at
the domain boundary will be added later.  Currently, it supports single
level only.

## Summary

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
