### PR TITLE
Docs: MLMG solver convergence criteria

### DIFF
--- a/Docs/sphinx_documentation/source/LinearSolvers.rst
+++ b/Docs/sphinx_documentation/source/LinearSolvers.rst
@@ -114,12 +114,11 @@ error tolerance is hard-coded to be at least :math:`10^{-16}`.
 Given the linear system :math:`Ax=b`, the solver will terminate when the
 max-norm of the residual (:math:`b-Ax`) is less than
 :cpp:`std::max(a_tol_abs, a_tol_rel*max_norm)` where :cpp:`max_norm`
-is the max-norm of the solution (rhs), :math:`b`, if the flag
-:cpp:`always_use_bnorm` is set to True or if the solution max-norm is greater
-than or equal to the max-norm error of the initial guess, otherwise
-:cpp:`max_norm` is equal to the max-norm error of the initial guess. Set the
-absolute tolerance to zero if one does not have a good value for it.  The return
-value of :cpp:`solve` is the max-norm error.
+is the max-norm of the rhs, :math:`b`, if the flag :cpp:`always_use_bnorm` is
+set to True or if the rhs max-norm is greater than or equal to the max-norm error
+of the initial guess, otherwise :cpp:`max_norm` is equal to the max-norm error
+of the initial guess.  Set the absolute tolerance to zero if one does not have a
+good value for it.  The return value of :cpp:`solve` is the max-norm error.
 
 After the solver returns successfully, if needed, we can call
 

--- a/Docs/sphinx_documentation/source/LinearSolvers.rst
+++ b/Docs/sphinx_documentation/source/LinearSolvers.rst
@@ -109,16 +109,17 @@ and then we can use the ``MLMG`` member function
 
 to solve the problem given an initial guess and a right-hand side.
 Zero is a perfectly fine initial guess.  The two :cpp:`Reals` in the argument
-list are the targeted relative and absolute error tolerances. The absolute
+list are the targeted relative and absolute error tolerances. The relative
 error tolerance is hard-coded to be at least :math:`10^{-16}`.
-The solver will terminate when the max-norm error is less than
+Given the linear system :math:`Ax=b`, the solver will terminate when the
+max-norm of the residual (:math:`b-Ax`) is less than
 :cpp:`std::max(a_tol_abs, a_tol_rel*max_norm)` where :cpp:`max_norm`
-is the max-norm of the solution, :math:`f`, if the flag :cpp:`always_use_bnorm`
-is set to True or if the solution max-norm is greater than the max-norm error of
-the initial guess, otherwise :cpp:`max_norm` is equal to the max-norm error of
-the initial guess. Set the absolute tolerance to zero if one
-does not have a good value for it.  The return value of :cpp:`solve`
-is the max-norm error.
+is the max-norm of the solution (rhs), :math:`b`, if the flag
+:cpp:`always_use_bnorm` is set to True or if the solution max-norm is greater
+than or equal to the max-norm error of the initial guess, otherwise
+:cpp:`max_norm` is equal to the max-norm error of the initial guess. Set the
+absolute tolerance to zero if one does not have a good value for it.  The return
+value of :cpp:`solve` is the max-norm error.
 
 After the solver returns successfully, if needed, we can call
 

--- a/Docs/sphinx_documentation/source/LinearSolvers.rst
+++ b/Docs/sphinx_documentation/source/LinearSolvers.rst
@@ -109,9 +109,14 @@ and then we can use the ``MLMG`` member function
 
 to solve the problem given an initial guess and a right-hand side.
 Zero is a perfectly fine initial guess.  The two :cpp:`Reals` in the argument
-list are the targeted relative and absolute error tolerances.
-The solver will terminate when one of these targets is met.
-Set the absolute tolerance to zero if one
+list are the targeted relative and absolute error tolerances. The absolute
+error tolerance is hard-coded to be at least :math:`10^{-16}`.
+The solver will terminate when the max-norm error is less than
+:cpp:`std::max(a_tol_abs, a_tol_rel*max_norm)` where :cpp:`max_norm`
+is the max-norm of the solution, :math:`f`, if the flag :cpp:`always_use_bnorm`
+is set to True or if the solution max-norm is greater than the max-norm error of
+the initial guess, otherwise :cpp:`max_norm` is equal to the max-norm error of
+the initial guess. Set the absolute tolerance to zero if one
 does not have a good value for it.  The return value of :cpp:`solve`
 is the max-norm error.
 


### PR DESCRIPTION
## Summary

Expanded the documentation with regards to convergence criteria for the MLMG solver

## Additional background

This is in response to @RemiLehe's request for expanded documentation for [WarpX PR #2410](https://github.com/ECP-WarpX/WarpX/pull/2410). I figured it is better to keep the explanation of the different convergence parameters in the AMReX documentation and just add a link to it in the WarpX documentation.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
