### PR TITLE
Allow the ghost-particle exchange to communicate different variables than the particle redistribution on GPU.

### DIFF
--- a/Src/Particle/AMReX_NeighborParticles.H
+++ b/Src/Particle/AMReX_NeighborParticles.H
@@ -276,7 +276,7 @@ public:
     {
         ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>::
             AddRealComp(communicate);
-        rc.push_back(communicate);
+        ghost_real_comp.push_back(communicate);
         calcCommSize();
     }
 
@@ -286,7 +286,7 @@ public:
     {
         ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>::
             AddIntComp(communicate);
-        ic.push_back(communicate);
+        ghost_int_comp.push_back(communicate);
         calcCommSize();
     }
 
@@ -397,8 +397,8 @@ protected:
     Long num_snds;
     std::map<int, Vector<char> > send_data;
 
-    Vector<int> rc;
-    Vector<int> ic;
+    Vector<int> ghost_real_comp;
+    Vector<int> ghost_int_comp;
 
     static bool use_mask;
 

--- a/Src/Particle/AMReX_NeighborParticlesCPUImpl.H
+++ b/Src/Particle/AMReX_NeighborParticlesCPUImpl.H
@@ -335,14 +335,14 @@ NeighborParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
                         char* dst_ptr = &send_data[who][tag.dst_index];
                         char* src_ptr = (char *) &p;
                         for (int ii = 0; ii < AMREX_SPACEDIM + NStructReal; ++ii) {
-                            if (rc[ii]) {
+                            if (ghost_real_comp[ii]) {
                                 std::memcpy(dst_ptr, src_ptr, sizeof(typename ParticleType::RealType));
                                 dst_ptr += sizeof(typename ParticleType::RealType);
                             }
                             src_ptr += sizeof(typename ParticleType::RealType);
                         }
                         for (int ii = 0; ii < this->NumRealComps(); ++ii) {
-                            if (rc[ii+AMREX_SPACEDIM+NStructReal])
+                            if (ghost_real_comp[ii+AMREX_SPACEDIM+NStructReal])
                             {
                                 std::memcpy(dst_ptr, &(soa.GetRealData(ii)[tag.src_index]),
                                             sizeof(typename ParticleType::RealType));
@@ -350,14 +350,14 @@ NeighborParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
                             }
                         }
                         for (int ii = 0; ii < 2 + NStructInt; ++ii) {
-                            if (ic[ii]) {
+                            if (ghost_int_comp[ii]) {
                                 std::memcpy(dst_ptr, src_ptr, sizeof(int));
                                 dst_ptr += sizeof(int);
                             }
                             src_ptr += sizeof(int);
                         }
                         for (int ii = 0; ii < this->NumIntComps(); ++ii) {
-                            if (ic[ii+2+NStructInt])
+                            if (ghost_int_comp[ii+2+NStructInt])
                             {
                                 std::memcpy(dst_ptr, &(soa.GetIntData(ii)[tag.src_index]),
                                             sizeof(int));
@@ -591,14 +591,14 @@ fillNeighborsMPI (bool reuse_rcv_counts) {
                     char* dst_aos = (char*) &neighbors[lev][dst_index].GetArrayOfStructs()[old_size+n];
                     auto& dst_soa = neighbors[lev][dst_index].GetStructOfArrays();
                     for (int ii = 0; ii < AMREX_SPACEDIM + NStructReal; ++ii) {
-                        if (rc[ii]) {
+                        if (ghost_real_comp[ii]) {
                             std::memcpy(dst_aos, src, sizeof(typename ParticleType::RealType));
                             src += sizeof(typename ParticleType::RealType);
                         }
                         dst_aos += sizeof(typename ParticleType::RealType);
                     }
                     for (int ii = 0; ii < this->NumRealComps(); ++ii) {
-                        if (rc[ii+AMREX_SPACEDIM+NStructReal])
+                        if (ghost_real_comp[ii+AMREX_SPACEDIM+NStructReal])
                         {
                             std::memcpy(&(dst_soa.GetRealData(ii)[old_size+n]),
                                         src, sizeof(typename ParticleType::RealType));
@@ -606,14 +606,14 @@ fillNeighborsMPI (bool reuse_rcv_counts) {
                         }
                     }
                     for (int ii = 0; ii < 2 + NStructInt; ++ii) {
-                        if (ic[ii]) {
+                        if (ghost_int_comp[ii]) {
                             std::memcpy(dst_aos, src, sizeof(int));
                             src += sizeof(int);
                         }
                         dst_aos += sizeof(int);
                     }
                     for (int ii = 0; ii < this->NumIntComps(); ++ii) {
-                        if (ic[ii+2+NStructInt])
+                        if (ghost_int_comp[ii+2+NStructInt])
                         {
                             std::memcpy(&(dst_soa.GetIntData(ii)[old_size+n]),
                                         src, sizeof(int));

--- a/Src/Particle/AMReX_NeighborParticlesGPUImpl.H
+++ b/Src/Particle/AMReX_NeighborParticlesGPUImpl.H
@@ -235,7 +235,8 @@ fillNeighborsGPU ()
     neighbor_copy_op.clear();
     neighbor_copy_plan.clear();
     buildNeighborCopyOp();
-    neighbor_copy_plan.build(*this, neighbor_copy_op, true);
+    neighbor_copy_plan.build(*this, neighbor_copy_op, ghost_int_comp,
+                             ghost_real_comp, true);
     updateNeighborsGPU(false);
 }
 
@@ -250,7 +251,8 @@ updateNeighborsGPU (bool boundary_neighbors_only)
         neighbor_copy_op.clear();
         neighbor_copy_plan.clear();
         buildNeighborCopyOp(true);
-        neighbor_copy_plan.build(*this, neighbor_copy_op, true);
+        neighbor_copy_plan.build(*this, neighbor_copy_op, ghost_int_comp,
+                                 ghost_real_comp, true);
     }
 
     clearNeighbors();

--- a/Src/Particle/AMReX_NeighborParticlesI.H
+++ b/Src/Particle/AMReX_NeighborParticlesI.H
@@ -43,9 +43,9 @@ void
 NeighborParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
 ::initializeCommComps () {
     for (int ii = 0; ii < AMREX_SPACEDIM + NStructReal + this->NumRealComps(); ++ii)
-        rc.push_back(1);
+        ghost_real_comp.push_back(1);
     for (int ii = 0; ii < 2 + NStructInt + this->NumIntComps(); ++ii)
-        ic.push_back(1);
+        ghost_int_comp.push_back(1);
     calcCommSize();
 }
 
@@ -53,7 +53,7 @@ template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt>
 void
 NeighborParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
 ::setRealCommComp (int i, bool value) {
-    rc[i] = value;
+    ghost_real_comp[i] = value;
     calcCommSize();
 }
 
@@ -61,7 +61,7 @@ template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt>
 void
 NeighborParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
 ::setIntCommComp (int i, bool value) {
-    ic[i] = value;
+    ghost_int_comp[i] = value;
     calcCommSize();
 }
 
@@ -71,12 +71,12 @@ NeighborParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
 ::calcCommSize () {
     size_t comm_size = 0;
     for (int ii = 0; ii < AMREX_SPACEDIM + NStructReal + this->NumRealComps(); ++ii) {
-        if (rc[ii]) {
+        if (ghost_real_comp[ii]) {
             comm_size += sizeof(typename ParticleType::RealType);
         }
     }
     for (int ii = 0; ii < 2 + NStructInt + this->NumIntComps(); ++ii) {
-        if (ic[ii]) {
+        if (ghost_int_comp[ii]) {
             comm_size += sizeof(int);
         }
     }

--- a/Src/Particle/AMReX_ParticleCommunication.H
+++ b/Src/Particle/AMReX_ParticleCommunication.H
@@ -113,8 +113,17 @@ struct ParticleCopyPlan
     Vector<std::size_t> m_rcv_pad_correction_h;
     Gpu::DeviceVector<std::size_t> m_rcv_pad_correction_d;
 
+    Gpu::DeviceVector<int> d_int_comp_mask, d_real_comp_mask;
+    Long m_superparticle_size;
+
+    Long superParticleSize() const { return m_superparticle_size; }
+
     template <class PC, std::enable_if_t<IsParticleContainer<PC>::value, int> foo = 0>
-    void build (const PC& pc, const ParticleCopyOp& op, bool local)
+    void build (const PC& pc,
+                const ParticleCopyOp& op,
+                const Vector<int>& int_comp_mask,
+                const Vector<int>& real_comp_mask,
+                bool local)
     {
         BL_PROFILE("ParticleCopyPlan::build");
 
@@ -185,7 +194,31 @@ struct ParticleCopyPlan
         Gpu::copy(Gpu::hostToDevice, m_snd_pad_correction_h.begin(), m_snd_pad_correction_h.end(),
                   m_snd_pad_correction_d.begin());
 
-        buildMPIStart(pc.BufferMap(), pc.superParticleSize());
+        d_int_comp_mask.resize(int_comp_mask.size());
+        Gpu::copy(Gpu::hostToDevice,  int_comp_mask.begin(),  int_comp_mask.end(),
+                  d_int_comp_mask.begin());
+        d_real_comp_mask.resize(real_comp_mask.size());
+        Gpu::copy(Gpu::hostToDevice, real_comp_mask.begin(), real_comp_mask.end(),
+                  d_real_comp_mask.begin());
+
+        int NStructReal = PC::ParticleContainerType::NStructReal;
+        int NStructInt  = PC::ParticleContainerType::NStructInt;
+
+        int num_real_comm_comp = 0;
+        for (int i = AMREX_SPACEDIM + NStructReal; i < real_comp_mask.size(); ++i) {
+            if (real_comp_mask[i]) {++num_real_comm_comp;}
+        }
+
+        int num_int_comm_comp = 0;
+        for (int i = 2 + NStructInt; i < int_comp_mask.size(); ++i) {
+            if (int_comp_mask[i])  {++num_int_comm_comp;}
+        }
+
+        m_superparticle_size = sizeof(typename PC::ParticleType)
+                             + num_real_comm_comp * sizeof(typename PC::ParticleType::RealType)
+                             + num_int_comm_comp  * sizeof(int);
+
+        buildMPIStart(pc.BufferMap(), m_superparticle_size);
     }
 
     void clear ();
@@ -257,7 +290,7 @@ void packBuffer (const PC& pc, const ParticleCopyOp& op, const ParticleCopyPlan&
 
     using ParticleType = typename PC::ParticleType;
 
-    Long psize = pc.superParticleSize();
+    Long psize = plan.superParticleSize();
 
     int num_levels = pc.BufferMap().numLevels();
     int num_buckets = pc.BufferMap().numBuckets();
@@ -276,8 +309,8 @@ void packBuffer (const PC& pc, const ParticleCopyOp& op, const ParticleCopyPlan&
     }
     snd_buffer.resize(total_buffer_size);
 
-    auto p_comm_real = pc.d_communicate_real_comp.dataPtr();
-    auto p_comm_int  = pc.d_communicate_int_comp.dataPtr();
+    auto p_comm_real = plan.d_real_comp_mask.dataPtr();
+    auto p_comm_int  = plan.d_int_comp_mask.dataPtr();
 
     for (int lev = 0; lev < num_levels; ++lev)
     {
@@ -352,7 +385,7 @@ void unpackBuffer (PC& pc, const ParticleCopyPlan& plan, const Buffer& snd_buffe
     using PTile = typename PC::ParticleTileType;
 
     int num_levels = pc.BufferMap().numLevels();
-    Long psize = pc.superParticleSize();
+    Long psize = plan.superParticleSize();
 
     // count how many particles we have to add to each tile
     std::vector<int> sizes;
@@ -374,8 +407,8 @@ void unpackBuffer (PC& pc, const ParticleCopyPlan& plan, const Buffer& snd_buffe
     std::vector<int> offsets;
     policy.resizeTiles(tiles, sizes, offsets);
 
-    auto p_comm_real = pc.d_communicate_real_comp.dataPtr();
-    auto p_comm_int  = pc.d_communicate_int_comp.dataPtr();
+    auto p_comm_real = plan.d_real_comp_mask.dataPtr();
+    auto p_comm_int  = plan.d_int_comp_mask.dataPtr();
 
     // local unpack
     int uindex = 0;
@@ -415,7 +448,7 @@ void communicateParticlesStart (const PC& pc, ParticleCopyPlan& plan, const Buff
     BL_PROFILE("amrex::communicateParticlesStart");
 
 #ifdef AMREX_USE_MPI
-    Long psize = pc.superParticleSize();
+    Long psize = plan.superParticleSize();
     const int NProcs = ParallelContext::NProcsSub();
     const int MyProc = ParallelContext::MyProcSub();
 
@@ -495,6 +528,8 @@ void communicateParticlesStart (const PC& pc, ParticleCopyPlan& plan, const Buff
         ParallelDescriptor::Send((char const*)(snd_buffer.dataPtr()+snd_offset), Cnt, Who, SeqNum,
                                  ParallelContext::CommunicatorSub());
     }
+
+    amrex::ignore_unused(pc);
 #else
     amrex::ignore_unused(pc,plan,snd_buffer,rcv_buffer);
 #endif // MPI
@@ -518,8 +553,8 @@ void unpackRemotes (PC& pc, const ParticleCopyPlan& plan, Buffer& rcv_buffer, Un
 
     if (plan.m_nrcvs > 0)
     {
-        auto p_comm_real = pc.d_communicate_real_comp.dataPtr();
-        auto p_comm_int  = pc.d_communicate_int_comp.dataPtr();
+        auto p_comm_real = plan.d_real_comp_mask.dataPtr();
+        auto p_comm_int  = plan.d_int_comp_mask.dataPtr();
         auto p_rcv_buffer = rcv_buffer.dataPtr();
 
         std::vector<int> sizes;
@@ -559,7 +594,7 @@ void unpackRemotes (PC& pc, const ParticleCopyPlan& plan, Buffer& rcv_buffer, Un
             int size = sizes[uindex];
             ++uindex;
 
-            Long psize = pc.superParticleSize();
+            Long psize = plan.superParticleSize();
             auto p_pad_adjust = plan.m_rcv_pad_correction_d.dataPtr();
 
             AMREX_FOR_1D ( size, ip, {

--- a/Src/Particle/AMReX_ParticleContainerI.H
+++ b/Src/Particle/AMReX_ParticleContainerI.H
@@ -4,32 +4,16 @@ template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt,
 void
 ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>::SetParticleSize ()
 {
-    if (NumRealComps() > 0 || NumIntComps() > 0) {
-        if (NumRealComps() > 0) {
-            d_communicate_real_comp.resize(NumRealComps());
-            Gpu::copyAsync(Gpu::hostToDevice,
-                           h_communicate_real_comp.begin(),
-                           h_communicate_real_comp.end(),
-                           d_communicate_real_comp.begin());
-        }
-        if (NumIntComps() > 0) {
-            d_communicate_int_comp.resize(NumIntComps());
-            Gpu::copyAsync(Gpu::hostToDevice,
-                           h_communicate_int_comp.begin(),
-                           h_communicate_int_comp.end(),
-                           d_communicate_int_comp.begin());
-        }
-        Gpu::synchronize();
-    }
-
-    num_real_comm_comps = 0;
-    for (int i = 0; i < NumRealComps(); ++i) {
-        if (h_communicate_real_comp[i]) ++num_real_comm_comps;
+    num_real_comm_comps  = 0;
+    int comm_comps_start = AMREX_SPACEDIM + NStructReal;
+    for (int i = comm_comps_start; i < comm_comps_start + NumRealComps(); ++i) {
+        if (h_redistribute_real_comp[i]) {++num_real_comm_comps;}
     }
 
     num_int_comm_comps = 0;
-    for (int i = 0; i < NumIntComps(); ++i) {
-        if (h_communicate_int_comp[i]) ++num_int_comm_comps;
+    comm_comps_start   = 2 + NStructInt;
+    for (int i = comm_comps_start; i < comm_comps_start + NumIntComps(); ++i) {
+        if (h_redistribute_int_comp[i]) {++num_int_comm_comps;}
     }
 
     particle_size = sizeof(ParticleType);
@@ -1263,7 +1247,8 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>
 
     ParticleCopyPlan plan;
 
-    plan.build(*this, op, local);
+    plan.build(*this, op, h_redistribute_int_comp,
+               h_redistribute_real_comp, local);
 
     Gpu::DeviceVector<char> snd_buffer;
     Gpu::DeviceVector<char> rcv_buffer;
@@ -1494,14 +1479,16 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>
                       particles_to_send.resize(new_size);
                       std::memcpy(&particles_to_send[old_size], &p, particle_size);
                       char* dst = &particles_to_send[old_size] + particle_size;
+                      int array_comp_start = AMREX_SPACEDIM + NStructReal;
                       for (int comp = 0; comp < NumRealComps(); comp++) {
-                          if (h_communicate_real_comp[comp]) {
+                          if (h_redistribute_real_comp[array_comp_start + comp]) {
                               std::memcpy(dst, &soa.GetRealData(comp)[pindex], sizeof(ParticleReal));
                               dst += sizeof(ParticleReal);
                           }
                       }
+                      array_comp_start = 2 + NStructInt;
                       for (int comp = 0; comp < NumIntComps(); comp++) {
-                          if (h_communicate_int_comp[comp]) {
+                          if (h_redistribute_int_comp[array_comp_start + comp]) {
                               std::memcpy(dst, &soa.GetIntData(comp)[pindex], sizeof(int));
                               dst += sizeof(int);
                           }
@@ -1814,8 +1801,9 @@ RedistributeMPI (std::map<int, Vector<char> >& not_ours,
                 std::memcpy(&p, pbuf, sizeof(ParticleType));
                 pbuf += sizeof(ParticleType);
                 ptile.push_back(p);
+                int array_comp_start = AMREX_SPACEDIM + NStructReal;
                 for (int comp = 0; comp < NumRealComps(); ++comp) {
-                    if (h_communicate_real_comp[comp]) {
+                    if (h_redistribute_real_comp[array_comp_start + comp]) {
                         ParticleReal rdata;
                         std::memcpy(&rdata, pbuf, sizeof(ParticleReal));
                         pbuf += sizeof(ParticleReal);
@@ -1825,8 +1813,9 @@ RedistributeMPI (std::map<int, Vector<char> >& not_ours,
                     }
                 }
 
+                array_comp_start = 2 + NStructInt;
                 for (int comp = 0; comp < NumIntComps(); ++comp) {
-                    if (h_communicate_int_comp[comp]) {
+                    if (h_redistribute_int_comp[array_comp_start + comp]) {
                         int idata;
                         std::memcpy(&idata, pbuf, sizeof(int));
                         pbuf += sizeof(int);
@@ -1877,8 +1866,9 @@ RedistributeMPI (std::map<int, Vector<char> >& not_ours,
                 host_particles[lev][ind].push_back(p);
 
                 // add the real...
+                int array_comp_start = AMREX_SPACEDIM + NStructReal;
                 for (int comp = 0; comp < NumRealComps(); ++comp) {
-                    if (h_communicate_real_comp[comp]) {
+                    if (h_redistribute_real_comp[array_comp_start + comp]) {
                         Real rdata;
                         std::memcpy(&rdata, pbuf, sizeof(Real));
                         pbuf += sizeof(Real);
@@ -1889,8 +1879,9 @@ RedistributeMPI (std::map<int, Vector<char> >& not_ours,
                 }
 
                 // ... and int array data
+                array_comp_start = 2 + NStructInt;
                 for (int comp = 0; comp < NumIntComps(); ++comp) {
-                    if (h_communicate_int_comp[comp]) {
+                    if (h_redistribute_int_comp[array_comp_start + comp]) {
                         int idata;
                         std::memcpy(&idata, pbuf, sizeof(int));
                         pbuf += sizeof(int);

--- a/Src/Particle/AMReX_ParticleTile.H
+++ b/Src/Particle/AMReX_ParticleTile.H
@@ -38,33 +38,37 @@ struct ParticleTileData
         auto dst = buffer + dst_offset;
         memcpy(dst, m_aos + src_index, sizeof(ParticleType));
         dst += sizeof(ParticleType);
+        int array_start_index  = AMREX_SPACEDIM + NStructReal;
         for (int i = 0; i < NArrayReal; ++i)
         {
-            if (comm_real[i])
+            if (comm_real[array_start_index + i])
             {
                 memcpy(dst, m_rdata[i] + src_index, sizeof(ParticleReal));
                 dst += sizeof(ParticleReal);
             }
         }
+        int runtime_start_index  = AMREX_SPACEDIM + NStructReal + NArrayReal;
         for (int i = 0; i < m_num_runtime_real; ++i)
         {
-            if (comm_real[NArrayReal+i])
+            if (comm_real[runtime_start_index + i])
             {
                 memcpy(dst, m_runtime_rdata[i] + src_index, sizeof(ParticleReal));
                 dst += sizeof(ParticleReal);
             }
         }
+        array_start_index  = 2 + NStructInt;
         for (int i = 0; i < NArrayInt; ++i)
         {
-            if (comm_int[i])
+            if (comm_int[array_start_index + i])
             {
                 memcpy(dst, m_idata[i] + src_index, sizeof(int));
                 dst += sizeof(int);
             }
         }
+        runtime_start_index  = 2 + NStructInt + NArrayInt;
         for (int i = 0; i < m_num_runtime_int; ++i)
         {
-            if (comm_int[NArrayInt+i])
+            if (comm_int[runtime_start_index + i])
             {
                 memcpy(dst, m_runtime_idata[i] + src_index, sizeof(int));
                 dst += sizeof(int);
@@ -80,33 +84,37 @@ struct ParticleTileData
         auto src = buffer + src_offset;
         memcpy(m_aos + dst_index, src, sizeof(ParticleType));
         src += sizeof(ParticleType);
+        int array_start_index  = AMREX_SPACEDIM + NStructReal;
         for (int i = 0; i < NArrayReal; ++i)
         {
-            if (comm_real[i])
+            if (comm_real[array_start_index + i])
             {
                 memcpy(m_rdata[i] + dst_index, src, sizeof(ParticleReal));
                 src += sizeof(ParticleReal);
             }
         }
+        int runtime_start_index  = AMREX_SPACEDIM + NStructReal + NArrayReal;
         for (int i = 0; i < m_num_runtime_real; ++i)
         {
-            if (comm_real[NArrayReal+i])
+            if (comm_real[runtime_start_index + i])
             {
                 memcpy(m_runtime_rdata[i] + dst_index, src, sizeof(ParticleReal));
                 src += sizeof(ParticleReal);
             }
         }
+        array_start_index  = 2 + NStructInt;
         for (int i = 0; i < NArrayInt; ++i)
         {
-            if (comm_int[i])
+            if (comm_int[array_start_index + i])
             {
                 memcpy(m_idata[i] + dst_index, src, sizeof(int));
                 src += sizeof(int);
             }
         }
+        runtime_start_index  = 2 + NStructInt + NArrayInt;
         for (int i = 0; i < m_num_runtime_int; ++i)
         {
-            if (comm_int[NArrayInt+i])
+            if (comm_int[runtime_start_index + i])
             {
                 memcpy(m_runtime_idata[i] + dst_index, src, sizeof(int));
                 src += sizeof(int);
@@ -178,33 +186,37 @@ struct ConstParticleTileData
         auto dst = buffer + dst_offset;
         memcpy(dst, m_aos + src_index, sizeof(ParticleType));
         dst += sizeof(ParticleType);
+        int array_start_index  = AMREX_SPACEDIM + NStructReal;
         for (int i = 0; i < NArrayReal; ++i)
         {
-            if (comm_real[i])
+            if (comm_real[array_start_index + i])
             {
                 memcpy(dst, m_rdata[i] + src_index, sizeof(ParticleReal));
                 dst += sizeof(ParticleReal);
             }
         }
+        int runtime_start_index  = AMREX_SPACEDIM + NStructReal + NArrayReal;
         for (int i = 0; i < m_num_runtime_real; ++i)
         {
-            if (comm_real[NArrayReal+i])
+            if (comm_real[runtime_start_index + i])
             {
                 memcpy(dst, m_runtime_rdata[i] + src_index, sizeof(ParticleReal));
                 dst += sizeof(ParticleReal);
             }
         }
+        array_start_index  = 2 + NStructInt;
         for (int i = 0; i < NArrayInt; ++i)
         {
-            if (comm_int[i])
+            if (comm_int[array_start_index + i])
             {
                 memcpy(dst, m_idata[i] + src_index, sizeof(int));
                 dst += sizeof(int);
             }
         }
+        runtime_start_index  = 2 + NStructInt + NArrayInt;
         for (int i = 0; i < m_num_runtime_int; ++i)
         {
-            if (comm_int[NArrayInt+i])
+            if (comm_int[runtime_start_index + i])
             {
                 memcpy(dst, m_runtime_idata[i] + src_index, sizeof(int));
                 dst += sizeof(int);

--- a/Src/Particle/AMReX_Particles.H
+++ b/Src/Particle/AMReX_Particles.H
@@ -190,8 +190,8 @@ public:
     ParticleContainer ()
       :
       ParticleContainerBase(),
-      h_communicate_real_comp(NArrayReal, true),
-      h_communicate_int_comp(NArrayInt, true),
+      h_redistribute_real_comp(AMREX_SPACEDIM + NStructReal + NArrayReal, true),
+      h_redistribute_int_comp(2 + NStructInt + NArrayInt, true),
       m_runtime_comps_defined(false),
       m_num_runtime_real(0),
       m_num_runtime_int(0)
@@ -209,8 +209,8 @@ public:
     ParticleContainer (ParGDBBase* gdb)
         :
         ParticleContainerBase(gdb),
-        h_communicate_real_comp(NArrayReal, true),
-        h_communicate_int_comp(NArrayInt, true),
+        h_redistribute_real_comp(AMREX_SPACEDIM + NStructReal + NArrayReal, true),
+        h_redistribute_int_comp(2 + NStructInt + NArrayInt, true),
         m_runtime_comps_defined(false),
         m_num_runtime_real(0),
         m_num_runtime_int(0)
@@ -232,8 +232,8 @@ public:
                        const BoxArray            & ba)
         :
         ParticleContainerBase(geom, dmap, ba),
-        h_communicate_real_comp(NArrayReal, true),
-        h_communicate_int_comp(NArrayInt, true),
+        h_redistribute_real_comp(AMREX_SPACEDIM + NStructReal + NArrayReal, true),
+        h_redistribute_int_comp(2 + NStructInt + NArrayInt, true),
         m_runtime_comps_defined(false),
         m_num_runtime_real(0),
         m_num_runtime_int(0)
@@ -258,8 +258,8 @@ public:
                        const Vector<int>                 & rr)
         :
         ParticleContainerBase(geom, dmap, ba, rr),
-        h_communicate_real_comp(NArrayReal, true),
-        h_communicate_int_comp(NArrayInt, true),
+        h_redistribute_real_comp(AMREX_SPACEDIM + NStructReal + NArrayReal, true),
+        h_redistribute_int_comp(2 + NStructInt + NArrayInt, true),
         m_runtime_comps_defined(false),
         m_num_runtime_real(0),
         m_num_runtime_int(0)
@@ -283,8 +283,8 @@ public:
                        const Vector<IntVect>             & rr)
         :
         ParticleContainerBase(geom, dmap, ba, rr),
-        h_communicate_real_comp(NArrayReal, true),
-        h_communicate_int_comp(NArrayInt, true),
+        h_redistribute_real_comp(AMREX_SPACEDIM + NStructReal + NArrayReal, true),
+        h_redistribute_int_comp(2 + NStructInt + NArrayInt, true),
         m_runtime_comps_defined(false),
         m_num_runtime_real(0),
         m_num_runtime_int(0)
@@ -1199,7 +1199,7 @@ public:
     {
         m_runtime_comps_defined = true;
         m_num_runtime_real++;
-        h_communicate_real_comp.push_back(communicate);
+        h_redistribute_real_comp.push_back(communicate);
         SetParticleSize();
     }
 
@@ -1209,7 +1209,7 @@ public:
     {
         m_runtime_comps_defined = true;
         m_num_runtime_int++;
-        h_communicate_int_comp.push_back(communicate);
+        h_redistribute_int_comp.push_back(communicate);
         SetParticleSize();
     }
 
@@ -1219,10 +1219,8 @@ public:
     int NumRealComps () const { return NArrayReal + NumRuntimeRealComps(); }
     int NumIntComps  () const { return NArrayInt  + NumRuntimeIntComps() ; }
 
-    Vector<int> h_communicate_real_comp;
-    Vector<int> h_communicate_int_comp;
-    Gpu::DeviceVector<int> d_communicate_real_comp;
-    Gpu::DeviceVector<int> d_communicate_int_comp;
+    Vector<int> h_redistribute_real_comp;
+    Vector<int> h_redistribute_int_comp;
 
     //! Variables for i/o optimization saved for pre and post checkpoint
     mutable bool levelDirectoriesCreated;


### PR DESCRIPTION
## Summary

## Additional background
The current GPU implementation communicates the same variables for the ghost-particle update and particle redistribution, while the former may involve fewer variables than the latter. This PR restricts the ghost-particle exchange to only communicate variables specified by the user.

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
