### PR TITLE
Enable default construction for AmrParticleContainer and add isDefined() method.

### DIFF
--- a/Src/AmrCore/AMReX_AmrParticles.H
+++ b/Src/AmrCore/AMReX_AmrParticles.H
@@ -259,6 +259,11 @@ public:
 
     typedef Particle<NStructReal, NStructInt> ParticleType;
 
+    AmrParticleContainer ()
+        : ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>()
+    {
+    }
+
     AmrParticleContainer (AmrCore* amr_core)
         : ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>(amr_core->GetParGDB())
     {

--- a/Src/Particle/AMReX_ParticleContainerBase.H
+++ b/Src/Particle/AMReX_ParticleContainerBase.H
@@ -90,6 +90,8 @@ public:
                  const Vector<BoxArray>            & ba,
                  const Vector<int>                 & rr);
 
+	bool isDefined () const { return m_gdb != nullptr; }
+
     void reserveData ();
     void resizeData ();
     void RedefineDummyMF (int lev);

--- a/Src/Particle/AMReX_ParticleContainerBase.H
+++ b/Src/Particle/AMReX_ParticleContainerBase.H
@@ -90,7 +90,7 @@ public:
                  const Vector<BoxArray>            & ba,
                  const Vector<int>                 & rr);
 
-	bool isDefined () const { return m_gdb != nullptr; }
+    bool isDefined () const { return m_gdb != nullptr; }
 
     void reserveData ();
     void resizeData ();


### PR DESCRIPTION
A Particle container is considered "defined" if it has been given a set of grids, otherwise not. 

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
