### PR TITLE
Eb flow diffusive solve

### DIFF
--- a/Src/LinearSolvers/MLMG/AMReX_MLEBTensorOp.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBTensorOp.H
@@ -57,6 +57,7 @@ public:
 
     void setEBShearViscosity (int amrlev, MultiFab const& eta);
     void setEBShearViscosity (int amrlev, Real eta);
+    void setEBShearViscosityWithInflow (int amrlev, MultiFab const& eta, MultiFab const& eb_vel);
 
     void setEBBulkViscosity (int amrlev, MultiFab const& kappa);
     void setEBBulkViscosity (int amrlev, Real eta);

--- a/Src/LinearSolvers/MLMG/AMReX_MLEBTensor_2D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBTensor_2D_K.H
@@ -109,7 +109,7 @@ void mlebtensor_cross_terms (Box const& box, Array4<Real> const& Ax,
                              Array4<Real const> const& fx,
                              Array4<Real const> const& fy,
                              Array4<Real const> const& vel,
-//                             Array4<Real const> const& velb,
+                             Array4<Real const> const& velb,
                              Array4<Real const> const& etab,
                              Array4<Real const> const& kapb,
                              Array4<int const> const& ccm,
@@ -120,7 +120,7 @@ void mlebtensor_cross_terms (Box const& box, Array4<Real> const& Ax,
                              Array4<Real const> const& fcx,
                              Array4<Real const> const& fcy,
                              Array4<Real const> const& bc,
-//                             int is_dirichlet, int is_inhomog,
+                             int is_dirichlet, int is_inhomog,
                              GpuArray<Real,AMREX_SPACEDIM> const& dxinv,
                              Real bscalar) noexcept
 {
@@ -180,7 +180,7 @@ void mlebtensor_cross_terms (Box const& box, Array4<Real> const& Ax,
                 Real kappa = vol(i,j,0);
                 Real feb_0 = 0.0;
                 Real feb_1 = 0.0;
-//                if (is_dirichlet) {
+                if (is_dirichlet) {
                 {
                     Real dapx = apx(i+1,j,0)-apx(i,j,0);
                     Real dapy = apy(i,j+1,0)-apy(i,j,0);
@@ -189,12 +189,11 @@ void mlebtensor_cross_terms (Box const& box, Array4<Real> const& Ax,
                     Real anrmy = -dapy * anorminv;
 
                     Real velb_0 = 0, velb_1 = 0;
-#if 0
+
                     if (is_inhomog) {
                         velb_0 = velb(i,j,0,0);
                         velb_1 = velb(i,j,0,1);
                     }
-#endif
 
                     Real dx_eb = amrex::max(0.3, (kappa*kappa-0.25)/(2.*kappa));
                     Real dg = dx_eb / amrex::max(amrex::Math::abs(anrmx),amrex::Math::abs(anrmy));

--- a/Src/LinearSolvers/MLMG/AMReX_MLEBTensor_2D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBTensor_2D_K.H
@@ -120,7 +120,7 @@ void mlebtensor_cross_terms (Box const& box, Array4<Real> const& Ax,
                              Array4<Real const> const& fcx,
                              Array4<Real const> const& fcy,
                              Array4<Real const> const& bc,
-                             int is_dirichlet, int is_inhomog,
+                             bool is_dirichlet, bool is_inhomog,
                              GpuArray<Real,AMREX_SPACEDIM> const& dxinv,
                              Real bscalar) noexcept
 {

--- a/Src/LinearSolvers/MLMG/AMReX_MLEBTensor_2D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBTensor_2D_K.H
@@ -180,7 +180,7 @@ void mlebtensor_cross_terms (Box const& box, Array4<Real> const& Ax,
                 Real kappa = vol(i,j,0);
                 Real feb_0 = 0.0;
                 Real feb_1 = 0.0;
-                if (is_dirichlet) {
+                if (is_dirichlet)
                 {
                     Real dapx = apx(i+1,j,0)-apx(i,j,0);
                     Real dapy = apy(i,j+1,0)-apy(i,j,0);

--- a/Src/LinearSolvers/MLMG/AMReX_MLEBTensor_3D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBTensor_3D_K.H
@@ -220,7 +220,7 @@ void mlebtensor_cross_terms (Box const& box, Array4<Real> const& Ax,
                              Array4<Real const> const& fcy,
                              Array4<Real const> const& fcz,
                              Array4<Real const> const& bc,
-                             int is_dirichlet, int is_inhomog,
+                             bool is_dirichlet, bool is_inhomog,
                              GpuArray<Real,AMREX_SPACEDIM> const& dxinv,
                              Real bscalar) noexcept
 {

--- a/Src/LinearSolvers/MLMG/AMReX_MLEBTensor_3D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBTensor_3D_K.H
@@ -207,7 +207,7 @@ void mlebtensor_cross_terms (Box const& box, Array4<Real> const& Ax,
                              Array4<Real const> const& fy,
                              Array4<Real const> const& fz,
                              Array4<Real const> const& vel,
-//                             Array4<Real const> const& velb,
+                             Array4<Real const> const& velb,
                              Array4<Real const> const& etab,
                              Array4<Real const> const& kapb,
                              Array4<int const> const& ccm,
@@ -220,7 +220,7 @@ void mlebtensor_cross_terms (Box const& box, Array4<Real> const& Ax,
                              Array4<Real const> const& fcy,
                              Array4<Real const> const& fcz,
                              Array4<Real const> const& bc,
-//                             int is_dirichlet, int is_inhomog,
+                             int is_dirichlet, int is_inhomog,
                              GpuArray<Real,AMREX_SPACEDIM> const& dxinv,
                              Real bscalar) noexcept
 {
@@ -384,7 +384,8 @@ void mlebtensor_cross_terms (Box const& box, Array4<Real> const& Ax,
                     Real feb_0 = 0.0;
                     Real feb_1 = 0.0;
                     Real feb_2 = 0.0;
-                    // if (is_dirichlet)
+
+                    if (is_dirichlet)
                     {
                         Real dapx = apx(i+1,j,k)-apx(i,j,k);
                         Real dapy = apy(i,j+1,k)-apy(i,j,k);
@@ -395,13 +396,12 @@ void mlebtensor_cross_terms (Box const& box, Array4<Real> const& Ax,
                         Real anrmz = -dapz * anorminv;
 
                         Real velb_0 = 0, velb_1 = 0, velb_2 = 0;
-#if 0
+
                         if (is_inhomog) {
                             velb_0 = velb(i,j,k,0);
                             velb_1 = velb(i,j,k,1);
                             velb_2 = velb(i,j,k,2);
                         }
-#endif
 
                         Real dx_eb = amrex::max(0.3, (kappa*kappa-0.25)/(2.*kappa));
                         Real dg = dx_eb / amrex::max(amrex::Math::abs(anrmx),


### PR DESCRIPTION
## Summary
Expose a new method `setEBShearViscosityWithInflow` in MLEBTensorOp that will allow us to set an inflow velocity on the EB. Requires adding back support for `is_inhomog` flag in `mlebtensor_cross_terms`.

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
