### PR TITLE
Update WarpX's MLEBNodeFDLaplacian for 2D RZ

### DIFF
--- a/Src/LinearSolvers/MLMG/AMReX_MLEBNodeFDLaplacian.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBNodeFDLaplacian.H
@@ -18,8 +18,9 @@ namespace amrex {
 // where phi and rhs are nodal multifab, and sigma is a tensor constant
 // with only diagonal components.  The EB is assumed to be Dirichlet.
 //
-// del dot grad phi - alpha/r^2 phi = rhs, for RZ
-// where alpha is a scalar constant.  For now, it is assumed alpha.
+// del dot (simga grad phi) - alpha/r^2 phi = rhs, for RZ where alpha is a
+// scalar constant that is zero by default.  sigma is non-zero in
+// z-direction only.  For now the `alpha` term has not been implemented yet.
 
 class MLEBNodeFDLaplacian
     : public MLNodeLinOp
@@ -51,6 +52,8 @@ public:
     void setSigma (Array<Real,AMREX_SPACEDIM> const& a_sigma) noexcept;
 
     void setRZ (bool flag);
+
+    void setAlpha (Real a_alpha);
 
 #ifdef AMREX_USE_EB
 
@@ -120,6 +123,7 @@ private:
     Real m_s_phi_eb = std::numeric_limits<Real>::lowest();
     Vector<MultiFab> m_phi_eb;
     int m_rz = false;
+    Real m_rz_alpha = 0._rt;
 };
 
 #ifdef AMREX_USE_EB

--- a/Src/LinearSolvers/MLMG/AMReX_MLEBNodeFDLaplacian.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBNodeFDLaplacian.cpp
@@ -48,6 +48,16 @@ MLEBNodeFDLaplacian::setRZ (bool flag)
 #endif
 }
 
+void
+MLEBNodeFDLaplacian::setAlpha (Real a_alpha)
+{
+#if (AMREX_SPACEDIM == 2)
+    m_rz_alpha = a_alpha;
+#else
+    amrex::ignore_unused(a_alpha);
+#endif
+}
+
 #ifdef AMREX_USE_EB
 
 void
@@ -300,6 +310,8 @@ MLEBNodeFDLaplacian::prepareForSolve ()
             AMREX_ALWAYS_ASSERT_WITH_MESSAGE(m_lobc[0][0] == BCType::Neumann,
                                              "The lo-x BC must be Neumann for 2d RZ");
         }
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(m_sigma[0] == 0._rt,
+                                         "r-direction sigma must be zero");
     }
 #endif
 }
@@ -342,8 +354,10 @@ MLEBNodeFDLaplacian::Fapply (int amrlev, int mglev, MultiFab& out, const MultiFa
     const auto dxinv = m_geom[amrlev][mglev].InvCellSizeArray();
 #if (AMREX_SPACEDIM == 2)
     const auto dx0 = m_geom[amrlev][mglev].CellSize(0);
-    const auto dx1 = m_geom[amrlev][mglev].CellSize(1);
+    const auto dx1 = m_geom[amrlev][mglev].CellSize(1)/std::sqrt(m_sigma[1]);
     const auto xlo = m_geom[amrlev][mglev].ProbLo(0);
+    const auto alpha = m_rz_alpha;
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(alpha == 0._rt, "alpha != 0 not implemented yet");
 #endif
     AMREX_D_TERM(const Real bx = m_sigma[0]*dxinv[0]*dxinv[0];,
                  const Real by = m_sigma[1]*dxinv[1]*dxinv[1];,
@@ -378,7 +392,7 @@ MLEBNodeFDLaplacian::Fapply (int amrlev, int mglev, MultiFab& out, const MultiFa
                 if (m_rz) {
                     AMREX_HOST_DEVICE_FOR_3D(box, i, j, k,
                     {
-                        mlebndfdlap_adotx_rz_eb(i,j,k,yarr,xarr,dmarr,AMREX_D_DECL(ecx,ecy,ecz),
+                        mlebndfdlap_adotx_rz_eb(i,j,k,yarr,xarr,dmarr,ecx,ecy,
                                                 phiebarr, dx0, dx1, xlo);
                     });
                 } else
@@ -395,7 +409,7 @@ MLEBNodeFDLaplacian::Fapply (int amrlev, int mglev, MultiFab& out, const MultiFa
                 if (m_rz) {
                     AMREX_HOST_DEVICE_FOR_3D(box, i, j, k,
                     {
-                        mlebndfdlap_adotx_rz_eb(i,j,k,yarr,xarr,dmarr,AMREX_D_DECL(ecx,ecy,ecz),
+                        mlebndfdlap_adotx_rz_eb(i,j,k,yarr,xarr,dmarr,ecx,ecy,
                                                 phieb, dx0, dx1, xlo);
                     });
                 } else
@@ -437,8 +451,10 @@ MLEBNodeFDLaplacian::Fsmooth (int amrlev, int mglev, MultiFab& sol, const MultiF
     const auto dxinv = m_geom[amrlev][mglev].InvCellSizeArray();
 #if (AMREX_SPACEDIM == 2)
     const auto dx0 = m_geom[amrlev][mglev].CellSize(0);
-    const auto dx1 = m_geom[amrlev][mglev].CellSize(1);
+    const auto dx1 = m_geom[amrlev][mglev].CellSize(1)/std::sqrt(m_sigma[1]);
     const auto xlo = m_geom[amrlev][mglev].ProbLo(0);
+    const auto alpha = m_rz_alpha;
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(alpha == 0._rt, "alpha != 0 not implemented yet");
 #endif
     AMREX_D_TERM(const Real bx = m_sigma[0]*dxinv[0]*dxinv[0];,
                  const Real by = m_sigma[1]*dxinv[1]*dxinv[1];,


### PR DESCRIPTION
This adds support for sigma coefficient in the z-direction for the 2D RZ
LinOp MLEBNodeFDLaplacian used by WarpX.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
