### PR TITLE
MLNodeLaplacian: Fix max coarsening level for enclosed EB

### DIFF
--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian.H
@@ -164,6 +164,10 @@ public :
                           Real* const rhs, Array4<Real const> const& bfab) const override;
 #endif
 
+protected:
+
+    virtual void resizeMultiGrid (int new_size) override final;
+
 private:
 
     int m_is_rz = 0;

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian.cpp
@@ -124,6 +124,30 @@ MLNodeLaplacian::define (const Vector<Geometry>& a_geom,
 #endif
 
 void
+MLNodeLaplacian::resizeMultiGrid (int new_size)
+{
+    if (!   m_sigma.empty()) {
+        if (m_sigma[0].size() > new_size) {
+            m_sigma[0].resize(new_size);
+        }
+    }
+
+    if (!   m_stencil.empty()) {
+        if (m_stencil[0].size() > new_size) {
+            m_stencil[0].resize(new_size);
+        }
+    }
+
+    if (!   m_s0_norm0.empty()) {
+        if (m_s0_norm0[0].size() > new_size) {
+            m_s0_norm0[0].resize(new_size);
+        }
+    }
+
+    MLNodeLinOp::resizeMultiGrid(new_size);
+}
+
+void
 MLNodeLaplacian::unimposeNeumannBC (int amrlev, MultiFab& rhs) const
 {
     if (m_coarsening_strategy == CoarseningStrategy::RAP) {

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian_sten.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian_sten.cpp
@@ -226,9 +226,6 @@ MLNodeLaplacian::buildStencil ()
         }
     }
 
-    // This is only needed at the bottom.
-    m_s0_norm0[0].back() = m_stencil[0].back()->norm0(0,0) * m_normalization_threshold;
-
 #ifdef AMREX_USE_EB
     for (int amrlev = 0; amrlev < m_num_amr_levels; ++amrlev) {
         for (int mglev = 0; mglev < m_num_mg_levels[amrlev]; ++mglev) {
@@ -266,6 +263,21 @@ MLNodeLaplacian::buildStencil ()
     }
 #endif
 
+#ifdef AMREX_USE_EB
+    int max_eb_level = 0;
+    for (int mglev = m_num_mg_levels[0]-1; mglev > 0; --mglev) {
+        int mlo = m_dirichlet_mask[0][mglev]->min(0);
+        if (!mlo) {
+            // This level is good because not every nodes are Dirichlet.
+            max_eb_level = mglev;
+            break;
+        }
+    }
+    if (max_eb_level+1 < m_num_mg_levels[0]) {
+        resizeMultiGrid(max_eb_level+1);
+    }
+#endif
+
     {
         int amrlev = 0;
         int mglev = m_num_mg_levels[amrlev]-1;
@@ -296,6 +308,9 @@ MLNodeLaplacian::buildStencil ()
     }
 
     Gpu::synchronize();
+
+    // This is only needed at the bottom.
+    m_s0_norm0[0].back() = m_stencil[0].back()->norm0(0,0) * m_normalization_threshold;
 }
 
 }


### PR DESCRIPTION
Where the domain is fully enclosed by EB, we need to make sure that it does
not coarsen too much that there are no valid nodes left.

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
