### PR TITLE
CI: AMD `hip::device` also for Fortran

### DIFF
--- a/.github/workflows/dependencies/dependencies_hip.sh
+++ b/.github/workflows/dependencies/dependencies_hip.sh
@@ -46,6 +46,7 @@ source /etc/profile.d/rocm.sh
 hipcc --version
 which clang
 which clang++
+which flang
 
 # cmake-easyinstall
 #

--- a/.github/workflows/hip.yml
+++ b/.github/workflows/hip.yml
@@ -7,11 +7,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # MPI_C is broken since HIP 4.1
-  # https://gitlab.kitware.com/cmake/cmake/-/issues/21968
-  # https://github.com/ROCm-Developer-Tools/HIP/issues/2246
   tests-hip:
-    name: HIP ROCm GFortran@9.3 C++17 [tests]
+    name: HIP ROCm Flang C++17 [tests]
     runs-on: ubuntu-20.04
     # Have to have -Wno-deprecated-declarations due to deprecated atomicAddNoRet
     # Have to have -Wno-gnu-zero-variadic-macro-arguments to avoid
@@ -34,25 +31,27 @@ jobs:
         hipcc --version
         which clang
         which clang++
+        which flang
 
         # "mpic++ --showme" forgets open-pal in Ubuntu 20.04 + OpenMPI 4.0.3
         #   https://bugs.launchpad.net/ubuntu/+source/openmpi/+bug/1941786
         #   https://github.com/open-mpi/ompi/issues/9317
         export LDFLAGS="-lopen-pal"
 
-        cmake -S . -B build_nofortran                     \
+        cmake -S . -B build                               \
             -DCMAKE_VERBOSE_MAKEFILE=ON                   \
             -DAMReX_EB=ON                                 \
             -DAMReX_ENABLE_TESTS=ON                       \
             -DAMReX_PARTICLES=ON                          \
-            -DAMReX_FORTRAN=OFF                           \
+            -DAMReX_FORTRAN=ON                            \
             -DAMReX_LINEAR_SOLVERS=ON                     \
             -DAMReX_GPU_BACKEND=HIP                       \
             -DAMReX_AMD_ARCH=gfx908                       \
             -DCMAKE_C_COMPILER=$(which clang)             \
             -DCMAKE_CXX_COMPILER=$(which clang++)         \
+            -DCMAKE_Fortran_COMPILER=$(which flang)       \
             -DCMAKE_CXX_STANDARD=17
-        cmake --build build_nofortran -j 2
+        cmake --build build -j 2
 
   tests-hip-wrapper:
     name: HIP ROCm GFortran@9.3 C++17 [tests-hipcc]

--- a/Tools/CMake/AMReXParallelBackends.cmake
+++ b/Tools/CMake/AMReXParallelBackends.cmake
@@ -231,6 +231,13 @@ if (AMReX_HIP)
    # Cray's CC wrapper that points to AMD's clang++ underneath
    if(NOT ${_this_comp} STREQUAL hipcc)
        target_link_libraries(amrex PUBLIC hip::device)
+
+       # work-around for
+       #   https://github.com/ROCm-Developer-Tools/hipamd/issues/12
+       # not being added for Cray CC
+       target_compile_options(amrex PUBLIC
+          "$<$<COMPILE_LANGUAGE:CXX>:SHELL:-mllvm;-amdgpu-early-inline-all=true;-mllvm;-amdgpu-function-calls=false>"
+       )
    endif()
 
    # Link to hiprand -- must include rocrand too

--- a/Tools/CMake/AMReXParallelBackends.cmake
+++ b/Tools/CMake/AMReXParallelBackends.cmake
@@ -182,8 +182,8 @@ if (AMReX_HIP)
    if (NOT (_this_comp IN_LIST _valid_hip_compilers) )
       message(WARNING "\nCMAKE_CXX_COMPILER (${_this_comp}) is likely "
          "incompatible with HIP.\n"
-         "Set CMAKE_CXX_COMPILER to either AMD's clang++ (preferred) or "
-         "hipcc or nvcc for HIP builds.\n")
+         "Set CMAKE_CXX_COMPILER to either Cray's CC or AMD's clang++/amdclang++ "
+         "or hipcc or nvcc for HIP builds.\n")
    endif ()
 
    unset(_hip_compiler)
@@ -222,29 +222,15 @@ if (AMReX_HIP)
          " Ensure that HIP is either installed in /opt/rocm/hip or the variable HIP_PATH is set to point to the right location.")
    endif()
 
-   if(${_this_comp} STREQUAL hipcc AND NOT AMReX_FORTRAN)
+   if(${_this_comp} STREQUAL hipcc)
        message(WARNING "You are using the legacy wrapper 'hipcc' as the HIP compiler.\n"
-           "This is only needed when building with Fortran support and with ROCm/HIP <=4.2.0. "
-           "Use AMD's 'clang++' compiler instead.")
+           "Use AMD's 'clang++'/'amdclang++' compiler, or on Cray "
+           "the CC compiler wrapper instead.")
    endif()
    # AMD's or mainline clang++ with support for "-x hip"
    # Cray's CC wrapper that points to AMD's clang++ underneath
    if(NOT ${_this_comp} STREQUAL hipcc)
        target_link_libraries(amrex PUBLIC hip::device)
-
-       # work-around for https://github.com/ROCm-Developer-Tools/HIP/issues/2278
-       # CXX_STANDARD always adds -std=c++XX, even if the compiler default fulfills it
-       #set_property(TARGET amrex PROPERTY CXX_STANDARD 17)
-       # note: already bumped to C++17 (cxx_std_17) or newer in AMReX_Config.cmake
-
-       # work-around for ROCm <=4.2
-       # https://github.com/ROCm-Developer-Tools/HIP/pull/2190
-       target_compile_options(amrex PUBLIC
-          "$<$<COMPILE_LANGUAGE:CXX>:SHELL:-mllvm;-amdgpu-early-inline-all=true;-mllvm;-amdgpu-function-calls=false>"
-       )
-       target_compile_options(amrex PUBLIC
-          "$<$<COMPILE_LANGUAGE:CXX>:SHELL:-x hip>"
-       )
    endif()
 
    # Link to hiprand -- must include rocrand too
@@ -261,13 +247,7 @@ if (AMReX_HIP)
 
    # avoid forcing the rocm LLVM flags on a gfortran
    # https://github.com/ROCm-Developer-Tools/HIP/issues/2275
-   if(AMReX_FORTRAN)
-       message(WARNING "As of ROCm/HIP <= 4.2.0, Fortran support might be flaky.\n"
-                       "Especially, we cannot yet support reloctable device code (RDC)."
-                       "See https://github.com/ROCm-Developer-Tools/HIP/issues/2275 "
-                       "and https://github.com/AMReX-Codes/amrex/pull/2031 "
-                       "for details.")
-   elseif(${_this_comp} STREQUAL hipcc)
+   if(${_this_comp} STREQUAL hipcc)
        # hipcc expects a comma-separated list
        string(REPLACE ";" "," AMReX_AMD_ARCH_HIPCC "${AMReX_AMD_ARCH}")
 


### PR DESCRIPTION
## Summary

By now (HIP 4.5), we should be able to link also against Fortran targets.

Let's remove work-arounds and ditch old HIP releases, so improve maintainability and avoid surprises.

## Additional background

X-ref:
- https://github.com/ROCm-Developer-Tools/HIP/pull/2280 (https://github.com/ROCm-Developer-Tools/HIP/pull/2190)
- https://github.com/ROCm-Developer-Tools/HIP/issues/2275

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
