### PR TITLE
Avoid the use of null stream

### DIFF
--- a/Docs/sphinx_documentation/source/GPU.rst
+++ b/Docs/sphinx_documentation/source/GPU.rst
@@ -18,7 +18,7 @@ for AMD and DPC++ for Intel. This will be designated with ``CUDA/HIP/DPC++``
 throughout the documentation.  However, application teams can also use
 OpenACC or OpenMP in their individual codes.
 
-At this time, AMReX does not support cross-native language compliation
+At this time, AMReX does not support cross-native language compilation
 (HIP for non-AMD systems and DPC++ for non Intel systems).  It may work with
 a given version, but AMReX does not track or guarantee such functionality.
 
@@ -1250,7 +1250,7 @@ the destructor of :cpp:`MFIter`.  This ensures that all GPU work
 inside of an :cpp:`MFIter` loop will complete before code outside of
 the loop is executed. Any CUDA kernel launches made outside of an
 :cpp:`MFIter` loop must ensure appropriate device synchronization
-occurs. This can be done by calling :cpp:`Gpu::synchronize()`.
+occurs. This can be done by calling :cpp:`Gpu::streamSynchronize()`.
 
 CUDA supports multiple streams and kernels. Kernels launched in the
 same stream are executed sequentially, but different streams of kernel
@@ -1355,6 +1355,48 @@ will show little improvement or even perform worse. So, this conditional stateme
 should be added to MFIter loops that contain GPU work, unless users specifically test
 the performance or are designing more complex workflows that require OpenMP.
 
+.. _sec:gpu:stream
+
+Stream and Synchronization
+==========================
+
+As mentioned in Section :ref:`sec:gpu:overview`, AMReX uses a number of GPU
+streams that are either CUDA streams or HIP streams or SYCL queues.  Many
+GPU functions (e.g., :cpp:`ParallelFor` and :cpp:`Gpu::copyAsync`) are
+asynchronous with respect to the host.  To facilitate synchronization that
+is sometimes necessary, AMReX provides :cpp:`Gpu::streamSynchronize()` and
+:cpp:`Gpu::streamSynchronizeAll()` to synchronize the current stream and all
+AMReX streams, respectively.  For performance reasons, one should try to
+minimize the number of synchronization calls.  For example,
+
+.. highlight:: c++
+
+::
+
+   // The synchronous version is NOT recommended
+   Gpu::copy(Gpu::deviceToHost, ....);
+   Gpu::copy(Gpu::deviceToHost, ....);
+   Gpu::copy(Gpu::deviceToHost, ....);
+
+   // NOT recommended because of unnecessary synchronization
+   Gpu::copyAsync(Gpu::deviceToHost, ....);
+   Gpu::streamSynchronize();
+   Gpu::copyAsync(Gpu::deviceToHost, ....);
+   Gpu::streamSynchronize();
+   Gpu::copyAsync(Gpu::deviceToHost, ....);
+   Gpu::streamSynchronize();
+
+   // recommended
+   Gpu::copyAsync(Gpu::deviceToHost, ....);
+   Gpu::copyAsync(Gpu::deviceToHost, ....);
+   Gpu::copyAsync(Gpu::deviceToHost, ....);
+   Gpu::streamSynchronize();
+
+In addition to stream synchronization, there is also
+`:cpp:Gpu::synchronize()` that will perform a device wide synchronization.
+However, a device wide synchronization is usually an overkill and it might
+interfere with other libraries (e.g., MPI).
+
 .. _sec:gpu:example:
 
 An Example of Migrating to GPU
@@ -1450,8 +1492,8 @@ portable way.
 .. _sec:gpu:assertion:
 
 
-Assertions, Error Checking and Synchronization
-================================================
+Assertions and Error Checking
+=============================
 
 To help debugging, we often use :cpp:`amrex::Assert` and
 :cpp:`amrex::Abort`.  These functions are GPU safe and can be used in
@@ -1474,10 +1516,11 @@ However, due to asynchronicity, determining the source of the error
 can be difficult.  Even if GPU kernels launched earlier in the code
 result in a CUDA error, the error may not be output at a nearby call to
 :cpp:`AMREX_GPU_ERROR_CHECK()` by the CPU.  When tracking down a CUDA
-launch error, :cpp:`Gpu::synchronize()` and
-:cpp:`Gpu::streamSynchronize()` can be used to synchronize
-the device or the CUDA stream, respectively, and track down the specific
-launch that causes the error.
+launch error, :cpp:`Gpu::synchronize()`,
+:cpp:`Gpu::streamSynchronize()`, or :cpp:`Gpu::streamSynchronizeAll()` can
+be used to synchronize the device, the current GPU stream, or all GPU
+streams, respectively, and track down the specific launch that causes the
+error.
 
 .. ===================================================================
 

--- a/Docs/sphinx_documentation/source/GPU.rst
+++ b/Docs/sphinx_documentation/source/GPU.rst
@@ -1393,8 +1393,8 @@ minimize the number of synchronization calls.  For example,
    Gpu::streamSynchronize();
 
 In addition to stream synchronization, there is also
-`:cpp:Gpu::synchronize()` that will perform a device wide synchronization.
-However, a device wide synchronization is usually an overkill and it might
+:cpp:`Gpu::synchronize()` that will perform a device wide synchronization.
+However, a device wide synchronization is usually too excessive and it might
 interfere with other libraries (e.g., MPI).
 
 .. _sec:gpu:example:

--- a/Src/Amr/AMReX_AmrLevel.cpp
+++ b/Src/Amr/AMReX_AmrLevel.cpp
@@ -1495,13 +1495,13 @@ FillPatchIteratorHelper::fill (FArrayBox& fab,
                                          dcomp,
                                          m_scomp,
                                          m_ncomp);
-        Gpu::synchronize();  // In case this runs on GPU
+        Gpu::streamSynchronize();  // In case this runs on GPU
     }
 
     if (m_FixUpCorners)
     {
         FixUpPhysCorners(fab,m_amrlevel,m_index,m_time,m_scomp,dcomp,m_ncomp);
-        Gpu::synchronize();  // In case this runs on GPU
+        Gpu::streamSynchronize();  // In case this runs on GPU
     }
 }
 

--- a/Src/Amr/AMReX_StateData.cpp
+++ b/Src/Amr/AMReX_StateData.cpp
@@ -511,9 +511,9 @@ StateData::FillBoundary (FArrayBox&     dest,
     }
 
 #ifdef AMREX_USE_GPU
-    // Add a synchronize here in case the user code launched kernels
+    // Add a streamSynchronize here in case the user code launched kernels
     // to handle the boundary fills.
-    Gpu::synchronize();
+    Gpu::streamSynchronize();
 #endif
 }
 

--- a/Src/AmrCore/AMReX_FluxRegister.cpp
+++ b/Src/AmrCore/AMReX_FluxRegister.cpp
@@ -721,7 +721,7 @@ FluxRegister::ClearInternalBorders (const Geometry& geom)
     }
 
 #ifdef AMREX_USE_GPU
