### PR TITLE
OverlapSync nowait and finish.

### DIFF
--- a/Src/Base/AMReX_FabArray.H
+++ b/Src/Base/AMReX_FabArray.H
@@ -151,7 +151,6 @@ using TheFaArenaPointer = std::unique_ptr<char, TheFaArenaDeleter>;
 template <class FAB>
 struct FBData {
 
-    //! Data used in non-blocking FillBoundary
     const FabArrayBase::FB*  fb = nullptr;
     int                 scomp;
     int                 ncomp;
@@ -1128,8 +1127,10 @@ public:
 #endif
 
     std::unique_ptr<FBData<FAB>> fbd;
-
     std::unique_ptr<PCData<FAB>> pcd;
+
+    // Pointer to temporary fab used in non-blocking OverrideSync
+    std::unique_ptr< FabArray<FAB> > os_temp;
 };
 
 

--- a/Src/Base/AMReX_FabArrayUtility.H
+++ b/Src/Base/AMReX_FabArrayUtility.H
@@ -1377,7 +1377,7 @@ void
 OverrideSync_nowait (FabArray<FAB> & fa, FabArray<IFAB> const& msk, const Periodicity& period)
 {
     BL_PROFILE("OverrideSync_nowait()");
-    AMREX_ASSERT_WITH_MESSAGE(fa.os_temp, "OverrideSync_nowait() called when already in progress.");
+    AMREX_ASSERT_WITH_MESSAGE(!fa.os_temp, "OverrideSync_nowait() called when already in progress.");
 
     if (fa.ixType().cellCentered()) return;
 

--- a/Src/Base/AMReX_FabArrayUtility.H
+++ b/Src/Base/AMReX_FabArrayUtility.H
@@ -1366,22 +1366,20 @@ OverrideSync (FabArray<FAB> & fa, FabArray<IFAB> const& msk, const Periodicity& 
 {
     BL_PROFILE("OverrideSync()");
 
-    auto tmpmf = OverrideSync_nowait(fa, msk, period);
-    OverrideSync_finish(fa, tmpmf);
+    OverrideSync_nowait(fa, msk, period);
+    OverrideSync_finish(fa);
 }
 
 
 template <class FAB, class IFAB, class bar = std::enable_if_t<IsBaseFab<FAB>::value
                                                                && IsBaseFab<IFAB>::value> >
-std::unique_ptr< FabArray<FAB> >
+void
 OverrideSync_nowait (FabArray<FAB> & fa, FabArray<IFAB> const& msk, const Periodicity& period)
 {
     BL_PROFILE("OverrideSync_nowait()");
+    AMREX_ASSERT_WITH_MESSAGE(fa.os_temp, "OverrideSync_nowait() called when already in progress.");
 
-    if (fa.ixType().cellCentered())
-    {
-        return (std::unique_ptr< FabArray<FAB> >(nullptr));
-    }
+    if (fa.ixType().cellCentered()) return;
 
     const int ncomp = fa.nComp();
 
@@ -1413,30 +1411,24 @@ OverrideSync_nowait (FabArray<FAB> & fa, FabArray<IFAB> const& msk, const Period
         }
     }
 
-    std::unique_ptr< FabArray<FAB> > tmpmf =
-         std::make_unique< FabArray<FAB> > ( fa.boxArray(), fa.DistributionMap(),
-                                             ncomp, 0, MFInfo(), fa.Factory() );
-    tmpmf->setVal(0);
-    tmpmf->ParallelCopy_nowait(fa, period, FabArrayBase::ADD);
-
-    return tmpmf;
+    fa.os_temp = std::make_unique< FabArray<FAB> > ( fa.boxArray(), fa.DistributionMap(),
+                                                     ncomp, 0, MFInfo(), fa.Factory() );
+    fa.os_temp->setVal(0);
+    fa.os_temp->ParallelCopy_nowait(fa, period, FabArrayBase::ADD);
 }
 
 template <class FAB, class bar = std::enable_if_t<IsBaseFab<FAB>::value> >
 void
-OverrideSync_finish (FabArray<FAB> & fa, std::unique_ptr< FabArray<FAB> >& tmpmf)
+OverrideSync_finish (FabArray<FAB> & fa)
 {
     BL_PROFILE("OverrideSync_finish()");
 
-    if (tmpmf)
-    {
-        tmpmf->ParallelCopy_finish();
-    }
+    if (fa.ixType().cellCentered()) return;
 
-    const int ncomp = fa.nComp();
-    amrex::Copy(fa, *tmpmf, 0, 0, ncomp, 0);
+    fa.os_temp->ParallelCopy_finish();
+    amrex::Copy(fa, *(fa.os_temp), 0, 0, fa.nComp(), 0);
 
-    tmpmf.reset();
+    fa.os_temp.reset();
 }
 
 template <class FAB, class foo = std::enable_if_t<IsBaseFab<FAB>::value> >

--- a/Src/Base/AMReX_FabArrayUtility.H
+++ b/Src/Base/AMReX_FabArrayUtility.H
@@ -1428,8 +1428,7 @@ OverrideSync_finish (FabArray<FAB> & fa, std::unique_ptr< FabArray<FAB> >& tmpmf
 {
     BL_PROFILE("OverrideSync_finish()");
 
-    // If !pcd, PC is done (all local), so skip finish.
-    if ( (fa.ixType().cellCentered()) && (tmpmf->pcd) )
+    if (tmpmf)
     {
         tmpmf->ParallelCopy_finish();
     }

--- a/Src/Base/AMReX_FabArrayUtility.H
+++ b/Src/Base/AMReX_FabArrayUtility.H
@@ -1358,6 +1358,7 @@ prefetchToDevice (FabArray<FAB> const& fa, const bool synchronous = true)
 #endif
 }
 
+
 template <class FAB, class IFAB, class bar = std::enable_if_t<IsBaseFab<FAB>::value
                                                                && IsBaseFab<IFAB>::value> >
 void
@@ -1365,7 +1366,22 @@ OverrideSync (FabArray<FAB> & fa, FabArray<IFAB> const& msk, const Periodicity& 
 {
     BL_PROFILE("OverrideSync()");
 
-    if (fa.ixType().cellCentered()) return;
+    auto tmpmf = OverrideSync_nowait(fa, msk, period);
+    OverrideSync_finish(fa, tmpmf);
+}
+
+
+template <class FAB, class IFAB, class bar = std::enable_if_t<IsBaseFab<FAB>::value
+                                                               && IsBaseFab<IFAB>::value> >
+std::unique_ptr< FabArray<FAB> >
+OverrideSync_nowait (FabArray<FAB> & fa, FabArray<IFAB> const& msk, const Periodicity& period)
+{
+    BL_PROFILE("OverrideSync_nowait()");
+
+    if (fa.ixType().cellCentered())
+    {
+        return (std::unique_ptr< FabArray<FAB> >(nullptr));
+    }
 
     const int ncomp = fa.nComp();
 
@@ -1397,12 +1413,31 @@ OverrideSync (FabArray<FAB> & fa, FabArray<IFAB> const& msk, const Periodicity& 
         }
     }
 
-    FabArray<FAB> tmpmf(fa.boxArray(), fa.DistributionMap(), ncomp, 0,
-                        MFInfo(), fa.Factory());
-    tmpmf.setVal(0);
-    tmpmf.ParallelCopy(fa, period, FabArrayBase::ADD);
+    std::unique_ptr< FabArray<FAB> > tmpmf =
+         std::make_unique< FabArray<FAB> > ( fa.boxArray(), fa.DistributionMap(),
+                                             ncomp, 0, MFInfo(), fa.Factory() );
+    tmpmf->setVal(0);
+    tmpmf->ParallelCopy_nowait(fa, period, FabArrayBase::ADD);
 
-    amrex::Copy(fa, tmpmf, 0, 0, ncomp, 0);
+    return tmpmf;
+}
+
+template <class FAB, class bar = std::enable_if_t<IsBaseFab<FAB>::value> >
+void
+OverrideSync_finish (FabArray<FAB> & fa, std::unique_ptr< FabArray<FAB> >& tmpmf)
+{
+    BL_PROFILE("OverrideSync_finish()");
+
+    // If !pcd, PC is done (all local), so skip finish.
+    if ( (fa.ixType().cellCentered()) && (tmpmf->pcd) )
+    {
+        tmpmf->ParallelCopy_finish();
+    }
+
+    const int ncomp = fa.nComp();
+    amrex::Copy(fa, *tmpmf, 0, 0, ncomp, 0);
+
+    tmpmf.reset();
 }
 
 template <class FAB, class foo = std::enable_if_t<IsBaseFab<FAB>::value> >

--- a/Src/Base/AMReX_MultiFab.H
+++ b/Src/Base/AMReX_MultiFab.H
@@ -665,6 +665,11 @@ public:
     void OverrideSync (const Periodicity& period = Periodicity::NonPeriodic());
     void OverrideSync (const iMultiFab& msk, const Periodicity& period = Periodicity::NonPeriodic());
 
+    void OverrideSync_nowait (const Periodicity& period = Periodicity::NonPeriodic());
+    void OverrideSync_nowait (const iMultiFab& msk, const Periodicity& period = Periodicity::NonPeriodic());
+    void OverrideSync_finish ();
+
+
     static void Initialize ();
     static void Finalize ();
 

--- a/Src/Base/AMReX_MultiFab.cpp
+++ b/Src/Base/AMReX_MultiFab.cpp
@@ -1778,7 +1778,7 @@ MultiFab::OverrideSync (const Periodicity& period)
 {
     if (ixType().cellCentered()) return;
     auto msk = this->OwnerMask(period);
-    this->OverrideSync(*msk, period);
+    amrex::OverrideSync(*this, *msk, period);
 }
 
 void

--- a/Src/Base/AMReX_MultiFab.cpp
+++ b/Src/Base/AMReX_MultiFab.cpp
@@ -1787,4 +1787,24 @@ MultiFab::OverrideSync (const iMultiFab& msk, const Periodicity& period)
     amrex::OverrideSync(*this, msk, period);
 }
 
+void
+MultiFab::OverrideSync_nowait (const Periodicity& period)
+{
+    if (ixType().cellCentered()) return;
+    auto msk = this->OwnerMask(period);
+    amrex::OverrideSync_nowait(*this, *msk, period);
+}
+
+void
+MultiFab::OverrideSync_nowait (const iMultiFab& msk, const Periodicity& period)
+{
+    amrex::OverrideSync_nowait(*this, msk, period);
+}
+
+void
+MultiFab::OverrideSync_finish ()
+{
+    amrex::OverrideSync_finish(*this);
+}
+
 }


### PR DESCRIPTION
## Summary

Adds OverlapSync_nowait and OverlapSync_finish functionality.

## Additional background

Because this is not a FabArray member function, it requires returning the temporary and passing it to `_finish`, along with the target FabArray. If the function was in FabArray.H, it could have a traditional blank `_finish` function signature.  Any opinions?

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
