### PR TITLE
Silence uninitialized value warning in valgrind in neighbor list construction.

### DIFF
--- a/Src/Particle/AMReX_NeighborList.H
+++ b/Src/Particle/AMReX_NeighborList.H
@@ -193,7 +193,7 @@ public:
                      });
 
         // first pass - count the number of neighbors for each particle
-        m_nbor_counts.resize(np_real+1);
+        m_nbor_counts.resize(np_real+1, 0);
         m_nbor_offsets.resize(np_real+1);
 
         auto pnbor_counts = m_nbor_counts.dataPtr();


### PR DESCRIPTION
I don't think this is an actual bug, but it's good to play nice with valgrind. Thanks to Bruce Palmer.

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
