### PR TITLE
Update for oneAPI 2023

### DIFF
--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -29,7 +29,7 @@ jobs:
             -DAMReX_PARTICLES=ON                           \
             -DAMReX_GPU_BACKEND=SYCL                       \
             -DCMAKE_C_COMPILER=$(which clang)              \
-            -DCMAKE_CXX_COMPILER=$(which dpcpp)            \
+            -DCMAKE_CXX_COMPILER=$(which icpx)             \
             -DCMAKE_Fortran_COMPILER=$(which gfortran)
         cmake --build build --parallel 2
 

--- a/Docs/sphinx_documentation/source/GPU.rst
+++ b/Docs/sphinx_documentation/source/GPU.rst
@@ -366,16 +366,16 @@ for example ``CMAKE_CXX_FLAGS``, can be used for DPCPP as well.
 
 
 Since CMake does not support autodetection of SYCL compilers yet,
-``CMAKE_CXX_COMPILER`` must be set to a valid SYCL compiler. i.e. ``dpcpp``.
+``CMAKE_CXX_COMPILER`` must be set to a valid SYCL compiler. i.e. ``icpx``.
 Thus **CMAKE_CXX_COMPILER is a required user-input when AMReX_GPU_BACKEND=SYCL**.
-At this time, **the only supported SYCL compiler is dpcpp**.
+At this time, **the only supported SYCL compiler is icpx**.
 Below is an example configuration for SYCL:
 
 .. highlight:: console
 
 ::
 
-   cmake -DAMReX_GPU_BACKEND=SYCL -DCMAKE_CXX_COMPILER=$(which dpcpp)  [other options] /path/to/amrex/source
+   cmake -DAMReX_GPU_BACKEND=SYCL -DCMAKE_CXX_COMPILER=$(which icpx)  [other options] /path/to/amrex/source
 
 
 .. raw:: latex

--- a/Src/Base/AMReX_GpuAssert.H
+++ b/Src/Base/AMReX_GpuAssert.H
@@ -7,7 +7,11 @@
 #include <cassert>
 
 #ifdef AMREX_USE_DPCPP
-#include <CL/sycl.hpp>
+#  if defined(__INTEL_LLVM_COMPILER) && (__INTEL_LLVM_COMPILER < 20230100)
+#    include <CL/sycl.hpp>
+#  else
+#    include <sycl/sycl.hpp>
+#  endif
 #endif
 
 #if defined(AMREX_USE_DPCPP)

