### PR TITLE
CMake CUDA Debug: -G by Default

### DIFF
--- a/Docs/sphinx_documentation/source/GPU.rst
+++ b/Docs/sphinx_documentation/source/GPU.rst
@@ -215,7 +215,7 @@ check the :ref:`table <tab:cmakecudavar>` below.
    +------------------------------+-------------------------------------------------+-------------+-----------------+
    | AMReX_CUDA_COMPILATION_TIMER |  CSV table with time for each compilation phase | NO          | YES, NO         |
    +------------------------------+-------------------------------------------------+-------------+-----------------+
-   | AMReX_CUDA_DEBUG             |  Device debug information (optimizations: off)  | NO          | YES, NO         |
+   | AMReX_CUDA_DEBUG             |  Device debug information (optimizations: off)  | YES: Debug  | YES, NO         |
    +------------------------------+-------------------------------------------------+-------------+-----------------+
    | AMReX_CUDA_ERROR_CAPTURE_THIS|  Error if a CUDA lambda captures a class' this  | NO          | YES, NO         |
    +------------------------------+-------------------------------------------------+-------------+-----------------+

--- a/Tools/CMake/AMReXCUDAOptions.cmake
+++ b/Tools/CMake/AMReXCUDAOptions.cmake
@@ -70,12 +70,21 @@ cuda_print_option(AMReX_CUDA_PTX_VERBOSE)
 option(AMReX_CUDA_COMPILATION_TIMER "Generate CSV table with time for each compilation phase" OFF)
 cuda_print_option(AMReX_CUDA_COMPILATION_TIMER)
 
-# not a good default-candidate for CMAKE_BUILD_TYPE "Debug": often does not
-# compile at all, is very sensitive to further set options, or compiles super slowly;
-# im some cases, such as recursive function usage, apps need to increase
+# Default on for CMAKE_BUILD_TYPE "Debug":
+# In the past, this often did not compile at all, was very sensitive to further set options, or
+# compiled super slowly;
+# in some cases, such as recursive function usage, apps need to increase
 # `cudaLimitStackSize` in order to not stack overflow with device debug symbols
 # (this costs some extra DRAM).
-option(AMReX_CUDA_DEBUG "Generate debug information for device code (optimizations: off)" OFF)
+# Nonetheless, for CUDA approx. 11.0+, we see the opposite: we have very slow Debug builds with CUDA if
+# we do not activate -G for some LinearSolvers/MLMG objects. Thus, we default-on now to -G in
+# Debug builds.
+if ( "${CMAKE_BUILD_TYPE}" MATCHES "Debug" )
+    set(AMReX_CUDA_DEBUG_DEFAULT ON)
+else ()
+    set(AMReX_CUDA_DEBUG_DEFAULT OFF)
+endif ()
+option(AMReX_CUDA_DEBUG "Generate debug information for device code (optimizations: off)" ${AMReX_CUDA_DEBUG_DEFAULT})
 cuda_print_option(AMReX_CUDA_DEBUG)
 
 # both are performance-neutral debug symbols

--- a/Tools/CMake/AMReXParallelBackends.cmake
+++ b/Tools/CMake/AMReXParallelBackends.cmake
@@ -144,7 +144,7 @@ if (  AMReX_GPU_BACKEND STREQUAL "CUDA"
       if (CMAKE_SYSTEM_NAME STREQUAL "Windows")
          list(APPEND _cuda_flags "SHELL:-Xcompiler /Zi") # comes with Debug & RelWithDebInfo
       else ()
-         list(APPEND _cuda_flags "SHELL:Xcompiler -rdynamic")
+         list(APPEND _cuda_flags "SHELL:-Xcompiler -rdynamic")
       endif ()
    endif ()
 


### PR DESCRIPTION
## Summary

In the past, this often did not compile at all, was very sensitive to further set options, or compiled super slowly; in some cases, such as recursive function usage, apps need to increase `cudaLimitStackSize` in order to not stack overflow with device debug symbols (this costs some extra DRAM).

Nonetheless, for CUDA approx. 11.0+, we see the opposite: we have very slow Debug builds with CUDA if we do not activate -G for some `LinearSolvers/MLMG` objects: `AMReX_MLNodeLaplacian.cpp` & `AMReX_MLNodeLaplacian_sten.cpp`. Thus, we default-on now to -G in Debug builds.

- [x] testing: now some other TUs compile a bit longer (1-2min), but that's better than the other two 5min TUs above without `-G` in Debug

## Additional background

Thanks to @WeiqunZhang and @maxpkatz to looking into this with me.

**Note:** This means the new CMake `Debug` mode will disable GPU optimizations!
That's already the default in GNUmake, so we sync up.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
