### PR TITLE
Add gradient error tagging in Tests/Advection_AmrLevel

### DIFF
--- a/Tests/Amr/Advection_AmrLevel/Exec/SingleVortex/inputs
+++ b/Tests/Amr/Advection_AmrLevel/Exec/SingleVortex/inputs
@@ -41,5 +41,7 @@ amr.plot_int          = 100    # number of timesteps between plot files
 adv.do_tracers = 0
 
 # ERROR TAGGING
-tagging.phierr =  1.01  1.1   1.5
-tagging.max_phierr_lev = 10
+tagging.phierr  =  1.01  1.1   1.5
+tagging.phigrad =  1e+20 1e+20 1e+20
+tagging.max_phierr_lev  = 10
+tagging.max_phigrad_lev = 10

--- a/Tests/Amr/Advection_AmrLevel/Exec/SingleVortex/inputs
+++ b/Tests/Amr/Advection_AmrLevel/Exec/SingleVortex/inputs
@@ -41,5 +41,5 @@ amr.plot_int          = 100    # number of timesteps between plot files
 adv.do_tracers = 0
 
 # ERROR TAGGING
-tagging.phierr  =  1.01  1.1   1.5
-tagging.max_phierr_lev  = 10
+tagging.phierr =  1.01  1.1   1.5
+tagging.max_phierr_lev = 10

--- a/Tests/Amr/Advection_AmrLevel/Exec/SingleVortex/inputs
+++ b/Tests/Amr/Advection_AmrLevel/Exec/SingleVortex/inputs
@@ -42,6 +42,4 @@ adv.do_tracers = 0
 
 # ERROR TAGGING
 tagging.phierr  =  1.01  1.1   1.5
-tagging.phigrad =  1e+20 1e+20 1e+20
 tagging.max_phierr_lev  = 10
-tagging.max_phigrad_lev = 10

--- a/Tests/Amr/Advection_AmrLevel/Source/AmrLevelAdv.cpp
+++ b/Tests/Amr/Advection_AmrLevel/Source/AmrLevelAdv.cpp
@@ -710,6 +710,11 @@ AmrLevelAdv::errorEst (TagBoxArray& tags,
 {
     MultiFab& S_new = get_new_data(Phi_Type);
 
+    // Create temporary multifab with properly filled patches
+    const Real cur_time = state[Phi_Type].curTime();
+    MultiFab phi(S_new.boxArray(), S_new.DistributionMap(), NUM_STATE, 1);
+    FillPatch(*this, phi, phi.nGrow(), cur_time, Phi_Type, 0, NUM_STATE);
+
     const char   tagval = TagBox::SET;
     // const char clearval = TagBox::CLEAR;
 
@@ -718,10 +723,10 @@ AmrLevelAdv::errorEst (TagBoxArray& tags,
 #endif
     {
 
-        for (MFIter mfi(S_new,TilingIfNotGPU()); mfi.isValid(); ++mfi)
+        for (MFIter mfi(phi,TilingIfNotGPU()); mfi.isValid(); ++mfi)
         {
             const Box& tilebx = mfi.tilebox();
-            const auto phiarr = S_new.array(mfi);
+            const auto phiarr = phi.array(mfi);
             auto       tagarr = tags.array(mfi);
 
             // Tag cells with high phi.

--- a/Tests/Amr/Advection_AmrLevel/Source/AmrLevelAdv.cpp
+++ b/Tests/Amr/Advection_AmrLevel/Source/AmrLevelAdv.cpp
@@ -710,10 +710,12 @@ AmrLevelAdv::errorEst (TagBoxArray& tags,
 {
     MultiFab& S_new = get_new_data(Phi_Type);
 
-    // Create temporary multifab with properly filled patches
-    const Real cur_time = state[Phi_Type].curTime();
+    // Properly fill patches and ghost cells for phi gradient check.
     MultiFab phi(S_new.boxArray(), S_new.DistributionMap(), NUM_STATE, 1);
-    FillPatch(*this, phi, phi.nGrow(), cur_time, Phi_Type, 0, NUM_STATE);
+    if (level < max_phigrad_lev) {
+        const Real cur_time = state[Phi_Type].curTime();
+        FillPatch(*this, phi, 1, cur_time, Phi_Type, 0, NUM_STATE);
+    }
 
     const char   tagval = TagBox::SET;
     // const char clearval = TagBox::CLEAR;
@@ -722,12 +724,12 @@ AmrLevelAdv::errorEst (TagBoxArray& tags,
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     {
-
-        for (MFIter mfi(phi,TilingIfNotGPU()); mfi.isValid(); ++mfi)
+        for (MFIter mfi(S_new,TilingIfNotGPU()); mfi.isValid(); ++mfi)
         {
-            const Box& tilebx = mfi.tilebox();
-            const auto phiarr = phi.array(mfi);
-            auto       tagarr = tags.array(mfi);
+            const Box& tilebx  = mfi.tilebox();
+            const auto phiarr  = S_new.array(mfi);
+            const auto gradarr = phi.array(mfi);
+            auto       tagarr  = tags.array(mfi);
 
             // Tag cells with high phi.
             if (level < max_phierr_lev) {
@@ -745,7 +747,7 @@ AmrLevelAdv::errorEst (TagBoxArray& tags,
                 amrex::ParallelFor(tilebx,
                 [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
                 {
-                    grad_error(i, j, k, tagarr, phiarr, phigrad_lev, tagval);
+                    grad_error(i, j, k, tagarr, gradarr, phigrad_lev, tagval);
                 });
             }
         }


### PR DESCRIPTION
## Summary
Add proper `FillPatch()`ing for gradient checks in `AmrLevelAdv::errorEst()`.

## Additional background
While working on #2268, I "accidentally" discovered that even though gradient error tagging is coded in `Advection_AmrLevel`, this check is never actually performed. This PR tries to fix that by adapting the error tagging code from `Tests/GPU/CNS`.
Tested on local for CPU (error = exactly 0) and on Gigan for NVIDIA GPU (error = 1e-14 range).

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [x] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
