### PR TITLE
Remove faulty assertion from PC::Restart()

### DIFF
--- a/Src/Particle/AMReX_ParticleIO.H
+++ b/Src/Particle/AMReX_ParticleIO.H
@@ -795,9 +795,6 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>
     for (int lev = 0; lev <= finest_level_in_file; lev++) {
         HdrFile >> ngrids[lev];
         AMREX_ASSERT(ngrids[lev] > 0);
-        if (lev <= finestLevel()) {
-            AMREX_ASSERT(ngrids[lev] == int(ParticleBoxArray(lev).size()));
-        }
     }
 
     resizeData();


### PR DESCRIPTION
Follow on to #2276 

This assertion is not always true when there are no particles at some levels in the Checkpoint file.

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
