### PR TITLE
Correct the parameter name in the usage string

### DIFF
--- a/Tools/Postprocessing/C_Src/IntegrateComp.cpp
+++ b/Tools/Postprocessing/C_Src/IntegrateComp.cpp
@@ -22,7 +22,7 @@ print_usage (int,
              char* argv[])
 {
   std::cerr << "usage:\n";
-  std::cerr << argv[0] << " infile=<plotfilename> varName=v1 v2 ... \n";
+  std::cerr << argv[0] << " infile=<plotfilename> varNames=v1 v2 ... \n";
   exit(1);
 }
 


### PR DESCRIPTION
## Summary

The parameter `varName` in the usage string should be `varNames`.

## Additional background

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
