### PR TITLE
Add template parameter to ParallelFor and launch specifying block size

### DIFF
--- a/Docs/sphinx_documentation/source/GPU.rst
+++ b/Docs/sphinx_documentation/source/GPU.rst
@@ -1001,7 +1001,7 @@ launch function.
 
 ``amrex::ParallelFor()`` expands into different variations of a quadruply-nested
 :cpp:`for` loop depending dimensionality and whether it is being implemented on CPU or GPU.
-The best way to understand this macro is to take a look at the 4D :cpp:`amrex::ParallelFor`
+The best way to understand this function is to take a look at the 4D :cpp:`amrex::ParallelFor`
 that is implemented when ``USE_CUDA=FALSE``. A simplified version is reproduced here:
 
 .. highlight:: c++
@@ -1103,6 +1103,15 @@ bounds, a :cpp:`long` or :cpp:`int` number of elements is passed to bound the si
 passing the number of elements to work on and indexing the pointer to the starting
 element: :cpp:`p[idx + 15]`.
 
+GPU block size
+--------------
+
+By default, :cpp:`ParallelFor` launches ``AMREX_GPU_MAX_THREADS`` threads
+per GPU block, where ``AMREX_GPU_MAX_THREADS`` is a compile-time constant
+with a default value of 256.  The users can also explcitly specify the
+number of threads per block by :cpp:`ParallelFor<MY_BLOCK_SIZE>(...)`, where
+``MY_BLOCK_SIZE`` is a multiple of the warp size (e.g., 128).  This allows
+the users to do performance tuning for individual kernels.
 
 Launching general kernels
 -------------------------

--- a/Src/Base/AMReX_GpuLaunch.H
+++ b/Src/Base/AMReX_GpuLaunch.H
@@ -30,11 +30,11 @@
 #define AMREX_GPU_Z_STRIDE 1
 
 #ifdef AMREX_USE_CUDA
-#  define AMREX_LAUNCH_KERNEL(blocks, threads, sharedMem, stream, ... ) \
-        amrex::launch_global<AMREX_GPU_MAX_THREADS><<<blocks, threads, sharedMem, stream>>>(__VA_ARGS__);
+#  define AMREX_LAUNCH_KERNEL(MT, blocks, threads, sharedMem, stream, ... ) \
+        amrex::launch_global<MT><<<blocks, threads, sharedMem, stream>>>(__VA_ARGS__)
 #elif defined(AMREX_USE_HIP)
-#  define AMREX_LAUNCH_KERNEL(blocks, threads, sharedMem, stream, ... ) \
-        hipLaunchKernelGGL(launch_global<AMREX_GPU_MAX_THREADS>, blocks, threads, sharedMem, stream, __VA_ARGS__);
+#  define AMREX_LAUNCH_KERNEL(MT, blocks, threads, sharedMem, stream, ... ) \
+        hipLaunchKernelGGL(launch_global<MT>, blocks, threads, sharedMem, stream, __VA_ARGS__)
 #endif
 
 
@@ -151,6 +151,28 @@ namespace Gpu {
         dim3 numThreads;
         std::size_t sharedMem = 0;
     };
+
+    template <int MT>
+    ExecutionConfig
+    makeExecutionConfig (Long N) noexcept
+    {
+        ExecutionConfig ec(dim3{}, dim3{});
+        ec.numBlocks.x = (std::max(N,Long(1)) + MT - 1) / MT;
+        ec.numThreads.x = MT;
+        AMREX_ASSERT(MT % Gpu::Device::warp_size == 0);
+        return ec;
+    }
+
+    template <int MT>
+    ExecutionConfig
+    makeExecutionConfig (const Box& box) noexcept
+    {
+        ExecutionConfig ec(dim3{}, dim3{});
+        ec.numBlocks.x = (std::max(box.numPts(),Long(1)) + MT - 1) / MT;
+        ec.numThreads.x = MT;
+        AMREX_ASSERT(MT % Gpu::Device::warp_size == 0);
+        return ec;
+    }
 #endif
 
 }

--- a/Src/Base/AMReX_GpuLaunchFunctsC.H
+++ b/Src/Base/AMReX_GpuLaunchFunctsC.H
@@ -55,8 +55,15 @@ namespace detail {
 }
 
 template<typename T, typename L>
-void launch (T const& n, L&& f, std::size_t /*shared_mem_bytes*/=0) noexcept
+void launch (T const& n, L&& f) noexcept
 {
+    f(n);
+}
+
+template<int MT, typename T, typename L>
+void launch (T const& n, L&& f) noexcept
+{
+    amrex::ignore_unused(MT);
     f(n);
 }
 
@@ -68,9 +75,23 @@ void For (T n, L&& f) noexcept
     }
 }
 
+template <int MT, typename T, typename L, typename M=std::enable_if_t<std::is_integral<T>::value> >
+void For (T n, L&& f) noexcept
+{
+    amrex::ignore_unused(MT);
+    For(n, std::forward<L>(f));
+}
+
 template <typename T, typename L, typename M=std::enable_if_t<std::is_integral<T>::value> >
 void For (Gpu::KernelInfo const&, T n, L&& f) noexcept
 {
+    For(n, std::forward<L>(f));
+}
+
+template <int MT, typename T, typename L, typename M=std::enable_if_t<std::is_integral<T>::value> >
+void For (Gpu::KernelInfo const&, T n, L&& f) noexcept
+{
+    amrex::ignore_unused(MT);
     For(n, std::forward<L>(f));
 }
 
@@ -83,9 +104,23 @@ void ParallelFor (T n, L&& f) noexcept
     }
 }
 
+template <int MT, typename T, typename L, typename M=std::enable_if_t<std::is_integral<T>::value> >
+void ParallelFor (T n, L&& f) noexcept
+{
+    amrex::ignore_unused(MT);
+    ParallelFor(n, std::forward<L>(f));
+}
+
 template <typename T, typename L, typename M=std::enable_if_t<std::is_integral<T>::value> >
 void ParallelFor (Gpu::KernelInfo const&, T n, L&& f) noexcept
 {
+    ParallelFor(n, std::forward<L>(f));
+}
+
+template <int MT, typename T, typename L, typename M=std::enable_if_t<std::is_integral<T>::value> >
+void ParallelFor (Gpu::KernelInfo const&, T n, L&& f) noexcept
+{
+    amrex::ignore_unused(MT);
     ParallelFor(n, std::forward<L>(f));
 }
 
@@ -101,9 +136,23 @@ void For (Box const& box, L&& f) noexcept
     }}}
 }
 
+template <int MT, typename L>
+void For (Box const& box, L&& f) noexcept
+{
+    amrex::ignore_unused(MT);
+    For(box, std::forward<L>(f));
+}
+
 template <typename L>
 void For (Gpu::KernelInfo const&, Box const& box, L&& f) noexcept
 {
+    For(box, std::forward<L>(f));
+}
+
+template <int MT, typename L>
+void For (Gpu::KernelInfo const&, Box const& box, L&& f) noexcept
+{
+    amrex::ignore_unused(MT);
     For(box, std::forward<L>(f));
 }
 
@@ -120,9 +169,23 @@ void ParallelFor (Box const& box, L&& f) noexcept
     }}}
 }
 
+template <int MT, typename L>
+void ParallelFor (Box const& box, L&& f) noexcept
+{
+    amrex::ignore_unused(MT);
+    ParallelFor(box, std::forward<L>(f));
+}
+
 template <typename L>
 void ParallelFor (Gpu::KernelInfo const&, Box const& box, L&& f) noexcept
 {
+    ParallelFor(box, std::forward<L>(f));
+}
+
+template <int MT, typename L>
+void ParallelFor (Gpu::KernelInfo const&, Box const& box, L&& f) noexcept
+{
+    amrex::ignore_unused(MT);
     ParallelFor(box, std::forward<L>(f));
 }
 
@@ -140,9 +203,23 @@ void For (Box const& box, T ncomp, L&& f) noexcept
     }
 }
 
+template <int MT, typename T, typename L, typename M=std::enable_if_t<std::is_integral<T>::value> >
+void For (Box const& box, T ncomp, L&& f) noexcept
+{
+    amrex::ignore_unused(MT);
+    For(box, ncomp, std::forward<L>(f));
+}
+
 template <typename T, typename L, typename M=std::enable_if_t<std::is_integral<T>::value> >
 void For (Gpu::KernelInfo const&, Box const& box, T ncomp, L&& f) noexcept
 {
+    For(box, ncomp, std::forward<L>(f));
+}
+
+template <int MT, typename T, typename L, typename M=std::enable_if_t<std::is_integral<T>::value> >
+void For (Gpu::KernelInfo const&, Box const& box, T ncomp, L&& f) noexcept
+{
+    amrex::ignore_unused(MT);
     For(box, ncomp, std::forward<L>(f));
 }
 
@@ -161,9 +238,23 @@ void ParallelFor (Box const& box, T ncomp, L&& f) noexcept
     }
 }
 
+template <int MT, typename T, typename L, typename M=std::enable_if_t<std::is_integral<T>::value> >
+void ParallelFor (Box const& box, T ncomp, L&& f) noexcept
+{
+    amrex::ignore_unused(MT);
+    ParallelFor(box, ncomp, std::forward<L>(f));
+}
+
 template <typename T, typename L, typename M=std::enable_if_t<std::is_integral<T>::value> >
 void ParallelFor (Gpu::KernelInfo const&, Box const& box, T ncomp, L&& f) noexcept
 {
+    ParallelFor(box, ncomp, std::forward<L>(f));
+}
+
+template <int MT, typename T, typename L, typename M=std::enable_if_t<std::is_integral<T>::value> >
+void ParallelFor (Gpu::KernelInfo const&, Box const& box, T ncomp, L&& f) noexcept
+{
+    amrex::ignore_unused(MT);
     ParallelFor(box, ncomp, std::forward<L>(f));
 }
 
@@ -174,9 +265,24 @@ void For (Box const& box1, Box const& box2, L1&& f1, L2&& f2) noexcept
     For(box2, std::forward<L2>(f2));
 }
 
+template <int MT, typename L1, typename L2>
+void For (Box const& box1, Box const& box2, L1&& f1, L2&& f2) noexcept
+{
+    amrex::ignore_unused(MT);
+    For(box1, std::forward<L1>(f1));
+    For(box2, std::forward<L2>(f2));
+}
+
 template <typename L1, typename L2>
 void For (Gpu::KernelInfo const&, Box const& box1, Box const& box2, L1&& f1, L2&& f2) noexcept
 {
+    For (box1, box2, std::forward<L1>(f1), std::forward<L2>(f2));
+}
+
+template <int MT, typename L1, typename L2>
+void For (Gpu::KernelInfo const&, Box const& box1, Box const& box2, L1&& f1, L2&& f2) noexcept
+{
+    amrex::ignore_unused(MT);
     For (box1, box2, std::forward<L1>(f1), std::forward<L2>(f2));
 }
 
@@ -188,9 +294,25 @@ void For (Box const& box1, Box const& box2, Box const& box3, L1&& f1, L2&& f2, L
     For(box3, std::forward<L3>(f3));
 }
 
+template <int MT, typename L1, typename L2, typename L3>
+void For (Box const& box1, Box const& box2, Box const& box3, L1&& f1, L2&& f2, L3&& f3) noexcept
+{
+    amrex::ignore_unused(MT);
+    For(box1, std::forward<L1>(f1));
+    For(box2, std::forward<L2>(f2));
+    For(box3, std::forward<L3>(f3));
+}
+
 template <typename L1, typename L2, typename L3>
 void For (Gpu::KernelInfo const&, Box const& box1, Box const& box2, Box const& box3, L1&& f1, L2&& f2, L3&& f3) noexcept
 {
+    For(box1, box2, box3, std::forward<L1>(f1), std::forward<L2>(f2), std::forward<L3>(f3));
+}
+
+template <int MT, typename L1, typename L2, typename L3>
+void For (Gpu::KernelInfo const&, Box const& box1, Box const& box2, Box const& box3, L1&& f1, L2&& f2, L3&& f3) noexcept
+{
+    amrex::ignore_unused(MT);
     For(box1, box2, box3, std::forward<L1>(f1), std::forward<L2>(f2), std::forward<L3>(f3));
 }
 
@@ -200,6 +322,17 @@ template <typename T1, typename T2, typename L1, typename L2,
 void For (Box const& box1, T1 ncomp1, L1&& f1,
           Box const& box2, T2 ncomp2, L2&& f2) noexcept
 {
+    For(box1, ncomp1, std::forward<L1>(f1));
+    For(box2, ncomp2, std::forward<L2>(f2));
+}
+
+template <int MT, typename T1, typename T2, typename L1, typename L2,
+          typename M1=std::enable_if_t<std::is_integral<T1>::value>,
+          typename M2=std::enable_if_t<std::is_integral<T2>::value> >
+void For (Box const& box1, T1 ncomp1, L1&& f1,
+          Box const& box2, T2 ncomp2, L2&& f2) noexcept
+{
+    amrex::ignore_unused(MT);
     For(box1, ncomp1, std::forward<L1>(f1));
     For(box2, ncomp2, std::forward<L2>(f2));
 }
@@ -214,6 +347,17 @@ void For (Gpu::KernelInfo const&,
     For(box1,ncomp1,std::forward<L1>(f1),box2,ncomp2,std::forward<L2>(f2));
 }
 
+template <int MT, typename T1, typename T2, typename L1, typename L2,
+          typename M1=std::enable_if_t<std::is_integral<T1>::value>,
+          typename M2=std::enable_if_t<std::is_integral<T2>::value> >
+void For (Gpu::KernelInfo const&,
+          Box const& box1, T1 ncomp1, L1&& f1,
+          Box const& box2, T2 ncomp2, L2&& f2) noexcept
+{
+    amrex::ignore_unused(MT);
+    For(box1,ncomp1,std::forward<L1>(f1),box2,ncomp2,std::forward<L2>(f2));
+}
+
 template <typename T1, typename T2, typename T3, typename L1, typename L2, typename L3,
           typename M1=std::enable_if_t<std::is_integral<T1>::value>,
           typename M2=std::enable_if_t<std::is_integral<T2>::value>,
@@ -222,6 +366,20 @@ void For (Box const& box1, T1 ncomp1, L1&& f1,
           Box const& box2, T2 ncomp2, L2&& f2,
           Box const& box3, T3 ncomp3, L3&& f3) noexcept
 {
+    For(box1, ncomp1, std::forward<L1>(f1));
+    For(box2, ncomp2, std::forward<L2>(f2));
+    For(box3, ncomp3, std::forward<L3>(f3));
+}
+
+template <int MT, typename T1, typename T2, typename T3, typename L1, typename L2, typename L3,
+          typename M1=std::enable_if_t<std::is_integral<T1>::value>,
+          typename M2=std::enable_if_t<std::is_integral<T2>::value>,
+          typename M3=std::enable_if_t<std::is_integral<T3>::value> >
+void For (Box const& box1, T1 ncomp1, L1&& f1,
+          Box const& box2, T2 ncomp2, L2&& f2,
+          Box const& box3, T3 ncomp3, L3&& f3) noexcept
+{
+    amrex::ignore_unused(MT);
     For(box1, ncomp1, std::forward<L1>(f1));
     For(box2, ncomp2, std::forward<L2>(f2));
     For(box3, ncomp3, std::forward<L3>(f3));
@@ -241,6 +399,21 @@ void For (Gpu::KernelInfo const&,
         box3,ncomp3,std::forward<L3>(f3));
 }
 
