### PR TITLE
Add GPU-compatible upper bound and lower bound algorithms to AMReX_Algorithm

### DIFF
--- a/Src/Base/AMReX_Algorithm.H
+++ b/Src/Base/AMReX_Algorithm.H
@@ -167,7 +167,7 @@ namespace amrex
             auto it = first;
             const auto step = count/2;
             it += step;
-            if (!(val<*it)){
+            if (!(val < *it)){
                 first = ++it;
                 count -= step + 1;
             }
@@ -193,7 +193,7 @@ namespace amrex
             auto it = first;
             const auto step = count/2;
             it += step;
-            if (!(val<=*it)){
+            if (*it < val){
                 first = ++it;
                 count -= step + 1;
             }

--- a/Src/Base/AMReX_Algorithm.H
+++ b/Src/Base/AMReX_Algorithm.H
@@ -162,12 +162,10 @@ namespace amrex
     ItType upper_bound (ItType first, ItType last, const ValType& val)
     {
 #if AMREX_DEVICE_COMPILE
-        ItType it;
-        std::ptrdiff_t count, step;
-        count = last-first;
+        std::ptrdiff_t count = last-first;
         while(count>0){
-            it = first;
-            step = count/2;
+            auto it = first;
+            const auto step = count/2;
             it += step;
             if (!(val<*it)){
                 first = ++it;
@@ -190,7 +188,8 @@ namespace amrex
     {
 #ifdef AMREX_DEVICE_COMPILE
         std::ptrdiff_t count = last-first;
-        do{
+        while(count>0)
+        {
             auto it = first;
             const auto step = count/2;
             it += step;
@@ -201,7 +200,7 @@ namespace amrex
             else{
                 count = step;
             }
-        } while(count>0);
+        }
 
         return first;
 #else

--- a/Src/Base/AMReX_Algorithm.H
+++ b/Src/Base/AMReX_Algorithm.H
@@ -157,6 +157,58 @@ namespace amrex
         return hi;
     }
 
+    template<typename ItType, typename ValType>
+    AMREX_GPU_DEVICE
+    ItType upper_bound (ItType first, ItType last, const ValType& val)
+    {
+#if AMREX_DEVICE_COMPILE
+        ItType it;
+        size_t count, step;
+        count = last-first;
+        while(count>0){
+            it = first;
+            step = count/2;
+            it += step;
+            if (!(val<*it)){
+                first = ++it;
+                count -= step + 1;
+            }
+            else{
+                count = step;
+            }
+        }
+
+        return first;
+#else
+        return std::upper_bound(first, last, val);
+#endif
+    }
+
+    template<typename ItType, typename ValType>
+    AMREX_GPU_DEVICE
+    ItType lower_bound (ItType first, ItType last, const ValType& val)
+    {
+#ifdef AMREX_DEVICE_COMPILE
+        size_t count = last-first;
+        do{
+            auto it = first;
+            const auto step = count/2;
+            it += step;
+            if (!(val<=*it)){
+                first = ++it;
+                count -= step + 1;
+            }
+            else{
+                count = step;
+            }
+        } while(count>0);
+
+        return first;
+#else
+        return std::lower_bound(first, last, val);
+#endif
+    }
+
 namespace detail {
 
 struct clzll_tag {};

--- a/Src/Base/AMReX_Algorithm.H
+++ b/Src/Base/AMReX_Algorithm.H
@@ -158,7 +158,7 @@ namespace amrex
     }
 
     template<typename ItType, typename ValType>
-    AMREX_GPU_DEVICE
+    AMREX_GPU_HOST_DEVICE
     ItType upper_bound (ItType first, ItType last, const ValType& val)
     {
 #if AMREX_DEVICE_COMPILE
@@ -185,7 +185,7 @@ namespace amrex
     }
 
     template<typename ItType, typename ValType>
-    AMREX_GPU_DEVICE
+    AMREX_GPU_HOST_DEVICE
     ItType lower_bound (ItType first, ItType last, const ValType& val)
     {
 #ifdef AMREX_DEVICE_COMPILE

--- a/Src/Base/AMReX_Algorithm.H
+++ b/Src/Base/AMReX_Algorithm.H
@@ -163,7 +163,7 @@ namespace amrex
     {
 #if AMREX_DEVICE_COMPILE
         ItType it;
-        size_t count, step;
+        std::ptrdiff_t count, step;
         count = last-first;
         while(count>0){
             it = first;
@@ -189,7 +189,7 @@ namespace amrex
     ItType lower_bound (ItType first, ItType last, const ValType& val)
     {
 #ifdef AMREX_DEVICE_COMPILE
-        size_t count = last-first;
+        std::ptrdiff_t count = last-first;
         do{
             auto it = first;
             const auto step = count/2;


### PR DESCRIPTION
## Summary

This PR adds a GPU-compatible replacement of the STL `upper_bound` and  `lower_bound` algorithms to `AMReX_Algorithm.H`. If `AMREX_DEVICE_COMPILE` is not defined, it defaults back to the STL algorithms.

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [X] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
