### PR TITLE
Add more functionalities to TypeList

### DIFF
--- a/Src/Base/AMReX_CTOParallelForImpl.H
+++ b/Src/Base/AMReX_CTOParallelForImpl.H
@@ -24,29 +24,6 @@ struct CompileTimeOptions {
 
 #if (__cplusplus >= 201703L)
 
-//namespace meta
-//{
-    template <typename... As, typename... Bs>
-    constexpr auto operator+ (TypeList<As...>, TypeList<Bs...>) {
-        return TypeList<As..., Bs...>{};
-    }
-
-    template <typename... Ls, typename A>
-    constexpr auto single_product (TypeList<Ls...>, A) {
-        return TypeList<decltype(Ls{} + TypeList<A>{})...>{};
-    }
-
-    template <typename LLs, typename... As>
-    constexpr auto operator* (LLs, TypeList<As...>) {
-        return (TypeList<>{} + ... + single_product(LLs{}, As{}));
-    }
-
-    template <typename... Ls>
-    constexpr auto cartesian_product_n (TypeList<Ls...>) {
-        return (TypeList<TypeList<>>{} * ... * Ls{});
-    }
-//}
-
 namespace detail
 {
     template <int MT, typename T, class F, typename... As>
@@ -122,9 +99,8 @@ ParallelFor (TypeList<CTOs...> /*list_of_compile_time_options*/,
              T N, F&& f)
 {
 #if (__cplusplus >= 201703L)
-    using OptionsListList = TypeList<typename CTOs::list_type...>;
     detail::ParallelFor_helper1<MT>(N, std::forward<F>(f),
-                                    cartesian_product_n(OptionsListList{}),
+                                    CartesianProduct(typename CTOs::list_type{}...),
                                     runtime_options);
 #else
     amrex::ignore_unused(N, f, runtime_options);
@@ -138,9 +114,8 @@ void ParallelFor (TypeList<CTOs...> /*list_of_compile_time_options*/,
                   Box const& box, F&& f)
 {
 #if (__cplusplus >= 201703L)
-    using OptionsListList = TypeList<typename CTOs::list_type...>;
     detail::ParallelFor_helper1<MT>(box, std::forward<F>(f),
-                                    cartesian_product_n(OptionsListList{}),
+                                    CartesianProduct(typename CTOs::list_type{}...),
                                     runtime_options);
 #else
     amrex::ignore_unused(box, f, runtime_options);
@@ -155,9 +130,8 @@ ParallelFor (TypeList<CTOs...> /*list_of_compile_time_options*/,
              Box const& box, T ncomp, F&& f)
 {
 #if (__cplusplus >= 201703L)
-    using OptionsListList = TypeList<typename CTOs::list_type...>;
     detail::ParallelFor_helper1<MT>(box, ncomp, std::forward<F>(f),
-                                    cartesian_product_n(OptionsListList{}),
+                                    CartesianProduct(typename CTOs::list_type{}...),
                                     runtime_options);
 #else
     amrex::ignore_unused(box, ncomp, f, runtime_options);

--- a/Src/Base/AMReX_Tuple.H
+++ b/Src/Base/AMReX_Tuple.H
@@ -3,21 +3,18 @@
 #define AMREX_TUPLE_H_
 #include <AMReX_Config.H>
 
-#include <AMReX_TypeTraits.H>
 #include <AMReX_Functional.H>
 #include <AMReX_GpuQualifiers.H>
+#include <AMReX_TypeList.H>
+#include <AMReX_TypeTraits.H>
 
 #include <array>
-#include <tuple>
 #include <functional>
-#include <type_traits>
-#include <utility>
+#include <tuple>
 
 namespace amrex {
     template <class... Ts>
     using Tuple = std::tuple<Ts...>;
-
-    template <class... Ts> struct TypeList {};
 }
 
 namespace amrex {

--- a/Src/Base/AMReX_TypeList.H
+++ b/Src/Base/AMReX_TypeList.H
@@ -1,0 +1,156 @@
+#ifndef AMREX_TYPELIST_H_
+#define AMREX_TYPELIST_H_
+#include <AMReX_Config.H>
+
+#include <utility>
+
+namespace amrex {
+
+//! Struct for holding types
+template <class... Ts>
+struct TypeList
+{
+    //! Number of types in the TypeList
+    static constexpr std::size_t size () noexcept { return sizeof...(Ts); }
+};
+
+namespace detail {
+    template <std::size_t I, typename T> struct TypeListGet;
+
+    template <std::size_t I, typename Head, typename... Tail>
+    struct TypeListGet<I, TypeList<Head, Tail...> >
+        : TypeListGet<I-1, TypeList<Tail...> > {};
+
+    template <typename Head, typename... Tail>
+    struct TypeListGet<0, TypeList<Head, Tail...> > {
+        using type = Head;
+    };
+}
+
+//! Type at position I of a TypeList
+template <std::size_t I, typename T>
+using TypeAt = typename detail::TypeListGet<I,T>::type;
+
+namespace detail
+{
+    template <typename TL, typename F, std::size_t...N>
+    constexpr void for_each_impl (F&&f, std::index_sequence<N...>)
+    {
+        (f(TypeAt<N,TL>{}), ...);
+    }
+
+    template <typename TL, typename F, std::size_t...N>
+    constexpr bool for_each_until_impl (F&&f, std::index_sequence<N...>)
+    {
+        return (f(TypeAt<N,TL>{}) || ...);
+    }
+}
+
+/**
+ * \brief For each type t in TypeList, call f(t)
+ *
+ * For example, instead of
+ \verbatim
+     int order = ...;
+     if (order == 1) {
+         interp<1>(...);
+     } else if (order == 2) {
+         interp<2>(...);
+     } else if (order == 4) {
+         interp<4>(...);
+     }
+ \endverbatim
+ * we could have
+ \verbatim
+     int order = ...;
+     ForEach(TypeList<std::integral_constant<int,1>,
+                      std::integral_constant<int,2>,
+                      std::integral_constant<int,4>>{},
+             [&] (auto order_const) {
+                 if (order_const() == order) {
+                     interp<order_const()>(...);
+                 }
+             });
+ \endverbatim
+ */
+template <typename... Ts, typename F>
+constexpr void
+ForEach (TypeList<Ts...>, F&& f)
+{
+    detail::for_each_impl<TypeList<Ts...>>
+        (std::forward<F>(f), std::make_index_sequence<sizeof...(Ts)>());
+}
+
+/**
+ * \brief For each type t in TypeList, call f(t) until true is returned.
+ *
+ * This behaves like return (f(t0) || f(t1) || f(t2) || ...).  Note that
+ * shor-circuting occurs for the || operators.
+ *
+ * An example,
+ \verbatim
+     void AnyF (Any& dst, Any const& src) {
+         // dst and src are either MultiFab or fMultiFab
+         auto tt = CartesianProduct(TypeList<MultiFab,fMultiFab>{},
+                                    TypeList<MultiFab,fMultiFab>{});
+         bool r = ForEachUtil(tt, [&] (auto t) -> bool
+         {
+             using MF0 = TypeAt<0,decltype(t)>;
+             using MF1 = TypeAt<1,decltype(t)>;
+             if (dst.is<MF0>() && src.is<MF1>()) {
+                 MF0      & dmf = dst.get<MF0>();
+                 MF1 const& smf = src.get<MF1>();
+                 f(dmf, smf);
+                 return true;
+             } else {
+                 return false;
+             }
+         });
+         if (!r) amrex::Abort("Unsupported types");
+     }
+ \endverbatim
+ */
+template <typename... Ts, typename F>
+constexpr bool
+ForEachUntil (TypeList<Ts...>, F&& f)
+{
+    return detail::for_each_until_impl<TypeList<Ts...>>
+        (std::forward<F>(f), std::make_index_sequence<sizeof...(Ts)>());
+}
+
+//! Concatenate two TypeLists
+template <typename... As, typename... Bs>
+constexpr auto operator+ (TypeList<As...>, TypeList<Bs...>) {
+    return TypeList<As..., Bs...>{};
+}
+
+template <typename... Ls, typename A>
+constexpr auto single_product (TypeList<Ls...>, A) {
+    return TypeList<decltype(Ls{} + TypeList<A>{})...>{};
+}
+
+template <typename LLs, typename... As>
+constexpr auto operator* (LLs, TypeList<As...>) {
+    return (TypeList<>{} + ... + single_product(LLs{}, As{}));
+}
+
+/**
+ * \brief Cartesian Product of TypeLists.
+ *
+ * For example,
+ \verbatim
+     CartesianProduct(TypeList<std::integral_constant<int,0>,
+                               std::integral_constant<int,1>>{},
+                      TypeList<std::integral_constant<int,2>,
+                               std::integral_constant<int,3>>{});
+ \endverbatim
+ * returns TypeList of TypeList of integral_constants {{0,2},{1,2},{0,3},{1,3}}.
+ */
+template <typename... Ls>
+constexpr auto CartesianProduct (Ls...) {
+    return (TypeList<TypeList<>>{} * ... * Ls{});
+}
+
+}
+
+#endif

--- a/Src/Base/CMakeLists.txt
+++ b/Src/Base/CMakeLists.txt
@@ -15,6 +15,7 @@ target_sources( amrex
    AMReX_Vector.H
    AMReX_TableData.H
    AMReX_Tuple.H
+   AMReX_TypeList.H
    AMReX.cpp
    AMReX_error_fi.cpp
    AMReX_Version.cpp

--- a/Src/Base/Make.package
+++ b/Src/Base/Make.package
@@ -4,6 +4,8 @@ AMREX_BASE=EXE
 C$(AMREX_BASE)_headers += AMReX_ccse-mpi.H AMReX_Algorithm.H AMReX_Any.H AMReX_Array.H
 C$(AMREX_BASE)_headers += AMReX_Vector.H AMReX_TableData.H AMReX_Tuple.H AMReX_Math.H
 
+C$(AMREX_BASE)_headers += AMReX_TypeList.H
+
 #
 # Utility classes.
 #


### PR DESCRIPTION
Move TypeList to its own header and add more functionalities.

  - TypeList::size() returns the number of types in the TypeList.

  - TypeAt is the type at a given position of a TypeList.

  - ForEach applies a function to each type of a TypeList.

  - ForEachUntil applies a function to each type of a TypeList until true is returned.

  - operator+ concatenates two TypeLists. This is an existing capability.

  - CartesianProduct returns the Cartesian product of TypeLists.  This is an existing capability with a change.  The function now takes a number of TypeLists, instead of a single TypeList packed with these TypeLists.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
