### PR TITLE
Check component and derive names for `canDerive` and `get`

### DIFF
--- a/Src/Amr/AMReX_Derive.cpp
+++ b/Src/Amr/AMReX_Derive.cpp
@@ -430,6 +430,12 @@ DeriveList::canDerive (const std::string& name) const
          li != End;
          ++li)
     {
+        // Can be either a component name ...
+        for (int i = 0; i < li->numDerive(); i++) {
+           if (li->variableName(i) == name)
+               return true;
+        }
+        // ... or a derive name
         if (li->derive_name == name)
             return true;
     }
@@ -443,6 +449,12 @@ DeriveList::get (const std::string& name) const
          li != End;
          ++li)
     {
+        // Can be either a component name ...
+        for (int i = 0; i < li->numDerive(); i++) {
+           if (li->variableName(i) == name)
+               return &(*li);
+        }
+        // ... or a derive name
         if (li->derive_name == name)
             return &(*li);
     }


### PR DESCRIPTION
## Summary

`canDerive` and `get` in the `DeriveList` class only check the derive name but not the variable component names. This code adds a check on the variable names. @esclapez did this internally for PeleLMeX and we need it for PeleC as well so I thought this should just belong in AMReX. 

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
