### PR TITLE
Update flags for DPC++ AOT

### DIFF
--- a/Tools/CMake/AMReXSYCL.cmake
+++ b/Tools/CMake/AMReXSYCL.cmake
@@ -114,12 +114,12 @@ target_link_options( SYCL
 if (AMReX_DPCPP_AOT)
    target_compile_options( SYCL
       INTERFACE
-      "$<${_cxx_dpcpp}:-fsycl-targets=spir64_gen-unknown-unknown-sycldevice>"
+      "$<${_cxx_dpcpp}:-fsycl-targets=spir64_gen>"
       "$<${_cxx_dpcpp}:SHELL:-Xsycl-target-backend \"-device ${AMReX_INTEL_ARCH}\">" )
 
    target_link_options( SYCL
       INTERFACE
-      "$<${_cxx_dpcpp}:-fsycl-targets=spir64_gen-unknown-unknown-sycldevice>"
+      "$<${_cxx_dpcpp}:-fsycl-targets=spir64_gen>"
       "$<${_cxx_dpcpp}:SHELL:-Xsycl-target-backend \"-device ${AMReX_INTEL_ARCH}\">" )
 endif ()
 

--- a/Tools/GNUMake/comps/dpcpp.mak
+++ b/Tools/GNUMake/comps/dpcpp.mak
@@ -95,7 +95,7 @@ ifeq ($(DPCPP_AOT),TRUE)
     endif
   endif
   endif
-  CXXFLAGS += -fsycl-targets=spir64_gen-unknown-unknown-sycldevice -Xsycl-target-backend '-device $(INTEL_CPU_SHORT_NAME)'
+  CXXFLAGS += -fsycl-targets=spir64_gen -Xsycl-target-backend '-device $(INTEL_CPU_SHORT_NAME)'
 endif
 endif
 


### PR DESCRIPTION
Argument spir64_gen-unknown-unknown-sycldevice has been deprecated recently.
We need to use spir64_gen instead.  Note that we are not trying to support
old oneAPI compilers.  So we simply replace the deprecated argument with the
new one.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
