### PR TITLE
YAFluxRegister with blocking factor of 1

### DIFF
--- a/Src/Boundary/AMReX_YAFluxRegister_1D_K.H
+++ b/Src/Boundary/AMReX_YAFluxRegister_1D_K.H
@@ -20,7 +20,8 @@ void yafluxreg_crseadd (Box const& bx, Array4<Real> const& d, Array4<int const> 
                 for (int n = 0; n < nc; ++n) {
                     d(i,0,0,n) -= dtdx*fx(i,0,0,n);
                 }
-            } else if (flag(i+1,0,0) == amrex_yafluxreg_fine_cell) {
+            }
+            if (flag(i+1,0,0) == amrex_yafluxreg_fine_cell) {
                 for (int n = 0; n < nc; ++n) {
                     d(i,0,0,n) += dtdx*fx(i+1,0,0,n);
                 }

--- a/Src/Boundary/AMReX_YAFluxRegister_2D_K.H
+++ b/Src/Boundary/AMReX_YAFluxRegister_2D_K.H
@@ -22,7 +22,8 @@ void yafluxreg_crseadd (Box const& bx, Array4<Real> const& d, Array4<int const> 
                 for (int n = 0; n < nc; ++n) {
                     d(i,j,0,n) -= dtdx*fx(i,j,0,n);
                 }
-            } else if (flag(i+1,j,0) == amrex_yafluxreg_fine_cell) {
+            }
+            if (flag(i+1,j,0) == amrex_yafluxreg_fine_cell) {
                 for (int n = 0; n < nc; ++n) {
                     d(i,j,0,n) += dtdx*fx(i+1,j,0,n);
                 }
@@ -32,7 +33,8 @@ void yafluxreg_crseadd (Box const& bx, Array4<Real> const& d, Array4<int const> 
                 for (int n = 0; n < nc; ++n) {
                     d(i,j,0,n) -= dtdy*fy(i,j,0,n);
                 }
-            } else if (flag(i,j+1,0) == amrex_yafluxreg_fine_cell) {
+            }
+            if (flag(i,j+1,0) == amrex_yafluxreg_fine_cell) {
                 for (int n = 0; n < nc; ++n) {
                     d(i,j,0,n) += dtdy*fy(i,j+1,0,n);
                 }

--- a/Src/Boundary/AMReX_YAFluxRegister_3D_K.H
+++ b/Src/Boundary/AMReX_YAFluxRegister_3D_K.H
@@ -25,7 +25,8 @@ void yafluxreg_crseadd (Box const& bx, Array4<Real> const& d, Array4<int const> 
                 for (int n = 0; n < nc; ++n) {
                     d(i,j,k,n) -= dtdx*fx(i,j,k,n);
                 }
-            } else if (flag(i+1,j,k) == amrex_yafluxreg_fine_cell) {
+            }
+            if (flag(i+1,j,k) == amrex_yafluxreg_fine_cell) {
                 for (int n = 0; n < nc; ++n) {
                     d(i,j,k,n) += dtdx*fx(i+1,j,k,n);
                 }
@@ -35,7 +36,8 @@ void yafluxreg_crseadd (Box const& bx, Array4<Real> const& d, Array4<int const> 
                 for (int n = 0; n < nc; ++n) {
                     d(i,j,k,n) -= dtdy*fy(i,j,k,n);
                 }
-            } else if (flag(i,j+1,k) == amrex_yafluxreg_fine_cell) {
+            }
+            if (flag(i,j+1,k) == amrex_yafluxreg_fine_cell) {
                 for (int n = 0; n < nc; ++n) {
                     d(i,j,k,n) += dtdy*fy(i,j+1,k,n);
                 }
@@ -45,7 +47,8 @@ void yafluxreg_crseadd (Box const& bx, Array4<Real> const& d, Array4<int const> 
                 for (int n = 0; n < nc; ++n) {
                     d(i,j,k,n) -= dtdz*fz(i,j,k,n);
                 }
-            } else if (flag(i,j,k+1) == amrex_yafluxreg_fine_cell) {
+            }
+            if (flag(i,j,k+1) == amrex_yafluxreg_fine_cell) {
                 for (int n = 0; n < nc; ++n) {
                     d(i,j,k,n) += dtdz*fz(i,j,k+1,n);
                 }


### PR DESCRIPTION
Fix YAFluxRegister for the case that the blocking factor is 1.  In that
case, a coarse cell might have fine neighbors at both x-lo and x-hi faces.

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
