### PR TITLE
Remove deprecated SYCL declaration

### DIFF
--- a/Src/Base/AMReX_GpuAssert.H
+++ b/Src/Base/AMReX_GpuAssert.H
@@ -7,11 +7,7 @@
 #include <cassert>
 
 #ifdef AMREX_USE_DPCPP
-#  if defined(__INTEL_LLVM_COMPILER) && (__INTEL_LLVM_COMPILER < 20230100)
-#    include <CL/sycl.hpp>
-#  else
-#    include <sycl/sycl.hpp>
-#  endif
+#  include <sycl/sycl.hpp>
 #endif
 
 #if defined(AMREX_USE_DPCPP)

--- a/Src/Base/AMReX_GpuDevice.cpp
+++ b/Src/Base/AMReX_GpuDevice.cpp
@@ -151,12 +151,7 @@ Device::Initialize ()
     int gpu_device_count = 0;
 #ifdef AMREX_USE_DPCPP
     {
-#if defined(__INTEL_LLVM_COMPILER) && (__INTEL_LLVM_COMPILER < 20230100)
-        sycl::gpu_selector device_selector;
-        sycl::platform platform(device_selector);
-#else
         sycl::platform platform(sycl::gpu_selector_v);
-#endif
         auto const& gpu_devices = platform.get_devices();
         gpu_device_count = gpu_devices.size();
         if (gpu_device_count <= 0) {
@@ -432,12 +427,7 @@ Device::initialize_gpu ()
 
 #elif defined(AMREX_USE_DPCPP)
     { // create device, context and queues
-#if defined(__INTEL_LLVM_COMPILER) && (__INTEL_LLVM_COMPILER < 20230100)
-        sycl::gpu_selector gpu_device_selector;
-        sycl::platform platform(gpu_device_selector);
-#else
         sycl::platform platform(sycl::gpu_selector_v);
-#endif
         auto const& gpu_devices = platform.get_devices();
         sycl_device = std::make_unique<sycl::device>(gpu_devices[device_id]);
         sycl_context = std::make_unique<sycl::context>(*sycl_device, amrex_sycl_error_handler);
@@ -455,11 +445,7 @@ Device::initialize_gpu ()
         device_prop.multiProcessorCount = d.get_info<sycl::info::device::max_compute_units>();
         device_prop.maxThreadsPerMultiProcessor = -1; // xxxxx DPCPP todo: d.get_info<sycl::info::device::max_work_items_per_compute_unit>(); // unknown
         device_prop.maxThreadsPerBlock = d.get_info<sycl::info::device::max_work_group_size>();
-#if defined(__INTEL_LLVM_COMPILER) && (__INTEL_LLVM_COMPILER < 20230100)
-        auto mtd = d.get_info<sycl::info::device::max_work_item_sizes>();
-#else
         auto mtd = d.get_info<sycl::info::device::max_work_item_sizes<3>>();
-#endif
         device_prop.maxThreadsDim[0] = mtd[0];
         device_prop.maxThreadsDim[1] = mtd[1];
         device_prop.maxThreadsDim[2] = mtd[2];

--- a/Src/Base/AMReX_GpuLaunchFunctsG.H
+++ b/Src/Base/AMReX_GpuLaunchFunctsG.H
@@ -29,11 +29,7 @@ void launch (int nblocks, int nthreads_per_block, std::size_t shared_mem_bytes,
     auto& q = *(stream.queue);
     try {
         q.submit([&] (sycl::handler& h) {
-#if defined(__INTEL_LLVM_COMPILER) && (__INTEL_LLVM_COMPILER < 20230100)
-            sycl::accessor<unsigned long long, 1, sycl::access::mode::read_write, sycl::access::target::local>
-#else
             sycl::local_accessor<unsigned long long>
-#endif
                 shared_data(sycl::range<1>(shared_mem_numull), h);
             h.parallel_for(sycl::nd_range<1>(sycl::range<1>(nthreads_total),
                                              sycl::range<1>(nthreads_per_block)),
@@ -167,12 +163,7 @@ void ParallelFor (Gpu::KernelInfo const& info, T n, L&& f) noexcept
     try {
         if (info.hasReduction()) {
             q.submit([&] (sycl::handler& h) {
-#if defined(__INTEL_LLVM_COMPILER) && (__INTEL_LLVM_COMPILER < 20230100)
-                sycl::accessor<unsigned long long, 1, sycl::access::mode::read_write,
-                               sycl::access::target::local>
-#else
                 sycl::local_accessor<unsigned long long>
-#endif
                     shared_data(sycl::range<1>(Gpu::Device::warp_size), h);
                 h.parallel_for(sycl::nd_range<1>(sycl::range<1>(nthreads_total),
                                                  sycl::range<1>(nthreads_per_block)),
@@ -223,12 +214,7 @@ void ParallelFor (Gpu::KernelInfo const& info, Box const& box, L&& f) noexcept
     try {
         if (info.hasReduction()) {
             q.submit([&] (sycl::handler& h) {
-#if defined(__INTEL_LLVM_COMPILER) && (__INTEL_LLVM_COMPILER < 20230100)
-                sycl::accessor<unsigned long long, 1, sycl::access::mode::read_write,
-                               sycl::access::target::local>
-#else
                 sycl::local_accessor<unsigned long long>
-#endif
                     shared_data(sycl::range<1>(Gpu::Device::warp_size), h);
                 h.parallel_for(sycl::nd_range<1>(sycl::range<1>(nthreads_total),
                                                  sycl::range<1>(nthreads_per_block)),
@@ -291,12 +277,7 @@ void ParallelFor (Gpu::KernelInfo const& info, Box const& box, T ncomp, L&& f) n
     try {
         if (info.hasReduction()) {
             q.submit([&] (sycl::handler& h) {
-#if defined(__INTEL_LLVM_COMPILER) && (__INTEL_LLVM_COMPILER < 20230100)
-                sycl::accessor<unsigned long long, 1, sycl::access::mode::read_write,
-                               sycl::access::target::local>
-#else
                 sycl::local_accessor<unsigned long long>
-#endif
                     shared_data(sycl::range<1>(Gpu::Device::warp_size), h);
                 h.parallel_for(sycl::nd_range<1>(sycl::range<1>(nthreads_total),
                                                  sycl::range<1>(nthreads_per_block)),

--- a/Src/Base/AMReX_GpuPrint.H
+++ b/Src/Base/AMReX_GpuPrint.H
@@ -7,11 +7,7 @@
 #include <cstdio>
 
 #ifdef AMREX_USE_DPCPP
-#  if defined(__INTEL_LLVM_COMPILER) && (__INTEL_LLVM_COMPILER < 20230100)
-#    include <CL/sycl.hpp>
-#  else
-#    include <sycl/sycl.hpp>
-#  endif
+#  include <sycl/sycl.hpp>
 #endif
 
 #if defined(AMREX_USE_DPCPP)

--- a/Src/Base/AMReX_GpuQualifiers.H
+++ b/Src/Base/AMReX_GpuQualifiers.H
@@ -33,11 +33,7 @@
 
 #ifdef AMREX_USE_DPCPP
 
-#  if defined(__INTEL_LLVM_COMPILER) && (__INTEL_LLVM_COMPILER < 20230100)
-#    include <CL/sycl.hpp>
-#  else
-#    include <sycl/sycl.hpp>
-#  endif
+# include <sycl/sycl.hpp>
 
 # define AMREX_REQUIRE_SUBGROUP_SIZE(x) \
   _Pragma("clang diagnostic push") \

--- a/Src/Base/AMReX_GpuTypes.H
+++ b/Src/Base/AMReX_GpuTypes.H
@@ -7,11 +7,7 @@
 #ifdef AMREX_USE_GPU
 
 #ifdef AMREX_USE_DPCPP
-#  if defined(__INTEL_LLVM_COMPILER) && (__INTEL_LLVM_COMPILER < 20230100)
-#    include <CL/sycl.hpp>
-#  else
-#    include <sycl/sycl.hpp>
-#  endif
+#  include <sycl/sycl.hpp>
 #endif
 
 namespace amrex {

--- a/Src/Base/AMReX_Math.H
+++ b/Src/Base/AMReX_Math.H
@@ -10,11 +10,7 @@
 #include <utility>
 
 #ifdef AMREX_USE_DPCPP
-#  if defined(__INTEL_LLVM_COMPILER) && (__INTEL_LLVM_COMPILER < 20230100)
-#    include <CL/sycl.hpp>
-#  else
-#    include <sycl/sycl.hpp>
-#  endif
+#  include <sycl/sycl.hpp>
 #endif
 
 namespace amrex { inline namespace disabled {

--- a/Src/Base/AMReX_RandomEngine.H
+++ b/Src/Base/AMReX_RandomEngine.H
@@ -14,11 +14,7 @@
 #include <curand.h>
 #include <curand_kernel.h>
 #elif defined(AMREX_USE_DPCPP)
-#  if defined(__INTEL_LLVM_COMPILER) && (__INTEL_LLVM_COMPILER < 20230100)
-#    include <CL/sycl.hpp>
-#  else
-#    include <sycl/sycl.hpp>
-#  endif
+#include <sycl/sycl.hpp>
 #include <oneapi/mkl/rng/device.hpp>
 namespace mkl = oneapi::mkl;
 #endif


### PR DESCRIPTION
The macros we used do not work with the latest oneapi public release.