### PR TITLE
Add another overload for PC::Checkpoint

### DIFF
--- a/Src/Particle/AMReX_ParticleIO.H
+++ b/Src/Particle/AMReX_ParticleIO.H
@@ -87,40 +87,6 @@ template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt,
           template<class> class Allocator>
 void
 ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>
-::Checkpoint (const std::string& dir, const std::string& name) const
-{
-    Vector<int> write_real_comp;
-    Vector<std::string> real_comp_names;
-    for (int i = 0; i < NStructReal + NumRealComps(); ++i )
-    {
-        write_real_comp.push_back(1);
-        std::stringstream ss;
-        ss << "real_comp" << i;
-        real_comp_names.push_back(ss.str());
-    }
-
-    Vector<int> write_int_comp;
-    Vector<std::string> int_comp_names;
-    for (int i = 0; i < NStructInt + NumIntComps(); ++i )
-    {
-        write_int_comp.push_back(1);
-        std::stringstream ss;
-        ss << "int_comp" << i;
-        int_comp_names.push_back(ss.str());
-    }
-
-    WriteBinaryParticleData(dir, name, write_real_comp, write_int_comp,
-                            real_comp_names, int_comp_names,
-                            [=] AMREX_GPU_HOST_DEVICE (const SuperParticleType& p) -> int
-                            {
-                                return p.id() > 0;
-                            });
-}
-
-template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt,
-          template<class> class Allocator>
-void
-ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>
 ::WritePlotFile (const std::string& dir, const std::string& name) const
 {
     Vector<int> write_real_comp;

--- a/Src/Particle/AMReX_Particles.H
+++ b/Src/Particle/AMReX_Particles.H
@@ -693,12 +693,8 @@ public:
      *
      * \param dir The base directory into which to write (i.e. "plt00000")
      * \param name The name of the sub-directory for this particle type (i.e. "Tracer")
-     */
-    void Checkpoint (const std::string& dir, const std::string& name) const;
-
-    /**
-     * \brief Writes a particle checkpoint to file, suitable for restarting.
-     *        This version allows the particle component names to be passed in.
+     * \param real_comp_names vector of real component names, optional
+     * \param int_comp_names vector of int component names, optional
      */
     void Checkpoint (const std::string& dir, const std::string& name,
                      const Vector<std::string>& real_comp_names = Vector<std::string>(),

--- a/Src/Particle/AMReX_Particles.H
+++ b/Src/Particle/AMReX_Particles.H
@@ -698,6 +698,19 @@ public:
 
     /**
      * \brief Writes a particle checkpoint to file, suitable for restarting.
+     *        This version allows the particle component names to be passed in.
+     */
+    void Checkpoint (const std::string& dir, const std::string& name,
+                     const Vector<std::string>& real_comp_names = Vector<std::string>(),
+                     const Vector<std::string>& int_comp_names = Vector<std::string>()) const
+    {
+        Checkpoint(dir, name, true, real_comp_names, int_comp_names);
+    }
+
+    /**
+     * \brief Writes a particle checkpoint to file, suitable for restarting.
+     *        This version allows the particle component names to be passed in.
+     *        This overload exists for backwards comptability. The is_checkpoint parameter is ignored.
      */
     void Checkpoint (const std::string& dir, const std::string& name, bool is_checkpoint,
                      const Vector<std::string>& real_comp_names = Vector<std::string>(),


### PR DESCRIPTION
The version of "Checkpoint" that takes a boolean "is_checkpoint" argument is needed for backwards compatibility (don't ask). This PR adds another overload so that users don't need to pass that in when calling the version that writes the component names.

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
