### PR TITLE
Fix dash/underscore mistake with H5Z-ZFP

### DIFF
--- a/Tools/CMake/AMReXConfig.cmake.in
+++ b/Tools/CMake/AMReXConfig.cmake.in
@@ -204,7 +204,7 @@ if (@AMReX_HDF5@)
 endif ()
 
 if (@AMReX_HDF5_ZFP@)
-    find_dependency(H5Z-ZFP REQUIRED)
+    find_dependency(H5Z_ZFP REQUIRED)
 endif ()
 
 if (@AMReX_HYPRE@)


### PR DESCRIPTION
## Summary

This fixes a small mistake I made in https://github.com/AMReX-Codes/amrex/pull/2753 which would cause problems for downstream packages finding H5Z-ZFP correctly.

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
