### PR TITLE
Add option not to remove particles with negative ids when calling Redistribute.

### DIFF
--- a/Src/Particle/AMReX_ParticleContainerI.H
+++ b/Src/Particle/AMReX_ParticleContainerI.H
@@ -1317,7 +1317,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>
     Gpu::Device::synchronize();
     AMREX_ASSERT(numParticlesOutOfRange(*this, lev_min, lev_max, nGrow) == 0);
 #else
-    amrex::ignore_unused(lev_min,lev_max,nGrow,local);
+    amrex::ignore_unused(lev_min,lev_max,nGrow,local,remove_negative);
 #endif
 }
 

--- a/Src/Particle/AMReX_ParticleContainerI.H
+++ b/Src/Particle/AMReX_ParticleContainerI.H
@@ -1435,10 +1435,13 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>
               while (pindex <= last) {
                   ParticleType& p = aos[pindex];
 
-                  bool skip_invalid = false;
-                  if ((remove_negative == true) && (p.id() < 0))
+                  if ((remove_negative == false) && (p.id() < 0)) {
+                      ++pindex;
+                      continue;
+                  }
+
+                  if (p.id() < 0)
                   {
-                      skip_invalid = true;
                       aos[pindex] = aos[last];
                       for (int comp = 0; comp < NumRealComps(); comp++)
                           soa.GetRealData(comp)[pindex] = soa.GetRealData(comp)[last];
@@ -1453,7 +1456,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>
 
                   particlePostLocate(p, pld, lev);
 
-                  if ((!skip_invalid) && (p.id() < 0))
+                  if (p.id() < 0)
                   {
                       aos[pindex] = aos[last];
                       for (int comp = 0; comp < NumRealComps(); comp++)
@@ -1507,7 +1510,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>
                       p.id() = -p.id(); // Invalidate the particle
                   }
 
-                  if ((!skip_invalid) && (p.id() < 0))
+                  if (p.id() < 0)
                   {
                       aos[pindex] = aos[last];
                       for (int comp = 0; comp < NumRealComps(); comp++)

--- a/Src/Particle/AMReX_ParticleContainerI.H
+++ b/Src/Particle/AMReX_ParticleContainerI.H
@@ -1069,14 +1069,14 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>
 #ifdef AMREX_USE_GPU
     if ( Gpu::inLaunchRegion() )
     {
-        RedistributeGPU(lev_min, lev_max, nGrow, local);
+        RedistributeGPU(lev_min, lev_max, nGrow, local, remove_invalid);
     }
     else
     {
-        RedistributeCPU(lev_min, lev_max, nGrow, local);
+        RedistributeCPU(lev_min, lev_max, nGrow, local, remove_invalid);
     }
 #else
-    RedistributeCPU(lev_min, lev_max, nGrow, local);
+    RedistributeCPU(lev_min, lev_max, nGrow, local, remove_invalid);
 #endif
 }
 

--- a/Src/Particle/AMReX_ParticleContainerI.H
+++ b/Src/Particle/AMReX_ParticleContainerI.H
@@ -1064,19 +1064,19 @@ template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt,
           template<class> class Allocator>
 void
 ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>
-::Redistribute (int lev_min, int lev_max, int nGrow, int local, bool remove_invalid)
+::Redistribute (int lev_min, int lev_max, int nGrow, int local, bool remove_negative)
 {
 #ifdef AMREX_USE_GPU
     if ( Gpu::inLaunchRegion() )
     {
-        RedistributeGPU(lev_min, lev_max, nGrow, local, remove_invalid);
+        RedistributeGPU(lev_min, lev_max, nGrow, local, remove_negative);
     }
     else
     {
-        RedistributeCPU(lev_min, lev_max, nGrow, local, remove_invalid);
+        RedistributeCPU(lev_min, lev_max, nGrow, local, remove_negative);
     }
 #else
-    RedistributeCPU(lev_min, lev_max, nGrow, local, remove_invalid);
+    RedistributeCPU(lev_min, lev_max, nGrow, local, remove_negative);
 #endif
 }
 
@@ -1178,7 +1178,7 @@ template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt,
           template<class> class Allocator>
 void
 ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>
-::RedistributeGPU (int lev_min, int lev_max, int nGrow, int local, bool remove_invalid)
+::RedistributeGPU (int lev_min, int lev_max, int nGrow, int local, bool remove_negative)
 {
 #ifdef AMREX_USE_GPU
 
@@ -1228,7 +1228,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>
 
             int num_stay = partitionParticlesByDest(src_tile, assign_grid, BufferMap(),
                                                     geom, lev, gid, tid,
-                                                    lev_min, lev_max, nGrow, remove_invalid);
+                                                    lev_min, lev_max, nGrow, remove_negative);
 
             int num_move = np - num_stay;
             new_sizes[lev][gid] = num_stay;
@@ -1328,7 +1328,7 @@ template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt,
           template<class> class Allocator>
 void
 ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>
-::RedistributeCPU (int lev_min, int lev_max, int nGrow, int local, bool remove_invalid)
+::RedistributeCPU (int lev_min, int lev_max, int nGrow, int local, bool remove_negative)
 {
   BL_PROFILE("ParticleContainer::RedistributeCPU()");
 
@@ -1436,7 +1436,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>
                   ParticleType& p = aos[pindex];
 
                   bool skip_invalid = false;
-                  if ((remove_invalid == true) && (p.id() < 0))
+                  if ((remove_negative == true) && (p.id() < 0))
                   {
                       skip_invalid = true;
                       aos[pindex] = aos[last];

--- a/Src/Particle/AMReX_ParticleContainerI.H
+++ b/Src/Particle/AMReX_ParticleContainerI.H
@@ -1064,7 +1064,7 @@ template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt,
           template<class> class Allocator>
 void
 ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>
-::Redistribute (int lev_min, int lev_max, int nGrow, int local)
+::Redistribute (int lev_min, int lev_max, int nGrow, int local, bool remove_invalid)
 {
 #ifdef AMREX_USE_GPU
     if ( Gpu::inLaunchRegion() )
@@ -1178,7 +1178,7 @@ template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt,
           template<class> class Allocator>
 void
 ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>
-::RedistributeGPU (int lev_min, int lev_max, int nGrow, int local)
+::RedistributeGPU (int lev_min, int lev_max, int nGrow, int local, bool remove_invalid)
 {
 #ifdef AMREX_USE_GPU
 
@@ -1228,7 +1228,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>
 
             int num_stay = partitionParticlesByDest(src_tile, assign_grid, BufferMap(),
                                                     geom, lev, gid, tid,
-                                                    lev_min, lev_max, nGrow);
+                                                    lev_min, lev_max, nGrow, remove_invalid);
 
             int num_move = np - num_stay;
             new_sizes[lev][gid] = num_stay;
@@ -1328,7 +1328,7 @@ template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt,
           template<class> class Allocator>
 void
 ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>
-::RedistributeCPU (int lev_min, int lev_max, int nGrow, int local)
+::RedistributeCPU (int lev_min, int lev_max, int nGrow, int local, bool remove_invalid)
 {
   BL_PROFILE("ParticleContainer::RedistributeCPU()");
 
@@ -1435,8 +1435,10 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>
               while (pindex <= last) {
                   ParticleType& p = aos[pindex];
 
-                  if (p.id() < 0)
+                  bool skip_invalid = false;
+                  if ((remove_invalid == true) && (p.id() < 0))
                   {
+                      skip_invalid = true;
                       aos[pindex] = aos[last];
                       for (int comp = 0; comp < NumRealComps(); comp++)
                           soa.GetRealData(comp)[pindex] = soa.GetRealData(comp)[last];
@@ -1451,7 +1453,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>
 
                   particlePostLocate(p, pld, lev);
 
-                  if (p.id() < 0)
+                  if ((!skip_invalid) && (p.id() < 0))
                   {
                       aos[pindex] = aos[last];
                       for (int comp = 0; comp < NumRealComps(); comp++)
@@ -1505,7 +1507,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>
                       p.id() = -p.id(); // Invalidate the particle
                   }
 
-                  if (p.id() < 0)
+                  if ((!skip_invalid) && (p.id() < 0))
                   {
                       aos[pindex] = aos[last];
                       for (int comp = 0; comp < NumRealComps(); comp++)

--- a/Src/Particle/AMReX_ParticleUtil.H
+++ b/Src/Particle/AMReX_ParticleUtil.H
@@ -463,7 +463,7 @@ template <typename PTile, typename PLocator>
 int
 partitionParticlesByDest (PTile& ptile, const PLocator& ploc, const ParticleBufferMap& pmap,
                           const Geometry& geom, int lev, int gid, int /*tid*/,
-                          int lev_min, int lev_max, int nGrow)
+                          int lev_min, int lev_max, int nGrow, bool remove_invalid)
 {
     const auto plo    = geom.ProbLoArray();
     const auto phi    = geom.ProbHiArray();
@@ -527,6 +527,10 @@ partitionParticlesByDest (PTile& ptile, const PLocator& ploc, const ParticleBuff
                       assigned_grid = amrex::get<0>(tup);
                       assigned_lev  = amrex::get<1>(tup);
                     }
+                }
+
+                if ((remove_invalid == false) && (p.id() < 0)) {
+                    return true;
                 }
 
                 return ((assigned_grid == gid) && (assigned_lev == lev) && (getPID(lev, gid) == pid));

--- a/Src/Particle/AMReX_ParticleUtil.H
+++ b/Src/Particle/AMReX_ParticleUtil.H
@@ -463,7 +463,7 @@ template <typename PTile, typename PLocator>
 int
 partitionParticlesByDest (PTile& ptile, const PLocator& ploc, const ParticleBufferMap& pmap,
                           const Geometry& geom, int lev, int gid, int /*tid*/,
-                          int lev_min, int lev_max, int nGrow, bool remove_invalid)
+                          int lev_min, int lev_max, int nGrow, bool remove_negative)
 {
     const auto plo    = geom.ProbLoArray();
     const auto phi    = geom.ProbHiArray();
@@ -529,7 +529,7 @@ partitionParticlesByDest (PTile& ptile, const PLocator& ploc, const ParticleBuff
                     }
                 }
 
-                if ((remove_invalid == false) && (p.id() < 0)) {
+                if ((remove_negative == false) && (p.id() < 0)) {
                     return true;
                 }
 

--- a/Src/Particle/AMReX_Particles.H
+++ b/Src/Particle/AMReX_Particles.H
@@ -475,7 +475,8 @@ public:
     *              a particle can have moved since the last Redistribute() call. Knowing this number
     *              allows an optimized MPI communication pattern to be used.
     */
-    void Redistribute (int lev_min = 0, int lev_max = -1, int nGrow = 0, int local=0);
+    void Redistribute (int lev_min = 0, int lev_max = -1, int nGrow = 0, int local=0,
+                       bool remove_invalid=true);
 
     /**
      * \brief Sort the particles on each tile by cell, using Fortran ordering.
@@ -1184,9 +1185,11 @@ public:
       return doUnlink;
     }
 
-    void RedistributeCPU (int lev_min = 0, int lev_max = -1, int nGrow = 0, int local=0);
+    void RedistributeCPU (int lev_min = 0, int lev_max = -1, int nGrow = 0, int local=0,
+                          bool remove_invalid=true);
 
-    void RedistributeGPU (int lev_min = 0, int lev_max = -1, int nGrow = 0, int local=0);
+    void RedistributeGPU (int lev_min = 0, int lev_max = -1, int nGrow = 0, int local=0,
+                          bool remove_invalid=true);
 
     Long superParticleSize() const { return superparticle_size; }
 

--- a/Src/Particle/AMReX_Particles.H
+++ b/Src/Particle/AMReX_Particles.H
@@ -476,7 +476,7 @@ public:
     *              allows an optimized MPI communication pattern to be used.
     */
     void Redistribute (int lev_min = 0, int lev_max = -1, int nGrow = 0, int local=0,
-                       bool remove_invalid=true);
+                       bool remove_negative=true);
 
     /**
      * \brief Sort the particles on each tile by cell, using Fortran ordering.
@@ -1186,10 +1186,10 @@ public:
     }
 
     void RedistributeCPU (int lev_min = 0, int lev_max = -1, int nGrow = 0, int local=0,
-                          bool remove_invalid=true);
+                          bool remove_negative=true);
 
     void RedistributeGPU (int lev_min = 0, int lev_max = -1, int nGrow = 0, int local=0,
-                          bool remove_invalid=true);
+                          bool remove_negative=true);
 
     Long superParticleSize() const { return superparticle_size; }
 


### PR DESCRIPTION
This is useful for WarpX when interacting particles with EB walls. The default behavior of Redistribute is not changed by this PR.

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
