### PR TITLE
CMake: Fix `export` with `AMReX_INSTALL=OFF`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -149,10 +149,10 @@ endif ()
 #
 # Install amrex  -- Export
 #
-if(AMReX_INSTALL)
-    include(AMReXInstallHelpers)
-    install_amrex_targets(${_amrex_targets})
+include(AMReXInstallHelpers)
+install_amrex_targets(${_amrex_targets})
 
+if(AMReX_INSTALL)
     # Add a test_install target to smoke-test
     # the installation
     add_test_install_target(

--- a/Tools/CMake/AMReXInstallHelpers.cmake
+++ b/Tools/CMake/AMReXInstallHelpers.cmake
@@ -39,51 +39,53 @@ function (install_amrex_targets)
        ${PROJECT_BINARY_DIR}/${CMAKE_FILES_DIR}/AMReXConfigVersion.cmake
        COMPATIBILITY AnyNewerVersion )
 
-   install( FILES
-      ${PROJECT_BINARY_DIR}/${CMAKE_FILES_DIR}/AMReXConfig.cmake
-      ${PROJECT_BINARY_DIR}/${CMAKE_FILES_DIR}/AMReXConfigVersion.cmake
-      DESTINATION ${CMAKE_FILES_DIR} )
+   if(AMReX_INSTALL)
+       install( FILES
+          ${PROJECT_BINARY_DIR}/${CMAKE_FILES_DIR}/AMReXConfig.cmake
+          ${PROJECT_BINARY_DIR}/${CMAKE_FILES_DIR}/AMReXConfigVersion.cmake
+          DESTINATION ${CMAKE_FILES_DIR} )
 
-   #
-   # Export install-tree
-   #
-   install(
-      TARGETS       ${_targets}
-      EXPORT        AMReXTargets
-      ARCHIVE       DESTINATION lib
-      LIBRARY       DESTINATION lib
-      INCLUDES      DESTINATION include # Adds proper directory to INTERFACE_INCLUDE_DIRECTORIES
-      PUBLIC_HEADER DESTINATION include
-      RUNTIME       DESTINATION bin
-      )
+       #
+       # Export install-tree
+       #
+       install(
+          TARGETS       ${_targets}
+          EXPORT        AMReXTargets
+          ARCHIVE       DESTINATION lib
+          LIBRARY       DESTINATION lib
+          INCLUDES      DESTINATION include # Adds proper directory to INTERFACE_INCLUDE_DIRECTORIES
+          PUBLIC_HEADER DESTINATION include
+          RUNTIME       DESTINATION bin
+          )
 
-   install( EXPORT AMReXTargets
-      NAMESPACE AMReX::
-      DESTINATION lib/cmake/AMReX )
+       install( EXPORT AMReXTargets
+          NAMESPACE AMReX::
+          DESTINATION lib/cmake/AMReX )
 
-   # Install fortran modules if Fortran is enabled
-   get_property(_lang GLOBAL PROPERTY ENABLED_LANGUAGES)
-   if ("Fortran" IN_LIST _lang AND "amrex" IN_LIST _targets)
-      get_target_property(_mod_dir amrex Fortran_MODULE_DIRECTORY )
-      install( DIRECTORY ${_mod_dir}/ DESTINATION include ) # Trailing backslash is crucial here!
-   endif ()
+       # Install fortran modules if Fortran is enabled
+       get_property(_lang GLOBAL PROPERTY ENABLED_LANGUAGES)
+       if ("Fortran" IN_LIST _lang AND "amrex" IN_LIST _targets)
+          get_target_property(_mod_dir amrex Fortran_MODULE_DIRECTORY )
+          install( DIRECTORY ${_mod_dir}/ DESTINATION include ) # Trailing backslash is crucial here!
+       endif ()
 
-   # Install Tools directory
-   install(
-      DIRECTORY
-      ${PROJECT_SOURCE_DIR}/Tools/CMake
-      ${PROJECT_SOURCE_DIR}/Tools/C_scripts
-      ${PROJECT_SOURCE_DIR}/Tools/typechecker
-      DESTINATION
-      Tools
-      USE_SOURCE_PERMISSIONS
-      )
+       # Install Tools directory
+       install(
+          DIRECTORY
+          ${PROJECT_SOURCE_DIR}/Tools/CMake
+          ${PROJECT_SOURCE_DIR}/Tools/C_scripts
+          ${PROJECT_SOURCE_DIR}/Tools/typechecker
+          DESTINATION
+          Tools
+          USE_SOURCE_PERMISSIONS
+          )
+   endif()
 
    #
    # Export build-tree
    #
-   export( EXPORT AMReXTargets NAMESPACE AMReX::
-      FILE ${PROJECT_BINARY_DIR}/${CMAKE_FILES_DIR}/AMReXTargets.cmake )
+   export(TARGETS ${_targets} NAMESPACE AMReX::
+          FILE ${PROJECT_BINARY_DIR}/${CMAKE_FILES_DIR}/AMReXTargets.cmake)
 
    # Copy Tools directory to build tree
    file(


### PR DESCRIPTION
## Summary

When introducing `AMReX_INSTALL` #1831, the `export` of targets #1149 broke for `OFF`. This generalizes this to work in either case.

## Additional background

Check the change without white space changes to see the changed logic more cleanly:
https://github.com/AMReX-Codes/amrex/pull/2838/files?diff=unified&w=1

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
