### PR TITLE
Fix bug in async IO for particles

### DIFF
--- a/Src/Particle/AMReX_WriteBinaryParticleData.H
+++ b/Src/Particle/AMReX_WriteBinaryParticleData.H
@@ -774,16 +774,13 @@ void WriteBinaryParticleDataAsync (PC const& pc,
                 const auto runtime_real_comps = ptile.NumRuntimeRealComps();
                 const auto runtime_int_comps = ptile.NumRuntimeIntComps();
 
-                constexpr auto NReal = NArrayReal + NStructReal;
-                constexpr auto NInt = NArrayInt + NStructInt;
-
                 new_ptile.define(runtime_real_comps, runtime_int_comps);
 
                 for (auto comp(0); comp < runtime_real_comps; ++comp)
-                  new_ptile.push_back_real(NReal+comp, np, 0.);
+                  new_ptile.push_back_real(NArrayReal+comp, np, 0.);
 
                 for (auto comp(0); comp < runtime_int_comps; ++comp)
-                  new_ptile.push_back_int(NInt+comp, np, 0);
+                  new_ptile.push_back_int(NArrayInt+comp, np, 0);
 
                 amrex::filterParticles(new_ptile, ptile, KeepValidFilter());
             }


### PR DESCRIPTION
Without this fix the following will fail:

> amrex/Tests/Particles/NeighborParticles(development)$ make -j8 TINY_PROFILE=TRUE BL_NO_FORT=TRUE USE_MPI=FALSE DEBUG=TRUE
> $ ./main3d.gnu.DEBUG.TPROF.CUDA.ex inputs amrex.async_out=1 amrex.the_arena_is_managed=0
> Initializing CUDA...
> CUDA initialized with 1 device.
> AMReX (23.02-21-g858e72dcc651) initialized
> 0::Assertion `index >= 0 && index < NReal + static_cast<int>(m_runtime_rdata.size())' failed, file "../../..//Src/Particle/AMReX_StructOfArrays.H", line 43 !!!
> SIGABRT

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
