### PR TITLE
MF ParallelFor: LinearSolvers

### DIFF
--- a/Src/Boundary/AMReX_FabSet.H
+++ b/Src/Boundary/AMReX_FabSet.H
@@ -71,6 +71,10 @@ public:
     Array4<Real const> const_array (const MFIter& mfi) const noexcept { return m_mf.const_array(mfi); }
     Array4<Real const> const_array (int i)             const noexcept { return m_mf.const_array(i); }
 
+    MultiArray4<Real const> arrays () const noexcept { return m_mf.const_arrays(); }
+    MultiArray4<Real      > arrays ()       noexcept { return m_mf.arrays(); }
+    MultiArray4<Real const> const_arrays () const noexcept { return m_mf.const_arrays(); }
+
     Box fabbox (int K) const noexcept { return m_mf.fabbox(K); }
 
     int size () const noexcept { return m_mf.size(); }

--- a/Src/Boundary/AMReX_MultiMask.H
+++ b/Src/Boundary/AMReX_MultiMask.H
@@ -39,6 +39,13 @@ public:
 
     Array4<int const> array (const MFIter& mfi) const noexcept { return m_fa.array(mfi); }
     Array4<int      > array (const MFIter& mfi)       noexcept { return m_fa.array(mfi); }
+    Array4<int const> const_array (const MFIter& mfi) const noexcept {
+        return m_fa.const_array(mfi);
+    }
+
+    MultiArray4<int const> arrays () const noexcept { return m_fa.const_arrays(); }
+    MultiArray4<int      > arrays ()       noexcept { return m_fa.arrays(); }
+    MultiArray4<int const> const_arrays () const noexcept { return m_fa.const_arrays(); }
 
     int nComp () const noexcept { return m_fa.nComp(); }
 
@@ -66,4 +73,3 @@ public:
 }
 
 #endif
-

