### PR TITLE
Add another overload for MakeSimilarDM.

### DIFF
--- a/Src/Base/AMReX_DistributionMapping.H
+++ b/Src/Base/AMReX_DistributionMapping.H
@@ -388,6 +388,22 @@ std::ostream& operator<< (std::ostream& os, const DistributionMapping::RefID& id
  */
 DistributionMapping MakeSimilarDM (const BoxArray& ba, const MultiFab& mf, const IntVect& ng);
 
+/**
+ *  \brief Function that creates a DistributionMapping "similar" to that of a MultiFab.
+ *
+ *  "Similar" means that, if a box in "ba" intersects with any of the
+ *  boxes in the BoxArray associated with "mf", taking "ngrow" ghost cells into account,
+ *  then that box will be assigned to the proc owning the one it has the maximum amount
+ *  of overlap with.
+ *
+ *  @param[in] ba The BoxArray we want to generate a DistributionMapping for.
+ *  @param[in] src_ba The BoxArray associatied with the src DistributionMapping.
+ *  @param[in] src_dm The input DistributionMapping we want the output to be similar to.
+ *  @param[in] ng The number of grow cells to use when computing intersection / overlap
+ *  @return The computed DistributionMapping.
+ */
+DistributionMapping MakeSimilarDM (const BoxArray& ba, const BoxArray& src_ba,
+                                   const DistributionMapping& src_dm, const IntVect& ng);
 }
 
 #endif /*BL_DISTRIBUTIONMAPPING_H*/

--- a/Src/Base/AMReX_DistributionMapping.cpp
+++ b/Src/Base/AMReX_DistributionMapping.cpp
@@ -1888,15 +1888,20 @@ DistributionMapping::writeOn (std::ostream& os) const
 
 DistributionMapping MakeSimilarDM (const BoxArray& ba, const MultiFab& mf, const IntVect& ng)
 {
-    Vector<int> pmap(ba.size());
     const DistributionMapping& mf_dm = mf.DistributionMap();
     const BoxArray& mf_ba = convert(mf.boxArray(),ba.ixType());
+    return MakeSimilarDM(ba, mf_ba, mf_dm, ng);
+}
 
+DistributionMapping MakeSimilarDM (const BoxArray& ba, const BoxArray& src_ba,
+                                   const DistributionMapping& src_dm, const IntVect& ng)
+{
+    Vector<int> pmap(ba.size());
     for (Long i = 0; i < ba.size(); ++i) {
         Box box = ba[i];
         box.grow(ng);
         bool first_only = false;
-        auto isects = mf_ba.intersections(box, first_only, ng);
+        auto isects = src_ba.intersections(box, first_only, ng);
         if (isects.empty()) {
             // no intersection found, revert to round-robin
             int nprocs = ParallelContext::NProcsSub();
@@ -1913,7 +1918,7 @@ DistributionMapping MakeSimilarDM (const BoxArray& ba, const MultiFab& mf, const
                 }
             }
             AMREX_ASSERT(max_overlap > 0);
-            pmap[i] = mf_dm[max_overlap_index];
+            pmap[i] = src_dm[max_overlap_index];
         }
     }
     return DistributionMapping(std::move(pmap));

--- a/Src/Base/AMReX_DistributionMapping.cpp
+++ b/Src/Base/AMReX_DistributionMapping.cpp
@@ -1896,6 +1896,8 @@ DistributionMapping MakeSimilarDM (const BoxArray& ba, const MultiFab& mf, const
 DistributionMapping MakeSimilarDM (const BoxArray& ba, const BoxArray& src_ba,
                                    const DistributionMapping& src_dm, const IntVect& ng)
 {
+    AMREX_ASSERT(ba.ixType() == src_ba.ixType());
+
     Vector<int> pmap(ba.size());
     for (Long i = 0; i < ba.size(); ++i) {
         Box box = ba[i];

--- a/Src/Base/AMReX_DistributionMapping.cpp
+++ b/Src/Base/AMReX_DistributionMapping.cpp
@@ -1896,7 +1896,8 @@ DistributionMapping MakeSimilarDM (const BoxArray& ba, const MultiFab& mf, const
 DistributionMapping MakeSimilarDM (const BoxArray& ba, const BoxArray& src_ba,
                                    const DistributionMapping& src_dm, const IntVect& ng)
 {
-    AMREX_ASSERT(ba.ixType() == src_ba.ixType());
+    AMREX_ASSERT_WITH_MESSAGE(ba.ixType() == src_ba.ixType(),
+                              "input BoxArrays must have the same centering.";);
 
     Vector<int> pmap(ba.size());
     for (Long i = 0; i < ba.size(); ++i) {


### PR DESCRIPTION
This one works with an input `ba` and `dm` instead of a `MultiFab.`

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
