### PR TITLE
Add SENSEI adaptor and bridge for amrMesh+Particles

### DIFF
--- a/Src/Extern/SENSEI/AMReX_AmrMeshParticleDataAdaptor.H
+++ b/Src/Extern/SENSEI/AMReX_AmrMeshParticleDataAdaptor.H
@@ -1,0 +1,78 @@
+#ifndef AMReX_AmrMeshParticleDataAdaptor_h
+#define AMReX_AmrMeshParticleDataAdaptor_h
+
+// AMReX includes
+#include <AMReX_Config.H>
+#ifdef AMREX_PARTICLES
+
+#include <AMReX_Particles.H>
+
+#include <AMReX_AmrMesh.H>
+#include <AMReX_MultiFab.H>
+#include <AMReX_AmrMeshDataAdaptor.H>
+#include <AMReX_ParticleDataAdaptor.H>
+// sensei includes
+#include "DataAdaptor.h"
+
+namespace amrex
+{
+template<int NStructReal, int NStructInt, int NArrayReal, int NArrayInt>
+class AmrMeshParticleDataAdaptor : public sensei::DataAdaptor
+{
+public:
+  static AmrMeshParticleDataAdaptor* New();
+  senseiTypeMacro(AmrMeshParticleDataAdaptor, sensei::DataAdaptor);
+
+  int SetDataSource(
+    AmrMesh *mesh,
+    const std::vector<amrex::Vector<amrex::MultiFab>*> &mesh_states,
+    const std::vector<std::vector<std::string>> &mesh_names,
+    amrex::ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt> * particles,
+    const std::map<std::string, std::vector<int>> & rStructs = {},
+    const std::map<std::string, int> & iStructs = {},
+    const std::map<std::string, std::vector<int>> & rArrays = {},
+    const std::map<std::string, int> & iArrays = {}
+  );
+
+  // SENSEI API
+#if SENSEI_VERSION_MAJOR >= 3
+  int GetMeshMetadata(unsigned int id, sensei::MeshMetadataPtr &metadata) override;
+#else
+  int GetMeshName(unsigned int id, std::string &meshName) override;
+  int GetMeshHasGhostNodes(const std::string &meshName, int &nLayers) override;
+  int GetMeshHasGhostCells(const std::string &meshName, int &nLayers) override;
+  int GetNumberOfArrays(const std::string &meshName, int association, unsigned int &numberOfArrays) override;
+  int GetArrayName(const std::string &meshName, int association, unsigned int index, std::string &arrayName) override;
+#endif
+  int GetNumberOfMeshes(unsigned int &numMeshes) override;
+  int GetMesh(const std::string &meshName, bool structureOnly, vtkDataObject *&mesh) override;
+  int AddGhostNodesArray(vtkDataObject* mesh, const std::string &meshName) override;
+  int AddGhostCellsArray(vtkDataObject* mesh, const std::string &meshName) override;
+  int AddArray(vtkDataObject* mesh, const std::string &meshName, int association, const std::string &arrayName) override;
+  int ReleaseData() override;
+
+protected:
+  AmrMeshParticleDataAdaptor()
+  {
+    m_meshAdaptor = AmrMeshDataAdaptor::New();
+    m_particleAdaptor = ParticleDataAdaptor<NStructReal, NStructInt, NArrayReal, NArrayInt>::New();
+  }
+
+  ~AmrMeshParticleDataAdaptor()
+  {
+    m_meshAdaptor->Delete();
+    m_particleAdaptor->Delete();
+  }
+
+private:
+  ParticleDataAdaptor<NStructReal, NStructInt, NArrayReal, NArrayInt>* m_particleAdaptor;
+  AmrMeshDataAdaptor* m_meshAdaptor;
+
+  const std::string m_meshName = "mesh";
+  const std::string m_particlesName = "particles";
+};
+}
+
+#include "AMReX_AmrMeshParticleDataAdaptorI.H"
+#endif // AMREX_PARTICLES
+#endif // AMReX_AmrMeshParticleDataAdaptor_h

