### PR TITLE
SinCos Guard: Apple Define

### DIFF
--- a/Src/Base/AMReX_Math.H
+++ b/Src/Base/AMReX_Math.H
@@ -130,7 +130,7 @@ std::pair<double,double> sincos (double x)
     r.first = sycl::sincos(x, &r.second);
 #elif defined(__CUDA_ARCH__) && defined(AMREX_USE_CUDA) || \
       defined(__HIP_DEVICE_COMPILE__) && defined(AMREX_USE_HIP) || \
-      (defined(_GNU_SOURCE) && !defined(__apple_build_version__))
+      (defined(_GNU_SOURCE) && !defined(__APPLE__))
     ::sincos(x, &r.first, &r.second);
 #else
     r.first  = std::sin(x);
@@ -148,7 +148,7 @@ std::pair<float,float> sincos (float x)
     r.first = sycl::sincos(x, &r.second);
 #elif defined(__CUDA_ARCH__) && defined(AMREX_USE_CUDA) || \
       defined(__HIP_DEVICE_COMPILE__) && defined(AMREX_USE_HIP) || \
-      (defined(_GNU_SOURCE) && !defined(__apple_build_version__))
+      (defined(_GNU_SOURCE) && !defined(__APPLE__))
     ::sincosf(x, &r.first, &r.second);
 #else
     r.first  = std::sin(x);


### PR DESCRIPTION
## Summary

The issue also occurs on vanilla Clang, not only AppleClang.

Thus, we exclude the specialization for all Apple platforms.

## Additional background

Follow-up to #3094 #3008

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
