### PR TITLE
New EB optimization parameter: eb2.num_coarsen_opt

### DIFF
--- a/Src/Base/AMReX_Box.cpp
+++ b/Src/Base/AMReX_Box.cpp
@@ -126,7 +126,7 @@ AllGatherBoxes (Vector<Box>& bxs, int n_extra_reserve)
     if (count_tot == 0) return;
 
     if (count_tot > static_cast<Long>(std::numeric_limits<int>::max())) {
-        amrex::Abort("AllGatherBoxes: not many boxes");
+        amrex::Abort("AllGatherBoxes: too many boxes");
     }
 
     Vector<Box> recv_buffer;
@@ -161,7 +161,7 @@ AllGatherBoxes (Vector<Box>& bxs, int n_extra_reserve)
     if (count_tot == 0) return;
 
     if (count_tot > static_cast<Long>(std::numeric_limits<int>::max())) {
-        amrex::Abort("AllGatherBoxes: not many boxes");
+        amrex::Abort("AllGatherBoxes: too many boxes");
     }
 
     Vector<Box> recv_buffer;

--- a/Src/EB/AMReX_EB2.H
+++ b/Src/EB/AMReX_EB2.H
@@ -66,7 +66,7 @@ public:
     IndexSpaceImp (const G& gshop, const Geometry& geom,
                    int required_coarsening_level, int max_coarsening_level,
                    int ngrow, bool build_coarse_level_by_coarsening,
-                   bool extend_domain_face);
+                   bool extend_domain_face, int num_coarsen_opt);
 
     IndexSpaceImp (IndexSpaceImp<G> const&) = delete;
     IndexSpaceImp (IndexSpaceImp<G> &&) = delete;
@@ -95,27 +95,32 @@ private:
 #include <AMReX_EB2_IndexSpaceI.H>
 
 bool ExtendDomainFace ();
+int NumCoarsenOpt ();
 
 template <typename G>
 void
 Build (const G& gshop, const Geometry& geom,
        int required_coarsening_level, int max_coarsening_level,
        int ngrow = 4, bool build_coarse_level_by_coarsening = true,
-       bool extend_domain_face = ExtendDomainFace())
+       bool extend_domain_face = ExtendDomainFace(),
+       int num_coarsen_opt = NumCoarsenOpt())
 {
     BL_PROFILE("EB2::Initialize()");
     IndexSpace::push(new IndexSpaceImp<G>(gshop, geom,
                                           required_coarsening_level,
                                           max_coarsening_level,
                                           ngrow, build_coarse_level_by_coarsening,
-                                          extend_domain_face));
+                                          extend_domain_face,
+                                          num_coarsen_opt));
 }
 
 void Build (const Geometry& geom,
             int required_coarsening_level,
             int max_coarsening_level,
             int ngrow = 4,
-            bool build_coarse_level_by_coarsening = true);
+            bool build_coarse_level_by_coarsening = true,
+            bool extend_domain_face = ExtendDomainFace(),
+            int num_coarsen_opt = NumCoarsenOpt());
 
 int maxCoarseningLevel (const Geometry& geom);
 int maxCoarseningLevel (IndexSpace const* ebis, const Geometry& geom);

--- a/Src/EB/AMReX_EB2.cpp
+++ b/Src/EB/AMReX_EB2.cpp
@@ -21,12 +21,14 @@ AMREX_EXPORT Vector<std::unique_ptr<IndexSpace> > IndexSpace::m_instance;
 
 AMREX_EXPORT int max_grid_size = 64;
 AMREX_EXPORT bool extend_domain_face = true;
+AMREX_EXPORT int num_coarsen_opt = 0;
 
 void Initialize ()
 {
     ParmParse pp("eb2");
     pp.queryAdd("max_grid_size", max_grid_size);
     pp.queryAdd("extend_domain_face", extend_domain_face);
+    pp.queryAdd("num_coarsen_opt", num_coarsen_opt);
 
     amrex::ExecOnFinalize(Finalize);
 }
@@ -39,6 +41,11 @@ void Finalize ()
 bool ExtendDomainFace ()
 {
     return extend_domain_face;
+}
+
+int NumCoarsenOpt ()
+{
+    return num_coarsen_opt;
 }
 
 void
