### PR TITLE
Remove macro: CRSEGRNDOMP and AMREX_CRSEGRNDOMP

### DIFF
--- a/Src/Amr/AMReX_AmrLevel.cpp
+++ b/Src/Amr/AMReX_AmrLevel.cpp
@@ -1066,10 +1066,8 @@ FillPatchIterator::Initialize (int  boxGrow,
                                                   NComp,
                                                   desc.interp(SComp));
 
-#if defined(AMREX_CRSEGRNDOMP) || (!defined(AMREX_XSDK) && defined(CRSEGRNDOMP))
 #ifdef AMREX_USE_OMP
 #pragma omp parallel
-#endif
 #endif
                 for (MFIter mfi(m_fabs); mfi.isValid(); ++mfi)
                 {
@@ -1664,7 +1662,6 @@ AmrLevel::derive (const std::string& name, Real time, int ngrow)
         }
         else
         {
-#if defined(AMREX_CRSEGRNDOMP) || (!defined(AMREX_XSDK) && defined(CRSEGRNDOMP))
 #ifdef AMREX_USE_OMP
 #pragma omp parallel
 #endif
@@ -1709,46 +1706,6 @@ AmrLevel::derive (const std::string& name, Real time, int ngrow)
                amrex::Error("AmrLevel::derive: no function available");
             }
         }
-#else
-        for (MFIter mfi(srcMF); mfi.isValid(); ++mfi)
-        {
-            int         grid_no = mfi.index();
-            const RealBox gridloc(grids[grid_no],geom.CellSize(),geom.ProbLo());
-            Real*       ddat    = (*mf)[mfi].dataPtr();
-            const int*  dlo     = (*mf)[mfi].loVect();
-            const int*  dhi     = (*mf)[mfi].hiVect();
-            int         n_der   = rec->numDerive();
-            Real*       cdat    = srcMF[mfi].dataPtr();
-            const int*  clo     = srcMF[mfi].loVect();
-            const int*  chi     = srcMF[mfi].hiVect();
-            int         n_state = rec->numState();
-            const int*  dom_lo  = state[index].getDomain().loVect();
-            const int*  dom_hi  = state[index].getDomain().hiVect();
-            const Real* dx      = geom.CellSize();
-            const int*  bcr     = rec->getBC();
-            const Real* xlo     = gridloc.lo();
-            Real        dt      = parent->dtLevel(level);
-
-            if (rec->derFunc() != static_cast<DeriveFunc>(0)){
-               rec->derFunc()(ddat,AMREX_ARLIM(dlo),AMREX_ARLIM(dhi),&n_der,
-               cdat,AMREX_ARLIM(clo),AMREX_ARLIM(chi),&n_state,
-               dlo,dhi,dom_lo,dom_hi,dx,xlo,&time,&dt,bcr,
-               &level,&grid_no);
-            } else if (rec->derFunc3D() != static_cast<DeriveFunc3D>(0)){
-               const int *bc3D = rec->getBC3D();
-               rec->derFunc3D()(ddat,AMREX_ARLIM_3D(dlo),AMREX_ARLIM_3D(dhi),&n_der,
-                                cdat,AMREX_ARLIM_3D(clo),AMREX_ARLIM_3D(chi),&n_state,
-                                AMREX_ARLIM_3D(dlo),AMREX_ARLIM_3D(dhi),
-                                AMREX_ARLIM_3D(dom_lo),AMREX_ARLIM_3D(dom_hi),
-                                AMREX_ZFILL(dx),AMREX_ZFILL(xlo),
-                                &time,&dt,
-                                bc3D,
-                                &level,&grid_no);
-            } else {
-               amrex::Error("AmrLevel::derive: no function available");
-            }
-        }
-#endif
         }
     }
     else
@@ -1816,7 +1773,6 @@ AmrLevel::derive (const std::string& name, Real time, MultiFab& mf, int dcomp)
         }
         else
         {
-#if defined(AMREX_CRSEGRNDOMP) || (!defined(AMREX_XSDK) && defined(CRSEGRNDOMP))
 #ifdef AMREX_USE_OMP
 #pragma omp parallel
 #endif
@@ -1861,46 +1817,6 @@ AmrLevel::derive (const std::string& name, Real time, MultiFab& mf, int dcomp)
                amrex::Error("AmrLevel::derive: no function available");
             }
         }
