### PR TITLE
Add MPI support to GpuComplex

### DIFF
--- a/Src/Base/AMReX_ParallelDescriptor.H
+++ b/Src/Base/AMReX_ParallelDescriptor.H
@@ -10,6 +10,7 @@
 #include <AMReX_Extension.H>
 #include <AMReX_INT.H>
 #include <AMReX_REAL.H>
+#include <AMReX_GpuComplex.H>
 #include <AMReX_Array.H>
 #include <AMReX_Vector.H>
 #include <AMReX_ValLocPair.H>
@@ -664,6 +665,26 @@ while ( false )
 namespace amrex {
 
 #ifdef BL_USE_MPI
+
+namespace ParallelDescriptor
+{
+    template <class T>
+    struct Mpi_typemap<GpuComplex<T>>
+    {
+        static MPI_Datatype type ()
+        {
+            if constexpr (std::is_same<T,double>()) {
+                return MPI_C_DOUBLE_COMPLEX;
+            } else if constexpr (std::is_same<T,float>()) {
+                return MPI_C_FLOAT_COMPLEX;
+            } else {
+                amrex::Abort("Unsupported type T for GpuComplex");
+                return MPI_DATATYPE_NULL;
+            }
+        }
+    };
+}
+
 template <class T>
 ParallelDescriptor::Message
 ParallelDescriptor::Asend (const T* buf, size_t n, int dst_pid, int tag)

--- a/Src/EB/AMReX_distFcnElement.cpp
+++ b/Src/EB/AMReX_distFcnElement.cpp
@@ -75,7 +75,7 @@ amrex::Real SplineDistFcnElement2d::dist(amrex::RealVect pt,
   delta = spt - pt;
 
   amrex::Real dist;
-  dist = sqrt(delta[0]*delta[0] + delta[1]*delta[1]);
+  dist = std::sqrt(delta[0]*delta[0] + delta[1]*delta[1]);
 
   return dist;
 }
@@ -431,7 +431,7 @@ void LineDistFcnElement2d::single_seg_cpdist(amrex::RealVect pt,
   }
 
   amrex::RealVect delta = pt - cp;
-  dist = sqrt(delta[0]*delta[0] + delta[1]*delta[1] );
+  dist = std::sqrt(delta[0]*delta[0] + delta[1]*delta[1] );
 
   return;
 }


### PR DESCRIPTION
This creates a specialization of Mpi_typemap for GpuComplex<T>.

Needed by https://github.com/ECP-WarpX/WarpX/pull/3618/

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
