### PR TITLE
Fix two IO overflow bugs uncovered by NyX.

### DIFF
--- a/Src/Base/AMReX_FabConv.cpp
+++ b/Src/Base/AMReX_FabConv.cpp
@@ -992,7 +992,7 @@ RealDescriptor::convertToNativeFormat (Real*                 out,
 
     while (nitems > 0)
     {
-        Long get = nitems > Long(readBufferSize) ? Long(readBufferSize) : nitems;
+        int get = nitems > readBufferSize ? readBufferSize : int(nitems);
         is.read(bufr, id.numBytes()*get);
         PD_convert(out,
                    bufr,
@@ -1062,7 +1062,7 @@ RealDescriptor::convertFromNativeFormat (std::ostream&         os,
 
     while (nitems > 0)
     {
-        Long put = nitems > Long(writeBufferSize) ? Long(writeBufferSize) : nitems;
+        int put = nitems > writeBufferSize ? writeBufferSize : int(nitems);
         PD_convert(bufr,
                    in,
                    put,
@@ -1104,7 +1104,7 @@ RealDescriptor::convertFromNativeFloatFormat (std::ostream&         os,
 
     while (nitems > 0)
     {
-        Long put = nitems > Long(writeBufferSize) ? Long(writeBufferSize) : nitems;
+        int put = nitems > writeBufferSize ? writeBufferSize : int(nitems);
         PD_convert(bufr,
                    in,
                    put,
@@ -1146,7 +1146,7 @@ RealDescriptor::convertFromNativeDoubleFormat (std::ostream&         os,
 
     while (nitems > 0)
     {
-        Long put = nitems > Long(writeBufferSize) ? Long(writeBufferSize) : nitems;
+        int put = nitems > writeBufferSize ? writeBufferSize : int(nitems);
         PD_convert(bufr,
                    in,
                    put,
@@ -1180,7 +1180,7 @@ RealDescriptor::convertToNativeFloatFormat (float*                out,
 
     while (nitems > 0)
     {
-        Long get = nitems > Long(readBufferSize) ? Long(readBufferSize) : nitems;
+        int get = nitems > readBufferSize ? readBufferSize : int(nitems);
         is.read(bufr, id.numBytes()*get);
         PD_convert(out,
                    bufr,
@@ -1222,7 +1222,7 @@ RealDescriptor::convertToNativeDoubleFormat (double*               out,
 
     while (nitems > 0)
     {
-        Long get = nitems > Long(readBufferSize) ? Long(readBufferSize) : nitems;
+        int get = nitems > readBufferSize ? readBufferSize : int(nitems);
         is.read(bufr, id.numBytes()*get);
         PD_convert(out,
                    bufr,

--- a/Src/Base/AMReX_FabConv.cpp
+++ b/Src/Base/AMReX_FabConv.cpp
@@ -992,7 +992,7 @@ RealDescriptor::convertToNativeFormat (Real*                 out,
 
     while (nitems > 0)
     {
-        int get = int(nitems) > readBufferSize ? readBufferSize : int(nitems);
+        int get = Long(nitems) > readBufferSize ? readBufferSize : int(nitems);
         is.read(bufr, id.numBytes()*get);
         PD_convert(out,
                    bufr,
@@ -1062,7 +1062,7 @@ RealDescriptor::convertFromNativeFormat (std::ostream&         os,
 
     while (nitems > 0)
     {
-        int put = int(nitems) > writeBufferSize ? writeBufferSize : int(nitems);
+        Long put = nitems > Long(writeBufferSize) ? Long(writeBufferSize) : nitems;
         PD_convert(bufr,
                    in,
                    put,
@@ -1104,7 +1104,7 @@ RealDescriptor::convertFromNativeFloatFormat (std::ostream&         os,
 
     while (nitems > 0)
     {
-        int put = int(nitems) > writeBufferSize ? writeBufferSize : int(nitems);
+        Long put = nitems > Long(writeBufferSize) ? Long(writeBufferSize) : nitems;
         PD_convert(bufr,
                    in,
                    put,
@@ -1146,7 +1146,7 @@ RealDescriptor::convertFromNativeDoubleFormat (std::ostream&         os,
 
     while (nitems > 0)
     {
-        int put = int(nitems) > writeBufferSize ? writeBufferSize : int(nitems);
+        Long put = nitems > Long(writeBufferSize) ? Long(writeBufferSize) : nitems;
         PD_convert(bufr,
                    in,
                    put,
@@ -1180,7 +1180,7 @@ RealDescriptor::convertToNativeFloatFormat (float*                out,
 
     while (nitems > 0)
     {
-        int get = int(nitems) > readBufferSize ? readBufferSize : int(nitems);
+        Long get = nitems > Long(readBufferSize) ? Long(readBufferSize) : nitems;
         is.read(bufr, id.numBytes()*get);
         PD_convert(out,
                    bufr,
@@ -1222,7 +1222,7 @@ RealDescriptor::convertToNativeDoubleFormat (double*               out,
 
     while (nitems > 0)
     {
-        int get = int(nitems) > readBufferSize ? readBufferSize : int(nitems);
+        Long get = nitems > Long(readBufferSize) ? Long(readBufferSize) : nitems;
         is.read(bufr, id.numBytes()*get);
         PD_convert(out,
                    bufr,

--- a/Src/Base/AMReX_FabConv.cpp
+++ b/Src/Base/AMReX_FabConv.cpp
@@ -992,7 +992,7 @@ RealDescriptor::convertToNativeFormat (Real*                 out,
 
     while (nitems > 0)
     {
-        int get = Long(nitems) > readBufferSize ? readBufferSize : int(nitems);
+        Long get = nitems > Long(readBufferSize) ? Long(readBufferSize) : nitems;
         is.read(bufr, id.numBytes()*get);
         PD_convert(out,
                    bufr,

--- a/Src/Particle/AMReX_WriteBinaryParticleData.H
+++ b/Src/Particle/AMReX_WriteBinaryParticleData.H
@@ -150,14 +150,14 @@ packIOData (Vector<int>& idata, Vector<ParticleReal>& rdata, const PC& pc, int l
     for (int i = 0; i < pc.NumIntComps() + PC::NStructInt; ++i)
         if (write_int_comp[i]) ++num_output_int;
 
-    const int iChunkSize = 2 + num_output_int;
+    const Long iChunkSize = 2 + num_output_int;
     idata.resize(np*iChunkSize);
 
     int num_output_real = 0;
     for (int i = 0; i < pc.NumRealComps() + PC::NStructReal; ++i)
         if (write_real_comp[i]) ++num_output_real;
 
-    const int rChunkSize = AMREX_SPACEDIM + num_output_real;
+    const Long rChunkSize = AMREX_SPACEDIM + num_output_real;
     rdata.resize(np*rChunkSize);
 
     typename PC::IntVector  idata_d(idata.size());
@@ -241,14 +241,14 @@ packIOData (Vector<int>& idata, Vector<ParticleReal>& rdata, const PC& pc, int l
     for (int i = 0; i < pc.NumIntComps() + PC::NStructInt; ++i)
         if (write_int_comp[i]) ++num_output_int;
 
-    const int iChunkSize = 2 + num_output_int;
+    const Long iChunkSize = 2 + num_output_int;
     idata.resize(np*iChunkSize);
 
     int num_output_real = 0;
     for (int i = 0; i < pc.NumRealComps() + PC::NStructReal; ++i)
         if (write_real_comp[i]) ++num_output_real;
 
-    const int rChunkSize = AMREX_SPACEDIM + num_output_real;
+    const Long rChunkSize = AMREX_SPACEDIM + num_output_real;
     rdata.resize(np*rChunkSize);
 
     int* iptr = idata.dataPtr();
@@ -882,7 +882,7 @@ void WriteBinaryParticleDataAsync (PC const& pc,
                 for (int i = 0; i < nic + NStructInt; ++i)
                     if (write_int_comp[i]) ++num_output_int;
 
-                const int iChunkSize = 2 + num_output_int;
+                const Long iChunkSize = 2 + num_output_int;
                 Vector<int> istuff(np_per_grid_local[lev][grid]*iChunkSize);
                 int* iptr = istuff.dataPtr();
 
@@ -931,7 +931,7 @@ void WriteBinaryParticleDataAsync (PC const& pc,
                 for (int i = 0; i < nrc + NStructReal; ++i)
                     if (write_real_comp[i]) ++num_output_real;
 
-                const int rChunkSize = AMREX_SPACEDIM + num_output_real;
+                const Long rChunkSize = AMREX_SPACEDIM + num_output_real;
                 Vector<typename PC::ParticleType::RealType> rstuff(np_per_grid_local[lev][grid]*rChunkSize);
                 typename PC::ParticleType::RealType* rptr = rstuff.dataPtr();
 


### PR DESCRIPTION
This fixes two IO bugs that have to do with integer overflow. 

1. In AMReX_WriteBinaryParticleData.H, the number of reals numbers written to disk can overflow an `int` even if the number of particles on a box doesn't. This fixes this behavior. 

2. The AMReX_FabConv.cpp, the conversion functions take a `Long` specifying the number of objects to convert. However, this number is inappropriately cast to int before checking its size. This PR fixes this as well. 

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
