### PR TITLE
Add Gatherv for USE_MPI=FALSE.

### DIFF
--- a/Src/Base/AMReX_ParallelDescriptor.H
+++ b/Src/Base/AMReX_ParallelDescriptor.H
@@ -1169,6 +1169,17 @@ Gather(const T& t, int /*root*/)
 
 template <class T>
 void
+Gatherv (const T* send, int sc,
+         T* recv, const std::vector<int>& /*rc*/,
+         const std::vector<int>& /*disp*/, int /*root*/)
+{
+    std::vector<T> resl(sc);
+    for (int j=0; j<sc; ++j) { recv[j] = send[j]; }
+    return resl;
+}
+
+template <class T>
+void
 GatherLayoutDataToVector (const LayoutData<T>& sendbuf,
                           Vector<T>& recvbuf, int /*root*/)
 {

--- a/Src/Base/AMReX_ParallelDescriptor.H
+++ b/Src/Base/AMReX_ParallelDescriptor.H
@@ -1173,7 +1173,6 @@ Gatherv (const T* send, int sc,
          T* recv, const std::vector<int>& /*rc*/,
          const std::vector<int>& /*disp*/, int /*root*/)
 {
-    std::vector<T> resl(sc);
     for (int j=0; j<sc; ++j) { recv[j] = send[j]; }
 }
 

--- a/Src/Base/AMReX_ParallelDescriptor.H
+++ b/Src/Base/AMReX_ParallelDescriptor.H
@@ -1175,7 +1175,6 @@ Gatherv (const T* send, int sc,
 {
     std::vector<T> resl(sc);
     for (int j=0; j<sc; ++j) { recv[j] = send[j]; }
-    return resl;
 }
 
 template <class T>


### PR DESCRIPTION
## Summary

This adds a Gatherv implementation for when USE_MPI=FALSE.

## Additional background

This is causing a runtime error in the GitHub checks for my graph object _only_ in the simple processing tools, like fcompare. Not sure why isn't not throwing an error in other USE_MPI=FALSE tests, and I'm really curious about it, but adding in the USE_MPI=FALSE implementation for completion can't hurt.

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
