### PR TITLE
InterpFaceRegister

### DIFF
--- a/Src/AmrCore/AMReX_AmrCoreFwd.H
+++ b/Src/AmrCore/AMReX_AmrCoreFwd.H
@@ -9,9 +9,12 @@ class AmrMesh;
 
 class FluxRegister;
 class Interpolater;
+class MFInterpolater;
 
 class TagBox;
 class TagBoxArray;
+
+class InterpFaceRegister;
 
 }
 

--- a/Src/AmrCore/AMReX_InterpFaceReg_1D_C.H
+++ b/Src/AmrCore/AMReX_InterpFaceReg_1D_C.H
@@ -1,0 +1,8 @@
+#ifndef AMREX_INTERP_FACE_REG_1D_C_H_
+#define AMREX_INTERP_FACE_REG_1D_C_H_
+
+namespace amrex {
+
+}
+
+#endif

--- a/Src/AmrCore/AMReX_InterpFaceReg_2D_C.H
+++ b/Src/AmrCore/AMReX_InterpFaceReg_2D_C.H
@@ -1,0 +1,66 @@
+#ifndef AMREX_INTERP_FACE_REG_2D_C_H_
+#define AMREX_INTERP_FACE_REG_2D_C_H_
+
+namespace amrex {
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void interp_face_reg (int i, int j, IntVect const& rr, Array4<Real> const& fine, int scomp,
+                      Array4<Real const> const& crse, Array4<Real> const& slope, int ncomp,
+                      Box const& domface, int idim)
+{
+    int ic = amrex::coarsen(i,rr[0]);
+    int jc = amrex::coarsen(j,rr[1]);
+    if (idim == 0) {
+        if (jc == domface.smallEnd(1) || jc == domface.bigEnd(1)) {
+            for (int n = 0; n < ncomp; ++n) {
+                fine(i,j,0,n+scomp) = crse(ic,jc,0,n);
+            }
+        } else {
+            Real sfy = Real(1.0);
+            for (int n = 0; n < ncomp; ++n) {
+                Real dc = Real(0.5) * (crse(ic,jc+1,0,n) - crse(ic,jc-1,0,n));
+                Real df = Real(2.0) * (crse(ic,jc+1,0,n) - crse(ic,jc  ,0,n));
+                Real db = Real(2.0) * (crse(ic,jc  ,0,n) - crse(ic,jc-1,0,n));
+                Real sy = (df*db >= Real(0.0)) ?
+                    amrex::min(amrex::Math::abs(df),amrex::Math::abs(db)) : Real(0.);
+                sy = amrex::Math::copysign(Real(1.),dc)*amrex::min(sy,amrex::Math::abs(dc));
+                if (dc != Real(0.0)) {
+                    sfy = amrex::min(sfy, sy / dc);
+                }
+                slope(i,j,0,n) = dc;
+            }
+            Real yoff = (j - jc*rr[1] + Real(0.5)) / Real(rr[1]) - Real(0.5);
+            for (int n = 0; n < ncomp; ++n) {
+                fine(i,j,0,n+scomp) = crse(ic,jc,0,n) + yoff * slope(i,j,0,n) * sfy;
+            }
+        }
+    } else {
+        if (ic == domface.smallEnd(0) || ic == domface.bigEnd(0)) {
+            for (int n = 0; n < ncomp; ++n) {
+                fine(i,j,0,n+scomp) = crse(ic,jc,0,n);
+            }
+        } else {
+            Real sfx = Real(1.0);
+            for (int n = 0; n < ncomp; ++n) {
+                Real dc = Real(0.5) * (crse(ic+1,jc,0,n) - crse(ic-1,jc,0,n));
+                Real df = Real(2.0) * (crse(ic+1,jc,0,n) - crse(ic  ,jc,0,n));
+                Real db = Real(2.0) * (crse(ic  ,jc,0,n) - crse(ic-1,jc,0,n));
+                Real sx = (df*db >= Real(0.0)) ?
+                    amrex::min(amrex::Math::abs(df),amrex::Math::abs(db)) : Real(0.);
+                sx = amrex::Math::copysign(Real(1.),dc)*amrex::min(sx,amrex::Math::abs(dc));
+                if (dc != Real(0.0)) {
+                    sfx = amrex::min(sfx, sx / dc);
+                }
+                slope(i,j,0,n) = dc;
+            }
+            Real xoff = (i - ic*rr[0] + Real(0.5)) / Real(rr[0]) - Real(0.5);
+            for (int n = 0; n < ncomp; ++n) {
+                fine(i,j,0,n+scomp) = crse(ic,jc,0,n) + xoff * slope(i,j,0,n) * sfx;
+            }
+        }
+    }
+}
+
+}
+
+#endif

