### PR TITLE
SYCL: Reinforce device compilation preprocessor conditionals

### DIFF
--- a/Src/Base/AMReX_Extension.H
+++ b/Src/Base/AMReX_Extension.H
@@ -45,7 +45,7 @@
 #if defined(AMREX_DEBUG)
 #define AMREX_PRAGMA_SIMD
 
-#elif defined(__CUDA_ARCH__)
+#elif defined(__CUDA_ARCH__) && defined(AMREX_USE_CUDA)
 #define AMREX_PRAGMA_SIMD
 
 #elif defined(__HIP_DEVICE_COMPILE__)
@@ -84,7 +84,7 @@
 #endif /* simd */
 
 // force inline
-#if defined(__CUDA_ARCH__)
+#if defined(__CUDA_ARCH__) && defined(AMREX_USE_CUDA)
 #define AMREX_FORCE_INLINE __forceinline__
 
 #elif defined(__HIP_DEVICE_COMPILE__)

--- a/Src/Base/AMReX_Extension.H
+++ b/Src/Base/AMReX_Extension.H
@@ -48,7 +48,7 @@
 #elif defined(__CUDA_ARCH__) && defined(AMREX_USE_CUDA)
 #define AMREX_PRAGMA_SIMD
 
-#elif defined(__HIP_DEVICE_COMPILE__)
+#elif defined(__HIP_DEVICE_COMPILE__) && defined(AMREX_USE_HIP)
 #define AMREX_PRAGMA_SIMD
 
 //#elif defined(AMREX_USE_OMP) && defined(_OPENMP) && (_OPENMP >= 201307) && !defined(__PGI)
@@ -87,7 +87,7 @@
 #if defined(__CUDA_ARCH__) && defined(AMREX_USE_CUDA)
 #define AMREX_FORCE_INLINE __forceinline__
 
-#elif defined(__HIP_DEVICE_COMPILE__)
+#elif defined(__HIP_DEVICE_COMPILE__) && defined(AMREX_USE_HIP)
 #define AMREX_FORCE_INLINE __forceinline__
 
 #elif defined(__INTEL_COMPILER)

