### PR TITLE
Allow ParticleToMesh and MeshToParticle to access runtime particle components

### DIFF
--- a/Src/Particle/AMReX_ParticleUtil.H
+++ b/Src/Particle/AMReX_ParticleUtil.H
@@ -136,8 +136,7 @@ auto call_f (F const& f,
 }
 
 // Lambda takes a ConstParticleTileData
-template <typename F, typename T, int NSR, int NSI, int NAR, int NAI,
-          typename std::enable_if<(NAR != 0) || (NAI != 0), int>::type = 0>
+template <typename F, typename T, int NSR, int NSI, int NAR, int NAI>
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 auto call_f (F const& f,
              const ConstParticleTileData<NSR, NSI, NAR, NAI>& p,
@@ -150,8 +149,7 @@ auto call_f (F const& f,
 }
 
 // Lambda takes a ConstParticleTileData
-template <typename F, typename T, int NSR, int NSI, int NAR, int NAI,
-          typename std::enable_if<(NAR != 0) || (NAI != 0), int>::type = 0>
+template <typename F, typename T, int NSR, int NSI, int NAR, int NAI>
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 auto call_f (F const& f,
              const ConstParticleTileData<NSR, NSI, NAR, NAI>& p,
@@ -161,20 +159,6 @@ auto call_f (F const& f,
     -> decltype(f(p, i, fabarr, plo, dxi))
 {
     return f(p, i, fabarr, plo, dxi);
-}
-
-// Lambda takes a SuperParticle
-template <typename F, typename T, int NSR, int NSI, int NAR, int NAI,
-          typename std::enable_if<(NAR != 0) || (NAI != 0), int>::type = 0>
-AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-auto call_f (F const& f,
-             const ConstParticleTileData<NSR, NSI, NAR, NAI>& p,
-             const int i, Array4<T> const& fabarr,
-             GpuArray<Real,AMREX_SPACEDIM> const&,
-             GpuArray<Real,AMREX_SPACEDIM> const&) noexcept
-    -> decltype(f(p.getSuperParticle(i), fabarr))
-{
-    return f(p.getSuperParticle(i), fabarr);
 }
 
 }

--- a/Src/Particle/AMReX_ParticleUtil.H
+++ b/Src/Particle/AMReX_ParticleUtil.H
@@ -135,6 +135,48 @@ auto call_f (F const& f,
     return f(p.getSuperParticle(i), fabarr);
 }
 
+// Lambda takes a ConstParticleTileData
+template <typename F, typename T, int NSR, int NSI, int NAR, int NAI,
+          typename std::enable_if<(NAR != 0) || (NAI != 0), int>::type = 0>
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+auto call_f (F const& f,
+             const ConstParticleTileData<NSR, NSI, NAR, NAI>& p,
+             const int i, Array4<T> const& fabarr,
+             GpuArray<Real,AMREX_SPACEDIM> const&,
+             GpuArray<Real,AMREX_SPACEDIM> const&) noexcept
+    -> decltype(f(p, i, fabarr))
+{
+    return f(p, i, fabarr);
+}
+
+// Lambda takes a ConstParticleTileData
+template <typename F, typename T, int NSR, int NSI, int NAR, int NAI,
+          typename std::enable_if<(NAR != 0) || (NAI != 0), int>::type = 0>
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+auto call_f (F const& f,
+             const ConstParticleTileData<NSR, NSI, NAR, NAI>& p,
+             const int i, Array4<T> const& fabarr,
+             GpuArray<Real,AMREX_SPACEDIM> const& plo,
+             GpuArray<Real,AMREX_SPACEDIM> const& dxi) noexcept
+    -> decltype(f(p, i, fabarr, plo, dxi))
+{
+    return f(p, i, fabarr, plo, dxi);
+}
+
+// Lambda takes a SuperParticle
+template <typename F, typename T, int NSR, int NSI, int NAR, int NAI,
+          typename std::enable_if<(NAR != 0) || (NAI != 0), int>::type = 0>
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+auto call_f (F const& f,
+             const ConstParticleTileData<NSR, NSI, NAR, NAI>& p,
+             const int i, Array4<T> const& fabarr,
+             GpuArray<Real,AMREX_SPACEDIM> const&,
+             GpuArray<Real,AMREX_SPACEDIM> const&) noexcept
+    -> decltype(f(p.getSuperParticle(i), fabarr))
+{
+    return f(p.getSuperParticle(i), fabarr);
+}
+
 }
 
 /**

--- a/Src/Particle/AMReX_ParticleUtil.H
+++ b/Src/Particle/AMReX_ParticleUtil.H
@@ -161,6 +161,33 @@ auto call_f (F const& f,
     return f(p, i, fabarr, plo, dxi);
 }
 
+// Lambda takes a ParticleTileData
+template <typename F, typename T, int NSR, int NSI, int NAR, int NAI>
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+auto call_f (F const& f,
+             const ParticleTileData<NSR, NSI, NAR, NAI>& p,
+             const int i, Array4<const T> const& fabarr,
+             GpuArray<Real,AMREX_SPACEDIM> const& plo,
+             GpuArray<Real,AMREX_SPACEDIM> const& dxi) noexcept
+    -> decltype(f(p, i, fabarr, plo, dxi))
+{
+    return f(p, i, fabarr, plo, dxi);
+}
+
+// Lambda takes a ParticleTileData
+template <typename F, typename T, int NSR, int NSI, int NAR, int NAI>
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+auto call_f (F const& f,
+             const ParticleTileData<NSR, NSI, NAR, NAI>& p,
+             const int i, Array4<const T> const& fabarr,
+             GpuArray<Real,AMREX_SPACEDIM> const&,
+             GpuArray<Real,AMREX_SPACEDIM> const&) noexcept
+    -> decltype(f(p, i, fabarr))
+{
+    return f(p, i, fabarr);
+}
+
+
 }
 
 /**

--- a/Tests/Particles/ParticleMesh/main.cpp
+++ b/Tests/Particles/ParticleMesh/main.cpp
@@ -128,10 +128,10 @@ void testParticleMesh (TestParams& parms)
       });
 
   amrex::MeshToParticle(myPC, partiMF, 0,
-                        [=] AMREX_GPU_DEVICE (const MyParticleContainer::ParticleTileType::ParticleTileDataType& ptd, int i,
+                        [=] AMREX_GPU_DEVICE (const MyParticleContainer::ParticleTileType::ParticleTileDataType& ptd, int ip,
                                               amrex::Array4<const int> const& count)
       {
-          auto p = ptd.m_aos[i];
+          auto p = ptd.m_aos[ip];
           ParticleInterpolator::Nearest interp(p, plo, dxi);
 
           interp.MeshToParticle(p, count, 0, 0, 1,

--- a/Tests/Particles/ParticleMesh/main.cpp
+++ b/Tests/Particles/ParticleMesh/main.cpp
@@ -71,9 +71,10 @@ void testParticleMesh (TestParams& parms)
   const auto plo = geom.ProbLoArray();
   const auto dxi = geom.InvCellSizeArray();
   amrex::ParticleToMesh(myPC, partMF, 0,
-      [=] AMREX_GPU_DEVICE (const MyParticleContainer::ParticleType& p,
-                            amrex::Array4<amrex::Real> const& rho)
+                        [=] AMREX_GPU_DEVICE (const MyParticleContainer::ParticleTileType::ConstParticleTileDataType& ptd, int i,
+                                              amrex::Array4<amrex::Real> const& rho)
       {
+          auto p = ptd.m_aos[i];
           ParticleInterpolator::Linear interp(p, plo, dxi);
 
           interp.ParticleToMesh(p, rho, 0, 0, 1,

--- a/Tests/Particles/ParticleMesh/main.cpp
+++ b/Tests/Particles/ParticleMesh/main.cpp
@@ -128,9 +128,10 @@ void testParticleMesh (TestParams& parms)
       });
 
   amrex::MeshToParticle(myPC, partiMF, 0,
-      [=] AMREX_GPU_DEVICE (MyParticleContainer::ParticleType& p,
-                            amrex::Array4<const int> const& count)
+                        [=] AMREX_GPU_DEVICE (const MyParticleContainer::ParticleTileType::ParticleTileDataType& ptd, int i,
+                                              amrex::Array4<const int> const& count)
       {
+          auto p = ptd.m_aos[i];
           ParticleInterpolator::Nearest interp(p, plo, dxi);
 
           interp.MeshToParticle(p, count, 0, 0, 1,


### PR DESCRIPTION
The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