+template <int MT, typename T1, typename T2, typename T3, typename L1, typename L2, typename L3,
+          typename M1=std::enable_if_t<std::is_integral<T1>::value>,
+          typename M2=std::enable_if_t<std::is_integral<T2>::value>,
+          typename M3=std::enable_if_t<std::is_integral<T3>::value> >
+void For (Gpu::KernelInfo const&,
+          Box const& box1, T1 ncomp1, L1&& f1,
+          Box const& box2, T2 ncomp2, L2&& f2,
+          Box const& box3, T3 ncomp3, L3&& f3) noexcept
+{
+    amrex::ignore_unused(MT);
+    For(box1,ncomp1,std::forward<L1>(f1),
+        box2,ncomp2,std::forward<L2>(f2),
+        box3,ncomp3,std::forward<L3>(f3));
+}
+
 template <typename L1, typename L2>
 void ParallelFor (Box const& box1, Box const& box2, L1&& f1, L2&& f2) noexcept
 {
@@ -248,9 +421,24 @@ void ParallelFor (Box const& box1, Box const& box2, L1&& f1, L2&& f2) noexcept
     ParallelFor(box2, std::forward<L2>(f2));
 }
 
+template <int MT, typename L1, typename L2>
+void ParallelFor (Box const& box1, Box const& box2, L1&& f1, L2&& f2) noexcept
+{
+    amrex::ignore_unused(MT);
+    ParallelFor(box1, std::forward<L1>(f1));
+    ParallelFor(box2, std::forward<L2>(f2));
+}
+
 template <typename L1, typename L2>
 void ParallelFor (Gpu::KernelInfo const&, Box const& box1, Box const& box2, L1&& f1, L2&& f2) noexcept
 {
+    ParallelFor(box1,box2,f1,f2);
+}
+
+template <int MT, typename L1, typename L2>
+void ParallelFor (Gpu::KernelInfo const&, Box const& box1, Box const& box2, L1&& f1, L2&& f2) noexcept
+{
+    amrex::ignore_unused(MT);
     ParallelFor(box1,box2,f1,f2);
 }
 
@@ -262,9 +450,25 @@ void ParallelFor (Box const& box1, Box const& box2, Box const& box3, L1&& f1, L2
     ParallelFor(box3, std::forward<L3>(f3));
 }
 
+template <int MT, typename L1, typename L2, typename L3>
+void ParallelFor (Box const& box1, Box const& box2, Box const& box3, L1&& f1, L2&& f2, L3&& f3) noexcept
+{
+    amrex::ignore_unused(MT);
+    ParallelFor(box1, std::forward<L1>(f1));
+    ParallelFor(box2, std::forward<L2>(f2));
+    ParallelFor(box3, std::forward<L3>(f3));
+}
+
 template <typename L1, typename L2, typename L3>
 void ParallelFor (Gpu::KernelInfo const&, Box const& box1, Box const& box2, Box const& box3, L1&& f1, L2&& f2, L3&& f3) noexcept
 {
+    ParallelFor(box1,box2,box3,std::forward<L1>(f1),std::forward<L2>(f2),std::forward<L3>(f3));
+}
+
+template <int MT, typename L1, typename L2, typename L3>
+void ParallelFor (Gpu::KernelInfo const&, Box const& box1, Box const& box2, Box const& box3, L1&& f1, L2&& f2, L3&& f3) noexcept
+{
+    amrex::ignore_unused(MT);
     ParallelFor(box1,box2,box3,std::forward<L1>(f1),std::forward<L2>(f2),std::forward<L3>(f3));
 }
 
@@ -274,6 +478,17 @@ template <typename T1, typename T2, typename L1, typename L2,
 void ParallelFor (Box const& box1, T1 ncomp1, L1&& f1,
                   Box const& box2, T2 ncomp2, L2&& f2) noexcept
 {
+    ParallelFor(box1, ncomp1, std::forward<L1>(f1));
+    ParallelFor(box2, ncomp2, std::forward<L2>(f2));
+}
+
+template <int MT, typename T1, typename T2, typename L1, typename L2,
+          typename M1=std::enable_if_t<std::is_integral<T1>::value>,
+          typename M2=std::enable_if_t<std::is_integral<T2>::value> >
+void ParallelFor (Box const& box1, T1 ncomp1, L1&& f1,
+                  Box const& box2, T2 ncomp2, L2&& f2) noexcept
+{
+    amrex::ignore_unused(MT);
     ParallelFor(box1, ncomp1, std::forward<L1>(f1));
     ParallelFor(box2, ncomp2, std::forward<L2>(f2));
 }
@@ -289,6 +504,18 @@ void ParallelFor (Gpu::KernelInfo const&,
                 box2,ncomp2,std::forward<L2>(f2));
 }
 
+template <int MT, typename T1, typename T2, typename L1, typename L2,
+          typename M1=std::enable_if_t<std::is_integral<T1>::value>,
+          typename M2=std::enable_if_t<std::is_integral<T2>::value> >
+void ParallelFor (Gpu::KernelInfo const&,
+                  Box const& box1, T1 ncomp1, L1&& f1,
+                  Box const& box2, T2 ncomp2, L2&& f2) noexcept
+{
+    amrex::ignore_unused(MT);
+    ParallelFor(box1,ncomp1,std::forward<L1>(f1),
+                box2,ncomp2,std::forward<L2>(f2));
+}
+
 template <typename T1, typename T2, typename T3, typename L1, typename L2, typename L3,
           typename M1=std::enable_if_t<std::is_integral<T1>::value>,
           typename M2=std::enable_if_t<std::is_integral<T2>::value>,
@@ -297,6 +524,20 @@ void ParallelFor (Box const& box1, T1 ncomp1, L1&& f1,
                   Box const& box2, T2 ncomp2, L2&& f2,
                   Box const& box3, T3 ncomp3, L3&& f3) noexcept
 {
+    ParallelFor(box1, ncomp1, std::forward<L1>(f1));
+    ParallelFor(box2, ncomp2, std::forward<L2>(f2));
+    ParallelFor(box3, ncomp3, std::forward<L3>(f3));
+}
+
+template <int MT, typename T1, typename T2, typename T3, typename L1, typename L2, typename L3,
+          typename M1=std::enable_if_t<std::is_integral<T1>::value>,
+          typename M2=std::enable_if_t<std::is_integral<T2>::value>,
+          typename M3=std::enable_if_t<std::is_integral<T3>::value> >
+void ParallelFor (Box const& box1, T1 ncomp1, L1&& f1,
+                  Box const& box2, T2 ncomp2, L2&& f2,
+                  Box const& box3, T3 ncomp3, L3&& f3) noexcept
+{
+    amrex::ignore_unused(MT);
     ParallelFor(box1, ncomp1, std::forward<L1>(f1));
     ParallelFor(box2, ncomp2, std::forward<L2>(f2));
     ParallelFor(box3, ncomp3, std::forward<L3>(f3));
@@ -316,9 +557,31 @@ void ParallelFor (Gpu::KernelInfo const&,
                 box3, ncomp3, std::forward<L3>(f3));
 }
 
+template <int MT, typename T1, typename T2, typename T3, typename L1, typename L2, typename L3,
+          typename M1=std::enable_if_t<std::is_integral<T1>::value>,
+          typename M2=std::enable_if_t<std::is_integral<T2>::value>,
+          typename M3=std::enable_if_t<std::is_integral<T3>::value> >
+void ParallelFor (Gpu::KernelInfo const&,
+                  Box const& box1, T1 ncomp1, L1&& f1,
+                  Box const& box2, T2 ncomp2, L2&& f2,
+                  Box const& box3, T3 ncomp3, L3&& f3) noexcept
+{
+    amrex::ignore_unused(MT);
+    ParallelFor(box1, ncomp1, std::forward<L1>(f1),
+                box2, ncomp2, std::forward<L2>(f2),
+                box3, ncomp3, std::forward<L3>(f3));
+}
+
 template <typename T, typename L, typename M=std::enable_if_t<std::is_integral<T>::value> >
 void HostDeviceParallelFor (T n, L&& f) noexcept
 {
+    ParallelFor(n,std::forward<L>(f));
+}
+
+template <int MT, typename T, typename L, typename M=std::enable_if_t<std::is_integral<T>::value> >
+void HostDeviceParallelFor (T n, L&& f) noexcept
+{
+    amrex::ignore_unused(MT);
     ParallelFor(n,std::forward<L>(f));
 }
 
@@ -328,15 +591,36 @@ void HostDeviceParallelFor (Box const& box, L&& f) noexcept
     ParallelFor(box,std::forward<L>(f));
 }
 
+template <int MT, typename L>
+void HostDeviceParallelFor (Box const& box, L&& f) noexcept
+{
+    amrex::ignore_unused(MT);
+    ParallelFor(box,std::forward<L>(f));
+}
+
 template <typename T, typename L, typename M=std::enable_if_t<std::is_integral<T>::value> >
 void HostDeviceParallelFor (Box const& box, T ncomp, L&& f) noexcept
 {
     ParallelFor(box,ncomp,std::forward<L>(f));
 }
 
+template <int MT, typename T, typename L, typename M=std::enable_if_t<std::is_integral<T>::value> >
+void HostDeviceParallelFor (Box const& box, T ncomp, L&& f) noexcept
+{
+    amrex::ignore_unused(MT);
+    ParallelFor(box,ncomp,std::forward<L>(f));
+}
+
 template <typename L1, typename L2>
 void HostDeviceParallelFor (Box const& box1, Box const& box2, L1&& f1, L2&& f2) noexcept
 {
+    ParallelFor(box1,box2,std::forward<L1>(f1),std::forward<L2>(f2));
+}
+
+template <int MT, typename L1, typename L2>
+void HostDeviceParallelFor (Box const& box1, Box const& box2, L1&& f1, L2&& f2) noexcept
+{
+    amrex::ignore_unused(MT);
     ParallelFor(box1,box2,std::forward<L1>(f1),std::forward<L2>(f2));
 }
 
@@ -347,12 +631,30 @@ void HostDeviceParallelFor (Box const& box1, Box const& box2, Box const& box3,
     ParallelFor(box1,box2,box3,std::forward<L1>(f1),std::forward<L2>(f2),std::forward<L3>(f3));
 }
 
+template <int MT, typename L1, typename L2, typename L3>
+void HostDeviceParallelFor (Box const& box1, Box const& box2, Box const& box3,
+                            L1&& f1, L2&& f2, L3&& f3) noexcept
+{
+    amrex::ignore_unused(MT);
+    ParallelFor(box1,box2,box3,std::forward<L1>(f1),std::forward<L2>(f2),std::forward<L3>(f3));
+}
+
 template <typename T1, typename T2, typename L1, typename L2,
           typename M1=std::enable_if_t<std::is_integral<T1>::value>,
           typename M2=std::enable_if_t<std::is_integral<T2>::value> >
 void HostDeviceParallelFor (Box const& box1, T1 ncomp1, L1&& f1,
                             Box const& box2, T2 ncomp2, L2&& f2) noexcept
 {
+    ParallelFor(box1,ncomp1,std::forward<L1>(f1),box2,ncomp2,std::forward<L2>(f2));
+}
+
+template <int MT, typename T1, typename T2, typename L1, typename L2,
+          typename M1=std::enable_if_t<std::is_integral<T1>::value>,
+          typename M2=std::enable_if_t<std::is_integral<T2>::value> >
+void HostDeviceParallelFor (Box const& box1, T1 ncomp1, L1&& f1,
+                            Box const& box2, T2 ncomp2, L2&& f2) noexcept
+{
+    amrex::ignore_unused(MT);
     ParallelFor(box1,ncomp1,std::forward<L1>(f1),box2,ncomp2,std::forward<L2>(f2));
 }
 
@@ -369,9 +671,30 @@ void HostDeviceParallelFor (Box const& box1, T1 ncomp1, L1&& f1,
                 box3,ncomp3,std::forward<L3>(f3));
 }
 
+template <int MT, typename T1, typename T2, typename T3, typename L1, typename L2, typename L3,
+          typename M1=std::enable_if_t<std::is_integral<T1>::value>,
+          typename M2=std::enable_if_t<std::is_integral<T2>::value>,
+          typename M3=std::enable_if_t<std::is_integral<T3>::value> >
+void HostDeviceParallelFor (Box const& box1, T1 ncomp1, L1&& f1,
+                            Box const& box2, T2 ncomp2, L2&& f2,
+                            Box const& box3, T3 ncomp3, L3&& f3) noexcept
+{
+    amrex::ignore_unused(MT);
+    ParallelFor(box1,ncomp1,std::forward<L1>(f1),
+                box2,ncomp2,std::forward<L2>(f2),
+                box3,ncomp3,std::forward<L3>(f3));
+}
+
 template <typename T, typename L, typename M=std::enable_if_t<std::is_integral<T>::value> >
 void HostDeviceFor (T n, L&& f) noexcept
 {
+    For(n,std::forward<L>(f));
+}
+
+template <int MT, typename T, typename L, typename M=std::enable_if_t<std::is_integral<T>::value> >
+void HostDeviceFor (T n, L&& f) noexcept
+{
+    amrex::ignore_unused(MT);
     For(n,std::forward<L>(f));
 }
 
@@ -381,15 +704,36 @@ void HostDeviceFor (Box const& box, L&& f) noexcept
     For(box,std::forward<L>(f));
 }
 
+template <int MT, typename L>
+void HostDeviceFor (Box const& box, L&& f) noexcept
+{
+    amrex::ignore_unused(MT);
+    For(box,std::forward<L>(f));
+}
+
 template <typename T, typename L, typename M=std::enable_if_t<std::is_integral<T>::value> >
 void HostDeviceFor (Box const& box, T ncomp, L&& f) noexcept
 {
     For(box,ncomp,std::forward<L>(f));
 }
 
+template <int MT, typename T, typename L, typename M=std::enable_if_t<std::is_integral<T>::value> >
+void HostDeviceFor (Box const& box, T ncomp, L&& f) noexcept
+{
+    amrex::ignore_unused(MT);
+    For(box,ncomp,std::forward<L>(f));
+}
+
 template <typename L1, typename L2>
 void HostDeviceFor (Box const& box1, Box const& box2, L1&& f1, L2&& f2) noexcept
 {
+    For(box1,box2,std::forward<L1>(f1),std::forward<L2>(f2));
+}
+
+template <int MT, typename L1, typename L2>
+void HostDeviceFor (Box const& box1, Box const& box2, L1&& f1, L2&& f2) noexcept
+{
+    amrex::ignore_unused(MT);
     For(box1,box2,std::forward<L1>(f1),std::forward<L2>(f2));
 }
 
