### PR TITLE
Add error message in ParallelFor for CUDA 11.6 bug

### DIFF
--- a/Src/Base/AMReX_GpuLaunchFunctsG.H
+++ b/Src/Base/AMReX_GpuLaunchFunctsG.H
@@ -1034,6 +1034,9 @@ ParallelFor (Gpu::KernelInfo const&,
              L1&& f1, L2&& f2, L3&& f3) noexcept
 {
     if (amrex::isEmpty(box1) && amrex::isEmpty(box2) && amrex::isEmpty(box3)) return;
+#if defined(__CUDACC__) && (__CUDACC_VER_MAJOR__ == 11) && (__CUDACC_VER_MINOR__ == 6)
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(0, "CUDA 11.6 bug: https://github.com/AMReX-Codes/amrex/issues/2607");
+#endif
     int ncells1 = box1.numPts();
     int ncells2 = box2.numPts();
     int ncells3 = box3.numPts();


### PR DESCRIPTION
## Summary

Seemingly the same `nvcc` bug first detected in issue #2607 also now causes a failure during the WarpX B-field evolve step. This PR simply adds a user friendly error statement when this happens to help identify the problem.
It is still possible that the same bug would impact other AMReX functions. The location of the current error statement covers the observed issue without impacting other working cases (such as electrostatic WarpX simulations).

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
