### PR TITLE
Update FabArray::copyTo

### DIFF
--- a/Src/Base/AMReX_FabArray.H
+++ b/Src/Base/AMReX_FabArray.H
@@ -858,50 +858,21 @@ public:
                        int                  num_comp,
                        const IntVect&       nghost);
 
-    //
-    // In the following copyTo functions, the destination FAB is identical on each process!!
-    //
-
-    /**
-    * brief Copy the values contained in the intersection of the
-    * valid + nghost region of this FabArray with the FAB dest into dest.
-    */
-    void copyTo (FAB& dest,
-                 int  nghost = 0) const;
-
     /**
     * \brief Copy the values contained in the intersection of the
-    * valid + nghost region of this FabArray with the FAB dest and the Box
-    * subbox into that subregion of dest.
+    * valid + nghost region of this FabArray with the FAB dest into dest.
+    * Note that FAB dest is assumed to be identical on each process.
     */
-    void copyTo (FAB&       dest,
-                 const Box& subbox,
-                 int        nghost = 0) const;
+    void copyTo (FAB& dest, int  nghost = 0) const;
 
     /**
     * \brief Copy the values contained in the intersection of the
     * num_comp component valid + nghost region of this FabArray, starting at
     * component src_comp, with the FAB dest into dest, starting at
     * component dest_comp in dest.
+    * Note that FAB dest is assumed to be identical on each process.
     */
-    void copyTo (FAB& dest,
-                 int  src_comp,
-                 int  dest_comp,
-                 int  num_comp,
-                 int  nghost = 0) const;
-
-    /**
-    * \brief Copy the values contained in the intersection of the
-    * num_comp component valid + nghost region of this FabArray, starting at
-    * component src_comp, with the FAB dest and the Box subbox, into
-    * dest, starting at component dest_comp in dest.
-    */
-    void copyTo (FAB&       dest,
-                 const Box& subbox,
-                 int        src_comp,
-                 int        dest_comp,
-                 int        num_comp,
-                 int        nghost = 0) const;
+    void copyTo (FAB& dest, int  src_comp, int  dest_comp, int  num_comp, int  nghost = 0) const;
 
     //! Shift the boxarray by vector v
     void shift (const IntVect& v);
@@ -2110,36 +2081,11 @@ FabArray<FAB>::setDomainBndry (value_type val,
     }
 }
 
-//
-// Copies to FABs, note that destination is first arg.
-//
-
 template <class FAB>
 void
-FabArray<FAB>::copyTo (FAB& dest,
-                       int  nghost) const
+FabArray<FAB>::copyTo (FAB& dest, int  nghost) const
 {
-    copyTo(dest, dest.box(), 0, 0, dest.nComp(), nghost);
-}
-
-template <class FAB>
-void
-FabArray<FAB>::copyTo (FAB&       dest,
-                       const Box& subbox,
-                       int        nghost) const
-{
-    copyTo(dest, subbox, 0, 0, dest.nComp(), nghost);
-}
-
-template <class FAB>
-void
-FabArray<FAB>::copyTo (FAB& dest,
-                       int  scomp,
-                       int  dcomp,
-                       int  ncomp,
-                       int  nghost) const
-{
-    copyTo(dest, dest.box(), scomp, dcomp, ncomp, nghost);
+    copyTo(dest, 0, 0, dest.nComp(), nghost);
 }
 
 template <class FAB>

--- a/Src/Base/AMReX_FabArrayCommI.H
+++ b/Src/Base/AMReX_FabArrayCommI.H
@@ -563,72 +563,48 @@ FabArray<FAB>::ParallelCopy_finish ()
 
 template <class FAB>
 void
