### PR TITLE
Update the SWFFT project site

### DIFF
--- a/Docs/sphinx_documentation/source/SWFFT.rst
+++ b/Docs/sphinx_documentation/source/SWFFT.rst
@@ -98,7 +98,7 @@ AMReX contains two SWFFT tutorials, `SWFFT Poisson`_ and `SWFFT Simple`_:
 .. _`SWFFT Simple`: https://amrex-codes.github.io/amrex/tutorials_html/SWFFT_Tutorial.html#swfft-simple
 
 .. [1]
-   https://xgitlab.cels.anl.gov/hacc/SWFFT
+   https://git.cels.anl.gov/hacc/SWFFT
 
 .. [2]
    SWFFT source code directory in AMReX: amrex/Src/Extern/SWFFT


### PR DESCRIPTION
## Summary
As stated in the [original site](https://xgitlab.cels.anl.gov/hacc/SWFFT), the site moved to https://git.cels.anl.gov/hacc/SWFFT .
The link in the documentation is updated accordingly.

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [x] are described in the proposed changes to the AMReX documentation, if appropriate
