### PR TITLE
GCC 10.3: Wstringop-overflow in FabConv

### DIFF
--- a/Src/Base/AMReX_FabConv.cpp
+++ b/Src/Base/AMReX_FabConv.cpp
@@ -390,6 +390,11 @@ _pd_btrvout (char* out,
         {
             char tmp = *p1;
             *p1 = *p2;
+            // In function 'void amrex::_pd_btrvout(char*, amrex::Long, amrex::Long)',
+            //    inlined from 'void amrex::_pd_insert_field(amrex::Long, int, char*, int, int, int)' at ./amrex/Src/Base/AMReX_FabConv.cpp:462:20,
+            //    inlined from 'void amrex::PD_fconvert(void*, const void*, amrex::Long, int, const Long*, const int*, const Long*, const int*, int, int, int)' at ./amrex/Src/Base/AMReX_FabConv.cpp:685:29:
+            // ./amrex/Src/Base/AMReX_FabConv.cpp:393:17:
+            //   warning: writing 1 byte into a region of size 0 [-Wstringop-overflow=]
             *p2 = tmp;
             p1 += nb;
             p2 += nb;


### PR DESCRIPTION
## Summary

Spotted a buffer overflow when building amrvis with GCC 10.3.

## Additional background

See https://github.com/AMReX-Codes/Amrvis/pull/17
See https://github.com/ECP-WarpX/WarpX/pull/2978

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
