### PR TITLE
Generalize the type of lambdas that can be passed into ParticleReduce

### DIFF
--- a/Src/Particle/AMReX_ParticleReduce.H
+++ b/Src/Particle/AMReX_ParticleReduce.H
@@ -8,6 +8,7 @@
 #include <AMReX_Print.H>
 #include <AMReX_GpuUtility.H>
 #include <AMReX_TypeTraits.H>
+#include <AMReX_ParticleUtil.H>
 
 #include <limits>
 
@@ -34,7 +35,8 @@ namespace amrex
  */
 template <class PC, class F, std::enable_if_t<IsParticleContainer<PC>::value, int> foo = 0>
 auto
-ReduceSum (PC const& pc, F&& f) -> decltype(f(typename PC::SuperParticleType()))
+ReduceSum (PC const& pc, F&& f)
+    -> decltype(particle_detail::call_f(f, typename PC::ParticleTileType::ConstParticleTileDataType(), int()))
 {
     return ReduceSum(pc, 0, pc.finestLevel(), std::forward<F>(f));
 }
@@ -60,7 +62,8 @@ ReduceSum (PC const& pc, F&& f) -> decltype(f(typename PC::SuperParticleType()))
  */
 template <class PC, class F, std::enable_if_t<IsParticleContainer<PC>::value, int> foo = 0>
 auto
-ReduceSum (PC const& pc, int lev, F&& f) -> decltype(f(typename PC::SuperParticleType()))
+ReduceSum (PC const& pc, int lev, F&& f)
+    -> decltype(particle_detail::call_f(f, typename PC::ParticleTileType::ConstParticleTileDataType(), int()))
 {
     return ReduceSum(pc, lev, lev, std::forward<F>(f));
 }
