### PR TITLE
Move Basic Time Integration into AMReX

### DIFF
--- a/Docs/sphinx_documentation/source/TimeIntegration_Chapter.rst
+++ b/Docs/sphinx_documentation/source/TimeIntegration_Chapter.rst
@@ -1,0 +1,101 @@
+
+.. _sec:basics:timeintegration:
+
+Time Integration
+================
+
+AMReX provides a basic explicit time integrator capable of Forward Euler or
+both predefined and custom Runge-Kutta schemes designed to advance data on a
+particular AMR level by a timestep. This integrator is designed to be flexible,
+requiring the user to supply a right-hand side function taking a ``MultiFab``
+of state data and filling a ``MultiFab`` of the corresponding right hand side
+data. The user simply needs to supply a C++ lambda function to implement
+whatever right hand side operations they need.
+
+A Simple Time Integrator Setup
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This is best shown with some sample code that sets up a time integrator and
+asks it to step forwards by some interval ``dt``. The user needs to supply at
+minimum, the right-hand side function using the ``TimeIntegrator::set_rhs()``
+function. A user can also supply a post update function which is called on
+state data immediately before evaluating the right-hand side. This post update
+function is a good opportunity to fill boundary conditions for Runge-Kutta
+stage solution data so that ghost cells are filled when the right hand side
+function is called on that solution data.
+
+.. highlight:: c++
+
+::
+
+   #include <AMReX_TimeIntegrator.H>
+
+   MultiFab Sborder; // MultiFab containing old-time state data and ghost cells
+   MultiFab Snew;    // MultiFab where we want new-time state data
+   Geometry geom;    // The domain (or level) geometry
+
+   // [Fill Sborder here]
+
+   // Create a time integrator that will work with
+   // MultiFabs with the same BoxArray, DistributionMapping,
+   // and number of components as the state_data MultiFab.
+   TimeIntegrator<MultiFab> integrator(Sborder);
+
+   // Create a RHS source function we will integrate
+   auto source_fun = [&](MultiFab& rhs, const MultiFab& state, const Real time){
+       // User function to calculate the rhs MultiFab given the state MultiFab
+       fill_rhs(rhs, state, time);
+   };
+
+   // Create a function to call after updating a state
+   auto post_update_fun = [&](MultiFab& S_data, const Real time) {
+       // Call user function to update state MultiFab, e.g. fill BCs
+       post_update(S_data, time, geom);
+   };
+
+   // Attach the right hand side and post-update functions
+   // to the integrator
+   integrator.set_rhs(source_fun);
+   integrator.set_post_update(post_update_fun);
+
+   // integrate forward one step from `time` by `dt` to fill S_new
+   integrator.advance(Sborder, S_new, time, dt);
+
+
+Picking A Time Integration Method
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The user can customize which integration method they wish to use with a set of
+runtime paramters that allow choosing between a simple Forward Euler method or
+a generic explicit Runge-Kutta method. If Runge-Kutta is selected, then the
+user can choose which of a set of predefined Butcher Tables to use, or can
+choose to use a custom table and supply it manually. The options are detailed as follows:
+
+::
+
+  # INTEGRATION
+  ## integration.type can take on the following values:
+  ## 0 = Forward Euler
+  ## 1 = Explicit Runge Kutta
+  integration.type = 1
+
+  ## Explicit Runge-Kutta parameters
+  #
+  ## integration.rk.type can take the following values:
+  ### 0 = User-specified Butcher Tableau
+  ### 1 = Forward Euler
+  ### 2 = Trapezoid Method
+  ### 3 = SSPRK3 Method
+  ### 4 = RK4 Method
+  integration.rk.type = 3
+
+  ## If using a user-specified Butcher Tableau, then
+  ## set nodes, weights, and table entries here:
+  #
+  ## The Butcher Tableau is read as a flattened,
+  ## lower triangular matrix (but including the diagonal)
+  ## in row major format.
+  integration.rk.weights = 1
+  integration.rk.nodes = 0
+  integration.rk.tableau = 0.0
+

--- a/Docs/sphinx_documentation/source/TimeIntegration_Chapter.rst
+++ b/Docs/sphinx_documentation/source/TimeIntegration_Chapter.rst
@@ -66,7 +66,7 @@ Picking A Time Integration Method
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The user can customize which integration method they wish to use with a set of
-runtime paramters that allow choosing between a simple Forward Euler method or
+runtime parameters that allow choosing between a simple Forward Euler method or
 a generic explicit Runge-Kutta method. If Runge-Kutta is selected, then the
 user can choose which of a set of predefined Butcher Tables to use, or can
 choose to use a custom table and supply it manually. The options are detailed as follows:

--- a/Docs/sphinx_documentation/source/TimeIntegration_Chapter.rst
+++ b/Docs/sphinx_documentation/source/TimeIntegration_Chapter.rst
@@ -18,11 +18,11 @@ A Simple Time Integrator Setup
 This is best shown with some sample code that sets up a time integrator and
 asks it to step forwards by some interval ``dt``. The user needs to supply at
 minimum, the right-hand side function using the ``TimeIntegrator::set_rhs()``
-function. A user can also supply a post update function which is called on
-state data immediately before evaluating the right-hand side. This post update
-function is a good opportunity to fill boundary conditions for Runge-Kutta
-stage solution data so that ghost cells are filled when the right hand side
-function is called on that solution data.
+function. By using the ``TimeIntegrator::set_post_update()`` function, a user
+can also supply a post update function which is called on state data immediately
+before evaluating the right-hand side. This post update function is a good
+opportunity to fill boundary conditions for Runge-Kutta stage solution data so that
+ghost cells are filled when the right hand side function is called on that solution data.
 
 .. highlight:: c++
 

--- a/Docs/sphinx_documentation/source/index.rst
+++ b/Docs/sphinx_documentation/source/index.rst
@@ -52,6 +52,7 @@ Documentation on migration from BoxLib is available in the AMReX repository at D
    Particle_Chapter
    Fortran_Chapter
    EB_Chapter
+   TimeIntegration_Chapter
    GPU_Chapter
    Visualization_Chapter
    Post_Processing_Chapter

--- a/Src/Base/AMReX_FEIntegrator.H
+++ b/Src/Base/AMReX_FEIntegrator.H
@@ -1,0 +1,58 @@
+#ifndef AMREX_FE_INTEGRATOR_H
+#define AMREX_FE_INTEGRATOR_H
+#include <functional>
+#include <AMReX_REAL.H>
+#include <AMReX_Vector.H>
+#include "AMReX_IntegratorBase.H"
+
+template<class T>
+class FEIntegrator : public IntegratorBase<T>
+{
+private:
+    typedef IntegratorBase<T> BaseT;
+
+    amrex::Vector<std::unique_ptr<T> > F_nodes;
+
+public:
+    FEIntegrator(T& S_data)
+    {
+        IntegratorOps<T>::CreateLike(F_nodes, S_data);
+    }
+
+    virtual ~FEIntegrator() {}
+
+    amrex::Real advance(T& S_old, T& S_new, amrex::Real time, const amrex::Real timestep)
+    {
+        // Assume before advance() that S_old is valid data at the current time ("time" argument)
+        // So we initialize S_new by copying the old state.
+        IntegratorOps<T>::Copy(S_new, S_old);
+
+        // F = RHS(S, t)
+        T& F = *F_nodes[0];
+        BaseT::rhs(F, S_new, time);
+
+        // S_new += timestep * dS/dt
+        IntegratorOps<T>::Saxpy(S_new, timestep, F);
+
+        // Call the post-update hook for S_new
+        BaseT::post_update(S_new, time + timestep);
+
+        // Return timestep
+        return timestep;
+    }
+
+    void time_interpolate(const T& S_new, const T& S_old, amrex::Real timestep_fraction, T& data)
+    {
+        amrex::Error("Time interpolation not yet supported by forward euler integrator.");
+    }
+
+    void map_data(std::function<void(T&)> Map)
+    {
+        for (auto& F : F_nodes) {
+            Map(*F);
+        }
+    }
+
+};
+
+#endif

--- a/Src/Base/AMReX_FEIntegrator.H
+++ b/Src/Base/AMReX_FEIntegrator.H
@@ -1,9 +1,11 @@
 #ifndef AMREX_FE_INTEGRATOR_H
 #define AMREX_FE_INTEGRATOR_H
-#include <functional>
 #include <AMReX_REAL.H>
 #include <AMReX_Vector.H>
