### PR TITLE
Parser: noinline

### DIFF
--- a/Src/Base/AMReX_Extension.H
+++ b/Src/Base/AMReX_Extension.H
@@ -4,6 +4,11 @@
 
 #if !defined(BL_LANG_FORT)
 
+#if defined(__INTEL_COMPILER) && defined(__EDG__)
+// Disable "routine is both inline and noinline" warning from classical Intel compiler
+#pragma warning disable 2196
+#endif
+
 // restrict
 
 #ifdef __cplusplus

--- a/Src/Base/Parser/AMReX_IParser.H
+++ b/Src/Base/Parser/AMReX_IParser.H
@@ -17,72 +17,36 @@ template <int N>
 struct IParserExecutor
 {
     template <int M=N, typename std::enable_if_t<M==0,int> = 0>
-    AMREX_GPU_HOST_DEVICE AMREX_NO_INLINE
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     int operator() () const noexcept
     {
 #if AMREX_DEVICE_COMPILE
-        return iparser_exe_eval(m_device_executor, nullptr);
+        return iparser_exe_eval<int>(m_device_executor, nullptr);
 #else
-        return iparser_exe_eval(m_host_executor, nullptr);
+        return iparser_exe_eval<int>(m_host_executor, nullptr);
 #endif
     }
 
     template <typename... Ts>
-    AMREX_GPU_HOST_DEVICE AMREX_NO_INLINE
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     std::enable_if_t<sizeof...(Ts) == N, int>
     operator() (Ts... var) const noexcept
     {
         amrex::GpuArray<int,N> l_var{var...};
 #if AMREX_DEVICE_COMPILE
-        return iparser_exe_eval(m_device_executor, l_var.data());
+        return iparser_exe_eval<int>(m_device_executor, l_var.data());
 #else
-        return iparser_exe_eval(m_host_executor, l_var.data());
+        return iparser_exe_eval<int>(m_host_executor, l_var.data());
 #endif
     }
 
-    AMREX_GPU_HOST_DEVICE AMREX_NO_INLINE
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     int operator() (GpuArray<int,N> const& var) const noexcept
     {
 #if AMREX_DEVICE_COMPILE
-        return iparser_exe_eval(m_device_executor, var.data());
+        return iparser_exe_eval<int>(m_device_executor, var.data());
 #else
-        return iparser_exe_eval(m_host_executor, var.data());
-#endif
-    }
-
-    // Unlike operator(), eval is force inlined.
-
-    template <int M=N, typename std::enable_if_t<M==0,int> = 0>
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-    int eval () const noexcept
-    {
-#if AMREX_DEVICE_COMPILE
-        return iparser_exe_eval(m_device_executor, nullptr);
-#else
-        return iparser_exe_eval(m_host_executor, nullptr);
-#endif
-    }
-
-    template <typename... Ts>
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-    std::enable_if_t<sizeof...(Ts) == N, int>
-    eval (Ts... var) const noexcept
-    {
-        amrex::GpuArray<int,N> l_var{var...};
-#if AMREX_DEVICE_COMPILE
-        return iparser_exe_eval(m_device_executor, l_var.data());
-#else
-        return iparser_exe_eval(m_host_executor, l_var.data());
-#endif
-    }
-
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-    int eval (GpuArray<int,N> const& var) const noexcept
-    {
-#if AMREX_DEVICE_COMPILE
-        return iparser_exe_eval(m_device_executor, var.data());
-#else
-        return iparser_exe_eval(m_host_executor, var.data());
+        return iparser_exe_eval<int>(m_host_executor, var.data());
 #endif
     }
 

--- a/Src/Base/Parser/AMReX_IParser.H
+++ b/Src/Base/Parser/AMReX_IParser.H
@@ -17,7 +17,7 @@ template <int N>
 struct IParserExecutor
 {
     template <int M=N, typename std::enable_if_t<M==0,int> = 0>
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    AMREX_GPU_HOST_DEVICE AMREX_NO_INLINE
     int operator() () const noexcept
     {
 #if AMREX_DEVICE_COMPILE
@@ -28,7 +28,7 @@ struct IParserExecutor
     }
 
     template <typename... Ts>
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    AMREX_GPU_HOST_DEVICE AMREX_NO_INLINE
     std::enable_if_t<sizeof...(Ts) == N, int>
     operator() (Ts... var) const noexcept
     {
@@ -40,8 +40,44 @@ struct IParserExecutor
 #endif
     }
 
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    AMREX_GPU_HOST_DEVICE AMREX_NO_INLINE
     int operator() (GpuArray<int,N> const& var) const noexcept
+    {
+#if AMREX_DEVICE_COMPILE
+        return iparser_exe_eval(m_device_executor, var.data());
+#else
+        return iparser_exe_eval(m_host_executor, var.data());
+#endif
+    }
+
+    // Unlike operator(), eval is force inlined.
+
+    template <int M=N, typename std::enable_if_t<M==0,int> = 0>
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    int eval () const noexcept
+    {
+#if AMREX_DEVICE_COMPILE
+        return iparser_exe_eval(m_device_executor, nullptr);
+#else
+        return iparser_exe_eval(m_host_executor, nullptr);
+#endif
+    }
+
+    template <typename... Ts>
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    std::enable_if_t<sizeof...(Ts) == N, int>
+    eval (Ts... var) const noexcept
+    {
+        amrex::GpuArray<int,N> l_var{var...};
+#if AMREX_DEVICE_COMPILE
+        return iparser_exe_eval(m_device_executor, l_var.data());
+#else
+        return iparser_exe_eval(m_host_executor, l_var.data());
+#endif
+    }
+
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    int eval (GpuArray<int,N> const& var) const noexcept
     {
 #if AMREX_DEVICE_COMPILE
         return iparser_exe_eval(m_device_executor, var.data());

--- a/Src/Base/Parser/AMReX_IParser_Exe.H
+++ b/Src/Base/Parser/AMReX_IParser_Exe.H
@@ -236,7 +236,7 @@ struct IParserStack
     constexpr int operator[] (int i) const { return m_data[i]; }
 };
 
-AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+AMREX_GPU_HOST_DEVICE inline
 int iparser_exe_eval (char* p, int const* x)
 {
     IParserStack<AMREX_IPARSER_STACK_SIZE> pstack;

--- a/Src/Base/Parser/AMReX_IParser_Exe.H
+++ b/Src/Base/Parser/AMReX_IParser_Exe.H
@@ -236,8 +236,10 @@ struct IParserStack
     constexpr int operator[] (int i) const { return m_data[i]; }
 };
 
-AMREX_GPU_HOST_DEVICE inline
-int iparser_exe_eval (char* p, int const* x)
+// The purpose of template is to noinline.
+template <typename T>
+AMREX_GPU_HOST_DEVICE AMREX_NO_INLINE
+T iparser_exe_eval (char* p, T const* x)
 {
     IParserStack<AMREX_IPARSER_STACK_SIZE> pstack;
     while (*((iparser_exe_t*)p) != IPARSER_EXE_NULL) {

--- a/Src/Base/Parser/AMReX_Parser.H
+++ b/Src/Base/Parser/AMReX_Parser.H
@@ -18,7 +18,7 @@ template <int N>
 struct ParserExecutor
 {
     template <int M=N, typename std::enable_if_t<M==0,int> = 0>
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    AMREX_GPU_HOST_DEVICE AMREX_NO_INLINE
     double operator() () const noexcept
     {
 #if AMREX_DEVICE_COMPILE
@@ -29,7 +29,7 @@ struct ParserExecutor
     }
 
     template <typename... Ts>
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    AMREX_GPU_HOST_DEVICE AMREX_NO_INLINE
     std::enable_if_t<sizeof...(Ts) == N && !amrex::Same<float,Ts...>::value, double>
     operator() (Ts... var) const noexcept
     {
@@ -42,7 +42,7 @@ struct ParserExecutor
     }
 
     template <typename... Ts>
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    AMREX_GPU_HOST_DEVICE AMREX_NO_INLINE
     std::enable_if_t<sizeof...(Ts) == N &&  amrex::Same<float,Ts...>::value, float>
     operator() (Ts... var) const noexcept
     {
@@ -54,8 +54,57 @@ struct ParserExecutor
 #endif
     }
 
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    AMREX_GPU_HOST_DEVICE AMREX_NO_INLINE
     double operator() (GpuArray<double,N> const& var) const noexcept
+    {
+#if AMREX_DEVICE_COMPILE
+        return parser_exe_eval(m_device_executor, var.data());
+#else
+        return parser_exe_eval(m_host_executor, var.data());
+#endif
+    }
+
+    // Unlike operator(), eval is force inlined.
+
+    template <int M=N, typename std::enable_if_t<M==0,int> = 0>
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    double eval () const noexcept
+    {
+#if AMREX_DEVICE_COMPILE
+        return parser_exe_eval(m_device_executor, nullptr);
+#else
+        return parser_exe_eval(m_host_executor, nullptr);
+#endif
+    }
+
+    template <typename... Ts>
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    std::enable_if_t<sizeof...(Ts) == N && !amrex::Same<float,Ts...>::value, double>
+    eval (Ts... var) const noexcept
+    {
+        amrex::GpuArray<double,N> l_var{var...};
+#if AMREX_DEVICE_COMPILE
+        return parser_exe_eval(m_device_executor, l_var.data());
+#else
+        return parser_exe_eval(m_host_executor, l_var.data());
+#endif
+    }
+
+    template <typename... Ts>
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    std::enable_if_t<sizeof...(Ts) == N &&  amrex::Same<float,Ts...>::value, float>
+    eval (Ts... var) const noexcept
+    {
+        amrex::GpuArray<double,N> l_var{var...};
+#if AMREX_DEVICE_COMPILE
+        return static_cast<float>(parser_exe_eval(m_device_executor, l_var.data()));
+#else
+        return static_cast<float>(parser_exe_eval(m_host_executor, l_var.data()));
+#endif
+    }
+
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    double eval (GpuArray<double,N> const& var) const noexcept
     {
 #if AMREX_DEVICE_COMPILE
         return parser_exe_eval(m_device_executor, var.data());

--- a/Src/Base/Parser/AMReX_Parser.H
+++ b/Src/Base/Parser/AMReX_Parser.H
@@ -18,98 +18,49 @@ template <int N>
 struct ParserExecutor
 {
     template <int M=N, typename std::enable_if_t<M==0,int> = 0>
-    AMREX_GPU_HOST_DEVICE AMREX_NO_INLINE
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     double operator() () const noexcept
     {
 #if AMREX_DEVICE_COMPILE
-        return parser_exe_eval(m_device_executor, nullptr);
+        return parser_exe_eval<double>(m_device_executor, nullptr);
 #else
-        return parser_exe_eval(m_host_executor, nullptr);
+        return parser_exe_eval<double>(m_host_executor, nullptr);
 #endif
     }
 
     template <typename... Ts>
-    AMREX_GPU_HOST_DEVICE AMREX_NO_INLINE
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     std::enable_if_t<sizeof...(Ts) == N && !amrex::Same<float,Ts...>::value, double>
     operator() (Ts... var) const noexcept
     {
         amrex::GpuArray<double,N> l_var{var...};
 #if AMREX_DEVICE_COMPILE
-        return parser_exe_eval(m_device_executor, l_var.data());
+        return parser_exe_eval<double>(m_device_executor, l_var.data());
 #else
-        return parser_exe_eval(m_host_executor, l_var.data());
+        return parser_exe_eval<double>(m_host_executor, l_var.data());
 #endif
     }
 
     template <typename... Ts>
-    AMREX_GPU_HOST_DEVICE AMREX_NO_INLINE
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     std::enable_if_t<sizeof...(Ts) == N &&  amrex::Same<float,Ts...>::value, float>
     operator() (Ts... var) const noexcept
     {
         amrex::GpuArray<double,N> l_var{var...};
 #if AMREX_DEVICE_COMPILE
-        return static_cast<float>(parser_exe_eval(m_device_executor, l_var.data()));
+        return static_cast<float>(parser_exe_eval<double>(m_device_executor, l_var.data()));
 #else
-        return static_cast<float>(parser_exe_eval(m_host_executor, l_var.data()));
+        return static_cast<float>(parser_exe_eval<double>(m_host_executor, l_var.data()));
 #endif
     }
 
-    AMREX_GPU_HOST_DEVICE AMREX_NO_INLINE
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     double operator() (GpuArray<double,N> const& var) const noexcept
     {
 #if AMREX_DEVICE_COMPILE
-        return parser_exe_eval(m_device_executor, var.data());
+        return parser_exe_eval<double>(m_device_executor, var.data());
 #else
-        return parser_exe_eval(m_host_executor, var.data());
-#endif
-    }
-
-    // Unlike operator(), eval is force inlined.
-
-    template <int M=N, typename std::enable_if_t<M==0,int> = 0>
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-    double eval () const noexcept
-    {
-#if AMREX_DEVICE_COMPILE
-        return parser_exe_eval(m_device_executor, nullptr);
-#else
-        return parser_exe_eval(m_host_executor, nullptr);
-#endif
-    }
-
-    template <typename... Ts>
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-    std::enable_if_t<sizeof...(Ts) == N && !amrex::Same<float,Ts...>::value, double>
-    eval (Ts... var) const noexcept
-    {
-        amrex::GpuArray<double,N> l_var{var...};
-#if AMREX_DEVICE_COMPILE
-        return parser_exe_eval(m_device_executor, l_var.data());
-#else
-        return parser_exe_eval(m_host_executor, l_var.data());
-#endif
-    }
-
-    template <typename... Ts>
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-    std::enable_if_t<sizeof...(Ts) == N &&  amrex::Same<float,Ts...>::value, float>
-    eval (Ts... var) const noexcept
-    {
-        amrex::GpuArray<double,N> l_var{var...};
-#if AMREX_DEVICE_COMPILE
-        return static_cast<float>(parser_exe_eval(m_device_executor, l_var.data()));
-#else
-        return static_cast<float>(parser_exe_eval(m_host_executor, l_var.data()));
-#endif
-    }
-
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-    double eval (GpuArray<double,N> const& var) const noexcept
-    {
-#if AMREX_DEVICE_COMPILE
-        return parser_exe_eval(m_device_executor, var.data());
-#else
-        return parser_exe_eval(m_host_executor, var.data());
+        return parser_exe_eval<double>(m_host_executor, var.data());
 #endif
     }
 

--- a/Src/Base/Parser/AMReX_Parser_Exe.H
+++ b/Src/Base/Parser/AMReX_Parser_Exe.H
@@ -223,7 +223,7 @@ struct ParserStack
     constexpr double operator[] (int i) const { return m_data[i]; }
 };
 
-AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+AMREX_GPU_HOST_DEVICE inline
 double parser_exe_eval (char* p, double const* x)
 {
     ParserStack<AMREX_PARSER_STACK_SIZE> pstack;

--- a/Src/Base/Parser/AMReX_Parser_Exe.H
+++ b/Src/Base/Parser/AMReX_Parser_Exe.H
@@ -223,8 +223,10 @@ struct ParserStack
     constexpr double operator[] (int i) const { return m_data[i]; }
 };
 
-AMREX_GPU_HOST_DEVICE inline
-double parser_exe_eval (char* p, double const* x)
+// The purpose of template is to noinline.
+template <typename T>
+AMREX_GPU_HOST_DEVICE AMREX_NO_INLINE
+T parser_exe_eval (char* p, T const* x)
 {
     ParserStack<AMREX_PARSER_STACK_SIZE> pstack;
     while (*((parser_exe_t*)p) != PARSER_EXE_NULL) {


### PR DESCRIPTION
Make [i]parser_exe_eval noinline.

For some WarpX kernels, having parser calls inlined makes them much slower even when they
are not used at runtime.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