@@ -87,9 +90,10 @@ ReduceSum (PC const& pc, int lev, F&& f) -> decltype(f(typename PC::SuperParticl
  */
 template <class PC, class F, std::enable_if_t<IsParticleContainer<PC>::value, int> foo = 0>
 auto
-ReduceSum (PC const& pc, int lev_min, int lev_max, F&& f) -> decltype(f(typename PC::SuperParticleType()))
+ReduceSum (PC const& pc, int lev_min, int lev_max, F&& f)
+    -> decltype(particle_detail::call_f(f, typename PC::ParticleTileType::ConstParticleTileDataType(), int()))
 {
-    using value_type = decltype(f(typename PC::SuperParticleType()));
+    using value_type = decltype(particle_detail::call_f(f, typename PC::ParticleTileType::ConstParticleTileDataType(), int()));
     using ParIter = typename PC::ParConstIterType;
     value_type sm = 0;
 
@@ -108,7 +112,9 @@ ReduceSum (PC const& pc, int lev_min, int lev_max, F&& f) -> decltype(f(typename
                 const auto np = tile.numParticles();
                 const auto ptd = tile.getConstParticleTileData();
                 reduce_op.eval(np, reduce_data,
-                [=] AMREX_GPU_DEVICE (const int i) -> ReduceTuple {return {f(ptd.getSuperParticle(i))};});
+                               [=] AMREX_GPU_DEVICE (const int i) -> ReduceTuple {
+                                   return particle_detail::call_f(f, ptd, i);
+                               });
             }
         }
 
@@ -129,7 +135,7 @@ ReduceSum (PC const& pc, int lev_min, int lev_max, F&& f) -> decltype(f(typename
                 const auto np = tile.numParticles();
                                 const auto ptd = tile.getConstParticleTileData();
                 for (int i = 0; i < np; ++i)
-                    sm += f(ptd.getSuperParticle(i));
+                    sm += particle_detail::call_f(f, ptd, i);
             }
         }
     }
@@ -157,7 +163,8 @@ ReduceSum (PC const& pc, int lev_min, int lev_max, F&& f) -> decltype(f(typename
  */
 template <class PC, class F, std::enable_if_t<IsParticleContainer<PC>::value, int> foo = 0>
 auto
-ReduceMax (PC const& pc, F&& f) -> decltype(f(typename PC::SuperParticleType()))
+ReduceMax (PC const& pc, F&& f)
+    -> decltype(particle_detail::call_f(f, typename PC::ParticleTileType::ConstParticleTileDataType(), int()))
 {
     return ReduceMax(pc, 0, pc.finestLevel(), std::forward<F>(f));
 }
@@ -183,7 +190,8 @@ ReduceMax (PC const& pc, F&& f) -> decltype(f(typename PC::SuperParticleType()))
  */
 template <class PC, class F, std::enable_if_t<IsParticleContainer<PC>::value, int> foo = 0>
 auto
-ReduceMax (PC const& pc, int lev, F&& f) -> decltype(f(typename PC::SuperParticleType()))
+ReduceMax (PC const& pc, int lev, F&& f)
+    -> decltype(particle_detail::call_f(f, typename PC::ParticleTileType::ConstParticleTileDataType(), int()))
 {
     return ReduceMax(pc, lev, lev, std::forward<F>(f));
 }
@@ -210,9 +218,10 @@ ReduceMax (PC const& pc, int lev, F&& f) -> decltype(f(typename PC::SuperParticl
  */
 template <class PC, class F, std::enable_if_t<IsParticleContainer<PC>::value, int> foo = 0>
 auto
-ReduceMax (PC const& pc, int lev_min, int lev_max, F&& f) -> decltype(f(typename PC::SuperParticleType()))
+ReduceMax (PC const& pc, int lev_min, int lev_max, F&& f)
+    -> decltype(particle_detail::call_f(f, typename PC::ParticleTileType::ConstParticleTileDataType(), int()))
 {
-    using value_type = decltype(f(typename PC::SuperParticleType()));
+    using value_type = decltype(particle_detail::call_f(f, typename PC::ParticleTileType::ConstParticleTileDataType(), int()));
     using ParIter = typename PC::ParConstIterType;
     constexpr value_type value_lowest = std::numeric_limits<value_type>::lowest();
     value_type r = value_lowest;
@@ -232,7 +241,9 @@ ReduceMax (PC const& pc, int lev_min, int lev_max, F&& f) -> decltype(f(typename
                 const auto np = tile.numParticles();
                                 const auto ptd = tile.getConstParticleTileData();
                 reduce_op.eval(np, reduce_data,
-                [=] AMREX_GPU_DEVICE (const int i) -> ReduceTuple {return {f(ptd.getSuperParticle(i))};});
+                               [=] AMREX_GPU_DEVICE (const int i) -> ReduceTuple {
+                                   return particle_detail::call_f(f, ptd, i);
+                               });
             }
         }
 
@@ -253,7 +264,7 @@ ReduceMax (PC const& pc, int lev_min, int lev_max, F&& f) -> decltype(f(typename
                 const auto np = tile.numParticles();
                                 const auto ptd = tile.getConstParticleTileData();
                 for (int i = 0; i < np; ++i)
-                    r = std::max(r, f(ptd.getSuperParticle(i)));
+                    r = std::max(r, particle_detail::call_f(f, ptd, i));
             }
         }
     }
@@ -281,7 +292,8 @@ ReduceMax (PC const& pc, int lev_min, int lev_max, F&& f) -> decltype(f(typename
  */
 template <class PC, class F, std::enable_if_t<IsParticleContainer<PC>::value, int> foo = 0>
 auto
-ReduceMin (PC const& pc, F&& f) -> decltype(f(typename PC::SuperParticleType()))
+ReduceMin (PC const& pc, F&& f)
+    -> decltype(particle_detail::call_f(f, typename PC::ParticleTileType::ConstParticleTileDataType(), int()))
 {
     return ReduceMin(pc, 0, pc.finestLevel(), std::forward<F>(f));
 }
@@ -307,7 +319,8 @@ ReduceMin (PC const& pc, F&& f) -> decltype(f(typename PC::SuperParticleType()))
  */
 template <class PC, class F, std::enable_if_t<IsParticleContainer<PC>::value, int> foo = 0>
 auto
-ReduceMin (PC const& pc, int lev, F&& f) -> decltype(f(typename PC::SuperParticleType()))
+ReduceMin (PC const& pc, int lev, F&& f)
+    -> decltype(particle_detail::call_f(f, typename PC::ParticleTileType::ConstParticleTileDataType(), int()))
 {
     return ReduceMin(pc, lev, lev, std::forward<F>(f));
 }
@@ -334,9 +347,10 @@ ReduceMin (PC const& pc, int lev, F&& f) -> decltype(f(typename PC::SuperParticl
  */
 template <class PC, class F, std::enable_if_t<IsParticleContainer<PC>::value, int> foo = 0>
 auto
-ReduceMin (PC const& pc, int lev_min, int lev_max, F&& f) -> decltype(f(typename PC::SuperParticleType()))
+ReduceMin (PC const& pc, int lev_min, int lev_max, F&& f)
+    -> decltype(particle_detail::call_f(f, typename PC::ParticleTileType::ConstParticleTileDataType(), int()))
 {
-    using value_type = decltype(f(typename PC::SuperParticleType()));
+    using value_type = decltype(particle_detail::call_f(f, typename PC::ParticleTileType::ConstParticleTileDataType(), int()));
     using ParIter = typename PC::ParConstIterType;
     constexpr value_type value_max = std::numeric_limits<value_type>::max();
     value_type r = value_max;
@@ -356,7 +370,9 @@ ReduceMin (PC const& pc, int lev_min, int lev_max, F&& f) -> decltype(f(typename
                 const auto np = tile.numParticles();
                                 const auto ptd = tile.getConstParticleTileData();
                 reduce_op.eval(np, reduce_data,
-                [=] AMREX_GPU_DEVICE (const int i) -> ReduceTuple {return {f(ptd.getSuperParticle(i))};});
+                               [=] AMREX_GPU_DEVICE (const int i) -> ReduceTuple {
+                                   return particle_detail::call_f(f, ptd, i);
+                               });
             }
         }
 
@@ -377,7 +393,7 @@ ReduceMin (PC const& pc, int lev_min, int lev_max, F&& f) -> decltype(f(typename
                 const auto np = tile.numParticles();
                                 const auto ptd = tile.getConstParticleTileData();
                 for (int i = 0; i < np; ++i)
-                    r = std::min(r, f(ptd.getSuperParticle(i)));
+                    r = std::min(r, particle_detail::call_f(f, ptd, i));
             }
         }
     }
@@ -478,7 +494,9 @@ ReduceLogicalAnd (PC const& pc, int lev_min, int lev_max, F&& f)
                 const auto np = tile.numParticles();
                                 const auto ptd = tile.getConstParticleTileData();
                 reduce_op.eval(np, reduce_data,
-                [=] AMREX_GPU_DEVICE (const int i) -> ReduceTuple {return {f(ptd.getSuperParticle(i))};});
+                               [=] AMREX_GPU_DEVICE (const int i) -> ReduceTuple {
+                                   return particle_detail::call_f(f, ptd, i);
+                               });
             }
         }
 
@@ -499,7 +517,7 @@ ReduceLogicalAnd (PC const& pc, int lev_min, int lev_max, F&& f)
                 const auto np = tile.numParticles();
                                 const auto ptd = tile.getConstParticleTileData();
                 for (int i = 0; i < np; ++i)
-                    r = r && f(ptd.getSuperParticle(i));
+                    r = r && particle_detail::call_f(f, ptd, i);
             }
         }
     }
@@ -600,7 +618,10 @@ ReduceLogicalOr (PC const& pc, int lev_min, int lev_max, F&& f)
                 const auto np = tile.numParticles();
                                 const auto ptd = tile.getConstParticleTileData();
                 reduce_op.eval(np, reduce_data,
-                                [=] AMREX_GPU_DEVICE (const int i) -> ReduceTuple {return {f(ptd.getSuperParticle(i))};});
+                               [=] AMREX_GPU_DEVICE (const int i) -> ReduceTuple
+                               {
+                                   return particle_detail::call_f(f, ptd, i);
+                               });
             }
         }
 
@@ -621,8 +642,7 @@ ReduceLogicalOr (PC const& pc, int lev_min, int lev_max, F&& f)
                 const auto np = tile.numParticles();
                                 const auto ptd = tile.getConstParticleTileData();
                 for (int i = 0; i < np; ++i)
-                    r = r || f(ptd.getSuperParticle(i));
-
+                    r = r || particle_detail::call_f(f, ptd, i);
             }
         }
     }
@@ -775,7 +795,7 @@ ParticleReduce (PC const& pc, int lev_min, int lev_max, F&& f, ReduceOps& reduce
             reduce_ops.eval(np, reduce_data,
                             [=] AMREX_GPU_DEVICE (const int i) noexcept
                             {
-                                return f(ptd.getSuperParticle(i));
+                                return particle_detail::call_f(f, ptd, i);
                             });
         }
     }

--- a/Src/Particle/AMReX_ParticleReduce.H
+++ b/Src/Particle/AMReX_ParticleReduce.H
@@ -32,7 +32,28 @@ namespace amrex
  * \tparam F a function object
  *
  * \param pc the ParticleContainer to operate on