-#include "AMReX_IntegratorBase.H"
+#include <AMReX_IntegratorBase.H>
+#include <functional>
+
+namespace amrex {
 
 template<class T>
 class FEIntegrator : public IntegratorBase<T>
@@ -54,5 +56,7 @@ public:
     }
 
 };
+
+}
 
 #endif

--- a/Src/Base/AMReX_FEIntegrator.H
+++ b/Src/Base/AMReX_FEIntegrator.H
@@ -55,7 +55,7 @@ public:
         return timestep;
     }
 
-    void time_interpolate(const T& S_new, const T& S_old, amrex::Real timestep_fraction, T& data)
+    virtual void time_interpolate(const T& S_new, const T& S_old, amrex::Real timestep_fraction, T& data) override
     {
         amrex::Error("Time interpolation not yet supported by forward euler integrator.");
     }

--- a/Src/Base/AMReX_FEIntegrator.H
+++ b/Src/Base/AMReX_FEIntegrator.H
@@ -15,27 +15,27 @@ private:
 
     amrex::Vector<std::unique_ptr<T> > F_nodes;
 
-    void initialize_stages(const T& S_data)
+    void initialize_stages (const T& S_data)
     {
         IntegratorOps<T>::CreateLike(F_nodes, S_data);
     }
 
 public:
-    FEIntegrator() {}
+    FEIntegrator () {}
 
-    FEIntegrator(const T& S_data)
+    FEIntegrator (const T& S_data)
     {
         initialize(S_data);
     }
 
-    virtual ~FEIntegrator() {}
+    virtual ~FEIntegrator () {}
 
-    void initialize(const T& S_data)
+    void initialize (const T& S_data)
     {
         initialize_stages(S_data);
     }
 
-    amrex::Real advance(T& S_old, T& S_new, amrex::Real time, const amrex::Real timestep)
+    amrex::Real advance (T& S_old, T& S_new, amrex::Real time, const amrex::Real timestep)
     {
         // Assume before advance() that S_old is valid data at the current time ("time" argument)
         // So we initialize S_new by copying the old state.
@@ -55,12 +55,12 @@ public:
         return timestep;
     }
 
-    virtual void time_interpolate(const T& S_new, const T& S_old, amrex::Real timestep_fraction, T& data) override
+    virtual void time_interpolate (const T& S_new, const T& S_old, amrex::Real timestep_fraction, T& data) override
     {
         amrex::Error("Time interpolation not yet supported by forward euler integrator.");
     }
 
