### PR TITLE
avoid divide by zero in EB

### DIFF
--- a/Src/EB/AMReX_EB2_2D_C.cpp
+++ b/Src/EB/AMReX_EB2_2D_C.cpp
@@ -18,7 +18,7 @@ void set_eb_data (const int i, const int j,
     const Real axp = apx(i+1,j  ,0);
     const Real aym = apy(i  ,j  ,0);
     const Real ayp = apy(i  ,j+1,0);
-    const Real apnorm = std::hypot(axm-axp,aym-ayp);
+    const Real apnorm = std::hypot(axm-axp,aym-ayp) + 1.e-30;
     const Real nx = (axm-axp) * (1.0/apnorm);
     const Real ny = (aym-ayp) * (1.0/apnorm);
 


### PR DESCRIPTION
## Summary

Add a small number to the variable `apnorm` in the 2D EB code to avoid a divide by zero.

## Additional background

In some circumstances the calculation for `apnorm` results in a zero which leads to divide by zero errors. Adding a small value avoids this issue and means an `if` statement is not required for checking when `axm-axp=aym-ayp=0`.

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
