### PR TITLE
HIP: Add -munsafe-fp-atomics to CMake

### DIFF
--- a/Tools/CMake/AMReXParallelBackends.cmake
+++ b/Tools/CMake/AMReXParallelBackends.cmake
@@ -281,6 +281,10 @@ if (AMReX_HIP)
 
    target_compile_options(amrex PUBLIC $<$<COMPILE_LANGUAGE:CXX>:-m64>)
 
+   # ROCm 4.5: use unsafe floating point atomics, otherwise atomicAdd is much slower
+   # 
+   target_compile_options(amrex PUBLIC $<$<COMPILE_LANGUAGE:CXX>:-munsafe-fp-atomics>)
+
    # Equivalently, relocatable-device-code (RDC) flags are needed for `extern`
    # device variable support (for codes that use global variables on device)
    # as well as our kernel fusion in AMReX, e.g. happening likely in amr regrid


### PR DESCRIPTION
## Summary

Otherwise atomicAdd is much slower. Same as already done in GNU Make  #2567

## Additional background

- #2567 
- https://reviews.llvm.org/D91546?id=305522
- https://reviews.llvm.org/D97967 (https://llvm-gpu-news.github.io/2021/03/05/issue-7.html)

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