@@ -400,12 +744,30 @@ void HostDeviceFor (Box const& box1, Box const& box2, Box const& box3,
     For(box1,box2,box3,std::forward<L1>(f1),std::forward<L2>(f2),std::forward<L3>(f3));
 }
 
+template <int MT, typename L1, typename L2, typename L3>
+void HostDeviceFor (Box const& box1, Box const& box2, Box const& box3,
+                    L1&& f1, L2&& f2, L3&& f3) noexcept
+{
+    amrex::ignore_unused(MT);
+    For(box1,box2,box3,std::forward<L1>(f1),std::forward<L2>(f2),std::forward<L3>(f3));
+}
+
 template <typename T1, typename T2, typename L1, typename L2,
           typename M1=std::enable_if_t<std::is_integral<T1>::value>,
           typename M2=std::enable_if_t<std::is_integral<T2>::value> >
 void HostDeviceFor (Box const& box1, T1 ncomp1, L1&& f1,
                     Box const& box2, T2 ncomp2, L2&& f2) noexcept
 {
+    For(box1,ncomp1,std::forward<L1>(f1),box2,ncomp2,std::forward<L2>(f2));
+}
+
+template <int MT, typename T1, typename T2, typename L1, typename L2,
+          typename M1=std::enable_if_t<std::is_integral<T1>::value>,
+          typename M2=std::enable_if_t<std::is_integral<T2>::value> >
+void HostDeviceFor (Box const& box1, T1 ncomp1, L1&& f1,
+                    Box const& box2, T2 ncomp2, L2&& f2) noexcept
+{
+    amrex::ignore_unused(MT);
     For(box1,ncomp1,std::forward<L1>(f1),box2,ncomp2,std::forward<L2>(f2));
 }
 
@@ -422,9 +784,30 @@ void HostDeviceFor (Box const& box1, T1 ncomp1, L1&& f1,
         box3,ncomp3,std::forward<L3>(f3));
 }
 
+template <int MT, typename T1, typename T2, typename T3, typename L1, typename L2, typename L3,
+          typename M1=std::enable_if_t<std::is_integral<T1>::value>,
+          typename M2=std::enable_if_t<std::is_integral<T2>::value>,
+          typename M3=std::enable_if_t<std::is_integral<T3>::value> >
+void HostDeviceFor (Box const& box1, T1 ncomp1, L1&& f1,
+                    Box const& box2, T2 ncomp2, L2&& f2,
+                    Box const& box3, T3 ncomp3, L3&& f3) noexcept
+{
+    amrex::ignore_unused(MT);
+    For(box1,ncomp1,std::forward<L1>(f1),
+        box2,ncomp2,std::forward<L2>(f2),
+        box3,ncomp3,std::forward<L3>(f3));
+}
+
 template <typename T, typename L, typename M=std::enable_if_t<std::is_integral<T>::value> >
 void HostDeviceParallelFor (Gpu::KernelInfo const&, T n, L&& f) noexcept
 {
+    ParallelFor(n,std::forward<L>(f));
+}
+
+template <int MT, typename T, typename L, typename M=std::enable_if_t<std::is_integral<T>::value> >
+void HostDeviceParallelFor (Gpu::KernelInfo const&, T n, L&& f) noexcept
+{
+    amrex::ignore_unused(MT);
     ParallelFor(n,std::forward<L>(f));
 }
 
@@ -434,15 +817,36 @@ void HostDeviceParallelFor (Gpu::KernelInfo const&, Box const& box, L&& f) noexc
     ParallelFor(box,std::forward<L>(f));
 }
 
+template <int MT, typename L>
+void HostDeviceParallelFor (Gpu::KernelInfo const&, Box const& box, L&& f) noexcept
+{
+    amrex::ignore_unused(MT);
+    ParallelFor(box,std::forward<L>(f));
+}
+
 template <typename T, typename L, typename M=std::enable_if_t<std::is_integral<T>::value> >
 void HostDeviceParallelFor (Gpu::KernelInfo const&, Box const& box, T ncomp, L&& f) noexcept
 {
     ParallelFor(box,ncomp,std::forward<L>(f));
 }
 
+template <int MT, typename T, typename L, typename M=std::enable_if_t<std::is_integral<T>::value> >
+void HostDeviceParallelFor (Gpu::KernelInfo const&, Box const& box, T ncomp, L&& f) noexcept
+{
+    amrex::ignore_unused(MT);
+    ParallelFor(box,ncomp,std::forward<L>(f));
+}
+
 template <typename L1, typename L2>
 void HostDeviceParallelFor (Gpu::KernelInfo const&, Box const& box1, Box const& box2, L1&& f1, L2&& f2) noexcept
 {
+    ParallelFor(box1,box2,std::forward<L1>(f1),std::forward<L2>(f2));
+}
+
+template <int MT, typename L1, typename L2>
+void HostDeviceParallelFor (Gpu::KernelInfo const&, Box const& box1, Box const& box2, L1&& f1, L2&& f2) noexcept
+{
+    amrex::ignore_unused(MT);
     ParallelFor(box1,box2,std::forward<L1>(f1),std::forward<L2>(f2));
 }
 
@@ -454,6 +858,15 @@ void HostDeviceParallelFor (Gpu::KernelInfo const&,
     ParallelFor(box1,box2,box3,std::forward<L1>(f1),std::forward<L2>(f2),std::forward<L3>(f3));
 }
 
+template <int MT, typename L1, typename L2, typename L3>
+void HostDeviceParallelFor (Gpu::KernelInfo const&,
+                            Box const& box1, Box const& box2, Box const& box3,
+                            L1&& f1, L2&& f2, L3&& f3) noexcept
+{
+    amrex::ignore_unused(MT);
+    ParallelFor(box1,box2,box3,std::forward<L1>(f1),std::forward<L2>(f2),std::forward<L3>(f3));
+}
+
 template <typename T1, typename T2, typename L1, typename L2,
           typename M1=std::enable_if_t<std::is_integral<T1>::value>,
           typename M2=std::enable_if_t<std::is_integral<T2>::value> >
@@ -461,6 +874,17 @@ void HostDeviceParallelFor (Gpu::KernelInfo const&,
                             Box const& box1, T1 ncomp1, L1&& f1,
                             Box const& box2, T2 ncomp2, L2&& f2) noexcept
 {
+    ParallelFor(box1,ncomp1,std::forward<L1>(f1),box2,ncomp2,std::forward<L2>(f2));
+}
+
+template <int MT, typename T1, typename T2, typename L1, typename L2,
+          typename M1=std::enable_if_t<std::is_integral<T1>::value>,
+          typename M2=std::enable_if_t<std::is_integral<T2>::value> >
+void HostDeviceParallelFor (Gpu::KernelInfo const&,
+                            Box const& box1, T1 ncomp1, L1&& f1,
+                            Box const& box2, T2 ncomp2, L2&& f2) noexcept
+{
+    amrex::ignore_unused(MT);
     ParallelFor(box1,ncomp1,std::forward<L1>(f1),box2,ncomp2,std::forward<L2>(f2));
 }
 
@@ -478,9 +902,31 @@ void HostDeviceParallelFor (Gpu::KernelInfo const&,
                 box3,ncomp3,std::forward<L3>(f3));
 }
 
+template <int MT, typename T1, typename T2, typename T3, typename L1, typename L2, typename L3,
+          typename M1=std::enable_if_t<std::is_integral<T1>::value>,
+          typename M2=std::enable_if_t<std::is_integral<T2>::value>,
+          typename M3=std::enable_if_t<std::is_integral<T3>::value> >
+void HostDeviceParallelFor (Gpu::KernelInfo const&,
+                            Box const& box1, T1 ncomp1, L1&& f1,
+                            Box const& box2, T2 ncomp2, L2&& f2,
+                            Box const& box3, T3 ncomp3, L3&& f3) noexcept
+{
+    amrex::ignore_unused(MT);
+    ParallelFor(box1,ncomp1,std::forward<L1>(f1),
+                box2,ncomp2,std::forward<L2>(f2),
+                box3,ncomp3,std::forward<L3>(f3));
+}
+
 template <typename T, typename L, typename M=std::enable_if_t<std::is_integral<T>::value> >
 void HostDeviceFor (Gpu::KernelInfo const&, T n, L&& f) noexcept
 {
+    For(n,std::forward<L>(f));
+}
+
+template <int MT, typename T, typename L, typename M=std::enable_if_t<std::is_integral<T>::value> >
+void HostDeviceFor (Gpu::KernelInfo const&, T n, L&& f) noexcept
+{
+    amrex::ignore_unused(MT);
     For(n,std::forward<L>(f));
 }
 
@@ -490,9 +936,23 @@ void HostDeviceFor (Gpu::KernelInfo const&, Box const& box, L&& f) noexcept
     For(box,std::forward<L>(f));
 }
 
+template <int MT, typename L>
+void HostDeviceFor (Gpu::KernelInfo const&, Box const& box, L&& f) noexcept
+{
+    amrex::ignore_unused(MT);
+    For(box,std::forward<L>(f));
+}
+
 template <typename T, typename L, typename M=std::enable_if_t<std::is_integral<T>::value> >
 void HostDeviceFor (Gpu::KernelInfo const&, Box const& box, T ncomp, L&& f) noexcept
 {
+    For(box,ncomp,std::forward<L>(f));
+}
+
+template <int MT, typename T, typename L, typename M=std::enable_if_t<std::is_integral<T>::value> >
+void HostDeviceFor (Gpu::KernelInfo const&, Box const& box, T ncomp, L&& f) noexcept
+{
+    amrex::ignore_unused(MT);
     For(box,ncomp,std::forward<L>(f));
 }
 
@@ -502,11 +962,27 @@ void HostDeviceFor (Gpu::KernelInfo const&, Box const& box1, Box const& box2, L1
     For(box1,box2,std::forward<L1>(f1),std::forward<L2>(f2));
 }
 
+template <int MT, typename L1, typename L2>
+void HostDeviceFor (Gpu::KernelInfo const&, Box const& box1, Box const& box2, L1&& f1, L2&& f2) noexcept
+{
+    amrex::ignore_unused(MT);
+    For(box1,box2,std::forward<L1>(f1),std::forward<L2>(f2));
+}
+
 template <typename L1, typename L2, typename L3>
 void HostDeviceFor (Gpu::KernelInfo const&,
                     Box const& box1, Box const& box2, Box const& box3,
                     L1&& f1, L2&& f2, L3&& f3) noexcept
 {
+    For(box1,box2,box3,std::forward<L1>(f1),std::forward<L2>(f2),std::forward<L3>(f3));
+}
+
+template <int MT, typename L1, typename L2, typename L3>
+void HostDeviceFor (Gpu::KernelInfo const&,
+                    Box const& box1, Box const& box2, Box const& box3,
+                    L1&& f1, L2&& f2, L3&& f3) noexcept
+{
+    amrex::ignore_unused(MT);
     For(box1,box2,box3,std::forward<L1>(f1),std::forward<L2>(f2),std::forward<L3>(f3));
 }
 
@@ -520,6 +996,17 @@ void HostDeviceFor (Gpu::KernelInfo const&,
     For(box1,ncomp1,std::forward<L1>(f1),box2,ncomp2,std::forward<L2>(f2));
 }
 
+template <int MT, typename T1, typename T2, typename L1, typename L2,
+          typename M1=std::enable_if_t<std::is_integral<T1>::value>,
+          typename M2=std::enable_if_t<std::is_integral<T2>::value> >
+void HostDeviceFor (Gpu::KernelInfo const&,
+                    Box const& box1, T1 ncomp1, L1&& f1,
+                    Box const& box2, T2 ncomp2, L2&& f2) noexcept
+{
+    amrex::ignore_unused(MT);
+    For(box1,ncomp1,std::forward<L1>(f1),box2,ncomp2,std::forward<L2>(f2));
+}
+
 template <typename T1, typename T2, typename T3, typename L1, typename L2, typename L3,
           typename M1=std::enable_if_t<std::is_integral<T1>::value>,
           typename M2=std::enable_if_t<std::is_integral<T2>::value>,
@@ -529,6 +1016,21 @@ void HostDeviceFor (Gpu::KernelInfo const&,
                     Box const& box2, T2 ncomp2, L2&& f2,
                     Box const& box3, T3 ncomp3, L3&& f3) noexcept
 {
+    For(box1,ncomp1,std::forward<L1>(f1),
+        box2,ncomp2,std::forward<L2>(f2),
+        box3,ncomp3,std::forward<L3>(f3));
+}
+
+template <int MT, typename T1, typename T2, typename T3, typename L1, typename L2, typename L3,
+          typename M1=std::enable_if_t<std::is_integral<T1>::value>,
+          typename M2=std::enable_if_t<std::is_integral<T2>::value>,
+          typename M3=std::enable_if_t<std::is_integral<T3>::value> >
+void HostDeviceFor (Gpu::KernelInfo const&,
+                    Box const& box1, T1 ncomp1, L1&& f1,
+                    Box const& box2, T2 ncomp2, L2&& f2,
+                    Box const& box3, T3 ncomp3, L3&& f3) noexcept
+{
+    amrex::ignore_unused(MT);
     For(box1,ncomp1,std::forward<L1>(f1),
         box2,ncomp2,std::forward<L2>(f2),
         box3,ncomp3,std::forward<L3>(f3));

--- a/Src/Base/AMReX_GpuLaunchFunctsG.H
+++ b/Src/Base/AMReX_GpuLaunchFunctsG.H
@@ -64,11 +64,24 @@ void launch (int nblocks, int nthreads_per_block, gpuStream_t stream, L&& f) noe
     }
 }
 
-template<typename T, typename L>
+template <int MT, typename L>
+void launch (int nblocks, std::size_t shared_mem_bytes, gpuStream_t stream,
+             L&& f) noexcept
+{
+    launch(nblocks, MT, shared_mem_bytes, stream, std::forward<L>(f));
+}
+
+template <int MT, typename L>
+void launch (int nblocks, gpuStream_t stream, L&& f) noexcept
+{
+    launch(nblocks, MT, stream, std::forward<L>(f));
+}
+
+template<int MT, typename T, typename L>
 void launch (T const& n, L&& f) noexcept
 {
     if (amrex::isEmpty(n)) return;
-    const auto ec = Gpu::ExecutionConfig(n);
+    const auto ec = Gpu::makeExecutionConfig<MT>(n);
     int nthreads_per_block = ec.numThreads.x;
     int nthreads_total = nthreads_per_block * ec.numBlocks.x;
     auto& q = Gpu::Device::streamQueue();
@@ -139,11 +152,11 @@ namespace detail {
     }
 }
 
