### PR TITLE
Byte spread fixes

### DIFF
--- a/Src/Particle/AMReX_ParticleContainer.H
+++ b/Src/Particle/AMReX_ParticleContainer.H
@@ -524,9 +524,9 @@ public:
     */
     bool OK (int lev_min = 0, int lev_max = -1, int nGrow = 0) const;
 
-    std::array<Long, Long, Long> ByteSpread () const;
+    std::array<Long, 3> ByteSpread () const;
 
-    std::array<Long, Long, Long> PrintCapacity () const;
+    std::array<Long, 3> PrintCapacity () const;
 
     void ShrinkToFit ();
 

--- a/Src/Particle/AMReX_ParticleContainer.H
+++ b/Src/Particle/AMReX_ParticleContainer.H
@@ -524,13 +524,9 @@ public:
     */
     bool OK (int lev_min = 0, int lev_max = -1, int nGrow = 0) const;
 
-    void ByteSpread () const;
+    std::array<Long, Long, Long> ByteSpread () const;
 
-    void PrintCapacity () const;
-
-    void ByteSpread (Long& a_mn, Long& a_mx, Long& a_cnt) const;
-
-    void PrintCapacity (Long& a_mn, Long& a_mx, Long& a_cnt) const;
+    std::array<Long, Long, Long> PrintCapacity () const;
 
     void ShrinkToFit ();
 

--- a/Src/Particle/AMReX_ParticleContainer.H
+++ b/Src/Particle/AMReX_ParticleContainer.H
@@ -528,6 +528,10 @@ public:
 
     void PrintCapacity () const;
 
