### PR TITLE
Make the ParticleReduce functions not rely on ParIter.

### DIFF
--- a/Src/Particle/AMReX_ParticleReduce.H
+++ b/Src/Particle/AMReX_ParticleReduce.H
@@ -121,12 +121,19 @@ ReduceSum (PC const& pc, int lev_min, int lev_max, F&& f) -> decltype(f(typename
         for (int lev = lev_min; lev <= lev_max; ++lev)
         {
             const auto& plev = pc.GetParticles(lev);
-#ifdef AMREX_USE_OMP
-#pragma omp parallel if (!system::regtest_reduction) reduction(+:sm)
-#endif
-            for (const auto& kv : plev)
+            Vector<std::pair<int, int> > grid_tile_ids;
+            Vector<const typename PC::ParticleTileType*> ptile_ptrs;
+            for (auto& kv : plev)
             {
-                const auto& tile = plev.at(std::make_pair(kv.first.first, kv.first.second));
+                grid_tile_ids.push_back(kv.first);
+                ptile_ptrs.push_back(&(kv.second));
+            }
+#ifdef AMREX_USE_OMP
+#pragma omp parallel for if (!system::regtest_reduction) reduction(+:sm)
+#endif
+            for (int pmap_it = 0; pmap_it < static_cast<int>(ptile_ptrs.size()); ++pmap_it)
+            {
+                const auto& tile = plev.at(grid_tile_ids[pmap_it]);
                 const auto np = tile.numParticles();
                 const auto ptd = tile.getConstParticleTileData();
                 for (int i = 0; i < np; ++i) {
@@ -247,12 +254,19 @@ ReduceMax (PC const& pc, int lev_min, int lev_max, F&& f) -> decltype(f(typename
         for (int lev = lev_min; lev <= lev_max; ++lev)
         {
             const auto& plev = pc.GetParticles(lev);
-#ifdef AMREX_USE_OMP
-#pragma omp parallel if (!system::regtest_reduction) reduction(max:r)
-#endif
-            for (const auto& kv : plev)
+            Vector<std::pair<int, int> > grid_tile_ids;
+            Vector<const typename PC::ParticleTileType*> ptile_ptrs;
+            for (auto& kv : plev)
             {
-                const auto& tile = plev.at(std::make_pair(kv.first.first, kv.first.second));
+                grid_tile_ids.push_back(kv.first);
+                ptile_ptrs.push_back(&(kv.second));
+            }
+#ifdef AMREX_USE_OMP
+#pragma omp parallel for if (!system::regtest_reduction) reduction(max:r)
+#endif
+            for (int pmap_it = 0; pmap_it < static_cast<int>(ptile_ptrs.size()); ++pmap_it)
+            {
+                const auto& tile = plev.at(grid_tile_ids[pmap_it]);
                 const auto np = tile.numParticles();
                 const auto ptd = tile.getConstParticleTileData();
                 for (int i = 0; i < np; ++i) {
@@ -373,12 +387,19 @@ ReduceMin (PC const& pc, int lev_min, int lev_max, F&& f) -> decltype(f(typename
         for (int lev = lev_min; lev <= lev_max; ++lev)
         {
             const auto& plev = pc.GetParticles(lev);
-#ifdef AMREX_USE_OMP
-#pragma omp parallel if (!system::regtest_reduction) reduction(min:r)
-#endif
-            for (const auto& kv : plev)
+            Vector<std::pair<int, int> > grid_tile_ids;
+            Vector<const typename PC::ParticleTileType*> ptile_ptrs;
+            for (auto& kv : plev)
             {
-                const auto& tile = plev.at(std::make_pair(kv.first.first, kv.first.second));
+                grid_tile_ids.push_back(kv.first);
+                ptile_ptrs.push_back(&(kv.second));
+            }
+#ifdef AMREX_USE_OMP
+#pragma omp parallel for if (!system::regtest_reduction) reduction(min:r)
+#endif
+            for (int pmap_it = 0; pmap_it < static_cast<int>(ptile_ptrs.size()); ++pmap_it)
+            {
+                const auto& tile = plev.at(grid_tile_ids[pmap_it]);
                 const auto np = tile.numParticles();
                 const auto ptd = tile.getConstParticleTileData();
                 for (int i = 0; i < np; ++i) {
@@ -497,12 +518,19 @@ ReduceLogicalAnd (PC const& pc, int lev_min, int lev_max, F&& f)
         for (int lev = lev_min; lev <= lev_max; ++lev)
         {
             const auto& plev = pc.GetParticles(lev);
-#ifdef AMREX_USE_OMP
-#pragma omp parallel if (!system::regtest_reduction) reduction(&&:r)
-#endif
-            for (const auto& kv : plev)
+            Vector<std::pair<int, int> > grid_tile_ids;
+            Vector<const typename PC::ParticleTileType*> ptile_ptrs;
+            for (auto& kv : plev)
             {
-                const auto& tile = plev.at(std::make_pair(kv.first.first, kv.first.second));
+                grid_tile_ids.push_back(kv.first);
+                ptile_ptrs.push_back(&(kv.second));
+            }
+#ifdef AMREX_USE_OMP
+#pragma omp parallel for if (!system::regtest_reduction) reduction(&&:r)
+#endif
+            for (int pmap_it = 0; pmap_it < static_cast<int>(ptile_ptrs.size()); ++pmap_it)
+            {
+                const auto& tile = plev.at(grid_tile_ids[pmap_it]);
                 const auto np = tile.numParticles();
                 const auto ptd = tile.getConstParticleTileData();
                 for (int i = 0; i < np; ++i) {
@@ -621,12 +649,19 @@ ReduceLogicalOr (PC const& pc, int lev_min, int lev_max, F&& f)
         for (int lev = lev_min; lev <= lev_max; ++lev)
         {
             const auto& plev = pc.GetParticles(lev);
-#ifdef AMREX_USE_OMP
-#pragma omp parallel if (!system::regtest_reduction) reduction(||:r)
-#endif
-            for (const auto& kv : plev)
+            Vector<std::pair<int, int> > grid_tile_ids;
+            Vector<const typename PC::ParticleTileType*> ptile_ptrs;
+            for (auto& kv : plev)
             {
-                const auto& tile = plev.at(std::make_pair(kv.first.first, kv.first.second));
+                grid_tile_ids.push_back(kv.first);
+                ptile_ptrs.push_back(&(kv.second));
+            }
+#ifdef AMREX_USE_OMP
+#pragma omp parallel for if (!system::regtest_reduction) reduction(||:r)
+#endif
+            for (int pmap_it = 0; pmap_it < static_cast<int>(ptile_ptrs.size()); ++pmap_it)
+            {
+                const auto& tile = plev.at(grid_tile_ids[pmap_it]);
                 const auto np = tile.numParticles();
                 const auto ptd = tile.getConstParticleTileData();
                 for (int i = 0; i < np; ++i) {
@@ -773,14 +808,21 @@ typename RD::Type
 ParticleReduce (PC const& pc, int lev_min, int lev_max, F&& f, ReduceOps& reduce_ops)
 {
     RD reduce_data(reduce_ops);
-#if !defined(AMREX_USE_GPU) && defined(AMREX_USE_OMP)
-#pragma omp parallel
-#endif
     for (int lev = lev_min; lev <= lev_max; ++lev) {
         const auto& plev = pc.GetParticles(lev);
-        for (const auto& kv : plev)
+        Vector<std::pair<int, int> > grid_tile_ids;
+        Vector<const typename PC::ParticleTileType*> ptile_ptrs;
+        for (auto& kv : plev)
         {
-            const auto& tile = plev.at(std::make_pair(kv.first.first, kv.first.second));
+            grid_tile_ids.push_back(kv.first);
+            ptile_ptrs.push_back(&(kv.second));
+        }
+#if !defined(AMREX_USE_GPU) && defined(AMREX_USE_OMP)
+#pragma omp parallel for
+#endif
+        for (int pmap_it = 0; pmap_it < static_cast<int>(ptile_ptrs.size()); ++pmap_it)
+        {
+            const auto& tile = plev.at(grid_tile_ids[pmap_it]);
             const auto np = tile.numParticles();
             const auto ptd = tile.getConstParticleTileData();
             reduce_ops.eval(np, reduce_data,

--- a/Src/Particle/AMReX_ParticleReduce.H
+++ b/Src/Particle/AMReX_ParticleReduce.H
@@ -102,9 +102,10 @@ ReduceSum (PC const& pc, int lev_min, int lev_max, F&& f) -> decltype(f(typename
 
         for (int lev = lev_min; lev <= lev_max; ++lev)
         {
-            for(ParIter pti(pc, lev); pti.isValid(); ++pti)
+            const auto& plev = pc.GetParticles(lev);
+            for (const auto& kv : plev)
             {
-                const auto& tile = pti.GetParticleTile();
+                const auto& tile = plev.at(std::make_pair(kv.first.first, kv.first.second));
                 const auto np = tile.numParticles();
                 const auto ptd = tile.getConstParticleTileData();
                 reduce_op.eval(np, reduce_data,
@@ -120,16 +121,18 @@ ReduceSum (PC const& pc, int lev_min, int lev_max, F&& f) -> decltype(f(typename
     {
         for (int lev = lev_min; lev <= lev_max; ++lev)
         {
+            const auto& plev = pc.GetParticles(lev);
 #ifdef AMREX_USE_OMP
 #pragma omp parallel if (!system::regtest_reduction) reduction(+:sm)
 #endif
-            for(ParIter pti(pc, lev); pti.isValid(); ++pti)
+            for (const auto& kv : plev)
             {
-                const auto& tile = pti.GetParticleTile();
+                const auto& tile = plev.at(std::make_pair(kv.first.first, kv.first.second));
                 const auto np = tile.numParticles();
-                                const auto ptd = tile.getConstParticleTileData();
-                for (int i = 0; i < np; ++i)
+                const auto ptd = tile.getConstParticleTileData();
+                for (int i = 0; i < np; ++i) {
                     sm += f(ptd.getSuperParticle(i));
+                }
             }
         }
     }
@@ -226,11 +229,12 @@ ReduceMax (PC const& pc, int lev_min, int lev_max, F&& f) -> decltype(f(typename
 
         for (int lev = lev_min; lev <= lev_max; ++lev)
         {
-            for(ParIter pti(pc, lev); pti.isValid(); ++pti)
+            const auto& plev = pc.GetParticles(lev);
+            for (const auto& kv : plev)
             {
-                const auto& tile = pti.GetParticleTile();
+                const auto& tile = plev.at(std::make_pair(kv.first.first, kv.first.second));
                 const auto np = tile.numParticles();
-                                const auto ptd = tile.getConstParticleTileData();
+                const auto ptd = tile.getConstParticleTileData();
                 reduce_op.eval(np, reduce_data,
                 [=] AMREX_GPU_DEVICE (const int i) -> ReduceTuple {return {f(ptd.getSuperParticle(i))};});
             }
@@ -244,16 +248,18 @@ ReduceMax (PC const& pc, int lev_min, int lev_max, F&& f) -> decltype(f(typename
     {
         for (int lev = lev_min; lev <= lev_max; ++lev)
         {
+            const auto& plev = pc.GetParticles(lev);
 #ifdef AMREX_USE_OMP
 #pragma omp parallel if (!system::regtest_reduction) reduction(max:r)
 #endif
-            for(ParIter pti(pc, lev); pti.isValid(); ++pti)
+            for (const auto& kv : plev)
             {
-                const auto& tile = pti.GetParticleTile();
+                const auto& tile = plev.at(std::make_pair(kv.first.first, kv.first.second));
                 const auto np = tile.numParticles();
-                                const auto ptd = tile.getConstParticleTileData();
-                for (int i = 0; i < np; ++i)
+                const auto ptd = tile.getConstParticleTileData();
+                for (int i = 0; i < np; ++i) {
                     r = std::max(r, f(ptd.getSuperParticle(i)));
+                }
             }
         }
     }
@@ -350,11 +356,12 @@ ReduceMin (PC const& pc, int lev_min, int lev_max, F&& f) -> decltype(f(typename
 
         for (int lev = lev_min; lev <= lev_max; ++lev)
         {
-            for(ParIter pti(pc, lev); pti.isValid(); ++pti)
+            const auto& plev = pc.GetParticles(lev);
+            for (const auto& kv : plev)
             {
-                const auto& tile = pti.GetParticleTile();
+                const auto& tile = plev.at(std::make_pair(kv.first.first, kv.first.second));
                 const auto np = tile.numParticles();
-                                const auto ptd = tile.getConstParticleTileData();
+                const auto ptd = tile.getConstParticleTileData();
                 reduce_op.eval(np, reduce_data,
                 [=] AMREX_GPU_DEVICE (const int i) -> ReduceTuple {return {f(ptd.getSuperParticle(i))};});
             }
@@ -368,16 +375,18 @@ ReduceMin (PC const& pc, int lev_min, int lev_max, F&& f) -> decltype(f(typename
     {
         for (int lev = lev_min; lev <= lev_max; ++lev)
         {
+            const auto& plev = pc.GetParticles(lev);
 #ifdef AMREX_USE_OMP
 #pragma omp parallel if (!system::regtest_reduction) reduction(min:r)
 #endif
-            for(ParIter pti(pc, lev); pti.isValid(); ++pti)
+            for (const auto& kv : plev)
             {
-                const auto& tile = pti.GetParticleTile();
+                const auto& tile = plev.at(std::make_pair(kv.first.first, kv.first.second));
                 const auto np = tile.numParticles();
-                                const auto ptd = tile.getConstParticleTileData();
-                for (int i = 0; i < np; ++i)
+                const auto ptd = tile.getConstParticleTileData();
+                for (int i = 0; i < np; ++i) {
                     r = std::min(r, f(ptd.getSuperParticle(i)));
+                }
             }
         }
     }
@@ -472,11 +481,12 @@ ReduceLogicalAnd (PC const& pc, int lev_min, int lev_max, F&& f)
 
         for (int lev = lev_min; lev <= lev_max; ++lev)
         {
-            for(ParIter pti(pc, lev); pti.isValid(); ++pti)
+            const auto& plev = pc.GetParticles(lev);
+            for (const auto& kv : plev)
             {
-                const auto& tile = pti.GetParticleTile();
+                const auto& tile = plev.at(std::make_pair(kv.first.first, kv.first.second));
                 const auto np = tile.numParticles();
-                                const auto ptd = tile.getConstParticleTileData();
+                const auto ptd = tile.getConstParticleTileData();
                 reduce_op.eval(np, reduce_data,
                 [=] AMREX_GPU_DEVICE (const int i) -> ReduceTuple {return {f(ptd.getSuperParticle(i))};});
             }
@@ -490,16 +500,18 @@ ReduceLogicalAnd (PC const& pc, int lev_min, int lev_max, F&& f)
     {
         for (int lev = lev_min; lev <= lev_max; ++lev)
         {
+            const auto& plev = pc.GetParticles(lev);
 #ifdef AMREX_USE_OMP
 #pragma omp parallel if (!system::regtest_reduction) reduction(&&:r)
 #endif
-            for(ParIter pti(pc, lev); pti.isValid(); ++pti)
+            for (const auto& kv : plev)
             {
-                const auto& tile = pti.GetParticleTile();
+                const auto& tile = plev.at(std::make_pair(kv.first.first, kv.first.second));
                 const auto np = tile.numParticles();
-                                const auto ptd = tile.getConstParticleTileData();
-                for (int i = 0; i < np; ++i)
+                const auto ptd = tile.getConstParticleTileData();
+                for (int i = 0; i < np; ++i) {
                     r = r && f(ptd.getSuperParticle(i));
+                }
             }
         }
     }
@@ -594,13 +606,14 @@ ReduceLogicalOr (PC const& pc, int lev_min, int lev_max, F&& f)
 
         for (int lev = lev_min; lev <= lev_max; ++lev)
         {
-            for(ParIter pti(pc, lev); pti.isValid(); ++pti)
+            const auto& plev = pc.GetParticles(lev);
+            for (const auto& kv : plev)
             {
-                const auto& tile = pti.GetParticleTile();
+                const auto& tile = plev.at(std::make_pair(kv.first.first, kv.first.second));
                 const auto np = tile.numParticles();
-                                const auto ptd = tile.getConstParticleTileData();
+                const auto ptd = tile.getConstParticleTileData();
                 reduce_op.eval(np, reduce_data,
-                                [=] AMREX_GPU_DEVICE (const int i) -> ReduceTuple {return {f(ptd.getSuperParticle(i))};});
+                               [=] AMREX_GPU_DEVICE (const int i) -> ReduceTuple {return {f(ptd.getSuperParticle(i))};});
             }
         }
 
@@ -612,16 +625,18 @@ ReduceLogicalOr (PC const& pc, int lev_min, int lev_max, F&& f)
     {
         for (int lev = lev_min; lev <= lev_max; ++lev)
         {
+            const auto& plev = pc.GetParticles(lev);
 #ifdef AMREX_USE_OMP
 #pragma omp parallel if (!system::regtest_reduction) reduction(||:r)
 #endif
-            for(ParIter pti(pc, lev); pti.isValid(); ++pti)
+            for (const auto& kv : plev)
             {
-                const auto& tile = pti.GetParticleTile();
+                const auto& tile = plev.at(std::make_pair(kv.first.first, kv.first.second));
                 const auto np = tile.numParticles();
-                                const auto ptd = tile.getConstParticleTileData();
-                for (int i = 0; i < np; ++i)
+                const auto ptd = tile.getConstParticleTileData();
+                for (int i = 0; i < np; ++i) {
                     r = r || f(ptd.getSuperParticle(i));
+                }
 
             }
         }
@@ -768,8 +783,10 @@ ParticleReduce (PC const& pc, int lev_min, int lev_max, F&& f, ReduceOps& reduce
 #pragma omp parallel
 #endif
     for (int lev = lev_min; lev <= lev_max; ++lev) {
-        for (ParIter pti(pc, lev); pti.isValid(); ++pti) {
-            const auto& tile = pti.GetParticleTile();
+        const auto& plev = pc.GetParticles(lev);
+        for (const auto& kv : plev)
+        {
+            const auto& tile = plev.at(std::make_pair(kv.first.first, kv.first.second));
             const auto np = tile.numParticles();
             const auto ptd = tile.getConstParticleTileData();
             reduce_ops.eval(np, reduce_data,

--- a/Src/Particle/AMReX_ParticleReduce.H
+++ b/Src/Particle/AMReX_ParticleReduce.H
@@ -90,7 +90,6 @@ auto
 ReduceSum (PC const& pc, int lev_min, int lev_max, F&& f) -> decltype(f(typename PC::SuperParticleType()))
 {
     using value_type = decltype(f(typename PC::SuperParticleType()));
-    using ParIter = typename PC::ParConstIterType;
     value_type sm = 0;
 
 #ifdef AMREX_USE_GPU
@@ -216,7 +215,6 @@ auto
 ReduceMax (PC const& pc, int lev_min, int lev_max, F&& f) -> decltype(f(typename PC::SuperParticleType()))
 {
     using value_type = decltype(f(typename PC::SuperParticleType()));
-    using ParIter = typename PC::ParConstIterType;
     constexpr value_type value_lowest = std::numeric_limits<value_type>::lowest();
     value_type r = value_lowest;
 
@@ -343,7 +341,6 @@ auto
 ReduceMin (PC const& pc, int lev_min, int lev_max, F&& f) -> decltype(f(typename PC::SuperParticleType()))
 {
     using value_type = decltype(f(typename PC::SuperParticleType()));
-    using ParIter = typename PC::ParConstIterType;
     constexpr value_type value_max = std::numeric_limits<value_type>::max();
     value_type r = value_max;
 
@@ -469,7 +466,6 @@ template <class PC, class F, std::enable_if_t<IsParticleContainer<PC>::value, in
 bool
 ReduceLogicalAnd (PC const& pc, int lev_min, int lev_max, F&& f)
 {
-    using ParIter = typename PC::ParConstIterType;
     int r = true;
 
 #ifdef AMREX_USE_GPU
@@ -594,7 +590,6 @@ template <class PC, class F, std::enable_if_t<IsParticleContainer<PC>::value, in
 bool
 ReduceLogicalOr (PC const& pc, int lev_min, int lev_max, F&& f)
 {
-    using ParIter = typename PC::ParConstIterType;
     int r = false;
 
 #ifdef AMREX_USE_GPU
@@ -778,7 +773,6 @@ typename RD::Type
 ParticleReduce (PC const& pc, int lev_min, int lev_max, F&& f, ReduceOps& reduce_ops)
 {
     RD reduce_data(reduce_ops);
-    using ParIter = typename PC::ParConstIterType;
 #if !defined(AMREX_USE_GPU) && defined(AMREX_USE_OMP)
 #pragma omp parallel
 #endif

--- a/Src/Particle/AMReX_ParticleReduce.H
+++ b/Src/Particle/AMReX_ParticleReduce.H
@@ -8,8 +8,10 @@
 #include <AMReX_Print.H>
 #include <AMReX_GpuUtility.H>
 #include <AMReX_TypeTraits.H>
+#include <AMReX_Vector.H>
 
 #include <limits>
+#include <utility>
 
 namespace amrex
 {


### PR DESCRIPTION
A potentially useful pattern that came up in ImpactX is to add particles to a container on grid 0, compute the extrema of the particle positions, set the box size, then call Redistribute(). However, this currently doesn't work because the ParticleReduce functions rely on ParIter, which require the Redistribute method to have already been called after adding the particles on grid 0. This changes the ParticleReduce functions to not rely on ParIter so the above order of operations will work.

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
