### PR TITLE
Doc + CMake: AMREX_EXPORT_DYNAMIC

### DIFF
--- a/Docs/sphinx_documentation/source/BuildingAMReX.rst
+++ b/Docs/sphinx_documentation/source/BuildingAMReX.rst
@@ -495,6 +495,8 @@ The list of available options is reported in the :ref:`table <tab:cmakevar>` bel
    +------------------------------+-------------------------------------------------+-------------------------+-----------------------+
    | AMReX_BOUND_CHECK            |  Enable bound checking in Array4 class          | NO                      | YES, NO               |
    +------------------------------+-------------------------------------------------+-------------------------+-----------------------+
+   | AMReX_EXPORT_DYNAMIC         |  Enable backtrace on macOS                      | NO (unless Darwin)      | YES, NO               |
+   +------------------------------+-------------------------------------------------+-------------------------+-----------------------+
    | AMReX_SENSEI                 |  Enable the SENSEI in situ infrastucture        | NO                      | YES, NO               |
    +------------------------------+-------------------------------------------------+-------------------------+-----------------------+
    | AMReX_NO_SENSEI_AMR_INST     |  Disables the instrumentation in amrex::Amr     | NO                      | YES, NO               |

--- a/Tools/CMake/AMReXOptions.cmake
+++ b/Tools/CMake/AMReXOptions.cmake
@@ -331,6 +331,14 @@ print_option( AMReX_ASSERTIONS )
 option(AMReX_BOUND_CHECK  "Enable bound checking in Array4 class" OFF)
 print_option( AMReX_BOUND_CHECK )
 
+if("${CMAKE_SYSTEM_NAME}" MATCHES "Darwin")
+    set(AMReX_EXPORT_DYNAMIC_DEFAULT ON)
+else()
+    set(AMReX_EXPORT_DYNAMIC_DEFAULT OFF)
+endif()
+option( AMReX_EXPORT_DYNAMIC "Enable Backtrace for macOS/Darwin" ${AMReX_EXPORT_DYNAMIC_DEFAULT})
+print_option( AMReX_EXPORT_DYNAMIC )
+
 #
 # Profiling options  =========================================================
 #

--- a/Tools/CMake/AMReXSetDefines.cmake
+++ b/Tools/CMake/AMReXSetDefines.cmake
@@ -76,6 +76,9 @@ add_amrex_define( AMREX_USE_ASSERTION NO_LEGACY IF AMReX_ASSERTIONS )
 # Bound checking
 add_amrex_define( AMREX_BOUND_CHECK NO_LEGACY IF AMReX_BOUND_CHECK )
 
+# Backtraces on macOS
+add_amrex_define( AMREX_EXPORT_DYNAMIC NO_LEGACY IF AMReX_EXPORT_DYNAMIC )
+
 if (AMReX_FORTRAN)
 
    # Fortran-specific defines, BL_LANG_FORT and AMREX_LANG_FORT do not get


### PR DESCRIPTION
## Summary

- [x] Add the CMake control for `AMREX_EXPORT_DYNAMIC`
- [ ] Add documentation (help wanted)
- [ ] Is this still needed on modern macOS or can we assume that we can roll with `dlopen` and these imports?

## Additional background

CMake builds currently generate empty backtraces on macOS/Darwin.
cc @RTSandberg

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
