### PR TITLE
Fix a bug in ReduceOps when there is no work

### DIFF
--- a/Src/Base/AMReX_Reduce.H
+++ b/Src/Base/AMReX_Reduce.H
@@ -274,6 +274,8 @@ class ReduceData
 public:
     using Type = GpuTuple<Ts...>;
 
+    template <typename... Ps> friend class ReduceOps;
+
     template <typename... Ps>
     explicit ReduceData (ReduceOps<Ps...>& reduce_op)
         : m_max_blocks(Gpu::Device::maxBlocksPerLaunch()),
@@ -330,6 +332,7 @@ private:
     Type* m_device_tuple = nullptr;
     GpuArray<int,AMREX_GPU_MAX_STREAMS+1> m_nblocks;
     std::function<Type()> m_fn_value;
+    bool m_device_tuple_set = false;
 };
 
 namespace Reduce { namespace detail {
@@ -450,6 +453,7 @@ public:
                 Reduce::detail::for_each_parallel<0, ReduceTuple, Ps...>(dst, r);
 #endif
             });
+            reduce_data.m_device_tuple_set = true;
         }
     }
 
@@ -567,6 +571,7 @@ public:
 #endif
         });
         nblocks = std::max(nblocks, nblocks_ec);
+        reduce_data.m_device_tuple_set = true;
     }
 
     template <typename N, typename D, typename F,
@@ -627,6 +632,7 @@ public:
 #endif
         });
         nblocks = std::max(nblocks, nblocks_ec);
+        reduce_data.m_device_tuple_set = true;
     }
 
     template <typename N, typename D, typename F,
@@ -675,14 +681,20 @@ public:
 #endif
         });
         nblocks = amrex::max(nblocks, nblocks_ec);
+        reduce_data.m_device_tuple_set = true;
     }
 
     template <typename D>
     typename D::Type value (D & reduce_data)
     {
         using ReduceTuple = typename D::Type;
-        auto const& stream = Gpu::gpuStream();
         auto hp = reduce_data.hostPtr();
+        if (!reduce_data.m_device_tuple_set) {
+            Reduce::detail::for_each_init<0, ReduceTuple, Ps...>(*hp);
+            return *hp;
+        }
+
+        auto const& stream = Gpu::gpuStream();
         auto dp = reduce_data.devicePtr();
         auto const& nblocks = reduce_data.nBlocks();
         int maxblocks = reduce_data.maxBlocks();


### PR DESCRIPTION
This fixes a bug in the GPU version of ReduceOps.  If there is no work for GPU, the tuple on the device is uninitialized. It is then copied to the host and returned.  This could happen in ParReduce when a MultiFab has no boxes on a process, as reported in #3000 by @BenWibking.  The bug was introduced in April 2021.

Close #3000.

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
