### PR TITLE
DPCPP: Fix warning on tautological-constant-compare

### DIFF
--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -11,8 +11,7 @@ jobs:
     name: DPCPP GFortran@7.5 C++17 [tests]
     runs-on: ubuntu-20.04
     # mkl/rng/device/detail/mrg32k3a_impl.hpp has a number of sign-compare error
-    # Since 2021.4.0, AMReX_GpuUtility.H: error: comparison with NaN always evaluates to false in fast floating point modes
-    env: {CXXFLAGS: "-fno-operator-names -Werror -Wall -Wextra -Wpedantic -Wnull-dereference -Wfloat-conversion -Wshadow -Woverloaded-virtual -Wextra-semi -Wunreachable-code -Wno-sign-compare -Wno-tautological-constant-compare"}
+    env: {CXXFLAGS: "-fno-operator-names -Werror -Wall -Wextra -Wpedantic -Wnull-dereference -Wfloat-conversion -Wshadow -Woverloaded-virtual -Wextra-semi -Wunreachable-code -Wno-sign-compare"}
     steps:
     - uses: actions/checkout@v2
     - name: Dependencies

--- a/Tools/CMake/AMReXSYCL.cmake
+++ b/Tools/CMake/AMReXSYCL.cmake
@@ -62,6 +62,13 @@ target_compile_options( SYCL
    INTERFACE
    $<${_cxx_dpcpp}:-fno-sycl-early-optimizations>)
 
+# disable warning: comparison with infinity always evaluates to false in fast floating point modes [-Wtautological-constant-compare]
+#                  return std::isinf(m);
+# appeared since 2021.4.0
+target_compile_options( SYCL
+   INTERFACE
+   $<${_cxx_dpcpp}:-Wno-tautological-constant-compare>)
+
 # Need this option to compile with mpiicpc
 if (AMReX_MPI)
   target_compile_options( SYCL

--- a/Tools/GNUMake/comps/dpcpp.mak
+++ b/Tools/GNUMake/comps/dpcpp.mak
@@ -54,6 +54,11 @@ ifeq ($(WARN_ALL),TRUE)
   CFLAGS += $(warning_flags)
 endif
 
+# disable warning: comparison with infinity always evaluates to false in fast floating point modes [-Wtautological-constant-compare]
+#                  return std::isinf(m);
+# appeared since 2021.4.0
+CXXFLAGS += -Wno-tautological-constant-compare
+
 ifeq ($(WARN_ERROR),TRUE)
   CXXFLAGS += -Werror
   CFLAGS += -Werror


### PR DESCRIPTION
Disable warning on tautological constant compare that has appeared since
2021.04.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
