### PR TITLE
Geometry: M_PI (`<cmath>`)

### DIFF
--- a/Src/Base/AMReX_Geometry.H
+++ b/Src/Base/AMReX_Geometry.H
@@ -12,6 +12,7 @@
 #include <omp.h>
 #endif
 
+#include <cmath>
 #include <iosfwd>
 #include <map>
 

--- a/Tools/CMake/AMReXSetDefines.cmake
+++ b/Tools/CMake/AMReXSetDefines.cmake
@@ -186,3 +186,11 @@ if(WIN32 AND BUILD_SHARED_LIBS)
   add_amrex_define(AMREX_IS_DLL NO_LEGACY)
   target_compile_definitions( amrex PRIVATE AMREX_IS_DLL_BUILDING)
 endif()
+
+#
+# Windows math symbols <cmath>: M_PI
+# https://docs.microsoft.com/en-us/cpp/c-runtime-library/math-constants?view=msvc-170
+#
+if(WIN32)
+  target_compile_definitions(amrex PUBLIC _USE_MATH_DEFINES)
+endif()


### PR DESCRIPTION
## Summary

Missing include leads to compile error on Windows:
```
build\temp.win-amd64-cpython-37\Release\1\_deps\fetchedamrex-src\Src\Base\AMReX_Geometry.H(255,39):
error C2065: 'M_PI': undeclared identifier
[C:\Users\VssAdministrator\AppData\Local\Temp\pip-req-build-9ov6s5p1\build\temp.win-amd64-cpython-37\Release\1\_deps\fetchedamrex-build\Src\amrex.vcxproj]
```

Technically, we also need to define `_USE_MATH_DEFINES` (we do that in WarpX). Added now.

## Additional background

Seen on Nightly installation tests for Windows "pip"-from-source test:
```
2022-05-25T05:37:01.5391654Z   -- Building for: Visual Studio 17 2022
2022-05-25T05:37:14.6537255Z   -- The C compiler identification is MSVC 19.32.31328.0
2022-05-25T05:37:16.7716754Z   -- The CXX compiler identification is MSVC 19.32.31328.0
2022-05-25T05:37:16.8589563Z   -- Detecting C compiler ABI info
2022-05-25T05:37:18.0896710Z   -- Detecting C compiler ABI info - done
2022-05-25T05:37:18.0928251Z   -- Check for working C compiler: C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Tools/MSVC/14.32.31326/bin/Hostx64/x64/cl.exe - skipped
...
2022-05-25T05:37:19.1780344Z   -- Check for working CXX compiler: C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Tools/MSVC/14.32.31326/bin/Hostx64/x64/cl.exe - skipped
...
```

- https://docs.microsoft.com/en-us/cpp/c-runtime-library/math-constants?view=msvc-170
- http://www.cplusplus.com/forum/beginner/105176/

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
