### PR TITLE
update the SENSEI in situ coupling for SENSEI v4.0.0

### DIFF
--- a/.github/workflows/sensei.yml
+++ b/.github/workflows/sensei.yml
@@ -17,9 +17,9 @@ jobs:
       CC: clang
       CXXFLAGS: "-Werror -Wshadow -Woverloaded-virtual -Wunreachable-code -fno-operator-names"
       CMAKE_GENERATOR: Ninja
-      CMAKE_PREFIX_PATH: /root/install/sensei/develop/lib/cmake
+      CMAKE_PREFIX_PATH: /root/install/sensei/v4.0.0/lib64/cmake
     container:
-      image: ryankrattiger/sensei:fedora33-vtk-mpi-20210616
+      image: senseiinsitu/ci:fedora35-amrex-20220613
     steps:
     - uses: actions/checkout@v2
     - name: Setup
@@ -27,7 +27,7 @@ jobs:
     - name: Configure
       run: |
         cd build
-        cmake ..                  \
+        cmake ..                     \
             -DCMAKE_BUILD_TYPE=Debug \
             -DAMReX_ENABLE_TESTS=ON  \
             -DAMReX_FORTRAN=OFF      \

--- a/Docs/sphinx_documentation/source/Visualization.rst
+++ b/Docs/sphinx_documentation/source/Visualization.rst
@@ -873,9 +873,12 @@ and point to the CMake configuration installed with SENSEI.
 
 .. code-block:: bash
 
-   cmake -DAMReX_SENSEI=ON -DSENSEI_DIR=<path to install>/lib/cmake ..
+   cmake -DAMReX_SENSEI=ON -DSENSEI_DIR=<path to install>/<lib dir>/cmake ..
 
-When CMake generates the make files proceed as usual.
+When CMake generates the make files proceed as usual. Note: <lib dir> may be
+`lib` or `lib64` or something else depending on what CMake decided to use for
+your particular OS. See the CMake GNUInstallDirs documentation for more
+information.
 
 .. code-block:: bash
 
@@ -952,8 +955,7 @@ dataset.
 
 Obtaining SENSEI
 -----------------
-SENSEI is hosted on Kitware's Gitlab site at https://gitlab.kitware.com/sensei/sensei
-It's best to checkout the latest release rather than working on the master branch.
+SENSEI is hosted on github at https://github.com/SENSEI-insitu/SENSEI.git
 
 To ease the burden of wrangling back end installs SENSEI provides two platforms
 with all dependencies pre-installed, a VirtualBox VM, and a NERSC Cori

--- a/Src/Extern/SENSEI/AMReX_AmrDataAdaptor.H
+++ b/Src/Extern/SENSEI/AMReX_AmrDataAdaptor.H
@@ -30,10 +30,10 @@ public:
   int GetNumberOfArrays(const std::string &meshName, int association, unsigned int &numberOfArrays) override;
   int GetArrayName(const std::string &meshName, int association, unsigned int index, std::string &arrayName) override;
 #endif
-  int GetMesh(const std::string &meshName, bool structureOnly, vtkDataObject *&mesh) override;
-  int AddGhostNodesArray(vtkDataObject* mesh, const std::string &meshName) override;
-  int AddGhostCellsArray(vtkDataObject* mesh, const std::string &meshName) override;
-  int AddArray(vtkDataObject* mesh, const std::string &meshName, int association, const std::string &arrayName) override;
+  int GetMesh(const std::string &meshName, bool structureOnly, svtkDataObject *&mesh) override;
+  int AddGhostNodesArray(svtkDataObject* mesh, const std::string &meshName) override;
+  int AddGhostCellsArray(svtkDataObject* mesh, const std::string &meshName) override;
+  int AddArray(svtkDataObject* mesh, const std::string &meshName, int association, const std::string &arrayName) override;
   int ReleaseData() override;
 
 protected:

--- a/Src/Extern/SENSEI/AMReX_AmrDataAdaptor.cpp
+++ b/Src/Extern/SENSEI/AMReX_AmrDataAdaptor.cpp
@@ -1,22 +1,22 @@
 #include "AMReX_AmrDataAdaptor.H"
 
+#include "senseiConfig.h"
 #include "MPIUtils.h"
 #include "STLUtils.h"
-#include "VTKUtils.h"
+#include "SVTKUtils.h"
 #include "Profiler.h"
 #include "Error.h"
 
-#include <vtkObjectFactory.h>
-#include <vtkOverlappingAMR.h>
-#include <vtkAMRBox.h>
-#include <vtkUniformGrid.h>
-#include <vtkXMLUniformGridAMRWriter.h>
-#include <vtkDataSetAttributes.h>
-#include <vtkUnsignedCharArray.h>
-#include <vtkFloatArray.h>
-#include <vtkDoubleArray.h>
-#include <vtkCellData.h>
-#include <vtkPointData.h>
+#include <svtkObjectFactory.h>
+#include <svtkOverlappingAMR.h>
+#include <svtkAMRBox.h>
+#include <svtkUniformGrid.h>
+#include <svtkDataSetAttributes.h>
+#include <svtkUnsignedCharArray.h>
+#include <svtkFloatArray.h>
+#include <svtkDoubleArray.h>
+#include <svtkCellData.h>
+#include <svtkPointData.h>
 
 #include <AMReX_AmrLevel.H>
 #include <AMReX_BoxArray.H>
@@ -62,15 +62,15 @@ int DescriptorMap::Initialize(const DescriptorList &descriptors)
 
             if (itype.cellCentered())
             {
-                this->Map[vtkDataObject::CELL][arrayName] = std::make_pair(i,j);
+                this->Map[svtkDataObject::CELL][arrayName] = std::make_pair(i,j);
             }
             else if (itype.nodeCentered())
             {
-                this->Map[vtkDataObject::POINT][arrayName] = std::make_pair(i,j);
+                this->Map[svtkDataObject::POINT][arrayName] = std::make_pair(i,j);
             }
             else
             {
-                this->Map[vtkDataObject::FIELD][arrayName] = std::make_pair(i,j);
+                this->Map[svtkDataObject::FIELD][arrayName] = std::make_pair(i,j);
             }
         }
     }
@@ -156,7 +156,7 @@ struct AmrDataAdaptor::InternalsType
     int PinMesh;
     amrex::InSituUtils::DescriptorMap SimMetadata;
 #if SENSEI_VERSION_MAJOR < 3
-    std::vector<vtkDataObject*> ManagedObjects;
+    std::vector<svtkDataObject*> ManagedObjects;
 #endif
     std::vector<std::vector<unsigned char *>> Masks;
 };
@@ -225,11 +225,11 @@ int AmrDataAdaptor::GetMeshMetadata(unsigned int id,
     metadata->GlobalView = true;
 
     metadata->MeshName = "mesh";
-    metadata->MeshType = VTK_OVERLAPPING_AMR;
-    metadata->BlockType = VTK_UNIFORM_GRID;
+    metadata->MeshType = SVTK_OVERLAPPING_AMR;
+    metadata->BlockType = SVTK_UNIFORM_GRID;
     metadata->NumBlocks = 0;
     metadata->NumBlocksLocal = {-1};
-    metadata->CoordinateType = InSituUtils::amrex_tt<amrex_real>::vtk_type_enum();
+    metadata->CoordinateType = InSituUtils::amrex_tt<amrex_real>::svtk_type_enum();
     metadata->StaticMesh = 0;
 
     // TODO
@@ -318,14 +318,14 @@ int AmrDataAdaptor::GetMeshMetadata(unsigned int id,
             std::string arrayName = desc.name(j);
             metadata->ArrayName.push_back(arrayName);
             metadata->ArrayComponents.push_back(1);
-            metadata->ArrayType.push_back(InSituUtils::amrex_tt<amrex_real>::vtk_type_enum());
+            metadata->ArrayType.push_back(InSituUtils::amrex_tt<amrex_real>::svtk_type_enum());
 
             if (itype.cellCentered())
-                metadata->ArrayCentering.push_back(vtkDataObject::CELL);
+                metadata->ArrayCentering.push_back(svtkDataObject::CELL);
             else if (itype.nodeCentered())
-                metadata->ArrayCentering.push_back(vtkDataObject::POINT);
+                metadata->ArrayCentering.push_back(svtkDataObject::POINT);
             else
-                metadata->ArrayCentering.push_back(vtkDataObject::FIELD);
+                metadata->ArrayCentering.push_back(svtkDataObject::FIELD);
         }
 
     }
@@ -557,8 +557,8 @@ int AmrDataAdaptor::GetNumberOfArrays(const std::string &meshName,
         return -1;
     }
 
