### PR TITLE
Fix parser expressions

### DIFF
--- a/Src/Base/Parser/AMReX_Parser_Exe.cpp
+++ b/Src/Base/Parser/AMReX_Parser_Exe.cpp
@@ -546,6 +546,10 @@ parser_compile_exe_size (struct parser_node* node, char*& p, std::size_t& exe_si
                 t->i = AMREX_PARSER_LOCAL_IDX0 + lidx;
             } else {
                 t->i = node->rip;
+                    if (t->i < 0) {
+                        throw std::runtime_error(std::string("Unknown variable ")
+                                                 + ((struct parser_symbol*)node->r)->name);
+                    }
             }
             t->v = node->lvp.v;
         }
@@ -564,6 +568,10 @@ parser_compile_exe_size (struct parser_node* node, char*& p, std::size_t& exe_si
                 t->i = AMREX_PARSER_LOCAL_IDX0 + lidx;
             } else {
                 t->i = node->rip;
+                    if (t->i < 0) {
+                        throw std::runtime_error(std::string("Unknown variable ")
+                                                 + ((struct parser_symbol*)node->r)->name);
+                    }
             }
             t->v = node->lvp.v;
         }
@@ -582,6 +590,10 @@ parser_compile_exe_size (struct parser_node* node, char*& p, std::size_t& exe_si
                 t->i = AMREX_PARSER_LOCAL_IDX0 + lidx;
             } else {
                 t->i = node->rip;
+                    if (t->i < 0) {
+                        throw std::runtime_error(std::string("Unknown variable ")
+                                                 + ((struct parser_symbol*)node->r)->name);
+                    }
             }
             t->v = node->lvp.v;
         }
@@ -600,6 +612,10 @@ parser_compile_exe_size (struct parser_node* node, char*& p, std::size_t& exe_si
                 t->i = AMREX_PARSER_LOCAL_IDX0 + lidx;
             } else {
                 t->i = node->rip;
+                    if (t->i < 0) {
+                        throw std::runtime_error(std::string("Unknown variable ")
+                                                 + ((struct parser_symbol*)node->r)->name);
+                    }
             }
             t->v = node->lvp.v;
         }
@@ -710,6 +726,10 @@ parser_compile_exe_size (struct parser_node* node, char*& p, std::size_t& exe_si
                 t->i = AMREX_PARSER_LOCAL_IDX0 + lidx;
             } else {
                 t->i = node->lvp.ip;
+                    if (t->i < 0) {
+                        throw std::runtime_error(std::string("Unknown variable ")
+                                                 + ((struct parser_symbol*)node->l)->name);
+                    }
             }
         }
         exe_size += sizeof(ParserExeNEG_P);

--- a/Src/Base/Parser/AMReX_Parser_Exe.cpp
+++ b/Src/Base/Parser/AMReX_Parser_Exe.cpp
@@ -546,10 +546,10 @@ parser_compile_exe_size (struct parser_node* node, char*& p, std::size_t& exe_si
                 t->i = AMREX_PARSER_LOCAL_IDX0 + lidx;
             } else {
                 t->i = node->rip;
-                    if (t->i < 0) {
-                        throw std::runtime_error(std::string("Unknown variable ")
-                                                 + ((struct parser_symbol*)node->r)->name);
-                    }
+		if (t->i < 0) {
+		  throw std::runtime_error(std::string("Unknown variable ")
+					   + ((struct parser_symbol*)node->r)->name);
+		}
             }
             t->v = node->lvp.v;
         }
@@ -568,10 +568,10 @@ parser_compile_exe_size (struct parser_node* node, char*& p, std::size_t& exe_si
                 t->i = AMREX_PARSER_LOCAL_IDX0 + lidx;
             } else {
                 t->i = node->rip;
-                    if (t->i < 0) {
-                        throw std::runtime_error(std::string("Unknown variable ")
-                                                 + ((struct parser_symbol*)node->r)->name);
-                    }
+		if (t->i < 0) {
+		  throw std::runtime_error(std::string("Unknown variable ")
+					   + ((struct parser_symbol*)node->r)->name);
+		}
             }
             t->v = node->lvp.v;
         }
