### PR TITLE
Fix and update multifab ParallelFor

### DIFF
--- a/Src/Base/AMReX_FabArrayBase.H
+++ b/Src/Base/AMReX_FabArrayBase.H
@@ -647,7 +647,7 @@ public:
     //! For ParallelFor(FabArray)
     struct ParForInfo
     {
-        ParForInfo (const FabArrayBase& fa, const IntVect& nghost);
+        ParForInfo (const FabArrayBase& fa, const IntVect& nghost, int nthreads);
         ~ParForInfo ();
 
         std::pair<int*,int*> const& getBlocks () const { return m_nblocks_x; }
@@ -660,10 +660,12 @@ public:
 
         IndexType m_typ;
         IntVect m_crse_ratio;
+        IntVect m_ng;
+        int m_nthreads;
         std::pair<int*,int*> m_nblocks_x;
     };
 
-    ParForInfo const& getParForInfo (const IntVect& nghost) const;
+    ParForInfo const& getParForInfo (const IntVect& nghost, int nthreads) const;
 
     static std::multimap<BDKey,ParForInfo*> m_TheParForCache;
 

--- a/Src/Base/AMReX_FabArrayBase.cpp
+++ b/Src/Base/AMReX_FabArrayBase.cpp
@@ -2482,9 +2482,11 @@ FabArrayBase::is_cell_centered () const noexcept
 
 #ifdef AMREX_USE_GPU
 
-FabArrayBase::ParForInfo::ParForInfo (const FabArrayBase& fa, const IntVect& nghost)
+FabArrayBase::ParForInfo::ParForInfo (const FabArrayBase& fa, const IntVect& nghost, int nthreads)
     : m_typ(fa.boxArray().ixType()),
       m_crse_ratio(fa.boxArray().crseRatio()),
+      m_ng(nghost),
+      m_nthreads(nthreads),
       m_nblocks_x({nullptr,nullptr})
 {
     Vector<Long> ncells;
@@ -2498,7 +2500,7 @@ FabArrayBase::ParForInfo::ParForInfo (const FabArrayBase& fa, const IntVect& ngh
         }
         ncells.push_back(N);
     }
-    m_nblocks_x = detail::build_par_for_nblocks(ncells);
+    m_nblocks_x = detail::build_par_for_nblocks(ncells, nthreads);
 }
 
 FabArrayBase::ParForInfo::~ParForInfo ()
@@ -2507,19 +2509,21 @@ FabArrayBase::ParForInfo::~ParForInfo ()
 }
 
 FabArrayBase::ParForInfo const&
-FabArrayBase::getParForInfo (const IntVect& nghost) const
+FabArrayBase::getParForInfo (const IntVect& nghost, int nthreads) const
 {
     AMREX_ASSERT(getBDKey() == m_bdkey);
     auto er_it = m_TheParForCache.equal_range(m_bdkey);
     for (auto it = er_it.first; it != er_it.second; ++it) {
         if (it->second->m_typ        == boxArray().ixType()    &&
-            it->second->m_crse_ratio == boxArray().crseRatio())
+            it->second->m_crse_ratio == boxArray().crseRatio() &&
+            it->second->m_ng         == nghost                 &&
+            it->second->m_nthreads   == nthreads)
         {
             return *(it->second);
         }
     }
 
-    ParForInfo* new_pfi = new ParForInfo(*this, nghost);
+    ParForInfo* new_pfi = new ParForInfo(*this, nghost, nthreads);
     m_TheParForCache.insert(er_it.second,
                             std::multimap<BDKey,ParForInfo*>::value_type(m_bdkey,new_pfi));
     return *new_pfi;

