### PR TITLE
CMake: FindDependency CUDAToolkit

### DIFF
--- a/Tools/CMake/AMReXConfig.cmake.in
+++ b/Tools/CMake/AMReXConfig.cmake.in
@@ -223,10 +223,12 @@ endif ()
 # CUDA
 #
 # AMReX 21.06+ supports CUDA_ARCHITECTURES
-if(CMAKE_VERSION VERSION_LESS 3.20)
-   if (@AMReX_CUDA@)
-      include(AMReX_SetupCUDA)
-   endif ()
+if (@AMReX_CUDA@)
+    if (CMAKE_VERSION VERSION_LESS 3.20)
+        include(AMReX_SetupCUDA)
+    else ()
+        find_dependency(CUDAToolkit REQUIRED)
+    endif ()
 endif ()
 
 include( "${CMAKE_CURRENT_LIST_DIR}/AMReXTargets.cmake" )


### PR DESCRIPTION
## Summary

If we install AMReX with CUDA support using a modern CMake, we need to repopulate targets such as `CUDA::curand` from `find_dependency` for downstream.
Downstream users find us via `find_package` and that target link dependency showed up to be unpopulated in MFIX.

## Additional background

cc @jmusser304 

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
