### PR TITLE
Fix Coarse/Fine Boundary BoxArray generated in FPInfo for FillPatch

### DIFF
--- a/Src/Base/AMReX_FabArrayBase.cpp
+++ b/Src/Base/AMReX_FabArrayBase.cpp
@@ -1747,7 +1747,11 @@ FabArrayBase::FPinfo::FPinfo (const FabArrayBase& srcfa,
 #endif
                     numblk[longdir] *= 2;
                 }
-                numblk.min(len);
+                for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+                    // make sure not to use too many blocks that could
+                    // result in very small boxes
+                    numblk[idim] = std::min(numblk[idim], (len[idim]+15)/16);
+                }
                 IntVect sz, extra;
                 for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
                     sz[idim] = len[idim] / numblk[idim];


### PR DESCRIPTION
The issue was degenerate boxes could appear when the coarse/fine boxarray
was split into smaller chunks.  This is usually not an issue except for a
small extra cost.  But in IAMR this could result in external Dirichlet
pressure boundary function that has not been implemented being called.

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
