### PR TITLE
Shorten CI tests and Enable CNS in CI

### DIFF
--- a/.github/workflows/hip.yml
+++ b/.github/workflows/hip.yml
@@ -44,6 +44,29 @@ jobs:
             -DCMAKE_CXX_COMPILER=$(which clang++)         \
             -DCMAKE_CXX_STANDARD=17
         cmake --build build_nofortran -j 2
+
+  tests-hip-wrapper:
+    name: HIP ROCm GFortran@9.3 C++17 [tests-hipcc]
+    runs-on: ubuntu-20.04
+    # Have to have -Wno-deprecated-declarations due to deprecated atomicAddNoRet
+    # Have to have -Wno-gnu-zero-variadic-macro-arguments to avoid
+    #    amrex/Src/Base/AMReX_GpuLaunchGlobal.H:15:5: error: must specify at least one argument for '...' parameter of variadic macro [-Werror,-Wgnu-zero-variadic-macro-arguments]
+    #        __launch_bounds__(amrex_launch_bounds_max_threads)
+    #        ^
+    #    /opt/rocm-4.1.1/hip/include/hip/hcc_detail/hip_runtime.h:178:71: note: expanded from macro '__launch_bounds__'
+    #        select_impl_(__VA_ARGS__, launch_bounds_impl1, launch_bounds_impl0)(__VA_ARGS__)
+    #                                                                          ^
+    #    /opt/rocm-4.1.1/hip/include/hip/hcc_detail/hip_runtime.h:176:9: note: macro 'select_impl_' defined here
+    #    #define select_impl_(_1, _2, impl_, ...) impl_
+    env: {CXXFLAGS: "-fno-operator-names -Werror -Wall -Wextra -Wpedantic -Wnull-dereference -Wfloat-conversion -Wshadow -Woverloaded-virtual -Wextra-semi -Wunreachable-code -Wno-deprecated-declarations -Wno-gnu-zero-variadic-macro-arguments -Wno-pass-failed"}
+    steps:
+    - uses: actions/checkout@v2
+    - name: Dependencies
+      run: .github/workflows/dependencies/dependencies_hip.sh
+    - name: Build & Install
+      run: |
+        source /etc/profile.d/rocm.sh
+        hipcc --version
         cmake -S . -B build_full_legacywrapper            \
             -DCMAKE_VERBOSE_MAKEFILE=ON                   \
             -DAMReX_EB=OFF                                \

--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -73,4 +73,4 @@ jobs:
         source /opt/intel/oneapi/setvars.sh
         set -e
         cd build
-        ctest --output-on-failure -E CNS
+        ctest --output-on-failure

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -70,13 +70,14 @@ jobs:
         export PATH=/tmp/my-amrex/bin:$PATH
         which fcompare
 
-        ctest --output-on-failure -E CNS
+        ctest --output-on-failure
 
   # Build libamrex and all tests
   tests_build:
     name: GNU@7.5 C++14 Debug Fortran [tests]
     runs-on: ubuntu-18.04
-    env: {CXXFLAGS: "-fno-operator-names -Werror -Wall -Wextra -Wpedantic -Wnull-dereference -Wfloat-conversion -Wshadow -Woverloaded-virtual"}
+    env: {CXXFLAGS: "-fno-operator-names -Werror -Wall -Wextra -Wpedantic -Wnull-dereference -Wfloat-conversion -Wshadow -Woverloaded-virtual -O1"}
+      # It's too slow with -O0
     steps:
     - uses: actions/checkout@v2
     - name: Dependencies
@@ -94,7 +95,7 @@ jobs:
             -DAMReX_PARTICLES=ON
         make -j 2
 
-        ctest --output-on-failure -E "(CNS|Particles_GhostsAndVirtuals)"
+        ctest --output-on-failure -E Particles_GhostsAndVirtuals
 
   test_sensei:
     name: SENSEI Adaptor [test]
@@ -140,10 +141,14 @@ jobs:
         mkdir build
         cd build
         cmake ..                        \
-            -DCMAKE_BUILD_TYPE=Debug    \
+            -DCMAKE_BUILD_TYPE=RelWithDebInfo \
             -DCMAKE_VERBOSE_MAKEFILE=ON \
+            -DAMReX_ASSERTIONS=ON       \
+            -DAMReX_TESTING=ON          \
             -DAMReX_EB=OFF              \
             -DAMReX_ENABLE_TESTS=ON     \
+            -DAMReX_BOUND_CHECK=ON      \
+            -DAMReX_FPE=ON              \
             -DAMReX_FORTRAN=ON          \
             -DAMReX_OMP=ON              \
             -DAMReX_PARTICLES=ON        \
@@ -183,8 +188,7 @@ jobs:
             -DCMAKE_Fortran_COMPILER=$(which gfortran)
         make -j 2
 
