### PR TITLE
A bug related to the data type

### DIFF
--- a/Src/Extern/HYPRE/AMReX_HypreIJIface.H
+++ b/Src/Extern/HYPRE/AMReX_HypreIJIface.H
@@ -93,11 +93,11 @@ private:
     HypreIntType (*m_precondSolvePtr)(
         HYPRE_Solver, HYPRE_ParCSRMatrix, HYPRE_ParVector, HYPRE_ParVector){nullptr};
 
-    HypreIntType (*m_solverSetTolPtr)(HYPRE_Solver, double){nullptr};
-    HypreIntType (*m_solverSetAbsTolPtr)(HYPRE_Solver, double){nullptr};
+    HypreIntType (*m_solverSetTolPtr)(HYPRE_Solver, amrex::Real){nullptr};
+    HypreIntType (*m_solverSetAbsTolPtr)(HYPRE_Solver, amrex::Real){nullptr};
     HypreIntType (*m_solverSetMaxIterPtr)(HYPRE_Solver, HypreIntType){nullptr};
     HypreIntType (*m_solverNumItersPtr)(HYPRE_Solver, HypreIntType*){nullptr};
-    HypreIntType (*m_solverFinalResidualNormPtr)(HYPRE_Solver, double*){nullptr};
+    HypreIntType (*m_solverFinalResidualNormPtr)(HYPRE_Solver, amrex::Real*){nullptr};
 
     HypreIntType m_ilower{0};
     HypreIntType m_iupper{0};

--- a/Src/Extern/HYPRE/AMReX_HypreIJIface.cpp
+++ b/Src/Extern/HYPRE/AMReX_HypreIJIface.cpp
@@ -275,7 +275,7 @@ void HypreIJIface::boomeramg_precond_configure (const std::string& prefix)
 
         if (hpp.pp.contains("bamg_non_galerkin_level_tols")) {
             std::vector<int> levels;
-            std::vector<double> tols;
+            std::vector<amrex::Real> tols;
             hpp.pp.getarr("bamg_non_galerkin_level_levels", levels);
             hpp.pp.getarr("bamg_non_galerkin_level_tols", tols);
 


### PR DESCRIPTION
change data types from double to amrex::Real, and thus we can use single precision data type for the hypre IJ interface

## Summary

## Additional background

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