-    // There is Gpu::synchronize in Parallelfor below internally.
+    // There is Gpu::streamSynchronize in Parallelfor below internally.
     ParallelFor(tags, nc,
     [=] AMREX_GPU_DEVICE (int i, int j, int k, int n, Array4BoxTag<Real> const& tag)
     {

--- a/Src/AmrCore/AMReX_TagBox.cpp
+++ b/Src/AmrCore/AMReX_TagBox.cpp
@@ -503,10 +503,7 @@ TagBoxArray::local_collate_gpu (Gpu::PinnedVector<IntVect>& v) const
 
     PODVector<int,DeviceArenaAllocator<int> > dv_tags_offset(ntotblocks);
     int* dp_tags_offset = dv_tags_offset.data();
-    Gpu::htod_memcpy(dp_tags_offset, hv_tags_offset.data(), ntotblocks*sizeof(int));
-#ifdef AMREX_USE_DPCPP
-    Gpu::synchronize();
-#endif
+    Gpu::htod_memcpy_async(dp_tags_offset, hv_tags_offset.data(), ntotblocks*sizeof(int));
 
     PODVector<IntVect,DeviceArenaAllocator<IntVect> > dv_tags(ntotaltags);
     IntVect* dp_tags = dv_tags.data();

--- a/Src/Base/AMReX.cpp
+++ b/Src/Base/AMReX.cpp
@@ -603,7 +603,7 @@ void
 amrex::Finalize (amrex::AMReX* pamrex)
 {
 #ifdef AMREX_USE_GPU
-    Gpu::synchronize();
+    Gpu::streamSynchronizeAll();
 #endif
 
     AMReX::erase(pamrex);

--- a/Src/Base/AMReX_BlockMutex.cpp
+++ b/Src/Base/AMReX_BlockMutex.cpp
@@ -9,7 +9,7 @@ void BlockMutex::init_states (state_t* state, int N) noexcept {
     amrex::ignore_unused(state,N);
     amrex::Abort("xxxxx DPCPP todo");
 #else
-    amrex::launch((N+255)/256, 256, Gpu::nullStream(),
+    amrex::launch((N+255)/256, 256, Gpu::gpuStream(),
     [=] AMREX_GPU_DEVICE () noexcept
     {
         int i = threadIdx.x + blockIdx.x*blockDim.x;
@@ -38,4 +38,3 @@ BlockMutex::~BlockMutex () {
 #endif
 
 }
-

--- a/Src/Base/AMReX_FBI.H
+++ b/Src/Base/AMReX_FBI.H
@@ -775,11 +775,11 @@ FabArray<FAB>::pack_send_buffer_gpu (FabArray<FAB> const& src, int scomp, int nc
     detail::fab_to_fab<BUF, value_type>(snd_copy_tags, scomp, 0, ncomp,
                                         detail::CellStore<BUF, value_type>());
 
-    // There is Gpu::synchronize in fab_to_fab.
+    // There is Gpu::streamSynchronize in fab_to_fab.
 
     if (pbuffer != send_data[0]) {
         Gpu::copyAsync(Gpu::deviceToHost,pbuffer,pbuffer+szbuffer,send_data[0]);
-        Gpu::synchronize();
+        Gpu::streamSynchronize();
         The_Arena()->free(pbuffer);
     }
 }
@@ -808,7 +808,7 @@ FabArray<FAB>::unpack_recv_buffer_gpu (FabArray<FAB>& dst, int dcomp, int ncomp,
         szbuffer = (recv_data[N_rcvs-1]-recv_data[0]) + recv_size[N_rcvs-1];
         pbuffer = (char*)The_Arena()->alloc(szbuffer);
         Gpu::copyAsync(Gpu::hostToDevice,recv_data[0],recv_data[0]+szbuffer,pbuffer);
-        Gpu::synchronize();
+        Gpu::streamSynchronize();
     }
 #endif
 
@@ -885,7 +885,7 @@ FabArray<FAB>::unpack_recv_buffer_gpu (FabArray<FAB>& dst, int dcomp, int ncomp,
         }
     }
 
-    // There is Gpu::synchronize in fab_to_fab.
+    // There is Gpu::streamSynchronize in fab_to_fab.
 
     if (pbuffer != recv_data[0]) {
         The_Arena()->free(pbuffer);

--- a/Src/Base/AMReX_FabArray.H
+++ b/Src/Base/AMReX_FabArray.H
@@ -1807,7 +1807,7 @@ FabArray<FAB>::define (const BoxArray&            bxs,
 
     if(info.alloc) {
         AllocFabs(*m_factory, m_dallocator.m_arena, info.tags);
-        Gpu::synchronize();
+        Gpu::streamSynchronizeAll();
 #ifdef BL_USE_TEAM
         ParallelDescriptor::MyTeam().MemoryBarrier();
 #endif

--- a/Src/Base/AMReX_GpuAsyncArray.H
+++ b/Src/Base/AMReX_GpuAsyncArray.H
@@ -124,7 +124,7 @@ public:
 #ifdef AMREX_USE_GPU
         if (d_data)
         {
-            Gpu::dtoh_memcpy_async(h_p, d_data, n*sizeof(T));
+            Gpu::dtoh_memcpy(h_p, d_data, n*sizeof(T));
         }
         else
 #endif

--- a/Src/Base/AMReX_GpuBuffer.H
+++ b/Src/Base/AMReX_GpuBuffer.H
@@ -33,9 +33,6 @@ public:
         {
             d_data = static_cast<T*>(The_Arena()->alloc(m_size*sizeof(T)));
             Gpu::htod_memcpy_async(d_data, h_data, m_size*sizeof(T));
-#ifdef AMREX_USE_DPCPP
-            if (Gpu::onNullStream()) Gpu::synchronize();
-#endif
         }
 #endif
     }
@@ -55,9 +52,6 @@ public:
         {
             d_data = static_cast<T*>(The_Arena()->alloc(m_size*sizeof(T)));
             Gpu::htod_memcpy_async(d_data, h_data, m_size*sizeof(T));
-#ifdef AMREX_USE_DPCPP
-            if (Gpu::onNullStream()) Gpu::synchronize();
-#endif
         }
 #endif
     }

--- a/Src/Base/AMReX_GpuContainers.H
+++ b/Src/Base/AMReX_GpuContainers.H
@@ -222,7 +222,7 @@ namespace Gpu {
      *
      * Example usage:
      *
-     *    Gpu::copy(Gpu::hostToDevice, a.begin(), a.end(), b.begin());
+     *    Gpu::copyAsync(Gpu::hostToDevice, a.begin(), a.end(), b.begin());
      */
     template<class InIter, class OutIter>
     void copyAsync (HostToDevice, InIter begin, InIter end, OutIter result) noexcept
@@ -256,7 +256,7 @@ namespace Gpu {
      *
      * Example usage:
      *
-     *    Gpu::copy(Gpu::deviceToHost, a.begin(), a.end(), b.begin());
+     *    Gpu::copyAsync(Gpu::deviceToHost, a.begin(), a.end(), b.begin());
      */
     template<class InIter, class OutIter>
     void copyAsync (DeviceToHost, InIter begin, InIter end, OutIter result) noexcept
@@ -290,7 +290,7 @@ namespace Gpu {
      *
      * Example usage:
      *
-     *    Gpu::copy(Gpu::deviceToDevice, a.begin(), a.end(), b.begin());
+     *    Gpu::copyAsync(Gpu::deviceToDevice, a.begin(), a.end(), b.begin());
      */
     template<class InIter, class OutIter>
     void copyAsync (DeviceToDevice, InIter begin, InIter end, OutIter result) noexcept
@@ -335,7 +335,7 @@ namespace Gpu {
 #endif
 #endif
 
-        Gpu::synchronize();
+        Gpu::streamSynchronize();
     }
 
     /**
@@ -366,7 +366,7 @@ namespace Gpu {
 #endif
 #endif
 
-        Gpu::synchronize();
+        Gpu::streamSynchronize();
     }
 
 }}

--- a/Src/Base/AMReX_GpuDevice.H
+++ b/Src/Base/AMReX_GpuDevice.H
@@ -53,17 +53,13 @@ public:
 
 #if defined(AMREX_USE_GPU)
     static gpuStream_t gpuStream () noexcept { return gpu_stream[OpenMP::get_thread_num()]; }
-    static gpuStream_t nullStream () noexcept { return gpu_default_stream; }
 #ifdef AMREX_USE_CUDA
     /** for backward compatibility */
     static cudaStream_t cudaStream () noexcept { return gpu_stream[OpenMP::get_thread_num()]; }
 #endif
 #ifdef AMREX_USE_DPCPP
-    static sycl::queue& nullQueue () noexcept { return *(gpu_default_stream.queue); }
     static sycl::queue& streamQueue () noexcept { return *(gpu_stream[OpenMP::get_thread_num()].queue); }
     static sycl::queue& streamQueue (int i) noexcept { return *(gpu_stream_pool[i].queue); }
-    static bool onNullStream () noexcept { return gpu_stream[OpenMP::get_thread_num()] == gpu_default_stream; }
-    static bool onNullStream (gpuStream_t stream) noexcept { return stream == gpu_default_stream; }
 #endif
 #endif
 
@@ -90,13 +86,16 @@ public:
     static void synchronize () noexcept;
 
     /**
-     * Halt execution of code until GPU stream has finished processing all
+     * Halt execution of code until the current AMReX GPU stream has finished processing all
      * previously requested tasks.
      */
     static void streamSynchronize () noexcept;
-#ifdef AMREX_USE_DPCPP
-    static void nonNullStreamSynchronize () noexcept;
-#endif
+
+    /**
+     * Halt execution of code until all AMReX GPU streams have finished processing all
+     * previously requested tasks.
+     */
+    static void streamSynchronizeAll () noexcept;
 
 #if defined(__CUDACC__)
     /**  Generic graph selection. These should be called by users.  */
@@ -176,9 +175,12 @@ private:
     static dim3 numThreadsMin;
     static dim3 numBlocksOverride, numThreadsOverride;
 
+    // We build gpu_default_stream and gpu_stream_pool.
+    // The non-owning gpu_stream is used to store the current stream that will be used.
+    // gpu_stream is a vector so that it's thread safe to write to it.
     static gpuStream_t gpu_default_stream;
-    static Vector<gpuStream_t> gpu_stream_pool;
-    static Vector<gpuStream_t> gpu_stream;
+    static Vector<gpuStream_t> gpu_stream_pool; // The size of this is max_gpu_stream
+    static Vector<gpuStream_t> gpu_stream; // The size of this is omp_max_threads
     static gpuDeviceProp_t device_prop;
     static int memory_pools_supported;
     static unsigned int max_blocks_per_launch;
@@ -197,12 +199,6 @@ inline gpuStream_t
 gpuStream () noexcept
 {
     return Device::gpuStream();
-}
-
-inline gpuStream_t
-nullStream () noexcept
-{
-    return Device::nullStream();
 }
 #endif
 
@@ -224,84 +220,19 @@ streamSynchronize () noexcept
     Device::streamSynchronize();
 }
 
-#ifdef AMREX_USE_DPCPP
 inline void
-nonNullStreamSynchronize () noexcept
+streamSynchronizeAll () noexcept
 {
-    Device::nonNullStreamSynchronize();
+    Device::streamSynchronizeAll();
 }
-#endif
 
 #ifdef AMREX_USE_GPU
-
-inline void
-htod_memcpy (void* p_d, const void* p_h, const std::size_t sz) noexcept
-{
-    if (sz == 0) return;
-#ifdef AMREX_USE_DPCPP
-    Device::nonNullStreamSynchronize();
-    auto& q = Device::nullQueue();
-    q.submit([&] (sycl::handler& h) { h.memcpy(p_d, p_h, sz); });
-    try {
-        q.wait_and_throw();
-    } catch (sycl::exception const& ex) {
-        amrex::Abort(std::string("htod_memcpy: ")+ex.what()+"!!!!!");
-    }
-    if (Device::onNullStream()) Gpu::synchronize();
-#else
-    AMREX_HIP_OR_CUDA(
-        AMREX_HIP_SAFE_CALL(hipMemcpy(p_d, p_h, sz, hipMemcpyHostToDevice));,
-        AMREX_CUDA_SAFE_CALL(cudaMemcpy(p_d, p_h, sz, cudaMemcpyHostToDevice)); )
-#endif
-}
-
-inline void
-dtoh_memcpy (void* p_h, const void* p_d, const std::size_t sz) noexcept
-{
-    if (sz == 0) return;
-#ifdef AMREX_USE_DPCPP
-    Device::nonNullStreamSynchronize();
-    auto& q = Device::nullQueue();
-    q.submit([&] (sycl::handler& h) { h.memcpy(p_h, p_d, sz); });
-    try {
-        q.wait_and_throw();
-    } catch (sycl::exception const& ex) {
-        amrex::Abort(std::string("dtoh_memcpy: ")+ex.what()+"!!!!!");
-    }
-    Gpu::synchronize(); // To mimic cuda behavior
-#else
-    AMREX_HIP_OR_CUDA(
-        AMREX_HIP_SAFE_CALL(hipMemcpy(p_h, p_d, sz, hipMemcpyDeviceToHost));,
-        AMREX_CUDA_SAFE_CALL(cudaMemcpy(p_h, p_d, sz, cudaMemcpyDeviceToHost)); )
-#endif
-}
-
-inline void
-dtod_memcpy (void* p_d_dst, const void* p_d_src, const std::size_t sz) noexcept
-{
-    if (sz == 0) return;
-#ifdef AMREX_USE_DPCPP
-    Device::nonNullStreamSynchronize();
-    auto& q = Device::nullQueue();
-    q.submit([&] (sycl::handler& h) { h.memcpy(p_d_dst, p_d_src, sz); });
-    try {
-        q.wait_and_throw();
-    } catch (sycl::exception const& ex) {
-        amrex::Abort(std::string("dtod_memcpy: ")+ex.what()+"!!!!!");
-    }
-#else
-    AMREX_HIP_OR_CUDA(
-        AMREX_HIP_SAFE_CALL(hipMemcpy(p_d_dst, p_d_src, sz, hipMemcpyDeviceToDevice));,
-        AMREX_CUDA_SAFE_CALL(cudaMemcpy(p_d_dst, p_d_src, sz, cudaMemcpyDeviceToDevice)); )
-#endif
-}
 
 inline void
 htod_memcpy_async (void* p_d, const void* p_h, const std::size_t sz) noexcept
 {
     if (sz == 0) return;
 #ifdef AMREX_USE_DPCPP
-    if (Device::onNullStream()) Device::nonNullStreamSynchronize();
     auto& q = Device::streamQueue();
     q.submit([&] (sycl::handler& h) { h.memcpy(p_d, p_h, sz); });
 #else
@@ -316,7 +247,6 @@ dtoh_memcpy_async (void* p_h, const void* p_d, const std::size_t sz) noexcept
 {
     if (sz == 0) return;
 #ifdef AMREX_USE_DPCPP
-    if (Device::onNullStream()) Device::nonNullStreamSynchronize();
     auto& q = Device::streamQueue();
     q.submit([&] (sycl::handler& h) { h.memcpy(p_h, p_d, sz); });
 #else
@@ -331,7 +261,6 @@ dtod_memcpy_async (void* p_d_dst, const void* p_d_src, const std::size_t sz) noe
 {
     if (sz == 0) return;
 #ifdef AMREX_USE_DPCPP
-    if (Device::onNullStream()) Device::nonNullStreamSynchronize();
     auto& q = Device::streamQueue();
     q.submit([&] (sycl::handler& h) { h.memcpy(p_d_dst, p_d_src, sz); });
 #else
@@ -341,20 +270,30 @@ dtod_memcpy_async (void* p_d_dst, const void* p_d_src, const std::size_t sz) noe
 #endif
 }
 
-#endif
-
-#ifdef AMREX_USE_DPCPP
-inline bool
-onNullStream ()
+inline void
+htod_memcpy (void* p_d, const void* p_h, const std::size_t sz) noexcept
 {
-    return Device::onNullStream();
+    if (sz == 0) return;
+    htod_memcpy_async(p_d, p_h, sz);
+    Gpu::streamSynchronize();
 }
 
-inline bool
-onNullStream (gpuStream_t stream)
+inline void
+dtoh_memcpy (void* p_h, const void* p_d, const std::size_t sz) noexcept
 {
-    return Device::onNullStream(stream);
+    if (sz == 0) return;
+    dtoh_memcpy_async(p_h, p_d, sz);
+    Gpu::streamSynchronize();
 }
+
+inline void
+dtod_memcpy (void* p_d_dst, const void* p_d_src, const std::size_t sz) noexcept
+{
+    if (sz == 0) return;
+    dtod_memcpy_async(p_d_dst, p_d_src, sz);
+    Gpu::streamSynchronize();
+}
+
 #endif
 
 }}

--- a/Src/Base/AMReX_GpuLaunchFunctsG.H
+++ b/Src/Base/AMReX_GpuLaunchFunctsG.H
@@ -9,7 +9,6 @@ namespace amrex {
 template <typename L>
 void single_task (gpuStream_t stream, L&& f) noexcept
 {
-    if (Gpu::onNullStream(stream)) Gpu::nonNullStreamSynchronize();
     auto& q = *(stream.queue);
     try {
         q.submit([&] (sycl::handler& h) {
@@ -24,7 +23,6 @@ template<typename L>
 void launch (int nblocks, int nthreads_per_block, std::size_t shared_mem_bytes,
              gpuStream_t stream, L&& f) noexcept
 {
-    if (Gpu::onNullStream(stream)) Gpu::nonNullStreamSynchronize();
     int nthreads_total = nthreads_per_block * nblocks;
     std::size_t shared_mem_numull = (shared_mem_bytes+sizeof(unsigned long long)-1)
         / sizeof(unsigned long long);
@@ -49,7 +47,6 @@ void launch (int nblocks, int nthreads_per_block, std::size_t shared_mem_bytes,
 template<typename L>
 void launch (int nblocks, int nthreads_per_block, gpuStream_t stream, L&& f) noexcept
 {
-    if (Gpu::onNullStream(stream)) Gpu::nonNullStreamSynchronize();
     int nthreads_total = nthreads_per_block * nblocks;
     auto& q = *(stream.queue);
     try {
@@ -72,8 +69,6 @@ void launch (T const& n, L&& f) noexcept
 {
     if (amrex::isEmpty(n)) return;
     const auto ec = Gpu::ExecutionConfig(n);
-    // If we are on default queue, block all other streams
-    if (Gpu::onNullStream()) Gpu::nonNullStreamSynchronize();
     int nthreads_per_block = ec.numThreads.x;
     int nthreads_total = nthreads_per_block * ec.numBlocks.x;
     auto& q = Gpu::Device::streamQueue();
@@ -149,8 +144,6 @@ void ParallelFor (Gpu::KernelInfo const& info, T n, L&& f) noexcept
 {
     if (amrex::isEmpty(n)) return;
     const auto ec = Gpu::ExecutionConfig(n);
-    // If we are on default queue, block all other streams
-    if (Gpu::onNullStream()) Gpu::nonNullStreamSynchronize();
     int nthreads_per_block = ec.numThreads.x;
     int nthreads_total = nthreads_per_block * ec.numBlocks.x;
     auto& q = Gpu::Device::streamQueue();
@@ -203,8 +196,6 @@ void ParallelFor (Gpu::KernelInfo const& info, Box const& box, L&& f) noexcept
     const auto lenxy = len.x*len.y;
     const auto lenx = len.x;
     const auto ec = Gpu::ExecutionConfig(ncells);
-    // If we are on default queue, block all other streams
-    if (Gpu::onNullStream()) Gpu::nonNullStreamSynchronize();
     int nthreads_per_block = ec.numThreads.x;
     int nthreads_total = nthreads_per_block * ec.numBlocks.x;
     auto& q = Gpu::Device::streamQueue();
@@ -269,8 +260,6 @@ void ParallelFor (Gpu::KernelInfo const& info, Box const& box, T ncomp, L&& f) n
     const auto lenxy = len.x*len.y;
     const auto lenx = len.x;
     const auto ec = Gpu::ExecutionConfig(ncells);
-    // If we are on default queue, block all other streams
-    if (Gpu::onNullStream()) Gpu::nonNullStreamSynchronize();
     int nthreads_per_block = ec.numThreads.x;
     int nthreads_total = nthreads_per_block * ec.numBlocks.x;
     auto& q = Gpu::Device::streamQueue();
@@ -331,11 +320,9 @@ void ParallelForRNG (T n, L&& f) noexcept
 {
     if (amrex::isEmpty(n)) return;
     const auto ec = Gpu::ExecutionConfig(n);
-    // If we are on default queue, block all other streams
-    if (Gpu::onNullStream()) Gpu::nonNullStreamSynchronize();
     int nthreads_per_block = ec.numThreads.x;
     int nthreads_total = nthreads_per_block * amrex::min(ec.numBlocks.x,Gpu::Device::maxBlocksPerLaunch());
-    auto& q = Gpu::Device::nullQueue();
+    auto& q = Gpu::Device::streamQueue();
     auto& engdescr = *(getRandEngineDescriptor());
     try {
         q.submit([&] (sycl::handler& h) {
@@ -370,11 +357,9 @@ void ParallelForRNG (Box const& box, L&& f) noexcept
     const auto lenxy = len.x*len.y;
     const auto lenx = len.x;
     const auto ec = Gpu::ExecutionConfig(ncells);
-    // If we are on default queue, block all other streams
-    if (Gpu::onNullStream()) Gpu::nonNullStreamSynchronize();
     int nthreads_per_block = ec.numThreads.x;
     int nthreads_total = nthreads_per_block * amrex::min(ec.numBlocks.x,Gpu::Device::maxBlocksPerLaunch());
-    auto& q = Gpu::Device::nullQueue();
+    auto& q = Gpu::Device::streamQueue();
     auto& engdescr = *(getRandEngineDescriptor());
     try {
         q.submit([&] (sycl::handler& h) {
@@ -416,8 +401,6 @@ void ParallelForRNG (Box const& box, T ncomp, L&& f) noexcept
     const auto lenxy = len.x*len.y;
     const auto lenx = len.x;
     const auto ec = Gpu::ExecutionConfig(ncells);
-    // If we are on default queue, block all other streams
-    if (Gpu::onNullStream()) Gpu::nonNullStreamSynchronize();
     int nthreads_per_block = ec.numThreads.x;
     int nthreads_total = nthreads_per_block * amrex::min(ec.numBlocks.x,Gpu::Device::maxBlocksPerLaunch());
     auto& q = Gpu::Device::streamQueue();
@@ -470,8 +453,6 @@ void ParallelFor (Gpu::KernelInfo const& /*info*/, Box const& box1, Box const& b
     const auto len1x = len1.x;
     const auto len2x = len2.x;
     const auto ec = Gpu::ExecutionConfig(ncells);
-    // If we are on default queue, block all other streams
-    if (Gpu::onNullStream()) Gpu::nonNullStreamSynchronize();
     int nthreads_per_block = ec.numThreads.x;
     int nthreads_total = nthreads_per_block * ec.numBlocks.x;
     auto& q = Gpu::Device::streamQueue();
@@ -533,8 +514,6 @@ void ParallelFor (Gpu::KernelInfo const& /*info*/,
     const auto len2x = len2.x;
     const auto len3x = len3.x;
     const auto ec = Gpu::ExecutionConfig(ncells);
-    // If we are on default queue, block all other streams
-    if (Gpu::onNullStream()) Gpu::nonNullStreamSynchronize();
     int nthreads_per_block = ec.numThreads.x;
     int nthreads_total = nthreads_per_block * ec.numBlocks.x;
     auto& q = Gpu::Device::streamQueue();
@@ -602,8 +581,6 @@ void ParallelFor (Gpu::KernelInfo const& /*info*/,
     const auto len1x = len1.x;
     const auto len2x = len2.x;
     const auto ec = Gpu::ExecutionConfig(ncells);
-    // If we are on default queue, block all other streams
-    if (Gpu::onNullStream()) Gpu::nonNullStreamSynchronize();
     int nthreads_per_block = ec.numThreads.x;
     int nthreads_total = nthreads_per_block * ec.numBlocks.x;
     auto& q = Gpu::Device::streamQueue();
@@ -673,8 +650,6 @@ void ParallelFor (Gpu::KernelInfo const& /*info*/,
     const auto len2x = len2.x;
     const auto len3x = len3.x;
     const auto ec = Gpu::ExecutionConfig(ncells);
-    // If we are on default queue, block all other streams
-    if (Gpu::onNullStream()) Gpu::nonNullStreamSynchronize();
     int nthreads_per_block = ec.numThreads.x;
     int nthreads_total = nthreads_per_block * ec.numBlocks.x;
     auto& q = Gpu::Device::streamQueue();
@@ -897,7 +872,7 @@ ParallelForRNG (T n, L&& f) noexcept
     randState_t* rand_state = getRandState();
     const auto ec = Gpu::ExecutionConfig(n);
     AMREX_LAUNCH_KERNEL(amrex::min(ec.numBlocks.x, Gpu::Device::maxBlocksPerLaunch()),
-                        ec.numThreads, 0, Gpu::nullStream(),  // use null stream
+                        ec.numThreads, 0, Gpu::gpuStream(),
     [=] AMREX_GPU_DEVICE () noexcept {
         int tid = blockDim.x*blockIdx.x+threadIdx.x;
         RandomEngine engine{&(rand_state[tid])};
@@ -905,6 +880,7 @@ ParallelForRNG (T n, L&& f) noexcept
             f(i,engine);
         }
     });
+    Gpu::streamSynchronize(); // To avoid multiple streams using RNG
     AMREX_GPU_ERROR_CHECK();
 }
 
@@ -921,7 +897,7 @@ ParallelForRNG (Box const& box, L&& f) noexcept
     const auto lenx = len.x;
     const auto ec = Gpu::ExecutionConfig(ncells);
     AMREX_LAUNCH_KERNEL(amrex::min(ec.numBlocks.x, Gpu::Device::maxBlocksPerLaunch()),
-                        ec.numThreads, 0, Gpu::nullStream(),  // use null stream
+                        ec.numThreads, 0, Gpu::gpuStream(),
     [=] AMREX_GPU_DEVICE () noexcept {
         int tid = blockDim.x*blockIdx.x+threadIdx.x;
         RandomEngine engine{&(rand_state[tid])};
@@ -935,6 +911,7 @@ ParallelForRNG (Box const& box, L&& f) noexcept
             f(i,j,k,engine);
         }
     });
+    Gpu::streamSynchronize(); // To avoid multiple streams using RNG
     AMREX_GPU_ERROR_CHECK();
 }
 
@@ -951,7 +928,7 @@ ParallelForRNG (Box const& box, T ncomp, L&& f) noexcept
     const auto lenx = len.x;
     const auto ec = Gpu::ExecutionConfig(ncells);
     AMREX_LAUNCH_KERNEL(amrex::min(ec.numBlocks.x, Gpu::Device::maxBlocksPerLaunch()),
-                        ec.numThreads, 0, Gpu::nullStream(), // use null stream
+                        ec.numThreads, 0, Gpu::gpuStream(),
     [=] AMREX_GPU_DEVICE () noexcept {
         int tid = blockDim.x*blockIdx.x+threadIdx.x;
         RandomEngine engine{&(rand_state[tid])};
@@ -967,6 +944,7 @@ ParallelForRNG (Box const& box, T ncomp, L&& f) noexcept
             }
         }
     });
+    Gpu::streamSynchronize(); // To avoid multiple streams using RNG
     AMREX_GPU_ERROR_CHECK();
 }
 

--- a/Src/Base/AMReX_GpuLaunchMacrosG.H
+++ b/Src/Base/AMReX_GpuLaunchMacrosG.H
@@ -9,7 +9,6 @@
     if (amrex::Gpu::inLaunchRegion()) \
     { \
         const auto amrex_i_ec = amrex::Gpu::ExecutionConfig(amrex_i_tn); \
-        if (amrex::Gpu::onNullStream()) amrex::Gpu::nonNullStreamSynchronize(); \
         int amrex_i_nthreads_per_block = amrex_i_ec.numThreads.x; \
         int amrex_i_nthreads_total = amrex_i_nthreads_per_block * amrex_i_ec.numBlocks.x; \
         auto& amrex_i_q = amrex::Gpu::Device::streamQueue(); \
@@ -68,7 +67,6 @@
         dim3 amrex_i_nblocks = amrex::max(amrex_i_ec1.numBlocks.x, \
                                           amrex_i_ec2.numBlocks.x); \
         amrex_i_nblocks.y = 2; \
-        if (amrex::Gpu::onNullStream()) amrex::Gpu::nonNullStreamSynchronize(); \
         int amrex_i_nthreads_per_block = amrex_i_ec1.numThreads.x; \
         int amrex_i_nthreads_total = amrex_i_nthreads_per_block * amrex_i_nblocks.x; \
         auto& amrex_i_q = amrex::Gpu::Device::streamQueue(); \
@@ -151,7 +149,6 @@
                                                      amrex_i_ec2.numBlocks.x), \
                                                      amrex_i_ec3.numBlocks.x); \
         amrex_i_nblocks.y = 3; \
-        if (amrex::Gpu::onNullStream()) amrex::Gpu::nonNullStreamSynchronize(); \
         int amrex_i_nthreads_per_block = amrex_i_ec1.numThreads.x; \
         int amrex_i_nthreads_total = amrex_i_nthreads_per_block * amrex_i_nblocks.x; \
         auto& amrex_i_q = amrex::Gpu::Device::streamQueue(); \
@@ -243,7 +240,6 @@
     if (amrex::Gpu::inLaunchRegion()) \
     { \
         auto amrex_i_ec = amrex::Gpu::ExecutionConfig(amrex_i_tn); \
-        if (amrex::Gpu::onNullStream()) amrex::Gpu::nonNullStreamSynchronize(); \
         int amrex_i_nthreads_per_block = amrex_i_ec.numThreads.x; \
         int amrex_i_nthreads_total = amrex_i_nthreads_per_block * amrex_i_ec.numBlocks.x; \
         auto& amrex_i_q = amrex::Gpu::Device::streamQueue(); \
@@ -298,7 +294,6 @@
         dim3 amrex_i_nblocks = amrex::max(amrex_i_ec1.numBlocks.x, \
                                           amrex_i_ec2.numBlocks.x); \
         amrex_i_nblocks.y = 2; \
-        if (amrex::Gpu::onNullStream()) amrex::Gpu::nonNullStreamSynchronize(); \
         int amrex_i_nthreads_per_block = amrex_i_ec1.numThreads.x; \
         int amrex_i_nthreads_total = amrex_i_nthreads_per_block * amrex_i_nblocks.x; \
         auto& amrex_i_q = amrex::Gpu::Device::streamQueue(); \
@@ -371,7 +366,6 @@
                                                      amrex_i_ec2.numBlocks.x), \
                                                      amrex_i_ec3.numBlocks.x); \
         amrex_i_nblocks.y = 3; \
-        if (amrex::Gpu::onNullStream()) amrex::Gpu::nonNullStreamSynchronize(); \
         int amrex_i_nthreads_per_block = amrex_i_ec1.numThreads.x; \
         int amrex_i_nthreads_total = amrex_i_nthreads_per_block * amrex_i_nblocks.x; \
         auto& amrex_i_q = amrex::Gpu::Device::streamQueue(); \

--- a/Src/Base/AMReX_GpuUtility.cpp
+++ b/Src/Base/AMReX_GpuUtility.cpp
@@ -38,6 +38,12 @@ StreamIter::init() noexcept
     amrex::ignore_unused(m_threadsafe);
     amrex::ignore_unused(m_sync);
 #if defined(AMREX_USE_GPU)
+    if (m_sync) {
+#ifdef AMREX_USE_OMP
+#pragma omp single
+#endif
+        Gpu::streamSynchronize();
+    }
     Gpu::Device::setStreamIndex(m_i);
 #elif defined(AMREX_USE_OMP)
     int nthreads = omp_get_num_threads();
@@ -59,7 +65,7 @@ StreamIter::init() noexcept
 StreamIter::~StreamIter () {
 #ifdef AMREX_USE_GPU
     if (m_sync) {
-        Gpu::synchronize();
+        Gpu::streamSynchronizeAll();
     }
     AMREX_GPU_ERROR_CHECK();
     Gpu::Device::resetStreamIndex();
@@ -79,4 +85,3 @@ StreamIter::operator++ () noexcept
 #endif
 
 }}
-

--- a/Src/Base/AMReX_MFIter.cpp
+++ b/Src/Base/AMReX_MFIter.cpp
@@ -222,7 +222,7 @@ MFIter::~MFIter ()
 #endif
 
 #ifdef AMREX_USE_GPU
-    if (device_sync) Gpu::synchronize();
+    if (device_sync) Gpu::streamSynchronizeAll();
 #endif
 
 #ifdef AMREX_USE_GPU
@@ -250,6 +250,15 @@ MFIter::Initialize ()
         AMREX_ALWAYS_ASSERT_WITH_MESSAGE(depth == 1 || MFIter::allow_multiple_mfiters,
             "Nested or multiple active MFIters is not supported by default.  This can be changed by calling MFIter::allowMultipleMFIters(true)".);
     }
+
+#ifdef AMREX_USE_GPU
+    if (device_sync) {
+#ifdef AMREX_USE_OMP
+#pragma omp single
+#endif
+        Gpu::streamSynchronize();
+    }
+#endif
 
     if (flags & AllBoxes)  // a very special case
     {

--- a/Src/Base/AMReX_NonLocalBCImpl.H
+++ b/Src/Base/AMReX_NonLocalBCImpl.H
@@ -296,7 +296,7 @@ unpack_recv_buffer_gpu (FabArray<FAB>& mf, int scomp, int ncomp,
         szbuffer = (recv_data[N_rcvs-1]-recv_data[0]) + recv_size[N_rcvs-1];
         pbuffer = (char*)The_Arena()->alloc(szbuffer);
         Gpu::copyAsync(Gpu::hostToDevice,recv_data[0],recv_data[0]+szbuffer,pbuffer);
-        Gpu::synchronize();
+        Gpu::streamSynchronize();
     }
 #endif
 
@@ -327,7 +327,7 @@ unpack_recv_buffer_gpu (FabArray<FAB>& mf, int scomp, int ncomp,
         tag.dfab(i,j,k,scomp+n) = proj(tag.sfab, si ,n);
     });
 
-    // There is Gpu::synchronize in ParallelFor above
+    // There is Gpu::streamSynchronize in ParallelFor above
 
     if (pbuffer != recv_data[0]) {
         The_Arena()->free(pbuffer);

--- a/Src/Base/AMReX_Partition.H
+++ b/Src/Base/AMReX_Partition.H
@@ -51,7 +51,7 @@ namespace detail
             {
                 amrex::Swap(p[i], p[n2-1-i]);
             });
-            Gpu::synchronize();
+            Gpu::streamSynchronize();
         }
     }
 }

--- a/Src/Base/AMReX_Random.cpp
+++ b/Src/Base/AMReX_Random.cpp
@@ -40,7 +40,7 @@ void ResizeRandomSeed (amrex::ULong gpu_seed)
 #ifdef AMREX_USE_DPCPP
 
     rand_engine_descr = new dpcpp_rng_descr
-        (Gpu::Device::nullQueue(), sycl::range<1>(N), gpu_seed, 1);
+        (Gpu::Device::streamQueue(), sycl::range<1>(N), gpu_seed, 1);
 
 #elif defined(AMREX_USE_CUDA) || defined(AMREX_USE_HIP)
 
@@ -54,7 +54,7 @@ void ResizeRandomSeed (amrex::ULong gpu_seed)
     });
 #endif
 
-    Gpu::synchronize();
+    Gpu::streamSynchronize();
 }
 }
 #endif
@@ -182,7 +182,7 @@ amrex::DeallocateRandomSeedDevArray ()
 #ifdef AMREX_USE_DPCPP
     if (rand_engine_descr) {
         delete rand_engine_descr;
-        Gpu::synchronize();
+        Gpu::streamSynchronize();
         rand_engine_descr = nullptr;
     }
 #else

--- a/Src/Base/AMReX_Reduce.H
+++ b/Src/Base/AMReX_Reduce.H
@@ -813,7 +813,7 @@ bool AnyOf (N n, T const* v, P&& pred)
 #ifdef AMREX_USE_DPCPP
     const int num_ints = std::max(Gpu::Device::warp_size, int(ec.numThreads.x)/Gpu::Device::warp_size) + 1;
     const std::size_t shared_mem_bytes = num_ints*sizeof(int);
-    amrex::launch(ec.numBlocks.x, ec.numThreads.x, shared_mem_bytes, Gpu::nullStream(),
+    amrex::launch(ec.numBlocks.x, ec.numThreads.x, shared_mem_bytes, Gpu::gpuStream(),
     [=] AMREX_GPU_DEVICE (Gpu::Handler const& gh) noexcept {
         int* has_any = &(static_cast<int*>(gh.sharedMemory())[num_ints-1]);
         if (gh.threadIdx() == 0) { *has_any = *dp; }
@@ -834,7 +834,7 @@ bool AnyOf (N n, T const* v, P&& pred)
         }
     });
 #else
-    amrex::launch(ec.numBlocks.x, ec.numThreads.x, 0, 0,
+    amrex::launch(ec.numBlocks.x, ec.numThreads.x, 0, Gpu::gpuStream(),
     [=] AMREX_GPU_DEVICE () noexcept {
         __shared__ int has_any;
         if (threadIdx.x == 0) has_any = *dp;
@@ -874,7 +874,7 @@ bool AnyOf (Box const& box, P&& pred)
 #ifdef AMREX_USE_DPCPP
     const int num_ints = std::max(Gpu::Device::warp_size, int(ec.numThreads.x)/Gpu::Device::warp_size) + 1;
     const std::size_t shared_mem_bytes = num_ints*sizeof(int);
-    amrex::launch(ec.numBlocks.x, ec.numThreads.x, shared_mem_bytes, Gpu::nullStream(),
+    amrex::launch(ec.numBlocks.x, ec.numThreads.x, shared_mem_bytes, Gpu::gpuStream(),
     [=] AMREX_GPU_DEVICE (Gpu::Handler const& gh) noexcept {
         int* has_any = &(static_cast<int*>(gh.sharedMemory())[num_ints-1]);
         if (gh.threadIdx() == 0) { *has_any = *dp; }
@@ -899,7 +899,7 @@ bool AnyOf (Box const& box, P&& pred)
         }
     });
 #else
-    AMREX_LAUNCH_KERNEL(ec.numBlocks, ec.numThreads, 0, 0,
+    AMREX_LAUNCH_KERNEL(ec.numBlocks, ec.numThreads, 0, Gpu::gpuStream(),
     [=] AMREX_GPU_DEVICE () noexcept {
         __shared__ int has_any;
         if (threadIdx.x == 0) has_any = *dp;

--- a/Src/Base/AMReX_TagParallelFor.H
+++ b/Src/Base/AMReX_TagParallelFor.H
@@ -215,7 +215,7 @@ ParallelFor_doit (Vector<TagType> const& tags, F && f)
 #endif
     });
 
-    Gpu::synchronize();
+    Gpu::streamSynchronize();
     The_Pinned_Arena()->free(h_buffer);
     The_Arena()->free(d_buffer);
 }

--- a/Src/Base/AMReX_TinyProfiler.cpp
+++ b/Src/Base/AMReX_TinyProfiler.cpp
@@ -95,7 +95,7 @@ TinyProfiler::start () noexcept
 
 #ifdef AMREX_USE_GPU
             if (device_synchronize_around_region) {
-                amrex::Gpu::Device::synchronize();
+                amrex::Gpu::streamSynchronize();
             }
 #endif
 
@@ -187,7 +187,7 @@ TinyProfiler::stop () noexcept
 
 #ifdef AMREX_USE_GPU
             if (device_synchronize_around_region) {
-                amrex::Gpu::Device::synchronize();
+                amrex::Gpu::streamSynchronize();
             }
 #endif
 
@@ -271,7 +271,7 @@ TinyProfiler::stop (unsigned boxUintID) noexcept
             }
 
             if (device_synchronize_around_region) {
-                amrex::Gpu::Device::synchronize();
+                amrex::Gpu::streamSynchronize();
             }
 
 #ifdef AMREX_USE_CUDA

--- a/Src/Base/AMReX_VisMF.cpp
+++ b/Src/Base/AMReX_VisMF.cpp
@@ -1022,7 +1022,7 @@ VisMF::Write (const FabArray<FArrayBox>&    mf,
                     fio.write_header(hss, fab, fab.nComp());
                     hLength = static_cast<std::streamoff>(hss.tellp());
                     auto tstr = hss.str();
-                    memcpy(afPtr, tstr.c_str(), hLength);  // ---- the fab header
+                    std::memcpy(afPtr, tstr.c_str(), hLength);  // ---- the fab header
                 }
                 Real const* fabdata = fab.dataPtr();
 #ifdef AMREX_USE_GPU
@@ -1721,7 +1721,7 @@ VisMF::Read (FabArray<FArrayBox> &mf,
                       RealDescriptor::convertToNativeFormat(fabdata, readDataItems,
                                                             afPtr, hdr.m_writtenRD);
                     } else {
-                      memcpy(fabdata, afPtr, fab.nBytes());
+                      std::memcpy(fabdata, afPtr, fab.nBytes());
                     }
                     currentOffset += readDataItems * hdr.m_writtenRD.numBytes();
 #ifdef AMREX_USE_GPU
@@ -2342,7 +2342,7 @@ VisMF::AsyncWriteDoit (const FabArray<FArrayBox>& mf, const std::string& mf_name
             if (strip_ghost) {
                 new_fab.copy<RunOn::Device>(mf[mfi], bx);
             } else {
-                Gpu::dtoh_memcpy(new_fab.dataPtr(), mf[mfi].dataPtr(), new_fab.size()*sizeof(Real));
+                Gpu::dtoh_memcpy_async(new_fab.dataPtr(), mf[mfi].dataPtr(), new_fab.size()*sizeof(Real));
             }
         } else
 #endif

--- a/Src/EB/AMReX_EBMultiFabUtil.cpp
+++ b/Src/EB/AMReX_EBMultiFabUtil.cpp
@@ -939,7 +939,6 @@ EB_interp_CC_to_FaceCentroid (const MultiFab& cc,
     {
         Gpu::copy(Gpu::hostToDevice, a_bcs.begin(), a_bcs.begin()+ncomp, dv_bcs.begin());
         d_bcs = dv_bcs.dataPtr();
-        Gpu::synchronize();
     }
     else
 #endif
@@ -1078,7 +1077,6 @@ EB_interp_CellCentroid_to_FaceCentroid (const MultiFab& phi_centroid,
     {
         Gpu::copy(Gpu::hostToDevice, a_bcs.begin(), a_bcs.begin()+ncomp, dv_bcs.begin());
         d_bcs = dv_bcs.dataPtr();
-        Gpu::synchronize();
     }
     else
 #endif

--- a/Src/EB/AMReX_EB_utils.cpp
+++ b/Src/EB/AMReX_EB_utils.cpp
@@ -213,7 +213,7 @@ namespace amrex {
             div(i,j,k,icomp+n) = divc(i,j,k,n) + optmp(i,j,k,n);
         });
 
-        Gpu::synchronize();
+        Gpu::streamSynchronize();
     }
 
     //
@@ -658,7 +658,7 @@ void FillSignedDistance (MultiFab& mf, EB2::Level const& ls_lev,
                         fab(i,j,k) = (-fluid_sign) * usd;
                     }
                 });
-                Gpu::synchronize();
+                Gpu::streamSynchronize();
             }
         } else {
             amrex::ParallelFor(gbx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept

--- a/Src/Extern/HDF5/AMReX_ParticleHDF5.H
+++ b/Src/Extern/HDF5/AMReX_ParticleHDF5.H
@@ -1477,21 +1477,21 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>
           auto new_size = old_size + src_tile.size();
           dst_tile.resize(new_size);
 
-          Gpu::copy(Gpu::hostToDevice, src_tile.begin(), src_tile.end(),
-                    dst_tile.GetArrayOfStructs().begin() + old_size);
+          Gpu::copyAsync(Gpu::hostToDevice, src_tile.begin(), src_tile.end(),
+                         dst_tile.GetArrayOfStructs().begin() + old_size);
 
           for (int i = 0; i < NumRealComps(); ++i) {
-              Gpu::copy(Gpu::hostToDevice,
-                        host_real_attribs[host_lev][std::make_pair(grid,tile)][i].begin(),
-                        host_real_attribs[host_lev][std::make_pair(grid,tile)][i].end(),
-                        dst_tile.GetStructOfArrays().GetRealData(i).begin() + old_size);
+              Gpu::copyAsync(Gpu::hostToDevice,
+                             host_real_attribs[host_lev][std::make_pair(grid,tile)][i].begin(),
+                             host_real_attribs[host_lev][std::make_pair(grid,tile)][i].end(),
+                             dst_tile.GetStructOfArrays().GetRealData(i).begin() + old_size);
           }
 
           for (int i = 0; i < NumIntComps(); ++i) {
-              Gpu::copy(Gpu::hostToDevice,
-                        host_int_attribs[host_lev][std::make_pair(grid,tile)][i].begin(),
-                        host_int_attribs[host_lev][std::make_pair(grid,tile)][i].end(),
-                        dst_tile.GetStructOfArrays().GetIntData(i).begin() + old_size);
+              Gpu::copyAsync(Gpu::hostToDevice,
+                             host_int_attribs[host_lev][std::make_pair(grid,tile)][i].begin(),
+                             host_int_attribs[host_lev][std::make_pair(grid,tile)][i].end(),
+                             dst_tile.GetStructOfArrays().GetIntData(i).begin() + old_size);
           }
         }
       }

--- a/Src/Extern/HDF5/AMReX_WriteBinaryParticleDataHDF5.H
+++ b/Src/Extern/HDF5/AMReX_WriteBinaryParticleDataHDF5.H
@@ -201,7 +201,7 @@ void WriteHDF5ParticleDataSync (PC const& pc,
         }
     }
 
-    Gpu::Device::synchronize();
+    Gpu::streamSynchronize();
 
     if(pc.GetUsePrePost())
     {

--- a/Src/Extern/HYPRE/AMReX_HypreABecLap3.cpp
+++ b/Src/Extern/HYPRE/AMReX_HypreABecLap3.cpp
@@ -675,7 +675,7 @@ HypreABecLap3::loadVectors (MultiFab& soln, const MultiFab& rhs)
                         bp[0] = Real(0.0);
                     }
                 });
-                Gpu::synchronize();
+                Gpu::streamSynchronize();
             }
 
             HYPRE_IJVectorSetValues(b, nrows, cell_id_vec[mfi].dataPtr(), rhs_diag[mfi].dataPtr());

--- a/Src/LinearSolvers/MLMG/AMReX_MLCellLinOp.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLCellLinOp.cpp
@@ -1312,7 +1312,7 @@ MLCellLinOp::BndryCondLoc::setLOBndryConds (const Geometry& geom, const Real* dx
         }
     }
     Gpu::copyAsync(Gpu::hostToDevice, hv.begin(), hv.end(), bctl_dv.begin());
-    Gpu::synchronize();
+    Gpu::streamSynchronize();
 }
 
 void

--- a/Src/LinearSolvers/MLMG/AMReX_MLEBNodeFDLaplacian.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBNodeFDLaplacian.cpp
@@ -302,7 +302,7 @@ MLEBNodeFDLaplacian::prepareForSolve ()
         });
     }
 
-    Gpu::synchronize();
+    Gpu::streamSynchronize();
 
 #if (AMREX_SPACEDIM == 2)
     if (m_rz) {

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian.cpp
@@ -323,7 +323,7 @@ MLNodeLaplacian::restriction (int amrlev, int cmglev, MultiFab& crse, MultiFab& 
                 mlndlap_restriction_rap(i,j,k,pcrse_ma[box_no],fine_ma[box_no],st_ma[box_no],msk_ma[box_no]);
             });
         }
-        Gpu::synchronize();
+        Gpu::streamSynchronize();
     } else
 #endif
     {
@@ -451,7 +451,7 @@ MLNodeLaplacian::interpolation (int amrlev, int fmglev, MultiFab& fine, const Mu
                 mlndlap_semi_interpadd_aa(i, j, k, fine_ma[box_no], crse_ma[box_no], sig_ma[box_no], msk_ma[box_no], idir);
             });
         }
