### PR TITLE
HIP Memory Advise : Set managed memory to coarse grain

### DIFF
--- a/Src/Base/AMReX_Arena.cpp
+++ b/Src/Base/AMReX_Arena.cpp
@@ -165,6 +165,11 @@ Arena::allocate_system (std::size_t nbytes)
                 (AMREX_HIP_SAFE_CALL(hipMallocManaged(&p, nbytes));,
                  AMREX_CUDA_SAFE_CALL(cudaMallocManaged(&p, nbytes));,
                  p = sycl::malloc_shared(nbytes, Gpu::Device::syclDevice(), Gpu::Device::syclContext()));
+#ifdef AMREX_USE_HIP
+            // Otherwise atomiAdd won't work because we instruct the compiler to do unsafe atomics
+            AMREX_HIP_SAFE_CALL(hipMemAdvise(p, nbytes, hipMemAdviseSetCoarseGrain,
+                                             Gpu::Device::deviceId()));
+#endif
             if (arena_info.device_set_readonly)
             {
                 Gpu::Device::mem_advise_set_readonly(p, nbytes);

--- a/Src/Base/AMReX_GpuAtomic.H
+++ b/Src/Base/AMReX_GpuAtomic.H
@@ -140,6 +140,21 @@ namespace detail {
 #endif
     }
 
+#if defined(AMREX_USE_HIP) && defined(__gfx90a__)
+    // https://github.com/ROCm-Developer-Tools/hipamd/blob/rocm-4.5.x/include/hip/amd_detail/amd_hip_unsafe_atomics.h
+    AMREX_GPU_DEVICE AMREX_FORCE_INLINE
+    float Add_device (float* const sum, float const value) noexcept
+    {
+        return unsafeAtomicAdd(sum, value);
+    }
+
+    AMREX_GPU_DEVICE AMREX_FORCE_INLINE
+    double Add_device (double* const sum, double const value) noexcept
+    {
+        return unsafeAtomicAdd(sum, value);
+    }
+#endif
+
 #ifdef AMREX_USE_DPCPP
 
     // Valid atomic types are available at

--- a/Src/Base/AMReX_GpuDevice.cpp
+++ b/Src/Base/AMReX_GpuDevice.cpp
@@ -783,13 +783,14 @@ void
 Device::mem_advise_set_preferred (void* p, const std::size_t sz, const int device)
 {
     amrex::ignore_unused(p,sz,device);
-    // HIP does not support memory advise.
-#ifdef AMREX_USE_CUDA
-#ifndef AMREX_USE_HIP
+#if defined(AMREX_USE_CUDA) || defined(AMREX_USE_HIP)
     if (device_prop.managedMemory == 1 && device_prop.concurrentManagedAccess == 1)
-#endif
     {
-        AMREX_CUDA_SAFE_CALL(cudaMemAdvise(p, sz, cudaMemAdviseSetPreferredLocation, device));
+        AMREX_HIP_OR_CUDA
+            (AMREX_HIP_SAFE_CALL(
+                 hipMemAdvise(p, sz, hipMemAdviseSetPreferredLocation, device)),
+             AMREX_CUDA_SAFE_CALL(
+                 cudaMemAdvise(p, sz, cudaMemAdviseSetPreferredLocation, device)));
     }
 #elif defined(AMREX_USE_DPCPP)
     // xxxxx DPCPP todo: mem_advise
@@ -805,13 +806,14 @@ void
 Device::mem_advise_set_readonly (void* p, const std::size_t sz)
 {
     amrex::ignore_unused(p,sz);
-    // HIP does not support memory advise.
-#ifdef AMREX_USE_CUDA
-#ifndef AMREX_USE_HIP
+#if defined(AMREX_USE_CUDA) || defined(AMREX_USE_HIP)
     if (device_prop.managedMemory == 1 && device_prop.concurrentManagedAccess == 1)
-#endif
     {
-        AMREX_CUDA_SAFE_CALL(cudaMemAdvise(p, sz, cudaMemAdviseSetReadMostly, cudaCpuDeviceId));
+        AMREX_HIP_OR_CUDA
+            (AMREX_HIP_SAFE_CALL(
+                 hipMemAdvise(p, sz, hipMemAdviseSetReadMostly, hipCpuDeviceId)),
+             AMREX_CUDA_SAFE_CALL(
+                 cudaMemAdvise(p, sz, cudaMemAdviseSetReadMostly, cudaCpuDeviceId)));
     }
 #elif defined(AMREX_USE_DPCPP)
     // xxxxx DPCPP todo: mem_advise


### PR DESCRIPTION
For unsafe atomics to work on managed memory, we must set it to coarse
grain.

For gfx90a, we can explicitly use unsafeAtomicAdd.

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
