### PR TITLE
DPCPP: Use -g1 for non-debug build

### DIFF
--- a/Tools/GNUMake/comps/dpcpp.mak
+++ b/Tools/GNUMake/comps/dpcpp.mak
@@ -29,10 +29,8 @@ ifeq ($(DEBUG),TRUE)
 
 else
 
-  CXXFLAGS += -O3 # // xxxx DPCPP: todo -g in beta6 causes a lot of warning messages
-  CFLAGS   += -O3 #                       and makes linking much slower
-#  CXXFLAGS += -g -O3
-#  CFLAGS   += -g -O3
+  CXXFLAGS += -g1 -O3 # // xxxx DPCPP: todo -g in beta6 causes a lot of warning messages
+  CFLAGS   += -g1 -O3 #                       and makes linking much slower
   FFLAGS   += -g -O3
   F90FLAGS += -g -O3
 


### PR DESCRIPTION
Because `-g` makes link extremely slow, we have disabled that in GNU make
since oneAPI beta6.  It turns out we could still use `-g1` to get some basic
debug information without slowing down link too much.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
