### PR TITLE
Use BL_PROFILE rather than explicit NVTX region in Device::Initialize

### DIFF
--- a/Src/Base/AMReX.cpp
+++ b/Src/Base/AMReX.cpp
@@ -366,6 +366,7 @@ amrex::Initialize (int& argc, char**& argv, bool build_parm_parse,
     }
 
     BL_PROFILE_INITIALIZE();
+    BL_TINY_PROFILE_INITIALIZE();
 
 #ifndef BL_AMRPROF
     if (build_parm_parse)
@@ -559,8 +560,6 @@ amrex::Initialize (int& argc, char**& argv, bool build_parm_parse,
 
         amrex::Print() << "AMReX (" << amrex::Version() << ") initialized" << std::endl;
     }
-
-    BL_TINY_PROFILE_INITIALIZE();
 
     AMReX::push(new AMReX());
     return AMReX::top();

--- a/Src/Base/AMReX_GpuDevice.cpp
+++ b/Src/Base/AMReX_GpuDevice.cpp
@@ -121,17 +121,7 @@ namespace {
 void
 Device::Initialize ()
 {
-
-#if defined(AMREX_USE_CUDA) && (defined(AMREX_PROFILING) || defined(AMREX_TINY_PROFILING))
-    // Wrap cuda init to identify it appropriately in nvvp.
-    // Note: first substantial cuda call may cause a lengthy
-    // cuda API and cuda driver API initialization that will
-    // be captured by the profiler. It a necessary, system
-    // dependent step that is unavoidable.
-    nvtxRangeId_t nvtx_init;
-    const char* pname = "initialize_device";
-    nvtx_init = nvtxRangeStartA(pname);
-#endif
+    BL_PROFILE("Device::Initialize()");
 
     ParmParse ppamrex("amrex");
     ppamrex.queryAdd("max_gpu_streams", max_gpu_streams);
@@ -318,9 +308,6 @@ Device::Initialize ()
     delete[] recvbuf;
 #endif
 
-#if (defined(AMREX_PROFILING) || defined(AMREX_TINY_PROFILING))
-    nvtxRangeEnd(nvtx_init);
-#endif
     if (amrex::Verbose()) {
 #if defined(AMREX_USE_MPI) && (__CUDACC_VER_MAJOR__ >= 10)
         if (num_devices_used == ParallelDescriptor::NProcs())


### PR DESCRIPTION
## Summary

BL_PROFILE injects NVTX regions automatically when TINY_PROFILE=TRUE and USE_CUDA=TRUE, so there's no longer need to explicitly add one.

The TinyProfiler initialization is also moved up to be at the same time as the full profiler initialization so that this is actually captured.

## Additional background

I think we didn't yet have NVTX support in BL_PROFILE when this code was first added a few years ago.

The fact that TinyProfiler initialization was done at the end of AMReX initialization was added in commit f02acdce177f3c9fa03b510ffefa7dbe7538e945, and the comment in the commit was that this was to avoid costly profiling of the initialization activities, but actually starting the TinyProfiler later is orthogonal to whether the profiler (Nsight Systems) records all of the initialization activities; if that needs to be controlled, it can be done by using the option `nsys profile -c cudaProfilerApi`; the `Device::profilerStart()` call at the end of Device::Initialize() will then take care of starting CUDA profiling.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
