### PR TITLE
Workaround to fix amrex_particles_to_vtp.py samplefiles

### DIFF
--- a/Tools/Py_util/amrex_particles_to_vtp/samplefiles/particles00000
+++ b/Tools/Py_util/amrex_particles_to_vtp/samplefiles/particles00000
@@ -1,4 +1,8 @@
 512
+# This line is ignored by amrex_particles_to_vtp.py. In a real output file, something else may be here.
+# This line is ignored by amrex_particles_to_vtp.py. In a real output file, something else may be here.
+# This line is ignored by amrex_particles_to_vtp.py. In a real output file, something else may be here.
+# This line is ignored by amrex_particles_to_vtp.py. In a real output file, something else may be here.
 0.5 0.5 0.5 -0.369269499824166 -0.67190616444452 -0.915895644078094 0 0 0 1 0 
 1.5 0.5 0.5 0.228540167391324 0.966027306499735 0.691586821925875 0 0 0 2 0 
 2.5 0.5 0.5 0.372003185643917 0.402140774968749 -0.898984789476028 0 0 0 3 0 

--- a/Tools/Py_util/amrex_particles_to_vtp/samplefiles/particles00001
+++ b/Tools/Py_util/amrex_particles_to_vtp/samplefiles/particles00001
@@ -1,4 +1,8 @@
 512
+# This line is ignored by amrex_particles_to_vtp.py. In a real output file, something else may be here.
+# This line is ignored by amrex_particles_to_vtp.py. In a real output file, something else may be here.
+# This line is ignored by amrex_particles_to_vtp.py. In a real output file, something else may be here.
+# This line is ignored by amrex_particles_to_vtp.py. In a real output file, something else may be here.
 0.130730500175834 0.17190616444452 0.415895644078094 -0.369269499824166 0.67190616444452 0.915895644078094 0 0 0 1 0 
 1.72854016739132 1.46602730649973 1.19158682192587 0.228540167391324 0.966027306499735 0.691586821925875 0 0 0 2 0 
 2.87200318564392 0.902140774968749 0.398984789476028 0.372003185643917 0.402140774968749 0.898984789476028 0 0 0 3 0 

--- a/Tools/Py_util/amrex_particles_to_vtp/samplefiles/particles00002
+++ b/Tools/Py_util/amrex_particles_to_vtp/samplefiles/particles00002
@@ -1,4 +1,8 @@
 512
+# This line is ignored by amrex_particles_to_vtp.py. In a real output file, something else may be here.
+# This line is ignored by amrex_particles_to_vtp.py. In a real output file, something else may be here.
+# This line is ignored by amrex_particles_to_vtp.py. In a real output file, something else may be here.
+# This line is ignored by amrex_particles_to_vtp.py. In a real output file, something else may be here.
 0.238538999648332 0.843812328889041 1.33179128815619 0.369269499824166 0.67190616444452 0.915895644078094 0 0 0 1 0 
 1.95708033478265 2.43205461299947 1.88317364385175 0.228540167391324 0.966027306499735 0.691586821925875 0 0 0 2 0 
 3.24400637128783 1.3042815499375 1.29796957895206 0.372003185643917 0.402140774968749 0.898984789476028 0 0 0 3 0 


### PR DESCRIPTION
## Summary

The sample input files for `amrex_paticles_to_vtp.py` were modified in order to stop the script from crashing. Based on comparison against output from the [Electrostatic PIC tutorial](https://amrex-codes.github.io/amrex/tutorials_html/Particles_Tutorial.html#electrostaticpic), I believe that the sample input files are in an outdated format. ([electrostatic_pic_particles50000.txt](https://github.com/AMReX-Codes/amrex/files/7637608/electrostatic_pic_particles50000.txt) is attached for reference.)

## Additional background

`amrex_particles_to_vtp.py` skips the first four lines after the first line (containing the number of particles) of the input file. Then, the number of lines that are read is equal to exactly the number of particles specified on the first line.

The sample input files under the `samplefiles/` directory do not contain these four "skipped" lines, and as a result, not only does
`amrex_particles_to_vtp.py` skip four lines of valid particle data, the script crashes because it tries to read past the end of the file. (In other words, the script assumes that the file is four lines longer than it really is.)

As a workaround, I've added four "dummy" lines to each file. This is NOT an ideal solution because real particle output would not contain my four "dummy" lines, and instead there would be some other information there (i.e. I believe the number of extra real and int components in the particle data/attributes). However, my workaround is adequate for the purpose of demonstrating correct usage of `amrex_particles_to_vtp.py`. I have confirmed that the resulting `.vtp` files produce sensible-looking results in ParaView. (See attached screenshots below for reference.)

`particles00000`:
![particles00000](https://user-images.githubusercontent.com/5407450/144328022-71b847a8-d78a-4837-81dc-ea8d1cafd682.gif)
`particles00001`:
![particles00001](https://user-images.githubusercontent.com/5407450/144328021-34077dda-fe6b-40b0-8849-4265bb4539f9.gif)
`particles00002`:
![particles00002](https://user-images.githubusercontent.com/5407450/144328017-504b1158-b38c-49e9-924b-957ecc9a0fbd.gif)

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate