### PR TITLE
Remove some versions of ParallelFor(MF)

### DIFF
--- a/Src/Base/AMReX_MFParallelFor.H
+++ b/Src/Base/AMReX_MFParallelFor.H
@@ -128,57 +128,6 @@ ParallelFor (MF const& mf, IntVect const& ng, F&& f)
 /**
  * \brief ParallelFor for MultiFab/FabArray.
  *
- * This version launches a kernel to work on the valid region.  If built for
- * CPU, tiling will be enabled.  For GPU builds, this function is
- * NON-BLOCKING on the host. Conceptually, this is a 5D loop.
- *
- * \tparam MF the MultiFab/FabArray type
- * \tparam F a callable type like lambda
- *
- * \param mf the MultiFab/FabArray object used to specify the iteration space
- * \param ncomp the number of component
- * \param f a callable object void(int,int,int,int,int), where the first argument
- *           is the local box index, the following three are spatial indices
- *           for x, y, and z-directions, and the last is for component.
- */
-template <typename MF, typename F>
-std::enable_if_t<IsFabArray<MF>::value>
-ParallelFor (MF const& mf, int ncomp, F&& f)
-{
-    detail::ParallelFor(mf, IntVect(0), ncomp, FabArrayBase::mfiter_tile_size, false, std::forward<F>(f));
-}
-
-/**
- * \brief ParallelFor for MultiFab/FabArray.
- *
- * This version launches a kernel to work on the valid region.  If built for
- * CPU, tiling will be enabled.  For GPU builds, this function is
- * NON-BLOCKING on the host. Conceptually, this is a 5D loop.
- *
- * \tparam MT max threads in GPU blocks (Only relevant for GPU builds)
- * \tparam MF the MultiFab/FabArray type
- * \tparam F a callable type like lambda
- *
- * \param mf the MultiFab/FabArray object used to specify the iteration space
- * \param ncomp the number of component
- * \param f a callable object void(int,int,int,int,int), where the first argument
- *           is the local box index, the following three are spatial indices
- *           for x, y, and z-directions, and the last is for component.
- */
-template <int MT, typename MF, typename F>
-std::enable_if_t<IsFabArray<MF>::value>
-ParallelFor (MF const& mf, int ncomp, F&& f)
-{
-#ifdef AMREX_USE_GPU
-    detail::ParallelFor<MT>(mf, IntVect(0), ncomp, FabArrayBase::mfiter_tile_size, false, std::forward<F>(f));
-#else
-    detail::ParallelFor(mf, IntVect(0), ncomp, FabArrayBase::mfiter_tile_size, false, std::forward<F>(f));
-#endif
-}
-
-/**
- * \brief ParallelFor for MultiFab/FabArray.
- *
  * This version launches a kernel to work on the valid and ghost regions.  If
  * built for CPU, tiling will be enabled.  For GPU builds, this function is
  * NON-BLOCKING on the host. Conceptually, this is a 5D loop.
@@ -334,61 +283,6 @@ ParallelFor (MF const& mf, IntVect const& ng, TileSize const& ts, F&& f)
     detail::ParallelFor<MT>(mf, ng, ts.tile_size, false, std::forward<F>(f));
 #else
     detail::ParallelFor(mf, ng, ts.tile_size, false, std::forward<F>(f));
-#endif
-}
-
-/**
- * \brief ParallelFor for MultiFab/FabArray.
- *
- * This version launches a kernel to work on the valid region.  If built for
- * CPU, tiling will be enabled.  However, one could specify a huge tile size
- * to effectively disable tiling.  For gpu builds, this function is
- * NON-BLOCKING on the host. Conceptually, this is a 5D loop.
- *
- * \tparam MF the MultiFab/FabArray type
- * \tparam F a callable type like lambda
- *
- * \param mf the MultiFab/FabArray object used to specify the iteration space
- * \param ncomp the number of component
- * \param ts tile size, ignored by GPU build
- * \param f a callable object void(int,int,int,int,int), where the first argument
- *           is the local box index, the following three are spatial indices
- *           for x, y, and z-directions, and the last is for component.
- */
-template <typename MF, typename F>
-std::enable_if_t<IsFabArray<MF>::value>
-ParallelFor (MF const& mf, int ncomp, TileSize const& ts, F&& f)
-{
-    detail::ParallelFor(mf, IntVect(0), ncomp, ts.tile_size, false, std::forward<F>(f));
-}
-
-/**
- * \brief ParallelFor for MultiFab/FabArray.
- *
- * This version launches a kernel to work on the valid region.  If built for
- * CPU, tiling will be enabled.  However, one could specify a huge tile size
- * to effectively disable tiling.  For gpu builds, this function is
- * NON-BLOCKING on the host. Conceptually, this is a 5D loop.
- *
- * \tparam MT max threads in GPU blocks (Only relevant for GPU builds)
- * \tparam MF the MultiFab/FabArray type
- * \tparam F a callable type like lambda
- *
- * \param mf the MultiFab/FabArray object used to specify the iteration space
- * \param ncomp the number of component
- * \param ts tile size, ignored by GPU build
- * \param f a callable object void(int,int,int,int,int), where the first argument
- *           is the local box index, the following three are spatial indices
- *           for x, y, and z-directions, and the last is for component.
- */
-template <int MT, typename MF, typename F>
-std::enable_if_t<IsFabArray<MF>::value>
-ParallelFor (MF const& mf, int ncomp, TileSize const& ts, F&& f)
-{
-#ifdef AMREX_USE_GPU
-    detail::ParallelFor<MT>(mf, IntVect(0), ncomp, ts.tile_size, false, std::forward<F>(f));
-#else
-    detail::ParallelFor(mf, IntVect(0), ncomp, ts.tile_size, false, std::forward<F>(f));
 #endif
 }
 

