### PR TITLE
Test Build Variant

### DIFF
--- a/Docs/sphinx_documentation/source/BuildingAMReX.rst
+++ b/Docs/sphinx_documentation/source/BuildingAMReX.rst
@@ -46,6 +46,8 @@ list of important variables.
    +-----------------+-------------------------------------+--------------------+
    | TEST            | TRUE or FALSE                       | FALSE              |
    +-----------------+-------------------------------------+--------------------+
+   | USE_ASSERTION   | TRUE or FALSE                       | FALSE              |
+   +-----------------+-------------------------------------+--------------------+
    | USE_MPI         | TRUE or FALSE                       | FALSE              |
    +-----------------+-------------------------------------+--------------------+
    | USE_OMP         | TRUE or FALSE                       | FALSE              |
@@ -112,8 +114,8 @@ Variables ``DEBUG``, ``TEST``, ``USE_MPI`` and ``USE_OMP`` are optional with
 default set to FALSE.  The meaning of these variables should
 be obvious.  When ``DEBUG=TRUE``, aggressive compiler optimization flags are
 turned off and assertions in source code are turned on. For production runs,
-``DEBUG`` should be set to FALSE. ``TEST`` is set by default in CI and adds
-slight debugging, e.g., initializing default values in FABs.
+``DEBUG`` should be set to FALSE. ``TEST`` and ``USE_ASSERTION`` are set by
+default in CI and add slight debugging, e.g., initializing default values in FABs.
 An advanced variable, ``MPI_THREAD_MULTIPLE``, can be set to TRUE to initialize
 MPI with support for concurrent MPI calls from multiple threads.
 

--- a/Docs/sphinx_documentation/source/BuildingAMReX.rst
+++ b/Docs/sphinx_documentation/source/BuildingAMReX.rst
@@ -44,6 +44,8 @@ list of important variables.
    +-----------------+-------------------------------------+--------------------+
    | PRECISION       | DOUBLE or FLOAT                     | DOUBLE             |
    +-----------------+-------------------------------------+--------------------+
+   | TEST            | TRUE or FALSE                       | FALSE              |
+   +-----------------+-------------------------------------+--------------------+
    | USE_MPI         | TRUE or FALSE                       | FALSE              |
    +-----------------+-------------------------------------+--------------------+
    | USE_OMP         | TRUE or FALSE                       | FALSE              |
@@ -106,11 +108,12 @@ AMReX uses double precision by default.  One can change to single
 precision by setting ``PRECISION=FLOAT``.
 (Particles have an equivalent flag ``USE_SINGLE_PRECISION_PARTICLES=TRUE/FALSE``.)
 
-Variables ``DEBUG``, ``USE_MPI`` and ``USE_OMP`` are optional with default set
-to FALSE.  The meaning of these variables should
+Variables ``DEBUG``, ``TEST``, ``USE_MPI`` and ``USE_OMP`` are optional with
+default set to FALSE.  The meaning of these variables should
 be obvious.  When ``DEBUG=TRUE``, aggressive compiler optimization flags are
 turned off and assertions in source code are turned on. For production runs,
-``DEBUG`` should be set to FALSE.
+``DEBUG`` should be set to FALSE. ``TEST`` is set by default in CI and adds
+slight debugging, e.g., initializing default values in FABs.
 An advanced variable, ``MPI_THREAD_MULTIPLE``, can be set to TRUE to initialize
 MPI with support for concurrent MPI calls from multiple threads.
 
@@ -474,6 +477,8 @@ The list of available options is reported in the :ref:`table <tab:cmakevar>` bel
    | AMReX_COMM_PROFILE           |  Build with comm-profiling support              | NO                      | YES, NO               |
    +------------------------------+-------------------------------------------------+-------------------------+-----------------------+
    | AMReX_MEM_PROFILE            |  Build with memory-profiling support            | NO                      | YES, NO               |
+   +------------------------------+-------------------------------------------------+-------------------------+-----------------------+
+   | AMReX_TESTING                |  Build for testing (CI)                         | NO                      | YES, NO               |
    +------------------------------+-------------------------------------------------+-------------------------+-----------------------+
    | AMReX_MPI_THREAD_MULTIPLE    |  Concurrent MPI calls from multiple threads     | NO                      | YES, NO               |
    +------------------------------+-------------------------------------------------+-------------------------+-----------------------+

--- a/Tools/CMake/AMReXSetDefines.cmake
+++ b/Tools/CMake/AMReXSetDefines.cmake
@@ -37,6 +37,9 @@ add_amrex_define( AMREX_USE_ROCTX NO_LEGACY IF AMReX_ROCTX )
 # Mem profiler
 add_amrex_define( AMREX_MEM_PROFILING NO_LEGACY IF AMReX_MEM_PROFILE )
 
+# Testing
+add_amrex_define( AMREX_TESTING NO_LEGACY IF AMReX_TESTING )
+
 # MPI
 add_amrex_define( AMREX_USE_MPI IF AMReX_MPI )
 add_amrex_define( AMREX_MPI_THREAD_MULTIPLE NO_LEGACY IF AMReX_MPI_THREAD_MULTIPLE)


### PR DESCRIPTION
## Summary

The AMReX "test" build variant that is used by [regression tests](https://github.com/AMReX-Codes/regression_testing) by default was not documented, which leads to some confusion when debugging failing apps.

This PR:
- documents GNUmake's `TEST` & `USE_ASSERTION` options
- adds a CMake option `AMReX_TESTING`

that are in sync with the define `-DAMREX_TESTING` that changes FAB default values and other debug-like options.

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
