### PR TITLE
Semicoarsening in WarpX Linear Solvers

### DIFF
--- a/Src/Base/AMReX_BoxArray.H
+++ b/Src/Base/AMReX_BoxArray.H
@@ -643,9 +643,9 @@ public:
     BoxArray& coarsen (int refinement_ratio);
 
     //! Coarsen each Box in the BoxArray to the specified ratio.
-    bool coarsenable(int refinement_ratio, int min_width=1) const;
-    bool coarsenable(const IntVect& refinement_ratio, int min_width=1) const;
-    bool coarsenable(const IntVect& refinement_ratio, const IntVect& min_width) const;
+    bool coarsenable (int refinement_ratio, int min_width=1) const;
+    bool coarsenable (const IntVect& refinement_ratio, int min_width=1) const;
+    bool coarsenable (const IntVect& refinement_ratio, const IntVect& min_width) const;
 
     //! Coarsen each Box in the BoxArray to the specified ratio.
     BoxArray& coarsen (const IntVect& refinement_ratio);

--- a/Src/Base/AMReX_BoxArray.cpp
+++ b/Src/Base/AMReX_BoxArray.cpp
@@ -593,19 +593,19 @@ BoxArray::refine (const IntVect& iv)
 }
 
 bool
-BoxArray::coarsenable(int refinement_ratio, int min_width) const
+BoxArray::coarsenable (int refinement_ratio, int min_width) const
 {
     return coarsenable(IntVect{refinement_ratio}, IntVect(min_width));
 }
 
 bool
-BoxArray::coarsenable(const IntVect& refinement_ratio, int min_width) const
+BoxArray::coarsenable (const IntVect& refinement_ratio, int min_width) const
 {
     return coarsenable(refinement_ratio, IntVect(min_width));
 }
 
 bool
