### PR TITLE
Explicitly invoke python3

### DIFF
--- a/Tools/Backtrace/parse_bt.py
+++ b/Tools/Backtrace/parse_bt.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 import re

--- a/Tools/C_scripts/describe_sources.py
+++ b/Tools/C_scripts/describe_sources.py
@@ -1,10 +1,6 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
-
-if sys.version_info < (2, 7):
-    sys.exit("ERROR: need python 2.7 or later for dep.py")
-
 import argparse
 import os
 import subprocess

--- a/Tools/C_scripts/gatherbuildtime.py
+++ b/Tools/C_scripts/gatherbuildtime.py
@@ -1,10 +1,6 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
-from __future__ import print_function
 import sys, os, glob, operator, time
-
-if sys.version_info < (2, 7):
-    sys.exit("ERROR: need python 2.7 or later for dep.py")
 
 if __name__ == "__main__":
     dt = float(sys.argv[3])-float(sys.argv[2])

--- a/Tools/CompileTesting/compiletesting.py
+++ b/Tools/CompileTesting/compiletesting.py
@@ -1,6 +1,5 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
-from __future__ import print_function
 import sys
 import os
 import shlex
@@ -148,4 +147,3 @@ def run(command, outfile=None):
 
 if __name__ == "__main__":
     compiletesting(sys.argv[1:])
-

--- a/Tools/F_scripts/dep.py
+++ b/Tools/F_scripts/dep.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # automatically generate Makefile dependencies for Fortran 90 source.
 #
@@ -20,18 +20,7 @@
 #      (e.g. iso_c_binding).  Add any system-provided modules to the
 #      `IGNORES` list below
 
-from __future__ import print_function
-
 import sys
-
-if sys.version_info < (2, 7):
-    sys.exit("ERROR: need python 2.7 or later for dep.py")
-
-if sys.version[0] == "2":
-    reload(sys)
-    sys.setdefaultencoding('latin-1')
-
-
 import io
 import re
 import os

--- a/Tools/F_scripts/fcheck.py
+++ b/Tools/F_scripts/fcheck.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # a simple routine to parse Fortran files and make sure that things are
 # declared double precision, and constants are of the form 1.0_dp_t or
@@ -122,9 +122,3 @@ for ext in extensions:
 
         if (badFile == 1):
             print " "
-
-
-
-
-
-

--- a/Tools/F_scripts/find_files_vpath.py
+++ b/Tools/F_scripts/find_files_vpath.py
@@ -1,11 +1,9 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 Take a vpath and a list of files and find where in the first vpath the
 first occurrence of the file.
 """
-
-from __future__ import print_function
 
 import sys
 import os

--- a/Tools/F_scripts/findparams.py
+++ b/Tools/F_scripts/findparams.py
@@ -1,6 +1,4 @@
-#!/usr/bin/env python
-
-from __future__ import print_function
+#!/usr/bin/env python3
 
 import sys
 import os

--- a/Tools/F_scripts/makebuildinfo.py
+++ b/Tools/F_scripts/makebuildinfo.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # a simple script that writes the build_info.f90 file that is used
 # to store information for the job_info file that we store in plotfiles.

--- a/Tools/F_scripts/write_probin.py
+++ b/Tools/F_scripts/write_probin.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """This routine parses plain-text parameter files that list runtime
 parameters for use in our codes.  The general format of a parameter
