### PR TITLE
NVHPC adjustments (nvcc + g++)

### DIFF
--- a/Tools/GNUMake/Make.defs
+++ b/Tools/GNUMake/Make.defs
@@ -422,6 +422,8 @@ else ifeq ($(USE_CUDA),TRUE)
     AMREX_CCOMP = $(NVCC_HOST_COMP)
   else ifeq ($(COMP),cray)
     AMREX_CCOMP = cray
+  else ifeq ($(COMP),nvhpc)
+    AMREX_CCOMP = nvhpc
   else
     AMREX_CCOMP = gnu
   endif

--- a/Tools/GNUMake/Make.rules
+++ b/Tools/GNUMake/Make.rules
@@ -163,6 +163,7 @@ clean:: cleanconfig
 	$(SILENT) $(RM) -r $(TmpBuildDir) *~
 	$(SILENT) $(RM) *.ex *.o
 	$(SILENT) $(RM) *.mod
+	$(SILENT) $(RM) *.ptx
 	$(SILENT) $(RM) BLProfParser.lex.yy.cpp
 	$(SILENT) $(RM) BLProfParser.tab.cpp
 	$(SILENT) $(RM) BLProfParser.tab.H


### PR DESCRIPTION
## Summary
Some Perlmutter nvhpc (PrgEnv-nvidia) GNUmake adjustments.
Just for gcc, but compiler warning & error free after this.

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
