### PR TITLE
HIP: ftrapv causes issues with DEBUG linking

### DIFF
--- a/Tools/GNUMake/comps/hip.mak
+++ b/Tools/GNUMake/comps/hip.mak
@@ -66,8 +66,8 @@ endif  # BL_NO_FORT
 ifeq ($(HIP_COMPILER),clang)
 
   ifeq ($(DEBUG),TRUE)
-    CXXFLAGS += -g -O0 -ftrapv
-    CFLAGS   += -g -O0 -ftrapv
+    CXXFLAGS += -g -O0 #-ftrapv
+    CFLAGS   += -g -O0 #-ftrapv
 
     FFLAGS   += -g -O0 -ggdb -fbounds-check -fbacktrace -Wuninitialized -Wunused -ffpe-trap=invalid,zero -finit-real=snan -finit-integer=2147483647 -ftrapv
     F90FLAGS += -g -O0 -ggdb -fbounds-check -fbacktrace -Wuninitialized -Wunused -ffpe-trap=invalid,zero -finit-real=snan -finit-integer=2147483647 -ftrapv


### PR DESCRIPTION
## Summary

When `-ftrapv` is included, linking fails for `make -j DEBUG=TRUE USE_HIP=TRUE` in `amrex/Tests/GPU/Vector`

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
