### PR TITLE
min/max- and linear combination-preserving interpolater

### DIFF
--- a/Src/AmrCore/AMReX_MFInterp_1D_C.H
+++ b/Src/AmrCore/AMReX_MFInterp_1D_C.H
@@ -31,6 +31,8 @@ void mf_cell_cons_lin_interp_limit_minmax_llslope (int i, int, int, Array4<Real>
     for (int ns = 0; ns < ncomp; ++ns) {
         slope(i,0,0,ns) *= sfx;
     }
+
+    amrex::ignore_unused(ratio);
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE

--- a/Src/AmrCore/AMReX_MFInterp_1D_C.H
+++ b/Src/AmrCore/AMReX_MFInterp_1D_C.H
@@ -4,6 +4,36 @@
 namespace amrex {
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void mf_cell_cons_lin_interp_limit_minmax_llslope (int i, int, int, Array4<Real> const& slope,
+                                      Array4<Real const> const& u, int scomp, int ncomp,
+                                      Box const& domain, IntVect const& ratio, BCRec const* bc) noexcept
+{
+    Real sfx = Real(1.0);
+
+    for (int ns = 0; ns < ncomp; ++ns) {
+        int nu = ns + scomp;
+
+        // x-direction
+        Real dc = mf_compute_slopes_x(i, 0, 0, u, nu, domain, bc[ns]);
+        Real df = Real(2.0) * (u(i+1,0,0,nu) - u(i  ,0,0,nu));
+        Real db = Real(2.0) * (u(i  ,0,0,nu) - u(i-1,0,0,nu));
+        Real sx = (df*db >= Real(0.0)) ? amrex::min(amrex::Math::abs(df),amrex::Math::abs(db)) : Real(0.);
+        sx = amrex::Math::copysign(Real(1.),dc)*amrex::min(sx,amrex::Math::abs(dc));
+        slope(i,0,0,ns) = dc;
+
+        // additional limiting is unnecessary in 1D
+
+        if (dc != Real(0.0)) {
+            sfx = amrex::min(sfx, sx / dc);
+        }
+    }
+
+    for (int ns = 0; ns < ncomp; ++ns) {
+        slope(i,0,0,ns) *= sfx;
+    }
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 void mf_cell_cons_lin_interp_llslope (int i, int, int, Array4<Real> const& slope,
                                       Array4<Real const> const& u, int scomp, int ncomp,
                                       Box const& domain, BCRec const* bc) noexcept

--- a/Src/AmrCore/AMReX_MFInterp_2D_C.H
+++ b/Src/AmrCore/AMReX_MFInterp_2D_C.H
@@ -6,6 +6,71 @@
 namespace amrex {
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void mf_cell_cons_lin_interp_limit_minmax_llslope (int i, int j, int, Array4<Real> const& slope,
+                                      Array4<Real const> const& u, int scomp, int ncomp,
+                                      Box const& domain, IntVect const& ratio, BCRec const* bc) noexcept
+{
+    Real sfx = Real(1.0);
+    Real sfy = Real(1.0);
+
+    for (int ns = 0; ns < ncomp; ++ns) {
+        int nu = ns + scomp;
+
+        // x-direction
+        Real dcx = mf_compute_slopes_x(i, j, 0, u, nu, domain, bc[ns]);
+        Real df = Real(2.0) * (u(i+1,j,0,nu) - u(i  ,j,0,nu));
+        Real db = Real(2.0) * (u(i  ,j,0,nu) - u(i-1,j,0,nu));
+        Real sx = (df*db >= Real(0.0)) ? amrex::min(amrex::Math::abs(df),amrex::Math::abs(db)) : Real(0.);
+        sx = amrex::Math::copysign(Real(1.),dcx)*amrex::min(sx,amrex::Math::abs(dcx));
+        slope(i,j,0,ns        ) = dcx;
+
+        // y-direction
+        Real dcy = mf_compute_slopes_y(i, j, 0, u, nu, domain, bc[ns]);
+        df = Real(2.0) * (u(i,j+1,0,nu) - u(i,j  ,0,nu));
+        db = Real(2.0) * (u(i,j  ,0,nu) - u(i,j-1,0,nu));
+        Real sy = (df*db >= Real(0.0)) ? amrex::min(amrex::Math::abs(df),amrex::Math::abs(db)) : Real(0.);
+        sy = amrex::Math::copysign(Real(1.),dcy)*amrex::min(sy,amrex::Math::abs(dcy));
+        slope(i,j,0,ns+  ncomp) = dcy;
+
+        // adjust limited slopes to prevent new min/max for this component
+        Real alpha = Real(1.0);
+        if (sx != Real(0.0) || sy != Real(0.0)) {
+            Real dumax = amrex::Math::abs(sx) * Real(ratio[0]-1)/Real(2*ratio[0])
+                +        amrex::Math::abs(sy) * Real(ratio[1]-1)/Real(2*ratio[1]);
+            Real umax = u(i,j,0,nu);
+            Real umin = u(i,j,0,nu);
+            for (int joff = -1; joff <= 1; ++joff) {
+            for (int ioff = -1; ioff <= 1; ++ioff) {
+                umin = amrex::min(umin, u(i+ioff,j+joff,0,nu));
+                umax = amrex::max(umax, u(i+ioff,j+joff,0,nu));
+            }}
+            if (dumax * alpha > (umax - u(i,j,0,nu))) {
+                alpha = (umax - u(i,j,0,nu)) / dumax;
+            }
+            if (dumax * alpha > (u(i,j,0,nu) - umin)) {
+                alpha = (u(i,j,0,nu) - umin) / dumax;
+            }
+        }
+        sx *= alpha;
+        sy *= alpha;
+
+        // for each direction, compute minimum of the ratio of limited to unlimited slopes
+        if (dcx != Real(0.0)) {
+            sfx = amrex::min(sfx, sx / dcx);
+        }
+        if (dcy != Real(0.0)) {
+            sfy = amrex::min(sfy, sy / dcy);
+        }
+    }
+
+    // multiply unlimited slopes by the minimum of the ratio of limited to unlimited slopes
+    for (int ns = 0; ns < ncomp; ++ns) {
+        slope(i,j,0,ns        ) *= sfx;
+        slope(i,j,0,ns+  ncomp) *= sfy;
+    }
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 void mf_cell_cons_lin_interp_llslope (int i, int j, int, Array4<Real> const& slope,
                                       Array4<Real const> const& u, int scomp, int ncomp,
                                       Box const& domain, BCRec const* bc) noexcept

--- a/Src/AmrCore/AMReX_MFInterp_3D_C.H
+++ b/Src/AmrCore/AMReX_MFInterp_3D_C.H
@@ -4,6 +4,87 @@
 namespace amrex {
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void mf_cell_cons_lin_interp_limit_minmax_llslope (int i, int j, int k, Array4<Real> const& slope,
+                                      Array4<Real const> const& u, int scomp, int ncomp,
+                                      Box const& domain, IntVect const& ratio, BCRec const* bc) noexcept
+{
+    Real sfx = Real(1.0);
+    Real sfy = Real(1.0);
+    Real sfz = Real(1.0);
+
+    for (int ns = 0; ns < ncomp; ++ns) {
+        int nu = ns + scomp;
+
+        // x-direction
+        Real dcx = mf_compute_slopes_x(i, j, k, u, nu, domain, bc[ns]);
+        Real df = Real(2.0) * (u(i+1,j,k,nu) - u(i  ,j,k,nu));
+        Real db = Real(2.0) * (u(i  ,j,k,nu) - u(i-1,j,k,nu));
+        Real sx = (df*db >= Real(0.0)) ? amrex::min(amrex::Math::abs(df),amrex::Math::abs(db)) : Real(0.);
+        sx = amrex::Math::copysign(Real(1.),dcx)*amrex::min(sx,amrex::Math::abs(dcx));
+        slope(i,j,k,ns        ) = dcx;  // unlimited slope
+
+        // y-direction
+        Real dcy = mf_compute_slopes_y(i, j, k, u, nu, domain, bc[ns]);
+        df = Real(2.0) * (u(i,j+1,k,nu) - u(i,j  ,k,nu));
+        db = Real(2.0) * (u(i,j  ,k,nu) - u(i,j-1,k,nu));
+        Real sy = (df*db >= Real(0.0)) ? amrex::min(amrex::Math::abs(df),amrex::Math::abs(db)) : Real(0.);
+        sy = amrex::Math::copysign(Real(1.),dcy)*amrex::min(sy,amrex::Math::abs(dcy));
+        slope(i,j,k,ns+  ncomp) = dcy;  // unlimited slope
+
+        // z-direction
+        Real dcz = mf_compute_slopes_z(i, j, k, u, nu, domain, bc[ns]);
+        df = Real(2.0) * (u(i,j,k+1,nu) - u(i,j,k  ,nu));
+        db = Real(2.0) * (u(i,j,k  ,nu) - u(i,j,k-1,nu));
+        Real sz = (df*db >= Real(0.0)) ? amrex::min(amrex::Math::abs(df),amrex::Math::abs(db)) : Real(0.);
+        sz = amrex::Math::copysign(Real(1.),dcz)*amrex::min(sz,amrex::Math::abs(dcz));
+        slope(i,j,k,ns+2*ncomp) = dcz;  // unlimited slope
+
+        // adjust limited slopes to prevent new min/max for this component
+        Real alpha = 1.0;
+        if (sx != Real(0.0) || sy != Real(0.0) || sz != Real(0.0)) {
+            Real dumax = amrex::Math::abs(sx) * Real(ratio[0]-1)/Real(2*ratio[0])
+                +        amrex::Math::abs(sy) * Real(ratio[1]-1)/Real(2*ratio[1])
+                +        amrex::Math::abs(sz) * Real(ratio[2]-1)/Real(2*ratio[2]);
+            Real umax = u(i,j,k,nu);
+            Real umin = u(i,j,k,nu);
+            for (int koff = -1; koff <= 1; ++koff) {
+            for (int joff = -1; joff <= 1; ++joff) {
+            for (int ioff = -1; ioff <= 1; ++ioff) {
+                umin = amrex::min(umin, u(i+ioff,j+joff,k+koff,nu));
+                umax = amrex::max(umax, u(i+ioff,j+joff,k+koff,nu));
+            }}}
+            if (dumax * alpha > (umax - u(i,j,k,nu))) {
+                alpha = (umax - u(i,j,k,nu)) / dumax;
+            }
+            if (dumax * alpha > (u(i,j,k,nu) - umin)) {
+                alpha = (u(i,j,k,nu) - umin) / dumax;
+            }
+        }
+        sx *= alpha;
+        sy *= alpha;
+        sz *= alpha;
+
+        // for each direction, compute minimum of the ratio of limited to unlimited slopes
+        if (dcx != Real(0.0)) {
+            sfx = amrex::min(sfx, sx / dcx);
+        }
+        if (dcy != Real(0.0)) {
+            sfy = amrex::min(sfy, sy / dcy);
+        }
+        if (dcz != Real(0.0)) {
+            sfz = amrex::min(sfz, sz / dcz);
+        }
+    }
+
+    // multiply unlimited slopes by the minimum of the ratio of limited to unlimited slopes
+    for (int ns = 0; ns < ncomp; ++ns) {
+        slope(i,j,k,ns        ) *= sfx;
+        slope(i,j,k,ns+  ncomp) *= sfy;
+        slope(i,j,k,ns+2*ncomp) *= sfz;
+    }
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 void mf_cell_cons_lin_interp_llslope (int i, int j, int k, Array4<Real> const& slope,
                                       Array4<Real const> const& u, int scomp, int ncomp,
                                       Box const& domain, BCRec const* bc) noexcept

--- a/Src/AmrCore/AMReX_MFInterpolater.H
+++ b/Src/AmrCore/AMReX_MFInterpolater.H
@@ -71,6 +71,34 @@ protected:
 };
 
 /**
+* \brief Linear conservative interpolation on cell centered data
+*
+* Linear conservative interpolation on cell centered data, i.e, conservative
+* interpolation with a limiting scheme that preserves the value of any
+* linear combination of the fab components. If sum_ivar
+* a(ic,jc,ivar)*fab(ic,jc,ivar) = 0, then sum_ivar
+* a(ic,jc,ivar)*fab(if,jf,ivar) = 0 is satisfied in all fine cells if,jf
+* covering coarse cell ic,jc. This version *also* ensures no new min/max
+* are created by limiting the slope vector.
+*/
+class MFCellConsLinMinmaxLimitInterp
+    : public MFInterpolater
+{
+public:
+    explicit MFCellConsLinMinmaxLimitInterp () {}
+
+    virtual ~MFCellConsLinMinmaxLimitInterp () = default;
+
+    virtual Box CoarseBox (Box const& fine, int ratio) override;
+    virtual Box CoarseBox (Box const& fine, IntVect const& ratio) override;
+
+    virtual void interp (MultiFab const& crsemf, int ccomp, MultiFab& finemf, int fcomp, int ncomp,
+                         IntVect const& ng, Geometry const& cgeom, Geometry const& fgeom,
+                         Box const& dest_domain, IntVect const& ratio,
+                         Vector<BCRec> const& bcs, int bcscomp) override;
+};
+
+/**
  * \brief [Bi|Tri]linear interpolation on cell centered data.
  */
 class MFCellBilinear final
@@ -109,6 +137,7 @@ public:
 extern AMREX_EXPORT MFPCInterp          mf_pc_interp;
 extern AMREX_EXPORT MFCellConsLinInterp mf_cell_cons_interp;
 extern AMREX_EXPORT MFCellConsLinInterp mf_lincc_interp;
+extern AMREX_EXPORT MFCellConsLinMinmaxLimitInterp mf_linear_slope_minmax_interp;
 extern AMREX_EXPORT MFCellBilinear      mf_cell_bilinear_interp;
 extern AMREX_EXPORT MFNodeBilinear      mf_node_bilinear_interp;
 

--- a/Src/AmrCore/AMReX_MFInterpolater.cpp
+++ b/Src/AmrCore/AMReX_MFInterpolater.cpp
@@ -10,6 +10,7 @@ namespace amrex {
 MFPCInterp          mf_pc_interp;
 MFCellConsLinInterp mf_cell_cons_interp(false);
 MFCellConsLinInterp mf_lincc_interp(true);
+MFCellConsLinMinmaxLimitInterp mf_linear_slope_minmax_interp;
 MFCellBilinear      mf_cell_bilinear_interp;
 
 // Nodal
@@ -293,6 +294,102 @@ MFCellConsLinInterp::interp (MultiFab const& crsemf, int ccomp, MultiFab& finemf
                                                 crse, ccomp, nc, ratio);
                     });
                 }
+            }
+        }
+    }
+}
+
+
+Box
+MFCellConsLinMinmaxLimitInterp::CoarseBox (const Box& fine, const IntVect& ratio)
+{
+    Box crse = amrex::coarsen(fine,ratio);
+    crse.grow(1);
+    return crse;
+}
+
+Box
+MFCellConsLinMinmaxLimitInterp::CoarseBox (const Box& fine, int ratio)
+{
+    Box crse = amrex::coarsen(fine,ratio);
+    crse.grow(1);
+    return crse;
+}
+
+void
+MFCellConsLinMinmaxLimitInterp::interp (MultiFab const& crsemf, int ccomp, MultiFab& finemf, int fcomp, int nc,
+                             IntVect const& ng, Geometry const& cgeom, Geometry const& fgeom,
+                             Box const& dest_domain, IntVect const& ratio,
+                             Vector<BCRec> const& bcs, int bcomp)
+{
+    AMREX_ASSERT(crsemf.nGrowVect() == 0);
+    amrex::ignore_unused(fgeom);
+
+    Box const& cdomain = cgeom.Domain();
+
+#ifdef AMREX_USE_GPU
+    if (Gpu::inLaunchRegion()) {
+        MultiFab crse_tmp(crsemf.boxArray(), crsemf.DistributionMap(), AMREX_SPACEDIM*nc, 0);
+        auto const& crse = crsemf.const_arrays();
+        auto const& tmp = crse_tmp.arrays();
+        auto const& ctmp = crse_tmp.const_arrays();
+        auto const& fine = finemf.arrays();
+
+        Gpu::DeviceVector<BCRec> d_bc(nc);
+        BCRec const* pbc = d_bc.data();
+        Gpu::copyAsync(Gpu::hostToDevice, bcs.begin()+bcomp, bcs.begin()+bcomp+nc, d_bc.begin());
+
+        ParallelFor(crsemf, IntVect(-1),
+        [=] AMREX_GPU_DEVICE (int box_no, int i, int j, int k) noexcept
+        {
+            mf_cell_cons_lin_interp_limit_minmax_llslope(i,j,k, tmp[box_no], crse[box_no], ccomp, nc,
+                                     cdomain, ratio, pbc);
+        });
+
+        ParallelFor(finemf, ng, nc,
+        [=] AMREX_GPU_DEVICE (int box_no, int i, int j, int k, int n) noexcept
+        {
+            if (dest_domain.contains(i,j,k)) {
+                mf_cell_cons_lin_interp(i,j,k,n, fine[box_no], fcomp, ctmp[box_no],
+                                        crse[box_no], ccomp, nc, ratio);
+            }
+        });
+
+        Gpu::streamSynchronize();
+    } else
+#endif
+    {
+        BCRec const* pbc = bcs.data() + bcomp;
+
+#ifdef AMREX_USE_OMP
+#pragma omp parallel
+#endif
+        {
+            FArrayBox tmpfab;
+            for (MFIter mfi(finemf); mfi.isValid(); ++mfi) {
+                auto const& fine = finemf.array(mfi);
+                auto const& crse = crsemf.const_array(mfi);
+
+                Box const& cbox = amrex::grow(crsemf[mfi].box(), -1);
+                tmpfab.resize(cbox, AMREX_SPACEDIM*nc);
+                auto const& tmp = tmpfab.array();
+                auto const& ctmp = tmpfab.const_array();
+
+                Box const& fbox = amrex::grow(mfi.validbox(), ng) & dest_domain;
+
+                amrex::LoopConcurrentOnCpu(cbox,
+                [&] (int i, int j, int k) noexcept
+                {
+                    mf_cell_cons_lin_interp_limit_minmax_llslope(i,j,k, tmp, crse, ccomp, nc,
+                                             cdomain, ratio, pbc);
+                });
+
+                amrex::LoopConcurrentOnCpu(fbox, nc,
+                [&] (int i, int j, int k, int n) noexcept
+                {
+                    mf_cell_cons_lin_interp(i,j,k,n, fine, fcomp, ctmp,
+                                            crse, ccomp, nc, ratio);
+                });
             }
         }
     }


### PR DESCRIPTION
## Summary
This linearly interpolates onto fine grids, ensuring no new minima and maxima are created in multi-dimensions and also preserving linear combinations of components in each cell.

The current implementation is only for Cartesian geometry.

## Additional background
`CellConservativeLinear` can do each of these things separately (i.e., `CellConservativeLinear(0)` or `CellConservativeLinear(1)`), but does not preserve both of these properties at the same time.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
