### PR TITLE
CMake: Fix AMD Flags for ROCm 5.5

### DIFF
--- a/.github/workflows/hip.yml
+++ b/.github/workflows/hip.yml
@@ -20,9 +20,7 @@ jobs:
     #                                                                          ^
     #    /opt/rocm-4.1.1/hip/include/hip/hcc_detail/hip_runtime.h:176:9: note: macro 'select_impl_' defined here
     #    #define select_impl_(_1, _2, impl_, ...) impl_
-    # Have to have -Wno-unused-command-line-argument to avoid
-    #    clang-15: error: argument unused during compilation: '-Xoffload-linker --whole-archive' [-Werror,-Wunused-command-line-argument]
-    env: {CXXFLAGS: "-fno-operator-names -Werror -Wall -Wextra -Wpedantic -Wnull-dereference -Wfloat-conversion -Wshadow -Woverloaded-virtual -Wextra-semi -Wunreachable-code -Wnon-virtual-dtor -Wno-deprecated-declarations -Wno-gnu-zero-variadic-macro-arguments -Wno-unused-command-line-argument"}
+    env: {CXXFLAGS: "-fno-operator-names -Werror -Wall -Wextra -Wpedantic -Wnull-dereference -Wfloat-conversion -Wshadow -Woverloaded-virtual -Wextra-semi -Wunreachable-code -Wnon-virtual-dtor -Wno-deprecated-declarations -Wno-gnu-zero-variadic-macro-arguments"}
     steps:
     - uses: actions/checkout@v3
     - name: Dependencies
@@ -69,9 +67,7 @@ jobs:
     #                                                                          ^
     #    /opt/rocm-4.1.1/hip/include/hip/hcc_detail/hip_runtime.h:176:9: note: macro 'select_impl_' defined here
     #    #define select_impl_(_1, _2, impl_, ...) impl_
-    # Have to have -Wno-unused-command-line-argument to avoid
-    #    clang-15: error: argument unused during compilation: '-Xoffload-linker --whole-archive' [-Werror,-Wunused-command-line-argument]
-    env: {CXXFLAGS: "-fno-operator-names -Werror -Wall -Wextra -Wpedantic -Wnull-dereference -Wfloat-conversion -Wshadow -Woverloaded-virtual -Wextra-semi -Wunreachable-code -Wnon-virtual-dtor -Wno-deprecated-declarations -Wno-gnu-zero-variadic-macro-arguments -Wno-unused-command-line-argument"}
+    env: {CXXFLAGS: "-fno-operator-names -Werror -Wall -Wextra -Wpedantic -Wnull-dereference -Wfloat-conversion -Wshadow -Woverloaded-virtual -Wextra-semi -Wunreachable-code -Wnon-virtual-dtor -Wno-deprecated-declarations -Wno-gnu-zero-variadic-macro-arguments"}
     steps:
     - uses: actions/checkout@v3
     - name: Dependencies

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.17)
+cmake_minimum_required(VERSION 3.18)
 
 #
 # Allow for MSVC Runtime library controls

--- a/Docs/sphinx_documentation/source/BuildingAMReX.rst
+++ b/Docs/sphinx_documentation/source/BuildingAMReX.rst
@@ -730,7 +730,7 @@ You can tell CMake to look for the AMReX library in non-standard paths by settin
 ``AMReX_ROOT`` to point to the AMReX installation directory or by adding
 ``-DAMReX_ROOT=<path/to/amrex/installation/directory>`` to the ``cmake`` invocation.
 More details on ``find_package`` can be found
-`here <https://cmake.org/cmake/help/v3.17/command/find_package.html>`_.
+`here <https://cmake.org/cmake/help/v3.25/command/find_package.html>`_.
 
 .. _sec:build:windows:
 

--- a/Docs/sphinx_documentation/source/BuildingAMReX_Chapter.rst
+++ b/Docs/sphinx_documentation/source/BuildingAMReX_Chapter.rst
@@ -23,7 +23,7 @@ Fortran compiler that supports the Fortran 2003 standard, and a C
 compiler that supports the C99 standard.  Prerequisites for building
 with GNU Make include Python (>= 2.7, including 3) and standard tools
 available in any Unix-like environments (e.g., Perl and sed).  For
-building with CMake, the minimal requirement is version 3.17.
+building with CMake, the minimal requirement is version 3.18.
 
 Please note that we fully support AMReX for Linux systems in general and on the
 DOE supercomputers (e.g. Cori, Summit) in particular.  Many of our users do build

--- a/Tests/CMakeTestInstall/CMakeLists.txt
+++ b/Tests/CMakeTestInstall/CMakeLists.txt
@@ -3,7 +3,7 @@
 # building and running the code
 # in Tests/Amr/Advection_AmrCore/
 #
