### PR TITLE
Fix a corner case in fixing small cells.

### DIFF
--- a/Src/EB/AMReX_EB2_GeometryShop.H
+++ b/Src/EB/AMReX_EB2_GeometryShop.H
@@ -429,22 +429,41 @@ public:
             AMREX_HOST_DEVICE_PARALLEL_FOR_3D (bx, i, j, k,
             {
                 if (type(i,j,k) == Type::irregular) {
+                    bool is_nan = amrex::isnan(inter(i,j,k));
                     if (idim == 0) {
-                        if (lst(i,j,k) == Real(0.0)) {
+                        if (lst(i,j,k) == Real(0.0) ||
+                            (lst(i,j,k) > Real(0.0) && is_nan))
+                        {
+                            // interp might still be quiet_nan because lst that
+                            // was set to zero has been changed by FillBoundary
+                            // at periodic bounadries.
                             inter(i,j,k) = problo[0] + i*dx[0];
-                        } else if (lst(i+1,j,k) == Real(0.0)) {
+                        }
+                        else if (lst(i+1,j,k) == Real(0.0) ||
+                                 (lst(i+1,j,k) > Real(0.0) && is_nan))
+                        {
                             inter(i,j,k) = problo[0] + (i+1)*dx[0];
                         }
                     } else if (idim == 1) {
-                        if (lst(i,j,k) == Real(0.0)) {
+                        if (lst(i,j,k) == Real(0.0) ||
+                            (lst(i,j,k) > Real(0.0) && is_nan))
+                        {
                             inter(i,j,k) = problo[1] + j*dx[1];
-                        } else if (lst(i,j+1,k) == Real(0.0)) {
+                        }
+                        else if (lst(i,j+1,k) == Real(0.0) ||
+                                 (lst(i,j+1,k) > Real(0.0) && is_nan))
+                        {
                             inter(i,j,k) = problo[1] + (j+1)*dx[1];
                         }
                     } else {
-                        if (lst(i,j,k) == Real(0.0)) {
+                        if (lst(i,j,k) == Real(0.0) ||
+                            (lst(i,j,k) > Real(0.0) && is_nan))
+                        {
                             inter(i,j,k) = problo[2] + k*dx[2];
-                        } else if (lst(i,j,k+1) == Real(0.0)) {
+                        }
+                        else if (lst(i,j,k+1) == Real(0.0) ||
+                                 (lst(i,j,k+1) > Real(0.0) && is_nan))
+                        {
                             inter(i,j,k) = problo[2] + (k+1)*dx[2];
                         }
                     }


### PR DESCRIPTION
During the iteration of fixing small cells, the edge types and level sets
could become inconsistent if the fixed small cells are too close to periodic
boundaries.  The function that updates the edge types did not take that into
account.  This commit fixes that.

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
