### PR TITLE
Overloading reducesum with 4 multifabs

### DIFF
--- a/Src/Base/AMReX_FabArrayUtility.H
+++ b/Src/Base/AMReX_FabArrayUtility.H
@@ -327,6 +327,91 @@ ReduceSum (FabArray<FAB1> const& fa1, FabArray<FAB2> const& fa2,
 }
 #endif
 
+template <class FAB1, class FAB2, class FAB3, class FAB4, class F,
+          class bar = std::enable_if_t<IsBaseFab<FAB1>::value> >
+typename FAB1::value_type
+ReduceSum (FabArray<FAB1> const& fa1, FabArray<FAB2> const& fa2, FabArray<FAB3> const& fa3, FabArray<FAB4> const& fa4,
+           int nghost, F&& f)
+{
+  return ReduceSum(fa1, fa2, fa3, fa4, IntVect(nghost), std::forward<F>(f));
+}
+
+namespace fudetail {
+template <class FAB1, class FAB2, class FAB3, class FAB4, class F,
+          class bar = std::enable_if_t<IsBaseFab<FAB1>::value> >
+typename FAB1::value_type
+ReduceSum_host (FabArray<FAB1> const& fa1, FabArray<FAB2> const& fa2,
+                FabArray<FAB3> const& fa3, FabArray<FAB4> const& fa4,
+                IntVect const& nghost, F&& f)
+{
+    using value_type = typename FAB1::value_type;
+    value_type sm = 0;
+
+#ifdef AMREX_USE_OMP
+#pragma omp parallel if (!system::regtest_reduction) reduction(+:sm)
+#endif
+    for (MFIter mfi(fa1,true); mfi.isValid(); ++mfi)
+    {
+        const Box& bx = mfi.growntilebox(nghost);
+        const auto& arr1 = fa1.const_array(mfi);
+        const auto& arr2 = fa2.const_array(mfi);
+        const auto& arr3 = fa3.const_array(mfi);
+        const auto& arr4 = fa4.const_array(mfi);
+        sm += f(bx, arr1, arr2, arr3, arr4);
+    }
+
+    return sm;
+}
+}
+
+#ifdef AMREX_USE_GPU
+namespace fudetail {
+template <class FAB1, class FAB2, class FAB3, class FAB4, class F>
+std::enable_if_t<!amrex::DefinitelyNotHostRunnable<F>::value, typename FAB1::value_type>
+ReduceSum_host_wrapper (FabArray<FAB1> const& fa1, FabArray<FAB2> const& fa2,
+                        FabArray<FAB3> const& fa3, FabArray<FAB4> const& fa4,
+                        IntVect const& nghost, F&& f)
+{
+    return fudetail::ReduceSum_host(fa1,fa2,fa3,fa4,nghost,std::forward<F>(f));
+}
+
+template <class FAB1, class FAB2, class FAB3, class FAB4, class F>
+std::enable_if_t<amrex::DefinitelyNotHostRunnable<F>::value, typename FAB1::value_type>
+ReduceSum_host_wrapper (FabArray<FAB1> const& fa1, FabArray<FAB2> const& fa2,
+                        FabArray<FAB3> const& fa3, FabArray<FAB4> const& fa4,
+                        IntVect const& nghost, F&& f)
+{
+    amrex::ignore_unused(fa1,fa2,fa3,fa4,nghost,f);
+    amrex::Abort("ReduceSum: Launch Region is off. Device lambda cannot be called by host.");
+    return 0;
+}
+}
+
+template <class FAB1, class FAB2, class FAB3, class FAB4, class F,
+          class bar = std::enable_if_t<IsBaseFab<FAB1>::value> >
+typename FAB1::value_type
+ReduceSum (FabArray<FAB1> const& fa1, FabArray<FAB2> const& fa2,
+           FabArray<FAB3> const& fa3, FabArray<FAB4> const& fa4,
+           IntVect const& nghost, F&& f)
+{
+    if (Gpu::inLaunchRegion()) {
+        return fudetail::ReduceMF<ReduceOpSum>(fa1,fa2,fa3,fa4,nghost,std::forward<F>(f));
+    } else {
+        return fudetail::ReduceSum_host_wrapper(fa1,fa2,fa3,fa4,nghost,std::forward<F>(f));
+    }
+}
+#else
+template <class FAB1, class FAB2, class FAB3, class FAB4, class F,
+          class bar = std::enable_if_t<IsBaseFab<FAB1>::value> >
+typename FAB1::value_type
+ReduceSum (FabArray<FAB1> const& fa1, FabArray<FAB2> const& fa2,
+           FabArray<FAB3> const& fa3, FabArray<FAB4> const& fa4,
+           IntVect const& nghost, F&& f)
+{
+    return fudetail::ReduceSum_host(fa1,fa2,fa3,fa4,nghost,std::forward<F>(f));
+}
+#endif
+
 template <class FAB, class F,
           class bar = std::enable_if_t<IsBaseFab<FAB>::value> >
 typename FAB::value_type


### PR DESCRIPTION
## Summary
Overloading reduce sum to support 4 multifabs

## Additional background
With recent developments in amr-wind, we have noticed a need for using reducesum with 4 multifabs. I have coded this based on the other reducesum overloading calls. Please let me know if there would be a cleaner way for me to implement this. 

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
