### PR TITLE
Runtime parameters for Signal handling controls

### DIFF
--- a/Src/Base/AMReX.H
+++ b/Src/Base/AMReX.H
@@ -48,6 +48,12 @@ namespace amrex
         extern AMREX_EXPORT int verbose;
 
         extern AMREX_EXPORT int signal_handling;
+        extern AMREX_EXPORT int handle_sigsegv;
+        extern AMREX_EXPORT int handle_sigterm;
+        extern AMREX_EXPORT int handle_sigint;
+        extern AMREX_EXPORT int handle_sigabrt;
+        extern AMREX_EXPORT int handle_sigfpe;
+
         extern AMREX_EXPORT int call_addr2line;
         extern AMREX_EXPORT int throw_exception;
 

--- a/Src/Base/AMReX.cpp
+++ b/Src/Base/AMReX.cpp
@@ -86,6 +86,11 @@ namespace system
     std::string exename;
     int verbose = 1;
     int signal_handling;
+    int handle_sigsegv;
+    int handle_sigterm;
+    int handle_sigint;
+    int handle_sigabrt;
+    int handle_sigfpe;
     int call_addr2line;
     int throw_exception;
     int regtest_reduction;
@@ -106,17 +111,17 @@ namespace {
     std::streamsize  prev_err_precision;
     std::new_handler prev_new_handler;
     typedef void (*SignalHandler)(int);
-    SignalHandler prev_handler_sigsegv;
-    SignalHandler prev_handler_sigterm;
-    SignalHandler prev_handler_sigint;
-    SignalHandler prev_handler_sigabrt;
-    SignalHandler prev_handler_sigfpe;
+    SignalHandler prev_handler_sigsegv = SIG_ERR;
+    SignalHandler prev_handler_sigterm = SIG_ERR;
+    SignalHandler prev_handler_sigint  = SIG_ERR;
+    SignalHandler prev_handler_sigabrt = SIG_ERR;
+    SignalHandler prev_handler_sigfpe  = SIG_ERR;
 #if defined(__linux__)
-    int           prev_fpe_excepts;
-    int           curr_fpe_excepts;
+    int           prev_fpe_excepts = 0;
+    int           curr_fpe_excepts = 0;
 #elif defined(__APPLE__) && defined(__x86_64__)
-    unsigned int  prev_fpe_mask;
-    unsigned int  curr_fpe_excepts;
+    unsigned int  prev_fpe_mask = 0u;
+    unsigned int  curr_fpe_excepts = 0u;
 #endif
 }
 
