### PR TITLE
Fix FabArray::LocalCopy SFINAE

### DIFF
--- a/Src/Base/AMReX_FabArray.H
+++ b/Src/Base/AMReX_FabArray.H
@@ -212,10 +212,10 @@ struct MultiArray4
 template <class FAB> class FabArray;
 
 template <class DFAB, class SFAB,
-          typename DT = typename DFAB::value_type,
-          typename ST = typename SFAB::value_type,
-          std::enable_if_t<IsBaseFab<DFAB>::value && IsBaseFab<SFAB>::value &&
-                           std::is_convertible_v<ST,DT>, int> BAR = 0>
+          std::enable_if_t<std::conjunction_v<
+              IsBaseFab<DFAB>, IsBaseFab<SFAB>,
+              std::is_convertible<typename SFAB::value_type,
+                                  typename DFAB::value_type>>, int> BAR = 0>
 void
 Copy (FabArray<DFAB>& dst, FabArray<SFAB> const& src, int srccomp, int dstcomp, int numcomp, int nghost)
 {
@@ -223,14 +223,16 @@ Copy (FabArray<DFAB>& dst, FabArray<SFAB> const& src, int srccomp, int dstcomp, 
 }
 
 template <class DFAB, class SFAB,
-          typename DT = typename DFAB::value_type,
-          typename ST = typename SFAB::value_type,
-          std::enable_if_t<IsBaseFab<DFAB>::value && IsBaseFab<SFAB>::value &&
-                           std::is_convertible_v<ST,DT>, int> BAR = 0>
+          std::enable_if_t<std::conjunction_v<
+              IsBaseFab<DFAB>, IsBaseFab<SFAB>,
+              std::is_convertible<typename SFAB::value_type,
+                                  typename DFAB::value_type>>, int> BAR = 0>
 void
 Copy (FabArray<DFAB>& dst, FabArray<SFAB> const& src, int srccomp, int dstcomp, int numcomp, const IntVect& nghost)
 {
     BL_PROFILE("amrex::Copy()");
+
+    using DT = typename DFAB::value_type;
 
 #ifdef AMREX_USE_GPU
     if (Gpu::inLaunchRegion() && dst.isFusingCandidate()) {
@@ -583,11 +585,11 @@ public:
      * \param ncomp  number of components
      * \param nghost number of ghost cells
      */
-    template <typename SFAB,
-              std::enable_if_t<IsBaseFab<FAB>::value && IsBaseFab<SFAB>::value &&
-                               std::is_convertible_v<typename SFAB::value_type,
-                                                     typename  FAB::value_type>,
-                               int> = 0>
+    template <typename SFAB, typename DFAB = FAB,
+              std::enable_if_t<std::conjunction_v<
+                  IsBaseFab<DFAB>, IsBaseFab<SFAB>,
+                  std::is_convertible<typename SFAB::value_type,
+                                      typename DFAB::value_type>>, int> = 0>
     void LocalCopy (FabArray<SFAB> const& src, int scomp, int dcomp, int ncomp,
                     IntVect const& nghost);
 
@@ -1739,10 +1741,11 @@ FabArray<FAB>::clear ()
 }
 
 template <class FAB>
-template <typename SFAB,
-          std::enable_if_t<IsBaseFab<FAB>::value && IsBaseFab<SFAB>::value &&
-                           std::is_convertible_v<typename SFAB::value_type,
-                                                 typename  FAB::value_type>, int>>
+template <typename SFAB, typename DFAB,
+          std::enable_if_t<std::conjunction_v<
+              IsBaseFab<DFAB>, IsBaseFab<SFAB>,
+              std::is_convertible<typename SFAB::value_type,
+                                  typename DFAB::value_type>>, int>>
 void
 FabArray<FAB>::LocalCopy (FabArray<SFAB> const& src, int scomp, int dcomp, int ncomp,
                           IntVect const& nghost)

--- a/Src/Base/AMReX_TypeTraits.H
+++ b/Src/Base/AMReX_TypeTraits.H
@@ -22,7 +22,9 @@ namespace amrex
                             std::is_base_of<BaseFab<typename D::value_type>,
                                             D>::value>::type>
         : std::true_type {};
-
+    //
+    template <class A>
+    inline constexpr bool IsBaseFab_v = IsBaseFab<A>::value;
 
     template <class A, class Enable = void> struct IsFabArray : std::false_type {};
     //
@@ -31,6 +33,9 @@ namespace amrex
                              std::is_base_of<FabArray<typename D::FABType::value_type>,
                                              D>::value>::type>
         : std::true_type {};
+    //
+    template <class A>
+    inline constexpr bool IsFabArray_v = IsFabArray<A>::value;
 
     template <bool B, class T = void>
     using EnableIf_t = typename std::enable_if<B,T>::type;


### PR DESCRIPTION
Fix a bug in FabArray::LocalCopy SFINAE so that FAB in FabArray<FAB> does not need to have typename value_type defined.  Note that BaseFab has value_type, but FAB is not necessarily BaseFab.

For convenience, IsBaseFab_v and IsFabArray_v are added.