### PR TITLE
Added special case for Mac when using rpath

### DIFF
--- a/Tools/GNUMake/Make.defs
+++ b/Tools/GNUMake/Make.defs
@@ -877,7 +877,12 @@ CPPFLAGS	+= $(DEFINES)
 libraries	= $(XTRAOBJS) $(LIBRARIES) $(XTRALIBS)
 
 ifeq ($(USE_RPATH),TRUE)
-  LDFLAGS	+= -Xlinker -rpath='$(abspath .)' $(addprefix -Xlinker -rpath=, $(abspath $(LIBRARY_LOCATIONS)))
+  ifeq ($(shell uname),Darwin)
+      # The mac loader, ld, does not like the "=" with rpath
+      LDFLAGS	+= -Xlinker -rpath '$(abspath .)' $(addprefix -Xlinker -rpath , $(abspath $(LIBRARY_LOCATIONS)))
+  else
+      LDFLAGS	+= -Xlinker -rpath='$(abspath .)' $(addprefix -Xlinker -rpath=, $(abspath $(LIBRARY_LOCATIONS)))
+  endif
 endif
 LDFLAGS	+= -L. $(addprefix -L, $(LIBRARY_LOCATIONS))
 


### PR DESCRIPTION
## Summary
When building on a Mac, add a special definition of `LDFLAGS` that does not use equals signs for the `rpath` arguments. This is in response to PR #2439.

## Additional background
The built in loader on the Mac, `ld`, does not accept the equals sign with the `rpath` argument. It must be a space.

## Checklist

The proposed changes:
- [X ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
