### PR TITLE
Reset GPU RNG Seed

### DIFF
--- a/Docs/sphinx_documentation/source/GPU.rst
+++ b/Docs/sphinx_documentation/source/GPU.rst
@@ -939,7 +939,7 @@ compact and readable format.
 
 AMReX also provides a variation of the launch function that is implemented as a
 C++ macro.  It behaves identically to the function, but hides the lambda function
-from to the user.  There are some subtle differences between the two implementations,
+from the user.  There are some subtle differences between the two implementations,
 that will be discussed.  It is up to the user to select which version they would like
 to use.  For simplicity, the function variation will be discussed throughout the rest of
 this documentation, however all code snippets will also include the macro variation
@@ -1712,4 +1712,3 @@ Intel GPU Specific Tests
 - To report back-end information, set ``ZE_DEBUG=1`` in your environment variables.
 
 .. _`Intel Distribution for GDB`: https://software.intel.com/content/www/us/en/develop/tools/oneapi/components/distribution-for-gdb.html
-

--- a/Src/Base/AMReX_Random.H
+++ b/Src/Base/AMReX_Random.H
@@ -144,6 +144,12 @@ namespace amrex
     */
     ULong Random_long (ULong n); // [0,n-1]
 
+    namespace detail {
+        inline ULong DefaultGpuSeed () {
+            return ParallelDescriptor::MyProc()*1234567ULL + 12345ULL;
+        }
+    }
+
     /** \brief Set the seed of the random number generator.
     *
     *  There is also an entry point for Fortran callable as:
@@ -156,9 +162,10 @@ namespace amrex
     *  INTEGER seed
     *  call blinitrand(seed)
     */
-    void InitRandom (ULong seed, int nprocs=ParallelDescriptor::NProcs());
+    void InitRandom (ULong cpu_seed, int nprocs=ParallelDescriptor::NProcs(),
+                     ULong gpu_seed = detail::DefaultGpuSeed());
 
-    void ResetRandomSeed (ULong seed);
+    void ResetRandomSeed (ULong cpu_seed, ULong gpu_seed = detail::DefaultGpuSeed());
 
     /**
     * \brief Save and restore random state.


### PR DESCRIPTION
Add an optional parameter to amrex::ResetRandomSeed to allow the users to
reset the GPU RNG seed.

Slip in a typo fix.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
