### PR TITLE
Support implicit function class defined on host when using device memory explicitly. 

### DIFF
--- a/Src/EB/AMReX_EB2_GeometryShop.H
+++ b/Src/EB/AMReX_EB2_GeometryShop.H
@@ -331,12 +331,32 @@ public:
     void fillFab (BaseFab<Real>& levelset, const Geometry& geom, RunOn,
                   Box const& bounding_box) const noexcept
     {
+#ifdef AMREX_USE_GPU
+        if (!levelset.arena()->isHostAccessible()) {
+            const Box& bx = levelset.box();
+            BaseFab<Real> h_levelset(bx, levelset.nComp(), The_Pinned_Arena());
+            fillFab_Cpu(h_levelset, geom, bounding_box);
+            Gpu::htod_memcpy_async(levelset.dataPtr(), h_levelset.dataPtr(),
+                                   levelset.nBytes(bx, levelset.nComp()));
+            Gpu::streamSynchronize();
+        }
+        else
+#endif
+        {
+            fillFab_Cpu(levelset, geom, bounding_box);
+        }
+    }
+
+    void fillFab_Cpu(BaseFab<Real>& levelset, const Geometry& geom,
+                     Box const& bounding_box) const noexcept
+    {
         const auto problo = geom.ProbLoArray();
         const auto dx = geom.CellSizeArray();
         const Box& bx = levelset.box();
-        const auto& a = levelset.array();
         const auto blo = amrex::lbound(bounding_box);
         const auto bhi = amrex::ubound(bounding_box);
+
+        const auto& a = levelset.array();
         amrex::LoopOnCpu(bx, [&] (int i, int j, int k) noexcept
         {
             a(i,j,k) = m_f(RealArray{AMREX_D_DECL(problo[0]+amrex::Clamp(i,blo.x,bhi.x)*dx[0],
@@ -344,6 +364,7 @@ public:
                                                   problo[2]+amrex::Clamp(k,blo.z,bhi.z)*dx[2])});
         });
     }
+
 
     template <class U=F, typename std::enable_if<IsGPUable<U>::value>::type* FOO = nullptr >
     void getIntercept (Array<Array4<Real>,AMREX_SPACEDIM> const& inter_arr,
@@ -387,34 +408,67 @@ public:
                        Geometry const& geom, RunOn,
                        Box const& bounding_box) const noexcept
     {
+        for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+            Array4<Real> const& inter = inter_arr[idim];
+            Array4<Type_t const> const& type = type_arr[idim];
+            // When GShop is not GPUable, the intercept is either in managed memory or
+            // in device memory and needs to be copied to host and setup there.
+#ifdef AMREX_USE_GPU
+            if (!The_Arena()->isHostAccessible()) {
+                const Box bx{inter};
+                BaseFab<Real>  h_inter_fab(bx, 1, The_Pinned_Arena());
+                BaseFab<Type_t> h_type_fab(bx, 1, The_Pinned_Arena());
+                Gpu::dtoh_memcpy_async(h_type_fab.dataPtr(), type.dataPtr(),
+                                       h_type_fab.nBytes(bx, 1));
+                Gpu::streamSynchronize();
+                const auto& h_inter = h_inter_fab.array();
+                const auto& h_type  = h_type_fab.const_array();
+                getIntercept_Cpu(h_inter, h_type, geom, bounding_box, idim);
+                Gpu::htod_memcpy_async(inter.dataPtr(), h_inter.dataPtr(),
+                                       h_inter_fab.nBytes(bx, 1));
+                Gpu::streamSynchronize();
+            }
+            else
+#endif
+            {
+                getIntercept_Cpu(inter, type, geom, bounding_box, idim);
+            }
+
+        }
+    }
+
+    void getIntercept_Cpu(Array4<Real> const& inter,
+                          Array4<Type_t const> const& type,
+                          Geometry const& geom,
+                          Box const& bounding_box,
+                          const int idim) const noexcept
+    {
         auto const& dx = geom.CellSizeArray();
         auto const& problo = geom.ProbLoArray();
         const auto blo = amrex::lbound(bounding_box);
         const auto bhi = amrex::ubound(bounding_box);
-        for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-            Array4<Real> const& inter = inter_arr[idim];
-            Array4<Type_t const> const& type = type_arr[idim];
-            const Box bx{inter};
-            amrex::LoopOnCpu(bx, [&] (int i, int j, int k) noexcept
-            {
-                if (type(i,j,k) == Type::irregular) {
-                    IntVect ivlo(AMREX_D_DECL(i,j,k));
-                    IntVect ivhi(AMREX_D_DECL(i,j,k));
-                    ivhi[idim] += 1;
-                    inter(i,j,k) = BrentRootFinder
-                        ({AMREX_D_DECL(problo[0]+amrex::Clamp(ivlo[0],blo.x,bhi.x)*dx[0],
-                                       problo[1]+amrex::Clamp(ivlo[1],blo.y,bhi.y)*dx[1],
-                                       problo[2]+amrex::Clamp(ivlo[2],blo.z,bhi.z)*dx[2])},
-                         {AMREX_D_DECL(problo[0]+amrex::Clamp(ivhi[0],blo.x,bhi.x)*dx[0],
-                                       problo[1]+amrex::Clamp(ivhi[1],blo.y,bhi.y)*dx[1],
-                                       problo[2]+amrex::Clamp(ivhi[2],blo.z,bhi.z)*dx[2])},
-                          idim, m_f);
-                } else {
-                    inter(i,j,k) = std::numeric_limits<Real>::quiet_NaN();
-                }
-            });
-        }
+        const Box bx{inter};
+        amrex::LoopOnCpu(bx, [&] (int i, int j, int k) noexcept
+        {
+            if (type(i,j,k) == Type::irregular) {
+                IntVect ivlo(AMREX_D_DECL(i,j,k));
+                IntVect ivhi(AMREX_D_DECL(i,j,k));
+                ivhi[idim] += 1;
+                inter(i,j,k) = BrentRootFinder
+                    ({AMREX_D_DECL(problo[0]+amrex::Clamp(ivlo[0],blo.x,bhi.x)*dx[0],
+                                   problo[1]+amrex::Clamp(ivlo[1],blo.y,bhi.y)*dx[1],
+                                   problo[2]+amrex::Clamp(ivlo[2],blo.z,bhi.z)*dx[2])},
+                     {AMREX_D_DECL(problo[0]+amrex::Clamp(ivhi[0],blo.x,bhi.x)*dx[0],
+                                   problo[1]+amrex::Clamp(ivhi[1],blo.y,bhi.y)*dx[1],
+                                   problo[2]+amrex::Clamp(ivhi[2],blo.z,bhi.z)*dx[2])},
+                     idim, m_f);
+            } else {
+                inter(i,j,k) = std::numeric_limits<Real>::quiet_NaN();
+            }
+        });
     }
+
+
 
     void updateIntercept (Array<Array4<Real>,AMREX_SPACEDIM> const& inter_arr,
                           Array<Array4<Type_t const>,AMREX_SPACEDIM> const& type_arr,


### PR DESCRIPTION
## Summary 
AMReX needs to use managed memory if the user-defined implicit function (IF) class's member functions are only callable by the host. This PR allows users to use IF classes defined on the host with device memory.

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
