### PR TITLE
Tests/EB_CNS on GPU

### DIFF
--- a/Tests/EB_CNS/Exec/Pulse/cns_prob.H
+++ b/Tests/EB_CNS/Exec/Pulse/cns_prob.H
@@ -21,7 +21,11 @@ cns_initdata (int i, int j, int k, amrex::Array4<amrex::Real> const& state,
 
     Real x = (prob_lo[0] + (i+Real(0.5))*dx[0]) - 0.5 * (prob_lo[0] + prob_hi[0]);
     Real y = (prob_lo[1] + (j+Real(0.5))*dx[1]) - 0.5 * (prob_lo[1] + prob_hi[1]);
+#if (AMREX_SPACEDIM == 3)
     Real z = (prob_lo[2] + (k+Real(0.5))*dx[2]) - 0.5 * (prob_lo[2] + prob_hi[2]);
+#else
+    Real z = Real(0.0);
+#endif
     Real r = std::sqrt(x*x + y*y + z*z);
 
     if (r > prob_parm.rpulse) {
@@ -32,7 +36,9 @@ cns_initdata (int i, int j, int k, amrex::Array4<amrex::Real> const& state,
 
     state(i,j,k,UMX  ) = Real(0.0);
     state(i,j,k,UMY  ) = Real(0.0);
+#if (AMREX_SPACEDIM == 3)
     state(i,j,k,UMZ  ) = Real(0.0);
+#endif
 
     Real Pt = prob_parm.p0 * std::pow( (state(i,j,k,URHO) / prob_parm.rho0), parm.eos_gamma );
 

--- a/Tests/EB_CNS/Exec/ShockRef/cns_prob.H
+++ b/Tests/EB_CNS/Exec/ShockRef/cns_prob.H
@@ -32,7 +32,9 @@ cns_initdata (int i, int j, int k, amrex::Array4<amrex::Real> const& state,
     state(i,j,k,URHO ) = rhot;
     state(i,j,k,UMX  ) = rhot*uxt;
     state(i,j,k,UMY  ) = Real(0.0);
+#if (AMREX_SPACEDIM == 3)
     state(i,j,k,UMZ  ) = Real(0.0);
+#endif
     state(i,j,k,UEINT) = et;
     state(i,j,k,UEDEN) = et + Real(0.5)*rhot*uxt*uxt;
     state(i,j,k,UTEMP) = 0.0;

--- a/Tests/EB_CNS/Source/CNS.H
+++ b/Tests/EB_CNS/Source/CNS.H
@@ -123,15 +123,64 @@ protected:
 
     void buildMetrics ();
 
-    amrex::Real estTimeStep ();
-
     // Compute initial time step.
     amrex::Real initialTimeStep ();
 
-    void computeTemp (amrex::MultiFab& State, int ng);
-
     void compute_dSdt (const amrex::MultiFab& S, amrex::MultiFab& dSdt, amrex::Real dt,
                        amrex::EBFluxRegister* fr_as_crse, amrex::EBFluxRegister* fr_as_fine);
+
+    void printTotal () const;
+
+    const amrex::MultiFab* volfrac;
+    const amrex::MultiCutFab* bndrycent;
+    std::array<const amrex::MultiCutFab*,AMREX_SPACEDIM> areafrac;
+    std::array<const amrex::MultiCutFab*,AMREX_SPACEDIM> facecent;
+
+    amrex::iMultiFab level_mask;
+
+    amrex::EBFluxRegister flux_reg;
+
+    static constexpr int NUM_GROW = 5;
+
+    enum StateDataType {
+        State_Type = 0,
+        Cost_Type
+    };
+    static int num_state_data_types;
+
+    static amrex::BCRec phys_bc;
+
+    // Parameters
+    static int verbose;
+    static amrex::IntVect hydro_tile_size;
+    static amrex::Real cfl;
+
+    static bool do_visc;
+    static bool use_const_visc;
+
+    static int plm_iorder;
+    static amrex::Real plm_theta;
+
+    static int eb_weights_type;
+    static int do_reredistribution;
+
+    static int do_reflux;
+
+    static int refine_cutcells;
+
+    static int refine_max_dengrad_lev;
+    static amrex::Real refine_dengrad;
+
+    static amrex::Vector<amrex::RealBox> refine_boxes;
+    static amrex::RealBox* dp_refine_boxes;
+
+    static amrex::Real gravity;
+
+public:
+
+    amrex::Real estTimeStep ();
+
+    void computeTemp (amrex::MultiFab& State, int ng);
 
     void compute_dSdt_box (const amrex::Box& bx,
                            amrex::Array4<amrex::Real const>& Sfab,
@@ -177,53 +226,6 @@ protected:
                                 amrex::Array4<int               const> const& lev_mask,
                                 amrex::Real dt);
 
-    void printTotal () const;
-
-    const amrex::MultiFab* volfrac;
-    const amrex::MultiCutFab* bndrycent;
-    std::array<const amrex::MultiCutFab*,AMREX_SPACEDIM> areafrac;
-    std::array<const amrex::MultiCutFab*,AMREX_SPACEDIM> facecent;
-
-    amrex::iMultiFab level_mask;
-
-    amrex::EBFluxRegister flux_reg;
-
-    static constexpr int NUM_GROW = 5;
-
-    enum StateDataType {
-        State_Type = 0,
-        Cost_Type
-    };
-    static int num_state_data_types;
-
-    static amrex::BCRec phys_bc;
-
-    // Parameters
-    static int verbose;
-    static amrex::IntVect hydro_tile_size;
-    static amrex::Real cfl;
-
-    static bool do_visc;
-    static bool use_const_visc;
-
-    static int plm_iorder;
-    static amrex::Real plm_theta;
-
-    static int eb_weights_type;
-    static int do_reredistribution;
-
-    static int do_reflux;
-
-    static int refine_cutcells;
-
-    static int refine_max_dengrad_lev;
-    static amrex::Real refine_dengrad;
-
-    static amrex::Vector<amrex::RealBox> refine_boxes;
-
-    static amrex::Real gravity;
-
-public:
     static Parm* h_parm;
     static Parm* d_parm;
     static ProbParm* h_prob_parm;

--- a/Tests/EB_CNS/Source/CNS_K.H
+++ b/Tests/EB_CNS/Source/CNS_K.H
@@ -10,8 +10,7 @@
 #include "CNS_parm.H"
 #include "CNS_K.H"
 
-AMREX_GPU_HOST_DEVICE
-inline
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE
 amrex::Real
 cns_estdt (int i, int j, int k, amrex::Array4<Real const> const& state,
            amrex::GpuArray<amrex::Real,AMREX_SPACEDIM> const& dx,
@@ -48,8 +47,7 @@ cns_estdt (int i, int j, int k, amrex::Array4<Real const> const& state,
 }
 
 
-AMREX_GPU_DEVICE
-inline
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE
 void
 cns_compute_temperature (int i, int j, int k, amrex::Array4<amrex::Real> const& u,
                          Parm const& parm) noexcept

--- a/Tests/EB_CNS/Source/CNS_advance_box.cpp
+++ b/Tests/EB_CNS/Source/CNS_advance_box.cpp
@@ -26,156 +26,148 @@ CNS::compute_dSdt_box (const Box& bx,
                  auto const& fyfab = flux[1]->array();,
                  auto const& fzfab = flux[2]->array(););
 
-        const Box& bxg2 = amrex::grow(bx,2);
-        qtmp.resize(bxg2, NPRIM);
-        Elixir qeli = qtmp.elixir();
-        auto const& q = qtmp.array();
+    const Box& bxg2 = amrex::grow(bx,2);
+    qtmp.resize(bxg2, NPRIM);
+    auto const& q = qtmp.array();
 
-        Elixir dcoeff_eli;
+    if (do_visc == 1)
+    {
+       diff_coeff.resize(bxg2, NCOEF);
+    }
 
-        if (do_visc == 1)
-        {
-           diff_coeff.resize(bxg2, NCOEF);
-           dcoeff_eli = diff_coeff.elixir();
-        }
+    amrex::ParallelFor(bxg2,
+    [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+    {
+        cns_ctoprim(i, j, k, sfab, q, *lparm);
+    });
 
-        amrex::ParallelFor(bxg2,
-        [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
-        {
-            cns_ctoprim(i, j, k, sfab, q, *lparm);
-        });
+    if (do_visc == 1)
+    {
+       auto const& coefs = diff_coeff.array();
+       if(use_const_visc == 1 ) {
+          amrex::ParallelFor(bxg2,
+          [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+          {
+              cns_constcoef(i, j, k, coefs, *lparm);
+          });
+       } else {
+          amrex::ParallelFor(bxg2,
+          [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+          {
+              cns_diffcoef(i, j, k, q, coefs, *lparm);
+          });
+       }
+    }
 
-        if (do_visc == 1)
-        {
-           auto const& coefs = diff_coeff.array();
-           if(use_const_visc == 1 ) {
-              amrex::ParallelFor(bxg2,
-              [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
-              {
-                  cns_constcoef(i, j, k, coefs, *lparm);
-              });
-           } else {
-              amrex::ParallelFor(bxg2,
-              [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
-              {
-                  cns_diffcoef(i, j, k, q, coefs, *lparm);
-              });
-           }
-        }
+    const Box& bxg1 = amrex::grow(bx,1);
+    slopetmp.resize(bxg1,NEQNS);
+    auto const& slope = slopetmp.array();
 
-        const Box& bxg1 = amrex::grow(bx,1);
-        slopetmp.resize(bxg1,NEQNS);
-        Elixir slopeeli = slopetmp.elixir();
-        auto const& slope = slopetmp.array();
+    auto l_plm_iorder = plm_iorder;
+    auto l_plm_theta = plm_theta;
 
-        // x-direction
-        int cdir = 0;
-        const Box& xslpbx = amrex::grow(bx, cdir, 1);
-        amrex::ParallelFor(xslpbx,
-        [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
-        {
-            cns_slope_x(i, j, k, slope, q, plm_iorder, plm_theta);
-        });
-        const Box& xflxbx = amrex::surroundingNodes(bx,cdir);
-        amrex::ParallelFor(xflxbx,
-        [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
-        {
-            cns_riemann_x(i, j, k, fxfab, slope, q, *lparm);
-            for (int n = NEQNS; n < NCONS; ++n) fxfab(i,j,k,n) = Real(0.0);
-        });
+    // x-direction
+    int cdir = 0;
+    const Box& xslpbx = amrex::grow(bx, cdir, 1);
+    amrex::ParallelFor(xslpbx,
+    [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+    {
+        cns_slope_x(i, j, k, slope, q, l_plm_iorder, l_plm_theta);
+    });
+    const Box& xflxbx = amrex::surroundingNodes(bx,cdir);
+    amrex::ParallelFor(xflxbx,
+    [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+    {
+        cns_riemann_x(i, j, k, fxfab, slope, q, *lparm);
+        for (int n = NEQNS; n < NCONS; ++n) fxfab(i,j,k,n) = Real(0.0);
+    });
 
-        if (do_visc == 1)
-        {
-           auto const& coefs = diff_coeff.array();
-           amrex::ParallelFor(xflxbx,
-           [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
-           {
-               cns_diff_x(i, j, k, q, coefs, dxinv, fxfab);
-           });
-        }
+    if (do_visc == 1)
+    {
+       auto const& coefs = diff_coeff.array();
+       amrex::ParallelFor(xflxbx,
+       [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+       {
+           cns_diff_x(i, j, k, q, coefs, dxinv, fxfab);
+       });
+    }
 
-        // y-direction
-        cdir = 1;
-        const Box& yslpbx = amrex::grow(bx, cdir, 1);
-        amrex::ParallelFor(yslpbx,
-        [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
-        {
-            cns_slope_y(i, j, k, slope, q, plm_iorder, plm_theta);
-        });
-        const Box& yflxbx = amrex::surroundingNodes(bx,cdir);
-        amrex::ParallelFor(yflxbx,
-        [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
-        {
-            cns_riemann_y(i, j, k, fyfab, slope, q, *lparm);
-            for (int n = NEQNS; n < NCONS; ++n) fyfab(i,j,k,n) = Real(0.0);
-        });
+    // y-direction
+    cdir = 1;
+    const Box& yslpbx = amrex::grow(bx, cdir, 1);
+    amrex::ParallelFor(yslpbx,
+    [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+    {
+        cns_slope_y(i, j, k, slope, q, l_plm_iorder, l_plm_theta);
+    });
+    const Box& yflxbx = amrex::surroundingNodes(bx,cdir);
+    amrex::ParallelFor(yflxbx,
+    [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+    {
+        cns_riemann_y(i, j, k, fyfab, slope, q, *lparm);
+        for (int n = NEQNS; n < NCONS; ++n) fyfab(i,j,k,n) = Real(0.0);
+    });
 
-        if(do_visc == 1)
-        {
-           auto const& coefs = diff_coeff.array();
-           amrex::ParallelFor(yflxbx,
-           [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
-           {
-               cns_diff_y(i, j, k, q, coefs, dxinv, fyfab);
-           });
-        }
+    if(do_visc == 1)
+    {
+       auto const& coefs = diff_coeff.array();
+       amrex::ParallelFor(yflxbx,
+       [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+       {
+           cns_diff_y(i, j, k, q, coefs, dxinv, fyfab);
+       });
+    }
 
 #if (AMREX_SPACEDIM == 3)
-        // z-direction
-        cdir = 2;
-        const Box& zslpbx = amrex::grow(bx, cdir, 1);
-        amrex::ParallelFor(zslpbx,
-        [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
-        {
-            cns_slope_z(i, j, k, slope, q, plm_iorder, plm_theta);
-        });
-        const Box& zflxbx = amrex::surroundingNodes(bx,cdir);
-        amrex::ParallelFor(zflxbx,
-        [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
-        {
-            cns_riemann_z(i, j, k, fzfab, slope, q, *lparm);
-            for (int n = NEQNS; n < NCONS; ++n) fzfab(i,j,k,n) = Real(0.0);
-        });
+    // z-direction
+    cdir = 2;
+    const Box& zslpbx = amrex::grow(bx, cdir, 1);
+    amrex::ParallelFor(zslpbx,
+    [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+    {
+        cns_slope_z(i, j, k, slope, q, l_plm_iorder, l_plm_theta);
+    });
+    const Box& zflxbx = amrex::surroundingNodes(bx,cdir);
+    amrex::ParallelFor(zflxbx,
+    [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+    {
+        cns_riemann_z(i, j, k, fzfab, slope, q, *lparm);
+        for (int n = NEQNS; n < NCONS; ++n) fzfab(i,j,k,n) = Real(0.0);
+    });
 
-        if(do_visc == 1)
-        {
-           auto const& coefs = diff_coeff.array();
-           amrex::ParallelFor(zflxbx,
-           [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
-           {
-               cns_diff_z(i, j, k, q, coefs, dxinv, fzfab);
-           });
-        }
+    if(do_visc == 1)
+    {
+       auto const& coefs = diff_coeff.array();
+       amrex::ParallelFor(zflxbx,
+       [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+       {
+           cns_diff_z(i, j, k, q, coefs, dxinv, fzfab);
+       });
+    }
 #endif
 
-        // don't have to do this, but we could
-        qeli.clear(); // don't need them anymore
-        slopeeli.clear();
+    amrex::ParallelFor(bx, NCONS,
+    [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
+    {
+        cns_flux_to_dudt(i, j, k, n, dsdtfab, AMREX_D_DECL(fxfab,fyfab,fzfab), dxinv);
+    });
 
-        if (do_visc == 1) {
-           dcoeff_eli.clear();
-        }
-
-        amrex::ParallelFor(bx, NCONS,
-        [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
-        {
-            cns_flux_to_dudt(i, j, k, n, dsdtfab, AMREX_D_DECL(fxfab,fyfab,fzfab), dxinv);
-        });
-
-        if (gravity != Real(0.0)) {
-            const Real g = gravity;
-            const int irho = URHO;
+    if (gravity != Real(0.0)) {
+        const Real g = gravity;
+        const int irho = URHO;
 #if (AMREX_SPACEDIM == 2)
-            const int imz = UMY;
+        const int imz = UMY;
 #elif (AMREX_SPACEDIM == 3)
-            const int imz = UMZ;
+        const int imz = UMZ;
 #endif
-            const int irhoE = UEDEN;
-            amrex::ParallelFor(bx,
-            [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
-            {
-                dsdtfab(i,j,k,imz  ) += g * sfab(i,j,k,irho);
-                dsdtfab(i,j,k,irhoE) += g * sfab(i,j,k,imz);
-            });
-        }
+        const int irhoE = UEDEN;
+        amrex::ParallelFor(bx,
+        [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        {
+            dsdtfab(i,j,k,imz  ) += g * sfab(i,j,k,irho);
+            dsdtfab(i,j,k,irhoE) += g * sfab(i,j,k,imz);
+        });
+    }
+
+    Gpu::streamSynchronize();
 }

--- a/Tests/EB_CNS/Source/CNS_setup.cpp
+++ b/Tests/EB_CNS/Source/CNS_setup.cpp
@@ -113,7 +113,7 @@ CNS::variableSetUp ()
     bool store_in_checkpoint = true;
     desc_lst.addDescriptor(State_Type,IndexType::TheCellType(),
                            StateDescriptor::Point,NUM_GROW,NUM_STATE,
-                           &eb_cell_cons_interp,state_data_extrap,store_in_checkpoint);
+                           &eb_mf_cell_cons_interp,state_data_extrap,store_in_checkpoint);
 
     Vector<BCRec>       bcs(NUM_STATE);
     Vector<std::string> name(NUM_STATE);
@@ -181,4 +181,8 @@ CNS::variableCleanUp ()
     The_Arena()->free(d_prob_parm);
     desc_lst.clear();
     derive_lst.clear();
+
+#ifdef AMREX_USE_GPU
+    The_Arena()->free(dp_refine_boxes);
+#endif
 }

--- a/Tests/EB_CNS/Source/CNS_tagging.H
+++ b/Tests/EB_CNS/Source/CNS_tagging.H
@@ -5,8 +5,7 @@
 #include <AMReX_TagBox.H>
 #include <cmath>
 
-AMREX_GPU_HOST_DEVICE
-inline
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE
 void
 cns_tag_denerror (int i, int j, int k,
                   amrex::Array4<char> const& tag,

--- a/Tests/EB_CNS/Source/diffusion/CNS_diffusion_K.H
+++ b/Tests/EB_CNS/Source/diffusion/CNS_diffusion_K.H
@@ -7,8 +7,7 @@
 #include <AMReX_CONSTANTS.H>
 #include <cmath>
 
-AMREX_GPU_DEVICE
-inline
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE
 void
 cns_diffcoef (int i, int j, int k,
               amrex::Array4<amrex::Real const> const& q,
@@ -29,22 +28,18 @@ cns_diffcoef (int i, int j, int k,
     coefs(i,j,k,CLAM) = coefs(i,j,k,CETA)*parm.cp/parm.Pr;
 }
 
-AMREX_GPU_DEVICE
-inline
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE
 void
 cns_constcoef (int i, int j, int k,
               amrex::Array4<amrex::Real> const& coefs,
               Parm const& parm) noexcept
 {
-    using amrex::Real;
-
-     coefs(i,j,k,CETA) = parm.const_visc_mu;
-     coefs(i,j,k,CXI)  = parm.const_visc_ki;
-     coefs(i,j,k,CLAM) = parm.const_lambda;
+    coefs(i,j,k,CETA) = parm.const_visc_mu;
+    coefs(i,j,k,CXI)  = parm.const_visc_ki;
+    coefs(i,j,k,CLAM) = parm.const_lambda;
 }
 
-AMREX_GPU_DEVICE
-inline
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE
 void
 cns_diff_x (int i, int j, int k,
                amrex::Array4<amrex::Real const> const& q,
@@ -87,8 +82,7 @@ cns_diff_x (int i, int j, int k,
 
 }
 
-AMREX_GPU_DEVICE
-inline
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE
 void
 cns_diff_y (int i, int j, int k, amrex::Array4<amrex::Real const> const& q,
                amrex::Array4<amrex::Real const> const& coeffs,
@@ -131,8 +125,7 @@ cns_diff_y (int i, int j, int k, amrex::Array4<amrex::Real const> const& q,
 }
 
 #if (AMREX_SPACEDIM == 3)
-AMREX_GPU_DEVICE
-inline
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE
 void
 cns_diff_z (int i, int j, int k,
                amrex::Array4<amrex::Real const> const& q,

--- a/Tests/EB_CNS/Source/diffusion/CNS_diffusion_eb_K.H
+++ b/Tests/EB_CNS/Source/diffusion/CNS_diffusion_eb_K.H
@@ -7,8 +7,7 @@
 #include <AMReX_CONSTANTS.H>
 #include <cmath>
 
-AMREX_GPU_DEVICE
-inline
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE
 void
 cns_diffcoef_eb (int i, int j, int k,
                  amrex::Array4<amrex::Real const> const& q,
@@ -31,8 +30,7 @@ cns_diffcoef_eb (int i, int j, int k,
     coefs(i,j,k,CLAM) = cov ? -1.e10 : coefs(i,j,k,CETA)*parm.cp/parm.Pr;
 }
 
-AMREX_GPU_DEVICE
-inline
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE
 void
 cns_constcoef_eb (int i, int j, int k,
                  amrex::Array4<amrex::EBCellFlag const> const& flag,
@@ -47,8 +45,7 @@ cns_constcoef_eb (int i, int j, int k,
      coefs(i,j,k,CLAM) = cov ? -1.e01 : parm.const_lambda;
 }
 
-AMREX_GPU_DEVICE
-inline
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE
 void
 cns_diff_eb_x (int i, int j, int k,
                amrex::Array4<amrex::Real const> const& q,
@@ -122,8 +119,7 @@ cns_diff_eb_x (int i, int j, int k,
 
 }
 
-AMREX_GPU_DEVICE
-inline
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE
 void
 cns_diff_eb_y (int i, int j, int k, amrex::Array4<amrex::Real const> const& q,
                amrex::Array4<amrex::Real const> const& coeffs,
@@ -197,8 +193,7 @@ cns_diff_eb_y (int i, int j, int k, amrex::Array4<amrex::Real const> const& q,
 }
 
 #if (AMREX_SPACEDIM == 3)
-AMREX_GPU_DEVICE
-inline
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE
 void
 cns_diff_eb_z (int i, int j, int k,
                amrex::Array4<amrex::Real const> const& q,
@@ -257,17 +252,15 @@ cns_diff_eb_z (int i, int j, int k,
 }
 #endif
 
-AMREX_GPU_DEVICE
-inline
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE
 Real
-compute_interp1d(amrex::Real cym,amrex::Real cy0,amrex::Real cyp, Array1D<Real, 1,3>& v)
+compute_interp1d (amrex::Real cym,amrex::Real cy0,amrex::Real cyp, Array1D<Real, 1,3>& v)
 {
     Real x = cym*v(1) + cy0*v(2) + cyp*v(3);
     return x;
 }
 
-AMREX_GPU_DEVICE
-inline
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE
 Real
 compute_interp2d(amrex::Real cym,amrex::Real cy0,amrex::Real cyp,
                  amrex::Real czm,amrex::Real cz0,amrex::Real czp, Array2D<Real, 1,3,1,3>& v)
@@ -278,8 +271,7 @@ compute_interp2d(amrex::Real cym,amrex::Real cy0,amrex::Real cyp,
 }
 
 #if (AMREX_SPACEDIM == 2)
-AMREX_GPU_DEVICE
-inline
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE
 void
 compute_diff_wallflux ( int i, int j, int k,
                         amrex::Array4<amrex::Real const> const& q,
@@ -468,8 +460,7 @@ compute_diff_wallflux ( int i, int j, int k,
 
 #else // 3d version below
 
-AMREX_GPU_DEVICE
-inline
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE
 void
 compute_diff_wallflux ( int i, int j, int k,
                         amrex::Array4<amrex::Real const> const& q,

--- a/Tests/EB_CNS/Source/hydro/CNS_divop_K.H
+++ b/Tests/EB_CNS/Source/hydro/CNS_divop_K.H
@@ -3,8 +3,8 @@
 #include <CNS_parm.H>
 #include <CNS_diffusion_eb_K.H>
 
-AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-void eb_compute_div (int i, int j, int k, int n, int valid_cell,
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE
+void eb_compute_div (int i, int j, int k, int n, IntVect const& blo, IntVect const& bhi,
                      Array4<Real> const& q, Array4<Real> const& divu,
                      AMREX_D_DECL(Array4<Real const> const& u,
                                   Array4<Real const> const& v,
@@ -26,28 +26,41 @@ void eb_compute_div (int i, int j, int k, int n, int valid_cell,
                      GpuArray<Real,AMREX_SPACEDIM> const& dxinv, Parm const& parm,
                      int eb_weights_type, bool do_visc)
 {
+    AMREX_D_TERM(bool x_high = (i == bhi[0]);,
+                 bool y_high = (j == bhi[1]);,
+                 bool z_high = (k == bhi[2]));
+    bool valid_cell = AMREX_D_TERM( (blo[0] <= i) && (i <= bhi[0]),
+                                 && (blo[1] <= j) && (j <= bhi[1]),
+                                 && (blo[2] <= k) && (k <= bhi[2]) );
+
 #if (AMREX_SPACEDIM == 2)
     if (flag(i,j,k).isCovered())
     {
         divu(i,j,k,n) = 0.0;
-        if (valid_cell)
-        {
-            fx(i,  j,k,n) = 0.;
-            fx(i+1,j,k,n) = 0.;
-            fy(i,j  ,k,n) = 0.;
-            fy(i,j+1,k,n) = 0.;
+        if (valid_cell) {
+            fx(i,j,k,n) = 0.;
+            fy(i,j,k,n) = 0.;
+            if (x_high) {
+                fx(i+1,j,k,n) = 0.;
+            }
+            if (y_high) {
+                fy(i,j+1,k,n) = 0.;
+            }
         }
     }
     else if (flag(i,j,k).isRegular())
     {
         divu(i,j,k,n) = dxinv[0] * (u(i+1,j,k,n)-u(i,j,k,n))
             +           dxinv[1] * (v(i,j+1,k,n)-v(i,j,k,n));
-        if (valid_cell)
-        {
-            fx(i,  j,k,n) = u(i  ,j,k,n);
-            fx(i+1,j,k,n) = u(i+1,j,k,n);
-            fy(i,j  ,k,n) = v(i,j  ,k,n);
-            fy(i,j+1,k,n) = v(i,j+1,k,n);
+        if (valid_cell) {
+            fx(i,j,k,n) = u(i,j,k,n);
+            fy(i,j,k,n) = v(i,j,k,n);
+            if (x_high) {
+                fx(i+1,j,k,n) = u(i+1,j,k,n);
+            }
+            if (y_high) {
+                fy(i,j+1,k,n) = v(i,j+1,k,n);
+            }
         }
     }
     else
@@ -58,7 +71,9 @@ void eb_compute_div (int i, int j, int k, int n, int valid_cell,
             Real fracy = flag(i,j,k).isConnected(0,jj-j,0) ? amrex::Math::abs(fcx(i,j,k,0)) : 0.0_rt;
             fxm = (1.0-fracy)*fxm + fracy *u(i,jj,k ,n);
         }
-        if (valid_cell) fx(i,j,k,n) = fxm;
+        if (valid_cell) {
+            fx(i,j,k,n) = fxm;
+        }
 
         Real fxp = u(i+1,j,k,n);
         if (apx(i+1,j,k) != 0.0 && apx(i+1,j,k) != 1.0) {
@@ -67,7 +82,9 @@ void eb_compute_div (int i, int j, int k, int n, int valid_cell,
             fxp = (1.0-fracy)*fxp + fracy *u(i+1,jj,k,n);
 
         }
-        if (valid_cell) fx(i+1,j,k,n) = fxp;
+        if (valid_cell && x_high) {
+            fx(i+1,j,k,n) = fxp;
+        }
 
         Real fym = v(i,j,k,n);
         if (apy(i,j,k) != 0.0 && apy(i,j,k) != 1.0) {
@@ -75,7 +92,9 @@ void eb_compute_div (int i, int j, int k, int n, int valid_cell,
             Real fracx = flag(i,j,k).isConnected(ii-i,0,0) ? amrex::Math::abs(fcy(i,j,k,0)) : 0.0_rt;
             fym = (1.0-fracx)*fym +  fracx *v(ii,j,k,n);
         }
-        if (valid_cell) fy(i,j,k,n) = fym;
+        if (valid_cell) {
+            fy(i,j,k,n) = fym;
+        }
 
         Real fyp = v(i,j+1,k,n);
         if (apy(i,j+1,k) != 0.0 && apy(i,j+1,k) != 1.0) {
@@ -83,7 +102,9 @@ void eb_compute_div (int i, int j, int k, int n, int valid_cell,
             Real fracx = flag(i,j+1,k).isConnected(ii-i,0,0) ? amrex::Math::abs(fcy(i,j+1,k,0)) : 0.0_rt;
             fyp = (1.0-fracx)*fyp + fracx *v(ii,j+1,k,n);
         }
-        if (valid_cell) fy(i,j+1,k,n) = fyp;
+        if (valid_cell && y_high) {
+            fy(i,j+1,k,n) = fyp;
+        }
 
         divu(i,j,k,n) = (1.0/vfrc(i,j,k)) *
             ( dxinv[0] * (apx(i+1,j,k)*fxp-apx(i,j,k)*fxm)
@@ -114,12 +135,18 @@ void eb_compute_div (int i, int j, int k, int n, int valid_cell,
         divu(i,j,k,n) = 0.0;
         if (valid_cell)
         {
-            fx(i,  j,k,n) = 0.;
-            fx(i+1,j,k,n) = 0.;
-            fy(i,j  ,k,n) = 0.;
-            fy(i,j+1,k,n) = 0.;
-            fz(i,j,k  ,n) = 0.;
-            fz(i,j,k+1,n) = 0.;
+            fx(i,j,k,n) = 0.;
+            fy(i,j,k,n) = 0.;
+            fz(i,j,k,n) = 0.;
+            if (x_high) {
+                fx(i+1,j,k,n) = 0.;
+            }
+            if (y_high) {
+                fy(i,j+1,k,n) = 0.;
+            }
+            if (z_high) {
+                fz(i,j,k+1,n) = 0.;
+            }
         }
     }
     else if (flag(i,j,k).isRegular())
@@ -129,12 +156,18 @@ void eb_compute_div (int i, int j, int k, int n, int valid_cell,
             +           dxinv[2] * (w(i,j,k+1,n)-w(i,j,k,n));
         if (valid_cell)
         {
-            fx(i,  j,k,n) = u(i  ,j,k,n);
-            fx(i+1,j,k,n) = u(i+1,j,k,n);
-            fy(i,j  ,k,n) = v(i,j  ,k,n);
-            fy(i,j+1,k,n) = v(i,j+1,k,n);
-            fz(i,j,k  ,n) = w(i,j,k  ,n);
-            fz(i,j,k+1,n) = w(i,j,k+1,n);
+            fx(i,j,k,n) = u(i,j,k,n);
+            fy(i,j,k,n) = v(i,j,k,n);
+            fz(i,j,k,n) = w(i,j,k,n);
+            if (x_high) {
+                fx(i+1,j,k,n) = u(i+1,j,k,n);
+            }
+            if (y_high) {
+                fy(i,j+1,k,n) = v(i,j+1,k,n);
+            }
+            if (z_high) {
+                fz(i,j,k+1,n) = w(i,j,k+1,n);
+            }
         }
     }
     else
@@ -150,7 +183,9 @@ void eb_compute_div (int i, int j, int k, int n, int valid_cell,
                 +      fracz *(1.0-fracy)*u(i,j ,kk,n)
                 +      fracy *     fracz *u(i,jj,kk,n);
         }
-        if (valid_cell) fx(i,j,k,n) = fxm;
+        if (valid_cell) {
+            fx(i,j,k,n) = fxm;
+        }
 
         Real fxp = u(i+1,j,k,n);
         if (apx(i+1,j,k) != 0.0 && apx(i+1,j,k) != 1.0) {
@@ -164,7 +199,9 @@ void eb_compute_div (int i, int j, int k, int n, int valid_cell,
                 +      fracy *     fracz *u(i+1,jj,kk,n);
 
         }
-        if (valid_cell) fx(i+1,j,k,n) = fxp;
+        if (valid_cell && x_high) {
+            fx(i+1,j,k,n) = fxp;
+        }
 
         Real fym = v(i,j,k,n);
         if (apy(i,j,k) != 0.0 && apy(i,j,k) != 1.0) {
@@ -177,7 +214,9 @@ void eb_compute_div (int i, int j, int k, int n, int valid_cell,
                 +      fracz *(1.0-fracx)*v(i ,j,kk,n)
                 +      fracx *     fracz *v(ii,j,kk,n);
         }
-        if (valid_cell) fy(i,j,k,n) = fym;
+        if (valid_cell) {
+            fy(i,j,k,n) = fym;
+        }
 
         Real fyp = v(i,j+1,k,n);
         if (apy(i,j+1,k) != 0.0 && apy(i,j+1,k) != 1.0) {
@@ -190,7 +229,9 @@ void eb_compute_div (int i, int j, int k, int n, int valid_cell,
                 +      fracz *(1.0-fracx)*v(i ,j+1,kk,n)
                 +      fracx *     fracz *v(ii,j+1,kk,n);
         }
-        if (valid_cell) fy(i,j+1,k,n) = fyp;
+        if (valid_cell && y_high) {
+            fy(i,j+1,k,n) = fyp;
+        }
 
         Real fzm = w(i,j,k,n);
         if (apz(i,j,k) != 0.0 && apz(i,j,k) != 1.0) {
@@ -204,7 +245,9 @@ void eb_compute_div (int i, int j, int k, int n, int valid_cell,
                 +      fracy *(1.0-fracx)*w(i ,jj,k,n)
                 +      fracx *     fracy *w(ii,jj,k,n);
         }
-        if (valid_cell) fz(i,j,k,n) = fzm;
+        if (valid_cell) {
+            fz(i,j,k,n) = fzm;
+        }
 
         Real fzp = w(i,j,k+1,n);
         if (apz(i,j,k+1) != 0.0 && apz(i,j,k+1) != 1.0) {
@@ -217,7 +260,9 @@ void eb_compute_div (int i, int j, int k, int n, int valid_cell,
                 +      fracy *(1.0-fracx)*w(i ,jj,k+1,n)
                 +      fracx *     fracy *w(ii,jj,k+1,n);
         }
-        if (valid_cell) fz(i,j,k+1,n) = fzp;
+        if (valid_cell && z_high) {
+            fz(i,j,k+1,n) = fzp;
+        }
 
         divu(i,j,k,n) = (1.0/vfrc(i,j,k)) *
             ( dxinv[0] * (apx(i+1,j,k)*fxp-apx(i,j,k)*fxm)

--- a/Tests/EB_CNS/Source/hydro/CNS_hydro_K.H
+++ b/Tests/EB_CNS/Source/hydro/CNS_hydro_K.H
@@ -6,8 +6,7 @@
 #include <AMReX_FArrayBox.H>
 #include <cmath>
 
-AMREX_GPU_DEVICE
-inline
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE
 void
 cns_ctoprim (int i, int j, int k,
              amrex::Array4<amrex::Real const> const& u,
@@ -43,8 +42,7 @@ cns_ctoprim (int i, int j, int k,
     q(i,j,k,QTEMP) = ei/parm.cv;
 }
 
-AMREX_GPU_DEVICE
-inline
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE
 void
 cns_flux_to_dudt (int i, int j, int k, int n,
                   amrex::Array4<amrex::Real> const& dudt,
@@ -79,8 +77,7 @@ amrex::Real limiter (amrex::Real dlft, amrex::Real drgt, amrex::Real plm_theta) 
 
 }
 
-AMREX_GPU_DEVICE
-inline
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE
 void
 cns_slope_x (int i, int j, int k,
              amrex::Array4<amrex::Real> const& dq,
@@ -129,8 +126,7 @@ cns_slope_x (int i, int j, int k,
     }
 }
 
-AMREX_GPU_DEVICE
-inline
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE
 void
 cns_slope_y (int i, int j, int k,
              amrex::Array4<amrex::Real> const& dq,
@@ -180,8 +176,7 @@ cns_slope_y (int i, int j, int k,
 }
 
 #if (AMREX_SPACEDIM == 3)
-AMREX_GPU_DEVICE
-inline
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE
 void
 cns_slope_z (int i, int j, int k,
              amrex::Array4<amrex::Real> const& dq,
@@ -231,8 +226,7 @@ cns_slope_z (int i, int j, int k,
 
 namespace {
 
-AMREX_GPU_DEVICE
-inline
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE
 void
 riemann (const amrex::Real gamma, const amrex::Real smallp, const amrex::Real /*smallr*/,
          const amrex::Real rl, const amrex::Real ul, const amrex::Real pl,
@@ -383,8 +377,7 @@ riemann (const amrex::Real gamma, const amrex::Real smallp, const amrex::Real /*
 #endif
 }
 
-AMREX_GPU_DEVICE
-inline
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE
 void
 compute_hyp_wallflux (const amrex::Real rho,
                       AMREX_D_DECL(const amrex::Real u, const amrex::Real v, const amrex::Real w),
@@ -420,8 +413,7 @@ compute_hyp_wallflux (const amrex::Real rho,
 }
 }
 
-AMREX_GPU_DEVICE
-inline
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE
 void
 cns_riemann_x (int i, int j, int k,
                amrex::Array4<amrex::Real> const& fx,
@@ -461,8 +453,7 @@ cns_riemann_x (int i, int j, int k,
             AMREX_D_DECL(fx(i,j,k,UMX), fx(i,j,k,UMY), fx(i,j,k,UMZ)), fx(i,j,k,UEDEN));
 }
 
-AMREX_GPU_DEVICE
-inline
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE
 void
 cns_riemann_y (int i, int j, int k,
                amrex::Array4<amrex::Real> const& fy,
@@ -504,8 +495,7 @@ cns_riemann_y (int i, int j, int k,
 }
 
 #if (AMREX_SPACEDIM == 3)
-AMREX_GPU_DEVICE
-inline
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE
 void
 cns_riemann_z (int i, int j, int k,
                amrex::Array4<amrex::Real> const& fz,

--- a/Tests/EB_CNS/Source/hydro/CNS_hydro_eb_K.H
+++ b/Tests/EB_CNS/Source/hydro/CNS_hydro_eb_K.H
@@ -24,8 +24,7 @@ amrex::Real limiter_eb (amrex::Real dlft, amrex::Real drgt, amrex::Real plm_thet
 
 }
 
-AMREX_GPU_DEVICE
-inline
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE
 void
 cns_slope_eb_x (int i, int j, int k,
                 amrex::Array4<amrex::Real> const& dq,
@@ -95,8 +94,7 @@ cns_slope_eb_x (int i, int j, int k,
     }
 }
 
-AMREX_GPU_DEVICE
-inline
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE
 void
 cns_slope_eb_y (int i, int j, int k,
                 amrex::Array4<amrex::Real> const& dq,
@@ -167,8 +165,7 @@ cns_slope_eb_y (int i, int j, int k,
 }
 
 #if (AMREX_SPACEDIM == 3)
-AMREX_GPU_DEVICE
-inline
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE
 void
 cns_slope_eb_z (int i, int j, int k,
                 amrex::Array4<amrex::Real> const& dq,


### PR DESCRIPTION
* Make some member functions public for CUDA.

* Update calls to EBFluxRegister to run on device.

* Fix race conditions in two kernels, one by avoiding write with if test and
  the other with atomics.

* Use ParallelFor(MF) instead of ParallelFor(Box) for performance in a few
  places.

* Use MFInterpolater instead of Interpolater for performance.

* Remove Elixirs and rely on Gpu::streamSynchronize().  Maybe later, we
  could switch to using The_Async_Arena for these temporary Fabs for
  performance.

* inline -> AMREX_FORCE_INLINE

* Fix some 2D issues.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