--- a/Src/Extern/SENSEI/AMReX_AmrMeshParticleDataAdaptorI.H
+++ b/Src/Extern/SENSEI/AMReX_AmrMeshParticleDataAdaptorI.H
@@ -1,0 +1,226 @@
+#include "AMReX_AmrMeshParticleDataAdaptor.H"
+
+namespace amrex
+{
+//-----------------------------------------------------------------------------
+template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt>
+AmrMeshParticleDataAdaptor<NStructReal, NStructInt, NArrayReal, NArrayInt>*
+AmrMeshParticleDataAdaptor<NStructReal, NStructInt, NArrayReal, NArrayInt>::New()
+{
+  auto result = new AmrMeshParticleDataAdaptor<NStructReal, NStructInt, NArrayReal, NArrayInt>;
+  result->InitializeObjectBase();
+  return result;
+}
+
+//-----------------------------------------------------------------------------
+template<int NStructReal, int NStructInt, int NArrayReal, int NArrayInt>
+int AmrMeshParticleDataAdaptor<NStructReal, NStructInt, NArrayReal, NArrayInt>::SetDataSource(
+  AmrMesh *mesh,
+  const std::vector<amrex::Vector<amrex::MultiFab>*> &mesh_states,
+  const std::vector<std::vector<std::string>> &mesh_names,
+  amrex::ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt> * particles,
+  const std::map<std::string, std::vector<int>> & rStructs,
+  const std::map<std::string, int> & iStructs,
+  const std::map<std::string, std::vector<int>> & rArrays,
+  const std::map<std::string, int> & iArrays)
+{
+  int retMesh = this->m_meshAdaptor->SetDataSource(mesh, mesh_states, mesh_names);
+  int retPtls = this->m_particleAdaptor->SetDataSource(particles, rStructs, iStructs, rArrays, iArrays);
+  return retMesh + retPtls;
+}
+
+// SENSEI API
+#if SENSEI_VERSION_MAJOR >= 3
+template<int NStructReal, int NStructInt, int NArrayReal, int NArrayInt>
+int AmrMeshParticleDataAdaptor<NStructReal, NStructInt, NArrayReal, NArrayInt>::GetMeshMetadata(
+  unsigned int id,
+  sensei::MeshMetadataPtr &metadata)
+{
+  if(id == 0)
+  {
+    return this->m_meshAdaptor->GetMeshMetadata(0, metadata);
+  }
+  if(id == 1)
+  {
+    return this->m_particleAdaptor->GetMeshMetadata(1, metadata);
+  }
+  SENSEI_ERROR("unknown mesh ID in GetMeshMetadata");
+  return -1;
+}
+
+#else
+template<int NStructReal, int NStructInt, int NArrayReal, int NArrayInt>
+int AmrMeshParticleDataAdaptor<NStructReal, NStructInt, NArrayReal, NArrayInt>::GetMeshName(
+  unsigned int id,
+  std::string &meshName)
+{
+  if(id == 0)
+  {
+    return this->m_meshAdaptor->GetMeshName(0, meshName);
+  }
+  if(id == 1)
+  {
+    return this->m_particleAdaptor->GetMeshName(1, meshName);
+  }
+  SENSEI_ERROR("unknown mesh ID in GetMeshName");
+  return -1;
+}
+
+template<int NStructReal, int NStructInt, int NArrayReal, int NArrayInt>
+int AmrMeshParticleDataAdaptor<NStructReal, NStructInt, NArrayReal, NArrayInt>::GetMeshHasGhostNodes(
+  const std::string &meshName, int &nLayers)
+{
+  if(id == 0)
+  {
+    return this->m_meshAdaptor->GetMeshHasGhostNodes(meshName, nLayers);
+  }
+  if(id == 1)
+  {
+    return this->m_particleAdaptor->GetMeshHasGhostNodes(meshName, nLayers);
+  }
+  SENSEI_ERROR("unknown mesh ID in GetMeshHasGhostNodes");
+  return -1;
+}
+
+template<int NStructReal, int NStructInt, int NArrayReal, int NArrayInt>
+int AmrMeshParticleDataAdaptor<NStructReal, NStructInt, NArrayReal, NArrayInt>::GetMeshHasGhostCells(
+  const std::string &meshName, int &nLayers)
+{
+  if(id == 0)
+  {
+    return this->m_meshAdaptor->GetMeshHasGhostCells(meshName, nLayers);
+  }
+  if(id == 1)
+  {
+    return this->m_particleAdaptor->GetMeshHasGhostCells(meshName, nLayers);
+  }
+  SENSEI_ERROR("unknown mesh ID in GetMeshHasGhostCells");
+  return -1;
+}
+
+template<int NStructReal, int NStructInt, int NArrayReal, int NArrayInt>
+int AmrMeshParticleDataAdaptor<NStructReal, NStructInt, NArrayReal, NArrayInt>::GetNumberOfArrays(
+  const std::string &meshName,
+  int association,
+  unsigned int &numberOfArrays)
+{
+  if(id == 0)
+  {
+    return this->m_meshAdaptor->GetNumberOfArrays(meshName, association, numberOfArrays);
+  }
+  if(id == 1)
+  {
+    return this->m_particleAdaptor->GetNumberOfArrays(meshName, association, numberOfArrays);
+  }
+  SENSEI_ERROR("unknown mesh ID in GetNumberOfArrays");
+  return -1;
+}
+
+template<int NStructReal, int NStructInt, int NArrayReal, int NArrayInt>
+int AmrMeshParticleDataAdaptor<NStructReal, NStructInt, NArrayReal, NArrayInt>::GetArrayName(
+  const std::string &meshName,
+  int association,
+  unsigned int index,
+  std::string &arrayName)
+{
+  if(id == 0)
+  {
+    return this->m_meshAdaptor->GetArrayName(meshName, association, index, arrayName);
+  }
+  if(id == 1)
+  {
+    return this->m_particleAdaptor->GetArrayName(meshName, association, index, arrayName);
+  }
+  SENSEI_ERROR("unknown mesh ID in GetArrayName");
+  return -1;
+}
+#endif
+
+template<int NStructReal, int NStructInt, int NArrayReal, int NArrayInt>
+int AmrMeshParticleDataAdaptor<NStructReal, NStructInt, NArrayReal, NArrayInt>::GetNumberOfMeshes(
+  unsigned int &numMeshes)
+{
+  numMeshes = 2;
+  return 0;
+}
+
+template<int NStructReal, int NStructInt, int NArrayReal, int NArrayInt>
+int AmrMeshParticleDataAdaptor<NStructReal, NStructInt, NArrayReal, NArrayInt>::GetMesh(
+  const std::string &meshName,
+  bool structureOnly,
+  vtkDataObject *&mesh)
+{
+  if(meshName == m_meshName)
+  {
+    return this->m_meshAdaptor->GetMesh(meshName, structureOnly, mesh);
+  }
+  if(meshName == m_particlesName)
+  {
+    return this->m_particleAdaptor->GetMesh(meshName, structureOnly, mesh);
+  }
+  SENSEI_ERROR("unknown mesh name in GetMesh");
+  return -1;
+}
+
+template<int NStructReal, int NStructInt, int NArrayReal, int NArrayInt>
+int AmrMeshParticleDataAdaptor<NStructReal, NStructInt, NArrayReal, NArrayInt>::AddGhostNodesArray(
+  vtkDataObject* mesh,
+  const std::string &meshName)
+{
+  if(meshName == m_meshName)
+  {
+    return this->m_meshAdaptor->AddGhostNodesArray(mesh, meshName);
+  }
+  if(meshName == m_particlesName)
+  {
+    return this->m_particleAdaptor->AddGhostNodesArray(mesh, meshName);
+  }
+  SENSEI_ERROR("unknown mesh name in AddGhostNodesArray");
+  return -1;
+}
+
+template<int NStructReal, int NStructInt, int NArrayReal, int NArrayInt>
+int AmrMeshParticleDataAdaptor<NStructReal, NStructInt, NArrayReal, NArrayInt>::AddGhostCellsArray(
+  vtkDataObject* mesh,
+  const std::string &meshName)
+{
+  if(meshName == m_meshName)
+  {
+    return this->m_meshAdaptor->AddGhostCellsArray(mesh, meshName);
+  }
+  if(meshName == m_particlesName)
+  {
+    return this->m_particleAdaptor->AddGhostCellsArray(mesh, meshName);
+  }
+  SENSEI_ERROR("unknown mesh name in AddGhostCellsArray");
+  return -1;
+}
+
+template<int NStructReal, int NStructInt, int NArrayReal, int NArrayInt>
+int AmrMeshParticleDataAdaptor<NStructReal, NStructInt, NArrayReal, NArrayInt>::AddArray(
+  vtkDataObject* mesh,
+  const std::string &meshName,
+  int association,
+  const std::string &arrayName)
+{
+  if(meshName == m_meshName)
+  {
+    return this->m_meshAdaptor->AddArray(mesh, meshName, association, arrayName);
+  }
+  if(meshName == m_particlesName)
+  {
+    return this->m_particleAdaptor->AddArray(mesh, meshName, association, arrayName);
+  }
+  SENSEI_ERROR("unknown mesh name in AddArray");
+  return -1;
+}
+
+template<int NStructReal, int NStructInt, int NArrayReal, int NArrayInt>
+int AmrMeshParticleDataAdaptor<NStructReal, NStructInt, NArrayReal, NArrayInt>::ReleaseData()
+{
+  this->m_particleAdaptor->ReleaseData();
+  this->m_meshAdaptor->ReleaseData();
+  return 0;
+}
+
+} // end namespace amrex

