### PR TITLE
Update checkpoint format to account for expanded particle ids.

### DIFF
--- a/Src/Extern/HDF5/AMReX_ParticleHDF5.H
+++ b/Src/Extern/HDF5/AMReX_ParticleHDF5.H
@@ -60,7 +60,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>
                           [=] AMREX_GPU_HOST_DEVICE (const SuperParticleType& p) -> int
                           {
                               return p.id() > 0;
-                          });
+                          }, true);
 }
 
 template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt,
@@ -396,7 +396,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>
                          const Vector<int>& write_int_comp,
                          const Vector<std::string>& real_comp_names,
                          const Vector<std::string>& int_comp_names,
-                         F&& f) const
+                         F&& f, bool is_checkpoint) const
 {
     /* if (AsyncOut::UseAsyncOut()) { */
     /*     WriteHDF5ParticleDataAsync(*this, dir, name, */
@@ -407,7 +407,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>
         WriteHDF5ParticleDataSync(*this, dir, name,
                                   write_real_comp, write_int_comp,
                                   real_comp_names, int_comp_names,
-                                  std::forward<F>(f));
+                                  std::forward<F>(f), is_checkpoint);
     /* } */
 }
 
@@ -552,7 +552,8 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>
                       Vector<int>& which, Vector<int>& count, Vector<Long>& where,
                       const Vector<int>& write_real_comp,
                       const Vector<int>& write_int_comp,
-                      const Vector<std::map<std::pair<int, int>, IntVector>>& particle_io_flags) const
+                      const Vector<std::map<std::pair<int, int>, IntVector>>& particle_io_flags,
+                      bool is_checkpoint) const
 {
     BL_PROFILE("ParticleContainer::WriteParticlesHDF5()");
 
@@ -743,7 +744,8 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>
         Vector<ParticleReal> rstuff;
         particle_detail::packIOData(istuff, rstuff, *this, lev, grid,
                                     write_real_comp, write_int_comp,
-                                    particle_io_flags, tile_map[grid], count[grid]);
+                                    particle_io_flags, tile_map[grid], count[grid],
+                                    is_checkpoint);
 
         my_int_count = istuff.size();
         int_mem_space = H5Screate_simple(1, &my_int_count, NULL);
@@ -940,7 +942,12 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>
     // Appended to the latter version string are either "_single" or "_double" to
     // indicate how the particles were written.
     // "Version_Two_Dot_Zero" -- this is the AMReX particle file format
+    // "Version_Two_Dot_One" -- expanded particle ids to allow for 2**39-1 per proc
     std::string how;
+    bool convert_ids = false;
+    if (version.find("Version_Two_Dot_One") != std::string::npos) {
+        convert_ids = true;
+    }
     if (version.find("_single") != std::string::npos) {
         how = "single";
     }