--- a/Src/AmrCore/AMReX_InterpFaceReg_3D_C.H
+++ b/Src/AmrCore/AMReX_InterpFaceReg_3D_C.H
@@ -1,0 +1,151 @@
+#ifndef AMREX_INTERP_FACE_REG_3D_C_H_
+#define AMREX_INTERP_FACE_REG_3D_C_H_
+
+namespace amrex {
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void interp_face_reg (int i, int j, int k, IntVect const& rr, Array4<Real> const& fine, int scomp,
+                      Array4<Real const> const& crse, Array4<Real> const& slope, int ncomp,
+                      Box const& domface, int idim)
+{
+    int ic = amrex::coarsen(i,rr[0]);
+    int jc = amrex::coarsen(j,rr[1]);
+    int kc = amrex::coarsen(k,rr[2]);
+    if (idim == 0) {
+        if (jc == domface.smallEnd(1) || jc == domface.bigEnd(1)) {
+            for (int n = 0; n < ncomp; ++n) {
+                fine(i,j,k,n+scomp) = crse(ic,jc,kc,n);
+            }
+        } else {
+            Real sfy = Real(1.0);
+            for (int n = 0; n < ncomp; ++n) {
+                Real dc = Real(0.5) * (crse(ic,jc+1,kc,n) - crse(ic,jc-1,kc,n));
+                Real df = Real(2.0) * (crse(ic,jc+1,kc,n) - crse(ic,jc  ,kc,n));
+                Real db = Real(2.0) * (crse(ic,jc  ,kc,n) - crse(ic,jc-1,kc,n));
+                Real sy = (df*db >= Real(0.0)) ?
+                    amrex::min(amrex::Math::abs(df),amrex::Math::abs(db)) : Real(0.);
+                sy = amrex::Math::copysign(Real(1.),dc)*amrex::min(sy,amrex::Math::abs(dc));
+                if (dc != Real(0.0)) {
+                    sfy = amrex::min(sfy, sy / dc);
+                }
+                slope(i,j,k,n) = dc;
+            }
+            Real yoff = (j - jc*rr[1] + Real(0.5)) / Real(rr[1]) - Real(0.5);
+            for (int n = 0; n < ncomp; ++n) {
+                fine(i,j,k,n+scomp) = crse(ic,jc,kc,n) + yoff * slope(i,j,k,n) * sfy;
+            }
+        }
+
+        if (kc != domface.smallEnd(2) && kc != domface.bigEnd(2)) {
+            Real sfz = Real(1.0);
+            for (int n = 0; n < ncomp; ++n) {
+                Real dc = Real(0.5) * (crse(ic,jc,kc+1,n) - crse(ic,jc,kc-1,n));
+                Real df = Real(2.0) * (crse(ic,jc,kc+1,n) - crse(ic,jc,kc  ,n));
+                Real db = Real(2.0) * (crse(ic,jc,kc  ,n) - crse(ic,jc,kc-1,n));
+                Real sz = (df*db >= Real(0.0)) ?
+                    amrex::min(amrex::Math::abs(df),amrex::Math::abs(db)) : Real(0.);
+                sz = amrex::Math::copysign(Real(1.),dc)*amrex::min(sz,amrex::Math::abs(dc));
+                if (dc != Real(0.0)) {
+                    sfz = amrex::min(sfz, sz / dc);
+                }
+                slope(i,j,k,n) = dc;
+            }
+            Real zoff = (k - kc*rr[2] + Real(0.5)) / Real(rr[2]) - Real(0.5);
+            for (int n = 0; n < ncomp; ++n) {
+                fine(i,j,k,n+scomp) += zoff * slope(i,j,k,n) * sfz;
+            }
+        }
+    } else if (idim == 1) {
+        if (ic == domface.smallEnd(0) || ic == domface.bigEnd(0)) {
+            for (int n = 0; n < ncomp; ++n) {
+                fine(i,j,k,n+scomp) = crse(ic,jc,kc,n);
+            }
+        } else {
+            Real sfx = Real(1.0);
+            for (int n = 0; n < ncomp; ++n) {
+                Real dc = Real(0.5) * (crse(ic+1,jc,kc,n) - crse(ic-1,jc,kc,n));
+                Real df = Real(2.0) * (crse(ic+1,jc,kc,n) - crse(ic  ,jc,kc,n));
+                Real db = Real(2.0) * (crse(ic  ,jc,kc,n) - crse(ic-1,jc,kc,n));
+                Real sx = (df*db >= Real(0.0)) ?
+                    amrex::min(amrex::Math::abs(df),amrex::Math::abs(db)) : Real(0.);
+                sx = amrex::Math::copysign(Real(1.),dc)*amrex::min(sx,amrex::Math::abs(dc));
+                if (dc != Real(0.0)) {
+                    sfx = amrex::min(sfx, sx / dc);
+                }
+                slope(i,j,k,n) = dc;
+            }
+            Real xoff = (i - ic*rr[0] + Real(0.5)) / Real(rr[0]) - Real(0.5);
+            for (int n = 0; n < ncomp; ++n) {
+                fine(i,j,k,n+scomp) = crse(ic,jc,kc,n) + xoff * slope(i,j,k,n) * sfx;
+            }
+        }
+
+        if (kc != domface.smallEnd(2) && kc != domface.bigEnd(2)) {
+            Real sfz = Real(1.0);
+            for (int n = 0; n < ncomp; ++n) {
+                Real dc = Real(0.5) * (crse(ic,jc,kc+1,n) - crse(ic,jc,kc-1,n));
+                Real df = Real(2.0) * (crse(ic,jc,kc+1,n) - crse(ic,jc,kc  ,n));
+                Real db = Real(2.0) * (crse(ic,jc,kc  ,n) - crse(ic,jc,kc-1,n));
+                Real sz = (df*db >= Real(0.0)) ?
+                    amrex::min(amrex::Math::abs(df),amrex::Math::abs(db)) : Real(0.);
+                sz = amrex::Math::copysign(Real(1.),dc)*amrex::min(sz,amrex::Math::abs(dc));
+                if (dc != Real(0.0)) {
+                    sfz = amrex::min(sfz, sz / dc);
+                }
+                slope(i,j,k,n) = dc;
+            }
+            Real zoff = (k - kc*rr[2] + Real(0.5)) / Real(rr[2]) - Real(0.5);
+            for (int n = 0; n < ncomp; ++n) {
+                fine(i,j,k,n+scomp) += zoff * slope(i,j,k,n) * sfz;
+            }
+        }
+    } else {
+        if (ic == domface.smallEnd(0) || ic == domface.bigEnd(0)) {
+            for (int n = 0; n < ncomp; ++n) {
+                fine(i,j,k,n+scomp) = crse(ic,jc,kc,n);
+            }
+        } else {
+            Real sfx = Real(1.0);
+            for (int n = 0; n < ncomp; ++n) {
+                Real dc = Real(0.5) * (crse(ic+1,jc,kc,n) - crse(ic-1,jc,kc,n));
+                Real df = Real(2.0) * (crse(ic+1,jc,kc,n) - crse(ic  ,jc,kc,n));
+                Real db = Real(2.0) * (crse(ic  ,jc,kc,n) - crse(ic-1,jc,kc,n));
+                Real sx = (df*db >= Real(0.0)) ?
+                    amrex::min(amrex::Math::abs(df),amrex::Math::abs(db)) : Real(0.);
+                sx = amrex::Math::copysign(Real(1.),dc)*amrex::min(sx,amrex::Math::abs(dc));
+                if (dc != Real(0.0)) {
+                    sfx = amrex::min(sfx, sx / dc);
+                }
+                slope(i,j,k,n) = dc;
+            }
+            Real xoff = (i - ic*rr[0] + Real(0.5)) / Real(rr[0]) - Real(0.5);
+            for (int n = 0; n < ncomp; ++n) {
+                fine(i,j,k,n+scomp) = crse(ic,jc,kc,n) + xoff * slope(i,j,k,n) * sfx;
+            }
+        }
+
+        if (jc != domface.smallEnd(1) && jc != domface.bigEnd(1)) {
+            Real sfy = Real(1.0);
+            for (int n = 0; n < ncomp; ++n) {
+                Real dc = Real(0.5) * (crse(ic,jc+1,kc,n) - crse(ic,jc-1,kc,n));
+                Real df = Real(2.0) * (crse(ic,jc+1,kc,n) - crse(ic,jc  ,kc,n));
+                Real db = Real(2.0) * (crse(ic,jc  ,kc,n) - crse(ic,jc-1,kc,n));
+                Real sy = (df*db >= Real(0.0)) ?
+                    amrex::min(amrex::Math::abs(df),amrex::Math::abs(db)) : Real(0.);
+                sy = amrex::Math::copysign(Real(1.),dc)*amrex::min(sy,amrex::Math::abs(dc));
+                if (dc != Real(0.0)) {
+                    sfy = amrex::min(sfy, sy / dc);
+                }
+                slope(i,j,k,n) = dc;
+            }
+            Real yoff = (j - jc*rr[1] + Real(0.5)) / Real(rr[1]) - Real(0.5);
+            for (int n = 0; n < ncomp; ++n) {
+                fine(i,j,k,n+scomp) += yoff * slope(i,j,k,n) * sfy;
+            }
+        }
+    }
+}
+
+}
+
+#endif

