### PR TITLE
Enable CUDA in CMakeList.txt for Spack smoke test.

### DIFF
--- a/Tests/SpackSmokeTest/CMakeLists.txt
+++ b/Tests/SpackSmokeTest/CMakeLists.txt
@@ -17,43 +17,61 @@ set(_src_dir   ${_base_dir}/Source)
 set(_input_dir ${_base_dir}/Exec)
 
 
-# Use installed version of AMReX
-find_package(AMReX REQUIRED)
+if (AMReX_GPU_BACKEND STREQUAL "CUDA")
+    enable_language(CUDA)
+    find_package(AMReX REQUIRED CUDA)
+else()
+   # Use installed version of AMReX
+   find_package(AMReX REQUIRED)
+endif()
 
 if (AMReX_3D_FOUND)
-   set(_dim 3)
+    set(_dim 3)
 elseif (AMReX_2D_FOUND)
-   set(_dim 2)
+    set(_dim 2)
 else ()
-   message(FATAL_ERROR "Cannot find a 2D or 3D version of AMReX")
+    message(FATAL_ERROR "Cannot find a 2D or 3D version of AMReX")
 endif ()
 
 
 add_executable(install_test)
 
-target_link_libraries(install_test PUBLIC AMReX::amrex)
-
 target_include_directories(install_test
-   PUBLIC
-   ${_src_dir}
-   ${_src_dir}/Src_K/
-   ${_input_dir}
-   )
+    PUBLIC
+    ${_src_dir}
+    ${_src_dir}/Src_K/
+    ${_input_dir}
+    )
 
 target_sources(install_test
-   PRIVATE
-   ${_src_dir}/AdvancePhiAllLevels.cpp
-   ${_src_dir}/AdvancePhiAtLevel.cpp
-   ${_src_dir}/AmrCoreAdv.cpp
-   ${_src_dir}/AmrCoreAdv.H
-   ${_src_dir}/bc_fill.H
-   ${_src_dir}/DefineVelocity.cpp
-   ${_src_dir}/face_velocity.H
-   ${_src_dir}/Kernels.H
-   ${_src_dir}/main.cpp
-   ${_src_dir}/Tagging.H
-   ${_src_dir}/Src_K/Adv_K.H
-   ${_src_dir}/Src_K/compute_flux_2D_K.H
-   ${_src_dir}/Src_K/slope_K.H
-   ${_input_dir}/Prob.H
-   )
+    PRIVATE
+    ${_src_dir}/AdvancePhiAllLevels.cpp
+    ${_src_dir}/AdvancePhiAtLevel.cpp
+    ${_src_dir}/AmrCoreAdv.cpp
+    ${_src_dir}/AmrCoreAdv.H
+    ${_src_dir}/bc_fill.H
+    ${_src_dir}/DefineVelocity.cpp
+    ${_src_dir}/face_velocity.H
+    ${_src_dir}/Kernels.H
+    ${_src_dir}/main.cpp
+    ${_src_dir}/Tagging.H
+    ${_src_dir}/Src_K/Adv_K.H
+    ${_src_dir}/Src_K/compute_flux_2D_K.H
+    ${_src_dir}/Src_K/slope_K.H
+    ${_input_dir}/Prob.H
+    )
+
+target_link_libraries(install_test PUBLIC AMReX::amrex)
+
+
+# Additional CUDA configuration commands
+if (AMReX_GPU_BACKEND STREQUAL "CUDA")
+    set_target_properties(install_test PROPERTIES
+        LANGUAGE CUDA
+        CUDA_ARCHITECTURES "${AMREX_CUDA_ARCHS}"
+        CUDA_SEPARABLE_COMPILATION  ON)
+
+    get_target_property(Source_Files install_test SOURCES)
+    list(FILTER Source_Files INCLUDE REGEX "\\.cpp$")
+    set_source_files_properties(${Source_Files} PROPERTIES LANGUAGE CUDA)
+endif()


### PR DESCRIPTION
## Summary
Adds the necessary lines to CMakeLists.txt to enable CMake to compile the Spack smoke test with CUDA. 

## Additional background
Tested on spack/develop. Passed, but requires an extra step to make sure the CUDA compilers match. Next step is to adjust the smoke test script for AMReX in Spack. 

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
