### PR TITLE
Minor optimization of reducing 4 bytes

### DIFF
--- a/Src/AmrCore/AMReX_TagBox.cpp
+++ b/Src/AmrCore/AMReX_TagBox.cpp
@@ -529,6 +529,8 @@ TagBoxArray::local_collate_gpu (Gpu::PinnedVector<IntVect>& v) const
             Box const& bx = fai.fabbox();
             const auto lo  = amrex::lbound(bx);
             const auto len = amrex::length(bx);
+            const auto lenxy = len.x*len.y;
+            const auto lenx  = len.x;
             const int ncells = bx.numPts();
             const char* tags = (*this)[fai].dataPtr();
 #ifdef AMREX_USE_DPCPP
@@ -549,9 +551,9 @@ TagBoxArray::local_collate_gpu (Gpu::PinnedVector<IntVect>& v) const
                     unsigned int itag = Gpu::Atomic::Inc<sycl::access::address_space::local_space>
                         (shared_counter, 20480u);
                     IntVect* p = dp_tags + dp_tags_offset[iblock_begin+bid];
-                    int k =  icell /   (len.x*len.y);
-                    int j = (icell - k*(len.x*len.y)) /   len.x;
-                    int i = (icell - k*(len.x*len.y)) - j*len.x;
+                    int k =  icell /   lenxy;
+                    int j = (icell - k*lenxy) /   lenx;
+                    int i = (icell - k*lenxy) - j*lenx;
                     i += lo.x;
                     j += lo.y;
                     k += lo.z;
