### PR TITLE
NeighborParticles: memcpy -> memcpy_async

### DIFF
--- a/Src/Particle/AMReX_NeighborParticlesI.H
+++ b/Src/Particle/AMReX_NeighborParticlesI.H
@@ -929,11 +929,11 @@ buildNeighborList (CheckPair&& check_pair, int type_ind, int* ref_ratio,
                 auto ploa  = lgeom.ProbLoArray();
 
 #ifdef AMREX_USE_GPU
-                Gpu::htod_memcpy( dxi_v.data()   + type, dxInv.data(), sizeof(dxInv) );
-                Gpu::htod_memcpy( plo_v.data()   + type, ploa.data() , sizeof(ploa) );
-                Gpu::htod_memcpy( lo_v.data()    + type, &lo         , sizeof(lo)    );
-                Gpu::htod_memcpy( hi_v.data()    + type, &hi         , sizeof(hi)    );
-                Gpu::htod_memcpy( nbins_v.data() + type, &nbins      , sizeof(nbins) );
+                Gpu::htod_memcpy_async( dxi_v.data()   + type, dxInv.data(), sizeof(dxInv) );
+                Gpu::htod_memcpy_async( plo_v.data()   + type, ploa.data() , sizeof(ploa) );
+                Gpu::htod_memcpy_async( lo_v.data()    + type, &lo         , sizeof(lo)    );
+                Gpu::htod_memcpy_async( hi_v.data()    + type, &hi         , sizeof(hi)    );
+                Gpu::htod_memcpy_async( nbins_v.data() + type, &nbins      , sizeof(nbins) );
 #else
                 std::memcpy( dxi_v.data()   + type, dxInv.data(), sizeof(dxInv) );
                 std::memcpy( plo_v.data()   + type, ploa.data() , sizeof(ploa)  );


### PR DESCRIPTION
There are no reasons to use memcpy, which contains a stream sync.  Moreover, the scan function later has to do a stream sync internally because it has to allocate some temporary space.