### PR TITLE
CMake: add offload linker option --whole-archive for ROCm hipcc

### DIFF
--- a/.github/workflows/hip.yml
+++ b/.github/workflows/hip.yml
@@ -20,7 +20,9 @@ jobs:
     #                                                                          ^
     #    /opt/rocm-4.1.1/hip/include/hip/hcc_detail/hip_runtime.h:176:9: note: macro 'select_impl_' defined here
     #    #define select_impl_(_1, _2, impl_, ...) impl_
-    env: {CXXFLAGS: "-fno-operator-names -Werror -Wall -Wextra -Wpedantic -Wnull-dereference -Wfloat-conversion -Wshadow -Woverloaded-virtual -Wextra-semi -Wunreachable-code -Wnon-virtual-dtor -Wno-deprecated-declarations -Wno-gnu-zero-variadic-macro-arguments"}
+    # Have to have -Wno-unused-command-line-argument to avoid
+    #    clang-15: error: argument unused during compilation: '-Xoffload-linker --whole-archive' [-Werror,-Wunused-command-line-argument]
+    env: {CXXFLAGS: "-fno-operator-names -Werror -Wall -Wextra -Wpedantic -Wnull-dereference -Wfloat-conversion -Wshadow -Woverloaded-virtual -Wextra-semi -Wunreachable-code -Wnon-virtual-dtor -Wno-deprecated-declarations -Wno-gnu-zero-variadic-macro-arguments -Wno-unused-command-line-argument"}
     steps:
     - uses: actions/checkout@v3
     - name: Dependencies
@@ -67,7 +69,9 @@ jobs:
     #                                                                          ^
     #    /opt/rocm-4.1.1/hip/include/hip/hcc_detail/hip_runtime.h:176:9: note: macro 'select_impl_' defined here
     #    #define select_impl_(_1, _2, impl_, ...) impl_
-    env: {CXXFLAGS: "-fno-operator-names -Werror -Wall -Wextra -Wpedantic -Wnull-dereference -Wfloat-conversion -Wshadow -Woverloaded-virtual -Wextra-semi -Wunreachable-code -Wnon-virtual-dtor -Wno-deprecated-declarations -Wno-gnu-zero-variadic-macro-arguments"}
+    # Have to have -Wno-unused-command-line-argument to avoid
+    #    clang-15: error: argument unused during compilation: '-Xoffload-linker --whole-archive' [-Werror,-Wunused-command-line-argument]
+    env: {CXXFLAGS: "-fno-operator-names -Werror -Wall -Wextra -Wpedantic -Wnull-dereference -Wfloat-conversion -Wshadow -Woverloaded-virtual -Wextra-semi -Wunreachable-code -Wnon-virtual-dtor -Wno-deprecated-declarations -Wno-gnu-zero-variadic-macro-arguments -Wno-unused-command-line-argument"}
     steps:
     - uses: actions/checkout@v3
     - name: Dependencies

--- a/Tools/CMake/AMReXParallelBackends.cmake
+++ b/Tools/CMake/AMReXParallelBackends.cmake
@@ -282,6 +282,10 @@ if (AMReX_HIP)
           $<$<COMPILE_LANGUAGE:CXX>:--offload-arch=${AMReX_AMD_ARCH_HIPCC}>)
    endif()
 
+   # ROCm 5.5: hipcc now relies on clang to offload code objects from (.a) archive files,
+   # so we need to tell the offload-linker to include all code objects in archives.
+   target_link_options(amrex PUBLIC -Xoffload-linker --whole-archive)
+
    target_compile_options(amrex PUBLIC $<$<COMPILE_LANGUAGE:CXX>:-m64>)
 
    # ROCm 4.5: use unsafe floating point atomics, otherwise atomicAdd is much slower


### PR DESCRIPTION
## Summary
 Hipcc linking will be relying on clang to offload all code objects from archives, so we need to add -Xoffload-linker --whole-archive option.

## Additional background
 Existing hipcc would offload code objects in archive files. Now it will rely on clang to do this, but we need to tell the offload linker to include all symbols/functions in an archive file.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