@@ -590,10 +590,10 @@ parser_compile_exe_size (struct parser_node* node, char*& p, std::size_t& exe_si
                 t->i = AMREX_PARSER_LOCAL_IDX0 + lidx;
             } else {
                 t->i = node->rip;
-                    if (t->i < 0) {
-                        throw std::runtime_error(std::string("Unknown variable ")
-                                                 + ((struct parser_symbol*)node->r)->name);
-                    }
+		if (t->i < 0) {
+		  throw std::runtime_error(std::string("Unknown variable ")
+					   + ((struct parser_symbol*)node->r)->name);
+		}
             }
             t->v = node->lvp.v;
         }
@@ -612,10 +612,10 @@ parser_compile_exe_size (struct parser_node* node, char*& p, std::size_t& exe_si
                 t->i = AMREX_PARSER_LOCAL_IDX0 + lidx;
             } else {
                 t->i = node->rip;
-                    if (t->i < 0) {
-                        throw std::runtime_error(std::string("Unknown variable ")
-                                                 + ((struct parser_symbol*)node->r)->name);
-                    }
+		if (t->i < 0) {
+		  throw std::runtime_error(std::string("Unknown variable ")
+					   + ((struct parser_symbol*)node->r)->name);
+		}
             }
             t->v = node->lvp.v;
         }
@@ -726,10 +726,10 @@ parser_compile_exe_size (struct parser_node* node, char*& p, std::size_t& exe_si
                 t->i = AMREX_PARSER_LOCAL_IDX0 + lidx;
             } else {
                 t->i = node->lvp.ip;
-                    if (t->i < 0) {
-                        throw std::runtime_error(std::string("Unknown variable ")
-                                                 + ((struct parser_symbol*)node->l)->name);
-                    }
+		if (t->i < 0) {
+		  throw std::runtime_error(std::string("Unknown variable ")
+					   + ((struct parser_symbol*)node->l)->name);
+		}
             }
         }
         exe_size += sizeof(ParserExeNEG_P);

--- a/Src/Base/Parser/AMReX_Parser_Exe.cpp
+++ b/Src/Base/Parser/AMReX_Parser_Exe.cpp
@@ -546,10 +546,10 @@ parser_compile_exe_size (struct parser_node* node, char*& p, std::size_t& exe_si
                 t->i = AMREX_PARSER_LOCAL_IDX0 + lidx;
             } else {
                 t->i = node->rip;
-		if (t->i < 0) {
-		  throw std::runtime_error(std::string("Unknown variable ")
-					   + ((struct parser_symbol*)node->r)->name);
-		}
+                if (t->i < 0) {
+                  throw std::runtime_error(std::string("Unknown variable ")
+                                           + ((struct parser_symbol*)node->r)->name);
+                }
             }
             t->v = node->lvp.v;
         }
@@ -568,10 +568,10 @@ parser_compile_exe_size (struct parser_node* node, char*& p, std::size_t& exe_si
                 t->i = AMREX_PARSER_LOCAL_IDX0 + lidx;
             } else {
                 t->i = node->rip;
-		if (t->i < 0) {
-		  throw std::runtime_error(std::string("Unknown variable ")
-					   + ((struct parser_symbol*)node->r)->name);
-		}
+                if (t->i < 0) {
+                  throw std::runtime_error(std::string("Unknown variable ")
+                                           + ((struct parser_symbol*)node->r)->name);
+                }
             }
             t->v = node->lvp.v;
         }
