### PR TITLE
DPCPP:  Enable early optimizations

### DIFF
--- a/Tools/CMake/AMReXSYCL.cmake
+++ b/Tools/CMake/AMReXSYCL.cmake
@@ -56,12 +56,6 @@ target_compile_options( SYCL
      "$<${_cxx_dpcpp}:-mlong-double-64>"
      "$<${_cxx_dpcpp}:SHELL:-Xclang -mlong-double-64>")
 
-# Beta09 has enabled eary optimizations by default.  But this causes many
-# tests to crash.  So we disable it.
-target_compile_options( SYCL
-   INTERFACE
-   $<${_cxx_dpcpp}:-fno-sycl-early-optimizations>)
-
 # disable warning: comparison with infinity always evaluates to false in fast floating point modes [-Wtautological-constant-compare]
 #                  return std::isinf(m);
 # appeared since 2021.4.0

--- a/Tools/GNUMake/comps/dpcpp.mak
+++ b/Tools/GNUMake/comps/dpcpp.mak
@@ -102,10 +102,6 @@ endif
 #   https://github.com/intel/llvm/issues/2187
 CXXFLAGS += -mlong-double-64 -Xclang -mlong-double-64
 
-# Beta09 has enabled early optimizations by default.  But this causes many
-# tests to crash.  So we disable it.
-CXXFLAGS += -fno-sycl-early-optimizations
-
 F90FLAGS += -implicitnone
 
 FMODULES = -module $(fmoddir) -I$(fmoddir)


### PR DESCRIPTION
Early optimizations were disabled after beta9 was released to work around a
compiler bug.  The issue has been resolved.  So we enable it again.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
