### PR TITLE
Implement HOEXTRAPCC for more than single ghost cell

### DIFF
--- a/Src/Base/AMReX_FilCC_1D_C.H
+++ b/Src/Base/AMReX_FilCC_1D_C.H
@@ -56,7 +56,7 @@ struct FilccCell
                 }
                 case (BCType::hoextrapcc):
                 {
-                    q(i,0,0,n) = 2.*q(i+1,0,0,n) - q(i+2,0,0,n);
+                    q(i,0,0,n) = Real(ilo-i)*(q(ilo,0,0,n) - q(ilo+1,0,0,n)) + q(ilo,0,0,n);
                     break;
                 }
                 case (BCType::reflect_even):
@@ -98,7 +98,7 @@ struct FilccCell
                 }
                 case (BCType::hoextrapcc):
                 {
-                    q(i,0,0,n) = 2.*q(i-1,0,0,n) - q(i-2,0,0,n);
+                    q(i,0,0,n) = Real(i-ihi)*(q(ihi,0,0,n) - q(ihi-1,0,0,n)) + q(ihi,0,0,n);
                     break;
                 }
                 case (BCType::reflect_even):

--- a/Src/Base/AMReX_FilCC_2D_C.H
+++ b/Src/Base/AMReX_FilCC_2D_C.H
@@ -61,7 +61,7 @@ struct FilccCell
                 }
                 case (BCType::hoextrapcc):
                 {
-                    q(i,j,0,n) = Real(2.)*q(i+1,j,0,n) - q(i+2,j,0,n);
+                    q(i,j,0,n) = Real(ilo-i)*(q(ilo,j,0,n) - q(ilo+1,j,0,n)) + q(ilo,j,0,n);
                     break;
                 }
                 case (BCType::reflect_even):
@@ -103,7 +103,7 @@ struct FilccCell
                 }
                 case (BCType::hoextrapcc):
                 {
-                    q(i,j,0,n) = Real(2.)*q(i-1,j,0,n) - q(i-2,j,0,n);
+                    q(i,j,0,n) = Real(i-ihi)*(q(ihi,j,0,n) - q(ihi-1,j,0,n)) + q(ihi,j,0,n);
                     break;
                 }
                 case (BCType::reflect_even):
@@ -146,7 +146,7 @@ struct FilccCell
                 }
                 case (BCType::hoextrapcc):
                 {
-                    q(i,j,0,n) = Real(2.)*q(i,j+1,0,n) - q(i,j+2,0,n);
+                    q(i,j,0,n) = Real(jlo-j)*(q(i,jlo,0,n) - q(i,jlo+1,0,n)) + q(i,jlo,0,n);
                     break;
                 }
                 case (BCType::reflect_even):
@@ -188,7 +188,7 @@ struct FilccCell
                 }
                 case (BCType::hoextrapcc):
                 {
-                    q(i,j,0,n) = Real(2.)*q(i,j-1,0,n) - q(i,j-2,0,n);
+                    q(i,j,0,n) = Real(j-jhi)*(q(i,jhi,0,n) - q(i,jhi-1,0,n)) + q(i,jhi,0,n);
                     break;
                 }
                 case (BCType::reflect_even):

--- a/Src/Base/AMReX_FilCC_3D_C.H
+++ b/Src/Base/AMReX_FilCC_3D_C.H
@@ -60,7 +60,7 @@ struct FilccCell
                 }
                 case (BCType::hoextrapcc):
                 {
-                    q(i,j,k,n) = Real(2.)*q(i+1,j,k,n) - q(i+2,j,k,n);
+                    q(i,j,k,n) = Real(ilo-i)*(q(ilo,j,k,n) - q(ilo+1,j,k,n)) + q(ilo,j,k,n);
                     break;
                 }
                 case (BCType::reflect_even):
@@ -102,7 +102,7 @@ struct FilccCell
                 }
                 case (BCType::hoextrapcc):
                 {
-                    q(i,j,k,n) = Real(2.)*q(i-1,j,k,n) - q(i-2,j,k,n);
+                    q(i,j,k,n) = Real(i-ihi)*(q(ihi,j,k,n) - q(ihi-1,j,k,n)) + q(ihi,j,k,n);
                     break;
                 }
                 case (BCType::reflect_even):
@@ -145,7 +145,7 @@ struct FilccCell
                 }
                 case (BCType::hoextrapcc):
                 {
-                    q(i,j,k,n) = Real(2.)*q(i,j+1,k,n) - q(i,j+2,k,n);
+                    q(i,j,k,n) = Real(jlo-j)*(q(i,jlo,k,n) - q(i,jlo+1,k,n)) + q(i,jlo,k,n);
                     break;
                 }
                 case (BCType::reflect_even):
