### PR TITLE
Default of the Arena's Release Threshold

### DIFF
--- a/Docs/sphinx_documentation/source/GPU.rst
+++ b/Docs/sphinx_documentation/source/GPU.rst
@@ -461,15 +461,17 @@ specific type of GPU memory:
 
 .. table:: Memory Arenas
 
-    +---------------------+----------------------------+
-    | Arena               |        Memory Type         |
-    +=====================+============================+
-    | The_Arena()         |  managed or device memory  |
-    +---------------------+----------------------------+
-    | The_Managed_Arena() |  managed memory            |
-    +---------------------+----------------------------+
-    | The_Pinned_Arena()  |  pinned memory             |
-    +---------------------+----------------------------+
+    +---------------------+---------------------------------------------------+
+    | Arena               |        Memory Type                                |
+    +=====================+===================================================+
+    | The_Arena()         |  managed or device memory                         |
+    +---------------------+---------------------------------------------------+
+    | The_Device_Arena()  |  device memory, could be an alias to The_Arena()  |
+    +---------------------+---------------------------------------------------+
+    | The_Managed_Arena() |  managed memory, could be an alias to The_Arena() |
+    +---------------------+---------------------------------------------------+
+    | The_Pinned_Arena()  |  pinned memory                                    |
+    +---------------------+---------------------------------------------------+
 
 .. raw:: latex
 
@@ -496,6 +498,31 @@ gradually. The behavior of :cpp:`The_Managed_Arena()` likewise depends on the
 :cpp:`The_Managed_Arena()` is a separate pool of managed memory. If
 ``amrex.the_arena_is_managed=1``, :cpp:`The_Managed_Arena()` is simply aliased
 to :cpp:`The_Arena()` to reduce memory fragmentation.
+
+In :cpp:`amrex::Initialize`, a large amount of GPU device memory is
+allocated and is kept in :cpp:`The_Arena()`.  The default is 3/4 of the
+total device memory, and it can be changed with a :cpp:`ParmParse`
+parameter, ``amrex.the_arena_init_size``, in the unit of bytes.  The default
+initial size for other arenas is 8388608 (i.e., 8 MB).  For
+:cpp:`The_Managed_Arena()` and :cpp:`The_Device_Arena()`, it can be changed
+with ``amrex.the_managed_arena_init_size`` and
+``amrex.the_device_arena_init_size``, respectively, if they are not an alias
+to :cpp:`The_Arena()`.  For :cpp:`The_Pinned_Arena()`, it can be changed
+with ``amrex.the_pinned_arena_init_size``.  The user can also specify a
+release threshold for these arenas.  If the memory usage in an arena is
+below the threshold, the arena will keep the memory for later reuse,
+otherwise it will try to release memory back to the system if it is not
+being used.  By default, the release threshold for :cpp:`The_Arena()` is set
+to be the maximum of initial allocation size and 3/4 of the total device
+memory, and it can be changed with a parameter,
+``amrex.the_arena_release_threshold``.  For :cpp:`The_Pinned_Arena()`, the
+default release threshold is the size of the total device memory, and the
+runtime parameter is ``amrex.the_pinned_arena_release_threshold``.  If it is
+a separate arena, :cpp:`The_Device_Area()` or :cpp:`The_Managed_Arena()`
+does not release memory by default, and this can be changed with
+``amrex.the_device_arena_release_threshold`` or
+``amrex.the_managed_arena_release_threshold``.  Note that the units for all
+the parameter discussed above are bytes.
 
 If you want to print out the current memory usage
 of the Arenas, you can call :cpp:`amrex::Arena::PrintUsage()`.

--- a/Src/Base/AMReX_Arena.cpp
+++ b/Src/Base/AMReX_Arena.cpp
@@ -249,6 +249,7 @@ Arena::Initialize ()
     buddy_allocator_size = Gpu::Device::totalGlobalMem() / 4L * 3L;
 #endif
 
+    the_arena_release_threshold = the_arena_init_size;
     the_pinned_arena_release_threshold = Gpu::Device::totalGlobalMem();
 #endif
 
@@ -259,6 +260,7 @@ Arena::Initialize ()
     pp.query( "the_device_arena_init_size",  the_device_arena_init_size);
     pp.query("the_managed_arena_init_size", the_managed_arena_init_size);
     pp.query( "the_pinned_arena_init_size",  the_pinned_arena_init_size);
+    the_arena_release_threshold = std::max(the_arena_init_size, the_arena_release_threshold);
     pp.query(       "the_arena_release_threshold" ,         the_arena_release_threshold);
     pp.query( "the_device_arena_release_threshold",  the_device_arena_release_threshold);
     pp.query("the_managed_arena_release_threshold", the_managed_arena_release_threshold);

--- a/Src/Base/AMReX_CArena.cpp
+++ b/Src/Base/AMReX_CArena.cpp
@@ -37,7 +37,7 @@ CArena::alloc (std::size_t nbytes)
 
     nbytes = Arena::align(nbytes == 0 ? 1 : nbytes);
 
-    if (static_cast<Long>(m_used+nbytes) >= arena_info.release_threshold) {
+    if (static_cast<Long>(m_used+nbytes) > arena_info.release_threshold) {
         freeUnused_protected();
     }
 


### PR DESCRIPTION
Change the default of the Arena's release threshold from max (i.e., no
release) to the maximum of the initial allocation size and 3/4 of the GPU
memory.  This helps the memory oversubscription issue observed in some WarpX
runs.  Once we have to allocate additional device memory because the initial
allocation, which is 3/4 of the total global memory, has been used up, the
new additions to the Arena are not big enough for efficient reuse, resulting
in fragmentation in the Arena.  Because at that point we are very close to
use up all device memory, it's much more important to make sure we do not
oversubscribe due to memory fragmentation by releasing memory back to the
system than the performance gain we might have in memory allocation beyond
the initialize size.