### PR TITLE
Update locations from `amrex/Tutorials`

### DIFF
--- a/Docs/sphinx_documentation/source/AmrCore.rst
+++ b/Docs/sphinx_documentation/source/AmrCore.rst
@@ -47,7 +47,7 @@ AmrMesh and AmrCore
 -------------------
 
 For single-level simulations
-(see e.g., ``amrex/Tutorials/Basic/HeatEquation_EX1_C/main.cpp``)
+(see e.g., ``amrex-tutorials/ExampleCodes/Basic/HeatEquation_EX1_C/main.cpp``)
 the user needs to build :cpp:`Geometry`, :cpp:`DistributionMapping`,
 and :cpp:`BoxArray` objects associated with the simulation. For simulations
 with multiple levels of refinement, the :cpp:`AmrMesh` class can be thought
@@ -157,7 +157,7 @@ class :cpp:`AmrCoreAdv`.
     virtual void ClearLevel (int lev) = 0;
 
 Refer to the :cpp:`AmrCoreAdv` class in the
-``amrex/Tutorials/Amr/AmrCore_Advection/Source``
+``amrex-tutorials/ExampleCodes/Amr/AmrCore_Advection/Source``
 code for a sample implementation.
 
 TagBox, and Cluster
@@ -184,7 +184,7 @@ FillPatchUtil and Interpolater
    up since the :cpp:`FillPatch` routines call them.  In fact it is possible to
    avoid using the single-level calls directly if you fill all your grids and
    ghost cells using the :cpp:`FillPatch` routines.  Refer to
-   ``amrex/Tutorials/Amr/Advection_AmrCore/`` for an example.  The class
+   ``amrex-tutorials/ExampleCodes/Amr/Advection_AmrCore/`` for an example.  The class
    :cpp:`PhysBCFunct` in ``amrex/Src/Base/AMReX_PhysBCFunct.cpp``
    contains a :cpp:`Vector<BCRec>`, :cpp:`Geometry`, and a functor
    handling external Dirichlet boundaries, and provides an

--- a/Docs/sphinx_documentation/source/AmrCore_Chapter.rst
+++ b/Docs/sphinx_documentation/source/AmrCore_Chapter.rst
@@ -29,7 +29,7 @@ simulation code without these additional classes.
 In this Chapter, we restrict our use to the ``amrex/Src/AmrCore`` source code
 and present a tutorial that performs an adaptive, subcycling-in-time simulation
 of the advection equation for a passively advected scalar.  The accompanying
-tutorial code is available in ``amrex/Tutorials/Amr/Advection_AmrCore`` with
+tutorial code is available in ``amrex-tutorials/ExampleCodes/Amr/Advection_AmrCore`` with
 build/run directory ``Exec/SingleVortex``. In this example, the velocity field
 is a specified function of space and time, such that an initial Gaussian
 profile is displaced but returns to its original configuration at the final

--- a/Docs/sphinx_documentation/source/AmrLevel_Chapter.rst
+++ b/Docs/sphinx_documentation/source/AmrLevel_Chapter.rst
@@ -38,7 +38,7 @@ inherit directly from :cpp:`AmrLevel`. These include:
    contains a derived class :cpp:`PeleLM` that also inherits from
    :cpp:`NavierStokesBase` (but does not use :cpp:`NavierStokes`).
 
-The tutorial code in ``amrex/Tutorials/Amr/Advection_AmrLevel`` gives a simple
+The tutorial code in ``amrex-tutorials/ExampleCodes/Amr/Advection_AmrLevel`` gives a simple
 example of a class derived from :cpp:`AmrLevel` that can be used to solve the
 advection equation on a subcycling-in-time AMR hierarchy. Note that example is
 essentially the same as the `Advection AmrCore`_ tutorial and

--- a/Docs/sphinx_documentation/source/Basics_Chapter.rst
+++ b/Docs/sphinx_documentation/source/Basics_Chapter.rst
@@ -8,7 +8,7 @@ codes are in ``amrex/Src/Base/``. Note that AMReX classes and functions are in
 namespace ``amrex``. For clarity, we usually drop ``amrex::`` in the example
 codes here. It is also assumed that headers have been properly included. We
 recommend you study the tutorial in
