### PR TITLE
Change FPinfo's fact_fine_patch to always have ng=1.

### DIFF
--- a/Src/Base/AMReX_FabArrayBase.cpp
+++ b/Src/Base/AMReX_FabArrayBase.cpp
@@ -1795,7 +1795,7 @@ FabArrayBase::FPinfo::FPinfo (const FabArrayBase& srcfa,
                                            ba_crse_patch,
                                            dm_patch,
                                            {0,0,0}, EBSupport::basic);
-        int ng = boxtype.cellCentered() ? 0 : 1; // to avoid dengerate box
+        int ng = 1; // to avoid dengerate box
         fact_fine_patch = makeEBFabFactory(index_space,
                                            index_space->getGeometry(fdomain),
                                            ba_fine_patch,


### PR DESCRIPTION
This fixes a problem when using face_centered FillPatchTwoLevels
with EB and an odd number of ghost cells, and fact_fine_patch's
ebflag fab's box was too small.

## Summary

## Additional background

## Checklist

The proposed changes:
- [x ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
