### PR TITLE
Fix AmrParticleContainer::AssignDensity when ncomp == AMREX_SPACEDIM+1.

### DIFF
--- a/Src/AmrCore/AMReX_AmrParticles.H
+++ b/Src/AmrCore/AMReX_AmrParticles.H
@@ -90,7 +90,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>
     // configure this to do a no-op at the physical boundaries.
     int lo_bc[] = {BCType::int_dir, BCType::int_dir, BCType::int_dir};
     int hi_bc[] = {BCType::int_dir, BCType::int_dir, BCType::int_dir};
-    Vector<BCRec> bcs(1, BCRec(lo_bc, hi_bc));
+    Vector<BCRec> bcs(ncomp, BCRec(lo_bc, hi_bc));
     PCInterp mapper;
 
     Vector<std::unique_ptr<MultiFab> > tmp(finest_level+1);


### PR DESCRIPTION
The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
