### PR TITLE
Use amrex::math::abs in IntVect::maxDir.

### DIFF
--- a/Src/Base/AMReX_IntVect.H
+++ b/Src/Base/AMReX_IntVect.H
@@ -594,7 +594,7 @@ IntVect::maxDir(bool a_doAbsValue) const noexcept
     int retval = 0;
     if(a_doAbsValue)
     {
-        int maxval = abs((*this)[0]);
+        int maxval = amrex::Math::abs((*this)[0]);
         for(int idir = 1; idir < SpaceDim; idir++)
         {
             int curval = amrex::Math::abs((*this)[idir]);


### PR DESCRIPTION
## Summary
This fixes the warnings from lint.

## Additional background

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
