### PR TITLE
HIP: amdclang++

### DIFF
--- a/Tools/CMake/AMReXParallelBackends.cmake
+++ b/Tools/CMake/AMReXParallelBackends.cmake
@@ -176,7 +176,7 @@ endif ()
 #
 if (AMReX_HIP)
 
-   set(_valid_hip_compilers clang++ hipcc nvcc CC)
+   set(_valid_hip_compilers clang++ amdclang++ hipcc nvcc CC)
    get_filename_component(_this_comp ${CMAKE_CXX_COMPILER} NAME)
 
    if (NOT (_this_comp IN_LIST _valid_hip_compilers) )


### PR DESCRIPTION
## Summary

On Crusher, `clang++` from AMD is named `amdclang++`.
Add this to the known compiler name list and do not warn when encountered.

## Additional background

https://docs.olcf.ornl.gov/systems/crusher_quick_start_guide.html

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
