### PR TITLE
Update to SUNDIALS 6

### DIFF
--- a/Src/Base/AMReX.cpp
+++ b/Src/Base/AMReX.cpp
@@ -543,7 +543,11 @@ amrex::Initialize (int& argc, char**& argv, bool build_parm_parse,
 #endif
 
 #ifdef AMREX_USE_SUNDIALS
-    sundials::Initialize();
+#ifdef AMREX_USE_OMP
+    sundials::Initialize(omp_get_max_threads());
+#else
+    sundials::Initialize(1);
+#endif
 #endif
 
     if (system::verbose > 0)

--- a/Src/Base/AMReX.cpp
+++ b/Src/Base/AMReX.cpp
@@ -543,11 +543,7 @@ amrex::Initialize (int& argc, char**& argv, bool build_parm_parse,
 #endif
 
 #ifdef AMREX_USE_SUNDIALS
-#ifdef AMREX_USE_OMP
-    sundials::Initialize(omp_get_max_threads());
-#else
-    sundials::Initialize(1);
-#endif
+    sundials::Initialize(amrex::OpenMP::get_max_threads());
 #endif
 
     if (system::verbose > 0)

--- a/Src/Extern/SUNDIALS/AMReX_NVector_MultiFab.H
+++ b/Src/Extern/SUNDIALS/AMReX_NVector_MultiFab.H
@@ -25,11 +25,10 @@
 #include <cstdio>
 
 #ifdef __cplusplus  /* wrapper to enable C++ usage */
-extern "C" {
-#endif
-
 namespace amrex {
 namespace sundials {
+extern "C" {
+#endif
 
 /* -----------------------------------------------------------------
  * Vector content structure
@@ -64,9 +63,7 @@ void N_VDestroy_MultiFab(N_Vector v);
 void N_VSpace_MultiFab(N_Vector v, sunindextype *lrw,
                        sunindextype *liw);
 N_VectorContent_MultiFab N_VGetContent_MultiFab(N_Vector v);
-MultiFab*& getMFptr(N_Vector v);
 MultiFab* N_VGetVectorPointer_MultiFab(N_Vector v);
-MultiFab N_VGetVectorAlias_MultiFab(N_Vector v);
 amrex::Real NormHelper_NVector_MultiFab(N_Vector x, N_Vector w, N_Vector id, int use_id, bool rms);
 /* standard vector operations */
 void N_VLinearSum_MultiFab(amrex::Real a, N_Vector x,
@@ -92,11 +89,14 @@ int N_VConstrMask_MultiFab(N_Vector c, N_Vector x,
                            N_Vector m);
 amrex::Real N_VMinQuotient_MultiFab(N_Vector num, N_Vector denom);
 
-}
-
-}
 #ifdef __cplusplus
-}
+} // extern "C"
+
+MultiFab*& getMFptr(N_Vector v);
+MultiFab N_VGetVectorAlias_MultiFab(N_Vector v);
+
+}//namespace sundials
+}//namespace amrex
 #endif
 
 #endif

--- a/Src/Extern/SUNDIALS/AMReX_SUNMemory.H
+++ b/Src/Extern/SUNDIALS/AMReX_SUNMemory.H
@@ -9,20 +9,16 @@
 namespace amrex {
 namespace sundials {
 
-using SundialsContext = ::sundials::Context;
-
 class MemoryHelper {
 public:
-  MemoryHelper();
+  MemoryHelper(::sundials::Context*);
   ~MemoryHelper();
   operator SUNMemoryHelper() const { return helper; }
+  static void Initialize(::sundials::Context*);
+  static void Finalize();
 private:
-  SundialsContext sunctx;
   SUNMemoryHelper helper;
 };
-
-void Initialize();
-void Finalize();
 
 MemoryHelper* The_SUNMemory_Helper();
 amrex::Arena* getArena (SUNMemoryType type);

--- a/Src/Extern/SUNDIALS/AMReX_SUNMemory.H
+++ b/Src/Extern/SUNDIALS/AMReX_SUNMemory.H
@@ -3,10 +3,13 @@
 
 #include <AMReX.H>
 #include <AMReX_Arena.H>
+#include <sundials/sundials_context.h>
 #include <sundials/sundials_memory.h>
 
 namespace amrex {
 namespace sundials {
+
+using SundialsContext = ::sundials::Context;
 
 class MemoryHelper {
 public:
@@ -14,6 +17,7 @@ public:
   ~MemoryHelper();
   operator SUNMemoryHelper() const { return helper; }
 private:
+  SundialsContext sunctx;
   SUNMemoryHelper helper;
 };
 

--- a/Src/Extern/SUNDIALS/AMReX_SUNMemory.H
+++ b/Src/Extern/SUNDIALS/AMReX_SUNMemory.H
@@ -7,6 +7,12 @@
 namespace amrex {
 namespace sundials {
 
+/**
+ * \brief A SUNDIALS SUNMemoryHelper interface to the amrex::Arena.
+ *
+ * This class allows SUNDIALS to allocate memory using the amrex::Arena.
+ */
+
 class MemoryHelper {
 public:
     MemoryHelper(::sundials::Context* sunctx);
@@ -24,11 +30,23 @@ private:
     SUNMemoryHelper helper;
 };
 
-#ifdef AMREX_USE_OMP
-MemoryHelper* The_SUNMemory_Helper(int i = omp_get_thread_num());
-#else
-MemoryHelper* The_SUNMemory_Helper(int i = 0);
-#endif
+
+/**
+ * \brief Get the i-th SUNMemoryHelper instance.
+ *
+ * \param[in] i The index of the SUNMemoryHelper to return.
+ *
+ * SUNMemoryHelper_i is paired with the i-th SUNContext.
+ */
+
+MemoryHelper* The_SUNMemory_Helper(int i = amrex::OpenMP::get_thread_num());
+
+/**
+ * \brief Get the proper amrex::Arena based on the SUNMemoryType.
+ *
+ * \param[in] type A SUNDIALS SUNMemoryType.
+ */
+
 amrex::Arena* getArena (SUNMemoryType type);
 
 }//sundials

--- a/Src/Extern/SUNDIALS/AMReX_SUNMemory.H
+++ b/Src/Extern/SUNDIALS/AMReX_SUNMemory.H
@@ -1,8 +1,6 @@
 #ifndef AMREX_SUNMEMORY_H_
 #define AMREX_SUNMEMORY_H_
 
-#include <AMReX.H>
-#include <AMReX_Arena.H>
 #include <sundials/sundials_context.h>
 #include <sundials/sundials_memory.h>
 
@@ -11,19 +9,29 @@ namespace sundials {
 
 class MemoryHelper {
 public:
-  MemoryHelper(::sundials::Context*);
+  MemoryHelper(::sundials::Context* sunctx);
   ~MemoryHelper();
+  MemoryHelper(const MemoryHelper& helper);
+  MemoryHelper(MemoryHelper&& helper);
+  MemoryHelper& operator=(MemoryHelper other);
+  MemoryHelper& operator=(MemoryHelper&& other);
   operator SUNMemoryHelper() const { return helper; }
-  static void Initialize(::sundials::Context*);
+
+  static void Initialize(int nthreads);
   static void Finalize();
 private:
+  ::sundials::Context* sunctx;
   SUNMemoryHelper helper;
 };
 
-MemoryHelper* The_SUNMemory_Helper();
+#ifdef AMREX_USE_OMP
+MemoryHelper* The_SUNMemory_Helper(int i = omp_get_thread_num());
+#else
+MemoryHelper* The_SUNMemory_Helper(int i = 0);
+#endif
 amrex::Arena* getArena (SUNMemoryType type);
 
-}
-}
+}//sundials
+}//amrex
 
 #endif

--- a/Src/Extern/SUNDIALS/AMReX_SUNMemory.H
+++ b/Src/Extern/SUNDIALS/AMReX_SUNMemory.H
@@ -9,19 +9,19 @@ namespace sundials {
 
 class MemoryHelper {
 public:
-  MemoryHelper(::sundials::Context* sunctx);
-  ~MemoryHelper();
-  MemoryHelper(const MemoryHelper& helper);
-  MemoryHelper(MemoryHelper&& helper);
-  MemoryHelper& operator=(MemoryHelper other);
-  MemoryHelper& operator=(MemoryHelper&& other);
-  operator SUNMemoryHelper() const { return helper; }
+    MemoryHelper(::sundials::Context* sunctx);
+    ~MemoryHelper();
+    MemoryHelper(const MemoryHelper& helper);
+    MemoryHelper(MemoryHelper&& helper);
+    MemoryHelper& operator=(MemoryHelper other);
+    MemoryHelper& operator=(MemoryHelper&& other);
+    operator SUNMemoryHelper() const { return helper; }
 
-  static void Initialize(int nthreads);
-  static void Finalize();
+    static void Initialize(int nthreads);
+    static void Finalize();
 private:
-  ::sundials::Context* sunctx;
-  SUNMemoryHelper helper;
+    ::sundials::Context* sunctx;
+    SUNMemoryHelper helper;
 };
 
 #ifdef AMREX_USE_OMP

--- a/Src/Extern/SUNDIALS/AMReX_SUNMemory.cpp
+++ b/Src/Extern/SUNDIALS/AMReX_SUNMemory.cpp
@@ -15,199 +15,199 @@ namespace amrex {
 namespace sundials {
 
 namespace {
-  amrex::Arena* getArena (SUNMemoryType mem_type)
-  {
-    if (mem_type == SUNMEMTYPE_HOST) {
-      return The_Cpu_Arena();
-    } else if (mem_type == SUNMEMTYPE_UVM) {
-        if (The_Arena()->isManaged()) {
-          return The_Arena();
-        } else if (The_Managed_Arena()->isManaged()) {
-          return The_Managed_Arena();
+    amrex::Arena* getArena (SUNMemoryType mem_type)
+    {
+        if (mem_type == SUNMEMTYPE_HOST) {
+            return The_Cpu_Arena();
+        } else if (mem_type == SUNMEMTYPE_UVM) {
+                if (The_Arena()->isManaged()) {
+                    return The_Arena();
+                } else if (The_Managed_Arena()->isManaged()) {
+                    return The_Managed_Arena();
+                } else {
+                    return nullptr;
+                }
+        } else if (mem_type == SUNMEMTYPE_DEVICE) {
+            return The_Device_Arena();
+        } else if (mem_type == SUNMEMTYPE_PINNED) {
+            return The_Pinned_Arena();
         } else {
-          return nullptr;
+            return nullptr;
         }
-    } else if (mem_type == SUNMEMTYPE_DEVICE) {
-      return The_Device_Arena();
-    } else if (mem_type == SUNMEMTYPE_PINNED) {
-      return The_Pinned_Arena();
-    } else {
-      return nullptr;
-    }
-  }
-
-  int Alloc(SUNMemoryHelper, SUNMemory* memptr, size_t memsize, SUNMemoryType mem_type, void* /*queue*/)
-  {
-    SUNMemory mem = SUNMemoryNewEmpty();
-
-    if (mem == nullptr) return -1;
-    mem->ptr = NULL;
-    mem->own = SUNTRUE;
-    mem->type = mem_type;
-    auto arena = getArena(mem->type);
-    if (arena) {
-      mem->ptr = arena->alloc(memsize);
-      *memptr = mem;
-      return 0;
-    }
-    else {
-      free(mem);
-      memptr = nullptr;
-      return -1;
     }
 
-    return -1;
-  }
+    int Alloc(SUNMemoryHelper, SUNMemory* memptr, size_t memsize, SUNMemoryType mem_type, void* /*queue*/)
+    {
+        SUNMemory mem = SUNMemoryNewEmpty();
 
-  int Dealloc(SUNMemoryHelper, SUNMemory mem, void* /*queue*/)
-  {
+        if (mem == nullptr) return -1;
+        mem->ptr = NULL;
+        mem->own = SUNTRUE;
+        mem->type = mem_type;
+        auto arena = getArena(mem->type);
+        if (arena) {
+            mem->ptr = arena->alloc(memsize);
+            *memptr = mem;
+            return 0;
+        }
+        else {
+            free(mem);
+            memptr = nullptr;
+            return -1;
+        }
 
-    if (mem == nullptr) return 0;
-    auto arena = getArena(mem->type);
-    if (arena) {
-      if(mem->own)
-      {
-        arena->free(mem->ptr);
+        return -1;
+    }
+
+    int Dealloc(SUNMemoryHelper, SUNMemory mem, void* /*queue*/)
+    {
+
+        if (mem == nullptr) return 0;
+        auto arena = getArena(mem->type);
+        if (arena) {
+            if(mem->own)
+            {
+                arena->free(mem->ptr);
+                free(mem);
+                return 0;
+            }
+        }
+        else {
+            free(mem);
+            return -1;
+        }
+
         free(mem);
         return 0;
-      }
-    }
-    else {
-      free(mem);
-      return -1;
     }
 
-    free(mem);
-    return 0;
-  }
+    SUNMemoryHelper CloneMemoryHelper(SUNMemoryHelper)
+    {
+        return *The_SUNMemory_Helper();
+    }
 
-  SUNMemoryHelper CloneMemoryHelper(SUNMemoryHelper)
-  {
-    return *The_SUNMemory_Helper();
-  }
+    int DestroyMemoryHelper(SUNMemoryHelper)
+    {
+        // We just return because we do not want our
+        // memory helper instance to be destroyed
+        // except when Finalize is called.
+        return 0;
+    }
 
-  int DestroyMemoryHelper(SUNMemoryHelper)
-  {
-    // We just return because we do not want our
-    // memory helper instance to be destroyed
-    // except when Finalize is called.
-    return 0;
-  }
+    void ActuallyDestroySUNMemoryHelper(SUNMemoryHelper helper)
+    {
+        if (helper->ops) free(helper->ops);
+        free(helper);
+    }
 
-  void ActuallyDestroySUNMemoryHelper(SUNMemoryHelper helper)
-  {
-    if (helper->ops) free(helper->ops);
-    free(helper);
-  }
+    SUNMemoryHelper CreateMemoryHelper(::sundials::Context* sunctx)
+    {
+        SUNMemoryHelper helper;
 
-  SUNMemoryHelper CreateMemoryHelper(::sundials::Context* sunctx)
-  {
-    SUNMemoryHelper helper;
+        helper = SUNMemoryHelper_NewEmpty(*sunctx);
 
-    helper = SUNMemoryHelper_NewEmpty(*sunctx);
-
-    helper->content        = NULL;
-    helper->ops->clone     = CloneMemoryHelper;
-    helper->ops->alloc     = Alloc;
-    helper->ops->dealloc   = Dealloc;
-    helper->ops->destroy   = DestroyMemoryHelper;
+        helper->content              = NULL;
+        helper->ops->clone       = CloneMemoryHelper;
+        helper->ops->alloc       = Alloc;
+        helper->ops->dealloc     = Dealloc;
+        helper->ops->destroy     = DestroyMemoryHelper;
 #if defined(AMREX_USE_HIP)
-    helper->ops->copy      = SUNMemoryHelper_Copy_Hip;
-    helper->ops->copyasync = SUNMemoryHelper_CopyAsync_Hip;
+        helper->ops->copy            = SUNMemoryHelper_Copy_Hip;
+        helper->ops->copyasync = SUNMemoryHelper_CopyAsync_Hip;
 #elif defined(AMREX_USE_CUDA)
-    helper->ops->copy      = SUNMemoryHelper_Copy_Cuda;
-    helper->ops->copyasync = SUNMemoryHelper_CopyAsync_Cuda;
+        helper->ops->copy            = SUNMemoryHelper_Copy_Cuda;
+        helper->ops->copyasync = SUNMemoryHelper_CopyAsync_Cuda;
 #elif defined(AMREX_USE_DPCPP)
-    helper->ops->copy      = SUNMemoryHelper_Copy_Sycl;
-    helper->ops->copyasync = SUNMemoryHelper_CopyAsync_Sycl;
-    helper->ops->clone     = SUNMemoryHelper_Clone_Sycl;
+        helper->ops->copy            = SUNMemoryHelper_Copy_Sycl;
+        helper->ops->copyasync = SUNMemoryHelper_CopyAsync_Sycl;
+        helper->ops->clone       = SUNMemoryHelper_Clone_Sycl;
 
-    // Attach the queue pointer as the content
-    helper->content = (void*) &amrex::Gpu::Device::streamQueue();
+        // Attach the queue pointer as the content
+        helper->content = (void*) &amrex::Gpu::Device::streamQueue();
 #endif
 
-    return helper;
-  }
+        return helper;
+    }
 
-  Vector<int> initialized;
-  Vector<MemoryHelper*> the_sunmemory_helper;
+    Vector<int> initialized;
+    Vector<MemoryHelper*> the_sunmemory_helper;
 } //namespace
 
 MemoryHelper::MemoryHelper(::sundials::Context* sunctx)
-  : helper(CreateMemoryHelper(sunctx)),
-    sunctx(sunctx)
+    : helper(CreateMemoryHelper(sunctx)),
+        sunctx(sunctx)
 {
 }
 
 MemoryHelper::~MemoryHelper()
 {
-  ActuallyDestroySUNMemoryHelper(helper);
+    ActuallyDestroySUNMemoryHelper(helper);
 }
 
 MemoryHelper::MemoryHelper(const MemoryHelper& rhs)
-  : helper(CreateMemoryHelper(rhs.sunctx)),
-    sunctx(rhs.sunctx)
+    : helper(CreateMemoryHelper(rhs.sunctx)),
+        sunctx(rhs.sunctx)
 {}
 
 MemoryHelper::MemoryHelper(MemoryHelper&& rhs)
-  : helper(rhs.helper),
-    sunctx(rhs.sunctx)
+    : helper(rhs.helper),
+        sunctx(rhs.sunctx)
 {
-  rhs.helper = nullptr;
-  rhs.sunctx = nullptr;
+    rhs.helper = nullptr;
+    rhs.sunctx = nullptr;
 }
 
 MemoryHelper& MemoryHelper::operator=(MemoryHelper rhs)
 {
-  std::swap(helper, rhs.helper);
-  std::swap(sunctx, rhs.sunctx);
-  return *this;
+    std::swap(helper, rhs.helper);
+    std::swap(sunctx, rhs.sunctx);
+    return *this;
 }
 
 MemoryHelper& MemoryHelper::operator=(MemoryHelper&& rhs)
 {
-  if (this != &rhs)
-  {
-    ActuallyDestroySUNMemoryHelper(helper);
-    helper = rhs.helper;
-    rhs.helper = nullptr;
-    delete sunctx;
-    sunctx = rhs.sunctx;
-    rhs.sunctx = nullptr;
-  }
-  return *this;
+    if (this != &rhs)
+    {
+        ActuallyDestroySUNMemoryHelper(helper);
+        helper = rhs.helper;
+        rhs.helper = nullptr;
+        delete sunctx;
+        sunctx = rhs.sunctx;
+        rhs.sunctx = nullptr;
+    }
+    return *this;
 }
 
 void MemoryHelper::Initialize(int nthreads)
 {
-  if (initialized.size() == 0) {
-    initialized.resize(nthreads);
-    std::fill(initialized.begin(), initialized.end(), 0);
-    the_sunmemory_helper.resize(nthreads);
-    std::fill(the_sunmemory_helper.begin(), the_sunmemory_helper.end(), nullptr);
-  }
-  for (int i = 0; i < nthreads; i++) {
-    if (initialized[i]) continue;
-    initialized[i] = 1;
-    BL_ASSERT(the_sunmemory_helper[i] == nullptr);
-    the_sunmemory_helper[i] = new MemoryHelper(The_Sundials_Context(i));
-  }
+    if (initialized.size() == 0) {
+        initialized.resize(nthreads);
+        std::fill(initialized.begin(), initialized.end(), 0);
+        the_sunmemory_helper.resize(nthreads);
+        std::fill(the_sunmemory_helper.begin(), the_sunmemory_helper.end(), nullptr);
+    }
+    for (int i = 0; i < nthreads; i++) {
+        if (initialized[i]) continue;
+        initialized[i] = 1;
+        BL_ASSERT(the_sunmemory_helper[i] == nullptr);
+        the_sunmemory_helper[i] = new MemoryHelper(The_Sundials_Context(i));
+    }
 }
 
 void MemoryHelper::Finalize()
 {
-  for (int i = 0; i < initialized.size(); i++) {
-    initialized[i] = 0;
-    delete the_sunmemory_helper[i];
-    the_sunmemory_helper[i] = nullptr;
-  }
+    for (int i = 0; i < initialized.size(); i++) {
+        initialized[i] = 0;
+        delete the_sunmemory_helper[i];
+        the_sunmemory_helper[i] = nullptr;
+    }
 }
 
 MemoryHelper* The_SUNMemory_Helper(int i)
 {
-  BL_ASSERT(the_sunmemory_helper.size() <= i);
-  BL_ASSERT(the_sunmemory_helper[i] != nullptr);
-  return the_sunmemory_helper[i];
+    BL_ASSERT(the_sunmemory_helper.size() <= i);
+    BL_ASSERT(the_sunmemory_helper[i] != nullptr);
+    return the_sunmemory_helper[i];
 }
 
 }

--- a/Src/Extern/SUNDIALS/AMReX_SUNMemory.cpp
+++ b/Src/Extern/SUNDIALS/AMReX_SUNMemory.cpp
@@ -1,6 +1,7 @@
 #include <AMReX.H>
 #include <AMReX_Gpu.H>
 #include <AMReX_SUNMemory.H>
+#include <sundials/sundials_context.h>
 #if defined(AMREX_USE_HIP)
 #include <sunmemory/sunmemory_hip.h>
 #elif defined(AMREX_USE_CUDA)
@@ -92,11 +93,11 @@ namespace {
     return 0;
   }
 
-  SUNMemoryHelper CreateMemoryHelper()
+  SUNMemoryHelper CreateMemoryHelper(SundialsContext& sunctx)
   {
     SUNMemoryHelper helper;
 
-    helper = SUNMemoryHelper_NewEmpty();
+    helper = SUNMemoryHelper_NewEmpty(sunctx);
 
     helper->content        = NULL;
     helper->ops->clone     = CloneMemoryHelper;
@@ -123,11 +124,13 @@ namespace {
 
   bool initialized = false;
   MemoryHelper* the_sunmemory_helper = nullptr;
-}
+} //namespace
 
 MemoryHelper::MemoryHelper()
-  : helper(CreateMemoryHelper())
-{}
+  : sunctx(SundialsContext())
+{
+  helper = CreateMemoryHelper(sunctx);
+}
 
 MemoryHelper::~MemoryHelper()
 {
@@ -137,6 +140,7 @@ MemoryHelper::~MemoryHelper()
 
 void Initialize()
 {
+  std::cout << ">>>>>>>>>> Initialize()\n";
   if (initialized) return;
   initialized = true;
 

--- a/Src/Extern/SUNDIALS/AMReX_SUNMemory.cpp
+++ b/Src/Extern/SUNDIALS/AMReX_SUNMemory.cpp
@@ -143,7 +143,7 @@ MemoryHelper::~MemoryHelper()
 {
   ActuallyDestroySUNMemoryHelper(helper);
 }
-  
+
 MemoryHelper::MemoryHelper(const MemoryHelper& rhs)
   : helper(CreateMemoryHelper(rhs.sunctx)),
     sunctx(rhs.sunctx)

--- a/Src/Extern/SUNDIALS/AMReX_SUNMemory.cpp
+++ b/Src/Extern/SUNDIALS/AMReX_SUNMemory.cpp
@@ -129,8 +129,8 @@ namespace {
     return helper;
   }
 
-  std::vector<bool> initialized;
-  std::vector<MemoryHelper*> the_sunmemory_helper;
+  Vector<int> initialized;
+  Vector<MemoryHelper*> the_sunmemory_helper;
 } //namespace
 
 MemoryHelper::MemoryHelper(::sundials::Context* sunctx)
@@ -182,13 +182,13 @@ void MemoryHelper::Initialize(int nthreads)
 {
   if (initialized.size() == 0) {
     initialized.resize(nthreads);
-    std::fill(initialized.begin(), initialized.end(), false);
+    std::fill(initialized.begin(), initialized.end(), 0);
     the_sunmemory_helper.resize(nthreads);
     std::fill(the_sunmemory_helper.begin(), the_sunmemory_helper.end(), nullptr);
   }
   for (int i = 0; i < nthreads; i++) {
     if (initialized[i]) continue;
-    initialized[i] = true;
+    initialized[i] = 1;
     BL_ASSERT(the_sunmemory_helper[i] == nullptr);
     the_sunmemory_helper[i] = new MemoryHelper(The_Sundials_Context(i));
   }
@@ -197,7 +197,7 @@ void MemoryHelper::Initialize(int nthreads)
 void MemoryHelper::Finalize()
 {
   for (int i = 0; i < initialized.size(); i++) {
-    initialized[i] = false;
+    initialized[i] = 0;
     delete the_sunmemory_helper[i];
     the_sunmemory_helper[i] = nullptr;
   }

--- a/Src/Extern/SUNDIALS/AMReX_SUNMemory.cpp
+++ b/Src/Extern/SUNDIALS/AMReX_SUNMemory.cpp
@@ -93,7 +93,7 @@ namespace {
     return 0;
   }
 
-  SUNMemoryHelper CreateMemoryHelper(SundialsContext& sunctx)
+  SUNMemoryHelper CreateMemoryHelper(::sundials::Context& sunctx)
   {
     SUNMemoryHelper helper;
 
@@ -126,10 +126,9 @@ namespace {
   MemoryHelper* the_sunmemory_helper = nullptr;
 } //namespace
 
-MemoryHelper::MemoryHelper()
-  : sunctx(SundialsContext())
+MemoryHelper::MemoryHelper(::sundials::Context* sunctx)
 {
-  helper = CreateMemoryHelper(sunctx);
+  helper = CreateMemoryHelper(*sunctx);
 }
 
 MemoryHelper::~MemoryHelper()
@@ -138,17 +137,16 @@ MemoryHelper::~MemoryHelper()
   free(helper);
 }
 
-void Initialize()
+void MemoryHelper::Initialize(::sundials::Context* sunctx)
 {
-  std::cout << ">>>>>>>>>> Initialize()\n";
   if (initialized) return;
   initialized = true;
 
   BL_ASSERT(the_sunmemory_helper == nullptr);
-  the_sunmemory_helper = new MemoryHelper();
+  the_sunmemory_helper = new MemoryHelper(sunctx);
 }
 
-void Finalize()
+void MemoryHelper::Finalize()
 {
   initialized = false;
   delete the_sunmemory_helper;

--- a/Src/Extern/SUNDIALS/AMReX_Sundials.H
+++ b/Src/Extern/SUNDIALS/AMReX_Sundials.H
@@ -4,5 +4,16 @@
 #include <AMReX_SUNMemory.H>
 #include <AMReX_NVector_MultiFab.H>
 static_assert(std::is_same<amrex::Real,realtype>::value, "amrex::Real must be the same as SUNDIALS realtype");
+#include <sundials/sundials_context.h>
+
+namespace amrex {
+namespace sundials {
+
+void Initialize();
+void Finalize();
+::sundials::Context* The_Sundials_Context();
+
+}//sundials
+}//amrex
 
 #endif

--- a/Src/Extern/SUNDIALS/AMReX_Sundials.H
+++ b/Src/Extern/SUNDIALS/AMReX_Sundials.H
@@ -12,11 +12,7 @@ namespace sundials {
 
 void Initialize(int nthreads);
 void Finalize();
-#ifdef AMREX_USE_OMP
-::sundials::Context* The_Sundials_Context(int i = omp_get_thread_num());
-#else
-::sundials::Context* The_Sundials_Context(int i = 0);
-#endif
+::sundials::Context* The_Sundials_Context(int i = amrex::OpenMP::get_thread_num());
 
 }//sundials
 }//amrex

--- a/Src/Extern/SUNDIALS/AMReX_Sundials.H
+++ b/Src/Extern/SUNDIALS/AMReX_Sundials.H
@@ -10,8 +10,33 @@ static_assert(std::is_same<amrex::Real,realtype>::value, "amrex::Real must be th
 namespace amrex {
 namespace sundials {
 
+/**
+ * \brief Initialize the AMReX-SUNDIALS interface.
+ *
+ * \param[in] nthreads The number of threads that will be used with SUNDIALS.
+ *
+ * This will create the nthreads SUNDIALS context objects that are needed by
+ * the SUNDIALS solver and vector objects. Called by amrex::Initialize.
+ */
+
 void Initialize(int nthreads);
+
+/**
+ * \brief Cleanup everything allocated for the AMReX-SUNDIALS interface.
+ *
+ * Called by amrex::Finalize.
+ */
+
 void Finalize();
+
+/**
+ * \brief Get the i-th SUNDIALS context instance.
+ *
+ * \param[in] i The index of the SUNDIALS context to return.
+ *
+ * A SUNDIALS context should not be used concurrently from different threads.
+ */
+
 ::sundials::Context* The_Sundials_Context(int i = amrex::OpenMP::get_thread_num());
 
 }//sundials

--- a/Src/Extern/SUNDIALS/AMReX_Sundials.H
+++ b/Src/Extern/SUNDIALS/AMReX_Sundials.H
@@ -1,17 +1,22 @@
 #ifndef AMREX_SUNDIALS_H_
 #define AMREX_SUNDIALS_H_
 
-#include <AMReX_SUNMemory.H>
+#include <AMReX.H>
+#include <AMReX_Arena.H>
 #include <AMReX_NVector_MultiFab.H>
 static_assert(std::is_same<amrex::Real,realtype>::value, "amrex::Real must be the same as SUNDIALS realtype");
-#include <sundials/sundials_context.h>
+#include <AMReX_SUNMemory.H>
 
 namespace amrex {
 namespace sundials {
 
-void Initialize();
+void Initialize(int nthreads);
 void Finalize();
-::sundials::Context* The_Sundials_Context();
+#ifdef AMREX_USE_OMP
+::sundials::Context* The_Sundials_Context(int i = omp_get_thread_num());
+#else
+::sundials::Context* The_Sundials_Context(int i = 0);
+#endif
 
 }//sundials
 }//amrex

--- a/Src/Extern/SUNDIALS/AMReX_Sundials.cpp
+++ b/Src/Extern/SUNDIALS/AMReX_Sundials.cpp
@@ -4,8 +4,8 @@ namespace amrex {
 namespace sundials {
 
 namespace {
-  std::vector<bool> initialized;
-  std::vector<::sundials::Context*> the_sundials_context;
+  Vector<int> initialized;
+  Vector<::sundials::Context*> the_sundials_context;
 }
 
 void Initialize(int nthreads)
@@ -15,13 +15,13 @@ void Initialize(int nthreads)
   // Initalize the sundials context
   if (initialized.size() == 0) {
     initialized.resize(nthreads);
-    std::fill(initialized.begin(), initialized.end(), false);
+    std::fill(initialized.begin(), initialized.end(), 0);
     the_sundials_context.resize(nthreads);
     std::fill(the_sundials_context.begin(), the_sundials_context.end(), nullptr);
   }
   for (int i = 0; i < nthreads; i++) {
     if (initialized[i]) continue;
-    initialized[i] = true;
+    initialized[i] = 1;
     BL_ASSERT(the_sundials_context[i] == nullptr);
     the_sundials_context[i] = new ::sundials::Context();
   }
@@ -39,7 +39,7 @@ void Finalize()
 
   // Clean up the sundials contexts
   for (int i = 0; i < initialized.size(); i++) {
-    initialized[i] = false;
+    initialized[i] = 0;
     delete the_sundials_context[i];
     the_sundials_context[i] = nullptr;
   }

--- a/Src/Extern/SUNDIALS/AMReX_Sundials.cpp
+++ b/Src/Extern/SUNDIALS/AMReX_Sundials.cpp
@@ -1,0 +1,36 @@
+#include <AMReX_Sundials.H>
+
+namespace amrex {
+namespace sundials {
+
+namespace {
+  bool initialized = false;
+  ::sundials::Context* the_sundials_context = nullptr;
+}
+
+void Initialize()
+{
+  if (initialized) return;
+  initialized = true;
+
+  BL_ASSERT(the_sundials_context == nullptr);
+  the_sundials_context = new ::sundials::Context();
+  MemoryHelper::Initialize(the_sundials_context);
+}
+
+void Finalize()
+{
+  BL_ASSERT(the_sundials_context != nullptr);
+  MemoryHelper::Finalize();
+  delete the_sundials_context;
+  the_sundials_context = nullptr;
+}
+
+::sundials::Context* The_Sundials_Context()
+{
+  BL_ASSERT(the_sundials_context != nullptr);
+  return the_sundials_context;
+}
+
+}//sundials
+}//amrex

--- a/Src/Extern/SUNDIALS/AMReX_Sundials.cpp
+++ b/Src/Extern/SUNDIALS/AMReX_Sundials.cpp
@@ -4,52 +4,52 @@ namespace amrex {
 namespace sundials {
 
 namespace {
-  Vector<int> initialized;
-  Vector<::sundials::Context*> the_sundials_context;
+    Vector<int> initialized;
+    Vector<::sundials::Context*> the_sundials_context;
 }
 
 void Initialize(int nthreads)
 {
-  amrex::Print() << "Initializing SUNDIALS with " << nthreads << " threads...\n";
+    amrex::Print() << "Initializing SUNDIALS with " << nthreads << " threads...\n";
 
-  // Initalize the sundials context
-  if (initialized.size() == 0) {
-    initialized.resize(nthreads);
-    std::fill(initialized.begin(), initialized.end(), 0);
-    the_sundials_context.resize(nthreads);
-    std::fill(the_sundials_context.begin(), the_sundials_context.end(), nullptr);
-  }
-  for (int i = 0; i < nthreads; i++) {
-    if (initialized[i]) continue;
-    initialized[i] = 1;
-    BL_ASSERT(the_sundials_context[i] == nullptr);
-    the_sundials_context[i] = new ::sundials::Context();
-  }
+    // Initalize the sundials context
+    if (initialized.size() == 0) {
+        initialized.resize(nthreads);
+        std::fill(initialized.begin(), initialized.end(), 0);
+        the_sundials_context.resize(nthreads);
+        std::fill(the_sundials_context.begin(), the_sundials_context.end(), nullptr);
+    }
+    for (int i = 0; i < nthreads; i++) {
+        if (initialized[i]) continue;
+        initialized[i] = 1;
+        BL_ASSERT(the_sundials_context[i] == nullptr);
+        the_sundials_context[i] = new ::sundials::Context();
+    }
 
-  // Initialize the memory helper
-  MemoryHelper::Initialize(nthreads);
+    // Initialize the memory helper
+    MemoryHelper::Initialize(nthreads);
 
-  amrex::Print() << "SUNDIALS initialized.\n";
+    amrex::Print() << "SUNDIALS initialized.\n";
 }
 
 void Finalize()
 {
-  // Cleanup the memory helpers
-  MemoryHelper::Finalize();
+    // Cleanup the memory helpers
+    MemoryHelper::Finalize();
 
-  // Clean up the sundials contexts
-  for (int i = 0; i < initialized.size(); i++) {
-    initialized[i] = 0;
-    delete the_sundials_context[i];
-    the_sundials_context[i] = nullptr;
-  }
+    // Clean up the sundials contexts
+    for (int i = 0; i < initialized.size(); i++) {
+        initialized[i] = 0;
+        delete the_sundials_context[i];
+        the_sundials_context[i] = nullptr;
+    }
 }
 
 ::sundials::Context* The_Sundials_Context(int i)
 {
-  BL_ASSERT(the_sundials_context.size() <= i);
-  BL_ASSERT(the_sundials_context[i] != nullptr);
-  return the_sundials_context[i];
+    BL_ASSERT(the_sundials_context.size() <= i);
+    BL_ASSERT(the_sundials_context[i] != nullptr);
+    return the_sundials_context[i];
 }
 
 }//sundials

--- a/Src/Extern/SUNDIALS/AMReX_Sundials.cpp
+++ b/Src/Extern/SUNDIALS/AMReX_Sundials.cpp
@@ -28,7 +28,7 @@ void Initialize(int nthreads)
 
   // Initialize the memory helper
   MemoryHelper::Initialize(nthreads);
-  
+
   amrex::Print() << "SUNDIALS initialized.\n";
 }
 

--- a/Src/Extern/SUNDIALS/CMakeLists.txt
+++ b/Src/Extern/SUNDIALS/CMakeLists.txt
@@ -5,6 +5,7 @@ target_include_directories( amrex
 target_sources( amrex
    PRIVATE
    AMReX_Sundials.H
+   AMReX_Sundials.cpp
    AMReX_NVector_MultiFab.cpp
    AMReX_NVector_MultiFab.H
    AMReX_SUNMemory.cpp

--- a/Src/Extern/SUNDIALS/CMakeLists.txt
+++ b/Src/Extern/SUNDIALS/CMakeLists.txt
@@ -9,4 +9,5 @@ target_sources( amrex
    AMReX_NVector_MultiFab.H
    AMReX_SUNMemory.cpp
    AMReX_SUNMemory.H
+   AMReX_SUNProfiler.H
    )

--- a/Src/Extern/SUNDIALS/Make.package
+++ b/Src/Extern/SUNDIALS/Make.package
@@ -2,6 +2,7 @@ CEXE_sources += AMReX_SUNMemory.cpp
 CEXE_headers += AMReX_SUNMemory.H
 CEXE_sources += AMReX_NVector_MultiFab.cpp
 CEXE_headers += AMReX_NVector_MultiFab.H
+CEXE_sources += AMReX_Sundials.cpp
 CEXE_headers += AMReX_Sundials.H
 
 VPATH_LOCATIONS += $(AMREX_HOME)/Src/Extern/SUNDIALS


### PR DESCRIPTION
## Summary

Update AMReX to use SUNDIALS 6. We could make this backwards compatible with SUNDIALS 5.7.0/5.8.0 without too much effort (I think),  if that is desired.

## Additional background

SUNDIALS 6 introduces a `SUNContext` class (needed by all/most other SUNDIALS classes) that should be associated with only one SUNDIALS simulation at a time. Thus, when using multiple threads, multiple `SUNContext` objects are needed. This is why we create one (and one `SUNMemoryHelper`) for each OpenMP thread.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
