### PR TITLE
Gpu::Atomic::If

### DIFF
--- a/Src/Base/AMReX_Functional.H
+++ b/Src/Base/AMReX_Functional.H
@@ -16,6 +16,15 @@ struct Plus
 };
 
 template <typename T>
+struct Minus
+{
+    constexpr T operator() (const T & lhs, const T & rhs) const
+    {
+        return lhs - rhs;
+    }
+};
+
+template <typename T>
 struct Less
 {
     constexpr T operator() (const T & lhs, const T & rhs) const

--- a/Src/Base/AMReX_GpuAtomic.H
+++ b/Src/Base/AMReX_GpuAtomic.H
@@ -49,7 +49,7 @@ namespace detail {
 
     template <typename R, typename I, typename Op, typename Cond>
     AMREX_GPU_DEVICE AMREX_FORCE_INLINE
-    bool atomic_op_if (R* const address, R const val, Op const op, Cond const cond) noexcept
+    bool atomic_op_if (R* const address, R const val, Op&& op, Cond&& cond) noexcept
     {
 #if defined(__SYCL_DEVICE_ONLY__)
         constexpr auto mo = sycl::memory_order::relaxed;
@@ -96,7 +96,7 @@ namespace detail {
 
     template <typename R, typename I, typename Op, typename Cond>
     AMREX_GPU_DEVICE AMREX_FORCE_INLINE
-    bool atomic_op_if (R* const address, R const val, Op const op, Cond const cond) noexcept
+    bool atomic_op_if (R* const address, R const val, Op&& op, Cond&& cond) noexcept
     {
         static_assert(sizeof(R) == sizeof(I), "sizeof R != sizeof I");
         I* const add_as_I = reinterpret_cast<I*>(address);
@@ -203,34 +203,34 @@ namespace detail {
 #if defined(AMREX_USE_CUDA) || defined(AMREX_USE_HIP) || defined(AMREX_USE_DPCPP)
     template <typename Op, typename Cond>
     AMREX_GPU_DEVICE AMREX_FORCE_INLINE
-    bool If_device (double* const sum, double const value, Op const op, Cond const cond) noexcept
+    bool If_device (double* const sum, double const value, Op&& op, Cond&& cond) noexcept
     {
         return detail::atomic_op_if<double, unsigned long long>(sum, value,
-                   std::forward<Op const>(op), std::forward<Cond const>(cond));
+                   std::forward<Op>(op), std::forward<Cond>(cond));
     }
 
     template <typename Op, typename Cond>
     AMREX_GPU_DEVICE AMREX_FORCE_INLINE
-    bool If_device (float* const sum, float const value, Op const op, Cond const cond) noexcept
+    bool If_device (float* const sum, float const value, Op&& op, Cond&& cond) noexcept
     {
         return detail::atomic_op_if<float, unsigned int>(sum, value,
-                   std::forward<Op const>(op), std::forward<Cond const>(cond));
+                   std::forward<Op>(op), std::forward<Cond>(cond));
     }
 
     template <typename Op, typename Cond>
     AMREX_GPU_DEVICE AMREX_FORCE_INLINE
-    bool If_device (Long* const sum, Long const value, Op const op, Cond const cond) noexcept
+    bool If_device (Long* const sum, Long const value, Op&& op, Cond&& cond) noexcept
     {
         return detail::atomic_op_if<Long, unsigned long long>(sum, value,
-                   std::forward<Op const>(op), std::forward<Cond const>(cond));
+                   std::forward<Op>(op), std::forward<Cond>(cond));
     }
 
     template <typename T, typename Op, typename Cond>
     AMREX_GPU_DEVICE AMREX_FORCE_INLINE
-    bool If_device (T* const sum, T const value, Op const op, Cond const cond) noexcept
+    bool If_device (T* const sum, T const value, Op&& op, Cond&& cond) noexcept
     {
         return detail::atomic_op_if<T, T>(sum, value,
-                   std::forward<Op const>(op), std::forward<Cond const>(cond));
+                   std::forward<Op>(op), std::forward<Cond>(cond));
     }
 #endif
 
@@ -251,10 +251,10 @@ namespace detail {
 **/
     template<class T, class Op, class Cond>
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-    bool If (T* const add, T const value, Op const op, Cond const cond) noexcept
+    bool If (T* const add, T const value, Op&& op, Cond&& cond) noexcept
     {
 #if AMREX_DEVICE_COMPILE
-        return If_device(add, value, std::forward<Op const>(op), std::forward<Cond const>(cond));
+        return If_device(add, value, std::forward<Op>(op), std::forward<Cond>(cond));
 #else
         T old = *add;
         T const tmp = op(old, value);

--- a/Src/Base/AMReX_GpuAtomic.H
+++ b/Src/Base/AMReX_GpuAtomic.H
@@ -6,6 +6,8 @@
 #include <AMReX_Functional.H>
 #include <AMReX_INT.H>
 
+#include <utility>
+
 namespace amrex {
 
 namespace Gpu { namespace Atomic {
@@ -45,6 +47,36 @@ namespace detail {
 #endif
     }
 
+    template <typename R, typename I, typename Op, typename Cond>
+    AMREX_GPU_DEVICE AMREX_FORCE_INLINE
+    bool atomic_op_if (R* const address, R const val, Op const op, Cond const cond) noexcept
+    {
+#if defined(__SYCL_DEVICE_ONLY__)
+        constexpr auto mo = sycl::memory_order::relaxed;
+        constexpr auto as = sycl::accesss::address_space::global_space;
+        static_assert(sizeof(R) == sizeof(I), "sizeof R != sizeof I");
+        I* const add_as_I = reinterpret_cast<I*>(address);
+        sycl::atomic<I, as> a{sycl::multi_ptr<I,as>(add_as_I)};
+        I old_I = a.load(mo), new_I;
+        bool test_success;
+        do {
+            R const tmp = f(*(reinterpret_cast<R const*>(&old_I)), val);
+            new_I = *(reinterpret_cast<I const*>(&tmp));
+            test_success = cond(tmp);
+        } while (test_success && ! a.compare_exchange_strong(old_I, new_I, mo));
+        return test_success;
+#else
+        R old = *address;
+        R const tmp = f(*(reinterpret_cast<R const*>(&old)), val);
+        if (cond(tmp)) {
+            *address = tmp;
+            return true;
+        } else {
+            return false;
+        }
+#endif
+    }
+
 #elif defined(AMREX_USE_CUDA) || defined(AMREX_USE_HIP)
 
     template <typename R, typename I, typename F>
@@ -60,6 +92,25 @@ namespace detail {
             old_I = atomicCAS(add_as_I, assumed_I, *(reinterpret_cast<I const*>(&new_R)));
         } while (assumed_I != old_I);
         return *(reinterpret_cast<R const*>(&old_I));
+    }
+
+    template <typename R, typename I, typename Op, typename Cond>
+    AMREX_GPU_DEVICE AMREX_FORCE_INLINE
+    bool atomic_op_if (R* const address, R const val, Op const op, Cond const cond) noexcept
+    {
+        static_assert(sizeof(R) == sizeof(I), "sizeof R != sizeof I");
+        I* const add_as_I = reinterpret_cast<I*>(address);
+        I old_I = *add_as_I, assumed_I;
+        bool test_success;
+        do {
+            assumed_I = old_I;
+            R const new_R = op(*(reinterpret_cast<R const*>(&assumed_I)), val);
+            test_success = cond(new_R);
+            if (test_success) {
+                old_I = atomicCAS(add_as_I, assumed_I, *(reinterpret_cast<I const*>(&new_R)));
+            }
+        } while (test_success && assumed_I != old_I);
+        return test_success;
     }
 
 #endif
@@ -142,6 +193,77 @@ namespace detail {
         auto old = *sum;
         *sum += value;
         return old;
+#endif
+    }
+
+////////////////////////////////////////////////////////////////////////
+//  If
+////////////////////////////////////////////////////////////////////////
+
+#if defined(AMREX_USE_CUDA) || defined(AMREX_USE_HIP) || defined(AMREX_USE_DPCPP)
+    template <typename Op, typename Cond>
+    AMREX_GPU_DEVICE AMREX_FORCE_INLINE
+    bool If_device (double* const sum, double const value, Op const op, Cond const cond) noexcept
+    {
+        return detail::atomic_op_if<double, unsigned long long>(sum, value,
+                   std::forward<Op const>(op), std::forward<Cond const>(cond));
+    }
+
+    template <typename Op, typename Cond>
+    AMREX_GPU_DEVICE AMREX_FORCE_INLINE
+    bool If_device (float* const sum, float const value, Op const op, Cond const cond) noexcept
+    {
+        return detail::atomic_op_if<float, unsigned int>(sum, value,
+                   std::forward<Op const>(op), std::forward<Cond const>(cond));
+    }
+
+    template <typename Op, typename Cond>
+    AMREX_GPU_DEVICE AMREX_FORCE_INLINE
+    bool If_device (Long* const sum, Long const value, Op const op, Cond const cond) noexcept
+    {
+        return detail::atomic_op_if<Long, unsigned long long>(sum, value,
+                   std::forward<Op const>(op), std::forward<Cond const>(cond));
+    }
+
+    template <typename T, typename Op, typename Cond>
+    AMREX_GPU_DEVICE AMREX_FORCE_INLINE
+    bool If_device (T* const sum, T const value, Op const op, Cond const cond) noexcept
+    {
+        return detail::atomic_op_if<T, T>(sum, value,
+                   std::forward<Op const>(op), std::forward<Cond const>(cond));
+    }
+#endif
+
+/**
+*  \brief Conditionally perform an atomic operation.
+*
+*  Atomically updates the result at "add" with "value" using "op",
+*  but only if "cond" is true.
+*
+* \tparam T the type pointed to by add
+* \tparam Op callable that takes two T argument and combines them
+* \tparam Cond callable that takes a "T" a returns whether to do the update
+*
+* \param add address to atomically update
+* \param value value to combine
+* \param op callable specifying the operation to use to combine *add and value
+* \param cond callable specifying the condition to test on first.
+**/
+    template<class T, class Op, class Cond>
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    bool If (T* const add, T const value, Op const op, Cond const cond) noexcept
+    {
+#if AMREX_DEVICE_COMPILE
+        return If_device(add, value, std::forward<Op const>(op), std::forward<Cond const>(cond));
+#else
+        T old = *add;
+        T const tmp = op(old, value);
+        if (cond(tmp)) {
+            *add = tmp;
+            return true;
+        } else {
+            return false;
+        }
 #endif
     }
 

--- a/Src/Base/AMReX_GpuAtomic.H
+++ b/Src/Base/AMReX_GpuAtomic.H
@@ -248,6 +248,7 @@ namespace detail {
 * \param value value to combine
 * \param op callable specifying the operation to use to combine *add and value
 * \param cond callable specifying the condition to test on first.
+*        The value passed in to the cond function is the would-be combined value
 **/
     template<class T, class Op, class Cond>
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE

--- a/Src/Base/AMReX_GpuAtomic.H
+++ b/Src/Base/AMReX_GpuAtomic.H
@@ -60,14 +60,14 @@ namespace detail {
         I old_I = a.load(mo), new_I;
         bool test_success;
         do {
-            R const tmp = f(*(reinterpret_cast<R const*>(&old_I)), val);
+            R const tmp = op(*(reinterpret_cast<R const*>(&old_I)), val);
             new_I = *(reinterpret_cast<I const*>(&tmp));
             test_success = cond(tmp);
         } while (test_success && ! a.compare_exchange_strong(old_I, new_I, mo));
         return test_success;
 #else
         R old = *address;
-        R const tmp = f(*(reinterpret_cast<R const*>(&old)), val);
+        R const tmp = op(*(reinterpret_cast<R const*>(&old)), val);
         if (cond(tmp)) {
             *address = tmp;
             return true;

--- a/Src/Base/AMReX_GpuAtomic.H
+++ b/Src/Base/AMReX_GpuAtomic.H
@@ -201,35 +201,21 @@ namespace detail {
 ////////////////////////////////////////////////////////////////////////
 
 #if defined(AMREX_USE_CUDA) || defined(AMREX_USE_HIP) || defined(AMREX_USE_DPCPP)
-    template <typename Op, typename Cond>
-    AMREX_GPU_DEVICE AMREX_FORCE_INLINE
-    bool If_device (double* const sum, double const value, Op&& op, Cond&& cond) noexcept
-    {
-        return detail::atomic_op_if<double, unsigned long long>(sum, value,
-                   std::forward<Op>(op), std::forward<Cond>(cond));
-    }
-
-    template <typename Op, typename Cond>
-    AMREX_GPU_DEVICE AMREX_FORCE_INLINE
-    bool If_device (float* const sum, float const value, Op&& op, Cond&& cond) noexcept
-    {
-        return detail::atomic_op_if<float, unsigned int>(sum, value,
-                   std::forward<Op>(op), std::forward<Cond>(cond));
-    }
-
-    template <typename Op, typename Cond>
-    AMREX_GPU_DEVICE AMREX_FORCE_INLINE
-    bool If_device (Long* const sum, Long const value, Op&& op, Cond&& cond) noexcept
-    {
-        return detail::atomic_op_if<Long, unsigned long long>(sum, value,
-                   std::forward<Op>(op), std::forward<Cond>(cond));
-    }
-
-    template <typename T, typename Op, typename Cond>
+    template <typename T, typename Op, typename Cond,
+              std::enable_if_t<sizeof(T) == sizeof(unsigned int), int> foo = 0>
     AMREX_GPU_DEVICE AMREX_FORCE_INLINE
     bool If_device (T* const sum, T const value, Op&& op, Cond&& cond) noexcept
     {
-        return detail::atomic_op_if<T, T>(sum, value,
+        return detail::atomic_op_if<T, unsigned int>(sum, value,
+                   std::forward<Op>(op), std::forward<Cond>(cond));
+    }
+
+    template <typename T, typename Op, typename Cond,
+              std::enable_if_t<sizeof(T) == sizeof(unsigned long long), int> foo = 0>
+    AMREX_GPU_DEVICE AMREX_FORCE_INLINE
+    bool If_device (T* const sum, T const value, Op&& op, Cond&& cond) noexcept
+    {
+        return detail::atomic_op_if<T, unsigned long long>(sum, value,
                    std::forward<Op>(op), std::forward<Cond>(cond));
     }
 #endif

--- a/Src/Base/AMReX_GpuAtomic.H
+++ b/Src/Base/AMReX_GpuAtomic.H
@@ -53,7 +53,7 @@ namespace detail {
     {
 #if defined(__SYCL_DEVICE_ONLY__)
         constexpr auto mo = sycl::memory_order::relaxed;
-        constexpr auto as = sycl::accesss::address_space::global_space;
+        constexpr auto as = sycl::access::address_space::global_space;
         static_assert(sizeof(R) == sizeof(I), "sizeof R != sizeof I");
         I* const add_as_I = reinterpret_cast<I*>(address);
         sycl::atomic<I, as> a{sycl::multi_ptr<I,as>(add_as_I)};

--- a/Tests/GPU/AtomicIf/GNUmakefile
+++ b/Tests/GPU/AtomicIf/GNUmakefile
@@ -1,0 +1,23 @@
+AMREX_HOME = ../../../
+
+DEBUG	= FALSE
+
+DIM	= 3
+
+COMP    = gcc
+
+USE_CUDA  = FALSE
+USE_ACC   = FALSE
+USE_OMP_OFFLOAD = FALSE
+
+USE_MPI   = FALSE
+USE_OMP   = FALSE
+
+TINY_PROFILE = FALSE
+
+include $(AMREX_HOME)/Tools/GNUMake/Make.defs
+
+include ./Make.package
+include $(AMREX_HOME)/Src/Base/Make.package
+
+include $(AMREX_HOME)/Tools/GNUMake/Make.rules

--- a/Tests/GPU/AtomicIf/Make.package
+++ b/Tests/GPU/AtomicIf/Make.package
@@ -1,0 +1,2 @@
+CEXE_sources += main.cpp
+

--- a/Tests/GPU/AtomicIf/main.cpp
+++ b/Tests/GPU/AtomicIf/main.cpp
@@ -10,71 +10,75 @@ template <typename T>
 struct IsNonnegative {
     AMREX_GPU_DEVICE AMREX_FORCE_INLINE
     bool operator () (T const val) const noexcept {
-        return val >= T(0.0);
+        return val >= T(0.);
     }
 };
+
+template <typename T>
+void test ()
+{
+    int N = 8000;
+
+    amrex::Gpu::DeviceVector<T> v_d(N);
+    auto v_d_ptr = v_d.data();
+    amrex::ParallelForRNG(N,
+                          [=] AMREX_GPU_DEVICE (int i, RandomEngine const& engine) noexcept
+                          {
+                              v_d_ptr[i] = T(i);
+                          });
+
+    for (int j = 0; j < 1000; ++j) {
+        amrex::ParallelFor(N,
+                           [=] AMREX_GPU_DEVICE (int i) noexcept
+                           {
+                               // add -1.0 to v_d_ptr[i] if the result would be non-negative
+                               Gpu::Atomic::If(&v_d_ptr[i], T(-1.0), amrex::Plus<T>(), IsNonnegative<T>());
+                               // can also use +1.0 amrex::Minus<T>
+                               Gpu::Atomic::If(&v_d_ptr[N-i-1], T(1.0), amrex::Minus<T>(), IsNonnegative<T>());
+                           });
+
+        amrex::ParallelFor(N,
+                           [=] AMREX_GPU_DEVICE (int i) noexcept
+                           {
+                               // lambdas also work
+                               Gpu::Atomic::If(&v_d_ptr[N-i-1], T(1.0), amrex::Minus<T>(),
+                                               [=] AMREX_GPU_DEVICE (T tmp) noexcept
+                                               {
+                                                   return (tmp >= T(0.0));
+                                               });
+                               Gpu::Atomic::If(&v_d_ptr[i], T(1.0), amrex::Minus<T>(),
+                                               [=] AMREX_GPU_DEVICE (T tmp) noexcept
+                                               {
+                                                   return (tmp >= T(0.0));
+                                               });
+                           });
+    }
+    Gpu::synchronize();
+
+    std::vector<T> v_h(N);
+    Gpu::copyAsync(Gpu::deviceToHost, v_d.begin(), v_d.end(), v_h.begin());
+    Gpu::synchronize();
+
+    // The first 4000 entries should all be 0.0
+    for (int i = 0; i < 4000; ++i) {
+        AMREX_ALWAYS_ASSERT(v_h[i] == 0);
+    }
+
+    // The next 4000 should go from 0 to 3999
+    for (int i = 4000, j = 0; i < 8000; ++i, ++j) {
+        AMREX_ALWAYS_ASSERT(v_h[i] == j);
+    }
+}
+
 
 int main (int argc, char* argv[])
 {
     amrex::Initialize(argc,argv);
-    {
-        int N = 8000;
-
-        amrex::Gpu::DeviceVector<Real> v_d(N);
-        auto v_d_ptr = v_d.data();
-        amrex::ParallelForRNG(N,
-        [=] AMREX_GPU_DEVICE (int i, RandomEngine const& engine) noexcept
-        {
-            v_d_ptr[i] = Real(i);
-        });
-
-        for (int j = 0; j < 1000; ++j)
-        {
-            amrex::ParallelFor(N,
-               [=] AMREX_GPU_DEVICE (int i) noexcept
-               {
-                   // add -1.0 to v_d_ptr[i] if the result would be non-negative
-                   Gpu::Atomic::If(&v_d_ptr[i], -1.0, amrex::Plus<amrex::Real>(), IsNonnegative<amrex::Real>());
-                   // can also use +1.0 amrex::Minus<amrex::Real>
-                   Gpu::Atomic::If(&v_d_ptr[N-i-1], 1.0, amrex::Minus<amrex::Real>(), IsNonnegative<amrex::Real>());
-               });
-
-            amrex::ParallelFor(N,
-            [=] AMREX_GPU_DEVICE (int i) noexcept
-            {
-                // lambdas also work
-                Gpu::Atomic::If(&v_d_ptr[N-i-1], 1.0, amrex::Minus<amrex::Real>(),
-                                [=] AMREX_GPU_DEVICE (amrex::Real tmp) noexcept
-                                {
-                                    return (tmp >= amrex::Real(0.0));
-                                });
-                Gpu::Atomic::If(&v_d_ptr[i], 1.0, amrex::Minus<amrex::Real>(),
-                                [=] AMREX_GPU_DEVICE (amrex::Real tmp) noexcept
-                                {
-                                    return (tmp >= amrex::Real(0.0));
-                                });
-            });
-        }
-
-        Gpu::synchronize();
-
-        std::vector<Real> v_h(N);
-        Gpu::copyAsync(Gpu::deviceToHost, v_d.begin(), v_d.end(), v_h.begin());
-        Gpu::synchronize();
-
-        // The first 4000 entries should all be 0.0
-        for (int i = 0; i < 4000; ++i)
-        {
-            AMREX_ALWAYS_ASSERT(v_h[i] == 0);
-        }
-
-        // The next 4000 should go from 0 to 3999
-        for (int i = 4000, j = 0; i < 8000; ++i, ++j)
-        {
-            AMREX_ALWAYS_ASSERT(v_h[i] == j);
-        }
-
-    }
+    test<int>();
+    test<long>();
+    test<float>();
+    test<double>();
+    test<amrex::Long>();
     amrex::Finalize();
 }
 

--- a/Tests/GPU/AtomicIf/main.cpp
+++ b/Tests/GPU/AtomicIf/main.cpp
@@ -1,0 +1,80 @@
+#include <AMReX.H>
+#include <AMReX_Gpu.H>
+#include <AMReX_GpuContainers.H>
+#include <AMReX_ParmParse.H>
+#include <AMReX_GpuPrint.H>
+
+using namespace amrex;
+
+template <typename T>
+struct IsNonnegative {
+    AMREX_GPU_DEVICE AMREX_FORCE_INLINE
+    bool operator () (T const val) const noexcept {
+        return val >= T(0.0);
+    }
+};
+
+int main (int argc, char* argv[])
+{
+    amrex::Initialize(argc,argv);
+    {
+        int N = 8000;
+
+        amrex::Gpu::DeviceVector<Real> v_d(N);
+        auto v_d_ptr = v_d.data();
+        amrex::ParallelForRNG(N,
+        [=] AMREX_GPU_DEVICE (int i, RandomEngine const& engine) noexcept
+        {
+            v_d_ptr[i] = Real(i);
+        });
+
+        for (int j = 0; j < 1000; ++j)
+        {
+            amrex::ParallelFor(N,
+               [=] AMREX_GPU_DEVICE (int i) noexcept
+               {
+                   // add -1.0 to v_d_ptr[i] if the result would be non-negative
+                   Gpu::Atomic::If(&v_d_ptr[i], -1.0, amrex::Plus<amrex::Real>(), IsNonnegative<amrex::Real>());
+                   // can also use +1.0 amrex::Minus<amrex::Real>
+                   Gpu::Atomic::If(&v_d_ptr[N-i-1], 1.0, amrex::Minus<amrex::Real>(), IsNonnegative<amrex::Real>());
+               });
+
+            amrex::ParallelFor(N,
+            [=] AMREX_GPU_DEVICE (int i) noexcept
+            {
+                // lambdas also work
+                Gpu::Atomic::If(&v_d_ptr[N-i-1], 1.0, amrex::Minus<amrex::Real>(),
+                                [=] AMREX_GPU_DEVICE (amrex::Real tmp) noexcept
+                                {
+                                    return (tmp >= amrex::Real(0.0));
+                                });
+                Gpu::Atomic::If(&v_d_ptr[i], 1.0, amrex::Minus<amrex::Real>(),
+                                [=] AMREX_GPU_DEVICE (amrex::Real tmp) noexcept
+                                {
+                                    return (tmp >= amrex::Real(0.0));
+                                });
+            });
+        }
+
+        Gpu::synchronize();
+
+        std::vector<Real> v_h(N);
+        Gpu::copyAsync(Gpu::deviceToHost, v_d.begin(), v_d.end(), v_h.begin());
+        Gpu::synchronize();
+
+        // The first 4000 entries should all be 0.0
+        for (int i = 0; i < 4000; ++i)
+        {
+            AMREX_ALWAYS_ASSERT(v_h[i] == 0);
+        }
+
+        // The next 4000 should go from 0 to 3999
+        for (int i = 4000, j = 0; i < 8000; ++i, ++j)
+        {
+            AMREX_ALWAYS_ASSERT(v_h[i] == j);
+        }
+
+    }
+    amrex::Finalize();
+}
+


### PR DESCRIPTION
This adds support for *conditionally* doing atomic operations. For example, to atomically subtract one from a value, but only if the result would be non-negative:

```
Gpu::Atomic::If(&data[i], 1.0, amrex::Minus<amrex::Real>(),
                          [=] AMREX_GPU_DEVICE (amrex::Real res) noexcept
                          {
                              return (res >= 0.0);
                          });
```

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
