### PR TITLE
Disable warning on atomicAddNoRet in HIP

### DIFF
--- a/Src/Base/AMReX_GpuAtomic.H
+++ b/Src/Base/AMReX_GpuAtomic.H
@@ -274,7 +274,10 @@ namespace detail {
     void AddNoRet (float* const sum, float const value) noexcept
     {
 #if AMREX_DEVICE_COMPILE
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         atomicAddNoRet(sum, value);
+#pragma clang diagnostic pop
 #else
         *sum += value;
 #endif


### PR DESCRIPTION
It seems that we may continue using the deprecated atomicAddNoRet in the
near future.  This disables the compiler warning.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
