### PR TITLE
Carry over fix for ngbxy.smallEnd typo

### DIFF
--- a/Tests/Amr/Advection_AmrCore/Source/DefineVelocity.cpp
+++ b/Tests/Amr/Advection_AmrCore/Source/DefineVelocity.cpp
@@ -39,7 +39,7 @@ AmrCoreAdv::DefineVelocityAtLevel (int lev, Real time)
                                                                       facevel[lev][2].array(mfi)) };
 
             const Box& psibox = Box(IntVect(AMREX_D_DECL(std::min(ngbxx.smallEnd(0)-1, ngbxy.smallEnd(0)-1),
-                                                         std::min(ngbxx.smallEnd(1)-1, ngbxy.smallEnd(0)-1),
+                                                         std::min(ngbxx.smallEnd(1)-1, ngbxy.smallEnd(1)-1),
                                                          0)),
                                     IntVect(AMREX_D_DECL(std::max(ngbxx.bigEnd(0),   ngbxy.bigEnd(0)+1),
                                                          std::max(ngbxx.bigEnd(1)+1, ngbxy.bigEnd(1)),


### PR DESCRIPTION
## Summary
I think this a typo that got correct in other places but didn't get fixed here. 

## Additional background

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [x] changes answers in the test suite to more than roundoff level  (maybe?)
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
