### PR TITLE
Check if boundary particles container has been created before clearance.

### DIFF
--- a/Src/Particle/AMReX_NeighborParticlesI.H
+++ b/Src/Particle/AMReX_NeighborParticlesI.H
@@ -822,8 +822,10 @@ selectActualNeighbors (CheckPair&& check_pair, int num_cells)
     for (int lev = 0; lev < this->numLevels(); ++lev)
     {
         // clear previous neighbor particle ids
-        for (auto& keyval: m_boundary_particle_ids[lev]) {
-          keyval.second.clear();
+        if (!m_boundary_particle_ids.empty()) {
+          for (auto& keyval: m_boundary_particle_ids[lev]) {
+            keyval.second.clear();
+          }
         }
 
         for (MyParIter pti(*this, lev); pti.isValid(); ++pti) {


### PR DESCRIPTION
## Summary
This fixes a segmentation fault when using more GPUs for updating particles than fluid.

## Additional background

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
