### PR TITLE
Fix: Make Finalize->Initialize->F->I->... Work

### DIFF
--- a/Src/Base/AMReX_Arena.cpp
+++ b/Src/Base/AMReX_Arena.cpp
@@ -253,6 +253,7 @@ Arena::Initialize ()
     if (initialized) return;
     initialized = true;
 
+    // see reason on allowed reuse of the default CPU BArena in Arena::Finalize
     BL_ASSERT(the_arena == nullptr || the_arena == The_BArena());
     BL_ASSERT(the_async_arena == nullptr);
     BL_ASSERT(the_device_arena == nullptr || the_arena == The_BArena());
@@ -468,6 +469,13 @@ Arena::Finalize ()
 
     initialized = false;
 
+    // we reset Arenas unless they are the default "CPU malloc/free" BArena
+    // this is because we want to allow users to free their UB objects
+    // that they forgot to destruct after amrex::Finalize():
+    //   amrex::Initialize(...);
+    //   MultiFab mf(...);  // this should be scoped in { ... }
+    //   amrex::Finalize();
+    // mf cannot be used now, but it can at least be freed without a segfault
     if (!dynamic_cast<BArena*>(the_device_arena)) {
         if (the_device_arena != the_arena) {
             delete the_device_arena;

--- a/Src/Base/AMReX_Arena.cpp
+++ b/Src/Base/AMReX_Arena.cpp
@@ -253,12 +253,12 @@ Arena::Initialize ()
     if (initialized) return;
     initialized = true;
 
-    BL_ASSERT(the_arena == nullptr);
+    BL_ASSERT(the_arena == nullptr || the_arena == The_BArena());
     BL_ASSERT(the_async_arena == nullptr);
-    BL_ASSERT(the_device_arena == nullptr);
-    BL_ASSERT(the_managed_arena == nullptr);
+    BL_ASSERT(the_device_arena == nullptr || the_arena == The_BArena());
+    BL_ASSERT(the_managed_arena == nullptr || the_arena == The_BArena());
     BL_ASSERT(the_pinned_arena == nullptr);
-    BL_ASSERT(the_cpu_arena == nullptr);
+    BL_ASSERT(the_cpu_arena == nullptr || the_arena == The_BArena());
 
 #ifdef AMREX_USE_GPU
 #ifdef AMREX_USE_DPCPP
@@ -472,20 +472,20 @@ Arena::Finalize ()
         if (the_device_arena != the_arena) {
             delete the_device_arena;
         }
+        the_device_arena = nullptr;
     }
-    the_device_arena = nullptr;
 
     if (!dynamic_cast<BArena*>(the_managed_arena)) {
         if (the_managed_arena != the_arena) {
             delete the_managed_arena;
         }
+        the_managed_arena = nullptr;
     }
-    the_managed_arena = nullptr;
 
     if (!dynamic_cast<BArena*>(the_arena)) {
         delete the_arena;
+        the_arena = nullptr;
     }
-    the_arena = nullptr;
 
     delete the_async_arena;
     the_async_arena = nullptr;
@@ -495,8 +495,8 @@ Arena::Finalize ()
 
     if (!dynamic_cast<BArena*>(the_cpu_arena)) {
         delete the_cpu_arena;
+        the_cpu_arena = nullptr;
     }
-    the_cpu_arena = nullptr;
 }
 
 Arena*

--- a/Src/Base/AMReX_Arena.cpp
+++ b/Src/Base/AMReX_Arena.cpp
@@ -472,20 +472,20 @@ Arena::Finalize ()
         if (the_device_arena != the_arena) {
             delete the_device_arena;
         }
-        the_device_arena = nullptr;
     }
+    the_device_arena = nullptr;
 
     if (!dynamic_cast<BArena*>(the_managed_arena)) {
         if (the_managed_arena != the_arena) {
             delete the_managed_arena;
         }
-        the_managed_arena = nullptr;
     }
+    the_managed_arena = nullptr;
 
     if (!dynamic_cast<BArena*>(the_arena)) {
         delete the_arena;
-        the_arena = nullptr;
     }
+    the_arena = nullptr;
 
     delete the_async_arena;
     the_async_arena = nullptr;
@@ -495,8 +495,8 @@ Arena::Finalize ()
 
     if (!dynamic_cast<BArena*>(the_cpu_arena)) {
         delete the_cpu_arena;
-        the_cpu_arena = nullptr;
     }
+    the_cpu_arena = nullptr;
 }
 
 Arena*

--- a/Src/Base/AMReX_Arena.cpp
+++ b/Src/Base/AMReX_Arena.cpp
@@ -256,10 +256,10 @@ Arena::Initialize ()
     // see reason on allowed reuse of the default CPU BArena in Arena::Finalize
     BL_ASSERT(the_arena == nullptr || the_arena == The_BArena());
     BL_ASSERT(the_async_arena == nullptr);
-    BL_ASSERT(the_device_arena == nullptr || the_arena == The_BArena());
-    BL_ASSERT(the_managed_arena == nullptr || the_arena == The_BArena());
+    BL_ASSERT(the_device_arena == nullptr || the_device_arena == The_BArena());
+    BL_ASSERT(the_managed_arena == nullptr || the_managed_arena == The_BArena());
     BL_ASSERT(the_pinned_arena == nullptr);
-    BL_ASSERT(the_cpu_arena == nullptr || the_arena == The_BArena());
+    BL_ASSERT(the_cpu_arena == nullptr || the_cpu_arena == The_BArena());
 
 #ifdef AMREX_USE_GPU
 #ifdef AMREX_USE_DPCPP


### PR DESCRIPTION
## Summary

The arenas are not set in all cases to `nullptr`s yet. This causes that repeated finalize/initialize calls fail in debug mode.

## Additional background

Seen in https://github.com/ECP-WarpX/impactx/pull/172 and https://github.com/ECP-WarpX/impactx/pull/240

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
