### PR TITLE
Fix warning with Intel icpc

### DIFF
--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -33,3 +33,48 @@ jobs:
     # note: setting the CXX compiler ID is a work-around for
     # the 2021.1 DPC++ release / CMake 3.19.0-3.19.1
     # https://gitlab.kitware.com/cmake/cmake/-/issues/21551#note_869580
+
+# "Classic" EDG Intel Compiler
+# Ref.: https://github.com/rscohn2/oneapi-ci
+# intel-basekit intel-hpckit are too large in size
+  tests-icc:
+    name: ICC [tests]
+    runs-on: ubuntu-20.04
+    env: {CXXFLAGS: "-Werror"}
+    steps:
+    - uses: actions/checkout@v2
+    - name: install dependencies
+      run: |
+        export DEBIAN_FRONTEND=noninteractive
+        sudo apt-get -qqq update
+        sudo apt-get install -y wget build-essential pkg-config cmake ca-certificates gnupg
+        sudo wget https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
+        sudo apt-key add GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
+        echo "deb https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
+        sudo apt-get update
+        sudo apt-get install -y intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic intel-oneapi-compiler-fortran intel-oneapi-mpi-devel
+    - name: build
+      run: |
+        set +e
+        source /opt/intel/oneapi/setvars.sh
+        set -e
+        export CXX=$(which icpc)
+        export CC=$(which icc)
+        export FC=$(which ifort)
+
+        cmake -S . -B build                                \
+            -DCMAKE_VERBOSE_MAKEFILE=ON                    \
+            -DAMReX_ENABLE_TESTS=ON                        \
+            -DAMReX_FORTRAN=ON                             \
+            -DAMReX_PARTICLES=ON
+        cmake --build build --parallel 2
+        cmake --build build --target install
+        cmake --build build --target test_install
+
+    - name: Run tests
+      run: |
+        set +e
+        source /opt/intel/oneapi/setvars.sh
+        set -e
+        cd build
+        ctest --output-on-failure -R

--- a/Src/Base/AMReX_Extension.H
+++ b/Src/Base/AMReX_Extension.H
@@ -159,14 +159,17 @@
 #include <ciso646>
 #endif
 
-#if defined(__has_cpp_attribute) && __has_cpp_attribute(fallthrough) >= 201603L
-#define AMREX_FALLTHROUGH [[fallthrough]]
+#if defined(__INTEL_COMPILER) && defined(__EDG__) && (__cplusplus < 201703L)
+// Classical EDG based Intel compiler does not support fallthrough when std=c++14
+#    define AMREX_FALLTHROUGH ((void)0)
+#elif defined(__has_cpp_attribute) && __has_cpp_attribute(fallthrough) >= 201603L
+#    define AMREX_FALLTHROUGH [[fallthrough]]
 #elif defined(__clang__)
-#define AMREX_FALLTHROUGH [[clang::fallthrough]]
-#elif defined(__GNUC__) && (__GNUC__ >= 7) && !defined(__INTEL_COMPILER)
-#define AMREX_FALLTHROUGH [[gnu::fallthrough]]
+#    define AMREX_FALLTHROUGH [[clang::fallthrough]]
+#elif defined(__GNUC__) && (__GNUC__ >= 7)
+#    define AMREX_FALLTHROUGH [[gnu::fallthrough]]
 #else
-#define AMREX_FALLTHROUGH ((void)0)
+#    define AMREX_FALLTHROUGH ((void)0)
 #endif
 
 // CI uses -Werror -Wc++17-extension, thus we need to add the __cplusplus clause


### PR DESCRIPTION
## Summary

The classical EDG based Intel compiler gives warning about `fallthrough`
when `-std=c++14` is used, even though it passes the feature test for
`fallthrough`.

## Additional background

Close #2172 

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
