### PR TITLE
 Update MacProjector::project to check if m_umac is nullptr

### DIFF
--- a/Src/LinearSolvers/Projections/AMReX_MacProjector.cpp
+++ b/Src/LinearSolvers/Projections/AMReX_MacProjector.cpp
@@ -231,8 +231,6 @@ MacProjector::project (Real reltol, Real atol)
         for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
             u[idim] = m_umac[ilev][idim];
         }
-        MultiFab divu(m_rhs[ilev].boxArray(), m_rhs[ilev].DistributionMap(),
-                      1, 0, MFInfo(), m_rhs[ilev].Factory());
 #ifdef AMREX_USE_EB
         if (m_umac_loc != MLMG::Location::FaceCentroid)
         {
@@ -243,9 +241,9 @@ MacProjector::project (Real reltol, Real atol)
             }
         }
 
-        EB_computeDivergence(divu, u, m_geom[ilev], (m_umac_loc == MLMG::Location::FaceCentroid));
+        EB_computeDivergence(m_rhs[ilev], u, m_geom[ilev], (m_umac_loc == MLMG::Location::FaceCentroid));
 #else
-        computeDivergence(divu, u, m_geom[ilev]);
+        computeDivergence(m_rhs[ilev], u, m_geom[ilev]);
 #endif
 
         // For mlabeclaplacian, we solve -del dot (beta grad phi) = rhs
@@ -253,7 +251,6 @@ MacProjector::project (Real reltol, Real atol)
         // For mlpoisson, we solve `del dot grad phi = rhs/(-const_beta)`
         //   and set up RHS as (m_divu - divu)*(-1/const_beta)
         AMREX_ASSERT(m_poisson == nullptr || m_const_beta != Real(0.0));
-        MultiFab::Copy(m_rhs[ilev], divu, 0, 0, 1, 0);
         m_rhs[ilev].mult(m_poisson ? Real(1.0)/m_const_beta : Real(-1.0));
 
         if (m_divu[ilev].ok())

--- a/Src/LinearSolvers/Projections/AMReX_MacProjector.cpp
+++ b/Src/LinearSolvers/Projections/AMReX_MacProjector.cpp
@@ -230,7 +230,7 @@ MacProjector::project (Real reltol, Real atol)
     {
       if ( m_umac[0][0] )
       {
-	Array<MultiFab const*, AMREX_SPACEDIM> u;
+        Array<MultiFab const*, AMREX_SPACEDIM> u;
         for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
             u[idim] = m_umac[ilev][idim];
         }
@@ -260,8 +260,8 @@ MacProjector::project (Real reltol, Real atol)
 
       if (m_divu[ilev].ok())
       {
-	MultiFab::Saxpy(m_rhs[ilev], m_poisson ? Real(-1.0)/m_const_beta : Real(1.0),
-			m_divu[ilev], 0, 0, 1, 0);
+        MultiFab::Saxpy(m_rhs[ilev], m_poisson ? Real(-1.0)/m_const_beta : Real(1.0),
+                        m_divu[ilev], 0, 0, 1, 0);
       }
 
       // Always reset initial phi to be zero. This is needed to handle the


### PR DESCRIPTION
## Summary

Update MacProjector::project to check if m_umac is nullptr. If nullptr, don't compute div(umac) or attempt to average down or update umac.

This also removes an unnecessary temporary.

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
