### PR TITLE
Replace double with Real in Advection and Parser tests.

### DIFF
--- a/Tests/MultiBlock/Advection/main.cpp
+++ b/Tests/MultiBlock/Advection/main.cpp
@@ -109,13 +109,13 @@ class AdvectionAmrCore : public AmrCore {
     Direction velocity{};
 
   private:
-    void ErrorEst(int /*level*/, ::amrex::TagBoxArray& /*tags*/, double /*time_point*/,
+    void ErrorEst(int /*level*/, ::amrex::TagBoxArray& /*tags*/, Real /*time_point*/,
                   int /* ngrow */) override {
         throw std::runtime_error("For simplicity, this example supports only one level.");
     }
 
     void
-    MakeNewLevelFromScratch(int level, double, const ::amrex::BoxArray& box_array,
+    MakeNewLevelFromScratch(int level, Real, const ::amrex::BoxArray& box_array,
                             const ::amrex::DistributionMapping& distribution_mapping) override {
         if (level > 0) {
             throw std::runtime_error("For simplicity, this example supports only one level.");
@@ -125,12 +125,12 @@ class AdvectionAmrCore : public AmrCore {
         mass_next.define(box_array, distribution_mapping, three_components, ngrow);
     }
 
-    void MakeNewLevelFromCoarse(int /*level*/, double /*time_point*/, const ::amrex::BoxArray&,
+    void MakeNewLevelFromCoarse(int /*level*/, Real /*time_point*/, const ::amrex::BoxArray&,
                                 const ::amrex::DistributionMapping&) override {
         throw std::runtime_error("For simplicity, this example supports only one level.");
     }
 
-    void RemakeLevel(int /*level*/, double /*time_point*/, const ::amrex::BoxArray&,
+    void RemakeLevel(int /*level*/, Real /*time_point*/, const ::amrex::BoxArray&,
                      const ::amrex::DistributionMapping&) override {
         throw std::runtime_error("For simplicity, this example supports only one level.");
     }
@@ -200,7 +200,7 @@ struct FillBoundaryFn {
     }
 };
 
-void WritePlotfiles(const AdvectionAmrCore& core_x, const AdvectionAmrCore& core_y, double time_point, int step)
+void WritePlotfiles(const AdvectionAmrCore& core_x, const AdvectionAmrCore& core_y, Real time_point, int step)
 {
     static const Vector<std::string> varnames{"Mass", "Vector_X", "Vector_Y"};
     int nlevels = 1;
@@ -278,11 +278,11 @@ void MyMain() {
     FillBoundaryFn FillBoundary{std::move(multi_block_boundaries)};
 
     int step = 0;
-    const double min_dx1_dy2 = std::min(geom1.CellSize(0), geom2.CellSize(1));
-    const double cfl = 1.0;
-    const double dt = cfl * min_dx1_dy2;
-    const double final_time = 4.0;
-    double time_point = 0.0;
+    const Real min_dx1_dy2 = std::min(geom1.CellSize(0), geom2.CellSize(1));
+    const Real cfl = 1.0;
+    const Real dt = cfl * min_dx1_dy2;
+    const Real final_time = 4.0;
+    Real time_point = 0.0;
 
     WritePlotfiles(core_x, core_y, time_point, step);
     while (time_point < final_time) {

--- a/Tests/Parser/main.cpp
+++ b/Tests/Parser/main.cpp
@@ -31,10 +31,10 @@ int test1 (std::string const& f,
     Real max_relerror = 0.;
     for (int i = 0; i < N; ++i) {
         Real x = lo[0] + i*dx[0];
-        double result = exe(x);
-        double benchmark = fb(x);
-        double abserror = std::abs(result-benchmark);
-        double relerror = abserror / (1.e-50 + std::max(std::abs(result),std::abs(benchmark)));
+        Real result = exe(x);
+        Real benchmark = fb(x);
+        Real abserror = std::abs(result-benchmark);
+        Real relerror = abserror / (1.e-50 + std::max(std::abs(result),std::abs(benchmark)));
         if (abserror > abstol && relerror > reltol) {
             amrex::Print() << "\n    f(" << x << ") = " << result << ", "
                            << benchmark;
@@ -79,10 +79,10 @@ int test3 (std::string const& f,
         Real x = lo[0] + i*dx[0];
         Real y = lo[1] + j*dx[1];
         Real z = lo[2] + k*dx[2];
-        double result = exe(x,y,z);
-        double benchmark = fb(x,y,z);
-        double abserror = std::abs(result-benchmark);
-        double relerror = abserror / (1.e-50 + std::max(std::abs(result),std::abs(benchmark)));
+        Real result = exe(x,y,z);
+        Real benchmark = fb(x,y,z);
+        Real abserror = std::abs(result-benchmark);
+        Real relerror = abserror / (1.e-50 + std::max(std::abs(result),std::abs(benchmark)));
         if (abserror > abstol && relerror > reltol) {
             amrex::Print() << "    f(" << x << "," << y << "," << z << ") = " << result << ", "
                            << benchmark << "\n";
@@ -128,10 +128,10 @@ int test4 (std::string const& f,
         Real y = lo[1] + j*dx[1];
         Real z = lo[2] + k*dx[2];
         Real t = lo[3] + m*dx[3];
-        double result = exe(x,y,z,t);
-        double benchmark = fb(x,y,z,t);
-        double abserror = std::abs(result-benchmark);
-        double relerror = abserror / (1.e-50 + std::max(std::abs(result),std::abs(benchmark)));
+        Real result = exe(x,y,z,t);
+        Real benchmark = fb(x,y,z,t);
+        Real abserror = std::abs(result-benchmark);
+        Real relerror = abserror / (1.e-50 + std::max(std::abs(result),std::abs(benchmark)));
         if (abserror > abstol && relerror > reltol) {
             amrex::Print() << "    f(" << x << "," << y << "," << z << "," << t << ") = " << result << ", "
                            << benchmark << "\n";


### PR DESCRIPTION
## Summary

Advection and Parser tests used double, not amrex::Real,
in a couple of places, and failed to compile for single precision.

## Additional background

AFAIK, single precision is relevant for Nyx.

## Checklist

The proposed changes:
- [x ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
