### PR TITLE
Fix AppleClang CI by ignoring unused variables in GccPlacater

### DIFF
--- a/Src/Base/AMReX.H
+++ b/Src/Base/AMReX.H
@@ -226,6 +226,20 @@ namespace amrex
         std::allocator<float> a_f;
         std::allocator<double> a_d;
         std::allocator<std::string> a_s;
+
+        amrex::ignore_unused(a_b);
+        amrex::ignore_unused(a_c);
+        amrex::ignore_unused(a_i);
+        amrex::ignore_unused(a_l);
+        amrex::ignore_unused(a_ll);
+        amrex::ignore_unused(a_uc);
+        amrex::ignore_unused(a_ui);
+        amrex::ignore_unused(a_ul);
+        amrex::ignore_unused(a_ull);
+        amrex::ignore_unused(a_ll);
+        amrex::ignore_unused(a_f);
+        amrex::ignore_unused(a_d);
+        amrex::ignore_unused(a_s);
     }
 #endif
 

--- a/Src/Base/AMReX_MultiFab.H
+++ b/Src/Base/AMReX_MultiFab.H
@@ -689,6 +689,11 @@ inline void GccPlacaterMF ()
     std::allocator<MultiFab const*> a2;
     std::allocator<FabArray<FArrayBox>*> a3;
     std::allocator<FabArray<FArrayBox> const*> a4;
+
+    amrex::ignore_unused(a1);
+    amrex::ignore_unused(a2);
+    amrex::ignore_unused(a3);
+    amrex::ignore_unused(a4);
 }
 #endif
 


### PR DESCRIPTION
The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
