### PR TITLE
Fix some HIP warnings for IntegratorBase class

### DIFF
--- a/Src/Base/AMReX_IntegratorBase.H
+++ b/Src/Base/AMReX_IntegratorBase.H
@@ -65,7 +65,7 @@ struct IntegratorOps<T, typename std::enable_if<std::is_base_of<amrex::ParticleC
         {
             const int npy  = pty.numParticles();
             const int npx  = ptx.numParticles();
-            AMREX_ASSERT(npy == npx);
+            AMREX_ALWAYS_ASSERT(npy == npx);
 
             ParticleType* psy = &(pty.GetArrayOfStructs()[0]);
             ParticleType* psx = &(ptx.GetArrayOfStructs()[0]);

--- a/Src/Base/AMReX_IntegratorBase.H
+++ b/Src/Base/AMReX_IntegratorBase.H
@@ -184,7 +184,7 @@ protected:
 public:
     IntegratorBase () {}
 
-    IntegratorBase (const T& S_data) {}
+    IntegratorBase (const T& /* S_data */) {}
 
     virtual ~IntegratorBase () {}
 


### PR DESCRIPTION
## Summary

Fixes some HIP compiler warnings for the AMReX IntegratorBase class regarding unused variables.

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
