### PR TITLE
Only error if HDF5 is not parallel if MPI is enabled

### DIFF
--- a/Tools/CMake/AMReXThirdPartyLibraries.cmake
+++ b/Tools/CMake/AMReXThirdPartyLibraries.cmake
@@ -4,7 +4,7 @@
 if (AMReX_HDF5)
     set(HDF5_PREFER_PARALLEL TRUE)
     find_package(HDF5 1.10.4 REQUIRED)
-    if (NOT HDF5_IS_PARALLEL)
+    if (AMReX_MPI AND (NOT HDF5_IS_PARALLEL))
         message(FATAL_ERROR "\nHDF5 library does not support parallel I/O")
      endif ()
 


### PR DESCRIPTION
## Summary

This lets one use a non-parallel HDF5 in CMake if MPI is not enabled.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
