### PR TITLE
Implement Serial ParallelDescriptor::Gather

### DIFF
--- a/Src/Base/AMReX_ParallelDescriptor.H
+++ b/Src/Base/AMReX_ParallelDescriptor.H
@@ -1156,8 +1156,14 @@ Bcast(T* /*t*/, size_t /*n*/, int /*root*/, const MPI_Comm & /*comm*/)
 
 template <class T, class T1>
 void
-Gather(const T* /*t*/, size_t /*n*/, T1* /*t1*/, size_t /*n1*/, int /*root*/)
-{}
+Gather (const T* t, size_t n, T1* t1, size_t n1, int /*root*/)
+{
+    BL_ASSERT(n == n1);
+    amrex::ignore_unused(n1);
+
+    int const sc = n;
+    for (int j=0; j<sc; ++j) { t1[j] = t[j]; }
+}
 
 template <class T>
 std::vector<T>


### PR DESCRIPTION
## Summary

This causes a bug currently in the reduced FieldProbe diags in WarpX.

## Additional background

Similar to https://github.com/AMReX-Codes/amrex/pull/2549 for `Gatherv`

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
