### PR TITLE
Fix: CMake NVTX not only Hypre

### DIFF
--- a/Tools/CMake/AMReXParallelBackends.cmake
+++ b/Tools/CMake/AMReXParallelBackends.cmake
@@ -57,6 +57,11 @@ if (  AMReX_GPU_BACKEND STREQUAL "CUDA"
    find_package(CUDAToolkit REQUIRED)
    target_link_libraries(amrex PUBLIC CUDA::curand)
 
+    # nvToolsExt: if tiny profiler or base profiler are on.
+    if (AMReX_TINY_PROFILE OR AMReX_BASE_PROFILE)
+        target_link_libraries(amrex PUBLIC CUDA::nvToolsExt)
+    endif ()
+
    # Check cuda compiler and host compiler
    set_mininum_compiler_version(CUDA NVIDIA 9.0)
    check_cuda_host_compiler()

--- a/Tools/CMake/AMReXThirdPartyLibraries.cmake
+++ b/Tools/CMake/AMReXThirdPartyLibraries.cmake
@@ -85,11 +85,6 @@ if (AMReX_HYPRE)
 
         # mandatory CUDA dependencies: cuSPARSE, cuRAND
         target_link_libraries(amrex PUBLIC CUDA::cusparse CUDA::curand)
-
-        # nvToolsExt: if tiny profiler or base profiler are on.
-        if (AMReX_TINY_PROFILE OR AMReX_BASE_PROFILE)
-            target_link_libraries(amrex PUBLIC CUDA::nvToolsExt)
-        endif ()
     endif()
     target_link_libraries( amrex PUBLIC HYPRE )
 endif ()


### PR DESCRIPTION
## Summary

NVTX is used also without Hypre in AMReX.

## Additional background

Follow-up to:
- #2757 (here we started modernization)
- #2813 (onoging modernization)
- #2817 (this is correct, but revealed the issue)

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
