### PR TITLE
Command line parsing updates.

### DIFF
--- a/Src/Base/AMReX.cpp
+++ b/Src/Base/AMReX.cpp
@@ -385,19 +385,35 @@ amrex::Initialize (int& argc, char**& argv, bool build_parm_parse,
         }
         else if (argc > 1)
         {
-            int ppargc = 1;
-            for (; ppargc < argc; ++ppargc) {
-                if (strcmp(argv[ppargc], "--") == 0) break;
-            }
-            if (ppargc > 1)
+            if (argv[1][0] == '-')
             {
-                if (strchr(argv[1],'='))
-                {
-                    ParmParse::Initialize(ppargc-1,argv+1,0);
+                // If arguments list starts with "-", do not use ParmParse.
+                // Application code can then parse the command line. This will
+                // prevent "-h" or "--help" from creating errors in ParmParse,
+                // but only if it's the first argument after the executable.
+                ParmParse::Initialize(0,0,0);
+            }
+            else
+            {
+                // This counts command line arguments before a "--"
+                // and only sends the preceeding arguments to ParmParse;
+                // the rest get ingored.
+                int ppargc = 1;
+                for (; ppargc < argc; ++ppargc) {
+                    if (strcmp(argv[ppargc], "--") == 0) break;
                 }
-                else
+                if (ppargc > 1)
                 {
-                    ParmParse::Initialize(ppargc-2,argv+2,argv[1]);
+                    if (strchr(argv[1],'=') || (argc > 2 ? argv[2][0] == '=' : false) )
+                    {
+                        // No inputs file to parse
+                        ParmParse::Initialize(ppargc-1,argv+1,0);
+                    }
+                    else
+                    {
+                        // argv[1] is an inputs file
+                        ParmParse::Initialize(ppargc-2,argv+2,argv[1]);
+                    }
                 }
             }
         }


### PR DESCRIPTION
Fix command line parsing inconsistency: allow argv[1] to be of the
form "arg1 = my_arg", i.e. with spaces, since later arguments allow
this.
Also, if argv[1] starts with '-', do not use ParmParse. This will
prevent "-h" or "--help" from creating errors within ParmParse.
Application code can then parse the command line to handle these
cases, if desired.

## Summary

## Additional background

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
