### PR TITLE
Convert switch statement to if statement

### DIFF
--- a/Src/Base/AMReX_ParallelDescriptor.cpp
+++ b/Src/Base/AMReX_ParallelDescriptor.cpp
@@ -1524,20 +1524,17 @@ EndTeams ()
 std::string
 mpi_level_to_string (int mtlev)
 {
-    switch (mtlev) {
 #ifdef AMREX_USE_MPI
-        case MPI_THREAD_SINGLE:
+    if (mtlev == MPI_THREAD_SINGLE)
             return std::string("MPI_THREAD_SINGLE");
-        case MPI_THREAD_FUNNELED:
+    if (mtlev == MPI_THREAD_FUNNELED)
             return std::string("MPI_THREAD_FUNNELED");
-        case MPI_THREAD_SERIALIZED:
+    if (mtlev == MPI_THREAD_SERIALIZED)
             return std::string("MPI_THREAD_SERIALIZED");
-        case MPI_THREAD_MULTIPLE:
+    if (mtlev == MPI_THREAD_MULTIPLE)
             return std::string("MPI_THREAD_MULTIPLE");
 #endif
-        default:
-            return std::string("UNKNOWN");
-    }
+    return std::string("UNKNOWN");
 }
 
 #ifdef BL_USE_MPI

--- a/Src/Base/AMReX_ParallelDescriptor.cpp
+++ b/Src/Base/AMReX_ParallelDescriptor.cpp
@@ -1524,15 +1524,16 @@ EndTeams ()
 std::string
 mpi_level_to_string (int mtlev)
 {
+    amrex::ignore_unused(mtlev);
 #ifdef AMREX_USE_MPI
     if (mtlev == MPI_THREAD_SINGLE)
-            return std::string("MPI_THREAD_SINGLE");
+        return std::string("MPI_THREAD_SINGLE");
     if (mtlev == MPI_THREAD_FUNNELED)
-            return std::string("MPI_THREAD_FUNNELED");
+        return std::string("MPI_THREAD_FUNNELED");
     if (mtlev == MPI_THREAD_SERIALIZED)
-            return std::string("MPI_THREAD_SERIALIZED");
+        return std::string("MPI_THREAD_SERIALIZED");
     if (mtlev == MPI_THREAD_MULTIPLE)
-            return std::string("MPI_THREAD_MULTIPLE");
+        return std::string("MPI_THREAD_MULTIPLE");
 #endif
     return std::string("UNKNOWN");
 }


### PR DESCRIPTION
The MPI standard does not guarantee that the thread level constants are compile-time constants; they might only be link-time constants which are not allowed in switch statements.

## Summary

## Additional background

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate

Closes https://github.com/AMReX-Codes/amrex/issues/2569