-# TODO: Lots of failing RT tests, invalid particles, etc.
-#        ctest --output-on-failure -E CNS
+        ctest --output-on-failure -E Particles
 
   # Build libamrex and all tests w/o MPI
   tests-nonmpi:
@@ -200,8 +204,12 @@ jobs:
         mkdir build
         cd build
         cmake ..                        \
-            -DCMAKE_BUILD_TYPE=Debug    \
+            -DCMAKE_BUILD_TYPE=Release  \
             -DCMAKE_VERBOSE_MAKEFILE=ON \
+            -DAMReX_ASSERTIONS=ON       \
+            -DAMReX_TESTING=ON          \
+            -DAMReX_BOUND_CHECK=ON      \
+            -DAMReX_FPE=ON              \
             -DAMReX_EB=ON               \
             -DAMReX_ENABLE_TESTS=ON     \
             -DAMReX_FORTRAN=ON          \
@@ -209,7 +217,7 @@ jobs:
             -DAMReX_PARTICLES=ON
         make -j 2
 
-        ctest --output-on-failure -E "(CNS|Particles_GhostsAndVirtuals)"
+        ctest --output-on-failure -E Particles_GhostsAndVirtuals
 
   # Build libamrex and all tests
   tests-nofortran:
@@ -225,8 +233,12 @@ jobs:
         mkdir build
         cd build
         cmake ..                        \
-            -DCMAKE_BUILD_TYPE=Debug    \
+            -DCMAKE_BUILD_TYPE=RelWithDebINfo \
             -DCMAKE_VERBOSE_MAKEFILE=ON \
+            -DAMReX_ASSERTIONS=ON       \
+            -DAMReX_TESTING=ON          \
+            -DAMReX_BOUND_CHECK=ON      \
+            -DAMReX_FPE=ON              \
             -DAMReX_EB=ON               \
             -DAMReX_ENABLE_TESTS=ON     \
             -DAMReX_FORTRAN=OFF         \
@@ -234,7 +246,7 @@ jobs:
             -DAMReX_FORTRAN=OFF
         make -j 2
 
-        ctest --output-on-failure -E "(CNS|Particles_GhostsAndVirtuals)"
+        ctest --output-on-failure -E Particles_GhostsAndVirtuals
 
   # Build 1D libamrex with configure
   configure-1d:
@@ -341,4 +353,4 @@ jobs:
     - name: Run tests
       run: |
         cd build
-        ctest --output-on-failure -E CNS
+        ctest --output-on-failure

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -2,15 +2,13 @@ name: macos
 
 on: [push, pull_request]
 
-env:
-  # -Wno-range-loop-analysis: Apple clang has a bug in range-loop-analysis
-  CXXFLAGS: "-fno-operator-names -Werror -Wall -Wextra -Wpedantic -Wnull-dereference -Wfloat-conversion -Wshadow -Woverloaded-virtual -Wextra-semi -Wunreachable-code -Wno-c++17-extensions -Wno-range-loop-analysis"
-
 jobs:
   # Build libamrex and all tests
-  tests-macos:
-    name: AppleClang@11.0 GFortran@9.3 [tests]
+  tests-macos-eb:
+    name: AppleClang@11.0 GFortran@9.3 [tests-eb]
     runs-on: macos-latest
+    env: {CXXFLAGS: "-fno-operator-names -Werror -Wall -Wextra -Wpedantic -Wnull-dereference -Wfloat-conversion -Wshadow -Woverloaded-virtual -Wextra-semi -Wunreachable-code -Wno-c++17-extensions -Wno-range-loop-analysis -Wno-pass-failed"}
+      # -Wno-range-loop-analysis: Apple clang has a bug in range-loop-analysis
     steps:
     - uses: actions/checkout@v2
     - name: Dependencies
@@ -19,7 +17,7 @@ jobs:
       run: |
         cmake -S . -B build             \
             -DBUILD_SHARED_LIBS=ON      \
-            -DCMAKE_BUILD_TYPE=Debug    \
+            -DCMAKE_BUILD_TYPE=Release  \
             -DCMAKE_VERBOSE_MAKEFILE=ON \
             -DAMReX_EB=ON               \
             -DAMReX_ENABLE_TESTS=ON     \
@@ -28,10 +26,22 @@ jobs:
         cmake --build build --parallel 2
 
         cd build
-        ctest --output-on-failure -E "(CNS|Particles_GhostsAndVirtuals)"
+        ctest --output-on-failure -E Particles_GhostsAndVirtuals
         cd ..
 