@@ -1201,10 +1208,10 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>
             const int grid = grids_to_read[igrid];
 
             if (how == "single") {
-                ReadParticlesHDF5<float>(offset[grid], count[grid], grid, lev, int_dset, real_dset, finest_level_in_file);
+                ReadParticlesHDF5<float>(offset[grid], count[grid], grid, lev, int_dset, real_dset, finest_level_in_file, convert_ids);
             }
             else if (how == "double") {
-                ReadParticlesHDF5<double>(offset[grid], count[grid], grid, lev, int_dset, real_dset, finest_level_in_file);
+                ReadParticlesHDF5<double>(offset[grid], count[grid], grid, lev, int_dset, real_dset, finest_level_in_file, convert_ids);
             }
             else {
                 std::string msg("ParticleContainer::Restart(): bad parameter: ");
@@ -1238,7 +1245,8 @@ template <class RTYPE>
 void
 ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>
 ::ReadParticlesHDF5 (hsize_t offset, hsize_t cnt, int grd, int lev,
-                     hid_t int_dset, hid_t real_dset, int finest_level_in_file)
+                     hid_t int_dset, hid_t real_dset, int finest_level_in_file,
+                     bool convert_ids)
 {
     BL_PROFILE("ParticleContainer::ReadParticlesHDF5()");
     AMREX_ASSERT(cnt > 0);
@@ -1299,9 +1307,19 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>
     host_int_attribs.resize(finest_level_in_file+1);
 
     for (hsize_t i = 0; i < cnt; i++) {
-        p.id()   = iptr[0];
-        p.cpu()  = iptr[1];
-
+        if (convert_ids) {
+            union punner {
+                std::int32_t i;
+                std::uint32_t u;
+            };
+            punner x, y;
+            x.i = iptr[0];
+            y.i = iptr[1];
+            p.m_idcpu = ((std::uint64_t)x.u) << 32 | y.u;
+        } else {
+            p.id()   = iptr[0];
+            p.cpu()  = iptr[1];
+        }
         iptr += 2;
 
         for (int j = 0; j < NStructInt; j++)

--- a/Src/Extern/HDF5/AMReX_ParticleHDF5.H
+++ b/Src/Extern/HDF5/AMReX_ParticleHDF5.H
@@ -1308,14 +1308,13 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>
 
     for (hsize_t i = 0; i < cnt; i++) {
         if (convert_ids) {
-            union punner {
-                std::int32_t i;
-                std::uint32_t u;
-            };
-            punner x, y;
-            x.i = iptr[0];
-            y.i = iptr[1];
-            p.m_idcpu = ((std::uint64_t)x.u) << 32 | y.u;
+            std::int32_t  xi, yi;
+            std::uint32_t xu, yu;
+            xi = iptr[0];
+            yi = iptr[1];
+            std::memcpy(&xu, &xi, sizeof(xi));
+            std::memcpy(&yu, &yi, sizeof(yi));
+            p.m_idcpu = ((std::uint64_t)xu) << 32 | yu;
         } else {
             p.id()   = iptr[0];
             p.cpu()  = iptr[1];

--- a/Src/Extern/HDF5/AMReX_ParticlesHDF5.H
+++ b/Src/Extern/HDF5/AMReX_ParticlesHDF5.H
@@ -249,11 +249,11 @@ public:
     WriteParticlesHDF5 (int level, hid_t grp,
                         Vector<int>& which, Vector<int>& count, Vector<Long>& where,
                         const Vector<int>& write_real_comp, const Vector<int>& write_int_comp,
-                        const Vector<std::map<std::pair<int, int>,IntVector>>& particle_io_flags) const;
+                        const Vector<std::map<std::pair<int, int>,IntVector>>& particle_io_flags, bool is_checkpoint) const;
 
 protected:
 
 template <class RTYPE>
-    void ReadParticlesHDF5 (hsize_t offset, hsize_t count, int grd, int lev, hid_t int_dset, hid_t real_dset, int finest_level_in_file);
+void ReadParticlesHDF5 (hsize_t offset, hsize_t count, int grd, int lev, hid_t int_dset, hid_t real_dset, int finest_level_in_file, bool convert_ids);
 
 #endif

--- a/Src/Extern/HDF5/AMReX_ParticlesHDF5.H
+++ b/Src/Extern/HDF5/AMReX_ParticlesHDF5.H
@@ -56,7 +56,7 @@ public:
                                 const Vector<int>& write_int_comp,
                                 const Vector<std::string>& real_comp_names,
                                 const Vector<std::string>&  int_comp_names,
-                                                                F&& f) const;
+                                F&& f, bool is_checkpoint=false) const;
 
 
     void CheckpointPreHDF5 ();

--- a/Src/Extern/HDF5/AMReX_WriteBinaryParticleDataHDF5.H
+++ b/Src/Extern/HDF5/AMReX_WriteBinaryParticleDataHDF5.H
@@ -118,7 +118,7 @@ void WriteHDF5ParticleDataSync (PC const& pc,
                                   const Vector<int>& write_int_comp,
                                   const Vector<std::string>& real_comp_names,
                                   const Vector<std::string>& int_comp_names,
-                                  F&& f)
+                                  F&& f, bool is_checkpoint)
 {
     BL_PROFILE("WriteHDF5ParticleDataSync()");
     AMREX_ASSERT(pc.OK());
@@ -428,7 +428,8 @@ void WriteHDF5ParticleDataSync (PC const& pc,
         if (gotsome)
         {
             pc.WriteParticlesHDF5(lev, grp, which, count, where,
-                                  write_real_comp, write_int_comp, particle_io_flags);
+                                  write_real_comp, write_int_comp,
+                                  particle_io_flags, is_checkpoint);
 
             if(pc.usePrePost) {
                 pc.whichPrePost[lev] = which;

--- a/Src/Particle/AMReX_ParticleContainerBase.cpp
+++ b/Src/Particle/AMReX_ParticleContainerBase.cpp
@@ -102,8 +102,9 @@ const std::string& ParticleContainerBase::Version ()
     //
     //    "Version_One_Dot_Zero"
     //    "Version_One_Dot_One"
+    //    "Version_Two_Dot_Zero" (before checkpoints had expanded particle ids)
     //
-    static const std::string version("Version_Two_Dot_Zero");
+    static const std::string version("Version_Two_Dot_One");
 
     return version;
 }

--- a/Src/Particle/AMReX_ParticleIO.H
+++ b/Src/Particle/AMReX_ParticleIO.H
@@ -80,7 +80,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>
                             [=] AMREX_GPU_HOST_DEVICE (const SuperParticleType& p) -> int
                             {
                                 return p.id() > 0;
-                            });
+                            }, true);
 }
 
 template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt,
