### PR TITLE
Force turning off particle tiling for GPU on Advection_AmrLevel test

### DIFF
--- a/Tests/Amr/Advection_AmrLevel/Source/main.cpp
+++ b/Tests/Amr/Advection_AmrLevel/Source/main.cpp
@@ -24,6 +24,14 @@ main (int   argc,
     Real strt_time;
     Real stop_time;
 
+    // force particle tiling to be off for GPU
+#ifdef AMREX_USE_GPU
+    {
+        ParmParse pp("particles");
+        pp.add("do_tiling", 0);
+    }
+#endif
+
     {
         ParmParse pp;
 


### PR DESCRIPTION
This enables the same inputs file to be used for GPU / non-GPU runs.

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
