### PR TITLE
ROCMClang: work-around missing C++ Std Flag

### DIFF
--- a/.github/workflows/hip.yml
+++ b/.github/workflows/hip.yml
@@ -41,8 +41,7 @@ jobs:
             -DAMReX_GPU_BACKEND=HIP                       \
             -DAMReX_AMD_ARCH=gfx908                       \
             -DCMAKE_C_COMPILER=$(which clang)             \
-            -DCMAKE_CXX_COMPILER=$(which clang++)         \
-            -DCMAKE_CXX_STANDARD=17
+            -DCMAKE_CXX_COMPILER=$(which clang++)
         cmake --build build_nofortran -j 2
         cmake -S . -B build_full_legacywrapper            \
             -DCMAKE_VERBOSE_MAKEFILE=ON                   \
@@ -55,11 +54,7 @@ jobs:
             -DAMReX_AMD_ARCH=gfx908                       \
             -DCMAKE_C_COMPILER=$(which clang)             \
             -DCMAKE_CXX_COMPILER=$(which hipcc)           \
-            -DCMAKE_CXX_COMPILER_ID="Clang"               \
-            -DCMAKE_CXX_COMPILER_VERSION=12.0             \
-            -DCMAKE_CXX_STANDARD_COMPUTED_DEFAULT="17"    \
-            -DCMAKE_Fortran_COMPILER=$(which gfortran)    \
-            -DCMAKE_CXX_STANDARD=17
+            -DCMAKE_Fortran_COMPILER=$(which gfortran)
         cmake --build build_full_legacywrapper -j 2
 
   # Build 2D libamrex hip build with configure

--- a/Tools/CMake/AMReX_Config.cmake
+++ b/Tools/CMake/AMReX_Config.cmake
@@ -45,6 +45,12 @@ function (configure_amrex)
    # minimum: C++14 on Linux, C++17 on Windows, C++17 for dpc++ and hip
    if (AMReX_DPCPP OR AMReX_HIP)
       target_compile_features(amrex PUBLIC cxx_std_17)
+      # CMake 3.21+ identifies hipcc as ROCMClang
+      # work-arounds: ignores target_compile_features for CXX targets
+      # https://gitlab.kitware.com/cmake/cmake/-/issues/22460
+      if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "ROCMClang")
+          target_compile_options(amrex PUBLIC -std=c++17)
+      endif()
    else ()
       target_compile_features(amrex PUBLIC $<IF:$<STREQUAL:$<PLATFORM_ID>,Windows>,cxx_std_17,cxx_std_14>)
    endif ()


### PR DESCRIPTION
## Summary

Manually set std flag.

I usually try to avoid this fixed setting since the usual CMake logic allows users to explicitly set a specific CXX standard on the command line (e.g. `-DCMAKE_CXX_STANDARD=20`) or raise it in their subprojects further via `target_compile_features(warpx PUBLIC cxx_std_20)`.

This hacks in `-std=c++17` to work-around the `hipcc` bug reported in:
  https://gitlab.kitware.com/cmake/cmake/-/issues/22460

Also treats the CMake 3.21+ ROCMClang as `hipcc` with respect to the Fortran fix that will land in ROCm 4.4

Follow-up to #2184

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