- * \param f a function that takes a "superparticle" and returns the value to be reduced over all particles.
+ * \param f a callable that operates on a single particle. Example forms:
+ *
+ *        using PType = typename PC::ParticleType;
+ *        auto sm = amrex::ReduceSum(pc,
+ *                  [=] AMREX_GPU_HOST_DEVICE (const PType& p) -> ParticleReal
+ *                  {
+ *                      return p.rdata(0);
+ *                  });
+ *
+ *        using SPType  = typename PC::SuperParticleType;
+ *        auto sm = amrex::ReduceSum(pc,
+ *                  [=] AMREX_GPU_HOST_DEVICE (const SPType& p) -> int
+ *                  {
+ *                      return p.idata(0);
+ *                  });
+ *
+ *        using PTDType = typename PC::ParticleTileType::ConstParticleTileDataType;
+ *        auto sm = amrex::ReduceSum(pc,
+ *                  [=] AMREX_GPU_HOST_DEVICE (const PTDType& ptd, const int i) -> ParticleReal
+ *                  {
+ *                      return ptd.m_aos[i].rdata(0);
+ *                  });
  *
  */
 template <class PC, class F, std::enable_if_t<IsParticleContainer<PC>::value, int> foo = 0>
@@ -59,7 +80,28 @@ ReduceSum (PC const& pc, F&& f)
  *
  * \param pc the ParticleContainer to operate on
  * \param lev the level to operate on
- * \param f a function that takes a "superparticle" and returns the value to be reduced over all particles.
+ * \param f a callable that operates on a single particle. Example forms:
+ *
+ *        using PType = typename PC::ParticleType;
+ *        auto sm = amrex::ReduceSum(pc,
+ *                  [=] AMREX_GPU_HOST_DEVICE (const PType& p) -> ParticleReal
+ *                  {
+ *                      return p.rdata(0);
+ *                  });
+ *
+ *        using SPType  = typename PC::SuperParticleType;
+ *        auto sm = amrex::ReduceSum(pc,
+ *                  [=] AMREX_GPU_HOST_DEVICE (const SPType& p) -> int
+ *                  {
+ *                      return p.idata(0);
+ *                  });
+ *
+ *        using PTDType = typename PC::ParticleTileType::ConstParticleTileDataType;
+ *        auto sm = amrex::ReduceSum(pc,
+ *                  [=] AMREX_GPU_HOST_DEVICE (const PTDType& ptd, const int i) -> ParticleReal
+ *                  {
+ *                      return ptd.m_aos[i].rdata(0);
+ *                  });
  *
  */
 template <class PC, class F, std::enable_if_t<IsParticleContainer<PC>::value, int> foo = 0>
@@ -87,7 +129,28 @@ ReduceSum (PC const& pc, int lev, F&& f)
  * \param pc the ParticleContainer to operate on
  * \param lev_min the minimum level to include
  * \param lev_max the maximum level to include
- * \param f a function that takes a "superparticle" and returns the value to be reduced over all particles.
+ * \param f a callable that operates on a single particle. Example forms:
+ *
+ *        using PType = typename PC::ParticleType;
+ *        auto sm = amrex::ReduceSum(pc,
+ *                  [=] AMREX_GPU_HOST_DEVICE (const PType& p) -> ParticleReal
+ *                  {
+ *                      return p.rdata(0);
+ *                  });
+ *
+ *        using SPType  = typename PC::SuperParticleType;
+ *        auto sm = amrex::ReduceSum(pc,
+ *                  [=] AMREX_GPU_HOST_DEVICE (const SPType& p) -> int
+ *                  {
+ *                      return p.idata(0);
+ *                  });
+ *
+ *        using PTDType = typename PC::ParticleTileType::ConstParticleTileDataType;
+ *        auto sm = amrex::ReduceSum(pc,
+ *                  [=] AMREX_GPU_HOST_DEVICE (const PTDType& ptd, const int i) -> ParticleReal
+ *                  {
+ *                      return ptd.m_aos[i].rdata(0);
+ *                  });
  *
  */
 template <class PC, class F, std::enable_if_t<IsParticleContainer<PC>::value, int> foo = 0>
@@ -169,7 +232,28 @@ ReduceSum (PC const& pc, int lev_min, int lev_max, F&& f)
  * \tparam F a function object
  *
  * \param pc the ParticleContainer to operate on
- * \param f a function that takes a "superparticle" and returns the value to be reduced over all particles.
+ * \param f a callable that operates on a single particle. Example forms:
+ *
+ *        using PType = typename PC::ParticleType;
+ *        auto mx = amrex::ReduceMax(pc,
+ *                  [=] AMREX_GPU_HOST_DEVICE (const PType& p) -> ParticleReal
+ *                  {
+ *                      return p.rdata(0);
+ *                  });
+ *
+ *        using SPType  = typename PC::SuperParticleType;
+ *        auto mx = amrex::ReduceMax(pc,
+ *                  [=] AMREX_GPU_HOST_DEVICE (const SPType& p) -> int
+ *                  {
+ *                      return p.idata(0);
+ *                  });
+ *
+ *        using PTDType = typename PC::ParticleTileType::ConstParticleTileDataType;
+ *        auto mx = amrex::ReduceMax(pc,
+ *                  [=] AMREX_GPU_HOST_DEVICE (const PTDType& ptd, const int i) -> ParticleReal
+ *                  {
+ *                      return ptd.m_aos[i].rdata(0);
+ *                  });
  *
  */
 template <class PC, class F, std::enable_if_t<IsParticleContainer<PC>::value, int> foo = 0>
@@ -196,7 +280,28 @@ ReduceMax (PC const& pc, F&& f)
  *
  * \param pc the ParticleContainer to operate on
  * \param lev the level to operate on
- * \param f a function that takes a "superparticle" and returns the value to be reduced over all particles.
+ * \param f a callable that operates on a single particle. Example forms:
+ *
+ *        using PType = typename PC::ParticleType;
+ *        auto mx = amrex::ReduceMax(pc,
+ *                  [=] AMREX_GPU_HOST_DEVICE (const PType& p) -> ParticleReal
+ *                  {
+ *                      return p.rdata(0);
+ *                  });
+ *
+ *        using SPType  = typename PC::SuperParticleType;
+ *        auto mx = amrex::ReduceMax(pc,
+ *                  [=] AMREX_GPU_HOST_DEVICE (const SPType& p) -> int
+ *                  {
+ *                      return p.idata(0);
+ *                  });
+ *
+ *        using PTDType = typename PC::ParticleTileType::ConstParticleTileDataType;
+ *        auto mx = amrex::ReduceMax(pc,
+ *                  [=] AMREX_GPU_HOST_DEVICE (const PTDType& ptd, const int i) -> ParticleReal
+ *                  {
+ *                      return ptd.m_aos[i].rdata(0);
+ *                  });
  *
  */
 template <class PC, class F, std::enable_if_t<IsParticleContainer<PC>::value, int> foo = 0>
