### PR TITLE
`MFIter::Finalize`: Free `m_fa`

### DIFF
--- a/Src/Base/AMReX_MFIter.cpp
+++ b/Src/Base/AMReX_MFIter.cpp
@@ -249,6 +249,7 @@ MFIter::Finalize ()
 #pragma omp single
 #endif
         m_fa->clearThisBD();
+        m_fa.reset(nullptr);
     }
 }
 

--- a/Src/Base/AMReX_MFIter.cpp
+++ b/Src/Base/AMReX_MFIter.cpp
@@ -249,6 +249,8 @@ MFIter::Finalize ()
 #pragma omp single
 #endif
         m_fa->clearThisBD();
+    }
+    if (m_fa) {
         m_fa.reset(nullptr);
     }
 }


### PR DESCRIPTION
## Summary

This `free` should potentially not be delayed until the destructor is called.

## Additional background

Follow-up to #2985 #2983

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
