### PR TITLE
make sure there are no NaNs in the plotfiles

### DIFF
--- a/Tools/C_util/Convergence/ComparePlotfiles.cpp
+++ b/Tools/C_util/Convergence/ComparePlotfiles.cpp
@@ -90,6 +90,13 @@ main (int   argc,
     VisMF::Read(mf_c, iFile1);
     VisMF::Read(mf_f, iFile2);
 
+    if (mf_c.contains_nan()) {
+        Abort("First plotfile contains NaN(s)");
+    }
+    if (mf_f.contains_nan()) {
+        Abort("Second plotfile contains NaN(s)");
+    }
+
     // check number of components
     if (mf_c.nComp() != mf_f.nComp()) {
         Abort("plotfiles do not have the same number of variables");

--- a/Tools/C_util/Convergence/DiffSameDomainRefined.cpp
+++ b/Tools/C_util/Convergence/DiffSameDomainRefined.cpp
@@ -202,6 +202,13 @@ main (int   argc,
             MultiFab& data1     = amrData1.GetGrids(iLevel, iComp);
             MultiFab& data2Fine = amrData2.GetGrids(iLevel, iComp);
 
+            if (data1.contains_nan()) {
+                Abort("First plotfile contains NaN(s)");
+            }
+            if (data2Fine.contains_nan()) {
+                Abort("Second plotfile contains NaN(s)");
+            }
+
             // Copy the data at the coarse level one component at a time
             new_data1.copy(data1,0,0,1);
 

--- a/Tools/C_util/Convergence/DiffSameDomainRefinedComposite.cpp
+++ b/Tools/C_util/Convergence/DiffSameDomainRefinedComposite.cpp
@@ -209,6 +209,13 @@ main (int   argc,
             MultiFab& data1     = amrData1.GetGrids(iLevel, iComp);
             MultiFab& data2Fine = amrData2.GetGrids(iLevel, iComp);
 
+            if (data1.contains_nan()) {
+                Abort("First plotfile contains NaN(s)");
+            }
+            if (data2Fine.contains_nan()) {
+                Abort("Second plotfile contains NaN(s)");
+            }
+
             BoxArray baf;
             if (iLevel<finestLevel)
              {

--- a/Tools/C_util/Convergence/DiffSameDomainRefinedStag.cpp
+++ b/Tools/C_util/Convergence/DiffSameDomainRefinedStag.cpp
@@ -223,6 +223,13 @@ main (int   argc,
             MultiFab& data1     = amrData1.GetGrids(iLevel, iComp);
             MultiFab& data2Fine = amrData2.GetGrids(iLevel, iComp);
 
+            if (data1.contains_nan()) {
+                Abort("First plotfile contains NaN(s)");
+            }
+            if (data2Fine.contains_nan()) {
+                Abort("Second plotfile contains NaN(s)");
+            }
+
             // Copy the data at the coarse level one component at a time
             new_data1.copy(data1,0,0,1);
 

--- a/Tools/C_util/Convergence/DiffSameGrid.cpp
+++ b/Tools/C_util/Convergence/DiffSameGrid.cpp
@@ -153,6 +153,13 @@ main (int   argc,
         amrDataI.FillVar(dataI, iLevel, derives, destComps);
         amrDataE.FillVar(dataE, iLevel, derives, destComps);
 
+        if (dataI.contains_nan()) {
+            Abort("First plotfile contains NaN(s)");
+        }
+        if (dataE.contains_nan()) {
+            Abort("Second plotfile contains NaN(s)");
+        }
+
         for (int i = 0; i < destComps.size(); i++)
         {
             amrDataI.FlushGrids(destComps[i]);

--- a/Tools/C_util/Convergence/DiffSameGrid2.cpp
+++ b/Tools/C_util/Convergence/DiffSameGrid2.cpp
@@ -176,6 +176,13 @@ main (int   argc,
         amrDataI.FillVar(dataI, iLevel, derives, destComps);
         amrDataE.FillVar(dataE, iLevel, derives, destComps);
 
+        if (dataI.contains_nan()) {
+            Abort("First plotfile contains NaN(s)");
+        }
+        if (dataE.contains_nan()) {
+            Abort("Second plotfile contains NaN(s)");
+        }
+        
         if (iLevel == 0) {
             for (int iComp=0; iComp < nComp; ++iComp) {
                 maxAbsVal[iComp] = dataI.norm0(iComp);

--- a/Tools/C_util/Convergence/DiffSameGrid2.cpp
+++ b/Tools/C_util/Convergence/DiffSameGrid2.cpp
@@ -182,7 +182,7 @@ main (int   argc,
         if (dataE.contains_nan()) {
             Abort("Second plotfile contains NaN(s)");
         }
-        
+
         if (iLevel == 0) {
             for (int iComp=0; iComp < nComp; ++iComp) {
                 maxAbsVal[iComp] = dataI.norm0(iComp);

--- a/Tools/C_util/Convergence/DiffSameGridRefined.cpp
+++ b/Tools/C_util/Convergence/DiffSameGridRefined.cpp
@@ -198,6 +198,13 @@ main (int   argc,
             MultiFab& data1 = amrData1.GetGrids(iLevel, iComp);
             MultiFab& data2Fine = amrData2.GetGrids(iLevel, iComp);
 
+            if (data1.contains_nan()) {
+                Abort("First plotfile contains NaN(s)");
+            }
+            if (data2Fine.contains_nan()) {
+                Abort("Second plotfile contains NaN(s)");
+            }
+
 
             //
             // Calculate the errors  for each FAB in the MultiFab


### PR DESCRIPTION
## Summary
The following routines would report no difference between two input plotfiles if one of them contained NaNs, which makes for a really bad comparison for regression usage.  Now they abort with an error message if a NaN is detected.
ComparePlotfiles.cpp
DiffSameDomainRefined.cpp
DiffSameDomainRefinedComposite.cpp
DiffSameDomainRefinedStag.cpp
DiffSameGrid.cpp
DiffSameGrid2.cpp
DiffSameGridRefined.cpp

## Additional background

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
