### PR TITLE
Double quotes.

### DIFF
--- a/Tools/GNUMake/sites/Make.nersc
+++ b/Tools/GNUMake/sites/Make.nersc
@@ -25,8 +25,8 @@ ifeq ($(which_computer),$(filter $(which_computer),perlmutter))
   endif
 
   ifeq ($(USE_CUDA),TRUE)
-      CFLAGS += -Xcompiler='$(wordlist 2,1024,$(shell cc -craype-verbose 2> /dev/null))'
-      CXXFLAGS += -Xcompiler='$(wordlist 2,1024,$(shell CC -craype-verbose 2> /dev/null))'
+      CFLAGS += -Xcompiler="$(wordlist 2,1024,$(shell cc -craype-verbose 2> /dev/null))"
+      CXXFLAGS += -Xcompiler="$(wordlist 2,1024,$(shell CC -craype-verbose 2> /dev/null))"
   else ifeq ($(USE_MPI),FALSE)
       CFLAGS += $(wordlist 2,1024,$(shell cc -craype-verbose 2> /dev/null))
       CXXFLAGS += $(wordlist 2,1024,$(shell CC -craype-verbose 2> /dev/null))


### PR DESCRIPTION
## Summary
Single quotes breaks GNMake echo:

```
kngott@login35:~/amrex/amrex-tests/FBPointTest$ make print-CFLAGS
Loading ../../amrex/Tools/GNUMake/comps/gnu.mak...
Loading ../../amrex/Tools/GNUMake/sites/Make.nersc...
CFLAGS is -ccbin=g++ -Xcompiler= -Werror=return-type -gdwarf-4 -O3 -pthread -std=c++14 --std=c++14 -Wno-deprecated-gpu-targets -m64 -arch=compute_80 -code=sm_80 -maxrregcount=255 --expt-relaxed-constexpr --expt-extended-lambda -Xcudafe --diag_suppress=esa_on_defaulted_function_ignored --Werror cross-execution-space-call -lineinfo --ptxas-options=-O3 --ptxas-options=-v --use_fast_math  --forward-unknown-to-host-compiler --Werror ext-lambda-captures-this --display-error-number --diag-error 20092 -x cu -dc -Xcompiler=-march=znver3
    origin = file
/bin/sh: wordlist: command not found
     value = $(CFLAGS_FROM_HOST) $(NVCC_FLAGS) -x cu -dc -Xcompiler=
```

But, double quotes works fine, even reporting the "value" correctly:
```
kngott@login35:~/amrex/amrex-tests/FBPointTest$ make print-CFLAGS
Loading ../../amrex/Tools/GNUMake/comps/gnu.mak...
Loading ../../amrex/Tools/GNUMake/sites/Make.nersc...
CFLAGS is -ccbin=g++ -Xcompiler= -Werror=return-type -gdwarf-4 -O3 -pthread -std=c++14 --std=c++14 -Wno-deprecated-gpu-targets -m64 -arch=compute_80 -code=sm_80 -maxrregcount=255 --expt-relaxed-constexpr --expt-extended-lambda -Xcudafe --diag_suppress=esa_on_defaulted_function_ignored --Werror cross-execution-space-call -lineinfo --ptxas-options=-O3 --ptxas-options=-v --use_fast_math  --forward-unknown-to-host-compiler --Werror ext-lambda-captures-this --display-error-number --diag-error 20092 -x cu -dc -Xcompiler="-march=znver3"
    origin = file
     value = $(CFLAGS_FROM_HOST) $(NVCC_FLAGS) -x cu -dc -Xcompiler="$(wordlist 2,1024,$(shell cc -craype-verbose 2> /dev/null))"
```

Also, confirmed the flag is successfully passed through Xcompiler, using objdump + grep-ing for `ymm` instructions.

## Additional Discussion

Note that all single quotes are lost in GNUMake echo commands (i.e. the first Xcompiler in the above example lost it's quotes around several flags). So, it's possible this should be tweaked elsewhere as well, to make the `make help` output more readable, among other things. Of course, not a huge deal.

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
