### PR TITLE
[Docs] Move 'Example Codes' section under 'Getting Started'

### DIFF
--- a/Docs/sphinx_documentation/source/Basics.rst
+++ b/Docs/sphinx_documentation/source/Basics.rst
@@ -2695,14 +2695,3 @@ Backtrace files are produced by AMReX signal handler by default when
 segfault occurs or ``Abort`` is called.  If the application does not
 want AMReX to handle this, ``ParmParse`` parameter
 `amrex.signal_handling=0` can be used to disable it.
-
-
-
-Example Codes
-=============
-
-To assist users we have multiple example codes introducing AMReX functionality.
-They range from HelloWorld walk-thrus to stand-alone examples of complex
-features in practice. To access the available examples, please see
-`AMReX Guided Tutorials and Example Codes
-<https://amrex-codes.github.io/amrex/tutorials_html/>`_.

--- a/Docs/sphinx_documentation/source/EB.rst
+++ b/Docs/sphinx_documentation/source/EB.rst
@@ -49,7 +49,7 @@ Here is a simple example of initialize the database for an embedded sphere.
     EB2::Build(shop, geom, 0, 0);
 
 Alternatively, the EB information can be initialized from an STL file
-specified by a :cpp:`ParmParse` parameter ``eb2.stl_file`.  The
+specified by a :cpp:`ParmParse` parameter ``eb2.stl_file``.  The
 initialization is done by calling
 
 .. highlight:: c++

--- a/Docs/sphinx_documentation/source/EB_Chapter.rst
+++ b/Docs/sphinx_documentation/source/EB_Chapter.rst
@@ -43,11 +43,13 @@ AMReX's relatively simple grid generation technique allows computational
 meshes for rather complex geometries to be generated quickly and robustly.
 However, the technique can produce arbitrarily small cut cells in the domain.
 In practice such small cells can have significant impact on the robustness and
-stability of traditional finite volume methods. Section
-:ref:`amrex_hydro:sec:redistribution` in AMReX-Hydro's documentation overviews the
+stability of traditional finite volume methods. The redistribution_ section
+in AMReX-Hydro's documentation overviews the
 finite volume discretization in an embedded boundary cell and a
 class of approaches to deal with this "small cell" problem in a robust and
 efficient way.
+
+.. _redistribution: https://amrex-codes.github.io/amrex/hydro_html/Redistribution.html
 
 This chapter discusses the EB tools, data structures and algorithms currently
 supported by AMReX to enable the construction of discretizations of

--- a/Docs/sphinx_documentation/source/GPU.rst
+++ b/Docs/sphinx_documentation/source/GPU.rst
@@ -1342,7 +1342,7 @@ will show little improvement or even perform worse. So, this conditional stateme
 should be added to MFIter loops that contain GPU work, unless users specifically test
 the performance or are designing more complex workflows that require OpenMP.
 
-.. _sec:gpu:stream
+.. _sec:gpu:stream:
 
 Stream and Synchronization
 ==========================

--- a/Docs/sphinx_documentation/source/GettingStarted.rst
+++ b/Docs/sphinx_documentation/source/GettingStarted.rst
@@ -238,3 +238,11 @@ features by focusing on key concepts in a progressive way.
 
 .. _`Guided Tutorials`: https://amrex-codes.github.io/amrex/tutorials_html/
 
+Example Codes
+=============
+
+To assist users we have multiple example codes introducing AMReX functionality.
+They range from HelloWorld walk-thrus to stand-alone examples of complex
+features in practice. To access the available examples, please see
+`AMReX Guided Tutorials and Example Codes
+<https://amrex-codes.github.io/amrex/tutorials_html/>`_.


### PR DESCRIPTION
## Summary
In the User's Guide this PR moves the _Example Codes_ section under the _Getting Started_ chapter.  Also fixes various Sphinx doc warnings. 

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [x] include documentation in the code and/or rst files, if appropriate
