### PR TITLE
WIP : Implementation of MLPoisson::Fsmooth using ParallelFor(MultiFab)

### DIFF
--- a/Src/LinearSolvers/MLMG/AMReX_MLPoisson_1D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLPoisson_1D_K.H
@@ -91,26 +91,74 @@ void mlpoisson_flux_xface_m (Box const& box, Array4<Real> const& fx,
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-void mlpoisson_gsrb (Box const& box, Array4<Real> const& phi, Array4<Real const> const& rhs,
+void mlpoisson_gsrb (int i, int, int, Array4<Real> const& phi, Array4<Real const> const& rhs,
                      Real dhx,
                      Array4<Real const> const& f0, Array4<int const> const& m0,
                      Array4<Real const> const& f1, Array4<int const> const& m1,
                      Box const& vbox, int redblack) noexcept
 {
-    const auto lo = amrex::lbound(box);
-    const auto hi = amrex::ubound(box);
     const auto vlo = amrex::lbound(vbox);
     const auto vhi = amrex::ubound(vbox);
 
     Real gamma = -dhx*Real(2.0);
 
+    if ((i+redblack)%2 == 0) {
+        Real cf0=Real(0.0);
+        Real cf1=Real(0.0);
+        if (i==vlo.x) {
+            cf0 = m0(vlo.x-1,0,0) > 0 ? f0(vlo.x,0,0) : cf0;
+        } else if (i == vhi.x) {
+            cf1 = m1(vhi.x+1,0,0) > 0 ? f1(vhi.x,0,0) : cf1;
+        }
+
+        Real g_m_d = gamma + dhx*(cf0+cf1);
+
+        Real res = rhs(i,0,0) - gamma*phi(i,0,0)
+            - dhx*(phi(i-1,0,0) + phi(i+1,0,0));
+
+        phi(i,0,0) = phi(i,0,0) + res /g_m_d;
+    }
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void mlpoisson_gsrb_wrapper (Box const& box, Array4<Real> const& phi, Array4<Real const> const& rhs,
+                             Real dhx,
+                             Array4<Real const> const& f0, Array4<int const> const& m0,
+                             Array4<Real const> const& f1, Array4<int const> const& m1,
+                             Box const& vbox, int redblack) noexcept
+{
+    const auto lo = amrex::lbound(box);
+    const auto hi = amrex::ubound(box);
+
     AMREX_PRAGMA_SIMD
     for (int i = lo.x; i <= hi.x; ++i) {
-        if ((i+redblack)%2 == 0) {
-            Real cf0 = (i == vlo.x && m0(vlo.x-1,0,0) > 0)
-                ? f0(vlo.x,0,0) : Real(0.0);
-            Real cf1 = (i == vhi.x && m1(vhi.x+1,0,0) > 0)
-                ? f1(vhi.x,0,0) : Real(0.0);
+        mlpoisson_gsrb(i, 0, 0, phi, rhs, dhx, f0, m0, f1, m1, vbox, redblack);
+    }
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void mlpoisson_gsrb_os (int i, int, int, Array4<Real> const& phi, Array4<Real const> const& rhs,
+                        Array4<int const> const& osm, Real dhx,
+                        Array4<Real const> const& f0, Array4<int const> const& m0,
+                        Array4<Real const> const& f1, Array4<int const> const& m1,
+                        Box const& vbox, int redblack) noexcept
+{
+    const auto vlo = amrex::lbound(vbox);
+    const auto vhi = amrex::ubound(vbox);
+
+    Real gamma = -dhx*Real(2.0);
+
+    if ((i+redblack)%2 == 0) {
+        if (osm(i,0,0) == 0) {
+            phi(i,0,0) = Real(0.0);
+        } else {
+            Real cf0=Real(0.0);
+            Real cf1=Real(0.0);
+            if (i==vlo.x) {
+                cf0 = m0(vlo.x-1,0,0) > 0 ? f0(vlo.x,0,0) : cf0;
+            } else if (i == vhi.x) {
+                cf1 = m1(vhi.x+1,0,0) > 0 ? f1(vhi.x,0,0) : cf1;
+            }
 
             Real g_m_d = gamma + dhx*(cf0+cf1);
 
@@ -123,73 +171,67 @@ void mlpoisson_gsrb (Box const& box, Array4<Real> const& phi, Array4<Real const>
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-void mlpoisson_gsrb_os (Box const& box, Array4<Real> const& phi, Array4<Real const> const& rhs,
-                        Array4<int const> const& osm, Real dhx,
-                        Array4<Real const> const& f0, Array4<int const> const& m0,
-                        Array4<Real const> const& f1, Array4<int const> const& m1,
-                        Box const& vbox, int redblack) noexcept
+void mlpoisson_gsrb_os_wrapper (Box const& box, Array4<Real> const& phi, Array4<Real const> const& rhs,
+                                Array4<int const> const& osm, Real dhx,
+                                Array4<Real const> const& f0, Array4<int const> const& m0,
+                                Array4<Real const> const& f1, Array4<int const> const& m1,
+                                Box const& vbox, int redblack) noexcept
 {
     const auto lo = amrex::lbound(box);
     const auto hi = amrex::ubound(box);
-    const auto vlo = amrex::lbound(vbox);
-    const auto vhi = amrex::ubound(vbox);
-
-    Real gamma = -dhx*Real(2.0);
 
     AMREX_PRAGMA_SIMD
     for (int i = lo.x; i <= hi.x; ++i) {
-        if ((i+redblack)%2 == 0) {
-            if (osm(i,0,0) == 0) {
-                phi(i,0,0) = Real(0.0);
-            } else {
-                Real cf0 = (i == vlo.x && m0(vlo.x-1,0,0) > 0)
-                    ? f0(vlo.x,0,0) : Real(0.0);
-                Real cf1 = (i == vhi.x && m1(vhi.x+1,0,0) > 0)
-                    ? f1(vhi.x,0,0) : Real(0.0);
-
-                Real g_m_d = gamma + dhx*(cf0+cf1);
-
-                Real res = rhs(i,0,0) - gamma*phi(i,0,0)
-                    - dhx*(phi(i-1,0,0) + phi(i+1,0,0));
-
-                phi(i,0,0) = phi(i,0,0) + res /g_m_d;
-            }
-        }
+        mlpoisson_gsrb_os(i, 0, 0, phi, rhs, osm, dhx, f0, m0, f1, m1, vbox, redblack);
     }
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-void mlpoisson_gsrb_m (Box const& box, Array4<Real> const& phi, Array4<Real const> const& rhs,
+void mlpoisson_gsrb_m (int i, int, int, Array4<Real> const& phi, Array4<Real const> const& rhs,
                        Real dhx,
                        Array4<Real const> const& f0, Array4<int const> const& m0,
                        Array4<Real const> const& f1, Array4<int const> const& m1,
                        Box const& vbox, int redblack, Real dx, Real probxlo) noexcept
 {
-    const auto lo = amrex::lbound(box);
-    const auto hi = amrex::ubound(box);
     const auto vlo = amrex::lbound(vbox);
     const auto vhi = amrex::ubound(vbox);
 
+    if ((i+redblack)%2 == 0) {
+        Real cf0=Real(0.0);
+        Real cf1=Real(0.0);
+        if (i==vlo.x) {
+            cf0 = m0(vlo.x-1,0,0) > 0 ? f0(vlo.x,0,0) : cf0;
+        } else if (i == vhi.x) {
+            cf1 = m1(vhi.x+1,0,0) > 0 ? f1(vhi.x,0,0) : cf1;
+        }
+
+        Real rel = (probxlo + i   *dx) * (probxlo + i   *dx);
+        Real rer = (probxlo +(i+1)*dx) * (probxlo +(i+1)*dx);
+
+        Real gamma = -dhx*(rel+rer);
+
+        Real g_m_d = gamma + dhx*(rel*cf0+rer*cf1);
+
+        Real res = rhs(i,0,0) - gamma*phi(i,0,0)
+            - dhx*(rel*phi(i-1,0,0) + rer*phi(i+1,0,0));
+
+        phi(i,0,0) = phi(i,0,0) + res /g_m_d;
+    }
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void mlpoisson_gsrb_m_wrapper (Box const& box, Array4<Real> const& phi, Array4<Real const> const& rhs,
+                               Real dhx,
+                               Array4<Real const> const& f0, Array4<int const> const& m0,
+                               Array4<Real const> const& f1, Array4<int const> const& m1,
+                               Box const& vbox, int redblack, Real dx, Real probxlo) noexcept
+{
+    const auto lo = amrex::lbound(box);
+    const auto hi = amrex::ubound(box);
+
     AMREX_PRAGMA_SIMD
     for (int i = lo.x; i <= hi.x; ++i) {
-        if ((i+redblack)%2 == 0) {
-            Real cf0 = (i == vlo.x && m0(vlo.x-1,0,0) > 0)
-                ? f0(vlo.x,0,0) : Real(0.0);
-            Real cf1 = (i == vhi.x && m1(vhi.x+1,0,0) > 0)
-                ? f1(vhi.x,0,0) : Real(0.0);
-
-            Real rel = (probxlo + i   *dx) * (probxlo + i   *dx);
-            Real rer = (probxlo +(i+1)*dx) * (probxlo +(i+1)*dx);
-
-            Real gamma = -dhx*(rel+rer);
-
-            Real g_m_d = gamma + dhx*(rel*cf0+rer*cf1);
-
-            Real res = rhs(i,0,0) - gamma*phi(i,0,0)
-                - dhx*(rel*phi(i-1,0,0) + rer*phi(i+1,0,0));
-
-            phi(i,0,0) = phi(i,0,0) + res /g_m_d;
-        }
+        mlpoisson_gsrb_m(i, 0, 0, phi, rhs, dhx, f0, m0, f1, m1, vbox, redblack, dx, probxlo);
     }
 }
 
@@ -201,6 +243,7 @@ void mlpoisson_normalize (int i, int, int, Array4<Real> const& x,
     Real rer = (probxlo +(i+1)*dx) * (probxlo +(i+1)*dx);
     x(i,0,0) /= (-dhx*(rel+rer));
 }
+
 
 }
 

--- a/Src/LinearSolvers/MLMG/AMReX_MLPoisson_2D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLPoisson_2D_K.H
@@ -182,7 +182,7 @@ void mlpoisson_flux_yface_m (Box const& box, Array4<Real> const& fy,
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-void mlpoisson_gsrb (Box const& box, Array4<Real> const& phi, Array4<Real const> const& rhs,
+void mlpoisson_gsrb (int i, int j, int, Array4<Real> const& phi, Array4<Real const> const& rhs,
                      Real dhx, Real dhy,
                      Array4<Real const> const& f0, Array4<int const> const& m0,
                      Array4<Real const> const& f1, Array4<int const> const& m1,
@@ -190,40 +190,61 @@ void mlpoisson_gsrb (Box const& box, Array4<Real> const& phi, Array4<Real const>
                      Array4<Real const> const& f3, Array4<int const> const& m3,
                      Box const& vbox, int redblack) noexcept
 {
-    const auto lo = amrex::lbound(box);
-    const auto hi = amrex::ubound(box);
     const auto vlo = amrex::lbound(vbox);
     const auto vhi = amrex::ubound(vbox);
 
     Real gamma = Real(-2.0)*(dhx+dhy);
 
+    if ((i+j+redblack)%2 == 0) {
+        Real cf0=Real(0.0);
+        Real cf1=Real(0.0);
+        Real cf2=Real(0.0);
+        Real cf3=Real(0.0);
+        if (i==vlo.x) {
+            cf0 = m0(vlo.x-1,j,0) > 0 ? f0(vlo.x,j,0) : cf0;
+        } else if (i == vhi.x) {
+            cf2 = m2(vhi.x+1,j,0) > 0 ? f2(vhi.x,j,0) : cf2;
+        }
+        if (j==vlo.y) {
+            cf1 = m1(i,vlo.y-1,0) > 0 ? f1(i,vlo.y,0) : cf1;
+        } else if (j == vhi.y) {
+            cf3 = m3(i,vhi.y+1,0) > 0 ? f3(i,vhi.y,0) : cf3;
+        }
+
+        Real g_m_d = gamma + dhx*(cf0+cf2) + dhy*(cf1+cf3);
+
+        Real res = rhs(i,j,0) - gamma*phi(i,j,0)
+            - dhx*(phi(i-1,j,0) + phi(i+1,j,0))
+            - dhy*(phi(i,j-1,0) + phi(i,j+1,0));
+
+        phi(i,j,0) = phi(i,j,0) + res /g_m_d;
+    }
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void mlpoisson_gsrb_wrapper (Box const& box, Array4<Real> const& phi, Array4<Real const> const& rhs,
+                             Real dhx, Real dhy,
+                             Array4<Real const> const& f0, Array4<int const> const& m0,
+                             Array4<Real const> const& f1, Array4<int const> const& m1,
+                             Array4<Real const> const& f2, Array4<int const> const& m2,
+                             Array4<Real const> const& f3, Array4<int const> const& m3,
+                             Box const& vbox, int redblack) noexcept
+{
+    const auto lo = amrex::lbound(box);
+    const auto hi = amrex::ubound(box);
+
     for     (int j = lo.y; j <= hi.y; ++j) {
         AMREX_PRAGMA_SIMD
         for (int i = lo.x; i <= hi.x; ++i) {
-            if ((i+j+redblack)%2 == 0) {
-                Real cf0 = (i == vlo.x && m0(vlo.x-1,j,0) > 0)
-                    ? f0(vlo.x,j,0) : Real(0.0);
-                Real cf1 = (j == vlo.y && m1(i,vlo.y-1,0) > 0)
-                    ? f1(i,vlo.y,0) : Real(0.0);
-                Real cf2 = (i == vhi.x && m2(vhi.x+1,j,0) > 0)
-                    ? f2(vhi.x,j,0) : Real(0.0);
-                Real cf3 = (j == vhi.y && m3(i,vhi.y+1,0) > 0)
-                    ? f3(i,vhi.y,0) : Real(0.0);
-
-                Real g_m_d = gamma + dhx*(cf0+cf2) + dhy*(cf1+cf3);
-
-                Real res = rhs(i,j,0) - gamma*phi(i,j,0)
-                    - dhx*(phi(i-1,j,0) + phi(i+1,j,0))
-                    - dhy*(phi(i,j-1,0) + phi(i,j+1,0));
-
-                phi(i,j,0) = phi(i,j,0) + res /g_m_d;
-            }
+            mlpoisson_gsrb(i, j, 0, phi, rhs, dhx, dhy,
+                           f0, m0, f1, m1, f2, m2, f3, m3,
+                           vbox, redblack);
         }
     }
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-void mlpoisson_gsrb_os (Box const& box, Array4<Real> const& phi, Array4<Real const> const& rhs,
+void mlpoisson_gsrb_os (int i, int j, int, Array4<Real> const& phi, Array4<Real const> const& rhs,
                         Array4<int const> const& osm, Real dhx, Real dhy,
                         Array4<Real const> const& f0, Array4<int const> const& m0,
                         Array4<Real const> const& f1, Array4<int const> const& m1,
@@ -231,44 +252,65 @@ void mlpoisson_gsrb_os (Box const& box, Array4<Real> const& phi, Array4<Real con
                         Array4<Real const> const& f3, Array4<int const> const& m3,
                         Box const& vbox, int redblack) noexcept
 {
-    const auto lo = amrex::lbound(box);
-    const auto hi = amrex::ubound(box);
     const auto vlo = amrex::lbound(vbox);
     const auto vhi = amrex::ubound(vbox);
 
     Real gamma = Real(-2.0)*(dhx+dhy);
 
-    for     (int j = lo.y; j <= hi.y; ++j) {
-        AMREX_PRAGMA_SIMD
-        for (int i = lo.x; i <= hi.x; ++i) {
-            if ((i+j+redblack)%2 == 0) {
-                if (osm(i,j,0) == 0) {
-                    phi(i,j,0) = Real(0.0);
-                } else {
-                    Real cf0 = (i == vlo.x && m0(vlo.x-1,j,0) > 0)
-                        ? f0(vlo.x,j,0) : Real(0.0);
-                    Real cf1 = (j == vlo.y && m1(i,vlo.y-1,0) > 0)
-                        ? f1(i,vlo.y,0) : Real(0.0);
-                    Real cf2 = (i == vhi.x && m2(vhi.x+1,j,0) > 0)
-                        ? f2(vhi.x,j,0) : Real(0.0);
-                    Real cf3 = (j == vhi.y && m3(i,vhi.y+1,0) > 0)
-                        ? f3(i,vhi.y,0) : Real(0.0);
-
-                    Real g_m_d = gamma + dhx*(cf0+cf2) + dhy*(cf1+cf3);
-
-                    Real res = rhs(i,j,0) - gamma*phi(i,j,0)
-                        - dhx*(phi(i-1,j,0) + phi(i+1,j,0))
-                        - dhy*(phi(i,j-1,0) + phi(i,j+1,0));
-
-                    phi(i,j,0) = phi(i,j,0) + res /g_m_d;
-                }
+    if ((i+j+redblack)%2 == 0) {
+        if (osm(i,j,0) == 0) {
+            phi(i,j,0) = Real(0.0);
+        } else {
+            Real cf0=Real(0.0);
+            Real cf1=Real(0.0);
+            Real cf2=Real(0.0);
+            Real cf3=Real(0.0);
+            if (i==vlo.x) {
+                cf0 = m0(vlo.x-1,j,0) > 0 ? f0(vlo.x,j,0) : cf0;
+            } else if (i == vhi.x) {
+                cf2 = m2(vhi.x+1,j,0) > 0 ? f2(vhi.x,j,0) : cf2;
             }
+            if (j==vlo.y) {
+                cf1 = m1(i,vlo.y-1,0) > 0 ? f1(i,vlo.y,0) : cf1;
+            } else if (j == vhi.y) {
+                cf3 = m3(i,vhi.y+1,0) > 0 ? f3(i,vhi.y,0) : cf3;
+            }
+
+            Real g_m_d = gamma + dhx*(cf0+cf2) + dhy*(cf1+cf3);
+
+            Real res = rhs(i,j,0) - gamma*phi(i,j,0)
+                - dhx*(phi(i-1,j,0) + phi(i+1,j,0))
+                - dhy*(phi(i,j-1,0) + phi(i,j+1,0));
+
+            phi(i,j,0) = phi(i,j,0) + res /g_m_d;
         }
     }
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-void mlpoisson_gsrb_m (Box const& box, Array4<Real> const& phi, Array4<Real const> const& rhs,
+void mlpoisson_gsrb_os_wrapper (Box const& box, Array4<Real> const& phi, Array4<Real const> const& rhs,
+                                Array4<int const> const& osm, Real dhx, Real dhy,
+                                Array4<Real const> const& f0, Array4<int const> const& m0,
+                                Array4<Real const> const& f1, Array4<int const> const& m1,
+                                Array4<Real const> const& f2, Array4<int const> const& m2,
+                                Array4<Real const> const& f3, Array4<int const> const& m3,
+                                Box const& vbox, int redblack) noexcept
+{
+    const auto lo = amrex::lbound(box);
+    const auto hi = amrex::ubound(box);
+
+    for     (int j = lo.y; j <= hi.y; ++j) {
+        AMREX_PRAGMA_SIMD
+        for (int i = lo.x; i <= hi.x; ++i) {
+            mlpoisson_gsrb_os(i, j, 0, phi, rhs, osm, dhx, dhy,
+                              f0, m0, f1, m1, f2, m2, f3, m3,
+                              vbox, redblack);
+        }
+    }
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void mlpoisson_gsrb_m (int i, int j, int, Array4<Real> const& phi, Array4<Real const> const& rhs,
                        Real dhx, Real dhy,
                        Array4<Real const> const& f0, Array4<int const> const& m0,
                        Array4<Real const> const& f1, Array4<int const> const& m1,
@@ -276,38 +318,59 @@ void mlpoisson_gsrb_m (Box const& box, Array4<Real> const& phi, Array4<Real cons
                        Array4<Real const> const& f3, Array4<int const> const& m3,
                        Box const& vbox, int redblack, Real dx, Real probxlo) noexcept
 {
-    const auto lo = amrex::lbound(box);
-    const auto hi = amrex::ubound(box);
     const auto vlo = amrex::lbound(vbox);
     const auto vhi = amrex::ubound(vbox);
+
+    if ((i+j+redblack)%2 == 0) {
+        Real cf0=Real(0.0);
+        Real cf1=Real(0.0);
+        Real cf2=Real(0.0);
+        Real cf3=Real(0.0);
+        if (i==vlo.x) {
+            cf0 = m0(vlo.x-1,j,0) > 0 ? f0(vlo.x,j,0) : cf0;
+        } else if (i == vhi.x) {
+            cf2 = m2(vhi.x+1,j,0) > 0 ? f2(vhi.x,j,0) : cf2;
+        }
+        if (j==vlo.y) {
+            cf1 = m1(i,vlo.y-1,0) > 0 ? f1(i,vlo.y,0) : cf1;
+        } else if (j == vhi.y) {
+            cf3 = m3(i,vhi.y+1,0) > 0 ? f3(i,vhi.y,0) : cf3;
+        }
+
+        Real rel = probxlo + i*dx;
+        Real rer = probxlo +(i+1)*dx;
+        Real rc = probxlo + (i+Real(0.5))*dx;
+
+        Real gamma = -dhx*(rel+rer) - Real(2.0)*dhy*rc;
+
+        Real g_m_d = gamma + dhx*(rel*cf0+rer*cf2) + dhy*rc*(cf1+cf3);
+
+        Real res = rhs(i,j,0) - gamma*phi(i,j,0)
+            - dhx*(rel*phi(i-1,j,0) + rer*phi(i+1,j,0))
+            - dhy*rc *(phi(i,j-1,0) +     phi(i,j+1,0));
+
+        phi(i,j,0) = phi(i,j,0) + res /g_m_d;
+    }
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void mlpoisson_gsrb_m_wrapper (Box const& box, Array4<Real> const& phi, Array4<Real const> const& rhs,
+                               Real dhx, Real dhy,
+                               Array4<Real const> const& f0, Array4<int const> const& m0,
+                               Array4<Real const> const& f1, Array4<int const> const& m1,
+                               Array4<Real const> const& f2, Array4<int const> const& m2,
+                               Array4<Real const> const& f3, Array4<int const> const& m3,
+                               Box const& vbox, int redblack, Real dx, Real probxlo) noexcept
+{
+    const auto lo = amrex::lbound(box);
+    const auto hi = amrex::ubound(box);
 
     for     (int j = lo.y; j <= hi.y; ++j) {
         AMREX_PRAGMA_SIMD
         for (int i = lo.x; i <= hi.x; ++i) {
-            if ((i+j+redblack)%2 == 0) {
-                Real cf0 = (i == vlo.x && m0(vlo.x-1,j,0) > 0)
-                    ? f0(vlo.x,j,0) : Real(0.0);
-                Real cf1 = (j == vlo.y && m1(i,vlo.y-1,0) > 0)
-                    ? f1(i,vlo.y,0) : Real(0.0);
-                Real cf2 = (i == vhi.x && m2(vhi.x+1,j,0) > 0)
-                    ? f2(vhi.x,j,0) : Real(0.0);
-                Real cf3 = (j == vhi.y && m3(i,vhi.y+1,0) > 0)
-                    ? f3(i,vhi.y,0) : Real(0.0);
-
-                Real rel = probxlo + i*dx;
-                Real rer = probxlo +(i+1)*dx;
-                Real rc = probxlo + (i+Real(0.5))*dx;
-
-                Real gamma = -dhx*(rel+rer) - Real(2.0)*dhy*rc;
-
-                Real g_m_d = gamma + dhx*(rel*cf0+rer*cf2) + dhy*rc*(cf1+cf3);
-
-                Real res = rhs(i,j,0) - gamma*phi(i,j,0)
-                    - dhx*(rel*phi(i-1,j,0) + rer*phi(i+1,j,0))
-                    - dhy*rc *(phi(i,j-1,0) +     phi(i,j+1,0));
-
-                phi(i,j,0) = phi(i,j,0) + res /g_m_d;
-            }
+            mlpoisson_gsrb_m(i, j, 0, phi, rhs, dhx, dhy,
+                             f0, m0, f1, m1, f2, m2, f3, m3,
+                             vbox, redblack, dx, probxlo);
         }
     }
 }

--- a/Src/LinearSolvers/MLMG/AMReX_MLPoisson_3D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLPoisson_3D_K.H
@@ -143,7 +143,7 @@ void mlpoisson_flux_zface (Box const& box, Array4<Real> const& fz,
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-void mlpoisson_gsrb (Box const& box, Array4<Real> const& phi,
+void mlpoisson_gsrb (int i, int j, int k, Array4<Real> const& phi,
                      Array4<Real const> const& rhs,
                      Real dhx, Real dhy, Real dhz,
                      Array4<Real const> const& f0, Array4<int const> const& m0,
@@ -154,8 +154,6 @@ void mlpoisson_gsrb (Box const& box, Array4<Real> const& phi,
                      Array4<Real const> const& f5, Array4<int const> const& m5,
                      Box const& vbox, int redblack) noexcept
 {
-    const auto lo = amrex::lbound(box);
-    const auto hi = amrex::ubound(box);
     const auto vlo = amrex::lbound(vbox);
     const auto vhi = amrex::ubound(vbox);
 
@@ -163,40 +161,69 @@ void mlpoisson_gsrb (Box const& box, Array4<Real> const& phi,
 
     const Real gamma = Real(-2.)*(dhx+dhy+dhz);
 
+    if ((i+j+k+redblack)%2 == 0) {
+        Real cf0=Real(0.0);
+        Real cf1=Real(0.0);
+        Real cf2=Real(0.0);
+        Real cf3=Real(0.0);
+        Real cf4=Real(0.0);
+        Real cf5=Real(0.0);
+        if (i==vlo.x) {
+            cf0 = m0(vlo.x-1,j,k) > 0 ? f0(vlo.x,j,k) : cf0;
+        } else if (i == vhi.x) {
+            cf3 = m3(vhi.x+1,j,k) > 0 ? f3(vhi.x,j,k) : cf3;
+        }
+        if (j==vlo.y) {
+            cf1 = m1(i,vlo.y-1,k) > 0 ? f1(i,vlo.y,k) : cf1;
+        } else if (j == vhi.y) {
+            cf4 = m4(i,vhi.y+1,k) > 0 ? f4(i,vhi.y,k) : cf4;
+        }
+        if (k==vlo.z) {
+            cf2 = m2(i,j,vlo.z-1) > 0 ? f2(i,j,vlo.z) : cf2;
+        } else if (k == vhi.z) {
+            cf5 = m5(i,j,vhi.z+1) > 0 ? f5(i,j,vhi.z) : cf5;
+        }
+
+        Real g_m_d = gamma + dhx*(cf0+cf3) + dhy*(cf1+cf4) + dhz*(cf2+cf5);
+
+        Real res = rhs(i,j,k) - gamma*phi(i,j,k)
+            - dhx*(phi(i-1,j,k) + phi(i+1,j,k))
+            - dhy*(phi(i,j-1,k) + phi(i,j+1,k))
+            - dhz*(phi(i,j,k-1) + phi(i,j,k+1));
+
+        phi(i,j,k) = phi(i,j,k) + omega/g_m_d * res;
+    }
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void mlpoisson_gsrb_wrapper (Box const& box, Array4<Real> const& phi,
+                             Array4<Real const> const& rhs,
+                             Real dhx, Real dhy, Real dhz,
+                             Array4<Real const> const& f0, Array4<int const> const& m0,
+                             Array4<Real const> const& f1, Array4<int const> const& m1,
+                             Array4<Real const> const& f2, Array4<int const> const& m2,
+                             Array4<Real const> const& f3, Array4<int const> const& m3,
+                             Array4<Real const> const& f4, Array4<int const> const& m4,
+                             Array4<Real const> const& f5, Array4<int const> const& m5,
+                             Box const& vbox, int redblack) noexcept
+{
+    const auto lo = amrex::lbound(box);
+    const auto hi = amrex::ubound(box);
+
     for         (int k = lo.z; k <= hi.z; ++k) {
         for     (int j = lo.y; j <= hi.y; ++j) {
             AMREX_PRAGMA_SIMD
             for (int i = lo.x; i <= hi.x; ++i) {
-                if ((i+j+k+redblack)%2 == 0) {
-                    Real cf0 = (i == vlo.x && m0(vlo.x-1,j,k) > 0)
-                        ? f0(vlo.x,j,k) : Real(0.0);
-                    Real cf1 = (j == vlo.y && m1(i,vlo.y-1,k) > 0)
-                        ? f1(i,vlo.y,k) : Real(0.0);
-                    Real cf2 = (k == vlo.z && m2(i,j,vlo.z-1) > 0)
-                        ? f2(i,j,vlo.z) : Real(0.0);
-                    Real cf3 = (i == vhi.x && m3(vhi.x+1,j,k) > 0)
-                        ? f3(vhi.x,j,k) : Real(0.0);
-                    Real cf4 = (j == vhi.y && m4(i,vhi.y+1,k) > 0)
-                        ? f4(i,vhi.y,k) : Real(0.0);
-                    Real cf5 = (k == vhi.z && m5(i,j,vhi.z+1) > 0)
-                        ? f5(i,j,vhi.z) : Real(0.0);
-
-                    Real g_m_d = gamma + dhx*(cf0+cf3) + dhy*(cf1+cf4) + dhz*(cf2+cf5);
-
-                    Real res = rhs(i,j,k) - gamma*phi(i,j,k)
-                        - dhx*(phi(i-1,j,k) + phi(i+1,j,k))
-                        - dhy*(phi(i,j-1,k) + phi(i,j+1,k))
-                        - dhz*(phi(i,j,k-1) + phi(i,j,k+1));
-
-                    phi(i,j,k) = phi(i,j,k) + omega/g_m_d * res;
-                }
+                mlpoisson_gsrb(i, j, k, phi, rhs, dhx, dhy, dhz,
+                               f0, m0, f1, m1, f2, m2, f3, m3, f4, m4, f5, m5,
+                               vbox, redblack);
             }
         }
     }
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-void mlpoisson_gsrb_os (Box const& box, Array4<Real> const& phi,
+void mlpoisson_gsrb_os (int i, int j, int k, Array4<Real> const& phi,
                         Array4<Real const> const& rhs,
                         Array4<int const> const& osm,
                         Real dhx, Real dhy, Real dhz,
@@ -208,8 +235,6 @@ void mlpoisson_gsrb_os (Box const& box, Array4<Real> const& phi,
                         Array4<Real const> const& f5, Array4<int const> const& m5,
                         Box const& vbox, int redblack) noexcept
 {
-    const auto lo = amrex::lbound(box);
-    const auto hi = amrex::ubound(box);
     const auto vlo = amrex::lbound(vbox);
     const auto vhi = amrex::ubound(vbox);
 
@@ -217,37 +242,67 @@ void mlpoisson_gsrb_os (Box const& box, Array4<Real> const& phi,
 
     const Real gamma = Real(-2.)*(dhx+dhy+dhz);
 
+    if ((i+j+k+redblack)%2 == 0) {
+        if (osm(i,j,k) == 0) {
+            phi(i,j,k) = Real(0.0);
+        } else {
+            Real cf0=Real(0.0);
+            Real cf1=Real(0.0);
+            Real cf2=Real(0.0);
+            Real cf3=Real(0.0);
+            Real cf4=Real(0.0);
+            Real cf5=Real(0.0);
+            if (i==vlo.x) {
+                cf0 = m0(vlo.x-1,j,k) > 0 ? f0(vlo.x,j,k) : cf0;
+            } else if (i == vhi.x) {
+                cf3 = m3(vhi.x+1,j,k) > 0 ? f3(vhi.x,j,k) : cf3;
+            }
+            if (j==vlo.y) {
+                cf1 = m1(i,vlo.y-1,k) > 0 ? f1(i,vlo.y,k) : cf1;
+            } else if (j == vhi.y) {
+                cf4 = m4(i,vhi.y+1,k) > 0 ? f4(i,vhi.y,k) : cf4;
+            }
+            if (k==vlo.z) {
+                cf2 = m2(i,j,vlo.z-1) > 0 ? f2(i,j,vlo.z) : cf2;
+            } else if (k == vhi.z) {
+                cf5 = m5(i,j,vhi.z+1) > 0 ? f5(i,j,vhi.z) : cf5;
+            }
+
+            Real g_m_d = gamma + dhx*(cf0+cf3) + dhy*(cf1+cf4) + dhz*(cf2+cf5);
+
+            Real res = rhs(i,j,k) - gamma*phi(i,j,k)
+                - dhx*(phi(i-1,j,k) + phi(i+1,j,k))
+                - dhy*(phi(i,j-1,k) + phi(i,j+1,k))
+                - dhz*(phi(i,j,k-1) + phi(i,j,k+1));
+
+            phi(i,j,k) = phi(i,j,k) + omega/g_m_d * res;
+        }
+    }
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void mlpoisson_gsrb_os_wrapper (Box const& box, Array4<Real> const& phi,
+                                Array4<Real const> const& rhs,
+                                Array4<int const> const& osm,
+                                Real dhx, Real dhy, Real dhz,
+                                Array4<Real const> const& f0, Array4<int const> const& m0,
+                                Array4<Real const> const& f1, Array4<int const> const& m1,
+                                Array4<Real const> const& f2, Array4<int const> const& m2,
+                                Array4<Real const> const& f3, Array4<int const> const& m3,
+                                Array4<Real const> const& f4, Array4<int const> const& m4,
+                                Array4<Real const> const& f5, Array4<int const> const& m5,
+                                Box const& vbox, int redblack) noexcept
+{
+    const auto lo = amrex::lbound(box);
+    const auto hi = amrex::ubound(box);
+
     for         (int k = lo.z; k <= hi.z; ++k) {
         for     (int j = lo.y; j <= hi.y; ++j) {
             AMREX_PRAGMA_SIMD
             for (int i = lo.x; i <= hi.x; ++i) {
-                if ((i+j+k+redblack)%2 == 0) {
-                    if (osm(i,j,k) == 0) {
-                        phi(i,j,k) = Real(0.0);
-                    } else {
-                        Real cf0 = (i == vlo.x && m0(vlo.x-1,j,k) > 0)
-                            ? f0(vlo.x,j,k) : Real(0.0);
-                        Real cf1 = (j == vlo.y && m1(i,vlo.y-1,k) > 0)
-                            ? f1(i,vlo.y,k) : Real(0.0);
-                        Real cf2 = (k == vlo.z && m2(i,j,vlo.z-1) > 0)
-                            ? f2(i,j,vlo.z) : Real(0.0);
-                        Real cf3 = (i == vhi.x && m3(vhi.x+1,j,k) > 0)
-                            ? f3(vhi.x,j,k) : Real(0.0);
-                        Real cf4 = (j == vhi.y && m4(i,vhi.y+1,k) > 0)
-                            ? f4(i,vhi.y,k) : Real(0.0);
-                        Real cf5 = (k == vhi.z && m5(i,j,vhi.z+1) > 0)
-                            ? f5(i,j,vhi.z) : Real(0.0);
-
-                        Real g_m_d = gamma + dhx*(cf0+cf3) + dhy*(cf1+cf4) + dhz*(cf2+cf5);
-
-                        Real res = rhs(i,j,k) - gamma*phi(i,j,k)
-                            - dhx*(phi(i-1,j,k) + phi(i+1,j,k))
-                            - dhy*(phi(i,j-1,k) + phi(i,j+1,k))
-                            - dhz*(phi(i,j,k-1) + phi(i,j,k+1));
-
-                        phi(i,j,k) = phi(i,j,k) + omega/g_m_d * res;
-                    }
-                }
+                mlpoisson_gsrb_os(i, j, k, phi, rhs, osm, dhx, dhy, dhz,
+                                  f0, m0, f1, m1, f2, m2, f3, m3, f4, m4, f5, m5,
+                                  vbox, redblack);
             }
         }
     }


### PR DESCRIPTION
I had to write wrapper implementations that execute the loops over the box, when compiling for CPU. Also, the compactify method does not compile for GPU. So, the 3D impl with hasHiddenDimension is executed in the old manner. Lastly, the failing HIP tests seem unrelated to this PR.

## Summary

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
