### PR TITLE
Fix minor typo in fcompare docs

### DIFF
--- a/Docs/sphinx_documentation/source/Post_Processing.rst
+++ b/Docs/sphinx_documentation/source/Post_Processing.rst
@@ -76,8 +76,8 @@ variable.
 
 **How to build and run**
 
-In ``amrex/Tools/Plotfile``, type ``make`` and then ``./fextract.gnu.ex`` to run.
-Typing ``./fextract.gnu.ex`` without inputs will bring up usage and options.
+In ``amrex/Tools/Plotfile``, type ``make`` and then ``./fcompare.gnu.ex`` to run.
+Typing ``./fcompare.gnu.ex`` without inputs will bring up usage and options.
 
 
 **Example**


### PR DESCRIPTION
## Summary

Fixes a minor typo in the `fcompare` docs: `fextract` --> `fcompare`

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
