### PR TITLE
missing check for mapped solver support when not using GPU

### DIFF
--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian.cpp
@@ -476,7 +476,8 @@ MLNodeLaplacian::interpolation (int amrlev, int fmglev, MultiFab& fine, const Mu
                     mlndlap_interpadd_c(i,j,k,ffab,cfab,mfab);
                 });
             }
-            else if (m_use_harmonic_average && fmglev > 0)
+            else if ( (m_use_harmonic_average && fmglev > 0) ||
+                       m_use_mapped )
             {
                 AMREX_D_TERM(Array4<Real const> const& sxfab = sigma[0]->const_array(mfi);,
                              Array4<Real const> const& syfab = sigma[1]->const_array(mfi);,
@@ -686,7 +687,8 @@ MLNodeLaplacian::normalize (int amrlev, int mglev, MultiFab& mf) const
                     mlndlap_normalize_sten(i,j,k,arr,stenarr,dmskarr,s0_norm0);
                 });
             }
-            else if (m_use_harmonic_average && mglev > 0)
+            else if ( (m_use_harmonic_average && mglev > 0) ||
+                       m_use_mapped )
             {
                 AMREX_D_TERM(Array4<Real const> const& sxarr = sigma[0]->const_array(mfi);,
                              Array4<Real const> const& syarr = sigma[1]->const_array(mfi);,

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian_misc.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian_misc.cpp
@@ -285,7 +285,8 @@ MLNodeLaplacian::Fapply (int amrlev, int mglev, MultiFab& out, const MultiFab& i
                 });
 #endif
             }
-            else if (m_use_harmonic_average && mglev > 0)
+            else if ( (m_use_harmonic_average && mglev > 0) ||
+                       m_use_mapped )
             {
                 AMREX_D_TERM(Array4<Real const> const& sxarr = sigma[0]->const_array(mfi);,
                              Array4<Real const> const& syarr = sigma[1]->const_array(mfi);,


### PR DESCRIPTION
## Summary

Mapped solver support was introduced in #2088 Few places seem to be missing `m_use_mapped` which requires a multi-component sigma. This PR adds `m_use_mapped` to be used in those places.

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
