### PR TITLE
OpenBCSolver: Fix reuse

### DIFF
--- a/Src/LinearSolvers/OpenBC/AMReX_OpenBC.cpp
+++ b/Src/LinearSolvers/OpenBC/AMReX_OpenBC.cpp
@@ -349,6 +349,8 @@ Real OpenBCSolver::solve (const Vector<MultiFab*>& a_sol,
             m_mlmg_2->setHypreInterface(Hypre::Interface::structed);
         }
 #endif
+    } else {
+        m_poisson_2->setLevelBC(0, &sol_all[0]);
     }
 
     Real err = m_mlmg_2->solve(GetVecOfPtrs(sol_all), GetVecOfConstPtrs(rhs_all),


### PR DESCRIPTION
When the open BC solver is reused, we must update the level BC.