### PR TITLE
Allow a descriptor component's BndryFuncFabDefault to be stateful.

### DIFF
--- a/Src/Amr/AMReX_StateDescriptor.H
+++ b/Src/Amr/AMReX_StateDescriptor.H
@@ -20,11 +20,11 @@
 
 namespace amrex {
 
-typedef void (*BndryFuncFabDefault) (Box const& bx, FArrayBox& data,
-                                     const int dcomp, const int numcomp,
-                                     Geometry const& geom, const Real time,
-                                     const Vector<BCRec>& bcr, const int bcomp,
-                                     const int scomp);
+  typedef std::function<void(Box const& bx, FArrayBox& data,
+			     const int dcomp, const int numcomp,
+			     Geometry const& geom, const Real time,
+			     const Vector<BCRec>& bcr, const int bcomp,
+			     const int scomp)> BndryFuncFabDefault;
 
 /**
 * \brief Attributes of StateData.

--- a/Src/Amr/AMReX_StateDescriptor.H
+++ b/Src/Amr/AMReX_StateDescriptor.H
@@ -21,10 +21,10 @@
 namespace amrex {
 
   typedef std::function<void(Box const& bx, FArrayBox& data,
-			     const int dcomp, const int numcomp,
-			     Geometry const& geom, const Real time,
-			     const Vector<BCRec>& bcr, const int bcomp,
-			     const int scomp)> BndryFuncFabDefault;
+                             const int dcomp, const int numcomp,
+                             Geometry const& geom, const Real time,
+                             const Vector<BCRec>& bcr, const int bcomp,
+                             const int scomp)> BndryFuncFabDefault;
 
 /**
 * \brief Attributes of StateData.


### PR DESCRIPTION
## Summary

This allows a boundary condition function to depend on the descriptor index or other information only available when BndryFunc::setComponent() is called.

## Additional background

Previously, the BndryFuncFabDefault function passed to BndryFunc::setComponent() pointed to a function that did not take descriptor index or other information. In some cases (e.g. multi-material simulations where each material is in its own Descriptor), extra information is needed to map the boundary-function call to the correct material's boundary condition.
Making BndryFuncFabDefault a std::function instead of a plain function pointer makes this possible.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
