### PR TITLE
Update MLNodeTensorLap for WarpX

### DIFF
--- a/Src/EB/AMReX_EB2_2D_C.cpp
+++ b/Src/EB/AMReX_EB2_2D_C.cpp
@@ -282,7 +282,7 @@ int build_faces (Box const& bx, Array4<EBCellFlag> const& cell,
     nmulticuts.copyToHost();
 
     if (*hp > 0 && !cover_multiple_cuts) {
-        amrex::Abort("amerx::EB2::build_faces: more than 2 cuts not supported");
+        amrex::Abort("amrex::EB2::build_faces: more than 2 cuts not supported");
     }
 
     return *hp;

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLinOp.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLinOp.H
@@ -44,7 +44,7 @@ public:
                         StateMode s_mode, const MLMGBndry* bndry=nullptr) const final override;
 
     virtual void smooth (int amrlev, int mglev, MultiFab& sol, const MultiFab& rhs,
-                         bool skip_fillboundary=false) const final override;
+                         bool skip_fillboundary=false) const override;
 
     virtual void solutionResidual (int amrlev, MultiFab& resid, MultiFab& x, const MultiFab& b,
                                    const MultiFab* crse_bcdata=nullptr) override;

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeTensorLap_1D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeTensorLap_1D_K.H
@@ -9,25 +9,6 @@ void mlndtslap_interpadd (int, int, int, Array4<Real> const&,
                           Array4<Real const> const&, Array4<int const> const&) noexcept
 {}
 
-AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-void mlndtslap_adotx (Box const&, Array4<Real> const&, Array4<Real const> const&,
-                      GpuArray<Real,6> const&,
-                      GpuArray<Real,AMREX_SPACEDIM> const&) noexcept
-{}
-
-AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-void mlndtslap_gauss_seidel (Box const&, Array4<Real> const&,
-                             Array4<Real const> const&, Array4<int const> const&,
-                             GpuArray<Real,6> const&,
-                             GpuArray<Real,AMREX_SPACEDIM> const&) noexcept
-{}
-
-AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-void mlndtslap_normalize (Box const&, Array4<Real> const&,
-                          Array4<int const> const&, GpuArray<Real,6> const&,
-                          GpuArray<Real,AMREX_SPACEDIM> const&) noexcept
-{}
-
 }
 
 #endif

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeTensorLap_2D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeTensorLap_2D_K.H
@@ -54,70 +54,35 @@ void mlndtslap_interpadd (int i, int j, int, Array4<Real> const& fine,
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-void mlndtslap_adotx (Box const& b, Array4<Real> const& y, Array4<Real const> const& x,
-                      GpuArray<Real,3> const& s,
-                      GpuArray<Real,AMREX_SPACEDIM> const& dxinv) noexcept
+void mlndtslap_adotx (int i, int j, int k, Array4<Real> const& y, Array4<Real const> const& x,
+                      Array4<int const> const& msk, GpuArray<Real,3> const& s) noexcept
 {
-    const Real h00 = dxinv[0]*dxinv[0];
-    const Real h01 = dxinv[0]*dxinv[1];
-    const Real h11 = dxinv[1]*dxinv[1];
-    amrex::LoopConcurrent(b, [=] (int i, int j, int k) noexcept
-    {
-        y(i,j,k) = x(i-1,j-1,0) * (Real(1./6.)*h00*s[0] + Real(0.5)*h01*s[1] + Real(1./6.)*h11*s[2])
-            +      x(i-1,j  ,0) * (Real(2./3.)*h00*s[0] - Real(1./3.)*h11*s[2])
-            +      x(i-1,j+1,0) * (Real(1./6.)*h00*s[0] - Real(0.5)*h01*s[1] + Real(1./6.)*h11*s[2])
-            +      x(i  ,j-1,0) * (Real(-1./3.)*h00*s[0] + Real(2./3.)*h11*s[2])
-            +      x(i  ,j  ,0) * (Real(-4./3.)*h00*s[0] + Real(-4./3.)*h11*s[2])
-            +      x(i  ,j+1,0) * (Real(-1./3.)*h00*s[0] + Real(2./3.)*h11*s[2])
-            +      x(i+1,j-1,0) * (Real(1./6.)*h00*s[0] - Real(0.5)*h01*s[1] + Real(1./6.)*h11*s[2])
-            +      x(i+1,j  ,0) * (Real(2./3.)*h00*s[0] - Real(1./3.)*h11*s[2])
-            +      x(i+1,j+1,0) * (Real(1./6.)*h00*s[0] + Real(0.5)*h01*s[1] + Real(1./6.)*h11*s[2]);
-    });
+    if (msk(i,j,k)) {
+        y(i,j,k) = Real(0.0);
+    } else {
+        y(i,j,k) = s[0] * (x(i-1,j,0) + x(i+1,j,0))
+            +      s[2] * (x(i,j-1,0) + x(i,j+1,0))
+            - Real(2.)*(s[0]+s[2]) * x(i,j,0)
+            + Real(0.5)*s[1] * (x(i-1,j-1,0) + x(i+1,j+1,0) - x(i-1,j+1,0) - x(i+1,j-1,0));
+    }
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-void mlndtslap_gauss_seidel (Box const& b, Array4<Real> const& sol,
+void mlndtslap_gauss_seidel (int i, int j, int k, Array4<Real> const& sol,
                              Array4<Real const> const& rhs, Array4<int const> const& msk,
-                             GpuArray<Real,3> const& s,
-                             GpuArray<Real,AMREX_SPACEDIM> const& dxinv) noexcept
+                             GpuArray<Real,3> const& s) noexcept
 {
-    const Real h00 = dxinv[0]*dxinv[0];
-    const Real h01 = dxinv[0]*dxinv[1];
-    const Real h11 = dxinv[1]*dxinv[1];
-    amrex::Loop(b, [=] (int i, int j, int k) noexcept
-    {
-        if (msk(i,j,k)) {
-            sol(i,j,k) = 0.0;
-        } else {
-            Real s0 = (Real(-4./3.)*h00*s[0] + Real(-4./3.)*h11*s[2]);
-            Real Ax = sol(i-1,j-1,0) * (Real(1./6.)*h00*s[0] + Real(0.5)*h01*s[1] + Real(1./6.)*h11*s[2])
-                +     sol(i-1,j  ,0) * (Real(2./3.)*h00*s[0] - Real(1./3.)*h11*s[2])
-                +     sol(i-1,j+1,0) * (Real(1./6.)*h00*s[0] - Real(0.5)*h01*s[1] + Real(1./6.)*h11*s[2])
-                +     sol(i  ,j-1,0) * (Real(-1./3.)*h00*s[0] + Real(2./3.)*h11*s[2])
-                +     sol(i  ,j  ,0) * s0
-                +     sol(i  ,j+1,0) * (Real(-1./3.)*h00*s[0] + Real(2./3.)*h11*s[2])
-                +     sol(i+1,j-1,0) * (Real(1./6.)*h00*s[0] - Real(0.5)*h01*s[1] + Real(1./6.)*h11*s[2])
-                +     sol(i+1,j  ,0) * (Real(2./3.)*h00*s[0] - Real(1./3.)*h11*s[2])
-                +     sol(i+1,j+1,0) * (Real(1./6.)*h00*s[0] + Real(0.5)*h01*s[1] + Real(1./6.)*h11*s[2]);
-            sol(i,j,k) += (rhs(i,j,k) - Ax) / s0;
-        }
-    });
-}
-
-AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-void mlndtslap_normalize (Box const& b, Array4<Real> const& phi,
-                          Array4<int const> const& msk, GpuArray<Real,3> const& s,
-                          GpuArray<Real,AMREX_SPACEDIM> const& dxinv) noexcept
-{
-    const Real h00 = dxinv[0]*dxinv[0];
-    const Real h11 = dxinv[1]*dxinv[1];
-    amrex::Loop(b, [=] (int i, int j, int k) noexcept
-    {
-        if (!msk(i,j,k)) {
-            Real s0 = (Real(-4./3.)*h00*s[0] + Real(-4./3.)*h11*s[2]);
-            phi(i,j,k) /= s0;
-        }
-    });
+    if (msk(i,j,k)) {
+        sol(i,j,k) = 0.0;
+    } else {
+        constexpr Real omega = Real(1.25);
+        Real s0 = Real(-2.)*(s[0]+s[2]);
+        Real Ax = s[0] * (sol(i-1,j,0) + sol(i+1,j,0))
+            +     s[2] * (sol(i,j-1,0) + sol(i,j+1,0))
+            + s0 * sol(i,j,0)
+            + Real(0.5)*s[1] * (sol(i-1,j-1,0) + sol(i+1,j+1,0) - sol(i-1,j+1,0) - sol(i+1,j-1,0));
+        sol(i,j,k) += (rhs(i,j,k) - Ax) * (omega/s0);
+    }
 }
 
 #if defined(AMREX_USE_HYPRE) && (AMREX_SPACEDIM > 1)
@@ -127,13 +92,8 @@ void mlndtslap_fill_ijmatrix_cpu (Box const& ndbx,
                                   Array4<AtomicInt const> const& gid,
                                   Array4<int const> const& lid,
                                   HypreInt* const ncols, HypreInt* const cols, Real* const mat,
-                                  GpuArray<Real,3> const& s,
-                                  GpuArray<Real,AMREX_SPACEDIM> const& dxinv)
+                                  GpuArray<Real,3> const& s) noexcept
 {
-    const Real h00 = dxinv[0]*dxinv[0];
-    const Real h01 = dxinv[0]*dxinv[1];
-    const Real h11 = dxinv[1]*dxinv[1];
-
     constexpr auto gidmax = std::numeric_limits<AtomicInt>::max();
     HypreInt nelems = 0;
     amrex::LoopOnCpu(ndbx, [&] (int i, int j, int k) noexcept
@@ -143,54 +103,54 @@ void mlndtslap_fill_ijmatrix_cpu (Box const& ndbx,
             HypreInt nelems_old = nelems;
 
             cols[nelems] = gid(i,j,k);
-            mat[nelems] = Real(-4./3.)*h00*s[0] + Real(-4./3.)*h11*s[2];
+            mat[nelems] = Real(-2.)*(s[0]+s[2]);
             ++nelems;
 
             if                (gid(i-1,j-1,k) < gidmax) {
                 cols[nelems] = gid(i-1,j-1,k);
-                mat[nelems] = Real(1./6.)*h00*s[0] + Real(0.5)*h01*s[1] + Real(1./6.)*h11*s[2];
+                mat[nelems] = Real(0.5)*s[1];
                 ++nelems;
             }
 
             if                (gid(i,j-1,k) < gidmax) {
                 cols[nelems] = gid(i,j-1,k);
-                mat[nelems] = Real(-1./3.)*h00*s[0] + Real(2./3.)*h11*s[2];
+                mat[nelems] = s[2];
                 ++nelems;
             }
 
             if                (gid(i+1,j-1,k) < gidmax) {
                 cols[nelems] = gid(i+1,j-1,k);
-                mat[nelems] = Real(1./6.)*h00*s[0] - Real(0.5)*h01*s[1] + Real(1./6.)*h11*s[2];
+                mat[nelems] = Real(-0.5)*s[1];
                 ++nelems;
             }
 
             if                (gid(i-1,j,k) < gidmax) {
                 cols[nelems] = gid(i-1,j,k);
-                mat[nelems] = Real(2./3.)*h00*s[0] - Real(1./3.)*h11*s[2];
+                mat[nelems] = s[0];
                 ++nelems;
             }
 
             if                (gid(i+1,j,k) < gidmax) {
                 cols[nelems] = gid(i+1,j,k);
-                mat[nelems] = Real(2./3.)*h00*s[0] - Real(1./3.)*h11*s[2];
+                mat[nelems] = s[0];
                 ++nelems;
             }
 
             if                (gid(i-1,j+1,k) < gidmax) {
                 cols[nelems] = gid(i-1,j+1,k);
-                mat[nelems] = Real(1./6.)*h00*s[0] - Real(0.5)*h01*s[1] + Real(1./6.)*h11*s[2];
+                mat[nelems] = Real(-0.5)*s[1];
                 ++nelems;
             }
 
             if                (gid(i,j+1,k) < gidmax) {
                 cols[nelems] = gid(i,j+1,k);
-                mat[nelems] = Real(-1./3.)*h00*s[0] + Real(2./3.)*h11*s[2];
+                mat[nelems] = s[2];
                 ++nelems;
             }
 
             if                (gid(i+1,j+1,k) < gidmax) {
                 cols[nelems] = gid(i+1,j+1,k);
-                mat[nelems] = Real(1./6.)*h00*s[0] + Real(0.5)*h01*s[1] + Real(1./6.)*h11*s[2];
+                mat[nelems] = Real(0.5)*s[1];
                 ++nelems;
             }
 
@@ -207,20 +167,15 @@ void mlndtslap_fill_ijmatrix_gpu (const int ps, const int i, const int j, const 
                                   Array4<AtomicInt const> const& gid,
                                   Array4<int const> const& lid,
                                   HypreInt* const ncols, HypreInt* const cols, Real* const mat,
-                                  GpuArray<Real,3> const& s,
-                                  GpuArray<Real,AMREX_SPACEDIM> const& dxinv)
+                                  GpuArray<Real,3> const& s) noexcept
 {
     if (lid(i,j,k) >= 0)
     {
-        const Real h00 = dxinv[0]*dxinv[0];
-        const Real h01 = dxinv[0]*dxinv[1];
-        const Real h11 = dxinv[1]*dxinv[1];
-
         constexpr auto gidmax = std::numeric_limits<AtomicInt>::max();
 
         if (offset == 0) {
             cols[ps] = gid(i,j,k);
-            mat[ps] = Real(-4./3.)*h00*s[0] + Real(-4./3.)*h11*s[2];
+            mat[ps] = Real(-2.)*(s[0]+s[2]);
             int nc = 1;
             if (gid(i-1,j-1,k) < gidmax) { ++nc; }
             if (gid(i  ,j-1,k) < gidmax) { ++nc; }
@@ -234,35 +189,35 @@ void mlndtslap_fill_ijmatrix_gpu (const int ps, const int i, const int j, const 
         }
         else if (offset == 1 && gid(i-1,j-1,k) < gidmax) {
             cols[ps] =          gid(i-1,j-1,k);
-            mat[ps] = Real(1./6.)*h00*s[0] + Real(0.5)*h01*s[1] + Real(1./6.)*h11*s[2];
+            mat[ps] = Real(0.5)*s[1];
         }
         else if (offset == 2 && gid(i  ,j-1,k) < gidmax) {
             cols[ps] =          gid(i  ,j-1,k);
-            mat[ps] = Real(-1./3.)*h00*s[0] + Real(2./3.)*h11*s[2];
+            mat[ps] = s[2];
         }
         else if (offset == 3 && gid(i+1,j-1,k) < gidmax) {
             cols[ps] =          gid(i+1,j-1,k);
-            mat[ps] = Real(1./6.)*h00*s[0] - Real(0.5)*h01*s[1] + Real(1./6.)*h11*s[2];
+            mat[ps] = Real(-0.5)*s[1];
         }
         else if (offset == 4 && gid(i-1,j  ,k) < gidmax) {
             cols[ps] =          gid(i-1,j  ,k);
-            mat[ps] = Real(2./3.)*h00*s[0] - Real(1./3.)*h11*s[2];
+            mat[ps] = s[0];
         }
         else if (offset == 5 && gid(i+1,j  ,k) < gidmax) {
             cols[ps] =          gid(i+1,j  ,k);
-            mat[ps] = Real(2./3.)*h00*s[0] - Real(1./3.)*h11*s[2];
+            mat[ps] = s[0];
         }
         else if (offset == 6 && gid(i-1,j+1,k) < gidmax) {
             cols[ps] =          gid(i-1,j+1,k);
-            mat[ps] = Real(1./6.)*h00*s[0] - Real(0.5)*h01*s[1] + Real(1./6.)*h11*s[2];
+            mat[ps] = Real(-0.5)*s[1];
         }
         else if (offset == 7 && gid(i  ,j+1,k) < gidmax) {
             cols[ps] =          gid(i  ,j+1,k);
-            mat[ps] = Real(-1./3.)*h00*s[0] + Real(2./3.)*h11*s[2];
+            mat[ps] = s[2];
         }
         else if (offset == 8 && gid(i+1,j+1,k) < gidmax) {
             cols[ps] =          gid(i+1,j+1,k);
-            mat[ps] = Real(1./6.)*h00*s[0] + Real(0.5)*h01*s[1] + Real(1./6.)*h11*s[2];
+            mat[ps] = Real(0.5)*s[1];
         }
     }
 }

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeTensorLap_3D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeTensorLap_3D_K.H
@@ -103,115 +103,41 @@ void mlndtslap_interpadd (int i, int j, int k, Array4<Real> const& fine,
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-void mlndtslap_adotx (Box const& b, Array4<Real> const& y, Array4<Real const> const& x,
-                      GpuArray<Real,6> const& s,
-                      GpuArray<Real,AMREX_SPACEDIM> const& dxinv) noexcept
+void mlndtslap_adotx (int i, int j, int k, Array4<Real> const& y, Array4<Real const> const& x,
+                      Array4<int const> const& msk, GpuArray<Real,6> const& s) noexcept
 {
-    const Real h00 = dxinv[0]*dxinv[0];
-    const Real h01 = dxinv[0]*dxinv[1];
-    const Real h02 = dxinv[0]*dxinv[2];
-    const Real h11 = dxinv[1]*dxinv[1];
-    const Real h12 = dxinv[1]*dxinv[2];
-    const Real h22 = dxinv[2]*dxinv[2];
-    amrex::LoopConcurrent(b, [=] (int i, int j, int k) noexcept
-    {
-        y(i,j,k) = Real(1./36.) *
-            ( x(i-1,j-1,k-1) * ((h00*s[0]+h11*s[3]+h22*s[5])+Real(3.)*( h01*s[1]+h02*s[2]+h12*s[4]))
-            + x(i+1,j-1,k-1) * ((h00*s[0]+h11*s[3]+h22*s[5])+Real(3.)*(-h01*s[1]-h02*s[2]+h12*s[4]))
-            + x(i-1,j+1,k-1) * ((h00*s[0]+h11*s[3]+h22*s[5])+Real(3.)*(-h01*s[1]+h02*s[2]-h12*s[4]))
-            + x(i+1,j+1,k-1) * ((h00*s[0]+h11*s[3]+h22*s[5])+Real(3.)*( h01*s[1]-h02*s[2]-h12*s[4]))
-            + x(i-1,j-1,k+1) * ((h00*s[0]+h11*s[3]+h22*s[5])+Real(3.)*( h01*s[1]-h02*s[2]-h12*s[4]))
-            + x(i+1,j-1,k+1) * ((h00*s[0]+h11*s[3]+h22*s[5])+Real(3.)*(-h01*s[1]+h02*s[2]-h12*s[4]))
-            + x(i-1,j+1,k+1) * ((h00*s[0]+h11*s[3]+h22*s[5])+Real(3.)*(-h01*s[1]-h02*s[2]+h12*s[4]))
-            + x(i+1,j+1,k+1) * ((h00*s[0]+h11*s[3]+h22*s[5])+Real(3.)*( h01*s[1]+h02*s[2]+h12*s[4]))
-            + x(i-1,j-1,k  ) * (Real(4.)*(h00*s[0]+h11*s[3]-Real(0.5)*h22*s[5])+Real(12.)*h01*s[1])
-            + x(i+1,j-1,k  ) * (Real(4.)*(h00*s[0]+h11*s[3]-Real(0.5)*h22*s[5])-Real(12.)*h01*s[1])
-            + x(i-1,j+1,k  ) * (Real(4.)*(h00*s[0]+h11*s[3]-Real(0.5)*h22*s[5])-Real(12.)*h01*s[1])
-            + x(i+1,j+1,k  ) * (Real(4.)*(h00*s[0]+h11*s[3]-Real(0.5)*h22*s[5])+Real(12.)*h01*s[1])
-            + x(i-1,j  ,k-1) * (Real(4.)*(h00*s[0]+h22*s[5]-Real(0.5)*h11*s[3])+Real(12.)*h02*s[2])
-            + x(i+1,j  ,k-1) * (Real(4.)*(h00*s[0]+h22*s[5]-Real(0.5)*h11*s[3])-Real(12.)*h02*s[2])
-            + x(i-1,j  ,k+1) * (Real(4.)*(h00*s[0]+h22*s[5]-Real(0.5)*h11*s[3])-Real(12.)*h02*s[2])
-            + x(i+1,j  ,k+1) * (Real(4.)*(h00*s[0]+h22*s[5]-Real(0.5)*h11*s[3])+Real(12.)*h02*s[2])
-            + x(i  ,j-1,k-1) * (Real(4.)*(h11*s[3]+h22*s[5]-Real(0.5)*h00*s[0])+Real(12.)*h12*s[4])
-            + x(i  ,j+1,k-1) * (Real(4.)*(h11*s[3]+h22*s[5]-Real(0.5)*h00*s[0])-Real(12.)*h12*s[4])
-            + x(i  ,j-1,k+1) * (Real(4.)*(h11*s[3]+h22*s[5]-Real(0.5)*h00*s[0])-Real(12.)*h12*s[4])
-            + x(i  ,j+1,k+1) * (Real(4.)*(h11*s[3]+h22*s[5]-Real(0.5)*h00*s[0])+Real(12.)*h12*s[4])
-            + x(i-1,j  ,k  ) * (Real(8.)*(Real(2.)*h00*s[0]-h11*s[3]-h22*s[5]))
-            + x(i+1,j  ,k  ) * (Real(8.)*(Real(2.)*h00*s[0]-h11*s[3]-h22*s[5]))
-            + x(i  ,j-1,k  ) * (Real(8.)*(Real(2.)*h11*s[3]-h00*s[0]-h22*s[5]))
-            + x(i  ,j+1,k  ) * (Real(8.)*(Real(2.)*h11*s[3]-h00*s[0]-h22*s[5]))
-            + x(i  ,j  ,k-1) * (Real(8.)*(Real(2.)*h22*s[5]-h00*s[0]-h11*s[3]))
-            + x(i  ,j  ,k+1) * (Real(8.)*(Real(2.)*h22*s[5]-h00*s[0]-h11*s[3]))
-            + x(i  ,j  ,k  ) * Real(-32.)*(h00*s[0]+h11*s[3]+h22*s[5]) );
-    });
+    if (msk(i,j,k)) {
+        y(i,j,k) = Real(0.0);
+    } else {
+        y(i,j,k) = s[0] * (x(i-1,j  ,k  ) + x(i+1,j  ,k  ))
+            +      s[3] * (x(i  ,j-1,k  ) + x(i  ,j+1,k  ))
+            +      s[5] * (x(i  ,j  ,k-1) + x(i  ,j  ,k+1))
+            - Real(2.)*(s[0]+s[3]+s[5]) * x(i,j,k)
+            + Real(0.5)*s[1] * (x(i-1,j-1,k  ) + x(i+1,j+1,k  ) - x(i-1,j+1,k  ) - x(i+1,j-1,k  ))
+            + Real(0.5)*s[2] * (x(i-1,j  ,k-1) + x(i+1,j  ,k+1) - x(i-1,j  ,k+1) - x(i+1,j  ,k-1))
+            + Real(0.5)*s[4] * (x(i  ,j-1,k-1) + x(i  ,j+1,k+1) - x(i  ,j-1,k+1) - x(i  ,j+1,k-1));
+    }
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-void mlndtslap_gauss_seidel (Box const& b, Array4<Real> const& sol,
+void mlndtslap_gauss_seidel (int i, int j, int k, Array4<Real> const& sol,
                              Array4<Real const> const& rhs, Array4<int const> const& msk,
-                             GpuArray<Real,6> const& s,
-                             GpuArray<Real,AMREX_SPACEDIM> const& dxinv) noexcept
+                             GpuArray<Real,6> const& s) noexcept
 {
-    const Real h00 = dxinv[0]*dxinv[0];
-    const Real h01 = dxinv[0]*dxinv[1];
-    const Real h02 = dxinv[0]*dxinv[2];
-    const Real h11 = dxinv[1]*dxinv[1];
-    const Real h12 = dxinv[1]*dxinv[2];
-    const Real h22 = dxinv[2]*dxinv[2];
-    amrex::LoopConcurrent(b, [=] (int i, int j, int k) noexcept
-    {
-        if (msk(i,j,k)) {
-            sol(i,j,k) = 0.0;
-        } else {
-            Real s0 = Real(1./36.) * Real(-32.)*(h00*s[0]+h11*s[3]+h22*s[5]);
-            Real Ax = Real(1./36.) *
-                ( sol(i-1,j-1,k-1) * ((h00*s[0]+h11*s[3]+h22*s[5])+Real(3.)*( h01*s[1]+h02*s[2]+h12*s[4]))
-                + sol(i+1,j-1,k-1) * ((h00*s[0]+h11*s[3]+h22*s[5])+Real(3.)*(-h01*s[1]-h02*s[2]+h12*s[4]))
-                + sol(i-1,j+1,k-1) * ((h00*s[0]+h11*s[3]+h22*s[5])+Real(3.)*(-h01*s[1]+h02*s[2]-h12*s[4]))
-                + sol(i+1,j+1,k-1) * ((h00*s[0]+h11*s[3]+h22*s[5])+Real(3.)*( h01*s[1]-h02*s[2]-h12*s[4]))
-                + sol(i-1,j-1,k+1) * ((h00*s[0]+h11*s[3]+h22*s[5])+Real(3.)*( h01*s[1]-h02*s[2]-h12*s[4]))
-                + sol(i+1,j-1,k+1) * ((h00*s[0]+h11*s[3]+h22*s[5])+Real(3.)*(-h01*s[1]+h02*s[2]-h12*s[4]))
-                + sol(i-1,j+1,k+1) * ((h00*s[0]+h11*s[3]+h22*s[5])+Real(3.)*(-h01*s[1]-h02*s[2]+h12*s[4]))
-                + sol(i+1,j+1,k+1) * ((h00*s[0]+h11*s[3]+h22*s[5])+Real(3.)*( h01*s[1]+h02*s[2]+h12*s[4]))
-                + sol(i-1,j-1,k  ) * (Real(4.)*(h00*s[0]+h11*s[3]-Real(0.5)*h22*s[5])+Real(12.)*h01*s[1])
-                + sol(i+1,j-1,k  ) * (Real(4.)*(h00*s[0]+h11*s[3]-Real(0.5)*h22*s[5])-Real(12.)*h01*s[1])
-                + sol(i-1,j+1,k  ) * (Real(4.)*(h00*s[0]+h11*s[3]-Real(0.5)*h22*s[5])-Real(12.)*h01*s[1])
-                + sol(i+1,j+1,k  ) * (Real(4.)*(h00*s[0]+h11*s[3]-Real(0.5)*h22*s[5])+Real(12.)*h01*s[1])
-                + sol(i-1,j  ,k-1) * (Real(4.)*(h00*s[0]+h22*s[5]-Real(0.5)*h11*s[3])+Real(12.)*h02*s[2])
-                + sol(i+1,j  ,k-1) * (Real(4.)*(h00*s[0]+h22*s[5]-Real(0.5)*h11*s[3])-Real(12.)*h02*s[2])
-                + sol(i-1,j  ,k+1) * (Real(4.)*(h00*s[0]+h22*s[5]-Real(0.5)*h11*s[3])-Real(12.)*h02*s[2])
-                + sol(i+1,j  ,k+1) * (Real(4.)*(h00*s[0]+h22*s[5]-Real(0.5)*h11*s[3])+Real(12.)*h02*s[2])
-                + sol(i  ,j-1,k-1) * (Real(4.)*(h11*s[3]+h22*s[5]-Real(0.5)*h00*s[0])+Real(12.)*h12*s[4])
-                + sol(i  ,j+1,k-1) * (Real(4.)*(h11*s[3]+h22*s[5]-Real(0.5)*h00*s[0])-Real(12.)*h12*s[4])
-                + sol(i  ,j-1,k+1) * (Real(4.)*(h11*s[3]+h22*s[5]-Real(0.5)*h00*s[0])-Real(12.)*h12*s[4])
-                + sol(i  ,j+1,k+1) * (Real(4.)*(h11*s[3]+h22*s[5]-Real(0.5)*h00*s[0])+Real(12.)*h12*s[4])
-                + sol(i-1,j  ,k  ) * (Real(8.)*(Real(2.)*h00*s[0]-h11*s[3]-h22*s[5]))
-                + sol(i+1,j  ,k  ) * (Real(8.)*(Real(2.)*h00*s[0]-h11*s[3]-h22*s[5]))
-                + sol(i  ,j-1,k  ) * (Real(8.)*(Real(2.)*h11*s[3]-h00*s[0]-h22*s[5]))
-                + sol(i  ,j+1,k  ) * (Real(8.)*(Real(2.)*h11*s[3]-h00*s[0]-h22*s[5]))
-                + sol(i  ,j  ,k-1) * (Real(8.)*(Real(2.)*h22*s[5]-h00*s[0]-h11*s[3]))
-                + sol(i  ,j  ,k+1) * (Real(8.)*(Real(2.)*h22*s[5]-h00*s[0]-h11*s[3])) )
-                + sol(i  ,j  ,k  ) * s0;
-            sol(i,j,k) += (rhs(i,j,k) - Ax) / s0;
-        }
-    });
-}
-
-AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-void mlndtslap_normalize (Box const& b, Array4<Real> const& phi,
-                          Array4<int const> const& msk, GpuArray<Real,6> const& s,
-                          GpuArray<Real,AMREX_SPACEDIM> const& dxinv) noexcept
-{
-    const Real h00 = dxinv[0]*dxinv[0];
-    const Real h11 = dxinv[1]*dxinv[1];
-    const Real h22 = dxinv[2]*dxinv[2];
-    amrex::LoopConcurrent(b, [=] (int i, int j, int k) noexcept
-    {
-        if (!msk(i,j,k)) {
-            Real s0 = Real(1./36.) * Real(-32.)*(h00*s[0]+h11*s[3]+h22*s[5]);
-            phi(i,j,k) /= s0;
-        }
-    });
+    if (msk(i,j,k)) {
+        sol(i,j,k) = 0.0;
+    } else {
+        constexpr Real omega = Real(1.25);
+        Real s0 = Real(-2.)*(s[0]+s[3]+s[5]);
+        Real Ax = s[0] * (sol(i-1,j  ,k  ) + sol(i+1,j  ,k  ))
+            +     s[3] * (sol(i  ,j-1,k  ) + sol(i  ,j+1,k  ))
+            +     s[5] * (sol(i  ,j  ,k-1) + sol(i  ,j  ,k+1))
+            + s0 * sol(i,j,k)
+            + Real(0.5)*s[1] * (sol(i-1,j-1,k  ) + sol(i+1,j+1,k  ) - sol(i-1,j+1,k  ) - sol(i+1,j-1,k  ))
+            + Real(0.5)*s[2] * (sol(i-1,j  ,k-1) + sol(i+1,j  ,k+1) - sol(i-1,j  ,k+1) - sol(i+1,j  ,k-1))
+            + Real(0.5)*s[4] * (sol(i  ,j-1,k-1) + sol(i  ,j+1,k+1) - sol(i  ,j-1,k+1) - sol(i  ,j+1,k-1));
+        sol(i,j,k) += (rhs(i,j,k) - Ax) * (omega/s0);
+    }
 }
 
 #if defined(AMREX_USE_HYPRE) && (AMREX_SPACEDIM > 1)
@@ -221,16 +147,8 @@ void mlndtslap_fill_ijmatrix_cpu (Box const& ndbx,
                                   Array4<AtomicInt const> const& gid,
                                   Array4<int const> const& lid,
                                   HypreInt* const ncols, HypreInt* const cols, Real* const mat,
-                                  GpuArray<Real,6> const& s,
-                                  GpuArray<Real,AMREX_SPACEDIM> const& dxinv)
+                                  GpuArray<Real,6> const& s) noexcept
 {
-    const Real h00 = dxinv[0]*dxinv[0];
-    const Real h01 = dxinv[0]*dxinv[1];
-    const Real h02 = dxinv[0]*dxinv[2];
-    const Real h11 = dxinv[1]*dxinv[1];
-    const Real h12 = dxinv[1]*dxinv[2];
-    const Real h22 = dxinv[2]*dxinv[2];
-
     constexpr auto gidmax = std::numeric_limits<AtomicInt>::max();
     HypreInt nelems = 0;
     amrex::LoopOnCpu(ndbx, [&] (int i, int j, int k) noexcept
@@ -240,188 +158,114 @@ void mlndtslap_fill_ijmatrix_cpu (Box const& ndbx,
             HypreInt nelems_old = nelems;
 
             cols[nelems] = gid(i,j,k);
-            mat[nelems] = Real(1./36.) * Real(-32.)*(h00*s[0]+h11*s[3]+h22*s[5]);
+            mat[nelems] = Real(-2.)*(s[0]+s[3]+s[5]);
             ++nelems;
-
-            if (               gid(i-1,j-1,k-1) < gidmax) {
-                cols[nelems] = gid(i-1,j-1,k-1);
-                Real t = Real(1./36.)*((h00*s[0]+h11*s[3]+h22*s[5])+Real(3.)*( h01*s[1]+h02*s[2]+h12*s[4]));
-                mat[nelems] = t;
-                ++nelems;
-            }
 
             if (               gid(i  ,j-1,k-1) < gidmax) {
                 cols[nelems] = gid(i  ,j-1,k-1);
-                Real t = Real(1./36.)*(Real(4.)*(h11*s[3]+h22*s[5]-Real(0.5)*h00*s[0])+Real(12.)*h12*s[4]);
-                mat[nelems] = t;
-                ++nelems;
-            }
-
-            if (               gid(i+1,j-1,k-1) < gidmax) {
-                cols[nelems] = gid(i+1,j-1,k-1);
-                Real t = Real(1./36.)*((h00*s[0]+h11*s[3]+h22*s[5])+Real(3.)*(-h01*s[1]-h02*s[2]+h12*s[4]));
-                mat[nelems] = t;
+                mat[nelems] = Real(0.5)*s[4];
                 ++nelems;
             }
 
             if (               gid(i-1,j  ,k-1) < gidmax) {
                 cols[nelems] = gid(i-1,j  ,k-1);
-                Real t = Real(1./36.)*(Real(4.)*(h00*s[0]+h22*s[5]-Real(0.5)*h11*s[3])+Real(12.)*h02*s[2]);
-                mat[nelems] = t;
+                mat[nelems] = Real(0.5)*s[2];
                 ++nelems;
             }
 
             if (               gid(i  ,j  ,k-1) < gidmax) {
                 cols[nelems] = gid(i  ,j  ,k-1);
-                Real t = Real(1./36.)*(Real(8.)*(Real(2.)*h22*s[5]-h00*s[0]-h11*s[3]));
-                mat[nelems] = t;
+                mat[nelems] = s[5];
                 ++nelems;
             }
 
             if (               gid(i+1,j  ,k-1) < gidmax) {
                 cols[nelems] = gid(i+1,j  ,k-1);
-                Real t = Real(1./36.)*(Real(4.)*(h00*s[0]+h22*s[5]-Real(0.5)*h11*s[3])-Real(12.)*h02*s[2]);
-                mat[nelems] = t;
-                ++nelems;
-            }
-
-            if (               gid(i-1,j+1,k-1) < gidmax) {
-                cols[nelems] = gid(i-1,j+1,k-1);
-                Real t = Real(1./36.)*((h00*s[0]+h11*s[3]+h22*s[5])+Real(3.)*(-h01*s[1]+h02*s[2]-h12*s[4]));
-                mat[nelems] = t;
+                mat[nelems] = Real(-0.5)*s[2];
                 ++nelems;
             }
 
             if (               gid(i  ,j+1,k-1) < gidmax) {
                 cols[nelems] = gid(i  ,j+1,k-1);
-                Real t = Real(1./36.)*(Real(4.)*(h11*s[3]+h22*s[5]-Real(0.5)*h00*s[0])-Real(12.)*h12*s[4]);
-                mat[nelems] = t;
-                ++nelems;
-            }
-
-            if (               gid(i+1,j+1,k-1) < gidmax) {
-                cols[nelems] = gid(i+1,j+1,k-1);
-                Real t = Real(1./36.)*((h00*s[0]+h11*s[3]+h22*s[5])+Real(3.)*( h01*s[1]-h02*s[2]-h12*s[4]));
-                mat[nelems] = t;
+                mat[nelems] = Real(-0.5)*s[4];
                 ++nelems;
             }
 
             if (               gid(i-1,j-1,k  ) < gidmax) {
                 cols[nelems] = gid(i-1,j-1,k  );
-                Real t = Real(1./36.)*(Real(4.)*(h00*s[0]+h11*s[3]-Real(0.5)*h22*s[5])+Real(12.)*h01*s[1]);
-                mat[nelems] = t;
+                mat[nelems] = Real(0.5)*s[1];
                 ++nelems;
             }
 
-           if (               gid(i  ,j-1,k  ) < gidmax) {
+            if (               gid(i  ,j-1,k  ) < gidmax) {
                 cols[nelems] = gid(i  ,j-1,k  );
-                Real t = Real(1./36.)*(Real(8.)*(Real(2.)*h11*s[3]-h00*s[0]-h22*s[5]));
-                mat[nelems] = t;
+                mat[nelems] = s[3];
                 ++nelems;
             }
 
             if (               gid(i+1,j-1,k  ) < gidmax) {
                 cols[nelems] = gid(i+1,j-1,k  );
-                Real t = Real(1./36.)*(Real(4.)*(h00*s[0]+h11*s[3]-Real(0.5)*h22*s[5])-Real(12.)*h01*s[1]);
-                mat[nelems] = t;
+                mat[nelems] = Real(-0.5)*s[1];
                 ++nelems;
             }
 
             if (               gid(i-1,j  ,k  ) < gidmax) {
                 cols[nelems] = gid(i-1,j  ,k  );
-                Real t = Real(1./36.)*(Real(8.)*(Real(2.)*h00*s[0]-h11*s[3]-h22*s[5]));
-                mat[nelems] = t;
+                mat[nelems] = s[0];
                 ++nelems;
             }
 
             if (               gid(i+1,j  ,k  ) < gidmax) {
                 cols[nelems] = gid(i+1,j  ,k  );
-                Real t = Real(1./36.)*(Real(8.)*(Real(2.)*h00*s[0]-h11*s[3]-h22*s[5]));
-                mat[nelems] = t;
+                mat[nelems] = s[0];
                 ++nelems;
             }
 
             if (               gid(i-1,j+1,k  ) < gidmax) {
                 cols[nelems] = gid(i-1,j+1,k  );
-                Real t = Real(1./36.)*(Real(4.)*(h00*s[0]+h11*s[3]-Real(0.5)*h22*s[5])-Real(12.)*h01*s[1]);
-                mat[nelems] = t;
+                mat[nelems] = Real(-0.5)*s[1];
                 ++nelems;
             }
 
             if (               gid(i  ,j+1,k  ) < gidmax) {
                 cols[nelems] = gid(i  ,j+1,k  );
-                Real t = Real(1./36.)*(Real(8.)*(Real(2.)*h11*s[3]-h00*s[0]-h22*s[5]));
-                mat[nelems] = t;
+                mat[nelems] = s[3];
                 ++nelems;
             }
 
             if (               gid(i+1,j+1,k  ) < gidmax) {
                 cols[nelems] = gid(i+1,j+1,k  );
-                Real t = Real(1./36.)*(Real(4.)*(h00*s[0]+h11*s[3]-Real(0.5)*h22*s[5])+Real(12.)*h01*s[1]);
-                mat[nelems] = t;
-                ++nelems;
-            }
-
-            if (               gid(i-1,j-1,k+1) < gidmax) {
-                cols[nelems] = gid(i-1,j-1,k+1);
-                Real t = Real(1./36.)*((h00*s[0]+h11*s[3]+h22*s[5])+Real(3.)*( h01*s[1]-h02*s[2]-h12*s[4]));
-                mat[nelems] = t;
+                mat[nelems] = Real(0.5)*s[1];
                 ++nelems;
             }
 
             if (               gid(i  ,j-1,k+1) < gidmax) {
                 cols[nelems] = gid(i  ,j-1,k+1);
-                Real t = Real(1./36.)*(Real(4.)*(h11*s[3]+h22*s[5]-Real(0.5)*h00*s[0])-Real(12.)*h12*s[4]);
-                mat[nelems] = t;
-                ++nelems;
-            }
-
-            if (               gid(i+1,j-1,k+1) < gidmax) {
-                cols[nelems] = gid(i+1,j-1,k+1);
-                Real t = Real(1./36.)*((h00*s[0]+h11*s[3]+h22*s[5])+Real(3.)*(-h01*s[1]+h02*s[2]-h12*s[4]));
-                mat[nelems] = t;
+                mat[nelems] = Real(-0.5)*s[4];
                 ++nelems;
             }
 
             if (               gid(i-1,j  ,k+1) < gidmax) {
                 cols[nelems] = gid(i-1,j  ,k+1);
-                Real t = Real(1./36.)*(Real(4.)*(h00*s[0]+h22*s[5]-Real(0.5)*h11*s[3])-Real(12.)*h02*s[2]);
-                mat[nelems] = t;
+                mat[nelems] = Real(-0.5)*s[2];
                 ++nelems;
             }
 
             if (               gid(i  ,j  ,k+1) < gidmax) {
                 cols[nelems] = gid(i  ,j  ,k+1);
-                Real t = Real(1./36.)*(Real(8.)*(Real(2.)*h22*s[5]-h00*s[0]-h11*s[3]));
-                mat[nelems] = t;
+                mat[nelems] = s[5];
                 ++nelems;
             }
 
             if (               gid(i+1,j  ,k+1) < gidmax) {
                 cols[nelems] = gid(i+1,j  ,k+1);
-                Real t = Real(1./36.)*(Real(4.)*(h00*s[0]+h22*s[5]-Real(0.5)*h11*s[3])+Real(12.)*h02*s[2]);
-                mat[nelems] = t;
-                ++nelems;
-            }
-
-            if (               gid(i-1,j+1,k+1) < gidmax) {
-                cols[nelems] = gid(i-1,j+1,k+1);
-                Real t = Real(1./36.)*((h00*s[0]+h11*s[3]+h22*s[5])+Real(3.)*(-h01*s[1]-h02*s[2]+h12*s[4]));
-                mat[nelems] = t;
+                mat[nelems] = Real(0.5)*s[2];
                 ++nelems;
             }
 
             if (               gid(i  ,j+1,k+1) < gidmax) {
                 cols[nelems] = gid(i  ,j+1,k+1);
-                Real t = Real(1./36.)*(Real(4.)*(h11*s[3]+h22*s[5]-Real(0.5)*h00*s[0])+Real(12.)*h12*s[4]);
-                mat[nelems] = t;
-                ++nelems;
-            }
-
-            if (               gid(i+1,j+1,k+1) < gidmax) {
-                cols[nelems] = gid(i+1,j+1,k+1);
-                Real t = Real(1./36.)*((h00*s[0]+h11*s[3]+h22*s[5])+Real(3.)*( h01*s[1]+h02*s[2]+h12*s[4]));
-                mat[nelems] = t;
+                mat[nelems] = Real(0.5)*s[4];
                 ++nelems;
             }
 
@@ -439,23 +283,15 @@ void mlndtslap_fill_ijmatrix_gpu (const int ps, const int i, const int j, const 
                                   Array4<AtomicInt const> const& gid,
                                   Array4<int const> const& lid,
                                   HypreInt* const ncols, HypreInt* const cols, Real* const mat,
-                                  GpuArray<Real,6> const& s,
-                                  GpuArray<Real,AMREX_SPACEDIM> const& dxinv)
+                                  GpuArray<Real,6> const& s) noexcept
 {
     if (lid(i,j,k) >= 0)
     {
-        const Real h00 = dxinv[0]*dxinv[0];
-        const Real h01 = dxinv[0]*dxinv[1];
-        const Real h02 = dxinv[0]*dxinv[2];
-        const Real h11 = dxinv[1]*dxinv[1];
-        const Real h12 = dxinv[1]*dxinv[2];
-        const Real h22 = dxinv[2]*dxinv[2];
-
         constexpr auto gidmax = std::numeric_limits<AtomicInt>::max();
 
         if (offset == 0) {
             cols[ps] = gid(i,j,k);
-            mat[ps] = Real(1./36.) * Real(-32.)*(h00*s[0]+h11*s[3]+h22*s[5]);
+            mat[ps] = Real(-2.)*(s[0]+s[3]+s[5]);
             int nc = 1;
             if (gid(i-1,j-1,k-1) < gidmax) { ++nc; }
             if (gid(i  ,j-1,k-1) < gidmax) { ++nc; }
@@ -487,133 +323,107 @@ void mlndtslap_fill_ijmatrix_gpu (const int ps, const int i, const int j, const 
         }
         else if (offset == 1 && gid(i-1,j-1,k-1) < gidmax) {
             cols[ps] =          gid(i-1,j-1,k-1);
-            Real t = Real(1./36.)*((h00*s[0]+h11*s[3]+h22*s[5])+Real(3.)*( h01*s[1]+h02*s[2]+h12*s[4]));
-            mat[ps] = t;
+            mat[ps] = Real(0.0);
         }
         else if (offset == 2 && gid(i  ,j-1,k-1) < gidmax) {
             cols[ps] =          gid(i  ,j-1,k-1);
-            Real t = Real(1./36.)*(Real(4.)*(h11*s[3]+h22*s[5]-Real(0.5)*h00*s[0])+Real(12.)*h12*s[4]);
-            mat[ps] = t;
+            mat[ps] = Real(0.5)*s[4];
         }
         else if (offset == 3 && gid(i+1,j-1,k-1) < gidmax) {
             cols[ps] =          gid(i+1,j-1,k-1);
-            Real t = Real(1./36.)*((h00*s[0]+h11*s[3]+h22*s[5])+Real(3.)*(-h01*s[1]-h02*s[2]+h12*s[4]));
-            mat[ps] = t;
+            mat[ps] = Real(0.0);
         }
         else if (offset == 4 && gid(i-1,j  ,k-1) < gidmax) {
             cols[ps] =          gid(i-1,j  ,k-1);
-            Real t = Real(1./36.)*(Real(4.)*(h00*s[0]+h22*s[5]-Real(0.5)*h11*s[3])+Real(12.)*h02*s[2]);
-            mat[ps] = t;
+            mat[ps] = Real(0.5)*s[2];
         }
         else if (offset == 5 && gid(i  ,j  ,k-1) < gidmax) {
             cols[ps] =          gid(i  ,j  ,k-1);
-            Real t = Real(1./36.)*(Real(8.)*(Real(2.)*h22*s[5]-h00*s[0]-h11*s[3]));
-            mat[ps] = t;
+            mat[ps] = s[5];
         }
         else if (offset == 6 && gid(i+1,j  ,k-1) < gidmax) {
             cols[ps] =          gid(i+1,j  ,k-1);
-            Real t = Real(1./36.)*(Real(4.)*(h00*s[0]+h22*s[5]-Real(0.5)*h11*s[3])-Real(12.)*h02*s[2]);
-            mat[ps] = t;
+            mat[ps] = Real(-0.5)*s[2];
         }
         else if (offset == 7 && gid(i-1,j+1,k-1) < gidmax) {
             cols[ps] =          gid(i-1,j+1,k-1);
-            Real t = Real(1./36.)*((h00*s[0]+h11*s[3]+h22*s[5])+Real(3.)*(-h01*s[1]+h02*s[2]-h12*s[4]));
-            mat[ps] = t;
+            mat[ps] = Real(0.0);
         }
         else if (offset == 8 && gid(i  ,j+1,k-1) < gidmax) {
             cols[ps] =          gid(i  ,j+1,k-1);
-            Real t = Real(1./36.)*(Real(4.)*(h11*s[3]+h22*s[5]-Real(0.5)*h00*s[0])-Real(12.)*h12*s[4]);
-            mat[ps] = t;
+            mat[ps] = Real(-0.5)*s[4];
         }
         else if (offset == 9 && gid(i+1,j+1,k-1) < gidmax) {
             cols[ps] =          gid(i+1,j+1,k-1);
-            Real t = Real(1./36.)*((h00*s[0]+h11*s[3]+h22*s[5])+Real(3.)*( h01*s[1]-h02*s[2]-h12*s[4]));
-            mat[ps] = t;
+            mat[ps] = Real(0.0);
         }
         else if (offset == 10 && gid(i-1,j-1,k  ) < gidmax) {
             cols[ps] =           gid(i-1,j-1,k  );
-            Real t = Real(1./36.)*(Real(4.)*(h00*s[0]+h11*s[3]-Real(0.5)*h22*s[5])+Real(12.)*h01*s[1]);
-            mat[ps] = t;
+            mat[ps] = Real(0.5)*s[1];
         }
         else if (offset == 11 && gid(i  ,j-1,k  ) < gidmax) {
             cols[ps] =           gid(i  ,j-1,k  );
-            Real t = Real(1./36.)*(Real(8.)*(Real(2.)*h11*s[3]-h00*s[0]-h22*s[5]));
-            mat[ps] = t;
+            mat[ps] = s[3];
         }
         else if (offset == 12 && gid(i+1,j-1,k  ) < gidmax) {
             cols[ps] =           gid(i+1,j-1,k  );
-            Real t = Real(1./36.)*(Real(4.)*(h00*s[0]+h11*s[3]-Real(0.5)*h22*s[5])-Real(12.)*h01*s[1]);
-            mat[ps] = t;
+            mat[ps] = Real(-0.5)*s[1];
         }
         else if (offset == 13 && gid(i-1,j  ,k  ) < gidmax) {
             cols[ps] =           gid(i-1,j  ,k  );
-            Real t = Real(1./36.)*(Real(8.)*(Real(2.)*h00*s[0]-h11*s[3]-h22*s[5]));
-            mat[ps] = t;
+            mat[ps] = s[0];
         }
         else if (offset == 14 && gid(i+1,j  ,k  ) < gidmax) {
             cols[ps] =           gid(i+1,j  ,k  );
-            Real t = Real(1./36.)*(Real(8.)*(Real(2.)*h00*s[0]-h11*s[3]-h22*s[5]));
-            mat[ps] = t;
+            mat[ps] = s[0];
         }
         else if (offset == 15 && gid(i-1,j+1,k  ) < gidmax) {
             cols[ps] =           gid(i-1,j+1,k  );
-            Real t = Real(1./36.)*(Real(4.)*(h00*s[0]+h11*s[3]-Real(0.5)*h22*s[5])-Real(12.)*h01*s[1]);
-            mat[ps] = t;
+            mat[ps] = Real(-0.5)*s[1];
         }
         else if (offset == 16 && gid(i  ,j+1,k  ) < gidmax) {
             cols[ps] =           gid(i  ,j+1,k  );
-            Real t = Real(1./36.)*(Real(8.)*(Real(2.)*h11*s[3]-h00*s[0]-h22*s[5]));
-            mat[ps] = t;
+            mat[ps] = s[3];
         }
         else if (offset == 17 && gid(i+1,j+1,k  ) < gidmax) {
             cols[ps] =           gid(i+1,j+1,k  );
-            Real t = Real(1./36.)*(Real(4.)*(h00*s[0]+h11*s[3]-Real(0.5)*h22*s[5])+Real(12.)*h01*s[1]);
-            mat[ps] = t;
+            mat[ps] = Real(0.5)*s[1];
         }
         else if (offset == 18 && gid(i-1,j-1,k+1) < gidmax) {
             cols[ps] =           gid(i-1,j-1,k+1);
-            Real t = Real(1./36.)*((h00*s[0]+h11*s[3]+h22*s[5])+Real(3.)*( h01*s[1]-h02*s[2]-h12*s[4]));
-            mat[ps] = t;
+            mat[ps] = Real(0.0);
         }
         else if (offset == 19 && gid(i  ,j-1,k+1) < gidmax) {
             cols[ps] =           gid(i  ,j-1,k+1);
-            Real t = Real(1./36.)*(Real(4.)*(h11*s[3]+h22*s[5]-Real(0.5)*h00*s[0])-Real(12.)*h12*s[4]);
-            mat[ps] = t;
+            mat[ps] = Real(-0.5)*s[4];
         }
         else if (offset == 20 && gid(i+1,j-1,k+1) < gidmax) {
             cols[ps] =           gid(i+1,j-1,k+1);
-            Real t = Real(1./36.)*((h00*s[0]+h11*s[3]+h22*s[5])+Real(3.)*(-h01*s[1]+h02*s[2]-h12*s[4]));
-            mat[ps] = t;
+            mat[ps] = Real(0.0);
         }
         else if (offset == 21 && gid(i-1,j  ,k+1) < gidmax) {
             cols[ps] =           gid(i-1,j  ,k+1);
-            Real t = Real(1./36.)*(Real(4.)*(h00*s[0]+h22*s[5]-Real(0.5)*h11*s[3])-Real(12.)*h02*s[2]);
-            mat[ps] = t;
+            mat[ps] = Real(-0.5)*s[2];
         }
         else if (offset == 22 && gid(i  ,j  ,k+1) < gidmax) {
             cols[ps] =           gid(i  ,j  ,k+1);
-            Real t = Real(1./36.)*(Real(8.)*(Real(2.)*h22*s[5]-h00*s[0]-h11*s[3]));
-            mat[ps] = t;
+            mat[ps] = s[5];
         }
         else if (offset == 23 && gid(i+1,j  ,k+1) < gidmax) {
             cols[ps] =           gid(i+1,j  ,k+1);
-            Real t = Real(1./36.)*(Real(4.)*(h00*s[0]+h22*s[5]-Real(0.5)*h11*s[3])+Real(12.)*h02*s[2]);
-            mat[ps] = t;
+            mat[ps] = Real(0.5)*s[2];
         }
         else if (offset == 24 && gid(i-1,j+1,k+1) < gidmax) {
             cols[ps] =           gid(i-1,j+1,k+1);
-            Real t = Real(1./36.)*((h00*s[0]+h11*s[3]+h22*s[5])+Real(3.)*(-h01*s[1]-h02*s[2]+h12*s[4]));
-            mat[ps] = t;
+            mat[ps] = Real(0.0);
         }
         else if (offset == 25 && gid(i  ,j+1,k+1) < gidmax) {
             cols[ps] =           gid(i  ,j+1,k+1);
-            Real t = Real(1./36.)*(Real(4.)*(h11*s[3]+h22*s[5]-Real(0.5)*h00*s[0])+Real(12.)*h12*s[4]);
-            mat[ps] = t;
+            mat[ps] = Real(0.5)*s[4];
         }
         else if (offset == 26 && gid(i+1,j+1,k+1) < gidmax) {
             cols[ps] =           gid(i+1,j+1,k+1);
-            Real t = Real(1./36.)*((h00*s[0]+h11*s[3]+h22*s[5])+Real(3.)*( h01*s[1]+h02*s[2]+h12*s[4]));
-            mat[ps] = t;
+            mat[ps] = Real(0.0);
         }
     }
 }

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeTensorLaplacian.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeTensorLaplacian.H
@@ -57,6 +57,9 @@ public:
                          MultiFab& res, const MultiFab& crse_sol, const MultiFab& crse_rhs,
                          MultiFab& fine_res, MultiFab& fine_sol, const MultiFab& fine_rhs) const final override;
 
+    virtual void smooth (int amrlev, int mglev, MultiFab& sol, const MultiFab& rhs,
+                         bool skip_fillboundary=false) const final override;
+
     virtual void prepareForSolve () final override;
     virtual void Fapply (int amrlev, int mglev, MultiFab& out, const MultiFab& in) const final override;
     virtual void Fsmooth (int amrlev, int mglev, MultiFab& sol, const MultiFab& rhs) const final override;
@@ -80,7 +83,10 @@ public:
 
 private:
 
+    GpuArray<Real,nelems> scaledSigma (int amrlev, int mglev) const noexcept;
+
     GpuArray<Real,nelems> m_sigma;
+    mutable int m_redblack = 0;
 };
 
 }

--- a/Tests/LinearSolvers/NodeTensorLap/MyTest.cpp
+++ b/Tests/LinearSolvers/NodeTensorLap/MyTest.cpp
@@ -39,7 +39,7 @@ MyTest::solve ()
     } else
 #endif
     {
-        mlmg.setBottomSolver(MLMG::BottomSolver::cg);
+        mlmg.setBottomSolver(MLMG::BottomSolver::bicgstab);
     }
 
     mlmg.setBottomMaxIter(1000);
@@ -200,4 +200,3 @@ MyTest::initData ()
         }
     }
 }
-


### PR DESCRIPTION
Change the stencil of the linear operator so that L=D*G.  This could make
the solution satisfy div E = rho up to solver tolerance.  Previously, the
stencil was similar to that of the nodal solver for approximate projection

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