--- a/Src/AmrCore/AMReX_InterpFaceReg_C.H
+++ b/Src/AmrCore/AMReX_InterpFaceReg_C.H
@@ -1,0 +1,12 @@
+#ifndef AMREX_INTERP_FACE_REG_C_H_
+#define AMREX_INTERP_FACE_REG_C_H_
+
+#include <AMReX_Array4.H>
+
+#if (AMREX_SPACEDIM == 2)
+#include <AMReX_InterpFaceReg_2D_C.H>
+#elif (AMREX_SPACEDIM == 3)
+#include <AMReX_InterpFaceReg_3D_C.H>
+#endif
+
+#endif

--- a/Src/AmrCore/AMReX_InterpFaceRegister.H
+++ b/Src/AmrCore/AMReX_InterpFaceRegister.H
@@ -1,0 +1,85 @@
+#ifndef AMREX_INTERP_FACE_REGISTER_H_
+#define AMREX_INTERP_FACE_REGISTER_H_
+#include <AMReX_Config.H>
+
+#include <AMReX_MultiFab.H>
+#include <AMReX_iMultiFab.H>
+#include <AMReX_Geometry.H>
+
+namespace amrex {
+
+/**
+ *  \brief InterpFaceRegister is a coarse/fine boundary register for
+ *  interpolation of face data at the coarse/fine boundadry.
+ */
+
+class InterpFaceRegister
+{
+public:
+
+    InterpFaceRegister () = default;
+
+    /**
+     * \brief InterpFaceRegister Constructor.
+     *
+     * \param fba  The fine level BoxArray
+     * \param fdm  The fine level DistributionMapping
+     * \param fgeom  The fine level Geometry
+     * \param ref_ratio  The refinement ratio
+     */
+    InterpFaceRegister (BoxArray const& fba, DistributionMapping const& fdm,
+                        Geometry const& fgeom, IntVect const& ref_ratio);
+
+    /**
+     * \brief Defines an InterpFaceRegister objecct.
+     *
+     * \param fba  The fine level BoxArray
+     * \param fdm  The fine level DistributionMapping
+     * \param fgeom  The fine level Geometry
+     * \param ref_ratio  The refinement ratio
+     */
+    void define (BoxArray const& fba, DistributionMapping const& fdm,
+                 Geometry const& fgeom, IntVect const& ref_ratio);
+
+    /**
+     * \brief Returns a coarse/fine boundary mask for a given face.
+     *
+     * This returns an iMultiFab at the coarse/fine boundary of a given
+     * face.  The data are only defined on one face of each box in the fine
+     * level BoxArray passed to the InterpFaceRegister constructor.  It has
+     * two possible values: 1 for coarse/fine boundary and 0 for fine/fine
+     * boundary including non-periodic physical domain face.
+     *
+     * \param face  The face
+     */
+    iMultiFab const& mask (Orientation face) const;
+
+    /**
+     * \brief Interpolates from coarse to fine data at coarse/fine
+     * boundaries.
+     *
+     * \param fine  Array of pointers to the fine data.
+     * \param crse  Array of const pointers to the coarse data.
+     * \param scomp  Starting component
+     * \param ncomp  Number of components
+     */
+    void interp (Array<MultiFab*, AMREX_SPACEDIM> const& fine,
+                 Array<MultiFab const*, AMREX_SPACEDIM> const& crse,
+                 int scomp, int ncomp);
+
+private:
+    BoxArray m_fine_ba;
+    DistributionMapping m_fine_dm;
+    Geometry m_fine_geom;
+    IntVect m_ref_ratio;
+
+    Geometry m_crse_geom;
+
+    Array<BoxArray, 2*AMREX_SPACEDIM> m_fine_face_ba;
+    Array<BoxArray, 2*AMREX_SPACEDIM> m_crse_face_ba;
+    Array<iMultiFab,2*AMREX_SPACEDIM> m_face_mask; // crse/fine: 1, fine/fine & fine/physbc: 0
+};
+
+}
+
+#endif

