### PR TITLE
Return a zero-size vector in ParallelDescriptor::Gather.

### DIFF
--- a/Src/Base/AMReX_ParallelDescriptor.H
+++ b/Src/Base/AMReX_ParallelDescriptor.H
@@ -933,7 +933,12 @@ ParallelDescriptor::Gather (const T& t, int root)
                                root,
                                Communicator()) );
     BL_COMM_PROFILE(BLProfiler::GatherTi, sizeof(T), root, BLProfiler::NoTag());
-    return resl;
+
+    if ( root == MyProc() ) {
+        return resl;
+    } else {
+        return std::vector<T>;
+    }
 }
 
 template <class T>

--- a/Src/Base/AMReX_ParallelDescriptor.H
+++ b/Src/Base/AMReX_ParallelDescriptor.H
@@ -922,23 +922,19 @@ ParallelDescriptor::Gather (const T& t, int root)
     BL_PROFILE_T_S("ParallelDescriptor::Gather(Ti)", T);
     BL_COMM_PROFILE(BLProfiler::GatherTi, BLProfiler::BeforeCall(), root, BLProfiler::NoTag());
 
-    std::vector<T> resl(1);
+    std::vector<T> resl;
     if ( root == MyProc() ) resl.resize(NProcs());
     BL_MPI_REQUIRE( MPI_Gather(const_cast<T*>(&t),
                                1,
                                Mpi_typemap<T>::type(),
-                               &resl[0],
+                               resl.data(),
                                1,
                                Mpi_typemap<T>::type(),
                                root,
                                Communicator()) );
     BL_COMM_PROFILE(BLProfiler::GatherTi, sizeof(T), root, BLProfiler::NoTag());
 
-    if ( root == MyProc() ) {
-        return resl;
-    } else {
-        return std::vector<T>(0);
-    }
+    return resl;
 }
 
 template <class T>

--- a/Src/Base/AMReX_ParallelDescriptor.H
+++ b/Src/Base/AMReX_ParallelDescriptor.H
@@ -933,7 +933,6 @@ ParallelDescriptor::Gather (const T& t, int root)
                                root,
                                Communicator()) );
     BL_COMM_PROFILE(BLProfiler::GatherTi, sizeof(T), root, BLProfiler::NoTag());
-
     return resl;
 }
 

--- a/Src/Base/AMReX_ParallelDescriptor.H
+++ b/Src/Base/AMReX_ParallelDescriptor.H
@@ -937,7 +937,7 @@ ParallelDescriptor::Gather (const T& t, int root)
     if ( root == MyProc() ) {
         return resl;
     } else {
-        return std::vector<T>;
+        return std::vector<T>(0);
     }
 }
 


### PR DESCRIPTION
## Summary

The Gather implementation that returns a vector currently returns an un-initialized, 1-element vector to the non-root ranks. This seems unintuitive as a user and requires very careful consideration of the returned vector on non-root ranks.

This PR changes the non-root return to a zero-size vector instead, which seems safer and more intuitive than a one-element vector with un-initialized data that, for example, may be accessed in a range-loop over the vector. (Who would do such a thing? ... cough, cough... 😃). 

## Additional background

I just chose this style for simplicity and readability. Another option is set `std::vector<T> resl(0)` initially, and use `.front()` in the Gather call, but `.front()` is undefined if `size() == 0`, which seems less clear and potentially corner-case bug-inducing, so I opted for this.

The best implementation would probably be to return something with bounds-checking as well, such as an `amrex::Vector`. I assume `std::vector<T> a = amrex::Vector<T> b` should work everywhere and so such a change wouldn't break anything. Any thoughts?

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
