### PR TITLE
Fix issue concerning Fujitsu compiler in AMReX_BLBackTrace.H

### DIFF
--- a/Src/Base/AMReX_BLBackTrace.H
+++ b/Src/Base/AMReX_BLBackTrace.H
@@ -27,7 +27,7 @@ struct BLBackTrace
     static void print_backtrace_info (const std::string& filename);
 
     static std::stack<std::pair<std::string, std::string> > bt_stack;
-// threadprivate here doesn't work with Cray, Intel and Fujitsu
+// threadprivate here doesn't work with Cray, Intel, and Fujitsu
 #if defined(AMREX_USE_OMP) && !defined(_CRAYC) && !defined(__INTEL_COMPILER) && !defined(__PGI) && !defined(__NVCOMPILER) && !defined(__FUJITSU)
 #pragma omp threadprivate(bt_stack)
 #endif

--- a/Src/Base/AMReX_BLBackTrace.H
+++ b/Src/Base/AMReX_BLBackTrace.H
@@ -27,8 +27,8 @@ struct BLBackTrace
     static void print_backtrace_info (const std::string& filename);
 
     static std::stack<std::pair<std::string, std::string> > bt_stack;
-// threadprivate here doesn't work with Cray and Intel
-#if defined(AMREX_USE_OMP) && !defined(_CRAYC) && !defined(__INTEL_COMPILER) && !defined(__PGI) && !defined(__NVCOMPILER)
+// threadprivate here doesn't work with Cray, Intel and Fujitsu
+#if defined(AMREX_USE_OMP) && !defined(_CRAYC) && !defined(__INTEL_COMPILER) && !defined(__PGI) && !defined(__NVCOMPILER) && !defined(__FUJITSU)
 #pragma omp threadprivate(bt_stack)
 #endif
 };


### PR DESCRIPTION
## Summary

The line `#pragma omp threadprivate(bt_stack)` in `AMReX_BLBackTrace.H` can't be compiled with Fujitsu compiler
(as well as with Intel compiler and Cray compiler). This PR excludes this line when the Fujitsu compiler is used.

## Additional background

## Checklist

The proposed changes:
- [X] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
