### PR TITLE
DPCPP: AMREX_INTEL_ARCH

### DIFF
--- a/Docs/sphinx_documentation/source/GPU.rst
+++ b/Docs/sphinx_documentation/source/GPU.rst
@@ -319,7 +319,7 @@ we provide the helper function ``setup_target_for_cuda_compilation()``:
 
 
 
-Enabling HIP support
+Enabling HIP Support
 ^^^^^^^^^^^^^^^^^^^^
 
 To build AMReX with HIP support in CMake, add
@@ -350,7 +350,7 @@ Below is an example configuration for HIP on Tulip:
    cmake --build build -j 6
 
 
-Enabling SYCL support
+Enabling SYCL Support
 ^^^^^^^^^^^^^^^^^^^^^
 
 To build AMReX with SYCL support in CMake, add

--- a/Docs/sphinx_documentation/source/GPU.rst
+++ b/Docs/sphinx_documentation/source/GPU.rst
@@ -319,8 +319,8 @@ we provide the helper function ``setup_target_for_cuda_compilation()``:
 
 
 
-Enabling HIP support (experimental)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Enabling HIP support
+^^^^^^^^^^^^^^^^^^^^
 
 To build AMReX with HIP support in CMake, add
 ``-DAMReX_GPU_BACKEND=HIP -DAMReX_AMD_ARCH=<target-arch> -DCMAKE_CXX_COMPILER=<your-hip-compiler>``
@@ -350,8 +350,8 @@ Below is an example configuration for HIP on Tulip:
    cmake --build build -j 6
 
 
-Enabling SYCL support (experimental)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Enabling SYCL support
+^^^^^^^^^^^^^^^^^^^^^
 
 To build AMReX with SYCL support in CMake, add
 ``-DAMReX_GPU_BACKEND=SYCL -DCMAKE_CXX_COMPILER=<your-sycl-compiler>``
@@ -390,6 +390,8 @@ Below is an example configuration for SYCL:
    | Variable Name                | Description                                     | Default     | Possible values |
    +==============================+=================================================+=============+=================+
    | AMReX_DPCPP_AOT              | Enable DPCPP ahead-of-time compilation          | NO          | YES, NO         |
+   +------------------------------+-------------------------------------------------+-------------+-----------------+
+   | AMREX_INTEL_ARCH             | Specify target if AOT is enabled                | None        | Gen9, etc.      |
    +------------------------------+-------------------------------------------------+-------------+-----------------+
    | AMReX_DPCPP_SPLIT_KERNEL     | Enable DPCPP kernel splitting                   | YES         | YES, NO         |
    +------------------------------+-------------------------------------------------+-------------+-----------------+

--- a/Tools/CMake/AMReXOptions.cmake
+++ b/Tools/CMake/AMReXOptions.cmake
@@ -157,6 +157,20 @@ cmake_dependent_option( AMReX_DPCPP_ONEDPL "Enable DPCPP's oneDPL algorithms"  O
    "AMReX_GPU_BACKEND STREQUAL SYCL" OFF)
 print_option(  AMReX_DPCPP_ONEDPL )
 
+if (AMReX_DPCPP)
+   set(AMReX_INTEL_ARCH_DEFAULT "IGNORE")
+   if (DEFINED ENV{AMREX_INTEL_ARCH})
+      set(AMReX_INTEL_ARCH_DEFAULT "$ENV{AMREX_INTEL_ARCH}")
+   endif()
+
+   set(AMReX_INTEL_ARCH ${AMReX_INTEL_ARCH_DEFAULT} CACHE STRING
+      "INTEL GPU architecture (Must be provided if AMReX_GPU_BACKEND=SYCL and AMReX_DPCPP_AOT=ON)")
+
+   if (AMReX_DPCPP_AOT AND NOT AMReX_INTEL_ARCH)
+      message(FATAL_ERROR "\nMust specify AMReX_INTEL_ARCH if AMReX_GPU_BACKEND=SYCL and AMReX_DPCPP_AOT=ON\n")
+   endif()
+endif ()
+
 # --- HIP ----
 if (AMReX_HIP)
    set(AMReX_AMD_ARCH_DEFAULT "IGNORE")
