### PR TITLE
Update DiffMultiFab tool

### DIFF
--- a/Tools/C_util/DiffMultiFab/GNUmakefile
+++ b/Tools/C_util/DiffMultiFab/GNUmakefile
@@ -10,10 +10,7 @@ COMP    = gcc
 
 PRECISION = DOUBLE
 
-#########################################################
-#NOTE: this version of diffmultifab only works in serial;
-#      we must build it with USE_MPI = FALSE
-#########################################################
+BL_NO_FORT = TRUE
 
 USE_MPI   = FALSE
 USE_OMP   = FALSE
@@ -25,36 +22,10 @@ USE_ASSERTION=TRUE
 
 EBASE     = diffmultifab
 
-# If NEEDS_f90_SRC=TRUE, look for ${EBASE}_nd.f90
-NEEDS_f90_SRC = FALSE
-#NEEDS_f90_SRC = TRUE
-
 include $(AMREX_HOME)/Tools/GNUMake/Make.defs
 
 CEXE_sources += ${EBASE}.cpp
 
-INCLUDE_LOCATIONS += $(AMREX_HOME)/Src/Base
 include $(AMREX_HOME)/Src/Base/Make.package
-vpathdir += $(AMREX_HOME)/Src/Base
-
-INCLUDE_LOCATIONS += $(AMREX_HOME)/Src/Extern/amrdata
-include $(AMREX_HOME)/Src/Extern/amrdata/Make.package
-vpathdir += $(AMREX_HOME)/Src/Extern/amrdata
-
-INCLUDE_LOCATIONS += $(AMREX_HOME)/Tools/C_util
-include $(AMREX_HOME)/Tools/C_util/Make.package
-vpathdir += $(AMREX_HOME)/Tools/C_util
-
-ifeq ($(NEEDS_f90_SRC),TRUE)
-  f90EXE_sources += ${EBASE}_nd.f90
-endif
-
-vpath %.c   : . $(vpathdir)
-vpath %.h   : . $(vpathdir)
-vpath %.cpp : . $(vpathdir)
-vpath %.H   : . $(vpathdir)
-vpath %.F   : . $(vpathdir)
-vpath %.f   : . $(vpathdir)
-vpath %.f90 : . $(vpathdir)
 
 include $(AMREX_HOME)/Tools/GNUMake/Make.rules

--- a/Tools/C_util/DiffMultiFab/diffmultifab.cpp
+++ b/Tools/C_util/DiffMultiFab/diffmultifab.cpp
@@ -7,17 +7,10 @@
 #include <AMReX_VisMF.H>
 #include <AMReX_ParmParse.H>
 
-#ifdef AMREX_USE_MPI
-#define MY_USE_MPI 1
-#else
-#define MY_USE_MPI 0
-#endif
-
 using namespace amrex;
 
 void