@@ -187,7 +187,7 @@ struct FilccCell
                 }
                 case (BCType::hoextrapcc):
                 {
-                    q(i,j,k,n) = Real(2.)*q(i,j-1,k,n) - q(i,j-2,k,n);
+                    q(i,j,k,n) = Real(j-jhi)*(q(i,jhi,k,n) - q(i,jhi-1,k,n)) + q(i,jhi,k,n);
                     break;
                 }
                 case (BCType::reflect_even):
@@ -230,7 +230,7 @@ struct FilccCell
                 }
                 case (BCType::hoextrapcc):
                 {
-                    q(i,j,k,n) = Real(2.)*q(i,j,k+1,n) - q(i,j,k+2,n);
+                    q(i,j,k,n) = Real(klo-k)*(q(i,j,klo,n) - q(i,j,klo+1,n)) + q(i,j,klo,n);
                     break;
                 }
                 case (BCType::reflect_even):
@@ -272,7 +272,7 @@ struct FilccCell
                 }
                 case (BCType::hoextrapcc):
                 {
-                    q(i,j,k,n) = Real(2.)*q(i,j,k-1,n) - q(i,j,k-2,n);
+                    q(i,j,k,n) = Real(k-khi)*(q(i,j,khi,n) - q(i,j,khi-1,n)) + q(i,j,khi,n);
                     break;
                 }
                 case (BCType::reflect_even):

