### PR TITLE
Eliminate compiler warnings for time integration classes.

### DIFF
--- a/Src/Base/AMReX_FEIntegrator.H
+++ b/Src/Base/AMReX_FEIntegrator.H
@@ -35,8 +35,9 @@ public:
         initialize_stages(S_data);
     }
 
-    amrex::Real advance (T& S_old, T& S_new, amrex::Real time, const amrex::Real timestep)
+    amrex::Real advance (T& S_old, T& S_new, amrex::Real time, const amrex::Real time_step)
     {
+        BaseT::timestep = time_step;
         // Assume before advance() that S_old is valid data at the current time ("time" argument)
         // So we initialize S_new by copying the old state.
         IntegratorOps<T>::Copy(S_new, S_old);
@@ -46,16 +47,16 @@ public:
         BaseT::rhs(F, S_new, time);
 
         // S_new += timestep * dS/dt
-        IntegratorOps<T>::Saxpy(S_new, timestep, F);
+        IntegratorOps<T>::Saxpy(S_new, BaseT::timestep, F);
 
         // Call the post-update hook for S_new
-        BaseT::post_update(S_new, time + timestep);
+        BaseT::post_update(S_new, time + BaseT::timestep);
 
         // Return timestep
-        return timestep;
+        return BaseT::timestep;
     }
 
-    virtual void time_interpolate (const T& S_new, const T& S_old, amrex::Real timestep_fraction, T& data) override
+    virtual void time_interpolate (const T& /* S_new */, const T& /* S_old */, amrex::Real /* timestep_fraction */, T& /* data */) override
     {
         amrex::Error("Time interpolation not yet supported by forward euler integrator.");
     }

--- a/Src/Base/AMReX_IntegratorBase.H
+++ b/Src/Base/AMReX_IntegratorBase.H
@@ -153,11 +153,10 @@ private:
     std::function<void(T&, const T&, const amrex::Real)> Fun;
 
 protected:
+    amrex::Real timestep;
     std::function<void (T&, amrex::Real)> post_update;
 
 public:
-    amrex::Real timestep;
-
     IntegratorBase () {}
 
     IntegratorBase (const T& S_data) {}

--- a/Src/Base/AMReX_RKIntegrator.H
+++ b/Src/Base/AMReX_RKIntegrator.H
@@ -21,7 +21,6 @@ template<class T>
 class RKIntegrator : public IntegratorBase<T>
 {
 private:
-    amrex::Real timestep;
     typedef IntegratorBase<T> BaseT;
 
     ButcherTableauTypes tableau_type;
@@ -171,7 +170,7 @@ public:
 
     amrex::Real advance (T& S_old, T& S_new, amrex::Real time, const amrex::Real time_step)
     {
-        timestep = time_step;
+        BaseT::timestep = time_step;
         // Assume before advance() that S_old is valid data at the current time ("time" argument)
         // And that if data is a MultiFab, both S_old and S_new contain ghost cells for evaluating a stencil based RHS
         // We need this from S_old. This is convenient for S_new to have so we can use it
@@ -181,7 +180,7 @@ public:
         for (int i = 0; i < number_nodes; ++i)
         {
             // Get current stage time, t = t_old + h * Ci
-            amrex::Real stage_time = time + timestep * nodes[i];
+            amrex::Real stage_time = time + BaseT::timestep * nodes[i];
 
             // Fill S_new with the solution value for evaluating F at the current stage
             // Copy S_new = S_old
@@ -192,7 +191,7 @@ public:
                 // We should fuse these kernels ...
                 for (int j = 0; j < i; ++j)
                 {
-                    IntegratorOps<T>::Saxpy(S_new, timestep * tableau[i][j], *F_nodes[j]);
+                    IntegratorOps<T>::Saxpy(S_new, BaseT::timestep * tableau[i][j], *F_nodes[j]);
                 }
 
                 // Call the post-update hook for the stage state value
@@ -210,20 +209,20 @@ public:
         IntegratorOps<T>::Copy(S_new, S_old);
         for (int i = 0; i < number_nodes; ++i)
         {
-            IntegratorOps<T>::Saxpy(S_new, timestep * weights[i], *F_nodes[i]);
+            IntegratorOps<T>::Saxpy(S_new, BaseT::timestep * weights[i], *F_nodes[i]);
         }
 
         // Call the post-update hook for S_new
-        BaseT::post_update(S_new, time + timestep);
+        BaseT::post_update(S_new, time + BaseT::timestep);
 
         // If we are working with an extended Butcher tableau, we can estimate the error here,
         // and then calculate an adaptive timestep.
 
         // Return timestep
-        return timestep;
+        return BaseT::timestep;
     }
 
-    void time_interpolate (const T& S_new, const T& S_old, amrex::Real timestep_fraction, T& data)
+    void time_interpolate (const T& /* S_new */, const T& S_old, amrex::Real timestep_fraction, T& data)
     {
         // data = S_old*(1-time_step_fraction) + S_new*(time_step_fraction)
         /*
@@ -245,19 +244,19 @@ public:
 
         // data += (chi - 3/2 * chi^2 + 2/3 * chi^3) * k1
         c = timestep_fraction - 1.5 * std::pow(timestep_fraction, 2) + 2./3. * std::pow(timestep_fraction, 3);
-        IntegratorOps<T>::Saxpy(data, c*timestep, *F_nodes[0]);
+        IntegratorOps<T>::Saxpy(data, c*BaseT::timestep, *F_nodes[0]);
 
         // data += (chi^2 - 2/3 * chi^3) * k2
         c = std::pow(timestep_fraction, 2) - 2./3. * std::pow(timestep_fraction, 3);
-        IntegratorOps<T>::Saxpy(data, c*timestep, *F_nodes[1]);
+        IntegratorOps<T>::Saxpy(data, c*BaseT::timestep, *F_nodes[1]);
 
         // data += (chi^2 - 2/3 * chi^3) * k3
         c = std::pow(timestep_fraction, 2) - 2./3. * std::pow(timestep_fraction, 3);
-        IntegratorOps<T>::Saxpy(data, c*timestep, *F_nodes[2]);
+        IntegratorOps<T>::Saxpy(data, c*BaseT::timestep, *F_nodes[2]);
 
         // data += (-1/2 * chi^2 + 2/3 * chi^3) * k4
         c = -0.5 * std::pow(timestep_fraction, 2) + 2./3. * std::pow(timestep_fraction, 3);
-        IntegratorOps<T>::Saxpy(data, c*timestep, *F_nodes[3]);
+        IntegratorOps<T>::Saxpy(data, c*BaseT::timestep, *F_nodes[3]);
 
     }
 

--- a/Src/Base/AMReX_TimeIntegrator.H
+++ b/Src/Base/AMReX_TimeIntegrator.H
@@ -39,10 +39,10 @@ private:
 
         // By default, do nothing after updating the state
         // In general, this is where BCs should be filled
-        set_post_update([](T& S_data, amrex::Real S_time){});
+        set_post_update([](T& /* S_data */, amrex::Real /* S_time */){});
 
         // By default, do nothing
-        set_rhs([](T& S_rhs, const T& S_data, const amrex::Real time){});
+        set_rhs([](T& /* S_rhs */, const T& /* S_data */, const amrex::Real /* time */){});
     }
 
 public:


### PR DESCRIPTION
## Summary

The compiler was reporting some warnings for unused and shadowed variables in the time integration classes.

This PR fixes those warnings.

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
