### PR TITLE
Multi-component overset solver

### DIFF
--- a/Src/LinearSolvers/MLMG/AMReX_MLABecLaplacian.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLABecLaplacian.H
@@ -28,7 +28,8 @@ public:
                      const Vector<DistributionMapping>& a_dmap,
                      const Vector<iMultiFab const*>& a_overset_mask, // 1: unknown, 0: known
                      const LPInfo& a_info = LPInfo(),
-                     const Vector<FabFactory<FArrayBox> const*>& a_factory = {});
+                     const Vector<FabFactory<FArrayBox> const*>& a_factory = {},
+                     const int a_ncomp = 1);
 
     virtual ~MLABecLaplacian ();
 
@@ -41,14 +42,16 @@ public:
                  const Vector<BoxArray>& a_grids,
                  const Vector<DistributionMapping>& a_dmap,
                  const LPInfo& a_info = LPInfo(),
-                 const Vector<FabFactory<FArrayBox> const*>& a_factory = {});
+                 const Vector<FabFactory<FArrayBox> const*>& a_factory = {},
+                 const int a_ncomp = 1);
 
     void define (const Vector<Geometry>& a_geom,
                  const Vector<BoxArray>& a_grids,
                  const Vector<DistributionMapping>& a_dmap,
                  const Vector<iMultiFab const*>& a_overset_mask,
                  const LPInfo& a_info = LPInfo(),
-                 const Vector<FabFactory<FArrayBox> const*>& a_factory = {});
+                 const Vector<FabFactory<FArrayBox> const*>& a_factory = {},
+                 const int a_ncomp = 1);
 
     void setScalars (Real a, Real b) noexcept;
     void setACoeffs (int amrlev, const MultiFab& alpha);

--- a/Src/LinearSolvers/MLMG/AMReX_MLABecLaplacian.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLABecLaplacian.cpp
@@ -12,9 +12,8 @@ MLABecLaplacian::MLABecLaplacian (const Vector<Geometry>& a_geom,
                                   const LPInfo& a_info,
                                   const Vector<FabFactory<FArrayBox> const*>& a_factory,
                                   const int a_ncomp)
-    : m_ncomp(a_ncomp)
 {
-    define(a_geom, a_grids, a_dmap, a_info, a_factory);
+    define(a_geom, a_grids, a_dmap, a_info, a_factory, a_ncomp);
 }
 
 MLABecLaplacian::MLABecLaplacian (const Vector<Geometry>& a_geom,
@@ -22,9 +21,10 @@ MLABecLaplacian::MLABecLaplacian (const Vector<Geometry>& a_geom,
                                   const Vector<DistributionMapping>& a_dmap,
                                   const Vector<iMultiFab const*>& a_overset_mask,
                                   const LPInfo& a_info,
-                                  const Vector<FabFactory<FArrayBox> const*>& a_factory)
+                                  const Vector<FabFactory<FArrayBox> const*>& a_factory,
+                                  const int a_ncomp)
 {
-    define(a_geom, a_grids, a_dmap, a_overset_mask, a_info, a_factory);
+    define(a_geom, a_grids, a_dmap, a_overset_mask, a_info, a_factory, a_ncomp);
 }
 
 void
@@ -32,9 +32,11 @@ MLABecLaplacian::define (const Vector<Geometry>& a_geom,
                          const Vector<BoxArray>& a_grids,
                          const Vector<DistributionMapping>& a_dmap,
                          const LPInfo& a_info,
-                         const Vector<FabFactory<FArrayBox> const*>& a_factory)
+                         const Vector<FabFactory<FArrayBox> const*>& a_factory,
+                         const int a_ncomp)
 {
     BL_PROFILE("MLABecLaplacian::define()");
+    m_ncomp = a_ncomp;
     MLCellABecLap::define(a_geom, a_grids, a_dmap, a_info, a_factory);
     define_ab_coeffs();
 }
@@ -45,9 +47,11 @@ MLABecLaplacian::define (const Vector<Geometry>& a_geom,
                          const Vector<DistributionMapping>& a_dmap,
                          const Vector<iMultiFab const*>& a_overset_mask,
                          const LPInfo& a_info,
-                         const Vector<FabFactory<FArrayBox> const*>& a_factory)
+                         const Vector<FabFactory<FArrayBox> const*>& a_factory,
+                         const int a_ncomp)
 {
     BL_PROFILE("MLABecLaplacian::define(overset)");
+    m_ncomp = a_ncomp;
     MLCellABecLap::define(a_geom, a_grids, a_dmap, a_overset_mask, a_info, a_factory);
     define_ab_coeffs();
 }


### PR DESCRIPTION
Modify cell-centered overset solver's constructor to allow for multiple
components.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
