### PR TITLE
Allow `FillBoundary` to cast messages from double to single precision.

### DIFF
--- a/Src/Base/AMReX_BaseFab.H
+++ b/Src/Base/AMReX_BaseFab.H
@@ -553,18 +553,18 @@ public:
 
     //! Copy from raw memory to the dstbox of this Fab and return the number of bytes copied
 #if defined(AMREX_USE_GPU)
-    template <RunOn run_on>
+    template <RunOn run_on, typename BUF = T>
 #else
-    template <RunOn run_on=RunOn::Host>
+    template <RunOn run_on=RunOn::Host, typename BUF = T>
 #endif
     std::size_t copyFromMem (const Box& dstbox, int dstcomp,
                              int numcomp, const void* src) noexcept;
 
     //! Add from raw memory to the dstbox of this Fab and return the number of bytes copied
 #if defined(AMREX_USE_GPU)
-    template <RunOn run_on>
+    template <RunOn run_on, typename BUF = T>
 #else
-    template <RunOn run_on=RunOn::Host>
+    template <RunOn run_on=RunOn::Host, typename BUF = T>
 #endif
     std::size_t addFromMem (const Box& dstbox, int dstcomp,
                             int numcomp, const void* src) noexcept;
@@ -2167,7 +2167,7 @@ BaseFab<T>::copyToMem (const Box& srcbox,
 }
 
 template <class T>
