### PR TITLE
CMake: Always CUDA Perf-Neutral Debug

### DIFF
--- a/Tools/CMake/AMReXCUDAOptions.cmake
+++ b/Tools/CMake/AMReXCUDAOptions.cmake
@@ -78,16 +78,9 @@ cuda_print_option(AMReX_CUDA_COMPILATION_TIMER)
 option(AMReX_CUDA_DEBUG "Generate debug information for device code (optimizations: off)" OFF)
 cuda_print_option(AMReX_CUDA_DEBUG)
 
-set(_CUDA_PERF_NEUTRAL_DEBUG OFF)
-if ("${CMAKE_BUILD_TYPE}" MATCHES "Debug" OR "${CMAKE_BUILD_TYPE}" MATCHES "RelWithDebInfo")
-    set(_CUDA_PERF_NEUTRAL_DEBUG ON)
-endif ()
-
 # both are performance-neutral debug symbols
-option(AMReX_CUDA_SHOW_LINENUMBERS "Generate line-number information (optimizations: on)"
-       ${_CUDA_PERF_NEUTRAL_DEBUG})
-option(AMReX_CUDA_SHOW_CODELINES "Generate source information in PTX (optimizations: on)"
-       ${_CUDA_PERF_NEUTRAL_DEBUG})
+option(AMReX_CUDA_SHOW_LINENUMBERS "Generate line-number information (optimizations: on)" ON)
+option(AMReX_CUDA_SHOW_CODELINES "Generate source information in PTX (optimizations: on)" ON)
 cuda_print_option(AMReX_CUDA_SHOW_LINENUMBERS)
 cuda_print_option(AMReX_CUDA_SHOW_CODELINES)
 


### PR DESCRIPTION
## Summary

Always default-ON for performance-neutral debug info to CUDA builds with CMake, even in `Release` mode.

## Additional background

We used `RelWithDebInfo` before but switched downstream to `Release` by default as well to avoid `-O2`/`-O3` complications in flags.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
