### PR TITLE
In MLMG::mgFcycle, assert that for EB the linop is cell-centered.

### DIFF
--- a/Src/LinearSolvers/MLMG/AMReX_MLMG.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLMG.cpp
@@ -522,6 +522,10 @@ MLMG::mgFcycle ()
 {
     BL_PROFILE("MLMG::mgFcycle()");
 
+#ifdef AMREX_USE_EB
+    AMREX_ASSERT(linop.isCellCentered());
+#endif
+
     const int amrlev = 0;
     const int mg_bottom_lev = linop.NMGLevels(amrlev) - 1;
     IntVect nghost(0);


### PR DESCRIPTION
## Summary

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
