### PR TITLE
Add user defined BC types

### DIFF
--- a/Docs/sphinx_documentation/source/Basics.rst
+++ b/Docs/sphinx_documentation/source/Basics.rst
@@ -2549,7 +2549,11 @@ The basic idea behind physical boundary conditions is as follows:
            Reflection from interior cells with sign
            changed, :math:`q(-i) = -q(i)`.
 
--  For external Dirichlet boundaries, the user needs to provide a
+       user_1, user_2 and user_3
+           "User".  It is the user's responsibility to write a routine
+           to fill ghost cells (more details below).
+
+-  For external Dirichlet and user boundaries, the user needs to provide a
    callable object like below.
 
    .. highlight:: c++
@@ -2564,7 +2568,7 @@ The basic idea behind physical boundary conditions is as follows:
                             const BCRec* bcr, const int bcomp,
                             const int orig_comp) const
            {
-               // external Dirichlet for cell iv
+               // external Dirichlet or user BC for cell iv
            }
        };
 

--- a/Docs/sphinx_documentation/source/LinearSolvers.rst
+++ b/Docs/sphinx_documentation/source/LinearSolvers.rst
@@ -209,8 +209,8 @@ function
 
 ::
 
-    void setDomainBC (const Array<BCType,AMREX_SPACEDIM>& lobc,  // for lower ends
-                      const Array<BCType,AMREX_SPACEDIM>& hibc); // for higher ends
+    void setDomainBC (const Array<LinOpBCType,AMREX_SPACEDIM>& lobc,  // for lower ends
+                      const Array<LinOpBCType,AMREX_SPACEDIM>& hibc); // for higher ends
 
 The supported BC types at the physical domain boundaries are
 
@@ -761,4 +761,3 @@ An example (implemented in the ``MultiComponent`` tutorial) might be:
 See ``amrex-tutorials/ExampleCodes/LinearSolvers/MultiComponent`` for a complete working example.
 
 .. solver reuse
-

--- a/Src/Base/AMReX_BC_TYPES.H
+++ b/Src/Base/AMReX_BC_TYPES.H
@@ -73,7 +73,10 @@ enum mathematicalBndryTypes : int {
     foextrap     =  2,
     ext_dir      =  3,
     hoextrap     =  4,
-    hoextrapcc   =  5
+    hoextrapcc   =  5,
+    user_1       = 1001,
+    user_2       = 1002,
+    user_3       = 1003
 };
 }
 
@@ -102,4 +105,3 @@ enum mathematicalBndryTypes : int {
 #endif
 
 #endif
-

--- a/Src/Base/AMReX_bc_types_mod.F90
+++ b/Src/Base/AMReX_bc_types_mod.F90
@@ -15,6 +15,9 @@ module amrex_bc_types_module
   integer, parameter, public :: amrex_bc_ext_dir      =  3
   integer, parameter, public :: amrex_bc_hoextrap     =  4
   integer, parameter, public :: amrex_bc_hoextrapcc   =  5
+  integer, parameter, public :: amrex_bc_user_1       =  1001
+  integer, parameter, public :: amrex_bc_user_2       =  1002
+  integer, parameter, public :: amrex_bc_user_3       =  1003
 
   integer, parameter, public :: amrex_pbc_interior    = 0
   integer, parameter, public :: amrex_pbc_inflow      = 1


### PR DESCRIPTION
Add BCType::user_1, BCType::user_2 and BCType::user_3.  Previously the only "user" type is ext_dir (external Dirichlet).  The BC types are passed from the user's code to FillPatch, which in turn passes them back to the user provided BC filling function.  These new types will make it easy for the user to determine the user defined BC types in their BC filling functions.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
