### PR TITLE
Clamp particles shifted from plo boundary against rhi, rather than back to plo

### DIFF
--- a/Src/Particle/AMReX_ParticleUtil.H
+++ b/Src/Particle/AMReX_ParticleUtil.H
@@ -538,7 +538,7 @@ bool enforcePeriodic (P& p,
             }
             // clamp to avoid precision issues;
             if (p.pos(idim) >= rhi[idim]) {
-                p.pos(idim) = static_cast<ParticleReal>(plo[idim]);
+                p.pos(idim) = static_cast<ParticleReal>(rhi[idim]);
             }
             shifted = true;
         }


### PR DESCRIPTION
## Summary

https://github.com/ECP-WarpX/WarpX/issues/3155
Particles found outside the low end of the periodic boundary were shifted up by the domain size to be close to the high end boundary. If they were outside the rounding domain, and would thus trip up integer index calculations, they were being clamped back to the **low** end of the domain, rather than the high end. Looking again, I think this was actually just erroneous.

## Additional background

See https://github.com/AMReX-Codes/amrex/pull/2679#issuecomment-1079283896

## Checklist

The proposed changes:
- [X] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
