### PR TITLE
amrex::Any

### DIFF
--- a/Src/Base/AMReX_Any.H
+++ b/Src/Base/AMReX_Any.H
@@ -1,0 +1,84 @@
+#ifndef AMREX_ANY_H_
+#define AMREX_ANY_H_
+#include <AMReX_Config.H>
+
+#include <memory>
+#include <typeinfo>
+
+namespace amrex {
+
+/**
+ * This class is similar to std::any.  However, amrex::Any is for storing
+ * move-only types (e.g., amrex::MultiFab), whereas std::any is for copy
+ * constructible types.  An object of this class is non-copyable.
+ */
+class Any
+{
+public:
+
+    //! Default constructor.  By default it stores an int.
+    Any ()
+        : m_ptr(std::make_unique<innards<int> >(0))
+        {}
+
+    ~Any () = default;
+
+    Any (Any const& rhs) = delete;
+    Any& operator= (Any const& rhs) = delete;
+
+    Any (Any && rhs) = default;
+    Any& operator= (Any && rhs) = default;
+
+    //! Constructs by moving the given object.
+    template <typename MF>
+    Any (MF && mf)
+        : m_ptr(std::make_unique<innards<MF> >(std::forward<MF>(mf)))
+        {}
+
+    //! Assigns by moving the given object.
+    template <typename MF>
+    void operator= (MF && mf) {
+        m_ptr = std::make_unique<innards<MF> >(std::forward<MF>(mf));
+    }
+
+    //! Returns the contained type.
+    const std::type_info& Type () const {
+        return m_ptr->Type();
+    }
+
+    //! Returns a reference to the contained object.
+    template <typename MF>
+    MF& get () { return dynamic_cast<innards<MF>&>(*m_ptr).m_mf; }
+
+    //! Returns a const reference to the contained object.
+    template <typename MF>
+    MF const& get () const { return dynamic_cast<innards<MF> const&>(*m_ptr).m_mf; }
+
+    template <typename MF>
+    bool is () const { return m_ptr->Type() == typeid(MF); }
+
+private:
+    struct innards_base {
+        virtual const std::type_info& Type () const = 0;
+    };
+
+    template <typename MF>
+    struct innards : innards_base
+    {
+        innards(MF && mf)
+            : m_mf(std::forward<MF>(mf))
+            {}
+
+        virtual const std::type_info& Type () const override {
+            return typeid(MF);
+        }
+
+        MF m_mf;
+    };
+
+    std::unique_ptr<innards_base> m_ptr;
+};
+
+}
+
+#endif

--- a/Src/Base/CMakeLists.txt
+++ b/Src/Base/CMakeLists.txt
@@ -7,6 +7,7 @@ target_sources( amrex
    AMReX_ccse-mpi.H
    AMReX_Math.H
    AMReX_Algorithm.H
+   AMReX_Any.H
    AMReX_Array.H
    AMReX_BlockMutex.H
    AMReX_BlockMutex.cpp

--- a/Src/Base/Make.package
+++ b/Src/Base/Make.package
@@ -1,7 +1,8 @@
 
 AMREX_BASE=EXE
 
-C$(AMREX_BASE)_headers += AMReX_ccse-mpi.H AMReX_Algorithm.H AMReX_Array.H AMReX_Vector.H AMReX_TableData.H AMReX_Tuple.H AMReX_Math.H
+C$(AMREX_BASE)_headers += AMReX_ccse-mpi.H AMReX_Algorithm.H AMReX_Any.H AMReX_Array.H
+C$(AMREX_BASE)_headers += AMReX_Vector.H AMReX_TableData.H AMReX_Tuple.H AMReX_Math.H
 
 #
 # Utility classes.


### PR DESCRIPTION
Add amrex::Any that can be used to store any movable types.  Note that
std::any can only be used for copy constuctible types.  Thus, std::any
cannot be used to store MultiFab, whereas amrex::Any can.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
