### PR TITLE
Tweak GNU make on perlmutter

### DIFF
--- a/Tools/GNUMake/sites/Make.nersc
+++ b/Tools/GNUMake/sites/Make.nersc
@@ -16,8 +16,10 @@ ifeq ($(which_computer),$(filter $(which_computer),perlmutter))
     ifneq ($(lowercase_peenv),$(lowercase_comp))
       has_compiler_mismatch = COMP=$(COMP) does not match PrgEnv-$(lowercase_peenv)
     endif
-    ifeq ($(lowercase_peenv),nvidia)
-      $(error PrgEnv-nvidia cannot be used with CPU-only builds. Try PrgEnv-gnu instead.)
+    ifeq ($(MAKECMDGOALS),)
+      ifeq ($(lowercase_peenv),nvidia)
+        $(error PrgEnv-nvidia cannot be used with CPU-only builds. Try PrgEnv-gnu instead.)
+      endif
     endif
   endif
   endif


### PR DESCRIPTION
No need to throw error on `make clean`.

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
