### PR TITLE
HIP: amdgpu-target -> offload-arch

### DIFF
--- a/Tools/CMake/AMReXParallelBackends.cmake
+++ b/Tools/CMake/AMReXParallelBackends.cmake
@@ -279,7 +279,7 @@ if (AMReX_HIP)
        # else there will be a runtime issue (cannot find
        # missing gpu devices)
        target_compile_options(amrex PUBLIC
-          $<$<COMPILE_LANGUAGE:CXX>:--amdgpu-target=${AMReX_AMD_ARCH_HIPCC}>)
+          $<$<COMPILE_LANGUAGE:CXX>:--offload-arch=${AMReX_AMD_ARCH_HIPCC}>)
    endif()
 
    target_compile_options(amrex PUBLIC $<$<COMPILE_LANGUAGE:CXX>:-m64>)

--- a/Tools/GNUMake/comps/hip.mak
+++ b/Tools/GNUMake/comps/hip.mak
@@ -36,7 +36,7 @@ ifeq ($(USE_GPU_RDC),TRUE)
 endif
 
 # amd gpu target
-HIPCC_FLAGS += --amdgpu-target=$(AMD_ARCH)
+HIPCC_FLAGS += --offload-arch=$(AMD_ARCH)
 
 CXXFLAGS += $(HIPCC_FLAGS)
 


### PR DESCRIPTION
The amdgpu-target option has been deprecated since at least v4.5.