### PR TITLE
Test: Reinit AMReX

### DIFF
--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -1,7 +1,7 @@
 #
 # List of subdirectories to search for CMakeLists.
 #
-set( AMREX_TESTS_SUBDIRS AsyncOut MultiBlock Amr CLZ Parser CTOParFor)
+set( AMREX_TESTS_SUBDIRS AsyncOut MultiBlock Reinit Amr CLZ Parser CTOParFor)
 
 if (AMReX_PARTICLES)
    list(APPEND AMREX_TESTS_SUBDIRS Particles)

--- a/Tests/Reinit/CMakeLists.txt
+++ b/Tests/Reinit/CMakeLists.txt
@@ -1,0 +1,7 @@
+set(_sources     main.cpp)
+set(_input_files inputs)
+
+setup_test(_sources _input_files)
+
+unset(_sources)
+unset(_input_files)

--- a/Tests/Reinit/GNUmakefile
+++ b/Tests/Reinit/GNUmakefile
@@ -1,0 +1,18 @@
+AMREX_HOME = ../../
+
+DEBUG	= FALSE
+DIM	= 3
+COMP    = gcc
+
+USE_MPI   = TRUE
+USE_OMP   = FALSE
+USE_CUDA  = FALSE
+
+TINY_PROFILE = TRUE
+
+include $(AMREX_HOME)/Tools/GNUMake/Make.defs
+
+include ./Make.package
+include $(AMREX_HOME)/Src/Base/Make.package
+
+include $(AMREX_HOME)/Tools/GNUMake/Make.rules

--- a/Tests/Reinit/Make.package
+++ b/Tests/Reinit/Make.package
@@ -1,0 +1,1 @@
+CEXE_sources += main.cpp

--- a/Tests/Reinit/inputs
+++ b/Tests/Reinit/inputs
@@ -1,0 +1,5 @@
+amrex.abort_on_out_of_gpu_memory=1
+amrex.signal_handling=0
+amrex.the_arena_is_managed = 0
+amrex.throw_exception=1
+amrex.verbose=2

--- a/Tests/Reinit/main.cpp
+++ b/Tests/Reinit/main.cpp
@@ -1,0 +1,26 @@
+#include <AMReX.H>
+
+
+int main (int argc, char* argv[])
+{
+#ifdef AMREX_USE_MPI
+    MPI_Init(&argc, &argv);
+#endif
+    {
+        amrex::Initialize(argc,argv);
+        amrex::Finalize();
+    }
+
+    {
+        amrex::Initialize(argc,argv);
+        amrex::Finalize();
+    }
+
+    {
+        amrex::Initialize(argc,argv);
+        amrex::Finalize();
+    }
+#ifdef AMREX_USE_MPI
+    MPI_Finalize();
+#endif
+}


### PR DESCRIPTION
## Summary

Run a test that inits and finalizes AMReX multiple times.

```console
cmake -S . -B build -DAMReX_GPU_BACKEND=CUDA -DAMReX_ENABLE_TESTS=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo
cmake --build build -j 8
ctest --test-dir build --verbose -R Reinit
```
```console
build/Tests/Reinit
cuda-gdb -ex r -ex bt --args ./Test_Reinit inputs
```

## Additional background

This is often done in pytest tests, where the same process is reused for multiple tests.
Needed for pyAMReX, ImpactX, WarpX et al.

This also demonstrates a bug for GPU testing.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
