### PR TITLE
Use pc.WritePlotFile instead of pc.Checkpoint in Tests.

### DIFF
--- a/Src/Particle/AMReX_ParticleIO.H
+++ b/Src/Particle/AMReX_ParticleIO.H
@@ -234,7 +234,7 @@ WritePlotFile (const std::string& dir, const std::string& name,
 
 template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt,
           template<class> class Allocator>
-template <class F, typename std::enable_if<!std::is_same<F, Vector<std::string>>::value>::type*>
+template <class F, typename std::enable_if<!std::is_same<F, Vector<std::string>&>::value>::type*>
 void
 ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>
 ::WritePlotFile (const std::string& dir, const std::string& name, F&& f) const

--- a/Src/Particle/AMReX_Particles.H
+++ b/Src/Particle/AMReX_Particles.H
@@ -792,7 +792,7 @@ public:
      * \param name The name of the sub-directory for this particle type (i.e. "Tracer")
      * \param f callable that returns whether or not to write each particle
      */
-    template <class F, typename std::enable_if<!std::is_same<F, Vector<std::string>>::value>::type* = nullptr>
+    template <class F, typename std::enable_if<!std::is_same<F, Vector<std::string>&>::value>::type* = nullptr>
     void WritePlotFile (const std::string& dir, const std::string& name, F&& f) const;
 
     /**

--- a/Tests/Amr/Advection_AmrLevel/Source/AmrLevelAdv.cpp
+++ b/Tests/Amr/Advection_AmrLevel/Source/AmrLevelAdv.cpp
@@ -91,7 +91,7 @@ AmrLevelAdv::checkPoint (const std::string& dir,
   AmrLevel::checkPoint(dir, os, how, dump_old);
 #ifdef AMREX_PARTICLES
   if (do_tracers && level == 0) {
-    TracerPC->Checkpoint(dir, "Tracer", true);
+    TracerPC->WritePlotFile(dir, "Tracer");
   }
 #endif
 }
@@ -109,7 +109,7 @@ AmrLevelAdv::writePlotFile (const std::string& dir,
 
 #ifdef AMREX_PARTICLES
     if (do_tracers && level == 0) {
-      TracerPC->Checkpoint(dir, "Tracer", true);
+      TracerPC->WritePlotFile(dir, "Tracer");
     }
 #endif
 }

--- a/Tests/Particles/AssignDensity/main.cpp
+++ b/Tests/Particles/AssignDensity/main.cpp
@@ -79,7 +79,7 @@ void test_assign_density(TestParams& parms)
                            {"density", AMREX_D_DECL("vx", "vy", "vz")},
                            geom, 0.0, 0);
 
-  myPC.Checkpoint("plt00000", "particle0");
+  myPC.WritePlotFile("plt00000", "particle0");
 }
 
 int main(int argc, char* argv[])

--- a/Tests/Particles/AssignMultiLevelDensity/main.cpp
+++ b/Tests/Particles/AssignMultiLevelDensity/main.cpp
@@ -132,7 +132,7 @@ void test_assign_density(TestParams& parms)
 
     WriteMultiLevelPlotfile("plt00000", output_levs, outputMF,
                             varnames, geom, 0.0, level_steps, outputRR);
-    myPC.Checkpoint("plt00000", "particle0", true, particle_varnames);
+    myPC.WritePlotFile("plt00000", "particle0", particle_varnames);
 }
 
 int main(int argc, char* argv[])

--- a/Tests/Particles/ParticleMesh/main.cpp
+++ b/Tests/Particles/ParticleMesh/main.cpp
@@ -151,7 +151,7 @@ void testParticleMesh (TestParams& parms)
                            {"density", AMREX_D_DECL("vx", "vy", "vz")},
                            geom, 0.0, 0);
 
-  myPC.Checkpoint("plot", "particle0");
+  myPC.WritePlotFile("plot", "particle0");
 }
 
 int main(int argc, char* argv[])

--- a/Tests/Particles/ParticleMeshMultiLevel/main.cpp
+++ b/Tests/Particles/ParticleMeshMultiLevel/main.cpp
@@ -138,7 +138,7 @@ void testParticleMesh (TestParams& parms)
     }
     WriteMultiLevelPlotfile("plt00000_v1", output_levs, outputMF,
                             varnames, geom, 0.0, level_steps, outputRR);
-    myPC.Checkpoint("plt00000_v1", "particle0", true, particle_varnames);
+    myPC.WritePlotFile("plt00000_v1", "particle0", particle_varnames);
 
     for (int lev = 0; lev < output_levs; ++lev) {
         outputMF[lev] = &density2[lev];
@@ -146,7 +146,7 @@ void testParticleMesh (TestParams& parms)
     }
     WriteMultiLevelPlotfile("plt00000_v2", output_levs, outputMF,
                             varnames, geom, 0.0, level_steps, outputRR);
-    myPC.Checkpoint("plt00000_v2", "particle0", true, particle_varnames);
+    myPC.WritePlotFile("plt00000_v2", "particle0", particle_varnames);
 }
 
 int main(int argc, char* argv[])


### PR DESCRIPTION
This allows the particles in these plotfiles to be read by e.g. Paraview.

I've also fixed a bug in the `enable_if` in one of the WritePlotFile overloads that was needed for this to work.

I'll fix the ones in amrex-tutorials in a later PR.

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
