### PR TITLE
Use std::max when coarsening a TagBox to preserve TagBox::SET values

### DIFF
--- a/Src/AmrCore/AMReX_TagBox.cpp
+++ b/Src/AmrCore/AMReX_TagBox.cpp
@@ -55,7 +55,7 @@ TagBox::coarsen (const IntVect& ratio, const Box& cbox) noexcept
                 for (int ioff = 0; ioff < r.x; ++ioff) {
                     int ii = i*r.x + ioff;
                     if (fdomain.contains(IntVect(AMREX_D_DECL(ii,jj,kk)))) {
-                        t = t || farr(ii,jj,kk);
+                        t = std::max(t, farr(ii,jj,kk));
                     }
                 }
             }


### PR DESCRIPTION
## Summary
When coarsening a TagBox in the current version, cells with the status SET are changed to BUF. This can cause undesirable effects if, e.g., TagBox::buffer is called on a coarsened TagBox. With this pull request, the {CLEAR, BUF, SET} hierarchy is preserved when coarsening a TagBox. 

## Additional background

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
