### PR TITLE
Maintain the high end of the 'roundoff domain' in both float and double precision

### DIFF
--- a/Src/Base/AMReX_Geometry.H
+++ b/Src/Base/AMReX_Geometry.H
@@ -71,12 +71,12 @@ public:
         template <typename T>
         T bisect_prob_hi (amrex::Real plo, amrex::Real phi, amrex::Real idx, int ilo, int ihi, T tol) {
             T hi = static_cast<T>(phi - tol);
-            bool inside;
+            bool safe;
             {
                 int i = int(Math::floor(hi - plo)*idx);
-                inside = i >= ilo && i <= ihi;
+                safe = i >= ilo && i <= ihi;
             }
-            if (inside) {
+            if (safe) {
                 return hi;
             } else {
                 // bisect the point at which the cell no longer maps to inside the domain

--- a/Src/Base/AMReX_Geometry.H
+++ b/Src/Base/AMReX_Geometry.H
@@ -73,7 +73,7 @@ public:
             T hi = static_cast<T>(phi - tol);
             bool safe;
             {
-                int i = int(Math::floor(hi - plo)*idx) + ilo;
+                int i = int(Math::floor((x - plo)*idx)) + ilo;
                 safe = i >= ilo && i <= ihi;
             }
             if (safe) {

--- a/Src/Base/AMReX_Geometry.H
+++ b/Src/Base/AMReX_Geometry.H
@@ -69,7 +69,7 @@ public:
 
     namespace detail {
         template <typename T>
-        T bisect_prob_hi (amrex::Real plo, amrex::Real phi, amrex::Real idx, int ilo, int ihi, T tol) {
+        T bisect_prob_hi (amrex::Real plo, amrex::Real phi, amrex::Real idx, int ilo, int ihi, amrex::Real tol) {
             T hi = static_cast<T>(phi - tol);
             bool safe;
             {
@@ -87,8 +87,8 @@ public:
                                        int i = int(Math::floor((x - plo)*idx)) + ilo;
                                        bool inside = i >= ilo && i <= ihi;
                                        return static_cast<T>(inside) - T(0.5);
-                                   }, tol);
-                return mid - tol;
+                                   }, static_cast<T>(tol));
+                return mid - static_cast<T>(tol);
             }
         }
     }

--- a/Src/Base/AMReX_Geometry.H
+++ b/Src/Base/AMReX_Geometry.H
@@ -67,6 +67,32 @@ public:
     int coord;
 };
 
+    namespace detail {
+        template <typename T>
+        T bisect_prob_hi (amrex::Real plo, amrex::Real phi, amrex::Real idx, int ilo, int ihi, T tol) {
+            T hi = static_cast<T>(phi - tol);
+            bool inside;
+            {
+                int i = int(Math::floor(hi - plo)*idx);
+                inside = i >= ilo && i <= ihi;
+            }
+            if (inside) {
+                return hi;
+            } else {
+                // bisect the point at which the cell no longer maps to inside the domain
+                T lo = static_cast<T>(phi - 0.5_rt/idx);
+                T mid = bisect(lo, hi,
+                               [=] AMREX_GPU_HOST_DEVICE (T x) -> Real
+                                   {
+                                       int i = int(Math::floor((x - plo)*idx)) + ilo;
+                                       bool inside = i >= ilo && i <= ihi;
+                                       return static_cast<T>(inside) - T(0.5);
+                                   }, tol);
+                return mid - tol;
+            }
+        }
+    }
+
 class Geometry
     :
     public CoordSys
@@ -168,8 +194,6 @@ public:
 
     //! Returns the problem domain.
     const RealBox& ProbDomain () const noexcept { return prob_domain; }
-    //! Returns the roundoff domain.
-    const RealBox& RoundoffDomain () const noexcept { return roundoff_domain; }
     //! Sets the problem domain.
     void ProbDomain (const RealBox& rb) noexcept
     {
@@ -193,12 +217,12 @@ public:
         return {{AMREX_D_DECL(prob_domain.hi(0),prob_domain.hi(1),prob_domain.hi(2))}};
     }
 
