### PR TITLE
Parser Precision

### DIFF
--- a/Src/Base/Parser/AMReX_Parser.H
+++ b/Src/Base/Parser/AMReX_Parser.H
@@ -5,6 +5,7 @@
 #include <AMReX_Array.H>
 #include <AMReX_GpuDevice.H>
 #include <AMReX_Parser_Exe.H>
+#include <AMReX_REAL.H>
 #include <AMReX_Vector.H>
 
 #include <memory>
@@ -18,7 +19,7 @@ struct ParserExecutor
 {
     template <int M=N, typename std::enable_if_t<M==0,int> = 0>
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-    Real operator() () const noexcept
+    double operator() () const noexcept
     {
 #if AMREX_DEVICE_COMPILE
         return parser_exe_eval(m_device_executor, nullptr);
@@ -29,10 +30,10 @@ struct ParserExecutor
 
     template <typename... Ts>
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-    std::enable_if_t<sizeof...(Ts) == N && amrex::Same<amrex::Real,Ts...>::value, amrex::Real>
+    std::enable_if_t<sizeof...(Ts) == N && !amrex::Same<float,Ts...>::value, double>
     operator() (Ts... var) const noexcept
     {
-        amrex::GpuArray<amrex::Real,N> l_var{var...};
+        amrex::GpuArray<double,N> l_var{var...};
 #if AMREX_DEVICE_COMPILE
         return parser_exe_eval(m_device_executor, l_var.data());
 #else
@@ -40,8 +41,21 @@ struct ParserExecutor
 #endif
     }
 
+    template <typename... Ts>
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-    Real operator() (GpuArray<Real,N> const& var) const noexcept
+    std::enable_if_t<sizeof...(Ts) == N &&  amrex::Same<float,Ts...>::value, float>
+    operator() (Ts... var) const noexcept
+    {
+        amrex::GpuArray<double,N> l_var{var...};
+#if AMREX_DEVICE_COMPILE
+        return static_cast<float>(parser_exe_eval(m_device_executor, l_var.data()));
+#else
+        return static_cast<float>(parser_exe_eval(m_host_executor, l_var.data()));
+#endif
+    }
+
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    double operator() (GpuArray<double,N> const& var) const noexcept
     {
 #if AMREX_DEVICE_COMPILE
         return parser_exe_eval(m_device_executor, var.data());
@@ -75,7 +89,7 @@ public:
 
     explicit operator bool () const;
 
-    void setConstant (std::string const& name, amrex::Real c);
+    void setConstant (std::string const& name, double c);
 
     void registerVariables (Vector<std::string> const& vars);
 

--- a/Src/Base/Parser/AMReX_Parser.cpp
+++ b/Src/Base/Parser/AMReX_Parser.cpp
@@ -52,7 +52,7 @@ Parser::operator bool () const
 }
 
 void
-Parser::setConstant (std::string const& name, amrex::Real c)
+Parser::setConstant (std::string const& name, double c)
 {
     if (m_data && m_data->m_parser) {
         parser_setconst(m_data->m_parser, name.c_str(), c);

--- a/Src/Base/Parser/AMReX_Parser_Exe.H
+++ b/Src/Base/Parser/AMReX_Parser_Exe.H
@@ -16,7 +16,7 @@ namespace amrex {
 
 // N: node
 // P: pointer offset
-// V: value (i.e., Real literal)
+// V: value (i.e., double literal)
 
 enum parser_exe_t {
     PARSER_EXE_NULL = 0,
@@ -58,7 +58,7 @@ struct alignas(8) ParserExeNull {
 
 struct alignas(8) ParserExeNumber {
     enum parser_exe_t type = PARSER_EXE_NUMBER;
-    Real v;
+    double v;
 };
 
 struct alignas(8) ParserExeSymbol {
@@ -72,7 +72,7 @@ struct alignas(8) ParserExeADD {
 
 struct alignas(8) ParserExeSUB {
     enum parser_exe_t type = PARSER_EXE_SUB;
-    Real sign;
+    double sign;
 };
 
 struct alignas(8) ParserExeMUL {
@@ -109,25 +109,25 @@ struct alignas(8) ParserExeF2_B {
 struct alignas(8) ParserExeADD_VP {
     enum parser_exe_t type = PARSER_EXE_ADD_VP;
     int i;
-    Real v;
+    double v;
 };
 
 struct alignas(8) ParserExeSUB_VP {
     enum parser_exe_t type = PARSER_EXE_SUB_VP;
     int i;
-    Real v;
+    double v;
 };
 
 struct alignas(8) ParserExeMUL_VP {
     enum parser_exe_t type = PARSER_EXE_MUL_VP;
     int i;
-    Real v;
+    double v;
 };
 
 struct alignas(8) ParserExeDIV_VP {
     enum parser_exe_t type = PARSER_EXE_DIV_VP;
     int i;
-    Real v;
+    double v;
 };
 
 struct alignas(8) ParserExeADD_PP {
@@ -161,22 +161,22 @@ struct alignas(8) ParserExeNEG_P {
 
 struct alignas(8) ParserExeADD_VN {
     enum parser_exe_t type = PARSER_EXE_ADD_VN;
-    Real v;
+    double v;
 };
 
 struct alignas(8) ParserExeSUB_VN {
     enum parser_exe_t type = PARSER_EXE_SUB_VN;
-    Real v;
+    double v;
 };
 
 struct alignas(8) ParserExeMUL_VN {
     enum parser_exe_t type = PARSER_EXE_MUL_VN;
-    Real v;
+    double v;
 };
 
 struct alignas(8) ParserExeDIV_VN {
     enum parser_exe_t type = PARSER_EXE_DIV_VN;
-    Real v;
+    double v;
 };
 
 struct alignas(8) ParserExeADD_PN {
@@ -187,7 +187,7 @@ struct alignas(8) ParserExeADD_PN {
 struct alignas(8) ParserExeSUB_PN {
     enum parser_exe_t type = PARSER_EXE_SUB_PN;
     int i;
-    Real sign;
+    double sign;
 };
 
 struct alignas(8) ParserExeMUL_PN {
@@ -214,17 +214,17 @@ struct alignas(8) ParserExeJUMP {
 template <int N>
 struct ParserStack
 {
-    Real m_data[N];
+    double m_data[N];
     int m_size = 0;
-    constexpr void push (Real v) { m_data[m_size++] = v; }
+    constexpr void push (double v) { m_data[m_size++] = v; }
     constexpr void pop () { --m_size; }
-    constexpr Real const& top () const { return m_data[m_size-1]; }
-    constexpr Real      & top ()       { return m_data[m_size-1]; }
-    constexpr Real operator[] (int i) const { return m_data[i]; }
+    constexpr double const& top () const { return m_data[m_size-1]; }
+    constexpr double      & top ()       { return m_data[m_size-1]; }
+    constexpr double operator[] (int i) const { return m_data[i]; }
 };
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-Real parser_exe_eval (char* p, Real const* x)
+double parser_exe_eval (char* p, double const* x)
 {
     ParserStack<AMREX_PARSER_STACK_SIZE> pstack;
     while (*((parser_exe_t*)p) != PARSER_EXE_NULL) {
@@ -239,14 +239,14 @@ Real parser_exe_eval (char* p, Real const* x)
         case PARSER_EXE_SYMBOL:
         {
             int i = ((ParserExeSymbol*)p)->i;
-            Real d = AMREX_PARSER_GET_DATA(i);
+            double d = AMREX_PARSER_GET_DATA(i);
             pstack.push(d);
             p     += sizeof(ParserExeSymbol);
             break;
         }
         case PARSER_EXE_ADD:
         {
-            Real b = pstack.top();
+            double b = pstack.top();
             pstack.pop();
             pstack.top() += b;
             p += sizeof(ParserExeADD);
@@ -254,7 +254,7 @@ Real parser_exe_eval (char* p, Real const* x)
         }
         case PARSER_EXE_SUB:
         {
-            Real b = pstack.top();
+            double b = pstack.top();
             pstack.pop();
             pstack.top() = (pstack.top() - b) * (((ParserExeSUB*)p)->sign);
             p += sizeof(ParserExeSUB);
@@ -262,7 +262,7 @@ Real parser_exe_eval (char* p, Real const* x)
         }
         case PARSER_EXE_MUL:
         {
-            Real b = pstack.top();
+            double b = pstack.top();
             pstack.pop();
             pstack.top() *= b;
             p += sizeof(ParserExeMUL);
@@ -270,7 +270,7 @@ Real parser_exe_eval (char* p, Real const* x)
         }
         case PARSER_EXE_DIV_F:
         {
-            Real v = pstack.top();
+            double v = pstack.top();
             pstack.pop();
             pstack.top() /= v;
             p += sizeof(ParserExeDIV_F);
@@ -278,7 +278,7 @@ Real parser_exe_eval (char* p, Real const* x)
         }
         case PARSER_EXE_DIV_B:
         {
-            Real v = pstack.top();
+            double v = pstack.top();
             pstack.pop();
             pstack.top() = v / pstack.top();
             p += sizeof(ParserExeDIV_B);
@@ -298,7 +298,7 @@ Real parser_exe_eval (char* p, Real const* x)
         }
         case PARSER_EXE_F2_F:
         {
-            Real v = pstack.top();
+            double v = pstack.top();
             pstack.pop();
             pstack.top() = parser_call_f2(((ParserExeF2_F*)p)->ftype, pstack.top(), v);
             p += sizeof(ParserExeF2_F);
@@ -306,7 +306,7 @@ Real parser_exe_eval (char* p, Real const* x)
         }
         case PARSER_EXE_F2_B:
         {
-            Real v = pstack.top();
+            double v = pstack.top();
             pstack.pop();
             pstack.top() = parser_call_f2(((ParserExeF2_B*)p)->ftype, v, pstack.top());
             p += sizeof(ParserExeF2_B);
@@ -315,7 +315,7 @@ Real parser_exe_eval (char* p, Real const* x)
         case PARSER_EXE_ADD_VP:
         {
             int i = ((ParserExeADD_VP*)p)->i;
-            Real d = AMREX_PARSER_GET_DATA(i);
+            double d = AMREX_PARSER_GET_DATA(i);
             pstack.push(((ParserExeADD_VP*)p)->v + d);
             p     += sizeof(ParserExeADD_VP);
             break;
@@ -323,7 +323,7 @@ Real parser_exe_eval (char* p, Real const* x)
         case PARSER_EXE_SUB_VP:
         {
             int i = ((ParserExeSUB_VP*)p)->i;
-            Real d = AMREX_PARSER_GET_DATA(i);
+            double d = AMREX_PARSER_GET_DATA(i);
             pstack.push(((ParserExeSUB_VP*)p)->v - d);
             p     += sizeof(ParserExeSUB_VP);
             break;
@@ -331,7 +331,7 @@ Real parser_exe_eval (char* p, Real const* x)
         case PARSER_EXE_MUL_VP:
         {
             int i = ((ParserExeMUL_VP*)p)->i;
-            Real d = AMREX_PARSER_GET_DATA(i);
+            double d = AMREX_PARSER_GET_DATA(i);
             pstack.push(((ParserExeMUL_VP*)p)->v * d);
             p     += sizeof(ParserExeMUL_VP);
             break;
@@ -339,7 +339,7 @@ Real parser_exe_eval (char* p, Real const* x)
         case PARSER_EXE_DIV_VP:
         {
             int i = ((ParserExeDIV_VP*)p)->i;
-            Real d = AMREX_PARSER_GET_DATA(i);
+            double d = AMREX_PARSER_GET_DATA(i);
             pstack.push(((ParserExeDIV_VP*)p)->v / d);
             p     += sizeof(ParserExeDIV_VP);
             break;
@@ -347,9 +347,9 @@ Real parser_exe_eval (char* p, Real const* x)
         case PARSER_EXE_ADD_PP:
         {
             int i = ((ParserExeADD_PP*)p)->i1;
-            Real d1 = AMREX_PARSER_GET_DATA(i);
+            double d1 = AMREX_PARSER_GET_DATA(i);
             i     = ((ParserExeADD_PP*)p)->i2;
-            Real d2 = AMREX_PARSER_GET_DATA(i);
+            double d2 = AMREX_PARSER_GET_DATA(i);
             pstack.push(d1+d2);
             p     += sizeof(ParserExeADD_PP);
             break;
@@ -357,9 +357,9 @@ Real parser_exe_eval (char* p, Real const* x)
         case PARSER_EXE_SUB_PP:
         {
             int i = ((ParserExeSUB_PP*)p)->i1;
-            Real d1 = AMREX_PARSER_GET_DATA(i);
+            double d1 = AMREX_PARSER_GET_DATA(i);
             i     = ((ParserExeSUB_PP*)p)->i2;
-            Real d2 = AMREX_PARSER_GET_DATA(i);
+            double d2 = AMREX_PARSER_GET_DATA(i);
             pstack.push(d1-d2);
             p     += sizeof(ParserExeSUB_PP);
             break;
@@ -367,9 +367,9 @@ Real parser_exe_eval (char* p, Real const* x)
         case PARSER_EXE_MUL_PP:
         {
             int i = ((ParserExeMUL_PP*)p)->i1;
-            Real d1 = AMREX_PARSER_GET_DATA(i);
+            double d1 = AMREX_PARSER_GET_DATA(i);
             i     = ((ParserExeMUL_PP*)p)->i2;
-            Real d2 = AMREX_PARSER_GET_DATA(i);
+            double d2 = AMREX_PARSER_GET_DATA(i);
             pstack.push(d1*d2);
             p     += sizeof(ParserExeMUL_PP);
             break;
@@ -377,9 +377,9 @@ Real parser_exe_eval (char* p, Real const* x)
         case PARSER_EXE_DIV_PP:
         {
             int i = ((ParserExeDIV_PP*)p)->i1;
-            Real d1 = AMREX_PARSER_GET_DATA(i);
+            double d1 = AMREX_PARSER_GET_DATA(i);
             i     = ((ParserExeDIV_PP*)p)->i2;
-            Real d2 = AMREX_PARSER_GET_DATA(i);
+            double d2 = AMREX_PARSER_GET_DATA(i);
             pstack.push(d1/d2);
             p      += sizeof(ParserExeDIV_PP);
             break;
@@ -387,7 +387,7 @@ Real parser_exe_eval (char* p, Real const* x)
         case PARSER_EXE_NEG_P:
         {
             int i = ((ParserExeNEG_P*)p)->i;
-            Real d = AMREX_PARSER_GET_DATA(i);
+            double d = AMREX_PARSER_GET_DATA(i);
             pstack.push(-d);
             p     += sizeof(ParserExeNEG_P);
             break;
@@ -419,7 +419,7 @@ Real parser_exe_eval (char* p, Real const* x)
         case PARSER_EXE_ADD_PN:
         {
             int i = ((ParserExeADD_PN*)p)->i;
-            Real d = AMREX_PARSER_GET_DATA(i);
+            double d = AMREX_PARSER_GET_DATA(i);
             pstack.top() += d;
             p         += sizeof(ParserExeADD_PN);
             break;
@@ -427,7 +427,7 @@ Real parser_exe_eval (char* p, Real const* x)
         case PARSER_EXE_SUB_PN:
         {
             int i = ((ParserExeSUB_PN*)p)->i;
-            Real d = AMREX_PARSER_GET_DATA(i);
+            double d = AMREX_PARSER_GET_DATA(i);
             pstack.top() = (d - pstack.top()) * (((ParserExeSUB_PN*)p)->sign);
             p         += sizeof(ParserExeSUB_PN);
             break;
@@ -435,7 +435,7 @@ Real parser_exe_eval (char* p, Real const* x)
         case PARSER_EXE_MUL_PN:
         {
             int i = ((ParserExeMUL_PN*)p)->i;
-            Real d = AMREX_PARSER_GET_DATA(i);
+            double d = AMREX_PARSER_GET_DATA(i);
             pstack.top() *= d;
             p         += sizeof(ParserExeMUL_PN);
             break;
@@ -443,7 +443,7 @@ Real parser_exe_eval (char* p, Real const* x)
         case PARSER_EXE_DIV_PN:
         {
             int i = ((ParserExeDIV_PN*)p)->i;
-            Real d = AMREX_PARSER_GET_DATA(i);
+            double d = AMREX_PARSER_GET_DATA(i);
             if (((ParserExeDIV_PN*)p)->reverse) {
                 pstack.top() /= d;
             } else {
@@ -454,9 +454,9 @@ Real parser_exe_eval (char* p, Real const* x)
         }
         case PARSER_EXE_IF:
         {
-            Real cond = pstack.top();
+            double cond = pstack.top();
             pstack.pop();
-            if (cond == Real(0.0)) { // false branch
+            if (cond == 0.0) { // false branch
                 p += ((ParserExeIF*)p)->offset;
             }
             p += sizeof(ParserExeIF);

--- a/Src/Base/Parser/AMReX_Parser_Exe.cpp
+++ b/Src/Base/Parser/AMReX_Parser_Exe.cpp
@@ -330,7 +330,7 @@ parser_compile_exe_size (struct parser_node* node, char*& p, std::size_t& exe_si
             if (p) {
                 auto t = new(p) ParserExeMUL_VN;
                 p     += sizeof(ParserExeMUL_VN);
-                t->v = Real(1.0) / ((struct parser_number*)(node->r))->value;
+                t->v = 1.0 / ((struct parser_number*)(node->r))->value;
             }
             exe_size += sizeof(ParserExeMUL_VN);
         }

--- a/Src/Base/Parser/AMReX_Parser_Y.H
+++ b/Src/Base/Parser/AMReX_Parser_Y.H
@@ -95,7 +95,7 @@ enum parser_node_t {
 
 union parser_nvp {
     struct parser_node* n;
-    Real v;
+    double v;
     int ip;
 };
 
@@ -109,7 +109,7 @@ struct parser_node {
 
 struct parser_number {
     enum parser_node_t type;
-    Real value;
+    double value;
 };
 
 struct parser_symbol {
@@ -154,7 +154,7 @@ void parser_defexpr (struct parser_node* body);
 struct parser_symbol* parser_makesymbol (char* name);
 struct parser_node* parser_newnode (enum parser_node_t type, struct parser_node* l,
                                     struct parser_node* r);
-struct parser_node* parser_newnumber (Real d);
+struct parser_node* parser_newnumber (double d);
 struct parser_node* parser_newsymbol (struct parser_symbol* sym);
 struct parser_node* parser_newf1 (enum parser_f1_t ftype, struct parser_node* l);
 struct parser_node* parser_newf2 (enum parser_f2_t ftype, struct parser_node* l,
@@ -184,7 +184,7 @@ struct amrex_parser* parser_dup (struct amrex_parser* source);
 struct parser_node* parser_ast_dup (struct amrex_parser* parser, struct parser_node* src, int move);
 
 void parser_regvar (struct amrex_parser* parser, char const* name, int i);
-void parser_setconst (struct amrex_parser* parser, char const* name, Real c);
+void parser_setconst (struct amrex_parser* parser, char const* name, double c);
 void parser_print (struct amrex_parser* parser);
 std::set<std::string> parser_get_symbols (struct amrex_parser* parser);
 int parser_depth (struct amrex_parser* parser);
@@ -194,14 +194,14 @@ void parser_ast_optimize (struct parser_node* node);
 std::size_t parser_ast_size (struct parser_node* node);
 void parser_ast_print (struct parser_node* node, std::string const& space, AllPrint& printer);
 void parser_ast_regvar (struct parser_node* node, char const* name, int i);
-void parser_ast_setconst (struct parser_node* node, char const* name, Real c);
+void parser_ast_setconst (struct parser_node* node, char const* name, double c);
 void parser_ast_get_symbols (struct parser_node* node, std::set<std::string>& symbols);
 int parser_ast_depth (struct parser_node* node);
 
 /*******************************************************************/
 
-AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE Real
-parser_call_f1 (enum parser_f1_t type, Real a)
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE double
+parser_call_f1 (enum parser_f1_t type, double a)
 {
     switch (type) {
     case PARSER_SQRT:        return std::sqrt(a);
@@ -218,42 +218,42 @@ parser_call_f1 (enum parser_f1_t type, Real a)
     case PARSER_COSH:        return std::cosh(a);
     case PARSER_TANH:        return std::tanh(a);
     case PARSER_ABS:         return amrex::Math::abs(a);
-    case PARSER_POW_M3:      return amrex::Real(1.0)/(a*a*a);
-    case PARSER_POW_M2:      return amrex::Real(1.0)/(a*a);
-    case PARSER_POW_M1:      return amrex::Real(1.0)/a;
+    case PARSER_POW_M3:      return 1.0/(a*a*a);
+    case PARSER_POW_M2:      return 1.0/(a*a);
+    case PARSER_POW_M1:      return 1.0/a;
     case PARSER_POW_P1:      return a;
     case PARSER_POW_P2:      return a*a;
     case PARSER_POW_P3:      return a*a*a;
     default:
         amrex::Abort("parser_call_f1: Unknown function ");
-        return Real(0.0);
+        return 0.0;
     }
 }
 
-AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE Real
-parser_call_f2 (enum parser_f2_t type, Real a, Real b)
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE double
+parser_call_f2 (enum parser_f2_t type, double a, double b)
 {
     switch (type) {
     case PARSER_POW:
         return std::pow(a,b);
     case PARSER_GT:
-        return (a > b) ? Real(1.0) : Real(0.0);
+        return (a > b) ? 1.0 : 0.0;
     case PARSER_LT:
-        return (a < b) ? Real(1.0) : Real(0.0);
+        return (a < b) ? 1.0 : 0.0;
     case PARSER_GEQ:
-        return (a >= b) ? Real(1.0) : Real(0.0);
+        return (a >= b) ? 1.0 : 0.0;
     case PARSER_LEQ:
-        return (a <= b) ? Real(1.0) : Real(0.0);
+        return (a <= b) ? 1.0 : 0.0;
     case PARSER_EQ:
-        return (a == b) ? Real(1.0) : Real(0.0);
+        return (a == b) ? 1.0 : 0.0;
     case PARSER_NEQ:
-        return (a != b) ? Real(1.0) : Real(0.0);
+        return (a != b) ? 1.0 : 0.0;
     case PARSER_AND:
-        return ((a != Real(0.0)) && (b != Real(0.0))) ? Real(1.0) : Real(0.0);
+        return ((a != 0.0) && (b != 0.0)) ? 1.0 : 0.0;
     case PARSER_OR:
-        return ((a != Real(0.0)) || (b != Real(0.0))) ? Real(1.0) : Real(0.0);
+        return ((a != 0.0) || (b != 0.0)) ? 1.0 : 0.0;
     case PARSER_HEAVISIDE:
-        return (a < Real(0.0)) ? Real(0.0) : ((a > Real(0.0)) ? Real(1.0) : b);
+        return (a < 0.0) ? 0.0 : ((a > 0.0) ? 1.0 : b);
     case PARSER_JN:
 #if defined AMREX_USE_DPCPP || defined __MINGW32__
         // neither jn(f) nor std::cyl_bessel_j work yet
@@ -261,11 +261,7 @@ parser_call_f2 (enum parser_f2_t type, Real a, Real b)
         AMREX_ALWAYS_ASSERT_WITH_MESSAGE(false, "parser_call_f2: jn in SYCL/DPC++ not supported yet");
         return 0.0;
 #else
-#   if defined(AMREX_USE_FLOAT) && !defined(__APPLE__)
-        return jnf(int(a), b);
-#   else
         return jn(int(a), b);
-#   endif
 #endif
     case PARSER_MIN:
         return (a < b) ? a : b;
@@ -273,15 +269,15 @@ parser_call_f2 (enum parser_f2_t type, Real a, Real b)
         return (a > b) ? a : b;
     default:
         amrex::Abort("parser_call_f2: Unknown function");
-        return Real(0.0);
+        return 0.0;
     }
 }
 
-AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE Real
-parser_call_f3 (enum parser_f3_t /*type*/, Real a, Real b, Real c)
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE double
+parser_call_f3 (enum parser_f3_t /*type*/, double a, double b, double c)
 {
     // There is only one type currently
-    return (a != Real(0.0)) ? b : c;
+    return (a != 0.0) ? b : c;
 }
 
 }

--- a/Src/Base/Parser/AMReX_Parser_Y.cpp
+++ b/Src/Base/Parser/AMReX_Parser_Y.cpp
@@ -48,7 +48,7 @@ parser_newnode (enum parser_node_t type, struct parser_node* l, struct parser_no
 }
 
 struct parser_node*
-parser_newnumber (Real d)
+parser_newnumber (double d)
 {
     auto r = (struct parser_number*) std::malloc(sizeof(struct parser_number));
     r->type = PARSER_NUMBER;
@@ -388,7 +388,7 @@ parser_ast_optimize (struct parser_node* node)
         if (node->l->type == PARSER_NUMBER &&
             node->r->type == PARSER_NUMBER)
         {
-            Real v = ((struct parser_number*)(node->l))->value
+            double v = ((struct parser_number*)(node->l))->value
                 +    ((struct parser_number*)(node->r))->value;
             ((struct parser_number*)node)->type = PARSER_NUMBER;
             ((struct parser_number*)node)->value = v;
@@ -418,28 +418,28 @@ parser_ast_optimize (struct parser_node* node)
         else if (node->l->type == PARSER_NUMBER &&
                  node->r->type == PARSER_ADD_VP)
         {
-            Real v = ((struct parser_number*)(node->l))->value + PARSER_EVAL_R(node);
+            double v = ((struct parser_number*)(node->l))->value + PARSER_EVAL_R(node);
             PARSER_MOVEUP_R(node, v);
             node->type = PARSER_ADD_VP;
         }
         else if (node->l->type == PARSER_NUMBER &&
                  node->r->type == PARSER_SUB_VP)
         {
-            Real v = ((struct parser_number*)(node->l))->value + PARSER_EVAL_R(node);
+            double v = ((struct parser_number*)(node->l))->value + PARSER_EVAL_R(node);
             PARSER_MOVEUP_R(node, v);
             node->type = PARSER_SUB_VP;
         }
         else if (node->l->type == PARSER_ADD_VP &&
                  node->r->type == PARSER_NUMBER)
         {
-            Real v = PARSER_EVAL_L(node) + ((struct parser_number*)(node->r))->value;
+            double v = PARSER_EVAL_L(node) + ((struct parser_number*)(node->r))->value;
             PARSER_MOVEUP_L(node, v);
             node->type = PARSER_ADD_VP;
         }
         else if (node->l->type == PARSER_SUB_VP &&
                  node->r->type == PARSER_NUMBER)
         {
-            Real v = PARSER_EVAL_L(node) + ((struct parser_number*)(node->r))->value;
+            double v = PARSER_EVAL_L(node) + ((struct parser_number*)(node->r))->value;
             PARSER_MOVEUP_L(node, v);
             node->type = PARSER_SUB_VP;
         }
@@ -448,14 +448,14 @@ parser_ast_optimize (struct parser_node* node)
         {
             if (node->r->l->type == PARSER_NUMBER)
             { // #l + (#rl + node_rr) -> (#l + #rl) + node_rr, same type
-                Real v = ((struct parser_number*)(node->l))->value
+                double v = ((struct parser_number*)(node->l))->value
                     + ((struct parser_number*)(node->r->l))->value;
                 node->r = node->r->r;
                 ((struct parser_number*)(node->l))->value = v;
             }
             else if (node->r->r->type == PARSER_NUMBER)
             { // #l + (node_rl + #rr) -> (#l + #rr) + node_rl, same type
-                Real v = ((struct parser_number*)(node->l))->value
+                double v = ((struct parser_number*)(node->l))->value
                     + ((struct parser_number*)(node->r->r))->value;
                 node->r = node->r->l;
                 ((struct parser_number*)(node->l))->value = v;
@@ -466,7 +466,7 @@ parser_ast_optimize (struct parser_node* node)
         {
             if (node->r->l->type == PARSER_NUMBER)
             { // #l + (#rl - node_rr) -> (#l + #rl) - node_rr, type change
-                Real v = ((struct parser_number*)(node->l))->value
+                double v = ((struct parser_number*)(node->l))->value
                     + ((struct parser_number*)(node->r->l))->value;
                 node->r = node->r->r;
                 ((struct parser_number*)(node->l))->value = v;
@@ -474,7 +474,7 @@ parser_ast_optimize (struct parser_node* node)
             }
             else if (node->r->r->type == PARSER_NUMBER)
             { // #l + (node_rl - #rr) -> (#l - #rr) + node_rl, same type
-                Real v = ((struct parser_number*)(node->l))->value
+                double v = ((struct parser_number*)(node->l))->value
                     - ((struct parser_number*)(node->r->r))->value;
                 node->r = node->r->l;
                 ((struct parser_number*)(node->l))->value = v;
@@ -485,14 +485,14 @@ parser_ast_optimize (struct parser_node* node)
         {
             if (node->l->l->type == PARSER_NUMBER)
             { // (#ll + node_lr) + #r -> nodel_lr + (#ll + #r), same type
-                Real v = ((struct parser_number*)(node->l->l))->value
+                double v = ((struct parser_number*)(node->l->l))->value
                     + ((struct parser_number*)(node->r))->value;
                 node->l = node->l->r;
                 ((struct parser_number*)(node->r))->value = v;
             }
             else if (node->l->r->type == PARSER_NUMBER)
             { // (node_ll + #lr) + #r -> node_ll + (#lr + #r), same type
-                Real v = ((struct parser_number*)(node->l->r))->value
+                double v = ((struct parser_number*)(node->l->r))->value
                     + ((struct parser_number*)(node->r))->value;
                 node->l = node->l->l;
                 ((struct parser_number*)(node->r))->value = v;
@@ -503,7 +503,7 @@ parser_ast_optimize (struct parser_node* node)
         {
             if (node->l->l->type == PARSER_NUMBER)
             { // (#ll - node_lr) + #r -> (#ll + #r) - node_lr, type change
-                Real v = ((struct parser_number*)(node->l->l))->value
+                double v = ((struct parser_number*)(node->l->l))->value
                     + ((struct parser_number*)(node->r))->value;
                 node->r = node->l->r;
                 ((struct parser_number*)(node->l))->type = PARSER_NUMBER;
@@ -512,7 +512,7 @@ parser_ast_optimize (struct parser_node* node)
             }
             else if (node->l->r->type == PARSER_NUMBER)
             { // (node_ll - #lr) + #r -> node_ll + (#r - #lr), same type
-                Real v = ((struct parser_number*)(node->r))->value
+                double v = ((struct parser_number*)(node->r))->value
                     - ((struct parser_number*)(node->l->r))->value;
                 node->l = node->l->l;
                 ((struct parser_number*)(node->r))->value = v;
@@ -526,7 +526,7 @@ parser_ast_optimize (struct parser_node* node)
         if (node->l->type == PARSER_NUMBER &&
             node->r->type == PARSER_NUMBER)
         {
-            Real v = ((struct parser_number*)(node->l))->value
+            double v = ((struct parser_number*)(node->l))->value
                 -    ((struct parser_number*)(node->r))->value;
             ((struct parser_number*)node)->type = PARSER_NUMBER;
             ((struct parser_number*)node)->value = v;
@@ -556,28 +556,28 @@ parser_ast_optimize (struct parser_node* node)
         else if (node->l->type == PARSER_NUMBER &&
                  node->r->type == PARSER_ADD_VP)
         {
-            Real v = ((struct parser_number*)(node->l))->value - PARSER_EVAL_R(node);
+            double v = ((struct parser_number*)(node->l))->value - PARSER_EVAL_R(node);
             PARSER_MOVEUP_R(node, v);
             node->type = PARSER_SUB_VP;
         }
         else if (node->l->type == PARSER_NUMBER &&
                  node->r->type == PARSER_SUB_VP)
         {
-            Real v = ((struct parser_number*)(node->l))->value - PARSER_EVAL_R(node);
+            double v = ((struct parser_number*)(node->l))->value - PARSER_EVAL_R(node);
             PARSER_MOVEUP_R(node, v);
             node->type = PARSER_ADD_VP;
         }
         else if (node->l->type == PARSER_ADD_VP &&
                  node->r->type == PARSER_NUMBER)
         {
-            Real v = PARSER_EVAL_L(node) - ((struct parser_number*)(node->r))->value;
+            double v = PARSER_EVAL_L(node) - ((struct parser_number*)(node->r))->value;
             PARSER_MOVEUP_L(node, v);
             node->type = PARSER_ADD_VP;
         }
         else if (node->l->type == PARSER_SUB_VP &&
                  node->r->type == PARSER_NUMBER)
         {
-            Real v = PARSER_EVAL_L(node) - ((struct parser_number*)(node->r))->value;
+            double v = PARSER_EVAL_L(node) - ((struct parser_number*)(node->r))->value;
             PARSER_MOVEUP_L(node, v);
             node->type = PARSER_SUB_VP;
         }
@@ -586,14 +586,14 @@ parser_ast_optimize (struct parser_node* node)
         {
             if (node->r->l->type == PARSER_NUMBER)
             { // #l - (#rl + node_rr) -> (#l - #rl) - node_rr, same type
-                Real v = ((struct parser_number*)(node->l))->value
+                double v = ((struct parser_number*)(node->l))->value
                     - ((struct parser_number*)(node->r->l))->value;
                 node->r = node->r->r;
                 ((struct parser_number*)(node->l))->value = v;
             }
             else if (node->r->r->type == PARSER_NUMBER)
             { // #l - (node_rl + #rr) -> (#l - #rr) - node_rl, same type
-                Real v = ((struct parser_number*)(node->l))->value
+                double v = ((struct parser_number*)(node->l))->value
                     - ((struct parser_number*)(node->r->r))->value;
                 node->r = node->r->l;
                 ((struct parser_number*)(node->l))->value = v;
@@ -604,7 +604,7 @@ parser_ast_optimize (struct parser_node* node)
         {
             if (node->r->l->type == PARSER_NUMBER)
             { // #l - (#rl - node_rr) -> (#l - #rl) + node_rr, type change
-                Real v = ((struct parser_number*)(node->l))->value
+                double v = ((struct parser_number*)(node->l))->value
                     - ((struct parser_number*)(node->r->l))->value;
                 node->r = node->r->r;
                 ((struct parser_number*)(node->l))->value = v;
@@ -612,7 +612,7 @@ parser_ast_optimize (struct parser_node* node)
             }
             else if (node->r->r->type == PARSER_NUMBER)
             { // #l - (node_rl - #rr) -> (#l + #rr) - node_rl, same type
-                Real v = ((struct parser_number*)(node->l))->value
+                double v = ((struct parser_number*)(node->l))->value
                     + ((struct parser_number*)(node->r->r))->value;
                 node->r = node->r->l;
                 ((struct parser_number*)(node->l))->value = v;
@@ -623,14 +623,14 @@ parser_ast_optimize (struct parser_node* node)
         {
             if (node->l->l->type == PARSER_NUMBER)
             { // (#ll + node_lr) - #r -> node_lr - (#r - #ll), same type
-                Real v = ((struct parser_number*)(node->r))->value
+                double v = ((struct parser_number*)(node->r))->value
                     - ((struct parser_number*)(node->l->l))->value;
                 node->l = node->l->r;
                 ((struct parser_number*)(node->r))->value = v;
             }
             else if (node->l->r->type == PARSER_NUMBER)
             { // (node_ll + #lr) - #r -> node_ll - (#r - #lr), same type
-                Real v = ((struct parser_number*)(node->r))->value
+                double v = ((struct parser_number*)(node->r))->value
                     - ((struct parser_number*)(node->l->r))->value;
                 node->l = node->l->l;
                 ((struct parser_number*)(node->r))->value = v;
@@ -641,7 +641,7 @@ parser_ast_optimize (struct parser_node* node)
         {
             if (node->l->l->type == PARSER_NUMBER)
             { // (#ll - node_lr) - #r -> (#ll - #r) - node_lr, type change
-                Real v = ((struct parser_number*)(node->l->l))->value
+                double v = ((struct parser_number*)(node->l->l))->value
                     - ((struct parser_number*)(node->r))->value;
                 node->r = node->l->r;
                 node->l->type = PARSER_NUMBER;
@@ -649,7 +649,7 @@ parser_ast_optimize (struct parser_node* node)
             }
             else if (node->l->r->type == PARSER_NUMBER)
             { // (node_ll - #lr) - #r -> node_ll - (#r + #lr), same type
-                Real v = ((struct parser_number*)(node->r))->value
+                double v = ((struct parser_number*)(node->r))->value
                     + ((struct parser_number*)(node->l->r))->value;
                 node->l = node->l->l;
                 ((struct parser_number*)(node->r))->value = v;
@@ -663,7 +663,7 @@ parser_ast_optimize (struct parser_node* node)
         if (node->l->type == PARSER_NUMBER &&
             node->r->type == PARSER_NUMBER)
         {
-            Real v = ((struct parser_number*)(node->l))->value
+            double v = ((struct parser_number*)(node->l))->value
                 *    ((struct parser_number*)(node->r))->value;
             ((struct parser_number*)node)->type = PARSER_NUMBER;
             ((struct parser_number*)node)->value = v;
@@ -693,28 +693,28 @@ parser_ast_optimize (struct parser_node* node)
         else if (node->l->type == PARSER_NUMBER &&
                  node->r->type == PARSER_MUL_VP)
         {
-            Real v = ((struct parser_number*)(node->l))->value * PARSER_EVAL_R(node);
+            double v = ((struct parser_number*)(node->l))->value * PARSER_EVAL_R(node);
             PARSER_MOVEUP_R(node, v);
             node->type = PARSER_MUL_VP;
         }
         else if (node->l->type == PARSER_NUMBER &&
                  node->r->type == PARSER_DIV_VP)
         {
-            Real v = ((struct parser_number*)(node->l))->value * PARSER_EVAL_R(node);
+            double v = ((struct parser_number*)(node->l))->value * PARSER_EVAL_R(node);
             PARSER_MOVEUP_R(node, v);
             node->type = PARSER_DIV_VP;
         }
         else if (node->l->type == PARSER_MUL_VP &&
                  node->r->type == PARSER_NUMBER)
         {
-            Real v = PARSER_EVAL_L(node) * ((struct parser_number*)(node->r))->value;
+            double v = PARSER_EVAL_L(node) * ((struct parser_number*)(node->r))->value;
             PARSER_MOVEUP_L(node, v);
             node->type = PARSER_MUL_VP;
         }
         else if (node->l->type == PARSER_DIV_VP &&
                  node->r->type == PARSER_NUMBER)
         {
-            Real v = PARSER_EVAL_L(node) * ((struct parser_number*)(node->r))->value;
+            double v = PARSER_EVAL_L(node) * ((struct parser_number*)(node->r))->value;
             PARSER_MOVEUP_L(node, v);
             node->type = PARSER_DIV_VP;
         }
@@ -723,14 +723,14 @@ parser_ast_optimize (struct parser_node* node)
         {
             if (node->r->l->type == PARSER_NUMBER)
             { // #l * (#rl * node_rr) -> (#l * #rl) * node_rr, same type
-                Real v = ((struct parser_number*)(node->l))->value
+                double v = ((struct parser_number*)(node->l))->value
                     * ((struct parser_number*)(node->r->l))->value;
                 node->r = node->r->r;
                 ((struct parser_number*)(node->l))->value = v;
             }
             else if (node->r->r->type == PARSER_NUMBER)
             { // #l * (node_rl * #rr) -> (#l * #rr) * node_rl, same type
-                Real v = ((struct parser_number*)(node->l))->value
+                double v = ((struct parser_number*)(node->l))->value
                     * ((struct parser_number*)(node->r->r))->value;
                 node->r = node->r->l;
                 ((struct parser_number*)(node->l))->value = v;
@@ -741,7 +741,7 @@ parser_ast_optimize (struct parser_node* node)
         {
             if (node->r->l->type == PARSER_NUMBER)
             { // #l * (#rl / node_rr) -> (#l * #rl) / node_rr, type change
-                Real v = ((struct parser_number*)(node->l))->value
+                double v = ((struct parser_number*)(node->l))->value
                     * ((struct parser_number*)(node->r->l))->value;
                 node->r = node->r->r;
                 ((struct parser_number*)(node->l))->value = v;
@@ -750,7 +750,7 @@ parser_ast_optimize (struct parser_node* node)
             }
             else if (node->r->r->type == PARSER_NUMBER)
             { // #l * (node_rl / #rr) -> (#l / #rr) * node_rl, same type
-                Real v = ((struct parser_number*)(node->l))->value
+                double v = ((struct parser_number*)(node->l))->value
                     / ((struct parser_number*)(node->r->r))->value;
                 node->r = node->r->l;
                 ((struct parser_number*)(node->l))->value = v;
@@ -761,14 +761,14 @@ parser_ast_optimize (struct parser_node* node)
         {
             if (node->l->l->type == PARSER_NUMBER)
             { // (#ll * node_lr) * #r -> nodel_lr * (#ll * #r), same type
-                Real v = ((struct parser_number*)(node->l->l))->value
+                double v = ((struct parser_number*)(node->l->l))->value
                     * ((struct parser_number*)(node->r))->value;
                 node->l = node->l->r;
                 ((struct parser_number*)(node->r))->value = v;
             }
             else if (node->l->r->type == PARSER_NUMBER)
             { // (node_ll * #lr) * #r -> node_ll + (#lr * #r), same type
-                Real v = ((struct parser_number*)(node->l->r))->value
+                double v = ((struct parser_number*)(node->l->r))->value
                     * ((struct parser_number*)(node->r))->value;
                 node->l = node->l->l;
                 ((struct parser_number*)(node->r))->value = v;
@@ -779,7 +779,7 @@ parser_ast_optimize (struct parser_node* node)
         {
             if (node->l->l->type == PARSER_NUMBER)
             { // (#ll / node_lr) * #r -> (#ll * #r) / node_lr, type change
-                Real v = ((struct parser_number*)(node->l->l))->value
+                double v = ((struct parser_number*)(node->l->l))->value
                     * ((struct parser_number*)(node->r))->value;
                 node->r = node->l->r;
                 ((struct parser_number*)(node->l))->type = PARSER_NUMBER;
@@ -788,7 +788,7 @@ parser_ast_optimize (struct parser_node* node)
             }
             else if (node->l->r->type == PARSER_NUMBER)
             { // (node_ll / #lr) * #r -> node_ll * (#r / #lr), smae type
-                Real v = ((struct parser_number*)(node->r))->value
+                double v = ((struct parser_number*)(node->r))->value
                     / ((struct parser_number*)(node->l->r))->value;
                 node->l = node->l->l;
                 ((struct parser_number*)(node->r))->value = v;
@@ -802,7 +802,7 @@ parser_ast_optimize (struct parser_node* node)
         if (node->l->type == PARSER_NUMBER &&
             node->r->type == PARSER_NUMBER)
         {
-            Real v = ((struct parser_number*)(node->l))->value
+            double v = ((struct parser_number*)(node->l))->value
                 /    ((struct parser_number*)(node->r))->value;
             ((struct parser_number*)node)->type = PARSER_NUMBER;
             ((struct parser_number*)node)->value = v;
@@ -817,7 +817,7 @@ parser_ast_optimize (struct parser_node* node)
         else if (node->l->type == PARSER_SYMBOL &&
                  node->r->type == PARSER_NUMBER)
         {
-            node->lvp.v = Real(1.)/((struct parser_number*)(node->r))->value;
+            node->lvp.v = double(1.)/((struct parser_number*)(node->r))->value;
             node->rip   =          ((struct parser_symbol*)(node->l))->ip;
             node->r = node->l;
             node->type = PARSER_MUL_VP;
@@ -832,28 +832,28 @@ parser_ast_optimize (struct parser_node* node)
         else if (node->l->type == PARSER_NUMBER &&
                  node->r->type == PARSER_MUL_VP)
         {
-            Real v = ((struct parser_number*)(node->l))->value / PARSER_EVAL_R(node);
+            double v = ((struct parser_number*)(node->l))->value / PARSER_EVAL_R(node);
             PARSER_MOVEUP_R(node, v);
             node->type = PARSER_DIV_VP;
         }
         else if (node->l->type == PARSER_NUMBER &&
                  node->r->type == PARSER_DIV_VP)
         {
-            Real v = ((struct parser_number*)(node->l))->value / PARSER_EVAL_R(node);
+            double v = ((struct parser_number*)(node->l))->value / PARSER_EVAL_R(node);
             PARSER_MOVEUP_R(node, v);
             node->type = PARSER_MUL_VP;
         }
         else if (node->l->type == PARSER_MUL_VP &&
                  node->r->type == PARSER_NUMBER)
         {
-            Real v = PARSER_EVAL_L(node) / ((struct parser_number*)(node->r))->value;
+            double v = PARSER_EVAL_L(node) / ((struct parser_number*)(node->r))->value;
             PARSER_MOVEUP_L(node, v);
             node->type = PARSER_MUL_VP;
         }
         else if (node->l->type == PARSER_DIV_VP &&
                  node->r->type == PARSER_NUMBER)
         {
-            Real v = PARSER_EVAL_L(node) / ((struct parser_number*)(node->r))->value;
+            double v = PARSER_EVAL_L(node) / ((struct parser_number*)(node->r))->value;
             PARSER_MOVEUP_L(node, v);
             node->type = PARSER_DIV_VP;
         }
@@ -862,14 +862,14 @@ parser_ast_optimize (struct parser_node* node)
         {
             if (node->r->l->type == PARSER_NUMBER)
             { // #l / (#rl * node_rr) -> (#l / #rl) / node_rr, same type
-                Real v = ((struct parser_number*)(node->l))->value
+                double v = ((struct parser_number*)(node->l))->value
                     / ((struct parser_number*)(node->r->l))->value;
                 node->r = node->r->r;
                 ((struct parser_number*)(node->l))->value = v;
             }
             else if (node->r->r->type == PARSER_NUMBER)
             { // #l / (node_rl * #rr) -> (#l / #rr) / node_rl, same type
-                Real v = ((struct parser_number*)(node->l))->value
+                double v = ((struct parser_number*)(node->l))->value
                     / ((struct parser_number*)(node->r->r))->value;
                 node->r = node->r->l;
                 ((struct parser_number*)(node->l))->value = v;
@@ -880,7 +880,7 @@ parser_ast_optimize (struct parser_node* node)
         {
             if (node->r->l->type == PARSER_NUMBER)
             { // #l / (#rl / node_rr) -> (#l / #rl) * node_rr, type change
-                Real v = ((struct parser_number*)(node->l))->value
+                double v = ((struct parser_number*)(node->l))->value
                     / ((struct parser_number*)(node->r->l))->value;
                 node->r = node->r->r;
                 ((struct parser_number*)(node->l))->value = v;
@@ -888,7 +888,7 @@ parser_ast_optimize (struct parser_node* node)
             }
             else if (node->r->r->type == PARSER_NUMBER)
             { // #l / (node_rl / #rr) -> (#l * #rr) / node_rl, same type
-                Real v = ((struct parser_number*)(node->l))->value
+                double v = ((struct parser_number*)(node->l))->value
                     * ((struct parser_number*)(node->r->r))->value;
                 node->r = node->r->l;
                 ((struct parser_number*)(node->l))->value = v;
@@ -899,7 +899,7 @@ parser_ast_optimize (struct parser_node* node)
         {
             if (node->l->l->type == PARSER_NUMBER)
             { // (#ll * node_lr) / #r -> node_lr * (#ll / #r), type change
-                Real v = ((struct parser_number*)(node->l->l))->value
+                double v = ((struct parser_number*)(node->l->l))->value
                     / ((struct parser_number*)(node->r))->value;
                 node->l = node->l->r;
                 ((struct parser_number*)(node->r))->value = v;
@@ -907,7 +907,7 @@ parser_ast_optimize (struct parser_node* node)
             }
             else if (node->l->r->type == PARSER_NUMBER)
             { // (node_ll * #lr) / #r -> node_ll * (#lr / #r), type change
-                Real v = ((struct parser_number*)(node->l->r))->value
+                double v = ((struct parser_number*)(node->l->r))->value
                     / ((struct parser_number*)(node->r))->value;
                 node->l = node->l->l;
                 ((struct parser_number*)(node->r))->value = v;
@@ -919,7 +919,7 @@ parser_ast_optimize (struct parser_node* node)
         {
             if (node->l->l->type == PARSER_NUMBER)
             { // (#ll / node_lr) / #r -> (#ll / #r) / node_lr, type change
-                Real v = ((struct parser_number*)(node->l->l))->value
+                double v = ((struct parser_number*)(node->l->l))->value
                     / ((struct parser_number*)(node->r))->value;
                 node->r = node->l->r;
                 node->l->type = PARSER_NUMBER;
@@ -927,10 +927,10 @@ parser_ast_optimize (struct parser_node* node)
             }
             else if (node->l->r->type == PARSER_NUMBER)
             { // (node_ll / #lr) / #r -> node_ll * 1./(#r * #lr), type change
-                Real v = ((struct parser_number*)(node->r))->value
+                double v = ((struct parser_number*)(node->r))->value
                     * ((struct parser_number*)(node->l->r))->value;
                 node->l = node->l->l;
-                ((struct parser_number*)(node->r))->value = Real(1.)/v;
+                ((struct parser_number*)(node->r))->value = double(1.)/v;
                 node->type = PARSER_MUL;
             }
         }
@@ -939,7 +939,7 @@ parser_ast_optimize (struct parser_node* node)
         parser_ast_optimize(node->l);
         if (node->l->type == PARSER_NUMBER)
         {
-            Real v = -((struct parser_number*)(node->l))->value;
+            double v = -((struct parser_number*)(node->l))->value;
             ((struct parser_number*)node)->type = PARSER_NUMBER;
             ((struct parser_number*)node)->value = v;
         }
@@ -1039,7 +1039,7 @@ parser_ast_optimize (struct parser_node* node)
             { // -(node_ll / #lr) -> (-1/#lr) * node_ll
                 node->r = node->l->l;
                 ((struct parser_number*)(node->l))->value =
-                    Real(-1.0) / ((struct parser_number*)(node->l->r))->value;
+                    double(-1.0) / ((struct parser_number*)(node->l->r))->value;
                 node->l->type = PARSER_NUMBER;
                 node->type = PARSER_MUL;
             }
@@ -1049,7 +1049,7 @@ parser_ast_optimize (struct parser_node* node)
         parser_ast_optimize(node->l);
         if (node->l->type == PARSER_NUMBER)
         {
-            Real v = parser_call_f1
+            double v = parser_call_f1
                 (((struct parser_f1*)node)->ftype,
                  ((struct parser_number*)(((struct parser_f1*)node)->l))->value);
             ((struct parser_number*)node)->type = PARSER_NUMBER;
@@ -1062,7 +1062,7 @@ parser_ast_optimize (struct parser_node* node)
         if (node->l->type == PARSER_NUMBER &&
             node->r->type == PARSER_NUMBER)
         {
-            Real v = parser_call_f2
+            double v = parser_call_f2
                 (((struct parser_f2*)node)->ftype,
                  ((struct parser_number*)(((struct parser_f2*)node)->l))->value,
                  ((struct parser_number*)(((struct parser_f2*)node)->r))->value);
@@ -1072,31 +1072,31 @@ parser_ast_optimize (struct parser_node* node)
         else if (node->r->type == PARSER_NUMBER && ((struct parser_f2*)node)->ftype == PARSER_POW)
         {
             struct parser_node* n = node->l;
-            Real v = ((struct parser_number*)(node->r))->value;
-            if (Real(-3.0) == v) {
+            double v = ((struct parser_number*)(node->r))->value;
+            if (-3.0 == v) {
                 ((struct parser_f1*)node)->type = PARSER_F1;
                 ((struct parser_f1*)node)->l = n;
                 ((struct parser_f1*)node)->ftype = PARSER_POW_M3;
-            } else if (Real(-2.0) == v) {
+            } else if (-2.0 == v) {
                 ((struct parser_f1*)node)->type = PARSER_F1;
                 ((struct parser_f1*)node)->l = n;
                 ((struct parser_f1*)node)->ftype = PARSER_POW_M2;
-            } else if (Real(-1.0) == v) {
+            } else if (-1.0 == v) {
                 ((struct parser_f1*)node)->type = PARSER_F1;
                 ((struct parser_f1*)node)->l = n;
                 ((struct parser_f1*)node)->ftype = PARSER_POW_M1;
-            } else if (Real(0.0) == v) {
+            } else if (0.0 == v) {
                 ((struct parser_number*)node)->type = PARSER_NUMBER;
-                ((struct parser_number*)node)->value = Real(1.0);
-            } else if (Real(1.0) == v) {
+                ((struct parser_number*)node)->value = 1.0;
+            } else if (1.0 == v) {
                 ((struct parser_f1*)node)->type = PARSER_F1;
                 ((struct parser_f1*)node)->l = n;
                 ((struct parser_f1*)node)->ftype = PARSER_POW_P1;
-            } else if (Real(2.0) == v) {
+            } else if (2.0 == v) {
                 ((struct parser_f1*)node)->type = PARSER_F1;
                 ((struct parser_f1*)node)->l = n;
                 ((struct parser_f1*)node)->ftype = PARSER_POW_P2;
-            } else if (Real(3.0) == v) {
+            } else if (3.0 == v) {
                 ((struct parser_f1*)node)->type = PARSER_F1;
                 ((struct parser_f1*)node)->l = n;
                 ((struct parser_f1*)node)->ftype = PARSER_POW_P3;
@@ -1111,7 +1111,7 @@ parser_ast_optimize (struct parser_node* node)
             ((struct parser_f3*)node)->n2->type == PARSER_NUMBER &&
             ((struct parser_f3*)node)->n3->type == PARSER_NUMBER)
         {
-            Real v = parser_call_f3
+            double v = parser_call_f3
                 (((struct parser_f3*)node)->ftype,
                  ((struct parser_number*)(((struct parser_f3*)node)->n1))->value,
                  ((struct parser_number*)(((struct parser_f3*)node)->n2))->value,
@@ -1124,7 +1124,7 @@ parser_ast_optimize (struct parser_node* node)
         parser_ast_optimize(node->r);
         if (node->r->type == PARSER_NUMBER)
         {
-            Real v = node->lvp.v + ((struct parser_number*)(node->r))->value;
+            double v = node->lvp.v + ((struct parser_number*)(node->r))->value;
             ((struct parser_number*)node)->type = PARSER_NUMBER;
             ((struct parser_number*)node)->value = v;
         }
@@ -1133,7 +1133,7 @@ parser_ast_optimize (struct parser_node* node)
         parser_ast_optimize(node->r);
         if (node->r->type == PARSER_NUMBER)
         {
-            Real v = node->lvp.v - ((struct parser_number*)(node->r))->value;
+            double v = node->lvp.v - ((struct parser_number*)(node->r))->value;
             ((struct parser_number*)node)->type = PARSER_NUMBER;
             ((struct parser_number*)node)->value = v;
         }
@@ -1142,7 +1142,7 @@ parser_ast_optimize (struct parser_node* node)
         parser_ast_optimize(node->r);
         if (node->r->type == PARSER_NUMBER)
         {
-            Real v = node->lvp.v * ((struct parser_number*)(node->r))->value;
+            double v = node->lvp.v * ((struct parser_number*)(node->r))->value;
             ((struct parser_number*)node)->type = PARSER_NUMBER;
             ((struct parser_number*)node)->value = v;
         }
@@ -1151,7 +1151,7 @@ parser_ast_optimize (struct parser_node* node)
         parser_ast_optimize(node->r);
         if (node->r->type == PARSER_NUMBER)
         {
-            Real v = node->lvp.v / ((struct parser_number*)(node->r))->value;
+            double v = node->lvp.v / ((struct parser_number*)(node->r))->value;
             ((struct parser_number*)node)->type = PARSER_NUMBER;
             ((struct parser_number*)node)->value = v;
         }
@@ -1160,7 +1160,7 @@ parser_ast_optimize (struct parser_node* node)
         parser_ast_optimize(node->l);
         if (node->l->type == PARSER_NUMBER)
         {
-            Real v = -((struct parser_number*)(node->l))->value;
+            double v = -((struct parser_number*)(node->l))->value;
             ((struct parser_number*)node)->type = PARSER_NUMBER;
             ((struct parser_number*)node)->value = v;
         }
@@ -1492,7 +1492,7 @@ parser_ast_regvar (struct parser_node* node, char const* name, int i)
     }
 }
 
-void parser_ast_setconst (struct parser_node* node, char const* name, Real c)
+void parser_ast_setconst (struct parser_node* node, char const* name, double c)
 {
     switch (node->type)
     {
@@ -1604,7 +1604,7 @@ parser_regvar (struct amrex_parser* parser, char const* name, int i)
 }
 
 void
-parser_setconst (struct amrex_parser* parser, char const* name, Real c)
+parser_setconst (struct amrex_parser* parser, char const* name, double c)
 {
     parser_ast_setconst(parser->ast, name, c);
     parser_ast_optimize(parser->ast);

--- a/Src/Base/Parser/amrex_parser.tab.h
+++ b/Src/Base/Parser/amrex_parser.tab.h
@@ -88,7 +88,7 @@ union AMREX_PARSERSTYPE
 {
 
     struct amrex::parser_node* n;
-    amrex::Real d;
+    double d;
     struct amrex::parser_symbol* s;
     enum amrex::parser_f1_t f1;
     enum amrex::parser_f2_t f2;

--- a/Src/Base/Parser/amrex_parser.y
+++ b/Src/Base/Parser/amrex_parser.y
@@ -19,7 +19,7 @@ int amrex_parserlex (void);
 */
 %union {
     struct amrex::parser_node* n;
-    amrex::Real d;
+    double d;
     struct amrex::parser_symbol* s;
     enum amrex::parser_f1_t f1;
     enum amrex::parser_f2_t f2;


### PR DESCRIPTION
Use double internally.  If the arguments are all floats, the final result
will be converted to float.

This is necessary to avoid overflow in some WarpX single precision tests.

## Summary

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
