### PR TITLE
Gradient in WarpX EB nodal solver

### DIFF
--- a/Src/LinearSolvers/MLMG/AMReX_MLEBNodeFDLap_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBNodeFDLap_K.H
@@ -11,4 +11,143 @@
 #include <AMReX_MLEBNodeFDLap_3D_K.H>
 #endif
 
+namespace amrex {
+
+template <typename F>
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void mlebndfdlap_grad_x_doit (int i, int j, int k, Array4<Real> const& px,
+                              Array4<Real const> const& p, Array4<int const> const& dmsk,
+                              Array4<Real const> const& ecx, F&& phieb, Real dxi)
+{
+    if (dmsk(i,j,k) >= 0 && dmsk(i+1,j,k) >= 0) {
+        px(i,j,k) = dxi * (p(i+1,j,k) - p(i,j,k));
+    } else if (dmsk(i,j,k) < 0 && dmsk(i+1,j,k) < 0) {
+        px(i,j,k) = Real(0.0);
+    } else if (dmsk(i,j,k) < 0) {
+        px(i,j,k) = dxi * (p(i+1,j,k) - phieb(i,j,k)) / (Real(1.0) - Real(2.0) * ecx(i,j,k));
+    } else { //
+        px(i,j,k) = dxi * (phieb(i+1,j,k) - p(i,j,k)) / (Real(1.0) + Real(2.0) * ecx(i,j,k));
+    }
+}
+
+template <typename F>
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void mlebndfdlap_grad_y_doit (int i, int j, int k, Array4<Real> const& py,
+                              Array4<Real const> const& p, Array4<int const> const& dmsk,
+                              Array4<Real const> const& ecy, F&& phieb, Real dyi)
+{
+    if (dmsk(i,j,k) >= 0 && dmsk(i,j+1,k) >= 0) {
+        py(i,j,k) = dyi * (p(i,j+1,k) - p(i,j,k));
+    } else if (dmsk(i,j,k) < 0 && dmsk(i,j+1,k) < 0) {
+        py(i,j,k) = Real(0.0);
+    } else if (dmsk(i,j,k) < 0) {
+        py(i,j,k) = dyi * (p(i,j+1,k) - phieb(i,j,k)) / (Real(1.0) - Real(2.0) * ecy(i,j,k));
+    } else { //
+        py(i,j,k) = dyi * (phieb(i,j+1,k) - p(i,j,k)) / (Real(1.0) + Real(2.0) * ecy(i,j,k));
+    }
+}
+
+#if (AMREX_SPACEDIM > 2)
+template <typename F>
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void mlebndfdlap_grad_z_doit (int i, int j, int k, Array4<Real> const& pz,
+                              Array4<Real const> const& p, Array4<int const> const& dmsk,
+                              Array4<Real const> const& ecz, F&& phieb, Real dzi)
+{
+    if (dmsk(i,j,k) >= 0 && dmsk(i,j,k+1) >= 0) {
+        pz(i,j,k) = dzi * (p(i,j,k+1) - p(i,j,k));
+    } else if (dmsk(i,j,k) < 0 && dmsk(i,j,k+1) < 0) {
+        pz(i,j,k) = Real(0.0);
+    } else if (dmsk(i,j,k) < 0) {
+        pz(i,j,k) = dzi * (p(i,j,k+1) - phieb(i,j,k)) / (Real(1.0) - Real(2.0) * ecz(i,j,k));
+    } else { //
+        pz(i,j,k) = dzi * (phieb(i,j,k+1) - p(i,j,k)) / (Real(1.0) + Real(2.0) * ecz(i,j,k));
+    }
+}
+#endif
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void mlebndfdlap_grad_x (Box const& b, Array4<Real> const& px, Array4<Real const> const& p,
+                         Array4<int const> const& dmsk, Array4<Real const> const& ecx,
+                         Real phieb, Real dxi)
+{
+    AMREX_LOOP_3D(b, i, j, k,
+    {
+        mlebndfdlap_grad_x_doit(i,j,k, px, p, dmsk, ecx,
+                                [=] (int, int, int) -> Real { return phieb; },
+                                dxi);
+    });
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void mlebndfdlap_grad_x (Box const& b, Array4<Real> const& px, Array4<Real const> const& p,
+                         Array4<int const> const& dmsk, Array4<Real const> const& ecx,
+                         Array4<Real const> const& phieb, Real dxi)
+{
+    AMREX_LOOP_3D(b, i, j, k,
+    {
+        mlebndfdlap_grad_x_doit(i,j,k, px, p, dmsk, ecx,
+                                [=] (int i1, int i2, int i3) -> Real { return phieb(i1,i2,i3); },
+                                dxi);
+    });
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void mlebndfdlap_grad_y (Box const& b, Array4<Real> const& py, Array4<Real const> const& p,
+                         Array4<int const> const& dmsk, Array4<Real const> const& ecy,
+                         Real phieb, Real dyi)
+{
+    AMREX_LOOP_3D(b, i, j, k,
+    {
+        mlebndfdlap_grad_y_doit(i,j,k, py, p, dmsk, ecy,
+                                [=] (int, int, int) -> Real { return phieb; },
+                                dyi);
+    });
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void mlebndfdlap_grad_y (Box const& b, Array4<Real> const& py, Array4<Real const> const& p,
+                         Array4<int const> const& dmsk, Array4<Real const> const& ecy,
+                         Array4<Real const> const& phieb, Real dyi)
+{
+    AMREX_LOOP_3D(b, i, j, k,
+    {
+        mlebndfdlap_grad_y_doit(i,j,k, py, p, dmsk, ecy,
+                                [=] (int i1, int i2, int i3) -> Real { return phieb(i1,i2,i3); },
+                                dyi);
+    });
+}
+
+#if (AMREX_SPACEDIM > 2)
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void mlebndfdlap_grad_z (Box const& b, Array4<Real> const& pz, Array4<Real const> const& p,
+                         Array4<int const> const& dmsk, Array4<Real const> const& ecz,
+                         Real phieb, Real dzi)
+{
+    AMREX_LOOP_3D(b, i, j, k,
+    {
+        mlebndfdlap_grad_z_doit(i,j,k, pz, p, dmsk, ecz,
+                                [=] (int, int, int) -> Real { return phieb; },
+                                dzi);
+    });
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void mlebndfdlap_grad_z (Box const& b, Array4<Real> const& pz, Array4<Real const> const& p,
+                         Array4<int const> const& dmsk, Array4<Real const> const& ecz,
+                         Array4<Real const> const& phieb, Real dzi)
+{
+    AMREX_LOOP_3D(b, i, j, k,
+    {
+        mlebndfdlap_grad_z_doit(i,j,k, pz, p, dmsk, ecz,
+                                [=] (int i1, int i2, int i3) -> Real { return phieb(i1,i2,i3); },
+                                dzi);
+    });
+}
+
+#endif
+
+}
+
 #endif

--- a/Src/LinearSolvers/MLMG/AMReX_MLEBNodeFDLaplacian.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBNodeFDLaplacian.H
@@ -73,6 +73,9 @@ public:
 
     virtual bool isSingular (int) const final override { return false; }
 
+    virtual void compGrad (int amrlev, const Array<MultiFab*,AMREX_SPACEDIM>& grad,
+                           MultiFab& sol, Location /*loc*/) const override;
+
 #if defined(AMREX_USE_HYPRE)
     virtual void fillIJMatrix (MFIter const& mfi,
                                Array4<HypreNodeLap::AtomicInt const> const& gid,


### PR DESCRIPTION
Implement function that computes the gradient of potential in the EB nodal
solver for WarpX.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