-template <RunOn run_on>
+template <RunOn run_on, typename BUF>
 std::size_t
 BaseFab<T>::copyFromMem (const Box&  dstbox,
                          int         dstcomp,
@@ -2179,14 +2179,14 @@ BaseFab<T>::copyFromMem (const Box&  dstbox,
 
     if (dstbox.ok())
     {
-        Array4<T const> s(static_cast<T const*>(src), amrex::begin(dstbox),
-                          amrex::end(dstbox), numcomp);
+        Array4<BUF const> s(static_cast<BUF const*>(src), amrex::begin(dstbox),
+                            amrex::end(dstbox), numcomp);
         Array4<T> const& d = this->array();
         AMREX_HOST_DEVICE_PARALLEL_FOR_4D_FLAG(run_on, dstbox, numcomp, i, j, k, n,
         {
-            d(i,j,k,n+dstcomp) = s(i,j,k,n);
+            d(i,j,k,n+dstcomp) = static_cast<T>(s(i,j,k,n));
         });
-        return sizeof(T)*s.size();
+        return sizeof(BUF)*s.size();
     }
     else
     {
@@ -2195,7 +2195,7 @@ BaseFab<T>::copyFromMem (const Box&  dstbox,
 }
 
 template <class T>
-template <RunOn run_on>
+template <RunOn run_on, typename BUF>
 std::size_t
 BaseFab<T>::addFromMem (const Box&  dstbox,
                         int         dstcomp,
@@ -2207,14 +2207,14 @@ BaseFab<T>::addFromMem (const Box&  dstbox,
 
     if (dstbox.ok())
     {
-        Array4<T const> s(static_cast<T const*>(src), amrex::begin(dstbox),
-                          amrex::end(dstbox), numcomp);
+        Array4<BUF const> s(static_cast<BUF const*>(src), amrex::begin(dstbox),
+                            amrex::end(dstbox), numcomp);
         Array4<T> const& d = this->array();
         AMREX_HOST_DEVICE_PARALLEL_FOR_4D_FLAG(run_on, dstbox, numcomp, i, j, k, n,
         {
-            d(i,j,k,n+dstcomp) += s(i,j,k,n);
+            d(i,j,k,n+dstcomp) += static_cast<T>(s(i,j,k,n));
         });
-        return sizeof(T)*s.size();
+        return sizeof(BUF)*s.size();
     }
     else
     {

--- a/Src/Base/AMReX_FBI.H
+++ b/Src/Base/AMReX_FBI.H
@@ -17,41 +17,40 @@ namespace detail {
 
 #ifdef AMREX_USE_GPU
 
-template <class T>
+template <class T0, class T1>
 struct CellStore
 {
     AMREX_GPU_DEVICE AMREX_FORCE_INLINE void
-    operator() (T* d, T s) const noexcept
+    operator() (T0* d, T1 s) const noexcept
     {
-        *d = s;
+      *d = static_cast<T0>(s);
     }
 };
 
-template <class T>
+template <class T0, class T1>
 struct CellAdd
 {
     AMREX_GPU_DEVICE AMREX_FORCE_INLINE void
-    operator() (T* d, T s) const noexcept
+    operator() (T0* d, T1 s) const noexcept
     {
-        *d += s;
+        *d += static_cast<T0>(s);
     }
 };
 
-template <class T>
+template <class T0, class T1>
 struct CellAtomicAdd
 {
-    template<class U=T,
-             std::enable_if_t<amrex::HasAtomicAdd<U>::value,int> = 0>
+    template<class U0=T0, std::enable_if_t<amrex::HasAtomicAdd<U0>::value,int> = 0>
     AMREX_GPU_DEVICE AMREX_FORCE_INLINE void
-    operator() (U* d, U s) const noexcept
+    operator() (U0* d, T1 s) const noexcept
     {
-        Gpu::Atomic::AddNoRet(d,s);
+        Gpu::Atomic::AddNoRet(d, static_cast<U0>(s));
     }
 };
 
-template <class T, class F>
+template <class T0, class T1, class F>
 void
-fab_to_fab (Vector<Array4CopyTag<T> > const& copy_tags, int scomp, int dcomp, int ncomp,
+fab_to_fab (Vector<Array4CopyTag<T0, T1> > const& copy_tags, int scomp, int dcomp, int ncomp,
             F && f)
 {
     detail::ParallelFor_doit(copy_tags,
@@ -59,7 +58,7 @@ fab_to_fab (Vector<Array4CopyTag<T> > const& copy_tags, int scomp, int dcomp, in
 #ifdef AMREX_USE_DPCPP
             sycl::nd_item<1> const& /*item*/,
 #endif
-            int icell, int ncells, int i, int j, int k, Array4CopyTag<T> const tag) noexcept
+            int icell, int ncells, int i, int j, int k, Array4CopyTag<T0, T1> const tag) noexcept
         {
             if (icell < ncells) {
                 for (int n = 0; n < ncomp; ++n) {
@@ -70,12 +69,12 @@ fab_to_fab (Vector<Array4CopyTag<T> > const& copy_tags, int scomp, int dcomp, in
         });
 }
 
-template <class T, class F>
+template <class T0, class T1, class F>
 void
-fab_to_fab (Vector<Array4CopyTag<T> > const& copy_tags, int scomp, int dcomp, int ncomp,
-            F && f, Vector<Array4Tag<int> > const& masks)
+fab_to_fab (Vector<Array4CopyTag<T0, T1> > const& copy_tags, int scomp, int dcomp,
+            int ncomp, F && f, Vector<Array4Tag<int> > const& masks)
 {
-    typedef Array4MaskCopyTag<T> TagType;
+    typedef Array4MaskCopyTag<T0, T1> TagType;
     Vector<TagType> tags;
     const int N = copy_tags.size();
     tags.reserve(N);
@@ -167,36 +166,40 @@ fab_to_fab (Vector<Array4CopyTag<T> > const& copy_tags, int scomp, int dcomp, in
     });
 }
 
-template <typename T, std::enable_if_t<amrex::IsStoreAtomic<T>::value,int> = 0>
+template <typename T0, typename T1,
+          std::enable_if_t<amrex::IsStoreAtomic<T0>::value,int> = 0>
 void
-fab_to_fab_atomic_cpy (Vector<Array4CopyTag<T> > const& copy_tags, int scomp, int dcomp, int ncomp,
-                       Vector<Array4Tag<int> > const&)
+fab_to_fab_atomic_cpy (Vector<Array4CopyTag<T0, T1> > const& copy_tags, int scomp,
+                       int dcomp, int ncomp, Vector<Array4Tag<int> > const&)
 {
-    fab_to_fab<T>(copy_tags, scomp, dcomp, ncomp, CellStore<T>());
+    fab_to_fab<T0, T1>(copy_tags, scomp, dcomp, ncomp, CellStore<T0, T1>());
 }
 
-template <typename T, std::enable_if_t<!amrex::IsStoreAtomic<T>::value,int> = 0>
+template <typename T0, typename T1,
+          std::enable_if_t<!amrex::IsStoreAtomic<T0>::value,int> = 0>
 void
-fab_to_fab_atomic_cpy (Vector<Array4CopyTag<T> > const& copy_tags, int scomp, int dcomp, int ncomp,
-                       Vector<Array4Tag<int> > const& masks)
+fab_to_fab_atomic_cpy (Vector<Array4CopyTag<T0, T1> > const& copy_tags, int scomp,
+                       int dcomp, int ncomp, Vector<Array4Tag<int> > const& masks)
 {
-    fab_to_fab<T>(copy_tags, scomp, dcomp, ncomp, CellStore<T>(), masks);
+    fab_to_fab(copy_tags, scomp, dcomp, ncomp, CellStore<T0, T1>(), masks);
 }
 
-template <typename T, std::enable_if_t<amrex::HasAtomicAdd<T>::value,int> = 0>
+template <typename T0, typename T1,
+          std::enable_if_t<amrex::HasAtomicAdd<T0>::value,int> = 0>
 void
-fab_to_fab_atomic_add (Vector<Array4CopyTag<T> > const& copy_tags, int scomp, int dcomp, int ncomp,
-                       Vector<Array4Tag<int> > const&)
+fab_to_fab_atomic_add (Vector<Array4CopyTag<T0, T1> > const& copy_tags, int scomp,
+                       int dcomp, int ncomp, Vector<Array4Tag<int> > const&)
 {
-    fab_to_fab<T>(copy_tags, scomp, dcomp, ncomp, CellAtomicAdd<T>());
+    fab_to_fab(copy_tags, scomp, dcomp, ncomp, CellAtomicAdd<T0, T1>());
 }
 
-template <typename T, std::enable_if_t<!amrex::HasAtomicAdd<T>::value,int> = 0>
+template <typename T0, typename T1,
+          std::enable_if_t<!amrex::HasAtomicAdd<T0>::value,int> = 0>
 void
-fab_to_fab_atomic_add (Vector<Array4CopyTag<T> > const& copy_tags, int scomp, int dcomp, int ncomp,
-                       Vector<Array4Tag<int> > const& masks)
+fab_to_fab_atomic_add (Vector<Array4CopyTag<T0, T1> > const& copy_tags, int scomp,
+                       int dcomp, int ncomp, Vector<Array4Tag<int> > const& masks)
 {
-    fab_to_fab<T>(copy_tags, scomp, dcomp, ncomp, CellAdd<T>(), masks);
+    fab_to_fab(copy_tags, scomp, dcomp, ncomp, CellAdd<T0, T1>(), masks);
 }
 
 #endif /* AMREX_USE_GPU */
@@ -316,10 +319,11 @@ FabArray<FAB>::FB_local_copy_gpu (const FB& TheFB, int scomp, int ncomp)
     }
 
     if (is_thread_safe) {
-        detail::fab_to_fab<value_type>(loc_copy_tags, scomp, scomp, ncomp,
-                                       detail::CellStore<value_type>());
+        detail::fab_to_fab<value_type, value_type>(loc_copy_tags, scomp, scomp,
+            ncomp, detail::CellStore<value_type, value_type>());
     } else {
-        detail::fab_to_fab_atomic_cpy<value_type>(loc_copy_tags, scomp, scomp, ncomp, masks);
+        detail::fab_to_fab_atomic_cpy<value_type, value_type>(
+            loc_copy_tags, scomp, scomp, ncomp, masks);
     }
 }
 
@@ -721,6 +725,7 @@ FabArray<FAB>::FB_unpack_recv_buffer_cuda_graph (const FB& TheFB, int dcomp, int
 #endif /* CUDA >= 10 */
 
 template <class FAB>
+template <typename BUF>
 void
 FabArray<FAB>::pack_send_buffer_gpu (FabArray<FAB> const& src, int scomp, int ncomp,
                                      Vector<char*> const& send_data,
@@ -744,7 +749,7 @@ FabArray<FAB>::pack_send_buffer_gpu (FabArray<FAB> const& src, int scomp, int nc
     }
 #endif
 
-    typedef Array4CopyTag<value_type> TagType;
+    typedef Array4CopyTag<BUF, value_type> TagType;
     Vector<TagType> snd_copy_tags;
     for (int j = 0; j < N_snds; ++j)
     {
@@ -756,19 +761,19 @@ FabArray<FAB>::pack_send_buffer_gpu (FabArray<FAB> const& src, int scomp, int nc
             for (auto const& tag : cctc)
             {
                 snd_copy_tags.emplace_back(TagType{
-                    amrex::makeArray4((value_type*)(dptr), tag.sbox, ncomp),
+                    amrex::makeArray4((BUF*)(dptr), tag.sbox, ncomp),
                     src.array(tag.srcIndex),
                     tag.sbox,
                     Dim3{0,0,0}
                 });
-                dptr += (tag.sbox.numPts() * ncomp * sizeof(value_type));
+                dptr += (tag.sbox.numPts() * ncomp * sizeof(BUF));
             }
             BL_ASSERT(dptr <= pbuffer + offset + send_size[j]);
         }
     }
 
-    detail::fab_to_fab<value_type>(snd_copy_tags, scomp, 0, ncomp,
-                                   detail::CellStore<value_type>());
+    detail::fab_to_fab<BUF, value_type>(snd_copy_tags, scomp, 0, ncomp,
+                                        detail::CellStore<BUF, value_type>());
 
     // There is Gpu::synchronize in fab_to_fab.
 
@@ -780,6 +785,7 @@ FabArray<FAB>::pack_send_buffer_gpu (FabArray<FAB> const& src, int scomp, int nc
 }
 
 template <class FAB>
+template <typename BUF>
 void
 FabArray<FAB>::unpack_recv_buffer_gpu (FabArray<FAB>& dst, int dcomp, int ncomp,
                                        Vector<char*> const& recv_data,
@@ -806,7 +812,7 @@ FabArray<FAB>::unpack_recv_buffer_gpu (FabArray<FAB>& dst, int dcomp, int ncomp,
     }
 #endif
 
-    typedef Array4CopyTag<value_type> TagType;
+    typedef Array4CopyTag<value_type, BUF> TagType;
     Vector<TagType> recv_copy_tags;
     recv_copy_tags.reserve(N_rcvs);
 
@@ -833,11 +839,11 @@ FabArray<FAB>::unpack_recv_buffer_gpu (FabArray<FAB>& dst, int dcomp, int ncomp,
                 const int li = dst.localindex(tag.dstIndex);
                 recv_copy_tags.emplace_back(TagType{
                     dst.atLocalIdx(li).array(),
-                    amrex::makeArray4((value_type const*)(dptr), tag.dbox, ncomp),
+                    amrex::makeArray4((BUF const*)(dptr), tag.dbox, ncomp),
                     tag.dbox,
                     Dim3{0,0,0}
                 });
-                dptr += tag.dbox.numPts() * ncomp * sizeof(value_type);
+                dptr += tag.dbox.numPts() * ncomp * sizeof(BUF);
 
                 if (maskfabs.size() > 0) {
                     if (!maskfabs[li].isAllocated()) {
@@ -861,19 +867,21 @@ FabArray<FAB>::unpack_recv_buffer_gpu (FabArray<FAB>& dst, int dcomp, int ncomp,
     if (op == FabArrayBase::COPY)
     {
         if (is_thread_safe) {
-            detail::fab_to_fab<value_type>(recv_copy_tags, 0, dcomp, ncomp,
-                                           detail::CellStore<value_type>());
+            detail::fab_to_fab<value_type, BUF>(
+                recv_copy_tags, 0, dcomp, ncomp, detail::CellStore<value_type, BUF>());
         } else {
-            detail::fab_to_fab_atomic_cpy<value_type>(recv_copy_tags, 0, dcomp, ncomp, masks);
+            detail::fab_to_fab_atomic_cpy<value_type, BUF>(
+                recv_copy_tags, 0, dcomp, ncomp, masks);
         }
     }
     else
     {
         if (is_thread_safe) {
-            detail::fab_to_fab<value_type>(recv_copy_tags, 0, dcomp, ncomp,
-                                           detail::CellAdd<value_type>());
+            detail::fab_to_fab<value_type, BUF>(
+                recv_copy_tags, 0, dcomp, ncomp, detail::CellAdd<value_type, BUF>());
         } else {
-            detail::fab_to_fab_atomic_add<value_type>(recv_copy_tags, 0, dcomp, ncomp, masks);
+            detail::fab_to_fab_atomic_add<value_type, BUF>(
+                recv_copy_tags, 0, dcomp, ncomp, masks);
         }
     }
 
@@ -887,6 +895,7 @@ FabArray<FAB>::unpack_recv_buffer_gpu (FabArray<FAB>& dst, int dcomp, int ncomp,
 #endif /* AMREX_USE_GPU */
 
 template <class FAB>
+template <typename BUF>
 void
 FabArray<FAB>::pack_send_buffer_cpu (FabArray<FAB> const& src, int scomp, int ncomp,
                                      Vector<char*> const& send_data,
@@ -911,13 +920,13 @@ FabArray<FAB>::pack_send_buffer_cpu (FabArray<FAB> const& src, int scomp, int nc
             {
                 const Box& bx = tag.sbox;
                 auto const sfab = src.array(tag.srcIndex);
-                auto pfab = amrex::makeArray4((value_type*)(dptr),bx,ncomp);
+                auto pfab = amrex::makeArray4((BUF*)(dptr),bx,ncomp);
                 amrex::LoopConcurrentOnCpu( bx, ncomp,
                 [=] (int ii, int jj, int kk, int n) noexcept
                 {
                     pfab(ii,jj,kk,n) = sfab(ii,jj,kk,n+scomp);
                 });
-                dptr += (bx.numPts() * ncomp * sizeof(value_type));
+                dptr += (bx.numPts() * ncomp * sizeof(BUF));
             }
             BL_ASSERT(dptr <= send_data[j] + send_size[j]);
         }
@@ -925,6 +934,7 @@ FabArray<FAB>::pack_send_buffer_cpu (FabArray<FAB> const& src, int scomp, int nc
 }
 
 template <class FAB>
+template <typename BUF>
 void
 FabArray<FAB>::unpack_recv_buffer_cpu (FabArray<FAB>& dst, int dcomp, int ncomp,
                                        Vector<char*> const& recv_data,
@@ -954,13 +964,13 @@ FabArray<FAB>::unpack_recv_buffer_cpu (FabArray<FAB>& dst, int dcomp, int ncomp,
                     FAB& dfab = dst[tag.dstIndex];
                     if (op == FabArrayBase::COPY)
                     {
-                        dfab.template copyFromMem<RunOn::Host>(bx, dcomp, ncomp, dptr);
+                        dfab.template copyFromMem<RunOn::Host, BUF>(bx, dcomp, ncomp, dptr);
                     }
                     else
                     {
-                        dfab.template addFromMem<RunOn::Host>(tag.dbox, dcomp, ncomp, dptr);
+                        dfab.template addFromMem<RunOn::Host, BUF>(tag.dbox, dcomp, ncomp, dptr);
                     }
-                    dptr += bx.numPts() * ncomp * sizeof(value_type);
+                    dptr += bx.numPts() * ncomp * sizeof(BUF);
                 }
                 BL_ASSERT(dptr <= recv_data[k] + recv_size[k]);
             }
@@ -979,7 +989,7 @@ FabArray<FAB>::unpack_recv_buffer_cpu (FabArray<FAB>& dst, int dcomp, int ncomp,
                 for (auto const& tag : cctc)
                 {
                     recv_copy_tags[tag.dstIndex].push_back({dptr,tag.dbox});
-                    dptr += tag.dbox.numPts() * ncomp * sizeof(value_type);
+                    dptr += tag.dbox.numPts() * ncomp * sizeof(BUF);
                 }
                 BL_ASSERT(dptr <= recv_data[k] + recv_size[k]);
             }
@@ -994,7 +1004,7 @@ FabArray<FAB>::unpack_recv_buffer_cpu (FabArray<FAB>& dst, int dcomp, int ncomp,
             auto dfab = dst.array(mfi);
             for (auto const & tag : tags)
             {
-                auto pfab = amrex::makeArray4((value_type*)(tag.p), tag.dbox, ncomp);
+                auto pfab = amrex::makeArray4((BUF*)(tag.p), tag.dbox, ncomp);
                 if (op == FabArrayBase::COPY)
                 {
                     amrex::LoopConcurrentOnCpu(tag.dbox, ncomp,

--- a/Src/Base/AMReX_FabArray.H
+++ b/Src/Base/AMReX_FabArray.H
@@ -887,23 +887,45 @@ public:
     * FillBoundary expects that its cell-centered version of its BoxArray
     * is non-overlapping.
     */
+    template <typename BUF=value_type>
     void FillBoundary (bool cross = false);
 
+    template <typename BUF=value_type>
     void FillBoundary (const Periodicity& period, bool cross = false);
+
+    template <typename BUF=value_type>
     void FillBoundary (const IntVect& nghost, const Periodicity& period, bool cross = false);
 
     //! Same as FillBoundary(), but only copies ncomp components starting at scomp.
+    template <typename BUF=value_type>
     void FillBoundary (int scomp, int ncomp, bool cross = false);
+
+    template <typename BUF=value_type>
     void FillBoundary (int scomp, int ncomp, const Periodicity& period, bool cross = false);
+
+    template <typename BUF=value_type>
     void FillBoundary (int scomp, int ncomp, const IntVect& nghost, const Periodicity& period, bool cross = false);
 
+    template <typename BUF=value_type>
     void FillBoundary_nowait (bool cross = false);
+
+    template <typename BUF=value_type>
     void FillBoundary_nowait (const Periodicity& period, bool cross = false);
+
+    template <typename BUF=value_type>
     void FillBoundary_nowait (const IntVect& nghost, const Periodicity& period, bool cross = false);
+
+    template <typename BUF=value_type>
     void FillBoundary_nowait (int scomp, int ncomp, bool cross = false);
+
+    template <typename BUF=value_type>
     void FillBoundary_nowait (int scomp, int ncomp, const Periodicity& period, bool cross = false);
+
+    template <typename BUF=value_type>
     void FillBoundary_nowait (int scomp, int ncomp, const IntVect& nghost, const Periodicity& period, bool cross = false);
-    template <class F=FAB, typename std::enable_if<IsBaseFab<F>::value,int>::type = 0>
+
+    template <typename BUF=value_type,
+              class F=FAB, typename std::enable_if<IsBaseFab<F>::value,int>::type = 0>
     void FillBoundary_finish ();
 
     void FillBoundary_test ();
@@ -1019,7 +1041,8 @@ public:
 
     // The following are private functions.  But we have to make them public for cuda.
 
-    template <class F=FAB, typename std::enable_if<IsBaseFab<F>::value,int>::type = 0>
+    template <typename BUF=value_type,
+              class F=FAB, typename std::enable_if<IsBaseFab<F>::value,int>::type = 0>
     void FBEP_nowait (int scomp, int ncomp, const IntVect& nghost,
                       const Periodicity& period, bool cross,
                       bool enforce_periodicity_only = false,
@@ -1070,11 +1093,13 @@ public:
 
 #endif
 
+    template <typename BUF = value_type>
     static void pack_send_buffer_gpu (FabArray<FAB> const& src, int scomp, int ncomp,
                                       Vector<char*> const& send_data,
                                       Vector<std::size_t> const& send_size,
                                       Vector<const CopyComTagsContainer*> const& send_cctc);
 
+    template <typename BUF = value_type>
     static void unpack_recv_buffer_gpu (FabArray<FAB>& dst, int dcomp, int ncomp,
                                         Vector<char*> const& recv_data,
                                         Vector<std::size_t> const& recv_size,
@@ -1083,11 +1108,13 @@ public:
 
 #endif
 
+    template <typename BUF = value_type>
     static void pack_send_buffer_cpu (FabArray<FAB> const& src, int scomp, int ncomp,
                                       Vector<char*> const& send_data,
                                       Vector<std::size_t> const& send_size,
                                       Vector<const CopyComTagsContainer*> const& send_cctc);
 
+    template <typename BUF = value_type>
     static void unpack_recv_buffer_cpu (FabArray<FAB>& dst, int dcomp, int ncomp,
                                         Vector<char*> const& recv_data,
                                         Vector<std::size_t> const& recv_size,
@@ -1186,6 +1213,7 @@ public:
 #ifdef BL_USE_MPI
 
     //! Prepost nonblocking receives
+    template <typename BUF=value_type>
     void PostRcvs (const MapOfCopyComTagContainers&       RcvTags,
                    char*&                                 the_recv_data,
                    Vector<char*>&                         recv_data,
@@ -1195,7 +1223,7 @@ public:
                    int                                    ncomp,
                    int                                    SeqNum) const;
 
-
+    template <typename BUF=value_type>
     AMREX_NODISCARD TheFaArenaPointer PostRcvs (const MapOfCopyComTagContainers&       RcvTags,
                    Vector<char*>&                         recv_data,
                    Vector<std::size_t>&                   recv_size,
@@ -1204,6 +1232,7 @@ public:
                    int                                    ncomp,
                    int                                    SeqNum) const;
 
+    template <typename BUF=value_type>
     void PrepareSendBuffers (const MapOfCopyComTagContainers&     SndTags,
                              char*&                               the_send_data,
                              Vector<char*>&                       send_data,
@@ -1213,6 +1242,7 @@ public:
                              Vector<const CopyComTagsContainer*>& send_cctc,
                              int                                  ncomp) const;
 
+    template <typename BUF=value_type>
     AMREX_NODISCARD TheFaArenaPointer PrepareSendBuffers (const MapOfCopyComTagContainers&     SndTags,
                              Vector<char*>&                       send_data,
                              Vector<std::size_t>&                 send_size,
@@ -2554,28 +2584,31 @@ FabArray<FAB>::shift (const IntVect& v)
 }
 
 template <class FAB>
+template <typename BUF>
 void
 FabArray<FAB>::FillBoundary (bool cross)
 {
     BL_PROFILE("FabArray::FillBoundary()");
     if ( n_grow.max() > 0 ) {
-        FillBoundary_nowait(0, nComp(), n_grow, Periodicity::NonPeriodic(), cross);
-        FillBoundary_finish();
+        FillBoundary_nowait<BUF>(0, nComp(), n_grow, Periodicity::NonPeriodic(), cross);
+        FillBoundary_finish<BUF>();
     }
 }
 
 template <class FAB>
+template <typename BUF>
 void
 FabArray<FAB>::FillBoundary (const Periodicity& period, bool cross)
 {
     BL_PROFILE("FabArray::FillBoundary()");
     if ( n_grow.max() > 0 ) {
-        FillBoundary_nowait(0, nComp(), n_grow, period, cross);
-        FillBoundary_finish();
+        FillBoundary_nowait<BUF>(0, nComp(), n_grow, period, cross);
+        FillBoundary_finish<BUF>();
     }
 }
 
 template <class FAB>
+template <typename BUF>
 void
 FabArray<FAB>::FillBoundary (const IntVect& nghost, const Periodicity& period, bool cross)
 {
@@ -2583,34 +2616,37 @@ FabArray<FAB>::FillBoundary (const IntVect& nghost, const Periodicity& period, b
     AMREX_ALWAYS_ASSERT_WITH_MESSAGE(nghost.allLE(nGrowVect()),
                                      "FillBoundary: asked to fill more ghost cells than we have");
     if ( nghost.max() > 0 ) {
-        FillBoundary_nowait(0, nComp(), nghost, period, cross);
-        FillBoundary_finish();
+        FillBoundary_nowait<BUF>(0, nComp(), nghost, period, cross);
+        FillBoundary_finish<BUF>();
     }
 }
 
 template <class FAB>
+template <typename BUF>
 void
 FabArray<FAB>::FillBoundary (int scomp, int ncomp, bool cross)
 {
     BL_PROFILE("FabArray::FillBoundary()");
     if ( n_grow.max() > 0 ) {
-        FillBoundary_nowait(scomp, ncomp, n_grow, Periodicity::NonPeriodic(), cross);
-        FillBoundary_finish();
+        FillBoundary_nowait<BUF>(scomp, ncomp, n_grow, Periodicity::NonPeriodic(), cross);
+        FillBoundary_finish<BUF>();
     }
 }
 
 template <class FAB>
+template <typename BUF>
 void
 FabArray<FAB>::FillBoundary (int scomp, int ncomp, const Periodicity& period, bool cross)
 {
     BL_PROFILE("FabArray::FillBoundary()");
     if ( n_grow.max() > 0 ) {
-        FillBoundary_nowait(scomp, ncomp, n_grow, period, cross);
-        FillBoundary_finish();
+        FillBoundary_nowait<BUF>(scomp, ncomp, n_grow, period, cross);
+        FillBoundary_finish<BUF>();
     }
 }
 
 template <class FAB>
+template <typename BUF>
 void
 FabArray<FAB>::FillBoundary (int scomp, int ncomp, const IntVect& nghost,
                              const Periodicity& period, bool cross)
@@ -2619,37 +2655,41 @@ FabArray<FAB>::FillBoundary (int scomp, int ncomp, const IntVect& nghost,
     AMREX_ALWAYS_ASSERT_WITH_MESSAGE(nghost.allLE(nGrowVect()),
                                      "FillBoundary: asked to fill more ghost cells than we have");
     if ( nghost.max() > 0 ) {
-        FillBoundary_nowait(scomp, ncomp, nghost, period, cross);
-        FillBoundary_finish();
+        FillBoundary_nowait<BUF>(scomp, ncomp, nghost, period, cross);
+        FillBoundary_finish<BUF>();
     }
 }
 
 template <class FAB>
+template <typename BUF>
 void
 FabArray<FAB>::FillBoundary_nowait (bool cross)
 {
-    FillBoundary_nowait(0, nComp(), nGrowVect(), Periodicity::NonPeriodic(), cross);
+    FillBoundary_nowait<BUF>(0, nComp(), nGrowVect(), Periodicity::NonPeriodic(), cross);
 }
 
 template <class FAB>
+template <typename BUF>
 void
 FabArray<FAB>::FillBoundary_nowait (const Periodicity& period, bool cross)
 {
-    FillBoundary_nowait(0, nComp(), nGrowVect(), period, cross);
+    FillBoundary_nowait<BUF>(0, nComp(), nGrowVect(), period, cross);
 }
 
 template <class FAB>
+template <typename BUF>
 void
 FabArray<FAB>::FillBoundary_nowait (const IntVect& nghost, const Periodicity& period, bool cross)
 {
-    FillBoundary_nowait(0, nComp(), nghost, period, cross);
+    FillBoundary_nowait<BUF>(0, nComp(), nghost, period, cross);
 }
 
 template <class FAB>
+template <typename BUF>
 void
 FabArray<FAB>::FillBoundary_nowait (int scomp, int ncomp, bool cross)
 {
-    FillBoundary_nowait(scomp, ncomp, nGrowVect(), Periodicity::NonPeriodic(), cross);
+    FillBoundary_nowait<BUF>(scomp, ncomp, nGrowVect(), Periodicity::NonPeriodic(), cross);
 }
 
 template <class FAB>
@@ -2864,20 +2904,22 @@ FabArray<FAB>::EnforcePeriodicity (int scomp, int ncomp, const IntVect& nghost,
 }
 
 template <class FAB>
+template <typename BUF>
 void
 FabArray<FAB>::FillBoundary_nowait (int scomp, int ncomp, const Periodicity& period, bool cross)
 {
     BL_PROFILE("FillBoundary_nowait()");
-    FBEP_nowait(scomp, ncomp, nGrowVect(), period, cross);
+    FBEP_nowait<BUF>(scomp, ncomp, nGrowVect(), period, cross);
 }
 
 template <class FAB>
+template <typename BUF>
 void
 FabArray<FAB>::FillBoundary_nowait (int scomp, int ncomp, const IntVect& nghost,
                                     const Periodicity& period, bool cross)
 {
     BL_PROFILE("FillBoundary_nowait()");
-    FBEP_nowait(scomp, ncomp, nghost, period, cross);
+    FBEP_nowait<BUF>(scomp, ncomp, nghost, period, cross);
 }
 
 template <class FAB>

--- a/Src/Base/AMReX_FabArrayCommI.H
+++ b/Src/Base/AMReX_FabArrayCommI.H
@@ -3,7 +3,7 @@
 #include <AMReX_PCI.H>
 
 template <class FAB>
-template <class F, typename std::enable_if<IsBaseFab<F>::value,int>::type Z>
+template <typename BUF, class F, typename std::enable_if<IsBaseFab<F>::value,int>::type Z>
 void
 FabArray<FAB>::FBEP_nowait (int scomp, int ncomp, const IntVect& nghost,
                             const Periodicity& period, bool cross,
@@ -83,9 +83,9 @@ FabArray<FAB>::FBEP_nowait (int scomp, int ncomp, const IntVect& nghost,
     //
 
     if (N_rcvs > 0) {
-        PostRcvs(*TheFB.m_RcvTags, fbd->the_recv_data,
-                 fbd->recv_data, fbd->recv_size, fbd->recv_from, fbd->recv_reqs,
-                 ncomp, SeqNum);
+        PostRcvs<BUF>(*TheFB.m_RcvTags, fbd->the_recv_data,
+                      fbd->recv_data, fbd->recv_size, fbd->recv_from, fbd->recv_reqs,
+                      ncomp, SeqNum);
         fbd->recv_stat.resize(N_rcvs);
     }
 
@@ -101,7 +101,7 @@ FabArray<FAB>::FBEP_nowait (int scomp, int ncomp, const IntVect& nghost,
 
     if (N_snds > 0)
     {
-        PrepareSendBuffers(*TheFB.m_SndTags, the_send_data, send_data, send_size, send_rank,
+        PrepareSendBuffers<BUF>(*TheFB.m_SndTags, the_send_data, send_data, send_size, send_rank,
                            send_reqs, send_cctc, ncomp);
 
 #ifdef AMREX_USE_GPU
@@ -114,13 +114,13 @@ FabArray<FAB>::FBEP_nowait (int scomp, int ncomp, const IntVect& nghost,
             else
 #endif
             {
-                pack_send_buffer_gpu(*this, scomp, ncomp, send_data, send_size, send_cctc);
+                pack_send_buffer_gpu<BUF>(*this, scomp, ncomp, send_data, send_size, send_cctc);
             }
         }
         else
 #endif
         {
-            pack_send_buffer_cpu(*this, scomp, ncomp, send_data, send_size, send_cctc);
+            pack_send_buffer_cpu<BUF>(*this, scomp, ncomp, send_data, send_size, send_cctc);
         }
 
         AMREX_ASSERT(send_reqs.size() == N_snds);
@@ -160,7 +160,7 @@ FabArray<FAB>::FBEP_nowait (int scomp, int ncomp, const IntVect& nghost,
 }
 
 template <class FAB>
-template <class F, typename std::enable_if<IsBaseFab<F>::value,int>::type Z>
+template <typename BUF, class F, typename std::enable_if<IsBaseFab<F>::value,int>::type Z>
 void
 FabArray<FAB>::FillBoundary_finish ()
 {
@@ -211,15 +211,15 @@ FabArray<FAB>::FillBoundary_finish ()
             else
 #endif
             {
-                unpack_recv_buffer_gpu(*this, fbd->scomp, fbd->ncomp, fbd->recv_data, fbd->recv_size,
-                                       recv_cctc, FabArrayBase::COPY, is_thread_safe);
+                unpack_recv_buffer_gpu<BUF>(*this, fbd->scomp, fbd->ncomp, fbd->recv_data, fbd->recv_size,
+                                            recv_cctc, FabArrayBase::COPY, is_thread_safe);
             }
         }
         else
 #endif
         {
-            unpack_recv_buffer_cpu(*this, fbd->scomp, fbd->ncomp, fbd->recv_data, fbd->recv_size,
-                                   recv_cctc, FabArrayBase::COPY, is_thread_safe);
+            unpack_recv_buffer_cpu<BUF>(*this, fbd->scomp, fbd->ncomp, fbd->recv_data, fbd->recv_size,
+                                        recv_cctc, FabArrayBase::COPY, is_thread_safe);
         }
 
         if (fbd->the_recv_data)
@@ -608,6 +608,7 @@ FabArray<FAB>::copyTo (FAB& dest, int scomp, int dcomp, int ncomp, int nghost) c
 
 #ifdef BL_USE_MPI
 template <class FAB>
+template <typename BUF>
 AMREX_NODISCARD TheFaArenaPointer
 FabArray<FAB>::PrepareSendBuffers (const MapOfCopyComTagContainers&     SndTags,
                                    Vector<char*>&                       send_data,
@@ -618,11 +619,12 @@ FabArray<FAB>::PrepareSendBuffers (const MapOfCopyComTagContainers&     SndTags,
                                    int                                  ncomp) const
 {
     char* pointer = nullptr;
-    PrepareSendBuffers(SndTags, pointer, send_data, send_size, send_rank, send_reqs, send_cctc, ncomp);
+    PrepareSendBuffers<BUF>(SndTags, pointer, send_data, send_size, send_rank, send_reqs, send_cctc, ncomp);
     return TheFaArenaPointer(pointer);
 }
 
 template <class FAB>
+template <typename BUF>
 void
 FabArray<FAB>::PrepareSendBuffers (const MapOfCopyComTagContainers&     SndTags,
                                    char*&                               the_send_data,
@@ -655,15 +657,14 @@ FabArray<FAB>::PrepareSendBuffers (const MapOfCopyComTagContainers&     SndTags,
         std::size_t nbytes = 0;
         for (auto const& cct : kv.second)
         {
-            nbytes += (*this)[cct.srcIndex].nBytes(cct.sbox,ncomp);
+            nbytes += cct.sbox.numPts() * ncomp * sizeof(BUF);
         }
 
         std::size_t acd = ParallelDescriptor::alignof_comm_data(nbytes);
         nbytes = amrex::aligned_size(acd, nbytes); // so that bytes are aligned
 
         // Also need to align the offset properly
-        total_volume = amrex::aligned_size(std::max(alignof(typename FAB::value_type),
-                                                    acd),
+        total_volume = amrex::aligned_size(std::max(alignof(BUF), acd),
                                            total_volume);
 
         offset.push_back(total_volume);
@@ -709,6 +710,7 @@ FabArray<FAB>::PostSnds (Vector<char*> const&       send_data,
 }
 
 template <class FAB>
+template <typename BUF>
 TheFaArenaPointer FabArray<FAB>::PostRcvs (const MapOfCopyComTagContainers&       RcvTags,
                    Vector<char*>&                         recv_data,
                    Vector<std::size_t>&                   recv_size,
@@ -723,6 +725,7 @@ TheFaArenaPointer FabArray<FAB>::PostRcvs (const MapOfCopyComTagContainers&     
 }
 
 template <class FAB>
+template <typename BUF>
 void
 FabArray<FAB>::PostRcvs (const MapOfCopyComTagContainers&  RcvTags,
                          char*&                            the_recv_data,
@@ -745,14 +748,14 @@ FabArray<FAB>::PostRcvs (const MapOfCopyComTagContainers&  RcvTags,
         std::size_t nbytes = 0;
         for (auto const& cct : kv.second)
         {
-            nbytes += (*this)[cct.dstIndex].nBytes(cct.dbox,ncomp);
+            nbytes += cct.dbox.numPts() * ncomp * sizeof(BUF);
         }
 
         std::size_t acd = ParallelDescriptor::alignof_comm_data(nbytes);
         nbytes = amrex::aligned_size(acd, nbytes);  // so that nbytes are aligned
 
         // Also need to align the offset properly
-        TotalRcvsVolume = amrex::aligned_size(std::max(alignof(typename FAB::value_type),acd),
+        TotalRcvsVolume = amrex::aligned_size(std::max(alignof(BUF),acd),
                                               TotalRcvsVolume);
 
         offset.push_back(TotalRcvsVolume);

--- a/Src/Base/AMReX_PCI.H
+++ b/Src/Base/AMReX_PCI.H
@@ -139,19 +139,21 @@ FabArray<FAB>::PC_local_gpu (const CPC& thecpc, FabArray<FAB> const& src,
     if (op == FabArrayBase::COPY)
     {
         if (is_thread_safe) {
-            detail::fab_to_fab<value_type>(loc_copy_tags, scomp, dcomp, ncomp,
-                                           detail::CellStore<value_type>());
+            detail::fab_to_fab<value_type, value_type>(loc_copy_tags, scomp,
+                dcomp, ncomp, detail::CellStore<value_type, value_type>());
         } else {
-            detail::fab_to_fab_atomic_cpy<value_type>(loc_copy_tags, scomp, dcomp, ncomp, masks);
+            detail::fab_to_fab_atomic_cpy<value_type, value_type>(
+                loc_copy_tags, scomp, dcomp, ncomp, masks);
         }
     }
     else
     {
         if (is_thread_safe) {
-            detail::fab_to_fab<value_type>(loc_copy_tags, scomp, dcomp, ncomp,
-                                           detail::CellAdd<value_type>());
+            detail::fab_to_fab<value_type, value_type>(loc_copy_tags, scomp,
+                dcomp, ncomp, detail::CellAdd<value_type, value_type>());
         } else {
-            detail::fab_to_fab_atomic_add<value_type>(loc_copy_tags, scomp, dcomp, ncomp, masks);
+            detail::fab_to_fab_atomic_add<value_type, value_type>(
+                loc_copy_tags, scomp, dcomp, ncomp, masks);
         }
     }
 }

--- a/Src/Base/AMReX_TagParallelFor.H
+++ b/Src/Base/AMReX_TagParallelFor.H
@@ -21,10 +21,10 @@ struct Array4PairTag {
     Box const& box () const noexcept { return dbox; }
 };
 
-template <class T>
+template <class T0, class T1=T0>
 struct Array4CopyTag {
-    Array4<T      > dfab;
-    Array4<T const> sfab;
+    Array4<T0      > dfab;
+    Array4<T1 const> sfab;
     Box dbox;
     Dim3 offset; // sbox.smallEnd() - dbox.smallEnd()
 
@@ -32,11 +32,11 @@ struct Array4CopyTag {
     Box const& box () const noexcept { return dbox; }
 };
 
-template <class T>
+template <class T0, class T1=T0>
 struct Array4MaskCopyTag {
-    Array4<T      > dfab;
-    Array4<T const> sfab;
-    Array4<int    > mask;
+    Array4<T0      > dfab;
+    Array4<T1 const> sfab;
+    Array4<int     > mask;
     Box dbox;
     Dim3 offset; // sbox.smallEnd() - dbox.smallEnd()
 

--- a/Src/EB/AMReX_MultiCutFab.H
+++ b/Src/EB/AMReX_MultiCutFab.H
@@ -35,21 +35,21 @@ public:
     CutFab& operator= (const CutFab&) = delete;
     CutFab& operator= (CutFab&&) = delete;
 
-    template <RunOn run_on>
+    template <RunOn run_on, typename BUF = CutFab::value_type>
     std::size_t copyFromMem (const void* src) {
-        return copyFromMem<run_on>(box(), 0, nComp(), src);
+        return copyFromMem<run_on, BUF>(box(), 0, nComp(), src);
     }
 
-    template <RunOn run_on>
+    template <RunOn run_on, typename BUF = CutFab::value_type>
     std::size_t copyFromMem (const Box&  dstbox,
                              int         dstcomp,
                              int         numcomp,
                              const void* src)
     {
         if (dptr != nullptr) {
-            return FArrayBox::copyFromMem<run_on>(dstbox, dstcomp, numcomp, src);
+            return FArrayBox::copyFromMem<run_on, BUF>(dstbox, dstcomp, numcomp, src);
         } else {
-            return sizeof(CutFab::value_type)*static_cast<std::size_t>(dstbox.numPts()*numcomp);
+            return sizeof(BUF)*static_cast<std::size_t>(dstbox.numPts()*numcomp);
         }
     }
 


### PR DESCRIPTION
## Summary
For the GPU implementation, this PR allows `FillBoundary` to pack double-precision data into a single-precision buffer and unpack single-precision messages to double-precision FabArray, e.x. `mf.template FillBoundary<float>(...)`. 

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
