### PR TITLE
Add: `MultiFab::sum_unique`

### DIFF
--- a/Src/Base/AMReX_MultiFab.H
+++ b/Src/Base/AMReX_MultiFab.H
@@ -232,6 +232,12 @@ public:
     */
     Real sum (int comp = 0, bool local = false) const;
     /**
+    * \brief Same as sum with local=false, but for non-cell-centered data, this
+    *        skips non-unique points that are owned by multiple boxes.
+    */
+    Real sum_unique (int comp = 0,
+                     const Periodicity& period = Periodicity::NonPeriodic()) const;
+    /**
     * \brief Adds the scalar value val to the value of each cell in the
     * specified subregion of the MultiFab.  The subregion consists
     * of the num_comp components starting at component comp.

--- a/Src/Base/AMReX_MultiFab.H
+++ b/Src/Base/AMReX_MultiFab.H
@@ -236,6 +236,7 @@ public:
     *        skips non-unique points that are owned by multiple boxes.
     */
     Real sum_unique (int comp = 0,
+                     bool local = false,
                      const Periodicity& period = Periodicity::NonPeriodic()) const;
     /**
     * \brief Adds the scalar value val to the value of each cell in the

--- a/Src/Base/AMReX_MultiFab.cpp
+++ b/Src/Base/AMReX_MultiFab.cpp
@@ -1589,9 +1589,14 @@ MultiFab::sum (int comp, bool local) const
 
 Real
 MultiFab::sum_unique (int comp,
+                      bool local,
                       const Periodicity& period) const
 {
     BL_PROFILE("MultiFab::sum_unique()");
+
+    // no duplicatly distributed points if cell centered
+    if (ixType().cellCentered())
+        return this->sum(comp, local);
 
     // Owner is the grid with the lowest grid number containing the data
     std::unique_ptr<iMultiFab> owner_mask = OwnerMask(period);
@@ -1627,7 +1632,9 @@ MultiFab::sum_unique (int comp,
         }
     }
 
-    ParallelAllReduce::Sum(sm, ParallelContext::CommunicatorSub());
+    if (!local) {
+        ParallelAllReduce::Sum(sm, ParallelContext::CommunicatorSub());
+    }
 
     return sm;
 }

--- a/Src/Base/AMReX_MultiFab.cpp
+++ b/Src/Base/AMReX_MultiFab.cpp
@@ -5,6 +5,7 @@
 #include <AMReX_BLProfiler.H>
 #include <AMReX_iMultiFab.H>
 #include <AMReX_FabArrayUtility.H>
+#include <AMReX_REAL.H>
 
 #ifdef AMREX_MEM_PROFILING
 #include <AMReX_MemProfiler.H>
@@ -1582,6 +1583,53 @@ MultiFab::sum (int comp, bool local) const
     if (!local) {
         ParallelAllReduce::Sum(sm, ParallelContext::CommunicatorSub());
     }
+
+    return sm;
+}
+
+Real
+MultiFab::sum_unique (int comp,
+                      const Periodicity& period) const
+{
+    BL_PROFILE("MultiFab::sum_unique()");
+
+    using namespace amrex::literals;
+
+    // Owner is the grid with the lowest grid number containing the data
+    std::unique_ptr<iMultiFab> owner_mask = OwnerMask(period);
+
+    Real sm = Real(0.0);
+#ifdef AMREX_USE_GPU
+    if (Gpu::inLaunchRegion()) {
+        auto const& ma = this->const_arrays();
+        auto const& msk = owner_mask->const_array();
+        sm = ParReduce(TypeList<ReduceOpSum>{}, TypeList<Real>{}, *this, IntVect(0),
+        [=] AMREX_GPU_DEVICE (int box_no, int i, int j, int k) noexcept
+                       -> GpuTuple<Real>
+        {
+            return msk(i,j,k,comp) ? ma[box_no](i,j,k,comp) : 0.0_rt;
+        });
+    } else
+#endif
+    {
+#ifdef AMREX_USE_OMP
+#pragma omp parallel if (!system::regtest_reduction) reduction(+:sm)
+#endif
+        for (MFIter mfi(*this,true); mfi.isValid(); ++mfi)
+        {
+            Box const& bx = mfi.tilebox();
+            Array4<Real const> const& a = this->const_array(mfi);
+            Array4<int const> const& msk = owner_mask->const_array(mfi);
+            Real tmp = 0.0_rt;
+            AMREX_LOOP_3D(bx, i, j, k,
+            {
+                tmp += msk(i,j,k,comp) ? a(i,j,k,comp) : 0.0_rt;
+            });
+            sm += tmp; // Do it this way so that it does not break regression tests.
+        }
+    }
+
+    ParallelAllReduce::Sum(sm, ParallelContext::CommunicatorSub());
 
     return sm;
 }


### PR DESCRIPTION
## Summary

This provides a new method to sum values in a `MultiFab`.
For non-cell-centered data, `MultiFab::sum` double counts box boundary values that are owned by multiple boxes. This provides a function that does not double count these and provides a quick way to get only the sum of physically unique values.

- [ ] test: is there a good AMReX location to call this in an existing test (or write a new one)? I'll use this in ImpactX (see below)

## Additional background

https://github.com/ECP-WarpX/impactx/pull/165

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
