### PR TITLE
Update Build Systems for oneAPI

### DIFF
--- a/.github/workflows/dependencies/dependencies_dpcpp.sh
+++ b/.github/workflows/dependencies/dependencies_dpcpp.sh
@@ -21,5 +21,4 @@ sudo apt-get install -y --no-install-recommends \
     intel-oneapi-dpcpp-cpp-compiler \
     intel-oneapi-compiler-fortran \
     intel-oneapi-mkl-devel \
-    libopenmpi-dev  \
-    openmpi-bin
+    intel-oneapi-mpi-devel

--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -33,6 +33,31 @@ jobs:
             -DCMAKE_Fortran_COMPILER=$(which ifx)
         cmake --build build --parallel 2
 
+  tests-oneapi-sycl-eb:
+    name: oneAPI SYCL [tests w/ EB]
+    runs-on: ubuntu-20.04
+    # mkl/rng/device/detail/mrg32k3a_impl.hpp has a number of sign-compare error
+    env: {CXXFLAGS: "-fno-operator-names -Werror -Wall -Wextra -Wpedantic -Wnull-dereference -Wfloat-conversion -Wshadow -Woverloaded-virtual -Wextra-semi -Wunreachable-code -Wnon-virtual-dtor -Wno-sign-compare"}
+    steps:
+    - uses: actions/checkout@v3
+    - name: Dependencies
+      run: .github/workflows/dependencies/dependencies_dpcpp.sh
+    - name: Build & Install
+      run: |
+        set +e
+        source /opt/intel/oneapi/setvars.sh
+        set -e
+        cmake -S . -B build                                \
+            -DCMAKE_VERBOSE_MAKEFILE=ON                    \
+            -DAMReX_EB=ON                                  \
+            -DAMReX_ENABLE_TESTS=ON                        \
+            -DAMReX_FORTRAN=OFF                            \
+            -DAMReX_PARTICLES=ON                           \
+            -DAMReX_GPU_BACKEND=SYCL                       \
+            -DCMAKE_C_COMPILER=$(which icx)                \
+            -DCMAKE_CXX_COMPILER=$(which icpx)
+        cmake --build build --parallel 2
+
 # "Classic" EDG Intel Compiler
 # Ref.: https://github.com/rscohn2/oneapi-ci
 # intel-basekit intel-hpckit are too large in size

--- a/Docs/sphinx_documentation/source/GPU.rst
+++ b/Docs/sphinx_documentation/source/GPU.rst
@@ -391,7 +391,7 @@ Below is an example configuration for SYCL:
    +==============================+=================================================+=============+=================+
    | AMReX_DPCPP_AOT              | Enable DPCPP ahead-of-time compilation          | NO          | YES, NO         |
    +------------------------------+-------------------------------------------------+-------------+-----------------+
-   | AMREX_INTEL_ARCH             | Specify target if AOT is enabled                | None        | Gen9, etc.      |
+   | AMREX_INTEL_ARCH             | Specify target if AOT is enabled                | *           | Gen9, etc.      |
    +------------------------------+-------------------------------------------------+-------------+-----------------+
    | AMReX_DPCPP_SPLIT_KERNEL     | Enable DPCPP kernel splitting                   | YES         | YES, NO         |
    +------------------------------+-------------------------------------------------+-------------+-----------------+

--- a/Tools/CMake/AMReXOptions.cmake
+++ b/Tools/CMake/AMReXOptions.cmake
@@ -174,17 +174,13 @@ cmake_dependent_option( AMReX_DPCPP_ONEDPL "Enable DPCPP's oneDPL algorithms"  O
 print_option(  AMReX_DPCPP_ONEDPL )
 
 if (AMReX_DPCPP)
-   set(AMReX_INTEL_ARCH_DEFAULT "IGNORE")
+   set(AMReX_INTEL_ARCH_DEFAULT "*")
    if (DEFINED ENV{AMREX_INTEL_ARCH})
       set(AMReX_INTEL_ARCH_DEFAULT "$ENV{AMREX_INTEL_ARCH}")
    endif()
 
    set(AMReX_INTEL_ARCH ${AMReX_INTEL_ARCH_DEFAULT} CACHE STRING
-      "INTEL GPU architecture (Must be provided if AMReX_GPU_BACKEND=SYCL and AMReX_DPCPP_AOT=ON)")
-
-   if (AMReX_DPCPP_AOT AND NOT AMReX_INTEL_ARCH)
-      message(FATAL_ERROR "\nMust specify AMReX_INTEL_ARCH if AMReX_GPU_BACKEND=SYCL and AMReX_DPCPP_AOT=ON\n")
-   endif()
+      "INTEL GPU architecture")
 endif ()
 
 # --- HIP ----

