### PR TITLE
GNU Make: Fix rpath when LIBRARY_LOCATION is empty.

### DIFF
--- a/Tools/GNUMake/Make.defs
+++ b/Tools/GNUMake/Make.defs
@@ -879,7 +879,7 @@ CPPFLAGS	+= $(DEFINES)
 libraries	= $(XTRAOBJS) $(LIBRARIES) $(XTRALIBS)
 
 ifeq ($(USE_RPATH),TRUE)
-  LDFLAGS	+= -Xlinker -rpath='$(abspath .)' $(addprefix -Xlinker -rpath=, '$(abspath $(LIBRARY_LOCATIONS))')
+  LDFLAGS	+= -Xlinker -rpath='$(abspath .)' $(addprefix -Xlinker -rpath=, $(abspath $(LIBRARY_LOCATIONS)))
 endif
 LDFLAGS	+= -L. $(addprefix -L, $(LIBRARY_LOCATIONS))
 


### PR DESCRIPTION
Because of #2439, empty LIBRARY_LOCATION would result in

    -Xlinker -rpath=''

We would like to avoid that.

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