-template <typename T, typename L, typename M=std::enable_if_t<std::is_integral<T>::value> >
+template <int MT, typename T, typename L, typename M=std::enable_if_t<std::is_integral<T>::value> >
 void ParallelFor (Gpu::KernelInfo const& info, T n, L&& f) noexcept
 {
     if (amrex::isEmpty(n)) return;
-    const auto ec = Gpu::ExecutionConfig(n);
+    const auto ec = Gpu::makeExecutionConfig<MT>(n);
     int nthreads_per_block = ec.numThreads.x;
     int nthreads_total = nthreads_per_block * ec.numBlocks.x;
     auto& q = Gpu::Device::streamQueue();
@@ -186,7 +199,7 @@ void ParallelFor (Gpu::KernelInfo const& info, T n, L&& f) noexcept
     }
 }
 
-template <typename L>
+template <int MT, typename L>
 void ParallelFor (Gpu::KernelInfo const& info, Box const& box, L&& f) noexcept
 {
     if (amrex::isEmpty(box)) return;
@@ -195,7 +208,7 @@ void ParallelFor (Gpu::KernelInfo const& info, Box const& box, L&& f) noexcept
     const auto len = amrex::length(box);
     const auto lenxy = len.x*len.y;
     const auto lenx = len.x;
-    const auto ec = Gpu::ExecutionConfig(ncells);
+    const auto ec = Gpu::makeExecutionConfig<MT>(ncells);
     int nthreads_per_block = ec.numThreads.x;
     int nthreads_total = nthreads_per_block * ec.numBlocks.x;
     auto& q = Gpu::Device::streamQueue();
@@ -250,7 +263,7 @@ void ParallelFor (Gpu::KernelInfo const& info, Box const& box, L&& f) noexcept
     }
 }
 
-template <typename T, typename L, typename M=std::enable_if_t<std::is_integral<T>::value> >
+template <int MT, typename T, typename L, typename M=std::enable_if_t<std::is_integral<T>::value> >
 void ParallelFor (Gpu::KernelInfo const& info, Box const& box, T ncomp, L&& f) noexcept
 {
     if (amrex::isEmpty(box)) return;
@@ -259,7 +272,7 @@ void ParallelFor (Gpu::KernelInfo const& info, Box const& box, T ncomp, L&& f) n
     const auto len = amrex::length(box);
     const auto lenxy = len.x*len.y;
     const auto lenx = len.x;
-    const auto ec = Gpu::ExecutionConfig(ncells);
+    const auto ec = Gpu::makeExecutionConfig<MT>(ncells);
     int nthreads_per_block = ec.numThreads.x;
     int nthreads_total = nthreads_per_block * ec.numBlocks.x;
     auto& q = Gpu::Device::streamQueue();
@@ -437,7 +450,7 @@ void ParallelForRNG (Box const& box, T ncomp, L&& f) noexcept
     }
 }
 
