### PR TITLE
make tagging routines EB_aware

### DIFF
--- a/Src/AmrCore/AMReX_ErrorList.cpp
+++ b/Src/AmrCore/AMReX_ErrorList.cpp
@@ -308,7 +308,6 @@ AMRErrorTag::operator() (TagBoxArray&    tba,
                         ParallelFor(tba, [=] AMREX_GPU_DEVICE (int bi, int i, int j, int k) noexcept
                         {
                             auto const& dat  = datma[bi];
-                            auto const& tag  = tagma[bi];
                             auto const& flag = flags[bi];
 
                             Real ax = 0.; Real ay = 0.;
@@ -335,7 +334,7 @@ AMRErrorTag::operator() (TagBoxArray&    tba,
                             }
 #endif
                             if (amrex::max(AMREX_D_DECL(ax,ay,az)) >= threshold) {
-                                tag(i,j,k) = tag_update;
+                                tagma[bi](i,j,k) = tag_update;
                             }
                         });
                     } else
@@ -344,7 +343,6 @@ AMRErrorTag::operator() (TagBoxArray&    tba,
                         ParallelFor(tba, [=] AMREX_GPU_DEVICE (int bi, int i, int j, int k) noexcept
                         {
                             auto const& dat = datma[bi];
-                            auto const& tag  = tagma[bi];
 
                             Real ax = 0.; Real ay = 0.; Real az = 0.;
                             ax = amrex::Math::abs(dat(i+1,j,k) - dat(i,j,k));
@@ -359,7 +357,7 @@ AMRErrorTag::operator() (TagBoxArray&    tba,
                             az = amrex::max(az,amrex::Math::abs(dat(i,j,k) - dat(i,j,k-1)));
 #endif // DIM > 2
                             if (amrex::max(AMREX_D_DECL(ax,ay,az)) >= threshold) {
-                                tag(i,j,k) = tag_update;
+                                tagma[bi](i,j,k) = tag_update;
                             }
 #endif // DIM > 1
                        });
@@ -375,7 +373,6 @@ AMRErrorTag::operator() (TagBoxArray&    tba,
                         ParallelFor(tba, [=] AMREX_GPU_DEVICE (int bi, int i, int j, int k) noexcept
                         {
                             auto const& dat  = datma[bi];
-                            auto const& tag  = tagma[bi];
                             auto const& flag = flags[bi];
 
                             Real ax = 0.; Real ay = 0.;
@@ -400,19 +397,18 @@ AMRErrorTag::operator() (TagBoxArray&    tba,
                             if (flag(i,j,k).isConnected(0,0,-1)) {
                                 az = amrex::max(az,amrex::Math::abs(dat(i,j,k) - dat(i,j,k-1)));
                             }
+#endif // DIM > 2
                             if (amrex::max(AMREX_D_DECL(ax,ay,az))
                                 >= threshold * amrex::Math::abs(dat(i,j,k))) {
                                 tagma[bi](i,j,k) = tag_update;
                             }
                         });
-#endif // DIM > 2
                     } else
 #endif
                     {
                         ParallelFor(tba, [=] AMREX_GPU_DEVICE (int bi, int i, int j, int k) noexcept
                         {
                             auto const& dat = datma[bi];
-                            auto const& tag  = tagma[bi];
 
                             Real ax = 0.; Real ay = 0.; Real az = 0.;
                             ax = amrex::Math::abs(dat(i+1,j,k) - dat(i,j,k));

--- a/Src/AmrCore/AMReX_ErrorList.cpp
+++ b/Src/AmrCore/AMReX_ErrorList.cpp
@@ -311,7 +311,6 @@ AMRErrorTag::operator() (TagBoxArray&    tba,
                             auto const& flag = flags[bi];
 
                             Real ax = 0.; Real ay = 0.;
-
                             if (flag(i,j,k).isConnected(1,0,0)) {
                                 ax = amrex::max(ax,amrex::Math::abs(dat(i+1,j,k) - dat(i,j,k)));
                             }
@@ -344,15 +343,17 @@ AMRErrorTag::operator() (TagBoxArray&    tba,
                         {
                             auto const& dat = datma[bi];
 
-                            Real ax = 0.; Real ay = 0.; Real az = 0.;
+                            Real ax = 0.;
                             ax = amrex::Math::abs(dat(i+1,j,k) - dat(i,j,k));
                             ax = amrex::max(ax,amrex::Math::abs(dat(i,j,k) - dat(i-1,j,k)));
 #if AMREX_SPACEDIM == 1
                             if (ax >= threshold) { tagma[bi](i,j,k) = tag_update;}
 #else
+                            Real ay = 0.;
                             ay = amrex::Math::abs(dat(i,j+1,k) - dat(i,j,k));
                             ay = amrex::max(ay,amrex::Math::abs(dat(i,j,k) - dat(i,j-1,k)));
 #if AMREX_SPACEDIM > 2
+                            Real az = 0.;
                             az = amrex::Math::abs(dat(i,j,k+1) - dat(i,j,k));
                             az = amrex::max(az,amrex::Math::abs(dat(i,j,k) - dat(i,j,k-1)));
 #endif // DIM > 2
@@ -410,16 +411,15 @@ AMRErrorTag::operator() (TagBoxArray&    tba,
                         {
                             auto const& dat = datma[bi];
 
-                            Real ax = 0.; Real ay = 0.; Real az = 0.;
-                            ax = amrex::Math::abs(dat(i+1,j,k) - dat(i,j,k));
+                            Real ax = amrex::Math::abs(dat(i+1,j,k) - dat(i,j,k));
                             ax = amrex::max(ax,amrex::Math::abs(dat(i,j,k) - dat(i-1,j,k)));
 #if AMREX_SPACEDIM == 1
                             if (ax >= threshold * amrex::Math::abs(dat(i,j,k))) { tagma[bi](i,j,k) = tag_update;}
 #else
-                            ay = amrex::Math::abs(dat(i,j+1,k) - dat(i,j,k));
+                            Real ay = amrex::Math::abs(dat(i,j+1,k) - dat(i,j,k));
                             ay = amrex::max(ay,amrex::Math::abs(dat(i,j,k) - dat(i,j-1,k)));
 #if AMREX_SPACEDIM > 2
-                            az = amrex::Math::abs(dat(i,j,k+1) - dat(i,j,k));
+                            Real az = amrex::Math::abs(dat(i,j,k+1) - dat(i,j,k));
                             az = amrex::max(az,amrex::Math::abs(dat(i,j,k) - dat(i,j,k-1)));
 #endif // DIM > 2
                             if (amrex::max(AMREX_D_DECL(ax,ay,az))

--- a/Src/Base/AMReX_VisMF.H
+++ b/Src/Base/AMReX_VisMF.H
@@ -638,7 +638,6 @@ Read (FabArray<FAB>& fa, const std::string& name)
         }
 
         int totalioreqs = nboxes;
-        int messtotal = 0;
         int reqspending = 0;
         int iopfileindex;
         std::deque<int> iopreads;
@@ -669,7 +668,6 @@ Read (FabArray<FAB>& fa, const std::string& name)
                             }
                         } else {
                             ParallelDescriptor::Send(vreads, tryproc, readtag);
-                            ++messtotal;
                             ++reqspending;
                         }
                         availablefiles.erase(afilesiter);

--- a/Src/Particle/AMReX_ParticleInit.H
+++ b/Src/Particle/AMReX_ParticleInit.H
@@ -1022,8 +1022,6 @@ InitRandom (Long                    icount,
 
         ParticleLocData pld;
 
-        int cnt = 0;
-
         Vector<std::map<std::pair<int, int>, Gpu::HostVector<ParticleType> > > host_particles;
         host_particles.reserve(15);
         host_particles.resize(finestLevel()+1);
@@ -1079,8 +1077,6 @@ InitRandom (Long                    icount,
                 for (int i = 0; i < NArrayInt; i++) {
                     host_int_attribs[pld.m_lev][ind][i].push_back(pdata.int_array_data[i]);
                 }
-
-                cnt++;
               }
         }
 


### PR DESCRIPTION
## Summary
If AMREX_USE_EB is defined, the tagging routines (activated by setting refinement_indicators in the inputs file) now test on isConnected and isCovered to know whether to test on that cell 

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ X] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
