### PR TITLE
SYCL: Fix the order of destruction

### DIFF
--- a/Src/Base/AMReX_GpuDevice.cpp
+++ b/Src/Base/AMReX_GpuDevice.cpp
@@ -386,12 +386,12 @@ Device::Finalize ()
     Device::profilerStop();
 
 #ifdef AMREX_USE_DPCPP
-    sycl_context.reset();
-    sycl_device.reset();
     for (auto& s : gpu_stream_pool) {
         delete s.queue;
         s.queue = nullptr;
     }
+    sycl_context.reset();
+    sycl_device.reset();
 #else
     for (int i = 0; i < max_gpu_streams; ++i)
     {


### PR DESCRIPTION
Although we have not observed any issues, we should destroy the SYCL context, device, and queues in the reverse order of their construction.