### PR TITLE
add dropped CMake code for mesh+particle adaptor

### DIFF
--- a/Src/Extern/SENSEI/CMakeLists.txt
+++ b/Src/Extern/SENSEI/CMakeLists.txt
@@ -44,7 +44,10 @@ if ( AMReX_PARTICLES )
       list ( APPEND amrex_sensei_sources
          AMReX_AmrParticleDataAdaptor.H
          AMReX_AmrParticleDataAdaptorI.H
-         AMReX_AmrParticleInSituBridge.H )
+         AMReX_AmrParticleInSituBridge.H
+         AMReX_AmrMeshParticleDataAdaptor.H
+         AMReX_AmrMeshParticleDataAdaptorI.H
+         AMReX_AmrMeshParticleInSituBridge.H )
    endif()
 endif ()
 


### PR DESCRIPTION
## Summary
The CMake instructions for the new AmrMeshParticleDataAdaptor and AmrMeshParticleInSituBridge were accidentally dropped from https://github.com/AMReX-Codes/amrex/pull/2285. This PR adds those back in. 
## Additional background

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
