### PR TITLE
NodeLaplacian Updates

### DIFF
--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian.H
@@ -82,6 +82,10 @@ public :
         if (m_const_sigma == Real(0.0)) m_coarsening_strategy = cs;
     }
 
+    void setSmoothNumSweeps (int nsweeps) noexcept {
+        m_smooth_num_sweeps = nsweeps;
+    }
+
     virtual BottomSolver getDefaultBottomSolver () const final override {
         return (m_coarsening_strategy == CoarseningStrategy::RAP) ?
             BottomSolver::bicgcg : BottomSolver::bicgstab;

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLinOp.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLinOp.H
@@ -142,7 +142,11 @@ protected:
     bool m_is_bottom_singular = false;
     bool m_masks_built = false;
     bool m_overset_dirichlet_mask = false;
-
+#ifdef AMREX_USE_GPU
+    int m_smooth_num_sweeps = 4;
+#else
+    int m_smooth_num_sweeps = 2;
+#endif
     mutable bool m_in_solution_mode = true;
 };
 

--- a/Tests/LinearSolvers/NodalPoisson/MyTest.H
+++ b/Tests/LinearSolvers/NodalPoisson/MyTest.H
@@ -20,6 +20,9 @@ public:
 
     void initData ();
 
+    int getNumTrials() { return num_trials; }
+    int getDoPlots() { return do_plots; }
+
 private:
 
     void readParameters ();
@@ -45,8 +48,11 @@ private:
     bool semicoarsening = false;
     int max_coarsening_level = 30;
     int max_semicoarsening_level = 0;
+    //int smooth_num_sweeps = 4;
 
     bool use_hypre = false;
+    bool do_plots = true;
+    int num_trials = 1;
 
 #ifdef AMREX_USE_HYPRE
     int hypre_interface_i = 1;  // 1. structed, 2. semi-structed, 3. ij

--- a/Tests/LinearSolvers/NodalPoisson/MyTest.cpp
+++ b/Tests/LinearSolvers/NodalPoisson/MyTest.cpp
@@ -16,6 +16,7 @@ MyTest::MyTest ()
 void
 MyTest::solve ()
 {
+    BL_PROFILE("NodalPoisson::solve()");
     LPInfo info;
     info.setAgglomeration(agglomeration);
     info.setConsolidation(consolidation);
@@ -26,6 +27,7 @@ MyTest::solve ()
     if (composite_solve)
     {
         MLNodeLaplacian linop(geom, grids, dmap, info);
+        //linop.setSmoothNumSweeps(smooth_num_sweeps);
 
         linop.setDomainBC({AMREX_D_DECL(LinOpBCType::Dirichlet,
                                         LinOpBCType::Dirichlet,
@@ -157,6 +159,10 @@ MyTest::readParameters ()
     pp.query("semicoarsening", semicoarsening);
     pp.query("max_coarsening_level", max_coarsening_level);
     pp.query("max_semicoarsening_level", max_semicoarsening_level);
+    //pp.query("smooth_num_sweeps", smooth_num_sweeps);
+
+    pp.query("do_plots", do_plots);
+    pp.query("num_trials", num_trials);
 
 #ifdef AMREX_USE_HYPRE
     pp.query("use_hypre", use_hypre);

--- a/Tests/LinearSolvers/NodalPoisson/main.cpp
+++ b/Tests/LinearSolvers/NodalPoisson/main.cpp
@@ -9,9 +9,12 @@ int main (int argc, char* argv[])
     {
         BL_PROFILE("main");
         MyTest mytest;
-        mytest.solve();
-        mytest.compute_norms();
-        mytest.writePlotfile();
+        for(int i=0;i<mytest.getNumTrials();++i) {
+            mytest.solve();
+            mytest.compute_norms();
+        }
+        if (mytest.getDoPlots())
+            mytest.writePlotfile();
     }
 
     amrex::Finalize();


### PR DESCRIPTION
In this branch, I make the number of smoothing steps a user defined parameter. Previously it was fixed at 4 for GPUs and 2 for CPUs. I'm not sure why GPU and CPU had different settings. I set the default to 2 for both.

I also modified the NodalPoisson test to 
1) use this new parameter
2) include additional parameters that control plot file dumping and the number of trials of the test to be run.

## Summary

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [x] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
