### PR TITLE
Generalize problem size specification

### DIFF
--- a/Docs/sphinx_documentation/source/Basics.rst
+++ b/Docs/sphinx_documentation/source/Basics.rst
@@ -895,14 +895,18 @@ space domain, a :cpp:`RealBox` specifying the
 physical domain, an :cpp:`int` specifying coordinate system type, and
 an :cpp:`int` pointer or array specifying periodicity. If a :cpp:`RealBox` is not
 given in the first constructor, AMReX  will construct one based on :cpp:`ParmParse` parameters,
-``geometry.prob_lo`` and ``geometry.prob_hi``, where each of the parameter is
-an array of ``AMREX_SPACEDIM`` real numbers. It's a runtime error if this
-fails. The argument for coordinate system is an integer type with
+``geometry.prob_lo`` / ``geometry.prob_hi`` / ``geometry.prob_extent``,
+where each of the parameter is an array of ``AMREX_SPACEDIM`` real numbers.
+See the section on :ref:`sec:inputs:pd` for more details about how to specify these.
+
+The argument for coordinate system is an integer type with
 valid values being 0 (Cartesian), or 1 (cylindrical), or 2 (spherical). If it
 is invalid as in the case of the default argument value of the first constructor, AMReX will query the
 :cpp:`ParmParse` database for ``geometry.coord_sys`` and use it if one is
 found. If it cannot find the parameter, the coordinate system is set to 0
-(i.e., Cartesian coordinates). The :cpp:`Geometry` class has the concept of
+(i.e., Cartesian coordinates).
+
+The :cpp:`Geometry` class has the concept of
 periodicity.  An argument can be passed specifying periodicity in each
 dimension. If it is not given in the first constructor, the domain is assumed to be non-periodic unless
 there is the :cpp:`ParmParse` integer array parameter ``geometry.is_periodic``

--- a/Docs/sphinx_documentation/source/InputsProblemDefinition.rst
+++ b/Docs/sphinx_documentation/source/InputsProblemDefinition.rst
@@ -1,3 +1,5 @@
+.. _sec:inputs:pd:
+
 Problem Definition
 ==================
 
@@ -20,12 +22,20 @@ The following inputs must be preceded by "geometry."
 +-----------------+-----------------------------------------------------------------------+-------------+-----------+
 | is_periodic     | 1 for true, 0 for false (one value for each coordinate direction)     |   Ints      | 0 0 0     |
 +-----------------+-----------------------------------------------------------------------+-------------+-----------+
-| prob_lo         | Low corner of physical domain (physical not index space)              |   Reals     | None      |
+| prob_lo         | Low corner of physical domain (physical not index space)              |   Reals     | 0 0 0     |
 +-----------------+-----------------------------------------------------------------------+-------------+-----------+
 | prob_hi         | High corner of physical domain (physical not index space)             |   Reals     | None      |
 +-----------------+-----------------------------------------------------------------------+-------------+-----------+
 | prob_extent     | Extent of physical domain (physical not index space)                  |   Reals     | None      |
 +-----------------+-----------------------------------------------------------------------+-------------+-----------+
 
-Note that one can either specify both "prob_lo" and "prob_hi", or specify "prob_extent", but not both.  If "prob_extent" is
-specified, then internally prob_lo is set to 0 and prob_hi is set to prob_extent.
+Note that internally ``prob_lo`` and ``prob_hi`` are the variables carried by the ``Geometry`` class.
+In the inputs file (or command line), one can specify
+1) ``geometry.prob_hi`` only or
+2) ``geometry.prob_extent`` only or
+3) ``geometry.prob_lo`` and ``geometry.prob_hi`` or
+4) ``geometry.prob_lo`` and ``geometry.prob_extent``.
+If ``geometry.prob_lo`` is not specified then it will be 0 in each coordinate direction.
+If ``geometry.prob_extent`` is specified (and ``geometry.prob_hi`` is not) then internally
+"prob_hi" will be set to "prob_lo" + "prob_extent".
+

