### PR TITLE
Add methods for resetting the ParGDB of a ParticleContainer

### DIFF
--- a/Src/Particle/AMReX_ParticleContainerBase.H
+++ b/Src/Particle/AMReX_ParticleContainerBase.H
@@ -97,8 +97,8 @@ public:
 
     bool isDefined () const { return m_gdb != nullptr; }
 
-    void reserveData ();
-    void resizeData ();
+    virtual void reserveData ();
+    virtual void resizeData ();
     void RedefineDummyMF (int lev);
 
     MFIter MakeMFIter (int lev, const MFItInfo& info) const {

--- a/Src/Particle/AMReX_ParticleContainerBase.H
+++ b/Src/Particle/AMReX_ParticleContainerBase.H
@@ -116,6 +116,48 @@ public:
         return MFIter(*m_dummy_mf[lev], tile ? tile_size : IntVect::TheZeroVector());
     }
 
+    //! \brief Set the particle Geometry, DistributionMapping, and BoxArray. If the container
+    //! was previously set to to track the AMR hierarchy of an AmrCore or AmrLevel object, that
+    //! correspondence will be broken here. This is the single-level version.
+    //!
+    //! \param geom The new Geometry to use.
+    //! \param dmap The new DistributionMapping to use.
+    //! \param ba The new BoxArray to use.
+    //!
+    void SetParGDB (const Geometry            & geom,
+                    const DistributionMapping & dmap,
+                    const BoxArray            & ba);
+
+    //! \brief Set the particle Geometry, DistributionMapping, ref ratios, and BoxArray. If the container
+    //! was previously set to to track the AMR hierarchy of an AmrCore or AmrLevel object, that
+    //! correspondence will be broken here. This is the multi-level version.
+    //!
+    //! \param geom The new vector of Geometry objects to use.
+    //! \param dmap The new vector of DistributionMapping objects to use.
+    //! \param ba The new vector of BoxArray objects to use.
+    //! \param rr The new vector of refinement ratios to use.
+    //!
+    void SetParGDB (const Vector<Geometry>            & geom,
+                    const Vector<DistributionMapping> & dmap,
+                    const Vector<BoxArray>            & ba,
+                    const Vector<IntVect>             & rr);
+
+    //! \brief Set the particle Geometry, DistributionMapping, ref ratios, and BoxArray. If the container
+    //! was previously set to to track the AMR hierarchy of an AmrCore or AmrLevel object, that
+    //! correspondence will be broken here. This is the multi-level version.
+    //!
+    //! Like the above, except the refinement ratios are expressed as ints
+    //!
+    //! \param geom The new vector of Geometry objects to use.
+    //! \param dmap The new vector of DistributionMapping objects to use.
+    //! \param ba The new vector of BoxArray objects to use.
+    //! \param rr The new vector of refinement ratios to use.
+    //!
+    void SetParGDB (const Vector<Geometry>            & geom,
+                    const Vector<DistributionMapping> & dmap,
+                    const Vector<BoxArray>            & ba,
+                    const Vector<int>                 & rr);
+
     //! \brief Set the particle BoxArray. If the container was previously set to
     //! to track the AMR hierarchy of an AmrCore or AmrLevel object, that correspondence
     //! will be broken here.

--- a/Src/Particle/AMReX_ParticleContainerBase.H
+++ b/Src/Particle/AMReX_ParticleContainerBase.H
@@ -81,6 +81,12 @@ public:
 
     virtual ~ParticleContainerBase () = default;
 
+    ParticleContainerBase ( const ParticleContainerBase &) = delete;
+    ParticleContainerBase& operator= ( const ParticleContainerBase & ) = delete;
+
+    ParticleContainerBase ( ParticleContainerBase && ) = default;
+    ParticleContainerBase& operator= ( ParticleContainerBase && ) = default;
+
     void Define (ParGDBBase* gdb) { m_gdb = gdb;}
 
     void Define (const Geometry            & geom,

--- a/Src/Particle/AMReX_ParticleContainerBase.H
+++ b/Src/Particle/AMReX_ParticleContainerBase.H
@@ -79,6 +79,8 @@ public:
         m_gdb = &m_gdb_object;
     }
 
+    virtual ~ParticleContainerBase () = default;
+
     void Define (ParGDBBase* gdb) { m_gdb = gdb;}
 
     void Define (const Geometry            & geom,

--- a/Src/Particle/AMReX_ParticleContainerBase.cpp
+++ b/Src/Particle/AMReX_ParticleContainerBase.cpp
@@ -79,6 +79,35 @@ ParticleContainerBase::defineBufferMap () const
     }
 }
 
+void ParticleContainerBase::SetParGDB (const Geometry            & geom,
+                                       const DistributionMapping & dmap,
+                                       const BoxArray            & ba)
+{
+    m_gdb_object = ParGDB(geom, dmap, ba);
+    m_gdb = &m_gdb_object;
+    resizeData();
+}
+
+void ParticleContainerBase::SetParGDB (const Vector<Geometry>            & geom,
+                                       const Vector<DistributionMapping> & dmap,
+                                       const Vector<BoxArray>            & ba,
+                                       const Vector<int>                 & rr)
+{
+    m_gdb_object = ParGDB(geom, dmap, ba, rr);
+    m_gdb = &m_gdb_object;
+    resizeData();
+}
+
+void ParticleContainerBase::SetParGDB (const Vector<Geometry>            & geom,
+                                       const Vector<DistributionMapping> & dmap,
+                                       const Vector<BoxArray>            & ba,
+                                       const Vector<IntVect>             & rr)
+{
+    m_gdb_object = ParGDB(geom, dmap, ba, rr);
+    m_gdb = &m_gdb_object;
+    resizeData();
+}
+
 void ParticleContainerBase::SetParticleBoxArray (int lev, const BoxArray& new_ba)
 {
     m_gdb_object = ParGDB(m_gdb->ParticleGeom(), m_gdb->ParticleDistributionMap(),

--- a/Src/Particle/AMReX_Particles.H
+++ b/Src/Particle/AMReX_Particles.H
@@ -374,8 +374,8 @@ public:
     //! \brief The total number of tiles on this rank on this level
     int numLocalTilesAtLevel (int lev) const { return m_particles[lev].size(); }
 
-    void reserveData ();
-    void resizeData ();
+    void reserveData () override;
+    void resizeData () override;
 
     void InitFromAsciiFile (const std::string& file, int extradata,
                             const IntVect* Nrep = nullptr);

--- a/Src/Particle/AMReX_Particles.H
+++ b/Src/Particle/AMReX_Particles.H
@@ -294,7 +294,7 @@ public:
         resizeData();
     }
 
-    virtual ~ParticleContainer () {}
+    virtual ~ParticleContainer () = default;
 
     ParticleContainer ( const ParticleContainer &) = delete;
     ParticleContainer& operator= ( const ParticleContainer & ) = delete;


### PR DESCRIPTION
This is useful for when you want to add or remove levels of refinement, but you have *not* used the `AmrCore` version of the constructor.

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
