### PR TITLE
MLLinOp::postSolve

### DIFF
--- a/Src/LinearSolvers/MLMG/AMReX_MLEBNodeFDLaplacian.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBNodeFDLaplacian.H
@@ -119,6 +119,8 @@ public:
                           Array4<Real const> const& bfab) const override;
 #endif
 
+    virtual void postSolve (Vector<Any>& sol) const override;
+
 private:
     GpuArray<Real,AMREX_SPACEDIM> m_sigma{{AMREX_D_DECL(1_rt,1_rt,1_rt)}};
     Real m_s_phi_eb = std::numeric_limits<Real>::lowest();

--- a/Src/LinearSolvers/MLMG/AMReX_MLLinOp.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLLinOp.H
@@ -330,6 +330,8 @@ public:
 
     virtual void AnyAverageDownAndSync (Vector<Any>& sol) const = 0;
 
+    virtual void postSolve (Vector<Any>& sol) const;
+
     Real MFNormInf (MultiFab const& mf, iMultiFab const* fine_mask, bool local) const;
 
     bool isMFIterSafe (int amrlev, int mglev1, int mglev2) const;

--- a/Src/LinearSolvers/MLMG/AMReX_MLLinOp.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLLinOp.cpp
@@ -1159,6 +1159,9 @@ MLLinOp::AnyInterpAssignMG (int amrlev, int fmglev, Any& fine, Any& crse) const
     interpAssign(amrlev, fmglev, fine.get<MultiFab>(), crse.get<MultiFab>());
 }
 
+void
+MLLinOp::postSolve (Vector<Any>& /* sol */) const {}
+
 bool
 MLLinOp::isMFIterSafe (int amrlev, int mglev1, int mglev2) const
 {

--- a/Src/LinearSolvers/MLMG/AMReX_MLMG.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLMG.cpp
@@ -218,6 +218,8 @@ MLMG::solve (Vector<Any>& a_sol, const Vector<Any>& a_rhs,
         timer[iter_time] = amrex::second() - iter_start_time;
     }
 
+    linop.postSolve(sol);
+
     IntVect ng_back = final_fill_bc ? IntVect(1) : IntVect(0);
     if (linop.hasHiddenDimension()) {
         ng_back[linop.hiddenDirection()] = 0;


### PR DESCRIPTION
Add a virtual function MLLinOp::postSolve.  This allows WarpX to set EB covered nodes to prescribed values in the solver's output for visualization purpose.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