-    virtual void map_data(std::function<void(T&)> Map) override
+    virtual void map_data (std::function<void(T&)> Map) override
     {
         for (auto& F : F_nodes) {
             Map(*F);

--- a/Src/Base/AMReX_FEIntegrator.H
+++ b/Src/Base/AMReX_FEIntegrator.H
@@ -15,13 +15,25 @@ private:
 
     amrex::Vector<std::unique_ptr<T> > F_nodes;
 
-public:
-    FEIntegrator(T& S_data)
+    void initialize_stages(const T& S_data)
     {
         IntegratorOps<T>::CreateLike(F_nodes, S_data);
     }
 
+public:
+    FEIntegrator() {}
+
+    FEIntegrator(const T& S_data)
+    {
+        initialize(S_data);
+    }
+
     virtual ~FEIntegrator() {}
+
+    void initialize(const T& S_data)
+    {
+        initialize_stages(S_data);
+    }
 
     amrex::Real advance(T& S_old, T& S_new, amrex::Real time, const amrex::Real timestep)
     {

--- a/Src/Base/AMReX_FEIntegrator.H
+++ b/Src/Base/AMReX_FEIntegrator.H
@@ -60,7 +60,7 @@ public:
         amrex::Error("Time interpolation not yet supported by forward euler integrator.");
     }
 
-    void map_data(std::function<void(T&)> Map)
+    virtual void map_data(std::function<void(T&)> Map) override
     {
         for (auto& F : F_nodes) {
             Map(*F);

--- a/Src/Base/AMReX_IntegratorBase.H
+++ b/Src/Base/AMReX_IntegratorBase.H
@@ -1,0 +1,185 @@
+#ifndef AMREX_INTEGRATOR_BASE_H
+#define AMREX_INTEGRATOR_BASE_H
+#include <functional>
+#include <type_traits>
+#include <AMReX_REAL.H>
+#include <AMReX_Vector.H>
+#include <AMReX_MultiFab.H>
+
+#if defined(AMREX_PARTICLES)
+#include <AMReX_Particles.H>
+#endif
+
+template<class T, typename Tv = void> struct IntegratorOps;
+
+#if defined(AMREX_PARTICLES)
+template<class T>
+struct IntegratorOps<T, typename std::enable_if<std::is_base_of<amrex::ParticleContainerBase, T>::value>::type>
+{
+
+    static void CreateLike(amrex::Vector<std::unique_ptr<T> >& V, const T& Other)
+    {
+        // Emplace a new T in V with the same size as Other and get a reference
+        V.emplace_back(std::make_unique<T>(Other.Geom(0), Other.ParticleDistributionMap(0), Other.ParticleBoxArray(0)));
+        T& pc = *V[V.size()-1];
+
+        // We want the particles to have all the same position, cpu, etc.
+        // as in Other, so do a copy from Other to our new particle container.
+        Copy(pc, Other);
+    }
+
+    static void Copy(T& Y, const T& Other)
+    {
+        // Copy the contents of Other into Y
+        const bool local = true;
+        Y.copyParticles(Other, local);
+    }
+
+    static void Saxpy(T& Y, const amrex::Real a, T& X)
+    {
+        // Calculate Y += a * X using a particle-level saxpy function supplied by the particle container T
+        typedef amrex::ParIter<T::NStructReal, T::NStructInt, T::NArrayReal, T::NArrayInt> TParIter;
+        typedef amrex::Particle<T::NStructReal, T::NStructInt> ParticleType;
+
+        int lev = 0;
+        TParIter pty(Y, lev);
+        TParIter ptx(X, lev);
+
+        auto checkValid = [&]() -> bool {
+            bool pty_v = pty.isValid();
+            bool ptx_v = ptx.isValid();
+            AMREX_ASSERT(pty_v == ptx_v);
+            return pty_v && ptx_v;
+        };
+
+        auto ptIncrement = [&](){ ++pty; ++ptx; };
+
+#ifdef _OPENMP
+#pragma omp parallel
+#endif
+        for (; checkValid(); ptIncrement())
+        {
+            const int npy  = pty.numParticles();
+            const int npx  = ptx.numParticles();
+            AMREX_ASSERT(npy == npx);
+
+            ParticleType* psy = &(pty.GetArrayOfStructs()[0]);
+            ParticleType* psx = &(ptx.GetArrayOfStructs()[0]);
+
+            auto particle_apply_rhs = T::particle_apply_rhs;
+
+            amrex::ParallelFor ( npy, [=] AMREX_GPU_DEVICE (int i) {
+                ParticleType& py = psy[i];
+                const ParticleType& px = psx[i];
+                particle_apply_rhs(py, a, px);
+            });
+        }
+    }
+
+};
+#endif
+
+template<class T>
+struct IntegratorOps<T, typename std::enable_if<std::is_same<amrex::Vector<std::unique_ptr<amrex::MultiFab> >, T>::value>::type>
+{
+
+    static void CreateLike(amrex::Vector<std::unique_ptr<T> >& V, const T& Other, bool Grow = true)
+    {
+        // Emplace a new T in V with the same size as Other
+        V.emplace_back(std::make_unique<T>());
+        for (auto const& other_mf : Other) {
+            int nGrow = Grow ? other_mf->nGrow() : 0;
+            V.back()->emplace_back(std::make_unique<amrex::MultiFab>(other_mf->boxArray(), other_mf->DistributionMap(), other_mf->nComp(), nGrow));
+        }
+    }
+
+    static void Copy(T& Y, const T& Other, bool Grow = true)
+    {
+        // Copy the contents of Other into Y
+        const int size = Y.size();
+        for (int i = 0; i < size; ++i) {
+            int nGrow = Grow ? Other[i]->nGrow() : 0;
+            amrex::MultiFab::Copy(*Y[i], *Other[i], 0, 0, Other[i]->nComp(), nGrow);
+        }
+    }
+
+    static void Saxpy(T& Y, const amrex::Real a, const T& X, bool Grow = false)
+    {
+        // Calculate Y += a * X
+        const int size = Y.size();
+        for (int i = 0; i < size; ++i) {
+            int nGrow = Grow ? X[i]->nGrow() : 0;
+            amrex::MultiFab::Saxpy(*Y[i], a, *X[i], 0, 0, X[i]->nComp(), nGrow);
+        }
+    }
+
+};
+
+template<class T>
+struct IntegratorOps<T, typename std::enable_if<std::is_same<amrex::MultiFab, T>::value>::type>
+{
+
+    static void CreateLike(amrex::Vector<std::unique_ptr<T> >& V, const T& Other, bool Grow = false)
+    {
+        // Emplace a new T in V with the same size as Other
+        int nGrow = Grow ? Other.nGrow() : 0;
+        V.emplace_back(std::make_unique<T>(Other.boxArray(), Other.DistributionMap(), Other.nComp(), nGrow));
+    }
+
+    static void Copy(T& Y, const T& Other, bool Grow = true)
+    {
+        // Copy the contents of Other into Y
+        int nGrow = Grow ? Other.nGrow() : 0;
+        amrex::MultiFab::Copy(Y, Other, 0, 0, Other.nComp(), nGrow);
+    }
+
+    static void Saxpy(T& Y, const amrex::Real a, const T& X, bool Grow = false)
+    {
+        // Calculate Y += a * X
+        int nGrow = Grow ? X.nGrow() : 0;
+        amrex::MultiFab::Saxpy(Y, a, X, 0, 0, X.nComp(), nGrow);
+    }
+
+};
+
+template<class T>
+class IntegratorBase
+{
+private:
+    std::function<void(T&, const T&, const amrex::Real)> Fun;
+
+protected:
+    std::function<void (T&, amrex::Real)> post_update;
+
+public:
+    amrex::Real timestep;
+    IntegratorBase() {}
+
+    virtual ~IntegratorBase() {}
+
+    void set_rhs(std::function<void(T&, const T&, const amrex::Real)> F)
+    {
+        Fun = F;
+    }
+
+    void set_post_update(std::function<void (T&, amrex::Real)> F)
+    {
+        post_update = F;
+    }
+
+    virtual amrex::Real advance(T& S_old, T& S_new, amrex::Real time, const amrex::Real timestep)
+    {
+        return timestep;
+    }
+
+    void rhs(T& S_rhs, const T& S_data, const amrex::Real time)
+    {
+        Fun(S_rhs, S_data, time);
+    }
+
+    virtual void time_interpolate(const T& S_new, const T& S_old, amrex::Real timestep_fraction, T& data) {}
+
+    virtual void map_data(std::function<void(T&)> Map) {}
+};
+
+#endif

--- a/Src/Base/AMReX_IntegratorBase.H
+++ b/Src/Base/AMReX_IntegratorBase.H
@@ -126,7 +126,7 @@ struct IntegratorOps<T, typename std::enable_if<std::is_same<amrex::MultiFab, T>
     static void CreateLike(amrex::Vector<std::unique_ptr<T> >& V, const T& Other, bool Grow = false)
     {
         // Emplace a new T in V with the same size as Other
-        int nGrow = Grow ? Other.nGrow() : 0;
+        IntVect nGrow = Grow ? Other.nGrowVect() : IntVect(0);
         V.emplace_back(std::make_unique<T>(Other.boxArray(), Other.DistributionMap(), Other.nComp(), nGrow));
     }
 

--- a/Src/Base/AMReX_IntegratorBase.H
+++ b/Src/Base/AMReX_IntegratorBase.H
@@ -87,7 +87,7 @@ template<class T>
 struct IntegratorOps<T, typename std::enable_if<std::is_same<amrex::Vector<std::unique_ptr<amrex::MultiFab> >, T>::value>::type>
 {
 
-    static void CreateLike(amrex::Vector<std::unique_ptr<T> >& V, const T& Other, bool Grow = true)
+    static void CreateLike(amrex::Vector<std::unique_ptr<T> >& V, const T& Other, bool Grow = false)
     {
         // Emplace a new T in V with the same size as Other
         V.emplace_back(std::make_unique<T>());

--- a/Src/Base/AMReX_IntegratorBase.H
+++ b/Src/Base/AMReX_IntegratorBase.H
@@ -157,9 +157,14 @@ protected:
 
 public:
     amrex::Real timestep;
+
     IntegratorBase() {}
 
+    virtual IntegratorBase(const T& S_data) = 0;
+
     virtual ~IntegratorBase() {}
+
+    virtual void initialize(const T& S_data) = 0;
 
     void set_rhs(std::function<void(T&, const T&, const amrex::Real)> F)
     {

--- a/Src/Base/AMReX_IntegratorBase.H
+++ b/Src/Base/AMReX_IntegratorBase.H
@@ -59,7 +59,7 @@ struct IntegratorOps<T, typename std::enable_if<std::is_base_of<amrex::ParticleC
         auto ptIncrement = [&](){ ++pty; ++ptx; };
 
 #ifdef AMREX_USE_OMP
-#pragma omp parallel
+#pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
         for (; checkValid(); ptIncrement())
         {

--- a/Src/Base/AMReX_IntegratorBase.H
+++ b/Src/Base/AMReX_IntegratorBase.H
@@ -167,9 +167,9 @@ public:
         post_update = F;
     }
 
-    virtual amrex::Real advance(T& S_old, T& S_new, amrex::Real time, const amrex::Real timestep)
+    virtual amrex::Real advance(T& S_old, T& S_new, amrex::Real time, const amrex::Real dt)
     {
-        return timestep;
+        return dt;
     }
 
     void rhs(T& S_rhs, const T& S_data, const amrex::Real time)

--- a/Src/Base/AMReX_IntegratorBase.H
+++ b/Src/Base/AMReX_IntegratorBase.H
@@ -133,14 +133,14 @@ struct IntegratorOps<T, typename std::enable_if<std::is_same<amrex::MultiFab, T>
     static void Copy(T& Y, const T& Other, bool Grow = true)
     {
         // Copy the contents of Other into Y
-        int nGrow = Grow ? Other.nGrow() : 0;
+        IntVect nGrow = Grow ? Other.nGrowVect() : IntVect(0);
         amrex::MultiFab::Copy(Y, Other, 0, 0, Other.nComp(), nGrow);
     }
 
     static void Saxpy(T& Y, const amrex::Real a, const T& X, bool Grow = false)
     {
         // Calculate Y += a * X
-        int nGrow = Grow ? X.nGrow() : 0;
+        IntVect nGrow = Grow ? X.nGrowVect() : IntVect(0);
         amrex::MultiFab::Saxpy(Y, a, X, 0, 0, X.nComp(), nGrow);
     }
 

--- a/Src/Base/AMReX_IntegratorBase.H
+++ b/Src/Base/AMReX_IntegratorBase.H
@@ -1,7 +1,6 @@
 #ifndef AMREX_INTEGRATOR_BASE_H
 #define AMREX_INTEGRATOR_BASE_H
-#include <functional>
-#include <type_traits>
+#include <AMReX_Config.H>
 #include <AMReX_REAL.H>
 #include <AMReX_Vector.H>
 #include <AMReX_MultiFab.H>
@@ -9,6 +8,11 @@
 #if defined(AMREX_PARTICLES)
 #include <AMReX_Particles.H>
 #endif
+
+#include <functional>
+#include <type_traits>
+
+namespace amrex {
 
 template<class T, typename Tv = void> struct IntegratorOps;
 
@@ -181,5 +185,7 @@ public:
 
     virtual void map_data(std::function<void(T&)> Map) {}
 };
+
+}
 
 #endif

--- a/Src/Base/AMReX_IntegratorBase.H
+++ b/Src/Base/AMReX_IntegratorBase.H
@@ -84,7 +84,7 @@ struct IntegratorOps<T, typename std::enable_if<std::is_base_of<amrex::ParticleC
 #endif
 
 template<class T>
-struct IntegratorOps<T, typename std::enable_if<std::is_same<amrex::Vector<std::unique_ptr<amrex::MultiFab> >, T>::value>::type>
+struct IntegratorOps<T, typename std::enable_if<std::is_same<amrex::Vector<amrex::MultiFab>, T>::value>::type>
 {
 
     static void CreateLike(amrex::Vector<std::unique_ptr<T> >& V, const T& Other, bool Grow = false)
@@ -92,8 +92,8 @@ struct IntegratorOps<T, typename std::enable_if<std::is_same<amrex::Vector<std::
         // Emplace a new T in V with the same size as Other
         V.emplace_back(std::make_unique<T>());
         for (auto const& other_mf : Other) {
-            IntVect nGrow = Grow ? other_mf->nGrowVect() : IntVect(0);
-            V.back()->emplace_back(std::make_unique<amrex::MultiFab>(other_mf->boxArray(), other_mf->DistributionMap(), other_mf->nComp(), nGrow));
+            IntVect nGrow = Grow ? other_mf.nGrowVect() : IntVect(0);
+            V.back()->push_back(amrex::MultiFab(other_mf.boxArray(), other_mf.DistributionMap(), other_mf.nComp(), nGrow));
         }
     }
 
@@ -102,8 +102,8 @@ struct IntegratorOps<T, typename std::enable_if<std::is_same<amrex::Vector<std::
         // Copy the contents of Other into Y
         const int size = Y.size();
         for (int i = 0; i < size; ++i) {
-            IntVect nGrow = Grow ? Other[i]->nGrowVect() : IntVect(0);
-            amrex::MultiFab::Copy(*Y[i], *Other[i], 0, 0, Other[i]->nComp(), nGrow);
+            IntVect nGrow = Grow ? Other[i].nGrowVect() : IntVect(0);
+            amrex::MultiFab::Copy(Y[i], Other[i], 0, 0, Other[i].nComp(), nGrow);
         }
     }
 
@@ -112,8 +112,8 @@ struct IntegratorOps<T, typename std::enable_if<std::is_same<amrex::Vector<std::
         // Calculate Y += a * X
         const int size = Y.size();
         for (int i = 0; i < size; ++i) {
-            IntVect nGrow = Grow ? X[i]->nGrowVect() : IntVect(0);
-            amrex::MultiFab::Saxpy(*Y[i], a, *X[i], 0, 0, X[i]->nComp(), nGrow);
+            IntVect nGrow = Grow ? X[i].nGrowVect() : IntVect(0);
+            amrex::MultiFab::Saxpy(Y[i], a, X[i], 0, 0, X[i].nComp(), nGrow);
         }
     }
 

--- a/Src/Base/AMReX_IntegratorBase.H
+++ b/Src/Base/AMReX_IntegratorBase.H
@@ -160,7 +160,7 @@ public:
 
     IntegratorBase() {}
 
-    virtual IntegratorBase(const T& S_data) = 0;
+    IntegratorBase(const T& S_data) {}
 
     virtual ~IntegratorBase() {}
 

--- a/Src/Base/AMReX_IntegratorBase.H
+++ b/Src/Base/AMReX_IntegratorBase.H
@@ -171,19 +171,16 @@ public:
         post_update = F;
     }
 
-    virtual amrex::Real advance(T& S_old, T& S_new, amrex::Real time, const amrex::Real dt)
-    {
-        return dt;
-    }
-
     void rhs(T& S_rhs, const T& S_data, const amrex::Real time)
     {
         Fun(S_rhs, S_data, time);
     }
 
-    virtual void time_interpolate(const T& S_new, const T& S_old, amrex::Real timestep_fraction, T& data) {}
+    virtual amrex::Real advance(T& S_old, T& S_new, amrex::Real time, const amrex::Real dt) = 0;
 
-    virtual void map_data(std::function<void(T&)> Map) {}
+    virtual void time_interpolate(const T& S_new, const T& S_old, amrex::Real timestep_fraction, T& data) = 0;
+
+    virtual void map_data(std::function<void(T&)> Map) = 0;
 };
 
 }

--- a/Src/Base/AMReX_IntegratorBase.H
+++ b/Src/Base/AMReX_IntegratorBase.H
@@ -21,7 +21,7 @@ template<class T>
 struct IntegratorOps<T, typename std::enable_if<std::is_base_of<amrex::ParticleContainerBase, T>::value>::type>
 {
 
-    static void CreateLike(amrex::Vector<std::unique_ptr<T> >& V, const T& Other)
+    static void CreateLike (amrex::Vector<std::unique_ptr<T> >& V, const T& Other)
     {
         // Emplace a new T in V with the same size as Other and get a reference
         V.emplace_back(std::make_unique<T>(Other.Geom(0), Other.ParticleDistributionMap(0), Other.ParticleBoxArray(0)));
@@ -32,14 +32,14 @@ struct IntegratorOps<T, typename std::enable_if<std::is_base_of<amrex::ParticleC
         Copy(pc, Other);
     }
 
-    static void Copy(T& Y, const T& Other)
+    static void Copy (T& Y, const T& Other)
     {
         // Copy the contents of Other into Y
         const bool local = true;
         Y.copyParticles(Other, local);
     }
 
-    static void Saxpy(T& Y, const amrex::Real a, T& X)
+    static void Saxpy (T& Y, const amrex::Real a, T& X)
     {
         // Calculate Y += a * X using a particle-level saxpy function supplied by the particle container T
         typedef amrex::ParIter<T::NStructReal, T::NStructInt, T::NArrayReal, T::NArrayInt> TParIter;
@@ -87,7 +87,7 @@ template<class T>
 struct IntegratorOps<T, typename std::enable_if<std::is_same<amrex::Vector<amrex::MultiFab>, T>::value>::type>
 {
 
-    static void CreateLike(amrex::Vector<std::unique_ptr<T> >& V, const T& Other, bool Grow = false)
+    static void CreateLike (amrex::Vector<std::unique_ptr<T> >& V, const T& Other, bool Grow = false)
     {
         // Emplace a new T in V with the same size as Other
         V.emplace_back(std::make_unique<T>());
@@ -97,7 +97,7 @@ struct IntegratorOps<T, typename std::enable_if<std::is_same<amrex::Vector<amrex
         }
     }
 
-    static void Copy(T& Y, const T& Other, bool Grow = true)
+    static void Copy (T& Y, const T& Other, bool Grow = true)
     {
         // Copy the contents of Other into Y
         const int size = Y.size();
@@ -107,7 +107,7 @@ struct IntegratorOps<T, typename std::enable_if<std::is_same<amrex::Vector<amrex
         }
     }
 
-    static void Saxpy(T& Y, const amrex::Real a, const T& X, bool Grow = false)
+    static void Saxpy (T& Y, const amrex::Real a, const T& X, bool Grow = false)
     {
         // Calculate Y += a * X
         const int size = Y.size();
@@ -123,21 +123,21 @@ template<class T>
 struct IntegratorOps<T, typename std::enable_if<std::is_same<amrex::MultiFab, T>::value>::type>
 {
 
-    static void CreateLike(amrex::Vector<std::unique_ptr<T> >& V, const T& Other, bool Grow = false)
+    static void CreateLike (amrex::Vector<std::unique_ptr<T> >& V, const T& Other, bool Grow = false)
     {
         // Emplace a new T in V with the same size as Other
         IntVect nGrow = Grow ? Other.nGrowVect() : IntVect(0);
         V.emplace_back(std::make_unique<T>(Other.boxArray(), Other.DistributionMap(), Other.nComp(), nGrow));
     }
 
-    static void Copy(T& Y, const T& Other, bool Grow = true)
+    static void Copy (T& Y, const T& Other, bool Grow = true)
     {
         // Copy the contents of Other into Y
         IntVect nGrow = Grow ? Other.nGrowVect() : IntVect(0);
         amrex::MultiFab::Copy(Y, Other, 0, 0, Other.nComp(), nGrow);
     }
 
-    static void Saxpy(T& Y, const amrex::Real a, const T& X, bool Grow = false)
+    static void Saxpy (T& Y, const amrex::Real a, const T& X, bool Grow = false)
     {
         // Calculate Y += a * X
         IntVect nGrow = Grow ? X.nGrowVect() : IntVect(0);
@@ -158,34 +158,34 @@ protected:
 public:
     amrex::Real timestep;
 
-    IntegratorBase() {}
+    IntegratorBase () {}
 
-    IntegratorBase(const T& S_data) {}
+    IntegratorBase (const T& S_data) {}
 
-    virtual ~IntegratorBase() {}
+    virtual ~IntegratorBase () {}
 
-    virtual void initialize(const T& S_data) = 0;
+    virtual void initialize (const T& S_data) = 0;
 
-    void set_rhs(std::function<void(T&, const T&, const amrex::Real)> F)
+    void set_rhs (std::function<void(T&, const T&, const amrex::Real)> F)
     {
         Fun = F;
     }
 
-    void set_post_update(std::function<void (T&, amrex::Real)> F)
+    void set_post_update (std::function<void (T&, amrex::Real)> F)
     {
         post_update = F;
     }
 
-    void rhs(T& S_rhs, const T& S_data, const amrex::Real time)
+    void rhs (T& S_rhs, const T& S_data, const amrex::Real time)
     {
         Fun(S_rhs, S_data, time);
     }
 
-    virtual amrex::Real advance(T& S_old, T& S_new, amrex::Real time, const amrex::Real dt) = 0;
+    virtual amrex::Real advance (T& S_old, T& S_new, amrex::Real time, const amrex::Real dt) = 0;
 
-    virtual void time_interpolate(const T& S_new, const T& S_old, amrex::Real timestep_fraction, T& data) = 0;
+    virtual void time_interpolate (const T& S_new, const T& S_old, amrex::Real timestep_fraction, T& data) = 0;
 
-    virtual void map_data(std::function<void(T&)> Map) = 0;
+    virtual void map_data (std::function<void(T&)> Map) = 0;
 };
 
 }

--- a/Src/Base/AMReX_IntegratorBase.H
+++ b/Src/Base/AMReX_IntegratorBase.H
@@ -112,7 +112,7 @@ struct IntegratorOps<T, typename std::enable_if<std::is_same<amrex::Vector<std::
         // Calculate Y += a * X
         const int size = Y.size();
         for (int i = 0; i < size; ++i) {
-            int nGrow = Grow ? X[i]->nGrow() : 0;
+            IntVect nGrow = Grow ? X[i]->nGrowVect() : IntVect(0);
             amrex::MultiFab::Saxpy(*Y[i], a, *X[i], 0, 0, X[i]->nComp(), nGrow);
         }
     }

--- a/Src/Base/AMReX_IntegratorBase.H
+++ b/Src/Base/AMReX_IntegratorBase.H
@@ -102,7 +102,7 @@ struct IntegratorOps<T, typename std::enable_if<std::is_same<amrex::Vector<std::
         // Copy the contents of Other into Y
         const int size = Y.size();
         for (int i = 0; i < size; ++i) {
-            int nGrow = Grow ? Other[i]->nGrow() : 0;
+            IntVect nGrow = Grow ? Other[i]->nGrowVect() : IntVect(0);
             amrex::MultiFab::Copy(*Y[i], *Other[i], 0, 0, Other[i]->nComp(), nGrow);
         }
     }

--- a/Src/Base/AMReX_IntegratorBase.H
+++ b/Src/Base/AMReX_IntegratorBase.H
@@ -92,7 +92,7 @@ struct IntegratorOps<T, typename std::enable_if<std::is_same<amrex::Vector<std::
         // Emplace a new T in V with the same size as Other
         V.emplace_back(std::make_unique<T>());
         for (auto const& other_mf : Other) {
-            int nGrow = Grow ? other_mf->nGrow() : 0;
+            IntVect nGrow = Grow ? other_mf->nGrowVect() : IntVect(0);
             V.back()->emplace_back(std::make_unique<amrex::MultiFab>(other_mf->boxArray(), other_mf->DistributionMap(), other_mf->nComp(), nGrow));
         }
     }

