### PR TITLE
FillBoundaryAndSync

### DIFF
--- a/Src/Base/AMReX_FabArray.H
+++ b/Src/Base/AMReX_FabArray.H
@@ -154,10 +154,6 @@ struct FBData {
     const FabArrayBase::FB*  fb = nullptr;
     int                 scomp;
     int                 ncomp;
-    IntVect             nghost;
-    Periodicity         period;
-    bool                cross;
-    bool                epo;
 
     //
     char*               the_recv_data = nullptr;
@@ -912,6 +908,69 @@ public:
 
     void FillBoundary_test ();
 
+
+    /**
+     * \brief Fill ghost cells and synchronize nodal data. Ghost regions are
+     * filled with data from the intersecting valid regions. The
+     * synchronization will override valid regions by the intersecting valid
+     * regions with a higher precedence.  The smaller the global box index
+     * is, the higher precedence the box has.  With periodic boundaries, for
+     * cells in the same box, those near the lower corner have higher
+     * precedence than those near the upper corner.
+     *
+     * \param period periodic length if it's non-zero
+     */
+    void FillBoundaryAndSync (const Periodicity& period = Periodicity::NonPeriodic());
+    /**
+     * \brief Fill ghost cells and synchronize nodal data. Ghost regions are
+     * filled with data from the intersecting valid regions. The
+     * synchronization will override valid regions by the intersecting valid
+     * regions with a higher precedence.  The smaller the global box index
+     * is, the higher precedence the box has.  With periodic boundaries, for
+     * cells in the same box, those near the lower corner have higher
+     * precedence than those near the upper corner.
+     *
+     * \param scomp starting component
+     * \param ncomp number of components
+     * \param nghost number of ghost cells to fill
+     * \param period periodic length if it's non-zero
+     */
+    void FillBoundaryAndSync (int scomp, int ncomp, const IntVect& nghost,
+                              const Periodicity& period);
+    void FillBoundaryAndSync_nowait (const Periodicity& period = Periodicity::NonPeriodic());
+    void FillBoundaryAndSync_nowait (int scomp, int ncomp, const IntVect& nghost,
+                                     const Periodicity& period);
+    void FillBoundaryAndSync_finish ();
+
+    /**
+     * \brief Synchronize nodal data.  The synchronization will override
+     * valid regions by the intersecting valid regions with a higher
+     * precedence.  The smaller the global box index is, the higher
+     * precedence the box has.  With periodic boundaries, for cells in the
+     * same box, those near the lower corner have higher precedence than
+     * those near the upper corner.
+     *
+     * \param period periodic length if it's non-zero
+     */
+    void OverrideSync (const Periodicity& period = Periodicity::NonPeriodic());
+    /**
+     * \brief Synchronize nodal data.  The synchronization will override
+     * valid regions by the intersecting valid regions with a higher
+     * precedence.  The smaller the global box index is, the higher
+     * precedence the box has.  With periodic boundaries, for cells in the
+     * same box, those near the lower corner have higher precedence than
+     * those near the upper corner.
+     *
+     * \param scomp starting component
+     * \param ncomp number of components
+     * \param nghost number of ghost cells to fill
+     * \param period periodic length if it's non-zero
+     */
+    void OverrideSync (int scomp, int ncomp, const Periodicity& period);
+    void OverrideSync_nowait (const Periodicity& period = Periodicity::NonPeriodic());
+    void OverrideSync_nowait (int scomp, int ncomp, const Periodicity& period);
+    void OverrideSync_finish ();
+
     /**
     * \brief Sum values in overlapped cells.  The destination is limited to valid cells.
     */
@@ -963,7 +1022,8 @@ public:
     template <class F=FAB, typename std::enable_if<IsBaseFab<F>::value,int>::type = 0>
     void FBEP_nowait (int scomp, int ncomp, const IntVect& nghost,
                       const Periodicity& period, bool cross,
-                      bool enforce_periodicity_only = false);
+                      bool enforce_periodicity_only = false,
+                      bool override_sync = false);
 
     void FB_local_copy_cpu (const FB& TheFB, int scomp, int ncomp);
     void PC_local_cpu (const CPC& thecpc, FabArray<FAB> const& src,
@@ -1171,7 +1231,7 @@ public:
     std::unique_ptr<FBData<FAB>> fbd;
     std::unique_ptr<PCData<FAB>> pcd;
 
-    // Pointer to temporary fab used in non-blocking OverrideSync
+    // Pointer to temporary fab used in non-blocking amrex::OverrideSync
     std::unique_ptr< FabArray<FAB> > os_temp;
 };
 
