### PR TITLE
Add an optional volume weighting to AMRErrorTag

### DIFF
--- a/Src/AmrCore/AMReX_ErrorList.H
+++ b/Src/AmrCore/AMReX_ErrorList.H
@@ -382,6 +382,7 @@ std::ostream& operator << (std::ostream& os, const ErrorList& elst);
     int m_max_level = 1000;
     Real m_min_time = std::numeric_limits<Real>::lowest();
     Real m_max_time = std::numeric_limits<Real>::max();
+    int m_volume_weighting = 0;
     RealBox m_realbox;
 
     AMRErrorTagInfo& SetMaxLevel (int max_level) noexcept {
@@ -398,6 +399,10 @@ std::ostream& operator << (std::ostream& os, const ErrorList& elst);
     }
     AMRErrorTagInfo& SetRealBox (const amrex::RealBox& realbox) noexcept {
       m_realbox = realbox;
+      return *this;
+    }
+    AMRErrorTagInfo& SetVolumeWeighting (int volume_weighting) noexcept {
+      m_volume_weighting = volume_weighting;
       return *this;
     }
   };

--- a/Src/AmrCore/AMReX_ErrorList.cpp
+++ b/Src/AmrCore/AMReX_ErrorList.cpp
@@ -342,7 +342,7 @@ AMRErrorTag::operator() (TagBoxArray&    tba,
                 {
                     ParallelFor(tba, [=] AMREX_GPU_DEVICE (int bi, int i, int j, int k) noexcept
                     {
-                        Real vol = volume_weighting ? Geometry::Volume(IntVect{i,j,k}, geomdata) : 1.0_rt;
+                        Real vol = volume_weighting ? Geometry::Volume(IntVect{AMREX_D_DECL(i,j,k)}, geomdata) : 1.0_rt;
                         if (datma[bi](i,j,k) * vol <= threshold) {
                             tagma[bi](i,j,k) = tagval;
                         }
@@ -352,7 +352,7 @@ AMRErrorTag::operator() (TagBoxArray&    tba,
                 {
                     ParallelFor(tba, [=] AMREX_GPU_DEVICE (int bi, int i, int j, int k) noexcept
                     {
-                        Real vol = volume_weighting ? Geometry::Volume(IntVect{i,j,k}, geomdata) : 1.0_rt;
+                        Real vol = volume_weighting ? Geometry::Volume(IntVect{AMREX_D_DECL(i,j,k)}, geomdata) : 1.0_rt;
                         if (datma[bi](i,j,k) * vol >= threshold) {
                             tagma[bi](i,j,k) = tagval;
                         }

--- a/Src/AmrCore/AMReX_ErrorList.cpp
+++ b/Src/AmrCore/AMReX_ErrorList.cpp
@@ -291,6 +291,8 @@ AMRErrorTag::operator() (TagBoxArray&    tba,
             {
                 auto const& datma   = mf->const_arrays();
                 auto threshold = m_value[level];
+                auto const volume_weighting = m_info.m_volume_weighting;
+                auto geomdata = geom.data();
                 if (m_test == GRAD)
                 {
                     ParallelFor(tba, [=] AMREX_GPU_DEVICE (int bi, int i, int j, int k) noexcept
@@ -340,7 +342,8 @@ AMRErrorTag::operator() (TagBoxArray&    tba,
                 {
                     ParallelFor(tba, [=] AMREX_GPU_DEVICE (int bi, int i, int j, int k) noexcept
                     {
-                        if (datma[bi](i,j,k) <= threshold) {
+                        Real vol = volume_weighting ? Geometry::Volume(IntVect{i,j,k}, geomdata) : 1.0;
+                        if (datma[bi](i,j,k) * vol <= threshold) {
                             tagma[bi](i,j,k) = tagval;
                         }
                     });
@@ -349,7 +352,8 @@ AMRErrorTag::operator() (TagBoxArray&    tba,
                 {
                     ParallelFor(tba, [=] AMREX_GPU_DEVICE (int bi, int i, int j, int k) noexcept
                     {
-                        if (datma[bi](i,j,k) >= threshold) {
+                        Real vol = volume_weighting ? Geometry::Volume(IntVect{i,j,k}, geomdata) : 1.0;
+                        if (datma[bi](i,j,k) * vol >= threshold) {
                             tagma[bi](i,j,k) = tagval;
                         }
                     });

--- a/Src/AmrCore/AMReX_ErrorList.cpp
+++ b/Src/AmrCore/AMReX_ErrorList.cpp
@@ -342,7 +342,7 @@ AMRErrorTag::operator() (TagBoxArray&    tba,
                 {
                     ParallelFor(tba, [=] AMREX_GPU_DEVICE (int bi, int i, int j, int k) noexcept
                     {
-                        Real vol = volume_weighting ? Geometry::Volume(IntVect{i,j,k}, geomdata) : 1.0;
+                        Real vol = volume_weighting ? Geometry::Volume(IntVect{i,j,k}, geomdata) : 1.0_rt;
                         if (datma[bi](i,j,k) * vol <= threshold) {
                             tagma[bi](i,j,k) = tagval;
                         }
@@ -352,7 +352,7 @@ AMRErrorTag::operator() (TagBoxArray&    tba,
                 {
                     ParallelFor(tba, [=] AMREX_GPU_DEVICE (int bi, int i, int j, int k) noexcept
                     {
-                        Real vol = volume_weighting ? Geometry::Volume(IntVect{i,j,k}, geomdata) : 1.0;
+                        Real vol = volume_weighting ? Geometry::Volume(IntVect{i,j,k}, geomdata) : 1.0_rt;
                         if (datma[bi](i,j,k) * vol >= threshold) {
                             tagma[bi](i,j,k) = tagval;
                         }

--- a/Src/Base/AMReX_Geometry.H
+++ b/Src/Base/AMReX_Geometry.H
@@ -282,7 +282,7 @@ public:
 #endif
 
         return vol;
-    };
+    }
 
     /**
     * \brief Compute d(log(A))/dr at cell centers in given region and

--- a/Src/Base/AMReX_Geometry.H
+++ b/Src/Base/AMReX_Geometry.H
@@ -233,8 +233,6 @@ public:
     AMREX_GPU_HOST_DEVICE AMREX_INLINE
     static Real Volume (const IntVect& point, const GeometryData& geomdata)
     {
-        amrex::ignore_unused(point);
-
         auto dx = geomdata.CellSize();
 
         Real vol;
@@ -251,7 +249,7 @@ public:
         else {
             // Spherical
 
-            Real rl = geomdata.ProbLo()[0] + static_cast<Real>(i) * dx[0];
+            Real rl = geomdata.ProbLo()[0] + static_cast<Real>(point[0]) * dx[0];
             Real rr = rl + dx[0];
 
             vol = (4.0_rt / 3.0_rt) * M_PI * dx[0] * (rl * rl + rl * rr + rr * rr);
@@ -276,6 +274,8 @@ public:
         }
 
 #else
+
+        amrex::ignore_unused(point);
 
         // Cartesian
 

--- a/Src/Base/AMReX_Geometry.H
+++ b/Src/Base/AMReX_Geometry.H
@@ -233,6 +233,8 @@ public:
     AMREX_GPU_HOST_DEVICE AMREX_INLINE
     static Real Volume (const IntVect& point, const GeometryData& geomdata)
     {
+        amrex::ignore_unused(point);
+
         auto dx = geomdata.CellSize();
 
         Real vol;

--- a/Src/Base/AMReX_Geometry.H
+++ b/Src/Base/AMReX_Geometry.H
@@ -228,6 +228,62 @@ public:
                     const BoxArray& grds,
                     int             idx,
                     int             grow) const;
+
+    //! Return the volume of the specified cell.
+    AMREX_GPU_HOST_DEVICE AMREX_INLINE
+    static Real Volume (const IntVect& point, const GeometryData& geomdata)
+    {
+        auto dx = geomdata.CellSize();
+
+        Real vol;
+
+#if AMREX_SPACEDIM == 1
+
+        auto coord = geomdata.Coord();
+
+        if (coord == CoordSys::cartesian) {
+            // Cartesian
+
+            vol = dx[0];
+        }
+        else {
+            // Spherical
+
+            Real rl = geomdata.ProbLo()[0] + static_cast<Real>(i) * dx[0];
+            Real rr = rl + dx[0];
+
+            vol = (4.0_rt / 3.0_rt) * M_PI * dx[0] * (rl * rl + rl * rr + rr * rr);
+        }
+
+#elif AMREX_SPACEDIM == 2
+
+        auto coord = geomdata.Coord();
+
+        if (coord == CoordSys::cartesian) {
+            // Cartesian
+
+            vol = dx[0] * dx[1];
+        }
+        else {
+            // Cylindrical
+
+            Real r_l = geomdata.ProbLo()[0] + static_cast<Real>(point[0]) * dx[0];
+            Real r_r = geomdata.ProbLo()[0] + static_cast<Real>(point[0]+1) * dx[0];
+
+            vol = M_PI * (r_l + r_r) * dx[0] * dx[1];
+        }
+
+#else
+
+        // Cartesian
+
+        vol = dx[0] * dx[1] * dx[2];
+
+#endif
+
+        return vol;
+    };
+
     /**
     * \brief Compute d(log(A))/dr at cell centers in given region and
     *           stuff the results into the passed MultiFab.


### PR DESCRIPTION
## Summary

This allows, for example, refining based on the mass in a cell rather than only on its density.

## Additional background

A function to obtain the cell volume at runtime given an IntVect, that can be run inside a ParallelFor, is added to Geometry.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
