### PR TITLE
SENSEI 4.0: Fix Build for Particles

### DIFF
--- a/Src/Extern/SENSEI/AMReX_AmrMeshParticleInSituBridge.H
+++ b/Src/Extern/SENSEI/AMReX_AmrMeshParticleInSituBridge.H
@@ -86,7 +86,7 @@ int AmrMeshParticleInSituBridge::update(
 
     data_adaptor->SetDataTime(time);
     data_adaptor->SetDataTimeStep(step);
-    ret = analysis_adaptor->Execute(data_adaptor) ? 0 : -1;
+    ret = analysis_adaptor->Execute(data_adaptor, nullptr) ? 0 : -1;
     data_adaptor->ReleaseData();
     data_adaptor->Delete();
 


### PR DESCRIPTION
## Summary

This part causes a compile error now in WarpX.

cc  @burlen @kwryankrattiger

## Additional background

X-ref: Blocks WarpX 22.07 release https://github.com/ECP-WarpX/WarpX/pull/3211

Follow-up to:
- #2785 
- #2834

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
