### PR TITLE
Fix mis-matched array type that broke mixed-precision restarts

### DIFF
--- a/Src/Base/AMReX_GpuContainers.H
+++ b/Src/Base/AMReX_GpuContainers.H
@@ -137,8 +137,12 @@ namespace Gpu {
     void copy (HostToDevice, InIter begin, InIter end, OutIter result) noexcept
     {
         using value_type = typename std::iterator_traits<InIter>::value_type;
+
+        using out_value_type = typename std::iterator_traits<OutIter>::value_type;
+        static_assert(std::is_same_v<value_type, out_value_type>);
         static_assert(std::is_trivially_copyable<value_type>(),
                       "Can only copy trivially copyable types");
+
         auto size = std::distance(begin, end);
         if (size == 0) return;
 #ifdef AMREX_USE_GPU
@@ -170,8 +174,12 @@ namespace Gpu {
     void copy (DeviceToHost, InIter begin, InIter end, OutIter result) noexcept
     {
         using value_type = typename std::iterator_traits<InIter>::value_type;
+
+        using out_value_type = typename std::iterator_traits<OutIter>::value_type;
+        static_assert(std::is_same_v<value_type, out_value_type>);
         static_assert(std::is_trivially_copyable<value_type>(),
                       "Can only copy trivially copyable types");
+
         auto size = std::distance(begin, end);
         if (size == 0) return;
 #ifdef AMREX_USE_GPU
@@ -203,8 +211,12 @@ namespace Gpu {
     void copy (DeviceToDevice, InIter begin, InIter end, OutIter result) noexcept
     {
         using value_type = typename std::iterator_traits<InIter>::value_type;
+
+        using out_value_type = typename std::iterator_traits<OutIter>::value_type;
+        static_assert(std::is_same_v<value_type, out_value_type>);
         static_assert(std::is_trivially_copyable<value_type>(),
                       "Can only copy trivially copyable types");
+
         auto size = std::distance(begin, end);
         if (size == 0) return;
 #ifdef AMREX_USE_GPU
@@ -237,8 +249,12 @@ namespace Gpu {
     void copyAsync (HostToDevice, InIter begin, InIter end, OutIter result) noexcept
     {
         using value_type = typename std::iterator_traits<InIter>::value_type;
+
+        using out_value_type = typename std::iterator_traits<OutIter>::value_type;
+        static_assert(std::is_same_v<value_type, out_value_type>);
         static_assert(std::is_trivially_copyable<value_type>(),
                       "Can only copy trivially copyable types");
+
         auto size = std::distance(begin, end);
         if (size == 0) return;
 #ifdef AMREX_USE_GPU
@@ -271,8 +287,12 @@ namespace Gpu {
     void copyAsync (DeviceToHost, InIter begin, InIter end, OutIter result) noexcept
     {
         using value_type = typename std::iterator_traits<InIter>::value_type;
+
+        using out_value_type = typename std::iterator_traits<OutIter>::value_type;
+        static_assert(std::is_same_v<value_type, out_value_type>);
         static_assert(std::is_trivially_copyable<value_type>(),
                       "Can only copy trivially copyable types");
+
         auto size = std::distance(begin, end);
         if (size == 0) return;
 #ifdef AMREX_USE_GPU
@@ -305,8 +325,12 @@ namespace Gpu {
     void copyAsync (DeviceToDevice, InIter begin, InIter end, OutIter result) noexcept
     {
         using value_type = typename std::iterator_traits<InIter>::value_type;
+
+        using out_value_type = typename std::iterator_traits<OutIter>::value_type;
+        static_assert(std::is_same_v<value_type, out_value_type>);
         static_assert(std::is_trivially_copyable<value_type>(),
                       "Can only copy trivially copyable types");
+
         auto size = std::distance(begin, end);
         if (size == 0) return;
 #ifdef AMREX_USE_GPU

--- a/Src/Extern/HDF5/AMReX_ParticleHDF5.H
+++ b/Src/Extern/HDF5/AMReX_ParticleHDF5.H
@@ -1398,7 +1398,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>
     host_particles.resize(finest_level_in_file+1);
 
     Vector<std::map<std::pair<int, int>,
-                    std::vector<Gpu::HostVector<Real> > > > host_real_attribs;
+                    std::vector<Gpu::HostVector<ParticleReal> > > > host_real_attribs;
     host_real_attribs.reserve(15);
     host_real_attribs.resize(finest_level_in_file+1);
 

--- a/Src/Particle/AMReX_ParticleContainerI.H
+++ b/Src/Particle/AMReX_ParticleContainerI.H
@@ -1914,7 +1914,7 @@ RedistributeMPI (std::map<int, Vector<char> >& not_ours,
         host_particles.resize(finestLevel()+1);
 
         Vector<std::map<std::pair<int, int>,
-                        std::vector<Gpu::HostVector<Real> > > > host_real_attribs;
+                        std::vector<Gpu::HostVector<ParticleReal> > > > host_real_attribs;
         host_real_attribs.reserve(15);
         host_real_attribs.resize(finestLevel()+1);
 

--- a/Src/Particle/AMReX_ParticleIO.H
+++ b/Src/Particle/AMReX_ParticleIO.H
@@ -916,7 +916,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>
     host_particles.resize(finest_level_in_file+1);
 
     Vector<std::map<std::pair<int, int>,
-                    std::vector<Gpu::HostVector<Real> > > > host_real_attribs;
+                    std::vector<Gpu::HostVector<RTYPE> > > > host_real_attribs;
     host_real_attribs.reserve(15);
     host_real_attribs.resize(finest_level_in_file+1);
 

--- a/Src/Particle/AMReX_ParticleIO.H
+++ b/Src/Particle/AMReX_ParticleIO.H
@@ -972,7 +972,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>
 
         // add the real...
         for (int icomp = 0; icomp < NumRealComps(); icomp++) {
-            host_real_attribs[lev][ind][icomp].push_back(ParticleReal(*rptr));
+            host_real_attribs[lev][ind][icomp].push_back(*rptr);
             ++rptr;
         }
 

--- a/Src/Particle/AMReX_ParticleIO.H
+++ b/Src/Particle/AMReX_ParticleIO.H
@@ -842,11 +842,22 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>
 
             ParticleFile.seekg(where[grid], std::ios::beg);
 
+            // Use if constexpr to avoid instantiating the mis-matched
+            // type case and triggering the static_assert on the
+            // underlying copy calls
             if (how == "single") {
-                ReadParticles<float>(count[grid], grid, lev, ParticleFile, finest_level_in_file, convert_ids);
+                if constexpr (std::is_same_v<ParticleReal, float>) {
+                    ReadParticles<float>(count[grid], grid, lev, ParticleFile, finest_level_in_file, convert_ids);
+                } else {
+                    amrex::Error("File contains single-precision data, while AMReX is compiled with ParticleReal==double");
+                }
             }
             else if (how == "double") {
-                ReadParticles<double>(count[grid], grid, lev, ParticleFile, finest_level_in_file, convert_ids);
+                if constexpr (std::is_same_v<ParticleReal, double>) {
+                    ReadParticles<double>(count[grid], grid, lev, ParticleFile, finest_level_in_file, convert_ids);
+                } else {
+                    amrex::Error("File contains double-precision data, while AMReX is compiled with ParticleReal==float");
+                }
             }
             else {
                 std::string msg("ParticleContainer::Restart(): bad parameter: ");

--- a/Src/Particle/AMReX_ParticleInit.H
+++ b/Src/Particle/AMReX_ParticleInit.H
@@ -273,7 +273,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>
         host_particles.reserve(15);
         host_particles.resize(finestLevel()+1);
 
-        Vector<std::map<std::pair<int, int>, std::array<Gpu::HostVector<Real>, NArrayReal > > > host_real_attribs;
+        Vector<std::map<std::pair<int, int>, std::array<Gpu::HostVector<ParticleReal>, NArrayReal > > > host_real_attribs;
         host_real_attribs.reserve(15);
         host_real_attribs.resize(finestLevel()+1);
 
@@ -361,7 +361,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>
         host_particles.reserve(15);
         host_particles.resize(finestLevel()+1);
 
-        Vector<std::map<std::pair<int, int>, std::array<Gpu::HostVector<Real>, NArrayReal > > > host_real_attribs;
+        Vector<std::map<std::pair<int, int>, std::array<Gpu::HostVector<ParticleReal>, NArrayReal > > > host_real_attribs;
         host_real_attribs.reserve(15);
         host_real_attribs.resize(finestLevel()+1);
 
@@ -1451,7 +1451,7 @@ InitNRandomPerCell (int n_per_cell, const ParticleInitData& pdata)
         host_particles.reserve(15);
         host_particles.resize(finestLevel()+1);
 
-        Vector<std::map<std::pair<int, int>, std::array<Gpu::HostVector<Real>, NArrayReal > > > host_real_attribs;
+        Vector<std::map<std::pair<int, int>, std::array<Gpu::HostVector<ParticleReal>, NArrayReal > > > host_real_attribs;
         host_real_attribs.reserve(15);
         host_real_attribs.resize(finestLevel()+1);
 

--- a/Tests/Particles/AsyncIO/main.cpp
+++ b/Tests/Particles/AsyncIO/main.cpp
@@ -78,10 +78,10 @@ public:
             const Box& tile_box  = mfi.tilebox();
 
             Gpu::HostVector<ParticleType> host_particles;
-            std::array<Gpu::HostVector<Real>, NAR> host_real;
+            std::array<Gpu::HostVector<ParticleReal>, NAR> host_real;
             std::array<Gpu::HostVector<int>, NAI> host_int;
 
-            std::vector<Gpu::HostVector<Real> > host_runtime_real(NumRuntimeRealComps());
+            std::vector<Gpu::HostVector<ParticleReal> > host_runtime_real(NumRuntimeRealComps());
             std::vector<Gpu::HostVector<int> > host_runtime_int(NumRuntimeIntComps());
 
             for (IntVect iv = tile_box.smallEnd(); iv <= tile_box.bigEnd(); tile_box.next(iv))

--- a/Tests/Particles/ParticleTransformations/main.cpp
+++ b/Tests/Particles/ParticleTransformations/main.cpp
@@ -64,7 +64,7 @@ public:
             const Box& tile_box  = mfi.tilebox();
 
             Gpu::HostVector<ParticleType> host_particles;
-            std::array<Gpu::HostVector<Real>, NAR> host_real;
+            std::array<Gpu::HostVector<ParticleReal>, NAR> host_real;
             std::array<Gpu::HostVector<int>, NAI> host_int;
             for (IntVect iv = tile_box.smallEnd(); iv <= tile_box.bigEnd(); tile_box.next(iv))
             {


### PR DESCRIPTION
## Summary

A mixed-precision build of WarpX (DP fields, SP particles) would fail to restart from a checkpoint with added real particle components, crashing while reading in data.

## Additional background

Isolated with this modification of a WarpX example, and this fix tested similarly with `amr.restart = blah`

```
$ diff -u ~/repos/WarpX/Examples/Physics_applications/capacitive_discharge/inputs_2d inputs_2d 
--- /home/ubuntu/repos/WarpX/Examples/Physics_applications/capacitive_discharge/inputs_2d	2022-09-07 22:02:51.200174154 +0000
+++ inputs_2d	2022-11-07 21:52:04.764307593 +0000
@@ -39,6 +39,8 @@
 electrons.momentum_distribution_type = maxwell_boltzmann
 electrons.theta = (kb*30000/(m_e*clight^2))
 
+electrons.save_previous_position = 1
+
 he_ions.species_type = helium
 he_ions.charge = q_e
 he_ions.injection_style = nuniformpercell
@@ -55,24 +57,28 @@
 
-diagnostics.diags_names = diag1
+diagnostics.diags_names = diag1 ckpt
 diag1.diag_type = Full
 diag1.intervals = 50
 diag1.intervals = 10
 diag1.fields_to_plot = rho_electrons rho_he_ions
+
+ckpt.diag_type = Full
+ckpt.intervals = 7
+ckpt.format = checkpoint
```

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
