### PR TITLE
ROCm 4.5: Dev Packages

### DIFF
--- a/.github/workflows/dependencies/dependencies_hip.sh
+++ b/.github/workflows/dependencies/dependencies_hip.sh
@@ -39,7 +39,8 @@ sudo apt-get install -y --no-install-recommends \
 # add this to the above command once ROCm 4.5 is properly rolled out
 set +e
 sudo apt-get install -y --no-install-recommends \
-    rocrand-devel rocprim-devel
+    rocrand-dev     \
+    rocprim-dev
 set -e
 
 # activate

--- a/.github/workflows/dependencies/dependencies_hip.sh
+++ b/.github/workflows/dependencies/dependencies_hip.sh
@@ -34,7 +34,13 @@ sudo apt-get install -y --no-install-recommends \
     libnuma-dev     \
     libopenmpi-dev  \
     openmpi-bin     \
-    rocm-dev roctracer-dev rocprofiler-dev rocrand-devel rocprim-devel
+    rocm-dev roctracer-dev rocprofiler-dev rocrand rocprim
+
+# add this to the above command once ROCm 4.5 is properly rolled out
+set +e
+sudo apt-get install -y --no-install-recommends \
+    rocrand-devel rocprim-devel
+set -e
 
 # activate
 #

--- a/.github/workflows/dependencies/dependencies_hip.sh
+++ b/.github/workflows/dependencies/dependencies_hip.sh
@@ -34,14 +34,11 @@ sudo apt-get install -y --no-install-recommends \
     libnuma-dev     \
     libopenmpi-dev  \
     openmpi-bin     \
-    rocm-dev roctracer-dev rocprofiler-dev rocrand rocprim
-
-# add this to the above command once ROCm 4.5 is properly rolled out
-set +e
-sudo apt-get install -y --no-install-recommends \
+    rocm-dev        \
+    roctracer-dev   \
+    rocprofiler-dev \
     rocrand-dev     \
     rocprim-dev
-set -e
 
 # activate
 #

--- a/.github/workflows/dependencies/dependencies_hip.sh
+++ b/.github/workflows/dependencies/dependencies_hip.sh
@@ -34,7 +34,7 @@ sudo apt-get install -y --no-install-recommends \
     libnuma-dev     \
     libopenmpi-dev  \
     openmpi-bin     \
-    rocm-dev roctracer-dev rocprofiler-dev rocrand rocprim
+    rocm-dev roctracer-dev rocprofiler-dev rocrand-devel rocprim-devel
 
 # activate
 #


### PR DESCRIPTION
## Summary

In ROCm 4.5, libraries were split into binary and `-dev` packages, as often done in Debian/Ubuntu packaging.

We need the `-dev` packages for headers.

## Additional background

Release notes:
https://rocmdocs.amd.com/en/latest/Current_Release_Notes/Current-Release-Notes.html

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
