### PR TITLE
Use std::less for comparison of pointers

### DIFF
--- a/Src/Base/AMReX_CArena.H
+++ b/Src/Base/AMReX_CArena.H
@@ -89,7 +89,7 @@ protected:
         //! The "less-than" operator.
         bool operator< (const Node& rhs) const noexcept
         {
-            return m_block < rhs.m_block;
+            return std::less<void*>()(m_block, rhs.m_block);
         }
 
         //! The equality operator.


### PR DESCRIPTION
In principle, using `<` for pointer comparison is UB.  In practice, the compilers (e.g., clang) use `<` in their implementation.