-template <typename L1, typename L2>
+template <int MT, typename L1, typename L2>
 void ParallelFor (Gpu::KernelInfo const& /*info*/, Box const& box1, Box const& box2, L1&& f1, L2&& f2) noexcept
 {
     if (amrex::isEmpty(box1) && amrex::isEmpty(box2)) return;
@@ -452,7 +465,7 @@ void ParallelFor (Gpu::KernelInfo const& /*info*/, Box const& box1, Box const& b
     const auto len2xy = len2.x*len2.y;
     const auto len1x = len1.x;
     const auto len2x = len2.x;
-    const auto ec = Gpu::ExecutionConfig(ncells);
+    const auto ec = Gpu::makeExecutionConfig<MT>(ncells);
     int nthreads_per_block = ec.numThreads.x;
     int nthreads_total = nthreads_per_block * ec.numBlocks.x;
     auto& q = Gpu::Device::streamQueue();
@@ -491,7 +504,7 @@ void ParallelFor (Gpu::KernelInfo const& /*info*/, Box const& box1, Box const& b
     }
 }
 
-template <typename L1, typename L2, typename L3>
+template <int MT, typename L1, typename L2, typename L3>
 void ParallelFor (Gpu::KernelInfo const& /*info*/,
                   Box const& box1, Box const& box2, Box const& box3,
                   L1&& f1, L2&& f2, L3&& f3) noexcept
@@ -513,7 +526,7 @@ void ParallelFor (Gpu::KernelInfo const& /*info*/,
     const auto len1x = len1.x;
     const auto len2x = len2.x;
     const auto len3x = len3.x;
-    const auto ec = Gpu::ExecutionConfig(ncells);
+    const auto ec = Gpu::makeExecutionConfig<MT>(ncells);
     int nthreads_per_block = ec.numThreads.x;
     int nthreads_total = nthreads_per_block * ec.numBlocks.x;
     auto& q = Gpu::Device::streamQueue();
@@ -561,7 +574,7 @@ void ParallelFor (Gpu::KernelInfo const& /*info*/,
     }
 }
 
-template <typename T1, typename T2, typename L1, typename L2,
+template <int MT, typename T1, typename T2, typename L1, typename L2,
           typename M1=std::enable_if_t<std::is_integral<T1>::value>,
           typename M2=std::enable_if_t<std::is_integral<T2>::value> >
 void ParallelFor (Gpu::KernelInfo const& /*info*/,
@@ -580,7 +593,7 @@ void ParallelFor (Gpu::KernelInfo const& /*info*/,
     const auto len2xy = len2.x*len2.y;
     const auto len1x = len1.x;
     const auto len2x = len2.x;
-    const auto ec = Gpu::ExecutionConfig(ncells);
+    const auto ec = Gpu::makeExecutionConfig<MT>(ncells);
     int nthreads_per_block = ec.numThreads.x;
     int nthreads_total = nthreads_per_block * ec.numBlocks.x;
     auto& q = Gpu::Device::streamQueue();
@@ -623,7 +636,7 @@ void ParallelFor (Gpu::KernelInfo const& /*info*/,
     }
 }
 
-template <typename T1, typename T2, typename T3, typename L1, typename L2, typename L3,
+template <int MT, typename T1, typename T2, typename T3, typename L1, typename L2, typename L3,
           typename M1=std::enable_if_t<std::is_integral<T1>::value>,
           typename M2=std::enable_if_t<std::is_integral<T2>::value>,
           typename M3=std::enable_if_t<std::is_integral<T3>::value> >
@@ -649,7 +662,7 @@ void ParallelFor (Gpu::KernelInfo const& /*info*/,
     const auto len1x = len1.x;
     const auto len2x = len2.x;
     const auto len3x = len3.x;
-    const auto ec = Gpu::ExecutionConfig(ncells);
+    const auto ec = Gpu::makeExecutionConfig<MT>(ncells);
     int nthreads_per_block = ec.numThreads.x;
     int nthreads_total = nthreads_per_block * ec.numBlocks.x;
     auto& q = Gpu::Device::streamQueue();
@@ -709,8 +722,25 @@ void ParallelFor (Gpu::KernelInfo const& /*info*/,
 template <typename L>
 void single_task (gpuStream_t stream, L&& f) noexcept
 {
-    AMREX_LAUNCH_KERNEL(1, 1, 0, stream,
+    AMREX_LAUNCH_KERNEL(Gpu::Device::warp_size, 1, 1, 0, stream,
                         [=] AMREX_GPU_DEVICE () noexcept {f();});
+    AMREX_GPU_ERROR_CHECK();
+}
+
+template <int MT, typename L>
+void launch (int nblocks, std::size_t shared_mem_bytes, gpuStream_t stream,
+             L&& f) noexcept
+{
+    AMREX_LAUNCH_KERNEL(MT, nblocks, MT, shared_mem_bytes, stream,
+                        [=] AMREX_GPU_DEVICE () noexcept { f(); });
+    AMREX_GPU_ERROR_CHECK();
+}
+
+template <int MT, typename L>
+void launch (int nblocks, gpuStream_t stream, L&& f) noexcept
+{
+    AMREX_LAUNCH_KERNEL(MT, nblocks, MT, 0, stream,
+                        [=] AMREX_GPU_DEVICE () noexcept { f(); });
     AMREX_GPU_ERROR_CHECK();
 }
 
@@ -718,7 +748,8 @@ template<typename L>
 void launch (int nblocks, int nthreads_per_block, std::size_t shared_mem_bytes,
              gpuStream_t stream, L&& f) noexcept
 {
-    AMREX_LAUNCH_KERNEL(nblocks, nthreads_per_block, shared_mem_bytes,
+    AMREX_ASSERT(nthreads_per_block <= AMREX_GPU_MAX_THREADS);
+    AMREX_LAUNCH_KERNEL(AMREX_GPU_MAX_THREADS, nblocks, nthreads_per_block, shared_mem_bytes,
                         stream, [=] AMREX_GPU_DEVICE () noexcept { f(); });
     AMREX_GPU_ERROR_CHECK();
 }
@@ -729,12 +760,12 @@ void launch (int nblocks, int nthreads_per_block, gpuStream_t stream, L&& f) noe
     launch(nblocks, nthreads_per_block, 0, stream, std::forward<L>(f));
 }
 
-template<typename T, typename L>
+template<int MT, typename T, typename L>
 void launch (T const& n, L&& f) noexcept
 {
     if (amrex::isEmpty(n)) return;
-    const auto ec = Gpu::ExecutionConfig(n);
-    AMREX_LAUNCH_KERNEL(ec.numBlocks, ec.numThreads, 0, Gpu::gpuStream(),
+    const auto ec = Gpu::makeExecutionConfig<MT>(n);
+    AMREX_LAUNCH_KERNEL(MT, ec.numBlocks, ec.numThreads, 0, Gpu::gpuStream(),
     [=] AMREX_GPU_DEVICE () noexcept {
         for (auto const i : Gpu::Range(n)) {
             f(i);
@@ -793,13 +824,13 @@ namespace detail {
     }
 }
 
-template <typename T, typename L, typename M=std::enable_if_t<std::is_integral<T>::value> >
+template <int MT, typename T, typename L, typename M=std::enable_if_t<std::is_integral<T>::value> >
 std::enable_if_t<MaybeDeviceRunnable<L>::value>
 ParallelFor (Gpu::KernelInfo const&, T n, L&& f) noexcept
 {
     if (amrex::isEmpty(n)) return;
-    const auto ec = Gpu::ExecutionConfig(n);
-    AMREX_LAUNCH_KERNEL(ec.numBlocks, ec.numThreads, 0, Gpu::gpuStream(),
+    const auto ec = Gpu::makeExecutionConfig<MT>(n);
+    AMREX_LAUNCH_KERNEL(MT, ec.numBlocks, ec.numThreads, 0, Gpu::gpuStream(),
     [=] AMREX_GPU_DEVICE () noexcept {
         for (T i = blockDim.x*blockIdx.x+threadIdx.x, stride = blockDim.x*gridDim.x;
              i < n; i += stride) {
@@ -809,7 +840,7 @@ ParallelFor (Gpu::KernelInfo const&, T n, L&& f) noexcept
     AMREX_GPU_ERROR_CHECK();
 }
 
-template <typename L>
+template <int MT, typename L>
 std::enable_if_t<MaybeDeviceRunnable<L>::value>
 ParallelFor (Gpu::KernelInfo const&, Box const& box, L&& f) noexcept
 {
@@ -819,8 +850,8 @@ ParallelFor (Gpu::KernelInfo const&, Box const& box, L&& f) noexcept
     const auto len = amrex::length(box);
     const auto lenxy = len.x*len.y;
     const auto lenx = len.x;
-    const auto ec = Gpu::ExecutionConfig(ncells);
-    AMREX_LAUNCH_KERNEL(ec.numBlocks, ec.numThreads, 0, Gpu::gpuStream(),
+    const auto ec = Gpu::makeExecutionConfig<MT>(ncells);
+    AMREX_LAUNCH_KERNEL(MT, ec.numBlocks, ec.numThreads, 0, Gpu::gpuStream(),
     [=] AMREX_GPU_DEVICE () noexcept {
         for (int icell = blockDim.x*blockIdx.x+threadIdx.x, stride = blockDim.x*gridDim.x;
              icell < ncells; icell += stride)
@@ -837,7 +868,7 @@ ParallelFor (Gpu::KernelInfo const&, Box const& box, L&& f) noexcept
     AMREX_GPU_ERROR_CHECK();
 }
 
-template <typename T, typename L, typename M=std::enable_if_t<std::is_integral<T>::value> >
+template <int MT, typename T, typename L, typename M=std::enable_if_t<std::is_integral<T>::value> >
 std::enable_if_t<MaybeDeviceRunnable<L>::value>
 ParallelFor (Gpu::KernelInfo const&, Box const& box, T ncomp, L&& f) noexcept
 {
@@ -847,8 +878,8 @@ ParallelFor (Gpu::KernelInfo const&, Box const& box, T ncomp, L&& f) noexcept
     const auto len = amrex::length(box);
     const auto lenxy = len.x*len.y;
     const auto lenx = len.x;
-    const auto ec = Gpu::ExecutionConfig(ncells);
-    AMREX_LAUNCH_KERNEL(ec.numBlocks, ec.numThreads, 0, Gpu::gpuStream(),
+    const auto ec = Gpu::makeExecutionConfig<MT>(ncells);
+    AMREX_LAUNCH_KERNEL(MT, ec.numBlocks, ec.numThreads, 0, Gpu::gpuStream(),
     [=] AMREX_GPU_DEVICE () noexcept {
         for (int icell = blockDim.x*blockIdx.x+threadIdx.x, stride = blockDim.x*gridDim.x;
              icell < ncells; icell += stride) {
@@ -871,7 +902,8 @@ ParallelForRNG (T n, L&& f) noexcept
     if (amrex::isEmpty(n)) return;
     randState_t* rand_state = getRandState();
     const auto ec = Gpu::ExecutionConfig(n);
-    AMREX_LAUNCH_KERNEL(amrex::min(ec.numBlocks.x, Gpu::Device::maxBlocksPerLaunch()),
+    AMREX_LAUNCH_KERNEL(AMREX_GPU_MAX_THREADS,
+                        amrex::min(ec.numBlocks.x, Gpu::Device::maxBlocksPerLaunch()),
                         ec.numThreads, 0, Gpu::gpuStream(),
     [=] AMREX_GPU_DEVICE () noexcept {
         int tid = blockDim.x*blockIdx.x+threadIdx.x;
@@ -896,7 +928,8 @@ ParallelForRNG (Box const& box, L&& f) noexcept
     const auto lenxy = len.x*len.y;
     const auto lenx = len.x;
     const auto ec = Gpu::ExecutionConfig(ncells);
-    AMREX_LAUNCH_KERNEL(amrex::min(ec.numBlocks.x, Gpu::Device::maxBlocksPerLaunch()),
+    AMREX_LAUNCH_KERNEL(AMREX_GPU_MAX_THREADS,
+                        amrex::min(ec.numBlocks.x, Gpu::Device::maxBlocksPerLaunch()),
                         ec.numThreads, 0, Gpu::gpuStream(),
     [=] AMREX_GPU_DEVICE () noexcept {
         int tid = blockDim.x*blockIdx.x+threadIdx.x;
@@ -927,7 +960,8 @@ ParallelForRNG (Box const& box, T ncomp, L&& f) noexcept
     const auto lenxy = len.x*len.y;
     const auto lenx = len.x;
     const auto ec = Gpu::ExecutionConfig(ncells);
-    AMREX_LAUNCH_KERNEL(amrex::min(ec.numBlocks.x, Gpu::Device::maxBlocksPerLaunch()),
+    AMREX_LAUNCH_KERNEL(AMREX_GPU_MAX_THREADS,
+                        amrex::min(ec.numBlocks.x, Gpu::Device::maxBlocksPerLaunch()),
                         ec.numThreads, 0, Gpu::gpuStream(),
     [=] AMREX_GPU_DEVICE () noexcept {
         int tid = blockDim.x*blockIdx.x+threadIdx.x;
@@ -948,7 +982,7 @@ ParallelForRNG (Box const& box, T ncomp, L&& f) noexcept
     AMREX_GPU_ERROR_CHECK();
 }
 
-template <typename L1, typename L2>
+template <int MT, typename L1, typename L2>
 std::enable_if_t<MaybeDeviceRunnable<L1>::value && MaybeDeviceRunnable<L2>::value>
 ParallelFor (Gpu::KernelInfo const&,
              Box const& box1, Box const& box2, L1&& f1, L2&& f2) noexcept
@@ -965,8 +999,8 @@ ParallelFor (Gpu::KernelInfo const&,
     const auto len2xy = len2.x*len2.y;
     const auto len1x = len1.x;
     const auto len2x = len2.x;
-    const auto ec = Gpu::ExecutionConfig(ncells);
-    AMREX_LAUNCH_KERNEL(ec.numBlocks, ec.numThreads, 0, Gpu::gpuStream(),
+    const auto ec = Gpu::makeExecutionConfig<MT>(ncells);
+    AMREX_LAUNCH_KERNEL(MT, ec.numBlocks, ec.numThreads, 0, Gpu::gpuStream(),
     [=] AMREX_GPU_DEVICE () noexcept {
         for (int icell = blockDim.x*blockIdx.x+threadIdx.x, stride = blockDim.x*gridDim.x;
              icell < ncells; icell += stride) {
@@ -993,7 +1027,7 @@ ParallelFor (Gpu::KernelInfo const&,
     AMREX_GPU_ERROR_CHECK();
 }
 
-template <typename L1, typename L2, typename L3>
+template <int MT, typename L1, typename L2, typename L3>
 std::enable_if_t<MaybeDeviceRunnable<L1>::value && MaybeDeviceRunnable<L2>::value && MaybeDeviceRunnable<L3>::value>
 ParallelFor (Gpu::KernelInfo const&,
              Box const& box1, Box const& box2, Box const& box3,
@@ -1016,8 +1050,8 @@ ParallelFor (Gpu::KernelInfo const&,
     const auto len1x = len1.x;
     const auto len2x = len2.x;
     const auto len3x = len3.x;
-    const auto ec = Gpu::ExecutionConfig(ncells);
-    AMREX_LAUNCH_KERNEL(ec.numBlocks, ec.numThreads, 0, Gpu::gpuStream(),
+    const auto ec = Gpu::makeExecutionConfig<MT>(ncells);
+    AMREX_LAUNCH_KERNEL(MT, ec.numBlocks, ec.numThreads, 0, Gpu::gpuStream(),
     [=] AMREX_GPU_DEVICE () noexcept {
         for (int icell = blockDim.x*blockIdx.x+threadIdx.x, stride = blockDim.x*gridDim.x;
              icell < ncells; icell += stride) {
@@ -1053,7 +1087,7 @@ ParallelFor (Gpu::KernelInfo const&,
     AMREX_GPU_ERROR_CHECK();
 }
 
-template <typename T1, typename T2, typename L1, typename L2,
+template <int MT, typename T1, typename T2, typename L1, typename L2,
           typename M1=std::enable_if_t<std::is_integral<T1>::value>,
           typename M2=std::enable_if_t<std::is_integral<T2>::value> >
 std::enable_if_t<MaybeDeviceRunnable<L1>::value && MaybeDeviceRunnable<L2>::value>
@@ -1073,8 +1107,8 @@ ParallelFor (Gpu::KernelInfo const&,
     const auto len2xy = len2.x*len2.y;
     const auto len1x = len1.x;
     const auto len2x = len2.x;
-    const auto ec = Gpu::ExecutionConfig(ncells);
-    AMREX_LAUNCH_KERNEL(ec.numBlocks, ec.numThreads, 0, Gpu::gpuStream(),
+    const auto ec = Gpu::makeExecutionConfig<MT>(ncells);
+    AMREX_LAUNCH_KERNEL(MT, ec.numBlocks, ec.numThreads, 0, Gpu::gpuStream(),
     [=] AMREX_GPU_DEVICE () noexcept {
         for (int icell = blockDim.x*blockIdx.x+threadIdx.x, stride = blockDim.x*gridDim.x;
              icell < ncells; icell += stride) {
@@ -1105,7 +1139,7 @@ ParallelFor (Gpu::KernelInfo const&,
     AMREX_GPU_ERROR_CHECK();
 }
 
-template <typename T1, typename T2, typename T3, typename L1, typename L2, typename L3,
+template <int MT, typename T1, typename T2, typename T3, typename L1, typename L2, typename L3,
           typename M1=std::enable_if_t<std::is_integral<T1>::value>,
           typename M2=std::enable_if_t<std::is_integral<T2>::value>,
           typename M3=std::enable_if_t<std::is_integral<T3>::value> >
@@ -1132,8 +1166,8 @@ ParallelFor (Gpu::KernelInfo const&,
     const auto len1x = len1.x;
     const auto len2x = len2.x;
     const auto len3x = len3.x;
-    const auto ec = Gpu::ExecutionConfig(ncells);
-    AMREX_LAUNCH_KERNEL(ec.numBlocks, ec.numThreads, 0, Gpu::gpuStream(),
+    const auto ec = Gpu::makeExecutionConfig<MT>(ncells);
+    AMREX_LAUNCH_KERNEL(MT, ec.numBlocks, ec.numThreads, 0, Gpu::gpuStream(),
     [=] AMREX_GPU_DEVICE () noexcept {
         for (int icell = blockDim.x*blockIdx.x+threadIdx.x, stride = blockDim.x*gridDim.x;
              icell < ncells; icell += stride) {
@@ -1183,29 +1217,127 @@ void single_task (L&& f) noexcept
     single_task(Gpu::gpuStream(), std::forward<L>(f));
 }
 
+template<typename T, typename L>
+void launch (T const& n, L&& f) noexcept
+{
+    launch<AMREX_GPU_MAX_THREADS>(n, std::forward<L>(f));
+}
+
+template <typename T, typename L, typename M=std::enable_if_t<std::is_integral<T>::value> >
+std::enable_if_t<MaybeDeviceRunnable<L>::value>
+ParallelFor (Gpu::KernelInfo const& info, T n, L&& f) noexcept
+{
+    ParallelFor<AMREX_GPU_MAX_THREADS>(info, n, std::forward<L>(f));
+}
+
+template <typename L>
+std::enable_if_t<MaybeDeviceRunnable<L>::value>
+ParallelFor (Gpu::KernelInfo const& info, Box const& box, L&& f) noexcept
+{
+    ParallelFor<AMREX_GPU_MAX_THREADS>(info, box, std::forward<L>(f));
+}
+
+template <typename T, typename L, typename M=std::enable_if_t<std::is_integral<T>::value> >
+std::enable_if_t<MaybeDeviceRunnable<L>::value>
+ParallelFor (Gpu::KernelInfo const& info, Box const& box, T ncomp, L&& f) noexcept
+{
+    ParallelFor<AMREX_GPU_MAX_THREADS>(info, box, ncomp, std::forward<L>(f));
+}
+
+template <typename L1, typename L2>
+std::enable_if_t<MaybeDeviceRunnable<L1>::value && MaybeDeviceRunnable<L2>::value>
+ParallelFor (Gpu::KernelInfo const& info,
+             Box const& box1, Box const& box2, L1&& f1, L2&& f2) noexcept
+{
+    ParallelFor<AMREX_GPU_MAX_THREADS>(info, box1, box2, std::forward<L1>(f1),
+                                       std::forward<L2>(f2));
+}
+
+template <typename L1, typename L2, typename L3>
+std::enable_if_t<MaybeDeviceRunnable<L1>::value && MaybeDeviceRunnable<L2>::value && MaybeDeviceRunnable<L3>::value>
+ParallelFor (Gpu::KernelInfo const& info,
+             Box const& box1, Box const& box2, Box const& box3,
+             L1&& f1, L2&& f2, L3&& f3) noexcept
+{
+    ParallelFor<AMREX_GPU_MAX_THREADS>(info, box1, box2, box3, std::forward<L1>(f1),
+                                       std::forward<L2>(f2), std::forward<L3>(f3));
+}
+
+template <typename T1, typename T2, typename L1, typename L2,
+          typename M1=std::enable_if_t<std::is_integral<T1>::value>,
+          typename M2=std::enable_if_t<std::is_integral<T2>::value> >
+std::enable_if_t<MaybeDeviceRunnable<L1>::value && MaybeDeviceRunnable<L2>::value>
+ParallelFor (Gpu::KernelInfo const& info,
+             Box const& box1, T1 ncomp1, L1&& f1,
+             Box const& box2, T2 ncomp2, L2&& f2) noexcept
+{
+    ParallelFor<AMREX_GPU_MAX_THREADS>(info, box1, ncomp1, std::forward<L1>(f1),
+                                             box2, ncomp2, std::forward<L2>(f2));
+}
+
+template <typename T1, typename T2, typename T3, typename L1, typename L2, typename L3,
+          typename M1=std::enable_if_t<std::is_integral<T1>::value>,
+          typename M2=std::enable_if_t<std::is_integral<T2>::value>,
+          typename M3=std::enable_if_t<std::is_integral<T3>::value> >
+std::enable_if_t<MaybeDeviceRunnable<L1>::value && MaybeDeviceRunnable<L2>::value && MaybeDeviceRunnable<L3>::value>
+ParallelFor (Gpu::KernelInfo const& info,
+             Box const& box1, T1 ncomp1, L1&& f1,
+             Box const& box2, T2 ncomp2, L2&& f2,
+             Box const& box3, T3 ncomp3, L3&& f3) noexcept
+{
+    ParallelFor<AMREX_GPU_MAX_THREADS>(info, box1, ncomp1, std::forward<L1>(f1),
+                                             box2, ncomp2, std::forward<L2>(f2),
+                                             box3, ncomp3, std::forward<L3>(f3));
+}
+
 template <typename T, typename L, typename M=std::enable_if_t<std::is_integral<T>::value> >
 void For (Gpu::KernelInfo const& info, T n, L&& f) noexcept
 {
-    ParallelFor(info, n,std::forward<L>(f));
+    ParallelFor<AMREX_GPU_MAX_THREADS>(info, n,std::forward<L>(f));
+}
+
+template <int MT, typename T, typename L, typename M=std::enable_if_t<std::is_integral<T>::value> >
+void For (Gpu::KernelInfo const& info, T n, L&& f) noexcept
+{
+    ParallelFor<MT>(info, n,std::forward<L>(f));
 }
 
 template <typename L>
 void For (Gpu::KernelInfo const& info, Box const& box, L&& f) noexcept
 {
-    ParallelFor(info, box,std::forward<L>(f));
+    ParallelFor<AMREX_GPU_MAX_THREADS>(info, box,std::forward<L>(f));
+}
+
+template <int MT, typename L>
+void For (Gpu::KernelInfo const& info, Box const& box, L&& f) noexcept
+{
+    ParallelFor<MT>(info, box,std::forward<L>(f));
 }
 
 template <typename T, typename L, typename M=std::enable_if_t<std::is_integral<T>::value> >
 void For (Gpu::KernelInfo const& info, Box const& box, T ncomp, L&& f) noexcept
 {
-    ParallelFor(info,box,ncomp,std::forward<L>(f));
+    ParallelFor<AMREX_GPU_MAX_THREADS>(info,box,ncomp,std::forward<L>(f));
+}
+
+template <int MT, typename T, typename L, typename M=std::enable_if_t<std::is_integral<T>::value> >
+void For (Gpu::KernelInfo const& info, Box const& box, T ncomp, L&& f) noexcept
+{
+    ParallelFor<MT>(info,box,ncomp,std::forward<L>(f));
 }
 
 template <typename L1, typename L2>
 void For (Gpu::KernelInfo const& info,
           Box const& box1, Box const& box2, L1&& f1, L2&& f2) noexcept
 {
-    ParallelFor(info,box1,box2,std::forward<L1>(f1),std::forward<L2>(f2));
+    ParallelFor<AMREX_GPU_MAX_THREADS>(info,box1,box2,std::forward<L1>(f1),std::forward<L2>(f2));
+}
+
+template <int MT, typename L1, typename L2>
+void For (Gpu::KernelInfo const& info,
+          Box const& box1, Box const& box2, L1&& f1, L2&& f2) noexcept
+{
+    ParallelFor<MT>(info,box1,box2,std::forward<L1>(f1),std::forward<L2>(f2));
 }
 
 template <typename L1, typename L2, typename L3>
@@ -1213,7 +1345,15 @@ void For (Gpu::KernelInfo const& info,
           Box const& box1, Box const& box2, Box const& box3,
           L1&& f1, L2&& f2, L3&& f3) noexcept
 {
-    ParallelFor(info,box1,box2,box3,std::forward<L1>(f1),std::forward<L2>(f2),std::forward<L3>(f3));
+    ParallelFor<AMREX_GPU_MAX_THREADS>(info,box1,box2,box3,std::forward<L1>(f1),std::forward<L2>(f2),std::forward<L3>(f3));
+}
+
+template <int MT, typename L1, typename L2, typename L3>
+void For (Gpu::KernelInfo const& info,
+          Box const& box1, Box const& box2, Box const& box3,
+          L1&& f1, L2&& f2, L3&& f3) noexcept
+{
+    ParallelFor<MT>(info,box1,box2,box3,std::forward<L1>(f1),std::forward<L2>(f2),std::forward<L3>(f3));
 }
 
 template <typename T1, typename T2, typename L1, typename L2,
@@ -1223,7 +1363,17 @@ void For (Gpu::KernelInfo const& info,
           Box const& box1, T1 ncomp1, L1&& f1,
           Box const& box2, T2 ncomp2, L2&& f2) noexcept
 {
-    ParallelFor(info,box1,ncomp1,std::forward<L1>(f1),box2,ncomp2,std::forward<L2>(f2));
+    ParallelFor<AMREX_GPU_MAX_THREADS>(info,box1,ncomp1,std::forward<L1>(f1),box2,ncomp2,std::forward<L2>(f2));
+}
+
+template <int MT, typename T1, typename T2, typename L1, typename L2,
+          typename M1=std::enable_if_t<std::is_integral<T1>::value>,
+          typename M2=std::enable_if_t<std::is_integral<T2>::value> >
+void For (Gpu::KernelInfo const& info,
+          Box const& box1, T1 ncomp1, L1&& f1,
+          Box const& box2, T2 ncomp2, L2&& f2) noexcept
+{
+    ParallelFor<MT>(info,box1,ncomp1,std::forward<L1>(f1),box2,ncomp2,std::forward<L2>(f2));
 }
 
 template <typename T1, typename T2, typename T3, typename L1, typename L2, typename L3,
@@ -1235,7 +1385,22 @@ void For (Gpu::KernelInfo const& info,
           Box const& box2, T2 ncomp2, L2&& f2,
           Box const& box3, T3 ncomp3, L3&& f3) noexcept
 {
-    ParallelFor(info,
+    ParallelFor<AMREX_GPU_MAX_THREADS>(info,
+                box1,ncomp1,std::forward<L1>(f1),
+                box2,ncomp2,std::forward<L2>(f2),
+                box3,ncomp3,std::forward<L3>(f3));
+}
+
+template <int MT, typename T1, typename T2, typename T3, typename L1, typename L2, typename L3,
+          typename M1=std::enable_if_t<std::is_integral<T1>::value>,
+          typename M2=std::enable_if_t<std::is_integral<T2>::value>,
+          typename M3=std::enable_if_t<std::is_integral<T3>::value> >
+void For (Gpu::KernelInfo const& info,
+          Box const& box1, T1 ncomp1, L1&& f1,
+          Box const& box2, T2 ncomp2, L2&& f2,
+          Box const& box3, T3 ncomp3, L3&& f3) noexcept
+{
+    ParallelFor<MT>(info,
                 box1,ncomp1,std::forward<L1>(f1),
                 box2,ncomp2,std::forward<L2>(f2),
                 box3,ncomp3,std::forward<L3>(f3));
@@ -1244,32 +1409,63 @@ void For (Gpu::KernelInfo const& info,
 template <typename T, typename L, typename M=std::enable_if_t<std::is_integral<T>::value> >
 void ParallelFor (T n, L&& f) noexcept
 {
-    ParallelFor(Gpu::KernelInfo{}, n, std::forward<L>(f));
+    ParallelFor<AMREX_GPU_MAX_THREADS>(Gpu::KernelInfo{}, n, std::forward<L>(f));
+}
+
+template <int MT, typename T, typename L, typename M=std::enable_if_t<std::is_integral<T>::value> >
+void ParallelFor (T n, L&& f) noexcept
+{
+    ParallelFor<MT>(Gpu::KernelInfo{}, n, std::forward<L>(f));
 }
 
 template <typename L>
 void ParallelFor (Box const& box, L&& f) noexcept
 {
-    ParallelFor(Gpu::KernelInfo{}, box, std::forward<L>(f));
+    ParallelFor<AMREX_GPU_MAX_THREADS>(Gpu::KernelInfo{}, box, std::forward<L>(f));
+}
+
+template <int MT, typename L>
+void ParallelFor (Box const& box, L&& f) noexcept
+{
+    ParallelFor<MT>(Gpu::KernelInfo{}, box, std::forward<L>(f));
 }
 
 template <typename T, typename L, typename M=std::enable_if_t<std::is_integral<T>::value> >
 void ParallelFor (Box const& box, T ncomp, L&& f) noexcept
 {
-    ParallelFor(Gpu::KernelInfo{},box,ncomp,std::forward<L>(f));
+    ParallelFor<AMREX_GPU_MAX_THREADS>(Gpu::KernelInfo{},box,ncomp,std::forward<L>(f));
+}
+
+template <int MT, typename T, typename L, typename M=std::enable_if_t<std::is_integral<T>::value> >
+void ParallelFor (Box const& box, T ncomp, L&& f) noexcept
+{
+    ParallelFor<MT>(Gpu::KernelInfo{},box,ncomp,std::forward<L>(f));
 }
 
 template <typename L1, typename L2>
 void ParallelFor (Box const& box1, Box const& box2, L1&& f1, L2&& f2) noexcept
 {
-    ParallelFor(Gpu::KernelInfo{},box1,box2,std::forward<L1>(f1),std::forward<L2>(f2));
+    ParallelFor<AMREX_GPU_MAX_THREADS>(Gpu::KernelInfo{},box1,box2,std::forward<L1>(f1),std::forward<L2>(f2));
+}
+
+template <int MT, typename L1, typename L2>
+void ParallelFor (Box const& box1, Box const& box2, L1&& f1, L2&& f2) noexcept
+{
+    ParallelFor<MT>(Gpu::KernelInfo{},box1,box2,std::forward<L1>(f1),std::forward<L2>(f2));
 }
 
 template <typename L1, typename L2, typename L3>
 void ParallelFor (Box const& box1, Box const& box2, Box const& box3,
                   L1&& f1, L2&& f2, L3&& f3) noexcept
 {
-    ParallelFor(Gpu::KernelInfo{},box1,box2,box3,std::forward<L1>(f1),std::forward<L2>(f2),std::forward<L3>(f3));
+    ParallelFor<AMREX_GPU_MAX_THREADS>(Gpu::KernelInfo{},box1,box2,box3,std::forward<L1>(f1),std::forward<L2>(f2),std::forward<L3>(f3));
+}
+
+template <int MT, typename L1, typename L2, typename L3>
+void ParallelFor (Box const& box1, Box const& box2, Box const& box3,
+                  L1&& f1, L2&& f2, L3&& f3) noexcept
+{
+    ParallelFor<MT>(Gpu::KernelInfo{},box1,box2,box3,std::forward<L1>(f1),std::forward<L2>(f2),std::forward<L3>(f3));
 }
 
 template <typename T1, typename T2, typename L1, typename L2,
@@ -1278,7 +1474,16 @@ template <typename T1, typename T2, typename L1, typename L2,
 void ParallelFor (Box const& box1, T1 ncomp1, L1&& f1,
                   Box const& box2, T2 ncomp2, L2&& f2) noexcept
 {
-    ParallelFor(Gpu::KernelInfo{},box1,ncomp1,std::forward<L1>(f1),box2,ncomp2,std::forward<L2>(f2));
+    ParallelFor<AMREX_GPU_MAX_THREADS>(Gpu::KernelInfo{},box1,ncomp1,std::forward<L1>(f1),box2,ncomp2,std::forward<L2>(f2));
+}
+
+template <int MT, typename T1, typename T2, typename L1, typename L2,
+          typename M1=std::enable_if_t<std::is_integral<T1>::value>,
+          typename M2=std::enable_if_t<std::is_integral<T2>::value> >
+void ParallelFor (Box const& box1, T1 ncomp1, L1&& f1,
+                  Box const& box2, T2 ncomp2, L2&& f2) noexcept
+{
+    ParallelFor<MT>(Gpu::KernelInfo{},box1,ncomp1,std::forward<L1>(f1),box2,ncomp2,std::forward<L2>(f2));
 }
 
 template <typename T1, typename T2, typename T3, typename L1, typename L2, typename L3,
@@ -1289,7 +1494,21 @@ void ParallelFor (Box const& box1, T1 ncomp1, L1&& f1,
                   Box const& box2, T2 ncomp2, L2&& f2,
                   Box const& box3, T3 ncomp3, L3&& f3) noexcept
 {
-    ParallelFor(Gpu::KernelInfo{},
+    ParallelFor<AMREX_GPU_MAX_THREADS>(Gpu::KernelInfo{},
+                box1,ncomp1,std::forward<L1>(f1),
+                box2,ncomp2,std::forward<L2>(f2),
+                box3,ncomp3,std::forward<L3>(f3));
+}
+
+template <int MT, typename T1, typename T2, typename T3, typename L1, typename L2, typename L3,
+          typename M1=std::enable_if_t<std::is_integral<T1>::value>,
+          typename M2=std::enable_if_t<std::is_integral<T2>::value>,
+          typename M3=std::enable_if_t<std::is_integral<T3>::value> >
+void ParallelFor (Box const& box1, T1 ncomp1, L1&& f1,
+                  Box const& box2, T2 ncomp2, L2&& f2,
+                  Box const& box3, T3 ncomp3, L3&& f3) noexcept
+{
+    ParallelFor<MT>(Gpu::KernelInfo{},
                 box1,ncomp1,std::forward<L1>(f1),
                 box2,ncomp2,std::forward<L2>(f2),
                 box3,ncomp3,std::forward<L3>(f3));
@@ -1298,32 +1517,63 @@ void ParallelFor (Box const& box1, T1 ncomp1, L1&& f1,
 template <typename T, typename L, typename M=std::enable_if_t<std::is_integral<T>::value> >
 void For (T n, L&& f) noexcept
 {
-    ParallelFor(Gpu::KernelInfo{}, n,std::forward<L>(f));
+    ParallelFor<AMREX_GPU_MAX_THREADS>(Gpu::KernelInfo{}, n,std::forward<L>(f));
+}
+
+template <int MT, typename T, typename L, typename M=std::enable_if_t<std::is_integral<T>::value> >
+void For (T n, L&& f) noexcept
+{
+    ParallelFor<MT>(Gpu::KernelInfo{}, n,std::forward<L>(f));
 }
 
 template <typename L>
 void For (Box const& box, L&& f) noexcept
 {
-    ParallelFor(Gpu::KernelInfo{}, box,std::forward<L>(f));
+    ParallelFor<AMREX_GPU_MAX_THREADS>(Gpu::KernelInfo{}, box,std::forward<L>(f));
+}
+
+template <int MT, typename L>
+void For (Box const& box, L&& f) noexcept
+{
+    ParallelFor<MT>(Gpu::KernelInfo{}, box,std::forward<L>(f));
 }
 
 template <typename T, typename L, typename M=std::enable_if_t<std::is_integral<T>::value> >
 void For (Box const& box, T ncomp, L&& f) noexcept
 {
-    ParallelFor(Gpu::KernelInfo{},box,ncomp,std::forward<L>(f));
+    ParallelFor<AMREX_GPU_MAX_THREADS>(Gpu::KernelInfo{},box,ncomp,std::forward<L>(f));
+}
+
+template <int MT, typename T, typename L, typename M=std::enable_if_t<std::is_integral<T>::value> >
+void For (Box const& box, T ncomp, L&& f) noexcept
+{
+    ParallelFor<MT>(Gpu::KernelInfo{},box,ncomp,std::forward<L>(f));
 }
 
 template <typename L1, typename L2>
 void For (Box const& box1, Box const& box2, L1&& f1, L2&& f2) noexcept
 {
-    ParallelFor(Gpu::KernelInfo{},box1,box2,std::forward<L1>(f1),std::forward<L2>(f2));
+    ParallelFor<AMREX_GPU_MAX_THREADS>(Gpu::KernelInfo{},box1,box2,std::forward<L1>(f1),std::forward<L2>(f2));
+}
+
+template <int MT, typename L1, typename L2>
+void For (Box const& box1, Box const& box2, L1&& f1, L2&& f2) noexcept
+{
+    ParallelFor<MT>(Gpu::KernelInfo{},box1,box2,std::forward<L1>(f1),std::forward<L2>(f2));
 }
 
 template <typename L1, typename L2, typename L3>
 void For (Box const& box1, Box const& box2, Box const& box3,
           L1&& f1, L2&& f2, L3&& f3) noexcept
 {
-    ParallelFor(Gpu::KernelInfo{},box1,box2,box3,std::forward<L1>(f1),std::forward<L2>(f2),std::forward<L3>(f3));
+    ParallelFor<AMREX_GPU_MAX_THREADS>(Gpu::KernelInfo{},box1,box2,box3,std::forward<L1>(f1),std::forward<L2>(f2),std::forward<L3>(f3));
+}
+
+template <int MT, typename L1, typename L2, typename L3>
+void For (Box const& box1, Box const& box2, Box const& box3,
+          L1&& f1, L2&& f2, L3&& f3) noexcept
+{
+    ParallelFor<MT>(Gpu::KernelInfo{},box1,box2,box3,std::forward<L1>(f1),std::forward<L2>(f2),std::forward<L3>(f3));
 }
 
 template <typename T1, typename T2, typename L1, typename L2,
@@ -1332,7 +1582,16 @@ template <typename T1, typename T2, typename L1, typename L2,
 void For (Box const& box1, T1 ncomp1, L1&& f1,
           Box const& box2, T2 ncomp2, L2&& f2) noexcept
 {
-    ParallelFor(Gpu::KernelInfo{},box1,ncomp1,std::forward<L1>(f1),box2,ncomp2,std::forward<L2>(f2));
+    ParallelFor<AMREX_GPU_MAX_THREADS>(Gpu::KernelInfo{},box1,ncomp1,std::forward<L1>(f1),box2,ncomp2,std::forward<L2>(f2));
+}
+
+template <int MT, typename T1, typename T2, typename L1, typename L2,
+          typename M1=std::enable_if_t<std::is_integral<T1>::value>,
+          typename M2=std::enable_if_t<std::is_integral<T2>::value> >
+void For (Box const& box1, T1 ncomp1, L1&& f1,
+          Box const& box2, T2 ncomp2, L2&& f2) noexcept
+{
+    ParallelFor<MT>(Gpu::KernelInfo{},box1,ncomp1,std::forward<L1>(f1),box2,ncomp2,std::forward<L2>(f2));
 }
 
 template <typename T1, typename T2, typename T3, typename L1, typename L2, typename L3,
@@ -1343,7 +1602,21 @@ void For (Box const& box1, T1 ncomp1, L1&& f1,
           Box const& box2, T2 ncomp2, L2&& f2,
           Box const& box3, T3 ncomp3, L3&& f3) noexcept
 {
-    ParallelFor(Gpu::KernelInfo{},
+    ParallelFor<AMREX_GPU_MAX_THREADS>(Gpu::KernelInfo{},
+                box1,ncomp1,std::forward<L1>(f1),
+                box2,ncomp2,std::forward<L2>(f2),
+                box3,ncomp3,std::forward<L3>(f3));
+}
+
+template <int MT, typename T1, typename T2, typename T3, typename L1, typename L2, typename L3,
+          typename M1=std::enable_if_t<std::is_integral<T1>::value>,
+          typename M2=std::enable_if_t<std::is_integral<T2>::value>,
+          typename M3=std::enable_if_t<std::is_integral<T3>::value> >
+void For (Box const& box1, T1 ncomp1, L1&& f1,
+          Box const& box2, T2 ncomp2, L2&& f2,
+          Box const& box3, T3 ncomp3, L3&& f3) noexcept
+{
+    ParallelFor<MT>(Gpu::KernelInfo{},
                 box1,ncomp1,std::forward<L1>(f1),
                 box2,ncomp2,std::forward<L2>(f2),
                 box3,ncomp3,std::forward<L3>(f3));
@@ -1354,7 +1627,19 @@ std::enable_if_t<MaybeHostDeviceRunnable<L>::value>
 HostDeviceParallelFor (Gpu::KernelInfo const& info, T n, L&& f) noexcept
 {
     if (Gpu::inLaunchRegion()) {
-        ParallelFor(info,n,std::forward<L>(f));
+        ParallelFor<AMREX_GPU_MAX_THREADS>(info,n,std::forward<L>(f));
+    } else {
+        AMREX_PRAGMA_SIMD
+        for (T i = 0; i < n; ++i) f(i);
+    }
+}
+
+template <int MT, typename T, typename L, typename M=std::enable_if_t<std::is_integral<T>::value> >
+std::enable_if_t<MaybeHostDeviceRunnable<L>::value>
+HostDeviceParallelFor (Gpu::KernelInfo const& info, T n, L&& f) noexcept
+{
+    if (Gpu::inLaunchRegion()) {
+        ParallelFor<MT>(info,n,std::forward<L>(f));
     } else {
         AMREX_PRAGMA_SIMD
         for (T i = 0; i < n; ++i) f(i);
@@ -1365,7 +1650,14 @@ template <typename T, typename L, typename M=std::enable_if_t<std::is_integral<T
 std::enable_if_t<MaybeHostDeviceRunnable<L>::value>
 HostDeviceParallelFor (T n, L&& f) noexcept
 {
-    HostDeviceParallelFor(Gpu::KernelInfo{}, n, std::forward<L>(f));
+    HostDeviceParallelFor<AMREX_GPU_MAX_THREADS>(Gpu::KernelInfo{}, n, std::forward<L>(f));
+}
+
+template <int MT, typename T, typename L, typename M=std::enable_if_t<std::is_integral<T>::value> >
+std::enable_if_t<MaybeHostDeviceRunnable<L>::value>
+HostDeviceParallelFor (T n, L&& f) noexcept
+{
+    HostDeviceParallelFor<MT>(Gpu::KernelInfo{}, n, std::forward<L>(f));
 }
 
 template <typename L>
@@ -1373,7 +1665,18 @@ std::enable_if_t<MaybeHostDeviceRunnable<L>::value>
 HostDeviceParallelFor (Gpu::KernelInfo const& info, Box const& box, L&& f) noexcept
 {
     if (Gpu::inLaunchRegion()) {
-        ParallelFor(info, box,std::forward<L>(f));
+        ParallelFor<AMREX_GPU_MAX_THREADS>(info, box,std::forward<L>(f));
+    } else {
+        LoopConcurrentOnCpu(box,std::forward<L>(f));
+    }
+}
+
+template <int MT, typename L>
+std::enable_if_t<MaybeHostDeviceRunnable<L>::value>
+HostDeviceParallelFor (Gpu::KernelInfo const& info, Box const& box, L&& f) noexcept
+{
+    if (Gpu::inLaunchRegion()) {
+        ParallelFor<MT>(info, box,std::forward<L>(f));
     } else {
         LoopConcurrentOnCpu(box,std::forward<L>(f));
     }
@@ -1384,7 +1687,18 @@ std::enable_if_t<MaybeHostDeviceRunnable<L>::value>
 HostDeviceParallelFor (Gpu::KernelInfo const& info, Box const& box, T ncomp, L&& f) noexcept
 {
     if (Gpu::inLaunchRegion()) {
-        ParallelFor(info, box,ncomp,std::forward<L>(f));
+        ParallelFor<AMREX_GPU_MAX_THREADS>(info, box,ncomp,std::forward<L>(f));
+    } else {
+        LoopConcurrentOnCpu(box,ncomp,std::forward<L>(f));
+    }
+}
+
+template <int MT, typename T, typename L, typename M=std::enable_if_t<std::is_integral<T>::value> >
+std::enable_if_t<MaybeHostDeviceRunnable<L>::value>
+HostDeviceParallelFor (Gpu::KernelInfo const& info, Box const& box, T ncomp, L&& f) noexcept
+{
+    if (Gpu::inLaunchRegion()) {
+        ParallelFor<MT>(info, box,ncomp,std::forward<L>(f));
     } else {
         LoopConcurrentOnCpu(box,ncomp,std::forward<L>(f));
     }
@@ -1396,21 +1710,34 @@ HostDeviceParallelFor (Gpu::KernelInfo const& info,
                        Box const& box1, Box const& box2, L1&& f1, L2&& f2) noexcept
 {
     if (Gpu::inLaunchRegion()) {
-        ParallelFor(info,box1,box2,std::forward<L1>(f1),std::forward<L2>(f2));
+        ParallelFor<AMREX_GPU_MAX_THREADS>(info,box1,box2,std::forward<L1>(f1),std::forward<L2>(f2));
     } else {
         LoopConcurrentOnCpu(box1,std::forward<L1>(f1));
         LoopConcurrentOnCpu(box2,std::forward<L2>(f2));
     }
 }
 
-template <typename L1, typename L2, typename L3>
+template <int MT, typename L1, typename L2>
+std::enable_if_t<MaybeHostDeviceRunnable<L1>::value && MaybeHostDeviceRunnable<L2>::value>
+HostDeviceParallelFor (Gpu::KernelInfo const& info,
+                       Box const& box1, Box const& box2, L1&& f1, L2&& f2) noexcept
+{
+    if (Gpu::inLaunchRegion()) {
+        ParallelFor<MT>(info,box1,box2,std::forward<L1>(f1),std::forward<L2>(f2));
+    } else {
+        LoopConcurrentOnCpu(box1,std::forward<L1>(f1));
+        LoopConcurrentOnCpu(box2,std::forward<L2>(f2));
+    }
+}
+
+template <int MT, typename L1, typename L2, typename L3>
 std::enable_if_t<MaybeHostDeviceRunnable<L1>::value && MaybeHostDeviceRunnable<L2>::value && MaybeHostDeviceRunnable<L3>::value>
 HostDeviceParallelFor (Gpu::KernelInfo const& info,
                        Box const& box1, Box const& box2, Box const& box3,
                        L1&& f1, L2&& f2, L3&& f3) noexcept
 {
     if (Gpu::inLaunchRegion()) {
-        ParallelFor(info,box1,box2,box3,
+        ParallelFor<MT>(info,box1,box2,box3,
                     std::forward<L1>(f1),std::forward<L2>(f2),std::forward<L3>(f3));
     } else {
         LoopConcurrentOnCpu(box1,std::forward<L1>(f1));
@@ -1428,7 +1755,23 @@ HostDeviceParallelFor (Gpu::KernelInfo const& info,
                        Box const& box2, T2 ncomp2, L2&& f2) noexcept
 {
     if (Gpu::inLaunchRegion()) {
-        ParallelFor(info,box1,ncomp1,std::forward<L1>(f1),box2,ncomp2,std::forward<L2>(f2));
+        ParallelFor<AMREX_GPU_MAX_THREADS>(info,box1,ncomp1,std::forward<L1>(f1),box2,ncomp2,std::forward<L2>(f2));
+    } else {
+        LoopConcurrentOnCpu(box1,ncomp1,std::forward<L1>(f1));
+        LoopConcurrentOnCpu(box2,ncomp2,std::forward<L2>(f2));
+    }
+}
+
+template <int MT, typename T1, typename T2, typename L1, typename L2,
+          typename M1=std::enable_if_t<std::is_integral<T1>::value>,
+          typename M2=std::enable_if_t<std::is_integral<T2>::value> >
+std::enable_if_t<MaybeHostDeviceRunnable<L1>::value && MaybeHostDeviceRunnable<L2>::value>
+HostDeviceParallelFor (Gpu::KernelInfo const& info,
+                       Box const& box1, T1 ncomp1, L1&& f1,
+                       Box const& box2, T2 ncomp2, L2&& f2) noexcept
+{
+    if (Gpu::inLaunchRegion()) {
+        ParallelFor<MT>(info,box1,ncomp1,std::forward<L1>(f1),box2,ncomp2,std::forward<L2>(f2));
     } else {
         LoopConcurrentOnCpu(box1,ncomp1,std::forward<L1>(f1));
         LoopConcurrentOnCpu(box2,ncomp2,std::forward<L2>(f2));
@@ -1446,7 +1789,29 @@ HostDeviceParallelFor (Gpu::KernelInfo const& info,
                        Box const& box3, T3 ncomp3, L3&& f3) noexcept
 {
     if (Gpu::inLaunchRegion()) {
-        ParallelFor(info,
+        ParallelFor<AMREX_GPU_MAX_THREADS>(info,
+                    box1,ncomp1,std::forward<L1>(f1),
+                    box2,ncomp2,std::forward<L2>(f2),
+                    box3,ncomp3,std::forward<L3>(f3));
+    } else {
+        LoopConcurrentOnCpu(box1,ncomp1,std::forward<L1>(f1));
+        LoopConcurrentOnCpu(box2,ncomp2,std::forward<L2>(f2));
+        LoopConcurrentOnCpu(box3,ncomp3,std::forward<L3>(f3));
+    }
+}
+
+template <int MT, typename T1, typename T2, typename T3, typename L1, typename L2, typename L3,
+          typename M1=std::enable_if_t<std::is_integral<T1>::value>,
+          typename M2=std::enable_if_t<std::is_integral<T2>::value>,
+          typename M3=std::enable_if_t<std::is_integral<T3>::value> >
+std::enable_if_t<MaybeHostDeviceRunnable<L1>::value && MaybeHostDeviceRunnable<L2>::value && MaybeHostDeviceRunnable<L3>::value>
+HostDeviceParallelFor (Gpu::KernelInfo const& info,
+                       Box const& box1, T1 ncomp1, L1&& f1,
+                       Box const& box2, T2 ncomp2, L2&& f2,
+                       Box const& box3, T3 ncomp3, L3&& f3) noexcept
+{
+    if (Gpu::inLaunchRegion()) {
+        ParallelFor<MT>(info,
                     box1,ncomp1,std::forward<L1>(f1),
                     box2,ncomp2,std::forward<L2>(f2),
                     box3,ncomp3,std::forward<L3>(f3));
@@ -1460,26 +1825,51 @@ HostDeviceParallelFor (Gpu::KernelInfo const& info,
 template <typename T, typename L, typename M=std::enable_if_t<std::is_integral<T>::value> >
 void HostDeviceFor (Gpu::KernelInfo const& info, T n, L&& f) noexcept
 {
-    HostDeviceParallelFor(info,n,std::forward<L>(f));
+    HostDeviceParallelFor<AMREX_GPU_MAX_THREADS>(info,n,std::forward<L>(f));
+}
+
+template <int MT, typename T, typename L, typename M=std::enable_if_t<std::is_integral<T>::value> >
+void HostDeviceFor (Gpu::KernelInfo const& info, T n, L&& f) noexcept
+{
+    HostDeviceParallelFor<MT>(info,n,std::forward<L>(f));
 }
 
 template <typename L>
 void HostDeviceFor (Gpu::KernelInfo const& info, Box const& box, L&& f) noexcept
 {
-    HostDeviceParallelFor(info,box,std::forward<L>(f));
+    HostDeviceParallelFor<AMREX_GPU_MAX_THREADS>(info,box,std::forward<L>(f));
+}
+
+template <int MT, typename L>
+void HostDeviceFor (Gpu::KernelInfo const& info, Box const& box, L&& f) noexcept
+{
+    HostDeviceParallelFor<MT>(info,box,std::forward<L>(f));
 }
 
 template <typename T, typename L, typename M=std::enable_if_t<std::is_integral<T>::value> >
 void HostDeviceFor (Gpu::KernelInfo const& info, Box const& box, T ncomp, L&& f) noexcept
 {
-    HostDeviceParallelFor(info,box,ncomp,std::forward<L>(f));
+    HostDeviceParallelFor<AMREX_GPU_MAX_THREADS>(info,box,ncomp,std::forward<L>(f));
+}
+
+template <int MT, typename T, typename L, typename M=std::enable_if_t<std::is_integral<T>::value> >
+void HostDeviceFor (Gpu::KernelInfo const& info, Box const& box, T ncomp, L&& f) noexcept
+{
+    HostDeviceParallelFor<MT>(info,box,ncomp,std::forward<L>(f));
 }
 
 template <typename L1, typename L2>
 void HostDeviceFor (Gpu::KernelInfo const& info,
                     Box const& box1, Box const& box2, L1&& f1, L2&& f2) noexcept
 {
-    HostDeviceParallelFor(info,box1,box2,std::forward<L1>(f1),std::forward<L2>(f2));
+    HostDeviceParallelFor<AMREX_GPU_MAX_THREADS>(info,box1,box2,std::forward<L1>(f1),std::forward<L2>(f2));
+}
+
+template <int MT, typename L1, typename L2>
+void HostDeviceFor (Gpu::KernelInfo const& info,
+                    Box const& box1, Box const& box2, L1&& f1, L2&& f2) noexcept
+{
+    HostDeviceParallelFor<MT>(info,box1,box2,std::forward<L1>(f1),std::forward<L2>(f2));
 }
 
 template <typename L1, typename L2, typename L3>
@@ -1487,7 +1877,16 @@ void HostDeviceFor (Gpu::KernelInfo const& info,
                     Box const& box1, Box const& box2, Box const& box3,
                     L1&& f1, L2&& f2, L3&& f3) noexcept
 {
-    HostDeviceParallelFor(info, box1,box2,box3,
+    HostDeviceParallelFor<AMREX_GPU_MAX_THREADS>(info, box1,box2,box3,
+                          std::forward<L1>(f1),std::forward<L2>(f2),std::forward<L3>(f3));
+}
+
+template <int MT, typename L1, typename L2, typename L3>
+void HostDeviceFor (Gpu::KernelInfo const& info,
+                    Box const& box1, Box const& box2, Box const& box3,
+                    L1&& f1, L2&& f2, L3&& f3) noexcept
+{
+    HostDeviceParallelFor<MT>(info, box1,box2,box3,
                           std::forward<L1>(f1),std::forward<L2>(f2),std::forward<L3>(f3));
 }
 
@@ -1498,7 +1897,17 @@ void HostDeviceFor (Gpu::KernelInfo const& info,
                     Box const& box1, T1 ncomp1, L1&& f1,
                     Box const& box2, T2 ncomp2, L2&& f2) noexcept
 {
-    HostDeviceParallelFor(info,box1,ncomp1,std::forward<L1>(f1),box2,ncomp2,std::forward<L2>(f2));
+    HostDeviceParallelFor<AMREX_GPU_MAX_THREADS>(info,box1,ncomp1,std::forward<L1>(f1),box2,ncomp2,std::forward<L2>(f2));
+}
+
+template <int MT, typename T1, typename T2, typename L1, typename L2,
+          typename M1=std::enable_if_t<std::is_integral<T1>::value>,
+          typename M2=std::enable_if_t<std::is_integral<T2>::value> >
+void HostDeviceFor (Gpu::KernelInfo const& info,
+                    Box const& box1, T1 ncomp1, L1&& f1,
+                    Box const& box2, T2 ncomp2, L2&& f2) noexcept
+{
+    HostDeviceParallelFor<MT>(info,box1,ncomp1,std::forward<L1>(f1),box2,ncomp2,std::forward<L2>(f2));
 }
 
 template <typename T1, typename T2, typename T3, typename L1, typename L2, typename L3,
@@ -1510,7 +1919,22 @@ void HostDeviceFor (Gpu::KernelInfo const& info,
                     Box const& box2, T2 ncomp2, L2&& f2,
                     Box const& box3, T3 ncomp3, L3&& f3) noexcept
 {
-    HostDeviceParallelFor(info,
+    HostDeviceParallelFor<AMREX_GPU_MAX_THREADS>(info,
+                          box1,ncomp1,std::forward<L1>(f1),
+                          box2,ncomp2,std::forward<L2>(f2),
+                          box3,ncomp3,std::forward<L3>(f3));
+}
+
+template <int MT, typename T1, typename T2, typename T3, typename L1, typename L2, typename L3,
+          typename M1=std::enable_if_t<std::is_integral<T1>::value>,
+          typename M2=std::enable_if_t<std::is_integral<T2>::value>,
+          typename M3=std::enable_if_t<std::is_integral<T3>::value> >
+void HostDeviceFor (Gpu::KernelInfo const& info,
+                    Box const& box1, T1 ncomp1, L1&& f1,
+                    Box const& box2, T2 ncomp2, L2&& f2,
+                    Box const& box3, T3 ncomp3, L3&& f3) noexcept
+{
+    HostDeviceParallelFor<MT>(info,
                           box1,ncomp1,std::forward<L1>(f1),
                           box2,ncomp2,std::forward<L2>(f2),
                           box3,ncomp3,std::forward<L3>(f3));
@@ -1519,32 +1943,64 @@ void HostDeviceFor (Gpu::KernelInfo const& info,
 template <typename T, typename L, typename M=std::enable_if_t<std::is_integral<T>::value> >
 void HostDeviceParallelFor (T n, L&& f) noexcept
 {
-    HostDeviceParallelFor(Gpu::KernelInfo{},n,std::forward<L>(f));
+    HostDeviceParallelFor<AMREX_GPU_MAX_THREADS>(Gpu::KernelInfo{},n,std::forward<L>(f));
+}
+
+template <int MT, typename T, typename L, typename M=std::enable_if_t<std::is_integral<T>::value> >
+void HostDeviceParallelFor (T n, L&& f) noexcept
+{
+    HostDeviceParallelFor<MT>(Gpu::KernelInfo{},n,std::forward<L>(f));
 }
 
 template <typename L>
 void HostDeviceParallelFor (Box const& box, L&& f) noexcept
 {
-    HostDeviceParallelFor(Gpu::KernelInfo{},box,std::forward<L>(f));
+    HostDeviceParallelFor<AMREX_GPU_MAX_THREADS>(Gpu::KernelInfo{},box,std::forward<L>(f));
+}
+
+template <int MT, typename L>
+void HostDeviceParallelFor (Box const& box, L&& f) noexcept
+{
+    HostDeviceParallelFor<MT>(Gpu::KernelInfo{},box,std::forward<L>(f));
 }
 
 template <typename T, typename L, typename M=std::enable_if_t<std::is_integral<T>::value> >
 void HostDeviceParallelFor (Box const& box, T ncomp, L&& f) noexcept
 {
-    HostDeviceParallelFor(Gpu::KernelInfo{},box,ncomp,std::forward<L>(f));
+    HostDeviceParallelFor<AMREX_GPU_MAX_THREADS>(Gpu::KernelInfo{},box,ncomp,std::forward<L>(f));
+}
+
+template <int MT, typename T, typename L, typename M=std::enable_if_t<std::is_integral<T>::value> >
+void HostDeviceParallelFor (Box const& box, T ncomp, L&& f) noexcept
+{
+    HostDeviceParallelFor<MT>(Gpu::KernelInfo{},box,ncomp,std::forward<L>(f));
 }
 
 template <typename L1, typename L2>
 void HostDeviceParallelFor (Box const& box1, Box const& box2, L1&& f1, L2&& f2) noexcept
 {
-    HostDeviceParallelFor(Gpu::KernelInfo{},box1,box2,std::forward<L1>(f1),std::forward<L2>(f2));
+    HostDeviceParallelFor<AMREX_GPU_MAX_THREADS>(Gpu::KernelInfo{},box1,box2,std::forward<L1>(f1),std::forward<L2>(f2));
+}
+
+template <int MT, typename L1, typename L2>
+void HostDeviceParallelFor (Box const& box1, Box const& box2, L1&& f1, L2&& f2) noexcept
+{
+    HostDeviceParallelFor<MT>(Gpu::KernelInfo{},box1,box2,std::forward<L1>(f1),std::forward<L2>(f2));
 }
 
 template <typename L1, typename L2, typename L3>
 void HostDeviceParallelFor (Box const& box1, Box const& box2, Box const& box3,
                             L1&& f1, L2&& f2, L3&& f3) noexcept
 {
-    HostDeviceParallelFor(Gpu::KernelInfo{}, box1,box2,box3,
+    HostDeviceParallelFor<AMREX_GPU_MAX_THREADS>(Gpu::KernelInfo{}, box1,box2,box3,
+                          std::forward<L1>(f1),std::forward<L2>(f2),std::forward<L3>(f3));
+}
+
+template <int MT, typename L1, typename L2, typename L3>
+void HostDeviceParallelFor (Box const& box1, Box const& box2, Box const& box3,
+                            L1&& f1, L2&& f2, L3&& f3) noexcept
+{
+    HostDeviceParallelFor<MT>(Gpu::KernelInfo{}, box1,box2,box3,
                           std::forward<L1>(f1),std::forward<L2>(f2),std::forward<L3>(f3));
 }
 
@@ -1554,7 +2010,16 @@ template <typename T1, typename T2, typename L1, typename L2,
 void HostDeviceParallelFor (Box const& box1, T1 ncomp1, L1&& f1,
                             Box const& box2, T2 ncomp2, L2&& f2) noexcept
 {
-    HostDeviceParallelFor(Gpu::KernelInfo{},box1,ncomp1,std::forward<L1>(f1),box2,ncomp2,std::forward<L2>(f2));
+    HostDeviceParallelFor<AMREX_GPU_MAX_THREADS>(Gpu::KernelInfo{},box1,ncomp1,std::forward<L1>(f1),box2,ncomp2,std::forward<L2>(f2));
+}
+
+template <int MT, typename T1, typename T2, typename L1, typename L2,
+          typename M1=std::enable_if_t<std::is_integral<T1>::value>,
+          typename M2=std::enable_if_t<std::is_integral<T2>::value> >
+void HostDeviceParallelFor (Box const& box1, T1 ncomp1, L1&& f1,
+                            Box const& box2, T2 ncomp2, L2&& f2) noexcept
+{
+    HostDeviceParallelFor<MT>(Gpu::KernelInfo{},box1,ncomp1,std::forward<L1>(f1),box2,ncomp2,std::forward<L2>(f2));
 }
 
 template <typename T1, typename T2, typename T3, typename L1, typename L2, typename L3,
@@ -1565,7 +2030,21 @@ void HostDeviceParallelFor (Box const& box1, T1 ncomp1, L1&& f1,
                             Box const& box2, T2 ncomp2, L2&& f2,
                             Box const& box3, T3 ncomp3, L3&& f3) noexcept
 {
-    HostDeviceParallelFor(Gpu::KernelInfo{},
+    HostDeviceParallelFor<AMREX_GPU_MAX_THREADS>(Gpu::KernelInfo{},
+                          box1,ncomp1,std::forward<L1>(f1),
+                          box2,ncomp2,std::forward<L2>(f2),
+                          box3,ncomp3,std::forward<L3>(f3));
+}
+
+template <int MT, typename T1, typename T2, typename T3, typename L1, typename L2, typename L3,
+          typename M1=std::enable_if_t<std::is_integral<T1>::value>,
+          typename M2=std::enable_if_t<std::is_integral<T2>::value>,
+          typename M3=std::enable_if_t<std::is_integral<T3>::value> >
+void HostDeviceParallelFor (Box const& box1, T1 ncomp1, L1&& f1,
+                            Box const& box2, T2 ncomp2, L2&& f2,
+                            Box const& box3, T3 ncomp3, L3&& f3) noexcept
+{
+    HostDeviceParallelFor<MT>(Gpu::KernelInfo{},
                           box1,ncomp1,std::forward<L1>(f1),
                           box2,ncomp2,std::forward<L2>(f2),
                           box3,ncomp3,std::forward<L3>(f3));

--- a/Src/Base/AMReX_GpuLaunchMacrosG.H
+++ b/Src/Base/AMReX_GpuLaunchMacrosG.H
@@ -40,7 +40,7 @@
     if (amrex::Gpu::inLaunchRegion()) \
     { \
         const auto amrex_i_ec = amrex::Gpu::ExecutionConfig(amrex_i_tn); \
-        AMREX_LAUNCH_KERNEL(amrex_i_ec.numBlocks, amrex_i_ec.numThreads, amrex_i_ec.sharedMem, amrex::Gpu::gpuStream(), \
+        AMREX_LAUNCH_KERNEL(AMREX_GPU_MAX_THREADS, amrex_i_ec.numBlocks, amrex_i_ec.numThreads, amrex_i_ec.sharedMem, amrex::Gpu::gpuStream(), \
         [=] AMREX_GPU_DEVICE () noexcept { \
             for (auto const TI : amrex::Gpu::Range(amrex_i_tn)) { \
                 block \
@@ -111,7 +111,7 @@
         dim3 amrex_i_nblocks = amrex::max(amrex_i_ec1.numBlocks.x, \
                                           amrex_i_ec2.numBlocks.x); \
         amrex_i_nblocks.y = 2; \
-        AMREX_LAUNCH_KERNEL(amrex_i_nblocks, amrex_i_ec1.numThreads, 0, amrex::Gpu::gpuStream(), \
+        AMREX_LAUNCH_KERNEL(AMREX_GPU_MAX_THREADS, amrex_i_nblocks, amrex_i_ec1.numThreads, 0, amrex::Gpu::gpuStream(), \
         [=] AMREX_GPU_DEVICE () noexcept { \
             switch (blockIdx.y) { \
             case 0: for (auto const TI1 : amrex::Gpu::Range(amrex_i_tn1)) { \
@@ -202,7 +202,7 @@
                                                      amrex_i_ec2.numBlocks.x), \
                                                      amrex_i_ec3.numBlocks.x); \
         amrex_i_nblocks.y = 3; \
-        AMREX_LAUNCH_KERNEL(amrex_i_nblocks, amrex_i_ec1.numThreads, 0, amrex::Gpu::gpuStream(), \
+        AMREX_LAUNCH_KERNEL(AMREX_GPU_MAX_THREADS, amrex_i_nblocks, amrex_i_ec1.numThreads, 0, amrex::Gpu::gpuStream(), \
         [=] AMREX_GPU_DEVICE () noexcept { \
             switch (blockIdx.y) { \
             case 0: for (auto const TI1 : amrex::Gpu::Range(amrex_i_tn1)) { \
@@ -269,7 +269,7 @@
     if (amrex::Gpu::inLaunchRegion()) \
     { \
         auto amrex_i_ec = amrex::Gpu::ExecutionConfig(amrex_i_tn); \
-        AMREX_LAUNCH_KERNEL(amrex_i_ec.numBlocks, amrex_i_ec.numThreads, amrex_i_ec.sharedMem, amrex::Gpu::gpuStream(), \
+        AMREX_LAUNCH_KERNEL(AMREX_GPU_MAX_THREADS, amrex_i_ec.numBlocks, amrex_i_ec.numThreads, amrex_i_ec.sharedMem, amrex::Gpu::gpuStream(), \
         [=] AMREX_GPU_DEVICE () noexcept { \
             for (auto const TI : amrex::Gpu::Range(amrex_i_tn)) { \
                 block \
@@ -333,7 +333,7 @@
         dim3 amrex_i_nblocks = amrex::max(amrex_i_ec1.numBlocks.x, \
                                           amrex_i_ec2.numBlocks.x); \
         amrex_i_nblocks.y = 2; \
-        AMREX_LAUNCH_KERNEL(amrex_i_nblocks, amrex_i_ec1.numThreads, 0, amrex::Gpu::gpuStream(), \
+        AMREX_LAUNCH_KERNEL(AMREX_GPU_MAX_THREADS, amrex_i_nblocks, amrex_i_ec1.numThreads, 0, amrex::Gpu::gpuStream(), \
         [=] AMREX_GPU_DEVICE () noexcept { \
             switch (blockIdx.y) { \
             case 0: for (auto const TI1 : amrex::Gpu::Range(amrex_i_tn1)) { \
@@ -410,7 +410,7 @@
                                                      amrex_i_ec2.numBlocks.x), \
                                                      amrex_i_ec3.numBlocks.x); \
         amrex_i_nblocks.y = 3; \
-        AMREX_LAUNCH_KERNEL(amrex_i_nblocks, amrex_i_ec1.numThreads, 0, amrex::Gpu::gpuStream(), \
+        AMREX_LAUNCH_KERNEL(AMREX_GPU_MAX_THREADS, amrex_i_nblocks, amrex_i_ec1.numThreads, 0, amrex::Gpu::gpuStream(), \
         [=] AMREX_GPU_DEVICE () noexcept { \
             switch (blockIdx.y) { \
             case 0: for (auto const TI1 : amrex::Gpu::Range(amrex_i_tn1)) { \

--- a/Src/Base/AMReX_Reduce.H
+++ b/Src/Base/AMReX_Reduce.H
@@ -935,7 +935,8 @@ bool AnyOf (Box const& box, P&& pred)
         }
     });
 #else
-    AMREX_LAUNCH_KERNEL(ec.numBlocks, ec.numThreads, 0, Gpu::gpuStream(),
+    AMREX_LAUNCH_KERNEL(AMREX_GPU_MAX_THREADS, ec.numBlocks, ec.numThreads, 0,
+                        Gpu::gpuStream(),
     [=] AMREX_GPU_DEVICE () noexcept {
         __shared__ int has_any;
         if (threadIdx.x == 0) has_any = *dp;


### PR DESCRIPTION
By default, amrex::ParallelFor launches AMREX_GPU_MAX_THREADS threads per block. We can now explicitly specfiy the block size with `ParallelFor<BLOCK_SIZE>(...)`, where BLOCK_SIZE should be a multiple of the warp size (e.g., 64, 128, etc.).  A similar change has also been made to `launch`.

The changes are backward compatible.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
