### PR TITLE
ParReduce

### DIFF
--- a/Src/Base/AMReX_FabArray.H
+++ b/Src/Base/AMReX_FabArray.H
@@ -27,6 +27,7 @@
 #include <AMReX_BaseFabUtility.H>
 #include <AMReX_MFParallelFor.H>
 #include <AMReX_TagParallelFor.H>
+#include <AMReX_ParReduce.H>
 
 #include <AMReX_Gpu.H>
 
@@ -210,9 +211,9 @@ struct MultiArray4
     }
 
 #ifdef AMREX_USE_GPU
-    Array4<T>* dp = nullptr;
+    Array4<T> const* AMREX_RESTRICT dp = nullptr;
 #endif
-    Array4<T>* hp = nullptr;
+    Array4<T> const* AMREX_RESTRICT hp = nullptr;
 };
 
 template <class FAB> class FabArray;

--- a/Src/Base/AMReX_FabArrayUtility.H
+++ b/Src/Base/AMReX_FabArrayUtility.H
@@ -42,35 +42,95 @@ ReduceSum_host (FabArray<FAB> const& fa, IntVect const& nghost, F&& f)
 
 #ifdef AMREX_USE_GPU
 namespace fudetail {
-template <class FAB, class F,
-          class bar = std::enable_if_t<IsBaseFab<FAB>::value> >
-typename FAB::value_type
-ReduceSum_device (FabArray<FAB> const& fa, IntVect const& nghost, F&& f)
+template <class OP, class FAB, class F>
+std::enable_if_t<IsBaseFab<FAB>::value,
+                 std::conditional_t<std::is_same<OP,ReduceOpLogicalAnd>::value ||
+                                    std::is_same<OP,ReduceOpLogicalOr>::value,
+                                    int, typename FAB::value_type> >
+ReduceMF (FabArray<FAB> const& fa, IntVect const& nghost, F&& f)
 {
-    using value_type = typename FAB::value_type;
-    value_type sm = 0;
+    using T = std::conditional_t<std::is_same<OP,ReduceOpLogicalAnd>::value ||
+                                 std::is_same<OP,ReduceOpLogicalOr>::value,
+                                 int, typename FAB::value_type>;
+    ReduceOps<OP> reduce_op;
+    ReduceData<T> reduce_data(reduce_op);
+    using ReduceTuple = typename decltype(reduce_data)::Type;
 
+    for (MFIter mfi(fa); mfi.isValid(); ++mfi)
     {
-        ReduceOps<ReduceOpSum> reduce_op;
-        ReduceData<value_type> reduce_data(reduce_op);
-        using ReduceTuple = typename decltype(reduce_data)::Type;
-
-        for (MFIter mfi(fa); mfi.isValid(); ++mfi)
+        const Box& bx = amrex::grow(mfi.validbox(),nghost);
+        const auto& arr = fa.const_array(mfi);
+        reduce_op.eval(bx, reduce_data,
+        [=] AMREX_GPU_DEVICE (Box const& b) -> ReduceTuple
         {
-            const Box& bx = amrex::grow(mfi.validbox(),nghost);
-            const auto& arr = fa.const_array(mfi);
-            reduce_op.eval(bx, reduce_data,
-            [=] AMREX_GPU_DEVICE (Box const& b) -> ReduceTuple
-            {
-                return { f(b,arr) };
-            });
-        }
-
-        ReduceTuple hv = reduce_data.value(reduce_op);
-        sm = amrex::get<0>(hv);
+            return { static_cast<T>(f(b, arr)) };
+        });
     }
 
-    return sm;
+    ReduceTuple hv = reduce_data.value(reduce_op);
+    return amrex::get<0>(hv);
+}
+
+template <class OP, class FAB1, class FAB2, class F>
+std::enable_if_t<IsBaseFab<FAB1>::value && IsBaseFab<FAB2>::value,
+                 std::conditional_t<std::is_same<OP,ReduceOpLogicalAnd>::value ||
+                                    std::is_same<OP,ReduceOpLogicalOr>::value,
+                                    int, typename FAB1::value_type> >
+ReduceMF (FabArray<FAB1> const& fa1, FabArray<FAB2> const& fa2, IntVect const& nghost, F&& f)
+{
+    using T = std::conditional_t<std::is_same<OP,ReduceOpLogicalAnd>::value ||
+                                 std::is_same<OP,ReduceOpLogicalOr>::value,
+                                 int, typename FAB1::value_type>;
+    ReduceOps<OP> reduce_op;
+    ReduceData<T> reduce_data(reduce_op);
+    using ReduceTuple = typename decltype(reduce_data)::Type;
+
+    for (MFIter mfi(fa1); mfi.isValid(); ++mfi)
+    {
+        const Box& bx = amrex::grow(mfi.validbox(),nghost);
+        const auto& arr1 = fa1.const_array(mfi);
+        const auto& arr2 = fa2.const_array(mfi);
+        reduce_op.eval(bx, reduce_data,
+        [=] AMREX_GPU_DEVICE (Box const& b) -> ReduceTuple
+        {
+            return { static_cast<T>(f(b, arr1, arr2)) };
+        });
+    }
+
+    ReduceTuple hv = reduce_data.value(reduce_op);
+    return amrex::get<0>(hv);
+}
+
+template <class OP, class FAB1, class FAB2, class FAB3, class F>
+std::enable_if_t<IsBaseFab<FAB1>::value && IsBaseFab<FAB2>::value && IsBaseFab<FAB3>::value,
+                 std::conditional_t<std::is_same<OP,ReduceOpLogicalAnd>::value ||
+                                    std::is_same<OP,ReduceOpLogicalOr>::value,
+                                    int, typename FAB1::value_type> >
+ReduceMF (FabArray<FAB1> const& fa1, FabArray<FAB2> const& fa2,
+          FabArray<FAB3> const& fa3, IntVect const& nghost, F&& f)
+{
+    using T = std::conditional_t<std::is_same<OP,ReduceOpLogicalAnd>::value ||
+                                 std::is_same<OP,ReduceOpLogicalOr>::value,
+                                 int, typename FAB1::value_type>;
+    ReduceOps<OP> reduce_op;
+    ReduceData<T> reduce_data(reduce_op);
+    using ReduceTuple = typename decltype(reduce_data)::Type;
+
+    for (MFIter mfi(fa1); mfi.isValid(); ++mfi)
+    {
+        const Box& bx = amrex::grow(mfi.validbox(),nghost);
+        const auto& arr1 = fa1.const_array(mfi);
+        const auto& arr2 = fa2.const_array(mfi);
+        const auto& arr3 = fa3.const_array(mfi);
+        reduce_op.eval(bx, reduce_data,
+        [=] AMREX_GPU_DEVICE (Box const& b) -> ReduceTuple
+        {
+            return { static_cast<T>(f(b, arr1, arr2, arr3)) };
+        });
+    }
+
+    ReduceTuple hv = reduce_data.value(reduce_op);
+    return amrex::get<0>(hv);
 }
 
 template <class FAB, class F>
