### PR TITLE
Landon/fix bug ghost particles

### DIFF
--- a/Src/Particle/AMReX_ParticleLocator.H
+++ b/Src/Particle/AMReX_ParticleLocator.H
@@ -73,18 +73,17 @@ struct AssignGrid
                         if (bx.contains(iv)) {
                           return nbor.first;
                         }
-                        bx.grow(nGrow);
-                        if (bx.contains(iv)) {
+                        Box gbx = bx;
+                        gbx.grow(nGrow);
+                        if (gbx.contains(iv)) {
                            if (loc < 0) {
                              loc = nbor.first;
                            }
                            // Prefer particle not in corner ghost cells
                            for (int dir = 0; dir < AMREX_SPACEDIM; ++dir) {
-                               Box gbx = bx;
-                               IntVect gr(IntVect::TheZeroVector());
-                               gr[dir] = nGrow;
-                               gbx.grow(gr);
-                               if (gbx.contains(iv)) {
+                               Box gdbx = bx;
+                               gdbx.grow(dir, gr);
+                               if (gdbx.contains(iv)) {
                                   loc = nbor.first;
                                }
                            }

--- a/Src/Particle/AMReX_ParticleLocator.H
+++ b/Src/Particle/AMReX_ParticleLocator.H
@@ -82,7 +82,7 @@ struct AssignGrid
                            // Prefer particle not in corner ghost cells
                            for (int dir = 0; dir < AMREX_SPACEDIM; ++dir) {
                                Box gdbx = bx;
-                               gdbx.grow(dir, gr);
+                               gdbx.grow(dir, nGrow);
                                if (gdbx.contains(iv)) {
                                   loc = nbor.first;
                                }


### PR DESCRIPTION
## Summary
Fixed a bug introduced in commit #2685. `bx` should not be modified directly when checking for the closest box to particle.
## Additional background

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
