### PR TITLE
Add amrex::demangle for demangling C++ names

### DIFF
--- a/Src/Base/AMReX_Demangle.H
+++ b/Src/Base/AMReX_Demangle.H
@@ -1,0 +1,43 @@
+#ifndef AMREX_DEMANGLE_H_
+#define AMREX_DEMANGLE_H_
+#include <AMReX_Config.H>
+
+#include <string>
+
+#if __has_include(<cxxabi.h>)
+# include <cxxabi.h>
+# include <cstdlib>
+# define AMREX_USE_CXXABI
+#endif
+
+namespace amrex {
+
+/**
+ * \brief Demangle C++ name
+ *
+ * Demange C++ name if possible. For example
+ \verbatim
+     amrex::Box box;
+     std::cout << amrex::demangle(typeid(box).name());
+ \endverbatim
+ * Demangling turns "N5amrex3BoxE" into "amrex::Box".
+ */
+inline std::string demangle (const char* name)
+{
+#ifdef AMREX_USE_CXXABI
+    int status;
+    char* p = abi::__cxa_demangle(name, 0, 0, &status);
+    if (p) {
+        std::string s(p);
+        std::free(p);
+        return s;
+    } else
+#endif
+    {
+        return name;
+    }
+}
+
+}
+
+#endif

--- a/Src/Base/AMReX_Utility.H
+++ b/Src/Base/AMReX_Utility.H
@@ -9,6 +9,7 @@
 #include <AMReX_Vector.H>
 #include <AMReX_Box.H>
 #include <AMReX_BoxArray.H>
+#include <AMReX_Demangle.H>
 #include <AMReX_DistributionMapping.H>
 #include <AMReX_ParallelDescriptor.H>
 #include <AMReX_Random.H>
@@ -24,6 +25,7 @@
 #include <map>
 #include <sstream>
 #include <string>
+#include <typeinfo>
 #include <type_traits>
 
 namespace amrex

--- a/Src/Base/CMakeLists.txt
+++ b/Src/Base/CMakeLists.txt
@@ -19,6 +19,7 @@ target_sources( amrex
    AMReX_error_fi.cpp
    AMReX_Version.cpp
    AMReX.H
+   AMReX_Demangle.H
    AMReX_Exception.H
    AMReX_Extension.H
    AMReX_PODVector.H

--- a/Src/Base/Make.package
+++ b/Src/Base/Make.package
@@ -10,7 +10,7 @@ C$(AMREX_BASE)_headers += AMReX_Vector.H AMReX_TableData.H AMReX_Tuple.H AMReX_M
 C$(AMREX_BASE)_headers += AMReX.H AMReX_Exception.H
 C$(AMREX_BASE)_sources += AMReX.cpp AMReX_error_fi.cpp AMReX_Version.cpp
 
-C$(AMREX_BASE)_headers += AMReX_Extension.H
+C$(AMREX_BASE)_headers += AMReX_Demangle.H AMReX_Extension.H
 
 C$(AMREX_BASE)_headers += AMReX_GpuComplex.H
 


### PR DESCRIPTION
It can turn "N5amrex3BoxE" into "amrex::Box", and "Z4mainEUlvE_" into "main::{lambda()#1}".

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
