### PR TITLE
Add bounds-checking in InitFromAscii for CI null-dereference error

### DIFF
--- a/Src/Particle/AMReX_ParticleInit.H
+++ b/Src/Particle/AMReX_ParticleInit.H
@@ -333,7 +333,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>
                 Gpu::copy(Gpu::hostToDevice, src_tile.begin(), src_tile.end(),
                           dst_tile.GetArrayOfStructs().begin() + old_size);
 
-                if((host_real_attribs[lev][std::make_pair(grid, tile)]).size() > NArrayReal)
+                if((host_real_attribs[lev][std::make_pair(grid, tile)]).size() > (long unsigned int) NArrayReal)
                   for (int i = 0; i < NArrayReal; ++i) {
                     Gpu::copy(Gpu::hostToDevice,
                               host_real_attribs[lev][std::make_pair(grid,tile)][i].begin(),
@@ -372,7 +372,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>
                 Where(p, pld);
 
                 host_particles[pld.m_lev][std::make_pair(pld.m_grid, pld.m_tile)].push_back(p);
-                if((host_real_attribs[pld.m_lev][std::make_pair(pld.m_grid, pld.m_tile)]).size() > extradata - NStructReal)
+                if((host_real_attribs[pld.m_lev][std::make_pair(pld.m_grid, pld.m_tile)]).size() > (long unsigned int) (extradata - NStructReal))
                     for (int n = NStructReal; n < extradata; n++)
                     {
                         Real rdata = nreals[n-NStructReal].back();

--- a/Src/Particle/AMReX_ParticleInit.H
+++ b/Src/Particle/AMReX_ParticleInit.H
@@ -82,7 +82,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>
     Long how_many_read = 0;
 
     Gpu::HostVector<ParticleType> nparticles;
-    Vector<Gpu::HostVector<Real> > nreals;
+    Vector<Gpu::HostVector<Real> > nreals(0);
     if (extradata > NStructReal) nreals.resize(extradata - NStructReal);
 
     if (MyProc < NReaders)
@@ -183,10 +183,11 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>
             p.cpu() = MyProc;
 
             nparticles.push_back(p);
-            for (int n = NStructReal; n < extradata; n++)
-            {
-                nreals[n-NStructReal].push_back(r[n-NStructReal]);
-            }
+            if(nreals.size() > extradata - NStructReal)
+                for (int n = NStructReal; n < extradata; n++)
+                {
+                    nreals[n-NStructReal].push_back(r[n-NStructReal]);
+                }
 
             how_many++;
             how_many_read++;
@@ -240,10 +241,12 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>
                             p_rep.cpu() = MyProc;
 
                             nparticles.push_back(p_rep);
-                            for (int n = NStructReal; n < extradata; n++)
-                            {
-                                nreals[n-NStructReal].push_back(r[n-NStructReal]);
-                            }
+
+                            if (nreals.size() > extradata - NStructReal)
+                                for (int n = NStructReal; n < extradata; n++)
+                                {
+                                    nreals[n-NStructReal].push_back(r[n-NStructReal]);
+                                }
 
                             how_many++;
                         }
@@ -254,7 +257,9 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>
 #if AMREX_SPACEDIM > 2
             }
 #endif
+
         }
+
     }
 
     // Now Redistribute() each chunk separately to minimize memory bloat.
@@ -277,6 +282,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>
                            << nr*NRedist_chunk << " to "
                            << (nr+1)*NRedist_chunk-1 << '\n';
         }
