### PR TITLE
Redefine ParticleContainter multifab after setting particle boxarray and dmap

### DIFF
--- a/Src/Particle/AMReX_ParticleContainerBase.cpp
+++ b/Src/Particle/AMReX_ParticleContainerBase.cpp
@@ -75,6 +75,7 @@ void ParticleContainerBase::SetParticleBoxArray (int lev, const BoxArray& new_ba
                           m_gdb->ParticleBoxArray(), m_gdb->refRatio());
     m_gdb = &m_gdb_object;
     m_gdb->SetParticleBoxArray(lev, new_ba);
+    RedefineDummyMF(lev);
 }
 
 void ParticleContainerBase::SetParticleDistributionMap (int lev, const DistributionMapping& new_dmap)
@@ -83,6 +84,7 @@ void ParticleContainerBase::SetParticleDistributionMap (int lev, const Distribut
                           m_gdb->ParticleBoxArray(), m_gdb->refRatio());
     m_gdb = &m_gdb_object;
     m_gdb->SetParticleDistributionMap(lev, new_dmap);
+    RedefineDummyMF(lev);
 }
 
 void ParticleContainerBase::SetParticleGeometry (int lev, const Geometry& new_geom)

--- a/Src/Particle/AMReX_ParticleContainerBase.cpp
+++ b/Src/Particle/AMReX_ParticleContainerBase.cpp
@@ -52,9 +52,10 @@ void ParticleContainerBase::RedefineDummyMF (int lev)
         ! DistributionMapping::SameRefs(m_dummy_mf[lev]->DistributionMap(),
                                         ParticleDistributionMap(lev)))
     {
+        auto dm = (ParticleBoxArray(lev).size() == ParticleDistributionMap(lev).size()) ?
+            ParticleDistributionMap(lev) : DistributionMapping(ParticleBoxArray(lev));
         m_dummy_mf[lev] = std::make_unique<MultiFab>(ParticleBoxArray(lev),
-                                                     ParticleDistributionMap(lev),
-                                                     1,0,MFInfo().SetAlloc(false));
+                                                     dm, 1,0,MFInfo().SetAlloc(false));
     };
 }
 


### PR DESCRIPTION
## Summary
This PR calls the function to redefine the multifab in particle container base when it is set to have a new particle box array and distribution map.

## Additional background
In WarpX, we have diagnostics that need a different particle box array and distribution map compared to that used for the simulation. The current development branch was leading to a segfault when writing particles because it found that all the particles were out of range (when they were within the range for the diagnostics). This is because the ParIter was iterating over the boxes from the simulation and not from the newly set particle box array. This PR fixes this incorrect behavior.

Thank you @atmyers for your help!

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
