### PR TITLE
Replace all `sprintf` by `snprintf`

### DIFF
--- a/Src/Amr/AMReX_AmrLevel.cpp
+++ b/Src/Amr/AMReX_AmrLevel.cpp
@@ -266,7 +266,7 @@ AmrLevel::writePlotFile (const std::string& dir,
     //
     static const std::string BaseName = "/Cell";
     char buf[64];
-    sprintf(buf, "Level_%d", level);
+    snprintf(buf, sizeof buf, "Level_%d", level);
     std::string sLevel = buf;
     //
     // Now for the full pathname of that directory.

--- a/Src/Extern/HDF5/AMReX_PlotFileUtilHDF5.cpp
+++ b/Src/Extern/HDF5/AMReX_PlotFileUtilHDF5.cpp
@@ -175,7 +175,7 @@ WriteGenericPlotfileHeaderHDF5 (hid_t fid,
 
     char comp_name[32];
     for (int ivar = 0; ivar < varnames.size(); ++ivar) {
-        sprintf(comp_name, "component_%d", ivar);
+        snprintf(comp_name, sizeof comp_name, "component_%d", ivar);
         CreateWriteHDF5AttrString(fid, comp_name, varnames[ivar].c_str());
     }
 
@@ -222,8 +222,8 @@ WriteGenericPlotfileHeaderHDF5 (hid_t fid,
     }
 
     for (int level = 0; level <= finest_level; ++level) {
-        sprintf(level_name, "level_%d", level);
-        /* sprintf(level_name, "%s%d", levelPrefix.c_str(), level); */
+        snprintf(level_name, sizeof level_name, "level_%d", level);
+        /* snprintf(level_name, sizeof level_name, "%s%d", levelPrefix.c_str(), level); */
         grp = H5Gcreate(fid, level_name, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
         if (grp < 0) {
             std::cout << "H5Gcreate [" << level_name << "] failed!" << std::endl;
@@ -525,7 +525,7 @@ void WriteMultiLevelPlotfileHDF5SingleDset (const std::string& plotfilename,
     // Write data for each level
     char level_name[32];
     for (int level = 0; level <= finest_level; ++level) {
-        sprintf(level_name, "level_%d", level);
+        snprintf(level_name, sizeof level_name, "level_%d", level);
 #ifdef AMREX_USE_HDF5_ASYNC
         grp = H5Gopen_async(fid, level_name, H5P_DEFAULT, es_id_g);
 #else
@@ -961,7 +961,7 @@ void WriteMultiLevelPlotfileHDF5MultiDset (const std::string& plotfilename,
     char level_name[32];
 
     for (int level = 0; level <= finest_level; ++level) {
-        sprintf(level_name, "level_%d", level);
+        snprintf(level_name, sizeof level_name, "level_%d", level);
 #ifdef AMREX_USE_HDF5_ASYNC
         grp = H5Gopen_async(fid, level_name, H5P_DEFAULT, es_id_g);
 #else
@@ -1158,7 +1158,7 @@ void WriteMultiLevelPlotfileHDF5MultiDset (const std::string& plotfilename,
                 writeDataSize += writeDataItems;
             }
 
-            sprintf(dataname, "data:datatype=%d", jj);
+            snprintf(dataname, sizeof dataname, "data:datatype=%d", jj);
 #ifdef AMREX_USE_HDF5_ASYNC
             dataset = H5Dcreate_async(grp, dataname, H5T_NATIVE_DOUBLE, dataspace, H5P_DEFAULT, dcpl_id, H5P_DEFAULT, es_id_g);
             if(dataset < 0) std::cout << ParallelDescriptor::MyProc() << "create data failed!  ret = " << dataset << std::endl;

--- a/Src/Extern/HDF5/AMReX_WriteBinaryParticleDataHDF5.H
+++ b/Src/Extern/HDF5/AMReX_WriteBinaryParticleDataHDF5.H
@@ -244,7 +244,7 @@ void WriteHDF5ParticleDataSync (PC const& pc,
             set_stripe = 1;
         }
         if (set_stripe == 1) {
-            sprintf(setstripe, "lfs setstripe -c %d -S %dm %s", stripe_count, stripe_size, pdir.c_str());
+            snprintf(setstripe, sizeof setstripe, "lfs setstripe -c %d -S %dm %s", stripe_count, stripe_size, pdir.c_str());
             std::cout << "Setting stripe parameters for HDF5 output: " << setstripe << std::endl;
             amrex::ignore_unused(std::system(setstripe));
         }
@@ -290,7 +290,7 @@ void WriteHDF5ParticleDataSync (PC const& pc,
         for (int i = 0; i < NStructReal + pc.NumRealComps(); ++i ) {
             if (write_real_comp[i]) {
                 /* HdrFile << real_comp_names[i] << '\n'; */
-                sprintf(comp_name, "real_component_%d", i);
+                snprintf(comp_name, sizeof comp_name, "real_component_%d", i);
                 CreateWriteHDF5AttrString(fid, comp_name, real_comp_names[i].c_str());
             }
         }
@@ -301,7 +301,7 @@ void WriteHDF5ParticleDataSync (PC const& pc,
         // int component names
         for (int i = 0; i < NStructInt + pc.NumIntComps(); ++i ) {
             if (write_int_comp[i]) {
-                sprintf(comp_name, "int_component_%d", i);
+                snprintf(comp_name, sizeof comp_name, "int_component_%d", i);
                 CreateWriteHDF5AttrString(fid, comp_name, int_comp_names[i].c_str());
             }
         }
@@ -323,7 +323,7 @@ void WriteHDF5ParticleDataSync (PC const& pc,
         H5Pset_fill_time(dcpl_id, H5D_FILL_TIME_NEVER);
 
         for (int lev = 0; lev <= finest_level; ++lev) {
-            sprintf(level_name, "level_%d", lev);
+            snprintf(level_name, sizeof level_name, "level_%d", lev);
 
             grp = H5Gcreate(fid, level_name, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
             if (grp < 0) {
@@ -398,7 +398,7 @@ void WriteHDF5ParticleDataSync (PC const& pc,
     char level_name[64];
     for (int lev = 0; lev <= pc.finestLevel(); lev++)
     {
-        sprintf(level_name, "level_%d", lev);
+        snprintf(level_name, sizeof level_name, "level_%d", lev);
 #ifdef AMREX_USE_HDF5_ASYNC
         grp = H5Gopen_async(fid, level_name, H5P_DEFAULT, es_par_g);
 #else

--- a/Src/Extern/ProfParser/AMReX_BLWritePlotFile.cpp
+++ b/Src/Extern/ProfParser/AMReX_BLWritePlotFile.cpp
@@ -108,7 +108,7 @@ void WritePlotfile(const std::string         &pfversion,
         const BoxArray &ba = data[iLevel].boxArray();
         int nGrids = ba.size();
         char buf[64];
-        sprintf(buf, "Level_%d", iLevel);
+        snprintf(buf, sizeof buf, "Level_%d", iLevel);
 
         if(ParallelDescriptor::IOProcessor()) {
             os << iLevel << ' ' << nGrids << ' ' << time << '\n';
@@ -441,7 +441,7 @@ void WritePlotfile2DFrom3D(const std::string &pfversion,
         const BoxArray &ba = data[iLevel].boxArray();
         int nGrids = ba.size();
         char buf[64];
-        sprintf(buf, "Level_%d", iLevel);
+        snprintf(buf, sizeof buf, "Level_%d", iLevel);
 
         if(ParallelDescriptor::IOProcessor()) {
             os << iLevel << ' ' << nGrids << ' ' << time << '\n';


### PR DESCRIPTION
## Summary

Change all `sprintf` to `snprintf`. This makes the code safer, although the current code seems to be correct.

## Additional background

`sprintf` is deemed insecure and should not be used.

In many cases, the code could be changed to use `std::ostringstream` instead; this would probably reduce the code size as well.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