--- a/Src/Base/AMReX_IntegratorBase.H
+++ b/Src/Base/AMReX_IntegratorBase.H
@@ -58,7 +58,7 @@ struct IntegratorOps<T, typename std::enable_if<std::is_base_of<amrex::ParticleC
 
         auto ptIncrement = [&](){ ++pty; ++ptx; };
 
-#ifdef _OPENMP
+#ifdef AMREX_USE_OMP
 #pragma omp parallel
 #endif
         for (; checkValid(); ptIncrement())

--- a/Src/Base/AMReX_RKIntegrator.H
+++ b/Src/Base/AMReX_RKIntegrator.H
@@ -1,0 +1,258 @@
+#ifndef AMREX_RK_INTEGRATOR_H
+#define AMREX_RK_INTEGRATOR_H
+#include <functional>
+#include <AMReX_REAL.H>
+#include <AMReX_Vector.H>
+#include <AMReX_ParmParse.H>
+#include "AMReX_IntegratorBase.H"
+
+namespace ButcherTableauTypes {
+    enum ButcherTypes {User = 0, ForwardEuler, Trapezoid, SSPRK3, RK4, NumTypes};
+};
+
+template<class T>
+class RKIntegrator : public IntegratorBase<T>
+{
+private:
+    amrex::Real timestep;
+    typedef IntegratorBase<T> BaseT;
+
+    int tableau_type;
+    int number_nodes;
+    bool use_adaptive_timestep;
+    amrex::Vector<std::unique_ptr<T> > F_nodes;
+    amrex::Vector<amrex::Vector<amrex::Real> > tableau;
+    amrex::Vector<amrex::Real> weights;
+    amrex::Vector<amrex::Real> extended_weights;
+    amrex::Vector<amrex::Real> nodes;
+
+    void initialize_preset_tableau()
+    {
+        switch (tableau_type)
+        {
+            case ButcherTableauTypes::ForwardEuler:
+                nodes = {0.0};
+                tableau = {{0.0}};
+                weights = {1.0};
+                break;
+            case ButcherTableauTypes::Trapezoid:
+                nodes = {0.0,
+                        1.0};
+                tableau = {{0.0},
+                        {1.0, 0.0}};
+                weights = {0.5, 0.5};
+                break;
+            case ButcherTableauTypes::SSPRK3:
+                nodes = {0.0,
+                        1.0,
+                        0.5};
+                tableau = {{0.0},
+                        {1.0, 0.0},
+                        {0.25, 0.25, 0.0}};
+                weights = {1./6., 1./6., 2./3.};
+                break;
+            case ButcherTableauTypes::RK4:
+                nodes = {0.0,
+                        0.5,
+                        0.5,
+                        1.0};
+                tableau = {{0.0},
+                        {0.5, 0.0},
+                        {0.0, 0.5, 0.0},
+                        {0.0, 0.0, 1.0, 0.0}};
+                weights = {1./6., 1./3., 1./3., 1./6.};
+                break;
+            default:
+                amrex::Error("Invalid RK Integrator tableau type");
+                break;
+        }
+
+        number_nodes = weights.size();
+    }
+
+    void initialize_parameters()
+    {
+        amrex::ParmParse pp("integration.rk");
+
+        // Read an integrator type, if not recognized, then read weights/nodes/butcher tableau
+        tableau_type = 0;
+        pp.query("type", tableau_type);
+
+        // By default, define no extended weights and no adaptive timestepping
+        extended_weights = {};
+        use_adaptive_timestep = false;
+        pp.query("use_adaptive_timestep", use_adaptive_timestep);
+
+        if (tableau_type == ButcherTableauTypes::User)
+        {
+            // Read weights/nodes/butcher tableau"
+            pp.queryarr("weights", weights);
+            pp.queryarr("extended_weights", extended_weights);
+            pp.queryarr("nodes", nodes);
+
+            amrex::Vector<amrex::Real> btable; // flattened into row major format
+            pp.queryarr("tableau", btable);
+
+            // Sanity check the inputs
+            if (weights.size() != nodes.size())
+            {
+                amrex::Error("integration.rk.weights should be the same length as integration.rk.nodes");
+            } else {
+                number_nodes = weights.size();
+                const int nTableau = (number_nodes * (number_nodes + 1)) / 2; // includes diagonal
+                if (btable.size() != nTableau)
+                {
+                    amrex::Error("integration.rk.tableau incorrect length - should include the Butcher Tableau diagonal.");
+                }
+            }
+
+            // Fill tableau from the flattened entries
+            int k = 0;
+            for (int i = 0; i < number_nodes; ++i)
+            {
+                amrex::Vector<amrex::Real> stage_row;
+                for (int j = 0; j <= i; ++j)
+                {
+                    stage_row.push_back(btable[k]);
+                    ++k;
+                }
+
+                tableau.push_back(stage_row);
+            }
+
+            // Check that this is an explicit method
+            for (const auto& astage : tableau)
+            {
+                if (astage.back() != 0.0)
+                {
+                    amrex::Error("RKIntegrator currently only supports explicit Butcher tableaus.");
+                }
+            }
+        } else if (tableau_type > ButcherTableauTypes::User && tableau_type < ButcherTableauTypes::NumTypes)
+        {
+            initialize_preset_tableau();
+        } else {
+            amrex::Error("RKIntegrator received invalid input for integration.rk.type");
+        }
+    }
+
+    void initialize_stages(const T& S_data)
+    {
+        // Create data for stage RHS
+        for (int i = 0; i < number_nodes; ++i)
+        {
+            IntegratorOps<T>::CreateLike(F_nodes, S_data);
+        }
+    }
+
+public:
+    RKIntegrator(const T& S_data)
+    {
+        initialize_parameters();
+        initialize_stages(S_data);
+    }
+
+    virtual ~RKIntegrator() {}
+
+    amrex::Real advance(T& S_old, T& S_new, amrex::Real time, const amrex::Real time_step)
+    {
+        timestep = time_step;
+        // Assume before advance() that S_old is valid data at the current time ("time" argument)
+        // And that if data is a MultiFab, both S_old and S_new contain ghost cells for evaluating a stencil based RHS
+        // We need this from S_old. This is convenient for S_new to have so we can use it
+        // as scratch space for stage values without creating a new scratch MultiFab with ghost cells.
+
+        // Fill the RHS F_nodes at each stage
+        for (int i = 0; i < number_nodes; ++i)
+        {
+            // Get current stage time, t = t_old + h * Ci
+            amrex::Real stage_time = time + timestep * nodes[i];
+
+            // Fill S_new with the solution value for evaluating F at the current stage
+            // Copy S_new = S_old
+            IntegratorOps<T>::Copy(S_new, S_old);
+            if (i > 0) {
+                // Saxpy across the tableau row:
+                // S_new += h * Aij * Fj
+                // We should fuse these kernels ...
+                for (int j = 0; j < i; ++j)
+                {
+                    IntegratorOps<T>::Saxpy(S_new, timestep * tableau[i][j], *F_nodes[j]);
+                }
+
+                // Call the post-update hook for the stage state value
+                BaseT::post_update(S_new, stage_time);
+            }
+
+            // Fill F[i], the RHS at the current stage
+            // F[i] = RHS(y, t) at y = stage_value, t = stage_time
+            BaseT::rhs(*F_nodes[i], S_new, stage_time);
+        }
+
+        // Fill new State, starting with S_new = S_old.
+        // Then Saxpy S_new += h * Wi * Fi for integration weights Wi
+        // We should fuse these kernels ...
+        IntegratorOps<T>::Copy(S_new, S_old);
+        for (int i = 0; i < number_nodes; ++i)
+        {
+            IntegratorOps<T>::Saxpy(S_new, timestep * weights[i], *F_nodes[i]);
+        }
+
+        // Call the post-update hook for S_new
+        BaseT::post_update(S_new, time + timestep);
+
+        // If we are working with an extended Butcher tableau, we can estimate the error here,
+        // and then calculate an adaptive timestep.
+
+        // Return timestep
+        return timestep;
+    }
+
+    void time_interpolate(const T& S_new, const T& S_old, amrex::Real timestep_fraction, T& data)
+    {
+        // data = S_old*(1-time_step_fraction) + S_new*(time_step_fraction)
+        /*
+        data.setVal(0);
+
+        IntegratorOps<T>::Saxpy(data, 1-timestep_fraction, S_old);
+        IntegratorOps<T>::Saxpy(data, timestep_fraction, S_new);
+        */
+
+
+        // currently we only do this for 4th order RK
+        AMREX_ASSERT(number_nodes == 4);
+
+        // fill data using MC Equation 39 at time + timestep_fraction * dt
+        amrex::Real c = 0;
+
+        // data = S_old
+        IntegratorOps<T>::Copy(data, S_old);
+
+        // data += (chi - 3/2 * chi^2 + 2/3 * chi^3) * k1
+        c = timestep_fraction - 1.5 * std::pow(timestep_fraction, 2) + 2./3. * std::pow(timestep_fraction, 3);
+        IntegratorOps<T>::Saxpy(data, c*timestep, *F_nodes[0]);
+
+        // data += (chi^2 - 2/3 * chi^3) * k2
+        c = std::pow(timestep_fraction, 2) - 2./3. * std::pow(timestep_fraction, 3);
+        IntegratorOps<T>::Saxpy(data, c*timestep, *F_nodes[1]);
+
+        // data += (chi^2 - 2/3 * chi^3) * k3
+        c = std::pow(timestep_fraction, 2) - 2./3. * std::pow(timestep_fraction, 3);
+        IntegratorOps<T>::Saxpy(data, c*timestep, *F_nodes[2]);
+
+        // data += (-1/2 * chi^2 + 2/3 * chi^3) * k4
+        c = -0.5 * std::pow(timestep_fraction, 2) + 2./3. * std::pow(timestep_fraction, 3);
+        IntegratorOps<T>::Saxpy(data, c*timestep, *F_nodes[3]);
+
+    }
+
+    void map_data(std::function<void(T&)> Map)
+    {
+        for (auto& F : F_nodes) {
+            Map(*F);
+        }
+    }
+
+};
+
+#endif