-        Gpu::synchronize();
+        Gpu::streamSynchronize();
     } else
 #endif
     {

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian_misc.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian_misc.cpp
@@ -248,7 +248,7 @@ MLNodeLaplacian::Fapply (int amrlev, int mglev, MultiFab& out, const MultiFab& i
 #endif
             });
         }
-        Gpu::synchronize();
+        Gpu::streamSynchronize();
     } else
 #endif
     {
@@ -410,7 +410,7 @@ MLNodeLaplacian::Fsmooth (int amrlev, int mglev, MultiFab& sol, const MultiFab& 
             }
         }
 
-        Gpu::synchronize();
+        Gpu::streamSynchronize();
         if (m_smooth_num_sweeps > 1) nodalSync(amrlev, mglev, sol);
     }
     else // cpu

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian_sten.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian_sten.cpp
@@ -359,7 +359,7 @@ MLNodeLaplacian::buildStencil ()
         });
     }
 
-    Gpu::synchronize();
+    Gpu::streamSynchronize();
 
     // This is only needed at the bottom.
     m_s0_norm0[0].back() = m_stencil[0].back()->norm0(0,0) * m_normalization_threshold;

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeTensorLaplacian.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeTensorLaplacian.cpp
@@ -222,7 +222,7 @@ MLNodeTensorLaplacian::Fapply (int amrlev, int mglev, MultiFab& out, const Multi
     {
         mlndtslap_adotx(i,j,k, out_a[box_no], in_a[box_no], dmsk_a[box_no], s);
     });
