### PR TITLE
Add EditorConfig section for rst files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -43,9 +43,6 @@ indent_size = 3
 # Clean up trailing whitespace
 trim_trailing_whitespace = true
 
-# Automatically wrap lines at 80 columns
-max_line_length = 80
-
 [Makefile]
 # TABs are part of its syntax
 indent_style = tab

--- a/.editorconfig
+++ b/.editorconfig
@@ -26,6 +26,26 @@ insert_final_newline = true
 trim_trailing_whitespace = false
 
 
+[*.rst]
+# Enforce UTF-8 encoding
+charset = utf-8
+
+# Unix-style newlines
+end_of_line = lf
+
+# Newline ending in files
+insert_final_newline = true
+
+# 3 space indentation
+indent_style = space
+indent_size = 3
+
+# Clean up trailing whitespace
+trim_trailing_whitespace = true
+
+# Automatically wrap lines at 80 columns
+max_line_length = 80
+
 [Makefile]
 # TABs are part of its syntax
 indent_style = tab


### PR DESCRIPTION
## Summary
Add a section for `*.rst` files for EditorConfig.

## Additional background
When editing the Sphinx `rst` source files for AmrLevel (PR #2268), I found out that the root `.editorconfig` file doesn't have a section for `rst` files. This PR adds that section, roughly based on the guidelines at https://docs.typo3.org/m/typo3/docs-how-to-document/master/en-us/GeneralConventions/CodingGuidelines.html .
Note that I haven't gauged the "disruption" from whitespace changes that might be caused by this PR.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [x] include documentation in the code and/or rst files, if appropriate