--- a/Src/AmrCore/AMReX_InterpFaceRegister.cpp
+++ b/Src/AmrCore/AMReX_InterpFaceRegister.cpp
@@ -1,0 +1,201 @@
+#include <AMReX_InterpFaceRegister.H>
+#include <AMReX_InterpFaceReg_C.H>
+
+namespace amrex {
+
+InterpFaceRegister::InterpFaceRegister (BoxArray const& fba, DistributionMapping const& fdm,
+                                        Geometry const& fgeom, IntVect const& ref_ratio)
+{
+    define(fba, fdm, fgeom, ref_ratio);
+}
+
+void InterpFaceRegister::define (BoxArray const& fba, DistributionMapping const& fdm,
+                                 Geometry const& fgeom, IntVect const& ref_ratio)
+{
+    AMREX_ASSERT(fba.ixType().cellCentered());
+    m_fine_ba = fba;
+    m_fine_dm = fdm;
+    m_fine_geom = fgeom;
+    m_ref_ratio = ref_ratio;
+
+    m_crse_geom = amrex::coarsen(m_fine_geom, m_ref_ratio);
+
+    constexpr int crse_fine_face = 1;
+    constexpr int fine_fine_face = 0;
+    // First, set the face mask to 1 (i.e., coarse/fine boundary),
+    // except that it's 0 for non-periodic phys boundary.  For periodic
+    // boundary, it's set to 1 here, and it will be fixed later.
+    for (OrientationIter it; it; ++it) {
+        Orientation face = it();
+        int idim = face.coordDir();
+        IndexType t;
+        t.set(idim);
+        m_fine_face_ba[face] = BoxArray(m_fine_ba, BATransformer(face,t,0,0,0));
+        m_crse_face_ba[face] = amrex::coarsen(m_fine_face_ba[face], m_ref_ratio);
+        m_face_mask[face].define(m_fine_face_ba[face], m_fine_dm, 1, 0);
+
+        auto const& domface = amrex::bdryNode(m_fine_geom.Domain(), face);
+
+#ifdef AMREX_USE_GPU
+        Vector<Array4BoxValTag<int> > tags;
+#endif
+#ifdef AMREX_USE_OMP
+#pragma omp parallel if (Gpu::notInLaunchRegion())
+#endif
+        for (MFIter mfi(m_face_mask[face]); mfi.isValid(); ++mfi) {
+            auto& fab = m_face_mask[face][mfi];
+            Box const& dbox = fab.box();
+            int value = (m_fine_geom.isPeriodic(idim) || !dbox.intersects(domface))
+                ? crse_fine_face : fine_fine_face;
+#ifdef AMREX_USE_GPU
+            if (Gpu::inLaunchRegion()) {
+                tags.emplace_back(Array4BoxValTag<int>{fab.array(),dbox,value});
+            } else
+#endif
+            {
+                fab.template setVal<RunOn::Host>(value, dbox);
+            }
+        }
+
+#ifdef AMREX_USE_GPU
+        if (Gpu::inLaunchRegion()) {
+            ParallelFor(tags, [=] AMREX_GPU_DEVICE (int i, int j, int k,
+                                                    Array4BoxValTag<int> const& tag) noexcept
+            {
+                tag.dfab(i,j,k) = tag.val;
+            });
+        }
+#endif
+    }
+
+    // This set fine/fine boundary, including at periodic boundary.
+    for (OrientationIter it; it; ++it) {
+        Orientation face = it();
+        Orientation other_face = face.flip();
+        auto const& cpc = m_face_mask[face].getCPC(IntVect(0), m_face_mask[other_face],
+                                                   IntVect(0), m_fine_geom.periodicity());
+        m_face_mask[face].setVal(fine_fine_face, cpc, 0, 1);
+    }
+}
+
+iMultiFab const&
+InterpFaceRegister::mask (Orientation face) const
+{
+    return m_face_mask[face];
+}
+
+#ifdef AMREX_USE_GPU
+namespace {
+    struct IFRTag {
+        Array4<Real> fine;
+        Array4<Real> slope;
+        Array4<Real const> crse;
+        Array4<int const> mask;
+        Box domface;
+        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        Box box() const noexcept { return Box(mask); }
+    };
+}
+#endif
+
+void
+InterpFaceRegister::interp (Array<MultiFab*, AMREX_SPACEDIM> const& fine,
+                            Array<MultiFab const*, AMREX_SPACEDIM> const& crse,
+                            int scomp, int ncomp)
+{
+#if (AMREX_SPACEDIM == 1)
+    amrex::ignore_unused(fine,crse,scomp,ncomp);
+    amrex::Abort("InterpFaceRegister::interp: 1D not supported");
+#else
+    for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+        Orientation olo(idim, Orientation::low);
+        Orientation ohi(idim, Orientation::high);
+        IntVect ng(1);
+        ng[idim] = 0;
+        MultiFab clodata(m_crse_face_ba[olo], m_fine_dm, ncomp, ng);
+        MultiFab chidata(m_crse_face_ba[ohi], m_fine_dm, ncomp, ng);
+        clodata.ParallelCopy_nowait(*crse[idim], scomp, 0, ncomp, IntVect(0), ng,
+                                    m_crse_geom.periodicity());
+        chidata.ParallelCopy_nowait(*crse[idim], scomp, 0, ncomp, IntVect(0), ng,
+                                    m_crse_geom.periodicity());
+        clodata.ParallelCopy_finish();
+        chidata.ParallelCopy_finish();
+
+        IntVect rr = m_ref_ratio;
+
+        Box const& domain = m_crse_geom.growPeriodicDomain(1);
+        Box const& domlo = amrex::bdryLo(domain, idim);
+        Box const& domhi = amrex::bdryHi(domain, idim);
+
+#ifdef AMREX_USE_GPU
+        if (Gpu::inLaunchRegion()) {
+            auto const& mlo_mf = m_face_mask[Orientation(idim,Orientation::low)];
+            auto const& mhi_mf = m_face_mask[Orientation(idim,Orientation::high)];
+            MultiFab slope_lo(mlo_mf.boxArray(), mlo_mf.DistributionMap(), ncomp, 0);
+            MultiFab slope_hi(mhi_mf.boxArray(), mhi_mf.DistributionMap(), ncomp, 0);
+
+            Vector<IFRTag> tags;
+            for (MFIter mfi(*fine[idim]); mfi.isValid(); ++mfi) {
+                auto const& fine_arr = fine[idim]->array(mfi);
+                auto const& slo_arr = slope_lo.array(mfi);
+                auto const& shi_arr = slope_hi.array(mfi);
+                auto const& clo_arr = clodata.const_array(mfi);
+                auto const& chi_arr = chidata.const_array(mfi);
+                auto const& mlo_arr = mlo_mf.const_array(mfi);
+                auto const& mhi_arr = mhi_mf.const_array(mfi);
+                tags.push_back(IFRTag{fine_arr, slo_arr, clo_arr, mlo_arr, domlo});
+                tags.push_back(IFRTag{fine_arr, shi_arr, chi_arr, mhi_arr, domhi});
+            }
+
+            ParallelFor(tags, [=] AMREX_GPU_DEVICE (int i, int j, int k, IFRTag const& tag) noexcept
+            {
+                if (tag.mask(i,j,k)) {
+                    interp_face_reg(AMREX_D_DECL(i,j,k), rr, tag.fine, scomp, tag.crse,
+                                    tag.slope, ncomp, tag.domface, idim);
+                }
+            });
+        } else
+#endif
+        {
+#ifdef AMREX_USE_OMP
+#pragma omp parallel
+#endif
+            {
+                FArrayBox slope;
+                for (MFIter mfi(*fine[idim]); mfi.isValid(); ++mfi) {
+                    Box const& vbx = mfi.validbox();
+                    Box const& lobx = amrex::bdryLo(vbx, idim);
+                    Box const& hibx = amrex::bdryHi(vbx, idim);
+                    auto const& fine_arr = fine[idim]->array(mfi);
+                    auto const& clo_arr = clodata.const_array(mfi);
+                    auto const& chi_arr = chidata.const_array(mfi);
+                    auto const& mlo_arr =
+                        m_face_mask[Orientation(idim,Orientation::low)].const_array(mfi);
+                    auto const& mhi_arr =
+                        m_face_mask[Orientation(idim,Orientation::high)].const_array(mfi);
+                    slope.resize(lobx, ncomp);
+                    Array4<Real> slope_arr = slope.array();
+                    amrex::LoopOnCpu(lobx, [&] (int i, int j, int k)
+                    {
+                        if (mlo_arr(i,j,k)) {
+                            interp_face_reg(AMREX_D_DECL(i,j,k), rr, fine_arr, scomp, clo_arr,
+                                            slope_arr, ncomp, domlo, idim);
+                        }
+                    });
+                    slope.resize(hibx, ncomp);
+                    slope_arr = slope.array();
+                    amrex::LoopOnCpu(hibx, [&] (int i, int j, int k)
+                    {
+                        if (mhi_arr(i,j,k)) {
+                            interp_face_reg(AMREX_D_DECL(i,j,k), rr, fine_arr, scomp, chi_arr,
+                                            slope_arr, ncomp, domhi, idim);
+                        }
+                    });
+                }
+            }
+        }
+    }
+#endif
+}
+
+}

