### PR TITLE
Disable `jn` on Windows

### DIFF
--- a/Src/Base/Parser/AMReX_Parser_Y.H
+++ b/Src/Base/Parser/AMReX_Parser_Y.H
@@ -255,7 +255,7 @@ parser_call_f2 (enum parser_f2_t type, Real a, Real b)
     case PARSER_HEAVISIDE:
         return (a < Real(0.0)) ? Real(0.0) : ((a > Real(0.0)) ? Real(1.0) : b);
     case PARSER_JN:
-#ifdef AMREX_USE_DPCPP
+#if defined AMREX_USE_DPCPP || defined __MINGW32__
         // neither jn(f) nor std::cyl_bessel_j work yet
         // https://github.com/oneapi-src/oneAPI-spec/issues/308
         AMREX_ALWAYS_ASSERT_WITH_MESSAGE(false, "parser_call_f2: jn in SYCL/DPC++ not supported yet");


### PR DESCRIPTION
## Summary

Disable `jn` on Windows – not just when `dpcpp` is used, but also when building with other compilers in MINGW.

## Additional background

Windows does not support the `jn` function; it is not part of the C++ standard.

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
