### PR TITLE
Drop CUDA 9 support

### DIFF
--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -7,15 +7,15 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # Build libamrex and all tests with CUDA 9.2
-  tests-cuda9:
-    name: CUDA@9.2 GNU@6.5.0 C++14 Release [tests]
+  # Build libamrex and all tests with CUDA 10.2
+  tests-cuda10:
+    name: CUDA@10.2 GNU@6.5.0 C++14 Release [tests]
     runs-on: ubuntu-18.04
     env: {CXXFLAGS: "-fno-operator-names -Werror -Wall -Wextra -Wpedantic -Wnull-dereference -Wfloat-conversion -Wshadow -Woverloaded-virtual -Wunreachable-code"}
     steps:
     - uses: actions/checkout@v2
     - name: Dependencies
-      run: .github/workflows/dependencies/dependencies_nvcc9.sh
+      run: .github/workflows/dependencies/dependencies_nvcc10.sh
     - name: Build & Install
       run: |
         export PATH=/usr/local/nvidia/bin:/usr/local/cuda/bin:${PATH}
@@ -34,7 +34,7 @@ jobs:
             -DCMAKE_CXX_COMPILER=$(which g++-6)            \
             -DCMAKE_CUDA_HOST_COMPILER=$(which g++-6)      \
             -DCMAKE_Fortran_COMPILER=$(which gfortran-6)   \
-            -DAMReX_CUDA_ARCH=6.0 \
+            -DAMReX_CUDA_ARCH=7.0 \
             -DAMReX_CUDA_ERROR_CROSS_EXECUTION_SPACE_CALL=ON
         make -j 2
 

--- a/.github/workflows/dependencies/dependencies_nvcc10.sh
+++ b/.github/workflows/dependencies/dependencies_nvcc10.sh
@@ -4,11 +4,6 @@
 #
 # License: BSD-3-Clause-LBNL
 
-# search recursive inside a folder if a file contains tabs
-#
-# @result 0 if no files are found, else 1
-#
-
 set -eu -o pipefail
 
 sudo apt-get update
@@ -22,17 +17,15 @@ sudo apt-get install -y --no-install-recommends\
 
 sudo wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/x86_64/7fa2af80.pub
 sudo apt-key add 7fa2af80.pub
-echo "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/x86_64 /" \
+echo "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64 /" \
     | sudo tee /etc/apt/sources.list.d/cuda.list
 sudo apt-get update
 sudo apt-get install -y \
-    cuda-command-line-tools-9-2 \
-    cuda-compiler-9-2           \
-    cuda-minimal-build-9-2      \
-    cuda-nvml-dev-9-2           \
-    cuda-nvtx-9-2               \
-    cuda-curand-dev-9.2
-
-sudo ln -s cuda-9.2 /usr/local/cuda
-
-
+    cuda-command-line-tools-10-2 \
+    cuda-compiler-10-2           \
+    cuda-cupti-dev-10-2          \
+    cuda-minimal-build-10-2      \
+    cuda-nvml-dev-10-2           \
+    cuda-nvtx-10-2               \
+    cuda-curand-dev-10-2
+sudo ln -s cuda-10.2 /usr/local/cuda

--- a/.github/workflows/dependencies/dependencies_nvcc11.sh
+++ b/.github/workflows/dependencies/dependencies_nvcc11.sh
@@ -4,11 +4,6 @@
 #
 # License: BSD-3-Clause-LBNL
 
-# search recursive inside a folder if a file contains tabs
-#
-# @result 0 if no files are found, else 1
-#
-
 set -eu -o pipefail
 
 sudo apt-get -qqq update

--- a/Docs/sphinx_documentation/source/GPU_Chapter.rst
+++ b/Docs/sphinx_documentation/source/GPU_Chapter.rst
@@ -8,8 +8,8 @@ NVIDIA, AMD and Intel GPUs using their native vendor language and therefore
 requires CUDA, HIP/ROCm and DPC++/SYCL, for NVIDIA, AMD and Intel GPUs, respectively.
 Users can also use OpenMP and/or OpenACC in their applications.
 
-AMReX supports NVIDIA GPUs with compute capability >= 6 and CUDA >= 10
-as well as CUDA 9.1.  While HIP and DPC++ compilers are in development in
+AMReX supports NVIDIA GPUs with compute capability >= 6 and CUDA >= 10.
+While HIP and DPC++ compilers are in development in
 preparation for Frontier and Aurora, AMReX only supports the latest
 publicly released versions of those compilers on the Iris and Tulip testbeds.
 

