### PR TITLE
Multi-grid NeighborList GPU Sync

### DIFF
--- a/Src/Particle/AMReX_NeighborList.H
+++ b/Src/Particle/AMReX_NeighborList.H
@@ -448,7 +448,7 @@ public:
             }// ii
           } // type
         });
-        Gpu::Device::synchronize();
+        Gpu::Device::streamSynchronize();
     }
 
     NeighborData<ParticleType> data ()

--- a/Src/Particle/AMReX_NeighborList.H
+++ b/Src/Particle/AMReX_NeighborList.H
@@ -448,6 +448,7 @@ public:
             }// ii
           } // type
         });
+        Gpu::Device::synchronize();
     }
 
     NeighborData<ParticleType> data ()


### PR DESCRIPTION
## Summary
Synchronizing at the end of building the neighbor list avoids memory mis-references on GPU with the multi-grid approach.

## Additional background

## Checklist

The proposed changes:
- [X] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
