### PR TITLE
SYCL AOT: Fix warning

### DIFF
--- a/Tools/CMake/AMReXSYCL.cmake
+++ b/Tools/CMake/AMReXSYCL.cmake
@@ -65,8 +65,7 @@ target_link_options( SYCL
 if (AMReX_SYCL_AOT)
    target_compile_options( SYCL
       INTERFACE
-      "$<${_cxx_sycl}:-fsycl-targets=spir64_gen>"
-      "$<${_cxx_sycl}:SHELL:-Xsycl-target-backend \"-device ${AMReX_INTEL_ARCH}\">" )
+      "$<${_cxx_sycl}:-fsycl-targets=spir64_gen>" )
 
    target_link_options( SYCL
       INTERFACE

--- a/Tools/GNUMake/comps/dpcpp.mak
+++ b/Tools/GNUMake/comps/dpcpp.mak
@@ -134,7 +134,8 @@ ifeq ($(SYCL_AOT),TRUE)
     # amrex_intel_gpu_target = *
     $(error Either INTEL_ARCH or AMREX_INTEL_ARCH must be specified when SYCL_AOT is TRUE.)
   endif
-  CXXFLAGS += -fsycl-targets=spir64_gen -Xsycl-target-backend '-device $(amrex_intel_gpu_target)'
+  CXXFLAGS += -fsycl-targets=spir64_gen
+  LDFLAGS += -Xsycl-target-backend '-device $(amrex_intel_gpu_target)'
 endif
 
 ifeq ($(DEBUG),TRUE)


### PR DESCRIPTION
Finally set the proper flags without generating warnings about unused compiler arguments.