+
         for (int which = nr*NRedist_chunk; which < (nr+1)*NRedist_chunk; which++)
         {
             if (which == MyProc)
@@ -288,17 +294,23 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>
 
                     host_particles[pld.m_lev][std::make_pair(pld.m_grid, pld.m_tile)].push_back(p);
 
-                    for (int n = NStructReal; n < extradata; n++)
+                    if (nreals.size() > extradata - NStructReal && NArrayReal > 0)
                     {
-                        Real rdata = nreals[n-NStructReal].back();
-                        host_real_attribs[pld.m_lev][std::make_pair(pld.m_grid, pld.m_tile)][n-NStructReal].push_back(rdata);
+                        for (int n = NStructReal; n < extradata; n++)
+                        {
+                            Real rdata = nreals[n-NStructReal].back();
+                            host_real_attribs[pld.m_lev][std::make_pair(pld.m_grid, pld.m_tile)][n-NStructReal].push_back(rdata);
+                        }
                     }
 
                     nparticles.pop_back();
 
-                    for (int n = NStructReal; n < extradata; n++)
+                    if (nreals.size() > extradata - NStructReal)
                     {
-                        nreals[n-NStructReal].pop_back();
+                        for (int n = NStructReal; n < extradata; n++)
+                        {
+                            nreals[n-NStructReal].pop_back();
+                        }
                     }
                 }
             }
@@ -308,6 +320,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>
         {
             for (auto& kv : host_particles[lev])
             {
+
                 auto grid = kv.first.first;
                 auto tile = kv.first.second;
                 const auto& src_tile = kv.second;
@@ -320,12 +333,13 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>
                 Gpu::copy(Gpu::hostToDevice, src_tile.begin(), src_tile.end(),
                           dst_tile.GetArrayOfStructs().begin() + old_size);
 
-                for (int i = 0; i < NArrayReal; ++i) {
+                if((host_real_attribs[lev][std::make_pair(grid, tile)]).size() > NArrayReal)
+                  for (int i = 0; i < NArrayReal; ++i) {
                     Gpu::copy(Gpu::hostToDevice,
                               host_real_attribs[lev][std::make_pair(grid,tile)][i].begin(),
                               host_real_attribs[lev][std::make_pair(grid,tile)][i].end(),
                               dst_tile.GetStructOfArrays().GetRealData(i).begin() + old_size);
-                }
+         }
             }
         }
 
@@ -358,17 +372,20 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>
                 Where(p, pld);
 
                 host_particles[pld.m_lev][std::make_pair(pld.m_grid, pld.m_tile)].push_back(p);
-                for (int n = NStructReal; n < extradata; n++)
-                {
-                    Real rdata = nreals[n-NStructReal].back();
-                    host_real_attribs[pld.m_lev][std::make_pair(pld.m_grid, pld.m_tile)][n-NStructReal].push_back(rdata);
-                }
+                if((host_real_attribs[pld.m_lev][std::make_pair(pld.m_grid, pld.m_tile)]).size() > extradata - NStructReal)
+                    for (int n = NStructReal; n < extradata; n++)
+                    {
+                        Real rdata = nreals[n-NStructReal].back();
+                        host_real_attribs[pld.m_lev][std::make_pair(pld.m_grid, pld.m_tile)][n-NStructReal].push_back(rdata);
+                    }
 
                 nparticles.pop_back();
-                for (int n = NStructReal; n < extradata; n++)
-                {
-                    nreals[n-NStructReal].pop_back();
-                }
+
+                if (nreals.size() > extradata - NStructReal)
+                    for (int n = NStructReal; n < extradata; n++)
+                    {
+                        nreals[n-NStructReal].pop_back();
+                    }
             }
         }
 
@@ -398,6 +415,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>
         }
 
         Redistribute();
+
     }
 
     if (m_verbose > 0)

--- a/Tests/Particles/InitFromAscii/main.cpp
+++ b/Tests/Particles/InitFromAscii/main.cpp
@@ -40,7 +40,7 @@ void test_init_ascii (TestParams& parms)
 
     DistributionMapping dmap(ba);
 
-    typedef ParticleContainer<1, 0, AMREX_SPACEDIM> MyParticleContainer;
+    typedef ParticleContainer<4, 0> MyParticleContainer;
     MyParticleContainer myPC(geom, dmap, ba);
 
     myPC.InitFromAsciiFile("particles.txt", 1 + AMREX_SPACEDIM);


### PR DESCRIPTION
## Summary

* Changes InitFromAscii test to use template arguments 4,0 instead of 1,0,AMREX_SPACEDIM
* Constructor for Vector nreals set to 0 length
* Adds extradata - NStructReal bounds checking
* Check temporary host_real_attribs array sizes before assignment

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
