### PR TITLE
Add function for make a dmap that is similar to an input MultiFab.

### DIFF
--- a/Src/Base/AMReX_DistributionMapping.H
+++ b/Src/Base/AMReX_DistributionMapping.H
@@ -373,6 +373,21 @@ std::ostream& operator<< (std::ostream& os, const DistributionMapping& pmap);
 
 std::ostream& operator<< (std::ostream& os, const DistributionMapping::RefID& id);
 
+/**
+ *  \brief Function that creates a DistributionMapping "similar" to that of a MultiFab.
+ *
+ *  "Similar" means that, if a box in "ba" intersects with any of the
+ *  boxes in the BoxArray associated with "mf", taking "ngrow" ghost cells into account,
+ *  then that box will be assigned to the proc owning the one it has the maximum amount
+ *  of overlap with.
+ *
+ *  @param[in] ba The BoxArray we want to generate a DistributionMapping for.
+ *  @param[in] mf The MultiFab we want said DistributionMapping to be similar to.
+ *  @param[in] ng The number of grow cells to use when computing intersection / overlap
+ *  @return The computed DistributionMapping.
+ */
+DistributionMapping MakeSimilarDM (const BoxArray& ba, const MultiFab& mf, const IntVect& ng);
+
 }
 
 #endif /*BL_DISTRIBUTIONMAPPING_H*/


### PR DESCRIPTION
This was originally a PR to WarpX, but it makes more sense for it to live in AMReX: https://github.com/ECP-WarpX/WarpX/pull/2640

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