@@ -224,7 +329,28 @@ ReduceMax (PC const& pc, int lev, F&& f)
  * \param pc the ParticleContainer to operate on
  * \param lev_min the minimum level to include
  * \param lev_max the maximum level to include
- * \param f a function that takes a "superparticle" and returns the value to be reduced over all particles.
+ * \param f a callable that operates on a single particle. Example forms:
+ *
+ *        using PType = typename PC::ParticleType;
+ *        auto mx = amrex::ReduceMax(pc,
+ *                  [=] AMREX_GPU_HOST_DEVICE (const PType& p) -> ParticleReal
+ *                  {
+ *                      return p.rdata(0);
+ *                  });
+ *
+ *        using SPType  = typename PC::SuperParticleType;
+ *        auto mx = amrex::ReduceMax(pc,
+ *                  [=] AMREX_GPU_HOST_DEVICE (const SPType& p) -> int
+ *                  {
+ *                      return p.idata(0);
+ *                  });
+ *
+ *        using PTDType = typename PC::ParticleTileType::ConstParticleTileDataType;
+ *        auto mx = amrex::ReduceMax(pc,
+ *                  [=] AMREX_GPU_HOST_DEVICE (const PTDType& ptd, const int i) -> ParticleReal
+ *                  {
+ *                      return ptd.m_aos[i].rdata(0);
+ *                  });
  *
  */
 template <class PC, class F, std::enable_if_t<IsParticleContainer<PC>::value, int> foo = 0>
@@ -307,7 +433,28 @@ ReduceMax (PC const& pc, int lev_min, int lev_max, F&& f)
  * \tparam F a function object
  *
  * \param pc the ParticleContainer to operate on
- * \param f a function that takes a "superparticle" and returns the value to be reduced over all particles.
+ * \param f a callable that operates on a single particle. Example forms:
+ *
+ *        using PType = typename PC::ParticleType;
+ *        auto mn = amrex::ReduceMin(pc,
+ *                  [=] AMREX_GPU_HOST_DEVICE (const PType& p) -> ParticleReal
+ *                  {
+ *                      return p.rdata(0);
+ *                  });
+ *
+ *        using SPType  = typename PC::SuperParticleType;
+ *        auto mn = amrex::ReduceMin(pc,
+ *                  [=] AMREX_GPU_HOST_DEVICE (const SPType& p) -> int
+ *                  {
+ *                      return p.idata(0);
+ *                  });
+ *
+ *        using PTDType = typename PC::ParticleTileType::ConstParticleTileDataType;
+ *        auto mn = amrex::ReduceMin(pc,
+ *                  [=] AMREX_GPU_HOST_DEVICE (const PTDType& ptd, const int i) -> ParticleReal
+ *                  {
+ *                      return ptd.m_aos[i].rdata(0);
+ *                  });
  *
  */
 template <class PC, class F, std::enable_if_t<IsParticleContainer<PC>::value, int> foo = 0>
@@ -334,7 +481,28 @@ ReduceMin (PC const& pc, F&& f)
  *
  * \param pc the ParticleContainer to operate on
  * \param lev the level to operate on
- * \param f a function that takes a "superparticle" and returns the value to be reduced over all particles.
+ * \param f a callable that operates on a single particle. Example forms:
+ *
+ *        using PType = typename PC::ParticleType;
+ *        auto mn = amrex::ReduceMin(pc,
+ *                  [=] AMREX_GPU_HOST_DEVICE (const PType& p) -> ParticleReal
+ *                  {
+ *                      return p.rdata(0);
+ *                  });
+ *
+ *        using SPType  = typename PC::SuperParticleType;
+ *        auto mn = amrex::ReduceMin(pc,
+ *                  [=] AMREX_GPU_HOST_DEVICE (const SPType& p) -> int
+ *                  {
+ *                      return p.idata(0);
+ *                  });
+ *
+ *        using PTDType = typename PC::ParticleTileType::ConstParticleTileDataType;
+ *        auto mn = amrex::ReduceMin(pc,
+ *                  [=] AMREX_GPU_HOST_DEVICE (const PTDType& ptd, const int i) -> ParticleReal
+ *                  {
+ *                      return ptd.m_aos[i].rdata(0);
+ *                  });
  *
  */
 template <class PC, class F, std::enable_if_t<IsParticleContainer<PC>::value, int> foo = 0>
@@ -362,7 +530,28 @@ ReduceMin (PC const& pc, int lev, F&& f)
  * \param pc the ParticleContainer to operate on
  * \param lev_min the minimum level to include
  * \param lev_max the maximum level to include
- * \param f a function that takes a "superparticle" and returns the value to be reduced over all particles.
+ * \param f a callable that operates on a single particle. Example forms:
+ *
+ *        using PType = typename PC::ParticleType;
+ *        auto mn = amrex::ReduceMin(pc,
+ *                  [=] AMREX_GPU_HOST_DEVICE (const PType& p) -> ParticleReal
+ *                  {
+ *                      return p.rdata(0);
+ *                  });
+ *
+ *        using SPType  = typename PC::SuperParticleType;
+ *        auto mn = amrex::ReduceMin(pc,
+ *                  [=] AMREX_GPU_HOST_DEVICE (const SPType& p) -> int
+ *                  {
+ *                      return p.idata(0);
+ *                  });
+ *
+ *        using PTDType = typename PC::ParticleTileType::ConstParticleTileDataType;
+ *        auto mn = amrex::ReduceMin(pc,
+ *                  [=] AMREX_GPU_HOST_DEVICE (const PTDType& ptd, const int i) -> ParticleReal
+ *                  {
+ *                      return ptd.m_aos[i].rdata(0);
+ *                  });
  *
  */
 template <class PC, class F, std::enable_if_t<IsParticleContainer<PC>::value, int> foo = 0>
@@ -445,7 +634,28 @@ ReduceMin (PC const& pc, int lev_min, int lev_max, F&& f)
  * \tparam F a function object
  *
  * \param pc the ParticleContainer to operate on
