### PR TITLE
Call setLevelBC from getFluxes in case we have set up the projector c…

### DIFF
--- a/Src/LinearSolvers/Projections/AMReX_MacProjector.cpp
+++ b/Src/LinearSolvers/Projections/AMReX_MacProjector.cpp
@@ -312,6 +312,10 @@ void
 MacProjector::getFluxes (const Vector<Array<MultiFab*,AMREX_SPACEDIM> >& a_flux,
                          const Vector<MultiFab*>& a_sol, MLMG::Location a_loc) const
 {
+    int ilev = 0;
+    if (m_needs_level_bcs[ilev])
+        m_linop->setLevelBC(ilev, nullptr);
+
     m_linop->getFluxes(a_flux, a_sol, a_loc);
     if (m_poisson) {
         for (auto const& mfarr : a_flux) {


### PR DESCRIPTION
…lass but not yet called project

## Summary

## Additional background

## Checklist

The proposed changes:
- [X] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
