### PR TITLE
macOS: Fix Warning (ranlib, profiler)

### DIFF
--- a/Src/Base/CMakeLists.txt
+++ b/Src/Base/CMakeLists.txt
@@ -231,7 +231,6 @@ target_sources( amrex
    AMReX_MemPool.cpp
    AMReX_MemPool.H
    # Profiling ---------------------------------------------------------------
-   AMReX_BLProfiler.cpp
    AMReX_BLBackTrace.cpp
    # Parser ---------------------------------------------------------------
    Parser/AMReX_Parser.cpp
@@ -257,6 +256,16 @@ target_sources( amrex
    # Forward declaration -----------------------------------------------------
    AMReX_BaseFwd.H
    )
+
+# Profiling
+#   this source file has zero symbols in default conditions, which creates
+#   ranlib warnings, e.g., on macOS
+if(AMREX_PROFILING OR AMReX_FORTRAN)
+   target_sources( amrex
+     PRIVATE
+       AMReX_BLProfiler.cpp
+   )
+endif()
 
 # Fortran stuff
 if (AMReX_FORTRAN)


### PR DESCRIPTION
## Summary

Fix
```
[ 54%] Building CXX object _deps/fetchedamrex-build/Src/CMakeFiles/amrex.dir/Particle/AMReX_ParticleBufferMap.cpp.o
[ 54%] Building CXX object _deps/fetchedamrex-build/Src/CMakeFiles/amrex.dir/Particle/AMReX_ParticleCommunication.cpp.o
[ 55%] Building CXX object _deps/fetchedamrex-build/Src/CMakeFiles/amrex.dir/Particle/AMReX_ParticleContainerBase.cpp.o
[ 55%] Linking CXX static library ../../../lib/libamrex.a
/Library/Developer/CommandLineTools/usr/bin/ranlib: file: ../../../lib/libamrex.a(AMReX_BLProfiler.cpp.o) has no symbols
/Library/Developer/CommandLineTools/usr/bin/ranlib: file: ../../../lib/libamrex.a(AMReX_BLProfiler.cpp.o) has no symbols
[ 55%] Built target amrex
```

when building AMReX with CMake on macOS for C++-only users.

First seen by @Yin-YinjianZhao

## Additional background

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