--- a/Src/Extern/SENSEI/AMReX_AmrMeshParticleInSituBridge.H
+++ b/Src/Extern/SENSEI/AMReX_AmrMeshParticleInSituBridge.H
@@ -1,0 +1,104 @@
+#ifndef AMReX_AmrMeshParticleInSituBridge_H
+#define AMReX_AmrMeshParticleInSituBridge_H
+#include <AMReX_Config.H>
+
+#ifdef AMREX_PARTICLES
+
+#include <AMReX_InSituBridge.H>
+#include <AMReX_Vector.H>
+
+#include <AMReX_AmrParticles.H>
+
+#include <AMReX_AmrMeshParticleDataAdaptor.H>
+
+#ifdef AMREX_USE_SENSEI_INSITU
+#include <AnalysisAdaptor.h>
+#include <Profiler.h>
+#endif
+
+#include <chrono>
+
+namespace amrex
+{
+
+/// SENSEI bridge code for simulations proccessing both amrex::Amr and amrex::ParticleContainer
+class AmrMeshParticleInSituBridge : public InSituBridge
+{
+public:
+  AmrMeshParticleInSituBridge() {}
+  ~AmrMeshParticleInSituBridge() {}
+
+  AmrMeshParticleInSituBridge(const AmrMeshParticleInSituBridge&) = delete;
+  void operator=(const AmrMeshParticleInSituBridge&) = delete;
+
+  // invoke the in situ analysis with data from an AmrMesh and ParticleContainer
+  // instance.
+  template<int NStructReal, int NStructInt, int NArrayReal, int NArrayInt>
+  int update(
+    long step, double time,
+    amrex::AmrMesh *mesh,
+    const std::vector<amrex::Vector<amrex::MultiFab>*> &mesh_states,
+    const std::vector<std::vector<std::string>> &mesh_names,
+    amrex::ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt> * particles,
+    const std::map<std::string, std::vector<int>> & particles_rStructs = {},
+    const std::map<std::string, int> & particles_iStructs = {},
+    const std::map<std::string, std::vector<int>> & particles_rArrays = {},
+    const std::map<std::string, int> & particles_iArrays = {});
+};
+
+template<int NStructReal, int NStructInt, int NArrayReal, int NArrayInt>
+int AmrMeshParticleInSituBridge::update(
+  long step, double time,
+  amrex::AmrMesh *mesh,
+  const std::vector<amrex::Vector<amrex::MultiFab>*> &mesh_states,
+  const std::vector<std::vector<std::string>> &mesh_names,
+  amrex::ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt> * particles,
+  const std::map<std::string, std::vector<int>> & particles_rStructs,
+  const std::map<std::string, int> & particles_iStructs,
+  const std::map<std::string, std::vector<int>> & particles_rArrays,
+  const std::map<std::string, int> & particles_iArrays)
+{
+  int ret = 0;
+#if defined(AMREX_USE_SENSEI_INSITU)
+  if (doUpdate())
+  {
+    amrex::Print() << "SENSEI AmrMesh+Particles Begin update..." << std::endl;
+    auto t0 = std::chrono::high_resolution_clock::now();
+
+    sensei::TimeEvent<64> event("AmrMeshParticleInSituBridge::update");
+
+    if(!particles)
+    {
+      SENSEI_ERROR("no particles presented at update call");
+      return -1;
+    }
+
+    amrex::AmrMeshParticleDataAdaptor<NStructReal, NStructInt, NArrayReal, NArrayInt> *data_adaptor
+      = amrex::AmrMeshParticleDataAdaptor<NStructReal, NStructInt, NArrayReal, NArrayInt>::New();
+
+    if (comm != MPI_COMM_NULL)
+      data_adaptor->SetCommunicator(comm);
+
+    data_adaptor->SetDataSource(
+      mesh, mesh_states, mesh_names,
+      particles, particles_rStructs, particles_iStructs,
+      particles_rArrays, particles_iArrays);
+
+    data_adaptor->SetDataTime(time);
+    data_adaptor->SetDataTimeStep(step);
+    ret = analysis_adaptor->Execute(data_adaptor) ? 0 : -1;
+    data_adaptor->ReleaseData();
+    data_adaptor->Delete();
+
+    auto t1 = std::chrono::high_resolution_clock::now();
+    auto dt = std::chrono::duration_cast<std::chrono::duration<double>>(t1 - t0);
+    amrex::Print() << "SENSEI update complete (" << dt.count() << " sec)" << std::endl;
+  }
+#endif
+  return ret;
+}
+
+}
+
+#endif // AMREX_PARTICLES
+#endif // AMReX_AmrMeshParticleInSituBridge_H

