### PR TITLE
Fix bug in Device::Finalize: Forgot to clear streams

### DIFF
--- a/Src/Base/AMReX_GpuDevice.cpp
+++ b/Src/Base/AMReX_GpuDevice.cpp
@@ -385,12 +385,6 @@ Device::Finalize ()
 #ifdef AMREX_USE_GPU
     Device::profilerStop();
 
-    for (int i = 0; i < max_gpu_streams; ++i)
-    {
-        AMREX_HIP_OR_CUDA( AMREX_HIP_SAFE_CALL( hipStreamDestroy(gpu_stream_pool[i]));,
-                          AMREX_CUDA_SAFE_CALL(cudaStreamDestroy(gpu_stream_pool[i])); );
-    }
-
 #ifdef AMREX_USE_DPCPP
     sycl_context.reset();
     sycl_device.reset();
@@ -398,8 +392,15 @@ Device::Finalize ()
         delete s.queue;
         s.queue = nullptr;
     }
-    gpu_stream.clear();
+#else
+    for (int i = 0; i < max_gpu_streams; ++i)
+    {
+        AMREX_HIP_OR_CUDA( AMREX_HIP_SAFE_CALL( hipStreamDestroy(gpu_stream_pool[i]));,
+                          AMREX_CUDA_SAFE_CALL(cudaStreamDestroy(gpu_stream_pool[i])); );
+    }
 #endif
+
+    gpu_stream.clear();
 
 #ifdef AMREX_USE_ACC
     amrex_finalize_acc();


### PR DESCRIPTION
## Summary

We forgot to clear the non-owning gpu_stream vector.  They still held the old streams after we destroyed the streams in Device::Finalize.  This bug affects codes that call amrex::Initialize and amrex::Finalize repeatedly.

Note that we have the non-owning gpu stream vector for OMP CPU thread safety.

The bug was introduced in #1064.

## Additional background

#3141 

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
