### PR TITLE
Make AsyncOut::Finish safe to call when async_out is not enabled.

### DIFF
--- a/Src/Base/AMReX_AsyncOut.cpp
+++ b/Src/Base/AMReX_AsyncOut.cpp
@@ -111,7 +111,9 @@ void Submit (std::function<void()> const& a_f)
 
 void Finish ()
 {
-    s_thread->Finish();
+    if (s_thread) {
+        s_thread->Finish();
+    }
 }
 
 void Wait ()


### PR DESCRIPTION
Close #2714

## Summary

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
