### PR TITLE
Add Filesystem::DirectorySeparator

### DIFF
--- a/Src/Base/AMReX_FileSystem.H
+++ b/Src/Base/AMReX_FileSystem.H
@@ -13,6 +13,20 @@ typedef unsigned short mode_t;
 namespace amrex {
 namespace FileSystem {
 
+/** The Platform-Specific Directory Separator
+ *
+ * Return a backslash on Windows and a slash on all other platforms.
+ */
+static constexpr char
+DirectorySeparator ()
+{
+#ifdef _WIN32
+    return '\\';
+#else
+    return '/';
+#endif
+}
+
 bool
 CreateDirectories (std::string const& filename, mode_t mode, bool verbose = false);
 

--- a/Src/Base/AMReX_FileSystem.cpp
+++ b/Src/Base/AMReX_FileSystem.cpp
@@ -82,7 +82,7 @@ CreateDirectories (std::string const& path, mode_t mode, bool verbose)
     bool retVal(false);
     Vector<std::pair<std::string, int> > pathError;
 
-    const char* path_sep_str = "/";
+    const char* path_sep_str = DirectorySeparator();
 
     if (path.length() == 0 || path == path_sep_str) {
         return true;

--- a/Src/Base/AMReX_FileSystem.cpp
+++ b/Src/Base/AMReX_FileSystem.cpp
@@ -82,7 +82,7 @@ CreateDirectories (std::string const& path, mode_t mode, bool verbose)
     bool retVal(false);
     Vector<std::pair<std::string, int> > pathError;
 
-    const char* path_sep_str = DirectorySeparator();
+    const char* path_sep_str = "/";
 
     if (path.length() == 0 || path == path_sep_str) {
         return true;


### PR DESCRIPTION
## Summary

Add a public function to that returns the platform specific directory separator. We currently need this in WarpX and defining this in a central place makes sense for re-use.

It looks like plotfile writing works on Windows as of now through std filesystem operations, so no further changes are needed at this point unless we observe otherwise down the road.

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
