### PR TITLE
Fix Wstringop-overflow warning in FabConv

### DIFF
--- a/Src/Base/AMReX_FabConv.cpp
+++ b/Src/Base/AMReX_FabConv.cpp
@@ -375,15 +375,14 @@ _pd_extract_field (char const* in,
 // Byte reverse nitems words.  Each word is nb bytes Long where nb is even.
 //
 
+template <int NB>
 static
 void
-_pd_btrvout (char* out,
-             Long  nb,
-             Long  nitems)
+_pd_btrvout (char* out, Long  nitems)
 {
-    for (Long jl = 0, nbo2 = nb >> 1; jl < nbo2; jl++)
+    for (int jl = 0, nbo2 = NB >> 1; jl < nbo2; jl++)
     {
-        Long jh  = nb - jl - 1;
+        int jh  = NB - jl - 1;
         char* p1 = out + jh;
         char* p2 = out + jl;
         for (Long i = 0L; i < nitems; i++)
@@ -391,8 +390,8 @@ _pd_btrvout (char* out,
             char tmp = *p1;
             *p1 = *p2;
             *p2 = tmp;
-            p1 += nb;
-            p2 += nb;
+            p1 += NB;
+            p2 += NB;
         }
     }
 }
@@ -458,8 +457,13 @@ _pd_insert_field (Long  in_long,
     //
     // Reorder the bytes appropriately.
     //
-    if (l_order == REVERSE_ORDER)
-        _pd_btrvout(in, l_bytes, 1L);
+    if (l_order == REVERSE_ORDER) {
+        if (l_bytes == 4) {
+            _pd_btrvout<4>(in, 1L);
+        } else { // It's either 4 or 8.  There is an assertion in PD_fconvert.
+            _pd_btrvout<8>(in, 1L);
+        }
+    }
     //
     // Copy the remaining aligned bytes over.
     //
@@ -622,6 +626,9 @@ PD_fconvert (void*       out,
              int         onescmp)
 {
 //    BL_PROFILE("PD_fconvert");
+
+    AMREX_ASSERT(l_bytes == 4 || l_bytes == 8); // Otherwise, we need to update _pd_btrvout
+
     Long i, expn, expn_max, hexpn, mant, DeltaBias, hmbo, hmbi;
     int nbits, inbytes, outbytes, sign;
     int indxin, indxout, inrem, outrem, dindx;


### PR DESCRIPTION
On Perlmutter, `g++ -O3 -march=znver3` produces lots of stringop-overflow warnings in
FabConv.  These warnings are false positive because the compiler does not know
sizeof(amrex::Real) is either 4 or 8.  This commit fixes the warnings.

Close #2750

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
