### PR TITLE
Add Gpu::synchronize to Hypre interface

### DIFF
--- a/Src/Extern/HYPRE/AMReX_HypreABecLap.cpp
+++ b/Src/Extern/HYPRE/AMReX_HypreABecLap.cpp
@@ -115,6 +115,7 @@ HypreABecLap::getSolution (MultiFab& a_soln)
         auto reghi = Hypre::hiV(reg);
         HYPRE_StructVectorGetBoxValues(x, reglo.data(), reghi.data(), (*soln)[mfi].dataPtr());
     }
+    Gpu::synchronize();
 
     if (a_soln.nGrowVect() != 0) {
         MultiFab::Copy(a_soln, tmp, 0, 0, 1, 0);
@@ -298,6 +299,7 @@ HypreABecLap::loadVectors (MultiFab& soln, const MultiFab& rhs)
         HYPRE_StructVectorSetBoxValues(x, reglo.data(), reghi.data(), soln[mfi].dataPtr());
         HYPRE_StructVectorSetBoxValues(b, reglo.data(), reghi.data(), rhs_diag[mfi].dataPtr());
     }
+    Gpu::synchronize();
 }
 
 }

--- a/Src/Extern/HYPRE/AMReX_HypreABecLap2.cpp
+++ b/Src/Extern/HYPRE/AMReX_HypreABecLap2.cpp
@@ -137,6 +137,7 @@ HypreABecLap2::getSolution (MultiFab& a_soln)
         HYPRE_SStructVectorGetBoxValues(x, part, reglo.data(), reghi.data(),
                                         0, (*soln)[mfi].dataPtr());
     }
+    Gpu::synchronize();
 
     if (a_soln.nGrowVect() != 0) {
         MultiFab::Copy(a_soln, tmp, 0, 0, 1, 0);
@@ -324,7 +325,6 @@ HypreABecLap2::loadVectors (MultiFab& soln, const MultiFab& rhs)
     }
 
     const HYPRE_Int part = 0;
-    FArrayBox rhsfab;
     for (MFIter mfi(soln); mfi.isValid(); ++mfi)
     {
         const Box &reg = mfi.validbox();
@@ -335,6 +335,7 @@ HypreABecLap2::loadVectors (MultiFab& soln, const MultiFab& rhs)
         HYPRE_SStructVectorSetBoxValues(b, part, reglo.data(), reghi.data(),
                                         0, rhs_diag[mfi].dataPtr());
     }
+    Gpu::synchronize();
 }
 
 }

--- a/Src/Extern/HYPRE/AMReX_HypreABecLap3.cpp
+++ b/Src/Extern/HYPRE/AMReX_HypreABecLap3.cpp
@@ -78,6 +78,7 @@ HypreABecLap3::getSolution (MultiFab& a_soln)
             (*l_soln)[mfi].setVal<RunOn::Device>(0.0);
         }
     }
+    Gpu::synchronize();
 
     if (use_tmp_mf) {
         MultiFab::Copy(a_soln, tmp, 0, 0, 1, 0);
@@ -681,6 +682,7 @@ HypreABecLap3::loadVectors (MultiFab& soln, const MultiFab& rhs)
             HYPRE_IJVectorSetValues(b, nrows, cell_id_vec[mfi].dataPtr(), rhs_diag[mfi].dataPtr());
         }
     }
+    Gpu::synchronize();
 }
 
 }  // namespace amrex

--- a/Src/Extern/HYPRE/AMReX_HypreNodeLap.cpp
+++ b/Src/Extern/HYPRE/AMReX_HypreNodeLap.cpp
@@ -348,6 +348,7 @@ HypreNodeLap::getSolution (MultiFab& soln)
             xvec.resize(nrows);
             Real* xp = xvec.data();
             HYPRE_IJVectorGetValues(x, nrows, rows_vec.data(), xp);
+            Gpu::synchronize();
 
             const Box& bx = mfi.validbox();
             const auto& xfab = tmpsoln.array(mfi);

--- a/Src/Extern/PETSc/AMReX_PETSc.cpp
+++ b/Src/Extern/PETSc/AMReX_PETSc.cpp
@@ -689,6 +689,7 @@ PETScABecLap::loadVectors (MultiFab& soln, const MultiFab& rhs)
             VecSetValues(b, nrows, cell_id_vec[mfi].dataPtr(), rhs_diag[mfi].dataPtr(), INSERT_VALUES);
         }
     }
+    Gpu::synchronize();
 }
 
 void
@@ -711,6 +712,7 @@ PETScABecLap::getSolution (MultiFab& a_soln)
             (*l_soln)[mfi].setVal<RunOn::Device>(0.0);
         }
     }
+    Gpu::synchronize();
 
     if (use_tmp_mf) {
         MultiFab::Copy(a_soln, tmp, 0, 0, 1, 0);


### PR DESCRIPTION
This fixes a bug introduced in #2754 that removed the null stream.  Some of
the Gpu::synchronize might not be necessary.  But we have to be on the safe
side because the synchronization behavior of Hypre is unclear.

Thank @esclapez for reporting the bug.

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
