### PR TITLE
MFIter::Finalize

### DIFF
--- a/Src/Base/AMReX_MFIter.H
+++ b/Src/Base/AMReX_MFIter.H
@@ -180,6 +180,7 @@ protected:
     IndexType     typ;
 
     bool          dynamic;
+    bool          initialized;
 
     struct DeviceSync {
         DeviceSync () = default;

--- a/Src/Base/AMReX_MFIter.H
+++ b/Src/Base/AMReX_MFIter.H
@@ -201,6 +201,7 @@ protected:
     static AMREX_EXPORT int allow_multiple_mfiters;
 
     void Initialize ();
+    void Finalize ();
 };
 
 //! Is it safe to have these two MultiFabs in the same MFiter?

--- a/Src/Base/AMReX_MFIter.H
+++ b/Src/Base/AMReX_MFIter.H
@@ -180,7 +180,7 @@ protected:
     IndexType     typ;
 
     bool          dynamic;
-    bool          initialized;
+    bool          finalized = false;
 
     struct DeviceSync {
         DeviceSync () = default;

--- a/Src/Base/AMReX_MFIter.cpp
+++ b/Src/Base/AMReX_MFIter.cpp
@@ -209,6 +209,12 @@ MFIter::MFIter (const FabArrayBase& fabarray_, const MFItInfo& info)
 
 MFIter::~MFIter ()
 {
+    Finalize();
+}
+
+void
+MFIter::Finalize ()
+{
 #ifdef AMREX_USE_OMP
 #pragma omp master
 #endif

--- a/Src/Base/AMReX_MFIter.cpp
+++ b/Src/Base/AMReX_MFIter.cpp
@@ -215,10 +215,13 @@ MFIter::~MFIter ()
 void
 MFIter::Finalize ()
 {
+    if (!initialized) return;
+
 #ifdef AMREX_USE_OMP
 #pragma omp master
 #endif
     {
+        initialized = false;
         depth = 0;
     }
 
@@ -353,6 +356,13 @@ MFIter::Initialize ()
 #endif
 
         typ = fabArray.boxArray().ixType();
+    }
+
+#ifdef AMREX_USE_OMP
+#pragma omp master
+#endif
+    {
+        initialized = true;
     }
 }
 

--- a/Src/Base/AMReX_MFIter.cpp
+++ b/Src/Base/AMReX_MFIter.cpp
@@ -215,13 +215,13 @@ MFIter::~MFIter ()
 void
 MFIter::Finalize ()
 {
-    if (!initialized) return;
+    if (finalized) return;
+    finalized = true;
 
 #ifdef AMREX_USE_OMP
 #pragma omp master
 #endif
     {
-        initialized = false;
         depth = 0;
     }
 
@@ -356,13 +356,6 @@ MFIter::Initialize ()
 #endif
 
         typ = fabArray.boxArray().ixType();
-    }
-
-#ifdef AMREX_USE_OMP
-#pragma omp master
-#endif
-    {
-        initialized = true;
     }
 }
 


### PR DESCRIPTION
## Summary

Add a Finalize function to MFIter.

The idea about this is, that we can call this already before destruction in Python, where `for` loops do not create scope.

This function must be robust enough to be called again in the constructor (or we need to add an extra bool to guard that it is not called again in the destructor).

## Additional background

See: https://github.com/AMReX-Codes/pyamrex/pull/30 and WarpX dev meeting notes from Oct 11th, 2022.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
