### PR TITLE
GNU Make: Add support for Intel LLVM compiler in CPU builds

### DIFF
--- a/Src/Base/AMReX_Extension.H
+++ b/Src/Base/AMReX_Extension.H
@@ -2,16 +2,9 @@
 #define AMREX_EXTENSION_H_
 #include <AMReX_Config.H>
 
-#if !defined(BL_LANG_FORT)
-
-// restrict
-
-#ifdef __cplusplus
-
-
-#if defined(__INTEL_COMPILER)
+#if defined(__INTEL_COMPILER) || (defined(__INTEL_LLVM_COMPILER) && !defined(SYCL_LANGUAGE_VERSION))
 #define AMREX_CXX_INTEL
-#elif defined(_CRAYC)
+#elif defined(_CRAYC) || defined(__cray__)
 #define AMREX_CXX_CRAY
 #elif defined(__PGI)
 #define AMREX_CXX_PGI
@@ -27,6 +20,11 @@
 #define AMREX_CXX_GCC
 #endif
 
+#if !defined(BL_LANG_FORT)
+
+// restrict
+
+#ifdef __cplusplus
 
 #ifdef _WIN32
 #define AMREX_RESTRICT __restrict
@@ -54,22 +52,22 @@
 //#elif defined(AMREX_USE_OMP) && defined(_OPENMP) && (_OPENMP >= 201307) && !defined(__PGI)
 //#define AMREX_PRAGMA_SIMD _Pragma("omp simd")
 
-#elif defined(__INTEL_COMPILER)
+#elif defined(AMREX_CXX_INTEL)
 #define AMREX_PRAGMA_SIMD _Pragma("ivdep")
 
-#elif defined(_CRAYC) || defined(__cray__)
+#elif defined(AMREX_CXX_CRAY)
 #define AMREX_PRAGMA_SIMD _Pragma("ivdep")
 
-#elif defined(__PGI)
+#elif defined(AMREX_CXX_PGI)
 #define AMREX_PRAGMA_SIMD _Pragma("loop ivdep")
 
-#elif defined(__NVCOMPILER)
+#elif defined(AMREX_CXX_NVHPC)
 #define AMREX_PRAGMA_SIMD _Pragma("loop ivdep")
 
-#elif defined(__NEC__)
+#elif defined(AMREX_CXX_NEC)
 #define AMREX_PRAGMA_SIMD
 
-#elif defined(__ibmxl__)
+#elif defined(AMREX_CXX_IBM)
 #define AMREX_PRAGMA_SIMD _Pragma("ibm independent_loop")
 
 #elif defined(__clang__)
@@ -90,22 +88,22 @@
 #elif defined(__HIP_DEVICE_COMPILE__) && defined(AMREX_USE_HIP)
 #define AMREX_FORCE_INLINE __forceinline__
 
-#elif defined(__INTEL_COMPILER)
+#elif defined(AMREX_CXX_INTEL)
 #define AMREX_FORCE_INLINE inline __attribute__((always_inline))
 
-#elif defined(_CRAYC)
+#elif defined(AMREX_CXX_CRAY)
 #define AMREX_FORCE_INLINE inline
 
-#elif defined(__PGI)
+#elif defined(AMREX_CXX_PGI)
 #define AMREX_FORCE_INLINE inline
 
-#elif defined(__NVCOMPILER)
+#elif defined(AMREX_CXX_NVHPC)
 #define AMREX_FORCE_INLINE inline
 
-#elif defined(__NEC__)
+#elif defined(AMREX_CXX_NEC)
 #define AMREX_FORCE_INLINE inline
 
-#elif defined(__ibmxl__)
+#elif defined(AMREX_CXX_IBM)
 #define AMREX_FORCE_INLINE inline __attribute__((always_inline))
 
 #elif defined(__clang__)