--- a/Src/Base/AMReX_BaseFab.H
+++ b/Src/Base/AMReX_BaseFab.H
@@ -1882,12 +1882,7 @@ BaseFab<T>::define ()
 {
     AMREX_ASSERT(this->dptr == 0);
     AMREX_ASSERT(this->domain.numPts() > 0);
-#if !defined(__CUDACC__) || (__CUDACC_VER_MAJOR__ != 9) || (__CUDACC_VER_MINOR__ != 2)
     AMREX_ASSERT(std::numeric_limits<Long>::max()/this->nvar > this->domain.numPts());
-#else
-    AMREX_ASSERT(LONG_MAX/this->nvar > this->domain.numPts());
-#endif
-
     AMREX_ASSERT(this->nvar >= 0);
     if (this->nvar == 0) return;
 

--- a/Src/Base/AMReX_CudaGraph.H
+++ b/Src/Base/AMReX_CudaGraph.H
@@ -2,7 +2,7 @@
 #define AMREX_CUDA_GRAPH_H_
 #include <AMReX_Config.H>
 
-#if ( defined(__CUDACC__) && (__CUDACC_VER_MAJOR__ >= 10))
+#if defined(__CUDACC__)
 
 #include <AMReX.H>
 #include <AMReX_Array.H>

--- a/Src/Base/AMReX_FArrayBox.cpp
+++ b/Src/Base/AMReX_FArrayBox.cpp
@@ -170,12 +170,10 @@ FArrayBox::initVal () noexcept
 #if defined(AMREX_USE_GPU)
             if (runon == RunOn::Gpu)
             {
-#if (__CUDACC_VER_MAJOR__ != 9) || (__CUDACC_VER_MINOR__ != 2)
                 amrex::ParallelFor(s, [=] AMREX_GPU_DEVICE (Long i) noexcept
                 {
                     p[i] = std::numeric_limits<Real>::signaling_NaN();
                 });
-#endif
                 Gpu::streamSynchronize();
             }
             else

--- a/Src/Base/AMReX_FBI.H
+++ b/Src/Base/AMReX_FBI.H
@@ -385,7 +385,7 @@ FabArray<FAB>::CMD_remote_setVal_gpu (typename FabArray<FAB>::value_type x,
     });
 }
 
-#if ( defined(__CUDACC__) && (__CUDACC_VER_MAJOR__ >= 10))
+#if defined(__CUDACC__)
 template <class FAB>
 void
 FabArray<FAB>::FB_local_copy_cuda_graph_1 (const FB& TheFB, int scomp, int ncomp)
@@ -543,7 +543,7 @@ FabArray<FAB>::FB_local_copy_cuda_graph_n (const FB& TheFB, int scomp, int ncomp
 }
 #endif /* AMREX_USE_MPI */
 
-#endif /* CUDA >= 10 */
+#endif /* __CUDACC__ */
 
 #endif /* AMREX_USE_GPU */
 
