### PR TITLE
Fix compilation for PETSc

### DIFF
--- a/Src/Extern/PETSc/AMReX_PETSc.cpp
+++ b/Src/Extern/PETSc/AMReX_PETSc.cpp
@@ -1,13 +1,13 @@
 
-#include <petscksp.h>
-#include <AMReX_PETSc.H>
-
 #ifdef AMREX_USE_EB
 #include <AMReX_MultiCutFab.H>
 #include <AMReX_EBFabFactory.H>
 #endif
 
 #include <AMReX_Habec_K.H>
+
+#include <petscksp.h>
+#include <AMReX_PETSc.H>
 
 #include <cmath>
 #include <numeric>


### PR DESCRIPTION
We cannot include PETSc headers too early because it might redefine MPI routines as macros
(https://github.com/petsc/petsc/blob/main/include/petsclog.h#L441).  They break MPI calls like below,

    MPI_Allreduce(&tmp, &vi, 1,
                  ParallelDescriptor::Mpi_typemap<T>::type(),
                  ParallelDescriptor::Mpi_op<T,amrex::Greater<T>>(), comm);

because of the `,` in `<T,amrex::Greater<T>>`.
