### PR TITLE
Fix solvability issue in the nodal solver RAP approach

### DIFF
--- a/Src/LinearSolvers/MLMG/AMReX_MLLinOp.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLLinOp.H
@@ -231,6 +231,8 @@ public:
     virtual void applyInhomogNeumannTerm (int /*amrlev*/, MultiFab& /*rhs*/) const {}
     virtual void applyOverset (int /*amlev*/, MultiFab& /*rhs*/) const {}
     virtual void scaleRHS (int /*amrlev*/, MultiFab& /*rhs*/) const {}
+    virtual Real getSolvabilityOffset (int /*amrlev*/, int /*mglev*/, MultiFab const& /*rhs*/) const { return 0._rt; } // Only nodal solvers need it
+    virtual void fixSolvabilityByOffset (int /*amrlev*/, int /*mglev*/, MultiFab& /*rhs*/, Real /*offset*/) const {} // Only nodal solvers need it
 
     virtual void prepareForSolve () = 0;
     virtual bool isSingular (int amrlev) const = 0;

--- a/Src/LinearSolvers/MLMG/AMReX_MLMG.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLMG.H
@@ -156,7 +156,6 @@ public:
     void computeVolInv ();
     void makeSolvable ();
     void makeSolvable (int amrlev, int mglev, MultiFab& mf);
-    Real getNodalSum (int amrlev, int mglev, MultiFab& mf) const;
 
 #if defined(AMREX_USE_HYPRE) && (AMREX_SPACEDIM > 1)
     void bottomSolveWithHypre (MultiFab& x, const MultiFab& b);

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian.H
@@ -117,6 +117,8 @@ public :
     virtual void getFluxes (const Vector<MultiFab*>& a_flux,
                             const Vector<MultiFab*>& a_sol) const final override;
     virtual void unimposeNeumannBC (int amrlev, MultiFab& rhs) const final override;
+    virtual Real getSolvabilityOffset (int amrlev, int mglev, MultiFab const& rhs) const override;
+    virtual void fixSolvabilityByOffset (int amrlev, int mglev, MultiFab& rhs, Real offset) const override;
 
     virtual void compGrad (int /*amrlev*/, const Array<MultiFab*,AMREX_SPACEDIM>& /*grad*/,
                            MultiFab& /*sol*/, Location /*loc*/) const final override {

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian.cpp
@@ -171,6 +171,219 @@ MLNodeLaplacian::unimposeNeumannBC (int amrlev, MultiFab& rhs) const
     }
 }
 