--- a/Src/Base/AMReX_RKIntegrator.H
+++ b/Src/Base/AMReX_RKIntegrator.H
@@ -33,7 +33,7 @@ private:
     amrex::Vector<amrex::Real> extended_weights;
     amrex::Vector<amrex::Real> nodes;
 
-    void initialize_preset_tableau()
+    void initialize_preset_tableau ()
     {
         switch (tableau_type)
         {
@@ -77,7 +77,7 @@ private:
         number_nodes = weights.size();
     }
 
-    void initialize_parameters()
+    void initialize_parameters ()
     {
         amrex::ParmParse pp("integration.rk");
 
@@ -144,7 +144,7 @@ private:
         }
     }
 
-    void initialize_stages(const T& S_data)
+    void initialize_stages (const T& S_data)
     {
         // Create data for stage RHS
         for (int i = 0; i < number_nodes; ++i)
@@ -154,22 +154,22 @@ private:
     }
 
 public:
-    RKIntegrator() {}
+    RKIntegrator () {}
 
-    RKIntegrator(const T& S_data)
+    RKIntegrator (const T& S_data)
     {
         initialize(S_data);
     }
 
-    void initialize(const T& S_data)
+    void initialize (const T& S_data)
     {
         initialize_parameters();
         initialize_stages(S_data);
     }
 