@@ -576,9 +578,9 @@ TagBoxArray::local_collate_gpu (Gpu::PinnedVector<IntVect>& v) const
                 if (icell < ncells && tags[icell] != TagBox::CLEAR) {
                     unsigned int itag = Gpu::Atomic::Inc(shared_counter, blockDim.x);
                     IntVect* p = dp_tags + dp_tags_offset[iblock_begin+bid];
-                    int k =  icell /   (len.x*len.y);
-                    int j = (icell - k*(len.x*len.y)) /   len.x;
-                    int i = (icell - k*(len.x*len.y)) - j*len.x;
+                    int k =  icell /   lenxy;
+                    int j = (icell - k*lenxy) /   lenx;
+                    int i = (icell - k*lenxy) - j*lenx;
                     i += lo.x;
                     j += lo.y;
                     k += lo.z;

--- a/Src/Base/AMReX_BaseFabUtility.H
+++ b/Src/Base/AMReX_BaseFabUtility.H
@@ -38,6 +38,8 @@ void fill (BaseFab<STRUCT>& aos_fab, F && f)
     if (Gpu::inLaunchRegion()) {
         const auto lo  = amrex::lbound(box);
         const auto len = amrex::length(box);
+        const auto lenxy = len.x*len.y;
+        const auto lenx = len.x;
         int ntotcells = box.numPts();
         int nthreads_per_block = (STRUCTSIZE <= 8) ? 256 : 128;
         int nblocks = (ntotcells+nthreads_per_block-1)/nthreads_per_block;
@@ -54,9 +56,9 @@ void fill (BaseFab<STRUCT>& aos_fab, F && f)
             auto const shared = (T*)handler.sharedMemory();
             if (icell < ntotcells) {
                 auto ga = new(shared+threadIdxx*STRUCTSIZE) STRUCT;
-                int k =  icell /   (len.x*len.y);
-                int j = (icell - k*(len.x*len.y)) /   len.x;
-                int i = (icell - k*(len.x*len.y)) - j*len.x;
+                int k =  icell /   lenxy;
+                int j = (icell - k*lenxy) /   lenx;
+                int i = (icell - k*lenxy) - j*lenx;
                 i += lo.x;
                 j += lo.y;
                 k += lo.z;
@@ -78,9 +80,9 @@ void fill (BaseFab<STRUCT>& aos_fab, F && f)
             T* const shared = gsm.dataPtr();
             if (icell < ntotcells) {
                 auto ga = new(shared+threadIdx.x*STRUCTSIZE) STRUCT;
-                int k =  icell /   (len.x*len.y);
-                int j = (icell - k*(len.x*len.y)) /   len.x;
-                int i = (icell - k*(len.x*len.y)) - j*len.x;
+                int k =  icell /   lenxy;
+                int j = (icell - k*lenxy) /   lenx;
+                int i = (icell - k*lenxy) - j*lenx;
                 i += lo.x;
                 j += lo.y;
                 k += lo.z;

--- a/Src/Base/AMReX_GpuLaunchFunctsG.H
+++ b/Src/Base/AMReX_GpuLaunchFunctsG.H
@@ -200,6 +200,8 @@ void ParallelFor (Gpu::KernelInfo const& info, Box const& box, L&& f) noexcept
     int ncells = box.numPts();
     const auto lo  = amrex::lbound(box);
     const auto len = amrex::length(box);
+    const auto lenxy = len.x*len.y;
+    const auto lenx = len.x;
     const auto ec = Gpu::ExecutionConfig(ncells);
     // If we are on default queue, block all other streams
     if (Gpu::onNullStream()) Gpu::nonNullStreamSynchronize();
@@ -219,9 +221,9 @@ void ParallelFor (Gpu::KernelInfo const& info, Box const& box, L&& f) noexcept
                 {
                     for (int icell = item.get_global_id(0), stride = item.get_global_range(0);
                          icell < ncells; icell += stride) {
-                        int k =  icell /   (len.x*len.y);
-                        int j = (icell - k*(len.x*len.y)) /   len.x;
-                        int i = (icell - k*(len.x*len.y)) - j*len.x;
+                        int k =  icell /   lenxy;
+                        int j = (icell - k*lenxy) /   lenx;
+                        int i = (icell - k*lenxy) - j*lenx;
                         i += lo.x;
                         j += lo.y;
                         k += lo.z;
@@ -241,9 +243,9 @@ void ParallelFor (Gpu::KernelInfo const& info, Box const& box, L&& f) noexcept
                 {
                     for (int icell = item.get_global_id(0), stride = item.get_global_range(0);
                          icell < ncells; icell += stride) {
-                        int k =  icell /   (len.x*len.y);
-                        int j = (icell - k*(len.x*len.y)) /   len.x;
-                        int i = (icell - k*(len.x*len.y)) - j*len.x;
+                        int k =  icell /   lenxy;
+                        int j = (icell - k*lenxy) /   lenx;
+                        int i = (icell - k*lenxy) - j*lenx;
                         i += lo.x;
                         j += lo.y;
                         k += lo.z;
@@ -264,6 +266,8 @@ void ParallelFor (Gpu::KernelInfo const& info, Box const& box, T ncomp, L&& f) n
     int ncells = box.numPts();
     const auto lo  = amrex::lbound(box);
     const auto len = amrex::length(box);
+    const auto lenxy = len.x*len.y;
+    const auto lenx = len.x;
     const auto ec = Gpu::ExecutionConfig(ncells);
     // If we are on default queue, block all other streams
     if (Gpu::onNullStream()) Gpu::nonNullStreamSynchronize();
@@ -283,9 +287,9 @@ void ParallelFor (Gpu::KernelInfo const& info, Box const& box, T ncomp, L&& f) n
                 {
                     for (int icell = item.get_global_id(0), stride = item.get_global_range(0);
                          icell < ncells; icell += stride) {
-                        int k =  icell /   (len.x*len.y);
-                        int j = (icell - k*(len.x*len.y)) /   len.x;
-                        int i = (icell - k*(len.x*len.y)) - j*len.x;
+                        int k =  icell /   lenxy;
+                        int j = (icell - k*lenxy) /   lenx;
+                        int i = (icell - k*lenxy) - j*lenx;
                         i += lo.x;
                         j += lo.y;
                         k += lo.z;
@@ -306,9 +310,9 @@ void ParallelFor (Gpu::KernelInfo const& info, Box const& box, T ncomp, L&& f) n
                 {
                     for (int icell = item.get_global_id(0), stride = item.get_global_range(0);
                          icell < ncells; icell += stride) {
-                        int k =  icell /   (len.x*len.y);
-                        int j = (icell - k*(len.x*len.y)) /   len.x;
-                        int i = (icell - k*(len.x*len.y)) - j*len.x;
+                        int k =  icell /   lenxy;
+                        int j = (icell - k*lenxy) /   lenx;
+                        int i = (icell - k*lenxy) - j*lenx;
                         i += lo.x;
                         j += lo.y;
                         k += lo.z;
@@ -363,6 +367,8 @@ void ParallelForRNG (Box const& box, L&& f) noexcept
     int ncells = box.numPts();
     const auto lo  = amrex::lbound(box);
     const auto len = amrex::length(box);
+    const auto lenxy = len.x*len.y;
+    const auto lenx = len.x;
     const auto ec = Gpu::ExecutionConfig(ncells);
     // If we are on default queue, block all other streams
     if (Gpu::onNullStream()) Gpu::nonNullStreamSynchronize();
@@ -383,9 +389,9 @@ void ParallelForRNG (Box const& box, L&& f) noexcept
                 RandomEngine rand_eng{&engine};
                 for (int icell = tid, stride = item.get_global_range(0);
                      icell < ncells; icell += stride) {
-                    int k =  icell /   (len.x*len.y);
-                    int j = (icell - k*(len.x*len.y)) /   len.x;
-                    int i = (icell - k*(len.x*len.y)) - j*len.x;
+                    int k =  icell /   lenxy;
+                    int j = (icell - k*lenxy) /   lenx;
+                    int i = (icell - k*lenxy) - j*lenx;
                     i += lo.x;
                     j += lo.y;
                     k += lo.z;
@@ -407,6 +413,8 @@ void ParallelForRNG (Box const& box, T ncomp, L&& f) noexcept
     int ncells = box.numPts();
     const auto lo  = amrex::lbound(box);
     const auto len = amrex::length(box);
+    const auto lenxy = len.x*len.y;
+    const auto lenx = len.x;
     const auto ec = Gpu::ExecutionConfig(ncells);
     // If we are on default queue, block all other streams
     if (Gpu::onNullStream()) Gpu::nonNullStreamSynchronize();
@@ -427,9 +435,9 @@ void ParallelForRNG (Box const& box, T ncomp, L&& f) noexcept
                 RandomEngine rand_eng{&engine};
                 for (int icell = tid, stride = item.get_global_range(0);
                      icell < ncells; icell += stride) {
-                    int k =  icell /   (len.x*len.y);
-                    int j = (icell - k*(len.x*len.y)) /   len.x;
-                    int i = (icell - k*(len.x*len.y)) - j*len.x;
+                    int k =  icell /   lenxy;
+                    int j = (icell - k*lenxy) /   lenx;
+                    int i = (icell - k*lenxy) - j*lenx;
                     i += lo.x;
                     j += lo.y;
                     k += lo.z;
@@ -457,6 +465,10 @@ void ParallelFor (Gpu::KernelInfo const& /*info*/, Box const& box1, Box const& b
     const auto lo2  = amrex::lbound(box2);
     const auto len1 = amrex::length(box1);
     const auto len2 = amrex::length(box2);
+    const auto len1xy = len1.x*len1.y;
+    const auto len2xy = len2.x*len2.y;
+    const auto len1x = len1.x;
+    const auto len2x = len2.x;
     const auto ec = Gpu::ExecutionConfig(ncells);
     // If we are on default queue, block all other streams
     if (Gpu::onNullStream()) Gpu::nonNullStreamSynchronize();
@@ -473,18 +485,18 @@ void ParallelFor (Gpu::KernelInfo const& /*info*/, Box const& box1, Box const& b
                 for (int icell = item.get_global_id(0), stride = item.get_global_range(0);
                      icell < ncells; icell += stride) {
                     if (icell < ncells1) {
-                        int k =  icell /   (len1.x*len1.y);
-                        int j = (icell - k*(len1.x*len1.y)) /   len1.x;
-                        int i = (icell - k*(len1.x*len1.y)) - j*len1.x;
+                        int k =  icell /   len1xy;
+                        int j = (icell - k*len1xy) /   len1x;
+                        int i = (icell - k*len1xy) - j*len1x;
                         i += lo1.x;
                         j += lo1.y;
                         k += lo1.z;
                         f1(i,j,k);
                     }
                     if (icell < ncells2) {
-                        int k =  icell /   (len2.x*len2.y);
-                        int j = (icell - k*(len2.x*len2.y)) /   len2.x;
-                        int i = (icell - k*(len2.x*len2.y)) - j*len2.x;
+                        int k =  icell /   len2xy;
+                        int j = (icell - k*len2xy) /   len2x;
+                        int i = (icell - k*len2xy) - j*len2x;
                         i += lo2.x;
                         j += lo2.y;
                         k += lo2.z;
@@ -514,6 +526,12 @@ void ParallelFor (Gpu::KernelInfo const& /*info*/,
     const auto len1 = amrex::length(box1);
     const auto len2 = amrex::length(box2);
     const auto len3 = amrex::length(box3);
+    const auto len1xy = len1.x*len1.y;
+    const auto len2xy = len2.x*len2.y;
+    const auto len3xy = len3.x*len3.y;
+    const auto len1x = len1.x;
+    const auto len2x = len2.x;
+    const auto len3x = len3.x;
     const auto ec = Gpu::ExecutionConfig(ncells);
     // If we are on default queue, block all other streams
     if (Gpu::onNullStream()) Gpu::nonNullStreamSynchronize();
@@ -530,27 +548,27 @@ void ParallelFor (Gpu::KernelInfo const& /*info*/,
                 for (int icell = item.get_global_id(0), stride = item.get_global_range(0);
                      icell < ncells; icell += stride) {
                     if (icell < ncells1) {
-                        int k =  icell /   (len1.x*len1.y);
-                        int j = (icell - k*(len1.x*len1.y)) /   len1.x;
-                        int i = (icell - k*(len1.x*len1.y)) - j*len1.x;
+                        int k =  icell /   len1xy;
+                        int j = (icell - k*len1xy) /   len1x;
+                        int i = (icell - k*len1xy) - j*len1x;
                         i += lo1.x;
                         j += lo1.y;
                         k += lo1.z;
                         f1(i,j,k);
                     }
                     if (icell < ncells2) {
-                        int k =  icell /   (len2.x*len2.y);
-                        int j = (icell - k*(len2.x*len2.y)) /   len2.x;
-                        int i = (icell - k*(len2.x*len2.y)) - j*len2.x;
+                        int k =  icell /   len2xy;
+                        int j = (icell - k*len2xy) /   len2x;
+                        int i = (icell - k*len2xy) - j*len2x;
                         i += lo2.x;
                         j += lo2.y;
                         k += lo2.z;
                         f2(i,j,k);
                     }
                     if (icell < ncells3) {
-                        int k =  icell /   (len3.x*len3.y);
-                        int j = (icell - k*(len3.x*len3.y)) /   len3.x;
-                        int i = (icell - k*(len3.x*len3.y)) - j*len3.x;
+                        int k =  icell /   len3xy;
+                        int j = (icell - k*len3xy) /   len3x;
+                        int i = (icell - k*len3xy) - j*len3x;
                         i += lo3.x;
                         j += lo3.y;
                         k += lo3.z;
@@ -579,6 +597,10 @@ void ParallelFor (Gpu::KernelInfo const& /*info*/,
     const auto lo2  = amrex::lbound(box2);
     const auto len1 = amrex::length(box1);
     const auto len2 = amrex::length(box2);
+    const auto len1xy = len1.x*len1.y;
+    const auto len2xy = len2.x*len2.y;
+    const auto len1x = len1.x;
+    const auto len2x = len2.x;
     const auto ec = Gpu::ExecutionConfig(ncells);
     // If we are on default queue, block all other streams
     if (Gpu::onNullStream()) Gpu::nonNullStreamSynchronize();
@@ -595,9 +617,9 @@ void ParallelFor (Gpu::KernelInfo const& /*info*/,
                 for (int icell = item.get_global_id(0), stride = item.get_global_range(0);
                      icell < ncells; icell += stride) {
                     if (icell < ncells1) {
-                        int k =  icell /   (len1.x*len1.y);
-                        int j = (icell - k*(len1.x*len1.y)) /   len1.x;
-                        int i = (icell - k*(len1.x*len1.y)) - j*len1.x;
+                        int k =  icell /   len1xy;
+                        int j = (icell - k*len1xy) /   len1x;
+                        int i = (icell - k*len1xy) - j*len1x;
                         i += lo1.x;
                         j += lo1.y;
                         k += lo1.z;
@@ -606,9 +628,9 @@ void ParallelFor (Gpu::KernelInfo const& /*info*/,
                         }
                     }
                     if (icell < ncells2) {
-                        int k =  icell /   (len2.x*len2.y);
-                        int j = (icell - k*(len2.x*len2.y)) /   len2.x;
-                        int i = (icell - k*(len2.x*len2.y)) - j*len2.x;
+                        int k =  icell /   len2xy;
+                        int j = (icell - k*len2xy) /   len2x;
+                        int i = (icell - k*len2xy) - j*len2x;
                         i += lo2.x;
                         j += lo2.y;
                         k += lo2.z;
@@ -644,6 +666,12 @@ void ParallelFor (Gpu::KernelInfo const& /*info*/,
     const auto len1 = amrex::length(box1);
     const auto len2 = amrex::length(box2);
     const auto len3 = amrex::length(box3);
+    const auto len1xy = len1.x*len1.y;
+    const auto len2xy = len2.x*len2.y;
+    const auto len3xy = len3.x*len3.y;
+    const auto len1x = len1.x;
+    const auto len2x = len2.x;
+    const auto len3x = len3.x;
     const auto ec = Gpu::ExecutionConfig(ncells);
     // If we are on default queue, block all other streams
     if (Gpu::onNullStream()) Gpu::nonNullStreamSynchronize();
@@ -660,9 +688,9 @@ void ParallelFor (Gpu::KernelInfo const& /*info*/,
                 for (int icell = item.get_global_id(0), stride = item.get_global_range(0);
                      icell < ncells; icell += stride) {
                     if (icell < ncells1) {
-                        int k =  icell /   (len1.x*len1.y);
-                        int j = (icell - k*(len1.x*len1.y)) /   len1.x;
-                        int i = (icell - k*(len1.x*len1.y)) - j*len1.x;
+                        int k =  icell /   len1xy;
+                        int j = (icell - k*len1xy) /   len1x;
+                        int i = (icell - k*len1xy) - j*len1x;
                         i += lo1.x;
                         j += lo1.y;
                         k += lo1.z;
@@ -671,9 +699,9 @@ void ParallelFor (Gpu::KernelInfo const& /*info*/,
                         }
                     }
                     if (icell < ncells2) {
-                        int k =  icell /   (len2.x*len2.y);
-                        int j = (icell - k*(len2.x*len2.y)) /   len2.x;
-                        int i = (icell - k*(len2.x*len2.y)) - j*len2.x;
+                        int k =  icell /   len2xy;
+                        int j = (icell - k*len2xy) /   len2x;
+                        int i = (icell - k*len2xy) - j*len2x;
                         i += lo2.x;
                         j += lo2.y;
                         k += lo2.z;
@@ -682,9 +710,9 @@ void ParallelFor (Gpu::KernelInfo const& /*info*/,
                         }
                     }
                     if (icell < ncells3) {
-                        int k =  icell /   (len3.x*len3.y);
-                        int j = (icell - k*(len3.x*len3.y)) /   len3.x;
-                        int i = (icell - k*(len3.x*len3.y)) - j*len3.x;
+                        int k =  icell /   len3xy;
+                        int j = (icell - k*len3xy) /   len3x;
+                        int i = (icell - k*len3xy) - j*len3x;
                         i += lo3.x;
                         j += lo3.y;
                         k += lo3.z;
@@ -830,6 +858,8 @@ ParallelFor (Gpu::KernelInfo const& info, Box const& box, L&& f) noexcept
         amrex::ignore_unused(info);
         const auto lo  = amrex::lbound(box);
         const auto len = amrex::length(box);
+        const auto lenxy = len.x*len.y;
+        const auto lenx = len.x;
         const auto ec = Gpu::ExecutionConfig(ncells);
 
         AMREX_LAUNCH_KERNEL(ec.numBlocks, ec.numThreads, 0, Gpu::gpuStream(),
@@ -837,9 +867,9 @@ ParallelFor (Gpu::KernelInfo const& info, Box const& box, L&& f) noexcept
             for (int icell = blockDim.x*blockIdx.x+threadIdx.x, stride = blockDim.x*gridDim.x;
                  icell < ncells; icell += stride)
             {
-                int k =  icell /   (len.x*len.y);
-                int j = (icell - k*(len.x*len.y)) /   len.x;
-                int i = (icell - k*(len.x*len.y)) - j*len.x;
+                int k =  icell /   lenxy;
+                int j = (icell - k*lenxy) /   lenx;
+                int i = (icell - k*lenxy) - j*lenx;
                 i += lo.x;
                 j += lo.y;
                 k += lo.z;
@@ -865,15 +895,17 @@ ParallelFor (Gpu::KernelInfo const& info, Box const& box, T ncomp, L&& f) noexce
         amrex::ignore_unused(info);
         const auto lo  = amrex::lbound(box);
         const auto len = amrex::length(box);
+        const auto lenxy = len.x*len.y;
+        const auto lenx = len.x;
         const auto ec = Gpu::ExecutionConfig(ncells);
 
         AMREX_LAUNCH_KERNEL(ec.numBlocks, ec.numThreads, 0, Gpu::gpuStream(),
         [=] AMREX_GPU_DEVICE () noexcept {
             for (int icell = blockDim.x*blockIdx.x+threadIdx.x, stride = blockDim.x*gridDim.x;
                  icell < ncells; icell += stride) {
-                int k =  icell /   (len.x*len.y);
-                int j = (icell - k*(len.x*len.y)) /   len.x;
-                int i = (icell - k*(len.x*len.y)) - j*len.x;
+                int k =  icell /   lenxy;
+                int j = (icell - k*lenxy) /   lenx;
+                int i = (icell - k*lenxy) - j*lenx;
                 i += lo.x;
                 j += lo.y;
                 k += lo.z;
@@ -912,6 +944,8 @@ ParallelForRNG (Box const& box, L&& f) noexcept
     int ncells = box.numPts();
     const auto lo  = amrex::lbound(box);
     const auto len = amrex::length(box);
+    const auto lenxy = len.x*len.y;
+    const auto lenx = len.x;
     const auto ec = Gpu::ExecutionConfig(ncells);
     AMREX_LAUNCH_KERNEL(amrex::min(ec.numBlocks.x, Gpu::Device::maxBlocksPerLaunch()),
                         ec.numThreads, 0, Gpu::nullStream(),  // use null stream
@@ -919,9 +953,9 @@ ParallelForRNG (Box const& box, L&& f) noexcept
         int tid = blockDim.x*blockIdx.x+threadIdx.x;
         RandomEngine engine{&(rand_state[tid])};
         for (int icell = tid, stride = blockDim.x*gridDim.x; icell < ncells; icell += stride) {
-            int k =  icell /   (len.x*len.y);
-            int j = (icell - k*(len.x*len.y)) /   len.x;
-            int i = (icell - k*(len.x*len.y)) - j*len.x;
+            int k =  icell /   lenxy;
+            int j = (icell - k*lenxy) /   lenx;
+            int i = (icell - k*lenxy) - j*lenx;
             i += lo.x;
             j += lo.y;
             k += lo.z;
@@ -940,6 +974,8 @@ ParallelForRNG (Box const& box, T ncomp, L&& f) noexcept
     int ncells = box.numPts();
     const auto lo  = amrex::lbound(box);
     const auto len = amrex::length(box);
+    const auto lenxy = len.x*len.y;
+    const auto lenx = len.x;
     const auto ec = Gpu::ExecutionConfig(ncells);
     AMREX_LAUNCH_KERNEL(amrex::min(ec.numBlocks.x, Gpu::Device::maxBlocksPerLaunch()),
                         ec.numThreads, 0, Gpu::nullStream(), // use null stream
@@ -947,9 +983,9 @@ ParallelForRNG (Box const& box, T ncomp, L&& f) noexcept
         int tid = blockDim.x*blockIdx.x+threadIdx.x;
         RandomEngine engine{&(rand_state[tid])};
         for (int icell = tid, stride = blockDim.x*gridDim.x; icell < ncells; icell += stride) {
-            int k =  icell /   (len.x*len.y);
-            int j = (icell - k*(len.x*len.y)) /   len.x;
-            int i = (icell - k*(len.x*len.y)) - j*len.x;
+            int k =  icell /   lenxy;
+            int j = (icell - k*lenxy) /   lenx;
+            int i = (icell - k*lenxy) - j*lenx;
             i += lo.x;
             j += lo.y;
             k += lo.z;
@@ -982,24 +1018,28 @@ ParallelFor (Gpu::KernelInfo const& info,
         const auto lo2  = amrex::lbound(box2);
         const auto len1 = amrex::length(box1);
         const auto len2 = amrex::length(box2);
+        const auto len1xy = len1.x*len1.y;
+        const auto len2xy = len2.x*len2.y;
+        const auto len1x = len1.x;
+        const auto len2x = len2.x;
         const auto ec = Gpu::ExecutionConfig(ncells);
         AMREX_LAUNCH_KERNEL(ec.numBlocks, ec.numThreads, 0, Gpu::gpuStream(),
         [=] AMREX_GPU_DEVICE () noexcept {
             for (int icell = blockDim.x*blockIdx.x+threadIdx.x, stride = blockDim.x*gridDim.x;
                  icell < ncells; icell += stride) {
                 if (icell < ncells1) {
-                    int k =  icell /   (len1.x*len1.y);
-                    int j = (icell - k*(len1.x*len1.y)) /   len1.x;
-                    int i = (icell - k*(len1.x*len1.y)) - j*len1.x;
+                    int k =  icell /   len1xy;
+                    int j = (icell - k*len1xy) /   len1x;
+                    int i = (icell - k*len1xy) - j*len1x;
                     i += lo1.x;
                     j += lo1.y;
                     k += lo1.z;
                     f1(i,j,k);
                 }
                 if (icell < ncells2) {
-                    int k =  icell /   (len2.x*len2.y);
-                    int j = (icell - k*(len2.x*len2.y)) /   len2.x;
-                    int i = (icell - k*(len2.x*len2.y)) - j*len2.x;
+                    int k =  icell /   len2xy;
+                    int j = (icell - k*len2xy) /   len2x;
+                    int i = (icell - k*len2xy) - j*len2x;
                     i += lo2.x;
                     j += lo2.y;
                     k += lo2.z;
@@ -1037,33 +1077,39 @@ ParallelFor (Gpu::KernelInfo const& info,
         const auto len1 = amrex::length(box1);
         const auto len2 = amrex::length(box2);
         const auto len3 = amrex::length(box3);
+        const auto len1xy = len1.x*len1.y;
+        const auto len2xy = len2.x*len2.y;
+        const auto len3xy = len3.x*len3.y;
+        const auto len1x = len1.x;
+        const auto len2x = len2.x;
+        const auto len3x = len3.x;
         const auto ec = Gpu::ExecutionConfig(ncells);
         AMREX_LAUNCH_KERNEL(ec.numBlocks, ec.numThreads, 0, Gpu::gpuStream(),
         [=] AMREX_GPU_DEVICE () noexcept {
             for (int icell = blockDim.x*blockIdx.x+threadIdx.x, stride = blockDim.x*gridDim.x;
                  icell < ncells; icell += stride) {
                 if (icell < ncells1) {
-                    int k =  icell /   (len1.x*len1.y);
-                    int j = (icell - k*(len1.x*len1.y)) /   len1.x;
-                    int i = (icell - k*(len1.x*len1.y)) - j*len1.x;
+                    int k =  icell /   len1xy;
+                    int j = (icell - k*len1xy) /   len1x;
+                    int i = (icell - k*len1xy) - j*len1x;
                     i += lo1.x;
                     j += lo1.y;
                     k += lo1.z;
                     f1(i,j,k);
                 }
                 if (icell < ncells2) {
-                    int k =  icell /   (len2.x*len2.y);
-                    int j = (icell - k*(len2.x*len2.y)) /   len2.x;
-                    int i = (icell - k*(len2.x*len2.y)) - j*len2.x;
+                    int k =  icell /   len2xy;
+                    int j = (icell - k*len2xy) /   len2x;
+                    int i = (icell - k*len2xy) - j*len2x;
                     i += lo2.x;
                     j += lo2.y;
                     k += lo2.z;
                     f2(i,j,k);
                 }
                 if (icell < ncells3) {
-                    int k =  icell /   (len3.x*len3.y);
-                    int j = (icell - k*(len3.x*len3.y)) /   len3.x;
-                    int i = (icell - k*(len3.x*len3.y)) - j*len3.x;
+                    int k =  icell /   len3xy;
+                    int j = (icell - k*len3xy) /   len3x;
+                    int i = (icell - k*len3xy) - j*len3x;
                     i += lo3.x;
                     j += lo3.y;
                     k += lo3.z;
@@ -1099,15 +1145,19 @@ ParallelFor (Gpu::KernelInfo const& info,
         const auto lo2  = amrex::lbound(box2);
         const auto len1 = amrex::length(box1);
         const auto len2 = amrex::length(box2);
+        const auto len1xy = len1.x*len1.y;
+        const auto len2xy = len2.x*len2.y;
+        const auto len1x = len1.x;
+        const auto len2x = len2.x;
         const auto ec = Gpu::ExecutionConfig(ncells);
         AMREX_LAUNCH_KERNEL(ec.numBlocks, ec.numThreads, 0, Gpu::gpuStream(),
         [=] AMREX_GPU_DEVICE () noexcept {
             for (int icell = blockDim.x*blockIdx.x+threadIdx.x, stride = blockDim.x*gridDim.x;
                  icell < ncells; icell += stride) {
                 if (icell < ncells1) {
-                    int k =  icell /   (len1.x*len1.y);
-                    int j = (icell - k*(len1.x*len1.y)) /   len1.x;
-                    int i = (icell - k*(len1.x*len1.y)) - j*len1.x;
+                    int k =  icell /   len1xy;
+                    int j = (icell - k*len1xy) /   len1x;
+                    int i = (icell - k*len1xy) - j*len1x;
                     i += lo1.x;
                     j += lo1.y;
                     k += lo1.z;
@@ -1116,9 +1166,9 @@ ParallelFor (Gpu::KernelInfo const& info,
                     }
                 }
                 if (icell < ncells2) {
-                    int k =  icell /   (len2.x*len2.y);
-                    int j = (icell - k*(len2.x*len2.y)) /   len2.x;
-                    int i = (icell - k*(len2.x*len2.y)) - j*len2.x;
+                    int k =  icell /   len2xy;
+                    int j = (icell - k*len2xy) /   len2x;
+                    int i = (icell - k*len2xy) - j*len2x;
                     i += lo2.x;
                     j += lo2.y;
                     k += lo2.z;
@@ -1162,15 +1212,21 @@ ParallelFor (Gpu::KernelInfo const& info,
         const auto len1 = amrex::length(box1);
         const auto len2 = amrex::length(box2);
         const auto len3 = amrex::length(box3);
+        const auto len1xy = len1.x*len1.y;
+        const auto len2xy = len2.x*len2.y;
+        const auto len3xy = len3.x*len3.y;
+        const auto len1x = len1.x;
+        const auto len2x = len2.x;
+        const auto len3x = len3.x;
         const auto ec = Gpu::ExecutionConfig(ncells);
         AMREX_LAUNCH_KERNEL(ec.numBlocks, ec.numThreads, 0, Gpu::gpuStream(),
         [=] AMREX_GPU_DEVICE () noexcept {
             for (int icell = blockDim.x*blockIdx.x+threadIdx.x, stride = blockDim.x*gridDim.x;
                  icell < ncells; icell += stride) {
                 if (icell < ncells1) {
-                    int k =  icell /   (len1.x*len1.y);
-                    int j = (icell - k*(len1.x*len1.y)) /   len1.x;
-                    int i = (icell - k*(len1.x*len1.y)) - j*len1.x;
+                    int k =  icell /   len1xy;
+                    int j = (icell - k*len1xy) /   len1x;
+                    int i = (icell - k*len1xy) - j*len1x;
                     i += lo1.x;
                     j += lo1.y;
                     k += lo1.z;
@@ -1179,9 +1235,9 @@ ParallelFor (Gpu::KernelInfo const& info,
                     }
                 }
                 if (icell < ncells2) {
-                    int k =  icell /   (len2.x*len2.y);
-                    int j = (icell - k*(len2.x*len2.y)) /   len2.x;
-                    int i = (icell - k*(len2.x*len2.y)) - j*len2.x;
+                    int k =  icell /   len2xy;
+                    int j = (icell - k*len2xy) /   len2x;
+                    int i = (icell - k*len2xy) - j*len2x;
                     i += lo2.x;
                     j += lo2.y;
                     k += lo2.z;
@@ -1190,9 +1246,9 @@ ParallelFor (Gpu::KernelInfo const& info,
                     }
                 }
                 if (icell < ncells3) {
-                    int k =  icell /   (len3.x*len3.y);
-                    int j = (icell - k*(len3.x*len3.y)) /   len3.x;
-                    int i = (icell - k*(len3.x*len3.y)) - j*len3.x;
+                    int k =  icell /   len3xy;
+                    int j = (icell - k*len3xy) /   len3x;
+                    int i = (icell - k*len3xy) - j*len3x;
                     i += lo3.x;
                     j += lo3.y;
                     k += lo3.z;

--- a/Src/Base/AMReX_Reduce.H
+++ b/Src/Base/AMReX_Reduce.H
@@ -316,6 +316,8 @@ public:
         int ncells = box.numPts();
         const auto lo  = amrex::lbound(box);
         const auto len = amrex::length(box);
+        const auto lenxy = len.x*len.y;
+        const auto lenx = len.x;
         IndexType ixtype = box.ixType();
         constexpr int nitems_per_thread = 4;
         int nblocks_ec = (ncells + nitems_per_thread*AMREX_GPU_MAX_THREADS-1)
@@ -335,9 +337,9 @@ public:
             }
             for (int icell = gh.item->get_global_id(0), stride = gh.item->get_global_range(0);
                  icell < ncells; icell += stride) {
-                int k =  icell /   (len.x*len.y);
-                int j = (icell - k*(len.x*len.y)) /   len.x;
-                int i = (icell - k*(len.x*len.y)) - j*len.x;
+                int k =  icell /   lenxy;
+                int j = (icell - k*lenxy) /   lenx;
+                int i = (icell - k*lenxy) - j*lenx;
                 i += lo.x;
                 j += lo.y;
                 k += lo.z;
@@ -358,9 +360,9 @@ public:
             }
             for (int icell = blockDim.x*blockIdx.x+threadIdx.x, stride = blockDim.x*gridDim.x;
                  icell < ncells; icell += stride) {
-                int k =  icell /   (len.x*len.y);
-                int j = (icell - k*(len.x*len.y)) /   len.x;
-                int i = (icell - k*(len.x*len.y)) - j*len.x;
+                int k =  icell /   lenxy;
+                int j = (icell - k*lenxy) /   lenx;
+                int i = (icell - k*lenxy) - j*lenx;
                 i += lo.x;
                 j += lo.y;
                 k += lo.z;
@@ -384,6 +386,8 @@ public:
         int ncells = box.numPts();
         const auto lo  = amrex::lbound(box);
         const auto len = amrex::length(box);
+        const auto lenxy = len.x*len.y;
+        const auto lenx = len.x;
         constexpr int nitems_per_thread = 4;
         int nblocks_ec = (ncells + nitems_per_thread*AMREX_GPU_MAX_THREADS-1)
             / (nitems_per_thread*AMREX_GPU_MAX_THREADS);
@@ -402,9 +406,9 @@ public:
             }
             for (int icell = gh.item->get_global_id(0), stride = gh.item->get_global_range(0);
                  icell < ncells; icell += stride) {
-                int k =  icell /   (len.x*len.y);
-                int j = (icell - k*(len.x*len.y)) /   len.x;
-                int i = (icell - k*(len.x*len.y)) - j*len.x;
+                int k =  icell /   lenxy;
+                int j = (icell - k*lenxy) /   lenx;
+                int i = (icell - k*lenxy) - j*lenx;
                 i += lo.x;
                 j += lo.y;
                 k += lo.z;
@@ -426,9 +430,9 @@ public:
             }
             for (int icell = blockDim.x*blockIdx.x+threadIdx.x, stride = blockDim.x*gridDim.x;
                  icell < ncells; icell += stride) {
-                int k =  icell /   (len.x*len.y);
-                int j = (icell - k*(len.x*len.y)) /   len.x;
-                int i = (icell - k*(len.x*len.y)) - j*len.x;
+                int k =  icell /   lenxy;
+                int j = (icell - k*lenxy) /   lenx;
+                int i = (icell - k*lenxy) - j*lenx;
                 i += lo.x;
                 j += lo.y;
                 k += lo.z;
@@ -710,6 +714,8 @@ bool AnyOf (Box const& box, P&& pred)
     int ncells = box.numPts();
     const auto lo  = amrex::lbound(box);
     const auto len = amrex::length(box);
+    const auto lenxy = len.x*len.y;
+    const auto lenx = len.x;
     auto ec = Gpu::ExecutionConfig(ncells);
     ec.numBlocks.x = std::min(ec.numBlocks.x, Gpu::Device::maxBlocksPerLaunch());
 
@@ -727,9 +733,9 @@ bool AnyOf (Box const& box, P&& pred)
             int r = false;
             for (int icell = gh.blockDim()*gh.blockIdx()+gh.threadIdx(), stride = gh.blockDim()*gh.gridDim();
                  icell < ncells && !r; icell += stride) {
-                int k =  icell /   (len.x*len.y);
-                int j = (icell - k*(len.x*len.y)) /   len.x;
-                int i = (icell - k*(len.x*len.y)) - j*len.x;
+                int k =  icell /   lenxy;
+                int j = (icell - k*lenxy) /   lenx;
+                int i = (icell - k*lenxy) - j*lenx;
                 i += lo.x;
                 j += lo.y;
                 k += lo.z;
@@ -752,9 +758,9 @@ bool AnyOf (Box const& box, P&& pred)
             int r = false;
             for (int icell = blockDim.x*blockIdx.x+threadIdx.x, stride = blockDim.x*gridDim.x;
                  icell < ncells && !r; icell += stride) {
-                int k =  icell /   (len.x*len.y);
-                int j = (icell - k*(len.x*len.y)) /   len.x;
-                int i = (icell - k*(len.x*len.y)) - j*len.x;
+                int k =  icell /   lenxy;
+                int j = (icell - k*lenxy) /   lenx;
+                int i = (icell - k*lenxy) - j*lenx;
                 i += lo.x;
                 j += lo.y;
                 k += lo.z;


### PR DESCRIPTION
Box length is used in many kernels.  Because the length in z-direction is
not needed, we only need 2 integers, not Dim3 that has 3 integers.

## Summary

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
