### PR TITLE
Fix I/O bug in Amr class

### DIFF
--- a/Src/Amr/AMReX_Amr.cpp
+++ b/Src/Amr/AMReX_Amr.cpp
@@ -1037,7 +1037,8 @@ Amr::writePlotFileDoit (std::string const& pltfile, bool regular)
         } else {
             ParallelDescriptor::Barrier("Amr::writePlotFile::end");
             if(ParallelDescriptor::IOProcessor()) {
-            std::rename(pltfileTemp.c_str(), pltfile.c_str());
+                HeaderFile.close();
+                std::rename(pltfileTemp.c_str(), pltfile.c_str());
             }
             ParallelDescriptor::Barrier("Renaming temporary plotfile.");
             //
@@ -1865,6 +1866,7 @@ Amr::checkPoint ()
     } else {
         ParallelDescriptor::Barrier("Amr::checkPoint::end");
         if(ParallelDescriptor::IOProcessor()) {
+            HeaderFile.close();
             std::rename(ckfileTemp.c_str(), ckfile.c_str());
         }
         ParallelDescriptor::Barrier("Renaming temporary checkPoint file.");


### PR DESCRIPTION
The file stream for the header must be closed before the parent directory
can be renamed.

Closes #2608

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