+    void ByteSpread (Long& a_mn, Long& a_mx, Long& a_cnt) const;
+
+    void PrintCapacity (Long& a_mn, Long& a_mx, Long& a_cnt) const;
+    
     void ShrinkToFit ();
 
     /**

--- a/Src/Particle/AMReX_ParticleContainer.H
+++ b/Src/Particle/AMReX_ParticleContainer.H
@@ -531,7 +531,7 @@ public:
     void ByteSpread (Long& a_mn, Long& a_mx, Long& a_cnt) const;
 
     void PrintCapacity (Long& a_mn, Long& a_mx, Long& a_cnt) const;
-    
+
     void ShrinkToFit ();
 
     /**

--- a/Src/Particle/AMReX_ParticleContainerI.H
+++ b/Src/Particle/AMReX_ParticleContainerI.H
@@ -497,7 +497,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>
     Long mn = cnt, mx = mn;
 
     const int IOProc = ParallelContext::IOProcessorNumberSub();
-    const std::size_t sz = sizeof(ParticleType)+NumRealComps()*sizeof(ParticleReal)+NumIntComps()*sizeof(int);
+    const Long sz = sizeof(ParticleType)+NumRealComps()*sizeof(ParticleReal)+NumIntComps()*sizeof(int);
 
 #ifdef AMREX_LAZY
     Lazy::QueueReduction( [=] () mutable {
@@ -519,7 +519,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>
         });
 #endif
 
-    return {(Long) mn*sz, (Long) mx*sz, (Long) cnt*sz};
+    return {mn*sz, mx*sz, cnt*sz};
 }
 
 template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt,

--- a/Src/Particle/AMReX_ParticleContainerI.H
+++ b/Src/Particle/AMReX_ParticleContainerI.H
@@ -481,7 +481,8 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>::Nu
 template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt,
           template<class> class Allocator>
 void
-ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>::ByteSpread () const
+ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>
+::ByteSpread (Long& a_mn, Long& a_mx, Long& a_cnt) const
 {
     Long cnt = 0;
 
@@ -505,10 +506,10 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>::By
             ParallelReduce::Max(mx,  IOProc, ParallelContext::CommunicatorSub());
             ParallelReduce::Sum(cnt, IOProc, ParallelContext::CommunicatorSub());
 
-            amrex::Print() << "ParticleContainer byte spread across MPI nodes: [Min: "
+            amrex::Print() << "ParticleContainer spread across MPI nodes - bytes (num particles): [Min: "
                            << mn*sz
                            << " (" << mn << ")"
-                           << ", Max:  "
+                           << ", Max: "
                            << mx*sz
                            << " (" << mx << ")"
                            << ", Total: "
@@ -517,12 +518,17 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>::By
 #ifdef AMREX_LAZY
         });
 #endif
+
+    a_mn += mn*sz;
+    a_mx += mx*sz;
+    a_cnt += cnt*sz;
 }
 
 template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt,
           template<class> class Allocator>
 void
-ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>::PrintCapacity () const
+ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>
+::PrintCapacity (Long& a_mn, Long& a_mx, Long& a_cnt) const
 {
     Long cnt = 0;
 
@@ -537,7 +543,6 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>::Pr
     Long mn = cnt, mx = mn;
 
     const int IOProc = ParallelContext::IOProcessorNumberSub();
-    const std::size_t sz = sizeof(ParticleType)+NumRealComps()*sizeof(ParticleReal)+NumIntComps()*sizeof(int);
 
 #ifdef AMREX_LAZY
     Lazy::QueueReduction( [=] () mutable {
@@ -546,18 +551,43 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>::Pr
             ParallelReduce::Max(mx,  IOProc, ParallelContext::CommunicatorSub());
             ParallelReduce::Sum(cnt, IOProc, ParallelContext::CommunicatorSub());
 
-            amrex::Print() << "ParticleContainer byte spread across MPI nodes: [Min: "
-                           << mn*sz
-                           << " (" << mn << ")"
-                           << ", Max:  "
-                           << mx*sz
-                           << " (" << mx << ")"
+            amrex::Print() << "ParticleContainer spread across MPI nodes - bytes: [Min: "
+                           << mn
+                           << ", Max: "
+                           << mx
                            << ", Total: "
-                           << cnt*sz
-                           << " (" << cnt << ")]\n";
+                           << cnt
+                           << "]\n";
 #ifdef AMREX_LAZY
         });
 #endif
+    a_mn += mn;
+    a_mx += mx;
+    a_cnt += cnt;
+}
+
+template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt,
+          template<class> class Allocator>
+void
+ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>
+::ByteSpread () const
+{
+    Long mn = 0;
+    Long mx = 0;
+    Long cnt = 0;
+    ByteSpread(mn, mx, cnt);
+}
+
+template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt,
+          template<class> class Allocator>
+void
+ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>
+::PrintCapacity () const
+{
+    Long mn = 0;
+    Long mx = 0;
+    Long cnt = 0;
+    PrintCapacity(mn, mx, cnt);
 }
 
 template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt,

--- a/Src/Particle/AMReX_ParticleContainerI.H
+++ b/Src/Particle/AMReX_ParticleContainerI.H
@@ -566,30 +566,6 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>
 template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt,
           template<class> class Allocator>
 void
-ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>
-::ByteSpread () const
-{
-    Long mn = 0;
-    Long mx = 0;
-    Long cnt = 0;
-    ByteSpread(mn, mx, cnt);
-}
-
-template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt,
-          template<class> class Allocator>
-void
-ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>
-::PrintCapacity () const
-{
-    Long mn = 0;
-    Long mx = 0;
-    Long cnt = 0;
-    PrintCapacity(mn, mx, cnt);
-}
-
-template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt,
-          template<class> class Allocator>
-void
 ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>::ShrinkToFit ()
 {
     for (unsigned lev = 0; lev < m_particles.size(); lev++) {

--- a/Src/Particle/AMReX_ParticleContainerI.H
+++ b/Src/Particle/AMReX_ParticleContainerI.H
@@ -480,7 +480,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>::Nu
 
 template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt,
           template<class> class Allocator>
-std::array<Long, Long, Long>
+std::array<Long, 3>
 ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>
 ::ByteSpread () const
 {
@@ -524,7 +524,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>
 
 template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt,
           template<class> class Allocator>
-std::array<Long, Long, Long>
+std::array<Long, 3>
 ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>
 ::PrintCapacity () const
 {

--- a/Src/Particle/AMReX_ParticleContainerI.H
+++ b/Src/Particle/AMReX_ParticleContainerI.H
@@ -496,7 +496,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>::By
     Long mn = cnt, mx = mn;
 
     const int IOProc = ParallelContext::IOProcessorNumberSub();
-    const std::size_t sz = sizeof(ParticleType)+NumRealComps()*sizeof(Real)+NumIntComps()*sizeof(int);
+    const std::size_t sz = sizeof(ParticleType)+NumRealComps()*sizeof(ParticleReal)+NumIntComps()*sizeof(int);
 
 #ifdef AMREX_LAZY
     Lazy::QueueReduction( [=] () mutable {
@@ -505,13 +505,15 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>::By
             ParallelReduce::Max(mx,  IOProc, ParallelContext::CommunicatorSub());
             ParallelReduce::Sum(cnt, IOProc, ParallelContext::CommunicatorSub());
 
-            amrex::Print() << "ParticleContainer byte spread across MPI nodes: ["
+            amrex::Print() << "ParticleContainer byte spread across MPI nodes: [Min: "
                            << mn*sz
                            << " (" << mn << ")"
-                           << " ... "
+                           << ", Max:  "
                            << mx*sz
                            << " (" << mx << ")"
-                           << "] total particles: (" << cnt << ")\n";
+                           << ", Total: "
+                           << cnt*sz
+                           << " (" << cnt << ")]\n";
 #ifdef AMREX_LAZY
         });
 #endif
@@ -535,6 +537,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>::Pr
     Long mn = cnt, mx = mn;
 
     const int IOProc = ParallelContext::IOProcessorNumberSub();
+    const std::size_t sz = sizeof(ParticleType)+NumRealComps()*sizeof(ParticleReal)+NumIntComps()*sizeof(int);
 
 #ifdef AMREX_LAZY
     Lazy::QueueReduction( [=] () mutable {
@@ -543,13 +546,15 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>::Pr
             ParallelReduce::Max(mx,  IOProc, ParallelContext::CommunicatorSub());
             ParallelReduce::Sum(cnt, IOProc, ParallelContext::CommunicatorSub());
 
-            amrex::Print() << "ParticleContainer byte spread across MPI nodes: ["
-                           << mn
+            amrex::Print() << "ParticleContainer byte spread across MPI nodes: [Min: "
+                           << mn*sz
                            << " (" << mn << ")"
-                           << " ... "
-                           << mx
+                           << ", Max:  "
+                           << mx*sz
                            << " (" << mx << ")"
-                           << "] total memory: (" << cnt << ")\n";
+                           << ", Total: "
+                           << cnt*sz
+                           << " (" << cnt << ")]\n";
 #ifdef AMREX_LAZY
         });
 #endif

--- a/Src/Particle/AMReX_ParticleContainerI.H
+++ b/Src/Particle/AMReX_ParticleContainerI.H
@@ -519,7 +519,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>
         });
 #endif
 
-    return {mn*sz, mx*sz, cnt*sz};
+    return {(Long) mn*sz, (Long) mx*sz, (Long) cnt*sz};
 }
 
 template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt,

--- a/Src/Particle/AMReX_ParticleContainerI.H
+++ b/Src/Particle/AMReX_ParticleContainerI.H
@@ -480,9 +480,9 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>::Nu
 
 template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt,
           template<class> class Allocator>
-void
+std::array<Long, Long, Long>
 ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>
-::ByteSpread (Long& a_mn, Long& a_mx, Long& a_cnt) const
+::ByteSpread () const
 {
     Long cnt = 0;
 
@@ -519,16 +519,14 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>
         });
 #endif
 
-    a_mn += mn*sz;
-    a_mx += mx*sz;
-    a_cnt += cnt*sz;
+    return {mn*sz, mx*sz, cnt*sz};
 }
 
 template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt,
           template<class> class Allocator>
-void
+std::array<Long, Long, Long>
 ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>
-::PrintCapacity (Long& a_mn, Long& a_mx, Long& a_cnt) const
+::PrintCapacity () const
 {
     Long cnt = 0;
 
@@ -561,9 +559,8 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>
 #ifdef AMREX_LAZY
         });
 #endif
-    a_mn += mn;
-    a_mx += mx;
-    a_cnt += cnt;
+
+    return {mn, mx, cnt};
 }
 
 template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt,

--- a/Src/Particle/AMReX_ParticleTile.H
+++ b/Src/Particle/AMReX_ParticleTile.H
@@ -504,11 +504,11 @@ struct ParticleTile
     Long capacity () const
     {
         Long nbytes = 0;
-        nbytes += m_aos_tile().capacity()*sizeof(ParticleType);
+        nbytes += m_aos_tile().capacity() * sizeof(ParticleType);
         for (int j = 0; j < NumRealComps(); ++j)
         {
             auto& rdata = GetStructOfArrays().GetRealData(j);
-            nbytes += rdata.capacity()*sizeof(ParticleReal);
+            nbytes += rdata.capacity() * sizeof(ParticleReal);
         }
 
         for (int j = 0; j < NumIntComps(); ++j)

--- a/Src/Particle/AMReX_ParticleTile.H
+++ b/Src/Particle/AMReX_ParticleTile.H
@@ -503,20 +503,20 @@ struct ParticleTile
 
     Long capacity () const
     {
-        Long nbytes = 0;
-        nbytes += m_aos_tile().capacity() * sizeof(ParticleType);
+        Long nparts = 0;
+        nparts += m_aos_tile().capacity();
         for (int j = 0; j < NumRealComps(); ++j)
         {
             auto& rdata = GetStructOfArrays().GetRealData(j);
-            nbytes += rdata.capacity() * sizeof(ParticleReal);
+            nparts += rdata.capacity();
         }
 
         for (int j = 0; j < NumIntComps(); ++j)
         {
             auto& idata = GetStructOfArrays().GetIntData(j);
-            nbytes += idata.capacity()*sizeof(int);
+            nparts += idata.capacity();
         }
-        return nbytes;
+        return nparts;
     }
 
     void swap (ParticleTile<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>& other)

--- a/Src/Particle/AMReX_ParticleTile.H
+++ b/Src/Particle/AMReX_ParticleTile.H
@@ -503,20 +503,20 @@ struct ParticleTile
 
     Long capacity () const
     {
-        Long nparts = 0;
-        nparts += m_aos_tile().capacity();
+        Long nbytes = 0;
+        nbytes += m_aos_tile().capacity()*sizeof(ParticleType);
         for (int j = 0; j < NumRealComps(); ++j)
         {
             auto& rdata = GetStructOfArrays().GetRealData(j);
-            nparts += rdata.capacity();
+            nbytes += rdata.capacity()*sizeof(ParticleReal);
         }
 
         for (int j = 0; j < NumIntComps(); ++j)
         {
             auto& idata = GetStructOfArrays().GetIntData(j);
-            nparts += idata.capacity();
+            nbytes += idata.capacity()*sizeof(int);
         }
-        return nparts;
+        return nbytes;
     }
 
     void swap (ParticleTile<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>& other)


### PR DESCRIPTION
1. Add a new overload to the ByteSpread and PrintCapacity methods of ParticleContainer that allow a total to be implemented (if you are computing the total memory usage across multiple particle species, for example)

2. Fix a bug that used "Real" instead of "ParticleReal" to compute a memory footprint.

3. More clearly describe the output format of these functions in the printed messages.

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