--- a/Src/Base/AMReX_MultiFabUtil.cpp
+++ b/Src/Base/AMReX_MultiFabUtil.cpp
@@ -305,7 +305,7 @@ namespace amrex
             MultiFab foo(amrex::convert(cc.boxArray(),IntVect(1)), cc.DistributionMap(), 1, 0,
                          MFInfo().SetAlloc(false));
             IntVect ng = -cc.nGrowVect();
-            ParallelFor(foo, ncomp,
+            ParallelFor(foo, IntVect(0), ncomp,
             [=] AMREX_GPU_DEVICE (int box_no, int i, int j, int k, int n) noexcept
             {
                 Box ccbx(ccma[box_no]);
@@ -407,7 +407,7 @@ namespace amrex
             auto const& crsema = crse_S_fine.arrays();
             auto const& finema = S_fine.const_arrays();
             auto const& finevolma = fvolume.const_arrays();
-            ParallelFor(crse_S_fine, ncomp,
+            ParallelFor(crse_S_fine, IntVect(0), ncomp,
             [=] AMREX_GPU_DEVICE (int box_no, int i, int j, int k, int n) noexcept
             {
                 amrex_avgdown_with_vol(i,j,k,n,crsema[box_no],finema[box_no],finevolma[box_no],
@@ -523,13 +523,13 @@ namespace amrex
                 auto const& crsema = S_crse.arrays();
                 auto const& finema = S_fine.const_arrays();
                 if (is_cell_centered) {
-                    ParallelFor(S_crse, ncomp,
+                    ParallelFor(S_crse, IntVect(0), ncomp,
                     [=] AMREX_GPU_DEVICE (int box_no, int i, int j, int k, int n) noexcept
                     {
                         amrex_avgdown(i,j,k,n,crsema[box_no],finema[box_no],scomp,scomp,ratio);
                     });
                 } else {
-                    ParallelFor(S_crse, ncomp,
+                    ParallelFor(S_crse, IntVect(0), ncomp,
                     [=] AMREX_GPU_DEVICE (int box_no, int i, int j, int k, int n) noexcept
                     {
                         amrex_avgdown_nodes(i,j,k,n,crsema[box_no],finema[box_no],scomp,scomp,ratio);
@@ -572,13 +572,13 @@ namespace amrex
                 auto const& crsema = crse_S_fine.arrays();
                 auto const& finema = S_fine.const_arrays();
                 if (is_cell_centered) {
-                    ParallelFor(crse_S_fine, ncomp,
+                    ParallelFor(crse_S_fine, IntVect(0), ncomp,
                     [=] AMREX_GPU_DEVICE (int box_no, int i, int j, int k, int n) noexcept
                     {
                         amrex_avgdown(i,j,k,n,crsema[box_no],finema[box_no],0,scomp,ratio);
                     });
                 } else {
-                    ParallelFor(crse_S_fine, ncomp,
+                    ParallelFor(crse_S_fine, IntVect(0), ncomp,
                     [=] AMREX_GPU_DEVICE (int box_no, int i, int j, int k, int n) noexcept
                     {
                         amrex_avgdown_nodes(i,j,k,n,crsema[box_no],finema[box_no],0,scomp,ratio);

--- a/Src/LinearSolvers/MLMG/AMReX_MLABecLaplacian.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLABecLaplacian.cpp
@@ -465,7 +465,7 @@ MLABecLaplacian::Fapply (int amrlev, int mglev, MultiFab& out, const MultiFab& i
                      const auto& bzma = bzcoef.const_arrays(););
         if (m_overset_mask[amrlev][mglev]) {
             const auto& osmma = m_overset_mask[amrlev][mglev]->const_arrays();
-            ParallelFor(out, ncomp,
+            ParallelFor(out, IntVect(0), ncomp,
             [=] AMREX_GPU_DEVICE (int box_no, int i, int j, int k, int n) noexcept
             {
                 mlabeclap_adotx_os(i,j,k,n, yma[box_no], xma[box_no], ama[box_no],
@@ -473,7 +473,7 @@ MLABecLaplacian::Fapply (int amrlev, int mglev, MultiFab& out, const MultiFab& i
                                    osmma[box_no], dxinv, ascalar, bscalar);
             });
         } else {
-            ParallelFor(out, ncomp,
+            ParallelFor(out, IntVect(0), ncomp,
             [=] AMREX_GPU_DEVICE (int box_no, int i, int j, int k, int n) noexcept
             {
                 mlabeclap_adotx(i,j,k,n, yma[box_no], xma[box_no], ama[box_no],
@@ -539,7 +539,7 @@ MLABecLaplacian::normalize (int amrlev, int mglev, MultiFab& mf) const
         AMREX_D_TERM(const auto& bxma = bxcoef.const_arrays();,
                      const auto& byma = bycoef.const_arrays();,
                      const auto& bzma = bzcoef.const_arrays(););
-        ParallelFor(mf, ncomp,
+        ParallelFor(mf, IntVect(0), ncomp,
         [=] AMREX_GPU_DEVICE (int box_no, int i, int j, int k, int n) noexcept
         {
             mlabeclap_normalize(i,j,k,n, ma[box_no], ama[box_no],
@@ -656,7 +656,7 @@ MLABecLaplacian::Fsmooth (int amrlev, int mglev, MultiFab& sol, const MultiFab& 
 
         if (m_overset_mask[amrlev][mglev]) {
             const auto& osmma = m_overset_mask[amrlev][mglev]->const_arrays();
-            ParallelFor(sol, nc,
+            ParallelFor(sol, IntVect(0), nc,
             [=] AMREX_GPU_DEVICE (int box_no, int i, int j, int k, int n) noexcept
             {
                 Box vbx(ama[box_no]);
@@ -670,7 +670,7 @@ MLABecLaplacian::Fsmooth (int amrlev, int mglev, MultiFab& sol, const MultiFab& 
                              osmma[box_no], vbx, redblack);
             });
         } else if (regular_coarsening) {
-            ParallelFor(sol, nc,
+            ParallelFor(sol, IntVect(0), nc,
             [=] AMREX_GPU_DEVICE (int box_no, int i, int j, int k, int n) noexcept
             {
                 Box vbx(ama[box_no]);
@@ -968,7 +968,7 @@ MLABecLaplacian::makeNLinOp (int /*grid_size*/) const
         auto const& ama = alpha.arrays();
         auto const& abotma = alpha_bottom.const_arrays();
         auto const& mma = osm_bottom.const_arrays();
-        ParallelFor(alpha, ncomp,
+        ParallelFor(alpha, IntVect(0), ncomp,
         [=] AMREX_GPU_DEVICE (int box_no, int i, int j, int k, int n) noexcept
         {
             if (mma[box_no](i,j,k)) {
@@ -1018,7 +1018,7 @@ MLABecLaplacian::copyNSolveSolution (MultiFab& dst, MultiFab const& src) const
         auto const& dstma = dst.arrays();
         auto const& srcma = src.const_arrays();
         auto const& mma = m_overset_mask[0].back()->const_arrays();
-        ParallelFor(dst, ncomp,
+        ParallelFor(dst, IntVect(0), ncomp,
         [=] AMREX_GPU_DEVICE (int box_no, int i, int j, int k, int n) noexcept
         {
             if (mma[box_no](i,j,k)) {

--- a/Src/LinearSolvers/MLMG/AMReX_MLCellLinOp.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLCellLinOp.cpp
@@ -422,7 +422,7 @@ MLCellLinOp::interpolation (int amrlev, int fmglev, MultiFab& fine, const MultiF
     if (Gpu::inLaunchRegion() && fine.isFusingCandidate()) {
         auto const& finema = fine.arrays();
         auto const& crsema = crse.const_arrays();
-        ParallelFor(fine, ncomp,
+        ParallelFor(fine, IntVect(0), ncomp,
         [=] AMREX_GPU_DEVICE (int box_no, int i, int j, int k, int n) noexcept
         {
             int ic = amrex::coarsen(i,ratio3.x);


### PR DESCRIPTION
Remove ParallelFor(MF) functions that only take `int ncomp`, but not `IntVect nghost` to
avoid potential bugs. The versions we have kept are,

 * ParallelFor(MF const&, ...); // valid region only
 * ParallelFor(MF const&, IntVect const& nghost, ...); // valid+nghost
 * ParallelFor(MF const&, IntVect const& nghost, int ncomp, ...); // valid+nghost and loop over component

The version that is removed is

  * ParallelFor(MF const&, int ncomp, ...);

This avoids bugs like below

    ParallelFor(mf, mf.nGrow(), ...); // should use mf.nGrowVect()

Here, `mf.nGrow()` returns `int` and therefore would be treated as the number of
components in the removed version.

## Summary

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
