### PR TITLE
Default Arena for MultiFab/iMultiFab/FabArray

### DIFF
--- a/Src/Base/AMReX_FabArray.H
+++ b/Src/Base/AMReX_FabArray.H
@@ -324,7 +324,15 @@ public:
 
     //
     //! Constructs an empty FabArray<FAB>.
-    FabArray ();
+    FabArray () noexcept;
+
+    /**
+     * \brief Construct an empty FabArray<FAB> that has a default Arena.  If
+     * `define` is called later with a nulltpr as MFInfo's arena, the
+     * default Arena `a` will be used.  If the arena in MFInfo is not a
+     * nullptr, the MFInfo's arena will be used.
+     */
+    FabArray (Arena* a) noexcept;
 
     /**
     * \brief Construct a FabArray<FAB> with a valid region defined by bxs
@@ -1551,8 +1559,16 @@ FabArray<FAB>::setVal (value_type val, const Box& region, const IntVect& nghost)
 }
 
 template <class FAB>
-FabArray<FAB>::FabArray ()
+FabArray<FAB>::FabArray () noexcept
     : shmem()
+{
+    m_FA_stats.recordBuild();
+}
+
+template <class FAB>
+FabArray<FAB>::FabArray (Arena* a) noexcept
+    : m_dallocator(a),
+      shmem()
 {
     m_FA_stats.recordBuild();
 }
@@ -1714,10 +1730,11 @@ FabArray<FAB>::define (const BoxArray&            bxs,
 {
     std::unique_ptr<FabFactory<FAB> > factory(a_factory.clone());
 
+    auto default_arena = m_dallocator.m_arena;
     clear();
 
     m_factory = std::move(factory);
-    m_dallocator.m_arena = info.arena;
+    m_dallocator.m_arena = info.arena ? info.arena : default_arena;
 
     define_function_called = true;
 
@@ -1728,7 +1745,7 @@ FabArray<FAB>::define (const BoxArray&            bxs,
     addThisBD();
 
     if(info.alloc) {
-        AllocFabs(*m_factory, info.arena, info.tags);
+        AllocFabs(*m_factory, m_dallocator.m_arena, info.tags);
         Gpu::synchronize();
 #ifdef BL_USE_TEAM
         ParallelDescriptor::MyTeam().MemoryBarrier();

--- a/Src/Base/AMReX_FabArray.H
+++ b/Src/Base/AMReX_FabArray.H
@@ -332,7 +332,7 @@ public:
      * default Arena `a` will be used.  If the arena in MFInfo is not a
      * nullptr, the MFInfo's arena will be used.
      */
-    FabArray (Arena* a) noexcept;
+    explicit FabArray (Arena* a) noexcept;
 
     /**
     * \brief Construct a FabArray<FAB> with a valid region defined by bxs

--- a/Src/Base/AMReX_MultiFab.H
+++ b/Src/Base/AMReX_MultiFab.H
@@ -51,7 +51,7 @@ public:
     * Arena `a` will be used.  If the arena in MFInfo is not a nullptr, the
     * MFInfo's arena will be used.
     */
-    MultiFab (Arena* a) noexcept;
+    explicit MultiFab (Arena* a) noexcept;
 
     /**
     * \brief

--- a/Src/Base/AMReX_MultiFab.H
+++ b/Src/Base/AMReX_MultiFab.H
@@ -43,6 +43,16 @@ public:
     * from FabArray.
     */
     MultiFab () noexcept;
+
+    /**
+    * \brief Constructs an empty MultiFab.  Data can be defined at a later
+    * time using the define member functions inherited from FabArray.  If
+    * `define` is called later with a nulltpr as MFInfo's arena, the default
+    * Arena `a` will be used.  If the arena in MFInfo is not a nullptr, the
+    * MFInfo's arena will be used.
+    */
+    MultiFab (Arena* a) noexcept;
+
     /**
     * \brief
     * Constructs a MultiFab

--- a/Src/Base/AMReX_MultiFab.cpp
+++ b/Src/Base/AMReX_MultiFab.cpp
@@ -651,6 +651,15 @@ MultiFab::MultiFab () noexcept
 #endif
 }
 
+MultiFab::MultiFab (Arena* a) noexcept
+    : FabArray<FArrayBox>(a)
+{
+#ifdef AMREX_MEM_PROFILING
+    ++num_multifabs;
+    num_multifabs_hwm = std::max(num_multifabs_hwm, num_multifabs);
+#endif
+}
+
 MultiFab::MultiFab (const BoxArray&            bxs,
                     const DistributionMapping& dm,
                     int                        ncomp,

--- a/Src/Base/AMReX_iMultiFab.H
+++ b/Src/Base/AMReX_iMultiFab.H
@@ -46,7 +46,7 @@ public:
     * Arena `a` will be used.  If the arena in MFInfo is not a nullptr, the
     * MFInfo's arena will be used.
     */
-    iMultiFab (Arena* a) noexcept;
+    explicit iMultiFab (Arena* a) noexcept;
 
     /**
     * \brief Constructs a iMultiFab with a valid region defined by bxs and

--- a/Src/Base/AMReX_iMultiFab.H
+++ b/Src/Base/AMReX_iMultiFab.H
@@ -37,7 +37,17 @@ public:
     * time using the define member functions inherited
     * from FabArray.
     */
-    iMultiFab ();
+    iMultiFab () noexcept;
+
+    /**
+    * \brief Constructs an empty iMultiFab.  Data can be defined at a later
+    * time using the define member functions inherited from FabArray.  If
+    * `define` is called later with a nulltpr as MFInfo's arena, the default
+    * Arena `a` will be used.  If the arena in MFInfo is not a nullptr, the
+    * MFInfo's arena will be used.
+    */
+    iMultiFab (Arena* a) noexcept;
+
     /**
     * \brief Constructs a iMultiFab with a valid region defined by bxs and
     * a region of definition defined by the grow factor ngrow.

--- a/Src/Base/AMReX_iMultiFab.cpp
+++ b/Src/Base/AMReX_iMultiFab.cpp
@@ -161,7 +161,11 @@ iMultiFab::Finalize ()
     initialized = false;
 }
 
-iMultiFab::iMultiFab () {}
+iMultiFab::iMultiFab () noexcept {}
+
+iMultiFab::iMultiFab (Arena* a) noexcept
+    : FabArray<IArrayBox>(a)
+{}
 
 iMultiFab::iMultiFab (const BoxArray&            bxs,
                       const DistributionMapping& dm,


### PR DESCRIPTION
Add a new constructor to MultiFab/iMultiFab/FabArray that can be used to set
the default constructor that will be used when `define` is called with
MFInfo containing a nullptr as Arena.  Below is an example of using this.

    MultiFab mf(The_Pinned_Arena());
    MultiFab mf2;
    VisMF::Read(mf, "mf");
    VisMF::Read(mf2, "mf2");
    // mf is allocated with The_Pinned_Arena(), whereas mf2 is allocated
    // with The_Arena(), in VisMF::Read.

## Summary

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
