### PR TITLE
Fix: Shared CMake builds w/ `AMReX_BUILD_SHARED_LIBS`

### DIFF
--- a/Src/CMakeLists.txt
+++ b/Src/CMakeLists.txt
@@ -5,7 +5,11 @@
 # the properties of this object, like setting the sources,
 # setting the compile definitions and so on
 #
-add_library( amrex )
+if (AMReX_BUILD_SHARED_LIBS)
+    add_library( amrex SHARED )
+else ()
+    add_library( amrex STATIC )
+endif ()
 add_library( AMReX::amrex ALIAS amrex )
 
 #


### PR DESCRIPTION
## Summary

Forgot to honor the new option. All builds that did not set `BUILD_SHARED_LIBS` were static now.

## Additional background

Introduced in #3013

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
