### PR TITLE
Restore RedistributeLocal() call to InitParticles in redistribute test (removed in #2414)

### DIFF
--- a/Tests/Particles/Redistribute/main.cpp
+++ b/Tests/Particles/Redistribute/main.cpp
@@ -175,6 +175,8 @@ public:
 
             Gpu::synchronize();
         }
+
+        RedistributeLocal();
     }
 
     void moveParticles (const IntVect& move_dir, int do_random)


### PR DESCRIPTION
This is needed in the versions of these tests with mesh refinement: https://ccse.lbl.gov/pub/GpuRegressionTesting/AMReX/2021-10-20/index.html

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
