### PR TITLE
Allow StateDataPhysBCFunct to operate on face-centered data

### DIFF
--- a/Src/Amr/AMReX_StateData.cpp
+++ b/Src/Amr/AMReX_StateData.cpp
@@ -528,7 +528,7 @@ StateData::FillBoundary (Box const&      bx,
 {
     BL_PROFILE("StateData::FillBoundary(geom)");
 
-    if (domain.contains(enclosedCells(bx))) return;
+    if (domain.contains(convert(bx,domain.ixType()))) return;
 
     Vector<BCRec> bcr(num_comp);
 

--- a/Src/Amr/AMReX_StateData.cpp
+++ b/Src/Amr/AMReX_StateData.cpp
@@ -923,7 +923,7 @@ StateDataPhysBCFunct::operator() (MultiFab& mf, int dest_comp, int num_comp, Int
                             if (hi > 0) GrownDomain.growHi(dir,hi);
                         }
                     }
-                    
+
                     for (int dir = 0; dir < AMREX_SPACEDIM; dir++)
                     {
                         if (!geom.isPeriodic(dir)) continue;


### PR DESCRIPTION
## Summary
This allows the velocity fill function (to fill external Dirichlet BCs) stored in the StateDescriptor to be used to fill the face-centered Umac. 

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