--- a/Src/Extern/SENSEI/AMReX_ParticleDataAdaptorI.H
+++ b/Src/Extern/SENSEI/AMReX_ParticleDataAdaptorI.H
@@ -266,7 +266,7 @@ int ParticleDataAdaptor<NStructReal, NStructInt, NArrayReal, NArrayInt>::GetMesh
     SENSEI_ERROR("No mesh named \"" << meshName << "\"")
     return -1;
   }
-  vtkMultiBlockDataSet *mb = vtkMultiBlockDataSet::New();
+  vtkMultiBlockDataSet* mb = vtkMultiBlockDataSet::New();
 
   if (structureOnly)
   {
@@ -656,15 +656,15 @@ vtkPolyData* ParticleDataAdaptor<NStructReal, NStructInt, NArrayReal, NArrayInt>
 
   // allocate vertex storage for particles
 #ifdef AMREX_SINGLE_PRECISION_PARTICLES
-  vtkFloatArray *coords = vtkFloatArray::New();
+  vtkNew<vtkFloatArray> coords;
 #else
-  vtkDoubleArray *coords = vtkDoubleArray::New();
+  vtkNew<vtkDoubleArray> coords;
 #endif
   coords->SetName("coords");
   coords->SetNumberOfComponents(3);
   coords->SetNumberOfTuples(numParticles);
 #ifdef AMREX_SINGLE_PRECISION_PARTICLES
-  float *pCoords = coords->GetPointer(0);;
+  float *pCoords = coords->GetPointer(0);
 #else
   double *pCoords = coords->GetPointer(0);
 #endif
@@ -674,32 +674,28 @@ vtkPolyData* ParticleDataAdaptor<NStructReal, NStructInt, NArrayReal, NArrayInt>
   long long ptId = 0;
 
   // allocate connectivity array for particles
-  vtkSmartPointer<vtkCellArray> vertex = vtkSmartPointer<vtkCellArray>::New();
+  vtkNew<vtkCellArray> vertex;
   vertex->AllocateExact(numParticles, 1);
+
+  // points->SetNumberOfPoints(numParticles);
 
   // loop over levels in the particle container
   for (int lev = 0; lev < particles.size();  lev++)
   {
-    // loop over ParticleTiles on level
-    auto& pmap = particles[lev];
-    for (const auto& kv : pmap)
+    using MyParIter = ParIter<NStructReal, NStructInt, NArrayReal, NArrayInt>;
+    for (MyParIter pti(*this->m_particles, lev); pti.isValid(); ++pti)
     {
-      // loop over particles in ParticleTile
-      const auto& aos = kv.second.GetArrayOfStructs();
-      const auto &parts = aos();
+      auto& aos = pti.GetArrayOfStructs();
+      auto numReal = pti.numParticles();
 
-      // visit only the "real" particles, skip the "neighbor" particles.
-      long long numReal = aos.numRealParticles();
       for (long long i = 0; i < numReal; ++i)
       {
-        const auto &part = parts[i];
-
+        const auto &part = aos[i];
         if (part.id() > 0)
         {
           // add a vertex type cell
           vertex->InsertNextCell(1);
           vertex->InsertCellPoint(ptId);
-
           // copy the partilce coordinates
 #if (AMREX_SPACEDIM == 1)
           pCoords[0] = part.pos(0);
@@ -722,9 +718,8 @@ vtkPolyData* ParticleDataAdaptor<NStructReal, NStructInt, NArrayReal, NArrayInt>
   }
 
   // pass the particle coordinates into VTK's point data structure.
-  vtkSmartPointer<vtkPoints> points = vtkSmartPointer<vtkPoints>::New();
+  vtkNew<vtkPoints> points;
   points->SetData(coords);
-  coords->Delete();
 
   // add point and vertex data to output mesh
   pd->SetPoints(points);
@@ -735,44 +730,45 @@ vtkPolyData* ParticleDataAdaptor<NStructReal, NStructInt, NArrayReal, NArrayInt>
 
 //-----------------------------------------------------------------------------
 template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt>
-int ParticleDataAdaptor<NStructReal, NStructInt, NArrayReal, NArrayInt>::AddParticlesIDArray(vtkDataObject* mesh)
+int ParticleDataAdaptor<NStructReal, NStructInt, NArrayReal, NArrayInt>::AddParticlesIDArray(
+  vtkDataObject* mesh)
 {
   auto vtk_particles = dynamic_cast<vtkPolyData*>(mesh);
   const auto& particles = this->m_particles->GetParticles();
   auto nptsOnProc = this->m_particles->TotalNumberOfParticles(true, true);
 
-  vtkSmartPointer<vtkIntArray> intArray = vtkSmartPointer<vtkIntArray>::New();
-  intArray->SetName("id");
-  intArray->SetNumberOfComponents(1);
-  intArray->SetNumberOfValues(nptsOnProc);
+ // allocate a VTK array for the data
+  vtkNew<vtkIntArray> idArray;
+  idArray->SetName("id");
+  idArray->SetNumberOfComponents(1);
+  idArray->SetNumberOfValues(nptsOnProc);
 
-  int *partIds = intArray->GetPointer(0);
+  // get pointer underlying to data
+  int *partIds = idArray->GetPointer(0);
 
+  // loop over particles and append their cpu value to the list
+  using MyParIter = ParIter<NStructReal, NStructInt, NArrayReal, NArrayInt>;
+  long ptId = 0;
   for (int level = 0; level < particles.size(); ++level)
   {
-    auto &pmap = particles[level];
-    for (const auto &kv : pmap)
+    for (MyParIter pti(*this->m_particles, level); pti.isValid(); ++pti)
     {
-      const auto &aos = kv.second.GetArrayOfStructs();
-      const auto &parts = aos();
-
-      // visit only the "real" particles, skip the "neighbor" particles.
-      long long numReal = aos.numRealParticles();
+      auto& aos = pti.GetArrayOfStructs();
+      auto numReal = pti.numParticles();
       for (long long i = 0; i < numReal; ++i)
       {
-        const auto &part = parts[i];
+        const auto &part = aos[i];
         if (part.id() > 0)
         {
           partIds[i] = part.id();
         }
       }
-
       partIds += numReal;
     }
   }
 
   // the association for this array is vtkDataObject::POINT
-  vtk_particles->GetPointData()->AddArray(intArray);
+  vtk_particles->GetPointData()->AddArray(idArray);
 
   return 0;
 }
@@ -787,38 +783,36 @@ int ParticleDataAdaptor<NStructReal, NStructInt, NArrayReal, NArrayInt>::AddPart
   auto nptsOnProc = this->m_particles->TotalNumberOfParticles(true, true);
 
   // allocate a VTK array for the data
-  vtkSmartPointer<vtkIntArray> intArray = vtkSmartPointer<vtkIntArray>::New();
-  intArray->SetName("cpu");
-  intArray->SetNumberOfComponents(1);
-  intArray->SetNumberOfValues(nptsOnProc);
+  vtkNew<vtkIntArray> cpuArray;
+  cpuArray->SetName("cpu");
+  cpuArray->SetNumberOfComponents(1);
+  cpuArray->SetNumberOfValues(nptsOnProc);
 
-  int *partCpu = intArray->GetPointer(0);
+  // get pointer to underlying data
+  int* partCpu = cpuArray->GetPointer(0);
 
+  // loop over particles and append their cpu value to the list
+  using MyParIter = ParIter<NStructReal, NStructInt, NArrayReal, NArrayInt>;
   for (int level = 0; level < particles.size(); ++level)
   {
-    auto &pmap = particles[level];
-    for (const auto &kv : pmap)
+    for (MyParIter pti(*this->m_particles, level); pti.isValid(); ++pti)
     {
-      const auto &aos = kv.second.GetArrayOfStructs();
-      const auto &parts = aos();
-
-      // visit only the "real" particles, skip the "neighbor" particles.
-      long long numReal = aos.numRealParticles();
+      auto& aos = pti.GetArrayOfStructs();
+      auto numReal = pti.numParticles();
       for (long long i = 0; i < numReal; ++i)
       {
-        const auto &part = parts[i];
+        const auto &part = aos[i];
         if (part.id() > 0)
         {
           partCpu[i] = part.cpu();
         }
       }
-
       partCpu += numReal;
     }
   }
 
   // the association for this array is vtkDataObject::POINT
-  vtk_particles->GetPointData()->AddArray(intArray);
+  vtk_particles->GetPointData()->AddArray(cpuArray);
 
   return 0;
 }
@@ -829,9 +823,7 @@ int ParticleDataAdaptor<NStructReal, NStructInt, NArrayReal, NArrayInt>::AddPart
   const std::string &arrayName,
   vtkDataObject* mesh)
 {
-  // get the particles from the particle container
-  const auto& particles = this->m_particles->GetParticles();
-  auto nptsOnProc = this->m_particles->TotalNumberOfParticles(true, true);
+  const long nParticles = this->m_particles->TotalNumberOfParticles(true, true);
 
   // check that the name of the arrays is listed in the m_realArrays
   RealDataMapType::iterator ait = m_realArrays.find(arrayName);
@@ -857,50 +849,46 @@ int ParticleDataAdaptor<NStructReal, NStructInt, NArrayReal, NArrayInt>::AddPart
 
   // allocate the vtkArray
 #ifdef AMREX_SINGLE_PRECISION_PARTICLES
-  vtkFloatArray *data = vtkFloatArray::New();
+  vtkNew<vtkFloatArray> data;
 #else
-  vtkDoubleArray *data = vtkDoubleArray::New();
+  vtkNew<vtkDoubleArray> data;
 #endif
   data->SetName(arrayName.c_str());
   data->SetNumberOfComponents(nComps);
-  data->SetNumberOfTuples(nptsOnProc);
+  data->SetNumberOfTuples(nParticles);
+
 #ifdef AMREX_SINGLE_PRECISION_PARTICLES
-  float *pData = data->GetPointer(0);
+  float* pData = data->GetPointer(0);
 #else
-  double *pData = data->GetPointer(0);
+  double* pData = data->GetPointer(0);
 #endif
 
-  for (int level = 0; level < particles.size(); ++level)
+  using MyParIter = ParIter<NStructReal, NStructInt, NArrayReal, NArrayInt>;
+  for (int level = 0; level < this->m_particles->numLevels(); ++level)
   {
-    auto &pmap = particles[level];
-    for (const auto &kv : pmap)
+    for (MyParIter pti(*this->m_particles, level); pti.isValid(); ++pti)
     {
-      const auto &aos = kv.second.GetArrayOfStructs();
+      auto& particle_attributes = pti.GetStructOfArrays();
+      auto& aos = pti.GetArrayOfStructs();
 
-      // visit only the "real" particles, skip the "neighbor" particles.
-      long long numReal = aos.numRealParticles();
-      const auto &parts = aos();
-
-      // the data we're about to copy
-      const auto &soa = kv.second.GetStructOfArrays();
-
+      auto numReal = pti.numParticles();
       // shuffle from the AMReX component order
       for (int j = 0; j < nComps; ++j)
       {
+        int compInd = indices[j];
         // component to copy
-        const auto &realData = soa.GetRealData(j);
+        const auto &realData = particle_attributes.GetRealData(compInd);
 
         for (long long i = 0; i < numReal; ++i)
         {
-          const auto &part = parts[i];
+          const auto &part = aos[i];
           if (part.id() > 0)
           {
             pData[i*nComps + j] = realData[i];
           }
         }
-
-        pData += numReal*nComps;
       }
+      pData += numReal * nComps;
     }
   }
 
@@ -923,7 +911,6 @@ int ParticleDataAdaptor<NStructReal, NStructInt, NArrayReal, NArrayInt>::AddPart
   vtkDataObject* mesh)
 {
   // get the particles from the particle container
-  const auto& particles = this->m_particles->GetParticles();
   auto nptsOnProc = this->m_particles->TotalNumberOfParticles(true, true);
 
   // check that the name of the arrays is listed in the m_intArrays
@@ -944,40 +931,34 @@ int ParticleDataAdaptor<NStructReal, NStructInt, NArrayReal, NArrayInt>::AddPart
     return -1;
   }
 
-  vtkSmartPointer<vtkIntArray> data = vtkSmartPointer<vtkIntArray>::New();
+  vtkNew<vtkIntArray> data;
   data->SetName(arrayName.c_str());
   data->SetNumberOfComponents(1);
   data->SetNumberOfValues(nptsOnProc);
-
-  int *pData = data->GetPointer(0);
+  int* pData = data->GetPointer(0);
 
   // fill array
-  for (int level = 0; level<particles.size();level++)
+  using MyParIter = ParIter<NStructReal, NStructInt, NArrayReal, NArrayInt>;
+  for (int level = 0; level< this->m_particles->numLevels(); level++)
   {
-    auto &pmap = particles[level];
-    for (const auto &kv : pmap)
+    for (MyParIter pti(*this->m_particles, level); pti.isValid(); ++pti)
     {
-      const auto &aos = kv.second.GetArrayOfStructs();
+      auto& particle_attributes = pti.GetStructOfArrays();
+      auto& aos = pti.GetArrayOfStructs();
 
-      // visit only the "real" particles, skip the "neighbor" particles.
-      long long numReal = aos.numRealParticles();
-      const auto &parts = aos();
-
-      // the data we're about to copy
-      const auto &soa = kv.second.GetStructOfArrays();
-
+      auto numReal = pti.numParticles();
+      // shuffle from the AMReX component order
       // component to copy
-      const auto &intData = soa.GetIntData(index);
+      const auto &intData = particle_attributes.GetIntData(index);
 
       for (long long i = 0; i < numReal; ++i)
       {
-        const auto &part = parts[i];
+        const auto &part = aos[i];
         if (part.id() > 0)
         {
           pData[i] = intData[i];
         }
       }
-
       pData += numReal;
     }
   }
@@ -1028,46 +1009,43 @@ int ParticleDataAdaptor<NStructReal, NStructInt, NArrayReal, NArrayInt>::AddPart
 
   // allocate the vtk array
 #ifdef AMREX_SINGLE_PRECISION_PARTICLES
-  vtkFloatArray *dataOut = vtkFloatArray::New();
+  vtkNew<vtkFloatArray> data;
 #else
-  vtkDoubleArray *dataOut = vtkDoubleArray::New();
+  vtkNew<vtkDoubleArray> data;
 #endif
-  dataOut->SetName(arrayName.c_str());
-  dataOut->SetNumberOfComponents(nComps);
-  dataOut->SetNumberOfTuples(nptsOnProc);
+
+  data->SetName(arrayName.c_str());
+  data->SetNumberOfComponents(nComps);
+  data->SetNumberOfTuples(nptsOnProc);
+
 #ifdef AMREX_SINGLE_PRECISION_PARTICLES
-  float *pDataOut = dataOut->GetPointer(0);
+  float *pData = data->GetPointer(0);
 #else
-  double *pDataOut = dataOut->GetPointer(0);
+  double *pData = data->GetPointer(0);
 #endif
 
   // copy the data from each level
-  int count = 0;
-  std::vector<double> tuple(nComps);
+  using MyParIter = ParIter<NStructReal, NStructInt, NArrayReal, NArrayInt>;
   for (int level = 0; level<particles.size();level++)
   {
-    auto &pmap = particles[level];
-    for (const auto &kv : pmap)
+    for (MyParIter pti(*this->m_particles, level); pti.isValid(); ++pti)
     {
-      // loop over particles in ParticleTile
-      const auto& aos = kv.second.GetArrayOfStructs();
-      const auto &parts = aos();
+      auto& aos = pti.GetArrayOfStructs();
 
-      // visit only the "real" particles, skip the "neighbor" particles.
-      long long numReal = aos.numRealParticles();
-      for (long long i = 0; i < numReal; ++i)
+      auto numReal = pti.numParticles();
+      // shuffle from the AMReX component order
+      for (int j = 0; j < nComps; ++j)
       {
-        const auto &part = parts[i];
-        if (part.id() > 0)
+        for (long long i = 0; i < numReal; ++i)
         {
-          for(int q = 0; q < nComps; ++q)
+          const auto &part = aos[i];
+          if (part.id() > 0)
           {
-            pDataOut[i*nComps + q] = part.rdata(indices[q]);
+            pData[i*nComps + j] = part.rdata(indices[j]);
           }
         }
       }
-
-      pDataOut += numReal*nComps;
+      pData += numReal * nComps;
     }
   }
 
@@ -1078,8 +1056,7 @@ int ParticleDataAdaptor<NStructReal, NStructInt, NArrayReal, NArrayInt>::AddPart
   auto blocks = dynamic_cast<vtkMultiBlockDataSet*>(mesh);
 
   auto block = dynamic_cast<vtkPolyData*>(blocks->GetBlock(rank));
-  block->GetPointData()->AddArray(dataOut);
-  dataOut->Delete();
+  block->GetPointData()->AddArray(data);
 
   return 0;
 }
@@ -1114,33 +1091,28 @@ int ParticleDataAdaptor<NStructReal, NStructInt, NArrayReal, NArrayInt>::AddPart
   }
 
   // allocate vtkArray
