### PR TITLE
CMake: Prebuild & SetupCUDA

### DIFF
--- a/Tools/CMake/AMReXConfig.cmake.in
+++ b/Tools/CMake/AMReXConfig.cmake.in
@@ -204,8 +204,11 @@ endif ()
 #
 # CUDA
 #
-if (@AMReX_CUDA@)
-   include(AMReX_SetupCUDA)
+# AMReX 21.06+ supports CUDA_ARCHITECTURES
+if(CMAKE_VERSION VERSION_LESS 3.20)
+   if (@AMReX_CUDA@)
+      include(AMReX_SetupCUDA)
+   endif ()
 endif ()
 
 include( "${CMAKE_CURRENT_LIST_DIR}/AMReXTargets.cmake" )


### PR DESCRIPTION
## Summary

With CMake 3.20+, we don't need to include the `SetupCUDA.cmake` scripts anymore.

## Additional background

Follow-up to #2012

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
