### PR TITLE
Fix Multi-Level Open BC Solver

### DIFF
--- a/Src/LinearSolvers/OpenBC/AMReX_OpenBC.H
+++ b/Src/LinearSolvers/OpenBC/AMReX_OpenBC.H
@@ -131,9 +131,10 @@ private:
     MultiFab m_phind;
     BoxArray m_bag;
 
-    BoxArray m_ba_all;
-    DistributionMapping m_dm_all;
-    Geometry m_geom_all;
+    Vector<IntVect> m_box_offset;
+    Vector<BoxArray> m_ba_all;
+    Vector<DistributionMapping> m_dm_all;
+    Vector<Geometry> m_geom_all;
 };
 
 }


### PR DESCRIPTION
In the open BC solver, the enlarged level 0 grids are shifted so that the lower left corner is at (0,0,0).  This allows the grids to be coarsened more than if they are not shifted.  However, we did not shift the fine level grids and this was a bug.  This bug is fixed here.

Close #3023 

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
