### PR TITLE
Fix compiler warnings in debug mode for integrator

### DIFF
--- a/Src/Base/AMReX_TimeIntegrator.H
+++ b/Src/Base/AMReX_TimeIntegrator.H
@@ -25,8 +25,8 @@ template<class T>
 class TimeIntegrator
 {
 private:
-    amrex::Real time, timestep;
-    int step_number;
+    amrex::Real m_time, m_timestep;
+    int m_step_number;
     std::unique_ptr<IntegratorBase<T> > integrator_ptr;
     std::function<void ()> post_timestep;
 
@@ -79,9 +79,9 @@ private:
         set_fast_rhs([](T& /* S_rhs */, T& /* S_extra */, const T& /* S_data */, const amrex::Real /* time */){});
 
         // By default, initialize time, timestep, step number to 0's
-        time = 0.0_rt;
-        timestep = 0.0_rt;
-        step_number = 0;
+        m_time = 0.0_rt;
+        m_timestep = 0.0_rt;
+        m_step_number = 0;
     }
 
 public:
@@ -170,22 +170,22 @@ public:
 
     int get_step_number ()
     {
-        return step_number;
+        return m_step_number;
     }
 
     amrex::Real get_time ()
     {
-        return time;
+        return m_time;
     }
 
     amrex::Real get_timestep ()
     {
-        return timestep;
+        return m_timestep;
     }
 
     void set_timestep (amrex::Real dt)
     {
-        timestep = dt;
+        m_timestep = dt;
     }
 
     std::function<void ()> get_post_timestep ()
@@ -216,25 +216,25 @@ public:
     void integrate (T& S_old, T& S_new, amrex::Real start_time, const amrex::Real start_timestep,
                     const amrex::Real end_time, const int start_step, const int max_steps)
     {
-        time = start_time;
-        timestep = start_timestep;
+        m_time = start_time;
+        m_timestep = start_timestep;
         bool stop_advance = false;
-        for (step_number = start_step; step_number < max_steps && !stop_advance; ++step_number)
+        for (m_step_number = start_step; m_step_number < max_steps && !stop_advance; ++m_step_number)
         {
-            if (end_time - time < timestep) {
-                timestep = end_time - time;
+            if (end_time - m_time < m_timestep) {
+                m_timestep = end_time - m_time;
                 stop_advance = true;
             }
 
-            if (step_number > 0) {
+            if (m_step_number > 0) {
                 std::swap(S_old, S_new);
             }
 
             // Call the time integrator advance
-            integrator_ptr->advance(S_old, S_new, time, timestep);
+            integrator_ptr->advance(S_old, S_new, m_time, m_timestep);
 
             // Update our time variable
-            time += timestep;
+            m_time += m_timestep;
 
             // Call the post-timestep hook
             post_timestep();


### PR DESCRIPTION
The latest PR for the integrator classes added some new class variables.

This PR renames them using the `m_` prefix convention, avoiding warnings when compiling in debug mode.

## Summary

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
