### PR TITLE
CI: Apple Silicon

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -9,9 +9,12 @@ concurrency:
 jobs:
   # Build libamrex and all tests
   tests-macos-eb:
-    name: AppleClang@11.0 GFortran@9.3 [tests-eb]
+    name: AppleClang@11.0 GFortran@9.3 Universal [tests-eb]
     runs-on: macos-latest
-    env: {CXXFLAGS: "-fno-operator-names -Werror -Wall -Wextra -Wpedantic -Wnull-dereference -Wfloat-conversion -Wshadow -Woverloaded-virtual -Wextra-semi -Wunreachable-code -Wno-c++17-extensions -Wno-range-loop-analysis -Wno-pass-failed"}
+    env:
+      # build universal binaries for M1 "Apple Silicon" and Intel CPUs
+      CMAKE_OSX_ARCHITECTURES: "arm64;x86_64"
+      CXXFLAGS: "-fno-operator-names -Werror -Wall -Wextra -Wpedantic -Wnull-dereference -Wfloat-conversion -Wshadow -Woverloaded-virtual -Wextra-semi -Wunreachable-code -Wno-c++17-extensions -Wno-range-loop-analysis -Wno-pass-failed"
       # -Wno-range-loop-analysis: Apple clang has a bug in range-loop-analysis
     steps:
     - uses: actions/checkout@v2
@@ -29,9 +32,7 @@ jobs:
             -DCMAKE_CXX_COMPILER_LAUNCHER=$(which ccache)
         cmake --build build --parallel 2
 
-        cd build
-        ctest --output-on-failure
-        cd ..
+        ctest --test-dir build --output-on-failure
 
   # Build libamrex and all tests
   tests-macos:
@@ -56,5 +57,4 @@ jobs:
         cmake --build build --parallel 2
         cmake --build build --target install
 
-        cd build
-        ctest --output-on-failure
+        ctest --test-dir build --output-on-failure

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -8,8 +8,8 @@ concurrency:
 
 jobs:
   # Build libamrex and all tests
-  tests-macos-eb:
-    name: AppleClang@11.0 GFortran@9.3 Universal [tests-eb]
+  tests-macos-universal-nompi:
+    name: AppleClang Universal w/o MPI [tests-universal]
     runs-on: macos-latest
     env:
       # build universal binaries for M1 "Apple Silicon" and Intel CPUs
@@ -27,9 +27,9 @@ jobs:
             -DCMAKE_BUILD_TYPE=Release  \
             -DCMAKE_VERBOSE_MAKEFILE=ON \
             -DAMReX_EB=ON               \
+            -DAMReX_MPI=OFF             \
             -DAMReX_ENABLE_TESTS=ON     \
-            -DAMReX_PARTICLES=ON        \
-            -DCMAKE_CXX_COMPILER_LAUNCHER=$(which ccache)
+            -DAMReX_PARTICLES=ON
         cmake --build build --parallel 2
 
         ctest --test-dir build --output-on-failure
@@ -38,9 +38,9 @@ jobs:
   tests-macos:
     name: AppleClang@11.0 GFortran@9.3 [tests]
     runs-on: macos-latest
-    env: {CXXFLAGS: "-fno-operator-names -Werror -Wall -Wextra -Wpedantic -Wnull-dereference -Wfloat-conversion -Wshadow -Woverloaded-virtual -Wextra-semi -Wunreachable-code -Wno-c++17-extensions -Wno-range-loop-analysis -Wno-pass-failed -O1"}
+    env:
+      CXXFLAGS: "-fno-operator-names -Werror -Wall -Wextra -Wpedantic -Wnull-dereference -Wfloat-conversion -Wshadow -Woverloaded-virtual -Wextra-semi -Wunreachable-code -Wno-c++17-extensions -Wno-range-loop-analysis -Wno-pass-failed"
       # -Wno-range-loop-analysis: Apple clang has a bug in range-loop-analysis
-      # It's too slow with -O0
     steps:
     - uses: actions/checkout@v2
     - name: Dependencies
@@ -50,10 +50,9 @@ jobs:
         cmake -S . -B build             \
             -DCMAKE_BUILD_TYPE=Debug    \
             -DCMAKE_VERBOSE_MAKEFILE=ON \
-            -DAMReX_EB=OFF              \
+            -DAMReX_EB=ON               \
             -DAMReX_ENABLE_TESTS=ON     \
-            -DAMReX_PARTICLES=ON        \
-            -DCMAKE_CXX_COMPILER_LAUNCHER=$(which ccache)
+            -DAMReX_PARTICLES=ON
         cmake --build build --parallel 2
         cmake --build build --target install
 

--- a/Src/Base/AMReX.cpp
+++ b/Src/Base/AMReX.cpp
@@ -55,7 +55,7 @@
 #include <omp.h>
 #endif
 
-#if defined(__APPLE__) && !defined(__arm64__)
+#if defined(__APPLE__) && defined(__x86_64__)
 #include <xmmintrin.h>
 #endif
 
@@ -114,7 +114,7 @@ namespace {
 #if defined(__linux__)
     int           prev_fpe_excepts;
     int           curr_fpe_excepts;
-#elif defined(__APPLE__) && !defined(__arm64__)
+#elif defined(__APPLE__) && defined(__x86_64__)
     unsigned int  prev_fpe_mask;
     unsigned int  curr_fpe_excepts;
 #endif
@@ -474,7 +474,7 @@ amrex::Initialize (int& argc, char**& argv, bool build_parm_parse,
             }
 #endif
 
-#elif defined(__APPLE__) && !defined(__arm64__)
+#elif defined(__APPLE__) && defined(__x86_64__)
             prev_fpe_mask = _MM_GET_EXCEPTION_MASK();
             curr_fpe_excepts = 0u;
             if (invalid)   curr_fpe_excepts |= _MM_MASK_INVALID;
@@ -671,7 +671,7 @@ amrex::Finalize (amrex::AMReX* pamrex)
             feenableexcept(prev_fpe_excepts);
         }
 #endif
-#elif defined(__APPLE__) && !defined(__arm64__)
+#elif defined(__APPLE__) && defined(__x86_64__)
         if (curr_fpe_excepts != 0u) {
             _MM_SET_EXCEPTION_MASK(prev_fpe_mask);
         }

--- a/Src/Base/AMReX.cpp
+++ b/Src/Base/AMReX.cpp
@@ -114,7 +114,7 @@ namespace {
 #if defined(__linux__)
     int           prev_fpe_excepts;
     int           curr_fpe_excepts;
-#elif defined(__APPLE__)
+#elif defined(__APPLE__) && !defined(__arm64__)
     unsigned int  prev_fpe_mask;
     unsigned int  curr_fpe_excepts;
 #endif


### PR DESCRIPTION
## Summary

Make sure we can cross-compile AMReX from Intel CPUs (x86) to "Apple Silicon"/M1 (arm64). Using fancy universal binaries here (aka fat binaries) that even support both architectures at the same time.

## Additional background

Refs.:
- https://developer.apple.com/documentation/apple-silicon/building-a-universal-macos-binary
- https://cmake.org/cmake/help/latest/envvar/CMAKE_OSX_ARCHITECTURES.html

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
