### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/clang.yml
+++ b/.github/workflows/clang.yml
@@ -8,6 +8,9 @@ concurrency:
   group: ${{ github.ref }}-${{ github.head_ref }}-linux-clang
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   # Build and install libamrex as AMReX CMake project
   # Note: this is an intentional "minimal" build that does not enable (many) options

--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -6,6 +6,9 @@ concurrency:
   group: ${{ github.ref }}-${{ github.head_ref }}-cuda
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   # Build libamrex and all tests with CUDA 10.2
   tests-cuda10:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,8 +6,13 @@ concurrency:
   group: ${{ github.ref }}-${{ github.head_ref }}-docs
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   build-and-deploy:
+    permissions:
+      contents: write  # for JamesIves/github-pages-deploy-action to push changes in repo
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/gcc.yml
+++ b/.github/workflows/gcc.yml
@@ -9,6 +9,9 @@ concurrency:
   group: ${{ github.ref }}-${{ github.head_ref }}-linux-gcc
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   # Build and install libamrex as AMReX CMake project
   # Note: this is an intentional "minimal" build that does not enable (many) options

--- a/.github/workflows/hip.yml
+++ b/.github/workflows/hip.yml
@@ -6,6 +6,9 @@ concurrency:
   group: ${{ github.ref }}-${{ github.head_ref }}-hip
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   tests-hip:
     name: HIP ROCm Flang C++17 [tests]

--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -6,6 +6,9 @@ concurrency:
   group: ${{ github.ref }}-${{ github.head_ref }}-intel
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   tests-dpcpp:
     name: DPCPP GFortran@7.5 C++17 [tests]

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -6,6 +6,9 @@ concurrency:
   group: ${{ github.ref }}-${{ github.head_ref }}-macos
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   # Build libamrex and all tests
   tests-macos-universal-nompi:

--- a/.github/workflows/sensei.yml
+++ b/.github/workflows/sensei.yml
@@ -8,6 +8,9 @@ concurrency:
   group: ${{ github.ref }}-${{ github.head_ref }}-sensei
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   test_sensei:
     name: SENSEI Adaptor [test]

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -6,6 +6,9 @@ concurrency:
   group: ${{ github.ref }}-${{ github.head_ref }}-style
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   tabs:
     runs-on: ubuntu-latest


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: neilnaveen <42328488+neilnaveen@users.noreply.github.com>