-BoxArray::coarsenable(const IntVect& refinement_ratio, const IntVect& min_width) const
+BoxArray::coarsenable (const IntVect& refinement_ratio, const IntVect& min_width) const
 {
     const Long sz = size();
     if(size() == 0) return false;

--- a/Src/LinearSolvers/MLMG/AMReX_MLLinOp.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLLinOp.H
@@ -41,6 +41,7 @@ struct LPInfo
     bool has_metric_term = true;
     int max_coarsening_level = 30;
     int max_semicoarsening_level = 0;
+    int semicoarsening_direction = -1;
     int hidden_direction = -1;
 
     LPInfo& setAgglomeration (bool x) noexcept { do_agglomeration = x; return *this; }
@@ -51,6 +52,7 @@ struct LPInfo
     LPInfo& setMetricTerm (bool x) noexcept { has_metric_term = x; return *this; }
     LPInfo& setMaxCoarseningLevel (int n) noexcept { max_coarsening_level = n; return *this; }
     LPInfo& setMaxSemicoarseningLevel (int n) noexcept { max_semicoarsening_level = n; return *this; }
+    LPInfo& setSemicoarseningDirection (int n) noexcept { semicoarsening_direction = n; return *this; }
     LPInfo& setHiddenDirection (int n) noexcept { hidden_direction = n; return *this; }
 
     bool hasHiddenDimension () const noexcept {

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeTensorLap_1D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeTensorLap_1D_K.H
@@ -9,6 +9,13 @@ void mlndtslap_interpadd (int, int, int, Array4<Real> const&,
                           Array4<Real const> const&, Array4<int const> const&) noexcept
 {}
 
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void mlndtslap_semi_interpadd (int, int, int, Array4<Real> const&,
+                               Array4<Real const> const&, Array4<int const> const&,
+                               int) noexcept
+{
+}
+
 }
 
 #endif

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeTensorLap_2D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeTensorLap_2D_K.H
@@ -54,6 +54,36 @@ void mlndtslap_interpadd (int i, int j, int, Array4<Real> const& fine,
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void mlndtslap_semi_interpadd (int i, int j, int, Array4<Real> const& fine,
+                               Array4<Real const> const& crse, Array4<int const> const& msk,
+                               int semi_dir) noexcept
+{
+    if (!msk(i,j,0)) {
+        if (semi_dir == 0) {
+            int jc = amrex::coarsen(j,2);
+            bool j_is_odd = (jc*2 != j);
+            if (j_is_odd) {
+                // Node on Y line
+                fine(i,j,0) += ts_interp_line_y(crse,i,jc);
+            } else {
+                // Node coincident with coarse node
+                fine(i,j,0) += crse(i,jc,0);
+            }
+        } else {
+            int ic = amrex::coarsen(i,2);
+            bool i_is_odd = (ic*2 != i);
+            if (i_is_odd) {
+                // Node on X line
+                fine(i,j,0) += ts_interp_line_x(crse,ic,j);
+            } else {
+                // Node coincident with coarse node
+                fine(i,j,0) += crse(ic,j,0);
+            }
+        }
+    }
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 void mlndtslap_adotx (int i, int j, int k, Array4<Real> const& y, Array4<Real const> const& x,
                       Array4<int const> const& msk, GpuArray<Real,3> const& s) noexcept
 {

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeTensorLap_3D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeTensorLap_3D_K.H
@@ -103,6 +103,70 @@ void mlndtslap_interpadd (int i, int j, int k, Array4<Real> const& fine,
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void mlndtslap_semi_interpadd (int i, int j, int k, Array4<Real> const& fine,
+                               Array4<Real const> const& crse, Array4<int const> const& msk,
+                               int semi_dir) noexcept
+{
+    if (!msk(i,j,k)) {
+        if (semi_dir == 0) {
+            int jc = amrex::coarsen(j,2);
+            int kc = amrex::coarsen(k,2);
+            bool j_is_odd = (jc*2 != j);
+            bool k_is_odd = (kc*2 != k);
+            if (j_is_odd && k_is_odd) {
+                // Node on a Y-Z face
+                fine(i,j,k) += ts_interp_face_yz(crse,i,jc,kc);
+            } else if (j_is_odd) {
+                // Node on Y line
+                fine(i,j,k) += ts_interp_line_y(crse,i,jc,kc);
+            } else if (k_is_odd) {
+                // Node on Z line
+                fine(i,j,k) += ts_interp_line_z(crse,i,jc,kc);
+            } else {
+                // Node coincident with coarse node
+                fine(i,j,k) += crse(i,jc,kc);
+            }
+        } else if (semi_dir == 1) {
+            int ic = amrex::coarsen(i,2);
+            int kc = amrex::coarsen(k,2);
+            bool i_is_odd = (ic*2 != i);
+            bool k_is_odd = (kc*2 != k);
+            if (i_is_odd && k_is_odd) {
+                // Node on a Z-X face
+                fine(i,j,k) += ts_interp_face_xz(crse,ic,j,kc);
+            } else if (i_is_odd) {
+                // Node on X line
+                fine(i,j,k) += ts_interp_line_x(crse,ic,j,kc);
+            } else if (k_is_odd) {
+                // Node on Z line
+                fine(i,j,k) += ts_interp_line_z(crse,ic,j,kc);
+            } else {
+                // Node coincident with coarse node
+                fine(i,j,k) += crse(ic,j,kc);
+            }
+        } else {
+            int ic = amrex::coarsen(i,2);
+            int jc = amrex::coarsen(j,2);
+            bool i_is_odd = (ic*2 != i);
+            bool j_is_odd = (jc*2 != j);
+            if (i_is_odd && j_is_odd) {
+                // Node on a X-Y face
+                fine(i,j,k) += ts_interp_face_xy(crse,ic,jc,k);
+            } else if (i_is_odd) {
+                // Node on X line
+                fine(i,j,k) += ts_interp_line_x(crse,ic,jc,k);
+            } else if (j_is_odd) {
+                // Node on Y line
+                fine(i,j,k) += ts_interp_line_y(crse,ic,jc,k);
+            } else {
+                // Node coincident with coarse node
+                fine(i,j,k) += crse(ic,jc,k);
+            }
+        }
+    }
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 void mlndtslap_adotx (int i, int j, int k, Array4<Real> const& y, Array4<Real const> const& x,
                       Array4<int const> const& msk, GpuArray<Real,6> const& s) noexcept
 {

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeTensorLaplacian.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeTensorLaplacian.cpp
@@ -88,10 +88,13 @@ MLNodeTensorLaplacian::restriction (int amrlev, int cmglev, MultiFab& crse, Mult
 
     applyBC(amrlev, cmglev-1, fine, BCMode::Homogeneous, StateMode::Solution);
 
+    IntVect const ratio = mg_coarsen_ratio_vec[cmglev-1];
+    int semicoarsening_dir = info.semicoarsening_direction;
+
     bool need_parallel_copy = !amrex::isMFIterSafe(crse, fine);
     MultiFab cfine;
     if (need_parallel_copy) {
-        const BoxArray& ba = amrex::coarsen(fine.boxArray(), 2);
+        const BoxArray& ba = amrex::coarsen(fine.boxArray(), ratio);
         cfine.define(ba, fine.DistributionMap(), 1, 0);
     }
 
@@ -107,10 +110,17 @@ MLNodeTensorLaplacian::restriction (int amrlev, int cmglev, MultiFab& crse, Mult
         Array4<Real> cfab = pcrse->array(mfi);
         Array4<Real const> const& ffab = fine.const_array(mfi);
         Array4<int const> const& mfab = dmsk.const_array(mfi);
-        AMREX_HOST_DEVICE_PARALLEL_FOR_3D(bx, i, j, k,
-        {
-            mlndlap_restriction(i,j,k,cfab,ffab,mfab);
-        });
+        if (ratio == 2) {
+            AMREX_HOST_DEVICE_PARALLEL_FOR_3D(bx, i, j, k,
+            {
+                mlndlap_restriction(i,j,k,cfab,ffab,mfab);
+            });
+        } else {
+            AMREX_HOST_DEVICE_PARALLEL_FOR_3D(bx, i, j, k,
+            {
+                mlndlap_semi_restriction(i,j,k,cfab,ffab,mfab, semicoarsening_dir);
+            });
+        }
     }
 
     if (need_parallel_copy) {
@@ -124,11 +134,14 @@ MLNodeTensorLaplacian::interpolation (int amrlev, int fmglev, MultiFab& fine,
 {
     BL_PROFILE("MLNodeTensorLaplacian::interpolation()");
 
+    IntVect const ratio = mg_coarsen_ratio_vec[fmglev];
+    int semicoarsening_dir = info.semicoarsening_direction;
+
     bool need_parallel_copy = !amrex::isMFIterSafe(crse, fine);
     MultiFab cfine;
     const MultiFab* cmf = &crse;
     if (need_parallel_copy) {
-        const BoxArray& ba = amrex::coarsen(fine.boxArray(), 2);
+        const BoxArray& ba = amrex::coarsen(fine.boxArray(), ratio);
         cfine.define(ba, fine.DistributionMap(), 1, 0);
         cfine.ParallelCopy(crse);
         cmf = &cfine;
@@ -145,10 +158,17 @@ MLNodeTensorLaplacian::interpolation (int amrlev, int fmglev, MultiFab& fine,
         Array4<Real> const& ffab = fine.array(mfi);
         Array4<Real const> const& cfab = cmf->const_array(mfi);
         Array4<int const> const& mfab = dmsk.const_array(mfi);
-        AMREX_HOST_DEVICE_PARALLEL_FOR_3D(bx, i, j, k,
-        {
-            mlndtslap_interpadd(i,j,k,ffab,cfab,mfab);
-        });
+        if (ratio == 2) {
+            AMREX_HOST_DEVICE_PARALLEL_FOR_3D(bx, i, j, k,
+            {
+                mlndtslap_interpadd(i,j,k,ffab,cfab,mfab);
+            });
+        } else {
+            AMREX_HOST_DEVICE_PARALLEL_FOR_3D(bx, i, j, k,
+            {
+                mlndtslap_semi_interpadd(i,j,k,ffab,cfab,mfab,semicoarsening_dir);
+            });
+        }
     }
 }
 


### PR DESCRIPTION
Add support for semicoarsening in two linear solvers used by WarpX,
MLNodeTensorLap and EBNodeFDLaplacian.  The semicoarsening approach here is
different from the existing approach for the nodal projection solver.  There
the grids are coarsened regularly as much as possible and then we switch to
coarsening in directions that are still coarsenable, whereas here we do
semicoarsening first in specified direction and then switch to regular
coarsening if the specified maximum semicoarsening level has not been
reached.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