-FabArray<FAB>::copyTo (FAB&       dest,
-                       const Box& subbox,
-                       int        scomp,
-                       int        dcomp,
-                       int        ncomp,
-                       int        nghost) const
+FabArray<FAB>::copyTo (FAB& dest, int scomp, int dcomp, int ncomp, int nghost) const
 {
     BL_PROFILE("FabArray::copy(fab)");
 
     BL_ASSERT(dcomp + ncomp <= dest.nComp());
-    BL_ASSERT(nghost <= nGrow());
+    BL_ASSERT(IntVect(nghost).allLE(nGrowVect()));
 
-    if (ParallelContext::NProcsSub() == 1)
-    {
-        for (int j = 0, N = size(); j < N; ++j)
-        {
-            const Box& bx = amrex::grow(boxarray[j],nghost);
-            const Box& destbox = bx & subbox;
-            if (destbox.ok())
-            {
-                dest.template copy<RunOn::Host>(get(j),destbox,scomp,destbox,dcomp,ncomp);
-            }
-        }
+    int root_proc = this->DistributionMap()[0];
 
-        return;
+    BoxArray ba(dest.box());
+    DistributionMapping dm(Vector<int>{root_proc});
+    FabArray<FAB> destmf(ba, dm, ncomp, 0, MFInfo().SetAlloc(false));
+    if (ParallelDescriptor::MyProc() == root_proc) {
+        destmf.setFab(0, FAB(dest, amrex::make_alias, dcomp, ncomp));
     }
 
-    //
-    //  Note that subbox must be identical on each process!!
-    //
-#ifdef AMREX_DEBUG
-    {
-        BoxCommHelper bch(subbox);
-        ParallelDescriptor::Bcast(bch.data(), bch.size(), 0, ParallelContext::CommunicatorSub());
-        const Box& bx0 = bch.make_box();
-        BL_ASSERT(subbox == bx0);
+    destmf.ParallelCopy(*this, scomp, 0, ncomp, nghost, 0);
+
+#ifdef BL_USE_MPI
+    using T = typename FAB::value_type;
+    if (ParallelContext::NProcsSub() > 1) {
+        Long count = dest.numPts()*ncomp;
+        T* const p0 = dest.dataPtr(dcomp);
+        T* pb = p0;
+#ifdef AMREX_USE_GPU
+        if (dest.arena()->isDevice()) {
+            pb = (T*)The_Pinned_Arena()->alloc(sizeof(T)*count);
+            Gpu::dtoh_memcpy_async(pb, p0, sizeof(T)*count);
+            Gpu::streamSynchronize();
+        }
+#endif
+        ParallelDescriptor::Bcast(pb, count, ParallelContext::global_to_local_rank(root_proc),
+                                  ParallelContext::CommunicatorSub());
+#ifdef AMREX_USE_GPU
+        if (pb != p0) {
+            Gpu::htod_memcpy_async(p0, pb, sizeof(T)*count);
+            Gpu::streamSynchronize();
+        }
+#endif
     }
 #endif
-
-    FAB ovlp;
-
-    std::vector< std::pair<int,Box> > isects;
-    boxarray.intersections(subbox, isects, false, nghost);
-
-    for (int j = 0, M = isects.size(); j < M; ++j)
-    {
-        const int  k  = isects[j].first;
-        const Box& bx = isects[j].second;
-
-        ovlp.resize(bx,ncomp);
-
-        if (ParallelDescriptor::MyProc() == distributionMap[k])
-        {
-            ovlp.template copy<RunOn::Host>(get(k),bx,scomp,bx,0,ncomp);
-        }
-
-        const int N = bx.numPts()*ncomp;
-
-        ParallelDescriptor::Bcast(ovlp.dataPtr(),N,
-                                  ParallelContext::global_to_local_rank(distributionMap[k]),
-                                  ParallelContext::CommunicatorSub());
-
-        dest.template copy<RunOn::Host>(ovlp,bx,0,bx,dcomp,ncomp);
-    }
 }
-
 
 #ifdef BL_USE_MPI
 template <class FAB>


### PR DESCRIPTION
Remove the two versions taking a sub box.  I don't think those versions are
used by any codes.  This allows for simplification of the implementation.
Reimplement copyTo to reduce the number of bcast to just one.  Also the new
versions work without managed memory.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
