### PR TITLE
BackTrace workarounds

### DIFF
--- a/Src/Base/AMReX_BLBackTrace.cpp
+++ b/Src/Base/AMReX_BLBackTrace.cpp
@@ -226,7 +226,7 @@ BLBackTrace::print_backtrace_info (FILE* f)
                 }
             }
 
-            if ((!(amrex::system::call_addr2line && have_eu_addr2line) || addr2line_result.empty()) &&
+            if (addr2line_result.empty() &&
                 amrex::system::call_addr2line && have_addr2line && !amrex::system::exename.empty())
             {
                 const std::string line = strings[i];

--- a/Src/Base/AMReX_BLBackTrace.cpp
+++ b/Src/Base/AMReX_BLBackTrace.cpp
@@ -180,17 +180,18 @@ BLBackTrace::print_backtrace_info (FILE* f)
     if (strings != NULL) {
         int have_eu_addr2line = 0;
         int have_addr2line = 0;
-        std::string cmd;
+        std::string eu_cmd;
         {
             have_eu_addr2line = file_exists("/usr/bin/eu-addr2line");
             if (have_eu_addr2line) {
                 const pid_t pid = getpid();
                 // cmd = "/usr/bin/eu-addr2line -C -f -i --pretty-print -p "
-                cmd = "/usr/bin/eu-addr2line -C -f -i -p "
+                eu_cmd = "/usr/bin/eu-addr2line -C -f -i -p "
                     + std::to_string(pid);
             }
         }
-        if (!have_eu_addr2line) {
+        std::string cmd;
+        {
             have_addr2line = file_exists("/usr/bin/addr2line");
             if (have_addr2line) {
                 cmd = "/usr/bin/addr2line -Cpfie " + amrex::system::exename;
@@ -218,7 +219,7 @@ BLBackTrace::print_backtrace_info (FILE* f)
                 if (bt_buffer[i] != nullptr) {
                     char print_buff[32];
                     std::snprintf(print_buff,sizeof(print_buff),"%p",bt_buffer[i]);
-                    const std::string full_cmd = cmd + " " + print_buff;
+                    const std::string full_cmd = eu_cmd + " " + print_buff;
                     addr2line_result = run_command(full_cmd);
                     if (addr2line_result.find("??:") != std::string::npos) { // found ??:
                         try_addr2line = true;

--- a/Src/Base/AMReX_BLBackTrace.cpp
+++ b/Src/Base/AMReX_BLBackTrace.cpp
@@ -190,7 +190,7 @@ BLBackTrace::print_backtrace_info (FILE* f)
                     + std::to_string(pid);
             }
         }
-        if (!have_eu_addr2line) {
+        {
             have_addr2line = file_exists("/usr/bin/addr2line");
             if (have_addr2line) {
                 cmd = "/usr/bin/addr2line -Cpfie " + amrex::system::exename;
@@ -220,8 +220,14 @@ BLBackTrace::print_backtrace_info (FILE* f)
                     const std::string full_cmd = cmd + " " + print_buff;
                     addr2line_result = run_command(full_cmd);
                 }
-            } else if (amrex::system::call_addr2line && have_addr2line &&
-                       !amrex::system::exename.empty())
+
+                if (addr2line_result.find('?') != std::string::npos) {
+                    addr2line_result.clear();
+                }
+            }
+
+            if ((!(amrex::system::call_addr2line && have_eu_addr2line) || addr2line_result.empty()) &&
+                amrex::system::call_addr2line && have_addr2line && !amrex::system::exename.empty())
             {
                 const std::string line = strings[i];
                 std::size_t found_libc = line.find("libc.so");

--- a/Src/Base/AMReX_BLBackTrace.cpp
+++ b/Src/Base/AMReX_BLBackTrace.cpp
@@ -180,6 +180,7 @@ BLBackTrace::print_backtrace_info (FILE* f)
     if (strings != NULL) {
         int have_eu_addr2line = 0;
         int have_addr2line = 0;
+        int use_eu_addr2line = 0;
         std::string cmd;
         {
             have_eu_addr2line = file_exists("/usr/bin/eu-addr2line");
@@ -188,9 +189,29 @@ BLBackTrace::print_backtrace_info (FILE* f)
                 // cmd = "/usr/bin/eu-addr2line -C -f -i --pretty-print -p "
                 cmd = "/usr/bin/eu-addr2line -C -f -i -p "
                     + std::to_string(pid);
+
+                for (int i = 0; i < nentries; ++i)
+                {
+
+#if !defined(AMREX_USE_OMP) || !defined(__INTEL_COMPILER)
+                  std::string addr2line_result;
+                  if (amrex::system::call_addr2line && have_eu_addr2line) {
+                    if (bt_buffer[i] != nullptr) {
+                      char print_buff[32];
+                      std::snprintf(print_buff,sizeof(print_buff),"%p",bt_buffer[i]);
+                      const std::string full_cmd = cmd + " " + print_buff;
+                      addr2line_result = run_command(full_cmd);
+                    }
+                  }
+                  if (addr2line_result.find("AMReX_BLBackTrace.cpp:") != std::string::npos) {
+                    use_eu_addr2line = 1;
+                    break;
+                  }
+                }
+#endif
             }
         }
-        {
+        if (!have_eu_addr2line || !use_eu_addr2line) {
             have_addr2line = file_exists("/usr/bin/addr2line");
             if (have_addr2line) {
                 cmd = "/usr/bin/addr2line -Cpfie " + amrex::system::exename;
@@ -213,21 +234,15 @@ BLBackTrace::print_backtrace_info (FILE* f)
 
 #if !defined(AMREX_USE_OMP) || !defined(__INTEL_COMPILER)
             std::string addr2line_result;
-            if (amrex::system::call_addr2line && have_eu_addr2line) {
+            if (amrex::system::call_addr2line && have_eu_addr2line && use_eu_addr2line) {
                 if (bt_buffer[i] != nullptr) {
                     char print_buff[32];
                     std::snprintf(print_buff,sizeof(print_buff),"%p",bt_buffer[i]);
                     const std::string full_cmd = cmd + " " + print_buff;
                     addr2line_result = run_command(full_cmd);
                 }
-
-                if (addr2line_result.find('?') != std::string::npos) {
-                    addr2line_result.clear();
-                }
-            }
-
-            if (addr2line_result.empty() &&
-                amrex::system::call_addr2line && have_addr2line && !amrex::system::exename.empty())
+            } else if (amrex::system::call_addr2line && have_addr2line &&
+                       !amrex::system::exename.empty())
             {
                 const std::string line = strings[i];
                 std::size_t found_libc = line.find("libc.so");
@@ -246,7 +261,7 @@ BLBackTrace::print_backtrace_info (FILE* f)
                     if (!addr.empty()) {
                         const std::string full_cmd = cmd + " " + addr;
                         addr2line_result = run_command(full_cmd);
-                        if (addr2line_result.find('?') != std::string::npos) {
+                        if (addr2line_result.find("AMReX_BLBackTrace.cpp:") != std::string::npos) {
                             addr2line_result.clear();
                         }
                     }

--- a/Tools/GNUMake/comps/gnu.mak
+++ b/Tools/GNUMake/comps/gnu.mak
@@ -44,6 +44,7 @@ gcc_major_ge_7 = $(shell expr $(gcc_major_version) \>= 7)
 gcc_major_ge_8 = $(shell expr $(gcc_major_version) \>= 8)
 gcc_major_ge_9 = $(shell expr $(gcc_major_version) \>= 9)
 gcc_major_ge_10 = $(shell expr $(gcc_major_version) \>= 10)
+gcc_major_ge_11 = $(shell expr $(gcc_major_version) \>= 11)
 
 ifeq ($(THREAD_SANITIZER),TRUE)
   GENERIC_GNU_FLAGS += -fsanitize=thread
@@ -78,11 +79,21 @@ CXXFLAGS += -Werror=return-type
 CFLAGS   += -Werror=return-type
 
 ifeq ($(DEBUG),TRUE)
-  CXXFLAGS += -g -O0 -ggdb -ftrapv
-  CFLAGS   += -g -O0 -ggdb -ftrapv
+  ifeq ($(gcc_major_ge_11),1)
+    CXXFLAGS += -gdwarf-4 -O0 -ggdb -ftrapv
+    CFLAGS   += -gdwarf-4 -O0 -ggdb -ftrapv
+  else
+    CXXFLAGS += -g -O0 -ggdb -ftrapv
+    CFLAGS   += -g -O0 -ggdb -ftrapv
+  endif
 else
-  CXXFLAGS += -g -O3
-  CFLAGS   += -g -O3
+  ifeq ($(gcc_major_ge_11),1)
+    CXXFLAGS += -gdwarf-4 -O3
+    CFLAGS   += -gdwarf-4 -O3
+  else
+    CXXFLAGS += -g -O3
+    CFLAGS   += -g -O3
+  endif
 endif
 
 ifeq ($(WARN_ALL),TRUE)


### PR DESCRIPTION
## Summary
This fixes two different addr2line issues seen at OLCF using amrex

## Additional background
Uses `-gdwarf-4` instead of `-g` for gcc 11 to fix `/usr/bin/addr2line: Dwarf Error: Can't find .debug_ranges section`. This affects systems where binutils is too old. https://gcc.gnu.org/bugzilla/show_bug.cgi?id=100725
Uses addr2line as a fallback if eu-addr2line gives results such as `??:0`

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
