### PR TITLE
Option for dynamic tiling in CPU build of MF ParallelFor

### DIFF
--- a/Src/Base/AMReX_MFParallelFor.H
+++ b/Src/Base/AMReX_MFParallelFor.H
@@ -454,7 +454,7 @@ ParallelFor (MF const& mf, IntVect const& ng, int ncomp, TileSize const& ts, F&&
  *
  * This version launches a kernel to work on the valid and ghost regions.  If
  * built for CPU, tiling will be enabled.  However, one could specify a huge
- * tile size to effectively disable tiling.  For GPU build, this function is
+ * tile size to effectively disable tiling.  For GPU builds, this function is
  * NON-BLOCKING on the host. Conceptually, this is a 4D loop.
  *
  * \tparam MF the MultiFab/FabArray type

--- a/Src/Base/AMReX_MFParallelFor.H
+++ b/Src/Base/AMReX_MFParallelFor.H
@@ -12,15 +12,19 @@
 #endif
 
 namespace amrex {
-namespace experimental {
 
-struct ParForMFTileSize {
+struct TileSize {
     IntVect tile_size;
-    ParForMFTileSize (int sx, int sy, int sz)
-        : tile_size(AMREX_D_DECL(sx,sy,sz))
-        { amrex::ignore_unused(sy,sz); }
+    explicit TileSize (IntVect const& ts) noexcept : tile_size(ts) {}
 };
 
+struct DynamicTiling {
+    bool dynamic;
+    explicit DynamicTiling (bool f) noexcept : dynamic(f) {}
+};
+
+namespace experimental {
+
 /**
  * \brief ParallelFor for MultiFab/FabArray.
  *
@@ -40,7 +44,7 @@ template <typename MF, typename F>
 std::enable_if_t<IsFabArray<MF>::value>
 ParallelFor (MF const& mf, F&& f)
 {
-    detail::ParallelFor(mf, IntVect(0), FabArrayBase::mfiter_tile_size, std::forward<F>(f));
+    detail::ParallelFor(mf, IntVect(0), FabArrayBase::mfiter_tile_size, false, std::forward<F>(f));
 }
 
 /**
@@ -64,9 +68,9 @@ std::enable_if_t<IsFabArray<MF>::value>
 ParallelFor (MF const& mf, F&& f)
 {
 #ifdef AMREX_USE_GPU
-    detail::ParallelFor<MT>(mf, IntVect(0), FabArrayBase::mfiter_tile_size, std::forward<F>(f));
+    detail::ParallelFor<MT>(mf, IntVect(0), FabArrayBase::mfiter_tile_size, false, std::forward<F>(f));
 #else
-    detail::ParallelFor(mf, IntVect(0), FabArrayBase::mfiter_tile_size, std::forward<F>(f));
+    detail::ParallelFor(mf, IntVect(0), FabArrayBase::mfiter_tile_size, false, std::forward<F>(f));
 #endif
 }
 
@@ -90,7 +94,7 @@ template <typename MF, typename F>
 std::enable_if_t<IsFabArray<MF>::value>
 ParallelFor (MF const& mf, IntVect const& ng, F&& f)
 {
-    detail::ParallelFor(mf, ng, FabArrayBase::mfiter_tile_size, std::forward<F>(f));
+    detail::ParallelFor(mf, ng, FabArrayBase::mfiter_tile_size, false, std::forward<F>(f));
 }
 
 /**
@@ -115,9 +119,9 @@ std::enable_if_t<IsFabArray<MF>::value>
 ParallelFor (MF const& mf, IntVect const& ng, F&& f)
 {
 #ifdef AMREX_USE_GPU
-    detail::ParallelFor<MT>(mf, ng, FabArrayBase::mfiter_tile_size, std::forward<F>(f));
+    detail::ParallelFor<MT>(mf, ng, FabArrayBase::mfiter_tile_size, false, std::forward<F>(f));
 #else
-    detail::ParallelFor(mf, ng, FabArrayBase::mfiter_tile_size, std::forward<F>(f));
+    detail::ParallelFor(mf, ng, FabArrayBase::mfiter_tile_size, false, std::forward<F>(f));
 #endif
 }
 
@@ -141,7 +145,7 @@ template <typename MF, typename F>
 std::enable_if_t<IsFabArray<MF>::value>
 ParallelFor (MF const& mf, int ncomp, F&& f)
 {
-    detail::ParallelFor(mf, IntVect(0), ncomp, FabArrayBase::mfiter_tile_size, std::forward<F>(f));
+    detail::ParallelFor(mf, IntVect(0), ncomp, FabArrayBase::mfiter_tile_size, false, std::forward<F>(f));
 }
 
 /**
@@ -166,9 +170,9 @@ std::enable_if_t<IsFabArray<MF>::value>
 ParallelFor (MF const& mf, int ncomp, F&& f)
 {
 #ifdef AMREX_USE_GPU
-    detail::ParallelFor<MT>(mf, IntVect(0), ncomp, FabArrayBase::mfiter_tile_size, std::forward<F>(f));
+    detail::ParallelFor<MT>(mf, IntVect(0), ncomp, FabArrayBase::mfiter_tile_size, false, std::forward<F>(f));
 #else
-    detail::ParallelFor(mf, IntVect(0), ncomp, FabArrayBase::mfiter_tile_size, std::forward<F>(f));
+    detail::ParallelFor(mf, IntVect(0), ncomp, FabArrayBase::mfiter_tile_size, false, std::forward<F>(f));
 #endif
 }
 
@@ -193,7 +197,7 @@ template <typename MF, typename F>
 std::enable_if_t<IsFabArray<MF>::value>
 ParallelFor (MF const& mf, IntVect const& ng, int ncomp, F&& f)
 {
-    detail::ParallelFor(mf, ng, ncomp, FabArrayBase::mfiter_tile_size, std::forward<F>(f));
+    detail::ParallelFor(mf, ng, ncomp, FabArrayBase::mfiter_tile_size, false, std::forward<F>(f));
 }
 
 /**
@@ -219,9 +223,9 @@ std::enable_if_t<IsFabArray<MF>::value>
 ParallelFor (MF const& mf, IntVect const& ng, int ncomp, F&& f)
 {
 #ifdef AMREX_USE_GPU
-    detail::ParallelFor<MT>(mf, ng, ncomp, FabArrayBase::mfiter_tile_size, std::forward<F>(f));
+    detail::ParallelFor<MT>(mf, ng, ncomp, FabArrayBase::mfiter_tile_size, false, std::forward<F>(f));
 #else
-    detail::ParallelFor(mf, ng, ncomp, FabArrayBase::mfiter_tile_size, std::forward<F>(f));
+    detail::ParallelFor(mf, ng, ncomp, FabArrayBase::mfiter_tile_size, false, std::forward<F>(f));
 #endif
 }
 
@@ -244,9 +248,9 @@ ParallelFor (MF const& mf, IntVect const& ng, int ncomp, F&& f)
  */
 template <typename MF, typename F>
 std::enable_if_t<IsFabArray<MF>::value>
-ParallelFor (MF const& mf, ParForMFTileSize const& ts, F&& f)
+ParallelFor (MF const& mf, TileSize const& ts, F&& f)
 {
-    detail::ParallelFor(mf, IntVect(0), ts.tile_size, std::forward<F>(f));
+    detail::ParallelFor(mf, IntVect(0), ts.tile_size, false, std::forward<F>(f));
 }
 
 /**
@@ -269,12 +273,12 @@ ParallelFor (MF const& mf, ParForMFTileSize const& ts, F&& f)
  */
 template <int MT, typename MF, typename F>
 std::enable_if_t<IsFabArray<MF>::value>
-ParallelFor (MF const& mf, ParForMFTileSize const& ts, F&& f)
+ParallelFor (MF const& mf, TileSize const& ts, F&& f)
 {
 #ifdef AMREX_USE_GPU
-    detail::ParallelFor<MT>(mf, IntVect(0), ts.tile_size, std::forward<F>(f));
+    detail::ParallelFor<MT>(mf, IntVect(0), ts.tile_size, false, std::forward<F>(f));
 #else
-    detail::ParallelFor(mf, IntVect(0), ts.tile_size, std::forward<F>(f));
+    detail::ParallelFor(mf, IntVect(0), ts.tile_size, false, std::forward<F>(f));
 #endif
 }
 
@@ -298,9 +302,9 @@ ParallelFor (MF const& mf, ParForMFTileSize const& ts, F&& f)
  */
 template <typename MF, typename F>
 std::enable_if_t<IsFabArray<MF>::value>
-ParallelFor (MF const& mf, IntVect const& ng, ParForMFTileSize const& ts, F&& f)
+ParallelFor (MF const& mf, IntVect const& ng, TileSize const& ts, F&& f)
 {
-    detail::ParallelFor(mf, ng, ts.tile_size, std::forward<F>(f));
+    detail::ParallelFor(mf, ng, ts.tile_size, false, std::forward<F>(f));
 }
 
 /**
@@ -324,12 +328,12 @@ ParallelFor (MF const& mf, IntVect const& ng, ParForMFTileSize const& ts, F&& f)
  */
 template <int MT, typename MF, typename F>
 std::enable_if_t<IsFabArray<MF>::value>
-ParallelFor (MF const& mf, IntVect const& ng, ParForMFTileSize const& ts, F&& f)
+ParallelFor (MF const& mf, IntVect const& ng, TileSize const& ts, F&& f)
 {
 #ifdef AMREX_USE_GPU
-    detail::ParallelFor<MT>(mf, ng, ts.tile_size, std::forward<F>(f));
+    detail::ParallelFor<MT>(mf, ng, ts.tile_size, false, std::forward<F>(f));
 #else
-    detail::ParallelFor(mf, ng, ts.tile_size, std::forward<F>(f));
+    detail::ParallelFor(mf, ng, ts.tile_size, false, std::forward<F>(f));
 #endif
 }
 
@@ -353,9 +357,9 @@ ParallelFor (MF const& mf, IntVect const& ng, ParForMFTileSize const& ts, F&& f)
  */
 template <typename MF, typename F>
 std::enable_if_t<IsFabArray<MF>::value>
-ParallelFor (MF const& mf, int ncomp, ParForMFTileSize const& ts, F&& f)
+ParallelFor (MF const& mf, int ncomp, TileSize const& ts, F&& f)
 {
-    detail::ParallelFor(mf, IntVect(0), ncomp, ts.tile_size, std::forward<F>(f));
+    detail::ParallelFor(mf, IntVect(0), ncomp, ts.tile_size, false, std::forward<F>(f));
 }
 
 /**
@@ -379,12 +383,12 @@ ParallelFor (MF const& mf, int ncomp, ParForMFTileSize const& ts, F&& f)
  */
 template <int MT, typename MF, typename F>
 std::enable_if_t<IsFabArray<MF>::value>
-ParallelFor (MF const& mf, int ncomp, ParForMFTileSize const& ts, F&& f)
+ParallelFor (MF const& mf, int ncomp, TileSize const& ts, F&& f)
 {
 #ifdef AMREX_USE_GPU
-    detail::ParallelFor<MT>(mf, IntVect(0), ncomp, ts.tile_size, std::forward<F>(f));
+    detail::ParallelFor<MT>(mf, IntVect(0), ncomp, ts.tile_size, false, std::forward<F>(f));
 #else
-    detail::ParallelFor(mf, IntVect(0), ncomp, ts.tile_size, std::forward<F>(f));
+    detail::ParallelFor(mf, IntVect(0), ncomp, ts.tile_size, false, std::forward<F>(f));
 #endif
 }
 
@@ -409,9 +413,9 @@ ParallelFor (MF const& mf, int ncomp, ParForMFTileSize const& ts, F&& f)
  */
 template <typename MF, typename F>
 std::enable_if_t<IsFabArray<MF>::value>
-ParallelFor (MF const& mf, IntVect const& ng, int ncomp, ParForMFTileSize const& ts, F&& f)
+ParallelFor (MF const& mf, IntVect const& ng, int ncomp, TileSize const& ts, F&& f)
 {
-    detail::ParallelFor(mf, ng, ncomp, ts.tile_size, std::forward<F>(f));
+    detail::ParallelFor(mf, ng, ncomp, ts.tile_size, false, std::forward<F>(f));
 }
 
 /**
@@ -436,12 +440,131 @@ ParallelFor (MF const& mf, IntVect const& ng, int ncomp, ParForMFTileSize const&
  */
 template <int MT, typename MF, typename F>
 std::enable_if_t<IsFabArray<MF>::value>
-ParallelFor (MF const& mf, IntVect const& ng, int ncomp, ParForMFTileSize const& ts, F&& f)
+ParallelFor (MF const& mf, IntVect const& ng, int ncomp, TileSize const& ts, F&& f)
 {
 #ifdef AMREX_USE_GPU
-    detail::ParallelFor<MT>(mf, ng, ncomp, ts.tile_size, std::forward<F>(f));
+    detail::ParallelFor<MT>(mf, ng, ncomp, ts.tile_size, false, std::forward<F>(f));
 #else
-    detail::ParallelFor(mf, ng, ncomp, ts.tile_size, std::forward<F>(f));
+    detail::ParallelFor(mf, ng, ncomp, ts.tile_size, false, std::forward<F>(f));
+#endif
+}
+
+/**
+ * \brief ParallelFor for MultiFab/FabArray.
+ *
+ * This version launch a kernel to work on the valid and ghost region.  If
+ * built for CPU, tiling will be enabled.  However, one could specify a huge
+ * tile size to effectively disable tiling.  For GPU build, this function is
+ * NON-BLOCKING on the host. Conceptually, this is a 4D loop.
+ *
+ * \tparam MF the MultiFab/FabArray type
+ * \tparam F a callable type like lambda
+ *
+ * \param mf the MultiFab/FabArray object used to specify the iteration space
+ * \param ng the number of ghost cells around the valid region
+ * \param ts tile size, ignored by GPU build
+ * \param dt controls dynamic tiling for the cpu build
+ * \param f a calable object void(int,int,int,int), where the first argument
+ *           is the local box index, and the following three are spatial indices
+ *           for x, y, and z-directions.
+ */
+template <typename MF, typename F>
+std::enable_if_t<IsFabArray<MF>::value>
+ParallelFor (MF const& mf, IntVect const& ng, TileSize const& ts, DynamicTiling dt, F&& f)
+{
+    detail::ParallelFor(mf, ng, ts.tile_size, dt.dynamic, std::forward<F>(f));
+}
+
+/**
+ * \brief ParallelFor for MultiFab/FabArray.
+ *
+ * This version launch a kernel to work on the valid and ghost region.  If
+ * built for CPU, tiling will be enabled.  However, one could specify a huge
+ * tile size to effectively disable tiling.  For GPU build, this function is
+ * NON-BLOCKING on the host. Conceptually, this is a 5D loop.
+ *
+ * \tparam MF the MultiFab/FabArray type
+ * \tparam F a callable type like lambda
+ *
+ * \param mf the MultiFab/FabArray object used to specify the iteration space
+ * \param ng the number of ghost cells around the valid region
+ * \param ncomp the number of component
+ * \param ts tile size, ignored by GPU build
+ * \param dt controls dynamic tiling for the cpu build
+ * \param f a calable object void(int,int,int,int,int), where the first argument
+ *           is the local box index, the following three are spatial indices
+ *           for x, y, and z-directions, and the last is for component.
+ */
+template <typename MF, typename F>
+std::enable_if_t<IsFabArray<MF>::value>
+ParallelFor (MF const& mf, IntVect const& ng, int ncomp, TileSize const& ts,
+             DynamicTiling dt, F&& f)
+{
+    detail::ParallelFor(mf, ng, ncomp, ts.tile_size, dt.dynamic, std::forward<F>(f));
+}
+
+/**
+ * \brief ParallelFor for MultiFab/FabArray.
+ *
+ * This version launch a kernel to work on the valid and ghost region.  If
+ * built for CPU, tiling will be enabled.  However, one could specify a huge
+ * tile size to effectively disable tiling.  For GPU build, this function is
+ * NON-BLOCKING on the host. Conceptually, this is a 4D loop.
+ *
+ * \tparam MT max threads in GPU blocks (Only relevant for GPU builds)
+ * \tparam MF the MultiFab/FabArray type
+ * \tparam F a callable type like lambda
+ *
+ * \param mf the MultiFab/FabArray object used to specify the iteration space
+ * \param ng the number of ghost cells around the valid region
+ * \param ts tile size, ignored by GPU build
+ * \param dt controls dynamic tiling for the cpu build
+ * \param f a calable object void(int,int,int,int), where the first argument
+ *           is the local box index, and the following three are spatial indices
+ *           for x, y, and z-directions.
+ */
+template <int MT, typename MF, typename F>
+std::enable_if_t<IsFabArray<MF>::value>
+ParallelFor (MF const& mf, IntVect const& ng, TileSize const& ts,
+             DynamicTiling dt, F&& f)
+{
+#ifdef AMREX_USE_GPU
+    detail::ParallelFor<MT>(mf, ng, ts.tile_size, dt.dynamic, std::forward<F>(f));
+#else
+    detail::ParallelFor(mf, ng, ts.tile_size, dt.dynamic, std::forward<F>(f));
+#endif
+}
+
+/**
+ * \brief ParallelFor for MultiFab/FabArray.
+ *
+ * This version launch a kernel to work on the valid and ghost region.  If
+ * built for CPU, tiling will be enabled.  However, one could specify a huge
+ * tile size to effectively disable tiling.  For GPU build, this function is
+ * NON-BLOCKING on the host. Conceptually, this is a 5D loop.
+ *
+ * \tparam MT max threads in GPU blocks (Only relevant for GPU builds)
+ * \tparam MF the MultiFab/FabArray type
+ * \tparam F a callable type like lambda
+ *
+ * \param mf the MultiFab/FabArray object used to specify the iteration space
+ * \param ng the number of ghost cells around the valid region
+ * \param ncomp the number of component
+ * \param ts tile size, ignored by GPU build
+ * \param dt controls dynamic tiling for the cpu build
+ * \param f a calable object void(int,int,int,int,int), where the first argument
+ *           is the local box index, the following three are spatial indices
+ *           for x, y, and z-directions, and the last is for component.
+ */
+template <int MT, typename MF, typename F>
+std::enable_if_t<IsFabArray<MF>::value>
+ParallelFor (MF const& mf, IntVect const& ng, int ncomp, TileSize const& ts,
+             DynamicTiling dt, F&& f)
+{
+#ifdef AMREX_USE_GPU
+    detail::ParallelFor<MT>(mf, ng, ncomp, ts.tile_size, dt.dynamic, std::forward<F>(f));
+#else
+    detail::ParallelFor(mf, ng, ncomp, ts.tile_size, dt.dynamic, std::forward<F>(f));
 #endif
 }
 

--- a/Src/Base/AMReX_MFParallelFor.H
+++ b/Src/Base/AMReX_MFParallelFor.H
@@ -28,15 +28,15 @@ namespace experimental {
 /**
  * \brief ParallelFor for MultiFab/FabArray.
  *
- * This version launch a kernel to work on the valid region.  If built for
- * CPU, tiling will be enabled.  For GPU build, this function is
+ * This version launches a kernel to work on the valid region.  If built for
+ * CPU, tiling will be enabled.  For GPU builds, this function is
  * NON-BLOCKING on the host. Conceptually, this is a 4D loop.
  *
  * \tparam MF the MultiFab/FabArray type
  * \tparam F a callable type like lambda
  *
  * \param mf the MultiFab/FabArray object used to specify the iteration space
- * \param f a calable object void(int,int,int,int), where the first argument
+ * \param f a callable object void(int,int,int,int), where the first argument
  *           is the local box index, and the following three are spatial indices
  *           for x, y, and z-directions.
  */
@@ -50,8 +50,8 @@ ParallelFor (MF const& mf, F&& f)
 /**
  * \brief ParallelFor for MultiFab/FabArray.
  *
- * This version launch a kernel to work on the valid region.  If built for
- * CPU, tiling will be enabled.  For GPU build, this function is
+ * This version launches a kernel to work on the valid region.  If built for
+ * CPU, tiling will be enabled.  For GPU builds, this function is
  * NON-BLOCKING on the host. Conceptually, this is a 4D loop.
  *
  * \tparam MT max threads in GPU blocks (Only relevant for GPU builds)
@@ -59,7 +59,7 @@ ParallelFor (MF const& mf, F&& f)
  * \tparam F a callable type like lambda
  *
  * \param mf the MultiFab/FabArray object used to specify the iteration space
- * \param f a calable object void(int,int,int,int), where the first argument
+ * \param f a callable object void(int,int,int,int), where the first argument
  *           is the local box index, and the following three are spatial indices
  *           for x, y, and z-directions.
  */
@@ -77,8 +77,8 @@ ParallelFor (MF const& mf, F&& f)
 /**
  * \brief ParallelFor for MultiFab/FabArray.
  *
- * This version launch a kernel to work on the valid and ghost region.  If
- * built for CPU, tiling will be enabled.  For GPU build, this function is
+ * This version launches a kernel to work on the valid and ghost regions.  If
+ * built for CPU, tiling will be enabled.  For GPU builds, this function is
  * NON-BLOCKING on the host. Conceptually, this is a 4D loop.
  *
  * \tparam MF the MultiFab/FabArray type
@@ -86,7 +86,7 @@ ParallelFor (MF const& mf, F&& f)
  *
  * \param mf the MultiFab/FabArray object used to specify the iteration space
  * \param ng the number of ghost cells around the valid region
- * \param f a calable object void(int,int,int,int), where the first argument
+ * \param f a callable object void(int,int,int,int), where the first argument
  *           is the local box index, and the following three are spatial indices
  *           for x, y, and z-directions.
  */
@@ -100,8 +100,8 @@ ParallelFor (MF const& mf, IntVect const& ng, F&& f)
 /**
  * \brief ParallelFor for MultiFab/FabArray.
  *
- * This version launch a kernel to work on the valid and ghost region.  If
- * built for CPU, tiling will be enabled.  For GPU build, this function is
+ * This version launches a kernel to work on the valid and ghost regions.  If
+ * built for CPU, tiling will be enabled.  For GPU builds, this function is
  * NON-BLOCKING on the host. Conceptually, this is a 4D loop.
  *
  * \tparam MT max threads in GPU blocks (Only relevant for GPU builds)
@@ -110,7 +110,7 @@ ParallelFor (MF const& mf, IntVect const& ng, F&& f)
  *
  * \param mf the MultiFab/FabArray object used to specify the iteration space
  * \param ng the number of ghost cells around the valid region
- * \param f a calable object void(int,int,int,int), where the first argument
+ * \param f a callable object void(int,int,int,int), where the first argument
  *           is the local box index, and the following three are spatial indices
  *           for x, y, and z-directions.
  */
@@ -128,8 +128,8 @@ ParallelFor (MF const& mf, IntVect const& ng, F&& f)
 /**
  * \brief ParallelFor for MultiFab/FabArray.
  *
- * This version launch a kernel to work on the valid region.  If built for
- * CPU, tiling will be enabled.  For GPU build, this function is
+ * This version launches a kernel to work on the valid region.  If built for
+ * CPU, tiling will be enabled.  For GPU builds, this function is
  * NON-BLOCKING on the host. Conceptually, this is a 5D loop.
  *
  * \tparam MF the MultiFab/FabArray type
@@ -137,7 +137,7 @@ ParallelFor (MF const& mf, IntVect const& ng, F&& f)
  *
  * \param mf the MultiFab/FabArray object used to specify the iteration space
  * \param ncomp the number of component
- * \param f a calable object void(int,int,int,int,int), where the first argument
+ * \param f a callable object void(int,int,int,int,int), where the first argument
  *           is the local box index, the following three are spatial indices
  *           for x, y, and z-directions, and the last is for component.
  */
@@ -151,8 +151,8 @@ ParallelFor (MF const& mf, int ncomp, F&& f)
 /**
  * \brief ParallelFor for MultiFab/FabArray.
  *
- * This version launch a kernel to work on the valid region.  If built for
- * CPU, tiling will be enabled.  For GPU build, this function is
+ * This version launches a kernel to work on the valid region.  If built for
+ * CPU, tiling will be enabled.  For GPU builds, this function is
  * NON-BLOCKING on the host. Conceptually, this is a 5D loop.
  *
  * \tparam MT max threads in GPU blocks (Only relevant for GPU builds)
@@ -161,7 +161,7 @@ ParallelFor (MF const& mf, int ncomp, F&& f)
  *
  * \param mf the MultiFab/FabArray object used to specify the iteration space
  * \param ncomp the number of component
- * \param f a calable object void(int,int,int,int,int), where the first argument
+ * \param f a callable object void(int,int,int,int,int), where the first argument
  *           is the local box index, the following three are spatial indices
  *           for x, y, and z-directions, and the last is for component.
  */
@@ -179,8 +179,8 @@ ParallelFor (MF const& mf, int ncomp, F&& f)
 /**
  * \brief ParallelFor for MultiFab/FabArray.
  *
- * This version launch a kernel to work on the valid and ghost region.  If
- * built for CPU, tiling will be enabled.  For GPU build, this function is
+ * This version launches a kernel to work on the valid and ghost regions.  If
+ * built for CPU, tiling will be enabled.  For GPU builds, this function is
  * NON-BLOCKING on the host. Conceptually, this is a 5D loop.
  *
  * \tparam MF the MultiFab/FabArray type
@@ -189,7 +189,7 @@ ParallelFor (MF const& mf, int ncomp, F&& f)
  * \param mf the MultiFab/FabArray object used to specify the iteration space
  * \param ng the number of ghost cells around the valid region
  * \param ncomp the number of component
- * \param f a calable object void(int,int,int,int,int), where the first argument
+ * \param f a callable object void(int,int,int,int,int), where the first argument
  *           is the local box index, the following three are spatial indices
  *           for x, y, and z-directions, and the last is for component.
  */
@@ -203,8 +203,8 @@ ParallelFor (MF const& mf, IntVect const& ng, int ncomp, F&& f)
 /**
  * \brief ParallelFor for MultiFab/FabArray.
  *
- * This version launch a kernel to work on the valid and ghost region.  If
- * built for CPU, tiling will be enabled.  For GPU build, this function is
+ * This version launches a kernel to work on the valid and ghost regions.  If
+ * built for CPU, tiling will be enabled.  For gpu builds, this function is
  * NON-BLOCKING on the host. Conceptually, this is a 5D loop.
  *
  * \tparam MT max threads in GPU blocks (Only relevant for GPU builds)
@@ -214,7 +214,7 @@ ParallelFor (MF const& mf, IntVect const& ng, int ncomp, F&& f)
  * \param mf the MultiFab/FabArray object used to specify the iteration space
  * \param ng the number of ghost cells around the valid region
  * \param ncomp the number of component
- * \param f a calable object void(int,int,int,int,int), where the first argument
+ * \param f a callable object void(int,int,int,int,int), where the first argument
  *           is the local box index, the following three are spatial indices
  *           for x, y, and z-directions, and the last is for component.
  */
@@ -232,9 +232,9 @@ ParallelFor (MF const& mf, IntVect const& ng, int ncomp, F&& f)
 /**
  * \brief ParallelFor for MultiFab/FabArray.
  *
- * This version launch a kernel to work on the valid region.  If built for
+ * This version launches a kernel to work on the valid region.  If built for
  * CPU, tiling will be enabled.  However, one could specify a huge tile size
- * to effectively disable tiling.  For GPU build, this function is
+ * to effectively disable tiling.  For gpu builds, this function is
  * NON-BLOCKING on the host. Conceptually, this is a 4D loop.
  *
  * \tparam MF the MultiFab/FabArray type
@@ -242,7 +242,7 @@ ParallelFor (MF const& mf, IntVect const& ng, int ncomp, F&& f)
  *
  * \param mf the MultiFab/FabArray object used to specify the iteration space
  * \param ts tile size, ignored by GPU build
- * \param f a calable object void(int,int,int,int), where the first argument
+ * \param f a callable object void(int,int,int,int), where the first argument
  *           is the local box index, and the following three are spatial indices
  *           for x, y, and z-directions.
  */
@@ -256,9 +256,9 @@ ParallelFor (MF const& mf, TileSize const& ts, F&& f)
 /**
  * \brief ParallelFor for MultiFab/FabArray.
  *
- * This version launch a kernel to work on the valid region.  If built for
+ * This version launches a kernel to work on the valid region.  If built for
  * CPU, tiling will be enabled.  However, one could specify a huge tile size
- * to effectively disable tiling.  For GPU build, this function is
+ * to effectively disable tiling.  For gpu builds, this function is
  * NON-BLOCKING on the host. Conceptually, this is a 4D loop.
  *
  * \tparam MT max threads in GPU blocks (Only relevant for GPU builds)
@@ -267,7 +267,7 @@ ParallelFor (MF const& mf, TileSize const& ts, F&& f)
  *
  * \param mf the MultiFab/FabArray object used to specify the iteration space
  * \param ts tile size, ignored by GPU build
- * \param f a calable object void(int,int,int,int), where the first argument
+ * \param f a callable object void(int,int,int,int), where the first argument
  *           is the local box index, and the following three are spatial indices
  *           for x, y, and z-directions.
  */
@@ -285,9 +285,9 @@ ParallelFor (MF const& mf, TileSize const& ts, F&& f)
 /**
  * \brief ParallelFor for MultiFab/FabArray.
  *
- * This version launch a kernel to work on the valid and ghost region.  If
+ * This version launches a kernel to work on the valid and ghost regions.  If
  * built for CPU, tiling will be enabled.  However, one could specify a huge
- * tile size to effectively disable tiling.  For GPU build, this function is
+ * tile size to effectively disable tiling.  For gpu builds, this function is
  * NON-BLOCKING on the host. Conceptually, this is a 4D loop.
  *
  * \tparam MF the MultiFab/FabArray type
@@ -296,7 +296,7 @@ ParallelFor (MF const& mf, TileSize const& ts, F&& f)
  * \param mf the MultiFab/FabArray object used to specify the iteration space
  * \param ng the number of ghost cells around the valid region
  * \param ts tile size, ignored by GPU build
- * \param f a calable object void(int,int,int,int), where the first argument
+ * \param f a callable object void(int,int,int,int), where the first argument
  *           is the local box index, and the following three are spatial indices
  *           for x, y, and z-directions.
  */
@@ -310,9 +310,9 @@ ParallelFor (MF const& mf, IntVect const& ng, TileSize const& ts, F&& f)
 /**
  * \brief ParallelFor for MultiFab/FabArray.
  *
- * This version launch a kernel to work on the valid and ghost region.  If
+ * This version launches a kernel to work on the valid and ghost regions.  If
  * built for CPU, tiling will be enabled.  However, one could specify a huge
- * tile size to effectively disable tiling.  For GPU build, this function is
+ * tile size to effectively disable tiling.  For gpu builds, this function is
  * NON-BLOCKING on the host. Conceptually, this is a 4D loop.
  *
  * \tparam MT max threads in GPU blocks (Only relevant for GPU builds)
@@ -322,7 +322,7 @@ ParallelFor (MF const& mf, IntVect const& ng, TileSize const& ts, F&& f)
  * \param mf the MultiFab/FabArray object used to specify the iteration space
  * \param ng the number of ghost cells around the valid region
  * \param ts tile size, ignored by GPU build
- * \param f a calable object void(int,int,int,int), where the first argument
+ * \param f a callable object void(int,int,int,int), where the first argument
  *           is the local box index, and the following three are spatial indices
  *           for x, y, and z-directions.
  */
@@ -340,9 +340,9 @@ ParallelFor (MF const& mf, IntVect const& ng, TileSize const& ts, F&& f)
 /**
  * \brief ParallelFor for MultiFab/FabArray.
  *
- * This version launch a kernel to work on the valid region.  If built for
+ * This version launches a kernel to work on the valid region.  If built for
  * CPU, tiling will be enabled.  However, one could specify a huge tile size
- * to effectively disable tiling.  For GPU build, this function is
+ * to effectively disable tiling.  For gpu builds, this function is
  * NON-BLOCKING on the host. Conceptually, this is a 5D loop.
  *
  * \tparam MF the MultiFab/FabArray type
@@ -351,7 +351,7 @@ ParallelFor (MF const& mf, IntVect const& ng, TileSize const& ts, F&& f)
  * \param mf the MultiFab/FabArray object used to specify the iteration space
  * \param ncomp the number of component
  * \param ts tile size, ignored by GPU build
- * \param f a calable object void(int,int,int,int,int), where the first argument
+ * \param f a callable object void(int,int,int,int,int), where the first argument
  *           is the local box index, the following three are spatial indices
  *           for x, y, and z-directions, and the last is for component.
  */
@@ -365,9 +365,9 @@ ParallelFor (MF const& mf, int ncomp, TileSize const& ts, F&& f)
 /**
  * \brief ParallelFor for MultiFab/FabArray.
  *
- * This version launch a kernel to work on the valid region.  If built for
+ * This version launches a kernel to work on the valid region.  If built for
  * CPU, tiling will be enabled.  However, one could specify a huge tile size
- * to effectively disable tiling.  For GPU build, this function is
+ * to effectively disable tiling.  For gpu builds, this function is
  * NON-BLOCKING on the host. Conceptually, this is a 5D loop.
  *
  * \tparam MT max threads in GPU blocks (Only relevant for GPU builds)
@@ -377,7 +377,7 @@ ParallelFor (MF const& mf, int ncomp, TileSize const& ts, F&& f)
  * \param mf the MultiFab/FabArray object used to specify the iteration space
  * \param ncomp the number of component
  * \param ts tile size, ignored by GPU build
- * \param f a calable object void(int,int,int,int,int), where the first argument
+ * \param f a callable object void(int,int,int,int,int), where the first argument
  *           is the local box index, the following three are spatial indices
  *           for x, y, and z-directions, and the last is for component.
  */
@@ -395,9 +395,9 @@ ParallelFor (MF const& mf, int ncomp, TileSize const& ts, F&& f)
 /**
  * \brief ParallelFor for MultiFab/FabArray.
  *
- * This version launch a kernel to work on the valid and ghost region.  If
+ * This version launches a kernel to work on the valid and ghost regions.  If
  * built for CPU, tiling will be enabled.  However, one could specify a huge
- * tile size to effectively disable tiling.  For GPU build, this function is
+ * tile size to effectively disable tiling.  For gpu builds, this function is
  * NON-BLOCKING on the host. Conceptually, this is a 5D loop.
  *
  * \tparam MF the MultiFab/FabArray type
@@ -407,7 +407,7 @@ ParallelFor (MF const& mf, int ncomp, TileSize const& ts, F&& f)
  * \param ng the number of ghost cells around the valid region
  * \param ncomp the number of component
  * \param ts tile size, ignored by GPU build
- * \param f a calable object void(int,int,int,int,int), where the first argument
+ * \param f a callable object void(int,int,int,int,int), where the first argument
  *           is the local box index, the following three are spatial indices
  *           for x, y, and z-directions, and the last is for component.
  */
@@ -423,7 +423,7 @@ ParallelFor (MF const& mf, IntVect const& ng, int ncomp, TileSize const& ts, F&&
  *
  * This version launches a kernel to work on the valid and ghost regions.  If
  * built for CPU, tiling will be enabled.  However, one could specify a huge
- * tile size to effectively disable tiling.  For GPU build, this function is
+ * tile size to effectively disable tiling.  For gpu builds, this function is
  * NON-BLOCKING on the host. Conceptually, this is a 5D loop.
  *
  * \tparam MT max threads in GPU blocks (Only relevant for GPU builds)
@@ -478,9 +478,9 @@ ParallelFor (MF const& mf, IntVect const& ng, TileSize const& ts, DynamicTiling 
 /**
  * \brief ParallelFor for MultiFab/FabArray.
  *
- * This version launch a kernel to work on the valid and ghost region.  If
+ * This version launches a kernel to work on the valid and ghost regions.  If
  * built for CPU, tiling will be enabled.  However, one could specify a huge
- * tile size to effectively disable tiling.  For GPU build, this function is
+ * tile size to effectively disable tiling.  For gpu builds, this function is
  * NON-BLOCKING on the host. Conceptually, this is a 5D loop.
  *
  * \tparam MF the MultiFab/FabArray type
@@ -506,7 +506,7 @@ ParallelFor (MF const& mf, IntVect const& ng, int ncomp, TileSize const& ts,
 /**
  * \brief ParallelFor for MultiFab/FabArray.
  *
- * This version launch a kernel to work on the valid and ghost region.  If
+ * This version launches a kernel to work on the valid and ghost regions.  If
  * built for CPU, tiling will be enabled.  However, one could specify a huge
  * tile size to effectively disable tiling.  For GPU builds, this function is
  * NON-BLOCKING on the host. Conceptually, this is a 4D loop.
@@ -519,7 +519,7 @@ ParallelFor (MF const& mf, IntVect const& ng, int ncomp, TileSize const& ts,
  * \param ng the number of ghost cells around the valid region
  * \param ts tile size, ignored by GPU build
  * \param dt controls dynamic tiling for the cpu build
- * \param f a calable object void(int,int,int,int), where the first argument
+ * \param f a callable object void(int,int,int,int), where the first argument
  *           is the local box index, and the following three are spatial indices
  *           for x, y, and z-directions.
  */
@@ -538,9 +538,9 @@ ParallelFor (MF const& mf, IntVect const& ng, TileSize const& ts,
 /**
  * \brief ParallelFor for MultiFab/FabArray.
  *
- * This version launch a kernel to work on the valid and ghost region.  If
+ * This version launches a kernel to work on the valid and ghost regions.  If
  * built for CPU, tiling will be enabled.  However, one could specify a huge
- * tile size to effectively disable tiling.  For GPU build, this function is
+ * tile size to effectively disable tiling.  For gpu builds, this function is
  * NON-BLOCKING on the host. Conceptually, this is a 5D loop.
  *
  * \tparam MT max threads in GPU blocks (Only relevant for GPU builds)
@@ -552,7 +552,7 @@ ParallelFor (MF const& mf, IntVect const& ng, TileSize const& ts,
  * \param ncomp the number of component
  * \param ts tile size, ignored by GPU build
  * \param dt controls dynamic tiling for the cpu build
- * \param f a calable object void(int,int,int,int,int), where the first argument
+ * \param f a callable object void(int,int,int,int,int), where the first argument
  *           is the local box index, the following three are spatial indices
  *           for x, y, and z-directions, and the last is for component.
  */

--- a/Src/Base/AMReX_MFParallelFor.H
+++ b/Src/Base/AMReX_MFParallelFor.H
@@ -434,7 +434,7 @@ ParallelFor (MF const& mf, IntVect const& ng, int ncomp, TileSize const& ts, F&&
  * \param ng the number of ghost cells around the valid region
  * \param ncomp the number of component
  * \param ts tile size, ignored by GPU build
- * \param f a calable object void(int,int,int,int,int), where the first argument
+ * \param f a callable object void(int,int,int,int,int), where the first argument
  *           is the local box index, the following three are spatial indices
  *           for x, y, and z-directions, and the last is for component.
  */

--- a/Src/Base/AMReX_MFParallelFor.H
+++ b/Src/Base/AMReX_MFParallelFor.H
@@ -452,7 +452,7 @@ ParallelFor (MF const& mf, IntVect const& ng, int ncomp, TileSize const& ts, F&&
 /**
  * \brief ParallelFor for MultiFab/FabArray.
  *
- * This version launch a kernel to work on the valid and ghost region.  If
+ * This version launches a kernel to work on the valid and ghost regions.  If
  * built for CPU, tiling will be enabled.  However, one could specify a huge
  * tile size to effectively disable tiling.  For GPU build, this function is
  * NON-BLOCKING on the host. Conceptually, this is a 4D loop.

--- a/Src/Base/AMReX_MFParallelFor.H
+++ b/Src/Base/AMReX_MFParallelFor.H
@@ -508,7 +508,7 @@ ParallelFor (MF const& mf, IntVect const& ng, int ncomp, TileSize const& ts,
  *
  * This version launch a kernel to work on the valid and ghost region.  If
  * built for CPU, tiling will be enabled.  However, one could specify a huge
- * tile size to effectively disable tiling.  For GPU build, this function is
+ * tile size to effectively disable tiling.  For GPU builds, this function is
  * NON-BLOCKING on the host. Conceptually, this is a 4D loop.
  *
  * \tparam MT max threads in GPU blocks (Only relevant for GPU builds)

--- a/Src/Base/AMReX_MFParallelFor.H
+++ b/Src/Base/AMReX_MFParallelFor.H
@@ -464,7 +464,7 @@ ParallelFor (MF const& mf, IntVect const& ng, int ncomp, TileSize const& ts, F&&
  * \param ng the number of ghost cells around the valid region
  * \param ts tile size, ignored by GPU build
  * \param dt controls dynamic tiling for the cpu build
- * \param f a calable object void(int,int,int,int), where the first argument
+ * \param f a callable object void(int,int,int,int), where the first argument
  *           is the local box index, and the following three are spatial indices
  *           for x, y, and z-directions.
  */

--- a/Src/Base/AMReX_MFParallelFor.H
+++ b/Src/Base/AMReX_MFParallelFor.H
@@ -491,7 +491,7 @@ ParallelFor (MF const& mf, IntVect const& ng, TileSize const& ts, DynamicTiling 
  * \param ncomp the number of component
  * \param ts tile size, ignored by GPU build
  * \param dt controls dynamic tiling for the cpu build
- * \param f a calable object void(int,int,int,int,int), where the first argument
+ * \param f a callable object void(int,int,int,int,int), where the first argument
  *           is the local box index, the following three are spatial indices
  *           for x, y, and z-directions, and the last is for component.
  */

--- a/Src/Base/AMReX_MFParallelFor.H
+++ b/Src/Base/AMReX_MFParallelFor.H
@@ -421,7 +421,7 @@ ParallelFor (MF const& mf, IntVect const& ng, int ncomp, TileSize const& ts, F&&
 /**
  * \brief ParallelFor for MultiFab/FabArray.
  *
- * This version launch a kernel to work on the valid and ghost region.  If
+ * This version launches a kernel to work on the valid and ghost regions.  If
  * built for CPU, tiling will be enabled.  However, one could specify a huge
  * tile size to effectively disable tiling.  For GPU build, this function is
  * NON-BLOCKING on the host. Conceptually, this is a 5D loop.

--- a/Src/Base/AMReX_MFParallelForC.H
+++ b/Src/Base/AMReX_MFParallelForC.H
@@ -12,12 +12,12 @@ namespace detail {
 
 template <typename MF, typename F>
 std::enable_if_t<IsFabArray<MF>::value>
-ParallelFor (MF const& mf, IntVect const& nghost, IntVect const& ts, F&& f)
+ParallelFor (MF const& mf, IntVect const& nghost, IntVect const& ts, bool dynamic, F&& f)
 {
 #ifdef AMREX_USE_OMP
 #pragma omp parallel
 #endif
-    for (MFIter mfi(mf,MFItInfo().EnableTiling(ts)); mfi.isValid(); ++mfi) {
+    for (MFIter mfi(mf,MFItInfo().EnableTiling(ts).SetDynamic(dynamic)); mfi.isValid(); ++mfi) {
         Box const& bx = mfi.growntilebox(nghost);
         int const lidx = mfi.LocalIndex();
         const auto lo = amrex::lbound(bx);
@@ -35,12 +35,12 @@ ParallelFor (MF const& mf, IntVect const& nghost, IntVect const& ts, F&& f)
 
 template <typename MF, typename F>
 std::enable_if_t<IsFabArray<MF>::value>
-ParallelFor (MF const& mf, IntVect const& nghost, int ncomp, IntVect const& ts, F&& f)
+ParallelFor (MF const& mf, IntVect const& nghost, int ncomp, IntVect const& ts, bool dynamic, F&& f)
 {
 #ifdef AMREX_USE_OMP
 #pragma omp parallel
 #endif
-    for (MFIter mfi(mf,MFItInfo().EnableTiling(ts)); mfi.isValid(); ++mfi) {
+    for (MFIter mfi(mf,MFItInfo().EnableTiling(ts).SetDynamic(dynamic)); mfi.isValid(); ++mfi) {
         Box const& bx = mfi.growntilebox(nghost);
         int const lidx = mfi.LocalIndex();
         const auto lo = amrex::lbound(bx);

--- a/Src/Base/AMReX_MFParallelForG.H
+++ b/Src/Base/AMReX_MFParallelForG.H
@@ -70,7 +70,7 @@ namespace parfor_mf_detail {
 
 template <int MT, typename MF, typename F>
 std::enable_if_t<IsFabArray<MF>::value>
-ParallelFor (MF const& mf, IntVect const& nghost, int ncomp, IntVect const&, F&& f)
+ParallelFor (MF const& mf, IntVect const& nghost, int ncomp, IntVect const&, bool, F&& f)
 {
     const auto& index_array = mf.IndexArray();
     const int nboxes = index_array.size();
@@ -146,16 +146,16 @@ ParallelFor (MF const& mf, IntVect const& nghost, int ncomp, IntVect const&, F&&
 
 template <typename MF, typename F>
 std::enable_if_t<IsFabArray<MF>::value>
-ParallelFor (MF const& mf, IntVect const& nghost, int ncomp, IntVect const& ts, F&& f)
+ParallelFor (MF const& mf, IntVect const& nghost, int ncomp, IntVect const& ts, bool dynamic, F&& f)
 {
-    ParallelFor<AMREX_GPU_MAX_THREADS>(mf, nghost, ncomp, ts, std::forward<F>(f));
+    ParallelFor<AMREX_GPU_MAX_THREADS>(mf, nghost, ncomp, ts, dynamic, std::forward<F>(f));
 }
 
 template <typename MF, typename F>
 std::enable_if_t<IsFabArray<MF>::value>
-ParallelFor (MF const& mf, IntVect const& nghost, IntVect const& ts, F&& f)
+ParallelFor (MF const& mf, IntVect const& nghost, IntVect const& ts, bool dynamic, F&& f)
 {
-    ParallelFor<AMREX_GPU_MAX_THREADS>(mf, nghost, 1, ts, std::forward<F>(f));
+    ParallelFor<AMREX_GPU_MAX_THREADS>(mf, nghost, 1, ts, dynamic, std::forward<F>(f));
 }
 
 }


### PR DESCRIPTION
Examples:

    experimental::ParallelFor(mf, nghost, TileSize{my_tile_size}, DynamicTiling{true}, [=] ...);

    experimental::ParallelFor(mf, nghost, ncomp, TileSize{my_tile_size}, DynamicTiling{true}, [=] ...);

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
