### PR TITLE
Add curly brackets between amrex::Initialize and amrex::Finalize.

### DIFF
--- a/Tools/C_util/Convergence/Add.cpp
+++ b/Tools/C_util/Convergence/Add.cpp
@@ -44,38 +44,40 @@ main (int   argc,
       char* argv[])
 {
     amrex::Initialize(argc,argv);
+    {
 
-    if (argc == 1)
-        PrintUsage(argv[0]);
+	if (argc == 1)
+	    PrintUsage(argv[0]);
 
-    ParmParse pp;
+	ParmParse pp;
 
-    FArrayBox::setFormat(FABio::FAB_IEEE_32);
-    //
-    // Scan the arguments.
-    //
-    std::string iFileDir, iFile, eFile, oFile, oFileDir;
-    Real factor;
+	FArrayBox::setFormat(FABio::FAB_IEEE_32);
+	//
+	// Scan the arguments.
+	//
+	std::string iFileDir, iFile, eFile, oFile, oFileDir;
+	Real factor;
 
-    pp.query("infile", iFile);
-    if (iFile.empty())
-        amrex::Abort("You must specify `infile'");
+	pp.query("infile", iFile);
+	if (iFile.empty())
+	    amrex::Abort("You must specify `infile'");
 
-    pp.query("factor", factor);
+	pp.query("factor", factor);
 
-    pp.query("outfile", oFile);
-    if (oFile.empty())
-        amrex::Abort("You must specify `outfile'");
+	pp.query("outfile", oFile);
+	if (oFile.empty())
+	    amrex::Abort("You must specify `outfile'");
 
-    std::ifstream is(iFile.c_str(),ios::in);
-    std::ofstream os(oFile.c_str(),ios::out);
+	std::ifstream is(iFile.c_str(),ios::in);
+	std::ofstream os(oFile.c_str(),ios::out);
 
-    FArrayBox dataI, dataE;
-    dataI.readFrom(is);
+	FArrayBox dataI, dataE;
+	dataI.readFrom(is);
 
-    dataI.plus(factor);
+	dataI.plus(factor);
 
-    dataI.writeOn(os);
+	dataI.writeOn(os);
 
+    }
     amrex::Finalize();
 }

