### PR TITLE
Add inputs for redistribute test that uses a message type other than char.

### DIFF
--- a/Tests/Particles/Redistribute/inputs.rt.cuda.big
+++ b/Tests/Particles/Redistribute/inputs.rt.cuda.big
@@ -1,0 +1,12 @@
+redistribute.size = (64, 64, 128)
+redistribute.max_grid_size = 64
+redistribute.is_periodic = 1
+redistribute.num_ppc = 4
+redistribute.move_dir = (1, 1, 1)
+redistribute.do_random = 1
+redistribute.nsteps = 0
+redistribute.nlevs = 1
+redistribute.do_regrid = 1
+
+redistribute.num_runtime_real = 2
+redistribute.num_runtime_int = 3


### PR DESCRIPTION
PR #2376 fixed a bug in the particle communication routines that was only exposed if a message size was larger than `2**31-1` bytes. This was not caught by any test, so this PR adds an inputs file that triggers this situation, which I will add to the nightly test suite.  

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
