### PR TITLE
Add default move constructors / assignment operators for other pc types.

### DIFF
--- a/Src/AmrCore/AMReX_AmrParticles.H
+++ b/Src/AmrCore/AMReX_AmrParticles.H
@@ -274,6 +274,11 @@ public:
 
     ~AmrParticleContainer () {}
 
+    AmrParticleContainer ( const AmrParticleContainer &) = delete;
+    AmrParticleContainer& operator= ( const AmrParticleContainer & ) = delete;
+
+    AmrParticleContainer ( AmrParticleContainer && ) = default;
+    AmrParticleContainer& operator= ( AmrParticleContainer && ) = default;
 };
 
 class AmrTracerParticleContainer
@@ -287,6 +292,12 @@ public:
     }
 
     ~AmrTracerParticleContainer () {}
+
+    AmrTracerParticleContainer ( const AmrTracerParticleContainer &) = delete;
+    AmrTracerParticleContainer& operator= ( const AmrTracerParticleContainer & ) = delete;
+
+    AmrTracerParticleContainer ( AmrTracerParticleContainer && ) = default;
+    AmrTracerParticleContainer& operator= ( AmrTracerParticleContainer && ) = default;
 };
 
 }

--- a/Src/Particle/AMReX_NeighborParticles.H
+++ b/Src/Particle/AMReX_NeighborParticles.H
@@ -211,6 +211,12 @@ public:
                                const Vector<int>                 & rr,
                                int                               nneighbor);
 
+    NeighborParticleContainer ( const NeighborParticleContainer &) = delete;
+    NeighborParticleContainer& operator= ( const NeighborParticleContainer & ) = delete;
+
+    NeighborParticleContainer ( NeighborParticleContainer && ) = default;
+    NeighborParticleContainer& operator= ( NeighborParticleContainer && ) = default;
+
     ///
     /// Regrid functions
     ///

--- a/Src/Particle/AMReX_TracerParticles.H
+++ b/Src/Particle/AMReX_TracerParticles.H
@@ -23,6 +23,12 @@ public:
 
     ~TracerParticleContainer () {}
 
+    TracerParticleContainer ( const TracerParticleContainer &) = delete;
+    TracerParticleContainer& operator= ( const TracerParticleContainer & ) = delete;
+
+    TracerParticleContainer ( TracerParticleContainer && ) = default;
+    TracerParticleContainer& operator= ( TracerParticleContainer && ) = default;
+
     void AdvectWithUmac (MultiFab* umac, int level, Real dt);
 
     void AdvectWithUcc (const MultiFab& ucc, int level, Real dt);


### PR DESCRIPTION
The base ParticleContainer class has this - this adds the same behavior for AmrParticleContainer, TracerParticleContainer, NeighborParticleContainer, etc... 

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