-    Gpu::synchronize();
+    Gpu::streamSynchronize();
 #endif
 }
 
@@ -264,7 +264,7 @@ MLNodeTensorLaplacian::Fsmooth (int amrlev, int mglev, MultiFab& sol, const Mult
             mlndtslap_gauss_seidel(i, j, k, sol_a[box_no], rhs_a[box_no], dmsk_a[box_no], s);
         }
     });
-    Gpu::synchronize();
+    Gpu::streamSynchronize();
 #endif
 }
 

--- a/Src/Particle/AMReX_DenseBins.H
+++ b/Src/Particle/AMReX_DenseBins.H
@@ -217,7 +217,7 @@ public:
 
         Gpu::exclusive_scan(m_counts.begin(), m_counts.end(), m_offsets.begin());
 
-        Gpu::copy(Gpu::deviceToDevice, m_offsets.begin(), m_offsets.end(), m_counts.begin());
+        Gpu::copyAsync(Gpu::deviceToDevice, m_offsets.begin(), m_offsets.end(), m_counts.begin());
 
         index_type* pperm = m_perm.dataPtr();
         constexpr index_type max_index = std::numeric_limits<index_type>::max();

--- a/Src/Particle/AMReX_NeighborList.H
+++ b/Src/Particle/AMReX_NeighborList.H
@@ -334,8 +334,9 @@ public:
         Gpu::HostVector<unsigned int> host_nbor_offsets(m_nbor_offsets.size());
         Gpu::HostVector<unsigned int> host_nbor_list(m_nbor_list.size());
 