-#else
-        for (MFIter mfi(srcMF); mfi.isValid(); ++mfi)
-        {
-            int         idx     = mfi.index();
-            Real*       ddat    = mf[mfi].dataPtr(dcomp);
-            const int*  dlo     = mf[mfi].loVect();
-            const int*  dhi     = mf[mfi].hiVect();
-            int         n_der   = rec->numDerive();
-            Real*       cdat    = srcMF[mfi].dataPtr();
-            const int*  clo     = srcMF[mfi].loVect();
-            const int*  chi     = srcMF[mfi].hiVect();
-            int         n_state = rec->numState();
-            const int*  dom_lo  = state[index].getDomain().loVect();
-            const int*  dom_hi  = state[index].getDomain().hiVect();
-            const Real* dx      = geom.CellSize();
-            const int*  bcr     = rec->getBC();
-            const RealBox& temp = RealBox(mf[mfi].box(),geom.CellSize(),geom.ProbLo());
-            const Real* xlo     = temp.lo();
-            Real        dt      = parent->dtLevel(level);
-
-            if (rec->derFunc() != static_cast<DeriveFunc>(0)){
-               rec->derFunc()(ddat,AMREX_ARLIM(dlo),AMREX_ARLIM(dhi),&n_der,
-                              cdat,AMREX_ARLIM(clo),AMREX_ARLIM(chi),&n_state,
-                              dlo,dhi,dom_lo,dom_hi,dx,xlo,&time,&dt,bcr,
-                              &level,&idx);
-            } else if (rec->derFunc3D() != static_cast<DeriveFunc3D>(0)){
-               const int *bc3D = rec->getBC3D();
-               rec->derFunc3D()(ddat,AMREX_ARLIM_3D(dlo),AMREX_ARLIM_3D(dhi),&n_der,
-                                cdat,AMREX_ARLIM_3D(clo),AMREX_ARLIM_3D(chi),&n_state,
-                                AMREX_ARLIM_3D(dlo),AMREX_ARLIM_3D(dhi),
-                                AMREX_ARLIM_3D(dom_lo),AMREX_ARLIM_3D(dom_hi),
-                                AMREX_ZFILL(dx),AMREX_ZFILL(xlo),
-                                &time,&dt,
-                                bc3D,
-                                &level,&idx);
-            } else {
-               amrex::Error("AmrLevel::derive: no function available");
-            }
-        }
-#endif
         }
     }
     else

--- a/Src/Amr/AMReX_StateData.cpp
+++ b/Src/Amr/AMReX_StateData.cpp
@@ -878,10 +878,8 @@ StateDataPhysBCFunct::operator() (MultiFab& mf, int dest_comp, int num_comp, Int
     bool has_bndryfunc_fab = statedata->desc->hasBndryFuncFab();
     bool run_on_gpu = statedata->desc->RunOnGPU() && Gpu::inLaunchRegion();
 
-#if defined(AMREX_CRSEGRNDOMP) || (!defined(AMREX_XSDK) && defined(CRSEGRNDOMP))
 #ifdef AMREX_USE_OMP
 #pragma omp parallel if (!run_on_gpu)
-#endif
 #endif
     {
         FArrayBox tmp;

--- a/Tests/EB/CNS/Exec/Make.CNS
+++ b/Tests/EB/CNS/Exec/Make.CNS
@@ -11,9 +11,6 @@ LAZY := TRUE
 
 include $(AMREX_HOME)/Tools/GNUMake/Make.defs
 
-# CNS uses a coarse grained OMP approach
-DEFINES += -DAMREX_CRSEGRNDOMP
-
 include $(TOP)/Source/Make.package
 INCLUDE_LOCATIONS += $(TOP)/Source
 VPATH_LOCATIONS   += $(TOP)/Source

--- a/Tests/EB_CNS/Exec/Make.CNS
+++ b/Tests/EB_CNS/Exec/Make.CNS
@@ -11,9 +11,6 @@ BL_NO_FORT = TRUE
 
 include $(AMREX_HOME)/Tools/GNUMake/Make.defs
 
-# CNS uses a coarse grained OMP approach
-DEFINES += -DAMREX_CRSEGRNDOMP
-
 include $(TOP)/Source/Make.package
 INCLUDE_LOCATIONS += $(TOP)/Source
 VPATH_LOCATIONS   += $(TOP)/Source

--- a/Tests/GPU/CNS/Exec/Make.CNS
+++ b/Tests/GPU/CNS/Exec/Make.CNS
@@ -11,9 +11,6 @@ BL_NO_FORT = TRUE
 
 include $(AMREX_HOME)/Tools/GNUMake/Make.defs
 
-# CNS uses a coarse grained OMP approach
-DEFINES += -DAMREX_CRSEGRNDOMP
-
 include $(TOP)/Source/Make.package
 INCLUDE_LOCATIONS += $(TOP)/Source
 VPATH_LOCATIONS   += $(TOP)/Source


### PR DESCRIPTION
## Summary

The macro was added for backward compatibility when BoxLib first
transitioned to omp over tiles.  This can be removed now because We no
longer have any Fab level functions containing OpenMP parallel regions.

## Additional background

#2336 

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
