### PR TITLE
Scope of NonLocalBC::ParallelCopy

### DIFF
--- a/Src/Base/AMReX_MultiFab.H
+++ b/Src/Base/AMReX_MultiFab.H
@@ -8,6 +8,7 @@
 #include <AMReX_FabArray.H>
 #include <AMReX_FabArrayUtility.H>
 #include <AMReX_Periodicity.H>
+#include <AMReX_NonLocalBC.H>
 
 #ifdef AMREX_USE_EB
 #include <AMReX_EBMultiFabUtil.H>

--- a/Src/Base/AMReX_NonLocalBC.H
+++ b/Src/Base/AMReX_NonLocalBC.H
@@ -1038,4 +1038,13 @@ FillPolar (FabArray<FAB>& mf, Box const& domain);
 
 #include <AMReX_NonLocalBCImpl.H>
 
+namespace amrex {
+    using NonLocalBC::ParallelCopy;
+    using NonLocalBC::ParallelCopy_nowait;
+    using NonLocalBC::ParallelCopy_finish;
+    using NonLocalBC::MultiBlockIndexMapping;
+    using NonLocalBC::MultiBlockCommMetaData;
+    using NonLocalBC::CommHandler;
+}
+
 #endif


### PR DESCRIPTION
Make NonLocalBC::ParallelCopy accessible in namespace amrex, because it can
be useful in situations other than non-local BC.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
