### PR TITLE
Gpu Streams: Performance Tuning

### DIFF
--- a/Src/Base/AMReX_FabArray.H
+++ b/Src/Base/AMReX_FabArray.H
@@ -1989,7 +1989,6 @@ FabArray<FAB>::define (const BoxArray&            bxs,
 
     if(info.alloc) {
         AllocFabs(*m_factory, m_dallocator.m_arena, info.tags);
-        Gpu::streamSynchronizeAll();
 #ifdef BL_USE_TEAM
         ParallelDescriptor::MyTeam().MemoryBarrier();
 #endif

--- a/Src/Base/AMReX_GpuDevice.H
+++ b/Src/Base/AMReX_GpuDevice.H
@@ -67,10 +67,9 @@ public:
     static int numGpuStreams () noexcept { return max_gpu_streams; }
 
     static void setStreamIndex (const int idx) noexcept;
-    static void resetStreamIndex () noexcept { setStreamIndex(-1); }
+    static void resetStreamIndex () noexcept { setStreamIndex(0); }
 
 #ifdef AMREX_USE_GPU
-    /** For Index, the null stream is -1, and the other streams are 0, 1, 2, ...  */
     static int streamIndex (gpuStream_t s = gpuStream()) noexcept;
 
     static gpuStream_t setStream (gpuStream_t s) noexcept;
@@ -176,11 +175,9 @@ private:
     static AMREX_EXPORT dim3 numThreadsMin;
     static AMREX_EXPORT dim3 numBlocksOverride, numThreadsOverride;
 
-    // We build gpu_default_stream and gpu_stream_pool.
+    static AMREX_EXPORT Vector<gpuStream_t> gpu_stream_pool; // The size of this is max_gpu_stream
     // The non-owning gpu_stream is used to store the current stream that will be used.
     // gpu_stream is a vector so that it's thread safe to write to it.
-    static AMREX_EXPORT gpuStream_t gpu_default_stream;
-    static AMREX_EXPORT Vector<gpuStream_t> gpu_stream_pool; // The size of this is max_gpu_stream
     static AMREX_EXPORT Vector<gpuStream_t> gpu_stream; // The size of this is omp_max_threads
     static AMREX_EXPORT gpuDeviceProp_t device_prop;
     static AMREX_EXPORT int memory_pools_supported;

--- a/Src/Base/AMReX_GpuDevice.cpp
+++ b/Src/Base/AMReX_GpuDevice.cpp
@@ -71,7 +71,6 @@ dim3 Device::numThreadsOverride = dim3(0, 0, 0);
 dim3 Device::numBlocksOverride  = dim3(0, 0, 0);
 unsigned int Device::max_blocks_per_launch = 2560;
 
-gpuStream_t         Device::gpu_default_stream;
 Vector<gpuStream_t> Device::gpu_stream_pool;
 Vector<gpuStream_t> Device::gpu_stream;
 gpuDeviceProp_t     Device::device_prop;
@@ -134,6 +133,7 @@ Device::Initialize ()
     ParmParse ppamrex("amrex");
     ppamrex.queryAdd("max_gpu_streams", max_gpu_streams);
     max_gpu_streams = std::min(max_gpu_streams, AMREX_GPU_MAX_STREAMS);
+    max_gpu_streams = std::max(max_gpu_streams, 1);
 
     ParmParse pp("device");
 
@@ -379,8 +379,6 @@ Device::Finalize ()
         s.queue = nullptr;
     }
     gpu_stream.clear();
-    delete gpu_default_stream.queue;
-    gpu_default_stream.queue = nullptr;
 #endif
 
 #ifdef AMREX_USE_ACC
@@ -403,7 +401,6 @@ Device::initialize_gpu ()
 
     // AMD devices do not support shared cache banking.
 
-    AMREX_HIP_SAFE_CALL(hipStreamCreate(&gpu_default_stream));
     for (int i = 0; i < max_gpu_streams; ++i) {
         AMREX_HIP_SAFE_CALL(hipStreamCreate(&gpu_stream_pool[i]));
     }
@@ -424,7 +421,6 @@ Device::initialize_gpu ()
         AMREX_CUDA_SAFE_CALL(cudaDeviceSetSharedMemConfig(cudaSharedMemBankSizeFourByte));
     }
 