@@ -2590,6 +2650,98 @@ void
 FabArray<FAB>::FillBoundary_nowait (int scomp, int ncomp, bool cross)
 {
     FillBoundary_nowait(scomp, ncomp, nGrowVect(), Periodicity::NonPeriodic(), cross);
+}
+
+template <class FAB>
+void
+FabArray<FAB>::FillBoundaryAndSync (const Periodicity& period)
+{
+    BL_PROFILE("FAbArray::FillBoundaryAndSync()");
+    if (n_grow.max() > 0 || !is_cell_centered()) {
+        FillBoundaryAndSync_nowait(0, nComp(), n_grow, period);
+        FillBoundaryAndSync_finish();
+    }
+}
+
+template <class FAB>
+void
+FabArray<FAB>::FillBoundaryAndSync (int scomp, int ncomp, const IntVect& nghost,
+                                    const Periodicity& period)
+{
+    BL_PROFILE("FAbArray::FillBoundaryAndSync()");
+    if (nghost.max() > 0 || !is_cell_centered()) {
+        FillBoundaryAndSync_nowait(scomp, ncomp, nghost, period);
+        FillBoundaryAndSync_finish();
+    }
+}
+
+template <class FAB>
+void
+FabArray<FAB>::FillBoundaryAndSync_nowait (const Periodicity& period)
+{
+    FillBoundaryAndSync_nowait(0, nComp(), nGrowVect(), period);
+}
+
+template <class FAB>
+void
+FabArray<FAB>::FillBoundaryAndSync_nowait (int scomp, int ncomp, const IntVect& nghost,
+                                           const Periodicity& period)
+{
+    BL_PROFILE("FillBoundaryAndSync_nowait()");
+    FBEP_nowait(scomp, ncomp, nghost, period, false, false, true);
+}
+
+template <class FAB>
+void
+FabArray<FAB>::FillBoundaryAndSync_finish ()
+{
+    BL_PROFILE("FillBoundaryAndSync_finish()");
+    FillBoundary_finish();
+}
+
+template <class FAB>
+void
+FabArray<FAB>::OverrideSync (const Periodicity& period)
+{
+    BL_PROFILE("FAbArray::OverrideSync()");
+    if (!is_cell_centered()) {
+        OverrideSync_nowait(0, nComp(), period);
+        OverrideSync_finish();
+    }
+}
+
+template <class FAB>
+void
+FabArray<FAB>::OverrideSync (int scomp, int ncomp, const Periodicity& period)
+{
+    BL_PROFILE("FAbArray::OverrideSync()");
+    if (!is_cell_centered()) {
+        OverrideSync_nowait(scomp, ncomp, period);
+        OverrideSync_finish();
+    }
+}
+
+template <class FAB>
+void
+FabArray<FAB>::OverrideSync_nowait (const Periodicity& period)
+{
+    OverrideSync_nowait(0, nComp(), period);
+}
+
+template <class FAB>
+void
+FabArray<FAB>::OverrideSync_nowait (int scomp, int ncomp, const Periodicity& period)
+{
+    BL_PROFILE("OverrideSync_nowait()");
+    FBEP_nowait(scomp, ncomp, IntVect(0), period, false, false, true);
+}
+
+template <class FAB>
+void
+FabArray<FAB>::OverrideSync_finish ()
+{
+    BL_PROFILE("OverrideSync_finish()");
+    FillBoundary_finish();
 }
 
 template <class FAB>