--- a/Tools/CMake/AMReXSYCL.cmake
+++ b/Tools/CMake/AMReXSYCL.cmake
@@ -63,16 +63,16 @@ target_link_options( SYCL
 
 
 if (AMReX_DPCPP_AOT)
-   target_compile_options( SYCL
-      INTERFACE
-      "$<${_cxx_dpcpp}:-fsycl-targets=spir64_gen>"
-      "$<${_cxx_dpcpp}:SHELL:-Xsycl-target-backend \"-device ${AMReX_INTEL_ARCH}\">" )
-
    target_link_options( SYCL
       INTERFACE
       "$<${_cxx_dpcpp}:-fsycl-targets=spir64_gen>"
       "$<${_cxx_dpcpp}:SHELL:-Xsycl-target-backend \"-device ${AMReX_INTEL_ARCH}\">" )
 endif ()
 
+if (CMAKE_SYSTEM_NAME STREQUAL "Linux" AND "${CMAKE_BUILD_TYPE}" MATCHES "Debug")
+   target_link_options( SYCL
+      INTERFACE
+      "$<${_cxx_dpcpp}:-fsycl-link-huge-device-code>" )
+endif ()
 
 unset(_cxx_dpcpp)

--- a/Tools/GNUMake/comps/dpcpp.mak
+++ b/Tools/GNUMake/comps/dpcpp.mak
@@ -71,36 +71,8 @@ endif
 CXXFLAGS += -fsycl
 CFLAGS   += -std=c11
 
-ifneq ($(DEBUG),TRUE)  # There is currently a bug that DEBUG build will crash.
-ifeq ($(DPCPP_AOT),TRUE)
-  ifdef AMREX_INTEL_ARCH
-    INTEL_CPU_SHORT_NAME = $(AMREX_INTEL_ARCH)
-  else
-  ifdef INTEL_ARCH
-    INTEL_CPU_SHORT_NAME = $(INTEL_ARCH)
-  else
-    INTEL_CPU_LONG_NAME = $(shell cat /sys/devices/cpu/caps/pmu_name)
-    ifneq ($(INTEL_CPU_LONG_NAME),)
-      ifeq ($(INTEL_CPU_LONG_NAME),skylake)
-        INTEL_CPU_SHORT_NAME = skl
-      else ifeq ($(INTEL_CPU_LONG_NAME),kabylake)
-        INTEL_CPU_SHORT_NAME = kbl
-      else ifeq ($(INTEL_CPU_LONG_NAME),cascadelake)
-        INTEL_CPU_SHORT_NAME = cfl
-      else
-        $(error AOT TODO: $(INTEL_CPU_LONG_NAME))
-      endif
-    endif
-  endif
-  endif
-  CXXFLAGS += -fsycl-targets=spir64_gen -Xsycl-target-backend '-device $(INTEL_CPU_SHORT_NAME)'
-endif
-endif
-
-ifneq ($(DPCPP_AOT),TRUE)
 ifneq ($(DPCPP_SPLIT_KERNEL),FALSE)
   CXXFLAGS += -fsycl-device-code-split=per_kernel
-endif
 endif
 
 # temporary work-around for DPC++ beta08 bug
@@ -149,6 +121,26 @@ ifneq ($(BL_NO_FORT),TRUE)
 endif
 
 LDFLAGS += -fsycl-device-lib=libc,libm-fp32,libm-fp64
+
+ifeq ($(DPCPP_AOT),TRUE)
+  ifndef AMREX_INTEL_ARCH
+    ifdef INTEL_ARCH
+      AMREX_INTEL_ARCH = $(INTEL_ARCH)
+    endif
+  endif
+  ifdef AMREX_INTEL_ARCH
+    amrex_intel_gpu_target = $(AMREX_INTEL_ARCH)
+  else
+    amrex_intel_gpu_target = *
+    $(info Because neither INTEL_ARCH nor AMREX_INTEL_ARCH is specified, AOT will be performed for all devices.)
+  endif
+  LDFLAGS += -fsycl-targets=spir64_gen -Xsycl-target-backend '-device $(amrex_intel_gpu_target)'
+endif
+
+ifeq ($(DEBUG),TRUE)
+  # This might be needed for linking device code larger than 2GB.
+  LDFLAGS += -fsycl-link-huge-device-code
+endif
 
 ifeq ($(FSANITIZER),TRUE)
   override XTRALIBS += -lubsan


### PR DESCRIPTION
* For DEBUG builds, link with -fsycl-link-huge-device-code, otherwise it might crash due to device code larger than 2GB.

* The AOT arguments are for the linker only.  So they are removed from compile options.

* Change the default of AMReX_INTEL_ARCH to * (i.e., all devices).  This does not seem to increase link time or executable size that much. The movtivation for this is that the users do not have to set the device target to some magic numbers.

* Add new CI to test EB.  Also switch to use Intel MPI.

* Fix a mistake in GNU Make. DPCPP_SPLIT_KERNEL can be used independent of AOT.