-        Gpu::copy(Gpu::deviceToHost, m_nbor_offsets.begin(), m_nbor_offsets.end(), host_nbor_offsets.begin());
-        Gpu::copy(Gpu::deviceToHost, m_nbor_list.begin(), m_nbor_list.end(), host_nbor_list.begin());
+        Gpu::copyAsync(Gpu::deviceToHost, m_nbor_offsets.begin(), m_nbor_offsets.end(), host_nbor_offsets.begin());
+        Gpu::copyAsync(Gpu::deviceToHost, m_nbor_list.begin(), m_nbor_list.end(), host_nbor_list.begin());
+        Gpu::streamSynchronize();
 
         for (int i = 0; i < numParticles(); ++i) {
             amrex::Print() << "Particle " << i << " could collide with: ";

--- a/Src/Particle/AMReX_NeighborParticlesGPUImpl.H
+++ b/Src/Particle/AMReX_NeighborParticlesGPUImpl.H
@@ -101,15 +101,13 @@ buildNeighborMask ()
             }
 
             m_code_array[grid].resize(h_code_arr.size());
-            Gpu::copy(Gpu::hostToDevice, h_code_arr.begin(), h_code_arr.end(),
+            Gpu::copyAsync(Gpu::hostToDevice, h_code_arr.begin(), h_code_arr.end(),
                       m_code_array[grid].begin());
             m_isec_boxes[grid].resize(h_isec_boxes.size());
-            Gpu::copy(Gpu::hostToDevice, h_isec_boxes.begin(), h_isec_boxes.end(),
+            Gpu::copyAsync(Gpu::hostToDevice, h_isec_boxes.begin(), h_isec_boxes.end(),
                       m_isec_boxes[grid].begin());
 
-
-
-            Gpu::Device::synchronize();
+            Gpu::streamSynchronize();
         }
 
         RemoveDuplicates(neighbor_procs);
@@ -186,7 +184,8 @@ buildNeighborCopyOp (bool use_boundary_neighbor)
         amrex::Gpu::exclusive_scan(counts.begin(), counts.end(), offsets.begin());
 
         int num_copies;
-        Gpu::dtoh_memcpy(&num_copies, offsets.data()+np, sizeof(int));
+        Gpu::dtoh_memcpy_async(&num_copies, offsets.data()+np, sizeof(int));
+        Gpu::streamSynchronize();
 
         neighbor_copy_op.resize(gid, lev, num_copies);
 
@@ -267,11 +266,11 @@ updateNeighborsGPU (bool boundary_neighbors_only)
     }
     else
     {
-        Gpu::Device::synchronize();
+        Gpu::streamSynchronize();
         pinned_snd_buffer.resize(snd_buffer.size());
         Gpu::dtoh_memcpy_async(pinned_snd_buffer.dataPtr(), snd_buffer.dataPtr(), snd_buffer.size());
         neighbor_copy_plan.buildMPIFinish(this->BufferMap());
-        Gpu::Device::synchronize();
+        Gpu::streamSynchronize();
         communicateParticlesStart(*this, neighbor_copy_plan, pinned_snd_buffer, pinned_rcv_buffer);
         rcv_buffer.resize(pinned_rcv_buffer.size());
         unpackBuffer(*this, neighbor_copy_plan, snd_buffer, NeighborUnpackPolicy());
@@ -280,7 +279,7 @@ updateNeighborsGPU (bool boundary_neighbors_only)
         unpackRemotes(*this, neighbor_copy_plan, rcv_buffer, NeighborUnpackPolicy());
     }
 
-    Gpu::Device::synchronize();
+    Gpu::streamSynchronize();
 }
 
 template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt>

--- a/Src/Particle/AMReX_ParticleBufferMap.cpp
+++ b/Src/Particle/AMReX_ParticleBufferMap.cpp
@@ -104,9 +104,10 @@ void ParticleBufferMap::define (const ParGDBBase* a_gdb)
     d_lev_offsets.resize(0);
     d_lev_offsets.resize(m_lev_offsets.size());
 
-    Gpu::copy(Gpu::hostToDevice, m_lev_gid_to_bucket.begin(),m_lev_gid_to_bucket.end(),d_lev_gid_to_bucket.begin());
-    Gpu::copy(Gpu::hostToDevice, m_lev_offsets.begin(),m_lev_offsets.end(),d_lev_offsets.begin());
-    Gpu::copy(Gpu::hostToDevice, m_bucket_to_pid.begin(),m_bucket_to_pid.end(),d_bucket_to_pid.begin());
+    Gpu::copyAsync(Gpu::hostToDevice, m_lev_gid_to_bucket.begin(),m_lev_gid_to_bucket.end(),d_lev_gid_to_bucket.begin());
+    Gpu::copyAsync(Gpu::hostToDevice, m_lev_offsets.begin(),m_lev_offsets.end(),d_lev_offsets.begin());
+    Gpu::copyAsync(Gpu::hostToDevice, m_bucket_to_pid.begin(),m_bucket_to_pid.end(),d_bucket_to_pid.begin());
+    Gpu::streamSynchronize();
 }
 
 bool ParticleBufferMap::isValid (const ParGDBBase* a_gdb) const

--- a/Src/Particle/AMReX_ParticleCommunication.H
+++ b/Src/Particle/AMReX_ParticleCommunication.H
@@ -186,22 +186,24 @@ struct ParticleCopyPlan
                                    m_box_offsets.begin());
 
         m_box_counts_h.resize(m_box_counts_d.size());
-        Gpu::copy(Gpu::deviceToHost, m_box_counts_d.begin(), m_box_counts_d.end(),
-                  m_box_counts_h.begin());
+        Gpu::copyAsync(Gpu::deviceToHost, m_box_counts_d.begin(), m_box_counts_d.end(),
+                       m_box_counts_h.begin());
 
         m_snd_pad_correction_h.resize(0);
         m_snd_pad_correction_h.resize(ParallelContext::NProcsSub()+1, 0);
 
         m_snd_pad_correction_d.resize(m_snd_pad_correction_h.size());
-        Gpu::copy(Gpu::hostToDevice, m_snd_pad_correction_h.begin(), m_snd_pad_correction_h.end(),
-                  m_snd_pad_correction_d.begin());
+        Gpu::copyAsync(Gpu::hostToDevice, m_snd_pad_correction_h.begin(), m_snd_pad_correction_h.end(),
+                       m_snd_pad_correction_d.begin());
 
         d_int_comp_mask.resize(int_comp_mask.size());
-        Gpu::copy(Gpu::hostToDevice,  int_comp_mask.begin(),  int_comp_mask.end(),
-                  d_int_comp_mask.begin());
+        Gpu::copyAsync(Gpu::hostToDevice,  int_comp_mask.begin(),  int_comp_mask.end(),
+                       d_int_comp_mask.begin());
         d_real_comp_mask.resize(real_comp_mask.size());
-        Gpu::copy(Gpu::hostToDevice, real_comp_mask.begin(), real_comp_mask.end(),
-                  d_real_comp_mask.begin());
+        Gpu::copyAsync(Gpu::hostToDevice, real_comp_mask.begin(), real_comp_mask.end(),
+                       d_real_comp_mask.begin());
+
+        Gpu::streamSynchronize();
 
         int NStructReal = PC::ParticleContainerType::NStructReal;
         int NStructInt  = PC::ParticleContainerType::NStructInt;
@@ -572,7 +574,7 @@ void unpackRemotes (PC& pc, const ParticleCopyPlan& plan, Buffer& rcv_buffer, Un
 
         Vector<int> offsets;
         policy.resizeTiles(tiles, sizes, offsets);
-        Gpu::Device::synchronize();
+        Gpu::streamSynchronize();
         int uindex = 0;
         int procindex = 0, rproc = plan.m_rcv_box_pids[0];
         for (int i = 0, N = plan.m_rcv_box_counts.size(); i < N; ++i)
@@ -604,7 +606,7 @@ void unpackRemotes (PC& pc, const ParticleCopyPlan& plan, Buffer& rcv_buffer, Un
                                        p_comm_real, p_comm_int);
               });
 
-            Gpu::synchronize();
+            Gpu::streamSynchronize();
         }
     }
 #else

--- a/Src/Particle/AMReX_ParticleContainerI.H
+++ b/Src/Particle/AMReX_ParticleContainerI.H
@@ -864,7 +864,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>
 
         });
         last_offset+=next_offset;
-        Gpu::synchronize();
+        Gpu::streamSynchronize();
     }
 
     // last_offset should equal virts.numParticles()
@@ -876,10 +876,10 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>
         auto np = src_tile.numParticles();
         virts.resize(virts_offset+np);
         virts_offset += filterAndTransformParticles(virts, src_tile, FilterVirt(assign_buffer_grid,plo,dxi,domain), TransformerVirt(),0,virts_offset);
-        Gpu::synchronize();
+        Gpu::streamSynchronize();
     }
-    //Resize implicitly includes a Gpu::synchronize()
     virts.resize(virts_offset);
+    Gpu::streamSynchronize();
     }
 }
 
@@ -966,8 +966,8 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>
         ghosts.resize(ghost_offset+np);
         ghost_offset += filterAndTransformParticles(ghosts, src_tile, AssignGridFilter(assign_grid,gid,level,nGrow), TransformerGhost(),0,ghost_offset);
     }
-    //Resize implicitly includes a Gpu::synchronize()
     ghosts.resize(ghost_offset);
+    Gpu::streamSynchronize();
 }
 
 template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt,
@@ -1129,7 +1129,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>::So
                         dst[i] = src.m_aos[inds[i]];
                     });
 
-                    Gpu::synchronize();
+                    Gpu::streamSynchronize();
                     ptile.GetArrayOfStructs()().swap(tmp_particles);
                 }
 
@@ -1142,7 +1142,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>::So
                         dst[i] = src[inds[i]];
                     });
 
-                    Gpu::synchronize();
+                    Gpu::streamSynchronize();
 
                     ptile.GetStructOfArrays().GetRealData(comp).swap(tmp_real);
                 }
@@ -1156,7 +1156,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>::So
                         dst[i] = src[inds[i]];
                     });
 
-                    Gpu::synchronize();
+                    Gpu::streamSynchronize();
 
                     ptile.GetStructOfArrays().GetIntData(comp).swap(tmp_int);
                 }
@@ -1332,13 +1332,13 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>
     }
     else
     {
-        Gpu::Device::synchronize();
+        Gpu::Device::streamSynchronize();
         Gpu::PinnedVector<char> pinned_snd_buffer;
         Gpu::PinnedVector<char> pinned_rcv_buffer;
         pinned_snd_buffer.resize(snd_buffer.size());
         Gpu::dtoh_memcpy_async(pinned_snd_buffer.dataPtr(), snd_buffer.dataPtr(), snd_buffer.size());
         plan.buildMPIFinish(BufferMap());
-        Gpu::Device::synchronize();
+        Gpu::Device::streamSynchronize();
         communicateParticlesStart(*this, plan, pinned_snd_buffer, pinned_rcv_buffer);
         rcv_buffer.resize(pinned_rcv_buffer.size());
         unpackBuffer(*this, plan, snd_buffer, RedistributeUnpackPolicy());
@@ -1347,7 +1347,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>
         unpackRemotes(*this, plan, rcv_buffer, RedistributeUnpackPolicy());
     }
 
