### PR TITLE
Add static_cast for ParticleReal, and check assertion

### DIFF
--- a/Src/Amr/AMReX_Derive.cpp
+++ b/Src/Amr/AMReX_Derive.cpp
@@ -266,9 +266,11 @@ DeriveRec::getRange (int  k,
     for (r = rng; r != 0 && k > 0; k--, r = r->next)
         ;
     BL_ASSERT(r != 0);
-    state_indx = r->typ;
-    src_comp   = r->sc;
-    num_comp   = r->nc;
+    if (r != 0) {
+        state_indx = r->typ;
+        src_comp   = r->sc;
+        num_comp   = r->nc;
+    }
 }
 
 void

--- a/Src/Particle/AMReX_NeighborParticlesCPUImpl.H
+++ b/Src/Particle/AMReX_NeighborParticlesCPUImpl.H
@@ -303,9 +303,9 @@ NeighborParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
                             for (int dir = 0; dir < AMREX_SPACEDIM; ++dir) {
                                 if (! periodicity.isPeriodic(dir)) continue;
                                 if (tag.periodic_shift[dir] < 0)
-                                    p.pos(dir) += prob_domain.length(dir);
+                                    p.pos(dir) += static_cast<ParticleReal> (prob_domain.length(dir));
                                 else if (tag.periodic_shift[dir] > 0)
-                                    p.pos(dir) -= prob_domain.length(dir);
+                                    p.pos(dir) -= static_cast<ParticleReal> (prob_domain.length(dir));
                             }
                         }
 
@@ -326,9 +326,9 @@ NeighborParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
                             for (int dir = 0; dir < AMREX_SPACEDIM; ++dir) {
                                 if (! periodicity.isPeriodic(dir)) continue;
                                 if (tag.periodic_shift[dir] < 0)
-                                    p.pos(dir) += prob_domain.length(dir);
+                                    p.pos(dir) += static_cast<ParticleReal> (prob_domain.length(dir));
                                 else if (tag.periodic_shift[dir] > 0)
-                                    p.pos(dir) -= prob_domain.length(dir);
+                                    p.pos(dir) -= static_cast<ParticleReal> (prob_domain.length(dir));
                             }
                         }
 

--- a/Tests/Particles/AsyncIO/main.cpp
+++ b/Tests/Particles/AsyncIO/main.cpp
@@ -93,12 +93,12 @@ public:
                     ParticleType p;
                     p.id()  = ParticleType::NextID();
                     p.cpu() = ParallelDescriptor::MyProc();
-                    p.pos(0) = plo[0] + (iv[0] + r[0])*dx[0];
+                    p.pos(0) = static_cast<ParticleReal> (plo[0] + (iv[0] + r[0])*dx[0]);
 #if AMREX_SPACEDIM > 1
-                    p.pos(1) = plo[1] + (iv[1] + r[1])*dx[1];
+                    p.pos(1) = static_cast<ParticleReal> (plo[1] + (iv[1] + r[1])*dx[1]);
 #endif
 #if AMREX_SPACEDIM > 2
-                    p.pos(2) = plo[2] + (iv[2] + r[2])*dx[2];
+                    p.pos(2) = static_cast<ParticleReal> (plo[2] + (iv[2] + r[2])*dx[2]);
 #endif
 
                     for (int i = 0; i < NSR; ++i) p.rdata(i) = p.id();

--- a/Tests/Particles/NeighborParticles/MDParticleContainer.H
+++ b/Tests/Particles/NeighborParticles/MDParticleContainer.H
@@ -51,7 +51,7 @@ public:
 
     std::pair<amrex::Real, amrex::Real>  minAndMaxDistance ();
 
-    void moveParticles (amrex::Real dx);
+    void moveParticles (amrex::ParticleReal dx);
 };
 
 #endif

