### PR TITLE
ParticleTile: push_back_real/int w/ Vector

### DIFF
--- a/Src/Particle/AMReX_ParticleTile.H
+++ b/Src/Particle/AMReX_ParticleTile.H
@@ -401,6 +401,22 @@ struct ParticleTile
     }
 
     ///
+    /// Add a range of Real values to the struct-of-arrays for the given comp.
+    /// This sets the data for several particles at once.
+    ///
+    void push_back_real (int comp, amrex::Vector<amrex::ParticleReal>::const_iterator beg, amrex::Vector<amrex::ParticleReal>::const_iterator end) {
+        push_back_real(comp, &(*beg), &(*end));
+    }
+
+    ///
+    /// Add a range of Real values to the struct-of-arrays for the given comp.
+    /// This sets the data for several particles at once.
+    ///
+    void push_back_real (int comp, amrex::Vector<amrex::ParticleReal> const & vec) {
+        push_back_real(comp, vec.cbegin(), vec.cend());
+    }
+
+    ///
     /// Add npar copies of the Real value v to the struct-of-arrays for the given comp.
     /// This sets the data for several particles at once.
     ///
@@ -434,6 +450,22 @@ struct ParticleTile
     void push_back_int (int comp, const int* beg, const int* end) {
         auto it = m_soa_tile.GetIntData(comp).end();
         m_soa_tile.GetIntData(comp).insert(it, beg, end);
+    }
+
+    ///
+    /// Add a range of int values to the struct-of-arrays for the given comp.
+    /// This sets the data for several particles at once.
+    ///
+    void push_back_int (int comp, amrex::Vector<int>::const_iterator beg, amrex::Vector<int>::const_iterator end) {
+        push_back_int(comp, &(*beg), &(*end));
+    }
+
+    ///
+    /// Add a range of int values to the struct-of-arrays for the given comp.
+    /// This sets the data for several particles at once.
+    ///
+    void push_back_int (int comp, amrex::Vector<int> const & vec) {
+        push_back_int(comp, vec.cbegin(), vec.cend());
     }
 
     ///


### PR DESCRIPTION
## Summary

Add more overloads to `push_back_real`/`int` to support `amrex::Vector` and its const iterators.

This makes initialization routines more natural / C++-y (similar to `std::vector` constructors).

## Additional background

See C pointer plays in https://github.com/ECP-WarpX/impactx/pull/67

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
