### PR TITLE
Allow CUDA compilation on Perlmutter if only PrgEnv-nvidia is loaded

### DIFF
--- a/Tools/GNUMake/sites/Make.nersc
+++ b/Tools/GNUMake/sites/Make.nersc
@@ -59,6 +59,9 @@ ifeq ($(which_computer),$(filter $(which_computer),perlmutter))
     else ifneq ($(CUDA_PATH),)
         SYSTEM_CUDA_PATH := $(CUDA_PATH)
         COMPILE_CUDA_PATH := $(CUDA_PATH)
+    else ifneq ($(NVIDIA_PATH),)
+        SYSTEM_CUDA_PATH := $(NVIDIA_PATH)/cuda
+        COMPILE_CUDA_PATH := $(NVIDIA_PATH)/cuda
     else
         $(error No CUDA_ROOT nor CUDA_HOME nor CUDA_PATH found. Please load a cuda module.)
     endif


### PR DESCRIPTION
## Summary

In this scenario, there is not a CUDA module loaded by default; nvcc is provided as part of the NVIDIA HPC SDK. In the Cray PE the environment variable defined pointing to the top level of the HPC SDK is `NVIDIA_PATH` so we can use this to indicate to the make system that we should have CUDA support.

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