@@ -590,10 +590,10 @@ parser_compile_exe_size (struct parser_node* node, char*& p, std::size_t& exe_si
                 t->i = AMREX_PARSER_LOCAL_IDX0 + lidx;
             } else {
                 t->i = node->rip;
-		if (t->i < 0) {
-		  throw std::runtime_error(std::string("Unknown variable ")
-					   + ((struct parser_symbol*)node->r)->name);
-		}
+                if (t->i < 0) {
+                  throw std::runtime_error(std::string("Unknown variable ")
+                                           + ((struct parser_symbol*)node->r)->name);
+                }
             }
             t->v = node->lvp.v;
         }
@@ -612,10 +612,10 @@ parser_compile_exe_size (struct parser_node* node, char*& p, std::size_t& exe_si
                 t->i = AMREX_PARSER_LOCAL_IDX0 + lidx;
             } else {
                 t->i = node->rip;
-		if (t->i < 0) {
-		  throw std::runtime_error(std::string("Unknown variable ")
-					   + ((struct parser_symbol*)node->r)->name);
-		}
+                if (t->i < 0) {
+                  throw std::runtime_error(std::string("Unknown variable ")
+                                           + ((struct parser_symbol*)node->r)->name);
+                }
             }
             t->v = node->lvp.v;
         }
@@ -726,10 +726,10 @@ parser_compile_exe_size (struct parser_node* node, char*& p, std::size_t& exe_si
                 t->i = AMREX_PARSER_LOCAL_IDX0 + lidx;
             } else {
                 t->i = node->lvp.ip;
-		if (t->i < 0) {
-		  throw std::runtime_error(std::string("Unknown variable ")
-					   + ((struct parser_symbol*)node->l)->name);
-		}
+                if (t->i < 0) {
+                  throw std::runtime_error(std::string("Unknown variable ")
+                                           + ((struct parser_symbol*)node->l)->name);
+                }
             }
         }
         exe_size += sizeof(ParserExeNEG_P);


### PR DESCRIPTION
## Summary
Some amrex::Parser expressions still seg-fault if variables are not defined. With these fixes, hopefully all cases of undefined variables should be turned into thrown exceptions.

## Additional background

Without this fix, the following segments of code all seg-fault.
With this fix, each of them will throw an exception instead.
(If the setConstant lines are uncommented, the tests will pass with or without this fix.)

  { 
    amrex::Print() << "Attempt 2+a" << std::endl;
    amrex::Parser parser("2+a");
    //parser.setConstant("a", (amrex::Real)3.0);                                                                                                                                                                   
    const auto parserExec = parser.compile<0>();
    AMREX_ALWAYS_ASSERT(parserExec() == 5);
  }
  { 
    amrex::Print() << "Attempt 2-a" << std::endl;
    amrex::Parser parser("2-a");
    //parser.setConstant("a", (amrex::Real)3.0);                                                                                                                                                                   
    const auto parserExec = parser.compile<0>();
    AMREX_ALWAYS_ASSERT(parserExec() == -1);
  }
  { 
    amrex::Print() << "Attempt 2*a" << std::endl;
    amrex::Parser parser("2*a");
    //parser.setConstant("a", (amrex::Real)3.0);                                                                                                                                                                   
    const auto parserExec = parser.compile<0>();
    AMREX_ALWAYS_ASSERT(parserExec() == 6);
  }
  { 
    amrex::Print() << "Attempt 3/a" << std::endl;
    amrex::Parser parser("3/a");
    //parser.setConstant("a", (amrex::Real)3.0);                                                                                                                                                                   
    const auto parserExec = parser.compile<0>();
    AMREX_ALWAYS_ASSERT(parserExec() == 1);
  }
  { 
    amrex::Print() << "Attempt -a" << std::endl;
    amrex::Parser parser("-a");
    //parser.setConstant("a", (amrex::Real)3.0);                                                                                                                                                                   
    const auto parserExec = parser.compile<0>();
    AMREX_ALWAYS_ASSERT(parserExec() == -3);
  }

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
