### PR TITLE
Add extra braces in initialization of GpuArray

### DIFF
--- a/Src/Base/AMReX_TableData.H
+++ b/Src/Base/AMReX_TableData.H
@@ -77,8 +77,8 @@ struct Table2D
 {
     T* AMREX_RESTRICT p = nullptr;
     Long jstride = 0;
-    GpuArray<int,2> begin{1,1};
-    GpuArray<int,2> end{0,0};
+    GpuArray<int,2> begin{{1,1}};
+    GpuArray<int,2> end{{0,0}};
 
     AMREX_GPU_HOST_DEVICE
     constexpr Table2D () noexcept {}
@@ -142,8 +142,8 @@ struct Table3D
     T* AMREX_RESTRICT p = nullptr;
     Long jstride = 0;
     Long kstride = 0;
-    GpuArray<int,3> begin{1,1,1};
-    GpuArray<int,3> end{0,0,0};
+    GpuArray<int,3> begin{{1,1,1}};
+    GpuArray<int,3> end{{0,0,0}};
 
     AMREX_GPU_HOST_DEVICE
     constexpr Table3D () noexcept {}
@@ -213,8 +213,8 @@ struct Table4D
     Long jstride = 0;
     Long kstride = 0;
     Long nstride = 0;
-    GpuArray<int,4> begin{1,1,1,1};
-    GpuArray<int,4> end{0,0,0,0};
+    GpuArray<int,4> begin{{1,1,1,1}};
+    GpuArray<int,4> end{{0,0,0,0}};
 
     AMREX_GPU_HOST_DEVICE
     constexpr Table4D () noexcept {}

--- a/Src/LinearSolvers/MLMG/AMReX_MLEBNodeFDLaplacian.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBNodeFDLaplacian.H
@@ -119,7 +119,7 @@ public:
 #endif
 
 private:
-    GpuArray<Real,AMREX_SPACEDIM> m_sigma{AMREX_D_DECL(1_rt,1_rt,1_rt)};
+    GpuArray<Real,AMREX_SPACEDIM> m_sigma{{AMREX_D_DECL(1_rt,1_rt,1_rt)}};
     Real m_s_phi_eb = std::numeric_limits<Real>::lowest();
     Vector<MultiFab> m_phi_eb;
     int m_rz = false;


### PR DESCRIPTION
It should not be needed since C++14.  But some compilers seem to need the
double braces.

## Additional background

https://github.com/AMReX-Codes/IAMR/issues/131

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