-    Gpu::Device::synchronize();
+    Gpu::Device::streamSynchronize();
     AMREX_ASSERT(numParticlesOutOfRange(*this, lev_min, lev_max, nGrow) == 0);
 #else
     amrex::ignore_unused(lev_min,lev_max,nGrow,local,remove_negative);
@@ -1954,22 +1954,22 @@ RedistributeMPI (std::map<int, Vector<char> >& not_ours,
               auto new_size = old_size + src_tile.size();
               dst_tile.resize(new_size);
 
-              Gpu::copy(Gpu::hostToDevice,
-                        src_tile.begin(), src_tile.end(),
-                        dst_tile.GetArrayOfStructs().begin() + old_size);
+              Gpu::copyAsync(Gpu::hostToDevice,
+                             src_tile.begin(), src_tile.end(),
+                             dst_tile.GetArrayOfStructs().begin() + old_size);
 
               for (int i = 0; i < NumRealComps(); ++i) {
-                  Gpu::copy(Gpu::hostToDevice,
-                            host_real_attribs[host_lev][std::make_pair(grid,tile)][i].begin(),
-                            host_real_attribs[host_lev][std::make_pair(grid,tile)][i].end(),
-                            dst_tile.GetStructOfArrays().GetRealData(i).begin() + old_size);
+                  Gpu::copyAsync(Gpu::hostToDevice,
+                                 host_real_attribs[host_lev][std::make_pair(grid,tile)][i].begin(),
+                                 host_real_attribs[host_lev][std::make_pair(grid,tile)][i].end(),
+                                 dst_tile.GetStructOfArrays().GetRealData(i).begin() + old_size);
               }
 
               for (int i = 0; i < NumIntComps(); ++i) {
-                  Gpu::copy(Gpu::hostToDevice,
-                            host_int_attribs[host_lev][std::make_pair(grid,tile)][i].begin(),
-                            host_int_attribs[host_lev][std::make_pair(grid,tile)][i].end(),
-                            dst_tile.GetStructOfArrays().GetIntData(i).begin() + old_size);
+                  Gpu::copyAsync(Gpu::hostToDevice,
+                                 host_int_attribs[host_lev][std::make_pair(grid,tile)][i].begin(),
+                                 host_int_attribs[host_lev][std::make_pair(grid,tile)][i].end(),
+                                 dst_tile.GetStructOfArrays().GetIntData(i).begin() + old_size);
               }
             }
           }

--- a/Src/Particle/AMReX_ParticleIO.H
+++ b/Src/Particle/AMReX_ParticleIO.H
@@ -995,21 +995,21 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>
           auto new_size = old_size + src_tile.size();
           dst_tile.resize(new_size);
 
-          Gpu::copy(Gpu::hostToDevice, src_tile.begin(), src_tile.end(),
-                    dst_tile.GetArrayOfStructs().begin() + old_size);
+          Gpu::copyAsync(Gpu::hostToDevice, src_tile.begin(), src_tile.end(),
+                         dst_tile.GetArrayOfStructs().begin() + old_size);
 
           for (int i = 0; i < NumRealComps(); ++i) {
-              Gpu::copy(Gpu::hostToDevice,
-                        host_real_attribs[host_lev][std::make_pair(grid,tile)][i].begin(),
-                        host_real_attribs[host_lev][std::make_pair(grid,tile)][i].end(),
-                        dst_tile.GetStructOfArrays().GetRealData(i).begin() + old_size);
+              Gpu::copyAsync(Gpu::hostToDevice,
+                             host_real_attribs[host_lev][std::make_pair(grid,tile)][i].begin(),
+                             host_real_attribs[host_lev][std::make_pair(grid,tile)][i].end(),
+                             dst_tile.GetStructOfArrays().GetRealData(i).begin() + old_size);
           }
 
           for (int i = 0; i < NumIntComps(); ++i) {
-              Gpu::copy(Gpu::hostToDevice,
-                        host_int_attribs[host_lev][std::make_pair(grid,tile)][i].begin(),
-                        host_int_attribs[host_lev][std::make_pair(grid,tile)][i].end(),
-                        dst_tile.GetStructOfArrays().GetIntData(i).begin() + old_size);
+              Gpu::copyAsync(Gpu::hostToDevice,
+                             host_int_attribs[host_lev][std::make_pair(grid,tile)][i].begin(),
+                             host_int_attribs[host_lev][std::make_pair(grid,tile)][i].end(),
+                             dst_tile.GetStructOfArrays().GetIntData(i).begin() + old_size);
           }
         }
       }

--- a/Src/Particle/AMReX_ParticleInit.H
+++ b/Src/Particle/AMReX_ParticleInit.H
@@ -330,18 +330,19 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>
                 auto new_size = old_size + src_tile.size();
                 dst_tile.resize(new_size);
 
-                Gpu::copy(Gpu::hostToDevice, src_tile.begin(), src_tile.end(),
-                          dst_tile.GetArrayOfStructs().begin() + old_size);
+                Gpu::copyAsync(Gpu::hostToDevice, src_tile.begin(), src_tile.end(),
+                               dst_tile.GetArrayOfStructs().begin() + old_size);
 
                 if((host_real_attribs[lev][std::make_pair(grid, tile)]).size() > (long unsigned int) NArrayReal)
                   for (int i = 0; i < NArrayReal; ++i) {
-                    Gpu::copy(Gpu::hostToDevice,
-                              host_real_attribs[lev][std::make_pair(grid,tile)][i].begin(),
-                              host_real_attribs[lev][std::make_pair(grid,tile)][i].end(),
-                              dst_tile.GetStructOfArrays().GetRealData(i).begin() + old_size);
-         }
+                    Gpu::copyAsync(Gpu::hostToDevice,
+                                   host_real_attribs[lev][std::make_pair(grid,tile)][i].begin(),
+                                   host_real_attribs[lev][std::make_pair(grid,tile)][i].end(),
+                                   dst_tile.GetStructOfArrays().GetRealData(i).begin() + old_size);
+                  }
             }
         }
+        Gpu::streamSynchronize();
 
         Redistribute();
     }
@@ -402,17 +403,18 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>
                 auto new_size = old_size + src_tile.size();
                 dst_tile.resize(new_size);
 
-                Gpu::copy(Gpu::hostToDevice, src_tile.begin(), src_tile.end(),
-                          dst_tile.GetArrayOfStructs().begin() + old_size);
+                Gpu::copyAsync(Gpu::hostToDevice, src_tile.begin(), src_tile.end(),
+                               dst_tile.GetArrayOfStructs().begin() + old_size);
 
                 for (int i = 0; i < NArrayReal; ++i) {
-                    Gpu::copy(Gpu::hostToDevice,
-                              host_real_attribs[lev][std::make_pair(grid,tile)][i].begin(),
-                              host_real_attribs[lev][std::make_pair(grid,tile)][i].end(),
-                              dst_tile.GetStructOfArrays().GetRealData(i).begin() + old_size);
+                    Gpu::copyAsync(Gpu::hostToDevice,
+                                   host_real_attribs[lev][std::make_pair(grid,tile)][i].begin(),
+                                   host_real_attribs[lev][std::make_pair(grid,tile)][i].end(),
+                                   dst_tile.GetStructOfArrays().GetRealData(i).begin() + old_size);
                 }
             }
         }
+        Gpu::streamSynchronize();
 
         Redistribute();
 
@@ -836,10 +838,11 @@ InitFromBinaryFile (const std::string& file,
                 auto new_size = old_size + src_tile.size();
                 dst_tile.resize(new_size);
 
-                Gpu::copy(Gpu::hostToDevice, src_tile.begin(), src_tile.end(),
-                          dst_tile.GetArrayOfStructs().begin() + old_size);
+                Gpu::copyAsync(Gpu::hostToDevice, src_tile.begin(), src_tile.end(),
+                               dst_tile.GetArrayOfStructs().begin() + old_size);
             }
         }
+        Gpu::streamSynchronize();
 
         Redistribute();
 
@@ -1093,24 +1096,25 @@ InitRandom (Long                    icount,
                 auto new_size = old_size + src_tile.size();
                 dst_tile.resize(new_size);
 
-                Gpu::copy(Gpu::hostToDevice, src_tile.begin(), src_tile.end(),
-                          dst_tile.GetArrayOfStructs().begin() + old_size);
+                Gpu::copyAsync(Gpu::hostToDevice, src_tile.begin(), src_tile.end(),
+                               dst_tile.GetArrayOfStructs().begin() + old_size);
 
                 for (int i = 0; i < NArrayReal; ++i) {
-                    Gpu::copy(Gpu::hostToDevice,
-                              host_real_attribs[host_lev][std::make_pair(grid,tile)][i].begin(),
-                              host_real_attribs[host_lev][std::make_pair(grid,tile)][i].end(),
-                              dst_tile.GetStructOfArrays().GetRealData(i).begin() + old_size);
+                    Gpu::copyAsync(Gpu::hostToDevice,
+                                   host_real_attribs[host_lev][std::make_pair(grid,tile)][i].begin(),
+                                   host_real_attribs[host_lev][std::make_pair(grid,tile)][i].end(),
+                                   dst_tile.GetStructOfArrays().GetRealData(i).begin() + old_size);
                 }
 
                 for (int i = 0; i < NArrayInt; ++i) {
-                    Gpu::copy(Gpu::hostToDevice,
-                              host_int_attribs[host_lev][std::make_pair(grid,tile)][i].begin(),
-                              host_int_attribs[host_lev][std::make_pair(grid,tile)][i].end(),
-                              dst_tile.GetStructOfArrays().GetIntData(i).begin() + old_size);
+                    Gpu::copyAsync(Gpu::hostToDevice,
+                                   host_int_attribs[host_lev][std::make_pair(grid,tile)][i].begin(),
+                                   host_int_attribs[host_lev][std::make_pair(grid,tile)][i].end(),
+                                   dst_tile.GetStructOfArrays().GetIntData(i).begin() + old_size);
                 }
             }
         }
+        Gpu::streamSynchronize();
 
         AMREX_ASSERT(OK());
     }
@@ -1197,25 +1201,27 @@ InitRandom (Long                    icount,
                 auto new_size = old_size + src_tile.size();
                 dst_tile.resize(new_size);
 
-                Gpu::copy(Gpu::hostToDevice, src_tile.begin(), src_tile.end(),
-                          dst_tile.GetArrayOfStructs().begin() + old_size);
+                Gpu::copyAsync(Gpu::hostToDevice, src_tile.begin(), src_tile.end(),
+                               dst_tile.GetArrayOfStructs().begin() + old_size);
 
                 for (int i = 0; i < NArrayReal; ++i) {
-                    Gpu::copy(Gpu::hostToDevice,
-                              host_real_attribs[host_lev][std::make_pair(grid,tile)][i].begin(),
-                              host_real_attribs[host_lev][std::make_pair(grid,tile)][i].end(),
-                              dst_tile.GetStructOfArrays().GetRealData(i).begin() + old_size);
+                    Gpu::copyAsync(Gpu::hostToDevice,
+                                   host_real_attribs[host_lev][std::make_pair(grid,tile)][i].begin(),
+                                   host_real_attribs[host_lev][std::make_pair(grid,tile)][i].end(),
+                                   dst_tile.GetStructOfArrays().GetRealData(i).begin() + old_size);
                 }
 
                 for (int i = 0; i < NArrayInt; ++i) {
-                    Gpu::copy(Gpu::hostToDevice,
-                              host_int_attribs[host_lev][std::make_pair(grid,tile)][i].begin(),
-                              host_int_attribs[host_lev][std::make_pair(grid,tile)][i].end(),
-                              dst_tile.GetStructOfArrays().GetIntData(i).begin() + old_size);
+                    Gpu::copyAsync(Gpu::hostToDevice,
+                                   host_int_attribs[host_lev][std::make_pair(grid,tile)][i].begin(),
+                                   host_int_attribs[host_lev][std::make_pair(grid,tile)][i].end(),
+                                   dst_tile.GetStructOfArrays().GetIntData(i).begin() + old_size);
                 }
             }
         }
-        // Let Redistribute() sort out where the particles beLong.
+        Gpu::streamSynchronize();
+
+        // Let Redistribute() sort out where the particles belong.
         Redistribute();
     }
 
@@ -1399,7 +1405,7 @@ InitOnePerCell (Real x_off, Real y_off, Real z_off, const ParticleInitData& pdat
 
         m_particles[0][ind].resize(ptile_tmp.numParticles());
         amrex::copyParticles(m_particles[0][ind], ptile_tmp);
-        Gpu::Device::synchronize();
+        Gpu::Device::streamSynchronize();
     }
 
     Redistribute();
@@ -1521,27 +1527,27 @@ InitNRandomPerCell (int n_per_cell, const ParticleInitData& pdata)
                 auto new_size = old_size + src_tid.size();
                 dst_tile.resize(new_size);
 
-                Gpu::copy(Gpu::hostToDevice, src_tid.begin(), src_tid.end(),
-                          dst_tile.GetArrayOfStructs().begin() + old_size);
+                Gpu::copyAsync(Gpu::hostToDevice, src_tid.begin(), src_tid.end(),
+                               dst_tile.GetArrayOfStructs().begin() + old_size);
 
                 for (int i = 0; i < NArrayReal; ++i)
                 {
-                    Gpu::copy(Gpu::hostToDevice,
-                              host_real_attribs[host_lev][std::make_pair(gid,tid)][i].begin(),
-                              host_real_attribs[host_lev][std::make_pair(gid,tid)][i].end(),
-                              dst_tile.GetStructOfArrays().GetRealData(i).begin() + old_size);
+                    Gpu::copyAsync(Gpu::hostToDevice,
+                                   host_real_attribs[host_lev][std::make_pair(gid,tid)][i].begin(),
+                                   host_real_attribs[host_lev][std::make_pair(gid,tid)][i].end(),
+                                   dst_tile.GetStructOfArrays().GetRealData(i).begin() + old_size);
                 }
 
                 for (int i = 0; i < NArrayInt; ++i)
                 {
-                    Gpu::copy(Gpu::hostToDevice,
-                              host_int_attribs[host_lev][std::make_pair(gid,tid)][i].begin(),
-                              host_int_attribs[host_lev][std::make_pair(gid,tid)][i].end(),
-                              dst_tile.GetStructOfArrays().GetIntData(i).begin() + old_size);
+                    Gpu::copyAsync(Gpu::hostToDevice,
+                                   host_int_attribs[host_lev][std::make_pair(gid,tid)][i].begin(),
+                                   host_int_attribs[host_lev][std::make_pair(gid,tid)][i].end(),
+                                   dst_tile.GetStructOfArrays().GetIntData(i).begin() + old_size);
                 }
             }
         }
