### PR TITLE
Update MPI config checking to include Intel MPI wrappers for DPCPP

### DIFF
--- a/Tools/GNUMake/Make.defs
+++ b/Tools/GNUMake/Make.defs
@@ -1016,10 +1016,6 @@ FINAL_LIBS = $(libraries)
 
 ifeq ($(USE_DPCPP),TRUE)
 
-    ifeq ($(USE_MPI),TRUE)
-        CXXFLAGS += -cxx=dpcpp
-    endif
-
 else ifeq ($(USE_HIP),TRUE)
 
     LINKFLAGS = $(HIPCC_FLAGS)

--- a/Tools/GNUMake/Make.defs
+++ b/Tools/GNUMake/Make.defs
@@ -42,8 +42,6 @@ ifeq ($(USE_DPCPP),TRUE)
   USE_HIP := FALSE
   # disable ccache for now
   USE_CCACHE := FALSE
-  # Make.unknown's mpi checking does not work with mpiicpc
-  NO_MPI_CHECKING := TRUE
   ifdef USE_ONEDPL
     USE_ONEDPL := $(strip $(USE_ONEDPL))
   else
@@ -1019,10 +1017,6 @@ FINAL_LIBS = $(libraries)
 ifeq ($(USE_DPCPP),TRUE)
 
     ifeq ($(USE_MPI),TRUE)
-        CC  = mpiicc
-        CXX = mpiicpc
-        FC  = mpiifort
-        F90 = mpiifort
         CXXFLAGS += -cxx=dpcpp
     endif
 

--- a/Tools/GNUMake/sites/Make.unknown
+++ b/Tools/GNUMake/sites/Make.unknown
@@ -4,6 +4,17 @@
 
 os_type := $(shell uname)
 
+ifeq ($(USE_DPCPP),TRUE)
+   ifeq ($(shell mpiicpc -show > /dev/null 2>&1; echo $$?), 0)
+      CC  := mpiicc
+      CXX := mpiicpc
+      FC  := mpiifort
+      F90 := mpiifort
+      CXXFLAGS += -cxx=dpcpp
+      NO_MPI_CHECKING = TRUE
+   endif
+endif
+
 ifneq ($(NO_CONFIG_CHECKING),TRUE)
 
 ifneq ($(NO_MPI_CHECKING),TRUE)
@@ -13,17 +24,6 @@ ifeq ($(USE_MPI),TRUE)
   CC  := mpicc
   FC  := mpif90
   F90 := mpif90
-
-  ifeq ($(USE_DPCPP),TRUE)
-     ifneq ($(findstring icpc, $(shell mpiicpc -show 2>&1)),)
-         CC  := mpiicc
-         CXX := mpiicpc
-         FC  := mpiifort
-         F90 := mpiifort
-         mpicxx_link_libs := -lmpi
-     endif
-  endif
-
 
   ifeq ($(LINK_WITH_FORTRAN_COMPILER),TRUE)
     MPI_OTHER_COMP := mpicxx

--- a/Tools/GNUMake/sites/Make.unknown
+++ b/Tools/GNUMake/sites/Make.unknown
@@ -14,6 +14,17 @@ ifeq ($(USE_MPI),TRUE)
   FC  := mpif90
   F90 := mpif90
 
+  ifeq ($(USE_DPCPP),TRUE)
+     ifneq ($(findstring icpc, $(shell mpiicpc -show 2>&1)),)
+         CC  := mpiicc
+         CXX := mpiicpc
+         FC  := mpiifort
+         F90 := mpiifort
+         mpicxx_link_libs := -lmpi
+     endif
+  endif
+
+
   ifeq ($(LINK_WITH_FORTRAN_COMPILER),TRUE)
     MPI_OTHER_COMP := mpicxx
   else


### PR DESCRIPTION
## Summary

For Make.unknown, if USE_DPCC=TRUE and mpiicpc is found with icpc as the compiler, use Intel MPI wrappers. Otherwise use mpicxx, etc

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
