### PR TITLE
Link particles in ghost cells to closest box

### DIFF
--- a/Src/Particle/AMReX_ParticleContainerI.H
+++ b/Src/Particle/AMReX_ParticleContainerI.H
@@ -120,8 +120,23 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>
       AMREX_ASSERT(ba.ixType().cellCentered());
 
       if (local_grid < 0) {
-          ba.intersections(Box(iv, iv), isects, true, nGrow);
+          bool findfirst = (nGrow == 0) ? true : false;
+          ba.intersections(Box(iv, iv), isects, findfirst, nGrow);
           grid = isects.empty() ? -1 : isects[0].first;
+          if (nGrow > 0 && isects.size() > 1) {
+             for (int n = 0; n < isects.size(); ++n) {
+                 Box bx = ba.getCellCenteredBox(isects[n].first);
+                 for (int dir = 0; dir < AMREX_SPACEDIM; ++dir) {
+                     Box gbx = bx;
+                     IntVect gr(IntVect::TheZeroVector());
+                     gr[dir] = nGrow;
+                     gbx.grow(gr);
+                     if (gbx.contains(iv)) {
+                        grid = isects[n].first;
+                     }
+                 }
+             }
+          }
       } else {
           grid = (*redistribute_mask_ptr)[local_grid](iv, 0);
       }

--- a/Src/Particle/AMReX_ParticleContainerI.H
+++ b/Src/Particle/AMReX_ParticleContainerI.H
@@ -124,7 +124,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>
           ba.intersections(Box(iv, iv), isects, findfirst, nGrow);
           grid = isects.empty() ? -1 : isects[0].first;
           if (nGrow > 0 && isects.size() > 1) {
-             for (int n = 0; n < isects.size(); ++n) {
+             for (std::size_t n = 0; n < isects.size(); ++n) {
                  Box bx = ba.getCellCenteredBox(isects[n].first);
                  for (int dir = 0; dir < AMREX_SPACEDIM; ++dir) {
                      Box gbx = bx;

--- a/Src/Particle/AMReX_ParticleLocator.H
+++ b/Src/Particle/AMReX_ParticleLocator.H
@@ -63,21 +63,38 @@ struct AssignGrid
         int ix_hi = amrex::min((lo.x + nGrow - m_lo.x) / m_bin_size.x, m_num_bins.x-1);
         int iy_hi = amrex::min((lo.y + nGrow - m_lo.y) / m_bin_size.y, m_num_bins.y-1);
         int iz_hi = amrex::min((lo.z + nGrow - m_lo.z) / m_bin_size.z, m_num_bins.z-1);
-
+        int loc = -1;
+        Box curbox;
         for (int ii = ix_lo; ii <= ix_hi; ++ii) {
             for (int jj = iy_lo; jj <= iy_hi; ++jj) {
                 for (int kk = iz_lo; kk <= iz_hi; ++kk) {
                     int index = (ii * m_num_bins.y + jj) * m_num_bins.z + kk;
                     for (const auto& nbor : m_bif.getBinIterator(index)) {
                         Box bx = nbor.second;
+                        if (bx.contains(iv)) {
+                          return nbor.first;
+                        }
                         bx.grow(nGrow);
-                        if (bx.contains(iv)) return nbor.first;
+                        if (bx.contains(iv)) {
+                           if (loc < 0) {
+                             loc = nbor.first;
+                           }
+                           // Prefer particle not in corner ghost cells
+                           for (int dir = 0; dir < AMREX_SPACEDIM; ++dir) {
+                               Box gbx = bx;
+                               IntVect gr(IntVect::TheZeroVector());
+                               gr[dir] = nGrow;
+                               gbx.grow(gr);
+                               if (gbx.contains(iv)) {
+                                  loc = nbor.first;
+                               }
+                           }
+                        }
                     }
                 }
             }
         }
-
-        return -1;
+        return loc;
     }
 };
 

--- a/Src/Particle/AMReX_ParticleLocator.H
+++ b/Src/Particle/AMReX_ParticleLocator.H
@@ -64,7 +64,6 @@ struct AssignGrid
         int iy_hi = amrex::min((lo.y + nGrow - m_lo.y) / m_bin_size.y, m_num_bins.y-1);
         int iz_hi = amrex::min((lo.z + nGrow - m_lo.z) / m_bin_size.z, m_num_bins.z-1);
         int loc = -1;
-        Box curbox;
         for (int ii = ix_lo; ii <= ix_hi; ++ii) {
             for (int jj = iy_lo; jj <= iy_hi; ++jj) {
                 for (int kk = iz_lo; kk <= iz_hi; ++kk) {


### PR DESCRIPTION
## Summary
Currently, particles in ghost cells are simply assigned to the first box that contains them. This PR adds tests to see if the particle is contained in multiple boxes. If it is, it checks if the particle isn't in the corner ghost cells of a box and assigns the particle to that box. Otherwise, it retains the behavior before.
## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
