### PR TITLE
Fix bug affecting neighbor proc calculation with mesh refinement.

### DIFF
--- a/Src/Particle/AMReX_NeighborParticlesI.H
+++ b/Src/Particle/AMReX_NeighborParticlesI.H
@@ -254,7 +254,7 @@ NeighborParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
         {
             box.refine(ref_fac);
         }
-        box.grow(computeRefFac(0, src_lev)*m_num_neighbor_cells);
+        box.grow(computeRefFac(0, lev)*m_num_neighbor_cells);
         const Periodicity& periodicity = this->Geom(lev).periodicity();
         const std::vector<IntVect>& pshifts = periodicity.shiftIntVect();
         const BoxArray& ba = this->ParticleBoxArray(lev);


### PR DESCRIPTION
This bug was spotted by Bruce Palmer with the BoltzmannMFX code. When computing the NeighborCommTags, we need to grow the boxes by the refinement ratio between 0 and the *dst* lev, not the *src* lev. 

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
