### PR TITLE
Redo of PR #2450 HDF5 fillvalue never.

### DIFF
--- a/Src/Extern/HDF5/AMReX_PlotFileUtilHDF5.cpp
+++ b/Src/Extern/HDF5/AMReX_PlotFileUtilHDF5.cpp
@@ -934,6 +934,10 @@ void WriteMultiLevelPlotfileHDF5MultiDset (const std::string& plotfilename,
 
     // Write data for each level
     char level_name[32];
+
+    hid_t dcpl_id = H5Pcreate(H5P_DATASET_CREATE);
+    H5Pset_fill_time(dcpl_id, H5D_FILL_TIME_NEVER);
+
     for (int level = 0; level <= finest_level; ++level) {
         sprintf(level_name, "level_%d", level);
 #ifdef AMREX_USE_HDF5_ASYNC
@@ -959,9 +963,9 @@ void WriteMultiLevelPlotfileHDF5MultiDset (const std::string& plotfilename,
         boxdataspace = H5Screate_simple(1, flatdims, NULL);
 
 #ifdef AMREX_USE_HDF5_ASYNC
-        boxdataset = H5Dcreate_async(grp, bdsname.c_str(), babox_id, boxdataspace, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT, es_id_g);
+        boxdataset = H5Dcreate_async(grp, bdsname.c_str(), babox_id, boxdataspace, H5P_DEFAULT, dcpl_id, H5P_DEFAULT, es_id_g);
 #else
-        boxdataset = H5Dcreate(grp, bdsname.c_str(), babox_id, boxdataspace, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+        boxdataset = H5Dcreate(grp, bdsname.c_str(), babox_id, boxdataspace, H5P_DEFAULT, dcpl_id, H5P_DEFAULT);
 #endif
         if (boxdataset < 0) { std::cout << "H5Dcreate [" << bdsname << "] failed!" << std::endl; break; }
 
@@ -989,9 +993,9 @@ void WriteMultiLevelPlotfileHDF5MultiDset (const std::string& plotfilename,
         oflatdims[0] = sortedGrids.size() + 1;
         offsetdataspace = H5Screate_simple(1, oflatdims, NULL);
 #ifdef AMREX_USE_HDF5_ASYNC
-        offsetdataset = H5Dcreate_async(grp, odsname.c_str(), H5T_NATIVE_LLONG, offsetdataspace, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT, es_id_g);
+        offsetdataset = H5Dcreate_async(grp, odsname.c_str(), H5T_NATIVE_LLONG, offsetdataspace, H5P_DEFAULT, dcpl_id, H5P_DEFAULT, es_id_g);
 #else
-        offsetdataset = H5Dcreate(grp, odsname.c_str(), H5T_NATIVE_LLONG, offsetdataspace, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+        offsetdataset = H5Dcreate(grp, odsname.c_str(), H5T_NATIVE_LLONG, offsetdataspace, H5P_DEFAULT, dcpl_id, H5P_DEFAULT);
 #endif
         if(offsetdataset < 0) { std::cout << "create offset dataset failed! ret = " << offsetdataset << std::endl; break;}
 
@@ -999,9 +1003,9 @@ void WriteMultiLevelPlotfileHDF5MultiDset (const std::string& plotfilename,
         centerdims[0]   = sortedGrids.size() ;
         centerdataspace = H5Screate_simple(1, centerdims, NULL);
 #ifdef AMREX_USE_HDF5_ASYNC
-        centerdataset = H5Dcreate_async(grp, centername.c_str(), center_id, centerdataspace, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT, es_id_g);
+        centerdataset = H5Dcreate_async(grp, centername.c_str(), center_id, centerdataspace, H5P_DEFAULT, dcpl_id, H5P_DEFAULT, es_id_g);
 #else
-        centerdataset = H5Dcreate(grp, centername.c_str(), center_id, centerdataspace, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+        centerdataset = H5Dcreate(grp, centername.c_str(), center_id, centerdataspace, H5P_DEFAULT, dcpl_id, H5P_DEFAULT);
 #endif
         if(centerdataset < 0) { std::cout << "Create center dataset failed! ret = " << centerdataset << std::endl; break;}
 
@@ -1164,6 +1168,7 @@ void WriteMultiLevelPlotfileHDF5MultiDset (const std::string& plotfilename,
     H5Tclose(center_id);
     H5Tclose(babox_id);
     H5Pclose(fapl);
+    H5Pclose(dcpl_id);
     H5Pclose(dxpl_col);
     H5Pclose(dxpl_ind);
     H5Pclose(dcpl);

--- a/Src/Extern/HDF5/AMReX_WriteBinaryParticleDataHDF5.H
+++ b/Src/Extern/HDF5/AMReX_WriteBinaryParticleDataHDF5.H
@@ -317,6 +317,10 @@ void WriteHDF5ParticleDataSync (PC const& pc,
 
         char level_name[128];
         int ngrids;
+
+        hid_t dcpl_id = H5Pcreate(H5P_DATASET_CREATE);
+        H5Pset_fill_time(dcpl_id, H5D_FILL_TIME_NEVER);
+
         for (int lev = 0; lev <= finest_level; ++lev) {
             sprintf(level_name, "level_%d", lev);
 
@@ -337,7 +341,7 @@ void WriteHDF5ParticleDataSync (PC const& pc,
             hsize_t mfs_dim = (hsize_t)ngrids;
 
             hid_t mfs_dset_space = H5Screate_simple(1, &mfs_dim, NULL);
-            hid_t mfs_dset= H5Dcreate(grp, "boxes", comp_dtype, mfs_dset_space, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+            hid_t mfs_dset= H5Dcreate(grp, "boxes", comp_dtype, mfs_dset_space, H5P_DEFAULT, dcpl_id, H5P_DEFAULT);
 
             Vector<int> vbox(ngrids * mfs_size);
             for(int j = 0; j < pc.ParticleBoxArray(lev).size(); ++j) {
@@ -358,7 +362,7 @@ void WriteHDF5ParticleDataSync (PC const& pc,
 
             H5Gclose(grp);
         }
-
+        H5Pclose(dcpl_id);
         H5Fclose(fid);
     }
 


### PR DESCRIPTION
## Summary

PR #2432 wiped out the PR #2450 changes, this PR reintroduces PR #2450.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
