### PR TITLE
Switch nvtxRangeStart to nvtxRangePush

### DIFF
--- a/Src/Base/AMReX_GpuDevice.cpp
+++ b/Src/Base/AMReX_GpuDevice.cpp
@@ -128,9 +128,7 @@ Device::Initialize ()
     // cuda API and cuda driver API initialization that will
     // be captured by the profiler. It a necessary, system
     // dependent step that is unavoidable.
-    nvtxRangeId_t nvtx_init;
-    const char* pname = "initialize_device";
-    nvtx_init = nvtxRangeStartA(pname);
+    nvtxRangePush("initialize_device");
 #endif
 
     ParmParse ppamrex("amrex");
@@ -317,7 +315,7 @@ Device::Initialize ()
     delete[] recvbuf;
 
 #if (defined(AMREX_PROFILING) || defined(AMREX_TINY_PROFILING))
-    nvtxRangeEnd(nvtx_init);
+    nvtxRangePop();
 #endif
     if (amrex::Verbose()) {
 #if defined(AMREX_USE_MPI)


### PR DESCRIPTION
## Summary

This brings this profiling region in line with BL_PROFILE, which also uses nvtxRangePush.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
