### PR TITLE
Add extra check for multicut cell

### DIFF
--- a/Src/EB/AMReX_EB2_3D_C.cpp
+++ b/Src/EB/AMReX_EB2_3D_C.cpp
@@ -46,7 +46,7 @@ void set_eb_data (const int i, const int j, const int k,
 
     // Check for multiple cuts
     // We know there are no multiple cuts on faces by now.
-    // So we only need to check the case that there are two cuts
+    // Firstly, we need to check the case that there are two cuts
     // at the opposite corners.
     bool multi_cuts = (axm >= 0.5_rt && axm < 1.0_rt &&
                        axp >= 0.5_rt && axp < 1.0_rt &&
@@ -54,6 +54,14 @@ void set_eb_data (const int i, const int j, const int k,
                        ayp >= 0.5_rt && ayp < 1.0_rt &&
                        azm >= 0.5_rt && azm < 1.0_rt &&
                        azp >= 0.5_rt && azp < 1.0_rt);
+    // Secondly, we also need to check if area fractions became 0
+    // at any opposite face when building the faces
+    if (axm == 0.0_rt && axp == 0.0_rt ||
+        aym == 0.0_rt && ayp == 0.0_rt ||
+        azm == 0.0_rt && azp == 0.0_rt) {
+        multi_cuts = true;
+    }
+
     if (multi_cuts) {
         set_covered(i, j, k, cell, vfrac, vcent, barea, bcent, bnorm);
         is_multicut = true;

--- a/Src/EB/AMReX_EB2_3D_C.cpp
+++ b/Src/EB/AMReX_EB2_3D_C.cpp
@@ -56,9 +56,9 @@ void set_eb_data (const int i, const int j, const int k,
                        azp >= 0.5_rt && azp < 1.0_rt);
     // Secondly, we also need to check if area fractions became 0
     // at any opposite face when building the faces
-    if (axm == 0.0_rt && axp == 0.0_rt ||
-        aym == 0.0_rt && ayp == 0.0_rt ||
-        azm == 0.0_rt && azp == 0.0_rt) {
+    if ((axm == 0.0_rt && axp == 0.0_rt) ||
+        (aym == 0.0_rt && ayp == 0.0_rt) ||
+        (azm == 0.0_rt && azp == 0.0_rt)) {
         multi_cuts = true;
     }
 


### PR DESCRIPTION
## Summary
For some edge EB geometry cases when building the faces during an EB iteration, nodes can go from regular to covered. Additional check needs to be added to label appropriate cells as a `multicut` cell.

## Additional background

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