-``amrex/Tutorials/Basic/HeatEquation_EX1_C`` while reading this chapter.  After
+``amrex-tutorials/ExampleCodes/Basic/HeatEquation_EX1_C`` while reading this chapter.  After
 reading this chapter, one should be able to develop single-level parallel codes
 using AMReX. It should also be noted that this is not a comprehensive reference
 manual.

--- a/Docs/sphinx_documentation/source/BuildingAMReX.rst
+++ b/Docs/sphinx_documentation/source/BuildingAMReX.rst
@@ -17,7 +17,7 @@ Dissecting a Simple Make File
 -----------------------------
 
 An example of building with GNU Make can be found in
-``amrex/Tutorials/Basic/HelloWorld_C``.  :numref:`tab:makevars` below shows a
+``amrex-tutorials/ExampleCodes/Basic/HelloWorld_C``.  :numref:`tab:makevars` below shows a
 list of important variables.
 
 .. raw:: latex
@@ -77,7 +77,7 @@ list of important variables.
 
    \end{center}
 
-At the beginning of ``amrex/Tutorials/Basic/HelloWorld_C/GNUmakefile``,
+At the beginning of ``amrex-tutorials/ExampleCodes/Basic/HelloWorld_C/GNUmakefile``,
 ``AMREX_HOME`` is set to the path to the top directory of AMReX.  Note that in
 the example :cpp:`?=` is a conditional variable assignment operator that only
 has an effect if ``AMREX_HOME`` has not been defined (including in the

--- a/Docs/sphinx_documentation/source/GettingStarted.rst
+++ b/Docs/sphinx_documentation/source/GettingStarted.rst
@@ -18,7 +18,7 @@ you have spack installed, simply type "spack install amrex".
 Example: Hello World
 ====================
 
-The source code of this example is at ``amrex/Tutorials/Basic/HelloWorld_C/``
+The source code of this example is at ``amrex-tutorials/ExampleCodes/Basic/HelloWorld_C/``
 and is also shown below.
 
 .. highlight:: c++
@@ -48,13 +48,13 @@ AMReX.H). All AMReX C++ functions are in the :cpp:`amrex` namespace.
 Building the Code
 -----------------
 
-You build the code in the ``amrex/Tutorials/Basic/HelloWorld_C/`` directory.
+You build the code in the ``amrex-tutorials/Tutorials/Basic/HelloWorld_C/`` directory.
 Typing ``make`` will start the compilation process and result in an executable
 named ``main3d.gnu.DEBUG.ex``. The name shows that the GNU compiler with debug
 options set by AMReX is used.  It also shows that the executable is built for
 3D. Although this simple example code is dimension independent, dimensionality
 does matter for all non-trivial examples. The build process can be adjusted by
-modifying the ``amrex/Tutorials/Basic/HelloWorld_C/GNUmakefile`` file.  More
+modifying the ``amrex-tutorials/Tutorials/Basic/HelloWorld_C/GNUmakefile`` file.  More
 details on how to build AMReX can be found in :ref:`Chap:BuildingAMReX`.
 
 Running the Code
@@ -169,7 +169,7 @@ Example: Heat Equation Solver
 =============================
 
 We now look at a more complicated example at
-``amrex/Tutorials/Basic/HeatEquation_EX1_C`` and show how simulation results
+``amrex-tutorials/ExampleCodes/Basic/HeatEquation_EX1_C`` and show how simulation results
 can be visualized. This example solves the heat equation,
 
 .. math:: \frac{\partial\phi}{\partial t} = \nabla^2\phi
@@ -198,7 +198,7 @@ Building and Running the Code
 -----------------------------
 
 To build a 2D executable, go to
-``amrex/Tutorials/Basic/HeatEquation_EX1_C/Exec`` and type ``make DIM=2``. This
+``amrex-tutorials/ExampleCodes/Basic/HeatEquation_EX1_C/Exec`` and type ``make DIM=2``. This
 will generate an executable named ``main2d.gnu.ex``. To run it, type,
 
 .. highlight:: console

--- a/Docs/sphinx_documentation/source/LinearSolvers_Chapter.rst
+++ b/Docs/sphinx_documentation/source/LinearSolvers_Chapter.rst
@@ -47,7 +47,7 @@ cell-centered velocity.
 
 The tutorials in `Linear Solvers`_ show examples of
 using the solvers.  The tutorial
