### PR TITLE
Use ParallelFor(Tag) in Linear Solver Preparation

### DIFF
--- a/Src/LinearSolvers/MLMG/AMReX_MLCellLinOp.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLCellLinOp.cpp
@@ -29,6 +29,45 @@ namespace {
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         Box const& box() const noexcept { return bx; }
     };
+
+    struct PSTag {
+        Array4<Real> flo;
+        Array4<Real> fhi;
+        Array4<int const> mlo;
+        Array4<int const> mhi;
+        Real bcllo;
+        Real bclhi;
+        Box bx;
+        BoundCond bctlo;
+        BoundCond bcthi;
+        int blen;
+        int comp;
+        int dir;
+
+        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        Box const& box() const noexcept { return bx; }
+    };
+
+#ifdef AMREX_USE_EB
+    struct PSEBTag {
+        Array4<Real> flo;
+        Array4<Real> fhi;
+        Array4<Real const> ap;
+        Array4<int const> mlo;
+        Array4<int const> mhi;
+        Real bcllo;
+        Real bclhi;
+        Box bx;
+        BoundCond bctlo;
+        BoundCond bcthi;
+        int blen;
+        int comp;
+        int dir;
+
+        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        Box const& box() const noexcept { return bx; }
+    };
+#endif
 }
 
 MLCellLinOp::MLCellLinOp ()
@@ -936,223 +975,203 @@ MLCellLinOp::prepareForSolve ()
                 : Array<const MultiCutFab*,AMREX_SPACEDIM>{AMREX_D_DECL(nullptr,nullptr,nullptr)};
 #endif
 
