### PR TITLE
MLEBNodeFDLaplacian Coarsening

### DIFF
--- a/Src/LinearSolvers/MLMG/AMReX_MLEBNodeFDLap_2D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBNodeFDLap_2D_K.H
@@ -177,6 +177,20 @@ void mlebndfdlap_gsrb(int i, int j, int k, Array4<Real> const& x,
     }
 }
 
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE
+int mlebndfdlap_check_coarsening (int i, int j, int, Array4<int const> const& mask) noexcept
+{
+    if ((i%2 == 0) || (j%2 == 0)) {
+        return 0;
+    } else {
+        return !mask(i,j,0)
+            && mask(i-1,j-1,0)
+            && mask(i+1,j-1,0)
+            && mask(i-1,j+1,0)
+            && mask(i+1,j+1,0);
+    }
+}
+
 }
 
 #endif

--- a/Src/LinearSolvers/MLMG/AMReX_MLEBNodeFDLap_3D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBNodeFDLap_3D_K.H
@@ -226,6 +226,24 @@ void mlebndfdlap_gsrb (int i, int j, int k, Array4<Real> const& x,
     }
 }
 
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE
+int mlebndfdlap_check_coarsening (int i, int j, int k, Array4<int const> const& mask) noexcept
+{
+    if ((i%2 == 0) || (j%2 == 0) || (k%2 == 0)) {
+        return 0;
+    } else {
+        return !mask(i,j,k)
+            && mask(i-1,j-1,k-1)
+            && mask(i+1,j-1,k-1)
+            && mask(i-1,j+1,k-1)
+            && mask(i+1,j+1,k-1)
+            && mask(i-1,j-1,k+1)
+            && mask(i+1,j-1,k+1)
+            && mask(i-1,j+1,k+1)
+            && mask(i+1,j+1,k+1);
+    }
+}
+
 }
 
 #endif

--- a/Src/LinearSolvers/MLMG/AMReX_MLLinOp.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLLinOp.H
@@ -402,6 +402,8 @@ protected:
         return std::make_unique<FArrayBoxFactory>();
     }
 
+    virtual void resizeMultiGrid (int new_size);
+
     bool hasHiddenDimension () const noexcept { return info.hasHiddenDimension(); }
     int hiddenDirection () const noexcept { return info.hidden_direction; }
     Box compactify (Box const& b) const noexcept;

--- a/Src/LinearSolvers/MLMG/AMReX_MLLinOp.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLLinOp.cpp
@@ -999,6 +999,23 @@ MLLinOp::compactify (Box const& b) const noexcept
     }
 }
 
+void
+MLLinOp::resizeMultiGrid (int new_size)
+{
+    if (new_size <= 0 || new_size >= m_num_mg_levels[0]) { return; }
+
+    m_num_mg_levels[0] = new_size;
+
+    m_geom[0].resize(new_size);
+    m_grids[0].resize(new_size);
+    m_dmap[0].resize(new_size);
+    m_factory[0].resize(new_size);
+
+    if (m_bottom_comm != m_default_comm) {
+        m_bottom_comm = makeSubCommunicator(m_dmap[0].back());
+    }
+}
+
 #ifdef AMREX_USE_PETSC
 std::unique_ptr<PETScABecLap>
 MLLinOp::makePETSc () const

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLinOp.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLinOp.H
@@ -125,6 +125,8 @@ public:
 
 protected:
 
+    virtual void resizeMultiGrid (int new_size) override;
+
     Vector<Vector<std::unique_ptr<iMultiFab> > > m_owner_mask;      // ownership of nodes
     Vector<Vector<std::unique_ptr<iMultiFab> > > m_dirichlet_mask;  // dirichlet?
     Vector<std::unique_ptr<iMultiFab> > m_cc_fine_mask;          // cell-centered mask for cells covered by fine


### PR DESCRIPTION
Limit the maximum coarsening level so that EB objects do not disappear due
to coarsening.  The solver would fail to converge if the coarsening causes
EB objects to disappear entirely.

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
