### PR TITLE
Fix the size of the BC Vector in the multi-level version of ParticleToMesh.

### DIFF
--- a/Src/AmrCore/AMReX_AmrParticles.H
+++ b/Src/AmrCore/AMReX_AmrParticles.H
@@ -202,7 +202,7 @@ ParticleToMesh (PC const& pc, const Vector<MultiFab*>& mf,
     // configure this to do a no-op at the physical boundaries.
     int lo_bc[] = {BCType::int_dir, BCType::int_dir, BCType::int_dir};
     int hi_bc[] = {BCType::int_dir, BCType::int_dir, BCType::int_dir};
-    Vector<BCRec> bcs(1, BCRec(lo_bc, hi_bc));
+    Vector<BCRec> bcs(mf_part[lev_min].nComp(), BCRec(lo_bc, hi_bc));
     PCInterp mapper;
 
     for (int lev = lev_min; lev <= lev_max; ++lev)


### PR DESCRIPTION
The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
