### PR TITLE
include rocsparse library when compiling with Hypre compiled with hip

### DIFF
--- a/Tools/CMake/AMReXParallelBackends.cmake
+++ b/Tools/CMake/AMReXParallelBackends.cmake
@@ -246,6 +246,7 @@ if (AMReX_HIP)
    # Link to hiprand -- must include rocrand too
    find_package(rocrand REQUIRED CONFIG)
    find_package(rocprim REQUIRED CONFIG)
+   find_package(rocsparse REQUIRED CONFIG)
    find_package(hiprand REQUIRED CONFIG)
    if(AMReX_ROCTX)
        # To be modernized in the future, please see:
@@ -253,7 +254,7 @@ if (AMReX_HIP)
        target_include_directories(amrex PUBLIC ${HIP_PATH}/../roctracer/include ${HIP_PATH}/../rocprofiler/include)
        target_link_libraries(amrex PUBLIC "-L${HIP_PATH}/../roctracer/lib/ -lroctracer64" "-L${HIP_PATH}/../roctracer/lib -lroctx64")
    endif ()
-   target_link_libraries(amrex PUBLIC hip::hiprand roc::rocrand roc::rocprim)
+   target_link_libraries(amrex PUBLIC hip::hiprand roc::rocrand roc::rocprim roc::rocsparse)
 
    # avoid forcing the rocm LLVM flags on a gfortran
    # https://github.com/ROCm-Developer-Tools/HIP/issues/2275
@@ -272,7 +273,7 @@ if (AMReX_HIP)
    target_compile_options(amrex PUBLIC $<$<COMPILE_LANGUAGE:CXX>:-m64>)
 
    # ROCm 4.5: use unsafe floating point atomics, otherwise atomicAdd is much slower
-   # 
+   #
    target_compile_options(amrex PUBLIC $<$<COMPILE_LANGUAGE:CXX>:-munsafe-fp-atomics>)
 
    # Equivalently, relocatable-device-code (RDC) flags are needed for `extern`

--- a/Tools/CMake/AMReXParallelBackends.cmake
+++ b/Tools/CMake/AMReXParallelBackends.cmake
@@ -246,7 +246,6 @@ if (AMReX_HIP)
    # Link to hiprand -- must include rocrand too
    find_package(rocrand REQUIRED CONFIG)
    find_package(rocprim REQUIRED CONFIG)
-   find_package(rocsparse REQUIRED CONFIG)
    find_package(hiprand REQUIRED CONFIG)
    if(AMReX_ROCTX)
        # To be modernized in the future, please see:
@@ -254,7 +253,7 @@ if (AMReX_HIP)
        target_include_directories(amrex PUBLIC ${HIP_PATH}/../roctracer/include ${HIP_PATH}/../rocprofiler/include)
        target_link_libraries(amrex PUBLIC "-L${HIP_PATH}/../roctracer/lib/ -lroctracer64" "-L${HIP_PATH}/../roctracer/lib -lroctx64")
    endif ()
-   target_link_libraries(amrex PUBLIC hip::hiprand roc::rocrand roc::rocprim roc::rocsparse)
+   target_link_libraries(amrex PUBLIC hip::hiprand roc::rocrand roc::rocprim)
 
    # avoid forcing the rocm LLVM flags on a gfortran
    # https://github.com/ROCm-Developer-Tools/HIP/issues/2275

--- a/Tools/GNUMake/packages/Make.hypre
+++ b/Tools/GNUMake/packages/Make.hypre
@@ -21,3 +21,8 @@ endif
 ifeq ($(USE_CUDA),TRUE)
   LIBRARIES += -lcusparse -lcurand
 endif
+
+ifeq ($(USE_HIP),TRUE)
+  LIBRARIES += -lrocsparse
+endif
+


### PR DESCRIPTION
## Summary
Includes the rocsparse library for HIP enabled builds with HYPRE 

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