@@ -96,7 +156,7 @@ typename FAB::value_type
 ReduceSum (FabArray<FAB> const& fa, IntVect const& nghost, F&& f)
 {
     if (Gpu::inLaunchRegion()) {
-        return fudetail::ReduceSum_device(fa, nghost, std::forward<F>(f));
+        return fudetail::ReduceMF<ReduceOpSum>(fa, nghost, std::forward<F>(f));
     } else {
         return fudetail::ReduceSum_host_wrapper(fa, nghost, std::forward<F>(f));
     }
@@ -146,40 +206,6 @@ ReduceSum_host (FabArray<FAB1> const& fa1, FabArray<FAB2> const& fa2,
 
 #ifdef AMREX_USE_GPU
 namespace fudetail {
-template <class FAB1, class FAB2, class F,
-          class bar = std::enable_if_t<IsBaseFab<FAB1>::value> >
-typename FAB1::value_type
-ReduceSum_device (FabArray<FAB1> const& fa1, FabArray<FAB2> const& fa2,
-                  IntVect const& nghost, F&& f)
-{
-    using value_type = typename FAB1::value_type;
-    value_type sm = 0;
-
-    BL_PROFILE("ReduceSum_device");
-
-    {
-        ReduceOps<ReduceOpSum> reduce_op;
-        ReduceData<value_type> reduce_data(reduce_op);
-        using ReduceTuple = typename decltype(reduce_data)::Type;
-        for (MFIter mfi(fa1); mfi.isValid(); ++mfi)
-        {
-            const Box& bx = amrex::grow(mfi.validbox(),nghost);
-            const auto& arr1 = fa1.const_array(mfi);
-            const auto& arr2 = fa2.const_array(mfi);
-            reduce_op.eval(bx, reduce_data,
-            [=] AMREX_GPU_DEVICE (Box const& b) -> ReduceTuple
-            {
-                return { f(b, arr1, arr2) };
-            });
-        }
-
-        ReduceTuple hv = reduce_data.value(reduce_op);
-        sm = amrex::get<0>(hv);
-    }
-
-    return sm;
-}
-
 template <class FAB1, class FAB2, class F>
 std::enable_if_t<!amrex::DefinitelyNotHostRunnable<F>::value, typename FAB1::value_type>
 ReduceSum_host_wrapper (FabArray<FAB1> const& fa1, FabArray<FAB2> const& fa2,
@@ -206,7 +232,7 @@ ReduceSum (FabArray<FAB1> const& fa1, FabArray<FAB2> const& fa2,
            IntVect const& nghost, F&& f)
 {
     if (Gpu::inLaunchRegion()) {
-        return fudetail::ReduceSum_device(fa1,fa2,nghost,std::forward<F>(f));
+        return fudetail::ReduceMF<ReduceOpSum>(fa1,fa2,nghost,std::forward<F>(f));
     } else {
         return fudetail::ReduceSum_host_wrapper(fa1,fa2,nghost,std::forward<F>(f));
     }
@@ -259,40 +285,6 @@ ReduceSum_host (FabArray<FAB1> const& fa1, FabArray<FAB2> const& fa2,
 
 #ifdef AMREX_USE_GPU
 namespace fudetail {
-template <class FAB1, class FAB2, class FAB3, class F,
-          class bar = std::enable_if_t<IsBaseFab<FAB1>::value> >
-typename FAB1::value_type
-ReduceSum_device (FabArray<FAB1> const& fa1, FabArray<FAB2> const& fa2,
-                  FabArray<FAB3> const& fa3, IntVect const& nghost, F&& f)
-{
-    using value_type = typename FAB1::value_type;
-    value_type sm = 0;
-
-    {
-        ReduceOps<ReduceOpSum> reduce_op;
-        ReduceData<value_type> reduce_data(reduce_op);
-        using ReduceTuple = typename decltype(reduce_data)::Type;
-
-        for (MFIter mfi(fa1); mfi.isValid(); ++mfi)
-        {
-            const Box& bx = amrex::grow(mfi.validbox(),nghost);
-            const auto& arr1 = fa1.const_array(mfi);
-            const auto& arr2 = fa2.const_array(mfi);
-            const auto& arr3 = fa3.const_array(mfi);
-            reduce_op.eval(bx, reduce_data,
-            [=] AMREX_GPU_DEVICE (Box const& b) -> ReduceTuple
-            {
-                return { f(b, arr1, arr2, arr3) };
-            });
-        }
-
-        ReduceTuple hv = reduce_data.value(reduce_op);
-        sm = amrex::get<0>(hv);
-    }
-
-    return sm;
-}
-
 template <class FAB1, class FAB2, class FAB3, class F>
 std::enable_if_t<!amrex::DefinitelyNotHostRunnable<F>::value, typename FAB1::value_type>
 ReduceSum_host_wrapper (FabArray<FAB1> const& fa1, FabArray<FAB2> const& fa2,
@@ -319,7 +311,7 @@ ReduceSum (FabArray<FAB1> const& fa1, FabArray<FAB2> const& fa2,
            FabArray<FAB3> const& fa3, IntVect const& nghost, F&& f)
 {
     if (Gpu::inLaunchRegion()) {
-        return fudetail::ReduceSum_device(fa1,fa2,fa3,nghost,std::forward<F>(f));
+        return fudetail::ReduceMF<ReduceOpSum>(fa1,fa2,fa3,nghost,std::forward<F>(f));
     } else {
         return fudetail::ReduceSum_host_wrapper(fa1,fa2,fa3,nghost,std::forward<F>(f));
     }
@@ -350,8 +342,7 @@ typename FAB::value_type
 ReduceMin_host (FabArray<FAB> const& fa, IntVect const& nghost, F&& f)
 {
     using value_type = typename FAB::value_type;
-    constexpr value_type value_max = std::numeric_limits<value_type>::max();
-    value_type r = value_max;
+    value_type r = std::numeric_limits<value_type>::max();
 
 #ifdef AMREX_USE_OMP
 #pragma omp parallel reduction(min:r)
@@ -368,38 +359,6 @@ ReduceMin_host (FabArray<FAB> const& fa, IntVect const& nghost, F&& f)
 
 #ifdef AMREX_USE_GPU
 namespace fudetail {
-template <class FAB, class F,
-          class bar = std::enable_if_t<IsBaseFab<FAB>::value> >
-typename FAB::value_type
-ReduceMin_device (FabArray<FAB> const& fa, IntVect const& nghost, F&& f)
-{
-    using value_type = typename FAB::value_type;
-    constexpr value_type value_max = std::numeric_limits<value_type>::max();
-    value_type r = value_max;
-
-    {
-        ReduceOps<ReduceOpMin> reduce_op;
-        ReduceData<value_type> reduce_data(reduce_op);
-        using ReduceTuple = typename decltype(reduce_data)::Type;
-
-        for (MFIter mfi(fa); mfi.isValid(); ++mfi)
-        {
-            const Box& bx = amrex::grow(mfi.validbox(),nghost);
-            const auto& arr = fa.const_array(mfi);
-            reduce_op.eval(bx, reduce_data,
-            [=] AMREX_GPU_DEVICE (Box const& b) -> ReduceTuple
-            {
-                return { f(b, arr) };
-            });
-        }
-
-        ReduceTuple hv = reduce_data.value(reduce_op);
-        r = amrex::get<0>(hv);
-    }
-
-    return r;
-}
-
 template <class FAB, class F>
 std::enable_if_t<!amrex::DefinitelyNotHostRunnable<F>::value, typename FAB::value_type>
 ReduceMin_host_wrapper (FabArray<FAB> const& fa, IntVect const& nghost, F&& f)
@@ -423,7 +382,7 @@ typename FAB::value_type
 ReduceMin (FabArray<FAB> const& fa, IntVect const& nghost, F&& f)
 {
     if (Gpu::inLaunchRegion()) {
-        return fudetail::ReduceMin_device(fa, nghost, std::forward<F>(f));
+        return fudetail::ReduceMF<ReduceOpMin>(fa, nghost, std::forward<F>(f));
     } else {
         return fudetail::ReduceMin_host_wrapper(fa, nghost, std::forward<F>(f));
     }
@@ -454,8 +413,7 @@ ReduceMin_host (FabArray<FAB1> const& fa1, FabArray<FAB2> const& fa2,
                 IntVect const& nghost, F&& f)
 {
     using value_type = typename FAB1::value_type;
-    constexpr value_type value_max = std::numeric_limits<value_type>::max();
-    value_type r = value_max;
+    value_type r = std::numeric_limits<value_type>::max();
 
 #ifdef AMREX_USE_OMP
 #pragma omp parallel reduction(min:r)
@@ -474,40 +432,6 @@ ReduceMin_host (FabArray<FAB1> const& fa1, FabArray<FAB2> const& fa2,
 
 #ifdef AMREX_USE_GPU
 namespace fudetail {
-template <class FAB1, class FAB2, class F,
-          class bar = std::enable_if_t<IsBaseFab<FAB1>::value> >
-typename FAB1::value_type
-ReduceMin_device (FabArray<FAB1> const& fa1, FabArray<FAB2> const& fa2,
-                  IntVect const& nghost, F&& f)
-{
-    using value_type = typename FAB1::value_type;
-    constexpr value_type value_max = std::numeric_limits<value_type>::max();
-    value_type r = value_max;
-
-    {
-        ReduceOps<ReduceOpMin> reduce_op;
-        ReduceData<value_type> reduce_data(reduce_op);
-        using ReduceTuple = typename decltype(reduce_data)::Type;
-
-        for (MFIter mfi(fa1); mfi.isValid(); ++mfi)
-        {
-            const Box& bx = amrex::grow(mfi.validbox(),nghost);
-            const auto& arr1 = fa1.const_array(mfi);
-            const auto& arr2 = fa2.const_array(mfi);
-            reduce_op.eval(bx, reduce_data,
-            [=] AMREX_GPU_DEVICE (Box const& b) -> ReduceTuple
-            {
-                return { f(b, arr1, arr2) };
-            });
-        }
-
-        ReduceTuple hv = reduce_data.value(reduce_op);
-        r = amrex::get<0>(hv);
-    }
-
-    return r;
-}
-
 template <class FAB1, class FAB2, class F>
 std::enable_if_t<!amrex::DefinitelyNotHostRunnable<F>::value, typename FAB1::value_type>
 ReduceMin_host_wrapper (FabArray<FAB1> const& fa1, FabArray<FAB2> const& fa2,
@@ -534,7 +458,7 @@ ReduceMin (FabArray<FAB1> const& fa1, FabArray<FAB2> const& fa2,
            IntVect const& nghost, F&& f)
 {
     if (Gpu::inLaunchRegion()) {
-        return fudetail::ReduceMin_device(fa1,fa2,nghost,std::forward<F>(f));
+        return fudetail::ReduceMF<ReduceOpMin>(fa1,fa2,nghost,std::forward<F>(f));
     } else {
         return fudetail::ReduceMin_host_wrapper(fa1,fa2,nghost,std::forward<F>(f));
     }
@@ -567,8 +491,7 @@ ReduceMin_host (FabArray<FAB1> const& fa1, FabArray<FAB2> const& fa2,
                 FabArray<FAB3> const& fa3, IntVect const& nghost, F&& f)
 {
     using value_type = typename FAB1::value_type;
-    constexpr value_type value_max = std::numeric_limits<value_type>::max();
-    value_type r = value_max;
+    value_type r = std::numeric_limits<value_type>::max();
 
 #ifdef AMREX_USE_OMP
 #pragma omp parallel reduction(min:r)
@@ -588,41 +511,6 @@ ReduceMin_host (FabArray<FAB1> const& fa1, FabArray<FAB2> const& fa2,
 
 #ifdef AMREX_USE_GPU
 namespace fudetail {
-template <class FAB1, class FAB2, class FAB3, class F,
-          class bar = std::enable_if_t<IsBaseFab<FAB1>::value> >
-typename FAB1::value_type
-ReduceMin_device (FabArray<FAB1> const& fa1, FabArray<FAB2> const& fa2,
-                  FabArray<FAB3> const& fa3, IntVect const& nghost, F&& f)
-{
-    using value_type = typename FAB1::value_type;
-    constexpr value_type value_max = std::numeric_limits<value_type>::max();
-    value_type r = value_max;
-
-    {
-        ReduceOps<ReduceOpMin> reduce_op;
-        ReduceData<value_type> reduce_data(reduce_op);
-        using ReduceTuple = typename decltype(reduce_data)::Type;
-
-        for (MFIter mfi(fa1); mfi.isValid(); ++mfi)
-        {
-            const Box& bx = amrex::grow(mfi.validbox(),nghost);
-            const auto& arr1 = fa1.const_array(mfi);
-            const auto& arr2 = fa2.const_array(mfi);
-            const auto& arr3 = fa3.const_array(mfi);
-            reduce_op.eval(bx, reduce_data,
-            [=] AMREX_GPU_DEVICE (Box const& b) -> ReduceTuple
-            {
-                return { f(b, arr1, arr2, arr3) };
-            });
-        }
-
-        ReduceTuple hv = reduce_data.value(reduce_op);
-        r = amrex::get<0>(hv);
-    }
-
-    return r;
-}
-
 template <class FAB1, class FAB2, class FAB3, class F>
 std::enable_if_t<!amrex::DefinitelyNotHostRunnable<F>::value, typename FAB1::value_type>
 ReduceMin_host_wrapper (FabArray<FAB1> const& fa1, FabArray<FAB2> const& fa2,
@@ -649,7 +537,7 @@ ReduceMin (FabArray<FAB1> const& fa1, FabArray<FAB2> const& fa2,
            FabArray<FAB3> const& fa3, IntVect const& nghost, F&& f)
 {
     if (Gpu::inLaunchRegion()) {
-        return fudetail::ReduceMin_device(fa1,fa2,fa3,nghost,std::forward<F>(f));
+        return fudetail::ReduceMF<ReduceOpMin>(fa1,fa2,fa3,nghost,std::forward<F>(f));
     } else {
         return fudetail::ReduceMin_host_wrapper(fa1,fa2,fa3,nghost,std::forward<F>(f));
     }
@@ -680,8 +568,7 @@ typename FAB::value_type
 ReduceMax_host (FabArray<FAB> const& fa, IntVect const& nghost, F&& f)
 {
     using value_type = typename FAB::value_type;
-    constexpr value_type value_lowest = std::numeric_limits<value_type>::lowest();
-    value_type r = value_lowest;
+    value_type r = std::numeric_limits<value_type>::lowest();
 
 #ifdef AMREX_USE_OMP
 #pragma omp parallel reduction(max:r)
@@ -699,38 +586,6 @@ ReduceMax_host (FabArray<FAB> const& fa, IntVect const& nghost, F&& f)
 
 #ifdef AMREX_USE_GPU
 namespace fudetail {
-template <class FAB, class F,
-          class bar = std::enable_if_t<IsBaseFab<FAB>::value> >
-typename FAB::value_type
-ReduceMax_device (FabArray<FAB> const& fa, IntVect const& nghost, F&& f)
-{
-    using value_type = typename FAB::value_type;
-    constexpr value_type value_lowest = std::numeric_limits<value_type>::lowest();
-    value_type r = value_lowest;
-
-    {
-        ReduceOps<ReduceOpMax> reduce_op;
-        ReduceData<value_type> reduce_data(reduce_op);
-        using ReduceTuple = typename decltype(reduce_data)::Type;
-
-        for (MFIter mfi(fa); mfi.isValid(); ++mfi)
-        {
-            const Box& bx = amrex::grow(mfi.validbox(),nghost);
-            const auto& arr = fa.const_array(mfi);
-            reduce_op.eval(bx, reduce_data,
-            [=] AMREX_GPU_DEVICE (Box const& b) -> ReduceTuple
-            {
-                return { f(b, arr) };
-            });
-        }
-
-        ReduceTuple hv = reduce_data.value(reduce_op);
-        r = amrex::get<0>(hv);
-    }
-
-    return r;
-}
-
 template <class FAB, class F>
 std::enable_if_t<!amrex::DefinitelyNotHostRunnable<F>::value, typename FAB::value_type>
 ReduceMax_host_wrapper (FabArray<FAB> const& fa, IntVect const& nghost, F&& f)
@@ -754,7 +609,7 @@ typename FAB::value_type
 ReduceMax (FabArray<FAB> const& fa, IntVect const& nghost, F&& f)
 {
     if (Gpu::inLaunchRegion()) {
-        return fudetail::ReduceMax_device(fa,nghost,std::forward<F>(f));
+        return fudetail::ReduceMF<ReduceOpMax>(fa,nghost,std::forward<F>(f));
     } else {
         return fudetail::ReduceMax_host_wrapper(fa,nghost,std::forward<F>(f));
     }
@@ -785,8 +640,7 @@ ReduceMax_host (FabArray<FAB1> const& fa1, FabArray<FAB2> const& fa2,
                 IntVect const& nghost, F&& f)
 {
     using value_type = typename FAB1::value_type;
-    constexpr value_type value_lowest = std::numeric_limits<value_type>::lowest();
-    value_type r = value_lowest;
+    value_type r = std::numeric_limits<value_type>::lowest();
 
 #ifdef AMREX_USE_OMP
 #pragma omp parallel reduction(max:r)
@@ -805,40 +659,6 @@ ReduceMax_host (FabArray<FAB1> const& fa1, FabArray<FAB2> const& fa2,
 
 #ifdef AMREX_USE_GPU
 namespace fudetail {
-template <class FAB1, class FAB2, class F,
-          class bar = std::enable_if_t<IsBaseFab<FAB1>::value> >
-typename FAB1::value_type
-ReduceMax_device (FabArray<FAB1> const& fa1, FabArray<FAB2> const& fa2,
-                  IntVect const& nghost, F&& f)
-{
-    using value_type = typename FAB1::value_type;
-    constexpr value_type value_lowest = std::numeric_limits<value_type>::lowest();
-    value_type r = value_lowest;
-
-    {
-        ReduceOps<ReduceOpMax> reduce_op;
-        ReduceData<value_type> reduce_data(reduce_op);
-        using ReduceTuple = typename decltype(reduce_data)::Type;
-
-        for (MFIter mfi(fa1); mfi.isValid(); ++mfi)
-        {
-            const Box& bx = amrex::grow(mfi.validbox(),nghost);
-            const auto& arr1 = fa1.const_array(mfi);
-            const auto& arr2 = fa2.const_array(mfi);
-            reduce_op.eval(bx, reduce_data,
-            [=] AMREX_GPU_DEVICE (Box const& b) -> ReduceTuple
-            {
-                return { f(b, arr1, arr2) };
-            });
-        }
-
-        ReduceTuple hv = reduce_data.value(reduce_op);
-        r = amrex::get<0>(hv);
-    }
-
-    return r;
-}
-
 template <class FAB1, class FAB2, class F>
 std::enable_if_t<!amrex::DefinitelyNotHostRunnable<F>::value, typename FAB1::value_type>
 ReduceMax_host_wrapper (FabArray<FAB1> const& fa1, FabArray<FAB2> const& fa2,
@@ -865,7 +685,7 @@ ReduceMax (FabArray<FAB1> const& fa1, FabArray<FAB2> const& fa2,
            IntVect const& nghost, F&& f)
 {
     if (Gpu::inLaunchRegion()) {
-        return fudetail::ReduceMax_device(fa1,fa2,nghost,std::forward<F>(f));
+        return fudetail::ReduceMF<ReduceOpMax>(fa1,fa2,nghost,std::forward<F>(f));
     } else {
         return fudetail::ReduceMax_host_wrapper(fa1,fa2,nghost,std::forward<F>(f));
     }
@@ -898,8 +718,7 @@ ReduceMax_host (FabArray<FAB1> const& fa1, FabArray<FAB2> const& fa2,
                 FabArray<FAB3> const& fa3, IntVect const& nghost, F&& f)
 {
     using value_type = typename FAB1::value_type;
-    constexpr value_type value_lowest = std::numeric_limits<value_type>::lowest();
-    value_type r = value_lowest;
+    value_type r = std::numeric_limits<value_type>::lowest();
 
 #ifdef AMREX_USE_OMP
 #pragma omp parallel reduction(max:r)
@@ -919,41 +738,6 @@ ReduceMax_host (FabArray<FAB1> const& fa1, FabArray<FAB2> const& fa2,
 
 #ifdef AMREX_USE_GPU
 namespace fudetail {
-template <class FAB1, class FAB2, class FAB3, class F,
-          class bar = std::enable_if_t<IsBaseFab<FAB1>::value> >
-typename FAB1::value_type
-ReduceMax_device (FabArray<FAB1> const& fa1, FabArray<FAB2> const& fa2,
-                  FabArray<FAB3> const& fa3, IntVect const& nghost, F&& f)
-{
-    using value_type = typename FAB1::value_type;
-    constexpr value_type value_lowest = std::numeric_limits<value_type>::lowest();
-    value_type r = value_lowest;
-
-    {
-        ReduceOps<ReduceOpMax> reduce_op;
-        ReduceData<value_type> reduce_data(reduce_op);
-        using ReduceTuple = typename decltype(reduce_data)::Type;
-
-        for (MFIter mfi(fa1); mfi.isValid(); ++mfi)
-        {
-            const Box& bx = amrex::grow(mfi.validbox(),nghost);
-            const auto& arr1 = fa1.const_array(mfi);
-            const auto& arr2 = fa2.const_array(mfi);
-            const auto& arr3 = fa3.const_array(mfi);
-            reduce_op.eval(bx, reduce_data,
-            [=] AMREX_GPU_DEVICE (Box const& b) -> ReduceTuple
-            {
-                return { f(b, arr1, arr2, arr3) };
-            });
-        }
-
-        ReduceTuple hv = reduce_data.value(reduce_op);
-        r = amrex::get<0>(hv);
-    }
-
-    return r;
-}
-
 template <class FAB1, class FAB2, class FAB3, class F>
 std::enable_if_t<!amrex::DefinitelyNotHostRunnable<F>::value, typename FAB1::value_type>
 ReduceMax_host_wrapper (FabArray<FAB1> const& fa1, FabArray<FAB2> const& fa2,
@@ -980,7 +764,7 @@ ReduceMax (FabArray<FAB1> const& fa1, FabArray<FAB2> const& fa2,
            FabArray<FAB3> const& fa3, IntVect const& nghost, F&& f)
 {
     if (Gpu::inLaunchRegion()) {
-        return fudetail::ReduceMax_device(fa1,fa2,fa3,nghost,std::forward<F>(f));
+        return fudetail::ReduceMF<ReduceOpMax>(fa1,fa2,fa3,nghost,std::forward<F>(f));
     } else {
         return fudetail::ReduceMax_host_wrapper(fa1,fa2,fa3,nghost,std::forward<F>(f));
     }
@@ -1028,37 +812,6 @@ ReduceLogicalAnd_host (FabArray<FAB> const& fa, IntVect const& nghost, F&& f)
 
 #ifdef AMREX_USE_GPU
 namespace fudetail {
-template <class FAB, class F,
-          class bar = std::enable_if_t<IsBaseFab<FAB>::value> >
-bool
-ReduceLogicalAnd_device (FabArray<FAB> const& fa, IntVect const& nghost, F&& f)
-{
-    int r = true;
-
-    {
-        ReduceOps<ReduceOpLogicalAnd> reduce_op;
-        ReduceData<int> reduce_data(reduce_op);
-        using ReduceTuple = typename decltype(reduce_data)::Type;
-
-        for (MFIter mfi(fa); mfi.isValid(); ++mfi)
-        {
-            const Box& bx = amrex::grow(mfi.validbox(),nghost);
-            const auto& arr = fa.const_array(mfi);
-            reduce_op.eval(bx, reduce_data,
-            [=] AMREX_GPU_DEVICE (Box const& b) -> ReduceTuple
-            {
-                int tr = f(b,arr);
-                return {tr};
-            });
-        }
-
-        ReduceTuple hv = reduce_data.value(reduce_op);
-        r = amrex::get<0>(hv);
-    }
-
-    return r;
-}
-
 template <class FAB, class F>
 std::enable_if_t<!amrex::DefinitelyNotHostRunnable<F>::value, bool>
 ReduceLogicalAnd_host_wrapper (FabArray<FAB> const& fa, IntVect const& nghost, F&& f)
@@ -1082,7 +835,7 @@ bool
 ReduceLogicalAnd (FabArray<FAB> const& fa, IntVect const& nghost, F&& f)
 {
     if (Gpu::inLaunchRegion()) {
-        return fudetail::ReduceLogicalAnd_device(fa,nghost,std::forward<F>(f));
+        return fudetail::ReduceMF<ReduceOpLogicalAnd>(fa,nghost,std::forward<F>(f));
     } else {
         return fudetail::ReduceLogicalAnd_host_wrapper(fa,nghost,std::forward<F>(f));
     }
@@ -1132,39 +885,6 @@ ReduceLogicalAnd_host (FabArray<FAB1> const& fa1, FabArray<FAB2> const& fa2,
 
 #ifdef AMREX_USE_GPU
 namespace fudetail {
-template <class FAB1, class FAB2, class F,
-          class bar = std::enable_if_t<IsBaseFab<FAB1>::value> >
-bool
-ReduceLogicalAnd_device (FabArray<FAB1> const& fa1, FabArray<FAB2> const& fa2,
-                         IntVect const& nghost, F&& f)
-{
-    int r = true;
-
-    {
-        ReduceOps<ReduceOpLogicalAnd> reduce_op;
-        ReduceData<int> reduce_data(reduce_op);
-        using ReduceTuple = typename decltype(reduce_data)::Type;
-
-        for (MFIter mfi(fa1); mfi.isValid(); ++mfi)
-        {
-            const Box& bx = amrex::grow(mfi.validbox(),nghost);
-            const auto& arr1 = fa1.const_array(mfi);
-            const auto& arr2 = fa2.const_array(mfi);
-            reduce_op.eval(bx, reduce_data,
-            [=] AMREX_GPU_DEVICE (Box const& b) -> ReduceTuple
-            {
-                int tr = f(b, arr1, arr2);
-                return {tr};
-            });
-        }
-
-        ReduceTuple hv = reduce_data.value(reduce_op);
-        r = amrex::get<0>(hv);
-    }
-
-    return r;
-}
-
 template <class FAB1, class FAB2, class F>
 std::enable_if_t<!amrex::DefinitelyNotHostRunnable<F>::value, bool>
 ReduceLogicalAnd_host_wrapper (FabArray<FAB1> const& fa1, FabArray<FAB2> const& fa2,
@@ -1191,7 +911,7 @@ ReduceLogicalAnd (FabArray<FAB1> const& fa1, FabArray<FAB2> const& fa2,
                   IntVect const& nghost, F&& f)
 {
     if (Gpu::inLaunchRegion()) {
-        return fudetail::ReduceLogicalAnd_device(fa1,fa2,nghost,std::forward<F>(f));
+        return fudetail::ReduceMF<ReduceOpLogicalAnd>(fa1,fa2,nghost,std::forward<F>(f));
     } else {
         return fudetail::ReduceLogicalAnd_host_wrapper(fa1,fa2,nghost,std::forward<F>(f));
     }
@@ -1239,37 +959,6 @@ ReduceLogicalOr_host (FabArray<FAB> const& fa, IntVect const& nghost, F&& f)
 
 #ifdef AMREX_USE_GPU
 namespace fudetail {
-template <class FAB, class F,
-          class bar = std::enable_if_t<IsBaseFab<FAB>::value> >
-bool
-ReduceLogicalOr_device (FabArray<FAB> const& fa, IntVect const& nghost, F&& f)
-{
-    int r = false;
-
-    {
-        ReduceOps<ReduceOpLogicalOr> reduce_op;
-        ReduceData<int> reduce_data(reduce_op);
-        using ReduceTuple = typename decltype(reduce_data)::Type;
-
-        for (MFIter mfi(fa); mfi.isValid(); ++mfi)
-        {
-            const Box& bx = amrex::grow(mfi.validbox(),nghost);
-            const auto& arr = fa.const_array(mfi);
-            reduce_op.eval(bx, reduce_data,
-            [=] AMREX_GPU_DEVICE (Box const& b) -> ReduceTuple
-            {
-                int tr = f(b, arr);
-                return {tr};
-            });
-        }
-
-        ReduceTuple hv = reduce_data.value(reduce_op);
-        r = amrex::get<0>(hv);
-    }
-
-    return r;
-}
-
 template <class FAB, class F>
 std::enable_if_t<!amrex::DefinitelyNotHostRunnable<F>::value, bool>
 ReduceLogicalOr_host_wrapper (FabArray<FAB> const& fa, IntVect const& nghost, F&& f)
@@ -1293,7 +982,7 @@ bool
 ReduceLogicalOr (FabArray<FAB> const& fa, IntVect const& nghost, F&& f)
 {
     if (Gpu::inLaunchRegion()) {
-        return fudetail::ReduceLogicalOr_device(fa,nghost,std::forward<F>(f));
+        return fudetail::ReduceMF<ReduceOpLogicalOr>(fa,nghost,std::forward<F>(f));
     } else {
         return fudetail::ReduceLogicalOr_host_wrapper(fa,nghost,std::forward<F>(f));
     }
@@ -1343,39 +1032,6 @@ ReduceLogicalOr_host (FabArray<FAB1> const& fa1, FabArray<FAB2> const& fa2,
 
 #ifdef AMREX_USE_GPU
 namespace fudetail {
-template <class FAB1, class FAB2, class F,
-          class bar = std::enable_if_t<IsBaseFab<FAB1>::value> >
-bool
-ReduceLogicalOr_device (FabArray<FAB1> const& fa1, FabArray<FAB2> const& fa2,
-                        IntVect const& nghost, F&& f)
-{
-    int r = false;
-
-    {
-        ReduceOps<ReduceOpLogicalOr> reduce_op;
-        ReduceData<int> reduce_data(reduce_op);
-        using ReduceTuple = typename decltype(reduce_data)::Type;
-
-        for (MFIter mfi(fa1); mfi.isValid(); ++mfi)
-        {
-            const Box& bx = amrex::grow(mfi.validbox(),nghost);
-            const auto& arr1 = fa1.const_array(mfi);
-            const auto& arr2 = fa2.const_array(mfi);
-            reduce_op.eval(bx, reduce_data,
-            [=] AMREX_GPU_DEVICE (Box const& b) -> ReduceTuple
-            {
-                int tr = f(b, arr1, arr2);
-                return {tr};
-            });
-        }
-
-        ReduceTuple hv = reduce_data.value(reduce_op);
-        r = amrex::get<0>(hv);
-    }
-
-    return r;
-}
-
 template <class FAB1, class FAB2, class F>
 std::enable_if_t<!amrex::DefinitelyNotHostRunnable<F>::value, bool>
 ReduceLogicalOr_host_wrapper (FabArray<FAB1> const& fa1, FabArray<FAB2> const& fa2,
@@ -1402,7 +1058,7 @@ ReduceLogicalOr (FabArray<FAB1> const& fa1, FabArray<FAB2> const& fa2,
                  IntVect const& nghost, F&& f)
 {
     if (Gpu::inLaunchRegion()) {
-        return fudetail::ReduceLogicalOr_device(fa1,fa2,nghost,std::forward<F>(f));
+        return fudetail::ReduceMF<ReduceOpLogicalOr>(fa1,fa2,nghost,std::forward<F>(f));
     } else {
         return fudetail::ReduceLogicalOr_host_wrapper(fa1,fa2,nghost,std::forward<F>(f));
     }

--- a/Src/Base/AMReX_GpuTypes.H
+++ b/Src/Base/AMReX_GpuTypes.H
@@ -23,6 +23,10 @@ struct dim3 {
     constexpr dim3 (unsigned int x_, unsigned int y_=1, unsigned int z_=1) : x(x_),y(y_),z(z_) {}
 };
 
+struct Dim1 {
+    std::size_t x;
+};
+
 struct gpuStream_t {
     sycl::queue* queue = nullptr;
     bool operator== (gpuStream_t const& rhs) noexcept { return queue == rhs.queue; }

--- a/Src/Base/AMReX_MultiFab.H
+++ b/Src/Base/AMReX_MultiFab.H
@@ -171,6 +171,13 @@ public:
         return norm0(mask,comp,nghost,local);
     }
 
+    Real norm0 (int comp, int ncomp, IntVect const& nghost, bool local = false,
+                bool ignore_covered = false) const;
+    Real norminf (int comp, int ncomp, IntVect const& nghost, bool local = false,
+                  bool ignore_covered = false) const {
+        return norm0(comp, ncomp, nghost, local, ignore_covered);
+    }
+
     /**
     * \brief Returns the maximum *absolute* values contained in
     * each component of "comps" of the MultiFab.  No ghost cells are used.

--- a/Src/Base/AMReX_MultiFab.cpp
+++ b/Src/Base/AMReX_MultiFab.cpp
@@ -43,24 +43,27 @@ MultiFab::Dot (const MultiFab& x, int xcomp,
 
     BL_PROFILE("MultiFab::Dot()");
 
-    Real sm = 0.0;
+    Real sm = Real(0.0);
 #ifdef AMREX_USE_GPU
     if (Gpu::inLaunchRegion()) {
-        sm = amrex::ReduceSum(x, y, nghost,
-        [=] AMREX_GPU_HOST_DEVICE (Box const& bx, Array4<Real const> const& xfab, Array4<Real const> const& yfab) -> Real
+        auto const& xma = x.const_arrays();
+        auto const& yma = y.const_arrays();
+        sm = ParReduce(TypeList<ReduceOpSum>{}, TypeList<Real>{}, x, IntVect(nghost),
+        [=] AMREX_GPU_DEVICE (int box_no, int i, int j, int k) noexcept -> GpuTuple<Real>
         {
-            Real t = 0.0;
-            AMREX_LOOP_4D(bx, numcomp, i, j, k, n,
-            {
+            Real t = Real(0.0);
+            auto const& xfab = xma[box_no];
+            auto const& yfab = yma[box_no];
+            for (int n = 0; n < numcomp; ++n) {
                 t += xfab(i,j,k,xcomp+n) * yfab(i,j,k,ycomp+n);
-            });
+            }
             return t;
         });
     } else
 #endif
     {
 #ifdef AMREX_USE_OMP
-#pragma omp parallel reduction(+:sm)
+#pragma omp parallel if (!system::regtest_reduction) reduction(+:sm)
 #endif
         for (MFIter mfi(x,true); mfi.isValid(); ++mfi)
         {
@@ -74,7 +77,9 @@ MultiFab::Dot (const MultiFab& x, int xcomp,
         }
     }
 
-    if (!local) ParallelAllReduce::Sum(sm, ParallelContext::CommunicatorSub());
+    if (!local) {
+        ParallelAllReduce::Sum(sm, ParallelContext::CommunicatorSub());
+    }
 
     return sm;
 }
@@ -84,19 +89,42 @@ MultiFab::Dot (const MultiFab& x, int xcomp, int numcomp, int nghost, bool local
 {
     BL_ASSERT(x.nGrow() >= nghost);
 
-    Real sm = amrex::ReduceSum(x, nghost,
-    [=] AMREX_GPU_HOST_DEVICE (Box const& bx, Array4<Real const> const& xfab) -> Real
-    {
-        Real t = 0.0;
-        AMREX_LOOP_4D(bx, numcomp, i, j, k, n,
-        {
-            Real tmp = xfab(i,j,k,xcomp+n);
-            t += tmp*tmp;
-        });
-        return t;
-    });
+    BL_PROFILE("MultiFab::Dot()");
 
-    if (!local) ParallelAllReduce::Sum(sm, ParallelContext::CommunicatorSub());
+    Real sm = Real(0.0);
+#ifdef AMREX_USE_GPU
+    if (Gpu::inLaunchRegion()) {
+        auto const& xma = x.const_arrays();
+        sm = ParReduce(TypeList<ReduceOpSum>{}, TypeList<Real>{}, x, IntVect(nghost),
+        [=] AMREX_GPU_DEVICE (int box_no, int i, int j, int k) noexcept -> GpuTuple<Real>
+        {
+            Real t = Real(0.0);
+            auto const& xfab = xma[box_no];
+            for (int n = 0; n < numcomp; ++n) {
+                t += xfab(i,j,k,xcomp+n) * xfab(i,j,k,xcomp+n);
+            }
+            return t;
+        });
+    } else
+#endif
+    {
+#ifdef AMREX_USE_OMP
+#pragma omp parallel if (!system::regtest_reduction) reduction(+:sm)
+#endif
+        for (MFIter mfi(x,true); mfi.isValid(); ++mfi)
+        {
+            Box const& bx = mfi.growntilebox(nghost);
+            Array4<Real const> const& xfab = x.const_array(mfi);
+            AMREX_LOOP_4D(bx, numcomp, i, j, k, n,
+            {
+                sm += xfab(i,j,k,xcomp+n) * xfab(i,j,k,xcomp+n);
+            });
+        }
+    }
+
+    if (!local) {
+        ParallelAllReduce::Sum(sm, ParallelContext::CommunicatorSub());
+    }
 
     return sm;
 }
@@ -115,22 +143,49 @@ MultiFab::Dot (const iMultiFab& mask,
     BL_ASSERT(x.nGrow() >= nghost && y.nGrow() >= nghost);
     BL_ASSERT(mask.nGrow() >= nghost);
 
-    Real sm = amrex::ReduceSum(x, y, mask, nghost,
-    [=] AMREX_GPU_HOST_DEVICE (Box const& bx, Array4<Real const> const& xfab,
-                               Array4<Real const> const& yfab,
-                               Array4<int const> const& mskfab) -> Real
-    {
-        Real t = 0.0;
-        AMREX_LOOP_4D(bx, numcomp, i, j, k, n,
+    Real sm = Real(0.0);
+#ifdef AMREX_USE_GPU
+    if (Gpu::inLaunchRegion()) {
+        auto const& xma = x.const_arrays();
+        auto const& yma = y.const_arrays();
+        auto const& mma = mask.const_arrays();
+        sm = ParReduce(TypeList<ReduceOpSum>{}, TypeList<Real>{}, x, IntVect(nghost),
+        [=] AMREX_GPU_DEVICE (int box_no, int i, int j, int k) noexcept -> GpuTuple<Real>
         {
-            int mi = static_cast<int>(static_cast<bool>(mskfab(i,j,k)));
-            t += xfab(i,j,k,xcomp+n) * yfab(i,j,k,ycomp+n) * mi;
+            Real t = Real(0.0);
+            if (mma[box_no](i,j,k)) {
+                auto const& xfab = xma[box_no];
+                auto const& yfab = yma[box_no];
+                for (int n = 0; n < numcomp; ++n) {
+                    t += xfab(i,j,k,xcomp+n) * yfab(i,j,k,ycomp+n);
+                }
+            }
+            return t;
         });
-        return t;
-    });
+    } else
+#endif
+    {
+#ifdef AMREX_USE_OMP
+#pragma omp parallel if (!system::regtest_reduction) reduction(+:sm)
+#endif
+        for (MFIter mfi(x,true); mfi.isValid(); ++mfi)
+        {
+            Box const& bx = mfi.growntilebox(nghost);
+            Array4<Real const> const& xfab = x.const_array(mfi);
+            Array4<Real const> const& yfab = y.const_array(mfi);
+            Array4<int const> const& mfab = mask.const_array(mfi);
+            AMREX_LOOP_4D(bx, numcomp, i, j, k, n,
+            {
+                if (mfab(i,j,k)) {
+                    sm += xfab(i,j,k,xcomp+n) * yfab(i,j,k,ycomp+n);
+                }
+            });
+        }
+    }
 
-    if (!local)
+    if (!local) {
         ParallelAllReduce::Sum(sm, ParallelContext::CommunicatorSub());
+    }
 
     return sm;
 }
@@ -691,34 +746,46 @@ MultiFab::initVal ()
 }
 
 bool
-MultiFab::contains_nan (int scomp,
-                        int ncomp,
-                        int ngrow,
-                        bool local) const
+MultiFab::contains_nan (int scomp, int ncomp, int ngrow, bool local) const
 {
     return contains_nan(scomp, ncomp, IntVect(ngrow), local);
 }
 
 bool
-MultiFab::contains_nan (int scomp,
-                        int ncomp,
-                        const IntVect& ngrow,
-                        bool local) const
+MultiFab::contains_nan (int scomp, int ncomp, const IntVect& ngrow, bool local) const
 {
     BL_ASSERT(scomp >= 0);
     BL_ASSERT(scomp + ncomp <= nComp());
     BL_ASSERT(ncomp >  0 && ncomp <= nComp());
     BL_ASSERT(IntVect::TheZeroVector().allLE(ngrow) && ngrow.allLE(nGrowVect()));
 
-    bool r = amrex::ReduceLogicalOr(*this, ngrow,
-    [=] AMREX_GPU_HOST_DEVICE (Box const& bx, Array4<Real const> const& fab) -> bool
-    {
-        AMREX_LOOP_4D(bx, ncomp, i, j, k, n,
+    BL_PROFILE("MultiFab::contains_nan()");
+
+    bool r = false;
+#ifdef AMREX_USE_GPU
+    if (Gpu::inLaunchRegion()) {
+        auto const& ma = this->const_arrays();
+        r = ParReduce(TypeList<ReduceOpLogicalOr>{}, TypeList<bool>{}, *this, ngrow, ncomp,
+        [=] AMREX_GPU_DEVICE (int box_no, int i, int j, int k, int n) noexcept -> GpuTuple<bool>
         {
-            if (amrex::isnan(fab(i,j,k,n+scomp))) return true;
+            return amrex::isnan(ma[box_no](i,j,k,n+scomp));
         });
-        return false;
-    });
+    } else
+#endif
+    {
+#ifdef AMREX_USE_OMP
+#pragma omp parallel reduction(||:r)
+#endif
+        for (MFIter mfi(*this,true); mfi.isValid() && !r; ++mfi)
+        {
+            Box const& bx = mfi.growntilebox(ngrow);
+            Array4<Real const> const& fab = this->const_array(mfi);
+            AMREX_LOOP_4D(bx, ncomp, i, j, k, n,
+            {
+                r = r || amrex::isnan(fab(i,j,k,n+scomp));
+            });
+        }
+    }
 
     if (!local) {
         ParallelAllReduce::Or(r, ParallelContext::CommunicatorSub());
@@ -741,18 +808,37 @@ MultiFab::contains_inf (int scomp, int ncomp, IntVect const& ngrow, bool local) 
     BL_ASSERT(ncomp >  0 && ncomp <= nComp());
     BL_ASSERT(IntVect::TheZeroVector().allLE(ngrow) && ngrow.allLE(nGrowVect()));
 
-    bool r = amrex::ReduceLogicalOr(*this, ngrow,
-    [=] AMREX_GPU_HOST_DEVICE (Box const& bx, Array4<Real const> const& fab) -> bool
-    {
-        AMREX_LOOP_4D(bx, ncomp, i, j, k, n,
-        {
-            if (amrex::isinf(fab(i,j,k,n+scomp))) return true;
-        });
-        return false;
-    });
+    BL_PROFILE("MultiFab::contains_inf()");
 
-    if (!local)
+    bool r = false;
+#ifdef AMREX_USE_GPU
+    if (Gpu::inLaunchRegion()) {
+        auto const& ma = this->const_arrays();
+        r = ParReduce(TypeList<ReduceOpLogicalOr>{}, TypeList<bool>{}, *this, ngrow, ncomp,
+        [=] AMREX_GPU_DEVICE (int box_no, int i, int j, int k, int n) noexcept -> GpuTuple<bool>
+        {
+            return amrex::isinf(ma[box_no](i,j,k,n+scomp));
+        });
+    } else
+#endif
+    {
+#ifdef AMREX_USE_OMP
+#pragma omp parallel reduction(||:r)
+#endif
+        for (MFIter mfi(*this,true); mfi.isValid() && !r; ++mfi)
+        {
+            Box const& bx = mfi.growntilebox(ngrow);
+            Array4<Real const> const& fab = this->const_array(mfi);
+            AMREX_LOOP_4D(bx, ncomp, i, j, k, n,
+            {
+                r = r || amrex::isinf(fab(i,j,k,n+scomp));
+            });
+        }
+    }
+
+    if (!local) {
         ParallelAllReduce::Or(r, ParallelContext::CommunicatorSub());
+    }
 
     return r;
 }
@@ -772,44 +858,82 @@ MultiFab::contains_inf (bool local) const
 Real
 MultiFab::min (int comp, int nghost, bool local) const
 {
+    BL_PROFILE("MultiFab::min()");
+
     BL_ASSERT(nghost >= 0 && nghost <= n_grow.min());
 
-    Real mn;
+    Real mn = std::numeric_limits<Real>::max();
 
 #ifdef AMREX_USE_EB
     if ( this->hasEBFabFactory() )
     {
         const auto& ebfactory = dynamic_cast<EBFArrayBoxFactory const&>(this->Factory());
         auto const& flags = ebfactory.getMultiEBCellFlagFab();
-        mn = amrex::ReduceMin(*this, flags, nghost,
-        [=] AMREX_GPU_HOST_DEVICE (Box const& bx, Array4<Real const> const& a,
-                                   Array4<EBCellFlag const> const& flag) -> Real
-        {
-            Real r = AMREX_REAL_MAX;
-            AMREX_LOOP_3D(bx, i, j, k,
+#ifdef AMREX_USE_GPU
+        if (Gpu::inLaunchRegion()) {
+            auto const& flagsma = flags.const_arrays();
+            auto const& ma = this->const_arrays();
+            mn = ParReduce(TypeList<ReduceOpMin>{}, TypeList<Real>{}, *this, IntVect(nghost),
+            [=] AMREX_GPU_DEVICE (int box_no, int i, int j, int k) noexcept -> GpuTuple<Real>
             {
-                if (!flag(i,j,k).isCovered()) r = amrex::min(r, a(i,j,k,comp));
+                if (flagsma[box_no](i,j,k).isCovered()) {
+                    return AMREX_REAL_MAX;
+                } else {
+                    return ma[box_no](i,j,k,comp);
+                }
             });
-            return r;
-        });
+        } else
+#endif
+        {
+#ifdef AMREX_USE_OMP
+#pragma omp parallel reduction(min:mn)
+#endif
+            for (MFIter mfi(*this,true); mfi.isValid(); ++mfi) {
+                Box const& bx = mfi.growntilebox(nghost);
+                if (flags[mfi].getType(bx) != FabType::covered) {
+                    auto const& flag = flags.const_array(mfi);
+                    auto const& a = this->const_array(mfi);
+                    AMREX_LOOP_3D(bx, i, j, k,
+                    {
+                        if (!flag(i,j,k).isCovered()) {
+                            mn = std::min(mn, a(i,j,k,comp));
+                        }
+                    });
+                }
+            }
+        }
     }
     else
 #endif
     {
-        mn = amrex::ReduceMin(*this, nghost,
-        [=] AMREX_GPU_HOST_DEVICE (Box const& bx, Array4<Real const> const& fab) -> Real
-        {
-            Real r = AMREX_REAL_MAX;
-            AMREX_LOOP_3D(bx, i, j, k,
+#ifdef AMREX_USE_GPU
+        if (Gpu::inLaunchRegion()) {
+            auto const& ma = this->const_arrays();
+            mn = ParReduce(TypeList<ReduceOpMin>{}, TypeList<Real>{}, *this, IntVect(nghost),
+            [=] AMREX_GPU_DEVICE (int box_no, int i, int j, int k) noexcept -> GpuTuple<Real>
             {
-                r = amrex::min(r, fab(i,j,k,comp));
+                return ma[box_no](i,j,k,comp);
             });
-            return r;
-        });
+        } else
+#endif
+        {
+#ifdef AMREX_USE_OMP
+#pragma omp parallel reduction(min:mn)
+#endif
+            for (MFIter mfi(*this,true); mfi.isValid(); ++mfi) {
+                Box const& bx = mfi.growntilebox(nghost);
+                auto const& a = this->const_array(mfi);
+                AMREX_LOOP_3D(bx, i, j, k,
+                {
+                    mn = std::min(mn, a(i,j,k,comp));
+                });
+            }
+        }
     }
 
-    if (!local)
+    if (!local) {
         ParallelAllReduce::Min(mn, ParallelContext::CommunicatorSub());
+    }
 
     return mn;
 }
@@ -819,23 +943,45 @@ MultiFab::min (const Box& region, int comp, int nghost, bool local) const
 {
     BL_ASSERT(nghost >= 0 && nghost <= n_grow.min());
 
-    Real mn = amrex::ReduceMin(*this, nghost,
-    [=] AMREX_GPU_HOST_DEVICE (Box const& bx, Array4<Real const> const& fab) -> Real
-    {
-        const Box& b = bx & region;
-        Real r = AMREX_REAL_MAX;
-        AMREX_LOOP_3D(b, i, j, k,
-        {
-            r = amrex::min(r, fab(i,j,k,comp));
-        });
-        return r;
-    });
+    BL_PROFILE("MultiFab::min(region)");
 
-    if (!local)
+    Real mn = std::numeric_limits<Real>::max();
+
+#ifdef AMREX_USE_GPU
+    if (Gpu::inLaunchRegion()) {
+        auto const& ma = this->const_arrays();
+        mn = ParReduce(TypeList<ReduceOpMin>{}, TypeList<Real>{}, *this, IntVect(nghost),
+        [=] AMREX_GPU_DEVICE (int box_no, int i, int j, int k) noexcept -> GpuTuple<Real>
+        {
+            if (region.contains(i,j,k)) {
+                return ma[box_no](i,j,k,comp);
+            } else {
+                return AMREX_REAL_MAX;
+            }
+        });
+    } else
+#endif
+    {
+#ifdef AMREX_USE_OMP
+#pragma omp parallel reduction(min:mn)
+#endif
+        for (MFIter mfi(*this,true); mfi.isValid(); ++mfi) {
+            Box const& bx = mfi.growntilebox(nghost) & region;
+            if (bx.ok()) {
+                auto const& a = this->const_array(mfi);
+                AMREX_LOOP_3D(bx, i, j, k,
+                {
+                    mn = std::min(mn, a(i,j,k,comp));
+                });
+            }
+        }
+    }
+
+    if (!local) {
         ParallelAllReduce::Min(mn, ParallelContext::CommunicatorSub());
+    }
 
     return mn;
-
 }
 
 Real
@@ -843,42 +989,80 @@ MultiFab::max (int comp, int nghost, bool local) const
 {
     BL_ASSERT(nghost >= 0 && nghost <= n_grow.min());
 
-    Real mx;
+    BL_PROFILE("MultiFab::max()");
+
+    Real mx = std::numeric_limits<Real>::lowest();
 
 #ifdef AMREX_USE_EB
     if ( this->hasEBFabFactory() )
     {
         const auto& ebfactory = dynamic_cast<EBFArrayBoxFactory const&>(this->Factory());
         auto const& flags = ebfactory.getMultiEBCellFlagFab();
-        mx = amrex::ReduceMax(*this, flags, nghost,
-        [=] AMREX_GPU_HOST_DEVICE (Box const& bx, Array4<Real const> const& a,
-                                   Array4<EBCellFlag const> const& flag) -> Real
-        {
-            Real r = AMREX_REAL_LOWEST;
-            AMREX_LOOP_3D(bx, i, j, k,
+#ifdef AMREX_USE_GPU
+        if (Gpu::inLaunchRegion()) {
+            auto const& flagsma = flags.const_arrays();
+            auto const& ma = this->const_arrays();
+            mx = ParReduce(TypeList<ReduceOpMax>{}, TypeList<Real>{}, *this, IntVect(nghost),
+            [=] AMREX_GPU_DEVICE (int box_no, int i, int j, int k) noexcept -> GpuTuple<Real>
             {
-                if (!flag(i,j,k).isCovered()) r = amrex::max(r, a(i,j,k,comp));
+                if (flagsma[box_no](i,j,k).isCovered()) {
+                    return AMREX_REAL_LOWEST;
+                } else {
+                    return ma[box_no](i,j,k,comp);
+                }
             });
-            return r;
-        });
+        } else
+#endif
+        {
+#ifdef AMREX_USE_OMP
+#pragma omp parallel reduction(max:mx)
+#endif
+            for (MFIter mfi(*this,true); mfi.isValid(); ++mfi) {
+                Box const& bx = mfi.growntilebox(nghost);
+                if (flags[mfi].getType(bx) != FabType::covered) {
+                    auto const& flag = flags.const_array(mfi);
+                    auto const& a = this->const_array(mfi);
+                    AMREX_LOOP_3D(bx, i, j, k,
+                    {
+                        if (!flag(i,j,k).isCovered()) {
+                            mx = std::max(mx, a(i,j,k,comp));
+                        }
+                    });
+                }
+            }
+        }
     }
     else
 #endif
     {
-        mx = amrex::ReduceMax(*this, nghost,
-        [=] AMREX_GPU_HOST_DEVICE (Box const& bx, Array4<Real const> const& fab) -> Real
-        {
-            Real r = AMREX_REAL_LOWEST;
-            AMREX_LOOP_3D(bx, i, j, k,
+#ifdef AMREX_USE_GPU
+        if (Gpu::inLaunchRegion()) {
+            auto const& ma = this->const_arrays();
+            mx = ParReduce(TypeList<ReduceOpMax>{}, TypeList<Real>{}, *this, IntVect(nghost),
+            [=] AMREX_GPU_DEVICE (int box_no, int i, int j, int k) noexcept -> GpuTuple<Real>
             {
-                r = amrex::max(r, fab(i,j,k,comp));
+                return ma[box_no](i,j,k,comp);
             });
-            return r;
-        });
+        } else
+#endif
+        {
+#ifdef AMREX_USE_OMP
+#pragma omp parallel reduction(max:mx)
+#endif
+            for (MFIter mfi(*this,true); mfi.isValid(); ++mfi) {
+                Box const& bx = mfi.growntilebox(nghost);
+                auto const& a = this->const_array(mfi);
+                AMREX_LOOP_3D(bx, i, j, k,
+                {
+                    mx = std::max(mx, a(i,j,k,comp));
+                });
+            }
+        }
     }
 
-    if (!local)
+    if (!local) {
         ParallelAllReduce::Max(mx, ParallelContext::CommunicatorSub());
+    }
 
     return mx;
 }
@@ -886,22 +1070,43 @@ MultiFab::max (int comp, int nghost, bool local) const
 Real
 MultiFab::max (const Box& region, int comp, int nghost, bool local) const
 {
-    BL_ASSERT(nghost >= 0 && nghost <= n_grow.min());
+    BL_PROFILE("MultiFab::max(region)");
 
-    Real mx = amrex::ReduceMax(*this, nghost,
-    [=] AMREX_GPU_HOST_DEVICE (Box const& bx, Array4<Real const> const& fab) -> Real
-    {
-        const Box& b = bx & region;
-        Real r = AMREX_REAL_LOWEST;
-        AMREX_LOOP_3D(b, i, j, k,
+    Real mx = std::numeric_limits<Real>::lowest();
+
+#ifdef AMREX_USE_GPU
+    if (Gpu::inLaunchRegion()) {
+        auto const& ma = this->const_arrays();
+        mx = ParReduce(TypeList<ReduceOpMax>{}, TypeList<Real>{}, *this, IntVect(nghost),
+        [=] AMREX_GPU_DEVICE (int box_no, int i, int j, int k) noexcept -> GpuTuple<Real>
         {
-            r = amrex::max(r, fab(i,j,k,comp));
+            if (region.contains(i,j,k)) {
+                return ma[box_no](i,j,k,comp);
+            } else {
+                return AMREX_REAL_LOWEST;
+            }
         });
-        return r;
-    });
+    } else
+#endif
+    {
+#ifdef AMREX_USE_OMP
+#pragma omp parallel reduction(max:mx)
+#endif
+        for (MFIter mfi(*this,true); mfi.isValid(); ++mfi) {
+            Box const& bx = mfi.growntilebox(nghost) & region;
+            if (bx.ok()) {
+                auto const& a = this->const_array(mfi);
+                AMREX_LOOP_3D(bx, i, j, k,
+                {
+                    mx = std::max(mx, a(i,j,k,comp));
+                });
+            }
+        }
+    }
 
-    if (!local)
+    if (!local) {
         ParallelAllReduce::Max(mx, ParallelContext::CommunicatorSub());
+    }
 
     return mx;
 }
@@ -957,19 +1162,45 @@ MultiFab::maxIndex (int comp, int nghost) const
 Real
 MultiFab::norm0 (const iMultiFab& mask, int comp, int nghost, bool local) const
 {
-    Real nm0 = amrex::ReduceMax(*this, mask, nghost,
-    [=] AMREX_GPU_HOST_DEVICE (Box const& bx, Array4<Real const> const& fab,
-                               Array4<int const> const& mskfab) -> Real
-    {
-        Real r = 0.0;
-        AMREX_LOOP_3D(bx, i, j, k,
-        {
-            if (mskfab(i,j,k)) r = amrex::max(r, amrex::Math::abs(fab(i,j,k,comp)));
-        });
-        return r;
-    });
+    BL_PROFILE("MultiFab::norm0(mask)");
 
-    if (!local)        ParallelAllReduce::Max(nm0, ParallelContext::CommunicatorSub());
+    Real nm0 = Real(0.0);
+
+#ifdef AMREX_USE_GPU
+    if (Gpu::inLaunchRegion()) {
+        auto const& ma = this->const_arrays();
+        auto const& maskma = mask.const_arrays();
+        nm0 = ParReduce(TypeList<ReduceOpMax>{}, TypeList<Real>{}, *this, IntVect(nghost),
+        [=] AMREX_GPU_DEVICE (int box_no, int i, int j, int k) noexcept -> GpuTuple<Real>
+        {
+            if (maskma[box_no](i,j,k)) {
+                return amrex::Math::abs(ma[box_no](i,j,k,comp));
+            } else {
+                return Real(0.0);
+            }
+        });
+    } else
+#endif
+    {
+#ifdef AMREX_USE_OMP
+#pragma omp parallel reduction(max:nm0)
+#endif
+        for (MFIter mfi(*this,true); mfi.isValid(); ++mfi) {
+            Box const& bx = mfi.growntilebox(nghost);
+            auto const& a = this->const_array(mfi);
+            auto const& mskfab = mask.const_array(mfi);
+            AMREX_LOOP_3D(bx, i, j, k,
+            {
+                if (mskfab(i,j,k)) {
+                    nm0 = std::max(nm0, amrex::Math::abs(a(i,j,k,comp)));
+                }
+            });
+        }
+    }
+
+    if (!local) {
+        ParallelAllReduce::Max(nm0, ParallelContext::CommunicatorSub());
+    }
 
     return nm0;
 }
@@ -979,42 +1210,164 @@ MultiFab::norm0 (int comp, int nghost, bool local, bool ignore_covered ) const
 {
     amrex::ignore_unused(ignore_covered);
 
-    Real nm0;
+    Real nm0 = Real(0.0);
 
 #ifdef AMREX_USE_EB
-    if ( this -> hasEBFabFactory() && ignore_covered )
+    if ( this->hasEBFabFactory() && ignore_covered )
     {
         const auto& ebfactory = dynamic_cast<EBFArrayBoxFactory const&>(this->Factory());
         auto const& flags = ebfactory.getMultiEBCellFlagFab();
-        nm0 = amrex::ReduceMax(*this, flags, nghost,
-        [=] AMREX_GPU_HOST_DEVICE (Box const& bx, Array4<Real const> const& a,
-                                   Array4<EBCellFlag const> const& flag) -> Real
-        {
-            Real r = 0.;
-            AMREX_LOOP_3D(bx, i, j, k,
+#ifdef AMREX_USE_GPU
+        if (Gpu::inLaunchRegion()) {
+            auto const& flagsma = flags.const_arrays();
+            auto const& ma = this->const_arrays();
+            nm0 = ParReduce(TypeList<ReduceOpMax>{}, TypeList<Real>{}, *this, IntVect(nghost),
+            [=] AMREX_GPU_DEVICE (int box_no, int i, int j, int k) noexcept -> GpuTuple<Real>
             {
-                if (!flag(i,j,k).isCovered()) r = amrex::max(r, amrex::Math::abs(a(i,j,k,comp)));
+                if (flagsma[box_no](i,j,k).isCovered()) {
+                    return Real(0.0);
+                } else {
+                    return amrex::Math::abs(ma[box_no](i,j,k,comp));
+                }
             });
-            return r;
-        });
+        } else
+#endif
+        {
+#ifdef AMREX_USE_OMP
+#pragma omp parallel reduction(max:nm0)
+#endif
+            for (MFIter mfi(*this,true); mfi.isValid(); ++mfi) {
+                Box const& bx = mfi.growntilebox(nghost);
+                if (flags[mfi].getType(bx) != FabType::covered) {
+                    auto const& flag = flags.const_array(mfi);
+                    auto const& a = this->const_array(mfi);
+                    AMREX_LOOP_3D(bx, i, j, k,
+                    {
+                        if (!flag(i,j,k).isCovered()) {
+                            nm0 = std::max(nm0, amrex::Math::abs(a(i,j,k,comp)));
+                        }
+                    });
+                }
+            }
+        }
     }
     else
 #endif
     {
-        nm0 = amrex::ReduceMax(*this, nghost,
-        [=] AMREX_GPU_HOST_DEVICE (Box const& bx, Array4<Real const> const& fab) -> Real
-        {
-            Real r = 0.;
-            AMREX_LOOP_3D(bx, i, j, k,
+#ifdef AMREX_USE_GPU
+        if (Gpu::inLaunchRegion()) {
+            auto const& ma = this->const_arrays();
+            nm0 = ParReduce(TypeList<ReduceOpMax>{}, TypeList<Real>{}, *this, IntVect(nghost),
+            [=] AMREX_GPU_DEVICE (int box_no, int i, int j, int k) noexcept -> GpuTuple<Real>
             {
-                r = amrex::max(r, amrex::Math::abs(fab(i,j,k,comp)));
+                return amrex::Math::abs(ma[box_no](i,j,k,comp));
             });
-            return r;
-        });
-
+        } else
+#endif
+        {
+#ifdef AMREX_USE_OMP
+#pragma omp parallel reduction(max:nm0)
+#endif
+            for (MFIter mfi(*this,true); mfi.isValid(); ++mfi) {
+                Box const& bx = mfi.growntilebox(nghost);
+                auto const& a = this->const_array(mfi);
+                AMREX_LOOP_3D(bx, i, j, k,
+                {
+                    nm0 = std::max(nm0, amrex::Math::abs(a(i,j,k,comp)));
+                });
+            }
+        }
     }
-    if (!local)
+
+    if (!local) {
         ParallelAllReduce::Max(nm0, ParallelContext::CommunicatorSub());
+    }
+
+    return nm0;
+}
+
+Real
+MultiFab::norm0 (int comp, int ncomp, IntVect const& nghost, bool local, bool ignore_covered ) const
+{
+    amrex::ignore_unused(ignore_covered);
+
+    Real nm0 = Real(0.0);
+
+#ifdef AMREX_USE_EB
+    if ( this->hasEBFabFactory() && ignore_covered )
+    {
+        const auto& ebfactory = dynamic_cast<EBFArrayBoxFactory const&>(this->Factory());
+        auto const& flags = ebfactory.getMultiEBCellFlagFab();
+#ifdef AMREX_USE_GPU
+        if (Gpu::inLaunchRegion()) {
+            auto const& flagsma = flags.const_arrays();
+            auto const& ma = this->const_arrays();
+            nm0 = ParReduce(TypeList<ReduceOpMax>{}, TypeList<Real>{}, *this, nghost,
+            [=] AMREX_GPU_DEVICE (int box_no, int i, int j, int k) noexcept -> GpuTuple<Real>
+            {
+                if (flagsma[box_no](i,j,k).isCovered()) {
+                    return Real(0.0);
+                } else {
+                    Real tmp = Real(0.0);
+                    auto const& a = ma[box_no];
+                    for (int n = 0; n < ncomp; ++n) {
+                        tmp = amrex::max(tmp, amrex::Math::abs(a(i,j,k,comp+n)));
+                    }
+                    return tmp;
+                }
+            });
+        } else
+#endif
+        {
+#ifdef AMREX_USE_OMP
+#pragma omp parallel reduction(max:nm0)
+#endif
+            for (MFIter mfi(*this,true); mfi.isValid(); ++mfi) {
+                Box const& bx = mfi.growntilebox(nghost);
+                if (flags[mfi].getType(bx) != FabType::covered) {
+                    auto const& flag = flags.const_array(mfi);
+                    auto const& a = this->const_array(mfi);
+                    AMREX_LOOP_4D(bx, ncomp, i, j, k, n,
+                    {
+                        if (!flag(i,j,k).isCovered()) {
+                            nm0 = std::max(nm0, amrex::Math::abs(a(i,j,k,comp+n)));
+                        }
+                    });
+                }
+            }
+        }
+    }
+    else
+#endif
+    {
+#ifdef AMREX_USE_GPU
+        if (Gpu::inLaunchRegion()) {
+            auto const& ma = this->const_arrays();
+            nm0 = ParReduce(TypeList<ReduceOpMax>{}, TypeList<Real>{}, *this, nghost, ncomp,
+            [=] AMREX_GPU_DEVICE (int box_no, int i, int j, int k, int n) noexcept -> GpuTuple<Real>
+            {
+                return amrex::Math::abs(ma[box_no](i,j,k,comp+n));
+            });
+        } else
+#endif
+        {
+#ifdef AMREX_USE_OMP
+#pragma omp parallel reduction(max:nm0)
+#endif
+            for (MFIter mfi(*this,true); mfi.isValid(); ++mfi) {
+                Box const& bx = mfi.growntilebox(nghost);
+                auto const& a = this->const_array(mfi);
+                AMREX_LOOP_4D(bx, ncomp, i, j, k, n,
+                {
+                    nm0 = std::max(nm0, amrex::Math::abs(a(i,j,k,comp+n)));
+                });
+            }
+        }
+    }
+
+    if (!local) {
+        ParallelAllReduce::Max(nm0, ParallelContext::CommunicatorSub());
+    }
 
     return nm0;
 }
@@ -1030,8 +1383,9 @@ MultiFab::norm0 (const Vector<int>& comps, int nghost, bool local, bool ignore_c
         nm0.push_back(this->norm0(comp, nghost, true, ignore_covered));
     }
 
-    if (!local)
+    if (!local) {
         ParallelAllReduce::Max(nm0.dataPtr(), n, ParallelContext::CommunicatorSub());
+    }
 
     return nm0;
 }
@@ -1049,20 +1403,40 @@ MultiFab::norm2 (int comp) const
 Real
 MultiFab::norm2 (int comp, const Periodicity& period) const
 {
+    BL_PROFILE("MultiFab::norm2(period)");
+
+    Real nm2 = Real(0.0);
+
     auto mask = OverlapMask(period);
 
-    Real nm2 = amrex::ReduceSum(*this, *mask, 0,
-    [=] AMREX_GPU_HOST_DEVICE (Box const& bx, Array4<Real const> const& xfab,
-                               Array4<Real const> const& mfab) -> Real
-    {
-        Real r = 0.0;
-        AMREX_LOOP_3D(bx, i, j, k,
+#ifdef AMREX_USE_GPU
+    if (Gpu::inLaunchRegion()) {
+        auto const& ma = this->const_arrays();
+        auto const& maskma = mask->const_arrays();
+        nm2 = ParReduce(TypeList<ReduceOpSum>{}, TypeList<Real>{}, *this,
+        [=] AMREX_GPU_DEVICE (int box_no, int i, int j, int k) noexcept -> GpuTuple<Real>
         {
-            Real tmp = xfab(i,j,k,comp);
-            r += tmp*tmp/mfab(i,j,k);
+            Real tmp = ma[box_no](i,j,k,comp);
+            return tmp*tmp/maskma[box_no](i,j,k);
         });
-        return r;
-    });
+    } else
+#endif
+    {
+#ifdef AMREX_USE_OMP
+#pragma omp parallel if (!system::regtest_reduction) reduction(+:nm2)
+#endif
+        for (MFIter mfi(*this,true); mfi.isValid(); ++mfi)
+        {
+            Box const& bx = mfi.tilebox();
+            auto const& a = this->const_array(mfi);
+            auto const& m = mask->const_array(mfi);
+            AMREX_LOOP_3D(bx, i, j, k,
+            {
+                Real tmp = a(i,j,k,comp);
+                nm2 += tmp*tmp/m(i,j,k);
+            });
+        }
+    }
 
     ParallelAllReduce::Sum(nm2, ParallelContext::CommunicatorSub());
     return std::sqrt(nm2);
@@ -1096,7 +1470,7 @@ MultiFab::norm1 (int comp, const Periodicity& period, bool ignore_covered ) cons
 
 #ifdef AMREX_USE_EB
     if ( this -> hasEBFabFactory() && ignore_covered )
-        EB_set_covered( tmpmf, 0.0 );
+        EB_set_covered( tmpmf, Real(0.0) );
 #endif
 
     auto mask = OverlapMask(period);
@@ -1108,19 +1482,37 @@ MultiFab::norm1 (int comp, const Periodicity& period, bool ignore_covered ) cons
 Real
 MultiFab::norm1 (int comp, int ngrow, bool local) const
 {
-    Real nm1 = amrex::ReduceSum(*this, ngrow,
-    [=] AMREX_GPU_HOST_DEVICE (Box const& bx, Array4<Real const> const& fab) -> Real
-    {
-        Real r = 0.0;
-        AMREX_LOOP_3D(bx, i, j, k,
-        {
-            r += amrex::Math::abs(fab(i,j,k,comp));
-        });
-        return r;
-    });
+    BL_PROFILE("MultiFab::norm1");
 
-    if (!local)
+    Real nm1 = Real(0.0);
+
+#ifdef AMREX_USE_GPU
+    if (Gpu::inLaunchRegion()) {
+        auto const& ma = this->const_arrays();
+        nm1 = ParReduce(TypeList<ReduceOpSum>{}, TypeList<Real>{}, *this, IntVect(ngrow),
+        [=] AMREX_GPU_DEVICE (int box_no, int i, int j, int k) noexcept -> GpuTuple<Real>
+        {
+            return amrex::Math::abs(ma[box_no](i,j,k,comp));
+        });
+    } else
+#endif
+    {
+#ifdef AMREX_USE_OMP
+#pragma omp parallel reduction(+:nm1)
+#endif
+        for (MFIter mfi(*this,true); mfi.isValid(); ++mfi) {
+            Box const& bx = mfi.growntilebox(ngrow);
+            auto const& a = this->const_array(mfi);
+            AMREX_LOOP_3D(bx, i, j, k,
+            {
+                nm1 += amrex::Math::abs(a(i,j,k,comp));
+            });
+        }
+    }
+
+    if (!local) {
         ParallelAllReduce::Sum(nm1, ParallelContext::CommunicatorSub());
+    }
 
     return nm1;
 }
@@ -1147,20 +1539,40 @@ MultiFab::norm1 (const Vector<int>& comps, int ngrow, bool local) const
 Real
 MultiFab::sum (int comp, bool local) const
 {
-    // 0 ghost cells
-    Real sm = amrex::ReduceSum(*this, 0,
-    [=] AMREX_GPU_HOST_DEVICE (Box const& bx, Array4<Real const> const& fab) -> Real
-    {
-        Real r = 0.0;
-        AMREX_LOOP_3D(bx, i, j, k,
-        {
-            r += fab(i,j,k,comp);
-        });
-        return r;
-    });
+    BL_PROFILE("MultiFab::sum()");
 
-    if (!local)
+    Real sm = Real(0.0);
+#ifdef AMREX_USE_GPU
+    if (Gpu::inLaunchRegion()) {
+        auto const& ma = this->const_arrays();
+        sm = ParReduce(TypeList<ReduceOpSum>{}, TypeList<Real>{}, *this, IntVect(0),
+        [=] AMREX_GPU_DEVICE (int box_no, int i, int j, int k) noexcept
+                       -> GpuTuple<Real>
+        {
+            return ma[box_no](i,j,k,comp);
+        });
+    } else
+#endif
+    {
+#ifdef AMREX_USE_OMP
+#pragma omp parallel if (!system::regtest_reduction) reduction(+:sm)
+#endif
+        for (MFIter mfi(*this,true); mfi.isValid(); ++mfi)
+        {
+            Box const& bx = mfi.tilebox();
+            Array4<Real const> const& a = this->const_array(mfi);
+            Real tmp = Real(0.0);
+            AMREX_LOOP_3D(bx, i, j, k,
+            {
+                tmp += a(i,j,k,comp);
+            });
+            sm += tmp; // Do it this way so that it does not break regression tests.
+        }
+    }
+
+    if (!local) {
         ParallelAllReduce::Sum(sm, ParallelContext::CommunicatorSub());
+    }
 
     return sm;
 }
@@ -1290,7 +1702,7 @@ MultiFab::OverlapMask (const Periodicity& period) const
 
             AMREX_HOST_DEVICE_PARALLEL_FOR_3D(bx, i, j, k,
             {
-                arr(i,j,k) = 0.0;
+                arr(i,j,k) = Real(0.0);
             });
 
             for (const auto& iv : pshifts)
@@ -1355,7 +1767,7 @@ MultiFab::WeightedSync (const MultiFab& wgt, const Periodicity& period)
     }
 
     MultiFab tmpmf(boxArray(), DistributionMap(), ncomp, 0, MFInfo(), Factory());
-    tmpmf.setVal(0.0);
+    tmpmf.setVal(Real(0.0));
     tmpmf.ParallelCopy(*this, period, FabArrayBase::ADD);
 
     MultiFab::Copy(*this, tmpmf, 0, 0, ncomp, 0);

--- a/Src/Base/AMReX_ParReduce.H
+++ b/Src/Base/AMReX_ParReduce.H
@@ -1,0 +1,292 @@
+#ifndef AMREX_PAR_REDUCE_H_
+#define AMREX_PAR_REDUCE_H_
+#include <AMReX_Config.H>
+
+#include <AMReX_Reduce.H>
+
+namespace amrex {
+
+/**
+ * \brief Parallel reduce for MultiFab/FabArray.
+ *
+ * This performs reduction over a MultiFab's valid and specified ghost regions. For
+ * example, the code below computes the minimum of the first MultiFab and the maximum of
+ * the second MultiFab.
+ \verbatim
+     auto const& ma1 = mf1.const_arrays();
+     auot const& ma2 = mf2.const_arrays();
+     GpuTuple<Real,Real> mm = ParReduce(TypeList<ReduceOpMin,ReduceOpMax>{},
+                                        TypeList<Real,Real>{},
+                                        mf1, mf1.nGrowVect(),
+     [=] AMREX_GPU_DEVICE (int box_no, int i, int j, int k) noexcept
+         -> GpuTuple<Real,Real>
+     {
+         return { ma1[box_no](i,j,k), ma2[box_no](i,j,k) };
+     });
+ \endverbatim
+ *
+ * \tparam Ops... reduce operators (e.g., ReduceOpSum, ReduceOpMin, ReduceOpMax,
+ *                ReduceOpLogicalAnd, and ReduceOpLogicalOr)
+ * \tparam Ts...  data types (e.g., Real, int, etc.)
+ * \tparam FAB    MultiFab/FabArray type
+ * \tparam F      callable type like a lambda funcion
+ *
+ * \param operation_list list of reduce operators
+ * \param type_list      list of data types
+ * \param fa     a MultiFab/FabArray object used to specify the iteration space
+ * \param nghost the number of ghost cells included in the iteration space
+ * \param f      a callable object returning GpuTuple<Ts...>.  It takes four ints,
+ *               where the first int is the local box index and the others are
+ *               spatial indices for x, y, and z-directions.
+ *
+ * \return reduction result (GpuTuple<Ts...>)
+ */
+template <typename... Ops, typename... Ts, typename FAB, typename F,
+          typename foo = std::enable_if_t<IsBaseFab<FAB>::value> >
+typename ReduceData<Ts...>::Type
+ParReduce (TypeList<Ops...> operation_list, TypeList<Ts...> type_list,
+           FabArray<FAB> const& fa, IntVect const& nghost, F&& f)
+{
+    amrex::ignore_unused(operation_list,type_list);
+    ReduceOps<Ops...> reduce_op;
+    ReduceData<Ts...> reduce_data(reduce_op);
+    reduce_op.eval(fa, nghost, reduce_data, std::forward<F>(f));
+    return reduce_data.value(reduce_op);
+}
+
+/**
+ * \brief Parallel reduce for MultiFab/FabArray.
+ *
+ * This performs reduction over a MultiFab's valid and specified ghost regions. For
+ * example, the code below computes the sum of the processed data in a MultiFab.
+ \verbatim
+     auto const& ma = mf.const_arrays();
+     Real ektot = ParReduce(TypeList<ReduceOpSum>{}, TypeList<Real>{},
+                            mf, IntVect(0),
+     [=] AMREX_GPU_DEVICE (int box_no, int i, int j, int k) noexcept
+         -> GpuTuple<Real>
+     {
+         auto rho = ma[box_no](i,j,k,0);
+         auto mx = ma[box_no](i,j,k,1);
+         auto my = ma[box_no](i,j,k,2);
+         auto mz = ma[box_no](i,j,k,3);
+         auto ek = (mx*mx+my*my+mz*mz)/(2.*rho);
+         return { ek };
+     });
+ \endverbatim
+ *
+ * \tparam Op  Reduce operator (e.g., ReduceOpSum, ReduceOpMin, ReduceOpMax,
+ *             ReduceOpLogicalAnd, and ReduceOpLogicalOr)
+ * \tparam T   data type (e.g., Real, int, etc.)
+ * \tparam FAB MultiFab/FabArray type
+ * \tparam F   callable type like a lambda funcion
+ *
+ * \param operation_list a reduce operator stored in TypeList
+ * \param type_list      a data type stored in TypeList
+ * \param fa     a MultiFab/FabArray object used to specify the iteration space
+ * \param nghost the number of ghost cells included in the iteration space
+ * \param f      a callable object returning GpuTuple<T>.  It takes four ints,
+ *               where the first int is the local box index and the others are
+ *               spatial indices for x, y, and z-directions.
+ *
+ * \return reduction result (T)
+ */
+template <typename Op, typename T, typename FAB, typename F,
+          typename foo = std::enable_if_t<IsBaseFab<FAB>::value> >
+T
+ParReduce (TypeList<Op> operation_list, TypeList<T> type_list,
+           FabArray<FAB> const& fa, IntVect const& nghost, F&& f)
+{
+    amrex::ignore_unused(operation_list,type_list);
+    ReduceOps<Op> reduce_op;
+    ReduceData<T> reduce_data(reduce_op);
+    reduce_op.eval(fa, nghost, reduce_data, std::forward<F>(f));
+    auto const& hv = reduce_data.value(reduce_op);
+    return amrex::get<0>(hv);
+}
+
+/**
+ * \brief Parallel reduce for MultiFab/FabArray.
+ *
+ * This performs reduction over a MultiFab's valid and specified ghost regions and
+ * components.  For example, the code below computes the minimum of the first MultiFab
+ * and the maximum of the second MultiFab.
+ \verbatim
+     auto const& ma1 = mf1.const_arrays();
+     auot const& ma2 = mf2.const_arrays();
+     GpuTuple<Real,Real> mm = ParReduce(TypeList<ReduceOpMin,ReduceOpMax>{},
+                                        TypeList<Real,Real>{},
+                                        mf1, mf1.nGrowVect(), mf1.nComp(),
+     [=] AMREX_GPU_DEVICE (int box_no, int i, int j, int k, int n) noexcept
+         -> GpuTuple<Real,Real>
+     {
+         return { ma1[box_no](i,j,k,n), ma2[box_no](i,j,k,n) };
+     });
+ \endverbatim
+ *
+ * \tparam Ops... reduce operators (e.g., ReduceOpSum, ReduceOpMin, ReduceOpMax,
+ *                ReduceOpLogicalAnd, and ReduceOpLogicalOr)
+ * \tparam Ts...  data types (e.g., Real, int, etc.)
+ * \tparam FAB    MultiFab/FabArray type
+ * \tparam F      callable type like a lambda funcion
+ *
+ * \param operation_list list of reduce operators
+ * \param type_list      list of data types
+ * \param fa     a MultiFab/FabArray object used to specify the iteration space
+ * \param nghost the number of ghost cells included in the iteration space
+ * \param ncomp  the number of components in the iteration space
+ * \param f      a callable object returning GpuTuple<Ts...>.  It takes five ints,
+ *               where the first int is the local box index, the next three are
+ *               spatial indices for x, y, and z-directions, and the last is for
+ *               component.
+ *
+ * \return reduction result (GpuTuple<Ts...>)
+ */
+template <typename... Ops, typename... Ts, typename FAB, typename F,
+          typename foo = std::enable_if_t<IsBaseFab<FAB>::value> >
+typename ReduceData<Ts...>::Type
+ParReduce (TypeList<Ops...> operation_list, TypeList<Ts...> type_list,
+           FabArray<FAB> const& fa, IntVect const& nghost, int ncomp, F&& f)
+{
+    amrex::ignore_unused(operation_list,type_list);
+    ReduceOps<Ops...> reduce_op;
+    ReduceData<Ts...> reduce_data(reduce_op);
+    reduce_op.eval(fa, nghost, ncomp, reduce_data, std::forward<F>(f));
+    return reduce_data.value(reduce_op);
+}
+
+/**
+ * \brief Parallel reduce for MultiFab/FabArray.
+ *
+ * This performs reduction over a MultiFab's valid and specified ghost regions. For
+ * example, the code below computes the sum of the data in a MultiFab.
+ \verbatim
+     auto const& ma = mf.const_arrays();
+     Real ektot = ParReduce(TypeList<ReduceOpSum>{}, TypeList<Real>{},
+                            mf, mf.nGrowVect(), mf.nComp(),
+     [=] AMREX_GPU_DEVICE (int box_no, int i, int j, int k, int n) noexcept
+         -> GpuTuple<Real>
+     {
+         return { ma[box_no](i,j,k,n) };
+     });
+ \endverbatim
+ *
+ * \tparam Op  Reduce operator (e.g., ReduceOpSum, ReduceOpMin, ReduceOpMax,
+ *             ReduceOpLogicalAnd, and ReduceOpLogicalOr)
+ * \tparam T   data type (e.g., Real, int, etc.)
+ * \tparam FAB MultiFab/FabArray type
+ * \tparam F   callable type like a lambda funcion
+ *
+ * \param operation_list a reduce operator stored in TypeList
+ * \param type_list      a data type stored in TypeList
+ * \param fa     a MultiFab/FabArray object used to specify the iteration space
+ * \param nghost the number of ghost cells included in the iteration space
+ * \param ncomp  the number of components in the iteration space
+ * \param f      a callable object returning GpuTuple<T>.  It takes four ints,
+ *               where the first int is the local box index and the others are
+ *               spatial indices for x, y, and z-directions.
+ *
+ * \return reduction result (T)
+ */
+template <typename Op, typename T, typename FAB, typename F,
+          typename foo = std::enable_if_t<IsBaseFab<FAB>::value> >
+T
+ParReduce (TypeList<Op> operation_list, TypeList<T> type_list,
+           FabArray<FAB> const& fa, IntVect const& nghost, int ncomp, F&& f)
+{
+    amrex::ignore_unused(operation_list,type_list);
+    ReduceOps<Op> reduce_op;
+    ReduceData<T> reduce_data(reduce_op);
+    reduce_op.eval(fa, nghost, ncomp, reduce_data, std::forward<F>(f));
+    auto const& hv = reduce_data.value(reduce_op);
+    return amrex::get<0>(hv);
+}
+
+/**
+ * \brief Parallel reduce for MultiFab/FabArray.
+ *
+ * This performs reduction over a MultiFab's valid region. For
+ * example, the code below computes the minimum of the first MultiFab and the maximum of
+ * the second MultiFab.
+ \verbatim
+     auto const& ma1 = mf1.const_arrays();
+     auot const& ma2 = mf2.const_arrays();
+     GpuTuple<Real,Real> mm = ParReduce(TypeList<ReduceOpMin,ReduceOpMax>{},
+                                        TypeList<Real,Real>{}, mf1,
+     [=] AMREX_GPU_DEVICE (int box_no, int i, int j, int k) noexcept
+         -> GpuTuple<Real,Real>
+     {
+         return { ma1[box_no](i,j,k), ma2[box_no](i,j,k) };
+     });
+ \endverbatim
+ *
+ * \tparam Ops... reduce operators (e.g., ReduceOpSum, ReduceOpMin, ReduceOpMax,
+ *                ReduceOpLogicalAnd, and ReduceOpLogicalOr)
+ * \tparam Ts...  data types (e.g., Real, int, etc.)
+ * \tparam FAB    MultiFab/FabArray type
+ * \tparam F      callable type like a lambda funcion
+ *
+ * \param operation_list list of reduce operators
+ * \param type_list      list of data types
+ * \param fa     a MultiFab/FabArray object used to specify the iteration space
+ * \param f      a callable object returning GpuTuple<Ts...>.  It takes four ints,
+ *               where the first int is the local box index and the others are
+ *               spatial indices for x, y, and z-directions.
+ *
+ * \return reduction result (GpuTuple<Ts...>)
+ */
+template <typename... Ops, typename... Ts, typename FAB, typename F,
+          typename foo = std::enable_if_t<IsBaseFab<FAB>::value> >
+typename ReduceData<Ts...>::Type
+ParReduce (TypeList<Ops...> operation_list, TypeList<Ts...> type_list,
+           FabArray<FAB> const& fa, F&& f)
+{
+    return ParReduce(operation_list, type_list, fa, IntVect(0), std::forward<F>(f));
+}
+
+/**
+ * \brief Parallel reduce for MultiFab/FabArray.
+ *
+ * This performs reduction over a MultiFab's valid region. For
+ * example, the code below computes the sum of the processed data in a MultiFab.
+ \verbatim
+     auto const& ma = mf.const_arrays();
+     Real ektot = ParReduce(TypeList<ReduceOpSum>{}, TypeList<Real>{}, mf,
+     [=] AMREX_GPU_DEVICE (int box_no, int i, int j, int k) noexcept
+         -> GpuTuple<Real>
+     {
+         auto rho = ma[box_no](i,j,k,0);
+         auto mx = ma[box_no](i,j,k,1);
+         auto my = ma[box_no](i,j,k,2);
+         auto mz = ma[box_no](i,j,k,3);
+         auto ek = (mx*mx+my*my+mz*mz)/(2.*rho);
+         return { ek };
+     });
+ \endverbatim
+ *
+ * \tparam Op  Reduce operator (e.g., ReduceOpSum, ReduceOpMin, ReduceOpMax,
+ *             ReduceOpLogicalAnd, and ReduceOpLogicalOr)
+ * \tparam T   data type (e.g., Real, int, etc.)
+ * \tparam FAB MultiFab/FabArray type
+ * \tparam F   callable type like a lambda funcion
+ *
+ * \param operation_list a reduce operator stored in TypeList
+ * \param type_list      a data type stored in TypeList
+ * \param fa     a MultiFab/FabArray object used to specify the iteration space
+ * \param f      a callable object returning GpuTuple<T>.  It takes four ints,
+ *               where the first int is the local box index and the others are
+ *               spatial indices for x, y, and z-directions.
+ *
+ * \return reduction result (T)
+ */
+template <typename Op, typename T, typename FAB, typename F,
+          typename foo = std::enable_if_t<IsBaseFab<FAB>::value> >
+T
+ParReduce (TypeList<Op> operation_list, TypeList<T> type_list,
+           FabArray<FAB> const& fa, F&& f)
+{
+    return ParReduce(operation_list, type_list, fa, IntVect(0), std::forward<F>(f));
+}
+
+}
+#endif

--- a/Src/Base/AMReX_Reduce.H
+++ b/Src/Base/AMReX_Reduce.H
@@ -5,6 +5,7 @@
 #include <AMReX_Gpu.H>
 #include <AMReX_Arena.H>
 #include <AMReX_OpenMP.H>
+#include <AMReX_MFIter.H>
 
 #include <algorithm>
 #include <functional>
@@ -16,14 +17,14 @@ namespace Reduce { namespace detail {
 #ifdef AMREX_USE_GPU
 #ifdef AMREX_USE_DPCPP
     template <std::size_t I, typename T, typename P>
-    AMREX_GPU_DEVICE
+    AMREX_GPU_DEVICE AMREX_FORCE_INLINE
     void for_each_parallel (T& d, T const& s, Gpu::Handler const& h)
     {
         P().parallel_update(amrex::get<I>(d), amrex::get<I>(s), h);
     }
 
     template <std::size_t I, typename T, typename P, typename P1, typename... Ps>
-    AMREX_GPU_DEVICE
+    AMREX_GPU_DEVICE AMREX_FORCE_INLINE
     void for_each_parallel (T& d, T const& s, Gpu::Handler const& h)
     {
         P().parallel_update(amrex::get<I>(d), amrex::get<I>(s), h);
@@ -31,14 +32,14 @@ namespace Reduce { namespace detail {
     }
 #else
     template <std::size_t I, typename T, typename P>
-    AMREX_GPU_DEVICE
+    AMREX_GPU_DEVICE AMREX_FORCE_INLINE
     void for_each_parallel (T& d, T const& s)
     {
         P().parallel_update(amrex::get<I>(d), amrex::get<I>(s));
     }
 
     template <std::size_t I, typename T, typename P, typename P1, typename... Ps>
-    AMREX_GPU_DEVICE
+    AMREX_GPU_DEVICE AMREX_FORCE_INLINE
     void for_each_parallel (T& d, T const& s)
     {
         P().parallel_update(amrex::get<I>(d), amrex::get<I>(s));
@@ -48,14 +49,14 @@ namespace Reduce { namespace detail {
 #endif
 
     template <std::size_t I, typename T, typename P>
-    AMREX_GPU_HOST_DEVICE
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     void for_each_local (T& d, T const& s)
     {
         P().local_update(amrex::get<I>(d), amrex::get<I>(s));
     }
 
     template <std::size_t I, typename T, typename P, typename P1, typename... Ps>
-    AMREX_GPU_HOST_DEVICE
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     void for_each_local (T& d, T const& s)
     {
         P().local_update(amrex::get<I>(d), amrex::get<I>(s));
@@ -63,14 +64,14 @@ namespace Reduce { namespace detail {
     }
 
     template <std::size_t I, typename T, typename P>
-    AMREX_GPU_HOST_DEVICE
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     void for_each_init (T& t)
     {
         P().init(amrex::get<I>(t));
     }
 
     template <std::size_t I, typename T, typename P, typename P1, typename... Ps>
-    AMREX_GPU_HOST_DEVICE
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     void for_each_init (T& t)
     {
         P().init(amrex::get<I>(t));
@@ -167,48 +168,64 @@ struct ReduceOpLogicalAnd
 {
 #ifdef AMREX_USE_GPU
 #ifdef AMREX_USE_DPCPP
+    template <typename T>
     AMREX_GPU_DEVICE AMREX_FORCE_INLINE
-    void parallel_update (int& d, int s, Gpu::Handler const& h) const noexcept {
-        int r = Gpu::blockReduceLogicalAnd(s,h);
+    std::enable_if_t<std::is_integral<T>::value>
+    parallel_update (T& d, T s, Gpu::Handler const& h) const noexcept {
+        T r = Gpu::blockReduceLogicalAnd(s,h);
         if (h.threadIdx() == 0) { d = d && r; }
     }
 #else
+    template <typename T>
     AMREX_GPU_DEVICE AMREX_FORCE_INLINE
-    void parallel_update (int& d, int s) const noexcept {
-        int r = Gpu::blockReduceLogicalAnd<AMREX_GPU_MAX_THREADS>(s);
+    std::enable_if_t<std::is_integral<T>::value>
+    parallel_update (T& d, T s) const noexcept {
+        T r = Gpu::blockReduceLogicalAnd<AMREX_GPU_MAX_THREADS>(s);
         if (threadIdx.x == 0) { d = d && r; }
     }
 #endif
 #endif
 
+    template <typename T>
     AMREX_GPU_DEVICE AMREX_FORCE_INLINE
-    void local_update (int& d, int s) const noexcept { d = d && s; }
+    std::enable_if_t<std::is_integral<T>::value>
+    local_update (T& d, T s) const noexcept { d = d && s; }
 
-    constexpr void init (int& t) const noexcept { t = true; }
+    template <typename T>
+    constexpr std::enable_if_t<std::is_integral<T>::value>
+    init (T& t) const noexcept { t = true; }
 };
 
 struct ReduceOpLogicalOr
 {
 #ifdef AMREX_USE_GPU
 #ifdef AMREX_USE_DPCPP
+    template <typename T>
     AMREX_GPU_DEVICE AMREX_FORCE_INLINE
-    void parallel_update (int& d, int s, Gpu::Handler const& h) const noexcept {
-        int r = Gpu::blockReduceLogicalOr(s,h);
+    std::enable_if_t<std::is_integral<T>::value>
+    parallel_update (T& d, T s, Gpu::Handler const& h) const noexcept {
+        T r = Gpu::blockReduceLogicalOr(s,h);
         if (h.threadIdx() == 0) { d = d || r; }
     }
 #else
+    template <typename T>
     AMREX_GPU_DEVICE AMREX_FORCE_INLINE
-    void parallel_update (int& d, int s) const noexcept {
-        int r = Gpu::blockReduceLogicalOr<AMREX_GPU_MAX_THREADS>(s);
+    std::enable_if_t<std::is_integral<T>::value>
+    parallel_update (T& d, T s) const noexcept {
+        T r = Gpu::blockReduceLogicalOr<AMREX_GPU_MAX_THREADS>(s);
         if (threadIdx.x == 0) { d = d || r; }
     }
 #endif
 #endif
 
+    template <typename T>
     AMREX_GPU_DEVICE AMREX_FORCE_INLINE
-    void local_update (int& d, int s) const noexcept { d = d || s; }
+    std::enable_if_t<std::is_integral<T>::value>
+    local_update (T& d, T s) const noexcept { d = d || s; }
 
-    constexpr void init (int& t) const noexcept { t = false; }
+    template <typename T>
+    constexpr std::enable_if_t<std::is_integral<T>::value>
+    init (T& t) const noexcept { t = false; }
 };
 
 template <typename... Ps> class ReduceOps;
@@ -223,11 +240,10 @@ public:
 
     template <typename... Ps>
     explicit ReduceData (ReduceOps<Ps...>& reduce_op)
-        : m_host_tuple((Type*)(The_Pinned_Arena()->alloc(sizeof(Type)))),
+        : m_max_blocks(Gpu::Device::maxBlocksPerLaunch()),
+          m_host_tuple((Type*)(The_Pinned_Arena()->alloc(sizeof(Type)))),
           m_device_tuple((Type*)(The_Arena()->alloc((AMREX_GPU_MAX_STREAMS+1)
-                                                    *Gpu::Device::maxBlocksPerLaunch()
-                                                    *sizeof(Type)))),
-          m_max_blocks(Gpu::Device::maxBlocksPerLaunch()),
+                                                    * m_max_blocks * sizeof(Type)))),
           m_fn_value([&reduce_op,this] () -> Type { return this->value(reduce_op); })
     {
         static_assert(std::is_trivially_copyable<Type>(),
@@ -273,9 +289,9 @@ public:
     int maxBlocks () const { return m_max_blocks; }
 
 private:
+    int m_max_blocks;
     Type* m_host_tuple = nullptr;
     Type* m_device_tuple = nullptr;
-    int m_max_blocks;
     GpuArray<int,AMREX_GPU_MAX_STREAMS+1> m_nblocks;
     std::function<Type()> m_fn_value;
 };
@@ -299,12 +315,165 @@ namespace Reduce { namespace detail {
                      IntVect(AMREX_D_DECL(i,j,k)),
                      t));
     }
+
+    struct iterate_box {};
+    struct iterate_box_comp {};
+
+    template <typename I, typename F, typename T, typename... Ps,
+              std::enable_if_t<std::is_same<iterate_box,I>::value,int> = 0>
+    AMREX_GPU_DEVICE AMREX_FORCE_INLINE
+    void mf_call_f (F const& f, int ibox, int i, int j, int k, int, T& r) noexcept
+    {
+        auto const& pr = f(ibox,i,j,k);
+        Reduce::detail::for_each_local<0, T, Ps...>(r, pr);
+    }
+
+    template <typename I, typename F, typename T, typename... Ps,
+              std::enable_if_t<std::is_same<iterate_box_comp,I>::value,int> = 0>
+    AMREX_GPU_DEVICE AMREX_FORCE_INLINE
+    void mf_call_f (F const& f, int ibox, int i, int j, int k, int ncomp, T& r) noexcept
+    {
+        for (int n = 0; n < ncomp; ++n) {
+            auto const& pr = f(ibox,i,j,k,n);
+            Reduce::detail::for_each_local<0, T, Ps...>(r, pr);
+        }
+    }
 }}
 
 template <typename... Ps>
 class ReduceOps
 {
 public:
+
+    // This is public for CUDA
+    template <typename I, typename MF, typename D, typename F>
+    void eval_mf (I, MF const& mf, IntVect const& nghost, int ncomp, D& reduce_data, F&&f)
+    {
+        using ReduceTuple = typename D::Type;
+        const int nboxes = mf.local_size();
+        if (nboxes > 0) {
+            auto const& parforinfo = mf.getParForInfo(nghost,AMREX_GPU_MAX_THREADS);
+            auto par_for_blocks = parforinfo.getBlocks();
+            const int nblocks = par_for_blocks.first[nboxes];
+            const int block_0_size = par_for_blocks.first[1];
+            const int* dp_nblocks = par_for_blocks.second;
+            const Box* dp_boxes = parforinfo.getBoxes();
+
+            auto const& stream = Gpu::gpuStream();
+            auto pdst = reduce_data.devicePtr(stream);
+            int nblocks_ec = std::min(nblocks, reduce_data.maxBlocks());
+            reduce_data.nBlocks(stream) = nblocks_ec;
+
+#ifdef AMREX_USE_DPCPP
+            // device reduce needs local(i.e., shared) memory
+            constexpr std::size_t shared_mem_bytes = sizeof(unsigned long long)*Gpu::Device::warp_size;
+            amrex::launch(nblocks_ec, AMREX_GPU_MAX_THREADS, shared_mem_bytes, stream,
+                          [=] AMREX_GPU_DEVICE (Gpu::Handler const& gh) noexcept
+            {
+                Dim1 blockIdx {gh.blockIdx()};
+                Dim1 threadIdx{gh.threadIdx()};
+#else
+            amrex::launch_global<AMREX_GPU_MAX_THREADS>
+                <<<nblocks_ec, AMREX_GPU_MAX_THREADS, 0, stream>>>
+                ([=] AMREX_GPU_DEVICE () noexcept
+            {
+#endif
+                ReduceTuple r;
+                Reduce::detail::for_each_init<0, ReduceTuple, Ps...>(r);
+                ReduceTuple& dst = pdst[blockIdx.x];
+                if (threadIdx.x == 0) {
+                    dst = r;
+                }
+                for (int iblock = blockIdx.x; iblock < nblocks; iblock += nblocks_ec) {
+                    int ibox, icell;
+                    if (dp_nblocks) {
+                        ibox = amrex::bisect(dp_nblocks, 0, nboxes, iblock);
+                        icell = (iblock-dp_nblocks[ibox])*AMREX_GPU_MAX_THREADS + threadIdx.x;
+                    } else {
+                        ibox = iblock / block_0_size;
+                        icell = (iblock-ibox*block_0_size)*AMREX_GPU_MAX_THREADS + threadIdx.x;
+                    }
+
+                    Box const& b = dp_boxes[ibox];
+                    int ncells = b.numPts();
+                    if (icell < ncells) {
+                        const auto len = amrex::length(b);
+                        int k =  icell /   (len.x*len.y);
+                        int j = (icell - k*(len.x*len.y)) /   len.x;
+                        int i = (icell - k*(len.x*len.y)) - j*len.x;
+                        AMREX_D_TERM(i += b.smallEnd(0);,
+                                     j += b.smallEnd(1);,
+                                     k += b.smallEnd(2););
+                        Reduce::detail::mf_call_f<I, F, ReduceTuple, Ps...>
+                            (f, ibox, i, j, k, ncomp, r);
+                    }
+                }
+#ifdef AMREX_USE_DPCPP
+                Reduce::detail::for_each_parallel<0, ReduceTuple, Ps...>(dst, r, gh);
+#else
+                Reduce::detail::for_each_parallel<0, ReduceTuple, Ps...>(dst, r);
+#endif
+            });
+        }
+    }
+
+    template <typename MF, typename D, typename F>
+    std::enable_if_t<IsFabArray<MF>::value
+#ifndef AMREX_USE_CUDA
+                     && IsCallable<F, int, int, int, int>::value
+#endif
+                    >
+    eval (MF const& mf, IntVect const& nghost, D& reduce_data, F&& f)
+    {
+        using ReduceTuple = typename D::Type;
+        const int nboxes = mf.local_size();
+        if (nboxes == 0) {
+            return;
+        } else if (!mf.isFusingCandidate()) {
+            for (MFIter mfi(mf); mfi.isValid(); ++mfi) {
+                Box const& b = amrex::grow(mfi.validbox(), nghost);
+                const int li = mfi.LocalIndex();
+                this->eval(b, reduce_data,
+                [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept -> ReduceTuple
+                {
+                    return f(li, i, j, k);
+                });
+            }
+        } else {
+            eval_mf(Reduce::detail::iterate_box{},
+                    mf, nghost, 0, reduce_data, std::forward<F>(f));
+        }
+    }
+
+    template <typename MF, typename D, typename F>
+    std::enable_if_t<IsFabArray<MF>::value
+#ifndef AMREX_USE_CUDA
+                     && IsCallable<F, int, int, int, int, int>::value
+#endif
+                     >
+    eval (MF const& mf, IntVect const& nghost, int ncomp, D& reduce_data, F&& f)
+    {
+        using ReduceTuple = typename D::Type;
+
+        const int nboxes = mf.local_size();
+
+        if (nboxes == 0) {
+            return;
+        } else if (!mf.isFusingCandidate()) {
+            for (MFIter mfi(mf); mfi.isValid(); ++mfi) {
+                Box const& b = amrex::grow(mfi.validbox(), nghost);
+                const int li = mfi.LocalIndex();
+                this->eval(b, ncomp, reduce_data,
+                [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept -> ReduceTuple
+                {
+                    return f(li, i, j, k, n);
+                });
+            }
+        } else {
+            eval_mf(Reduce::detail::iterate_box_comp{},
+                    mf, nghost, ncomp, reduce_data, std::forward<F>(f));
+        }
+    }
 
     template <typename D, typename F>
     void eval (Box const& box, D & reduce_data, F&& f)
@@ -322,36 +491,22 @@ public:
         constexpr int nitems_per_thread = 4;
         int nblocks_ec = (ncells + nitems_per_thread*AMREX_GPU_MAX_THREADS-1)
             / (nitems_per_thread*AMREX_GPU_MAX_THREADS);
-        nblocks_ec = std::min(nblocks_ec, static_cast<int>(Gpu::Device::maxBlocksPerLaunch()));
+        nblocks_ec = std::min(nblocks_ec, reduce_data.maxBlocks());
 #ifdef AMREX_USE_DPCPP
         // device reduce needs local(i.e., shared) memory
         constexpr std::size_t shared_mem_bytes = sizeof(unsigned long long)*Gpu::Device::warp_size;
         amrex::launch(nblocks_ec, AMREX_GPU_MAX_THREADS, shared_mem_bytes, stream,
         [=] AMREX_GPU_DEVICE (Gpu::Handler const& gh) noexcept
         {
-            ReduceTuple r;
-            Reduce::detail::for_each_init<0, ReduceTuple, Ps...>(r);
-            ReduceTuple& dst = *(dp+gh.blockIdx());
-            if (gh.threadIdx() == 0 && gh.blockIdx() >= nblocks) {
-                dst = r;
-            }
-            for (int icell = gh.item->get_global_id(0), stride = gh.item->get_global_range(0);
-                 icell < ncells; icell += stride) {
-                int k =  icell /   lenxy;
-                int j = (icell - k*lenxy) /   lenx;
-                int i = (icell - k*lenxy) - j*lenx;
-                i += lo.x;
-                j += lo.y;
-                k += lo.z;
-                auto pr = Reduce::detail::call_f(f,i,j,k,ixtype);
-                Reduce::detail::for_each_local<0, ReduceTuple, Ps...>(r, pr);
-            }
-            Reduce::detail::for_each_parallel<0, ReduceTuple, Ps...>(dst, r, gh);
-        });
+            Dim1 blockIdx {gh.blockIdx()};
+            Dim1 threadIdx{gh.threadIdx()};
+            Dim1 blockDim {gh.blockDim()};
+            Dim1 gridDim  {gh.blockDim()};
 #else
         amrex::launch(nblocks_ec, AMREX_GPU_MAX_THREADS, 0, stream,
         [=] AMREX_GPU_DEVICE () noexcept
         {
+#endif
             ReduceTuple r;
             Reduce::detail::for_each_init<0, ReduceTuple, Ps...>(r);
             ReduceTuple& dst = *(dp+blockIdx.x);
@@ -369,9 +524,12 @@ public:
                 auto pr = Reduce::detail::call_f(f,i,j,k,ixtype);
                 Reduce::detail::for_each_local<0, ReduceTuple, Ps...>(r, pr);
             }
+#ifdef AMREX_USE_DPCPP
+            Reduce::detail::for_each_parallel<0, ReduceTuple, Ps...>(dst, r, gh);
+#else
             Reduce::detail::for_each_parallel<0, ReduceTuple, Ps...>(dst, r);
-        });
 #endif
+        });
         nblocks = std::max(nblocks, nblocks_ec);
     }
 
@@ -391,37 +549,22 @@ public:
         constexpr int nitems_per_thread = 4;
         int nblocks_ec = (ncells + nitems_per_thread*AMREX_GPU_MAX_THREADS-1)
             / (nitems_per_thread*AMREX_GPU_MAX_THREADS);
-        nblocks_ec = std::min(nblocks_ec, static_cast<int>(Gpu::Device::maxBlocksPerLaunch()));
+        nblocks_ec = std::min(nblocks_ec, reduce_data.maxBlocks());
 #ifdef AMREX_USE_DPCPP
         // device reduce needs local(i.e., shared) memory
         constexpr std::size_t shared_mem_bytes = sizeof(unsigned long long)*Gpu::Device::warp_size;
         amrex::launch(nblocks_ec, AMREX_GPU_MAX_THREADS, shared_mem_bytes, stream,
         [=] AMREX_GPU_DEVICE (Gpu::Handler const& gh) noexcept
         {
-            ReduceTuple r;
-            Reduce::detail::for_each_init<0, ReduceTuple, Ps...>(r);
-            ReduceTuple& dst = *(dp+gh.blockIdx());
-            if (gh.threadIdx() == 0 && gh.blockIdx() >= nblocks) {
-                dst = r;
-            }
-            for (int icell = gh.item->get_global_id(0), stride = gh.item->get_global_range(0);
-                 icell < ncells; icell += stride) {
-                int k =  icell /   lenxy;
-                int j = (icell - k*lenxy) /   lenx;
-                int i = (icell - k*lenxy) - j*lenx;
-                i += lo.x;
-                j += lo.y;
-                k += lo.z;
-                for (N n = 0; n < ncomp; ++n) {
-                    auto pr = f(i,j,k,n);
-                    Reduce::detail::for_each_local<0, ReduceTuple, Ps...>(r, pr);
-                }
-            }
-            Reduce::detail::for_each_parallel<0, ReduceTuple, Ps...>(dst, r, gh);
-        });
+            Dim1 blockIdx {gh.blockIdx()};
+            Dim1 threadIdx{gh.threadIdx()};
+            Dim1 blockDim {gh.blockDim()};
+            Dim1 gridDim  {gh.blockDim()};
 #else
         amrex::launch(nblocks_ec, AMREX_GPU_MAX_THREADS, 0, stream,
-        [=] AMREX_GPU_DEVICE () noexcept {
+        [=] AMREX_GPU_DEVICE () noexcept
+        {
+#endif
             ReduceTuple r;
             Reduce::detail::for_each_init<0, ReduceTuple, Ps...>(r);
             ReduceTuple& dst = *(dp+blockIdx.x);
@@ -441,9 +584,12 @@ public:
                     Reduce::detail::for_each_local<0, ReduceTuple, Ps...>(r, pr);
                 }
             }
+#ifdef AMREX_USE_DPCPP
+            Reduce::detail::for_each_parallel<0, ReduceTuple, Ps...>(dst, r, gh);
+#else
             Reduce::detail::for_each_parallel<0, ReduceTuple, Ps...>(dst, r);
-        });
 #endif
+        });
         nblocks = std::max(nblocks, nblocks_ec);
     }
 
@@ -459,29 +605,22 @@ public:
         constexpr int nitems_per_thread = 4;
         int nblocks_ec = (n + nitems_per_thread*AMREX_GPU_MAX_THREADS-1)
             / (nitems_per_thread*AMREX_GPU_MAX_THREADS);
-        nblocks_ec = std::min(nblocks_ec, static_cast<int>(Gpu::Device::maxBlocksPerLaunch()));
+        nblocks_ec = std::min(nblocks_ec, reduce_data.maxBlocks());
 #ifdef AMREX_USE_DPCPP
         // device reduce needs local(i.e., shared) memory
         constexpr std::size_t shared_mem_bytes = sizeof(unsigned long long)*Gpu::Device::warp_size;
         amrex::launch(nblocks_ec, AMREX_GPU_MAX_THREADS, shared_mem_bytes, stream,
         [=] AMREX_GPU_DEVICE (Gpu::Handler const& gh) noexcept
         {
-            ReduceTuple r;
-            Reduce::detail::for_each_init<0, ReduceTuple, Ps...>(r);
-            ReduceTuple& dst = *(dp+gh.blockIdx());
-            if (gh.threadIdx() == 0 && gh.blockIdx() >= nblocks) {
-                dst = r;
-            }
-            for (N i = gh.item->get_global_id(0), stride = gh.item->get_global_range(0);
-                 i < n; i += stride) {
-                auto pr = f(i);
-                Reduce::detail::for_each_local<0, ReduceTuple, Ps...>(r,pr);
-            }
-            Reduce::detail::for_each_parallel<0, ReduceTuple, Ps...>(dst, r, gh);
-        });
+            Dim1 blockIdx {gh.blockIdx()};
+            Dim1 threadIdx{gh.threadIdx()};
+            Dim1 blockDim {gh.blockDim()};
+            Dim1 gridDim  {gh.blockDim()};
 #else
         amrex::launch(nblocks_ec, AMREX_GPU_MAX_THREADS, 0, stream,
-        [=] AMREX_GPU_DEVICE () noexcept {
+        [=] AMREX_GPU_DEVICE () noexcept
+        {
+#endif
             ReduceTuple r;
             Reduce::detail::for_each_init<0, ReduceTuple, Ps...>(r);
             ReduceTuple& dst = *(dp+blockIdx.x);
@@ -493,9 +632,12 @@ public:
                 auto pr = f(i);
                 Reduce::detail::for_each_local<0, ReduceTuple, Ps...>(r,pr);
             }
+#ifdef AMREX_USE_DPCPP
+            Reduce::detail::for_each_parallel<0, ReduceTuple, Ps...>(dst, r, gh);
+#else
             Reduce::detail::for_each_parallel<0, ReduceTuple, Ps...>(dst, r);
-        });
 #endif
+        });
         nblocks = amrex::max(nblocks, nblocks_ec);
     }
 
@@ -867,6 +1009,51 @@ private:
     }
 
 public:
+
+    template <typename MF, typename D, typename F>
+    std::enable_if_t<IsFabArray<MF>::value && IsCallable<F, int, int, int, int>::value>
+    eval (MF const& mf, IntVect const& nghost, D & reduce_data, F&& f)
+    {
+        using ReduceTuple = typename D::Type;
+#ifdef AMREX_USE_OMP
+#pragma omp parallel
+#endif
+        for (MFIter mfi(mf,true); mfi.isValid(); ++mfi) {
+            Box const& b = mfi.growntilebox(nghost);
+            const int li = mfi.LocalIndex();
+            auto& rr = reduce_data.reference(OpenMP::get_thread_num());
+            const auto lo = amrex::lbound(b);
+            const auto hi = amrex::ubound(b);
+            for (int k = lo.z; k <= hi.z; ++k) {
+            for (int j = lo.y; j <= hi.y; ++j) {
+            for (int i = lo.x; i <= hi.x; ++i) {
+                Reduce::detail::for_each_local<0, ReduceTuple, Ps...>(rr, f(li,i,j,k));
+            }}}
+        }
+    }
+
+    template <typename MF, typename D, typename F>
+    std::enable_if_t<IsFabArray<MF>::value && IsCallable<F, int, int, int, int, int>::value>
+    eval (MF const& mf, IntVect const& nghost, int ncomp, D & reduce_data, F&& f)
+    {
+        using ReduceTuple = typename D::Type;
+#ifdef AMREX_USE_OMP
+#pragma omp parallel
+#endif
+        for (MFIter mfi(mf,true); mfi.isValid(); ++mfi) {
+            Box const& b = mfi.growntilebox(nghost);
+            const int li = mfi.LocalIndex();
+            auto& rr = reduce_data.reference(OpenMP::get_thread_num());
+            const auto lo = amrex::lbound(b);
+            const auto hi = amrex::ubound(b);
+            for (int n = 0; n < ncomp; ++n) {
+            for (int k = lo.z; k <= hi.z; ++k) {
+            for (int j = lo.y; j <= hi.y; ++j) {
+            for (int i = lo.x; i <= hi.x; ++i) {
+                Reduce::detail::for_each_local<0, ReduceTuple, Ps...>(rr, f(li,i,j,k,n));
+            }}}}
+        }
+    }
 
     template <typename D, typename F>
     void eval (Box const& box, D & reduce_data, F&& f)

--- a/Src/Base/AMReX_Tuple.H
+++ b/Src/Base/AMReX_Tuple.H
@@ -16,6 +16,8 @@
 namespace amrex {
     template <class... Ts>
     using Tuple = std::tuple<Ts...>;
+
+    template <class... Ts> struct TypeList {};
 }
 
 namespace amrex {

--- a/Src/Base/CMakeLists.txt
+++ b/Src/Base/CMakeLists.txt
@@ -214,6 +214,7 @@ target_sources( amrex
    AMReX_MFParallelForC.H
    AMReX_MFParallelForG.H
    AMReX_TagParallelFor.H
+   AMReX_ParReduce.H
    # CUDA --------------------------------------------------------------------
    AMReX_CudaGraph.H
    # Machine model -----------------------------------------------------------

--- a/Src/Base/Make.package
+++ b/Src/Base/Make.package
@@ -98,6 +98,8 @@ C$(AMREX_BASE)_headers += AMReX_MFParallelForG.H
 
 C$(AMREX_BASE)_headers += AMReX_TagParallelFor.H
 
+C$(AMREX_BASE)_headers += AMReX_ParReduce.H
+
 #
 # I/O stuff.
 #

--- a/Src/LinearSolvers/MLMG/AMReX_MLCGSolver.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLCGSolver.cpp
@@ -410,10 +410,7 @@ Real
 MLCGSolver::norm_inf (const MultiFab& res, bool local)
 {
     int ncomp = res.nComp();
-    Real result = std::numeric_limits<Real>::lowest();
-    for (int n=0; n<ncomp; n++)
-      result = std::max(result,res.norm0(n,0,true));
-
+    Real result = res.norm0(0,ncomp,IntVect(0),true);
     if (!local) {
         BL_PROFILE("MLCGSolver::ParallelAllReduce");
         ParallelAllReduce::Max(result, Lp.BottomCommunicator());


### PR DESCRIPTION
* Add ParReduce functions for MultiFab/FabArray and 1D iteration space.

* The implementation of ParReduce(MF) uses new ReduceOps::eval functions that launch one
  GPU kernel for the whole MultiFab/MultiFab.

* Use the new ParReduce functions in MultiFab/FabArray reduction functions.

## Additional background

The name `ParallelReduce` has been used for the namespace containing MPI reduce wrappers.  So we have to use a different name.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [x] include documentation in the code and/or rst files, if appropriate