--- a/Src/AmrCore/CMakeLists.txt
+++ b/Src/AmrCore/CMakeLists.txt
@@ -29,6 +29,10 @@ target_sources(amrex
    AMReX_Interp_${AMReX_SPACEDIM}D_C.H
    AMReX_MFInterp_C.H
    AMReX_MFInterp_${AMReX_SPACEDIM}D_C.H
+   AMReX_InterpFaceRegister.H
+   AMReX_InterpFaceRegister.cpp
+   AMReX_InterpFaceReg_C.H
+   AMReX_InterpFaceReg_${AMReX_SPACEDIM}D_C.H
    AMReX_AmrCoreFwd.H
    )
 

--- a/Src/AmrCore/Make.package
+++ b/Src/AmrCore/Make.package
@@ -15,6 +15,10 @@ ifeq ($(USE_PARTICLES), TRUE)
   CEXE_headers += AMReX_AmrParGDB.H AMReX_AmrParticles.H
 endif
 
+CEXE_headers += AMReX_InterpFaceRegister.H
+CEXE_sources += AMReX_InterpFaceRegister.cpp
+CEXE_headers += AMReX_InterpFaceReg_C.H AMReX_InterpFaceReg_$(DIM)D_C.H
+
 CEXE_headers += AMReX_AmrCoreFwd.H
 
 ifneq ($(BL_NO_FORT),TRUE)

