### PR TITLE
Add option to derefine to AMRErrorTag

### DIFF
--- a/Src/AmrCore/AMReX_ErrorList.H
+++ b/Src/AmrCore/AMReX_ErrorList.H
@@ -383,6 +383,7 @@ std::ostream& operator << (std::ostream& os, const ErrorList& elst);
     Real m_min_time = std::numeric_limits<Real>::lowest();
     Real m_max_time = std::numeric_limits<Real>::max();
     int m_volume_weighting = 0;
+    int m_derefine = 0;
     RealBox m_realbox;
 
     AMRErrorTagInfo& SetMaxLevel (int max_level) noexcept {
@@ -403,6 +404,10 @@ std::ostream& operator << (std::ostream& os, const ErrorList& elst);
     }
     AMRErrorTagInfo& SetVolumeWeighting (int volume_weighting) noexcept {
       m_volume_weighting = volume_weighting;
+      return *this;
+    }
+    AMRErrorTagInfo& SetDerefine (int derefine) noexcept {
+      m_derefine = derefine;
       return *this;
     }
   };


### PR DESCRIPTION
## Summary

This allows a refinement field to specify *derefinement* (by setting a zone's tagging value to the clear value).

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
