### PR TITLE
Add math functions to amrex::Math

### DIFF
--- a/Src/Base/AMReX_Math.H
+++ b/Src/Base/AMReX_Math.H
@@ -6,6 +6,8 @@
 #include <AMReX_Extension.H>
 #include <cmath>
 #include <cstdlib>
+#include <type_traits>
+#include <utility>
 
 #ifdef AMREX_USE_DPCPP
 #include <CL/sycl.hpp>
@@ -56,6 +58,128 @@ using std::isfinite;
 using std::isinf;
 
 #endif
+
+template <typename T>
+constexpr std::enable_if_t<std::is_floating_point<T>::value,T> pi ()
+{
+    return T(3.1415926535897932384626433832795029L);
+}
+
+//! Return cos(x*pi) given x
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+double cospi (double x)
+{
+#if defined(AMREX_USE_DPCPP)
+    return sycl::cospi(x);
+#elif defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+    return ::cospi(x);
+#else
+    return std::cos(pi<double>()*x);
+#endif
+}
+
+//! Return cos(x*pi) given x
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+float cospi (float x)
+{
+#if defined(AMREX_USE_DPCPP)
+    return sycl::cospi(x);
+#elif defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+    return ::cospif(x);
+#else
+    return std::cos(pi<float>()*x);
+#endif
+}
+
+//! Return sin(x*pi) given x
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+double sinpi (double x)
+{
+#if defined(AMREX_USE_DPCPP)
+    return sycl::sinpi(x);
+#elif defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+    return ::sinpi(x);
+#else
+    return std::sin(pi<double>()*x);
+#endif
+}
+
+//! Return sin(x*pi) given x
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+float sinpi (float x)
+{
+#if defined(AMREX_USE_DPCPP)
+    return sycl::sinpi(x);
+#elif defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+    return ::sinpif(x);
+#else
+    return std::sin(pi<float>()*x);
+#endif
+}
+
+//! Return sine and cosine of given number
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+std::pair<double,double> sincos (double x)
+{
+    std::pair<double,double> r;
+#if defined(AMREX_USE_DPCPP)
+    r.first = sycl::sincos(x, &r.second);
+#elif defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__) || defined(_GNU_SOURCE)
+    ::sincos(x, &r.first, &r.second);
+#else
+    r.first  = std::sin(x);
+    r.second = std::cos(x);
+#endif
+    return r;
+}
+
+//! Return sine and cosine of given number
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+std::pair<float,float> sincos (float x)
+{
+    std::pair<float,float> r;
+#if defined(AMREX_USE_DPCPP)
+    r.first = sycl::sincos(x, &r.second);
+#elif defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__) || defined(_GNU_SOURCE)
+    ::sincosf(x, &r.first, &r.second);
+#else
+    r.first  = std::sin(x);
+    r.second = std::cos(x);
+#endif
+    return r;
+}
+
+//! Return sin(pi*x) and cos(pi*x) given x
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+std::pair<double,double> sincospi (double x)
+{
+    std::pair<double,double> r;
+#if defined(AMREX_USE_DPCPP)
+    r.first = sycl::sincos(pi<double>()*x, &r.second);
+#elif defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+    ::sincospi(x, &r.first, &r.second);
+#else
+    r.first  = std::sin(pi<double>()*x);
+    r.second = std::cos(pi<double>()*x);
+#endif
+    return r;
+}
+
+//! Return sin(pi*x) and cos(pi*x) given x
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+std::pair<float,float> sincospi (float x)
+{
+    std::pair<float,float> r;
+#if defined(AMREX_USE_DPCPP)
+    r.first = sycl::sincos(pi<float>()*x, &r.second);
+#elif defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+    ::sincospif(x, &r.first, &r.second);
+#else
+    r.first  = std::sin(pi<float>()*x);
+    r.second = std::cos(pi<float>()*x);
+#endif
+    return r;
+}
 
 }}
 


### PR DESCRIPTION
Add a function to return PI and the following trig functions,

  - `cospi(x)` returns `cos(pi*x)`
  - `sinpi(x)` returns `sin(pi*x)`
  - `sincos(x)` returns `sin(x)` and `cos(x)` in `std::pair`
  - `sincospi(x)` returns `sin(pi*x)` and `cos(pi*x)` in `std::pair`

Because we use C++17 now, one could use structured binding on the `std::pair`
returned by `sincos` and `sincospi`.

    auto const [sin_x, cos_x] = amrex::Math::sincos(x);
