### PR TITLE
SinCos: AppleClang Fix

### DIFF
--- a/Src/Base/AMReX_Math.H
+++ b/Src/Base/AMReX_Math.H
@@ -130,7 +130,7 @@ std::pair<double,double> sincos (double x)
     r.first = sycl::sincos(x, &r.second);
 #elif defined(__CUDA_ARCH__) && defined(AMREX_USE_CUDA) || \
       defined(__HIP_DEVICE_COMPILE__) && defined(AMREX_USE_HIP) || \
-      defined(_GNU_SOURCE)
+      (defined(_GNU_SOURCE) && !defined(__apple_build_version__))
     ::sincos(x, &r.first, &r.second);
 #else
     r.first  = std::sin(x);
@@ -148,7 +148,7 @@ std::pair<float,float> sincos (float x)
     r.first = sycl::sincos(x, &r.second);
 #elif defined(__CUDA_ARCH__) && defined(AMREX_USE_CUDA) || \
       defined(__HIP_DEVICE_COMPILE__) && defined(AMREX_USE_HIP) || \
-      defined(_GNU_SOURCE)
+      (defined(_GNU_SOURCE) && !defined(__apple_build_version__))
     ::sincosf(x, &r.first, &r.second);
 #else
     r.first  = std::sin(x);


### PR DESCRIPTION
## Summary

I noticed that in some situations, e.g., when building Python sources that include Python headers, `_GNU_SOURCE` is sometimes defined. This can confuse AppleClang builds of AMReX:
```
error: no member named 'sincos' in the global namespace; did you mean '__sincos'?
    ::sincos(x, &r.first, &r.second);
```

Adding the respective guard here should allow GCC builds on macOS but ignore the GCC-ism when building with AppleClang.

Follow-up to  #3008

## Additional background

First seen in pyAMReX the other week.
Avoided with restructured includes, but ultimately a defect that CPython headers pull in.

Seen again today by @RTSandberg 

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
