### PR TITLE
fix WritePlotfileToASCII compilation

### DIFF
--- a/Tools/Postprocessing/C_Src/Make.package
+++ b/Tools/Postprocessing/C_Src/Make.package
@@ -1,6 +1,7 @@
 CEXE_sources += ${EBASE}.cpp
 
 ifneq ($(EBASE), particle_compare)
+ifneq ($(EBASE), WritePlotfileToASCII)
 
   INCLUDE_LOCATIONS += $(AMREX_HOME)/Src/Base
   include $(AMREX_HOME)/Src/Base/Make.package
@@ -13,4 +14,6 @@ ifneq ($(EBASE), particle_compare)
   ifeq ($(NEEDS_f90_SRC),TRUE)
     f90EXE_sources += ${EBASE}_nd.f90
   endif
+
+endif
 endif

--- a/Tools/Postprocessing/C_Src/Make.package
+++ b/Tools/Postprocessing/C_Src/Make.package
@@ -1,7 +1,8 @@
 CEXE_sources += ${EBASE}.cpp
 
-ifeq ($(EBASE), PtwisePltTransform)
-ifeq ($(EBASE), PlotfileToTurb)
+
+ifneq ($(EBASE), particle_compare)
+ifneq ($(EBASE), WritePlotfileToASCII)
 
   INCLUDE_LOCATIONS += $(AMREX_HOME)/Src/Base
   include $(AMREX_HOME)/Src/Base/Make.package

--- a/Tools/Postprocessing/C_Src/Make.package
+++ b/Tools/Postprocessing/C_Src/Make.package
@@ -1,7 +1,7 @@
 CEXE_sources += ${EBASE}.cpp
 
-ifneq ($(EBASE), particle_compare)
-ifneq ($(EBASE), WritePlotfileToASCII)
+ifeq ($(EBASE), PtwisePltTransform)
+ifeq ($(EBASE), PlotfileToTurb)
 
   INCLUDE_LOCATIONS += $(AMREX_HOME)/Src/Base
   include $(AMREX_HOME)/Src/Base/Make.package


### PR DESCRIPTION
## Summary
fix an issue with compilation of WritePlotfileToASCII on certain systems

## Additional background

## Checklist

The proposed changes:
- [ x ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
