### PR TITLE
Fix missing MPI flags in Perlmutter.

### DIFF
--- a/Tools/GNUMake/sites/Make.nersc
+++ b/Tools/GNUMake/sites/Make.nersc
@@ -28,8 +28,7 @@ ifeq ($(which_computer),$(filter $(which_computer),perlmutter))
       LIBRARIES += -lmpichf90
     endif
 
-#    For Reference --> getting cflags on Perlmutter.
-#    includes += $(shell CC --cray-print-opts=cflags)
+    includes += $(shell CC --cray-print-opts=cflags)
   endif
 
   ifeq ($(USE_CUDA),TRUE)


### PR DESCRIPTION
## Summary
On both NVIDIA and GNU PrgEnv, this allows MPI builds. Confirmed with Nyx builds.

## Additional background

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
