### PR TITLE
Update read path for HDF5 benchmark

### DIFF
--- a/Tests/HDF5Benchmark/main.cpp
+++ b/Tests/HDF5Benchmark/main.cpp
@@ -214,10 +214,10 @@ void test ()
         MyPC newPC(geom, dmap, ba, ref_ratio);
 #ifdef AMREX_USE_HDF5
         sprintf(directory_path, "%s%s", directory.c_str(), "plt00000/particle0");
-        newPC.RestartHDF5("plt00000/particle0", "particle0");
+        newPC.RestartHDF5(directory_path, "particle0");
 #else
         sprintf(directory_path, "%s%s", directory.c_str(), "plt00000");
-        newPC.Restart("plt00000", "particle0");
+        newPC.Restart(directory_path, "particle0");
 #endif
 
         using PType = typename MyPC::SuperParticleType;


### PR DESCRIPTION
Update read path (missing) after including the directory prefix

## Summary

Once we included the directory prefix as optional for the HDF5 benchmark (https://github.com/AMReX-Codes/amrex/pull/2461) the path used for read requests was [not updated](https://github.com/AMReX-Codes/amrex/pull/2461/files#diff-e38be6d7f9d1c638f925e6dd11e901e4214ad6005fac3750401e6731c16846acR214-R218). This PR fixes that.

## Checklist

The proposed changes:
- [X] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
