### PR TITLE
Set options to allow other Doxygen docs to link to AMReX.

### DIFF
--- a/Docs/Doxygen/doxygen.conf
+++ b/Docs/Doxygen/doxygen.conf
@@ -44,14 +44,14 @@ PROJECT_NUMBER         =
 # for a project that appears at the top of each page and should give viewer a
 # quick idea about the purpose of the project. Keep the description short.
 
-PROJECT_BRIEF          = "Block-Structured AMR Software Framework" 
+PROJECT_BRIEF          = "Block-Structured AMR Software Framework"
 
 # With the PROJECT_LOGO tag one can specify a logo or an icon that is included
 # in the documentation. The maximum height of the logo should not exceed 55
 # pixels and the maximum width should not exceed 200 pixels. Doxygen will copy
 # the logo to the output directory.
 
-PROJECT_LOGO           = "./resize_AMReX_logo.png" 
+PROJECT_LOGO           = "./resize_AMReX_logo.png"
 
 # The OUTPUT_DIRECTORY tag is used to specify the (relative or absolute) path
 # into which the generated documentation will be written. If a relative path is
@@ -328,7 +328,7 @@ AUTOLINK_SUPPORT       = YES
 # diagrams that involve STL classes more complete and accurate.
 # The default value is: NO.
 
-BUILTIN_STL_SUPPORT    = NO
+BUILTIN_STL_SUPPORT    = YES
 
 # If you use Microsoft's C++/CLI language, you should set this option to YES to
 # enable parsing support.
@@ -2099,7 +2099,7 @@ TAGFILES               =
 # tag file that is based on the input files it reads. See section "Linking to
 # external documentation" for more information about the usage of tag files.
 
-GENERATE_TAGFILE       =
+GENERATE_TAGFILE       = amrex-doxygen-web.tag.xml
 
 # If the ALLEXTERNALS tag is set to YES, all external class will be listed in
 # the class index. If set to NO, only the inherited external classes will be

--- a/build_docs.sh
+++ b/build_docs.sh
@@ -25,6 +25,8 @@ mkdir -p docs_html/doxygen
 cp -rp ../Docs/Doxygen/html/* docs_html/doxygen/
 mkdir -p docs_xml/doxygen
 cp -rp ../Docs/Doxygen/xml/* docs_xml/doxygen/
+# add tagfile to allow other docs to interlink with amrex
+cp ../Docs/Doxygen/amrex-doxygen-web.tag.xml docs_xml/doxygen/.
 
 # add sphinx
 cp -rp ../Docs/sphinx_documentation/build/html/* docs_html/


### PR DESCRIPTION
## Summary

Change doxygen.conf options to allow outside documentation to link with AMReX.

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