--- a/Src/Base/AMReX_FilCC_C.cpp
+++ b/Src/Base/AMReX_FilCC_C.cpp
@@ -67,7 +67,7 @@ void fab_filcc (Box const& bx, Array4<Real> const& qn, int ncomp,
                for (int k = lo.z; k <= hi.z; ++k) {
                for (int j = lo.y; j <= hi.y; ++j) {
                for (int i = imin; i <= imax; ++i) {
-                   q(i,j,k) = Real(2.)*q(ilo,j,k) - q(ilo+1,j,k);
+                   q(i,j,k) = (ilo - i)*(q(ilo,j,k) - q(ilo+1,j,k)) + q(ilo,j,k);
                }}}
            } else if (bc.lo(0) == BCType::reflect_even) {
                for (int k = lo.z; k <= hi.z; ++k) {
@@ -114,7 +114,7 @@ void fab_filcc (Box const& bx, Array4<Real> const& qn, int ncomp,
                 for (int k = lo.z; k <= hi.z; ++k) {
                 for (int j = lo.y; j <= hi.y; ++j) {
                 for (int i = imin; i <= imax; ++i) {
-                    q(i,j,k) = Real(2.)*q(ihi,j,k) - q(ihi-1,j,k);
+                    q(i,j,k) = (i - ihi)*(q(ihi,j,k) - q(ihi-1,j,k)) + q(ihi,j,k);
                 }}}
             } else if (bc.hi(0) == BCType::reflect_even) {
                 for (int k = lo.z; k <= hi.z; ++k) {
@@ -162,7 +162,7 @@ void fab_filcc (Box const& bx, Array4<Real> const& qn, int ncomp,
                 for (int k = lo.z; k <= hi.z; ++k) {
                 for (int j = jmin; j <= jmax; ++j) {
                 for (int i = lo.x; i <= hi.x; ++i) {
-                    q(i,j,k) = Real(2.)*q(i,jlo,k) - q(i,jlo+1,k);
+                    q(i,j,k) = (jlo - j)*(q(i,jlo,k) - q(i,jlo+1,k)) + q(i,jlo,k);
                 }}}
             } else if (bc.lo(1) == BCType::reflect_even) {
                 for (int k = lo.z; k <= hi.z; ++k) {
@@ -208,7 +208,7 @@ void fab_filcc (Box const& bx, Array4<Real> const& qn, int ncomp,
                 for (int k = lo.z; k <= hi.z; ++k) {
                 for (int j = jmin; j <= jmax; ++j) {
                 for (int i = lo.x; i <= hi.x; ++i) {
-                    q(i,j,k) = Real(2.)*q(i,jhi,k) - q(i,jhi-1,k);
+                    q(i,j,k) = (j - jhi)*(q(i,jhi,k) - q(i,jhi-1,k)) + q(i,jhi,k);
                 }}}
             } else if (bc.hi(1) == BCType::reflect_even) {
                 for (int k = lo.z; k <= hi.z; ++k) {
@@ -257,7 +257,7 @@ void fab_filcc (Box const& bx, Array4<Real> const& qn, int ncomp,
                 for (int k = kmin; k <= kmax; ++k) {
                 for (int j = lo.y; j <= hi.y; ++j) {
                 for (int i = lo.x; i <= hi.x; ++i) {
-                    q(i,j,k) = Real(2.)*q(i,j,klo) - q(i,j,klo+1);
+                    q(i,j,k) = (klo - k)*(q(i,j,klo) - q(i,j,klo+1)) + q(i,j,klo);
                 }}}
             } else if (bc.lo(2) == BCType::reflect_even) {
                 for (int k = kmin; k <= kmax; ++k) {
@@ -303,7 +303,7 @@ void fab_filcc (Box const& bx, Array4<Real> const& qn, int ncomp,
                 for (int k = kmin; k <= kmax; ++k) {
                 for (int j = lo.y; j <= hi.y; ++j) {
                 for (int i = lo.x; i <= hi.x; ++i) {
-                    q(i,j,k) = Real(2.)*q(i,j,khi) - q(i,j,khi-1);
+                    q(i,j,k) = (k - khi)*(q(i,j,khi) - q(i,j,khi-1)) + q(i,j,khi);
                 }}}
             } else if (bc.hi(2) == BCType::reflect_even) {
                 for (int k = kmin; k <= kmax; ++k) {

--- a/Src/Base/AMReX_filcc_mod.F90
+++ b/Src/Base/AMReX_filcc_mod.F90
@@ -204,7 +204,7 @@ contains
              do k = lo(3), hi(3)
                 do j = lo(2), hi(2)
                    do i = imin, imax
-                      q(i,j,k,n) = 2*q(ilo,j,k,n) - q(ilo+1,j,k,n)
+                      q(i,j,k,n) = (ilo-i)*(q(ilo,j,k,n) - q(ilo+1,j,k,n)) + q(ilo,j,k,n)
                    end do
                 end do
              end do
@@ -276,7 +276,7 @@ contains
              do k = lo(3), hi(3)
                 do j = lo(2), hi(2)
                    do i = imin, imax
-                      q(i,j,k,n) = 2*q(ihi,j,k,n) - q(ihi-1,j,k,n)
+                      q(i,j,k,n) = (i-ihi)*(q(ihi,j,k,n) - q(ihi-1,j,k,n)) + q(ihi,j,k,n)
                    end do
                 end do
              end do
@@ -350,7 +350,7 @@ contains
              do k = lo(3), hi(3)
                 do j = jmin, jmax
                    do i = lo(1), hi(1)
-                      q(i,j,k,n) = 2*q(i,jlo,k,n) - q(i,jlo+1,k,n)
+                      q(i,j,k,n) = (jlo-j)*(q(i,jlo,k,n) - q(i,jlo+1,k,n)) + q(i,jlo,k,n)
                    end do
                 end do
              end do
@@ -422,7 +422,7 @@ contains
              do k = lo(3), hi(3)
                 do j = jmin, jmax
                    do i = lo(1), hi(1)
-                      q(i,j,k,n) = 2*q(i,jhi,k,n) - q(i,jhi-1,k,n)
+                      q(i,j,k,n) = (j-jhi)*(q(i,jhi,k,n) - q(i,jhi-1,k,n)) + q(i,jhi,k,n)
                    end do
                 end do
              end do
@@ -500,7 +500,7 @@ contains
              do k = kmin, kmax
                 do j = lo(2), hi(2)
                    do i = lo(1), hi(1)
-                      q(i,j,k,n) = 2*q(i,j,klo,n) - q(i,j,klo+1,n)
+                      q(i,j,k,n) = (klo-k)*(q(i,j,klo,n) - q(i,j,klo+1,n)) + q(i,j,klo,n)
                    end do
                 end do
              end do
@@ -572,7 +572,7 @@ contains
              do k = kmin, kmax
                 do j = lo(2), hi(2)
                    do i = lo(1), hi(1)
-                      q(i,j,k,n) = 2*q(i,j,khi,n) - q(i,j,khi-1,n)
+                      q(i,j,k,n) = (k-khi)*(q(i,j,khi,n) - q(i,j,khi-1,n)) + q(i,j,khi,n)
                    end do
                 end do
              end do


### PR DESCRIPTION
## Summary
Implement HOEXTRAPCC for N ghost cells, N > 1

## Additional background
Previous HOEXTRAPCC works only for N = 1

## Checklist

The proposed changes:
- [x] add new capabilities to AMReX