-    virtual ~RKIntegrator() {}
+    virtual ~RKIntegrator () {}
 
-    amrex::Real advance(T& S_old, T& S_new, amrex::Real time, const amrex::Real time_step)
+    amrex::Real advance (T& S_old, T& S_new, amrex::Real time, const amrex::Real time_step)
     {
         timestep = time_step;
         // Assume before advance() that S_old is valid data at the current time ("time" argument)
@@ -223,7 +223,7 @@ public:
         return timestep;
     }
 
-    void time_interpolate(const T& S_new, const T& S_old, amrex::Real timestep_fraction, T& data)
+    void time_interpolate (const T& S_new, const T& S_old, amrex::Real timestep_fraction, T& data)
     {
         // data = S_old*(1-time_step_fraction) + S_new*(time_step_fraction)
         /*
@@ -261,7 +261,7 @@ public:
 
     }
 
-    void map_data(std::function<void(T&)> Map)
+    void map_data (std::function<void(T&)> Map)
     {
         for (auto& F : F_nodes) {
             Map(*F);

--- a/Src/Base/AMReX_RKIntegrator.H
+++ b/Src/Base/AMReX_RKIntegrator.H
@@ -1,10 +1,12 @@
 #ifndef AMREX_RK_INTEGRATOR_H
 #define AMREX_RK_INTEGRATOR_H
-#include <functional>
 #include <AMReX_REAL.H>
 #include <AMReX_Vector.H>
 #include <AMReX_ParmParse.H>
-#include "AMReX_IntegratorBase.H"
+#include <AMReX_IntegratorBase.H>
+#include <functional>
+
+namespace amrex {
 
 namespace ButcherTableauTypes {
     enum ButcherTypes {User = 0, ForwardEuler, Trapezoid, SSPRK3, RK4, NumTypes};
@@ -254,5 +256,7 @@ public:
     }
 
 };
+
+}
 
 #endif

--- a/Src/Base/AMReX_RKIntegrator.H
+++ b/Src/Base/AMReX_RKIntegrator.H
@@ -8,8 +8,13 @@
 
 namespace amrex {
 
-namespace ButcherTableauTypes {
-    enum ButcherTypes {User = 0, ForwardEuler, Trapezoid, SSPRK3, RK4, NumTypes};
+enum struct ButcherTableauTypes {
+    User = 0,
+    ForwardEuler,
+    Trapezoid,
+    SSPRK3,
+    RK4,
+    NumTypes
 };
 
 template<class T>

--- a/Src/Base/AMReX_RKIntegrator.H
+++ b/Src/Base/AMReX_RKIntegrator.H
@@ -153,7 +153,14 @@ private:
     }
 
 public:
+    RKIntegrator() {}
+
     RKIntegrator(const T& S_data)
+    {
+        initialize(S_data);
+    }
+
+    void initialize(const T& S_data)
     {
         initialize_parameters();
         initialize_stages(S_data);

--- a/Src/Base/AMReX_RKIntegrator.H
+++ b/Src/Base/AMReX_RKIntegrator.H
@@ -76,7 +76,7 @@ private:
 
         // Read an integrator type, if not recognized, then read weights/nodes/butcher tableau
         tableau_type = 0;
-        pp.query("type", tableau_type);
+        pp.get("type", tableau_type);
 
         // By default, define no extended weights and no adaptive timestepping
         extended_weights = {};
@@ -86,12 +86,12 @@ private:
         if (tableau_type == ButcherTableauTypes::User)
         {
             // Read weights/nodes/butcher tableau"
-            pp.queryarr("weights", weights);
+            pp.getarr("weights", weights);
             pp.queryarr("extended_weights", extended_weights);
-            pp.queryarr("nodes", nodes);
+            pp.getarr("nodes", nodes);
 
             amrex::Vector<amrex::Real> btable; // flattened into row major format
-            pp.queryarr("tableau", btable);
+            pp.getarr("tableau", btable);
 
             // Sanity check the inputs
             if (weights.size() != nodes.size())

--- a/Src/Base/AMReX_RKIntegrator.H
+++ b/Src/Base/AMReX_RKIntegrator.H
@@ -24,7 +24,7 @@ private:
     amrex::Real timestep;
     typedef IntegratorBase<T> BaseT;
 
-    int tableau_type;
+    ButcherTableauTypes tableau_type;
     int number_nodes;
     bool use_adaptive_timestep;
     amrex::Vector<std::unique_ptr<T> > F_nodes;
@@ -82,8 +82,9 @@ private:
         amrex::ParmParse pp("integration.rk");
 
         // Read an integrator type, if not recognized, then read weights/nodes/butcher tableau
-        tableau_type = 0;
-        pp.get("type", tableau_type);
+        int _tableau_type = 0;
+        pp.get("type", _tableau_type);
+        tableau_type = static_cast<ButcherTableauTypes>(_tableau_type);
 
         // By default, define no extended weights and no adaptive timestepping
         extended_weights = {};

--- a/Src/Base/AMReX_TimeIntegrator.H
+++ b/Src/Base/AMReX_TimeIntegrator.H
@@ -1,0 +1,116 @@
+#ifndef AMREX_TIME_INTEGRATOR_H
+#define AMREX_TIME_INTEGRATOR_H
+#include <functional>
+#include <AMReX_REAL.H>
+#include <AMReX_Vector.H>
+#include <AMReX_ParmParse.H>
+#include "AMReX_IntegratorBase.H"
+#include "AMReX_FEIntegrator.H"
+#include "AMReX_RKIntegrator.H"
+
+namespace IntegratorTypes {
+    enum TimeIntegratorTypes {ForwardEuler = 0,
+                              ExplicitRungeKutta};
+};
+
+template<class T>
+class TimeIntegrator
+{
+private:
+    std::unique_ptr<IntegratorBase<T> > integrator_ptr;
+    std::function<void ()> post_timestep;
+
+public:
+    TimeIntegrator(T& S_data)
+    {
+        amrex::ParmParse pp("integration");
+
+        int integrator_type = IntegratorTypes::ForwardEuler;
+        pp.query("type", integrator_type);
+
+        switch (integrator_type)
+        {
+            case IntegratorTypes::ForwardEuler:
+                integrator_ptr = std::make_unique<FEIntegrator<T> >(S_data);
+                break;
+            case IntegratorTypes::ExplicitRungeKutta:
+                integrator_ptr = std::make_unique<RKIntegrator<T> >(S_data);
+                break;
+            default:
+                amrex::Error("integration.type did not name a valid integrator type.");
+                break;
+        }
+
+        // By default, do nothing post-timestep
+        set_post_timestep([](){});
+
+        // By default, do nothing after updating the state
+        // In general, this is where BCs should be filled
+        set_post_update([](T& S_data, amrex::Real S_time){});
+
+        // By default, do nothing
+        set_rhs([](T& S_rhs, const T& S_data, const amrex::Real time){});
+    }
+
+    virtual ~TimeIntegrator() {}
+
+    void set_post_timestep(std::function<void ()> F)
+    {
+        post_timestep = F;
+    }
+
+    void set_post_update(std::function<void (T&, amrex::Real)> F)
+    {
+        integrator_ptr->set_post_update(F);
+    }
+
+    void set_rhs(std::function<void(T&, const T&, const amrex::Real)> F)
+    {
+        integrator_ptr->set_rhs(F);
+    }
+
+    void advance(T& S_old, T& S_new, amrex::Real time, const amrex::Real timestep)
+    {
+        integrator_ptr->advance(S_old, S_new, time, timestep);
+    }
+
+    void integrate(T& S_old, T& S_new, amrex::Real start_time, const amrex::Real start_timestep,
+                   const amrex::Real end_time, const int nsteps)
+    {
+        amrex::Real time = start_time;
+        amrex::Real timestep = start_timestep;
+        bool stop_advance = false;
+        for (int step_number = 0; step_number < nsteps && !stop_advance; ++step_number)
+        {
+            if (end_time - time < timestep) {
+                timestep = end_time - time;
+                stop_advance = true;
+            }
+
+            if (step_number > 0) {
+                std::swap(S_old, S_new);
+            }
+
+            // Call the time integrator advance
+            integrator_ptr->advance(S_old, S_new, time, timestep);
+
+            // Update our time variable
+            time += timestep;
+
+            // Call the post-timestep hook
+            post_timestep();
+        }
+    }
+
+    void time_interpolate(const T& S_new, const T& S_old, amrex::Real timestep_fraction, T& data)
+    {
+        integrator_ptr->time_interpolate(S_new, S_old, timestep_fraction, data);
+    }
+
+    void map_data(std::function<void(T&)> Map)
+    {
+        integrator_ptr->map_data(Map);
+    }
+};
+
+#endif

--- a/Src/Base/AMReX_TimeIntegrator.H
+++ b/Src/Base/AMReX_TimeIntegrator.H
@@ -26,7 +26,7 @@ public:
         amrex::ParmParse pp("integration");
 
         int integrator_type = IntegratorTypes::ForwardEuler;
-        pp.query("type", integrator_type);
+        pp.get("type", integrator_type);
 
         switch (integrator_type)
         {

--- a/Src/Base/AMReX_TimeIntegrator.H
+++ b/Src/Base/AMReX_TimeIntegrator.H
@@ -22,27 +22,18 @@ private:
     std::unique_ptr<IntegratorBase<T> > integrator_ptr;
     std::function<void ()> post_timestep;
 
-public:
-    TimeIntegrator(T& S_data)
+    IntegratorTypes read_parameters()
     {
         amrex::ParmParse pp("integration");
 
         int integrator_type = IntegratorTypes::ForwardEuler;
         pp.get("type", integrator_type);
 
-        switch (integrator_type)
-        {
-            case IntegratorTypes::ForwardEuler:
-                integrator_ptr = std::make_unique<FEIntegrator<T> >(S_data);
-                break;
-            case IntegratorTypes::ExplicitRungeKutta:
-                integrator_ptr = std::make_unique<RKIntegrator<T> >(S_data);
-                break;
-            default:
-                amrex::Error("integration.type did not name a valid integrator type.");
-                break;
-        }
+        return static_cast<IntegratorTypes>(integrator_type);
+    }
 
+    void set_default_functions()
+    {
         // By default, do nothing post-timestep
         set_post_timestep([](){});
 
@@ -54,7 +45,49 @@ public:
         set_rhs([](T& S_rhs, const T& S_data, const amrex::Real time){});
     }
 
+public:
+
+    TimeIntegrator() {
+        // initialize functions to do nothing
+        set_default_functions();
+    }
+
+    TimeIntegrator(IntegratorTypes integrator_type, const T& S_data)
+    {
+        // initialize the integrator class corresponding to the desired type
+        initialize_integrator(integrator_type, S_data);
+
+        // initialize functions to do nothing
+        set_default_functions();
+    }
+
+    TimeIntegrator(const T& S_data)
+    {
+        // initialize the integrator class corresponding to the input parameter selection
+        IntegratorTypes integrator_type = read_parameters();
+        initialize_integrator(integrator_type, S_data);
+
+        // initialize functions to do nothing
+        set_default_functions();
+    }
+
     virtual ~TimeIntegrator() {}
+
+    void initialize_integrator(IntegratorTypes integrator_type, const T& S_data)
+    {
+        switch (integrator_type)
+        {
+            case IntegratorTypes::ForwardEuler:
+                integrator_ptr = std::make_unique<FEIntegrator<T> >(S_data);
+                break;
+            case IntegratorTypes::ExplicitRungeKutta:
+                integrator_ptr = std::make_unique<RKIntegrator<T> >(S_data);
+                break;
+            default:
+                amrex::Error("integrator type did not match a valid integrator type.");
+                break;
+        }
+    }
 
     void set_post_timestep(std::function<void ()> F)
     {

--- a/Src/Base/AMReX_TimeIntegrator.H
+++ b/Src/Base/AMReX_TimeIntegrator.H
@@ -22,7 +22,7 @@ private:
     std::unique_ptr<IntegratorBase<T> > integrator_ptr;
     std::function<void ()> post_timestep;
 
-    IntegratorTypes read_parameters()
+    IntegratorTypes read_parameters ()
     {
         amrex::ParmParse pp("integration");
 
@@ -32,7 +32,7 @@ private:
         return static_cast<IntegratorTypes>(integrator_type);
     }
 
-    void set_default_functions()
+    void set_default_functions ()
     {
         // By default, do nothing post-timestep
         set_post_timestep([](){});
@@ -47,12 +47,12 @@ private:
 
 public:
 
-    TimeIntegrator() {
+    TimeIntegrator () {
         // initialize functions to do nothing
         set_default_functions();
     }
 
-    TimeIntegrator(IntegratorTypes integrator_type, const T& S_data)
+    TimeIntegrator (IntegratorTypes integrator_type, const T& S_data)
     {
         // initialize the integrator class corresponding to the desired type
         initialize_integrator(integrator_type, S_data);
@@ -61,7 +61,7 @@ public:
         set_default_functions();
     }
 
-    TimeIntegrator(const T& S_data)
+    TimeIntegrator (const T& S_data)
     {
         // initialize the integrator class corresponding to the input parameter selection
         IntegratorTypes integrator_type = read_parameters();
@@ -71,9 +71,9 @@ public:
         set_default_functions();
     }
 
-    virtual ~TimeIntegrator() {}
+    virtual ~TimeIntegrator () {}
 
-    void initialize_integrator(IntegratorTypes integrator_type, const T& S_data)
+    void initialize_integrator (IntegratorTypes integrator_type, const T& S_data)
     {
         switch (integrator_type)
         {
@@ -89,28 +89,28 @@ public:
         }
     }
 
-    void set_post_timestep(std::function<void ()> F)
+    void set_post_timestep (std::function<void ()> F)
     {
         post_timestep = F;
     }
 
-    void set_post_update(std::function<void (T&, amrex::Real)> F)
+    void set_post_update (std::function<void (T&, amrex::Real)> F)
     {
         integrator_ptr->set_post_update(F);
     }
 
-    void set_rhs(std::function<void(T&, const T&, const amrex::Real)> F)
+    void set_rhs (std::function<void(T&, const T&, const amrex::Real)> F)
     {
         integrator_ptr->set_rhs(F);
     }
 
-    void advance(T& S_old, T& S_new, amrex::Real time, const amrex::Real timestep)
+    void advance (T& S_old, T& S_new, amrex::Real time, const amrex::Real timestep)
     {
         integrator_ptr->advance(S_old, S_new, time, timestep);
     }
 
-    void integrate(T& S_old, T& S_new, amrex::Real start_time, const amrex::Real start_timestep,
-                   const amrex::Real end_time, const int nsteps)
+    void integrate (T& S_old, T& S_new, amrex::Real start_time, const amrex::Real start_timestep,
+                    const amrex::Real end_time, const int nsteps)
     {
         amrex::Real time = start_time;
         amrex::Real timestep = start_timestep;
@@ -137,12 +137,12 @@ public:
         }
     }
 
-    void time_interpolate(const T& S_new, const T& S_old, amrex::Real timestep_fraction, T& data)
+    void time_interpolate (const T& S_new, const T& S_old, amrex::Real timestep_fraction, T& data)
     {
         integrator_ptr->time_interpolate(S_new, S_old, timestep_fraction, data);
     }
 
-    void map_data(std::function<void(T&)> Map)
+    void map_data (std::function<void(T&)> Map)
     {
         integrator_ptr->map_data(Map);
     }

--- a/Src/Base/AMReX_TimeIntegrator.H
+++ b/Src/Base/AMReX_TimeIntegrator.H
@@ -26,7 +26,7 @@ private:
     {
         amrex::ParmParse pp("integration");
 
-        int integrator_type = IntegratorTypes::ForwardEuler;
+        int integrator_type = static_cast<int>(IntegratorTypes::ForwardEuler);
         pp.get("type", integrator_type);
 
         return static_cast<IntegratorTypes>(integrator_type);

--- a/Src/Base/AMReX_TimeIntegrator.H
+++ b/Src/Base/AMReX_TimeIntegrator.H
@@ -1,12 +1,14 @@
 #ifndef AMREX_TIME_INTEGRATOR_H
 #define AMREX_TIME_INTEGRATOR_H
-#include <functional>
 #include <AMReX_REAL.H>
 #include <AMReX_Vector.H>
 #include <AMReX_ParmParse.H>
-#include "AMReX_IntegratorBase.H"
-#include "AMReX_FEIntegrator.H"
-#include "AMReX_RKIntegrator.H"
+#include <AMReX_IntegratorBase.H>
+#include <AMReX_FEIntegrator.H>
+#include <AMReX_RKIntegrator.H>
+#include <functional>
+
+namespace amrex {
 
 namespace IntegratorTypes {
     enum TimeIntegratorTypes {ForwardEuler = 0,
@@ -112,5 +114,7 @@ public:
         integrator_ptr->map_data(Map);
     }
 };
+
+}
 
 #endif

--- a/Src/Base/AMReX_TimeIntegrator.H
+++ b/Src/Base/AMReX_TimeIntegrator.H
@@ -10,9 +10,9 @@
 
 namespace amrex {
 
-namespace IntegratorTypes {
-    enum TimeIntegratorTypes {ForwardEuler = 0,
-                              ExplicitRungeKutta};
+enum struct IntegratorTypes {
+    ForwardEuler = 0,
+    ExplicitRungeKutta
 };
 
 template<class T>

--- a/Src/Base/CMakeLists.txt
+++ b/Src/Base/CMakeLists.txt
@@ -175,6 +175,11 @@ target_sources( amrex
    AMReX_PlotFileUtil.H
    AMReX_PlotFileDataImpl.H
    AMReX_PlotFileDataImpl.cpp
+   # Time Integration
+   AMReX_FEIntegrator.H
+   AMReX_IntegratorBase.H
+   AMReX_RKIntegrator.H
+   AMReX_TimeIntegrator.H
    # GPU --------------------------------------------------------------------
    AMReX_Gpu.H
    AMReX_GpuQualifiers.H

--- a/Src/Base/Make.package
+++ b/Src/Base/Make.package
@@ -193,6 +193,15 @@ C$(AMREX_BASE)_sources += AMReX_PlotFileUtil.cpp AMReX_PlotFileDataImpl.cpp
 C$(AMREX_BASE)_headers += AMReX_PlotFileUtil.H AMReX_PlotFileDataImpl.H
 
 #
+# Time Integration
+#
+C$(AMREX_BASE)_headers += AMReX_FEIntegrator.H
+C$(AMREX_BASE)_headers += AMReX_IntegratorBase.H
+C$(AMREX_BASE)_headers += AMReX_RKIntegrator.H
+C$(AMREX_BASE)_headers += AMReX_TimeIntegrator.H
+
+
+#
 # Fortran interface routines.
 #
 ifneq ($(BL_NO_FORT),TRUE)


### PR DESCRIPTION
## Summary

This PR moves the latest versions of a basic general explicit time integrator into AMReX. We are already using this time integrator for the Emu (https://github.com/AMReX-Astro/Emu), ET-Integration (https://github.com/amrex-codes/ET-integration), and ERF (https://github.com/erf-model/ERF) codes and this will let us consolidate the code and let other codes can benefit from it.

The time integrator includes both forward Euler and several explicit Runge-Kutta methods and example code with input parameter explanations are supplied in a new documentation webpage labeled "Time Integration."

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [X] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [X] include documentation in the code and/or rst files, if appropriate