--- a/Tools/GNUMake/comps/intel-classic.mak
+++ b/Tools/GNUMake/comps/intel-classic.mak
@@ -1,0 +1,78 @@
+#
+# Generic setup for using Intel classic compiler
+#
+CXX = icpc
+CC  = icc
+FC  = ifort
+F90 = ifort
+
+CXXFLAGS =
+CFLAGS   =
+FFLAGS   =
+F90FLAGS =
+
+########################################################################
+
+intel_version = $(shell $(CXX) -dumpversion)
+
+COMP_VERSION = $(intel_version)
+
+########################################################################
+
+ifeq ($(DEBUG),TRUE)
+
+  CXXFLAGS += -g -O0 -traceback -Wcheck
+  CFLAGS   += -g -O0 -traceback -Wcheck
+  FFLAGS   += -g -O0 -traceback -check bounds,uninit,pointers
+  F90FLAGS += -g -O0 -traceback -check bounds,uninit,pointers
+
+else
+
+  CXXFLAGS += -g -O2 -ip -qopt-report=5 -qopt-report-phase=vec
+  CFLAGS   += -g -O2 -ip -qopt-report=5 -qopt-report-phase=vec
+  FFLAGS   += -g -O2 -ip -qopt-report=5 -qopt-report-phase=vec
+  F90FLAGS += -g -O2 -ip -qopt-report=5 -qopt-report-phase=vec
+
+endif
+
+########################################################################
+
+ifdef CXXSTD
+  CXXSTD := $(strip $(CXXSTD))
+  CXXFLAGS += -std=$(CXXSTD)
+else
+  CXXFLAGS += -std=c++17
+endif
+
+CFLAGS   += -std=c11
+
+F90FLAGS += -implicitnone
+
+FMODULES = -module $(fmoddir) -I$(fmoddir)
+
+########################################################################
+
+GENERIC_COMP_FLAGS =
+
+ifeq ($(USE_OMP),TRUE)
+  GENERIC_COMP_FLAGS += -qopenmp
+endif
+
+CXXFLAGS += $(GENERIC_COMP_FLAGS) -pthread
+CFLAGS   += $(GENERIC_COMP_FLAGS)
+FFLAGS   += $(GENERIC_COMP_FLAGS)
+F90FLAGS += $(GENERIC_COMP_FLAGS)
+
+########################################################################
+
+override XTRALIBS += -lifcore
+
+ifeq ($(USE_OMP),TRUE)
+  override XTRALIBS += -lifcoremt
+endif
+
+LINK_WITH_FORTRAN_COMPILER ?= $(USE_F_INTERFACES)
+
+ifeq ($(LINK_WITH_FORTRAN_COMPILER),TRUE)
+  override XTRALIBS += -lstdc++
+endif

--- a/Tools/GNUMake/comps/intel-llvm.mak
+++ b/Tools/GNUMake/comps/intel-llvm.mak
@@ -1,0 +1,111 @@
+#
+# Generic setup for using Intel LLVM compiler
+#
+CXX = icpx
+CC  = icx
+FC  = ifx
+F90 = ifx
+
+CXXFLAGS =
+CFLAGS   =
+FFLAGS   =
+F90FLAGS =
+
+########################################################################
+
+intel_version = $(shell $(CXX) -dumpversion)
+
+COMP_VERSION = $(intel_version)
+
+########################################################################
+
+ifeq ($(DEBUG),TRUE)
+
+  CXXFLAGS += -g -O0 -ftrapv
+  CFLAGS   += -g -O0 -ftrapv
+  FFLAGS   += -g -O0 -ftrapuv -check bounds,pointers,uninit -traceback
+  F90FLAGS += -g -O0 -ftrapuv -check bounds,pointers,uninit -traceback
+
+else
+
+  CXXFLAGS += -g1 -O3
+  CFLAGS   += -g1 -O3
+  FFLAGS   += -g -O3
+  F90FLAGS += -g -O3
+
+endif
+
+########################################################################
+
+ifeq ($(WARN_ALL),TRUE)
+  warning_flags = -Wall -Wextra -Wno-sign-compare -Wunreachable-code -Wnull-dereference
+  warning_flags += -Wfloat-conversion -Wextra-semi
+
+  ifneq ($(USE_CUDA),TRUE)
+    warning_flags += -Wpedantic
+  endif
+
+  ifneq ($(WARN_SHADOW),FALSE)
+    warning_flags += -Wshadow
+  endif
+
+  CXXFLAGS += $(warning_flags) -Woverloaded-virtual -Wnon-virtual-dtor
+  CFLAGS += $(warning_flags)
+endif
+
+ifeq ($(WARN_ERROR),TRUE)
+  CXXFLAGS += -Werror
+  CFLAGS += -Werror
+endif
+
+CXXFLAGS += -Wno-tautological-constant-compare
+CFLAGS += -Wno-tautological-constant-compare
+
+########################################################################
+
+ifdef CXXSTD
+  CXXSTD := $(strip $(CXXSTD))
+  CXXFLAGS += -std=$(CXXSTD)
+else
+  CXXFLAGS += -std=c++17
+endif
+
+CFLAGS   += -std=c11
+
+F90FLAGS += -implicitnone
+
+FMODULES = -module $(fmoddir) -I$(fmoddir)
+
+########################################################################
+
+# ../../../../Src/Base/AMReX_GpuUtility.H:148:16: warning: comparison with NaN
+# always evaluates to false in fast floating point modes
+# [-Wtautological-constant-compare]
+#        return std::isnan(m);
+#               ^~~~~~~~~~~~~
+GENERIC_COMP_FLAGS =
+
+ifeq ($(USE_OMP),TRUE)
+  GENERIC_COMP_FLAGS += -qopenmp
+endif
+
+CXXFLAGS += $(GENERIC_COMP_FLAGS) -pthread
+CFLAGS   += $(GENERIC_COMP_FLAGS)
+FFLAGS   += $(GENERIC_COMP_FLAGS)
+F90FLAGS += $(GENERIC_COMP_FLAGS)
+
+########################################################################
+
+ifneq ($(BL_NO_FORT),TRUE)
+  override XTRALIBS += -lifcore
+
+  ifeq ($(USE_OMP),TRUE)
+    override XTRALIBS += -lifcoremt
+  endif
+
+  LINK_WITH_FORTRAN_COMPILER ?= $(USE_F_INTERFACES)
+
+  ifeq ($(LINK_WITH_FORTRAN_COMPILER),TRUE)
+    override XTRALIBS += -lstdc++
+  endif
+endif

