### PR TITLE
fixes to enable building with CUDA Clang

### DIFF
--- a/Src/Base/AMReX_GpuUtility.H
+++ b/Src/Base/AMReX_GpuUtility.H
@@ -27,7 +27,7 @@ namespace Gpu {
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     T LDG (Array4<T> const& a, int i, int j, int k) noexcept {
 #ifdef __CUDA_ARCH__
-        return __ldg(a.ptr(i,j,k,n));
+        return __ldg(a.ptr(i,j,k));
 #else
         return a(i,j,k);
 #endif

--- a/Src/Base/AMReX_TypeTraits.H
+++ b/Src/Base/AMReX_TypeTraits.H
@@ -81,7 +81,7 @@ namespace amrex
     template <class T, class Enable = void>
     struct DefinitelyNotHostRunnable : std::false_type {};
 
-#if defined(AMREX_USE_CUDA)
+#if defined(AMREX_USE_CUDA) && defined(__NVCC__)
 
     template <class T>
     struct MaybeHostDeviceRunnable<T, std::enable_if_t<__nv_is_extended_device_lambda_closure_type(T)> >


### PR DESCRIPTION
## Summary

This allows AMReX to build successfully with Clang as the CUDA compiler. There is no GNUMakefile support, but CMake can be invoked to build libamrex as:

`cmake .. -DAMReX_GPU_BACKEND=CUDA -DCMAKE_CUDA_COMPILER=clang`

There are three issues:

1. Unlike nvcc, CUDA clang does not have the concept of extended lambdas, so they can just be treated as normal lambdas with automatic execution space inference ([example](https://godbolt.org/z/4bo68jKPq) from LLVM Discourse [thread](https://discourse.llvm.org/t/compiling-cuda-code-fails/61240/4)).
2.  The array accessor on line 30 of AMReX_GpuUtility.H must be correctly specified. I think this is a bug since there is no variable 'n' in this function. It doesn't cause a problem when building with nvcc, but clang stops with an error.
3. `__float128` has to be disabled in glibc when building device code, since Clang does not support `__float128` for nvptx targets. This can be done by adding `-D__STRICT_ANSI__` to the CUDA compile options. This requires no changes to AMReX itself. _(For future reference:_ other workarounds for the lack of `__float128` support for a given target are listed [here](https://bugs.llvm.org/show_bug.cgi?id=13530#c3).)

## Additional background

AMReX tests can be built with:

`LDFLAGS="-lm -lstdc++" cmake .. -DAMReX_GPU_BACKEND=CUDA -DCMAKE_CUDA_COMPILER=clang -DAMReX_ENABLE_TESTS=ON -DAMReX_GPU_RDC=OFF -DCMAKE_CUDA_ARCHITECTURES=70 -DCMAKE_CUDA_FLAGS="-D__STRICT_ANSI__"`

All tests pass when compiling using Clang 14.0.0 (as both host/device compiler) and running on a V100 GPU.

(Note that CUDA clang has a [different compilation model](https://llvm.org/docs/CompileCudaWithLLVM.html#compilation-models), which means that host code must be semantically correct when compiling for device, and vice versa. This may explain item 2 above.)

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
