### PR TITLE
ParmPaser::queryAdd

### DIFF
--- a/Src/Amr/AMReX_Amr.cpp
+++ b/Src/Amr/AMReX_Amr.cpp
@@ -256,27 +256,27 @@ Amr::InitAmr ()
     //
     // Check for command line flags.
     //
-    pp.query("regrid_on_restart",regrid_on_restart);
-    pp.query("use_efficient_regrid",use_efficient_regrid);
-    pp.query("plotfile_on_restart",plotfile_on_restart);
-    pp.query("insitu_on_restart",insitu_on_restart);
-    pp.query("checkpoint_on_restart",checkpoint_on_restart);
+    pp.queryAdd("regrid_on_restart",regrid_on_restart);
+    pp.queryAdd("use_efficient_regrid",use_efficient_regrid);
+    pp.queryAdd("plotfile_on_restart",plotfile_on_restart);
+    pp.queryAdd("insitu_on_restart",insitu_on_restart);
+    pp.queryAdd("checkpoint_on_restart",checkpoint_on_restart);
 
-    pp.query("compute_new_dt_on_regrid",compute_new_dt_on_regrid);
+    pp.queryAdd("compute_new_dt_on_regrid",compute_new_dt_on_regrid);
 
-    pp.query("mffile_nstreams", mffile_nstreams);
+    pp.queryAdd("mffile_nstreams", mffile_nstreams);
 
 #ifndef AMREX_NO_PROBINIT
-    pp.query("probinit_natonce", probinit_natonce);
+    pp.queryAdd("probinit_natonce", probinit_natonce);
     probinit_natonce = std::max(1, std::min(ParallelDescriptor::NProcs(), probinit_natonce));
 #endif
 
-    pp.query("file_name_digits", file_name_digits);
+    pp.queryAdd("file_name_digits", file_name_digits);
 
-    pp.query("initial_grid_file",initial_grids_file);
-    pp.query("regrid_file"      , regrid_grids_file);
+    pp.queryAdd("initial_grid_file",initial_grids_file);
+    pp.queryAdd("regrid_file"      , regrid_grids_file);
 
-    pp.query("message_int", message_int);
+    pp.queryAdd("message_int", message_int);
 
     if (pp.contains("run_log"))
     {
@@ -318,11 +318,11 @@ Amr::InitAmr ()
     //
     // If set, then restart from checkpoint file.
     //
-    pp.query("restart", restart_chkfile);
+    pp.queryAdd("restart", restart_chkfile);
     //
     // If set, then restart from plotfile.
     //
-    pp.query("restart_from_plotfile", restart_pltfile);
+    pp.queryAdd("restart_from_plotfile", restart_pltfile);
 
     int nlev     = max_level+1;
     dt_level.resize(nlev);
@@ -492,13 +492,13 @@ Amr::InitAmr ()
     }
 
     loadbalance_with_workestimates = 0;
-    pp.query("loadbalance_with_workestimates", loadbalance_with_workestimates);
+    pp.queryAdd("loadbalance_with_workestimates", loadbalance_with_workestimates);
 
     loadbalance_level0_int = 2;
-    pp.query("loadbalance_level0_int", loadbalance_level0_int);
+    pp.queryAdd("loadbalance_level0_int", loadbalance_level0_int);
 
     loadbalance_max_fac = 1.5;
-    pp.query("loadbalance_max_fac", loadbalance_max_fac);
+    pp.queryAdd("loadbalance_max_fac", loadbalance_max_fac);
 }
 
 int
@@ -3093,7 +3093,7 @@ Amr::initSubcycle ()
     else
     {
         subcycling_mode = "Auto";
-        pp.query("subcycling_mode",subcycling_mode);
+        pp.queryAdd("subcycling_mode",subcycling_mode);
     }
 
     if (subcycling_mode == "None")
