### PR TITLE
Update GNU Make file for OLCF

### DIFF
--- a/Tools/GNUMake/Make.machines
+++ b/Tools/GNUMake/Make.machines
@@ -57,7 +57,7 @@ ifdef OLCF_MODULEPATH_ROOT
   endif
 endif
 
-ifdef OLCF_ROCM_ROOT
+ifeq ($(LMOD_SITE_NAME),OLCF)
   ifeq ($(findstring spock, $(host_name)), spock)
     which_site := olcf
     which_computer := spock


### PR DESCRIPTION
OLCF_ROCM_ROOT is not defined if the amd module instead of rocm is loaded. So using LMOD_SITE_NAME seems to be a better option.
