### PR TITLE
Fix HIP CI

### DIFF
--- a/.github/workflows/hip.yml
+++ b/.github/workflows/hip.yml
@@ -96,7 +96,6 @@ jobs:
             -DCMAKE_CXX_COMPILER=$(which hipcc)           \
             -DCMAKE_CXX_COMPILER_ID="Clang"               \
             -DCMAKE_CXX_COMPILER_VERSION=12.0             \
-            -DCMAKE_CXX_STANDARD_COMPUTED_DEFAULT="17"    \
             -DCMAKE_Fortran_COMPILER=$(which gfortran)    \
             -DCMAKE_CXX_STANDARD=17
         cmake --build build_full_legacywrapper -j 2

--- a/.github/workflows/hip.yml
+++ b/.github/workflows/hip.yml
@@ -94,8 +94,6 @@ jobs:
             -DAMReX_AMD_ARCH=gfx908                       \
             -DCMAKE_C_COMPILER=$(which clang)             \
             -DCMAKE_CXX_COMPILER=$(which hipcc)           \
-            -DCMAKE_CXX_COMPILER_ID="Clang"               \
-            -DCMAKE_CXX_COMPILER_VERSION=12.0             \
             -DCMAKE_Fortran_COMPILER=$(which gfortran)    \
             -DCMAKE_CXX_STANDARD=17
         cmake --build build_full_legacywrapper -j 2


### PR DESCRIPTION
It's not correctly being passed the "-std=c++17" flag.

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