-
+        Gpu::streamSynchronize();
     }
 
     if (m_verbose > 1)

--- a/Src/Particle/AMReX_ParticleLocator.H
+++ b/Src/Particle/AMReX_ParticleLocator.H
@@ -116,7 +116,7 @@ public:
         for (int i = 0; i < num_boxes; ++i) m_host_boxes.push_back(ba[i]);
 
         m_device_boxes.resize(num_boxes);
-        Gpu::copy(Gpu::hostToDevice, m_host_boxes.begin(), m_host_boxes.end(), m_device_boxes.begin());
+        Gpu::copyAsync(Gpu::hostToDevice, m_host_boxes.begin(), m_host_boxes.end(), m_device_boxes.begin());
 
         // compute the lo, hi and the max box size in each direction
         ReduceOps<AMREX_D_DECL(ReduceOpMin, ReduceOpMin, ReduceOpMin),
@@ -274,9 +274,9 @@ public:
             m_locators[lev].build(a_ba[lev], a_geom[lev]);
             h_grid_assignors[lev] = m_locators[lev].getGridAssignor();
         }
-        Gpu::htod_memcpy(m_grid_assignors.data(), h_grid_assignors.data(),
-                         sizeof(AssignGrid<BinIteratorFactory>)*num_levels);
-        Gpu::synchronize();
+        Gpu::htod_memcpy_async(m_grid_assignors.data(), h_grid_assignors.data(),
+                               sizeof(AssignGrid<BinIteratorFactory>)*num_levels);
+        Gpu::streamSynchronize();
 #else
         for (int lev = 0; lev < num_levels; ++lev)
         {
@@ -329,9 +329,9 @@ public:
             m_locators[lev].setGeometry(a_gdb->Geom(lev));
             h_grid_assignors[lev] = m_locators[lev].getGridAssignor();
         }
-        Gpu::htod_memcpy(m_grid_assignors.data(), h_grid_assignors.data(),
-                         sizeof(AssignGrid<BinIteratorFactory>)*num_levels);
-        Gpu::synchronize();
+        Gpu::htod_memcpy_async(m_grid_assignors.data(), h_grid_assignors.data(),
+                               sizeof(AssignGrid<BinIteratorFactory>)*num_levels);
+        Gpu::streamSynchronize();
 #else
         for (int lev = 0; lev < num_levels; ++lev)
         {

--- a/Src/Particle/AMReX_ParticleTile.H
+++ b/Src/Particle/AMReX_ParticleTile.H
@@ -583,7 +583,7 @@ struct ParticleTile
 
 #ifdef AMREX_USE_GPU
         if ((h_runtime_r_ptrs.size() > 0) || (h_runtime_i_ptrs.size() > 0)) {
-            Gpu::synchronize();
+            Gpu::streamSynchronize();
         }
 #endif
 
@@ -638,7 +638,7 @@ struct ParticleTile
 
 #ifdef AMREX_USE_GPU
         if ((h_runtime_r_cptrs.size() > 0) || (h_runtime_i_cptrs.size() > 0)) {
-            Gpu::synchronize();
+            Gpu::streamSynchronize();
         }
 #endif
 

--- a/Src/Particle/AMReX_ParticleTransformation.H
+++ b/Src/Particle/AMReX_ParticleTransformation.H
@@ -162,7 +162,7 @@ void copyParticles (DstTile& dst, const SrcTile& src,
         copyParticle(dst_data, src_data, src_start+i, dst_start+i);
     });
 
