### PR TITLE
Remove ifdefs for older compiler version.

### DIFF
--- a/Src/Base/AMReX_FBI.H
+++ b/Src/Base/AMReX_FBI.H
@@ -102,24 +102,12 @@ fab_to_fab (Vector<Array4CopyTag<T> > const& copy_tags, int scomp, int dcomp, in
         int to_try  = 1;
         while (true) {
             int msk = (m && to_try) ? Gpu::Atomic::CAS(m, 0, mypriority) : 0;
-#if (__INTEL_LLVM_COMPILER <= 20210300)
-            if (sycl::ONEAPI::all_of(item.get_sub_group(), msk == 0)) {  // 0 means lock acquired
-#else
             if (sycl::all_of_group(item.get_sub_group(), msk == 0)) {  // 0 means lock acquired
-#endif
                 break; // all threads have acquired.
             } else {
-#if (__INTEL_LLVM_COMPILER <= 20210300)
-                if (sycl::ONEAPI::any_of(item.get_sub_group(), msk > mypriority)) {
-#else
                 if (sycl::any_of_group(item.get_sub_group(), msk > mypriority)) {
-#endif
-                    if (m) *m = 0; // yield
-#if (__INTEL_LLVM_COMPILER <= 20210300)
-                    item.mem_fence(sycl::access::fence_space::global_and_local);
-#else
+                    if (m) { *m = 0; } // yield
                     sycl::atomic_fence(sycl::memory_order::acq_rel, sycl::memory_scope::device);
-#endif
                     to_try = 1;
                 } else {
                     to_try = (msk > 0); // hold on to my lock

--- a/Src/Base/AMReX_GpuPrint.H
+++ b/Src/Base/AMReX_GpuPrint.H
@@ -12,15 +12,9 @@
 
 #if defined(AMREX_USE_DPCPP)
 #if defined(__SYCL_DEVICE_ONLY__)
-#  if (__INTEL_LLVM_COMPILER <= 20210300)
-#    define AMREX_DEVICE_PRINTF(format,...) { \
-         static const __attribute__((opencl_constant)) char amrex_i_format[] = format ; \
-         sycl::ONEAPI::experimental::printf(amrex_i_format, __VA_ARGS__); }
-#  else
-#    define AMREX_DEVICE_PRINTF(format,...) { \
-         static const __attribute__((opencl_constant)) char amrex_i_format[] = format ; \
-         sycl::ext::oneapi::experimental::printf(amrex_i_format, __VA_ARGS__); }
-#  endif
+#  define AMREX_DEVICE_PRINTF(format,...) { \
+      static const __attribute__((opencl_constant)) char amrex_i_format[] = format ; \
+      sycl::ext::oneapi::experimental::printf(amrex_i_format, __VA_ARGS__); }
 #else
 #  define AMREX_DEVICE_PRINTF(format,...) { \
       std::printf(format, __VA_ARGS__); }

--- a/Src/Base/AMReX_GpuQualifiers.H
+++ b/Src/Base/AMReX_GpuQualifiers.H
@@ -42,11 +42,7 @@
 # include <CL/sycl.hpp>
 
 namespace amrex {
-# if (__INTEL_LLVM_COMPILER <= 20210300)
-    namespace oneapi = sycl::ONEAPI;
-# else
     namespace oneapi = sycl::ext::oneapi;
-# endif
 }
 
 # define AMREX_REQUIRE_SUBGROUP_SIZE(x) \

--- a/Src/Base/AMReX_Scan.H
+++ b/Src/Base/AMReX_Scan.H
@@ -60,11 +60,7 @@ struct BlockStatus<T, true>
     Data<T> d;
 
     AMREX_GPU_DEVICE AMREX_FORCE_INLINE
-#if defined(AMREX_USE_DPCPP) && (__INTEL_LLVM_COMPILER <= 20210300)
-    void write (char a_status, T a_value, sycl::nd_item<1> const& /*item*/) {
-#else
     void write (char a_status, T a_value) {
-#endif
 #if defined(AMREX_USE_CUDA)
         volatile uint64_t tmp;
         reinterpret_cast<STVA<T> volatile&>(tmp).status = a_status;
@@ -102,19 +98,11 @@ struct BlockStatus<T, true>
     void set_status (char a_status) { d.s.status = a_status; }
 
     AMREX_GPU_DEVICE AMREX_FORCE_INLINE
-#if defined(AMREX_USE_DPCPP) && (__INTEL_LLVM_COMPILER <= 20210300)
-    STVA<T> wait (sycl::nd_item<1> const& item) volatile {
-#else
     STVA<T> wait () volatile {
-#endif
         STVA<T> r;
         do {
 #if defined(AMREX_USE_DPCPP)
-#if (__INTEL_LLVM_COMPILER <= 20210300)
-            item.mem_fence();
-#else
             sycl::atomic_fence(sycl::memory_order::acq_rel, sycl::memory_scope::work_group);
-#endif
 #else
             __threadfence_block();
 #endif
@@ -132,22 +120,14 @@ struct BlockStatus<T, false>
     char status;
 
     AMREX_GPU_DEVICE AMREX_FORCE_INLINE
-#if defined(AMREX_USE_DPCPP) && (__INTEL_LLVM_COMPILER <= 20210300)
-    void write (char a_status, T a_value, sycl::nd_item<1> const& item) {
-#else
     void write (char a_status, T a_value) {
-#endif
         if (a_status == 'a') {
             aggregate = a_value;
         } else {
             inclusive = a_value;
         }
 #if defined(AMREX_USE_DPCPP)
-#if (__INTEL_LLVM_COMPILER <= 20210300)
-        item.mem_fence(sycl::access::fence_space::global_and_local);
-#else
         sycl::atomic_fence(sycl::memory_order::acq_rel, sycl::memory_scope::device);
-#endif
 #else
         __threadfence();
 #endif
@@ -172,20 +152,12 @@ struct BlockStatus<T, false>
     void set_status (char a_status) { status = a_status; }
 
     AMREX_GPU_DEVICE AMREX_FORCE_INLINE
-#if defined(AMREX_USE_DPCPP) && (__INTEL_LLVM_COMPILER <= 20210300)
-    STVA<T> wait (sycl::nd_item<1> const& item) volatile {
-#else
     STVA<T> wait () volatile {
-#endif
         STVA<T> r;
         do {
             r = read();
 #if defined(AMREX_USE_DPCPP)
-#if (__INTEL_LLVM_COMPILER <= 20210300)
-            item.mem_fence(sycl::access::fence_space::global_and_local);
-#else
             sycl::atomic_fence(sycl::memory_order::acq_rel, sycl::memory_scope::device);
-#endif
 #else
             __threadfence();
 #endif
@@ -541,11 +513,7 @@ T PrefixSum (N n, FIN && fin, FOUT && fout, TYPE type, RetSum a_ret_sum = retSum
         // sum_prev_chunk now holds the sum of the whole block.
         if (threadIdxx == 0 && gridDimx > 1) {
             block_status.write((virtual_block_id == 0) ? 'p' : 'a',
-                               sum_prev_chunk
-#if (__INTEL_LLVM_COMPILER <= 20210300)
-                               , *gh.item
-#endif
-                );
+                               sum_prev_chunk);
         }
 
         if (virtual_block_id == 0) {
@@ -567,11 +535,7 @@ T PrefixSum (N n, FIN && fin, FOUT && fout, TYPE type, RetSum a_ret_sum = retSum
                     int iblock = iblock0-lane;
                     detail::STVA<T> stva{'p', 0};
                     if (iblock >= 0) {
-#if (__INTEL_LLVM_COMPILER <= 20210300)
-                        stva = pbs[iblock].wait(*gh.item);
-#else
                         stva = pbs[iblock].wait();
-#endif
                     }
 
                     T x = stva.value;
@@ -608,11 +572,7 @@ T PrefixSum (N n, FIN && fin, FOUT && fout, TYPE type, RetSum a_ret_sum = retSum
                 }
 
                 if (lane == 0) {
-                    block_status.write('p', block_status.get_aggregate() + exclusive_prefix
-#if (__INTEL_LLVM_COMPILER <= 20210300)
-                                       , *gh.item
-#endif
-                        );
+                    block_status.write('p', block_status.get_aggregate() + exclusive_prefix);
                     shared[0] = exclusive_prefix;
                 }
             }


### PR DESCRIPTION
## Summary
Remove the ifdefs for a previous Intel compiler.

Note: this was done by prepping for ` __INTEL_LLVM_COMPILER`. If this is present in other capacities, we'll have to take another pass to finish this cleanup.

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
