### PR TITLE
DPCPP: workaround for the scan issue

### DIFF
--- a/Src/Base/AMReX_Scan.H
+++ b/Src/Base/AMReX_Scan.H
@@ -198,11 +198,9 @@ struct BlockStatus<T, false>
 
 #if defined(AMREX_USE_DPCPP)
 
-template <typename T, typename N, typename FIN, typename FOUT, typename TYPE,
-          typename M=std::enable_if_t<std::is_integral<N>::value &&
-                                      (std::is_same<std::decay_t<TYPE>,Type::Inclusive>::value ||
-                                       std::is_same<std::decay_t<TYPE>,Type::Exclusive>::value)> >
-T PrefixSum (N n, FIN && fin, FOUT && fout, TYPE, RetSum a_ret_sum = retSum)
+#ifndef AMREX_DPCPP_NO_MULTIPASS_SCAN
+template <typename T, typename N, typename FIN, typename FOUT, typename TYPE>
+T PrefixSum_mp (N n, FIN && fin, FOUT && fout, TYPE, RetSum a_ret_sum)
 {
     if (n <= 0) return 0;
     constexpr int nwarps_per_block = 8;
@@ -211,6 +209,214 @@ T PrefixSum (N n, FIN && fin, FOUT && fout, TYPE, RetSum a_ret_sum = retSum)
     constexpr int nelms_per_block = nthreads * nchunks;
     AMREX_ALWAYS_ASSERT(static_cast<Long>(n) < static_cast<Long>(std::numeric_limits<int>::max())*nelms_per_block);
     int nblocks = (static_cast<Long>(n) + nelms_per_block - 1) / nelms_per_block;
+    std::size_t sm = sizeof(T) * (Gpu::Device::warp_size + nwarps_per_block);
+    auto stream = Gpu::gpuStream();
+
+    std::size_t nbytes_blockresult = Arena::align(sizeof(T)*n);
+    std::size_t nbytes_blocksum = Arena::align(sizeof(T)*nblocks);
+    std::size_t nbytes_totalsum = Arena::align(sizeof(T));
+    auto dp = (char*)(The_Arena()->alloc(nbytes_blockresult
+                                         + nbytes_blocksum
+                                         + nbytes_totalsum));
+    T* blockresult_p = (T*)dp;
+    T* blocksum_p = (T*)(dp + nbytes_blockresult);
+    T* totalsum_p = (T*)(dp + nbytes_blockresult + nbytes_blocksum);
+
+    amrex::launch(nblocks, nthreads, sm, stream,
+    [=] AMREX_GPU_DEVICE (Gpu::Handler const& gh) noexcept
+    {
+        amrex::oneapi::sub_group const& sg = gh.item->get_sub_group();
+        int lane = sg.get_local_id()[0];
+        int warp = sg.get_group_id()[0];
+        int nwarps = sg.get_group_range()[0];
+
+        int threadIdxx = gh.item->get_local_id(0);
+        int blockIdxx = gh.item->get_group_linear_id();
+        int blockDimx = gh.item->get_local_range(0);
+
+        T* shared = (T*)(gh.local);
+        T* shared2 = shared + Gpu::Device::warp_size;
+
+        // Each block processes [ibegin,iend).
+        N ibegin = nelms_per_block * blockIdxx;
+        N iend = amrex::min(static_cast<N>(ibegin+nelms_per_block), n);
+
+        // Each block is responsible for nchunks chunks of data,
+        // where each chunk has blockDim.x elements, one for each
+        // thread in the block.
+        T sum_prev_chunk = 0; // inclusive sum from previous chunks.
+        for (int ichunk = 0; ichunk < nchunks; ++ichunk) {
+            N offset = ibegin + ichunk*blockDimx;
+            if (offset >= iend) break;
+
+            offset += threadIdxx;
+            T x0 = (offset < iend) ? fin(offset) : 0;
+            T x = x0;
+            // Scan within a warp
+            for (int i = 1; i <= Gpu::Device::warp_size; i *= 2) {
+                T s = sg.shuffle_up(x, i);
+                if (lane >= i) x += s;
+            }
+
+            // x now holds the inclusive sum within the warp.  The
+            // last thread in each warp holds the inclusive sum of
+            // this warp.  We will store it in shared memory.
+            if (lane == Gpu::Device::warp_size - 1) {
+                shared[warp] = x;
+            }
+
+            gh.item->barrier(sycl::access::fence_space::local_space);
+
+            // The first warp will do scan on the warp sums for the
+            // whole block.
+            if (warp == 0) {
+                T y = (lane < nwarps) ? shared[lane] : 0;
+                for (int i = 1; i <= Gpu::Device::warp_size; i *= 2) {
+                    T s = sg.shuffle_up(y, i);
+                    if (lane >= i) y += s;
+                }
+
+                if (lane < nwarps) shared2[lane] = y;
+            }
+
+            gh.item->barrier(sycl::access::fence_space::local_space);
+
+            // shared[0:nwarps) holds the inclusive sum of warp sums.
+
+            // Also note x still holds the inclusive sum within the
+            // warp.  Given these two, we can compute the inclusive
+            // sum within this chunk.
+            T sum_prev_warp = (warp == 0) ? 0 : shared2[warp-1];
+            T tmp_out = sum_prev_warp + sum_prev_chunk +
+                (std::is_same<std::decay_t<TYPE>,Type::Inclusive>::value ? x : x-x0);
+            sum_prev_chunk += shared2[nwarps-1];
+
+            if (offset < iend) {
+                blockresult_p[offset] = tmp_out;
+            }
+        }
+
+        // sum_prev_chunk now holds the sum of the whole block.
+        if (threadIdxx == 0) {
+            blocksum_p[blockIdxx] = sum_prev_chunk;
+        }
+    });
+
+    amrex::launch(1, nthreads, sm, stream,
+    [=] AMREX_GPU_DEVICE (Gpu::Handler const& gh) noexcept
+    {
+        amrex::oneapi::sub_group const& sg = gh.item->get_sub_group();
+        int lane = sg.get_local_id()[0];
+        int warp = sg.get_group_id()[0];
+        int nwarps = sg.get_group_range()[0];
+
+        int threadIdxx = gh.item->get_local_id(0);
+        int blockDimx = gh.item->get_local_range(0);
+
+        T* shared = (T*)(gh.local);
+        T* shared2 = shared + Gpu::Device::warp_size;
+
+        T sum_prev_chunk = 0;
+        for (int offset = threadIdxx; offset - threadIdxx < nblocks; offset += blockDimx) {
+            T x = (offset < nblocks) ? blocksum_p[offset] : 0;
+            // Scan within a warp
+            for (int i = 1; i <= Gpu::Device::warp_size; i *= 2) {
+                T s = sg.shuffle_up(x, i);
+                if (lane >= i) x += s;
+            }
+
+            // x now holds the inclusive sum within the warp.  The
+            // last thread in each warp holds the inclusive sum of
+            // this warp.  We will store it in shared memory.
+            if (lane == Gpu::Device::warp_size - 1) {
+                shared[warp] = x;
+            }
+
+            gh.item->barrier(sycl::access::fence_space::local_space);
+
+            // The first warp will do scan on the warp sums for the
+            // whole block.
+            if (warp == 0) {
+                T y = (lane < nwarps) ? shared[lane] : 0;
+                for (int i = 1; i <= Gpu::Device::warp_size; i *= 2) {
+                    T s = sg.shuffle_up(y, i);
+                    if (lane >= i) y += s;
+                }
+
+                if (lane < nwarps) shared2[lane] = y;
+            }
+
+            gh.item->barrier(sycl::access::fence_space::local_space);
+
+            // shared[0:nwarps) holds the inclusive sum of warp sums.
+
+            // Also note x still holds the inclusive sum within the
+            // warp.  Given these two, we can compute the inclusive
+            // sum within this chunk.
+            T sum_prev_warp = (warp == 0) ? 0 : shared2[warp-1];
+            T tmp_out = sum_prev_warp + sum_prev_chunk + x;
+            sum_prev_chunk += shared2[nwarps-1];
+
+            if (offset < nblocks) {
+                blocksum_p[offset] = tmp_out;
+            }
+        }
+
+        // sum_prev_chunk now holds the total sum.
+        if (threadIdxx == 0) {
+            *totalsum_p = sum_prev_chunk;
+        }
+    });
+
+    amrex::launch(nblocks, nthreads, 0, stream,
+    [=] AMREX_GPU_DEVICE (Gpu::Handler const& gh) noexcept
+    {
+        int threadIdxx = gh.item->get_local_id(0);
+        int blockIdxx = gh.item->get_group_linear_id();
+        int blockDimx = gh.item->get_local_range(0);
+
+        // Each block processes [ibegin,iend).
+        N ibegin = nelms_per_block * blockIdxx;
+        N iend = amrex::min(static_cast<N>(ibegin+nelms_per_block), n);
+        T prev_sum = (blockIdxx == 0) ? 0 : blocksum_p[blockIdxx-1];
+        for (N offset = ibegin + threadIdxx; offset < iend; offset += blockDimx) {
+            fout(offset, prev_sum + blockresult_p[offset]);
+        }
+    });
+
+    T totalsum = 0;
+    if (a_ret_sum) {
+        Gpu::dtoh_memcpy_async(&totalsum, totalsum_p, sizeof(T));
+    }
+    Gpu::streamSynchronize();
+    The_Arena()->free(dp);
+
+    AMREX_GPU_ERROR_CHECK();
+
+    return totalsum;
+}
+#endif
+
+template <typename T, typename N, typename FIN, typename FOUT, typename TYPE,
+          typename M=std::enable_if_t<std::is_integral<N>::value &&
+                                      (std::is_same<std::decay_t<TYPE>,Type::Inclusive>::value ||
+                                       std::is_same<std::decay_t<TYPE>,Type::Exclusive>::value)> >
+T PrefixSum (N n, FIN && fin, FOUT && fout, TYPE type, RetSum a_ret_sum = retSum)
+{
+    if (n <= 0) return 0;
+    constexpr int nwarps_per_block = 8;
+    constexpr int nthreads = nwarps_per_block*Gpu::Device::warp_size;
+    constexpr int nchunks = 12;
+    constexpr int nelms_per_block = nthreads * nchunks;
+    AMREX_ALWAYS_ASSERT(static_cast<Long>(n) < static_cast<Long>(std::numeric_limits<int>::max())*nelms_per_block);
+    int nblocks = (static_cast<Long>(n) + nelms_per_block - 1) / nelms_per_block;
+
+#ifndef AMREX_DPCPP_NO_MULTIPASS_SCAN
+    if (nblocks > 1) {
+        return PrefixSum_mp<T>(n, std::forward<FIN>(fin), std::forward<FOUT>(fout), type, retSum);
+    }
+#endif
+
     std::size_t sm = sizeof(T) * (Gpu::Device::warp_size + nwarps_per_block) + sizeof(int);
     auto stream = Gpu::gpuStream();
 


### PR DESCRIPTION
A multi-pass algorithm is implemented.  Extensive testing on early hardware
shows it works for int, but there are still issues with long.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