@@ -3176,11 +3176,11 @@ Amr::initPltAndChk ()
 {
     ParmParse pp("amr");
 
-    pp.query("checkpoint_files_output", checkpoint_files_output);
-    pp.query("plot_files_output", plot_files_output);
+    pp.queryAdd("checkpoint_files_output", checkpoint_files_output);
+    pp.queryAdd("plot_files_output", plot_files_output);
 
-    pp.query("plot_nfiles", plot_nfiles);
-    pp.query("checkpoint_nfiles", checkpoint_nfiles);
+    pp.queryAdd("plot_nfiles", plot_nfiles);
+    pp.queryAdd("checkpoint_nfiles", checkpoint_nfiles);
     //
     // -1 ==> use ParallelDescriptor::NProcs().
     //
@@ -3188,13 +3188,13 @@ Amr::initPltAndChk ()
     if (checkpoint_nfiles == -1) checkpoint_nfiles = ParallelDescriptor::NProcs();
 
     check_file_root = "chk";
-    pp.query("check_file",check_file_root);
+    pp.queryAdd("check_file",check_file_root);
 
     check_int = -1;
-    pp.query("check_int",check_int);
+    pp.queryAdd("check_int",check_int);
 
     check_per = -1.0;
-    pp.query("check_per",check_per);
+    pp.queryAdd("check_per",check_per);
 
     if (check_int > 0 && check_per > 0)
     {
@@ -3203,16 +3203,16 @@ Amr::initPltAndChk ()
     }
 
     plot_file_root = "plt";
-    pp.query("plot_file",plot_file_root);
+    pp.queryAdd("plot_file",plot_file_root);
 
     plot_int = -1;
-    pp.query("plot_int",plot_int);
+    pp.queryAdd("plot_int",plot_int);
 
     plot_per = -1.0;
-    pp.query("plot_per",plot_per);
+    pp.queryAdd("plot_per",plot_per);
 
     plot_log_per = -1.0;
-    pp.query("plot_log_per",plot_log_per);
+    pp.queryAdd("plot_log_per",plot_log_per);
 
     if (plot_int > 0 && plot_per > 0)
     {
@@ -3221,16 +3221,16 @@ Amr::initPltAndChk ()
     }
 
     small_plot_file_root = "smallplt";
-    pp.query("small_plot_file",small_plot_file_root);
+    pp.queryAdd("small_plot_file",small_plot_file_root);
 
     small_plot_int = -1;
-    pp.query("small_plot_int",small_plot_int);
+    pp.queryAdd("small_plot_int",small_plot_int);
 
     small_plot_per = -1.0;
-    pp.query("small_plot_per",small_plot_per);
+    pp.queryAdd("small_plot_per",small_plot_per);
 
     small_plot_log_per = -1.0;
-    pp.query("small_plot_log_per",small_plot_log_per);
+    pp.queryAdd("small_plot_log_per",small_plot_log_per);
 
     if (small_plot_int > 0 && small_plot_per > 0)
     {
@@ -3239,24 +3239,24 @@ Amr::initPltAndChk ()
     }
 
     write_plotfile_with_checkpoint = 1;
-    pp.query("write_plotfile_with_checkpoint",write_plotfile_with_checkpoint);
+    pp.queryAdd("write_plotfile_with_checkpoint",write_plotfile_with_checkpoint);
 
     stream_max_tries = 4;
-    pp.query("stream_max_tries",stream_max_tries);
+    pp.queryAdd("stream_max_tries",stream_max_tries);
     stream_max_tries = std::max(stream_max_tries, 1);
 
     abort_on_stream_retry_failure = false;
-    pp.query("abort_on_stream_retry_failure",abort_on_stream_retry_failure);
+    pp.queryAdd("abort_on_stream_retry_failure",abort_on_stream_retry_failure);
 
-    pp.query("precreateDirectories", precreateDirectories);
-    pp.query("prereadFAHeaders", prereadFAHeaders);
+    pp.queryAdd("precreateDirectories", precreateDirectories);
+    pp.queryAdd("prereadFAHeaders", prereadFAHeaders);
 
     int phvInt(plot_headerversion), chvInt(checkpoint_headerversion);
-    pp.query("plot_headerversion", phvInt);
+    pp.queryAdd("plot_headerversion", phvInt);
     if(phvInt != plot_headerversion) {
       plot_headerversion = static_cast<VisMF::Header::Version> (phvInt);
     }
-    pp.query("checkpoint_headerversion", chvInt);
+    pp.queryAdd("checkpoint_headerversion", chvInt);
     if(chvInt != checkpoint_headerversion) {
       checkpoint_headerversion = static_cast<VisMF::Header::Version> (chvInt);
     }

--- a/Src/AmrCore/AMReX_AmrMesh.cpp
+++ b/Src/AmrCore/AMReX_AmrMesh.cpp
@@ -71,7 +71,7 @@ AmrMesh::InitAmrMesh (int max_level_in, const Vector<int>& n_cell_in,
 {
     ParmParse pp("amr");
 
-    pp.query("v",verbose);
+    pp.queryAdd("v",verbose);
 
     if (max_level_in == -1) {
        pp.get("max_level", max_level);
@@ -103,8 +103,8 @@ AmrMesh::InitAmrMesh (int max_level_in, const Vector<int>& n_cell_in,
       ref_ratio[i] = 2 * IntVect::TheUnitVector();
     }
 
-    pp.query("n_proper",n_proper);
-    pp.query("grid_eff",grid_eff);
+    pp.queryAdd("n_proper",n_proper);
+    pp.queryAdd("grid_eff",grid_eff);
     int cnt = pp.countval("n_error_buf");
     if (cnt > 0) {
         Vector<int> neb;
@@ -360,17 +360,17 @@ AmrMesh::InitAmrMesh (int max_level_in, const Vector<int>& n_cell_in,
 
     //chop up grids to have the number of grids be no less the number of procs
     {
-        pp.query("refine_grid_layout", refine_grid_layout);
+        pp.queryAdd("refine_grid_layout", refine_grid_layout);
 
         refine_grid_layout_dims = IntVect(refine_grid_layout);
-        AMREX_D_TERM(pp.query("refine_grid_layout_x", refine_grid_layout_dims[0]);,
-                     pp.query("refine_grid_layout_y", refine_grid_layout_dims[1]);,
-                     pp.query("refine_grid_layout_z", refine_grid_layout_dims[2]));
+        AMREX_D_TERM(pp.queryAdd("refine_grid_layout_x", refine_grid_layout_dims[0]);,
+                     pp.queryAdd("refine_grid_layout_y", refine_grid_layout_dims[1]);,
+                     pp.queryAdd("refine_grid_layout_z", refine_grid_layout_dims[2]));
 
         refine_grid_layout = refine_grid_layout_dims != 0;
     }
 
-    pp.query("check_input", check_input);
+    pp.queryAdd("check_input", check_input);
 
     finest_level = -1;
 

--- a/Src/Base/AMReX.cpp
+++ b/Src/Base/AMReX.cpp
@@ -427,8 +427,8 @@ amrex::Initialize (int& argc, char**& argv, bool build_parm_parse,
 
     {
         ParmParse pp("amrex");
-        pp.query("v", system::verbose);
-        pp.query("verbose", system::verbose);
+        pp.queryAdd("v", system::verbose);
+        pp.queryAdd("verbose", system::verbose);
     }
 
 #ifdef AMREX_USE_GPU
@@ -441,11 +441,11 @@ amrex::Initialize (int& argc, char**& argv, bool build_parm_parse,
 
     {
         ParmParse pp("amrex");
-        pp.query("regtest_reduction", system::regtest_reduction);
-        pp.query("signal_handling", system::signal_handling);
-        pp.query("throw_exception", system::throw_exception);
-        pp.query("call_addr2line", system::call_addr2line);
-        pp.query("abort_on_unused_inputs", system::abort_on_unused_inputs);
+        pp.queryAdd("regtest_reduction", system::regtest_reduction);
+        pp.queryAdd("signal_handling", system::signal_handling);
+        pp.queryAdd("throw_exception", system::throw_exception);
+        pp.queryAdd("call_addr2line", system::call_addr2line);
+        pp.queryAdd("abort_on_unused_inputs", system::abort_on_unused_inputs);
 
         if (system::signal_handling)
         {
@@ -455,7 +455,7 @@ amrex::Initialize (int& argc, char**& argv, bool build_parm_parse,
             prev_handler_sigabrt = signal(SIGABRT, BLBackTrace::handler);
 
             int term = 0;
-            pp.query("handle_sigterm", term);
+            pp.queryAdd("handle_sigterm", term);
             if (term) {
                 prev_handler_sigterm = signal(SIGTERM,  BLBackTrace::handler);
             } else {
@@ -465,9 +465,9 @@ amrex::Initialize (int& argc, char**& argv, bool build_parm_parse,
             prev_handler_sigfpe = SIG_ERR;
 
             int invalid = 0, divbyzero=0, overflow=0;
-            pp.query("fpe_trap_invalid", invalid);
-            pp.query("fpe_trap_zero", divbyzero);
-            pp.query("fpe_trap_overflow", overflow);
+            pp.queryAdd("fpe_trap_invalid", invalid);
+            pp.queryAdd("fpe_trap_zero", divbyzero);
+            pp.queryAdd("fpe_trap_overflow", overflow);
 
 #if defined(__linux__)
             curr_fpe_excepts = 0;
@@ -497,7 +497,7 @@ amrex::Initialize (int& argc, char**& argv, bool build_parm_parse,
         }
 
 #ifdef AMREX_USE_HYPRE
-        pp.query("init_hypre", init_hypre);
+        pp.queryAdd("init_hypre", init_hypre);
 #endif
     }
 

--- a/Src/Base/AMReX_Arena.cpp
+++ b/Src/Base/AMReX_Arena.cpp
@@ -253,17 +253,17 @@ Arena::Initialize ()
 #endif
 
     ParmParse pp("amrex");
-    pp.query(        "the_arena_init_size",         the_arena_init_size);
-    pp.query( "the_device_arena_init_size",  the_device_arena_init_size);
-    pp.query("the_managed_arena_init_size", the_managed_arena_init_size);
-    pp.query( "the_pinned_arena_init_size",  the_pinned_arena_init_size);
-    pp.query(       "the_arena_release_threshold" ,         the_arena_release_threshold);
-    pp.query( "the_device_arena_release_threshold",  the_device_arena_release_threshold);
-    pp.query("the_managed_arena_release_threshold", the_managed_arena_release_threshold);
-    pp.query( "the_pinned_arena_release_threshold",  the_pinned_arena_release_threshold);
-    pp.query(  "the_async_arena_release_threshold",   the_async_arena_release_threshold);
-    pp.query("the_arena_is_managed", the_arena_is_managed);
-    pp.query("abort_on_out_of_gpu_memory", abort_on_out_of_gpu_memory);
+    pp.queryAdd(        "the_arena_init_size",         the_arena_init_size);
+    pp.queryAdd( "the_device_arena_init_size",  the_device_arena_init_size);
+    pp.queryAdd("the_managed_arena_init_size", the_managed_arena_init_size);
+    pp.queryAdd( "the_pinned_arena_init_size",  the_pinned_arena_init_size);
+    pp.queryAdd(       "the_arena_release_threshold" ,         the_arena_release_threshold);
+    pp.queryAdd( "the_device_arena_release_threshold",  the_device_arena_release_threshold);
+    pp.queryAdd("the_managed_arena_release_threshold", the_managed_arena_release_threshold);
+    pp.queryAdd( "the_pinned_arena_release_threshold",  the_pinned_arena_release_threshold);
+    pp.queryAdd(  "the_async_arena_release_threshold",   the_async_arena_release_threshold);
+    pp.queryAdd("the_arena_is_managed", the_arena_is_managed);
+    pp.queryAdd("abort_on_out_of_gpu_memory", abort_on_out_of_gpu_memory);
 
     {
 #if defined(BL_COALESCE_FABS) || defined(AMREX_USE_GPU)

--- a/Src/Base/AMReX_AsyncOut.cpp
+++ b/Src/Base/AMReX_AsyncOut.cpp
@@ -32,8 +32,8 @@ void Initialize ()
     amrex::ignore_unused(s_comm,s_info);
 
     ParmParse pp("amrex");
-    pp.query("async_out", s_asyncout);
-    pp.query("async_out_nfiles", s_noutfiles);
+    pp.queryAdd("async_out", s_asyncout);
+    pp.queryAdd("async_out_nfiles", s_noutfiles);
 
     int nprocs = ParallelDescriptor::NProcs();
     s_noutfiles = std::min(s_noutfiles, nprocs);

--- a/Src/Base/AMReX_BLProfiler.cpp
+++ b/Src/Base/AMReX_BLProfiler.cpp
@@ -272,20 +272,12 @@ void BLProfiler::Initialize() {
 
 void BLProfiler::InitParams() {
   ParmParse pParse("blprofiler");
-  pParse.query("prof_nfiles", nProfFiles);
-  pParse.query("prof_csflushsize", csFlushSize);
-  pParse.query("prof_traceflushsize", traceFlushSize);
-  pParse.query("prof_flushinterval", flushInterval);
-  pParse.query("prof_flushtimeinterval", flushTimeInterval);
-  pParse.query("prof_flushprint", bFlushPrint);
-#if 0
-  amrex::Print() << "PPPPPPPP::  nProfFiles         = " << nProfFiles << '\n';
-  amrex::Print() << "PPPPPPPP::  csFlushSize        = " << csFlushSize << '\n';
-  amrex::Print() << "PPPPPPPP::  traceFlushSize     = " << traceFlushSize << '\n';
-  amrex::Print() << "PPPPPPPP::  flushInterval      = " << flushInterval << '\n';
-  amrex::Print() << "PPPPPPPP::  flushTimeInterval  = " << flushTimeInterval << " s." << '\n';
-  amrex::Print() << "PPPPPPPP::  flushPrint         = " << bFlushPrint << '\n';
-#endif
+  pParse.queryAdd("prof_nfiles", nProfFiles);
+  pParse.queryAdd("prof_csflushsize", csFlushSize);
+  pParse.queryAdd("prof_traceflushsize", traceFlushSize);
+  pParse.queryAdd("prof_flushinterval", flushInterval);
+  pParse.queryAdd("prof_flushtimeinterval", flushTimeInterval);
+  pParse.queryAdd("prof_flushprint", bFlushPrint);
 }
 
 

--- a/Src/Base/AMReX_DistributionMapping.cpp
+++ b/Src/Base/AMReX_DistributionMapping.cpp
@@ -118,12 +118,12 @@ DistributionMapping::Initialize ()
 
     ParmParse pp("DistributionMapping");
 
-    pp.query("v"      ,             verbose);
-    pp.query("verbose",             verbose);
-    pp.query("efficiency",          max_efficiency);
-    pp.query("sfc_threshold",       sfc_threshold);
-    pp.query("node_size",           node_size);
-    pp.query("verbose_mapper",      flag_verbose_mapper);
+    pp.queryAdd("v"      ,             verbose);
+    pp.queryAdd("verbose",             verbose);
+    pp.queryAdd("efficiency",          max_efficiency);
+    pp.queryAdd("sfc_threshold",       sfc_threshold);
+    pp.queryAdd("node_size",           node_size);
+    pp.queryAdd("verbose_mapper",      flag_verbose_mapper);
 
     std::string theStrategy;
 

--- a/Src/Base/AMReX_FArrayBox.cpp
+++ b/Src/Base/AMReX_FArrayBox.cpp
@@ -442,9 +442,9 @@ FArrayBox::Initialize ()
             ? std::numeric_limits<Real>::quiet_NaN()
             : std::numeric_limits<Real>::max();
 
-    pp.query("initval",    initval);
-    pp.query("do_initval", do_initval);
-    pp.query("init_snan", init_snan);
+    pp.queryAdd("initval",    initval);
+    pp.queryAdd("do_initval", do_initval);
+    pp.queryAdd("init_snan", init_snan);
 
     amrex::ExecOnFinalize(FArrayBox::Finalize);
 }

--- a/Src/Base/AMReX_FabArrayBase.cpp
+++ b/Src/Base/AMReX_FabArrayBase.cpp
@@ -116,7 +116,7 @@ FabArrayBase::Initialize ()
         for (int i=0; i<AMREX_SPACEDIM; i++) FabArrayBase::comm_tile_size[i] = tilesize[i];
     }
 
-    pp.query("maxcomp",             FabArrayBase::MaxComp);
+    pp.queryAdd("maxcomp",             FabArrayBase::MaxComp);
 
     if (MaxComp < 1) {
         MaxComp = 1;

--- a/Src/Base/AMReX_ForkJoin.cpp
+++ b/Src/Base/AMReX_ForkJoin.cpp
@@ -69,7 +69,7 @@ void
 ForkJoin::init(const Vector<int> &task_rank_n)
 {
     ParmParse pp("forkjoin");
-    pp.query("verbose", flag_verbose);
+    pp.queryAdd("verbose", flag_verbose);
 
     const auto task_n = task_rank_n.size();
     AMREX_ALWAYS_ASSERT_WITH_MESSAGE(task_n > 0,

--- a/Src/Base/AMReX_Geometry.cpp
+++ b/Src/Base/AMReX_Geometry.cpp
@@ -120,7 +120,7 @@ Geometry::Setup (const RealBox* rb, int coord, int const* isper) noexcept
         gg->SetCoord( (CoordType) coord );
     } else {
         coord = 0;  // default is Cartesian coordinates
-        pp.query("coord_sys",coord);
+        pp.queryAdd("coord_sys",coord);
         gg->SetCoord( (CoordType) coord );
     }
 
@@ -129,8 +129,8 @@ Geometry::Setup (const RealBox* rb, int coord, int const* isper) noexcept
         Vector<Real> prob_hi(AMREX_SPACEDIM);
         Vector<Real> prob_extent(AMREX_SPACEDIM);
 
-        for (int i = 0; i < AMREX_SPACEDIM; i++) prob_lo[i] = 0.;
-        pp.queryarr("prob_lo",prob_lo,0,AMREX_SPACEDIM);
+        for (int i = 0; i < AMREX_SPACEDIM; i++) { prob_lo[i] = 0.; }
+        pp.queryAdd("prob_lo", prob_lo, AMREX_SPACEDIM);
         AMREX_ASSERT(prob_lo.size() == AMREX_SPACEDIM);
 
         bool read_prob_hi = pp.queryarr("prob_hi",prob_hi,0,AMREX_SPACEDIM);
@@ -164,7 +164,7 @@ Geometry::Setup (const RealBox* rb, int coord, int const* isper) noexcept
     if (isper == nullptr)
     {
         Vector<int> is_per(AMREX_SPACEDIM,0);
-        pp.queryarr("is_periodic",is_per,0,AMREX_SPACEDIM);
+        pp.queryAdd("is_periodic", is_per);
         for (int n = 0; n < AMREX_SPACEDIM; n++) {
             gg->is_periodic[n] = is_per[n];
         }

--- a/Src/Base/AMReX_GpuDevice.cpp
+++ b/Src/Base/AMReX_GpuDevice.cpp
@@ -134,13 +134,13 @@ Device::Initialize ()
 #endif
 
     ParmParse ppamrex("amrex");
-    ppamrex.query("max_gpu_streams", max_gpu_streams);
+    ppamrex.queryAdd("max_gpu_streams", max_gpu_streams);
     max_gpu_streams = std::min(max_gpu_streams, AMREX_GPU_MAX_STREAMS);
 
     ParmParse pp("device");
 
-    pp.query("v", verbose);
-    pp.query("verbose", verbose);
+    pp.queryAdd("v", verbose);
+    pp.queryAdd("verbose", verbose);
 
     if (amrex::Verbose()) {
         AMREX_HIP_OR_CUDA_OR_DPCPP
@@ -506,9 +506,9 @@ Device::initialize_gpu ()
     int ny = 0;
     int nz = 0;
 
-    pp.query("numThreads.x", nx);
-    pp.query("numThreads.y", ny);
-    pp.query("numThreads.z", nz);
+    pp.queryAdd("numThreads.x", nx);
+    pp.queryAdd("numThreads.y", ny);
+    pp.queryAdd("numThreads.z", nz);
 
     numThreadsOverride.x = (int) nx;
     numThreadsOverride.y = (int) ny;
@@ -518,9 +518,9 @@ Device::initialize_gpu ()
     ny = 0;
     nz = 0;
 
-    pp.query("numBlocks.x", nx);
-    pp.query("numBlocks.y", ny);
-    pp.query("numBlocks.z", nz);
+    pp.queryAdd("numBlocks.x", nx);
+    pp.queryAdd("numBlocks.y", ny);
+    pp.queryAdd("numBlocks.z", nz);
 
     numBlocksOverride.x = (int) nx;
     numBlocksOverride.y = (int) ny;
@@ -529,8 +529,8 @@ Device::initialize_gpu ()
     // Graph initialization
     int graph_init = 0;
     int graph_size = 10000;
-    pp.query("graph_init", graph_init);
-    pp.query("graph_init_nodes", graph_size);
+    pp.queryAdd("graph_init", graph_init);
+    pp.queryAdd("graph_init_nodes", graph_size);
 
     if (graph_init)
     {

--- a/Src/Base/AMReX_Machine.cpp
+++ b/Src/Base/AMReX_Machine.cpp
@@ -329,8 +329,8 @@ class Machine
     void get_params ()
     {
         ParmParse pp("machine");
-        pp.query("verbose", flag_verbose);
-        pp.query("very_verbose", flag_very_verbose);
+        pp.queryAdd("verbose", flag_verbose);
+        pp.queryAdd("very_verbose", flag_very_verbose);
     }
 
     std::string get_env_str (std::string env_key)

--- a/Src/Base/AMReX_MemPool.cpp
+++ b/Src/Base/AMReX_MemPool.cpp
@@ -39,7 +39,7 @@ void amrex_mempool_init ()
         initialized = true;
 
         ParmParse pp("fab");
-        pp.query("init_snan", init_snan);
+        pp.queryAdd("init_snan", init_snan);
 
         int nthreads = OpenMP::get_max_threads();
 

--- a/Src/Base/AMReX_MemProfiler.cpp
+++ b/Src/Base/AMReX_MemProfiler.cpp
@@ -67,10 +67,9 @@ MemProfiler::report (const std::string& prefix)
 {
     static std::string memory_log_name;
     if (memory_log_name.empty()) {
+        memory_log_name = "memlog";
         ParmParse pp("amrex");
-        pp.query("memory_log", memory_log_name);
-        if (memory_log_name.empty())
-            memory_log_name = "memlog";
+        pp.queryAdd("memory_log", memory_log_name);
     }
 
     getInstance().report_(prefix, memory_log_name);

--- a/Src/Base/AMReX_ParallelDescriptor.cpp
+++ b/Src/Base/AMReX_ParallelDescriptor.cpp
@@ -1446,7 +1446,7 @@ Initialize ()
 {
 #ifndef BL_AMRPROF
     ParmParse pp("amrex");
-    pp.query("use_gpu_aware_mpi", use_gpu_aware_mpi);
+    pp.queryAdd("use_gpu_aware_mpi", use_gpu_aware_mpi);
 
     StartTeams();
 #endif
@@ -1469,8 +1469,8 @@ StartTeams ()
 
 #if defined(BL_USE_MPI3)
     ParmParse pp("team");
-    pp.query("size", team_size);
-    pp.query("reduce", do_team_reduce);
+    pp.queryAdd("size", team_size);
+    pp.queryAdd("reduce", do_team_reduce);
 #endif
 
     int nprocs = ParallelDescriptor::NProcs();

--- a/Src/Base/AMReX_ParmParse.H
+++ b/Src/Base/AMReX_ParmParse.H
@@ -4,6 +4,7 @@
 #include <AMReX_Config.H>
 
 #include <AMReX_BLassert.H>
+#include <AMReX_TypeTraits.H>
 
 #include <set>
 #include <stack>
@@ -932,6 +933,84 @@ public:
             for (std::size_t i = 0; i < N; ++i) {
                 ref[i] = v[i];
             }
+        }
+        return exist;
+    }
+
+    /**
+     * \brief If `name` is found, the value in the ParmParse database will
+     * be stored in the `ref` argument.  If not, the value in `ref` will be
+     * added to the ParmParse database.  The return value indicates if it
+     * existed previously.
+     */
+    template <typename T, std::enable_if_t<!IsStdVector<T>::value, int> = 0>
+    int queryAdd (const char* name, T& ref) {
+        int exist = this->query(name, ref);
+        if (!exist) {
+            this->add(name, ref);
+        }
+        return exist;
+    }
+
+    int queryAdd (const char* name, std::string& ref) {
+        int exist = this->query(name, ref);
+        if (!exist && !ref.empty()) {
+            this->add(name, ref);
+        }
+        return exist;
+    }
+
+    /**
+     * \brief If `name` is found, the value in the ParmParse database will
+     * be stored in the `ref` argument.  If not, the value in `ref` will be
+     * added to the ParmParse database.  The return value indicates if it
+     * existed previously.
+     */
+    template <typename T>
+    int queryAdd (const char* name, std::vector<T>& ref) {
+        int exist = this->queryarr(name, ref);
+        if (!exist && !ref.empty()) {
+            this->addarr(name, ref);
+        }
+        return exist;
+    }
+
+    /**
+     * \brief If `name` is found, the value in the ParmParse database will
+     * be stored in the `ref` argument.  If not, the value in `ref` will be
+     * added to the ParmParse database.  The return value indicates if it
+     * existed previously.
+     */
+    template <typename T>
+    int queryAdd (const char* name, std::vector<T>& ref, int num_val) {
+        int exist = this->queryarr(name, ref, 0, num_val);
+        if (!exist) {
+            this->addarr(name, ref);
+        }
+        return exist;
+    }
+
+    /**
+     * \brief If `name` is found, the value in the ParmParse database will
+     * be stored in the `ref` argument.  If not, the value in `ref` will be
+     * added to the ParmParse database.  The return value indicates if it
+     * existed previously.
+     */
+    template <typename T, std::size_t N>
+    int queryAdd (const char* name, std::array<T,N>& ref) {
+        std::vector<T> v;
+        int exist = this->queryarr(name, v);
+        if (exist) {
+            AMREX_ALWAYS_ASSERT(v.size() >= N);
+            for (std::size_t i = 0; i < N; ++i) {
+                ref[i] = v[i];
+            }
+        } else {
+            v.resize(N);
+            for (std::size_t i = 0; i < N; ++i) {
+                v[i] = ref[i];
+            }
+            this->addarr(name, v);
         }
         return exist;
     }

--- a/Src/Base/AMReX_RKIntegrator.H
+++ b/Src/Base/AMReX_RKIntegrator.H
@@ -88,7 +88,7 @@ private:
         // By default, define no extended weights and no adaptive timestepping
         extended_weights = {};
         use_adaptive_timestep = false;
-        pp.query("use_adaptive_timestep", use_adaptive_timestep);
+        pp.queryAdd("use_adaptive_timestep", use_adaptive_timestep);
 
         if (tableau_type == ButcherTableauTypes::User)
         {

--- a/Src/Base/AMReX_TinyProfiler.cpp
+++ b/Src/Base/AMReX_TinyProfiler.cpp
@@ -300,9 +300,9 @@ TinyProfiler::Initialize () noexcept
 
     {
         amrex::ParmParse pp("tiny_profiler");
-        pp.query("device_synchronize_around_region", device_synchronize_around_region);
-        pp.query("verbose", verbose);
-        pp.query("v", verbose);
+        pp.queryAdd("device_synchronize_around_region", device_synchronize_around_region);
+        pp.queryAdd("verbose", verbose);
+        pp.queryAdd("v", verbose);
     }
 }
 

--- a/Src/Base/AMReX_TypeTraits.H
+++ b/Src/Base/AMReX_TypeTraits.H
@@ -3,6 +3,7 @@
 #include <AMReX_Config.H>
 
 #include <AMReX_Extension.H>
+#include <vector>
 #include <type_traits>
 
 // In case they are still used by applications
@@ -227,6 +228,15 @@ namespace amrex
                                 std::is_arithmetic<T>::value
                                 && sizeof(T) <= 8 >::type >
         : std::true_type {};
+
+    template <class T, class Enable = void>
+    struct IsStdVector : std::false_type {};
+    //
+    template <class T>
+    struct IsStdVector<T, std::enable_if_t<std::is_base_of<std::vector<typename T::value_type,
+                                                                       typename T::allocator_type>,
+                                                           T>::value> >
+                       : std::true_type {};
 
 }
 

--- a/Src/Base/AMReX_VisMF.cpp
+++ b/Src/Base/AMReX_VisMF.cpp
@@ -58,24 +58,24 @@ VisMF::Initialize ()
     amrex::ExecOnFinalize(VisMF::Finalize);
 
     ParmParse pp("vismf");
-    pp.query("v",verbose);
+    pp.queryAdd("v",verbose);
 
     int headerVersion(currentVersion);
-    pp.query("headerversion", headerVersion);
+    pp.queryAdd("headerversion", headerVersion);
     if(headerVersion != currentVersion) {
       currentVersion = static_cast<VisMF::Header::Version> (headerVersion);
     }
 
-    pp.query("groupsets", groupSets);
-    pp.query("setbuf", setBuf);
-    pp.query("usesingleread", useSingleRead);
-    pp.query("usesinglewrite", useSingleWrite);
-    pp.query("checkfilepositions", checkFilePositions);
-    pp.query("usepersistentifstreams", usePersistentIFStreams);
-    pp.query("usesynchronousreads", useSynchronousReads);
-    pp.query("usedynamicsetselection", useDynamicSetSelection);
-    pp.query("iobuffersize", ioBufferSize);
-    pp.query("allowsparsewrites", allowSparseWrites);
+    pp.queryAdd("groupsets", groupSets);
+    pp.queryAdd("setbuf", setBuf);
+    pp.queryAdd("usesingleread", useSingleRead);
+    pp.queryAdd("usesinglewrite", useSingleWrite);
+    pp.queryAdd("checkfilepositions", checkFilePositions);
+    pp.queryAdd("usepersistentifstreams", usePersistentIFStreams);
+    pp.queryAdd("usesynchronousreads", useSynchronousReads);
+    pp.queryAdd("usedynamicsetselection", useDynamicSetSelection);
+    pp.queryAdd("iobuffersize", ioBufferSize);
+    pp.queryAdd("allowsparsewrites", allowSparseWrites);
 
     initialized = true;
 }

--- a/Src/Base/AMReX_parstream.cpp
+++ b/Src/Base/AMReX_parstream.cpp
@@ -58,7 +58,7 @@ namespace amrex
   {
     int outInterv = 1;
     ParmParse pp("amrex");
-    pp.query("pout_int", outInterv);
+    pp.queryAdd("pout_int", outInterv);
     if (outInterv == 0) outInterv=ParallelDescriptor::NProcs();
 
     int thisProc = ParallelDescriptor::MyProc();
@@ -215,4 +215,3 @@ namespace amrex
     return s_pout_filename ;
   }
 }
-

--- a/Src/EB/AMReX_EB2.cpp
+++ b/Src/EB/AMReX_EB2.cpp
@@ -24,8 +24,8 @@ AMREX_EXPORT bool extend_domain_face = true;
 void Initialize ()
 {
     ParmParse pp("eb2");
-    pp.query("max_grid_size", max_grid_size);
-    pp.query("extend_domain_face", extend_domain_face);
+    pp.queryAdd("max_grid_size", max_grid_size);
+    pp.queryAdd("extend_domain_face", extend_domain_face);
 
     amrex::ExecOnFinalize(Finalize);
 }
@@ -112,7 +112,7 @@ Build (const Geometry& geom, int required_coarsening_level,
         pp.get("cylinder_radius", radius);
 
         Real height = -1.0;
-        pp.query("cylinder_height", height);
+        pp.queryAdd("cylinder_height", height);
 
         int direction;
         pp.get("cylinder_direction", direction);

--- a/Src/EB/AMReX_EB2_Level.H
+++ b/Src/EB/AMReX_EB2_Level.H
@@ -125,9 +125,9 @@ GShopLevel<G>::GShopLevel (IndexSpace const* is, G const& gshop, const Geometry&
     int maxiter = 32;
     {
         ParmParse pp("eb2");
-        pp.query("small_volfrac", small_volfrac);
-        pp.query("cover_multiple_cuts", cover_multiple_cuts);
-        pp.query("maxiter", maxiter);
+        pp.queryAdd("small_volfrac", small_volfrac);
+        pp.queryAdd("cover_multiple_cuts", cover_multiple_cuts);
+        pp.queryAdd("maxiter", maxiter);
     }
 
     // make sure ngrow is multiple of 16

--- a/Src/Extern/HDF5/AMReX_WriteBinaryParticleDataHDF5.H
+++ b/Src/Extern/HDF5/AMReX_WriteBinaryParticleDataHDF5.H
@@ -374,7 +374,7 @@ void WriteHDF5ParticleDataSync (PC const& pc,
     int nOutFiles(-1);
 
     ParmParse pp("particles");
-    pp.query("particles_nfiles",nOutFiles);
+    pp.queryAdd("particles_nfiles",nOutFiles);
     if(nOutFiles == -1) nOutFiles = NProcs;
     /* nOutFiles = std::max(1, std::min(nOutFiles,NProcs)); */
     pc.nOutFilesPrePost = nOutFiles;

--- a/Src/Extern/HYPRE/AMReX_HypreIJIface.cpp
+++ b/Src/Extern/HYPRE/AMReX_HypreIJIface.cpp
@@ -17,12 +17,12 @@ struct HypreOptParse
     //! Hypre solver/preconditioner whose options are being set
     HYPRE_Solver solver;
 
-    HypreOptParse(const std::string& prefix, HYPRE_Solver sinp)
+    HypreOptParse (const std::string& prefix, HYPRE_Solver sinp)
         : pp(prefix), solver(sinp)
     {}
 
     template <typename F>
-    void operator()(const std::string& key, F&& func)
+    void operator() (const std::string& key, F&& func)
     {
         if (pp.contains(key.c_str())) {
             int val;
@@ -32,23 +32,23 @@ struct HypreOptParse
     }
 
     template <typename F, typename T>
-    void operator()(const std::string& key, F&& func, T default_val)
+    void operator() (const std::string& key, F&& func, T default_val)
     {
         T val = default_val;
-        pp.query(key.c_str(), val);
+        pp.queryAdd(key.c_str(), val);
         func(solver, val);
     }
 
     template <typename F, typename T>
-    void operator()(const std::string& key, F&& func, T default_val, int index)
+    void operator() (const std::string& key, F&& func, T default_val, int index)
     {
         T val = default_val;
-        pp.query(key.c_str(), val);
+        pp.queryAdd(key.c_str(), val);
         func(solver, val, index);
     }
 
     template <typename T, typename F>
-    void set(const std::string& key, F&& func)
+    void set (const std::string& key, F&& func)
     {
         if (pp.contains(key.c_str())) {
             T val;
@@ -60,7 +60,7 @@ struct HypreOptParse
 
 } // namespace
 
-HypreIJIface::HypreIJIface(
+HypreIJIface::HypreIJIface (
     MPI_Comm comm, HypreIntType ilower, HypreIntType iupper, int verbose)
     : m_comm(comm), m_ilower(ilower), m_iupper(iupper), m_verbose(verbose)
 {
@@ -78,7 +78,7 @@ HypreIJIface::HypreIJIface(
     HYPRE_IJVectorInitialize(m_sln);
 }
 
-HypreIJIface::~HypreIJIface()
+HypreIJIface::~HypreIJIface ()
 {
     HYPRE_IJMatrixDestroy(m_mat);
     m_mat = nullptr;
@@ -98,7 +98,7 @@ HypreIJIface::~HypreIJIface()
     }
 }
 
-void HypreIJIface::solve(
+void HypreIJIface::solve (
     const HypreRealType rel_tol, const HypreRealType abs_tol, const HypreIntType max_iter)
 {
     // Assuming that Matrix/rhs etc. has been assembled by calling code
@@ -154,16 +154,16 @@ void HypreIJIface::solve(
                        << std::endl;
 }
 
-void HypreIJIface::parse_inputs(const std::string& prefix)
+void HypreIJIface::parse_inputs (const std::string& prefix)
 {
     amrex::ParmParse pp(prefix);
 
-    pp.query("hypre_solver", m_solver_name);
-    pp.query("hypre_preconditioner", m_preconditioner_name);
-    pp.query("recompute_preconditioner", m_recompute_preconditioner);
-    pp.query("write_matrix_files", m_write_files);
-    pp.query("overwrite_existing_matrix_files", m_overwrite_files);
-    pp.query("adjust_singular_matrix", m_adjust_singular_matrix);
+    pp.queryAdd("hypre_solver", m_solver_name);
+    pp.queryAdd("hypre_preconditioner", m_preconditioner_name);
+    pp.queryAdd("recompute_preconditioner", m_recompute_preconditioner);
+    pp.queryAdd("write_matrix_files", m_write_files);
+    pp.queryAdd("overwrite_existing_matrix_files", m_overwrite_files);
+    pp.queryAdd("adjust_singular_matrix", m_adjust_singular_matrix);
 
     if (m_verbose > 2)
         amrex::Print() << "HYPRE: solver = " << m_solver_name
@@ -180,7 +180,7 @@ void HypreIJIface::parse_inputs(const std::string& prefix)
     init_solver(prefix, m_solver_name);
 }
 
-void HypreIJIface::init_preconditioner(
+void HypreIJIface::init_preconditioner (
     const std::string& prefix, const std::string& name)
 {
     if (name == "BoomerAMG") {
@@ -192,7 +192,7 @@ void HypreIJIface::init_preconditioner(
     }
 }
 
-void HypreIJIface::init_solver(
+void HypreIJIface::init_solver (
     const std::string& prefix, const std::string& name)
 {
     if (name == "BoomerAMG") {
@@ -216,7 +216,7 @@ void HypreIJIface::init_solver(
     }
 }
 
-void HypreIJIface::boomeramg_precond_configure(const std::string& prefix)
+void HypreIJIface::boomeramg_precond_configure (const std::string& prefix)
 {
     if (m_verbose > 2)
         amrex::Print() << "Creating BoomerAMG preconditioner" << std::endl;
@@ -328,7 +328,7 @@ void HypreIJIface::boomeramg_precond_configure(const std::string& prefix)
     }
 }
 
-void HypreIJIface::euclid_precond_configure(const std::string& prefix)
+void HypreIJIface::euclid_precond_configure (const std::string& prefix)
 {
     HYPRE_EuclidCreate(m_comm, &m_precond);
 
@@ -348,7 +348,7 @@ void HypreIJIface::euclid_precond_configure(const std::string& prefix)
     hpp("euclid_mem", HYPRE_EuclidSetMem, 0);
 }
 
-void HypreIJIface::boomeramg_solver_configure(const std::string& prefix)
+void HypreIJIface::boomeramg_solver_configure (const std::string& prefix)
 {
     if (m_has_preconditioner) {
         amrex::Warning(
@@ -399,12 +399,12 @@ void HypreIJIface::boomeramg_solver_configure(const std::string& prefix)
     hpp("bamg_max_levels", HYPRE_BoomerAMGSetMaxLevels);
 
     bool use_old_default = true;
-    hpp.pp.query("bamg_use_old_default", use_old_default);
+    hpp.pp.queryAdd("bamg_use_old_default", use_old_default);
     if (use_old_default)
         HYPRE_BoomerAMGSetOldDefault(m_solver);
 }
 
-void HypreIJIface::gmres_solver_configure(const std::string& prefix)
+void HypreIJIface::gmres_solver_configure (const std::string& prefix)
 {
     if (m_verbose > 2)
         amrex::Print() << "Creating GMRES solver" << std::endl;
@@ -434,7 +434,7 @@ void HypreIJIface::gmres_solver_configure(const std::string& prefix)
     hpp.set<amrex::Real>("atol", HYPRE_ParCSRGMRESSetAbsoluteTol);
 }
 
-void HypreIJIface::cogmres_solver_configure(const std::string& prefix)
+void HypreIJIface::cogmres_solver_configure (const std::string& prefix)
 {
     HYPRE_ParCSRCOGMRESCreate(m_comm, &m_solver);
 
@@ -462,7 +462,7 @@ void HypreIJIface::cogmres_solver_configure(const std::string& prefix)
     hpp.set<amrex::Real>("atol", HYPRE_ParCSRCOGMRESSetAbsoluteTol);
 }
 
-void HypreIJIface::lgmres_solver_configure(const std::string& prefix)
+void HypreIJIface::lgmres_solver_configure (const std::string& prefix)
 {
     HYPRE_ParCSRLGMRESCreate(m_comm, &m_solver);
 
@@ -490,7 +490,7 @@ void HypreIJIface::lgmres_solver_configure(const std::string& prefix)
     hpp.set<amrex::Real>("atol", HYPRE_ParCSRLGMRESSetAbsoluteTol);
 }
 
-void HypreIJIface::flex_gmres_solver_configure(const std::string& prefix)
+void HypreIJIface::flex_gmres_solver_configure (const std::string& prefix)
 {
     HYPRE_ParCSRFlexGMRESCreate(m_comm, &m_solver);
 
@@ -518,7 +518,7 @@ void HypreIJIface::flex_gmres_solver_configure(const std::string& prefix)
     hpp.set<amrex::Real>("atol", HYPRE_ParCSRFlexGMRESSetAbsoluteTol);
 }
 
-void HypreIJIface::bicgstab_solver_configure(const std::string& prefix)
+void HypreIJIface::bicgstab_solver_configure (const std::string& prefix)
 {
     HYPRE_ParCSRBiCGSTABCreate(m_comm, &m_solver);
 
@@ -545,7 +545,7 @@ void HypreIJIface::bicgstab_solver_configure(const std::string& prefix)
     hpp.set<amrex::Real>("atol", HYPRE_ParCSRBiCGSTABSetAbsoluteTol);
 }
 
-void HypreIJIface::pcg_solver_configure(const std::string& prefix)
+void HypreIJIface::pcg_solver_configure (const std::string& prefix)
 {
     HYPRE_ParCSRPCGCreate(m_comm, &m_solver);
 
@@ -571,7 +571,7 @@ void HypreIJIface::pcg_solver_configure(const std::string& prefix)
     hpp.set<amrex::Real>("atol", HYPRE_ParCSRPCGSetAbsoluteTol);
 }
 
-void HypreIJIface::hybrid_solver_configure(const std::string& prefix)
+void HypreIJIface::hybrid_solver_configure (const std::string& prefix)
 {
     HYPRE_ParCSRHybridCreate(&m_solver);
 

--- a/Src/Extern/SENSEI/AMReX_InSituBridge.cpp
+++ b/Src/Extern/SENSEI/AMReX_InSituBridge.cpp
@@ -47,14 +47,14 @@ InSituBridge::initialize()
     // read config from ParmParse
     ParmParse pp("sensei");
 
-    pp.query("enabled", enabled);
+    pp.queryAdd("enabled", enabled);
 
     if (!enabled)
         return 0;
 
-    pp.query("config", config);
-    pp.query("frequency", frequency);
-    pp.query("pin_mesh", pinMesh);
+    pp.queryAdd("config", config);
+    pp.queryAdd("frequency", frequency);
+    pp.queryAdd("pin_mesh", pinMesh);
 
     amrex::Print() << "SENSEI Begin initialize..." << std::endl;
 

--- a/Src/F_Interfaces/Octree/AMReX_octree_fi.cpp
+++ b/Src/F_Interfaces/Octree/AMReX_octree_fi.cpp
@@ -40,17 +40,17 @@ extern "C" {
         pp.add("blocking_factor", blocking_factor);
 
         int max_grid_size_x = max_grid_size;
-        pp.query("max_grid_size_x", max_grid_size_x);
+        pp.queryAdd("max_grid_size_x", max_grid_size_x);
         int blocking_factor_x = 2*max_grid_size_x;
         pp.add("blocking_factor_x", blocking_factor_x);
 
         int max_grid_size_y = max_grid_size;
-        pp.query("max_grid_size_y", max_grid_size_y);
+        pp.queryAdd("max_grid_size_y", max_grid_size_y);
         int blocking_factor_y = 2*max_grid_size_y;
         pp.add("blocking_factor_y", blocking_factor_y);
 
         int max_grid_size_z = max_grid_size;
-        pp.query("max_grid_size_z", max_grid_size_z);
+        pp.queryAdd("max_grid_size_z", max_grid_size_z);
         int blocking_factor_z = 2*max_grid_size_z;
         pp.add("blocking_factor_z", blocking_factor_z);
 

--- a/Src/LinearSolvers/MLMG/AMReX_MLLinOp.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLLinOp.cpp
@@ -95,13 +95,13 @@ namespace {
 void MLLinOp::Initialize ()
 {
     ParmParse pp("mg");
-    pp.query("consolidation_threshold", consolidation_threshold);
-    pp.query("consolidation_ratio", consolidation_ratio);
-    pp.query("consolidation_strategy", consolidation_strategy);
-    pp.query("verbose_linop", flag_verbose_linop);
-    pp.query("comm_cache", flag_comm_cache);
-    pp.query("mota", flag_use_mota);
-    pp.query("remap_nbh_lb", remap_nbh_lb);
+    pp.queryAdd("consolidation_threshold", consolidation_threshold);
+    pp.queryAdd("consolidation_ratio", consolidation_ratio);
+    pp.queryAdd("consolidation_strategy", consolidation_strategy);
+    pp.queryAdd("verbose_linop", flag_verbose_linop);
+    pp.queryAdd("comm_cache", flag_comm_cache);
+    pp.queryAdd("mota", flag_use_mota);
+    pp.queryAdd("remap_nbh_lb", remap_nbh_lb);
 
 #ifdef BL_USE_MPI
     comm_cache = std::make_unique<CommCache>();

--- a/Src/Particle/AMReX_ParticleContainerBase.cpp
+++ b/Src/Particle/AMReX_ParticleContainerBase.cpp
@@ -129,7 +129,7 @@ int ParticleContainerBase::MaxReaders ()
         first = false;
         ParmParse pp("particles");
         Max_Readers = Max_Readers_def;
-        pp.query("nreaders", Max_Readers);
+        pp.queryAdd("nreaders", Max_Readers);
         Max_Readers = std::min(ParallelDescriptor::NProcs(),Max_Readers);
         if (Max_Readers <= 0)
         {
@@ -155,7 +155,7 @@ Long ParticleContainerBase::MaxParticlesPerRead ()
         first = false;
         ParmParse pp("particles");
         Max_Particles_Per_Read = Max_Particles_Per_Read_def;
-        pp.query("nparts_per_read", Max_Particles_Per_Read);
+        pp.queryAdd("nparts_per_read", Max_Particles_Per_Read);
         if (Max_Particles_Per_Read <= 0)
         {
             amrex::Abort("particles.nparts_per_read must be positive");
@@ -175,7 +175,7 @@ const std::string& ParticleContainerBase::AggregationType ()
         first = false;
         aggregation_type = "None";
         ParmParse pp("particles");
-        pp.query("aggregation_type", aggregation_type);
+        pp.queryAdd("aggregation_type", aggregation_type);
         if (!(aggregation_type == "None" || aggregation_type == "Cell"))
         {
             amrex::Abort("particles.aggregation_type not implemented.");
@@ -195,7 +195,7 @@ int ParticleContainerBase::AggregationBuffer ()
         first = false;
         aggregation_buffer = 2;
         ParmParse pp("particles");
-        pp.query("aggregation_buffer", aggregation_buffer);
+        pp.queryAdd("aggregation_buffer", aggregation_buffer);
         if (aggregation_buffer <= 0)
         {
             amrex::Abort("particles.aggregation_buffer must be positive");

--- a/Src/Particle/AMReX_ParticleContainerI.H
+++ b/Src/Particle/AMReX_ParticleContainerI.H
@@ -55,7 +55,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator> :: 
                       "sizeof ParticleType is not a multiple of sizeof RealType");
 
         ParmParse pp("particles");
-        pp.query("do_tiling", do_tiling);
+        pp.queryAdd("do_tiling", do_tiling);
         Vector<int> tilesize(AMREX_SPACEDIM);
         if (pp.queryarr("tile_size", tilesize, 0, AMREX_SPACEDIM)) {
             for (int i=0; i<AMREX_SPACEDIM; ++i) tile_size[i] = tilesize[i];
@@ -66,9 +66,9 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator> :: 
         //                   && std::is_trivial<ParticleType>::value,
         //                      "Particle type must be standard layout and trivial.");
 
-        pp.query("use_prepost", usePrePost);
-        pp.query("do_unlink", doUnlink);
-        pp.query("do_mem_efficient_sort", memEfficientSort);
+        pp.queryAdd("use_prepost", usePrePost);
+        pp.queryAdd("do_unlink", doUnlink);
+        pp.queryAdd("do_mem_efficient_sort", memEfficientSort);
 
         initialized = true;
     }

--- a/Src/Particle/AMReX_ParticleIO.H
+++ b/Src/Particle/AMReX_ParticleIO.H
@@ -607,7 +607,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>
 
     int DATA_Digits_Read(5);
     ParmParse pp("particles");
-    pp.query("datadigits_read",DATA_Digits_Read);
+    pp.queryAdd("datadigits_read",DATA_Digits_Read);
 
     std::string fullname = dir;
     if (!fullname.empty() && fullname[fullname.size()-1] != '/')

--- a/Src/Particle/AMReX_TracerParticles.cpp
+++ b/Src/Particle/AMReX_TracerParticles.cpp
@@ -225,7 +225,7 @@ TracerParticleContainer::Timestamp (const std::string&      basename,
     // We'll spread the output over this many files.
     int nOutFiles(64);
     ParmParse pp("particles");
-    pp.query("particles_nfiles",nOutFiles);
+    pp.queryAdd("particles_nfiles",nOutFiles);
     if(nOutFiles == -1) {
       nOutFiles = NProcs;
     }

--- a/Src/Particle/AMReX_WriteBinaryParticleData.H
+++ b/Src/Particle/AMReX_WriteBinaryParticleData.H
@@ -448,7 +448,7 @@ void WriteBinaryParticleDataSync (PC const& pc,
     int nOutFiles(256);
 
     ParmParse pp("particles");
-    pp.query("particles_nfiles",nOutFiles);
+    pp.queryAdd("particles_nfiles",nOutFiles);
     if(nOutFiles == -1) nOutFiles = NProcs;
     nOutFiles = std::max(1, std::min(nOutFiles,NProcs));
     pc.nOutFilesPrePost = nOutFiles;


### PR DESCRIPTION
Add a new member function, queryAdd, to ParmParse.  If the name is found,
the value in the ParmParse database will be stored in the reference
argument.  If not, the value in the argument will be added to the ParmParse
database.  The return value indicates if it existed previously.

Many codes use ParmParse::dumpTable to store the ParmParse data in
plot/checkpoint files.  But for parameters that not present in inputs files
or command line arguments, they would not appear in the dumped tables.  The
new queryAdd function can be used to address this issue.

In amrex/Src, the calls to `query` are replaced by `queryAdd` so that it's
easy to find their values.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
