### PR TITLE
FabSet::multiFab

### DIFF
--- a/Src/Boundary/AMReX_FabSet.H
+++ b/Src/Boundary/AMReX_FabSet.H
@@ -84,6 +84,9 @@ public:
     const DistributionMapping& DistributionMap () const noexcept
         { return m_mf.DistributionMap(); }
 
+    MultiFab      & multiFab ()       noexcept { return m_mf; }
+    MultiFab const& multiFab () const noexcept { return m_mf; }
+
     int nComp () const noexcept { return m_mf.nComp(); }
 
     void clear () { m_mf.clear(); }


### PR DESCRIPTION
Add public member functions to FabSet to expose the internal MultiFab data.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