- * \param f a function that takes a "superparticle" and returns the value to be reduced over all particles.
+ * \param f a callable that operates on a single particle. Example forms:
+ *
+ *        using PType = typename PC::ParticleType;
+ *        auto rv = amrex::ReduceLogicalAnd(pc,
+ *                  [=] AMREX_GPU_HOST_DEVICE (const PType& p) -> bool
+ *                  {
+ *                      return p.id() > 0;
+ *                  });
+ *
+ *        using SPType  = typename PC::SuperParticleType;
+ *        auto rv = amrex::ReduceLogicalAnd(pc,
+ *                  [=] AMREX_GPU_HOST_DEVICE (const SPType& p) -> bool
+ *                  {
+ *                      return p.id() > 0;
+ *                  });
+ *
+ *        using PTDType = typename PC::ParticleTileType::ConstParticleTileDataType;
+ *        auto rv = amrex::ReduceLogicalAnd(pc,
+ *                  [=] AMREX_GPU_HOST_DEVICE (const PTDType& ptd, const int i) -> bool
+ *                  {
+ *                      return ptd.m_aos[i].id() > 0;
+ *                  });
  *
  */
 template <class PC, class F, std::enable_if_t<IsParticleContainer<PC>::value, int> foo = 0>
@@ -471,7 +681,28 @@ ReduceLogicalAnd (PC const& pc, F&& f)
  *
  * \param pc the ParticleContainer to operate on
  * \param lev the level to operate on
- * \param f a function that takes a "superparticle" and returns the value to be reduced over all particles.
+ * \param f a callable that operates on a single particle. Example forms:
+ *
+ *        using PType = typename PC::ParticleType;
+ *        auto rv = amrex::ReduceLogicalAnd(pc,
+ *                  [=] AMREX_GPU_HOST_DEVICE (const PType& p) -> bool
+ *                  {
+ *                      return p.id() > 0;
+ *                  });
+ *
+ *        using SPType  = typename PC::SuperParticleType;
+ *        auto rv = amrex::ReduceLogicalAnd(pc,
+ *                  [=] AMREX_GPU_HOST_DEVICE (const SPType& p) -> bool
+ *                  {
+ *                      return p.id() > 0;
+ *                  });
+ *
+ *        using PTDType = typename PC::ParticleTileType::ConstParticleTileDataType;
+ *        auto rv = amrex::ReduceLogicalAnd(pc,
+ *                  [=] AMREX_GPU_HOST_DEVICE (const PTDType& ptd, const int i) -> bool
+ *                  {
+ *                      return ptd.m_aos[i].id() > 0;
+ *                  });
  *
  */
 template <class PC, class F, std::enable_if_t<IsParticleContainer<PC>::value, int> foo = 0>
@@ -498,7 +729,28 @@ ReduceLogicalAnd (PC const& pc, int lev, F&& f)
  * \param pc the ParticleContainer to operate on
  * \param lev_min the minimum level to include
  * \param lev_max the maximum level to include
- * \param f a function that takes a "superparticle" and returns the value to be reduced over all particles.
+ * \param f a callable that operates on a single particle. Example forms:
+ *
+ *        using PType = typename PC::ParticleType;
+ *        auto rv = amrex::ReduceLogicalAnd(pc,
+ *                  [=] AMREX_GPU_HOST_DEVICE (const PType& p) -> bool
+ *                  {
+ *                      return p.id() > 0;
+ *                  });
+ *
+ *        using SPType  = typename PC::SuperParticleType;
+ *        auto rv = amrex::ReduceLogicalAnd(pc,
+ *                  [=] AMREX_GPU_HOST_DEVICE (const SPType& p) -> bool
+ *                  {
+ *                      return p.id() > 0;
+ *                  });
+ *
+ *        using PTDType = typename PC::ParticleTileType::ConstParticleTileDataType;
+ *        auto rv = amrex::ReduceLogicalAnd(pc,
+ *                  [=] AMREX_GPU_HOST_DEVICE (const PTDType& ptd, const int i) -> bool
+ *                  {
+ *                      return ptd.m_aos[i].id() > 0;
+ *                  });
  *
  */
 template <class PC, class F, std::enable_if_t<IsParticleContainer<PC>::value, int> foo = 0>
@@ -578,7 +830,28 @@ ReduceLogicalAnd (PC const& pc, int lev_min, int lev_max, F&& f)
  * \tparam F a function object
  *
  * \param pc the ParticleContainer to operate on
- * \param f a function that takes a "superparticle" and returns the value to be reduced over all particles.
+ * \param f a callable that operates on a single particle. Example forms:
+ *
+ *        using PType = typename PC::ParticleType;
+ *        auto rv = amrex::ReduceLogicalOr(pc,
+ *                  [=] AMREX_GPU_HOST_DEVICE (const PType& p) -> bool
+ *                  {
+ *                      return p.id() < 1;
+ *                  });
+ *
+ *        using SPType  = typename PC::SuperParticleType;
+ *        auto rv = amrex::ReduceLogicalOr(pc,
+ *                  [=] AMREX_GPU_HOST_DEVICE (const SPType& p) -> bool
+ *                  {
+ *                      return p.id() < 1;
+ *                  });
+ *
+ *        using PTDType = typename PC::ParticleTileType::ConstParticleTileDataType;
+ *        auto rv = amrex::ReduceLogicalOr(pc,
+ *                  [=] AMREX_GPU_HOST_DEVICE (const PTDType& ptd, const int i) -> bool
+ *                  {
+ *                      return ptd.m_aos[i].id() < 1;
+ *                  });
  *
  */
 template <class PC, class F, std::enable_if_t<IsParticleContainer<PC>::value, int> foo = 0>
@@ -604,7 +877,28 @@ ReduceLogicalOr (PC const& pc, F&& f)
  *
  * \param pc the ParticleContainer to operate on
  * \param lev the level to operate on
- * \param f a function that takes a "superparticle" and returns the value to be reduced over all particles.
+ * \param f a callable that operates on a single particle. Example forms:
+ *
+ *        using PType = typename PC::ParticleType;
+ *        auto rv = amrex::ReduceLogicalOr(pc,
+ *                  [=] AMREX_GPU_HOST_DEVICE (const PType& p) -> bool
+ *                  {
+ *                      return p.id() < 1;
+ *                  });
+ *
+ *        using SPType  = typename PC::SuperParticleType;
+ *        auto rv = amrex::ReduceLogicalOr(pc,
+ *                  [=] AMREX_GPU_HOST_DEVICE (const SPType& p) -> bool
+ *                  {
+ *                      return p.id() < 1;
+ *                  });
+ *
+ *        using PTDType = typename PC::ParticleTileType::ConstParticleTileDataType;
+ *        auto rv = amrex::ReduceLogicalOr(pc,
+ *                  [=] AMREX_GPU_HOST_DEVICE (const PTDType& ptd, const int i) -> bool
+ *                  {
+ *                      return ptd.m_aos[i].id() < 1;
+ *                  });
  *
  */
 template <class PC, class F, std::enable_if_t<IsParticleContainer<PC>::value, int> foo = 0>
