### PR TITLE
Fix Parser ODR

### DIFF
--- a/Src/Base/Parser/amrex_iparser.tab.cpp
+++ b/Src/Base/Parser/amrex_iparser.tab.cpp
@@ -81,6 +81,13 @@
 #include <stdlib.h>
 #include <string.h>
 int amrex_iparserlex (void);
+/* Bison seems to have a bug. yyalloc etc. do not have the api.prefix. */
+#ifndef yyalloc
+#  define yyalloc amrex_iparseralloc
+#endif
+#ifndef yysymbol_kind_t
+#  define yysymbol_kind_t amrex_iparsersymbol_kind_t
+#endif
 
 
 # ifndef YY_CAST
@@ -525,9 +532,9 @@ static const yytype_int8 yytranslate[] =
   /* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */
 static const yytype_int8 yyrline[] =
 {
-       0,    72,    72,    73,    82,    83,    84,    85,    86,    87,
-      88,    89,    90,    91,    92,    93,    94,    95,    96,    97,
-      98,    99,   100,   101,   102,   103,   104,   105,   106
+       0,    79,    79,    80,    89,    90,    91,    92,    93,    94,
+      95,    96,    97,    98,    99,   100,   101,   102,   103,   104,
+     105,   106,   107,   108,   109,   110,   111,   112,   113
 };
 #endif
 

--- a/Src/Base/Parser/amrex_iparser.y
+++ b/Src/Base/Parser/amrex_iparser.y
@@ -5,6 +5,13 @@
 #include <stdlib.h>
 #include <string.h>
 int amrex_iparserlex (void);
+/* Bison seems to have a bug. yyalloc etc. do not have the api.prefix. */
+#ifndef yyalloc
+#  define yyalloc amrex_iparseralloc
+#endif
+#ifndef yysymbol_kind_t
+#  define yysymbol_kind_t amrex_iparsersymbol_kind_t
+#endif
 %}
 
 /* We do not need to make this reentrant safe, because we use flex and

--- a/Src/Base/Parser/amrex_parser.tab.cpp
+++ b/Src/Base/Parser/amrex_parser.tab.cpp
@@ -81,6 +81,13 @@
 #include <stdlib.h>
 #include <string.h>
 int amrex_parserlex (void);
+/* Bison seems to have a bug. yyalloc etc. do not have the api.prefix. */
+#ifndef yyalloc
+#  define yyalloc amrex_parseralloc
+#endif
+#ifndef yysymbol_kind_t
+#  define yysymbol_kind_t amrex_parsersymbol_kind_t
+#endif
 
 
 # ifndef YY_CAST
@@ -524,9 +531,9 @@ static const yytype_int8 yytranslate[] =
   /* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */
 static const yytype_int8 yyrline[] =
 {
-       0,    71,    71,    72,    81,    82,    83,    84,    85,    86,
-      87,    88,    89,    90,    91,    92,    93,    94,    95,    96,
-      97,    98,    99,   100,   101,   102,   103,   104
+       0,    78,    78,    79,    88,    89,    90,    91,    92,    93,
+      94,    95,    96,    97,    98,    99,   100,   101,   102,   103,
+     104,   105,   106,   107,   108,   109,   110,   111
 };
 #endif
 

--- a/Src/Base/Parser/amrex_parser.y
+++ b/Src/Base/Parser/amrex_parser.y
@@ -5,6 +5,13 @@
 #include <stdlib.h>
 #include <string.h>
 int amrex_parserlex (void);
+/* Bison seems to have a bug. yyalloc etc. do not have the api.prefix. */
+#ifndef yyalloc
+#  define yyalloc amrex_parseralloc
+#endif
+#ifndef yysymbol_kind_t
+#  define yysymbol_kind_t amrex_parsersymbol_kind_t
+#endif
 %}
 
 /* We do not need to make this reentrant safe, because we use flex and


### PR DESCRIPTION
## Summary

Although we define api.prefix, Bison does not use it for all the symbols.
So we fix it by manually adding the prefix to yyalloc and yysymbol_kind_t.

## Additional background

Partially address #2818.

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
