### PR TITLE
FaceLinear interpolater: Option to use coarse data

### DIFF
--- a/Src/AmrCore/AMReX_FillPatchUtil_I.H
+++ b/Src/AmrCore/AMReX_FillPatchUtil_I.H
@@ -381,15 +381,19 @@ namespace {
         {
             const InterpolaterBoxCoarsener& coarsener = mapper->BoxCoarsener(ratio);
 
-            // Test for Face-centered data
-            if ( AMREX_D_TERM(  mf.ixType().nodeCentered(0),
-                              + mf.ixType().nodeCentered(1),
-                              + mf.ixType().nodeCentered(2) ) == 1 )
-            {
-                if ( !dynamic_cast<Interpolater*>(mapper) ){
-                    amrex::Abort("This interpolater has not yet implemented a version for face-based data");
-                }
+            bool is_face_data = AMREX_D_TERM(  mf.ixType().nodeCentered(0),
+                                             + mf.ixType().nodeCentered(1),
+                                             + mf.ixType().nodeCentered(2) ) == 1;
+            bool is_face_linear_fine_interp;
+            FaceLinear* pinterp = dynamic_cast<FaceLinear*>(mapper);
+            if (pinterp) {
+                is_face_linear_fine_interp = pinterp->useFineData();
+            } else {
+                is_face_linear_fine_interp = false;
+            }
 
+            if (is_face_data && is_face_linear_fine_interp)
+            {
                 // Convert to cell-centered MF meta-data for FPInfo.
                 MF mf_cc_dummy( amrex::convert(mf.boxArray(), IntVect::TheZeroVector()),
                                 mf.DistributionMap(), ncomp, nghost, MFInfo().SetAlloc(false) );

--- a/Src/AmrCore/AMReX_Interp_1D_C.H
+++ b/Src/AmrCore/AMReX_Interp_1D_C.H
@@ -92,20 +92,6 @@ facediv_int (int /*ci*/, int /*cj*/, int /*ck*/, int /*nf*/,
     amrex::Abort("No 1D version of FaceDiv exists.\n");
 }
 
-template<typename T>
-AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE void
-face_linear_interp_x (int i, int /*j*/, int /*k*/, int n, Array4<T> const& fine,
-                      Array4<T const> const& crse, IntVect const& ratio) noexcept
-{
-    const int ii = amrex::coarsen(i,ratio[0]);
-    if (i-ii*ratio[0] == 0) {
-        fine(i,0,0,n) = crse(ii,0,0,n);
-    } else {
-        Real const w = static_cast<Real>(i-ii*ratio[0]) * (Real(1.)/ratio[0]);
-        fine(i,0,0,n) = (Real(1.)-w) * crse(ii,0,0,n) + w * crse(ii+1,0,0,n);
-    }
-}
-
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 void ccquartic_interp (int i, int /*j*/, int /*k*/, int n,
                        Array4<Real const> const& crse,

--- a/Src/AmrCore/AMReX_Interp_C.H
+++ b/Src/AmrCore/AMReX_Interp_C.H
@@ -154,5 +154,69 @@ face_linear_interp_z (int i, int j, int k, int n, amrex::Array4<amrex::Real> con
     }
 }
 
+template<typename T>
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE void
+face_linear_coarse_interp_x (int i, int j, int k, int n, Array4<T> const& fine,
+                             Array4<T const> const& crse, IntVect const& ratio) noexcept
+{
+    const int ii = amrex::coarsen(i,ratio[0]);
+#if (AMREX_SPACEDIM >= 2)
+    const int jj = amrex::coarsen(j,ratio[1]);
+#else
+    const int jj = j;
+#endif
+#if (AMREX_SPACEDIM == 3)
+    const int kk = amrex::coarsen(k,ratio[2]);
+#else
+    const int kk = k;
+#endif
+    if (i-ii*ratio[0] == 0) {
+        fine(i,j,k,n) = crse(ii,jj,kk,n);
+    } else {
+        Real const w = static_cast<Real>(i-ii*ratio[0]) * (Real(1.)/ratio[0]);
+        fine(i,j,k,n) = (Real(1.)-w) * crse(ii,jj,kk,n) + w * crse(ii+1,jj,kk,n);
+    }
+}
+
+#if (AMREX_SPACEDIM >= 2)
+template<typename T>
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE void
+face_linear_coarse_interp_y (int i, int j, int k, int n, Array4<T> const& fine,
+                             Array4<T const> const& crse, IntVect const& ratio) noexcept
+{
+    const int ii = amrex::coarsen(i,ratio[0]);
+    const int jj = amrex::coarsen(j,ratio[1]);
+#if (AMREX_SPACEDIM == 3)
+    const int kk = amrex::coarsen(k,ratio[2]);
+#else
+    const int kk = k;
+#endif
+    if (j-jj*ratio[1] == 0) {
+        fine(i,j,k,n) = crse(ii,jj,kk,n);
+    } else {
+        Real const w = static_cast<Real>(j-jj*ratio[1]) * (Real(1.)/ratio[1]);
+        fine(i,j,k,n) = (Real(1.)-w) * crse(ii,jj,kk,n) + w * crse(ii,jj+1,kk,n);
+    }
+}
+#endif
+
+#if (AMREX_SPACEDIM == 3)
+template<typename T>
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE void
+face_linear_coarse_interp_z (int i, int j, int k, int n, Array4<T> const& fine,
+                             Array4<T const> const& crse, IntVect const& ratio) noexcept
+{
+    const int ii = amrex::coarsen(i,ratio[0]);
+    const int jj = amrex::coarsen(j,ratio[1]);
+    const int kk = amrex::coarsen(k,ratio[2]);
+    if (k-kk*ratio[2] == 0) {
+        fine(i,j,k,n) = crse(ii,jj,kk,n);
+    } else {
+        Real const w = static_cast<Real>(k-kk*ratio[2]) * (Real(1.)/ratio[2]);
+        fine(i,j,k,n) = (Real(1.)-w) * crse(ii,jj,kk,n) + w * crse(ii,jj,kk+1,n);
+    }
+}
+#endif
+
 }
 #endif

--- a/Src/AmrCore/AMReX_Interpolater.H
+++ b/Src/AmrCore/AMReX_Interpolater.H
@@ -728,6 +728,9 @@ class FaceLinear
 {
 public:
 
+    explicit FaceLinear (bool use_coarse_data = false)
+        : m_use_coarse_data(use_coarse_data) {}
+
     /**
     * \brief The destructor.
     */
@@ -841,7 +844,10 @@ public:
                              const int         /*actual_state*/,
                              const RunOn       runon) override;
 
+    bool useFineData () const { return !m_use_coarse_data; }
 
+private:
+    bool m_use_coarse_data = false; // use coarse data at coarse/fine interface?
 };
 
 
@@ -850,6 +856,7 @@ extern AMREX_EXPORT PCInterp                  pc_interp;
 extern AMREX_EXPORT NodeBilinear              node_bilinear_interp;
 extern AMREX_EXPORT FaceDivFree               face_divfree_interp;
 extern AMREX_EXPORT FaceLinear                face_linear_interp;
+extern AMREX_EXPORT FaceLinear                face_linear_coarse_interp;
 extern AMREX_EXPORT CellConservativeLinear    lincc_interp;
 extern AMREX_EXPORT CellConservativeLinear    cell_cons_interp;
 extern AMREX_EXPORT CellBilinear              cell_bilinear_interp;


### PR DESCRIPTION
Add an option to use coarse data for interpolation at the coarse/fine
interface.  This is a feature request by ERF.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
