### PR TITLE
`FabArray::isDefined`

### DIFF
--- a/Src/Base/AMReX_FabArray.H
+++ b/Src/Base/AMReX_FabArray.H
@@ -440,7 +440,10 @@ public:
 
     /** Has define() been called on this rank?
      *
-     * \return true if define has been called on this MultiFab to allocate it
+     * \return true if `define` has been called on this `FabArray`.  Note that all constructors except `FabArray ()`
+     * and `FabArray(Arena*a)` call `define`, even if the `MFInfo` argument has `alloc=false`.  One could
+     * also use `FabArrayBase::empty()` to find whether `define` is called or not, although they are not exactly
+     * the same.
      */
     bool isDefined () const;
 

--- a/Src/Base/AMReX_FabArray.H
+++ b/Src/Base/AMReX_FabArray.H
@@ -438,6 +438,12 @@ public:
     */
     bool ok () const;
 
+    /** Has define() been called on this rank?
+     *
+     * \return true if define has been called on this MultiFab to allocate it
+     */
+    bool isDefined () const;
+
     //! Return a constant reference to the FAB associated with mfi.
     const FAB& operator[] (const MFIter& mfi) const noexcept { return *(this->fabPtr(mfi)); }
 
@@ -1128,6 +1134,7 @@ protected:
     std::unique_ptr<FabFactory<FAB> > m_factory;
     DataAllocator m_dallocator;
 
+    //! has define() been called?
     bool define_function_called = false;
 
     //
@@ -1766,6 +1773,13 @@ FabArray<FAB>::ok () const
     ParallelAllReduce::Min(isok, ParallelContext::CommunicatorSub());
 
     return isok == 1;
+}
+
+template <class FAB>
+bool
+FabArray<FAB>::isDefined () const
+{
+    return define_function_called;
 }
 
 template <class FAB>


### PR DESCRIPTION
## Summary

Add a new query to `define_function_called`.

## Additional background

This is a cheaper check than `ok()` for finding out if a MultiFab has been allocated or not yet, assuming that the calling code follows the convention that `define()` is called collectively.

Update: It turns out you can also call `empty` inherited from `FabArrayBase`. The new API is quite explicit, which is ok, too.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
