### PR TITLE
Disable AsyncOut by default for HIP and DPC++

### DIFF
--- a/Src/Base/AMReX_AsyncOut.cpp
+++ b/Src/Base/AMReX_AsyncOut.cpp
@@ -11,13 +11,7 @@ namespace AsyncOut {
 
 namespace {
 
-#if defined(AMREX_USE_DPCPP) || defined(AMREX_USE_HIP)
-int s_asyncout = true; // Have this on by default for DPC++ for now so that
-                       // I/O writing plotfile does not depend on unified
-                       // memory.
-#else
 int s_asyncout = false;
-#endif
 int s_noutfiles = 64;
 MPI_Comm s_comm = MPI_COMM_NULL;
 


### PR DESCRIPTION
This makes it the same behavior as other builds.  We had it on by default
because in the past our I/O functions relied on managed memory and there
were issues with HIP and DPC++.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
