### PR TITLE
add fvolumesum to GNUmakefile

### DIFF
--- a/Tools/Plotfile/CMakeLists.txt
+++ b/Tools/Plotfile/CMakeLists.txt
@@ -15,6 +15,7 @@ set(_exe_names
    fsnapshot
    ftime
    fvarnames
+   fvolumesum
    )
 
 # Build targets one by one

--- a/Tools/Plotfile/GNUmakefile
+++ b/Tools/Plotfile/GNUmakefile
@@ -21,6 +21,7 @@ ifeq ($(strip $(programs)),)
   programs += fsnapshot
   programs += ftime
   programs += fvarnames
+  programs += fvolumesum
 endif
 
 include $(AMREX_HOME)/Tools/GNUMake/Make.defs

--- a/Tools/Plotfile/fvolumesum.cpp
+++ b/Tools/Plotfile/fvolumesum.cpp
@@ -120,7 +120,7 @@ void main_main()
                                                         problo[2]+static_cast<Real>(k+0.5)*dx[2])};
 
                                     // compute the volume
-                                    Real vol;
+                                    Real vol = NAN;
                                     if (coord == 0) {
                                         // Cartesian
                                         vol = 1.0_rt;

--- a/Tools/Plotfile/fvolumesum.cpp
+++ b/Tools/Plotfile/fvolumesum.cpp
@@ -120,7 +120,7 @@ void main_main()
                                                         problo[2]+static_cast<Real>(k+0.5)*dx[2])};
 
                                     // compute the volume
-                                    Real vol = NAN;
+                                    Real vol = std::numeric_limits<Real>::quiet_NaN();
                                     if (coord == 0) {
                                         // Cartesian
                                         vol = 1.0_rt;
@@ -163,7 +163,7 @@ void main_main()
                                                     problo[2]+static_cast<Real>(k+0.5)*dx[2])};
 
                                     // compute the volume
-                                    Real vol = NAN;
+                                    Real vol = std::numeric_limits<Real>::quiet_NaN();
                                     if (coord == 0) {
                                         // Cartesian
                                         vol = 1.0_rt;

--- a/Tools/Plotfile/fvolumesum.cpp
+++ b/Tools/Plotfile/fvolumesum.cpp
@@ -163,7 +163,7 @@ void main_main()
                                                     problo[2]+static_cast<Real>(k+0.5)*dx[2])};
 
                                     // compute the volume
-                                    Real vol;
+                                    Real vol = NAN;
                                     if (coord == 0) {
                                         // Cartesian
                                         vol = 1.0_rt;


### PR DESCRIPTION
## Summary
`fvolumesum` was missing from the GNUmakefile and CMakeLists.txt inside Tools/Plotfile. It is now built alongside the rest of the plotfile tools.

## Additional background

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