-    AMREX_CUDA_SAFE_CALL(cudaStreamCreate(&gpu_default_stream));
     for (int i = 0; i < max_gpu_streams; ++i) {
         AMREX_CUDA_SAFE_CALL(cudaStreamCreate(&gpu_stream_pool[i]));
 #ifdef AMREX_USE_ACC
@@ -445,8 +441,6 @@ Device::initialize_gpu ()
         auto const& gpu_devices = platform.get_devices();
         sycl_device = std::make_unique<sycl::device>(gpu_devices[device_id]);
         sycl_context = std::make_unique<sycl::context>(*sycl_device, amrex_sycl_error_handler);
-        gpu_default_stream.queue = new sycl::queue(*sycl_context, *sycl_device,
-                                         sycl::property_list{sycl::property::queue::in_order{}});
         for (int i = 0; i < max_gpu_streams; ++i) {
             gpu_stream_pool[i].queue = new sycl::queue(*sycl_context, *sycl_device,
                                          sycl::property_list{sycl::property::queue::in_order{}});
@@ -502,7 +496,7 @@ Device::initialize_gpu ()
     }
 #endif
 
-    gpu_stream.resize(OpenMP::get_max_threads(), gpu_default_stream);
+    gpu_stream.resize(OpenMP::get_max_threads(), gpu_stream_pool[0]);
 
     ParmParse pp("device");
 
@@ -567,12 +561,8 @@ Device::numDevicesUsed () noexcept
 int
 Device::streamIndex (gpuStream_t s) noexcept
 {
-    if (s == gpu_default_stream) {
-        return -1;
-    } else {
-        auto it = std::find(std::begin(gpu_stream_pool), std::end(gpu_stream_pool), s);
-        return static_cast<int>(std::distance(std::begin(gpu_stream_pool), it));
-    }
+    auto it = std::find(std::begin(gpu_stream_pool), std::end(gpu_stream_pool), s);
+    return static_cast<int>(std::distance(std::begin(gpu_stream_pool), it));
 }
 #endif
 
@@ -581,19 +571,10 @@ Device::setStreamIndex (const int idx) noexcept
 {
     amrex::ignore_unused(idx);
 #ifdef AMREX_USE_GPU
-    if (idx < 0) {
-        gpu_stream[OpenMP::get_thread_num()] = gpu_default_stream;
-
+    gpu_stream[OpenMP::get_thread_num()] = gpu_stream_pool[idx % max_gpu_streams];
 #ifdef AMREX_USE_ACC
-        amrex_set_acc_stream(acc_async_sync);
+    amrex_set_acc_stream(idx % max_gpu_streams);
 #endif
-    } else {
-        gpu_stream[OpenMP::get_thread_num()] = gpu_stream_pool[idx % max_gpu_streams];
-
-#ifdef AMREX_USE_ACC
-        amrex_set_acc_stream(idx % max_gpu_streams);
-#endif
-    }
 #endif
 }
 
@@ -602,7 +583,7 @@ gpuStream_t
 Device::resetStream () noexcept
 {
     gpuStream_t r = gpu_stream[OpenMP::get_thread_num()];
-    gpu_stream[OpenMP::get_thread_num()] = gpu_default_stream;
+    gpu_stream[OpenMP::get_thread_num()] = gpu_stream_pool[0];
     return r;
 }
 
@@ -619,12 +600,6 @@ void
 Device::synchronize () noexcept
 {
 #ifdef AMREX_USE_DPCPP
-    auto& q = *(gpu_default_stream.queue);
-    try {
-        q.wait_and_throw();
-    } catch (sycl::exception const& ex) {
-        amrex::Abort(std::string("synchronize: ")+ex.what()+"!!!!!");
-    }
     for (auto const& s : gpu_stream_pool) {
         try {
             s.queue->wait_and_throw();
@@ -661,8 +636,6 @@ Device::streamSynchronizeAll () noexcept
 #ifdef AMREX_USE_DPCPP
     Device::synchronize();
 #else
-    AMREX_HIP_OR_CUDA( AMREX_HIP_SAFE_CALL(hipStreamSynchronize(gpu_default_stream));,
-                       AMREX_CUDA_SAFE_CALL(cudaStreamSynchronize(gpu_default_stream)); )
     for (auto const& s : gpu_stream_pool) {
         AMREX_HIP_OR_CUDA( AMREX_HIP_SAFE_CALL(hipStreamSynchronize(s));,
                            AMREX_CUDA_SAFE_CALL(cudaStreamSynchronize(s)); )

--- a/Src/Base/AMReX_GpuUtility.cpp
+++ b/Src/Base/AMReX_GpuUtility.cpp
@@ -65,7 +65,11 @@ StreamIter::init() noexcept
 StreamIter::~StreamIter () {
 #ifdef AMREX_USE_GPU
     if (m_sync) {
-        Gpu::streamSynchronizeAll();
+        const int nstreams = std::min(m_n, Gpu::numGpuStreams());
+        for (int i = 0; i < nstreams; ++i) {
+            Gpu::Device::setStreamIndex(i);
+            Gpu::streamSynchronize();
+        }
     }
     AMREX_GPU_ERROR_CHECK();
     Gpu::Device::resetStreamIndex();

--- a/Src/Base/AMReX_MFIter.H
+++ b/Src/Base/AMReX_MFIter.H
@@ -48,7 +48,7 @@ struct MFItInfo
         return *this;
     }
     MFItInfo& UseDefaultStream () noexcept {
-        num_streams = -1;
+        num_streams = 1;
         return *this;
     }
 };

--- a/Src/Base/AMReX_MFIter.cpp
+++ b/Src/Base/AMReX_MFIter.cpp
@@ -271,6 +271,15 @@ MFIter::Initialize ()
             "Nested or multiple active MFIters is not supported by default.  This can be changed by calling MFIter::allowMultipleMFIters(true)".);
     }
 
+#ifdef AMREX_USE_GPU
+    if (device_sync) {
+#ifdef AMREX_USE_OMP
+#pragma omp single
+#endif
+        Gpu::streamSynchronize();
+    }
+#endif
+
     if (flags & AllBoxes)  // a very special case
     {
         index_map    = &(fabArray.IndexArray());


### PR DESCRIPTION
 * Change the number of GPU streams from 4 to 2. Recent tests on summit and crusher show that using 2 GPU streams seems to be better than 4 or 1 in most cases.  One reason is that it reduces the cost associated with stream synchronization, which could be significant for small kernels.

 * In ~MFIter and ~StreamIter, there is no need to synchronize the streams that were not used.  It appears that for HIP there is very little cost to sychronize a stream that does not have any GPU kerenels since the last synchronization, but that's not the case for CUDA.

 * Remove the dedicated stream for kernels outside MFIter, and simply use the first stream used by MFIter.

 * Remove synchronization in FabArray::define.  It was needed when we were putting FAB in managed memory, but that's no longer the case.