### PR TITLE
AMReX_Array.H: Fix [-Warray-bounds] Warning

### DIFF
--- a/Src/Base/AMReX_Array.H
+++ b/Src/Base/AMReX_Array.H
@@ -35,10 +35,10 @@ namespace amrex {
         using reference_type = T&;
 
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-        const T& operator [] (int i) const noexcept { return arr[i]; }
+        const T& operator [] (unsigned int i) const noexcept { return arr[i]; }
 
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-        T& operator [] (int i) noexcept { return arr[i]; }
+        T& operator [] (unsigned int i) noexcept { return arr[i]; }
 
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         const T* data () const noexcept { return arr; }


### PR DESCRIPTION
## Summary
Hi, I'm a [WarpX](https://github.com/ECP-WarpX/WarpX) developer and I noticed that we have various warnings that look like this
```
../amrex/Src/Base/AMReX_Array.H:38:65:
warning: array subscript -1 is below array bounds of 'int* const __restrict__ [1]' [-Warray-bounds]
38 |     const T& operator [] (int i) const noexcept { return arr[i]; }
   |   
```
when we compile WarpX with GNU Make (with all default build options).

I saw that using `unsigned int` instead of `int` as the type of the integer argument passed to the operators `[]` of the struct `GpuArray` fixes the warnings.

For example, this is done already for the iterator of the `for` loop in the function `fill` of the same struct:
https://github.com/AMReX-Codes/amrex/blob/6ab65e7fc0ace3cd116f2b7e2c51a3506e7d4ff1/Src/Base/AMReX_Array.H#L64-L66

I have not been able to observe the same warning if I build AMReX alone, with CMake (with all default build options).

So I am not sure that the solution suggested in this PR is the correct way to go. One option is also that the warning itself is a bogus warning due to a compiler issue.

I opened the PR as draft, to leave room for discussion and feedback. Please feel free to close the PR directly, if the changes suggested are not appropriate or correct.

## Checklist

The proposed changes:
- [x] fix a compiler warning
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
