### PR TITLE
SYCL header

### DIFF
--- a/Src/Base/AMReX_GpuAssert.H
+++ b/Src/Base/AMReX_GpuAssert.H
@@ -7,7 +7,7 @@
 #include <cassert>
 
 #ifdef AMREX_USE_DPCPP
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #endif
 
 #if defined(AMREX_USE_DPCPP)

--- a/Src/Base/AMReX_GpuAssert.H
+++ b/Src/Base/AMReX_GpuAssert.H
@@ -7,7 +7,7 @@
 #include <cassert>
 
 #ifdef AMREX_USE_DPCPP
-#include <sycl/sycl.hpp>
+#include <SYCL/sycl.hpp>
 #endif
 
 #if defined(AMREX_USE_DPCPP)

--- a/Src/Base/AMReX_GpuPrint.H
+++ b/Src/Base/AMReX_GpuPrint.H
@@ -7,7 +7,7 @@
 #include <cstdio>
 
 #ifdef AMREX_USE_DPCPP
-#include <sycl/sycl.hpp>
+#include <SYCL/sycl.hpp>
 #endif
 
 #if defined(AMREX_USE_DPCPP)

--- a/Src/Base/AMReX_GpuPrint.H
+++ b/Src/Base/AMReX_GpuPrint.H
@@ -7,7 +7,7 @@
 #include <cstdio>
 
 #ifdef AMREX_USE_DPCPP
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #endif
 
 #if defined(AMREX_USE_DPCPP)

--- a/Src/Base/AMReX_GpuQualifiers.H
+++ b/Src/Base/AMReX_GpuQualifiers.H
@@ -39,7 +39,7 @@
 
 #ifdef AMREX_USE_DPCPP
 
-# include <CL/sycl.hpp>
+# include <sycl/sycl.hpp>
 
 # define AMREX_REQUIRE_SUBGROUP_SIZE(x) \
   _Pragma("clang diagnostic push") \

--- a/Src/Base/AMReX_GpuQualifiers.H
+++ b/Src/Base/AMReX_GpuQualifiers.H
@@ -39,7 +39,7 @@
 
 #ifdef AMREX_USE_DPCPP
 
-# include <sycl/sycl.hpp>
+# include <SYCL/sycl.hpp>
 
 # define AMREX_REQUIRE_SUBGROUP_SIZE(x) \
   _Pragma("clang diagnostic push") \

--- a/Src/Base/AMReX_GpuTypes.H
+++ b/Src/Base/AMReX_GpuTypes.H
@@ -7,7 +7,7 @@
 #ifdef AMREX_USE_GPU
 
 #ifdef AMREX_USE_DPCPP
-#include <sycl/sycl.hpp>
+#include <SYCL/sycl.hpp>
 #endif
 
 namespace amrex {

--- a/Src/Base/AMReX_GpuTypes.H
+++ b/Src/Base/AMReX_GpuTypes.H
@@ -7,8 +7,7 @@
 #ifdef AMREX_USE_GPU
 
 #ifdef AMREX_USE_DPCPP
-#include <CL/sycl.hpp>
-namespace sycl = cl::sycl;
+#include <sycl/sycl.hpp>
 #endif
 
 namespace amrex {

--- a/Src/Base/AMReX_Math.H
+++ b/Src/Base/AMReX_Math.H
@@ -8,8 +8,7 @@
 #include <cstdlib>
 
 #ifdef AMREX_USE_DPCPP
-#include <CL/sycl.hpp>
-namespace sycl = cl::sycl;
+#include <sycl/sycl.hpp>
 #endif
 
 namespace amrex { inline namespace disabled {

--- a/Src/Base/AMReX_Math.H
+++ b/Src/Base/AMReX_Math.H
@@ -8,7 +8,7 @@
 #include <cstdlib>
 
 #ifdef AMREX_USE_DPCPP
-#include <sycl/sycl.hpp>
+#include <SYCL/sycl.hpp>
 #endif
 
 namespace amrex { inline namespace disabled {

--- a/Src/Base/AMReX_RandomEngine.H
+++ b/Src/Base/AMReX_RandomEngine.H
@@ -14,7 +14,7 @@
 #include <curand.h>
 #include <curand_kernel.h>
 #elif defined(AMREX_USE_DPCPP)
-#include <sycl/sycl.hpp>
+#include <SYCL/sycl.hpp>
 #include <oneapi/mkl/rng/device.hpp>
 namespace mkl = oneapi::mkl;
 #endif

--- a/Src/Base/AMReX_RandomEngine.H
+++ b/Src/Base/AMReX_RandomEngine.H
@@ -14,8 +14,7 @@
 #include <curand.h>
 #include <curand_kernel.h>
 #elif defined(AMREX_USE_DPCPP)
-#include <CL/sycl.hpp>
-namespace sycl = cl::sycl;
+#include <sycl/sycl.hpp>
 #include <oneapi/mkl/rng/device.hpp>
 namespace mkl = oneapi::mkl;
 #endif


### PR DESCRIPTION
Change from `CL/sycl.hpp` to `sycl/sycl.hpp`.  The latter is what we should use now since SYCL 2020.