### PR TITLE
Fix bug in the particle communication routines when the number of chars in the message is > MAXINT.

### DIFF
--- a/Src/Particle/AMReX_ParticleCommunication.H
+++ b/Src/Particle/AMReX_ParticleCommunication.H
@@ -485,15 +485,14 @@ void communicateParticlesStart (const PC& pc, ParticleCopyPlan& plan, const Buff
     {
         if (i == MyProc) continue;
         const auto Who  = i;
-        Long nbytes     = plan.m_snd_num_particles[i]*psize;
         const auto Cnt  = plan.m_snd_counts[i];
         if (Cnt == 0) continue;
 
         auto snd_offset = plan.m_snd_offsets[i];
-        AMREX_ASSERT(plan.m_snd_counts[i] % ParallelDescriptor::alignof_comm_data(nbytes) == 0);
+        AMREX_ASSERT(plan.m_snd_counts[i] % ParallelDescriptor::alignof_comm_data(plan.m_snd_num_particles[i]*psize) == 0);
         AMREX_ASSERT(Who >= 0 && Who < NProcs);
         AMREX_ASSERT(Cnt < std::numeric_limits<int>::max());
-        AMREX_ASSERT(snd_offset % ParallelDescriptor::alignof_comm_data(nbytes) == 0);
+        AMREX_ASSERT(snd_offset % ParallelDescriptor::alignof_comm_data(plan.m_snd_num_particles[i]*psize) == 0);
 
         ParallelDescriptor::Send((char const*)(snd_buffer.dataPtr()+snd_offset), Cnt, Who, SeqNum,
                                  ParallelContext::CommunicatorSub());

--- a/Src/Particle/AMReX_ParticleCommunication.H
+++ b/Src/Particle/AMReX_ParticleCommunication.H
@@ -467,7 +467,7 @@ void communicateParticlesStart (const PC& pc, ParticleCopyPlan& plan, const Buff
         const auto offset = rOffset[i];
         Long nbytes       = plan.m_rcv_num_particles[Who]*psize;
         std::size_t acd   = ParallelDescriptor::alignof_comm_data(nbytes);
-        const auto Cnt    = amrex::aligned_size(acd, nbytes) / acd;
+        const auto Cnt    = amrex::aligned_size(acd, nbytes);
 
         AMREX_ASSERT(Cnt > 0);
         AMREX_ASSERT(Cnt < std::numeric_limits<int>::max());
@@ -486,15 +486,14 @@ void communicateParticlesStart (const PC& pc, ParticleCopyPlan& plan, const Buff
         if (i == MyProc) continue;
         const auto Who  = i;
         Long nbytes     = plan.m_snd_num_particles[i]*psize;
-        std::size_t acd = ParallelDescriptor::alignof_comm_data(nbytes);
-        const auto Cnt  = plan.m_snd_counts[i] / acd;
+        const auto Cnt  = plan.m_snd_counts[i];
         if (Cnt == 0) continue;
 
         auto snd_offset = plan.m_snd_offsets[i];
-        AMREX_ASSERT(plan.m_snd_counts[i] % acd == 0);
+        AMREX_ASSERT(plan.m_snd_counts[i] % ParallelDescriptor::alignof_comm_data(nbytes) == 0);
         AMREX_ASSERT(Who >= 0 && Who < NProcs);
         AMREX_ASSERT(Cnt < std::numeric_limits<int>::max());
-        AMREX_ASSERT(snd_offset % acd == 0);
+        AMREX_ASSERT(snd_offset % ParallelDescriptor::alignof_comm_data(nbytes) == 0);
 
         ParallelDescriptor::Send((char const*)(snd_buffer.dataPtr()+snd_offset), Cnt, Who, SeqNum,
                                  ParallelContext::CommunicatorSub());


### PR DESCRIPTION
I believe this bug was introduced in PR#1569.

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
