### PR TITLE
Clear the boundary particle indices container before updating it.

### DIFF
--- a/Src/Particle/AMReX_NeighborParticlesI.H
+++ b/Src/Particle/AMReX_NeighborParticlesI.H
@@ -821,6 +821,11 @@ selectActualNeighbors (CheckPair&& check_pair, int num_cells)
 
     for (int lev = 0; lev < this->numLevels(); ++lev)
     {
+        // clear previous neighbor particle ids
+        for (auto& keyval: m_boundary_particle_ids[lev]) {
+          keyval.second.clear();
+        }
+
         for (MyParIter pti(*this, lev); pti.isValid(); ++pti) {
             PairIndex index(pti.index(), pti.LocalTileIndex());
 


### PR DESCRIPTION
## Summary
Clear the boundary particle indices container before updating it. 

## Additional background
A `for(pti ...)` loop skips empty particle grids because the iterator becomes invalid when there is no particle. If the particles in one grid all move to other grids, the loop won't clear the boundary particle indices. The subsequent routines may assume there are still boundary particles and result in segmentation faults.

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
