### PR TITLE
nvc++ w/ OMP: work-around atomic capture

### DIFF
--- a/Src/Base/AMReX_FabArrayUtility.H
+++ b/Src/Base/AMReX_FabArrayUtility.H
@@ -1540,7 +1540,7 @@ indexFromValue (FabArray<FAB> const& mf, int comp, IntVect const& nghost,
                 bool old;
 // we should be able to test on _OPENMP < 201107 for capture (version 3.1)
 // but we must work around a bug in gcc < 4.9
-// And, with NVHPC 21.9, we see an ICE with the atomic capture.
+// And, with NVHPC 21.9, we see an ICE with the atomic capture (NV bug: #3390723)
 #if defined(AMREX_USE_OMP) && defined(_OPENMP) && (_OPENMP < 201307 || defined(__NVCOMPILER)) // OpenMP 4.0
 #pragma omp critical (amrex_indexfromvalueaa)
 #elif defined(AMREX_USE_OMP)

--- a/Src/Base/AMReX_FabArrayUtility.H
+++ b/Src/Base/AMReX_FabArrayUtility.H
@@ -1542,7 +1542,7 @@ indexFromValue (FabArray<FAB> const& mf, int comp, IntVect const& nghost,
 // but we must work around a bug in gcc < 4.9
 // And, with NVHPC 21.9, we see an ICE with the atomic capture (NV bug: #3390723)
 #if defined(AMREX_USE_OMP) && defined(_OPENMP) && (_OPENMP < 201307 || defined(__NVCOMPILER)) // OpenMP 4.0
-#pragma omp critical (amrex_indexfromvalueaa)
+#pragma omp critical (amrex_indexfromvalue)
 #elif defined(AMREX_USE_OMP)
 #pragma omp atomic capture
 #endif

--- a/Src/Base/AMReX_FabArrayUtility.H
+++ b/Src/Base/AMReX_FabArrayUtility.H
@@ -1540,8 +1540,9 @@ indexFromValue (FabArray<FAB> const& mf, int comp, IntVect const& nghost,
                 bool old;
 // we should be able to test on _OPENMP < 201107 for capture (version 3.1)
 // but we must work around a bug in gcc < 4.9
-#if defined(AMREX_USE_OMP) && defined(_OPENMP) && _OPENMP < 201307 // OpenMP 4.0
-#pragma omp critical (amrex_indexfromvalue)
+// And, with NVHPC 21.9, we see an ICE with the atomic capture.
+#if defined(AMREX_USE_OMP) && defined(_OPENMP) && (_OPENMP < 201307 || defined(__NVCOMPILER)) // OpenMP 4.0
+#pragma omp critical (amrex_indexfromvalueaa)
 #elif defined(AMREX_USE_OMP)
 #pragma omp atomic capture
 #endif


### PR DESCRIPTION
## Summary

Internal compiler error in this region with NVHPC 21.9 when compiling for OpenMP (host-only).

## Additional background

Nvidia bug report: 3390723.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