--- a/Src/LinearSolvers/MLMG/AMReX_MLABecLap_1D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLABecLap_1D_K.H
@@ -5,74 +5,47 @@
 namespace amrex {
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-void mlabeclap_adotx (Box const& box, Array4<Real> const& y,
+void mlabeclap_adotx (int i, int, int, int n, Array4<Real> const& y,
                       Array4<Real const> const& x,
                       Array4<Real const> const& a,
                       Array4<Real const> const& bX,
                       GpuArray<Real,AMREX_SPACEDIM> const& dxinv,
-                      Real alpha, Real beta, int ncomp) noexcept
+                      Real alpha, Real beta) noexcept
 {
     const Real dhx = beta*dxinv[0]*dxinv[0];
-
-    const auto lo = amrex::lbound(box);
-    const auto hi = amrex::ubound(box);
-
-    for (int n = 0; n < ncomp; ++n) {
-    AMREX_PRAGMA_SIMD
-    for (int i = lo.x; i <= hi.x; ++i) {
-        y(i,0,0,n) = alpha*a(i,0,0)*x(i,0,0,n)
-            - dhx * (bX(i+1,0,0,n)*(x(i+1,0,0,n) - x(i  ,0,0,n))
-                   - bX(i  ,0,0,n)*(x(i  ,0,0,n) - x(i-1,0,0,n)));
-    }
-    }
+    y(i,0,0,n) = alpha*a(i,0,0)*x(i,0,0,n)
+        - dhx * (bX(i+1,0,0,n)*(x(i+1,0,0,n) - x(i  ,0,0,n))
+               - bX(i  ,0,0,n)*(x(i  ,0,0,n) - x(i-1,0,0,n)));
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-void mlabeclap_adotx_os (Box const& box, Array4<Real> const& y,
+void mlabeclap_adotx_os (int i, int, int, int n, Array4<Real> const& y,
                          Array4<Real const> const& x,
                          Array4<Real const> const& a,
                          Array4<Real const> const& bX,
                          Array4<int const> const& osm,
                          GpuArray<Real,AMREX_SPACEDIM> const& dxinv,
-                         Real alpha, Real beta, int ncomp) noexcept
+                         Real alpha, Real beta) noexcept
 {
     const Real dhx = beta*dxinv[0]*dxinv[0];
-
-    const auto lo = amrex::lbound(box);
-    const auto hi = amrex::ubound(box);
-
-    for (int n = 0; n < ncomp; ++n) {
-    AMREX_PRAGMA_SIMD
-    for (int i = lo.x; i <= hi.x; ++i) {
-        if (osm(i,0,0) == 0) {
-            y(i,0,0,n) = Real(0.0);
-        } else {
-            y(i,0,0,n) = alpha*a(i,0,0)*x(i,0,0,n)
-                - dhx * (bX(i+1,0,0,n)*(x(i+1,0,0,n) - x(i  ,0,0,n))
-                       - bX(i  ,0,0,n)*(x(i  ,0,0,n) - x(i-1,0,0,n)));
-        }
-    }
+    if (osm(i,0,0) == 0) {
+        y(i,0,0,n) = Real(0.0);
+    } else {
+        y(i,0,0,n) = alpha*a(i,0,0)*x(i,0,0,n)
+            - dhx * (bX(i+1,0,0,n)*(x(i+1,0,0,n) - x(i  ,0,0,n))
+                   - bX(i  ,0,0,n)*(x(i  ,0,0,n) - x(i-1,0,0,n)));
     }
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-void mlabeclap_normalize (Box const& box, Array4<Real> const& x,
+void mlabeclap_normalize (int i, int, int, int n, Array4<Real> const& x,
                           Array4<Real const> const& a,
                           Array4<Real const> const& bX,
                           GpuArray<Real,AMREX_SPACEDIM> const& dxinv,
-                          Real alpha, Real beta, int ncomp) noexcept
+                          Real alpha, Real beta) noexcept
 {
     const Real dhx = beta*dxinv[0]*dxinv[0];
-
-    const auto lo = amrex::lbound(box);
-    const auto hi = amrex::ubound(box);
-
-    for (int n = 0; n < ncomp; ++n) {
-    AMREX_PRAGMA_SIMD
-    for (int i = lo.x; i <= hi.x; ++i) {
-        x(i,0,0,n) /= alpha*a(i,0,0) + dhx*(bX(i,0,0,n)+bX(i+1,0,0,n));
-    }
-    }
+    x(i,0,0,n) /= alpha*a(i,0,0) + dhx*(bX(i,0,0,n)+bX(i+1,0,0,n));
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
@@ -105,7 +78,7 @@ void mlabeclap_flux_xface (Box const& box, Array4<Real> const& fx, Array4<Real c
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-void abec_gsrb (Box const& box, Array4<Real> const& phi, Array4<Real const> const& rhs,
+void abec_gsrb (int i, int, int, int n, Array4<Real> const& phi, Array4<Real const> const& rhs,
                 Real alpha, Array4<Real const> const& a,
                 Real dhx,
                 Array4<Real const> const& bX,
@@ -113,39 +86,32 @@ void abec_gsrb (Box const& box, Array4<Real> const& phi, Array4<Real const> cons
                 Array4<int const> const& m1,
                 Array4<Real const> const& f0,
                 Array4<Real const> const& f1,
-                Box const& vbox, int redblack, int nc) noexcept
+                Box const& vbox, int redblack) noexcept
 {
-    const auto lo = amrex::lbound(box);
-    const auto hi = amrex::ubound(box);
-    const auto vlo = amrex::lbound(vbox);
-    const auto vhi = amrex::ubound(vbox);
+    if ((i+redblack)%2 == 0) {
+        const auto vlo = amrex::lbound(vbox);
+        const auto vhi = amrex::ubound(vbox);
 
-    for (int n = 0; n < nc; ++n) {
-        AMREX_PRAGMA_SIMD
-        for (int i = lo.x; i <= hi.x; ++i) {
-            if ((i+redblack)%2 == 0) {
-                Real cf0 = (i == vlo.x && m0(vlo.x-1,0,0) > 0)
-                    ? f0(vlo.x,0,0,n) : Real(0.0);
-                Real cf1 = (i == vhi.x && m1(vhi.x+1,0,0) > 0)
-                    ? f1(vhi.x,0,0,n) : Real(0.0);
+        Real cf0 = (i == vlo.x && m0(vlo.x-1,0,0) > 0)
+            ? f0(vlo.x,0,0,n) : Real(0.0);
+        Real cf1 = (i == vhi.x && m1(vhi.x+1,0,0) > 0)
+            ? f1(vhi.x,0,0,n) : Real(0.0);
 
-                Real delta = dhx*(bX(i,0,0,n)*cf0 + bX(i+1,0,0,n)*cf1);
+        Real delta = dhx*(bX(i,0,0,n)*cf0 + bX(i+1,0,0,n)*cf1);
 
-                Real gamma = alpha*a(i,0,0)
-                    +   dhx*( bX(i,0,0,n) + bX(i+1,0,0,n) );
+        Real gamma = alpha*a(i,0,0)
+            +   dhx*( bX(i,0,0,n) + bX(i+1,0,0,n) );
 
-                Real rho = dhx*(bX(i  ,0  ,0,n)*phi(i-1,0  ,0,n)
-                              + bX(i+1,0  ,0,n)*phi(i+1,0  ,0,n));
+        Real rho = dhx*(bX(i  ,0  ,0,n)*phi(i-1,0  ,0,n)
+                        + bX(i+1,0  ,0,n)*phi(i+1,0  ,0,n));
 
-                phi(i,0,0,n) = (rhs(i,0,0,n) + rho - phi(i,0,0,n)*delta)
-                    / (gamma - delta);
-            }
-        }
+        phi(i,0,0,n) = (rhs(i,0,0,n) + rho - phi(i,0,0,n)*delta)
+            / (gamma - delta);
     }
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-void abec_gsrb_os (Box const& box, Array4<Real> const& phi, Array4<Real const> const& rhs,
+void abec_gsrb_os (int i, int, int, int n, Array4<Real> const& phi, Array4<Real const> const& rhs,
                    Real alpha, Array4<Real const> const& a,
                    Real dhx,
                    Array4<Real const> const& bX,
@@ -154,37 +120,30 @@ void abec_gsrb_os (Box const& box, Array4<Real> const& phi, Array4<Real const> c
                    Array4<Real const> const& f0,
                    Array4<Real const> const& f1,
                    Array4<int const> const& osm,
-                   Box const& vbox, int redblack, int nc) noexcept
+                   Box const& vbox, int redblack) noexcept
 {
-    const auto lo = amrex::lbound(box);
-    const auto hi = amrex::ubound(box);
-    const auto vlo = amrex::lbound(vbox);
-    const auto vhi = amrex::ubound(vbox);
+    if ((i+redblack)%2 == 0) {
+        if (osm(i,0,0) == 0) {
+            phi(i,0,0) = Real(0.0);
+        } else {
+            const auto vlo = amrex::lbound(vbox);
+            const auto vhi = amrex::ubound(vbox);
 
-    for (int n = 0; n < nc; ++n) {
-        AMREX_PRAGMA_SIMD
-        for (int i = lo.x; i <= hi.x; ++i) {
-            if ((i+redblack)%2 == 0) {
-                if (osm(i,0,0) == 0) {
-                    phi(i,0,0) = Real(0.0);
-                } else {
-                    Real cf0 = (i == vlo.x && m0(vlo.x-1,0,0) > 0)
-                        ? f0(vlo.x,0,0,n) : Real(0.0);
-                    Real cf1 = (i == vhi.x && m1(vhi.x+1,0,0) > 0)
-                        ? f1(vhi.x,0,0,n) : Real(0.0);
+            Real cf0 = (i == vlo.x && m0(vlo.x-1,0,0) > 0)
+                ? f0(vlo.x,0,0,n) : Real(0.0);
+            Real cf1 = (i == vhi.x && m1(vhi.x+1,0,0) > 0)
+                ? f1(vhi.x,0,0,n) : Real(0.0);
 
-                    Real delta = dhx*(bX(i,0,0,n)*cf0 + bX(i+1,0,0,n)*cf1);
+            Real delta = dhx*(bX(i,0,0,n)*cf0 + bX(i+1,0,0,n)*cf1);
 
-                    Real gamma = alpha*a(i,0,0)
-                        +   dhx*( bX(i,0,0,n) + bX(i+1,0,0,n) );
+            Real gamma = alpha*a(i,0,0)
+                +   dhx*( bX(i,0,0,n) + bX(i+1,0,0,n) );
 
-                    Real rho = dhx*(bX(i  ,0  ,0,n)*phi(i-1,0  ,0,n)
-                                  + bX(i+1,0  ,0,n)*phi(i+1,0  ,0,n));
+            Real rho = dhx*(bX(i  ,0  ,0,n)*phi(i-1,0  ,0,n)
+                            + bX(i+1,0  ,0,n)*phi(i+1,0  ,0,n));
 
-                    phi(i,0,0,n) = (rhs(i,0,0,n) + rho - phi(i,0,0,n)*delta)
-                        / (gamma - delta);
-                }
-            }
+            phi(i,0,0,n) = (rhs(i,0,0,n) + rho - phi(i,0,0,n)*delta)
+                / (gamma - delta);
         }
     }
 }

--- a/Src/LinearSolvers/MLMG/AMReX_MLABecLap_2D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLABecLap_2D_K.H
@@ -5,92 +5,59 @@
 namespace amrex {
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-void mlabeclap_adotx (Box const& box, Array4<Real> const& y,
+void mlabeclap_adotx (int i, int j, int, int n, Array4<Real> const& y,
                       Array4<Real const> const& x,
                       Array4<Real const> const& a,
                       Array4<Real const> const& bX,
                       Array4<Real const> const& bY,
                       GpuArray<Real,AMREX_SPACEDIM> const& dxinv,
-                      Real alpha, Real beta, int ncomp) noexcept
+                      Real alpha, Real beta) noexcept
 {
     const Real dhx = beta*dxinv[0]*dxinv[0];
     const Real dhy = beta*dxinv[1]*dxinv[1];
-
-    const auto lo = amrex::lbound(box);
-    const auto hi = amrex::ubound(box);
-
-    for (int n = 0; n < ncomp; ++n) {
-    for     (int j = lo.y; j <= hi.y; ++j) {
-        AMREX_PRAGMA_SIMD
-        for (int i = lo.x; i <= hi.x; ++i) {
-            y(i,j,0,n) = alpha*a(i,j,0)*x(i,j,0,n)
-                - dhx * (bX(i+1,j,0,n)*(x(i+1,j,0,n) - x(i  ,j,0,n))
-                       - bX(i  ,j,0,n)*(x(i  ,j,0,n) - x(i-1,j,0,n)))
-                - dhy * (bY(i,j+1,0,n)*(x(i,j+1,0,n) - x(i,j  ,0,n))
-                       - bY(i,j  ,0,n)*(x(i,j  ,0,n) - x(i,j-1,0,n)));
-        }
-    }
-    }
+    y(i,j,0,n) = alpha*a(i,j,0)*x(i,j,0,n)
+            - dhx * (bX(i+1,j,0,n)*(x(i+1,j,0,n) - x(i  ,j,0,n))
+                   - bX(i  ,j,0,n)*(x(i  ,j,0,n) - x(i-1,j,0,n)))
+            - dhy * (bY(i,j+1,0,n)*(x(i,j+1,0,n) - x(i,j  ,0,n))
+                   - bY(i,j  ,0,n)*(x(i,j  ,0,n) - x(i,j-1,0,n)));
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-void mlabeclap_adotx_os (Box const& box, Array4<Real> const& y,
+void mlabeclap_adotx_os (int i, int j, int, int n, Array4<Real> const& y,
                          Array4<Real const> const& x,
                          Array4<Real const> const& a,
                          Array4<Real const> const& bX,
                          Array4<Real const> const& bY,
                          Array4<int const> const& osm,
                          GpuArray<Real,AMREX_SPACEDIM> const& dxinv,
-                         Real alpha, Real beta, int ncomp) noexcept
+                         Real alpha, Real beta) noexcept
 {
     const Real dhx = beta*dxinv[0]*dxinv[0];
     const Real dhy = beta*dxinv[1]*dxinv[1];
-
-    const auto lo = amrex::lbound(box);
-    const auto hi = amrex::ubound(box);
-
-    for (int n = 0; n < ncomp; ++n) {
-    for     (int j = lo.y; j <= hi.y; ++j) {
-        AMREX_PRAGMA_SIMD
-        for (int i = lo.x; i <= hi.x; ++i) {
-            if (osm(i,j,0) == 0) {
-                y(i,j,0,n) = Real(0.0);
-            } else {
-                y(i,j,0,n) = alpha*a(i,j,0)*x(i,j,0,n)
-                    - dhx * (bX(i+1,j,0,n)*(x(i+1,j,0,n) - x(i  ,j,0,n))
-                           - bX(i  ,j,0,n)*(x(i  ,j,0,n) - x(i-1,j,0,n)))
-                    - dhy * (bY(i,j+1,0,n)*(x(i,j+1,0,n) - x(i,j  ,0,n))
-                           - bY(i,j  ,0,n)*(x(i,j  ,0,n) - x(i,j-1,0,n)));
-            }
-        }
-    }
+    if (osm(i,j,0) == 0) {
+        y(i,j,0,n) = Real(0.0);
+    } else {
+        y(i,j,0,n) = alpha*a(i,j,0)*x(i,j,0,n)
+            - dhx * (bX(i+1,j,0,n)*(x(i+1,j,0,n) - x(i  ,j,0,n))
+                   - bX(i  ,j,0,n)*(x(i  ,j,0,n) - x(i-1,j,0,n)))
+            - dhy * (bY(i,j+1,0,n)*(x(i,j+1,0,n) - x(i,j  ,0,n))
+                   - bY(i,j  ,0,n)*(x(i,j  ,0,n) - x(i,j-1,0,n)));
     }
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-void mlabeclap_normalize (Box const& box, Array4<Real> const& x,
+void mlabeclap_normalize (int i, int j, int, int n, Array4<Real> const& x,
                           Array4<Real const> const& a,
                           Array4<Real const> const& bX,
                           Array4<Real const> const& bY,
                           GpuArray<Real,AMREX_SPACEDIM> const& dxinv,
-                          Real alpha, Real beta, int ncomp) noexcept
+                          Real alpha, Real beta) noexcept
 {
     const Real dhx = beta*dxinv[0]*dxinv[0];
     const Real dhy = beta*dxinv[1]*dxinv[1];
-
-    const auto lo = amrex::lbound(box);
-    const auto hi = amrex::ubound(box);
-
-    for (int n = 0; n < ncomp; ++n) {
-    for     (int j = lo.y; j <= hi.y; ++j) {
-        AMREX_PRAGMA_SIMD
-        for (int i = lo.x; i <= hi.x; ++i) {
-            x(i,j,0,n) /= alpha*a(i,j,0)
-                + dhx*(bX(i,j,0,n)+bX(i+1,j,0,n))
-                + dhy*(bY(i,j,0,n)+bY(i,j+1,0,n));
-        }
-    }
-    }
+    x(i,j,0,n) /= alpha*a(i,j,0)
+        + dhx*(bX(i,j,0,n)+bX(i+1,j,0,n))
+        + dhy*(bY(i,j,0,n)+bY(i,j+1,0,n));
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
@@ -166,7 +133,7 @@ void mlabeclap_flux_yface (Box const& box, Array4<Real> const& fy, Array4<Real c
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-void abec_gsrb (Box const& box, Array4<Real> const& phi, Array4<Real const> const& rhs,
+void abec_gsrb (int i, int j, int, int n, Array4<Real> const& phi, Array4<Real const> const& rhs,
                 Real alpha, Array4<Real const> const& a,
                 Real dhx, Real dhy,
                 Array4<Real const> const& bX, Array4<Real const> const& bY,
@@ -174,49 +141,40 @@ void abec_gsrb (Box const& box, Array4<Real> const& phi, Array4<Real const> cons
                 Array4<int const> const& m1, Array4<int const> const& m3,
                 Array4<Real const> const& f0, Array4<Real const> const& f2,
                 Array4<Real const> const& f1, Array4<Real const> const& f3,
-                Box const& vbox, int redblack, int nc) noexcept
+                Box const& vbox, int redblack) noexcept
 {
-    const auto lo = amrex::lbound(box);
-    const auto hi = amrex::ubound(box);
-    const auto vlo = amrex::lbound(vbox);
-    const auto vhi = amrex::ubound(vbox);
+    if ((i+j+redblack)%2 == 0) {
+        const auto vlo = amrex::lbound(vbox);
+        const auto vhi = amrex::ubound(vbox);
 
-    for (int n = 0; n < nc; ++n) {
-        for     (int j = lo.y; j <= hi.y; ++j) {
-            AMREX_PRAGMA_SIMD
-            for (int i = lo.x; i <= hi.x; ++i) {
-                if ((i+j+redblack)%2 == 0) {
-                    Real cf0 = (i == vlo.x && m0(vlo.x-1,j,0) > 0)
-                        ? f0(vlo.x,j,0,n) : Real(0.0);
-                    Real cf1 = (j == vlo.y && m1(i,vlo.y-1,0) > 0)
-                        ? f1(i,vlo.y,0,n) : Real(0.0);
-                    Real cf2 = (i == vhi.x && m2(vhi.x+1,j,0) > 0)
-                        ? f2(vhi.x,j,0,n) : Real(0.0);
-                    Real cf3 = (j == vhi.y && m3(i,vhi.y+1,0) > 0)
-                        ? f3(i,vhi.y,0,n) : Real(0.0);
+        Real cf0 = (i == vlo.x && m0(vlo.x-1,j,0) > 0)
+            ? f0(vlo.x,j,0,n) : Real(0.0);
+        Real cf1 = (j == vlo.y && m1(i,vlo.y-1,0) > 0)
+            ? f1(i,vlo.y,0,n) : Real(0.0);
+        Real cf2 = (i == vhi.x && m2(vhi.x+1,j,0) > 0)
+            ? f2(vhi.x,j,0,n) : Real(0.0);
+        Real cf3 = (j == vhi.y && m3(i,vhi.y+1,0) > 0)
+            ? f3(i,vhi.y,0,n) : Real(0.0);
 
-                    Real delta = dhx*(bX(i,j,0,n)*cf0 + bX(i+1,j,0,n)*cf2)
-                              +  dhy*(bY(i,j,0,n)*cf1 + bY(i,j+1,0,n)*cf3);
+        Real delta = dhx*(bX(i,j,0,n)*cf0 + bX(i+1,j,0,n)*cf2)
+            +  dhy*(bY(i,j,0,n)*cf1 + bY(i,j+1,0,n)*cf3);
 
-                    Real gamma = alpha*a(i,j,0)
-                        +   dhx*( bX(i,j,0,n) + bX(i+1,j,0,n) )
-                        +   dhy*( bY(i,j,0,n) + bY(i,j+1,0,n) );
+        Real gamma = alpha*a(i,j,0)
+            +   dhx*( bX(i,j,0,n) + bX(i+1,j,0,n) )
+            +   dhy*( bY(i,j,0,n) + bY(i,j+1,0,n) );
 
-                    Real rho = dhx*(bX(i  ,j  ,0,n)*phi(i-1,j  ,0,n)
-                                  + bX(i+1,j  ,0,n)*phi(i+1,j  ,0,n))
-                              +dhy*(bY(i  ,j  ,0,n)*phi(i  ,j-1,0,n)
-                                  + bY(i  ,j+1,0,n)*phi(i  ,j+1,0,n));
+        Real rho = dhx*(bX(i  ,j  ,0,n)*phi(i-1,j  ,0,n)
+                      + bX(i+1,j  ,0,n)*phi(i+1,j  ,0,n))
+                  +dhy*(bY(i  ,j  ,0,n)*phi(i  ,j-1,0,n)
+                      + bY(i  ,j+1,0,n)*phi(i  ,j+1,0,n));
 
-                    phi(i,j,0,n) = (rhs(i,j,0,n) + rho - phi(i,j,0,n)*delta)
-                        / (gamma - delta);
-                }
-            }
-        }
+        phi(i,j,0,n) = (rhs(i,j,0,n) + rho - phi(i,j,0,n)*delta)
+            / (gamma - delta);
     }
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-void abec_gsrb_os (Box const& box, Array4<Real> const& phi, Array4<Real const> const& rhs,
+void abec_gsrb_os (int i, int j, int, int n, Array4<Real> const& phi, Array4<Real const> const& rhs,
                    Real alpha, Array4<Real const> const& a,
                    Real dhx, Real dhy,
                    Array4<Real const> const& bX, Array4<Real const> const& bY,
@@ -225,47 +183,38 @@ void abec_gsrb_os (Box const& box, Array4<Real> const& phi, Array4<Real const> c
                    Array4<Real const> const& f0, Array4<Real const> const& f2,
                    Array4<Real const> const& f1, Array4<Real const> const& f3,
                    Array4<int const> const& osm,
-                   Box const& vbox, int redblack, int nc) noexcept
+                   Box const& vbox, int redblack) noexcept
 {
-    const auto lo = amrex::lbound(box);
-    const auto hi = amrex::ubound(box);
-    const auto vlo = amrex::lbound(vbox);
-    const auto vhi = amrex::ubound(vbox);
+    if ((i+j+redblack)%2 == 0) {
+        if (osm(i,j,0) == 0) {
+            phi(i,j,0,n) = Real(0.0);
+        } else {
+            const auto vlo = amrex::lbound(vbox);
+            const auto vhi = amrex::ubound(vbox);
 
-    for (int n = 0; n < nc; ++n) {
-        for     (int j = lo.y; j <= hi.y; ++j) {
-            AMREX_PRAGMA_SIMD
-            for (int i = lo.x; i <= hi.x; ++i) {
-                if ((i+j+redblack)%2 == 0) {
-                    if (osm(i,j,0) == 0) {
-                        phi(i,j,0,n) = Real(0.0);
-                    } else {
-                        Real cf0 = (i == vlo.x && m0(vlo.x-1,j,0) > 0)
-                            ? f0(vlo.x,j,0,n) : Real(0.0);
-                        Real cf1 = (j == vlo.y && m1(i,vlo.y-1,0) > 0)
-                            ? f1(i,vlo.y,0,n) : Real(0.0);
-                        Real cf2 = (i == vhi.x && m2(vhi.x+1,j,0) > 0)
-                            ? f2(vhi.x,j,0,n) : Real(0.0);
-                        Real cf3 = (j == vhi.y && m3(i,vhi.y+1,0) > 0)
-                            ? f3(i,vhi.y,0,n) : Real(0.0);
+            Real cf0 = (i == vlo.x && m0(vlo.x-1,j,0) > 0)
+                ? f0(vlo.x,j,0,n) : Real(0.0);
+            Real cf1 = (j == vlo.y && m1(i,vlo.y-1,0) > 0)
+                ? f1(i,vlo.y,0,n) : Real(0.0);
+            Real cf2 = (i == vhi.x && m2(vhi.x+1,j,0) > 0)
+                ? f2(vhi.x,j,0,n) : Real(0.0);
+            Real cf3 = (j == vhi.y && m3(i,vhi.y+1,0) > 0)
+                ? f3(i,vhi.y,0,n) : Real(0.0);
 
-                        Real delta = dhx*(bX(i,j,0,n)*cf0 + bX(i+1,j,0,n)*cf2)
-                                  +  dhy*(bY(i,j,0,n)*cf1 + bY(i,j+1,0,n)*cf3);
+            Real delta = dhx*(bX(i,j,0,n)*cf0 + bX(i+1,j,0,n)*cf2)
+                      +  dhy*(bY(i,j,0,n)*cf1 + bY(i,j+1,0,n)*cf3);
 
-                        Real gamma = alpha*a(i,j,0)
-                            +   dhx*( bX(i,j,0,n) + bX(i+1,j,0,n) )
-                            +   dhy*( bY(i,j,0,n) + bY(i,j+1,0,n) );
+            Real gamma = alpha*a(i,j,0)
+                +   dhx*( bX(i,j,0,n) + bX(i+1,j,0,n) )
+                +   dhy*( bY(i,j,0,n) + bY(i,j+1,0,n) );
 
-                        Real rho = dhx*(bX(i  ,j  ,0,n)*phi(i-1,j  ,0,n)
-                                      + bX(i+1,j  ,0,n)*phi(i+1,j  ,0,n))
-                                  +dhy*(bY(i  ,j  ,0,n)*phi(i  ,j-1,0,n)
-                                      + bY(i  ,j+1,0,n)*phi(i  ,j+1,0,n));
+            Real rho = dhx*(bX(i  ,j  ,0,n)*phi(i-1,j  ,0,n)
+                          + bX(i+1,j  ,0,n)*phi(i+1,j  ,0,n))
+                      +dhy*(bY(i  ,j  ,0,n)*phi(i  ,j-1,0,n)
+                         + bY(i  ,j+1,0,n)*phi(i  ,j+1,0,n));
 
-                        phi(i,j,0,n) = (rhs(i,j,0,n) + rho - phi(i,j,0,n)*delta)
-                            / (gamma - delta);
-                    }
-                }
-            }
+            phi(i,j,0,n) = (rhs(i,j,0,n) + rho - phi(i,j,0,n)*delta)
+                / (gamma - delta);
         }
     }
 }

--- a/Src/LinearSolvers/MLMG/AMReX_MLABecLap_3D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLABecLap_3D_K.H
@@ -5,42 +5,29 @@
 namespace amrex {
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-void mlabeclap_adotx (Box const& box, Array4<Real> const& y,
+void mlabeclap_adotx (int i, int j, int k, int n, Array4<Real> const& y,
                       Array4<Real const> const& x,
                       Array4<Real const> const& a,
                       Array4<Real const> const& bX,
                       Array4<Real const> const& bY,
                       Array4<Real const> const& bZ,
                       GpuArray<Real,AMREX_SPACEDIM> const& dxinv,
-                      Real alpha, Real beta, int ncomp) noexcept
+                      Real alpha, Real beta) noexcept
 {
     const Real dhx = beta*dxinv[0]*dxinv[0];
     const Real dhy = beta*dxinv[1]*dxinv[1];
     const Real dhz = beta*dxinv[2]*dxinv[2];
-
-    const auto lo = amrex::lbound(box);
-    const auto hi = amrex::ubound(box);
-
-    for (int n = 0; n < ncomp; ++n) {
-    for         (int k = lo.z; k <= hi.z; ++k) {
-        for     (int j = lo.y; j <= hi.y; ++j) {
-            AMREX_PRAGMA_SIMD
-            for (int i = lo.x; i <= hi.x; ++i) {
-                y(i,j,k,n) = alpha*a(i,j,k)*x(i,j,k,n)
-                    - dhx * (bX(i+1,j,k,n)*(x(i+1,j,k,n) - x(i  ,j,k,n))
-                           - bX(i  ,j,k,n)*(x(i  ,j,k,n) - x(i-1,j,k,n)))
-                    - dhy * (bY(i,j+1,k,n)*(x(i,j+1,k,n) - x(i,j  ,k,n))
-                           - bY(i,j  ,k,n)*(x(i,j  ,k,n) - x(i,j-1,k,n)))
-                    - dhz * (bZ(i,j,k+1,n)*(x(i,j,k+1,n) - x(i,j,k  ,n))
-                           - bZ(i,j,k  ,n)*(x(i,j,k  ,n) - x(i,j,k-1,n)));
-            }
-        }
-    }
-    }
+    y(i,j,k,n) = alpha*a(i,j,k)*x(i,j,k,n)
+        - dhx * (bX(i+1,j,k,n)*(x(i+1,j,k,n) - x(i  ,j,k,n))
+               - bX(i  ,j,k,n)*(x(i  ,j,k,n) - x(i-1,j,k,n)))
+        - dhy * (bY(i,j+1,k,n)*(x(i,j+1,k,n) - x(i,j  ,k,n))
+               - bY(i,j  ,k,n)*(x(i,j  ,k,n) - x(i,j-1,k,n)))
+        - dhz * (bZ(i,j,k+1,n)*(x(i,j,k+1,n) - x(i,j,k  ,n))
+               - bZ(i,j,k  ,n)*(x(i,j,k  ,n) - x(i,j,k-1,n)));
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-void mlabeclap_adotx_os (Box const& box, Array4<Real> const& y,
+void mlabeclap_adotx_os (int i, int j, int k, int n, Array4<Real> const& y,
                          Array4<Real const> const& x,
                          Array4<Real const> const& a,
                          Array4<Real const> const& bX,
@@ -48,66 +35,40 @@ void mlabeclap_adotx_os (Box const& box, Array4<Real> const& y,
                          Array4<Real const> const& bZ,
                          Array4<int const> const& osm,
                          GpuArray<Real,AMREX_SPACEDIM> const& dxinv,
-                         Real alpha, Real beta, int ncomp) noexcept
+                         Real alpha, Real beta) noexcept
 {
     const Real dhx = beta*dxinv[0]*dxinv[0];
     const Real dhy = beta*dxinv[1]*dxinv[1];
     const Real dhz = beta*dxinv[2]*dxinv[2];
-
-    const auto lo = amrex::lbound(box);
-    const auto hi = amrex::ubound(box);
-
-    for (int n = 0; n < ncomp; ++n) {
-    for         (int k = lo.z; k <= hi.z; ++k) {
-        for     (int j = lo.y; j <= hi.y; ++j) {
-            AMREX_PRAGMA_SIMD
-            for (int i = lo.x; i <= hi.x; ++i) {
-                if (osm(i,j,k) == 0) {
-                    y(i,j,k,n) = Real(0.0);
-                } else {
-                    y(i,j,k,n) = alpha*a(i,j,k)*x(i,j,k,n)
-                        - dhx * (bX(i+1,j,k,n)*(x(i+1,j,k,n) - x(i  ,j,k,n))
-                               - bX(i  ,j,k,n)*(x(i  ,j,k,n) - x(i-1,j,k,n)))
-                        - dhy * (bY(i,j+1,k,n)*(x(i,j+1,k,n) - x(i,j  ,k,n))
-                               - bY(i,j  ,k,n)*(x(i,j  ,k,n) - x(i,j-1,k,n)))
-                        - dhz * (bZ(i,j,k+1,n)*(x(i,j,k+1,n) - x(i,j,k  ,n))
-                               - bZ(i,j,k  ,n)*(x(i,j,k  ,n) - x(i,j,k-1,n)));
-                }
-            }
-        }
-    }
+    if (osm(i,j,k) == 0) {
+        y(i,j,k,n) = Real(0.0);
+    } else {
+        y(i,j,k,n) = alpha*a(i,j,k)*x(i,j,k,n)
+            - dhx * (bX(i+1,j,k,n)*(x(i+1,j,k,n) - x(i  ,j,k,n))
+                   - bX(i  ,j,k,n)*(x(i  ,j,k,n) - x(i-1,j,k,n)))
+            - dhy * (bY(i,j+1,k,n)*(x(i,j+1,k,n) - x(i,j  ,k,n))
+                   - bY(i,j  ,k,n)*(x(i,j  ,k,n) - x(i,j-1,k,n)))
+            - dhz * (bZ(i,j,k+1,n)*(x(i,j,k+1,n) - x(i,j,k  ,n))
+                   - bZ(i,j,k  ,n)*(x(i,j,k  ,n) - x(i,j,k-1,n)));
     }
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-void mlabeclap_normalize (Box const& box, Array4<Real> const& x,
+void mlabeclap_normalize (int i, int j, int k, int n, Array4<Real> const& x,
                           Array4<Real const> const& a,
                           Array4<Real const> const& bX,
                           Array4<Real const> const& bY,
                           Array4<Real const> const& bZ,
                           GpuArray<Real,AMREX_SPACEDIM> const& dxinv,
-                          Real alpha, Real beta, int ncomp) noexcept
+                          Real alpha, Real beta) noexcept
 {
     const Real dhx = beta*dxinv[0]*dxinv[0];
     const Real dhy = beta*dxinv[1]*dxinv[1];
     const Real dhz = beta*dxinv[2]*dxinv[2];
-
-    const auto lo = amrex::lbound(box);
-    const auto hi = amrex::ubound(box);
-
-    for (int n = 0; n < ncomp; ++n) {
-    for         (int k = lo.z; k <= hi.z; ++k) {
-        for     (int j = lo.y; j <= hi.y; ++j) {
-            AMREX_PRAGMA_SIMD
-            for (int i = lo.x; i <= hi.x; ++i) {
-                x(i,j,k,n) /= alpha*a(i,j,k)
-                    + dhx*(bX(i,j,k,n)+bX(i+1,j,k,n))
-                    + dhy*(bY(i,j,k,n)+bY(i,j+1,k,n))
-                    + dhz*(bZ(i,j,k,n)+bZ(i,j,k+1,n));
-            }
-        }
-    }
-    }
+    x(i,j,k,n) /= alpha*a(i,j,k)
+        + dhx*(bX(i,j,k,n)+bX(i+1,j,k,n))
+        + dhy*(bY(i,j,k,n)+bY(i,j+1,k,n))
+        + dhz*(bZ(i,j,k,n)+bZ(i,j,k+1,n));
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
@@ -236,7 +197,7 @@ void mlabeclap_flux_zface (Box const& box, Array4<Real> const& fz, Array4<Real c
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-void abec_gsrb (Box const& box, Array4<Real> const& phi, Array4<Real const> const& rhs,
+void abec_gsrb (int i, int j, int k, int n, Array4<Real> const& phi, Array4<Real const> const& rhs,
                 Real alpha, Array4<Real const> const& a,
                 Real dhx, Real dhy, Real dhz,
                 Array4<Real const> const& bX, Array4<Real const> const& bY,
@@ -249,62 +210,52 @@ void abec_gsrb (Box const& box, Array4<Real> const& phi, Array4<Real const> cons
                 Array4<Real const> const& f4,
                 Array4<Real const> const& f1, Array4<Real const> const& f3,
                 Array4<Real const> const& f5,
-                Box const& vbox, int redblack, int nc) noexcept
+                Box const& vbox, int redblack) noexcept
 {
-    const auto lo = amrex::lbound(box);
-    const auto hi = amrex::ubound(box);
-    const auto vlo = amrex::lbound(vbox);
-    const auto vhi = amrex::ubound(vbox);
-
     constexpr Real omega = Real(1.15);
 
-    for (int n = 0; n < nc; ++n) {
-        for         (int k = lo.z; k <= hi.z; ++k) {
-            for     (int j = lo.y; j <= hi.y; ++j) {
-                AMREX_PRAGMA_SIMD
-                for (int i = lo.x; i <= hi.x; ++i) {
-                    if ((i+j+k+redblack)%2 == 0) {
-                        Real cf0 = (i == vlo.x && m0(vlo.x-1,j,k) > 0)
-                            ? f0(vlo.x,j,k,n) : Real(0.0);
-                        Real cf1 = (j == vlo.y && m1(i,vlo.y-1,k) > 0)
-                            ? f1(i,vlo.y,k,n) : Real(0.0);
-                        Real cf2 = (k == vlo.z && m2(i,j,vlo.z-1) > 0)
-                            ? f2(i,j,vlo.z,n) : Real(0.0);
-                        Real cf3 = (i == vhi.x && m3(vhi.x+1,j,k) > 0)
-                            ? f3(vhi.x,j,k,n) : Real(0.0);
-                        Real cf4 = (j == vhi.y && m4(i,vhi.y+1,k) > 0)
-                            ? f4(i,vhi.y,k,n) : Real(0.0);
-                        Real cf5 = (k == vhi.z && m5(i,j,vhi.z+1) > 0)
-                            ? f5(i,j,vhi.z,n) : Real(0.0);
+    if ((i+j+k+redblack)%2 == 0) {
+        const auto vlo = amrex::lbound(vbox);
+        const auto vhi = amrex::ubound(vbox);
 
-                        Real gamma = alpha*a(i,j,k)
-                            +   dhx*(bX(i,j,k,n)+bX(i+1,j,k,n))
-                            +   dhy*(bY(i,j,k,n)+bY(i,j+1,k,n))
-                            +   dhz*(bZ(i,j,k,n)+bZ(i,j,k+1,n));
+        Real cf0 = (i == vlo.x && m0(vlo.x-1,j,k) > 0)
+            ? f0(vlo.x,j,k,n) : Real(0.0);
+        Real cf1 = (j == vlo.y && m1(i,vlo.y-1,k) > 0)
+            ? f1(i,vlo.y,k,n) : Real(0.0);
+        Real cf2 = (k == vlo.z && m2(i,j,vlo.z-1) > 0)
+            ? f2(i,j,vlo.z,n) : Real(0.0);
+        Real cf3 = (i == vhi.x && m3(vhi.x+1,j,k) > 0)
+            ? f3(vhi.x,j,k,n) : Real(0.0);
+        Real cf4 = (j == vhi.y && m4(i,vhi.y+1,k) > 0)
+            ? f4(i,vhi.y,k,n) : Real(0.0);
+        Real cf5 = (k == vhi.z && m5(i,j,vhi.z+1) > 0)
+            ? f5(i,j,vhi.z,n) : Real(0.0);
 
-                        Real g_m_d = gamma
-                            - (dhx*(bX(i,j,k,n)*cf0 + bX(i+1,j,k,n)*cf3)
-                            +  dhy*(bY(i,j,k,n)*cf1 + bY(i,j+1,k,n)*cf4)
-                            +  dhz*(bZ(i,j,k,n)*cf2 + bZ(i,j,k+1,n)*cf5));
+        Real gamma = alpha*a(i,j,k)
+            +   dhx*(bX(i,j,k,n)+bX(i+1,j,k,n))
+            +   dhy*(bY(i,j,k,n)+bY(i,j+1,k,n))
+            +   dhz*(bZ(i,j,k,n)+bZ(i,j,k+1,n));
 
-                        Real rho =  dhx*( bX(i  ,j,k,n)*phi(i-1,j,k,n)
-                                  +       bX(i+1,j,k,n)*phi(i+1,j,k,n) )
-                                  + dhy*( bY(i,j  ,k,n)*phi(i,j-1,k,n)
-                                  +       bY(i,j+1,k,n)*phi(i,j+1,k,n) )
-                                  + dhz*( bZ(i,j,k  ,n)*phi(i,j,k-1,n)
-                                  +       bZ(i,j,k+1,n)*phi(i,j,k+1,n) );
+        Real g_m_d = gamma
+            - (dhx*(bX(i,j,k,n)*cf0 + bX(i+1,j,k,n)*cf3)
+            +  dhy*(bY(i,j,k,n)*cf1 + bY(i,j+1,k,n)*cf4)
+            +  dhz*(bZ(i,j,k,n)*cf2 + bZ(i,j,k+1,n)*cf5));
 
-                        Real res =  rhs(i,j,k,n) - (gamma*phi(i,j,k,n) - rho);
-                        phi(i,j,k,n) = phi(i,j,k,n) + omega/g_m_d * res;
-                    }
-                }
-            }
-        }
+        Real rho =  dhx*( bX(i  ,j,k,n)*phi(i-1,j,k,n)
+                  +       bX(i+1,j,k,n)*phi(i+1,j,k,n) )
+                  + dhy*( bY(i,j  ,k,n)*phi(i,j-1,k,n)
+                  +       bY(i,j+1,k,n)*phi(i,j+1,k,n) )
+                  + dhz*( bZ(i,j,k  ,n)*phi(i,j,k-1,n)
+                  +       bZ(i,j,k+1,n)*phi(i,j,k+1,n) );
+
+        Real res =  rhs(i,j,k,n) - (gamma*phi(i,j,k,n) - rho);
+        phi(i,j,k,n) = phi(i,j,k,n) + omega/g_m_d * res;
     }
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-void abec_gsrb_os (Box const& box, Array4<Real> const& phi, Array4<Real const> const& rhs,
+void abec_gsrb_os (int i, int j, int k, int n,
+                   Array4<Real> const& phi, Array4<Real const> const& rhs,
                    Real alpha, Array4<Real const> const& a,
                    Real dhx, Real dhy, Real dhz,
                    Array4<Real const> const& bX, Array4<Real const> const& bY,
@@ -318,60 +269,49 @@ void abec_gsrb_os (Box const& box, Array4<Real> const& phi, Array4<Real const> c
                    Array4<Real const> const& f1, Array4<Real const> const& f3,
                    Array4<Real const> const& f5,
                    Array4<int const> const& osm,
-                   Box const& vbox, int redblack, int nc) noexcept
+                   Box const& vbox, int redblack) noexcept
 {
-    const auto lo = amrex::lbound(box);
-    const auto hi = amrex::ubound(box);
-    const auto vlo = amrex::lbound(vbox);
-    const auto vhi = amrex::ubound(vbox);
-
     constexpr Real omega = Real(1.15);
 
-    for (int n = 0; n < nc; ++n) {
-        for         (int k = lo.z; k <= hi.z; ++k) {
-            for     (int j = lo.y; j <= hi.y; ++j) {
-                AMREX_PRAGMA_SIMD
-                for (int i = lo.x; i <= hi.x; ++i) {
-                    if ((i+j+k+redblack)%2 == 0) {
-                        if (osm(i,j,k) == 0) {
-                            phi(i,j,k,n) = Real(0.0);
-                        } else {
-                            Real cf0 = (i == vlo.x && m0(vlo.x-1,j,k) > 0)
-                                ? f0(vlo.x,j,k,n) : Real(0.0);
-                            Real cf1 = (j == vlo.y && m1(i,vlo.y-1,k) > 0)
-                                ? f1(i,vlo.y,k,n) : Real(0.0);
-                            Real cf2 = (k == vlo.z && m2(i,j,vlo.z-1) > 0)
-                                ? f2(i,j,vlo.z,n) : Real(0.0);
-                            Real cf3 = (i == vhi.x && m3(vhi.x+1,j,k) > 0)
-                                ? f3(vhi.x,j,k,n) : Real(0.0);
-                            Real cf4 = (j == vhi.y && m4(i,vhi.y+1,k) > 0)
-                                ? f4(i,vhi.y,k,n) : Real(0.0);
-                            Real cf5 = (k == vhi.z && m5(i,j,vhi.z+1) > 0)
-                                ? f5(i,j,vhi.z,n) : Real(0.0);
+    if ((i+j+k+redblack)%2 == 0) {
+        if (osm(i,j,k) == 0) {
+            phi(i,j,k,n) = Real(0.0);
+        } else {
+            const auto vlo = amrex::lbound(vbox);
+            const auto vhi = amrex::ubound(vbox);
 
-                            Real gamma = alpha*a(i,j,k)
-                                +   dhx*(bX(i,j,k,n)+bX(i+1,j,k,n))
-                                +   dhy*(bY(i,j,k,n)+bY(i,j+1,k,n))
-                                +   dhz*(bZ(i,j,k,n)+bZ(i,j,k+1,n));
+            Real cf0 = (i == vlo.x && m0(vlo.x-1,j,k) > 0)
+                ? f0(vlo.x,j,k,n) : Real(0.0);
+            Real cf1 = (j == vlo.y && m1(i,vlo.y-1,k) > 0)
+                ? f1(i,vlo.y,k,n) : Real(0.0);
+            Real cf2 = (k == vlo.z && m2(i,j,vlo.z-1) > 0)
+                ? f2(i,j,vlo.z,n) : Real(0.0);
+            Real cf3 = (i == vhi.x && m3(vhi.x+1,j,k) > 0)
+                ? f3(vhi.x,j,k,n) : Real(0.0);
+            Real cf4 = (j == vhi.y && m4(i,vhi.y+1,k) > 0)
+                ? f4(i,vhi.y,k,n) : Real(0.0);
+            Real cf5 = (k == vhi.z && m5(i,j,vhi.z+1) > 0)
+                ? f5(i,j,vhi.z,n) : Real(0.0);
 
-                            Real g_m_d = gamma
-                                - (dhx*(bX(i,j,k,n)*cf0 + bX(i+1,j,k,n)*cf3)
-                                +  dhy*(bY(i,j,k,n)*cf1 + bY(i,j+1,k,n)*cf4)
-                                +  dhz*(bZ(i,j,k,n)*cf2 + bZ(i,j,k+1,n)*cf5));
+            Real gamma = alpha*a(i,j,k)
+                +   dhx*(bX(i,j,k,n)+bX(i+1,j,k,n))
+                +   dhy*(bY(i,j,k,n)+bY(i,j+1,k,n))
+                +   dhz*(bZ(i,j,k,n)+bZ(i,j,k+1,n));
 
-                            Real rho =  dhx*( bX(i  ,j,k,n)*phi(i-1,j,k,n)
-                                      +       bX(i+1,j,k,n)*phi(i+1,j,k,n) )
-                                      + dhy*( bY(i,j  ,k,n)*phi(i,j-1,k,n)
-                                      +       bY(i,j+1,k,n)*phi(i,j+1,k,n) )
-                                      + dhz*( bZ(i,j,k  ,n)*phi(i,j,k-1,n)
-                                      +       bZ(i,j,k+1,n)*phi(i,j,k+1,n) );
+            Real g_m_d = gamma
+                - (dhx*(bX(i,j,k,n)*cf0 + bX(i+1,j,k,n)*cf3)
+                +  dhy*(bY(i,j,k,n)*cf1 + bY(i,j+1,k,n)*cf4)
+                +  dhz*(bZ(i,j,k,n)*cf2 + bZ(i,j,k+1,n)*cf5));
 
-                            Real res =  rhs(i,j,k,n) - (gamma*phi(i,j,k,n) - rho);
-                            phi(i,j,k,n) = phi(i,j,k,n) + omega/g_m_d * res;
-                        }
-                    }
-                }
-            }
+            Real rho =  dhx*( bX(i  ,j,k,n)*phi(i-1,j,k,n)
+                      +       bX(i+1,j,k,n)*phi(i+1,j,k,n) )
+                      + dhy*( bY(i,j  ,k,n)*phi(i,j-1,k,n)
+                      +       bY(i,j+1,k,n)*phi(i,j+1,k,n) )
+                      + dhz*( bZ(i,j,k  ,n)*phi(i,j,k-1,n)
+                      +       bZ(i,j,k+1,n)*phi(i,j,k+1,n) );
+
+            Real res =  rhs(i,j,k,n) - (gamma*phi(i,j,k,n) - rho);
+            phi(i,j,k,n) = phi(i,j,k,n) + omega/g_m_d * res;
         }
     }
 }

--- a/Src/LinearSolvers/MLMG/AMReX_MLABecLaplacian.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLABecLaplacian.cpp
@@ -455,31 +455,62 @@ MLABecLaplacian::Fapply (int amrlev, int mglev, MultiFab& out, const MultiFab& i
 
     const int ncomp = getNComp();
 
+#ifdef AMREX_USE_GPU
+    if (Gpu::inLaunchRegion() && out.isFusingCandidate()) {
+        const auto& xma = in.const_arrays();
+        const auto& yma = out.arrays();
+        const auto& ama = acoef.arrays();
+        AMREX_D_TERM(const auto& bxma = bxcoef.const_arrays();,
+                     const auto& byma = bycoef.const_arrays();,
+                     const auto& bzma = bzcoef.const_arrays(););
+        if (m_overset_mask[amrlev][mglev]) {
+            const auto& osmma = m_overset_mask[amrlev][mglev]->const_arrays();
+            ParallelFor(out, ncomp,
+            [=] AMREX_GPU_DEVICE (int box_no, int i, int j, int k, int n) noexcept
+            {
+                mlabeclap_adotx_os(i,j,k,n, yma[box_no], xma[box_no], ama[box_no],
+                                   AMREX_D_DECL(bxma[box_no],byma[box_no],bzma[box_no]),
+                                   osmma[box_no], dxinv, ascalar, bscalar);
+            });
+        } else {
+            ParallelFor(out, ncomp,
+            [=] AMREX_GPU_DEVICE (int box_no, int i, int j, int k, int n) noexcept
+            {
+                mlabeclap_adotx(i,j,k,n, yma[box_no], xma[box_no], ama[box_no],
+                                AMREX_D_DECL(bxma[box_no],byma[box_no],bzma[box_no]),
+                                dxinv, ascalar, bscalar);
+            });
+        }
+        Gpu::streamSynchronize();
+    } else
+#endif
+    {
 #ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
-    for (MFIter mfi(out, TilingIfNotGPU()); mfi.isValid(); ++mfi)
-    {
-        const Box& bx = mfi.tilebox();
-        const auto& xfab = in.array(mfi);
-        const auto& yfab = out.array(mfi);
-        const auto& afab = acoef.array(mfi);
-        AMREX_D_TERM(const auto& bxfab = bxcoef.array(mfi);,
-                     const auto& byfab = bycoef.array(mfi);,
-                     const auto& bzfab = bzcoef.array(mfi););
-        if (m_overset_mask[amrlev][mglev]) {
-            const auto& osm = m_overset_mask[amrlev][mglev]->const_array(mfi);
-            AMREX_LAUNCH_HOST_DEVICE_FUSIBLE_LAMBDA ( bx, tbx,
-            {
-                mlabeclap_adotx_os(tbx, yfab, xfab, afab, AMREX_D_DECL(bxfab,byfab,bzfab),
-                                   osm, dxinv, ascalar, bscalar, ncomp);
-            });
-        } else {
-            AMREX_LAUNCH_HOST_DEVICE_FUSIBLE_LAMBDA ( bx, tbx,
-            {
-                mlabeclap_adotx(tbx, yfab, xfab, afab, AMREX_D_DECL(bxfab,byfab,bzfab),
-                                dxinv, ascalar, bscalar, ncomp);
-            });
+        for (MFIter mfi(out, TilingIfNotGPU()); mfi.isValid(); ++mfi)
+        {
+            const Box& bx = mfi.tilebox();
+            const auto& xfab = in.array(mfi);
+            const auto& yfab = out.array(mfi);
+            const auto& afab = acoef.array(mfi);
+            AMREX_D_TERM(const auto& bxfab = bxcoef.array(mfi);,
+                         const auto& byfab = bycoef.array(mfi);,
+                         const auto& bzfab = bzcoef.array(mfi););
+            if (m_overset_mask[amrlev][mglev]) {
+                const auto& osm = m_overset_mask[amrlev][mglev]->const_array(mfi);
+                AMREX_HOST_DEVICE_PARALLEL_FOR_4D(bx, ncomp, i, j, k, n,
+                {
+                    mlabeclap_adotx_os(i,j,k,n, yfab, xfab, afab, AMREX_D_DECL(bxfab,byfab,bzfab),
+                                       osm, dxinv, ascalar, bscalar);
+                });
+            } else {
+                AMREX_HOST_DEVICE_PARALLEL_FOR_4D(bx, ncomp, i, j, k, n,
+                {
+                    mlabeclap_adotx(i,j,k,n, yfab, xfab, afab, AMREX_D_DECL(bxfab,byfab,bzfab),
+                                    dxinv, ascalar, bscalar);
+                });
+            }
         }
     }
 }
@@ -501,23 +532,42 @@ MLABecLaplacian::normalize (int amrlev, int mglev, MultiFab& mf) const
 
     const int ncomp = getNComp();
 
+#ifdef AMREX_USE_GPU
+    if (Gpu::inLaunchRegion() && mf.isFusingCandidate()) {
+        const auto& ma = mf.arrays();
+        const auto& ama = acoef.const_arrays();
+        AMREX_D_TERM(const auto& bxma = bxcoef.const_arrays();,
+                     const auto& byma = bycoef.const_arrays();,
+                     const auto& bzma = bzcoef.const_arrays(););
+        ParallelFor(mf, ncomp,
+        [=] AMREX_GPU_DEVICE (int box_no, int i, int j, int k, int n) noexcept
+        {
+            mlabeclap_normalize(i,j,k,n, ma[box_no], ama[box_no],
+                                AMREX_D_DECL(bxma[box_no],byma[box_no],bzma[box_no]),
+                                dxinv, ascalar, bscalar);
+        });
+        Gpu::streamSynchronize();
+    } else
+#endif
+    {
 #ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
-    for (MFIter mfi(mf, TilingIfNotGPU()); mfi.isValid(); ++mfi)
-    {
-        const Box& bx = mfi.tilebox();
-        const auto& fab = mf.array(mfi);
-        const auto& afab = acoef.array(mfi);
-        AMREX_D_TERM(const auto& bxfab = bxcoef.array(mfi);,
-                     const auto& byfab = bycoef.array(mfi);,
-                     const auto& bzfab = bzcoef.array(mfi););
-
-        AMREX_LAUNCH_HOST_DEVICE_FUSIBLE_LAMBDA ( bx, tbx,
+        for (MFIter mfi(mf, TilingIfNotGPU()); mfi.isValid(); ++mfi)
         {
-            mlabeclap_normalize(tbx, fab, afab, AMREX_D_DECL(bxfab,byfab,bzfab),
-                                dxinv, ascalar, bscalar, ncomp);
-        });
+            const Box& bx = mfi.tilebox();
+            const auto& fab = mf.array(mfi);
+            const auto& afab = acoef.array(mfi);
+            AMREX_D_TERM(const auto& bxfab = bxcoef.array(mfi);,
+                         const auto& byfab = bycoef.array(mfi);,
+                         const auto& bzfab = bzcoef.array(mfi););
+
+            AMREX_HOST_DEVICE_PARALLEL_FOR_4D(bx, ncomp, i, j, k, n,
+            {
+                mlabeclap_normalize(i,j,k,n, fab, afab, AMREX_D_DECL(bxfab,byfab,bzfab),
+                                    dxinv, ascalar, bscalar);
+            });
+        }
     }
 }
 
@@ -532,6 +582,7 @@ MLABecLaplacian::Fsmooth (int amrlev, int mglev, MultiFab& sol, const MultiFab& 
     }
 
     const MultiFab& acoef = m_a_coeffs[amrlev][mglev];
+    AMREX_ALWAYS_ASSERT(acoef.nGrowVect() == 0);
     AMREX_D_TERM(const MultiFab& bxcoef = m_b_coeffs[amrlev][mglev][0];,
                  const MultiFab& bycoef = m_b_coeffs[amrlev][mglev][1];,
                  const MultiFab& bzcoef = m_b_coeffs[amrlev][mglev][2];);
@@ -569,85 +620,154 @@ MLABecLaplacian::Fsmooth (int amrlev, int mglev, MultiFab& sol, const MultiFab& 
                  const Real dhz = m_b_scalar/(h[2]*h[2]));
     const Real alpha = m_a_scalar;
 
-    MFItInfo mfi_info;
-    if (Gpu::notInLaunchRegion()) mfi_info.EnableTiling().SetDynamic(true);
-
-#ifdef AMREX_USE_OMP
-#pragma omp parallel if (Gpu::notInLaunchRegion())
-#endif
-    for (MFIter mfi(sol,mfi_info); mfi.isValid(); ++mfi)
+#ifdef AMREX_USE_GPU
+    if (Gpu::inLaunchRegion() && sol.isFusingCandidate()
+        && (m_overset_mask[amrlev][mglev] || regular_coarsening))
     {
-        const auto& m0 = mm0.array(mfi);
-        const auto& m1 = mm1.array(mfi);
+        const auto& m0ma = mm0.const_arrays();
+        const auto& m1ma = mm1.const_arrays();
 #if (AMREX_SPACEDIM > 1)
-        const auto& m2 = mm2.array(mfi);
-        const auto& m3 = mm3.array(mfi);
+        const auto& m2ma = mm2.const_arrays();
+        const auto& m3ma = mm3.const_arrays();
 #if (AMREX_SPACEDIM > 2)
-        const auto& m4 = mm4.array(mfi);
-        const auto& m5 = mm5.array(mfi);
+        const auto& m4ma = mm4.const_arrays();
+        const auto& m5ma = mm5.const_arrays();
 #endif
 #endif
 
-        const Box& tbx = mfi.tilebox();
-        const Box& vbx = mfi.validbox();
-        const auto& solnfab = sol.array(mfi);
-        const auto& rhsfab  = rhs.array(mfi);
-        const auto& afab    = acoef.array(mfi);
+        const auto& solnma = sol.arrays();
+        const auto& rhsma = rhs.const_arrays();
+        const auto& ama = acoef.const_arrays();
 
-        AMREX_D_TERM(const auto& bxfab = bxcoef.array(mfi);,
-                     const auto& byfab = bycoef.array(mfi);,
-                     const auto& bzfab = bzcoef.array(mfi););
+        AMREX_D_TERM(const auto& bxma = bxcoef.const_arrays();,
+                     const auto& byma = bycoef.const_arrays();,
+                     const auto& bzma = bzcoef.const_arrays(););
 
-        const auto& f0fab = f0.array(mfi);
-        const auto& f1fab = f1.array(mfi);
+        const auto& f0ma = f0.const_arrays();
+        const auto& f1ma = f1.const_arrays();
 #if (AMREX_SPACEDIM > 1)
-        const auto& f2fab = f2.array(mfi);
-        const auto& f3fab = f3.array(mfi);
+        const auto& f2ma = f2.const_arrays();
+        const auto& f3ma = f3.const_arrays();
 #if (AMREX_SPACEDIM > 2)
-        const auto& f4fab = f4.array(mfi);
-        const auto& f5fab = f5.array(mfi);
+        const auto& f4ma = f4.const_arrays();
+        const auto& f5ma = f5.const_arrays();
 #endif
 #endif
 
         if (m_overset_mask[amrlev][mglev]) {
-            const auto& osm = m_overset_mask[amrlev][mglev]->array(mfi);
-            AMREX_LAUNCH_HOST_DEVICE_FUSIBLE_LAMBDA ( tbx, thread_box,
+            const auto& osmma = m_overset_mask[amrlev][mglev]->const_arrays();
+            ParallelFor(sol, nc,
+            [=] AMREX_GPU_DEVICE (int box_no, int i, int j, int k, int n) noexcept
             {
-                abec_gsrb_os(thread_box, solnfab, rhsfab, alpha, afab,
+                Box vbx(ama[box_no]);
+                abec_gsrb_os(i,j,k,n, solnma[box_no], rhsma[box_no], alpha, ama[box_no],
                              AMREX_D_DECL(dhx, dhy, dhz),
-                             AMREX_D_DECL(bxfab, byfab, bzfab),
-                             AMREX_D_DECL(m0,m2,m4),
-                             AMREX_D_DECL(m1,m3,m5),
-                             AMREX_D_DECL(f0fab,f2fab,f4fab),
-                             AMREX_D_DECL(f1fab,f3fab,f5fab),
-                             osm, vbx, redblack, nc);
+                             AMREX_D_DECL(bxma[box_no],byma[box_no],bzma[box_no]),
+                             AMREX_D_DECL(m0ma[box_no],m2ma[box_no],m4ma[box_no]),
+                             AMREX_D_DECL(m1ma[box_no],m3ma[box_no],m5ma[box_no]),
+                             AMREX_D_DECL(f0ma[box_no],f2ma[box_no],f4ma[box_no]),
+                             AMREX_D_DECL(f1ma[box_no],f3ma[box_no],f5ma[box_no]),
+                             osmma[box_no], vbx, redblack);
             });
         } else if (regular_coarsening) {
-            AMREX_LAUNCH_HOST_DEVICE_FUSIBLE_LAMBDA ( tbx, thread_box,
+            ParallelFor(sol, nc,
+            [=] AMREX_GPU_DEVICE (int box_no, int i, int j, int k, int n) noexcept
             {
-                abec_gsrb(thread_box, solnfab, rhsfab, alpha, afab,
+                Box vbx(ama[box_no]);
+                abec_gsrb(i,j,k,n, solnma[box_no], rhsma[box_no], alpha, ama[box_no],
                           AMREX_D_DECL(dhx, dhy, dhz),
-                          AMREX_D_DECL(bxfab, byfab, bzfab),
-                          AMREX_D_DECL(m0,m2,m4),
-                          AMREX_D_DECL(m1,m3,m5),
-                          AMREX_D_DECL(f0fab,f2fab,f4fab),
-                          AMREX_D_DECL(f1fab,f3fab,f5fab),
-                          vbx, redblack, nc);
+                          AMREX_D_DECL(bxma[box_no],byma[box_no],bzma[box_no]),
+                          AMREX_D_DECL(m0ma[box_no],m2ma[box_no],m4ma[box_no]),
+                          AMREX_D_DECL(m1ma[box_no],m3ma[box_no],m5ma[box_no]),
+                          AMREX_D_DECL(f0ma[box_no],f2ma[box_no],f4ma[box_no]),
+                          AMREX_D_DECL(f1ma[box_no],f3ma[box_no],f5ma[box_no]),
+                          vbx, redblack);
             });
-        } else {
-            Gpu::LaunchSafeGuard lsg(false); // xxxxx gpu todo
-            // line solve does not with with GPU
-            AMREX_LAUNCH_HOST_DEVICE_LAMBDA ( tbx, thread_box,
-            {
-                abec_gsrb_with_line_solve(thread_box, solnfab, rhsfab, alpha, afab,
-                                          AMREX_D_DECL(dhx, dhy, dhz),
-                                          AMREX_D_DECL(bxfab, byfab, bzfab),
-                                          AMREX_D_DECL(m0,m2,m4),
-                                          AMREX_D_DECL(m1,m3,m5),
-                                          AMREX_D_DECL(f0fab,f2fab,f4fab),
-                                          AMREX_D_DECL(f1fab,f3fab,f5fab),
-                                          vbx, redblack, nc);
-            });
+        }
+        Gpu::streamSynchronize();
+    } else
+#endif
+    {
+        MFItInfo mfi_info;
+        if (Gpu::notInLaunchRegion()) mfi_info.EnableTiling().SetDynamic(true);
+
+#ifdef AMREX_USE_OMP
+#pragma omp parallel if (Gpu::notInLaunchRegion())
+#endif
+        for (MFIter mfi(sol,mfi_info); mfi.isValid(); ++mfi)
+        {
+            const auto& m0 = mm0.array(mfi);
+            const auto& m1 = mm1.array(mfi);
+#if (AMREX_SPACEDIM > 1)
+            const auto& m2 = mm2.array(mfi);
+            const auto& m3 = mm3.array(mfi);
+#if (AMREX_SPACEDIM > 2)
+            const auto& m4 = mm4.array(mfi);
+            const auto& m5 = mm5.array(mfi);
+#endif
+#endif
+
+            const Box& tbx = mfi.tilebox();
+            const Box& vbx = mfi.validbox();
+            const auto& solnfab = sol.array(mfi);
+            const auto& rhsfab  = rhs.const_array(mfi);
+            const auto& afab    = acoef.const_array(mfi);
+
+            AMREX_D_TERM(const auto& bxfab = bxcoef.const_array(mfi);,
+                         const auto& byfab = bycoef.const_array(mfi);,
+                         const auto& bzfab = bzcoef.const_array(mfi););
+
+            const auto& f0fab = f0.const_array(mfi);
+            const auto& f1fab = f1.const_array(mfi);
+#if (AMREX_SPACEDIM > 1)
+            const auto& f2fab = f2.const_array(mfi);
+            const auto& f3fab = f3.const_array(mfi);
+#if (AMREX_SPACEDIM > 2)
+            const auto& f4fab = f4.const_array(mfi);
+            const auto& f5fab = f5.const_array(mfi);
+#endif
+#endif
+
+            if (m_overset_mask[amrlev][mglev]) {
+                const auto& osm = m_overset_mask[amrlev][mglev]->const_array(mfi);
+                AMREX_HOST_DEVICE_PARALLEL_FOR_4D(tbx, nc, i, j, k, n,
+                {
+                    abec_gsrb_os(i,j,k,n, solnfab, rhsfab, alpha, afab,
+                                 AMREX_D_DECL(dhx, dhy, dhz),
+                                 AMREX_D_DECL(bxfab, byfab, bzfab),
+                                 AMREX_D_DECL(m0,m2,m4),
+                                 AMREX_D_DECL(m1,m3,m5),
+                                 AMREX_D_DECL(f0fab,f2fab,f4fab),
+                                 AMREX_D_DECL(f1fab,f3fab,f5fab),
+                                 osm, vbx, redblack);
+                });
+            } else if (regular_coarsening) {
+                AMREX_HOST_DEVICE_PARALLEL_FOR_4D(tbx, nc, i, j, k, n,
+                {
+                    abec_gsrb(i,j,k,n, solnfab, rhsfab, alpha, afab,
+                              AMREX_D_DECL(dhx, dhy, dhz),
+                              AMREX_D_DECL(bxfab, byfab, bzfab),
+                              AMREX_D_DECL(m0,m2,m4),
+                              AMREX_D_DECL(m1,m3,m5),
+                              AMREX_D_DECL(f0fab,f2fab,f4fab),
+                              AMREX_D_DECL(f1fab,f3fab,f5fab),
+                              vbx, redblack);
+                });
+            } else {
+                Gpu::LaunchSafeGuard lsg(false); // xxxxx gpu todo
+                // line solve does not with with GPU
+                AMREX_LAUNCH_HOST_DEVICE_LAMBDA ( tbx, thread_box,
+                {
+                    abec_gsrb_with_line_solve(thread_box, solnfab, rhsfab, alpha, afab,
+                                              AMREX_D_DECL(dhx, dhy, dhz),
+                                              AMREX_D_DECL(bxfab, byfab, bzfab),
+                                              AMREX_D_DECL(m0,m2,m4),
+                                              AMREX_D_DECL(m1,m3,m5),
+                                              AMREX_D_DECL(f0fab,f2fab,f4fab),
+                                              AMREX_D_DECL(f1fab,f3fab,f5fab),
+                                              vbx, redblack, nc);
+                });
+            }
         }
     }
 }
@@ -676,9 +796,9 @@ MLABecLaplacian::FFlux (Box const& box, Real const* dxinv, Real bscalar,
                         Array<FArrayBox*,AMREX_SPACEDIM> const& flux,
                         FArrayBox const& sol, int face_only, int ncomp)
 {
-    AMREX_D_TERM(const auto bx = bcoef[0]->array();,
-                 const auto by = bcoef[1]->array();,
-                 const auto bz = bcoef[2]->array(););
+    AMREX_D_TERM(const auto bx = bcoef[0]->const_array();,
+                 const auto by = bcoef[1]->const_array();,
+                 const auto bz = bcoef[2]->const_array(););
     AMREX_D_TERM(const auto& fxarr = flux[0]->array();,
                  const auto& fyarr = flux[1]->array();,
                  const auto& fzarr = flux[2]->array(););
@@ -689,7 +809,7 @@ MLABecLaplacian::FFlux (Box const& box, Real const* dxinv, Real bscalar,
         Real fac = bscalar*dxinv[0];
         Box blo = amrex::bdryLo(box, 0);
         int blen = box.length(0);
-        AMREX_LAUNCH_HOST_DEVICE_FUSIBLE_LAMBDA ( blo, tbox,
+        AMREX_LAUNCH_HOST_DEVICE_LAMBDA ( blo, tbox,
         {
             mlabeclap_flux_xface(tbox, fxarr, solarr, bx, fac, blen, ncomp);
         });
@@ -697,7 +817,7 @@ MLABecLaplacian::FFlux (Box const& box, Real const* dxinv, Real bscalar,
         fac = bscalar*dxinv[1];
         blo = amrex::bdryLo(box, 1);
         blen = box.length(1);
-        AMREX_LAUNCH_HOST_DEVICE_FUSIBLE_LAMBDA ( blo, tbox,
+        AMREX_LAUNCH_HOST_DEVICE_LAMBDA ( blo, tbox,
         {
             mlabeclap_flux_yface(tbox, fyarr, solarr, by, fac, blen, ncomp);
         });
@@ -706,7 +826,7 @@ MLABecLaplacian::FFlux (Box const& box, Real const* dxinv, Real bscalar,
         fac = bscalar*dxinv[2];
         blo = amrex::bdryLo(box, 2);
         blen = box.length(2);
-        AMREX_LAUNCH_HOST_DEVICE_FUSIBLE_LAMBDA ( blo, tbox,
+        AMREX_LAUNCH_HOST_DEVICE_LAMBDA ( blo, tbox,
         {
             mlabeclap_flux_zface(tbox, fzarr, solarr, bz, fac, blen, ncomp);
         });
@@ -716,14 +836,14 @@ MLABecLaplacian::FFlux (Box const& box, Real const* dxinv, Real bscalar,
     {
         Real fac = bscalar*dxinv[0];
         Box bflux = amrex::surroundingNodes(box, 0);
-        AMREX_LAUNCH_HOST_DEVICE_FUSIBLE_LAMBDA ( bflux, tbox,
+        AMREX_LAUNCH_HOST_DEVICE_LAMBDA ( bflux, tbox,
         {
             mlabeclap_flux_x(tbox, fxarr, solarr, bx, fac, ncomp);
         });
 #if (AMREX_SPACEDIM >= 2)
         fac = bscalar*dxinv[1];
         bflux = amrex::surroundingNodes(box, 1);
-        AMREX_LAUNCH_HOST_DEVICE_FUSIBLE_LAMBDA ( bflux, tbox,
+        AMREX_LAUNCH_HOST_DEVICE_LAMBDA ( bflux, tbox,
         {
             mlabeclap_flux_y(tbox, fyarr, solarr, by, fac, ncomp);
         });
@@ -731,7 +851,7 @@ MLABecLaplacian::FFlux (Box const& box, Real const* dxinv, Real bscalar,
 #if (AMREX_SPACEDIM == 3)
         fac = bscalar*dxinv[2];
         bflux = amrex::surroundingNodes(box, 2);
-        AMREX_LAUNCH_HOST_DEVICE_FUSIBLE_LAMBDA ( bflux, tbox,
+        AMREX_LAUNCH_HOST_DEVICE_LAMBDA ( bflux, tbox,
         {
             mlabeclap_flux_z(tbox, fzarr, solarr, bz, fac, ncomp);
         });
@@ -843,22 +963,41 @@ MLABecLaplacian::makeNLinOp (int /*grid_size*/) const
                                 std::abs(m_b_scalar)*bz_max*dxinv[2]*dxinv[2]));
     ParallelAllReduce::Max(huge_alpha, ParallelContext::CommunicatorSub());
 
+#ifdef AMREX_USE_GPU
+    if (Gpu::inLaunchRegion() && alpha.isFusingCandidate()) {
+        auto const& ama = alpha.arrays();
+        auto const& abotma = alpha_bottom.const_arrays();
+        auto const& mma = osm_bottom.const_arrays();
+        ParallelFor(alpha, ncomp,
+        [=] AMREX_GPU_DEVICE (int box_no, int i, int j, int k, int n) noexcept
+        {
+            if (mma[box_no](i,j,k)) {
+                ama[box_no](i,j,k,n) = abotma[box_no](i,j,k,n);
+            } else {
+                ama[box_no](i,j,k,n) = huge_alpha;
+            }
+        });
+        Gpu::streamSynchronize();
+    } else
+#endif
+    {
 #ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
-    for (MFIter mfi(alpha,TilingIfNotGPU()); mfi.isValid(); ++mfi) {
-        Box const& bx = mfi.tilebox();
-        Array4<Real> const& a = alpha.array(mfi);
-        Array4<Real const> const& abot = alpha_bottom.const_array(mfi);
-        Array4<int const> const& m = osm_bottom.const_array(mfi);
-        AMREX_HOST_DEVICE_PARALLEL_FOR_4D_FUSIBLE(bx, ncomp, i, j, k, n,
-        {
-            if (m(i,j,k)) {
-                a(i,j,k,n) = abot(i,j,k,n);
-            } else {
-                a(i,j,k,n) = huge_alpha;
-            }
-        });
+        for (MFIter mfi(alpha,TilingIfNotGPU()); mfi.isValid(); ++mfi) {
+            Box const& bx = mfi.tilebox();
+            Array4<Real> const& a = alpha.array(mfi);
+            Array4<Real const> const& abot = alpha_bottom.const_array(mfi);
+            Array4<int const> const& m = osm_bottom.const_array(mfi);
+            AMREX_HOST_DEVICE_PARALLEL_FOR_4D(bx, ncomp, i, j, k, n,
+            {
+                if (m(i,j,k)) {
+                    a(i,j,k,n) = abot(i,j,k,n);
+                } else {
+                    a(i,j,k,n) = huge_alpha;
+                }
+            });
+        }
     }
 
     nop->setACoeffs(0, alpha);
@@ -873,22 +1012,42 @@ MLABecLaplacian::copyNSolveSolution (MultiFab& dst, MultiFab const& src) const
     if (m_overset_mask[0].back() == nullptr) return;
 
     const int ncomp = dst.nComp();
+
+#ifdef AMREX_USE_GPU
+    if (Gpu::inLaunchRegion() && dst.isFusingCandidate()) {
+        auto const& dstma = dst.arrays();
+        auto const& srcma = src.const_arrays();
+        auto const& mma = m_overset_mask[0].back()->const_arrays();
+        ParallelFor(dst, ncomp,
+        [=] AMREX_GPU_DEVICE (int box_no, int i, int j, int k, int n) noexcept
+        {
+            if (mma[box_no](i,j,k)) {
+                dstma[box_no](i,j,k,n) = srcma[box_no](i,j,k,n);
+            } else {
+                dstma[box_no](i,j,k,n) = Real(0.0);
+            }
+        });
+        Gpu::streamSynchronize();
+    } else
+#endif
+    {
 #ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
-    for (MFIter mfi(dst,TilingIfNotGPU()); mfi.isValid(); ++mfi) {
-        Box const& bx = mfi.tilebox();
-        Array4<Real> const& dfab = dst.array(mfi);
-        Array4<Real const> const& sfab = src.const_array(mfi);
-        Array4<int const> const& m = m_overset_mask[0].back()->const_array(mfi);
-        AMREX_HOST_DEVICE_PARALLEL_FOR_4D_FUSIBLE(bx, ncomp, i, j, k, n,
-        {
-            if (m(i,j,k)) {
-                dfab(i,j,k,n) = sfab(i,j,k,n);
-            } else {
-                dfab(i,j,k,n) = Real(0.0);
-            }
-        });
+        for (MFIter mfi(dst,TilingIfNotGPU()); mfi.isValid(); ++mfi) {
+            Box const& bx = mfi.tilebox();
+            Array4<Real> const& dfab = dst.array(mfi);
+            Array4<Real const> const& sfab = src.const_array(mfi);
+            Array4<int const> const& m = m_overset_mask[0].back()->const_array(mfi);
+            AMREX_HOST_DEVICE_PARALLEL_FOR_4D(bx, ncomp, i, j, k, n,
+            {
+                if (m(i,j,k)) {
+                    dfab(i,j,k,n) = sfab(i,j,k,n);
+                } else {
+                    dfab(i,j,k,n) = Real(0.0);
+                }
+            });
+        }
     }
 }
 

--- a/Src/LinearSolvers/MLMG/AMReX_MLCellABecLap_1D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLCellABecLap_1D_K.H
@@ -23,6 +23,17 @@ int coarsen_overset_mask (Box const& bx, Array4<int> const& cmsk, Array4<int con
     return nerrors;
 }
 
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void coarsen_overset_mask (int i, int, int, Array4<int> const& cmsk,
+                           Array4<int const> const& fmsk) noexcept
+{
+    int ii = 2*i;
+    cmsk(i,0,0) = fmsk(ii,0,0) + fmsk(ii+1,0,0);
+    if (cmsk(i,0,0) == 2) {
+        cmsk(i,0,0) = 1;
+    }
+}
+
 }
 
 #endif

--- a/Src/LinearSolvers/MLMG/AMReX_MLCellABecLap_2D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLCellABecLap_2D_K.H
@@ -25,6 +25,18 @@ int coarsen_overset_mask (Box const& bx, Array4<int> const& cmsk, Array4<int con
     return nerrors;
 }
 
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void coarsen_overset_mask (int i, int j, int, Array4<int> const& cmsk,
+                           Array4<int const> const& fmsk) noexcept
+{
+    int ii = 2*i;
+    int jj = 2*j;
+    cmsk(i,j,0) = fmsk(ii,jj,0) + fmsk(ii+1,jj,0) + fmsk(ii,jj+1,0) + fmsk(ii+1,jj+1,0);
+    if (cmsk(i,j,0) == 4) {
+        cmsk(i,j,0) = 1;
+    }
+}
+
 }
 
 #endif

--- a/Src/LinearSolvers/MLMG/AMReX_MLCellABecLap_3D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLCellABecLap_3D_K.H
@@ -30,6 +30,22 @@ int coarsen_overset_mask (Box const& bx, Array4<int> const& cmsk, Array4<int con
     return nerrors;
 }
 
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void coarsen_overset_mask (int i, int j, int k, Array4<int> const& cmsk,
+                           Array4<int const> const& fmsk) noexcept
+{
+    int ii = 2*i;
+    int jj = 2*j;
+    int kk = 2*k;
+    cmsk(i,j,k) = fmsk(ii,jj  ,kk  ) + fmsk(ii+1,jj  ,kk  )
+        +         fmsk(ii,jj+1,kk  ) + fmsk(ii+1,jj+1,kk  )
+        +         fmsk(ii,jj  ,kk+1) + fmsk(ii+1,jj  ,kk+1)
+        +         fmsk(ii,jj+1,kk+1) + fmsk(ii+1,jj+1,kk+1);
+    if (cmsk(i,j,k) == 8) {
+        cmsk(i,j,k) = 1;
+    }
+}
+
 }
 
 #endif

--- a/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap.cpp
@@ -889,10 +889,10 @@ MLEBABecLap::normalize (int amrlev, int mglev, MultiFab& mf) const
 
         if (fabtyp == FabType::regular)
         {
-            AMREX_LAUNCH_HOST_DEVICE_LAMBDA (bx, tbx,
+            AMREX_HOST_DEVICE_PARALLEL_FOR_4D(bx, ncomp, i, j, k, n,
             {
-                mlabeclap_normalize(tbx, fab, afab, AMREX_D_DECL(bxfab, byfab, bzfab),
-                                    dxinvarray, ascalar, bscalar, ncomp);
+                mlabeclap_normalize(i,j,k,n, fab, afab, AMREX_D_DECL(bxfab, byfab, bzfab),
+                                    dxinvarray, ascalar, bscalar);
             });
         }
         else if (fabtyp == FabType::singlevalued)

--- a/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap_F.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap_F.cpp
@@ -80,11 +80,11 @@ MLEBABecLap::Fapply (int amrlev, int mglev, MultiFab& out, const MultiFab& in) c
                 yfab(i,j,k,n) = 0.0;
             });
         } else if (fabtyp == FabType::regular) {
-            AMREX_LAUNCH_HOST_DEVICE_LAMBDA ( bx, tbx,
+            AMREX_HOST_DEVICE_PARALLEL_FOR_4D( bx, ncomp, i, j, k, n,
             {
-                mlabeclap_adotx(tbx, yfab, xfab, afab,
+                mlabeclap_adotx(i,j,k,n, yfab, xfab, afab,
                                 AMREX_D_DECL(bxfab,byfab,bzfab),
-                                dxinvarr, ascalar, bscalar, ncomp);
+                                dxinvarr, ascalar, bscalar);
             });
         } else {
             Array4<int const> const& ccmfab = ccmask.const_array(mfi);
@@ -248,16 +248,16 @@ MLEBABecLap::Fsmooth (int amrlev, int mglev, MultiFab& sol, const MultiFab& rhs,
         }
         else if (fabtyp == FabType::regular)
         {
-            AMREX_LAUNCH_HOST_DEVICE_LAMBDA ( vbx, thread_box,
+            AMREX_HOST_DEVICE_PARALLEL_FOR_4D(vbx, nc, i, j, k, n,
             {
-                abec_gsrb(thread_box, solnfab, rhsfab, alpha, afab,
+                abec_gsrb(i,j,k,n, solnfab, rhsfab, alpha, afab,
                           AMREX_D_DECL(dhx, dhy, dhz),
                           AMREX_D_DECL(bxfab, byfab, bzfab),
                           AMREX_D_DECL(m0,m2,m4),
                           AMREX_D_DECL(m1,m3,m5),
                           AMREX_D_DECL(f0fab,f2fab,f4fab),
                           AMREX_D_DECL(f1fab,f3fab,f5fab),
-                          vbx, redblack, nc);
+                          vbx, redblack);
             });
         }
         else

--- a/Src/LinearSolvers/MLMG/AMReX_MLPoisson_1D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLPoisson_1D_K.H
@@ -194,18 +194,12 @@ void mlpoisson_gsrb_m (Box const& box, Array4<Real> const& phi, Array4<Real cons
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-void mlpoisson_normalize (Box const& box, Array4<Real> const& x,
+void mlpoisson_normalize (int i, int, int, Array4<Real> const& x,
                           Real dhx, Real dx, Real probxlo) noexcept
 {
-    const auto lo = amrex::lbound(box);
-    const auto hi = amrex::ubound(box);
-
-    AMREX_PRAGMA_SIMD
-    for (int i = lo.x; i <= hi.x; ++i) {
-        Real rel = (probxlo + i   *dx) * (probxlo + i   *dx);
-        Real rer = (probxlo +(i+1)*dx) * (probxlo +(i+1)*dx);
-        x(i,0,0) /= (-dhx*(rel+rer));
-    }
+    Real rel = (probxlo + i   *dx) * (probxlo + i   *dx);
+    Real rer = (probxlo +(i+1)*dx) * (probxlo +(i+1)*dx);
+    x(i,0,0) /= (-dhx*(rel+rer));
 }
 
 }

--- a/Src/LinearSolvers/MLMG/AMReX_MLPoisson_2D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLPoisson_2D_K.H
@@ -313,21 +313,13 @@ void mlpoisson_gsrb_m (Box const& box, Array4<Real> const& phi, Array4<Real cons
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-void mlpoisson_normalize (Box const& box, Array4<Real> const& x,
+void mlpoisson_normalize (int i, int j, int, Array4<Real> const& x,
                           Real dhx, Real dhy, Real dx, Real probxlo) noexcept
 {
-    const auto lo = amrex::lbound(box);
-    const auto hi = amrex::ubound(box);
-
-    for     (int j = lo.y; j <= hi.y; ++j) {
-        AMREX_PRAGMA_SIMD
-        for (int i = lo.x; i <= hi.x; ++i) {
-            Real rel = probxlo + i*dx;
-            Real rer = probxlo +(i+1)*dx;
-            Real rc = probxlo + (i+Real(0.5))*dx;
-            x(i,j,0) /= (-dhx*(rel+rer) - dhy*rc*Real(2.0));
-        }
-    }
+    Real rel = probxlo + i*dx;
+    Real rer = probxlo +(i+1)*dx;
+    Real rc = probxlo + (i+Real(0.5))*dx;
+    x(i,j,0) /= (-dhx*(rel+rer) - dhy*rc*Real(2.0));
 }
 
 #if (AMREX_SPACEDIM != 2)


### PR DESCRIPTION
Replace some `*_FUSIBLE` macros with MF ParallelFor.  Note that the FUSIBLE
macros are still used in some boundary functions.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
