### PR TITLE
Fix multi-level EB nodal solver solvability fix

### DIFF
--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian.H
@@ -175,6 +175,7 @@ private:
     Real m_const_sigma = Real(0.0);
     Vector<Vector<Array<std::unique_ptr<MultiFab>,AMREX_SPACEDIM> > > m_sigma;
     Vector<Vector<std::unique_ptr<MultiFab> > > m_stencil;
+    Vector<std::unique_ptr<MultiFab> > m_nosigma_stencil;
     Vector<Vector<Real> > m_s0_norm0;
 
     Real m_normalization_threshold = Real(1.e-8);

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian.cpp
@@ -534,7 +534,7 @@ MLNodeLaplacian::restrictInteriorNodes (int camrlev, MultiFab& crhs, MultiFab& a
     const auto hibc = HiBC();
 
     const iMultiFab& fdmsk = *m_dirichlet_mask[camrlev+1][0];
-    const auto& stencil    =  m_stencil[camrlev+1][0];
+    const auto& stencil    =  m_nosigma_stencil[camrlev+1];
 
     MultiFab cfine(amrex::coarsen(fba, amrrr), fdm, 1, 0);
 

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian_sync.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian_sync.cpp
@@ -657,7 +657,7 @@ MLNodeLaplacian::reflux (int crse_amrlev,
     const DistributionMapping& fdm = fine_sol.DistributionMap();
 
     const iMultiFab& fdmsk = *m_dirichlet_mask[crse_amrlev+1][0];
-    const auto& stencil    =  m_stencil[crse_amrlev+1][0];
+    const auto& stencil    =  m_nosigma_stencil[crse_amrlev+1];
 
     MultiFab fine_res_for_coarse(amrex::coarsen(fba, amrrr), fdm, 1, 0);
 


### PR DESCRIPTION
For the multi-level EB nodal solver with a singular matrix, we restrict the
fine level RHS to the coarse level, and fix the coarse level's solvability
by making the total sum of RHS is zero.  The restriction is done with the
stencil instead of simply geometric restriction because we need to take the
EB into account.  However, the previous way is incorrect if the sigma
coefficient is not a constant, because the stencil includes sigma.  But the
restriction should be based on EB information only.  In this commit, we fix
this by constructing a special constant sigma stencil.  We use this new
stencil for the restriction of RHS, and for consistence the residual as
well.  Because we used to use the original stencil for the restriction of
residual, this commit will change the answer at the tolerance level for
multi-level problems.

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