--- a/Src/Base/AMReX_BoxArray.H
+++ b/Src/Base/AMReX_BoxArray.H
@@ -177,24 +177,38 @@ struct BATbndryReg
         m_loshft = IntVect(-a_extent_rad);
         m_hishft = IntVect( a_extent_rad);
         IntVect nodal = a_typ.ixType();
-        m_hishft += nodal;
         const int d = a_face.coordDir();
-        if (m_face.isLow()) {
-            m_loshft[d] = nodal[d] - a_out_rad;
-            m_hishft[d] = nodal[d] + a_in_rad - 1;
+        if (nodal[d]) {
+            // InterpFaceRegister
+            if (m_face.isLow()) {
+                m_loshft[d] = 0;
+                m_hishft[d] = 0;
+            } else {
+                m_loshft[d] = 1;
+                m_hishft[d] = 1;
+            }
+            m_doilo = IntVect(0);
+            m_doihi = IntVect(1);
         } else {
-            m_loshft[d] = 1 - a_in_rad;
-            m_hishft[d] = a_out_rad;
-        }
-        m_doilo = IntVect(a_extent_rad);
-        m_doihi = IntVect(a_extent_rad);
-        m_doihi += nodal;
-        if (m_face.isLow()) {  // domain of influence in index space
-            m_doilo[d] = std::max(0, a_out_rad - nodal[d]);
-            m_doihi[d] = 0;
-        } else {
-            m_doilo[d] = 0;
-            m_doihi[d] = a_out_rad;
+            // BndryRegister
+            m_hishft += nodal;
+            if (m_face.isLow()) {
+                m_loshft[d] = nodal[d] - a_out_rad;
+                m_hishft[d] = nodal[d] + a_in_rad - 1;
+            } else {
+                m_loshft[d] = 1 - a_in_rad;
+                m_hishft[d] = a_out_rad;
+            }
+            m_doilo = IntVect(a_extent_rad);
+            m_doihi = IntVect(a_extent_rad);
+            m_doihi += nodal;
+            if (m_face.isLow()) {  // domain of influence in index space
+                m_doilo[d] = a_out_rad;
+                m_doihi[d] = 0;
+            } else {
+                m_doilo[d] = 0;
+                m_doihi[d] = a_out_rad;
+            }
         }
     }
 


### PR DESCRIPTION
This is a new class for interpolating from coarse to fine at the coarse/fine
boundary faces.  It also provides masks that can be used to test if a face
is at coarse/fine boundary.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [x] include documentation in the code and/or rst files, if appropriate
