### PR TITLE
fix AmrMeshParticle cmake issue

### DIFF
--- a/Src/Extern/SENSEI/CMakeLists.txt
+++ b/Src/Extern/SENSEI/CMakeLists.txt
@@ -32,22 +32,22 @@ if( AMReX_AMRLEVEL )
 endif()
 
 #
-# Pareticle  based adaptors and bridges
+# Particle based adaptors and bridges
 #
 if ( AMReX_PARTICLES )
    list ( APPEND amrex_sensei_sources
       AMReX_ParticleDataAdaptor.H
       AMReX_ParticleDataAdaptorI.H
-      AMReX_ParticleInSituBridge.H )
+      AMReX_ParticleInSituBridge.H
+      AMReX_AmrMeshParticleDataAdaptor.H
+      AMReX_AmrMeshParticleDataAdaptorI.H
+      AMReX_AmrMeshParticleInSituBridge.H )
 
    if( AMReX_AMRLEVEL )
       list ( APPEND amrex_sensei_sources
          AMReX_AmrParticleDataAdaptor.H
          AMReX_AmrParticleDataAdaptorI.H
-         AMReX_AmrParticleInSituBridge.H
-         AMReX_AmrMeshParticleDataAdaptor.H
-         AMReX_AmrMeshParticleDataAdaptorI.H
-         AMReX_AmrMeshParticleInSituBridge.H )
+         AMReX_AmrParticleInSituBridge.H )
    endif()
 endif ()
 


### PR DESCRIPTION
## Summary
The `AMReX_AmrMeshParticle*` files do not have a dependency on the Amr class, and should thus not be locked behind the `AMReX_AMRLEVEL` cmake flag. 
## Additional background

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
