### PR TITLE
Implement GPU MinLoc reduction

### DIFF
--- a/Src/Base/AMReX_GpuAtomic.H
+++ b/Src/Base/AMReX_GpuAtomic.H
@@ -5,6 +5,7 @@
 #include <AMReX_GpuQualifiers.H>
 #include <AMReX_Functional.H>
 #include <AMReX_INT.H>
+#include <AMReX_Tuple.H>
 
 #include <utility>
 
@@ -360,6 +361,36 @@ namespace detail {
     }
 
 ////////////////////////////////////////////////////////////////////////
+//  MinLoc
+////////////////////////////////////////////////////////////////////////
+
+#ifdef AMREX_USE_GPU
+
+    template<class T>
+    AMREX_GPU_DEVICE AMREX_FORCE_INLINE
+    T MinLoc_device (T* const m, T const value) noexcept
+    {
+      return If_device(m, value,
+                       [](T x, T value) { return value; },
+                       [](T x) { return get<0>(value) < get<0>(x); });
+    }
+
+#endif
+
+    template<class T>
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    T MinLoc (T* const m, T const value) noexcept
+    {
+#if AMREX_DEVICE_COMPILE
+        return MinLoc_device(m, value);
+#else
+        auto const old = *m;
+        *m = (get<0>(*m) < get<0>(value)) ? (*m) : value;
+        return old;
+#endif
+    }
+
+////////////////////////////////////////////////////////////////////////
 //  Max
 ////////////////////////////////////////////////////////////////////////
 
@@ -603,6 +634,14 @@ namespace Gpu {
     {
         AMREX_GPU_DEVICE void operator() (T* const dest, T const source) noexcept {
             Gpu::Atomic::Min(dest, source);
+        }
+    };
+
+    template <typename T>
+    struct AtomicMinLoc
+    {
+        AMREX_GPU_DEVICE void operator() (T* const dest, T const source) noexcept {
+            Gpu::Atomic::MinLoc(dest, source);
         }
     };
 

--- a/Src/Base/AMReX_GpuAtomic.H
+++ b/Src/Base/AMReX_GpuAtomic.H
@@ -372,7 +372,7 @@ namespace detail {
     {
       return If_device(m, value,
                        [](T x, T value) { return value; },
-                       [](T x) { return get<0>(value) < get<0>(x); });
+                       [value](T x) { return get<0>(value) < get<0>(x); });
     }
 
 #endif

--- a/Src/Base/AMReX_GpuReduce.H
+++ b/Src/Base/AMReX_GpuReduce.H
@@ -8,6 +8,7 @@
 #include <AMReX_GpuAtomic.H>
 #include <AMReX_GpuUtility.H>
 #include <AMReX_Functional.H>
+#include <AMReX_Tuple.H>
 
 #if !defined(AMREX_USE_CUB) && defined(AMREX_USE_CUDA) && defined(__CUDACC__) && (__CUDACC_VER_MAJOR__ >= 11)
 #define AMREX_USE_CUB 1
@@ -264,6 +265,23 @@ struct warpReduce
     }
 };
 
+template <int warpSize, typename T, typename F>
+struct warpReduceTagged
+{
+    AMREX_GPU_DEVICE AMREX_FORCE_INLINE
+    T operator() (T x) const noexcept
+    {
+        for (int offset = warpSize/2; offset > 0; offset /= 2) {
+            AMREX_HIP_OR_CUDA(T y(__shfl_down(get<0>(x), offset),
+                                  __shfl_down(get<1>(x), offset));,
+                              T y(__shfl_down_sync(0xffffffff, get<0>(x), offset),
+                                  __shfl_down_sync(0xffffffff, get<1>(x), offset)); )
+            x = F()(x,y);
+        }
+        return x;
+    }
+};
+
 template <int warpSize, typename T, typename WARPREDUCE>
 AMREX_GPU_DEVICE AMREX_FORCE_INLINE
 T blockReduce (T x, WARPREDUCE && warp_reduce, T x0)
@@ -447,6 +465,56 @@ void deviceReduceMax_full (T * dest, T source) noexcept
 {
     T aggregate = blockReduceMax<BLOCKDIMX>(source);
     if (threadIdx.x == 0) { Gpu::Atomic::Max(dest, aggregate); }
+}
+
+// Compute the block-wide reduction for thread0
+template <typename T>
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE
+T blockReduceMinLoc (T source) noexcept
+{
+    return Gpu::blockReduce<Gpu::Device::warp_size>
+        (source, Gpu::warpReduce<Gpu::Device::warp_size,T,amrex::LessTagged<T> >(), source);
+}
+
+template <typename T>
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE
+void deviceReduceMinLoc_full (T * dest, T source) noexcept
+{
+    T aggregate = blockReduceMinLoc(source);
+    if (threadIdx.x == 0) { Gpu::Atomic::MinLoc(dest, aggregate); }
+}
+
+// Compute the block-wide reduction for thread0
+template <int BLOCKDIMX, typename T>
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE
+T blockReduceMinLoc (T source) noexcept
+{
+#if defined(AMREX_USE_CUB)
+    typedef cub::BlockReduce<T,BLOCKDIMX> BlockReduce;
+    __shared__ typename BlockReduce::TempStorage temp_storage;
+    // __syncthreads() prior to writing to shared memory is necessary
+    // if this reduction call is occurring multiple times in a kernel,
+    // and since we don't know how many times the user is calling it,
+    // we do it always to be safe.
+    __syncthreads();
+    return BlockReduce(temp_storage).Reduce(source, cub::MinLoc());
+#elif defined(AMREX_USE_HIP)
+    typedef rocprim::block_reduce<T,BLOCKDIMX> BlockReduce;
+    __shared__ typename BlockReduce::storage_type temp_storage;
+    __syncthreads();
+    BlockReduce().reduce(source, source, temp_storage, rocprim::minimum_loc<T>());
+    return source;
+#else
+    return blockReduceMinLoc(source);
+#endif
+}
+
+template <int BLOCKDIMX, typename T>
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE
+void deviceReduceMinLoc_full (T * dest, T source) noexcept
+{
+    T aggregate = blockReduceMinLoc<BLOCKDIMX>(source);
+    if (threadIdx.x == 0) { Gpu::Atomic::MinLoc(dest, aggregate); }
 }
 
 // Compute the block-wide reduction for thread0

--- a/Src/Base/AMReX_Tuple.H
+++ b/Src/Base/AMReX_Tuple.H
@@ -381,6 +381,15 @@ ForwardAsTuple (Ts&&... args) noexcept
     return GpuTuple<Ts&&...>(std::forward<Ts>(args)...);
 }
 
+template <typename T>
+struct LessTagged
+{
+    constexpr T operator() (const T & lhs, const T & rhs) const
+    {
+        return (get<0>(lhs) < get<0>(rhs)) ? lhs : rhs;
+    }
+};
+
 }
 
 #endif /*AMREX_TUPLE_H_*/


### PR DESCRIPTION
## Summary

I am looking for a GPU-enabled `MinLoc` reduction operator. This PR provides a proof-of-concept implementation. I am looking for feedback.

## Additional background

To implement `MinLoc`, I view the quantity that is to be reduced as a tuple of two elements: (1) the quantity that is to be reduced, and (2) and additional arbitrary payload (the location). I add respective functions that handle tuples. For example, the `Less` operation compares the first element of the tuple, whereas a `__shfl_down_sync` needs to shuffle both elements of the tuple.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