--- a/Src/Base/AMReX_GpuDevice.cpp
+++ b/Src/Base/AMReX_GpuDevice.cpp
@@ -151,8 +151,12 @@ Device::Initialize ()
     int gpu_device_count = 0;
 #ifdef AMREX_USE_DPCPP
     {
+#if defined(__INTEL_LLVM_COMPILER) && (__INTEL_LLVM_COMPILER < 20230100)
         sycl::gpu_selector device_selector;
         sycl::platform platform(device_selector);
+#else
+        sycl::platform platform(sycl::gpu_selector_v);
+#endif
         auto const& gpu_devices = platform.get_devices();
         gpu_device_count = gpu_devices.size();
         if (gpu_device_count <= 0) {
@@ -432,8 +436,12 @@ Device::initialize_gpu ()
 
 #elif defined(AMREX_USE_DPCPP)
     { // create device, context and queues
+#if defined(__INTEL_LLVM_COMPILER) && (__INTEL_LLVM_COMPILER < 20230100)
         sycl::gpu_selector gpu_device_selector;
         sycl::platform platform(gpu_device_selector);
+#else
+        sycl::platform platform(sycl::gpu_selector_v);
+#endif
         auto const& gpu_devices = platform.get_devices();
         sycl_device = std::make_unique<sycl::device>(gpu_devices[device_id]);
         sycl_context = std::make_unique<sycl::context>(*sycl_device, amrex_sycl_error_handler);
@@ -453,7 +461,11 @@ Device::initialize_gpu ()
         device_prop.multiProcessorCount = d.get_info<sycl::info::device::max_compute_units>();
         device_prop.maxThreadsPerMultiProcessor = -1; // xxxxx DPCPP todo: d.get_info<sycl::info::device::max_work_items_per_compute_unit>(); // unknown
         device_prop.maxThreadsPerBlock = d.get_info<sycl::info::device::max_work_group_size>();
+#if defined(__INTEL_LLVM_COMPILER) && (__INTEL_LLVM_COMPILER < 20230100)
         auto mtd = d.get_info<sycl::info::device::max_work_item_sizes>();
+#else
+        auto mtd = d.get_info<sycl::info::device::max_work_item_sizes<3>>();
+#endif
         device_prop.maxThreadsDim[0] = mtd[0];
         device_prop.maxThreadsDim[1] = mtd[1];
         device_prop.maxThreadsDim[2] = mtd[2];

--- a/Src/Base/AMReX_GpuLaunchFunctsG.H
+++ b/Src/Base/AMReX_GpuLaunchFunctsG.H
@@ -29,7 +29,11 @@ void launch (int nblocks, int nthreads_per_block, std::size_t shared_mem_bytes,
     auto& q = *(stream.queue);
     try {
         q.submit([&] (sycl::handler& h) {
+#if defined(__INTEL_LLVM_COMPILER) && (__INTEL_LLVM_COMPILER < 20230100)
             sycl::accessor<unsigned long long, 1, sycl::access::mode::read_write, sycl::access::target::local>
+#else
+            sycl::local_accessor<unsigned long long>
+#endif
                 shared_data(sycl::range<1>(shared_mem_numull), h);
             h.parallel_for(sycl::nd_range<1>(sycl::range<1>(nthreads_total),
                                              sycl::range<1>(nthreads_per_block)),
@@ -163,8 +167,12 @@ void ParallelFor (Gpu::KernelInfo const& info, T n, L&& f) noexcept
     try {
         if (info.hasReduction()) {
             q.submit([&] (sycl::handler& h) {
+#if defined(__INTEL_LLVM_COMPILER) && (__INTEL_LLVM_COMPILER < 20230100)
                 sycl::accessor<unsigned long long, 1, sycl::access::mode::read_write,
                                sycl::access::target::local>
+#else
+                sycl::local_accessor<unsigned long long>
+#endif
                     shared_data(sycl::range<1>(Gpu::Device::warp_size), h);
                 h.parallel_for(sycl::nd_range<1>(sycl::range<1>(nthreads_total),
                                                  sycl::range<1>(nthreads_per_block)),
@@ -215,8 +223,12 @@ void ParallelFor (Gpu::KernelInfo const& info, Box const& box, L&& f) noexcept
     try {
         if (info.hasReduction()) {
             q.submit([&] (sycl::handler& h) {
+#if defined(__INTEL_LLVM_COMPILER) && (__INTEL_LLVM_COMPILER < 20230100)
                 sycl::accessor<unsigned long long, 1, sycl::access::mode::read_write,
                                sycl::access::target::local>
+#else
+                sycl::local_accessor<unsigned long long>
+#endif
                     shared_data(sycl::range<1>(Gpu::Device::warp_size), h);
                 h.parallel_for(sycl::nd_range<1>(sycl::range<1>(nthreads_total),
                                                  sycl::range<1>(nthreads_per_block)),
@@ -279,8 +291,12 @@ void ParallelFor (Gpu::KernelInfo const& info, Box const& box, T ncomp, L&& f) n
     try {
         if (info.hasReduction()) {
             q.submit([&] (sycl::handler& h) {
+#if defined(__INTEL_LLVM_COMPILER) && (__INTEL_LLVM_COMPILER < 20230100)
                 sycl::accessor<unsigned long long, 1, sycl::access::mode::read_write,
                                sycl::access::target::local>
+#else
+                sycl::local_accessor<unsigned long long>
+#endif
                     shared_data(sycl::range<1>(Gpu::Device::warp_size), h);
                 h.parallel_for(sycl::nd_range<1>(sycl::range<1>(nthreads_total),
                                                  sycl::range<1>(nthreads_per_block)),

--- a/Src/Base/AMReX_GpuPrint.H
+++ b/Src/Base/AMReX_GpuPrint.H
@@ -7,7 +7,11 @@
 #include <cstdio>
 
 #ifdef AMREX_USE_DPCPP
-#include <CL/sycl.hpp>
+#  if defined(__INTEL_LLVM_COMPILER) && (__INTEL_LLVM_COMPILER < 20230100)
+#    include <CL/sycl.hpp>
+#  else
+#    include <sycl/sycl.hpp>
+#  endif
 #endif
 
 #if defined(AMREX_USE_DPCPP)

--- a/Src/Base/AMReX_GpuQualifiers.H
+++ b/Src/Base/AMReX_GpuQualifiers.H
@@ -13,7 +13,6 @@
 #define AMREX_GPU_GLOBAL __global__
 #define AMREX_GPU_HOST_DEVICE __host__ __device__
 #define AMREX_GPU_CONSTANT __constant__
-#define AMREX_GPU_EXTERNAL
 
 #define AMREX_GPU_MANAGED __managed__
 #define AMREX_GPU_DEVICE_MANAGED __device__ __managed__
@@ -27,11 +26,6 @@
 #define AMREX_GPU_CONSTANT
 #define AMREX_GPU_MANAGED
 #define AMREX_GPU_DEVICE_MANAGED
-#ifdef AMREX_USE_DPCPP
-#define AMREX_GPU_EXTERNAL SYCL_EXTERNAL
-#else
-#define AMREX_GPU_EXTERNAL
-#endif
 
 #endif
 
@@ -39,7 +33,11 @@
 
 #ifdef AMREX_USE_DPCPP
 
-# include <CL/sycl.hpp>
+#  if defined(__INTEL_LLVM_COMPILER) && (__INTEL_LLVM_COMPILER < 20230100)
+#    include <CL/sycl.hpp>
+#  else
+#    include <sycl/sycl.hpp>
+#  endif
 
 # define AMREX_REQUIRE_SUBGROUP_SIZE(x) \
   _Pragma("clang diagnostic push") \

--- a/Src/Base/AMReX_GpuTypes.H
+++ b/Src/Base/AMReX_GpuTypes.H
@@ -7,7 +7,11 @@
 #ifdef AMREX_USE_GPU
 
 #ifdef AMREX_USE_DPCPP
-#include <CL/sycl.hpp>
+#  if defined(__INTEL_LLVM_COMPILER) && (__INTEL_LLVM_COMPILER < 20230100)
+#    include <CL/sycl.hpp>
+#  else
+#    include <sycl/sycl.hpp>
+#  endif
 #endif
 
 namespace amrex {

--- a/Src/Base/AMReX_Math.H
+++ b/Src/Base/AMReX_Math.H
@@ -8,7 +8,11 @@
 #include <cstdlib>
 
 #ifdef AMREX_USE_DPCPP
-#include <CL/sycl.hpp>
+#  if defined(__INTEL_LLVM_COMPILER) && (__INTEL_LLVM_COMPILER < 20230100)
+#    include <CL/sycl.hpp>
+#  else
+#    include <sycl/sycl.hpp>
+#  endif
 #endif
 
 namespace amrex { inline namespace disabled {

--- a/Src/Base/AMReX_RandomEngine.H
+++ b/Src/Base/AMReX_RandomEngine.H
@@ -14,7 +14,11 @@
 #include <curand.h>
 #include <curand_kernel.h>
 #elif defined(AMREX_USE_DPCPP)
-#include <CL/sycl.hpp>
+#  if defined(__INTEL_LLVM_COMPILER) && (__INTEL_LLVM_COMPILER < 20230100)
+#    include <CL/sycl.hpp>
+#  else
+#    include <sycl/sycl.hpp>
+#  endif
 #include <oneapi/mkl/rng/device.hpp>
 namespace mkl = oneapi::mkl;
 #endif

--- a/Tests/GPU/AnyOf/GNUmakefile
+++ b/Tests/GPU/AnyOf/GNUmakefile
@@ -9,7 +9,6 @@ USE_OMP      = FALSE
 TINY_PROFILE = TRUE
 #USE_CUDA     = TRUE
 USE_DPCPP    = TRUE
-COMP         = dpcpp 
 DIM          = 3 
 
 include $(AMREX_HOME)/Tools/GNUMake/Make.defs

--- a/Tools/CMake/AMReXOptions.cmake
+++ b/Tools/CMake/AMReXOptions.cmake
@@ -140,7 +140,7 @@ if (AMReX_DPCPP)
    if (NOT (CMAKE_CXX_COMPILER_ID IN_LIST _valid_dpcpp_compiler_ids) )
       message(WARNING "\nAMReX_GPU_BACKEND=${AMReX_GPU_BACKEND} is tested with "
          "DPCPP. Verify '${CMAKE_CXX_COMPILER_ID}' is correct and potentially "
-         "set CMAKE_CXX_COMPILER=dpcpp.")
+         "set CMAKE_CXX_COMPILER=icpx.")
    endif ()
    unset(_valid_dpcpp_compiler_ids)
 endif ()

--- a/Tools/CMake/AMReXSYCL.cmake
+++ b/Tools/CMake/AMReXSYCL.cmake
@@ -45,7 +45,7 @@ target_compile_features(SYCL INTERFACE cxx_std_17)
 #
 target_compile_options( SYCL
    INTERFACE
-   $<${_cxx_dpcpp}:-Wno-error=sycl-strict -fsycl>
+   $<${_cxx_dpcpp}:-fsycl>
    $<${_cxx_dpcpp}:$<$<BOOL:${AMReX_DPCPP_SPLIT_KERNEL}>:-fsycl-device-code-split=per_kernel>>)
 
 # temporary work-around for DPC++ beta08 bug
@@ -62,13 +62,6 @@ target_compile_options( SYCL
 target_compile_options( SYCL
    INTERFACE
    $<${_cxx_dpcpp}:-Wno-tautological-constant-compare>)
-
-# Need this option to compile with mpiicpc
-if (AMReX_MPI)
-  target_compile_options( SYCL
-    INTERFACE
-    $<${_cxx_dpcpp}:-fsycl-unnamed-lambda>)
-endif ()
 
 if(AMReX_DPCPP_ONEDPL)
     # TBB and PSTL are broken in oneAPI 2021.3.0

--- a/Tools/GNUMake/comps/dpcpp.mak
+++ b/Tools/GNUMake/comps/dpcpp.mak
@@ -1,8 +1,8 @@
 #
 # Generic setup for using gcc
 #
-CXX = dpcpp
-CC  = dpcpp
+CXX = icpx
+CC  = icx
 FC  = ifx
 F90 = ifx
 
@@ -68,7 +68,7 @@ else
   CXXFLAGS += -std=c++17
 endif
 
-CXXFLAGS += -Wno-error=sycl-strict -fsycl
+CXXFLAGS += -fsycl
 CFLAGS   += -std=c11
 
 ifneq ($(DEBUG),TRUE)  # There is currently a bug that DEBUG build will crash.

--- a/Tools/GNUMake/sites/Make.unknown
+++ b/Tools/GNUMake/sites/Make.unknown
@@ -11,7 +11,7 @@ ifeq ($(USE_DPCPP),TRUE)
       CXX := mpiicpc
       FC  := mpiifort
       F90 := mpiifort
-      CXXFLAGS += -cxx=dpcpp
+      CXXFLAGS += -cxx=icpx
       NO_MPI_CHECKING = TRUE
    endif
 endif


### PR DESCRIPTION
A number of things have been deprecated and need to be updated.

  - dpcpp -> icpx

  - sycl::gpu_selector -> sycl::gpu_selector_v

  - sycl::info::device::max_work_item_sizes -> sycl::info::device::max_work_item_sizes<3>

  - sycl::accessor<...,sycl::access::target::local> -> sycl_local_accessor

  - CL/sycl.hpp -> sycl/sycl.hpp

Also remove AMREX_GPU_EXTERNAL because SYCL_EXTERNAL never worked for us.