--- a/Tools/GNUMake/comps/intel.mak
+++ b/Tools/GNUMake/comps/intel.mak
@@ -1,78 +1,10 @@
-#
-# Generic setup for using Intel
-#
-CXX = icpc
-CC  = icc
-FC  = ifort
-F90 = ifort
+CXX = icpx
+has_intel_llvm_compiler := $(shell $(CXX) -dumpversion)
 
-CXXFLAGS =
-CFLAGS   =
-FFLAGS   =
-F90FLAGS =
-
-########################################################################
-
-intel_version = $(shell $(CXX) -dumpversion)
-
-COMP_VERSION = $(intel_version)
-
-########################################################################
-
-ifeq ($(DEBUG),TRUE)
-
-  CXXFLAGS += -g -O0 -traceback -Wcheck
-  CFLAGS   += -g -O0 -traceback -Wcheck
-  FFLAGS   += -g -O0 -traceback -check bounds,uninit,pointers
-  F90FLAGS += -g -O0 -traceback -check bounds,uninit,pointers
-
+ifdef has_intel_llvm_compiler
+  $(info Using intel-llvm)
+  include $(AMREX_HOME)/Tools/GNUMake/comps/intel-llvm.mak
 else
-
-  CXXFLAGS += -g -O2 -ip -qopt-report=5 -qopt-report-phase=vec
-  CFLAGS   += -g -O2 -ip -qopt-report=5 -qopt-report-phase=vec
-  FFLAGS   += -g -O2 -ip -qopt-report=5 -qopt-report-phase=vec
-  F90FLAGS += -g -O2 -ip -qopt-report=5 -qopt-report-phase=vec
-
-endif
-
-########################################################################
-
-ifdef CXXSTD
-  CXXSTD := $(strip $(CXXSTD))
-  CXXFLAGS += -std=$(CXXSTD)
-else
-  CXXFLAGS += -std=c++17
-endif
-
-CFLAGS   += -std=c11
-
-F90FLAGS += -implicitnone
-
-FMODULES = -module $(fmoddir) -I$(fmoddir)
-
-########################################################################
-
-GENERIC_COMP_FLAGS =
-
-ifeq ($(USE_OMP),TRUE)
-  GENERIC_COMP_FLAGS += -qopenmp
-endif
-
-CXXFLAGS += $(GENERIC_COMP_FLAGS) -pthread
-CFLAGS   += $(GENERIC_COMP_FLAGS)
-FFLAGS   += $(GENERIC_COMP_FLAGS)
-F90FLAGS += $(GENERIC_COMP_FLAGS)
-
-########################################################################
-
-override XTRALIBS += -lifcore
-
-ifeq ($(USE_OMP),TRUE)
-  override XTRALIBS += -lifcoremt
-endif
-
-LINK_WITH_FORTRAN_COMPILER ?= $(USE_F_INTERFACES)
-
-ifeq ($(LINK_WITH_FORTRAN_COMPILER),TRUE)
-  override XTRALIBS += -lstdc++
+  $(info Using intel-classic)
+  include $(AMREX_HOME)/Tools/GNUMake/comps/intel-classic.mak
 endif


### PR DESCRIPTION
icpc: remark #10441: The Intel(R) C++ Compiler Classic (ICC) is deprecated and will be removed from product release in the second half of 2023.