@@ -631,7 +925,28 @@ ReduceLogicalOr (PC const& pc, int lev, F&& f)
  * \param pc the ParticleContainer to operate on
  * \param lev_min the minimum level to include
  * \param lev_max the maximum level to include
- * \param f a function that takes a "superparticle" and returns the value to be reduced over all particles.
+ * \param f a callable that operates on a single particle. Example forms:
+ *
+ *        using PType = typename PC::ParticleType;
+ *        auto rv = amrex::ReduceLogicalOr(pc,
+ *                  [=] AMREX_GPU_HOST_DEVICE (const PType& p) -> bool
+ *                  {
+ *                      return p.id() < 1;
+ *                  });
+ *
+ *        using SPType  = typename PC::SuperParticleType;
+ *        auto rv = amrex::ReduceLogicalOr(pc,
+ *                  [=] AMREX_GPU_HOST_DEVICE (const SPType& p) -> bool
+ *                  {
+ *                      return p.id() < 1;
+ *                  });
+ *
+ *        using PTDType = typename PC::ParticleTileType::ConstParticleTileDataType;
+ *        auto rv = amrex::ReduceLogicalOr(pc,
+ *                  [=] AMREX_GPU_HOST_DEVICE (const PTDType& ptd, const int i) -> bool
+ *                  {
+ *                      return ptd.m_aos[i].id() < 1;
+ *                  });
  *
  */
 template <class PC, class F, std::enable_if_t<IsParticleContainer<PC>::value, int> foo = 0>
@@ -717,10 +1032,11 @@ ReduceLogicalOr (PC const& pc, int lev_min, int lev_max, F&& f)
  * \tparam ReduceOps a ReduceOps type
  *
  * \param pc the ParticleContainer to operate on
- * \param f a function that takes a "superparticle" and returns a tuple of values to be reduced over all particles.
+ * \param f a callable that operates on a single particle, see below for example forms.
  * \param reduce_ops specifies the reduction operations for each tuple element
  *
  * Example usage:
+ *    using PType = typename PC::ParticleType;
  *    amrex::ReduceOps<ReduceOpSum, ReduceOpMin, ReduceOpMax> reduce_ops;
  *    auto r = amrex::ParticleReduce<ReduceData<amrex::Real, amrex::Real,int>> (
  *                 pc, [=] AMREX_GPU_DEVICE (const PType& p) noexcept
@@ -729,6 +1045,30 @@ ReduceLogicalOr (PC const& pc, int lev_min, int lev_max, F&& f)
  *                 const amrex::Real a = p.rdata(1);
  *                 const amrex::Real b = p.rdata(2);
  *                 const int c = p.idata(1);
+ *                 return {a, b, c};
+ *             }, reduce_ops);
+ *
+ *    using SPType  = typename PC::SuperParticleType;
+ *    amrex::ReduceOps<ReduceOpSum, ReduceOpMin, ReduceOpMax> reduce_ops;
+ *    auto r = amrex::ParticleReduce<ReduceData<amrex::Real, amrex::Real,int>> (
+ *                 pc, [=] AMREX_GPU_DEVICE (const SPType& p) noexcept
+ *                               -> amrex::GpuTuple<amrex::Real,amrex::Real,int>
+ *             {
+ *                 const amrex::Real a = p.rdata(1);
+ *                 const amrex::Real b = p.rdata(2);
+ *                 const int c = p.idata(1);
+ *                 return {a, b, c};
+ *             }, reduce_ops);
+ *
+ *    using PTDType = typename PC::ParticleTileType::ConstParticleTileDataType;
+ *    amrex::ReduceOps<ReduceOpSum, ReduceOpMin, ReduceOpMax> reduce_ops;
+ *    auto r = amrex::ParticleReduce<ReduceData<amrex::Real, amrex::Real,int>> (
+ *                 pc, [=] AMREX_GPU_DEVICE (const PTDType& ptd, const int i) noexcept
+ *                               -> amrex::GpuTuple<amrex::Real,amrex::Real,int>
+ *             {
+ *                 const amrex::Real a = ptd.m_aos[i].rdata(1);
+ *                 const amrex::Real b = ptd.m_aos[i].rdata(2);
+ *                 const int c = ptd.m_aos[i].idata(1);
  *                 return {a, b, c};
  *             }, reduce_ops);
  *
@@ -762,18 +1102,43 @@ ParticleReduce (PC const& pc, F&& f, ReduceOps& reduce_ops)
  *
  * \param pc the ParticleContainer to operate on
  * \param lev the level to operate on
- * \param f a function that takes a "superparticle" and returns a tuple of values to be reduced over all particles.
+ * \param f a callable that operates on a single particle, see below for example forms.
  * \param reduce_ops specifies the reduction operations for each tuple element
  *
  * Example usage:
+ *    using PType = typename PC::ParticleType;
  *    amrex::ReduceOps<ReduceOpSum, ReduceOpMin, ReduceOpMax> reduce_ops;
  *    auto r = amrex::ParticleReduce<ReduceData<amrex::Real, amrex::Real,int>> (
- *                 pc, 0, [=] AMREX_GPU_DEVICE (const PType& p) noexcept
+ *                 pc, [=] AMREX_GPU_DEVICE (const PType& p) noexcept
  *                               -> amrex::GpuTuple<amrex::Real,amrex::Real,int>
  *             {
  *                 const amrex::Real a = p.rdata(1);
  *                 const amrex::Real b = p.rdata(2);
  *                 const int c = p.idata(1);
+ *                 return {a, b, c};
+ *             }, reduce_ops);
+ *
+ *    using SPType  = typename PC::SuperParticleType;
+ *    amrex::ReduceOps<ReduceOpSum, ReduceOpMin, ReduceOpMax> reduce_ops;
+ *    auto r = amrex::ParticleReduce<ReduceData<amrex::Real, amrex::Real,int>> (
+ *                 pc, [=] AMREX_GPU_DEVICE (const SPType& p) noexcept
+ *                               -> amrex::GpuTuple<amrex::Real,amrex::Real,int>
+ *             {
+ *                 const amrex::Real a = p.rdata(1);
+ *                 const amrex::Real b = p.rdata(2);
+ *                 const int c = p.idata(1);
+ *                 return {a, b, c};
+ *             }, reduce_ops);
+ *
+ *    using PTDType = typename PC::ParticleTileType::ConstParticleTileDataType;
+ *    amrex::ReduceOps<ReduceOpSum, ReduceOpMin, ReduceOpMax> reduce_ops;
+ *    auto r = amrex::ParticleReduce<ReduceData<amrex::Real, amrex::Real,int>> (
+ *                 pc, [=] AMREX_GPU_DEVICE (const PTDType& ptd, const int i) noexcept
+ *                               -> amrex::GpuTuple<amrex::Real,amrex::Real,int>
+ *             {
+ *                 const amrex::Real a = ptd.m_aos[i].rdata(1);
+ *                 const amrex::Real b = ptd.m_aos[i].rdata(2);
+ *                 const int c = ptd.m_aos[i].idata(1);
  *                 return {a, b, c};
  *             }, reduce_ops);
  *
