### PR TITLE
make sure m_particles is sized properly when numLocalTilesAtLevel is called

### DIFF
--- a/Src/Particle/AMReX_Particles.H
+++ b/Src/Particle/AMReX_Particles.H
@@ -373,9 +373,7 @@ public:
 
     //! \brief The total number of tiles on this rank on this level
     int numLocalTilesAtLevel (int lev) const {
-        reserveData();
-        resizeData();
-        return m_particles[lev].size();
+        return (lev < m_particles.size()) ? m_particles[lev].size() : 0;
     }
 
     void reserveData () override;

--- a/Src/Particle/AMReX_Particles.H
+++ b/Src/Particle/AMReX_Particles.H
@@ -372,7 +372,11 @@ public:
     }
 
     //! \brief The total number of tiles on this rank on this level
-    int numLocalTilesAtLevel (int lev) const { return m_particles[lev].size(); }
+    int numLocalTilesAtLevel (int lev) const {
+        reserveData();
+        resizeData();
+        return m_particles[lev].size();
+    }
 
     void reserveData () override;
     void resizeData () override;


### PR DESCRIPTION
Addresses Issue #2709.

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