-        rm -rf build
+  # Build libamrex and all tests
+  tests-macos:
+    name: AppleClang@11.0 GFortran@9.3 [tests]
+    runs-on: macos-latest
+    env: {CXXFLAGS: "-fno-operator-names -Werror -Wall -Wextra -Wpedantic -Wnull-dereference -Wfloat-conversion -Wshadow -Woverloaded-virtual -Wextra-semi -Wunreachable-code -Wno-c++17-extensions -Wno-range-loop-analysis -Wno-pass-failed -O1"}
+      # -Wno-range-loop-analysis: Apple clang has a bug in range-loop-analysis
+      # It's too slow with -O0
+    steps:
+    - uses: actions/checkout@v2
+    - name: Dependencies
+      run: .github/workflows/dependencies/dependencies_mac.sh
+    - name: Build & Install
+      run: |
         cmake -S . -B build             \
             -DCMAKE_BUILD_TYPE=Debug    \
             -DCMAKE_VERBOSE_MAKEFILE=ON \

--- a/Tests/Amr/Advection_AmrCore/CMakeLists.txt
+++ b/Tests/Amr/Advection_AmrCore/CMakeLists.txt
@@ -10,7 +10,7 @@ list(TRANSFORM _sources PREPEND Source/)
 list(APPEND _sources Exec/Prob.H)
 
 # List of input files
-set(_input_files inputs)
+set(_input_files inputs-ci)
 list(TRANSFORM _input_files PREPEND "Exec/")
 
 setup_test(_sources _input_files)

--- a/Tests/Amr/Advection_AmrCore/Exec/inputs-ci
+++ b/Tests/Amr/Advection_AmrCore/Exec/inputs-ci
@@ -1,0 +1,79 @@
+# *****************************************************************
+# Run until nsteps == max_step or time == stop_time, 
+#     whichever comes first
+# *****************************************************************
+max_step  = 20
+stop_time = 2.0
+
+# *****************************************************************
+# Are we restarting from an existing checkpoint file?
+# *****************************************************************
+#amr.restart  = chk00060 # restart from this checkpoint file
+
+# *****************************************************************
+# Problem size and geometry
+# *****************************************************************
+geometry.prob_lo     =  0.0  0.0  0.0 
+geometry.prob_hi     =  1.0  1.0  0.125
+geometry.is_periodic =  1    1    1
+
+# *****************************************************************
+# VERBOSITY
+# *****************************************************************
+amr.v              = 1       # verbosity in Amr
+
+# *****************************************************************
+# Resolution and refinement
+# *****************************************************************
+amr.n_cell          = 64 64 8
+amr.max_level       = 2       # maximum level number allowed -- 
+                              # number of levels = max_level + 1
+
+amr.ref_ratio       = 2 2 2 2 # refinement ratio between levels
+
+# *****************************************************************
+# Control of grid creation
+# *****************************************************************
+# Blocking factor for grid creation in each dimension --
+#   this ensures that every grid is coarsenable by a factor of 8 --
+#   this is mostly relevant for multigrid performance
+amr.blocking_factor_x = 8
+amr.blocking_factor_y = 8
+amr.blocking_factor_z = 8
+
+amr.max_grid_size   = 16
+
+amr.regrid_int      = 2       # how often to regrid
+
+# *****************************************************************
+# Time step control
+# *****************************************************************
+adv.cfl            = 0.7     # CFL constraint for explicit advection
+
+adv.do_subcycle    = 1       # Do we subcycle in time?
+
+# *****************************************************************
+# Should we reflux at coarse-fine boundaries?
+# *****************************************************************
+adv.do_reflux = 1
+
+# *****************************************************************
+# Tagging -  if phi > 1.01 at level 0, then refine 
+#            if phi > 1.1  at level 1, then refine 
+#            if phi > 1.5  at level 2, then refine 
+# *****************************************************************
+adv.phierr = 1.01  1.1  1.5
+
+# *****************************************************************
+# Plotfile name and frequency
+# *****************************************************************
+amr.plot_file  = plt    # root name of plot file
+amr.plot_int   = 100    # number of timesteps between plot files
+                        # if negative then no plot files will be written
+
+# *****************************************************************
+# Checkpoint name and frequency
+# *****************************************************************
+amr.chk_file = chk      # root name of checkpoint file
+amr.chk_int  = -1       # number of timesteps between checkpoint files
+                        # if negative then no checkpoint files will be written

--- a/Tests/Amr/Advection_AmrLevel/CMakeLists.txt
+++ b/Tests/Amr/Advection_AmrLevel/CMakeLists.txt
@@ -36,7 +36,7 @@ set(_sv_sources face_velocity_${AMReX_SPACEDIM}d.f90  Prob.f90)
 list(TRANSFORM _sv_sources PREPEND ${_sv_exe_dir})
 list(APPEND _sv_sources ${_sources})
 
