### PR TITLE
Fix FluxRegister::SumReg for GPU builds

### DIFF
--- a/Src/Base/AMReX_BoxArray.H
+++ b/Src/Base/AMReX_BoxArray.H
@@ -497,25 +497,13 @@ struct BATransformer
     }
 
     friend bool operator== (BATransformer const& a, BATransformer const& b) noexcept {
-        switch (a.m_bat_type)
-        {
-        case BATType::bndryReg:
-            switch (b.m_bat_type)
-            {
-            case BATType::bndryReg:
-                return a.m_op.m_bndryReg == b.m_op.m_bndryReg;
-            default:
-                return false;
-            }
-        default:
-            switch (b.m_bat_type)
-            {
-            case BATType::bndryReg:
-                return false;
-            default:
-                return a.index_type() == b.index_type()
-                    && a.coarsen_ratio() == b.coarsen_ratio();
-            }
+        if (a.m_bat_type != BATType::bndryReg && b.m_bat_type != BATType::bndryReg) {
+            return a.index_type() == b.index_type()
+                && a.coarsen_ratio() == b.coarsen_ratio();
+        } else if (a.m_bat_type == BATType::bndryReg && b.m_bat_type == BATType::bndryReg) {
+            return a.m_op.m_bndryReg == b.m_op.m_bndryReg;
+        } else {
+            return false;
         }
     }
 
@@ -824,6 +812,8 @@ public:
 
     BoxList const& simplified_list () const; // For regular AMR grids only!!!
     BoxArray simplified () const; // For regular AMR grids only!!!
+
+    BATransformer const& transformer () const;
 
     friend class AmrMesh;
     friend class FabArrayBase;

--- a/Src/Base/AMReX_BoxArray.cpp
+++ b/Src/Base/AMReX_BoxArray.cpp
@@ -1579,6 +1579,12 @@ BoxArray::simplified () const
     return BoxArray(simplified_list()).convert(ixType());
 }
 
+BATransformer const&
+BoxArray::transformer () const
+{
+    return m_bat;
+}
+
 std::ostream&
 operator<< (std::ostream&   os,
             const BoxArray& ba)

--- a/Src/Base/AMReX_FabArrayBase.H
+++ b/Src/Base/AMReX_FabArrayBase.H
@@ -669,8 +669,7 @@ public:
         void operator= (ParForInfo const&) = delete;
         void operator= (ParForInfo &&) = delete;
 
-        IndexType m_typ;
-        IntVect m_crse_ratio;
+        BATransformer m_bat;
         IntVect m_ng;
         int m_nthreads;
         std::pair<int*,int*> m_nblocks_x;

--- a/Src/Base/AMReX_FabArrayBase.cpp
+++ b/Src/Base/AMReX_FabArrayBase.cpp
@@ -2640,8 +2640,7 @@ FabArrayBase::isFusingCandidate () const noexcept
 #ifdef AMREX_USE_GPU
 
 FabArrayBase::ParForInfo::ParForInfo (const FabArrayBase& fa, const IntVect& nghost, int nthreads)
-    : m_typ(fa.boxArray().ixType()),
-      m_crse_ratio(fa.boxArray().crseRatio()),
+    : m_bat(fa.boxArray().transformer()),
       m_ng(nghost),
       m_nthreads(nthreads),
       m_nblocks_x({nullptr,nullptr})
@@ -2673,8 +2672,7 @@ FabArrayBase::getParForInfo (const IntVect& nghost, int nthreads) const
     AMREX_ASSERT(getBDKey() == m_bdkey);
     auto er_it = m_TheParForCache.equal_range(m_bdkey);
     for (auto it = er_it.first; it != er_it.second; ++it) {
-        if (it->second->m_typ        == boxArray().ixType()    &&
-            it->second->m_crse_ratio == boxArray().crseRatio() &&
+        if (it->second->m_bat        == boxArray().transformer() &&
             it->second->m_ng         == nghost                 &&
             it->second->m_nthreads   == nthreads)
         {


### PR DESCRIPTION
## Summary

It's incorrect to assume that the fused version of reduce is only used on
FabArrays with a simple BoxArray.  FluxRegister::SumReg uses the fused
version of reduce, and its BoxArray has a special BATransformer.  A
FluxRegister only has cells on the faces of regular Boxes, but the meta-data
provided to the GPU reduce function is for regular Boxes.  This results in
out-of-bound errors.  This commit fixes the issue by extending the meta-data
caching mechanism to include special BoxArrays used by FluxRegisters.

We have also refactored Batransformer's opeartor==.

## Additional background

This fixes https://github.com/AMReX-Astro/Castro/issues/2109.

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
