### PR TITLE
Extend EB signed distance reach

### DIFF
--- a/Src/EB/AMReX_EB_utils.H
+++ b/Src/EB/AMReX_EB_utils.H
@@ -89,10 +89,13 @@ namespace amrex {
      * \param eb_fac is an EBFArrayBoxFactory object containing EB informaiton.
      * \param refratio is the refinement ratio of mf to eb_fac.
      * \param fluid_has_positive_sign determines the sign of the fluid.
+     * \param extentFactor increase the signed distance valid region (at the expense
+     *               of increased cost).
      */
     void FillSignedDistance (MultiFab& mf, EB2::Level const& ls_lev,
                              EBFArrayBoxFactory const& eb_fac, int refratio,
-                             bool fluid_has_positive_sign=true);
+                             bool fluid_has_positive_sign=true,
+                             Real extentFactor = 1.0);
 
     /**
      * \brief Fill MultiFab with signed distance.
@@ -103,8 +106,11 @@ namespace amrex {
      *
      * \param mf is a nodal MultiFab built with EBFArrayBoxFactory.
      * \param fluid_has_positive_sign determines the sign of the fluid.
+     * \param extentFactor increase the signed distance valid region (at the expense
+     *               of increased cost).
      */
-    void FillSignedDistance (MultiFab& mf, bool fluid_has_positive_sign=true);
+    void FillSignedDistance (MultiFab& mf, bool fluid_has_positive_sign=true,
+                             Real extentFactor = 1.0);
 }
 
 #endif

--- a/Src/EB/AMReX_EB_utils.cpp
+++ b/Src/EB/AMReX_EB_utils.cpp
@@ -275,11 +275,11 @@ namespace amrex {
     }
 #endif
 
-void FillSignedDistance (MultiFab& mf, bool fluid_has_positive_sign)
+void FillSignedDistance (MultiFab& mf, bool fluid_has_positive_sign, Real extentFactor)
 {
     auto factory = dynamic_cast<EBFArrayBoxFactory const*>(&(mf.Factory()));
     if (factory) {
-        FillSignedDistance(mf, *(factory->getEBLevel()), *factory, 1, fluid_has_positive_sign);
+        FillSignedDistance(mf, *(factory->getEBLevel()), *factory, 1, fluid_has_positive_sign, extentFactor);
     } else {
         mf.setVal(std::numeric_limits<Real>::max());
     }
@@ -481,7 +481,7 @@ facets_nearest_pt (IntVect const& ind_pt, IntVect const& ind_loop, RealVect cons
 
 void FillSignedDistance (MultiFab& mf, EB2::Level const& ls_lev,
                          EBFArrayBoxFactory const& eb_factory, int refratio,
-                         bool fluid_has_positive_sign)
+                         bool fluid_has_positive_sign, Real extentFactor)
 {
     AMREX_ALWAYS_ASSERT(mf.is_nodal());
 
@@ -495,7 +495,7 @@ void FillSignedDistance (MultiFab& mf, EB2::Level const& ls_lev,
     const auto dx_ls = ls_lev.Geom().CellSizeArray();
     const auto dx_eb = eb_factory.Geom().CellSizeArray();
     Real dx_eb_max = amrex::max(AMREX_D_DECL(dx_eb[0],dx_eb[1],dx_eb[2]));
-    Real ls_roof = amrex::min(AMREX_D_DECL(dx_eb[0],dx_eb[1],dx_eb[2])) * (flags.nGrow()+1);
+    Real ls_roof = extentFactor * amrex::min(AMREX_D_DECL(dx_eb[0],dx_eb[1],dx_eb[2])) * (flags.nGrow()+1);
 
     Real fluid_sign = fluid_has_positive_sign ? 1._rt : -1._rt;
 


### PR DESCRIPTION
Add an optional argument to the FillSignedDistance functions to control
how far away from the EB the distance is built. Default value is 1.0 and higher values incur increased computations.

## Summary

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
