### PR TITLE
Add Polaris to GNUMake

### DIFF
--- a/Tools/GNUMake/Make.defs
+++ b/Tools/GNUMake/Make.defs
@@ -757,6 +757,7 @@ else ifeq ($(USE_CUDA),TRUE)
         LINK_WITH_FORTRAN_COMPILER=TRUE
     endif
 
+    $(info Loading $(AMREX_HOME)/Tools/GNUMake/comps/nvcc.mak...)
     include $(AMREX_HOME)/Tools/GNUMake/comps/nvcc.mak
 
     ifeq ($(USE_MPI),TRUE)
@@ -966,17 +967,17 @@ endif
 F90CACHE =
 
 ifeq ($(TP_PROFILING),VTUNE)
-  $(into Loading $(AMREX_HOME)/Tools/GNUMake/tools/Make.vtune
+  $(info Loading $(AMREX_HOME)/Tools/GNUMake/tools/Make.vtune
   include        $(AMREX_HOME)/Tools/GNUMake/tools/Make.vtune
 endif
 
 ifeq ($(TP_PROFILING),CRAYPAT)
-  $(into Loading $(AMREX_HOME)/Tools/GNUMake/tools/Make.craypat
+  $(info Loading $(AMREX_HOME)/Tools/GNUMake/tools/Make.craypat
   include        $(AMREX_HOME)/Tools/GNUMake/tools/Make.craypat
 endif
 
 ifeq ($(TP_PROFILING),FORGE)
-  $(into Loading $(AMREX_HOME)/Tools/GNUMake/tools/Make.forge
+  $(info Loading $(AMREX_HOME)/Tools/GNUMake/tools/Make.forge
   include        $(AMREX_HOME)/Tools/GNUMake/tools/Make.forge
 endif
 

--- a/Tools/GNUMake/Make.machines
+++ b/Tools/GNUMake/Make.machines
@@ -67,14 +67,15 @@ ifdef OLCF_ROCM_ROOT
   endif
 endif
 
-ifeq ($(findstring theta, $(host_name)), theta)
-  which_site := alcf
-  which_computer := theta
-endif
-
-ifeq ($(findstring polaris, $(host_name)), polaris)
-  which_site := alcf
-  which_computer := polaris
+ifeq ($(findstring alcf.anl.gov, $(host_name)),alcf.anl.gov)
+  ifeq ($(findstring theta, $(host_name)), theta)
+    which_site := alcf
+    which_computer := theta
+  endif
+  ifeq ($(findstring polaris, $(host_name)), polaris)
+    which_site := alcf
+    which_computer := polaris
+  endif
 endif
 
 ifeq ($(findstring sierra, $(host_name)), sierra)

--- a/Tools/GNUMake/Make.machines
+++ b/Tools/GNUMake/Make.machines
@@ -72,6 +72,11 @@ ifeq ($(findstring theta, $(host_name)), theta)
   which_computer := theta
 endif
 
+ifeq ($(findstring polaris, $(host_name)), polaris)
+  which_site := alcf
+  which_computer := polaris
+endif
+
 ifeq ($(findstring sierra, $(host_name)), sierra)
   which_site := llnl
   which_computer := sierra

--- a/Tools/GNUMake/comps/nvcc.mak
+++ b/Tools/GNUMake/comps/nvcc.mak
@@ -70,10 +70,6 @@ ifeq ($(lowercase_nvcc_host_comp),$(filter $(lowercase_nvcc_host_comp),gcc gnu g
   endif
 endif
 
-ifndef NVCC_CCBIN
-  NVCC_CCBIN_AUTOINITIALIZED := TRUE
-endif
-
 ifeq ($(lowercase_nvcc_host_comp),gnu)
 
   ifeq ($(shell expr $(gcc_major_version) \< 5),1)

--- a/Tools/GNUMake/comps/nvcc.mak
+++ b/Tools/GNUMake/comps/nvcc.mak
@@ -70,6 +70,10 @@ ifeq ($(lowercase_nvcc_host_comp),$(filter $(lowercase_nvcc_host_comp),gcc gnu g
   endif
 endif
 
+ifndef NVCC_CCBIN
+  NVCC_CCBIN_AUTOINITIALIZED := TRUE
+endif
+
 ifeq ($(lowercase_nvcc_host_comp),gnu)
 
   ifeq ($(shell expr $(gcc_major_version) \< 5),1)

--- a/Tools/GNUMake/sites/Make.alcf
+++ b/Tools/GNUMake/sites/Make.alcf
@@ -48,6 +48,20 @@ ifeq ($(which_computer),$(filter $(which_computer),polaris))
   ifeq ($(USE_CUDA),TRUE)
     CUDA_ARCH = 80
 
+    ifeq ($(NVCC_CCBIN_AUTOINITIALIZED),TRUE)
+      ifeq ($(lowercase_nvcc_host_comp),gnu)
+        CFLAGS := $(subst ccbin=g++,ccbin=CC,$(CFLAGS))
+        CXXFLAGS := $(subst ccbin=g++,ccbin=CC,$(CXXFLAGS))
+        CXXFLAGS_FROM_HOST := $(subst ccbin=g++,ccbin=CC,$(CXXFLAGS_FROM_HOST))
+      else
+      ifeq ($(lowercase_comp),nvhpc)
+        $(warning NVCC_CCBIN is auto-initialized)
+      else
+        $(error NVCC_CCBIN is auto-initialized and is likely wrong, try NVCC_CCBIN=CC)
+      endif
+      endif
+    endif
+
     ifeq ($(USE_MPI), FALSE)
       includes += $(CRAY_CUDATOOLKIT_INCLUDE_OPTS)
     endif

--- a/Tools/GNUMake/sites/Make.alcf
+++ b/Tools/GNUMake/sites/Make.alcf
@@ -75,6 +75,11 @@ ifeq ($(which_computer),$(filter $(which_computer),polaris))
         $(error No CUDA_ROOT nor CUDA_HOME nor CUDA_PATH found. Please load a cuda module.)
     endif
 
+    # Provide system configuration information.
+
+    GPUS_PER_NODE=4
+    GPUS_PER_SOCKET=4
+
   endif
 
 endif

--- a/Tools/GNUMake/sites/Make.alcf
+++ b/Tools/GNUMake/sites/Make.alcf
@@ -12,17 +12,17 @@ endif
 ifeq ($(which_computer),$(filter $(which_computer),polaris))
 
   ifdef PE_ENV
-  ifneq ($(USE_GPU),TRUE)
-    lowercase_peenv := $(shell echo $(PE_ENV) | tr A-Z a-z)
-    ifneq ($(lowercase_peenv),$(lowercase_comp))
-      has_compiler_mismatch = COMP=$(COMP) does not match PrgEnv-$(lowercase_peenv)
-    endif
-    ifeq ($(MAKECMDGOALS),)
-      ifeq ($(lowercase_peenv),nvidia)
-        $(error PrgEnv-nvidia cannot be used with CPU-only builds. Try PrgEnv-gnu instead.)
+    ifneq ($(USE_GPU),TRUE)
+      lowercase_peenv := $(shell echo $(PE_ENV) | tr A-Z a-z)
+      ifneq ($(lowercase_peenv),$(lowercase_comp))
+        has_compiler_mismatch = COMP=$(COMP) does not match PrgEnv-$(lowercase_peenv)
+      endif
+      ifeq ($(MAKECMDGOALS),)
+        ifeq ($(lowercase_peenv),nvidia)
+          $(error PrgEnv-nvidia cannot be used with CPU-only builds. Try PrgEnv-gnu instead.)
+        endif
       endif
     endif
-  endif
   endif
 
   ifeq ($(USE_CUDA),TRUE)
@@ -47,20 +47,6 @@ ifeq ($(which_computer),$(filter $(which_computer),polaris))
 
   ifeq ($(USE_CUDA),TRUE)
     CUDA_ARCH = 80
-
-    ifeq ($(NVCC_CCBIN_AUTOINITIALIZED),TRUE)
-      ifeq ($(lowercase_nvcc_host_comp),gnu)
-        CFLAGS := $(subst ccbin=g++,ccbin=CC,$(CFLAGS))
-        CXXFLAGS := $(subst ccbin=g++,ccbin=CC,$(CXXFLAGS))
-        CXXFLAGS_FROM_HOST := $(subst ccbin=g++,ccbin=CC,$(CXXFLAGS_FROM_HOST))
-      else
-      ifeq ($(lowercase_comp),nvhpc)
-        $(warning NVCC_CCBIN is auto-initialized)
-      else
-        $(error NVCC_CCBIN is auto-initialized and is likely wrong, try NVCC_CCBIN=CC)
-      endif
-      endif
-    endif
 
     ifeq ($(USE_MPI), FALSE)
       includes += $(CRAY_CUDATOOLKIT_INCLUDE_OPTS)

--- a/Tools/GNUMake/sites/Make.alcf
+++ b/Tools/GNUMake/sites/Make.alcf
@@ -8,3 +8,73 @@ ifeq ($(which_computer),theta)
     LIBRARIES += -lmpichf90
   endif
 endif
+
+ifeq ($(which_computer),$(filter $(which_computer),polaris))
+
+  ifdef PE_ENV
+  ifneq ($(USE_GPU),TRUE)
+    lowercase_peenv := $(shell echo $(PE_ENV) | tr A-Z a-z)
+    ifneq ($(lowercase_peenv),$(lowercase_comp))
+      has_compiler_mismatch = COMP=$(COMP) does not match PrgEnv-$(lowercase_peenv)
+    endif
+    ifeq ($(MAKECMDGOALS),)
+      ifeq ($(lowercase_peenv),nvidia)
+        $(error PrgEnv-nvidia cannot be used with CPU-only builds. Try PrgEnv-gnu instead.)
+      endif
+    endif
+  endif
+  endif
+
+  ifeq ($(USE_CUDA),TRUE)
+    CFLAGS += -Xcompiler='$(wordlist 2,1024,$(shell cc -craype-verbose 2> /dev/null))'
+    CXXFLAGS += -Xcompiler='$(wordlist 2,1024,$(shell CC -craype-verbose 2> /dev/null))'
+  else ifeq ($(USE_MPI),FALSE)
+    CFLAGS += $(wordlist 2,1024,$(shell cc -craype-verbose 2> /dev/null))
+    CXXFLAGS += $(wordlist 2,1024,$(shell CC -craype-verbose 2> /dev/null))
+  endif
+
+  ifeq ($(USE_MPI),TRUE)
+    ifneq ($(USE_CUDA),TRUE)
+      CC  = cc
+      CXX = CC
+      FC  = ftn
+      F90 = ftn
+      LIBRARIES += -lmpichf90
+    endif
+
+    includes += $(shell CC --cray-print-opts=cflags)
+  endif
+
+  ifeq ($(USE_CUDA),TRUE)
+    CUDA_ARCH = 80
+
+    ifeq ($(USE_MPI), FALSE)
+      includes += $(CRAY_CUDATOOLKIT_INCLUDE_OPTS)
+    endif
+
+    comm := ,
+    ifneq ($(BL_NO_FORT),TRUE)
+      LIBRARIES += $(subst -Wl$(comm),-Xlinker=,$(shell ftn --cray-print-opts=libs))
+    else
+      LIBRARIES += $(subst -Wl$(comm),-Xlinker=,$(shell CC --cray-print-opts=libs))
+    endif
+
+    ifneq ($(CUDA_ROOT),)
+        SYSTEM_CUDA_PATH := $(CUDA_ROOT)
+        COMPILE_CUDA_PATH := $(CUDA_ROOT)
+    else ifneq ($(CUDA_HOME),)
+        SYSTEM_CUDA_PATH := $(CUDA_HOME)
+        COMPILE_CUDA_PATH := $(CUDA_HOME)
+    else ifneq ($(CUDA_PATH),)
+        SYSTEM_CUDA_PATH := $(CUDA_PATH)
+        COMPILE_CUDA_PATH := $(CUDA_PATH)
+    else ifneq ($(NVIDIA_PATH),)
+        SYSTEM_CUDA_PATH := $(NVIDIA_PATH)/cuda
+        COMPILE_CUDA_PATH := $(NVIDIA_PATH)/cuda
+    else
+        $(error No CUDA_ROOT nor CUDA_HOME nor CUDA_PATH found. Please load a cuda module.)
+    endif
+
+  endif
+
+endif


### PR DESCRIPTION
## Summary
This adds Polaris as an ALCF machine by copying most of the perlmutter section of Make.nersc to Make.alcf .

## Additional background
This was tested using a similar strategy to [ALCF Getting Started - gpu affinity example  ](https://github.com/argonne-lcf/GettingStarted/blob/master/Examples/Polaris/affinity_gpu/submit.sh) with amrex/Tests/GPU/Vector on 1 node of Polaris

```
module swap PrgEnv-nvhpc PrgEnv-gnu
module load nvhpc-mixed
make USE_CUDA=TRUE USE_MPI=TRUE NVCC_CCBIN=CC
NRANKS_PER_NODE=4
NDEPTH=4
NNODES=1
NTOTRANKS=$(( NNODES * NRANKS_PER_NODE ))
mpiexec -n ${NTOTRANKS} --ppn ${NRANKS_PER_NODE} --depth=${NDEPTH} --cpu-bind depth ./set_affinity_gpu_polaris.sh ./main3d.gnu.MPI.CUDA.ex inputs
```
and 
`make USE_CUDA=TRUE USE_MPI=FALSE NVCC_CCBIN=CC`

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
