### PR TITLE
Workaround to bypass issue observed at very large scale with Fujitsu MPI

### DIFF
--- a/Src/AmrCore/AMReX_TagBox.cpp
+++ b/Src/AmrCore/AMReX_TagBox.cpp
@@ -650,6 +650,9 @@ TagBoxArray::collate (Gpu::PinnedVector<IntVect>& TheGlobalCollateSpace) const
     const IntVect* psend = (count > 0) ? TheLocalCollateSpace.data() : nullptr;
     IntVect* precv = TheGlobalCollateSpace.data();
 
+    //Issues have been observed with the following call at very large scale when using
+    //FujitsuMPI. The issue seems to be related to the use of MPI_Datatype. We can
+    //bypasses the issue by exchanging simpler integer arrays.
 #ifndef __FUJITSU
     ParallelDescriptor::Gatherv(psend, count, precv, countvec, offset, IOProcNumber);
 #else
@@ -658,10 +661,9 @@ TagBoxArray::collate (Gpu::PinnedVector<IntVect>& TheGlobalCollateSpace) const
     Long count_int = count * AMREX_SPACEDIM;
     auto countvec_int = std::vector<int>(countvec.size());
     auto offset_int = std::vector<int>(offset.size());
-    std::transform(countvec.begin(), countvec.end(), countvec_int.begin(),
-        [](const auto el){return el*AMREX_SPACEDIM;});
-    std::transform(offset.begin(), offset.end(), offset_int.begin(),
-        [](const auto el){return el*AMREX_SPACEDIM;});
+    const auto mul_funct = [](const auto el){return el*AMREX_SPACEDIM;};
+    std::transform(countvec.begin(), countvec.end(), countvec_int.begin(), mul_funct);
+    std::transform(offset.begin(), offset.end(), offset_int.begin(), mul_funct);
     ParallelDescriptor::Gatherv(
         psend_int, count_int, precv_int, countvec_int, offset_int, IOProcNumber);
 #endif


### PR DESCRIPTION
## Summary

We have observed some MPI issues at very large scale when WarpX is compiled using Fujitsu MPI (i.e., with the Fujitsu compiler). These issues seem to be related to the use of MPI Gatherv with MPI_Datatype. This PR implements a possible workaround, initially proposed by @WeiqunZhang . The idea is that, when WarpX is compiled with the Fujitsu compiler, simpler integer arrays instead of MPI_Datatype are used in the routine where the issue was observed.

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
