### PR TITLE
ParamParse: Add Files at Runtime

### DIFF
--- a/Src/Base/AMReX_ParmParse.H
+++ b/Src/Base/AMReX_ParmParse.H
@@ -552,6 +552,13 @@ public:
     //! Add a key 'name'with value 'ref' to the end of the PP table.
     void add (const char* name,
               const std::string&  val);
+
+    //! keyword for files to load
+    static std::string FileKeyword;
+
+    //! Add keys and values from a file to the end of the PP table.
+    void addfile (std::string const filename);
+
     /**
     * \brief Get the ival'th value of kth occurrence of the requested name.
     * If successful, the value is converted to an IntVect and stored

--- a/Src/Base/AMReX_ParmParse.H
+++ b/Src/Base/AMReX_ParmParse.H
@@ -557,7 +557,7 @@ public:
     static std::string FileKeyword;
 
     //! Add keys and values from a file to the end of the PP table.
-    void addfile (std::string const filename);
+    static void addfile (std::string const filename);
 
     /**
     * \brief Get the ival'th value of kth occurrence of the requested name.
@@ -1053,7 +1053,7 @@ public:
     static std::set<std::string> getEntries (const std::string& prefix = std::string());
 
     struct PP_entry;
-    typedef std::list<PP_entry> Table;
+    using Table = std::list<PP_entry>;
     static void appendTable(ParmParse::Table& tab);
     const Table& table() const {return m_table;}
 

--- a/Src/Base/AMReX_ParmParse.cpp
+++ b/Src/Base/AMReX_ParmParse.cpp
@@ -34,6 +34,8 @@ static bool finalize_verbose = false;
 static bool finalize_verbose = true;
 #endif
 
+std::string ParmParse::FileKeyword = "FILE";
+
 //
 // Used by constructor to build table.
 //
@@ -575,7 +577,6 @@ addDefn (std::string&         def,
          std::list<std::string>&   val,
          std::list<ParmParse::PP_entry>& tab)
 {
-    static const std::string FileKeyword("FILE");
     //
     // Check that defn exists.
     //
@@ -595,7 +596,7 @@ addDefn (std::string&         def,
     //
     // Check if this defn is a file include directive.
     //
-    if ( def == FileKeyword && val.size() == 1 )
+    if ( def == ParmParse::FileKeyword && val.size() == 1 )
     {
         //
         // Read file and add to this table.
@@ -985,6 +986,14 @@ ParmParse::prefixedName (const std::string& str) const
         return m_pstack.top() + '.' + str;
     }
     return str;
+}
+
+void
+ParmParse::addfile (std::string const filename) {
+    auto l = std::list<std::string>{filename};
+    addDefn(FileKeyword,
+            l,
+            m_table);
 }
 
 void

--- a/Src/Base/AMReX_ParmParse.cpp
+++ b/Src/Base/AMReX_ParmParse.cpp
@@ -993,7 +993,7 @@ ParmParse::addfile (std::string const filename) {
     auto l = std::list<std::string>{filename};
     addDefn(FileKeyword,
             l,
-            m_table);
+            g_table);
 }
 
 void


### PR DESCRIPTION
## Summary

Add a new runtime API to load whole files. This was currently only possible during the first initialize.

## Questions for Reviewers

- [x] does this work with MPI or do I need to call more functions?
- [ ] where shall I add a unit test for this?

## Additional background

Needed for pyAMReX and ImpactX' Python bindings.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
