### PR TITLE
Add YAFluxRegister::getFineData

### DIFF
--- a/Src/Boundary/AMReX_YAFluxRegister.H
+++ b/Src/Boundary/AMReX_YAFluxRegister.H
@@ -58,6 +58,8 @@ public:
 
     MultiFab& getFineData ();
 
+    MultiFab& getCrseData ();
+
     enum CellType : int {
         // must be same as in AMReX_YAFluxRegiser_K.H
         crse_cell = 0, crse_fine_boundary_cell, fine_cell

--- a/Src/Boundary/AMReX_YAFluxRegister.H
+++ b/Src/Boundary/AMReX_YAFluxRegister.H
@@ -56,6 +56,8 @@ public:
         return !(m_cfp_fab[mfi.LocalIndex()].empty());
     }
 
+    MultiFab& getFineData ();
+
     enum CellType : int {
         // must be same as in AMReX_YAFluxRegiser_K.H
         crse_cell = 0, crse_fine_boundary_cell, fine_cell

--- a/Src/Boundary/AMReX_YAFluxRegister.cpp
+++ b/Src/Boundary/AMReX_YAFluxRegister.cpp
@@ -377,4 +377,10 @@ YAFluxRegister::getFineData ()
     return m_cfpatch;
 }
 
+MultiFab&
+YAFluxRegister::getCrseData ()
+{
+    return m_crse_data;
+}
+
 }

--- a/Src/Boundary/AMReX_YAFluxRegister.cpp
+++ b/Src/Boundary/AMReX_YAFluxRegister.cpp
@@ -371,4 +371,10 @@ YAFluxRegister::Reflux (MultiFab& state, int dc)
     MultiFab::Add(state, m_crse_data, 0, dc, m_ncomp, 0);
 }
 
+MultiFab&
+YAFluxRegister::getFineData ()
+{
+    return m_cfpatch;
+}
+
 }


### PR DESCRIPTION
This will allow an application code to save and reset the fine data stored in YAFluxRegister.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
