### PR TITLE
CMake: 3.17+

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.17)
 
 #
 # Allow for MSVC Runtime library controls

--- a/Docs/sphinx_documentation/source/BuildingAMReX.rst
+++ b/Docs/sphinx_documentation/source/BuildingAMReX.rst
@@ -728,7 +728,7 @@ You can tell CMake to look for the AMReX library in non-standard paths by settin
 ``AMReX_ROOT`` to point to the AMReX installation directory or by adding
 ``-DAMReX_ROOT=<path/to/amrex/installation/directory>`` to the ``cmake`` invocation.
 More details on ``find_package`` can be found
-`here <https://cmake.org/cmake/help/v3.14/command/find_package.html>`_.
+`here <https://cmake.org/cmake/help/v3.17/command/find_package.html>`_.
 
 .. _sec:build:windows:
 

--- a/Docs/sphinx_documentation/source/BuildingAMReX_Chapter.rst
+++ b/Docs/sphinx_documentation/source/BuildingAMReX_Chapter.rst
@@ -23,7 +23,7 @@ Fortran compiler that supports the Fortran 2003 standard, and a C
 compiler that supports the C99 standard.  Prerequisites for building
 with GNU Make include Python (>= 2.7, including 3) and standard tools
 available in any Unix-like environments (e.g., Perl and sed).  For
-building with CMake, the minimal requirement is version 3.14.
+building with CMake, the minimal requirement is version 3.17.
 
 Please note that we fully support AMReX for Linux systems in general and on the
 DOE supercomputers (e.g. Cori, Summit) in particular.  Many of our users do build

--- a/Tests/CMakeTestInstall/CMakeLists.txt
+++ b/Tests/CMakeTestInstall/CMakeLists.txt
@@ -3,7 +3,7 @@
 # building and running the code
 # in Tests/Amr/Advection_AmrCore/
 #
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.17)
 
 project(amrex-test-install)
 

--- a/Tests/SpackSmokeTest/CMakeLists.txt
+++ b/Tests/SpackSmokeTest/CMakeLists.txt
@@ -6,7 +6,7 @@
 # against a currently installed version of AMReX. The resulting
 # executable can then be ran to test functionality.
 
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.17)
 
 project(amrex-test-install)
 

--- a/Tools/CMake/AMReXThirdPartyLibraries.cmake
+++ b/Tools/CMake/AMReXThirdPartyLibraries.cmake
@@ -82,7 +82,14 @@ if (AMReX_HYPRE)
     find_package(HYPRE 2.20.0 REQUIRED)
     if(AMReX_CUDA)
         find_package(CUDAToolkit REQUIRED)
+
+        # mandatory CUDA dependencies: cuSPARSE, cuRAND
         target_link_libraries(amrex PUBLIC CUDA::cusparse CUDA::curand)
+
+        # nvToolsExt: if tiny profiler or base profiler are on.
+        if (AMReX_TINY_PROFILE OR AMReX_BASE_PROFILE)
+            target_link_libraries(amrex PUBLIC CUDA::nvToolsExt)
+        endif ()
     endif()
     target_link_libraries( amrex PUBLIC HYPRE )
 endif ()

--- a/Tools/CMake/AMReX_Config.cmake
+++ b/Tools/CMake/AMReX_Config.cmake
@@ -49,7 +49,7 @@ function (configure_amrex)
       target_compile_features(amrex PUBLIC $<IF:$<STREQUAL:$<PLATFORM_ID>,Windows>,cxx_std_17,cxx_std_14>)
    endif ()
 
-   if (AMReX_CUDA AND (CMAKE_VERSION VERSION_GREATER_EQUAL 3.17) )
+   if (AMReX_CUDA)
       set_target_properties(amrex PROPERTIES CUDA_EXTENSIONS OFF)
       # minimum: C++14 on Linux, C++17 on Windows
       target_compile_features(amrex PUBLIC $<IF:$<STREQUAL:$<PLATFORM_ID>,Windows>,cuda_std_17,cuda_std_14>)
@@ -132,8 +132,9 @@ function (configure_amrex)
       endif ()
 
       #
-      # Add manually nvToolsExt if tiny profiler or base profiler are on.n
+      # Add manually nvToolsExt if tiny profiler or base profiler are on.
       # CMake >= 3.17 provides the module FindCUDAToolkit to do this natively.
+      # TODO: Modernize me, now that we require CMake 3.17+.
       #
       if (AMReX_TINY_PROFILE OR AMReX_BASE_PROFILE )
           find_library(LIBNVTOOLSEXT nvToolsExt PATHS ${CMAKE_CUDA_IMPLICIT_LINK_DIRECTORIES})


### PR DESCRIPTION
## Summary

We are using `find_package(CUDAToolkit ...)` now, which is only supported in CMake 3.17+.
Follow-up to #2757

## Additional background

Technically, we want to go to 3.20+ soon as well, so that we can drop the old CUDA code paths that we used to forward device flags and CUDA architectures.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
