### PR TITLE
Fix read unitialized memory issue in MLMG solver

### DIFF
--- a/Src/LinearSolvers/MLMG/AMReX_MLEBNodeFDLaplacian.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBNodeFDLaplacian.H
@@ -109,6 +109,7 @@ MLEBNodeFDLaplacian::setEBDirichlet (F&& f)
             auto const cellsize = geom.CellSizeArray();
             m_phi_eb[amrlev].define(amrex::convert(m_grids[amrlev][0],IntVect(1)),
                                     m_dmap[amrlev][0], 1, 1);
+            m_phi_eb[amrlev].setVal(0.0);
             auto const& flags = factory->getMultiEBCellFlagFab();
             auto const& levset = factory->getLevelSet();
 #ifdef AMREX_USE_OMP


### PR DESCRIPTION
## Summary
Running valgrind on one of our failing circleCi tests revealed that the MLMG solver read allocated but uninitialized memory. Setting `m_phi_eb` to 0 after it is allocated fixes this issue. Attached is the valgrind logs, Line 17275 shows where valgrind detected reading of uninitialized memory.

[vgout.txt](https://github.com/AMReX-Codes/amrex/files/7269235/vgout.txt)

## Additional background
This was found due to one of our warpx circleCI test failing after a fetch and merge with development. This fix did not solve that issue though.

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
