### PR TITLE
Fix the bug in the CMake build with AMReX_BASE_PROFILE.

### DIFF
--- a/Src/Base/CMakeLists.txt
+++ b/Src/Base/CMakeLists.txt
@@ -260,7 +260,7 @@ target_sources( amrex
 # Profiling
 #   this source file has zero symbols in default conditions, which creates
 #   ranlib warnings, e.g., on macOS
-if(AMREX_PROFILING OR AMReX_FORTRAN)
+if(AMReX_BASE_PROFILE OR AMReX_FORTRAN)
    target_sources( amrex
      PRIVATE
        AMReX_BLProfiler.cpp


### PR DESCRIPTION
## Summary
Use the macro 'AMReX_BASE_PROFILE' to control whether to include AMReX_BLProfiler.cpp. This solves the linkage error when building applications with base profiling. 

## Additional background

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