@@ -382,18 +382,18 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>
                            const Vector<int>& write_int_comp,
                            const Vector<std::string>& real_comp_names,
                            const Vector<std::string>& int_comp_names,
-                           F&& f) const
+                           F&& f, bool is_checkpoint) const
 {
     if (AsyncOut::UseAsyncOut()) {
         WriteBinaryParticleDataAsync(*this, dir, name,
                                      write_real_comp, write_int_comp,
-                                     real_comp_names, int_comp_names);
+                                     real_comp_names, int_comp_names, is_checkpoint);
     } else
     {
         WriteBinaryParticleDataSync(*this, dir, name,
                                     write_real_comp, write_int_comp,
                                     real_comp_names, int_comp_names,
-                                    std::forward<F>(f));
+                                    std::forward<F>(f), is_checkpoint);
     }
 }
 
@@ -538,7 +538,8 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>
                   Vector<int>& which, Vector<int>& count, Vector<Long>& where,
                   const Vector<int>& write_real_comp,
                   const Vector<int>& write_int_comp,
-                  const Vector<std::map<std::pair<int, int>, IntVector>>& particle_io_flags) const
+                  const Vector<std::map<std::pair<int, int>, IntVector>>& particle_io_flags,
+                  bool is_checkpoint) const
 {
     BL_PROFILE("ParticleContainer::WriteParticles()");
 
@@ -573,7 +574,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>
         Vector<ParticleReal> rstuff;
         particle_detail::packIOData(istuff, rstuff, *this, lev, grid,
                                     write_real_comp, write_int_comp,
-                                    particle_io_flags, tile_map[grid], count[grid]);
+                                    particle_io_flags, tile_map[grid], count[grid], is_checkpoint);
 
         writeIntData(istuff.dataPtr(), istuff.size(), ofs);
         ofs.flush();  // Some systems require this flush() (probably due to a bug)
@@ -633,7 +634,12 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>
     // Appended to the latter version string are either "_single" or "_double" to
     // indicate how the particles were written.
     // "Version_Two_Dot_Zero" -- this is the AMReX particle file format
+    // "Version_Two_Dot_One" -- expanded particle ids to allow for 2**39-1 per proc
     std::string how;
+    bool convert_ids = false;
+    if (version.find("Version_Two_Dot_One") != std::string::npos) {
+        convert_ids = true;
+    }
     if (version.find("Version_One_Dot_Zero") != std::string::npos) {
         how = "double";
     }
