### PR TITLE
Specialize `GpuArray<T, 0>`

### DIFF
--- a/Src/Base/AMReX_Array.H
+++ b/Src/Base/AMReX_Array.H
@@ -136,73 +136,33 @@ namespace amrex {
         using value_type = T;
         using reference_type = T&;
 
-        /**
-         * GpuArray elements are indexed using square brackets, as with any
-         * other array.
-         */
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         const T& operator [] (int) const noexcept { return *static_cast<T*>(nullptr); }
 
-        /**
-         * GpuArray elements are indexed using square brackets, as with any
-         * other array.
-         */
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         T& operator [] (int) noexcept { return *static_cast<T*>(nullptr); }
 
-        /**
-         * Returns a \c const pointer to the underlying data of a GpuArray object.
-         */
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         const T* data () const noexcept { return nullptr; }
 
-        /**
-         * Returns a pointer to the underlying data of a GpuArray object.
-         */
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         T* data () noexcept { return nullptr; }
 
-        /**
-         * Returns the number of elements in the GpuArray object as an
-         * unsigned integer.
-         */
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         static constexpr unsigned int size () noexcept { return 0u; }
 
-        /**
-         * Returns a \c const pointer address to the first element of the
-         * GpuArray object.
-         */
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         const T* begin () const noexcept { return nullptr; }
 
-        /**
-         * Returns a const pointer address right after the last element of the
-         * GpuArray object.
-         */
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         const T* end () const noexcept { return nullptr; }
 
-        /**
-         * Returns a pointer address to the first element of the
-         * GpuArray object.
-         */
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         T* begin () noexcept { return nullptr; }
 
-        /**
-         * Returns a pointer address right after the last element of the
-         * GpuArray object.
-         */
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         T* end () noexcept { return nullptr; }
 
-        /**
-         * Fills in all of the elements in the GpuArray object to the same
-         * value.
-         *
-         * \param value The fill value
-         */
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         void fill ( const T& value ) noexcept
         { (void) value; }

--- a/Src/Base/AMReX_Array.H
+++ b/Src/Base/AMReX_Array.H
@@ -127,7 +127,85 @@ namespace amrex {
             return p;
         }
 
-        T arr[amrex::max(N,1u)];
+        T arr[N];
+    };
+
+    template <class T>
+    struct GpuArray<T, 0u>
+    {
+        using value_type = T;
+        using reference_type = T&;
+
+        /**
+         * GpuArray elements are indexed using square brackets, as with any
+         * other array.
+         */
+        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        const T& operator [] (int) const noexcept { return *static_cast<T*>(nullptr); }
+
+        /**
+         * GpuArray elements are indexed using square brackets, as with any
+         * other array.
+         */
+        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        T& operator [] (int) noexcept { return *static_cast<T*>(nullptr); }
+
+        /**
+         * Returns a \c const pointer to the underlying data of a GpuArray object.
+         */
+        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        const T* data () const noexcept { return nullptr; }
+
+        /**
+         * Returns a pointer to the underlying data of a GpuArray object.
+         */
+        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        T* data () noexcept { return nullptr; }
+
+        /**
+         * Returns the number of elements in the GpuArray object as an
+         * unsigned integer.
+         */
+        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        static constexpr unsigned int size () noexcept { return 0u; }
+
+        /**
+         * Returns a \c const pointer address to the first element of the
+         * GpuArray object.
+         */
+        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        const T* begin () const noexcept { return nullptr; }
+
+        /**
+         * Returns a const pointer address right after the last element of the
+         * GpuArray object.
+         */
+        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        const T* end () const noexcept { return nullptr; }
+
+        /**
+         * Returns a pointer address to the first element of the
+         * GpuArray object.
+         */
+        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        T* begin () noexcept { return nullptr; }
+
+        /**
+         * Returns a pointer address right after the last element of the
+         * GpuArray object.
+         */
+        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        T* end () noexcept { return nullptr; }
+
+        /**
+         * Fills in all of the elements in the GpuArray object to the same
+         * value.
+         *
+         * \param value The fill value
+         */
+        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        void fill ( const T& value ) noexcept
+        { (void) value; }
     };
 }
 

--- a/Src/Particle/AMReX_ParticleTile.H
+++ b/Src/Particle/AMReX_ParticleTile.H
@@ -626,10 +626,12 @@ struct ParticleTile
 
         ConstParticleTileDataType ptd;
         ptd.m_aos = m_aos_tile().dataPtr();
-        for (int i = 0; i < NArrayReal; ++i)
-            ptd.m_rdata[i] = m_soa_tile.GetRealData(i).dataPtr();
-        for (int i = 0; i < NArrayInt; ++i)
-            ptd.m_idata[i] = m_soa_tile.GetIntData(i).dataPtr();
+        AMREX_IF_CONSTEXPR(NArrayReal>0)
+            for (int i = 0; i < NArrayReal; ++i)
+                ptd.m_rdata[i] = m_soa_tile.GetRealData(i).dataPtr();
+        AMREX_IF_CONSTEXPR(NArrayInt>0)
+            for (int i = 0; i < NArrayInt; ++i)
+                ptd.m_idata[i] = m_soa_tile.GetIntData(i).dataPtr();
         ptd.m_size = size();
         ptd.m_num_runtime_real = m_runtime_r_cptrs.size();
         ptd.m_num_runtime_int = m_runtime_i_cptrs.size();

