### PR TITLE
Add ROCMClang as an LLVM compiler to cmake

### DIFF
--- a/.github/workflows/hip.yml
+++ b/.github/workflows/hip.yml
@@ -55,6 +55,9 @@ jobs:
             -DAMReX_AMD_ARCH=gfx908                       \
             -DCMAKE_C_COMPILER=$(which clang)             \
             -DCMAKE_CXX_COMPILER=$(which hipcc)           \
+            -DCMAKE_CXX_COMPILER_ID="Clang"               \
+            -DCMAKE_CXX_COMPILER_VERSION=12.0             \
+            -DCMAKE_CXX_STANDARD_COMPUTED_DEFAULT="17"    \
             -DCMAKE_Fortran_COMPILER=$(which gfortran)    \
             -DCMAKE_CXX_STANDARD=17
         cmake --build build_full_legacywrapper -j 2

--- a/Tools/CMake/AMReXGenerateConfigHeader.cmake
+++ b/Tools/CMake/AMReXGenerateConfigHeader.cmake
@@ -43,6 +43,7 @@ function ( generate_config_header )
            set(COMPILER_ID_MACRO  __PGI)
        elseif ( ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" )       OR
                 ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "AppleClang" )  OR
+                ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "ROCMClang" )   OR
                 ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "IntelLLVM" )   )
            set(COMPILER_ID_MACRO  __llvm__)
        elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC" )


### PR DESCRIPTION
Since CMake >= 3.21, `hipcc` is identified as ROCMClang and unwrapped to `clang++`.
AMD's `clang++` is still identified as vanilla `Clang`.

## References

- https://gitlab.kitware.com/cmake/cmake/-/blob/v3.21.0/Modules/CMakeDetermineCompilerId.cmake#L153-159
- https://github.com/AMReX-Codes/amrex/pull/2184

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
