### PR TITLE
CI: Groups Include Branch

### DIFF
--- a/.github/workflows/clang.yml
+++ b/.github/workflows/clang.yml
@@ -5,7 +5,7 @@ name: Linux Clang
 on: [push, pull_request]
 
 concurrency:
-  group: ${{ github.head_ref }}-linux-clang
+  group: ${{ github.ref }}-${{ github.head_ref }}-linux-clang
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -3,7 +3,7 @@ name: cuda
 on: [push, pull_request]
 
 concurrency:
-  group: ${{ github.head_ref }}-cuda
+  group: ${{ github.ref }}-${{ github.head_ref }}-cuda
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,7 +3,7 @@ name: Build and Deploy
 on: [push, pull_request]
 
 concurrency:
-  group: ${{ github.head_ref }}-docs
+  group: ${{ github.ref }}-${{ github.head_ref }}-docs
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/gcc.yml
+++ b/.github/workflows/gcc.yml
@@ -6,7 +6,7 @@ name: Linux GCC
 on: [push, pull_request]
 
 concurrency:
-  group: ${{ github.head_ref }}-linux-gcc
+  group: ${{ github.ref }}-${{ github.head_ref }}-linux-gcc
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/hip.yml
+++ b/.github/workflows/hip.yml
@@ -3,7 +3,7 @@ name: hip
 on: [push, pull_request]
 
 concurrency:
-  group: ${{ github.head_ref }}-hip
+  group: ${{ github.ref }}-${{ github.head_ref }}-hip
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -3,7 +3,7 @@ name: intel
 on: [push, pull_request]
 
 concurrency:
-  group: ${{ github.head_ref }}-intel
+  group: ${{ github.ref }}-${{ github.head_ref }}-intel
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -3,7 +3,7 @@ name: macos
 on: [push, pull_request]
 
 concurrency:
-  group: ${{ github.head_ref }}-macos
+  group: ${{ github.ref }}-${{ github.head_ref }}-macos
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/sensei.yml
+++ b/.github/workflows/sensei.yml
@@ -5,7 +5,7 @@ name: SENSEI
 on: [push, pull_request]
 
 concurrency:
-  group: ${{ github.head_ref }}-sensei
+  group: ${{ github.ref }}-${{ github.head_ref }}-sensei
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -3,7 +3,7 @@ name: Style
 on: [push, pull_request]
 
 concurrency:
-  group: ${{ github.head_ref }}-style
+  group: ${{ github.ref }}-${{ github.head_ref }}-style
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -3,7 +3,7 @@ name: windows
 on: [push, pull_request]
 
 concurrency:
-  group: ${{ github.head_ref }}-windows
+  group: ${{ github.ref }}-${{ github.head_ref }}-windows
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Summary

On pushes to mainline, if mainline (or a fork with enabled CI) contains multiple branches, these branches cancelled each other. This should fix this.

## Additional background

`github.head_ref` is only defined in PRs.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
