### PR TITLE
Add ParallelCopyToGhost and fix a bug in FillPatch

### DIFF
--- a/Src/AmrCore/AMReX_FillPatchUtil_I.H
+++ b/Src/AmrCore/AMReX_FillPatchUtil_I.H
@@ -573,7 +573,17 @@ namespace {
 
                 for (int d=0; d<AMREX_SPACEDIM; ++d)
                 {
-                    mf[d]->ParallelCopy(mf_refined_patch[d], 0, dcomp, ncomp, IntVect{0}, nghost);
+                    bool aliasing = false;
+                    for (auto const& fmf_a : fmf) {
+                        aliasing = aliasing || (mf[d] == fmf_a[d]);
+                    }
+                    if (aliasing) {
+                        mf[d]->ParallelCopyToGhost(mf_refined_patch[d], 0, dcomp, ncomp,
+                                                   IntVect{0}, nghost);
+                    } else {
+                        mf[d]->ParallelCopy(mf_refined_patch[d], 0, dcomp, ncomp,
+                                            IntVect{0}, nghost);
+                    }
                 }
             }
         }
@@ -581,7 +591,7 @@ namespace {
         for (int d=0; d<AMREX_SPACEDIM; ++d)
         {
             Vector<MF*> fmf_time;
-            for (auto ffab : fmf)
+            for (auto const& ffab : fmf)
                  { fmf_time.push_back(ffab[d]); }
 
             FillPatchSingleLevel(*mf[d], nghost, time, fmf_time, ft, scomp, dcomp, ncomp,

--- a/Src/Base/AMReX_FabArray.H
+++ b/Src/Base/AMReX_FabArray.H
@@ -183,8 +183,6 @@ struct PCData {
     FabArrayBase::CpOp  op;
     int                 tag = -1;
     int                 actual_n_rcvs = -1;
-    IntVect             snghost, dnghost;
-    Periodicity         period;
     int                 SC = -1, NC = -1, DC = -1;
 
     char*               the_recv_data = nullptr;
@@ -755,9 +753,18 @@ public:
                               const IntVect&       dst_nghost,
                               const Periodicity&   period = Periodicity::NonPeriodic(),
                               CpOp                 op = FabArrayBase::COPY,
-                              const FabArrayBase::CPC* a_cpc = nullptr);
+                              const FabArrayBase::CPC* a_cpc = nullptr,
+                              bool                 to_ghost_cells_only = false);
 
     void ParallelCopy_finish ();
+
+    void ParallelCopyToGhost (const FabArray<FAB>& src,
+                              int                  src_comp,
+                              int                  dest_comp,
+                              int                  num_comp,
+                              const IntVect&       src_nghost,
+                              const IntVect&       dst_nghost,
+                              const Periodicity&   period = Periodicity::NonPeriodic());
 
     [[deprecated("Use FabArray::ParallelCopy() instead.")]]
     void copy (const FabArray<FAB>& src,

--- a/Src/Base/AMReX_FabArray.H
+++ b/Src/Base/AMReX_FabArray.H
@@ -766,6 +766,16 @@ public:
                               const IntVect&       dst_nghost,
                               const Periodicity&   period = Periodicity::NonPeriodic());
 
+    void ParallelCopyToGhost_nowait (const FabArray<FAB>& src,
+                                     int                  src_comp,
+                                     int                  dest_comp,
+                                     int                  num_comp,
+                                     const IntVect&       src_nghost,
+                                     const IntVect&       dst_nghost,
+                                     const Periodicity&   period = Periodicity::NonPeriodic());
+
+    void ParallelCopyToGhost_finish();
+
     [[deprecated("Use FabArray::ParallelCopy() instead.")]]
     void copy (const FabArray<FAB>& src,
                int                  src_comp,

--- a/Src/Base/AMReX_FabArrayBase.H
+++ b/Src/Base/AMReX_FabArrayBase.H
@@ -533,7 +533,7 @@ public:
     {
         CPC (const FabArrayBase& dstfa, const IntVect& dstng,
              const FabArrayBase& srcfa, const IntVect& srcng,
-             const Periodicity& period);
+             const Periodicity& period, bool to_ghost_cells_only = false);
         CPC (const BoxArray& dstba, const DistributionMapping& dstdm,
              const Vector<int>& dstidx, const IntVect& dstng,
              const BoxArray& srcba, const DistributionMapping& srcdm,
@@ -550,6 +550,7 @@ public:
         IntVect     m_srcng;
         IntVect     m_dstng;
         Periodicity m_period;
+        bool        m_tgco;
         BoxArray    m_srcba;
         BoxArray    m_dstba;
         //
@@ -571,7 +572,7 @@ public:
     static CacheStats m_CPC_stats;
     //
     const CPC& getCPC (const IntVect& dstng, const FabArrayBase& src, const IntVect& srcng,
-                       const Periodicity& period) const;
+                       const Periodicity& period, bool to_ghost_cells_only = false) const;
     //
     void flushCPC (bool no_assertion=false) const;      //!< This flushes its own CPC.
     static void flushCPCache (); //!< This flusheds the entire cache.

--- a/Src/Base/AMReX_FabArrayCommI.H
+++ b/Src/Base/AMReX_FabArrayCommI.H
@@ -262,6 +262,23 @@ FabArray<FAB>::ParallelCopy (const FabArray<FAB>& src,
 
 template <class FAB>
 void
+FabArray<FAB>::ParallelCopyToGhost (const FabArray<FAB>& src,
+                                    int                  scomp,
+                                    int                  dcomp,
+                                    int                  ncomp,
+                                    const IntVect&       snghost,
+                                    const IntVect&       dnghost,
+                                    const Periodicity&   period)
+{
+    BL_PROFILE("FabArray::ParallelCopyToGhost()");
+
+    ParallelCopy_nowait(src, scomp, dcomp, ncomp, snghost, dnghost, period,
+                        FabArrayBase::COPY, nullptr, true);
+    ParallelCopy_finish();
+}
+
+template <class FAB>
+void
 FabArray<FAB>::ParallelCopy_nowait (const FabArray<FAB>& src,
                                     int                  scomp,
                                     int                  dcomp,
@@ -270,7 +287,8 @@ FabArray<FAB>::ParallelCopy_nowait (const FabArray<FAB>& src,
                                     const IntVect&       dnghost,
                                     const Periodicity&   period,
                                     CpOp                 op,
-                                    const FabArrayBase::CPC * a_cpc)
+                                    const FabArrayBase::CPC * a_cpc,
+                                    bool                 to_ghost_cells_only)
 {
     BL_PROFILE("FabArray::ParallelCopy_nowait()");
 
@@ -291,7 +309,7 @@ FabArray<FAB>::ParallelCopy_nowait (const FabArray<FAB>& src,
         (boxarray == src.boxarray && distributionMap == src.distributionMap) &&
         snghost == IntVect::TheZeroVector() &&
         dnghost == IntVect::TheZeroVector() &&
-        !period.isAnyPeriodic())
+        !period.isAnyPeriodic() && !to_ghost_cells_only)
     {
         //
         // Short-circuit full intersection code if we're doing copy()s or if
@@ -326,7 +344,7 @@ FabArray<FAB>::ParallelCopy_nowait (const FabArray<FAB>& src,
         return;
     }
 
-    const CPC& thecpc = (a_cpc) ? *a_cpc : getCPC(dnghost, src, snghost, period);
+    const CPC& thecpc = (a_cpc) ? *a_cpc : getCPC(dnghost, src, snghost, period, to_ghost_cells_only);
 
     if (ParallelContext::NProcsSub() == 1)
     {
@@ -381,9 +399,6 @@ FabArray<FAB>::ParallelCopy_nowait (const FabArray<FAB>& src,
         pcd = std::make_unique<PCData<FAB>>();
         pcd->cpc = &thecpc;
         pcd->src = &src;
-        pcd->snghost = snghost;
-        pcd->dnghost = dnghost;
-        pcd->period = period;
         pcd->op = op;
         pcd->tag = tag;
 

--- a/Src/Base/AMReX_FabArrayCommI.H
+++ b/Src/Base/AMReX_FabArrayCommI.H
@@ -279,6 +279,28 @@ FabArray<FAB>::ParallelCopyToGhost (const FabArray<FAB>& src,
 
 template <class FAB>
 void
+FabArray<FAB>::ParallelCopyToGhost_nowait (const FabArray<FAB>& src,
+                                           int                  scomp,
+                                           int                  dcomp,
+                                           int                  ncomp,
+                                           const IntVect&       snghost,
+                                           const IntVect&       dnghost,
+                                           const Periodicity&   period)
+{
+    ParallelCopy_nowait(src, scomp, dcomp, ncomp, snghost, dnghost, period,
+                        FabArrayBase::COPY, nullptr, true);
+}
+
+template <class FAB>
+void
+FabArray<FAB>::ParallelCopyToGhost_finish ()
+{
+    ParallelCopy_finish();
+}
+
+
+template <class FAB>
+void
 FabArray<FAB>::ParallelCopy_nowait (const FabArray<FAB>& src,
                                     int                  scomp,
                                     int                  dcomp,


### PR DESCRIPTION
* Add ParallelCopyToGhost function that copies data to ghost cells only.

* There was a bug in the Array version of FillPatch for Face data.  The
  issue is, if the destination is the same FabArray as one of the source
  FabArrays on the fine level, some valid data on valid box faces are
  overwritten with the interpolated values.  This is now fixed with the use
  of ParallelCopyToGhost in that case.

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
