### PR TITLE
ANSI Escape Codes

### DIFF
--- a/Src/Base/AMReX_ANSIEscCode.H
+++ b/Src/Base/AMReX_ANSIEscCode.H
@@ -1,0 +1,63 @@
+#ifndef AMREX_ANSI_ESC_CODE_H_
+#define AMREX_ANSI_ESC_CODE_H_
+
+// https://en.wikipedia.org/wiki/ANSI_escape_code
+
+namespace amrex {
+
+constexpr char ResetDisplay[] = "\033[0m";
+
+namespace Font {
+    constexpr char Bold        [] = "\033[1m";
+    constexpr char Faint       [] = "\033[2m";
+    constexpr char Italic      [] = "\033[3m";
+    constexpr char Underline   [] = "\033[4m";
+    constexpr char SlowBlink   [] = "\033[5m";
+    constexpr char RapidBlink  [] = "\033[6m";
+}
+
+namespace FGColor { // Forground colors
+    constexpr char Black         [] = "\033[30m";
+    constexpr char Red           [] = "\033[31m";
+    constexpr char Green         [] = "\033[32m";
+    constexpr char Yellow        [] = "\033[33m";
+    constexpr char Blue          [] = "\033[34m";
+    constexpr char Magenta       [] = "\033[35m";
+    constexpr char Cyan          [] = "\033[36m";
+    constexpr char White         [] = "\033[37m";
+
+    constexpr char Gray          [] = "\033[90m";
+    constexpr char BrightBlack   [] = "\033[90m";
+    constexpr char BrightRed     [] = "\033[91m";
+    constexpr char BrightGreen   [] = "\033[92m";
+    constexpr char BrightYellow  [] = "\033[93m";
+    constexpr char BrightBLUE    [] = "\033[94m";
+    constexpr char BrightMagenta [] = "\033[95m";
+    constexpr char BrightCyan    [] = "\033[96m";
+    constexpr char BrightWhite   [] = "\033[97m";
+}
+
+namespace BGColor { // Background colors
+    constexpr char Black          [] = "\033[40m";
+    constexpr char Red            [] = "\033[41m";
+    constexpr char Green          [] = "\033[42m";
+    constexpr char Yellow         [] = "\033[43m";
+    constexpr char Blue           [] = "\033[44m";
+    constexpr char Magenta        [] = "\033[45m";
+    constexpr char Cyan           [] = "\033[46m";
+    constexpr char White          [] = "\033[47m";
+
+    constexpr char Gray           [] = "\033[100m";
+    constexpr char BrightBlack    [] = "\033[100m";
+    constexpr char BrightRed      [] = "\033[101m";
+    constexpr char BrightGreen    [] = "\033[102m";
+    constexpr char BrightYellow   [] = "\033[103m";
+    constexpr char BrightBlue     [] = "\033[104m";
+    constexpr char BrightMagenta  [] = "\033[105m";
+    constexpr char BrightCyan     [] = "\033[106m";
+    constexpr char BrightWhite    [] = "\033[107m";
+}
+
+}
+
+#endif

--- a/Src/Base/AMReX_Print.H
+++ b/Src/Base/AMReX_Print.H
@@ -5,6 +5,7 @@
 #include <AMReX.H>
 #include <AMReX_ParallelContext.H>
 #include <AMReX_ParallelDescriptor.H>
+#include <AMReX_ANSIEscCode.H>
 
 #include <sstream>
 #include <fstream>

--- a/Src/Base/CMakeLists.txt
+++ b/Src/Base/CMakeLists.txt
@@ -72,6 +72,7 @@ target_sources( amrex
    AMReX_parstream.H
    AMReX_parstream.cpp
    # I/O stuff  --------------------------------------------------------------
+   AMReX_ANSIEscCode.H
    AMReX_FabConv.H
    AMReX_FabConv.cpp
    AMReX_FPC.H

--- a/Src/Base/Make.package
+++ b/Src/Base/Make.package
@@ -103,7 +103,7 @@ C$(AMREX_BASE)_headers += AMReX_ParReduce.H
 #
 # I/O stuff.
 #
-C${AMREX_BASE}_headers += AMReX_FabConv.H AMReX_FPC.H AMReX_Print.H AMReX_IntConv.H AMReX_VectorIO.H
+C${AMREX_BASE}_headers += AMReX_ANSIEscCode.H AMReX_FabConv.H AMReX_FPC.H AMReX_Print.H AMReX_IntConv.H AMReX_VectorIO.H
 C${AMREX_BASE}_sources += AMReX_FabConv.cpp AMReX_FPC.cpp AMReX_IntConv.cpp AMReX_VectorIO.cpp
 
 #


### PR DESCRIPTION
Add commonly used ANSI escape codes to AMReX_ANSIEscCode.H.  They can be
used to print colored output.  For example,

    amrex::Print() << Font::Bold << FGColor::Red << "Hello world from AMReX\n"
                   << ResetDisplay << Font::Faint << FGColor::BrightCyan
                   << Font::Underline << "Hello world again from AMReX "
                   << ResetDisplay << BGColor::White << FGColor::Black << amrex::Version()
                   << ResetDisplay << std::endl;

## Summary

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