@@ -23,8 +23,6 @@ initialize the parameters, setup a namelist, and allow for
 commandline overriding of their defaults.
 
 """
-
-from __future__ import print_function
 
 import os
 import sys

--- a/Tools/GNUMake/Make.defs
+++ b/Tools/GNUMake/Make.defs
@@ -1,8 +1,3 @@
-# Check python version
-my_python_version := $(word 2, $(shell python --version 2>&1))
-ifneq ($(firstword $(sort 2.7 $(my_python_version))), 2.7)
-  $(error Python >= 2.7 required! Your version is $(my_python_version))
-endif
 
 ifneq (,$(findstring ~,$(AMREX_HOME)))
   $(warning *** AMREX_HOME string constains ~ and make will not like it. So it is replaced.)

--- a/Tools/Postprocessing/python/column_depth.py
+++ b/Tools/Postprocessing/python/column_depth.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import sys
 import numpy
 

--- a/Tools/Postprocessing/python/conv_slopes.py
+++ b/Tools/Postprocessing/python/conv_slopes.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import sys
 import os
 import commands

--- a/Tools/Postprocessing/python/dumpparthistory.py
+++ b/Tools/Postprocessing/python/dumpparthistory.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # a simple routine to parse particle files and dump out the particle
 # histories into separate files (1 file per particle) so that they can
@@ -96,8 +96,3 @@ if __name__== "__main__":
         sys.exit(2)
 
     main(sys.argv[1:])
-
-
-
-
-

--- a/Tools/Postprocessing/python/test_helmeos.py
+++ b/Tools/Postprocessing/python/test_helmeos.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # a script showing how to use the helmeos module
 # it reads T, rho, X data from a sample data file, calculates abar and zbar

--- a/Tools/Postprocessing/python/test_parseparticles.py
+++ b/Tools/Postprocessing/python/test_parseparticles.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # simple script showing how to make plots of particles using the parseparticles
 # module
@@ -92,4 +92,3 @@ if __name__ == "__main__":
 
 # this is for profiling
 #    cProfile.run("main(sys.argv[1:])","profile.tmp2")
-

--- a/Tools/Py_util/plotsinglevar.py
+++ b/Tools/Py_util/plotsinglevar.py
@@ -1,10 +1,8 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # a simple script to plot 2-d or 3-d BoxLib data using the matplotlib
 # library
 #
-
-from __future__ import print_function
 
 import matplotlib
 matplotlib.use('agg')

--- a/Tools/Release/ppCleanup.py
+++ b/Tools/Release/ppCleanup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os
 import shutil

--- a/Tools/Release/ppCleanupDir.py
+++ b/Tools/Release/ppCleanupDir.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os
 import shutil

--- a/Tools/Release/release.py
+++ b/Tools/Release/release.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os
 import shutil

--- a/Tools/libamrex/configure.py
+++ b/Tools/libamrex/configure.py
@@ -1,12 +1,6 @@
-#!/usr/bin/env python
-
-from __future__ import print_function
+#!/usr/bin/env python3
 
 import sys
-
-if sys.version_info < (2, 7):
-    sys.exit("ERROR: need python 2.7 or later for configure.py")
-
 import argparse
 
 def configure(argv):

--- a/Tools/libamrex/mkconfig.py
+++ b/Tools/libamrex/mkconfig.py
@@ -1,12 +1,6 @@
-#!/usr/bin/env python
-
-from __future__ import print_function
+#!/usr/bin/env python3
 
 import sys, re
-
-if sys.version_info < (2, 7):
-    sys.exit("ERROR: need python 2.7 or later for mkconfig.py")
-
 import argparse
 
 def doit(defines, undefines, comp, allow_diff_comp):

--- a/Tools/libamrex/mkpkgconfig.py
+++ b/Tools/libamrex/mkpkgconfig.py
@@ -1,12 +1,6 @@
-#!/usr/bin/env python
-
-from __future__ import print_function
+#!/usr/bin/env python3
 
 import sys
-
-if sys.version_info < (2, 7):
-    sys.exit("ERROR: need python 2.7 or later for mkpkgconfig.py")
-
 import argparse
 
 def doit(prefix, version, cflags, libs, libpriv, fflags):

--- a/Tools/libamrex/mkversionheader.py
+++ b/Tools/libamrex/mkversionheader.py
@@ -1,12 +1,6 @@
-#!/usr/bin/env python
-
-from __future__ import print_function
+#!/usr/bin/env python3
 
 import sys, re
-
-if sys.version_info < (2, 7):
-    sys.exit("ERROR: need python 2.7 or later for mkversionheader.py")
-
 import argparse
 
 def doit(code, defines):

--- a/Tools/typechecker/typechecker.py
+++ b/Tools/typechecker/typechecker.py
@@ -1,6 +1,4 @@
-#!/usr/bin/env python
-
-from __future__ import print_function
+#!/usr/bin/env python3
 
 import os
 import sys


### PR DESCRIPTION
According to PEP 394, a python distributor may choose to not provide the
python command.  In fact, that's what recent versions of macOS do.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
