### PR TITLE
Added an option to set fast MRI dt directly (Sundials interface)

### DIFF
--- a/Src/Base/AMReX_IntegratorBase.H
+++ b/Src/Base/AMReX_IntegratorBase.H
@@ -169,7 +169,12 @@ protected:
    /**
     * \brief For multirate problems, the ratio of slow timestep size / fast timestep size (int)
     */
-    int slow_fast_timestep_ratio;
+    int slow_fast_timestep_ratio = 0;
+
+   /**
+    * \brief For multirate problems, the fast timestep size (Real)
+    */
+    Real fast_timestep = 0.0;
 
    /**
     * \brief The post_update function is called by the integrator on state data before using it to evaluate a right-hand side.
@@ -200,6 +205,11 @@ public:
         slow_fast_timestep_ratio = timestep_ratio;
     }
 
+    void set_fast_timestep (const Real fast_dt = 1.0)
+    {
+        fast_timestep = fast_dt;
+    }
+
     void set_post_update (std::function<void (T&, amrex::Real)> F)
     {
         post_update = F;
@@ -223,6 +233,11 @@ public:
     int get_slow_fast_timestep_ratio ()
     {
         return slow_fast_timestep_ratio;
+    }
+
+    Real get_fast_timestep ()
+    {
+        return fast_timestep;
     }
 
     void rhs (T& S_rhs, const T& S_data, const amrex::Real time)

--- a/Src/Base/AMReX_TimeIntegrator.H
+++ b/Src/Base/AMReX_TimeIntegrator.H
@@ -151,6 +151,16 @@ public:
         integrator_ptr->set_slow_fast_timestep_ratio(timestep_ratio);
     }
 
+    void set_fast_timestep (const Real fast_dt = 1.0)
+    {
+        integrator_ptr->set_fast_timestep(fast_dt);
+    }
+
+    Real get_fast_timestep ()
+    {
+        return integrator_ptr->get_fast_timestep();
+    }
+
     std::function<void ()> get_post_timestep ()
     {
         return post_timestep;

--- a/Src/Extern/SUNDIALS/AMReX_SundialsIntegrator.H
+++ b/Src/Extern/SUNDIALS/AMReX_SundialsIntegrator.H
@@ -312,11 +312,12 @@ public:
     amrex::Real advance_mri (T& S_old, T& S_new, amrex::Real time, const amrex::Real time_step)
     {
         int mri_time_step_ratio = BaseT::get_slow_fast_timestep_ratio();
-        AMREX_ALWAYS_ASSERT(mri_time_step_ratio >= 1);
+        Real mri_fast_time_step = BaseT::get_fast_timestep();
+        AMREX_ALWAYS_ASSERT(mri_time_step_ratio >= 1 || mri_fast_time_step >= 0.0);
         t               = time;
         tout            = time+time_step;
         hfixed          = time_step;
-        hfixed_mri      = time_step / mri_time_step_ratio;
+        hfixed_mri      = mri_fast_time_step >= 0.0 ? mri_fast_time_step : time_step / mri_time_step_ratio;
         timestep = time_step;
 
         // NOTE: hardcoded for now ...


### PR DESCRIPTION
As an alternative to setting the integer ratio of slow/fast dt, this lets us set the fast dt directly.

## Summary

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [X] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
