### PR TITLE
Resize vector inside GatherLayoutDataToVector

### DIFF
--- a/Src/Base/AMReX_ParallelDescriptor.H
+++ b/Src/Base/AMReX_ParallelDescriptor.H
@@ -971,6 +971,7 @@ ParallelDescriptor::GatherLayoutDataToVector (const LayoutData<T>& sendbuf,
 
     int nprocs = ParallelContext::NProcsSub();
     Vector<int> recvcount(nprocs, 0);
+    recvbuf.resize(nprocs);
     const Vector<int>& old_pmap = sendbuf.DistributionMap().ProcessorMap();
     for (int i=0; i<old_pmap.size(); ++i)
     {
@@ -1028,7 +1029,7 @@ ParallelDescriptor::GatherLayoutDataToVector (const LayoutData<T>& sendbuf,
 
         for (int i=0; i<recvbuf.size(); ++i)
         {
-                recvbuf[i] = new_index_to_T[old_index_to_new_index[i]];
+            recvbuf[i] = new_index_to_T[old_index_to_new_index[i]];
         }
     }
 }

--- a/Src/Base/AMReX_ParallelDescriptor.H
+++ b/Src/Base/AMReX_ParallelDescriptor.H
@@ -1173,6 +1173,8 @@ void
 GatherLayoutDataToVector (const LayoutData<T>& sendbuf,
                           Vector<T>& recvbuf, int /*root*/)
 {
+    recvbuf.resize(sendbuf.size());
+
     for (int i=0; i<sendbuf.size(); ++i)
     {
         recvbuf[i] = sendbuf[i];

--- a/Src/Base/AMReX_ParallelDescriptor.H
+++ b/Src/Base/AMReX_ParallelDescriptor.H
@@ -971,7 +971,7 @@ ParallelDescriptor::GatherLayoutDataToVector (const LayoutData<T>& sendbuf,
 
     int nprocs = ParallelContext::NProcsSub();
     Vector<int> recvcount(nprocs, 0);
-    recvbuf.resize(nprocs);
+    recvbuf.resize(sendbuf.size());
     const Vector<int>& old_pmap = sendbuf.DistributionMap().ProcessorMap();
     for (int i=0; i<old_pmap.size(); ++i)
     {


### PR DESCRIPTION
## Summary

The output vector of GatherLayoutDataToVector doesn't resize the resulting vector; the user has to pass a minimally `nrank` sized vector themselves. This PR resizes the result vector inside the function.

The only potential issue is if someone has been passing in something larger than `nranks`, attempting to use it for some type of concatenation with whatever is hanging over the end of the vector. But, I doubt we want that to be an actual use case for this function. If I'm wrong, we can make the resize conditional.

## Additional background

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