-            MFItInfo mfi_info;
-            if (Gpu::notInLaunchRegion()) mfi_info.SetDynamic(true);
-
-#ifdef AMREX_USE_OMP
-#pragma omp parallel if (Gpu::notInLaunchRegion())
-#endif
-            for (MFIter mfi(foo, mfi_info); mfi.isValid(); ++mfi)
-            {
-                const Box& vbx = mfi.validbox();
-
-                const auto & bdlv = bcondloc.bndryLocs(mfi);
-                const auto & bdcv = bcondloc.bndryConds(mfi);
-
-#ifdef AMREX_USE_EB
-                auto fabtyp = (flags) ? (*flags)[mfi].getType(vbx) : FabType::regular;
-#endif
-
 #ifdef AMREX_USE_GPU
-                if (Gpu::inLaunchRegion()) {
-                    GpuArray<Array4<int const>,AMREX_SPACEDIM> mlo;
-                    GpuArray<Array4<int const>,AMREX_SPACEDIM> mhi;
-                    GpuArray<Array4<Real>,AMREX_SPACEDIM> flo;
-                    GpuArray<Array4<Real>,AMREX_SPACEDIM> fhi;
-                    GpuArray<BCTL,2*AMREX_SPACEDIM> const* bctl = bcondloc.getBCTLPtr(mfi);
-                    for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-                        const Orientation olo(idim,Orientation::low);
-                        const Orientation ohi(idim,Orientation::high);
-                        mlo[idim] = maskvals[olo].array(mfi);
-                        mhi[idim] = maskvals[ohi].array(mfi);
-                        flo[idim] = undrrelxr[olo].array(mfi);
-                        fhi[idim] = undrrelxr[ohi].array(mfi);
-                    }
-                    const auto len = vbx.length3d();
-                    int nthreads
-                        = AMREX_D_PICK(1;,
-                                       amrex::max(len[0],len[1]);,
-                                       amrex::max(len[0]*len[1],len[0]*len[2],len[1]*len[2]));
-                    if (hasHiddenDimension()) {
-#if AMREX_SPACEDIM <= 2
-                        nthreads = 1;
-#else
-                        amrex::max(AMREX_D_DECL(len[0],len[1],len[2]));
-#endif
-                    }
+            if (Gpu::inLaunchRegion()) {
 #ifdef AMREX_USE_EB
-                    if (fabtyp == FabType::singlevalued) {
-                        GpuArray<Array4<Real const>,AMREX_SPACEDIM> ap
-                            {AMREX_D_DECL(area[0]->const_array(mfi),
-                                          area[1]->const_array(mfi),
-                                          area[2]->const_array(mfi))};
-                        amrex::ParallelFor(Gpu::KernelInfo().setFusible(true), nthreads,
-                        [=] AMREX_GPU_DEVICE (int tid) noexcept
-                        {
-                            int idim = 0;
-                            if (idim != hidden_direction) {
-                                Box const& bbox = amrex::adjCellLo(vbx,idim);
-                                IntVect const& iv = bbox.atOffset(tid);
-                                if (bbox.contains(iv)) {
-                                    const int blen = vbx.length(idim);
-                                    const Box blo(iv,iv);
-                                    const Box bhi = amrex::shift(blo,idim,blen+1);
-                                    const int loface = Orientation(idim,Orientation::low);
-                                    const int hiface = Orientation(idim,Orientation::high);
-                                    for (int icomp = 0; icomp < ncomp; ++icomp) {
-                                        mllinop_comp_interp_coef0_x_eb
-                                            (0, blo, blen, flo[idim], mlo[idim], ap[idim],
-                                             bctl[icomp][loface].type,
-                                             bctl[icomp][loface].location,
-                                             imaxorder, dxi, icomp);
-                                        mllinop_comp_interp_coef0_x_eb
-                                            (1, bhi, blen, fhi[idim], mhi[idim], ap[idim],
-                                             bctl[icomp][hiface].type,
-                                             bctl[icomp][hiface].location,
-                                             imaxorder, dxi, icomp);
-                                    }
-                                }
-                            }
-#if (AMREX_SPACEDIM >= 2)
-                            idim = 1;
-                            if (idim != hidden_direction) {
-                                Box const& bbox = amrex::adjCellLo(vbx,idim);
-                                IntVect const& iv = bbox.atOffset(tid);
-                                if (bbox.contains(iv)) {
-                                    const int blen = vbx.length(idim);
-                                    const Box blo(iv,iv);
-                                    const Box bhi = amrex::shift(blo,idim,blen+1);
-                                    const int loface = Orientation(idim,Orientation::low);
-                                    const int hiface = Orientation(idim,Orientation::high);
-                                    for (int icomp = 0; icomp < ncomp; ++icomp) {
-                                        mllinop_comp_interp_coef0_y_eb
-                                            (0, blo, blen, flo[idim], mlo[idim], ap[idim],
-                                             bctl[icomp][loface].type,
-                                             bctl[icomp][loface].location,
-                                             imaxorder, dyi, icomp);
-                                        mllinop_comp_interp_coef0_y_eb
-                                            (1, bhi, blen, fhi[idim], mhi[idim], ap[idim],
-                                             bctl[icomp][hiface].type,
-                                             bctl[icomp][hiface].location,
-                                             imaxorder, dyi, icomp);
-                                    }
-                                }
-                            }
-#endif
-#if (AMREX_SPACEDIM == 3)
-                            idim = 2;
-                            if (idim != hidden_direction) {
-                                Box const& bbox = amrex::adjCellLo(vbx,idim);
-                                IntVect const& iv = bbox.atOffset(tid);
-                                if (bbox.contains(iv)) {
-                                    const int blen = vbx.length(idim);
-                                    const Box blo(iv,iv);
-                                    const Box bhi = amrex::shift(blo,idim,blen+1);
-                                    const int loface = Orientation(idim,Orientation::low);
-                                    const int hiface = Orientation(idim,Orientation::high);
-                                    for (int icomp = 0; icomp < ncomp; ++icomp) {
-                                        mllinop_comp_interp_coef0_z_eb
-                                            (0, blo, blen, flo[idim], mlo[idim], ap[idim],
-                                             bctl[icomp][loface].type,
-                                             bctl[icomp][loface].location,
-                                             imaxorder, dzi, icomp);
-                                        mllinop_comp_interp_coef0_z_eb
-                                            (1, bhi, blen, fhi[idim], mhi[idim], ap[idim],
-                                             bctl[icomp][hiface].type,
-                                             bctl[icomp][hiface].location,
-                                             imaxorder, dzi, icomp);
-                                    }
-                                }
-                            }
-#endif
-                        });
-                    } else
-#endif
+                if (factory) {
+                    Vector<PSEBTag> tags;
+                    tags.reserve(foo.local_size()*AMREX_SPACEDIM*ncomp);
+
+                    for (MFIter mfi(foo); mfi.isValid(); ++mfi)
                     {
-                        amrex::ParallelFor(Gpu::KernelInfo().setFusible(true), nthreads,
-                        [=] AMREX_GPU_DEVICE (int tid) noexcept
+                        const Box& vbx = mfi.validbox();
+
+                        const auto & bdlv = bcondloc.bndryLocs(mfi);
+                        const auto & bdcv = bcondloc.bndryConds(mfi);
+
+                        auto fabtyp = (flags) ? (*flags)[mfi].getType(vbx) : FabType::regular;
+
+                        for (int idim = 0; idim < AMREX_SPACEDIM; ++idim)
                         {
-                            int idim = 0;
-                            if (idim != hidden_direction) {
-                                Box const& bbox = amrex::adjCellLo(vbx,idim);
-                                IntVect const& iv = bbox.atOffset(tid);
-                                if (bbox.contains(iv)) {
-                                    const int blen = vbx.length(idim);
-                                    const Box blo(iv,iv);
-                                    const Box bhi = amrex::shift(blo,idim,blen+1);
-                                    const int loface = Orientation(idim,Orientation::low);
-                                    const int hiface = Orientation(idim,Orientation::high);
-                                    for (int icomp = 0; icomp < ncomp; ++icomp) {
-                                        mllinop_comp_interp_coef0_x
-                                            (0, blo, blen, flo[idim], mlo[idim],
-                                             bctl[icomp][loface].type,
-                                             bctl[icomp][loface].location,
-                                             imaxorder, dxi, icomp);
-                                        mllinop_comp_interp_coef0_x
-                                            (1, bhi, blen, fhi[idim], mhi[idim],
-                                             bctl[icomp][hiface].type,
-                                             bctl[icomp][hiface].location,
-                                             imaxorder, dxi, icomp);
-                                    }
+                            if (idim != hidden_direction && fabtyp != FabType::covered) {
+                                const Orientation olo(idim,Orientation::low);
+                                const Orientation ohi(idim,Orientation::high);
+                                auto const& ap = (fabtyp == FabType::singlevalued)
+                                    ? area[idim]->const_array(mfi) : Array4<Real const>{};
+                                for (int icomp = 0; icomp < ncomp; ++icomp) {
+                                    tags.emplace_back(PSEBTag{undrrelxr[olo].array(mfi),
+                                                              undrrelxr[ohi].array(mfi),
+                                                              ap,
+                                                              maskvals[olo].const_array(mfi),
+                                                              maskvals[ohi].const_array(mfi),
+                                                              bdlv[icomp][olo], bdlv[icomp][ohi],
+                                                              amrex::adjCell(vbx,olo),
+                                                              bdcv[icomp][olo], bdcv[icomp][ohi],
+                                                              vbx.length(idim), icomp, idim});
                                 }
                             }
-#if (AMREX_SPACEDIM >= 2)
-                            idim = 1;
-                            if (idim != hidden_direction) {
-                                Box const& bbox = amrex::adjCellLo(vbx,idim);
-                                IntVect const& iv = bbox.atOffset(tid);
-                                if (bbox.contains(iv)) {
-                                    const int blen = vbx.length(idim);
-                                    const Box blo(iv,iv);
-                                    const Box bhi = amrex::shift(blo,idim,blen+1);
-                                    const int loface = Orientation(idim,Orientation::low);
-                                    const int hiface = Orientation(idim,Orientation::high);
-                                    for (int icomp = 0; icomp < ncomp; ++icomp) {
-                                        mllinop_comp_interp_coef0_y
-                                            (0, blo, blen, flo[idim], mlo[idim],
-                                             bctl[icomp][loface].type,
-                                             bctl[icomp][loface].location,
-                                             imaxorder, dyi, icomp);
-                                        mllinop_comp_interp_coef0_y
-                                            (1, bhi, blen, fhi[idim], mhi[idim],
-                                             bctl[icomp][hiface].type,
-                                             bctl[icomp][hiface].location,
-                                             imaxorder, dyi, icomp);
-                                    }
-                                }
-                            }
-#endif
-#if (AMREX_SPACEDIM == 3)
-                            idim = 2;
-                            if (idim != hidden_direction) {
-                                Box const& bbox = amrex::adjCellLo(vbx,idim);
-                                IntVect const& iv = bbox.atOffset(tid);
-                                if (bbox.contains(iv)) {
-                                    const int blen = vbx.length(idim);
-                                    const Box blo(iv,iv);
-                                    const Box bhi = amrex::shift(blo,idim,blen+1);
-                                    const int loface = Orientation(idim,Orientation::low);
-                                    const int hiface = Orientation(idim,Orientation::high);
-                                    for (int icomp = 0; icomp < ncomp; ++icomp) {
-                                        mllinop_comp_interp_coef0_z
-                                            (0, blo, blen, flo[idim], mlo[idim],
-                                             bctl[icomp][loface].type,
-                                             bctl[icomp][loface].location,
-                                             imaxorder, dzi, icomp);
-                                        mllinop_comp_interp_coef0_z
-                                            (1, bhi, blen, fhi[idim], mhi[idim],
-                                             bctl[icomp][hiface].type,
-                                             bctl[icomp][hiface].location,
-                                             imaxorder, dzi, icomp);
-                                    }
-                                }
-                            }
-#endif
-                        });
+                        }
                     }
+
+                    ParallelFor(tags,
+                    [=] AMREX_GPU_DEVICE (int i, int j, int k, PSEBTag const& tag) noexcept
+                    {
+                        if (tag.ap) {
+                            if (tag.dir == 0)
+                            {
+                                mllinop_comp_interp_coef0_x_eb
+                                    (0, i           , j, k, tag.blen, tag.flo, tag.mlo, tag.ap,
+                                     tag.bctlo, tag.bcllo, imaxorder, dxi, tag.comp);
+                                mllinop_comp_interp_coef0_x_eb
+                                    (1, i+tag.blen+1, j, k, tag.blen, tag.fhi, tag.mhi, tag.ap,
+                                     tag.bcthi, tag.bclhi, imaxorder, dxi, tag.comp);
+                            }
+#if (AMREX_SPACEDIM > 1)
+                            else
+#if (AMREX_SPACEDIM > 2)
+                            if (tag.dir == 1)
+#endif
+                            {
+                                mllinop_comp_interp_coef0_y_eb
+                                    (0, i, j           , k, tag.blen, tag.flo, tag.mlo, tag.ap,
+                                     tag.bctlo, tag.bcllo, imaxorder, dyi, tag.comp);
+                                mllinop_comp_interp_coef0_y_eb
+                                    (1, i, j+tag.blen+1, k, tag.blen, tag.fhi, tag.mhi, tag.ap,
+                                     tag.bcthi, tag.bclhi, imaxorder, dyi, tag.comp);
+                            }
+#if (AMREX_SPACEDIM > 2)
+                            else {
+                                mllinop_comp_interp_coef0_z_eb
+                                    (0, i, j, k           , tag.blen, tag.flo, tag.mlo, tag.ap,
+                                     tag.bctlo, tag.bcllo, imaxorder, dzi, tag.comp);
+                                mllinop_comp_interp_coef0_z_eb
+                                    (1, i, j, k+tag.blen+1, tag.blen, tag.fhi, tag.mhi, tag.ap,
+                                     tag.bcthi, tag.bclhi, imaxorder, dzi, tag.comp);
+                            }
+#endif
+#endif
+                        } else {
+                            if (tag.dir == 0)
+                            {
+                                mllinop_comp_interp_coef0_x
+                                    (0, i           , j, k, tag.blen, tag.flo, tag.mlo,
+                                     tag.bctlo, tag.bcllo, imaxorder, dxi, tag.comp);
+                                mllinop_comp_interp_coef0_x
+                                    (1, i+tag.blen+1, j, k, tag.blen, tag.fhi, tag.mhi,
+                                     tag.bcthi, tag.bclhi, imaxorder, dxi, tag.comp);
+                            }
+#if (AMREX_SPACEDIM > 1)
+                            else
+#if (AMREX_SPACEDIM > 2)
+                            if (tag.dir == 1)
+#endif
+                            {
+                                mllinop_comp_interp_coef0_y
+                                    (0, i, j           , k, tag.blen, tag.flo, tag.mlo,
+                                     tag.bctlo, tag.bcllo, imaxorder, dyi, tag.comp);
+                                mllinop_comp_interp_coef0_y
+                                    (1, i, j+tag.blen+1, k, tag.blen, tag.fhi, tag.mhi,
+                                     tag.bcthi, tag.bclhi, imaxorder, dyi, tag.comp);
+                            }
+#if (AMREX_SPACEDIM > 2)
+                            else {
+                                mllinop_comp_interp_coef0_z
+                                    (0, i, j, k           , tag.blen, tag.flo, tag.mlo,
+                                     tag.bctlo, tag.bcllo, imaxorder, dzi, tag.comp);
+                                mllinop_comp_interp_coef0_z
+                                    (1, i, j, k+tag.blen+1, tag.blen, tag.fhi, tag.mhi,
+                                     tag.bcthi, tag.bclhi, imaxorder, dzi, tag.comp);
+                            }
+#endif
+#endif
+                        }
+                    });
                 } else
 #endif
                 {
+                    Vector<PSTag> tags;
+                    tags.reserve(foo.local_size()*AMREX_SPACEDIM*ncomp);
+
+                    for (MFIter mfi(foo); mfi.isValid(); ++mfi)
+                    {
+                        const Box& vbx = mfi.validbox();
+
+                        const auto & bdlv = bcondloc.bndryLocs(mfi);
+                        const auto & bdcv = bcondloc.bndryConds(mfi);
+
+                        for (int idim = 0; idim < AMREX_SPACEDIM; ++idim)
+                        {
+                            if (idim != hidden_direction) {
+                                const Orientation olo(idim,Orientation::low);
+                                const Orientation ohi(idim,Orientation::high);
+                                for (int icomp = 0; icomp < ncomp; ++icomp) {
+                                    tags.emplace_back(PSTag{undrrelxr[olo].array(mfi),
+                                                            undrrelxr[ohi].array(mfi),
+                                                            maskvals[olo].const_array(mfi),
+                                                            maskvals[ohi].const_array(mfi),
+                                                            bdlv[icomp][olo], bdlv[icomp][ohi],
+                                                            amrex::adjCell(vbx,olo),
+                                                            bdcv[icomp][olo], bdcv[icomp][ohi],
+                                                            vbx.length(idim), icomp, idim});
+                                }
+                            }
+                        }
+                    }
+
+                    ParallelFor(tags,
+                    [=] AMREX_GPU_DEVICE (int i, int j, int k, PSTag const& tag) noexcept
+                    {
+                        if (tag.dir == 0)
+                        {
+                            mllinop_comp_interp_coef0_x
+                                (0, i           , j, k, tag.blen, tag.flo, tag.mlo,
+                                 tag.bctlo, tag.bcllo, imaxorder, dxi, tag.comp);
+                            mllinop_comp_interp_coef0_x
+                                (1, i+tag.blen+1, j, k, tag.blen, tag.fhi, tag.mhi,
+                                 tag.bcthi, tag.bclhi, imaxorder, dxi, tag.comp);
+                        }
+#if (AMREX_SPACEDIM > 1)
+                        else
+#if (AMREX_SPACEDIM > 2)
+                        if (tag.dir == 1)
+#endif
+                        {
+                            mllinop_comp_interp_coef0_y
+                                (0, i, j           , k, tag.blen, tag.flo, tag.mlo,
+                                 tag.bctlo, tag.bcllo, imaxorder, dyi, tag.comp);
+                            mllinop_comp_interp_coef0_y
+                                (1, i, j+tag.blen+1, k, tag.blen, tag.fhi, tag.mhi,
+                                 tag.bcthi, tag.bclhi, imaxorder, dyi, tag.comp);
+                        }
+#if (AMREX_SPACEDIM > 2)
+                        else {
+                            mllinop_comp_interp_coef0_z
+                                (0, i, j, k           , tag.blen, tag.flo, tag.mlo,
+                                 tag.bctlo, tag.bcllo, imaxorder, dzi, tag.comp);
+                            mllinop_comp_interp_coef0_z
+                                (1, i, j, k+tag.blen+1, tag.blen, tag.fhi, tag.mhi,
+                                 tag.bcthi, tag.bclhi, imaxorder, dzi, tag.comp);
+                        }
+#endif
+#endif
+                    });
+                }
+            } else
+#endif
+            {
+#ifdef AMREX_USE_OMP
+#pragma omp parallel
+#endif
+                for (MFIter mfi(foo, MFItInfo{}.SetDynamic(true)); mfi.isValid(); ++mfi)
+                {
+                    const Box& vbx = mfi.validbox();
+
+                    const auto & bdlv = bcondloc.bndryLocs(mfi);
+                    const auto & bdcv = bcondloc.bndryConds(mfi);
+
+#ifdef AMREX_USE_EB
+                    auto fabtyp = (flags) ? (*flags)[mfi].getType(vbx) : FabType::regular;
+#endif
                     for (int idim = 0; idim < AMREX_SPACEDIM; ++idim)
                     {
                         if (idim == hidden_direction) continue;
@@ -1195,7 +1214,7 @@ MLCellLinOp::prepareForSolve ()
                                         (1, bhi, blen, fhi, mhi, ap, bcthi, bclhi,
                                          imaxorder, dzi, icomp);
                                 }
-                            } else
+                            } else if (fabtyp == FabType::regular)
 #endif
                             {
                                 if (idim == 0) {

--- a/Src/LinearSolvers/MLMG/AMReX_MLLinOp_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLLinOp_K.H
@@ -366,6 +366,38 @@ void mllinop_comp_interp_coef0_x (int side, Box const& box, int blen,
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void mllinop_comp_interp_coef0_x (int side, int i, int j, int k, int blen,
+                                  Array4<Real> const& f,
+                                  Array4<int const> const& mask,
+                                  BoundCond bct, Real bcl,
+                                  int maxorder, Real dxinv, int icomp) noexcept
+{
+    const int ii = i + (1-2*side); // interior cell
+    switch (bct) {
+    case AMREX_LO_NEUMANN:
+    {
+        f(ii,j,k,icomp) = Real(1.0);
+        break;
+    }
+    case AMREX_LO_REFLECT_ODD:
+    {
+        f(ii,j,k,icomp) = (mask(i,j,k) > 0) ? Real(1.0) : Real(0.0);
+        break;
+    }
+    case AMREX_LO_DIRICHLET:
+    {
+        const int NX = amrex::min(blen+1, maxorder);
+        GpuArray<Real,4> x{{-bcl * dxinv, Real(0.5), Real(1.5), Real(2.5)}};
+        GpuArray<Real,4> coef{};
+        poly_interp_coeff(-Real(0.5), &x[0], NX, &coef[0]);
+        f(ii,j,k,icomp) = (mask(i,j,k) > 0) ? coef[1] : Real(0.0);
+        break;
+    }
+    default: {}
+    }
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 void mllinop_comp_interp_coef0_y (int side, Box const& box, int blen,
                                   Array4<Real> const& f,
                                   Array4<int const> const& mask,
@@ -413,6 +445,38 @@ void mllinop_comp_interp_coef0_y (int side, Box const& box, int blen,
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void mllinop_comp_interp_coef0_y (int side, int i, int j, int k, int blen,
+                                  Array4<Real> const& f,
+                                  Array4<int const> const& mask,
+                                  BoundCond bct, Real bcl,
+                                  int maxorder, Real dyinv, int icomp) noexcept
+{
+    const int ji = j + (1-2*side); // interior cell
+    switch (bct) {
+    case AMREX_LO_NEUMANN:
+    {
+        f(i,ji,k,icomp) = Real(1.0);
+        break;
+    }
+    case AMREX_LO_REFLECT_ODD:
+    {
+        f(i,ji,k,icomp) = (mask(i,j,k) > 0) ? Real(1.0) : Real(0.0);
+        break;
+    }
+    case AMREX_LO_DIRICHLET:
+    {
+        const int NX = amrex::min(blen+1, maxorder);
+        GpuArray<Real,4> x{{-bcl * dyinv, Real(0.5), Real(1.5), Real(2.5)}};
+        GpuArray<Real,4> coef{};
+        poly_interp_coeff(-Real(0.5), &x[0], NX, &coef[0]);
+        f(i,ji,k,icomp) = (mask(i,j,k) > 0) ? coef[1] : Real(0.0);
+        break;
+    }
+    default: {}
+    }
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 void mllinop_comp_interp_coef0_z (int side, Box const& box, int blen,
                                   Array4<Real> const& f,
                                   Array4<int const> const& mask,
@@ -453,6 +517,38 @@ void mllinop_comp_interp_coef0_z (int side, Box const& box, int blen,
                 f(i,j,ki,icomp) = (mask(i,j,kb) > 0) ? coef[1] : Real(0.0);
             }
         }
+        break;
+    }
+    default: {}
+    }
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void mllinop_comp_interp_coef0_z (int side, int i, int j, int k, int blen,
+                                  Array4<Real> const& f,
+                                  Array4<int const> const& mask,
+                                  BoundCond bct, Real bcl,
+                                  int maxorder, Real dzinv, int icomp) noexcept
+{
+    const int ki = k + (1-2*side); // interior cell
+    switch (bct) {
+    case AMREX_LO_NEUMANN:
+    {
+        f(i,j,ki,icomp) = Real(1.0);
+        break;
+    }
+    case AMREX_LO_REFLECT_ODD:
+    {
+        f(i,j,ki,icomp) = (mask(i,j,k) > 0) ? Real(1.0) : Real(0.0);
+        break;
+    }
+    case AMREX_LO_DIRICHLET:
+    {
+        const int NX = amrex::min(blen+1, maxorder);
+        GpuArray<Real,4> x{{-bcl * dzinv, Real(0.5), Real(1.5), Real(2.5)}};
+        GpuArray<Real,4> coef{};
+        poly_interp_coeff(-Real(0.5), &x[0], NX, &coef[0]);
+        f(i,j,ki,icomp) = (mask(i,j,k) > 0) ? coef[1] : Real(0.0);
         break;
     }
     default: {}
@@ -529,6 +625,58 @@ void mllinop_comp_interp_coef0_x_eb (int side, Box const& box, int blen,
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void mllinop_comp_interp_coef0_x_eb (int side, int i, int j, int k, int blen,
+                                     Array4<Real> const& f,
+                                     Array4<int const> const& mask,
+                                     Array4<Real const> const& area,
+                                     BoundCond bct, Real bcl,
+                                     int maxorder, Real dxinv, int icomp) noexcept
+{
+    const int s = 1-2*side;  // +1 for lo and -1 for hi
+    const int ii = i + s; // interior cell
+    switch (bct) {
+    case AMREX_LO_NEUMANN:
+    {
+        f(ii,j,k,icomp) = Real(1.0);
+        break;
+    }
+    case AMREX_LO_REFLECT_ODD:
+    {
+        f(ii,j,k,icomp) = (mask(i,j,k) > 0) ? Real(1.0) : Real(0.0);
+        break;
+    }
+    case AMREX_LO_DIRICHLET:
+    {
+        const int NX = amrex::min(blen+1, maxorder);
+        GpuArray<Real,4> x{{-bcl * dxinv, Real(0.5), Real(1.5), Real(2.5)}};
+        Array2D<Real, 0, 3, 0, 2> coef{};
+        for (int r = 0; r <= maxorder-2; ++r) {
+            poly_interp_coeff(-Real(0.5), &x[0], r+2, &coef(0,r));
+        }
+        int order = 1;
+        if (mask(i,j,k) > 0) {
+            bool has_cutfaces = false;
+            for (int r = 0; r <= NX-2; ++r) {
+                Real a = area(ii+side+s*r,j,k);
+                if (a > Real(0.0)) {
+                    ++order;
+                    if (a < Real(1.0)) {
+                        has_cutfaces = true;
+                    }
+                } else {
+                    break;
+                }
+            }
+            if (has_cutfaces) order = amrex::min(2,order);
+        }
+        f(ii,j,k,icomp) = (order==1) ? Real(0.0) : coef(1,order-2);
+        break;
+    }
+    default: {}
+    }
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 void mllinop_comp_interp_coef0_y_eb (int side, Box const& box, int blen,
                                      Array4<Real> const& f,
                                      Array4<int const> const& mask,
@@ -596,6 +744,58 @@ void mllinop_comp_interp_coef0_y_eb (int side, Box const& box, int blen,
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void mllinop_comp_interp_coef0_y_eb (int side, int i, int j, int k, int blen,
+                                     Array4<Real> const& f,
+                                     Array4<int const> const& mask,
+                                     Array4<Real const> const& area,
+                                     BoundCond bct, Real bcl,
+                                     int maxorder, Real dyinv, int icomp) noexcept
+{
+    const int s = 1-2*side;  // +1 for lo and -1 for hi
+    const int ji = j + s; // interior cell
+    switch (bct) {
+    case AMREX_LO_NEUMANN:
+    {
+        f(i,ji,k,icomp) = Real(1.0);
+        break;
+    }
+    case AMREX_LO_REFLECT_ODD:
+    {
+        f(i,ji,k,icomp) = (mask(i,j,k) > 0) ? Real(1.0) : Real(0.0);
+        break;
+    }
+    case AMREX_LO_DIRICHLET:
+    {
+        const int NX = amrex::min(blen+1, maxorder);
+        GpuArray<Real,4> x{{-bcl * dyinv, Real(0.5), Real(1.5), Real(2.5)}};
+        Array2D<Real, 0, 3, 0, 2> coef{};
+        for (int r = 0; r <= maxorder-2; ++r) {
+            poly_interp_coeff(-Real(0.5), &x[0], r+2, &coef(0,r));
+        }
+        int order = 1;
+        if (mask(i,j,k) > 0) {
+            bool has_cutfaces = false;
+            for (int r = 0; r <= NX-2; ++r) {
+                Real a = area(i,ji+side+s*r,k);
+                if (a > Real(0.0)) {
+                    ++order;
+                    if (a < Real(1.0)) {
+                        has_cutfaces = true;
+                    }
+                } else {
+                    break;
+                }
+            }
+            if (has_cutfaces) order = amrex::min(2,order);
+        }
+        f(i,ji,k,icomp) = (order==1) ? Real(0.0) : coef(1,order-2);
+        break;
+    }
+    default: {}
+    }
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 void mllinop_comp_interp_coef0_z_eb (int side, Box const& box, int blen,
                                      Array4<Real> const& f,
                                      Array4<int const> const& mask,
@@ -656,6 +856,58 @@ void mllinop_comp_interp_coef0_z_eb (int side, Box const& box, int blen,
                 f(i,j,ki,icomp) = (order==1) ? Real(0.0) : coef(1,order-2);
             }
         }
+        break;
+    }
+    default: {}
+    }
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void mllinop_comp_interp_coef0_z_eb (int side, int i, int j, int k, int blen,
+                                     Array4<Real> const& f,
+                                     Array4<int const> const& mask,
+                                     Array4<Real const> const& area,
+                                     BoundCond bct, Real bcl,
+                                     int maxorder, Real dzinv, int icomp) noexcept
+{
+    const int s = 1-2*side;  // +1 for lo and -1 for hi
+    const int ki = k + s; // interior cell
+    switch (bct) {
+    case AMREX_LO_NEUMANN:
+    {
+        f(i,j,ki,icomp) = Real(1.0);
+        break;
+    }
+    case AMREX_LO_REFLECT_ODD:
+    {
+        f(i,j,ki,icomp) = (mask(i,j,k) > 0) ? Real(1.0) : Real(0.0);
+        break;
+    }
+    case AMREX_LO_DIRICHLET:
+    {
+        const int NX = amrex::min(blen+1, maxorder);
+        GpuArray<Real,4> x{{-bcl * dzinv, Real(0.5), Real(1.5), Real(2.5)}};
+        Array2D<Real, 0, 3, 0, 2> coef{};
+        for (int r = 0; r <= maxorder-2; ++r) {
+            poly_interp_coeff(-Real(0.5), &x[0], r+2, &coef(0,r));
+        }
+        int order = 1;
+        if (mask(i,j,k) > 0) {
+            bool has_cutfaces = false;
+            for (int r = 0; r <= NX-2; ++r) {
+                Real a = area(i,j,ki+side+s*r);
+                if (a > Real(0.0)) {
+                    ++order;
+                    if (a < Real(1.0)) {
+                        has_cutfaces = true;
+                    }
+                } else {
+                    break;
+                }
+            }
+            if (has_cutfaces) order = amrex::min(2,order);
+        }
+        f(i,j,ki,icomp) = (order==1) ? Real(0.0) : coef(1,order-2);
         break;
     }
     default: {}


### PR DESCRIPTION
Replace the old fusing approach with ParallelFor(Tag) in
MLCellLinOp::prepareForSolve.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