--- a/Tests/Particles/NeighborParticles/MDParticleContainer.cpp
+++ b/Tests/Particles/NeighborParticles/MDParticleContainer.cpp
@@ -69,9 +69,9 @@ InitParticles(const IntVect& a_num_particles_per_cell,
                 get_gaussian_random_momentum(v, a_thermal_momentum_mean,
                                              a_thermal_momentum_std);
 
-                Real x = plo[0] + (iv[0] + r[0])*dx[0];
-                Real y = plo[1] + (iv[1] + r[1])*dx[1];
-                Real z = plo[2] + (iv[2] + r[2])*dx[2];
+                ParticleReal x = static_cast<ParticleReal> (plo[0] + (iv[0] + r[0])*dx[0]);
+                ParticleReal y = static_cast<ParticleReal> (plo[1] + (iv[1] + r[1])*dx[1]);
+                ParticleReal z = static_cast<ParticleReal> (plo[2] + (iv[2] + r[2])*dx[2]);
 
                 ParticleType p;
                 p.id()  = ParticleType::NextID();
@@ -80,9 +80,9 @@ InitParticles(const IntVect& a_num_particles_per_cell,
                 p.pos(1) = y;
                 p.pos(2) = z;
 
-                p.rdata(PIdx::vx) = v[0];
-                p.rdata(PIdx::vy) = v[1];
-                p.rdata(PIdx::vz) = v[2];
+                p.rdata(PIdx::vx) = static_cast<ParticleReal> (v[0]);
+                p.rdata(PIdx::vy) = static_cast<ParticleReal> (v[1]);
+                p.rdata(PIdx::vz) = static_cast<ParticleReal> (v[2]);
 
                 p.rdata(PIdx::ax) = 0.0;
                 p.rdata(PIdx::ay) = 0.0;
@@ -189,7 +189,7 @@ std::pair<Real, Real> MDParticleContainer::minAndMaxDistance()
     return std::make_pair(min_d, max_d);
 }
 
-void MDParticleContainer::moveParticles(amrex::Real dx)
+void MDParticleContainer::moveParticles(amrex::ParticleReal dx)
 {
     BL_PROFILE("MDParticleContainer::moveParticles");
 
@@ -446,7 +446,7 @@ void MDParticleContainer::reset_test_id()
         {
             ParticleType& p1 = pstruct[i];
             p1.idata(0) = gid;
-            rdata[i] = (Real) gid;
+            rdata[i] = (ParticleReal) gid;
             idata[i] = gid;
         });
     }

--- a/Tests/Particles/NeighborParticles/main.cpp
+++ b/Tests/Particles/NeighborParticles/main.cpp
@@ -124,19 +124,19 @@ void testNeighborParticles ()
     amrex::PrintToFile("neighbor_test") << "Min distance is " << pc.minAndMaxDistance() << ", should be (1, 1) \n";
 
     amrex::PrintToFile("neighbor_test") << "Moving particles and updating neighbors \n";
-    pc.moveParticles(0.1);
+    pc.moveParticles(static_cast<amrex::ParticleReal> (0.1));
     pc.updateNeighbors();
 
     amrex::PrintToFile("neighbor_test") << "Min distance is " << pc.minAndMaxDistance() << ", should be (1, 1) \n";
 
     amrex::PrintToFile("neighbor_test") << "Moving particles and updating neighbors again \n";
-    pc.moveParticles(0.1);
+    pc.moveParticles(static_cast<amrex::ParticleReal> (0.1));
     pc.updateNeighbors();
 
     amrex::PrintToFile("neighbor_test") << "Min distance is " << pc.minAndMaxDistance() << ", should be (1, 1) \n";
 
     amrex::PrintToFile("neighbor_test") << "Moving particles and updating neighbors yet again \n";
-    pc.moveParticles(0.1);
+    pc.moveParticles(static_cast<amrex::ParticleReal> (0.1));
     pc.updateNeighbors();
 
     amrex::PrintToFile("neighbor_test") << "Min distance is " << pc.minAndMaxDistance() << ", should be (1, 1) \n";

--- a/Tests/Particles/ParallelContext/main.cpp
+++ b/Tests/Particles/ParallelContext/main.cpp
@@ -98,12 +98,12 @@ public:
                     ParticleType p;
                     p.id()  = ParticleType::NextID();
                     p.cpu() = ParallelDescriptor::MyProc();
-                    p.pos(0) = plo[0] + (iv[0] + r[0])*dx[0];
+                    p.pos(0) = static_cast<ParticleReal> (plo[0] + (iv[0] + r[0])*dx[0]);
 #if AMREX_SPACEDIM > 1
