### PR TITLE
oneAPI: Work around compiler bug

### DIFF
--- a/Src/EB/AMReX_algoim_K.H
+++ b/Src/EB/AMReX_algoim_K.H
@@ -571,6 +571,19 @@ struct ImplicitIntegral
         new_free[e0] = false;
         ImplicitIntegral<M-1,N,Phi,ImplicitIntegral<M,N,Phi,F,S>,false>
             (phi, *this, new_free, newPsi, newPsiCount);
+
+#if defined(AMREX_USE_DPCPP)
+#if AMREX_DEVICE_COMPILE
+        if constexpr (std::is_same<F,QuadratureRule>()) {
+            if (&f != &f_) {
+                // xxxxx DPCPP todo The only purpose of the following
+                // statement is to work around a compiler bug.  Nothing will
+                // actually be printed because &f == &f_.
+                AMREX_DEVICE_PRINTF("Work around compiler bug. %p %p\n", &f, &f_);
+            }
+        }
+#endif
+#endif
     }
 };
 


### PR DESCRIPTION
This makes Tests/LinearSolvers/NodeEB/ 3D test work with oneAPI.