### PR TITLE
Fix EBInterpolater

### DIFF
--- a/Src/EB/AMReX_EBInterpolater.cpp
+++ b/Src/EB/AMReX_EBInterpolater.cpp
@@ -43,7 +43,7 @@ EBCellConservativeLinear::interp (const FArrayBox& crse,
 
         const Box& crse_bx = CoarseBox(target_fine_region,ratio);
 
-        const FabType ftype = fine_flag.getType(amrex::refine(crse_bx,ratio));
+        const FabType ftype = fine_flag.getType(target_fine_region);
         const FabType ctype = crse_flag.getType(crse_bx);
 
         if (ftype == FabType::multivalued || ctype == FabType::multivalued)


### PR DESCRIPTION
Fix bug in #2203.  The fine factory may not contain information on boxes
outside the fine target region.

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