-                    p.pos(1) = plo[1] + (iv[1] + r[1])*dx[1];
+                    p.pos(1) = static_cast<ParticleReal> (plo[1] + (iv[1] + r[1])*dx[1]);
 #endif
 #if AMREX_SPACEDIM > 2
-                    p.pos(2) = plo[2] + (iv[2] + r[2])*dx[2];
+                    p.pos(2) = static_cast<ParticleReal> (plo[2] + (iv[2] + r[2])*dx[2]);
 #endif
 
                     for (int i = 0; i < NSR; ++i) p.rdata(i) = p.id();
@@ -193,12 +193,12 @@ public:
                     [=] AMREX_GPU_DEVICE (size_t i) noexcept
                     {
                         ParticleType& p = pstruct[i];
-                        p.pos(0) += move_dir[0]*dx[0];
+                        p.pos(0) += static_cast<ParticleReal> (move_dir[0]*dx[0]);
 #if AMREX_SPACEDIM > 1
-                        p.pos(1) += move_dir[1]*dx[1];
+                        p.pos(1) += static_cast<ParticleReal> (move_dir[1]*dx[1]);
 #endif
 #if AMREX_SPACEDIM > 2
-                        p.pos(2) += move_dir[2]*dx[2];
+                        p.pos(2) += static_cast<ParticleReal> (move_dir[2]*dx[2]);
 #endif
                     });
                 }
@@ -209,12 +209,12 @@ public:
                     {
                         ParticleType& p = pstruct[i];
 
-                        p.pos(0) += (2*amrex::Random(engine)-1)*move_dir[0]*dx[0];
+                        p.pos(0) += static_cast<ParticleReal> ((2*amrex::Random(engine)-1)*move_dir[0]*dx[0]);
 #if AMREX_SPACEDIM > 1
-                        p.pos(1) += (2*amrex::Random(engine)-1)*move_dir[1]*dx[1];
+                        p.pos(1) += static_cast<ParticleReal> ((2*amrex::Random(engine)-1)*move_dir[1]*dx[1]);
 #endif
 #if AMREX_SPACEDIM > 2
-                        p.pos(2) += (2*amrex::Random(engine)-1)*move_dir[2]*dx[2];
+                        p.pos(2) += static_cast<ParticleReal> ((2*amrex::Random(engine)-1)*move_dir[2]*dx[2]);
 #endif
                     });
                 }

--- a/Tests/Particles/ParticleMesh/main.cpp
+++ b/Tests/Particles/ParticleMesh/main.cpp
@@ -138,7 +138,7 @@ void testParticleMesh (TestParams& parms)
               for (int kk = 0; kk <= 1; ++kk) {
                   for (int jj = 0; jj <= 1; ++jj) {
                       for (int ii = 0; ii <= 1; ++ii) {
-                          p.rdata(4+comp) += sx[ii]*sy[jj]*sz[kk]*acc(i+ii-1,j+jj-1,k+kk-1,comp);
+                          p.rdata(4+comp) += static_cast<ParticleReal> (sx[ii]*sy[jj]*sz[kk]*acc(i+ii-1,j+jj-1,k+kk-1,comp));
                       }
                   }
               }

--- a/Tests/Particles/ParticleReduce/main.cpp
+++ b/Tests/Particles/ParticleReduce/main.cpp
@@ -61,9 +61,9 @@ public:
                     Real r[3];
                     get_position_unit_cell(r, a_num_particles_per_cell, i_part);
 
-                    Real x = plo[0] + (iv[0] + r[0])*dx[0];
-                    Real y = plo[1] + (iv[1] + r[1])*dx[1];
-                    Real z = plo[2] + (iv[2] + r[2])*dx[2];
+                    ParticleReal x = static_cast<ParticleReal> (plo[0] + (iv[0] + r[0])*dx[0]);
+                    ParticleReal y = static_cast<ParticleReal> (plo[1] + (iv[1] + r[1])*dx[1]);
+                    ParticleReal z = static_cast<ParticleReal> (plo[2] + (iv[2] + r[2])*dx[2]);
 
                     ParticleType p;
                     p.id()  = ParticleType::NextID();

