### PR TITLE
Add AsyncVector.

### DIFF
--- a/Src/Base/AMReX_GpuAllocators.H
+++ b/Src/Base/AMReX_GpuAllocators.H
@@ -115,6 +115,27 @@ namespace amrex {
     };
 
     template<typename T>
+    class AsyncArenaAllocator
+        : public ArenaAllocatorTraits
+    {
+    public :
+
+        using value_type = T;
+
+        inline value_type* allocate(std::size_t n)
+        {
+            value_type* result = nullptr;
+            result = (value_type*) The_Async_Arena()->alloc(n * sizeof(T));
+            return result;
+        }
+
+        inline void deallocate(value_type* ptr, std::size_t)
+        {
+            The_Async_Arena()->free(ptr);
+        }
+    };
+
+    template<typename T>
     class PolymorphicAllocator
     {
     public :
@@ -176,6 +197,9 @@ namespace amrex {
 
     template <typename T>
     struct RunOnGpu<ManagedArenaAllocator<T> > : std::true_type {};
+
+    template <typename T>
+    struct RunOnGpu<AsyncArenaAllocator<T> > : std::true_type {};
 
 #endif // AMREX_USE_GPU
 

--- a/Src/Base/AMReX_GpuContainers.H
+++ b/Src/Base/AMReX_GpuContainers.H
@@ -41,6 +41,15 @@ namespace Gpu {
     using PinnedVector = PODVector<T, PinnedArenaAllocator<T> >;
 
     /**
+     * \brief A PODVector that uses the async memory arena.
+     *        Maybe useful for temporary vectors inside MFIters
+     *        that are accessed on the device.
+     *
+     */
+    template <class T>
+    using AsyncVector = PODVector<T, AsyncArenaAllocator<T> >;
+
+    /**
      * \brief A PODVector that uses pinned host memory. Same as PinnedVector.
      * For a vector class that uses std::allocator by default, see amrex::Vector.
      *
@@ -82,6 +91,9 @@ namespace Gpu {
 
     template <class T>
     using PinnedVector = PODVector<T>;
+
+    template <class T>
+    using AsyncVector = PODVector<T>;
 
     template <class T>
     using PolymorphicVector = PODVector<T>;

--- a/Tests/GPU/Vector/main.cpp
+++ b/Tests/GPU/Vector/main.cpp
@@ -2,6 +2,7 @@
 #include <AMReX_Gpu.H>
 #include <AMReX_GpuContainers.H>
 #include <AMReX_ParmParse.H>
+#include <AMReX_GpuPrint.H>
 
 using namespace amrex;
 
@@ -56,6 +57,46 @@ void test_container()
     checkV3<Container>(v3);
 }
 
+void async_test()
+{
+    {
+        int N = 32*10;  // 10 warps. Arbitrarily chosen.
+
+        Gpu::AsyncVector<Real> vec(N, 0.0);
+        auto ptr = vec.dataPtr();
+
+        // Compute-bound test. Should take some time.
+        amrex::ParallelFor(N, [=] AMREX_GPU_DEVICE (int n) noexcept
+        {
+            Real y = ptr[n];
+            Real x = 1.0;
+            for (int n = 0; n < 20; ++n) {
+                Real dx = -(x*x-y) / (2.*x);
+                x += dx;
+            }
+            ptr[n] = x;
+
+            if (n == 0)
+#ifdef AMREX_USE_GPU
+                { AMREX_DEVICE_PRINTF(" Answer = %1.16f -- should print second.\n", ptr[n]); }
+#else
+                { std::cout << "Answer = " << ptr[n] << " -- should print first." << std::endl; }
+#endif
+
+        });
+    }
+
+    // Async Vector now out of scope. Still completes correctly. 
+
+#ifdef AMREX_USE_GPU
+    amrex::Print() << "Async Synching -- should print first." << std::endl;
+#else
+    amrex::Print() << "Async Synching -- should print second." << std::endl;
+#endif
+
+    Gpu::Device::synchronize();
+}
+
 int main (int argc, char* argv[])
 {
     amrex::Initialize(argc,argv);
@@ -64,6 +105,10 @@ int main (int argc, char* argv[])
         test_container<Gpu::HostVector   >();
         test_container<Gpu::ManagedVector>();
         test_container<Gpu::PinnedVector> ();
+        test_container<Gpu::AsyncVector>  ();
+
+        async_test();
+
         amrex::Print() << "Passed! \n";
     }
     amrex::Finalize();

--- a/Tests/GPU/Vector/main.cpp
+++ b/Tests/GPU/Vector/main.cpp
@@ -86,7 +86,7 @@ void async_test()
         });
     }
 
-    // Async Vector now out of scope. Still completes correctly. 
+    // Async Vector now out of scope. Still completes correctly.
 
 #ifdef AMREX_USE_GPU
     amrex::Print() << "Async Synching -- should print first." << std::endl;


### PR DESCRIPTION
## Summary
Add Gpu::AsyncVector that uses the Async_Arena. Potentially useful for temporary vectors on the device, hiding the Elixir where possible.

## Additional background
@atmyers As the resident expert, can you double check I did all the necessary things. :) Thanks!

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
