### PR TITLE
Fix a new bug in GNU Make

### DIFF
--- a/Tools/GNUMake/sites/Make.unknown
+++ b/Tools/GNUMake/sites/Make.unknown
@@ -4,6 +4,7 @@
 
 os_type := $(shell uname)
 
+ifeq ($(USE_MPI),TRUE)
 ifeq ($(USE_DPCPP),TRUE)
    ifeq ($(shell mpiicpc -show > /dev/null 2>&1; echo $$?), 0)
       CC  := mpiicc
@@ -13,6 +14,7 @@ ifeq ($(USE_DPCPP),TRUE)
       CXXFLAGS += -cxx=dpcpp
       NO_MPI_CHECKING = TRUE
    endif
+endif
 endif
 
 ifneq ($(NO_CONFIG_CHECKING),TRUE)


### PR DESCRIPTION
CXX should not be set to mpiicpc if it's not an MPI build.  This is a new
bug introduced by me in #2435.

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
