### PR TITLE
Amrvis build cleanup.

### DIFF
--- a/Src/Extern/amrdata/AMReX_DataServices.H
+++ b/Src/Extern/amrdata/AMReX_DataServices.H
@@ -18,7 +18,7 @@
 #include <AMReX_Array.H>
 #include <AMReX_Vector.H>
 #include <AMReX_BLProfStats.H>
-#include <BLProfParser.tab.H>
+//#include <BLProfParser.tab.H>
 #include <AMReX_CommProfStats.H>
 #include <AMReX_RegionsProfStats.H>
 #endif

--- a/Tools/GNUMake/Make.rules
+++ b/Tools/GNUMake/Make.rules
@@ -93,7 +93,6 @@ BLProfParser.tab.H BLProfParser.tab.cpp: $(AMREX_HOME)/Src/Extern/ProfParser/BLP
 	cat $(AMREX_HOME)/Src/Extern/ProfParser/BLProfParser.y $(SED0) $(SED1) > BLProfParserNC.y
 	bison --defines=BLProfParser.tab.H --output=BLProfParser.tab.cpp \
 		BLProfParserNC.y
-	rm BLProfParserNC.y
 
 BLProfParser.lex.yy.cpp: BLProfParser.tab.H $(AMREX_HOME)/Src/Extern/ProfParser/BLProfParser.l
 	flex --outfile=BLProfParser.lex.yy.cpp $(AMREX_HOME)/Src/Extern/ProfParser/BLProfParser.l
@@ -167,6 +166,7 @@ clean:: cleanconfig
 	$(SILENT) $(RM) BLProfParser.lex.yy.cpp
 	$(SILENT) $(RM) BLProfParser.tab.cpp
 	$(SILENT) $(RM) BLProfParser.tab.H
+	$(SILENT) $(RM) BLProfParserNC.y
 
 realclean:: clean
 


### PR DESCRIPTION
## Summary
Fixes to allow Amrvis to build cleanly with profiling. This cleans up errors when building with multiple threads, due to the flex/bison generated files dependencies and an unnecessary ``rm``.

## Additional background

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
