### PR TITLE
CMake 3.22+: Policy CMP0127

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,13 +8,12 @@ if(POLICY CMP0091)
 endif()
 
 #
-# We use use sometimes ;-connected AND syntax in cmake_dependent_option,
-# so we need to update some of those options once we require CMake 3.22+
-# only
+# We use simple syntax in cmake_dependent_option, so we are compatible with the
+# extended syntax in CMake 3.22+
 # https://cmake.org/cmake/help/v3.22/policy/CMP0127.html
 #
 if(POLICY CMP0127)
-    cmake_policy(SET CMP0127 OLD)
+    cmake_policy(SET CMP0127 NEW)
 endif()
 
 #

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,16 @@ if(POLICY CMP0091)
 endif()
 
 #
+# We use use sometimes ;-connected AND syntax in cmake_dependent_option,
+# so we need to update some of those options once we require CMake 3.22+
+# only
+# https://cmake.org/cmake/help/v3.22/policy/CMP0127.html
+#
+if(POLICY CMP0127)
+    cmake_policy(SET CMP0127 OLD)
+endif()
+
+#
 # Prevent in-source builds
 #
 if (CMAKE_BINARY_DIR STREQUAL CMAKE_SOURCE_DIR)


### PR DESCRIPTION
## Summary

Fix a warning with CMake 3.22+.

~~We use use sometimes ;-connected AND syntax in `cmake_dependent_option`, so we need to update some of those options once we require CMake 3.22+ only.~~
We use simple syntax in `cmake_dependent_option`, so we are compatible with the extended syntax in CMake 3.22+
  https://cmake.org/cmake/help/v3.22/policy/CMP0127.html

## Additional background

First seen on Perlmutter.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
