### PR TITLE
Fix WarpX EB solver's grad phi computation

### DIFF
--- a/Src/LinearSolvers/MLMG/AMReX_MLEBNodeFDLaplacian.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBNodeFDLaplacian.cpp
@@ -171,7 +171,8 @@ MLEBNodeFDLaplacian::prepareForSolve ()
 
     buildMasks();
 
-    // Set covered nodes to Dirichlet
+    // Set covered nodes to Dirichlet, but with a negative value.
+    // compGrad relies on the negative value to detect EB.
     for (int amrlev = 0; amrlev < m_num_amr_levels; ++amrlev) {
         for (int mglev = 0; mglev < m_num_mg_levels[amrlev]; ++mglev) {
             auto factory = dynamic_cast<EBFArrayBoxFactory const*>(m_factory[amrlev][mglev].get());
@@ -183,7 +184,7 @@ MLEBNodeFDLaplacian::prepareForSolve ()
             [=] AMREX_GPU_DEVICE (int box_no, int i, int j, int k) noexcept
             {
                 if (levset_ar[box_no](i,j,k) >= Real(0.0)) {
-                    dmask_ar[box_no](i,j,k) = 1;
+                    dmask_ar[box_no](i,j,k) = -1;
                 }
             });
         }


### PR DESCRIPTION
## Summary

Must set the Dirichlet mask on covered nodes to a negative value, because
the function that computes the gradient relies on the information to detect
EB.  This is a bug introduced recently in #2421.

## Additional background

https://github.com/ECP-WarpX/WarpX/issues/2512

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
