### PR TITLE
CI: HIP Cleanup

### DIFF
--- a/.github/workflows/dependencies/dependencies_hip.sh
+++ b/.github/workflows/dependencies/dependencies_hip.sh
@@ -20,7 +20,7 @@ wget -q -O - http://repo.radeon.com/rocm/rocm.gpg.key \
 echo 'deb [arch=amd64] http://repo.radeon.com/rocm/apt/4.1.1/ xenial main' \
   | sudo tee /etc/apt/sources.list.d/rocm.list
 
-echo 'export PATH=$PATH:/opt/rocm/bin:/opt/rocm/profiler/bin:/opt/rocm/opencl/bin' \
+echo 'export PATH=/opt/rocm-4.1.1/llvm/bin:/opt/rocm/bin:/opt/rocm/profiler/bin:/opt/rocm/opencl/bin:$PATH' \
   | sudo tee -a /etc/profile.d/rocm.sh
 # we should not need to export HIP_PATH=/opt/rocm/hip with those installs
 
@@ -42,6 +42,8 @@ sudo apt-get install -y --no-install-recommends \
 #
 source /etc/profile.d/rocm.sh
 hipcc --version
+which clang
+which clang++
 
 # cmake-easyinstall
 #

--- a/.github/workflows/hip.yml
+++ b/.github/workflows/hip.yml
@@ -27,7 +27,6 @@ jobs:
     - name: Build & Install
       run: |
         source /etc/profile.d/rocm.sh
-        export PATH=/opt/rocm-4.1.1/llvm/bin:$PATH
         hipcc --version
         which clang
         which clang++


### PR DESCRIPTION
## Summary

Move the PATH setup for the AMD `clang`/`clang++` executables to a common location for the setup scripts.
As a reminder, this is needed so the system clang is not taken by accident.

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
