### PR TITLE
CUDA On Cray: More Robust w/o Wrapper

### DIFF
--- a/Tools/CMake/AMReXParallelBackends.cmake
+++ b/Tools/CMake/AMReXParallelBackends.cmake
@@ -54,6 +54,9 @@ if (  AMReX_GPU_BACKEND STREQUAL "CUDA"
       AND
       CMAKE_VERSION VERSION_GREATER_EQUAL 3.20 )
 
+   find_package(CUDAToolkit REQUIRED)
+   target_link_libraries(amrex PUBLIC CUDA::curand)
+
    # Check cuda compiler and host compiler
    set_mininum_compiler_version(CUDA NVIDIA 9.0)
    check_cuda_host_compiler()


### PR DESCRIPTION
## Summary

Searching for `curand` explicitly (required by default by AMReX) makes HPE/Cray builds more robust when we build w/o compiler wrappers, e.g., if files are distributed in a non-standard layout.

## Additional background

https://gitlab.kitware.com/cmake/cmake/-/merge_requests/7247

Compile error on Perlmutter with `g++` and `nvcc` as compilers was:
```
                 from /global/homes/a/ahuebl/src/amrex/Src/Base/AMReX_Utility.cpp:4:
/global/homes/a/ahuebl/src/amrex/Src/Base/AMReX_RandomEngine.H:14:10: fatal error: curand.h: No such file or directory
   14 | #include <curand.h>
      |          ^~~~~~~~~~
```

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
