### PR TITLE
Remove amr adaptor/bridge when AMRLEVEL is off

### DIFF
--- a/Src/Extern/SENSEI/AMReX_AmrParticleDataAdaptor.H
+++ b/Src/Extern/SENSEI/AMReX_AmrParticleDataAdaptor.H
@@ -9,7 +9,6 @@
 
 #include <AMReX_AmrMesh.H>
 #include <AMReX_MultiFab.H>
-#include <AMReX_AmrDataAdaptor.H>
 #include <AMReX_ParticleDataAdaptor.H>
 // sensei includes
 #include "DataAdaptor.h"

--- a/Src/Extern/SENSEI/AMReX_InSituBridge.cpp
+++ b/Src/Extern/SENSEI/AMReX_InSituBridge.cpp
@@ -1,6 +1,6 @@
 #include <AMReX_InSituBridge.H>
-
 #include <AMReX_ParmParse.H>
+#include <AMReX_Print.H>
 
 #ifdef AMREX_USE_SENSEI_INSITU
 #include <chrono>
@@ -8,8 +8,6 @@
 #include <AnalysisAdaptor.h>
 #include <ConfigurableAnalysis.h>
 #include <Profiler.h>
-#include <AMReX_AmrDataAdaptor.H>
-#include <AMReX_AmrMeshDataAdaptor.H>
 #endif
 
 namespace amrex {

--- a/Src/Extern/SENSEI/CMakeLists.txt
+++ b/Src/Extern/SENSEI/CMakeLists.txt
@@ -15,17 +15,21 @@ add_amrex_define( AMREX_NO_SENSEI_AMR_INST IF AMReX_NO_SENSEI_AMR_INST NO_LEGACY
 #
 set ( amrex_sensei_sources
    AMReX_AmrMeshDataAdaptor.H
-   AMReX_AmrDataAdaptor.H
-   AMReX_InSituBridge.H
    AMReX_AmrMeshInSituBridge.H
-   AMReX_AmrInSituBridge.H
+   AMReX_InSituBridge.H
    AMReX_InSituUtils.H
    AMReX_AmrMeshDataAdaptor.cpp
-   AMReX_AmrDataAdaptor.cpp
-   AMReX_InSituBridge.cpp
    AMReX_AmrMeshInSituBridge.cpp
-   AMReX_AmrInSituBridge.cpp
+   AMReX_InSituBridge.cpp
    AMReX_InSituUtils.cpp )
+
+if( AMReX_AMRLEVEL )
+   list ( APPEND amrex_sensei_sources
+      AMReX_AmrDataAdaptor.H
+      AMReX_AmrInSituBridge.H
+      AMReX_AmrDataAdaptor.cpp
+      AMReX_AmrInSituBridge.cpp )
+endif()
 
 #
 # Pareticle  based adaptors and bridges
@@ -34,10 +38,14 @@ if ( AMReX_PARTICLES )
    list ( APPEND amrex_sensei_sources
       AMReX_ParticleDataAdaptor.H
       AMReX_ParticleDataAdaptorI.H
-      AMReX_AmrParticleDataAdaptor.H
-      AMReX_AmrParticleDataAdaptorI.H
       AMReX_ParticleInSituBridge.H
       AMReX_AmrParticleInSituBridge.H )
+
+   if( AMReX_AMRLEVEL )
+      list ( APPEND amrex_sensei_sources
+         AMReX_AmrParticleDataAdaptor.H
+         AMReX_AmrParticleDataAdaptorI.H )
+   endif()
 endif ()
 
 target_include_directories( amrex PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}> )


### PR DESCRIPTION
## Summary
This PR moves the AMR data adaptor and bridge code behind the AMReX_AMRLEVEL compiler option so that it is not compiled if the end application does not need those optional features.

Fixes https://github.com/AMReX-Codes/amrex/issues/2263

## Additional background
This addresses the problem noted in https://github.com/ECP-WarpX/WarpX/pull/2192#issuecomment-901285722. 
This PR ought to render https://github.com/ECP-WarpX/WarpX/pull/2209 unnecessary.
 
## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
