### PR TITLE
Downgrade to docutils v0.16

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,7 +19,7 @@ jobs:
         run: |
           .github/workflows/dependencies/documentation.sh
           python3 -m pip install sphinx sphinx_rtd_theme breathe
-          python3 -m pip install -I docutils==0.16  # Downgrade docutils so that bullet points render properly with Sphinx 
+          python3 -m pip install -I docutils==0.16  # Downgrade docutils so that bullet points render properly with Sphinx
 
       - name: Install and Build
         run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,6 +19,7 @@ jobs:
         run: |
           .github/workflows/dependencies/documentation.sh
           python3 -m pip install sphinx sphinx_rtd_theme breathe
+          python3 -m pip install -I docutils==0.16  # Downgrade docutils so that bullet points render properly with Sphinx 
 
       - name: Install and Build
         run: |


### PR DESCRIPTION
## Summary
Alters the docs CI to downgrade the python package `docutils` to version 0.16. This is to fix the issue of bullet lists not rendering properly in the sphinx documentation.

## Additional background

It appears sphinx is actively working on fixing the issue. So hopefully the fix can be removed when the next version is released.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
