### PR TITLE
SYCL: Fix AOT

### DIFF
--- a/Docs/sphinx_documentation/source/GPU.rst
+++ b/Docs/sphinx_documentation/source/GPU.rst
@@ -395,7 +395,7 @@ Below is an example configuration for SYCL:
    +==============================+=================================================+=============+=================+
    | AMReX_SYCL_AOT               | Enable SYCL ahead-of-time compilation           | NO          | YES, NO         |
    +------------------------------+-------------------------------------------------+-------------+-----------------+
-   | AMREX_INTEL_ARCH             | Specify target if AOT is enabled                | *           | Gen9, etc.      |
+   | AMREX_INTEL_ARCH             | Specify target if AOT is enabled                | None        | pvc, etc.       |
    +------------------------------+-------------------------------------------------+-------------+-----------------+
    | AMReX_SYCL_SPLIT_KERNEL      | Enable SYCL kernel splitting                    | YES         | YES, NO         |
    +------------------------------+-------------------------------------------------+-------------+-----------------+

--- a/Tools/CMake/AMReXOptions.cmake
+++ b/Tools/CMake/AMReXOptions.cmake
@@ -180,13 +180,17 @@ cmake_dependent_option( AMReX_SYCL_ONEDPL "Enable Intel's oneDPL algorithms"  OF
 print_option(  AMReX_SYCL_ONEDPL )
 
 if (AMReX_SYCL)
-   set(AMReX_INTEL_ARCH_DEFAULT "*")
+   set(AMReX_INTEL_ARCH_DEFAULT "IGNORE")
    if (DEFINED ENV{AMREX_INTEL_ARCH})
       set(AMReX_INTEL_ARCH_DEFAULT "$ENV{AMREX_INTEL_ARCH}")
    endif()
 
    set(AMReX_INTEL_ARCH ${AMReX_INTEL_ARCH_DEFAULT} CACHE STRING
-      "INTEL GPU architecture")
+      "INTEL GPU architecture (Must be provided if AMReX_GPU_BACKEND=SYCL and AMReX_SYCL_AOT=ON)")
+
+   if (AMReX_SYCL_AOT AND NOT AMReX_INTEL_ARCH)
+      message(FATAL_ERROR "\nMust specify AMReX_INTEL_ARCH if AMReX_GPU_BACKEND=SYCL and AMReX_SYCL_AOT=ON\n")
+   endif()
 endif ()
 
 # --- HIP ----

--- a/Tools/CMake/AMReXSYCL.cmake
+++ b/Tools/CMake/AMReXSYCL.cmake
@@ -63,6 +63,11 @@ target_link_options( SYCL
 
 
 if (AMReX_SYCL_AOT)
+   target_compile_options( SYCL
+      INTERFACE
+      "$<${_cxx_sycl}:-fsycl-targets=spir64_gen>"
+      "$<${_cxx_sycl}:SHELL:-Xsycl-target-backend \"-device ${AMReX_INTEL_ARCH}\">" )
+
    target_link_options( SYCL
       INTERFACE
       "$<${_cxx_sycl}:-fsycl-targets=spir64_gen>"

--- a/Tools/GNUMake/comps/dpcpp.mak
+++ b/Tools/GNUMake/comps/dpcpp.mak
@@ -134,7 +134,7 @@ ifeq ($(SYCL_AOT),TRUE)
     amrex_intel_gpu_target = *
     $(info Because neither INTEL_ARCH nor AMREX_INTEL_ARCH is specified, AOT will be performed for all devices.)
   endif
-  LDFLAGS += -fsycl-targets=spir64_gen -Xsycl-target-backend '-device $(amrex_intel_gpu_target)'
+  CXXFLAGS += -fsycl-targets=spir64_gen -Xsycl-target-backend '-device $(amrex_intel_gpu_target)'
 endif
 
 ifeq ($(DEBUG),TRUE)


### PR DESCRIPTION
This reverts part of #3123 because the AOT argument is a compile option. Also we must provide AMReX_INTEL_ARCH when SYCL AOT is on.