-print_usage (int,
-             char* argv[])
+print_usage (int, char* argv[])
 {
     std::cerr << "usage:\n";
     std::cerr << argv[0] << " infile1=f1 infile2=f2, ngrow=ngrow" << std::endl;
@@ -26,11 +19,11 @@ print_usage (int,
 
 int main(int argc, char* argv[])
 {
-    static_assert(MY_USE_MPI!=1, "cannot work with MPI" );
     amrex::Initialize(argc,argv);
     {
-        if (argc < 3)
+        if (argc < 3) {
             print_usage(argc,argv);
+        }
 
         std::string name1, name2;
         int ngrow = -1;
@@ -49,19 +42,22 @@ int main(int argc, char* argv[])
         Print() << "Reading " << name2 << std::endl;
         VisMF::Read(mf2, name2);
 
-        if (ngrow < 0) ngrow = std::min(mf1.nGrow(), mf2.nGrow());
-        if (ngrow > mf1.nGrow())
+        if (ngrow < 0) {
+            ngrow = std::min(mf1.nGrow(), mf2.nGrow());
+        }
+        if (ngrow > mf1.nGrow()) {
             Abort(" ngrow bigger than infile1's ngrow! ");
-         if (ngrow > mf2.nGrow())
+        }
+        if (ngrow > mf2.nGrow()) {
             Abort(" ngrow bigger than infile2's ngrow! ");
-
+        }
         if (mf1.boxArray() != mf2.boxArray()) {
             Abort("The two multifabs have different BoxArray");
         }
 
         const int ncomp = mf1.nComp();
 
-/*        std::vector<Real> mf1_min(ncomp);
+        std::vector<Real> mf1_min(ncomp);
         std::vector<Real> mf1_max(ncomp);
         std::vector<Real> mf2_min(ncomp);
         std::vector<Real> mf2_max(ncomp);
@@ -72,31 +68,40 @@ int main(int argc, char* argv[])
             mf2_min[icomp] = mf2.min(icomp,ngrow);
             mf2_max[icomp] = mf2.max(icomp,ngrow);
         }
-*/
 
-        MultiFab mfdiff(mf1.boxArray(), mf1.DistributionMap(), ncomp, ngrow);
-
+        MultiFab mfdiff(mf1.boxArray(), mf2.DistributionMap(), ncomp, ngrow);
+#ifdef AMREX_USE_MPI
+        {
+            MultiFab tmp(mf1.boxArray(), mf1.DistributionMap(), ncomp, ngrow);
+            MultiFab::Copy(tmp, mf1, 0, 0, ncomp, ngrow);
+            mfdiff.Redistribute(tmp, 0, 0, ncomp, IntVect(ngrow));
+        }
+#else
         MultiFab::Copy(mfdiff, mf1, 0, 0, ncomp, ngrow);
+#endif
         MultiFab::Subtract(mfdiff, mf2, 0, 0, ncomp, ngrow);
 
         for (int icomp = 0; icomp < ncomp; ++icomp) {
-            Print() << "Component " << icomp << std::endl;
-            Print() << "diff Min,max: " << mfdiff.min(icomp,ngrow)
-                    << " , " << mfdiff.max(icomp,ngrow) << std::endl;
-        }
-/*            if (ncomp > 1) {
-                Print() << " for component " << icomp;
+            Real mn = mfdiff.min(icomp,ngrow);
+            Real mx = mfdiff.max(icomp,ngrow);
+            if (ncomp > 1) {
+                Print() << "Component " << icomp << "\n";
             }
-                Print() << " 1st mf min,max: " << mf1_min[icomp]
-                      << ", " << mf1_max[icomp]
-                      << ", 2nd mf min,max: ";
-                Print() << mf2_min[icomp]
-                          << ", " << mf2_max[icomp] << "\n";
-         } */
+            Print() << "    Min and max of the diff are " << mn << " and " << mx << "\n";
+            if (mn != 0.0) {
+                Print() << "    Min Index: " << mfdiff.minIndex(icomp,ngrow) << "\n";
+            }
+            if (mx != 0.0) {
+                Print() << "    Max Index: " << mfdiff.maxIndex(icomp,ngrow) << "\n";
+            }
+            Print() << "    Min and max of 1st mf are " << mf1_min[icomp]
+                    << " and " << mf1_max[icomp] << "\n";
+            Print() << "    Min and max of 2nd mf are " << mf2_min[icomp]
+                    << " and " << mf2_max[icomp] << "\n";
+        }
 
-         Print() << "Writing mfdiff" << std::endl;
-         VisMF::Write(mfdiff, "mfdiff");
+        Print() << "Writing mfdiff" << "\n";
+        VisMF::Write(mfdiff, "mfdiff");
     }
     amrex::Finalize();
 }
-


### PR DESCRIPTION
Print the location of min and max diff.  Make it work with MPI.  An example
of output is below,

```
diffmultifab3d.gnu.TEST.ex infile1=mf1  infile2=mf2 ngrow=0

Reading mf1
Reading mf2
Component 0
    Min and max of the diff are -0.5738299806 and 0.3011247047
    Min Index: (63,127,127)
    Max Index: (75,127,127)
    Min and max of 1st mf are 0.1249966244 and 1.000010767
    Min and max of 2nd mf are 0.125 and 1
Component 1
    Min and max of the diff are -1.273924814e-05 and 0.3954904262
    Min Index: (31,127,127)
    Max Index: (64,127,127)
    Min and max of 1st mf are -1.273924814e-05 and 0.3954904262
    Min and max of 2nd mf are 0 and 0
Component 2
    Min and max of the diff are 0 and 0
    Min and max of 1st mf are 0 and 0
    Min and max of 2nd mf are 0 and 0
Writing mfdiff
```

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