--- a/Src/Base/AMReX_MFParallelFor.H
+++ b/Src/Base/AMReX_MFParallelFor.H
@@ -46,6 +46,33 @@ ParallelFor (MF const& mf, F&& f)
 /**
  * \brief ParallelFor for MultiFab/FabArray.
  *
+ * This version launch a kernel to work on the valid region.  If built for
+ * CPU, tiling will be enabled.  For GPU build, this function is
+ * NON-BLOCKING on the host. Conceptually, this is a 4D loop.
+ *
+ * \tparam MT max threads in GPU blocks (Only relevant for GPU builds)
+ * \tparam MF the MultiFab/FabArray type
+ * \tparam F a callable type like lambda
+ *
+ * \param mf the MultiFab/FabArray object used to specify the iteration space
+ * \param f a calable object void(int,int,int,int), where the first argument
+ *           is the local box index, and the following three are spatial indices
+ *           for x, y, and z-directions.
+ */
+template <int MT, typename MF, typename F>
+std::enable_if_t<IsFabArray<MF>::value>
+ParallelFor (MF const& mf, F&& f)
+{
+#ifdef AMREX_USE_GPU
+    detail::ParallelFor<MT>(mf, IntVect(0), FabArrayBase::mfiter_tile_size, std::forward<F>(f));
+#else
+    detail::ParallelFor(mf, IntVect(0), FabArrayBase::mfiter_tile_size, std::forward<F>(f));
+#endif
+}
+
+/**
+ * \brief ParallelFor for MultiFab/FabArray.
+ *
  * This version launch a kernel to work on the valid and ghost region.  If
  * built for CPU, tiling will be enabled.  For GPU build, this function is
  * NON-BLOCKING on the host. Conceptually, this is a 4D loop.
@@ -69,6 +96,34 @@ ParallelFor (MF const& mf, IntVect const& ng, F&& f)
 /**
  * \brief ParallelFor for MultiFab/FabArray.
  *
+ * This version launch a kernel to work on the valid and ghost region.  If
+ * built for CPU, tiling will be enabled.  For GPU build, this function is
+ * NON-BLOCKING on the host. Conceptually, this is a 4D loop.
+ *
+ * \tparam MT max threads in GPU blocks (Only relevant for GPU builds)
+ * \tparam MF the MultiFab/FabArray type
+ * \tparam F a callable type like lambda
+ *
+ * \param mf the MultiFab/FabArray object used to specify the iteration space
+ * \param ng the number of ghost cells around the valid region
+ * \param f a calable object void(int,int,int,int), where the first argument
+ *           is the local box index, and the following three are spatial indices
+ *           for x, y, and z-directions.
+ */
+template <int MT, typename MF, typename F>
+std::enable_if_t<IsFabArray<MF>::value>
+ParallelFor (MF const& mf, IntVect const& ng, F&& f)
+{
+#ifdef AMREX_USE_GPU
+    detail::ParallelFor<MT>(mf, ng, FabArrayBase::mfiter_tile_size, std::forward<F>(f));
+#else
+    detail::ParallelFor(mf, ng, FabArrayBase::mfiter_tile_size, std::forward<F>(f));
+#endif
+}
+
+/**
+ * \brief ParallelFor for MultiFab/FabArray.
+ *
  * This version launch a kernel to work on the valid region.  If built for
  * CPU, tiling will be enabled.  For GPU build, this function is
  * NON-BLOCKING on the host. Conceptually, this is a 5D loop.
@@ -87,6 +142,34 @@ std::enable_if_t<IsFabArray<MF>::value>
 ParallelFor (MF const& mf, int ncomp, F&& f)
 {
     detail::ParallelFor(mf, IntVect(0), ncomp, FabArrayBase::mfiter_tile_size, std::forward<F>(f));
+}
+
+/**
+ * \brief ParallelFor for MultiFab/FabArray.
+ *
+ * This version launch a kernel to work on the valid region.  If built for
+ * CPU, tiling will be enabled.  For GPU build, this function is
+ * NON-BLOCKING on the host. Conceptually, this is a 5D loop.
+ *
+ * \tparam MT max threads in GPU blocks (Only relevant for GPU builds)
+ * \tparam MF the MultiFab/FabArray type
+ * \tparam F a callable type like lambda
+ *
+ * \param mf the MultiFab/FabArray object used to specify the iteration space
+ * \param ncomp the number of component
+ * \param f a calable object void(int,int,int,int,int), where the first argument
+ *           is the local box index, the following three are spatial indices
+ *           for x, y, and z-directions, and the last is for component.
+ */
+template <int MT, typename MF, typename F>
+std::enable_if_t<IsFabArray<MF>::value>
+ParallelFor (MF const& mf, int ncomp, F&& f)
+{
+#ifdef AMREX_USE_GPU
+    detail::ParallelFor<MT>(mf, IntVect(0), ncomp, FabArrayBase::mfiter_tile_size, std::forward<F>(f));
+#else
+    detail::ParallelFor(mf, IntVect(0), ncomp, FabArrayBase::mfiter_tile_size, std::forward<F>(f));
+#endif
 }
 
 /**
@@ -116,6 +199,35 @@ ParallelFor (MF const& mf, IntVect const& ng, int ncomp, F&& f)
 /**
  * \brief ParallelFor for MultiFab/FabArray.
  *
+ * This version launch a kernel to work on the valid and ghost region.  If
+ * built for CPU, tiling will be enabled.  For GPU build, this function is
+ * NON-BLOCKING on the host. Conceptually, this is a 5D loop.
+ *
+ * \tparam MT max threads in GPU blocks (Only relevant for GPU builds)
+ * \tparam MF the MultiFab/FabArray type
+ * \tparam F a callable type like lambda
+ *
+ * \param mf the MultiFab/FabArray object used to specify the iteration space
+ * \param ng the number of ghost cells around the valid region
+ * \param ncomp the number of component
+ * \param f a calable object void(int,int,int,int,int), where the first argument
+ *           is the local box index, the following three are spatial indices
+ *           for x, y, and z-directions, and the last is for component.
+ */
+template <int MT, typename MF, typename F>
+std::enable_if_t<IsFabArray<MF>::value>
+ParallelFor (MF const& mf, IntVect const& ng, int ncomp, F&& f)
+{
+#ifdef AMREX_USE_GPU
+    detail::ParallelFor<MT>(mf, ng, ncomp, FabArrayBase::mfiter_tile_size, std::forward<F>(f));
+#else
+    detail::ParallelFor(mf, ng, ncomp, FabArrayBase::mfiter_tile_size, std::forward<F>(f));
+#endif
+}
+
+/**
+ * \brief ParallelFor for MultiFab/FabArray.
+ *
  * This version launch a kernel to work on the valid region.  If built for
  * CPU, tiling will be enabled.  However, one could specify a huge tile size
  * to effectively disable tiling.  For GPU build, this function is
@@ -135,6 +247,35 @@ std::enable_if_t<IsFabArray<MF>::value>
 ParallelFor (MF const& mf, ParForMFTileSize const& ts, F&& f)
 {
     detail::ParallelFor(mf, IntVect(0), ts.tile_size, std::forward<F>(f));
+}
+
+/**
+ * \brief ParallelFor for MultiFab/FabArray.
+ *
+ * This version launch a kernel to work on the valid region.  If built for
+ * CPU, tiling will be enabled.  However, one could specify a huge tile size
+ * to effectively disable tiling.  For GPU build, this function is
+ * NON-BLOCKING on the host. Conceptually, this is a 4D loop.
+ *
+ * \tparam MT max threads in GPU blocks (Only relevant for GPU builds)
+ * \tparam MF the MultiFab/FabArray type
+ * \tparam F a callable type like lambda
+ *
+ * \param mf the MultiFab/FabArray object used to specify the iteration space
+ * \param ts tile size, ignored by GPU build
+ * \param f a calable object void(int,int,int,int), where the first argument
+ *           is the local box index, and the following three are spatial indices
+ *           for x, y, and z-directions.
+ */
+template <int MT, typename MF, typename F>
+std::enable_if_t<IsFabArray<MF>::value>
+ParallelFor (MF const& mf, ParForMFTileSize const& ts, F&& f)
+{
+#ifdef AMREX_USE_GPU
+    detail::ParallelFor<MT>(mf, IntVect(0), ts.tile_size, std::forward<F>(f));
+#else
+    detail::ParallelFor(mf, IntVect(0), ts.tile_size, std::forward<F>(f));
+#endif
 }
 
 /**
@@ -165,6 +306,36 @@ ParallelFor (MF const& mf, IntVect const& ng, ParForMFTileSize const& ts, F&& f)
 /**
  * \brief ParallelFor for MultiFab/FabArray.
  *
+ * This version launch a kernel to work on the valid and ghost region.  If
+ * built for CPU, tiling will be enabled.  However, one could specify a huge
+ * tile size to effectively disable tiling.  For GPU build, this function is
+ * NON-BLOCKING on the host. Conceptually, this is a 4D loop.
+ *
+ * \tparam MT max threads in GPU blocks (Only relevant for GPU builds)
+ * \tparam MF the MultiFab/FabArray type
+ * \tparam F a callable type like lambda
+ *
+ * \param mf the MultiFab/FabArray object used to specify the iteration space
+ * \param ng the number of ghost cells around the valid region
+ * \param ts tile size, ignored by GPU build
+ * \param f a calable object void(int,int,int,int), where the first argument
+ *           is the local box index, and the following three are spatial indices
+ *           for x, y, and z-directions.
+ */
+template <int MT, typename MF, typename F>
+std::enable_if_t<IsFabArray<MF>::value>
+ParallelFor (MF const& mf, IntVect const& ng, ParForMFTileSize const& ts, F&& f)
+{
+#ifdef AMREX_USE_GPU
+    detail::ParallelFor<MT>(mf, ng, ts.tile_size, std::forward<F>(f));
+#else
+    detail::ParallelFor(mf, ng, ts.tile_size, std::forward<F>(f));
+#endif
+}
+
+/**
+ * \brief ParallelFor for MultiFab/FabArray.
+ *
  * This version launch a kernel to work on the valid region.  If built for
  * CPU, tiling will be enabled.  However, one could specify a huge tile size
  * to effectively disable tiling.  For GPU build, this function is
@@ -185,6 +356,36 @@ std::enable_if_t<IsFabArray<MF>::value>
 ParallelFor (MF const& mf, int ncomp, ParForMFTileSize const& ts, F&& f)
 {
     detail::ParallelFor(mf, IntVect(0), ncomp, ts.tile_size, std::forward<F>(f));
+}
+
+/**
+ * \brief ParallelFor for MultiFab/FabArray.
+ *
+ * This version launch a kernel to work on the valid region.  If built for
+ * CPU, tiling will be enabled.  However, one could specify a huge tile size
+ * to effectively disable tiling.  For GPU build, this function is
+ * NON-BLOCKING on the host. Conceptually, this is a 5D loop.
+ *
+ * \tparam MT max threads in GPU blocks (Only relevant for GPU builds)
+ * \tparam MF the MultiFab/FabArray type
+ * \tparam F a callable type like lambda
+ *
+ * \param mf the MultiFab/FabArray object used to specify the iteration space
+ * \param ncomp the number of component
+ * \param ts tile size, ignored by GPU build
+ * \param f a calable object void(int,int,int,int,int), where the first argument
+ *           is the local box index, the following three are spatial indices
+ *           for x, y, and z-directions, and the last is for component.
+ */
+template <int MT, typename MF, typename F>
+std::enable_if_t<IsFabArray<MF>::value>
+ParallelFor (MF const& mf, int ncomp, ParForMFTileSize const& ts, F&& f)
+{
+#ifdef AMREX_USE_GPU
+    detail::ParallelFor<MT>(mf, IntVect(0), ncomp, ts.tile_size, std::forward<F>(f));
+#else
+    detail::ParallelFor(mf, IntVect(0), ncomp, ts.tile_size, std::forward<F>(f));
+#endif
 }
 
 /**
@@ -211,6 +412,37 @@ std::enable_if_t<IsFabArray<MF>::value>
 ParallelFor (MF const& mf, IntVect const& ng, int ncomp, ParForMFTileSize const& ts, F&& f)
 {
     detail::ParallelFor(mf, ng, ncomp, ts.tile_size, std::forward<F>(f));
+}
+
+/**
+ * \brief ParallelFor for MultiFab/FabArray.
+ *
+ * This version launch a kernel to work on the valid and ghost region.  If
+ * built for CPU, tiling will be enabled.  However, one could specify a huge
+ * tile size to effectively disable tiling.  For GPU build, this function is
+ * NON-BLOCKING on the host. Conceptually, this is a 5D loop.
+ *
+ * \tparam MT max threads in GPU blocks (Only relevant for GPU builds)
+ * \tparam MF the MultiFab/FabArray type
+ * \tparam F a callable type like lambda
+ *
+ * \param mf the MultiFab/FabArray object used to specify the iteration space
+ * \param ng the number of ghost cells around the valid region
+ * \param ncomp the number of component
+ * \param ts tile size, ignored by GPU build
+ * \param f a calable object void(int,int,int,int,int), where the first argument
+ *           is the local box index, the following three are spatial indices
+ *           for x, y, and z-directions, and the last is for component.
+ */
+template <int MT, typename MF, typename F>
+std::enable_if_t<IsFabArray<MF>::value>
+ParallelFor (MF const& mf, IntVect const& ng, int ncomp, ParForMFTileSize const& ts, F&& f)
+{
+#ifdef AMREX_USE_GPU
+    detail::ParallelFor<MT>(mf, ng, ncomp, ts.tile_size, std::forward<F>(f));
+#else
+    detail::ParallelFor(mf, ng, ncomp, ts.tile_size, std::forward<F>(f));
+#endif
 }
 
 }