-  vtkSmartPointer<vtkIntArray> data = vtkSmartPointer<vtkIntArray>::New();
+  vtkNew<vtkIntArray> data;
   data->SetName(arrayName.c_str());
   data->SetNumberOfComponents(1);
   data->SetNumberOfValues(nptsOnProc);
+  int* pData = data->GetPointer(0);
 
-  int *pData = data->GetPointer(0);
-
+  using MyParIter = ParIter<NStructReal, NStructInt, NArrayReal, NArrayInt>;
   for (int level = 0; level<particles.size(); ++level)
   {
-    auto &pmap = particles[level];
-    for (const auto &kv : pmap)
+    for (MyParIter pti(*this->m_particles, level); pti.isValid(); ++pti)
     {
-      // loop over particles in ParticleTile
-      const auto& aos = kv.second.GetArrayOfStructs();
-      const auto &parts = aos();
+      const auto& aos = pti.GetArrayOfStructs();
 
-      // visit only the "real" particles, skip the "neighbor" particles.
-      long long numReal = aos.numRealParticles();
+      long long numReal = pti.numParticles();
       for (long long i = 0; i < numReal; ++i)
       {
-        const auto &part = parts[i];
+        const auto &part = aos[i];
         if (part.id() > 0)
         {
           pData[i] = part.idata(index);
         }
       }
-
       pData += numReal;
     }
   }


### PR DESCRIPTION
## Summary
This PR adds a new composite data adaptor which enables processing AmrMesh data alongside ParticleContainer data. 

Currently tested working in WarpX with the [3D Beam-driven electron acceleration](https://warpx.readthedocs.io/en/latest/usage/examples.html) using the WarpX version in https://github.com/ECP-WarpX/WarpX/pull/2243.

This PR also reworks how the ParticleDataAdapter loops over particle data. 

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
