### PR TITLE
Fix OOB access of ref ratio on HDF write header

### DIFF
--- a/Src/Extern/HDF5/AMReX_PlotFileUtilHDF5.cpp
+++ b/Src/Extern/HDF5/AMReX_PlotFileUtilHDF5.cpp
@@ -232,11 +232,8 @@ WriteGenericPlotfileHeaderHDF5 (hid_t fid,
 
         int ratio = 1;
         if (ref_ratio.size() > 0)
-            ratio = ref_ratio[level][0];
+            ratio = (level == finest_level)? 1: ref_ratio[level][0];
 
-        if (level == finest_level) {
-            ratio = 1;
-        }
         CreateWriteHDF5AttrInt(grp, "ref_ratio", 1, &ratio);
 
         for (int k = 0; k < AMREX_SPACEDIM; ++k) {


### PR DESCRIPTION
## Summary
In `WriteGenericPlotfileHeaderHDF5`,  there is a loop `for (int level = 0; level <= finest_level; ++level) {` and an access of `ref_ratio[level][0]`. However, `ref_ratio` is of size `max_level` and therefore this leads to an OOB access of ref_ratio when `level == finest_level`. This fix avoids that OOB access.

## Checklist

The proposed changes:
- [X] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