--- a/Tests/Particles/ParticleTransformations/main.cpp
+++ b/Tests/Particles/ParticleTransformations/main.cpp
@@ -64,9 +64,9 @@ public:
                     Real r[3];
                     get_position_unit_cell(r, a_num_particles_per_cell, i_part);
 
-                    Real x = plo[0] + (iv[0] + r[0])*dx[0];
-                    Real y = plo[1] + (iv[1] + r[1])*dx[1];
-                    Real z = plo[2] + (iv[2] + r[2])*dx[2];
+                    ParticleReal x = static_cast<ParticleReal> (plo[0] + (iv[0] + r[0])*dx[0]);
+                    ParticleReal y = static_cast<ParticleReal> (plo[1] + (iv[1] + r[1])*dx[1]);
+                    ParticleReal z = static_cast<ParticleReal> (plo[2] + (iv[2] + r[2])*dx[2]);
 
                     ParticleType p;
                     p.id()  = ParticleType::NextID();

--- a/Tests/Particles/Redistribute/main.cpp
+++ b/Tests/Particles/Redistribute/main.cpp
@@ -108,12 +108,12 @@ public:
                     ParticleType p;
                     p.id()  = ParticleType::NextID();
                     p.cpu() = ParallelDescriptor::MyProc();
-                    p.pos(0) = plo[0] + (iv[0] + r[0])*dx[0];
+                    p.pos(0) = static_cast<ParticleReal> (plo[0] + (iv[0] + r[0])*dx[0]);
 #if AMREX_SPACEDIM > 1
-                    p.pos(1) = plo[1] + (iv[1] + r[1])*dx[1];
+                    p.pos(1) = static_cast<ParticleReal> (plo[1] + (iv[1] + r[1])*dx[1]);
 #endif
 #if AMREX_SPACEDIM > 2
-                    p.pos(2) = plo[2] + (iv[2] + r[2])*dx[2];
+                    p.pos(2) = static_cast<ParticleReal> (plo[2] + (iv[2] + r[2])*dx[2]);
 #endif
 
                     for (int i = 0; i < NSR; ++i) p.rdata(i) = p.id();
@@ -202,12 +202,12 @@ public:
                     amrex::ParallelFor( np, [=] AMREX_GPU_DEVICE (int i) noexcept
                     {
                         ParticleType& p = pstruct[i];
-                        p.pos(0) += move_dir[0]*dx[0];
+                        p.pos(0) += static_cast<ParticleReal> (move_dir[0]*dx[0]);
 #if AMREX_SPACEDIM > 1
-                        p.pos(1) += move_dir[1]*dx[1];
+                        p.pos(1) += static_cast<ParticleReal> (move_dir[1]*dx[1]);
 #endif
 #if AMREX_SPACEDIM > 2
-                        p.pos(2) += move_dir[2]*dx[2];
+                        p.pos(2) += static_cast<ParticleReal> (move_dir[2]*dx[2]);
 #endif
                     });
                 }
@@ -218,12 +218,12 @@ public:
                     {
                         ParticleType& p = pstruct[i];
 
-                        p.pos(0) += (2*amrex::Random(engine)-1)*move_dir[0]*dx[0];
+                        p.pos(0) += static_cast<ParticleReal> ((2*amrex::Random(engine)-1)*move_dir[0]*dx[0]);
 #if AMREX_SPACEDIM > 1
-                        p.pos(1) += (2*amrex::Random(engine)-1)*move_dir[1]*dx[1];
+                        p.pos(1) += static_cast<ParticleReal> ((2*amrex::Random(engine)-1)*move_dir[1]*dx[1]);
 #endif
 #if AMREX_SPACEDIM > 2
-                        p.pos(2) += (2*amrex::Random(engine)-1)*move_dir[2]*dx[2];
+                        p.pos(2) += static_cast<ParticleReal> ((2*amrex::Random(engine)-1)*move_dir[2]*dx[2]);
 #endif
                     });
                 }


### PR DESCRIPTION
## Summary
This adds explicit casts for ParticleReal and fixes a null-dereference compile warning.

## Additional background

## Checklist

The proposed changes:
- [X] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
