### PR TITLE
Fix order of processing of `add_par` function and parsing inputs file.

### DIFF
--- a/Src/Base/AMReX.cpp
+++ b/Src/Base/AMReX.cpp
@@ -377,6 +377,10 @@ amrex::Initialize (int& argc, char**& argv, bool build_parm_parse,
     BL_PROFILE_INITIALIZE();
 
 #ifndef BL_AMRPROF
+    if (func_parm_parse) {
+        func_parm_parse();
+    }
+
     if (build_parm_parse)
     {
         if (argc == 1)
@@ -419,10 +423,6 @@ amrex::Initialize (int& argc, char**& argv, bool build_parm_parse,
         }
     } else {
         ParmParse::Initialize(0,0,0);
-    }
-
-    if (func_parm_parse) {
-        func_parm_parse();
     }
 
     {


### PR DESCRIPTION
## Summary
Fix order of processing `add_par` function and inputs file, so that the
`add_par` function is evaluated first. This allows the variables, 
if specified in the inputs file, to be overwriten. 

## Additional background
The behavior of the code now matches the description in the docs.

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