--- a/Tools/C_util/Convergence/Add.cpp
+++ b/Tools/C_util/Convergence/Add.cpp
@@ -46,37 +46,37 @@ main (int   argc,
     amrex::Initialize(argc,argv);
     {
 
-	if (argc == 1)
-	    PrintUsage(argv[0]);
+        if (argc == 1)
+            PrintUsage(argv[0]);
 
-	ParmParse pp;
+        ParmParse pp;
 
-	FArrayBox::setFormat(FABio::FAB_IEEE_32);
-	//
-	// Scan the arguments.
-	//
-	std::string iFileDir, iFile, eFile, oFile, oFileDir;
-	Real factor;
+        FArrayBox::setFormat(FABio::FAB_IEEE_32);
+        //
+        // Scan the arguments.
+        //
+        std::string iFileDir, iFile, eFile, oFile, oFileDir;
+        Real factor;
 
-	pp.query("infile", iFile);
-	if (iFile.empty())
-	    amrex::Abort("You must specify `infile'");
+        pp.query("infile", iFile);
+        if (iFile.empty())
+            amrex::Abort("You must specify `infile'");
 
-	pp.query("factor", factor);
+        pp.query("factor", factor);
 
-	pp.query("outfile", oFile);
-	if (oFile.empty())
-	    amrex::Abort("You must specify `outfile'");
+        pp.query("outfile", oFile);
+        if (oFile.empty())
+            amrex::Abort("You must specify `outfile'");
 
-	std::ifstream is(iFile.c_str(),ios::in);
-	std::ofstream os(oFile.c_str(),ios::out);
+        std::ifstream is(iFile.c_str(),ios::in);
+        std::ofstream os(oFile.c_str(),ios::out);
 
-	FArrayBox dataI, dataE;
-	dataI.readFrom(is);
+        FArrayBox dataI, dataE;
+        dataI.readFrom(is);
 
-	dataI.plus(factor);
+        dataI.plus(factor);
 
-	dataI.writeOn(os);
+        dataI.writeOn(os);
 
     }
     amrex::Finalize();

--- a/Tools/C_util/Convergence/ComparePlotfiles.cpp
+++ b/Tools/C_util/Convergence/ComparePlotfiles.cpp
@@ -46,209 +46,212 @@ main (int   argc,
       char* argv[])
 {
     amrex::Initialize(argc,argv);
+    {
 
-    if (argc == 1) {
-        PrintUsage(argv[0]);
-    }
+	if (argc == 1) {
+	    PrintUsage(argv[0]);
+	}
 
-    // plotfile names for the coarse, fine, and subtracted output
-    std::string iFile1, iFile2, difFile="";
+	// plotfile names for the coarse, fine, and subtracted output
+	std::string iFile1, iFile2, difFile="";
 
-    // read in parameters from inputs file
-    ParmParse pp;
+	// read in parameters from inputs file
+	ParmParse pp;
 
-    // coarse MultiFab
-    pp.query("infile1", iFile1);
-    if (iFile1.empty())
-        amrex::Abort("You must specify `infile1'");
+	// coarse MultiFab
+	pp.query("infile1", iFile1);
+	if (iFile1.empty())
+	    amrex::Abort("You must specify `infile1'");
 
-    // fine MultiFab (might have same resolution as coarse)
-    pp.query("reffile", iFile2);
-    if (iFile2.empty())
-        amrex::Abort("You must specify `reffile'");
+	// fine MultiFab (might have same resolution as coarse)
+	pp.query("reffile", iFile2);
+	if (iFile2.empty())
+	    amrex::Abort("You must specify `reffile'");
 
-    // subtracted output (optional)
-    pp.query("diffile", difFile);
+	// subtracted output (optional)
+	pp.query("diffile", difFile);
 
-    // single-level for now
-    // AMR comes later, where we iterate over each level in isolation
+	// single-level for now
+	// AMR comes later, where we iterate over each level in isolation
 
-    // check to see whether the user pointed to the plotfile base directory
-    // or the data itself
-    if (amrex::FileExists(iFile1+"/Level_0/Cell_H")) {
-       iFile1 += "/Level_0/Cell";
-    }
-    if (amrex::FileExists(iFile2+"/Level_0/Cell_H")) {
-       iFile2 += "/Level_0/Cell";
-    }
+	// check to see whether the user pointed to the plotfile base directory
+	// or the data itself
+	if (amrex::FileExists(iFile1+"/Level_0/Cell_H")) {
+	    iFile1 += "/Level_0/Cell";
+	}
+	if (amrex::FileExists(iFile2+"/Level_0/Cell_H")) {
+	    iFile2 += "/Level_0/Cell";
+	}
 
-    // storage for the input coarse and fine MultiFabs
-    MultiFab mf_c, mf_f;
+	// storage for the input coarse and fine MultiFabs
+	MultiFab mf_c, mf_f;
 
-    // read in plotfiles, 'coarse' and 'fine' to MultiFabs
-    // note: fine could be the same resolution as coarse
-    VisMF::Read(mf_c, iFile1);
-    VisMF::Read(mf_f, iFile2);
+	// read in plotfiles, 'coarse' and 'fine' to MultiFabs
+	// note: fine could be the same resolution as coarse
+	VisMF::Read(mf_c, iFile1);
+	VisMF::Read(mf_f, iFile2);
 
-    if (mf_c.contains_nan()) {
-        Abort("First plotfile contains NaN(s)");
-    }
-    if (mf_f.contains_nan()) {
-        Abort("Second plotfile contains NaN(s)");
-    }
+	if (mf_c.contains_nan()) {
+	    Abort("First plotfile contains NaN(s)");
+	}
+	if (mf_f.contains_nan()) {
+	    Abort("Second plotfile contains NaN(s)");
+	}
 
-    // check number of components
-    if (mf_c.nComp() != mf_f.nComp()) {
-        Abort("plotfiles do not have the same number of variables");
-    }
-    int ncomp = mf_c.nComp();
-    Print() << "ncomp = " << ncomp << std::endl;
+	// check number of components
+	if (mf_c.nComp() != mf_f.nComp()) {
+	    Abort("plotfiles do not have the same number of variables");
+	}
+	int ncomp = mf_c.nComp();
+	Print() << "ncomp = " << ncomp << std::endl;
 
-    // check nodality
-    IntVect c_nodality = mf_c.ixType().toIntVect();
-    IntVect f_nodality = mf_f.ixType().toIntVect();
-    if (c_nodality != f_nodality) {
-        Abort("plotfiles do not have the same nodality");
-    }
-    Print() << "nodality " << c_nodality << std::endl;
+	// check nodality
+	IntVect c_nodality = mf_c.ixType().toIntVect();
+	IntVect f_nodality = mf_f.ixType().toIntVect();
+	if (c_nodality != f_nodality) {
+	    Abort("plotfiles do not have the same nodality");
+	}
+	Print() << "nodality " << c_nodality << std::endl;
 
-    // get coarse and fine boxArrays
-    BoxArray ba_c = mf_c.boxArray();
-    BoxArray ba_f = mf_f.boxArray();
+	// get coarse and fine boxArrays
+	BoxArray ba_c = mf_c.boxArray();
+	BoxArray ba_f = mf_f.boxArray();
 
-    // minimalBox() computes a single box to enclose all the boxes
-    // enclosedCells() converts it to a cell-centered Box
-    Box bx_c = ba_c.minimalBox().enclosedCells();
-    Box bx_f = ba_f.minimalBox().enclosedCells();
+	// minimalBox() computes a single box to enclose all the boxes
+	// enclosedCells() converts it to a cell-centered Box
+	Box bx_c = ba_c.minimalBox().enclosedCells();
+	Box bx_f = ba_f.minimalBox().enclosedCells();
 
-    // number of cells in the coarse domain
-    Print() << "npts in coarse domain = " << bx_c.numPts() << std::endl;
-    Print() << "npts in fine   domain = " << bx_f.numPts() << std::endl;
-    long npts_coarsedomain = bx_c.numPts();
+	// number of cells in the coarse domain
+	Print() << "npts in coarse domain = " << bx_c.numPts() << std::endl;
+	Print() << "npts in fine   domain = " << bx_f.numPts() << std::endl;
+	long npts_coarsedomain = bx_c.numPts();
 
-    // assume ref_ratio is the same in each direction
-    int rr = bx_f.length(0)/bx_c.length(0);
+	// assume ref_ratio is the same in each direction
+	int rr = bx_f.length(0)/bx_c.length(0);
 
-    Print() << "ref_ratio = " << rr << std::endl;
+	Print() << "ref_ratio = " << rr << std::endl;
 
-    // check to make sure refinement ratio is an integer
-    for (int i=0; i<AMREX_SPACEDIM; ++i) {
-        if (bx_f.length(i)%bx_c.length(i) != 0) {
-            Abort("not an integer refinement ratio");
-        }
-    }
+	// check to make sure refinement ratio is an integer
+	for (int i=0; i<AMREX_SPACEDIM; ++i) {
+	    if (bx_f.length(i)%bx_c.length(i) != 0) {
+		Abort("not an integer refinement ratio");
+	    }
+	}
 
-    // check to make sure refinement ratio is the same in each direction
-    for (int i=0; i<AMREX_SPACEDIM; ++i) {
-        if ( bx_f.length(i)/bx_c.length(i) != rr ) {
-            Abort("ref_ratio not the same in each direction");
-        }
-    }
+	// check to make sure refinement ratio is the same in each direction
+	for (int i=0; i<AMREX_SPACEDIM; ++i) {
+	    if ( bx_f.length(i)/bx_c.length(i) != rr ) {
+		Abort("ref_ratio not the same in each direction");
+	    }
+	}
 
-    // make a new BoxArray that is a refined version of the coarse BoxArray with the same
-    // problem domain as the fine BoxArray
-    BoxArray ba_c2 = ba_c;
-    ba_c2.refine(rr);
+	// make a new BoxArray that is a refined version of the coarse BoxArray with the same
+	// problem domain as the fine BoxArray
+	BoxArray ba_c2 = ba_c;
+	ba_c2.refine(rr);
 
-    // grab the distribution map from the coarse MultiFab
-    DistributionMapping dm = mf_c.DistributionMap();
+	// grab the distribution map from the coarse MultiFab
+	DistributionMapping dm = mf_c.DistributionMap();
 
-    // create a fine MultiFab with same distribution mapping as coarse MultiFab
-    MultiFab mf_f2(ba_c2,dm,ncomp,0);
+	// create a fine MultiFab with same distribution mapping as coarse MultiFab
+	MultiFab mf_f2(ba_c2,dm,ncomp,0);
 
-    // copy fine data into new fine MultiFab
-    mf_f2.ParallelCopy(mf_f,0,0,ncomp,0,0);
+	// copy fine data into new fine MultiFab
+	mf_f2.ParallelCopy(mf_f,0,0,ncomp,0,0);
 
-    // storage for averaged-down fine MultiFab
-    MultiFab mf_c2(ba_c,dm,ncomp,0);
+	// storage for averaged-down fine MultiFab
+	MultiFab mf_c2(ba_c,dm,ncomp,0);
 
-    // now we average down mf_f2 into mf_c2
+	// now we average down mf_f2 into mf_c2
 
-    int how_many_nodal = 0;
-    for (int i=0; i<AMREX_SPACEDIM; ++i ) {
-        if (c_nodality[i] == 1) {
-            ++how_many_nodal;
-        }
-    }
+	int how_many_nodal = 0;
+	for (int i=0; i<AMREX_SPACEDIM; ++i ) {
+	    if (c_nodality[i] == 1) {
+		++how_many_nodal;
+	    }
+	}
 
-    int npts_avg = pow(rr,AMREX_SPACEDIM-how_many_nodal);
+	int npts_avg = pow(rr,AMREX_SPACEDIM-how_many_nodal);
 
-    int rr_i = (c_nodality[0] == 0) ? rr : 1;
-    int rr_j = (c_nodality[1] == 0) ? rr : 1;
+	int rr_i = (c_nodality[0] == 0) ? rr : 1;
+	int rr_j = (c_nodality[1] == 0) ? rr : 1;
 #if (AMREX_SPACEDIM == 3)
-    int rr_k = (c_nodality[2] == 0) ? rr : 1;
+	int rr_k = (c_nodality[2] == 0) ? rr : 1;
 #else
-    int rr_k = 0;
+	int rr_k = 0;
 #endif
 
-    for ( MFIter mfi(mf_c,TilingIfNotGPU()); mfi.isValid(); ++mfi ) {
+	for ( MFIter mfi(mf_c,TilingIfNotGPU()); mfi.isValid(); ++mfi ) {
 
-        const Box& bx = mfi.tilebox();
+	    const Box& bx = mfi.tilebox();
 
-        const Array4<Real const>& fine   = mf_f2.array(mfi);
-        const Array4<Real      >& coarse = mf_c2.array(mfi);
+	    const Array4<Real const>& fine   = mf_f2.array(mfi);
+	    const Array4<Real      >& coarse = mf_c2.array(mfi);
 
-        amrex::ParallelFor(bx, ncomp, [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
-        {
-            coarse(i,j,k,n) = 0.;
+	    amrex::ParallelFor(bx, ncomp, [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
+			       {
+				   coarse(i,j,k,n) = 0.;
 
 #if (AMREX_SPACEDIM==3)
-            for (int kk=0; kk<rr_k; ++kk) {
+				   for (int kk=0; kk<rr_k; ++kk) {
 #else
-                int kk=0;
+				       int kk=0;
 #endif
-                for (int jj=0; jj<rr_j; ++jj) {
-                    for (int ii=0; ii<rr_i; ++ii) {
-                        coarse(i,j,k,n) += fine(rr*i+ii,rr*j+jj,rr*k+kk,n);
-                    }
-                }
+				       for (int jj=0; jj<rr_j; ++jj) {
+					   for (int ii=0; ii<rr_i; ++ii) {
+					       coarse(i,j,k,n) += fine(rr*i+ii,rr*j+jj,rr*k+kk,n);
+					   }
+				       }
 #if (AMREX_SPACEDIM==3)
-            }
+				   }
 #endif
-            coarse(i,j,k,n) /= npts_avg;
-        });
+				   coarse(i,j,k,n) /= npts_avg;
+			       });
 
-    } // end MFIter
+	} // end MFIter
 
-    // subtract coarse from coarsened fine
-    MultiFab::Subtract(mf_c2,mf_c,0,0,ncomp,0);
+	// subtract coarse from coarsened fine
+	MultiFab::Subtract(mf_c2,mf_c,0,0,ncomp,0);
 
-    // force periodicity so faces/edges/nodes get weighted accordingly for L1 and L2 norms
-    IntVect iv(AMREX_D_DECL(bx_c.length(0),
-                            bx_c.length(1),
-                            bx_c.length(2)));
-    Periodicity period(iv);
+	// force periodicity so faces/edges/nodes get weighted accordingly for L1 and L2 norms
+	IntVect iv(AMREX_D_DECL(bx_c.length(0),
+				bx_c.length(1),
+				bx_c.length(2)));
+	Periodicity period(iv);
 
-    // compute norms of mf_c2
-    for (int i=0; i<ncomp; ++i) {
-        Real norm0 = mf_c2.norm0(i);
-        Real norm1 = mf_c2.norm1(i,period);
-        Real norm2 = mf_c2.norm2(i,period);
-        Print() << "(comp,L0,L1,L2) " << i << " "
-                << norm0 << " "
-                << norm1/npts_coarsedomain << " "
-                << norm2/sqrt(npts_coarsedomain) << " " << std::endl;
+	// compute norms of mf_c2
+	for (int i=0; i<ncomp; ++i) {
+	    Real norm0 = mf_c2.norm0(i);
+	    Real norm1 = mf_c2.norm1(i,period);
+	    Real norm2 = mf_c2.norm2(i,period);
+	    Print() << "(comp,L0,L1,L2) " << i << " "
+		    << norm0 << " "
+		    << norm1/npts_coarsedomain << " "
+		    << norm2/sqrt(npts_coarsedomain) << " " << std::endl;
+	}
+
+	// write out the subtracted plotfile if diffile was specified at the command line
+	if (difFile != "") {
+
+	    // define the problem domain as (0,1) for now
+	    RealBox real_box({AMREX_D_DECL(0.,0.,0.)},
+			     {AMREX_D_DECL(1.,1.,1.)});
+
+	    Vector<int> is_periodic(AMREX_SPACEDIM,1);
+
+	    // build a geometry object so we can use WriteSingleLevelPlotfile
+	    Geometry geom(bx_c,&real_box,CoordSys::cartesian,is_periodic.data());
+
+	    // give generic variables names for now
+	    Vector<std::string> varNames(ncomp);
+	    for (int i=0; i<ncomp; ++i) {
+		varNames[i] = std::to_string(i);
+	    }
+
+	    WriteSingleLevelPlotfile(difFile,mf_c2,varNames,geom,0.,0);
+	}
+
     }
-
-    // write out the subtracted plotfile if diffile was specified at the command line
-    if (difFile != "") {
-
-        // define the problem domain as (0,1) for now
-        RealBox real_box({AMREX_D_DECL(0.,0.,0.)},
-                         {AMREX_D_DECL(1.,1.,1.)});
-
-        Vector<int> is_periodic(AMREX_SPACEDIM,1);
-
-        // build a geometry object so we can use WriteSingleLevelPlotfile
-        Geometry geom(bx_c,&real_box,CoordSys::cartesian,is_periodic.data());
-
-        // give generic variables names for now
-        Vector<std::string> varNames(ncomp);
-        for (int i=0; i<ncomp; ++i) {
-            varNames[i] = std::to_string(i);
-        }
-
-        WriteSingleLevelPlotfile(difFile,mf_c2,varNames,geom,0.,0);
-    }
-
+    amrex::Finalize();
 }

--- a/Tools/C_util/Convergence/ComparePlotfiles.cpp
+++ b/Tools/C_util/Convergence/ComparePlotfiles.cpp
@@ -48,209 +48,209 @@ main (int   argc,
     amrex::Initialize(argc,argv);
     {
 
-	if (argc == 1) {
-	    PrintUsage(argv[0]);
-	}
+        if (argc == 1) {
+            PrintUsage(argv[0]);
+        }
 
-	// plotfile names for the coarse, fine, and subtracted output
-	std::string iFile1, iFile2, difFile="";
+        // plotfile names for the coarse, fine, and subtracted output
+        std::string iFile1, iFile2, difFile="";
 
-	// read in parameters from inputs file
-	ParmParse pp;
+        // read in parameters from inputs file
+        ParmParse pp;
 
-	// coarse MultiFab
-	pp.query("infile1", iFile1);
-	if (iFile1.empty())
-	    amrex::Abort("You must specify `infile1'");
+        // coarse MultiFab
+        pp.query("infile1", iFile1);
+        if (iFile1.empty())
+            amrex::Abort("You must specify `infile1'");
 
-	// fine MultiFab (might have same resolution as coarse)
-	pp.query("reffile", iFile2);
-	if (iFile2.empty())
-	    amrex::Abort("You must specify `reffile'");
+        // fine MultiFab (might have same resolution as coarse)
+        pp.query("reffile", iFile2);
+        if (iFile2.empty())
+            amrex::Abort("You must specify `reffile'");
 
-	// subtracted output (optional)
-	pp.query("diffile", difFile);
+        // subtracted output (optional)
+        pp.query("diffile", difFile);
 
-	// single-level for now
-	// AMR comes later, where we iterate over each level in isolation
+        // single-level for now
+        // AMR comes later, where we iterate over each level in isolation
 
-	// check to see whether the user pointed to the plotfile base directory
-	// or the data itself
-	if (amrex::FileExists(iFile1+"/Level_0/Cell_H")) {
-	    iFile1 += "/Level_0/Cell";
-	}
-	if (amrex::FileExists(iFile2+"/Level_0/Cell_H")) {
-	    iFile2 += "/Level_0/Cell";
-	}
+        // check to see whether the user pointed to the plotfile base directory
+        // or the data itself
+        if (amrex::FileExists(iFile1+"/Level_0/Cell_H")) {
+            iFile1 += "/Level_0/Cell";
+        }
+        if (amrex::FileExists(iFile2+"/Level_0/Cell_H")) {
+            iFile2 += "/Level_0/Cell";
+        }
 
-	// storage for the input coarse and fine MultiFabs
-	MultiFab mf_c, mf_f;
+        // storage for the input coarse and fine MultiFabs
+        MultiFab mf_c, mf_f;
 
-	// read in plotfiles, 'coarse' and 'fine' to MultiFabs
-	// note: fine could be the same resolution as coarse
-	VisMF::Read(mf_c, iFile1);
-	VisMF::Read(mf_f, iFile2);
+        // read in plotfiles, 'coarse' and 'fine' to MultiFabs
+        // note: fine could be the same resolution as coarse
+        VisMF::Read(mf_c, iFile1);
+        VisMF::Read(mf_f, iFile2);
 
-	if (mf_c.contains_nan()) {
-	    Abort("First plotfile contains NaN(s)");
-	}
-	if (mf_f.contains_nan()) {
-	    Abort("Second plotfile contains NaN(s)");
-	}
+        if (mf_c.contains_nan()) {
+            Abort("First plotfile contains NaN(s)");
+        }
+        if (mf_f.contains_nan()) {
+            Abort("Second plotfile contains NaN(s)");
+        }
 
-	// check number of components
-	if (mf_c.nComp() != mf_f.nComp()) {
-	    Abort("plotfiles do not have the same number of variables");
-	}
-	int ncomp = mf_c.nComp();
-	Print() << "ncomp = " << ncomp << std::endl;
+        // check number of components
+        if (mf_c.nComp() != mf_f.nComp()) {
+            Abort("plotfiles do not have the same number of variables");
+        }
+        int ncomp = mf_c.nComp();
+        Print() << "ncomp = " << ncomp << std::endl;
 
-	// check nodality
-	IntVect c_nodality = mf_c.ixType().toIntVect();
-	IntVect f_nodality = mf_f.ixType().toIntVect();
-	if (c_nodality != f_nodality) {
-	    Abort("plotfiles do not have the same nodality");
-	}
-	Print() << "nodality " << c_nodality << std::endl;
+        // check nodality
+        IntVect c_nodality = mf_c.ixType().toIntVect();
+        IntVect f_nodality = mf_f.ixType().toIntVect();
+        if (c_nodality != f_nodality) {
+            Abort("plotfiles do not have the same nodality");
+        }
+        Print() << "nodality " << c_nodality << std::endl;
 
-	// get coarse and fine boxArrays
-	BoxArray ba_c = mf_c.boxArray();
-	BoxArray ba_f = mf_f.boxArray();
+        // get coarse and fine boxArrays
+        BoxArray ba_c = mf_c.boxArray();
+        BoxArray ba_f = mf_f.boxArray();
 
-	// minimalBox() computes a single box to enclose all the boxes
-	// enclosedCells() converts it to a cell-centered Box
-	Box bx_c = ba_c.minimalBox().enclosedCells();
-	Box bx_f = ba_f.minimalBox().enclosedCells();
+        // minimalBox() computes a single box to enclose all the boxes
+        // enclosedCells() converts it to a cell-centered Box
+        Box bx_c = ba_c.minimalBox().enclosedCells();
+        Box bx_f = ba_f.minimalBox().enclosedCells();
 
-	// number of cells in the coarse domain
-	Print() << "npts in coarse domain = " << bx_c.numPts() << std::endl;
-	Print() << "npts in fine   domain = " << bx_f.numPts() << std::endl;
-	long npts_coarsedomain = bx_c.numPts();
+        // number of cells in the coarse domain
+        Print() << "npts in coarse domain = " << bx_c.numPts() << std::endl;
+        Print() << "npts in fine   domain = " << bx_f.numPts() << std::endl;
+        long npts_coarsedomain = bx_c.numPts();
 
-	// assume ref_ratio is the same in each direction
-	int rr = bx_f.length(0)/bx_c.length(0);
+        // assume ref_ratio is the same in each direction
+        int rr = bx_f.length(0)/bx_c.length(0);
 
-	Print() << "ref_ratio = " << rr << std::endl;
+        Print() << "ref_ratio = " << rr << std::endl;
 
-	// check to make sure refinement ratio is an integer
-	for (int i=0; i<AMREX_SPACEDIM; ++i) {
-	    if (bx_f.length(i)%bx_c.length(i) != 0) {
-		Abort("not an integer refinement ratio");
-	    }
-	}
+        // check to make sure refinement ratio is an integer
+        for (int i=0; i<AMREX_SPACEDIM; ++i) {
+            if (bx_f.length(i)%bx_c.length(i) != 0) {
+                Abort("not an integer refinement ratio");
+            }
+        }
 
-	// check to make sure refinement ratio is the same in each direction
-	for (int i=0; i<AMREX_SPACEDIM; ++i) {
-	    if ( bx_f.length(i)/bx_c.length(i) != rr ) {
-		Abort("ref_ratio not the same in each direction");
-	    }
-	}
+        // check to make sure refinement ratio is the same in each direction
+        for (int i=0; i<AMREX_SPACEDIM; ++i) {
+            if ( bx_f.length(i)/bx_c.length(i) != rr ) {
+                Abort("ref_ratio not the same in each direction");
+            }
+        }
 
-	// make a new BoxArray that is a refined version of the coarse BoxArray with the same
-	// problem domain as the fine BoxArray
-	BoxArray ba_c2 = ba_c;
-	ba_c2.refine(rr);
+        // make a new BoxArray that is a refined version of the coarse BoxArray with the same
+        // problem domain as the fine BoxArray
+        BoxArray ba_c2 = ba_c;
+        ba_c2.refine(rr);
 
-	// grab the distribution map from the coarse MultiFab
-	DistributionMapping dm = mf_c.DistributionMap();
+        // grab the distribution map from the coarse MultiFab
+        DistributionMapping dm = mf_c.DistributionMap();
 
-	// create a fine MultiFab with same distribution mapping as coarse MultiFab
-	MultiFab mf_f2(ba_c2,dm,ncomp,0);
+        // create a fine MultiFab with same distribution mapping as coarse MultiFab
+        MultiFab mf_f2(ba_c2,dm,ncomp,0);
 
-	// copy fine data into new fine MultiFab
-	mf_f2.ParallelCopy(mf_f,0,0,ncomp,0,0);
+        // copy fine data into new fine MultiFab
+        mf_f2.ParallelCopy(mf_f,0,0,ncomp,0,0);
 
-	// storage for averaged-down fine MultiFab
-	MultiFab mf_c2(ba_c,dm,ncomp,0);
+        // storage for averaged-down fine MultiFab
+        MultiFab mf_c2(ba_c,dm,ncomp,0);
 
-	// now we average down mf_f2 into mf_c2
+        // now we average down mf_f2 into mf_c2
 
-	int how_many_nodal = 0;
-	for (int i=0; i<AMREX_SPACEDIM; ++i ) {
-	    if (c_nodality[i] == 1) {
-		++how_many_nodal;
-	    }
-	}
+        int how_many_nodal = 0;
+        for (int i=0; i<AMREX_SPACEDIM; ++i ) {
+            if (c_nodality[i] == 1) {
+                ++how_many_nodal;
+            }
+        }
 
-	int npts_avg = pow(rr,AMREX_SPACEDIM-how_many_nodal);
+        int npts_avg = pow(rr,AMREX_SPACEDIM-how_many_nodal);
 
-	int rr_i = (c_nodality[0] == 0) ? rr : 1;
-	int rr_j = (c_nodality[1] == 0) ? rr : 1;
+        int rr_i = (c_nodality[0] == 0) ? rr : 1;
+        int rr_j = (c_nodality[1] == 0) ? rr : 1;
 #if (AMREX_SPACEDIM == 3)
-	int rr_k = (c_nodality[2] == 0) ? rr : 1;
+        int rr_k = (c_nodality[2] == 0) ? rr : 1;
 #else
-	int rr_k = 0;
+        int rr_k = 0;
 #endif
 
-	for ( MFIter mfi(mf_c,TilingIfNotGPU()); mfi.isValid(); ++mfi ) {
+        for ( MFIter mfi(mf_c,TilingIfNotGPU()); mfi.isValid(); ++mfi ) {
 
-	    const Box& bx = mfi.tilebox();
+            const Box& bx = mfi.tilebox();
 
-	    const Array4<Real const>& fine   = mf_f2.array(mfi);
-	    const Array4<Real      >& coarse = mf_c2.array(mfi);
+            const Array4<Real const>& fine   = mf_f2.array(mfi);
+            const Array4<Real      >& coarse = mf_c2.array(mfi);
 
-	    amrex::ParallelFor(bx, ncomp, [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
-			       {
-				   coarse(i,j,k,n) = 0.;
+            amrex::ParallelFor(bx, ncomp, [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
+                               {
+                                   coarse(i,j,k,n) = 0.;
 
 #if (AMREX_SPACEDIM==3)
-				   for (int kk=0; kk<rr_k; ++kk) {
+                                   for (int kk=0; kk<rr_k; ++kk) {
 #else
-				       int kk=0;
+                                       int kk=0;
 #endif
-				       for (int jj=0; jj<rr_j; ++jj) {
-					   for (int ii=0; ii<rr_i; ++ii) {
-					       coarse(i,j,k,n) += fine(rr*i+ii,rr*j+jj,rr*k+kk,n);
-					   }
-				       }
+                                       for (int jj=0; jj<rr_j; ++jj) {
+                                           for (int ii=0; ii<rr_i; ++ii) {
+                                               coarse(i,j,k,n) += fine(rr*i+ii,rr*j+jj,rr*k+kk,n);
+                                           }
+                                       }
 #if (AMREX_SPACEDIM==3)
-				   }
+                                   }
 #endif
-				   coarse(i,j,k,n) /= npts_avg;
-			       });
+                                   coarse(i,j,k,n) /= npts_avg;
+                               });
 
-	} // end MFIter
+        } // end MFIter
 
-	// subtract coarse from coarsened fine
-	MultiFab::Subtract(mf_c2,mf_c,0,0,ncomp,0);
+        // subtract coarse from coarsened fine
+        MultiFab::Subtract(mf_c2,mf_c,0,0,ncomp,0);
 
-	// force periodicity so faces/edges/nodes get weighted accordingly for L1 and L2 norms
-	IntVect iv(AMREX_D_DECL(bx_c.length(0),
-				bx_c.length(1),
-				bx_c.length(2)));
-	Periodicity period(iv);
+        // force periodicity so faces/edges/nodes get weighted accordingly for L1 and L2 norms
+        IntVect iv(AMREX_D_DECL(bx_c.length(0),
+                                bx_c.length(1),
+                                bx_c.length(2)));
+        Periodicity period(iv);
 
-	// compute norms of mf_c2
-	for (int i=0; i<ncomp; ++i) {
-	    Real norm0 = mf_c2.norm0(i);
-	    Real norm1 = mf_c2.norm1(i,period);
-	    Real norm2 = mf_c2.norm2(i,period);
-	    Print() << "(comp,L0,L1,L2) " << i << " "
-		    << norm0 << " "
-		    << norm1/npts_coarsedomain << " "
-		    << norm2/sqrt(npts_coarsedomain) << " " << std::endl;
-	}
+        // compute norms of mf_c2
+        for (int i=0; i<ncomp; ++i) {
+            Real norm0 = mf_c2.norm0(i);
+            Real norm1 = mf_c2.norm1(i,period);
+            Real norm2 = mf_c2.norm2(i,period);
+            Print() << "(comp,L0,L1,L2) " << i << " "
+                    << norm0 << " "
+                    << norm1/npts_coarsedomain << " "
+                    << norm2/sqrt(npts_coarsedomain) << " " << std::endl;
+        }
 
-	// write out the subtracted plotfile if diffile was specified at the command line
-	if (difFile != "") {
+        // write out the subtracted plotfile if diffile was specified at the command line
+        if (difFile != "") {
 
-	    // define the problem domain as (0,1) for now
-	    RealBox real_box({AMREX_D_DECL(0.,0.,0.)},
-			     {AMREX_D_DECL(1.,1.,1.)});
+            // define the problem domain as (0,1) for now
+            RealBox real_box({AMREX_D_DECL(0.,0.,0.)},
+                             {AMREX_D_DECL(1.,1.,1.)});
 
-	    Vector<int> is_periodic(AMREX_SPACEDIM,1);
+            Vector<int> is_periodic(AMREX_SPACEDIM,1);
 
-	    // build a geometry object so we can use WriteSingleLevelPlotfile
-	    Geometry geom(bx_c,&real_box,CoordSys::cartesian,is_periodic.data());
+            // build a geometry object so we can use WriteSingleLevelPlotfile
+            Geometry geom(bx_c,&real_box,CoordSys::cartesian,is_periodic.data());
 
-	    // give generic variables names for now
-	    Vector<std::string> varNames(ncomp);
-	    for (int i=0; i<ncomp; ++i) {
-		varNames[i] = std::to_string(i);
-	    }
+            // give generic variables names for now
+            Vector<std::string> varNames(ncomp);
+            for (int i=0; i<ncomp; ++i) {
+                varNames[i] = std::to_string(i);
+            }
 
-	    WriteSingleLevelPlotfile(difFile,mf_c2,varNames,geom,0.,0);
-	}
+            WriteSingleLevelPlotfile(difFile,mf_c2,varNames,geom,0.,0);
+        }
 
     }
     amrex::Finalize();

--- a/Tools/C_util/Convergence/DiffFab.cpp
+++ b/Tools/C_util/Convergence/DiffFab.cpp
@@ -67,89 +67,89 @@ main (int   argc,
     amrex::Initialize(argc,argv);
     {
 
-	ParmParse pp;
+        ParmParse pp;
 
-	FArrayBox::setFormat(FABio::FAB_IEEE_32);
-	//
-	// Scan the arguments.
-	//
-	std::string iFileDir, iFile, eFile, oFile, oFileDir;
+        FArrayBox::setFormat(FABio::FAB_IEEE_32);
+        //
+        // Scan the arguments.
+        //
+        std::string iFileDir, iFile, eFile, oFile, oFileDir;
 
 
-	pp.query("infile", iFile);
-	if (iFile.empty())
-	    amrex::Abort("You must specify `infile'");
+        pp.query("infile", iFile);
+        if (iFile.empty())
+            amrex::Abort("You must specify `infile'");
 
-	pp.query("exact", eFile);
-	if (eFile.empty())
-	    amrex::Abort("You must specify `exact' file");
+        pp.query("exact", eFile);
+        if (eFile.empty())
+            amrex::Abort("You must specify `exact' file");
 
-	pp.query("outfile", oFile);
-	bool do_out = !oFile.empty();
+        pp.query("outfile", oFile);
+        bool do_out = !oFile.empty();
 
-	std::ifstream is1(iFile.c_str(),ios::in);
-	std::ifstream is2(eFile.c_str(),ios::in);
-	std::ofstream os;
-	if (do_out) {
-	    os.open(oFile.c_str(),ios::out);
-	}
+        std::ifstream is1(iFile.c_str(),ios::in);
+        std::ifstream is2(eFile.c_str(),ios::in);
+        std::ofstream os;
+        if (do_out) {
+            os.open(oFile.c_str(),ios::out);
+        }
 
-	FArrayBox dataI, dataE;
-	dataI.readFrom(is1);
-	dataE.readFrom(is2);
+        FArrayBox dataI, dataE;
+        dataI.readFrom(is1);
+        dataE.readFrom(is2);
 
-	bool has_nan_I = dataE.contains_nan();
-	bool has_nan_E = dataI.contains_nan();
-	bool fabs_agree = false;
+        bool has_nan_I = dataE.contains_nan();
+        bool has_nan_E = dataI.contains_nan();
+        bool fabs_agree = false;
 
-	if (!has_nan_I && !has_nan_E) {
-	    BL_ASSERT(dataI.nComp() == dataE.nComp());
+        if (!has_nan_I && !has_nan_E) {
+            BL_ASSERT(dataI.nComp() == dataE.nComp());
 
-	    //
-	    // Compute the error
-	    //
-	    int nComp = dataI.nComp();
-	    const Box& domainI = dataI.box();
-	    const Box& domainE = dataE.box();
-	    IntVect refine_ratio = getRefRatio(domainI, domainE);
+            //
+            // Compute the error
+            //
+            int nComp = dataI.nComp();
+            const Box& domainI = dataI.box();
+            const Box& domainE = dataE.box();
+            IntVect refine_ratio = getRefRatio(domainI, domainE);
 
-	    if (refine_ratio == IntVect())
-		amrex::Error("Cannot find refinement ratio from data to exact");
+            if (refine_ratio == IntVect())
+                amrex::Error("Cannot find refinement ratio from data to exact");
 
-	    FArrayBox error(domainI,nComp);
-	    error.setVal(GARBAGE);
+            FArrayBox error(domainI,nComp);
+            error.setVal(GARBAGE);
 
-	    FArrayBox exactAvg(domainI,nComp);
+            FArrayBox exactAvg(domainI,nComp);
 
-	    FORT_CV_AVGDOWN(exactAvg.dataPtr(),
-			    ARLIM(exactAvg.loVect()),
-			    ARLIM(exactAvg.hiVect()), &nComp,
-			    dataE.dataPtr(),
-			    ARLIM(dataE.loVect()), ARLIM(dataE.hiVect()),
-			    domainI.loVect(), domainI.hiVect(),
-			    refine_ratio.getVect());
+            FORT_CV_AVGDOWN(exactAvg.dataPtr(),
+                            ARLIM(exactAvg.loVect()),
+                            ARLIM(exactAvg.hiVect()), &nComp,
+                            dataE.dataPtr(),
+                            ARLIM(dataE.loVect()), ARLIM(dataE.hiVect()),
+                            domainI.loVect(), domainI.hiVect(),
+                            refine_ratio.getVect());
 
-	    error.copy(exactAvg);
-	    error.minus(dataI);
-	    if (do_out) {
-		error.writeOn(os);
-	    }
-	    Box bx = error.box();
-	    int points = bx.numPts();
+            error.copy(exactAvg);
+            error.minus(dataI);
+            if (do_out) {
+                error.writeOn(os);
+            }
+            Box bx = error.box();
+            int points = bx.numPts();
 
-	    Real norm0 = error.norm(0);
-	    Real norm1 = error.norm(1)/points;
-	    Real norm2 = error.norm(2)/sqrt(points);
-	    std::cout << "L0 NORM                           = " << norm0 << std::endl;
-	    std::cout << "L1 NORM (normalized by 1/N)       = " << norm1 << std::endl;
-	    std::cout << "L2 NORM (normalized by 1/sqrt(N)) = " << norm2 << std::endl;
+            Real norm0 = error.norm(0);
+            Real norm1 = error.norm(1)/points;
+            Real norm2 = error.norm(2)/sqrt(points);
+            std::cout << "L0 NORM                           = " << norm0 << std::endl;
+            std::cout << "L1 NORM (normalized by 1/N)       = " << norm1 << std::endl;
+            std::cout << "L2 NORM (normalized by 1/sqrt(N)) = " << norm2 << std::endl;
 
-	    fabs_agree = (norm0 <= 1.e-20) && (norm1 <= 1.e-20) && (norm2 <= 1.e-20);
-	}
+            fabs_agree = (norm0 <= 1.e-20) && (norm1 <= 1.e-20) && (norm2 <= 1.e-20);
+        }
 
-	if (!has_nan_I && !has_nan_E && fabs_agree) {
-	    std::cout << "FABS AGREE" << std::endl;
-	}
+        if (!has_nan_I && !has_nan_E && fabs_agree) {
+            std::cout << "FABS AGREE" << std::endl;
+        }
 
     }
     amrex::Finalize();

--- a/Tools/C_util/Convergence/DiffFab.cpp
+++ b/Tools/C_util/Convergence/DiffFab.cpp
@@ -65,90 +65,92 @@ main (int   argc,
         PrintUsage(argv[0]);
 
     amrex::Initialize(argc,argv);
+    {
 
-    ParmParse pp;
+	ParmParse pp;
 
-    FArrayBox::setFormat(FABio::FAB_IEEE_32);
-    //
-    // Scan the arguments.
-    //
-    std::string iFileDir, iFile, eFile, oFile, oFileDir;
+	FArrayBox::setFormat(FABio::FAB_IEEE_32);
+	//
+	// Scan the arguments.
+	//
+	std::string iFileDir, iFile, eFile, oFile, oFileDir;
 
 
-    pp.query("infile", iFile);
-    if (iFile.empty())
-        amrex::Abort("You must specify `infile'");
+	pp.query("infile", iFile);
+	if (iFile.empty())
+	    amrex::Abort("You must specify `infile'");
 
-    pp.query("exact", eFile);
-    if (eFile.empty())
-        amrex::Abort("You must specify `exact' file");
+	pp.query("exact", eFile);
+	if (eFile.empty())
+	    amrex::Abort("You must specify `exact' file");
 
-    pp.query("outfile", oFile);
-    bool do_out = !oFile.empty();
+	pp.query("outfile", oFile);
+	bool do_out = !oFile.empty();
 
-    std::ifstream is1(iFile.c_str(),ios::in);
-    std::ifstream is2(eFile.c_str(),ios::in);
-    std::ofstream os;
-    if (do_out) {
-      os.open(oFile.c_str(),ios::out);
+	std::ifstream is1(iFile.c_str(),ios::in);
+	std::ifstream is2(eFile.c_str(),ios::in);
+	std::ofstream os;
+	if (do_out) {
+	    os.open(oFile.c_str(),ios::out);
+	}
+
+	FArrayBox dataI, dataE;
+	dataI.readFrom(is1);
+	dataE.readFrom(is2);
+
+	bool has_nan_I = dataE.contains_nan();
+	bool has_nan_E = dataI.contains_nan();
+	bool fabs_agree = false;
+
+	if (!has_nan_I && !has_nan_E) {
+	    BL_ASSERT(dataI.nComp() == dataE.nComp());
+
+	    //
+	    // Compute the error
+	    //
+	    int nComp = dataI.nComp();
+	    const Box& domainI = dataI.box();
+	    const Box& domainE = dataE.box();
+	    IntVect refine_ratio = getRefRatio(domainI, domainE);
+
+	    if (refine_ratio == IntVect())
+		amrex::Error("Cannot find refinement ratio from data to exact");
+
+	    FArrayBox error(domainI,nComp);
+	    error.setVal(GARBAGE);
+
+	    FArrayBox exactAvg(domainI,nComp);
+
+	    FORT_CV_AVGDOWN(exactAvg.dataPtr(),
+			    ARLIM(exactAvg.loVect()),
+			    ARLIM(exactAvg.hiVect()), &nComp,
+			    dataE.dataPtr(),
+			    ARLIM(dataE.loVect()), ARLIM(dataE.hiVect()),
+			    domainI.loVect(), domainI.hiVect(),
+			    refine_ratio.getVect());
+
+	    error.copy(exactAvg);
+	    error.minus(dataI);
+	    if (do_out) {
+		error.writeOn(os);
+	    }
+	    Box bx = error.box();
+	    int points = bx.numPts();
+
+	    Real norm0 = error.norm(0);
+	    Real norm1 = error.norm(1)/points;
+	    Real norm2 = error.norm(2)/sqrt(points);
+	    std::cout << "L0 NORM                           = " << norm0 << std::endl;
+	    std::cout << "L1 NORM (normalized by 1/N)       = " << norm1 << std::endl;
+	    std::cout << "L2 NORM (normalized by 1/sqrt(N)) = " << norm2 << std::endl;
+
+	    fabs_agree = (norm0 <= 1.e-20) && (norm1 <= 1.e-20) && (norm2 <= 1.e-20);
+	}
+
+	if (!has_nan_I && !has_nan_E && fabs_agree) {
+	    std::cout << "FABS AGREE" << std::endl;
+	}
+
     }
-
-    FArrayBox dataI, dataE;
-    dataI.readFrom(is1);
-    dataE.readFrom(is2);
-
-    bool has_nan_I = dataE.contains_nan();
-    bool has_nan_E = dataI.contains_nan();
-    bool fabs_agree = false;
-
-    if (!has_nan_I && !has_nan_E) {
-      BL_ASSERT(dataI.nComp() == dataE.nComp());
-
-      //
-      // Compute the error
-      //
-      int nComp = dataI.nComp();
-      const Box& domainI = dataI.box();
-      const Box& domainE = dataE.box();
-      IntVect refine_ratio = getRefRatio(domainI, domainE);
-
-      if (refine_ratio == IntVect())
-        amrex::Error("Cannot find refinement ratio from data to exact");
-
-      FArrayBox error(domainI,nComp);
-      error.setVal(GARBAGE);
-
-      FArrayBox exactAvg(domainI,nComp);
-
-      FORT_CV_AVGDOWN(exactAvg.dataPtr(),
-                      ARLIM(exactAvg.loVect()),
-                      ARLIM(exactAvg.hiVect()), &nComp,
-                      dataE.dataPtr(),
-                      ARLIM(dataE.loVect()), ARLIM(dataE.hiVect()),
-                      domainI.loVect(), domainI.hiVect(),
-                      refine_ratio.getVect());
-
-      error.copy(exactAvg);
-      error.minus(dataI);
-      if (do_out) {
-        error.writeOn(os);
-      }
-      Box bx = error.box();
-      int points = bx.numPts();
-
-      Real norm0 = error.norm(0);
-      Real norm1 = error.norm(1)/points;
-      Real norm2 = error.norm(2)/sqrt(points);
-      std::cout << "L0 NORM                           = " << norm0 << std::endl;
-      std::cout << "L1 NORM (normalized by 1/N)       = " << norm1 << std::endl;
-      std::cout << "L2 NORM (normalized by 1/sqrt(N)) = " << norm2 << std::endl;
-
-      fabs_agree = (norm0 <= 1.e-20) && (norm1 <= 1.e-20) && (norm2 <= 1.e-20);
-    }
-
-    if (!has_nan_I && !has_nan_E && fabs_agree) {
-      std::cout << "FABS AGREE" << std::endl;
-    }
-
     amrex::Finalize();
 }

--- a/Tools/C_util/Convergence/DiffSameDomainRefined.cpp
+++ b/Tools/C_util/Convergence/DiffSameDomainRefined.cpp
@@ -70,267 +70,269 @@ main (int   argc,
       char* argv[])
 {
     amrex::Initialize(argc,argv);
-
-    if (argc == 1)
-        PrintUsage(argv[0]);
-
-    ParmParse pp;
-
-    if (pp.contains("help"))
-        PrintUsage(argv[0]);
-
-    FArrayBox::setFormat(FABio::FAB_IEEE_32);
-    //
-    // Scan the arguments.
-    //
-    std::string iFile1, iFile2, difFile;
-
-    bool verbose = false;
-    if (pp.contains("verbose"))
     {
-        verbose = true;
-    }
-    pp.query("infile1", iFile1);
-    if (iFile1.empty())
-        amrex::Abort("You must specify `infile1'");
 
-    pp.query("reffile", iFile2);
-    if (iFile2.empty())
-        amrex::Abort("You must specify `reffile'");
+	if (argc == 1)
+	    PrintUsage(argv[0]);
 
-    pp.query("diffile", difFile);
+	ParmParse pp;
 
-    int norm = 2;
-    pp.query("norm", norm);
+	if (pp.contains("help"))
+	    PrintUsage(argv[0]);
 
-    DataServices::SetBatchMode();
-    Amrvis::FileType fileType(Amrvis::NEWPLT);
+	FArrayBox::setFormat(FABio::FAB_IEEE_32);
+	//
+	// Scan the arguments.
+	//
+	std::string iFile1, iFile2, difFile;
 
-    DataServices dataServices1(iFile1, fileType);
-    DataServices dataServices2(iFile2, fileType);
-
-    if (!dataServices1.AmrDataOk() || !dataServices2.AmrDataOk())
-        amrex::Abort("ERROR: Dataservices not OK");
-
-    //
-    // Generate AmrData Objects
-    //
-    AmrData& amrData1 = dataServices1.AmrDataRef();
-    AmrData& amrData2 = dataServices2.AmrDataRef();
-
-    //
-    // Initial Tests
-    //
-    if (amrData1.FinestLevel() != amrData2.FinestLevel())
-        amrex::Abort("ERROR: Finest level is not the same in the two plotfiles");
-
-    int nComp1      = amrData1.NComp();
-    int nComp2      = amrData2.NComp();
-
-    int nComp = std::min(nComp1,nComp2);
-
-    if (!amrDatasHaveSameDerives(amrData1,amrData2))
-    {
-        std::cout << "Warning: Plotfiles do not have the same state variables" << std::endl;
-        std::cout << "         Setting nComp to be the minimum number of variables: " << nComp << std::endl;
-    }
-
-    int finestLevel = amrData1.FinestLevel();
-    const Vector<std::string>& derives = amrData1.PlotVarNames();
-    Vector<int> destComps(nComp);
-    for (int i = 0; i < nComp; i++)
-        destComps[i] = i;
-
-
-    //
-    // Compute the error
-    //
-    Vector<MultiFab*> error(finestLevel+1);
-
-    if (ParallelDescriptor::IOProcessor())
-        std::cout << "Level  L"<< norm << " norm of Error in Each Component" << std::endl
-             << "-----------------------------------------------" << std::endl;
-
-    for (int iLevel = 0; iLevel <= finestLevel; ++iLevel)
-    {
-        //
-        // Construct level box array and check that the lengths are the same
-        //
-        const BoxArray& ba1 = amrData1.boxArray(iLevel);
-        const BoxArray& ba2 = amrData2.boxArray(iLevel);
-
-        if (ba1.size() != ba2.size())
-           std::cout << "Warning: BoxArray lengths are not the same at level " << iLevel << std::endl;
-
-        //
-        // Construct refinement ratio, build the coarsened boxarray
-        // (amrData2 is the refined plotfile)
-        //
-        const Box& domain1     = amrData1.ProbDomain()[iLevel];
-        const Box& domain2     = amrData2.ProbDomain()[iLevel];
-        IntVect refine_ratio   = getRefRatio(domain1, domain2);
-        if (refine_ratio == IntVect())
-            amrex::Error("Cannot find refinement ratio from data to exact");
-
-        if (verbose)
-            std::cerr << "level = " << iLevel << "  Ref_Ratio = " << refine_ratio
-                                                                  << std::endl;
-
-        BoxArray ba2Coarse(ba2);
-        ba2Coarse.coarsen(refine_ratio);
-
-        // Define new_data1 in case the boxarrays are not the same
-        DistributionMapping dm2Coarse(ba2Coarse);
-        MultiFab new_data1(ba2Coarse,dm2Coarse,1,0);
-
-        //
-        // Construct MultiFab for errors
-        //
-        error[iLevel] = new MultiFab(ba2Coarse, dm2Coarse, nComp, 0);
-        error[iLevel]->setVal(GARBAGE);
-
-        //
-        // For each component, average the fine fields down and calculate
-        // the errors
-        //
-        Vector<Real> norms(nComp);
-        for (int iComp = 0; iComp < nComp; iComp++)
-            norms[iComp] = 0.0;
-
-        for (int iComp = 0; iComp < nComp; ++iComp)
+	bool verbose = false;
+	if (pp.contains("verbose"))
         {
-            MultiFab& data1     = amrData1.GetGrids(iLevel, iComp);
-            MultiFab& data2Fine = amrData2.GetGrids(iLevel, iComp);
+	    verbose = true;
+        }
+	pp.query("infile1", iFile1);
+	if (iFile1.empty())
+	    amrex::Abort("You must specify `infile1'");
 
-            if (data1.contains_nan()) {
-                Abort("First plotfile contains NaN(s)");
-            }
-            if (data2Fine.contains_nan()) {
-                Abort("Second plotfile contains NaN(s)");
-            }
+	pp.query("reffile", iFile2);
+	if (iFile2.empty())
+	    amrex::Abort("You must specify `reffile'");
 
-            // Copy the data at the coarse level one component at a time
-            new_data1.copy(data1,0,0,1);
+	pp.query("diffile", difFile);
 
-            //
-            // Calculate the errors  for each FAB in the MultiFab
-            //
-            for (MFIter mfi(new_data1); mfi.isValid(); ++mfi)
-            {
-                //
-                // Create the Coarsened version of data2
-                //
-                int index = mfi.index();
+	int norm = 2;
+	pp.query("norm", norm);
 
-                const Box& bx = ba2Coarse[index];
-                FArrayBox data2Coarse(bx, 1);
-                int ncCoarse = 1;
+	DataServices::SetBatchMode();
+	Amrvis::FileType fileType(Amrvis::NEWPLT);
 
-                FORT_CV_AVGDOWN(data2Coarse.dataPtr(),
-                                ARLIM(bx.loVect()), ARLIM(bx.hiVect()),
-                                &ncCoarse,
-                                data2Fine[mfi].dataPtr(),
-                                ARLIM(data2Fine[mfi].loVect()),
-                                ARLIM(data2Fine[mfi].hiVect()),
-                                bx.loVect(), bx.hiVect(),
-                                refine_ratio.getVect());
+	DataServices dataServices1(iFile1, fileType);
+	DataServices dataServices2(iFile2, fileType);
 
+	if (!dataServices1.AmrDataOk() || !dataServices2.AmrDataOk())
+	    amrex::Abort("ERROR: Dataservices not OK");
 
-                //
-                // Calculate the errors on this FAB for this component
-                //
+	//
+	// Generate AmrData Objects
+	//
+	AmrData& amrData1 = dataServices1.AmrDataRef();
+	AmrData& amrData2 = dataServices2.AmrDataRef();
 
-                (*error[iLevel])[mfi].copy(new_data1[mfi], 0, iComp, 1);
-                (*error[iLevel])[mfi].minus(data2Coarse  , 0, iComp, 1);
+	//
+	// Initial Tests
+	//
+	if (amrData1.FinestLevel() != amrData2.FinestLevel())
+	    amrex::Abort("ERROR: Finest level is not the same in the two plotfiles");
 
-                Real grdL2 = (*error[iLevel])[mfi].norm(norm, iComp, 1);
+	int nComp1      = amrData1.NComp();
+	int nComp2      = amrData2.NComp();
 
-                if (norm != 0)
-                {
-                    norms[iComp] = norms[iComp] + pow(grdL2, norm);
-                }
-                else
-                {
-                    norms[iComp] = std::max(norms[iComp], grdL2);
-                }
-            }
+	int nComp = std::min(nComp1,nComp2);
+
+	if (!amrDatasHaveSameDerives(amrData1,amrData2))
+        {
+	    std::cout << "Warning: Plotfiles do not have the same state variables" << std::endl;
+	    std::cout << "         Setting nComp to be the minimum number of variables: " << nComp << std::endl;
         }
 
+	int finestLevel = amrData1.FinestLevel();
+	const Vector<std::string>& derives = amrData1.PlotVarNames();
+	Vector<int> destComps(nComp);
+	for (int i = 0; i < nComp; i++)
+	    destComps[i] = i;
 
-        //
-        // Output Statistics
-        //
-        if (ParallelDescriptor::IOProcessor())
-            std::cout << " Level: " << iLevel << "   \n";
+
+	//
+	// Compute the error
+	//
+	Vector<MultiFab*> error(finestLevel+1);
+
+	if (ParallelDescriptor::IOProcessor())
+	    std::cout << "Level  L"<< norm << " norm of Error in Each Component" << std::endl
+		      << "-----------------------------------------------" << std::endl;
+
+	for (int iLevel = 0; iLevel <= finestLevel; ++iLevel)
+        {
+	    //
+	    // Construct level box array and check that the lengths are the same
+	    //
+	    const BoxArray& ba1 = amrData1.boxArray(iLevel);
+	    const BoxArray& ba2 = amrData2.boxArray(iLevel);
+
+	    if (ba1.size() != ba2.size())
+		std::cout << "Warning: BoxArray lengths are not the same at level " << iLevel << std::endl;
+
+	    //
+	    // Construct refinement ratio, build the coarsened boxarray
+	    // (amrData2 is the refined plotfile)
+	    //
+	    const Box& domain1     = amrData1.ProbDomain()[iLevel];
+	    const Box& domain2     = amrData2.ProbDomain()[iLevel];
+	    IntVect refine_ratio   = getRefRatio(domain1, domain2);
+	    if (refine_ratio == IntVect())
+		amrex::Error("Cannot find refinement ratio from data to exact");
+
+	    if (verbose)
+		std::cerr << "level = " << iLevel << "  Ref_Ratio = " << refine_ratio
+			  << std::endl;
+
+	    BoxArray ba2Coarse(ba2);
+	    ba2Coarse.coarsen(refine_ratio);
+
+	    // Define new_data1 in case the boxarrays are not the same
+	    DistributionMapping dm2Coarse(ba2Coarse);
+	    MultiFab new_data1(ba2Coarse,dm2Coarse,1,0);
+
+	    //
+	    // Construct MultiFab for errors
+	    //
+	    error[iLevel] = new MultiFab(ba2Coarse, dm2Coarse, nComp, 0);
+	    error[iLevel]->setVal(GARBAGE);
+
+	    //
+	    // For each component, average the fine fields down and calculate
+	    // the errors
+	    //
+	    Vector<Real> norms(nComp);
+	    for (int iComp = 0; iComp < nComp; iComp++)
+		norms[iComp] = 0.0;
+
+	    for (int iComp = 0; iComp < nComp; ++iComp)
+            {
+		MultiFab& data1     = amrData1.GetGrids(iLevel, iComp);
+		MultiFab& data2Fine = amrData2.GetGrids(iLevel, iComp);
+
+		if (data1.contains_nan()) {
+		    Abort("First plotfile contains NaN(s)");
+		}
+		if (data2Fine.contains_nan()) {
+		    Abort("Second plotfile contains NaN(s)");
+		}
+
+		// Copy the data at the coarse level one component at a time
+		new_data1.copy(data1,0,0,1);
+
+		//
+		// Calculate the errors  for each FAB in the MultiFab
+		//
+		for (MFIter mfi(new_data1); mfi.isValid(); ++mfi)
+                {
+		    //
+		    // Create the Coarsened version of data2
+		    //
+		    int index = mfi.index();
+
+		    const Box& bx = ba2Coarse[index];
+		    FArrayBox data2Coarse(bx, 1);
+		    int ncCoarse = 1;
+
+		    FORT_CV_AVGDOWN(data2Coarse.dataPtr(),
+				    ARLIM(bx.loVect()), ARLIM(bx.hiVect()),
+				    &ncCoarse,
+				    data2Fine[mfi].dataPtr(),
+				    ARLIM(data2Fine[mfi].loVect()),
+				    ARLIM(data2Fine[mfi].hiVect()),
+				    bx.loVect(), bx.hiVect(),
+				    refine_ratio.getVect());
+
+
+		    //
+		    // Calculate the errors on this FAB for this component
+		    //
+
+		    (*error[iLevel])[mfi].copy(new_data1[mfi], 0, iComp, 1);
+		    (*error[iLevel])[mfi].minus(data2Coarse  , 0, iComp, 1);
+
+		    Real grdL2 = (*error[iLevel])[mfi].norm(norm, iComp, 1);
+
+		    if (norm != 0)
+                    {
+			norms[iComp] = norms[iComp] + pow(grdL2, norm);
+                    }
+		    else
+                    {
+			norms[iComp] = std::max(norms[iComp], grdL2);
+                    }
+                }
+            }
+
+
+	    //
+	    // Output Statistics
+	    //
+	    if (ParallelDescriptor::IOProcessor())
+		std::cout << " Level: " << iLevel << "   \n";
 
 
 #ifdef BL_USE_MPI
-        MPI_Datatype datatype = ParallelDescriptor::Mpi_typemap<Real>::type();
-        if (ParallelDescriptor::IOProcessor())
-        {
-            Vector<Real> tmp(nComp);
-            for (int proc = 0; proc < ParallelDescriptor::NProcs(); proc++)
-                if (proc != ParallelDescriptor::IOProcessorNumber())
-                {
-                    MPI_Status stat;
-                    int rc = MPI_Recv(tmp.dataPtr(), nComp, datatype,
-                                      MPI_ANY_SOURCE, proc, ParallelDescriptor::Communicator(),
-                                      &stat);
+	    MPI_Datatype datatype = ParallelDescriptor::Mpi_typemap<Real>::type();
+	    if (ParallelDescriptor::IOProcessor())
+            {
+		Vector<Real> tmp(nComp);
+		for (int proc = 0; proc < ParallelDescriptor::NProcs(); proc++)
+		    if (proc != ParallelDescriptor::IOProcessorNumber())
+		    {
+			MPI_Status stat;
+			int rc = MPI_Recv(tmp.dataPtr(), nComp, datatype,
+					  MPI_ANY_SOURCE, proc, ParallelDescriptor::Communicator(),
+					  &stat);
 
-                    if (rc != MPI_SUCCESS)
-                        ParallelDescriptor::Abort(rc);
+			if (rc != MPI_SUCCESS)
+			    ParallelDescriptor::Abort(rc);
 
-                    for (int iComp = 0; iComp < nComp; iComp++)
-                        if (norm != 0)
-                        {
-                            norms[iComp] = norms[iComp] + tmp[iComp];
-                        }
-                        else
-                        {
-                            norms[iComp] = std::max(norms[iComp], tmp[iComp]);
-                        }
-                }
-        }
-        else
-        {
-            int rc = MPI_Send(norms.dataPtr(), nComp, datatype,
-                              ParallelDescriptor::IOProcessorNumber(),
-                              ParallelDescriptor::MyProc(),
-                              ParallelDescriptor::Communicator());
+			for (int iComp = 0; iComp < nComp; iComp++)
+			    if (norm != 0)
+			    {
+				norms[iComp] = norms[iComp] + tmp[iComp];
+			    }
+			    else
+			    {
+				norms[iComp] = std::max(norms[iComp], tmp[iComp]);
+			    }
+		    }
+            }
+	    else
+            {
+		int rc = MPI_Send(norms.dataPtr(), nComp, datatype,
+				  ParallelDescriptor::IOProcessorNumber(),
+				  ParallelDescriptor::MyProc(),
+				  ParallelDescriptor::Communicator());
 
-            if (rc != MPI_SUCCESS)
-                ParallelDescriptor::Abort(rc);
-        }
+		if (rc != MPI_SUCCESS)
+		    ParallelDescriptor::Abort(rc);
+            }
 #endif
 
 
-        Real vol = 1.0;
-        for (int dir = 0; dir < BL_SPACEDIM; dir++)
-            vol *= amrData1.DxLevel()[iLevel][dir];
+	    Real vol = 1.0;
+	    for (int dir = 0; dir < BL_SPACEDIM; dir++)
+		vol *= amrData1.DxLevel()[iLevel][dir];
 
-        if (ParallelDescriptor::IOProcessor())
-        {
-            for (int iComp = 0; iComp < nComp; iComp++)
+	    if (ParallelDescriptor::IOProcessor())
             {
-                if (norm != 0)
+		for (int iComp = 0; iComp < nComp; iComp++)
                 {
-                    norms[iComp] = norms[iComp] * vol;
-                    norms[iComp] = pow(norms[iComp], (1.0/norm));
+		    if (norm != 0)
+                    {
+			norms[iComp] = norms[iComp] * vol;
+			norms[iComp] = pow(norms[iComp], (1.0/norm));
+                    }
+
+		    std::cout << derives[iComp] << " : " << norms[iComp] << " \n";
                 }
-
-                std::cout << derives[iComp] << " : " << norms[iComp] << " \n";
+		std::cout << std::endl;
             }
-            std::cout << std::endl;
         }
+
+
+	if (!difFile.empty())
+	    WritePlotFile(error, amrData1, difFile, verbose);
+
+	for (int iLevel = 0; iLevel <= finestLevel; ++iLevel)
+	    delete error[iLevel];
+
     }
-
-
-    if (!difFile.empty())
-        WritePlotFile(error, amrData1, difFile, verbose);
-
-    for (int iLevel = 0; iLevel <= finestLevel; ++iLevel)
-        delete error[iLevel];
-
     amrex::Finalize();
 }
 

--- a/Tools/C_util/Convergence/DiffSameDomainRefined.cpp
+++ b/Tools/C_util/Convergence/DiffSameDomainRefined.cpp
@@ -72,265 +72,265 @@ main (int   argc,
     amrex::Initialize(argc,argv);
     {
 
-	if (argc == 1)
-	    PrintUsage(argv[0]);
+        if (argc == 1)
+            PrintUsage(argv[0]);
 
-	ParmParse pp;
+        ParmParse pp;
 
-	if (pp.contains("help"))
-	    PrintUsage(argv[0]);
+        if (pp.contains("help"))
+            PrintUsage(argv[0]);
 
-	FArrayBox::setFormat(FABio::FAB_IEEE_32);
-	//
-	// Scan the arguments.
-	//
-	std::string iFile1, iFile2, difFile;
+        FArrayBox::setFormat(FABio::FAB_IEEE_32);
+        //
+        // Scan the arguments.
+        //
+        std::string iFile1, iFile2, difFile;
 
-	bool verbose = false;
-	if (pp.contains("verbose"))
+        bool verbose = false;
+        if (pp.contains("verbose"))
         {
-	    verbose = true;
+            verbose = true;
         }
-	pp.query("infile1", iFile1);
-	if (iFile1.empty())
-	    amrex::Abort("You must specify `infile1'");
+        pp.query("infile1", iFile1);
+        if (iFile1.empty())
+            amrex::Abort("You must specify `infile1'");
 
-	pp.query("reffile", iFile2);
-	if (iFile2.empty())
-	    amrex::Abort("You must specify `reffile'");
+        pp.query("reffile", iFile2);
+        if (iFile2.empty())
+            amrex::Abort("You must specify `reffile'");
 
-	pp.query("diffile", difFile);
+        pp.query("diffile", difFile);
 
-	int norm = 2;
-	pp.query("norm", norm);
+        int norm = 2;
+        pp.query("norm", norm);
 
-	DataServices::SetBatchMode();
-	Amrvis::FileType fileType(Amrvis::NEWPLT);
+        DataServices::SetBatchMode();
+        Amrvis::FileType fileType(Amrvis::NEWPLT);
 
-	DataServices dataServices1(iFile1, fileType);
-	DataServices dataServices2(iFile2, fileType);
+        DataServices dataServices1(iFile1, fileType);
+        DataServices dataServices2(iFile2, fileType);
 
-	if (!dataServices1.AmrDataOk() || !dataServices2.AmrDataOk())
-	    amrex::Abort("ERROR: Dataservices not OK");
+        if (!dataServices1.AmrDataOk() || !dataServices2.AmrDataOk())
+            amrex::Abort("ERROR: Dataservices not OK");
 
-	//
-	// Generate AmrData Objects
-	//
-	AmrData& amrData1 = dataServices1.AmrDataRef();
-	AmrData& amrData2 = dataServices2.AmrDataRef();
+        //
+        // Generate AmrData Objects
+        //
+        AmrData& amrData1 = dataServices1.AmrDataRef();
+        AmrData& amrData2 = dataServices2.AmrDataRef();
 
-	//
-	// Initial Tests
-	//
-	if (amrData1.FinestLevel() != amrData2.FinestLevel())
-	    amrex::Abort("ERROR: Finest level is not the same in the two plotfiles");
+        //
+        // Initial Tests
+        //
+        if (amrData1.FinestLevel() != amrData2.FinestLevel())
+            amrex::Abort("ERROR: Finest level is not the same in the two plotfiles");
 
-	int nComp1      = amrData1.NComp();
-	int nComp2      = amrData2.NComp();
+        int nComp1      = amrData1.NComp();
+        int nComp2      = amrData2.NComp();
 
-	int nComp = std::min(nComp1,nComp2);
+        int nComp = std::min(nComp1,nComp2);
 
-	if (!amrDatasHaveSameDerives(amrData1,amrData2))
+        if (!amrDatasHaveSameDerives(amrData1,amrData2))
         {
-	    std::cout << "Warning: Plotfiles do not have the same state variables" << std::endl;
-	    std::cout << "         Setting nComp to be the minimum number of variables: " << nComp << std::endl;
+            std::cout << "Warning: Plotfiles do not have the same state variables" << std::endl;
+            std::cout << "         Setting nComp to be the minimum number of variables: " << nComp << std::endl;
         }
 
-	int finestLevel = amrData1.FinestLevel();
-	const Vector<std::string>& derives = amrData1.PlotVarNames();
-	Vector<int> destComps(nComp);
-	for (int i = 0; i < nComp; i++)
-	    destComps[i] = i;
+        int finestLevel = amrData1.FinestLevel();
+        const Vector<std::string>& derives = amrData1.PlotVarNames();
+        Vector<int> destComps(nComp);
+        for (int i = 0; i < nComp; i++)
+            destComps[i] = i;
 
 
-	//
-	// Compute the error
-	//
-	Vector<MultiFab*> error(finestLevel+1);
+        //
+        // Compute the error
+        //
+        Vector<MultiFab*> error(finestLevel+1);
 
-	if (ParallelDescriptor::IOProcessor())
-	    std::cout << "Level  L"<< norm << " norm of Error in Each Component" << std::endl
-		      << "-----------------------------------------------" << std::endl;
+        if (ParallelDescriptor::IOProcessor())
+            std::cout << "Level  L"<< norm << " norm of Error in Each Component" << std::endl
+                      << "-----------------------------------------------" << std::endl;
 
-	for (int iLevel = 0; iLevel <= finestLevel; ++iLevel)
+        for (int iLevel = 0; iLevel <= finestLevel; ++iLevel)
         {
-	    //
-	    // Construct level box array and check that the lengths are the same
-	    //
-	    const BoxArray& ba1 = amrData1.boxArray(iLevel);
-	    const BoxArray& ba2 = amrData2.boxArray(iLevel);
+            //
+            // Construct level box array and check that the lengths are the same
+            //
+            const BoxArray& ba1 = amrData1.boxArray(iLevel);
+            const BoxArray& ba2 = amrData2.boxArray(iLevel);
 
-	    if (ba1.size() != ba2.size())
-		std::cout << "Warning: BoxArray lengths are not the same at level " << iLevel << std::endl;
+            if (ba1.size() != ba2.size())
+                std::cout << "Warning: BoxArray lengths are not the same at level " << iLevel << std::endl;
 
-	    //
-	    // Construct refinement ratio, build the coarsened boxarray
-	    // (amrData2 is the refined plotfile)
-	    //
-	    const Box& domain1     = amrData1.ProbDomain()[iLevel];
-	    const Box& domain2     = amrData2.ProbDomain()[iLevel];
-	    IntVect refine_ratio   = getRefRatio(domain1, domain2);
-	    if (refine_ratio == IntVect())
-		amrex::Error("Cannot find refinement ratio from data to exact");
+            //
+            // Construct refinement ratio, build the coarsened boxarray
+            // (amrData2 is the refined plotfile)
+            //
+            const Box& domain1     = amrData1.ProbDomain()[iLevel];
+            const Box& domain2     = amrData2.ProbDomain()[iLevel];
+            IntVect refine_ratio   = getRefRatio(domain1, domain2);
+            if (refine_ratio == IntVect())
+                amrex::Error("Cannot find refinement ratio from data to exact");
 
-	    if (verbose)
-		std::cerr << "level = " << iLevel << "  Ref_Ratio = " << refine_ratio
-			  << std::endl;
+            if (verbose)
+                std::cerr << "level = " << iLevel << "  Ref_Ratio = " << refine_ratio
+                          << std::endl;
 
-	    BoxArray ba2Coarse(ba2);
-	    ba2Coarse.coarsen(refine_ratio);
+            BoxArray ba2Coarse(ba2);
+            ba2Coarse.coarsen(refine_ratio);
 
-	    // Define new_data1 in case the boxarrays are not the same
-	    DistributionMapping dm2Coarse(ba2Coarse);
-	    MultiFab new_data1(ba2Coarse,dm2Coarse,1,0);
+            // Define new_data1 in case the boxarrays are not the same
+            DistributionMapping dm2Coarse(ba2Coarse);
+            MultiFab new_data1(ba2Coarse,dm2Coarse,1,0);
 
-	    //
-	    // Construct MultiFab for errors
-	    //
-	    error[iLevel] = new MultiFab(ba2Coarse, dm2Coarse, nComp, 0);
-	    error[iLevel]->setVal(GARBAGE);
+            //
+            // Construct MultiFab for errors
+            //
+            error[iLevel] = new MultiFab(ba2Coarse, dm2Coarse, nComp, 0);
+            error[iLevel]->setVal(GARBAGE);
 
-	    //
-	    // For each component, average the fine fields down and calculate
-	    // the errors
-	    //
-	    Vector<Real> norms(nComp);
-	    for (int iComp = 0; iComp < nComp; iComp++)
-		norms[iComp] = 0.0;
+            //
+            // For each component, average the fine fields down and calculate
+            // the errors
+            //
+            Vector<Real> norms(nComp);
+            for (int iComp = 0; iComp < nComp; iComp++)
+                norms[iComp] = 0.0;
 
-	    for (int iComp = 0; iComp < nComp; ++iComp)
+            for (int iComp = 0; iComp < nComp; ++iComp)
             {
-		MultiFab& data1     = amrData1.GetGrids(iLevel, iComp);
-		MultiFab& data2Fine = amrData2.GetGrids(iLevel, iComp);
+                MultiFab& data1     = amrData1.GetGrids(iLevel, iComp);
+                MultiFab& data2Fine = amrData2.GetGrids(iLevel, iComp);
 
-		if (data1.contains_nan()) {
-		    Abort("First plotfile contains NaN(s)");
-		}
-		if (data2Fine.contains_nan()) {
-		    Abort("Second plotfile contains NaN(s)");
-		}
+                if (data1.contains_nan()) {
+                    Abort("First plotfile contains NaN(s)");
+                }
+                if (data2Fine.contains_nan()) {
+                    Abort("Second plotfile contains NaN(s)");
+                }
 
-		// Copy the data at the coarse level one component at a time
-		new_data1.copy(data1,0,0,1);
+                // Copy the data at the coarse level one component at a time
+                new_data1.copy(data1,0,0,1);
 
-		//
-		// Calculate the errors  for each FAB in the MultiFab
-		//
-		for (MFIter mfi(new_data1); mfi.isValid(); ++mfi)
+                //
+                // Calculate the errors  for each FAB in the MultiFab
+                //
+                for (MFIter mfi(new_data1); mfi.isValid(); ++mfi)
                 {
-		    //
-		    // Create the Coarsened version of data2
-		    //
-		    int index = mfi.index();
+                    //
+                    // Create the Coarsened version of data2
+                    //
+                    int index = mfi.index();
 
-		    const Box& bx = ba2Coarse[index];
-		    FArrayBox data2Coarse(bx, 1);
-		    int ncCoarse = 1;
+                    const Box& bx = ba2Coarse[index];
+                    FArrayBox data2Coarse(bx, 1);
+                    int ncCoarse = 1;
 
-		    FORT_CV_AVGDOWN(data2Coarse.dataPtr(),
-				    ARLIM(bx.loVect()), ARLIM(bx.hiVect()),
-				    &ncCoarse,
-				    data2Fine[mfi].dataPtr(),
-				    ARLIM(data2Fine[mfi].loVect()),
-				    ARLIM(data2Fine[mfi].hiVect()),
-				    bx.loVect(), bx.hiVect(),
-				    refine_ratio.getVect());
+                    FORT_CV_AVGDOWN(data2Coarse.dataPtr(),
+                                    ARLIM(bx.loVect()), ARLIM(bx.hiVect()),
+                                    &ncCoarse,
+                                    data2Fine[mfi].dataPtr(),
+                                    ARLIM(data2Fine[mfi].loVect()),
+                                    ARLIM(data2Fine[mfi].hiVect()),
+                                    bx.loVect(), bx.hiVect(),
+                                    refine_ratio.getVect());
 
 
-		    //
-		    // Calculate the errors on this FAB for this component
-		    //
+                    //
+                    // Calculate the errors on this FAB for this component
+                    //
 
-		    (*error[iLevel])[mfi].copy(new_data1[mfi], 0, iComp, 1);
-		    (*error[iLevel])[mfi].minus(data2Coarse  , 0, iComp, 1);
+                    (*error[iLevel])[mfi].copy(new_data1[mfi], 0, iComp, 1);
+                    (*error[iLevel])[mfi].minus(data2Coarse  , 0, iComp, 1);
 
-		    Real grdL2 = (*error[iLevel])[mfi].norm(norm, iComp, 1);
+                    Real grdL2 = (*error[iLevel])[mfi].norm(norm, iComp, 1);
 
-		    if (norm != 0)
+                    if (norm != 0)
                     {
-			norms[iComp] = norms[iComp] + pow(grdL2, norm);
+                        norms[iComp] = norms[iComp] + pow(grdL2, norm);
                     }
-		    else
+                    else
                     {
-			norms[iComp] = std::max(norms[iComp], grdL2);
+                        norms[iComp] = std::max(norms[iComp], grdL2);
                     }
                 }
             }
 
 
-	    //
-	    // Output Statistics
-	    //
-	    if (ParallelDescriptor::IOProcessor())
-		std::cout << " Level: " << iLevel << "   \n";
+            //
+            // Output Statistics
+            //
+            if (ParallelDescriptor::IOProcessor())
+                std::cout << " Level: " << iLevel << "   \n";
 
 
 #ifdef BL_USE_MPI
-	    MPI_Datatype datatype = ParallelDescriptor::Mpi_typemap<Real>::type();
-	    if (ParallelDescriptor::IOProcessor())
+            MPI_Datatype datatype = ParallelDescriptor::Mpi_typemap<Real>::type();
+            if (ParallelDescriptor::IOProcessor())
             {
-		Vector<Real> tmp(nComp);
-		for (int proc = 0; proc < ParallelDescriptor::NProcs(); proc++)
-		    if (proc != ParallelDescriptor::IOProcessorNumber())
-		    {
-			MPI_Status stat;
-			int rc = MPI_Recv(tmp.dataPtr(), nComp, datatype,
-					  MPI_ANY_SOURCE, proc, ParallelDescriptor::Communicator(),
-					  &stat);
+                Vector<Real> tmp(nComp);
+                for (int proc = 0; proc < ParallelDescriptor::NProcs(); proc++)
+                    if (proc != ParallelDescriptor::IOProcessorNumber())
+                    {
+                        MPI_Status stat;
+                        int rc = MPI_Recv(tmp.dataPtr(), nComp, datatype,
+                                          MPI_ANY_SOURCE, proc, ParallelDescriptor::Communicator(),
+                                          &stat);
 
-			if (rc != MPI_SUCCESS)
-			    ParallelDescriptor::Abort(rc);
+                        if (rc != MPI_SUCCESS)
+                            ParallelDescriptor::Abort(rc);
 
-			for (int iComp = 0; iComp < nComp; iComp++)
-			    if (norm != 0)
-			    {
-				norms[iComp] = norms[iComp] + tmp[iComp];
-			    }
-			    else
-			    {
-				norms[iComp] = std::max(norms[iComp], tmp[iComp]);
-			    }
-		    }
+                        for (int iComp = 0; iComp < nComp; iComp++)
+                            if (norm != 0)
+                            {
+                                norms[iComp] = norms[iComp] + tmp[iComp];
+                            }
+                            else
+                            {
+                                norms[iComp] = std::max(norms[iComp], tmp[iComp]);
+                            }
+                    }
             }
-	    else
+            else
             {
-		int rc = MPI_Send(norms.dataPtr(), nComp, datatype,
-				  ParallelDescriptor::IOProcessorNumber(),
-				  ParallelDescriptor::MyProc(),
-				  ParallelDescriptor::Communicator());
+                int rc = MPI_Send(norms.dataPtr(), nComp, datatype,
+                                  ParallelDescriptor::IOProcessorNumber(),
+                                  ParallelDescriptor::MyProc(),
+                                  ParallelDescriptor::Communicator());
 
-		if (rc != MPI_SUCCESS)
-		    ParallelDescriptor::Abort(rc);
+                if (rc != MPI_SUCCESS)
+                    ParallelDescriptor::Abort(rc);
             }
 #endif
 
 
-	    Real vol = 1.0;
-	    for (int dir = 0; dir < BL_SPACEDIM; dir++)
-		vol *= amrData1.DxLevel()[iLevel][dir];
+            Real vol = 1.0;
+            for (int dir = 0; dir < BL_SPACEDIM; dir++)
+                vol *= amrData1.DxLevel()[iLevel][dir];
 
-	    if (ParallelDescriptor::IOProcessor())
+            if (ParallelDescriptor::IOProcessor())
             {
-		for (int iComp = 0; iComp < nComp; iComp++)
+                for (int iComp = 0; iComp < nComp; iComp++)
                 {
-		    if (norm != 0)
+                    if (norm != 0)
                     {
-			norms[iComp] = norms[iComp] * vol;
-			norms[iComp] = pow(norms[iComp], (1.0/norm));
+                        norms[iComp] = norms[iComp] * vol;
+                        norms[iComp] = pow(norms[iComp], (1.0/norm));
                     }
 
-		    std::cout << derives[iComp] << " : " << norms[iComp] << " \n";
+                    std::cout << derives[iComp] << " : " << norms[iComp] << " \n";
                 }
-		std::cout << std::endl;
+                std::cout << std::endl;
             }
         }
 
 
-	if (!difFile.empty())
-	    WritePlotFile(error, amrData1, difFile, verbose);
+        if (!difFile.empty())
+            WritePlotFile(error, amrData1, difFile, verbose);
 
-	for (int iLevel = 0; iLevel <= finestLevel; ++iLevel)
-	    delete error[iLevel];
+        for (int iLevel = 0; iLevel <= finestLevel; ++iLevel)
+            delete error[iLevel];
 
     }
     amrex::Finalize();

--- a/Tools/C_util/Convergence/DiffSameDomainRefinedComposite.cpp
+++ b/Tools/C_util/Convergence/DiffSameDomainRefinedComposite.cpp
@@ -72,300 +72,302 @@ int
 main (int   argc,
       char* argv[])
 {
-  amrex::Initialize(argc,argv);
-
-    if (argc == 1)
-        PrintUsage(argv[0]);
-
-    ParmParse pp;
-
-    if (pp.contains("help"))
-        PrintUsage(argv[0]);
-
-    FArrayBox::setFormat(FABio::FAB_IEEE_32);
-    //
-    // Scan the arguments.
-    //
-    std::string iFile1, iFile2, difFile;
-
-    bool verbose = false;
-    if (pp.contains("verbose"))
+    amrex::Initialize(argc,argv);
     {
-        verbose = true;
-    }
-    pp.query("infile1", iFile1);
-    if (iFile1.empty())
-        amrex::Abort("You must specify `infile1'");
 
-    pp.query("reffile", iFile2);
-    if (iFile2.empty())
-        amrex::Abort("You must specify `reffile'");
+	if (argc == 1)
+	    PrintUsage(argv[0]);
 
-    pp.query("diffile", difFile);
+	ParmParse pp;
 
-    int norm = 2;
-    pp.query("norm", norm);
+	if (pp.contains("help"))
+	    PrintUsage(argv[0]);
 
-    DataServices::SetBatchMode();
-    Amrvis::FileType fileType(Amrvis::NEWPLT);
+	FArrayBox::setFormat(FABio::FAB_IEEE_32);
+	//
+	// Scan the arguments.
+	//
+	std::string iFile1, iFile2, difFile;
 
-    DataServices dataServices1(iFile1, fileType);
-    DataServices dataServices2(iFile2, fileType);
+	bool verbose = false;
+	if (pp.contains("verbose"))
+	{
+	    verbose = true;
+	}
+	pp.query("infile1", iFile1);
+	if (iFile1.empty())
+	    amrex::Abort("You must specify `infile1'");
 
-    if (!dataServices1.AmrDataOk() || !dataServices2.AmrDataOk())
-        amrex::Abort("ERROR: Dataservices not OK");
+	pp.query("reffile", iFile2);
+	if (iFile2.empty())
+	    amrex::Abort("You must specify `reffile'");
 
-    //
-    // Generate AmrData Objects
-    //
-    AmrData& amrData1 = dataServices1.AmrDataRef();
-    AmrData& amrData2 = dataServices2.AmrDataRef();
+	pp.query("diffile", difFile);
 
-    //
-    // Initial Tests
-    //
-    if (amrData1.FinestLevel() != amrData2.FinestLevel())
-        amrex::Abort("ERROR: Finest level is not the same in the two plotfiles");
+	int norm = 2;
+	pp.query("norm", norm);
 
-    int nComp1      = amrData1.NComp();
-    int nComp2      = amrData2.NComp();
+	DataServices::SetBatchMode();
+	Amrvis::FileType fileType(Amrvis::NEWPLT);
 
-    int nComp = std::min(nComp1,nComp2);
+	DataServices dataServices1(iFile1, fileType);
+	DataServices dataServices2(iFile2, fileType);
 
-    if (!amrDatasHaveSameDerives(amrData1,amrData2))
-    {
-        std::cout << "Warning: Plotfiles do not have the same state variables" << std::endl;
-        std::cout << "         Setting nComp to be the minimum number of variables: " << nComp << std::endl;
-    }
+	if (!dataServices1.AmrDataOk() || !dataServices2.AmrDataOk())
+	    amrex::Abort("ERROR: Dataservices not OK");
 
-    int finestLevel = amrData1.FinestLevel();
-    const Vector<std::string>& derives = amrData1.PlotVarNames();
-    Vector<int> destComps(nComp);
-    for (int i = 0; i < nComp; i++)
-        destComps[i] = i;
+	//
+	// Generate AmrData Objects
+	//
+	AmrData& amrData1 = dataServices1.AmrDataRef();
+	AmrData& amrData2 = dataServices2.AmrDataRef();
 
+	//
+	// Initial Tests
+	//
+	if (amrData1.FinestLevel() != amrData2.FinestLevel())
+	    amrex::Abort("ERROR: Finest level is not the same in the two plotfiles");
 
-    //
-    // Compute the error
-    //
-    Vector<MultiFab*> error(finestLevel+1);
+	int nComp1      = amrData1.NComp();
+	int nComp2      = amrData2.NComp();
 
-    if (ParallelDescriptor::IOProcessor())
-        std::cout << "Level  L"<< norm << " norm of Error in Each Component" << std::endl
-             << "-----------------------------------------------" << std::endl;
+	int nComp = std::min(nComp1,nComp2);
 
-    int ratio = 1;
-    Vector<Real> sum_norms(nComp);
-        for (int iComp = 0; iComp < nComp; iComp++)
-            sum_norms[iComp] = 0.0;
-    for (int iLevel = 0; iLevel <= finestLevel; ++iLevel)
-    {
-        //
-        // Construct level box array and check that the lengths are the same
-        //
-        const BoxArray& ba1 = amrData1.boxArray(iLevel);
-        const BoxArray& ba2 = amrData2.boxArray(iLevel);
+	if (!amrDatasHaveSameDerives(amrData1,amrData2))
+	{
+	    std::cout << "Warning: Plotfiles do not have the same state variables" << std::endl;
+	    std::cout << "         Setting nComp to be the minimum number of variables: " << nComp << std::endl;
+	}
 
-        if (ba1.size() != ba2.size())
-           std::cout << "Warning: BoxArray lengths are not the same at level " << iLevel << std::endl;
-
-        //
-        // Construct refinement ratio, build the coarsened boxarray
-        // (amrData2 is the refined plotfile)
-        //
-        const Box& domain1     = amrData1.ProbDomain()[iLevel];
-        const Box& domain2     = amrData2.ProbDomain()[iLevel];
-        IntVect refine_ratio   = getRefRatio(domain1, domain2);
-        if (refine_ratio == IntVect())
-            amrex::Error("Cannot find refinement ratio from data to exact");
-
-        if (verbose)
-            std::cerr << "level = " << iLevel << "  Ref_Ratio = " << refine_ratio
-                                                                  << std::endl;
-
-        BoxArray ba2Coarse(ba2);
-        ba2Coarse.coarsen(refine_ratio);
-
-        // Define new_data1 in case the boxarrays are not the same
-        DistributionMapping dm2Coarse(ba2Coarse);
-        MultiFab new_data1(ba2Coarse,dm2Coarse, 1,0);
-
-        //
-        // Construct MultiFab for errors
-        //
-        error[iLevel] = new MultiFab(ba2Coarse, dm2Coarse, nComp, 0);
-        error[iLevel]->setVal(GARBAGE);
-
-        //
-        // For each component, average the fine fields down and calculate
-        // the errors
-        //
-        Vector<Real> norms(nComp);
-        for (int iComp = 0; iComp < nComp; iComp++)
-            norms[iComp] = 0.0;
-
-        for (int iComp = 0; iComp < nComp; ++iComp)
-        {
-            MultiFab& data1     = amrData1.GetGrids(iLevel, iComp);
-            MultiFab& data2Fine = amrData2.GetGrids(iLevel, iComp);
-
-            if (data1.contains_nan()) {
-                Abort("First plotfile contains NaN(s)");
-            }
-            if (data2Fine.contains_nan()) {
-                Abort("Second plotfile contains NaN(s)");
-            }
-
-            BoxArray baf;
-            if (iLevel<finestLevel)
-             {
-              baf = BoxArray(amrData1.boxArray(iLevel+1)).coarsen(refine_ratio);
-             }
+	int finestLevel = amrData1.FinestLevel();
+	const Vector<std::string>& derives = amrData1.PlotVarNames();
+	Vector<int> destComps(nComp);
+	for (int i = 0; i < nComp; i++)
+	    destComps[i] = i;
 
 
-            // Copy the data at the coarse level one component at a time
-            new_data1.copy(data1,0,0,1);
+	//
+	// Compute the error
+	//
+	Vector<MultiFab*> error(finestLevel+1);
 
-            //
-            // Calculate the errors  for each FAB in the MultiFab
-            //
-            for (MFIter mfi(new_data1); mfi.isValid(); ++mfi)
-            {
-                //
-                // Create the Coarsened version of data2
-                //
-                int index = mfi.index();
+	if (ParallelDescriptor::IOProcessor())
+	    std::cout << "Level  L"<< norm << " norm of Error in Each Component" << std::endl
+		      << "-----------------------------------------------" << std::endl;
 
-                const Box& bx = ba2Coarse[index];
-                FArrayBox data2Coarse(bx, 1);
-                int ncCoarse = 1;
+	int ratio = 1;
+	Vector<Real> sum_norms(nComp);
+	for (int iComp = 0; iComp < nComp; iComp++)
+	    sum_norms[iComp] = 0.0;
+	for (int iLevel = 0; iLevel <= finestLevel; ++iLevel)
+	{
+	    //
+	    // Construct level box array and check that the lengths are the same
+	    //
+	    const BoxArray& ba1 = amrData1.boxArray(iLevel);
+	    const BoxArray& ba2 = amrData2.boxArray(iLevel);
+
+	    if (ba1.size() != ba2.size())
+		std::cout << "Warning: BoxArray lengths are not the same at level " << iLevel << std::endl;
+
+	    //
+	    // Construct refinement ratio, build the coarsened boxarray
+	    // (amrData2 is the refined plotfile)
+	    //
+	    const Box& domain1     = amrData1.ProbDomain()[iLevel];
+	    const Box& domain2     = amrData2.ProbDomain()[iLevel];
+	    IntVect refine_ratio   = getRefRatio(domain1, domain2);
+	    if (refine_ratio == IntVect())
+		amrex::Error("Cannot find refinement ratio from data to exact");
+
+	    if (verbose)
+		std::cerr << "level = " << iLevel << "  Ref_Ratio = " << refine_ratio
+			  << std::endl;
+
+	    BoxArray ba2Coarse(ba2);
+	    ba2Coarse.coarsen(refine_ratio);
+
+	    // Define new_data1 in case the boxarrays are not the same
+	    DistributionMapping dm2Coarse(ba2Coarse);
+	    MultiFab new_data1(ba2Coarse,dm2Coarse, 1,0);
+
+	    //
+	    // Construct MultiFab for errors
+	    //
+	    error[iLevel] = new MultiFab(ba2Coarse, dm2Coarse, nComp, 0);
+	    error[iLevel]->setVal(GARBAGE);
+
+	    //
+	    // For each component, average the fine fields down and calculate
+	    // the errors
+	    //
+	    Vector<Real> norms(nComp);
+	    for (int iComp = 0; iComp < nComp; iComp++)
+		norms[iComp] = 0.0;
+
+	    for (int iComp = 0; iComp < nComp; ++iComp)
+	    {
+		MultiFab& data1     = amrData1.GetGrids(iLevel, iComp);
+		MultiFab& data2Fine = amrData2.GetGrids(iLevel, iComp);
+
+		if (data1.contains_nan()) {
+		    Abort("First plotfile contains NaN(s)");
+		}
+		if (data2Fine.contains_nan()) {
+		    Abort("Second plotfile contains NaN(s)");
+		}
+
+		BoxArray baf;
+		if (iLevel<finestLevel)
+		{
+		    baf = BoxArray(amrData1.boxArray(iLevel+1)).coarsen(refine_ratio);
+		}
+
+
+		// Copy the data at the coarse level one component at a time
+		new_data1.copy(data1,0,0,1);
+
+		//
+		// Calculate the errors  for each FAB in the MultiFab
+		//
+		for (MFIter mfi(new_data1); mfi.isValid(); ++mfi)
+		{
+		    //
+		    // Create the Coarsened version of data2
+		    //
+		    int index = mfi.index();
+
+		    const Box& bx = ba2Coarse[index];
+		    FArrayBox data2Coarse(bx, 1);
+		    int ncCoarse = 1;
 
 
 
-                FORT_CV_AVGDOWN(data2Coarse.dataPtr(),
-                                ARLIM(bx.loVect()), ARLIM(bx.hiVect()),
-                                &ncCoarse,
-                                data2Fine[mfi].dataPtr(),
-                                ARLIM(data2Fine[mfi].loVect()),
-                                ARLIM(data2Fine[mfi].hiVect()),
-                                bx.loVect(), bx.hiVect(),
-                                refine_ratio.getVect());
+		    FORT_CV_AVGDOWN(data2Coarse.dataPtr(),
+				    ARLIM(bx.loVect()), ARLIM(bx.hiVect()),
+				    &ncCoarse,
+				    data2Fine[mfi].dataPtr(),
+				    ARLIM(data2Fine[mfi].loVect()),
+				    ARLIM(data2Fine[mfi].hiVect()),
+				    bx.loVect(), bx.hiVect(),
+				    refine_ratio.getVect());
 
 
-                //
-                // Calculate the errors on this FAB for this component
-                //
+		    //
+		    // Calculate the errors on this FAB for this component
+		    //
 
-                (*error[iLevel])[mfi].copy(new_data1[mfi], 0, iComp, 1);
-                (*error[iLevel])[mfi].minus(data2Coarse  , 0, iComp, 1);
+		    (*error[iLevel])[mfi].copy(new_data1[mfi], 0, iComp, 1);
+		    (*error[iLevel])[mfi].minus(data2Coarse  , 0, iComp, 1);
 
-                if (iLevel<finestLevel)
-                {
-                  std::vector< std::pair<int,Box> > isects = baf.intersections(bx);
+		    if (iLevel<finestLevel)
+		    {
+			std::vector< std::pair<int,Box> > isects = baf.intersections(bx);
 
-                  for (int ii = 0; ii < isects.size(); ii++)
-                    (*error[iLevel])[mfi].setVal(0,isects[ii].second,iComp,1);
-                }
+			for (int ii = 0; ii < isects.size(); ii++)
+			    (*error[iLevel])[mfi].setVal(0,isects[ii].second,iComp,1);
+		    }
 
-                Real grdL2 = (*error[iLevel])[mfi].norm(norm, iComp, 1);
+		    Real grdL2 = (*error[iLevel])[mfi].norm(norm, iComp, 1);
 
-                if (norm != 0)
-                {
-                    norms[iComp] = norms[iComp] + pow(grdL2, norm);
-                }
-                else
-                {
-                    norms[iComp] = std::max(norms[iComp], grdL2);
-                }
-            }
-        }
+		    if (norm != 0)
+		    {
+			norms[iComp] = norms[iComp] + pow(grdL2, norm);
+		    }
+		    else
+		    {
+			norms[iComp] = std::max(norms[iComp], grdL2);
+		    }
+		}
+	    }
 
 
-        //
-        // Output Statistics
-        //
-        if (ParallelDescriptor::IOProcessor())
-            std::cout << "  " << iLevel << "    ";
+	    //
+	    // Output Statistics
+	    //
+	    if (ParallelDescriptor::IOProcessor())
+		std::cout << "  " << iLevel << "    ";
 
 
 #ifdef BL_USE_MPI
-        MPI_Datatype datatype = ParallelDescriptor::Mpi_typemap<Real>::type();
-        if (ParallelDescriptor::IOProcessor())
-        {
-            Vector<Real> tmp(nComp);
-            for (int proc = 0; proc < ParallelDescriptor::NProcs(); proc++)
-                if (proc != ParallelDescriptor::IOProcessorNumber())
-                {
-                    MPI_Status stat;
-                    int rc = MPI_Recv(tmp.dataPtr(), nComp, datatype,
-                                      MPI_ANY_SOURCE, proc, ParallelDescriptor::Communicator(),
-                                      &stat);
+	    MPI_Datatype datatype = ParallelDescriptor::Mpi_typemap<Real>::type();
+	    if (ParallelDescriptor::IOProcessor())
+	    {
+		Vector<Real> tmp(nComp);
+		for (int proc = 0; proc < ParallelDescriptor::NProcs(); proc++)
+		    if (proc != ParallelDescriptor::IOProcessorNumber())
+		    {
+			MPI_Status stat;
+			int rc = MPI_Recv(tmp.dataPtr(), nComp, datatype,
+					  MPI_ANY_SOURCE, proc, ParallelDescriptor::Communicator(),
+					  &stat);
 
-                    if (rc != MPI_SUCCESS)
-                        ParallelDescriptor::Abort(rc);
+			if (rc != MPI_SUCCESS)
+			    ParallelDescriptor::Abort(rc);
 
-                    for (int iComp = 0; iComp < nComp; iComp++)
-                        if (norm != 0)
-                        {
-                            norms[iComp] = norms[iComp] + tmp[iComp];
-                        }
-                        else
-                        {
-                            norms[iComp] = std::max(norms[iComp], tmp[iComp]);
-                        }
-                }
-        }
-        else
-        {
-            int rc = MPI_Send(norms.dataPtr(), nComp, datatype,
-                              ParallelDescriptor::IOProcessorNumber(),
-                              ParallelDescriptor::MyProc(),
-                              ParallelDescriptor::Communicator());
+			for (int iComp = 0; iComp < nComp; iComp++)
+			    if (norm != 0)
+			    {
+				norms[iComp] = norms[iComp] + tmp[iComp];
+			    }
+			    else
+			    {
+				norms[iComp] = std::max(norms[iComp], tmp[iComp]);
+			    }
+		    }
+	    }
+	    else
+	    {
+		int rc = MPI_Send(norms.dataPtr(), nComp, datatype,
+				  ParallelDescriptor::IOProcessorNumber(),
+				  ParallelDescriptor::MyProc(),
+				  ParallelDescriptor::Communicator());
 
-            if (rc != MPI_SUCCESS)
-                ParallelDescriptor::Abort(rc);
-        }
+		if (rc != MPI_SUCCESS)
+		    ParallelDescriptor::Abort(rc);
+	    }
 #endif
 
 
-        Real vol = 1.0;
-        for (int dir = 0; dir < BL_SPACEDIM; dir++)
-            vol *= amrData1.DxLevel()[iLevel][dir];
+	    Real vol = 1.0;
+	    for (int dir = 0; dir < BL_SPACEDIM; dir++)
+		vol *= amrData1.DxLevel()[iLevel][dir];
 
-        if (ParallelDescriptor::IOProcessor())
-        {
-            for (int iComp = 0; iComp < nComp; iComp++)
-            {
-                if (norm != 0)
-                {
-                    norms[iComp] = norms[iComp] * vol;
-                    norms[iComp] = pow(norms[iComp], (1.0/norm));
-                }
+	    if (ParallelDescriptor::IOProcessor())
+	    {
+		for (int iComp = 0; iComp < nComp; iComp++)
+		{
+		    if (norm != 0)
+		    {
+			norms[iComp] = norms[iComp] * vol;
+			norms[iComp] = pow(norms[iComp], (1.0/norm));
+		    }
 
-                std::cout << norms[iComp] << " ";
-                sum_norms[iComp] = sum_norms[iComp] + norms[iComp];
-            }
+		    std::cout << norms[iComp] << " ";
+		    sum_norms[iComp] = sum_norms[iComp] + norms[iComp];
+		}
 
-            std::cout << std::endl;
+		std::cout << std::endl;
+	    }
         }
+
+	if (ParallelDescriptor::IOProcessor())
+	    std::cout << "  Sum    ";
+	if (ParallelDescriptor::IOProcessor())
+	{
+	    for (int iComp = 0; iComp < nComp; iComp++)
+	    {
+		std::cout << sum_norms[iComp] << " ";
+	    }
+	}
+
+	if (!difFile.empty())
+	    WritePlotFile(error, amrData1, difFile, verbose);
+
+	for (int iLevel = 0; iLevel <= finestLevel; ++iLevel)
+	    delete error[iLevel];
+
     }
-
-    if (ParallelDescriptor::IOProcessor())
-            std::cout << "  Sum    ";
-    if (ParallelDescriptor::IOProcessor())
-        {
-          for (int iComp = 0; iComp < nComp; iComp++)
-            {
-              std::cout << sum_norms[iComp] << " ";
-            }
-        }
-
-    if (!difFile.empty())
-        WritePlotFile(error, amrData1, difFile, verbose);
-
-    for (int iLevel = 0; iLevel <= finestLevel; ++iLevel)
-        delete error[iLevel];
-
     amrex::Finalize();
 }
 

--- a/Tools/C_util/Convergence/DiffSameDomainRefinedComposite.cpp
+++ b/Tools/C_util/Convergence/DiffSameDomainRefinedComposite.cpp
@@ -75,297 +75,297 @@ main (int   argc,
     amrex::Initialize(argc,argv);
     {
 
-	if (argc == 1)
-	    PrintUsage(argv[0]);
+        if (argc == 1)
+            PrintUsage(argv[0]);
 
-	ParmParse pp;
+        ParmParse pp;
 
-	if (pp.contains("help"))
-	    PrintUsage(argv[0]);
+        if (pp.contains("help"))
+            PrintUsage(argv[0]);
 
-	FArrayBox::setFormat(FABio::FAB_IEEE_32);
-	//
-	// Scan the arguments.
-	//
-	std::string iFile1, iFile2, difFile;
+        FArrayBox::setFormat(FABio::FAB_IEEE_32);
+        //
+        // Scan the arguments.
+        //
+        std::string iFile1, iFile2, difFile;
 
-	bool verbose = false;
-	if (pp.contains("verbose"))
-	{
-	    verbose = true;
-	}
-	pp.query("infile1", iFile1);
-	if (iFile1.empty())
-	    amrex::Abort("You must specify `infile1'");
+        bool verbose = false;
+        if (pp.contains("verbose"))
+        {
+            verbose = true;
+        }
+        pp.query("infile1", iFile1);
+        if (iFile1.empty())
+            amrex::Abort("You must specify `infile1'");
 
-	pp.query("reffile", iFile2);
-	if (iFile2.empty())
-	    amrex::Abort("You must specify `reffile'");
+        pp.query("reffile", iFile2);
+        if (iFile2.empty())
+            amrex::Abort("You must specify `reffile'");
 
-	pp.query("diffile", difFile);
+        pp.query("diffile", difFile);
 
-	int norm = 2;
-	pp.query("norm", norm);
+        int norm = 2;
+        pp.query("norm", norm);
 
-	DataServices::SetBatchMode();
-	Amrvis::FileType fileType(Amrvis::NEWPLT);
+        DataServices::SetBatchMode();
+        Amrvis::FileType fileType(Amrvis::NEWPLT);
 
-	DataServices dataServices1(iFile1, fileType);
-	DataServices dataServices2(iFile2, fileType);
+        DataServices dataServices1(iFile1, fileType);
+        DataServices dataServices2(iFile2, fileType);
 
-	if (!dataServices1.AmrDataOk() || !dataServices2.AmrDataOk())
-	    amrex::Abort("ERROR: Dataservices not OK");
+        if (!dataServices1.AmrDataOk() || !dataServices2.AmrDataOk())
+            amrex::Abort("ERROR: Dataservices not OK");
 
-	//
-	// Generate AmrData Objects
-	//
-	AmrData& amrData1 = dataServices1.AmrDataRef();
-	AmrData& amrData2 = dataServices2.AmrDataRef();
+        //
+        // Generate AmrData Objects
+        //
+        AmrData& amrData1 = dataServices1.AmrDataRef();
+        AmrData& amrData2 = dataServices2.AmrDataRef();
 
-	//
-	// Initial Tests
-	//
-	if (amrData1.FinestLevel() != amrData2.FinestLevel())
-	    amrex::Abort("ERROR: Finest level is not the same in the two plotfiles");
+        //
+        // Initial Tests
+        //
+        if (amrData1.FinestLevel() != amrData2.FinestLevel())
+            amrex::Abort("ERROR: Finest level is not the same in the two plotfiles");
 
-	int nComp1      = amrData1.NComp();
-	int nComp2      = amrData2.NComp();
+        int nComp1      = amrData1.NComp();
+        int nComp2      = amrData2.NComp();
 
-	int nComp = std::min(nComp1,nComp2);
+        int nComp = std::min(nComp1,nComp2);
 
-	if (!amrDatasHaveSameDerives(amrData1,amrData2))
-	{
-	    std::cout << "Warning: Plotfiles do not have the same state variables" << std::endl;
-	    std::cout << "         Setting nComp to be the minimum number of variables: " << nComp << std::endl;
-	}
+        if (!amrDatasHaveSameDerives(amrData1,amrData2))
+        {
+            std::cout << "Warning: Plotfiles do not have the same state variables" << std::endl;
+            std::cout << "         Setting nComp to be the minimum number of variables: " << nComp << std::endl;
+        }
 
-	int finestLevel = amrData1.FinestLevel();
-	const Vector<std::string>& derives = amrData1.PlotVarNames();
-	Vector<int> destComps(nComp);
-	for (int i = 0; i < nComp; i++)
-	    destComps[i] = i;
-
-
-	//
-	// Compute the error
-	//
-	Vector<MultiFab*> error(finestLevel+1);
-
-	if (ParallelDescriptor::IOProcessor())
-	    std::cout << "Level  L"<< norm << " norm of Error in Each Component" << std::endl
-		      << "-----------------------------------------------" << std::endl;
-
-	int ratio = 1;
-	Vector<Real> sum_norms(nComp);
-	for (int iComp = 0; iComp < nComp; iComp++)
-	    sum_norms[iComp] = 0.0;
-	for (int iLevel = 0; iLevel <= finestLevel; ++iLevel)
-	{
-	    //
-	    // Construct level box array and check that the lengths are the same
-	    //
-	    const BoxArray& ba1 = amrData1.boxArray(iLevel);
-	    const BoxArray& ba2 = amrData2.boxArray(iLevel);
-
-	    if (ba1.size() != ba2.size())
-		std::cout << "Warning: BoxArray lengths are not the same at level " << iLevel << std::endl;
-
-	    //
-	    // Construct refinement ratio, build the coarsened boxarray
-	    // (amrData2 is the refined plotfile)
-	    //
-	    const Box& domain1     = amrData1.ProbDomain()[iLevel];
-	    const Box& domain2     = amrData2.ProbDomain()[iLevel];
-	    IntVect refine_ratio   = getRefRatio(domain1, domain2);
-	    if (refine_ratio == IntVect())
-		amrex::Error("Cannot find refinement ratio from data to exact");
-
-	    if (verbose)
-		std::cerr << "level = " << iLevel << "  Ref_Ratio = " << refine_ratio
-			  << std::endl;
-
-	    BoxArray ba2Coarse(ba2);
-	    ba2Coarse.coarsen(refine_ratio);
-
-	    // Define new_data1 in case the boxarrays are not the same
-	    DistributionMapping dm2Coarse(ba2Coarse);
-	    MultiFab new_data1(ba2Coarse,dm2Coarse, 1,0);
-
-	    //
-	    // Construct MultiFab for errors
-	    //
-	    error[iLevel] = new MultiFab(ba2Coarse, dm2Coarse, nComp, 0);
-	    error[iLevel]->setVal(GARBAGE);
-
-	    //
-	    // For each component, average the fine fields down and calculate
-	    // the errors
-	    //
-	    Vector<Real> norms(nComp);
-	    for (int iComp = 0; iComp < nComp; iComp++)
-		norms[iComp] = 0.0;
-
-	    for (int iComp = 0; iComp < nComp; ++iComp)
-	    {
-		MultiFab& data1     = amrData1.GetGrids(iLevel, iComp);
-		MultiFab& data2Fine = amrData2.GetGrids(iLevel, iComp);
-
-		if (data1.contains_nan()) {
-		    Abort("First plotfile contains NaN(s)");
-		}
-		if (data2Fine.contains_nan()) {
-		    Abort("Second plotfile contains NaN(s)");
-		}
-
-		BoxArray baf;
-		if (iLevel<finestLevel)
-		{
-		    baf = BoxArray(amrData1.boxArray(iLevel+1)).coarsen(refine_ratio);
-		}
+        int finestLevel = amrData1.FinestLevel();
+        const Vector<std::string>& derives = amrData1.PlotVarNames();
+        Vector<int> destComps(nComp);
+        for (int i = 0; i < nComp; i++)
+            destComps[i] = i;
 
 
-		// Copy the data at the coarse level one component at a time
-		new_data1.copy(data1,0,0,1);
+        //
+        // Compute the error
+        //
+        Vector<MultiFab*> error(finestLevel+1);
 
-		//
-		// Calculate the errors  for each FAB in the MultiFab
-		//
-		for (MFIter mfi(new_data1); mfi.isValid(); ++mfi)
-		{
-		    //
-		    // Create the Coarsened version of data2
-		    //
-		    int index = mfi.index();
+        if (ParallelDescriptor::IOProcessor())
+            std::cout << "Level  L"<< norm << " norm of Error in Each Component" << std::endl
+                      << "-----------------------------------------------" << std::endl;
 
-		    const Box& bx = ba2Coarse[index];
-		    FArrayBox data2Coarse(bx, 1);
-		    int ncCoarse = 1;
+        int ratio = 1;
+        Vector<Real> sum_norms(nComp);
+        for (int iComp = 0; iComp < nComp; iComp++)
+            sum_norms[iComp] = 0.0;
+        for (int iLevel = 0; iLevel <= finestLevel; ++iLevel)
+        {
+            //
+            // Construct level box array and check that the lengths are the same
+            //
+            const BoxArray& ba1 = amrData1.boxArray(iLevel);
+            const BoxArray& ba2 = amrData2.boxArray(iLevel);
+
+            if (ba1.size() != ba2.size())
+                std::cout << "Warning: BoxArray lengths are not the same at level " << iLevel << std::endl;
+
+            //
+            // Construct refinement ratio, build the coarsened boxarray
+            // (amrData2 is the refined plotfile)
+            //
+            const Box& domain1     = amrData1.ProbDomain()[iLevel];
+            const Box& domain2     = amrData2.ProbDomain()[iLevel];
+            IntVect refine_ratio   = getRefRatio(domain1, domain2);
+            if (refine_ratio == IntVect())
+                amrex::Error("Cannot find refinement ratio from data to exact");
+
+            if (verbose)
+                std::cerr << "level = " << iLevel << "  Ref_Ratio = " << refine_ratio
+                          << std::endl;
+
+            BoxArray ba2Coarse(ba2);
+            ba2Coarse.coarsen(refine_ratio);
+
+            // Define new_data1 in case the boxarrays are not the same
+            DistributionMapping dm2Coarse(ba2Coarse);
+            MultiFab new_data1(ba2Coarse,dm2Coarse, 1,0);
+
+            //
+            // Construct MultiFab for errors
+            //
+            error[iLevel] = new MultiFab(ba2Coarse, dm2Coarse, nComp, 0);
+            error[iLevel]->setVal(GARBAGE);
+
+            //
+            // For each component, average the fine fields down and calculate
+            // the errors
+            //
+            Vector<Real> norms(nComp);
+            for (int iComp = 0; iComp < nComp; iComp++)
+                norms[iComp] = 0.0;
+
+            for (int iComp = 0; iComp < nComp; ++iComp)
+            {
+                MultiFab& data1     = amrData1.GetGrids(iLevel, iComp);
+                MultiFab& data2Fine = amrData2.GetGrids(iLevel, iComp);
+
+                if (data1.contains_nan()) {
+                    Abort("First plotfile contains NaN(s)");
+                }
+                if (data2Fine.contains_nan()) {
+                    Abort("Second plotfile contains NaN(s)");
+                }
+
+                BoxArray baf;
+                if (iLevel<finestLevel)
+                {
+                    baf = BoxArray(amrData1.boxArray(iLevel+1)).coarsen(refine_ratio);
+                }
+
+
+                // Copy the data at the coarse level one component at a time
+                new_data1.copy(data1,0,0,1);
+
+                //
+                // Calculate the errors  for each FAB in the MultiFab
+                //
+                for (MFIter mfi(new_data1); mfi.isValid(); ++mfi)
+                {
+                    //
+                    // Create the Coarsened version of data2
+                    //
+                    int index = mfi.index();
+
+                    const Box& bx = ba2Coarse[index];
+                    FArrayBox data2Coarse(bx, 1);
+                    int ncCoarse = 1;
 
 
 
-		    FORT_CV_AVGDOWN(data2Coarse.dataPtr(),
-				    ARLIM(bx.loVect()), ARLIM(bx.hiVect()),
-				    &ncCoarse,
-				    data2Fine[mfi].dataPtr(),
-				    ARLIM(data2Fine[mfi].loVect()),
-				    ARLIM(data2Fine[mfi].hiVect()),
-				    bx.loVect(), bx.hiVect(),
-				    refine_ratio.getVect());
+                    FORT_CV_AVGDOWN(data2Coarse.dataPtr(),
+                                    ARLIM(bx.loVect()), ARLIM(bx.hiVect()),
+                                    &ncCoarse,
+                                    data2Fine[mfi].dataPtr(),
+                                    ARLIM(data2Fine[mfi].loVect()),
+                                    ARLIM(data2Fine[mfi].hiVect()),
+                                    bx.loVect(), bx.hiVect(),
+                                    refine_ratio.getVect());
 
 
-		    //
-		    // Calculate the errors on this FAB for this component
-		    //
+                    //
+                    // Calculate the errors on this FAB for this component
+                    //
 
-		    (*error[iLevel])[mfi].copy(new_data1[mfi], 0, iComp, 1);
-		    (*error[iLevel])[mfi].minus(data2Coarse  , 0, iComp, 1);
+                    (*error[iLevel])[mfi].copy(new_data1[mfi], 0, iComp, 1);
+                    (*error[iLevel])[mfi].minus(data2Coarse  , 0, iComp, 1);
 
-		    if (iLevel<finestLevel)
-		    {
-			std::vector< std::pair<int,Box> > isects = baf.intersections(bx);
+                    if (iLevel<finestLevel)
+                    {
+                        std::vector< std::pair<int,Box> > isects = baf.intersections(bx);
 
-			for (int ii = 0; ii < isects.size(); ii++)
-			    (*error[iLevel])[mfi].setVal(0,isects[ii].second,iComp,1);
-		    }
+                        for (int ii = 0; ii < isects.size(); ii++)
+                            (*error[iLevel])[mfi].setVal(0,isects[ii].second,iComp,1);
+                    }
 
-		    Real grdL2 = (*error[iLevel])[mfi].norm(norm, iComp, 1);
+                    Real grdL2 = (*error[iLevel])[mfi].norm(norm, iComp, 1);
 
-		    if (norm != 0)
-		    {
-			norms[iComp] = norms[iComp] + pow(grdL2, norm);
-		    }
-		    else
-		    {
-			norms[iComp] = std::max(norms[iComp], grdL2);
-		    }
-		}
-	    }
+                    if (norm != 0)
+                    {
+                        norms[iComp] = norms[iComp] + pow(grdL2, norm);
+                    }
+                    else
+                    {
+                        norms[iComp] = std::max(norms[iComp], grdL2);
+                    }
+                }
+            }
 
 
-	    //
-	    // Output Statistics
-	    //
-	    if (ParallelDescriptor::IOProcessor())
-		std::cout << "  " << iLevel << "    ";
+            //
+            // Output Statistics
+            //
+            if (ParallelDescriptor::IOProcessor())
+                std::cout << "  " << iLevel << "    ";
 
 
 #ifdef BL_USE_MPI
-	    MPI_Datatype datatype = ParallelDescriptor::Mpi_typemap<Real>::type();
-	    if (ParallelDescriptor::IOProcessor())
-	    {
-		Vector<Real> tmp(nComp);
-		for (int proc = 0; proc < ParallelDescriptor::NProcs(); proc++)
-		    if (proc != ParallelDescriptor::IOProcessorNumber())
-		    {
-			MPI_Status stat;
-			int rc = MPI_Recv(tmp.dataPtr(), nComp, datatype,
-					  MPI_ANY_SOURCE, proc, ParallelDescriptor::Communicator(),
-					  &stat);
+            MPI_Datatype datatype = ParallelDescriptor::Mpi_typemap<Real>::type();
+            if (ParallelDescriptor::IOProcessor())
+            {
+                Vector<Real> tmp(nComp);
+                for (int proc = 0; proc < ParallelDescriptor::NProcs(); proc++)
+                    if (proc != ParallelDescriptor::IOProcessorNumber())
+                    {
+                        MPI_Status stat;
+                        int rc = MPI_Recv(tmp.dataPtr(), nComp, datatype,
+                                          MPI_ANY_SOURCE, proc, ParallelDescriptor::Communicator(),
+                                          &stat);
 
-			if (rc != MPI_SUCCESS)
-			    ParallelDescriptor::Abort(rc);
+                        if (rc != MPI_SUCCESS)
+                            ParallelDescriptor::Abort(rc);
 
-			for (int iComp = 0; iComp < nComp; iComp++)
-			    if (norm != 0)
-			    {
-				norms[iComp] = norms[iComp] + tmp[iComp];
-			    }
-			    else
-			    {
-				norms[iComp] = std::max(norms[iComp], tmp[iComp]);
-			    }
-		    }
-	    }
-	    else
-	    {
-		int rc = MPI_Send(norms.dataPtr(), nComp, datatype,
-				  ParallelDescriptor::IOProcessorNumber(),
-				  ParallelDescriptor::MyProc(),
-				  ParallelDescriptor::Communicator());
+                        for (int iComp = 0; iComp < nComp; iComp++)
+                            if (norm != 0)
+                            {
+                                norms[iComp] = norms[iComp] + tmp[iComp];
+                            }
+                            else
+                            {
+                                norms[iComp] = std::max(norms[iComp], tmp[iComp]);
+                            }
+                    }
+            }
+            else
+            {
+                int rc = MPI_Send(norms.dataPtr(), nComp, datatype,
+                                  ParallelDescriptor::IOProcessorNumber(),
+                                  ParallelDescriptor::MyProc(),
+                                  ParallelDescriptor::Communicator());
 
-		if (rc != MPI_SUCCESS)
-		    ParallelDescriptor::Abort(rc);
-	    }
+                if (rc != MPI_SUCCESS)
+                    ParallelDescriptor::Abort(rc);
+            }
 #endif
 
 
-	    Real vol = 1.0;
-	    for (int dir = 0; dir < BL_SPACEDIM; dir++)
-		vol *= amrData1.DxLevel()[iLevel][dir];
+            Real vol = 1.0;
+            for (int dir = 0; dir < BL_SPACEDIM; dir++)
+                vol *= amrData1.DxLevel()[iLevel][dir];
 
-	    if (ParallelDescriptor::IOProcessor())
-	    {
-		for (int iComp = 0; iComp < nComp; iComp++)
-		{
-		    if (norm != 0)
-		    {
-			norms[iComp] = norms[iComp] * vol;
-			norms[iComp] = pow(norms[iComp], (1.0/norm));
-		    }
+            if (ParallelDescriptor::IOProcessor())
+            {
+                for (int iComp = 0; iComp < nComp; iComp++)
+                {
+                    if (norm != 0)
+                    {
+                        norms[iComp] = norms[iComp] * vol;
+                        norms[iComp] = pow(norms[iComp], (1.0/norm));
+                    }
 
-		    std::cout << norms[iComp] << " ";
-		    sum_norms[iComp] = sum_norms[iComp] + norms[iComp];
-		}
+                    std::cout << norms[iComp] << " ";
+                    sum_norms[iComp] = sum_norms[iComp] + norms[iComp];
+                }
 
-		std::cout << std::endl;
-	    }
+                std::cout << std::endl;
+            }
         }
 
-	if (ParallelDescriptor::IOProcessor())
-	    std::cout << "  Sum    ";
-	if (ParallelDescriptor::IOProcessor())
-	{
-	    for (int iComp = 0; iComp < nComp; iComp++)
-	    {
-		std::cout << sum_norms[iComp] << " ";
-	    }
-	}
+        if (ParallelDescriptor::IOProcessor())
+            std::cout << "  Sum    ";
+        if (ParallelDescriptor::IOProcessor())
+        {
+            for (int iComp = 0; iComp < nComp; iComp++)
+            {
+                std::cout << sum_norms[iComp] << " ";
+            }
+        }
 
-	if (!difFile.empty())
-	    WritePlotFile(error, amrData1, difFile, verbose);
+        if (!difFile.empty())
+            WritePlotFile(error, amrData1, difFile, verbose);
 
-	for (int iLevel = 0; iLevel <= finestLevel; ++iLevel)
-	    delete error[iLevel];
+        for (int iLevel = 0; iLevel <= finestLevel; ++iLevel)
+            delete error[iLevel];
 
     }
     amrex::Finalize();

--- a/Tools/C_util/Convergence/DiffSameDomainRefinedFD.cpp
+++ b/Tools/C_util/Convergence/DiffSameDomainRefinedFD.cpp
@@ -70,262 +70,264 @@ main (int   argc,
       char* argv[])
 {
     amrex::Initialize(argc,argv);
-
-    if (argc == 1)
-        PrintUsage(argv[0]);
-
-    ParmParse pp;
-
-    if (pp.contains("help"))
-        PrintUsage(argv[0]);
-
-    FArrayBox::setFormat(FABio::FAB_IEEE_32);
-    //
-    // Scan the arguments.
-    //
-    std::string iFile1, iFile2, difFile;
-
-    bool verbose = false;
-    if (pp.contains("verbose"))
     {
-        verbose = true;
-    }
-    pp.query("infile1", iFile1);
-    if (iFile1.empty())
-        amrex::Abort("You must specify `infile1'");
 
-    pp.query("reffile", iFile2);
-    if (iFile2.empty())
-        amrex::Abort("You must specify `reffile'");
+        if (argc == 1)
+            PrintUsage(argv[0]);
 
-    pp.query("diffile", difFile);
+        ParmParse pp;
 
-    int norm = 2;
-    pp.query("norm", norm);
+        if (pp.contains("help"))
+            PrintUsage(argv[0]);
 
-    DataServices::SetBatchMode();
-    Amrvis::FileType fileType(Amrvis::NEWPLT);
-
-    DataServices dataServices1(iFile1, fileType);
-    DataServices dataServices2(iFile2, fileType);
-
-    if (!dataServices1.AmrDataOk() || !dataServices2.AmrDataOk())
-        amrex::Abort("ERROR: Dataservices not OK");
-
-    //
-    // Generate AmrData Objects
-    //
-    AmrData& amrData1 = dataServices1.AmrDataRef();
-    AmrData& amrData2 = dataServices2.AmrDataRef();
-
-    //
-    // Initial Tests
-    //
-    if (amrData1.FinestLevel() != amrData2.FinestLevel())
-        amrex::Abort("ERROR: Finest level is not the same in the two plotfiles");
-
-    int nComp1      = amrData1.NComp();
-    int nComp2      = amrData2.NComp();
-
-    int nComp = std::min(nComp1,nComp2);
-
-    if (!amrDatasHaveSameDerives(amrData1,amrData2))
-    {
-        std::cout << "Warning: Plotfiles do not have the same state variables" << std::endl;
-        std::cout << "         Setting nComp to be the minimum number of variables: " << nComp << std::endl;
-    }
-
-    int finestLevel = amrData1.FinestLevel();
-    const Vector<std::string>& derives = amrData1.PlotVarNames();
-    Vector<int> destComps(nComp);
-    for (int i = 0; i < nComp; i++)
-        destComps[i] = i;
-
-
-    //
-    // Compute the error
-    //
-    Vector<MultiFab*> error(finestLevel+1);
-
-    if (ParallelDescriptor::IOProcessor())
-        std::cout << "Level  L"<< norm << " norm of Error in Each Component" << std::endl
-             << "-----------------------------------------------" << std::endl;
-
-    for (int iLevel = 0; iLevel <= finestLevel; ++iLevel)
-    {
+        FArrayBox::setFormat(FABio::FAB_IEEE_32);
         //
-        // Construct level box array and check that the lengths are the same
+        // Scan the arguments.
         //
-        const BoxArray& ba1 = amrData1.boxArray(iLevel);
-        const BoxArray& ba2 = amrData2.boxArray(iLevel);
+        std::string iFile1, iFile2, difFile;
 
-        if (ba1.size() != ba2.size())
-           std::cout << "Warning: BoxArray lengths are not the same at level " << iLevel << std::endl;
-
-        //
-        // Construct refinement ratio, build the coarsened boxarray
-        // (amrData2 is the refined plotfile)
-        //
-        const Box& domain1     = amrData1.ProbDomain()[iLevel];
-        const Box& domain2     = amrData2.ProbDomain()[iLevel];
-        IntVect refine_ratio   = getRefRatio(domain1, domain2);
-        if (refine_ratio == IntVect())
-            amrex::Error("Cannot find refinement ratio from data to exact");
-
-        if (verbose)
-            std::cerr << "level = " << iLevel << "  Ref_Ratio = " << refine_ratio
-                                                                  << std::endl;
-
-        BoxArray ba2Coarse(ba2);
-        ba2Coarse.coarsen(refine_ratio);
-
-        // Define new_data1 in case the boxarrays are not the same
-        MultiFab new_data1(ba2Coarse,1,0,Fab_allocate);
-
-        //
-        // Construct MultiFab for errors
-        //
-        error[iLevel] = new MultiFab(ba2Coarse, nComp, 0);
-        error[iLevel]->setVal(GARBAGE);
-
-        //
-        // For each component, compute errors by striding through fine
-        // solution
-        //
-        Vector<Real> norms(nComp);
-        for (int iComp = 0; iComp < nComp; iComp++)
-            norms[iComp] = 0.0;
-
-        for (int iComp = 0; iComp < nComp; ++iComp)
+        bool verbose = false;
+        if (pp.contains("verbose"))
         {
-            MultiFab& data1     = amrData1.GetGrids(iLevel, iComp);
-            MultiFab& data2Fine = amrData2.GetGrids(iLevel, iComp);
+            verbose = true;
+        }
+        pp.query("infile1", iFile1);
+        if (iFile1.empty())
+            amrex::Abort("You must specify `infile1'");
 
-            // Copy the data at the coarse level one component at a time
-            new_data1.copy(data1,0,0,1);
+        pp.query("reffile", iFile2);
+        if (iFile2.empty())
+            amrex::Abort("You must specify `reffile'");
 
-            //
-            // Calculate the errors for each FAB in the MultiFab
-            //
-            for (MFIter mfi(new_data1); mfi.isValid(); ++mfi)
-            {
-                //
-                // Create the Coarsened version of data2
-                //
-                int index = mfi.index();
+        pp.query("diffile", difFile);
 
-                FArrayBox data2Coarse(ba2Coarse[index], 1);
-                int ncCoarse = 1;
+        int norm = 2;
+        pp.query("norm", norm);
 
-                int i, j, k;
-                IntVect cidx, fidx;
-                const int *lo = data2Coarse.loVect();
-                const int *hi = data2Coarse.hiVect();
+        DataServices::SetBatchMode();
+        Amrvis::FileType fileType(Amrvis::NEWPLT);
 
-                for (i=lo[0]; i<=hi[0]; i++) {
-                  cidx[0] = i; fidx[0] = i * refine_ratio[0];
+        DataServices dataServices1(iFile1, fileType);
+        DataServices dataServices2(iFile2, fileType);
 
-                  for (j=lo[1]; j<=hi[1]; j++) {
-                    cidx[1] = j; fidx[1] = j * refine_ratio[1];
+        if (!dataServices1.AmrDataOk() || !dataServices2.AmrDataOk())
+            amrex::Abort("ERROR: Dataservices not OK");
 
-                    for (k=lo[2]; k<=hi[2]; k++) {
-                      cidx[2] = k; fidx[2] = k * refine_ratio[2];
+        //
+        // Generate AmrData Objects
+        //
+        AmrData& amrData1 = dataServices1.AmrDataRef();
+        AmrData& amrData2 = dataServices2.AmrDataRef();
 
-                      data2Coarse(cidx) = data2Fine[mfi](fidx);
-                    }
-                  }
-                }
+        //
+        // Initial Tests
+        //
+        if (amrData1.FinestLevel() != amrData2.FinestLevel())
+            amrex::Abort("ERROR: Finest level is not the same in the two plotfiles");
 
-                //
-                // Calculate the errors on this FAB for this component
-                //
+        int nComp1      = amrData1.NComp();
+        int nComp2      = amrData2.NComp();
 
-                (*error[iLevel])[mfi].copy(new_data1[mfi], 0, iComp, 1);
-                (*error[iLevel])[mfi].minus(data2Coarse  , 0, iComp, 1);
+        int nComp = std::min(nComp1,nComp2);
 
-                Real grdL2 = (*error[iLevel])[mfi].norm(norm, iComp, 1);
-
-                if (norm != 0)
-                {
-                    norms[iComp] = norms[iComp] + pow(grdL2, norm);
-                }
-                else
-                {
-                    norms[iComp] = std::max(norms[iComp], grdL2);
-                }
-            }
+        if (!amrDatasHaveSameDerives(amrData1,amrData2))
+        {
+            std::cout << "Warning: Plotfiles do not have the same state variables" << std::endl;
+            std::cout << "         Setting nComp to be the minimum number of variables: " << nComp << std::endl;
         }
 
+        int finestLevel = amrData1.FinestLevel();
+        const Vector<std::string>& derives = amrData1.PlotVarNames();
+        Vector<int> destComps(nComp);
+        for (int i = 0; i < nComp; i++)
+            destComps[i] = i;
+
 
         //
-        // Output Statistics
+        // Compute the error
         //
+        Vector<MultiFab*> error(finestLevel+1);
+
         if (ParallelDescriptor::IOProcessor())
-            std::cout << "  " << iLevel << "    ";
+            std::cout << "Level  L"<< norm << " norm of Error in Each Component" << std::endl
+                      << "-----------------------------------------------" << std::endl;
+
+        for (int iLevel = 0; iLevel <= finestLevel; ++iLevel)
+        {
+            //
+            // Construct level box array and check that the lengths are the same
+            //
+            const BoxArray& ba1 = amrData1.boxArray(iLevel);
+            const BoxArray& ba2 = amrData2.boxArray(iLevel);
+
+            if (ba1.size() != ba2.size())
+                std::cout << "Warning: BoxArray lengths are not the same at level " << iLevel << std::endl;
+
+            //
+            // Construct refinement ratio, build the coarsened boxarray
+            // (amrData2 is the refined plotfile)
+            //
+            const Box& domain1     = amrData1.ProbDomain()[iLevel];
+            const Box& domain2     = amrData2.ProbDomain()[iLevel];
+            IntVect refine_ratio   = getRefRatio(domain1, domain2);
+            if (refine_ratio == IntVect())
+                amrex::Error("Cannot find refinement ratio from data to exact");
+
+            if (verbose)
+                std::cerr << "level = " << iLevel << "  Ref_Ratio = " << refine_ratio
+                          << std::endl;
+
+            BoxArray ba2Coarse(ba2);
+            ba2Coarse.coarsen(refine_ratio);
+
+            // Define new_data1 in case the boxarrays are not the same
+            MultiFab new_data1(ba2Coarse,1,0,Fab_allocate);
+
+            //
+            // Construct MultiFab for errors
+            //
+            error[iLevel] = new MultiFab(ba2Coarse, nComp, 0);
+            error[iLevel]->setVal(GARBAGE);
+
+            //
+            // For each component, compute errors by striding through fine
+            // solution
+            //
+            Vector<Real> norms(nComp);
+            for (int iComp = 0; iComp < nComp; iComp++)
+                norms[iComp] = 0.0;
+
+            for (int iComp = 0; iComp < nComp; ++iComp)
+            {
+                MultiFab& data1     = amrData1.GetGrids(iLevel, iComp);
+                MultiFab& data2Fine = amrData2.GetGrids(iLevel, iComp);
+
+                // Copy the data at the coarse level one component at a time
+                new_data1.copy(data1,0,0,1);
+
+                //
+                // Calculate the errors for each FAB in the MultiFab
+                //
+                for (MFIter mfi(new_data1); mfi.isValid(); ++mfi)
+                {
+                    //
+                    // Create the Coarsened version of data2
+                    //
+                    int index = mfi.index();
+
+                    FArrayBox data2Coarse(ba2Coarse[index], 1);
+                    int ncCoarse = 1;
+
+                    int i, j, k;
+                    IntVect cidx, fidx;
+                    const int *lo = data2Coarse.loVect();
+                    const int *hi = data2Coarse.hiVect();
+
+                    for (i=lo[0]; i<=hi[0]; i++) {
+                        cidx[0] = i; fidx[0] = i * refine_ratio[0];
+
+                        for (j=lo[1]; j<=hi[1]; j++) {
+                            cidx[1] = j; fidx[1] = j * refine_ratio[1];
+
+                            for (k=lo[2]; k<=hi[2]; k++) {
+                                cidx[2] = k; fidx[2] = k * refine_ratio[2];
+
+                                data2Coarse(cidx) = data2Fine[mfi](fidx);
+                            }
+                        }
+                    }
+
+                    //
+                    // Calculate the errors on this FAB for this component
+                    //
+
+                    (*error[iLevel])[mfi].copy(new_data1[mfi], 0, iComp, 1);
+                    (*error[iLevel])[mfi].minus(data2Coarse  , 0, iComp, 1);
+
+                    Real grdL2 = (*error[iLevel])[mfi].norm(norm, iComp, 1);
+
+                    if (norm != 0)
+                    {
+                        norms[iComp] = norms[iComp] + pow(grdL2, norm);
+                    }
+                    else
+                    {
+                        norms[iComp] = std::max(norms[iComp], grdL2);
+                    }
+                }
+            }
+
+
+            //
+            // Output Statistics
+            //
+            if (ParallelDescriptor::IOProcessor())
+                std::cout << "  " << iLevel << "    ";
 
 
 #ifdef BL_USE_MPI
-        MPI_Datatype datatype = ParallelDescriptor::Mpi_typemap<Real>::type();
-        if (ParallelDescriptor::IOProcessor())
-        {
-            Vector<Real> tmp(nComp);
-            for (int proc = 0; proc < ParallelDescriptor::NProcs(); proc++)
-                if (proc != ParallelDescriptor::IOProcessorNumber())
-                {
-                    MPI_Status stat;
-                    int rc = MPI_Recv(tmp.dataPtr(), nComp, datatype,
-                                      MPI_ANY_SOURCE, proc, ParallelDescriptor::Communicator(),
-                                      &stat);
+            MPI_Datatype datatype = ParallelDescriptor::Mpi_typemap<Real>::type();
+            if (ParallelDescriptor::IOProcessor())
+            {
+                Vector<Real> tmp(nComp);
+                for (int proc = 0; proc < ParallelDescriptor::NProcs(); proc++)
+                    if (proc != ParallelDescriptor::IOProcessorNumber())
+                    {
+                        MPI_Status stat;
+                        int rc = MPI_Recv(tmp.dataPtr(), nComp, datatype,
+                                          MPI_ANY_SOURCE, proc, ParallelDescriptor::Communicator(),
+                                          &stat);
 
-                    if (rc != MPI_SUCCESS)
-                        ParallelDescriptor::Abort(rc);
+                        if (rc != MPI_SUCCESS)
+                            ParallelDescriptor::Abort(rc);
 
-                    for (int iComp = 0; iComp < nComp; iComp++)
-                        if (norm != 0)
-                        {
-                            norms[iComp] = norms[iComp] + tmp[iComp];
-                        }
-                        else
-                        {
-                            norms[iComp] = std::max(norms[iComp], tmp[iComp]);
-                        }
-                }
-        }
-        else
-        {
-            int rc = MPI_Send(norms.dataPtr(), nComp, datatype,
-                              ParallelDescriptor::IOProcessorNumber(),
-                              ParallelDescriptor::MyProc(),
-                              ParallelDescriptor::Communicator());
+                        for (int iComp = 0; iComp < nComp; iComp++)
+                            if (norm != 0)
+                            {
+                                norms[iComp] = norms[iComp] + tmp[iComp];
+                            }
+                            else
+                            {
+                                norms[iComp] = std::max(norms[iComp], tmp[iComp]);
+                            }
+                    }
+            }
+            else
+            {
+                int rc = MPI_Send(norms.dataPtr(), nComp, datatype,
+                                  ParallelDescriptor::IOProcessorNumber(),
+                                  ParallelDescriptor::MyProc(),
+                                  ParallelDescriptor::Communicator());
 
-            if (rc != MPI_SUCCESS)
-                ParallelDescriptor::Abort(rc);
-        }
+                if (rc != MPI_SUCCESS)
+                    ParallelDescriptor::Abort(rc);
+            }
 #endif
 
 
-        if (ParallelDescriptor::IOProcessor())
-        {
-            for (int iComp = 0; iComp < nComp; iComp++)
+            if (ParallelDescriptor::IOProcessor())
             {
-                if (norm != 0)
+                for (int iComp = 0; iComp < nComp; iComp++)
                 {
-                    norms[iComp] = pow(norms[iComp], (1.0/norm));
+                    if (norm != 0)
+                    {
+                        norms[iComp] = pow(norms[iComp], (1.0/norm));
+                    }
+
+                    std::cout << norms[iComp] << " ";
                 }
-
-                std::cout << norms[iComp] << " ";
+                std::cout << std::endl;
             }
-            std::cout << std::endl;
         }
+
+
+        if (!difFile.empty())
+            WritePlotFile(error, amrData1, difFile, verbose);
+
+        for (int iLevel = 0; iLevel <= finestLevel; ++iLevel)
+            delete error[iLevel];
+
     }
-
-
-    if (!difFile.empty())
-        WritePlotFile(error, amrData1, difFile, verbose);
-
-    for (int iLevel = 0; iLevel <= finestLevel; ++iLevel)
-        delete error[iLevel];
-
     amrex::Finalize();
 }
 

--- a/Tools/C_util/Convergence/DiffSameDomainRefinedStag.cpp
+++ b/Tools/C_util/Convergence/DiffSameDomainRefinedStag.cpp
@@ -72,292 +72,294 @@ main (int   argc,
       char* argv[])
 {
     amrex::Initialize(argc,argv);
-
-    if (argc == 1)
-        PrintUsage(argv[0]);
-
-    ParmParse pp;
-
-    if (pp.contains("help"))
-        PrintUsage(argv[0]);
-
-    FArrayBox::setFormat(FABio::FAB_IEEE_32);
-    //
-    // Scan the arguments.
-    //
-    std::string iFile1, iFile2, difFile;
-
-    bool verbose = false;
-    if (pp.contains("verbose"))
     {
-        verbose = true;
-    }
-    pp.query("infile1", iFile1);
-    if (iFile1.empty())
-        amrex::Abort("You must specify `infile1'");
 
-    pp.query("reffile", iFile2);
-    if (iFile2.empty())
-        amrex::Abort("You must specify `reffile'");
+        if (argc == 1)
+            PrintUsage(argv[0]);
 
-    pp.query("diffile", difFile);
+        ParmParse pp;
 
-    int norm = 2;
-    pp.query("norm", norm);
+        if (pp.contains("help"))
+            PrintUsage(argv[0]);
 
-    DataServices::SetBatchMode();
-    Amrvis::FileType fileType(Amrvis::NEWPLT);
-
-    DataServices dataServices1(iFile1, fileType);
-    DataServices dataServices2(iFile2, fileType);
-
-    if (!dataServices1.AmrDataOk() || !dataServices2.AmrDataOk())
-        amrex::Abort("ERROR: Dataservices not OK");
-
-    //
-    // Generate AmrData Objects
-    //
-    AmrData& amrData1 = dataServices1.AmrDataRef();
-    AmrData& amrData2 = dataServices2.AmrDataRef();
-
-    //
-    // Initial Tests
-    //
-    if (amrData1.FinestLevel() != amrData2.FinestLevel())
-        amrex::Abort("ERROR: Finest level is not the same in the two plotfiles");
-
-    int nComp1      = amrData1.NComp();
-    int nComp2      = amrData2.NComp();
-
-    int nComp = std::min(nComp1,nComp2);
-
-    if (!amrDatasHaveSameDerives(amrData1,amrData2))
-    {
-        std::cout << "Warning: Plotfiles do not have the same state variables" << std::endl;
-        std::cout << "         Setting nComp to be the minimum number of variables: " << nComp << std::endl;
-    }
-
-    int finestLevel = amrData1.FinestLevel();
-    const Vector<std::string>& derives = amrData1.PlotVarNames();
-    Vector<int> destComps(nComp);
-    for (int i = 0; i < nComp; i++)
-        destComps[i] = i;
-
-
-    //
-    // Compute the error
-    //
-    Vector<MultiFab*> error(finestLevel+1);
-
-    if (ParallelDescriptor::IOProcessor())
-        std::cout << "Level  L"<< norm << " norm of Error in Each Component" << std::endl
-             << "-----------------------------------------------" << std::endl;
-
-    for (int iLevel = 0; iLevel <= finestLevel; ++iLevel)
-    {
+        FArrayBox::setFormat(FABio::FAB_IEEE_32);
         //
-        // Construct level box array and check that the lengths are the same
+        // Scan the arguments.
         //
-        const BoxArray& ba1 = amrData1.boxArray(iLevel);
-        const BoxArray& ba2 = amrData2.boxArray(iLevel);
+        std::string iFile1, iFile2, difFile;
 
-        /*
-        if (ba1.size() != ba2.size())
-           std::cout << "Warning: BoxArray lengths are not the same at level "
-                     << iLevel << std::endl;
-        */
-
-        //
-        // Construct refinement ratio, build the coarsened boxarray
-        // (amrData2 is the refined plotfile)
-        //
-        const Box& domain1     = amrData1.ProbDomain()[iLevel];
-        const Box& domain2     = amrData2.ProbDomain()[iLevel];
-
-        int nodal_dir = -1;
-        for (int i=0; i<BL_SPACEDIM; i++)
-          {
-            if (ba1[0].type(i) == 1)
-              {
-                nodal_dir = i;
-              }
-          }
-        std::cout << "Nodal Direction = " << nodal_dir << std::endl;
-        if (nodal_dir == -1)
-          {
-            amrex::Error("Data is not nodal in any direction");
-          }
-
-        IntVect refine_ratio   = getRefRatio(domain1, domain2);
-
-        if (refine_ratio == IntVect())
-            amrex::Error("Cannot find refinement ratio from data to exact");
-
-        if (verbose)
-            std::cerr << "level = " << iLevel << "  Ref_Ratio = " << refine_ratio
-                                                                  << std::endl;
-
-        BoxArray ba2Coarse(ba2);
-        ba2Coarse.coarsen(refine_ratio);
-
-        // Define new_data1 in case the boxarrays are not the same
-        DistributionMapping dm2Coarse(ba2Coarse);
-        MultiFab new_data1(ba2Coarse,dm2Coarse,1,0);
-
-        //
-        // Construct MultiFab for errors
-        //
-        error[iLevel] = new MultiFab(ba2Coarse, dm2Coarse, nComp, 0);
-        error[iLevel]->setVal(GARBAGE);
-
-        //
-        // For each component, average the fine fields down and calculate
-        // the errors
-        //
-        Vector<Real> norms(nComp);
-        for (int iComp = 0; iComp < nComp; iComp++)
-            norms[iComp] = 0.0;
-
-        for (int iComp = 0; iComp < nComp; ++iComp)
+        bool verbose = false;
+        if (pp.contains("verbose"))
         {
-            MultiFab& data1     = amrData1.GetGrids(iLevel, iComp);
-            MultiFab& data2Fine = amrData2.GetGrids(iLevel, iComp);
+            verbose = true;
+        }
+        pp.query("infile1", iFile1);
+        if (iFile1.empty())
+            amrex::Abort("You must specify `infile1'");
 
-            if (data1.contains_nan()) {
-                Abort("First plotfile contains NaN(s)");
-            }
-            if (data2Fine.contains_nan()) {
-                Abort("Second plotfile contains NaN(s)");
-            }
+        pp.query("reffile", iFile2);
+        if (iFile2.empty())
+            amrex::Abort("You must specify `reffile'");
 
-            // Copy the data at the coarse level one component at a time
-            new_data1.copy(data1,0,0,1);
+        pp.query("diffile", difFile);
 
-            //
-            // Calculate the errors  for each FAB in the MultiFab
-            //
-            for (MFIter mfi(new_data1); mfi.isValid(); ++mfi)
-            {
-                //
-                // Create the Coarsened version of data2
-                //
-                int index = mfi.index();
+        int norm = 2;
+        pp.query("norm", norm);
 
-                FArrayBox data2Coarse(ba2Coarse[index], 1);
-                int ncCoarse = 1;
+        DataServices::SetBatchMode();
+        Amrvis::FileType fileType(Amrvis::NEWPLT);
 
-                Box box2c = ba2Coarse[mfi];
-                IntVect loiv = box2c.smallEnd();
-                IntVect hiiv = box2c.bigEnd();
+        DataServices dataServices1(iFile1, fileType);
+        DataServices dataServices2(iFile2, fileType);
 
-                FORT_CV_AVGDOWN_STAG(&nodal_dir,
-                                     data2Coarse.dataPtr(),
-                                     ARLIM(data2Coarse.loVect()),
-                                     ARLIM(data2Coarse.hiVect()),
-                                     &ncCoarse,
-                                     data2Fine[mfi].dataPtr(),
-                                     ARLIM(data2Fine[mfi].loVect()),
-                                     ARLIM(data2Fine[mfi].hiVect()),
-                                     loiv.getVect(),
-                                     hiiv.getVect(),
-                                     refine_ratio.getVect());
+        if (!dataServices1.AmrDataOk() || !dataServices2.AmrDataOk())
+            amrex::Abort("ERROR: Dataservices not OK");
 
+        //
+        // Generate AmrData Objects
+        //
+        AmrData& amrData1 = dataServices1.AmrDataRef();
+        AmrData& amrData2 = dataServices2.AmrDataRef();
 
-                //
-                // Calculate the errors on this FAB for this component
-                //
+        //
+        // Initial Tests
+        //
+        if (amrData1.FinestLevel() != amrData2.FinestLevel())
+            amrex::Abort("ERROR: Finest level is not the same in the two plotfiles");
 
-                (*error[iLevel])[mfi].copy(new_data1[mfi], 0, iComp, 1);
-                (*error[iLevel])[mfi].minus(data2Coarse  , 0, iComp, 1);
+        int nComp1      = amrData1.NComp();
+        int nComp2      = amrData2.NComp();
 
-                Real grdL2 = (*error[iLevel])[mfi].norm(norm, iComp, 1);
+        int nComp = std::min(nComp1,nComp2);
 
-                if (norm != 0)
-                {
-                    norms[iComp] = norms[iComp] + pow(grdL2, norm);
-                }
-                else
-                {
-                    norms[iComp] = std::max(norms[iComp], grdL2);
-                }
-            }
+        if (!amrDatasHaveSameDerives(amrData1,amrData2))
+        {
+            std::cout << "Warning: Plotfiles do not have the same state variables" << std::endl;
+            std::cout << "         Setting nComp to be the minimum number of variables: " << nComp << std::endl;
         }
 
+        int finestLevel = amrData1.FinestLevel();
+        const Vector<std::string>& derives = amrData1.PlotVarNames();
+        Vector<int> destComps(nComp);
+        for (int i = 0; i < nComp; i++)
+            destComps[i] = i;
+
 
         //
-        // Output Statistics
+        // Compute the error
         //
+        Vector<MultiFab*> error(finestLevel+1);
+
         if (ParallelDescriptor::IOProcessor())
-            std::cout << "  " << iLevel << "    ";
+            std::cout << "Level  L"<< norm << " norm of Error in Each Component" << std::endl
+                      << "-----------------------------------------------" << std::endl;
+
+        for (int iLevel = 0; iLevel <= finestLevel; ++iLevel)
+        {
+            //
+            // Construct level box array and check that the lengths are the same
+            //
+            const BoxArray& ba1 = amrData1.boxArray(iLevel);
+            const BoxArray& ba2 = amrData2.boxArray(iLevel);
+
+            /*
+              if (ba1.size() != ba2.size())
+              std::cout << "Warning: BoxArray lengths are not the same at level "
+              << iLevel << std::endl;
+            */
+
+            //
+            // Construct refinement ratio, build the coarsened boxarray
+            // (amrData2 is the refined plotfile)
+            //
+            const Box& domain1     = amrData1.ProbDomain()[iLevel];
+            const Box& domain2     = amrData2.ProbDomain()[iLevel];
+
+            int nodal_dir = -1;
+            for (int i=0; i<BL_SPACEDIM; i++)
+            {
+                if (ba1[0].type(i) == 1)
+                {
+                    nodal_dir = i;
+                }
+            }
+            std::cout << "Nodal Direction = " << nodal_dir << std::endl;
+            if (nodal_dir == -1)
+            {
+                amrex::Error("Data is not nodal in any direction");
+            }
+
+            IntVect refine_ratio   = getRefRatio(domain1, domain2);
+
+            if (refine_ratio == IntVect())
+                amrex::Error("Cannot find refinement ratio from data to exact");
+
+            if (verbose)
+                std::cerr << "level = " << iLevel << "  Ref_Ratio = " << refine_ratio
+                          << std::endl;
+
+            BoxArray ba2Coarse(ba2);
+            ba2Coarse.coarsen(refine_ratio);
+
+            // Define new_data1 in case the boxarrays are not the same
+            DistributionMapping dm2Coarse(ba2Coarse);
+            MultiFab new_data1(ba2Coarse,dm2Coarse,1,0);
+
+            //
+            // Construct MultiFab for errors
+            //
+            error[iLevel] = new MultiFab(ba2Coarse, dm2Coarse, nComp, 0);
+            error[iLevel]->setVal(GARBAGE);
+
+            //
+            // For each component, average the fine fields down and calculate
+            // the errors
+            //
+            Vector<Real> norms(nComp);
+            for (int iComp = 0; iComp < nComp; iComp++)
+                norms[iComp] = 0.0;
+
+            for (int iComp = 0; iComp < nComp; ++iComp)
+            {
+                MultiFab& data1     = amrData1.GetGrids(iLevel, iComp);
+                MultiFab& data2Fine = amrData2.GetGrids(iLevel, iComp);
+
+                if (data1.contains_nan()) {
+                    Abort("First plotfile contains NaN(s)");
+                }
+                if (data2Fine.contains_nan()) {
+                    Abort("Second plotfile contains NaN(s)");
+                }
+
+                // Copy the data at the coarse level one component at a time
+                new_data1.copy(data1,0,0,1);
+
+                //
+                // Calculate the errors  for each FAB in the MultiFab
+                //
+                for (MFIter mfi(new_data1); mfi.isValid(); ++mfi)
+                {
+                    //
+                    // Create the Coarsened version of data2
+                    //
+                    int index = mfi.index();
+
+                    FArrayBox data2Coarse(ba2Coarse[index], 1);
+                    int ncCoarse = 1;
+
+                    Box box2c = ba2Coarse[mfi];
+                    IntVect loiv = box2c.smallEnd();
+                    IntVect hiiv = box2c.bigEnd();
+
+                    FORT_CV_AVGDOWN_STAG(&nodal_dir,
+                                         data2Coarse.dataPtr(),
+                                         ARLIM(data2Coarse.loVect()),
+                                         ARLIM(data2Coarse.hiVect()),
+                                         &ncCoarse,
+                                         data2Fine[mfi].dataPtr(),
+                                         ARLIM(data2Fine[mfi].loVect()),
+                                         ARLIM(data2Fine[mfi].hiVect()),
+                                         loiv.getVect(),
+                                         hiiv.getVect(),
+                                         refine_ratio.getVect());
+
+
+                    //
+                    // Calculate the errors on this FAB for this component
+                    //
+
+                    (*error[iLevel])[mfi].copy(new_data1[mfi], 0, iComp, 1);
+                    (*error[iLevel])[mfi].minus(data2Coarse  , 0, iComp, 1);
+
+                    Real grdL2 = (*error[iLevel])[mfi].norm(norm, iComp, 1);
+
+                    if (norm != 0)
+                    {
+                        norms[iComp] = norms[iComp] + pow(grdL2, norm);
+                    }
+                    else
+                    {
+                        norms[iComp] = std::max(norms[iComp], grdL2);
+                    }
+                }
+            }
+
+
+            //
+            // Output Statistics
+            //
+            if (ParallelDescriptor::IOProcessor())
+                std::cout << "  " << iLevel << "    ";
 
 
 #ifdef BL_USE_MPI
-        MPI_Datatype datatype = ParallelDescriptor::Mpi_typemap<Real>::type();
-        if (ParallelDescriptor::IOProcessor())
-        {
-            Vector<Real> tmp(nComp);
-            for (int proc = 0; proc < ParallelDescriptor::NProcs(); proc++)
-                if (proc != ParallelDescriptor::IOProcessorNumber())
-                {
-                    MPI_Status stat;
-                    int rc = MPI_Recv(tmp.dataPtr(), nComp, datatype,
-                                      MPI_ANY_SOURCE, proc, ParallelDescriptor::Communicator(),
-                                      &stat);
+            MPI_Datatype datatype = ParallelDescriptor::Mpi_typemap<Real>::type();
+            if (ParallelDescriptor::IOProcessor())
+            {
+                Vector<Real> tmp(nComp);
+                for (int proc = 0; proc < ParallelDescriptor::NProcs(); proc++)
+                    if (proc != ParallelDescriptor::IOProcessorNumber())
+                    {
+                        MPI_Status stat;
+                        int rc = MPI_Recv(tmp.dataPtr(), nComp, datatype,
+                                          MPI_ANY_SOURCE, proc, ParallelDescriptor::Communicator(),
+                                          &stat);
 
-                    if (rc != MPI_SUCCESS)
-                        ParallelDescriptor::Abort(rc);
+                        if (rc != MPI_SUCCESS)
+                            ParallelDescriptor::Abort(rc);
 
-                    for (int iComp = 0; iComp < nComp; iComp++)
-                        if (norm != 0)
-                        {
-                            norms[iComp] = norms[iComp] + tmp[iComp];
-                        }
-                        else
-                        {
-                            norms[iComp] = std::max(norms[iComp], tmp[iComp]);
-                        }
-                }
-        }
-        else
-        {
-            int rc = MPI_Send(norms.dataPtr(), nComp, datatype,
-                              ParallelDescriptor::IOProcessorNumber(),
-                              ParallelDescriptor::MyProc(),
-                              ParallelDescriptor::Communicator());
+                        for (int iComp = 0; iComp < nComp; iComp++)
+                            if (norm != 0)
+                            {
+                                norms[iComp] = norms[iComp] + tmp[iComp];
+                            }
+                            else
+                            {
+                                norms[iComp] = std::max(norms[iComp], tmp[iComp]);
+                            }
+                    }
+            }
+            else
+            {
+                int rc = MPI_Send(norms.dataPtr(), nComp, datatype,
+                                  ParallelDescriptor::IOProcessorNumber(),
+                                  ParallelDescriptor::MyProc(),
+                                  ParallelDescriptor::Communicator());
 
-            if (rc != MPI_SUCCESS)
-                ParallelDescriptor::Abort(rc);
-        }
+                if (rc != MPI_SUCCESS)
+                    ParallelDescriptor::Abort(rc);
+            }
 #endif
 
 
-        Real vol = 1.0;
-        for (int dir = 0; dir < BL_SPACEDIM; dir++)
-            vol *= amrData1.DxLevel()[iLevel][dir];
+            Real vol = 1.0;
+            for (int dir = 0; dir < BL_SPACEDIM; dir++)
+                vol *= amrData1.DxLevel()[iLevel][dir];
 
-        if (ParallelDescriptor::IOProcessor())
-        {
-            for (int iComp = 0; iComp < nComp; iComp++)
+            if (ParallelDescriptor::IOProcessor())
             {
-                if (norm != 0)
+                for (int iComp = 0; iComp < nComp; iComp++)
                 {
-                    norms[iComp] = norms[iComp] * vol;
-                    norms[iComp] = pow(norms[iComp], (1.0/norm));
+                    if (norm != 0)
+                    {
+                        norms[iComp] = norms[iComp] * vol;
+                        norms[iComp] = pow(norms[iComp], (1.0/norm));
+                    }
+
+                    std::cout << norms[iComp] << " ";
                 }
-
-                std::cout << norms[iComp] << " ";
+                std::cout << std::endl;
             }
-            std::cout << std::endl;
         }
+
+
+        if (!difFile.empty())
+            WritePlotFile(error, amrData1, difFile, verbose);
+
+        for (int iLevel = 0; iLevel <= finestLevel; ++iLevel)
+            delete error[iLevel];
+
     }
-
-
-    if (!difFile.empty())
-        WritePlotFile(error, amrData1, difFile, verbose);
-
-    for (int iLevel = 0; iLevel <= finestLevel; ++iLevel)
-        delete error[iLevel];
-
     amrex::Finalize();
 }
 

--- a/Tools/C_util/Convergence/DiffSameGrid.cpp
+++ b/Tools/C_util/Convergence/DiffSameGrid.cpp
@@ -63,198 +63,200 @@ main (int   argc,
       char* argv[])
 {
     amrex::Initialize(argc,argv);
-
-    if (argc == 1)
-        PrintUsage(argv[0]);
-
-    ParmParse pp;
-
-    if (pp.contains("help"))
-        PrintUsage(argv[0]);
-
-    std::string iFile1, iFile2, difFile;
-
-    bool verbose = false;
-    if (pp.contains("verbose"))
     {
-        verbose = true;
-        AmrData::SetVerbose(true);
-    }
 
-    pp.query("infile1", iFile1);
-    if (iFile1.empty())
-        amrex::Abort("You must specify `infile1'");
+        if (argc == 1)
+            PrintUsage(argv[0]);
 
-    pp.query("infile2", iFile2);
-    if (iFile2.empty())
-        amrex::Abort("You must specify `infile2'");
+        ParmParse pp;
 
-    pp.query("diffile", difFile);
+        if (pp.contains("help"))
+            PrintUsage(argv[0]);
 
-    int norm = 2;
-    pp.query("norm", norm);
+        std::string iFile1, iFile2, difFile;
 
-    DataServices::SetBatchMode();
-    Amrvis::FileType fileType(Amrvis::NEWPLT);
-
-    DataServices dataServicesC(iFile1, fileType);
-    DataServices dataServicesF(iFile2, fileType);
-
-    if (!dataServicesC.AmrDataOk() || !dataServicesF.AmrDataOk())
-        amrex::Abort("ERROR: Dataservices not OK");
-    //
-    // Generate AmrData Objects
-    //
-    AmrData& amrDataI = dataServicesC.AmrDataRef();
-    AmrData& amrDataE = dataServicesF.AmrDataRef();
-    //
-    // Initial Tests
-    //
-    if (!amrDatasHaveSameDerives(amrDataI,amrDataE))
-        amrex::Abort("ERROR: Plotfiles do not have the same state variables");
-
-    if (amrDataI.FinestLevel() != amrDataE.FinestLevel())
-        amrex::Abort("ERROR: Finest level is not the same in the two plotfiles");
-
-    int nComp       = amrDataI.NComp();
-    int finestLevel = amrDataI.FinestLevel();
-    const Vector<std::string>& derives = amrDataI.PlotVarNames();
-    Vector<int> destComps(nComp);
-    for (int i = 0; i < nComp; i++)
-        destComps[i] = i;
-    //
-    // Compute the error
-    //
-    Vector<MultiFab*> error(finestLevel+1);
-
-    if (ParallelDescriptor::IOProcessor())
-        std::cout << "L"<< norm << " norm of Error in Each Component" << std::endl
-             << "-----------------------------------------" << std::endl;
-
-    for (int iLevel = 0; iLevel <= finestLevel; ++iLevel)
-    {
-        const BoxArray& baI = amrDataI.boxArray(iLevel);
-        const BoxArray& baE = amrDataE.boxArray(iLevel);
-
-        if (baI != baE)
+        bool verbose = false;
+        if (pp.contains("verbose"))
         {
-            std::cout << "ERROR: BoxArrays are not the same at level " << iLevel << std::endl;
-            ParallelDescriptor::Abort();
+            verbose = true;
+            AmrData::SetVerbose(true);
         }
 
-        DistributionMapping dmI(baI);
-        error[iLevel] = new MultiFab(baI, dmI, nComp, 0);
-        error[iLevel]->setVal(GARBAGE);
+        pp.query("infile1", iFile1);
+        if (iFile1.empty())
+            amrex::Abort("You must specify `infile1'");
 
-        DistributionMapping dmE(baE);
-        MultiFab dataI(baI, dmI, nComp, 0);
-        MultiFab dataE(baE, dmE, nComp, 0);
+        pp.query("infile2", iFile2);
+        if (iFile2.empty())
+            amrex::Abort("You must specify `infile2'");
 
-        amrDataI.FillVar(dataI, iLevel, derives, destComps);
-        amrDataE.FillVar(dataE, iLevel, derives, destComps);
+        pp.query("diffile", difFile);
 
-        if (dataI.contains_nan()) {
-            Abort("First plotfile contains NaN(s)");
-        }
-        if (dataE.contains_nan()) {
-            Abort("Second plotfile contains NaN(s)");
-        }
+        int norm = 2;
+        pp.query("norm", norm);
 
-        for (int i = 0; i < destComps.size(); i++)
-        {
-            amrDataI.FlushGrids(destComps[i]);
-            amrDataE.FlushGrids(destComps[i]);
-        }
+        DataServices::SetBatchMode();
+        Amrvis::FileType fileType(Amrvis::NEWPLT);
 
-        (*error[iLevel]).copy(dataI);
-        (*error[iLevel]).minus(dataE, 0, nComp, 0);
+        DataServices dataServicesC(iFile1, fileType);
+        DataServices dataServicesF(iFile2, fileType);
+
+        if (!dataServicesC.AmrDataOk() || !dataServicesF.AmrDataOk())
+            amrex::Abort("ERROR: Dataservices not OK");
         //
-        // Output Statistics
+        // Generate AmrData Objects
         //
+        AmrData& amrDataI = dataServicesC.AmrDataRef();
+        AmrData& amrDataE = dataServicesF.AmrDataRef();
+        //
+        // Initial Tests
+        //
+        if (!amrDatasHaveSameDerives(amrDataI,amrDataE))
+            amrex::Abort("ERROR: Plotfiles do not have the same state variables");
+
+        if (amrDataI.FinestLevel() != amrDataE.FinestLevel())
+            amrex::Abort("ERROR: Finest level is not the same in the two plotfiles");
+
+        int nComp       = amrDataI.NComp();
+        int finestLevel = amrDataI.FinestLevel();
+        const Vector<std::string>& derives = amrDataI.PlotVarNames();
+        Vector<int> destComps(nComp);
+        for (int i = 0; i < nComp; i++)
+            destComps[i] = i;
+        //
+        // Compute the error
+        //
+        Vector<MultiFab*> error(finestLevel+1);
+
         if (ParallelDescriptor::IOProcessor())
-          std::cout << "Level:  " << iLevel << std::endl;
+            std::cout << "L"<< norm << " norm of Error in Each Component" << std::endl
+                      << "-----------------------------------------" << std::endl;
 
-        Vector<Real> norms(nComp,0);
-
-        for (MFIter mfi(*error[iLevel]); mfi.isValid(); ++mfi)
+        for (int iLevel = 0; iLevel <= finestLevel; ++iLevel)
         {
-            for (int iComp = 0; iComp < nComp; iComp++)
-            {
-                const Real grdL2 = (*error[iLevel])[mfi].norm(norm, iComp, 1);
+            const BoxArray& baI = amrDataI.boxArray(iLevel);
+            const BoxArray& baE = amrDataE.boxArray(iLevel);
 
-                if (norm != 0)
-                    norms[iComp] = norms[iComp] + pow(grdL2, norm);
-                else
-                    norms[iComp] = std::max(norms[iComp], grdL2);
+            if (baI != baE)
+            {
+                std::cout << "ERROR: BoxArrays are not the same at level " << iLevel << std::endl;
+                ParallelDescriptor::Abort();
             }
-        }
+
+            DistributionMapping dmI(baI);
+            error[iLevel] = new MultiFab(baI, dmI, nComp, 0);
+            error[iLevel]->setVal(GARBAGE);
+
+            DistributionMapping dmE(baE);
+            MultiFab dataI(baI, dmI, nComp, 0);
+            MultiFab dataE(baE, dmE, nComp, 0);
+
+            amrDataI.FillVar(dataI, iLevel, derives, destComps);
+            amrDataE.FillVar(dataE, iLevel, derives, destComps);
+
+            if (dataI.contains_nan()) {
+                Abort("First plotfile contains NaN(s)");
+            }
+            if (dataE.contains_nan()) {
+                Abort("Second plotfile contains NaN(s)");
+            }
+
+            for (int i = 0; i < destComps.size(); i++)
+            {
+                amrDataI.FlushGrids(destComps[i]);
+                amrDataE.FlushGrids(destComps[i]);
+            }
+
+            (*error[iLevel]).copy(dataI);
+            (*error[iLevel]).minus(dataE, 0, nComp, 0);
+            //
+            // Output Statistics
+            //
+            if (ParallelDescriptor::IOProcessor())
+                std::cout << "Level:  " << iLevel << std::endl;
+
+            Vector<Real> norms(nComp,0);
+
+            for (MFIter mfi(*error[iLevel]); mfi.isValid(); ++mfi)
+            {
+                for (int iComp = 0; iComp < nComp; iComp++)
+                {
+                    const Real grdL2 = (*error[iLevel])[mfi].norm(norm, iComp, 1);
+
+                    if (norm != 0)
+                        norms[iComp] = norms[iComp] + pow(grdL2, norm);
+                    else
+                        norms[iComp] = std::max(norms[iComp], grdL2);
+                }
+            }
 
 #ifdef BL_USE_MPI
-        MPI_Datatype datatype = ParallelDescriptor::Mpi_typemap<Real>::type();
+            MPI_Datatype datatype = ParallelDescriptor::Mpi_typemap<Real>::type();
 
-        if (ParallelDescriptor::IOProcessor())
-        {
-            Vector<Real> tmp(nComp);
-            for (int proc = 0; proc < ParallelDescriptor::NProcs(); proc++)
+            if (ParallelDescriptor::IOProcessor())
             {
-                if (proc != ParallelDescriptor::IOProcessorNumber())
+                Vector<Real> tmp(nComp);
+                for (int proc = 0; proc < ParallelDescriptor::NProcs(); proc++)
                 {
-                    MPI_Status stat;
-                    int rc = MPI_Recv(tmp.dataPtr(), nComp, datatype,
-                                      MPI_ANY_SOURCE, proc, ParallelDescriptor::Communicator(),
-                                      &stat);
-
-                    if (rc != MPI_SUCCESS)
-                        ParallelDescriptor::Abort(rc);
-
-                    for (int iComp = 0; iComp < nComp; iComp++)
+                    if (proc != ParallelDescriptor::IOProcessorNumber())
                     {
-                        if (norm != 0)
-                            norms[iComp] = norms[iComp] + tmp[iComp];
-                        else
-                            norms[iComp] = std::max(norms[iComp], tmp[iComp]);
+                        MPI_Status stat;
+                        int rc = MPI_Recv(tmp.dataPtr(), nComp, datatype,
+                                          MPI_ANY_SOURCE, proc, ParallelDescriptor::Communicator(),
+                                          &stat);
+
+                        if (rc != MPI_SUCCESS)
+                            ParallelDescriptor::Abort(rc);
+
+                        for (int iComp = 0; iComp < nComp; iComp++)
+                        {
+                            if (norm != 0)
+                                norms[iComp] = norms[iComp] + tmp[iComp];
+                            else
+                                norms[iComp] = std::max(norms[iComp], tmp[iComp]);
+                        }
                     }
                 }
             }
-        }
-        else
-        {
-            int rc = MPI_Send(norms.dataPtr(), nComp, datatype,
-                              ParallelDescriptor::IOProcessorNumber(),
-                              ParallelDescriptor::MyProc(),
-                              ParallelDescriptor::Communicator());
+            else
+            {
+                int rc = MPI_Send(norms.dataPtr(), nComp, datatype,
+                                  ParallelDescriptor::IOProcessorNumber(),
+                                  ParallelDescriptor::MyProc(),
+                                  ParallelDescriptor::Communicator());
 
-            if (rc != MPI_SUCCESS)
-                ParallelDescriptor::Abort(rc);
-        }
+                if (rc != MPI_SUCCESS)
+                    ParallelDescriptor::Abort(rc);
+            }
 #endif
 
-        Real vol = 1.0;
-        for (int dir = 0; dir < BL_SPACEDIM; dir++)
-            vol *= amrDataI.DxLevel()[iLevel][dir];
+            Real vol = 1.0;
+            for (int dir = 0; dir < BL_SPACEDIM; dir++)
+                vol *= amrDataI.DxLevel()[iLevel][dir];
 
-        if (ParallelDescriptor::IOProcessor())
-        {
-            for (int iComp = 0; iComp < nComp; iComp++)
+            if (ParallelDescriptor::IOProcessor())
             {
-                if (norm != 0)
+                for (int iComp = 0; iComp < nComp; iComp++)
                 {
-                    norms[iComp] = norms[iComp] * vol;
-                    norms[iComp] = pow(norms[iComp], (1.0/norm));
+                    if (norm != 0)
+                    {
+                        norms[iComp] = norms[iComp] * vol;
+                        norms[iComp] = pow(norms[iComp], (1.0/norm));
+                    }
+
+                    std::cout << "  " << derives[iComp] << ": " << norms[iComp] << std::endl;
                 }
-
-                std::cout << "  " << derives[iComp] << ": " << norms[iComp] << std::endl;
+                std::cout << std::endl;
             }
-            std::cout << std::endl;
         }
+
+        if (!difFile.empty())
+            WritePlotFile(error, amrDataI, difFile, verbose);
+
+        for (int iLevel = 0; iLevel <= finestLevel; ++iLevel)
+            delete error[iLevel];
+
     }
-
-    if (!difFile.empty())
-        WritePlotFile(error, amrDataI, difFile, verbose);
-
-    for (int iLevel = 0; iLevel <= finestLevel; ++iLevel)
-        delete error[iLevel];
-
     amrex::Finalize();
 
     return 0;

--- a/Tools/C_util/Convergence/DiffSameGrid2.cpp
+++ b/Tools/C_util/Convergence/DiffSameGrid2.cpp
@@ -71,296 +71,298 @@ main (int   argc,
       char* argv[])
 {
     amrex::Initialize(argc,argv);
-
-    if (argc == 1)
-        PrintUsage(argv[0]);
-
-    ParmParse pp;
-
-    if (pp.contains("help"))
-        PrintUsage(argv[0]);
-
-    std::string iFile1, iFile2, difFile;
-
-    bool verbose = false;
-    if (pp.contains("verbose"))
     {
-        verbose = true;
-        AmrData::SetVerbose(true);
-    }
 
-    pp.query("infile1", iFile1);
-    if (iFile1.empty())
-        amrex::Abort("You must specify `infile1'");
+        if (argc == 1)
+            PrintUsage(argv[0]);
 
-    pp.query("infile2", iFile2);
-    if (iFile2.empty())
-        amrex::Abort("You must specify `infile2'");
+        ParmParse pp;
 
-    pp.query("diffile", difFile);
+        if (pp.contains("help"))
+            PrintUsage(argv[0]);
 
-    int norm = 2;
-    pp.query("norm", norm);
+        std::string iFile1, iFile2, difFile;
 
-    DataServices::SetBatchMode();
-    Amrvis::FileType fileType(Amrvis::NEWPLT);
-
-    DataServices dataServicesC(iFile1, fileType);
-    DataServices dataServicesF(iFile2, fileType);
-
-    if (!dataServicesC.AmrDataOk() || !dataServicesF.AmrDataOk())
-        amrex::Abort("ERROR: Dataservices not OK");
-    //
-    // Generate AmrData Objects
-    //
-    AmrData& amrDataI = dataServicesC.AmrDataRef();
-    AmrData& amrDataE = dataServicesF.AmrDataRef();
-    //
-    // Initial Tests
-    //
-    if (!amrDatasHaveSameDerives(amrDataI,amrDataE))
-        amrex::Abort("ERROR: Plotfiles do not have the same state variables");
-
-    if (amrDataI.FinestLevel() != amrDataE.FinestLevel())
-        amrex::Abort("ERROR: Finest level is not the same in the two plotfiles");
-
-    int nComp       = amrDataI.NComp();
-    int finestLevel = amrDataI.FinestLevel();
-    const Vector<std::string>& derives = amrDataI.PlotVarNames();
-    Vector<int> destComps(nComp);
-    for (int i = 0; i < nComp; i++)
-        destComps[i] = i;
-    //
-    // Compute the absolute and relative errors
-    //
-    Vector<MultiFab*> aerror(finestLevel+1);
-    Vector<MultiFab*> rerror(finestLevel+1);
-
-    // keep track of the absolute errors -- if any of them are different than 0, then
-    // then we failed the comparison
-    bool failed = false;
-
-    if (ParallelDescriptor::IOProcessor()) {
-        if (norm == 0) {
-            std::cout << "L"<< norm << " norm of absolute error, relative error, and absolute error divided by the max coarse absolute value" << std::endl
-                      << std::setfill('-') << std::setw(80) << "-" << std::setfill(' ') << std::endl;
-        } else {
-            std::cout << "L"<< norm << " norm of Absolute and Relative Error in Each Component" << std::endl
-                      << std::setfill('-') << std::setw(80) << "-" << std::setfill(' ') << std::endl;
-        }
-    }
-
-    Vector<Real> maxAbsVal(nComp);
-
-    for (int iLevel = 0; iLevel <= finestLevel; ++iLevel)
-    {
-        const BoxArray& baI = amrDataI.boxArray(iLevel);
-        const BoxArray& baE = amrDataE.boxArray(iLevel);
-
-        DistributionMapping dm {baI};
-        if (baI != baE)
+        bool verbose = false;
+        if (pp.contains("verbose"))
         {
-            std::cout << "ERROR: BoxArrays are not the same at level " << iLevel << std::endl;
-            ParallelDescriptor::Abort();
+            verbose = true;
+            AmrData::SetVerbose(true);
         }
 
-        aerror[iLevel] = new MultiFab(baI, dm, nComp, 0);
-        aerror[iLevel]->setVal(GARBAGE);
+        pp.query("infile1", iFile1);
+        if (iFile1.empty())
+            amrex::Abort("You must specify `infile1'");
 
-        rerror[iLevel] = new MultiFab(baI, dm, nComp, 0);
-        rerror[iLevel]->setVal(GARBAGE);
+        pp.query("infile2", iFile2);
+        if (iFile2.empty())
+            amrex::Abort("You must specify `infile2'");
 
-        MultiFab dataI(baI, dm, nComp, 0);
-        MultiFab dataE(baE, dm, nComp, 0);
+        pp.query("diffile", difFile);
 
-        amrDataI.FillVar(dataI, iLevel, derives, destComps);
-        amrDataE.FillVar(dataE, iLevel, derives, destComps);
+        int norm = 2;
+        pp.query("norm", norm);
 
-        if (dataI.contains_nan()) {
-            Abort("First plotfile contains NaN(s)");
-        }
-        if (dataE.contains_nan()) {
-            Abort("Second plotfile contains NaN(s)");
-        }
+        DataServices::SetBatchMode();
+        Amrvis::FileType fileType(Amrvis::NEWPLT);
 
-        if (iLevel == 0) {
-            for (int iComp=0; iComp < nComp; ++iComp) {
-                maxAbsVal[iComp] = dataI.norm0(iComp);
+        DataServices dataServicesC(iFile1, fileType);
+        DataServices dataServicesF(iFile2, fileType);
+
+        if (!dataServicesC.AmrDataOk() || !dataServicesF.AmrDataOk())
+            amrex::Abort("ERROR: Dataservices not OK");
+        //
+        // Generate AmrData Objects
+        //
+        AmrData& amrDataI = dataServicesC.AmrDataRef();
+        AmrData& amrDataE = dataServicesF.AmrDataRef();
+        //
+        // Initial Tests
+        //
+        if (!amrDatasHaveSameDerives(amrDataI,amrDataE))
+            amrex::Abort("ERROR: Plotfiles do not have the same state variables");
+
+        if (amrDataI.FinestLevel() != amrDataE.FinestLevel())
+            amrex::Abort("ERROR: Finest level is not the same in the two plotfiles");
+
+        int nComp       = amrDataI.NComp();
+        int finestLevel = amrDataI.FinestLevel();
+        const Vector<std::string>& derives = amrDataI.PlotVarNames();
+        Vector<int> destComps(nComp);
+        for (int i = 0; i < nComp; i++)
+            destComps[i] = i;
+        //
+        // Compute the absolute and relative errors
+        //
+        Vector<MultiFab*> aerror(finestLevel+1);
+        Vector<MultiFab*> rerror(finestLevel+1);
+
+        // keep track of the absolute errors -- if any of them are different than 0, then
+        // then we failed the comparison
+        bool failed = false;
+
+        if (ParallelDescriptor::IOProcessor()) {
+            if (norm == 0) {
+                std::cout << "L"<< norm << " norm of absolute error, relative error, and absolute error divided by the max coarse absolute value" << std::endl
+                          << std::setfill('-') << std::setw(80) << "-" << std::setfill(' ') << std::endl;
+            } else {
+                std::cout << "L"<< norm << " norm of Absolute and Relative Error in Each Component" << std::endl
+                          << std::setfill('-') << std::setw(80) << "-" << std::setfill(' ') << std::endl;
             }
         }
 
-        // this part needs to be checked -- it appears that
-        // FlushGrids works on all levels at once -- but we are
-        // looping over levels
-        for (int i = 0; i < destComps.size(); i++)
+        Vector<Real> maxAbsVal(nComp);
+
+        for (int iLevel = 0; iLevel <= finestLevel; ++iLevel)
         {
-            amrDataI.FlushGrids(destComps[i]);
-            amrDataE.FlushGrids(destComps[i]);
-        }
+            const BoxArray& baI = amrDataI.boxArray(iLevel);
+            const BoxArray& baE = amrDataE.boxArray(iLevel);
 
-        // aerror will contain the absolute errors
-        (*aerror[iLevel]).copy(dataI);
-        (*aerror[iLevel]).minus(dataE, 0, nComp, 0);
-
-        // rerror will contain the relative errors
-        (*rerror[iLevel]).copy(dataI);
-        (*rerror[iLevel]).minus(dataE, 0, nComp, 0);
-        (*rerror[iLevel]).divide(dataI, 0, nComp, 0);
-
-
-        //
-        // Output Statistics
-        //
-        if (ParallelDescriptor::IOProcessor())
-          std::cout << "Level:  " << iLevel << std::endl;
-
-        Vector<Real> anorms(nComp,0);
-        Vector<Real> rnorms(nComp,0);
-
-        for (MFIter mfi(*aerror[iLevel]); mfi.isValid(); ++mfi)
-        {
-            for (int iComp = 0; iComp < nComp; iComp++)
+            DistributionMapping dm {baI};
+            if (baI != baE)
             {
-
-              // compute the norm of the absolute and relative errors for the
-              // current FAB
-              const Real agrdL2 = (*aerror[iLevel])[mfi].norm(norm, iComp, 1);
-              const Real rgrdL2 = (*rerror[iLevel])[mfi].norm(norm, iComp, 1);
-
-              // Adding the current norm to that from the previous FABs.
-              // note: right now, we are storing anorm**norm, so that the
-              // summation makes sense.
-              if (norm != 0) {
-                anorms[iComp] = anorms[iComp] + pow(agrdL2, norm);
-                rnorms[iComp] = rnorms[iComp] + pow(rgrdL2, norm);
-              }
-              else {
-                anorms[iComp] = std::max(anorms[iComp], agrdL2);
-                rnorms[iComp] = std::max(rnorms[iComp], rgrdL2);
-              }
-
+                std::cout << "ERROR: BoxArrays are not the same at level " << iLevel << std::endl;
+                ParallelDescriptor::Abort();
             }
-        }
+
+            aerror[iLevel] = new MultiFab(baI, dm, nComp, 0);
+            aerror[iLevel]->setVal(GARBAGE);
+
+            rerror[iLevel] = new MultiFab(baI, dm, nComp, 0);
+            rerror[iLevel]->setVal(GARBAGE);
+
+            MultiFab dataI(baI, dm, nComp, 0);
+            MultiFab dataE(baE, dm, nComp, 0);
+
+            amrDataI.FillVar(dataI, iLevel, derives, destComps);
+            amrDataE.FillVar(dataE, iLevel, derives, destComps);
+
+            if (dataI.contains_nan()) {
+                Abort("First plotfile contains NaN(s)");
+            }
+            if (dataE.contains_nan()) {
+                Abort("Second plotfile contains NaN(s)");
+            }
+
+            if (iLevel == 0) {
+                for (int iComp=0; iComp < nComp; ++iComp) {
+                    maxAbsVal[iComp] = dataI.norm0(iComp);
+                }
+            }
+
+            // this part needs to be checked -- it appears that
+            // FlushGrids works on all levels at once -- but we are
+            // looping over levels
+            for (int i = 0; i < destComps.size(); i++)
+            {
+                amrDataI.FlushGrids(destComps[i]);
+                amrDataE.FlushGrids(destComps[i]);
+            }
+
+            // aerror will contain the absolute errors
+            (*aerror[iLevel]).copy(dataI);
+            (*aerror[iLevel]).minus(dataE, 0, nComp, 0);
+
+            // rerror will contain the relative errors
+            (*rerror[iLevel]).copy(dataI);
+            (*rerror[iLevel]).minus(dataE, 0, nComp, 0);
+            (*rerror[iLevel]).divide(dataI, 0, nComp, 0);
+
+
+            //
+            // Output Statistics
+            //
+            if (ParallelDescriptor::IOProcessor())
+                std::cout << "Level:  " << iLevel << std::endl;
+
+            Vector<Real> anorms(nComp,0);
+            Vector<Real> rnorms(nComp,0);
+
+            for (MFIter mfi(*aerror[iLevel]); mfi.isValid(); ++mfi)
+            {
+                for (int iComp = 0; iComp < nComp; iComp++)
+                {
+
+                    // compute the norm of the absolute and relative errors for the
+                    // current FAB
+                    const Real agrdL2 = (*aerror[iLevel])[mfi].norm(norm, iComp, 1);
+                    const Real rgrdL2 = (*rerror[iLevel])[mfi].norm(norm, iComp, 1);
+
+                    // Adding the current norm to that from the previous FABs.
+                    // note: right now, we are storing anorm**norm, so that the
+                    // summation makes sense.
+                    if (norm != 0) {
+                        anorms[iComp] = anorms[iComp] + pow(agrdL2, norm);
+                        rnorms[iComp] = rnorms[iComp] + pow(rgrdL2, norm);
+                    }
+                    else {
+                        anorms[iComp] = std::max(anorms[iComp], agrdL2);
+                        rnorms[iComp] = std::max(rnorms[iComp], rgrdL2);
+                    }
+
+                }
+            }
 
 #ifdef BL_USE_MPI
-        MPI_Datatype datatype = ParallelDescriptor::Mpi_typemap<Real>::type();
+            MPI_Datatype datatype = ParallelDescriptor::Mpi_typemap<Real>::type();
 
-        if (ParallelDescriptor::IOProcessor())
-        {
-            Vector<Real> atmp(nComp);
-            Vector<Real> rtmp(nComp);
-            for (int proc = 0; proc < ParallelDescriptor::NProcs(); proc++)
+            if (ParallelDescriptor::IOProcessor())
             {
-                if (proc != ParallelDescriptor::IOProcessorNumber())
+                Vector<Real> atmp(nComp);
+                Vector<Real> rtmp(nComp);
+                for (int proc = 0; proc < ParallelDescriptor::NProcs(); proc++)
                 {
-                    MPI_Status stat;
-                    int rc = MPI_Recv(atmp.dataPtr(), nComp, datatype,
-                                      MPI_ANY_SOURCE,
-                                      proc,
-                                      ParallelDescriptor::Communicator(),
-                                      &stat);
+                    if (proc != ParallelDescriptor::IOProcessorNumber())
+                    {
+                        MPI_Status stat;
+                        int rc = MPI_Recv(atmp.dataPtr(), nComp, datatype,
+                                          MPI_ANY_SOURCE,
+                                          proc,
+                                          ParallelDescriptor::Communicator(),
+                                          &stat);
 
-                    if (rc != MPI_SUCCESS)
-                        ParallelDescriptor::Abort(rc);
+                        if (rc != MPI_SUCCESS)
+                            ParallelDescriptor::Abort(rc);
 
-                    rc = MPI_Recv(rtmp.dataPtr(), nComp, datatype,
+                        rc = MPI_Recv(rtmp.dataPtr(), nComp, datatype,
                                       MPI_ANY_SOURCE,
                                       ParallelDescriptor::NProcs() + proc,
                                       ParallelDescriptor::Communicator(),
                                       &stat);
 
-                    if (rc != MPI_SUCCESS)
-                        ParallelDescriptor::Abort(rc);
+                        if (rc != MPI_SUCCESS)
+                            ParallelDescriptor::Abort(rc);
 
 
-                    for (int iComp = 0; iComp < nComp; iComp++)
-                    {
-                      if (norm != 0) {
-                        anorms[iComp] = anorms[iComp] + atmp[iComp];
-                        rnorms[iComp] = rnorms[iComp] + rtmp[iComp];
-                      }
-                      else {
-                        anorms[iComp] = std::max(anorms[iComp], atmp[iComp]);
-                        rnorms[iComp] = std::max(rnorms[iComp], rtmp[iComp]);
-                      }
+                        for (int iComp = 0; iComp < nComp; iComp++)
+                        {
+                            if (norm != 0) {
+                                anorms[iComp] = anorms[iComp] + atmp[iComp];
+                                rnorms[iComp] = rnorms[iComp] + rtmp[iComp];
+                            }
+                            else {
+                                anorms[iComp] = std::max(anorms[iComp], atmp[iComp]);
+                                rnorms[iComp] = std::max(rnorms[iComp], rtmp[iComp]);
+                            }
 
+                        }
                     }
                 }
             }
-        }
-        else
-        {
-            int rc = MPI_Send(anorms.dataPtr(), nComp, datatype,
-                              ParallelDescriptor::IOProcessorNumber(),
-                              ParallelDescriptor::MyProc(),
-                              ParallelDescriptor::Communicator());
+            else
+            {
+                int rc = MPI_Send(anorms.dataPtr(), nComp, datatype,
+                                  ParallelDescriptor::IOProcessorNumber(),
+                                  ParallelDescriptor::MyProc(),
+                                  ParallelDescriptor::Communicator());
 
-            if (rc != MPI_SUCCESS)
-                ParallelDescriptor::Abort(rc);
+                if (rc != MPI_SUCCESS)
+                    ParallelDescriptor::Abort(rc);
 
 
-            rc = MPI_Send(rnorms.dataPtr(), nComp, datatype,
+                rc = MPI_Send(rnorms.dataPtr(), nComp, datatype,
                               ParallelDescriptor::IOProcessorNumber(),
                               ParallelDescriptor::NProcs() + ParallelDescriptor::MyProc(),
                               ParallelDescriptor::Communicator());
 
-            if (rc != MPI_SUCCESS)
-                ParallelDescriptor::Abort(rc);
-        }
+                if (rc != MPI_SUCCESS)
+                    ParallelDescriptor::Abort(rc);
+            }
 #endif
 
-        // normalize the norms and print out
-        Real vol = 1.0;
-        for (int dir = 0; dir < BL_SPACEDIM; dir++)
-            vol *= amrDataI.DxLevel()[iLevel][dir];
+            // normalize the norms and print out
+            Real vol = 1.0;
+            for (int dir = 0; dir < BL_SPACEDIM; dir++)
+                vol *= amrDataI.DxLevel()[iLevel][dir];
 
-        if (ParallelDescriptor::IOProcessor())
-        {
-            for (int iComp = 0; iComp < nComp; iComp++)
+            if (ParallelDescriptor::IOProcessor())
             {
-                if (norm != 0)
+                for (int iComp = 0; iComp < nComp; iComp++)
                 {
-                  anorms[iComp] = anorms[iComp] * vol;
-                  anorms[iComp] = pow(anorms[iComp], (1.0/norm));
+                    if (norm != 0)
+                    {
+                        anorms[iComp] = anorms[iComp] * vol;
+                        anorms[iComp] = pow(anorms[iComp], (1.0/norm));
 
-                  rnorms[iComp] = rnorms[iComp] * vol;
-                  rnorms[iComp] = pow(rnorms[iComp], (1.0/norm));
+                        rnorms[iComp] = rnorms[iComp] * vol;
+                        rnorms[iComp] = pow(rnorms[iComp], (1.0/norm));
+                    }
+
+                    if (anorms[iComp] != 0.0) failed = true;
+
+                    if (norm == 0) {
+                        Real absOverMax = (maxAbsVal[iComp] == 0.) ? 0. : anorms[iComp]/maxAbsVal[iComp];
+
+                        std::cout << "  " << std::setw(32) << derives[iComp]
+                                  << ": " << std::setw(20) << anorms[iComp]
+                                  << std::setw(20) << rnorms[iComp]
+                                  << std::setw(20) << absOverMax
+                                  << std::endl;
+                    } else {
+                        std::cout << "  " << std::setw(32) << derives[iComp]
+                                  << ": " << std::setw(20) << anorms[iComp]
+                                  << std::setw(20) << rnorms[iComp]
+                                  << std::endl;
+                    }
                 }
-
-                if (anorms[iComp] != 0.0) failed = true;
-
-                if (norm == 0) {
-                    Real absOverMax = (maxAbsVal[iComp] == 0.) ? 0. : anorms[iComp]/maxAbsVal[iComp];
-
-                    std::cout << "  " << std::setw(32) << derives[iComp]
-                              << ": " << std::setw(20) << anorms[iComp]
-                              << std::setw(20) << rnorms[iComp]
-                              << std::setw(20) << absOverMax
-                              << std::endl;
-                } else {
-                    std::cout << "  " << std::setw(32) << derives[iComp]
-                              << ": " << std::setw(20) << anorms[iComp]
-                              << std::setw(20) << rnorms[iComp]
-                              << std::endl;
-                }
+                std::cout << std::endl;
             }
-            std::cout << std::endl;
         }
+
+        if (!failed) {
+            std::cout << "PLOTFILES AGREE" << std::endl;
+        }
+
+        // optionally dump out a plotfile containing the absolute errors
+        if (!difFile.empty())
+            WritePlotFile(aerror, amrDataI, difFile, verbose);
+
+        for (int iLevel = 0; iLevel <= finestLevel; ++iLevel) {
+            delete aerror[iLevel];
+            delete rerror[iLevel];
+        }
+
     }
-
-    if (!failed) {
-      std::cout << "PLOTFILES AGREE" << std::endl;
-    }
-
-    // optionally dump out a plotfile containing the absolute errors
-    if (!difFile.empty())
-        WritePlotFile(aerror, amrDataI, difFile, verbose);
-
-    for (int iLevel = 0; iLevel <= finestLevel; ++iLevel) {
-      delete aerror[iLevel];
-      delete rerror[iLevel];
-    }
-
     amrex::Finalize();
 
     return 0;

--- a/Tools/C_util/Convergence/DiffSameGridRefined.cpp
+++ b/Tools/C_util/Convergence/DiffSameGridRefined.cpp
@@ -71,261 +71,263 @@ main (int   argc,
       char* argv[])
 {
     amrex::Initialize(argc,argv);
-
-    if (argc == 1)
-        PrintUsage(argv[0]);
-
-    ParmParse pp;
-
-    if (pp.contains("help"))
-        PrintUsage(argv[0]);
-
-    FArrayBox::setFormat(FABio::FAB_IEEE_32);
-    //
-    // Scan the arguments.
-    //
-    std::string iFile1, iFile2, difFile;
-
-    bool verbose = false;
-    if (pp.contains("verbose"))
     {
-        verbose = true;
-    }
-    pp.query("infile1", iFile1);
-    if (iFile1.empty())
-        amrex::Abort("You must specify `infile1'");
 
-    pp.query("reffile", iFile2);
-    if (iFile2.empty())
-        amrex::Abort("You must specify `reffile'");
+        if (argc == 1)
+            PrintUsage(argv[0]);
 
-    pp.query("diffile", difFile);
+        ParmParse pp;
 
-    int norm = 2;
-    pp.query("norm", norm);
+        if (pp.contains("help"))
+            PrintUsage(argv[0]);
 
-    DataServices::SetBatchMode();
-    Amrvis::FileType fileType(Amrvis::NEWPLT);
-
-    DataServices dataServices1(iFile1, fileType);
-    DataServices dataServices2(iFile2, fileType);
-
-    if (!dataServices1.AmrDataOk() || !dataServices2.AmrDataOk())
-        amrex::Abort("ERROR: Dataservices not OK");
-
-
-    //
-    // Generate AmrData Objects
-    //
-    AmrData& amrData1 = dataServices1.AmrDataRef();
-    AmrData& amrData2 = dataServices2.AmrDataRef();
-
-    //
-    // Initial Tests
-    //
-    if (!amrDatasHaveSameDerives(amrData1,amrData2))
-        amrex::Abort("ERROR: Plotfiles do not have the same state variables");
-
-    if (amrData1.FinestLevel() != amrData2.FinestLevel())
-        amrex::Abort("ERROR: Finest level is not the same in the two plotfiles");
-
-    int nComp       = amrData1.NComp();
-    int finestLevel = amrData1.FinestLevel();
-    const Vector<std::string>& derives = amrData1.PlotVarNames();
-    Vector<int> destComps(nComp);
-    for (int i = 0; i < nComp; i++)
-        destComps[i] = i;
-
-
-    //
-    // Compute the error
-    //
-    Vector<MultiFab*> error(finestLevel+1);
-
-    if (ParallelDescriptor::IOProcessor())
-        std::cout << "Level  L"<< norm << " norm of Error in Each Component" << std::endl
-             << "-----------------------------------------------" << std::endl;
-
-    for (int iLevel = 0; iLevel <= finestLevel; ++iLevel)
-    {
+        FArrayBox::setFormat(FABio::FAB_IEEE_32);
         //
-        // Construct level box array and check that the lengths are the same
+        // Scan the arguments.
         //
-        const BoxArray& ba1 = amrData1.boxArray(iLevel);
-        const BoxArray& ba2 = amrData2.boxArray(iLevel);
+        std::string iFile1, iFile2, difFile;
 
-        if (ba1.size() != ba2.size())
+        bool verbose = false;
+        if (pp.contains("verbose"))
         {
-            std::cout << "ERROR: BoxArray lengths are not the same at level "
-                 << iLevel << std::endl;
-            ParallelDescriptor::Abort();
+            verbose = true;
         }
+        pp.query("infile1", iFile1);
+        if (iFile1.empty())
+            amrex::Abort("You must specify `infile1'");
 
-        //
-        // Construct MultiFab for errors
-        //
-        DistributionMapping dm(ba1);
-        error[iLevel] = new MultiFab(ba1, dm, nComp, 0);
-        error[iLevel]->setVal(GARBAGE);
+        pp.query("reffile", iFile2);
+        if (iFile2.empty())
+            amrex::Abort("You must specify `reffile'");
 
-        //
-        // Construct refinement ratio, build the coarsened boxarray
-        // (amrData2 is the refined plotfile)
-        //
-        const Box& domain1     = amrData1.ProbDomain()[iLevel];
-        const Box& domain2     = amrData2.ProbDomain()[iLevel];
-        IntVect refine_ratio   = getRefRatio(domain1, domain2);
-        if (refine_ratio == IntVect())
-            amrex::Error("Cannot find refinement ratio from data to exact");
+        pp.query("diffile", difFile);
 
-        if (verbose)
-            std::cerr << "level = " << iLevel << "  Ref_Ratio = " << refine_ratio
-                                                                  << std::endl;
+        int norm = 2;
+        pp.query("norm", norm);
 
-        BoxArray ba2Coarse(ba2);
-        ba2Coarse.coarsen(refine_ratio);
+        DataServices::SetBatchMode();
+        Amrvis::FileType fileType(Amrvis::NEWPLT);
 
-        //
-        // For each component, average the fine fields down and calculate
-        // the errors
-        //
-        Vector<Real> norms(nComp);
-        for (int iComp = 0; iComp < nComp; iComp++)
-            norms[iComp] = 0.0;
+        DataServices dataServices1(iFile1, fileType);
+        DataServices dataServices2(iFile2, fileType);
 
-        for (int iComp = 0; iComp < nComp; ++iComp)
-        {
-            MultiFab& data1 = amrData1.GetGrids(iLevel, iComp);
-            MultiFab& data2Fine = amrData2.GetGrids(iLevel, iComp);
-
-            if (data1.contains_nan()) {
-                Abort("First plotfile contains NaN(s)");
-            }
-            if (data2Fine.contains_nan()) {
-                Abort("Second plotfile contains NaN(s)");
-            }
-
-
-            //
-            // Calculate the errors  for each FAB in the MultiFab
-            //
-            for (MFIter mfi(data1); mfi.isValid(); ++mfi)
-            {
-                //
-                // Create the Coarsened version of data2
-                //
-                int index = mfi.index();
-
-                const Box& bx = ba2Coarse[index];
-                FArrayBox data2Coarse(bx, 1);
-                int ncCoarse = data2Coarse.nComp();
-
-                FORT_CV_AVGDOWN(data2Coarse.dataPtr(),
-                                  ARLIM(bx.loVect()), ARLIM(bx.hiVect()),
-                                &ncCoarse,
-                                data2Fine[mfi].dataPtr(),
-                                  ARLIM(data2Fine[mfi].loVect()),
-                                  ARLIM(data2Fine[mfi].hiVect()),
-                                bx.loVect(), bx.hiVect(),
-                                refine_ratio.getVect());
-
-
-                //
-                // Calculate the errors on this FAB for this component
-                //
-                (*error[iLevel])[mfi].copy(data1[mfi], 0, iComp, 1);
-                (*error[iLevel])[mfi].minus(data2Coarse, 0, iComp, 1);
-
-                Real grdL2 = (*error[iLevel])[mfi].norm(norm, iComp, 1);
-
-                if (norm != 0)
-                {
-                    norms[iComp] = norms[iComp] + pow(grdL2, norm);
-                }
-                else
-                {
-                    norms[iComp] = std::max(norms[iComp], grdL2);
-                }
-            }
-        }
+        if (!dataServices1.AmrDataOk() || !dataServices2.AmrDataOk())
+            amrex::Abort("ERROR: Dataservices not OK");
 
 
         //
-        // Output Statistics
+        // Generate AmrData Objects
         //
+        AmrData& amrData1 = dataServices1.AmrDataRef();
+        AmrData& amrData2 = dataServices2.AmrDataRef();
+
+        //
+        // Initial Tests
+        //
+        if (!amrDatasHaveSameDerives(amrData1,amrData2))
+            amrex::Abort("ERROR: Plotfiles do not have the same state variables");
+
+        if (amrData1.FinestLevel() != amrData2.FinestLevel())
+            amrex::Abort("ERROR: Finest level is not the same in the two plotfiles");
+
+        int nComp       = amrData1.NComp();
+        int finestLevel = amrData1.FinestLevel();
+        const Vector<std::string>& derives = amrData1.PlotVarNames();
+        Vector<int> destComps(nComp);
+        for (int i = 0; i < nComp; i++)
+            destComps[i] = i;
+
+
+        //
+        // Compute the error
+        //
+        Vector<MultiFab*> error(finestLevel+1);
+
         if (ParallelDescriptor::IOProcessor())
-            std::cout << "  " << iLevel << "    ";
+            std::cout << "Level  L"<< norm << " norm of Error in Each Component" << std::endl
+                      << "-----------------------------------------------" << std::endl;
+
+        for (int iLevel = 0; iLevel <= finestLevel; ++iLevel)
+        {
+            //
+            // Construct level box array and check that the lengths are the same
+            //
+            const BoxArray& ba1 = amrData1.boxArray(iLevel);
+            const BoxArray& ba2 = amrData2.boxArray(iLevel);
+
+            if (ba1.size() != ba2.size())
+            {
+                std::cout << "ERROR: BoxArray lengths are not the same at level "
+                          << iLevel << std::endl;
+                ParallelDescriptor::Abort();
+            }
+
+            //
+            // Construct MultiFab for errors
+            //
+            DistributionMapping dm(ba1);
+            error[iLevel] = new MultiFab(ba1, dm, nComp, 0);
+            error[iLevel]->setVal(GARBAGE);
+
+            //
+            // Construct refinement ratio, build the coarsened boxarray
+            // (amrData2 is the refined plotfile)
+            //
+            const Box& domain1     = amrData1.ProbDomain()[iLevel];
+            const Box& domain2     = amrData2.ProbDomain()[iLevel];
+            IntVect refine_ratio   = getRefRatio(domain1, domain2);
+            if (refine_ratio == IntVect())
+                amrex::Error("Cannot find refinement ratio from data to exact");
+
+            if (verbose)
+                std::cerr << "level = " << iLevel << "  Ref_Ratio = " << refine_ratio
+                          << std::endl;
+
+            BoxArray ba2Coarse(ba2);
+            ba2Coarse.coarsen(refine_ratio);
+
+            //
+            // For each component, average the fine fields down and calculate
+            // the errors
+            //
+            Vector<Real> norms(nComp);
+            for (int iComp = 0; iComp < nComp; iComp++)
+                norms[iComp] = 0.0;
+
+            for (int iComp = 0; iComp < nComp; ++iComp)
+            {
+                MultiFab& data1 = amrData1.GetGrids(iLevel, iComp);
+                MultiFab& data2Fine = amrData2.GetGrids(iLevel, iComp);
+
+                if (data1.contains_nan()) {
+                    Abort("First plotfile contains NaN(s)");
+                }
+                if (data2Fine.contains_nan()) {
+                    Abort("Second plotfile contains NaN(s)");
+                }
+
+
+                //
+                // Calculate the errors  for each FAB in the MultiFab
+                //
+                for (MFIter mfi(data1); mfi.isValid(); ++mfi)
+                {
+                    //
+                    // Create the Coarsened version of data2
+                    //
+                    int index = mfi.index();
+
+                    const Box& bx = ba2Coarse[index];
+                    FArrayBox data2Coarse(bx, 1);
+                    int ncCoarse = data2Coarse.nComp();
+
+                    FORT_CV_AVGDOWN(data2Coarse.dataPtr(),
+                                    ARLIM(bx.loVect()), ARLIM(bx.hiVect()),
+                                    &ncCoarse,
+                                    data2Fine[mfi].dataPtr(),
+                                    ARLIM(data2Fine[mfi].loVect()),
+                                    ARLIM(data2Fine[mfi].hiVect()),
+                                    bx.loVect(), bx.hiVect(),
+                                    refine_ratio.getVect());
+
+
+                    //
+                    // Calculate the errors on this FAB for this component
+                    //
+                    (*error[iLevel])[mfi].copy(data1[mfi], 0, iComp, 1);
+                    (*error[iLevel])[mfi].minus(data2Coarse, 0, iComp, 1);
+
+                    Real grdL2 = (*error[iLevel])[mfi].norm(norm, iComp, 1);
+
+                    if (norm != 0)
+                    {
+                        norms[iComp] = norms[iComp] + pow(grdL2, norm);
+                    }
+                    else
+                    {
+                        norms[iComp] = std::max(norms[iComp], grdL2);
+                    }
+                }
+            }
+
+
+            //
+            // Output Statistics
+            //
+            if (ParallelDescriptor::IOProcessor())
+                std::cout << "  " << iLevel << "    ";
 
 
 #ifdef BL_USE_MPI
 
-        MPI_Datatype datatype = ParallelDescriptor::Mpi_typemap<Real>::type();
+            MPI_Datatype datatype = ParallelDescriptor::Mpi_typemap<Real>::type();
 
-        if (ParallelDescriptor::IOProcessor())
-        {
-            Vector<Real> tmp(nComp);
-            for (int proc = 0; proc < ParallelDescriptor::NProcs(); proc++)
-                if (proc != ParallelDescriptor::IOProcessorNumber())
-                {
-                    MPI_Status stat;
-                    int rc = MPI_Recv(tmp.dataPtr(), nComp, datatype,
-                                      MPI_ANY_SOURCE, proc, ParallelDescriptor::Communicator(),
-                                      &stat);
+            if (ParallelDescriptor::IOProcessor())
+            {
+                Vector<Real> tmp(nComp);
+                for (int proc = 0; proc < ParallelDescriptor::NProcs(); proc++)
+                    if (proc != ParallelDescriptor::IOProcessorNumber())
+                    {
+                        MPI_Status stat;
+                        int rc = MPI_Recv(tmp.dataPtr(), nComp, datatype,
+                                          MPI_ANY_SOURCE, proc, ParallelDescriptor::Communicator(),
+                                          &stat);
 
-                    if (rc != MPI_SUCCESS)
-                        ParallelDescriptor::Abort(rc);
+                        if (rc != MPI_SUCCESS)
+                            ParallelDescriptor::Abort(rc);
 
-                    for (int iComp = 0; iComp < nComp; iComp++)
-                        if (norm != 0)
-                        {
-                            norms[iComp] = norms[iComp] + tmp[iComp];
-                        }
-                        else
-                        {
-                            norms[iComp] = std::max(norms[iComp], tmp[iComp]);
-                        }
-                }
-        }
-        else
-        {
-            int rc = MPI_Send(norms.dataPtr(), nComp, datatype,
-                              ParallelDescriptor::IOProcessorNumber(),
-                              ParallelDescriptor::MyProc(),
-                              ParallelDescriptor::Communicator());
+                        for (int iComp = 0; iComp < nComp; iComp++)
+                            if (norm != 0)
+                            {
+                                norms[iComp] = norms[iComp] + tmp[iComp];
+                            }
+                            else
+                            {
+                                norms[iComp] = std::max(norms[iComp], tmp[iComp]);
+                            }
+                    }
+            }
+            else
+            {
+                int rc = MPI_Send(norms.dataPtr(), nComp, datatype,
+                                  ParallelDescriptor::IOProcessorNumber(),
+                                  ParallelDescriptor::MyProc(),
+                                  ParallelDescriptor::Communicator());
 
-            if (rc != MPI_SUCCESS)
-                ParallelDescriptor::Abort(rc);
-        }
+                if (rc != MPI_SUCCESS)
+                    ParallelDescriptor::Abort(rc);
+            }
 #endif
 
 
-        Real vol = 1.0;
-        for (int dir = 0; dir < BL_SPACEDIM; dir++)
-            vol *= amrData1.DxLevel()[iLevel][dir];
+            Real vol = 1.0;
+            for (int dir = 0; dir < BL_SPACEDIM; dir++)
+                vol *= amrData1.DxLevel()[iLevel][dir];
 
-        if (ParallelDescriptor::IOProcessor())
-        {
-            for (int iComp = 0; iComp < nComp; iComp++)
+            if (ParallelDescriptor::IOProcessor())
             {
-                if (norm != 0)
+                for (int iComp = 0; iComp < nComp; iComp++)
                 {
-                    norms[iComp] = norms[iComp] * vol;
-                    norms[iComp] = pow(norms[iComp], (1.0/norm));
+                    if (norm != 0)
+                    {
+                        norms[iComp] = norms[iComp] * vol;
+                        norms[iComp] = pow(norms[iComp], (1.0/norm));
+                    }
+
+                    std::cout << norms[iComp] << " ";
                 }
-
-                std::cout << norms[iComp] << " ";
+                std::cout << std::endl;
             }
-            std::cout << std::endl;
         }
+
+
+        if (!difFile.empty())
+            WritePlotFile(error, amrData1, difFile, verbose);
+
+        for (int iLevel = 0; iLevel <= finestLevel; ++iLevel)
+            delete error[iLevel];
+
     }
-
-
-    if (!difFile.empty())
-        WritePlotFile(error, amrData1, difFile, verbose);
-
-    for (int iLevel = 0; iLevel <= finestLevel; ++iLevel)
-        delete error[iLevel];
-
     amrex::Finalize();
 }
 

--- a/Tools/C_util/Convergence/DiffUniform.cpp
+++ b/Tools/C_util/Convergence/DiffUniform.cpp
@@ -63,142 +63,144 @@ main (int   argc,
       char* argv[])
 {
     amrex::Initialize(argc,argv);
-
-    if (argc == 1)
-        PrintUsage(argv[0]);
-
-    ParmParse pp;
-
-    if (pp.contains("help"))
-        PrintUsage(argv[0]);
-
-    FArrayBox::setFormat(FABio::FAB_IEEE_32);
-    //
-    // Scan the arguments.
-    //
-    std::string iFileDir, iFile, eFile, oFile, oFileDir;
-
-    bool verbose = false;
-    if (pp.contains("verbose"))
     {
-        verbose = true;
-        AmrData::SetVerbose(true);
-    }
-    pp.query("infile", iFile);
-    if (iFile.empty())
-        amrex::Abort("You must specify `infile'");
 
-    pp.query("exact", eFile);
-    if (eFile.empty())
-        amrex::Abort("You must specify `exact' file");
+        if (argc == 1)
+            PrintUsage(argv[0]);
 
-    pp.query("outfile", oFile);
-    if (oFile.empty())
-        amrex::Abort("You must specify `outfile'");
+        ParmParse pp;
 
-    DataServices::SetBatchMode();
-    Amrvis::FileType fileType(Amrvis::NEWPLT);
+        if (pp.contains("help"))
+            PrintUsage(argv[0]);
 
-    DataServices dataServicesC(iFile, fileType);
-    DataServices dataServicesF(eFile, fileType);
-
-    if (!dataServicesC.AmrDataOk() || !dataServicesF.AmrDataOk())
+        FArrayBox::setFormat(FABio::FAB_IEEE_32);
         //
-        // This calls ParallelDescriptor::EndParallel() and exit()
+        // Scan the arguments.
         //
-        DataServices::Dispatch(DataServices::ExitRequest, NULL);
+        std::string iFileDir, iFile, eFile, oFile, oFileDir;
 
-    AmrData& amrDataC = dataServicesC.AmrDataRef();
-    AmrData& amrDataF = dataServicesF.AmrDataRef();
-
-    BL_ASSERT(amrDatasHaveSameDerives(amrDataC,amrDataF));
-    int exact_level = finestLevelCoveringDomain(amrDataF);
-    if (exact_level < 0)
-    {
-        std::cout << "Exact data does not contain a level covering the domain" << '\n';
-        amrex::Abort();
-    }
-    if (verbose)
-        std::cout << "Using level = " << exact_level << " in 'exact' file" << '\n';
-
-    int finestLevel = amrDataC.FinestLevel();
-
-    //
-    // Compute the error
-    //
-    Vector<MultiFab*> error(finestLevel+1);
-
-    for (int iLevel = 0; iLevel <= finestLevel; ++iLevel)
-    {
-        const BoxArray& crseBA = amrDataC.boxArray(iLevel);
-        int nComp              = amrDataC.NComp();
-        const Box& domainC     = amrDataC.ProbDomain()[iLevel];
-        const Box& domainF     = amrDataF.ProbDomain()[exact_level];
-        IntVect refine_ratio   = getRefRatio(domainC, domainF);
-        if (refine_ratio == IntVect())
-            amrex::Error("Cannot find refinement ratio from data to exact");
-
-        if (ParallelDescriptor::IOProcessor())
-          std::cout << "Ratio for level " << iLevel << " is " << refine_ratio << std::endl;
-
-        DistributionMapping dm(crseBA);
-        error[iLevel] = new MultiFab(crseBA, dm, nComp, 0);
-        error[iLevel]->setVal(GARBAGE);
-
-        for (int iComp=0; iComp<nComp; ++iComp)
+        bool verbose = false;
+        if (pp.contains("verbose"))
         {
-            MultiFab& exact = amrDataF.GetGrids(exact_level,iComp);
-            const BoxArray& exactBA = exact.boxArray();
-            const BoxArray crseBA = ::BoxArray(exactBA).coarsen(refine_ratio);
-            MultiFab aveExact(crseBA,dm, 1,0);
-            std::cout << crseBA;
-            int nc = exact.nComp();
-            for (MFIter amfi(aveExact); amfi.isValid(); ++amfi)
-            {
-                const Box& crseBox = amfi.validbox();
-                const int* a_lo = aveExact[amfi].loVect();
-                const int* a_hi = aveExact[amfi].hiVect();
-                const int* e_lo = exact[amfi].loVect();
-                const int* e_hi = exact[amfi].hiVect();
-                FORT_CV_AVGDOWN(aveExact[amfi].dataPtr(),
-                                ARLIM(a_lo), ARLIM(a_hi), &nc,
-                                exact[amfi].dataPtr(),
-                                ARLIM(e_lo), ARLIM(e_hi),
-                                crseBox.loVect(), crseBox.hiVect(),
-                                refine_ratio.getVect());
-            }
-
-            // Copy result of coarsening into error as temporary storage
-            error[iLevel]->copy(aveExact,0,iComp,nc);
-
-            // Subtract coarse data from coarsened exact data
-            MultiFab& data = amrDataC.GetGrids(iLevel,iComp);
-            BL_ASSERT(data.boxArray() == error[iLevel]->boxArray());
-
-            Real norm_before = (*error[iLevel]).norm2(iComp);
-
-            if (ParallelDescriptor::IOProcessor())
-            {
-              std::cout << "DOING ICOMP " << iComp << std::endl;
-              std::cout << "BEFORE: NORM OF ERROR " << norm_before << std::endl;
-            }
-            for (MFIter dmfi(data); dmfi.isValid(); ++dmfi)
-            {
-                (*error[iLevel])[dmfi].minus(data[dmfi],0,iComp,1);
-
-            }
-            Real norm_after = (*error[iLevel]).norm2(iComp);
-
-            if (ParallelDescriptor::IOProcessor())
-              std::cout << "AFTER: NORM OF ERROR " << norm_after << std::endl;
+            verbose = true;
+            AmrData::SetVerbose(true);
         }
+        pp.query("infile", iFile);
+        if (iFile.empty())
+            amrex::Abort("You must specify `infile'");
+
+        pp.query("exact", eFile);
+        if (eFile.empty())
+            amrex::Abort("You must specify `exact' file");
+
+        pp.query("outfile", oFile);
+        if (oFile.empty())
+            amrex::Abort("You must specify `outfile'");
+
+        DataServices::SetBatchMode();
+        Amrvis::FileType fileType(Amrvis::NEWPLT);
+
+        DataServices dataServicesC(iFile, fileType);
+        DataServices dataServicesF(eFile, fileType);
+
+        if (!dataServicesC.AmrDataOk() || !dataServicesF.AmrDataOk())
+            //
+            // This calls ParallelDescriptor::EndParallel() and exit()
+            //
+            DataServices::Dispatch(DataServices::ExitRequest, NULL);
+
+        AmrData& amrDataC = dataServicesC.AmrDataRef();
+        AmrData& amrDataF = dataServicesF.AmrDataRef();
+
+        BL_ASSERT(amrDatasHaveSameDerives(amrDataC,amrDataF));
+        int exact_level = finestLevelCoveringDomain(amrDataF);
+        if (exact_level < 0)
+        {
+            std::cout << "Exact data does not contain a level covering the domain" << '\n';
+            amrex::Abort();
+        }
+        if (verbose)
+            std::cout << "Using level = " << exact_level << " in 'exact' file" << '\n';
+
+        int finestLevel = amrDataC.FinestLevel();
+
+        //
+        // Compute the error
+        //
+        Vector<MultiFab*> error(finestLevel+1);
+
+        for (int iLevel = 0; iLevel <= finestLevel; ++iLevel)
+        {
+            const BoxArray& crseBA = amrDataC.boxArray(iLevel);
+            int nComp              = amrDataC.NComp();
+            const Box& domainC     = amrDataC.ProbDomain()[iLevel];
+            const Box& domainF     = amrDataF.ProbDomain()[exact_level];
+            IntVect refine_ratio   = getRefRatio(domainC, domainF);
+            if (refine_ratio == IntVect())
+                amrex::Error("Cannot find refinement ratio from data to exact");
+
+            if (ParallelDescriptor::IOProcessor())
+                std::cout << "Ratio for level " << iLevel << " is " << refine_ratio << std::endl;
+
+            DistributionMapping dm(crseBA);
+            error[iLevel] = new MultiFab(crseBA, dm, nComp, 0);
+            error[iLevel]->setVal(GARBAGE);
+
+            for (int iComp=0; iComp<nComp; ++iComp)
+            {
+                MultiFab& exact = amrDataF.GetGrids(exact_level,iComp);
+                const BoxArray& exactBA = exact.boxArray();
+                const BoxArray crseBA = ::BoxArray(exactBA).coarsen(refine_ratio);
+                MultiFab aveExact(crseBA,dm, 1,0);
+                std::cout << crseBA;
+                int nc = exact.nComp();
+                for (MFIter amfi(aveExact); amfi.isValid(); ++amfi)
+                {
+                    const Box& crseBox = amfi.validbox();
+                    const int* a_lo = aveExact[amfi].loVect();
+                    const int* a_hi = aveExact[amfi].hiVect();
+                    const int* e_lo = exact[amfi].loVect();
+                    const int* e_hi = exact[amfi].hiVect();
+                    FORT_CV_AVGDOWN(aveExact[amfi].dataPtr(),
+                                    ARLIM(a_lo), ARLIM(a_hi), &nc,
+                                    exact[amfi].dataPtr(),
+                                    ARLIM(e_lo), ARLIM(e_hi),
+                                    crseBox.loVect(), crseBox.hiVect(),
+                                    refine_ratio.getVect());
+                }
+
+                // Copy result of coarsening into error as temporary storage
+                error[iLevel]->copy(aveExact,0,iComp,nc);
+
+                // Subtract coarse data from coarsened exact data
+                MultiFab& data = amrDataC.GetGrids(iLevel,iComp);
+                BL_ASSERT(data.boxArray() == error[iLevel]->boxArray());
+
+                Real norm_before = (*error[iLevel]).norm2(iComp);
+
+                if (ParallelDescriptor::IOProcessor())
+                {
+                    std::cout << "DOING ICOMP " << iComp << std::endl;
+                    std::cout << "BEFORE: NORM OF ERROR " << norm_before << std::endl;
+                }
+                for (MFIter dmfi(data); dmfi.isValid(); ++dmfi)
+                {
+                    (*error[iLevel])[dmfi].minus(data[dmfi],0,iComp,1);
+
+                }
+                Real norm_after = (*error[iLevel]).norm2(iComp);
+
+                if (ParallelDescriptor::IOProcessor())
+                    std::cout << "AFTER: NORM OF ERROR " << norm_after << std::endl;
+            }
+        }
+
+        WritePlotFile(error, amrDataC, oFile, verbose);
+
+        for (int iLevel = 0; iLevel <= finestLevel; ++iLevel)
+            delete error[iLevel];
+
     }
-
-    WritePlotFile(error, amrDataC, oFile, verbose);
-
-    for (int iLevel = 0; iLevel <= finestLevel; ++iLevel)
-        delete error[iLevel];
-
     amrex::Finalize();
 }
 

--- a/Tools/C_util/Convergence/PltFileNorm.cpp
+++ b/Tools/C_util/Convergence/PltFileNorm.cpp
@@ -42,106 +42,109 @@ main (int   argc,
       char* argv[])
 {
     amrex::Initialize(argc,argv);
-
-    if (argc == 1)
-        PrintUsage(argv[0]);
-
-    ParmParse pp;
-
-    if (pp.contains("help"))
-        PrintUsage(argv[0]);
-
-    FArrayBox::setFormat(FABio::FAB_IEEE_32);
-    //
-    // Scan the arguments.
-    //
-    std::string iFile;
-    int integrate = 1;
-    pp.query("integrate", integrate);
-    bool verbose = false;
-    if (pp.contains("verbose"))
     {
-        verbose = true;
-        AmrData::SetVerbose(true);
-    }
-    pp.query("infile", iFile);
-    if (iFile.empty())
-        amrex::Abort("You must specify `infile'");
 
-    Vector<Real> norm0, norm1, norm2;
+        if (argc == 1)
+            PrintUsage(argv[0]);
 
-    DataServices::SetBatchMode();
-    Amrvis::FileType fileType(Amrvis::NEWPLT);
+        ParmParse pp;
 
-    DataServices dataServices(iFile, fileType);
+        if (pp.contains("help"))
+            PrintUsage(argv[0]);
 
-    AmrData& amrData = dataServices.AmrDataRef();
-
-
-
-    if (integrate)
-    {
-      ComputeAmrDataInt(amrData, norm1,  verbose);
-
-      // Write norms to screen
-      if (ParallelDescriptor::IOProcessor())
-      {
-        const Vector<std::string>& names = amrData.PlotVarNames();
-        int maxl = 0;
-        for (int i=0; i<names.size(); ++i)
-            maxl = std::max(maxl,int(names[i].size()));
-
-        std::string maxl_str = amrex::Concatenate("", maxl, 1);
-
-        std::string formatStr =
-            std::string("\t%") + maxl_str + std::string("s |  %10e   \n");
-        std::string sformatStr =
-            std::string("\t%") + maxl_str + std::string("s |  %10s   \n");
-
-        std::cout << '\n' << "Norms for pltfile = " << iFile << ": " << '\n' << '\n';
-        printf(sformatStr.c_str(),"Derived", "Integral");
-        std::cout << '\t'
-             << "--------------+------------------------------------------" << '\n';
-
-        for (int i=0; i<names.size(); ++i)
+        FArrayBox::setFormat(FABio::FAB_IEEE_32);
+        //
+        // Scan the arguments.
+        //
+        std::string iFile;
+        int integrate = 1;
+        pp.query("integrate", integrate);
+        bool verbose = false;
+        if (pp.contains("verbose"))
         {
-            printf(formatStr.c_str(),names[i].c_str(),norm1[i]);
+            verbose = true;
+            AmrData::SetVerbose(true);
         }
-        std::cout << '\n';
+        pp.query("infile", iFile);
+        if (iFile.empty())
+            amrex::Abort("You must specify `infile'");
 
-      }
-    }
-    else
-    {
-      ComputeAmrDataNorms(amrData, norm0, norm1, norm2, verbose);
+        Vector<Real> norm0, norm1, norm2;
 
-      // Write norms to screen
-      if (ParallelDescriptor::IOProcessor())
-      {
-        const Vector<std::string>& names = amrData.PlotVarNames();
-        int maxl = 0;
-        for (int i=0; i<names.size(); ++i)
-            maxl = std::max(maxl,int(names[i].size()));
+        DataServices::SetBatchMode();
+        Amrvis::FileType fileType(Amrvis::NEWPLT);
 
-        std::string maxl_str = amrex::Concatenate("", maxl, 1);
+        DataServices dataServices(iFile, fileType);
 
-        std::string formatStr =
-            std::string("\t%") + maxl_str + std::string("s |  %10e   %10e   %10e\n");
-        std::string sformatStr =
-            std::string("\t%") + maxl_str + std::string("s |  %10s   %10s   %10s\n");
+        AmrData& amrData = dataServices.AmrDataRef();
 
-        std::cout << '\n' << "Norms for pltfile = " << iFile << ": " << '\n' << '\n';
-        printf(sformatStr.c_str(),"Derived","L-inf","L1","L2");
-        std::cout << '\t'
-             << "--------------+------------------------------------------" << '\n';
 
-        for (int i=0; i<names.size(); ++i)
+
+        if (integrate)
         {
-            printf(formatStr.c_str(),names[i].c_str(),norm0[i],norm1[i],norm2[i]);
-        }
-        std::cout << '\n';
+            ComputeAmrDataInt(amrData, norm1,  verbose);
 
-      }
+            // Write norms to screen
+            if (ParallelDescriptor::IOProcessor())
+            {
+                const Vector<std::string>& names = amrData.PlotVarNames();
+                int maxl = 0;
+                for (int i=0; i<names.size(); ++i)
+                    maxl = std::max(maxl,int(names[i].size()));
+
+                std::string maxl_str = amrex::Concatenate("", maxl, 1);
+
+                std::string formatStr =
+                    std::string("\t%") + maxl_str + std::string("s |  %10e   \n");
+                std::string sformatStr =
+                    std::string("\t%") + maxl_str + std::string("s |  %10s   \n");
+
+                std::cout << '\n' << "Norms for pltfile = " << iFile << ": " << '\n' << '\n';
+                printf(sformatStr.c_str(),"Derived", "Integral");
+                std::cout << '\t'
+                          << "--------------+------------------------------------------" << '\n';
+
+                for (int i=0; i<names.size(); ++i)
+                {
+                    printf(formatStr.c_str(),names[i].c_str(),norm1[i]);
+                }
+                std::cout << '\n';
+
+            }
+        }
+        else
+        {
+            ComputeAmrDataNorms(amrData, norm0, norm1, norm2, verbose);
+
+            // Write norms to screen
+            if (ParallelDescriptor::IOProcessor())
+            {
+                const Vector<std::string>& names = amrData.PlotVarNames();
+                int maxl = 0;
+                for (int i=0; i<names.size(); ++i)
+                    maxl = std::max(maxl,int(names[i].size()));
+
+                std::string maxl_str = amrex::Concatenate("", maxl, 1);
+
+                std::string formatStr =
+                    std::string("\t%") + maxl_str + std::string("s |  %10e   %10e   %10e\n");
+                std::string sformatStr =
+                    std::string("\t%") + maxl_str + std::string("s |  %10s   %10s   %10s\n");
+
+                std::cout << '\n' << "Norms for pltfile = " << iFile << ": " << '\n' << '\n';
+                printf(sformatStr.c_str(),"Derived","L-inf","L1","L2");
+                std::cout << '\t'
+                          << "--------------+------------------------------------------" << '\n';
+
+                for (int i=0; i<names.size(); ++i)
+                {
+                    printf(formatStr.c_str(),names[i].c_str(),norm0[i],norm1[i],norm2[i]);
+                }
+                std::cout << '\n';
+
+            }
+        }
+
     }
     amrex::Finalize();
 }

--- a/Tools/C_util/Convergence/PltFileNormB.cpp
+++ b/Tools/C_util/Convergence/PltFileNormB.cpp
@@ -44,166 +44,168 @@ main (int   argc,
       char* argv[])
 {
     amrex::Initialize(argc,argv);
-
-    if (argc == 1)
-        PrintUsage(argv[0]);
-
-    ParmParse pp;
-
-    if (pp.contains("help"))
-        PrintUsage(argv[0]);
-
-    FArrayBox::setFormat(FABio::FAB_IEEE_32);
-    //
-    // Scan the arguments.
-    //
-    std::string iFile;
-
-    bool verbose = false;
-    if (pp.contains("verbose"))
     {
-        verbose = true;
-        AmrData::SetVerbose(true);
-    }
-    pp.query("infile", iFile);
-    if (iFile.empty())
-        amrex::Abort("You must specify `infile'");
 
-    int norm = 2;
-    pp.query("norm", norm);
+        if (argc == 1)
+            PrintUsage(argv[0]);
 
-    DataServices::SetBatchMode();
-    Amrvis::FileType fileType(Amrvis::NEWPLT);
+        ParmParse pp;
 
-    DataServices dataServicesC(iFile, fileType);
+        if (pp.contains("help"))
+            PrintUsage(argv[0]);
 
-    if (!dataServicesC.AmrDataOk())
-        amrex::Abort("ERROR: Dataservices not OK");
-
-
-    //
-    // Generate AmrData Objects
-    //
-    AmrData& amrDataI = dataServicesC.AmrDataRef();
-
-    //
-    // Initial Tests
-    //
-    int nComp       = amrDataI.NComp();
-    int finestLevel = amrDataI.FinestLevel();
-    const Vector<std::string>& derives = amrDataI.PlotVarNames();
-    Vector<int> destComps(nComp);
-    for (int i = 0; i < nComp; i++)
-        destComps[i] = i;
-
-
-    //
-    // Compute the error
-    //
-    Vector<MultiFab*> error(finestLevel+1);
-
-    if (ParallelDescriptor::IOProcessor())
-        std::cout << "Level  L"<< norm << " norm of Error in Each Component" << std::endl
-             << "-----------------------------------------------" << std::endl;
-
-    for (int iLevel = 0; iLevel <= finestLevel; ++iLevel)
-    {
-        const BoxArray& baI = amrDataI.boxArray(iLevel);
-
-        DistributionMapping dm(baI);
-        MultiFab dataI(baI, dm, nComp, 0);
-
-        amrDataI.FillVar(dataI, iLevel, derives, destComps);
-
+        FArrayBox::setFormat(FABio::FAB_IEEE_32);
         //
-        // Output Statistics
+        // Scan the arguments.
         //
-        if (ParallelDescriptor::IOProcessor())
-            std::cout << "  " << iLevel << "    ";
+        std::string iFile;
 
-        Vector<Real> norms(nComp);
-        for (int iComp = 0; iComp < nComp; iComp++)
-            norms[iComp] = 0.0;
-
-        for (MFIter mfi(dataI); mfi.isValid(); ++mfi)
+        bool verbose = false;
+        if (pp.contains("verbose"))
         {
-            for (int iComp = 0; iComp < nComp; iComp++)
-            {
-                Real grdL2 = dataI[mfi].norm(norm, iComp, 1);
-
-                if (norm != 0)
-                {
-                    norms[iComp] = norms[iComp] + pow(grdL2, norm);
-                }
-                else
-                {
-                    norms[iComp] = std::max(norms[iComp], grdL2);
-                }
-
-            }
+            verbose = true;
+            AmrData::SetVerbose(true);
         }
+        pp.query("infile", iFile);
+        if (iFile.empty())
+            amrex::Abort("You must specify `infile'");
+
+        int norm = 2;
+        pp.query("norm", norm);
+
+        DataServices::SetBatchMode();
+        Amrvis::FileType fileType(Amrvis::NEWPLT);
+
+        DataServices dataServicesC(iFile, fileType);
+
+        if (!dataServicesC.AmrDataOk())
+            amrex::Abort("ERROR: Dataservices not OK");
+
+
+        //
+        // Generate AmrData Objects
+        //
+        AmrData& amrDataI = dataServicesC.AmrDataRef();
+
+        //
+        // Initial Tests
+        //
+        int nComp       = amrDataI.NComp();
+        int finestLevel = amrDataI.FinestLevel();
+        const Vector<std::string>& derives = amrDataI.PlotVarNames();
+        Vector<int> destComps(nComp);
+        for (int i = 0; i < nComp; i++)
+            destComps[i] = i;
+
+
+        //
+        // Compute the error
+        //
+        Vector<MultiFab*> error(finestLevel+1);
+
+        if (ParallelDescriptor::IOProcessor())
+            std::cout << "Level  L"<< norm << " norm of Error in Each Component" << std::endl
+                      << "-----------------------------------------------" << std::endl;
+
+        for (int iLevel = 0; iLevel <= finestLevel; ++iLevel)
+        {
+            const BoxArray& baI = amrDataI.boxArray(iLevel);
+
+            DistributionMapping dm(baI);
+            MultiFab dataI(baI, dm, nComp, 0);
+
+            amrDataI.FillVar(dataI, iLevel, derives, destComps);
+
+            //
+            // Output Statistics
+            //
+            if (ParallelDescriptor::IOProcessor())
+                std::cout << "  " << iLevel << "    ";
+
+            Vector<Real> norms(nComp);
+            for (int iComp = 0; iComp < nComp; iComp++)
+                norms[iComp] = 0.0;
+
+            for (MFIter mfi(dataI); mfi.isValid(); ++mfi)
+            {
+                for (int iComp = 0; iComp < nComp; iComp++)
+                {
+                    Real grdL2 = dataI[mfi].norm(norm, iComp, 1);
+
+                    if (norm != 0)
+                    {
+                        norms[iComp] = norms[iComp] + pow(grdL2, norm);
+                    }
+                    else
+                    {
+                        norms[iComp] = std::max(norms[iComp], grdL2);
+                    }
+
+                }
+            }
 
 
 #ifdef BL_USE_MPI
-        MPI_Datatype datatype = mpi_data_type(norms.dataPtr());
-        if (ParallelDescriptor::IOProcessor())
-        {
-            Vector<Real> tmp(nComp);
-            for (int proc = 0; proc < ParallelDescriptor::NProcs(); proc++)
-                if (proc != ParallelDescriptor::IOProcessorNumber())
-                {
-                    MPI_Status stat;
-                    int rc = MPI_Recv(tmp.dataPtr(), nComp, datatype,
-                                      MPI_ANY_SOURCE, proc, ParallelDescriptor::Communicator(),
-                                      &stat);
+            MPI_Datatype datatype = mpi_data_type(norms.dataPtr());
+            if (ParallelDescriptor::IOProcessor())
+            {
+                Vector<Real> tmp(nComp);
+                for (int proc = 0; proc < ParallelDescriptor::NProcs(); proc++)
+                    if (proc != ParallelDescriptor::IOProcessorNumber())
+                    {
+                        MPI_Status stat;
+                        int rc = MPI_Recv(tmp.dataPtr(), nComp, datatype,
+                                          MPI_ANY_SOURCE, proc, ParallelDescriptor::Communicator(),
+                                          &stat);
 
-                    if (rc != MPI_SUCCESS)
-                        ParallelDescriptor::Abort(rc);
+                        if (rc != MPI_SUCCESS)
+                            ParallelDescriptor::Abort(rc);
 
-                    for (int iComp = 0; iComp < nComp; iComp++)
-                        if (norm != 0)
-                        {
-                            norms[iComp] = norms[iComp] + tmp[iComp];
-                        }
-                        else
-                        {
-                            norms[iComp] = Max(norms[iComp], tmp[iComp]);
-                        }
-                }
-        }
-        else
-        {
-            int rc = MPI_Send(norms.dataPtr(), nComp, datatype,
-                              ParallelDescriptor::IOProcessorNumber(),
-                              ParallelDescriptor::MyProc(),
-                              ParallelDescriptor::Communicator());
+                        for (int iComp = 0; iComp < nComp; iComp++)
+                            if (norm != 0)
+                            {
+                                norms[iComp] = norms[iComp] + tmp[iComp];
+                            }
+                            else
+                            {
+                                norms[iComp] = Max(norms[iComp], tmp[iComp]);
+                            }
+                    }
+            }
+            else
+            {
+                int rc = MPI_Send(norms.dataPtr(), nComp, datatype,
+                                  ParallelDescriptor::IOProcessorNumber(),
+                                  ParallelDescriptor::MyProc(),
+                                  ParallelDescriptor::Communicator());
 
-            if (rc != MPI_SUCCESS)
-                ParallelDescriptor::Abort(rc);
-        }
+                if (rc != MPI_SUCCESS)
+                    ParallelDescriptor::Abort(rc);
+            }
 #endif
 
 
-        Real vol = 1.0;
-        for (int dir = 0; dir < BL_SPACEDIM; dir++)
-            vol *= amrDataI.DxLevel()[iLevel][dir];
+            Real vol = 1.0;
+            for (int dir = 0; dir < BL_SPACEDIM; dir++)
+                vol *= amrDataI.DxLevel()[iLevel][dir];
 
-        if (ParallelDescriptor::IOProcessor())
-        {
-            for (int iComp = 0; iComp < nComp; iComp++)
+            if (ParallelDescriptor::IOProcessor())
             {
-                if (norm != 0)
+                for (int iComp = 0; iComp < nComp; iComp++)
                 {
-                    norms[iComp] = norms[iComp] * vol;
-                    norms[iComp] = pow(norms[iComp], (1.0/norm));
+                    if (norm != 0)
+                    {
+                        norms[iComp] = norms[iComp] * vol;
+                        norms[iComp] = pow(norms[iComp], (1.0/norm));
+                    }
+
+                    std::cout << norms[iComp] << " ";
                 }
-
-                std::cout << norms[iComp] << " ";
+                std::cout << std::endl;
             }
-            std::cout << std::endl;
         }
-    }
 
+    }
     amrex::Finalize();
 }
 

--- a/Tools/C_util/Convergence/PltFileScalConvRate.cpp
+++ b/Tools/C_util/Convergence/PltFileScalConvRate.cpp
@@ -42,86 +42,88 @@ main (int   argc,
       char* argv[])
 {
     amrex::Initialize(argc,argv);
-
-    if (argc == 1)
-        PrintUsage(argv[0]);
-
-    ParmParse pp;
-
-    if (pp.contains("help"))
-        PrintUsage(argv[0]);
-
-    FArrayBox::setFormat(FABio::FAB_IEEE_32);
-    //
-    // Scan the arguments.
-    //
-    std::string cFile, fFile;
-
-    bool verbose = false;
-    if (pp.contains("verbose"))
     {
-        verbose = true;
-        AmrData::SetVerbose(true);
-    }
-    pp.query("errorC", cFile);
-    if (cFile.empty())
-        amrex::Abort("You must specify `errorC'");
 
-    pp.query("errorF", fFile);
-    if (fFile.empty())
-        amrex::Abort("You must specify `errorF'");
+        if (argc == 1)
+            PrintUsage(argv[0]);
 
-    Vector<Real> norm0c, norm1c, norm2c;
-    Vector<Real> norm0f, norm1f, norm2f;
+        ParmParse pp;
 
-    DataServices::SetBatchMode();
-    Amrvis::FileType fileType(Amrvis::NEWPLT);
+        if (pp.contains("help"))
+            PrintUsage(argv[0]);
 
-    DataServices dataServicesC(cFile, fileType);
-    DataServices dataServicesF(fFile, fileType);
+        FArrayBox::setFormat(FABio::FAB_IEEE_32);
+        //
+        // Scan the arguments.
+        //
+        std::string cFile, fFile;
 
-    AmrData& amrDataC = dataServicesC.AmrDataRef();
-    AmrData& amrDataF = dataServicesF.AmrDataRef();
-    BL_ASSERT(amrDatasHaveSameDerives(amrDataC,amrDataF));
-
-    ComputeAmrDataNorms(amrDataC, norm0c, norm1c, norm2c, verbose);
-    ComputeAmrDataNorms(amrDataF, norm0f, norm1f, norm2f, verbose);
-
-    // Write norms to screen
-    if (ParallelDescriptor::IOProcessor())
-    {
-        const Vector<std::string>& names = amrDataC.PlotVarNames();
-        int maxl = 0;
-        for (int i=0; i<names.size(); ++i)
-            maxl = std::max(maxl,int(names[i].size()));
-
-        std::string maxl_str = amrex::Concatenate("", maxl, 1);
-
-        std::string formatStr =
-            std::string("\t%") + maxl_str + std::string("s |  %10e   %10e   %10e\n");
-        std::string sformatStr =
-            std::string("\t%") + maxl_str + std::string("s |  %10s   %10s   %10s\n");
-
-        std::cout << '\n' << "Rates for pltfiles = "
-             << cFile << ", "
-             << fFile << ": " << '\n' << '\n';
-        printf(sformatStr.c_str(),"Derived","rate_L-inf","rate_L1","rate_L2");
-        std::cout << '\t'
-             << "--------------+------------------------------------------" << '\n';
-
-        Real log2 = log(2.0);
-        for (int i=0; i<names.size(); ++i)
+        bool verbose = false;
+        if (pp.contains("verbose"))
         {
-            Real rate0, rate1, rate2;
-            rate0 = (norm0f[i]==0 ? 0.0 : log(norm0c[i]/norm0f[i])/log2);
-            rate1 = (norm1f[i]==0 ? 0.0 : log(norm1c[i]/norm1f[i])/log2);
-            rate2 = (norm2f[i]==0 ? 0.0 : log(norm2c[i]/norm2f[i])/log2);
-            printf(formatStr.c_str(),names[i].c_str(),rate0,rate1,rate2);
+            verbose = true;
+            AmrData::SetVerbose(true);
         }
-        std::cout << '\n';
+        pp.query("errorC", cFile);
+        if (cFile.empty())
+            amrex::Abort("You must specify `errorC'");
+
+        pp.query("errorF", fFile);
+        if (fFile.empty())
+            amrex::Abort("You must specify `errorF'");
+
+        Vector<Real> norm0c, norm1c, norm2c;
+        Vector<Real> norm0f, norm1f, norm2f;
+
+        DataServices::SetBatchMode();
+        Amrvis::FileType fileType(Amrvis::NEWPLT);
+
+        DataServices dataServicesC(cFile, fileType);
+        DataServices dataServicesF(fFile, fileType);
+
+        AmrData& amrDataC = dataServicesC.AmrDataRef();
+        AmrData& amrDataF = dataServicesF.AmrDataRef();
+        BL_ASSERT(amrDatasHaveSameDerives(amrDataC,amrDataF));
+
+        ComputeAmrDataNorms(amrDataC, norm0c, norm1c, norm2c, verbose);
+        ComputeAmrDataNorms(amrDataF, norm0f, norm1f, norm2f, verbose);
+
+        // Write norms to screen
+        if (ParallelDescriptor::IOProcessor())
+        {
+            const Vector<std::string>& names = amrDataC.PlotVarNames();
+            int maxl = 0;
+            for (int i=0; i<names.size(); ++i)
+                maxl = std::max(maxl,int(names[i].size()));
+
+            std::string maxl_str = amrex::Concatenate("", maxl, 1);
+
+            std::string formatStr =
+                std::string("\t%") + maxl_str + std::string("s |  %10e   %10e   %10e\n");
+            std::string sformatStr =
+                std::string("\t%") + maxl_str + std::string("s |  %10s   %10s   %10s\n");
+
+            std::cout << '\n' << "Rates for pltfiles = "
+                      << cFile << ", "
+                      << fFile << ": " << '\n' << '\n';
+            printf(sformatStr.c_str(),"Derived","rate_L-inf","rate_L1","rate_L2");
+            std::cout << '\t'
+                      << "--------------+------------------------------------------" << '\n';
+
+            Real log2 = log(2.0);
+            for (int i=0; i<names.size(); ++i)
+            {
+                Real rate0, rate1, rate2;
+                rate0 = (norm0f[i]==0 ? 0.0 : log(norm0c[i]/norm0f[i])/log2);
+                rate1 = (norm1f[i]==0 ? 0.0 : log(norm1c[i]/norm1f[i])/log2);
+                rate2 = (norm2f[i]==0 ? 0.0 : log(norm2c[i]/norm2f[i])/log2);
+                printf(formatStr.c_str(),names[i].c_str(),rate0,rate1,rate2);
+            }
+            std::cout << '\n';
+
+        }
 
     }
-
     amrex::Finalize();
 }
 

--- a/Tools/C_util/Convergence/RichardsonConvergenceTest.cpp
+++ b/Tools/C_util/Convergence/RichardsonConvergenceTest.cpp
@@ -416,146 +416,147 @@ main (int   argc,
       char* argv[])
 {
   amrex::Initialize(argc,argv);
-
-  if (argc == 1)
-    PrintUsage(argv[0]);
-
-  ParmParse pp;
-
-  if (pp.contains("help"))
-    PrintUsage(argv[0]);
-
-  bool verbose = false;
-  if (pp.contains("verbose"))
-    verbose = true;
-
-  bool latex = false;
-  if (pp.contains("latex"))
-    latex = true;
-
-  FArrayBox::setFormat(FABio::FAB_IEEE_32);
-  //
-  // Scan the arguments.
-  //
-  std::string coarFile, mediFile, fineFile;
-  std::string coarError, mediError;
-
-
-  pp.query("fineFile", fineFile);
-  if (fineFile.empty())
-    amrex::Abort("You must specify fineFile");
-
-  pp.query("mediFile", mediFile);
-  if (mediFile.empty())
-    amrex::Abort("You must specify mediFile");
-
-  pp.query("coarFile", coarFile);
-  if (coarFile.empty())
-    amrex::Abort("You must specify coarFile");
-
-
-  pp.query("mediError", mediError);
-  pp.query("coarError", coarError);
-
-  //l2 is not supported
-  for(int inorm = 0; inorm <=1; inorm++)
   {
-    Vector<Real> normsMedi, normsCoar;
-    Vector<string> namesMedi, namesCoar;
 
-    amrex::Print() << std::endl;
-    amrex::Print() << "Level  L"<< inorm << " norm of Error in Each Component" << std::endl
-                   << "-----------------------------------------------" << std::endl;
+      if (argc == 1)
+          PrintUsage(argv[0]);
 
-    getErrorNorms(normsMedi, namesMedi, fineFile, mediFile, mediError, inorm, verbose, true);
-    getErrorNorms(normsCoar, namesCoar, mediFile, coarFile, coarError, inorm, verbose, false);
-    int ncompMedi = normsMedi.size();
-    int ncompCoar = normsCoar.size();
-    int ncomp = std::min(ncompMedi, ncompCoar);
+      ParmParse pp;
 
-    if (latex) {
-      amrex::Print() << "\\begin{table}[p]" << std::endl;
-      amrex::Print() << "\\begin{center}" << std::endl;
-      amrex::Print() << "\\begin{tabular}{|cccc|} \\hline" << std::endl;
-      amrex::Print() << "Variable & $e_{4h \\rightarrow 2h}$ & Order & $e_{2h \\rightarrow h}$\\\\" << std::endl;;
-      amrex::Print() << "\\hline " << std::endl;
-    }
+      if (pp.contains("help"))
+          PrintUsage(argv[0]);
 
-    for (int icomp = 0; icomp < ncomp; icomp++)
-    {
-      bool printOrder = false;
-      Real order;
-      Real finenorm = normsMedi[icomp];
-      Real coarnorm = normsCoar[icomp];
-      if(std::abs(finenorm) > 1.0e-40)
+      bool verbose = false;
+      if (pp.contains("verbose"))
+          verbose = true;
+
+      bool latex = false;
+      if (pp.contains("latex"))
+          latex = true;
+
+      FArrayBox::setFormat(FABio::FAB_IEEE_32);
+      //
+      // Scan the arguments.
+      //
+      std::string coarFile, mediFile, fineFile;
+      std::string coarError, mediError;
+
+
+      pp.query("fineFile", fineFile);
+      if (fineFile.empty())
+          amrex::Abort("You must specify fineFile");
+
+      pp.query("mediFile", mediFile);
+      if (mediFile.empty())
+          amrex::Abort("You must specify mediFile");
+
+      pp.query("coarFile", coarFile);
+      if (coarFile.empty())
+          amrex::Abort("You must specify coarFile");
+
+
+      pp.query("mediError", mediError);
+      pp.query("coarError", coarError);
+
+      //l2 is not supported
+      for(int inorm = 0; inorm <=1; inorm++)
       {
-        order = log(std::abs(coarnorm/finenorm))/log(2.0);
-        printOrder = true;
-      }
+          Vector<Real> normsMedi, normsCoar;
+          Vector<string> namesMedi, namesCoar;
 
-      amrex::Print() << setw(24) << namesMedi[icomp];
-      if (latex) {
-        amrex::Print() << "&    \t ";
-      } else {
-        amrex::Print() << "        ";
-      }
-      amrex::Print().SetPrecision(6) << setw(12) << std::right << std::scientific << normsCoar[icomp];
-      if (latex) {
-        amrex::Print() << " & ";
-      } else {
-        amrex::Print() << "   ";
-      }
+          amrex::Print() << std::endl;
+          amrex::Print() << "Level  L"<< inorm << " norm of Error in Each Component" << std::endl
+                         << "-----------------------------------------------" << std::endl;
 
-      if(printOrder)
-      {
-        amrex::Print().SetPrecision(6)  << setw(12) << std::right << std::fixed << order;
-        if (latex) {
-          amrex::Print() << " & ";
-        } else {
-          amrex::Print() << "   ";
-        }
+          getErrorNorms(normsMedi, namesMedi, fineFile, mediFile, mediError, inorm, verbose, true);
+          getErrorNorms(normsCoar, namesCoar, mediFile, coarFile, coarError, inorm, verbose, false);
+          int ncompMedi = normsMedi.size();
+          int ncompCoar = normsCoar.size();
+          int ncomp = std::min(ncompMedi, ncompCoar);
+
+          if (latex) {
+              amrex::Print() << "\\begin{table}[p]" << std::endl;
+              amrex::Print() << "\\begin{center}" << std::endl;
+              amrex::Print() << "\\begin{tabular}{|cccc|} \\hline" << std::endl;
+              amrex::Print() << "Variable & $e_{4h \\rightarrow 2h}$ & Order & $e_{2h \\rightarrow h}$\\\\" << std::endl;;
+              amrex::Print() << "\\hline " << std::endl;
+          }
+
+          for (int icomp = 0; icomp < ncomp; icomp++)
+          {
+              bool printOrder = false;
+              Real order;
+              Real finenorm = normsMedi[icomp];
+              Real coarnorm = normsCoar[icomp];
+              if(std::abs(finenorm) > 1.0e-40)
+              {
+                  order = log(std::abs(coarnorm/finenorm))/log(2.0);
+                  printOrder = true;
+              }
+
+              amrex::Print() << setw(24) << namesMedi[icomp];
+              if (latex) {
+                  amrex::Print() << "&    \t ";
+              } else {
+                  amrex::Print() << "        ";
+              }
+              amrex::Print().SetPrecision(6) << setw(12) << std::right << std::scientific << normsCoar[icomp];
+              if (latex) {
+                  amrex::Print() << " & ";
+              } else {
+                  amrex::Print() << "   ";
+              }
+
+              if(printOrder)
+              {
+                  amrex::Print().SetPrecision(6)  << setw(12) << std::right << std::fixed << order;
+                  if (latex) {
+                      amrex::Print() << " & ";
+                  } else {
+                      amrex::Print() << "   ";
+                  }
+              }
+              else
+              {
+                  amrex::Print() << "------------ ";
+                  if (latex) {
+                      amrex::Print() << "& ";
+                  } else {
+                      amrex::Print() << "  ";
+                  }
+              }
+
+              amrex::Print().SetPrecision(6) << setw(12) << std::right << std::scientific << normsMedi[icomp];
+              if (latex) {
+                  amrex::Print() << " \\\\ " << std::endl;
+              } else {
+                  amrex::Print() << std::endl;
+              }
+
+          }
+
+          if (latex) {
+              amrex::Print() << "\\hline " << std::endl;
+              amrex::Print() << "\\end{tabular}" << std::endl;
+              amrex::Print() << "\\end{center}" << std::endl;
+              amrex::Print() << "\\caption{Solution error convergence rates using $L_";
+
+              if(inorm == 0)
+              {
+                  amrex::Print() <<"\\infty$ norm." << std::endl;;
+              }
+              else
+              {
+                  amrex::Print() << inorm << "$ norm.";
+              }
+              amrex::Print() << "}" << std::endl;
+              amrex::Print() << "\\end{table}" << std::endl;
+              amrex::Print() << std::endl << std::endl;
+          }
+
       }
-      else
-      {
-        amrex::Print() << "------------ ";
-        if (latex) {
-          amrex::Print() << "& ";
-        } else {
-          amrex::Print() << "  ";
-        }
-      }
-
-      amrex::Print().SetPrecision(6) << setw(12) << std::right << std::scientific << normsMedi[icomp];
-      if (latex) {
-        amrex::Print() << " \\\\ " << std::endl;
-      } else {
-        amrex::Print() << std::endl;
-      }
-
-    }
-
-    if (latex) {
-      amrex::Print() << "\\hline " << std::endl;
-      amrex::Print() << "\\end{tabular}" << std::endl;
-      amrex::Print() << "\\end{center}" << std::endl;
-      amrex::Print() << "\\caption{Solution error convergence rates using $L_";
-
-      if(inorm == 0)
-        {
-          amrex::Print() <<"\\infty$ norm." << std::endl;;
-        }
-      else
-        {
-          amrex::Print() << inorm << "$ norm.";
-        }
-      amrex::Print() << "}" << std::endl;
-      amrex::Print() << "\\end{table}" << std::endl;
-      amrex::Print() << std::endl << std::endl;
-    }
 
   }
-
-
   amrex::Finalize();
   return 0;
 }


### PR DESCRIPTION
This prevents segmentation faults that can occur if amrex objects
(like MultiFabs) are still in scope when Finalize is called.

## Summary

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
