### PR TITLE
Fix: AmrCore Move

### DIFF
--- a/Src/AmrCore/AMReX_AmrCore.H
+++ b/Src/AmrCore/AMReX_AmrCore.H
@@ -40,8 +40,8 @@ public:
 
     AmrCore (Geometry const& level_0_geom, AmrInfo const& amr_info);
 
-    AmrCore (AmrCore&& rhs) = default;
-    AmrCore& operator= (AmrCore&& rhs) = default;
+    AmrCore (AmrCore&& rhs);
+    AmrCore& operator= (AmrCore&& rhs);
 
     AmrCore (const AmrCore& rhs) = delete;
     AmrCore& operator= (const AmrCore& rhs) = delete;

--- a/Src/AmrCore/AMReX_AmrCore.cpp
+++ b/Src/AmrCore/AMReX_AmrCore.cpp
@@ -46,6 +46,26 @@ AmrCore::AmrCore (Geometry const& level_0_geom, AmrInfo const& amr_info)
 #endif
 }
 
+AmrCore::AmrCore (AmrCore&& rhs)
+    : AmrMesh(std::move(rhs))
+{
+#ifdef AMREX_PARTICLES
+    m_gdb = std::move(rhs.m_gdb);
+    m_gdb->m_amrcore = this;
+#endif
+}
+
+AmrCore& AmrCore::operator= (AmrCore&& rhs)
+{
+    AmrMesh::operator=(std::move(rhs));
+#ifdef AMREX_PARTICLES
+    m_gdb = std::move(rhs.m_gdb);
+    m_gdb->m_amrcore = this;
+#endif
+
+    return *this;
+}
+
 AmrCore::~AmrCore ()
 {
 }

--- a/Src/AmrCore/AMReX_AmrParGDB.H
+++ b/Src/AmrCore/AMReX_AmrParGDB.H
@@ -10,6 +10,8 @@ namespace amrex {
 class AmrParGDB
     : public ParGDBBase
 {
+    friend AmrCore;
+
 public:
 
     explicit AmrParGDB (AmrCore* amr) noexcept


### PR DESCRIPTION
## Summary

The move constructor and assignment operator for `AmrCore` with particles was broken. The underlying issue was a user-after free from a stale pointer to the old `AmrCore` object, transitively through the `m_gdb` member.

When moving the `unique_ptr<AmrParGDB>` typed `m_gdb` member, its internal `m_amrcore` pointer needs to be updated, too.

## Additional background

First seen in https://github.com/ECP-WarpX/impactx/pull/127

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
