### PR TITLE
NERSC Programming Environment prototype

### DIFF
--- a/Tools/GNUMake/sites/Make.nersc
+++ b/Tools/GNUMake/sites/Make.nersc
@@ -25,8 +25,8 @@ ifeq ($(which_computer),$(filter $(which_computer),perlmutter))
   endif
 
   ifeq ($(USE_CUDA),TRUE)
-      CFLAGS += -Xcompiler='$(wordlist 2,1024,$(shell cc -craype-verbose 2> /dev/null))'
-      CXXFLAGS += -Xcompiler='$(wordlist 2,1024,$(shell CC -craype-verbose 2> /dev/null))'
+      CFLAGS += -Xcompiler="$(wordlist 2,1024,$(shell cc -craype-verbose 2> /dev/null))"
+      CXXFLAGS += -Xcompiler="$(wordlist 2,1024,$(shell CC -craype-verbose 2> /dev/null))"
   else ifeq ($(USE_MPI),FALSE)
       CFLAGS += $(wordlist 2,1024,$(shell cc -craype-verbose 2> /dev/null))
       CXXFLAGS += $(wordlist 2,1024,$(shell CC -craype-verbose 2> /dev/null))

--- a/Tools/GNUMake/sites/Make.nersc
+++ b/Tools/GNUMake/sites/Make.nersc
@@ -25,19 +25,15 @@ ifeq ($(which_computer),$(filter $(which_computer),perlmutter))
   endif
 
   ifdef NPE_VERSION
-    WRAP_C_FLAGS = $(wordlist 2,1024,$(shell mpicc -show 2> /dev/null))
-    WRAP_CXX_FLAGS = $(wordlist 2,1024,$(shell mpicc -show 2> /dev/null))
-    WRAP_FTN_FLAGS = $(wordlist 2,1024,$(shell mpifort -show 2> /dev/null))
-
-    WRAP_C_FILTERED = $(filter-out -Wl%, $(WRAP_C_FLAGS))
-    WRAP_CXX_FILTERED = $(filter-out -Wl%, $(WRAP_CXX_FLAGS))
-
+    NPE_CFLAGS   = $(filter-out -Wl%, $(wordlist 2,1024,$(shell mpicc -show 2> /dev/null))))
+    NPE_CXXFLAGS = $(filter-out -Wl%, $(wordlist 2,1024,$(shell mpicxx -show 2> /dev/null)))
+    NPE_FTNFLAGS = $(wordlist 2,1024,$(shell mpifort -show 2> /dev/null))
   endif
 
   ifeq ($(USE_CUDA),TRUE)
     ifdef NPE_VERSION
-      CFLAGS += -Xcompiler="$(WRAP_C_FILTERED)"
-      CXXFLAGS += -Xcompiler="$(WRAP_CXX_FILTERED)"
+      CFLAGS += -Xcompiler="$(NPE_CFLAGS)"
+      CXXFLAGS += -Xcompiler="$(NPE_CXXFLAGS)"
     else
       CFLAGS += -Xcompiler="$(wordlist 2,1024,$(shell cc -craype-verbose 2> /dev/null))"
       CXXFLAGS += -Xcompiler="$(wordlist 2,1024,$(shell CC -craype-verbose 2> /dev/null))"

--- a/Tools/GNUMake/sites/Make.nersc
+++ b/Tools/GNUMake/sites/Make.nersc
@@ -24,16 +24,10 @@ ifeq ($(which_computer),$(filter $(which_computer),perlmutter))
   endif
   endif
 
-  ifdef NPE_VERSION
-    NPE_CFLAGS   = $(filter-out -Wl%, $(wordlist 2,1024,$(shell mpicc -show 2> /dev/null))))
-    NPE_CXXFLAGS = $(filter-out -Wl%, $(wordlist 2,1024,$(shell mpicxx -show 2> /dev/null)))
-    NPE_FTNFLAGS = $(wordlist 2,1024,$(shell mpifort -show 2> /dev/null))
-  endif
-
   ifeq ($(USE_CUDA),TRUE)
     ifdef NPE_VERSION
-      CFLAGS += -Xcompiler="$(NPE_CFLAGS)"
-      CXXFLAGS += -Xcompiler="$(NPE_CXXFLAGS)"
+      CFLAGS += -Xcompiler="$(filter-out -Wl%, $(wordlist 2,1024,$(shell mpicc -show 2> /dev/null))))"
+      CXXFLAGS += -Xcompiler="$(filter-out -Wl%, $(wordlist 2,1024,$(shell mpicxx -show 2> /dev/null)))"
     else
       CFLAGS += -Xcompiler="$(wordlist 2,1024,$(shell cc -craype-verbose 2> /dev/null))"
       CXXFLAGS += -Xcompiler="$(wordlist 2,1024,$(shell CC -craype-verbose 2> /dev/null))"

--- a/Tools/GNUMake/sites/Make.nersc
+++ b/Tools/GNUMake/sites/Make.nersc
@@ -26,7 +26,7 @@ ifeq ($(which_computer),$(filter $(which_computer),perlmutter))
 
   ifeq ($(USE_CUDA),TRUE)
     ifdef NPE_VERSION
-      CFLAGS += -Xcompiler="$(filter-out -Wl%, $(wordlist 2,1024,$(shell mpicc -show 2> /dev/null))))"
+      CFLAGS += -Xcompiler="$(filter-out -Wl%, $(wordlist 2,1024,$(shell mpicc -show 2> /dev/null)))"
       CXXFLAGS += -Xcompiler="$(filter-out -Wl%, $(wordlist 2,1024,$(shell mpicxx -show 2> /dev/null)))"
     else
       CFLAGS += -Xcompiler="$(wordlist 2,1024,$(shell cc -craype-verbose 2> /dev/null))"

--- a/Tools/GNUMake/sites/Make.nersc
+++ b/Tools/GNUMake/sites/Make.nersc
@@ -24,12 +24,27 @@ ifeq ($(which_computer),$(filter $(which_computer),perlmutter))
   endif
   endif
 
+  ifdef NPE_VERSION
+    WRAP_C_FLAGS = $(wordlist 2,1024,$(shell mpicc -show 2> /dev/null))
+    WRAP_CXX_FLAGS = $(wordlist 2,1024,$(shell mpicc -show 2> /dev/null))
+    WRAP_FTN_FLAGS = $(wordlist 2,1024,$(shell mpifort -show 2> /dev/null))
+
+    WRAP_C_FILTERED = $(filter-out -Wl%, $(WRAP_C_FLAGS))
+    WRAP_CXX_FILTERED = $(filter-out -Wl%, $(WRAP_CXX_FLAGS))
+
+  endif
+
   ifeq ($(USE_CUDA),TRUE)
+    ifdef NPE_VERSION
+      CFLAGS += -Xcompiler="$(WRAP_C_FILTERED)"
+      CXXFLAGS += -Xcompiler="$(WRAP_CXX_FILTERED)"
+    else
       CFLAGS += -Xcompiler="$(wordlist 2,1024,$(shell cc -craype-verbose 2> /dev/null))"
       CXXFLAGS += -Xcompiler="$(wordlist 2,1024,$(shell CC -craype-verbose 2> /dev/null))"
+    endif
   else ifeq ($(USE_MPI),FALSE)
-      CFLAGS += $(wordlist 2,1024,$(shell cc -craype-verbose 2> /dev/null))
-      CXXFLAGS += $(wordlist 2,1024,$(shell CC -craype-verbose 2> /dev/null))
+    CFLAGS += $(wordlist 2,1024,$(shell cc -craype-verbose 2> /dev/null))
+    CXXFLAGS += $(wordlist 2,1024,$(shell CC -craype-verbose 2> /dev/null))
   endif
 
   ifeq ($(USE_MPI),TRUE)
@@ -41,7 +56,9 @@ ifeq ($(which_computer),$(filter $(which_computer),perlmutter))
       LIBRARIES += -lmpichf90
     endif
 
-    includes += $(shell CC --cray-print-opts=cflags)
+    ifndef NPE_VERSION
+      includes += $(shell CC --cray-print-opts=cflags)
+    endif
   endif
 
   ifeq ($(USE_CUDA),TRUE)
@@ -51,11 +68,23 @@ ifeq ($(which_computer),$(filter $(which_computer),perlmutter))
       includes += $(CRAY_CUDATOOLKIT_INCLUDE_OPTS)
     endif
 
+    ifdef NPE_VERSION
+      includes += $(CRAY_CUDATOOLKIT_INCLUDE_OPTS)
+    endif
+
     comm := ,
     ifneq ($(BL_NO_FORT),TRUE)
+      ifdef NPE_VERSION
+        LIBRARIES += $(subst -Wl$(comm),-Xlinker=,$(wordlist 2,1024,$(shell mpifort -show)))
+      else
         LIBRARIES += $(subst -Wl$(comm),-Xlinker=,$(shell ftn --cray-print-opts=libs))
+      endif
     else
+      ifdef NPE_VERSION
+        LIBRARIES += $(subst -Wl$(comm),-Xlinker=,$(wordlist 2,1024,$(shell mpicxx -show)))
+      else
         LIBRARIES += $(subst -Wl$(comm),-Xlinker=,$(shell CC --cray-print-opts=libs))
+      endif
     endif
 
     ifneq ($(CUDA_ROOT),)


### PR DESCRIPTION
## Summary

Adds NERSC's programming environment prototype on Perlmutter to the make system.

NPE is experimental at this time.

## Additional background

I'm using it to compile with a more up-to-date MPICH version. Makes sense to add it to the repo for future analyses and others to use, if interested.

To use:
```
module use /global/cfs/cdirs/nstaff/cookbg/pe/modulefiles
module load npe
module load mpich
module unload cray-libsci darshan
```

Tested compiling in the GNU environment with CUDA.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