--- a/Src/Base/AMReX_GpuAtomic.H
+++ b/Src/Base/AMReX_GpuAtomic.H
@@ -129,7 +129,7 @@ namespace detail {
     AMREX_GPU_DEVICE AMREX_FORCE_INLINE
     T Add_device (T* const sum, T const value) noexcept
     {
-#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+#if defined(__CUDA_ARCH__) && defined(AMREX_USE_CUDA) || defined(__HIP_DEVICE_COMPILE__)
         return atomicAdd(sum, value);
 #elif defined(__SYCL_DEVICE_ONLY__)
         constexpr auto mo = sycl::memory_order::relaxed;
@@ -295,7 +295,7 @@ namespace detail {
     AMREX_GPU_DEVICE AMREX_FORCE_INLINE
     T Min_device (T* const m, T const value) noexcept
     {
-#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+#if defined(__CUDA_ARCH__) && defined(AMREX_USE_CUDA) || defined(__HIP_DEVICE_COMPILE__)
         return atomicMin(m, value);
 #elif defined(__SYCL_DEVICE_ONLY__)
         constexpr auto mo = sycl::memory_order::relaxed;
@@ -356,7 +356,7 @@ namespace detail {
     AMREX_GPU_DEVICE AMREX_FORCE_INLINE
     T Max_device (T* const m, T const value) noexcept
     {
-#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+#if defined(__CUDA_ARCH__) && defined(AMREX_USE_CUDA) || defined(__HIP_DEVICE_COMPILE__)
         return atomicMax(m, value);
 #elif defined(__SYCL_DEVICE_ONLY__)
         constexpr auto mo = sycl::memory_order::relaxed;
@@ -414,7 +414,7 @@ namespace detail {
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     int LogicalOr (int* const m, int const value) noexcept
     {
-#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+#if defined(__CUDA_ARCH__) && defined(AMREX_USE_CUDA) || defined(__HIP_DEVICE_COMPILE__)
         return atomicOr(m, value);
 #elif defined(__SYCL_DEVICE_ONLY__)
         constexpr auto mo = sycl::memory_order::relaxed;
@@ -436,7 +436,7 @@ namespace detail {
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     int LogicalAnd (int* const m, int const value) noexcept
     {
-#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+#if defined(__CUDA_ARCH__) && defined(AMREX_USE_CUDA) || defined(__HIP_DEVICE_COMPILE__)
         return atomicAnd(m, value ? ~0x0 : 0);
 #elif defined(__SYCL_DEVICE_ONLY__)
         constexpr auto mo = sycl::memory_order::relaxed;
@@ -479,7 +479,7 @@ namespace detail {
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     unsigned int Inc (unsigned int* const m, unsigned int const value) noexcept
     {
-#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+#if defined(__CUDA_ARCH__) && defined(AMREX_USE_CUDA) || defined(__HIP_DEVICE_COMPILE__)
         return atomicInc(m, value);
 #else
         auto const old = *m;
@@ -496,7 +496,7 @@ namespace detail {
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     unsigned int Dec (unsigned int* const m, unsigned int const value) noexcept
     {
-#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+#if defined(__CUDA_ARCH__) && defined(AMREX_USE_CUDA) || defined(__HIP_DEVICE_COMPILE__)
         return atomicDec(m, value);
 #elif defined(__SYCL_DEVICE_ONLY__)
         constexpr auto mo = sycl::memory_order::relaxed;
@@ -523,7 +523,7 @@ namespace detail {
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     T Exch (T* const address, T const val) noexcept
     {
-#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+#if defined(__CUDA_ARCH__) && defined(AMREX_USE_CUDA) || defined(__HIP_DEVICE_COMPILE__)
         return atomicExch(address, val);
 #elif defined(__SYCL_DEVICE_ONLY__)
         constexpr auto mo = sycl::memory_order::relaxed;
@@ -546,7 +546,7 @@ namespace detail {
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     T CAS (T* const address, T compare, T const val) noexcept
     {           // cannot be T const compare because of compare_exchange_strong
-#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+#if defined(__CUDA_ARCH__) && defined(AMREX_USE_CUDA) || defined(__HIP_DEVICE_COMPILE__)
         return atomicCAS(address, compare, val);
 #elif defined(__SYCL_DEVICE_ONLY__)
         constexpr auto mo = sycl::memory_order::relaxed;

--- a/Src/Base/AMReX_GpuAtomic.H
+++ b/Src/Base/AMReX_GpuAtomic.H
@@ -129,7 +129,8 @@ namespace detail {
     AMREX_GPU_DEVICE AMREX_FORCE_INLINE
     T Add_device (T* const sum, T const value) noexcept
     {
-#if defined(__CUDA_ARCH__) && defined(AMREX_USE_CUDA) || defined(__HIP_DEVICE_COMPILE__)
+#if defined(__CUDA_ARCH__) && defined(AMREX_USE_CUDA) || \
+    defined(__HIP_DEVICE_COMPILE__) && defined(AMREX_USE_HIP)
         return atomicAdd(sum, value);
 #elif defined(__SYCL_DEVICE_ONLY__)
         constexpr auto mo = sycl::memory_order::relaxed;
@@ -295,7 +296,8 @@ namespace detail {
     AMREX_GPU_DEVICE AMREX_FORCE_INLINE
     T Min_device (T* const m, T const value) noexcept
     {
-#if defined(__CUDA_ARCH__) && defined(AMREX_USE_CUDA) || defined(__HIP_DEVICE_COMPILE__)
+#if defined(__CUDA_ARCH__) && defined(AMREX_USE_CUDA) || \
+    defined(__HIP_DEVICE_COMPILE__) && defined(AMREX_USE_HIP)
         return atomicMin(m, value);
 #elif defined(__SYCL_DEVICE_ONLY__)
         constexpr auto mo = sycl::memory_order::relaxed;
@@ -356,7 +358,8 @@ namespace detail {
     AMREX_GPU_DEVICE AMREX_FORCE_INLINE
     T Max_device (T* const m, T const value) noexcept
     {
-#if defined(__CUDA_ARCH__) && defined(AMREX_USE_CUDA) || defined(__HIP_DEVICE_COMPILE__)
+#if defined(__CUDA_ARCH__) && defined(AMREX_USE_CUDA) || \
+    defined(__HIP_DEVICE_COMPILE__) && defined(AMREX_USE_HIP)
         return atomicMax(m, value);
 #elif defined(__SYCL_DEVICE_ONLY__)
         constexpr auto mo = sycl::memory_order::relaxed;
@@ -414,7 +417,8 @@ namespace detail {
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     int LogicalOr (int* const m, int const value) noexcept
     {
-#if defined(__CUDA_ARCH__) && defined(AMREX_USE_CUDA) || defined(__HIP_DEVICE_COMPILE__)
+#if defined(__CUDA_ARCH__) && defined(AMREX_USE_CUDA) || \
+    defined(__HIP_DEVICE_COMPILE__) && defined(AMREX_USE_HIP)
         return atomicOr(m, value);
 #elif defined(__SYCL_DEVICE_ONLY__)
         constexpr auto mo = sycl::memory_order::relaxed;
@@ -436,7 +440,8 @@ namespace detail {
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     int LogicalAnd (int* const m, int const value) noexcept
     {
-#if defined(__CUDA_ARCH__) && defined(AMREX_USE_CUDA) || defined(__HIP_DEVICE_COMPILE__)
+#if defined(__CUDA_ARCH__) && defined(AMREX_USE_CUDA) || \
+    defined(__HIP_DEVICE_COMPILE__) && defined(AMREX_USE_HIP)
         return atomicAnd(m, value ? ~0x0 : 0);
 #elif defined(__SYCL_DEVICE_ONLY__)
         constexpr auto mo = sycl::memory_order::relaxed;
@@ -479,7 +484,8 @@ namespace detail {
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     unsigned int Inc (unsigned int* const m, unsigned int const value) noexcept
     {
-#if defined(__CUDA_ARCH__) && defined(AMREX_USE_CUDA) || defined(__HIP_DEVICE_COMPILE__)
+#if defined(__CUDA_ARCH__) && defined(AMREX_USE_CUDA) || \
+    defined(__HIP_DEVICE_COMPILE__) && defined(AMREX_USE_HIP)
         return atomicInc(m, value);
 #else
         auto const old = *m;
@@ -496,7 +502,8 @@ namespace detail {
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     unsigned int Dec (unsigned int* const m, unsigned int const value) noexcept
     {
-#if defined(__CUDA_ARCH__) && defined(AMREX_USE_CUDA) || defined(__HIP_DEVICE_COMPILE__)
+#if defined(__CUDA_ARCH__) && defined(AMREX_USE_CUDA) || \
+    defined(__HIP_DEVICE_COMPILE__) && defined(AMREX_USE_HIP)
         return atomicDec(m, value);
 #elif defined(__SYCL_DEVICE_ONLY__)
         constexpr auto mo = sycl::memory_order::relaxed;
@@ -523,7 +530,8 @@ namespace detail {
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     T Exch (T* const address, T const val) noexcept
     {
-#if defined(__CUDA_ARCH__) && defined(AMREX_USE_CUDA) || defined(__HIP_DEVICE_COMPILE__)
+#if defined(__CUDA_ARCH__) && defined(AMREX_USE_CUDA) || \
+    defined(__HIP_DEVICE_COMPILE__) && defined(AMREX_USE_HIP)
         return atomicExch(address, val);
 #elif defined(__SYCL_DEVICE_ONLY__)
         constexpr auto mo = sycl::memory_order::relaxed;
@@ -546,7 +554,8 @@ namespace detail {
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     T CAS (T* const address, T compare, T const val) noexcept
     {           // cannot be T const compare because of compare_exchange_strong
-#if defined(__CUDA_ARCH__) && defined(AMREX_USE_CUDA) || defined(__HIP_DEVICE_COMPILE__)
+#if defined(__CUDA_ARCH__) && defined(AMREX_USE_CUDA) || \
+    defined(__HIP_DEVICE_COMPILE__) && defined(AMREX_USE_HIP)
         return atomicCAS(address, compare, val);
 #elif defined(__SYCL_DEVICE_ONLY__)
         constexpr auto mo = sycl::memory_order::relaxed;

--- a/Src/Base/AMReX_GpuRange.H
+++ b/Src/Base/AMReX_GpuRange.H
@@ -92,7 +92,7 @@ struct range_impl
 
     AMREX_GPU_HOST_DEVICE
     iterator begin () const noexcept {
-#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+#if defined(__CUDA_ARCH__) && defined(AMREX_USE_CUDA) || defined(__HIP_DEVICE_COMPILE__)
         return iterator(m_b, blockDim.x*blockIdx.x+threadIdx.x, blockDim.x*gridDim.x);
 #elif defined (__SYCL_DEVICE_ONLY__)
         return iterator(m_b, m_gid, m_grange);

--- a/Src/Base/AMReX_GpuRange.H
+++ b/Src/Base/AMReX_GpuRange.H
@@ -92,7 +92,8 @@ struct range_impl
 
     AMREX_GPU_HOST_DEVICE
     iterator begin () const noexcept {
-#if defined(__CUDA_ARCH__) && defined(AMREX_USE_CUDA) || defined(__HIP_DEVICE_COMPILE__)
+#if defined(__CUDA_ARCH__) && defined(AMREX_USE_CUDA) || \
+    defined(__HIP_DEVICE_COMPILE__) && defined(AMREX_USE_HIP)
         return iterator(m_b, blockDim.x*blockIdx.x+threadIdx.x, blockDim.x*gridDim.x);
 #elif defined (__SYCL_DEVICE_ONLY__)
         return iterator(m_b, m_gid, m_grange);

--- a/Src/Base/AMReX_GpuUtility.H
+++ b/Src/Base/AMReX_GpuUtility.H
@@ -139,7 +139,8 @@ namespace Gpu {
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     bool isnan (T m) noexcept
     {
-#if defined(__CUDA_ARCH__) && defined(AMREX_USE_CUDA) || defined(__HIP_DEVICE_COMPILE__)
+#if defined(__CUDA_ARCH__) && defined(AMREX_USE_CUDA) || \
+    defined(__HIP_DEVICE_COMPILE__) && defined(AMREX_USE_HIP)
         return ::isnan(m);
 #elif defined(__SYCL_DEVICE_ONLY__)
         return sycl::isnan(m);
@@ -152,7 +153,8 @@ namespace Gpu {
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     bool isinf (T m) noexcept
     {
-#if defined(__CUDA_ARCH__) && defined(AMREX_USE_CUDA) || defined(__HIP_DEVICE_COMPILE__)
+#if defined(__CUDA_ARCH__) && defined(AMREX_USE_CUDA) || \
+    defined(__HIP_DEVICE_COMPILE__) && defined(AMREX_USE_HIP)
         return ::isinf(m);
 #elif defined(__SYCL_DEVICE_ONLY__)
         return sycl::isinf(m);
@@ -207,7 +209,7 @@ namespace Gpu {
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 void* memcpy (void* dest, const void* src, std::size_t count)
 {
-#ifdef __HIP_DEVICE_COMPILE__
+#if defined(__HIP_DEVICE_COMPILE__) && defined(AMREX_USE_HIP)
     return ::memcpy(dest, src, count);
 #else
     return std::memcpy(dest, src, count);

--- a/Src/Base/AMReX_GpuUtility.H
+++ b/Src/Base/AMReX_GpuUtility.H
@@ -26,7 +26,7 @@ namespace Gpu {
     template <typename T>
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     T LDG (Array4<T> const& a, int i, int j, int k) noexcept {
-#ifdef __CUDA_ARCH__
+#if defined(__CUDA_ARCH__) && defined(AMREX_USE_CUDA)
         return __ldg(a.ptr(i,j,k));
 #else
         return a(i,j,k);
@@ -36,7 +36,7 @@ namespace Gpu {
     template <typename T>
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     T LDG (Array4<T> const& a, int i, int j, int k, int n) noexcept {
-#ifdef __CUDA_ARCH__
+#if defined(__CUDA_ARCH__) && defined(AMREX_USE_CUDA)
         return __ldg(a.ptr(i,j,k,n));
 #else
         return a(i,j,k,n);
@@ -139,7 +139,7 @@ namespace Gpu {
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     bool isnan (T m) noexcept
     {
-#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+#if defined(__CUDA_ARCH__) && defined(AMREX_USE_CUDA) || defined(__HIP_DEVICE_COMPILE__)
         return ::isnan(m);
 #elif defined(__SYCL_DEVICE_ONLY__)
         return sycl::isnan(m);
@@ -152,7 +152,7 @@ namespace Gpu {
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     bool isinf (T m) noexcept
     {
-#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+#if defined(__CUDA_ARCH__) && defined(AMREX_USE_CUDA) || defined(__HIP_DEVICE_COMPILE__)
         return ::isinf(m);
 #elif defined(__SYCL_DEVICE_ONLY__)
         return sycl::isinf(m);

--- a/Src/Base/AMReX_Math.H
+++ b/Src/Base/AMReX_Math.H
@@ -71,7 +71,8 @@ double cospi (double x)
 {
 #if defined(AMREX_USE_DPCPP)
     return sycl::cospi(x);
-#elif defined(__CUDA_ARCH__) && defined(AMREX_USE_CUDA) || defined(__HIP_DEVICE_COMPILE__)
+#elif defined(__CUDA_ARCH__) && defined(AMREX_USE_CUDA) || \
+      defined(__HIP_DEVICE_COMPILE__) && defined(AMREX_USE_HIP)
     return ::cospi(x);
 #else
     return std::cos(pi<double>()*x);
@@ -84,7 +85,8 @@ float cospi (float x)
 {
 #if defined(AMREX_USE_DPCPP)
     return sycl::cospi(x);
-#elif defined(__CUDA_ARCH__) && defined(AMREX_USE_CUDA) || defined(__HIP_DEVICE_COMPILE__)
+#elif defined(__CUDA_ARCH__) && defined(AMREX_USE_CUDA) || \
+      defined(__HIP_DEVICE_COMPILE__) && defined(AMREX_USE_HIP)
     return ::cospif(x);
 #else
     return std::cos(pi<float>()*x);
@@ -97,7 +99,8 @@ double sinpi (double x)
 {
 #if defined(AMREX_USE_DPCPP)
     return sycl::sinpi(x);
-#elif defined(__CUDA_ARCH__) && defined(AMREX_USE_CUDA) || defined(__HIP_DEVICE_COMPILE__)
+#elif defined(__CUDA_ARCH__) && defined(AMREX_USE_CUDA) || \
+      defined(__HIP_DEVICE_COMPILE__) && defined(AMREX_USE_HIP)
     return ::sinpi(x);
 #else
     return std::sin(pi<double>()*x);
@@ -110,7 +113,8 @@ float sinpi (float x)
 {
 #if defined(AMREX_USE_DPCPP)
     return sycl::sinpi(x);
-#elif defined(__CUDA_ARCH__) && defined(AMREX_USE_CUDA) || defined(__HIP_DEVICE_COMPILE__)
+#elif defined(__CUDA_ARCH__) && defined(AMREX_USE_CUDA) || \
+      defined(__HIP_DEVICE_COMPILE__) && defined(AMREX_USE_HIP)
     return ::sinpif(x);
 #else
     return std::sin(pi<float>()*x);
@@ -124,7 +128,9 @@ std::pair<double,double> sincos (double x)
     std::pair<double,double> r;
 #if defined(AMREX_USE_DPCPP)
     r.first = sycl::sincos(x, &r.second);
-#elif defined(__CUDA_ARCH__) && defined(AMREX_USE_CUDA) || defined(__HIP_DEVICE_COMPILE__) || defined(_GNU_SOURCE)
+#elif defined(__CUDA_ARCH__) && defined(AMREX_USE_CUDA) || \
+      defined(__HIP_DEVICE_COMPILE__) && defined(AMREX_USE_HIP) || \
+      defined(_GNU_SOURCE)
     ::sincos(x, &r.first, &r.second);
 #else
     r.first  = std::sin(x);
@@ -140,7 +146,9 @@ std::pair<float,float> sincos (float x)
     std::pair<float,float> r;
 #if defined(AMREX_USE_DPCPP)
     r.first = sycl::sincos(x, &r.second);
-#elif defined(__CUDA_ARCH__) && defined(AMREX_USE_CUDA) || defined(__HIP_DEVICE_COMPILE__) || defined(_GNU_SOURCE)
+#elif defined(__CUDA_ARCH__) && defined(AMREX_USE_CUDA) || \
+      defined(__HIP_DEVICE_COMPILE__) && defined(AMREX_USE_HIP) || \
+      defined(_GNU_SOURCE)
     ::sincosf(x, &r.first, &r.second);
 #else
     r.first  = std::sin(x);
@@ -156,7 +164,8 @@ std::pair<double,double> sincospi (double x)
     std::pair<double,double> r;
 #if defined(AMREX_USE_DPCPP)
     r.first = sycl::sincos(pi<double>()*x, &r.second);
-#elif defined(__CUDA_ARCH__) && defined(AMREX_USE_CUDA) || defined(__HIP_DEVICE_COMPILE__)
+#elif defined(__CUDA_ARCH__) && defined(AMREX_USE_CUDA) || \
+      defined(__HIP_DEVICE_COMPILE__) && defined(AMREX_USE_HIP)
     ::sincospi(x, &r.first, &r.second);
 #else
     r.first  = std::sin(pi<double>()*x);
@@ -172,7 +181,8 @@ std::pair<float,float> sincospi (float x)
     std::pair<float,float> r;
 #if defined(AMREX_USE_DPCPP)
     r.first = sycl::sincos(pi<float>()*x, &r.second);
-#elif defined(__CUDA_ARCH__) && defined(AMREX_USE_CUDA) || defined(__HIP_DEVICE_COMPILE__)
+#elif defined(__CUDA_ARCH__) && defined(AMREX_USE_CUDA) || \
+      defined(__HIP_DEVICE_COMPILE__) && defined(AMREX_USE_HIP)
     ::sincospif(x, &r.first, &r.second);
 #else
     r.first  = std::sin(pi<float>()*x);

--- a/Src/Base/AMReX_Math.H
+++ b/Src/Base/AMReX_Math.H
@@ -71,7 +71,7 @@ double cospi (double x)
 {
 #if defined(AMREX_USE_DPCPP)
     return sycl::cospi(x);
-#elif defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+#elif defined(__CUDA_ARCH__) && defined(AMREX_USE_CUDA) || defined(__HIP_DEVICE_COMPILE__)
     return ::cospi(x);
 #else
     return std::cos(pi<double>()*x);
@@ -84,7 +84,7 @@ float cospi (float x)
 {
 #if defined(AMREX_USE_DPCPP)
     return sycl::cospi(x);
-#elif defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+#elif defined(__CUDA_ARCH__) && defined(AMREX_USE_CUDA) || defined(__HIP_DEVICE_COMPILE__)
     return ::cospif(x);
 #else
     return std::cos(pi<float>()*x);
@@ -97,7 +97,7 @@ double sinpi (double x)
 {
 #if defined(AMREX_USE_DPCPP)
     return sycl::sinpi(x);
-#elif defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+#elif defined(__CUDA_ARCH__) && defined(AMREX_USE_CUDA) || defined(__HIP_DEVICE_COMPILE__)
     return ::sinpi(x);
 #else
     return std::sin(pi<double>()*x);
@@ -110,7 +110,7 @@ float sinpi (float x)
 {
 #if defined(AMREX_USE_DPCPP)
     return sycl::sinpi(x);
-#elif defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+#elif defined(__CUDA_ARCH__) && defined(AMREX_USE_CUDA) || defined(__HIP_DEVICE_COMPILE__)
     return ::sinpif(x);
 #else
     return std::sin(pi<float>()*x);
@@ -124,7 +124,7 @@ std::pair<double,double> sincos (double x)
     std::pair<double,double> r;
 #if defined(AMREX_USE_DPCPP)
     r.first = sycl::sincos(x, &r.second);
-#elif defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__) || defined(_GNU_SOURCE)
+#elif defined(__CUDA_ARCH__) && defined(AMREX_USE_CUDA) || defined(__HIP_DEVICE_COMPILE__) || defined(_GNU_SOURCE)
     ::sincos(x, &r.first, &r.second);
 #else
     r.first  = std::sin(x);
@@ -140,7 +140,7 @@ std::pair<float,float> sincos (float x)
     std::pair<float,float> r;
 #if defined(AMREX_USE_DPCPP)
     r.first = sycl::sincos(x, &r.second);
-#elif defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__) || defined(_GNU_SOURCE)
+#elif defined(__CUDA_ARCH__) && defined(AMREX_USE_CUDA) || defined(__HIP_DEVICE_COMPILE__) || defined(_GNU_SOURCE)
     ::sincosf(x, &r.first, &r.second);
 #else
     r.first  = std::sin(x);
@@ -156,7 +156,7 @@ std::pair<double,double> sincospi (double x)
     std::pair<double,double> r;
 #if defined(AMREX_USE_DPCPP)
     r.first = sycl::sincos(pi<double>()*x, &r.second);
-#elif defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+#elif defined(__CUDA_ARCH__) && defined(AMREX_USE_CUDA) || defined(__HIP_DEVICE_COMPILE__)
     ::sincospi(x, &r.first, &r.second);
 #else
     r.first  = std::sin(pi<double>()*x);
@@ -172,7 +172,7 @@ std::pair<float,float> sincospi (float x)
     std::pair<float,float> r;
 #if defined(AMREX_USE_DPCPP)
     r.first = sycl::sincos(pi<float>()*x, &r.second);
-#elif defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+#elif defined(__CUDA_ARCH__) && defined(AMREX_USE_CUDA) || defined(__HIP_DEVICE_COMPILE__)
     ::sincospif(x, &r.first, &r.second);
 #else
     r.first  = std::sin(pi<float>()*x);

--- a/Src/Base/AMReX_Random.H
+++ b/Src/Base/AMReX_Random.H
@@ -23,7 +23,7 @@ namespace amrex
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     Real Random (RandomEngine const& random_engine)
     {
-#if defined(__CUDA_ARCH__)
+#if defined(__CUDA_ARCH__) && defined(AMREX_USE_CUDA)
 #ifdef BL_USE_FLOAT
         return 1.0f - curand_uniform(random_engine.rand_state);
 #else
@@ -56,7 +56,7 @@ namespace amrex
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     Real RandomNormal (Real mean, Real stddev, RandomEngine const& random_engine)
     {
-#if defined(__CUDA_ARCH__)
+#if defined(__CUDA_ARCH__) && defined(AMREX_USE_CUDA)
 #ifdef BL_USE_FLOAT
         return stddev * curand_normal(random_engine.rand_state) + mean;
 #else
@@ -91,7 +91,7 @@ namespace amrex
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     unsigned int RandomPoisson (Real lambda, RandomEngine const& random_engine)
     {
-#if defined(__CUDA_ARCH__)
+#if defined(__CUDA_ARCH__) && defined(AMREX_USE_CUDA)
         return curand_poisson(random_engine.rand_state, lambda);
 #elif defined(__HIP_DEVICE_COMPILE__)
         return hiprand_poisson(random_engine.rand_state, lambda);

--- a/Src/Base/AMReX_Random.H
+++ b/Src/Base/AMReX_Random.H
@@ -29,7 +29,7 @@ namespace amrex
 #else
         return 1.0 - curand_uniform_double(random_engine.rand_state);
 #endif
-#elif defined(__HIP_DEVICE_COMPILE__)
+#elif defined(__HIP_DEVICE_COMPILE__) && defined(AMREX_USE_HIP)
 #ifdef BL_USE_FLOAT
         return 1.0f - hiprand_uniform(random_engine.rand_state);
 #else
@@ -62,7 +62,7 @@ namespace amrex
 #else
         return stddev * curand_normal_double(random_engine.rand_state) + mean;
 #endif
-#elif defined(__HIP_DEVICE_COMPILE__)
+#elif defined(__HIP_DEVICE_COMPILE__) && defined(AMREX_USE_HIP)
 #ifdef BL_USE_FLOAT
         return stddev * hiprand_normal(random_engine.rand_state) + mean;
 #else
@@ -93,7 +93,7 @@ namespace amrex
     {
 #if defined(__CUDA_ARCH__) && defined(AMREX_USE_CUDA)
         return curand_poisson(random_engine.rand_state, lambda);
-#elif defined(__HIP_DEVICE_COMPILE__)
+#elif defined(__HIP_DEVICE_COMPILE__) && defined(AMREX_USE_HIP)
         return hiprand_poisson(random_engine.rand_state, lambda);
 #elif defined (__SYCL_DEVICE_ONLY__)
         mkl::rng::device::poisson<unsigned int> distr(lambda);


### PR DESCRIPTION
Hi @WeiqunZhang,

## Summary

The changes in these two commits, although apparently redundant, guard SYCL compilations targeting CUDA or HIP devices by preventing the compiler from seeing the CUDA/HIP code already in AMReX.

## Additional background

The 'vanilla' version of LLVM, which is used by hipSYCL for example, enables `__CUDA_ARCH__` and `__HIP_DEVICE_COMPILE__` when compiling device code, for both [CUDA](https://llvm.org/docs/CompileCudaWithLLVM.html#detecting-clang-vs-nvcc-from-code) and [HIP](https://reviews.llvm.org/D45441), respectively. Intel's version of LLVM is also moving in the same direction with [CUDA](https://github.com/intel/llvm/issues/7722) and [HIP](https://github.com/intel/llvm/issues/7720), although the latter is off to a rocky start.

I couldn't decide between a more wordy implementation like this or instead defining a macro like you did for `AMREX_DEVICE_COMPILE`. I went with the former but we could just as easily switch to the latter.

Finally, I don't know if you are going to the ECP meeting next week, but it'd be great to say hi, personally thank you for your work and maybe walk you through my poster about how I've been using SYCL with AMReX.

Cheers,
Nuno