-cmake_minimum_required(VERSION 3.17)
+cmake_minimum_required(VERSION 3.18)
 
 project(amrex-test-install)
 

--- a/Tests/SpackSmokeTest/CMakeLists.txt
+++ b/Tests/SpackSmokeTest/CMakeLists.txt
@@ -6,7 +6,7 @@
 # against a currently installed version of AMReX. The resulting
 # executable can then be ran to test functionality.
 
-cmake_minimum_required(VERSION 3.17)
+cmake_minimum_required(VERSION 3.18)
 
 project(amrex-test-install)
 
@@ -22,9 +22,6 @@ if (AMReX_FORTRAN_INTERFACES)
 endif()
 
 if (AMReX_GPU_BACKEND STREQUAL "CUDA")
-    if(CMAKE_VERSION VERSION_LESS 3.17)
-        message(FATAL_ERROR "Cuda requires CMake version 3.17 or newer")
-    endif()
     enable_language(CUDA)
     find_package(AMReX REQUIRED CUDA)
 

--- a/Tools/CMake/AMReXParallelBackends.cmake
+++ b/Tools/CMake/AMReXParallelBackends.cmake
@@ -285,9 +285,13 @@ if (AMReX_HIP)
    # ROCm 5.5: hipcc now relies on clang to offload code objects from (.a) archive files,
    # so we need to tell the offload-linker to include all code objects in archives.
    include(CheckLinkerFlag)
-   check_linker_flag("-Xoffload-linker --whole-archive" LINKER_HAS_WHOLE_ARCHIVE_OFFLOAD)
+   check_linker_flag(
+       CXX
+       "SHELL:-Xoffload-linker --whole-archive"
+       LINKER_HAS_WHOLE_ARCHIVE_OFFLOAD)
    if(LINKER_HAS_WHOLE_ARCHIVE_OFFLOAD)
-       target_link_options(amrex PUBLIC "SHELL:-Xoffload-linker --whole-archive")
+       target_link_options(amrex PUBLIC
+           "$<$<LINK_LANGUAGE:CXX>:SHELL:-Xoffload-linker --whole-archive>")
    endif()
 
    target_compile_options(amrex PUBLIC $<$<COMPILE_LANGUAGE:CXX>:-m64>)

--- a/Tools/CMake/AMReXParallelBackends.cmake
+++ b/Tools/CMake/AMReXParallelBackends.cmake
@@ -284,7 +284,11 @@ if (AMReX_HIP)
 
    # ROCm 5.5: hipcc now relies on clang to offload code objects from (.a) archive files,
    # so we need to tell the offload-linker to include all code objects in archives.
-   target_link_options(amrex PUBLIC "SHELL:-Xoffload-linker --whole-archive")
+   include(CheckLinkerFlag)
+   check_linker_flag("-Xoffload-linker --whole-archive" LINKER_HAS_WHOLE_ARCHIVE_OFFLOAD)
+   if(LINKER_HAS_WHOLE_ARCHIVE_OFFLOAD)
+       target_link_options(amrex PUBLIC "SHELL:-Xoffload-linker --whole-archive")
+   endif()
 
    target_compile_options(amrex PUBLIC $<$<COMPILE_LANGUAGE:CXX>:-m64>)
 

--- a/Tools/CMake/AMReXParallelBackends.cmake
+++ b/Tools/CMake/AMReXParallelBackends.cmake
@@ -284,7 +284,7 @@ if (AMReX_HIP)
 
    # ROCm 5.5: hipcc now relies on clang to offload code objects from (.a) archive files,
    # so we need to tell the offload-linker to include all code objects in archives.
-   target_link_options(amrex PUBLIC -Xoffload-linker --whole-archive)
+   target_link_options(amrex PUBLIC "SHELL:-Xoffload-linker --whole-archive")
 
    target_compile_options(amrex PUBLIC $<$<COMPILE_LANGUAGE:CXX>:-m64>)
 


### PR DESCRIPTION
## First Commit: Shell-Excape Tokens

- [x] The new ROCm 5.5 flag `-Xoffload-linker --whole-archive` is a flag with an argument. CMake will deduplicate the command line if it encounters another `-Xoffload-linker` on it, which will break compilations in the future.

This marks the whole string as a token that can only be deduplicated as a whole.
Ref.: https://cmake.org/cmake/help/v3.25/command/target_link_options.html#option-de-duplication

## Second Commit: Only ROCm 5.5+

- [x] Do not add the flags `-Xoffload-linker --whole-archive` in earlier ROCm releases, avoiding compile-time warnings.

## Third Commit: Clean Up CI

- [x] Remove warning suppression introduced in #3097

## Additional background

Follow-up to @david-salinas's #3097

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
