### PR TITLE
Revert "Turn on managed memory by default in The_Arena for HIP (#2734)"

### DIFF
--- a/Src/Base/AMReX_Arena.cpp
+++ b/Src/Base/AMReX_Arena.cpp
@@ -43,7 +43,11 @@ namespace {
     Long the_managed_arena_release_threshold = std::numeric_limits<Long>::max();
     Long the_pinned_arena_release_threshold = std::numeric_limits<Long>::max();
     Long the_async_arena_release_threshold = std::numeric_limits<Long>::max();
+#ifdef AMREX_USE_HIP
+    bool the_arena_is_managed = false; // xxxxx HIP FIX HERE
+#else
     bool the_arena_is_managed = true;
+#endif
     bool abort_on_out_of_gpu_memory = false;
 }
 


### PR DESCRIPTION
This reverts commit 09e8b9b1179e3e3d7b9b6e288ebe6d2864a8cc67.

The managed memory on AMD GPUs is still extremely slow.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
