### PR TITLE
add option AMREX_ALLOW_USER_OMP

### DIFF
--- a/Src/Base/AMReX_OpenMP.H
+++ b/Src/Base/AMReX_OpenMP.H
@@ -2,7 +2,7 @@
 #define AMREX_OPENMP_H_
 #include <AMReX_Config.H>
 
-#ifdef AMREX_USE_OMP
+#if defined(AMREX_USE_OMP) || defined(AMREX_ALLOW_USER_OMP)
 #include <omp.h>
 
 namespace amrex {

--- a/Tools/CMake/AMReX_Config.H.in
+++ b/Tools/CMake/AMReX_Config.H.in
@@ -17,6 +17,7 @@
 #cmakedefine BL_USE_MPI
 #cmakedefine AMREX_MPI_THREAD_MULTIPLE
 #cmakedefine AMREX_USE_OMP
+#cmakedefine AMREX_ALLOW_USER_OMP
 #cmakedefine BL_USE_OMP
 #cmakedefine AMREX_USE_DPCPP
 #cmakedefine AMREX_USE_ONEDPL


### PR DESCRIPTION
## Summary
Allows the application code to use multiple OpenMP threads to launch AMReX GPU kernels.

## Additional background
This is necessary for Quokka's implementation of communication-computation overlapping: Quokka creates an OpenMP parallel region with 2 threads. Thread 0 is used to call the FillPatch utility routines that block on completion of MPI communication. Thread 1 is used to launch kernels to perform updates on the 'inner' box of each FAB which does not need ghost cells to be updated (i.e., `iter.validbox().ngrow(-nghost)`). After both of these operations complete, control returns to the main thread, which launches kernels to update the 'outer' boxes of each FAB.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
