### PR TITLE
Make AmrData::IntVectFromLocation const

### DIFF
--- a/Src/Extern/amrdata/AMReX_AmrData.H
+++ b/Src/Extern/amrdata/AMReX_AmrData.H
@@ -103,7 +103,7 @@ class AmrData {
   // returns the intvect, the finest level it is contained on,
   // and the intvect at the given finest level
   void IntVectFromLocation(const int finestFillLevel, const Vector<Real> &location,
-                           IntVect &ivLoc, int &ivLevel, IntVect &ivFinestFillLev);
+                           IntVect &ivLoc, int &ivLevel, IntVect &ivFinestFillLev) const;
 
   const Vector< Vector< Vector<Real> > > &GridLocLo() const { return gridLocLo; }
   const Vector< Vector< Vector<Real> > > &GridLocHi() const { return gridLocHi; }

--- a/Src/Extern/amrdata/AMReX_AmrData.cpp
+++ b/Src/Extern/amrdata/AMReX_AmrData.cpp
@@ -1061,7 +1061,7 @@ void AmrData::HiNodeLoc(int lev, IntVect ix, Vector<Real> &pos) const {
 void AmrData::IntVectFromLocation(const int finestFillLevel,
                                   const Vector<Real> &location,
                                   IntVect &ivLoc, int &ivLevel,
-                                  IntVect &ivFinestFillLev)
+                                  IntVect &ivFinestFillLev) const
 {
    BL_ASSERT(location.size() == BL_SPACEDIM);
    BL_ASSERT(finestFillLevel <= finestLevel);


### PR DESCRIPTION
## Summary
This PR makes the method `AmrData::IntVectFromLocation` const. This is valid since the routine does not change anything in the class. This change is needed by PR #24 in Amrvis (which adds calls to the method from a const instance of AmrData).

## Additional background

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
