### PR TITLE
Fix Mixed Precision Particle CI Tests

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -163,7 +163,8 @@ jobs:
   tests_clang:
     name: Clang@6.0 C++14 SP Particles DP Mesh Debug [tests]
     runs-on: ubuntu-18.04
-    env: {CXXFLAGS: "-fno-operator-names -Werror -Wall -Wextra -Wpedantic -Wnull-dereference -Wfloat-conversion -Wshadow -Woverloaded-virtual -Wextra-semi -Wunreachable-code -Wno-c++17-extensions"}
+    env: {CXXFLAGS: "-fno-operator-names -Werror -Wall -Wextra -Wpedantic -Wnull-dereference -Wfloat-conversion -Wshadow -Woverloaded-virtual -Wextra-semi -Wunreachable-code -Wno-c++17-extensions -O1"}
+      # It's too slow with -O0
     steps:
     - uses: actions/checkout@v2
     - name: Dependencies
@@ -188,7 +189,7 @@ jobs:
             -DCMAKE_Fortran_COMPILER=$(which gfortran)
         make -j 2
 
-        ctest --output-on-failure -E Particles
+        ctest --output-on-failure -E GhostsAndVirtuals
 
   # Build libamrex and all tests w/o MPI
   tests-nonmpi:

--- a/Src/AmrCore/AMReX_MFInterp_1D_C.H
+++ b/Src/AmrCore/AMReX_MFInterp_1D_C.H
@@ -33,7 +33,7 @@ void mf_cell_cons_lin_interp_llslope (int i, int, int, Array4<Real> const& slope
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 void mf_cell_cons_lin_interp_mcslope (int i, int /*j*/, int /*k*/, int ns,
                                       Array4<Real> const& slope,
-                                      Array4<Real const> const& u, int scomp, int ncomp,
+                                      Array4<Real const> const& u, int scomp, int /*ncomp*/,
                                       Box const& domain, IntVect const& ratio,
                                       BCRec const* bc) noexcept
 {
@@ -70,7 +70,7 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 void mf_cell_cons_lin_interp (int i, int /*j*/, int /*k*/, int ns,
                               Array4<Real> const& fine, int fcomp,
                               Array4<Real const> const& slope, Array4<Real const> const& crse,
-                              int ccomp, int ncomp, IntVect const& ratio) noexcept
+                              int ccomp, int /*ncomp*/, IntVect const& ratio) noexcept
 {
     const int ic = amrex::coarsen(i, ratio[0]);
     const Real xoff = (i - ic*ratio[0] + Real(0.5)) / Real(ratio[0]) - Real(0.5);
@@ -80,7 +80,7 @@ void mf_cell_cons_lin_interp (int i, int /*j*/, int /*k*/, int ns,
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 void mf_cell_cons_lin_interp_mcslope_sph (int i, int ns, Array4<Real> const& slope,
-                                          Array4<Real const> const& u, int scomp, int ncomp,
+                                          Array4<Real const> const& u, int scomp, int /*ncomp*/,
                                           Box const& domain, IntVect const& ratio,
                                           BCRec const* bc, Real drf, Real rlo) noexcept
 {
@@ -132,7 +132,7 @@ void mf_cell_cons_lin_interp_mcslope_sph (int i, int ns, Array4<Real> const& slo
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 void mf_cell_cons_lin_interp_sph (int i, int ns, Array4<Real> const& fine, int fcomp,
                                   Array4<Real const> const& slope, Array4<Real const> const& crse,
-                                  int ccomp, int ncomp, IntVect const& ratio, Real drf, Real rlo) noexcept
+                                  int ccomp, int /*ncomp*/, IntVect const& ratio, Real drf, Real rlo) noexcept
 {
     const int ic = amrex::coarsen(i, ratio[0]);
     const Real drc =  drf * ratio[0];

--- a/Src/Particle/AMReX_ParticleInit.H
+++ b/Src/Particle/AMReX_ParticleInit.H
@@ -1004,7 +1004,7 @@ InitRandom (Long                    icount,
                         r = amrex::Random();
                         x = geom.ProbLo(i) + (r * len[i]);
                     }
-                    while (x < xlo[i] || x > xhi[i]);
+                    while (static_cast<ParticleReal>(x) < static_cast<ParticleReal>(xlo[i]) || static_cast<ParticleReal>(x) >= static_cast<ParticleReal>(xhi[i]));
 
                     pos[j*AMREX_SPACEDIM + i] = static_cast<ParticleReal>(x);
                 }
@@ -1021,7 +1021,7 @@ InitRandom (Long                    icount,
         host_particles.reserve(15);
         host_particles.resize(finestLevel()+1);
 
-        Vector<std::map<std::pair<int, int>, std::array<Gpu::HostVector<Real>, NArrayReal > > > host_real_attribs;
+        Vector<std::map<std::pair<int, int>, std::array<Gpu::HostVector<ParticleReal>, NArrayReal > > > host_real_attribs;
         host_real_attribs.reserve(15);
         host_real_attribs.resize(finestLevel()+1);
 
@@ -1065,7 +1065,7 @@ InitRandom (Long                    icount,
 
                 // add the real...
                 for (int i = 0; i < NArrayReal; i++) {
-                    host_real_attribs[pld.m_lev][ind][i].push_back(pdata.real_array_data[i]);
+                    host_real_attribs[pld.m_lev][ind][i].push_back(static_cast<ParticleReal>(pdata.real_array_data[i]));
                 }
 
                 // ... and int array data
@@ -1125,7 +1125,7 @@ InitRandom (Long                    icount,
         host_particles.reserve(15);
         host_particles.resize(finestLevel()+1);
 
-        Vector<std::map<std::pair<int, int>, std::array<Gpu::HostVector<Real>, NArrayReal > > > host_real_attribs;
+        Vector<std::map<std::pair<int, int>, std::array<Gpu::HostVector<ParticleReal>, NArrayReal > > > host_real_attribs;
         host_real_attribs.reserve(15);
         host_real_attribs.resize(finestLevel()+1);
 
@@ -1140,7 +1140,7 @@ InitRandom (Long                    icount,
                     r = amrex::Random();
                     x = geom.ProbLo(i) + (r * len[i]);
                 }
-                while (x < xlo[i] || x > xhi[i]);
+                while (static_cast<ParticleReal>(x) < static_cast<ParticleReal>(xlo[i]) || static_cast<ParticleReal>(x) >= static_cast<ParticleReal>(xhi[i]));
 
                 p.pos(i) = static_cast<ParticleReal>(x);
 
@@ -1172,7 +1172,7 @@ InitRandom (Long                    icount,
 
             // add the real...
             for (int i = 0; i < NArrayReal; i++) {
-                host_real_attribs[pld.m_lev][ind][i].push_back(pdata.real_array_data[i]);
+                host_real_attribs[pld.m_lev][ind][i].push_back(static_cast<ParticleReal>(pdata.real_array_data[i]));
             }
 
             // ... and int array data

--- a/Tests/Particles/AssignDensity/main.cpp
+++ b/Tests/Particles/AssignDensity/main.cpp
@@ -63,7 +63,7 @@ void test_assign_density(TestParams& parms)
 
   bool serialize = true;
   int iseed = 451;
-  Real mass = 10.0;
+  double mass = 10.0;
 
   MyParticleContainer::ParticleInitData pdata = {{mass, AMREX_D_DECL(1.0, 2.0, 3.0)}, {}, {}, {}};
   myPC.InitRandom(num_particles, iseed, pdata, serialize);

--- a/Tests/Particles/AssignMultiLevelDensity/main.cpp
+++ b/Tests/Particles/AssignMultiLevelDensity/main.cpp
@@ -96,7 +96,7 @@ void test_assign_density(TestParams& parms)
     int num_particles = parms.nppc * AMREX_D_TERM(parms.nx, * parms.ny, * parms.nz);
     bool serialize = true;
     int iseed = 451;
-    Real mass = 10.0;
+    double mass = 10.0;
     MyParticleContainer::ParticleInitData pdata = {{mass},{},{},{}};
 
     //    myPC.InitRandom(num_particles, iseed, pdata, serialize, fine_box);

--- a/Tests/Particles/GhostsAndVirtuals/main.cpp
+++ b/Tests/Particles/GhostsAndVirtuals/main.cpp
@@ -90,7 +90,7 @@ void test_ghosts_and_virtuals (TestParams& parms)
     int num_particles = parms.nppc * AMREX_D_TERM(parms.nx, * parms.ny, * parms.nz);
     bool serialize = true;
     int iseed = 451;
-    Real mass = 10.0;
+    double mass = 10.0;
     MyParticleContainer::ParticleInitData pdata = {{mass}, {}, {}, {}};
 
     myPC.InitRandom(num_particles, iseed, pdata, serialize);
@@ -420,8 +420,8 @@ void test_ghosts_and_virtuals_randomperbox (TestParams& parms)
 
     int num_particles = parms.nppc;
     int iseed = 451;
-    Real mass = 10.0;
-    Real xvel, yvel, zvel;
+    double mass = 10.0;
+    double xvel, yvel, zvel;
     Real total_virts_test = 0.0;
     Real tol = 1e-4;
     xvel = 1.0;
@@ -611,8 +611,8 @@ void test_ghosts_and_virtuals_onepercell (TestParams& parms)
     MyParticleContainer myPC(geom, dmap, ba, rr);
     myPC.SetVerbose(false);
 
-    Real mass = 10.0;
-    Real xvel, yvel, zvel;
+    double mass = 10.0;
+    double xvel, yvel, zvel;
     Real xoff, yoff, zoff;
     xvel = 1.0;
     yvel = 2.0;

--- a/Tests/Particles/ParallelContext/main.cpp
+++ b/Tests/Particles/ParallelContext/main.cpp
@@ -83,10 +83,10 @@ public:
             const Box& tile_box  = mfi.tilebox();
 
             Gpu::HostVector<ParticleType> host_particles;
-            std::array<Gpu::HostVector<Real>, NAR> host_real;
+            std::array<Gpu::HostVector<ParticleReal>, NAR> host_real;
             std::array<Gpu::HostVector<int>, NAI> host_int;
 
-            std::vector<Gpu::HostVector<Real> > host_runtime_real(NumRuntimeRealComps());
+            std::vector<Gpu::HostVector<ParticleReal> > host_runtime_real(NumRuntimeRealComps());
             std::vector<Gpu::HostVector<int> > host_runtime_int(NumRuntimeIntComps());
 
             for (IntVect iv = tile_box.smallEnd(); iv <= tile_box.bigEnd(); tile_box.next(iv))

--- a/Tests/Particles/ParticleMesh/main.cpp
+++ b/Tests/Particles/ParticleMesh/main.cpp
@@ -61,7 +61,7 @@ void testParticleMesh (TestParams& parms)
 
   bool serialize = true;
   int iseed = 451;
-  Real mass = 10.0;
+  double mass = 10.0;
 
   MyParticleContainer::ParticleInitData pdata = {{mass, AMREX_D_DECL(1.0, 2.0, 3.0), AMREX_D_DECL(0.0, 0.0, 0.0)}, {},{},{}};
   myPC.InitRandom(num_particles, iseed, pdata, serialize);

--- a/Tests/Particles/ParticleMeshMultiLevel/main.cpp
+++ b/Tests/Particles/ParticleMeshMultiLevel/main.cpp
@@ -81,7 +81,7 @@ void testParticleMesh (TestParams& parms)
 
     bool serialize = true;
     int iseed = 451;
-    Real mass = 10.0;
+    double mass = 10.0;
 
     MyParticleContainer::ParticleInitData pdata = {{mass}, {}, {}, {}};
     myPC.InitRandom(num_particles, iseed, pdata, serialize);

--- a/Tests/Particles/ParticleReduce/main.cpp
+++ b/Tests/Particles/ParticleReduce/main.cpp
@@ -53,7 +53,7 @@ public:
             const Box& tile_box  = mfi.tilebox();
 
             Gpu::HostVector<ParticleType> host_particles;
-            std::array<Gpu::HostVector<Real>, NAR> host_real;
+            std::array<Gpu::HostVector<ParticleReal>, NAR> host_real;
             std::array<Gpu::HostVector<int>, NAI> host_int;
             for (IntVect iv = tile_box.smallEnd(); iv <= tile_box.bigEnd(); tile_box.next(iv))
             {


### PR DESCRIPTION
A number of CI tests had issues with mixing single precision particle data
with double precision amrex::Real.

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
