### PR TITLE
Functional: Less -> Minimum, Greater -> Maximum

### DIFF
--- a/Src/Base/AMReX_Functional.H
+++ b/Src/Base/AMReX_Functional.H
@@ -4,6 +4,9 @@
 
 #include <AMReX_GpuQualifiers.H>
 
+// Note that since C++14, std::functional class's operator() is constexpr.
+// So we don't need to use the classes here except for Minimum and Maximum.
+
 namespace amrex {
 
 template <typename T>
@@ -25,7 +28,7 @@ struct Minus
 };
 
 template <typename T>
-struct Less
+struct Minimum
 {
     constexpr T operator() (const T & lhs, const T & rhs) const
     {
@@ -34,7 +37,7 @@ struct Less
 };
 
 template <typename T>
-struct Greater
+struct Maximum
 {
     constexpr T operator() (const T & lhs, const T & rhs) const
     {

--- a/Src/Base/AMReX_GpuAtomic.H
+++ b/Src/Base/AMReX_GpuAtomic.H
@@ -332,13 +332,13 @@ namespace detail {
     AMREX_GPU_DEVICE AMREX_FORCE_INLINE
     float Min_device (float* const m, float const value) noexcept
     {
-        return detail::atomic_op<float,int>(m,value,amrex::Less<float>());
+        return detail::atomic_op<float,int>(m,value,amrex::Minimum<float>());
     }
 
     AMREX_GPU_DEVICE AMREX_FORCE_INLINE
     double Min_device (double* const m, double const value) noexcept
     {
-        return detail::atomic_op<double, unsigned long long int>(m,value,amrex::Less<double>());
+        return detail::atomic_op<double, unsigned long long int>(m,value,amrex::Minimum<double>());
     }
 
 #if defined(AMREX_USE_CUDA) || defined(AMREX_USE_HIP)
@@ -346,7 +346,7 @@ namespace detail {
     AMREX_GPU_DEVICE AMREX_FORCE_INLINE
     Long Min_device (Long* const m, Long const value) noexcept
     {
-        return detail::atomic_op<Long, unsigned long long int>(m,value,amrex::Less<Long>());
+        return detail::atomic_op<Long, unsigned long long int>(m,value,amrex::Minimum<Long>());
     }
 
 #endif
@@ -394,13 +394,13 @@ namespace detail {
     AMREX_GPU_DEVICE AMREX_FORCE_INLINE
     float Max_device (float* const m, float const value) noexcept
     {
-        return detail::atomic_op<float,int>(m,value,amrex::Greater<float>());
+        return detail::atomic_op<float,int>(m,value,amrex::Maximum<float>());
     }
 
     AMREX_GPU_DEVICE AMREX_FORCE_INLINE
     double Max_device (double* const m, double const value) noexcept
     {
-        return detail::atomic_op<double, unsigned long long int>(m,value,amrex::Greater<double>());
+        return detail::atomic_op<double, unsigned long long int>(m,value,amrex::Maximum<double>());
     }
 
 #if defined(AMREX_USE_CUDA) || defined(AMREX_USE_HIP)
@@ -408,7 +408,7 @@ namespace detail {
     AMREX_GPU_DEVICE AMREX_FORCE_INLINE
     Long Max_device (Long* const m, Long const value) noexcept
     {
-        return detail::atomic_op<Long, unsigned long long int>(m,value,amrex::Greater<Long>());
+        return detail::atomic_op<Long, unsigned long long int>(m,value,amrex::Maximum<Long>());
     }
 
 #endif

--- a/Src/Base/AMReX_GpuReduce.H
+++ b/Src/Base/AMReX_GpuReduce.H
@@ -127,7 +127,7 @@ AMREX_GPU_DEVICE AMREX_FORCE_INLINE
 T blockReduceMin (T source, Gpu::Handler const& h) noexcept
 {
     return Gpu::blockReduce<Gpu::Device::warp_size>
-        (source, Gpu::warpReduce<Gpu::Device::warp_size,T,amrex::Less<T> >(), source, h);
+        (source, Gpu::warpReduce<Gpu::Device::warp_size,T,amrex::Minimum<T> >(), source, h);
 }
 
 template <typename T>
@@ -144,7 +144,7 @@ AMREX_GPU_DEVICE AMREX_FORCE_INLINE
 T blockReduceMax (T source, Gpu::Handler const& h) noexcept
 {
     return Gpu::blockReduce<Gpu::Device::warp_size>
-        (source, Gpu::warpReduce<Gpu::Device::warp_size,T,amrex::Greater<T> >(), source, h);
+        (source, Gpu::warpReduce<Gpu::Device::warp_size,T,amrex::Maximum<T> >(), source, h);
 }
 
 template <typename T>
@@ -206,7 +206,7 @@ void deviceReduceMin (T * dest, T source, Gpu::Handler const& h) noexcept
         deviceReduceMin_full(dest, source, h);
     } else {
         Gpu::blockReduce_partial<Gpu::Device::warp_size>
-            (dest, source, Gpu::warpReduce<Gpu::Device::warp_size,T,amrex::Less<T> >(),
+            (dest, source, Gpu::warpReduce<Gpu::Device::warp_size,T,amrex::Minimum<T> >(),
              Gpu::AtomicMin<T>(), h);
     }
 }
@@ -219,7 +219,7 @@ void deviceReduceMax (T * dest, T source, Gpu::Handler const& h) noexcept
         deviceReduceMax_full(dest, source, h);
     } else {
         Gpu::blockReduce_partial<Gpu::Device::warp_size>
-            (dest, source, Gpu::warpReduce<Gpu::Device::warp_size,T,amrex::Greater<T> >(),
+            (dest, source, Gpu::warpReduce<Gpu::Device::warp_size,T,amrex::Maximum<T> >(),
              Gpu::AtomicMax<T>(), h);
     }
 }
@@ -395,7 +395,7 @@ AMREX_GPU_DEVICE AMREX_FORCE_INLINE
 T blockReduceMin (T source) noexcept
 {
     return Gpu::blockReduce<Gpu::Device::warp_size>
-        (source, Gpu::warpReduce<Gpu::Device::warp_size,T,amrex::Less<T> >(), source);
+        (source, Gpu::warpReduce<Gpu::Device::warp_size,T,amrex::Minimum<T> >(), source);
 }
 
 template <typename T>
@@ -445,7 +445,7 @@ AMREX_GPU_DEVICE AMREX_FORCE_INLINE
 T blockReduceMax (T source) noexcept
 {
     return Gpu::blockReduce<Gpu::Device::warp_size>
-        (source, Gpu::warpReduce<Gpu::Device::warp_size,T,amrex::Greater<T> >(), source);
+        (source, Gpu::warpReduce<Gpu::Device::warp_size,T,amrex::Maximum<T> >(), source);
 }
 
 template <typename T>
@@ -622,7 +622,7 @@ void deviceReduceMin (T * dest, T source, Gpu::Handler const& handler) noexcept
         }
     } else {
         Gpu::blockReduce_partial<Gpu::Device::warp_size>
-            (dest, source, Gpu::warpReduce<Gpu::Device::warp_size,T,amrex::Less<T> >(),
+            (dest, source, Gpu::warpReduce<Gpu::Device::warp_size,T,amrex::Minimum<T> >(),
              Gpu::AtomicMin<T>(), handler);
     }
 }
@@ -641,7 +641,7 @@ void deviceReduceMax (T * dest, T source, Gpu::Handler const& handler) noexcept
         }
     } else {
         Gpu::blockReduce_partial<Gpu::Device::warp_size>
-            (dest, source, Gpu::warpReduce<Gpu::Device::warp_size,T,amrex::Greater<T> >(),
+            (dest, source, Gpu::warpReduce<Gpu::Device::warp_size,T,amrex::Maximum<T> >(),
              Gpu::AtomicMax<T>(), handler);
     }
 }

--- a/Src/Base/AMReX_ParallelReduce.H
+++ b/Src/Base/AMReX_ParallelReduce.H
@@ -128,7 +128,7 @@ namespace ParallelAllReduce {
         using T = ValLocPair<TV,TI>;
         MPI_Allreduce(&tmp, &vi, 1,
                       ParallelDescriptor::Mpi_typemap<T>::type(),
-                      (ParallelDescriptor::Mpi_op<T,amrex::Greater<T>>()), comm);
+                      (ParallelDescriptor::Mpi_op<T,amrex::Maximum<T>>()), comm);
 #else
         amrex::ignore_unused(vi, comm);
 #endif
@@ -141,7 +141,7 @@ namespace ParallelAllReduce {
         using T = ValLocPair<TV,TI>;
         MPI_Allreduce(&tmp, &vi, 1,
                       ParallelDescriptor::Mpi_typemap<T>::type(),
-                      (ParallelDescriptor::Mpi_op<T,amrex::Less<T>>()), comm);
+                      (ParallelDescriptor::Mpi_op<T,amrex::Minimum<T>>()), comm);
 #else
         amrex::ignore_unused(vi, comm);
 #endif
@@ -208,7 +208,7 @@ namespace ParallelReduce {
         using T = ValLocPair<TV,TI>;
         MPI_Reduce(&tmp, &vi, 1,
                    ParallelDescriptor::Mpi_typemap<T>::type(),
-                   (ParallelDescriptor::Mpi_op<T,amrex::Greater<T>>()),
+                   (ParallelDescriptor::Mpi_op<T,amrex::Maximum<T>>()),
                    root, comm);
 #else
         amrex::ignore_unused(vi, root, comm);
@@ -222,7 +222,7 @@ namespace ParallelReduce {
         using T = ValLocPair<TV,TI>;
         MPI_Reduce(&tmp, &vi, 1,
                    ParallelDescriptor::Mpi_typemap<T>::type(),
-                   (ParallelDescriptor::Mpi_op<T,amrex::Less<T>>()),
+                   (ParallelDescriptor::Mpi_op<T,amrex::Minimum<T>>()),
                    root, comm);
 #else
         amrex::ignore_unused(vi, root, comm);


### PR DESCRIPTION
The functional classes for returning the lesser and greater of two arguments have been misnamed, because std::less and std::greater are for comparison and they return bool.  To avoid confusion, they have been renamed.

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
