### PR TITLE
Fix ParmParse: Loading Files Again

### DIFF
--- a/Src/Base/AMReX_ParmParse.H
+++ b/Src/Base/AMReX_ParmParse.H
@@ -554,7 +554,7 @@ public:
               const std::string&  val);
 
     //! keyword for files to load
-    static std::string FileKeyword;
+    static std::string const FileKeyword;
 
     //! Add keys and values from a file to the end of the PP table.
     static void addfile (std::string const filename);

--- a/Src/Base/AMReX_ParmParse.cpp
+++ b/Src/Base/AMReX_ParmParse.cpp
@@ -34,7 +34,7 @@ static bool finalize_verbose = false;
 static bool finalize_verbose = true;
 #endif
 
-std::string ParmParse::FileKeyword = "FILE";
+std::string const ParmParse::FileKeyword = "FILE";
 
 //
 // Used by constructor to build table.
@@ -609,7 +609,8 @@ addDefn (std::string&         def,
         tab.push_back(ParmParse::PP_entry(def,val));
     }
     val.clear();
-    def = std::string();
+    if ( def != ParmParse::FileKeyword )
+        def = std::string();
 }
 
 void
@@ -991,7 +992,8 @@ ParmParse::prefixedName (const std::string& str) const
 void
 ParmParse::addfile (std::string const filename) {
     auto l = std::list<std::string>{filename};
-    addDefn(FileKeyword,
+    auto file = FileKeyword;
+    addDefn(file,
             l,
             g_table);
 }


### PR DESCRIPTION
## Summary

This enables that `amrex::ParmParse::addfile` can be called multiple times. Before this, we accidentally overwrite the `FILE` static keyword.

## Additional background

Follow-up to #2842

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