-    if ((association != vtkDataObject::POINT) &&
-        (association != vtkDataObject::CELL))
+    if ((association != svtkDataObject::POINT) &&
+        (association != svtkDataObject::CELL))
     {
         SENSEI_ERROR("Invalid association " << association)
         return -1;
@@ -590,7 +590,7 @@ int AmrDataAdaptor::GetArrayName(const std::string &meshName,
     if (this->Internals->SimMetadata.GetName(association, index, arrayName))
     {
         SENSEI_ERROR("No array named \"" << arrayName << "\" in "
-            << sensei::VTKUtils::GetAttributesName(association)
+            << sensei::SVTKUtils::GetAttributesName(association)
             << " data")
         return -1;
     }
@@ -603,7 +603,7 @@ int AmrDataAdaptor::GetArrayName(const std::string &meshName,
 
 //-----------------------------------------------------------------------------
 int AmrDataAdaptor::GetMesh(const std::string &meshName,
-    bool structureOnly, vtkDataObject *&mesh)
+    bool structureOnly, svtkDataObject *&mesh)
 {
     amrex::ignore_unused(structureOnly);
 
@@ -626,8 +626,8 @@ int AmrDataAdaptor::GetMesh(const std::string &meshName,
 
     unsigned int nLevels = InSituUtils::NumActiveLevels(levels);
 
-    // initialize new vtk datasets
-    vtkOverlappingAMR *amrMesh = vtkOverlappingAMR::New();
+    // initialize new svtk datasets
+    svtkOverlappingAMR *amrMesh = svtkOverlappingAMR::New();
 #if SENSEI_VERSION_MAJOR < 3
     Internals->ManagedObjects.push_back(amrMesh);
 #endif
@@ -685,12 +685,12 @@ int AmrDataAdaptor::GetMesh(const std::string &meshName,
             int cboxLo[3] = {AMREX_ARLIM(cbox.loVect())};
             int cboxHi[3] = {AMREX_ARLIM(cbox.hiVect())};
 
-            // vtk's representation of box metadata
-            vtkAMRBox block(cboxLo, cboxHi);
+            // svtk's representation of box metadata
+            svtkAMRBox block(cboxLo, cboxHi);
             amrMesh->SetAMRBox(i, j, block);
             amrMesh->SetAMRBlockSourceIndex(i, j, gid++);
 
-            // skip building a vtk amrMesh for the non local boxes
+            // skip building a svtk amrMesh for the non local boxes
             if (dmap[j] != rank)
                 continue;
 
@@ -705,14 +705,14 @@ int AmrDataAdaptor::GetMesh(const std::string &meshName,
             int nboxLo[3] = {AMREX_ARLIM(nbox.loVect())};
             int nboxHi[3] = {AMREX_ARLIM(nbox.hiVect())};
 
-            // new vtk uniform amrMesh, node centered
-            vtkUniformGrid *ug = vtkUniformGrid::New();
+            // new svtk uniform amrMesh, node centered
+            svtkUniformGrid *ug = svtkUniformGrid::New();
             ug->SetOrigin(origin);
             ug->SetSpacing(spacing);
             ug->SetExtent(nboxLo[0], nboxHi[0],
                 nboxLo[1], nboxHi[1], nboxLo[2], nboxHi[2]);
 
-            // pass the block into vtk
+            // pass the block into svtk
             amrMesh->SetDataSet(i, j, ug);
             ug->Delete();
         }
@@ -722,7 +722,7 @@ int AmrDataAdaptor::GetMesh(const std::string &meshName,
 }
 
 //-----------------------------------------------------------------------------
-int AmrDataAdaptor::AddGhostCellsArray(vtkDataObject* mesh,
+int AmrDataAdaptor::AddGhostCellsArray(svtkDataObject* mesh,
     const std::string &meshName)
 {
     sensei::TimeEvent<64> event("AmrDataAdaptor::AddGhostCellsArray");
@@ -733,7 +733,7 @@ int AmrDataAdaptor::AddGhostCellsArray(vtkDataObject* mesh,
         return -1;
     }
 
-    vtkOverlappingAMR *amrMesh = dynamic_cast<vtkOverlappingAMR*>(mesh);
+    svtkOverlappingAMR *amrMesh = dynamic_cast<svtkOverlappingAMR*>(mesh);
     if (!amrMesh)
     {
         SENSEI_ERROR("Invalid mesh type "
@@ -780,7 +780,7 @@ int AmrDataAdaptor::AddGhostCellsArray(vtkDataObject* mesh,
             if (dMap[j] != rank)
                 continue;
 
-            vtkUniformGrid *blockMesh = amrMesh->GetDataSet(i, j);
+            svtkUniformGrid *blockMesh = amrMesh->GetDataSet(i, j);
 
             if (!blockMesh)
             {
@@ -790,24 +790,24 @@ int AmrDataAdaptor::AddGhostCellsArray(vtkDataObject* mesh,
 
             long nCells = blockMesh->GetNumberOfCells();
 
-            // transfer mask array into vtk
-            vtkUnsignedCharArray *ga = vtkUnsignedCharArray::New();
-            ga->SetName("vtkGhostType");
+            // transfer mask array into svtk
+            svtkUnsignedCharArray *ga = svtkUnsignedCharArray::New();
+            ga->SetName("svtkGhostType");
             ga->SetArray(mask[j], nCells, 0);
             blockMesh->GetCellData()->AddArray(ga);
             ga->Delete();
 
             // for debug can visualize the ghost cells
             // FIXME -- a bug in Catalyst ignores internal ghost zones
-            // when using the VTK writrer. Until that bug gets fixed, one
+            // when using the SVTK writrer. Until that bug gets fixed, one
             // can manually inject this copy using a PV Python filter
-            ga = vtkUnsignedCharArray::New();
+            ga = svtkUnsignedCharArray::New();
             ga->SetName("GhostType");
             ga->SetArray(mask[j], nCells, 1);
             blockMesh->GetCellData()->AddArray(ga);
             ga->Delete();
 
-            // because VTK takes ownership
+            // because SVTK takes ownership
             mask[j] = nullptr;
         }
     }
@@ -816,7 +816,7 @@ int AmrDataAdaptor::AddGhostCellsArray(vtkDataObject* mesh,
 }
 
 //-----------------------------------------------------------------------------
-int AmrDataAdaptor::AddGhostNodesArray(vtkDataObject *mesh,
+int AmrDataAdaptor::AddGhostNodesArray(svtkDataObject *mesh,
     const std::string &meshName)
 {
     amrex::ignore_unused(mesh);
@@ -834,7 +834,7 @@ int AmrDataAdaptor::AddGhostNodesArray(vtkDataObject *mesh,
 }
 
 //-----------------------------------------------------------------------------
-int AmrDataAdaptor::AddArray(vtkDataObject* mesh, const std::string &meshName,
+int AmrDataAdaptor::AddArray(svtkDataObject* mesh, const std::string &meshName,
     int association, const std::string &arrayName)
 {
     sensei::TimeEvent<64> event("AmrDataAdaptor::AddArray");
@@ -848,7 +848,7 @@ int AmrDataAdaptor::AddArray(vtkDataObject* mesh, const std::string &meshName,
         return -1;
     }
 
-    vtkOverlappingAMR *amrMesh = dynamic_cast<vtkOverlappingAMR*>(mesh);
+    svtkOverlappingAMR *amrMesh = dynamic_cast<svtkOverlappingAMR*>(mesh);
     if (!amrMesh)
     {
         SENSEI_ERROR("Invalid mesh type "
@@ -861,8 +861,8 @@ int AmrDataAdaptor::AddArray(vtkDataObject* mesh, const std::string &meshName,
         return -1;
     }
 
-    if ((association != vtkDataObject::CELL) &&
-        (association != vtkDataObject::POINT))
+    if ((association != svtkDataObject::CELL) &&
+        (association != svtkDataObject::POINT))
     {
         SENSEI_ERROR("Invalid association " << association)
         return -1;
@@ -878,7 +878,7 @@ int AmrDataAdaptor::AddArray(vtkDataObject* mesh, const std::string &meshName,
     if (this->Internals->SimMetadata.GetIndex(arrayName, association, fab, comp))
     {
         SENSEI_ERROR("Failed to locate descriptor for "
-            << sensei::VTKUtils::GetAttributesName(association)
+            << sensei::SVTKUtils::GetAttributesName(association)
             << " data array \"" << arrayName << "\"")
         return -1;
     }
@@ -894,8 +894,8 @@ int AmrDataAdaptor::AddArray(vtkDataObject* mesh, const std::string &meshName,
         amrex::MultiFab& state = levels[i]->get_new_data(fab);
         unsigned int ng = state.nGrow();
 
-        if (!((association == vtkDataObject::CELL) && state.is_cell_centered()) &&
-            !((association == vtkDataObject::POINT) && state.is_nodal()))
+        if (!((association == svtkDataObject::CELL) && state.is_cell_centered()) &&
+            !((association == svtkDataObject::POINT) && state.is_nodal()))
         {
             SENSEI_ERROR("association does not match MultiFAB centering")
             return -1;
@@ -926,7 +926,7 @@ int AmrDataAdaptor::AddArray(vtkDataObject* mesh, const std::string &meshName,
             int cboxLo[3] = {AMREX_ARLIM(cbox.loVect())};
             int cboxHi[3] = {AMREX_ARLIM(cbox.hiVect())};
 
-            // skip building a vtk mesh for the non local boxes
+            // skip building a svtk mesh for the non local boxes
             if (dmap[j] != rank)
                 continue;
 
@@ -938,7 +938,7 @@ int AmrDataAdaptor::AddArray(vtkDataObject* mesh, const std::string &meshName,
             int nboxHi[3] = {AMREX_ARLIM(nbox.hiVect())};
 
             // get the block mesh
-            vtkUniformGrid *ug = amrMesh->GetDataSet(i, j);
+            svtkUniformGrid *ug = amrMesh->GetDataSet(i, j);
 
             // node centered size
             long nlen = 1;
@@ -953,9 +953,9 @@ int AmrDataAdaptor::AddArray(vtkDataObject* mesh, const std::string &meshName,
             // pointer to the data
             amrex_real *pcd = state[j].dataPtr(comp);
 
-            // allocate vtk array
-            InSituUtils::amrex_tt<amrex_real>::vtk_type *da =
-                InSituUtils::amrex_tt<amrex_real>::vtk_type::New();
+            // allocate svtk array
+            InSituUtils::amrex_tt<amrex_real>::svtk_type *da =
+                InSituUtils::amrex_tt<amrex_real>::svtk_type::New();
 
             // set component name
             da->SetName(arrayName.c_str());
@@ -981,7 +981,7 @@ int AmrDataAdaptor::AddArray(vtkDataObject* mesh, const std::string &meshName,
 
 #if defined(SENSEI_DEBUG)
             // mark level id
-            vtkFloatArray *la = vtkFloatArray::New();
+            svtkFloatArray *la = svtkFloatArray::New();
             la->SetName("amrex_level_id");
             la->SetNumberOfTuples(clen);
             la->Fill(i);
@@ -989,7 +989,7 @@ int AmrDataAdaptor::AddArray(vtkDataObject* mesh, const std::string &meshName,
             la->Delete();
 
             // mark mpi rank
-            vtkFloatArray *ra = vtkFloatArray::New();
+            svtkFloatArray *ra = svtkFloatArray::New();
             ra->SetName("amrex_mpi_rank");
             ra->SetNumberOfTuples(clen);
             ra->Fill(rank);

--- a/Src/Extern/SENSEI/AMReX_AmrInSituBridge.cpp
+++ b/Src/Extern/SENSEI/AMReX_AmrInSituBridge.cpp
@@ -29,7 +29,7 @@ AmrInSituBridge::update(Amr *dataSource)
         data_adaptor->SetDataSource(dataSource);
         data_adaptor->SetDataTime(dataSource->cumTime());
         data_adaptor->SetDataTimeStep(dataSource->levelSteps(0));
-        ret = analysis_adaptor->Execute(data_adaptor) ? 0 : -1;
+        ret = analysis_adaptor->Execute(data_adaptor, nullptr) ? 0 : -1;
         data_adaptor->ReleaseData();
         data_adaptor->Delete();
 

--- a/Src/Extern/SENSEI/AMReX_AmrMeshDataAdaptor.H
+++ b/Src/Extern/SENSEI/AMReX_AmrMeshDataAdaptor.H
@@ -34,10 +34,10 @@ public:
   int GetNumberOfArrays(const std::string &meshName, int association, unsigned int &numberOfArrays) override;
   int GetArrayName(const std::string &meshName, int association, unsigned int index, std::string &arrayName) override;
 #endif
-  int GetMesh(const std::string &meshName, bool structureOnly, vtkDataObject *&mesh) override;
-  int AddGhostNodesArray(vtkDataObject* mesh, const std::string &meshName) override;
-  int AddGhostCellsArray(vtkDataObject* mesh, const std::string &meshName) override;
-  int AddArray(vtkDataObject* mesh, const std::string &meshName, int association, const std::string &arrayName) override;
+  int GetMesh(const std::string &meshName, bool structureOnly, svtkDataObject *&mesh) override;
+  int AddGhostNodesArray(svtkDataObject* mesh, const std::string &meshName) override;
+  int AddGhostCellsArray(svtkDataObject* mesh, const std::string &meshName) override;
+  int AddArray(svtkDataObject* mesh, const std::string &meshName, int association, const std::string &arrayName) override;
   int ReleaseData() override;
 
 protected:

--- a/Src/Extern/SENSEI/AMReX_AmrMeshDataAdaptor.cpp
+++ b/Src/Extern/SENSEI/AMReX_AmrMeshDataAdaptor.cpp
@@ -2,18 +2,18 @@
 
 #include "Profiler.h"
 #include "Error.h"
-#include "VTKUtils.h"
+#include "SVTKUtils.h"
 
-#include <vtkObjectFactory.h>
-#include <vtkOverlappingAMR.h>
-#include <vtkAMRBox.h>
-#include <vtkUniformGrid.h>
-#include <vtkDataSetAttributes.h>
-#include <vtkUnsignedCharArray.h>
-#include <vtkFloatArray.h>
-#include <vtkDoubleArray.h>
-#include <vtkCellData.h>
-#include <vtkPointData.h>
+#include <svtkObjectFactory.h>
+#include <svtkOverlappingAMR.h>
+#include <svtkAMRBox.h>
+#include <svtkUniformGrid.h>
+#include <svtkDataSetAttributes.h>
+#include <svtkUnsignedCharArray.h>
+#include <svtkFloatArray.h>
+#include <svtkDoubleArray.h>
+#include <svtkCellData.h>
+#include <svtkPointData.h>
 
 #include <AMReX_BoxArray.H>
 #include <AMReX_Geometry.H>
@@ -58,11 +58,11 @@ int MeshStateMap::Initialize(
 
             if (state.is_cell_centered())
             {
-                this->Map[vtkDataObject::CELL][arrayName] = std::make_pair(i,j);
+                this->Map[svtkDataObject::CELL][arrayName] = std::make_pair(i,j);
             }
             else if (state.is_nodal())
             {
-                this->Map[vtkDataObject::POINT][arrayName] = std::make_pair(i,j);
+                this->Map[svtkDataObject::POINT][arrayName] = std::make_pair(i,j);
             }
         }
     }
@@ -83,7 +83,7 @@ struct AmrMeshDataAdaptor::InternalsType
     std::vector<std::vector<std::string>> Names;
     amrex::InSituUtils::MeshStateMap StateMetadata;
 #if SENSEI_VERSION_MAJOR < 3
-    std::vector<vtkDataObject*> ManagedObjects;
+    std::vector<svtkDataObject*> ManagedObjects;
 #endif
 };
 
@@ -149,13 +149,13 @@ int AmrMeshDataAdaptor::GetMeshMetadata(unsigned int id,
     metadata->GlobalView = true;
 
     metadata->MeshName = "mesh";
-    metadata->MeshType = VTK_OVERLAPPING_AMR;
-    metadata->BlockType = VTK_UNIFORM_GRID;
+    metadata->MeshType = SVTK_OVERLAPPING_AMR;
+    metadata->BlockType = SVTK_UNIFORM_GRID;
     metadata->NumBlocks = 0;
     metadata->NumCells = 0;
     metadata->NumPoints = 0;
     metadata->NumBlocksLocal = {-1};
-    metadata->CoordinateType = InSituUtils::amrex_tt<amrex_real>::vtk_type_enum();
+    metadata->CoordinateType = InSituUtils::amrex_tt<amrex_real>::svtk_type_enum();
     metadata->StaticMesh = 0;
 
     // num levels
@@ -224,7 +224,7 @@ int AmrMeshDataAdaptor::GetMeshMetadata(unsigned int id,
             {pdLo[0], pdHi[0], pdLo[1], pdHi[1], pdLo[2], pdHi[2]});
     }
 
-    // global extent (note: VTK uses point centered indexing)
+    // global extent (note: SVTK uses point centered indexing)
     const amrex::Box& cdom = this->Internals->Mesh->Geom(0).Domain();
     amrex::Box ndom = surroundingNodes(cdom);
 
@@ -261,19 +261,19 @@ int AmrMeshDataAdaptor::GetMeshMetadata(unsigned int id,
         // scalar, vector, tensor
         metadata->ArrayComponents[j] = 1;
         // POD type
-        metadata->ArrayType[j] = InSituUtils::amrex_tt<amrex_real>::vtk_type_enum();
+        metadata->ArrayType[j] = InSituUtils::amrex_tt<amrex_real>::svtk_type_enum();
         // mesh centering
         if (state0.is_cell_centered())
         {
-            metadata->ArrayCentering[j] = vtkDataObject::CELL;
+            metadata->ArrayCentering[j] = svtkDataObject::CELL;
         }
         else if (state0.is_nodal())
         {
-            metadata->ArrayCentering[j] = vtkDataObject::POINT;
+            metadata->ArrayCentering[j] = svtkDataObject::POINT;
         }
         else
         {
-            metadata->ArrayCentering[j] = vtkDataObject::FIELD;
+            metadata->ArrayCentering[j] = svtkDataObject::FIELD;
         }
     }
 
@@ -396,8 +396,8 @@ int AmrMeshDataAdaptor::GetNumberOfArrays(const std::string &meshName,
         return -1;
     }
 
-    if ((association != vtkDataObject::POINT) &&
-        (association != vtkDataObject::CELL))
+    if ((association != svtkDataObject::POINT) &&
+        (association != svtkDataObject::CELL))
     {
         SENSEI_ERROR("Invalid association " << association)
         return -1;
@@ -427,7 +427,7 @@ int AmrMeshDataAdaptor::GetArrayName(const std::string &meshName,
     if (this->Internals->StateMetadata.GetName(association, index, arrayName))
     {
         SENSEI_ERROR("No array named \"" << arrayName << "\" in "
-            << sensei::VTKUtils::GetAttributesName(association)
+            << sensei::SVTKUtils::GetAttributesName(association)
             << " data")
         return -1;
     }
@@ -475,7 +475,7 @@ int AmrMeshDataAdaptor::GetMeshHasGhostCells(const std::string &meshName, int &n
 
 //-----------------------------------------------------------------------------
 int AmrMeshDataAdaptor::GetMesh(const std::string &meshName,
-    bool structureOnly, vtkDataObject *&mesh)
+    bool structureOnly, svtkDataObject *&mesh)
 {
     amrex::ignore_unused(structureOnly);
 
@@ -498,8 +498,8 @@ int AmrMeshDataAdaptor::GetMesh(const std::string &meshName,
 
     int nLevels = this->Internals->Mesh->finestLevel() + 1;
 
-    // initialize new vtk datasets
-    vtkOverlappingAMR *amrMesh = vtkOverlappingAMR::New();
+    // initialize new svtk datasets
+    svtkOverlappingAMR *amrMesh = svtkOverlappingAMR::New();
 #if SENSEI_VERSION_MAJOR < 3
     Internals->ManagedObjects.push_back(amrMesh);
 #endif
@@ -560,12 +560,12 @@ int AmrMeshDataAdaptor::GetMesh(const std::string &meshName,
             int cboxLo[3] = {AMREX_ARLIM(cbox.loVect())};
             int cboxHi[3] = {AMREX_ARLIM(cbox.hiVect())};
 
-            // vtk's representation of box metadata
-            vtkAMRBox block(cboxLo, cboxHi);
+            // svtk's representation of box metadata
+            svtkAMRBox block(cboxLo, cboxHi);
             amrMesh->SetAMRBox(i, j, block);
             amrMesh->SetAMRBlockSourceIndex(i, j, gid++);
 
-            // skip building a vtk amrMesh for the non local boxes
+            // skip building a svtk amrMesh for the non local boxes
             if (dmap[j] != rank)
                 continue;
 
@@ -580,14 +580,14 @@ int AmrMeshDataAdaptor::GetMesh(const std::string &meshName,
             int nboxLo[3] = {AMREX_ARLIM(nbox.loVect())};
             int nboxHi[3] = {AMREX_ARLIM(nbox.hiVect())};
 
-            // new vtk uniform amrMesh, node centered
-            vtkUniformGrid *ug = vtkUniformGrid::New();
+            // new svtk uniform amrMesh, node centered
+            svtkUniformGrid *ug = svtkUniformGrid::New();
             ug->SetOrigin(origin);
             ug->SetSpacing(spacing);
             ug->SetExtent(nboxLo[0], nboxHi[0],
                 nboxLo[1], nboxHi[1], nboxLo[2], nboxHi[2]);
 
-            // pass the block into vtk
+            // pass the block into svtk
             amrMesh->SetDataSet(i, j, ug);
             ug->Delete();
         }
@@ -597,7 +597,7 @@ int AmrMeshDataAdaptor::GetMesh(const std::string &meshName,
 }
 
 //-----------------------------------------------------------------------------
-int AmrMeshDataAdaptor::AddGhostNodesArray(vtkDataObject *mesh,
+int AmrMeshDataAdaptor::AddGhostNodesArray(svtkDataObject *mesh,
     const std::string &meshName)
 {
     amrex::ignore_unused(mesh);
@@ -613,7 +613,7 @@ int AmrMeshDataAdaptor::AddGhostNodesArray(vtkDataObject *mesh,
 }
 
 //-----------------------------------------------------------------------------
-int AmrMeshDataAdaptor::AddGhostCellsArray(vtkDataObject* mesh,
+int AmrMeshDataAdaptor::AddGhostCellsArray(svtkDataObject* mesh,
     const std::string &meshName)
 {
     if (meshName != "mesh")
@@ -622,7 +622,7 @@ int AmrMeshDataAdaptor::AddGhostCellsArray(vtkDataObject* mesh,
         return -1;
     }
 
-    vtkOverlappingAMR *amrMesh = dynamic_cast<vtkOverlappingAMR*>(mesh);
+    svtkOverlappingAMR *amrMesh = dynamic_cast<svtkOverlappingAMR*>(mesh);
     if (!amrMesh)
     {
         SENSEI_ERROR("Invalid mesh type "
@@ -701,7 +701,7 @@ int AmrMeshDataAdaptor::AddGhostCellsArray(vtkDataObject* mesh,
             if (dmap[j] != rank)
                 continue;
 
-            vtkUniformGrid *blockMesh = amrMesh->GetDataSet(i, j);
+            svtkUniformGrid *blockMesh = amrMesh->GetDataSet(i, j);
 
             if (!blockMesh)
             {
@@ -711,18 +711,18 @@ int AmrMeshDataAdaptor::AddGhostCellsArray(vtkDataObject* mesh,
 
             long nCells = blockMesh->GetNumberOfCells();
 
-            // transfer mask array into vtk
-            vtkUnsignedCharArray *ga = vtkUnsignedCharArray::New();
-            ga->SetName("vtkGhostType");
+            // transfer mask array into svtk
+            svtkUnsignedCharArray *ga = svtkUnsignedCharArray::New();
+            ga->SetName("svtkGhostType");
             ga->SetArray(mask[j], nCells, 0);
             blockMesh->GetCellData()->AddArray(ga);
             ga->Delete();
 
             // for debug can visualize the ghost cells
             // FIXME -- a bug in Catalyst ignores internal ghost zones
-            // when using the VTK writrer. Until that bug gets fixed, one
+            // when using the SVTK writrer. Until that bug gets fixed, one
             // can manually inject this copy using a PV Python filter
-            ga = vtkUnsignedCharArray::New();
+            ga = svtkUnsignedCharArray::New();
             ga->SetName("GhostType");
             ga->SetArray(mask[j], nCells, 1);
             blockMesh->GetCellData()->AddArray(ga);
@@ -734,7 +734,7 @@ int AmrMeshDataAdaptor::AddGhostCellsArray(vtkDataObject* mesh,
 }
 
 //-----------------------------------------------------------------------------
-int AmrMeshDataAdaptor::AddArray(vtkDataObject* mesh,
+int AmrMeshDataAdaptor::AddArray(svtkDataObject* mesh,
     const std::string &meshName, int association,
     const std::string &arrayName)
 {
@@ -747,7 +747,7 @@ int AmrMeshDataAdaptor::AddArray(vtkDataObject* mesh,
         return -1;
     }
 
-    vtkOverlappingAMR *amrMesh = dynamic_cast<vtkOverlappingAMR*>(mesh);
+    svtkOverlappingAMR *amrMesh = dynamic_cast<svtkOverlappingAMR*>(mesh);
     if (!amrMesh)
     {
         SENSEI_ERROR("Invalid mesh type "
@@ -760,8 +760,8 @@ int AmrMeshDataAdaptor::AddArray(vtkDataObject* mesh,
         return -1;
     }
 
-    if ((association != vtkDataObject::CELL) &&
-        (association != vtkDataObject::CELL))
+    if ((association != svtkDataObject::CELL) &&
+        (association != svtkDataObject::CELL))
     {
         SENSEI_ERROR("Invalid association " << association)
         return -1;
@@ -774,7 +774,7 @@ int AmrMeshDataAdaptor::AddArray(vtkDataObject* mesh,
     if (this->Internals->StateMetadata.GetIndex(arrayName, association, fab, comp))
     {
         SENSEI_ERROR("Failed to locate descriptor for "
-            << sensei::VTKUtils::GetAttributesName(association)
+            << sensei::SVTKUtils::GetAttributesName(association)
             << " data array \"" << arrayName << "\"")
         return -1;
     }
@@ -792,8 +792,8 @@ int AmrMeshDataAdaptor::AddArray(vtkDataObject* mesh,
         unsigned int ng = state.nGrow();
 
         // check centering
-        if (!((association == vtkDataObject::CELL) && state.is_cell_centered()) &&
-            !((association == vtkDataObject::POINT) && state.is_nodal()))
+        if (!((association == svtkDataObject::CELL) && state.is_cell_centered()) &&
+            !((association == svtkDataObject::POINT) && state.is_nodal()))
         {
             SENSEI_ERROR("association does not match MultiFab centering")
             return -1;
@@ -824,7 +824,7 @@ int AmrMeshDataAdaptor::AddArray(vtkDataObject* mesh,
             int cboxLo[3] = {AMREX_ARLIM(cbox.loVect())};
             int cboxHi[3] = {AMREX_ARLIM(cbox.hiVect())};
 
-            // skip building a vtk mesh for the non local boxes
+            // skip building a svtk mesh for the non local boxes
             if (dmap[j] != rank)
                 continue;
 
@@ -836,7 +836,7 @@ int AmrMeshDataAdaptor::AddArray(vtkDataObject* mesh,
             int nboxHi[3] = {AMREX_ARLIM(nbox.hiVect())};
 
             // get the block mesh
-            vtkUniformGrid *ug = amrMesh->GetDataSet(i, j);
+            svtkUniformGrid *ug = amrMesh->GetDataSet(i, j);
 
             // node centered size
             long nlen = 1;
@@ -851,9 +851,9 @@ int AmrMeshDataAdaptor::AddArray(vtkDataObject* mesh,
             // pointer to the data
             amrex_real *pcd = state[j].dataPtr(comp);
 
-            // allocate vtk array
-            InSituUtils::amrex_tt<amrex_real>::vtk_type *da =
-                InSituUtils::amrex_tt<amrex_real>::vtk_type::New();
+            // allocate svtk array
+            InSituUtils::amrex_tt<amrex_real>::svtk_type *da =
+                InSituUtils::amrex_tt<amrex_real>::svtk_type::New();
 
             // set component name
             da->SetName(arrayName.c_str());
@@ -879,7 +879,7 @@ int AmrMeshDataAdaptor::AddArray(vtkDataObject* mesh,
 
 #if defined(SENSEI_DEBUG)
             // mark level id
-            vtkFloatArray *la = vtkFloatArray::New();
+            svtkFloatArray *la = svtkFloatArray::New();
             la->SetName("amrex_level_id");
             la->SetNumberOfTuples(clen);
             la->Fill(i);
@@ -887,7 +887,7 @@ int AmrMeshDataAdaptor::AddArray(vtkDataObject* mesh,
             la->Delete();
 
             // mark mpi rank
-            vtkFloatArray *ra = vtkFloatArray::New();
+            svtkFloatArray *ra = svtkFloatArray::New();
             ra->SetName("amrex_mpi_rank");
             ra->SetNumberOfTuples(clen);
             ra->Fill(rank);

--- a/Src/Extern/SENSEI/AMReX_AmrMeshDataAdaptor.cpp
+++ b/Src/Extern/SENSEI/AMReX_AmrMeshDataAdaptor.cpp
@@ -720,7 +720,7 @@ int AmrMeshDataAdaptor::AddGhostCellsArray(svtkDataObject* mesh,
 
             // for debug can visualize the ghost cells
             // FIXME -- a bug in Catalyst ignores internal ghost zones
-            // when using the SVTK writrer. Until that bug gets fixed, one
+            // when using the SVTK writer. Until that bug gets fixed, one
             // can manually inject this copy using a PV Python filter
             ga = svtkUnsignedCharArray::New();
             ga->SetName("GhostType");

--- a/Src/Extern/SENSEI/AMReX_AmrMeshInSituBridge.cpp
+++ b/Src/Extern/SENSEI/AMReX_AmrMeshInSituBridge.cpp
@@ -35,7 +35,7 @@ AmrMeshInSituBridge::update(unsigned int step, double time,
         data_adaptor->SetDataSource(mesh, states, names);
         data_adaptor->SetDataTime(time);
         data_adaptor->SetDataTimeStep(step);
-        ret = analysis_adaptor->Execute(data_adaptor) ? 0 : -1;
+        ret = analysis_adaptor->Execute(data_adaptor, nullptr) ? 0 : -1;
         data_adaptor->ReleaseData();
         data_adaptor->Delete();
 

--- a/Src/Extern/SENSEI/AMReX_AmrMeshParticleDataAdaptor.H
+++ b/Src/Extern/SENSEI/AMReX_AmrMeshParticleDataAdaptor.H
@@ -45,10 +45,10 @@ public:
   int GetArrayName(const std::string &meshName, int association, unsigned int index, std::string &arrayName) override;
 #endif
   int GetNumberOfMeshes(unsigned int &numMeshes) override;
-  int GetMesh(const std::string &meshName, bool structureOnly, vtkDataObject *&mesh) override;
-  int AddGhostNodesArray(vtkDataObject* mesh, const std::string &meshName) override;
-  int AddGhostCellsArray(vtkDataObject* mesh, const std::string &meshName) override;
-  int AddArray(vtkDataObject* mesh, const std::string &meshName, int association, const std::string &arrayName) override;
+  int GetMesh(const std::string &meshName, bool structureOnly, svtkDataObject *&mesh) override;
+  int AddGhostNodesArray(svtkDataObject* mesh, const std::string &meshName) override;
+  int AddGhostCellsArray(svtkDataObject* mesh, const std::string &meshName) override;
+  int AddArray(svtkDataObject* mesh, const std::string &meshName, int association, const std::string &arrayName) override;
   int ReleaseData() override;
 
 protected:

--- a/Src/Extern/SENSEI/AMReX_AmrMeshParticleDataAdaptorI.H
+++ b/Src/Extern/SENSEI/AMReX_AmrMeshParticleDataAdaptorI.H
@@ -148,7 +148,7 @@ template<int NStructReal, int NStructInt, int NArrayReal, int NArrayInt>
 int AmrMeshParticleDataAdaptor<NStructReal, NStructInt, NArrayReal, NArrayInt>::GetMesh(
   const std::string &meshName,
   bool structureOnly,
-  vtkDataObject *&mesh)
+  svtkDataObject *&mesh)
 {
   if(meshName == m_meshName)
   {
@@ -164,7 +164,7 @@ int AmrMeshParticleDataAdaptor<NStructReal, NStructInt, NArrayReal, NArrayInt>::
 
 template<int NStructReal, int NStructInt, int NArrayReal, int NArrayInt>
 int AmrMeshParticleDataAdaptor<NStructReal, NStructInt, NArrayReal, NArrayInt>::AddGhostNodesArray(
-  vtkDataObject* mesh,
+  svtkDataObject* mesh,
   const std::string &meshName)
 {
   if(meshName == m_meshName)
@@ -181,7 +181,7 @@ int AmrMeshParticleDataAdaptor<NStructReal, NStructInt, NArrayReal, NArrayInt>::
 
 template<int NStructReal, int NStructInt, int NArrayReal, int NArrayInt>
 int AmrMeshParticleDataAdaptor<NStructReal, NStructInt, NArrayReal, NArrayInt>::AddGhostCellsArray(
-  vtkDataObject* mesh,
+  svtkDataObject* mesh,
   const std::string &meshName)
 {
   if(meshName == m_meshName)
@@ -198,7 +198,7 @@ int AmrMeshParticleDataAdaptor<NStructReal, NStructInt, NArrayReal, NArrayInt>::
 
 template<int NStructReal, int NStructInt, int NArrayReal, int NArrayInt>
 int AmrMeshParticleDataAdaptor<NStructReal, NStructInt, NArrayReal, NArrayInt>::AddArray(
-  vtkDataObject* mesh,
+  svtkDataObject* mesh,
   const std::string &meshName,
   int association,
   const std::string &arrayName)

--- a/Src/Extern/SENSEI/AMReX_AmrParticleDataAdaptor.H
+++ b/Src/Extern/SENSEI/AMReX_AmrParticleDataAdaptor.H
@@ -43,10 +43,10 @@ public:
   int GetArrayName(const std::string &meshName, int association, unsigned int index, std::string &arrayName) override;
 #endif
   int GetNumberOfMeshes(unsigned int &numMeshes) override;
-  int GetMesh(const std::string &meshName, bool structureOnly, vtkDataObject *&mesh) override;
-  int AddGhostNodesArray(vtkDataObject* mesh, const std::string &meshName) override;
-  int AddGhostCellsArray(vtkDataObject* mesh, const std::string &meshName) override;
-  int AddArray(vtkDataObject* mesh, const std::string &meshName, int association, const std::string &arrayName) override;
+  int GetMesh(const std::string &meshName, bool structureOnly, svtkDataObject *&mesh) override;
+  int AddGhostNodesArray(svtkDataObject* mesh, const std::string &meshName) override;
+  int AddGhostCellsArray(svtkDataObject* mesh, const std::string &meshName) override;
+  int AddArray(svtkDataObject* mesh, const std::string &meshName, int association, const std::string &arrayName) override;
   int ReleaseData() override;
 
 protected:

--- a/Src/Extern/SENSEI/AMReX_AmrParticleDataAdaptorI.H
+++ b/Src/Extern/SENSEI/AMReX_AmrParticleDataAdaptorI.H
@@ -146,7 +146,7 @@ template<int NStructReal, int NStructInt, int NArrayReal, int NArrayInt>
 int AmrParticleDataAdaptor<NStructReal, NStructInt, NArrayReal, NArrayInt>::GetMesh(
   const std::string &meshName,
   bool structureOnly,
-  vtkDataObject *&mesh)
+  svtkDataObject *&mesh)
 {
   if(meshName == m_meshName)
   {
@@ -162,7 +162,7 @@ int AmrParticleDataAdaptor<NStructReal, NStructInt, NArrayReal, NArrayInt>::GetM
 
 template<int NStructReal, int NStructInt, int NArrayReal, int NArrayInt>
 int AmrParticleDataAdaptor<NStructReal, NStructInt, NArrayReal, NArrayInt>::AddGhostNodesArray(
-  vtkDataObject* mesh,
+  svtkDataObject* mesh,
   const std::string &meshName)
 {
   if(meshName == m_meshName)
@@ -179,7 +179,7 @@ int AmrParticleDataAdaptor<NStructReal, NStructInt, NArrayReal, NArrayInt>::AddG
 
 template<int NStructReal, int NStructInt, int NArrayReal, int NArrayInt>
 int AmrParticleDataAdaptor<NStructReal, NStructInt, NArrayReal, NArrayInt>::AddGhostCellsArray(
-  vtkDataObject* mesh,
+  svtkDataObject* mesh,
   const std::string &meshName)
 {
   if(meshName == m_meshName)
@@ -196,7 +196,7 @@ int AmrParticleDataAdaptor<NStructReal, NStructInt, NArrayReal, NArrayInt>::AddG
 
 template<int NStructReal, int NStructInt, int NArrayReal, int NArrayInt>
 int AmrParticleDataAdaptor<NStructReal, NStructInt, NArrayReal, NArrayInt>::AddArray(
-  vtkDataObject* mesh,
+  svtkDataObject* mesh,
   const std::string &meshName,
   int association,
   const std::string &arrayName)

--- a/Src/Extern/SENSEI/AMReX_InSituUtils.H
+++ b/Src/Extern/SENSEI/AMReX_InSituUtils.H
@@ -2,10 +2,10 @@
 #define AMReX_InSituUtils_H
 #include <AMReX_Config.H>
 
-#include <vtkDataSetAttributes.h>
-#include <vtkUnsignedCharArray.h>
-#include <vtkFloatArray.h>
-#include <vtkDoubleArray.h>
+#include <svtkDataSetAttributes.h>
+#include <svtkUnsignedCharArray.h>
+#include <svtkFloatArray.h>
+#include <svtkDoubleArray.h>
 
 #include <AMReX_BoxArray.H>
 #include <AMReX_Geometry.H>
@@ -47,21 +47,21 @@ enum PointGhostTypes
 
 
 
-// traits helper for mapping between amrex_real and vtkDataArray
+// traits helper for mapping between amrex_real and svtkDataArray
 template <typename cpp_t> struct amrex_tt {};
 
-#define amrex_tt_specialize(cpp_t, vtk_t, vtk_t_e)      \
+#define amrex_tt_specialize(cpp_t, svtk_t, svtk_t_e)    \
 template <>                                             \
 struct amrex_tt<cpp_t>                                  \
 {                                                       \
-    using vtk_type = vtk_t;                             \
+    using svtk_type = svtk_t;                           \
                                                         \
     static                                              \
-    constexpr int vtk_type_enum() { return vtk_t_e; }   \
+    constexpr int svtk_type_enum() { return svtk_t_e; } \
 };
 
-amrex_tt_specialize(float, vtkFloatArray, VTK_FLOAT)
-amrex_tt_specialize(double, vtkDoubleArray, VTK_DOUBLE)
+amrex_tt_specialize(float, svtkFloatArray, SVTK_FLOAT)
+amrex_tt_specialize(double, svtkDoubleArray, SVTK_DOUBLE)
 
 
 // helpers to modify values

--- a/Src/Extern/SENSEI/AMReX_InSituUtils.cpp
+++ b/Src/Extern/SENSEI/AMReX_InSituUtils.cpp
@@ -1,7 +1,7 @@
 #include "AMReX_InSituUtils.H"
 
 #include "Error.h"
-#include "VTKUtils.h"
+#include "SVTKUtils.h"
 
 namespace amrex {
 namespace InSituUtils {
@@ -14,7 +14,7 @@ int StateMap::GetIndex(const std::string &name, int centering,
 
     if (cit == this->Map.end())
     {
-        SENSEI_ERROR("No " << sensei::VTKUtils::GetAttributesName(centering)
+        SENSEI_ERROR("No " << sensei::SVTKUtils::GetAttributesName(centering)
           << " arrays")
         return -1;
     }
@@ -23,7 +23,7 @@ int StateMap::GetIndex(const std::string &name, int centering,
     if (nit == cit->second.end())
     {
         SENSEI_ERROR("No array named \"" << name  << "\" in "
-            << sensei::VTKUtils::GetAttributesName(centering)
+            << sensei::SVTKUtils::GetAttributesName(centering)
             << " centered data")
         return -1;
     }
@@ -41,7 +41,7 @@ int StateMap::GetName(int centering, int id, std::string &name)
 
     if (cit == this->Map.end())
     {
-        SENSEI_ERROR("No " << sensei::VTKUtils::GetAttributesName(centering)
+        SENSEI_ERROR("No " << sensei::SVTKUtils::GetAttributesName(centering)
           << " arrays")
         return -1;
     }

--- a/Src/Extern/SENSEI/AMReX_ParticleDataAdaptor.H
+++ b/Src/Extern/SENSEI/AMReX_ParticleDataAdaptor.H
@@ -8,7 +8,7 @@
 #include <AMReX_MultiFab.H>
 
 #include <DataAdaptor.h>
-class vtkPolyData;
+class svtkPolyData;
 
 namespace amrex
 {
@@ -40,22 +40,22 @@ public:
   void SetPinMesh(int val);
 
   // get particle id numbers
-  int AddParticlesIDArray(vtkDataObject* mesh);
+  int AddParticlesIDArray(svtkDataObject* mesh);
 
   // get particle cpu numbers (process each particle was generated on)
-  int AddParticlesCPUArray(vtkDataObject* mesh);
+  int AddParticlesCPUArray(svtkDataObject* mesh);
 
   // get particle integer arrays in Structs of Arrays format
-  int AddParticlesSOAIntArray(const std::string &arrayName, vtkDataObject* mesh);
+  int AddParticlesSOAIntArray(const std::string &arrayName, svtkDataObject* mesh);
 
   // get particle real arrays in Structs of Arrays format
-  int AddParticlesSOARealArray(const std::string &arrayName, vtkDataObject* mesh);
+  int AddParticlesSOARealArray(const std::string &arrayName, svtkDataObject* mesh);
 
   // get particle integer arrays in Array Of Structs format
-  int AddParticlesAOSIntArray(const std::string &arrayName, vtkDataObject* mesh);
+  int AddParticlesAOSIntArray(const std::string &arrayName, svtkDataObject* mesh);
 
   // get particle real arrays in Array Of Structs format
-  int AddParticlesAOSRealArray(const std::string &arrayName, vtkDataObject* mesh);
+  int AddParticlesAOSRealArray(const std::string &arrayName, svtkDataObject* mesh);
 
   // SENSEI API
 #if SENSEI_VERSION_MAJOR >= 3
@@ -68,10 +68,10 @@ public:
   int GetArrayName(const std::string &meshName, int association, unsigned int index, std::string &arrayName) override;
 #endif
   int GetNumberOfMeshes(unsigned int &numMeshes) override;
-  int GetMesh(const std::string &meshName, bool structureOnly, vtkDataObject *&mesh) override;
-  int AddGhostNodesArray(vtkDataObject* mesh, const std::string &meshName) override;
-  int AddGhostCellsArray(vtkDataObject* mesh, const std::string &meshName) override;
-  int AddArray(vtkDataObject* mesh, const std::string &meshName, int association, const std::string &arrayName) override;
+  int GetMesh(const std::string &meshName, bool structureOnly, svtkDataObject *&mesh) override;
+  int AddGhostNodesArray(svtkDataObject* mesh, const std::string &meshName) override;
+  int AddGhostCellsArray(svtkDataObject* mesh, const std::string &meshName) override;
+  int AddArray(svtkDataObject* mesh, const std::string &meshName, int association, const std::string &arrayName) override;
   int ReleaseData() override;
 
 protected:
@@ -79,7 +79,7 @@ protected:
   ~ParticleDataAdaptor() = default;
 
 private:
-  vtkPolyData* BuildParticles();
+  svtkPolyData* BuildParticles();
 
   const std::string m_particlesName = "particles";
 

--- a/Src/Extern/SENSEI/AMReX_ParticleDataAdaptorI.H
+++ b/Src/Extern/SENSEI/AMReX_ParticleDataAdaptorI.H
@@ -1,13 +1,13 @@
 #include "Profiler.h"
 #include "Error.h"
-#include "VTKUtils.h"
+#include "SVTKUtils.h"
 #include "MeshMetadata.h"
-// vtk includes
-#include <vtkPolyData.h>
-#include <vtkDataSetAttributes.h>
-#include <vtkCellData.h>
-#include <vtkPointData.h>
-#include <vtkMultiBlockDataSet.h>
+// svtk includes
+#include <svtkPolyData.h>
+#include <svtkDataSetAttributes.h>
+#include <svtkCellData.h>
+#include <svtkPointData.h>
+#include <svtkMultiBlockDataSet.h>
 
 
 
@@ -194,7 +194,7 @@ int ParticleDataAdaptor<NStructReal, NStructInt, NArrayReal, NArrayInt>::GetNumb
   unsigned int &numberOfArrays)
 {
   numberOfArrays = 0;
-  if(association == vtkDataObject::POINT)
+  if(association == svtkDataObject::POINT)
   {
     numberOfArrays = m_realStructs.size()
                    + m_intStructs.size()
@@ -213,7 +213,7 @@ int ParticleDataAdaptor<NStructReal, NStructInt, NArrayReal, NArrayInt>::GetArra
   unsigned int index,
   std::string &arrayName)
 {
-  if(association == vtkDataObject::POINT)
+  if(association == svtkDataObject::POINT)
   {
     if(index < m_realStructs.size())
     {
@@ -253,7 +253,7 @@ template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt>
 int ParticleDataAdaptor<NStructReal, NStructInt, NArrayReal, NArrayInt>::GetMesh(
   const std::string &meshName,
   bool structureOnly,
-  vtkDataObject *&mesh)
+  svtkDataObject *&mesh)
 {
   mesh = nullptr;
   int nprocs = 1;
@@ -266,7 +266,7 @@ int ParticleDataAdaptor<NStructReal, NStructInt, NArrayReal, NArrayInt>::GetMesh
     SENSEI_ERROR("No mesh named \"" << meshName << "\"")
     return -1;
   }
-  vtkMultiBlockDataSet* mb = vtkMultiBlockDataSet::New();
+  svtkMultiBlockDataSet* mb = svtkMultiBlockDataSet::New();
 
   if (structureOnly)
   {
@@ -275,7 +275,7 @@ int ParticleDataAdaptor<NStructReal, NStructInt, NArrayReal, NArrayInt>::GetMesh
   }
 
   mb->SetNumberOfBlocks(nprocs);
-  vtkPolyData *pd = BuildParticles();
+  svtkPolyData *pd = BuildParticles();
   mb->SetBlock(rank, pd);
   pd->Delete();
   mesh = mb;
@@ -286,7 +286,7 @@ int ParticleDataAdaptor<NStructReal, NStructInt, NArrayReal, NArrayInt>::GetMesh
 //-----------------------------------------------------------------------------
 template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt>
 int ParticleDataAdaptor<NStructReal, NStructInt, NArrayReal, NArrayInt>::AddGhostNodesArray(
-  vtkDataObject*,
+  svtkDataObject*,
   const std::string &meshName)
 {
   if (meshName != m_particlesName)
@@ -300,7 +300,7 @@ int ParticleDataAdaptor<NStructReal, NStructInt, NArrayReal, NArrayInt>::AddGhos
 //-----------------------------------------------------------------------------
 template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt>
 int ParticleDataAdaptor<NStructReal, NStructInt, NArrayReal, NArrayInt>::AddGhostCellsArray(
-  vtkDataObject*,
+  svtkDataObject*,
   const std::string &meshName)
 {
   if (meshName != m_particlesName)
@@ -314,7 +314,7 @@ int ParticleDataAdaptor<NStructReal, NStructInt, NArrayReal, NArrayInt>::AddGhos
 //-----------------------------------------------------------------------------
 template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt>
 int ParticleDataAdaptor<NStructReal, NStructInt, NArrayReal, NArrayInt>::AddArray(
-  vtkDataObject* mesh,
+  svtkDataObject* mesh,
   const std::string &meshName,
   int association,
   const std::string &arrayName)
@@ -325,7 +325,7 @@ int ParticleDataAdaptor<NStructReal, NStructInt, NArrayReal, NArrayInt>::AddArra
     return -1;
   }
 
-  if (association != vtkDataObject::POINT)
+  if (association != svtkDataObject::POINT)
   {
     SENSEI_ERROR("Invalid association " << association);
     return -1;
@@ -393,10 +393,10 @@ int ParticleDataAdaptor<NStructReal, NStructInt, NArrayReal, NArrayInt>::GetMesh
   metadata->MeshName = m_particlesName;
 
   // container mesh type (all)
-  metadata->MeshType = VTK_MULTIBLOCK_DATA_SET;
+  metadata->MeshType = SVTK_MULTIBLOCK_DATA_SET;
 
   // block mesh type (all)
-  metadata->BlockType = VTK_POLY_DATA;
+  metadata->BlockType = SVTK_POLY_DATA;
 
   // global number of blocks (all)
   metadata->NumBlocks = nprocs;
@@ -412,9 +412,9 @@ int ParticleDataAdaptor<NStructReal, NStructInt, NArrayReal, NArrayInt>::GetMesh
 
   // type enum of point data (unstructured, optional)
 #ifdef AMREX_SINGLE_PRECISION_PARTICLES
-  metadata->CoordinateType = VTK_FLOAT;
+  metadata->CoordinateType = SVTK_FLOAT;
 #else
-  metadata->CoordinateType = VTK_DOUBLE;
+  metadata->CoordinateType = SVTK_DOUBLE;
 #endif
 
   // total number of points in all blocks (all, optional)
@@ -467,19 +467,19 @@ int ParticleDataAdaptor<NStructReal, NStructInt, NArrayReal, NArrayInt>::GetMesh
   metadata->ArrayCentering = {};
   for(auto s : m_realStructs)
   {
-    metadata->ArrayCentering.push_back(vtkDataObject::POINT);
+    metadata->ArrayCentering.push_back(svtkDataObject::POINT);
   }
   for(auto s : m_intStructs)
   {
-    metadata->ArrayCentering.push_back(vtkDataObject::POINT);
+    metadata->ArrayCentering.push_back(svtkDataObject::POINT);
   }
   for(auto s : m_realArrays)
   {
-    metadata->ArrayCentering.push_back(vtkDataObject::POINT);
+    metadata->ArrayCentering.push_back(svtkDataObject::POINT);
   }
   for(auto s : m_intArrays)
   {
-    metadata->ArrayCentering.push_back(vtkDataObject::POINT);
+    metadata->ArrayCentering.push_back(svtkDataObject::POINT);
   }
 
   // number of components of each array (all)
@@ -506,26 +506,26 @@ int ParticleDataAdaptor<NStructReal, NStructInt, NArrayReal, NArrayInt>::GetMesh
   for(auto s : m_realStructs)
   {
 #ifdef AMREX_SINGLE_PRECISION_PARTICLES
-    metadata->ArrayType.push_back(VTK_FLOAT);
+    metadata->ArrayType.push_back(SVTK_FLOAT);
 #else
-    metadata->ArrayType.push_back(VTK_DOUBLE);
+    metadata->ArrayType.push_back(SVTK_DOUBLE);
 #endif
   }
   for(auto s : m_intStructs)
   {
-    metadata->ArrayType.push_back(VTK_INT);
+    metadata->ArrayType.push_back(SVTK_INT);
   }
   for(auto s : m_realArrays)
   {
 #ifdef AMREX_SINGLE_PRECISION_PARTICLES
-    metadata->ArrayType.push_back(VTK_FLOAT);
+    metadata->ArrayType.push_back(SVTK_FLOAT);
 #else
-    metadata->ArrayType.push_back(VTK_DOUBLE);
+    metadata->ArrayType.push_back(SVTK_DOUBLE);
 #endif
   }
   for(auto s : m_intArrays)
   {
-    metadata->ArrayType.push_back(VTK_INT);
+    metadata->ArrayType.push_back(SVTK_INT);
   }
 
   // global min,max of each array (all, optional)
@@ -646,19 +646,19 @@ int ParticleDataAdaptor<NStructReal, NStructInt, NArrayReal, NArrayInt>::GetMesh
 
 //-----------------------------------------------------------------------------
 template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt>
-vtkPolyData* ParticleDataAdaptor<NStructReal, NStructInt, NArrayReal, NArrayInt>::BuildParticles()
+svtkPolyData* ParticleDataAdaptor<NStructReal, NStructInt, NArrayReal, NArrayInt>::BuildParticles()
 {
   // return particle data pd
-  vtkPolyData* pd  = vtkPolyData::New();
+  svtkPolyData* pd  = svtkPolyData::New();
 
   const auto& particles = this->m_particles->GetParticles();
   long long numParticles = this->m_particles->TotalNumberOfParticles(true, true);
 
   // allocate vertex storage for particles
 #ifdef AMREX_SINGLE_PRECISION_PARTICLES
-  vtkNew<vtkFloatArray> coords;
+  svtkNew<svtkFloatArray> coords;
 #else
-  vtkNew<vtkDoubleArray> coords;
+  svtkNew<svtkDoubleArray> coords;
 #endif
   coords->SetName("coords");
   coords->SetNumberOfComponents(3);
@@ -669,12 +669,12 @@ vtkPolyData* ParticleDataAdaptor<NStructReal, NStructInt, NArrayReal, NArrayInt>
   double *pCoords = coords->GetPointer(0);
 #endif
 
-  // use this to index into the VTK array as we copy level by level and tile by
+  // use this to index into the SVTK array as we copy level by level and tile by
   // tile
   long long ptId = 0;
 
   // allocate connectivity array for particles
-  vtkNew<vtkCellArray> vertex;
+  svtkNew<svtkCellArray> vertex;
   vertex->AllocateExact(numParticles, 1);
 
   // points->SetNumberOfPoints(numParticles);
@@ -717,8 +717,8 @@ vtkPolyData* ParticleDataAdaptor<NStructReal, NStructInt, NArrayReal, NArrayInt>
     }
   }
 
-  // pass the particle coordinates into VTK's point data structure.
-  vtkNew<vtkPoints> points;
+  // pass the particle coordinates into SVTK's point data structure.
+  svtkNew<svtkPoints> points;
   points->SetData(coords);
 
   // add point and vertex data to output mesh
@@ -731,14 +731,14 @@ vtkPolyData* ParticleDataAdaptor<NStructReal, NStructInt, NArrayReal, NArrayInt>
 //-----------------------------------------------------------------------------
 template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt>
 int ParticleDataAdaptor<NStructReal, NStructInt, NArrayReal, NArrayInt>::AddParticlesIDArray(
-  vtkDataObject* mesh)
+  svtkDataObject* mesh)
 {
-  auto vtk_particles = dynamic_cast<vtkPolyData*>(mesh);
+  auto svtk_particles = dynamic_cast<svtkPolyData*>(mesh);
   const auto& particles = this->m_particles->GetParticles();
   auto nptsOnProc = this->m_particles->TotalNumberOfParticles(true, true);
 
- // allocate a VTK array for the data
-  vtkNew<vtkIntArray> idArray;
+ // allocate a SVTK array for the data
+  svtkNew<svtkIntArray> idArray;
   idArray->SetName("id");
   idArray->SetNumberOfComponents(1);
   idArray->SetNumberOfValues(nptsOnProc);
@@ -767,8 +767,8 @@ int ParticleDataAdaptor<NStructReal, NStructInt, NArrayReal, NArrayInt>::AddPart
     }
   }
 
-  // the association for this array is vtkDataObject::POINT
-  vtk_particles->GetPointData()->AddArray(idArray);
+  // the association for this array is svtkDataObject::POINT
+  svtk_particles->GetPointData()->AddArray(idArray);
 
   return 0;
 }
@@ -776,14 +776,14 @@ int ParticleDataAdaptor<NStructReal, NStructInt, NArrayReal, NArrayInt>::AddPart
 //-----------------------------------------------------------------------------
 template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt>
 int ParticleDataAdaptor<NStructReal, NStructInt, NArrayReal, NArrayInt>::AddParticlesCPUArray(
-  vtkDataObject* mesh)
+  svtkDataObject* mesh)
 {
-  auto vtk_particles = dynamic_cast<vtkPolyData*>(mesh);
+  auto svtk_particles = dynamic_cast<svtkPolyData*>(mesh);
   const auto& particles = this->m_particles->GetParticles();
   auto nptsOnProc = this->m_particles->TotalNumberOfParticles(true, true);
 
-  // allocate a VTK array for the data
-  vtkNew<vtkIntArray> cpuArray;
+  // allocate a SVTK array for the data
+  svtkNew<svtkIntArray> cpuArray;
   cpuArray->SetName("cpu");
   cpuArray->SetNumberOfComponents(1);
   cpuArray->SetNumberOfValues(nptsOnProc);
@@ -811,8 +811,8 @@ int ParticleDataAdaptor<NStructReal, NStructInt, NArrayReal, NArrayInt>::AddPart
     }
   }
 
-  // the association for this array is vtkDataObject::POINT
-  vtk_particles->GetPointData()->AddArray(cpuArray);
+  // the association for this array is svtkDataObject::POINT
+  svtk_particles->GetPointData()->AddArray(cpuArray);
 
   return 0;
 }
@@ -821,7 +821,7 @@ int ParticleDataAdaptor<NStructReal, NStructInt, NArrayReal, NArrayInt>::AddPart
 template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt>
 int ParticleDataAdaptor<NStructReal, NStructInt, NArrayReal, NArrayInt>::AddParticlesSOARealArray(
   const std::string &arrayName,
-  vtkDataObject* mesh)
+  svtkDataObject* mesh)
 {
   const long nParticles = this->m_particles->TotalNumberOfParticles(true, true);
 
@@ -847,11 +847,11 @@ int ParticleDataAdaptor<NStructReal, NStructInt, NArrayReal, NArrayInt>::AddPart
     }
   }
 
-  // allocate the vtkArray
+  // allocate the svtkArray
 #ifdef AMREX_SINGLE_PRECISION_PARTICLES
-  vtkNew<vtkFloatArray> data;
+  svtkNew<svtkFloatArray> data;
 #else
-  vtkNew<vtkDoubleArray> data;
+  svtkNew<svtkDoubleArray> data;
 #endif
   data->SetName(arrayName.c_str());
   data->SetNumberOfComponents(nComps);
@@ -896,9 +896,9 @@ int ParticleDataAdaptor<NStructReal, NStructInt, NArrayReal, NArrayInt>::AddPart
   int rank = 0;
   MPI_Comm_rank(this->GetCommunicator(), &rank);
 
-  auto blocks = dynamic_cast<vtkMultiBlockDataSet*>(mesh);
+  auto blocks = dynamic_cast<svtkMultiBlockDataSet*>(mesh);
 
-  auto block = dynamic_cast<vtkPolyData*>(blocks->GetBlock(rank));
+  auto block = dynamic_cast<svtkPolyData*>(blocks->GetBlock(rank));
   block->GetPointData()->AddArray(data);
 
   return 0;
@@ -908,7 +908,7 @@ int ParticleDataAdaptor<NStructReal, NStructInt, NArrayReal, NArrayInt>::AddPart
 template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt>
 int ParticleDataAdaptor<NStructReal, NStructInt, NArrayReal, NArrayInt>::AddParticlesSOAIntArray(
   const std::string &arrayName,
-  vtkDataObject* mesh)
+  svtkDataObject* mesh)
 {
   // get the particles from the particle container
   auto nptsOnProc = this->m_particles->TotalNumberOfParticles(true, true);
@@ -931,7 +931,7 @@ int ParticleDataAdaptor<NStructReal, NStructInt, NArrayReal, NArrayInt>::AddPart
     return -1;
   }
 
-  vtkNew<vtkIntArray> data;
+  svtkNew<svtkIntArray> data;
   data->SetName(arrayName.c_str());
   data->SetNumberOfComponents(1);
   data->SetNumberOfValues(nptsOnProc);
@@ -967,9 +967,9 @@ int ParticleDataAdaptor<NStructReal, NStructInt, NArrayReal, NArrayInt>::AddPart
   int rank = 0;
   MPI_Comm_rank(this->GetCommunicator(), &rank);
 
-  auto blocks = dynamic_cast<vtkMultiBlockDataSet*>(mesh);
+  auto blocks = dynamic_cast<svtkMultiBlockDataSet*>(mesh);
 
-  auto block = dynamic_cast<vtkPolyData*>(blocks->GetBlock(rank));
+  auto block = dynamic_cast<svtkPolyData*>(blocks->GetBlock(rank));
   block->GetPointData()->AddArray(data);
 
   return 0;
@@ -979,7 +979,7 @@ int ParticleDataAdaptor<NStructReal, NStructInt, NArrayReal, NArrayInt>::AddPart
 template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt>
 int ParticleDataAdaptor<NStructReal, NStructInt, NArrayReal, NArrayInt>::AddParticlesAOSRealArray(
   const std::string &arrayName,
-  vtkDataObject* mesh)
+  svtkDataObject* mesh)
 {
   // get the particles from the particle container
   const auto& particles = this->m_particles->GetParticles();
@@ -1007,11 +1007,11 @@ int ParticleDataAdaptor<NStructReal, NStructInt, NArrayReal, NArrayInt>::AddPart
     }
   }
 
-  // allocate the vtk array
+  // allocate the svtk array
 #ifdef AMREX_SINGLE_PRECISION_PARTICLES
-  vtkNew<vtkFloatArray> data;
+  svtkNew<svtkFloatArray> data;
 #else
-  vtkNew<vtkDoubleArray> data;
+  svtkNew<svtkDoubleArray> data;
 #endif
 
   data->SetName(arrayName.c_str());
@@ -1053,9 +1053,9 @@ int ParticleDataAdaptor<NStructReal, NStructInt, NArrayReal, NArrayInt>::AddPart
   int rank = 0;
   MPI_Comm_rank(this->GetCommunicator(), &rank);
 
-  auto blocks = dynamic_cast<vtkMultiBlockDataSet*>(mesh);
+  auto blocks = dynamic_cast<svtkMultiBlockDataSet*>(mesh);
 
-  auto block = dynamic_cast<vtkPolyData*>(blocks->GetBlock(rank));
+  auto block = dynamic_cast<svtkPolyData*>(blocks->GetBlock(rank));
   block->GetPointData()->AddArray(data);
 
   return 0;
@@ -1065,7 +1065,7 @@ int ParticleDataAdaptor<NStructReal, NStructInt, NArrayReal, NArrayInt>::AddPart
 template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt>
 int ParticleDataAdaptor<NStructReal, NStructInt, NArrayReal, NArrayInt>::AddParticlesAOSIntArray(
   const std::string &arrayName,
-  vtkDataObject* mesh)
+  svtkDataObject* mesh)
 {
   // get the particles from the particle container
   const auto& particles = this->m_particles->GetParticles();
@@ -1090,8 +1090,8 @@ int ParticleDataAdaptor<NStructReal, NStructInt, NArrayReal, NArrayInt>::AddPart
     return -1;
   }
 
-  // allocate vtkArray
-  vtkNew<vtkIntArray> data;
+  // allocate svtkArray
+  svtkNew<svtkIntArray> data;
   data->SetName(arrayName.c_str());
   data->SetNumberOfComponents(1);
   data->SetNumberOfValues(nptsOnProc);
@@ -1121,9 +1121,9 @@ int ParticleDataAdaptor<NStructReal, NStructInt, NArrayReal, NArrayInt>::AddPart
   int rank = 0;
   MPI_Comm_rank(this->GetCommunicator(), &rank);
 
-  auto blocks = dynamic_cast<vtkMultiBlockDataSet*>(mesh);
+  auto blocks = dynamic_cast<svtkMultiBlockDataSet*>(mesh);
 
-  auto block = dynamic_cast<vtkPolyData*>(blocks->GetBlock(rank));
+  auto block = dynamic_cast<svtkPolyData*>(blocks->GetBlock(rank));
   block->GetPointData()->AddArray(data);
 
 

--- a/Tools/CMake/AMReXThirdPartyLibraries.cmake
+++ b/Tools/CMake/AMReXThirdPartyLibraries.cmake
@@ -45,7 +45,7 @@ endif ()
 # Sensei
 #
 if (AMReX_SENSEI)
-    find_package(SENSEI REQUIRED)
+    find_package( SENSEI 4.0.0 REQUIRED )
     target_link_libraries( amrex PUBLIC sensei )
 endif ()
 


### PR DESCRIPTION
## Summary
In this release of SENSEI, an install of VTK is no longer required. To compile AMReX w/ SENSEI use:

```cmake
-DAMReX_SENSEI=ON -DSENSEI_DIR=<path to SENSEI install>/lib64/cmake
```

Tested with AMReX CMake build system, a validation using GNUMakefiles will come later.

## Additional background
None

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
