### PR TITLE
Protect against nullptr when calling PODVector dtor.

### DIFF
--- a/Src/Base/AMReX_GpuAllocators.H
+++ b/Src/Base/AMReX_GpuAllocators.H
@@ -47,7 +47,7 @@ namespace amrex {
 
         inline void deallocate(value_type* ptr, std::size_t)
         {
-            The_Arena()->free(ptr);
+            if (ptr != nullptr) { The_Arena()->free(ptr); }
         }
     };
 
@@ -68,7 +68,7 @@ namespace amrex {
 
         inline void deallocate(value_type* ptr, std::size_t)
         {
-            The_Device_Arena()->free(ptr);
+            if (ptr != nullptr) { The_Device_Arena()->free(ptr); }
         }
     };
 
@@ -89,7 +89,7 @@ namespace amrex {
 
         inline void deallocate(value_type* ptr, std::size_t)
         {
-            The_Pinned_Arena()->free(ptr);
+            if (ptr != nullptr) { The_Pinned_Arena()->free(ptr); }
         }
     };
 
@@ -110,7 +110,7 @@ namespace amrex {
 
         inline void deallocate(value_type* ptr, std::size_t)
         {
-            The_Managed_Arena()->free(ptr);
+            if (ptr != nullptr) { The_Managed_Arena()->free(ptr); }
         }
     };
 
@@ -131,7 +131,7 @@ namespace amrex {
 
         inline void deallocate(value_type* ptr, std::size_t)
         {
-            The_Async_Arena()->free(ptr);
+            if (ptr != nullptr) { The_Async_Arena()->free(ptr); }
         }
     };
 
@@ -160,13 +160,16 @@ namespace amrex {
 
         inline void deallocate(value_type* ptr, std::size_t)
         {
-            if (m_use_gpu_aware_mpi)
+            if (ptr != nullptr)
             {
-                The_Arena()->free(ptr);
-            }
-            else
-            {
-                The_Pinned_Arena()->free(ptr);
+                if (m_use_gpu_aware_mpi)
+                {
+                    The_Arena()->free(ptr);
+                }
+                else
+                {
+                    The_Pinned_Arena()->free(ptr);
+                }
             }
         }
 

--- a/Src/Base/AMReX_PODVector.H
+++ b/Src/Base/AMReX_PODVector.H
@@ -212,7 +212,7 @@ namespace amrex
             a_vector.m_capacity = 0;
         }
 
-        ~PODVector () noexcept { deallocate(m_data, capacity()); }
+        ~PODVector () noexcept { if (m_data != nullptr) { deallocate(m_data, capacity()); }}
 
         PODVector& operator= (const PODVector<T, Allocator>& a_vector) noexcept
         {


### PR DESCRIPTION
This should allow DeviceVector, etc, to be used as global variables provided we swap with an empty vector before `amrex::Finalize()` is called.

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
