### PR TITLE
SYCL: Remove floating-point specialisations for atomic adds

### DIFF
--- a/Src/Base/AMReX_GpuAtomic.H
+++ b/Src/Base/AMReX_GpuAtomic.H
@@ -158,24 +158,7 @@ namespace detail {
     }
 #endif
 
-#ifdef AMREX_USE_DPCPP
-
-    // Valid atomic types are available at
-    // https://github.com/intel/llvm/blob/sycl/sycl/include/CL/sycl/atomic.hpp
-
-    AMREX_GPU_DEVICE AMREX_FORCE_INLINE
-    double Add_device (double* const sum, double const value) noexcept
-    {
-        return detail::atomic_op<double, unsigned long long>(sum, value, amrex::Plus<double>());
-    }
-
-    AMREX_GPU_DEVICE AMREX_FORCE_INLINE
-    float Add_device (float* const sum, float const value) noexcept
-    {
-        return detail::atomic_op<float, unsigned int>(sum, value, amrex::Plus<float>());
-    }
-
-#elif defined(AMREX_USE_CUDA) || defined(AMREX_USE_HIP)
+#if defined(AMREX_USE_CUDA) || defined(AMREX_USE_HIP)
 
     // https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#atomicadd
     // https://rocmdocs.amd.com/en/latest/Programming_Guides/Kernel_language.html?#atomic-functions


### PR DESCRIPTION
Hi @WeiqunZhang, @ax3l,

A few years ago, the intel compiler had no support for some floating-point atomic operations like `fetch_add`. This has since been fixed, meaning we should be able to remove the CAS fallbacks in AMReX. See [here](https://github.com/intel/llvm/blob/f2983fc0d8fcd7bd6022a7006ad489c591838041/sycl/ReleaseNotes.md#sycl-library-14).

Cheers,
-Nuno
