### PR TITLE
Tests: Safe-Guard Module Dirs

### DIFF
--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -72,11 +72,11 @@ function (setup_test _srcs  _inputs)
    if (_HAS_FORTRAN_MODULES)
       target_include_directories(${_exe_name}
          PRIVATE
-         ${CMAKE_CURRENT_BINARY_DIR}/mod_files)
+         ${CMAKE_CURRENT_BINARY_DIR}/${_exe_name}_mod_files)
       set_target_properties( ${_exe_name}
          PROPERTIES
          Fortran_MODULE_DIRECTORY
-         ${CMAKE_CURRENT_BINARY_DIR}/mod_files )
+         ${CMAKE_CURRENT_BINARY_DIR}/${_exe_name}_mod_files )
    endif ()
 
    target_link_libraries( ${_exe_name} AMReX::amrex )


### PR DESCRIPTION
## Summary

Make sure Fortran `mod_file` dirs are per executable. Avoid potential race conditions if people use the `setup_test` in loops in funny ways.

## Additional background

This should fix a collision of module names in `Tests/Amr/Advection_AmrLevel` which writes the same executable in two base names.

Similar to #1112

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