--- a/Src/Base/AMReX_MFParallelForG.H
+++ b/Src/Base/AMReX_MFParallelForG.H
@@ -12,7 +12,7 @@ namespace amrex {
 namespace detail {
 
 inline
-std::pair<int*,int*> build_par_for_nblocks (Vector<Long> const& ncells)
+std::pair<int*,int*> build_par_for_nblocks (Vector<Long> const& ncells, int nthreads)
 {
     int* hp = nullptr;
     int* dp = nullptr;
@@ -24,7 +24,7 @@ std::pair<int*,int*> build_par_for_nblocks (Vector<Long> const& ncells)
         Long ntot = 0;
         bool same_size = true;
         for (int i = 0; i < nboxes; ++i) {
-            Long nblocks = (ncells[i] + AMREX_GPU_MAX_THREADS-1) / AMREX_GPU_MAX_THREADS;
+            Long nblocks = (ncells[i] + nthreads-1) / nthreads;
             hp[i+1] = hp[i] + static_cast<int>(nblocks);
             ntot += nblocks;
             same_size = same_size && (ncells[i] == ncells[0]);
@@ -68,7 +68,7 @@ namespace parfor_mf_detail {
     }
 }
 
-template <typename MF, typename F>
+template <int MT, typename MF, typename F>
 std::enable_if_t<IsFabArray<MF>::value>
 ParallelFor (MF const& mf, IntVect const& nghost, int ncomp, IntVect const&, F&& f)
 {
@@ -89,29 +89,29 @@ ParallelFor (MF const& mf, IntVect const& nghost, int ncomp, IntVect const&, F&&
         IntVect ngrow = nghost - mf.nGrowVect(); // We use this to go from fabbox to valid+nghost.
         auto ma = mf.arrays();
 
-        auto par_for_blocks = mf.getParForInfo(nghost).getBlocks();
+        auto par_for_blocks = mf.getParForInfo(nghost,MT).getBlocks();
         const int nblocks = par_for_blocks.first[nboxes];
         const int block_0_size = par_for_blocks.first[1];
         const int* dp_nblocks = par_for_blocks.second;
 
 #if defined(AMREX_USE_CUDA) || defined(AMREX_USE_HIP)
 
-        amrex::launch_global<AMREX_GPU_MAX_THREADS>
-            <<<nblocks, AMREX_GPU_MAX_THREADS, 0, Gpu::gpuStream()>>>
+        amrex::launch_global<MT>
+            <<<nblocks, MT, 0, Gpu::gpuStream()>>>
             ([=] AMREX_GPU_DEVICE () noexcept
              {
                  int ibox, icell;
                  if (dp_nblocks) {
                      ibox = amrex::bisect(dp_nblocks, 0, nboxes, static_cast<int>(blockIdx.x));
-                     icell = (blockIdx.x-dp_nblocks[ibox])*AMREX_GPU_MAX_THREADS + threadIdx.x;
+                     icell = (blockIdx.x-dp_nblocks[ibox])*MT + threadIdx.x;
                  } else {
                      ibox = blockIdx.x / block_0_size;
-                     icell = (blockIdx.x-ibox*block_0_size)*AMREX_GPU_MAX_THREADS + threadIdx.x;
+                     icell = (blockIdx.x-ibox*block_0_size)*MT + threadIdx.x;
                  }
 
 #elif defined(AMREX_USE_DPCPP)
 
-        amrex::launch(nblocks, AMREX_GPU_MAX_THREADS, Gpu::gpuStream(),
+        amrex::launch(nblocks, MT, Gpu::gpuStream(),
              [=] AMREX_GPU_DEVICE (sycl::nd_item<1> const& item) noexcept
              {
                  int ibox, icell;
@@ -119,10 +119,10 @@ ParallelFor (MF const& mf, IntVect const& nghost, int ncomp, IntVect const&, F&&
                  int threadIdxx = item.get_local_linear_id();
                  if (dp_nblocks) {
                      ibox = amrex::bisect(dp_nblocks, 0, nboxes, static_cast<int>(blockIdxx));
-                     icell = (blockIdxx-dp_nblocks[ibox])*AMREX_GPU_MAX_THREADS + threadIdxx;
+                     icell = (blockIdxx-dp_nblocks[ibox])*MT + threadIdxx;
                  } else {
                      ibox = blockIdxx / block_0_size;
-                     icell = (blockIdxx-ibox*block_0_size)*AMREX_GPU_MAX_THREADS + threadIdxx;
+                     icell = (blockIdxx-ibox*block_0_size)*MT + threadIdxx;
                  }
 #endif
                  Box b(ma[ibox]);
@@ -147,9 +147,16 @@ ParallelFor (MF const& mf, IntVect const& nghost, int ncomp, IntVect const&, F&&
 
 template <typename MF, typename F>
 std::enable_if_t<IsFabArray<MF>::value>
+ParallelFor (MF const& mf, IntVect const& nghost, int ncomp, IntVect const& ts, F&& f)
+{
+    ParallelFor<AMREX_GPU_MAX_THREADS>(mf, nghost, ncomp, ts, std::forward<F>(f));
+}
+
+template <typename MF, typename F>
+std::enable_if_t<IsFabArray<MF>::value>
 ParallelFor (MF const& mf, IntVect const& nghost, IntVect const& ts, F&& f)
 {
-    ParallelFor(mf, nghost, 1, ts, std::forward<F>(f));
+    ParallelFor<AMREX_GPU_MAX_THREADS>(mf, nghost, 1, ts, std::forward<F>(f));
 }
 
 }


### PR DESCRIPTION
- Fix a bug in caching multifab ParallelFor meta-data.

- Add new versions of multifab ParallelFor that are templated on max threads per block.

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
