### PR TITLE
Adds `get` functions to the TimeIntegrator classes

### DIFF
--- a/Src/Base/AMReX_IntegratorBase.H
+++ b/Src/Base/AMReX_IntegratorBase.H
@@ -176,6 +176,16 @@ public:
         post_update = F;
     }
 
+    std::function<void(T&, const T&, const amrex::Real)> get_rhs ()
+    {
+        return Fun;
+    }
+
+    std::function<void (T&, amrex::Real)> get_post_update ()
+    {
+        return post_update;
+    }
+
     void rhs (T& S_rhs, const T& S_data, const amrex::Real time)
     {
         Fun(S_rhs, S_data, time);

--- a/Src/Base/AMReX_TimeIntegrator.H
+++ b/Src/Base/AMReX_TimeIntegrator.H
@@ -104,6 +104,21 @@ public:
         integrator_ptr->set_rhs(F);
     }
 
+    std::function<void ()> get_post_timestep ()
+    {
+        return post_timestep;
+    }
+
+    std::function<void (T&, amrex::Real)> get_post_update ()
+    {
+        return integrator_ptr->get_post_update();
+    }
+
+    std::function<void(T&, const T&, const amrex::Real)> set_rhs ()
+    {
+        return integrator_ptr->get_rhs();
+    }
+
     void advance (T& S_old, T& S_new, amrex::Real time, const amrex::Real timestep)
     {
         integrator_ptr->advance(S_old, S_new, time, timestep);

--- a/Src/Base/AMReX_TimeIntegrator.H
+++ b/Src/Base/AMReX_TimeIntegrator.H
@@ -114,7 +114,7 @@ public:
         return integrator_ptr->get_post_update();
     }
 
-    std::function<void(T&, const T&, const amrex::Real)> set_rhs ()
+    std::function<void(T&, const T&, const amrex::Real)> get_rhs ()
     {
         return integrator_ptr->get_rhs();
     }


### PR DESCRIPTION
## Summary

This adds functions to allow the user to get the right-hand-side and post-update lambda functions from the TimeIntegrator classes if they are needed.

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
