### PR TITLE
Reimplement amrex::min and max to work around an nvcc bug

### DIFF
--- a/Docs/sphinx_documentation/source/Basics.rst
+++ b/Docs/sphinx_documentation/source/Basics.rst
@@ -34,9 +34,9 @@ main difference between :cpp:`Vector` and :cpp:`std::vector` is that
 :cpp:`DEBUG=TRUE`.
 
 :cpp:`Array` class in ``AMReX_Array.H`` is simply an alias to :cpp:`std::array`.
-It is used throughout AMReX, however its functions are not defined
-for device code. :cpp:`GpuArray` is AMReX's built-in alternative.  It
-is a trivial type that works on both host and device.  It also works
+AMReX also provides :cpp:`GpuArray`, a trivial type that works on both host
+and device. (It was added when the minimal requirement for C++ standard was
+C++11, for which :cpp:`std::array` does not work on device.) It also works
 when compiled just for CPU.  Besides :cpp:`GpuArray`, AMReX also
 provides GPU safe :cpp:`Array1D`, :cpp:`Array2D` and :cpp:`Array3D` that are
 1, 2 and 3-dimensional fixed size arrays, respectively.  These three

--- a/Docs/sphinx_documentation/source/GPU.rst
+++ b/Docs/sphinx_documentation/source/GPU.rst
@@ -575,9 +575,7 @@ that are important for programming GPUs.
 GpuArray, Array1D, Array2D, and Array3D
 ---------------------------------------
 
-As we have mentioned in :ref:`sec:basics:vecandarr`, :cpp:`std::array`
-cannot be used in device code, whereas :cpp:`GpuArray`,
-:cpp:`Array1D`, :cpp:`Array2D`, and :cpp:`Array3D` are trivial types
+:cpp:`GpuArray`, :cpp:`Array1D`, :cpp:`Array2D`, and :cpp:`Array3D` are trivial types
 that work on both host and device. They can be used whenever a fixed size array
 needs to be passed to the GPU or created on GPU.  A variety of
 functions in AMReX return :cpp:`GpuArray` and they can be
@@ -699,17 +697,6 @@ Also note: :cpp:`Gpu::ManagedVector` is not async-safe.  It cannot be safely
 constructed inside of an MFIter loop with GPU kernels and great care should
 be used when accessing :cpp:`Gpu::ManagedVector` data on GPUs to avoid race
 conditions.
-
-amrex::min and amrex::max
--------------------------
-
-GPU versions of ``std::min`` and ``std::max`` are not provided in CUDA.
-So, AMReX provides a templated :cpp:`min` and :cpp:`max` with host and
-device versions to allow functionality on GPUs. Invoke the explicitly
-namespaced :cpp:`amrex::min(A, B)` or :cpp:`amrex::max(x, y)` to use the
-GPU safe implementations. These functions are variadic, so they can take
-any number of arguments and can be invoked with any standard data type.
-
 
 MultiFab Reductions
 -------------------

--- a/Src/Base/AMReX_Algorithm.H
+++ b/Src/Base/AMReX_Algorithm.H
@@ -20,7 +20,7 @@ namespace amrex
     AMREX_GPU_HOST_DEVICE
     AMREX_FORCE_INLINE constexpr const T& min (const T& a, const T& b) noexcept
     {
-        return (b < a) ? b : a;
+        return std::min(a,b);
     }
 
     template <class T, class ... Ts>
@@ -34,7 +34,7 @@ namespace amrex
     AMREX_GPU_HOST_DEVICE
     AMREX_FORCE_INLINE constexpr const T& max (const T& a, const T& b) noexcept
     {
-        return (a < b) ? b : a;
+        return std::max(a,b);
     }
 
     template <class T, class ... Ts>


### PR DESCRIPTION
This is a workaround for an nvcc bug when compiling ERF in debug mode.

Note that because std::min and max have been constexpr functions since C++14
and AMReX uses C++14 now, there is no need to use amrex::min and max
anymore.  But for backward compatibility, we will still keep them.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
