### PR TITLE
Disable EB solver's phi-on-centroid for hip for now

### DIFF
--- a/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap_F.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap_F.cpp
@@ -111,6 +111,10 @@ MLEBABecLap::Fapply (int amrlev, int mglev, MultiFab& out, const MultiFab& in) c
 
             if (treat_phi_as_on_centroid) {
 #ifdef AMREX_USE_HIP
+                // This causes an abort in HIP 4.5 but works in earlier versions
+                // A follow-up release should fix this.
+                // Error message:
+                //   lld: error: ran out of registers during register allocation
                 amrex::Abort("MLEBABecLap::Fapply: phi on centroid not supported for HIP");
                 amrex::ignore_unused(AMREX_D_DECL(domlo_x, domlo_y, domlo_z),
                                      AMREX_D_DECL(domhi_x, domhi_y, domhi_z),

--- a/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap_F.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap_F.cpp
@@ -110,6 +110,13 @@ MLEBABecLap::Fapply (int amrlev, int mglev, MultiFab& out, const MultiFab& in) c
             bool treat_phi_as_on_centroid = ( phi_on_centroid && (mglev == 0) );
 
             if (treat_phi_as_on_centroid) {
+#ifdef AMREX_USE_HIP
+                amrex::Abort("MLEBABecLap::Fapply: phi on centroid not supported for HIP");
+                amrex::ignore_unused(AMREX_D_DECL(domlo_x, domlo_y, domlo_z),
+                                     AMREX_D_DECL(domhi_x, domhi_y, domhi_z),
+                                     AMREX_D_DECL(extdir_x, extdir_y, extdir_z));
+                amrex::ignore_unused(ccfab);
+#else
                AMREX_LAUNCH_HOST_DEVICE_LAMBDA ( bx, tbx,
                {
                    mlebabeclap_adotx_centroid(tbx, yfab, xfab, afab, AMREX_D_DECL(bxfab,byfab,bzfab),
@@ -123,6 +130,7 @@ MLEBABecLap::Fapply (int amrlev, int mglev, MultiFab& out, const MultiFab& in) c
                                      is_eb_dirichlet, is_eb_inhomog, dxinvarr,
                                      ascalar, bscalar, ncomp);
                });
+#endif
             } else {
                AMREX_LAUNCH_HOST_DEVICE_LAMBDA ( bx, tbx,
                {


### PR DESCRIPTION
We need this to work around the out-of-register issue with current
compilers.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
