### PR TITLE
Catch CUDA 11.6 bug at compile time

### DIFF
--- a/Src/Base/AMReX_BCUtil.cpp
+++ b/Src/Base/AMReX_BCUtil.cpp
@@ -1,6 +1,9 @@
 #include <AMReX_BCUtil.H>
 #include <AMReX_PhysBCFunct.H>
 
+// CUDA 11.6 bug: https://github.com/AMReX-Codes/amrex/issues/2607
+#if !defined(__CUDACC__) || (__CUDACC_VER_MAJOR__ != 11) || (__CUDACC_VER_MINOR__ != 6)
+
 namespace amrex
 {
 
@@ -53,3 +56,5 @@ void FillDomainBoundary (MultiFab& phi, const Geometry& geom, const Vector<BCRec
 }
 
 }
+
+#endif

--- a/Src/Base/AMReX_PhysBCFunct.H
+++ b/Src/Base/AMReX_PhysBCFunct.H
@@ -200,6 +200,14 @@ GpuBndryFuncFab<F>::operator() (Box const& bx, FArrayBox& dest,
                                 const Vector<BCRec>& bcr, const int bcomp,
                                 const int orig_comp)
 {
+#if defined(__CUDACC__) && (__CUDACC_VER_MAJOR__ == 11) && (__CUDACC_VER_MINOR__ == 6)
+    // The compiler is allowed to always reject static_assert(false,..) even
+    // without instantiating this function.  The following is to work around
+    // the issue.  Now the compiler is not allowed to reject the code unless
+    // GpuBndryFuncFab::operator() is instantiated.
+    static_assert(std::is_same<F,int>::value,
+                  "CUDA 11.6 bug: https://github.com/AMReX-Codes/amrex/issues/2607");
+#endif
     if (bx.ixType().cellCentered()) {
         ccfcdoit(bx,dest,dcomp,numcomp,geom,time,bcr,bcomp,orig_comp, FilccCell{});
     } else if (bx.ixType().nodeCentered()) {


### PR DESCRIPTION
Make it a compile time error if CUDA 11.6 is used to instantiate
GpuBndryFuncFab.  This used to be a mysterious runtime error (#2607).  Note
that if GpuBndryFuncFab is not used in your code, you can still use CUDA
11.6.  However, the bug might still be triggered at runtime in other places.

Closes #2607.
