### PR TITLE
HIP: Remove explicit unsafeAtomicAdd() calls

### DIFF
--- a/Src/Base/AMReX_GpuAtomic.H
+++ b/Src/Base/AMReX_GpuAtomic.H
@@ -144,21 +144,6 @@ namespace detail {
 #endif
     }
 
-#if defined(AMREX_USE_HIP) && defined(__gfx90a__)
-    // https://github.com/ROCm-Developer-Tools/hipamd/blob/rocm-4.5.x/include/hip/amd_detail/amd_hip_unsafe_atomics.h
-    AMREX_GPU_DEVICE AMREX_FORCE_INLINE
-    float Add_device (float* const sum, float const value) noexcept
-    {
-        return unsafeAtomicAdd(sum, value);
-    }
-
-    AMREX_GPU_DEVICE AMREX_FORCE_INLINE
-    double Add_device (double* const sum, double const value) noexcept
-    {
-        return unsafeAtomicAdd(sum, value);
-    }
-#endif
-
 #if defined(AMREX_USE_CUDA) || defined(AMREX_USE_HIP)
 
     // https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#atomicadd


### PR DESCRIPTION
## Summary

Since we are already passing the `-munsafe-fp-atomics` flag to the compiler, it is unnecessary to explicitly call `unsafeAtomicAdd()`. See the [HIP programming guide](https://docs.amd.com/bundle/HIP-Programming-Guide-v5.4/page/Programming_with_HIP.html) under _Unsafe Floating-point Atomic RMW Operations_.

## Additional background

I've used the [ElectromagneticPIC](https://github.com/AMReX-Codes/amrex-tutorials/tree/main/ExampleCodes/Particles/ElectromagneticPIC) benchmark, which performs an atomic reduction when depositing the current onto the grid, to verify there is indeed no loss in performance when executing on either an AMD MI210 or an AMD MI250.

Interestingly, however, I came across an unrelated quirk in the HIP compiler.
Since it's enabled by default, I was using `-fgpu-rdc` - which enables relocatable device code - to compile AMReX. It turns out, however, that this means compilation is no longer deterministic, meaning back-to-back compilations will produce different binaries. Crucially, these binaries also have different performance, meaning a single compilation is not guaranteed to output the best performing binary but, instead, that a series of compilations might be needed until a well performing binary is obtained.
I've built with `USE_GPU_RDC=FALSE` to guarantee a fair comparison above regarding the unsafe atomics. Notably, I've noticed that the binary obtained this way is not as fast as the best binary, but it's also not as slow as the worst binary, I got with `-fgpu-rdc` enabled.

Cheers,
-Nuno