### PR TITLE
Include optional directory to HDF5 Test Benchmark

### DIFF
--- a/Tests/HDF5Benchmark/inputs
+++ b/Tests/HDF5Benchmark/inputs
@@ -34,4 +34,4 @@ restart_check = 1
 ## Uncomment to enable compression
 hdf5compression=ZFP_ACCURACY#0.001
 
-directory=
+directory=.

--- a/Tests/HDF5Benchmark/inputs
+++ b/Tests/HDF5Benchmark/inputs
@@ -33,3 +33,5 @@ restart_check = 1
 
 ## Uncomment to enable compression
 hdf5compression=ZFP_ACCURACY#0.001
+
+directory=

--- a/Tests/HDF5Benchmark/main.cpp
+++ b/Tests/HDF5Benchmark/main.cpp
@@ -30,6 +30,7 @@ void test ()
     int restart_check = 0, nplotfile = 1, nparticlefile = 1, sleeptime = 0;
     int grids_from_file = 0;
     std::string compression = "None#0";
+    std::string directory = "";
 
     ParmParse pp;
     pp.get("ncells", ncells);
@@ -43,6 +44,12 @@ void test ()
     pp.query("sleeptime", sleeptime);
     pp.query("restart_check", restart_check);
     pp.query("grids_from_file", grids_from_file);
+    pp.query("directory", directory);
+
+    if (directory != "" && directory.back() != '/') {
+        // Include separator if one was not provided
+        directory += "/";
+    }
 
     Vector<Box> domains;
     Vector<BoxArray> ba;
@@ -99,9 +106,9 @@ void test ()
     /* if (compression.compare("None#0") != 0) */
     /*     std::cout << "Compression: " << compression << std::endl; */
 
-    char fname[128];
+    char fname[512];
     for (int ts = 0; ts < nplotfile; ts++) {
-        sprintf(fname, "plt%05d", ts);
+        sprintf(fname, "%splt%05d", directory.c_str(), ts);
 
         // Fake computation
         if (ts > 0 && sleeptime > 0) {
@@ -171,7 +178,7 @@ void test ()
             particle_intnames.push_back("particle_int_component_" + std::to_string(i));
 
         for (int ts = 0; ts < nparticlefile; ts++) {
-            sprintf(fname, "plt%05d", ts);
+            sprintf(fname, "%splt%05d", directory.c_str(), ts);
 
             // Fake computation
             if (ts > 0 && sleeptime > 0) {
@@ -198,12 +205,16 @@ void test ()
         }
     }
 
+    char directory_path[512];
+
     if (restart_check && nparticlefile > 0)
     {
         MyPC newPC(geom, dmap, ba, ref_ratio);
 #ifdef AMREX_USE_HDF5
+        sprintf(directory_path, "%s%s", directory.c_str(), "plt00000/particle0");
         newPC.RestartHDF5("plt00000/particle0", "particle0");
 #else
+        sprintf(directory_path, "%s%s", directory.c_str(), "plt00000");
         newPC.Restart("plt00000", "particle0");
 #endif
 


### PR DESCRIPTION
## Summary
Include an option to provide a prefix path or directory for the files generated by the HDF5 test benchmark.

## Additional background
Originally the file is created in the current directory, this will add flexibility by allowing the user to specify another location for the generated files.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [X] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
