### PR TITLE
Lower Hypre minimum version

### DIFF
--- a/Src/Extern/HYPRE/AMReX_HypreIJIface.cpp
+++ b/Src/Extern/HYPRE/AMReX_HypreIJIface.cpp
@@ -296,6 +296,7 @@ void HypreIJIface::boomeramg_precond_configure(const std::string& prefix)
 
         hpp("bamg_smooth_type", HYPRE_BoomerAMGSetSmoothType);
 
+#if defined(HYPRE_RELEASE_NUMBER) && (HYPRE_RELEASE_NUMBER >= 22100)
         // Process ILU smoother parameters
         if (smooth_type == 5) { // ParILUK
             hpp("bamg_smooth_num_sweeps", HYPRE_BoomerAMGSetSmoothNumSweeps);
@@ -311,6 +312,7 @@ void HypreIJIface::boomeramg_precond_configure(const std::string& prefix)
             hpp("bamg_ilu_max_row_nnz", HYPRE_BoomerAMGSetILUMaxRowNnz);
             hpp("bamg_ilu_drop_tol", HYPRE_BoomerAMGSetILUDroptol, 1.e-10);
         }
+#endif
 
         // Process Euclid smoother parameters
         if (smooth_type == 9) {

--- a/Tools/CMake/AMReXConfig.cmake.in
+++ b/Tools/CMake/AMReXConfig.cmake.in
@@ -190,7 +190,7 @@ if (@AMReX_CONDUIT@)
 endif ()
 
 if (@AMReX_HYPRE@)
-   find_dependency(HYPRE 2.21.0 REQUIRED)
+   find_dependency(HYPRE 2.20.0 REQUIRED)
 endif ()
 
 if (@AMReX_PETSC@)

--- a/Tools/CMake/AMReXThirdPartyLibraries.cmake
+++ b/Tools/CMake/AMReXThirdPartyLibraries.cmake
@@ -57,7 +57,7 @@ endif ()
 # HYPRE
 #
 if (AMReX_HYPRE)
-    find_package(HYPRE 2.21.0 REQUIRED)
+    find_package(HYPRE 2.20.0 REQUIRED)
     if(AMReX_CUDA)
         find_package(CUDAToolkit REQUIRED)
         target_link_libraries(amrex PUBLIC CUDA::cusparse CUDA::curand)


### PR DESCRIPTION
Lower Hypre minimum version to 2.20.  This will allow users to use the
provided installation on summit.  The ILU smoother that requires 2.21 is
still available for hypre >= 2.21.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
