### PR TITLE
Fix #2256

### DIFF
--- a/Src/Base/AMReX_FabArrayBase.H
+++ b/Src/Base/AMReX_FabArrayBase.H
@@ -654,6 +654,7 @@ public:
         ~ParForInfo ();
 
         std::pair<int*,int*> const& getBlocks () const { return m_nblocks_x; }
+        Box const* getBoxes () const { return m_boxes; }
 
         ParForInfo () = delete;
         ParForInfo (ParForInfo const&) = delete;
@@ -666,6 +667,9 @@ public:
         IntVect m_ng;
         int m_nthreads;
         std::pair<int*,int*> m_nblocks_x;
+        Box* m_boxes = nullptr;
+        char* m_hp = nullptr;
+        char* m_dp = nullptr;
     };
 
     ParForInfo const& getParForInfo (const IntVect& nghost, int nthreads) const;

--- a/Src/Base/AMReX_FabArrayBase.cpp
+++ b/Src/Base/AMReX_FabArrayBase.cpp
@@ -2517,6 +2517,7 @@ FabArrayBase::ParForInfo::ParForInfo (const FabArrayBase& fa, const IntVect& ngh
       m_nthreads(nthreads),
       m_nblocks_x({nullptr,nullptr})
 {
+    Vector<Box> boxes;
     Vector<Long> ncells;
     ncells.reserve(fa.indexArray.size());
     for (int K : fa.indexArray) {
@@ -2526,14 +2527,15 @@ FabArrayBase::ParForInfo::ParForInfo (const FabArrayBase& fa, const IntVect& ngh
             b.grow(nghost);
             N = b.numPts();
         }
+        boxes.push_back(b);
         ncells.push_back(N);
     }
-    m_nblocks_x = detail::build_par_for_nblocks(ncells, nthreads);
+    detail::build_par_for_nblocks(m_hp, m_dp, m_nblocks_x, m_boxes, boxes, ncells, nthreads);
 }
 
 FabArrayBase::ParForInfo::~ParForInfo ()
 {
-    detail::destroy_par_for_nblocks(m_nblocks_x);
+    detail::destroy_par_for_nblocks(m_hp, m_dp);
 }
 
 FabArrayBase::ParForInfo const&

--- a/Src/Base/AMReX_MFParallelForG.H
+++ b/Src/Base/AMReX_MFParallelForG.H
@@ -12,38 +12,45 @@ namespace amrex {
 namespace detail {
 
 inline
-std::pair<int*,int*> build_par_for_nblocks (Vector<Long> const& ncells, int nthreads)
+void build_par_for_nblocks (char*& a_hp, char*& a_dp, std::pair<int*,int*>& blocks_x, Box*& pboxes,
+                            Vector<Box> const& boxes, Vector<Long> const& ncells, int nthreads)
 {
-    int* hp = nullptr;
-    int* dp = nullptr;
     if (!ncells.empty()) {
         const int nboxes = ncells.size();
-        const std::size_t nbytes = (nboxes+1) * sizeof(int);
-        hp = (int*)The_Pinned_Arena()->alloc(nbytes);
-        hp[0] = 0;
+        const std::size_t nbytes_boxes = amrex::aligned_size(16, (nboxes+1) * sizeof(int));
+        const std::size_t nbytes = nbytes_boxes + nboxes*sizeof(Box);
+        a_hp = (char*)The_Pinned_Arena()->alloc(nbytes);
+        int* hp_blks = (int*)a_hp;
+        Box* hp_boxes = (Box*)(a_hp + nbytes_boxes);
+        hp_blks[0] = 0;
         Long ntot = 0;
         bool same_size = true;
         for (int i = 0; i < nboxes; ++i) {
             Long nblocks = (ncells[i] + nthreads-1) / nthreads;
-            hp[i+1] = hp[i] + static_cast<int>(nblocks);
+            hp_blks[i+1] = hp_blks[i] + static_cast<int>(nblocks);
             ntot += nblocks;
             same_size = same_size && (ncells[i] == ncells[0]);
+
+            new (hp_boxes+i) Box;
+            hp_boxes[i] = boxes[i];
         }
         amrex::ignore_unused(ntot);
-        AMREX_ASSERT(static_cast<Long>(hp[nboxes]) == ntot); // no overflow
-        if (!same_size) {
-            dp = (int*) The_Arena()->alloc(nbytes);
-            Gpu::htod_memcpy(dp, hp, nbytes);
-        }
+        AMREX_ASSERT(static_cast<Long>(hp_blks[nboxes]) == ntot); // no overflow
+
+        a_dp = (char*) The_Arena()->alloc(nbytes);
+        Gpu::htod_memcpy_async(a_dp, a_hp, nbytes);
+
+        blocks_x.first = hp_blks;
+        blocks_x.second = (same_size) ? nullptr : (int*)a_dp;
+        pboxes = (Box*)(a_dp + nbytes_boxes);
     }
-    return std::make_pair(hp,dp);
 }
 
 inline
-void destroy_par_for_nblocks (std::pair<int*,int*> const& pp)
+void destroy_par_for_nblocks (char* hp, char* dp)
 {
-    The_Pinned_Arena()->free(pp.first);
-    The_Arena()->free(pp.second);
+    The_Pinned_Arena()->free(hp);
+    The_Arena()->free(dp);
 }
 }
 
@@ -78,20 +85,18 @@ ParallelFor (MF const& mf, IntVect const& nghost, int ncomp, IntVect const&, boo
     if (nboxes == 0) {
         return;
     } else if (nboxes == 1) {
-        auto const& fab = mf.atLocalIdx(0);
-        Box const& b = amrex::grow(fab.box(), nghost-mf.nGrowVect());
+        Box const& b = amrex::grow(mf.box(index_array[0]), nghost);
         amrex::ParallelFor(b, ncomp, [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
         {
             parfor_mf_detail::call_f(f, 0, i, j, k, n);
         });
     } else {
-        IntVect ngrow = nghost - mf.nGrowVect(); // We use this to go from fabbox to valid+nghost.
-        auto ma = mf.arrays();
-
-        auto par_for_blocks = mf.getParForInfo(nghost,MT).getBlocks();
+        auto const& parforinfo = mf.getParForInfo(nghost,MT);
+        auto par_for_blocks = parforinfo.getBlocks();
         const int nblocks = par_for_blocks.first[nboxes];
         const int block_0_size = par_for_blocks.first[1];
         const int* dp_nblocks = par_for_blocks.second;
+        const Box* dp_boxes = parforinfo.getBoxes();
 
 #if defined(AMREX_USE_CUDA) || defined(AMREX_USE_HIP)
 
@@ -124,8 +129,7 @@ ParallelFor (MF const& mf, IntVect const& nghost, int ncomp, IntVect const&, boo
                      icell = (blockIdxx-ibox*block_0_size)*MT + threadIdxx;
                  }
 #endif
-                 Box b(ma[ibox]);
-                 b.grow(ngrow);
+                 Box const& b = dp_boxes[ibox];
                  int ncells = b.numPts();
                  if (icell < ncells) {
                      const auto len = amrex::length(b);


### PR DESCRIPTION
In #2256, a no-allocated MultiFab was passed to the MF ParalleFor.  This
resulted in segfault because of how the ParallelFor was implemented.  In
this commit, we fix the bug by reimplementing it without relying on Fabs
being allocated.

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] are described in the proposed changes to the AMReX documentation, if appropriate