--- a/Src/Base/AMReX_FabArrayBase.H
+++ b/Src/Base/AMReX_FabArrayBase.H
@@ -489,7 +489,8 @@ public:
     {
         FB (const FabArrayBase& fa, const IntVect& nghost,
             bool cross, const Periodicity& period,
-            bool enforce_periodicity_only, bool multi_ghost = false);
+            bool enforce_periodicity_only, bool override_sync,
+            bool multi_ghost);
         ~FB ();
 
         IndexType    m_typ;
@@ -497,6 +498,7 @@ public:
         IntVect      m_ngrow;
         bool         m_cross;
         bool         m_epo;
+        bool         m_override_sync;
         Periodicity  m_period;
         //
         Long         m_nuse;
@@ -512,6 +514,9 @@ public:
     private:
         void define_fb (const FabArrayBase& fa);
         void define_epo (const FabArrayBase& fa);
+        void define_os (const FabArrayBase& fa);
+        void tag_one_box (int krcv, BoxArray const& ba, DistributionMapping const& dm,
+                          bool build_recv_tag);
     };
     //
     typedef std::multimap<BDKey,FabArrayBase::FB*> FBCache;
@@ -521,7 +526,8 @@ public:
     static CacheStats m_FBC_stats;
     //
     const FB& getFB (const IntVect& nghost, const Periodicity& period,
-                     bool cross=false, bool enforce_periodicity_only = false) const;
+                     bool cross=false, bool enforce_periodicity_only = false,
+                     bool override_sync = false) const;
     //
     void flushFB (bool no_assertion=false) const;       //!< This flushes its own FB.
     static void flushFBCache (); //!< This flushes the entire cache.

--- a/Src/Base/AMReX_FabArrayBase.cpp
+++ b/Src/Base/AMReX_FabArrayBase.cpp
@@ -23,6 +23,7 @@
 #endif
 
 #include <algorithm>
