### PR TITLE
Embed more EB data in EBFArrayBox

### DIFF
--- a/Src/EB/AMReX_EBFArrayBox.H
+++ b/Src/EB/AMReX_EBFArrayBox.H
@@ -14,7 +14,7 @@ class EBFArrayBox
 {
 public:
     EBFArrayBox ();
-    EBFArrayBox (Arena* ar);
+    explicit EBFArrayBox (Arena* ar);
     EBFArrayBox (const EBCellFlagFab& ebcellflag, const Box& box, int ncomps, Arena* ar,
                  const EBFArrayBoxFactory* factory=nullptr, int box_index=-1);
     EBFArrayBox (EBFArrayBox const& rhs, MakeType make_type, int scomp, int ncomp);

--- a/Src/EB/AMReX_EBFArrayBox.H
+++ b/Src/EB/AMReX_EBFArrayBox.H
@@ -7,6 +7,7 @@
 namespace amrex {
 
 class EBCellFlagFab;
+class EBFArrayBoxFactory;
 
 class EBFArrayBox
     : public FArrayBox
@@ -14,7 +15,8 @@ class EBFArrayBox
 public:
     EBFArrayBox ();
     EBFArrayBox (Arena* ar);
-    EBFArrayBox (const EBCellFlagFab& ebcellflag, const Box& box, int ncomps, Arena* ar);
+    EBFArrayBox (const EBCellFlagFab& ebcellflag, const Box& box, int ncomps, Arena* ar,
+                 const EBFArrayBoxFactory* factory=nullptr, int box_index=-1);
     EBFArrayBox (EBFArrayBox const& rhs, MakeType make_type, int scomp, int ncomp);
 
     EBFArrayBox (EBFArrayBox&& rhs) noexcept = default;
@@ -24,10 +26,49 @@ public:
 
     ~EBFArrayBox ();
 
+    //! Get EBCellFlag Fab
     const EBCellFlagFab& getEBCellFlagFab () const { return *m_ebcellflag; }
 
+    //! Get a pointer to levelset data if available.  The return value could
+    //! be nullptr if not available.
+    const FArrayBox* getLevelSetData () const;
+
+    //! Get a pointer to volume fraction data if available.  The return
+    //! value could be nullptr if not available.
+    const FArrayBox* getVolFracData () const;
+
+    //! Get a pointer to volume centroid data if available.  The return
+    //! value could be nullptr if not available.
+    const FArrayBox* getCentroidData () const;
+
+    //! Get a pointer to boundary centroid data if available.  The return
+    //! value could be nullptr if not available.
+    const FArrayBox* getBndryCentData () const;
+
+    //! Get a pointer to boundary normal data if available.  The return
+    //! value could be nullptr if not available.
+    const FArrayBox* getBndryNormalData () const;
+
+    //! Get a pointer to boundary area data if available.  The return
+    //! value could be nullptr if not available.
+    const FArrayBox* getBndryAreaData () const;
+
+    //! Get pointers to area fraction data if available.  The return value
+    //! could be nullptr if not available.
+    Array<const FArrayBox*, AMREX_SPACEDIM> getAreaFracData () const;
+
+    //! Get pointers to face centroid data if available.  The return value
+    //! could be nullptr if not available.
+    Array<const FArrayBox*, AMREX_SPACEDIM> getFaceCentData () const;
+
+    //! Get pointers to edge centroid data if available.  The return value
+    //! could be nullptr if not available.
+    Array<const FArrayBox*, AMREX_SPACEDIM> getEdgeCentData () const;
+
 private:
-    const EBCellFlagFab* m_ebcellflag;
+    const EBCellFlagFab* m_ebcellflag = nullptr;
+    const EBFArrayBoxFactory* m_factory = nullptr;
+    int m_box_index = -1;
 };
 
 const EBCellFlagFab& getEBCellFlagFab (const FArrayBox& fab);

--- a/Src/EB/AMReX_EBFArrayBox.cpp
+++ b/Src/EB/AMReX_EBFArrayBox.cpp
@@ -1,24 +1,27 @@
 
 #include <AMReX_EBFArrayBox.H>
 #include <AMReX_EBCellFlag.H>
+#include <AMReX_EBFabFactory.H>
+#include <AMReX_MultiFab.H>
+#include <AMReX_MultiCutFab.H>
 
 namespace amrex {
 
 EBFArrayBox::EBFArrayBox ()
-    : FArrayBox(),
-      m_ebcellflag(nullptr)
 {
 }
 
 EBFArrayBox::EBFArrayBox (Arena* ar)
-    : FArrayBox(ar),
-      m_ebcellflag(nullptr)
+    : FArrayBox(ar)
 {
 }
 
-EBFArrayBox::EBFArrayBox (const EBCellFlagFab& ebflag, const Box& bx, int ncomps, Arena* ar)
+EBFArrayBox::EBFArrayBox (const EBCellFlagFab& ebflag, const Box& bx, int ncomps, Arena* ar,
+                          const EBFArrayBoxFactory* factory, int box_index)
     : FArrayBox(bx, ncomps, ar),
-      m_ebcellflag(&ebflag)
+      m_ebcellflag(&ebflag),
+      m_factory(factory),
+      m_box_index(box_index)
 {
     BL_ASSERT(ebflag.box().contains(amrex::enclosedCells(bx)));
     const Box& ccbx = amrex::enclosedCells(bx);
@@ -26,15 +29,150 @@ EBFArrayBox::EBFArrayBox (const EBCellFlagFab& ebflag, const Box& bx, int ncomps
 }
 
 EBFArrayBox::EBFArrayBox (EBFArrayBox const& rhs, MakeType make_type, int scomp, int ncomp)
-    : FArrayBox(rhs, make_type, scomp, ncomp)
+    : FArrayBox(rhs, make_type, scomp, ncomp),
+      m_ebcellflag(rhs.m_ebcellflag),
+      m_factory(rhs.m_factory),
+      m_box_index(rhs.m_box_index)
 {
     m_type = rhs.m_type;
-    m_ebcellflag = rhs.m_ebcellflag;
 }
 
 EBFArrayBox::~EBFArrayBox ()
 {
 
+}
+
+const FArrayBox*
+EBFArrayBox::getLevelSetData () const
+{
+    if (m_factory && m_box_index >= 0) {
+        MultiFab const& mf = m_factory->getLevelSet();
+        return &(mf[m_box_index]);
+    } else {
+        return nullptr;
+    }
+}
+
+const FArrayBox*
+EBFArrayBox::getVolFracData () const
+{
+    if (m_factory && m_box_index >= 0) {
+        MultiFab const& mf = m_factory->getVolFrac();
+        return &(mf[m_box_index]);
+    } else {
+        return nullptr;
+    }
+}
+
+const FArrayBox*
+EBFArrayBox::getCentroidData () const
+{
+    if (m_factory && m_box_index >= 0) {
+        MultiCutFab const& mf = m_factory->getCentroid();
+        if (mf.ok(m_box_index)) {
+            return &(mf[m_box_index]);
+        } else {
+            return nullptr;
+        }
+    } else {
+        return nullptr;
+    }
+}
+
+const FArrayBox*
+EBFArrayBox::getBndryCentData () const
+{
+    if (m_factory && m_box_index >= 0) {
+        MultiCutFab const& mf = m_factory->getBndryCent();
+        if (mf.ok(m_box_index)) {
+            return &(mf[m_box_index]);
+        } else {
+            return nullptr;
+        }
+    } else {
+        return nullptr;
+    }
+}
+
+const FArrayBox*
+EBFArrayBox::getBndryNormalData () const
+{
+    if (m_factory && m_box_index >= 0) {
+        MultiCutFab const& mf = m_factory->getBndryNormal();
+        if (mf.ok(m_box_index)) {
+            return &(mf[m_box_index]);
+        } else {
+            return nullptr;
+        }
+    } else {
+        return nullptr;
+    }
+}
+
+const FArrayBox*
+EBFArrayBox::getBndryAreaData () const
+{
+    if (m_factory && m_box_index >= 0) {
+        MultiCutFab const& mf = m_factory->getBndryArea();
+        if (mf.ok(m_box_index)) {
+            return &(mf[m_box_index]);
+        } else {
+            return nullptr;
+        }
+    } else {
+        return nullptr;
+    }
+}
+
+Array<const FArrayBox*, AMREX_SPACEDIM>
+EBFArrayBox::getAreaFracData () const
+{
+    if (m_factory && m_box_index >= 0) {
+        Array<MultiCutFab const*, AMREX_SPACEDIM> const& mfs = m_factory->getAreaFrac();
+        if (mfs[0]->ok(m_box_index)) {
+            return {AMREX_D_DECL(&((*mfs[0])[m_box_index]),
+                                 &((*mfs[1])[m_box_index]),
+                                 &((*mfs[2])[m_box_index]))};
+        } else {
+            return {AMREX_D_DECL(nullptr,nullptr,nullptr)};
+        }
+    } else {
+        return {AMREX_D_DECL(nullptr,nullptr,nullptr)};
+    }
+}
+
+Array<const FArrayBox*, AMREX_SPACEDIM>
+EBFArrayBox::getFaceCentData () const
+{
+    if (m_factory && m_box_index >= 0) {
+        Array<MultiCutFab const*, AMREX_SPACEDIM> const& mfs = m_factory->getFaceCent();
+        if (mfs[0]->ok(m_box_index)) {
+            return {AMREX_D_DECL(&((*mfs[0])[m_box_index]),
+                                 &((*mfs[1])[m_box_index]),
+                                 &((*mfs[2])[m_box_index]))};
+        } else {
+            return {AMREX_D_DECL(nullptr,nullptr,nullptr)};
+        }
+    } else {
+        return {AMREX_D_DECL(nullptr,nullptr,nullptr)};
+    }
+}
+
+Array<const FArrayBox*, AMREX_SPACEDIM>
+EBFArrayBox::getEdgeCentData () const
+{
+    if (m_factory && m_box_index >= 0) {
+        Array<MultiCutFab const*, AMREX_SPACEDIM> const& mfs = m_factory->getEdgeCent();
+        if (mfs[0]->ok(m_box_index)) {
+            return {AMREX_D_DECL(&((*mfs[0])[m_box_index]),
+                                 &((*mfs[1])[m_box_index]),
+                                 &((*mfs[2])[m_box_index]))};
+        } else {
+            return {AMREX_D_DECL(nullptr,nullptr,nullptr)};
+        }
+    } else {
+        return {AMREX_D_DECL(nullptr,nullptr,nullptr)};
+    }
 }
 
 const EBCellFlagFab&

--- a/Src/EB/AMReX_EBFabFactory.cpp
+++ b/Src/EB/AMReX_EBFabFactory.cpp
@@ -34,7 +34,7 @@ EBFArrayBoxFactory::create (const Box& box, int ncomps,
     else
     {
         const EBCellFlagFab& ebcellflag = m_ebdc->getMultiEBCellFlagFab()[box_index];
-        return new EBFArrayBox(ebcellflag, box, ncomps, info.arena);
+        return new EBFArrayBox(ebcellflag, box, ncomps, info.arena, this, box_index);
     }
 }
 

--- a/Src/EB/AMReX_MultiCutFab.H
+++ b/Src/EB/AMReX_MultiCutFab.H
@@ -100,11 +100,18 @@ public:
     const CutFab& operator[] (const MFIter& mfi) const noexcept;
     CutFab& operator[] (const MFIter& mfi) noexcept;
 
+    const CutFab& operator[] (int global_box_index) const noexcept;
+    CutFab& operator[] (int global_box_index) noexcept;
+
     Array4<Real      > array (const MFIter& mfi) noexcept;
     Array4<Real const> array (const MFIter& mfi) const noexcept;
     Array4<Real const> const_array (const MFIter& mfi) const noexcept;
 
+    //! Is it OK to call operator[] with this MFIter?
     bool ok (const MFIter& mfi) const noexcept;
+
+    //! Is it OK to call operator[] with this global box index?
+    bool ok (int global_box_index) const noexcept;
 
     void setVal (Real val);
 

--- a/Src/EB/AMReX_MultiCutFab.cpp
+++ b/Src/EB/AMReX_MultiCutFab.cpp
@@ -57,6 +57,20 @@ MultiCutFab::operator[] (const MFIter& mfi) noexcept
     return m_data[mfi];
 }
 
+const CutFab&
+MultiCutFab::operator[] (int global_box_index) const noexcept
+{
+    AMREX_ASSERT(ok(global_box_index));
+    return m_data[global_box_index];
+}
+
+CutFab&
+MultiCutFab::operator[] (int global_box_index) noexcept
+{
+    AMREX_ASSERT(ok(global_box_index));
+    return m_data[global_box_index];
+}
+
 Array4<Real const>
 MultiCutFab::const_array (const MFIter& mfi) const noexcept
 {
@@ -82,6 +96,12 @@ bool
 MultiCutFab::ok (const MFIter& mfi) const noexcept
 {
     return (*m_cellflags)[mfi].getType() == FabType::singlevalued;
+}
+
+bool
+MultiCutFab::ok (int global_box_index) const noexcept
+{
+    return (*m_cellflags)[global_box_index].getType() == FabType::singlevalued;
 }
 
 void


### PR DESCRIPTION
Before this, we only had access to EBCellFlag given an EBFArrayBox.  This
adds access to more EB data via EBFArrayBox.  This could be useful for
functions with Fab parameters (e.g., AmrLevel's derive functions).

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