@@ -316,6 +321,11 @@ amrex::Initialize (int& argc, char**& argv, bool build_parm_parse,
 //    system::verbose = 0;
     system::regtest_reduction = 0;
     system::signal_handling = 1;
+    system::handle_sigsegv = 1;
+    system::handle_sigterm = 0;
+    system::handle_sigint  = 1;
+    system::handle_sigabrt = 1;
+    system::handle_sigfpe  = 1;
     system::call_addr2line = 1;
     system::throw_exception = 0;
     system::osout = &a_osout;
@@ -463,53 +473,83 @@ amrex::Initialize (int& argc, char**& argv, bool build_parm_parse,
         pp.queryAdd("call_addr2line", system::call_addr2line);
         pp.queryAdd("abort_on_unused_inputs", system::abort_on_unused_inputs);
 
+#ifdef AMREX_USE_DPCPP
+        // Disable SIGSEGV handling by default for certain Intel GPUs,
+        // because it is currently used by their managed memory
+        // implementation.
+        if (Gpu::Device::deviceName().find("[0x0bd6]") != std::string::npos || // PVC
+            Gpu::Device::deviceName().find("[0x020f]") != std::string::npos) { // ATS
+            system::handle_sigsegv = 0;
+        }
+#endif
+
         if (system::signal_handling)
         {
-            // We could save the singal handlers and restore them in Finalize.
-            prev_handler_sigsegv = signal(SIGSEGV, BLBackTrace::handler); // catch seg fault
-            prev_handler_sigint = signal(SIGINT,  BLBackTrace::handler);
-            prev_handler_sigabrt = signal(SIGABRT, BLBackTrace::handler);
+            pp.queryAdd("handle_sigsegv", system::handle_sigsegv);
+            pp.queryAdd("handle_sigterm", system::handle_sigterm);
+            pp.queryAdd("handle_sigint" , system::handle_sigint );
+            pp.queryAdd("handle_sigabrt", system::handle_sigabrt);
+            pp.queryAdd("handle_sigfpe" , system::handle_sigfpe );
 
-            int term = 0;
-            pp.queryAdd("handle_sigterm", term);
-            if (term) {
-                prev_handler_sigterm = signal(SIGTERM,  BLBackTrace::handler);
+            // We save the singal handlers and restore them in Finalize.
+            if (system::handle_sigsegv) {
+                prev_handler_sigsegv = std::signal(SIGSEGV, BLBackTrace::handler);
+            } else {
+                prev_handler_sigsegv = SIG_ERR;
+            }
+
+            if (system::handle_sigterm) {
+                prev_handler_sigterm = std::signal(SIGTERM,  BLBackTrace::handler);
             } else {
                 prev_handler_sigterm = SIG_ERR;
             }
 
-            prev_handler_sigfpe = SIG_ERR;
+            if (system::handle_sigint) {
+                prev_handler_sigint = std::signal(SIGINT,  BLBackTrace::handler);
+            } else {
+                prev_handler_sigint = SIG_ERR;
+            }
 
-            int invalid = 0, divbyzero=0, overflow=0;
-            pp.queryAdd("fpe_trap_invalid", invalid);
-            pp.queryAdd("fpe_trap_zero", divbyzero);
-            pp.queryAdd("fpe_trap_overflow", overflow);
+            if (system::handle_sigabrt) {
+                prev_handler_sigabrt = std::signal(SIGABRT, BLBackTrace::handler);
+            } else {
+                prev_handler_sigabrt = SIG_ERR;
+            }
+
+            prev_handler_sigfpe = SIG_ERR;
+            if (system::handle_sigfpe)
+            {
+                int invalid = 0, divbyzero=0, overflow=0;
+                pp.queryAdd("fpe_trap_invalid", invalid);
+                pp.queryAdd("fpe_trap_zero", divbyzero);
+                pp.queryAdd("fpe_trap_overflow", overflow);
 
 #if defined(__linux__)
-            curr_fpe_excepts = 0;
-            if (invalid)   curr_fpe_excepts |= FE_INVALID;
-            if (divbyzero) curr_fpe_excepts |= FE_DIVBYZERO;
-            if (overflow)  curr_fpe_excepts |= FE_OVERFLOW;
+                curr_fpe_excepts = 0;
+                if (invalid)   curr_fpe_excepts |= FE_INVALID;
+                if (divbyzero) curr_fpe_excepts |= FE_DIVBYZERO;
+                if (overflow)  curr_fpe_excepts |= FE_OVERFLOW;
 #if !defined(AMREX_USE_DPCPP) && (!defined(__PGI) || (__PGIC__ >= 16))
-            // xxxxx DPCPP todo: fpe trap
-            prev_fpe_excepts = fegetexcept();
-            if (curr_fpe_excepts != 0) {
-                feenableexcept(curr_fpe_excepts);  // trap floating point exceptions
-                prev_handler_sigfpe = signal(SIGFPE,  BLBackTrace::handler);
-            }
+                // xxxxx DPCPP todo: fpe trap
+                prev_fpe_excepts = fegetexcept();
+                if (curr_fpe_excepts != 0) {
+                    feenableexcept(curr_fpe_excepts);  // trap floating point exceptions
+                    prev_handler_sigfpe = std::signal(SIGFPE,  BLBackTrace::handler);
+                }
 #endif
 
 #elif defined(__APPLE__) && defined(__x86_64__)
-            prev_fpe_mask = _MM_GET_EXCEPTION_MASK();
-            curr_fpe_excepts = 0u;
-            if (invalid)   curr_fpe_excepts |= _MM_MASK_INVALID;
-            if (divbyzero) curr_fpe_excepts |= _MM_MASK_DIV_ZERO;
-            if (overflow)  curr_fpe_excepts |= _MM_MASK_OVERFLOW;
-            if (curr_fpe_excepts != 0u) {
-                _MM_SET_EXCEPTION_MASK(prev_fpe_mask & ~curr_fpe_excepts);
-                prev_handler_sigfpe = signal(SIGFPE,  BLBackTrace::handler);
-            }
+                prev_fpe_mask = _MM_GET_EXCEPTION_MASK();
+                curr_fpe_excepts = 0u;
+                if (invalid)   curr_fpe_excepts |= _MM_MASK_INVALID;
+                if (divbyzero) curr_fpe_excepts |= _MM_MASK_DIV_ZERO;
+                if (overflow)  curr_fpe_excepts |= _MM_MASK_OVERFLOW;
+                if (curr_fpe_excepts != 0u) {
+                    _MM_SET_EXCEPTION_MASK(prev_fpe_mask & ~curr_fpe_excepts);
+                    prev_handler_sigfpe = std::signal(SIGFPE,  BLBackTrace::handler);
+                }
 #endif
+            }
         }
 
 #ifdef AMREX_USE_HYPRE
@@ -697,11 +737,11 @@ amrex::Finalize (amrex::AMReX* pamrex)
 #ifndef BL_AMRPROF
     if (system::signal_handling)
     {
-        if (prev_handler_sigsegv != SIG_ERR) signal(SIGSEGV, prev_handler_sigsegv);
-        if (prev_handler_sigterm != SIG_ERR) signal(SIGTERM, prev_handler_sigterm);
-        if (prev_handler_sigint != SIG_ERR) signal(SIGINT, prev_handler_sigint);
-        if (prev_handler_sigabrt != SIG_ERR) signal(SIGABRT, prev_handler_sigabrt);
-        if (prev_handler_sigfpe != SIG_ERR) signal(SIGFPE, prev_handler_sigfpe);
+        if (prev_handler_sigsegv != SIG_ERR) std::signal(SIGSEGV, prev_handler_sigsegv);
+        if (prev_handler_sigterm != SIG_ERR) std::signal(SIGTERM, prev_handler_sigterm);
+        if (prev_handler_sigint  != SIG_ERR) std::signal(SIGINT , prev_handler_sigint);
+        if (prev_handler_sigabrt != SIG_ERR) std::signal(SIGABRT, prev_handler_sigabrt);
+        if (prev_handler_sigfpe  != SIG_ERR) std::signal(SIGFPE , prev_handler_sigfpe);
 #if defined(__linux__)
 #if !defined(__PGI) || (__PGIC__ >= 16)
         if (curr_fpe_excepts != 0) {

--- a/Src/Base/AMReX_BLBackTrace.cpp
+++ b/Src/Base/AMReX_BLBackTrace.cpp
@@ -47,7 +47,7 @@ void
 BLBackTrace::handler(int s)
 {
 
-    signal(s, SIG_DFL);
+    std::signal(s, SIG_DFL);
 
     AsyncOut::Finalize();
 

--- a/Src/Base/AMReX_GpuDevice.cpp
+++ b/Src/Base/AMReX_GpuDevice.cpp
@@ -485,6 +485,7 @@ Device::initialize_gpu ()
         device_prop.managedMemory = d.has(sycl::aspect::usm_host_allocations);
         device_prop.concurrentManagedAccess = d.has(sycl::aspect::usm_shared_allocations);
         device_prop.maxParameterSize = d.get_info<sycl::info::device::max_parameter_size>();
+        if (verbose)
         {
             amrex::Print() << "Device Properties:\n"
                            << "  name: " << device_prop.name << "\n"


### PR DESCRIPTION
Add amrex.handle_sigsegv, handle_sigint, handle_sigabrt, and handle_sigfpe for more fine controls.  Disable sigsegv handling for certain Intel GPUs because it's incompatible with the managed memory.