### PR TITLE
Remove hardcoded CUDA version for NVHPC

### DIFF
--- a/Tools/GNUMake/comps/nvhpc.mak
+++ b/Tools/GNUMake/comps/nvhpc.mak
@@ -46,16 +46,7 @@ endif
 ifeq ($(USE_ACC),TRUE)
   GENERIC_NVHPC_FLAGS += -acc=gpu -Minfo=accel -mcmodel=medium
   ifneq ($(CUDA_ARCH),)
-    # We use 10.1 because nvcc defaults to 10.1 if it can't detect a GPU
-    # driver. And in Cori GPU interactive jobs, nvcc can't see the GPU driver
-    # unless it is executed within an `srun`. Most people do not execute `srun
-    # make`, so nvcc defaults to 10.1. But HPC SDK defaults to CUDA 11, so we
-    # get link errors between nvcc and the HPC SDK if we don't do something
-    # about this. The easiest fix is to simply force HPC SDK to use CUDA 10.1
-    # to match the blind nvcc.
-    GENERIC_NVHPC_FLAGS += -acc=gpu -gpu=cc$(CUDA_ARCH),cuda10.1
-  else
-    GENERIC_NVHPC_FLAGS += -acc=gpu
+    GENERIC_NVHPC_FLAGS += -gpu=cc$(CUDA_ARCH)
   endif
 endif
 
@@ -179,8 +170,8 @@ endif
 
 ifeq ($(USE_CUDA),TRUE)
 
-  F90FLAGS += -gpu=cc$(CUDA_ARCH),fastmath,cuda10.1
-  FFLAGS   += -gpu=cc$(CUDA_ARCH),fastmath,cuda10.1
+  F90FLAGS += -gpu=cc$(CUDA_ARCH),fastmath
+  FFLAGS   += -gpu=cc$(CUDA_ARCH),fastmath
 
   ifneq ($(DEBUG),TRUE)
     F90FLAGS += -Mcuda=lineinfo


### PR DESCRIPTION
## Summary

This change removes the hardcoded CUDA 10.1 version when using NVHPC and CUDA/OpenACC. This should no longer be needed because the CUDA autodetection logic in NVHPC has improved substantially in recent versions, and also regarding the Cori GPU specific comments, that system has changed so that interactive jobs can directly see the GPU without needing srun.

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