-    Gpu::synchronize();
+    Gpu::streamSynchronize();
 }
 
 /**
@@ -216,7 +216,7 @@ void transformParticles (DstTile& dst, const SrcTile& src,
         f(dst_data, src_data, src_start+i, dst_start+i);
     });
 
-    Gpu::synchronize();
+    Gpu::streamSynchronize();
 }
 
 /**
@@ -277,7 +277,7 @@ void transformParticles (DstTile1& dst1, DstTile2& dst2, const SrcTile& src,
         f(dst1_data, dst2_data, src_data, src_start+i, dst1_start+i, dst2_start+i);
     });
 
-    Gpu::synchronize();
+    Gpu::streamSynchronize();
 }
 
 /**
@@ -338,7 +338,7 @@ Index filterParticles (DstTile& dst, const SrcTile& src, const Index* mask,
         if (mask[i]) copyParticle(dst_data, src_data, src_start+i, dst_start+p_offsets[i]);
     });
 
-    Gpu::synchronize();
+    Gpu::streamSynchronize();
     return last_mask + last_offset;
 }
 
@@ -434,7 +434,7 @@ Index filterAndTransformParticles (DstTile& dst, const SrcTile& src, Index* mask
                                            dst_start+p_offsets[src_start+i]);
     });
 
-    Gpu::synchronize();
+    Gpu::streamSynchronize();
     return last_mask + last_offset;
 }
 
@@ -522,7 +522,7 @@ Index filterAndTransformParticles (DstTile1& dst1, DstTile2& dst2,
         if (mask[i]) f(dst_data1, dst_data2, src_data, i, p_offsets[i], p_offsets[i]);
     });
 
-    Gpu::synchronize();
+    Gpu::streamSynchronize();
     return last_mask + last_offset;
 }
 
@@ -627,7 +627,7 @@ void gatherParticles (PTile& dst, const PTile& src, N np, const Index* inds)
         copyParticle(dst_data, src_data, inds[i], i);
     });
 
-    Gpu::synchronize();
+    Gpu::streamSynchronize();
 }
 
 /**
@@ -657,7 +657,7 @@ void scatterParticles (PTile& dst, const PTile& src, N np, const Index* inds)
         copyParticle(dst_data, src_data, i, inds[i]);
     });
 
-    Gpu::synchronize();
+    Gpu::streamSynchronize();
 }
 
 }

--- a/Src/Particle/AMReX_SparseBins.H
+++ b/Src/Particle/AMReX_SparseBins.H
@@ -139,13 +139,15 @@ public:
         }
 
         m_bins.resize(host_bins.size());
-        Gpu::copy(Gpu::hostToDevice, host_bins.begin(), host_bins.end(), m_bins.begin());
+        Gpu::copyAsync(Gpu::hostToDevice, host_bins.begin(), host_bins.end(), m_bins.begin());
 
         m_offsets.resize(host_offsets.size());
-        Gpu::copy(Gpu::hostToDevice, host_offsets.begin(), host_offsets.end(), m_offsets.begin());
+        Gpu::copyAsync(Gpu::hostToDevice, host_offsets.begin(), host_offsets.end(), m_offsets.begin());
 
         m_perm.resize(host_perm.size());
-        Gpu::copy(Gpu::hostToDevice, host_perm.begin(), host_perm.end(), m_perm.begin());
+        Gpu::copyAsync(Gpu::hostToDevice, host_perm.begin(), host_perm.end(), m_perm.begin());
+
+        Gpu::streamSynchronize();
     }
 
     //! \brief the number of items in the container

--- a/Src/Particle/AMReX_WriteBinaryParticleData.H
+++ b/Src/Particle/AMReX_WriteBinaryParticleData.H
@@ -184,11 +184,11 @@ packIOData (Vector<int>& idata, Vector<ParticleReal>& rdata, const PC& pc, int l
 
     typename PC::IntVector write_int_comp_d(write_int_comp.size());
     typename PC::IntVector write_real_comp_d(write_real_comp.size());
-    Gpu::copy(Gpu::hostToDevice, write_int_comp.begin(), write_int_comp.end(),
-              write_int_comp_d.begin());
-    Gpu::copy(Gpu::hostToDevice, write_real_comp.begin(), write_real_comp.end(),
-              write_real_comp_d.begin());
-    Gpu::Device::synchronize();
+    Gpu::copyAsync(Gpu::hostToDevice, write_int_comp.begin(), write_int_comp.end(),
+                   write_int_comp_d.begin());
+    Gpu::copyAsync(Gpu::hostToDevice, write_real_comp.begin(), write_real_comp.end(),
+                   write_real_comp_d.begin());
+    Gpu::Device::streamSynchronize();
 
     const auto write_int_comp_d_ptr = write_int_comp_d.data();
     const auto write_real_comp_d_ptr = write_real_comp_d.data();
@@ -243,9 +243,9 @@ packIOData (Vector<int>& idata, Vector<ParticleReal>& rdata, const PC& pc, int l
         poffset += num_copies;
     }
 
-    Gpu::copy(Gpu::deviceToHost, idata_d.begin(), idata_d.end(), idata.begin());
-    Gpu::copy(Gpu::deviceToHost, rdata_d.begin(), rdata_d.end(), rdata.begin());
-    Gpu::Device::synchronize();
+    Gpu::copyAsync(Gpu::deviceToHost, idata_d.begin(), idata_d.end(), idata.begin());
+    Gpu::copyAsync(Gpu::deviceToHost, rdata_d.begin(), rdata_d.end(), rdata.begin());
+    Gpu::Device::streamSynchronize();
 }
 
 template <class PC>
@@ -375,7 +375,7 @@ void WriteBinaryParticleDataSync (PC const& pc,
         }
     }
 
-    Gpu::Device::synchronize();
+    Gpu::Device::streamSynchronize();
 
     if(pc.GetUsePrePost())
     {

--- a/Tests/GPU/AnyOf/main.cpp
+++ b/Tests/GPU/AnyOf/main.cpp
@@ -54,7 +54,7 @@ void main_main ()
     {
         BL_PROFILE("Vector AnyOf");
 
-        Gpu::Device::synchronize();
+        Gpu::Device::streamSynchronize();
 
         bool anyof_M = Reduce::AnyOf(nitem, vec.dataPtr(),
                         [=] AMREX_GPU_DEVICE (Real item) noexcept -> int

--- a/Tests/GPU/AtomicIf/main.cpp
+++ b/Tests/GPU/AtomicIf/main.cpp
@@ -53,11 +53,11 @@ void test ()
                                                });
                            });
     }
-    Gpu::synchronize();
+    Gpu::streamSynchronize();
 
     std::vector<T> v_h(N);
     Gpu::copyAsync(Gpu::deviceToHost, v_d.begin(), v_d.end(), v_h.begin());
-    Gpu::synchronize();
+    Gpu::streamSynchronize();
 
     // The first 4000 entries should all be 0.0
     for (int i = 0; i < 4000; ++i) {
@@ -81,4 +81,3 @@ int main (int argc, char* argv[])
     test<amrex::Long>();
     amrex::Finalize();
 }
-

--- a/Tests/GPU/RandomNumberGeneration/main.cpp
+++ b/Tests/GPU/RandomNumberGeneration/main.cpp
@@ -45,7 +45,7 @@ void RandomNumGen ()
             z_d_ptr[i] = amrex::Random(engine);
         });
 
-        Gpu::synchronize();
+        Gpu::streamSynchronize();
     }
 
     std::vector<Real> x_h(Ndraw);
@@ -54,7 +54,7 @@ void RandomNumGen ()
     Gpu::copyAsync(Gpu::deviceToHost, x_d.begin(), x_d.end(), x_h.begin());
     Gpu::copyAsync(Gpu::deviceToHost, y_d.begin(), y_d.end(), y_h.begin());
     Gpu::copyAsync(Gpu::deviceToHost, z_d.begin(), z_d.end(), z_h.begin());
-    Gpu::synchronize();
+    Gpu::streamSynchronize();
 
     Real xmean=0., ymean=0., zmean=0., xvar=0., yvar=0., zvar=0.;
     for (int i = 0; i < Ndraw; ++i) {

--- a/Tests/GPU/Vector/main.cpp
+++ b/Tests/GPU/Vector/main.cpp
@@ -94,7 +94,7 @@ void async_test()
     amrex::Print() << "Async Synching -- should print second." << std::endl;
 #endif
 
-    Gpu::Device::synchronize();
+    Gpu::Device::streamSynchronize();
 }
 
 int main (int argc, char* argv[])
@@ -113,4 +113,3 @@ int main (int argc, char* argv[])
     }
     amrex::Finalize();
 }
-

--- a/Tests/Particles/AsyncIO/main.cpp
+++ b/Tests/Particles/AsyncIO/main.cpp
@@ -121,44 +121,44 @@ public:
             auto new_size = old_size + host_particles.size();
             particle_tile.resize(new_size);
 
-            Gpu::copy(Gpu::hostToDevice,
-                      host_particles.begin(),
-                      host_particles.end(),
-                      particle_tile.GetArrayOfStructs().begin() + old_size);
+            Gpu::copyAsync(Gpu::hostToDevice,
+                           host_particles.begin(),
+                           host_particles.end(),
+                           particle_tile.GetArrayOfStructs().begin() + old_size);
 
             auto& soa = particle_tile.GetStructOfArrays();
             for (int i = 0; i < NAR; ++i)
             {
-                Gpu::copy(Gpu::hostToDevice,
-                          host_real[i].begin(),
-                          host_real[i].end(),
-                          soa.GetRealData(i).begin() + old_size);
+                Gpu::copyAsync(Gpu::hostToDevice,
+                               host_real[i].begin(),
+                               host_real[i].end(),
+                               soa.GetRealData(i).begin() + old_size);
             }
 
             for (int i = 0; i < NAI; ++i)
             {
-                Gpu::copy(Gpu::hostToDevice,
-                          host_int[i].begin(),
-                          host_int[i].end(),
-                          soa.GetIntData(i).begin() + old_size);
+                Gpu::copyAsync(Gpu::hostToDevice,
+                               host_int[i].begin(),
+                               host_int[i].end(),
+                               soa.GetIntData(i).begin() + old_size);
             }
             for (int i = 0; i < NumRuntimeRealComps(); ++i)
             {
-                Gpu::copy(Gpu::hostToDevice,
-                          host_runtime_real[i].begin(),
-                          host_runtime_real[i].end(),
-                          soa.GetRealData(NAR+i).begin() + old_size);
+                Gpu::copyAsync(Gpu::hostToDevice,
+                               host_runtime_real[i].begin(),
+                               host_runtime_real[i].end(),
+                               soa.GetRealData(NAR+i).begin() + old_size);
             }
 
             for (int i = 0; i < NumRuntimeIntComps(); ++i)
             {
-                Gpu::copy(Gpu::hostToDevice,
-                          host_runtime_int[i].begin(),
-                          host_runtime_int[i].end(),
-                          soa.GetIntData(NAI+i).begin() + old_size);
+                Gpu::copyAsync(Gpu::hostToDevice,
+                               host_runtime_int[i].begin(),
+                               host_runtime_int[i].end(),
+                               soa.GetIntData(NAI+i).begin() + old_size);
             }
 
-            Gpu::synchronize();
+            Gpu::streamSynchronize();
         }
 
         Redistribute();

--- a/Tests/Particles/DenseBins/main.cpp
+++ b/Tests/Particles/DenseBins/main.cpp
@@ -60,8 +60,8 @@ void testGPU (int nbins, const amrex::Vector<int>& items)
 {
     // copy to device
     Gpu::DeviceVector<int> items_d(items.size());
-    Gpu::copy(Gpu::hostToDevice, items.begin(), items.end(), items_d.begin());
-    Gpu::Device::synchronize();
+    Gpu::copyAsync(Gpu::hostToDevice, items.begin(), items.end(), items_d.begin());
+    Gpu::Device::streamSynchronize();
 
     amrex::DenseBins<int> bins;
     bins.build(BinPolicy::GPU, items_d.size(), items_d.data(), nbins, [=] AMREX_GPU_DEVICE (int j) noexcept -> unsigned int { return j ; });

--- a/Tests/Particles/Intersection/main.cpp
+++ b/Tests/Particles/Intersection/main.cpp
@@ -83,7 +83,7 @@ void testIntersection()
             int num_cells = host_cells.size();
 
             Gpu::DeviceVector<IntVect> device_cells(num_cells);
-            Gpu::copy(Gpu::hostToDevice, host_cells.begin(), host_cells.end(), device_cells.begin());
+            Gpu::copyAsync(Gpu::hostToDevice, host_cells.begin(), host_cells.end(), device_cells.begin());
 
             Gpu::DeviceVector<int> device_grids(num_cells);
 

--- a/Tests/Particles/NeighborParticles/MDParticleContainer.cpp
+++ b/Tests/Particles/NeighborParticles/MDParticleContainer.cpp
@@ -112,27 +112,27 @@ InitParticles(const IntVect& a_num_particles_per_cell,
         auto new_size = old_size + host_particles.size();
         particle_tile.resize(new_size);
 
-        Gpu::copy(Gpu::hostToDevice, host_particles.begin(), host_particles.end(),
-                  particle_tile.GetArrayOfStructs().begin() + old_size);
+        Gpu::copyAsync(Gpu::hostToDevice, host_particles.begin(), host_particles.end(),
+                       particle_tile.GetArrayOfStructs().begin() + old_size);
 
         auto& soa = particle_tile.GetStructOfArrays();
         for (int i = 0; i < NumRealComps(); ++i)
         {
-            Gpu::copy(Gpu::hostToDevice,
-                      host_real[i].begin(),
-                      host_real[i].end(),
-                      soa.GetRealData(i).begin() + old_size);
+            Gpu::copyAsync(Gpu::hostToDevice,
+                           host_real[i].begin(),
+                           host_real[i].end(),
+                           soa.GetRealData(i).begin() + old_size);
         }
 
         for (int i = 0; i < NumIntComps(); ++i)
         {
-            Gpu::copy(Gpu::hostToDevice,
-                      host_int[i].begin(),
-                      host_int[i].end(),
-                      soa.GetIntData(i).begin() + old_size);
+            Gpu::copyAsync(Gpu::hostToDevice,
+                           host_int[i].begin(),
+                           host_int[i].end(),
+                           soa.GetIntData(i).begin() + old_size);
         }
 
-        Gpu::synchronize();
+        Gpu::streamSynchronize();
     }
 
     amrex::PrintToFile("neighbor_test") << " Number of particles is " << this->TotalNumberOfParticles()<< " \n";

--- a/Tests/Particles/ParallelContext/main.cpp
+++ b/Tests/Particles/ParallelContext/main.cpp
@@ -126,44 +126,44 @@ public:
             auto new_size = old_size + host_particles.size();
             particle_tile.resize(new_size);
 
-            Gpu::copy(Gpu::hostToDevice,
-                      host_particles.begin(),
-                      host_particles.end(),
-                      particle_tile.GetArrayOfStructs().begin() + old_size);
+            Gpu::copyAsync(Gpu::hostToDevice,
+                           host_particles.begin(),
+                           host_particles.end(),
+                           particle_tile.GetArrayOfStructs().begin() + old_size);
 
             auto& soa = particle_tile.GetStructOfArrays();
             for (int i = 0; i < NAR; ++i)
             {
-                Gpu::copy(Gpu::hostToDevice,
-                          host_real[i].begin(),
-                          host_real[i].end(),
-                          soa.GetRealData(i).begin() + old_size);
+                Gpu::copyAsync(Gpu::hostToDevice,
+                               host_real[i].begin(),
+                               host_real[i].end(),
+                               soa.GetRealData(i).begin() + old_size);
             }
 
             for (int i = 0; i < NAI; ++i)
             {
-                Gpu::copy(Gpu::hostToDevice,
-                          host_int[i].begin(),
-                          host_int[i].end(),
-                          soa.GetIntData(i).begin() + old_size);
+                Gpu::copyAsync(Gpu::hostToDevice,
+                               host_int[i].begin(),
+                               host_int[i].end(),
+                               soa.GetIntData(i).begin() + old_size);
             }
             for (int i = 0; i < NumRuntimeRealComps(); ++i)
             {
-                Gpu::copy(Gpu::hostToDevice,
-                          host_runtime_real[i].begin(),
-                          host_runtime_real[i].end(),
-                          soa.GetRealData(NAR+i).begin() + old_size);
+                Gpu::copyAsync(Gpu::hostToDevice,
+                               host_runtime_real[i].begin(),
+                               host_runtime_real[i].end(),
+                               soa.GetRealData(NAR+i).begin() + old_size);
             }
 
             for (int i = 0; i < NumRuntimeIntComps(); ++i)
             {
-                Gpu::copy(Gpu::hostToDevice,
-                          host_runtime_int[i].begin(),
-                          host_runtime_int[i].end(),
-                          soa.GetIntData(NAI+i).begin() + old_size);
+                Gpu::copyAsync(Gpu::hostToDevice,
+                               host_runtime_int[i].begin(),
+                               host_runtime_int[i].end(),
+                               soa.GetIntData(NAI+i).begin() + old_size);
             }
 
-            Gpu::synchronize();
+            Gpu::streamSynchronize();
         }
 
         RedistributeLocal();

--- a/Tests/Particles/ParticleReduce/main.cpp
+++ b/Tests/Particles/ParticleReduce/main.cpp
@@ -99,23 +99,23 @@ public:
             auto new_size = old_size + host_particles.size();
             particle_tile.resize(new_size);
 
-            Gpu::copy(Gpu::hostToDevice, host_particles.begin(), host_particles.end(),
-                      particle_tile.GetArrayOfStructs().begin() + old_size);
+            Gpu::copyAsync(Gpu::hostToDevice, host_particles.begin(), host_particles.end(),
+                           particle_tile.GetArrayOfStructs().begin() + old_size);
 
             auto& soa = particle_tile.GetStructOfArrays();
             for (int i = 0; i < NAR; ++i)
             {
-                Gpu::copy(Gpu::hostToDevice, host_real[i].begin(), host_real[i].end(),
-                          soa.GetRealData(i).begin() + old_size);
+                Gpu::copyAsync(Gpu::hostToDevice, host_real[i].begin(), host_real[i].end(),
+                               soa.GetRealData(i).begin() + old_size);
             }
 
             for (int i = 0; i < NAI; ++i)
             {
-                Gpu::copy(Gpu::hostToDevice, host_int[i].begin(), host_int[i].end(),
-                          soa.GetIntData(i).begin() + old_size);
+                Gpu::copyAsync(Gpu::hostToDevice, host_int[i].begin(), host_int[i].end(),
+                               soa.GetIntData(i).begin() + old_size);
             }
 
-            Gpu::synchronize();
+            Gpu::streamSynchronize();
         }
     }
 };

--- a/Tests/Particles/ParticleTransformations/main.cpp
+++ b/Tests/Particles/ParticleTransformations/main.cpp
@@ -100,23 +100,23 @@ public:
             auto new_size = old_size + host_particles.size();
             particle_tile.resize(new_size);
 
-            Gpu::copy(Gpu::hostToDevice, host_particles.begin(), host_particles.end(),
-                      particle_tile.GetArrayOfStructs().begin() + old_size);
+            Gpu::copyAsync(Gpu::hostToDevice, host_particles.begin(), host_particles.end(),
+                           particle_tile.GetArrayOfStructs().begin() + old_size);
 
             auto& soa = particle_tile.GetStructOfArrays();
             for (int i = 0; i < NAR; ++i)
             {
-                Gpu::copy(Gpu::hostToDevice, host_real[i].begin(), host_real[i].end(),
-                          soa.GetRealData(i).begin() + old_size);
+                Gpu::copyAsync(Gpu::hostToDevice, host_real[i].begin(), host_real[i].end(),
+                               soa.GetRealData(i).begin() + old_size);
             }
 
             for (int i = 0; i < NAI; ++i)
             {
-                Gpu::copy(Gpu::hostToDevice, host_int[i].begin(), host_int[i].end(),
-                          soa.GetIntData(i).begin() + old_size);
+                Gpu::copyAsync(Gpu::hostToDevice, host_int[i].begin(), host_int[i].end(),
+                               soa.GetIntData(i).begin() + old_size);
             }
 
-            Gpu::synchronize();
+            Gpu::streamSynchronize();
         }
     }
 };

--- a/Tests/Particles/Redistribute/main.cpp
+++ b/Tests/Particles/Redistribute/main.cpp
@@ -138,44 +138,44 @@ public:
             auto new_size = old_size + host_particles.size();
             particle_tile.resize(new_size);
 
-            Gpu::copy(Gpu::hostToDevice,
-                      host_particles.begin(),
-                      host_particles.end(),
-                      particle_tile.GetArrayOfStructs().begin() + old_size);
+            Gpu::copyAsync(Gpu::hostToDevice,
+                           host_particles.begin(),
+                           host_particles.end(),
+                           particle_tile.GetArrayOfStructs().begin() + old_size);
 
             auto& soa = particle_tile.GetStructOfArrays();
             for (int i = 0; i < NAR; ++i)
             {
-                Gpu::copy(Gpu::hostToDevice,
-                          host_real[i].begin(),
-                          host_real[i].end(),
-                          soa.GetRealData(i).begin() + old_size);
+                Gpu::copyAsync(Gpu::hostToDevice,
+                               host_real[i].begin(),
+                               host_real[i].end(),
+                               soa.GetRealData(i).begin() + old_size);
             }
 
             for (int i = 0; i < NAI; ++i)
             {
-                Gpu::copy(Gpu::hostToDevice,
-                          host_int[i].begin(),
-                          host_int[i].end(),
-                          soa.GetIntData(i).begin() + old_size);
+                Gpu::copyAsync(Gpu::hostToDevice,
+                               host_int[i].begin(),
+                               host_int[i].end(),
+                               soa.GetIntData(i).begin() + old_size);
             }
             for (int i = 0; i < NumRuntimeRealComps(); ++i)
             {
-                Gpu::copy(Gpu::hostToDevice,
-                          host_runtime_real[i].begin(),
-                          host_runtime_real[i].end(),
-                          soa.GetRealData(NAR+i).begin() + old_size);
+                Gpu::copyAsync(Gpu::hostToDevice,
+                               host_runtime_real[i].begin(),
+                               host_runtime_real[i].end(),
+                               soa.GetRealData(NAR+i).begin() + old_size);
             }
 
             for (int i = 0; i < NumRuntimeIntComps(); ++i)
             {
-                Gpu::copy(Gpu::hostToDevice,
-                          host_runtime_int[i].begin(),
-                          host_runtime_int[i].end(),
-                          soa.GetIntData(NAI+i).begin() + old_size);
+                Gpu::copyAsync(Gpu::hostToDevice,
+                               host_runtime_int[i].begin(),
+                               host_runtime_int[i].end(),
+                               soa.GetIntData(NAI+i).begin() + old_size);
             }
 
-            Gpu::synchronize();
+            Gpu::streamSynchronize();
         }
 
         RedistributeLocal();


### PR DESCRIPTION
The default stream (e.g., stream used outside MFIter) used to be the null
stream for CUDA and HIP.  By default, there is implicit synchronization
between the null stream and other streams.  To avoid that, the default
stream in AMReX is now no longer the null stream.

The behavior of Gpu::synchronize being device wide synchronization has not
changed.  However, for most of its use cases, it can be replaced by a new
function Gpu::streamSynchronizeAll that will synchronize the activities on
all AMReX streams without performing a device wide synchronization that
could potentially interfere with other libraries (e.g., MPI).

The behavior of [dtod|dtoh|htod]_memcpy has changed.  For CUDA and HIP,
these functions used to call the synchronous version of the memcpy.
However, the exact synchronization behavior depends on the memory types.
For SYCL/DPC++, there is no equivalent form because a queue (i.e., stream)
must be specified.  Furthermore, there is no guarantee of consistence across
different vendor platforms.  This has now changed to calling the
asynchronous form using the current stream followed by a stream
synchronization.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [x] include documentation in the code and/or rst files, if appropriate
