### PR TITLE
Add forward declarations for class template friends

### DIFF
--- a/Src/LinearSolvers/MLMG/AMReX_MLLinOp.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLLinOp.H
@@ -85,6 +85,11 @@ struct LinOpEnumType
     enum struct Location { FaceCenter, FaceCentroid, CellCenter, CellCentroid };
 };
 
+template <typename T> class MLMGT;
+template <typename T> class MLCGSolverT;
+template <typename T> class MLPoissonT;
+template <typename T> class MLABecLaplacianT;
+
 template <typename MF>
 class MLLinOpT
 {


### PR DESCRIPTION
It seems that GCC 7.5 requires these forward declarations.
