### PR TITLE
CMake 3.18+: Stay OLD CUDA_ARCHITECTURES Policy

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,16 @@ if(POLICY CMP0127)
 endif()
 
 #
+# CMake 3.18+: CMAKE_CUDA_ARCHITECTURES
+# https://cmake.org/cmake/help/latest/policy/CMP0104.html
+# We have to migrate there, but maybe the new "native" option (CMake 3.24+)
+# is what we want to wait for:
+# https://cmake.org/cmake/help/v3.24/prop_tgt/CUDA_ARCHITECTURES.html
+if(POLICY CMP0104)
+    cmake_policy(SET CMP0104 OLD)
+endif()
+
+#
 # Prevent in-source builds
 #
 if (CMAKE_BINARY_DIR STREQUAL CMAKE_SOURCE_DIR)
@@ -97,14 +107,6 @@ endif ()
 # Enable CUDA if requested
 #
 if (AMReX_CUDA)
-    if(CMAKE_VERSION VERSION_LESS 3.20)
-        # CMake 3.18+: CMAKE_CUDA_ARCHITECTURES
-        # https://cmake.org/cmake/help/latest/policy/CMP0104.html
-        if(POLICY CMP0104)
-            cmake_policy(SET CMP0104 OLD)
-        endif()
-    endif()
-
     enable_language(CUDA)
     if(CMAKE_VERSION VERSION_LESS 3.20)
         include(AMReX_SetupCUDA)

--- a/Tools/CMake/AMReXUtils.cmake
+++ b/Tools/CMake/AMReXUtils.cmake
@@ -254,7 +254,7 @@ endfunction ()
 # Note: if no target arch is specified, it will try to determine
 # which GPU architecture is supported by the system. If more than one is found,
 # it will build for all of them.
-# If autodetection fails, a list of “common” architectures is assumed.
+# If autodetection fails, a list of "common" architectures is assumed.
 #
 function (set_cuda_architectures _cuda_archs)
 


### PR DESCRIPTION
## Summary

For now... We removed this guard in WarpX & ImpactX a while ago. Need to revisit how we want to add the logic, probably by jumping to CMake 3.20+ requirements and ditching legacy CUDA logic.

## Additional background

Regression from switching to CMake 3.18+, which then enables new policies.
Introduced in #3107

- https://cmake.org/cmake/help/latest/policy/CMP0104.html
- https://cmake.org/cmake/help/v3.24/prop_tgt/CUDA_ARCHITECTURES.html#prop_tgt:CUDA_ARCHITECTURES

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