--- a/Docs/sphinx_documentation/source/InputsProblemDefinition.rst
+++ b/Docs/sphinx_documentation/source/InputsProblemDefinition.rst
@@ -24,4 +24,8 @@ The following inputs must be preceded by "geometry."
 +-----------------+-----------------------------------------------------------------------+-------------+-----------+
 | prob_hi         | High corner of physical domain (physical not index space)             |   Reals     | None      |
 +-----------------+-----------------------------------------------------------------------+-------------+-----------+
+| prob_extent     | Extent of physical domain (physical not index space)                  |   Reals     | None      |
++-----------------+-----------------------------------------------------------------------+-------------+-----------+
 
+Note that one can either specify both "prob_lo" and "prob_hi", or specify "prob_extent", but not both.  If "prob_extent" is
+specified, then internally prob_lo is set to 0 and prob_hi is set to prob_extent.

--- a/Src/Base/AMReX_Geometry.cpp
+++ b/Src/Base/AMReX_Geometry.cpp
@@ -112,7 +112,7 @@ Geometry::Setup (const RealBox* rb, int coord, int const* isper) noexcept
 
     if (gg->ok) return;
 
-    BL_ASSERT(!OpenMP::in_parallel());
+    AMREX_ASSERT(!OpenMP::in_parallel());
 
     ParmParse pp("geometry");
 
@@ -127,10 +127,26 @@ Geometry::Setup (const RealBox* rb, int coord, int const* isper) noexcept
     if (rb == nullptr) {
         Vector<Real> prob_lo(AMREX_SPACEDIM);
         Vector<Real> prob_hi(AMREX_SPACEDIM);
-        pp.getarr("prob_lo",prob_lo,0,AMREX_SPACEDIM);
-        BL_ASSERT(prob_lo.size() == AMREX_SPACEDIM);
-        pp.getarr("prob_hi",prob_hi,0,AMREX_SPACEDIM);
-        BL_ASSERT(prob_hi.size() == AMREX_SPACEDIM);
+        Vector<Real> prob_extent(AMREX_SPACEDIM);
+
+        for (int i = 0; i < AMREX_SPACEDIM; i++) prob_lo[i] = 0.;
+        pp.queryarr("prob_lo",prob_lo,0,AMREX_SPACEDIM);
+        AMREX_ASSERT(prob_lo.size() == AMREX_SPACEDIM);
+
+        bool read_prob_hi = pp.queryarr("prob_hi",prob_hi,0,AMREX_SPACEDIM);
+        AMREX_ASSERT(prob_hi.size() == AMREX_SPACEDIM);
+
+        bool read_prob_extent = pp.queryarr("prob_extent",prob_extent,0,AMREX_SPACEDIM);
+        AMREX_ASSERT(prob_extent.size() == AMREX_SPACEDIM);
+
+        // We enforce that one and only one of prob_hi vs prob_extent is input
+        AMREX_ALWAYS_ASSERT(  read_prob_hi || read_prob_extent);
+        AMREX_ALWAYS_ASSERT(!(read_prob_hi && read_prob_extent));
+
+        for (int i = 0; i < AMREX_SPACEDIM; i++) {
+            prob_hi[i] = prob_lo[i] + prob_extent[i];
+        }
+
         gg->prob_domain.setLo(prob_lo);
         gg->prob_domain.setHi(prob_hi);
         gg->SetOffset(prob_lo.data());

--- a/Src/Base/AMReX_Geometry.cpp
+++ b/Src/Base/AMReX_Geometry.cpp
@@ -143,8 +143,10 @@ Geometry::Setup (const RealBox* rb, int coord, int const* isper) noexcept
         AMREX_ALWAYS_ASSERT(  read_prob_hi || read_prob_extent);
         AMREX_ALWAYS_ASSERT(!(read_prob_hi && read_prob_extent));
 
-        for (int i = 0; i < AMREX_SPACEDIM; i++) {
-            prob_hi[i] = prob_lo[i] + prob_extent[i];
+        if (read_prob_extent)
+        {
+            for (int i = 0; i < AMREX_SPACEDIM; i++)
+                prob_hi[i] = prob_lo[i] + prob_extent[i];
         }
 
         gg->prob_domain.setLo(prob_lo);


### PR DESCRIPTION
Add the option to specify geometry.prob_extent instead of geometry.prob_lo and geometry.prob_hi

## Summary

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [X] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
