### PR TITLE
Optimization of ParallelFor for single box FabArray

### DIFF
--- a/Src/Base/AMReX_MFParallelForG.H
+++ b/Src/Base/AMReX_MFParallelForG.H
@@ -74,65 +74,74 @@ ParallelFor (MF const& mf, IntVect const& nghost, int ncomp, IntVect const&, F&&
 {
     const auto& index_array = mf.IndexArray();
     const int nboxes = index_array.size();
-    if (nboxes == 0) return;
 
-    AMREX_ASSERT(nghost.allLE(mf.nGrowVect()) && nghost.allGE(IntVect(0)));
-    IntVect ngrow = nghost - mf.nGrowVect(); // We use this to go from fabbox to valid+nghost.
-    auto ma = mf.arrays();
+    if (nboxes == 0) {
+        return;
+    } else if (nboxes == 1) {
+        auto const& fab = mf.atLocalIdx(0);
+        Box const& b = amrex::grow(fab.box(), nghost-mf.nGrowVect());
+        amrex::ParallelFor(b, ncomp, [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
+        {
+            parfor_mf_detail::call_f(f, 0, i, j, k, n);
+        });
+    } else {
+        AMREX_ASSERT(nghost.allLE(mf.nGrowVect()) && nghost.allGE(IntVect(0)));
+        IntVect ngrow = nghost - mf.nGrowVect(); // We use this to go from fabbox to valid+nghost.
+        auto ma = mf.arrays();
 
-    auto par_for_blocks = mf.getParForInfo(nghost).getBlocks();
-    const int nblocks = par_for_blocks.first[nboxes];
-    const int block_0_size = par_for_blocks.first[1];
-    const int* dp_nblocks = par_for_blocks.second;
+        auto par_for_blocks = mf.getParForInfo(nghost).getBlocks();
+        const int nblocks = par_for_blocks.first[nboxes];
+        const int block_0_size = par_for_blocks.first[1];
+        const int* dp_nblocks = par_for_blocks.second;
 
 #if defined(AMREX_USE_CUDA) || defined(AMREX_USE_HIP)
 
-    amrex::launch_global<AMREX_GPU_MAX_THREADS>
-        <<<nblocks, AMREX_GPU_MAX_THREADS, 0, Gpu::gpuStream()>>>
-        ([=] AMREX_GPU_DEVICE () noexcept
-         {
-             int ibox, icell;
-             if (dp_nblocks) {
-                 ibox = amrex::bisect(dp_nblocks, 0, nboxes, static_cast<int>(blockIdx.x));
-                 icell = (blockIdx.x-dp_nblocks[ibox])*AMREX_GPU_MAX_THREADS + threadIdx.x;
-             } else {
-                 ibox = blockIdx.x / block_0_size;
-                 icell = (blockIdx.x-ibox*block_0_size)*AMREX_GPU_MAX_THREADS + threadIdx.x;
-             }
+        amrex::launch_global<AMREX_GPU_MAX_THREADS>
+            <<<nblocks, AMREX_GPU_MAX_THREADS, 0, Gpu::gpuStream()>>>
+            ([=] AMREX_GPU_DEVICE () noexcept
+             {
+                 int ibox, icell;
+                 if (dp_nblocks) {
+                     ibox = amrex::bisect(dp_nblocks, 0, nboxes, static_cast<int>(blockIdx.x));
+                     icell = (blockIdx.x-dp_nblocks[ibox])*AMREX_GPU_MAX_THREADS + threadIdx.x;
+                 } else {
+                     ibox = blockIdx.x / block_0_size;
+                     icell = (blockIdx.x-ibox*block_0_size)*AMREX_GPU_MAX_THREADS + threadIdx.x;
+                 }
 
 #elif defined(AMREX_USE_DPCPP)
 
-    amrex::launch(nblocks, AMREX_GPU_MAX_THREADS, Gpu::gpuStream(),
-         [=] AMREX_GPU_DEVICE (sycl::nd_item<1> const& item) noexcept
-         {
-             int ibox, icell;
-             int blockIdxx = item.get_group_linear_id();
-             int threadIdxx = item.get_local_linear_id();
-             if (dp_nblocks) {
-                 ibox = amrex::bisect(dp_nblocks, 0, nboxes, static_cast<int>(blockIdxx));
-                 icell = (blockIdxx-dp_nblocks[ibox])*AMREX_GPU_MAX_THREADS + threadIdxx;
-             } else {
-                 ibox = blockIdxx / block_0_size;
-                 icell = (blockIdxx-ibox*block_0_size)*AMREX_GPU_MAX_THREADS + threadIdxx;
-             }
-#endif
-             Box b(ma[ibox]);
-             b.grow(ngrow);
-             int ncells = b.numPts();
-             if (icell < ncells) {
-                 const auto len = amrex::length(b);
-                 int k =  icell /   (len.x*len.y);
-                 int j = (icell - k*(len.x*len.y)) /   len.x;
-                 int i = (icell - k*(len.x*len.y)) - j*len.x;
-                 AMREX_D_TERM(i += b.smallEnd(0);,
-                              j += b.smallEnd(1);,
-                              k += b.smallEnd(2);)
-                 for (int n = 0; n < ncomp; ++n) {
-                     parfor_mf_detail::call_f(f, ibox, i, j, k, n);
+        amrex::launch(nblocks, AMREX_GPU_MAX_THREADS, Gpu::gpuStream(),
+             [=] AMREX_GPU_DEVICE (sycl::nd_item<1> const& item) noexcept
+             {
+                 int ibox, icell;
+                 int blockIdxx = item.get_group_linear_id();
+                 int threadIdxx = item.get_local_linear_id();
+                 if (dp_nblocks) {
+                     ibox = amrex::bisect(dp_nblocks, 0, nboxes, static_cast<int>(blockIdxx));
+                     icell = (blockIdxx-dp_nblocks[ibox])*AMREX_GPU_MAX_THREADS + threadIdxx;
+                 } else {
+                     ibox = blockIdxx / block_0_size;
+                     icell = (blockIdxx-ibox*block_0_size)*AMREX_GPU_MAX_THREADS + threadIdxx;
                  }
-             }
-         });
-
+#endif
+                 Box b(ma[ibox]);
+                 b.grow(ngrow);
+                 int ncells = b.numPts();
+                 if (icell < ncells) {
+                     const auto len = amrex::length(b);
+                     int k =  icell /   (len.x*len.y);
+                     int j = (icell - k*(len.x*len.y)) /   len.x;
+                     int i = (icell - k*(len.x*len.y)) - j*len.x;
+                     AMREX_D_TERM(i += b.smallEnd(0);,
+                                  j += b.smallEnd(1);,
+                                  k += b.smallEnd(2);)
+                     for (int n = 0; n < ncomp; ++n) {
+                         parfor_mf_detail::call_f(f, ibox, i, j, k, n);
+                     }
+                 }
+             });
+    }
     AMREX_GPU_ERROR_CHECK();
 }
 


### PR DESCRIPTION
When there is only one Fab, we can simplify the MF ParallelFor funciton.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
