### PR TITLE
fix bug in AmrLevel exclusion logic

### DIFF
--- a/Src/Extern/SENSEI/AMReX_AmrParticleDataAdaptor.H
+++ b/Src/Extern/SENSEI/AMReX_AmrParticleDataAdaptor.H
@@ -5,6 +5,7 @@
 #include <AMReX_Config.H>
 #ifdef AMREX_PARTICLES
 
+#include <AMReX_AmrDataAdaptor.H>
 #include <AMReX_Particles.H>
 
 #include <AMReX_AmrMesh.H>

--- a/Src/Extern/SENSEI/CMakeLists.txt
+++ b/Src/Extern/SENSEI/CMakeLists.txt
@@ -38,13 +38,13 @@ if ( AMReX_PARTICLES )
    list ( APPEND amrex_sensei_sources
       AMReX_ParticleDataAdaptor.H
       AMReX_ParticleDataAdaptorI.H
-      AMReX_ParticleInSituBridge.H
-      AMReX_AmrParticleInSituBridge.H )
+      AMReX_ParticleInSituBridge.H )
 
    if( AMReX_AMRLEVEL )
       list ( APPEND amrex_sensei_sources
          AMReX_AmrParticleDataAdaptor.H
-         AMReX_AmrParticleDataAdaptorI.H )
+         AMReX_AmrParticleDataAdaptorI.H
+         AMReX_AmrParticleInSituBridge.H )
    endif()
 endif ()
 


### PR DESCRIPTION
## Summary
Fixes a bug in the build logic regarding optional inclusion of the AMRLEVEL components, and return a required  dependency to AMReX_AmrParticleDataAdaptor.H

## Additional background
This bug was introduced in https://github.com/AMReX-Codes/amrex/pull/2258 where the SENSEI adaptors and bridges that processed data from the Amr class. A key dependency was removed, in the refactor. This Pr adds that dependency back in, and moves `AMReX_AmrParticleInSituBridge.H` behind the `AMReX_AMRLEVEL` compile option where it belongs.
## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
