### PR TITLE
Add option for makebuildsources to specify git describe style

### DIFF
--- a/Tools/C_scripts/makebuildinfo_C.py
+++ b/Tools/C_scripts/makebuildinfo_C.py
@@ -186,11 +186,11 @@ def runcommand(command):
     out = p.stdout.read()
     return out.strip().decode("ascii")
 
-def get_git_hash(d):
+def get_git_hash(d, git_style):
     cwd = os.getcwd()
     os.chdir(d)
     try:
-        ghash = runcommand("git describe --always --tags --dirty")
+        ghash = runcommand("git describe " + git_style)
     except:
         ghash = ""
     os.chdir(cwd)
@@ -259,6 +259,10 @@ if __name__ == "__main__":
                         help="the full path to the build directory that corresponds to build_git_name",
                         type=str, default="")
 
+    parser.add_argument("--GIT_STYLE",
+                        help="style options for the 'git describe' command used to construct hash strings",
+                        type=str, default="--always --tags --dirty")
+
 
     # parse and convert to a dictionary
     args = parser.parse_args()
@@ -281,7 +285,7 @@ if __name__ == "__main__":
     git_hashes = []
     for d in GIT:
         if d and os.path.isdir(d):
-            git_hashes.append(get_git_hash(d))
+            git_hashes.append(get_git_hash(d, args.GIT_STYLE))
         else:
             git_hashes.append("")
 
@@ -291,7 +295,7 @@ if __name__ == "__main__":
         except:
             build_git_hash = "directory not valid"
         else:
-            build_git_hash = get_git_hash(args.build_git_dir)
+            build_git_hash = get_git_hash(args.build_git_dir, args.GIT_STYLE)
             os.chdir(running_dir)
     else:
         build_git_hash = ""


### PR DESCRIPTION
This adds an optional command line argument `--GIT_STYLE` to the script we use to make the build info.

This argument defaults to the previous style so AMReX codes are not affected if they do not specify this optional argument.

Strings passed to this optional argument are used as the arguments for the `git describe` command used in the script.

## Summary

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
