### PR TITLE
Simplify CoordSys::IsRZ and IsSPHERICAL

### DIFF
--- a/Src/Base/AMReX_CoordSys.H
+++ b/Src/Base/AMReX_CoordSys.H
@@ -57,10 +57,14 @@ public:
     int CoordInt () const  noexcept { return static_cast<int>(c_sys); }
 
     //! Is CoordType == SPHERICAL?
-    bool IsSPHERICAL () const noexcept;
+    bool IsSPHERICAL () const noexcept {
+        BL_ASSERT(c_sys != undef); return (c_sys == SPHERICAL);
+    }
 
     //! Is CoordType == RZ?
-    bool IsRZ () const noexcept;
+    bool IsRZ () const noexcept {
+        BL_ASSERT(c_sys != undef); return (c_sys == RZ);
+    }
 
     //! Is CoordType == cartesion?
     bool IsCartesian () const noexcept {
@@ -255,32 +259,6 @@ protected:
                         std::numeric_limits<Real>::infinity())};
     bool ok = false;
 };
-
-inline
-bool
-CoordSys::IsSPHERICAL () const noexcept
-{
-    BL_ASSERT(c_sys != undef);
-#if (AMREX_SPACEDIM <= 2)
-    return (c_sys == SPHERICAL);
-#endif
-#if (AMREX_SPACEDIM == 3)
-    return false;
-#endif
-}
-
-inline
-bool
-CoordSys::IsRZ () const noexcept
-{
-    BL_ASSERT(c_sys != undef);
-#if (AMREX_SPACEDIM <= 2)
-    return (c_sys == RZ);
-#endif
-#if (AMREX_SPACEDIM == 3)
-    return false;
-#endif
-}
 
 }
 


### PR DESCRIPTION
## Summary

In the past, the enum types RZ and SPHERICAL were not defined in 3D and
therefore could not be used in IsRZ and IsSPHERICAL in 3D.  This is no
longer the case.

## Additional background

https://github.com/ECP-WarpX/WarpX/pull/2684#issuecomment-1050130128

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
