### PR TITLE
Removed the use of H5Aget_storage_size

### DIFF
--- a/Src/Extern/HDF5/AMReX_ParticleHDF5.H
+++ b/Src/Extern/HDF5/AMReX_ParticleHDF5.H
@@ -923,12 +923,21 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>
         amrex::Abort(msg.c_str());
     }
 
-    hsize_t attr_len = H5Aget_storage_size(attr);
+    atype = H5Aget_type(attr);
+    if (atype < 0) {
+        std::string msg("ParticleContainer::RestartHDF5(): unable to get type of attribute ");
+        amrex::Abort(msg.c_str());
+    }
+
+    size_t attr_len = H5Tget_size(atype);
+    if (attr_len == 0) {
+        std::string msg("ParticleContainer::RestartHDF5(): unable to get size of attribute ");
+        amrex::Abort(msg.c_str());
+    }
 
     std::string version;
     version.resize(attr_len+1);
 
-    atype = H5Aget_type(attr);
     ret = H5Aread(attr, atype, &version[0]);
     H5Tclose(atype);
 


### PR DESCRIPTION
## Summary
The HDF5 DAOS VOL does not support H5Aget_storage_size, so it was removed in favor of H5Tget_size instead.
With this change, the HDF5Benchmark test passes with the HDF5 DAOS VOL at ANL.

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
