### PR TITLE
remove erroneous BL_ASSERT in sundials initialization

### DIFF
--- a/Src/Extern/SUNDIALS/AMReX_SUNMemory.cpp
+++ b/Src/Extern/SUNDIALS/AMReX_SUNMemory.cpp
@@ -205,7 +205,6 @@ void MemoryHelper::Finalize()
 
 MemoryHelper* The_SUNMemory_Helper(int i)
 {
-    BL_ASSERT(the_sunmemory_helper.size() <= i);
     BL_ASSERT(the_sunmemory_helper[i] != nullptr);
     return the_sunmemory_helper[i];
 }

--- a/Src/Extern/SUNDIALS/AMReX_Sundials.cpp
+++ b/Src/Extern/SUNDIALS/AMReX_Sundials.cpp
@@ -47,7 +47,6 @@ void Finalize()
 
 ::sundials::Context* The_Sundials_Context(int i)
 {
-    BL_ASSERT(the_sundials_context.size() <= i);
     BL_ASSERT(the_sundials_context[i] != nullptr);
     return the_sundials_context[i];
 }


### PR DESCRIPTION
## Summary

Fixes a bug from #2551. CC @jrood-nrel. 

## Additional background

The BL_ASSERT logic should have been inverted. It was a redundant assert anyways, since amrex::Vector ended up being used. 

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
