### PR TITLE
Fix lincc_interp

### DIFF
--- a/Src/AmrCore/AMReX_MFInterp_1D_C.H
+++ b/Src/AmrCore/AMReX_MFInterp_1D_C.H
@@ -21,11 +21,8 @@ void mf_cell_cons_lin_interp_llslope (int i, int, int, Array4<Real> const& slope
         sx = amrex::Math::copysign(Real(1.),dc)*amrex::min(sx,amrex::Math::abs(dc));
         if (dc != Real(0.0)) {
             sfx = amrex::min(sfx, sx / dc);
-        } else {
-            sfx = Real(0.0);
         }
-
-        slope(i,0,0,ns) = sx;
+        slope(i,0,0,ns) = dc;
     }
 
     for (int ns = 0; ns < ncomp; ++ns) {

--- a/Src/AmrCore/AMReX_MFInterp_2D_C.H
+++ b/Src/AmrCore/AMReX_MFInterp_2D_C.H
@@ -22,9 +22,8 @@ void mf_cell_cons_lin_interp_llslope (int i, int j, int, Array4<Real> const& slo
         sx = amrex::Math::copysign(Real(1.),dc)*amrex::min(sx,amrex::Math::abs(dc));
         if (dc != Real(0.0)) {
             sfx = amrex::min(sfx, sx / dc);
-        } else {
-            sfx = Real(0.0);
         }
+        slope(i,j,0,ns        ) = dc;
 
         // y-direction
         dc = mf_compute_slopes_y(i, j, 0, u, nu, domain, bc[ns]);
@@ -34,12 +33,8 @@ void mf_cell_cons_lin_interp_llslope (int i, int j, int, Array4<Real> const& slo
         sy = amrex::Math::copysign(Real(1.),dc)*amrex::min(sy,amrex::Math::abs(dc));
         if (dc != Real(0.0)) {
             sfy = amrex::min(sfy, sy / dc);
-        } else {
-            sfy = Real(0.0);
         }
-
-        slope(i,j,0,ns        ) = sx;
-        slope(i,j,0,ns+  ncomp) = sy;
+        slope(i,j,0,ns+  ncomp) = dc;
     }
 
     for (int ns = 0; ns < ncomp; ++ns) {

--- a/Src/AmrCore/AMReX_MFInterp_3D_C.H
+++ b/Src/AmrCore/AMReX_MFInterp_3D_C.H
@@ -23,9 +23,8 @@ void mf_cell_cons_lin_interp_llslope (int i, int j, int k, Array4<Real> const& s
         sx = amrex::Math::copysign(Real(1.),dc)*amrex::min(sx,amrex::Math::abs(dc));
         if (dc != Real(0.0)) {
             sfx = amrex::min(sfx, sx / dc);
-        } else {
-            sfx = Real(0.0);
         }
+        slope(i,j,k,ns        ) = dc;
 
         // y-direction
         dc = mf_compute_slopes_y(i, j, k, u, nu, domain, bc[ns]);
@@ -35,9 +34,8 @@ void mf_cell_cons_lin_interp_llslope (int i, int j, int k, Array4<Real> const& s
         sy = amrex::Math::copysign(Real(1.),dc)*amrex::min(sy,amrex::Math::abs(dc));
         if (dc != Real(0.0)) {
             sfy = amrex::min(sfy, sy / dc);
-        } else {
-            sfy = Real(0.0);
         }
+        slope(i,j,k,ns+  ncomp) = dc;
 
         // z-direction
         dc = mf_compute_slopes_z(i, j, k, u, nu, domain, bc[ns]);
@@ -47,13 +45,8 @@ void mf_cell_cons_lin_interp_llslope (int i, int j, int k, Array4<Real> const& s
         sz = amrex::Math::copysign(Real(1.),dc)*amrex::min(sz,amrex::Math::abs(dc));
         if (dc != Real(0.0)) {
             sfz = amrex::min(sfz, sz / dc);
-        } else {
-            sfz = Real(0.0);
         }
-
-        slope(i,j,k,ns        ) = sx;
-        slope(i,j,k,ns+  ncomp) = sy;
-        slope(i,j,k,ns+2*ncomp) = sz;
+        slope(i,j,k,ns+2*ncomp) = dc;
     }
 
     for (int ns = 0; ns < ncomp; ++ns) {


### PR DESCRIPTION
This fixes a bug in lincc_interp that was introduced more than 2 years ago
when the Fortran code was converted to C++.  The slope was mistakenly
limited twice.  For each component, we compute a limiting factor and we use
the minimum of all components as the final limiting factor.  That final
limiting factor should be applied to the unlimited central difference slope,
not the monotonized central slope.

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [x] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
