### PR TITLE
Fix use-after-free

### DIFF
--- a/Src/Base/AMReX_FabArrayBase.cpp
+++ b/Src/Base/AMReX_FabArrayBase.cpp
@@ -555,12 +555,16 @@ FabArrayBase::flushCPC (bool no_assertion) const
 void
 FabArrayBase::flushCPCache ()
 {
+    std::vector<CPC*> cpcs;
     for (CPCacheIter it = m_TheCPCache.begin(); it != m_TheCPCache.end(); ++it)
     {
         if (it->first == it->second->m_srcbdk) {
             m_CPC_stats.recordErase(it->second->m_nuse);
-            delete it->second;
+            cpcs.push_back(it->second);
         }
+    }
+    for (auto& c : cpcs) {
+        delete c;
     }
     m_TheCPCache.clear();
 #ifdef AMREX_MEM_PROFILING
@@ -611,8 +615,9 @@ FabArrayBase::getCPC (const IntVect& dstng, const FabArrayBase& src, const IntVe
     m_CPC_stats.recordUse();
 
     m_TheCPCache.insert(er_it.second, CPCache::value_type(dstkey,new_cpc));
-    if (srckey != dstkey)
+    if (srckey != dstkey) {
         m_TheCPCache.insert(          CPCache::value_type(srckey,new_cpc));
+    }
 
     return *new_cpc;
 }


### PR DESCRIPTION
The parallel copy meta-data cache is store in std::multimap<BDKey,CPC*>.  A
CPC* might be stored multiple times in the multimap, and we need to delete
the pointers before clearing the multimap.  The previous way of avoiding
double free was incorrect, because it had a use-after-free.  In this commit,
we fix it by pushing a unique copy of the pointers to a vector first while
iterating the multimap.

This bug only manifests if a user's code has a memory leak of
MultiFab/FabArray.

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