--- a/Src/Particle/AMReX_ParticleTransformation.H
+++ b/Src/Particle/AMReX_ParticleTransformation.H
@@ -36,12 +36,14 @@ void copyParticle (const      ParticleTileData<NSR, NSI, NAR, NAI>& dst,
     AMREX_ASSERT(dst.m_num_runtime_int  == src.m_num_runtime_int );
 
     dst.m_aos[dst_i] = src.m_aos[src_i];
-    for (int j = 0; j < NAR; ++j)
-        dst.m_rdata[j][dst_i] = src.m_rdata[j][src_i];
+    AMREX_IF_CONSTEXPR(NAR>0)
+        for (int j = 0; j < NAR; ++j)
+            dst.m_rdata[j][dst_i] = src.m_rdata[j][src_i];
     for (int j = 0; j < dst.m_num_runtime_real; ++j)
         dst.m_runtime_rdata[j][dst_i] = src.m_runtime_rdata[j][src_i];
-    for (int j = 0; j < NAI; ++j)
-        dst.m_idata[j][dst_i] = src.m_idata[j][src_i];
+    AMREX_IF_CONSTEXPR(NAI>0)
+        for (int j = 0; j < NAI; ++j)
+            dst.m_idata[j][dst_i] = src.m_idata[j][src_i];
     for (int j = 0; j < dst.m_num_runtime_int; ++j)
         dst.m_runtime_idata[j][dst_i] = src.m_runtime_idata[j][src_i];
 }
@@ -70,12 +72,14 @@ void copyParticle (const ParticleTileData<NSR, NSI, NAR, NAI>& dst,
     AMREX_ASSERT(dst.m_num_runtime_int  == src.m_num_runtime_int );
 
     dst.m_aos[dst_i] = src.m_aos[src_i];
-    for (int j = 0; j < NAR; ++j)
-        dst.m_rdata[j][dst_i] = src.m_rdata[j][src_i];
+    AMREX_IF_CONSTEXPR(NAR>0)
+        for (int j = 0; j < NAR; ++j)
+            dst.m_rdata[j][dst_i] = src.m_rdata[j][src_i];
     for (int j = 0; j < dst.m_num_runtime_real; ++j)
         dst.m_runtime_rdata[j][dst_i] = src.m_runtime_rdata[j][src_i];
-    for (int j = 0; j < NAI; ++j)
-        dst.m_idata[j][dst_i] = src.m_idata[j][src_i];
+    AMREX_IF_CONSTEXPR(NAI>0)
+        for (int j = 0; j < NAI; ++j)
+            dst.m_idata[j][dst_i] = src.m_idata[j][src_i];
     for (int j = 0; j < dst.m_num_runtime_int; ++j)
         dst.m_runtime_idata[j][dst_i] = src.m_runtime_idata[j][src_i];
 }
@@ -104,12 +108,14 @@ void swapParticle (const ParticleTileData<NSR, NSI, NAR, NAI>& dst,
     AMREX_ASSERT(dst.m_num_runtime_int  == src.m_num_runtime_int );
 
     amrex::Swap(src.m_aos[src_i], dst.m_aos[dst_i]);
-    for (int j = 0; j < NAR; ++j)
-        amrex::Swap(dst.m_rdata[j][dst_i], src.m_rdata[j][src_i]);
+    AMREX_IF_CONSTEXPR(NAR>0)
+        for (int j = 0; j < NAR; ++j)
+            amrex::Swap(dst.m_rdata[j][dst_i], src.m_rdata[j][src_i]);
     for (int j = 0; j < dst.m_num_runtime_real; ++j)
         amrex::Swap(dst.m_runtime_rdata[j][dst_i], src.m_runtime_rdata[j][src_i]);
-    for (int j = 0; j < NAI; ++j)
-        amrex::Swap(dst.m_idata[j][dst_i], src.m_idata[j][src_i]);
+    AMREX_IF_CONSTEXPR(NAI>0)
+        for (int j = 0; j < NAI; ++j)
+            amrex::Swap(dst.m_idata[j][dst_i], src.m_idata[j][src_i]);
     for (int j = 0; j < dst.m_num_runtime_int; ++j)
         amrex::Swap(dst.m_runtime_idata[j][dst_i], src.m_runtime_idata[j][src_i]);
 }


### PR DESCRIPTION
## Summary

We need an implementation of AMReX' GPU array with zero entries for AoS-free particle implementations (#2878).

This applies the same specialization as `std::array` to make `amrex::GpuArray` trivially copyable again if used with zero size.

## Additional background

The implicit copy constructors tried to assign an array member of size 1 (rhs) to a size 0 (lhs), which does not compile.

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