@@ -808,18 +1173,43 @@ ParticleReduce (PC const& pc, int lev, F&& f, ReduceOps& reduce_ops)
  * \param pc the ParticleContainer to operate on
  * \param lev_min the minimum level to include
  * \param lev_max the maximum level to include
- * \param f a function that takes a "superparticle" and returns a tuple of values to be reduced over all particles.
+ * \param f a callable that operates on a single particle, see below for example forms.
  * \param reduce_ops specifies the reduction operations for each tuple element
  *
  * Example usage:
+ *    using PType = typename PC::ParticleType;
  *    amrex::ReduceOps<ReduceOpSum, ReduceOpMin, ReduceOpMax> reduce_ops;
  *    auto r = amrex::ParticleReduce<ReduceData<amrex::Real, amrex::Real,int>> (
- *                 pc, 0, 1, [=] AMREX_GPU_DEVICE (const PType& p) noexcept
+ *                 pc, [=] AMREX_GPU_DEVICE (const PType& p) noexcept
  *                               -> amrex::GpuTuple<amrex::Real,amrex::Real,int>
  *             {
  *                 const amrex::Real a = p.rdata(1);
  *                 const amrex::Real b = p.rdata(2);
  *                 const int c = p.idata(1);
+ *                 return {a, b, c};
+ *             }, reduce_ops);
+ *
+ *    using SPType  = typename PC::SuperParticleType;
+ *    amrex::ReduceOps<ReduceOpSum, ReduceOpMin, ReduceOpMax> reduce_ops;
+ *    auto r = amrex::ParticleReduce<ReduceData<amrex::Real, amrex::Real,int>> (
+ *                 pc, [=] AMREX_GPU_DEVICE (const SPType& p) noexcept
+ *                               -> amrex::GpuTuple<amrex::Real,amrex::Real,int>
+ *             {
+ *                 const amrex::Real a = p.rdata(1);
+ *                 const amrex::Real b = p.rdata(2);
+ *                 const int c = p.idata(1);
+ *                 return {a, b, c};
+ *             }, reduce_ops);
+ *
+ *    using PTDType = typename PC::ParticleTileType::ConstParticleTileDataType;
+ *    amrex::ReduceOps<ReduceOpSum, ReduceOpMin, ReduceOpMax> reduce_ops;
+ *    auto r = amrex::ParticleReduce<ReduceData<amrex::Real, amrex::Real,int>> (
+ *                 pc, [=] AMREX_GPU_DEVICE (const PTDType& ptd, const int i) noexcept
+ *                               -> amrex::GpuTuple<amrex::Real,amrex::Real,int>
+ *             {
+ *                 const amrex::Real a = ptd.m_aos[i].rdata(1);
+ *                 const amrex::Real b = ptd.m_aos[i].rdata(2);
+ *                 const int c = ptd.m_aos[i].idata(1);
  *                 return {a, b, c};
  *             }, reduce_ops);
  *

--- a/Src/Particle/AMReX_ParticleUtil.H
+++ b/Src/Particle/AMReX_ParticleUtil.H
@@ -53,6 +53,41 @@ auto call_f (F const& f, SrcData const& src, N i, amrex::RandomEngine const&) no
     return f(src,i);
 }
 
+// The next several functions are used by ParticleReduce
+
+// Lambda takes a Particle
+template <typename F, int NSR, int NSI, int NAR, int NAI>
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+auto call_f (F const& f,
+             const ConstParticleTileData<NSR, NSI, NAR, NAI>& p,
+             const int i) noexcept
+    -> decltype(f(p.m_aos[i]))
+{
+    return f(p.m_aos[i]);
+}
+
+// Lambda takes a SuperParticle
+template <typename F, int NSR, int NSI, int NAR, int NAI>
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+auto call_f (F const& f,
+             const ConstParticleTileData<NSR, NSI, NAR, NAI>& p,
+             const int i) noexcept
+    -> decltype(f(p.getSuperParticle(i)))
+{
+    return f(p.getSuperParticle(i));
+}
+
+// Lambda takes a ConstParticleTileData
+template <typename F, int NSR, int NSI, int NAR, int NAI>
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+auto call_f (F const& f,
+             const ConstParticleTileData<NSR, NSI, NAR, NAI>& p,
+             const int i) noexcept
+    -> decltype(f(p, i))
+{
+    return f(p, i);
+}
+
 // These next several functions are used by ParticleToMesh and MeshToParticle
 
 // Lambda takes a Particle

--- a/Src/Particle/AMReX_ParticleUtil.H
+++ b/Src/Particle/AMReX_ParticleUtil.H
@@ -67,7 +67,8 @@ auto call_f (F const& f,
 }
 
 // Lambda takes a SuperParticle
-template <typename F, int NSR, int NSI, int NAR, int NAI>
+template <typename F, int NSR, int NSI, int NAR, int NAI,
+          typename std::enable_if<NAR != 0 || NAI != 0, int>::type = 0>
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 auto call_f (F const& f,
              const ConstParticleTileData<NSR, NSI, NAR, NAI>& p,

--- a/Tests/Particles/GhostsAndVirtuals/main.cpp
+++ b/Tests/Particles/GhostsAndVirtuals/main.cpp
@@ -83,7 +83,7 @@ void test_ghosts_and_virtuals (TestParams& parms)
         dmap.at(lev) = DistributionMapping{ba.at(lev)};
     }
 
-    typedef AmrParticleContainer<1, 0, 0, 0> MyParticleContainer;
+    typedef AmrParticleContainer<1, 0, 0, 1> MyParticleContainer;
     MyParticleContainer myPC(geom, dmap, ba, rr);
     myPC.SetVerbose(parms.verbose);
 
@@ -219,7 +219,7 @@ void test_ghosts_and_virtuals_ascii (TestParams& parms)
     }
 
     typedef AmrParticleContainer<4, 0, 0, 0> MyParticleContainer;