-    GpuArray<Real,AMREX_SPACEDIM> RoundoffLoArray () const noexcept {
-        return {{AMREX_D_DECL(roundoff_domain.lo(0),roundoff_domain.lo(1),roundoff_domain.lo(2))}};
-    }
-
-    GpuArray<Real,AMREX_SPACEDIM> RoundoffHiArray () const noexcept {
-        return {{AMREX_D_DECL(roundoff_domain.hi(0),roundoff_domain.hi(1),roundoff_domain.hi(2))}};
+    GpuArray<ParticleReal,AMREX_SPACEDIM> ProbHiArrayInParticleReal () const noexcept {
+#ifdef AMREX_SINGLE_PRECISION_PARTICLES
+        return roundoff_hi_f;
+#else
+        return roundoff_hi_d;
+#endif
     }
 
     //! Returns the overall size of the domain by multiplying the ProbLength's together
@@ -406,7 +430,7 @@ public:
     *        are sure to be mapped to cells inside the Domain() box. Note that
     *        the same need not be true for all points inside ProbDomain().
     */
-    bool outsideRoundoffDomain (AMREX_D_DECL(Real x, Real y, Real z)) const;
+    bool outsideRoundoffDomain (AMREX_D_DECL(ParticleReal x, ParticleReal y, ParticleReal z)) const;
 
     /**
     * \brief Returns true if a point is inside the roundoff domain.
@@ -414,7 +438,7 @@ public:
     *        are sure to be mapped to cells inside the Domain() box. Note that
     *        the same need not be true for all points inside ProbDomain().
     */
-    bool insideRoundoffDomain (AMREX_D_DECL(Real x, Real y, Real z)) const;
+    bool insideRoundoffDomain (AMREX_D_DECL(ParticleReal x, ParticleReal y, ParticleReal z)) const;
 
     /**
     * \brief Compute the roundoff domain. Public because it contains an
@@ -430,10 +454,11 @@ private:
     RealBox prob_domain;
 
     // Due to round-off errors, not all floating point numbers for which plo >= x < phi
-    // will map to a cell that is inside "domain". "roundoff_domain" stores a phi
-    // that is very close to that in prob_domain, and for which all floating point numbers
-    // inside it according to a naive inequality check will map to a cell inside domain.
-    RealBox roundoff_domain;
+    // will map to a cell that is inside "domain". "roundoff_hi_d" and "roundoff_hi_f" each store
+    // a phi that is very close to that in prob_domain, and for which all doubles and floats less than
+    // it will map to a cell inside domain.
+    GpuArray<double, AMREX_SPACEDIM> roundoff_hi_d;
+    GpuArray<float , AMREX_SPACEDIM> roundoff_hi_f;
 
     //
     Box     domain;

--- a/Src/Base/AMReX_Geometry.H
+++ b/Src/Base/AMReX_Geometry.H
@@ -73,7 +73,7 @@ public:
             T hi = static_cast<T>(phi - tol);
             bool safe;
             {
-                int i = int(Math::floor((x - plo)*idx)) + ilo;
+                int i = int(Math::floor((hi - plo)*idx)) + ilo;
                 safe = i >= ilo && i <= ihi;
             }
             if (safe) {

--- a/Src/Base/AMReX_Geometry.H
+++ b/Src/Base/AMReX_Geometry.H
@@ -73,7 +73,7 @@ public:
             T hi = static_cast<T>(phi - tol);
             bool safe;
             {
-                int i = int(Math::floor(hi - plo)*idx);
+                int i = int(Math::floor(hi - plo)*idx) + ilo;
                 safe = i >= ilo && i <= ihi;
             }
             if (safe) {

--- a/Src/Base/AMReX_Geometry.H
+++ b/Src/Base/AMReX_Geometry.H
@@ -82,7 +82,7 @@ public:
                 // bisect the point at which the cell no longer maps to inside the domain
                 T lo = static_cast<T>(phi - 0.5_rt/idx);
                 T mid = bisect(lo, hi,
-                               [=] AMREX_GPU_HOST_DEVICE (T x) -> Real
+                               [=] AMREX_GPU_HOST_DEVICE (T x) -> T
                                    {
                                        int i = int(Math::floor((x - plo)*idx)) + ilo;
                                        bool inside = i >= ilo && i <= ihi;

--- a/Src/Particle/AMReX_ParticleContainerI.H
+++ b/Src/Particle/AMReX_ParticleContainerI.H
@@ -239,7 +239,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>
     const auto& geom = Geom(0);
     const auto plo = geom.ProbLoArray();
     const auto phi = geom.ProbHiArray();
-    const auto rhi = geom.RoundoffHiArray();
+    const auto rhi = geom.ProbHiArrayInParticleReal();
     const auto is_per = geom.isPeriodicArray();
 
     return enforcePeriodic(p, plo, phi, rhi, is_per);
@@ -314,20 +314,21 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>::lo
 
     if (! outside)
     {
-        if (Geom(0).outsideRoundoffDomain(AMREX_D_DECL(Real(p.pos(0)), Real(p.pos(1)), Real(p.pos(2)))))
+        if (Geom(0).outsideRoundoffDomain(AMREX_D_DECL(p.pos(0), p.pos(1), p.pos(2))))
         {
-            RealBox roundoff_domain = Geom(0).RoundoffDomain();
+            RealBox prob_domain = Geom(0).ProbDomain();
+            GpuArray<ParticleReal, AMREX_SPACEDIM> phi = Geom(0).ProbHiArrayInParticleReal();
             for (int idim=0; idim < AMREX_SPACEDIM; ++idim)
             {
-                if (p.pos(idim) <= roundoff_domain.lo(idim)) {
-                    p.pos(idim) = std::nextafter((ParticleReal) roundoff_domain.lo(idim), (ParticleReal) roundoff_domain.hi(idim));
+                if (p.pos(idim) <= prob_domain.lo(idim)) {
+                    p.pos(idim) = std::nextafter((ParticleReal) prob_domain.lo(idim), phi[idim]);
                 }
-                if (p.pos(idim) >= roundoff_domain.hi(idim)) {
-                    p.pos(idim) = std::nextafter((ParticleReal) roundoff_domain.hi(idim), (ParticleReal) roundoff_domain.lo(idim));
+                if (p.pos(idim) >= phi[idim]) {
+                    p.pos(idim) = std::nextafter(phi[idim], (ParticleReal) prob_domain.lo(idim));
                 }
             }
 
-            AMREX_ASSERT(! Geom(0).outsideRoundoffDomain(AMREX_D_DECL(Real(p.pos(0)), Real(p.pos(1)), Real(p.pos(2)))));
+            AMREX_ASSERT(! Geom(0).outsideRoundoffDomain(AMREX_D_DECL(p.pos(0), p.pos(1), p.pos(2))));
         }
     }
 
@@ -1233,7 +1234,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>
     Vector<std::map<int, int> > new_sizes(num_levels);
     const auto plo    = Geom(0).ProbLoArray();
     const auto phi    = Geom(0).ProbHiArray();
-    const auto rhi    = Geom(0).RoundoffHiArray();
+    const auto rhi    = Geom(0).ProbHiArrayInParticleReal();
     const auto is_per = Geom(0).isPeriodicArray();
     for (int lev = lev_min; lev <= finest_lev_particles; ++lev)
     {

--- a/Src/Particle/AMReX_ParticleUtil.H
+++ b/Src/Particle/AMReX_ParticleUtil.H
@@ -517,7 +517,7 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 bool enforcePeriodic (P& p,
                       amrex::GpuArray<amrex::Real,AMREX_SPACEDIM> const& plo,
                       amrex::GpuArray<amrex::Real,AMREX_SPACEDIM> const& phi,
-                      amrex::GpuArray<amrex::Real,AMREX_SPACEDIM> const& rhi,
+                      amrex::GpuArray<amrex::ParticleReal,AMREX_SPACEDIM> const& rhi,
                       amrex::GpuArray<int,AMREX_SPACEDIM> const& is_per) noexcept
 {
     bool shifted = false;
@@ -537,7 +537,7 @@ bool enforcePeriodic (P& p,
                 p.pos(idim) += static_cast<ParticleReal>(phi[idim] - plo[idim]);
             }
             // clamp to avoid precision issues;
-            if (p.pos(idim) >= rhi[idim]) {
+            if (p.pos(idim) > rhi[idim]) {
                 p.pos(idim) = static_cast<ParticleReal>(rhi[idim]);
             }
             shifted = true;
@@ -555,7 +555,7 @@ int
 partitionParticlesByDest (PTile& ptile, const PLocator& ploc, const ParticleBufferMap& pmap,
                           const GpuArray<Real,AMREX_SPACEDIM>& plo,
                           const GpuArray<Real,AMREX_SPACEDIM>& phi,
-                          const GpuArray<Real,AMREX_SPACEDIM>& rhi,
+                          const GpuArray<ParticleReal,AMREX_SPACEDIM>& rhi,
                           const GpuArray<int ,AMREX_SPACEDIM>& is_per,
                           int lev, int gid, int /*tid*/,
                           int lev_min, int lev_max, int nGrow, bool remove_negative)


### PR DESCRIPTION
This way we set the proper value for the high end when mixed precision is used.

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