+Real
+MLNodeLaplacian::getSolvabilityOffset (int amrlev, int mglev, MultiFab const& rhs) const
+{
+    amrex::ignore_unused(amrlev);
+    AMREX_ASSERT(amrlev==0);
+    AMREX_ASSERT(mglev+1==m_num_mg_levels[0] || mglev==0);
+
+    if (m_coarsening_strategy == CoarseningStrategy::RAP) {
+#ifdef AMREX_USE_EB
+        auto factory = dynamic_cast<EBFArrayBoxFactory const*>(m_factory[amrlev][0].get());
+        if (factory && !factory->isAllRegular()) {
+            if (mglev > 0) {
+                return 0._rt;
+            } else {
+                const MultiFab& vfrac = factory->getVolFrac();
+                const auto& vfrac_ma = vfrac.const_arrays();
+
+                Box dom = Geom(amrlev,mglev).Domain();
+                for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+                    if (m_lobc[0][idim] != LinOpBCType::Neumann &&
+                        m_lobc[0][idim] != LinOpBCType::inflow)
+                    {
+                        dom.growLo(idim, 10);
+                    }
+                    if (m_hibc[0][idim] != LinOpBCType::Neumann &&
+                        m_hibc[0][idim] != LinOpBCType::inflow)
+                    {
+                        dom.growHi(idim, 10);
+                    }
+                }
+
+                const auto& mask = (mglev+1 == m_num_mg_levels[0]) ? m_bottom_dot_mask : m_coarse_dot_mask;
+                const auto& mask_ma = mask.const_arrays();
+                const auto& rhs_ma = rhs.const_arrays();
+                auto r = ParReduce(TypeList<ReduceOpSum,ReduceOpSum>{}, TypeList<Real,Real>{},
+                                   rhs, IntVect(0),
+                                   [=] AMREX_GPU_DEVICE (int box_no, int i, int j, int k) noexcept
+                                       -> GpuTuple<Real,Real>
+                                   {
+                                       Real scale = 0.0_rt;
+#if (AMREX_SPACEDIM == 3)
+                                       int const koff = 1;
+                                       Real const fac = 0.125_rt;
+#else
+                                       int const koff = 0;
+                                       Real const fac = 0.25_rt;
+#endif
+                                       for (int kc = k-koff; kc <= k; ++kc) {
+                                       for (int jc = j-1   ; jc <= j; ++jc) {
+                                       for (int ic = i-1   ; ic <= i; ++ic) {
+                                           if (dom.contains(ic,jc,kc)) {
+                                               scale += vfrac_ma[box_no](ic,jc,kc) * fac;
+                                           }
+                                       }}}
+                                       return { mask_ma[box_no](i,j,k) * rhs_ma[box_no](i,j,k),
+                                                mask_ma[box_no](i,j,k) * scale };
+                                   });
+
+                Real s1 = amrex::get<0>(r);
+                Real s2 = amrex::get<1>(r);
+                ParallelAllReduce::Sum<Real>({s1,s2}, ParallelContext::CommunicatorSub());
+                return s1/s2;
+            }
+        } else
+#endif
+        {
+            Box nddom = amrex::surroundingNodes(Geom(amrlev,mglev).Domain());
+            for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+                if (m_lobc[0][idim] != LinOpBCType::Neumann &&
+                    m_lobc[0][idim] != LinOpBCType::inflow)
+                {
+                    nddom.growLo(idim, 10); // so that the test in ParReduce will faill
+                }
+                if (m_hibc[0][idim] != LinOpBCType::Neumann &&
+                    m_hibc[0][idim] != LinOpBCType::inflow)
+                {
+                    nddom.growHi(idim, 10);
+                }
+            }
+
+            const auto& mask = (mglev+1 == m_num_mg_levels[0]) ? m_bottom_dot_mask : m_coarse_dot_mask;
+            const auto& mask_ma = mask.const_arrays();
+            const auto& rhs_ma = rhs.const_arrays();
+            auto r = ParReduce(TypeList<ReduceOpSum,ReduceOpSum>{}, TypeList<Real,Real>{},
+                               rhs, IntVect(0),
+                               [=] AMREX_GPU_DEVICE (int box_no, int i, int j, int k) noexcept
+                                   -> GpuTuple<Real,Real>
+                               {
+                                   Real scale = 1.0_rt;
+                                   if (i == nddom.smallEnd(0) ||
+                                       i == nddom.bigEnd(0)) {
+                                       scale *= 0.5_rt;
+                                   }
+#if (AMREX_SPACEDIM >= 2)
+                                   if (j == nddom.smallEnd(1) ||
+                                       j == nddom.bigEnd(1)) {
+                                       scale *= 0.5_rt;
+                                   }
+#endif
+#if (AMREX_SPACEDIM == 3)
+                                   if (k == nddom.smallEnd(2) ||
+                                       k == nddom.bigEnd(2)) {
+                                       scale *= 0.5_rt;
+                                   }
+#endif
+                                   return { mask_ma[box_no](i,j,k) * rhs_ma[box_no](i,j,k),
+                                            mask_ma[box_no](i,j,k) * scale };
+                               });
+
+            Real s1 = amrex::get<0>(r);
+            Real s2 = amrex::get<1>(r);
+            ParallelAllReduce::Sum<Real>({s1,s2}, ParallelContext::CommunicatorSub());
+            return s1/s2;
+        }
+    } else {
+        return MLNodeLinOp::getSolvabilityOffset(amrlev, mglev, rhs);
+    }
+}
+
+void
+MLNodeLaplacian::fixSolvabilityByOffset (int amrlev, int mglev, MultiFab& rhs, Real offset) const
+{
+    if (m_coarsening_strategy == CoarseningStrategy::RAP) {
+#ifdef AMREX_USE_EB
+        auto factory = dynamic_cast<EBFArrayBoxFactory const*>(m_factory[amrlev][0].get());
+        if (factory && !factory->isAllRegular()) {
+            if (mglev == 0) {
+                const MultiFab& vfrac = factory->getVolFrac();
+                const auto& vfrac_ma = vfrac.const_arrays();
+
+                Box dom = Geom(amrlev,mglev).Domain();
+                for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+                    if (m_lobc[0][idim] != LinOpBCType::Neumann &&
+                        m_lobc[0][idim] != LinOpBCType::inflow)
+                    {
+                        dom.growLo(idim, 10);
+                    }
+                    if (m_hibc[0][idim] != LinOpBCType::Neumann &&
+                        m_hibc[0][idim] != LinOpBCType::inflow)
+                    {
+                        dom.growHi(idim, 10);
+                    }
+                }
+
+                auto const& rhs_ma = rhs.arrays();
+                ParallelFor(rhs, IntVect(0),
+                            [=] AMREX_GPU_DEVICE (int box_no, int i, int j, int k) noexcept
+                            {
+                                Real scale = 0.0_rt;
+#if (AMREX_SPACEDIM == 3)
+                                int const koff = 1;
+                                Real const fac = 0.125_rt;
+#else
+                                int const koff = 0;
+                                Real const fac = 0.25_rt;
+#endif
+                                for (int kc = k-koff; kc <= k; ++kc) {
+                                for (int jc = j-1   ; jc <= j; ++jc) {
+                                for (int ic = i-1   ; ic <= i; ++ic) {
+                                    if (dom.contains(ic,jc,kc)) {
+                                        scale += vfrac_ma[box_no](ic,jc,kc) * fac;
+                                    }
+                                }}}
+                                rhs_ma[box_no](i,j,k) -= offset * scale;
+                            });
+            }
+        } else
+#endif
+        {
+            Box nddom = amrex::surroundingNodes(Geom(amrlev,mglev).Domain());
+            for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+                if (m_lobc[0][idim] != LinOpBCType::Neumann &&
+                    m_lobc[0][idim] != LinOpBCType::inflow)
+                {
+                    nddom.growLo(idim, 10); // so that the test in ParReduce will faill
+                }
+                if (m_hibc[0][idim] != LinOpBCType::Neumann &&
+                    m_hibc[0][idim] != LinOpBCType::inflow)
+                {
+                    nddom.growHi(idim, 10);
+                }
+            }
+
+            auto const& rhs_ma = rhs.arrays();
+            ParallelFor(rhs, IntVect(0),
+                        [=] AMREX_GPU_DEVICE (int box_no, int i, int j, int k) noexcept
+                        {
+                            Real scale = 1.0_rt;
+                            if (i == nddom.smallEnd(0) ||
+                                i == nddom.bigEnd(0)) {
+                                scale *= 0.5_rt;
+                            }
+#if (AMREX_SPACEDIM >= 2)
+                            if (j == nddom.smallEnd(1) ||
+                                j == nddom.bigEnd(1)) {
+                                scale *= 0.5_rt;
+                            }
+#endif
+#if (AMREX_SPACEDIM == 3)
+                            if (k == nddom.smallEnd(2) ||
+                                k == nddom.bigEnd(2)) {
+                                scale *= 0.5_rt;
+                            }
+#endif
+                            rhs_ma[box_no](i,j,k) -= offset * scale;
+                        });
+        }
+        Gpu::streamSynchronize();
+    } else {
+        rhs.plus(-offset, 0, 1);
+    }
+}
+
 void
 MLNodeLaplacian::setSigma (int amrlev, const MultiFab& a_sigma)
 {

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLinOp.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLinOp.H
@@ -67,7 +67,10 @@ public:
         amrex::Abort("AMReX_MLNodeLinOp::fillSolutionBC::How did we get here?");
     }
 
-    virtual void applyInhomogNeumannTerm (int armlev, MultiFab& rhs) const override;
+    virtual void applyInhomogNeumannTerm (int amrlev, MultiFab& rhs) const override;
+
+    virtual Real getSolvabilityOffset (int amrlev, int mglev, MultiFab const& rhs) const override;
+    virtual void fixSolvabilityByOffset (int amrlev, int mglev, MultiFab& rhs, Real offset) const override;
 
     virtual void prepareForSolve () override {}
 


### PR DESCRIPTION
In the RAP approach of the nodal solver, the RHS at Neumann boundaries only
includes the integral inside the domain.  That is it's only half of what its
"physical" value is.  The usual way of subtracting a constant from the RHS
does not work for RAP.  We should only subtract half of the constant offset
at Neumann boundaries.  The computation of the constant offset needed for
the solvability fix is also affected by the way how RHS is computed at
Neumann boundaries.  For EB, the computation of the constant offset is an
integral of the RHS multiplied by the volume fraction, and the subtraction
also needs to be weighted by the volume fraction.

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