+#include <utility>
 
 namespace amrex {
 
@@ -637,11 +638,11 @@ FabArrayBase::getCPC (const IntVect& dstng, const FabArrayBase& src, const IntVe
 
 FabArrayBase::FB::FB (const FabArrayBase& fa, const IntVect& nghost,
                       bool cross, const Periodicity& period,
-                      bool enforce_periodicity_only,
+                      bool enforce_periodicity_only, bool override_sync,
                       bool multi_ghost)
     : m_typ(fa.boxArray().ixType()), m_crse_ratio(fa.boxArray().crseRatio()),
-      m_ngrow(nghost), m_cross(cross),
-      m_epo(enforce_periodicity_only), m_period(period),
+      m_ngrow(nghost), m_cross(cross), m_epo(enforce_periodicity_only),
+      m_override_sync(override_sync),  m_period(period),
       m_nuse(0), m_multi_ghost(multi_ghost)
 {
     BL_PROFILE("FabArrayBase::FB::FB()");
@@ -654,6 +655,9 @@ FabArrayBase::FB::FB (const FabArrayBase& fa, const IntVect& nghost,
         if (enforce_periodicity_only) {
             BL_ASSERT(m_cross==false);
             define_epo(fa);
+        } else if (override_sync) {
+            BL_ASSERT(m_cross==false);
+            define_os(fa);
         } else {
             define_fb(fa);
         }
@@ -1030,6 +1034,133 @@ FabArrayBase::FB::define_epo (const FabArrayBase& fa)
     }
 }
 
+void FabArrayBase::FB::tag_one_box (int krcv, BoxArray const& ba, DistributionMapping const& dm,
+                                    bool build_recv_tag)
+{
+    Box const& vbx = ba[krcv];
+    Box const& gbx = amrex::grow(vbx, m_ngrow);
+    IndexType const ixtype = vbx.ixType();
+
+    std::vector<std::pair<int,Box> > isects2;
+    std::vector<std::tuple<int,Box,IntVect> > isects3;
+    auto const& pshifts = m_period.shiftIntVect();
+    for (auto const& shft: pshifts) {
+        ba.intersections(gbx+shft, isects2);
+        for (auto const& is2 : isects2) {
+            if (is2.first != krcv || shft != 0) {
+                isects3.emplace_back(is2.first, is2.second-shft, shft);
+            }
+        }
+    }
+
+    int const dst_owner = dm[krcv];
+    bool const is_receiver = dst_owner == ParallelDescriptor::MyProc();
+
+    BoxList bl(ixtype);
+    BoxList tmpbl(ixtype);
+    for (auto const& is3 : isects3) {
+        int const      ksnd = std::get<int>(is3);
+        Box const&   dst_bx = std::get<Box>(is3);
+        IntVect const& shft = std::get<IntVect>(is3); // src = dst + shft
+        int const src_owner = dm[ksnd];
+        bool is_sender = src_owner == ParallelDescriptor::MyProc();
+
+        bl.clear();
+        tmpbl.clear();
+
+        if (ksnd < krcv || (ksnd == krcv && shft < IntVect::TheZeroVector())) {
+            bl.push_back(dst_bx); // valid cells are allowed to override valid cells
+        } else {
+            bl = boxDiff(dst_bx, vbx); // exclude valid cells
+        }
+
+        for (auto const& o_is3 : isects3) {
+            int const      o_ksnd = std::get<int>(o_is3);
+            IntVect const& o_shft = std::get<IntVect>(o_is3);
+            Box const&   o_dst_bx = std::get<Box>(o_is3);
+            if ((o_ksnd < ksnd || (o_ksnd == ksnd && o_shft < shft))
+                && o_dst_bx.intersects(dst_bx))
+            {
+                for (auto const& b : bl) {
+                    tmpbl.join(boxDiff(b, o_dst_bx));
+                }
+                std::swap(bl, tmpbl);
+                tmpbl.clear();
+            }
+        }
+
+        for (auto const& b : bl) {
+            if (build_recv_tag) {
+                if (ParallelDescriptor::sameTeam(src_owner)) { // local copy
+                    const BoxList tilelist(b, FabArrayBase::comm_tile_size);
+                    for (auto const& tbx : tilelist) {
+                        m_LocTags->emplace_back(tbx, tbx+shft, krcv, ksnd);
+                    }
+                } else if (is_receiver) {
+                    (*m_RcvTags)[src_owner].emplace_back(b, b+shft, krcv, ksnd);
+                }
+            } else if (is_sender && !ParallelDescriptor::sameTeam(dst_owner))  {
+                (*m_SndTags)[dst_owner].emplace_back(b, b+shft, krcv, ksnd);
+            }
+        }
+    }
+
+
+}
+
+void
+FabArrayBase::FB::define_os (const FabArrayBase& fa)
+{
+    m_threadsafe_loc = true;
+    m_threadsafe_rcv = true;
+
+    const BoxArray&            ba       = fa.boxArray();
+    const DistributionMapping& dm       = fa.DistributionMap();
+    const Vector<int>&         imap     = fa.IndexArray();
+    const int nlocal = imap.size();
+
+    for (int i = 0; i < nlocal; ++i)
+    {
+        tag_one_box(imap[i], ba, dm, true);
+    }
+
+#ifdef AMREX_USE_MPI
+    if (ParallelDescriptor::NProcs() > 1) {
+        const std::vector<IntVect>& pshifts = m_period.shiftIntVect();
+        std::vector< std::pair<int,Box> > isects;
+
+        std::set<int> my_receiver;
+        for (int i = 0; i < nlocal; ++i) {
+            int const ksnd = imap[i];
+            Box const& vbx = ba[ksnd];
+            for (auto const& shft : pshifts) {
+                ba.intersections(vbx+shft, isects, false, m_ngrow);
+                for (auto const& is : isects) {
+                    if (is.first != ksnd || shft != 0) {
+                        my_receiver.insert(is.first);
+                    }
+                }
+            }
+        }
+
+        // Unlike normal FillBoundary, we have to build the send tags
+        // differently.  This is because (b1 \ b2) \ b3 might produce
+        // different BoxList than (b1 \ b3) \ b2, not just in the order of
+        // Boxes in BoxList that can be fixed by sorting.  To make sure the
+        // send tags on the sender process matches the recv tags on the
+        // receiver process, we make the sender to use the same procedure to
+        // build tags as the receiver.
+
+        for (auto const& krcv : my_receiver) {
+            tag_one_box(krcv, ba, dm, false);
+        }
+    }
+#endif
+
+    // No need to sort send and recv tags because they are already sorted
+    // dut to the way they are built.
+}
+
 FabArrayBase::FB::~FB ()
 {}
 
@@ -1066,7 +1197,8 @@ FabArrayBase::flushFBCache ()
 
 const FabArrayBase::FB&
 FabArrayBase::getFB (const IntVect& nghost, const Periodicity& period,
-                     bool cross, bool enforce_periodicity_only) const
+                     bool cross, bool enforce_periodicity_only,
+                     bool override_sync) const
 {
     BL_PROFILE("FabArrayBase::getFB()");
 
@@ -1080,6 +1212,7 @@ FabArrayBase::getFB (const IntVect& nghost, const Periodicity& period,
             it->second->m_cross      == cross                    &&
             it->second->m_multi_ghost== m_multi_ghost            &&
             it->second->m_epo        == enforce_periodicity_only &&
+            it->second->m_override_sync == override_sync         &&
             it->second->m_period     == period              )
         {
             ++(it->second->m_nuse);
@@ -1089,7 +1222,8 @@ FabArrayBase::getFB (const IntVect& nghost, const Periodicity& period,
     }
 
     // Have to build a new one
-    FB* new_fb = new FB(*this, nghost, cross, period, enforce_periodicity_only,m_multi_ghost);
+    FB* new_fb = new FB(*this, nghost, cross, period, enforce_periodicity_only,
+                        override_sync, m_multi_ghost);
 
 #ifdef AMREX_MEM_PROFILING
     m_FBC_stats.bytes += new_fb->bytes();

--- a/Src/Base/AMReX_FabArrayBase.cpp
+++ b/Src/Base/AMReX_FabArrayBase.cpp
@@ -1158,7 +1158,7 @@ FabArrayBase::FB::define_os (const FabArrayBase& fa)
 #endif
 
     // No need to sort send and recv tags because they are already sorted
-    // dut to the way they are built.
+    // due to the way they are built.
 }
 
 FabArrayBase::FB::~FB ()

--- a/Src/Base/AMReX_FabArrayCommI.H
+++ b/Src/Base/AMReX_FabArrayCommI.H
@@ -7,19 +7,23 @@ template <class F, typename std::enable_if<IsBaseFab<F>::value,int>::type Z>
 void
 FabArray<FAB>::FBEP_nowait (int scomp, int ncomp, const IntVect& nghost,
                             const Periodicity& period, bool cross,
-                            bool enforce_periodicity_only)
+                            bool enforce_periodicity_only,
+                            bool override_sync)
 {
     AMREX_ASSERT_WITH_MESSAGE(!fbd, "FillBoundary_nowait() called when comm operation already in progress.");
+    AMREX_ASSERT(!enforce_periodicity_only || !override_sync);
 
     bool work_to_do;
     if (enforce_periodicity_only) {
         work_to_do = period.isAnyPeriodic();
+    } else if (override_sync) {
+        work_to_do = (nghost.max() > 0) || !is_cell_centered();
     } else {
         work_to_do = nghost.max() > 0;
     }
     if (!work_to_do) { return; }
 
-    const FB& TheFB = getFB(nghost, period, cross, enforce_periodicity_only);
+    const FB& TheFB = getFB(nghost, period, cross, enforce_periodicity_only, override_sync);
 
     if (ParallelContext::NProcsSub() == 1)
     {
@@ -72,10 +76,6 @@ FabArray<FAB>::FBEP_nowait (int scomp, int ncomp, const IntVect& nghost,
     fbd->fb    = &TheFB;
     fbd->scomp = scomp;
     fbd->ncomp = ncomp;
-    fbd->nghost = nghost;
-    fbd->period = period;
-    fbd->cross = cross;
-    fbd->epo   = enforce_periodicity_only;
     fbd->tag   = SeqNum;
 
     //

--- a/Src/Base/AMReX_MultiFab.H
+++ b/Src/Base/AMReX_MultiFab.H
@@ -672,13 +672,9 @@ public:
     //! Sync up nodal data with weights
     void WeightedSync (const MultiFab& wgt, const Periodicity& period = Periodicity::NonPeriodic());
     //! Sync up nodal data with owners overriding non-owners
-    void OverrideSync (const Periodicity& period = Periodicity::NonPeriodic());
     void OverrideSync (const iMultiFab& msk, const Periodicity& period = Periodicity::NonPeriodic());
 
-    void OverrideSync_nowait (const Periodicity& period = Periodicity::NonPeriodic());
-    void OverrideSync_nowait (const iMultiFab& msk, const Periodicity& period = Periodicity::NonPeriodic());
-    void OverrideSync_finish ();
-
+    using FabArray<FArrayBox>::OverrideSync;
 
     static void Initialize ();
     static void Finalize ();

--- a/Src/Base/AMReX_MultiFab.cpp
+++ b/Src/Base/AMReX_MultiFab.cpp
@@ -1783,37 +1783,9 @@ MultiFab::WeightedSync (const MultiFab& wgt, const Periodicity& period)
 }
 
 void
-MultiFab::OverrideSync (const Periodicity& period)
-{
-    if (ixType().cellCentered()) return;
-    auto msk = this->OwnerMask(period);
-    amrex::OverrideSync(*this, *msk, period);
-}
-
-void
 MultiFab::OverrideSync (const iMultiFab& msk, const Periodicity& period)
 {
     amrex::OverrideSync(*this, msk, period);
-}
-
-void
-MultiFab::OverrideSync_nowait (const Periodicity& period)
-{
-    if (ixType().cellCentered()) return;
-    auto msk = this->OwnerMask(period);
-    amrex::OverrideSync_nowait(*this, *msk, period);
-}
-
-void
-MultiFab::OverrideSync_nowait (const iMultiFab& msk, const Periodicity& period)
-{
-    amrex::OverrideSync_nowait(*this, msk, period);
-}
-
-void
-MultiFab::OverrideSync_finish ()
-{
-    amrex::OverrideSync_finish(*this);
 }
 
 }

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLinOp.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLinOp.H
@@ -127,7 +127,8 @@ protected:
 
     virtual void resizeMultiGrid (int new_size) override;
 
-    Vector<Vector<std::unique_ptr<iMultiFab> > > m_owner_mask;      // ownership of nodes
+    std::unique_ptr<iMultiFab> m_owner_mask_top;  // ownership of nodes
+    std::unique_ptr<iMultiFab> m_owner_mask_bottom;
     Vector<Vector<std::unique_ptr<iMultiFab> > > m_dirichlet_mask;  // dirichlet?
     Vector<std::unique_ptr<iMultiFab> > m_cc_fine_mask;          // cell-centered mask for cells covered by fine
     Vector<std::unique_ptr<iMultiFab> > m_nd_fine_mask;          // nodal mask: 0: this level node, 1: c/f boundary, 2: fine node


### PR DESCRIPTION
Add a new function to FabArray that fills ghost cells and synchronize nodal
data. Ghost regions are filled with data from the intersecting valid
regions. The synchronization will override valid regions by the intersecting
valid regions with a higher precedence.  The smaller the global box index
is, the higher precedence the box has.  With periodic boundaries, for cells
in the same box, those near the lower corner have higher precedence than
those near the upper corner.  This function produces the same result as
OverrideSync followed by FillBoundary in a single pass.

Also modify the implementation of OverrideSync to use this new function,
which is more efficient.

The nodal linear solvers use OverrideSync to sync up the nodal data.  They
have been updated to use the new OverrideSync function that does not use
an owner mask.  So we no longer need to build owner masks except for the
top and bottom multigrid levels that need to use the mask in the computation
of norms to avoid overcounting.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
