### PR TITLE
Avoid free after amrex::Finalize

### DIFF
--- a/Src/Base/AMReX_Arena.cpp
+++ b/Src/Base/AMReX_Arena.cpp
@@ -211,6 +211,22 @@ Arena::deallocate_system (void* p, std::size_t nbytes)
 #endif
 }
 
+namespace {
+
+    class NullArena final
+        : public Arena
+    {
+        virtual void* alloc (std::size_t) { return nullptr; }
+        virtual void free (void*) {}
+    };
+
+    Arena* The_Null_Arena ()
+    {
+        static NullArena the_null_arena;
+        return &the_null_arena;
+    }
+}
+
 void
 Arena::Initialize ()
 {
@@ -327,6 +343,10 @@ Arena::Initialize ()
     }
 
     the_cpu_arena = new BArena;
+
+    // Initialize the null arena
+    auto null_arena = The_Null_Arena();
+    amrex::ignore_unused(null_arena);
 }
 
 void
@@ -424,43 +444,61 @@ Arena::Finalize ()
 Arena*
 The_Arena ()
 {
-    BL_ASSERT(the_arena != nullptr);
-    return the_arena;
+    if        (the_arena) {
+        return the_arena;
+    } else {
+        return The_Null_Arena();
+    }
 }
 
 Arena*
 The_Async_Arena ()
 {
-    BL_ASSERT(the_async_arena != nullptr);
-    return the_async_arena;
+    if        (the_async_arena) {
+        return the_async_arena;
+    } else {
+        return The_Null_Arena();
+    }
 }
 
 Arena*
 The_Device_Arena ()
 {
-    BL_ASSERT(the_device_arena != nullptr);
-    return the_device_arena;
+    if        (the_device_arena) {
+        return the_device_arena;
+    } else {
+        return The_Null_Arena();
+    }
 }
 
 Arena*
 The_Managed_Arena ()
 {
-    BL_ASSERT(the_managed_arena != nullptr);
-    return the_managed_arena;
+    if        (the_managed_arena) {
+        return the_managed_arena;
+    } else {
+        return The_Null_Arena();
+    }
 }
 
 Arena*
 The_Pinned_Arena ()
 {
-    BL_ASSERT(the_pinned_arena != nullptr);
-    return the_pinned_arena;
+    if        (the_pinned_arena) {
+        return the_pinned_arena;
+    } else {
+        return The_Null_Arena();
+    }
 }
 
 Arena*
 The_Cpu_Arena ()
 {
-    BL_ASSERT(the_cpu_arena != nullptr);
-    return the_cpu_arena;
+    if        (the_cpu_arena) {
+        return the_cpu_arena;
+    } else {
+        return The_Null_Arena();
+    }
 }
 
 }


### PR DESCRIPTION
Previously calling Arena::free after amrex::Finalize resulted in segfault
because the Arena objects have been deleted.  It will cause the following
code to crash in the end.

    int main (int argc, char* argv[])
    {
        amrex::Initialize(argc, argv);
        amrex::MultiFab(...);
        amrex::Finalize();
    }

One way to fix it is to add a scope to the function body between Initialize
and Finalize so that the object inside will go out of scope before
amrex::Finalize is called.  In this commit, we implement a way of avoiding
this kind of errors even if one forgets to free everything allocated by
Arenas before Finalize.

## Summary

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
