### PR TITLE
NVHPC: CUDA

### DIFF
--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -67,12 +67,11 @@ jobs:
             -DCMAKE_VERBOSE_MAKEFILE=ON                  \
             -DAMReX_ENABLE_TESTS=ON                      \
             -DAMReX_PARTICLES=ON                         \
-            -DAMReX_FORTRAN=OFF                          \
+            -DAMReX_FORTRAN=ON                           \
             -DAMReX_GPU_BACKEND=CUDA                     \
             -DCMAKE_C_COMPILER=$(which nvc)              \
             -DCMAKE_CXX_COMPILER=$(which nvc++)          \
             -DCMAKE_CUDA_HOST_COMPILER=$(which nvc++)    \
-            -DCMAKE_Fortran_COMPILER=$(which nvfortran)  \
             -DCMAKE_Fortran_COMPILER=$(which nvfortran)  \
             -DAMReX_CUDA_ARCH=8.0                        \
             -DAMReX_CUDA_ERROR_CROSS_EXECUTION_SPACE_CALL=ON \

--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -68,10 +68,15 @@ jobs:
             -DAMReX_ENABLE_TESTS=ON                      \
             -DAMReX_PARTICLES=ON                         \
             -DAMReX_FORTRAN=OFF                          \
-            -DAMReX_OMP=ON                               \
+            -DAMReX_GPU_BACKEND=CUDA                     \
             -DCMAKE_C_COMPILER=$(which nvc)              \
             -DCMAKE_CXX_COMPILER=$(which nvc++)          \
-            -DCMAKE_Fortran_COMPILER=$(which nvfortran)
+            -DCMAKE_CUDA_HOST_COMPILER=$(which nvc++)    \
+            -DCMAKE_Fortran_COMPILER=$(which nvfortran)  \
+            -DCMAKE_Fortran_COMPILER=$(which nvfortran)  \
+            -DAMReX_CUDA_ARCH=8.0                        \
+            -DAMReX_CUDA_ERROR_CROSS_EXECUTION_SPACE_CALL=ON \
+            -DAMReX_CUDA_ERROR_CAPTURE_THIS=ON
 
         cmake --build build -j 2
 


### PR DESCRIPTION
## Summary

Ooops. In my last commit #3122, I accidentially switched NVHPC to compile for OpenMP instead of the CUDA backend.

## Additional background

But cool, that means OpenMP 4.0 works now #2378

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
