### PR TITLE
Initialize TinyProfiler earlier only for memory

### DIFF
--- a/Src/Base/AMReX.cpp
+++ b/Src/Base/AMReX.cpp
@@ -524,7 +524,7 @@ amrex::Initialize (int& argc, char**& argv, bool build_parm_parse,
 
     ParallelDescriptor::Initialize();
 
-    BL_TINY_PROFILE_INITIALIZE();
+    BL_TINY_PROFILE_MEMORYINITIALIZE();
     Arena::Initialize();
     amrex_mempool_init();
 
@@ -599,6 +599,8 @@ amrex::Initialize (int& argc, char**& argv, bool build_parm_parse,
         amrex::Print() << "AMReX (" << amrex::Version() << ") initialized" << std::endl;
     }
 
+    BL_TINY_PROFILE_INITIALIZE();
+
     AMReX::push(new AMReX());
     return AMReX::top();
 }
@@ -628,12 +630,14 @@ amrex::Finalize (amrex::AMReX* pamrex)
     if (init_hypre) HYPRE_Finalize();
 #endif
 
+    BL_TINY_PROFILE_FINALIZE();
+    BL_PROFILE_FINALIZE();
+
 #ifdef AMREX_USE_CUDA
     amrex::DeallocateRandomSeedDevArray();
 #endif
 
-    BL_TINY_PROFILE_FINALIZE();
-    BL_PROFILE_FINALIZE();
+    BL_TINY_PROFILE_MEMORYFINALIZE();
 
 #ifdef BL_LAZY
     Lazy::Finalize();

--- a/Src/Base/AMReX.cpp
+++ b/Src/Base/AMReX.cpp
@@ -524,6 +524,7 @@ amrex::Initialize (int& argc, char**& argv, bool build_parm_parse,
 
     ParallelDescriptor::Initialize();
 
+    BL_TINY_PROFILE_INITIALIZE();
     Arena::Initialize();
     amrex_mempool_init();
 
@@ -597,8 +598,6 @@ amrex::Initialize (int& argc, char**& argv, bool build_parm_parse,
     if (system::verbose > 0) {
         amrex::Print() << "AMReX (" << amrex::Version() << ") initialized" << std::endl;
     }
-
-    BL_TINY_PROFILE_INITIALIZE();
 
     AMReX::push(new AMReX());
     return AMReX::top();

--- a/Src/Base/AMReX_BLProfiler.H
+++ b/Src/Base/AMReX_BLProfiler.H
@@ -394,6 +394,9 @@ inline std::string BLProfiler::CommStats::CFTToString(CommFuncType cft) {
 #define BL_TINY_PROFILE_INITIALIZE()
 #define BL_TINY_PROFILE_FINALIZE()
 
+#define BL_TINY_PROFILE_MEMORYINITIALIZE()
+#define BL_TINY_PROFILE_MEMORYFINALIZE()
+
 #define BL_PROFILE(fname) amrex::BLProfiler bl_profiler_((fname));
 #define BL_PROFILE_T(fname, T) amrex::BLProfiler bl_profiler_((std::string(fname) + typeid(T).name()));
 #ifdef BL_PROFILING_SPECIAL
@@ -478,6 +481,9 @@ inline std::string BLProfiler::CommStats::CFTToString(CommFuncType cft) {
 #define BL_TINY_PROFILE_INITIALIZE()   amrex::TinyProfiler::Initialize(); amrex::BLProfileSync::InitParams()
 #define BL_TINY_PROFILE_FINALIZE()     amrex::TinyProfiler::Finalize()
 
+#define BL_TINY_PROFILE_MEMORYINITIALIZE()  amrex::TinyProfiler::MemoryInitialize()
+#define BL_TINY_PROFILE_MEMORYFINALIZE()    amrex::TinyProfiler::MemoryFinalize()
+
 #define BL_PROFILE(fname) BL_PROFILE_IMPL(fname, __COUNTER__)
 #define BL_PROFILE_IMPL(funame, counter)  amrex::TinyProfiler BL_PROFILE_PASTE(tiny_profiler_, counter)((funame)); \
     amrex::ignore_unused(BL_PROFILE_PASTE(tiny_profiler_, counter));
@@ -508,7 +514,7 @@ inline std::string BLProfiler::CommStats::CFTToString(CommFuncType cft) {
 #define BL_PROFILE_REGION_VAR(fname, rvname)
 #define BL_PROFILE_REGION_VAR_START(fname, rvname)
 #define BL_PROFILE_REGION_VAR_STOP(fname, rvname)
-#define BL_PROFILE_TINY_FLUSH() amrex::TinyProfiler::Finalize(true)
+#define BL_PROFILE_TINY_FLUSH() amrex::TinyProfiler::Finalize(true); TinyProfiler::MemoryFinalize(true)
 #define BL_PROFILE_FLUSH()
 #define BL_TRACE_PROFILE_FLUSH()
 #define BL_TRACE_PROFILE_SETFLUSHSIZE(fsize)
@@ -545,6 +551,9 @@ class BLProfiler
 
 #define BL_TINY_PROFILE_INITIALIZE()
 #define BL_TINY_PROFILE_FINALIZE()
+
+#define BL_TINY_PROFILE_MEMORYINITIALIZE()
+#define BL_TINY_PROFILE_MEMORYFINALIZE()
 
 #define BL_PROFILE(a)
 #define BL_PROFILE_T(a, T)

--- a/Src/Base/AMReX_TinyProfiler.H
+++ b/Src/Base/AMReX_TinyProfiler.H
@@ -73,6 +73,9 @@ public:
     static void Initialize () noexcept;
     static void Finalize (bool bFlushing = false) noexcept;
 
+    static void MemoryInitialize () noexcept;
+    static void MemoryFinalize (bool bFlushing = false) noexcept;
+
     static void StartRegion (std::string regname) noexcept;
     static void StopRegion (const std::string& regname) noexcept;
 


### PR DESCRIPTION
## Summary

Initialize TinyProfiler earlier only for memory and finalize it later only for memory as well.

## Additional background

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
