### PR TITLE
NVHPC: OpenMP Atomic Capture Fixed

### DIFF
--- a/Src/Base/AMReX_FabArrayUtility.H
+++ b/Src/Base/AMReX_FabArrayUtility.H
@@ -1493,8 +1493,8 @@ indexFromValue (FabArray<FAB> const& mf, int comp, IntVect const& nghost,
                 bool old;
 // we should be able to test on _OPENMP < 201107 for capture (version 3.1)
 // but we must work around a bug in gcc < 4.9
-// And, with NVHPC 21.9, we see an ICE with the atomic capture (NV bug: #3390723)
-#if defined(AMREX_USE_OMP) && defined(_OPENMP) && (_OPENMP < 201307 || defined(__NVCOMPILER)) // OpenMP 4.0
+// And, with NVHPC 21.9 to <23.1, we saw an ICE with the atomic capture (NV bug: #3390723)
+#if defined(AMREX_USE_OMP) && defined(_OPENMP) && (_OPENMP < 201307 || (defined(__NVCOMPILER) && __NVCOMPILER_MAJOR__ < 23)) // OpenMP 4.0
 #pragma omp critical (amrex_indexfromvalue)
 #elif defined(AMREX_USE_OMP)
 #pragma omp atomic capture


### PR DESCRIPTION
## Summary

Demonstrate `nvc++` OpenMP 4.0 issue.

CI Log: [nvhpc_omp.txt](https://github.com/AMReX-Codes/amrex/files/7279020/nvhpc_omp.txt)

Then, apply work-around only for affected NVHPC versions: <23.1

## Additional background

Work-arounded in #2365

Nvidia bug report: 3390723 (fixed in NVHPC 23.1).

- [x] try again with the NVHPC release after 21.9 in December: https://developer.nvidia.com/hpc-sdk :x:
- [x] or with 21.11 #2687 :x:
- [x] or with 23.01 #3122 :heavy_check_mark: 

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