@@ -165,10 +179,10 @@ if (AMReX_HIP)
    endif()
 
    set(AMReX_AMD_ARCH ${AMReX_AMD_ARCH_DEFAULT} CACHE STRING
-      "AMD GPU architecture (Must be provided if AMReX_HIP=ON)")
+      "AMD GPU architecture (Must be provided if AMReX_GPU_BACKEND=HIP)")
 
    if (NOT AMReX_AMD_ARCH)
-      message(FATAL_ERROR "\nMust specify AMReX_AMD_ARCH if AMReX_HIP=ON\n")
+      message(FATAL_ERROR "\nMust specify AMReX_AMD_ARCH if AMReX_GPU_BACKEND=HIP\n")
    endif ()
 endif ()
 

--- a/Tools/CMake/AMReXSYCL.cmake
+++ b/Tools/CMake/AMReXSYCL.cmake
@@ -112,38 +112,15 @@ target_link_options( SYCL
 
 
 if (AMReX_DPCPP_AOT)
-   message(FATAL_ERROR "\nAhead-of-time (AOT) compilation support not available yet.\nRe-configure with AMReX_DPCPP_AOT=OFF.")
+   target_compile_options( SYCL
+      INTERFACE
+      "$<${_cxx_dpcpp}:-fsycl-targets=spir64_gen-unknown-unknown-sycldevice>"
+      "$<${_cxx_dpcpp}:SHELL:-Xsycl-target-backend \"-device ${AMReX_INTEL_ARCH}\">" )
 
-   #
-   # TODO: remove comments to enable AOT support when the time comes
-   #       (main blocker: missing math library)
-   #
-   # if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
-   #    ## TODO: use file(READ)
-   #    execute_process( COMMAND cat /sys/devices/cpu/caps/pmu_name OUTPUT_VARIABLE _cpu_long_name )
-   # else ()
-   #    message(FATAL_ERROR "\nAMReX_DPCPP_AOT is not supported on ${CMAKE_SYSTEM_NAME}\n")
-   # endif ()
-
-   # string(STRIP "${_cpu_long_name}" _cpu_long_name)
-   # if (_cpu_long_name STREQUAL "skylake")
-   #    set(_cpu_short_name "skl")
-   # elseif (_cpu_long_name STREQUAL "kabylake")
-   #    set(_cpu_short_name "kbl")
-   # elseif (_cpu_long_name STREQUAL "cascadelake")
-   #    set(_cpu_short_name "cfl")
-   # else ()
-   #    message(FATAL_ERROR "\n Ahead-of-time compilation for CPU ${_cpu_long_name} is not yet supported\n"
-   #       "Maybe set AMReX_DPCPP_AOT to OFF?\n")
-   # endif ()
-
-   # target_compile_options( amrex
-   #    PUBLIC
-   #    $<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CXX_COMPILER_ID:Clang>,$<NOT:$<CONFIG:Debug>>>:
-   #    -fsycl-targets=spir64_gen-unknown-unknown-sycldevice -Xsycl-target-backend "-device ${_cpu_short_name}" >)
-   # target_link_options(amrex PUBLIC -fsycl-targets=spir64_gen-unknown-unknown-sycldevice -Xsycl-target-backend "-device ${_cpu_short_name}" )
-   # unset(_cpu_long_name)
-   # unset(_cpu_short_name)
+   target_link_options( SYCL
+      INTERFACE
+      "$<${_cxx_dpcpp}:-fsycl-targets=spir64_gen-unknown-unknown-sycldevice>"
+      "$<${_cxx_dpcpp}:SHELL:-Xsycl-target-backend \"-device ${AMReX_INTEL_ARCH}\">" )
 endif ()
 
 


### PR DESCRIPTION
When AOT is on, set the target to AMREX_INTEL_ARCH, which is required if the
SYCL backend is used and AOT is on.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