-``amrex/Tutorials/Basic/HeatEquation_EX3_C`` shows how to solve the
+``amrex-tutorials/ExampleCodes/Basic/HeatEquation_EX3_C`` shows how to solve the
 heat equation implicitly using the solver.  The tutorials also show
 how to add linear solvers into the build system.
 

--- a/Docs/sphinx_documentation/source/Particle.rst
+++ b/Docs/sphinx_documentation/source/Particle.rst
@@ -771,4 +771,4 @@ running on GPU platforms like Summit. We recommend leaving it off.
    Note that for the extra particle components, which component refers to which
    variable is an application-specific convention - the particles have 4 extra real comps, but which one is "mass" is up
    to the user. We suggest using an :cpp:`enum` to keep these indices straight; please
-   see ``amrex/Tutorials/Particles/ElectrostaticPIC/ElectrosticParticleContainer.H`` for an example of this.
+   see ``amrex-tutorials/ExampleCodes/Particles/ElectrostaticPIC/ElectrosticParticleContainer.H`` for an example of this.

--- a/Docs/sphinx_documentation/source/Visualization.rst
+++ b/Docs/sphinx_documentation/source/Visualization.rst
@@ -231,7 +231,7 @@ done using the command:
 
 ::
 
-    ~/amrex/Tutorials/Basic/HeatEquation_EX1_C> ls -1 plt*/Header | tee movie.visit
+    ~/amrex-tutorials/ExampleCodes/Basic/HeatEquation_EX1_C> ls -1 plt*/Header | tee movie.visit
     plt00000/Header
     plt01000/Header
     plt02000/Header
@@ -908,7 +908,8 @@ simulation will periodically write images during the run.
    ssh cori.nersc.gov
    cd $SCRATCH
    git clone https://github.com/AMReX-Codes/amrex.git
-   cd amrex/Tutorials/Amr/Advection_AmrLevel/Exec/SingleVortex
+   git clone https://github.com/AMReX-Codes/amrex-tutorials.git
+   cd amrex-tutorials/ExampleCodes/Amr/Advection_AmrLevel/Exec/SingleVortex
    module use /usr/common/software/sensei/modulefiles
    module load sensei/2.1.0-catalyst-shared
    source sensei_config
@@ -919,7 +920,7 @@ simulation will periodically write images during the run.
    # sensei.enabled=1
    # sensei.config=sensei/render_iso_catalyst_2d.xml
    salloc -C haswell -N 1 -t 00:30:00 -q debug
-   cd $SCRATCH/amrex/Tutorials/Amr/Advection_AmrLevel/Exec/SingleVortex
+   cd $SCRATCH/amrex-tutorials/ExampleCodes/Amr/Advection_AmrLevel/Exec/SingleVortex
    ./main2d.gnu.haswell.MPI.ex inputs
 
 
@@ -933,7 +934,8 @@ simulation will periodically write images during the run.
    ssh cori.nersc.gov
    cd $SCRATCH
    git clone https://github.com/AMReX-Codes/amrex.git
-   cd amrex/Tutorials/Amr/Advection_AmrLevel/Exec/SingleVortex
+   git clone https://github.com/AMReX-Codes/amrex-tutorials.git
+   cd amrex-tutorials/ExampleCodes/Amr/Advection_AmrLevel/Exec/SingleVortex
    module use /usr/common/software/sensei/modulefiles
    module load sensei/2.1.0-libsim-shared
    source sensei_config
@@ -944,5 +946,6 @@ simulation will periodically write images during the run.
    # sensei.enabled=1
    # sensei.config=sensei/render_iso_libsim_2d.xml
    salloc -C haswell -N 1 -t 00:30:00 -q debug
+   cd $SCRATCH/amrex-tutorials/ExampleCodes/Amr/Advection_AmrLevel/Exec/SingleVortex
    ./main2d.gnu.haswell.MPI.ex inputs
 


### PR DESCRIPTION
## Summary
Many tutorials are listed as residing at `amrex/Tutorials/...`. They have been updated to their new
location at `amrex-tutorials/ExampleCodes/...`.

## Additional background
The updated locations cause straightforward changes to the Catalyst and Libsim tutorials in Visualizations.rst (line 901 and 927). I made these changes but I did not retest the tutorials. I'll put this on my list, and update if any changes are necessary. 

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [x] include documentation in the code and/or rst files, if appropriate
