### PR TITLE
Fix bug in Parser

### DIFF
--- a/Src/Base/Parser/AMReX_IParser_Y.cpp
+++ b/Src/Base/Parser/AMReX_IParser_Y.cpp
@@ -100,7 +100,7 @@ iparser_newf3 (enum iparser_f3_t ftype, struct iparser_node* n1, struct iparser_
 struct iparser_node*
 iparser_newassign (struct iparser_symbol* sym, struct iparser_node* v)
 {
-    auto r = (struct iparser_assign*) std::malloc(sizeof(struct iparser_symbol));
+    auto r = (struct iparser_assign*) std::malloc(sizeof(struct iparser_assign));
     r->type = IPARSER_ASSIGN;
     r->s = sym;
     r->v = v;

--- a/Src/Base/Parser/AMReX_Parser_Y.cpp
+++ b/Src/Base/Parser/AMReX_Parser_Y.cpp
@@ -100,7 +100,7 @@ parser_newf3 (enum parser_f3_t ftype, struct parser_node* n1, struct parser_node
 struct parser_node*
 parser_newassign (struct parser_symbol* sym, struct parser_node* v)
 {
-    auto r = (struct parser_assign*) std::malloc(sizeof(struct parser_symbol));
+    auto r = (struct parser_assign*) std::malloc(sizeof(struct parser_assign));
     r->type = PARSER_ASSIGN;
     r->s = sym;
     r->v = v;


### PR DESCRIPTION
The size of malloc is wrong in parser_newassign.

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