-    using PType = typename amrex::ParticleContainer<4, 0>::SuperParticleType;
+    using PType = typename MyParticleContainer::SuperParticleType;
     MyParticleContainer myPC(geom, dmap_orig, ba_orig, rr);
 
     myPC.SetVerbose(parms.verbose);
@@ -414,7 +414,7 @@ void test_ghosts_and_virtuals_randomperbox (TestParams& parms)
     }
 
     typedef AmrParticleContainer<4, 0, 0, 0> MyParticleContainer;
-    using PType = typename amrex::ParticleContainer<4, 0>::SuperParticleType;
+    using PType = typename MyParticleContainer::SuperParticleType;
     MyParticleContainer myPC(geom, dmap, ba, rr);
     myPC.SetVerbose(false);
 
@@ -607,7 +607,7 @@ void test_ghosts_and_virtuals_onepercell (TestParams& parms)
     }
 
     typedef AmrParticleContainer<4, 0, 0, 0> MyParticleContainer;
-    using PType = typename amrex::ParticleContainer<4, 0>::SuperParticleType;
+    using PType = typename MyParticleContainer::SuperParticleType;
     MyParticleContainer myPC(geom, dmap, ba, rr);
     myPC.SetVerbose(false);
 

--- a/Tests/Particles/ParticleReduce/main.cpp
+++ b/Tests/Particles/ParticleReduce/main.cpp
@@ -184,50 +184,52 @@ void testReduce ()
 
     pc.InitParticles(nppc);
 
-    using PType = typename TestParticleContainer::SuperParticleType;
+    using SPType  = typename TestParticleContainer::SuperParticleType;
+    using PType   = typename TestParticleContainer::ParticleType;
+    using PTDType = typename TestParticleContainer::ParticleTileType::ConstParticleTileDataType;
 
     auto sm = amrex::ReduceSum(pc, [=] AMREX_GPU_HOST_DEVICE (const PType& p) -> Real { return p.rdata(1); });
     AMREX_ALWAYS_ASSERT(sm == pc.TotalNumberOfParticles());
 
-    auto sm2 = amrex::ReduceSum(pc, [=] AMREX_GPU_HOST_DEVICE (const PType& p) -> Real { return -p.rdata(NSR+1); });
+    auto sm2 = amrex::ReduceSum(pc, [=] AMREX_GPU_HOST_DEVICE (const SPType& p) -> Real { return -p.rdata(NSR+1); });
     AMREX_ALWAYS_ASSERT(sm2 == -pc.TotalNumberOfParticles());
 
-    auto mn = amrex::ReduceMin(pc, [=] AMREX_GPU_HOST_DEVICE (const PType& p) -> Real { return p.rdata(1); });
+    auto mn = amrex::ReduceMin(pc, [=] AMREX_GPU_HOST_DEVICE (const PTDType& ptd, const int i) -> Real { return ptd.m_aos[i].rdata(1);});
     AMREX_ALWAYS_ASSERT(mn == 1);
 
-    auto mn2 = amrex::ReduceMin(pc, [=] AMREX_GPU_HOST_DEVICE (const PType& p) -> Real { return p.rdata(NSR+1); });
+    auto mn2 = amrex::ReduceMin(pc, [=] AMREX_GPU_HOST_DEVICE (const SPType& p) -> Real { return p.rdata(NSR+1); });
     AMREX_ALWAYS_ASSERT(mn2 == 1);
 
-    auto mx = amrex::ReduceMax(pc, [=] AMREX_GPU_HOST_DEVICE (const PType& p) -> Real { return p.rdata(1); });
+    auto mx = amrex::ReduceMax(pc, [=] AMREX_GPU_HOST_DEVICE (const SPType& p) -> Real { return p.rdata(1); });
     AMREX_ALWAYS_ASSERT(mx == 1);
 
-    auto mx2 = amrex::ReduceMax(pc, [=] AMREX_GPU_HOST_DEVICE (const PType& p) -> int { return p.idata(NSI); });
+    auto mx2 = amrex::ReduceMax(pc, [=] AMREX_GPU_HOST_DEVICE (const SPType& p) -> int { return p.idata(NSI); });
     AMREX_ALWAYS_ASSERT(mx2 == 0);
 
     {
-        auto r = amrex::ReduceLogicalOr(pc, [=] AMREX_GPU_HOST_DEVICE (const PType& p) -> int { return p.id() == 1; });
+        auto r = amrex::ReduceLogicalOr(pc, [=] AMREX_GPU_HOST_DEVICE (const SPType& p) -> int { return p.id() == 1; });
         AMREX_ALWAYS_ASSERT(r == 1);
     }
 
     {
-        auto r = amrex::ReduceLogicalOr(pc, [=] AMREX_GPU_HOST_DEVICE (const PType& p) -> int { return p.id() == -1; });
+        auto r = amrex::ReduceLogicalOr(pc, [=] AMREX_GPU_HOST_DEVICE (const SPType& p) -> int { return p.id() == -1; });
         AMREX_ALWAYS_ASSERT(r == 0);
     }
 
     {
-        auto r = amrex::ReduceLogicalAnd(pc, [=] AMREX_GPU_HOST_DEVICE (const PType& p) -> int { return p.id() == p.id(); });
+        auto r = amrex::ReduceLogicalAnd(pc, [=] AMREX_GPU_HOST_DEVICE (const SPType& p) -> int { return p.id() == p.id(); });
         AMREX_ALWAYS_ASSERT(r == 1);
     }
 
     {
-        auto r = amrex::ReduceLogicalAnd(pc, [=] AMREX_GPU_HOST_DEVICE (const PType& p) -> int { return p.id() == 1; });
+        auto r = amrex::ReduceLogicalAnd(pc, [=] AMREX_GPU_HOST_DEVICE (const SPType& p) -> int { return p.id() == 1; });
         AMREX_ALWAYS_ASSERT(r == 0);
     }
 
     {
         amrex::ReduceOps<ReduceOpSum, ReduceOpMin, ReduceOpMax> reduce_ops;
         auto r = amrex::ParticleReduce<ReduceData<amrex::Real, amrex::Real,int>> (
-         pc, [=] AMREX_GPU_DEVICE (const PType& p) noexcept -> amrex::GpuTuple<amrex::Real,amrex::Real,int>
+         pc, [=] AMREX_GPU_DEVICE (const SPType& p) noexcept -> amrex::GpuTuple<amrex::Real,amrex::Real,int>
            {
                const amrex::Real a = p.rdata(1);
                const amrex::Real b = p.rdata(2);


### PR DESCRIPTION
This allows the user to access runtime attributes inside these functions.

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
