### PR TITLE
Workaround for nvcc bug that (sometimes) incorrectly complains about unused TinyProfiler variables.

### DIFF
--- a/Src/Base/AMReX_BLProfiler.H
+++ b/Src/Base/AMReX_BLProfiler.H
@@ -477,7 +477,10 @@ inline std::string BLProfiler::CommStats::CFTToString(CommFuncType cft) {
 #define BL_TINY_PROFILE_INITIALIZE()   amrex::TinyProfiler::Initialize()
 #define BL_TINY_PROFILE_FINALIZE()     amrex::TinyProfiler::Finalize()
 
-#define BL_PROFILE(fname)         amrex::TinyProfiler BL_PROFILE_PASTE(tiny_profiler_,__COUNTER__)((fname))
+#define BL_PROFILE(fname) BL_PROFILE_IMPL(fname, __COUNTER__)
+#define BL_PROFILE_IMPL(funame, counter)  amrex::TinyProfiler BL_PROFILE_PASTE(tiny_profiler_, counter)((funame)); \
+    amrex::ignore_unused(BL_PROFILE_PASTE(tiny_profiler_, counter));
+
 #define BL_PROFILE_T(a, T)
 #define BL_PROFILE_S(fname)
 #define BL_PROFILE_T_S(fname, T)

--- a/Src/Base/AMReX_BLProfiler.H
+++ b/Src/Base/AMReX_BLProfiler.H
@@ -7,6 +7,7 @@
 
 #ifdef BL_PROFILING
 
+#include <AMReX.H>
 #include <AMReX_REAL.H>
 #include <AMReX_Array.H>
 #include <AMReX_Vector.H>

--- a/Src/Base/AMReX_BLProfiler.H
+++ b/Src/Base/AMReX_BLProfiler.H
@@ -7,7 +7,6 @@
 
 #ifdef BL_PROFILING
 
-#include <AMReX.H>
 #include <AMReX_REAL.H>
 #include <AMReX_Array.H>
 #include <AMReX_Vector.H>
@@ -469,6 +468,7 @@ inline std::string BLProfiler::CommStats::CFTToString(CommFuncType cft) {
 // --------------------------------------------
 #elif defined(AMREX_TINY_PROFILING)
 
+#include <AMReX.H>
 #include <AMReX_TinyProfiler.H>
 
 #define BL_PROFILE_INITIALIZE()


### PR DESCRIPTION
This gets rids of warnings like:

```
../../..//Src/Base/AMReX_Machine.cpp(225): warning #177-D: variable "tiny_profiler_0" was declared but never referenced
../../..//Src/Base/AMReX_Machine.cpp(482): warning #177-D: variable "tiny_profiler_1" was declared but never referenced
```

These variables are not really unused because work is done in the constructor and destructor. 

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
