### PR TITLE
EB: Add Fine Levels

### DIFF
--- a/Src/EB/AMReX_EB2.H
+++ b/Src/EB/AMReX_EB2.H
@@ -49,6 +49,7 @@ public:
     virtual const Level& getLevel (const Geometry & geom) const = 0;
     virtual const Geometry& getGeometry (const Box& domain) const = 0;
     virtual const Box& coarsestDomain () const = 0;
+    virtual void addFineLevels (int num_new_fine_levels) = 0;
 
 protected:
     static AMREX_EXPORT Vector<std::unique_ptr<IndexSpace> > m_instance;
@@ -80,16 +81,21 @@ public:
     virtual const Box& coarsestDomain () const final {
         return m_geom.back().Domain();
     }
+    virtual void addFineLevels (int num_new_fine_levels) final;
 
     using F = typename G::FunctionType;
 
 private:
 
+    G m_gshop;
+    bool m_build_coarse_level_by_coarsening;
+    bool m_extend_domain_face;
+    int m_num_coarsen_opt;
+
     Vector<GShopLevel<G> > m_gslevel;
     Vector<Geometry> m_geom;
     Vector<Box> m_domain;
     Vector<int> m_ngrow;
-    std::unique_ptr<F> m_impfunc;
 };
 
 #include <AMReX_EB2_IndexSpaceI.H>
@@ -124,6 +130,8 @@ void Build (const Geometry& geom,
 
 int maxCoarseningLevel (const Geometry& geom);
 int maxCoarseningLevel (IndexSpace const* ebis, const Geometry& geom);
+
+void addFineLevels (int num_new_fine_levels);
 
 }}
 

--- a/Src/EB/AMReX_EB2.cpp
+++ b/Src/EB/AMReX_EB2.cpp
@@ -230,6 +230,15 @@ Build (const Geometry& geom, int required_coarsening_level,
     }
 }
 
+void addFineLevels (int num_new_fine_levels)
+{
+    BL_PROFILE("EB2::addFineLevels()");
+    auto p = const_cast<IndexSpace*>(TopIndexSpace());
+    if (p) {
+        p->addFineLevels(num_new_fine_levels);
+    }
+}
+
 namespace {
 static int comp_max_crse_level (Box cdomain, const Box& domain)
 {

--- a/Src/EB/AMReX_EB2_IndexSpaceI.H
+++ b/Src/EB/AMReX_EB2_IndexSpaceI.H
@@ -5,6 +5,10 @@ IndexSpaceImp<G>::IndexSpaceImp (const G& gshop, const Geometry& geom,
                                  int max_coarsening_level,
                                  int ngrow, bool build_coarse_level_by_coarsening,
                                  bool extend_domain_face, int num_coarsen_opt)
+    : m_gshop(gshop),
+      m_build_coarse_level_by_coarsening(build_coarse_level_by_coarsening),
+      m_extend_domain_face(extend_domain_face),
+      m_num_coarsen_opt(num_coarsen_opt)
 {
     // build finest level (i.e., level 0) first
     AMREX_ALWAYS_ASSERT(required_coarsening_level >= 0 && required_coarsening_level <= 30);
@@ -56,8 +60,6 @@ IndexSpaceImp<G>::IndexSpaceImp (const G& gshop, const Geometry& geom,
         m_domain.push_back(cdomain);
         m_ngrow.push_back(ng);
     }
-
-    m_impfunc = std::make_unique<F>(gshop.GetImpFunc());
 }
 
 
@@ -77,4 +79,30 @@ IndexSpaceImp<G>::getGeometry (const Box& dom) const
     auto it = std::find(std::begin(m_domain), std::end(m_domain), dom);
     int i = std::distance(m_domain.begin(), it);
     return m_geom[i];
+}
+
+template <typename G>
+void
+IndexSpaceImp<G>::addFineLevels (int num_new_fine_levels)
+{
+    if (num_new_fine_levels <= 0) { return; }
+
+    if (m_num_coarsen_opt > 0) {
+        m_num_coarsen_opt += num_new_fine_levels;
+    }
+
+    IndexSpaceImp<G> fine_isp(m_gshop, amrex::refine(m_geom[0], 1<<num_new_fine_levels),
+                              num_new_fine_levels-1, num_new_fine_levels-1,
+                              m_ngrow[0], m_build_coarse_level_by_coarsening,
+                              m_extend_domain_face, m_num_coarsen_opt);
+
+    fine_isp.m_gslevel.reserve(m_domain.size()+num_new_fine_levels);
+    for (int i = 0; i < m_domain.size(); ++i) {
+        fine_isp.m_gslevel.emplace_back(std::move(m_gslevel[i]));
+    }
+    std::swap(fine_isp.m_gslevel, m_gslevel);
+
+    m_geom.insert(m_geom.begin(), fine_isp.m_geom.begin(), fine_isp.m_geom.end());
+    m_domain.insert(m_domain.begin(), fine_isp.m_domain.begin(), fine_isp.m_domain.end());
+    m_ngrow.insert(m_ngrow.begin(), fine_isp.m_ngrow.begin(), fine_isp.m_ngrow.end());
 }

--- a/Src/EB/AMReX_EB2_IndexSpace_STL.H
+++ b/Src/EB/AMReX_EB2_IndexSpace_STL.H
@@ -33,6 +33,7 @@ public:
     virtual const Box& coarsestDomain () const final {
         return m_geom.back().Domain();
     }
+    virtual void addFineLevels (int num_new_fine_levels) final;
 
 private:
 

--- a/Src/EB/AMReX_EB2_IndexSpace_STL.cpp
+++ b/Src/EB/AMReX_EB2_IndexSpace_STL.cpp
@@ -82,4 +82,10 @@ IndexSpaceSTL::getGeometry (const Box& dom) const
     return m_geom[i];
 }
 
+void
+IndexSpaceSTL::addFineLevels (int /*num_new_fine_levels*/)
+{
+    amrex::Abort("IndexSpaceSTL::addFineLevels: todo");
+}
+
 }}

--- a/Tests/EB/CNS/Source/main.cpp
+++ b/Tests/EB/CNS/Source/main.cpp
@@ -53,7 +53,13 @@ int main (int argc, char* argv[])
         AmrLevel::SetEBSupportLevel(EBSupport::full);
         AmrLevel::SetEBMaxGrowCells(CNS::numGrow(),4,2);
 
-        initialize_EB2(amr.Geom(amr.maxLevel()), amr.maxLevel(), amr.maxLevel());
+        int max_eb_level = amr.maxLevel();
+        ParmParse pp("amr");
+        pp.query("max_eb_level", max_eb_level);
+        initialize_EB2(amr.Geom(max_eb_level), max_eb_level, max_eb_level);
+        if (max_eb_level < amr.maxLevel()) {
+            EB2::addFineLevels(amr.maxLevel() - max_eb_level);
+        }
 
         amr.init(strt_time,stop_time);
 


### PR DESCRIPTION
Add a new function EB2::addFineLevels() that can be used to add more fine
levels to the existing EB IndexSpace without changing the coarse levels.
This is useful for restarting with a larger amr.max_level.  The issue is we
build EB at the finest level first and then coarsen it to the coarse levels.
If the restart run has a different finest level, the EB on the coarse levels
could be different without using this new capability.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
