### PR TITLE
Allow some EB code to handle single precision

### DIFF
--- a/Src/EB/AMReX_EB2_IF_Scale.H
+++ b/Src/EB/AMReX_EB2_IF_Scale.H
@@ -21,7 +21,7 @@ public:
 #if (AMREX_SPACEDIM == 3)
           m_sfinv{1.0_rt/a_scalefactor[0], 1.0_rt/a_scalefactor[1], 1.0_rt/a_scalefactor[2]}
 #else
-          m_sfinv{1.0_rt/a_scalefactor[0], 1.0_rt/a_scalefactor[1], 0.0}
+          m_sfinv{1.0_rt/a_scalefactor[0], 1.0_rt/a_scalefactor[1], 0.0_rt}
 #endif
         {}
     ScaleIF (F const& a_f, const RealArray& a_scalefactor)

--- a/Src/EB/AMReX_EB2_IF_Scale.H
+++ b/Src/EB/AMReX_EB2_IF_Scale.H
@@ -29,7 +29,7 @@ public:
 #if (AMREX_SPACEDIM == 3)
           m_sfinv{1.0_rt/a_scalefactor[0], 1.0_rt/a_scalefactor[1], 1.0_rt/a_scalefactor[2]}
 #else
-          m_sfinv{1.0_rt/a_scalefactor[0], 1.0_rt/a_scalefactor[1], 0.0}
+          m_sfinv{1.0_rt/a_scalefactor[0], 1.0_rt/a_scalefactor[1], 0.0_rt}
 #endif
         {}
 

--- a/Src/EB/AMReX_EB2_IF_Scale.H
+++ b/Src/EB/AMReX_EB2_IF_Scale.H
@@ -19,17 +19,17 @@ public:
     ScaleIF (F&& a_f, const RealArray& a_scalefactor)
         : m_f(std::move(a_f)),
 #if (AMREX_SPACEDIM == 3)
-          m_sfinv{1.0/a_scalefactor[0], 1.0/a_scalefactor[1], 1.0/a_scalefactor[2]}
+          m_sfinv{1.0_rt/a_scalefactor[0], 1.0_rt/a_scalefactor[1], 1.0_rt/a_scalefactor[2]}
 #else
-          m_sfinv{1.0/a_scalefactor[0], 1.0/a_scalefactor[1], 0.0}
+          m_sfinv{1.0_rt/a_scalefactor[0], 1.0_rt/a_scalefactor[1], 0.0}
 #endif
         {}
     ScaleIF (F const& a_f, const RealArray& a_scalefactor)
         : m_f(a_f),
 #if (AMREX_SPACEDIM == 3)
-          m_sfinv{1.0/a_scalefactor[0], 1.0/a_scalefactor[1], 1.0/a_scalefactor[2]}
+          m_sfinv{1.0_rt/a_scalefactor[0], 1.0_rt/a_scalefactor[1], 1.0_rt/a_scalefactor[2]}
 #else
-          m_sfinv{1.0/a_scalefactor[0], 1.0/a_scalefactor[1], 0.0}
+          m_sfinv{1.0_rt/a_scalefactor[0], 1.0_rt/a_scalefactor[1], 0.0}
 #endif
         {}
 


### PR DESCRIPTION
## Summary

With these changes, I was able to compile PeleC with single precision.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
