### PR TITLE
NeighborList: Let scan function return total sum

### DIFF
--- a/Src/Particle/AMReX_NeighborList.H
+++ b/Src/Particle/AMReX_NeighborList.H
@@ -334,8 +334,8 @@ public:
         // First pass: count the number of neighbors for each particle
         //---------------------------------------------------------------------------------------------------------
         const size_t np_size  = (num_bin_types > 1) ? np_total : np_real;
-        m_nbor_counts.resize( np_size+1, 0);
-        m_nbor_offsets.resize(np_size+1);
+        m_nbor_counts.resize( np_size);
+        m_nbor_offsets.resize(np_size);
 
         auto pnbor_counts = m_nbor_counts.dataPtr();
         auto pnbor_offset = m_nbor_offsets.dataPtr();
@@ -393,16 +393,9 @@ public:
 
         // Second-pass: build the offsets (partial sums) and neighbor list
         //--------------------------------------------------------------------------------------------------------
-        Gpu::exclusive_scan(m_nbor_counts.begin(), m_nbor_counts.end(), m_nbor_offsets.begin());
+        auto total_nbors = Scan::ExclusiveSum(m_nbor_counts.size(), pnbor_counts, pnbor_offset);
 
         // Now we can allocate and build our neighbor list
-        unsigned int total_nbors;
-#ifdef AMREX_USE_GPU
-        Gpu::dtoh_memcpy(&total_nbors,m_nbor_offsets.dataPtr()+np_size,sizeof(unsigned int));
-#else
-        std::memcpy(&total_nbors,m_nbor_offsets.dataPtr()+np_size,sizeof(unsigned int));
-#endif
-
         m_nbor_list.resize(total_nbors);
         auto pm_nbor_list = m_nbor_list.dataPtr();
 

--- a/Src/Particle/AMReX_NeighborParticlesI.H
+++ b/Src/Particle/AMReX_NeighborParticlesI.H
@@ -929,11 +929,11 @@ buildNeighborList (CheckPair&& check_pair, int type_ind, int* ref_ratio,
                 auto ploa  = lgeom.ProbLoArray();
 
 #ifdef AMREX_USE_GPU
-                Gpu::htod_memcpy( dxi_v.data()   + type, dxInv.data(), sizeof(dxInv) );
-                Gpu::htod_memcpy( plo_v.data()   + type, ploa.data() , sizeof(ploa) );
-                Gpu::htod_memcpy( lo_v.data()    + type, &lo         , sizeof(lo)    );
-                Gpu::htod_memcpy( hi_v.data()    + type, &hi         , sizeof(hi)    );
-                Gpu::htod_memcpy( nbins_v.data() + type, &nbins      , sizeof(nbins) );
+                Gpu::htod_memcpy_async( dxi_v.data()   + type, dxInv.data(), sizeof(dxInv) );
+                Gpu::htod_memcpy_async( plo_v.data()   + type, ploa.data() , sizeof(ploa) );
+                Gpu::htod_memcpy_async( lo_v.data()    + type, &lo         , sizeof(lo)    );
+                Gpu::htod_memcpy_async( hi_v.data()    + type, &hi         , sizeof(hi)    );
+                Gpu::htod_memcpy_async( nbins_v.data() + type, &nbins      , sizeof(nbins) );
 #else
                 std::memcpy( dxi_v.data()   + type, dxInv.data(), sizeof(dxInv) );
                 std::memcpy( plo_v.data()   + type, ploa.data() , sizeof(ploa)  );


### PR DESCRIPTION
Instead of explicit memcpy, we could let Scan::ExclusiveSum return the total sum.

Also changed memcpy to memcpy_async in a number of places.  Note the scan function has to do a stream synn internally because it has to allocate some temporary space.