### PR TITLE
HIP: Add -munsafe-fp-atomics to GNU Make

### DIFF
--- a/Tools/GNUMake/comps/hip.mak
+++ b/Tools/GNUMake/comps/hip.mak
@@ -74,7 +74,7 @@ ifeq ($(HIP_COMPILER),clang)
 
   else  # DEBUG=FALSE flags
 
-    CXXFLAGS += -g -O3
+    CXXFLAGS += -g -O3 -munsafe-fp-atomics
     CFLAGS   += -g -O3
     FFLAGS   += -g -O3
     F90FLAGS += -g -O3


### PR DESCRIPTION
Otherwise atomicAdd is much slower.  Note this is not done for CMake yet.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