@@ -836,10 +842,10 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>
             ParticleFile.seekg(where[grid], std::ios::beg);
 
             if (how == "single") {
-                ReadParticles<float>(count[grid], grid, lev, ParticleFile, finest_level_in_file);
+                ReadParticles<float>(count[grid], grid, lev, ParticleFile, finest_level_in_file, convert_ids);
             }
             else if (how == "double") {
-                ReadParticles<double>(count[grid], grid, lev, ParticleFile, finest_level_in_file);
+                ReadParticles<double>(count[grid], grid, lev, ParticleFile, finest_level_in_file, convert_ids);
             }
             else {
                 std::string msg("ParticleContainer::Restart(): bad parameter: ");
@@ -878,7 +884,8 @@ template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt,
 template <class RTYPE>
 void
 ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>
-::ReadParticles (int cnt, int grd, int lev, std::ifstream& ifs, int finest_level_in_file)
+::ReadParticles (int cnt, int grd, int lev, std::ifstream& ifs,
+                 int finest_level_in_file, bool convert_ids)
 {
     BL_PROFILE("ParticleContainer::ReadParticles()");
     AMREX_ASSERT(cnt > 0);
@@ -918,9 +925,19 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>
     host_int_attribs.resize(finest_level_in_file+1);
 
     for (int i = 0; i < cnt; i++) {
-        p.id()   = iptr[0];
-        p.cpu()  = iptr[1];
-
+        if (convert_ids) {
+            union punner {
+                std::int32_t i;
+                std::uint32_t u;
+            };
+            punner x, y;
+            x.i = iptr[0];
+            y.i = iptr[1];
+            p.m_idcpu = ((std::uint64_t)x.u) << 32 | y.u;
+        } else {
+            p.id()   = iptr[0];
+            p.cpu()  = iptr[1];
+        }
         iptr += 2;
 
         for (int j = 0; j < NStructInt; j++)

--- a/Src/Particle/AMReX_ParticleIO.H
+++ b/Src/Particle/AMReX_ParticleIO.H
@@ -644,7 +644,8 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>
         how = "double";
     }
     else if (version.find("Version_One_Dot_One")  != std::string::npos ||
-             version.find("Version_Two_Dot_Zero") != std::string::npos) {
+             version.find("Version_Two_Dot_Zero") != std::string::npos ||
+             version.find("Version_Two_Dot_One") != std::string::npos) {
         if (version.find("_single") != std::string::npos) {
             how = "single";
         }

--- a/Src/Particle/AMReX_ParticleIO.H
+++ b/Src/Particle/AMReX_ParticleIO.H
@@ -927,14 +927,13 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>
 
     for (int i = 0; i < cnt; i++) {
         if (convert_ids) {
-            union punner {
-                std::int32_t i;
-                std::uint32_t u;
-            };
-            punner x, y;
-            x.i = iptr[0];
-            y.i = iptr[1];
-            p.m_idcpu = ((std::uint64_t)x.u) << 32 | y.u;
+            std::int32_t  xi, yi;
+            std::uint32_t xu, yu;
+            xi = iptr[0];
+            yi = iptr[1];
+            std::memcpy(&xu, &xi, sizeof(xi));
+            std::memcpy(&yu, &yi, sizeof(yi));
+            p.m_idcpu = ((std::uint64_t)xu) << 32 | yu;
         } else {
             p.id()   = iptr[0];
             p.cpu()  = iptr[1];

--- a/Src/Particle/AMReX_Particles.H
+++ b/Src/Particle/AMReX_Particles.H
@@ -722,6 +722,7 @@ public:
       * \param real_comp_names for each real component, a name to label the data with
       * \param int_comp_names for each integer component, a name to label the data with
       * \param f callable that returns whether a given particle should be written or not
+      * \param is_checkpoint whether the data is written to a checkpoint or plotfile
       */
     template <class F>
     void WriteBinaryParticleData (const std::string& dir,
@@ -730,7 +731,7 @@ public:
                                   const Vector<int>& write_int_comp,
                                   const Vector<std::string>& real_comp_names,
                                   const Vector<std::string>&  int_comp_names,
-                                                                  F&& f) const;
+                                  F&& f, bool is_checkpoint=false) const;
 
     void CheckpointPre ();
 
@@ -1276,7 +1277,7 @@ public:
     WriteParticles (int level, std::ofstream& ofs, int fnum,
                     Vector<int>& which, Vector<int>& count, Vector<Long>& where,
                     const Vector<int>& write_real_comp, const Vector<int>& write_int_comp,
-                    const Vector<std::map<std::pair<int, int>,IntVector>>& particle_io_flags) const;
+                    const Vector<std::map<std::pair<int, int>,IntVector>>& particle_io_flags, bool is_checkpoint) const;
 #ifdef AMREX_USE_HDF5
 #include "AMReX_ParticlesHDF5.H"
 #endif
@@ -1284,7 +1285,7 @@ public:
 protected:
 
     template <class RTYPE>
-    void ReadParticles (int cnt, int grd, int lev, std::ifstream& ifs, int finest_level_in_file);
+    void ReadParticles (int cnt, int grd, int lev, std::ifstream& ifs, int finest_level_in_file, bool convert_ids);
 
     void SetParticleSize ();
 

--- a/Src/Particle/AMReX_WriteBinaryParticleData.H
+++ b/Src/Particle/AMReX_WriteBinaryParticleData.H
@@ -139,12 +139,32 @@ countFlags (const Container<int,Allocator>& pflags)
     return nparticles;
 }
 
+template <typename P, typename I>
+AMREX_GPU_HOST_DEVICE
+void packParticleIDs (I* idata, const P& p, bool is_checkpoint) noexcept
+{
+    if (is_checkpoint) {
+        union punner {
+            std::int32_t i;
+            std::uint32_t u;
+        };
+        punner x, y;
+        x.u = (std::uint32_t)((p.m_idcpu & 0xFFFFFFFF00000000LL) >> 32);
+        y.u = (std::uint32_t)( p.m_idcpu & 0xFFFFFFFFLL);
+        idata[0] = x.i;
+        idata[1] = y.i;
+    } else {
+        idata[0] = p.id();
+        idata[1] = p.cpu();
+    }
+}
+
 template <class PC>
 typename std::enable_if<RunOnGpu<typename PC::template AllocatorType<int>>::value>::type
 packIOData (Vector<int>& idata, Vector<ParticleReal>& rdata, const PC& pc, int lev, int grid,
             const Vector<int>& write_real_comp, const Vector<int>& write_int_comp,
             const Vector<std::map<std::pair<int, int>, typename PC::IntVector>>& particle_io_flags,
-            const Vector<int>& tiles, int np)
+            const Vector<int>& tiles, int np, bool is_checkpoint)
 {
     int num_output_int = 0;
     for (int i = 0; i < pc.NumIntComps() + PC::NStructInt; ++i)
@@ -196,8 +216,7 @@ packIOData (Vector<int>& idata, Vector<ParticleReal>& rdata, const PC& pc, int l
 
             if (flag_ptr[pindex]) {
                 std::size_t iout_index = (pindex+poffset)*iChunkSize;
-                idata_d_ptr[iout_index] = p.id();
-                idata_d_ptr[iout_index+1] = p.cpu();
+                packParticleIDs(&idata_d_ptr[iout_index], p, is_checkpoint);
                 iout_index += 2;
 
                 std::size_t rout_index = (pindex+poffset)*rChunkSize;
@@ -235,7 +254,7 @@ typename std::enable_if<!RunOnGpu<typename PC::template AllocatorType<int>>::val
 packIOData (Vector<int>& idata, Vector<ParticleReal>& rdata, const PC& pc, int lev, int grid,
             const Vector<int>& write_real_comp, const Vector<int>& write_int_comp,
             const Vector<std::map<std::pair<int, int>, typename PC::IntVector>>& particle_io_flags,
-            const Vector<int>& tiles, int np)
+            const Vector<int>& tiles, int np, bool is_checkpoint)
 {
     int num_output_int = 0;
     for (int i = 0; i < pc.NumIntComps() + PC::NStructInt; ++i)
@@ -260,8 +279,9 @@ packIOData (Vector<int>& idata, Vector<ParticleReal>& rdata, const PC& pc, int l
             const auto& aos = ptile.GetArrayOfStructs();
             const auto& p = aos[pindex];
             if (pflags[pindex]) {
-                *iptr = p.id(); ++iptr;
-                *iptr = p.cpu(); ++iptr;
+                packParticleIDs(iptr, p, is_checkpoint);
+                iptr += 2;
+
                 for (int j = 0; j < AMREX_SPACEDIM; j++) rptr[j] = p.pos(j);
                 rptr += AMREX_SPACEDIM;
 
@@ -306,7 +326,7 @@ void WriteBinaryParticleDataSync (PC const& pc,
                                   const Vector<int>& write_int_comp,
                                   const Vector<std::string>& real_comp_names,
                                   const Vector<std::string>& int_comp_names,
-                                  F&& f)
+                                  F&& f, bool is_checkpoint)
 {
     BL_PROFILE("WriteBinaryParticleData()");
     AMREX_ASSERT(pc.OK());
@@ -426,8 +446,8 @@ void WriteBinaryParticleDataSync (PC const& pc,
         for (int i = 0; i < NStructInt + pc.NumIntComps(); ++i )
             if (write_int_comp[i]) HdrFile << int_comp_names[i] << '\n';
 
-        bool is_checkpoint = true; // legacy
-        HdrFile << is_checkpoint << '\n';
+        bool is_checkpoint_legacy = true; // legacy
+        HdrFile << is_checkpoint_legacy << '\n';
 
         // The total number of particles.
         HdrFile << nparticles << '\n';
@@ -522,7 +542,7 @@ void WriteBinaryParticleDataSync (PC const& pc,
             {
                 std::ofstream& myStream = (std::ofstream&) nfi.Stream();
                 pc.WriteParticles(lev, myStream, nfi.FileNumber(), which, count, where,
-                                  write_real_comp, write_int_comp, particle_io_flags);
+                                  write_real_comp, write_int_comp, particle_io_flags, is_checkpoint);
             }
 
             if(pc.usePrePost) {
@@ -585,7 +605,7 @@ void WriteBinaryParticleDataAsync (PC const& pc,
                                    const Vector<int>& write_real_comp,
                                    const Vector<int>& write_int_comp,
                                    const Vector<std::string>& real_comp_names,
-                                   const Vector<std::string>& int_comp_names)
+                                   const Vector<std::string>& int_comp_names, bool is_checkpoint)
 {
     BL_PROFILE("WriteBinaryParticleDataAsync");
     AMREX_ASSERT(pc.OK());
@@ -806,8 +826,8 @@ void WriteBinaryParticleDataAsync (PC const& pc,
             for (int i = 0; i < NStructInt + nic; ++i )
                 if (write_int_comp[i]) HdrFile << int_comp_names[i] << '\n';
 
-            bool is_checkpoint = true; // legacy
-            HdrFile << is_checkpoint << '\n';
+            bool is_checkpoint_legacy = true; // legacy
+            HdrFile << is_checkpoint_legacy << '\n';
 
             // The total number of particles.
             HdrFile << total_np << '\n';
@@ -898,8 +918,8 @@ void WriteBinaryParticleDataAsync (PC const& pc,
                         if (p.id() <= 0) continue;
 
                         // always write these
-                        *iptr = p.id(); ++iptr;
-                        *iptr = p.cpu(); ++iptr;
+                        particle_detail::packParticleIDs(iptr, p, is_checkpoint);
+                        iptr += 2;
 
                         // optionally write these
                         for (int j = 0; j < NStructInt; j++)

--- a/Src/Particle/AMReX_WriteBinaryParticleData.H
+++ b/Src/Particle/AMReX_WriteBinaryParticleData.H
@@ -144,15 +144,14 @@ AMREX_GPU_HOST_DEVICE
 void packParticleIDs (I* idata, const P& p, bool is_checkpoint) noexcept
 {
     if (is_checkpoint) {
-        union punner {
-            std::int32_t i;
-            std::uint32_t u;
-        };
-        punner x, y;
-        x.u = (std::uint32_t)((p.m_idcpu & 0xFFFFFFFF00000000LL) >> 32);
-        y.u = (std::uint32_t)( p.m_idcpu & 0xFFFFFFFFLL);
-        idata[0] = x.i;
-        idata[1] = y.i;
+        std::int32_t  xi, yi;
+        std::uint32_t xu, yu;
+        xu = (std::uint32_t)((p.m_idcpu & 0xFFFFFFFF00000000LL) >> 32);
+        yu = (std::uint32_t)( p.m_idcpu & 0xFFFFFFFFLL);
+        std::memcpy(&xi, &xu, sizeof(xu));
+        std::memcpy(&yi, &yu, sizeof(yu));
+        idata[0] = xi;
+        idata[1] = yi;
     } else {
         idata[0] = p.id();
         idata[1] = p.cpu();


### PR DESCRIPTION
See discussion here: https://github.com/ECP-WarpX/WarpX/issues/2785

Note that this does not alter plotfiles yet, only checkpoint / restart.

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
