### PR TITLE
Add override statements to avoid certain compiler warnings (GCC & Clang)

### DIFF
--- a/Src/Base/AMReX_FEIntegrator.H
+++ b/Src/Base/AMReX_FEIntegrator.H
@@ -30,12 +30,12 @@ public:
 
     virtual ~FEIntegrator () {}
 
-    void initialize (const T& S_data)
+    void initialize (const T& S_data) override
     {
         initialize_stages(S_data);
     }
 
-    amrex::Real advance (T& S_old, T& S_new, amrex::Real time, const amrex::Real time_step)
+    amrex::Real advance (T& S_old, T& S_new, amrex::Real time, const amrex::Real time_step) override
     {
         BaseT::timestep = time_step;
         // Assume before advance() that S_old is valid data at the current time ("time" argument)

--- a/Src/Base/AMReX_RKIntegrator.H
+++ b/Src/Base/AMReX_RKIntegrator.H
@@ -160,7 +160,7 @@ public:
         initialize(S_data);
     }
 
-    void initialize (const T& S_data)
+    void initialize (const T& S_data) override
     {
         initialize_parameters();
         initialize_stages(S_data);
@@ -168,7 +168,7 @@ public:
 
     virtual ~RKIntegrator () {}
 
-    amrex::Real advance (T& S_old, T& S_new, amrex::Real time, const amrex::Real time_step)
+    amrex::Real advance (T& S_old, T& S_new, amrex::Real time, const amrex::Real time_step) override
     {
         BaseT::timestep = time_step;
         // Assume before advance() that S_old is valid data at the current time ("time" argument)
@@ -222,7 +222,7 @@ public:
         return BaseT::timestep;
     }
 
-    void time_interpolate (const T& /* S_new */, const T& S_old, amrex::Real timestep_fraction, T& data)
+    void time_interpolate (const T& /* S_new */, const T& S_old, amrex::Real timestep_fraction, T& data) override
     {
         // data = S_old*(1-time_step_fraction) + S_new*(time_step_fraction)
         /*
@@ -260,7 +260,7 @@ public:
 
     }
 
-    void map_data (std::function<void(T&)> Map)
+    void map_data (std::function<void(T&)> Map) override
     {
         for (auto& F : F_nodes) {
             Map(*F);

--- a/Src/Extern/SUNDIALS/AMReX_SundialsIntegrator.H
+++ b/Src/Extern/SUNDIALS/AMReX_SundialsIntegrator.H
@@ -147,7 +147,7 @@ public:
         initialize();
     }
 
-    void initialize (const T& /* S_data */)
+    void initialize (const T& /* S_data */) override
     {
         initialize_parameters();
         mpi_comm = ParallelContext::CommunicatorSub();
@@ -165,7 +165,7 @@ public:
         SUNContext_Free(&sunctx);
     }
 
-    amrex::Real advance (T& S_old, T& S_new, amrex::Real time, const amrex::Real time_step)
+    amrex::Real advance (T& S_old, T& S_new, amrex::Real time, const amrex::Real time_step) override
     {
         if (use_mri_strategy) {
             return advance_mri(S_old, S_new, time, time_step);
@@ -568,9 +568,9 @@ public:
         return timestep;
     }
 
-    void time_interpolate (const T& /* S_new */, const T& /* S_old */, amrex::Real /* timestep_fraction */, T& /* data */) {}
+    void time_interpolate (const T& /* S_new */, const T& /* S_old */, amrex::Real /* timestep_fraction */, T& /* data */) override {}
 
-    void map_data (std::function<void(T&)> /* Map */) {}
+    void map_data (std::function<void(T&)> /* Map */) override {}
 
 };
 


### PR DESCRIPTION
The TimeIntegrator classes were missing a few override statements for function declarations.

This adds the missing statements.

## Summary

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