-set(_input_files inputs.tracers probin)
+set(_input_files inputs-ci probin)
 list(TRANSFORM _input_files PREPEND ${_sv_exe_dir})
 
 setup_test(_sv_sources _input_files
@@ -59,7 +59,7 @@ set(_uv_sources face_velocity_${AMReX_SPACEDIM}d.f90  Prob.f90 probdata.f90)
 list(TRANSFORM _uv_sources PREPEND ${_uv_exe_dir})
 list(APPEND _uv_sources ${_sources})
 
-set(_input_files inputs inputs.regt probin)
+set(_input_files inputs-ci probin)
 list(TRANSFORM _input_files PREPEND ${_uv_exe_dir})
 
 setup_test(_uv_sources _input_files

--- a/Tests/Amr/Advection_AmrLevel/Exec/SingleVortex/inputs-ci
+++ b/Tests/Amr/Advection_AmrLevel/Exec/SingleVortex/inputs-ci
@@ -1,0 +1,47 @@
+# ------------------  INPUTS TO MAIN PROGRAM  -------------------
+max_step = 20
+stop_time = 2.0
+
+# PROBLEM SIZE & GEOMETRY
+geometry.is_periodic =  1  1  1
+geometry.coord_sys   =  0       # 0 => cart
+geometry.prob_lo     =  0.0  0.0  0.0 
+geometry.prob_hi     =  1.0  1.0  1.0
+amr.n_cell           =  64   64   64
+
+# TIME STEP CONTROL
+adv.cfl            = 0.7     # cfl number for hyperbolic system
+                             # In this test problem, the velocity is
+			     # time-dependent.  We could use 0.9 in
+			     # the 3D test, but need to use 0.7 in 2D
+			     # to satisfy CFL condition.
+# VERBOSITY
+adv.v              = 1       # verbosity in Adv
+amr.v              = 1       # verbosity in Amr
+#amr.grid_log         = grdlog  # name of grid logging file
+
+# REFINEMENT / REGRIDDING
+amr.max_level       = 2       # maximum level number allowed
+amr.ref_ratio       = 2 2 2 2 # refinement ratio
+amr.regrid_int      = 2       # how often to regrid
+amr.blocking_factor = 8       # block factor in grid generation
+amr.max_grid_size   = 16
+
+# CHECKPOINT FILES
+amr.checkpoint_files_output = 0     # 0 will disable checkpoint files
+amr.check_file              = chk   # root name of checkpoint file
+amr.check_int               = 10    # number of timesteps between checkpoints
+
+# PLOTFILES
+amr.plot_files_output = 1      # 0 will disable plot files
+amr.plot_file         = plt    # root name of plot file
+amr.plot_int          = 100    # number of timesteps between plot files
+
+# PROBIN FILENAME
+amr.probin_file = probin
+
+# TRACER PARTICLES
+adv.do_tracers = 1
+
+particles.do_tiling = true
+particles.tile_size = 1024000 4 4

--- a/Tests/Amr/Advection_AmrLevel/Exec/UniformVelocity/inputs-ci
+++ b/Tests/Amr/Advection_AmrLevel/Exec/UniformVelocity/inputs-ci
@@ -1,0 +1,41 @@
+# ------------------  INPUTS TO MAIN PROGRAM  -------------------
+max_step = 100
+stop_time = 2.0
+
+# PROBLEM SIZE & GEOMETRY
+geometry.is_periodic =  1  1  1
+geometry.coord_sys   =  0       # 0 => cart
+geometry.prob_lo     = -1.0 -1.0 -1.0 
+geometry.prob_hi     =  1.0  1.0  1.0
+amr.n_cell           =  64   64   64
+
+# TIME STEP CONTROL
+adv.cfl            = 0.9     # cfl number for hyperbolic system
+
+# VERBOSITY
+adv.v              = 1       # verbosity in Adv
+amr.v              = 1       # verbosity in Amr
+#amr.grid_log         = grdlog  # name of grid logging file
+
+# REFINEMENT / REGRIDDING
+amr.max_level       = 2       # maximum level number allowed
+amr.ref_ratio       = 2 2 2 2 # refinement ratio
+amr.regrid_int      = 2       # how often to regrid
+amr.blocking_factor = 8       # block factor in grid generation
+amr.max_grid_size   = 16
+
+# CHECKPOINT FILES
+amr.checkpoint_files_output = 0     # 0 will disable checkpoint files
+amr.check_file              = chk   # root name of checkpoint file
+amr.check_int               = 10    # number of timesteps between checkpoints
+
+# PLOTFILES
+amr.plot_files_output = 1      # 0 will disable plot files
+amr.plot_file         = plt    # root name of plot file
+amr.plot_int          = 10     # number of timesteps between plot files
+
+# PROBIN FILENAME
+amr.probin_file = probin
+
+# TRACER PARTICLES
+adv.do_tracers = 0

--- a/Tests/EB/CNS/CMakeLists.txt
+++ b/Tests/EB/CNS/CMakeLists.txt
@@ -2,14 +2,6 @@ if (NOT (AMReX_SPACEDIM EQUAL 3) OR NOT CMAKE_Fortran_COMPILER_LOADED)
    return()
 endif ()
 
-#
-# This directory contains 4 tutorials
-#
-#  * Combustor
-#  * Pulse
-#  * ShockRef
-#  * Sod
-#
 
 set(_sources main.cpp CNS_advance.cpp CNSBld.cpp CNS.cpp CNS_F.H CNS.H CNS_init_eb2.cpp CNS_io.cpp
    CNS_setup.cpp )
@@ -33,65 +25,13 @@ unset(_fortran_sources)
 unset(_hydro_sources)
 
 
-
-##########################################################################################
-#
-# Combustor tutorial
-#
-##########################################################################################
-set(_combustor_sources Exec/Combustor/cns_prob.F90 ${_sources})
-set(_input_files Exec/Combustor/inputs Exec/Combustor/inputs.regt)
-
-setup_test(_combustor_sources _input_files
-   HAS_FORTRAN_MODULES
-   BASE_NAME CNS_Combustor
-   RUNTIME_SUBDIR Combustor)
-
-unset(_combustor_sources)
-
-
-
-##########################################################################################
-#
-# Pulse tutorial
-#
-##########################################################################################
-set(_pulse_sources Exec/Pulse/cns_prob.F90 ${_sources})
-set(_input_files Exec/Pulse/inputs Exec/Pulse/inputs.regt)
-
-setup_test(_pulse_sources _input_files
-   HAS_FORTRAN_MODULES
-   BASE_NAME CNS_Pulse
-   RUNTIME_SUBDIR Pulse)
-
-unset(_pulse_sources)
-
-
-
-##########################################################################################
-#
-# ShockRef tutorial
-#
-##########################################################################################
-set(_shockref_sources Exec/ShockRef/cns_prob.F90 ${_sources})
-set(_input_files Exec/ShockRef/inputs Exec/ShockRef/inputs.regt Exec/ShockRef/inputs.amr)
-
-setup_test(_shockref_sources _input_files
-   HAS_FORTRAN_MODULES
-   BASE_NAME CNS_ShockRef
-   RUNTIME_SUBDIR ShockRef)
-
-unset(_shockref_sources)
-
-
-
 ##########################################################################################
 #
 # Sod tutorial
 #
 ##########################################################################################
 set(_sod_sources Exec/Sod/cns_prob.F90 ${_sources})
-set(_input_files Exec/Sod/inputs)
+set(_input_files Exec/Sod/inputs-ci)
 
 setup_test(_sod_sources _input_files
    HAS_FORTRAN_MODULES

--- a/Tests/EB/CNS/Exec/Sod/inputs-ci
+++ b/Tests/EB/CNS/Exec/Sod/inputs-ci
@@ -1,0 +1,110 @@
+amrex.fpe_trap_invalid=1
+
+max_step  = 10
+stop_time = 0.2
+
+geometry.is_periodic = 0 0 0
+geometry.coord_sys   = 0  # 0 => cart, 1 => RZ  2=>spherical
+geometry.prob_lo     =   0.0     0.0     0.0
+geometry.prob_hi     =   1.0     1.0     1.0
+amr.n_cell           =    64      64      64
+
+# >>>>>>>>>>>>>  BC FLAGS <<<<<<<<<<<<<<<<
+# 0 = Interior           3 = Symmetry
+# 1 = Inflow             4 = SlipWall
+# 2 = Outflow            5 = NoSlipWall
+# >>>>>>>>>>>>>  BC FLAGS <<<<<<<<<<<<<<<<
+cns.lo_bc       =  2   5   5
+cns.hi_bc       =  2   5   5
+
+cns.cfl = 0.3  # cfl number for hyperbolic system
+
+cns.v = 2
+amr.v = 1
+
+# LOAD BALANCE
+amr.loadbalance_with_workestimates = 1
+amr.loadbalance_level0_int = 1000
+
+# REFINEMENT / REGRIDDING 
+amr.max_level       = 1       # maximum level number allowed
+amr.ref_ratio       = 2 2 2 2 # refinement ratio
+amr.regrid_int      = 2 2 2 2 # how often to regrid
+amr.blocking_factor = 8
+amr.max_grid_size   = 16
+amr.n_error_buf     = 0 0 0 0 # number of buffer cells in error est
+amr.grid_eff        = 0.99     # what constitutes an efficient grid
+
+# CHECKPOINT FILES
+amr.checkpoint_files_output = 0
+amr.check_file              = chk    # root name of checkpoint file
+amr.check_int               = 100    # number of timesteps between checkpoints
+
+# PLOTFILES
+amr.plot_files_output = 1
+amr.plot_file         = plt     # root name of plotfile
+amr.plot_int          = 10      # number of timesteps between plotfiles
+amr.derive_plot_vars  = pressure x_velocity y_velocity z_velocity
+
+# EB
+eb2.sphere_radius = 0.125
+#eb2.sphere_center = 0.45  0.65  0.54
+#eb2.sphere_center = 0.5  0.5  0.5
+eb2.sphere_center = 0.7 0.5 0.5
+eb2.sphere_has_fluid_inside = 0
+
+eb2.geom_type = sphere
+#eb2.geom_type = all_regular
+
+cns.refine_cutcells = 0
+
+# case 1: a single box at the top y-boundary
+#cns.refine_box_lo_0 = 0.45 0.90 0.45
+#cns.refine_box_hi_0 = 0.55 0.92 0.55
+
+# case 2: two boxes, one at the top, the other at the bottom
+cns.refine_box_lo_0 = 0.45 0.85 0.45
+cns.refine_box_hi_0 = 0.55 0.99 0.55
+
+# case 3: similar to case 2, but the bottom box is wider
+#cns.refine_box_lo_0 = 0.45 0.85 0.45
+#cns.refine_box_hi_0 = 0.55 0.99 0.55
+#
+#cns.refine_box_lo_1 = 0.45 0.08 0.35
+#cns.refine_box_hi_1 = 0.55 0.10 0.65
+
+# case 4: at the corner
+#cns.refine_box_lo_0 = 0.85 0.85 0.85
+#cns.refine_box_hi_0 = 0.99 0.99 0.99
+
+# case 5 : very wide box
+#cns.refine_box_lo_0 = 0.0 0.90 0.0
+#cns.refine_box_hi_0 = 1.0 0.92 1.0
+
+# case 6 : a box at the center
+cns.refine_box_lo_0 = 0.48 0.48 0.48
+cns.refine_box_hi_0 = 0.52 0.52 0.52
+amr.blocking_factor = 16
+amr.max_grid_size   = 64
+
+# case 7 : refine everywhere
+#cns.refine_box_lo_0 = 0. 0. 0.
+#cns.refine_box_hi_0 = 1. 1. 1.
+#geometry.is_periodic = 0 0 0
+#cns.lo_bc       =  2   2   2
+#cns.hi_bc       =  2   2   2
+
+#
+cns.refine_box_lo_0 = 0.55 0.5  0.3
+cns.refine_box_hi_0 = 0.85 0.65 0.7
+amr.blocking_factor = 16
+amr.max_grid_size   = 64
+
+# problem specific parameter
+prob.p_l   = 1.0 
+prob.p_r   = 0.1
+prob.rho_l = 1.0
+prob.rho_r = 0.125
+prob.u_l   = 0.0
+prob.u_r   = 0.0
+

--- a/Tests/EB_CNS/CMakeLists.txt
+++ b/Tests/EB_CNS/CMakeLists.txt
@@ -1,11 +1,3 @@
-#
-# This directory contains 4 tutorials
-#
-#  * Combustor
-#  * Pulse
-#  * ShockRef
-#  * Sod
-#
 
 set(_sources main.cpp CNS_advance.cpp CNS_advance_box.cpp CNS_advance_box_eb.cpp CNS_bcfill.cpp
    CNSBld.cpp CNS.cpp CNS.H CNS_derive.cpp CNS_derive.H CNS_index_macros.H CNS_init_eb2.cpp CNS_io.cpp
@@ -31,65 +23,13 @@ unset(_hydro_sources)
 set(_combustor_sources Exec/Combustor/cns_prob.H  Exec/Combustor/cns_prob.cpp
                        Exec/Combustor/cns_prob_parm.H  Exec/Combustor/cns_prob_parm.cpp
                        Exec/Combustor/CNS_bcfill.cpp ${_sources})
-set(_input_files Exec/Combustor/inputs Exec/Combustor/inputs.regt)
+set(_input_files Exec/Combustor/inputs Exec/Combustor/inputs-ci)
 
 setup_test(_combustor_sources _input_files
    BASE_NAME CNS_Combustor
    RUNTIME_SUBDIR Combustor)
 
 unset(_combustor_sources)
-
-
-
-##########################################################################################
-#
-# Pulse tutorial
-#
-##########################################################################################
-set(_pulse_sources Exec/Pulse/cns_prob.H Exec/Pulse/cns_prob.cpp
-                   Exec/Pulse/cns_prob_parm.H ${_sources})
-set(_input_files Exec/Pulse/inputs Exec/Pulse/inputs.regt)
-
-setup_test(_pulse_sources _input_files
-   BASE_NAME CNS_Pulse
-   RUNTIME_SUBDIR Pulse)
-
-unset(_pulse_sources)
-
-
-
-##########################################################################################
-#
-# ShockRef tutorial
-#
-##########################################################################################
-set(_pulse_sources Exec/ShockRef/cns_prob.H Exec/ShockRef/cns_prob.cpp
-                   Exec/ShockRef/cns_prob_parm.H ${_sources})
-set(_input_files Exec/ShockRef/inputs Exec/ShockRef/inputs.regt Exec/ShockRef/inputs.amr)
-
-setup_test(_shockref_sources _input_files
-   BASE_NAME CNS_ShockRef
-   RUNTIME_SUBDIR ShockRef)
-
-unset(_shockref_sources)
-
-
-
-##########################################################################################
-#
-# Sod tutorial
-#
-##########################################################################################
-set(_pulse_sources Exec/Sod/cns_prob.H Exec/Sod/cns_prob.cpp
-                   Exec/Sod/cns_prob_parm.H ${_sources})
-set(_input_files Exec/Sod/inputs)
-
-setup_test(_sod_sources _input_files
-   BASE_NAME CNS_Sod
-   RUNTIME_SUBDIR Sod)
-
-unset(_sod_sources)
-
 
 #
 # Clean-up

--- a/Tests/EB_CNS/Exec/Combustor/inputs-ci
+++ b/Tests/EB_CNS/Exec/Combustor/inputs-ci
@@ -1,0 +1,65 @@
+
+max_step = 25
+stop_time =  0.2
+
+geometry.is_periodic = 0 0 0
+geometry.coord_sys   = 0  # 0 => cart, 1 => RZ  2=>spherical
+geometry.prob_lo     =  0      0      0
+geometry.prob_hi     =  5.0   5.0    5.0
+amr.n_cell           =  64    64     64
+
+# >>>>>>>>>>>>>  BC FLAGS <<<<<<<<<<<<<<<<
+# 0 = Interior           3 = Symmetry
+# 1 = Inflow             4 = SlipWall
+# 2 = Outflow            5 = NoSlipWall
+# >>>>>>>>>>>>>  BC FLAGS <<<<<<<<<<<<<<<<
+cns.lo_bc       =  5 5 1 
+cns.hi_bc       =  5 5 2 
+
+cns.cfl = 0.3     # cfl number for hyperbolic system
+
+cns.v = 1
+amr.v = 1
+
+# LOAD BALANCE
+amr.loadbalance_with_workestimates = 1
+amr.loadbalance_level0_int = 1000
+
+# REFINEMENT / REGRIDDING
+amr.max_level       = 0       # maximum level number allowed
+amr.ref_ratio       = 2 2 2 2 # refinement ratio
+amr.regrid_int      = 2 2 2 2 # how often to regrid
+amr.blocking_factor = 16
+amr.max_grid_size   = 64
+amr.n_error_buf     = 2 2 2 2 # number of buffer cells in error est
+
+# CHECKPOINT FILES
+amr.checkpoint_files_output = 0
+amr.check_file      = chk        # root name of checkpoint file
+amr.check_int       = 10         # number of timesteps between checkpoints
+
+# PLOTFILES
+amr.plot_files_output = 1
+amr.plot_file         = plt      # root name of plotfile
+amr.plot_int          = 50       # number of timesteps between plotfiles
+amr.derive_plot_vars  = pressure x_velocity y_velocity z_velocity
+
+
+#this is for the JBB combustor
+eb2.geom_type = "combustor" 
+
+#Far wall location in x 
+combustor.far_wall_loc = 2.25
+
+#Ramp construct
+# Plane 1: horizontal
+# Plane 2: slope
+# plane 3: vertical
+combustor.ramp_plane1_point = 1.25 3.75
+combustor.ramp_plane2_point = 1.25 3.75
+combustor.ramp_plane2_normal = 3.45 -0.95
+combustor.ramp_plane3_point = 0.5 0.
+
+#pipe construct
+combustor.pipe_lo = 0.3 -5.0
+combustor.pipe_hi = 0.5 2.5

--- a/Tests/GPU/CNS/CMakeLists.txt
+++ b/Tests/GPU/CNS/CMakeLists.txt
@@ -2,12 +2,6 @@ if (NOT AMReX_SPACEDIM EQUAL 3)
    return()
 endif ()
 
-#
-# This directory contains 2 tutorials
-#
-#  * RT
-#  * Sod
-#
 set(_sources main.cpp CNS_advance.cpp CNS_bcfill.cpp CNSBld.cpp CNS.cpp CNS_derive.cpp CNS_derive.H CNS.H
    CNS_index_macros.H CNS_io.cpp CNS_K.H CNS_parm.cpp CNS_parm.H CNS_setup.cpp CNS_tagging.H
    hydro/CNS_hydro_K.H diffusion/CNS_diffusion_K.H)
@@ -15,26 +9,11 @@ list(TRANSFORM _sources PREPEND Source/)
 
 ##########################################################################################
 #
-# RT tutorial
-#
-##########################################################################################
-set(_rt_sources Exec/RT/cns_prob.cpp Exec/RT/cns_prob.H Exec/RT/cns_prob_parm.H ${_sources})
-set(_input_files Exec/RT/inputs-rt)
-
-setup_test(_rt_sources _input_files
-   BASE_NAME GPU_CNS_RT
-   RUNTIME_SUBDIR RT)
-
-unset(_rt_sources)
-
-
-##########################################################################################
-#
 # Sod tutorial
 #
 ##########################################################################################
 set(_sod_sources Exec/Sod/cns_prob.cpp Exec/Sod/cns_prob.H Exec/Sod/cns_prob_parm.H ${_sources})
-set(_input_files Exec/Sod/inputs-rt)
+set(_input_files Exec/Sod/inputs-ci)
 
 setup_test(_sod_sources _input_files
    BASE_NAME GPU_CNS_Sod

--- a/Tests/GPU/CNS/Exec/Sod/inputs-ci
+++ b/Tests/GPU/CNS/Exec/Sod/inputs-ci
@@ -1,0 +1,53 @@
+amrex.fpe_trap_invalid=1
+
+max_step  = 20
+stop_time = 0.2
+
+geometry.is_periodic = 0 1 1
+geometry.coord_sys   = 0  # 0 => cart, 1 => RZ  2=>spherical
+geometry.prob_lo     =   0.0     0.0     0.0
+geometry.prob_hi     =   1.0     1.0     1.0
+amr.n_cell           =    64      64      64
+
+# >>>>>>>>>>>>>  BC FLAGS <<<<<<<<<<<<<<<<
+# 0 = Interior           3 = Symmetry
+# 1 = Inflow             4 = SlipWall
+# 2 = Outflow            5 = NoSlipWall
+# >>>>>>>>>>>>>  BC FLAGS <<<<<<<<<<<<<<<<
+cns.lo_bc       =  2   0   0
+cns.hi_bc       =  2   0   0
+
+cns.cfl = 0.3  # cfl number for hyperbolic system
+
+cns.do_visc = false
+
+cns.v = 2
+amr.v = 1
+
+# REFINEMENT / REGRIDDING 
+amr.max_level       = 0       # maximum level number allowed
+amr.ref_ratio       = 2 2 2 2 # refinement ratio
+amr.regrid_int      = 2 2 2 2 # how often to regrid
+amr.blocking_factor = 16
+amr.max_grid_size   = 32
+amr.n_error_buf     = 0 0 0 0 # number of buffer cells in error est
+amr.grid_eff        = 0.99     # what constitutes an efficient grid
+
+# CHECKPOINT FILES
+amr.checkpoint_files_output = 0
+amr.check_file              = chk    # root name of checkpoint file
+amr.check_int               = 100    # number of timesteps between checkpoints
+
+# PLOTFILES
+amr.plot_files_output = 0
+amr.plot_file         = plt     # root name of plotfile
+amr.plot_int          = 10      # number of timesteps between plotfiles
+amr.derive_plot_vars  = pressure velocity
+
+# problem specific parameter
+prob.p_l   = 1.0 
+prob.p_r   = 0.1
+prob.rho_l = 1.0
+prob.rho_r = 0.125
+prob.u_l   = 0.0
+prob.u_r   = 0.0

--- a/Tests/LinearSolvers/NodalPoisson/CMakeLists.txt
+++ b/Tests/LinearSolvers/NodalPoisson/CMakeLists.txt
@@ -1,6 +1,6 @@
 set(_sources main.cpp MyTest.cpp MyTest.H MyTestPlotfile.cpp)
 
-file( GLOB_RECURSE _input_files LIST_DIRECTORIES false ${CMAKE_CURRENT_LIST_DIR}/input*)
+set(_input_files inputs-ci)
 
 setup_test(_sources _input_files)
 

--- a/Tests/LinearSolvers/NodalPoisson/inputs-ci
+++ b/Tests/LinearSolvers/NodalPoisson/inputs-ci
@@ -1,0 +1,14 @@
+
+max_level = 1
+ref_ratio = 2
+n_cell = 64
+max_grid_size = 32
+
+composite_solve = 1   # composite solve or level by level?
+
+# For MLMG
+verbose = 2
+bottom_verbose = 0
+max_iter = 100
+max_fmg_iter = 0     # # of F-cycles before switching to V.  To do pure V-cycle, set to 0
+reltol = 1.e-11


### PR DESCRIPTION
* Split macos ci tests into two checks
* Split hip ci tests
* Change some build types from Debug to RelWithDebInfo
* Enable Assertions and FPE in some tests
* Add some inputs for ci
* Enable CNS in CI

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