@@ -74,7 +81,8 @@ const IndexSpace* TopIndexSpaceIfPresent() noexcept {
 
 void
 Build (const Geometry& geom, int required_coarsening_level,
-       int max_coarsening_level, int ngrow, bool build_coarse_level_by_coarsening)
+       int max_coarsening_level, int ngrow, bool build_coarse_level_by_coarsening,
+       bool a_extend_domain_face, int a_num_coarsen_opt)
 {
     ParmParse pp("eb2");
     std::string geom_type;
@@ -85,7 +93,8 @@ Build (const Geometry& geom, int required_coarsening_level,
         EB2::AllRegularIF rif;
         EB2::GeometryShop<EB2::AllRegularIF> gshop(rif);
         EB2::Build(gshop, geom, required_coarsening_level,
-                   max_coarsening_level, ngrow, build_coarse_level_by_coarsening);
+                   max_coarsening_level, ngrow, build_coarse_level_by_coarsening,
+                   a_extend_domain_face, a_num_coarsen_opt);
     }
     else if (geom_type == "box")
     {
@@ -102,7 +111,8 @@ Build (const Geometry& geom, int required_coarsening_level,
 
         EB2::GeometryShop<EB2::BoxIF> gshop(bf);
         EB2::Build(gshop, geom, required_coarsening_level,
-                   max_coarsening_level, ngrow, build_coarse_level_by_coarsening);
+                   max_coarsening_level, ngrow, build_coarse_level_by_coarsening,
+                   a_extend_domain_face, a_num_coarsen_opt);
     }
     else if (geom_type == "cylinder")
     {
@@ -127,7 +137,8 @@ Build (const Geometry& geom, int required_coarsening_level,
 
         EB2::GeometryShop<EB2::CylinderIF> gshop(cf);
         EB2::Build(gshop, geom, required_coarsening_level,
-                   max_coarsening_level, ngrow, build_coarse_level_by_coarsening);
+                   max_coarsening_level, ngrow, build_coarse_level_by_coarsening,
+                   a_extend_domain_face, a_num_coarsen_opt);
     }
     else if (geom_type == "plane")
     {
@@ -141,7 +152,8 @@ Build (const Geometry& geom, int required_coarsening_level,
 
         EB2::GeometryShop<EB2::PlaneIF> gshop(pf);
         EB2::Build(gshop, geom, required_coarsening_level,
-                   max_coarsening_level, ngrow, build_coarse_level_by_coarsening);
+                   max_coarsening_level, ngrow, build_coarse_level_by_coarsening,
+                   a_extend_domain_face, a_num_coarsen_opt);
     }
     else if (geom_type == "sphere")
     {
@@ -158,7 +170,8 @@ Build (const Geometry& geom, int required_coarsening_level,
 
         EB2::GeometryShop<EB2::SphereIF> gshop(sf);
         EB2::Build(gshop, geom, required_coarsening_level,
-                   max_coarsening_level, ngrow, build_coarse_level_by_coarsening);
+                   max_coarsening_level, ngrow, build_coarse_level_by_coarsening,
+                   a_extend_domain_face, a_num_coarsen_opt);
     }
     else if (geom_type == "torus")
     {
@@ -177,7 +190,8 @@ Build (const Geometry& geom, int required_coarsening_level,
 
         EB2::GeometryShop<EB2::TorusIF> gshop(sf);
         EB2::Build(gshop, geom, required_coarsening_level,
-                   max_coarsening_level, ngrow, build_coarse_level_by_coarsening);
+                   max_coarsening_level, ngrow, build_coarse_level_by_coarsening,
+                   a_extend_domain_face, a_num_coarsen_opt);
     }
     else if (geom_type == "parser")
     {
@@ -188,7 +202,8 @@ Build (const Geometry& geom, int required_coarsening_level,
         EB2::ParserIF pif(parser.compile<3>());
         EB2::GeometryShop<EB2::ParserIF,Parser> gshop(pif,parser);
         EB2::Build(gshop, geom, required_coarsening_level,
-                   max_coarsening_level, ngrow, build_coarse_level_by_coarsening);
+                   max_coarsening_level, ngrow, build_coarse_level_by_coarsening,
+                   a_extend_domain_face, a_num_coarsen_opt);
     }
     else if (geom_type == "stl")
     {
@@ -206,7 +221,8 @@ Build (const Geometry& geom, int required_coarsening_level,
                                            geom, required_coarsening_level,
                                            max_coarsening_level, ngrow,
                                            build_coarse_level_by_coarsening,
-                                           extend_domain_face));
+                                           a_extend_domain_face,
+                                           a_num_coarsen_opt));
     }
     else
     {

--- a/Src/EB/AMReX_EB2_IndexSpaceI.H
+++ b/Src/EB/AMReX_EB2_IndexSpaceI.H
@@ -4,7 +4,7 @@ IndexSpaceImp<G>::IndexSpaceImp (const G& gshop, const Geometry& geom,
                                  int required_coarsening_level,
                                  int max_coarsening_level,
                                  int ngrow, bool build_coarse_level_by_coarsening,
-                                 bool extend_domain_face)
+                                 bool extend_domain_face, int num_coarsen_opt)
 {
     // build finest level (i.e., level 0) first
     AMREX_ALWAYS_ASSERT(required_coarsening_level >= 0 && required_coarsening_level <= 30);
@@ -20,7 +20,8 @@ IndexSpaceImp<G>::IndexSpaceImp (const G& gshop, const Geometry& geom,
     m_domain.push_back(geom.Domain());
     m_ngrow.push_back(ngrow_finest);
     m_gslevel.reserve(max_coarsening_level+1);
-    m_gslevel.emplace_back(this, gshop, geom, EB2::max_grid_size, ngrow_finest, extend_domain_face);
+    m_gslevel.emplace_back(this, gshop, geom, EB2::max_grid_size, ngrow_finest, extend_domain_face,
+                           num_coarsen_opt);
 
     for (int ilev = 1; ilev <= max_coarsening_level; ++ilev)
     {
@@ -44,7 +45,8 @@ IndexSpaceImp<G>::IndexSpaceImp (const G& gshop, const Geometry& geom,
                 if (build_coarse_level_by_coarsening) {
                     amrex::Abort("Failed to build required coarse EB level "+std::to_string(ilev));
                 } else {
-                    m_gslevel.emplace_back(this, gshop, cgeom, EB2::max_grid_size, ng, extend_domain_face);
+                    m_gslevel.emplace_back(this, gshop, cgeom, EB2::max_grid_size, ng, extend_domain_face,
+                                           num_coarsen_opt-ilev);
                 }
             } else {
                 break;

--- a/Src/EB/AMReX_EB2_IndexSpace_STL.H
+++ b/Src/EB/AMReX_EB2_IndexSpace_STL.H
@@ -19,7 +19,7 @@ public:
                   const Geometry& geom, int required_coarsening_level,
                   int max_coarsening_level, int ngrow,
                   bool build_coarse_level_by_coarsening,
-                  bool extend_domain_face);
+                  bool extend_domain_face, int num_coarsen_opt);
 
     IndexSpaceSTL (IndexSpaceSTL const&) = delete;
     IndexSpaceSTL (IndexSpaceSTL &&) = delete;

--- a/Src/EB/AMReX_EB2_IndexSpace_STL.cpp
+++ b/Src/EB/AMReX_EB2_IndexSpace_STL.cpp
@@ -7,7 +7,7 @@ IndexSpaceSTL::IndexSpaceSTL (const std::string& stl_file, Real stl_scale,
                               const Geometry& geom, int required_coarsening_level,
                               int max_coarsening_level, int ngrow,
                               bool build_coarse_level_by_coarsening,
-                              bool extend_domain_face)
+                              bool extend_domain_face, int num_coarsen_opt)
 {
     Gpu::LaunchSafeGuard lsg(true); // Always use GPU
 
@@ -29,7 +29,7 @@ IndexSpaceSTL::IndexSpaceSTL (const std::string& stl_file, Real stl_scale,
     m_ngrow.push_back(ngrow_finest);
     m_stllevel.reserve(max_coarsening_level+1);
     m_stllevel.emplace_back(this, stl_tools, geom, EB2::max_grid_size, ngrow_finest,
-                            extend_domain_face);
+                            extend_domain_face, num_coarsen_opt);
 
     for (int ilev = 1; ilev <= max_coarsening_level; ++ilev)
     {
@@ -54,7 +54,7 @@ IndexSpaceSTL::IndexSpaceSTL (const std::string& stl_file, Real stl_scale,
                     amrex::Abort("Failed to build required coarse EB level "+std::to_string(ilev));
                 } else {
                     m_stllevel.emplace_back(this, stl_tools, cgeom, EB2::max_grid_size, ng,
-                                            extend_domain_face);
+                                            extend_domain_face, num_coarsen_opt-ilev);
                 }
             } else {
                 break;

--- a/Src/EB/AMReX_EB2_Level.H
+++ b/Src/EB/AMReX_EB2_Level.H
@@ -98,12 +98,13 @@ class GShopLevel
     : public Level
 {
 public:
-    GShopLevel (IndexSpace const* is, G const& gshop, const Geometry& geom, int max_grid_size, int ngrow, bool extend_domain_face);
+    GShopLevel (IndexSpace const* is, G const& gshop, const Geometry& geom, int max_grid_size,
+                int ngrow, bool extend_domain_face, int num_crse_opt);
     GShopLevel (IndexSpace const* is, int ilev, int max_grid_size, int ngrow,
                 const Geometry& geom, GShopLevel<G>& fineLevel);
     GShopLevel (IndexSpace const* is, const Geometry& geom);
     void define_fine (G const& gshop, const Geometry& geom,
-                      int max_grid_size, int ngrow, bool extend_domain_face);
+                      int max_grid_size, int ngrow, bool extend_domain_face, int num_crse_opt);
 };
 
 template <typename G>
@@ -113,7 +114,7 @@ GShopLevel<G>::GShopLevel (IndexSpace const* is, const Geometry& geom)
 
 template <typename G>
 GShopLevel<G>::GShopLevel (IndexSpace const* is, G const& gshop, const Geometry& geom,
-                           int max_grid_size, int ngrow, bool extend_domain_face)
+                           int max_grid_size, int ngrow, bool extend_domain_face, int num_crse_opt)
     : Level(is, geom)
 {
     if (std::is_same<typename G::FunctionType, AllRegularIF>::value) {
@@ -122,13 +123,13 @@ GShopLevel<G>::GShopLevel (IndexSpace const* is, G const& gshop, const Geometry&
         return;
     }
 
-    define_fine(gshop, geom, max_grid_size, ngrow, extend_domain_face);
+    define_fine(gshop, geom, max_grid_size, ngrow, extend_domain_face, num_crse_opt);
 }
 
 template <typename G>
 void
 GShopLevel<G>::define_fine (G const& gshop, const Geometry& geom,
-                            int max_grid_size, int ngrow, bool extend_domain_face)
+                            int max_grid_size, int ngrow, bool extend_domain_face, int num_crse_opt)
 {
     if (amrex::Verbose() > 0 && extend_domain_face == false) {
         amrex::Print() << "AMReX WARNING: extend_domain_face=false is not recommended!\n";
@@ -166,57 +167,83 @@ GShopLevel<G>::define_fine (G const& gshop, const Geometry& geom,
     Box bounding_box = (extend_domain_face) ? domain : domain_grown;
     bounding_box.surroundingNodes();
 
-    BoxList bl(domain);
-    bl.maxSize(max_grid_size);
+    BoxList cut_boxes;
+    BoxList covered_boxes;
+
+    const int nprocs = ParallelDescriptor::NProcs();
+    const int iproc = ParallelDescriptor::MyProc();
+
+    num_crse_opt = std::max(0,std::min(8,num_crse_opt));
+    for (int clev = num_crse_opt; clev >= 0; --clev) {
+        IntVect crse_ratio(1 << clev);
+        if (domain.coarsenable(crse_ratio)) {
+            Box const& crse_bounding_box = amrex::coarsen(bounding_box, crse_ratio);
+            Geometry const& crse_geom = amrex::coarsen(geom, crse_ratio);
+            BoxList test_boxes;
+            if (cut_boxes.isEmpty()) {
+                covered_boxes.clear();
+                test_boxes = BoxList(crse_geom.Domain());
+                test_boxes.maxSize(max_grid_size);
+            } else {
+                test_boxes.swap(cut_boxes);
+                test_boxes.coarsen(crse_ratio);
+                test_boxes.maxSize(max_grid_size);
+            }
+
+            const Long nboxes = test_boxes.size();
+            const auto& boxes = test_boxes.data();
+            for (Long i = iproc; i < nboxes; i += nprocs) {
+                const Box& vbx = boxes[i];
+                const Box& gbx = amrex::surroundingNodes(amrex::grow(vbx,1));
+                auto box_type = gshop.getBoxType(gbx&crse_bounding_box,crse_geom,RunOn::Gpu);
+                if (box_type == gshop.allcovered) {
+                    covered_boxes.push_back(amrex::refine(vbx, crse_ratio));
+                } else if (box_type == gshop.mixedcells) {
+                    cut_boxes.push_back(amrex::refine(vbx, crse_ratio));
+                }
+            }
+
+            amrex::AllGatherBoxes(cut_boxes.data());
+            amrex::AllGatherBoxes(covered_boxes.data());
+        }
+    }
+
     if (m_ngrow != 0) {
-        const IntVect& domlo = domain.smallEnd();
-        const IntVect& domhi = domain.bigEnd();
-        for (auto& b : bl) {
-            for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-                if (m_ngrow[idim] != 0) {
-                    if (b.smallEnd(idim) == domlo[idim]) {
-                        b.growLo(idim,m_ngrow[idim]);
-                    }
-                    if (b.bigEnd(idim) == domhi[idim]) {
-                        b.growHi(idim,m_ngrow[idim]);
+        auto grow_at_domain_boundary = [&] (BoxList& bl)
+        {
+            const IntVect& domlo = domain.smallEnd();
+            const IntVect& domhi = domain.bigEnd();
+            for (auto& b : bl) {
+                for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+                    if (m_ngrow[idim] != 0) {
+                        if (b.smallEnd(idim) == domlo[idim]) {
+                            b.growLo(idim,m_ngrow[idim]);
+                        }
+                        if (b.bigEnd(idim) == domhi[idim]) {
+                            b.growHi(idim,m_ngrow[idim]);
+                        }
                     }
                 }
             }
-        }
+        };
+        grow_at_domain_boundary(covered_boxes);
+        grow_at_domain_boundary(cut_boxes);
     }
 
-    m_grids.define(std::move(bl));
-    m_dmap.define(m_grids);
-
-    Vector<Box> cut_boxes;
-    Vector<Box> covered_boxes;
-
-    for (MFIter mfi(m_grids, m_dmap); mfi.isValid(); ++mfi)
-    {
-        const Box& vbx = mfi.validbox();
-        const Box& gbx = amrex::surroundingNodes(amrex::grow(vbx,1));
-        int box_type = gshop.getBoxType(gbx & bounding_box, geom, RunOn::Gpu);
-        if (box_type == gshop.allcovered) {
-            covered_boxes.push_back(vbx);
-        } else if (box_type == gshop.mixedcells) {
-            cut_boxes.push_back(vbx);
-        }
-    }
-
-    amrex::AllGatherBoxes(cut_boxes);
-    amrex::AllGatherBoxes(covered_boxes);
-
-    if ( cut_boxes.empty() &&
-        !covered_boxes.empty())
+    if ( cut_boxes.isEmpty() &&
+        !covered_boxes.isEmpty())
     {
         amrex::Abort("AMReX_EB2_Level.H: Domain is completely covered");
     }
 
-    if (!covered_boxes.empty()) {
-        m_covered_grids = BoxArray(BoxList(std::move(covered_boxes)));
+    if (!covered_boxes.isEmpty()) {
+        if (num_crse_opt > 2) { // don't want the box too big
+            covered_boxes.maxSize(max_grid_size*4);
+        }
+        m_covered_grids = BoxArray(std::move(covered_boxes));
     }
 
-    if (cut_boxes.empty()) {
+    if (cut_boxes.isEmpty()) {
         m_grids = BoxArray();
         m_dmap = DistributionMapping();
         m_allregular = true;
@@ -224,7 +251,7 @@ GShopLevel<G>::define_fine (G const& gshop, const Geometry& geom,
         return;
     }
 
-    m_grids = BoxArray(BoxList(std::move(cut_boxes)));
+    m_grids = BoxArray(std::move(cut_boxes));
     m_dmap = DistributionMapping(m_grids);
 
     m_mgf.define(m_grids, m_dmap);

--- a/Src/EB/AMReX_EB2_Level.H
+++ b/Src/EB/AMReX_EB2_Level.H
@@ -204,9 +204,10 @@ GShopLevel<G>::define_fine (G const& gshop, const Geometry& geom,
             }
 
             amrex::AllGatherBoxes(cut_boxes.data());
-            amrex::AllGatherBoxes(covered_boxes.data());
         }
     }
+
+    amrex::AllGatherBoxes(covered_boxes.data());
 
     if (m_ngrow != 0) {
         auto grow_at_domain_boundary = [&] (BoxList& bl)

--- a/Src/EB/AMReX_EB2_Level_STL.H
+++ b/Src/EB/AMReX_EB2_Level_STL.H
@@ -13,7 +13,7 @@ class STLLevel
 public:
 
     STLLevel (IndexSpace const* is, STLtools const& stl_tools, const Geometry& geom,
-              int max_grid_size, int ngrow, bool extend_domain_face);
+              int max_grid_size, int ngrow, bool extend_domain_face, int num_crse_opt);
 
     STLLevel (IndexSpace const* is, int ilev, int max_grid_size, int ngrow,
               const Geometry& geom, STLLevel& fineLevel);

--- a/Src/EB/AMReX_EB2_Level_STL.cpp
+++ b/Src/EB/AMReX_EB2_Level_STL.cpp
@@ -3,12 +3,12 @@
 namespace amrex { namespace EB2 {
 
 STLLevel::STLLevel (IndexSpace const* is, STLtools const& stl_tools, const Geometry& geom,
-                    int max_grid_size, int ngrow, bool extend_domain_face)
+                    int max_grid_size, int ngrow, bool extend_domain_face, int num_crse_opt)
     : GShopLevel<STLtools>(is, geom)
 {
     BL_PROFILE("EB2::STLLevel()-fine");
 
-    define_fine(stl_tools, geom, max_grid_size, ngrow, extend_domain_face);
+    define_fine(stl_tools, geom, max_grid_size, ngrow, extend_domain_face, num_crse_opt);
 }
 
 STLLevel::STLLevel (IndexSpace const* is, int ilev, int max_grid_size, int ngrow,

--- a/Tests/LinearSolvers/CellEB2/inputs.rt.2d
+++ b/Tests/LinearSolvers/CellEB2/inputs.rt.2d
@@ -11,6 +11,7 @@ max_level = 1
 n_cell = 128
 max_grid_size = 64
 eb2.max_grid_size = 32
+eb2.num_coarsen_opt=3
 
 eb2.geom_type = sphere
 eb2.sphere_center = 0.5  0.5  0.5

--- a/Tests/LinearSolvers/CellEB2/inputs.rt.3d
+++ b/Tests/LinearSolvers/CellEB2/inputs.rt.3d
@@ -11,6 +11,7 @@ max_level = 1
 n_cell = 128
 max_grid_size = 64
 eb2.max_grid_size = 32
+eb2.num_coarsen_opt=3
 
 eb2.geom_type = sphere
 eb2.sphere_center = 0.5  0.5  0.5


### PR DESCRIPTION
At the beginning of EB generation, we chop the entire finest domain into
boxes and find out the type of the boxes.  We then collect the completely
covered boxes and cut boxes into two BoxArrays.  This process can be costly
because of the number of calls to the implicit functions.  In this commit,
we have introduced a new ParmParse parameter, eb2.num_coarsen_opt with a
default value of zero.  If for instance it is set to 3, we start the box
type categorization at a resolution that is coarsened by a factor of 2^3.
For the provisional cut boxes, we refine them by a factor of 2, Then we chop
them into small boxes and categorize the new boxes.  This process is
performed recursively until we are at the original finest resolution.

The users should be aware that, if eb2.num_coaren_opt is too big, this could
produce in erroneous results because evaluating the implicit function on
coarse boxes could miss fine structures in the EB.

Thank Robert Marskar for sharing this algorithm.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
