### PR TITLE
Fix a new bug introduced in #2858

### DIFF
--- a/Src/Base/AMReX_Any.H
+++ b/Src/Base/AMReX_Any.H
@@ -48,11 +48,25 @@ public:
 
     //! Returns a reference to the contained object.
     template <typename MF>
-    MF& get () { return dynamic_cast<innards<MF>&>(*m_ptr).m_mf; }
+    MF& get () {
+        if (auto p0 = dynamic_cast<innards<MF>*>(m_ptr.get())) {
+            return p0->m_mf;
+        } else {
+            return dynamic_cast<innards<MF&>&>(*m_ptr).m_mf;
+        }
+    }
 
     //! Returns a const reference to the contained object.
     template <typename MF>
-    MF const& get () const { return dynamic_cast<innards<MF> const&>(*m_ptr).m_mf; }
+    MF const& get () const {
+        if (auto p0 = dynamic_cast<innards<MF>*>(m_ptr.get())) {
+            return p0->m_mf;
+        } else if (auto p1 = dynamic_cast<innards<MF&>*>(m_ptr.get())) {
+            return p1->m_mf;
+        } else {
+            return dynamic_cast<innards<MF const&> const&>(*m_ptr).m_mf;
+        }
+    }
 
     template <typename MF>
     bool is () const { return m_ptr->Type() == typeid(MF); }

--- a/Src/LinearSolvers/MLMG/AMReX_MLMG.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLMG.cpp
@@ -1152,7 +1152,7 @@ MLMG::compResidual (const Vector<MultiFab*>& a_res, const Vector<MultiFab*>& a_s
     {
         if (cf_strategy == CFStrategy::ghostnodes || a_sol[alev]->nGrowVect() == ng_sol)
         {
-            sol[alev] = linop.AnyMakeAlias(a_sol[alev]);
+            sol[alev] = linop.AnyMakeAlias(*a_sol[alev]);
             sol_is_alias[alev] = true;
         }
         else


### PR DESCRIPTION
## Summary

We need to take into account that `amrex::Any` stores `MultiFab&` or `MultiFab const&`.

## Additional background

https://github.com/AMReX-Codes/amrex/issues/2900

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