@@ -551,7 +551,7 @@ FabArray<FAB>::FB_local_copy_cuda_graph_n (const FB& TheFB, int scomp, int ncomp
 
 #ifdef AMREX_USE_GPU
 
-#if ( defined(__CUDACC__) && (__CUDACC_VER_MAJOR__ >= 10) )
+#if defined(__CUDACC__)
 
 template <class FAB>
 void
@@ -722,7 +722,7 @@ FabArray<FAB>::FB_unpack_recv_buffer_cuda_graph (const FB& TheFB, int dcomp, int
     TheFB.m_copyFromBuffer.executeGraph();
 }
 
-#endif /* CUDA >= 10 */
+#endif /* __CUDACC__ */
 
 template <class FAB>
 template <typename BUF>

--- a/Src/Base/AMReX_FabArray.H
+++ b/Src/Base/AMReX_FabArray.H
@@ -1067,7 +1067,7 @@ public:
     void CMD_local_setVal_gpu (value_type x, const CommMetaData& thecmd, int scomp, int ncomp);
     void CMD_remote_setVal_gpu (value_type x, const CommMetaData& thecmd, int scomp, int ncomp);
 
-#if ( defined(__CUDACC__) && (__CUDACC_VER_MAJOR__ >= 10))
+#if defined(__CUDACC__)
 
     void FB_local_copy_cuda_graph_1 (const FB& TheFB, int scomp, int ncomp);
     void FB_local_copy_cuda_graph_n (const FB& TheFB, int scomp, int ncomp);
@@ -1078,7 +1078,7 @@ public:
 #ifdef AMREX_USE_MPI
 
 #ifdef AMREX_USE_GPU
-#if ( defined(__CUDACC__) && (__CUDACC_VER_MAJOR__ >= 10) )
+#if defined(__CUDACC__)
 
     void FB_pack_send_buffer_cuda_graph (const FB& TheFB, int scomp, int ncomp,
                                          Vector<char*>& send_data,

--- a/Src/Base/AMReX_FabArrayBase.H
+++ b/Src/Base/AMReX_FabArrayBase.H
@@ -504,7 +504,7 @@ public:
         Long         m_nuse;
         bool         m_multi_ghost = false;
         //
-#if ( defined(__CUDACC__) && (__CUDACC_VER_MAJOR__ >= 10) )
+#if defined(__CUDACC__)
         CudaGraph<CopyMemory> m_localCopy;
         CudaGraph<CopyMemory> m_copyToBuffer;
         CudaGraph<CopyMemory> m_copyFromBuffer;

--- a/Src/Base/AMReX_FabArrayCommI.H
+++ b/Src/Base/AMReX_FabArrayCommI.H
@@ -35,7 +35,7 @@ FabArray<FAB>::FBEP_nowait (int scomp, int ncomp, const IntVect& nghost,
 #ifdef AMREX_USE_GPU
         if (Gpu::inLaunchRegion())
         {
-#if ( defined(__CUDACC__) && (__CUDACC_VER_MAJOR__ >= 10))
+#if defined(__CUDACC__)
             if (Gpu::inGraphRegion())
             {
                 FB_local_copy_cuda_graph_1(TheFB, scomp, ncomp);
@@ -107,7 +107,7 @@ FabArray<FAB>::FBEP_nowait (int scomp, int ncomp, const IntVect& nghost,
 #ifdef AMREX_USE_GPU
         if (Gpu::inLaunchRegion())
         {
-#if ( defined(__CUDACC__) && (__CUDACC_VER_MAJOR__ >= 10))
+#if defined(__CUDACC__)
             if (Gpu::inGraphRegion()) {
                 FB_pack_send_buffer_cuda_graph(TheFB, scomp, ncomp, send_data, send_size, send_cctc);
             }
@@ -137,7 +137,7 @@ FabArray<FAB>::FBEP_nowait (int scomp, int ncomp, const IntVect& nghost,
 #ifdef AMREX_USE_GPU
         if (Gpu::inLaunchRegion())
         {
-#if ( defined(__CUDACC__) && (__CUDACC_VER_MAJOR__ >= 10) )
+#if defined(__CUDACC__)
             if (Gpu::inGraphRegion()) {
                 FB_local_copy_cuda_graph_n(TheFB, scomp, ncomp);
             }
@@ -201,7 +201,7 @@ FabArray<FAB>::FillBoundary_finish ()
 #ifdef AMREX_USE_GPU
         if (Gpu::inLaunchRegion())
         {
-#if ( defined(__CUDACC__) && (__CUDACC_VER_MAJOR__ >= 10) )
+#if defined(__CUDACC__)
             if (Gpu::inGraphRegion())
             {
                 FB_unpack_recv_buffer_cuda_graph(*TheFB, fbd->scomp, fbd->ncomp,

--- a/Src/Base/AMReX_GpuAsyncArray.H
+++ b/Src/Base/AMReX_GpuAsyncArray.H
@@ -15,10 +15,8 @@
 extern "C" {
 #if defined(AMREX_USE_HIP)
     void amrex_asyncarray_delete ( hipStream_t stream,  hipError_t error, void* p);
-#elif defined(__CUDACC__) && (__CUDACC_VER_MAJOR__ >= 10)
-    void CUDART_CB amrex_asyncarray_delete (void* p);
 #elif defined(AMREX_USE_CUDA)
-    void CUDART_CB amrex_asyncarray_delete (cudaStream_t stream, cudaError_t error, void* p);
+    void CUDART_CB amrex_asyncarray_delete (void* p);
 #endif
 }
 #endif
@@ -83,12 +81,9 @@ public:
 #if defined(AMREX_USE_HIP)
                 AMREX_HIP_SAFE_CALL ( hipStreamAddCallback(Gpu::gpuStream(),
                                                            amrex_asyncarray_delete, p, 0));
-#elif defined(__CUDACC__) && (__CUDACC_VER_MAJOR__ >= 10)
+#elif defined(AMREX_USE_CUDA)
                 AMREX_CUDA_SAFE_CALL(cudaLaunchHostFunc(Gpu::gpuStream(),
                                                         amrex_asyncarray_delete, p));
-#elif defined(AMREX_USE_CUDA)
-                AMREX_CUDA_SAFE_CALL(cudaStreamAddCallback(Gpu::gpuStream(),
-                                                           amrex_asyncarray_delete, p, 0));
 #endif
 #elif defined(AMREX_USE_DPCPP)
 #ifdef AMREX_USE_CODEPLAY_HOST_TASK

--- a/Src/Base/AMReX_GpuAsyncArray.cpp
+++ b/Src/Base/AMReX_GpuAsyncArray.cpp
@@ -6,10 +6,8 @@
 extern "C" {
 #if defined(AMREX_USE_HIP)
     void amrex_asyncarray_delete ( hipStream_t /*stream*/,  hipError_t /*error*/, void* p)
-#elif defined(__CUDACC__) && (__CUDACC_VER_MAJOR__ >= 10)
-    void CUDART_CB amrex_asyncarray_delete (void* p)
 #elif defined(AMREX_USE_CUDA)
-    void CUDART_CB amrex_asyncarray_delete (cudaStream_t /*stream*/, cudaError_t /*error*/, void* p)
+    void CUDART_CB amrex_asyncarray_delete (void* p)
 #endif
     {
         void** pp = (void**)p;

--- a/Src/Base/AMReX_GpuDevice.H
+++ b/Src/Base/AMReX_GpuDevice.H
@@ -98,7 +98,7 @@ public:
     static void nonNullStreamSynchronize () noexcept;
 #endif
 
-#if ( defined(__CUDACC__) && (__CUDACC_VER_MAJOR__ >= 10) )
+#if defined(__CUDACC__)
     /**  Generic graph selection. These should be called by users.  */
     static void startGraphRecording(bool first_iter, void* h_ptr, void* d_ptr, size_t sz);
     static cudaGraphExec_t stopGraphRecording(bool last_iter);

--- a/Src/Base/AMReX_GpuDevice.cpp
+++ b/Src/Base/AMReX_GpuDevice.cpp
@@ -86,7 +86,7 @@ std::unique_ptr<sycl::device>  Device::sycl_device;
 
 namespace {
 
-#if ( defined(__CUDACC__) && (__CUDACC_VER_MAJOR__ >= 10) )
+#if defined(__CUDACC__)
     AMREX_GPU_GLOBAL void emptyKernel() {}
 #endif
 
@@ -94,7 +94,7 @@ namespace {
     {
         amrex::ignore_unused(graph_size);
 
-#if ( defined(__CUDACC__) && (__CUDACC_VER_MAJOR__ >= 10) )
+#if defined(__CUDACC__)
 
         BL_PROFILE("InitGraph");
 
@@ -293,7 +293,6 @@ Device::Initialize ()
     // is only available starting from CUDA 10.0, so we will
     // leave num_devices_used as 0 for older CUDA toolkits.
 
-#if (__CUDACC_VER_MAJOR__ >= 10)
     size_t uuid_length = 16;
     size_t recv_sz = uuid_length * ParallelDescriptor::NProcs();
     const char* sendbuf = &device_prop.uuid.bytes[0];
@@ -316,13 +315,12 @@ Device::Initialize ()
     ParallelDescriptor::Bcast<int>(&num_devices_used, 1);
 
     delete[] recvbuf;
-#endif
 
 #if (defined(AMREX_PROFILING) || defined(AMREX_TINY_PROFILING))
     nvtxRangeEnd(nvtx_init);
 #endif
     if (amrex::Verbose()) {
-#if defined(AMREX_USE_MPI) && (__CUDACC_VER_MAJOR__ >= 10)
+#if defined(AMREX_USE_MPI)
         if (num_devices_used == ParallelDescriptor::NProcs())
         {
             amrex::Print() << "CUDA initialized with 1 GPU per MPI rank; "
@@ -333,9 +331,9 @@ Device::Initialize ()
             amrex::Print() << "CUDA initialized with " << num_devices_used << " GPU(s) and "
                            << ParallelDescriptor::NProcs() << " ranks.\n";
         }
-#else  // Should always be using NVCC >= 10 now, so not going to bother with other combinations.
+#else
         amrex::Print() << "CUDA initialized with 1 GPU\n";
-#endif // AMREX_USE_MPI && NVCC >= 10
+#endif // AMREX_USE_MPI
     }
 
 #elif defined(AMREX_USE_HIP)
@@ -657,7 +655,7 @@ Device::nonNullStreamSynchronize () noexcept
 }
 #endif
 
-#if ( defined(__CUDACC__) && (__CUDACC_VER_MAJOR__ >= 10) )
+#if defined(__CUDACC__)
 
 void
 Device::startGraphRecording(bool first_iter, void* h_ptr, void* d_ptr, size_t sz)

--- a/Src/Base/AMReX_GpuElixir.cpp
+++ b/Src/Base/AMReX_GpuElixir.cpp
@@ -16,10 +16,8 @@ namespace {
 extern "C" {
 #if defined(AMREX_USE_HIP)
     void amrex_elixir_delete ( hipStream_t /*stream*/,  hipError_t /*error*/, void* p)
-#elif defined(__CUDACC__) && (__CUDACC_VER_MAJOR__ >= 10)
-    void CUDART_CB amrex_elixir_delete (void* p)
 #elif defined(AMREX_USE_CUDA)
-    void CUDART_CB amrex_elixir_delete (cudaStream_t /*stream*/, cudaError_t /*error*/, void* p)
+    void CUDART_CB amrex_elixir_delete (void* p)
 #endif
     {
         auto p_pa = reinterpret_cast<Vector<std::pair<void*,Arena*> >*>(p);
@@ -46,12 +44,9 @@ Elixir::clear () noexcept
 #if defined(AMREX_USE_HIP)
             AMREX_HIP_SAFE_CALL ( hipStreamAddCallback(Gpu::gpuStream(),
                                                        amrex_elixir_delete, (void*)p, 0));
-#elif defined(__CUDACC__) && (__CUDACC_VER_MAJOR__ >= 10)
+#elif defined(AMREX_USE_CUDA)
             AMREX_CUDA_SAFE_CALL(cudaLaunchHostFunc(Gpu::gpuStream(),
                                                     amrex_elixir_delete, (void*)p));
-#elif defined(AMREX_USE_CUDA)
-            AMREX_CUDA_SAFE_CALL(cudaStreamAddCallback(Gpu::gpuStream(),
-                                                       amrex_elixir_delete, (void*)p, 0));
 #endif
 #elif defined(AMREX_USE_DPCPP)
 #ifdef AMREX_USE_CODEPLAY_HOST_TASK

--- a/Src/Base/AMReX_IntVect.H
+++ b/Src/Base/AMReX_IntVect.H
@@ -532,19 +532,11 @@ public:
 
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     static constexpr IntVect TheMaxVector () noexcept {
-#if !defined(__CUDACC__) || (__CUDACC_VER_MAJOR__ != 9) || (__CUDACC_VER_MINOR__ != 2)
         return IntVect(std::numeric_limits<int>::max());
-#else
-        return IntVect(INT_MAX);
-#endif
     }
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     static constexpr IntVect TheMinVector () noexcept {
-#if !defined(__CUDACC__) || (__CUDACC_VER_MAJOR__ != 9) || (__CUDACC_VER_MINOR__ != 2)
         return IntVect(std::numeric_limits<int>::lowest());
-#else
-        return IntVect(INT_MIN);
-#endif
     }
 
 private:

--- a/Src/EB/AMReX_EB2_IF_Box.H
+++ b/Src/EB/AMReX_EB2_IF_Box.H
@@ -32,11 +32,7 @@ public:
     AMREX_GPU_HOST_DEVICE inline
     Real operator() (AMREX_D_DECL(Real x, Real y, Real z)) const noexcept
     {
-#if !defined(__CUDACC__) || (__CUDACC_VER_MAJOR__ != 9) || (__CUDACC_VER_MINOR__ != 2)
         Real r = std::numeric_limits<Real>::lowest();
-#else
-        Real r = -1.e37;
-#endif
         AMREX_D_TERM(r = amrex::max(r, x-m_hi.x, -(x-m_lo.x));,
                      r = amrex::max(r, y-m_hi.y, -(y-m_lo.y));,
                      r = amrex::max(r, z-m_hi.z, -(z-m_lo.z)););

--- a/Src/EB/AMReX_EB_utils.cpp
+++ b/Src/EB/AMReX_EB_utils.cpp
@@ -309,13 +309,7 @@ facets_nearest_pt (IntVect const& ind_pt, IntVect const& ind_loop, RealVect cons
 
     // scalar characterizing EB facet position
     Real eb_h = eb_normal.dotProduct(eb_p0);
-
-#if (__CUDACC_VER_MAJOR__ != 9) || (__CUDACC_VER_MINOR__ != 2)
     Real min_dist = std::numeric_limits<Real>::max();
-#else
-    Real min_dist = 3.4e38_rt;
-#endif
-
     RealVect c_vec;
 
     // iterate over EB facet edges and find whichever has the closest nearest point
@@ -399,7 +393,6 @@ facets_nearest_pt (IntVect const& ind_pt, IntVect const& ind_loop, RealVect cons
         // the min/max values of lambda, in order for the point described by
         // lambda to be contained within the box.
         //
-#if (__CUDACC_VER_MAJOR__ != 9) || (__CUDACC_VER_MINOR__ != 2)
         Real cx_lo = -std::numeric_limits<Real>::max();
         Real cy_lo = -std::numeric_limits<Real>::max();
         Real cz_lo = -std::numeric_limits<Real>::max();
@@ -407,15 +400,6 @@ facets_nearest_pt (IntVect const& ind_pt, IntVect const& ind_loop, RealVect cons
         Real cy_hi = std::numeric_limits<Real>::max();
         Real cz_hi = std::numeric_limits<Real>::max();
         Real eps = std::numeric_limits<Real>::epsilon();
-#else
-        Real cx_lo = -3.4e38_rt;
-        Real cy_lo = -3.4e38_rt;
-        Real cz_lo = -3.4e38_rt;
-        Real cx_hi =  3.4e38_rt;
-        Real cy_hi =  3.4e38_rt;
-        Real cz_hi =  3.4e38_rt;
-        Real eps = 1.e-7_rt;
-#endif
         // if the line runs parallel to any of these dimensions (which is true for
         // EB edges), then skip -> the min/max functions at the end will skip them
         // due to the +/-huge(c...) defaults (above).
@@ -587,11 +571,7 @@ void FillSignedDistance (MultiFab& mf, EB2::Level const& ls_lev,
                     AMREX_D_TERM(Real x = i*dx_ls[0];,
                                  Real y = j*dx_ls[1];,
                                  Real z = k*dx_ls[2]);
-#if (__CUDACC_VER_MAJOR__ != 9) || (__CUDACC_VER_MINOR__ != 2)
                     Real min_dist2 = std::numeric_limits<Real>::max();
-#else
-                    Real min_dist2 = 3.4e38_rt;
-#endif
                     int i_nearest = 0;
                     for (int ifac  = 0; ifac < ncutcells; ++ifac) {
                         AMREX_D_TERM(Real cx = p_facets[ifac][0];,

--- a/Src/EB/AMReX_algoim_K.H
+++ b/Src/EB/AMReX_algoim_K.H
@@ -272,11 +272,7 @@ struct ImplicitIntegral
     AMREX_GPU_HOST_DEVICE
     bool prune () noexcept
     {
-#if !defined(__CUDACC__) || (__CUDACC_VER_MAJOR__ != 9) || (__CUDACC_VER_MINOR__ != 2)
         static constexpr Real eps = std::numeric_limits<Real>::epsilon();
-#else
-        static constexpr Real eps = DBL_EPSILON;
-#endif
         static constexpr Real almostone = 1.0-10.*eps;
 
         for (int i = 0; i < psiCount; )
@@ -440,11 +436,7 @@ struct ImplicitIntegral
         roots[nroots++] = x_max;
 
         // In rare cases, degenerate segments can be found, filter out with a tolerance
-#if !defined(__CUDACC__) || (__CUDACC_VER_MAJOR__ != 9) || (__CUDACC_VER_MINOR__ != 2)
         static constexpr Real eps = std::numeric_limits<Real>::epsilon();
-#else
-        static constexpr Real eps = DBL_EPSILON;
-#endif
         constexpr Real tol = 50.0*eps;
 
         // Loop over segments of divided interval

--- a/Src/Extern/SUNDIALS/AMReX_NVector_MultiFab.cpp
+++ b/Src/Extern/SUNDIALS/AMReX_NVector_MultiFab.cpp
@@ -720,11 +720,7 @@ amrex::Real N_VMinQuotient_MultiFab(N_Vector num, N_Vector denom)
     Real min = amrex::ReduceMin(*mf_num, *mf_denom, nghost,
                  [=] AMREX_GPU_HOST_DEVICE (Box const& bx, Array4<Real const> const& num_fab, Array4<Real const> const& denom_fab) -> Real
     {
-#if !defined(__CUDACC__) || (__CUDACC_VER_MAJOR__ != 9) || (__CUDACC_VER_MINOR__ != 2)
          Real min_loc = std::numeric_limits<Real>::max();
-#else
-         Real min_loc = Real(1.e37);
-#endif
          const auto lo = lbound(bx);
          const auto hi = ubound(bx);
 

--- a/Tests/GPU/CNS/Source/CNS_K.H
+++ b/Tests/GPU/CNS/Source/CNS_K.H
@@ -20,11 +20,7 @@ cns_estdt (amrex::Box const& bx, amrex::Array4<Real const> const& state,
 
     const auto lo = amrex::lbound(bx);
     const auto hi = amrex::ubound(bx);
-#if !defined(__CUDACC__) || (__CUDACC_VER_MAJOR__ != 9) || (__CUDACC_VER_MINOR__ != 2)
     Real dt = std::numeric_limits<Real>::max();
-#else
-    Real dt = Real(1.e37);
-#endif
 
     for         (int k = lo.z; k <= hi.z; ++k) {
         for     (int j = lo.y; j <= hi.y; ++j) {

--- a/Tools/CMake/AMReX_SetupCUDA.cmake
+++ b/Tools/CMake/AMReX_SetupCUDA.cmake
@@ -17,7 +17,7 @@ endif ()
 # Check CUDA compiler and host compiler
 #
 include(AMReXUtils)
-set_mininum_compiler_version(CUDA NVIDIA 9.0)
+set_mininum_compiler_version(CUDA NVIDIA 10.0)
 check_cuda_host_compiler()
 
 #

--- a/Tools/GNUMake/comps/nvcc.mak
+++ b/Tools/GNUMake/comps/nvcc.mak
@@ -10,11 +10,11 @@ else
   nvcc_minor_version := 9
 endif
 
-# Disallow CUDA toolkit versions < 8.0.
+# Disallow CUDA toolkit versions < 10
 
-nvcc_major_lt_8 = $(shell expr $(nvcc_major_version) \< 8)
-ifeq ($(nvcc_major_lt_8),1)
-  $(error Your nvcc version is $(nvcc_version). This is unsupported. Please use CUDA toolkit version 8.0 or newer.)
+nvcc_major_lt_10 = $(shell expr $(nvcc_major_version) \< 10)
+ifeq ($(nvcc_major_lt_10),1)
+  $(error Your nvcc version is $(nvcc_version). This is unsupported. Please use CUDA toolkit version 10.0 or newer.)
 endif
 
 nvcc_forward_unknowns = 0
@@ -192,13 +192,6 @@ ifeq ($(USE_GPU_RDC),TRUE)
 else
   CXXFLAGS += -c
   CFLAGS   += -c
-endif
-
-ifeq ($(nvcc_version),9.2)
-  # relaxed constexpr not supported
-  ifeq ($(USE_EB),TRUE)
-    $(error Cuda 9.2 is not supported with USE_EB=TRUE. Use 9.1 or 10.0 instead.)
-  endif
 endif
 
 CXX = nvcc


### PR DESCRIPTION
* Modify CI to test CUDA 10.2 instead of CUDA 9.2.

* Remove workarounds for CUDA 9.2

* No need to test for CUDA >= 10.

* Update Documentation.

* Update GNU Make and CMake.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
