### PR TITLE
Pass value of AMReX_GPU_RDC flag to CMake find_package(AMReX ... )

### DIFF
--- a/Tools/CMake/AMReXConfig.cmake.in
+++ b/Tools/CMake/AMReXConfig.cmake.in
@@ -114,6 +114,7 @@ set(AMReX_CUDA                      @AMReX_CUDA@)
 set(AMReX_SYCL                      @AMReX_DPCPP@)
 set(AMReX_HIP                       @AMReX_HIP@)
 set(AMReX_GPU_BACKEND               @AMReX_GPU_BACKEND@)
+set(AMReX_GPU_RDC                   @AMReX_GPU_RDC@)
 set(AMReX_PRECISION                 @AMReX_PRECISION@)
 set(AMReX_FORTRAN                   @AMReX_FORTRAN@)
 


### PR DESCRIPTION
## Summary
This sets the value of `AMReX_GPU_RDC` in `AMReXConfig.cmake` so when another package calls `find_package(AMREX ...)` in cmake, they can use the value. This fixes an issue where line 128 in `amrex/Tools/CMake/AMReXTargetHelpers.cmake` depends on the value being set. 
 
## Additional background
AMReX-Hydro calls AMReXTargetHelpers, but the value of `AMReX_GPU_RDC` wasn't passed from the AMReX install. This causes the configuration to fail. 

-- This fixes a potential bug in packages installed with CMake that depend on AMReX.

- Follow-up to: #2079 #2061 #2031

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
