### PR TITLE
amrex::Math: No longer need to use sycl math functions

### DIFF
--- a/Docs/sphinx_documentation/source/GPU.rst
+++ b/Docs/sphinx_documentation/source/GPU.rst
@@ -756,7 +756,7 @@ As another example, the following function computes the max- and 1-norm of a
                    noexcept -> GpuTuple<Real,Real>
                {
                    if (mask_ma[box_no](i,j,k)) {
-                       Real a = amrex::Math::abs(data_ma[box_no](i,j,k));
+                       Real a = std::abs(data_ma[box_no](i,j,k));
                        return { a, a };
                    } else {
                        return { 0., 0. };

--- a/Src/AmrCore/AMReX_ErrorList.cpp
+++ b/Src/AmrCore/AMReX_ErrorList.cpp
@@ -313,24 +313,24 @@ AMRErrorTag::operator() (TagBoxArray&    tba,
 
                             Real ax = 0.; Real ay = 0.;
                             if (flag(i,j,k).isConnected(1,0,0)) {
-                                ax = amrex::max(ax,amrex::Math::abs(dat(i+1,j,k) - dat(i,j,k)));
+                                ax = amrex::max(ax,std::abs(dat(i+1,j,k) - dat(i,j,k)));
                             }
                             if (flag(i,j,k).isConnected(-1,0,0)) {
-                                ax = amrex::max(ax,amrex::Math::abs(dat(i,j,k) - dat(i-1,j,k)));
+                                ax = amrex::max(ax,std::abs(dat(i,j,k) - dat(i-1,j,k)));
                             }
                             if (flag(i,j,k).isConnected(0,1,0)) {
-                                ay = amrex::max(ay,amrex::Math::abs(dat(i,j+1,k) - dat(i,j,k)));
+                                ay = amrex::max(ay,std::abs(dat(i,j+1,k) - dat(i,j,k)));
                             }
                             if (flag(i,j,k).isConnected(0,-1,0)) {
-                                ay = amrex::max(ay,amrex::Math::abs(dat(i,j,k) - dat(i,j-1,k)));
+                                ay = amrex::max(ay,std::abs(dat(i,j,k) - dat(i,j-1,k)));
                             }
 #if AMREX_SPACEDIM > 2
                             Real az = 0.;
                             if (flag(i,j,k).isConnected(0,0,1)) {
-                                az = amrex::max(az,amrex::Math::abs(dat(i,j,k+1) - dat(i,j,k)));
+                                az = amrex::max(az,std::abs(dat(i,j,k+1) - dat(i,j,k)));
                             }
                             if (flag(i,j,k).isConnected(0,0,-1)) {
-                                az = amrex::max(az,amrex::Math::abs(dat(i,j,k) - dat(i,j,k-1)));
+                                az = amrex::max(az,std::abs(dat(i,j,k) - dat(i,j,k-1)));
                             }
 #endif
                             if (amrex::max(AMREX_D_DECL(ax,ay,az)) >= threshold) {
@@ -345,18 +345,18 @@ AMRErrorTag::operator() (TagBoxArray&    tba,
                             auto const& dat = datma[bi];
 
                             Real ax = 0.;
-                            ax = amrex::Math::abs(dat(i+1,j,k) - dat(i,j,k));
-                            ax = amrex::max(ax,amrex::Math::abs(dat(i,j,k) - dat(i-1,j,k)));
+                            ax = std::abs(dat(i+1,j,k) - dat(i,j,k));
+                            ax = amrex::max(ax,std::abs(dat(i,j,k) - dat(i-1,j,k)));
 #if AMREX_SPACEDIM == 1
                             if (ax >= threshold) { tagma[bi](i,j,k) = tag_update;}
 #else
                             Real ay = 0.;
-                            ay = amrex::Math::abs(dat(i,j+1,k) - dat(i,j,k));
-                            ay = amrex::max(ay,amrex::Math::abs(dat(i,j,k) - dat(i,j-1,k)));
+                            ay = std::abs(dat(i,j+1,k) - dat(i,j,k));
+                            ay = amrex::max(ay,std::abs(dat(i,j,k) - dat(i,j-1,k)));
 #if AMREX_SPACEDIM > 2
                             Real az = 0.;
-                            az = amrex::Math::abs(dat(i,j,k+1) - dat(i,j,k));
-                            az = amrex::max(az,amrex::Math::abs(dat(i,j,k) - dat(i,j,k-1)));
+                            az = std::abs(dat(i,j,k+1) - dat(i,j,k));
+                            az = amrex::max(az,std::abs(dat(i,j,k) - dat(i,j,k-1)));
 #endif // DIM > 2
                             if (amrex::max(AMREX_D_DECL(ax,ay,az)) >= threshold) {
                                 tagma[bi](i,j,k) = tag_update;
@@ -380,28 +380,28 @@ AMRErrorTag::operator() (TagBoxArray&    tba,
                             Real ax = 0.; Real ay = 0.;
 
                             if (flag(i,j,k).isConnected(1,0,0)) {
-                                ax = amrex::max(ax,amrex::Math::abs(dat(i+1,j,k) - dat(i,j,k)));
+                                ax = amrex::max(ax,std::abs(dat(i+1,j,k) - dat(i,j,k)));
                             }
                             if (flag(i,j,k).isConnected(-1,0,0)) {
-                                ax = amrex::max(ax,amrex::Math::abs(dat(i,j,k) - dat(i-1,j,k)));
+                                ax = amrex::max(ax,std::abs(dat(i,j,k) - dat(i-1,j,k)));
                             }
                             if (flag(i,j,k).isConnected(0,1,0)) {
-                                ay = amrex::max(ay,amrex::Math::abs(dat(i,j+1,k) - dat(i,j,k)));
+                                ay = amrex::max(ay,std::abs(dat(i,j+1,k) - dat(i,j,k)));
                             }
                             if (flag(i,j,k).isConnected(0,-1,0)) {
-                                ay = amrex::max(ay,amrex::Math::abs(dat(i,j,k) - dat(i,j-1,k)));
+                                ay = amrex::max(ay,std::abs(dat(i,j,k) - dat(i,j-1,k)));
                             }
 #if AMREX_SPACEDIM > 2
                             Real az = 0.;
                             if (flag(i,j,k).isConnected(0,0,1)) {
-                                az = amrex::max(az,amrex::Math::abs(dat(i,j,k+1) - dat(i,j,k)));
+                                az = amrex::max(az,std::abs(dat(i,j,k+1) - dat(i,j,k)));
                             }
                             if (flag(i,j,k).isConnected(0,0,-1)) {
-                                az = amrex::max(az,amrex::Math::abs(dat(i,j,k) - dat(i,j,k-1)));
+                                az = amrex::max(az,std::abs(dat(i,j,k) - dat(i,j,k-1)));
                             }
 #endif // DIM > 2
                             if (amrex::max(AMREX_D_DECL(ax,ay,az))
-                                >= threshold * amrex::Math::abs(dat(i,j,k))) {
+                                >= threshold * std::abs(dat(i,j,k))) {
                                 tagma[bi](i,j,k) = tag_update;
                             }
                         });
@@ -412,19 +412,19 @@ AMRErrorTag::operator() (TagBoxArray&    tba,
                         {
                             auto const& dat = datma[bi];
 
-                            Real ax = amrex::Math::abs(dat(i+1,j,k) - dat(i,j,k));
-                            ax = amrex::max(ax,amrex::Math::abs(dat(i,j,k) - dat(i-1,j,k)));
+                            Real ax = std::abs(dat(i+1,j,k) - dat(i,j,k));
+                            ax = amrex::max(ax,std::abs(dat(i,j,k) - dat(i-1,j,k)));
 #if AMREX_SPACEDIM == 1
-                            if (ax >= threshold * amrex::Math::abs(dat(i,j,k))) { tagma[bi](i,j,k) = tag_update;}
+                            if (ax >= threshold * std::abs(dat(i,j,k))) { tagma[bi](i,j,k) = tag_update;}
 #else
-                            Real ay = amrex::Math::abs(dat(i,j+1,k) - dat(i,j,k));
-                            ay = amrex::max(ay,amrex::Math::abs(dat(i,j,k) - dat(i,j-1,k)));
+                            Real ay = std::abs(dat(i,j+1,k) - dat(i,j,k));
+                            ay = amrex::max(ay,std::abs(dat(i,j,k) - dat(i,j-1,k)));
 #if AMREX_SPACEDIM > 2
-                            Real az = amrex::Math::abs(dat(i,j,k+1) - dat(i,j,k));
-                            az = amrex::max(az,amrex::Math::abs(dat(i,j,k) - dat(i,j,k-1)));
+                            Real az = std::abs(dat(i,j,k+1) - dat(i,j,k));
+                            az = amrex::max(az,std::abs(dat(i,j,k) - dat(i,j,k-1)));
 #endif // DIM > 2
                             if (amrex::max(AMREX_D_DECL(ax,ay,az))
-                                >= threshold * amrex::Math::abs(dat(i,j,k))) {
+                                >= threshold * std::abs(dat(i,j,k))) {
                                 tagma[bi](i,j,k) = tag_update;
                             }
 #endif // DIM > 1

--- a/Src/AmrCore/AMReX_InterpFaceReg_2D_C.H
+++ b/Src/AmrCore/AMReX_InterpFaceReg_2D_C.H
@@ -22,8 +22,8 @@ void interp_face_reg (int i, int j, IntVect const& rr, Array4<Real> const& fine,
                 Real df = Real(2.0) * (crse(ic,jc+1,0,n) - crse(ic,jc  ,0,n));
                 Real db = Real(2.0) * (crse(ic,jc  ,0,n) - crse(ic,jc-1,0,n));
                 Real sy = (df*db >= Real(0.0)) ?
-                    amrex::min(amrex::Math::abs(df),amrex::Math::abs(db)) : Real(0.);
-                sy = amrex::Math::copysign(Real(1.),dc)*amrex::min(sy,amrex::Math::abs(dc));
+                    amrex::min(std::abs(df),std::abs(db)) : Real(0.);
+                sy = std::copysign(Real(1.),dc)*amrex::min(sy,std::abs(dc));
                 if (dc != Real(0.0)) {
                     sfy = amrex::min(sfy, sy / dc);
                 }
@@ -46,8 +46,8 @@ void interp_face_reg (int i, int j, IntVect const& rr, Array4<Real> const& fine,
                 Real df = Real(2.0) * (crse(ic+1,jc,0,n) - crse(ic  ,jc,0,n));
                 Real db = Real(2.0) * (crse(ic  ,jc,0,n) - crse(ic-1,jc,0,n));
                 Real sx = (df*db >= Real(0.0)) ?
-                    amrex::min(amrex::Math::abs(df),amrex::Math::abs(db)) : Real(0.);
-                sx = amrex::Math::copysign(Real(1.),dc)*amrex::min(sx,amrex::Math::abs(dc));
+                    amrex::min(std::abs(df),std::abs(db)) : Real(0.);
+                sx = std::copysign(Real(1.),dc)*amrex::min(sx,std::abs(dc));
                 if (dc != Real(0.0)) {
                     sfx = amrex::min(sfx, sx / dc);
                 }

--- a/Src/AmrCore/AMReX_InterpFaceReg_3D_C.H
+++ b/Src/AmrCore/AMReX_InterpFaceReg_3D_C.H
@@ -23,8 +23,8 @@ void interp_face_reg (int i, int j, int k, IntVect const& rr, Array4<Real> const
                 Real df = Real(2.0) * (crse(ic,jc+1,kc,n) - crse(ic,jc  ,kc,n));
                 Real db = Real(2.0) * (crse(ic,jc  ,kc,n) - crse(ic,jc-1,kc,n));
                 Real sy = (df*db >= Real(0.0)) ?
-                    amrex::min(amrex::Math::abs(df),amrex::Math::abs(db)) : Real(0.);
-                sy = amrex::Math::copysign(Real(1.),dc)*amrex::min(sy,amrex::Math::abs(dc));
+                    amrex::min(std::abs(df),std::abs(db)) : Real(0.);
+                sy = std::copysign(Real(1.),dc)*amrex::min(sy,std::abs(dc));
                 if (dc != Real(0.0)) {
                     sfy = amrex::min(sfy, sy / dc);
                 }
@@ -43,8 +43,8 @@ void interp_face_reg (int i, int j, int k, IntVect const& rr, Array4<Real> const
                 Real df = Real(2.0) * (crse(ic,jc,kc+1,n) - crse(ic,jc,kc  ,n));
                 Real db = Real(2.0) * (crse(ic,jc,kc  ,n) - crse(ic,jc,kc-1,n));
                 Real sz = (df*db >= Real(0.0)) ?
-                    amrex::min(amrex::Math::abs(df),amrex::Math::abs(db)) : Real(0.);
-                sz = amrex::Math::copysign(Real(1.),dc)*amrex::min(sz,amrex::Math::abs(dc));
+                    amrex::min(std::abs(df),std::abs(db)) : Real(0.);
+                sz = std::copysign(Real(1.),dc)*amrex::min(sz,std::abs(dc));
                 if (dc != Real(0.0)) {
                     sfz = amrex::min(sfz, sz / dc);
                 }
@@ -67,8 +67,8 @@ void interp_face_reg (int i, int j, int k, IntVect const& rr, Array4<Real> const
                 Real df = Real(2.0) * (crse(ic+1,jc,kc,n) - crse(ic  ,jc,kc,n));
                 Real db = Real(2.0) * (crse(ic  ,jc,kc,n) - crse(ic-1,jc,kc,n));
                 Real sx = (df*db >= Real(0.0)) ?
-                    amrex::min(amrex::Math::abs(df),amrex::Math::abs(db)) : Real(0.);
-                sx = amrex::Math::copysign(Real(1.),dc)*amrex::min(sx,amrex::Math::abs(dc));
+                    amrex::min(std::abs(df),std::abs(db)) : Real(0.);
+                sx = std::copysign(Real(1.),dc)*amrex::min(sx,std::abs(dc));
                 if (dc != Real(0.0)) {
                     sfx = amrex::min(sfx, sx / dc);
                 }
@@ -87,8 +87,8 @@ void interp_face_reg (int i, int j, int k, IntVect const& rr, Array4<Real> const
                 Real df = Real(2.0) * (crse(ic,jc,kc+1,n) - crse(ic,jc,kc  ,n));
                 Real db = Real(2.0) * (crse(ic,jc,kc  ,n) - crse(ic,jc,kc-1,n));
                 Real sz = (df*db >= Real(0.0)) ?
-                    amrex::min(amrex::Math::abs(df),amrex::Math::abs(db)) : Real(0.);
-                sz = amrex::Math::copysign(Real(1.),dc)*amrex::min(sz,amrex::Math::abs(dc));
+                    amrex::min(std::abs(df),std::abs(db)) : Real(0.);
+                sz = std::copysign(Real(1.),dc)*amrex::min(sz,std::abs(dc));
                 if (dc != Real(0.0)) {
                     sfz = amrex::min(sfz, sz / dc);
                 }
@@ -111,8 +111,8 @@ void interp_face_reg (int i, int j, int k, IntVect const& rr, Array4<Real> const
                 Real df = Real(2.0) * (crse(ic+1,jc,kc,n) - crse(ic  ,jc,kc,n));
                 Real db = Real(2.0) * (crse(ic  ,jc,kc,n) - crse(ic-1,jc,kc,n));
                 Real sx = (df*db >= Real(0.0)) ?
-                    amrex::min(amrex::Math::abs(df),amrex::Math::abs(db)) : Real(0.);
-                sx = amrex::Math::copysign(Real(1.),dc)*amrex::min(sx,amrex::Math::abs(dc));
+                    amrex::min(std::abs(df),std::abs(db)) : Real(0.);
+                sx = std::copysign(Real(1.),dc)*amrex::min(sx,std::abs(dc));
                 if (dc != Real(0.0)) {
                     sfx = amrex::min(sfx, sx / dc);
                 }
@@ -131,8 +131,8 @@ void interp_face_reg (int i, int j, int k, IntVect const& rr, Array4<Real> const
                 Real df = Real(2.0) * (crse(ic,jc+1,kc,n) - crse(ic,jc  ,kc,n));
                 Real db = Real(2.0) * (crse(ic,jc  ,kc,n) - crse(ic,jc-1,kc,n));
                 Real sy = (df*db >= Real(0.0)) ?
-                    amrex::min(amrex::Math::abs(df),amrex::Math::abs(db)) : Real(0.);
-                sy = amrex::Math::copysign(Real(1.),dc)*amrex::min(sy,amrex::Math::abs(dc));
+                    amrex::min(std::abs(df),std::abs(db)) : Real(0.);
+                sy = std::copysign(Real(1.),dc)*amrex::min(sy,std::abs(dc));
                 if (dc != Real(0.0)) {
                     sfy = amrex::min(sfy, sy / dc);
                 }

--- a/Src/AmrCore/AMReX_Interp_2D_C.H
+++ b/Src/AmrCore/AMReX_Interp_2D_C.H
@@ -263,7 +263,7 @@ void ccprotect_2d (int ic, int jc, int /*kc*/, int nvar,
                 }
             }
 
-            if ( (crseTot > 0) && (crseTot > Math::abs(SumN)) ) {
+            if ( (crseTot > 0) && (crseTot > std::abs(SumN)) ) {
 
                 /*
                  * Special case 1:
@@ -286,18 +286,18 @@ void ccprotect_2d (int ic, int jc, int /*kc*/, int nvar,
                         // Then, add the remaining positive proportionally.
                         if (SumP > 0.0) {
                             if (fine_state(i,j,0,n) > 0.0) {
-                                Real alpha = (crseTot - Math::abs(SumN)) / SumP;
+                                Real alpha = (crseTot - std::abs(SumN)) / SumP;
                                 fine(i,j,0,n) = alpha * fine_state(i,j,0,n);
                             }
                         } else { /* (SumP < 0) */
-                            Real posVal = (crseTot - Math::abs(SumN)) / cvol;
+                            Real posVal = (crseTot - std::abs(SumN)) / cvol;
                             fine(i,j,0,n) += posVal;
                         }
 
                     }
                 }
 
-            } else if ( (crseTot > 0) && (crseTot < Math::abs(SumN)) ) {
+            } else if ( (crseTot > 0) && (crseTot < std::abs(SumN)) ) {
 
                 /*
                  * Special case 2:
@@ -312,10 +312,10 @@ void ccprotect_2d (int ic, int jc, int /*kc*/, int nvar,
                 for     (int j = jlo; j <= jhi; ++j) {
                     for (int i = ilo; i <= ihi; ++i) {
 
-                        Real alpha = crseTot / Math::abs(SumN);
+                        Real alpha = crseTot / std::abs(SumN);
                         if (fine_state(i,j,0,n) < 0.0) {
                             // Add correction to negative cells proportionally.
-                            fine(i,j,0,n) = alpha * Math::abs(fine_state(i,j,0,n));
+                            fine(i,j,0,n) = alpha * std::abs(fine_state(i,j,0,n));
                         } else {
                             // Don't touch the positive states.
                             fine(i,j,0,n) = 0.0;
@@ -324,7 +324,7 @@ void ccprotect_2d (int ic, int jc, int /*kc*/, int nvar,
                     }
                 }
 
-            } else if ( (crseTot < 0) && (Math::abs(crseTot) > SumP) ) {
+            } else if ( (crseTot < 0) && (std::abs(crseTot) > SumP) ) {
 
                 /*
                  * Special case 3:
@@ -346,7 +346,7 @@ void ccprotect_2d (int ic, int jc, int /*kc*/, int nvar,
                     }
                 }
 
-            } else if ( (crseTot < 0) && (Math::abs(crseTot) < SumP) &&
+            } else if ( (crseTot < 0) && (std::abs(crseTot) < SumP) &&
                         ((SumP+SumN+crseTot) > 0.0) )  {
 
                 /*
@@ -372,7 +372,7 @@ void ccprotect_2d (int ic, int jc, int /*kc*/, int nvar,
                     }
                 }
 
-            } else if ( (crseTot < 0) && (Math::abs(crseTot) < SumP) &&
+            } else if ( (crseTot < 0) && (std::abs(crseTot) < SumP) &&
                         ((SumP+SumN+crseTot) < 0.0) )  {
                 /*
                  * Special case 5:

--- a/Src/AmrCore/AMReX_Interp_3D_C.H
+++ b/Src/AmrCore/AMReX_Interp_3D_C.H
@@ -405,7 +405,7 @@ void ccprotect_3d (int ic, int jc, int kc, int nvar,
                 }
             }
 
-            if ( (crseTot > 0) && (crseTot > Math::abs(SumN)) ) {
+            if ( (crseTot > 0) && (crseTot > std::abs(SumN)) ) {
 
                 /*
                  * Special case 1:
@@ -429,11 +429,11 @@ void ccprotect_3d (int ic, int jc, int kc, int nvar,
                             // Then, add the remaining positive proportionally.
                             if (SumP > 0.0) {
                                 if (fine_state(i,j,k,n) > 0.0) {
-                                    Real alpha = (crseTot - Math::abs(SumN)) / SumP;
+                                    Real alpha = (crseTot - std::abs(SumN)) / SumP;
                                     fine(i,j,k,n) = alpha * fine_state(i,j,k,n);
                                 }
                             } else { /* (SumP < 0) */
-                                Real posVal = (crseTot - Math::abs(SumN)) / (Real)numFineCells;
+                                Real posVal = (crseTot - std::abs(SumN)) / (Real)numFineCells;
                                 fine(i,j,k,n) += posVal;
                             }
 
@@ -441,7 +441,7 @@ void ccprotect_3d (int ic, int jc, int kc, int nvar,
                     }
                 }
 
-            } else if ( (crseTot > 0) && (crseTot < Math::abs(SumN)) ) {
+            } else if ( (crseTot > 0) && (crseTot < std::abs(SumN)) ) {
 
                 /*
                  * Special case 2:
@@ -456,10 +456,10 @@ void ccprotect_3d (int ic, int jc, int kc, int nvar,
                 for         (int k = klo; k <= khi; ++k) {
                     for     (int j = jlo; j <= jhi; ++j) {
                         for (int i = ilo; i <= ihi; ++i) {
-                            Real alpha = crseTot / Math::abs(SumN);
+                            Real alpha = crseTot / std::abs(SumN);
                             if (fine_state(i,j,k,n) < 0.0) {
                                 // Add correction to negative cells proportionally.
-                                fine(i,j,k,n) = alpha * Math::abs(fine_state(i,j,k,n));
+                                fine(i,j,k,n) = alpha * std::abs(fine_state(i,j,k,n));
                             } else {
                                 // Don't touch the positive states.
                                 fine(i,j,k,n) = 0.0;
@@ -469,7 +469,7 @@ void ccprotect_3d (int ic, int jc, int kc, int nvar,
                     }
                 }
 
-            } else if ( (crseTot < 0) && (Math::abs(crseTot) > SumP) ) {
+            } else if ( (crseTot < 0) && (std::abs(crseTot) > SumP) ) {
 
                 /*
                  * Special case 3:
@@ -492,7 +492,7 @@ void ccprotect_3d (int ic, int jc, int kc, int nvar,
                     }
                 }
 
-            } else if ( (crseTot < 0) && (Math::abs(crseTot) < SumP) &&
+            } else if ( (crseTot < 0) && (std::abs(crseTot) < SumP) &&
                         ((SumP+SumN+crseTot) > 0.0) )  {
 
                 /*
@@ -520,7 +520,7 @@ void ccprotect_3d (int ic, int jc, int kc, int nvar,
                     }
                 }
 
-            } else if ( (crseTot < 0) && (Math::abs(crseTot) < SumP) &&
+            } else if ( (crseTot < 0) && (std::abs(crseTot) < SumP) &&
                         ((SumP+SumN+crseTot) < 0.0) )  {
                 /*
                  * Special case 5:

--- a/Src/AmrCore/AMReX_MFInterp_1D_C.H
+++ b/Src/AmrCore/AMReX_MFInterp_1D_C.H
@@ -17,8 +17,8 @@ void mf_cell_cons_lin_interp_limit_minmax_llslope (int i, int, int, Array4<Real>
         Real dc = mf_compute_slopes_x(i, 0, 0, u, nu, domain, bc[ns]);
         Real df = Real(2.0) * (u(i+1,0,0,nu) - u(i  ,0,0,nu));
         Real db = Real(2.0) * (u(i  ,0,0,nu) - u(i-1,0,0,nu));
-        Real sx = (df*db >= Real(0.0)) ? amrex::min(amrex::Math::abs(df),amrex::Math::abs(db)) : Real(0.);
-        sx = amrex::Math::copysign(Real(1.),dc)*amrex::min(sx,amrex::Math::abs(dc));
+        Real sx = (df*db >= Real(0.0)) ? amrex::min(std::abs(df),std::abs(db)) : Real(0.);
+        sx = std::copysign(Real(1.),dc)*amrex::min(sx,std::abs(dc));
         slope(i,0,0,ns) = dc;
 
         // additional limiting is unnecessary in 1D
@@ -49,8 +49,8 @@ void mf_cell_cons_lin_interp_llslope (int i, int, int, Array4<Real> const& slope
         Real dc = mf_compute_slopes_x(i, 0, 0, u, nu, domain, bc[ns]);
         Real df = Real(2.0) * (u(i+1,0,0,nu) - u(i  ,0,0,nu));
         Real db = Real(2.0) * (u(i  ,0,0,nu) - u(i-1,0,0,nu));
-        Real sx = (df*db >= Real(0.0)) ? amrex::min(amrex::Math::abs(df),amrex::Math::abs(db)) : Real(0.);
-        sx = amrex::Math::copysign(Real(1.),dc)*amrex::min(sx,amrex::Math::abs(dc));
+        Real sx = (df*db >= Real(0.0)) ? amrex::min(std::abs(df),std::abs(db)) : Real(0.);
+        sx = std::copysign(Real(1.),dc)*amrex::min(sx,std::abs(dc));
         if (dc != Real(0.0)) {
             sfx = amrex::min(sfx, sx / dc);
         }
@@ -75,12 +75,12 @@ void mf_cell_cons_lin_interp_mcslope (int i, int /*j*/, int /*k*/, int ns,
     Real dc = mf_compute_slopes_x(i, 0, 0, u, nu, domain, bc[ns]);
     Real df = Real(2.0) * (u(i+1,0,0,nu) - u(i  ,0,0,nu));
     Real db = Real(2.0) * (u(i  ,0,0,nu) - u(i-1,0,0,nu));
-    Real sx = (df*db >= Real(0.0)) ? amrex::min(amrex::Math::abs(df),amrex::Math::abs(db)) : Real(0.);
-    sx = amrex::Math::copysign(Real(1.),dc)*amrex::min(sx,amrex::Math::abs(dc));
+    Real sx = (df*db >= Real(0.0)) ? amrex::min(std::abs(df),std::abs(db)) : Real(0.);
+    sx = std::copysign(Real(1.),dc)*amrex::min(sx,std::abs(dc));
 
     Real alpha = Real(1.0);
     if (sx != Real(0.0)) {
-        Real dumax = amrex::Math::abs(sx) * Real(ratio[0]-1)/Real(2*ratio[0]);
+        Real dumax = std::abs(sx) * Real(ratio[0]-1)/Real(2*ratio[0]);
         Real umax = u(i,0,0,nu);
         Real umin = u(i,0,0,nu);
         for (int ioff = -1; ioff <= 1; ++ioff) {
@@ -122,8 +122,8 @@ void mf_cell_cons_lin_interp_mcslope_sph (int i, int ns, Array4<Real> const& slo
     Real dc = mf_compute_slopes_x(i, 0, 0, u, nu, domain, bc[ns]);
     Real df = Real(2.0) * (u(i+1,0,0,nu) - u(i  ,0,0,nu));
     Real db = Real(2.0) * (u(i  ,0,0,nu) - u(i-1,0,0,nu));
-    Real sx = (df*db >= Real(0.0)) ? amrex::min(amrex::Math::abs(df),amrex::Math::abs(db)) : Real(0.);
-    sx = amrex::Math::copysign(Real(1.),dc)*amrex::min(sx,amrex::Math::abs(dc));
+    Real sx = (df*db >= Real(0.0)) ? amrex::min(std::abs(df),std::abs(db)) : Real(0.);
+    sx = std::copysign(Real(1.),dc)*amrex::min(sx,std::abs(dc));
 
     Real alpha = Real(1.0);
     if (sx != Real(0.0)) {

--- a/Src/AmrCore/AMReX_MFInterp_2D_C.H
+++ b/Src/AmrCore/AMReX_MFInterp_2D_C.H
@@ -20,23 +20,23 @@ void mf_cell_cons_lin_interp_limit_minmax_llslope (int i, int j, int, Array4<Rea
         Real dcx = mf_compute_slopes_x(i, j, 0, u, nu, domain, bc[ns]);
         Real df = Real(2.0) * (u(i+1,j,0,nu) - u(i  ,j,0,nu));
         Real db = Real(2.0) * (u(i  ,j,0,nu) - u(i-1,j,0,nu));
-        Real sx = (df*db >= Real(0.0)) ? amrex::min(amrex::Math::abs(df),amrex::Math::abs(db)) : Real(0.);
-        sx = amrex::Math::copysign(Real(1.),dcx)*amrex::min(sx,amrex::Math::abs(dcx));
+        Real sx = (df*db >= Real(0.0)) ? amrex::min(std::abs(df),std::abs(db)) : Real(0.);
+        sx = std::copysign(Real(1.),dcx)*amrex::min(sx,std::abs(dcx));
         slope(i,j,0,ns        ) = dcx;
 
         // y-direction
         Real dcy = mf_compute_slopes_y(i, j, 0, u, nu, domain, bc[ns]);
         df = Real(2.0) * (u(i,j+1,0,nu) - u(i,j  ,0,nu));
         db = Real(2.0) * (u(i,j  ,0,nu) - u(i,j-1,0,nu));
-        Real sy = (df*db >= Real(0.0)) ? amrex::min(amrex::Math::abs(df),amrex::Math::abs(db)) : Real(0.);
-        sy = amrex::Math::copysign(Real(1.),dcy)*amrex::min(sy,amrex::Math::abs(dcy));
+        Real sy = (df*db >= Real(0.0)) ? amrex::min(std::abs(df),std::abs(db)) : Real(0.);
+        sy = std::copysign(Real(1.),dcy)*amrex::min(sy,std::abs(dcy));
         slope(i,j,0,ns+  ncomp) = dcy;
 
         // adjust limited slopes to prevent new min/max for this component
         Real alpha = Real(1.0);
         if (sx != Real(0.0) || sy != Real(0.0)) {
-            Real dumax = amrex::Math::abs(sx) * Real(ratio[0]-1)/Real(2*ratio[0])
-                +        amrex::Math::abs(sy) * Real(ratio[1]-1)/Real(2*ratio[1]);
+            Real dumax = std::abs(sx) * Real(ratio[0]-1)/Real(2*ratio[0])
+                +        std::abs(sy) * Real(ratio[1]-1)/Real(2*ratio[1]);
             Real umax = u(i,j,0,nu);
             Real umin = u(i,j,0,nu);
             for (int joff = -1; joff <= 1; ++joff) {
@@ -85,8 +85,8 @@ void mf_cell_cons_lin_interp_llslope (int i, int j, int, Array4<Real> const& slo
         Real dc = mf_compute_slopes_x(i, j, 0, u, nu, domain, bc[ns]);
         Real df = Real(2.0) * (u(i+1,j,0,nu) - u(i  ,j,0,nu));
         Real db = Real(2.0) * (u(i  ,j,0,nu) - u(i-1,j,0,nu));
-        Real sx = (df*db >= Real(0.0)) ? amrex::min(amrex::Math::abs(df),amrex::Math::abs(db)) : Real(0.);
-        sx = amrex::Math::copysign(Real(1.),dc)*amrex::min(sx,amrex::Math::abs(dc));
+        Real sx = (df*db >= Real(0.0)) ? amrex::min(std::abs(df),std::abs(db)) : Real(0.);
+        sx = std::copysign(Real(1.),dc)*amrex::min(sx,std::abs(dc));
         if (dc != Real(0.0)) {
             sfx = amrex::min(sfx, sx / dc);
         }
@@ -96,8 +96,8 @@ void mf_cell_cons_lin_interp_llslope (int i, int j, int, Array4<Real> const& slo
         dc = mf_compute_slopes_y(i, j, 0, u, nu, domain, bc[ns]);
         df = Real(2.0) * (u(i,j+1,0,nu) - u(i,j  ,0,nu));
         db = Real(2.0) * (u(i,j  ,0,nu) - u(i,j-1,0,nu));
-        Real sy = (df*db >= Real(0.0)) ? amrex::min(amrex::Math::abs(df),amrex::Math::abs(db)) : Real(0.);
-        sy = amrex::Math::copysign(Real(1.),dc)*amrex::min(sy,amrex::Math::abs(dc));
+        Real sy = (df*db >= Real(0.0)) ? amrex::min(std::abs(df),std::abs(db)) : Real(0.);
+        sy = std::copysign(Real(1.),dc)*amrex::min(sy,std::abs(dc));
         if (dc != Real(0.0)) {
             sfy = amrex::min(sfy, sy / dc);
         }
@@ -122,20 +122,20 @@ void mf_cell_cons_lin_interp_mcslope (int i, int j, int /*k*/, int ns, Array4<Re
     Real dc = mf_compute_slopes_x(i, j, 0, u, nu, domain, bc[ns]);
     Real df = Real(2.0) * (u(i+1,j,0,nu) - u(i  ,j,0,nu));
     Real db = Real(2.0) * (u(i  ,j,0,nu) - u(i-1,j,0,nu));
-    Real sx = (df*db >= Real(0.0)) ? amrex::min(amrex::Math::abs(df),amrex::Math::abs(db)) : Real(0.);
-    sx = amrex::Math::copysign(Real(1.),dc)*amrex::min(sx,amrex::Math::abs(dc));
+    Real sx = (df*db >= Real(0.0)) ? amrex::min(std::abs(df),std::abs(db)) : Real(0.);
+    sx = std::copysign(Real(1.),dc)*amrex::min(sx,std::abs(dc));
 
     // y-direction
     dc = mf_compute_slopes_y(i, j, 0, u, nu, domain, bc[ns]);
     df = Real(2.0) * (u(i,j+1,0,nu) - u(i,j  ,0,nu));
     db = Real(2.0) * (u(i,j  ,0,nu) - u(i,j-1,0,nu));
-    Real sy = (df*db >= Real(0.0)) ? amrex::min(amrex::Math::abs(df),amrex::Math::abs(db)) : Real(0.);
-    sy = amrex::Math::copysign(Real(1.),dc)*amrex::min(sy,amrex::Math::abs(dc));
+    Real sy = (df*db >= Real(0.0)) ? amrex::min(std::abs(df),std::abs(db)) : Real(0.);
+    sy = std::copysign(Real(1.),dc)*amrex::min(sy,std::abs(dc));
 
     Real alpha = Real(1.0);
     if (sx != Real(0.0) || sy != Real(0.0)) {
-        Real dumax = amrex::Math::abs(sx) * Real(ratio[0]-1)/Real(2*ratio[0])
-            +        amrex::Math::abs(sy) * Real(ratio[1]-1)/Real(2*ratio[1]);
+        Real dumax = std::abs(sx) * Real(ratio[0]-1)/Real(2*ratio[0])
+            +        std::abs(sy) * Real(ratio[1]-1)/Real(2*ratio[1]);
         Real umax = u(i,j,0,nu);
         Real umin = u(i,j,0,nu);
         for (int joff = -1; joff <= 1; ++joff) {
@@ -181,15 +181,15 @@ void mf_cell_cons_lin_interp_mcslope_rz (int i, int j, int ns, Array4<Real> cons
     Real dc = mf_compute_slopes_x(i, j, 0, u, nu, domain, bc[ns]);
     Real df = Real(2.0) * (u(i+1,j,0,nu) - u(i  ,j,0,nu));
     Real db = Real(2.0) * (u(i  ,j,0,nu) - u(i-1,j,0,nu));
-    Real sx = (df*db >= Real(0.0)) ? amrex::min(amrex::Math::abs(df),amrex::Math::abs(db)) : Real(0.);
-    sx = amrex::Math::copysign(Real(1.),dc)*amrex::min(sx,amrex::Math::abs(dc));
+    Real sx = (df*db >= Real(0.0)) ? amrex::min(std::abs(df),std::abs(db)) : Real(0.);
+    sx = std::copysign(Real(1.),dc)*amrex::min(sx,std::abs(dc));
 
     // y-direction
     dc = mf_compute_slopes_y(i, j, 0, u, nu, domain, bc[ns]);
     df = Real(2.0) * (u(i,j+1,0,nu) - u(i,j  ,0,nu));
     db = Real(2.0) * (u(i,j  ,0,nu) - u(i,j-1,0,nu));
-    Real sy = (df*db >= Real(0.0)) ? amrex::min(amrex::Math::abs(df),amrex::Math::abs(db)) : Real(0.);
-    sy = amrex::Math::copysign(Real(1.),dc)*amrex::min(sy,amrex::Math::abs(dc));
+    Real sy = (df*db >= Real(0.0)) ? amrex::min(std::abs(df),std::abs(db)) : Real(0.);
+    sy = std::copysign(Real(1.),dc)*amrex::min(sy,std::abs(dc));
 
     Real alpha = Real(1.0);
     if (sx != Real(0.0) || sy != Real(0.0)) {
@@ -209,9 +209,9 @@ void mf_cell_cons_lin_interp_mcslope_rz (int i, int j, int ns, Array4<Real> cons
         vfp = rfp*rfp;
         Real xhi = Real(0.5) * ((vfm+vfp) - (vcm+vcp)) / (vcp - vcm);
         Real dumax =  amrex::max(sx*xlo, sx*xhi)
-            + amrex::Math::abs(sy) * Real(ratio[1]-1)/Real(2*ratio[1]);
+            + std::abs(sy) * Real(ratio[1]-1)/Real(2*ratio[1]);
         Real dumin = -amrex::min(sx*xlo, sx*xhi)
-            + amrex::Math::abs(sy) * Real(ratio[1]-1)/Real(2*ratio[1]);
+            + std::abs(sy) * Real(ratio[1]-1)/Real(2*ratio[1]);
         Real umax = u(i,j,0,nu);
         Real umin = u(i,j,0,nu);
         for (int joff = -1; joff <= 1; ++joff) {

--- a/Src/AmrCore/AMReX_MFInterp_3D_C.H
+++ b/Src/AmrCore/AMReX_MFInterp_3D_C.H
@@ -19,32 +19,32 @@ void mf_cell_cons_lin_interp_limit_minmax_llslope (int i, int j, int k, Array4<R
         Real dcx = mf_compute_slopes_x(i, j, k, u, nu, domain, bc[ns]);
         Real df = Real(2.0) * (u(i+1,j,k,nu) - u(i  ,j,k,nu));
         Real db = Real(2.0) * (u(i  ,j,k,nu) - u(i-1,j,k,nu));
-        Real sx = (df*db >= Real(0.0)) ? amrex::min(amrex::Math::abs(df),amrex::Math::abs(db)) : Real(0.);
-        sx = amrex::Math::copysign(Real(1.),dcx)*amrex::min(sx,amrex::Math::abs(dcx));
+        Real sx = (df*db >= Real(0.0)) ? amrex::min(std::abs(df),std::abs(db)) : Real(0.);
+        sx = std::copysign(Real(1.),dcx)*amrex::min(sx,std::abs(dcx));
         slope(i,j,k,ns        ) = dcx;  // unlimited slope
 
         // y-direction
         Real dcy = mf_compute_slopes_y(i, j, k, u, nu, domain, bc[ns]);
         df = Real(2.0) * (u(i,j+1,k,nu) - u(i,j  ,k,nu));
         db = Real(2.0) * (u(i,j  ,k,nu) - u(i,j-1,k,nu));
-        Real sy = (df*db >= Real(0.0)) ? amrex::min(amrex::Math::abs(df),amrex::Math::abs(db)) : Real(0.);
-        sy = amrex::Math::copysign(Real(1.),dcy)*amrex::min(sy,amrex::Math::abs(dcy));
+        Real sy = (df*db >= Real(0.0)) ? amrex::min(std::abs(df),std::abs(db)) : Real(0.);
+        sy = std::copysign(Real(1.),dcy)*amrex::min(sy,std::abs(dcy));
         slope(i,j,k,ns+  ncomp) = dcy;  // unlimited slope
 
         // z-direction
         Real dcz = mf_compute_slopes_z(i, j, k, u, nu, domain, bc[ns]);
         df = Real(2.0) * (u(i,j,k+1,nu) - u(i,j,k  ,nu));
         db = Real(2.0) * (u(i,j,k  ,nu) - u(i,j,k-1,nu));
-        Real sz = (df*db >= Real(0.0)) ? amrex::min(amrex::Math::abs(df),amrex::Math::abs(db)) : Real(0.);
-        sz = amrex::Math::copysign(Real(1.),dcz)*amrex::min(sz,amrex::Math::abs(dcz));
+        Real sz = (df*db >= Real(0.0)) ? amrex::min(std::abs(df),std::abs(db)) : Real(0.);
+        sz = std::copysign(Real(1.),dcz)*amrex::min(sz,std::abs(dcz));
         slope(i,j,k,ns+2*ncomp) = dcz;  // unlimited slope
 
         // adjust limited slopes to prevent new min/max for this component
         Real alpha = 1.0;
         if (sx != Real(0.0) || sy != Real(0.0) || sz != Real(0.0)) {
-            Real dumax = amrex::Math::abs(sx) * Real(ratio[0]-1)/Real(2*ratio[0])
-                +        amrex::Math::abs(sy) * Real(ratio[1]-1)/Real(2*ratio[1])
-                +        amrex::Math::abs(sz) * Real(ratio[2]-1)/Real(2*ratio[2]);
+            Real dumax = std::abs(sx) * Real(ratio[0]-1)/Real(2*ratio[0])
+                +        std::abs(sy) * Real(ratio[1]-1)/Real(2*ratio[1])
+                +        std::abs(sz) * Real(ratio[2]-1)/Real(2*ratio[2]);
             Real umax = u(i,j,k,nu);
             Real umin = u(i,j,k,nu);
             for (int koff = -1; koff <= 1; ++koff) {
@@ -100,8 +100,8 @@ void mf_cell_cons_lin_interp_llslope (int i, int j, int k, Array4<Real> const& s
         Real dc = mf_compute_slopes_x(i, j, k, u, nu, domain, bc[ns]);
         Real df = Real(2.0) * (u(i+1,j,k,nu) - u(i  ,j,k,nu));
         Real db = Real(2.0) * (u(i  ,j,k,nu) - u(i-1,j,k,nu));
-        Real sx = (df*db >= Real(0.0)) ? amrex::min(amrex::Math::abs(df),amrex::Math::abs(db)) : Real(0.);
-        sx = amrex::Math::copysign(Real(1.),dc)*amrex::min(sx,amrex::Math::abs(dc));
+        Real sx = (df*db >= Real(0.0)) ? amrex::min(std::abs(df),std::abs(db)) : Real(0.);
+        sx = std::copysign(Real(1.),dc)*amrex::min(sx,std::abs(dc));
         if (dc != Real(0.0)) {
             sfx = amrex::min(sfx, sx / dc);
         }
@@ -111,8 +111,8 @@ void mf_cell_cons_lin_interp_llslope (int i, int j, int k, Array4<Real> const& s
         dc = mf_compute_slopes_y(i, j, k, u, nu, domain, bc[ns]);
         df = Real(2.0) * (u(i,j+1,k,nu) - u(i,j  ,k,nu));
         db = Real(2.0) * (u(i,j  ,k,nu) - u(i,j-1,k,nu));
-        Real sy = (df*db >= Real(0.0)) ? amrex::min(amrex::Math::abs(df),amrex::Math::abs(db)) : Real(0.);
-        sy = amrex::Math::copysign(Real(1.),dc)*amrex::min(sy,amrex::Math::abs(dc));
+        Real sy = (df*db >= Real(0.0)) ? amrex::min(std::abs(df),std::abs(db)) : Real(0.);
+        sy = std::copysign(Real(1.),dc)*amrex::min(sy,std::abs(dc));
         if (dc != Real(0.0)) {
             sfy = amrex::min(sfy, sy / dc);
         }
@@ -122,8 +122,8 @@ void mf_cell_cons_lin_interp_llslope (int i, int j, int k, Array4<Real> const& s
         dc = mf_compute_slopes_z(i, j, k, u, nu, domain, bc[ns]);
         df = Real(2.0) * (u(i,j,k+1,nu) - u(i,j,k  ,nu));
         db = Real(2.0) * (u(i,j,k  ,nu) - u(i,j,k-1,nu));
-        Real sz = (df*db >= Real(0.0)) ? amrex::min(amrex::Math::abs(df),amrex::Math::abs(db)) : Real(0.);
-        sz = amrex::Math::copysign(Real(1.),dc)*amrex::min(sz,amrex::Math::abs(dc));
+        Real sz = (df*db >= Real(0.0)) ? amrex::min(std::abs(df),std::abs(db)) : Real(0.);
+        sz = std::copysign(Real(1.),dc)*amrex::min(sz,std::abs(dc));
         if (dc != Real(0.0)) {
             sfz = amrex::min(sfz, sz / dc);
         }
@@ -149,28 +149,28 @@ void mf_cell_cons_lin_interp_mcslope (int i, int j, int k, int ns, Array4<Real> 
     Real dc = mf_compute_slopes_x(i, j, k, u, nu, domain, bc[ns]);
     Real df = Real(2.0) * (u(i+1,j,k,nu) - u(i  ,j,k,nu));
     Real db = Real(2.0) * (u(i  ,j,k,nu) - u(i-1,j,k,nu));
-    Real sx = (df*db >= Real(0.0)) ? amrex::min(amrex::Math::abs(df),amrex::Math::abs(db)) : Real(0.);
-    sx = amrex::Math::copysign(Real(1.),dc)*amrex::min(sx,amrex::Math::abs(dc));
+    Real sx = (df*db >= Real(0.0)) ? amrex::min(std::abs(df),std::abs(db)) : Real(0.);
+    sx = std::copysign(Real(1.),dc)*amrex::min(sx,std::abs(dc));
 
     // y-direction
     dc = mf_compute_slopes_y(i, j, k, u, nu, domain, bc[ns]);
     df = Real(2.0) * (u(i,j+1,k,nu) - u(i,j  ,k,nu));
     db = Real(2.0) * (u(i,j  ,k,nu) - u(i,j-1,k,nu));
-    Real sy = (df*db >= Real(0.0)) ? amrex::min(amrex::Math::abs(df),amrex::Math::abs(db)) : Real(0.);
-    sy = amrex::Math::copysign(Real(1.),dc)*amrex::min(sy,amrex::Math::abs(dc));
+    Real sy = (df*db >= Real(0.0)) ? amrex::min(std::abs(df),std::abs(db)) : Real(0.);
+    sy = std::copysign(Real(1.),dc)*amrex::min(sy,std::abs(dc));
 
     // z-direction
     dc = mf_compute_slopes_z(i, j, k, u, nu, domain, bc[ns]);
     df = Real(2.0) * (u(i,j,k+1,nu) - u(i,j,k  ,nu));
     db = Real(2.0) * (u(i,j,k  ,nu) - u(i,j,k-1,nu));
-    Real sz = (df*db >= Real(0.0)) ? amrex::min(amrex::Math::abs(df),amrex::Math::abs(db)) : Real(0.);
-    sz = amrex::Math::copysign(Real(1.),dc)*amrex::min(sz,amrex::Math::abs(dc));
+    Real sz = (df*db >= Real(0.0)) ? amrex::min(std::abs(df),std::abs(db)) : Real(0.);
+    sz = std::copysign(Real(1.),dc)*amrex::min(sz,std::abs(dc));
 
     Real alpha = 1.0;
     if (sx != Real(0.0) || sy != Real(0.0) || sz != Real(0.0)) {
-        Real dumax = amrex::Math::abs(sx) * Real(ratio[0]-1)/Real(2*ratio[0])
-            +        amrex::Math::abs(sy) * Real(ratio[1]-1)/Real(2*ratio[1])
-            +        amrex::Math::abs(sz) * Real(ratio[2]-1)/Real(2*ratio[2]);
+        Real dumax = std::abs(sx) * Real(ratio[0]-1)/Real(2*ratio[0])
+            +        std::abs(sy) * Real(ratio[1]-1)/Real(2*ratio[1])
+            +        std::abs(sz) * Real(ratio[2]-1)/Real(2*ratio[2]);
         Real umax = u(i,j,k,nu);
         Real umin = u(i,j,k,nu);
         for (int koff = -1; koff <= 1; ++koff) {

--- a/Src/Base/AMReX_Algorithm.H
+++ b/Src/Base/AMReX_Algorithm.H
@@ -94,9 +94,9 @@ namespace amrex
     {
         // the machine epsilon has to be scaled to the magnitude of the values used
         // and multiplied by the desired precision in ULPs (units in the last place)
-        return amrex::Math::abs(x-y) <= std::numeric_limits<T>::epsilon() * amrex::Math::abs(x+y) * ulp
+        return std::abs(x-y) <= std::numeric_limits<T>::epsilon() * std::abs(x+y) * ulp
         // unless the result is subnormal
-        || amrex::Math::abs(x-y) < std::numeric_limits<T>::min();
+        || std::abs(x-y) < std::numeric_limits<T>::min();
     }
 
     template <class T, class F,

--- a/Src/Base/AMReX_BaseFab.H
+++ b/Src/Base/AMReX_BaseFab.H
@@ -2261,7 +2261,7 @@ BaseFab<T>::abs (const Box& subbox, int comp, int numcomp) noexcept
     Array4<T> const& a = this->array();
     AMREX_HOST_DEVICE_PARALLEL_FOR_4D_FLAG (run_on, subbox, numcomp, i, j, k, n,
     {
-        a(i,j,k,n+comp) = amrex::Math::abs(a(i,j,k,n+comp));
+        a(i,j,k,n+comp) = std::abs(a(i,j,k,n+comp));
     });
 }
 
@@ -2288,7 +2288,7 @@ BaseFab<T>::norminfmask (const Box& subbox, const BaseFab<int>& mask,
             Real t = 0.0;
             if (m(i,j,k)) {
                 for (int n = 0; n < ncomp; ++n) {
-                    t = amrex::max(t,static_cast<Real>(amrex::Math::abs(a(i,j,k,n+scomp))));
+                    t = amrex::max(t,static_cast<Real>(std::abs(a(i,j,k,n+scomp))));
                 }
             }
             return {t};
@@ -2301,7 +2301,7 @@ BaseFab<T>::norminfmask (const Box& subbox, const BaseFab<int>& mask,
         amrex::LoopOnCpu(subbox, ncomp, [=,&r] (int i, int j, int k, int n) noexcept
         {
             if (m(i,j,k)) {
-                Real t = static_cast<Real>(amrex::Math::abs(a(i,j,k,n+scomp)));
+                Real t = static_cast<Real>(std::abs(a(i,j,k,n+scomp)));
                 r = amrex::max(r,t);
             }
         });
@@ -2338,7 +2338,7 @@ BaseFab<T>::norm (const Box& subbox, int p, int comp, int numcomp) const noexcep
             {
                 Real t = 0.0;
                 for (int n = 0; n < numcomp; ++n) {
-                    t = amrex::max(t, static_cast<Real>(amrex::Math::abs(a(i,j,k,n+comp))));
+                    t = amrex::max(t, static_cast<Real>(std::abs(a(i,j,k,n+comp))));
                 }
                 return {t};
             });
@@ -2353,7 +2353,7 @@ BaseFab<T>::norm (const Box& subbox, int p, int comp, int numcomp) const noexcep
             {
                 Real t = 0.0;
                 for (int n = 0; n < numcomp; ++n) {
-                    t += static_cast<Real>(amrex::Math::abs(a(i,j,k,n+comp)));
+                    t += static_cast<Real>(std::abs(a(i,j,k,n+comp)));
                 }
                 return {t};
             });
@@ -2383,13 +2383,13 @@ BaseFab<T>::norm (const Box& subbox, int p, int comp, int numcomp) const noexcep
         if (p == 0) {
             amrex::LoopOnCpu(subbox, numcomp, [=,&nrm] (int i, int j, int k, int n) noexcept
             {
-                Real t = static_cast<Real>(amrex::Math::abs(a(i,j,k,n+comp)));
+                Real t = static_cast<Real>(std::abs(a(i,j,k,n+comp)));
                 nrm = amrex::max(nrm,t);
             });
         } else if (p == 1) {
             amrex::LoopOnCpu(subbox, numcomp, [=,&nrm] (int i, int j, int k, int n) noexcept
             {
-                nrm += amrex::Math::abs(a(i,j,k,n+comp));
+                nrm += std::abs(a(i,j,k,n+comp));
             });
         } else if (p == 2) {
             amrex::LoopOnCpu(subbox, numcomp, [=,&nrm] (int i, int j, int k, int n) noexcept
@@ -2544,7 +2544,7 @@ BaseFab<T>::maxabs (const Box& subbox, int comp) const noexcept
         reduce_op.eval(subbox, reduce_data,
         [=] AMREX_GPU_DEVICE (int i, int j, int k) -> ReduceTuple
         {
-            return { amrex::Math::abs(a(i,j,k)) };
+            return { std::abs(a(i,j,k)) };
         });
         ReduceTuple hv = reduce_data.value(reduce_op);
         return amrex::get<0>(hv);
@@ -2554,7 +2554,7 @@ BaseFab<T>::maxabs (const Box& subbox, int comp) const noexcept
         T r = 0;
         amrex::LoopOnCpu(subbox, [=,&r] (int i, int j, int k) noexcept
         {
-            r = amrex::max(r, amrex::Math::abs(a(i,j,k)));
+            r = amrex::max(r, std::abs(a(i,j,k)));
         });
         return r;
     }

--- a/Src/Base/AMReX_COORDSYS_1D_C.H
+++ b/Src/Base/AMReX_COORDSYS_1D_C.H
@@ -35,7 +35,7 @@ amrex_setvol (Box const& bx, Array4<Real> const& vol,
             Real ri = offset[0] + dx[0]*i;
             Real ro = ri + dx[0];
             Real v = pi*(ro-ri)*(ro + ri);
-            vol(i,0,0) = amrex::Math::abs(v);
+            vol(i,0,0) = std::abs(v);
         }
     }
     else
@@ -46,7 +46,7 @@ amrex_setvol (Box const& bx, Array4<Real> const& vol,
             Real ri = offset[0] + dx[0]*i;
             Real ro = ri + dx[0];
             Real v = (Real(4./3.)*pi)*(ro-ri)*(ro*ro+ro*ri+ri*ri);
-            vol(i,0,0) = amrex::Math::abs(v);
+            vol(i,0,0) = std::abs(v);
         }
     }
 }
@@ -75,7 +75,7 @@ amrex_setarea (Box const& bx, Array4<Real> const& area,
         for (int i = lo.x; i <= hi.x; ++i) {
             Real ri = offset[0] + dx[0]*i;
             Real a = (Real(2.)*pi)*ri;
-            area(i,0,0) = amrex::Math::abs(a);
+            area(i,0,0) = std::abs(a);
         }
     }
     else
@@ -85,7 +85,7 @@ amrex_setarea (Box const& bx, Array4<Real> const& area,
         for (int i = lo.x; i <= hi.x; ++i) {
             Real ri = offset[0] + dx[0]*i;
             Real a = (Real(4.0)*pi)*ri*ri;
-            area(i,0,0) = amrex::Math::abs(a);
+            area(i,0,0) = std::abs(a);
         }
     }
 }

--- a/Src/Base/AMReX_COORDSYS_2D_C.H
+++ b/Src/Base/AMReX_COORDSYS_2D_C.H
@@ -38,7 +38,7 @@ amrex_setvol (Box const& bx, Array4<Real> const& vol,
                 Real ri = offset[0] + dx[0]*(i);
                 Real ro = ri + dx[0];
                 Real v = pi*dx[1]*dx[0]*(ro + ri);
-                vol(i,j,0) = amrex::Math::abs(v);
+                vol(i,j,0) = std::abs(v);
             }
         }
     }
@@ -54,7 +54,7 @@ amrex_setvol (Box const& bx, Array4<Real> const& vol,
                 Real ri = offset[0] + dx[0]*(i);
                 Real ro = ri + dx[0];
                 Real v = tmp*(ro-ri)*(ro*ro+ro*ri+ri*ri);
-                vol(i,j,0) = amrex::Math::abs(v);
+                vol(i,j,0) = std::abs(v);
             }
         }
     }
@@ -89,7 +89,7 @@ amrex_setarea (Box const& bx, Array4<Real> const& area,
                 AMREX_PRAGMA_SIMD
                 for (int i = lo.x; i <= hi.x; ++i) {
                     Real ri = offset[0] + dx[0]*(i);
-                    Real a = amrex::Math::abs((Real(2.)*pi)*ri*dx[1]);
+                    Real a = std::abs((Real(2.)*pi)*ri*dx[1]);
                     area(i,j,0) = a;
                 }
             }
@@ -100,7 +100,7 @@ amrex_setarea (Box const& bx, Array4<Real> const& area,
                 AMREX_PRAGMA_SIMD
                 for (int i = lo.x; i <= hi.x; ++i) {
                     Real rc = offset[0] + dx[0]*(i+Real(0.5));
-                    Real a = amrex::Math::abs(dx[0]*(Real(2.)*pi)*rc);
+                    Real a = std::abs(dx[0]*(Real(2.)*pi)*rc);
                     area(i,j,0) = a;
                 }
             }

--- a/Src/Base/AMReX_FabArray.H
+++ b/Src/Base/AMReX_FabArray.H
@@ -2569,7 +2569,7 @@ FabArray<FAB>::abs (int comp, int ncomp, const IntVect& nghost)
         ParallelFor(*this, nghost, ncomp,
         [=] AMREX_GPU_DEVICE (int box_no, int i, int j, int k, int n) noexcept
         {
-            fa[box_no](i,j,k,n+comp) = amrex::Math::abs(fa[box_no](i,j,k,n+comp));
+            fa[box_no](i,j,k,n+comp) = std::abs(fa[box_no](i,j,k,n+comp));
         });
         if (!Gpu::inNoSyncRegion()) {
             Gpu::streamSynchronize();
@@ -2586,7 +2586,7 @@ FabArray<FAB>::abs (int comp, int ncomp, const IntVect& nghost)
             auto fab = this->array(mfi);
             AMREX_HOST_DEVICE_PARALLEL_FOR_4D( bx, ncomp, i, j, k, n,
             {
-                fab(i,j,k,n+comp) = amrex::Math::abs(fab(i,j,k,n+comp));
+                fab(i,j,k,n+comp) = std::abs(fab(i,j,k,n+comp));
             });
         }
     }
@@ -3486,7 +3486,7 @@ FabArray<FAB>::norminf (int comp, int ncomp, IntVect const& nghost, bool local,
                     auto tmp = RT(0.0);
                     auto const& a = ma[box_no];
                     for (int n = 0; n < ncomp; ++n) {
-                        tmp = amrex::max(tmp, amrex::Math::abs(a(i,j,k,comp+n)));
+                        tmp = amrex::max(tmp, std::abs(a(i,j,k,comp+n)));
                     }
                     return tmp;
                 }
@@ -3505,7 +3505,7 @@ FabArray<FAB>::norminf (int comp, int ncomp, IntVect const& nghost, bool local,
                     AMREX_LOOP_4D(bx, ncomp, i, j, k, n,
                     {
                         if (!flag(i,j,k).isCovered()) {
-                            nm0 = std::max(nm0, amrex::Math::abs(a(i,j,k,comp+n)));
+                            nm0 = std::max(nm0, std::abs(a(i,j,k,comp+n)));
                         }
                     });
                 }
@@ -3521,7 +3521,7 @@ FabArray<FAB>::norminf (int comp, int ncomp, IntVect const& nghost, bool local,
             nm0 = ParReduce(TypeList<ReduceOpMax>{}, TypeList<RT>{}, *this, nghost, ncomp,
             [=] AMREX_GPU_DEVICE (int box_no, int i, int j, int k, int n) noexcept -> GpuTuple<RT>
             {
-                return amrex::Math::abs(ma[box_no](i,j,k,comp+n));
+                return std::abs(ma[box_no](i,j,k,comp+n));
             });
         } else
 #endif
@@ -3534,7 +3534,7 @@ FabArray<FAB>::norminf (int comp, int ncomp, IntVect const& nghost, bool local,
                 auto const& a = this->const_array(mfi);
                 AMREX_LOOP_4D(bx, ncomp, i, j, k, n,
                 {
-                    nm0 = std::max(nm0, amrex::Math::abs(a(i,j,k,comp+n)));
+                    nm0 = std::max(nm0, std::abs(a(i,j,k,comp+n)));
                 });
             }
         }
@@ -3570,7 +3570,7 @@ FabArray<FAB>::norminf (FabArray<IFAB> const& mask, int comp, int ncomp,
                 auto tmp = RT(0.0);
                 auto const& a = ma[box_no];
                 for (int n = 0; n < ncomp; ++n) {
-                    tmp = amrex::max(tmp, amrex::Math::abs(a(i,j,k,comp+n)));
+                    tmp = amrex::max(tmp, std::abs(a(i,j,k,comp+n)));
                 }
                 return tmp;
             } else {
@@ -3590,7 +3590,7 @@ FabArray<FAB>::norminf (FabArray<IFAB> const& mask, int comp, int ncomp,
             AMREX_LOOP_4D(bx, ncomp, i, j, k, n,
             {
                 if (mskfab(i,j,k)) {
-                    nm0 = std::max(nm0, amrex::Math::abs(a(i,j,k,comp+n)));
+                    nm0 = std::max(nm0, std::abs(a(i,j,k,comp+n)));
                 }
             });
         }

--- a/Src/Base/AMReX_FabArrayUtility.H
+++ b/Src/Base/AMReX_FabArrayUtility.H
@@ -1236,7 +1236,7 @@ Abs (FabArray<FAB>& fa, int icomp, int numcomp, const IntVect& nghost)
         ParallelFor(fa, nghost, numcomp,
         [=] AMREX_GPU_DEVICE (int box_no, int i, int j, int k, int n) noexcept
         {
-            fabarr[box_no](i,j,k,n+icomp) = amrex::Math::abs(fabarr[box_no](i,j,k,n+icomp));
+            fabarr[box_no](i,j,k,n+icomp) = std::abs(fabarr[box_no](i,j,k,n+icomp));
         });
         if (!Gpu::inNoSyncRegion()) {
             Gpu::streamSynchronize();
@@ -1255,7 +1255,7 @@ Abs (FabArray<FAB>& fa, int icomp, int numcomp, const IntVect& nghost)
                 auto const& fab = fa.array(mfi);
                 AMREX_HOST_DEVICE_PARALLEL_FOR_4D( bx, numcomp, i, j, k, n,
                 {
-                    fab(i,j,k,n+icomp) = amrex::Math::abs(fab(i,j,k,n+icomp));
+                    fab(i,j,k,n+icomp) = std::abs(fab(i,j,k,n+icomp));
                 });
             }
         }

--- a/Src/Base/AMReX_Geometry.H
+++ b/Src/Base/AMReX_Geometry.H
@@ -73,7 +73,7 @@ public:
             T lo = static_cast<T>(plo + tol);
             bool safe;
             {
-                int i = int(Math::floor((lo - plo)*dxinv)) + ilo;
+                int i = int(std::floor((lo - plo)*dxinv)) + ilo;
                 safe = i >= ilo && i <= ihi;
             }
             if (safe) {
@@ -84,7 +84,7 @@ public:
                 T mid = bisect(lo, hi,
                                [=] AMREX_GPU_HOST_DEVICE (T x) -> T
                                {
-                                   int i = int(Math::floor((x - plo)*dxinv)) + ilo;
+                                   int i = int(std::floor((x - plo)*dxinv)) + ilo;
                                    bool inside = i >= ilo && i <= ihi;
                                    return static_cast<T>(inside) - T(0.5);
                                }, static_cast<T>(tol));
@@ -97,7 +97,7 @@ public:
             T hi = static_cast<T>(phi - tol);
             bool safe;
             {
-                int i = int(Math::floor((hi - plo)*dxinv)) + ilo;
+                int i = int(std::floor((hi - plo)*dxinv)) + ilo;
                 safe = i >= ilo && i <= ihi;
             }
             if (safe) {
@@ -108,7 +108,7 @@ public:
                 T mid = bisect(lo, hi,
                                [=] AMREX_GPU_HOST_DEVICE (T x) -> T
                                    {
-                                       int i = int(Math::floor((x - plo)*dxinv)) + ilo;
+                                       int i = int(std::floor((x - plo)*dxinv)) + ilo;
                                        bool inside = i >= ilo && i <= ihi;
                                        return static_cast<T>(inside) - T(0.5);
                                    }, static_cast<T>(tol));

--- a/Src/Base/AMReX_GpuComplex.H
+++ b/Src/Base/AMReX_GpuComplex.H
@@ -354,7 +354,7 @@ T abs (const GpuComplex<T>& a_z) noexcept
     T x = a_z.real();
     T y = a_z.imag();
 
-    const T s = amrex::max(amrex::Math::abs(x), amrex::Math::abs(y));
+    const T s = amrex::max(std::abs(x), std::abs(y));
     if (s == T())
         return s;
     x /= s;
@@ -374,16 +374,16 @@ GpuComplex<T> sqrt (const GpuComplex<T>& a_z) noexcept
 
     if (x == T())
     {
-        T t = std::sqrt(amrex::Math::abs(y) / 2);
+        T t = std::sqrt(std::abs(y) / 2);
         return GpuComplex<T>(t, y < T() ? -t : t);
     }
     else
     {
-        T t = std::sqrt(2 * (amrex::abs(a_z) + amrex::Math::abs(x)));
+        T t = std::sqrt(2 * (amrex::abs(a_z) + std::abs(x)));
         T u = t / 2;
         return x > T()
             ? GpuComplex<T>(u, y / t)
-            : GpuComplex<T>(amrex::Math::abs(y) / t, y < T() ? -u : u);
+            : GpuComplex<T>(std::abs(y) / t, y < T() ? -u : u);
     }
 }
 

--- a/Src/Base/AMReX_IntVect.H
+++ b/Src/Base/AMReX_IntVect.H
@@ -27,9 +27,9 @@ int coarsen (int i, int ratio) noexcept
 {
     switch (ratio) {
     case  1: return i;
-    case  2: return (i<0) ? -amrex::Math::abs(i+1)/2    -1 : i/2;
-    case  4: return (i<0) ? -amrex::Math::abs(i+1)/4    -1 : i/4;
-    default: return (i<0) ? -amrex::Math::abs(i+1)/ratio-1 : i/ratio;
+    case  2: return (i<0) ? -std::abs(i+1)/2    -1 : i/2;
+    case  4: return (i<0) ? -std::abs(i+1)/4    -1 : i/4;
+    default: return (i<0) ? -std::abs(i+1)/ratio-1 : i/ratio;
     }
 }
 
@@ -557,19 +557,19 @@ IntVect::coarsen (int s) noexcept
     case 1:
         break;
     case 2:
-        AMREX_D_TERM(vect[0] = (vect[0]<0) ? -amrex::Math::abs(vect[0]+1)/2-1 : vect[0]/2;,
-                     vect[1] = (vect[1]<0) ? -amrex::Math::abs(vect[1]+1)/2-1 : vect[1]/2;,
-                     vect[2] = (vect[2]<0) ? -amrex::Math::abs(vect[2]+1)/2-1 : vect[2]/2;);
+        AMREX_D_TERM(vect[0] = (vect[0]<0) ? -std::abs(vect[0]+1)/2-1 : vect[0]/2;,
+                     vect[1] = (vect[1]<0) ? -std::abs(vect[1]+1)/2-1 : vect[1]/2;,
+                     vect[2] = (vect[2]<0) ? -std::abs(vect[2]+1)/2-1 : vect[2]/2;);
         break;
     case 4:
-        AMREX_D_TERM(vect[0] = (vect[0]<0) ? -amrex::Math::abs(vect[0]+1)/4-1 : vect[0]/4;,
-                     vect[1] = (vect[1]<0) ? -amrex::Math::abs(vect[1]+1)/4-1 : vect[1]/4;,
-                     vect[2] = (vect[2]<0) ? -amrex::Math::abs(vect[2]+1)/4-1 : vect[2]/4;);
+        AMREX_D_TERM(vect[0] = (vect[0]<0) ? -std::abs(vect[0]+1)/4-1 : vect[0]/4;,
+                     vect[1] = (vect[1]<0) ? -std::abs(vect[1]+1)/4-1 : vect[1]/4;,
+                     vect[2] = (vect[2]<0) ? -std::abs(vect[2]+1)/4-1 : vect[2]/4;);
         break;
     default:
-        AMREX_D_TERM(vect[0] = (vect[0]<0) ? -amrex::Math::abs(vect[0]+1)/s-1 : vect[0]/s;,
-                     vect[1] = (vect[1]<0) ? -amrex::Math::abs(vect[1]+1)/s-1 : vect[1]/s;,
-                     vect[2] = (vect[2]<0) ? -amrex::Math::abs(vect[2]+1)/s-1 : vect[2]/s;);
+        AMREX_D_TERM(vect[0] = (vect[0]<0) ? -std::abs(vect[0]+1)/s-1 : vect[0]/s;,
+                     vect[1] = (vect[1]<0) ? -std::abs(vect[1]+1)/s-1 : vect[1]/s;,
+                     vect[2] = (vect[2]<0) ? -std::abs(vect[2]+1)/s-1 : vect[2]/s;);
     }
     return *this;
 }
@@ -594,10 +594,10 @@ IntVect::maxDir(bool a_doAbsValue) const noexcept
     int retval = 0;
     if(a_doAbsValue)
     {
-        int maxval = amrex::Math::abs((*this)[0]);
+        int maxval = std::abs((*this)[0]);
         for(int idir = 1; idir < SpaceDim; idir++)
         {
-            int curval = amrex::Math::abs((*this)[idir]);
+            int curval = std::abs((*this)[idir]);
             if(curval > maxval)
             {
                 maxval = curval;

--- a/Src/Base/AMReX_Math.H
+++ b/Src/Base/AMReX_Math.H
@@ -30,25 +30,9 @@ namespace amrex { inline namespace disabled {
 
 namespace amrex { namespace Math {
 
-#ifdef AMREX_USE_SYCL
-
-//List of unsupported math function can be found at
-// https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/C-CXX-StandardLibrary/C-CXX-StandardLibrary.rst
-
-//using sycl::abs;
-// We have to do this because somehow sycl::abs(int) return unsigned int.
-//template <typename T> T abs (T a) { return sycl::abs(a); } // The compiler seems to have trouble with this on DG1.
-template <typename T> T abs (T a) { return (a >= T(0)) ? a : -a; }
-
-using sycl::ceil;
-using sycl::copysign;
-using sycl::floor;
-using sycl::round;
-using sycl::isfinite;
-using sycl::isinf;
-
-#else
-
+// Since Intel's SYCL compiler now supports the following std functions on device,
+// one no longer needs to use amrex::Math::abs, etc.  They are kept here for
+// backward compatability.
 using std::abs;
 using std::ceil;
 using std::copysign;
@@ -56,8 +40,6 @@ using std::floor;
 using std::round;
 using std::isfinite;
 using std::isinf;
-
-#endif
 
 template <typename T>
 constexpr std::enable_if_t<std::is_floating_point<T>::value,T> pi ()

--- a/Src/Base/AMReX_MultiFab.cpp
+++ b/Src/Base/AMReX_MultiFab.cpp
@@ -1134,7 +1134,7 @@ MultiFab::norm1 (int comp, int ngrow, bool local) const
         nm1 = ParReduce(TypeList<ReduceOpSum>{}, TypeList<Real>{}, *this, IntVect(ngrow),
         [=] AMREX_GPU_DEVICE (int box_no, int i, int j, int k) noexcept -> GpuTuple<Real>
         {
-            return amrex::Math::abs(ma[box_no](i,j,k,comp));
+            return std::abs(ma[box_no](i,j,k,comp));
         });
     } else
 #endif
@@ -1147,7 +1147,7 @@ MultiFab::norm1 (int comp, int ngrow, bool local) const
             auto const& a = this->const_array(mfi);
             AMREX_LOOP_3D(bx, i, j, k,
             {
-                nm1 += amrex::Math::abs(a(i,j,k,comp));
+                nm1 += std::abs(a(i,j,k,comp));
             });
         }
     }

--- a/Src/Base/AMReX_MultiFabUtil_nd_C.H
+++ b/Src/Base/AMReX_MultiFabUtil_nd_C.H
@@ -24,7 +24,7 @@ void amrex_fill_slice_interp (Box const& bx, Array4<Real> slice,
     int ihi = 0, jhi = 0, khi = 0;
 
     Real weight = (coord - gd.ProbLo(dir)) / gd.CellSize(dir);
-    int dirhi = static_cast<int>(amrex::Math::floor(weight + Real(0.5)));
+    int dirhi = static_cast<int>(std::floor(weight + Real(0.5)));
     int dirlo = dirhi-1;
     weight -= dirlo+Real(0.5);
 

--- a/Src/Base/AMReX_RealVect.H
+++ b/Src/Base/AMReX_RealVect.H
@@ -703,9 +703,9 @@ inline
 IntVect
 RealVect::floor () const noexcept
 {
-  return IntVect(AMREX_D_DECL(static_cast<int>(amrex::Math::floor(vect[0])),
-                              static_cast<int>(amrex::Math::floor(vect[1])),
-                              static_cast<int>(amrex::Math::floor(vect[2]))));
+  return IntVect(AMREX_D_DECL(static_cast<int>(std::floor(vect[0])),
+                              static_cast<int>(std::floor(vect[1])),
+                              static_cast<int>(std::floor(vect[2]))));
 }
 
 AMREX_GPU_HOST_DEVICE
@@ -713,9 +713,9 @@ inline
 IntVect
 RealVect::ceil () const noexcept
 {
-  return IntVect(AMREX_D_DECL(static_cast<int>(amrex::Math::ceil(vect[0])),
-                              static_cast<int>(amrex::Math::ceil(vect[1])),
-                              static_cast<int>(amrex::Math::ceil(vect[2]))));
+  return IntVect(AMREX_D_DECL(static_cast<int>(std::ceil(vect[0])),
+                              static_cast<int>(std::ceil(vect[1])),
+                              static_cast<int>(std::ceil(vect[2]))));
 }
 
 AMREX_GPU_HOST_DEVICE
@@ -723,9 +723,9 @@ inline
 IntVect
 RealVect::round () const noexcept
 {
-  return IntVect(AMREX_D_DECL(static_cast<int>(amrex::Math::round(vect[0])),
-                              static_cast<int>(amrex::Math::round(vect[1])),
-                              static_cast<int>(amrex::Math::round(vect[2]))));
+  return IntVect(AMREX_D_DECL(static_cast<int>(std::round(vect[0])),
+                              static_cast<int>(std::round(vect[1])),
+                              static_cast<int>(std::round(vect[2]))));
 }
 
 AMREX_GPU_HOST_DEVICE
@@ -951,7 +951,7 @@ RealVect::minDir(const bool& a_doAbs) const noexcept
     {
         if (a_doAbs)
         {
-            if (amrex::Math::abs(vect[idir]) < amrex::Math::abs(vect[mDir]))
+            if (std::abs(vect[idir]) < std::abs(vect[mDir]))
             {
                 mDir = idir;
             }
@@ -976,7 +976,7 @@ RealVect::maxDir(const bool& a_doAbs) const noexcept
     {
         if (a_doAbs)
         {
-            if (amrex::Math::abs(vect[idir]) > amrex::Math::abs(vect[mDir]))
+            if (std::abs(vect[idir]) > std::abs(vect[mDir]))
             {
                 mDir = idir;
             }

--- a/Src/Base/Parser/AMReX_IParser_Y.H
+++ b/Src/Base/Parser/AMReX_IParser_Y.H
@@ -185,7 +185,7 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE int
 iparser_call_f1 (enum iparser_f1_t /*type*/, int a)
 {
     /// There is only one type for now
-    return amrex::Math::abs(a);
+    return std::abs(a);
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE int

--- a/Src/Base/Parser/AMReX_Parser_Y.H
+++ b/Src/Base/Parser/AMReX_Parser_Y.H
@@ -288,9 +288,9 @@ parser_call_f1 (enum parser_f1_t type, double a)
     case PARSER_SINH:        return parser_math_sinh<double>(a);
     case PARSER_COSH:        return parser_math_cosh<double>(a);
     case PARSER_TANH:        return parser_math_tanh<double>(a);
-    case PARSER_ABS:         return amrex::Math::abs(a);
-    case PARSER_FLOOR:       return amrex::Math::floor(a);
-    case PARSER_CEIL:        return amrex::Math::ceil(a);
+    case PARSER_ABS:         return std::abs(a);
+    case PARSER_FLOOR:       return std::floor(a);
+    case PARSER_CEIL:        return std::ceil(a);
     case PARSER_POW_M3:      return 1.0/(a*a*a);
     case PARSER_POW_M2:      return 1.0/(a*a);
     case PARSER_POW_M1:      return 1.0/a;

--- a/Src/EB/AMReX_EB2_2D_C.cpp
+++ b/Src/EB/AMReX_EB2_2D_C.cpp
@@ -33,8 +33,8 @@ void set_eb_data (const int i, const int j,
     const Real bareascaling = std::sqrt( (nx*dx[0])*(nx*dx[0]) +
             (ny*dx[1])*(ny*dx[1]) );
 
-    const Real nxabs = amrex::Math::abs(nx);
-    const Real nyabs = amrex::Math::abs(ny);
+    const Real nxabs = std::abs(nx);
+    const Real nyabs = std::abs(ny);
 
     Real x_ym, x_yp, y_xm, y_xp;
     if (nx > 0.0_rt) {

--- a/Src/EB/AMReX_EB2_3D_C.cpp
+++ b/Src/EB/AMReX_EB2_3D_C.cpp
@@ -201,8 +201,8 @@ void cut_face_2d (Real& areafrac, Real& centx, Real& centy,
     Real nx = (axm-axp) * (1.0_rt/apnorm); // pointing to the wall
     Real ny = (aym-ayp) * (1.0_rt/apnorm);
 
-    Real nxabs = amrex::Math::abs(nx);
-    Real nyabs = amrex::Math::abs(ny);
+    Real nxabs = std::abs(nx);
+    Real nyabs = std::abs(ny);
 
     if (nxabs < tiny || nyabs > 1.0_rt-tiny) {
         areafrac = 0.5_rt*(axm+axp);

--- a/Src/EB/AMReX_EB2_GeometryShop.H
+++ b/Src/EB/AMReX_EB2_GeometryShop.H
@@ -85,7 +85,7 @@ BrentRootFinder (GpuArray<Real,AMREX_SPACEDIM> const& lo,
             e = d;
         }
 
-        if (amrex::Math::abs(fc) < amrex::Math::abs(fb))
+        if (std::abs(fc) < std::abs(fb))
         {
             aPt[rangedir] = bPt[rangedir];
             bPt[rangedir] = c;
@@ -96,15 +96,15 @@ BrentRootFinder (GpuArray<Real,AMREX_SPACEDIM> const& lo,
         }
 
         //  Convergence check
-        Real tol1  = 2.0_rt * EPS * amrex::Math::abs(bPt[rangedir]) + 0.5_rt * tol;
+        Real tol1  = 2.0_rt * EPS * std::abs(bPt[rangedir]) + 0.5_rt * tol;
         Real xm    = 0.5_rt * (c - bPt[rangedir]);
 
-        if (amrex::Math::abs(xm) <= tol1 || fb == 0.0_rt)
+        if (std::abs(xm) <= tol1 || fb == 0.0_rt)
         {
             break;
         }
 
-        if (amrex::Math::abs(e) >= tol1 && amrex::Math::abs(fa) > amrex::Math::abs(fb))
+        if (std::abs(e) >= tol1 && std::abs(fa) > std::abs(fb))
         {
             //  Attempt inverse quadratic interpolation
             s = fb / fa;
@@ -124,9 +124,9 @@ BrentRootFinder (GpuArray<Real,AMREX_SPACEDIM> const& lo,
             //  Check whether in bounds
             if (p > 0) q = -q;
 
-            p = amrex::Math::abs(p);
+            p = std::abs(p);
 
-            if (2.0_rt * p < amrex::min(3.0_rt*xm*q-amrex::Math::abs(tol1*q), 1.0_rt*amrex::Math::abs(e*q)))
+            if (2.0_rt * p < amrex::min(3.0_rt*xm*q-std::abs(tol1*q), 1.0_rt*std::abs(e*q)))
             {
                 //  Accept interpolation
                 e = d;
@@ -151,7 +151,7 @@ BrentRootFinder (GpuArray<Real,AMREX_SPACEDIM> const& lo,
         fa  = fb;
 
         //  Evaluate new trial root
-        if (amrex::Math::abs(d) > tol1)
+        if (std::abs(d) > tol1)
         {
             bPt[rangedir] = bPt[rangedir] + d;
         }

--- a/Src/EB/AMReX_EBMultiFabUtil_2D_C.H
+++ b/Src/EB/AMReX_EBMultiFabUtil_2D_C.H
@@ -180,29 +180,29 @@ void eb_compute_divergence (int i, int j, int k, int n, Array4<Real> const& divu
     {
         Real fxm = u(i,j,k,n);
         if (apx(i,j,k) != 0.0_rt && apx(i,j,k) != 1.0_rt) {
-            int jj = j + static_cast<int>(amrex::Math::copysign(1.0_rt,fcx(i,j,k)));
-            Real fracy = (ccm(i-1,jj,k) || ccm(i,jj,k)) ? amrex::Math::abs(fcx(i,j,k)) : 0.0_rt;
+            int jj = j + static_cast<int>(std::copysign(1.0_rt,fcx(i,j,k)));
+            Real fracy = (ccm(i-1,jj,k) || ccm(i,jj,k)) ? std::abs(fcx(i,j,k)) : 0.0_rt;
             fxm = (1.0_rt-fracy)*fxm + fracy*u(i,jj,k,n);
         }
 
         Real fxp = u(i+1,j,k,n);
         if (apx(i+1,j,k) != 0.0_rt && apx(i+1,j,k) != 1.0_rt) {
-            int jj = j + static_cast<int>(amrex::Math::copysign(1.0_rt,fcx(i+1,j,k)));
-            Real fracy = (ccm(i,jj,k) || ccm(i+1,jj,k)) ? amrex::Math::abs(fcx(i+1,j,k)) : 0.0_rt;
+            int jj = j + static_cast<int>(std::copysign(1.0_rt,fcx(i+1,j,k)));
+            Real fracy = (ccm(i,jj,k) || ccm(i+1,jj,k)) ? std::abs(fcx(i+1,j,k)) : 0.0_rt;
             fxp = (1.0_rt-fracy)*fxp + fracy*u(i+1,jj,k,n);
         }
 
         Real fym = v(i,j,k,n);
         if (apy(i,j,k) != 0.0_rt && apy(i,j,k) != 1.0_rt) {
-            int ii = i + static_cast<int>(amrex::Math::copysign(1.0_rt,fcy(i,j,k)));
-            Real fracx = (ccm(ii,j-1,k) || ccm(ii,j,k)) ? amrex::Math::abs(fcy(i,j,k)) : 0.0_rt;
+            int ii = i + static_cast<int>(std::copysign(1.0_rt,fcy(i,j,k)));
+            Real fracx = (ccm(ii,j-1,k) || ccm(ii,j,k)) ? std::abs(fcy(i,j,k)) : 0.0_rt;
             fym = (1.0_rt-fracx)*fym + fracx*v(ii,j,k,n);
         }
 
         Real fyp = v(i,j+1,k,n);
         if (apy(i,j+1,k) != 0.0_rt && apy(i,j+1,k) != 1.0_rt) {
-            int ii = i + static_cast<int>(amrex::Math::copysign(1.0_rt,fcy(i,j+1,k)));
-            Real fracx = (ccm(ii,j,k) || ccm(ii,j+1,k)) ? amrex::Math::abs(fcy(i,j+1,k)) : 0.0_rt;
+            int ii = i + static_cast<int>(std::copysign(1.0_rt,fcy(i,j+1,k)));
+            Real fracx = (ccm(ii,j,k) || ccm(ii,j+1,k)) ? std::abs(fcy(i,j+1,k)) : 0.0_rt;
             fyp = (1.0_rt-fracx)*fyp + fracx*v(ii,j+1,k,n);
         }
 
@@ -266,8 +266,8 @@ void eb_interp_cc2cent (Box const& box,
         Real gy = cent(i,j,k,1);
         int ii = (gx < 0.0_rt) ? i - 1 : i + 1;
         int jj = (gy < 0.0_rt) ? j - 1 : j + 1;
-        gx = amrex::Math::abs(gx);
-        gy = amrex::Math::abs(gy);
+        gx = std::abs(gx);
+        gy = std::abs(gy);
         Real gxy = gx*gy;
 
         phicent(i,j,k,n) = ( 1.0_rt - gx - gy + gxy ) * phicc(i ,j ,k ,n)
@@ -319,7 +319,7 @@ void eb_interp_cc2facecent_x (Box const& ubx,
           int ii = i - 1;
           int jj = (fcx(i,j,k) < 0.0_rt) ? j - 1 : j + 1;
           Real gx = 0.5_rt;
-          Real gy = amrex::Math::abs(fcx(i,j,k));
+          Real gy = std::abs(fcx(i,j,k));
           Real gxy = gx*gy;
           edg_x(i,j,k,n) = ( 1.0_rt - gx - gy + gxy ) * phi(i ,j ,k ,n)
            +               (            gy - gxy ) * phi(i ,jj,k ,n)
@@ -369,7 +369,7 @@ void eb_interp_cc2facecent_y (Box const& vbx,
         {
           int ii = (fcy(i,j,k) < 0.0_rt) ? i - 1 : i + 1;
           int jj = j - 1;
-          Real gx = amrex::Math::abs(fcy(i,j,k));
+          Real gx = std::abs(fcy(i,j,k));
           Real gy = 0.5_rt;
           Real gxy = gx*gy;
           edg_y(i,j,k,n) = ( 1.0_rt - gx - gy + gxy ) * phi(i ,j ,k ,n)
@@ -413,7 +413,7 @@ void eb_interp_centroid2facecent_x (Box const& ubx,
       {
           edg_x(i,j,k,n) = 0.5_rt * ( phi(i,j,k,n) + phi(i-1,j,k,n) );
       }
-      else if (apx(i,j,k) == 1 && (amrex::Math::abs(ccent(i,j,k,1)-ccent(i-1,j,k,1)) < 1.e-8) )
+      else if (apx(i,j,k) == 1 && (std::abs(ccent(i,j,k,1)-ccent(i-1,j,k,1)) < 1.e-8) )
       {
           Real d0 = 0.5_rt + ccent(i  ,j,k,0);                               // distance in x-dir from centroid(i  ,j) to face(i,j)
           Real d1 = 0.5_rt - ccent(i-1,j,k,0);                               // distance in x-dir from centroid(i-1,j) to face(i,j)
@@ -425,7 +425,7 @@ void eb_interp_centroid2facecent_x (Box const& ubx,
       {
           int ii = i - 1;
           int jj;
-          if (amrex::Math::abs(fcx(i,j,k)) > 1.e-8) {
+          if (std::abs(fcx(i,j,k)) > 1.e-8) {
               jj = (fcx(i,j,k) < 0.0_rt) ? j - 1 : j + 1;
           } else {
 
@@ -492,7 +492,7 @@ void eb_interp_centroid2facecent_y (Box const& vbx,
       {
           edg_y(i,j,k,n) = 0.5_rt * (phi(i,j  ,k,n) + phi(i,j-1,k,n));
       }
-      else if (apy(i,j,k) == 1. && (amrex::Math::abs(ccent(i,j,k,0)-ccent(i,j-1,k,0)) < 1.e-8) )
+      else if (apy(i,j,k) == 1. && (std::abs(ccent(i,j,k,0)-ccent(i,j-1,k,0)) < 1.e-8) )
       {
           Real d0 = 0.5_rt + ccent(i,j  ,k,1);                                // distance in y-dir from centroid(i,j  ) to face(i,j)
           Real d1 = 0.5_rt - ccent(i,j-1,k,1);                                // distance in y-dir from centroid(i,j-1) to face(i,j)
@@ -507,7 +507,7 @@ void eb_interp_centroid2facecent_y (Box const& vbx,
 
           // We must add an additional test to avoid the case where fcy is very close to zero, but (i-1) or (i+1)
           //    might be covered cells -- this can happen when the EB is exactly aligned with the horizontal grid lines
-          if (amrex::Math::abs(fcy(i,j,k)) > 1.e-8) {
+          if (std::abs(fcy(i,j,k)) > 1.e-8) {
               ii = (fcy(i,j,k) < 0.0_rt) ? i - 1 : i + 1;
           } else {
               // We must add an additional test to avoid the case where fcx is very close to zero,

--- a/Src/EB/AMReX_EBMultiFabUtil_3D_C.H
+++ b/Src/EB/AMReX_EBMultiFabUtil_3D_C.H
@@ -254,10 +254,10 @@ void eb_compute_divergence (int i, int j, int k, int n, Array4<Real> const& divu
     {
         Real fxm = u(i,j,k,n);
         if (apx(i,j,k) != 0.0 && apx(i,j,k) != 1.0) {
-            int jj = j + static_cast<int>(amrex::Math::copysign(1.0_rt, fcx(i,j,k,0)));
-            int kk = k + static_cast<int>(amrex::Math::copysign(1.0_rt, fcx(i,j,k,1)));
-            Real fracy = (ccm(i-1,jj,k) || ccm(i,jj,k)) ? amrex::Math::abs(fcx(i,j,k,0)) : 0.0_rt;
-            Real fracz = (ccm(i-1,j,kk) || ccm(i,j,kk)) ? amrex::Math::abs(fcx(i,j,k,1)) : 0.0_rt;
+            int jj = j + static_cast<int>(std::copysign(1.0_rt, fcx(i,j,k,0)));
+            int kk = k + static_cast<int>(std::copysign(1.0_rt, fcx(i,j,k,1)));
+            Real fracy = (ccm(i-1,jj,k) || ccm(i,jj,k)) ? std::abs(fcx(i,j,k,0)) : 0.0_rt;
+            Real fracz = (ccm(i-1,j,kk) || ccm(i,j,kk)) ? std::abs(fcx(i,j,k,1)) : 0.0_rt;
             fxm = (1.0-fracy)*(1.0-fracz)*fxm
                 +      fracy *(1.0-fracz)*u(i,jj,k ,n)
                 +      fracz *(1.0-fracy)*u(i,j ,kk,n)
@@ -266,10 +266,10 @@ void eb_compute_divergence (int i, int j, int k, int n, Array4<Real> const& divu
 
         Real fxp = u(i+1,j,k,n);
         if (apx(i+1,j,k) != 0.0 && apx(i+1,j,k) != 1.0) {
-            int jj = j + static_cast<int>(amrex::Math::copysign(1.0_rt,fcx(i+1,j,k,0)));
-            int kk = k + static_cast<int>(amrex::Math::copysign(1.0_rt,fcx(i+1,j,k,1)));
-            Real fracy = (ccm(i,jj,k) || ccm(i+1,jj,k)) ? amrex::Math::abs(fcx(i+1,j,k,0)) : 0.0_rt;
-            Real fracz = (ccm(i,j,kk) || ccm(i+1,j,kk)) ? amrex::Math::abs(fcx(i+1,j,k,1)) : 0.0_rt;
+            int jj = j + static_cast<int>(std::copysign(1.0_rt,fcx(i+1,j,k,0)));
+            int kk = k + static_cast<int>(std::copysign(1.0_rt,fcx(i+1,j,k,1)));
+            Real fracy = (ccm(i,jj,k) || ccm(i+1,jj,k)) ? std::abs(fcx(i+1,j,k,0)) : 0.0_rt;
+            Real fracz = (ccm(i,j,kk) || ccm(i+1,j,kk)) ? std::abs(fcx(i+1,j,k,1)) : 0.0_rt;
             fxp = (1.0-fracy)*(1.0-fracz)*fxp
                 +      fracy *(1.0-fracz)*u(i+1,jj,k ,n)
                 +      fracz *(1.0-fracy)*u(i+1,j ,kk,n)
@@ -278,10 +278,10 @@ void eb_compute_divergence (int i, int j, int k, int n, Array4<Real> const& divu
 
         Real fym = v(i,j,k,n);
         if (apy(i,j,k) != 0.0 && apy(i,j,k) != 1.0) {
-            int ii = i + static_cast<int>(amrex::Math::copysign(1.0_rt,fcy(i,j,k,0)));
-            int kk = k + static_cast<int>(amrex::Math::copysign(1.0_rt,fcy(i,j,k,1)));
-            Real fracx = (ccm(ii,j-1,k) || ccm(ii,j,k)) ? amrex::Math::abs(fcy(i,j,k,0)) : 0.0_rt;
-            Real fracz = (ccm(i,j-1,kk) || ccm(i,j,kk)) ? amrex::Math::abs(fcy(i,j,k,1)) : 0.0_rt;
+            int ii = i + static_cast<int>(std::copysign(1.0_rt,fcy(i,j,k,0)));
+            int kk = k + static_cast<int>(std::copysign(1.0_rt,fcy(i,j,k,1)));
+            Real fracx = (ccm(ii,j-1,k) || ccm(ii,j,k)) ? std::abs(fcy(i,j,k,0)) : 0.0_rt;
+            Real fracz = (ccm(i,j-1,kk) || ccm(i,j,kk)) ? std::abs(fcy(i,j,k,1)) : 0.0_rt;
             fym = (1.0-fracx)*(1.0-fracz)*fym
                 +      fracx *(1.0-fracz)*v(ii,j,k ,n)
                 +      fracz *(1.0-fracx)*v(i ,j,kk,n)
@@ -290,10 +290,10 @@ void eb_compute_divergence (int i, int j, int k, int n, Array4<Real> const& divu
 
         Real fyp = v(i,j+1,k,n);
         if (apy(i,j+1,k) != 0.0 && apy(i,j+1,k) != 1.0) {
-            int ii = i + static_cast<int>(amrex::Math::copysign(1.0_rt,fcy(i,j+1,k,0)));
-            int kk = k + static_cast<int>(amrex::Math::copysign(1.0_rt,fcy(i,j+1,k,1)));
-            Real fracx = (ccm(ii,j,k) || ccm(ii,j+1,k)) ? amrex::Math::abs(fcy(i,j+1,k,0)) : 0.0_rt;
-            Real fracz = (ccm(i,j,kk) || ccm(i,j+1,kk)) ? amrex::Math::abs(fcy(i,j+1,k,1)) : 0.0_rt;
+            int ii = i + static_cast<int>(std::copysign(1.0_rt,fcy(i,j+1,k,0)));
+            int kk = k + static_cast<int>(std::copysign(1.0_rt,fcy(i,j+1,k,1)));
+            Real fracx = (ccm(ii,j,k) || ccm(ii,j+1,k)) ? std::abs(fcy(i,j+1,k,0)) : 0.0_rt;
+            Real fracz = (ccm(i,j,kk) || ccm(i,j+1,kk)) ? std::abs(fcy(i,j+1,k,1)) : 0.0_rt;
             fyp = (1.0-fracx)*(1.0-fracz)*fyp
                 +      fracx *(1.0-fracz)*v(ii,j+1,k ,n)
                 +      fracz *(1.0-fracx)*v(i ,j+1,kk,n)
@@ -302,10 +302,10 @@ void eb_compute_divergence (int i, int j, int k, int n, Array4<Real> const& divu
 
         Real fzm = w(i,j,k,n);
         if (apz(i,j,k) != 0.0 && apz(i,j,k) != 1.0) {
-            int ii = i + static_cast<int>(amrex::Math::copysign(1.0_rt,fcz(i,j,k,0)));
-            int jj = j + static_cast<int>(amrex::Math::copysign(1.0_rt,fcz(i,j,k,1)));
-            Real fracx = (ccm(ii,j,k-1) || ccm(ii,j,k)) ? amrex::Math::abs(fcz(i,j,k,0)) : 0.0_rt;
-            Real fracy = (ccm(i,jj,k-1) || ccm(i,jj,k)) ? amrex::Math::abs(fcz(i,j,k,1)) : 0.0_rt;
+            int ii = i + static_cast<int>(std::copysign(1.0_rt,fcz(i,j,k,0)));
+            int jj = j + static_cast<int>(std::copysign(1.0_rt,fcz(i,j,k,1)));
+            Real fracx = (ccm(ii,j,k-1) || ccm(ii,j,k)) ? std::abs(fcz(i,j,k,0)) : 0.0_rt;
+            Real fracy = (ccm(i,jj,k-1) || ccm(i,jj,k)) ? std::abs(fcz(i,j,k,1)) : 0.0_rt;
             fzm = (1.0-fracx)*(1.0-fracy)*fzm
                 +      fracx *(1.0-fracy)*w(ii,j ,k,n)
                 +      fracy *(1.0-fracx)*w(i ,jj,k,n)
@@ -314,10 +314,10 @@ void eb_compute_divergence (int i, int j, int k, int n, Array4<Real> const& divu
 
         Real fzp = w(i,j,k+1,n);
         if (apz(i,j,k+1) != 0.0 && apz(i,j,k+1) != 1.0) {
-            int ii = i + static_cast<int>(amrex::Math::copysign(1.0_rt,fcz(i,j,k+1,0)));
-            int jj = j + static_cast<int>(amrex::Math::copysign(1.0_rt,fcz(i,j,k+1,1)));
-            Real fracx = (ccm(ii,j,k) || ccm(ii,j,k+1)) ? amrex::Math::abs(fcz(i,j,k+1,0)) : 0.0_rt;
-            Real fracy = (ccm(i,jj,k) || ccm(i,jj,k+1)) ? amrex::Math::abs(fcz(i,j,k+1,1)) : 0.0_rt;
+            int ii = i + static_cast<int>(std::copysign(1.0_rt,fcz(i,j,k+1,0)));
+            int jj = j + static_cast<int>(std::copysign(1.0_rt,fcz(i,j,k+1,1)));
+            Real fracx = (ccm(ii,j,k) || ccm(ii,j,k+1)) ? std::abs(fcz(i,j,k+1,0)) : 0.0_rt;
+            Real fracy = (ccm(i,jj,k) || ccm(i,jj,k+1)) ? std::abs(fcz(i,j,k+1,1)) : 0.0_rt;
             fzp = (1.0-fracx)*(1.0-fracy)*fzp
                 +      fracx *(1.0-fracy)*w(ii,j ,k+1,n)
                 +      fracy *(1.0-fracx)*w(i ,jj,k+1,n)
@@ -397,9 +397,9 @@ void eb_interp_cc2cent (Box const& box,
         int ii = (gx < 0.0) ? i - 1 : i + 1;
         int jj = (gy < 0.0) ? j - 1 : j + 1;
         int kk = (gz < 0.0) ? k - 1 : k + 1;
-        gx = amrex::Math::abs(gx);
-        gy = amrex::Math::abs(gy);
-        gz = amrex::Math::abs(gz);
+        gx = std::abs(gx);
+        gy = std::abs(gy);
+        gz = std::abs(gz);
         Real gxy = gx*gy;
         Real gxz = gx*gz;
         Real gyz = gy*gz;
@@ -461,8 +461,8 @@ void eb_interp_cc2facecent_x (Box const& ubx,
         int ii = i - 1;
         int jj = (gy < 0.0) ? j - 1 : j + 1;
         int kk = (gz < 0.0) ? k - 1 : k + 1;
-        gy = amrex::Math::abs(gy);
-        gz = amrex::Math::abs(gz);
+        gy = std::abs(gy);
+        gz = std::abs(gz);
         Real gxy = gx*gy;
         Real gxz = gx*gz;
         Real gyz = gy*gz;
@@ -524,8 +524,8 @@ void eb_interp_cc2facecent_y (Box const& vbx,
         int ii = (gx < 0.0) ? i - 1 : i + 1;
         int jj = j - 1;
         int kk = (gz < 0.0) ? k - 1 : k + 1;
-        gx = amrex::Math::abs(gx);
-        gz = amrex::Math::abs(gz);
+        gx = std::abs(gx);
+        gz = std::abs(gz);
         Real gxy = gx*gy;
         Real gxz = gx*gz;
         Real gyz = gy*gz;
@@ -587,8 +587,8 @@ void eb_interp_cc2facecent_z (Box const& wbx,
         int ii = (gx < 0.0) ? i - 1 : i + 1;
         int jj = (gy < 0.0) ? j - 1 : j + 1;
         int kk = k -1;
-        gx = amrex::Math::abs(gx);
-        gy = amrex::Math::abs(gy);
+        gx = std::abs(gx);
+        gy = std::abs(gy);
         Real gxy = gx*gy;
         Real gxz = gx*gz;
         Real gyz = gy*gz;
@@ -641,8 +641,8 @@ void eb_interp_centroid2facecent_x (Box const& ubx,
       {
           phi_x(i,j,k,n) = 0.5 * ( phi(i,j,k,n) + phi(i-1,j,k,n) );
       }
-      else if ( apx(i,j,k) == 1 && (amrex::Math::abs(ccent(i,j,k,1)-ccent(i-1,j,k,1)) < 1.e-8) &&
-                                   (amrex::Math::abs(ccent(i,j,k,2)-ccent(i-1,j,k,2)) < 1.e-8) )
+      else if ( apx(i,j,k) == 1 && (std::abs(ccent(i,j,k,1)-ccent(i-1,j,k,1)) < 1.e-8) &&
+                                   (std::abs(ccent(i,j,k,2)-ccent(i-1,j,k,2)) < 1.e-8) )
       {
           Real d0 = 0.5 + ccent(i  ,j,k,0);                               // distance in x-dir from centroid(i  ,j) to face(i,j)
           Real d1 = 0.5 - ccent(i-1,j,k,0);                               // distance in x-dir from centroid(i-1,j) to face(i,j)
@@ -655,14 +655,14 @@ void eb_interp_centroid2facecent_x (Box const& ubx,
           // We must add additional tests to avoid the case where fcx is very close to zero, but j-1/j+1 or k-1/k+1
           //    might be covered cells -- this can happen when the EB is exactly aligned with the horizontal grid planes
           int jj,kk;
-          if (amrex::Math::abs(fcx(i,j,k,0)) > 1.e-8)
+          if (std::abs(fcx(i,j,k,0)) > 1.e-8)
               jj = (fcx(i,j,k,0) < 0.0) ? j - 1 : j + 1;
           else if (apx(i,j-1,k) > 0.)
               jj = j-1;
           else
               jj = j+1;
 
-          if (amrex::Math::abs(fcx(i,j,k,1)) > 1.e-8)
+          if (std::abs(fcx(i,j,k,1)) > 1.e-8)
               kk = (fcx(i,j,k,1) < 0.0) ? k - 1 : k + 1;
           else if (apx(i,j,k-1) > 0.)
               kk = k-1;
@@ -854,8 +854,8 @@ void eb_interp_centroid2facecent_y (Box const& vbx,
         {
             phi_y(i,j,k,n) = 0.5 * (phi(i,j  ,k,n) + phi(i,j-1,k,n));
         }
-        else if ( apy(i,j,k) == 1. && (amrex::Math::abs(ccent(i,j,k,0)-ccent(i,j-1,k,0)) < 1.e-8) &&
-                                      (amrex::Math::abs(ccent(i,j,k,2)-ccent(i,j-1,k,2)) < 1.e-8) )
+        else if ( apy(i,j,k) == 1. && (std::abs(ccent(i,j,k,0)-ccent(i,j-1,k,0)) < 1.e-8) &&
+                                      (std::abs(ccent(i,j,k,2)-ccent(i,j-1,k,2)) < 1.e-8) )
         {
             Real d0 = 0.5 + ccent(i,j  ,k,1);                                // distance in y-dir from centroid(i,j  ,k) to face(i,j,k)
             Real d1 = 0.5 - ccent(i,j-1,k,1);                                // distance in y-dir from centroid(i,j-1,k) to face(i,j,k)
@@ -869,14 +869,14 @@ void eb_interp_centroid2facecent_y (Box const& vbx,
           // We must add additional tests to avoid the case where fcy is very close to zero, but i-1/i+1 or k-1/k+1
           //    might be covered cells -- this can happen when the EB is exactly aligned with the grid planes
           int ii,kk;
-          if (amrex::Math::abs(fcy(i,j,k,0)) > 1.e-8)
+          if (std::abs(fcy(i,j,k,0)) > 1.e-8)
               ii = (fcy(i,j,k,0) < 0.0) ? i - 1 : i + 1;
           else if (apy(i-1,j,k) > 0.)
               ii = i-1;
           else
               ii = i+1;
 
-          if (amrex::Math::abs(fcy(i,j,k,1)) > 1.e-8)
+          if (std::abs(fcy(i,j,k,1)) > 1.e-8)
               kk = (fcy(i,j,k,1) < 0.0) ? k - 1 : k + 1;
           else if (apy(i,j,k-1) > 0.)
               kk = k-1;
@@ -1065,8 +1065,8 @@ void eb_interp_centroid2facecent_z (Box const& wbx,
         {
             phi_z(i,j,k,n) = 0.5 * (phi(i,j,k,n) + phi(i,j,k-1,n));
         }
-        else if ( apz(i,j,k) == 1. && (amrex::Math::abs(ccent(i,j,k,0)-ccent(i,j,k-1,0)) < 1.e-8) &&
-                                      (amrex::Math::abs(ccent(i,j,k,1)-ccent(i,j,k-1,1)) < 1.e-8) )
+        else if ( apz(i,j,k) == 1. && (std::abs(ccent(i,j,k,0)-ccent(i,j,k-1,0)) < 1.e-8) &&
+                                      (std::abs(ccent(i,j,k,1)-ccent(i,j,k-1,1)) < 1.e-8) )
         {
             Real d0 = 0.5 + ccent(i,j,k  ,2);                                // distance in z-dir from centroid(i,j,k  ) to face(i,j,k)
             Real d1 = 0.5 - ccent(i,j,k-1,2);                                // distance in z-dir from centroid(i,j,k-1) to face(i,j,k)
@@ -1079,14 +1079,14 @@ void eb_interp_centroid2facecent_z (Box const& wbx,
           // We must add additional tests to avoid the case where fcz is very close to zero, but i-1/i+1 or j-1/j+1
           //    might be covered cells -- this can happen when the EB is exactly aligned with the grid planes
           int ii,jj;
-          if (amrex::Math::abs(fcz(i,j,k,0)) > 1.e-8)
+          if (std::abs(fcz(i,j,k,0)) > 1.e-8)
               ii = (fcz(i,j,k,0) < 0.0) ? i - 1 : i + 1;
           else if (apz(i-1,j,k) > 0.)
               ii = i-1;
           else
               ii = i+1;
 
-          if (amrex::Math::abs(fcz(i,j,k,1)) > 1.e-8)
+          if (std::abs(fcz(i,j,k,1)) > 1.e-8)
               jj = (fcz(i,j,k,1) < 0.0) ? j - 1 : j + 1;
           else if (apz(i,j-1,k) > 0.)
               jj = j-1;

--- a/Src/EB/AMReX_EBToPVD.cpp
+++ b/Src/EB/AMReX_EBToPVD.cpp
@@ -245,12 +245,12 @@ void EBToPVD::reorder_polygon(const std::vector<std::array<Real,3>>& lpoints,
    center.fill(0.0);
 
    int longest = 2;
-   if(Math::abs(lnormal[0]) > Math::abs(lnormal[1])) {
-      if(Math::abs(lnormal[0]) > Math::abs(lnormal[2]))
+   if(std::abs(lnormal[0]) > std::abs(lnormal[1])) {
+      if(std::abs(lnormal[0]) > std::abs(lnormal[2]))
          longest = 0;
    }
    else {
-      if(Math::abs(lnormal[1]) > Math::abs(lnormal[2]))
+      if(std::abs(lnormal[1]) > std::abs(lnormal[2]))
          longest = 1;
    }
 
@@ -324,7 +324,7 @@ void EBToPVD::calc_hesse(Real& distance, std::array<Real,3>& n0, Real& p,
    distance = -dot_product(normal, centroid);
 
    // Get the sign of the distance
-   sign_of_dist = -distance / Math::abs(distance);
+   sign_of_dist = -distance / std::abs(distance);
 
    // Get the Hessian form
    Real fac = sign_of_dist/dot_product(normal, normal);
@@ -343,7 +343,7 @@ void EBToPVD::calc_alpha(std::array<Real,12>& alpha,
    std::fill(alpha.begin(), alpha.end(), 10.0);
 
    // Ray-xAxis intersection
-   if(Math::abs(n0[0]) > std::numeric_limits<Real>::epsilon()) {
+   if(std::abs(n0[0]) > std::numeric_limits<Real>::epsilon()) {
       alpha[0]  = (p - dot_product(n0,vertex[0]))/(n0[0]*dx[0]);
       alpha[2]  = (p - dot_product(n0,vertex[2]))/(n0[0]*dx[0]);
       alpha[8]  = (p - dot_product(n0,vertex[4]))/(n0[0]*dx[0]);
@@ -351,7 +351,7 @@ void EBToPVD::calc_alpha(std::array<Real,12>& alpha,
    }
 
    // Ray-yAxis intersection
-   if(Math::abs(n0[1]) > std::numeric_limits<Real>::epsilon()) {
+   if(std::abs(n0[1]) > std::numeric_limits<Real>::epsilon()) {
       alpha[1]  = (p - dot_product(n0,vertex[1]))/(n0[1]*dx[1]);
       alpha[3]  = (p - dot_product(n0,vertex[0]))/(n0[1]*dx[1]);
       alpha[9]  = (p - dot_product(n0,vertex[5]))/(n0[1]*dx[1]);
@@ -359,7 +359,7 @@ void EBToPVD::calc_alpha(std::array<Real,12>& alpha,
    }
 
    // Ray-zAxis intersection
-   if(Math::abs(n0[2]) > std::numeric_limits<Real>::epsilon()) {
+   if(std::abs(n0[2]) > std::numeric_limits<Real>::epsilon()) {
       alpha[4] = (p - dot_product(n0,vertex[0]))/(n0[2]*dx[2]);
       alpha[5] = (p - dot_product(n0,vertex[1]))/(n0[2]*dx[2]);
       alpha[6] = (p - dot_product(n0,vertex[3]))/(n0[2]*dx[2]);

--- a/Src/EB/AMReX_EB_STL_utils.cpp
+++ b/Src/EB/AMReX_EB_STL_utils.cpp
@@ -36,10 +36,10 @@ namespace {
     Real sign (Real x1, Real y1, Real x2, Real y2, Real x3, Real y3)
     {
         Real cp = (x2-x1)*(y3-y2) - (x3-x2)*(y2-y1);
-        if (amrex::Math::abs(cp) < std::numeric_limits<Real>::epsilon()) {
+        if (std::abs(cp) < std::numeric_limits<Real>::epsilon()) {
             return 0._rt;
         } else {
-            return amrex::Math::copysign(1.0_rt, cp);
+            return std::copysign(1.0_rt, cp);
         }
     }
 
@@ -78,9 +78,9 @@ namespace {
             Real s2 = sign(v2.y, v2.z, v3.y, v3.z, y, z);
             Real s3 = sign(v3.y, v3.z, v1.y, v1.z, y, z);
             if (s1 == 0._rt || s2 == 0._rt || s3 == 0._rt || (s1 == s2 && s2 == s3)) {
-                if (amrex::Math::abs(x1-x) < std::numeric_limits<Real>::epsilon()) {
+                if (std::abs(x1-x) < std::numeric_limits<Real>::epsilon()) {
                     return std::make_pair(true,x1);
-                } else if (amrex::Math::abs(x2-x) < std::numeric_limits<Real>::epsilon()) {
+                } else if (std::abs(x2-x) < std::numeric_limits<Real>::epsilon()) {
                     return std::make_pair(true,x2);
                 } else if (x>x1 && x<x2) {
                     return std::make_pair(true,x);

--- a/Src/EB/AMReX_EB_chkpt_file.cpp
+++ b/Src/EB/AMReX_EB_chkpt_file.cpp
@@ -149,9 +149,9 @@ ChkptFile::read_from_chkpt_file (BoxArray& cut_grids, BoxArray& covered_grids,
     }
 
     for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(Math::abs(prob_lo[idim] - geom.ProbLo()[idim]) < std::numeric_limits<Real>::epsilon(),
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(std::abs(prob_lo[idim] - geom.ProbLo()[idim]) < std::numeric_limits<Real>::epsilon(),
                                          "EB2::ChkptFile cannot read from a different problem domain");
-        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(Math::abs(prob_hi[idim] - geom.ProbHi()[idim]) < std::numeric_limits<Real>::epsilon(),
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(std::abs(prob_hi[idim] - geom.ProbHi()[idim]) < std::numeric_limits<Real>::epsilon(),
                                          "EB2::ChkptFile cannot read from a different problem domain");
     }
 

--- a/Src/EB/AMReX_EB_triGeomOps_K.H
+++ b/Src/EB/AMReX_EB_triGeomOps_K.H
@@ -163,7 +163,7 @@ namespace amrex
 
                 //Print()<<"midp:"<<midp[0]<<"\t"<<midp[1]<<"\t"<<midp[2]<<"\t"<<plane_eq_mid<<"\n";
 
-                if(Math::abs(plane_eq_mid) < tol)
+                if(std::abs(plane_eq_mid) < tol)
                 {
                     break;
                 }
@@ -217,7 +217,7 @@ namespace amrex
             Real eps = std::numeric_limits<Real>::epsilon();
 
             //coplanar (S1,S2,S3 = 0)
-            if(Math::abs(S1) < eps && Math::abs(S2) < eps && Math::abs(S3) < eps)
+            if(std::abs(S1) < eps && std::abs(S2) < eps && std::abs(S3) < eps)
             {
                 //Print()<<"line segment and triangle are in the same plane\t"<<S1<<"\t"<<S2<<"\t"<<S3<<"\n";
                 tri_area=triangle_area(t1,t2,t3);
@@ -229,7 +229,7 @@ namespace amrex
                 area1=(triangle_area(t1,t2,v1)+triangle_area(t2,t3,v1)+triangle_area(t3,t1,v1));
                 area2=(triangle_area(t1,t2,v2)+triangle_area(t2,t3,v2)+triangle_area(t3,t1,v2));
 
-                if( Math::abs(area1-tri_area)>eps || Math::abs(area2-tri_area)>eps )
+                if( std::abs(area1-tri_area)>eps || std::abs(area2-tri_area)>eps )
                 {
                     no_intersections = 0;
                 }
@@ -237,16 +237,16 @@ namespace amrex
             //proper and edge intersection
             else if( (S1 < 0.0 && S2 < 0.0 && S3 < 0.0) ||
                     (S1 > 0.0 && S2 > 0.0 && S3 > 0.0) ||
-                    (Math::abs(S1) < eps && S2*S3 > 0.0) ||     //S1=0
-                    (Math::abs(S2) < eps && S3*S1 > 0.0) ||     //S2=0
-                    (Math::abs(S3) < eps && S1*S2 > 0.0) )      //S3=0
+                    (std::abs(S1) < eps && S2*S3 > 0.0) ||     //S1=0
+                    (std::abs(S2) < eps && S3*S1 > 0.0) ||     //S2=0
+                    (std::abs(S3) < eps && S1*S2 > 0.0) )      //S3=0
             {
 
                 get_plucker_coords(v1,t1,L2);
                 get_plucker_coords(t1,v2,L3);
                 get_plucker_coords(t2,t3,L4);
 
-                /*if(Math::abs(S1*S2*S3) < eps)
+                /*if(std::abs(S1*S2*S3) < eps)
                   {
                   Print()<<"edge intersection S1,S2,S3:"
                   <<S1<<"\t"<<S2<<"\t"<<S3<<"\n";
@@ -261,8 +261,8 @@ namespace amrex
                 }
             }
             //vertex intersection
-            else if( (Math::abs(S1) < eps && Math::abs(S2) < eps) ||  //S1,S2=0
-                    (Math::abs(S2) < eps && Math::abs(S3) < eps) )   //S2,S3=0
+            else if( (std::abs(S1) < eps && std::abs(S2) < eps) ||  //S1,S2=0
+                    (std::abs(S2) < eps && std::abs(S3) < eps) )   //S2,S3=0
             {
 
                 //Print()<<"vertex intersection type 1\n";
@@ -279,7 +279,7 @@ namespace amrex
                     no_intersections = 0;
                 }
             }
-            else if(Math::abs(S3) < eps && Math::abs(S1) < eps) //S3,S1=0
+            else if(std::abs(S3) < eps && std::abs(S1) < eps) //S3,S1=0
             {
 
                 //Print()<<"vertex intersection type 2\n";

--- a/Src/EB/AMReX_EB_utils.cpp
+++ b/Src/EB/AMReX_EB_utils.cpp
@@ -322,9 +322,9 @@ facets_nearest_pt (IntVect const& ind_pt, IntVect const& ind_loop, RealVect cons
         facet_normal[tmp_facet] = 1.; // whether facing inwards or outwards is not important here
 
         // skip cases where cell faces coincide with the eb facets
-        if (AMREX_D_TERM(amrex::Math::abs(eb_normal[0]) == amrex::Math::abs(facet_normal[0]),
-                      && amrex::Math::abs(eb_normal[1]) == amrex::Math::abs(facet_normal[1]),
-                      && amrex::Math::abs(eb_normal[2]) == amrex::Math::abs(facet_normal[2])))
+        if (AMREX_D_TERM(std::abs(eb_normal[0]) == std::abs(facet_normal[0]),
+                      && std::abs(eb_normal[1]) == std::abs(facet_normal[1]),
+                      && std::abs(eb_normal[2]) == std::abs(facet_normal[2])))
         { continue; }
 
         int ind_cell = ind_loop[tmp_facet];
@@ -403,19 +403,19 @@ facets_nearest_pt (IntVect const& ind_pt, IntVect const& ind_loop, RealVect cons
         // if the line runs parallel to any of these dimensions (which is true for
         // EB edges), then skip -> the min/max functions at the end will skip them
         // due to the +/-huge(c...) defaults (above).
-        if ( amrex::Math::abs(edge_v[0]) > eps ) {
+        if ( std::abs(edge_v[0]) > eps ) {
             cx_lo = -( edge_p0[0] -   ind_loop[0]       * dx[0] ) / edge_v[0];
             cx_hi = -( edge_p0[0] - ( ind_loop[0] + 1 ) * dx[0] ) / edge_v[0];
             if ( edge_v[0] < 0._rt ) amrex::Swap(cx_lo, cx_hi);
         }
         //
-        if ( amrex::Math::abs(edge_v[1]) > eps ) {
+        if ( std::abs(edge_v[1]) > eps ) {
             cy_lo = -( edge_p0[1] -   ind_loop[1]       * dx[1] ) / edge_v[1];
             cy_hi = -( edge_p0[1] - ( ind_loop[1] + 1 ) * dx[1] ) / edge_v[1];
             if ( edge_v[1] < 0._rt ) amrex::Swap(cy_lo, cy_hi);
         }
         //
-        if ( amrex::Math::abs(edge_v[2]) > eps ) {
+        if ( std::abs(edge_v[2]) > eps ) {
             cz_lo = -( edge_p0[2] -   ind_loop[2]       * dx[2] ) / edge_v[2];
             cz_hi = -( edge_p0[2] - ( ind_loop[2] + 1 ) * dx[2] ) / edge_v[2];
             if ( edge_v[2] < 0._rt ) amrex::Swap(cz_lo, cz_hi);
@@ -595,16 +595,16 @@ void FillSignedDistance (MultiFab& mf, EB2::Level const& ls_lev,
                     AMREX_D_TERM(Real eb_min_x = x + nx*dist_proj;,
                                  Real eb_min_y = y + ny*dist_proj;,
                                  Real eb_min_z = z + nz*dist_proj);
-                    AMREX_D_TERM(int vi_cx = static_cast<int>(amrex::Math::floor(cx * dxinv));,
-                                 int vi_cy = static_cast<int>(amrex::Math::floor(cy * dyinv));,
-                                 int vi_cz = static_cast<int>(amrex::Math::floor(cz * dzinv)));
-                    AMREX_D_TERM(int vi_x = static_cast<int>(amrex::Math::floor(eb_min_x * dxinv));,
-                                 int vi_y = static_cast<int>(amrex::Math::floor(eb_min_y * dyinv));,
-                                 int vi_z = static_cast<int>(amrex::Math::floor(eb_min_z * dzinv)));
+                    AMREX_D_TERM(int vi_cx = static_cast<int>(std::floor(cx * dxinv));,
+                                 int vi_cy = static_cast<int>(std::floor(cy * dyinv));,
+                                 int vi_cz = static_cast<int>(std::floor(cz * dzinv)));
+                    AMREX_D_TERM(int vi_x = static_cast<int>(std::floor(eb_min_x * dxinv));,
+                                 int vi_y = static_cast<int>(std::floor(eb_min_y * dyinv));,
+                                 int vi_z = static_cast<int>(std::floor(eb_min_z * dzinv)));
 
                     bool min_pt_valid = false;
                     if ((AMREX_D_TERM(vi_cx == vi_x, && vi_cy == vi_y, && vi_cz == vi_z))  ||
-                        amrex::Math::abs(dist_proj) > ls_roof + dx_eb_max)
+                        std::abs(dist_proj) > ls_roof + dx_eb_max)
                     {
                         // If the distance is very big, we can set it to true as well.
                         // Later the signed distance will be assigned the roof value.
@@ -615,9 +615,9 @@ void FillSignedDistance (MultiFab& mf, EB2::Level const& ls_lev,
 #endif
                         for (int j_shift = -1; j_shift <= 1; ++j_shift) {
                         for (int i_shift = -1; i_shift <= 1; ++i_shift) {
-                            AMREX_D_TERM(vi_x = static_cast<int>(amrex::Math::floor((eb_min_x+i_shift*1.e-6_rt*dx_eb[0])*dxinv));,
-                                         vi_y = static_cast<int>(amrex::Math::floor((eb_min_y+j_shift*1.e-6_rt*dx_eb[1])*dyinv));,
-                                         vi_z = static_cast<int>(amrex::Math::floor((eb_min_z+k_shift*1.e-6_rt*dx_eb[2])*dzinv)));
+                            AMREX_D_TERM(vi_x = static_cast<int>(std::floor((eb_min_x+i_shift*1.e-6_rt*dx_eb[0])*dxinv));,
+                                         vi_y = static_cast<int>(std::floor((eb_min_y+j_shift*1.e-6_rt*dx_eb[1])*dyinv));,
+                                         vi_z = static_cast<int>(std::floor((eb_min_z+k_shift*1.e-6_rt*dx_eb[2])*dzinv)));
                             if (AMREX_D_TERM(vi_cx == vi_x, && vi_cy == vi_y, && vi_cz == vi_z)) {
                                 min_pt_valid = true;
                                 goto after_loops;
@@ -638,9 +638,9 @@ void FillSignedDistance (MultiFab& mf, EB2::Level const& ls_lev,
                     } else {
                         // fallback: find the nearest point on the EB edge
                         // revert the value of vi_x, vi_y and vi_z
-                        AMREX_D_TERM(vi_x = static_cast<int>(amrex::Math::floor(eb_min_x * dxinv));,
-                                     vi_y = static_cast<int>(amrex::Math::floor(eb_min_y * dyinv));,
-                                     vi_z = static_cast<int>(amrex::Math::floor(eb_min_z * dzinv)));
+                        AMREX_D_TERM(vi_x = static_cast<int>(std::floor(eb_min_x * dxinv));,
+                                     vi_y = static_cast<int>(std::floor(eb_min_y * dyinv));,
+                                     vi_z = static_cast<int>(std::floor(eb_min_z * dzinv)));
                         auto c_vec = detail::facets_nearest_pt
                             ({AMREX_D_DECL(vi_x,vi_y,vi_z)}, {AMREX_D_DECL(vi_cx, vi_cy, vi_cz)},
                              {AMREX_D_DECL(x,y,z)}, {AMREX_D_DECL(nx,ny,nz)},
@@ -651,7 +651,7 @@ void FillSignedDistance (MultiFab& mf, EB2::Level const& ls_lev,
                         min_dist = -std::sqrt(amrex::min(min_dist2, min_edge_dist2));
                     }
 
-                    Real usd = amrex::min(ls_roof,amrex::Math::abs(min_dist));
+                    Real usd = amrex::min(ls_roof,std::abs(min_dist));
                     if (fab(i,j,k) <= 0._rt) {
                         fab(i,j,k) = fluid_sign * usd;
                     } else {

--- a/Src/EB/AMReX_algoim_K.H
+++ b/Src/EB/AMReX_algoim_K.H
@@ -281,7 +281,7 @@ struct ImplicitIntegral
             Real dphi_max = 0.0_rt;
             for (int dim = 0; dim < N; ++dim) {
                 if (free[dim]) {
-                    dphi_max += amrex::Math::abs(phi.grad(dim));
+                    dphi_max += std::abs(phi.grad(dim));
                 } else {
                     mid[dim] = xrange(psi[i].side(dim),dim);
                 }
@@ -401,7 +401,7 @@ struct ImplicitIntegral
                     mag += phi.grad(dim)*phi.grad(dim);
                 }
                 mag = std::sqrt(mag);
-                f.evalIntegrand(x, (mag/amrex::Math::abs(phi.grad(e0)))*w);
+                f.evalIntegrand(x, (mag/std::abs(phi.grad(e0)))*w);
             }
 
             return;
@@ -537,8 +537,8 @@ struct ImplicitIntegral
         {
             Real gmax = -1.;
             for (int dim = 0; dim < N; ++dim) {
-                if (free[dim] && amrex::Math::abs(phi.grad(dim)) > gmax) {
-                    gmax = amrex::Math::abs(phi.grad(dim));
+                if (free[dim] && std::abs(phi.grad(dim)) > gmax) {
+                    gmax = std::abs(phi.grad(dim));
                     e0 = dim;
                 }
             }

--- a/Src/Extern/HYPRE/AMReX_Habec_2D_K.H
+++ b/Src/Extern/HYPRE/AMReX_Habec_2D_K.H
@@ -285,12 +285,12 @@ void habec_ijmat_eb (GpuArray<Real,9>& sten, Array4<Int> const& ncols,
             Real f = fac[0];
 
             if (area != Real(1.0)) {
-                joff = static_cast<int>(Math::copysign(Real(1.0), fcx(i,j,k)));
+                joff = static_cast<int>(std::copysign(Real(1.0), fcx(i,j,k)));
                 jj = j+joff;
                 if (cell_id(i-1,jj,k) < 0 && cell_id(i,jj,k) < 0) {
                     fracy = Real(0.0);
                 } else {
-                    fracy = Math::abs(fcx(i,j,k));
+                    fracy = std::abs(fcx(i,j,k));
                 }
             } else {
                 joff = 0;
@@ -334,12 +334,12 @@ void habec_ijmat_eb (GpuArray<Real,9>& sten, Array4<Int> const& ncols,
             Real f = fac[0];
 
             if (area != Real(1.0)) {
-                joff = static_cast<int>(Math::copysign(Real(1.0), fcx(i+1,j,k)));
+                joff = static_cast<int>(std::copysign(Real(1.0), fcx(i+1,j,k)));
                 jj = j+joff;
                 if (cell_id(i,jj,k) < 0 && cell_id(i+1,jj,k) < 0) {
                     fracy = Real(0.0);
                 } else {
-                    fracy = Math::abs(fcx(i+1,j,k));
+                    fracy = std::abs(fcx(i+1,j,k));
                 }
             } else {
                 joff = 0;
@@ -383,12 +383,12 @@ void habec_ijmat_eb (GpuArray<Real,9>& sten, Array4<Int> const& ncols,
             Real f = fac[1];
 
             if (area != Real(1.0)) {
-                ioff = static_cast<int>(Math::copysign(Real(1.0), fcy(i,j,k)));
+                ioff = static_cast<int>(std::copysign(Real(1.0), fcy(i,j,k)));
                 ii = i+ioff;
                 if (cell_id(ii,j-1,k) < 0 && cell_id(ii,j,k) < 0) {
                     fracx = Real(0.0);
                 } else {
-                    fracx = Math::abs(fcy(i,j,k));
+                    fracx = std::abs(fcy(i,j,k));
                 }
             } else {
                 ioff = 0;
@@ -432,12 +432,12 @@ void habec_ijmat_eb (GpuArray<Real,9>& sten, Array4<Int> const& ncols,
             Real f = fac[1];
 
             if (area != Real(1.0)) {
-                ioff = static_cast<int>(Math::copysign(Real(1.0), fcy(i,j+1,k)));
+                ioff = static_cast<int>(std::copysign(Real(1.0), fcy(i,j+1,k)));
                 ii = i+ioff;
                 if (cell_id(ii,j,k) < 0 && cell_id(ii,j+1,k) < 0) {
                     fracx = Real(0.0);
                 } else {
-                    fracx = Math::abs(fcy(i,j+1,k));
+                    fracx = std::abs(fcy(i,j+1,k));
                 }
             } else {
                 ioff = 0;
@@ -479,11 +479,11 @@ void habec_ijmat_eb (GpuArray<Real,9>& sten, Array4<Int> const& ncols,
             Real anorminv = Real(1.0)/anorm;
             Real anrmx = (apx(i,j,k) - apx(i+1,j,k))*anorminv;
             Real anrmy = (apy(i,j,k) - apy(i,j+1,k))*anorminv;
-            Real sx   = Math::copysign(Real(1.0),anrmx);
-            Real sy   = Math::copysign(Real(1.0),anrmy);
+            Real sx   = std::copysign(Real(1.0),anrmx);
+            Real sy   = std::copysign(Real(1.0),anrmy);
             Real bctx = bcen(i,j,k,0);
             Real bcty = bcen(i,j,k,1);
-            Real dg   = get_dx_eb(vfrc(i,j,k)) / amrex::max(Math::abs(anrmx), Math::abs(anrmy));
+            Real dg   = get_dx_eb(vfrc(i,j,k)) / amrex::max(std::abs(anrmx), std::abs(anrmy));
             Real gx   = bctx - dg*anrmx;
             Real gy   = bcty - dg*anrmy;
             int ioff = -static_cast<int>(sx);

--- a/Src/Extern/HYPRE/AMReX_Habec_3D_K.H
+++ b/Src/Extern/HYPRE/AMReX_Habec_3D_K.H
@@ -376,19 +376,19 @@ void habec_ijmat_eb (GpuArray<Real,27>& sten, Array4<Int> const& ncols,
             Real f = fac[0];
 
             if (area != Real(1.0)) {
-                joff = static_cast<int>(Math::copysign(Real(1.0), fcx(i,j,k,0)));
-                koff = static_cast<int>(Math::copysign(Real(1.0), fcx(i,j,k,1)));
+                joff = static_cast<int>(std::copysign(Real(1.0), fcx(i,j,k,0)));
+                koff = static_cast<int>(std::copysign(Real(1.0), fcx(i,j,k,1)));
                 jj = j+joff;
                 kk = k+koff;
                 if (cell_id(i-1,jj,k) < 0 && cell_id(i,jj,k) < 0) {
                     fracy = Real(0.0);
                 } else {
-                    fracy = Math::abs(fcx(i,j,k,0));
+                    fracy = std::abs(fcx(i,j,k,0));
                 }
                 if (cell_id(i-1,j,kk) < 0 && cell_id(i,j,kk) < 0) {
                     fracz = Real(0.0);
                 } else {
-                    fracz = Math::abs(fcx(i,j,k,1));
+                    fracz = std::abs(fcx(i,j,k,1));
                 }
                 if (cell_id(i-1,jj,kk) < 0 && cell_id(i,jj,kk) < 0 && (fracy*fracz) > Real(0.0)) {
                     fracy = Real(0.0);
@@ -468,19 +468,19 @@ void habec_ijmat_eb (GpuArray<Real,27>& sten, Array4<Int> const& ncols,
             Real f = fac[0];
 
             if (area != Real(1.0)) {
-                joff = static_cast<int>(Math::copysign(Real(1.0), fcx(i+1,j,k,0)));
-                koff = static_cast<int>(Math::copysign(Real(1.0), fcx(i+1,j,k,1)));
+                joff = static_cast<int>(std::copysign(Real(1.0), fcx(i+1,j,k,0)));
+                koff = static_cast<int>(std::copysign(Real(1.0), fcx(i+1,j,k,1)));
                 jj = j+joff;
                 kk = k+koff;
                 if (cell_id(i,jj,k) < 0 && cell_id(i+1,jj,k) < 0) {
                     fracy = Real(0.0);
                 } else {
-                    fracy = Math::abs(fcx(i+1,j,k,0));
+                    fracy = std::abs(fcx(i+1,j,k,0));
                 }
                 if (cell_id(i,j,kk) < 0 && cell_id(i+1,j,kk) < 0) {
                     fracz = Real(0.0);
                 } else {
-                    fracz = Math::abs(fcx(i+1,j,k,1));
+                    fracz = std::abs(fcx(i+1,j,k,1));
                 }
                 if (cell_id(i,jj,kk) < 0 && cell_id(i+1,jj,kk) < 0 && (fracy*fracz) > Real(0.0)) {
                     fracy = Real(0.0);
@@ -559,19 +559,19 @@ void habec_ijmat_eb (GpuArray<Real,27>& sten, Array4<Int> const& ncols,
             Real f = fac[1];
 
             if (area != Real(1.0)) {
-                ioff = static_cast<int>(Math::copysign(Real(1.0), fcy(i,j,k,0)));
-                koff = static_cast<int>(Math::copysign(Real(1.0), fcy(i,j,k,1)));
+                ioff = static_cast<int>(std::copysign(Real(1.0), fcy(i,j,k,0)));
+                koff = static_cast<int>(std::copysign(Real(1.0), fcy(i,j,k,1)));
                 ii = i+ioff;
                 kk = k+koff;
                 if (cell_id(ii,j-1,k) < 0 && cell_id(ii,j,k) < 0) {
                     fracx = Real(0.0);
                 } else {
-                    fracx = Math::abs(fcy(i,j,k,0));
+                    fracx = std::abs(fcy(i,j,k,0));
                 }
                 if (cell_id(i,j-1,kk) < 0 && cell_id(i,j,kk) < 0) {
                     fracz = Real(0.0);
                 } else {
-                    fracz = Math::abs(fcy(i,j,k,1));
+                    fracz = std::abs(fcy(i,j,k,1));
                 }
                 if (cell_id(ii,j-1,kk) < 0 && cell_id(ii,j,kk) < 0 && fracx*fracz > Real(0.0)) {
                     fracx = Real(0.0);
@@ -650,19 +650,19 @@ void habec_ijmat_eb (GpuArray<Real,27>& sten, Array4<Int> const& ncols,
             Real f = fac[1];
 
             if (area != Real(1.0)) {
-                ioff = static_cast<int>(Math::copysign(Real(1.0), fcy(i,j+1,k,0)));
-                koff = static_cast<int>(Math::copysign(Real(1.0), fcy(i,j+1,k,1)));
+                ioff = static_cast<int>(std::copysign(Real(1.0), fcy(i,j+1,k,0)));
+                koff = static_cast<int>(std::copysign(Real(1.0), fcy(i,j+1,k,1)));
                 ii = i+ioff;
                 kk = k+koff;
                 if (cell_id(ii,j,k) < 0 && cell_id(ii,j+1,k) < 0) {
                     fracx = Real(0.0);
                 } else {
-                    fracx = Math::abs(fcy(i,j+1,k,0));
+                    fracx = std::abs(fcy(i,j+1,k,0));
                 }
                 if (cell_id(i,j,kk) < 0 && cell_id(i,j+1,kk) < 0) {
                     fracz = Real(0.0);
                 } else {
-                    fracz = Math::abs(fcy(i,j+1,k,1));
+                    fracz = std::abs(fcy(i,j+1,k,1));
                 }
                 if (cell_id(ii,j,kk) < 0 && cell_id(ii,j+1,kk) < 0 && fracx*fracz > Real(0.0)) {
                     fracx = Real(0.0);
@@ -741,19 +741,19 @@ void habec_ijmat_eb (GpuArray<Real,27>& sten, Array4<Int> const& ncols,
             Real f = fac[2];
 
             if (area != Real(1.0)) {
-                ioff = static_cast<int>(Math::copysign(Real(1.0), fcz(i,j,k,0)));
-                joff = static_cast<int>(Math::copysign(Real(1.0), fcz(i,j,k,1)));
+                ioff = static_cast<int>(std::copysign(Real(1.0), fcz(i,j,k,0)));
+                joff = static_cast<int>(std::copysign(Real(1.0), fcz(i,j,k,1)));
                 ii = i+ioff;
                 jj = j+joff;
                 if (cell_id(ii,j,k-1) < 0 && cell_id(ii,j,k) < 0) {
                     fracx = Real(0.0);
                 } else {
-                    fracx = Math::abs(fcz(i,j,k,0));
+                    fracx = std::abs(fcz(i,j,k,0));
                 }
                 if (cell_id(i,jj,k-1) < 0 && cell_id(i,jj,k) < 0) {
                     fracy = Real(0.0);
                 } else {
-                    fracy = Math::abs(fcz(i,j,k,1));
+                    fracy = std::abs(fcz(i,j,k,1));
                 }
                 if (cell_id(ii,jj,k-1) < 0 && cell_id(ii,jj,k) < 0 && fracx*fracy > Real(0.0)) {
                     fracx = Real(0.0);
@@ -832,19 +832,19 @@ void habec_ijmat_eb (GpuArray<Real,27>& sten, Array4<Int> const& ncols,
             Real f = fac[2];
 
             if (area != Real(1.0)) {
-                ioff = static_cast<int>(Math::copysign(Real(1.0), fcz(i,j,k+1,0)));
-                joff = static_cast<int>(Math::copysign(Real(1.0), fcz(i,j,k+1,1)));
+                ioff = static_cast<int>(std::copysign(Real(1.0), fcz(i,j,k+1,0)));
+                joff = static_cast<int>(std::copysign(Real(1.0), fcz(i,j,k+1,1)));
                 ii = i+ioff;
                 jj = j+joff;
                 if (cell_id(ii,j,k) < 0 && cell_id(ii,j,k+1) < 0) {
                     fracx = Real(0.0);
                 } else {
-                    fracx = Math::abs(fcz(i,j,k+1,0));
+                    fracx = std::abs(fcz(i,j,k+1,0));
                 }
                 if (cell_id(i,jj,k) < 0 && cell_id(i,jj,k+1) < 0) {
                     fracy = Real(0.0);
                 } else {
-                    fracy = Math::abs(fcz(i,j,k+1,1));
+                    fracy = std::abs(fcz(i,j,k+1,1));
                 }
                 if (cell_id(ii,jj,k) < 0 && cell_id(ii,jj,k+1) < 0 && fracx*fracy > Real(0.0)) {
                     fracx = Real(0.0);
@@ -922,13 +922,13 @@ void habec_ijmat_eb (GpuArray<Real,27>& sten, Array4<Int> const& ncols,
             Real anrmx = (apx(i,j,k) - apx(i+1,j,k))*anorminv;
             Real anrmy = (apy(i,j,k) - apy(i,j+1,k))*anorminv;
             Real anrmz = (apz(i,j,k) - apz(i,j,k+1))*anorminv;
-            Real sx   = Math::copysign(Real(1.0),anrmx);
-            Real sy   = Math::copysign(Real(1.0),anrmy);
-            Real sz   = Math::copysign(Real(1.0),anrmz);
+            Real sx   = std::copysign(Real(1.0),anrmx);
+            Real sy   = std::copysign(Real(1.0),anrmy);
+            Real sz   = std::copysign(Real(1.0),anrmz);
             Real bctx = bcen(i,j,k,0);
             Real bcty = bcen(i,j,k,1);
             Real bctz = bcen(i,j,k,2);
-            Real dg   = get_dx_eb(vfrc(i,j,k)) / amrex::max(Math::abs(anrmx), Math::abs(anrmy), Math::abs(anrmz));
+            Real dg   = get_dx_eb(vfrc(i,j,k)) / amrex::max(std::abs(anrmx), std::abs(anrmy), std::abs(anrmz));
             Real gx   = bctx - dg*anrmx;
             Real gy   = bcty - dg*anrmy;
             Real gz   = bctz - dg*anrmz;

--- a/Src/Extern/SUNDIALS/AMReX_NVector_MultiFab.cpp
+++ b/Src/Extern/SUNDIALS/AMReX_NVector_MultiFab.cpp
@@ -427,7 +427,7 @@ void N_VAbs_MultiFab(N_Vector x, N_Vector z)
          amrex::ParallelFor(bx, ncomp,
          [=] AMREX_GPU_DEVICE (int i, int j, int k, int c) noexcept
          {
-             z_fab(i,j,k,c) = amrex::Math::abs(x_fab(i,j,k,c));
+             z_fab(i,j,k,c) = std::abs(x_fab(i,j,k,c));
          });
     }
 }
@@ -616,7 +616,7 @@ void N_VCompare_MultiFab(amrex::Real a, N_Vector x, N_Vector z)
          amrex::ParallelFor(bx, ncomp,
          [=] AMREX_GPU_DEVICE (int i, int j, int k, int c) noexcept
          {
-           z_fab(i,j,k,c) = (amrex::Math::abs(x_fab(i,j,k,c)) >= a) ? amrex::Real(1.0) : amrex::Real(0.0);
+           z_fab(i,j,k,c) = (std::abs(x_fab(i,j,k,c)) >= a) ? amrex::Real(1.0) : amrex::Real(0.0);
          });
     }
 
@@ -685,8 +685,8 @@ int N_VConstrMask_MultiFab(N_Vector a_a, N_Vector a_x, N_Vector a_m)
                     amrex::Real a, x;
                     a = a_fab(i,j,k,c);
                     x = x_fab(i,j,k,c);
-                    int test = (amrex::Math::abs(a) > amrex::Real(1.5) && x*a <= amrex::Real(0.0)) ||
-                        (amrex::Math::abs(a) > amrex::Real(0.5)   && x*a <  amrex::Real(0.0));
+                    int test = (std::abs(a) > amrex::Real(1.5) && x*a <= amrex::Real(0.0)) ||
+                        (std::abs(a) > amrex::Real(0.5)   && x*a <  amrex::Real(0.0));
                     if (test) {
                         m_fab(i,j,k,c) = amrex::Real(1.0);
                     }

--- a/Src/LinearSolvers/MLMG/AMReX_MLCellLinOp.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLCellLinOp.H
@@ -1985,7 +1985,7 @@ MLCellLinOpT<MF>::normInf (int amrlev, MF const& mf, bool local) const -> RT
                                      [=] AMREX_GPU_DEVICE (int box_no, int i, int j, int k, int n)
                                          -> GpuTuple<Real>
                                      {
-                                         return amrex::Math::abs(ma[box_no](i,j,k,n)
+                                         return std::abs(ma[box_no](i,j,k,n)
                                                                  *vfrac_ma[box_no](i,j,k));
                                      });
                 } else
@@ -2000,7 +2000,7 @@ MLCellLinOpT<MF>::normInf (int amrlev, MF const& mf, bool local) const -> RT
                         auto const& v = vfrac.const_array(mfi);
                         AMREX_LOOP_4D(bx, ncomp, i, j, k, n,
                         {
-                            norm = std::max(norm, amrex::Math::abs(fab(i,j,k,n)*v(i,j,k)));
+                            norm = std::max(norm, std::abs(fab(i,j,k,n)*v(i,j,k)));
                         });
                     }
                 }
@@ -2016,7 +2016,7 @@ MLCellLinOpT<MF>::normInf (int amrlev, MF const& mf, bool local) const -> RT
                                          -> GpuTuple<Real>
                                      {
                                          if (mask_ma[box_no](i,j,k)) {
-                                             return amrex::Math::abs(ma[box_no](i,j,k,n)
+                                             return std::abs(ma[box_no](i,j,k,n)
                                                                      *vfrac_ma[box_no](i,j,k));
                                          } else {
                                              return Real(0.0);
@@ -2036,7 +2036,7 @@ MLCellLinOpT<MF>::normInf (int amrlev, MF const& mf, bool local) const -> RT
                         AMREX_LOOP_4D(bx, ncomp, i, j, k, n,
                         {
                             if (mask(i,j,k)) {
-                                norm = std::max(norm, amrex::Math::abs(fab(i,j,k,n)*v(i,j,k)));
+                                norm = std::max(norm, std::abs(fab(i,j,k,n)*v(i,j,k)));
                             }
                         });
                     }

--- a/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap_2D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap_2D_K.H
@@ -208,8 +208,8 @@ void mlebabeclap_adotx (Box const& box, Array4<Real> const& y,
 
             Real fxm = bX(i,j,k,n) * (x(i,j,k,n)-x(i-1,j,k,n));
             if (apxm != 0.0_rt && apxm != 1.0_rt) {
-                int jj = j + static_cast<int>(amrex::Math::copysign(1.0_rt,fcx(i,j,k)));
-                Real fracy = (ccm(i-1,jj,k) || ccm(i,jj,k)) ? amrex::Math::abs(fcx(i,j,k)) : 0.0_rt;
+                int jj = j + static_cast<int>(std::copysign(1.0_rt,fcx(i,j,k)));
+                Real fracy = (ccm(i-1,jj,k) || ccm(i,jj,k)) ? std::abs(fcx(i,j,k)) : 0.0_rt;
                 if (beta_on_center && phi_on_center)
                    fxm = (1.0-fracy)*fxm + fracy*bX(i,jj,k,n)*(x(i,jj,k,n)-x(i-1,jj,k,n));
                 else if (beta_on_centroid && phi_on_center)
@@ -219,8 +219,8 @@ void mlebabeclap_adotx (Box const& box, Array4<Real> const& y,
 
             Real fxp = bX(i+1,j,k,n)*(x(i+1,j,k,n)-x(i,j,k,n));
             if (apxp != 0.0_rt && apxp != 1.0_rt) {
-                int jj = j + static_cast<int>(amrex::Math::copysign(1.0_rt,fcx(i+1,j,k)));
-                Real fracy = (ccm(i,jj,k) || ccm(i+1,jj,k)) ? amrex::Math::abs(fcx(i+1,j,k)) : 0.0_rt;
+                int jj = j + static_cast<int>(std::copysign(1.0_rt,fcx(i+1,j,k)));
+                Real fracy = (ccm(i,jj,k) || ccm(i+1,jj,k)) ? std::abs(fcx(i+1,j,k)) : 0.0_rt;
                 if (beta_on_center && phi_on_center)
                     fxp = (1.0-fracy)*fxp + fracy*bX(i+1,jj,k,n)*(x(i+1,jj,k,n)-x(i,jj,k,n));
                 else if (beta_on_centroid && phi_on_center)
@@ -230,8 +230,8 @@ void mlebabeclap_adotx (Box const& box, Array4<Real> const& y,
 
             Real fym = bY(i,j,k,n)*(x(i,j,k,n)-x(i,j-1,k,n));
             if (apym != 0.0_rt && apym != 1.0_rt) {
-                int ii = i + static_cast<int>(amrex::Math::copysign(1.0_rt,fcy(i,j,k)));
-                Real fracx = (ccm(ii,j-1,k) || ccm(ii,j,k)) ? amrex::Math::abs(fcy(i,j,k)) : 0.0_rt;
+                int ii = i + static_cast<int>(std::copysign(1.0_rt,fcy(i,j,k)));
+                Real fracx = (ccm(ii,j-1,k) || ccm(ii,j,k)) ? std::abs(fcy(i,j,k)) : 0.0_rt;
                 if (beta_on_center && phi_on_center)
                     fym = (1.0-fracx)*fym + fracx*bY(ii,j,k,n)*(x(ii,j,k,n)-x(ii,j-1,k,n));
                 else if (beta_on_centroid && phi_on_center)
@@ -241,8 +241,8 @@ void mlebabeclap_adotx (Box const& box, Array4<Real> const& y,
 
             Real fyp = bY(i,j+1,k,n)*(x(i,j+1,k,n)-x(i,j,k,n));
             if (apyp != 0.0_rt && apyp != 1.0_rt) {
-                int ii = i + static_cast<int>(amrex::Math::copysign(1.0_rt,fcy(i,j+1,k)));
-                Real fracx = (ccm(ii,j,k) || ccm(ii,j+1,k)) ? amrex::Math::abs(fcy(i,j+1,k)) : 0.0_rt;
+                int ii = i + static_cast<int>(std::copysign(1.0_rt,fcy(i,j+1,k)));
+                Real fracx = (ccm(ii,j,k) || ccm(ii,j+1,k)) ? std::abs(fcy(i,j+1,k)) : 0.0_rt;
                 if (beta_on_center && phi_on_center)
                     fyp = (1.0-fracx)*fyp + fracx*bY(ii,j+1,k,n)*(x(ii,j+1,k,n)-x(ii,j,k,n));
                 else if (beta_on_centroid && phi_on_center)
@@ -266,15 +266,15 @@ void mlebabeclap_adotx (Box const& box, Array4<Real> const& y,
                 Real dx_eb = get_dx_eb(kappa);
 
                 Real dg, gx, gy, sx, sy;
-                if (amrex::Math::abs(anrmx) > amrex::Math::abs(anrmy)) {
-                    dg = dx_eb / amrex::Math::abs(anrmx);
+                if (std::abs(anrmx) > std::abs(anrmy)) {
+                    dg = dx_eb / std::abs(anrmx);
                 } else {
-                    dg = dx_eb / amrex::Math::abs(anrmy);
+                    dg = dx_eb / std::abs(anrmy);
                 }
                 gx = (bctx - dg*anrmx);
                 gy = (bcty - dg*anrmy);
-                sx = amrex::Math::copysign(1.0_rt,anrmx);
-                sy = amrex::Math::copysign(1.0_rt,anrmy);
+                sx = std::copysign(1.0_rt,anrmx);
+                sy = std::copysign(1.0_rt,anrmy);
 
                 int ii = i - static_cast<int>(sx);
                 int jj = j - static_cast<int>(sy);
@@ -340,15 +340,15 @@ void mlebabeclap_ebflux (int i, int j, int k, int n,
         Real dx_eb = get_dx_eb(kappa);
 
         Real dg, gx, gy, sx, sy;
-        if (amrex::Math::abs(anrmx) > amrex::Math::abs(anrmy)) {
-            dg = dx_eb / amrex::Math::abs(anrmx);
+        if (std::abs(anrmx) > std::abs(anrmy)) {
+            dg = dx_eb / std::abs(anrmx);
         } else {
-            dg = dx_eb / amrex::Math::abs(anrmy);
+            dg = dx_eb / std::abs(anrmy);
         }
         gx = bctx - dg*anrmx;
         gy = bcty - dg*anrmy;
-        sx = amrex::Math::copysign(1.0_rt,anrmx);
-        sy = amrex::Math::copysign(1.0_rt,anrmy);
+        sx = std::copysign(1.0_rt,anrmx);
+        sy = std::copysign(1.0_rt,anrmy);
 
         int ii = i - static_cast<int>(sx);
         int jj = j - static_cast<int>(sy);
@@ -434,9 +434,9 @@ void mlebabeclap_gsrb (Box const& box,
                     Real oxm = -bX(i,j,k,n)*cf0;
                     Real sxm =  bX(i,j,k,n);
                     if (apxm != 0.0 && apxm != 1.0) {
-                        int jj = j + static_cast<int>(amrex::Math::copysign(1.0_rt,fcx(i,j,k)));
+                        int jj = j + static_cast<int>(std::copysign(1.0_rt,fcx(i,j,k)));
                         Real fracy = (ccm(i-1,jj,k) || ccm(i,jj,k))
-                            ? amrex::Math::abs(fcx(i,j,k)) : 0.0;
+                            ? std::abs(fcx(i,j,k)) : 0.0;
                         if (!beta_on_centroid && !phi_on_centroid)
                         {
                             fxm = (1.0-fracy)*fxm +
@@ -456,9 +456,9 @@ void mlebabeclap_gsrb (Box const& box,
                     Real oxp =  bX(i+1,j,k,n)*cf2;
                     Real sxp = -bX(i+1,j,k,n);
                     if (apxp != 0.0 && apxp != 1.0) {
-                        int jj = j + static_cast<int>(amrex::Math::copysign(1.0_rt,fcx(i+1,j,k)));
+                        int jj = j + static_cast<int>(std::copysign(1.0_rt,fcx(i+1,j,k)));
                         Real fracy = (ccm(i,jj,k) || ccm(i+1,jj,k))
-                            ? amrex::Math::abs(fcx(i+1,j,k)) : 0.0;
+                            ? std::abs(fcx(i+1,j,k)) : 0.0;
                         if (!beta_on_centroid && !phi_on_centroid)
                         {
                             fxp = (1.0-fracy)*fxp +
@@ -478,9 +478,9 @@ void mlebabeclap_gsrb (Box const& box,
                     Real oym = -bY(i,j,k,n)*cf1;
                     Real sym =  bY(i,j,k,n);
                     if (apym != 0.0 && apym != 1.0) {
-                        int ii = i + static_cast<int>(amrex::Math::copysign(1.0_rt,fcy(i,j,k)));
+                        int ii = i + static_cast<int>(std::copysign(1.0_rt,fcy(i,j,k)));
                         Real fracx = (ccm(ii,j-1,k) || ccm(ii,j,k))
-                            ? amrex::Math::abs(fcy(i,j,k)) : 0.0;
+                            ? std::abs(fcy(i,j,k)) : 0.0;
                         if (!beta_on_centroid && !phi_on_centroid)
                         {
                             fym = (1.0-fracx)*fym +
@@ -501,9 +501,9 @@ void mlebabeclap_gsrb (Box const& box,
                     Real oyp =  bY(i,j+1,k,n)*cf3;
                     Real syp = -bY(i,j+1,k,n);
                     if (apyp != 0.0 && apyp != 1.0) {
-                        int ii = i + static_cast<int>(amrex::Math::copysign(1.0_rt,fcy(i,j+1,k)));
+                        int ii = i + static_cast<int>(std::copysign(1.0_rt,fcy(i,j+1,k)));
                         Real fracx = (ccm(ii,j,k) || ccm(ii,j+1,k))
-                            ? amrex::Math::abs(fcy(i,j+1,k)) : 0.0;
+                            ? std::abs(fcy(i,j+1,k)) : 0.0;
                         if (!beta_on_centroid && !phi_on_centroid)
                         {
                             fyp = (1.0-fracx)*fyp +
@@ -544,15 +544,15 @@ void mlebabeclap_gsrb (Box const& box,
                         Real dx_eb = get_dx_eb(vfrc(i,j,k));
 
                         Real dg, gx, gy, sx, sy;
-                        if (amrex::Math::abs(anrmx) > amrex::Math::abs(anrmy)) {
-                            dg = dx_eb / amrex::Math::abs(anrmx);
+                        if (std::abs(anrmx) > std::abs(anrmy)) {
+                            dg = dx_eb / std::abs(anrmx);
                         } else {
-                            dg = dx_eb / amrex::Math::abs(anrmy);
+                            dg = dx_eb / std::abs(anrmy);
                         }
                         gx = bctx - dg*anrmx;
                         gy = bcty - dg*anrmy;
-                        sx = amrex::Math::copysign(1.0_rt,anrmx);
-                        sy = amrex::Math::copysign(1.0_rt,anrmy);
+                        sx = std::copysign(1.0_rt,anrmx);
+                        sy = std::copysign(1.0_rt,anrmy);
 
                         int ii = i - static_cast<int>(sx);
                         int jj = j - static_cast<int>(sy);
@@ -598,8 +598,8 @@ void mlebabeclap_flux_x (Box const& box, Array4<Real> const& fx, Array4<Real con
                 fx(i,j,k,n) = -dhx*bX(i,j,k,n)*(sol(i,j,k,n)-sol(i-1,j,k,n));
             } else {
                 Real fxm = bX(i,j,k,n)*(sol(i,j,k,n)-sol(i-1,j,k,n));
-                int jj = j + static_cast<int>(amrex::Math::copysign(1.0_rt,fcx(i,j,k)));
-                Real fracy = (ccm(i-1,jj,k) || ccm(i,jj,k)) ? amrex::Math::abs(fcx(i,j,k)) : 0.0_rt;
+                int jj = j + static_cast<int>(std::copysign(1.0_rt,fcx(i,j,k)));
+                Real fracy = (ccm(i-1,jj,k) || ccm(i,jj,k)) ? std::abs(fcx(i,j,k)) : 0.0_rt;
                 if (!beta_on_centroid && !phi_on_centroid)
                 {
                     fxm = (1.0-fracy)*fxm + fracy*bX(i,jj,k,n)*(sol(i,jj,k,n)-sol(i-1,jj,k,n));
@@ -630,8 +630,8 @@ void mlebabeclap_flux_y (Box const& box, Array4<Real> const& fy, Array4<Real con
                 fy(i,j,k,n) = -dhy*bY(i,j,k,n)*(sol(i,j,k,n)-sol(i,j-1,k,n));
             } else {
                 Real fym = bY(i,j,k,n)*(sol(i,j,k,n)-sol(i,j-1,k,n));
-                int ii = i + static_cast<int>(amrex::Math::copysign(1.0_rt,fcy(i,j,k)));
-                Real fracx = (ccm(ii,j-1,k) || ccm(ii,j,k)) ? amrex::Math::abs(fcy(i,j,k)) : 0.0_rt;
+                int ii = i + static_cast<int>(std::copysign(1.0_rt,fcy(i,j,k)));
+                Real fracx = (ccm(ii,j-1,k) || ccm(ii,j,k)) ? std::abs(fcy(i,j,k)) : 0.0_rt;
                 if (!beta_on_centroid && !phi_on_centroid)
                 {
                     fym = (1.0-fracx)*fym + fracx*bY(ii,j,k,n)*(sol(ii,j,k,n)-sol(ii,j-1,k,n));
@@ -696,8 +696,8 @@ void mlebabeclap_grad_x (Box const& box, Array4<Real> const& gx, Array4<Real con
             gx(i,j,k,n) = dxi*(sol(i,j,k,n)-sol(i-1,j,k,n));
         } else {
             Real gxm = (sol(i,j,k,n)-sol(i-1,j,k,n));
-            int jj = j + static_cast<int>(amrex::Math::copysign(1.0_rt,fcx(i,j,k)));
-            Real fracy = (ccm(i-1,jj,k) || ccm(i,jj,k)) ? amrex::Math::abs(fcx(i,j,k)) : 0.0_rt;
+            int jj = j + static_cast<int>(std::copysign(1.0_rt,fcx(i,j,k)));
+            Real fracy = (ccm(i-1,jj,k) || ccm(i,jj,k)) ? std::abs(fcx(i,j,k)) : 0.0_rt;
             if (!phi_on_centroid)
                gxm = (1.0-fracy)*gxm + fracy*(sol(i,jj,k,n)-sol(i-1,jj,k,n));
             gx(i,j,k,n) = gxm*dxi;
@@ -719,8 +719,8 @@ void mlebabeclap_grad_y (Box const& box, Array4<Real> const& gy, Array4<Real con
             gy(i,j,k,n) = dyi*(sol(i,j,k,n)-sol(i,j-1,k,n));
         } else {
             Real gym = (sol(i,j,k,n)-sol(i,j-1,k,n));
-            int ii = i + static_cast<int>(amrex::Math::copysign(1.0_rt,fcy(i,j,k)));
-            Real fracx = (ccm(ii,j-1,k) || ccm(ii,j,k)) ? amrex::Math::abs(fcy(i,j,k)) : 0.0_rt;
+            int ii = i + static_cast<int>(std::copysign(1.0_rt,fcy(i,j,k)));
+            Real fracx = (ccm(ii,j-1,k) || ccm(ii,j,k)) ? std::abs(fcy(i,j,k)) : 0.0_rt;
             if (!phi_on_centroid)
                 gym = (1.0-fracx)*gym + fracx*(sol(ii,j,k,n)-sol(ii,j-1,k,n));
             gy(i,j,k,n) = gym*dyi;
@@ -787,33 +787,33 @@ void mlebabeclap_normalize (Box const& box, Array4<Real> const& phi,
 
             Real sxm =  bX(i,j,k,n);
             if (apxm != 0.0 && apxm != 1.0 && !beta_on_centroid) {
-                int jj = j + static_cast<int>(amrex::Math::copysign(1.0_rt,fcx(i,j,k)));
+                int jj = j + static_cast<int>(std::copysign(1.0_rt,fcx(i,j,k)));
                 Real fracy = (ccm(i-1,jj,k) || ccm(i,jj,k))
-                    ? amrex::Math::abs(fcx(i,j,k)) : 0.0;
+                    ? std::abs(fcx(i,j,k)) : 0.0;
                 sxm = (1.0-fracy)*sxm;
             }
 
             Real sxp = -bX(i+1,j,k,n);
             if (apxp != 0.0 && apxp != 1.0 && !beta_on_centroid) {
-                int jj = j + static_cast<int>(amrex::Math::copysign(1.0_rt,fcx(i+1,j,k)));
+                int jj = j + static_cast<int>(std::copysign(1.0_rt,fcx(i+1,j,k)));
                 Real fracy = (ccm(i,jj,k) || ccm(i+1,jj,k))
-                    ? amrex::Math::abs(fcx(i+1,j,k)) : 0.0;
+                    ? std::abs(fcx(i+1,j,k)) : 0.0;
                 sxp = (1.0-fracy)*sxp;
             }
 
             Real sym =  bY(i,j,k,n);
             if (apym != 0.0 && apym != 1.0 && !beta_on_centroid) {
-                int ii = i + static_cast<int>(amrex::Math::copysign(1.0_rt,fcy(i,j,k)));
+                int ii = i + static_cast<int>(std::copysign(1.0_rt,fcy(i,j,k)));
                 Real fracx = (ccm(ii,j-1,k) || ccm(ii,j,k))
-                    ? amrex::Math::abs(fcy(i,j,k)) : 0.0;
+                    ? std::abs(fcy(i,j,k)) : 0.0;
                 sym = (1.0-fracx)*sym;
             }
 
             Real syp = -bY(i,j+1,k,n);
             if (apyp != 0.0 && apyp != 1.0 && !beta_on_centroid) {
-                int ii = i + static_cast<int>(amrex::Math::copysign(1.0_rt,fcy(i,j+1,k)));
+                int ii = i + static_cast<int>(std::copysign(1.0_rt,fcy(i,j+1,k)));
                 Real fracx = (ccm(ii,j,k) || ccm(ii,j+1,k))
-                    ? amrex::Math::abs(fcy(i,j+1,k)) : 0.0;
+                    ? std::abs(fcy(i,j+1,k)) : 0.0;
                 syp = (1.0-fracx)*syp;
             }
 
@@ -835,15 +835,15 @@ void mlebabeclap_normalize (Box const& box, Array4<Real> const& phi,
                 Real dx_eb = get_dx_eb(vfrc(i,j,k));
 
                 Real dg, gx, gy, sx, sy;
-                if (amrex::Math::abs(anrmx) > amrex::Math::abs(anrmy)) {
-                    dg = dx_eb / amrex::Math::abs(anrmx);
+                if (std::abs(anrmx) > std::abs(anrmy)) {
+                    dg = dx_eb / std::abs(anrmx);
                 } else {
-                    dg = dx_eb / amrex::Math::abs(anrmy);
+                    dg = dx_eb / std::abs(anrmy);
                 }
                 gx = bctx - dg*anrmx;
                 gy = bcty - dg*anrmy;
-                sx = amrex::Math::copysign(1.0_rt,anrmx);
-                sy = amrex::Math::copysign(1.0_rt,anrmy);
+                sx = std::copysign(1.0_rt,anrmx);
+                sy = std::copysign(1.0_rt,anrmy);
 
                 Real phig_gamma = (1.0 + gx*sx + gy*sy + gx*gy*sx*sy);
                 Real feb_gamma = -phig_gamma/dg * ba(i,j,k) * beb(i,j,k,n);

--- a/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap_3D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap_3D_K.H
@@ -263,10 +263,10 @@ void mlebabeclap_adotx (Box const& box, Array4<Real> const& y,
 
             Real fxm = bX(i,j,k,n)*(x(i,j,k,n) - x(i-1,j,k,n));
             if (apxm != 0.0 && apxm != 1.0) {
-                int jj = j + static_cast<int>(amrex::Math::copysign(1.0_rt, fcx(i,j,k,0)));
-                int kk = k + static_cast<int>(amrex::Math::copysign(1.0_rt, fcx(i,j,k,1)));
-                Real fracy = (ccm(i-1,jj,k) || ccm(i,jj,k)) ? amrex::Math::abs(fcx(i,j,k,0)) : 0.0_rt;
-                Real fracz = (ccm(i-1,j,kk) || ccm(i,j,kk)) ? amrex::Math::abs(fcx(i,j,k,1)) : 0.0_rt;
+                int jj = j + static_cast<int>(std::copysign(1.0_rt, fcx(i,j,k,0)));
+                int kk = k + static_cast<int>(std::copysign(1.0_rt, fcx(i,j,k,1)));
+                Real fracy = (ccm(i-1,jj,k) || ccm(i,jj,k)) ? std::abs(fcx(i,j,k,0)) : 0.0_rt;
+                Real fracz = (ccm(i-1,j,kk) || ccm(i,j,kk)) ? std::abs(fcx(i,j,k,1)) : 0.0_rt;
                 if (beta_on_center && phi_on_center)
                 {
                     fxm = (1.0-fracy)*(1.0-fracz)*fxm +
@@ -286,10 +286,10 @@ void mlebabeclap_adotx (Box const& box, Array4<Real> const& y,
 
             Real fxp = bX(i+1,j,k,n)*(x(i+1,j,k,n) - x(i,j,k,n));
             if (apxp != 0.0 && apxp != 1.0) {
-                int jj = j + static_cast<int>(amrex::Math::copysign(1.0_rt,fcx(i+1,j,k,0)));
-                int kk = k + static_cast<int>(amrex::Math::copysign(1.0_rt,fcx(i+1,j,k,1)));
-                Real fracy = (ccm(i,jj,k) || ccm(i+1,jj,k)) ? amrex::Math::abs(fcx(i+1,j,k,0)) : 0.0_rt;
-                Real fracz = (ccm(i,j,kk) || ccm(i+1,j,kk)) ? amrex::Math::abs(fcx(i+1,j,k,1)) : 0.0_rt;
+                int jj = j + static_cast<int>(std::copysign(1.0_rt,fcx(i+1,j,k,0)));
+                int kk = k + static_cast<int>(std::copysign(1.0_rt,fcx(i+1,j,k,1)));
+                Real fracy = (ccm(i,jj,k) || ccm(i+1,jj,k)) ? std::abs(fcx(i+1,j,k,0)) : 0.0_rt;
+                Real fracz = (ccm(i,j,kk) || ccm(i+1,j,kk)) ? std::abs(fcx(i+1,j,k,1)) : 0.0_rt;
                 if (beta_on_center && phi_on_center)
                 {
                     fxp = (1.0-fracy)*(1.0-fracz)*fxp +
@@ -310,10 +310,10 @@ void mlebabeclap_adotx (Box const& box, Array4<Real> const& y,
 
             Real fym = bY(i,j,k,n)*(x(i,j,k,n) - x(i,j-1,k,n));
             if (apym != 0.0 && apym != 1.0) {
-                int ii = i + static_cast<int>(amrex::Math::copysign(1.0_rt,fcy(i,j,k,0)));
-                int kk = k + static_cast<int>(amrex::Math::copysign(1.0_rt,fcy(i,j,k,1)));
-                Real fracx = (ccm(ii,j-1,k) || ccm(ii,j,k)) ? amrex::Math::abs(fcy(i,j,k,0)) : 0.0_rt;
-                Real fracz = (ccm(i,j-1,kk) || ccm(i,j,kk)) ? amrex::Math::abs(fcy(i,j,k,1)) : 0.0_rt;
+                int ii = i + static_cast<int>(std::copysign(1.0_rt,fcy(i,j,k,0)));
+                int kk = k + static_cast<int>(std::copysign(1.0_rt,fcy(i,j,k,1)));
+                Real fracx = (ccm(ii,j-1,k) || ccm(ii,j,k)) ? std::abs(fcy(i,j,k,0)) : 0.0_rt;
+                Real fracz = (ccm(i,j-1,kk) || ccm(i,j,kk)) ? std::abs(fcy(i,j,k,1)) : 0.0_rt;
                 if (beta_on_center && phi_on_center)
                 {
                     fym = (1.0-fracx)*(1.0-fracz)*fym +
@@ -334,10 +334,10 @@ void mlebabeclap_adotx (Box const& box, Array4<Real> const& y,
 
             Real fyp = bY(i,j+1,k,n)*(x(i,j+1,k,n) - x(i,j,k,n));
             if (apyp != 0.0 && apyp != 1.0) {
-                int ii = i + static_cast<int>(amrex::Math::copysign(1.0_rt,fcy(i,j+1,k,0)));
-                int kk = k + static_cast<int>(amrex::Math::copysign(1.0_rt,fcy(i,j+1,k,1)));
-                Real fracx = (ccm(ii,j,k) || ccm(ii,j+1,k)) ? amrex::Math::abs(fcy(i,j+1,k,0)) : 0.0_rt;
-                Real fracz = (ccm(i,j,kk) || ccm(i,j+1,kk)) ? amrex::Math::abs(fcy(i,j+1,k,1)) : 0.0_rt;
+                int ii = i + static_cast<int>(std::copysign(1.0_rt,fcy(i,j+1,k,0)));
+                int kk = k + static_cast<int>(std::copysign(1.0_rt,fcy(i,j+1,k,1)));
+                Real fracx = (ccm(ii,j,k) || ccm(ii,j+1,k)) ? std::abs(fcy(i,j+1,k,0)) : 0.0_rt;
+                Real fracz = (ccm(i,j,kk) || ccm(i,j+1,kk)) ? std::abs(fcy(i,j+1,k,1)) : 0.0_rt;
                 if (beta_on_center && phi_on_center)
                 {
                     fyp = (1.0-fracx)*(1.0-fracz)*fyp +
@@ -358,10 +358,10 @@ void mlebabeclap_adotx (Box const& box, Array4<Real> const& y,
 
             Real fzm = bZ(i,j,k,n)*(x(i,j,k,n) - x(i,j,k-1,n));
             if (apzm != 0.0 && apzm != 1.0) {
-                int ii = i + static_cast<int>(amrex::Math::copysign(1.0_rt,fcz(i,j,k,0)));
-                int jj = j + static_cast<int>(amrex::Math::copysign(1.0_rt,fcz(i,j,k,1)));
-                Real fracx = (ccm(ii,j,k-1) || ccm(ii,j,k)) ? amrex::Math::abs(fcz(i,j,k,0)) : 0.0_rt;
-                Real fracy = (ccm(i,jj,k-1) || ccm(i,jj,k)) ? amrex::Math::abs(fcz(i,j,k,1)) : 0.0_rt;
+                int ii = i + static_cast<int>(std::copysign(1.0_rt,fcz(i,j,k,0)));
+                int jj = j + static_cast<int>(std::copysign(1.0_rt,fcz(i,j,k,1)));
+                Real fracx = (ccm(ii,j,k-1) || ccm(ii,j,k)) ? std::abs(fcz(i,j,k,0)) : 0.0_rt;
+                Real fracy = (ccm(i,jj,k-1) || ccm(i,jj,k)) ? std::abs(fcz(i,j,k,1)) : 0.0_rt;
                 if (beta_on_center && phi_on_center)
                 {
                     fzm = (1.0-fracx)*(1.0-fracy)*fzm +
@@ -382,10 +382,10 @@ void mlebabeclap_adotx (Box const& box, Array4<Real> const& y,
 
             Real fzp = bZ(i,j,k+1,n)*(x(i,j,k+1,n) - x(i,j,k,n));
             if (apzp != 0.0 && apzp != 1.0) {
-                int ii = i + static_cast<int>(amrex::Math::copysign(1.0_rt,fcz(i,j,k+1,0)));
-                int jj = j + static_cast<int>(amrex::Math::copysign(1.0_rt,fcz(i,j,k+1,1)));
-                Real fracx = (ccm(ii,j,k) || ccm(ii,j,k+1)) ? amrex::Math::abs(fcz(i,j,k+1,0)) : 0.0_rt;
-                Real fracy = (ccm(i,jj,k) || ccm(i,jj,k+1)) ? amrex::Math::abs(fcz(i,j,k+1,1)) : 0.0_rt;
+                int ii = i + static_cast<int>(std::copysign(1.0_rt,fcz(i,j,k+1,0)));
+                int jj = j + static_cast<int>(std::copysign(1.0_rt,fcz(i,j,k+1,1)));
+                Real fracx = (ccm(ii,j,k) || ccm(ii,j,k+1)) ? std::abs(fcz(i,j,k+1,0)) : 0.0_rt;
+                Real fracy = (ccm(i,jj,k) || ccm(i,jj,k+1)) ? std::abs(fcz(i,j,k+1,1)) : 0.0_rt;
                 if (beta_on_center && phi_on_center)
                 {
                     fzp = (1.0-fracx)*(1.0-fracy)*fzp +
@@ -422,14 +422,14 @@ void mlebabeclap_adotx (Box const& box, Array4<Real> const& y,
                 Real bctz = bc(i,j,k,2);
                 Real dx_eb = get_dx_eb(kappa);
 
-                Real dg = dx_eb / amrex::max(amrex::Math::abs(anrmx), amrex::Math::abs(anrmy),
-                                             amrex::Math::abs(anrmz));
+                Real dg = dx_eb / amrex::max(std::abs(anrmx), std::abs(anrmy),
+                                             std::abs(anrmz));
                 Real gx = bctx - dg*anrmx;
                 Real gy = bcty - dg*anrmy;
                 Real gz = bctz - dg*anrmz;
-                Real sx = amrex::Math::copysign(1.0_rt,anrmx);
-                Real sy = amrex::Math::copysign(1.0_rt,anrmy);
-                Real sz = amrex::Math::copysign(1.0_rt,anrmz);
+                Real sx = std::copysign(1.0_rt,anrmx);
+                Real sy = std::copysign(1.0_rt,anrmy);
+                Real sz = std::copysign(1.0_rt,anrmz);
                 int ii = i - static_cast<int>(sx);
                 int jj = j - static_cast<int>(sy);
                 int kk = k - static_cast<int>(sz);
@@ -510,13 +510,13 @@ void mlebabeclap_ebflux (int i, int j, int k, int n,
         Real bctz = bc(i,j,k,2);
         Real dx_eb = get_dx_eb(kappa);
 
-        Real dg = dx_eb / amrex::max(amrex::Math::abs(anrmx), amrex::Math::abs(anrmy), amrex::Math::abs(anrmz));
+        Real dg = dx_eb / amrex::max(std::abs(anrmx), std::abs(anrmy), std::abs(anrmz));
         Real gx = bctx - dg*anrmx;
         Real gy = bcty - dg*anrmy;
         Real gz = bctz - dg*anrmz;
-        Real sx = amrex::Math::copysign(1.0_rt,anrmx);
-        Real sy = amrex::Math::copysign(1.0_rt,anrmy);
-        Real sz = amrex::Math::copysign(1.0_rt,anrmz);
+        Real sx = std::copysign(1.0_rt,anrmx);
+        Real sy = std::copysign(1.0_rt,anrmy);
+        Real sz = std::copysign(1.0_rt,anrmz);
         int ii = i - static_cast<int>(sx);
         int jj = j - static_cast<int>(sy);
         int kk = k - static_cast<int>(sz);
@@ -638,12 +638,12 @@ void mlebabeclap_gsrb (Box const& box,
                     Real oxm = -bX(i,j,k,n)*cf0;
                     Real sxm =  bX(i,j,k,n);
                     if (apxm != 0.0 && apxm != 1.0) {
-                        int jj = j + static_cast<int>(amrex::Math::copysign(1.0_rt, fcx(i,j,k,0)));
-                        int kk = k + static_cast<int>(amrex::Math::copysign(1.0_rt, fcx(i,j,k,1)));
+                        int jj = j + static_cast<int>(std::copysign(1.0_rt, fcx(i,j,k,0)));
+                        int kk = k + static_cast<int>(std::copysign(1.0_rt, fcx(i,j,k,1)));
                         Real fracy = (ccm(i-1,jj,k) || ccm(i,jj,k))
-                            ? amrex::Math::abs(fcx(i,j,k,0)) : 0.0_rt;
+                            ? std::abs(fcx(i,j,k,0)) : 0.0_rt;
                         Real fracz = (ccm(i-1,j,kk) || ccm(i,j,kk))
-                            ? amrex::Math::abs(fcx(i,j,k,1)) : 0.0_rt;
+                            ? std::abs(fcx(i,j,k,1)) : 0.0_rt;
                         if (!beta_on_centroid && !phi_on_centroid)
                         {
                             fxm = (1.0-fracy)*(1.0-fracz)*fxm
@@ -668,12 +668,12 @@ void mlebabeclap_gsrb (Box const& box,
                     Real oxp =  bX(i+1,j,k,n)*cf3;
                     Real sxp = -bX(i+1,j,k,n);
                     if (apxp != 0.0 && apxp != 1.0) {
-                        int jj = j + static_cast<int>(amrex::Math::copysign(1.0_rt,fcx(i+1,j,k,0)));
-                        int kk = k + static_cast<int>(amrex::Math::copysign(1.0_rt,fcx(i+1,j,k,1)));
+                        int jj = j + static_cast<int>(std::copysign(1.0_rt,fcx(i+1,j,k,0)));
+                        int kk = k + static_cast<int>(std::copysign(1.0_rt,fcx(i+1,j,k,1)));
                         Real fracy = (ccm(i,jj,k) || ccm(i+1,jj,k))
-                            ? amrex::Math::abs(fcx(i+1,j,k,0)) : 0.0_rt;
+                            ? std::abs(fcx(i+1,j,k,0)) : 0.0_rt;
                         Real fracz = (ccm(i,j,kk) || ccm(i+1,j,kk))
-                            ? amrex::Math::abs(fcx(i+1,j,k,1)) : 0.0_rt;
+                            ? std::abs(fcx(i+1,j,k,1)) : 0.0_rt;
                         if (!beta_on_centroid && !phi_on_centroid)
                         {
                             fxp = (1.0-fracy)*(1.0-fracz)*fxp
@@ -699,12 +699,12 @@ void mlebabeclap_gsrb (Box const& box,
                     Real oym = -bY(i,j,k,n)*cf1;
                     Real sym =  bY(i,j,k,n);
                     if (apym != 0.0 && apym != 1.0) {
-                        int ii = i + static_cast<int>(amrex::Math::copysign(1.0_rt,fcy(i,j,k,0)));
-                        int kk = k + static_cast<int>(amrex::Math::copysign(1.0_rt,fcy(i,j,k,1)));
+                        int ii = i + static_cast<int>(std::copysign(1.0_rt,fcy(i,j,k,0)));
+                        int kk = k + static_cast<int>(std::copysign(1.0_rt,fcy(i,j,k,1)));
                         Real fracx = (ccm(ii,j-1,k) || ccm(ii,j,k))
-                            ? amrex::Math::abs(fcy(i,j,k,0)) : 0.0_rt;
+                            ? std::abs(fcy(i,j,k,0)) : 0.0_rt;
                         Real fracz = (ccm(i,j-1,kk) || ccm(i,j,kk))
-                            ? amrex::Math::abs(fcy(i,j,k,1)) : 0.0_rt;
+                            ? std::abs(fcy(i,j,k,1)) : 0.0_rt;
                         if (!beta_on_centroid && !phi_on_centroid)
                         {
                             fym = (1.0-fracx)*(1.0-fracz)*fym
@@ -729,12 +729,12 @@ void mlebabeclap_gsrb (Box const& box,
                     Real oyp =  bY(i,j+1,k,n)*cf4;
                     Real syp = -bY(i,j+1,k,n);
                     if (apyp != 0.0 && apyp != 1.0) {
-                        int ii = i + static_cast<int>(amrex::Math::copysign(1.0_rt,fcy(i,j+1,k,0)));
-                        int kk = k + static_cast<int>(amrex::Math::copysign(1.0_rt,fcy(i,j+1,k,1)));
+                        int ii = i + static_cast<int>(std::copysign(1.0_rt,fcy(i,j+1,k,0)));
+                        int kk = k + static_cast<int>(std::copysign(1.0_rt,fcy(i,j+1,k,1)));
                         Real fracx = (ccm(ii,j,k) || ccm(ii,j+1,k))
-                            ? amrex::Math::abs(fcy(i,j+1,k,0)) : 0.0_rt;
+                            ? std::abs(fcy(i,j+1,k,0)) : 0.0_rt;
                         Real fracz = (ccm(i,j,kk) || ccm(i,j+1,kk))
-                            ? amrex::Math::abs(fcy(i,j+1,k,1)) : 0.0_rt;
+                            ? std::abs(fcy(i,j+1,k,1)) : 0.0_rt;
                         if (!beta_on_centroid && !phi_on_centroid)
                         {
                             fyp = (1.0-fracx)*(1.0-fracz)*fyp
@@ -759,12 +759,12 @@ void mlebabeclap_gsrb (Box const& box,
                     Real ozm = -bZ(i,j,k,n)*cf2;
                     Real szm =  bZ(i,j,k,n);
                     if (apzm != 0.0 && apzm != 1.0) {
-                        int ii = i + static_cast<int>(amrex::Math::copysign(1.0_rt,fcz(i,j,k,0)));
-                        int jj = j + static_cast<int>(amrex::Math::copysign(1.0_rt,fcz(i,j,k,1)));
+                        int ii = i + static_cast<int>(std::copysign(1.0_rt,fcz(i,j,k,0)));
+                        int jj = j + static_cast<int>(std::copysign(1.0_rt,fcz(i,j,k,1)));
                         Real fracx = (ccm(ii,j,k-1) || ccm(ii,j,k))
-                            ? amrex::Math::abs(fcz(i,j,k,0)) : 0.0_rt;
+                            ? std::abs(fcz(i,j,k,0)) : 0.0_rt;
                         Real fracy = (ccm(i,jj,k-1) || ccm(i,jj,k))
-                            ? amrex::Math::abs(fcz(i,j,k,1)) : 0.0_rt;
+                            ? std::abs(fcz(i,j,k,1)) : 0.0_rt;
                         if (!beta_on_centroid && !phi_on_centroid)
                         {
                             fzm = (1.0-fracx)*(1.0-fracy)*fzm
@@ -789,12 +789,12 @@ void mlebabeclap_gsrb (Box const& box,
                     Real ozp =  bZ(i,j,k+1,n)*cf5;
                     Real szp = -bZ(i,j,k+1,n);
                     if (apzp != 0.0 && apzp != 1.0) {
-                        int ii = i + static_cast<int>(amrex::Math::copysign(1.0_rt,fcz(i,j,k+1,0)));
-                        int jj = j + static_cast<int>(amrex::Math::copysign(1.0_rt,fcz(i,j,k+1,1)));
+                        int ii = i + static_cast<int>(std::copysign(1.0_rt,fcz(i,j,k+1,0)));
+                        int jj = j + static_cast<int>(std::copysign(1.0_rt,fcz(i,j,k+1,1)));
                         Real fracx = (ccm(ii,j,k) || ccm(ii,j,k+1))
-                            ? amrex::Math::abs(fcz(i,j,k+1,0)) : 0.0_rt;
+                            ? std::abs(fcz(i,j,k+1,0)) : 0.0_rt;
                         Real fracy = (ccm(i,jj,k) || ccm(i,jj,k+1))
-                            ? amrex::Math::abs(fcz(i,j,k+1,1)) : 0.0_rt;
+                            ? std::abs(fcz(i,j,k+1,1)) : 0.0_rt;
                         if (!beta_on_centroid && !phi_on_centroid)
                         {
                             fzp = (1.0-fracx)*(1.0-fracy)*fzp
@@ -845,15 +845,15 @@ void mlebabeclap_gsrb (Box const& box,
                         Real bctz = bc(i,j,k,2);
                         Real dx_eb = get_dx_eb(vfrc(i,j,k));
 
-                        Real dg = dx_eb / amrex::max(amrex::Math::abs(anrmx),amrex::Math::abs(anrmy),
-                                                     amrex::Math::abs(anrmz));
+                        Real dg = dx_eb / amrex::max(std::abs(anrmx),std::abs(anrmy),
+                                                     std::abs(anrmz));
 
                         Real gx = bctx - dg*anrmx;
                         Real gy = bcty - dg*anrmy;
                         Real gz = bctz - dg*anrmz;
-                        Real sx = amrex::Math::copysign(1.0_rt,anrmx);
-                        Real sy = amrex::Math::copysign(1.0_rt,anrmy);
-                        Real sz = amrex::Math::copysign(1.0_rt,anrmz);
+                        Real sx = std::copysign(1.0_rt,anrmx);
+                        Real sy = std::copysign(1.0_rt,anrmy);
+                        Real sz = std::copysign(1.0_rt,anrmz);
                         int ii = i - static_cast<int>(sx);
                         int jj = j - static_cast<int>(sy);
                         int kk = k - static_cast<int>(sz);
@@ -908,10 +908,10 @@ void mlebabeclap_flux_x (Box const& box, Array4<Real> const& fx, Array4<Real con
                 fx(i,j,k,n) = -dhx*bX(i,j,k,n)*(sol(i,j,k,n)-sol(i-1,j,k,n));
             } else {
                 Real fxm = bX(i,j,k,n)*(sol(i,j,k,n) - sol(i-1,j,k,n));
-                int jj = j + static_cast<int>(amrex::Math::copysign(1.0_rt, fcx(i,j,k,0)));
-                int kk = k + static_cast<int>(amrex::Math::copysign(1.0_rt, fcx(i,j,k,1)));
-                Real fracy = (ccm(i-1,jj,k) || ccm(i,jj,k)) ? amrex::Math::abs(fcx(i,j,k,0)) : 0.0_rt;
-                Real fracz = (ccm(i-1,j,kk) || ccm(i,j,kk)) ? amrex::Math::abs(fcx(i,j,k,1)) : 0.0_rt;
+                int jj = j + static_cast<int>(std::copysign(1.0_rt, fcx(i,j,k,0)));
+                int kk = k + static_cast<int>(std::copysign(1.0_rt, fcx(i,j,k,1)));
+                Real fracy = (ccm(i-1,jj,k) || ccm(i,jj,k)) ? std::abs(fcx(i,j,k,0)) : 0.0_rt;
+                Real fracz = (ccm(i-1,j,kk) || ccm(i,j,kk)) ? std::abs(fcx(i,j,k,1)) : 0.0_rt;
                 if (!beta_on_centroid && !phi_on_centroid)
                 {
                     fxm = (1.0-fracy)*(1.0-fracz)*fxm +
@@ -952,10 +952,10 @@ void mlebabeclap_flux_y (Box const& box, Array4<Real> const& fy, Array4<Real con
                 fy(i,j,k,n) = -dhy*bY(i,j,k,n)*(sol(i,j,k,n)-sol(i,j-1,k,n));
             } else {
                 Real fym = bY(i,j,k,n)*(sol(i,j,k,n) - sol(i,j-1,k,n));
-                int ii = i + static_cast<int>(amrex::Math::copysign(1.0_rt,fcy(i,j,k,0)));
-                int kk = k + static_cast<int>(amrex::Math::copysign(1.0_rt,fcy(i,j,k,1)));
-                Real fracx = (ccm(ii,j-1,k) || ccm(ii,j,k)) ? amrex::Math::abs(fcy(i,j,k,0)) : 0.0_rt;
-                Real fracz = (ccm(i,j-1,kk) || ccm(i,j,kk)) ? amrex::Math::abs(fcy(i,j,k,1)) : 0.0_rt;
+                int ii = i + static_cast<int>(std::copysign(1.0_rt,fcy(i,j,k,0)));
+                int kk = k + static_cast<int>(std::copysign(1.0_rt,fcy(i,j,k,1)));
+                Real fracx = (ccm(ii,j-1,k) || ccm(ii,j,k)) ? std::abs(fcy(i,j,k,0)) : 0.0_rt;
+                Real fracz = (ccm(i,j-1,kk) || ccm(i,j,kk)) ? std::abs(fcy(i,j,k,1)) : 0.0_rt;
                 if (!beta_on_centroid && !phi_on_centroid)
                 {
                     fym = (1.0-fracx)*(1.0-fracz)*fym +
@@ -996,10 +996,10 @@ void mlebabeclap_flux_z (Box const& box, Array4<Real> const& fz, Array4<Real con
                 fz(i,j,k,n) = -dhz*bZ(i,j,k,n)*(sol(i,j,k,n)-sol(i,j,k-1,n));
             } else {
                 Real fzm = bZ(i,j,k,n)*(sol(i,j,k,n) - sol(i,j,k-1,n));
-                int ii = i + static_cast<int>(amrex::Math::copysign(1.0_rt,fcz(i,j,k,0)));
-                int jj = j + static_cast<int>(amrex::Math::copysign(1.0_rt,fcz(i,j,k,1)));
-                Real fracx = (ccm(ii,j,k-1) || ccm(ii,j,k)) ? amrex::Math::abs(fcz(i,j,k,0)) : 0.0_rt;
-                Real fracy = (ccm(i,jj,k-1) || ccm(i,jj,k)) ? amrex::Math::abs(fcz(i,j,k,1)) : 0.0_rt;
+                int ii = i + static_cast<int>(std::copysign(1.0_rt,fcz(i,j,k,0)));
+                int jj = j + static_cast<int>(std::copysign(1.0_rt,fcz(i,j,k,1)));
+                Real fracx = (ccm(ii,j,k-1) || ccm(ii,j,k)) ? std::abs(fcz(i,j,k,0)) : 0.0_rt;
+                Real fracy = (ccm(i,jj,k-1) || ccm(i,jj,k)) ? std::abs(fcz(i,j,k,1)) : 0.0_rt;
                 if (!beta_on_centroid && !phi_on_centroid)
                 {
                     fzm = (1.0-fracx)*(1.0-fracy)*fzm +
@@ -1094,10 +1094,10 @@ void mlebabeclap_grad_x (Box const& box, Array4<Real> const& gx, Array4<Real con
             gx(i,j,k,n) = dxi*(sol(i,j,k,n)-sol(i-1,j,k,n));
         } else {
             Real gxm = (sol(i,j,k,n) - sol(i-1,j,k,n));
-            int jj = j + static_cast<int>(amrex::Math::copysign(1.0_rt, fcx(i,j,k,0)));
-            int kk = k + static_cast<int>(amrex::Math::copysign(1.0_rt, fcx(i,j,k,1)));
-            Real fracy = (ccm(i-1,jj,k) || ccm(i,jj,k)) ? amrex::Math::abs(fcx(i,j,k,0)) : 0.0_rt;
-            Real fracz = (ccm(i-1,j,kk) || ccm(i,j,kk)) ? amrex::Math::abs(fcx(i,j,k,1)) : 0.0_rt;
+            int jj = j + static_cast<int>(std::copysign(1.0_rt, fcx(i,j,k,0)));
+            int kk = k + static_cast<int>(std::copysign(1.0_rt, fcx(i,j,k,1)));
+            Real fracy = (ccm(i-1,jj,k) || ccm(i,jj,k)) ? std::abs(fcx(i,j,k,0)) : 0.0_rt;
+            Real fracz = (ccm(i-1,j,kk) || ccm(i,j,kk)) ? std::abs(fcx(i,j,k,1)) : 0.0_rt;
             if (!phi_on_centroid)
             {
                 gxm = (1.0-fracy)*(1.0-fracz)*gxm +
@@ -1124,10 +1124,10 @@ void mlebabeclap_grad_y (Box const& box, Array4<Real> const& gy, Array4<Real con
             gy(i,j,k,n) = dyi*(sol(i,j,k,n)-sol(i,j-1,k,n));
         } else {
             Real gym = (sol(i,j,k,n) - sol(i,j-1,k,n));
-            int ii = i + static_cast<int>(amrex::Math::copysign(1.0_rt,fcy(i,j,k,0)));
-            int kk = k + static_cast<int>(amrex::Math::copysign(1.0_rt,fcy(i,j,k,1)));
-            Real fracx = (ccm(ii,j-1,k) || ccm(ii,j,k)) ? amrex::Math::abs(fcy(i,j,k,0)) : 0.0_rt;
-            Real fracz = (ccm(i,j-1,kk) || ccm(i,j,kk)) ? amrex::Math::abs(fcy(i,j,k,1)) : 0.0_rt;
+            int ii = i + static_cast<int>(std::copysign(1.0_rt,fcy(i,j,k,0)));
+            int kk = k + static_cast<int>(std::copysign(1.0_rt,fcy(i,j,k,1)));
+            Real fracx = (ccm(ii,j-1,k) || ccm(ii,j,k)) ? std::abs(fcy(i,j,k,0)) : 0.0_rt;
+            Real fracz = (ccm(i,j-1,kk) || ccm(i,j,kk)) ? std::abs(fcy(i,j,k,1)) : 0.0_rt;
             if (!phi_on_centroid)
             {
                 gym = (1.0-fracx)*(1.0-fracz)*gym +
@@ -1154,10 +1154,10 @@ void mlebabeclap_grad_z (Box const& box, Array4<Real> const& gz, Array4<Real con
             gz(i,j,k,n) = dzi*(sol(i,j,k,n)-sol(i,j,k-1,n));
         } else {
             Real gzm = (sol(i,j,k,n) - sol(i,j,k-1,n));
-            int ii = i + static_cast<int>(amrex::Math::copysign(1.0_rt,fcz(i,j,k,0)));
-            int jj = j + static_cast<int>(amrex::Math::copysign(1.0_rt,fcz(i,j,k,1)));
-            Real fracx = (ccm(ii,j,k-1) || ccm(ii,j,k)) ? amrex::Math::abs(fcz(i,j,k,0)) : 0.0_rt;
-            Real fracy = (ccm(i,jj,k-1) || ccm(i,jj,k)) ? amrex::Math::abs(fcz(i,j,k,1)) : 0.0_rt;
+            int ii = i + static_cast<int>(std::copysign(1.0_rt,fcz(i,j,k,0)));
+            int jj = j + static_cast<int>(std::copysign(1.0_rt,fcz(i,j,k,1)));
+            Real fracx = (ccm(ii,j,k-1) || ccm(ii,j,k)) ? std::abs(fcz(i,j,k,0)) : 0.0_rt;
+            Real fracy = (ccm(i,jj,k-1) || ccm(i,jj,k)) ? std::abs(fcz(i,j,k,1)) : 0.0_rt;
             if (!phi_on_centroid)
             {
                 gzm = (1.0-fracx)*(1.0-fracy)*gzm +
@@ -1248,67 +1248,67 @@ void mlebabeclap_normalize (Box const& box, Array4<Real> const& phi,
 
             Real sxm =  bX(i,j,k,n);
             if (apxm != 0.0 && apxm != 1.0 && !beta_on_centroid) {
-                int jj = j + static_cast<int>(amrex::Math::copysign(1.0_rt, fcx(i,j,k,0)));
-                int kk = k + static_cast<int>(amrex::Math::copysign(1.0_rt, fcx(i,j,k,1)));
+                int jj = j + static_cast<int>(std::copysign(1.0_rt, fcx(i,j,k,0)));
+                int kk = k + static_cast<int>(std::copysign(1.0_rt, fcx(i,j,k,1)));
                 Real fracy = (ccm(i-1,jj,k) || ccm(i,jj,k))
-                    ? amrex::Math::abs(fcx(i,j,k,0)) : 0.0_rt;
+                    ? std::abs(fcx(i,j,k,0)) : 0.0_rt;
                 Real fracz = (ccm(i-1,j,kk) || ccm(i,j,kk))
-                    ? amrex::Math::abs(fcx(i,j,k,1)) : 0.0_rt;
+                    ? std::abs(fcx(i,j,k,1)) : 0.0_rt;
                 sxm = (1.0-fracy)*(1.0-fracz)*sxm;
             }
 
             Real sxp = -bX(i+1,j,k,n);
             if (apxp != 0.0 && apxp != 1.0 && !beta_on_centroid) {
-                int jj = j + static_cast<int>(amrex::Math::copysign(1.0_rt,fcx(i+1,j,k,0)));
-                int kk = k + static_cast<int>(amrex::Math::copysign(1.0_rt,fcx(i+1,j,k,1)));
+                int jj = j + static_cast<int>(std::copysign(1.0_rt,fcx(i+1,j,k,0)));
+                int kk = k + static_cast<int>(std::copysign(1.0_rt,fcx(i+1,j,k,1)));
                 Real fracy = (ccm(i,jj,k) || ccm(i+1,jj,k))
-                    ? amrex::Math::abs(fcx(i+1,j,k,0)) : 0.0_rt;
+                    ? std::abs(fcx(i+1,j,k,0)) : 0.0_rt;
                 Real fracz = (ccm(i,j,kk) || ccm(i+1,j,kk))
-                    ? amrex::Math::abs(fcx(i+1,j,k,1)) : 0.0_rt;
+                    ? std::abs(fcx(i+1,j,k,1)) : 0.0_rt;
                 sxp = (1.0-fracy)*(1.0-fracz)*sxp;
             }
 
             Real sym =  bY(i,j,k,n);
             if (apym != 0.0 && apym != 1.0 && !beta_on_centroid) {
-                int ii = i + static_cast<int>(amrex::Math::copysign(1.0_rt,fcy(i,j,k,0)));
-                int kk = k + static_cast<int>(amrex::Math::copysign(1.0_rt,fcy(i,j,k,1)));
+                int ii = i + static_cast<int>(std::copysign(1.0_rt,fcy(i,j,k,0)));
+                int kk = k + static_cast<int>(std::copysign(1.0_rt,fcy(i,j,k,1)));
                 Real fracx = (ccm(ii,j-1,k) || ccm(ii,j,k))
-                    ? amrex::Math::abs(fcy(i,j,k,0)) : 0.0_rt;
+                    ? std::abs(fcy(i,j,k,0)) : 0.0_rt;
                 Real fracz = (ccm(i,j-1,kk) || ccm(i,j,kk))
-                    ? amrex::Math::abs(fcy(i,j,k,1)) : 0.0_rt;
+                    ? std::abs(fcy(i,j,k,1)) : 0.0_rt;
                 sym = (1.0-fracx)*(1.0-fracz)*sym;
             }
 
             Real syp = -bY(i,j+1,k,n);
             if (apyp != 0.0 && apyp != 1.0 && !beta_on_centroid) {
-                int ii = i + static_cast<int>(amrex::Math::copysign(1.0_rt,fcy(i,j+1,k,0)));
-                int kk = k + static_cast<int>(amrex::Math::copysign(1.0_rt,fcy(i,j+1,k,1)));
+                int ii = i + static_cast<int>(std::copysign(1.0_rt,fcy(i,j+1,k,0)));
+                int kk = k + static_cast<int>(std::copysign(1.0_rt,fcy(i,j+1,k,1)));
                 Real fracx = (ccm(ii,j,k) || ccm(ii,j+1,k))
-                    ? amrex::Math::abs(fcy(i,j+1,k,0)) : 0.0_rt;
+                    ? std::abs(fcy(i,j+1,k,0)) : 0.0_rt;
                 Real fracz = (ccm(i,j,kk) || ccm(i,j+1,kk))
-                    ? amrex::Math::abs(fcy(i,j+1,k,1)) : 0.0_rt;
+                    ? std::abs(fcy(i,j+1,k,1)) : 0.0_rt;
                 syp = (1.0-fracx)*(1.0-fracz)*syp;
             }
 
             Real szm =  bZ(i,j,k,n);
             if (apzm != 0.0 && apzm != 1.0 && !beta_on_centroid) {
-                int ii = i + static_cast<int>(amrex::Math::copysign(1.0_rt,fcz(i,j,k,0)));
-                int jj = j + static_cast<int>(amrex::Math::copysign(1.0_rt,fcz(i,j,k,1)));
+                int ii = i + static_cast<int>(std::copysign(1.0_rt,fcz(i,j,k,0)));
+                int jj = j + static_cast<int>(std::copysign(1.0_rt,fcz(i,j,k,1)));
                 Real fracx = (ccm(ii,j,k-1) || ccm(ii,j,k))
-                    ? amrex::Math::abs(fcz(i,j,k,0)) : 0.0_rt;
+                    ? std::abs(fcz(i,j,k,0)) : 0.0_rt;
                 Real fracy = (ccm(i,jj,k-1) || ccm(i,jj,k))
-                    ? amrex::Math::abs(fcz(i,j,k,1)) : 0.0_rt;
+                    ? std::abs(fcz(i,j,k,1)) : 0.0_rt;
                 szm = (1.0-fracx)*(1.0-fracy)*szm;
             }
 
             Real szp = -bZ(i,j,k+1,n);
             if (apzp != 0.0 && apzp != 1.0 && !beta_on_centroid) {
-                int ii = i + static_cast<int>(amrex::Math::copysign(1.0_rt,fcz(i,j,k+1,0)));
-                int jj = j + static_cast<int>(amrex::Math::copysign(1.0_rt,fcz(i,j,k+1,1)));
+                int ii = i + static_cast<int>(std::copysign(1.0_rt,fcz(i,j,k+1,0)));
+                int jj = j + static_cast<int>(std::copysign(1.0_rt,fcz(i,j,k+1,1)));
                 Real fracx = (ccm(ii,j,k) || ccm(ii,j,k+1))
-                    ? amrex::Math::abs(fcz(i,j,k+1,0)) : 0.0_rt;
+                    ? std::abs(fcz(i,j,k+1,0)) : 0.0_rt;
                 Real fracy = (ccm(i,jj,k) || ccm(i,jj,k+1))
-                    ? amrex::Math::abs(fcz(i,j,k+1,1)) : 0.0_rt;
+                    ? std::abs(fcz(i,j,k+1,1)) : 0.0_rt;
                 szp = (1.0-fracx)*(1.0-fracy)*szp;
             }
 
@@ -1332,15 +1332,15 @@ void mlebabeclap_normalize (Box const& box, Array4<Real> const& phi,
                 Real bctz = bc(i,j,k,2);
                 Real dx_eb = get_dx_eb(vfrc(i,j,k));
 
-                Real dg = dx_eb / amrex::max(amrex::Math::abs(anrmx),amrex::Math::abs(anrmy),
-                                             amrex::Math::abs(anrmz));
+                Real dg = dx_eb / amrex::max(std::abs(anrmx),std::abs(anrmy),
+                                             std::abs(anrmz));
 
                 Real gx = bctx - dg*anrmx;
                 Real gy = bcty - dg*anrmy;
                 Real gz = bctz - dg*anrmz;
-                Real sx = amrex::Math::copysign(1.0_rt,anrmx);
-                Real sy = amrex::Math::copysign(1.0_rt,anrmy);
-                Real sz = amrex::Math::copysign(1.0_rt,anrmz);
+                Real sx = std::copysign(1.0_rt,anrmx);
+                Real sy = std::copysign(1.0_rt,anrmy);
+                Real sz = std::copysign(1.0_rt,anrmz);
 
                 gx *= sx;
                 gy *= sy;

--- a/Src/LinearSolvers/MLMG/AMReX_MLEBTensor_2D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBTensor_2D_K.H
@@ -247,7 +247,7 @@ void mlebtensor_cross_terms (Box const& box, Array4<Real> const& Ax,
                 Real fxm_1 = fx(i,j,0,1);
                 if (apx(i,j,0) > 0.0 && apx(i,j,0) < 1.0) {
                     int jj = j + (fcx(i,j,0,0) >= 0.0 ? 1 : -1);
-                    Real fracy = (ccm(i-1,jj,0) || ccm(i,jj,0)) ? amrex::Math::abs(fcx(i,j,0,0)) : 0.0;
+                    Real fracy = (ccm(i-1,jj,0) || ccm(i,jj,0)) ? std::abs(fcx(i,j,0,0)) : 0.0;
                     fxm_0 = (1.0-fracy)*fxm_0 + fracy*fx(i,jj,0,0);
                     fxm_1 = (1.0-fracy)*fxm_1 + fracy*fx(i,jj,0,1);
                 }
@@ -256,7 +256,7 @@ void mlebtensor_cross_terms (Box const& box, Array4<Real> const& Ax,
                 Real fxp_1 = fx(i+1,j,0,1);
                 if (apx(i+1,j,0) > 0.0 && apx(i+1,j,0) < 1.0) {
                     int jj = j + (fcx(i+1,j,0,0) >= 0.0 ? 1 : -1);
-                    Real fracy = (ccm(i,jj,0) || ccm(i+1,jj,0)) ? amrex::Math::abs(fcx(i+1,j,0,0)) : 0.0;
+                    Real fracy = (ccm(i,jj,0) || ccm(i+1,jj,0)) ? std::abs(fcx(i+1,j,0,0)) : 0.0;
                     fxp_0 = (1.0-fracy)*fxp_0 + fracy*fx(i+1,jj,0,0);
                     fxp_1 = (1.0-fracy)*fxp_1 + fracy*fx(i+1,jj,0,1);
                 }
@@ -265,7 +265,7 @@ void mlebtensor_cross_terms (Box const& box, Array4<Real> const& Ax,
                 Real fym_1 = fy(i,j,0,1);
                 if (apy(i,j,0) > 0.0 && apy(i,j,0) < 1.0) {
                     int ii = i + (fcy(i,j,0,0) >= 0.0 ? 1 : -1);
-                    Real fracx = (ccm(ii,j-1,0) || ccm(ii,j,0)) ? amrex::Math::abs(fcy(i,j,0,0)) : 0.0;
+                    Real fracx = (ccm(ii,j-1,0) || ccm(ii,j,0)) ? std::abs(fcy(i,j,0,0)) : 0.0;
                     fym_0 = (1.0-fracx)*fym_0 + fracx*fy(ii,j,0,0);
                     fym_1 = (1.0-fracx)*fym_1 + fracx*fy(ii,j,0,1);
                 }
@@ -274,7 +274,7 @@ void mlebtensor_cross_terms (Box const& box, Array4<Real> const& Ax,
                 Real fyp_1 = fy(i,j+1,0,1);
                 if (apy(i,j+1,0) > 0.0 && apy(i,j+1,0) < 1.0) {
                     int ii = i + (fcy(i,j+1,0,0) >= 0.0 ? 1 : -1);
-                    Real fracx = (ccm(ii,j,0) || ccm(ii,j+1,0)) ? amrex::Math::abs(fcy(i,j+1,0,0)) : 0.0;
+                    Real fracx = (ccm(ii,j,0) || ccm(ii,j+1,0)) ? std::abs(fcy(i,j+1,0,0)) : 0.0;
                     fyp_0 = (1.0-fracx)*fyp_0 + fracx*fy(ii,j+1,0,0);
                     fyp_1 = (1.0-fracx)*fyp_1 + fracx*fy(ii,j+1,0,1);
                 }
@@ -298,7 +298,7 @@ void mlebtensor_cross_terms (Box const& box, Array4<Real> const& Ax,
                     }
 
                     Real dx_eb = amrex::max(0.3, (kappa*kappa-0.25)/(2.*kappa));
-                    Real dg = dx_eb / amrex::max(amrex::Math::abs(anrmx),amrex::Math::abs(anrmy));
+                    Real dg = dx_eb / amrex::max(std::abs(anrmx),std::abs(anrmy));
                     Real dginv = 1.0/dg;
                     Real gx = bc(i,j,0,0) - dg*anrmx;
                     Real gy = bc(i,j,0,1) - dg*anrmy;
@@ -401,7 +401,7 @@ void mlebtensor_flux_x (Box const& box, Array4<Real> const& Ax,
                 Real fxm_1 = fx(i,j,0,1);
 
                 int jj = j + (fcx(i,j,0,0) >= 0.0 ? 1 : -1);
-                Real fracy = (ccm(i-1,jj,0) || ccm(i,jj,0)) ? amrex::Math::abs(fcx(i,j,0,0)) : 0.0;
+                Real fracy = (ccm(i-1,jj,0) || ccm(i,jj,0)) ? std::abs(fcx(i,j,0,0)) : 0.0;
                 fxm_0 = (1.0-fracy)*fxm_0 + fracy*fx(i,jj,0,0);
                 fxm_1 = (1.0-fracy)*fxm_1 + fracy*fx(i,jj,0,1);
 
@@ -434,7 +434,7 @@ void mlebtensor_flux_y (Box const& box, Array4<Real> const& Ay,
                 Real fym_1 = fy(i,j,0,1);
 
                 int ii = i + (fcy(i,j,0,0) >= 0.0 ? 1 : -1);
-                Real fracx = (ccm(ii,j-1,0) || ccm(ii,j,0)) ? amrex::Math::abs(fcy(i,j,0,0)) : 0.0;
+                Real fracx = (ccm(ii,j-1,0) || ccm(ii,j,0)) ? std::abs(fcy(i,j,0,0)) : 0.0;
                 fym_0 = (1.0-fracx)*fym_0 + fracx*fy(ii,j,0,0);
                 fym_1 = (1.0-fracx)*fym_1 + fracx*fy(ii,j,0,1);
 
@@ -672,7 +672,7 @@ void mlebtensor_vel_grads_fx (Box const& box, Array4<Real> const& fx,
                 Real dvdx =  (vel(i,j,0,1) - vel(i-1,j,0,1))*dxi;
                 if (apx(i,j,0) < 1.0) {
                     int jj = j + (fcx(i,j,0,0) >= 0.0 ? 1 : -1);
-                    Real fracy = (ccm(i-1,jj,0) || ccm(i,jj,0)) ? amrex::Math::abs(fcx(i,j,0,0)) : 0.0;
+                    Real fracy = (ccm(i-1,jj,0) || ccm(i,jj,0)) ? std::abs(fcx(i,j,0,0)) : 0.0;
                     dudx =  (1.0-fracy)*dudx
                           + fracy      *(vel(i,jj,0,0) - vel(i-1,jj,0,0))*dxi;
                     dvdx =  (1.0-fracy)*dvdx
@@ -738,7 +738,7 @@ void mlebtensor_vel_grads_fy (Box const& box, Array4<Real> const& fy,
                 Real dvdy =  (vel(i,j,0,1) - vel(i,j-1,0,1))*dyi;
                 if (apy(i,j,0) < 1.0) {
                     int ii = i + (fcy(i,j,0,0) >= 0.0 ? 1 : -1);
-                    Real fracx = (ccm(ii,j-1,0) || ccm(ii,j,0)) ? amrex::Math::abs(fcy(i,j,0,0)) : 0.0;
+                    Real fracx = (ccm(ii,j-1,0) || ccm(ii,j,0)) ? std::abs(fcy(i,j,0,0)) : 0.0;
                     dudy =  (1.0-fracx)*dudy
                           + fracx      *(vel(ii,j,0,0) - vel(ii,j-1,0,0))*dyi;
                     dvdy =  (1.0-fracx)*dvdy
@@ -789,7 +789,7 @@ void mlebtensor_vel_grads_fx (Box const& box, Array4<Real> const& fx,
                 Real dvdx = (vel(i,j,0,1) - vel(i-1,j,0,1))*dxi;
                 if (apx(i,j,0) < 1.0) {
                     int jj = j + (fcx(i,j,0,0) >= 0.0 ? 1 : -1);
-                    Real fracy = (ccm(i-1,jj,0) || ccm(i,jj,0)) ? amrex::Math::abs(fcx(i,j,0,0)) : 0.0;
+                    Real fracy = (ccm(i-1,jj,0) || ccm(i,jj,0)) ? std::abs(fcx(i,j,0,0)) : 0.0;
                     dudx =  (1.0-fracy)*dudx
                           + fracy      *(vel(i,jj,0,0) - vel(i-1,jj,0,0))*dxi;
                     dvdx =  (1.0-fracy)*dvdx
@@ -864,7 +864,7 @@ void mlebtensor_vel_grads_fy (Box const& box, Array4<Real> const& fy,
                 Real dvdy = (vel(i,j,0,1) - vel(i,j-1,0,1))*dyi;
                 if (apy(i,j,0) < 1.0) {
                     int ii = i + (fcy(i,j,0,0) >= 0.0 ? 1 : -1);
-                    Real fracx = (ccm(ii,j-1,0) || ccm(ii,j,0)) ? amrex::Math::abs(fcy(i,j,0,0)) : 0.0;
+                    Real fracx = (ccm(ii,j-1,0) || ccm(ii,j,0)) ? std::abs(fcy(i,j,0,0)) : 0.0;
                     dudy =  (1.0-fracx)*dudy
                           + fracx      *(vel(ii,j,0,0) - vel(ii,j-1,0,0))*dyi;
                     dvdy =  (1.0-fracx)*dvdy

--- a/Src/LinearSolvers/MLMG/AMReX_MLEBTensor_3D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBTensor_3D_K.H
@@ -713,8 +713,8 @@ void mlebtensor_cross_terms (Box const& box, Array4<Real> const& Ax,
                     if (apx(i,j,k) > 0.0 && apx(i,j,k) < 1.0) {
                         int jj = j + (fcx(i,j,k,0) >= 0.0 ? 1 : -1);
                         int kk = k + (fcx(i,j,k,1) >= 0.0 ? 1 : -1);
-                        Real fracy = (ccm(i-1,jj,k) || ccm(i,jj,k)) ? amrex::Math::abs(fcx(i,j,k,0)) : 0.0;
-                        Real fracz = (ccm(i-1,j,kk) || ccm(i,j,kk)) ? amrex::Math::abs(fcx(i,j,k,1)) : 0.0;
+                        Real fracy = (ccm(i-1,jj,k) || ccm(i,jj,k)) ? std::abs(fcx(i,j,k,0)) : 0.0;
+                        Real fracz = (ccm(i-1,j,kk) || ccm(i,j,kk)) ? std::abs(fcx(i,j,k,1)) : 0.0;
                         fxm_0 = (1.0-fracy)*(1.0-fracz) *fxm_0
                             + fracy*(1.0-fracz) * fx(i,jj,k ,0)
                             + fracz*(1.0-fracy) * fx(i,j ,kk,0)
@@ -735,8 +735,8 @@ void mlebtensor_cross_terms (Box const& box, Array4<Real> const& Ax,
                     if (apx(i+1,j,k) > 0.0 && apx(i+1,j,k) < 1.0) {
                         int jj = j + (fcx(i+1,j,k,0) >= 0.0 ? 1 : -1);
                         int kk = k + (fcx(i+1,j,k,1) >= 0.0 ? 1 : -1);
-                        Real fracy = (ccm(i,jj,k) || ccm(i+1,jj,k)) ? amrex::Math::abs(fcx(i+1,j,k,0)) : 0.0;
-                        Real fracz = (ccm(i,j,kk) || ccm(i+1,j,kk)) ? amrex::Math::abs(fcx(i+1,j,k,1)) : 0.0;
+                        Real fracy = (ccm(i,jj,k) || ccm(i+1,jj,k)) ? std::abs(fcx(i+1,j,k,0)) : 0.0;
+                        Real fracz = (ccm(i,j,kk) || ccm(i+1,j,kk)) ? std::abs(fcx(i+1,j,k,1)) : 0.0;
                         fxp_0 = (1.0-fracy)*(1.0-fracz) *  fxp_0
                             + fracy*(1.0-fracz) * fx(i+1,jj,k ,0)
                             + fracz*(1.0-fracy) * fx(i+1,j ,kk,0)
@@ -757,8 +757,8 @@ void mlebtensor_cross_terms (Box const& box, Array4<Real> const& Ax,
                     if (apy(i,j,k) > 0.0 && apy(i,j,k) < 1.0) {
                         int ii = i + (fcy(i,j,k,0) >= 0.0 ? 1 : -1);
                         int kk = k + (fcy(i,j,k,1) >= 0.0 ? 1 : -1);
-                        Real fracx = (ccm(ii,j-1,k) || ccm(ii,j,k)) ? amrex::Math::abs(fcy(i,j,k,0)) : 0.0;
-                        Real fracz = (ccm(i,j-1,kk) || ccm(i,j,kk)) ? amrex::Math::abs(fcy(i,j,k,1)) : 0.0;
+                        Real fracx = (ccm(ii,j-1,k) || ccm(ii,j,k)) ? std::abs(fcy(i,j,k,0)) : 0.0;
+                        Real fracz = (ccm(i,j-1,kk) || ccm(i,j,kk)) ? std::abs(fcy(i,j,k,1)) : 0.0;
                         fym_0 = (1.0-fracx)*(1.0-fracz) *fym_0
                             + fracx*(1.0-fracz) * fy(ii,j,k ,0)
                             + fracz*(1.0-fracx) * fy(i ,j,kk,0)
@@ -779,8 +779,8 @@ void mlebtensor_cross_terms (Box const& box, Array4<Real> const& Ax,
                     if (apy(i,j+1,k) > 0.0 && apy(i,j+1,k) < 1.0) {
                         int ii = i + (fcy(i,j+1,k,0) >= 0.0 ? 1 : -1);
                         int kk = k + (fcy(i,j+1,k,1) >= 0.0 ? 1 : -1);
-                        Real fracx = (ccm(ii,j,k) || ccm(ii,j+1,k)) ? amrex::Math::abs(fcy(i,j+1,k,0)) : 0.0;
-                        Real fracz = (ccm(i,j,kk) || ccm(i,j+1,kk)) ? amrex::Math::abs(fcy(i,j+1,k,1)) : 0.0;
+                        Real fracx = (ccm(ii,j,k) || ccm(ii,j+1,k)) ? std::abs(fcy(i,j+1,k,0)) : 0.0;
+                        Real fracz = (ccm(i,j,kk) || ccm(i,j+1,kk)) ? std::abs(fcy(i,j+1,k,1)) : 0.0;
                         fyp_0 = (1.0-fracx)*(1.0-fracz) *  fyp_0
                             + fracx*(1.0-fracz) * fy(ii,j+1,k ,0)
                             + fracz*(1.0-fracx) * fy(i ,j+1,kk,0)
@@ -801,8 +801,8 @@ void mlebtensor_cross_terms (Box const& box, Array4<Real> const& Ax,
                     if (apz(i,j,k) > 0.0 && apz(i,j,k) < 1.0) {
                         int ii = i + (fcz(i,j,k,0) >= 0.0 ? 1 : -1);
                         int jj = j + (fcz(i,j,k,1) >= 0.0 ? 1 : -1);
-                        Real fracx = (ccm(ii,j,k-1) || ccm(ii,j,k)) ? amrex::Math::abs(fcz(i,j,k,0)) : 0.0;
-                        Real fracy = (ccm(i,jj,k-1) || ccm(i,jj,k)) ? amrex::Math::abs(fcz(i,j,k,1)) : 0.0;
+                        Real fracx = (ccm(ii,j,k-1) || ccm(ii,j,k)) ? std::abs(fcz(i,j,k,0)) : 0.0;
+                        Real fracy = (ccm(i,jj,k-1) || ccm(i,jj,k)) ? std::abs(fcz(i,j,k,1)) : 0.0;
                         fzm_0 = (1.0-fracx)*(1.0-fracy) *fzm_0
                             + fracx*(1.0-fracy) * fz(ii,j ,k,0)
                             + fracy*(1.0-fracx) * fz(i ,jj,k,0)
@@ -823,8 +823,8 @@ void mlebtensor_cross_terms (Box const& box, Array4<Real> const& Ax,
                     if (apz(i,j,k+1) > 0.0 && apz(i,j,k+1) < 1.0) {
                         int ii = i + (fcz(i,j,k+1,0) >= 0.0 ? 1 : -1);
                         int jj = j + (fcz(i,j,k+1,1) >= 0.0 ? 1 : -1);
-                        Real fracx = (ccm(ii,j,k) || ccm(ii,j,k)) ? amrex::Math::abs(fcz(i,j,k+1,0)) : 0.0;
-                        Real fracy = (ccm(i,jj,k) || ccm(i,jj,k)) ? amrex::Math::abs(fcz(i,j,k+1,1)) : 0.0;
+                        Real fracx = (ccm(ii,j,k) || ccm(ii,j,k)) ? std::abs(fcz(i,j,k+1,0)) : 0.0;
+                        Real fracy = (ccm(i,jj,k) || ccm(i,jj,k)) ? std::abs(fcz(i,j,k+1,1)) : 0.0;
                         fzp_0 = (1.0-fracx)*(1.0-fracy) *  fzp_0
                             + fracx*(1.0-fracy) * fz(ii,j ,k+1,0)
                             + fracy*(1.0-fracx) * fz(i ,jj,k+1,0)
@@ -863,9 +863,9 @@ void mlebtensor_cross_terms (Box const& box, Array4<Real> const& Ax,
                         }
 
                         Real dx_eb = amrex::max(0.3, (kappa*kappa-0.25)/(2.*kappa));
-                        Real dg = dx_eb / amrex::max(amrex::Math::abs(anrmx),
-                                                     amrex::Math::abs(anrmy),
-                                                     amrex::Math::abs(anrmz));
+                        Real dg = dx_eb / amrex::max(std::abs(anrmx),
+                                                     std::abs(anrmy),
+                                                     std::abs(anrmz));
                         Real dginv = 1.0/dg;
                         Real gx = bc(i,j,k,0) - dg*anrmx;
                         Real gy = bc(i,j,k,1) - dg*anrmy;
@@ -1013,8 +1013,8 @@ void mlebtensor_flux_x (Box const& box, Array4<Real> const& Ax,
 
                 int jj = j + (fcx(i,j,k,0) >= 0.0 ? 1 : -1);
                 int kk = k + (fcx(i,j,k,1) >= 0.0 ? 1 : -1);
-                Real fracy = (ccm(i-1,jj,k) || ccm(i,jj,k)) ? amrex::Math::abs(fcx(i,j,k,0)) : 0.0;
-                Real fracz = (ccm(i-1,j,kk) || ccm(i,j,kk)) ? amrex::Math::abs(fcx(i,j,k,1)) : 0.0;
+                Real fracy = (ccm(i-1,jj,k) || ccm(i,jj,k)) ? std::abs(fcx(i,j,k,0)) : 0.0;
+                Real fracz = (ccm(i-1,j,kk) || ccm(i,j,kk)) ? std::abs(fcx(i,j,k,1)) : 0.0;
                 fxm_0 = (1.0-fracy)*(1.0-fracz) *fxm_0
                         + fracy*(1.0-fracz) * fx(i,jj,k ,0)
                         + fracz*(1.0-fracy) * fx(i,j ,kk,0)
@@ -1058,8 +1058,8 @@ void mlebtensor_flux_y (Box const& box, Array4<Real> const& Ay,
 
                   int ii = i + (fcy(i,j,k,0) >= 0.0 ? 1 : -1);
                   int kk = k + (fcy(i,j,k,1) >= 0.0 ? 1 : -1);
-                  Real fracx = (ccm(ii,j-1,k) || ccm(ii,j,k)) ? amrex::Math::abs(fcy(i,j,k,0)) : 0.0;
-                  Real fracz = (ccm(i,j-1,kk) || ccm(i,j,kk)) ? amrex::Math::abs(fcy(i,j,k,1)) : 0.0;
+                  Real fracx = (ccm(ii,j-1,k) || ccm(ii,j,k)) ? std::abs(fcy(i,j,k,0)) : 0.0;
+                  Real fracz = (ccm(i,j-1,kk) || ccm(i,j,kk)) ? std::abs(fcy(i,j,k,1)) : 0.0;
                   fym_0 = (1.0-fracx)*(1.0-fracz) *fym_0
                           + fracx*(1.0-fracz) * fy(ii,j,k ,0)
                           + fracz*(1.0-fracx) * fy(i ,j,kk,0)
@@ -1105,8 +1105,8 @@ void mlebtensor_flux_z (Box const& box, Array4<Real> const& Az,
 
                   int ii = i + (fcz(i,j,k,0) >= 0.0 ? 1 : -1);
                   int jj = j + (fcz(i,j,k,1) >= 0.0 ? 1 : -1);
-                  Real fracx = (ccm(ii,j,k-1) || ccm(ii,j,k)) ? amrex::Math::abs(fcz(i,j,k,0)) : 0.0;
-                  Real fracy = (ccm(i,jj,k-1) || ccm(i,jj,k)) ? amrex::Math::abs(fcz(i,j,k,1)) : 0.0;
+                  Real fracx = (ccm(ii,j,k-1) || ccm(ii,j,k)) ? std::abs(fcz(i,j,k,0)) : 0.0;
+                  Real fracy = (ccm(i,jj,k-1) || ccm(i,jj,k)) ? std::abs(fcz(i,j,k,1)) : 0.0;
                   fzm_0 = (1.0-fracx)*(1.0-fracy) *fzm_0
                           + fracx*(1.0-fracy) * fz(ii,j ,k,0)
                           + fracy*(1.0-fracx) * fz(i ,jj,k,0)
@@ -1653,8 +1653,8 @@ void mlebtensor_vel_grads_fx (Box const& box, Array4<Real> const& fx,
                     if (apx(i,j,k) < 1.0) {
                         int jj = j + (fcx(i,j,k,0) >= 0.0 ? 1 : -1);
                         int kk = k + (fcx(i,j,k,1) >= 0.0 ? 1 : -1);
-                        Real fracy = (ccm(i-1,jj,k) || ccm(i,jj,k)) ? amrex::Math::abs(fcx(i,j,k,0)) : 0.0;
-                        Real fracz = (ccm(i-1,j,kk) || ccm(i,j,kk)) ? amrex::Math::abs(fcx(i,j,k,1)) : 0.0;
+                        Real fracy = (ccm(i-1,jj,k) || ccm(i,jj,k)) ? std::abs(fcx(i,j,k,0)) : 0.0;
+                        Real fracz = (ccm(i-1,j,kk) || ccm(i,j,kk)) ? std::abs(fcx(i,j,k,1)) : 0.0;
                         dudx = (1.0-fracy)*(1.0-fracz) * dudx
                             + fracy*(1.0-fracz) * (vel(i,jj,k ,0) - vel(i-1,jj,k ,0))*dxi
                             + fracz*(1.0-fracy) * (vel(i,j ,kk,0) - vel(i-1,j ,kk,0))*dxi
@@ -1761,8 +1761,8 @@ void mlebtensor_vel_grads_fy (Box const& box, Array4<Real> const& fy,
                     if (apy(i,j,k) < 1.0) {
                         int ii = i + (fcy(i,j,k,0) >= 0.0 ? 1 : -1);
                         int kk = k + (fcy(i,j,k,1) >= 0.0 ? 1 : -1);
-                        Real fracx = (ccm(ii,j-1,k) || ccm(ii,j,k)) ? amrex::Math::abs(fcy(i,j,k,0)) : 0.0;
-                        Real fracz = (ccm(i,j-1,kk) || ccm(i,j,kk)) ? amrex::Math::abs(fcy(i,j,k,1)) : 0.0;
+                        Real fracx = (ccm(ii,j-1,k) || ccm(ii,j,k)) ? std::abs(fcy(i,j,k,0)) : 0.0;
+                        Real fracz = (ccm(i,j-1,kk) || ccm(i,j,kk)) ? std::abs(fcy(i,j,k,1)) : 0.0;
                         dudy = (1.0-fracx)*(1.0-fracz) * dudy
                             + fracx*(1.0-fracz) * (vel(ii,j,k ,0) - vel(ii,j-1,k ,0))*dyi
                             + fracz*(1.0-fracx) * (vel(i ,j,kk,0) - vel(i ,j-1,kk,0))*dyi
@@ -1869,8 +1869,8 @@ void mlebtensor_vel_grads_fz (Box const& box, Array4<Real> const& fz,
                     if (apz(i,j,k) < 1.0) {
                         int ii = i + (fcz(i,j,k,0) >= 0.0 ? 1 : -1);
                         int jj = j + (fcz(i,j,k,1) >= 0.0 ? 1 : -1);
-                        Real fracx = (ccm(ii,j,k-1) || ccm(ii,j,k)) ? amrex::Math::abs(fcz(i,j,k,0)) : 0.0;
-                        Real fracy = (ccm(i,jj,k-1) || ccm(i,jj,k)) ? amrex::Math::abs(fcz(i,j,k,1)) : 0.0;
+                        Real fracx = (ccm(ii,j,k-1) || ccm(ii,j,k)) ? std::abs(fcz(i,j,k,0)) : 0.0;
+                        Real fracy = (ccm(i,jj,k-1) || ccm(i,jj,k)) ? std::abs(fcz(i,j,k,1)) : 0.0;
                         dudz = (1.0-fracx)*(1.0-fracy) * dudz
                             + fracx*(1.0-fracy) * (vel(ii,j ,k,0) - vel(ii,j ,k-1,0))*dzi
                             + fracy*(1.0-fracx) * (vel(i ,jj,k,0) - vel(i ,jj,k-1,0))*dzi
@@ -1944,8 +1944,8 @@ void mlebtensor_vel_grads_fx (Box const& box, Array4<Real> const& fx,
                     if (apx(i,j,k) < 1.0) {
                         int jj = j + (fcx(i,j,k,0) >= 0.0 ? 1 : -1);
                         int kk = k + (fcx(i,j,k,1) >= 0.0 ? 1 : -1);
-                        Real fracy = (ccm(i-1,jj,k) || ccm(i,jj,k)) ? amrex::Math::abs(fcx(i,j,k,0)) : 0.0;
-                        Real fracz = (ccm(i-1,j,kk) || ccm(i,j,kk)) ? amrex::Math::abs(fcx(i,j,k,1)) : 0.0;
+                        Real fracy = (ccm(i-1,jj,k) || ccm(i,jj,k)) ? std::abs(fcx(i,j,k,0)) : 0.0;
+                        Real fracz = (ccm(i-1,j,kk) || ccm(i,j,kk)) ? std::abs(fcx(i,j,k,1)) : 0.0;
                         dudx = (1.0-fracy)*(1.0-fracz) * dudx
                             + fracy*(1.0-fracz) * (vel(i,jj,k ,0) - vel(i-1,jj,k ,0))*dxi
                             + fracz*(1.0-fracy) * (vel(i,j ,kk,0) - vel(i-1,j ,kk,0))*dxi
@@ -2067,8 +2067,8 @@ void mlebtensor_vel_grads_fy (Box const& box, Array4<Real> const& fy,
                     if (apy(i,j,k) < 1.0) {
                         int ii = i + (fcy(i,j,k,0) >= 0.0 ? 1 : -1);
                         int kk = k + (fcy(i,j,k,1) >= 0.0 ? 1 : -1);
-                        Real fracx = (ccm(ii,j-1,k) || ccm(ii,j,k)) ? amrex::Math::abs(fcy(i,j,k,0)) : 0.0;
-                        Real fracz = (ccm(i,j-1,kk) || ccm(i,j,kk)) ? amrex::Math::abs(fcy(i,j,k,1)) : 0.0;
+                        Real fracx = (ccm(ii,j-1,k) || ccm(ii,j,k)) ? std::abs(fcy(i,j,k,0)) : 0.0;
+                        Real fracz = (ccm(i,j-1,kk) || ccm(i,j,kk)) ? std::abs(fcy(i,j,k,1)) : 0.0;
                         dudy = (1.0-fracx)*(1.0-fracz) * dudy
                             + fracx*(1.0-fracz) * (vel(ii,j,k ,0) - vel(ii,j-1,k ,0))*dyi
                             + fracz*(1.0-fracx) * (vel(i ,j,kk,0) - vel(i ,j-1,kk,0))*dyi
@@ -2190,8 +2190,8 @@ void mlebtensor_vel_grads_fz (Box const& box, Array4<Real> const& fz,
                     if (apz(i,j,k) < 1.0) {
                         int ii = i + (fcz(i,j,k,0) >= 0.0 ? 1 : -1);
                         int jj = j + (fcz(i,j,k,1) >= 0.0 ? 1 : -1);
-                        Real fracx = (ccm(ii,j,k-1) || ccm(ii,j,k)) ? amrex::Math::abs(fcz(i,j,k,0)) : 0.0;
-                        Real fracy = (ccm(i,jj,k-1) || ccm(i,jj,k)) ? amrex::Math::abs(fcz(i,j,k,1)) : 0.0;
+                        Real fracx = (ccm(ii,j,k-1) || ccm(ii,j,k)) ? std::abs(fcz(i,j,k,0)) : 0.0;
+                        Real fracy = (ccm(i,jj,k-1) || ccm(i,jj,k)) ? std::abs(fcz(i,j,k,1)) : 0.0;
                         dudz = (1.0-fracx)*(1.0-fracy) * dudz
                             + fracx*(1.0-fracy) * (vel(ii,j ,k,0) - vel(ii,j ,k-1,0))*dzi
                             + fracy*(1.0-fracx) * (vel(i ,jj,k,0) - vel(i ,jj,k-1,0))*dzi

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLap_2D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLap_2D_K.H
@@ -829,9 +829,9 @@ void mlndlap_restriction (int i, int j, int k, Array4<Real> const& crse,
         const auto ndhi = amrex::ubound(fdom);
         Real tmp = Real(0.0);
         for (int joff = -rr+1; joff <= rr-1; ++joff) {
-            Real wy = rr - amrex::Math::abs(joff);
+            Real wy = rr - std::abs(joff);
             for (int ioff = -rr+1; ioff <= rr-1; ++ioff) {
-                Real wx = rr - amrex::Math::abs(ioff);
+                Real wx = rr - std::abs(ioff);
                 int itmp = ii + ioff;
                 int jtmp = jj + joff;
                 if ((itmp < ndlo.x && (bclo[0] == LinOpBCType::Neumann ||
@@ -1191,8 +1191,8 @@ void mlndlap_divu_fine_contrib (int i, int j, int /*k*/, Box const& fvbx, Box co
 
         for (int joff = jlo; joff <= jhi; ++joff) {
         for (int ioff = ilo; ioff <= ihi; ++ioff) {
-            Real scale = static_cast<Real>((rr-amrex::Math::abs(ii-ioff)) *
-                                           (rr-amrex::Math::abs(jj-joff)));
+            Real scale = static_cast<Real>((rr-std::abs(ii-ioff)) *
+                                           (rr-std::abs(jj-joff)));
             if (fvbx.strictly_contains(ioff,joff,0)) {
                 Df += scale * frhs(ioff,joff,0);
             } else {
@@ -1224,8 +1224,8 @@ void mlndlap_rhcc_fine_contrib (int i, int j, int, Box const& ccbx,
 
         for (int joff = jlo; joff <= jhi; ++joff) {
         for (int ioff = ilo; ioff <= ihi; ++ioff) {
-            Real scale = (static_cast<Real>(rr)-amrex::Math::abs(static_cast<Real>(ioff-ii)+Real(0.5)))
-                *        (static_cast<Real>(rr)-amrex::Math::abs(static_cast<Real>(joff-jj)+Real(0.5)));
+            Real scale = (static_cast<Real>(rr)-std::abs(static_cast<Real>(ioff-ii)+Real(0.5)))
+                *        (static_cast<Real>(rr)-std::abs(static_cast<Real>(joff-jj)+Real(0.5)));
             tmp += cc(ioff,joff,0) * scale;
         }}
 
@@ -1438,8 +1438,8 @@ namespace {
 
             for (int joff = jlo; joff <= jhi; ++joff) {
             for (int ioff = ilo; ioff <= ihi; ++ioff) {
-                Real scale = static_cast<Real>((rr-amrex::Math::abs(ii-ioff)) *
-                                               (rr-amrex::Math::abs(jj-joff)));
+                Real scale = static_cast<Real>((rr-std::abs(ii-ioff)) *
+                                               (rr-std::abs(jj-joff)));
                 if (ndbx.strictly_contains(ioff,joff,0)) {
                     Df += scale * (rhs(ioff,joff,0)-res(ioff,joff,0));
                 } else {
@@ -1579,10 +1579,10 @@ void mlndlap_set_stencil_s0 (int i, int j, int k, Array4<Real> const& sten) noex
                     + sten(i  ,j-1,k,2) + sten(i  ,j  ,k,2)
                     + sten(i-1,j-1,k,3) + sten(i  ,j-1,k,3)
                     + sten(i-1,j  ,k,3) + sten(i  ,j  ,k,3));
-    sten(i,j,k,4) = Real(1.0) / (amrex::Math::abs(sten(i-1,j  ,k,1)) + amrex::Math::abs(sten(i,j  ,k,1))
-                               + amrex::Math::abs(sten(i  ,j-1,k,2)) + amrex::Math::abs(sten(i,j  ,k,2))
-                               + amrex::Math::abs(sten(i-1,j-1,k,3)) + amrex::Math::abs(sten(i,j-1,k,3))
-                               + amrex::Math::abs(sten(i-1,j  ,k,3)) + amrex::Math::abs(sten(i,j  ,k,3)) + eps);
+    sten(i,j,k,4) = Real(1.0) / (std::abs(sten(i-1,j  ,k,1)) + std::abs(sten(i,j  ,k,1))
+                               + std::abs(sten(i  ,j-1,k,2)) + std::abs(sten(i,j  ,k,2))
+                               + std::abs(sten(i-1,j-1,k,3)) + std::abs(sten(i,j-1,k,3))
+                               + std::abs(sten(i-1,j  ,k,3)) + std::abs(sten(i,j  ,k,3)) + eps);
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
@@ -1593,48 +1593,48 @@ void mlndlap_stencil_rap (int i, int j, int, Array4<Real> const& csten,
 
 #if 0
     auto interp_from_mm_to = [&fsten] (int i_, int j_) -> Real {
-        Real wxm = amrex::Math::abs(fsten(i_-1,j_  ,0,1))/(amrex::Math::abs(fsten(i_-1,j_-1,0,3))+amrex::Math::abs(fsten(i_-1,j_  ,0,3))+eps);
-        Real wym = amrex::Math::abs(fsten(i_  ,j_-1,0,2))/(amrex::Math::abs(fsten(i_-1,j_-1,0,3))+amrex::Math::abs(fsten(i_  ,j_-1,0,3))+eps);
-        Real wmm = amrex::Math::abs(fsten(i_-1,j_-1,0,3)) * (Real(1.) + wxm + wym);
+        Real wxm = std::abs(fsten(i_-1,j_  ,0,1))/(std::abs(fsten(i_-1,j_-1,0,3))+std::abs(fsten(i_-1,j_  ,0,3))+eps);
+        Real wym = std::abs(fsten(i_  ,j_-1,0,2))/(std::abs(fsten(i_-1,j_-1,0,3))+std::abs(fsten(i_  ,j_-1,0,3))+eps);
+        Real wmm = std::abs(fsten(i_-1,j_-1,0,3)) * (Real(1.) + wxm + wym);
         return wmm * fsten(i_,j_,0,4);
     };
 #endif
 
     auto interp_from_mp_to = [&fsten] (int i_, int j_) -> Real {
-        Real wxm = amrex::Math::abs(fsten(i_-1,j_  ,0,1))/(amrex::Math::abs(fsten(i_-1,j_-1,0,3))+amrex::Math::abs(fsten(i_-1,j_  ,0,3))+eps);
-        Real wyp = amrex::Math::abs(fsten(i_  ,j_  ,0,2))/(amrex::Math::abs(fsten(i_-1,j_  ,0,3))+amrex::Math::abs(fsten(i_  ,j_  ,0,3))+eps);
-        Real wmp = amrex::Math::abs(fsten(i_-1,j_  ,0,3)) *(Real(1.) + wxm + wyp);
+        Real wxm = std::abs(fsten(i_-1,j_  ,0,1))/(std::abs(fsten(i_-1,j_-1,0,3))+std::abs(fsten(i_-1,j_  ,0,3))+eps);
+        Real wyp = std::abs(fsten(i_  ,j_  ,0,2))/(std::abs(fsten(i_-1,j_  ,0,3))+std::abs(fsten(i_  ,j_  ,0,3))+eps);
+        Real wmp = std::abs(fsten(i_-1,j_  ,0,3)) *(Real(1.) + wxm + wyp);
         return wmp * fsten(i_,j_,0,4);
     };
 
     auto interp_from_pm_to = [&fsten] (int i_, int j_) -> Real {
-        Real wxp = amrex::Math::abs(fsten(i_  ,j_  ,0,1))/(amrex::Math::abs(fsten(i_  ,j_-1,0,3))+amrex::Math::abs(fsten(i_  ,j_  ,0,3))+eps);
-        Real wym = amrex::Math::abs(fsten(i_  ,j_-1,0,2))/(amrex::Math::abs(fsten(i_-1,j_-1,0,3))+amrex::Math::abs(fsten(i_  ,j_-1,0,3))+eps);
-        Real wpm = amrex::Math::abs(fsten(i_  ,j_-1,0,3)) * (Real(1.) + wxp + wym);
+        Real wxp = std::abs(fsten(i_  ,j_  ,0,1))/(std::abs(fsten(i_  ,j_-1,0,3))+std::abs(fsten(i_  ,j_  ,0,3))+eps);
+        Real wym = std::abs(fsten(i_  ,j_-1,0,2))/(std::abs(fsten(i_-1,j_-1,0,3))+std::abs(fsten(i_  ,j_-1,0,3))+eps);
+        Real wpm = std::abs(fsten(i_  ,j_-1,0,3)) * (Real(1.) + wxp + wym);
         return wpm * fsten(i_,j_,0,4);
     };
 
     auto interp_from_pp_to = [&fsten] (int i_, int j_) -> Real {
-        Real wxp = amrex::Math::abs(fsten(i_  ,j_  ,0,1))/(amrex::Math::abs(fsten(i_  ,j_-1,0,3))+amrex::Math::abs(fsten(i_  ,j_  ,0,3))+eps);
-        Real wyp = amrex::Math::abs(fsten(i_  ,j_  ,0,2))/(amrex::Math::abs(fsten(i_-1,j_  ,0,3))+amrex::Math::abs(fsten(i_  ,j_  ,0,3))+eps);
-        Real wpp = amrex::Math::abs(fsten(i_  ,j_  ,0,3)) * (Real(1.) + wxp + wyp);
+        Real wxp = std::abs(fsten(i_  ,j_  ,0,1))/(std::abs(fsten(i_  ,j_-1,0,3))+std::abs(fsten(i_  ,j_  ,0,3))+eps);
+        Real wyp = std::abs(fsten(i_  ,j_  ,0,2))/(std::abs(fsten(i_-1,j_  ,0,3))+std::abs(fsten(i_  ,j_  ,0,3))+eps);
+        Real wpp = std::abs(fsten(i_  ,j_  ,0,3)) * (Real(1.) + wxp + wyp);
         return wpp * fsten(i_,j_,0,4);
     };
 
     auto interp_from_m0_to = [&fsten] (int i_, int j_) -> Real {
-        return amrex::Math::abs(fsten(i_-1,j_,0,1))/(amrex::Math::abs(fsten(i_-1,j_,0,1))+amrex::Math::abs(fsten(i_,j_,0,1))+eps);
+        return std::abs(fsten(i_-1,j_,0,1))/(std::abs(fsten(i_-1,j_,0,1))+std::abs(fsten(i_,j_,0,1))+eps);
     };
 
     auto interp_from_p0_to = [&fsten] (int i_, int j_) -> Real {
-        return amrex::Math::abs(fsten(i_,j_,0,1))/(amrex::Math::abs(fsten(i_-1,j_,0,1))+amrex::Math::abs(fsten(i_,j_,0,1))+eps);
+        return std::abs(fsten(i_,j_,0,1))/(std::abs(fsten(i_-1,j_,0,1))+std::abs(fsten(i_,j_,0,1))+eps);
     };
 
     auto interp_from_0m_to = [&fsten] (int i_, int j_) -> Real {
-        return amrex::Math::abs(fsten(i_,j_-1,0,2))/(amrex::Math::abs(fsten(i_,j_-1,0,2))+amrex::Math::abs(fsten(i_,j_,0,2))+eps);
+        return std::abs(fsten(i_,j_-1,0,2))/(std::abs(fsten(i_,j_-1,0,2))+std::abs(fsten(i_,j_,0,2))+eps);
     };
 
     auto interp_from_0p_to = [&fsten] (int i_, int j_) -> Real {
-        return amrex::Math::abs(fsten(i_,j_,0,2))/(amrex::Math::abs(fsten(i_,j_-1,0,2))+amrex::Math::abs(fsten(i_,j_,0,2))+eps);
+        return std::abs(fsten(i_,j_,0,2))/(std::abs(fsten(i_,j_-1,0,2))+std::abs(fsten(i_,j_,0,2))+eps);
     };
 
 #if 0
@@ -1677,47 +1677,47 @@ void mlndlap_stencil_rap (int i, int j, int, Array4<Real> const& csten,
 
 #if 0
     auto restrict_from_mm_to = [&fsten] (int ii_, int jj_) -> Real {
-        Real wxp = amrex::Math::abs(fsten(ii_-1,jj_-1,0,1))/(amrex::Math::abs(fsten(ii_-1,jj_-2,0,3))+amrex::Math::abs(fsten(ii_-1,jj_-1,0,3))+eps);
-        Real wyp = amrex::Math::abs(fsten(ii_-1,jj_-1,0,2))/(amrex::Math::abs(fsten(ii_-2,jj_-1,0,3))+amrex::Math::abs(fsten(ii_-1,jj_-1,0,3))+eps);
-        Real wpp = amrex::Math::abs(fsten(ii_-1,jj_-1,0,3))*(Real(1.)+wxp+wyp);
+        Real wxp = std::abs(fsten(ii_-1,jj_-1,0,1))/(std::abs(fsten(ii_-1,jj_-2,0,3))+std::abs(fsten(ii_-1,jj_-1,0,3))+eps);
+        Real wyp = std::abs(fsten(ii_-1,jj_-1,0,2))/(std::abs(fsten(ii_-2,jj_-1,0,3))+std::abs(fsten(ii_-1,jj_-1,0,3))+eps);
+        Real wpp = std::abs(fsten(ii_-1,jj_-1,0,3))*(Real(1.)+wxp+wyp);
         return wpp * fsten(ii_-1,jj_-1,0,4);
     };
 #endif
 
     auto restrict_from_0m_to = [&fsten] (int ii_, int jj_) -> Real {
-        return amrex::Math::abs(fsten(ii_,jj_-1,0,2))/(amrex::Math::abs(fsten(ii_,jj_-2,0,2))+amrex::Math::abs(fsten(ii_,jj_-1,0,2))+eps);
+        return std::abs(fsten(ii_,jj_-1,0,2))/(std::abs(fsten(ii_,jj_-2,0,2))+std::abs(fsten(ii_,jj_-1,0,2))+eps);
     };
 
     auto restrict_from_pm_to = [&fsten] (int ii_, int jj_) -> Real {
-        Real wxm = amrex::Math::abs(fsten(ii_  ,jj_-1,0,1))/(amrex::Math::abs(fsten(ii_,jj_-2,0,3))+amrex::Math::abs(fsten(ii_  ,jj_-1,0,3))+eps);
-        Real wyp = amrex::Math::abs(fsten(ii_+1,jj_-1,0,2))/(amrex::Math::abs(fsten(ii_,jj_-1,0,3))+amrex::Math::abs(fsten(ii_+1,jj_-1,0,3))+eps);
-        Real wmp = amrex::Math::abs(fsten(ii_  ,jj_-1,0,3)) *(Real(1.) + wxm + wyp);
+        Real wxm = std::abs(fsten(ii_  ,jj_-1,0,1))/(std::abs(fsten(ii_,jj_-2,0,3))+std::abs(fsten(ii_  ,jj_-1,0,3))+eps);
+        Real wyp = std::abs(fsten(ii_+1,jj_-1,0,2))/(std::abs(fsten(ii_,jj_-1,0,3))+std::abs(fsten(ii_+1,jj_-1,0,3))+eps);
+        Real wmp = std::abs(fsten(ii_  ,jj_-1,0,3)) *(Real(1.) + wxm + wyp);
         return wmp * fsten(ii_+1,jj_-1,0,4);
     };
 
     auto restrict_from_m0_to = [&fsten] (int ii_, int jj_) -> Real {
-        return amrex::Math::abs(fsten(ii_-1,jj_,0,1))/(amrex::Math::abs(fsten(ii_-2,jj_,0,1))+amrex::Math::abs(fsten(ii_-1,jj_,0,1))+eps);
+        return std::abs(fsten(ii_-1,jj_,0,1))/(std::abs(fsten(ii_-2,jj_,0,1))+std::abs(fsten(ii_-1,jj_,0,1))+eps);
     };
 
     auto restrict_from_p0_to = [&fsten] (int ii_, int jj_) -> Real {
-        return amrex::Math::abs(fsten(ii_,jj_,0,1))/(amrex::Math::abs(fsten(ii_,jj_,0,1))+amrex::Math::abs(fsten(ii_+1,jj_,0,1))+eps);
+        return std::abs(fsten(ii_,jj_,0,1))/(std::abs(fsten(ii_,jj_,0,1))+std::abs(fsten(ii_+1,jj_,0,1))+eps);
     };
 
     auto restrict_from_mp_to = [&fsten] (int ii_, int jj_) -> Real {
-        Real wxp = amrex::Math::abs(fsten(ii_-1,jj_+1,0,1))/(amrex::Math::abs(fsten(ii_-1,jj_,0,3))+amrex::Math::abs(fsten(ii_-1,jj_+1,0,3))+eps);
-        Real wym = amrex::Math::abs(fsten(ii_-1,jj_  ,0,2))/(amrex::Math::abs(fsten(ii_-2,jj_,0,3))+amrex::Math::abs(fsten(ii_-1,jj_  ,0,3))+eps);
-        Real wpm = amrex::Math::abs(fsten(ii_-1,jj_  ,0,3)) * (Real(1.) + wxp + wym);
+        Real wxp = std::abs(fsten(ii_-1,jj_+1,0,1))/(std::abs(fsten(ii_-1,jj_,0,3))+std::abs(fsten(ii_-1,jj_+1,0,3))+eps);
+        Real wym = std::abs(fsten(ii_-1,jj_  ,0,2))/(std::abs(fsten(ii_-2,jj_,0,3))+std::abs(fsten(ii_-1,jj_  ,0,3))+eps);
+        Real wpm = std::abs(fsten(ii_-1,jj_  ,0,3)) * (Real(1.) + wxp + wym);
         return wpm * fsten(ii_-1,jj_+1,0,4);
     };
 
     auto restrict_from_0p_to = [&fsten] (int ii_, int jj_) -> Real {
-        return amrex::Math::abs(fsten(ii_,jj_,0,2))/(amrex::Math::abs(fsten(ii_,jj_,0,2))+amrex::Math::abs(fsten(ii_,jj_+1,0,2))+eps);
+        return std::abs(fsten(ii_,jj_,0,2))/(std::abs(fsten(ii_,jj_,0,2))+std::abs(fsten(ii_,jj_+1,0,2))+eps);
     };
 
     auto restrict_from_pp_to = [&fsten] (int ii_, int jj_) -> Real {
-        Real wxm = amrex::Math::abs(fsten(ii_  ,jj_+1,0,1))/(amrex::Math::abs(fsten(ii_  ,jj_  ,0,3))+amrex::Math::abs(fsten(ii_  ,jj_+1,0,3))+eps);
-        Real wym = amrex::Math::abs(fsten(ii_+1,jj_  ,0,2))/(amrex::Math::abs(fsten(ii_  ,jj_  ,0,3))+amrex::Math::abs(fsten(ii_+1,jj_  ,0,3))+eps);
-        Real wmm = amrex::Math::abs(fsten(ii_  ,jj_  ,0,3)) * (Real(1.) + wxm + wym);
+        Real wxm = std::abs(fsten(ii_  ,jj_+1,0,1))/(std::abs(fsten(ii_  ,jj_  ,0,3))+std::abs(fsten(ii_  ,jj_+1,0,3))+eps);
+        Real wym = std::abs(fsten(ii_+1,jj_  ,0,2))/(std::abs(fsten(ii_  ,jj_  ,0,3))+std::abs(fsten(ii_+1,jj_  ,0,3))+eps);
+        Real wmm = std::abs(fsten(ii_  ,jj_  ,0,3)) * (Real(1.) + wxm + wym);
         return wmm * fsten(ii_+1,jj_+1,0,4);
     };
 
@@ -1870,26 +1870,26 @@ void mlndlap_interpadd_rap (int i, int j, int, Array4<Real> const& fine,
         if (ieven && jeven) {
             fv = crse(ic,jc,0);
         } else if (ieven) {
-            Real wym = amrex::Math::abs(sten(i,j-1,0,2));
-            Real wyp = amrex::Math::abs(sten(i,j  ,0,2));
+            Real wym = std::abs(sten(i,j-1,0,2));
+            Real wyp = std::abs(sten(i,j  ,0,2));
             fv = (wym*crse(ic,jc,0) + wyp*crse(ic,jc+1,0)) / (wym+wyp+eps);
         } else if (jeven) {
-            Real wxm = amrex::Math::abs(sten(i-1,j,0,1));
-            Real wxp = amrex::Math::abs(sten(i  ,j,0,1));
+            Real wxm = std::abs(sten(i-1,j,0,1));
+            Real wxp = std::abs(sten(i  ,j,0,1));
             fv = (wxm*crse(ic,jc,0) + wxp*crse(ic+1,jc,0)) / (wxm+wxp+eps);
         } else {
-            Real wxm = amrex::Math::abs(sten(i-1,j  ,0,1)) /
-                (amrex::Math::abs(sten(i-1,j-1,0,3))+amrex::Math::abs(sten(i-1,j  ,0,3))+eps);
-            Real wxp = amrex::Math::abs(sten(i  ,j  ,0,1)) /
-                (amrex::Math::abs(sten(i  ,j-1,0,3))+amrex::Math::abs(sten(i  ,j  ,0,3))+eps);
-            Real wym = amrex::Math::abs(sten(i  ,j-1,0,2)) /
-                (amrex::Math::abs(sten(i-1,j-1,0,3))+amrex::Math::abs(sten(i  ,j-1,0,3))+eps);
-            Real wyp = amrex::Math::abs(sten(i  ,j  ,0,2)) /
-                (amrex::Math::abs(sten(i-1,j  ,0,3))+amrex::Math::abs(sten(i  ,j  ,0,3))+eps);
-            Real wmm = amrex::Math::abs(sten(i-1,j-1,0,3)) * (Real(1.0) + wxm + wym);
-            Real wpm = amrex::Math::abs(sten(i,j-1,0,3)) * (Real(1.0) + wxp + wym);
-            Real wmp = amrex::Math::abs(sten(i-1,j,0,3)) *(Real(1.0) + wxm + wyp);
-            Real wpp = amrex::Math::abs(sten(i,j,0,3)) * (Real(1.0) + wxp + wyp);
+            Real wxm = std::abs(sten(i-1,j  ,0,1)) /
+                (std::abs(sten(i-1,j-1,0,3))+std::abs(sten(i-1,j  ,0,3))+eps);
+            Real wxp = std::abs(sten(i  ,j  ,0,1)) /
+                (std::abs(sten(i  ,j-1,0,3))+std::abs(sten(i  ,j  ,0,3))+eps);
+            Real wym = std::abs(sten(i  ,j-1,0,2)) /
+                (std::abs(sten(i-1,j-1,0,3))+std::abs(sten(i  ,j-1,0,3))+eps);
+            Real wyp = std::abs(sten(i  ,j  ,0,2)) /
+                (std::abs(sten(i-1,j  ,0,3))+std::abs(sten(i  ,j  ,0,3))+eps);
+            Real wmm = std::abs(sten(i-1,j-1,0,3)) * (Real(1.0) + wxm + wym);
+            Real wpm = std::abs(sten(i,j-1,0,3)) * (Real(1.0) + wxp + wym);
+            Real wmp = std::abs(sten(i-1,j,0,3)) *(Real(1.0) + wxm + wyp);
+            Real wpp = std::abs(sten(i,j,0,3)) * (Real(1.0) + wxp + wyp);
             fv = (wmm*crse(ic,jc,0) + wpm*crse(ic+1,jc,0)
                   + wmp*crse(ic,jc+1,0) + wpp*crse(ic+1,jc+1,0))
                 / (wmm+wpm+wmp+wpp+eps);
@@ -1911,53 +1911,53 @@ void mlndlap_restriction_rap (int i, int j, int /*k*/, Array4<Real> const& crse,
     } else {
 
         Real cv = fine(ii,jj,0)
-            + fine(ii-1,jj  ,0)*amrex::Math::abs(sten(ii-1,jj  ,0,1))
-            /                  (amrex::Math::abs(sten(ii-2,jj  ,0,1))
-                               +amrex::Math::abs(sten(ii-1,jj  ,0,1))+eps)
-            + fine(ii+1,jj  ,0)*amrex::Math::abs(sten(ii  ,jj  ,0,1))
-            /                  (amrex::Math::abs(sten(ii  ,jj  ,0,1))
-                               +amrex::Math::abs(sten(ii+1,jj  ,0,1))+eps)
-            + fine(ii  ,jj-1,0)*amrex::Math::abs(sten(ii  ,jj-1,0,2))
-            /                  (amrex::Math::abs(sten(ii  ,jj-2,0,2))
-                               +amrex::Math::abs(sten(ii  ,jj-1,0,2))+eps)
-            + fine(ii  ,jj+1,0)*amrex::Math::abs(sten(ii  ,jj  ,0,2))
-            /                  (amrex::Math::abs(sten(ii  ,jj  ,0,2))
-                               +amrex::Math::abs(sten(ii  ,jj+1,0,2))+eps);
+            + fine(ii-1,jj  ,0)*std::abs(sten(ii-1,jj  ,0,1))
+            /                  (std::abs(sten(ii-2,jj  ,0,1))
+                               +std::abs(sten(ii-1,jj  ,0,1))+eps)
+            + fine(ii+1,jj  ,0)*std::abs(sten(ii  ,jj  ,0,1))
+            /                  (std::abs(sten(ii  ,jj  ,0,1))
+                               +std::abs(sten(ii+1,jj  ,0,1))+eps)
+            + fine(ii  ,jj-1,0)*std::abs(sten(ii  ,jj-1,0,2))
+            /                  (std::abs(sten(ii  ,jj-2,0,2))
+                               +std::abs(sten(ii  ,jj-1,0,2))+eps)
+            + fine(ii  ,jj+1,0)*std::abs(sten(ii  ,jj  ,0,2))
+            /                  (std::abs(sten(ii  ,jj  ,0,2))
+                               +std::abs(sten(ii  ,jj+1,0,2))+eps);
 
-        Real wxp = amrex::Math::abs(sten(ii-1,jj-1,0,1))
-            /     (amrex::Math::abs(sten(ii-1,jj-2,0,3))
-                  +amrex::Math::abs(sten(ii-1,jj-1,0,3))+eps);
-        Real wyp = amrex::Math::abs(sten(ii-1,jj-1,0,2))
-            /     (amrex::Math::abs(sten(ii-2,jj-1,0,3))
-                  +amrex::Math::abs(sten(ii-1,jj-1,0,3))+eps);
-        Real wpp = amrex::Math::abs(sten(ii-1,jj-1,0,3))*(Real(1.0) + wxp + wyp);
+        Real wxp = std::abs(sten(ii-1,jj-1,0,1))
+            /     (std::abs(sten(ii-1,jj-2,0,3))
+                  +std::abs(sten(ii-1,jj-1,0,3))+eps);
+        Real wyp = std::abs(sten(ii-1,jj-1,0,2))
+            /     (std::abs(sten(ii-2,jj-1,0,3))
+                  +std::abs(sten(ii-1,jj-1,0,3))+eps);
+        Real wpp = std::abs(sten(ii-1,jj-1,0,3))*(Real(1.0) + wxp + wyp);
         cv +=           wpp*sten(ii-1,jj-1,0,4)*fine(ii-1,jj-1,0);
 
-        Real wxm = amrex::Math::abs(sten(ii  ,jj-1,0,1))
-            /     (amrex::Math::abs(sten(ii  ,jj-2,0,3))
-                  +amrex::Math::abs(sten(ii  ,jj-1,0,3))+eps);
-        wyp      = amrex::Math::abs(sten(ii+1,jj-1,0,2))
-            /     (amrex::Math::abs(sten(ii  ,jj-1,0,3))
-                  +amrex::Math::abs(sten(ii+1,jj-1,0,3))+eps);
-        Real wmp = amrex::Math::abs(sten(ii  ,jj-1,0,3))*(Real(1.0) + wxm + wyp);
+        Real wxm = std::abs(sten(ii  ,jj-1,0,1))
+            /     (std::abs(sten(ii  ,jj-2,0,3))
+                  +std::abs(sten(ii  ,jj-1,0,3))+eps);
+        wyp      = std::abs(sten(ii+1,jj-1,0,2))
+            /     (std::abs(sten(ii  ,jj-1,0,3))
+                  +std::abs(sten(ii+1,jj-1,0,3))+eps);
+        Real wmp = std::abs(sten(ii  ,jj-1,0,3))*(Real(1.0) + wxm + wyp);
         cv +=           wmp*sten(ii+1,jj-1,0,4)*fine(ii+1,jj-1,0);
 
-        wxp      = amrex::Math::abs(sten(ii-1,jj+1,0,1))
-            /     (amrex::Math::abs(sten(ii-1,jj  ,0,3))
-                  +amrex::Math::abs(sten(ii-1,jj+1,0,3))+eps);
-        Real wym = amrex::Math::abs(sten(ii-1,jj  ,0,2))
-            /     (amrex::Math::abs(sten(ii-2,jj  ,0,3))
-                  +amrex::Math::abs(sten(ii-1,jj  ,0,3))+eps);
-        Real wpm = amrex::Math::abs(sten(ii-1,jj  ,0,3)) * (Real(1.0) + wxp + wym);
+        wxp      = std::abs(sten(ii-1,jj+1,0,1))
+            /     (std::abs(sten(ii-1,jj  ,0,3))
+                  +std::abs(sten(ii-1,jj+1,0,3))+eps);
+        Real wym = std::abs(sten(ii-1,jj  ,0,2))
+            /     (std::abs(sten(ii-2,jj  ,0,3))
+                  +std::abs(sten(ii-1,jj  ,0,3))+eps);
+        Real wpm = std::abs(sten(ii-1,jj  ,0,3)) * (Real(1.0) + wxp + wym);
         cv +=           wpm*sten(ii-1,jj+1,0,4)*fine(ii-1,jj+1,0);
 
-        wxm      = amrex::Math::abs(sten(ii  ,jj+1,0,1))
-            /     (amrex::Math::abs(sten(ii  ,jj  ,0,3))
-                  +amrex::Math::abs(sten(ii  ,jj+1,0,3))+eps);
-        wym      = amrex::Math::abs(sten(ii+1,jj  ,0,2))
-            /     (amrex::Math::abs(sten(ii  ,jj  ,0,3))
-                  +amrex::Math::abs(sten(ii+1,jj  ,0,3))+eps);
-        Real wmm = amrex::Math::abs(sten(ii  ,jj  ,0,3)) * (Real(1.0) + wxm + wym);
+        wxm      = std::abs(sten(ii  ,jj+1,0,1))
+            /     (std::abs(sten(ii  ,jj  ,0,3))
+                  +std::abs(sten(ii  ,jj+1,0,3))+eps);
+        wym      = std::abs(sten(ii+1,jj  ,0,2))
+            /     (std::abs(sten(ii  ,jj  ,0,3))
+                  +std::abs(sten(ii+1,jj  ,0,3))+eps);
+        Real wmm = std::abs(sten(ii  ,jj  ,0,3)) * (Real(1.0) + wxm + wym);
         cv +=           wmm*sten(ii+1,jj+1,0,4)*fine(ii+1,jj+1,0);
 
         crse(i,j,0) = cv * Real(0.25);
@@ -2221,14 +2221,14 @@ void mlndlap_set_integral_eb (int i, int j, int, Array4<Real> const& intg,
             Real xmin4 = xmin3*xmin;
             Real xmax3 = xmax*xmax*xmax;
             Real xmax4 = xmax3*xmax;
-            Sx  = Real(1./8.) *(axp-axm) + (anrmx/amrex::Math::abs(anrmy))*Real(1./6.) *(xmax3-xmin3);
-            Sx2 = Real(1./24.)*(axp+axm) + (anrmx/amrex::Math::abs(anrmy))*Real(1./12.)*(xmax4-xmin4);
+            Sx  = Real(1./8.) *(axp-axm) + (anrmx/std::abs(anrmy))*Real(1./6.) *(xmax3-xmin3);
+            Sx2 = Real(1./24.)*(axp+axm) + (anrmx/std::abs(anrmy))*Real(1./12.)*(xmax4-xmin4);
 
             Real kk = -anrmx/anrmy;
             Real bb = bcy-kk*bcx;
             Sxy = Real(1./8.)*kk*kk*(xmax4-xmin4) + Real(1./3.)*kk*bb*(xmax3-xmin3)
                 + (Real(0.25)*bb*bb-Real(1./16.))*(xmax*xmax-xmin*xmin);
-            Sxy = amrex::Math::copysign(Sxy, anrmy);
+            Sxy = std::copysign(Sxy, anrmy);
         }
 
         if (std::abs(anrmy) <= almostzero) {
@@ -2250,8 +2250,8 @@ void mlndlap_set_integral_eb (int i, int j, int, Array4<Real> const& intg,
             Real ymin4 = ymin3*ymin;
             Real ymax3 = ymax*ymax*ymax;
             Real ymax4 = ymax3*ymax;
-            Sy  = Real(1./8.) *(ayp-aym) + (anrmy/amrex::Math::abs(anrmx))*Real(1./6.) *(ymax3-ymin3);
-            Sy2 = Real(1./24.)*(ayp+aym) + (anrmy/amrex::Math::abs(anrmx))*Real(1./12.)*(ymax4-ymin4);
+            Sy  = Real(1./8.) *(ayp-aym) + (anrmy/std::abs(anrmx))*Real(1./6.) *(ymax3-ymin3);
+            Sy2 = Real(1./24.)*(ayp+aym) + (anrmy/std::abs(anrmx))*Real(1./12.)*(ymax4-ymin4);
         }
 
         intg(i,j,0,i_S_x ) = Sx;

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLap_3D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLap_3D_K.H
@@ -1632,11 +1632,11 @@ void mlndlap_restriction (int i, int j, int k, Array4<Real> const& crse,
         const auto ndhi = amrex::ubound(fdom);
         Real tmp = Real(0.0);
         for (int koff = -rr+1; koff <= rr-1; ++koff) {
-            Real wz = rr - amrex::Math::abs(koff);
+            Real wz = rr - std::abs(koff);
             for (int joff = -rr+1; joff <= rr-1; ++joff) {
-                Real wy = rr - amrex::Math::abs(joff);
+                Real wy = rr - std::abs(joff);
                 for (int ioff = -rr+1; ioff <= rr-1; ++ioff) {
-                    Real wx = rr - amrex::Math::abs(ioff);
+                    Real wx = rr - std::abs(ioff);
                     int itmp = ii + ioff;
                     int jtmp = jj + joff;
                     int ktmp = kk + koff;
@@ -2243,9 +2243,9 @@ void mlndlap_divu_fine_contrib (int i, int j, int k, Box const& fvbx, Box const&
         for (int koff = klo; koff <= khi; ++koff) {
         for (int joff = jlo; joff <= jhi; ++joff) {
         for (int ioff = ilo; ioff <= ihi; ++ioff) {
-            Real scale = static_cast<Real>((rr-amrex::Math::abs(ii-ioff)) *
-                                           (rr-amrex::Math::abs(jj-joff)) *
-                                           (rr-amrex::Math::abs(kk-koff)));
+            Real scale = static_cast<Real>((rr-std::abs(ii-ioff)) *
+                                           (rr-std::abs(jj-joff)) *
+                                           (rr-std::abs(kk-koff)));
             if (fvbx.strictly_contains(ioff,joff,koff)) {
                 Df += scale * frhs(ioff,joff,koff);
             } else {
@@ -2281,9 +2281,9 @@ void mlndlap_rhcc_fine_contrib (int i, int j, int k, Box const& ccbx,
         for (int koff = klo; koff <= khi; ++koff) {
         for (int joff = jlo; joff <= jhi; ++joff) {
         for (int ioff = ilo; ioff <= ihi; ++ioff) {
-            Real scale = (static_cast<Real>(rr)-amrex::Math::abs(static_cast<Real>(ioff-ii)+Real(0.5)))
-                *        (static_cast<Real>(rr)-amrex::Math::abs(static_cast<Real>(joff-jj)+Real(0.5)))
-                *        (static_cast<Real>(rr)-amrex::Math::abs(static_cast<Real>(koff-kk)+Real(0.5)));
+            Real scale = (static_cast<Real>(rr)-std::abs(static_cast<Real>(ioff-ii)+Real(0.5)))
+                *        (static_cast<Real>(rr)-std::abs(static_cast<Real>(joff-jj)+Real(0.5)))
+                *        (static_cast<Real>(rr)-std::abs(static_cast<Real>(koff-kk)+Real(0.5)));
             tmp += cc(ioff,joff,koff) * scale;
         }}}
 
@@ -2630,9 +2630,9 @@ namespace {
             for (int koff = klo; koff <= khi; ++koff) {
             for (int joff = jlo; joff <= jhi; ++joff) {
             for (int ioff = ilo; ioff <= ihi; ++ioff) {
-                Real scale = static_cast<Real>((rr-amrex::Math::abs(ii-ioff)) *
-                                               (rr-amrex::Math::abs(jj-joff)) *
-                                               (rr-amrex::Math::abs(kk-koff)));
+                Real scale = static_cast<Real>((rr-std::abs(ii-ioff)) *
+                                               (rr-std::abs(jj-joff)) *
+                                               (rr-std::abs(kk-koff)));
                 if (ndbx.strictly_contains(ioff,joff,koff)) {
                     Df += scale * (rhs(ioff,joff,koff)-res(ioff,joff,koff));
                 } else {
@@ -2835,19 +2835,19 @@ void mlndlap_set_stencil_s0 (int i, int j, int k, Array4<Real> const& sten) noex
                           + sten(i-1,j-1,k,ist_ppp) + sten(i,j-1,k,ist_ppp)
                           + sten(i-1,j,k,ist_ppp) + sten(i,j,k,ist_ppp));
     sten(i,j,k,ist_inv) = Real(1.0) /
-        (  amrex::Math::abs(sten(i-1,j,k,ist_p00)) + amrex::Math::abs(sten(i,j,k,ist_p00))
-         + amrex::Math::abs(sten(i,j-1,k,ist_0p0)) + amrex::Math::abs(sten(i,j,k,ist_0p0))
-         + amrex::Math::abs(sten(i,j,k-1,ist_00p)) + amrex::Math::abs(sten(i,j,k,ist_00p))
-         + amrex::Math::abs(sten(i-1,j-1,k,ist_pp0)) + amrex::Math::abs(sten(i,j-1,k,ist_pp0))
-         + amrex::Math::abs(sten(i-1,j,k,ist_pp0)) + amrex::Math::abs(sten(i,j,k,ist_pp0))
-         + amrex::Math::abs(sten(i-1,j,k-1,ist_p0p)) + amrex::Math::abs(sten(i,j,k-1,ist_p0p))
-         + amrex::Math::abs(sten(i-1,j,k,ist_p0p)) + amrex::Math::abs(sten(i,j,k,ist_p0p))
-         + amrex::Math::abs(sten(i,j-1,k-1,ist_0pp)) + amrex::Math::abs(sten(i,j,k-1,ist_0pp))
-         + amrex::Math::abs(sten(i,j-1,k,ist_0pp)) + amrex::Math::abs(sten(i,j,k,ist_0pp))
-         + amrex::Math::abs(sten(i-1,j-1,k-1,ist_ppp)) + amrex::Math::abs(sten(i,j-1,k-1,ist_ppp))
-         + amrex::Math::abs(sten(i-1,j,k-1,ist_ppp)) + amrex::Math::abs(sten(i,j,k-1,ist_ppp))
-         + amrex::Math::abs(sten(i-1,j-1,k,ist_ppp)) + amrex::Math::abs(sten(i,j-1,k,ist_ppp))
-         + amrex::Math::abs(sten(i-1,j,k,ist_ppp)) + amrex::Math::abs(sten(i,j,k,ist_ppp)) + eps);
+        (  std::abs(sten(i-1,j,k,ist_p00)) + std::abs(sten(i,j,k,ist_p00))
+         + std::abs(sten(i,j-1,k,ist_0p0)) + std::abs(sten(i,j,k,ist_0p0))
+         + std::abs(sten(i,j,k-1,ist_00p)) + std::abs(sten(i,j,k,ist_00p))
+         + std::abs(sten(i-1,j-1,k,ist_pp0)) + std::abs(sten(i,j-1,k,ist_pp0))
+         + std::abs(sten(i-1,j,k,ist_pp0)) + std::abs(sten(i,j,k,ist_pp0))
+         + std::abs(sten(i-1,j,k-1,ist_p0p)) + std::abs(sten(i,j,k-1,ist_p0p))
+         + std::abs(sten(i-1,j,k,ist_p0p)) + std::abs(sten(i,j,k,ist_p0p))
+         + std::abs(sten(i,j-1,k-1,ist_0pp)) + std::abs(sten(i,j,k-1,ist_0pp))
+         + std::abs(sten(i,j-1,k,ist_0pp)) + std::abs(sten(i,j,k,ist_0pp))
+         + std::abs(sten(i-1,j-1,k-1,ist_ppp)) + std::abs(sten(i,j-1,k-1,ist_ppp))
+         + std::abs(sten(i-1,j,k-1,ist_ppp)) + std::abs(sten(i,j,k-1,ist_ppp))
+         + std::abs(sten(i-1,j-1,k,ist_ppp)) + std::abs(sten(i,j-1,k,ist_ppp))
+         + std::abs(sten(i-1,j,k,ist_ppp)) + std::abs(sten(i,j,k,ist_ppp)) + eps);
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
@@ -2856,440 +2856,440 @@ void mlndlap_stencil_rap (int i, int j, int k, Array4<Real> const& csten,
 {
     auto interp_from_mmm_to = [&fsten] (int i_, int j_, int k_) -> Real {
         Real p = Real(1.);
-        p += amrex::Math::abs(fsten(i_-1,j_  ,k_  ,ist_p00)) /
-           ( amrex::Math::abs(fsten(i_-1,j_-1,k_-1,ist_ppp))
-           + amrex::Math::abs(fsten(i_-1,j_  ,k_-1,ist_ppp))
-           + amrex::Math::abs(fsten(i_-1,j_-1,k_  ,ist_ppp))
-           + amrex::Math::abs(fsten(i_-1,j_  ,k_  ,ist_ppp)) + eps);
-        p += amrex::Math::abs(fsten(i_  ,j_-1,k_  ,ist_0p0)) /
-           ( amrex::Math::abs(fsten(i_-1,j_-1,k_-1,ist_ppp))
-           + amrex::Math::abs(fsten(i_  ,j_-1,k_-1,ist_ppp))
-           + amrex::Math::abs(fsten(i_-1,j_-1,k_  ,ist_ppp))
-           + amrex::Math::abs(fsten(i_  ,j_-1,k_  ,ist_ppp)) + eps);
-        p += amrex::Math::abs(fsten(i_  ,j_  ,k_-1,ist_00p)) /
-           ( amrex::Math::abs(fsten(i_-1,j_-1,k_-1,ist_ppp))
-           + amrex::Math::abs(fsten(i_  ,j_-1,k_-1,ist_ppp))
-           + amrex::Math::abs(fsten(i_-1,j_  ,k_-1,ist_ppp))
-           + amrex::Math::abs(fsten(i_  ,j_  ,k_-1,ist_ppp)) + eps);
-        p += amrex::Math::abs(fsten(i_-1,j_-1,k_  ,ist_pp0)) /
-           ( amrex::Math::abs(fsten(i_-1,j_-1,k_-1,ist_ppp))
-           + amrex::Math::abs(fsten(i_-1,j_-1,k_  ,ist_ppp)) + eps);
-        p += amrex::Math::abs(fsten(i_-1,j_  ,k_-1,ist_p0p)) /
-           ( amrex::Math::abs(fsten(i_-1,j_-1,k_-1,ist_ppp))
-           + amrex::Math::abs(fsten(i_-1,j_  ,k_-1,ist_ppp)) + eps);
-        p += amrex::Math::abs(fsten(i_  ,j_-1,k_-1,ist_0pp)) /
-           ( amrex::Math::abs(fsten(i_-1,j_-1,k_-1,ist_ppp))
-           + amrex::Math::abs(fsten(i_  ,j_-1,k_-1,ist_ppp)) + eps);
-        p *= amrex::Math::abs(fsten(i_-1,j_-1,k_-1,ist_ppp)) * fsten(i_,j_,k_,ist_inv);
+        p += std::abs(fsten(i_-1,j_  ,k_  ,ist_p00)) /
+           ( std::abs(fsten(i_-1,j_-1,k_-1,ist_ppp))
+           + std::abs(fsten(i_-1,j_  ,k_-1,ist_ppp))
+           + std::abs(fsten(i_-1,j_-1,k_  ,ist_ppp))
+           + std::abs(fsten(i_-1,j_  ,k_  ,ist_ppp)) + eps);
+        p += std::abs(fsten(i_  ,j_-1,k_  ,ist_0p0)) /
+           ( std::abs(fsten(i_-1,j_-1,k_-1,ist_ppp))
+           + std::abs(fsten(i_  ,j_-1,k_-1,ist_ppp))
+           + std::abs(fsten(i_-1,j_-1,k_  ,ist_ppp))
+           + std::abs(fsten(i_  ,j_-1,k_  ,ist_ppp)) + eps);
+        p += std::abs(fsten(i_  ,j_  ,k_-1,ist_00p)) /
+           ( std::abs(fsten(i_-1,j_-1,k_-1,ist_ppp))
+           + std::abs(fsten(i_  ,j_-1,k_-1,ist_ppp))
+           + std::abs(fsten(i_-1,j_  ,k_-1,ist_ppp))
+           + std::abs(fsten(i_  ,j_  ,k_-1,ist_ppp)) + eps);
+        p += std::abs(fsten(i_-1,j_-1,k_  ,ist_pp0)) /
+           ( std::abs(fsten(i_-1,j_-1,k_-1,ist_ppp))
+           + std::abs(fsten(i_-1,j_-1,k_  ,ist_ppp)) + eps);
+        p += std::abs(fsten(i_-1,j_  ,k_-1,ist_p0p)) /
+           ( std::abs(fsten(i_-1,j_-1,k_-1,ist_ppp))
+           + std::abs(fsten(i_-1,j_  ,k_-1,ist_ppp)) + eps);
+        p += std::abs(fsten(i_  ,j_-1,k_-1,ist_0pp)) /
+           ( std::abs(fsten(i_-1,j_-1,k_-1,ist_ppp))
+           + std::abs(fsten(i_  ,j_-1,k_-1,ist_ppp)) + eps);
+        p *= std::abs(fsten(i_-1,j_-1,k_-1,ist_ppp)) * fsten(i_,j_,k_,ist_inv);
         return p;
     };
     amrex::ignore_unused(interp_from_mmm_to);
 
     auto interp_from_pmm_to = [&fsten] (int i_, int j_, int k_) -> Real {
         Real p = Real(1.);
-        p += amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_p00)) /
-           ( amrex::Math::abs(fsten(i_  ,j_-1,k_-1,ist_ppp))
-           + amrex::Math::abs(fsten(i_  ,j_  ,k_-1,ist_ppp))
-           + amrex::Math::abs(fsten(i_  ,j_-1,k_  ,ist_ppp))
-           + amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_ppp)) + eps);
-        p += amrex::Math::abs(fsten(i_  ,j_-1,k_  ,ist_0p0)) /
-           ( amrex::Math::abs(fsten(i_-1,j_-1,k_-1,ist_ppp))
-           + amrex::Math::abs(fsten(i_  ,j_-1,k_-1,ist_ppp))
-           + amrex::Math::abs(fsten(i_-1,j_-1,k_  ,ist_ppp))
-           + amrex::Math::abs(fsten(i_  ,j_-1,k_  ,ist_ppp)) + eps);
-        p += amrex::Math::abs(fsten(i_  ,j_  ,k_-1,ist_00p)) /
-           ( amrex::Math::abs(fsten(i_-1,j_-1,k_-1,ist_ppp))
-           + amrex::Math::abs(fsten(i_  ,j_-1,k_-1,ist_ppp))
-           + amrex::Math::abs(fsten(i_-1,j_  ,k_-1,ist_ppp))
-           + amrex::Math::abs(fsten(i_  ,j_  ,k_-1,ist_ppp)) + eps);
-        p += amrex::Math::abs(fsten(i_  ,j_-1,k_  ,ist_pp0)) /
-           ( amrex::Math::abs(fsten(i_  ,j_-1,k_-1,ist_ppp))
-           + amrex::Math::abs(fsten(i_  ,j_-1,k_  ,ist_ppp)) + eps);
-        p += amrex::Math::abs(fsten(i_  ,j_  ,k_-1,ist_p0p)) /
-           ( amrex::Math::abs(fsten(i_  ,j_-1,k_-1,ist_ppp))
-           + amrex::Math::abs(fsten(i_  ,j_  ,k_-1,ist_ppp)) + eps);
-        p += amrex::Math::abs(fsten(i_  ,j_-1,k_-1,ist_0pp)) /
-           ( amrex::Math::abs(fsten(i_-1,j_-1,k_-1,ist_ppp))
-           + amrex::Math::abs(fsten(i_  ,j_-1,k_-1,ist_ppp)) + eps);
-        p *= amrex::Math::abs(fsten(i_  ,j_-1,k_-1,ist_ppp)) * fsten(i_,j_,k_,ist_inv);
+        p += std::abs(fsten(i_  ,j_  ,k_  ,ist_p00)) /
+           ( std::abs(fsten(i_  ,j_-1,k_-1,ist_ppp))
+           + std::abs(fsten(i_  ,j_  ,k_-1,ist_ppp))
+           + std::abs(fsten(i_  ,j_-1,k_  ,ist_ppp))
+           + std::abs(fsten(i_  ,j_  ,k_  ,ist_ppp)) + eps);
+        p += std::abs(fsten(i_  ,j_-1,k_  ,ist_0p0)) /
+           ( std::abs(fsten(i_-1,j_-1,k_-1,ist_ppp))
+           + std::abs(fsten(i_  ,j_-1,k_-1,ist_ppp))
+           + std::abs(fsten(i_-1,j_-1,k_  ,ist_ppp))
+           + std::abs(fsten(i_  ,j_-1,k_  ,ist_ppp)) + eps);
+        p += std::abs(fsten(i_  ,j_  ,k_-1,ist_00p)) /
+           ( std::abs(fsten(i_-1,j_-1,k_-1,ist_ppp))
+           + std::abs(fsten(i_  ,j_-1,k_-1,ist_ppp))
+           + std::abs(fsten(i_-1,j_  ,k_-1,ist_ppp))
+           + std::abs(fsten(i_  ,j_  ,k_-1,ist_ppp)) + eps);
+        p += std::abs(fsten(i_  ,j_-1,k_  ,ist_pp0)) /
+           ( std::abs(fsten(i_  ,j_-1,k_-1,ist_ppp))
+           + std::abs(fsten(i_  ,j_-1,k_  ,ist_ppp)) + eps);
+        p += std::abs(fsten(i_  ,j_  ,k_-1,ist_p0p)) /
+           ( std::abs(fsten(i_  ,j_-1,k_-1,ist_ppp))
+           + std::abs(fsten(i_  ,j_  ,k_-1,ist_ppp)) + eps);
+        p += std::abs(fsten(i_  ,j_-1,k_-1,ist_0pp)) /
+           ( std::abs(fsten(i_-1,j_-1,k_-1,ist_ppp))
+           + std::abs(fsten(i_  ,j_-1,k_-1,ist_ppp)) + eps);
+        p *= std::abs(fsten(i_  ,j_-1,k_-1,ist_ppp)) * fsten(i_,j_,k_,ist_inv);
         return p;
     };
 
     auto interp_from_mpm_to = [&fsten] (int i_, int j_, int k_) -> Real {
         Real p = Real(1.);
-        p += amrex::Math::abs(fsten(i_-1,j_  ,k_  ,ist_p00)) /
-           ( amrex::Math::abs(fsten(i_-1,j_-1,k_-1,ist_ppp))
-           + amrex::Math::abs(fsten(i_-1,j_  ,k_-1,ist_ppp))
-           + amrex::Math::abs(fsten(i_-1,j_-1,k_  ,ist_ppp))
-           + amrex::Math::abs(fsten(i_-1,j_  ,k_  ,ist_ppp)) + eps);
-        p += amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_0p0)) /
-           ( amrex::Math::abs(fsten(i_-1,j_  ,k_-1,ist_ppp))
-           + amrex::Math::abs(fsten(i_  ,j_  ,k_-1,ist_ppp))
-           + amrex::Math::abs(fsten(i_-1,j_  ,k_  ,ist_ppp))
-           + amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_ppp)) + eps);
-        p += amrex::Math::abs(fsten(i_  ,j_  ,k_-1,ist_00p)) /
-           ( amrex::Math::abs(fsten(i_-1,j_-1,k_-1,ist_ppp))
-           + amrex::Math::abs(fsten(i_  ,j_-1,k_-1,ist_ppp))
-           + amrex::Math::abs(fsten(i_-1,j_  ,k_-1,ist_ppp))
-           + amrex::Math::abs(fsten(i_  ,j_  ,k_-1,ist_ppp)) + eps);
-        p += amrex::Math::abs(fsten(i_-1,j_  ,k_  ,ist_pp0)) /
-           ( amrex::Math::abs(fsten(i_-1,j_  ,k_-1,ist_ppp))
-           + amrex::Math::abs(fsten(i_-1,j_  ,k_  ,ist_ppp)) + eps);
-        p += amrex::Math::abs(fsten(i_-1,j_  ,k_-1,ist_p0p)) /
-           ( amrex::Math::abs(fsten(i_-1,j_-1,k_-1,ist_ppp))
-           + amrex::Math::abs(fsten(i_-1,j_  ,k_-1,ist_ppp)) + eps);
-        p += amrex::Math::abs(fsten(i_  ,j_  ,k_-1,ist_0pp)) /
-           ( amrex::Math::abs(fsten(i_-1,j_  ,k_-1,ist_ppp))
-           + amrex::Math::abs(fsten(i_  ,j_  ,k_-1,ist_ppp)) + eps);
-        p *= amrex::Math::abs(fsten(i_-1,j_  ,k_-1,ist_ppp)) * fsten(i_,j_,k_,ist_inv);
+        p += std::abs(fsten(i_-1,j_  ,k_  ,ist_p00)) /
+           ( std::abs(fsten(i_-1,j_-1,k_-1,ist_ppp))
+           + std::abs(fsten(i_-1,j_  ,k_-1,ist_ppp))
+           + std::abs(fsten(i_-1,j_-1,k_  ,ist_ppp))
+           + std::abs(fsten(i_-1,j_  ,k_  ,ist_ppp)) + eps);
+        p += std::abs(fsten(i_  ,j_  ,k_  ,ist_0p0)) /
+           ( std::abs(fsten(i_-1,j_  ,k_-1,ist_ppp))
+           + std::abs(fsten(i_  ,j_  ,k_-1,ist_ppp))
+           + std::abs(fsten(i_-1,j_  ,k_  ,ist_ppp))
+           + std::abs(fsten(i_  ,j_  ,k_  ,ist_ppp)) + eps);
+        p += std::abs(fsten(i_  ,j_  ,k_-1,ist_00p)) /
+           ( std::abs(fsten(i_-1,j_-1,k_-1,ist_ppp))
+           + std::abs(fsten(i_  ,j_-1,k_-1,ist_ppp))
+           + std::abs(fsten(i_-1,j_  ,k_-1,ist_ppp))
+           + std::abs(fsten(i_  ,j_  ,k_-1,ist_ppp)) + eps);
+        p += std::abs(fsten(i_-1,j_  ,k_  ,ist_pp0)) /
+           ( std::abs(fsten(i_-1,j_  ,k_-1,ist_ppp))
+           + std::abs(fsten(i_-1,j_  ,k_  ,ist_ppp)) + eps);
+        p += std::abs(fsten(i_-1,j_  ,k_-1,ist_p0p)) /
+           ( std::abs(fsten(i_-1,j_-1,k_-1,ist_ppp))
+           + std::abs(fsten(i_-1,j_  ,k_-1,ist_ppp)) + eps);
+        p += std::abs(fsten(i_  ,j_  ,k_-1,ist_0pp)) /
+           ( std::abs(fsten(i_-1,j_  ,k_-1,ist_ppp))
+           + std::abs(fsten(i_  ,j_  ,k_-1,ist_ppp)) + eps);
+        p *= std::abs(fsten(i_-1,j_  ,k_-1,ist_ppp)) * fsten(i_,j_,k_,ist_inv);
         return p;
     };
 
     auto interp_from_ppm_to = [&fsten] (int i_, int j_, int k_) -> Real {
         Real p = Real(1.);
-        p += amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_p00)) /
-           ( amrex::Math::abs(fsten(i_  ,j_-1,k_-1,ist_ppp))
-           + amrex::Math::abs(fsten(i_  ,j_  ,k_-1,ist_ppp))
-           + amrex::Math::abs(fsten(i_  ,j_-1,k_  ,ist_ppp))
-           + amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_ppp)) + eps);
-        p += amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_0p0)) /
-           ( amrex::Math::abs(fsten(i_-1,j_  ,k_-1,ist_ppp))
-           + amrex::Math::abs(fsten(i_  ,j_  ,k_-1,ist_ppp))
-           + amrex::Math::abs(fsten(i_-1,j_  ,k_  ,ist_ppp))
-           + amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_ppp)) + eps);
-        p += amrex::Math::abs(fsten(i_  ,j_  ,k_-1,ist_00p)) /
-           ( amrex::Math::abs(fsten(i_-1,j_-1,k_-1,ist_ppp))
-           + amrex::Math::abs(fsten(i_  ,j_-1,k_-1,ist_ppp))
-           + amrex::Math::abs(fsten(i_-1,j_  ,k_-1,ist_ppp))
-           + amrex::Math::abs(fsten(i_  ,j_  ,k_-1,ist_ppp)) + eps);
-        p += amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_pp0)) /
-           ( amrex::Math::abs(fsten(i_  ,j_  ,k_-1,ist_ppp))
-           + amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_ppp)) + eps);
-        p += amrex::Math::abs(fsten(i_  ,j_  ,k_-1,ist_p0p)) /
-           ( amrex::Math::abs(fsten(i_  ,j_-1,k_-1,ist_ppp))
-           + amrex::Math::abs(fsten(i_  ,j_  ,k_-1,ist_ppp)) + eps);
-        p += amrex::Math::abs(fsten(i_  ,j_  ,k_-1,ist_0pp)) /
-           ( amrex::Math::abs(fsten(i_-1,j_  ,k_-1,ist_ppp))
-           + amrex::Math::abs(fsten(i_  ,j_  ,k_-1,ist_ppp)) + eps);
-        p *= amrex::Math::abs(fsten(i_  ,j_  ,k_-1,ist_ppp)) * fsten(i_,j_,k_,ist_inv);
+        p += std::abs(fsten(i_  ,j_  ,k_  ,ist_p00)) /
+           ( std::abs(fsten(i_  ,j_-1,k_-1,ist_ppp))
+           + std::abs(fsten(i_  ,j_  ,k_-1,ist_ppp))
+           + std::abs(fsten(i_  ,j_-1,k_  ,ist_ppp))
+           + std::abs(fsten(i_  ,j_  ,k_  ,ist_ppp)) + eps);
+        p += std::abs(fsten(i_  ,j_  ,k_  ,ist_0p0)) /
+           ( std::abs(fsten(i_-1,j_  ,k_-1,ist_ppp))
+           + std::abs(fsten(i_  ,j_  ,k_-1,ist_ppp))
+           + std::abs(fsten(i_-1,j_  ,k_  ,ist_ppp))
+           + std::abs(fsten(i_  ,j_  ,k_  ,ist_ppp)) + eps);
+        p += std::abs(fsten(i_  ,j_  ,k_-1,ist_00p)) /
+           ( std::abs(fsten(i_-1,j_-1,k_-1,ist_ppp))
+           + std::abs(fsten(i_  ,j_-1,k_-1,ist_ppp))
+           + std::abs(fsten(i_-1,j_  ,k_-1,ist_ppp))
+           + std::abs(fsten(i_  ,j_  ,k_-1,ist_ppp)) + eps);
+        p += std::abs(fsten(i_  ,j_  ,k_  ,ist_pp0)) /
+           ( std::abs(fsten(i_  ,j_  ,k_-1,ist_ppp))
+           + std::abs(fsten(i_  ,j_  ,k_  ,ist_ppp)) + eps);
+        p += std::abs(fsten(i_  ,j_  ,k_-1,ist_p0p)) /
+           ( std::abs(fsten(i_  ,j_-1,k_-1,ist_ppp))
+           + std::abs(fsten(i_  ,j_  ,k_-1,ist_ppp)) + eps);
+        p += std::abs(fsten(i_  ,j_  ,k_-1,ist_0pp)) /
+           ( std::abs(fsten(i_-1,j_  ,k_-1,ist_ppp))
+           + std::abs(fsten(i_  ,j_  ,k_-1,ist_ppp)) + eps);
+        p *= std::abs(fsten(i_  ,j_  ,k_-1,ist_ppp)) * fsten(i_,j_,k_,ist_inv);
         return p;
     };
 
     auto interp_from_mmp_to = [&fsten] (int i_, int j_, int k_) -> Real {
         Real p = Real(1.);
-        p += amrex::Math::abs(fsten(i_-1,j_  ,k_  ,ist_p00)) /
-           ( amrex::Math::abs(fsten(i_-1,j_-1,k_-1,ist_ppp))
-           + amrex::Math::abs(fsten(i_-1,j_  ,k_-1,ist_ppp))
-           + amrex::Math::abs(fsten(i_-1,j_-1,k_  ,ist_ppp))
-           + amrex::Math::abs(fsten(i_-1,j_  ,k_  ,ist_ppp)) + eps);
-        p += amrex::Math::abs(fsten(i_  ,j_-1,k_  ,ist_0p0)) /
-           ( amrex::Math::abs(fsten(i_-1,j_-1,k_-1,ist_ppp))
-           + amrex::Math::abs(fsten(i_  ,j_-1,k_-1,ist_ppp))
-           + amrex::Math::abs(fsten(i_-1,j_-1,k_  ,ist_ppp))
-           + amrex::Math::abs(fsten(i_  ,j_-1,k_  ,ist_ppp)) + eps);
-        p += amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_00p)) /
-           ( amrex::Math::abs(fsten(i_-1,j_-1,k_,ist_ppp))
-           + amrex::Math::abs(fsten(i_  ,j_-1,k_,ist_ppp))
-           + amrex::Math::abs(fsten(i_-1,j_  ,k_,ist_ppp))
-           + amrex::Math::abs(fsten(i_  ,j_  ,k_,ist_ppp)) + eps);
-        p += amrex::Math::abs(fsten(i_-1,j_-1,k_,ist_pp0)) /
-           ( amrex::Math::abs(fsten(i_-1,j_-1,k_-1,ist_ppp))
-           + amrex::Math::abs(fsten(i_-1,j_-1,k_  ,ist_ppp)) + eps);
-        p += amrex::Math::abs(fsten(i_-1,j_  ,k_,ist_p0p)) /
-           ( amrex::Math::abs(fsten(i_-1,j_-1,k_,ist_ppp))
-           + amrex::Math::abs(fsten(i_-1,j_  ,k_,ist_ppp)) + eps);
-        p += amrex::Math::abs(fsten(i_  ,j_-1,k_,ist_0pp)) /
-           ( amrex::Math::abs(fsten(i_-1,j_-1,k_,ist_ppp))
-           + amrex::Math::abs(fsten(i_  ,j_-1,k_,ist_ppp)) + eps);
-        p *= amrex::Math::abs(fsten(i_-1,j_-1,k_  ,ist_ppp)) * fsten(i_,j_,k_,ist_inv);
+        p += std::abs(fsten(i_-1,j_  ,k_  ,ist_p00)) /
+           ( std::abs(fsten(i_-1,j_-1,k_-1,ist_ppp))
+           + std::abs(fsten(i_-1,j_  ,k_-1,ist_ppp))
+           + std::abs(fsten(i_-1,j_-1,k_  ,ist_ppp))
+           + std::abs(fsten(i_-1,j_  ,k_  ,ist_ppp)) + eps);
+        p += std::abs(fsten(i_  ,j_-1,k_  ,ist_0p0)) /
+           ( std::abs(fsten(i_-1,j_-1,k_-1,ist_ppp))
+           + std::abs(fsten(i_  ,j_-1,k_-1,ist_ppp))
+           + std::abs(fsten(i_-1,j_-1,k_  ,ist_ppp))
+           + std::abs(fsten(i_  ,j_-1,k_  ,ist_ppp)) + eps);
+        p += std::abs(fsten(i_  ,j_  ,k_  ,ist_00p)) /
+           ( std::abs(fsten(i_-1,j_-1,k_,ist_ppp))
+           + std::abs(fsten(i_  ,j_-1,k_,ist_ppp))
+           + std::abs(fsten(i_-1,j_  ,k_,ist_ppp))
+           + std::abs(fsten(i_  ,j_  ,k_,ist_ppp)) + eps);
+        p += std::abs(fsten(i_-1,j_-1,k_,ist_pp0)) /
+           ( std::abs(fsten(i_-1,j_-1,k_-1,ist_ppp))
+           + std::abs(fsten(i_-1,j_-1,k_  ,ist_ppp)) + eps);
+        p += std::abs(fsten(i_-1,j_  ,k_,ist_p0p)) /
+           ( std::abs(fsten(i_-1,j_-1,k_,ist_ppp))
+           + std::abs(fsten(i_-1,j_  ,k_,ist_ppp)) + eps);
+        p += std::abs(fsten(i_  ,j_-1,k_,ist_0pp)) /
+           ( std::abs(fsten(i_-1,j_-1,k_,ist_ppp))
+           + std::abs(fsten(i_  ,j_-1,k_,ist_ppp)) + eps);
+        p *= std::abs(fsten(i_-1,j_-1,k_  ,ist_ppp)) * fsten(i_,j_,k_,ist_inv);
         return p;
     };
 
     auto interp_from_pmp_to = [&fsten] (int i_, int j_, int k_) -> Real {
         Real p = Real(1.);
-        p += amrex::Math::abs(fsten(i_  ,j_  ,k_,ist_p00)) /
-           ( amrex::Math::abs(fsten(i_  ,j_-1,k_-1,ist_ppp))
-           + amrex::Math::abs(fsten(i_  ,j_  ,k_-1,ist_ppp))
-           + amrex::Math::abs(fsten(i_  ,j_-1,k_  ,ist_ppp))
-           + amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_ppp)) + eps);
-        p += amrex::Math::abs(fsten(i_  ,j_-1,k_,ist_0p0)) /
-           ( amrex::Math::abs(fsten(i_-1,j_-1,k_-1,ist_ppp))
-           + amrex::Math::abs(fsten(i_  ,j_-1,k_-1,ist_ppp))
-           + amrex::Math::abs(fsten(i_-1,j_-1,k_  ,ist_ppp))
-           + amrex::Math::abs(fsten(i_  ,j_-1,k_  ,ist_ppp)) + eps);
-        p += amrex::Math::abs(fsten(i_  ,j_  ,k_,ist_00p)) /
-           ( amrex::Math::abs(fsten(i_-1,j_-1,k_,ist_ppp))
-           + amrex::Math::abs(fsten(i_  ,j_-1,k_,ist_ppp))
-           + amrex::Math::abs(fsten(i_-1,j_  ,k_,ist_ppp))
-           + amrex::Math::abs(fsten(i_  ,j_  ,k_,ist_ppp)) + eps);
-        p += amrex::Math::abs(fsten(i_  ,j_-1,k_,ist_pp0)) /
-           ( amrex::Math::abs(fsten(i_  ,j_-1,k_-1,ist_ppp))
-           + amrex::Math::abs(fsten(i_  ,j_-1,k_  ,ist_ppp)) + eps);
-        p += amrex::Math::abs(fsten(i_  ,j_  ,k_,ist_p0p)) /
-           ( amrex::Math::abs(fsten(i_  ,j_-1,k_,ist_ppp))
-           + amrex::Math::abs(fsten(i_  ,j_  ,k_,ist_ppp)) + eps);
-        p += amrex::Math::abs(fsten(i_  ,j_-1,k_,ist_0pp)) /
-           ( amrex::Math::abs(fsten(i_-1,j_-1,k_,ist_ppp))
-           + amrex::Math::abs(fsten(i_  ,j_-1,k_,ist_ppp)) + eps);
-        p *= amrex::Math::abs(fsten(i_  ,j_-1,k_  ,ist_ppp)) * fsten(i_,j_  ,k_,ist_inv);
+        p += std::abs(fsten(i_  ,j_  ,k_,ist_p00)) /
+           ( std::abs(fsten(i_  ,j_-1,k_-1,ist_ppp))
+           + std::abs(fsten(i_  ,j_  ,k_-1,ist_ppp))
+           + std::abs(fsten(i_  ,j_-1,k_  ,ist_ppp))
+           + std::abs(fsten(i_  ,j_  ,k_  ,ist_ppp)) + eps);
+        p += std::abs(fsten(i_  ,j_-1,k_,ist_0p0)) /
+           ( std::abs(fsten(i_-1,j_-1,k_-1,ist_ppp))
+           + std::abs(fsten(i_  ,j_-1,k_-1,ist_ppp))
+           + std::abs(fsten(i_-1,j_-1,k_  ,ist_ppp))
+           + std::abs(fsten(i_  ,j_-1,k_  ,ist_ppp)) + eps);
+        p += std::abs(fsten(i_  ,j_  ,k_,ist_00p)) /
+           ( std::abs(fsten(i_-1,j_-1,k_,ist_ppp))
+           + std::abs(fsten(i_  ,j_-1,k_,ist_ppp))
+           + std::abs(fsten(i_-1,j_  ,k_,ist_ppp))
+           + std::abs(fsten(i_  ,j_  ,k_,ist_ppp)) + eps);
+        p += std::abs(fsten(i_  ,j_-1,k_,ist_pp0)) /
+           ( std::abs(fsten(i_  ,j_-1,k_-1,ist_ppp))
+           + std::abs(fsten(i_  ,j_-1,k_  ,ist_ppp)) + eps);
+        p += std::abs(fsten(i_  ,j_  ,k_,ist_p0p)) /
+           ( std::abs(fsten(i_  ,j_-1,k_,ist_ppp))
+           + std::abs(fsten(i_  ,j_  ,k_,ist_ppp)) + eps);
+        p += std::abs(fsten(i_  ,j_-1,k_,ist_0pp)) /
+           ( std::abs(fsten(i_-1,j_-1,k_,ist_ppp))
+           + std::abs(fsten(i_  ,j_-1,k_,ist_ppp)) + eps);
+        p *= std::abs(fsten(i_  ,j_-1,k_  ,ist_ppp)) * fsten(i_,j_  ,k_,ist_inv);
         return p;
     };
 
     auto interp_from_mpp_to = [&fsten] (int i_, int j_, int k_) -> Real {
         Real p = Real(1.);
-        p += amrex::Math::abs(fsten(i_-1,j_  ,k_  ,ist_p00)) /
-           ( amrex::Math::abs(fsten(i_-1,j_-1,k_-1,ist_ppp))
-           + amrex::Math::abs(fsten(i_-1,j_  ,k_-1,ist_ppp))
-           + amrex::Math::abs(fsten(i_-1,j_-1,k_  ,ist_ppp))
-           + amrex::Math::abs(fsten(i_-1,j_  ,k_  ,ist_ppp)) + eps);
-        p += amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_0p0)) /
-           ( amrex::Math::abs(fsten(i_-1,j_  ,k_-1,ist_ppp))
-           + amrex::Math::abs(fsten(i_  ,j_  ,k_-1,ist_ppp))
-           + amrex::Math::abs(fsten(i_-1,j_  ,k_  ,ist_ppp))
-           + amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_ppp)) + eps);
-        p += amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_00p)) /
-           ( amrex::Math::abs(fsten(i_-1,j_-1,k_  ,ist_ppp))
-           + amrex::Math::abs(fsten(i_  ,j_-1,k_  ,ist_ppp))
-           + amrex::Math::abs(fsten(i_-1,j_  ,k_  ,ist_ppp))
-           + amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_ppp)) + eps);
-        p += amrex::Math::abs(fsten(i_-1,j_  ,k_  ,ist_pp0)) /
-           ( amrex::Math::abs(fsten(i_-1,j_  ,k_-1,ist_ppp))
-           + amrex::Math::abs(fsten(i_-1,j_  ,k_  ,ist_ppp)) + eps);
-        p += amrex::Math::abs(fsten(i_-1,j_  ,k_  ,ist_p0p)) /
-           ( amrex::Math::abs(fsten(i_-1,j_-1,k_  ,ist_ppp))
-           + amrex::Math::abs(fsten(i_-1,j_  ,k_  ,ist_ppp)) + eps);
-        p += amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_0pp)) /
-           ( amrex::Math::abs(fsten(i_-1,j_  ,k_  ,ist_ppp))
-           + amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_ppp)) + eps);
-        p *= amrex::Math::abs(fsten(i_-1,j_  ,k_  ,ist_ppp)) * fsten(i_,j_,k_,ist_inv);
+        p += std::abs(fsten(i_-1,j_  ,k_  ,ist_p00)) /
+           ( std::abs(fsten(i_-1,j_-1,k_-1,ist_ppp))
+           + std::abs(fsten(i_-1,j_  ,k_-1,ist_ppp))
+           + std::abs(fsten(i_-1,j_-1,k_  ,ist_ppp))
+           + std::abs(fsten(i_-1,j_  ,k_  ,ist_ppp)) + eps);
+        p += std::abs(fsten(i_  ,j_  ,k_  ,ist_0p0)) /
+           ( std::abs(fsten(i_-1,j_  ,k_-1,ist_ppp))
+           + std::abs(fsten(i_  ,j_  ,k_-1,ist_ppp))
+           + std::abs(fsten(i_-1,j_  ,k_  ,ist_ppp))
+           + std::abs(fsten(i_  ,j_  ,k_  ,ist_ppp)) + eps);
+        p += std::abs(fsten(i_  ,j_  ,k_  ,ist_00p)) /
+           ( std::abs(fsten(i_-1,j_-1,k_  ,ist_ppp))
+           + std::abs(fsten(i_  ,j_-1,k_  ,ist_ppp))
+           + std::abs(fsten(i_-1,j_  ,k_  ,ist_ppp))
+           + std::abs(fsten(i_  ,j_  ,k_  ,ist_ppp)) + eps);
+        p += std::abs(fsten(i_-1,j_  ,k_  ,ist_pp0)) /
+           ( std::abs(fsten(i_-1,j_  ,k_-1,ist_ppp))
+           + std::abs(fsten(i_-1,j_  ,k_  ,ist_ppp)) + eps);
+        p += std::abs(fsten(i_-1,j_  ,k_  ,ist_p0p)) /
+           ( std::abs(fsten(i_-1,j_-1,k_  ,ist_ppp))
+           + std::abs(fsten(i_-1,j_  ,k_  ,ist_ppp)) + eps);
+        p += std::abs(fsten(i_  ,j_  ,k_  ,ist_0pp)) /
+           ( std::abs(fsten(i_-1,j_  ,k_  ,ist_ppp))
+           + std::abs(fsten(i_  ,j_  ,k_  ,ist_ppp)) + eps);
+        p *= std::abs(fsten(i_-1,j_  ,k_  ,ist_ppp)) * fsten(i_,j_,k_,ist_inv);
         return p;
     };
 
     auto interp_from_ppp_to = [&fsten] (int i_, int j_, int k_) -> Real {
         Real p = Real(1.);
-        p += amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_p00)) /
-           ( amrex::Math::abs(fsten(i_  ,j_-1,k_-1,ist_ppp))
-           + amrex::Math::abs(fsten(i_  ,j_  ,k_-1,ist_ppp))
-           + amrex::Math::abs(fsten(i_  ,j_-1,k_  ,ist_ppp))
-           + amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_ppp)) + eps);
-        p += amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_0p0)) /
-           ( amrex::Math::abs(fsten(i_-1,j_  ,k_-1,ist_ppp))
-           + amrex::Math::abs(fsten(i_  ,j_  ,k_-1,ist_ppp))
-           + amrex::Math::abs(fsten(i_-1,j_  ,k_  ,ist_ppp))
-           + amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_ppp)) + eps);
-        p += amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_00p)) /
-           ( amrex::Math::abs(fsten(i_-1,j_-1,k_  ,ist_ppp))
-           + amrex::Math::abs(fsten(i_  ,j_-1,k_  ,ist_ppp))
-           + amrex::Math::abs(fsten(i_-1,j_  ,k_  ,ist_ppp))
-           + amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_ppp)) + eps);
-        p += amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_pp0)) /
-           ( amrex::Math::abs(fsten(i_  ,j_  ,k_-1,ist_ppp))
-           + amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_ppp)) + eps);
-        p += amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_p0p)) /
-           ( amrex::Math::abs(fsten(i_  ,j_-1,k_  ,ist_ppp))
-           + amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_ppp)) + eps);
-        p += amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_0pp)) /
-           ( amrex::Math::abs(fsten(i_-1,j_  ,k_  ,ist_ppp))
-           + amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_ppp)) + eps);
-        p *= amrex::Math::abs(fsten(i_  ,j_  ,k_,ist_ppp)) * fsten(i_,j_,k_,ist_inv);
+        p += std::abs(fsten(i_  ,j_  ,k_  ,ist_p00)) /
+           ( std::abs(fsten(i_  ,j_-1,k_-1,ist_ppp))
+           + std::abs(fsten(i_  ,j_  ,k_-1,ist_ppp))
+           + std::abs(fsten(i_  ,j_-1,k_  ,ist_ppp))
+           + std::abs(fsten(i_  ,j_  ,k_  ,ist_ppp)) + eps);
+        p += std::abs(fsten(i_  ,j_  ,k_  ,ist_0p0)) /
+           ( std::abs(fsten(i_-1,j_  ,k_-1,ist_ppp))
+           + std::abs(fsten(i_  ,j_  ,k_-1,ist_ppp))
+           + std::abs(fsten(i_-1,j_  ,k_  ,ist_ppp))
+           + std::abs(fsten(i_  ,j_  ,k_  ,ist_ppp)) + eps);
+        p += std::abs(fsten(i_  ,j_  ,k_  ,ist_00p)) /
+           ( std::abs(fsten(i_-1,j_-1,k_  ,ist_ppp))
+           + std::abs(fsten(i_  ,j_-1,k_  ,ist_ppp))
+           + std::abs(fsten(i_-1,j_  ,k_  ,ist_ppp))
+           + std::abs(fsten(i_  ,j_  ,k_  ,ist_ppp)) + eps);
+        p += std::abs(fsten(i_  ,j_  ,k_  ,ist_pp0)) /
+           ( std::abs(fsten(i_  ,j_  ,k_-1,ist_ppp))
+           + std::abs(fsten(i_  ,j_  ,k_  ,ist_ppp)) + eps);
+        p += std::abs(fsten(i_  ,j_  ,k_  ,ist_p0p)) /
+           ( std::abs(fsten(i_  ,j_-1,k_  ,ist_ppp))
+           + std::abs(fsten(i_  ,j_  ,k_  ,ist_ppp)) + eps);
+        p += std::abs(fsten(i_  ,j_  ,k_  ,ist_0pp)) /
+           ( std::abs(fsten(i_-1,j_  ,k_  ,ist_ppp))
+           + std::abs(fsten(i_  ,j_  ,k_  ,ist_ppp)) + eps);
+        p *= std::abs(fsten(i_  ,j_  ,k_,ist_ppp)) * fsten(i_,j_,k_,ist_inv);
         return p;
     };
 
     auto interp_from_0mm_to = [&fsten] (int i_, int j_, int k_) -> Real {
-        Real w1m = amrex::Math::abs(fsten(i_  ,j_-1,k_  ,ist_0p0)) / (amrex::Math::abs(fsten(i_  ,j_-1,k_-1,ist_0pp))
-                                                             +amrex::Math::abs(fsten(i_  ,j_-1,k_  ,ist_0pp)) + eps);
-        Real w1p = amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_0p0)) / (amrex::Math::abs(fsten(i_  ,j_  ,k_-1,ist_0pp))
-                                                             +amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_0pp)) + eps);
-        Real w2m = amrex::Math::abs(fsten(i_  ,j_  ,k_-1,ist_00p)) / (amrex::Math::abs(fsten(i_  ,j_-1,k_-1,ist_0pp))
-                                                             +amrex::Math::abs(fsten(i_  ,j_  ,k_-1,ist_0pp)) + eps);
-        Real w2p = amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_00p)) / (amrex::Math::abs(fsten(i_  ,j_-1,k_  ,ist_0pp))
-                                                             +amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_0pp)) + eps);
-        Real wmm = amrex::Math::abs(fsten(i_  ,j_-1,k_-1,ist_0pp)) * (Real(1.) + w1m + w2m);
-        Real wpm = amrex::Math::abs(fsten(i_  ,j_  ,k_-1,ist_0pp)) * (Real(1.) + w1p + w2m);
-        Real wmp = amrex::Math::abs(fsten(i_  ,j_-1,k_  ,ist_0pp)) * (Real(1.) + w1m + w2p);
-        Real wpp = amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_0pp)) * (Real(1.) + w1p + w2p);
+        Real w1m = std::abs(fsten(i_  ,j_-1,k_  ,ist_0p0)) / (std::abs(fsten(i_  ,j_-1,k_-1,ist_0pp))
+                                                             +std::abs(fsten(i_  ,j_-1,k_  ,ist_0pp)) + eps);
+        Real w1p = std::abs(fsten(i_  ,j_  ,k_  ,ist_0p0)) / (std::abs(fsten(i_  ,j_  ,k_-1,ist_0pp))
+                                                             +std::abs(fsten(i_  ,j_  ,k_  ,ist_0pp)) + eps);
+        Real w2m = std::abs(fsten(i_  ,j_  ,k_-1,ist_00p)) / (std::abs(fsten(i_  ,j_-1,k_-1,ist_0pp))
+                                                             +std::abs(fsten(i_  ,j_  ,k_-1,ist_0pp)) + eps);
+        Real w2p = std::abs(fsten(i_  ,j_  ,k_  ,ist_00p)) / (std::abs(fsten(i_  ,j_-1,k_  ,ist_0pp))
+                                                             +std::abs(fsten(i_  ,j_  ,k_  ,ist_0pp)) + eps);
+        Real wmm = std::abs(fsten(i_  ,j_-1,k_-1,ist_0pp)) * (Real(1.) + w1m + w2m);
+        Real wpm = std::abs(fsten(i_  ,j_  ,k_-1,ist_0pp)) * (Real(1.) + w1p + w2m);
+        Real wmp = std::abs(fsten(i_  ,j_-1,k_  ,ist_0pp)) * (Real(1.) + w1m + w2p);
+        Real wpp = std::abs(fsten(i_  ,j_  ,k_  ,ist_0pp)) * (Real(1.) + w1p + w2p);
         return wmm / (wmm+wpm+wmp+wpp+eps);
     };
 
     auto interp_from_0mp_to = [&fsten] (int i_, int j_, int k_) -> Real {
-        Real w1m = amrex::Math::abs(fsten(i_  ,j_-1,k_  ,ist_0p0)) / (amrex::Math::abs(fsten(i_  ,j_-1,k_-1,ist_0pp))
-                                                             +amrex::Math::abs(fsten(i_  ,j_-1,k_  ,ist_0pp)) + eps);
-        Real w1p = amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_0p0)) / (amrex::Math::abs(fsten(i_  ,j_  ,k_-1,ist_0pp))
-                                                             +amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_0pp)) + eps);
-        Real w2m = amrex::Math::abs(fsten(i_  ,j_  ,k_-1,ist_00p)) / (amrex::Math::abs(fsten(i_  ,j_-1,k_-1,ist_0pp))
-                                                             +amrex::Math::abs(fsten(i_  ,j_  ,k_-1,ist_0pp)) + eps);
-        Real w2p = amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_00p)) / (amrex::Math::abs(fsten(i_  ,j_-1,k_  ,ist_0pp))
-                                                             +amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_0pp)) + eps);
-        Real wmm = amrex::Math::abs(fsten(i_  ,j_-1,k_-1,ist_0pp)) * (Real(1.) + w1m + w2m);
-        Real wpm = amrex::Math::abs(fsten(i_  ,j_  ,k_-1,ist_0pp)) * (Real(1.) + w1p + w2m);
-        Real wmp = amrex::Math::abs(fsten(i_  ,j_-1,k_  ,ist_0pp)) * (Real(1.) + w1m + w2p);
-        Real wpp = amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_0pp)) * (Real(1.) + w1p + w2p);
+        Real w1m = std::abs(fsten(i_  ,j_-1,k_  ,ist_0p0)) / (std::abs(fsten(i_  ,j_-1,k_-1,ist_0pp))
+                                                             +std::abs(fsten(i_  ,j_-1,k_  ,ist_0pp)) + eps);
+        Real w1p = std::abs(fsten(i_  ,j_  ,k_  ,ist_0p0)) / (std::abs(fsten(i_  ,j_  ,k_-1,ist_0pp))
+                                                             +std::abs(fsten(i_  ,j_  ,k_  ,ist_0pp)) + eps);
+        Real w2m = std::abs(fsten(i_  ,j_  ,k_-1,ist_00p)) / (std::abs(fsten(i_  ,j_-1,k_-1,ist_0pp))
+                                                             +std::abs(fsten(i_  ,j_  ,k_-1,ist_0pp)) + eps);
+        Real w2p = std::abs(fsten(i_  ,j_  ,k_  ,ist_00p)) / (std::abs(fsten(i_  ,j_-1,k_  ,ist_0pp))
+                                                             +std::abs(fsten(i_  ,j_  ,k_  ,ist_0pp)) + eps);
+        Real wmm = std::abs(fsten(i_  ,j_-1,k_-1,ist_0pp)) * (Real(1.) + w1m + w2m);
+        Real wpm = std::abs(fsten(i_  ,j_  ,k_-1,ist_0pp)) * (Real(1.) + w1p + w2m);
+        Real wmp = std::abs(fsten(i_  ,j_-1,k_  ,ist_0pp)) * (Real(1.) + w1m + w2p);
+        Real wpp = std::abs(fsten(i_  ,j_  ,k_  ,ist_0pp)) * (Real(1.) + w1p + w2p);
         return wmp / (wmm+wpm+wmp+wpp+eps);
     };
 
     auto interp_from_0pm_to = [&fsten] (int i_, int j_, int k_) -> Real {
-        Real w1m = amrex::Math::abs(fsten(i_  ,j_-1,k_  ,ist_0p0)) / (amrex::Math::abs(fsten(i_  ,j_-1,k_-1,ist_0pp))
-                                                             +amrex::Math::abs(fsten(i_  ,j_-1,k_  ,ist_0pp)) + eps);
-        Real w1p = amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_0p0)) / (amrex::Math::abs(fsten(i_  ,j_  ,k_-1,ist_0pp))
-                                                             +amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_0pp)) + eps);
-        Real w2m = amrex::Math::abs(fsten(i_  ,j_  ,k_-1,ist_00p)) / (amrex::Math::abs(fsten(i_  ,j_-1,k_-1,ist_0pp))
-                                                             +amrex::Math::abs(fsten(i_  ,j_  ,k_-1,ist_0pp)) + eps);
-        Real w2p = amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_00p)) / (amrex::Math::abs(fsten(i_  ,j_-1,k_  ,ist_0pp))
-                                                             +amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_0pp)) + eps);
-        Real wmm = amrex::Math::abs(fsten(i_  ,j_-1,k_-1,ist_0pp)) * (Real(1.) + w1m + w2m);
-        Real wpm = amrex::Math::abs(fsten(i_  ,j_  ,k_-1,ist_0pp)) * (Real(1.) + w1p + w2m);
-        Real wmp = amrex::Math::abs(fsten(i_  ,j_-1,k_  ,ist_0pp)) * (Real(1.) + w1m + w2p);
-        Real wpp = amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_0pp)) * (Real(1.) + w1p + w2p);
+        Real w1m = std::abs(fsten(i_  ,j_-1,k_  ,ist_0p0)) / (std::abs(fsten(i_  ,j_-1,k_-1,ist_0pp))
+                                                             +std::abs(fsten(i_  ,j_-1,k_  ,ist_0pp)) + eps);
+        Real w1p = std::abs(fsten(i_  ,j_  ,k_  ,ist_0p0)) / (std::abs(fsten(i_  ,j_  ,k_-1,ist_0pp))
+                                                             +std::abs(fsten(i_  ,j_  ,k_  ,ist_0pp)) + eps);
+        Real w2m = std::abs(fsten(i_  ,j_  ,k_-1,ist_00p)) / (std::abs(fsten(i_  ,j_-1,k_-1,ist_0pp))
+                                                             +std::abs(fsten(i_  ,j_  ,k_-1,ist_0pp)) + eps);
+        Real w2p = std::abs(fsten(i_  ,j_  ,k_  ,ist_00p)) / (std::abs(fsten(i_  ,j_-1,k_  ,ist_0pp))
+                                                             +std::abs(fsten(i_  ,j_  ,k_  ,ist_0pp)) + eps);
+        Real wmm = std::abs(fsten(i_  ,j_-1,k_-1,ist_0pp)) * (Real(1.) + w1m + w2m);
+        Real wpm = std::abs(fsten(i_  ,j_  ,k_-1,ist_0pp)) * (Real(1.) + w1p + w2m);
+        Real wmp = std::abs(fsten(i_  ,j_-1,k_  ,ist_0pp)) * (Real(1.) + w1m + w2p);
+        Real wpp = std::abs(fsten(i_  ,j_  ,k_  ,ist_0pp)) * (Real(1.) + w1p + w2p);
         return wpm / (wmm+wpm+wmp+wpp+eps);
     };
 
     auto interp_from_0pp_to = [&fsten] (int i_, int j_, int k_) -> Real {
-        Real w1m = amrex::Math::abs(fsten(i_  ,j_-1,k_  ,ist_0p0)) / (amrex::Math::abs(fsten(i_  ,j_-1,k_-1,ist_0pp))
-                                                             +amrex::Math::abs(fsten(i_  ,j_-1,k_  ,ist_0pp)) + eps);
-        Real w1p = amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_0p0)) / (amrex::Math::abs(fsten(i_  ,j_  ,k_-1,ist_0pp))
-                                                             +amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_0pp)) + eps);
-        Real w2m = amrex::Math::abs(fsten(i_  ,j_  ,k_-1,ist_00p)) / (amrex::Math::abs(fsten(i_  ,j_-1,k_-1,ist_0pp))
-                                                             +amrex::Math::abs(fsten(i_  ,j_  ,k_-1,ist_0pp)) + eps);
-        Real w2p = amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_00p)) / (amrex::Math::abs(fsten(i_  ,j_-1,k_  ,ist_0pp))
-                                                             +amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_0pp)) + eps);
-        Real wmm = amrex::Math::abs(fsten(i_  ,j_-1,k_-1,ist_0pp)) * (Real(1.) + w1m + w2m);
-        Real wpm = amrex::Math::abs(fsten(i_  ,j_  ,k_-1,ist_0pp)) * (Real(1.) + w1p + w2m);
-        Real wmp = amrex::Math::abs(fsten(i_  ,j_-1,k_  ,ist_0pp)) * (Real(1.) + w1m + w2p);
-        Real wpp = amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_0pp)) * (Real(1.) + w1p + w2p);
+        Real w1m = std::abs(fsten(i_  ,j_-1,k_  ,ist_0p0)) / (std::abs(fsten(i_  ,j_-1,k_-1,ist_0pp))
+                                                             +std::abs(fsten(i_  ,j_-1,k_  ,ist_0pp)) + eps);
+        Real w1p = std::abs(fsten(i_  ,j_  ,k_  ,ist_0p0)) / (std::abs(fsten(i_  ,j_  ,k_-1,ist_0pp))
+                                                             +std::abs(fsten(i_  ,j_  ,k_  ,ist_0pp)) + eps);
+        Real w2m = std::abs(fsten(i_  ,j_  ,k_-1,ist_00p)) / (std::abs(fsten(i_  ,j_-1,k_-1,ist_0pp))
+                                                             +std::abs(fsten(i_  ,j_  ,k_-1,ist_0pp)) + eps);
+        Real w2p = std::abs(fsten(i_  ,j_  ,k_  ,ist_00p)) / (std::abs(fsten(i_  ,j_-1,k_  ,ist_0pp))
+                                                             +std::abs(fsten(i_  ,j_  ,k_  ,ist_0pp)) + eps);
+        Real wmm = std::abs(fsten(i_  ,j_-1,k_-1,ist_0pp)) * (Real(1.) + w1m + w2m);
+        Real wpm = std::abs(fsten(i_  ,j_  ,k_-1,ist_0pp)) * (Real(1.) + w1p + w2m);
+        Real wmp = std::abs(fsten(i_  ,j_-1,k_  ,ist_0pp)) * (Real(1.) + w1m + w2p);
+        Real wpp = std::abs(fsten(i_  ,j_  ,k_  ,ist_0pp)) * (Real(1.) + w1p + w2p);
         return wpp / (wmm+wpm+wmp+wpp+eps);
     };
 
     auto interp_from_m0m_to = [&fsten] (int i_, int j_, int k_) -> Real {
-        Real w1m = amrex::Math::abs(fsten(i_-1,j_  ,k_  ,ist_p00)) / (amrex::Math::abs(fsten(i_-1,j_  ,k_-1,ist_p0p))
-                                                             +amrex::Math::abs(fsten(i_-1,j_  ,k_  ,ist_p0p)) + eps);
-        Real w1p = amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_p00)) / (amrex::Math::abs(fsten(i_  ,j_  ,k_-1,ist_p0p))
-                                                             +amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_p0p)) + eps);
-        Real w2m = amrex::Math::abs(fsten(i_  ,j_  ,k_-1,ist_00p)) / (amrex::Math::abs(fsten(i_-1,j_  ,k_-1,ist_p0p))
-                                                             +amrex::Math::abs(fsten(i_  ,j_  ,k_-1,ist_p0p)) + eps);
-        Real w2p = amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_00p)) / (amrex::Math::abs(fsten(i_-1,j_  ,k_  ,ist_p0p))
-                                                             +amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_p0p)) + eps);
-        Real wmm = amrex::Math::abs(fsten(i_-1,j_  ,k_-1,ist_p0p)) * (Real(1.) + w1m + w2m);
-        Real wpm = amrex::Math::abs(fsten(i_  ,j_  ,k_-1,ist_p0p)) * (Real(1.) + w1p + w2m);
-        Real wmp = amrex::Math::abs(fsten(i_-1,j_  ,k_  ,ist_p0p)) * (Real(1.) + w1m + w2p);
-        Real wpp = amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_p0p)) * (Real(1.) + w1p + w2p);
+        Real w1m = std::abs(fsten(i_-1,j_  ,k_  ,ist_p00)) / (std::abs(fsten(i_-1,j_  ,k_-1,ist_p0p))
+                                                             +std::abs(fsten(i_-1,j_  ,k_  ,ist_p0p)) + eps);
+        Real w1p = std::abs(fsten(i_  ,j_  ,k_  ,ist_p00)) / (std::abs(fsten(i_  ,j_  ,k_-1,ist_p0p))
+                                                             +std::abs(fsten(i_  ,j_  ,k_  ,ist_p0p)) + eps);
+        Real w2m = std::abs(fsten(i_  ,j_  ,k_-1,ist_00p)) / (std::abs(fsten(i_-1,j_  ,k_-1,ist_p0p))
+                                                             +std::abs(fsten(i_  ,j_  ,k_-1,ist_p0p)) + eps);
+        Real w2p = std::abs(fsten(i_  ,j_  ,k_  ,ist_00p)) / (std::abs(fsten(i_-1,j_  ,k_  ,ist_p0p))
+                                                             +std::abs(fsten(i_  ,j_  ,k_  ,ist_p0p)) + eps);
+        Real wmm = std::abs(fsten(i_-1,j_  ,k_-1,ist_p0p)) * (Real(1.) + w1m + w2m);
+        Real wpm = std::abs(fsten(i_  ,j_  ,k_-1,ist_p0p)) * (Real(1.) + w1p + w2m);
+        Real wmp = std::abs(fsten(i_-1,j_  ,k_  ,ist_p0p)) * (Real(1.) + w1m + w2p);
+        Real wpp = std::abs(fsten(i_  ,j_  ,k_  ,ist_p0p)) * (Real(1.) + w1p + w2p);
         return wmm / (wmm+wpm+wmp+wpp+eps);
     };
 
     auto interp_from_p0m_to = [&fsten] (int i_, int j_, int k_) -> Real {
-        Real w1m = amrex::Math::abs(fsten(i_-1,j_  ,k_  ,ist_p00)) / (amrex::Math::abs(fsten(i_-1,j_  ,k_-1,ist_p0p))
-                                                             +amrex::Math::abs(fsten(i_-1,j_  ,k_  ,ist_p0p)) + eps);
-        Real w1p = amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_p00)) / (amrex::Math::abs(fsten(i_  ,j_  ,k_-1,ist_p0p))
-                                                             +amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_p0p)) + eps);
-        Real w2m = amrex::Math::abs(fsten(i_  ,j_  ,k_-1,ist_00p)) / (amrex::Math::abs(fsten(i_-1,j_  ,k_-1,ist_p0p))
-                                                             +amrex::Math::abs(fsten(i_  ,j_  ,k_-1,ist_p0p)) + eps);
-        Real w2p = amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_00p)) / (amrex::Math::abs(fsten(i_-1,j_  ,k_  ,ist_p0p))
-                                                             +amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_p0p)) + eps);
-        Real wmm = amrex::Math::abs(fsten(i_-1,j_  ,k_-1,ist_p0p)) * (Real(1.) + w1m + w2m);
-        Real wpm = amrex::Math::abs(fsten(i_  ,j_  ,k_-1,ist_p0p)) * (Real(1.) + w1p + w2m);
-        Real wmp = amrex::Math::abs(fsten(i_-1,j_  ,k_  ,ist_p0p)) * (Real(1.) + w1m + w2p);
-        Real wpp = amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_p0p)) * (Real(1.) + w1p + w2p);
+        Real w1m = std::abs(fsten(i_-1,j_  ,k_  ,ist_p00)) / (std::abs(fsten(i_-1,j_  ,k_-1,ist_p0p))
+                                                             +std::abs(fsten(i_-1,j_  ,k_  ,ist_p0p)) + eps);
+        Real w1p = std::abs(fsten(i_  ,j_  ,k_  ,ist_p00)) / (std::abs(fsten(i_  ,j_  ,k_-1,ist_p0p))
+                                                             +std::abs(fsten(i_  ,j_  ,k_  ,ist_p0p)) + eps);
+        Real w2m = std::abs(fsten(i_  ,j_  ,k_-1,ist_00p)) / (std::abs(fsten(i_-1,j_  ,k_-1,ist_p0p))
+                                                             +std::abs(fsten(i_  ,j_  ,k_-1,ist_p0p)) + eps);
+        Real w2p = std::abs(fsten(i_  ,j_  ,k_  ,ist_00p)) / (std::abs(fsten(i_-1,j_  ,k_  ,ist_p0p))
+                                                             +std::abs(fsten(i_  ,j_  ,k_  ,ist_p0p)) + eps);
+        Real wmm = std::abs(fsten(i_-1,j_  ,k_-1,ist_p0p)) * (Real(1.) + w1m + w2m);
+        Real wpm = std::abs(fsten(i_  ,j_  ,k_-1,ist_p0p)) * (Real(1.) + w1p + w2m);
+        Real wmp = std::abs(fsten(i_-1,j_  ,k_  ,ist_p0p)) * (Real(1.) + w1m + w2p);
+        Real wpp = std::abs(fsten(i_  ,j_  ,k_  ,ist_p0p)) * (Real(1.) + w1p + w2p);
         return wpm / (wmm+wpm+wmp+wpp+eps);
     };
 
     auto interp_from_m0p_to = [&fsten] (int i_, int j_, int k_) -> Real {
-        Real w1m = amrex::Math::abs(fsten(i_-1,j_  ,k_  ,ist_p00)) / (amrex::Math::abs(fsten(i_-1,j_  ,k_-1,ist_p0p))
-                                                             +amrex::Math::abs(fsten(i_-1,j_  ,k_  ,ist_p0p)) + eps);
-        Real w1p = amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_p00)) / (amrex::Math::abs(fsten(i_  ,j_  ,k_-1,ist_p0p))
-                                                             +amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_p0p)) + eps);
-        Real w2m = amrex::Math::abs(fsten(i_  ,j_  ,k_-1,ist_00p)) / (amrex::Math::abs(fsten(i_-1,j_  ,k_-1,ist_p0p))
-                                                             +amrex::Math::abs(fsten(i_  ,j_  ,k_-1,ist_p0p)) + eps);
-        Real w2p = amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_00p)) / (amrex::Math::abs(fsten(i_-1,j_  ,k_  ,ist_p0p))
-                                                             +amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_p0p)) + eps);
-        Real wmm = amrex::Math::abs(fsten(i_-1,j_  ,k_-1,ist_p0p)) * (Real(1.) + w1m + w2m);
-        Real wpm = amrex::Math::abs(fsten(i_  ,j_  ,k_-1,ist_p0p)) * (Real(1.) + w1p + w2m);
-        Real wmp = amrex::Math::abs(fsten(i_-1,j_  ,k_  ,ist_p0p)) * (Real(1.) + w1m + w2p);
-        Real wpp = amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_p0p)) * (Real(1.) + w1p + w2p);
+        Real w1m = std::abs(fsten(i_-1,j_  ,k_  ,ist_p00)) / (std::abs(fsten(i_-1,j_  ,k_-1,ist_p0p))
+                                                             +std::abs(fsten(i_-1,j_  ,k_  ,ist_p0p)) + eps);
+        Real w1p = std::abs(fsten(i_  ,j_  ,k_  ,ist_p00)) / (std::abs(fsten(i_  ,j_  ,k_-1,ist_p0p))
+                                                             +std::abs(fsten(i_  ,j_  ,k_  ,ist_p0p)) + eps);
+        Real w2m = std::abs(fsten(i_  ,j_  ,k_-1,ist_00p)) / (std::abs(fsten(i_-1,j_  ,k_-1,ist_p0p))
+                                                             +std::abs(fsten(i_  ,j_  ,k_-1,ist_p0p)) + eps);
+        Real w2p = std::abs(fsten(i_  ,j_  ,k_  ,ist_00p)) / (std::abs(fsten(i_-1,j_  ,k_  ,ist_p0p))
+                                                             +std::abs(fsten(i_  ,j_  ,k_  ,ist_p0p)) + eps);
+        Real wmm = std::abs(fsten(i_-1,j_  ,k_-1,ist_p0p)) * (Real(1.) + w1m + w2m);
+        Real wpm = std::abs(fsten(i_  ,j_  ,k_-1,ist_p0p)) * (Real(1.) + w1p + w2m);
+        Real wmp = std::abs(fsten(i_-1,j_  ,k_  ,ist_p0p)) * (Real(1.) + w1m + w2p);
+        Real wpp = std::abs(fsten(i_  ,j_  ,k_  ,ist_p0p)) * (Real(1.) + w1p + w2p);
         return wmp / (wmm+wpm+wmp+wpp+eps);
     };
 
     auto interp_from_p0p_to = [&fsten] (int i_, int j_, int k_) -> Real {
-        Real w1m = amrex::Math::abs(fsten(i_-1,j_  ,k_  ,ist_p00)) / (amrex::Math::abs(fsten(i_-1,j_  ,k_-1,ist_p0p))
-                                                             +amrex::Math::abs(fsten(i_-1,j_  ,k_  ,ist_p0p)) + eps);
-        Real w1p = amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_p00)) / (amrex::Math::abs(fsten(i_  ,j_  ,k_-1,ist_p0p))
-                                                             +amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_p0p)) + eps);
-        Real w2m = amrex::Math::abs(fsten(i_  ,j_  ,k_-1,ist_00p)) / (amrex::Math::abs(fsten(i_-1,j_  ,k_-1,ist_p0p))
-                                                             +amrex::Math::abs(fsten(i_  ,j_  ,k_-1,ist_p0p)) + eps);
-        Real w2p = amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_00p)) / (amrex::Math::abs(fsten(i_-1,j_  ,k_  ,ist_p0p))
-                                                             +amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_p0p)) + eps);
-        Real wmm = amrex::Math::abs(fsten(i_-1,j_  ,k_-1,ist_p0p)) * (Real(1.) + w1m + w2m);
-        Real wpm = amrex::Math::abs(fsten(i_  ,j_  ,k_-1,ist_p0p)) * (Real(1.) + w1p + w2m);
-        Real wmp = amrex::Math::abs(fsten(i_-1,j_  ,k_  ,ist_p0p)) * (Real(1.) + w1m + w2p);
-        Real wpp = amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_p0p)) * (Real(1.) + w1p + w2p);
+        Real w1m = std::abs(fsten(i_-1,j_  ,k_  ,ist_p00)) / (std::abs(fsten(i_-1,j_  ,k_-1,ist_p0p))
+                                                             +std::abs(fsten(i_-1,j_  ,k_  ,ist_p0p)) + eps);
+        Real w1p = std::abs(fsten(i_  ,j_  ,k_  ,ist_p00)) / (std::abs(fsten(i_  ,j_  ,k_-1,ist_p0p))
+                                                             +std::abs(fsten(i_  ,j_  ,k_  ,ist_p0p)) + eps);
+        Real w2m = std::abs(fsten(i_  ,j_  ,k_-1,ist_00p)) / (std::abs(fsten(i_-1,j_  ,k_-1,ist_p0p))
+                                                             +std::abs(fsten(i_  ,j_  ,k_-1,ist_p0p)) + eps);
+        Real w2p = std::abs(fsten(i_  ,j_  ,k_  ,ist_00p)) / (std::abs(fsten(i_-1,j_  ,k_  ,ist_p0p))
+                                                             +std::abs(fsten(i_  ,j_  ,k_  ,ist_p0p)) + eps);
+        Real wmm = std::abs(fsten(i_-1,j_  ,k_-1,ist_p0p)) * (Real(1.) + w1m + w2m);
+        Real wpm = std::abs(fsten(i_  ,j_  ,k_-1,ist_p0p)) * (Real(1.) + w1p + w2m);
+        Real wmp = std::abs(fsten(i_-1,j_  ,k_  ,ist_p0p)) * (Real(1.) + w1m + w2p);
+        Real wpp = std::abs(fsten(i_  ,j_  ,k_  ,ist_p0p)) * (Real(1.) + w1p + w2p);
         return wpp / (wmm+wpm+wmp+wpp+eps);
     };
 
     auto interp_from_mm0_to = [&fsten] (int i_, int j_, int k_) -> Real {
-        Real w1m = amrex::Math::abs(fsten(i_-1,j_  ,k_  ,ist_p00)) / (amrex::Math::abs(fsten(i_-1,j_-1,k_  ,ist_pp0))
-                                                             +amrex::Math::abs(fsten(i_-1,j_  ,k_  ,ist_pp0)) + eps);
-        Real w1p = amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_p00)) / (amrex::Math::abs(fsten(i_  ,j_-1,k_  ,ist_pp0))
-                                                             +amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_pp0)) + eps);
-        Real w2m = amrex::Math::abs(fsten(i_  ,j_-1,k_  ,ist_0p0)) / (amrex::Math::abs(fsten(i_-1,j_-1,k_  ,ist_pp0))
-                                                             +amrex::Math::abs(fsten(i_  ,j_-1,k_  ,ist_pp0)) + eps);
-      Real w2p = amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_0p0)) / (amrex::Math::abs(fsten(i_-1,j_  ,k_  ,ist_pp0))
-                                                            +amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_pp0)) + eps);
-        Real wmm = amrex::Math::abs(fsten(i_-1,j_-1,k_  ,ist_pp0)) * (Real(1.) + w1m + w2m);
-        Real wpm = amrex::Math::abs(fsten(i_  ,j_-1,k_  ,ist_pp0)) * (Real(1.) + w1p + w2m);
-        Real wmp = amrex::Math::abs(fsten(i_-1,j_  ,k_  ,ist_pp0)) * (Real(1.) + w1m + w2p);
-        Real wpp = amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_pp0)) * (Real(1.) + w1p + w2p);
+        Real w1m = std::abs(fsten(i_-1,j_  ,k_  ,ist_p00)) / (std::abs(fsten(i_-1,j_-1,k_  ,ist_pp0))
+                                                             +std::abs(fsten(i_-1,j_  ,k_  ,ist_pp0)) + eps);
+        Real w1p = std::abs(fsten(i_  ,j_  ,k_  ,ist_p00)) / (std::abs(fsten(i_  ,j_-1,k_  ,ist_pp0))
+                                                             +std::abs(fsten(i_  ,j_  ,k_  ,ist_pp0)) + eps);
+        Real w2m = std::abs(fsten(i_  ,j_-1,k_  ,ist_0p0)) / (std::abs(fsten(i_-1,j_-1,k_  ,ist_pp0))
+                                                             +std::abs(fsten(i_  ,j_-1,k_  ,ist_pp0)) + eps);
+      Real w2p = std::abs(fsten(i_  ,j_  ,k_  ,ist_0p0)) / (std::abs(fsten(i_-1,j_  ,k_  ,ist_pp0))
+                                                            +std::abs(fsten(i_  ,j_  ,k_  ,ist_pp0)) + eps);
+        Real wmm = std::abs(fsten(i_-1,j_-1,k_  ,ist_pp0)) * (Real(1.) + w1m + w2m);
+        Real wpm = std::abs(fsten(i_  ,j_-1,k_  ,ist_pp0)) * (Real(1.) + w1p + w2m);
+        Real wmp = std::abs(fsten(i_-1,j_  ,k_  ,ist_pp0)) * (Real(1.) + w1m + w2p);
+        Real wpp = std::abs(fsten(i_  ,j_  ,k_  ,ist_pp0)) * (Real(1.) + w1p + w2p);
         return wmm / (wmm+wpm+wmp+wpp+eps);
     };
 
     auto interp_from_mp0_to = [&fsten] (int i_, int j_, int k_) -> Real {
-        Real w1m = amrex::Math::abs(fsten(i_-1,j_  ,k_  ,ist_p00)) / (amrex::Math::abs(fsten(i_-1,j_-1,k_  ,ist_pp0))
-                                                             +amrex::Math::abs(fsten(i_-1,j_  ,k_  ,ist_pp0)) + eps);
-        Real w1p = amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_p00)) / (amrex::Math::abs(fsten(i_  ,j_-1,k_  ,ist_pp0))
-                                                             +amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_pp0)) + eps);
-        Real w2m = amrex::Math::abs(fsten(i_  ,j_-1,k_  ,ist_0p0)) / (amrex::Math::abs(fsten(i_-1,j_-1,k_  ,ist_pp0))
-                                                             +amrex::Math::abs(fsten(i_  ,j_-1,k_  ,ist_pp0)) + eps);
-        Real w2p = amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_0p0)) / (amrex::Math::abs(fsten(i_-1,j_  ,k_  ,ist_pp0))
-                                                             +amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_pp0)) + eps);
-        Real wmm = amrex::Math::abs(fsten(i_-1,j_-1,k_  ,ist_pp0)) * (Real(1.) + w1m + w2m);
-        Real wpm = amrex::Math::abs(fsten(i_  ,j_-1,k_  ,ist_pp0)) * (Real(1.) + w1p + w2m);
-        Real wmp = amrex::Math::abs(fsten(i_-1,j_  ,k_  ,ist_pp0)) * (Real(1.) + w1m + w2p);
-        Real wpp = amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_pp0)) * (Real(1.) + w1p + w2p);
+        Real w1m = std::abs(fsten(i_-1,j_  ,k_  ,ist_p00)) / (std::abs(fsten(i_-1,j_-1,k_  ,ist_pp0))
+                                                             +std::abs(fsten(i_-1,j_  ,k_  ,ist_pp0)) + eps);
+        Real w1p = std::abs(fsten(i_  ,j_  ,k_  ,ist_p00)) / (std::abs(fsten(i_  ,j_-1,k_  ,ist_pp0))
+                                                             +std::abs(fsten(i_  ,j_  ,k_  ,ist_pp0)) + eps);
+        Real w2m = std::abs(fsten(i_  ,j_-1,k_  ,ist_0p0)) / (std::abs(fsten(i_-1,j_-1,k_  ,ist_pp0))
+                                                             +std::abs(fsten(i_  ,j_-1,k_  ,ist_pp0)) + eps);
+        Real w2p = std::abs(fsten(i_  ,j_  ,k_  ,ist_0p0)) / (std::abs(fsten(i_-1,j_  ,k_  ,ist_pp0))
+                                                             +std::abs(fsten(i_  ,j_  ,k_  ,ist_pp0)) + eps);
+        Real wmm = std::abs(fsten(i_-1,j_-1,k_  ,ist_pp0)) * (Real(1.) + w1m + w2m);
+        Real wpm = std::abs(fsten(i_  ,j_-1,k_  ,ist_pp0)) * (Real(1.) + w1p + w2m);
+        Real wmp = std::abs(fsten(i_-1,j_  ,k_  ,ist_pp0)) * (Real(1.) + w1m + w2p);
+        Real wpp = std::abs(fsten(i_  ,j_  ,k_  ,ist_pp0)) * (Real(1.) + w1p + w2p);
         return wmp / (wmm+wpm+wmp+wpp+eps);
     };
 
     auto interp_from_pm0_to = [&fsten] (int i_, int j_, int k_) -> Real {
-        Real w1m = amrex::Math::abs(fsten(i_-1,j_  ,k_  ,ist_p00)) / (amrex::Math::abs(fsten(i_-1,j_-1,k_  ,ist_pp0))
-                                                             +amrex::Math::abs(fsten(i_-1,j_  ,k_  ,ist_pp0)) + eps);
-        Real w1p = amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_p00)) / (amrex::Math::abs(fsten(i_  ,j_-1,k_  ,ist_pp0))
-                                                             +amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_pp0)) + eps);
-        Real w2m = amrex::Math::abs(fsten(i_  ,j_-1,k_  ,ist_0p0)) / (amrex::Math::abs(fsten(i_-1,j_-1,k_  ,ist_pp0))
-                                                             +amrex::Math::abs(fsten(i_  ,j_-1,k_  ,ist_pp0)) + eps);
-        Real w2p = amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_0p0)) / (amrex::Math::abs(fsten(i_-1,j_  ,k_  ,ist_pp0))
-                                                             +amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_pp0)) + eps);
-        Real wmm = amrex::Math::abs(fsten(i_-1,j_-1,k_  ,ist_pp0)) * (Real(1.) + w1m + w2m);
-        Real wpm = amrex::Math::abs(fsten(i_  ,j_-1,k_  ,ist_pp0)) * (Real(1.) + w1p + w2m);
-        Real wmp = amrex::Math::abs(fsten(i_-1,j_  ,k_  ,ist_pp0)) * (Real(1.) + w1m + w2p);
-        Real wpp = amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_pp0)) * (Real(1.) + w1p + w2p);
+        Real w1m = std::abs(fsten(i_-1,j_  ,k_  ,ist_p00)) / (std::abs(fsten(i_-1,j_-1,k_  ,ist_pp0))
+                                                             +std::abs(fsten(i_-1,j_  ,k_  ,ist_pp0)) + eps);
+        Real w1p = std::abs(fsten(i_  ,j_  ,k_  ,ist_p00)) / (std::abs(fsten(i_  ,j_-1,k_  ,ist_pp0))
+                                                             +std::abs(fsten(i_  ,j_  ,k_  ,ist_pp0)) + eps);
+        Real w2m = std::abs(fsten(i_  ,j_-1,k_  ,ist_0p0)) / (std::abs(fsten(i_-1,j_-1,k_  ,ist_pp0))
+                                                             +std::abs(fsten(i_  ,j_-1,k_  ,ist_pp0)) + eps);
+        Real w2p = std::abs(fsten(i_  ,j_  ,k_  ,ist_0p0)) / (std::abs(fsten(i_-1,j_  ,k_  ,ist_pp0))
+                                                             +std::abs(fsten(i_  ,j_  ,k_  ,ist_pp0)) + eps);
+        Real wmm = std::abs(fsten(i_-1,j_-1,k_  ,ist_pp0)) * (Real(1.) + w1m + w2m);
+        Real wpm = std::abs(fsten(i_  ,j_-1,k_  ,ist_pp0)) * (Real(1.) + w1p + w2m);
+        Real wmp = std::abs(fsten(i_-1,j_  ,k_  ,ist_pp0)) * (Real(1.) + w1m + w2p);
+        Real wpp = std::abs(fsten(i_  ,j_  ,k_  ,ist_pp0)) * (Real(1.) + w1p + w2p);
         return wpm / (wmm+wpm+wmp+wpp+eps);
     };
 
     auto interp_from_pp0_to = [&fsten] (int i_, int j_, int k_) -> Real {
-        Real w1m = amrex::Math::abs(fsten(i_-1,j_  ,k_  ,ist_p00)) / (amrex::Math::abs(fsten(i_-1,j_-1,k_  ,ist_pp0))
-                                                             +amrex::Math::abs(fsten(i_-1,j_  ,k_  ,ist_pp0)) + eps);
-        Real w1p = amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_p00)) / (amrex::Math::abs(fsten(i_  ,j_-1,k_  ,ist_pp0))
-                                                             +amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_pp0)) + eps);
-        Real w2m = amrex::Math::abs(fsten(i_  ,j_-1,k_  ,ist_0p0)) / (amrex::Math::abs(fsten(i_-1,j_-1,k_  ,ist_pp0))
-                                                             +amrex::Math::abs(fsten(i_  ,j_-1,k_  ,ist_pp0)) + eps);
-        Real w2p = amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_0p0)) / (amrex::Math::abs(fsten(i_-1,j_  ,k_  ,ist_pp0))
-                                                             +amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_pp0)) + eps);
-        Real wmm = amrex::Math::abs(fsten(i_-1,j_-1,k_  ,ist_pp0)) * (Real(1.) + w1m + w2m);
-        Real wpm = amrex::Math::abs(fsten(i_  ,j_-1,k_  ,ist_pp0)) * (Real(1.) + w1p + w2m);
-        Real wmp = amrex::Math::abs(fsten(i_-1,j_  ,k_  ,ist_pp0)) * (Real(1.) + w1m + w2p);
-        Real wpp = amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_pp0)) * (Real(1.) + w1p + w2p);
+        Real w1m = std::abs(fsten(i_-1,j_  ,k_  ,ist_p00)) / (std::abs(fsten(i_-1,j_-1,k_  ,ist_pp0))
+                                                             +std::abs(fsten(i_-1,j_  ,k_  ,ist_pp0)) + eps);
+        Real w1p = std::abs(fsten(i_  ,j_  ,k_  ,ist_p00)) / (std::abs(fsten(i_  ,j_-1,k_  ,ist_pp0))
+                                                             +std::abs(fsten(i_  ,j_  ,k_  ,ist_pp0)) + eps);
+        Real w2m = std::abs(fsten(i_  ,j_-1,k_  ,ist_0p0)) / (std::abs(fsten(i_-1,j_-1,k_  ,ist_pp0))
+                                                             +std::abs(fsten(i_  ,j_-1,k_  ,ist_pp0)) + eps);
+        Real w2p = std::abs(fsten(i_  ,j_  ,k_  ,ist_0p0)) / (std::abs(fsten(i_-1,j_  ,k_  ,ist_pp0))
+                                                             +std::abs(fsten(i_  ,j_  ,k_  ,ist_pp0)) + eps);
+        Real wmm = std::abs(fsten(i_-1,j_-1,k_  ,ist_pp0)) * (Real(1.) + w1m + w2m);
+        Real wpm = std::abs(fsten(i_  ,j_-1,k_  ,ist_pp0)) * (Real(1.) + w1p + w2m);
+        Real wmp = std::abs(fsten(i_-1,j_  ,k_  ,ist_pp0)) * (Real(1.) + w1m + w2p);
+        Real wpp = std::abs(fsten(i_  ,j_  ,k_  ,ist_pp0)) * (Real(1.) + w1p + w2p);
         return wpp / (wmm+wpm+wmp+wpp+eps);
     };
 
     auto interp_from_00m_to = [&fsten] (int i_, int j_, int k_) -> Real {
-        Real w1 = amrex::Math::abs(fsten(i_  ,j_  ,k_-1,ist_00p));
-        Real w2 = amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_00p));
+        Real w1 = std::abs(fsten(i_  ,j_  ,k_-1,ist_00p));
+        Real w2 = std::abs(fsten(i_  ,j_  ,k_  ,ist_00p));
         if (w1 == Real(0.) && w2 == Real(0.)) {
             return Real(0.5);
         } else {
@@ -3298,8 +3298,8 @@ void mlndlap_stencil_rap (int i, int j, int k, Array4<Real> const& csten,
     };
 
     auto interp_from_00p_to = [&fsten] (int i_, int j_, int k_) -> Real {
-        Real w1 = amrex::Math::abs(fsten(i_  ,j_  ,k_-1,ist_00p));
-        Real w2 = amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_00p));
+        Real w1 = std::abs(fsten(i_  ,j_  ,k_-1,ist_00p));
+        Real w2 = std::abs(fsten(i_  ,j_  ,k_  ,ist_00p));
         if (w1 == Real(0.) && w2 == Real(0.)) {
             return Real(0.5);
         } else {
@@ -3308,8 +3308,8 @@ void mlndlap_stencil_rap (int i, int j, int k, Array4<Real> const& csten,
     };
 
     auto interp_from_0m0_to = [&fsten] (int i_, int j_, int k_) -> Real {
-        Real w1 = amrex::Math::abs(fsten(i_  ,j_-1,k_  ,ist_0p0));
-        Real w2 = amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_0p0));
+        Real w1 = std::abs(fsten(i_  ,j_-1,k_  ,ist_0p0));
+        Real w2 = std::abs(fsten(i_  ,j_  ,k_  ,ist_0p0));
         if (w1 == Real(0.) && w2 == Real(0.)) {
             return Real(0.5);
         } else {
@@ -3318,8 +3318,8 @@ void mlndlap_stencil_rap (int i, int j, int k, Array4<Real> const& csten,
     };
 
     auto interp_from_0p0_to = [&fsten] (int i_, int j_, int k_) -> Real {
-        Real w1 = amrex::Math::abs(fsten(i_  ,j_-1,k_  ,ist_0p0));
-        Real w2 = amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_0p0));
+        Real w1 = std::abs(fsten(i_  ,j_-1,k_  ,ist_0p0));
+        Real w2 = std::abs(fsten(i_  ,j_  ,k_  ,ist_0p0));
         if (w1 == Real(0.) && w2 == Real(0.)) {
             return Real(0.5);
         } else {
@@ -3328,8 +3328,8 @@ void mlndlap_stencil_rap (int i, int j, int k, Array4<Real> const& csten,
     };
 
     auto interp_from_m00_to = [&fsten] (int i_, int j_, int k_) -> Real {
-        Real w1 = amrex::Math::abs(fsten(i_-1,j_  ,k_  ,ist_p00));
-        Real w2 = amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_p00));
+        Real w1 = std::abs(fsten(i_-1,j_  ,k_  ,ist_p00));
+        Real w2 = std::abs(fsten(i_  ,j_  ,k_  ,ist_p00));
         if (w1 == Real(0.) && w2 == Real(0.)) {
             return Real(0.5);
         } else {
@@ -3338,8 +3338,8 @@ void mlndlap_stencil_rap (int i, int j, int k, Array4<Real> const& csten,
     };
 
     auto interp_from_p00_to = [&fsten] (int i_, int j_, int k_) -> Real {
-        Real w1 = amrex::Math::abs(fsten(i_-1,j_  ,k_  ,ist_p00));
-        Real w2 = amrex::Math::abs(fsten(i_  ,j_  ,k_  ,ist_p00));
+        Real w1 = std::abs(fsten(i_-1,j_  ,k_  ,ist_p00));
+        Real w2 = std::abs(fsten(i_  ,j_  ,k_  ,ist_p00));
         if (w1 == Real(0.) && w2 == Real(0.)) {
             return Real(0.5);
         } else {
@@ -3458,100 +3458,100 @@ void mlndlap_stencil_rap (int i, int j, int k, Array4<Real> const& csten,
 
     auto restrict_from_mmm_to = [&fsten] (int ii_, int jj_, int kk_) -> Real {
         Real r = Real(1.);
-        r += amrex::Math::abs(fsten(ii_-1,jj_-1,kk_-1,ist_p00)) /
-           ( amrex::Math::abs(fsten(ii_-1,jj_-2,kk_-2,ist_ppp))
-           + amrex::Math::abs(fsten(ii_-1,jj_-1,kk_-2,ist_ppp))
-           + amrex::Math::abs(fsten(ii_-1,jj_-2,kk_-1,ist_ppp))
-           + amrex::Math::abs(fsten(ii_-1,jj_-1,kk_-1,ist_ppp)) + eps);
-        r += amrex::Math::abs(fsten(ii_-1,jj_-1,kk_-1,ist_0p0)) /
-           ( amrex::Math::abs(fsten(ii_-2,jj_-1,kk_-2,ist_ppp))
-           + amrex::Math::abs(fsten(ii_-1,jj_-1,kk_-2,ist_ppp))
-           + amrex::Math::abs(fsten(ii_-2,jj_-1,kk_-1,ist_ppp))
-           + amrex::Math::abs(fsten(ii_-1,jj_-1,kk_-1,ist_ppp)) + eps);
-        r += amrex::Math::abs(fsten(ii_-1,jj_-1,kk_-1,ist_00p)) /
-           ( amrex::Math::abs(fsten(ii_-2,jj_-2,kk_-1,ist_ppp))
-           + amrex::Math::abs(fsten(ii_-1,jj_-2,kk_-1,ist_ppp))
-           + amrex::Math::abs(fsten(ii_-2,jj_-1,kk_-1,ist_ppp))
-           + amrex::Math::abs(fsten(ii_-1,jj_-1,kk_-1,ist_ppp)) + eps);
-        r += amrex::Math::abs(fsten(ii_-1,jj_-1,kk_-1,ist_pp0)) /
-           ( amrex::Math::abs(fsten(ii_-1,jj_-1,kk_-2,ist_ppp))
-           + amrex::Math::abs(fsten(ii_-1,jj_-1,kk_-1,ist_ppp)) + eps);
-        r += amrex::Math::abs(fsten(ii_-1,jj_-1,kk_-1,ist_p0p)) /
-           ( amrex::Math::abs(fsten(ii_-1,jj_-2,kk_-1,ist_ppp))
-           + amrex::Math::abs(fsten(ii_-1,jj_-1,kk_-1,ist_ppp)) + eps);
-        r += amrex::Math::abs(fsten(ii_-1,jj_-1,kk_-1,ist_0pp)) /
-           ( amrex::Math::abs(fsten(ii_-2,jj_-1,kk_-1,ist_ppp))
-           + amrex::Math::abs(fsten(ii_-1,jj_-1,kk_-1,ist_ppp)) + eps);
-        r *= amrex::Math::abs(fsten(ii_-1,jj_-1,kk_-1,ist_ppp)) * fsten(ii_-1,jj_-1,kk_-1,ist_inv);
+        r += std::abs(fsten(ii_-1,jj_-1,kk_-1,ist_p00)) /
+           ( std::abs(fsten(ii_-1,jj_-2,kk_-2,ist_ppp))
+           + std::abs(fsten(ii_-1,jj_-1,kk_-2,ist_ppp))
+           + std::abs(fsten(ii_-1,jj_-2,kk_-1,ist_ppp))
+           + std::abs(fsten(ii_-1,jj_-1,kk_-1,ist_ppp)) + eps);
+        r += std::abs(fsten(ii_-1,jj_-1,kk_-1,ist_0p0)) /
+           ( std::abs(fsten(ii_-2,jj_-1,kk_-2,ist_ppp))
+           + std::abs(fsten(ii_-1,jj_-1,kk_-2,ist_ppp))
+           + std::abs(fsten(ii_-2,jj_-1,kk_-1,ist_ppp))
+           + std::abs(fsten(ii_-1,jj_-1,kk_-1,ist_ppp)) + eps);
+        r += std::abs(fsten(ii_-1,jj_-1,kk_-1,ist_00p)) /
+           ( std::abs(fsten(ii_-2,jj_-2,kk_-1,ist_ppp))
+           + std::abs(fsten(ii_-1,jj_-2,kk_-1,ist_ppp))
+           + std::abs(fsten(ii_-2,jj_-1,kk_-1,ist_ppp))
+           + std::abs(fsten(ii_-1,jj_-1,kk_-1,ist_ppp)) + eps);
+        r += std::abs(fsten(ii_-1,jj_-1,kk_-1,ist_pp0)) /
+           ( std::abs(fsten(ii_-1,jj_-1,kk_-2,ist_ppp))
+           + std::abs(fsten(ii_-1,jj_-1,kk_-1,ist_ppp)) + eps);
+        r += std::abs(fsten(ii_-1,jj_-1,kk_-1,ist_p0p)) /
+           ( std::abs(fsten(ii_-1,jj_-2,kk_-1,ist_ppp))
+           + std::abs(fsten(ii_-1,jj_-1,kk_-1,ist_ppp)) + eps);
+        r += std::abs(fsten(ii_-1,jj_-1,kk_-1,ist_0pp)) /
+           ( std::abs(fsten(ii_-2,jj_-1,kk_-1,ist_ppp))
+           + std::abs(fsten(ii_-1,jj_-1,kk_-1,ist_ppp)) + eps);
+        r *= std::abs(fsten(ii_-1,jj_-1,kk_-1,ist_ppp)) * fsten(ii_-1,jj_-1,kk_-1,ist_inv);
         return r;
     };
     amrex::ignore_unused(restrict_from_mmm_to);
 
     auto restrict_from_0mm_to = [&fsten] (int ii_, int jj_, int kk_) -> Real {
-        Real w1m = amrex::Math::abs(fsten(ii_,jj_-2,kk_-1,ist_0p0)) / (amrex::Math::abs(fsten(ii_,jj_-2,kk_-2,ist_0pp))
-                                                              +amrex::Math::abs(fsten(ii_,jj_-2,kk_-1,ist_0pp)) + eps);
-        Real w1p = amrex::Math::abs(fsten(ii_,jj_-1,kk_-1,ist_0p0)) / (amrex::Math::abs(fsten(ii_,jj_-1,kk_-2,ist_0pp))
-                                                              +amrex::Math::abs(fsten(ii_,jj_-1,kk_-1,ist_0pp)) + eps);
-        Real w2m = amrex::Math::abs(fsten(ii_,jj_-1,kk_-2,ist_00p)) / (amrex::Math::abs(fsten(ii_,jj_-2,kk_-2,ist_0pp))
-                                                              +amrex::Math::abs(fsten(ii_,jj_-1,kk_-2,ist_0pp)) + eps);
-        Real w2p = amrex::Math::abs(fsten(ii_,jj_-1,kk_-1,ist_00p)) / (amrex::Math::abs(fsten(ii_,jj_-2,kk_-1,ist_0pp))
-                                                              +amrex::Math::abs(fsten(ii_,jj_-1,kk_-1,ist_0pp)) + eps);
-        Real wmm = amrex::Math::abs(fsten(ii_,jj_-2,kk_-2,ist_0pp)) * (Real(1.) + w1m + w2m);
-        Real wpm = amrex::Math::abs(fsten(ii_,jj_-1,kk_-2,ist_0pp)) * (Real(1.) + w1p + w2m);
-        Real wmp = amrex::Math::abs(fsten(ii_,jj_-2,kk_-1,ist_0pp)) * (Real(1.) + w1m + w2p);
-        Real wpp = amrex::Math::abs(fsten(ii_,jj_-1,kk_-1,ist_0pp)) * (Real(1.) + w1p + w2p);
+        Real w1m = std::abs(fsten(ii_,jj_-2,kk_-1,ist_0p0)) / (std::abs(fsten(ii_,jj_-2,kk_-2,ist_0pp))
+                                                              +std::abs(fsten(ii_,jj_-2,kk_-1,ist_0pp)) + eps);
+        Real w1p = std::abs(fsten(ii_,jj_-1,kk_-1,ist_0p0)) / (std::abs(fsten(ii_,jj_-1,kk_-2,ist_0pp))
+                                                              +std::abs(fsten(ii_,jj_-1,kk_-1,ist_0pp)) + eps);
+        Real w2m = std::abs(fsten(ii_,jj_-1,kk_-2,ist_00p)) / (std::abs(fsten(ii_,jj_-2,kk_-2,ist_0pp))
+                                                              +std::abs(fsten(ii_,jj_-1,kk_-2,ist_0pp)) + eps);
+        Real w2p = std::abs(fsten(ii_,jj_-1,kk_-1,ist_00p)) / (std::abs(fsten(ii_,jj_-2,kk_-1,ist_0pp))
+                                                              +std::abs(fsten(ii_,jj_-1,kk_-1,ist_0pp)) + eps);
+        Real wmm = std::abs(fsten(ii_,jj_-2,kk_-2,ist_0pp)) * (Real(1.) + w1m + w2m);
+        Real wpm = std::abs(fsten(ii_,jj_-1,kk_-2,ist_0pp)) * (Real(1.) + w1p + w2m);
+        Real wmp = std::abs(fsten(ii_,jj_-2,kk_-1,ist_0pp)) * (Real(1.) + w1m + w2p);
+        Real wpp = std::abs(fsten(ii_,jj_-1,kk_-1,ist_0pp)) * (Real(1.) + w1p + w2p);
         return wpp / (wmm+wpm+wmp+wpp+eps);
     };
 
     auto restrict_from_pmm_to = [&fsten] (int ii_, int jj_, int kk_) -> Real {
         Real r = Real(1.);
-        r += amrex::Math::abs(fsten(ii_  ,jj_-1,kk_-1,ist_p00)) /
-           ( amrex::Math::abs(fsten(ii_  ,jj_-2,kk_-2,ist_ppp))
-           + amrex::Math::abs(fsten(ii_  ,jj_-1,kk_-2,ist_ppp))
-           + amrex::Math::abs(fsten(ii_  ,jj_-2,kk_-1,ist_ppp))
-           + amrex::Math::abs(fsten(ii_  ,jj_-1,kk_-1,ist_ppp)) + eps);
-        r += amrex::Math::abs(fsten(ii_+1,jj_-1,kk_-1,ist_0p0)) /
-           ( amrex::Math::abs(fsten(ii_  ,jj_-1,kk_-2,ist_ppp))
-           + amrex::Math::abs(fsten(ii_+1,jj_-1,kk_-2,ist_ppp))
-           + amrex::Math::abs(fsten(ii_  ,jj_-1,kk_-1,ist_ppp))
-           + amrex::Math::abs(fsten(ii_+1,jj_-1,kk_-1,ist_ppp)) + eps);
-        r += amrex::Math::abs(fsten(ii_+1,jj_-1,kk_-1,ist_00p)) /
-           ( amrex::Math::abs(fsten(ii_  ,jj_-2,kk_-1,ist_ppp))
-           + amrex::Math::abs(fsten(ii_+1,jj_-2,kk_-1,ist_ppp))
-           + amrex::Math::abs(fsten(ii_  ,jj_-1,kk_-1,ist_ppp))
-           + amrex::Math::abs(fsten(ii_+1,jj_-1,kk_-1,ist_ppp)) + eps);
-        r += amrex::Math::abs(fsten(ii_  ,jj_-1,kk_-1,ist_pp0)) /
-           ( amrex::Math::abs(fsten(ii_  ,jj_-1,kk_-2,ist_ppp))
-           + amrex::Math::abs(fsten(ii_  ,jj_-1,kk_-1,ist_ppp)) + eps);
-        r += amrex::Math::abs(fsten(ii_  ,jj_-1,kk_-1,ist_p0p)) /
-           ( amrex::Math::abs(fsten(ii_  ,jj_-2,kk_-1,ist_ppp))
-           + amrex::Math::abs(fsten(ii_  ,jj_-1,kk_-1,ist_ppp)) + eps);
-        r += amrex::Math::abs(fsten(ii_+1,jj_-1,kk_-1,ist_0pp)) /
-           ( amrex::Math::abs(fsten(ii_  ,jj_-1,kk_-1,ist_ppp))
-           + amrex::Math::abs(fsten(ii_+1,jj_-1,kk_-1,ist_ppp)) + eps);
-        r *= amrex::Math::abs(fsten(ii_  ,jj_-1,kk_-1,ist_ppp)) * fsten(ii_+1,jj_-1,kk_-1,ist_inv);
+        r += std::abs(fsten(ii_  ,jj_-1,kk_-1,ist_p00)) /
+           ( std::abs(fsten(ii_  ,jj_-2,kk_-2,ist_ppp))
+           + std::abs(fsten(ii_  ,jj_-1,kk_-2,ist_ppp))
+           + std::abs(fsten(ii_  ,jj_-2,kk_-1,ist_ppp))
+           + std::abs(fsten(ii_  ,jj_-1,kk_-1,ist_ppp)) + eps);
+        r += std::abs(fsten(ii_+1,jj_-1,kk_-1,ist_0p0)) /
+           ( std::abs(fsten(ii_  ,jj_-1,kk_-2,ist_ppp))
+           + std::abs(fsten(ii_+1,jj_-1,kk_-2,ist_ppp))
+           + std::abs(fsten(ii_  ,jj_-1,kk_-1,ist_ppp))
+           + std::abs(fsten(ii_+1,jj_-1,kk_-1,ist_ppp)) + eps);
+        r += std::abs(fsten(ii_+1,jj_-1,kk_-1,ist_00p)) /
+           ( std::abs(fsten(ii_  ,jj_-2,kk_-1,ist_ppp))
+           + std::abs(fsten(ii_+1,jj_-2,kk_-1,ist_ppp))
+           + std::abs(fsten(ii_  ,jj_-1,kk_-1,ist_ppp))
+           + std::abs(fsten(ii_+1,jj_-1,kk_-1,ist_ppp)) + eps);
+        r += std::abs(fsten(ii_  ,jj_-1,kk_-1,ist_pp0)) /
+           ( std::abs(fsten(ii_  ,jj_-1,kk_-2,ist_ppp))
+           + std::abs(fsten(ii_  ,jj_-1,kk_-1,ist_ppp)) + eps);
+        r += std::abs(fsten(ii_  ,jj_-1,kk_-1,ist_p0p)) /
+           ( std::abs(fsten(ii_  ,jj_-2,kk_-1,ist_ppp))
+           + std::abs(fsten(ii_  ,jj_-1,kk_-1,ist_ppp)) + eps);
+        r += std::abs(fsten(ii_+1,jj_-1,kk_-1,ist_0pp)) /
+           ( std::abs(fsten(ii_  ,jj_-1,kk_-1,ist_ppp))
+           + std::abs(fsten(ii_+1,jj_-1,kk_-1,ist_ppp)) + eps);
+        r *= std::abs(fsten(ii_  ,jj_-1,kk_-1,ist_ppp)) * fsten(ii_+1,jj_-1,kk_-1,ist_inv);
         return r;
     };
 
     auto restrict_from_m0m_to = [&fsten] (int ii_, int jj_, int kk_) -> Real {
-        Real w1m = amrex::Math::abs(fsten(ii_-2,jj_,kk_-1,ist_p00)) / (amrex::Math::abs(fsten(ii_-2,jj_,kk_-2,ist_p0p))
-                                                              +amrex::Math::abs(fsten(ii_-2,jj_,kk_-1,ist_p0p)) + eps);
-        Real w1p = amrex::Math::abs(fsten(ii_-1,jj_,kk_-1,ist_p00)) / (amrex::Math::abs(fsten(ii_-1,jj_,kk_-2,ist_p0p))
-                                                              +amrex::Math::abs(fsten(ii_-1,jj_,kk_-1,ist_p0p)) + eps);
-        Real w2m = amrex::Math::abs(fsten(ii_-1,jj_,kk_-2,ist_00p)) / (amrex::Math::abs(fsten(ii_-2,jj_,kk_-2,ist_p0p))
-                                                              +amrex::Math::abs(fsten(ii_-1,jj_,kk_-2,ist_p0p)) + eps);
-        Real w2p = amrex::Math::abs(fsten(ii_-1,jj_,kk_-1,ist_00p)) / (amrex::Math::abs(fsten(ii_-2,jj_,kk_-1,ist_p0p))
-                                                              +amrex::Math::abs(fsten(ii_-1,jj_,kk_-1,ist_p0p)) + eps);
-        Real wmm = amrex::Math::abs(fsten(ii_-2,jj_,kk_-2,ist_p0p)) * (Real(1.) + w1m + w2m);
-        Real wpm = amrex::Math::abs(fsten(ii_-1,jj_,kk_-2,ist_p0p)) * (Real(1.) + w1p + w2m);
-        Real wmp = amrex::Math::abs(fsten(ii_-2,jj_,kk_-1,ist_p0p)) * (Real(1.) + w1m + w2p);
-        Real wpp = amrex::Math::abs(fsten(ii_-1,jj_,kk_-1,ist_p0p)) * (Real(1.) + w1p + w2p);
+        Real w1m = std::abs(fsten(ii_-2,jj_,kk_-1,ist_p00)) / (std::abs(fsten(ii_-2,jj_,kk_-2,ist_p0p))
+                                                              +std::abs(fsten(ii_-2,jj_,kk_-1,ist_p0p)) + eps);
+        Real w1p = std::abs(fsten(ii_-1,jj_,kk_-1,ist_p00)) / (std::abs(fsten(ii_-1,jj_,kk_-2,ist_p0p))
+                                                              +std::abs(fsten(ii_-1,jj_,kk_-1,ist_p0p)) + eps);
+        Real w2m = std::abs(fsten(ii_-1,jj_,kk_-2,ist_00p)) / (std::abs(fsten(ii_-2,jj_,kk_-2,ist_p0p))
+                                                              +std::abs(fsten(ii_-1,jj_,kk_-2,ist_p0p)) + eps);
+        Real w2p = std::abs(fsten(ii_-1,jj_,kk_-1,ist_00p)) / (std::abs(fsten(ii_-2,jj_,kk_-1,ist_p0p))
+                                                              +std::abs(fsten(ii_-1,jj_,kk_-1,ist_p0p)) + eps);
+        Real wmm = std::abs(fsten(ii_-2,jj_,kk_-2,ist_p0p)) * (Real(1.) + w1m + w2m);
+        Real wpm = std::abs(fsten(ii_-1,jj_,kk_-2,ist_p0p)) * (Real(1.) + w1p + w2m);
+        Real wmp = std::abs(fsten(ii_-2,jj_,kk_-1,ist_p0p)) * (Real(1.) + w1m + w2p);
+        Real wpp = std::abs(fsten(ii_-1,jj_,kk_-1,ist_p0p)) * (Real(1.) + w1p + w2p);
         return wpp / (wmm+wpm+wmp+wpp+eps);
     };
 
     auto restrict_from_00m_to = [&fsten] (int ii_, int jj_, int kk_) -> Real {
-        Real w1 = amrex::Math::abs(fsten(ii_,jj_,kk_-2,ist_00p));
-        Real w2 = amrex::Math::abs(fsten(ii_,jj_,kk_-1,ist_00p));
+        Real w1 = std::abs(fsten(ii_,jj_,kk_-2,ist_00p));
+        Real w2 = std::abs(fsten(ii_,jj_,kk_-1,ist_00p));
         if (w1 == Real(0.) && w2 == Real(0.)) {
             return Real(0.5);
         } else {
@@ -3560,116 +3560,116 @@ void mlndlap_stencil_rap (int i, int j, int k, Array4<Real> const& csten,
     };
 
     auto restrict_from_p0m_to = [&fsten] (int ii_, int jj_, int kk_) -> Real {
-        Real w1m = amrex::Math::abs(fsten(ii_  ,jj_,kk_-1,ist_p00)) / (amrex::Math::abs(fsten(ii_  ,jj_,kk_-2,ist_p0p))
-                                                              +amrex::Math::abs(fsten(ii_  ,jj_,kk_-1,ist_p0p)) + eps);
-        Real w1p = amrex::Math::abs(fsten(ii_+1,jj_,kk_-1,ist_p00)) / (amrex::Math::abs(fsten(ii_+1,jj_,kk_-2,ist_p0p))
-                                                              +amrex::Math::abs(fsten(ii_+1,jj_,kk_-1,ist_p0p)) + eps);
-        Real w2m = amrex::Math::abs(fsten(ii_+1,jj_,kk_-2,ist_00p)) / (amrex::Math::abs(fsten(ii_  ,jj_,kk_-2,ist_p0p))
-                                                              +amrex::Math::abs(fsten(ii_+1,jj_,kk_-2,ist_p0p)) + eps);
-        Real w2p = amrex::Math::abs(fsten(ii_+1,jj_,kk_-1,ist_00p)) / (amrex::Math::abs(fsten(ii_  ,jj_,kk_-1,ist_p0p))
-                                                              +amrex::Math::abs(fsten(ii_+1,jj_,kk_-1,ist_p0p)) + eps);
-        Real wmm = amrex::Math::abs(fsten(ii_  ,jj_,kk_-2,ist_p0p)) * (Real(1.) + w1m + w2m);
-        Real wpm = amrex::Math::abs(fsten(ii_+1,jj_,kk_-2,ist_p0p)) * (Real(1.) + w1p + w2m);
-        Real wmp = amrex::Math::abs(fsten(ii_  ,jj_,kk_-1,ist_p0p)) * (Real(1.) + w1m + w2p);
-        Real wpp = amrex::Math::abs(fsten(ii_+1,jj_,kk_-1,ist_p0p)) * (Real(1.) + w1p + w2p);
+        Real w1m = std::abs(fsten(ii_  ,jj_,kk_-1,ist_p00)) / (std::abs(fsten(ii_  ,jj_,kk_-2,ist_p0p))
+                                                              +std::abs(fsten(ii_  ,jj_,kk_-1,ist_p0p)) + eps);
+        Real w1p = std::abs(fsten(ii_+1,jj_,kk_-1,ist_p00)) / (std::abs(fsten(ii_+1,jj_,kk_-2,ist_p0p))
+                                                              +std::abs(fsten(ii_+1,jj_,kk_-1,ist_p0p)) + eps);
+        Real w2m = std::abs(fsten(ii_+1,jj_,kk_-2,ist_00p)) / (std::abs(fsten(ii_  ,jj_,kk_-2,ist_p0p))
+                                                              +std::abs(fsten(ii_+1,jj_,kk_-2,ist_p0p)) + eps);
+        Real w2p = std::abs(fsten(ii_+1,jj_,kk_-1,ist_00p)) / (std::abs(fsten(ii_  ,jj_,kk_-1,ist_p0p))
+                                                              +std::abs(fsten(ii_+1,jj_,kk_-1,ist_p0p)) + eps);
+        Real wmm = std::abs(fsten(ii_  ,jj_,kk_-2,ist_p0p)) * (Real(1.) + w1m + w2m);
+        Real wpm = std::abs(fsten(ii_+1,jj_,kk_-2,ist_p0p)) * (Real(1.) + w1p + w2m);
+        Real wmp = std::abs(fsten(ii_  ,jj_,kk_-1,ist_p0p)) * (Real(1.) + w1m + w2p);
+        Real wpp = std::abs(fsten(ii_+1,jj_,kk_-1,ist_p0p)) * (Real(1.) + w1p + w2p);
         return wmp / (wmm+wpm+wmp+wpp+eps);
     };
 
     auto restrict_from_mpm_to = [&fsten] (int ii_, int jj_, int kk_) -> Real {
         Real r = Real(1.);
-        r += amrex::Math::abs(fsten(ii_-1,jj_+1,kk_-1,ist_p00)) /
-           ( amrex::Math::abs(fsten(ii_-1,jj_  ,kk_-2,ist_ppp))
-           + amrex::Math::abs(fsten(ii_-1,jj_+1,kk_-2,ist_ppp))
-           + amrex::Math::abs(fsten(ii_-1,jj_  ,kk_-1,ist_ppp))
-           + amrex::Math::abs(fsten(ii_-1,jj_+1,kk_-1,ist_ppp)) + eps);
-        r += amrex::Math::abs(fsten(ii_-1,jj_  ,kk_-1,ist_0p0)) /
-           ( amrex::Math::abs(fsten(ii_-2,jj_  ,kk_-2,ist_ppp))
-           + amrex::Math::abs(fsten(ii_-1,jj_  ,kk_-2,ist_ppp))
-           + amrex::Math::abs(fsten(ii_-2,jj_  ,kk_-1,ist_ppp))
-           + amrex::Math::abs(fsten(ii_-1,jj_  ,kk_-1,ist_ppp)) + eps);
-        r += amrex::Math::abs(fsten(ii_-1,jj_+1,kk_-1,ist_00p)) /
-           ( amrex::Math::abs(fsten(ii_-2,jj_  ,kk_-1,ist_ppp))
-           + amrex::Math::abs(fsten(ii_-1,jj_  ,kk_-1,ist_ppp))
-           + amrex::Math::abs(fsten(ii_-2,jj_+1,kk_-1,ist_ppp))
-           + amrex::Math::abs(fsten(ii_-1,jj_+1,kk_-1,ist_ppp)) + eps);
-        r += amrex::Math::abs(fsten(ii_-1,jj_  ,kk_-1,ist_pp0)) /
-           ( amrex::Math::abs(fsten(ii_-1,jj_  ,kk_-2,ist_ppp))
-           + amrex::Math::abs(fsten(ii_-1,jj_  ,kk_-1,ist_ppp)) + eps);
-        r += amrex::Math::abs(fsten(ii_-1,jj_+1,kk_-1,ist_p0p)) /
-           ( amrex::Math::abs(fsten(ii_-1,jj_  ,kk_-1,ist_ppp))
-           + amrex::Math::abs(fsten(ii_-1,jj_+1,kk_-1,ist_ppp)) + eps);
-        r += amrex::Math::abs(fsten(ii_-1,jj_  ,kk_-1,ist_0pp)) /
-           ( amrex::Math::abs(fsten(ii_-2,jj_  ,kk_-1,ist_ppp))
-           + amrex::Math::abs(fsten(ii_-1,jj_  ,kk_-1,ist_ppp)) + eps);
-        r *= amrex::Math::abs(fsten(ii_-1,jj_  ,kk_-1,ist_ppp)) * fsten(ii_-1,jj_+1,kk_-1,ist_inv);
+        r += std::abs(fsten(ii_-1,jj_+1,kk_-1,ist_p00)) /
+           ( std::abs(fsten(ii_-1,jj_  ,kk_-2,ist_ppp))
+           + std::abs(fsten(ii_-1,jj_+1,kk_-2,ist_ppp))
+           + std::abs(fsten(ii_-1,jj_  ,kk_-1,ist_ppp))
+           + std::abs(fsten(ii_-1,jj_+1,kk_-1,ist_ppp)) + eps);
+        r += std::abs(fsten(ii_-1,jj_  ,kk_-1,ist_0p0)) /
+           ( std::abs(fsten(ii_-2,jj_  ,kk_-2,ist_ppp))
+           + std::abs(fsten(ii_-1,jj_  ,kk_-2,ist_ppp))
+           + std::abs(fsten(ii_-2,jj_  ,kk_-1,ist_ppp))
+           + std::abs(fsten(ii_-1,jj_  ,kk_-1,ist_ppp)) + eps);
+        r += std::abs(fsten(ii_-1,jj_+1,kk_-1,ist_00p)) /
+           ( std::abs(fsten(ii_-2,jj_  ,kk_-1,ist_ppp))
+           + std::abs(fsten(ii_-1,jj_  ,kk_-1,ist_ppp))
+           + std::abs(fsten(ii_-2,jj_+1,kk_-1,ist_ppp))
+           + std::abs(fsten(ii_-1,jj_+1,kk_-1,ist_ppp)) + eps);
+        r += std::abs(fsten(ii_-1,jj_  ,kk_-1,ist_pp0)) /
+           ( std::abs(fsten(ii_-1,jj_  ,kk_-2,ist_ppp))
+           + std::abs(fsten(ii_-1,jj_  ,kk_-1,ist_ppp)) + eps);
+        r += std::abs(fsten(ii_-1,jj_+1,kk_-1,ist_p0p)) /
+           ( std::abs(fsten(ii_-1,jj_  ,kk_-1,ist_ppp))
+           + std::abs(fsten(ii_-1,jj_+1,kk_-1,ist_ppp)) + eps);
+        r += std::abs(fsten(ii_-1,jj_  ,kk_-1,ist_0pp)) /
+           ( std::abs(fsten(ii_-2,jj_  ,kk_-1,ist_ppp))
+           + std::abs(fsten(ii_-1,jj_  ,kk_-1,ist_ppp)) + eps);
+        r *= std::abs(fsten(ii_-1,jj_  ,kk_-1,ist_ppp)) * fsten(ii_-1,jj_+1,kk_-1,ist_inv);
         return r;
     };
 
     auto restrict_from_0pm_to = [&fsten] (int ii_, int jj_, int kk_) -> Real {
-        Real w1m = amrex::Math::abs(fsten(ii_,jj_  ,kk_-1,ist_0p0)) / (amrex::Math::abs(fsten(ii_,jj_  ,kk_-2,ist_0pp))
-                                                              +amrex::Math::abs(fsten(ii_,jj_  ,kk_-1,ist_0pp)) + eps);
-        Real w1p = amrex::Math::abs(fsten(ii_,jj_+1,kk_-1,ist_0p0)) / (amrex::Math::abs(fsten(ii_,jj_+1,kk_-2,ist_0pp))
-                                                              +amrex::Math::abs(fsten(ii_,jj_+1,kk_-1,ist_0pp)) + eps);
-        Real w2m = amrex::Math::abs(fsten(ii_,jj_+1,kk_-2,ist_00p)) / (amrex::Math::abs(fsten(ii_,jj_  ,kk_-2,ist_0pp))
-                                                              +amrex::Math::abs(fsten(ii_,jj_+1,kk_-2,ist_0pp)) + eps);
-        Real w2p = amrex::Math::abs(fsten(ii_,jj_+1,kk_-1,ist_00p)) / (amrex::Math::abs(fsten(ii_,jj_  ,kk_-1,ist_0pp))
-                                                              +amrex::Math::abs(fsten(ii_,jj_+1,kk_-1,ist_0pp)) + eps);
-        Real wmm = amrex::Math::abs(fsten(ii_,jj_  ,kk_-2,ist_0pp)) * (Real(1.) + w1m + w2m);
-        Real wpm = amrex::Math::abs(fsten(ii_,jj_+1,kk_-2,ist_0pp)) * (Real(1.) + w1p + w2m);
-        Real wmp = amrex::Math::abs(fsten(ii_,jj_  ,kk_-1,ist_0pp)) * (Real(1.) + w1m + w2p);
-        Real wpp = amrex::Math::abs(fsten(ii_,jj_+1,kk_-1,ist_0pp)) * (Real(1.) + w1p + w2p);
+        Real w1m = std::abs(fsten(ii_,jj_  ,kk_-1,ist_0p0)) / (std::abs(fsten(ii_,jj_  ,kk_-2,ist_0pp))
+                                                              +std::abs(fsten(ii_,jj_  ,kk_-1,ist_0pp)) + eps);
+        Real w1p = std::abs(fsten(ii_,jj_+1,kk_-1,ist_0p0)) / (std::abs(fsten(ii_,jj_+1,kk_-2,ist_0pp))
+                                                              +std::abs(fsten(ii_,jj_+1,kk_-1,ist_0pp)) + eps);
+        Real w2m = std::abs(fsten(ii_,jj_+1,kk_-2,ist_00p)) / (std::abs(fsten(ii_,jj_  ,kk_-2,ist_0pp))
+                                                              +std::abs(fsten(ii_,jj_+1,kk_-2,ist_0pp)) + eps);
+        Real w2p = std::abs(fsten(ii_,jj_+1,kk_-1,ist_00p)) / (std::abs(fsten(ii_,jj_  ,kk_-1,ist_0pp))
+                                                              +std::abs(fsten(ii_,jj_+1,kk_-1,ist_0pp)) + eps);
+        Real wmm = std::abs(fsten(ii_,jj_  ,kk_-2,ist_0pp)) * (Real(1.) + w1m + w2m);
+        Real wpm = std::abs(fsten(ii_,jj_+1,kk_-2,ist_0pp)) * (Real(1.) + w1p + w2m);
+        Real wmp = std::abs(fsten(ii_,jj_  ,kk_-1,ist_0pp)) * (Real(1.) + w1m + w2p);
+        Real wpp = std::abs(fsten(ii_,jj_+1,kk_-1,ist_0pp)) * (Real(1.) + w1p + w2p);
         return wmp / (wmm+wpm+wmp+wpp+eps);
     };
 
     auto restrict_from_ppm_to = [&fsten] (int ii_, int jj_, int kk_) -> Real {
         Real r = Real(1.);
-        r += amrex::Math::abs(fsten(ii_  ,jj_+1,kk_-1,ist_p00)) /
-           ( amrex::Math::abs(fsten(ii_  ,jj_  ,kk_-2,ist_ppp))
-           + amrex::Math::abs(fsten(ii_  ,jj_+1,kk_-2,ist_ppp))
-           + amrex::Math::abs(fsten(ii_  ,jj_  ,kk_-1,ist_ppp))
-           + amrex::Math::abs(fsten(ii_  ,jj_+1,kk_-1,ist_ppp)) + eps);
-        r += amrex::Math::abs(fsten(ii_+1,jj_  ,kk_-1,ist_0p0)) /
-           ( amrex::Math::abs(fsten(ii_  ,jj_  ,kk_-2,ist_ppp))
-           + amrex::Math::abs(fsten(ii_+1,jj_  ,kk_-2,ist_ppp))
-           + amrex::Math::abs(fsten(ii_  ,jj_  ,kk_-1,ist_ppp))
-           + amrex::Math::abs(fsten(ii_+1,jj_  ,kk_-1,ist_ppp)) + eps);
-        r += amrex::Math::abs(fsten(ii_+1,jj_+1,kk_-1,ist_00p)) /
-           ( amrex::Math::abs(fsten(ii_  ,jj_  ,kk_-1,ist_ppp))
-           + amrex::Math::abs(fsten(ii_+1,jj_  ,kk_-1,ist_ppp))
-           + amrex::Math::abs(fsten(ii_  ,jj_+1,kk_-1,ist_ppp))
-           + amrex::Math::abs(fsten(ii_+1,jj_+1,kk_-1,ist_ppp)) + eps);
-        r += amrex::Math::abs(fsten(ii_  ,jj_  ,kk_-1,ist_pp0)) /
-           ( amrex::Math::abs(fsten(ii_  ,jj_  ,kk_-2,ist_ppp))
-           + amrex::Math::abs(fsten(ii_  ,jj_  ,kk_-1,ist_ppp)) + eps);
-        r += amrex::Math::abs(fsten(ii_  ,jj_+1,kk_-1,ist_p0p)) /
-           ( amrex::Math::abs(fsten(ii_  ,jj_  ,kk_-1,ist_ppp))
-           + amrex::Math::abs(fsten(ii_  ,jj_+1,kk_-1,ist_ppp)) + eps);
-        r += amrex::Math::abs(fsten(ii_+1,jj_  ,kk_-1,ist_0pp)) /
-           ( amrex::Math::abs(fsten(ii_  ,jj_  ,kk_-1,ist_ppp))
-           + amrex::Math::abs(fsten(ii_+1,jj_  ,kk_-1,ist_ppp)) + eps);
-        r *= amrex::Math::abs(fsten(ii_  ,jj_  ,kk_-1,ist_ppp)) * fsten(ii_+1,jj_+1,kk_-1,ist_inv);
+        r += std::abs(fsten(ii_  ,jj_+1,kk_-1,ist_p00)) /
+           ( std::abs(fsten(ii_  ,jj_  ,kk_-2,ist_ppp))
+           + std::abs(fsten(ii_  ,jj_+1,kk_-2,ist_ppp))
+           + std::abs(fsten(ii_  ,jj_  ,kk_-1,ist_ppp))
+           + std::abs(fsten(ii_  ,jj_+1,kk_-1,ist_ppp)) + eps);
+        r += std::abs(fsten(ii_+1,jj_  ,kk_-1,ist_0p0)) /
+           ( std::abs(fsten(ii_  ,jj_  ,kk_-2,ist_ppp))
+           + std::abs(fsten(ii_+1,jj_  ,kk_-2,ist_ppp))
+           + std::abs(fsten(ii_  ,jj_  ,kk_-1,ist_ppp))
+           + std::abs(fsten(ii_+1,jj_  ,kk_-1,ist_ppp)) + eps);
+        r += std::abs(fsten(ii_+1,jj_+1,kk_-1,ist_00p)) /
+           ( std::abs(fsten(ii_  ,jj_  ,kk_-1,ist_ppp))
+           + std::abs(fsten(ii_+1,jj_  ,kk_-1,ist_ppp))
+           + std::abs(fsten(ii_  ,jj_+1,kk_-1,ist_ppp))
+           + std::abs(fsten(ii_+1,jj_+1,kk_-1,ist_ppp)) + eps);
+        r += std::abs(fsten(ii_  ,jj_  ,kk_-1,ist_pp0)) /
+           ( std::abs(fsten(ii_  ,jj_  ,kk_-2,ist_ppp))
+           + std::abs(fsten(ii_  ,jj_  ,kk_-1,ist_ppp)) + eps);
+        r += std::abs(fsten(ii_  ,jj_+1,kk_-1,ist_p0p)) /
+           ( std::abs(fsten(ii_  ,jj_  ,kk_-1,ist_ppp))
+           + std::abs(fsten(ii_  ,jj_+1,kk_-1,ist_ppp)) + eps);
+        r += std::abs(fsten(ii_+1,jj_  ,kk_-1,ist_0pp)) /
+           ( std::abs(fsten(ii_  ,jj_  ,kk_-1,ist_ppp))
+           + std::abs(fsten(ii_+1,jj_  ,kk_-1,ist_ppp)) + eps);
+        r *= std::abs(fsten(ii_  ,jj_  ,kk_-1,ist_ppp)) * fsten(ii_+1,jj_+1,kk_-1,ist_inv);
         return r;
     };
 
     auto restrict_from_mm0_to = [&fsten] (int ii_, int jj_, int kk_) -> Real {
-        Real w1m = amrex::Math::abs(fsten(ii_-2,jj_-1,kk_,ist_p00)) / (amrex::Math::abs(fsten(ii_-2,jj_-2,kk_,ist_pp0))
-                                                              +amrex::Math::abs(fsten(ii_-2,jj_-1,kk_,ist_pp0)) + eps);
-        Real w1p = amrex::Math::abs(fsten(ii_-1,jj_-1,kk_,ist_p00)) / (amrex::Math::abs(fsten(ii_-1,jj_-2,kk_,ist_pp0))
-                                                              +amrex::Math::abs(fsten(ii_-1,jj_-1,kk_,ist_pp0)) + eps);
-        Real w2m = amrex::Math::abs(fsten(ii_-1,jj_-2,kk_,ist_0p0)) / (amrex::Math::abs(fsten(ii_-2,jj_-2,kk_,ist_pp0))
-                                                              +amrex::Math::abs(fsten(ii_-1,jj_-2,kk_,ist_pp0)) + eps);
-        Real w2p = amrex::Math::abs(fsten(ii_-1,jj_-1,kk_,ist_0p0)) / (amrex::Math::abs(fsten(ii_-2,jj_-1,kk_,ist_pp0))
-                                                              +amrex::Math::abs(fsten(ii_-1,jj_-1,kk_,ist_pp0)) + eps);
-        Real wmm = amrex::Math::abs(fsten(ii_-2,jj_-2,kk_,ist_pp0)) * (Real(1.) + w1m + w2m);
-        Real wpm = amrex::Math::abs(fsten(ii_-1,jj_-2,kk_,ist_pp0)) * (Real(1.) + w1p + w2m);
-        Real wmp = amrex::Math::abs(fsten(ii_-2,jj_-1,kk_,ist_pp0)) * (Real(1.) + w1m + w2p);
-        Real wpp = amrex::Math::abs(fsten(ii_-1,jj_-1,kk_,ist_pp0)) * (Real(1.) + w1p + w2p);
+        Real w1m = std::abs(fsten(ii_-2,jj_-1,kk_,ist_p00)) / (std::abs(fsten(ii_-2,jj_-2,kk_,ist_pp0))
+                                                              +std::abs(fsten(ii_-2,jj_-1,kk_,ist_pp0)) + eps);
+        Real w1p = std::abs(fsten(ii_-1,jj_-1,kk_,ist_p00)) / (std::abs(fsten(ii_-1,jj_-2,kk_,ist_pp0))
+                                                              +std::abs(fsten(ii_-1,jj_-1,kk_,ist_pp0)) + eps);
+        Real w2m = std::abs(fsten(ii_-1,jj_-2,kk_,ist_0p0)) / (std::abs(fsten(ii_-2,jj_-2,kk_,ist_pp0))
+                                                              +std::abs(fsten(ii_-1,jj_-2,kk_,ist_pp0)) + eps);
+        Real w2p = std::abs(fsten(ii_-1,jj_-1,kk_,ist_0p0)) / (std::abs(fsten(ii_-2,jj_-1,kk_,ist_pp0))
+                                                              +std::abs(fsten(ii_-1,jj_-1,kk_,ist_pp0)) + eps);
+        Real wmm = std::abs(fsten(ii_-2,jj_-2,kk_,ist_pp0)) * (Real(1.) + w1m + w2m);
+        Real wpm = std::abs(fsten(ii_-1,jj_-2,kk_,ist_pp0)) * (Real(1.) + w1p + w2m);
+        Real wmp = std::abs(fsten(ii_-2,jj_-1,kk_,ist_pp0)) * (Real(1.) + w1m + w2p);
+        Real wpp = std::abs(fsten(ii_-1,jj_-1,kk_,ist_pp0)) * (Real(1.) + w1p + w2p);
         return wpp / (wmm+wpm+wmp+wpp+eps);
     };
 
     auto restrict_from_0m0_to = [&fsten] (int ii_, int jj_, int kk_) -> Real {
-        Real w1 = amrex::Math::abs(fsten(ii_,jj_-2,kk_,ist_0p0));
-        Real w2 = amrex::Math::abs(fsten(ii_,jj_-1,kk_,ist_0p0));
+        Real w1 = std::abs(fsten(ii_,jj_-2,kk_,ist_0p0));
+        Real w2 = std::abs(fsten(ii_,jj_-1,kk_,ist_0p0));
         if (w1 == Real(0.) && w2 == Real(0.)) {
             return Real(0.5);
         } else {
@@ -3678,24 +3678,24 @@ void mlndlap_stencil_rap (int i, int j, int k, Array4<Real> const& csten,
     };
 
     auto restrict_from_pm0_to = [&fsten] (int ii_, int jj_, int kk_) -> Real {
-        Real w1m = amrex::Math::abs(fsten(ii_  ,jj_-1,kk_,ist_p00)) / (amrex::Math::abs(fsten(ii_  ,jj_-2,kk_,ist_pp0))
-                                                              +amrex::Math::abs(fsten(ii_  ,jj_-1,kk_,ist_pp0)) + eps);
-        Real w1p = amrex::Math::abs(fsten(ii_+1,jj_-1,kk_,ist_p00)) / (amrex::Math::abs(fsten(ii_+1,jj_-2,kk_,ist_pp0))
-                                                              +amrex::Math::abs(fsten(ii_+1,jj_-1,kk_,ist_pp0)) + eps);
-        Real w2m = amrex::Math::abs(fsten(ii_+1,jj_-2,kk_,ist_0p0)) / (amrex::Math::abs(fsten(ii_  ,jj_-2,kk_,ist_pp0))
-                                                              +amrex::Math::abs(fsten(ii_+1,jj_-2,kk_,ist_pp0)) + eps);
-        Real w2p = amrex::Math::abs(fsten(ii_+1,jj_-1,kk_,ist_0p0)) / (amrex::Math::abs(fsten(ii_  ,jj_-1,kk_,ist_pp0))
-                                                              +amrex::Math::abs(fsten(ii_+1,jj_-1,kk_,ist_pp0)) + eps);
-        Real wmm = amrex::Math::abs(fsten(ii_  ,jj_-2,kk_,ist_pp0)) * (Real(1.) + w1m + w2m);
-        Real wpm = amrex::Math::abs(fsten(ii_+1,jj_-2,kk_,ist_pp0)) * (Real(1.) + w1p + w2m);
-        Real wmp = amrex::Math::abs(fsten(ii_  ,jj_-1,kk_,ist_pp0)) * (Real(1.) + w1m + w2p);
-        Real wpp = amrex::Math::abs(fsten(ii_+1,jj_-1,kk_,ist_pp0)) * (Real(1.) + w1p + w2p);
+        Real w1m = std::abs(fsten(ii_  ,jj_-1,kk_,ist_p00)) / (std::abs(fsten(ii_  ,jj_-2,kk_,ist_pp0))
+                                                              +std::abs(fsten(ii_  ,jj_-1,kk_,ist_pp0)) + eps);
+        Real w1p = std::abs(fsten(ii_+1,jj_-1,kk_,ist_p00)) / (std::abs(fsten(ii_+1,jj_-2,kk_,ist_pp0))
+                                                              +std::abs(fsten(ii_+1,jj_-1,kk_,ist_pp0)) + eps);
+        Real w2m = std::abs(fsten(ii_+1,jj_-2,kk_,ist_0p0)) / (std::abs(fsten(ii_  ,jj_-2,kk_,ist_pp0))
+                                                              +std::abs(fsten(ii_+1,jj_-2,kk_,ist_pp0)) + eps);
+        Real w2p = std::abs(fsten(ii_+1,jj_-1,kk_,ist_0p0)) / (std::abs(fsten(ii_  ,jj_-1,kk_,ist_pp0))
+                                                              +std::abs(fsten(ii_+1,jj_-1,kk_,ist_pp0)) + eps);
+        Real wmm = std::abs(fsten(ii_  ,jj_-2,kk_,ist_pp0)) * (Real(1.) + w1m + w2m);
+        Real wpm = std::abs(fsten(ii_+1,jj_-2,kk_,ist_pp0)) * (Real(1.) + w1p + w2m);
+        Real wmp = std::abs(fsten(ii_  ,jj_-1,kk_,ist_pp0)) * (Real(1.) + w1m + w2p);
+        Real wpp = std::abs(fsten(ii_+1,jj_-1,kk_,ist_pp0)) * (Real(1.) + w1p + w2p);
         return wmp / (wmm+wpm+wmp+wpp+eps);
     };
 
     auto restrict_from_m00_to = [&fsten] (int ii_, int jj_, int kk_) -> Real {
-        Real w1 = amrex::Math::abs(fsten(ii_-2,jj_,kk_,ist_p00));
-        Real w2 = amrex::Math::abs(fsten(ii_-1,jj_,kk_,ist_p00));
+        Real w1 = std::abs(fsten(ii_-2,jj_,kk_,ist_p00));
+        Real w2 = std::abs(fsten(ii_-1,jj_,kk_,ist_p00));
         if (w1 == Real(0.) && w2 == Real(0.)) {
             return Real(0.5);
         } else {
@@ -3708,8 +3708,8 @@ void mlndlap_stencil_rap (int i, int j, int k, Array4<Real> const& csten,
     };
 
     auto restrict_from_p00_to = [&fsten] (int ii_, int jj_, int kk_) -> Real {
-        Real w1 = amrex::Math::abs(fsten(ii_  ,jj_,kk_,ist_p00));
-        Real w2 = amrex::Math::abs(fsten(ii_+1,jj_,kk_,ist_p00));
+        Real w1 = std::abs(fsten(ii_  ,jj_,kk_,ist_p00));
+        Real w2 = std::abs(fsten(ii_+1,jj_,kk_,ist_p00));
         if (w1 == Real(0.) && w2 == Real(0.)) {
             return Real(0.5);
         } else {
@@ -3718,24 +3718,24 @@ void mlndlap_stencil_rap (int i, int j, int k, Array4<Real> const& csten,
     };
 
     auto restrict_from_mp0_to = [&fsten] (int ii_, int jj_, int kk_) -> Real {
-        Real w1m = amrex::Math::abs(fsten(ii_-2,jj_+1,kk_,ist_p00)) / (amrex::Math::abs(fsten(ii_-2,jj_  ,kk_,ist_pp0))
-                                                              +amrex::Math::abs(fsten(ii_-2,jj_+1,kk_,ist_pp0)) + eps);
-        Real w1p = amrex::Math::abs(fsten(ii_-1,jj_+1,kk_,ist_p00)) / (amrex::Math::abs(fsten(ii_-1,jj_  ,kk_,ist_pp0))
-                                                              +amrex::Math::abs(fsten(ii_-1,jj_+1,kk_,ist_pp0)) + eps);
-        Real w2m = amrex::Math::abs(fsten(ii_-1,jj_  ,kk_,ist_0p0)) / (amrex::Math::abs(fsten(ii_-2,jj_  ,kk_,ist_pp0))
-                                                              +amrex::Math::abs(fsten(ii_-1,jj_  ,kk_,ist_pp0)) + eps);
-        Real w2p = amrex::Math::abs(fsten(ii_-1,jj_+1,kk_,ist_0p0)) / (amrex::Math::abs(fsten(ii_-2,jj_+1,kk_,ist_pp0))
-                                                              +amrex::Math::abs(fsten(ii_-1,jj_+1,kk_,ist_pp0)) + eps);
-        Real wmm = amrex::Math::abs(fsten(ii_-2,jj_  ,kk_,ist_pp0)) * (Real(1.) + w1m + w2m);
-        Real wpm = amrex::Math::abs(fsten(ii_-1,jj_  ,kk_,ist_pp0)) * (Real(1.) + w1p + w2m);
-        Real wmp = amrex::Math::abs(fsten(ii_-2,jj_+1,kk_,ist_pp0)) * (Real(1.) + w1m + w2p);
-        Real wpp = amrex::Math::abs(fsten(ii_-1,jj_+1,kk_,ist_pp0)) * (Real(1.) + w1p + w2p);
+        Real w1m = std::abs(fsten(ii_-2,jj_+1,kk_,ist_p00)) / (std::abs(fsten(ii_-2,jj_  ,kk_,ist_pp0))
+                                                              +std::abs(fsten(ii_-2,jj_+1,kk_,ist_pp0)) + eps);
+        Real w1p = std::abs(fsten(ii_-1,jj_+1,kk_,ist_p00)) / (std::abs(fsten(ii_-1,jj_  ,kk_,ist_pp0))
+                                                              +std::abs(fsten(ii_-1,jj_+1,kk_,ist_pp0)) + eps);
+        Real w2m = std::abs(fsten(ii_-1,jj_  ,kk_,ist_0p0)) / (std::abs(fsten(ii_-2,jj_  ,kk_,ist_pp0))
+                                                              +std::abs(fsten(ii_-1,jj_  ,kk_,ist_pp0)) + eps);
+        Real w2p = std::abs(fsten(ii_-1,jj_+1,kk_,ist_0p0)) / (std::abs(fsten(ii_-2,jj_+1,kk_,ist_pp0))
+                                                              +std::abs(fsten(ii_-1,jj_+1,kk_,ist_pp0)) + eps);
+        Real wmm = std::abs(fsten(ii_-2,jj_  ,kk_,ist_pp0)) * (Real(1.) + w1m + w2m);
+        Real wpm = std::abs(fsten(ii_-1,jj_  ,kk_,ist_pp0)) * (Real(1.) + w1p + w2m);
+        Real wmp = std::abs(fsten(ii_-2,jj_+1,kk_,ist_pp0)) * (Real(1.) + w1m + w2p);
+        Real wpp = std::abs(fsten(ii_-1,jj_+1,kk_,ist_pp0)) * (Real(1.) + w1p + w2p);
         return wpm / (wmm+wpm+wmp+wpp+eps);
     };
 
     auto restrict_from_0p0_to = [&fsten] (int ii_, int jj_, int kk_) -> Real {
-        Real w1 = amrex::Math::abs(fsten(ii_,jj_  ,kk_,ist_0p0));
-        Real w2 = amrex::Math::abs(fsten(ii_,jj_+1,kk_,ist_0p0));
+        Real w1 = std::abs(fsten(ii_,jj_  ,kk_,ist_0p0));
+        Real w2 = std::abs(fsten(ii_,jj_+1,kk_,ist_0p0));
         if (w1 == Real(0.) && w2 == Real(0.)) {
             return Real(0.5);
         } else {
@@ -3744,116 +3744,116 @@ void mlndlap_stencil_rap (int i, int j, int k, Array4<Real> const& csten,
     };
 
     auto restrict_from_pp0_to = [&fsten] (int ii_, int jj_, int kk_) -> Real {
-        Real w1m = amrex::Math::abs(fsten(ii_  ,jj_+1,kk_,ist_p00)) / (amrex::Math::abs(fsten(ii_  ,jj_  ,kk_,ist_pp0))
-                                                              +amrex::Math::abs(fsten(ii_  ,jj_+1,kk_,ist_pp0)) + eps);
-        Real w1p = amrex::Math::abs(fsten(ii_+1,jj_+1,kk_,ist_p00)) / (amrex::Math::abs(fsten(ii_+1,jj_  ,kk_,ist_pp0))
-                                                              +amrex::Math::abs(fsten(ii_+1,jj_+1,kk_,ist_pp0)) + eps);
-        Real w2m = amrex::Math::abs(fsten(ii_+1,jj_  ,kk_,ist_0p0)) / (amrex::Math::abs(fsten(ii_  ,jj_  ,kk_,ist_pp0))
-                                                              +amrex::Math::abs(fsten(ii_+1,jj_  ,kk_,ist_pp0)) + eps);
-        Real w2p = amrex::Math::abs(fsten(ii_+1,jj_+1,kk_,ist_0p0)) / (amrex::Math::abs(fsten(ii_  ,jj_+1,kk_,ist_pp0))
-                                                              +amrex::Math::abs(fsten(ii_+1,jj_+1,kk_,ist_pp0)) + eps);
-        Real wmm = amrex::Math::abs(fsten(ii_  ,jj_  ,kk_,ist_pp0)) * (Real(1.) + w1m + w2m);
-        Real wpm = amrex::Math::abs(fsten(ii_+1,jj_  ,kk_,ist_pp0)) * (Real(1.) + w1p + w2m);
-        Real wmp = amrex::Math::abs(fsten(ii_  ,jj_+1,kk_,ist_pp0)) * (Real(1.) + w1m + w2p);
-        Real wpp = amrex::Math::abs(fsten(ii_+1,jj_+1,kk_,ist_pp0)) * (Real(1.) + w1p + w2p);
+        Real w1m = std::abs(fsten(ii_  ,jj_+1,kk_,ist_p00)) / (std::abs(fsten(ii_  ,jj_  ,kk_,ist_pp0))
+                                                              +std::abs(fsten(ii_  ,jj_+1,kk_,ist_pp0)) + eps);
+        Real w1p = std::abs(fsten(ii_+1,jj_+1,kk_,ist_p00)) / (std::abs(fsten(ii_+1,jj_  ,kk_,ist_pp0))
+                                                              +std::abs(fsten(ii_+1,jj_+1,kk_,ist_pp0)) + eps);
+        Real w2m = std::abs(fsten(ii_+1,jj_  ,kk_,ist_0p0)) / (std::abs(fsten(ii_  ,jj_  ,kk_,ist_pp0))
+                                                              +std::abs(fsten(ii_+1,jj_  ,kk_,ist_pp0)) + eps);
+        Real w2p = std::abs(fsten(ii_+1,jj_+1,kk_,ist_0p0)) / (std::abs(fsten(ii_  ,jj_+1,kk_,ist_pp0))
+                                                              +std::abs(fsten(ii_+1,jj_+1,kk_,ist_pp0)) + eps);
+        Real wmm = std::abs(fsten(ii_  ,jj_  ,kk_,ist_pp0)) * (Real(1.) + w1m + w2m);
+        Real wpm = std::abs(fsten(ii_+1,jj_  ,kk_,ist_pp0)) * (Real(1.) + w1p + w2m);
+        Real wmp = std::abs(fsten(ii_  ,jj_+1,kk_,ist_pp0)) * (Real(1.) + w1m + w2p);
+        Real wpp = std::abs(fsten(ii_+1,jj_+1,kk_,ist_pp0)) * (Real(1.) + w1p + w2p);
         return wmm / (wmm+wpm+wmp+wpp+eps);
     };
 
     auto restrict_from_mmp_to = [&fsten] (int ii_, int jj_, int kk_) -> Real {
         Real r = Real(1.);
-        r += amrex::Math::abs(fsten(ii_-1,jj_-1,kk_+1,ist_p00)) /
-           ( amrex::Math::abs(fsten(ii_-1,jj_-2,kk_  ,ist_ppp))
-           + amrex::Math::abs(fsten(ii_-1,jj_-1,kk_  ,ist_ppp))
-           + amrex::Math::abs(fsten(ii_-1,jj_-2,kk_+1,ist_ppp))
-           + amrex::Math::abs(fsten(ii_-1,jj_-1,kk_+1,ist_ppp)) + eps);
-        r += amrex::Math::abs(fsten(ii_-1,jj_-1,kk_+1,ist_0p0)) /
-           ( amrex::Math::abs(fsten(ii_-2,jj_-1,kk_  ,ist_ppp))
-           + amrex::Math::abs(fsten(ii_-1,jj_-1,kk_  ,ist_ppp))
-           + amrex::Math::abs(fsten(ii_-2,jj_-1,kk_+1,ist_ppp))
-           + amrex::Math::abs(fsten(ii_-1,jj_-1,kk_+1,ist_ppp)) + eps);
-        r += amrex::Math::abs(fsten(ii_-1,jj_-1,kk_  ,ist_00p)) /
-           ( amrex::Math::abs(fsten(ii_-2,jj_-2,kk_  ,ist_ppp))
-           + amrex::Math::abs(fsten(ii_-1,jj_-2,kk_  ,ist_ppp))
-           + amrex::Math::abs(fsten(ii_-2,jj_-1,kk_  ,ist_ppp))
-           + amrex::Math::abs(fsten(ii_-1,jj_-1,kk_  ,ist_ppp)) + eps);
-        r += amrex::Math::abs(fsten(ii_-1,jj_-1,kk_+1,ist_pp0)) /
-           ( amrex::Math::abs(fsten(ii_-1,jj_-1,kk_  ,ist_ppp))
-           + amrex::Math::abs(fsten(ii_-1,jj_-1,kk_+1,ist_ppp)) + eps);
-        r += amrex::Math::abs(fsten(ii_-1,jj_-1,kk_  ,ist_p0p)) /
-           ( amrex::Math::abs(fsten(ii_-1,jj_-2,kk_  ,ist_ppp))
-           + amrex::Math::abs(fsten(ii_-1,jj_-1,kk_  ,ist_ppp)) + eps);
-        r += amrex::Math::abs(fsten(ii_-1,jj_-1,kk_  ,ist_0pp)) /
-           ( amrex::Math::abs(fsten(ii_-2,jj_-1,kk_  ,ist_ppp))
-           + amrex::Math::abs(fsten(ii_-1,jj_-1,kk_  ,ist_ppp)) + eps);
-        r *= amrex::Math::abs(fsten(ii_-1,jj_-1,kk_  ,ist_ppp)) * fsten(ii_-1,jj_-1,kk_+1,ist_inv);
+        r += std::abs(fsten(ii_-1,jj_-1,kk_+1,ist_p00)) /
+           ( std::abs(fsten(ii_-1,jj_-2,kk_  ,ist_ppp))
+           + std::abs(fsten(ii_-1,jj_-1,kk_  ,ist_ppp))
+           + std::abs(fsten(ii_-1,jj_-2,kk_+1,ist_ppp))
+           + std::abs(fsten(ii_-1,jj_-1,kk_+1,ist_ppp)) + eps);
+        r += std::abs(fsten(ii_-1,jj_-1,kk_+1,ist_0p0)) /
+           ( std::abs(fsten(ii_-2,jj_-1,kk_  ,ist_ppp))
+           + std::abs(fsten(ii_-1,jj_-1,kk_  ,ist_ppp))
+           + std::abs(fsten(ii_-2,jj_-1,kk_+1,ist_ppp))
+           + std::abs(fsten(ii_-1,jj_-1,kk_+1,ist_ppp)) + eps);
+        r += std::abs(fsten(ii_-1,jj_-1,kk_  ,ist_00p)) /
+           ( std::abs(fsten(ii_-2,jj_-2,kk_  ,ist_ppp))
+           + std::abs(fsten(ii_-1,jj_-2,kk_  ,ist_ppp))
+           + std::abs(fsten(ii_-2,jj_-1,kk_  ,ist_ppp))
+           + std::abs(fsten(ii_-1,jj_-1,kk_  ,ist_ppp)) + eps);
+        r += std::abs(fsten(ii_-1,jj_-1,kk_+1,ist_pp0)) /
+           ( std::abs(fsten(ii_-1,jj_-1,kk_  ,ist_ppp))
+           + std::abs(fsten(ii_-1,jj_-1,kk_+1,ist_ppp)) + eps);
+        r += std::abs(fsten(ii_-1,jj_-1,kk_  ,ist_p0p)) /
+           ( std::abs(fsten(ii_-1,jj_-2,kk_  ,ist_ppp))
+           + std::abs(fsten(ii_-1,jj_-1,kk_  ,ist_ppp)) + eps);
+        r += std::abs(fsten(ii_-1,jj_-1,kk_  ,ist_0pp)) /
+           ( std::abs(fsten(ii_-2,jj_-1,kk_  ,ist_ppp))
+           + std::abs(fsten(ii_-1,jj_-1,kk_  ,ist_ppp)) + eps);
+        r *= std::abs(fsten(ii_-1,jj_-1,kk_  ,ist_ppp)) * fsten(ii_-1,jj_-1,kk_+1,ist_inv);
         return r;
     };
 
     auto restrict_from_0mp_to = [&fsten] (int ii_, int jj_, int kk_) -> Real {
-        Real w1m = amrex::Math::abs(fsten(ii_,jj_-2,kk_+1,ist_0p0)) / (amrex::Math::abs(fsten(ii_,jj_-2,kk_  ,ist_0pp))
-                                                              +amrex::Math::abs(fsten(ii_,jj_-2,kk_+1,ist_0pp)) + eps);
-        Real w1p = amrex::Math::abs(fsten(ii_,jj_-1,kk_+1,ist_0p0)) / (amrex::Math::abs(fsten(ii_,jj_-1,kk_  ,ist_0pp))
-                                                              +amrex::Math::abs(fsten(ii_,jj_-1,kk_+1,ist_0pp)) + eps);
-        Real w2m = amrex::Math::abs(fsten(ii_,jj_-1,kk_  ,ist_00p)) / (amrex::Math::abs(fsten(ii_,jj_-2,kk_  ,ist_0pp))
-                                                              +amrex::Math::abs(fsten(ii_,jj_-1,kk_  ,ist_0pp)) + eps);
-        Real w2p = amrex::Math::abs(fsten(ii_,jj_-1,kk_+1,ist_00p)) / (amrex::Math::abs(fsten(ii_,jj_-2,kk_+1,ist_0pp))
-                                                              +amrex::Math::abs(fsten(ii_,jj_-1,kk_+1,ist_0pp)) + eps);
-        Real wmm = amrex::Math::abs(fsten(ii_,jj_-2,kk_  ,ist_0pp)) * (Real(1.) + w1m + w2m);
-        Real wpm = amrex::Math::abs(fsten(ii_,jj_-1,kk_  ,ist_0pp)) * (Real(1.) + w1p + w2m);
-        Real wmp = amrex::Math::abs(fsten(ii_,jj_-2,kk_+1,ist_0pp)) * (Real(1.) + w1m + w2p);
-        Real wpp = amrex::Math::abs(fsten(ii_,jj_-1,kk_+1,ist_0pp)) * (Real(1.) + w1p + w2p);
+        Real w1m = std::abs(fsten(ii_,jj_-2,kk_+1,ist_0p0)) / (std::abs(fsten(ii_,jj_-2,kk_  ,ist_0pp))
+                                                              +std::abs(fsten(ii_,jj_-2,kk_+1,ist_0pp)) + eps);
+        Real w1p = std::abs(fsten(ii_,jj_-1,kk_+1,ist_0p0)) / (std::abs(fsten(ii_,jj_-1,kk_  ,ist_0pp))
+                                                              +std::abs(fsten(ii_,jj_-1,kk_+1,ist_0pp)) + eps);
+        Real w2m = std::abs(fsten(ii_,jj_-1,kk_  ,ist_00p)) / (std::abs(fsten(ii_,jj_-2,kk_  ,ist_0pp))
+                                                              +std::abs(fsten(ii_,jj_-1,kk_  ,ist_0pp)) + eps);
+        Real w2p = std::abs(fsten(ii_,jj_-1,kk_+1,ist_00p)) / (std::abs(fsten(ii_,jj_-2,kk_+1,ist_0pp))
+                                                              +std::abs(fsten(ii_,jj_-1,kk_+1,ist_0pp)) + eps);
+        Real wmm = std::abs(fsten(ii_,jj_-2,kk_  ,ist_0pp)) * (Real(1.) + w1m + w2m);
+        Real wpm = std::abs(fsten(ii_,jj_-1,kk_  ,ist_0pp)) * (Real(1.) + w1p + w2m);
+        Real wmp = std::abs(fsten(ii_,jj_-2,kk_+1,ist_0pp)) * (Real(1.) + w1m + w2p);
+        Real wpp = std::abs(fsten(ii_,jj_-1,kk_+1,ist_0pp)) * (Real(1.) + w1p + w2p);
         return wpm / (wmm+wpm+wmp+wpp+eps);
     };
 
     auto restrict_from_pmp_to = [&fsten] (int ii_, int jj_, int kk_) -> Real {
         Real r = Real(1.);
-        r += amrex::Math::abs(fsten(ii_  ,jj_-1,kk_+1,ist_p00)) /
-           ( amrex::Math::abs(fsten(ii_  ,jj_-2,kk_  ,ist_ppp))
-           + amrex::Math::abs(fsten(ii_  ,jj_-1,kk_  ,ist_ppp))
-           + amrex::Math::abs(fsten(ii_  ,jj_-2,kk_+1,ist_ppp))
-           + amrex::Math::abs(fsten(ii_  ,jj_-1,kk_+1,ist_ppp)) + eps);
-        r += amrex::Math::abs(fsten(ii_+1,jj_-1,kk_+1,ist_0p0)) /
-           ( amrex::Math::abs(fsten(ii_  ,jj_-1,kk_  ,ist_ppp))
-           + amrex::Math::abs(fsten(ii_+1,jj_-1,kk_  ,ist_ppp))
-           + amrex::Math::abs(fsten(ii_  ,jj_-1,kk_+1,ist_ppp))
-           + amrex::Math::abs(fsten(ii_+1,jj_-1,kk_+1,ist_ppp)) + eps);
-        r += amrex::Math::abs(fsten(ii_+1,jj_-1,kk_  ,ist_00p)) /
-           ( amrex::Math::abs(fsten(ii_  ,jj_-2,kk_  ,ist_ppp))
-           + amrex::Math::abs(fsten(ii_+1,jj_-2,kk_  ,ist_ppp))
-           + amrex::Math::abs(fsten(ii_  ,jj_-1,kk_  ,ist_ppp))
-           + amrex::Math::abs(fsten(ii_+1,jj_-1,kk_  ,ist_ppp)) + eps);
-        r += amrex::Math::abs(fsten(ii_  ,jj_-1,kk_+1,ist_pp0)) /
-           ( amrex::Math::abs(fsten(ii_  ,jj_-1,kk_  ,ist_ppp))
-           + amrex::Math::abs(fsten(ii_  ,jj_-1,kk_+1,ist_ppp)) + eps);
-        r += amrex::Math::abs(fsten(ii_  ,jj_-1,kk_  ,ist_p0p)) /
-           ( amrex::Math::abs(fsten(ii_  ,jj_-2,kk_  ,ist_ppp))
-           + amrex::Math::abs(fsten(ii_  ,jj_-1,kk_  ,ist_ppp)) + eps);
-        r += amrex::Math::abs(fsten(ii_+1,jj_-1,kk_  ,ist_0pp)) /
-           ( amrex::Math::abs(fsten(ii_  ,jj_-1,kk_  ,ist_ppp))
-           + amrex::Math::abs(fsten(ii_+1,jj_-1,kk_  ,ist_ppp)) + eps);
-        r *= amrex::Math::abs(fsten(ii_  ,jj_-1,kk_  ,ist_ppp)) * fsten(ii_+1,jj_-1,kk_+1,ist_inv);
+        r += std::abs(fsten(ii_  ,jj_-1,kk_+1,ist_p00)) /
+           ( std::abs(fsten(ii_  ,jj_-2,kk_  ,ist_ppp))
+           + std::abs(fsten(ii_  ,jj_-1,kk_  ,ist_ppp))
+           + std::abs(fsten(ii_  ,jj_-2,kk_+1,ist_ppp))
+           + std::abs(fsten(ii_  ,jj_-1,kk_+1,ist_ppp)) + eps);
+        r += std::abs(fsten(ii_+1,jj_-1,kk_+1,ist_0p0)) /
+           ( std::abs(fsten(ii_  ,jj_-1,kk_  ,ist_ppp))
+           + std::abs(fsten(ii_+1,jj_-1,kk_  ,ist_ppp))
+           + std::abs(fsten(ii_  ,jj_-1,kk_+1,ist_ppp))
+           + std::abs(fsten(ii_+1,jj_-1,kk_+1,ist_ppp)) + eps);
+        r += std::abs(fsten(ii_+1,jj_-1,kk_  ,ist_00p)) /
+           ( std::abs(fsten(ii_  ,jj_-2,kk_  ,ist_ppp))
+           + std::abs(fsten(ii_+1,jj_-2,kk_  ,ist_ppp))
+           + std::abs(fsten(ii_  ,jj_-1,kk_  ,ist_ppp))
+           + std::abs(fsten(ii_+1,jj_-1,kk_  ,ist_ppp)) + eps);
+        r += std::abs(fsten(ii_  ,jj_-1,kk_+1,ist_pp0)) /
+           ( std::abs(fsten(ii_  ,jj_-1,kk_  ,ist_ppp))
+           + std::abs(fsten(ii_  ,jj_-1,kk_+1,ist_ppp)) + eps);
+        r += std::abs(fsten(ii_  ,jj_-1,kk_  ,ist_p0p)) /
+           ( std::abs(fsten(ii_  ,jj_-2,kk_  ,ist_ppp))
+           + std::abs(fsten(ii_  ,jj_-1,kk_  ,ist_ppp)) + eps);
+        r += std::abs(fsten(ii_+1,jj_-1,kk_  ,ist_0pp)) /
+           ( std::abs(fsten(ii_  ,jj_-1,kk_  ,ist_ppp))
+           + std::abs(fsten(ii_+1,jj_-1,kk_  ,ist_ppp)) + eps);
+        r *= std::abs(fsten(ii_  ,jj_-1,kk_  ,ist_ppp)) * fsten(ii_+1,jj_-1,kk_+1,ist_inv);
         return r;
     };
 
     auto restrict_from_m0p_to = [&fsten] (int ii_, int jj_, int kk_) -> Real {
-        Real w1m = amrex::Math::abs(fsten(ii_-2,jj_,kk_+1,ist_p00)) / (amrex::Math::abs(fsten(ii_-2,jj_,kk_  ,ist_p0p))
-                                                              +amrex::Math::abs(fsten(ii_-2,jj_,kk_+1,ist_p0p)) + eps);
-        Real w1p = amrex::Math::abs(fsten(ii_-1,jj_,kk_+1,ist_p00)) / (amrex::Math::abs(fsten(ii_-1,jj_,kk_  ,ist_p0p))
-                                                              +amrex::Math::abs(fsten(ii_-1,jj_,kk_+1,ist_p0p)) + eps);
-        Real w2m = amrex::Math::abs(fsten(ii_-1,jj_,kk_  ,ist_00p)) / (amrex::Math::abs(fsten(ii_-2,jj_,kk_  ,ist_p0p))
-                                                              +amrex::Math::abs(fsten(ii_-1,jj_,kk_  ,ist_p0p)) + eps);
-        Real w2p = amrex::Math::abs(fsten(ii_-1,jj_,kk_+1,ist_00p)) / (amrex::Math::abs(fsten(ii_-2,jj_,kk_+1,ist_p0p))
-                                                              +amrex::Math::abs(fsten(ii_-1,jj_,kk_+1,ist_p0p)) + eps);
-        Real wmm = amrex::Math::abs(fsten(ii_-2,jj_,kk_  ,ist_p0p)) * (Real(1.) + w1m + w2m);
-        Real wpm = amrex::Math::abs(fsten(ii_-1,jj_,kk_  ,ist_p0p)) * (Real(1.) + w1p + w2m);
-        Real wmp = amrex::Math::abs(fsten(ii_-2,jj_,kk_+1,ist_p0p)) * (Real(1.) + w1m + w2p);
-        Real wpp = amrex::Math::abs(fsten(ii_-1,jj_,kk_+1,ist_p0p)) * (Real(1.) + w1p + w2p);
+        Real w1m = std::abs(fsten(ii_-2,jj_,kk_+1,ist_p00)) / (std::abs(fsten(ii_-2,jj_,kk_  ,ist_p0p))
+                                                              +std::abs(fsten(ii_-2,jj_,kk_+1,ist_p0p)) + eps);
+        Real w1p = std::abs(fsten(ii_-1,jj_,kk_+1,ist_p00)) / (std::abs(fsten(ii_-1,jj_,kk_  ,ist_p0p))
+                                                              +std::abs(fsten(ii_-1,jj_,kk_+1,ist_p0p)) + eps);
+        Real w2m = std::abs(fsten(ii_-1,jj_,kk_  ,ist_00p)) / (std::abs(fsten(ii_-2,jj_,kk_  ,ist_p0p))
+                                                              +std::abs(fsten(ii_-1,jj_,kk_  ,ist_p0p)) + eps);
+        Real w2p = std::abs(fsten(ii_-1,jj_,kk_+1,ist_00p)) / (std::abs(fsten(ii_-2,jj_,kk_+1,ist_p0p))
+                                                              +std::abs(fsten(ii_-1,jj_,kk_+1,ist_p0p)) + eps);
+        Real wmm = std::abs(fsten(ii_-2,jj_,kk_  ,ist_p0p)) * (Real(1.) + w1m + w2m);
+        Real wpm = std::abs(fsten(ii_-1,jj_,kk_  ,ist_p0p)) * (Real(1.) + w1p + w2m);
+        Real wmp = std::abs(fsten(ii_-2,jj_,kk_+1,ist_p0p)) * (Real(1.) + w1m + w2p);
+        Real wpp = std::abs(fsten(ii_-1,jj_,kk_+1,ist_p0p)) * (Real(1.) + w1p + w2p);
         return wpm / (wmm+wpm+wmp+wpp+eps);
     };
 
     auto restrict_from_00p_to = [&fsten] (int ii_, int jj_, int kk_) -> Real {
-        Real w1 = amrex::Math::abs(fsten(ii_,jj_,kk_  ,ist_00p));
-        Real w2 = amrex::Math::abs(fsten(ii_,jj_,kk_+1,ist_00p));
+        Real w1 = std::abs(fsten(ii_,jj_,kk_  ,ist_00p));
+        Real w2 = std::abs(fsten(ii_,jj_,kk_+1,ist_00p));
         if (w1 == Real(0.) && w2 == Real(0.)) {
             return Real(0.5);
         } else {
@@ -3862,94 +3862,94 @@ void mlndlap_stencil_rap (int i, int j, int k, Array4<Real> const& csten,
     };
 
     auto restrict_from_p0p_to = [&fsten] (int ii_, int jj_, int kk_) -> Real {
-        Real w1m = amrex::Math::abs(fsten(ii_  ,jj_,kk_+1,ist_p00)) / (amrex::Math::abs(fsten(ii_  ,jj_,kk_  ,ist_p0p))
-                                                              +amrex::Math::abs(fsten(ii_  ,jj_,kk_+1,ist_p0p)) + eps);
-        Real w1p = amrex::Math::abs(fsten(ii_+1,jj_,kk_+1,ist_p00)) / (amrex::Math::abs(fsten(ii_+1,jj_,kk_  ,ist_p0p))
-                                                              +amrex::Math::abs(fsten(ii_+1,jj_,kk_+1,ist_p0p)) + eps);
-        Real w2m = amrex::Math::abs(fsten(ii_+1,jj_,kk_  ,ist_00p)) / (amrex::Math::abs(fsten(ii_  ,jj_,kk_  ,ist_p0p))
-                                                              +amrex::Math::abs(fsten(ii_+1,jj_,kk_  ,ist_p0p)) + eps);
-        Real w2p = amrex::Math::abs(fsten(ii_+1,jj_,kk_+1,ist_00p)) / (amrex::Math::abs(fsten(ii_  ,jj_,kk_+1,ist_p0p))
-                                                              +amrex::Math::abs(fsten(ii_+1,jj_,kk_+1,ist_p0p)) + eps);
-        Real wmm = amrex::Math::abs(fsten(ii_  ,jj_,kk_  ,ist_p0p)) * (Real(1.) + w1m + w2m);
-        Real wpm = amrex::Math::abs(fsten(ii_+1,jj_,kk_  ,ist_p0p)) * (Real(1.) + w1p + w2m);
-        Real wmp = amrex::Math::abs(fsten(ii_  ,jj_,kk_+1,ist_p0p)) * (Real(1.) + w1m + w2p);
-        Real wpp = amrex::Math::abs(fsten(ii_+1,jj_,kk_+1,ist_p0p)) * (Real(1.) + w1p + w2p);
+        Real w1m = std::abs(fsten(ii_  ,jj_,kk_+1,ist_p00)) / (std::abs(fsten(ii_  ,jj_,kk_  ,ist_p0p))
+                                                              +std::abs(fsten(ii_  ,jj_,kk_+1,ist_p0p)) + eps);
+        Real w1p = std::abs(fsten(ii_+1,jj_,kk_+1,ist_p00)) / (std::abs(fsten(ii_+1,jj_,kk_  ,ist_p0p))
+                                                              +std::abs(fsten(ii_+1,jj_,kk_+1,ist_p0p)) + eps);
+        Real w2m = std::abs(fsten(ii_+1,jj_,kk_  ,ist_00p)) / (std::abs(fsten(ii_  ,jj_,kk_  ,ist_p0p))
+                                                              +std::abs(fsten(ii_+1,jj_,kk_  ,ist_p0p)) + eps);
+        Real w2p = std::abs(fsten(ii_+1,jj_,kk_+1,ist_00p)) / (std::abs(fsten(ii_  ,jj_,kk_+1,ist_p0p))
+                                                              +std::abs(fsten(ii_+1,jj_,kk_+1,ist_p0p)) + eps);
+        Real wmm = std::abs(fsten(ii_  ,jj_,kk_  ,ist_p0p)) * (Real(1.) + w1m + w2m);
+        Real wpm = std::abs(fsten(ii_+1,jj_,kk_  ,ist_p0p)) * (Real(1.) + w1p + w2m);
+        Real wmp = std::abs(fsten(ii_  ,jj_,kk_+1,ist_p0p)) * (Real(1.) + w1m + w2p);
+        Real wpp = std::abs(fsten(ii_+1,jj_,kk_+1,ist_p0p)) * (Real(1.) + w1p + w2p);
         return wmm / (wmm+wpm+wmp+wpp+eps);
     };
 
     auto restrict_from_mpp_to = [&fsten] (int ii_, int jj_, int kk_) -> Real {
         Real r = Real(1.);
-        r += amrex::Math::abs(fsten(ii_-1,jj_+1,kk_+1,ist_p00)) /
-           ( amrex::Math::abs(fsten(ii_-1,jj_  ,kk_  ,ist_ppp))
-           + amrex::Math::abs(fsten(ii_-1,jj_+1,kk_  ,ist_ppp))
-           + amrex::Math::abs(fsten(ii_-1,jj_  ,kk_+1,ist_ppp))
-           + amrex::Math::abs(fsten(ii_-1,jj_+1,kk_+1,ist_ppp)) + eps);
-        r += amrex::Math::abs(fsten(ii_-1,jj_  ,kk_+1,ist_0p0)) /
-           ( amrex::Math::abs(fsten(ii_-2,jj_  ,kk_  ,ist_ppp))
-           + amrex::Math::abs(fsten(ii_-1,jj_  ,kk_  ,ist_ppp))
-           + amrex::Math::abs(fsten(ii_-2,jj_  ,kk_+1,ist_ppp))
-           + amrex::Math::abs(fsten(ii_-1,jj_  ,kk_+1,ist_ppp)) + eps);
-        r += amrex::Math::abs(fsten(ii_-1,jj_+1,kk_  ,ist_00p)) /
-           ( amrex::Math::abs(fsten(ii_-2,jj_  ,kk_  ,ist_ppp))
-           + amrex::Math::abs(fsten(ii_-1,jj_  ,kk_  ,ist_ppp))
-           + amrex::Math::abs(fsten(ii_-2,jj_+1,kk_  ,ist_ppp))
-           + amrex::Math::abs(fsten(ii_-1,jj_+1,kk_  ,ist_ppp)) + eps);
-        r += amrex::Math::abs(fsten(ii_-1,jj_  ,kk_+1,ist_pp0)) /
-           ( amrex::Math::abs(fsten(ii_-1,jj_  ,kk_  ,ist_ppp))
-           + amrex::Math::abs(fsten(ii_-1,jj_  ,kk_+1,ist_ppp)) + eps);
-        r += amrex::Math::abs(fsten(ii_-1,jj_+1,kk_  ,ist_p0p)) /
-           ( amrex::Math::abs(fsten(ii_-1,jj_  ,kk_  ,ist_ppp))
-           + amrex::Math::abs(fsten(ii_-1,jj_+1,kk_  ,ist_ppp)) + eps);
-        r += amrex::Math::abs(fsten(ii_-1,jj_  ,kk_  ,ist_0pp)) /
-           ( amrex::Math::abs(fsten(ii_-2,jj_  ,kk_  ,ist_ppp))
-           + amrex::Math::abs(fsten(ii_-1,jj_  ,kk_  ,ist_ppp)) + eps);
-        r *= amrex::Math::abs(fsten(ii_-1,jj_  ,kk_  ,ist_ppp)) * fsten(ii_-1,jj_+1,kk_+1,ist_inv);
+        r += std::abs(fsten(ii_-1,jj_+1,kk_+1,ist_p00)) /
+           ( std::abs(fsten(ii_-1,jj_  ,kk_  ,ist_ppp))
+           + std::abs(fsten(ii_-1,jj_+1,kk_  ,ist_ppp))
+           + std::abs(fsten(ii_-1,jj_  ,kk_+1,ist_ppp))
+           + std::abs(fsten(ii_-1,jj_+1,kk_+1,ist_ppp)) + eps);
+        r += std::abs(fsten(ii_-1,jj_  ,kk_+1,ist_0p0)) /
+           ( std::abs(fsten(ii_-2,jj_  ,kk_  ,ist_ppp))
+           + std::abs(fsten(ii_-1,jj_  ,kk_  ,ist_ppp))
+           + std::abs(fsten(ii_-2,jj_  ,kk_+1,ist_ppp))
+           + std::abs(fsten(ii_-1,jj_  ,kk_+1,ist_ppp)) + eps);
+        r += std::abs(fsten(ii_-1,jj_+1,kk_  ,ist_00p)) /
+           ( std::abs(fsten(ii_-2,jj_  ,kk_  ,ist_ppp))
+           + std::abs(fsten(ii_-1,jj_  ,kk_  ,ist_ppp))
+           + std::abs(fsten(ii_-2,jj_+1,kk_  ,ist_ppp))
+           + std::abs(fsten(ii_-1,jj_+1,kk_  ,ist_ppp)) + eps);
+        r += std::abs(fsten(ii_-1,jj_  ,kk_+1,ist_pp0)) /
+           ( std::abs(fsten(ii_-1,jj_  ,kk_  ,ist_ppp))
+           + std::abs(fsten(ii_-1,jj_  ,kk_+1,ist_ppp)) + eps);
+        r += std::abs(fsten(ii_-1,jj_+1,kk_  ,ist_p0p)) /
+           ( std::abs(fsten(ii_-1,jj_  ,kk_  ,ist_ppp))
+           + std::abs(fsten(ii_-1,jj_+1,kk_  ,ist_ppp)) + eps);
+        r += std::abs(fsten(ii_-1,jj_  ,kk_  ,ist_0pp)) /
+           ( std::abs(fsten(ii_-2,jj_  ,kk_  ,ist_ppp))
+           + std::abs(fsten(ii_-1,jj_  ,kk_  ,ist_ppp)) + eps);
+        r *= std::abs(fsten(ii_-1,jj_  ,kk_  ,ist_ppp)) * fsten(ii_-1,jj_+1,kk_+1,ist_inv);
         return r;
     };
 
     auto restrict_from_0pp_to = [&fsten] (int ii_, int jj_, int kk_) -> Real {
-        Real w1m = amrex::Math::abs(fsten(ii_,jj_  ,kk_+1,ist_0p0)) / (amrex::Math::abs(fsten(ii_,jj_  ,kk_  ,ist_0pp))
-                                                              +amrex::Math::abs(fsten(ii_,jj_  ,kk_+1,ist_0pp)) + eps);
-        Real w1p = amrex::Math::abs(fsten(ii_,jj_+1,kk_+1,ist_0p0)) / (amrex::Math::abs(fsten(ii_,jj_+1,kk_  ,ist_0pp))
-                                                              +amrex::Math::abs(fsten(ii_,jj_+1,kk_+1,ist_0pp)) + eps);
-        Real w2m = amrex::Math::abs(fsten(ii_,jj_+1,kk_  ,ist_00p)) / (amrex::Math::abs(fsten(ii_,jj_  ,kk_  ,ist_0pp))
-                                                              +amrex::Math::abs(fsten(ii_,jj_+1,kk_  ,ist_0pp)) + eps);
-        Real w2p = amrex::Math::abs(fsten(ii_,jj_+1,kk_+1,ist_00p)) / (amrex::Math::abs(fsten(ii_,jj_  ,kk_+1,ist_0pp))
-                                                              +amrex::Math::abs(fsten(ii_,jj_+1,kk_+1,ist_0pp)) + eps);
-        Real wmm = amrex::Math::abs(fsten(ii_,jj_  ,kk_  ,ist_0pp)) * (Real(1.) + w1m + w2m);
-        Real wpm = amrex::Math::abs(fsten(ii_,jj_+1,kk_  ,ist_0pp)) * (Real(1.) + w1p + w2m);
-        Real wmp = amrex::Math::abs(fsten(ii_,jj_  ,kk_+1,ist_0pp)) * (Real(1.) + w1m + w2p);
-        Real wpp = amrex::Math::abs(fsten(ii_,jj_+1,kk_+1,ist_0pp)) * (Real(1.) + w1p + w2p);
+        Real w1m = std::abs(fsten(ii_,jj_  ,kk_+1,ist_0p0)) / (std::abs(fsten(ii_,jj_  ,kk_  ,ist_0pp))
+                                                              +std::abs(fsten(ii_,jj_  ,kk_+1,ist_0pp)) + eps);
+        Real w1p = std::abs(fsten(ii_,jj_+1,kk_+1,ist_0p0)) / (std::abs(fsten(ii_,jj_+1,kk_  ,ist_0pp))
+                                                              +std::abs(fsten(ii_,jj_+1,kk_+1,ist_0pp)) + eps);
+        Real w2m = std::abs(fsten(ii_,jj_+1,kk_  ,ist_00p)) / (std::abs(fsten(ii_,jj_  ,kk_  ,ist_0pp))
+                                                              +std::abs(fsten(ii_,jj_+1,kk_  ,ist_0pp)) + eps);
+        Real w2p = std::abs(fsten(ii_,jj_+1,kk_+1,ist_00p)) / (std::abs(fsten(ii_,jj_  ,kk_+1,ist_0pp))
+                                                              +std::abs(fsten(ii_,jj_+1,kk_+1,ist_0pp)) + eps);
+        Real wmm = std::abs(fsten(ii_,jj_  ,kk_  ,ist_0pp)) * (Real(1.) + w1m + w2m);
+        Real wpm = std::abs(fsten(ii_,jj_+1,kk_  ,ist_0pp)) * (Real(1.) + w1p + w2m);
+        Real wmp = std::abs(fsten(ii_,jj_  ,kk_+1,ist_0pp)) * (Real(1.) + w1m + w2p);
+        Real wpp = std::abs(fsten(ii_,jj_+1,kk_+1,ist_0pp)) * (Real(1.) + w1p + w2p);
         return wmm / (wmm+wpm+wmp+wpp+eps);
     };
 
     auto restrict_from_ppp_to = [&fsten] (int ii_, int jj_, int kk_) -> Real {
         Real r = Real(1.);
-        r += amrex::Math::abs(fsten(ii_  ,jj_+1,kk_+1,ist_p00)) /
-           ( amrex::Math::abs(fsten(ii_  ,jj_  ,kk_  ,ist_ppp))
-           + amrex::Math::abs(fsten(ii_  ,jj_+1,kk_  ,ist_ppp))
-           + amrex::Math::abs(fsten(ii_  ,jj_  ,kk_+1,ist_ppp))
-           + amrex::Math::abs(fsten(ii_  ,jj_+1,kk_+1,ist_ppp)) + eps);
-        r += amrex::Math::abs(fsten(ii_+1,jj_  ,kk_+1,ist_0p0)) /
-           ( amrex::Math::abs(fsten(ii_  ,jj_  ,kk_  ,ist_ppp))
-           + amrex::Math::abs(fsten(ii_+1,jj_  ,kk_  ,ist_ppp))
-           + amrex::Math::abs(fsten(ii_  ,jj_  ,kk_+1,ist_ppp))
-           + amrex::Math::abs(fsten(ii_+1,jj_  ,kk_+1,ist_ppp)) + eps);
-        r += amrex::Math::abs(fsten(ii_+1,jj_+1,kk_  ,ist_00p)) /
-           ( amrex::Math::abs(fsten(ii_  ,jj_  ,kk_  ,ist_ppp))
-           + amrex::Math::abs(fsten(ii_+1,jj_  ,kk_  ,ist_ppp))
-           + amrex::Math::abs(fsten(ii_  ,jj_+1,kk_  ,ist_ppp))
-           + amrex::Math::abs(fsten(ii_+1,jj_+1,kk_  ,ist_ppp)) + eps);
-        r += amrex::Math::abs(fsten(ii_  ,jj_  ,kk_+1,ist_pp0)) /
-           ( amrex::Math::abs(fsten(ii_  ,jj_  ,kk_  ,ist_ppp))
-           + amrex::Math::abs(fsten(ii_  ,jj_  ,kk_+1,ist_ppp)) + eps);
-        r += amrex::Math::abs(fsten(ii_  ,jj_+1,kk_  ,ist_p0p)) /
-           ( amrex::Math::abs(fsten(ii_  ,jj_  ,kk_  ,ist_ppp))
-           + amrex::Math::abs(fsten(ii_  ,jj_+1,kk_  ,ist_ppp)) + eps);
-        r += amrex::Math::abs(fsten(ii_+1,jj_  ,kk_  ,ist_0pp)) /
-           ( amrex::Math::abs(fsten(ii_  ,jj_  ,kk_  ,ist_ppp))
-           + amrex::Math::abs(fsten(ii_+1,jj_  ,kk_  ,ist_ppp)) + eps);
-        r *= amrex::Math::abs(fsten(ii_  ,jj_  ,kk_  ,ist_ppp)) * fsten(ii_+1,jj_+1,kk_+1,ist_inv);
+        r += std::abs(fsten(ii_  ,jj_+1,kk_+1,ist_p00)) /
+           ( std::abs(fsten(ii_  ,jj_  ,kk_  ,ist_ppp))
+           + std::abs(fsten(ii_  ,jj_+1,kk_  ,ist_ppp))
+           + std::abs(fsten(ii_  ,jj_  ,kk_+1,ist_ppp))
+           + std::abs(fsten(ii_  ,jj_+1,kk_+1,ist_ppp)) + eps);
+        r += std::abs(fsten(ii_+1,jj_  ,kk_+1,ist_0p0)) /
+           ( std::abs(fsten(ii_  ,jj_  ,kk_  ,ist_ppp))
+           + std::abs(fsten(ii_+1,jj_  ,kk_  ,ist_ppp))
+           + std::abs(fsten(ii_  ,jj_  ,kk_+1,ist_ppp))
+           + std::abs(fsten(ii_+1,jj_  ,kk_+1,ist_ppp)) + eps);
+        r += std::abs(fsten(ii_+1,jj_+1,kk_  ,ist_00p)) /
+           ( std::abs(fsten(ii_  ,jj_  ,kk_  ,ist_ppp))
+           + std::abs(fsten(ii_+1,jj_  ,kk_  ,ist_ppp))
+           + std::abs(fsten(ii_  ,jj_+1,kk_  ,ist_ppp))
+           + std::abs(fsten(ii_+1,jj_+1,kk_  ,ist_ppp)) + eps);
+        r += std::abs(fsten(ii_  ,jj_  ,kk_+1,ist_pp0)) /
+           ( std::abs(fsten(ii_  ,jj_  ,kk_  ,ist_ppp))
+           + std::abs(fsten(ii_  ,jj_  ,kk_+1,ist_ppp)) + eps);
+        r += std::abs(fsten(ii_  ,jj_+1,kk_  ,ist_p0p)) /
+           ( std::abs(fsten(ii_  ,jj_  ,kk_  ,ist_ppp))
+           + std::abs(fsten(ii_  ,jj_+1,kk_  ,ist_ppp)) + eps);
+        r += std::abs(fsten(ii_+1,jj_  ,kk_  ,ist_0pp)) /
+           ( std::abs(fsten(ii_  ,jj_  ,kk_  ,ist_ppp))
+           + std::abs(fsten(ii_+1,jj_  ,kk_  ,ist_ppp)) + eps);
+        r *= std::abs(fsten(ii_  ,jj_  ,kk_  ,ist_ppp)) * fsten(ii_+1,jj_+1,kk_+1,ist_inv);
         return r;
     };
 
@@ -5560,74 +5560,74 @@ void mlndlap_interpadd_rap (int i, int j, int k, Array4<Real> const& fine,
         if (ieven && jeven && keven) {
             fv = crse(ic,jc,kc);
         } else if (ieven && jeven) {
-            Real w1 = amrex::Math::abs(sten(i,j,k-1,ist_00p));
-            Real w2 = amrex::Math::abs(sten(i,j,k  ,ist_00p));
+            Real w1 = std::abs(sten(i,j,k-1,ist_00p));
+            Real w2 = std::abs(sten(i,j,k  ,ist_00p));
             if (w1 == Real(0.0) && w2 == Real(0.0)) {
                 fv = Real(0.5)*(crse(ic,jc,kc)+crse(ic,jc,kc+1));
             } else {
                 fv = (w1*crse(ic,jc,kc) + w2*crse(ic,jc,kc+1)) / (w1+w2);
             }
         } else if (ieven && keven) {
-            Real w1 = amrex::Math::abs(sten(i,j-1,k,ist_0p0));
-            Real w2 = amrex::Math::abs(sten(i,j  ,k,ist_0p0));
+            Real w1 = std::abs(sten(i,j-1,k,ist_0p0));
+            Real w2 = std::abs(sten(i,j  ,k,ist_0p0));
             if (w1 == Real(0.0) && w2 == Real(0.0)) {
                 fv = Real(0.5)*(crse(ic,jc,kc)+crse(ic,jc+1,kc));
             } else {
                 fv = (w1*crse(ic,jc,kc) + w2*crse(ic,jc+1,kc)) / (w1+w2);
             }
         } else if (jeven && keven) {
-            Real w1 = amrex::Math::abs(sten(i-1,j,k,ist_p00));
-            Real w2 = amrex::Math::abs(sten(i  ,j,k,ist_p00));
+            Real w1 = std::abs(sten(i-1,j,k,ist_p00));
+            Real w2 = std::abs(sten(i  ,j,k,ist_p00));
             if (w1 == Real(0.0) && w2 == Real(0.0)) {
                 fv = Real(0.5)*(crse(ic,jc,kc)+crse(ic+1,jc,kc));
             } else {
                 fv = (w1*crse(ic,jc,kc) + w2*crse(ic+1,jc,kc)) / (w1+w2);
             }
         } else if (ieven) {
-            Real w1m = amrex::Math::abs(sten(i,j-1,k,ist_0p0)) / (amrex::Math::abs(sten(i,j-1,k-1,ist_0pp))
-                                                         +amrex::Math::abs(sten(i,j-1,k  ,ist_0pp)) + eps);
-            Real w1p = amrex::Math::abs(sten(i,j  ,k,ist_0p0)) / (amrex::Math::abs(sten(i,j  ,k-1,ist_0pp))
-                                                         +amrex::Math::abs(sten(i,j  ,k  ,ist_0pp)) + eps);
-            Real w2m = amrex::Math::abs(sten(i,j,k-1,ist_00p)) / (amrex::Math::abs(sten(i,j-1,k-1,ist_0pp))
-                                                         +amrex::Math::abs(sten(i,j  ,k-1,ist_0pp)) + eps);
-            Real w2p = amrex::Math::abs(sten(i,j,k  ,ist_00p)) / (amrex::Math::abs(sten(i,j-1,k  ,ist_0pp))
-                                                         +amrex::Math::abs(sten(i,j  ,k  ,ist_0pp)) + eps);
-            Real wmm = amrex::Math::abs(sten(i,j-1,k-1,ist_0pp)) * (Real(1.0) + w1m + w2m);
-            Real wpm = amrex::Math::abs(sten(i,j  ,k-1,ist_0pp)) * (Real(1.0) + w1p + w2m);
-            Real wmp = amrex::Math::abs(sten(i,j-1,k  ,ist_0pp)) * (Real(1.0) + w1m + w2p);
-            Real wpp = amrex::Math::abs(sten(i,j  ,k  ,ist_0pp)) * (Real(1.0) + w1p + w2p);
+            Real w1m = std::abs(sten(i,j-1,k,ist_0p0)) / (std::abs(sten(i,j-1,k-1,ist_0pp))
+                                                         +std::abs(sten(i,j-1,k  ,ist_0pp)) + eps);
+            Real w1p = std::abs(sten(i,j  ,k,ist_0p0)) / (std::abs(sten(i,j  ,k-1,ist_0pp))
+                                                         +std::abs(sten(i,j  ,k  ,ist_0pp)) + eps);
+            Real w2m = std::abs(sten(i,j,k-1,ist_00p)) / (std::abs(sten(i,j-1,k-1,ist_0pp))
+                                                         +std::abs(sten(i,j  ,k-1,ist_0pp)) + eps);
+            Real w2p = std::abs(sten(i,j,k  ,ist_00p)) / (std::abs(sten(i,j-1,k  ,ist_0pp))
+                                                         +std::abs(sten(i,j  ,k  ,ist_0pp)) + eps);
+            Real wmm = std::abs(sten(i,j-1,k-1,ist_0pp)) * (Real(1.0) + w1m + w2m);
+            Real wpm = std::abs(sten(i,j  ,k-1,ist_0pp)) * (Real(1.0) + w1p + w2m);
+            Real wmp = std::abs(sten(i,j-1,k  ,ist_0pp)) * (Real(1.0) + w1m + w2p);
+            Real wpp = std::abs(sten(i,j  ,k  ,ist_0pp)) * (Real(1.0) + w1p + w2p);
             fv = (wmm*crse(ic,jc,kc) + wpm*crse(ic,jc+1,kc)
                   + wmp*crse(ic,jc,kc+1) + wpp*crse(ic,jc+1,kc+1))
                 / (wmm+wpm+wmp+wpp+eps);
         } else if (jeven) {
-            Real w1m = amrex::Math::abs(sten(i-1,j,k,ist_p00)) / (amrex::Math::abs(sten(i-1,j,k-1,ist_p0p))
-                                                         +amrex::Math::abs(sten(i-1,j,k  ,ist_p0p)) + eps);
-            Real w1p = amrex::Math::abs(sten(i  ,j,k,ist_p00)) / (amrex::Math::abs(sten(i  ,j,k-1,ist_p0p))
-                                                         +amrex::Math::abs(sten(i  ,j,k  ,ist_p0p)) + eps);
-            Real w2m = amrex::Math::abs(sten(i,j,k-1,ist_00p)) / (amrex::Math::abs(sten(i-1,j,k-1,ist_p0p))
-                                                         +amrex::Math::abs(sten(i  ,j,k-1,ist_p0p)) + eps);
-            Real w2p = amrex::Math::abs(sten(i,j,k  ,ist_00p)) / (amrex::Math::abs(sten(i-1,j,k  ,ist_p0p))
-                                                         +amrex::Math::abs(sten(i  ,j,k  ,ist_p0p)) + eps);
-            Real wmm = amrex::Math::abs(sten(i-1,j,k-1,ist_p0p)) * (Real(1.0) + w1m + w2m);
-            Real wpm = amrex::Math::abs(sten(i  ,j,k-1,ist_p0p)) * (Real(1.0) + w1p + w2m);
-            Real wmp = amrex::Math::abs(sten(i-1,j,k  ,ist_p0p)) * (Real(1.0) + w1m + w2p);
-            Real wpp = amrex::Math::abs(sten(i  ,j,k  ,ist_p0p)) * (Real(1.0) + w1p + w2p);
+            Real w1m = std::abs(sten(i-1,j,k,ist_p00)) / (std::abs(sten(i-1,j,k-1,ist_p0p))
+                                                         +std::abs(sten(i-1,j,k  ,ist_p0p)) + eps);
+            Real w1p = std::abs(sten(i  ,j,k,ist_p00)) / (std::abs(sten(i  ,j,k-1,ist_p0p))
+                                                         +std::abs(sten(i  ,j,k  ,ist_p0p)) + eps);
+            Real w2m = std::abs(sten(i,j,k-1,ist_00p)) / (std::abs(sten(i-1,j,k-1,ist_p0p))
+                                                         +std::abs(sten(i  ,j,k-1,ist_p0p)) + eps);
+            Real w2p = std::abs(sten(i,j,k  ,ist_00p)) / (std::abs(sten(i-1,j,k  ,ist_p0p))
+                                                         +std::abs(sten(i  ,j,k  ,ist_p0p)) + eps);
+            Real wmm = std::abs(sten(i-1,j,k-1,ist_p0p)) * (Real(1.0) + w1m + w2m);
+            Real wpm = std::abs(sten(i  ,j,k-1,ist_p0p)) * (Real(1.0) + w1p + w2m);
+            Real wmp = std::abs(sten(i-1,j,k  ,ist_p0p)) * (Real(1.0) + w1m + w2p);
+            Real wpp = std::abs(sten(i  ,j,k  ,ist_p0p)) * (Real(1.0) + w1p + w2p);
             fv = (wmm*crse(ic,jc,kc) + wpm*crse(ic+1,jc,kc)
                   + wmp*crse(ic,jc,kc+1) + wpp*crse(ic+1,jc,kc+1))
                 / (wmm+wpm+wmp+wpp+eps);
         } else if (keven) {
-            Real w1m = amrex::Math::abs(sten(i-1,j,k,ist_p00)) / (amrex::Math::abs(sten(i-1,j-1,k,ist_pp0))
-                                                         +amrex::Math::abs(sten(i-1,j  ,k,ist_pp0)) + eps);
-            Real w1p = amrex::Math::abs(sten(i  ,j,k,ist_p00)) / (amrex::Math::abs(sten(i  ,j-1,k,ist_pp0))
-                                                         +amrex::Math::abs(sten(i  ,j  ,k,ist_pp0)) + eps);
-            Real w2m = amrex::Math::abs(sten(i,j-1,k,ist_0p0)) / (amrex::Math::abs(sten(i-1,j-1,k,ist_pp0))
-                                                         +amrex::Math::abs(sten(i  ,j-1,k,ist_pp0)) + eps);
-            Real w2p = amrex::Math::abs(sten(i,j  ,k,ist_0p0)) / (amrex::Math::abs(sten(i-1,j  ,k,ist_pp0))
-                                                         +amrex::Math::abs(sten(i  ,j  ,k,ist_pp0)) + eps);
-            Real wmm = amrex::Math::abs(sten(i-1,j-1,k,ist_pp0)) * (Real(1.0) + w1m + w2m);
-            Real wpm = amrex::Math::abs(sten(i  ,j-1,k,ist_pp0)) * (Real(1.0) + w1p + w2m);
-            Real wmp = amrex::Math::abs(sten(i-1,j  ,k,ist_pp0)) * (Real(1.0) + w1m + w2p);
-            Real wpp = amrex::Math::abs(sten(i  ,j  ,k,ist_pp0)) * (Real(1.0) + w1p + w2p);
+            Real w1m = std::abs(sten(i-1,j,k,ist_p00)) / (std::abs(sten(i-1,j-1,k,ist_pp0))
+                                                         +std::abs(sten(i-1,j  ,k,ist_pp0)) + eps);
+            Real w1p = std::abs(sten(i  ,j,k,ist_p00)) / (std::abs(sten(i  ,j-1,k,ist_pp0))
+                                                         +std::abs(sten(i  ,j  ,k,ist_pp0)) + eps);
+            Real w2m = std::abs(sten(i,j-1,k,ist_0p0)) / (std::abs(sten(i-1,j-1,k,ist_pp0))
+                                                         +std::abs(sten(i  ,j-1,k,ist_pp0)) + eps);
+            Real w2p = std::abs(sten(i,j  ,k,ist_0p0)) / (std::abs(sten(i-1,j  ,k,ist_pp0))
+                                                         +std::abs(sten(i  ,j  ,k,ist_pp0)) + eps);
+            Real wmm = std::abs(sten(i-1,j-1,k,ist_pp0)) * (Real(1.0) + w1m + w2m);
+            Real wpm = std::abs(sten(i  ,j-1,k,ist_pp0)) * (Real(1.0) + w1p + w2m);
+            Real wmp = std::abs(sten(i-1,j  ,k,ist_pp0)) * (Real(1.0) + w1m + w2p);
+            Real wpp = std::abs(sten(i  ,j  ,k,ist_pp0)) * (Real(1.0) + w1p + w2p);
             fv = (wmm*crse(ic,jc,kc) + wpm*crse(ic+1,jc,kc)
                   + wmp*crse(ic,jc+1,kc) + wpp*crse(ic+1,jc+1,kc))
                 / (wmm+wpm+wmp+wpp+eps);
@@ -5641,146 +5641,146 @@ void mlndlap_interpadd_rap (int i, int j, int k, Array4<Real> const& fine,
             Real wmpp = Real(1.0);
             Real wppp = Real(1.0);
 
-            Real wtmp = amrex::Math::abs(sten(i-1,j,k,ist_p00)) /
-                ( amrex::Math::abs(sten(i-1,j-1,k-1,ist_ppp))
-                + amrex::Math::abs(sten(i-1,j  ,k-1,ist_ppp))
-                + amrex::Math::abs(sten(i-1,j-1,k  ,ist_ppp))
-                + amrex::Math::abs(sten(i-1,j  ,k  ,ist_ppp)) + eps);
+            Real wtmp = std::abs(sten(i-1,j,k,ist_p00)) /
+                ( std::abs(sten(i-1,j-1,k-1,ist_ppp))
+                + std::abs(sten(i-1,j  ,k-1,ist_ppp))
+                + std::abs(sten(i-1,j-1,k  ,ist_ppp))
+                + std::abs(sten(i-1,j  ,k  ,ist_ppp)) + eps);
             wmmm += wtmp;
             wmpm += wtmp;
             wmmp += wtmp;
             wmpp += wtmp;
 
-            wtmp = amrex::Math::abs(sten(i,j,k,ist_p00)) /
-                ( amrex::Math::abs(sten(i,j-1,k-1,ist_ppp))
-                + amrex::Math::abs(sten(i,j  ,k-1,ist_ppp))
-                + amrex::Math::abs(sten(i,j-1,k  ,ist_ppp))
-                + amrex::Math::abs(sten(i,j  ,k  ,ist_ppp)) + eps);
+            wtmp = std::abs(sten(i,j,k,ist_p00)) /
+                ( std::abs(sten(i,j-1,k-1,ist_ppp))
+                + std::abs(sten(i,j  ,k-1,ist_ppp))
+                + std::abs(sten(i,j-1,k  ,ist_ppp))
+                + std::abs(sten(i,j  ,k  ,ist_ppp)) + eps);
             wpmm += wtmp;
             wppm += wtmp;
             wpmp += wtmp;
             wppp += wtmp;
 
-            wtmp = amrex::Math::abs(sten(i,j-1,k,ist_0p0)) /
-                ( amrex::Math::abs(sten(i-1,j-1,k-1,ist_ppp))
-                + amrex::Math::abs(sten(i  ,j-1,k-1,ist_ppp))
-                + amrex::Math::abs(sten(i-1,j-1,k  ,ist_ppp))
-                + amrex::Math::abs(sten(i  ,j-1,k  ,ist_ppp)) + eps);
+            wtmp = std::abs(sten(i,j-1,k,ist_0p0)) /
+                ( std::abs(sten(i-1,j-1,k-1,ist_ppp))
+                + std::abs(sten(i  ,j-1,k-1,ist_ppp))
+                + std::abs(sten(i-1,j-1,k  ,ist_ppp))
+                + std::abs(sten(i  ,j-1,k  ,ist_ppp)) + eps);
             wmmm += wtmp;
             wpmm += wtmp;
             wmmp += wtmp;
             wpmp += wtmp;
 
-            wtmp = amrex::Math::abs(sten(i,j,k,ist_0p0)) /
-                ( amrex::Math::abs(sten(i-1,j,k-1,ist_ppp))
-                + amrex::Math::abs(sten(i  ,j,k-1,ist_ppp))
-                + amrex::Math::abs(sten(i-1,j,k  ,ist_ppp))
-                + amrex::Math::abs(sten(i  ,j,k  ,ist_ppp)) + eps);
+            wtmp = std::abs(sten(i,j,k,ist_0p0)) /
+                ( std::abs(sten(i-1,j,k-1,ist_ppp))
+                + std::abs(sten(i  ,j,k-1,ist_ppp))
+                + std::abs(sten(i-1,j,k  ,ist_ppp))
+                + std::abs(sten(i  ,j,k  ,ist_ppp)) + eps);
             wmpm += wtmp;
             wppm += wtmp;
             wmpp += wtmp;
             wppp += wtmp;
 
-            wtmp = amrex::Math::abs(sten(i,j,k-1,ist_00p)) /
-                ( amrex::Math::abs(sten(i-1,j-1,k-1,ist_ppp))
-                + amrex::Math::abs(sten(i  ,j-1,k-1,ist_ppp))
-                + amrex::Math::abs(sten(i-1,j  ,k-1,ist_ppp))
-                + amrex::Math::abs(sten(i  ,j  ,k-1,ist_ppp)) + eps);
+            wtmp = std::abs(sten(i,j,k-1,ist_00p)) /
+                ( std::abs(sten(i-1,j-1,k-1,ist_ppp))
+                + std::abs(sten(i  ,j-1,k-1,ist_ppp))
+                + std::abs(sten(i-1,j  ,k-1,ist_ppp))
+                + std::abs(sten(i  ,j  ,k-1,ist_ppp)) + eps);
             wmmm += wtmp;
             wpmm += wtmp;
             wmpm += wtmp;
             wppm += wtmp;
 
-            wtmp = amrex::Math::abs(sten(i,j,k,ist_00p)) /
-                ( amrex::Math::abs(sten(i-1,j-1,k,ist_ppp))
-                + amrex::Math::abs(sten(i  ,j-1,k,ist_ppp))
-                + amrex::Math::abs(sten(i-1,j  ,k,ist_ppp))
-                + amrex::Math::abs(sten(i  ,j  ,k,ist_ppp)) + eps);
+            wtmp = std::abs(sten(i,j,k,ist_00p)) /
+                ( std::abs(sten(i-1,j-1,k,ist_ppp))
+                + std::abs(sten(i  ,j-1,k,ist_ppp))
+                + std::abs(sten(i-1,j  ,k,ist_ppp))
+                + std::abs(sten(i  ,j  ,k,ist_ppp)) + eps);
             wmmp += wtmp;
             wpmp += wtmp;
             wmpp += wtmp;
             wppp += wtmp;
 
-            wtmp = amrex::Math::abs(sten(i-1,j-1,k,ist_pp0)) /
-                ( amrex::Math::abs(sten(i-1,j-1,k-1,ist_ppp))
-                + amrex::Math::abs(sten(i-1,j-1,k  ,ist_ppp)) + eps);
+            wtmp = std::abs(sten(i-1,j-1,k,ist_pp0)) /
+                ( std::abs(sten(i-1,j-1,k-1,ist_ppp))
+                + std::abs(sten(i-1,j-1,k  ,ist_ppp)) + eps);
             wmmm += wtmp;
             wmmp += wtmp;
 
-            wtmp = amrex::Math::abs(sten(i,j-1,k,ist_pp0)) /
-                ( amrex::Math::abs(sten(i,j-1,k-1,ist_ppp))
-                + amrex::Math::abs(sten(i,j-1,k  ,ist_ppp)) + eps);
+            wtmp = std::abs(sten(i,j-1,k,ist_pp0)) /
+                ( std::abs(sten(i,j-1,k-1,ist_ppp))
+                + std::abs(sten(i,j-1,k  ,ist_ppp)) + eps);
             wpmm += wtmp;
             wpmp += wtmp;
 
-            wtmp = amrex::Math::abs(sten(i-1,j,k,ist_pp0)) /
-                ( amrex::Math::abs(sten(i-1,j,k-1,ist_ppp))
-                + amrex::Math::abs(sten(i-1,j,k  ,ist_ppp)) + eps);
+            wtmp = std::abs(sten(i-1,j,k,ist_pp0)) /
+                ( std::abs(sten(i-1,j,k-1,ist_ppp))
+                + std::abs(sten(i-1,j,k  ,ist_ppp)) + eps);
             wmpm += wtmp;
             wmpp += wtmp;
 
-            wtmp = amrex::Math::abs(sten(i,j,k,ist_pp0)) /
-                ( amrex::Math::abs(sten(i,j,k-1,ist_ppp))
-                + amrex::Math::abs(sten(i,j,k  ,ist_ppp)) + eps);
+            wtmp = std::abs(sten(i,j,k,ist_pp0)) /
+                ( std::abs(sten(i,j,k-1,ist_ppp))
+                + std::abs(sten(i,j,k  ,ist_ppp)) + eps);
             wppm += wtmp;
             wppp += wtmp;
 
-            wtmp = amrex::Math::abs(sten(i-1,j,k-1,ist_p0p)) /
-                ( amrex::Math::abs(sten(i-1,j-1,k-1,ist_ppp))
-                + amrex::Math::abs(sten(i-1,j  ,k-1,ist_ppp)) + eps);
+            wtmp = std::abs(sten(i-1,j,k-1,ist_p0p)) /
+                ( std::abs(sten(i-1,j-1,k-1,ist_ppp))
+                + std::abs(sten(i-1,j  ,k-1,ist_ppp)) + eps);
             wmmm += wtmp;
             wmpm += wtmp;
 
-            wtmp = amrex::Math::abs(sten(i,j,k-1,ist_p0p)) /
-                ( amrex::Math::abs(sten(i,j-1,k-1,ist_ppp))
-                + amrex::Math::abs(sten(i,j  ,k-1,ist_ppp)) + eps);
+            wtmp = std::abs(sten(i,j,k-1,ist_p0p)) /
+                ( std::abs(sten(i,j-1,k-1,ist_ppp))
+                + std::abs(sten(i,j  ,k-1,ist_ppp)) + eps);
             wpmm += wtmp;
             wppm += wtmp;
 
-            wtmp = amrex::Math::abs(sten(i-1,j,k,ist_p0p)) /
-                ( amrex::Math::abs(sten(i-1,j-1,k,ist_ppp))
-                + amrex::Math::abs(sten(i-1,j  ,k,ist_ppp)) + eps);
+            wtmp = std::abs(sten(i-1,j,k,ist_p0p)) /
+                ( std::abs(sten(i-1,j-1,k,ist_ppp))
+                + std::abs(sten(i-1,j  ,k,ist_ppp)) + eps);
             wmmp += wtmp;
             wmpp += wtmp;
 
-            wtmp = amrex::Math::abs(sten(i,j,k,ist_p0p)) /
-                ( amrex::Math::abs(sten(i,j-1,k,ist_ppp))
-                + amrex::Math::abs(sten(i,j  ,k,ist_ppp)) + eps);
+            wtmp = std::abs(sten(i,j,k,ist_p0p)) /
+                ( std::abs(sten(i,j-1,k,ist_ppp))
+                + std::abs(sten(i,j  ,k,ist_ppp)) + eps);
             wpmp += wtmp;
             wppp += wtmp;
 
-            wtmp = amrex::Math::abs(sten(i,j-1,k-1,ist_0pp)) /
-                ( amrex::Math::abs(sten(i-1,j-1,k-1,ist_ppp))
-                + amrex::Math::abs(sten(i  ,j-1,k-1,ist_ppp)) + eps);
+            wtmp = std::abs(sten(i,j-1,k-1,ist_0pp)) /
+                ( std::abs(sten(i-1,j-1,k-1,ist_ppp))
+                + std::abs(sten(i  ,j-1,k-1,ist_ppp)) + eps);
             wmmm += wtmp;
             wpmm += wtmp;
 
-            wtmp = amrex::Math::abs(sten(i,j,k-1,ist_0pp)) /
-                ( amrex::Math::abs(sten(i-1,j,k-1,ist_ppp))
-                + amrex::Math::abs(sten(i  ,j,k-1,ist_ppp)) + eps);
+            wtmp = std::abs(sten(i,j,k-1,ist_0pp)) /
+                ( std::abs(sten(i-1,j,k-1,ist_ppp))
+                + std::abs(sten(i  ,j,k-1,ist_ppp)) + eps);
             wmpm += wtmp;
             wppm += wtmp;
 
-            wtmp = amrex::Math::abs(sten(i,j-1,k,ist_0pp)) /
-                ( amrex::Math::abs(sten(i-1,j-1,k,ist_ppp))
-                + amrex::Math::abs(sten(i  ,j-1,k,ist_ppp)) + eps);
+            wtmp = std::abs(sten(i,j-1,k,ist_0pp)) /
+                ( std::abs(sten(i-1,j-1,k,ist_ppp))
+                + std::abs(sten(i  ,j-1,k,ist_ppp)) + eps);
             wmmp += wtmp;
             wpmp += wtmp;
 
-            wtmp = amrex::Math::abs(sten(i,j,k,ist_0pp)) /
-                ( amrex::Math::abs(sten(i-1,j,k,ist_ppp))
-                + amrex::Math::abs(sten(i  ,j,k,ist_ppp)) + eps);
+            wtmp = std::abs(sten(i,j,k,ist_0pp)) /
+                ( std::abs(sten(i-1,j,k,ist_ppp))
+                + std::abs(sten(i  ,j,k,ist_ppp)) + eps);
             wmpp += wtmp;
             wppp += wtmp;
 
-            wmmm *= amrex::Math::abs(sten(i-1,j-1,k-1,ist_ppp));
-            wpmm *= amrex::Math::abs(sten(i  ,j-1,k-1,ist_ppp));
-            wmpm *= amrex::Math::abs(sten(i-1,j  ,k-1,ist_ppp));
-            wppm *= amrex::Math::abs(sten(i  ,j  ,k-1,ist_ppp));
-            wmmp *= amrex::Math::abs(sten(i-1,j-1,k  ,ist_ppp));
-            wpmp *= amrex::Math::abs(sten(i  ,j-1,k  ,ist_ppp));
-            wmpp *= amrex::Math::abs(sten(i-1,j  ,k  ,ist_ppp));
-            wppp *= amrex::Math::abs(sten(i  ,j  ,k  ,ist_ppp));
+            wmmm *= std::abs(sten(i-1,j-1,k-1,ist_ppp));
+            wpmm *= std::abs(sten(i  ,j-1,k-1,ist_ppp));
+            wmpm *= std::abs(sten(i-1,j  ,k-1,ist_ppp));
+            wppm *= std::abs(sten(i  ,j  ,k-1,ist_ppp));
+            wmmp *= std::abs(sten(i-1,j-1,k  ,ist_ppp));
+            wpmp *= std::abs(sten(i  ,j-1,k  ,ist_ppp));
+            wmpp *= std::abs(sten(i-1,j  ,k  ,ist_ppp));
+            wppp *= std::abs(sten(i  ,j  ,k  ,ist_ppp));
             fv = (wmmm*crse(ic,jc  ,kc  ) + wpmm*crse(ic+1,jc  ,kc  )
                   + wmpm*crse(ic,jc+1,kc  ) + wppm*crse(ic+1,jc+1,kc  )
                   + wmmp*crse(ic,jc  ,kc+1) + wpmp*crse(ic+1,jc  ,kc+1)
@@ -5810,8 +5810,8 @@ void mlndlap_restriction_rap (int i, int j, int k, Array4<Real> const& crse,
         // Adding fine(ii-1,jj,kk)
         // ************************************
 
-        Real sten_lo = amrex::Math::abs(sten(ii-2,jj,kk,ist_p00));
-        Real sten_hi = amrex::Math::abs(sten(ii-1,jj,kk,ist_p00));
+        Real sten_lo = std::abs(sten(ii-2,jj,kk,ist_p00));
+        Real sten_hi = std::abs(sten(ii-1,jj,kk,ist_p00));
 
         if (sten_lo == Real(0.0) && sten_hi == Real(0.0)) {
             cv += Real(0.5)*fine(ii-1,jj,kk);
@@ -5823,8 +5823,8 @@ void mlndlap_restriction_rap (int i, int j, int k, Array4<Real> const& crse,
         // Adding fine(ii+1,jj,kk)
         // ************************************
 
-        sten_lo = amrex::Math::abs(sten(ii  ,jj,kk,ist_p00));
-        sten_hi = amrex::Math::abs(sten(ii+1,jj,kk,ist_p00));
+        sten_lo = std::abs(sten(ii  ,jj,kk,ist_p00));
+        sten_hi = std::abs(sten(ii+1,jj,kk,ist_p00));
 
         if (sten_lo == Real(0.0) && sten_hi == Real(0.0)) {
             cv += Real(0.5)*fine(ii+1,jj,kk);
@@ -5836,8 +5836,8 @@ void mlndlap_restriction_rap (int i, int j, int k, Array4<Real> const& crse,
         // Adding fine(ii,jj-1,kk)
         // ************************************
 
-        sten_lo = amrex::Math::abs(sten(ii,jj-2,kk,ist_0p0));
-        sten_hi = amrex::Math::abs(sten(ii,jj-1,kk,ist_0p0));
+        sten_lo = std::abs(sten(ii,jj-2,kk,ist_0p0));
+        sten_hi = std::abs(sten(ii,jj-1,kk,ist_0p0));
 
         if (sten_lo == Real(0.0) && sten_hi == Real(0.0)) {
             cv += Real(0.5)*fine(ii,jj-1,kk);
@@ -5849,8 +5849,8 @@ void mlndlap_restriction_rap (int i, int j, int k, Array4<Real> const& crse,
         // Adding fine(ii,jj+1,kk)
         // ************************************
 
-        sten_lo = amrex::Math::abs(sten(ii,jj  ,kk,ist_0p0));
-        sten_hi = amrex::Math::abs(sten(ii,jj+1,kk,ist_0p0));
+        sten_lo = std::abs(sten(ii,jj  ,kk,ist_0p0));
+        sten_hi = std::abs(sten(ii,jj+1,kk,ist_0p0));
 
         if (sten_lo == Real(0.0) && sten_hi == Real(0.0)) {
             cv += Real(0.5)*fine(ii,jj+1,kk);
@@ -5862,8 +5862,8 @@ void mlndlap_restriction_rap (int i, int j, int k, Array4<Real> const& crse,
         // Adding fine(ii,jj,kk-1)
         // ************************************
 
-        sten_lo = amrex::Math::abs(sten(ii,jj,kk-2,ist_00p));
-        sten_hi = amrex::Math::abs(sten(ii,jj,kk-1,ist_00p));
+        sten_lo = std::abs(sten(ii,jj,kk-2,ist_00p));
+        sten_hi = std::abs(sten(ii,jj,kk-1,ist_00p));
 
         if (sten_lo == Real(0.0) && sten_hi == Real(0.0)) {
             cv += Real(0.5)*fine(ii,jj,kk-1);
@@ -5875,8 +5875,8 @@ void mlndlap_restriction_rap (int i, int j, int k, Array4<Real> const& crse,
         // Adding fine(ii,jj,kk+1)
         // ************************************
 
-        sten_lo = amrex::Math::abs(sten(ii,jj,kk  ,ist_00p));
-        sten_hi = amrex::Math::abs(sten(ii,jj,kk+1,ist_00p));
+        sten_lo = std::abs(sten(ii,jj,kk  ,ist_00p));
+        sten_hi = std::abs(sten(ii,jj,kk+1,ist_00p));
 
         if (sten_lo == Real(0.0) && sten_hi == Real(0.0)) {
             cv += Real(0.5)*fine(ii,jj,kk+1);
@@ -5889,88 +5889,88 @@ void mlndlap_restriction_rap (int i, int j, int k, Array4<Real> const& crse,
         // ************************************
 
         // keven
-        Real w1m = amrex::Math::abs(sten(ii-2,jj-1,kk,ist_p00))
-            / (    amrex::Math::abs(sten(ii-2,jj-2,kk,ist_pp0))
-                  +amrex::Math::abs(sten(ii-2,jj-1,kk,ist_pp0)) + eps);
-        Real w1p = amrex::Math::abs(sten(ii-1,jj-1,kk,ist_p00))
-            / (    amrex::Math::abs(sten(ii-1,jj-2,kk,ist_pp0))
-                  +amrex::Math::abs(sten(ii-1,jj-1,kk,ist_pp0)) + eps);
-        Real w2m = amrex::Math::abs(sten(ii-1,jj-2,kk,ist_0p0))
-            / (    amrex::Math::abs(sten(ii-2,jj-2,kk,ist_pp0))
-                  +amrex::Math::abs(sten(ii-1,jj-2,kk,ist_pp0)) + eps);
-        Real w2p = amrex::Math::abs(sten(ii-1,jj-1,kk,ist_0p0))
-            / (    amrex::Math::abs(sten(ii-2,jj-1,kk,ist_pp0))
-                  +amrex::Math::abs(sten(ii-1,jj-1,kk,ist_pp0)) + eps);
-        Real wmm = amrex::Math::abs(sten(ii-2,jj-2,kk,ist_pp0)) * (Real(1.0) + w1m + w2m);
-        Real wpm = amrex::Math::abs(sten(ii-1,jj-2,kk,ist_pp0)) * (Real(1.0) + w1p + w2m);
-        Real wmp = amrex::Math::abs(sten(ii-2,jj-1,kk,ist_pp0)) * (Real(1.0) + w1m + w2p);
-        Real wpp = amrex::Math::abs(sten(ii-1,jj-1,kk,ist_pp0)) * (Real(1.0) + w1p + w2p);
+        Real w1m = std::abs(sten(ii-2,jj-1,kk,ist_p00))
+            / (    std::abs(sten(ii-2,jj-2,kk,ist_pp0))
+                  +std::abs(sten(ii-2,jj-1,kk,ist_pp0)) + eps);
+        Real w1p = std::abs(sten(ii-1,jj-1,kk,ist_p00))
+            / (    std::abs(sten(ii-1,jj-2,kk,ist_pp0))
+                  +std::abs(sten(ii-1,jj-1,kk,ist_pp0)) + eps);
+        Real w2m = std::abs(sten(ii-1,jj-2,kk,ist_0p0))
+            / (    std::abs(sten(ii-2,jj-2,kk,ist_pp0))
+                  +std::abs(sten(ii-1,jj-2,kk,ist_pp0)) + eps);
+        Real w2p = std::abs(sten(ii-1,jj-1,kk,ist_0p0))
+            / (    std::abs(sten(ii-2,jj-1,kk,ist_pp0))
+                  +std::abs(sten(ii-1,jj-1,kk,ist_pp0)) + eps);
+        Real wmm = std::abs(sten(ii-2,jj-2,kk,ist_pp0)) * (Real(1.0) + w1m + w2m);
+        Real wpm = std::abs(sten(ii-1,jj-2,kk,ist_pp0)) * (Real(1.0) + w1p + w2m);
+        Real wmp = std::abs(sten(ii-2,jj-1,kk,ist_pp0)) * (Real(1.0) + w1m + w2p);
+        Real wpp = std::abs(sten(ii-1,jj-1,kk,ist_pp0)) * (Real(1.0) + w1p + w2p);
         cv += fine(ii-1,jj-1,kk)*wpp/(wmm+wpm+wmp+wpp+eps);
 
         // ************************************
         // Adding fine(ii+1,jj-1,kk)
         // ************************************
 
-        w1m = amrex::Math::abs(sten(ii  ,jj-1,kk,ist_p00))
-           / (amrex::Math::abs(sten(ii  ,jj-2,kk,ist_pp0))
-             +amrex::Math::abs(sten(ii  ,jj-1,kk,ist_pp0)) + eps);
-        w1p = amrex::Math::abs(sten(ii+1,jj-1,kk,ist_p00))
-           / (amrex::Math::abs(sten(ii+1,jj-2,kk,ist_pp0))
-             +amrex::Math::abs(sten(ii+1,jj-1,kk,ist_pp0)) + eps);
-        w2m = amrex::Math::abs(sten(ii+1,jj-2,kk,ist_0p0))
-           / (amrex::Math::abs(sten(ii  ,jj-2,kk,ist_pp0))
-             +amrex::Math::abs(sten(ii+1,jj-2,kk,ist_pp0)) + eps);
-        w2p = amrex::Math::abs(sten(ii+1,jj-1,kk,ist_0p0))
-           / (amrex::Math::abs(sten(ii  ,jj-1,kk,ist_pp0))
-             +amrex::Math::abs(sten(ii+1,jj-1,kk,ist_pp0)) + eps);
-        wmm = amrex::Math::abs(sten(ii  ,jj-2,kk,ist_pp0)) * (Real(1.0) + w1m + w2m);
-        wpm = amrex::Math::abs(sten(ii+1,jj-2,kk,ist_pp0)) * (Real(1.0) + w1p + w2m);
-        wmp = amrex::Math::abs(sten(ii  ,jj-1,kk,ist_pp0)) * (Real(1.0) + w1m + w2p);
-        wpp = amrex::Math::abs(sten(ii+1,jj-1,kk,ist_pp0)) * (Real(1.0) + w1p + w2p);
+        w1m = std::abs(sten(ii  ,jj-1,kk,ist_p00))
+           / (std::abs(sten(ii  ,jj-2,kk,ist_pp0))
+             +std::abs(sten(ii  ,jj-1,kk,ist_pp0)) + eps);
+        w1p = std::abs(sten(ii+1,jj-1,kk,ist_p00))
+           / (std::abs(sten(ii+1,jj-2,kk,ist_pp0))
+             +std::abs(sten(ii+1,jj-1,kk,ist_pp0)) + eps);
+        w2m = std::abs(sten(ii+1,jj-2,kk,ist_0p0))
+           / (std::abs(sten(ii  ,jj-2,kk,ist_pp0))
+             +std::abs(sten(ii+1,jj-2,kk,ist_pp0)) + eps);
+        w2p = std::abs(sten(ii+1,jj-1,kk,ist_0p0))
+           / (std::abs(sten(ii  ,jj-1,kk,ist_pp0))
+             +std::abs(sten(ii+1,jj-1,kk,ist_pp0)) + eps);
+        wmm = std::abs(sten(ii  ,jj-2,kk,ist_pp0)) * (Real(1.0) + w1m + w2m);
+        wpm = std::abs(sten(ii+1,jj-2,kk,ist_pp0)) * (Real(1.0) + w1p + w2m);
+        wmp = std::abs(sten(ii  ,jj-1,kk,ist_pp0)) * (Real(1.0) + w1m + w2p);
+        wpp = std::abs(sten(ii+1,jj-1,kk,ist_pp0)) * (Real(1.0) + w1p + w2p);
         cv += fine(ii+1,jj-1,kk)*wmp/(wmm+wpm+wmp+wpp+eps);
 
         // ************************************
         // Adding fine(ii-1,jj+1,kk)
         // ************************************
 
-        w1m = amrex::Math::abs(sten(ii-2,jj+1,kk,ist_p00))
-           / (amrex::Math::abs(sten(ii-2,jj  ,kk,ist_pp0))
-             +amrex::Math::abs(sten(ii-2,jj+1,kk,ist_pp0)) + eps);
-        w1p = amrex::Math::abs(sten(ii-1,jj+1,kk,ist_p00))
-           / (amrex::Math::abs(sten(ii-1,jj  ,kk,ist_pp0))
-             +amrex::Math::abs(sten(ii-1,jj+1,kk,ist_pp0)) + eps);
-        w2m = amrex::Math::abs(sten(ii-1,jj  ,kk,ist_0p0))
-           / (amrex::Math::abs(sten(ii-2,jj  ,kk,ist_pp0))
-             +amrex::Math::abs(sten(ii-1,jj  ,kk,ist_pp0)) + eps);
-        w2p = amrex::Math::abs(sten(ii-1,jj+1,kk,ist_0p0))
-           / (amrex::Math::abs(sten(ii-2,jj+1,kk,ist_pp0))
-             +amrex::Math::abs(sten(ii-1,jj+1,kk,ist_pp0)) + eps);
-        wmm = amrex::Math::abs(sten(ii-2,jj  ,kk,ist_pp0)) * (Real(1.0) + w1m + w2m);
-        wpm = amrex::Math::abs(sten(ii-1,jj  ,kk,ist_pp0)) * (Real(1.0) + w1p + w2m);
-        wmp = amrex::Math::abs(sten(ii-2,jj+1,kk,ist_pp0)) * (Real(1.0) + w1m + w2p);
-        wpp = amrex::Math::abs(sten(ii-1,jj+1,kk,ist_pp0)) * (Real(1.0) + w1p + w2p);
+        w1m = std::abs(sten(ii-2,jj+1,kk,ist_p00))
+           / (std::abs(sten(ii-2,jj  ,kk,ist_pp0))
+             +std::abs(sten(ii-2,jj+1,kk,ist_pp0)) + eps);
+        w1p = std::abs(sten(ii-1,jj+1,kk,ist_p00))
+           / (std::abs(sten(ii-1,jj  ,kk,ist_pp0))
+             +std::abs(sten(ii-1,jj+1,kk,ist_pp0)) + eps);
+        w2m = std::abs(sten(ii-1,jj  ,kk,ist_0p0))
+           / (std::abs(sten(ii-2,jj  ,kk,ist_pp0))
+             +std::abs(sten(ii-1,jj  ,kk,ist_pp0)) + eps);
+        w2p = std::abs(sten(ii-1,jj+1,kk,ist_0p0))
+           / (std::abs(sten(ii-2,jj+1,kk,ist_pp0))
+             +std::abs(sten(ii-1,jj+1,kk,ist_pp0)) + eps);
+        wmm = std::abs(sten(ii-2,jj  ,kk,ist_pp0)) * (Real(1.0) + w1m + w2m);
+        wpm = std::abs(sten(ii-1,jj  ,kk,ist_pp0)) * (Real(1.0) + w1p + w2m);
+        wmp = std::abs(sten(ii-2,jj+1,kk,ist_pp0)) * (Real(1.0) + w1m + w2p);
+        wpp = std::abs(sten(ii-1,jj+1,kk,ist_pp0)) * (Real(1.0) + w1p + w2p);
         cv += fine(ii-1,jj+1,kk)*wpm/(wmm+wpm+wmp+wpp+eps);
 
         // ************************************
         // Adding fine(ii+1,jj+1,kk)
         // ************************************
 
-        w1m = amrex::Math::abs(sten(ii  ,jj+1,kk,ist_p00))
-           / (amrex::Math::abs(sten(ii  ,jj+1,kk,ist_pp0))
-             +amrex::Math::abs(sten(ii  ,jj  ,kk,ist_pp0)) + eps);
-        w1p = amrex::Math::abs(sten(ii+1,jj+1,kk,ist_p00))
-           / (amrex::Math::abs(sten(ii+1,jj+1,kk,ist_pp0))
-             +amrex::Math::abs(sten(ii+1,jj  ,kk,ist_pp0)) + eps);
-        w2m = amrex::Math::abs(sten(ii+1,jj  ,kk,ist_0p0))
-           / (amrex::Math::abs(sten(ii+1,jj  ,kk,ist_pp0))
-             +amrex::Math::abs(sten(ii  ,jj  ,kk,ist_pp0)) + eps);
-        w2p = amrex::Math::abs(sten(ii+1,jj+1,kk,ist_0p0))
-           / (amrex::Math::abs(sten(ii+1,jj+1,kk,ist_pp0))
-             +amrex::Math::abs(sten(ii  ,jj+1,kk,ist_pp0)) + eps);
-        wmm = amrex::Math::abs(sten(ii  ,jj  ,kk,ist_pp0)) * (Real(1.0) + w1m + w2m);
-        wpm = amrex::Math::abs(sten(ii+1,jj  ,kk,ist_pp0)) * (Real(1.0) + w1p + w2m);
-        wmp = amrex::Math::abs(sten(ii  ,jj+1,kk,ist_pp0)) * (Real(1.0) + w1m + w2p);
-        wpp = amrex::Math::abs(sten(ii+1,jj+1,kk,ist_pp0)) * (Real(1.0) + w1p + w2p);
+        w1m = std::abs(sten(ii  ,jj+1,kk,ist_p00))
+           / (std::abs(sten(ii  ,jj+1,kk,ist_pp0))
+             +std::abs(sten(ii  ,jj  ,kk,ist_pp0)) + eps);
+        w1p = std::abs(sten(ii+1,jj+1,kk,ist_p00))
+           / (std::abs(sten(ii+1,jj+1,kk,ist_pp0))
+             +std::abs(sten(ii+1,jj  ,kk,ist_pp0)) + eps);
+        w2m = std::abs(sten(ii+1,jj  ,kk,ist_0p0))
+           / (std::abs(sten(ii+1,jj  ,kk,ist_pp0))
+             +std::abs(sten(ii  ,jj  ,kk,ist_pp0)) + eps);
+        w2p = std::abs(sten(ii+1,jj+1,kk,ist_0p0))
+           / (std::abs(sten(ii+1,jj+1,kk,ist_pp0))
+             +std::abs(sten(ii  ,jj+1,kk,ist_pp0)) + eps);
+        wmm = std::abs(sten(ii  ,jj  ,kk,ist_pp0)) * (Real(1.0) + w1m + w2m);
+        wpm = std::abs(sten(ii+1,jj  ,kk,ist_pp0)) * (Real(1.0) + w1p + w2m);
+        wmp = std::abs(sten(ii  ,jj+1,kk,ist_pp0)) * (Real(1.0) + w1m + w2p);
+        wpp = std::abs(sten(ii+1,jj+1,kk,ist_pp0)) * (Real(1.0) + w1p + w2p);
         cv += fine(ii+1,jj+1,kk)*wmm/(wmm+wpm+wmp+wpp+eps);
 
         // ************************************
@@ -5978,88 +5978,88 @@ void mlndlap_restriction_rap (int i, int j, int k, Array4<Real> const& crse,
         // ************************************
 
         // jeven
-        w1m = amrex::Math::abs(sten(ii-2,jj,kk-1,ist_p00))
-           / (amrex::Math::abs(sten(ii-2,jj,kk-2,ist_p0p))
-             +amrex::Math::abs(sten(ii-2,jj,kk-1,ist_p0p)) + eps);
-        w1p = amrex::Math::abs(sten(ii-1,jj,kk-1,ist_p00))
-           / (amrex::Math::abs(sten(ii-1,jj,kk-2,ist_p0p))
-             +amrex::Math::abs(sten(ii-1,jj,kk-1,ist_p0p)) + eps);
-        w2m = amrex::Math::abs(sten(ii-1,jj,kk-2,ist_00p))
-           / (amrex::Math::abs(sten(ii-2,jj,kk-2,ist_p0p))
-             +amrex::Math::abs(sten(ii-1,jj,kk-2,ist_p0p)) + eps);
-        w2p = amrex::Math::abs(sten(ii-1,jj,kk-1,ist_00p))
-           / (amrex::Math::abs(sten(ii-2,jj,kk-1,ist_p0p))
-             +amrex::Math::abs(sten(ii-1,jj,kk-1,ist_p0p)) + eps);
-        wmm = amrex::Math::abs(sten(ii-2,jj,kk-2,ist_p0p)) * (Real(1.0) + w1m + w2m);
-        wpm = amrex::Math::abs(sten(ii-1,jj,kk-2,ist_p0p)) * (Real(1.0) + w1p + w2m);
-        wmp = amrex::Math::abs(sten(ii-2,jj,kk-1,ist_p0p)) * (Real(1.0) + w1m + w2p);
-        wpp = amrex::Math::abs(sten(ii-1,jj,kk-1,ist_p0p)) * (Real(1.0) + w1p + w2p);
+        w1m = std::abs(sten(ii-2,jj,kk-1,ist_p00))
+           / (std::abs(sten(ii-2,jj,kk-2,ist_p0p))
+             +std::abs(sten(ii-2,jj,kk-1,ist_p0p)) + eps);
+        w1p = std::abs(sten(ii-1,jj,kk-1,ist_p00))
+           / (std::abs(sten(ii-1,jj,kk-2,ist_p0p))
+             +std::abs(sten(ii-1,jj,kk-1,ist_p0p)) + eps);
+        w2m = std::abs(sten(ii-1,jj,kk-2,ist_00p))
+           / (std::abs(sten(ii-2,jj,kk-2,ist_p0p))
+             +std::abs(sten(ii-1,jj,kk-2,ist_p0p)) + eps);
+        w2p = std::abs(sten(ii-1,jj,kk-1,ist_00p))
+           / (std::abs(sten(ii-2,jj,kk-1,ist_p0p))
+             +std::abs(sten(ii-1,jj,kk-1,ist_p0p)) + eps);
+        wmm = std::abs(sten(ii-2,jj,kk-2,ist_p0p)) * (Real(1.0) + w1m + w2m);
+        wpm = std::abs(sten(ii-1,jj,kk-2,ist_p0p)) * (Real(1.0) + w1p + w2m);
+        wmp = std::abs(sten(ii-2,jj,kk-1,ist_p0p)) * (Real(1.0) + w1m + w2p);
+        wpp = std::abs(sten(ii-1,jj,kk-1,ist_p0p)) * (Real(1.0) + w1p + w2p);
         cv += fine(ii-1,jj,kk-1)*wpp/(wmm+wpm+wmp+wpp+eps);
 
         // ************************************
         // Adding fine(ii+1,jj,kk-1)
         // ************************************
 
-        w1m = amrex::Math::abs(sten(ii  ,jj,kk-1,ist_p00))
-           / (amrex::Math::abs(sten(ii  ,jj,kk-2,ist_p0p))
-             +amrex::Math::abs(sten(ii  ,jj,kk-1,ist_p0p)) + eps);
-        w1p = amrex::Math::abs(sten(ii+1,jj,kk-1,ist_p00))
-           / (amrex::Math::abs(sten(ii+1,jj,kk-2,ist_p0p))
-             +amrex::Math::abs(sten(ii+1,jj,kk-1,ist_p0p)) + eps);
-        w2m = amrex::Math::abs(sten(ii+1,jj,kk-2,ist_00p))
-           / (amrex::Math::abs(sten(ii+1,jj,kk-2,ist_p0p))
-             +amrex::Math::abs(sten(ii  ,jj,kk-2,ist_p0p)) + eps);
-        w2p = amrex::Math::abs(sten(ii+1,jj,kk-1,ist_00p))
-           / (amrex::Math::abs(sten(ii+1,jj,kk-1,ist_p0p))
-             +amrex::Math::abs(sten(ii  ,jj,kk-1,ist_p0p)) + eps);
-        wmm = amrex::Math::abs(sten(ii  ,jj,kk-2,ist_p0p)) * (Real(1.0) + w1m + w2m);
-        wpm = amrex::Math::abs(sten(ii+1,jj,kk-2,ist_p0p)) * (Real(1.0) + w1p + w2m);
-        wmp = amrex::Math::abs(sten(ii  ,jj,kk-1,ist_p0p)) * (Real(1.0) + w1m + w2p);
-        wpp = amrex::Math::abs(sten(ii+1,jj,kk-1,ist_p0p)) * (Real(1.0) + w1p + w2p);
+        w1m = std::abs(sten(ii  ,jj,kk-1,ist_p00))
+           / (std::abs(sten(ii  ,jj,kk-2,ist_p0p))
+             +std::abs(sten(ii  ,jj,kk-1,ist_p0p)) + eps);
+        w1p = std::abs(sten(ii+1,jj,kk-1,ist_p00))
+           / (std::abs(sten(ii+1,jj,kk-2,ist_p0p))
+             +std::abs(sten(ii+1,jj,kk-1,ist_p0p)) + eps);
+        w2m = std::abs(sten(ii+1,jj,kk-2,ist_00p))
+           / (std::abs(sten(ii+1,jj,kk-2,ist_p0p))
+             +std::abs(sten(ii  ,jj,kk-2,ist_p0p)) + eps);
+        w2p = std::abs(sten(ii+1,jj,kk-1,ist_00p))
+           / (std::abs(sten(ii+1,jj,kk-1,ist_p0p))
+             +std::abs(sten(ii  ,jj,kk-1,ist_p0p)) + eps);
+        wmm = std::abs(sten(ii  ,jj,kk-2,ist_p0p)) * (Real(1.0) + w1m + w2m);
+        wpm = std::abs(sten(ii+1,jj,kk-2,ist_p0p)) * (Real(1.0) + w1p + w2m);
+        wmp = std::abs(sten(ii  ,jj,kk-1,ist_p0p)) * (Real(1.0) + w1m + w2p);
+        wpp = std::abs(sten(ii+1,jj,kk-1,ist_p0p)) * (Real(1.0) + w1p + w2p);
         cv += fine(ii+1,jj,kk-1)*wmp/(wmm+wpm+wmp+wpp+eps);
 
         // ************************************
         // Adding fine(ii-1,jj,kk+1)
         // ************************************
 
-        w1m = amrex::Math::abs(sten(ii-2,jj,kk+1,ist_p00))
-           / (amrex::Math::abs(sten(ii-2,jj,kk+1,ist_p0p))
-             +amrex::Math::abs(sten(ii-2,jj,kk  ,ist_p0p)) + eps);
-        w1p = amrex::Math::abs(sten(ii-1,jj,kk+1,ist_p00))
-           / (amrex::Math::abs(sten(ii-1,jj,kk+1,ist_p0p))
-             +amrex::Math::abs(sten(ii-1,jj,kk  ,ist_p0p)) + eps);
-        w2m = amrex::Math::abs(sten(ii-1,jj,kk  ,ist_00p))
-           / (amrex::Math::abs(sten(ii-2,jj,kk  ,ist_p0p))
-             +amrex::Math::abs(sten(ii-1,jj,kk  ,ist_p0p)) + eps);
-        w2p = amrex::Math::abs(sten(ii-1,jj,kk+1,ist_00p))
-           / (amrex::Math::abs(sten(ii-2,jj,kk+1,ist_p0p))
-             +amrex::Math::abs(sten(ii-1,jj,kk+1,ist_p0p)) + eps);
-        wmm = amrex::Math::abs(sten(ii-2,jj,kk  ,ist_p0p)) * (Real(1.0) + w1m + w2m);
-        wpm = amrex::Math::abs(sten(ii-1,jj,kk  ,ist_p0p)) * (Real(1.0) + w1p + w2m);
-        wmp = amrex::Math::abs(sten(ii-2,jj,kk+1,ist_p0p)) * (Real(1.0) + w1m + w2p);
-        wpp = amrex::Math::abs(sten(ii-1,jj,kk+1,ist_p0p)) * (Real(1.0) + w1p + w2p);
+        w1m = std::abs(sten(ii-2,jj,kk+1,ist_p00))
+           / (std::abs(sten(ii-2,jj,kk+1,ist_p0p))
+             +std::abs(sten(ii-2,jj,kk  ,ist_p0p)) + eps);
+        w1p = std::abs(sten(ii-1,jj,kk+1,ist_p00))
+           / (std::abs(sten(ii-1,jj,kk+1,ist_p0p))
+             +std::abs(sten(ii-1,jj,kk  ,ist_p0p)) + eps);
+        w2m = std::abs(sten(ii-1,jj,kk  ,ist_00p))
+           / (std::abs(sten(ii-2,jj,kk  ,ist_p0p))
+             +std::abs(sten(ii-1,jj,kk  ,ist_p0p)) + eps);
+        w2p = std::abs(sten(ii-1,jj,kk+1,ist_00p))
+           / (std::abs(sten(ii-2,jj,kk+1,ist_p0p))
+             +std::abs(sten(ii-1,jj,kk+1,ist_p0p)) + eps);
+        wmm = std::abs(sten(ii-2,jj,kk  ,ist_p0p)) * (Real(1.0) + w1m + w2m);
+        wpm = std::abs(sten(ii-1,jj,kk  ,ist_p0p)) * (Real(1.0) + w1p + w2m);
+        wmp = std::abs(sten(ii-2,jj,kk+1,ist_p0p)) * (Real(1.0) + w1m + w2p);
+        wpp = std::abs(sten(ii-1,jj,kk+1,ist_p0p)) * (Real(1.0) + w1p + w2p);
         cv += fine(ii-1,jj,kk+1)*wpm/(wmm+wpm+wmp+wpp+eps);
 
         // ************************************
         // Adding fine(ii+1,jj,kk+1)
         // ************************************
 
-        w1m = amrex::Math::abs(sten(ii  ,jj,kk+1,ist_p00))
-           / (amrex::Math::abs(sten(ii  ,jj,kk+1,ist_p0p))
-             +amrex::Math::abs(sten(ii  ,jj,kk  ,ist_p0p)) + eps);
-        w1p = amrex::Math::abs(sten(ii+1,jj,kk+1,ist_p00))
-           / (amrex::Math::abs(sten(ii+1,jj,kk+1,ist_p0p))
-              +amrex::Math::abs(sten(ii+1,jj,kk  ,ist_p0p)) + eps);
-        w2m = amrex::Math::abs(sten(ii+1,jj,kk  ,ist_00p))
-           / (amrex::Math::abs(sten(ii+1,jj,kk  ,ist_p0p))
-             +amrex::Math::abs(sten(ii  ,jj,kk  ,ist_p0p)) + eps);
-        w2p = amrex::Math::abs(sten(ii+1,jj,kk+1,ist_00p))
-           / (amrex::Math::abs(sten(ii+1,jj,kk+1,ist_p0p))
-             +amrex::Math::abs(sten(ii  ,jj,kk+1,ist_p0p)) + eps);
-        wmm = amrex::Math::abs(sten(ii  ,jj,kk  ,ist_p0p)) * (Real(1.0) + w1m + w2m);
-        wpm = amrex::Math::abs(sten(ii+1,jj,kk  ,ist_p0p)) * (Real(1.0) + w1p + w2m);
-        wmp = amrex::Math::abs(sten(ii  ,jj,kk+1,ist_p0p)) * (Real(1.0) + w1m + w2p);
-        wpp = amrex::Math::abs(sten(ii+1,jj,kk+1,ist_p0p)) * (Real(1.0) + w1p + w2p);
+        w1m = std::abs(sten(ii  ,jj,kk+1,ist_p00))
+           / (std::abs(sten(ii  ,jj,kk+1,ist_p0p))
+             +std::abs(sten(ii  ,jj,kk  ,ist_p0p)) + eps);
+        w1p = std::abs(sten(ii+1,jj,kk+1,ist_p00))
+           / (std::abs(sten(ii+1,jj,kk+1,ist_p0p))
+              +std::abs(sten(ii+1,jj,kk  ,ist_p0p)) + eps);
+        w2m = std::abs(sten(ii+1,jj,kk  ,ist_00p))
+           / (std::abs(sten(ii+1,jj,kk  ,ist_p0p))
+             +std::abs(sten(ii  ,jj,kk  ,ist_p0p)) + eps);
+        w2p = std::abs(sten(ii+1,jj,kk+1,ist_00p))
+           / (std::abs(sten(ii+1,jj,kk+1,ist_p0p))
+             +std::abs(sten(ii  ,jj,kk+1,ist_p0p)) + eps);
+        wmm = std::abs(sten(ii  ,jj,kk  ,ist_p0p)) * (Real(1.0) + w1m + w2m);
+        wpm = std::abs(sten(ii+1,jj,kk  ,ist_p0p)) * (Real(1.0) + w1p + w2m);
+        wmp = std::abs(sten(ii  ,jj,kk+1,ist_p0p)) * (Real(1.0) + w1m + w2p);
+        wpp = std::abs(sten(ii+1,jj,kk+1,ist_p0p)) * (Real(1.0) + w1p + w2p);
         cv += fine(ii+1,jj,kk+1)*wmm/(wmm+wpm+wmp+wpp+eps);
 
         // ************************************
@@ -6067,88 +6067,88 @@ void mlndlap_restriction_rap (int i, int j, int k, Array4<Real> const& crse,
         // ************************************
 
         // ieven
-        w1m = amrex::Math::abs(sten(ii,jj-2,kk-1,ist_0p0))
-           / (amrex::Math::abs(sten(ii,jj-2,kk-2,ist_0pp))
-             +amrex::Math::abs(sten(ii,jj-2,kk-1,ist_0pp)) + eps);
-        w2m = amrex::Math::abs(sten(ii,jj-1,kk-2,ist_00p))
-           / (amrex::Math::abs(sten(ii,jj-2,kk-2,ist_0pp))
-             +amrex::Math::abs(sten(ii,jj-1,kk-2,ist_0pp)) + eps);
-        w1p = amrex::Math::abs(sten(ii,jj-1,kk-1,ist_0p0))
-           / (amrex::Math::abs(sten(ii,jj-1,kk-2,ist_0pp))
-             +amrex::Math::abs(sten(ii,jj-1,kk-1,ist_0pp)) + eps);
-        w2p = amrex::Math::abs(sten(ii,jj-1,kk-1,ist_00p))
-           / (amrex::Math::abs(sten(ii,jj-2,kk-1,ist_0pp))
-             +amrex::Math::abs(sten(ii,jj-1,kk-1,ist_0pp)) + eps);
-        wmm = amrex::Math::abs(sten(ii,jj-2,kk-2,ist_0pp)) * (Real(1.0) + w1m + w2m);
-        wpm = amrex::Math::abs(sten(ii,jj-1,kk-2,ist_0pp)) * (Real(1.0) + w1p + w2m);
-        wmp = amrex::Math::abs(sten(ii,jj-2,kk-1,ist_0pp)) * (Real(1.0) + w1m + w2p);
-        wpp = amrex::Math::abs(sten(ii,jj-1,kk-1,ist_0pp)) * (Real(1.0) + w1p + w2p);
+        w1m = std::abs(sten(ii,jj-2,kk-1,ist_0p0))
+           / (std::abs(sten(ii,jj-2,kk-2,ist_0pp))
+             +std::abs(sten(ii,jj-2,kk-1,ist_0pp)) + eps);
+        w2m = std::abs(sten(ii,jj-1,kk-2,ist_00p))
+           / (std::abs(sten(ii,jj-2,kk-2,ist_0pp))
+             +std::abs(sten(ii,jj-1,kk-2,ist_0pp)) + eps);
+        w1p = std::abs(sten(ii,jj-1,kk-1,ist_0p0))
+           / (std::abs(sten(ii,jj-1,kk-2,ist_0pp))
+             +std::abs(sten(ii,jj-1,kk-1,ist_0pp)) + eps);
+        w2p = std::abs(sten(ii,jj-1,kk-1,ist_00p))
+           / (std::abs(sten(ii,jj-2,kk-1,ist_0pp))
+             +std::abs(sten(ii,jj-1,kk-1,ist_0pp)) + eps);
+        wmm = std::abs(sten(ii,jj-2,kk-2,ist_0pp)) * (Real(1.0) + w1m + w2m);
+        wpm = std::abs(sten(ii,jj-1,kk-2,ist_0pp)) * (Real(1.0) + w1p + w2m);
+        wmp = std::abs(sten(ii,jj-2,kk-1,ist_0pp)) * (Real(1.0) + w1m + w2p);
+        wpp = std::abs(sten(ii,jj-1,kk-1,ist_0pp)) * (Real(1.0) + w1p + w2p);
         cv += fine(ii,jj-1,kk-1)*wpp/(wmm+wpm+wmp+wpp+eps);
 
         // ************************************
         // Adding fine(ii,jj+1,kk-1)
         // ************************************
 
-        w1m = amrex::Math::abs(sten(ii,jj  ,kk-1,ist_0p0))
-           / (amrex::Math::abs(sten(ii,jj  ,kk-2,ist_0pp))
-             +amrex::Math::abs(sten(ii,jj  ,kk-1,ist_0pp)) + eps);
-        w1p = amrex::Math::abs(sten(ii,jj+1,kk-1,ist_0p0))
-           / (amrex::Math::abs(sten(ii,jj+1,kk-2,ist_0pp))
-             +amrex::Math::abs(sten(ii,jj+1,kk-1,ist_0pp)) + eps);
-        w2m = amrex::Math::abs(sten(ii,jj+1,kk-2,ist_00p))
-           / (amrex::Math::abs(sten(ii,jj+1,kk-2,ist_0pp))
-             +amrex::Math::abs(sten(ii,jj  ,kk-2,ist_0pp)) + eps);
-        w2p = amrex::Math::abs(sten(ii,jj+1,kk-1,ist_00p))
-           / (amrex::Math::abs(sten(ii,jj+1,kk-1,ist_0pp))
-             +amrex::Math::abs(sten(ii,jj  ,kk-1,ist_0pp)) + eps);
-        wmm = amrex::Math::abs(sten(ii,jj  ,kk-2,ist_0pp)) * (Real(1.0) + w1m + w2m);
-        wpm = amrex::Math::abs(sten(ii,jj+1,kk-2,ist_0pp)) * (Real(1.0) + w1p + w2m);
-        wmp = amrex::Math::abs(sten(ii,jj  ,kk-1,ist_0pp)) * (Real(1.0) + w1m + w2p);
-        wpp = amrex::Math::abs(sten(ii,jj+1,kk-1,ist_0pp)) * (Real(1.0) + w1p + w2p);
+        w1m = std::abs(sten(ii,jj  ,kk-1,ist_0p0))
+           / (std::abs(sten(ii,jj  ,kk-2,ist_0pp))
+             +std::abs(sten(ii,jj  ,kk-1,ist_0pp)) + eps);
+        w1p = std::abs(sten(ii,jj+1,kk-1,ist_0p0))
+           / (std::abs(sten(ii,jj+1,kk-2,ist_0pp))
+             +std::abs(sten(ii,jj+1,kk-1,ist_0pp)) + eps);
+        w2m = std::abs(sten(ii,jj+1,kk-2,ist_00p))
+           / (std::abs(sten(ii,jj+1,kk-2,ist_0pp))
+             +std::abs(sten(ii,jj  ,kk-2,ist_0pp)) + eps);
+        w2p = std::abs(sten(ii,jj+1,kk-1,ist_00p))
+           / (std::abs(sten(ii,jj+1,kk-1,ist_0pp))
+             +std::abs(sten(ii,jj  ,kk-1,ist_0pp)) + eps);
+        wmm = std::abs(sten(ii,jj  ,kk-2,ist_0pp)) * (Real(1.0) + w1m + w2m);
+        wpm = std::abs(sten(ii,jj+1,kk-2,ist_0pp)) * (Real(1.0) + w1p + w2m);
+        wmp = std::abs(sten(ii,jj  ,kk-1,ist_0pp)) * (Real(1.0) + w1m + w2p);
+        wpp = std::abs(sten(ii,jj+1,kk-1,ist_0pp)) * (Real(1.0) + w1p + w2p);
         cv += fine(ii,jj+1,kk-1)*wmp/(wmm+wpm+wmp+wpp+eps);
 
         // ************************************
         // Adding fine(ii,jj-1,kk+1)
         // ************************************
 
-        w1m = amrex::Math::abs(sten(ii,jj-2,kk+1,ist_0p0))
-           / (amrex::Math::abs(sten(ii,jj-2,kk+1,ist_0pp))
-             +amrex::Math::abs(sten(ii,jj-2,kk  ,ist_0pp)) + eps);
-        w1p = amrex::Math::abs(sten(ii,jj-1,kk+1,ist_0p0))
-           / (amrex::Math::abs(sten(ii,jj-1,kk+1,ist_0pp))
-             +amrex::Math::abs(sten(ii,jj-1,kk  ,ist_0pp)) + eps);
-        w2m = amrex::Math::abs(sten(ii,jj-1,kk  ,ist_00p))
-           / (amrex::Math::abs(sten(ii,jj-2,kk  ,ist_0pp))
-             +amrex::Math::abs(sten(ii,jj-1,kk  ,ist_0pp)) + eps);
-        w2p = amrex::Math::abs(sten(ii,jj-1,kk+1,ist_00p))
-           / (amrex::Math::abs(sten(ii,jj-2,kk+1,ist_0pp))
-             +amrex::Math::abs(sten(ii,jj-1,kk+1,ist_0pp)) + eps);
-        wmm = amrex::Math::abs(sten(ii,jj-2,kk  ,ist_0pp)) * (Real(1.0) + w1m + w2m);
-        wpm = amrex::Math::abs(sten(ii,jj-1,kk  ,ist_0pp)) * (Real(1.0) + w1p + w2m);
-        wmp = amrex::Math::abs(sten(ii,jj-2,kk+1,ist_0pp)) * (Real(1.0) + w1m + w2p);
-        wpp = amrex::Math::abs(sten(ii,jj-1,kk+1,ist_0pp)) * (Real(1.0) + w1p + w2p);
+        w1m = std::abs(sten(ii,jj-2,kk+1,ist_0p0))
+           / (std::abs(sten(ii,jj-2,kk+1,ist_0pp))
+             +std::abs(sten(ii,jj-2,kk  ,ist_0pp)) + eps);
+        w1p = std::abs(sten(ii,jj-1,kk+1,ist_0p0))
+           / (std::abs(sten(ii,jj-1,kk+1,ist_0pp))
+             +std::abs(sten(ii,jj-1,kk  ,ist_0pp)) + eps);
+        w2m = std::abs(sten(ii,jj-1,kk  ,ist_00p))
+           / (std::abs(sten(ii,jj-2,kk  ,ist_0pp))
+             +std::abs(sten(ii,jj-1,kk  ,ist_0pp)) + eps);
+        w2p = std::abs(sten(ii,jj-1,kk+1,ist_00p))
+           / (std::abs(sten(ii,jj-2,kk+1,ist_0pp))
+             +std::abs(sten(ii,jj-1,kk+1,ist_0pp)) + eps);
+        wmm = std::abs(sten(ii,jj-2,kk  ,ist_0pp)) * (Real(1.0) + w1m + w2m);
+        wpm = std::abs(sten(ii,jj-1,kk  ,ist_0pp)) * (Real(1.0) + w1p + w2m);
+        wmp = std::abs(sten(ii,jj-2,kk+1,ist_0pp)) * (Real(1.0) + w1m + w2p);
+        wpp = std::abs(sten(ii,jj-1,kk+1,ist_0pp)) * (Real(1.0) + w1p + w2p);
         cv += fine(ii,jj-1,kk+1)*wpm/(wmm+wpm+wmp+wpp+eps);
 
         // ************************************
         // Adding fine(ii,jj+1,kk+1)
         // ************************************
 
-        w1m = amrex::Math::abs(sten(ii,jj  ,kk+1,ist_0p0))
-           / (amrex::Math::abs(sten(ii,jj  ,kk+1,ist_0pp))
-             +amrex::Math::abs(sten(ii,jj  ,kk  ,ist_0pp)) + eps);
-        w1p = amrex::Math::abs(sten(ii,jj+1,kk+1,ist_0p0))
-           / (amrex::Math::abs(sten(ii,jj+1,kk+1,ist_0pp))
-             +amrex::Math::abs(sten(ii,jj+1,kk  ,ist_0pp)) + eps);
-        w2m = amrex::Math::abs(sten(ii,jj+1,kk  ,ist_00p))
-           / (amrex::Math::abs(sten(ii,jj+1,kk  ,ist_0pp))
-             +amrex::Math::abs(sten(ii,jj  ,kk  ,ist_0pp)) + eps);
-        w2p = amrex::Math::abs(sten(ii,jj+1,kk+1,ist_00p))
-           / (amrex::Math::abs(sten(ii,jj+1,kk+1,ist_0pp))
-             +amrex::Math::abs(sten(ii,jj  ,kk+1,ist_0pp)) + eps);
-        wmm = amrex::Math::abs(sten(ii,jj  ,kk  ,ist_0pp)) * (Real(1.0) + w1m + w2m);
-        wpm = amrex::Math::abs(sten(ii,jj+1,kk  ,ist_0pp)) * (Real(1.0) + w1p + w2m);
-        wmp = amrex::Math::abs(sten(ii,jj  ,kk+1,ist_0pp)) * (Real(1.0) + w1m + w2p);
-        wpp = amrex::Math::abs(sten(ii,jj+1,kk+1,ist_0pp)) * (Real(1.0) + w1p + w2p);
+        w1m = std::abs(sten(ii,jj  ,kk+1,ist_0p0))
+           / (std::abs(sten(ii,jj  ,kk+1,ist_0pp))
+             +std::abs(sten(ii,jj  ,kk  ,ist_0pp)) + eps);
+        w1p = std::abs(sten(ii,jj+1,kk+1,ist_0p0))
+           / (std::abs(sten(ii,jj+1,kk+1,ist_0pp))
+             +std::abs(sten(ii,jj+1,kk  ,ist_0pp)) + eps);
+        w2m = std::abs(sten(ii,jj+1,kk  ,ist_00p))
+           / (std::abs(sten(ii,jj+1,kk  ,ist_0pp))
+             +std::abs(sten(ii,jj  ,kk  ,ist_0pp)) + eps);
+        w2p = std::abs(sten(ii,jj+1,kk+1,ist_00p))
+           / (std::abs(sten(ii,jj+1,kk+1,ist_0pp))
+             +std::abs(sten(ii,jj  ,kk+1,ist_0pp)) + eps);
+        wmm = std::abs(sten(ii,jj  ,kk  ,ist_0pp)) * (Real(1.0) + w1m + w2m);
+        wpm = std::abs(sten(ii,jj+1,kk  ,ist_0pp)) * (Real(1.0) + w1p + w2m);
+        wmp = std::abs(sten(ii,jj  ,kk+1,ist_0pp)) * (Real(1.0) + w1m + w2p);
+        wpp = std::abs(sten(ii,jj+1,kk+1,ist_0pp)) * (Real(1.0) + w1p + w2p);
         cv += fine(ii,jj+1,kk+1)*wmm/(wmm+wpm+wmp+wpp+eps);
 
         // ************************************
@@ -6156,227 +6156,227 @@ void mlndlap_restriction_rap (int i, int j, int k, Array4<Real> const& crse,
         // ************************************
 
         Real wmmm = Real(1.0)
-            + amrex::Math::abs(sten(ii  ,jj+1,kk+1,ist_p00)) /
-            ( amrex::Math::abs(sten(ii  ,jj  ,kk  ,ist_ppp))
-            + amrex::Math::abs(sten(ii  ,jj+1,kk  ,ist_ppp))
-            + amrex::Math::abs(sten(ii  ,jj  ,kk+1,ist_ppp))
-            + amrex::Math::abs(sten(ii  ,jj+1,kk+1,ist_ppp)) + eps)
-            + amrex::Math::abs(sten(ii+1,jj  ,kk+1,ist_0p0)) /
-            ( amrex::Math::abs(sten(ii  ,jj  ,kk  ,ist_ppp))
-            + amrex::Math::abs(sten(ii+1,jj  ,kk  ,ist_ppp))
-            + amrex::Math::abs(sten(ii  ,jj  ,kk+1,ist_ppp))
-            + amrex::Math::abs(sten(ii+1,jj  ,kk+1,ist_ppp)) + eps)
-            + amrex::Math::abs(sten(ii+1,jj+1,kk  ,ist_00p)) /
-            ( amrex::Math::abs(sten(ii  ,jj  ,kk  ,ist_ppp))
-            + amrex::Math::abs(sten(ii+1,jj  ,kk  ,ist_ppp))
-            + amrex::Math::abs(sten(ii  ,jj+1,kk  ,ist_ppp))
-            + amrex::Math::abs(sten(ii+1,jj+1,kk  ,ist_ppp)) + eps)
-            + amrex::Math::abs(sten(ii  ,jj  ,kk+1,ist_pp0)) /
-            ( amrex::Math::abs(sten(ii  ,jj  ,kk  ,ist_ppp))
-            + amrex::Math::abs(sten(ii  ,jj  ,kk+1,ist_ppp)) + eps)
-            + amrex::Math::abs(sten(ii  ,jj+1,kk  ,ist_p0p)) /
-            ( amrex::Math::abs(sten(ii  ,jj  ,kk  ,ist_ppp))
-            + amrex::Math::abs(sten(ii  ,jj+1,kk  ,ist_ppp)) + eps)
-            + amrex::Math::abs(sten(ii+1,jj  ,kk  ,ist_0pp)) /
-            ( amrex::Math::abs(sten(ii  ,jj  ,kk  ,ist_ppp))
-            + amrex::Math::abs(sten(ii+1,jj  ,kk  ,ist_ppp)) + eps);
-        wmmm *= amrex::Math::abs(sten(ii,jj,kk,ist_ppp));
+            + std::abs(sten(ii  ,jj+1,kk+1,ist_p00)) /
+            ( std::abs(sten(ii  ,jj  ,kk  ,ist_ppp))
+            + std::abs(sten(ii  ,jj+1,kk  ,ist_ppp))
+            + std::abs(sten(ii  ,jj  ,kk+1,ist_ppp))
+            + std::abs(sten(ii  ,jj+1,kk+1,ist_ppp)) + eps)
+            + std::abs(sten(ii+1,jj  ,kk+1,ist_0p0)) /
+            ( std::abs(sten(ii  ,jj  ,kk  ,ist_ppp))
+            + std::abs(sten(ii+1,jj  ,kk  ,ist_ppp))
+            + std::abs(sten(ii  ,jj  ,kk+1,ist_ppp))
+            + std::abs(sten(ii+1,jj  ,kk+1,ist_ppp)) + eps)
+            + std::abs(sten(ii+1,jj+1,kk  ,ist_00p)) /
+            ( std::abs(sten(ii  ,jj  ,kk  ,ist_ppp))
+            + std::abs(sten(ii+1,jj  ,kk  ,ist_ppp))
+            + std::abs(sten(ii  ,jj+1,kk  ,ist_ppp))
+            + std::abs(sten(ii+1,jj+1,kk  ,ist_ppp)) + eps)
+            + std::abs(sten(ii  ,jj  ,kk+1,ist_pp0)) /
+            ( std::abs(sten(ii  ,jj  ,kk  ,ist_ppp))
+            + std::abs(sten(ii  ,jj  ,kk+1,ist_ppp)) + eps)
+            + std::abs(sten(ii  ,jj+1,kk  ,ist_p0p)) /
+            ( std::abs(sten(ii  ,jj  ,kk  ,ist_ppp))
+            + std::abs(sten(ii  ,jj+1,kk  ,ist_ppp)) + eps)
+            + std::abs(sten(ii+1,jj  ,kk  ,ist_0pp)) /
+            ( std::abs(sten(ii  ,jj  ,kk  ,ist_ppp))
+            + std::abs(sten(ii+1,jj  ,kk  ,ist_ppp)) + eps);
+        wmmm *= std::abs(sten(ii,jj,kk,ist_ppp));
         cv += wmmm*fine(ii+1,jj+1,kk+1)*sten(ii+1,jj+1,kk+1,ist_inv);
 
         Real wpmm = Real(1.0)
-            + amrex::Math::abs(sten(ii-1,jj+1,kk+1,ist_p00)) /
-            ( amrex::Math::abs(sten(ii-1,jj  ,kk  ,ist_ppp))
-            + amrex::Math::abs(sten(ii-1,jj+1,kk  ,ist_ppp))
-            + amrex::Math::abs(sten(ii-1,jj  ,kk+1,ist_ppp))
-            + amrex::Math::abs(sten(ii-1,jj+1,kk+1,ist_ppp)) + eps)
-            + amrex::Math::abs(sten(ii-1,jj  ,kk+1,ist_0p0)) /
-            ( amrex::Math::abs(sten(ii-2,jj  ,kk  ,ist_ppp))
-            + amrex::Math::abs(sten(ii-1,jj  ,kk  ,ist_ppp))
-            + amrex::Math::abs(sten(ii-2,jj  ,kk+1,ist_ppp))
-            + amrex::Math::abs(sten(ii-1,jj  ,kk+1,ist_ppp)) + eps)
-            + amrex::Math::abs(sten(ii-1,jj+1,kk  ,ist_00p)) /
-            ( amrex::Math::abs(sten(ii-2,jj  ,kk  ,ist_ppp))
-            + amrex::Math::abs(sten(ii-1,jj  ,kk  ,ist_ppp))
-            + amrex::Math::abs(sten(ii-2,jj+1,kk  ,ist_ppp))
-            + amrex::Math::abs(sten(ii-1,jj+1,kk  ,ist_ppp)) + eps)
-            + amrex::Math::abs(sten(ii-1,jj  ,kk+1,ist_pp0)) /
-            ( amrex::Math::abs(sten(ii-1,jj  ,kk  ,ist_ppp))
-            + amrex::Math::abs(sten(ii-1,jj  ,kk+1,ist_ppp)) + eps)
-            + amrex::Math::abs(sten(ii-1,jj+1,kk  ,ist_p0p)) /
-            ( amrex::Math::abs(sten(ii-1,jj  ,kk  ,ist_ppp))
-            + amrex::Math::abs(sten(ii-1,jj+1,kk  ,ist_ppp)) + eps)
-            + amrex::Math::abs(sten(ii-1,jj  ,kk  ,ist_0pp)) /
-            ( amrex::Math::abs(sten(ii-2,jj  ,kk  ,ist_ppp))
-            + amrex::Math::abs(sten(ii-1,jj  ,kk  ,ist_ppp)) + eps);
-        wpmm *= amrex::Math::abs(sten(ii-1,jj,kk,ist_ppp));
+            + std::abs(sten(ii-1,jj+1,kk+1,ist_p00)) /
+            ( std::abs(sten(ii-1,jj  ,kk  ,ist_ppp))
+            + std::abs(sten(ii-1,jj+1,kk  ,ist_ppp))
+            + std::abs(sten(ii-1,jj  ,kk+1,ist_ppp))
+            + std::abs(sten(ii-1,jj+1,kk+1,ist_ppp)) + eps)
+            + std::abs(sten(ii-1,jj  ,kk+1,ist_0p0)) /
+            ( std::abs(sten(ii-2,jj  ,kk  ,ist_ppp))
+            + std::abs(sten(ii-1,jj  ,kk  ,ist_ppp))
+            + std::abs(sten(ii-2,jj  ,kk+1,ist_ppp))
+            + std::abs(sten(ii-1,jj  ,kk+1,ist_ppp)) + eps)
+            + std::abs(sten(ii-1,jj+1,kk  ,ist_00p)) /
+            ( std::abs(sten(ii-2,jj  ,kk  ,ist_ppp))
+            + std::abs(sten(ii-1,jj  ,kk  ,ist_ppp))
+            + std::abs(sten(ii-2,jj+1,kk  ,ist_ppp))
+            + std::abs(sten(ii-1,jj+1,kk  ,ist_ppp)) + eps)
+            + std::abs(sten(ii-1,jj  ,kk+1,ist_pp0)) /
+            ( std::abs(sten(ii-1,jj  ,kk  ,ist_ppp))
+            + std::abs(sten(ii-1,jj  ,kk+1,ist_ppp)) + eps)
+            + std::abs(sten(ii-1,jj+1,kk  ,ist_p0p)) /
+            ( std::abs(sten(ii-1,jj  ,kk  ,ist_ppp))
+            + std::abs(sten(ii-1,jj+1,kk  ,ist_ppp)) + eps)
+            + std::abs(sten(ii-1,jj  ,kk  ,ist_0pp)) /
+            ( std::abs(sten(ii-2,jj  ,kk  ,ist_ppp))
+            + std::abs(sten(ii-1,jj  ,kk  ,ist_ppp)) + eps);
+        wpmm *= std::abs(sten(ii-1,jj,kk,ist_ppp));
         cv += wpmm*fine(ii-1,jj+1,kk+1)*sten(ii-1,jj+1,kk+1,ist_inv);
 
         Real wmpm = Real(1.0)
-            + amrex::Math::abs(sten(ii  ,jj-1,kk+1,ist_p00)) /
-            ( amrex::Math::abs(sten(ii  ,jj-2,kk  ,ist_ppp))
-            + amrex::Math::abs(sten(ii  ,jj-1,kk  ,ist_ppp))
-            + amrex::Math::abs(sten(ii  ,jj-2,kk+1,ist_ppp))
-            + amrex::Math::abs(sten(ii  ,jj-1,kk+1,ist_ppp)) + eps)
-            + amrex::Math::abs(sten(ii+1,jj-1,kk+1,ist_0p0)) /
-            ( amrex::Math::abs(sten(ii  ,jj-1,kk  ,ist_ppp))
-            + amrex::Math::abs(sten(ii+1,jj-1,kk  ,ist_ppp))
-            + amrex::Math::abs(sten(ii  ,jj-1,kk+1,ist_ppp))
-            + amrex::Math::abs(sten(ii+1,jj-1,kk+1,ist_ppp)) + eps)
-            + amrex::Math::abs(sten(ii+1,jj-1,kk  ,ist_00p)) /
-            ( amrex::Math::abs(sten(ii  ,jj-2,kk  ,ist_ppp))
-            + amrex::Math::abs(sten(ii+1,jj-2,kk  ,ist_ppp))
-            + amrex::Math::abs(sten(ii  ,jj-1,kk  ,ist_ppp))
-            + amrex::Math::abs(sten(ii+1,jj-1,kk  ,ist_ppp)) + eps)
-            + amrex::Math::abs(sten(ii  ,jj-1,kk+1,ist_pp0)) /
-            ( amrex::Math::abs(sten(ii  ,jj-1,kk  ,ist_ppp))
-            + amrex::Math::abs(sten(ii  ,jj-1,kk+1,ist_ppp)) + eps)
-            + amrex::Math::abs(sten(ii  ,jj-1,kk  ,ist_p0p)) /
-            ( amrex::Math::abs(sten(ii  ,jj-2,kk  ,ist_ppp))
-            + amrex::Math::abs(sten(ii  ,jj-1,kk  ,ist_ppp)) + eps)
-            + amrex::Math::abs(sten(ii+1,jj-1,kk  ,ist_0pp)) /
-            ( amrex::Math::abs(sten(ii  ,jj-1,kk  ,ist_ppp))
-            + amrex::Math::abs(sten(ii+1,jj-1,kk  ,ist_ppp)) + eps);
-        wmpm *= amrex::Math::abs(sten(ii  ,jj-1,kk  ,ist_ppp));
+            + std::abs(sten(ii  ,jj-1,kk+1,ist_p00)) /
+            ( std::abs(sten(ii  ,jj-2,kk  ,ist_ppp))
+            + std::abs(sten(ii  ,jj-1,kk  ,ist_ppp))
+            + std::abs(sten(ii  ,jj-2,kk+1,ist_ppp))
+            + std::abs(sten(ii  ,jj-1,kk+1,ist_ppp)) + eps)
+            + std::abs(sten(ii+1,jj-1,kk+1,ist_0p0)) /
+            ( std::abs(sten(ii  ,jj-1,kk  ,ist_ppp))
+            + std::abs(sten(ii+1,jj-1,kk  ,ist_ppp))
+            + std::abs(sten(ii  ,jj-1,kk+1,ist_ppp))
+            + std::abs(sten(ii+1,jj-1,kk+1,ist_ppp)) + eps)
+            + std::abs(sten(ii+1,jj-1,kk  ,ist_00p)) /
+            ( std::abs(sten(ii  ,jj-2,kk  ,ist_ppp))
+            + std::abs(sten(ii+1,jj-2,kk  ,ist_ppp))
+            + std::abs(sten(ii  ,jj-1,kk  ,ist_ppp))
+            + std::abs(sten(ii+1,jj-1,kk  ,ist_ppp)) + eps)
+            + std::abs(sten(ii  ,jj-1,kk+1,ist_pp0)) /
+            ( std::abs(sten(ii  ,jj-1,kk  ,ist_ppp))
+            + std::abs(sten(ii  ,jj-1,kk+1,ist_ppp)) + eps)
+            + std::abs(sten(ii  ,jj-1,kk  ,ist_p0p)) /
+            ( std::abs(sten(ii  ,jj-2,kk  ,ist_ppp))
+            + std::abs(sten(ii  ,jj-1,kk  ,ist_ppp)) + eps)
+            + std::abs(sten(ii+1,jj-1,kk  ,ist_0pp)) /
+            ( std::abs(sten(ii  ,jj-1,kk  ,ist_ppp))
+            + std::abs(sten(ii+1,jj-1,kk  ,ist_ppp)) + eps);
+        wmpm *= std::abs(sten(ii  ,jj-1,kk  ,ist_ppp));
         cv += wmpm*fine(ii+1,jj-1,kk+1)*sten(ii+1,jj-1,kk+1,ist_inv);
 
         Real wppm = Real(1.0)
-            + amrex::Math::abs(sten(ii-1,jj-1,kk+1,ist_p00)) /
-            ( amrex::Math::abs(sten(ii-1,jj-2,kk  ,ist_ppp))
-            + amrex::Math::abs(sten(ii-1,jj-1,kk  ,ist_ppp))
-            + amrex::Math::abs(sten(ii-1,jj-2,kk+1,ist_ppp))
-            + amrex::Math::abs(sten(ii-1,jj-1,kk+1,ist_ppp)) + eps)
-            + amrex::Math::abs(sten(ii-1,jj-1,kk+1,ist_0p0)) /
-            ( amrex::Math::abs(sten(ii-2,jj-1,kk  ,ist_ppp))
-            + amrex::Math::abs(sten(ii-1,jj-1,kk  ,ist_ppp))
-            + amrex::Math::abs(sten(ii-2,jj-1,kk+1,ist_ppp))
-            + amrex::Math::abs(sten(ii-1,jj-1,kk+1,ist_ppp)) + eps)
-            + amrex::Math::abs(sten(ii-1,jj-1,kk  ,ist_00p)) /
-            ( amrex::Math::abs(sten(ii-2,jj-2,kk  ,ist_ppp))
-            + amrex::Math::abs(sten(ii-1,jj-2,kk  ,ist_ppp))
-            + amrex::Math::abs(sten(ii-2,jj-1,kk  ,ist_ppp))
-            + amrex::Math::abs(sten(ii-1,jj-1,kk  ,ist_ppp)) + eps)
-            + amrex::Math::abs(sten(ii-1,jj-1,kk+1,ist_pp0)) /
-            ( amrex::Math::abs(sten(ii-1,jj-1,kk  ,ist_ppp))
-            + amrex::Math::abs(sten(ii-1,jj-1,kk+1,ist_ppp)) + eps)
-            + amrex::Math::abs(sten(ii-1,jj-1,kk  ,ist_p0p)) /
-            ( amrex::Math::abs(sten(ii-1,jj-2,kk  ,ist_ppp))
-            + amrex::Math::abs(sten(ii-1,jj-1,kk  ,ist_ppp)) + eps)
-            + amrex::Math::abs(sten(ii-1,jj-1,kk  ,ist_0pp)) /
-            ( amrex::Math::abs(sten(ii-2,jj-1,kk  ,ist_ppp))
-            + amrex::Math::abs(sten(ii-1,jj-1,kk  ,ist_ppp)) + eps);
-        wppm *= amrex::Math::abs(sten(ii-1,jj-1,kk  ,ist_ppp));
+            + std::abs(sten(ii-1,jj-1,kk+1,ist_p00)) /
+            ( std::abs(sten(ii-1,jj-2,kk  ,ist_ppp))
+            + std::abs(sten(ii-1,jj-1,kk  ,ist_ppp))
+            + std::abs(sten(ii-1,jj-2,kk+1,ist_ppp))
+            + std::abs(sten(ii-1,jj-1,kk+1,ist_ppp)) + eps)
+            + std::abs(sten(ii-1,jj-1,kk+1,ist_0p0)) /
+            ( std::abs(sten(ii-2,jj-1,kk  ,ist_ppp))
+            + std::abs(sten(ii-1,jj-1,kk  ,ist_ppp))
+            + std::abs(sten(ii-2,jj-1,kk+1,ist_ppp))
+            + std::abs(sten(ii-1,jj-1,kk+1,ist_ppp)) + eps)
+            + std::abs(sten(ii-1,jj-1,kk  ,ist_00p)) /
+            ( std::abs(sten(ii-2,jj-2,kk  ,ist_ppp))
+            + std::abs(sten(ii-1,jj-2,kk  ,ist_ppp))
+            + std::abs(sten(ii-2,jj-1,kk  ,ist_ppp))
+            + std::abs(sten(ii-1,jj-1,kk  ,ist_ppp)) + eps)
+            + std::abs(sten(ii-1,jj-1,kk+1,ist_pp0)) /
+            ( std::abs(sten(ii-1,jj-1,kk  ,ist_ppp))
+            + std::abs(sten(ii-1,jj-1,kk+1,ist_ppp)) + eps)
+            + std::abs(sten(ii-1,jj-1,kk  ,ist_p0p)) /
+            ( std::abs(sten(ii-1,jj-2,kk  ,ist_ppp))
+            + std::abs(sten(ii-1,jj-1,kk  ,ist_ppp)) + eps)
+            + std::abs(sten(ii-1,jj-1,kk  ,ist_0pp)) /
+            ( std::abs(sten(ii-2,jj-1,kk  ,ist_ppp))
+            + std::abs(sten(ii-1,jj-1,kk  ,ist_ppp)) + eps);
+        wppm *= std::abs(sten(ii-1,jj-1,kk  ,ist_ppp));
         cv += wppm*fine(ii-1,jj-1,kk+1)*sten(ii-1,jj-1,kk+1,ist_inv);
 
         Real wmmp = Real(1.0)
-            + amrex::Math::abs(sten(ii  ,jj+1,kk-1,ist_p00)) /
-            ( amrex::Math::abs(sten(ii  ,jj  ,kk-2,ist_ppp))
-            + amrex::Math::abs(sten(ii  ,jj+1,kk-2,ist_ppp))
-            + amrex::Math::abs(sten(ii  ,jj  ,kk-1,ist_ppp))
-            + amrex::Math::abs(sten(ii  ,jj+1,kk-1,ist_ppp)) + eps)
-            + amrex::Math::abs(sten(ii+1,jj  ,kk-1,ist_0p0)) /
-            ( amrex::Math::abs(sten(ii  ,jj  ,kk-2,ist_ppp))
-            + amrex::Math::abs(sten(ii+1,jj  ,kk-2,ist_ppp))
-            + amrex::Math::abs(sten(ii  ,jj  ,kk-1,ist_ppp))
-            + amrex::Math::abs(sten(ii+1,jj  ,kk-1,ist_ppp)) + eps)
-            + amrex::Math::abs(sten(ii+1,jj+1,kk-1,ist_00p)) /
-            ( amrex::Math::abs(sten(ii  ,jj  ,kk-1,ist_ppp))
-            + amrex::Math::abs(sten(ii+1,jj  ,kk-1,ist_ppp))
-            + amrex::Math::abs(sten(ii  ,jj+1,kk-1,ist_ppp))
-            + amrex::Math::abs(sten(ii+1,jj+1,kk-1,ist_ppp)) + eps)
-            + amrex::Math::abs(sten(ii  ,jj  ,kk-1,ist_pp0)) /
-            ( amrex::Math::abs(sten(ii  ,jj  ,kk-2,ist_ppp))
-            + amrex::Math::abs(sten(ii  ,jj  ,kk-1,ist_ppp)) + eps)
-            + amrex::Math::abs(sten(ii  ,jj+1,kk-1,ist_p0p)) /
-            ( amrex::Math::abs(sten(ii  ,jj  ,kk-1,ist_ppp))
-            + amrex::Math::abs(sten(ii  ,jj+1,kk-1,ist_ppp)) + eps)
-            + amrex::Math::abs(sten(ii+1,jj  ,kk-1,ist_0pp)) /
-            ( amrex::Math::abs(sten(ii  ,jj  ,kk-1,ist_ppp))
-            + amrex::Math::abs(sten(ii+1,jj  ,kk-1,ist_ppp)) + eps);
-        wmmp *= amrex::Math::abs(sten(ii  ,jj  ,kk-1,ist_ppp));
+            + std::abs(sten(ii  ,jj+1,kk-1,ist_p00)) /
+            ( std::abs(sten(ii  ,jj  ,kk-2,ist_ppp))
+            + std::abs(sten(ii  ,jj+1,kk-2,ist_ppp))
+            + std::abs(sten(ii  ,jj  ,kk-1,ist_ppp))
+            + std::abs(sten(ii  ,jj+1,kk-1,ist_ppp)) + eps)
+            + std::abs(sten(ii+1,jj  ,kk-1,ist_0p0)) /
+            ( std::abs(sten(ii  ,jj  ,kk-2,ist_ppp))
+            + std::abs(sten(ii+1,jj  ,kk-2,ist_ppp))
+            + std::abs(sten(ii  ,jj  ,kk-1,ist_ppp))
+            + std::abs(sten(ii+1,jj  ,kk-1,ist_ppp)) + eps)
+            + std::abs(sten(ii+1,jj+1,kk-1,ist_00p)) /
+            ( std::abs(sten(ii  ,jj  ,kk-1,ist_ppp))
+            + std::abs(sten(ii+1,jj  ,kk-1,ist_ppp))
+            + std::abs(sten(ii  ,jj+1,kk-1,ist_ppp))
+            + std::abs(sten(ii+1,jj+1,kk-1,ist_ppp)) + eps)
+            + std::abs(sten(ii  ,jj  ,kk-1,ist_pp0)) /
+            ( std::abs(sten(ii  ,jj  ,kk-2,ist_ppp))
+            + std::abs(sten(ii  ,jj  ,kk-1,ist_ppp)) + eps)
+            + std::abs(sten(ii  ,jj+1,kk-1,ist_p0p)) /
+            ( std::abs(sten(ii  ,jj  ,kk-1,ist_ppp))
+            + std::abs(sten(ii  ,jj+1,kk-1,ist_ppp)) + eps)
+            + std::abs(sten(ii+1,jj  ,kk-1,ist_0pp)) /
+            ( std::abs(sten(ii  ,jj  ,kk-1,ist_ppp))
+            + std::abs(sten(ii+1,jj  ,kk-1,ist_ppp)) + eps);
+        wmmp *= std::abs(sten(ii  ,jj  ,kk-1,ist_ppp));
         cv += wmmp*fine(ii+1,jj+1,kk-1)*sten(ii+1,jj+1,kk-1,ist_inv);
 
         Real wpmp = Real(1.0)
-            + amrex::Math::abs(sten(ii-1,jj+1,kk-1,ist_p00)) /
-            ( amrex::Math::abs(sten(ii-1,jj  ,kk-2,ist_ppp))
-            + amrex::Math::abs(sten(ii-1,jj+1,kk-2,ist_ppp))
-            + amrex::Math::abs(sten(ii-1,jj  ,kk-1,ist_ppp))
-            + amrex::Math::abs(sten(ii-1,jj+1,kk-1,ist_ppp)) + eps)
-            + amrex::Math::abs(sten(ii-1,jj  ,kk-1,ist_0p0)) /
-            ( amrex::Math::abs(sten(ii-2,jj  ,kk-2,ist_ppp))
-            + amrex::Math::abs(sten(ii-1,jj  ,kk-2,ist_ppp))
-            + amrex::Math::abs(sten(ii-2,jj  ,kk-1,ist_ppp))
-            + amrex::Math::abs(sten(ii-1,jj  ,kk-1,ist_ppp)) + eps)
-            + amrex::Math::abs(sten(ii-1,jj+1,kk-1,ist_00p)) /
-            ( amrex::Math::abs(sten(ii-2,jj  ,kk-1,ist_ppp))
-            + amrex::Math::abs(sten(ii-1,jj  ,kk-1,ist_ppp))
-            + amrex::Math::abs(sten(ii-2,jj+1,kk-1,ist_ppp))
-            + amrex::Math::abs(sten(ii-1,jj+1,kk-1,ist_ppp)) + eps)
-            + amrex::Math::abs(sten(ii-1,jj  ,kk-1,ist_pp0)) /
-            ( amrex::Math::abs(sten(ii-1,jj  ,kk-2,ist_ppp))
-            + amrex::Math::abs(sten(ii-1,jj  ,kk-1,ist_ppp)) + eps)
-            + amrex::Math::abs(sten(ii-1,jj+1,kk-1,ist_p0p)) /
-            ( amrex::Math::abs(sten(ii-1,jj  ,kk-1,ist_ppp))
-            + amrex::Math::abs(sten(ii-1,jj+1,kk-1,ist_ppp)) + eps)
-            + amrex::Math::abs(sten(ii-1,jj  ,kk-1,ist_0pp)) /
-            ( amrex::Math::abs(sten(ii-2,jj  ,kk-1,ist_ppp))
-            + amrex::Math::abs(sten(ii-1,jj  ,kk-1,ist_ppp)) + eps);
-        wpmp *= amrex::Math::abs(sten(ii-1,jj  ,kk-1,ist_ppp));
+            + std::abs(sten(ii-1,jj+1,kk-1,ist_p00)) /
+            ( std::abs(sten(ii-1,jj  ,kk-2,ist_ppp))
+            + std::abs(sten(ii-1,jj+1,kk-2,ist_ppp))
+            + std::abs(sten(ii-1,jj  ,kk-1,ist_ppp))
+            + std::abs(sten(ii-1,jj+1,kk-1,ist_ppp)) + eps)
+            + std::abs(sten(ii-1,jj  ,kk-1,ist_0p0)) /
+            ( std::abs(sten(ii-2,jj  ,kk-2,ist_ppp))
+            + std::abs(sten(ii-1,jj  ,kk-2,ist_ppp))
+            + std::abs(sten(ii-2,jj  ,kk-1,ist_ppp))
+            + std::abs(sten(ii-1,jj  ,kk-1,ist_ppp)) + eps)
+            + std::abs(sten(ii-1,jj+1,kk-1,ist_00p)) /
+            ( std::abs(sten(ii-2,jj  ,kk-1,ist_ppp))
+            + std::abs(sten(ii-1,jj  ,kk-1,ist_ppp))
+            + std::abs(sten(ii-2,jj+1,kk-1,ist_ppp))
+            + std::abs(sten(ii-1,jj+1,kk-1,ist_ppp)) + eps)
+            + std::abs(sten(ii-1,jj  ,kk-1,ist_pp0)) /
+            ( std::abs(sten(ii-1,jj  ,kk-2,ist_ppp))
+            + std::abs(sten(ii-1,jj  ,kk-1,ist_ppp)) + eps)
+            + std::abs(sten(ii-1,jj+1,kk-1,ist_p0p)) /
+            ( std::abs(sten(ii-1,jj  ,kk-1,ist_ppp))
+            + std::abs(sten(ii-1,jj+1,kk-1,ist_ppp)) + eps)
+            + std::abs(sten(ii-1,jj  ,kk-1,ist_0pp)) /
+            ( std::abs(sten(ii-2,jj  ,kk-1,ist_ppp))
+            + std::abs(sten(ii-1,jj  ,kk-1,ist_ppp)) + eps);
+        wpmp *= std::abs(sten(ii-1,jj  ,kk-1,ist_ppp));
         cv += wpmp*fine(ii-1,jj+1,kk-1)*sten(ii-1,jj+1,kk-1,ist_inv);
 
         Real wmpp = Real(1.0)
-            + amrex::Math::abs(sten(ii  ,jj-1,kk-1,ist_p00)) /
-            ( amrex::Math::abs(sten(ii  ,jj-2,kk-2,ist_ppp))
-            + amrex::Math::abs(sten(ii  ,jj-1,kk-2,ist_ppp))
-            + amrex::Math::abs(sten(ii  ,jj-2,kk-1,ist_ppp))
-            + amrex::Math::abs(sten(ii  ,jj-1,kk-1,ist_ppp)) + eps)
-            + amrex::Math::abs(sten(ii+1,jj-1,kk-1,ist_0p0)) /
-            ( amrex::Math::abs(sten(ii  ,jj-1,kk-2,ist_ppp))
-            + amrex::Math::abs(sten(ii+1,jj-1,kk-2,ist_ppp))
-            + amrex::Math::abs(sten(ii  ,jj-1,kk-1,ist_ppp))
-            + amrex::Math::abs(sten(ii+1,jj-1,kk-1,ist_ppp)) + eps)
-            + amrex::Math::abs(sten(ii+1,jj-1,kk-1,ist_00p)) /
-            ( amrex::Math::abs(sten(ii  ,jj-2,kk-1,ist_ppp))
-            + amrex::Math::abs(sten(ii+1,jj-2,kk-1,ist_ppp))
-            + amrex::Math::abs(sten(ii  ,jj-1,kk-1,ist_ppp))
-            + amrex::Math::abs(sten(ii+1,jj-1,kk-1,ist_ppp)) + eps)
-            + amrex::Math::abs(sten(ii  ,jj-1,kk-1,ist_pp0)) /
-            ( amrex::Math::abs(sten(ii  ,jj-1,kk-2,ist_ppp))
-            + amrex::Math::abs(sten(ii  ,jj-1,kk-1,ist_ppp)) + eps)
-            + amrex::Math::abs(sten(ii  ,jj-1,kk-1,ist_p0p)) /
-            ( amrex::Math::abs(sten(ii  ,jj-2,kk-1,ist_ppp))
-            + amrex::Math::abs(sten(ii  ,jj-1,kk-1,ist_ppp)) + eps)
-            + amrex::Math::abs(sten(ii+1,jj-1,kk-1,ist_0pp)) /
-            ( amrex::Math::abs(sten(ii  ,jj-1,kk-1,ist_ppp))
-            + amrex::Math::abs(sten(ii+1,jj-1,kk-1,ist_ppp)) + eps);
-        wmpp *= amrex::Math::abs(sten(ii  ,jj-1,kk-1,ist_ppp));
+            + std::abs(sten(ii  ,jj-1,kk-1,ist_p00)) /
+            ( std::abs(sten(ii  ,jj-2,kk-2,ist_ppp))
+            + std::abs(sten(ii  ,jj-1,kk-2,ist_ppp))
+            + std::abs(sten(ii  ,jj-2,kk-1,ist_ppp))
+            + std::abs(sten(ii  ,jj-1,kk-1,ist_ppp)) + eps)
+            + std::abs(sten(ii+1,jj-1,kk-1,ist_0p0)) /
+            ( std::abs(sten(ii  ,jj-1,kk-2,ist_ppp))
+            + std::abs(sten(ii+1,jj-1,kk-2,ist_ppp))
+            + std::abs(sten(ii  ,jj-1,kk-1,ist_ppp))
+            + std::abs(sten(ii+1,jj-1,kk-1,ist_ppp)) + eps)
+            + std::abs(sten(ii+1,jj-1,kk-1,ist_00p)) /
+            ( std::abs(sten(ii  ,jj-2,kk-1,ist_ppp))
+            + std::abs(sten(ii+1,jj-2,kk-1,ist_ppp))
+            + std::abs(sten(ii  ,jj-1,kk-1,ist_ppp))
+            + std::abs(sten(ii+1,jj-1,kk-1,ist_ppp)) + eps)
+            + std::abs(sten(ii  ,jj-1,kk-1,ist_pp0)) /
+            ( std::abs(sten(ii  ,jj-1,kk-2,ist_ppp))
+            + std::abs(sten(ii  ,jj-1,kk-1,ist_ppp)) + eps)
+            + std::abs(sten(ii  ,jj-1,kk-1,ist_p0p)) /
+            ( std::abs(sten(ii  ,jj-2,kk-1,ist_ppp))
+            + std::abs(sten(ii  ,jj-1,kk-1,ist_ppp)) + eps)
+            + std::abs(sten(ii+1,jj-1,kk-1,ist_0pp)) /
+            ( std::abs(sten(ii  ,jj-1,kk-1,ist_ppp))
+            + std::abs(sten(ii+1,jj-1,kk-1,ist_ppp)) + eps);
+        wmpp *= std::abs(sten(ii  ,jj-1,kk-1,ist_ppp));
         cv += wmpp*fine(ii+1,jj-1,kk-1)*sten(ii+1,jj-1,kk-1,ist_inv);
 
         Real wppp = Real(1.0)
-            + amrex::Math::abs(sten(ii-1,jj-1,kk-1,ist_p00)) /
-            ( amrex::Math::abs(sten(ii-1,jj-2,kk-2,ist_ppp))
-            + amrex::Math::abs(sten(ii-1,jj-1,kk-2,ist_ppp))
-            + amrex::Math::abs(sten(ii-1,jj-2,kk-1,ist_ppp))
-            + amrex::Math::abs(sten(ii-1,jj-1,kk-1,ist_ppp)) + eps)
-            + amrex::Math::abs(sten(ii-1,jj-1,kk-1,ist_0p0)) /
-            ( amrex::Math::abs(sten(ii-2,jj-1,kk-2,ist_ppp))
-            + amrex::Math::abs(sten(ii-1,jj-1,kk-2,ist_ppp))
-            + amrex::Math::abs(sten(ii-2,jj-1,kk-1,ist_ppp))
-            + amrex::Math::abs(sten(ii-1,jj-1,kk-1,ist_ppp)) + eps)
-            + amrex::Math::abs(sten(ii-1,jj-1,kk-1,ist_00p)) /
-            ( amrex::Math::abs(sten(ii-2,jj-2,kk-1,ist_ppp))
-            + amrex::Math::abs(sten(ii-1,jj-2,kk-1,ist_ppp))
-            + amrex::Math::abs(sten(ii-2,jj-1,kk-1,ist_ppp))
-            + amrex::Math::abs(sten(ii-1,jj-1,kk-1,ist_ppp)) + eps)
-            + amrex::Math::abs(sten(ii-1,jj-1,kk-1,ist_pp0)) /
-            ( amrex::Math::abs(sten(ii-1,jj-1,kk-2,ist_ppp))
-            + amrex::Math::abs(sten(ii-1,jj-1,kk-1,ist_ppp)) + eps)
-            + amrex::Math::abs(sten(ii-1,jj-1,kk-1,ist_p0p)) /
-            ( amrex::Math::abs(sten(ii-1,jj-2,kk-1,ist_ppp))
-            + amrex::Math::abs(sten(ii-1,jj-1,kk-1,ist_ppp)) + eps)
-            + amrex::Math::abs(sten(ii-1,jj-1,kk-1,ist_0pp)) /
-            ( amrex::Math::abs(sten(ii-2,jj-1,kk-1,ist_ppp))
-            + amrex::Math::abs(sten(ii-1,jj-1,kk-1,ist_ppp)) + eps);
-        wppp *= amrex::Math::abs(sten(ii-1,jj-1,kk-1,ist_ppp));
+            + std::abs(sten(ii-1,jj-1,kk-1,ist_p00)) /
+            ( std::abs(sten(ii-1,jj-2,kk-2,ist_ppp))
+            + std::abs(sten(ii-1,jj-1,kk-2,ist_ppp))
+            + std::abs(sten(ii-1,jj-2,kk-1,ist_ppp))
+            + std::abs(sten(ii-1,jj-1,kk-1,ist_ppp)) + eps)
+            + std::abs(sten(ii-1,jj-1,kk-1,ist_0p0)) /
+            ( std::abs(sten(ii-2,jj-1,kk-2,ist_ppp))
+            + std::abs(sten(ii-1,jj-1,kk-2,ist_ppp))
+            + std::abs(sten(ii-2,jj-1,kk-1,ist_ppp))
+            + std::abs(sten(ii-1,jj-1,kk-1,ist_ppp)) + eps)
+            + std::abs(sten(ii-1,jj-1,kk-1,ist_00p)) /
+            ( std::abs(sten(ii-2,jj-2,kk-1,ist_ppp))
+            + std::abs(sten(ii-1,jj-2,kk-1,ist_ppp))
+            + std::abs(sten(ii-2,jj-1,kk-1,ist_ppp))
+            + std::abs(sten(ii-1,jj-1,kk-1,ist_ppp)) + eps)
+            + std::abs(sten(ii-1,jj-1,kk-1,ist_pp0)) /
+            ( std::abs(sten(ii-1,jj-1,kk-2,ist_ppp))
+            + std::abs(sten(ii-1,jj-1,kk-1,ist_ppp)) + eps)
+            + std::abs(sten(ii-1,jj-1,kk-1,ist_p0p)) /
+            ( std::abs(sten(ii-1,jj-2,kk-1,ist_ppp))
+            + std::abs(sten(ii-1,jj-1,kk-1,ist_ppp)) + eps)
+            + std::abs(sten(ii-1,jj-1,kk-1,ist_0pp)) /
+            ( std::abs(sten(ii-2,jj-1,kk-1,ist_ppp))
+            + std::abs(sten(ii-1,jj-1,kk-1,ist_ppp)) + eps);
+        wppp *= std::abs(sten(ii-1,jj-1,kk-1,ist_ppp));
         cv += wppp*fine(ii-1,jj-1,kk-1)*sten(ii-1,jj-1,kk-1,ist_inv);
 
         crse(i,j,k) = cv * Real(0.125);

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLap_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLap_K.H
@@ -163,7 +163,7 @@ void mlndlap_normalize_sten (int i, int j, int k, Array4<Real> const& x,
                              Array4<Real const> const& sten,
                              Array4<int const> const& msk, Real s0_norm0) noexcept
 {
-    if (!msk(i,j,k) && amrex::Math::abs(sten(i,j,k,0)) > s0_norm0) {
+    if (!msk(i,j,k) && std::abs(sten(i,j,k,0)) > s0_norm0) {
         x(i,j,k) /= sten(i,j,k,0);
     }
 }

--- a/Tests/Amr/Advection_AmrCore/Source/Src_K/slope_K.H
+++ b/Tests/Amr/Advection_AmrCore/Source/Src_K/slope_K.H
@@ -22,11 +22,11 @@ void slopex2(amrex::Box const& bx,
                 Real dlft = q(i,j,k) - q(i-1,j,k);
                 Real drgt = q(i+1,j,k) - q(i,j,k);
                 Real dcen = Real(0.5)*(dlft+drgt);
-                Real dsgn = amrex::Math::copysign(Real(1.0), dcen);
-                Real dslop = Real(2.0) * ((amrex::Math::abs(dlft) < amrex::Math::abs(drgt)) ?
-                                           amrex::Math::abs(dlft) : amrex::Math::abs(drgt));
+                Real dsgn = std::copysign(Real(1.0), dcen);
+                Real dslop = Real(2.0) * ((std::abs(dlft) < std::abs(drgt)) ?
+                                           std::abs(dlft) : std::abs(drgt));
                 Real dlim = (dlft*drgt >= Real(0.0)) ? dslop : Real(0.0);
-                dq(i,j,k) = dsgn*amrex::min(dlim, amrex::Math::abs(dcen));
+                dq(i,j,k) = dsgn*amrex::min(dlim, std::abs(dcen));
             }
         }
     }
@@ -50,12 +50,12 @@ void slopex4(amrex::Box const& bx,
                 Real dlft = q(i,j,k) - q(i-1,j,k);
                 Real drgt = q(i+1,j,k) - q(i,j,k);
                 Real dcen = Real(0.5)*(dlft+drgt);
-                Real dsgn = amrex::Math::copysign(Real(1.0), dcen);
-                Real dslop = Real(2.0) * ((amrex::Math::abs(dlft) < amrex::Math::abs(drgt)) ?
-                                           amrex::Math::abs(dlft) : amrex::Math::abs(drgt));
+                Real dsgn = std::copysign(Real(1.0), dcen);
+                Real dslop = Real(2.0) * ((std::abs(dlft) < std::abs(drgt)) ?
+                                           std::abs(dlft) : std::abs(drgt));
                 Real dlim = (dlft*drgt >= Real(0.0)) ? dslop : Real(0.0);
                 Real dq1 = Real(4.0/3.0)*dcen - Real(1.0/6.0)*(dq(i+1,j,k) + dq(i-1,j,k));
-                dq4(i,j,k) = dsgn*amrex::min(dlim, amrex::Math::abs(dq1));
+                dq4(i,j,k) = dsgn*amrex::min(dlim, std::abs(dq1));
             }
         }
     }
@@ -80,11 +80,11 @@ void slopey2(amrex::Box const& bx,
                 Real dlft = q(i,j,k) - q(i,j-1,k);
                 Real drgt = q(i,j+1,k) - q(i,j,k);
                 Real dcen = Real(0.5)*(dlft+drgt);
-                Real dsgn = amrex::Math::copysign(Real(1.0), dcen);
-                Real dslop = Real(2.0) * ((amrex::Math::abs(dlft) < amrex::Math::abs(drgt)) ?
-                                           amrex::Math::abs(dlft) : amrex::Math::abs(drgt));
+                Real dsgn = std::copysign(Real(1.0), dcen);
+                Real dslop = Real(2.0) * ((std::abs(dlft) < std::abs(drgt)) ?
+                                           std::abs(dlft) : std::abs(drgt));
                 Real dlim = (dlft*drgt >= Real(0.0)) ? dslop : Real(0.0);
-                dq(i,j,k) = dsgn*amrex::min(dlim, amrex::Math::abs(dcen));
+                dq(i,j,k) = dsgn*amrex::min(dlim, std::abs(dcen));
             }
         }
     }
@@ -108,12 +108,12 @@ void slopey4(amrex::Box const& bx,
                 Real dlft = q(i,j,k) - q(i,j-1,k);
                 Real drgt = q(i,j+1,k) - q(i,j,k);
                 Real dcen = Real(0.5)*(dlft+drgt);
-                Real dsgn = amrex::Math::copysign(Real(1.0), dcen);
-                Real dslop = Real(2.0) * ((amrex::Math::abs(dlft) < amrex::Math::abs(drgt)) ?
-                                           amrex::Math::abs(dlft) : amrex::Math::abs(drgt));
+                Real dsgn = std::copysign(Real(1.0), dcen);
+                Real dslop = Real(2.0) * ((std::abs(dlft) < std::abs(drgt)) ?
+                                           std::abs(dlft) : std::abs(drgt));
                 Real dlim = (dlft*drgt >= Real(0.0)) ? dslop : Real(0.0);
                 Real dq1 = Real(4.0/3.0)*dcen - Real(1.0/6.0)*(dq(i,j+1,k) + dq(i,j-1,k));
-                dq4(i,j,k) = dsgn*amrex::min(dlim, amrex::Math::abs(dq1));
+                dq4(i,j,k) = dsgn*amrex::min(dlim, std::abs(dq1));
             }
         }
     }
@@ -138,11 +138,11 @@ void slopez2(amrex::Box const& bx,
                 Real dlft = q(i,j,k) - q(i,j,k-1);
                 Real drgt = q(i,j,k+1) - q(i,j,k);
                 Real dcen = Real(0.5)*(dlft+drgt);
-                Real dsgn = amrex::Math::copysign(Real(1.0), dcen);
-                Real dslop = Real(2.0) * ((amrex::Math::abs(dlft) < amrex::Math::abs(drgt)) ?
-                                           amrex::Math::abs(dlft) : amrex::Math::abs(drgt));
+                Real dsgn = std::copysign(Real(1.0), dcen);
+                Real dslop = Real(2.0) * ((std::abs(dlft) < std::abs(drgt)) ?
+                                           std::abs(dlft) : std::abs(drgt));
                 Real dlim = (dlft*drgt >= Real(0.0)) ? dslop : Real(0.0);
-                dq(i,j,k) = dsgn*amrex::min(dlim, amrex::Math::abs(dcen));
+                dq(i,j,k) = dsgn*amrex::min(dlim, std::abs(dcen));
             }
         }
     }
@@ -166,12 +166,12 @@ void slopez4(amrex::Box const& bx,
                 Real dlft = q(i,j,k) - q(i,j,k-1);
                 Real drgt = q(i,j,k+1) - q(i,j,k);
                 Real dcen = Real(0.5)*(dlft+drgt);
-                Real dsgn = amrex::Math::copysign(Real(1.0), dcen);
-                Real dslop = Real(2.0) * ((amrex::Math::abs(dlft) < amrex::Math::abs(drgt)) ?
-                                           amrex::Math::abs(dlft) : amrex::Math::abs(drgt));
+                Real dsgn = std::copysign(Real(1.0), dcen);
+                Real dslop = Real(2.0) * ((std::abs(dlft) < std::abs(drgt)) ?
+                                           std::abs(dlft) : std::abs(drgt));
                 Real dlim = (dlft*drgt >= Real(0.0)) ? dslop : Real(0.0);
                 Real dq1 = Real(4.0/3.0)*dcen - Real(1.0/6.0)*(dq(i,j,k+1) + dq(i,j,k-1));
-                dq4(i,j,k) = dsgn*amrex::min(dlim, amrex::Math::abs(dq1));
+                dq4(i,j,k) = dsgn*amrex::min(dlim, std::abs(dq1));
             }
         }
     }

--- a/Tests/Amr/Advection_AmrLevel/Source/Src_K/slope_K.H
+++ b/Tests/Amr/Advection_AmrLevel/Source/Src_K/slope_K.H
@@ -22,11 +22,11 @@ void slopex2(amrex::Box const& bx,
                 Real dlft = q(i,j,k) - q(i-1,j,k);
                 Real drgt = q(i+1,j,k) - q(i,j,k);
                 Real dcen = Real(0.5)*(dlft+drgt);
-                Real dsgn = amrex::Math::copysign(Real(1.0), dcen);
-                Real dslop = Real(2.0) * ((amrex::Math::abs(dlft) < amrex::Math::abs(drgt)) ?
-                                           amrex::Math::abs(dlft) : amrex::Math::abs(drgt));
+                Real dsgn = std::copysign(Real(1.0), dcen);
+                Real dslop = Real(2.0) * ((std::abs(dlft) < std::abs(drgt)) ?
+                                           std::abs(dlft) : std::abs(drgt));
                 Real dlim = (dlft*drgt >= Real(0.0)) ? dslop : Real(0.0);
-                dq(i,j,k) = dsgn*amrex::min(dlim, amrex::Math::abs(dcen));
+                dq(i,j,k) = dsgn*amrex::min(dlim, std::abs(dcen));
             }
         }
     }
@@ -50,12 +50,12 @@ void slopex4(amrex::Box const& bx,
                 Real dlft = q(i,j,k) - q(i-1,j,k);
                 Real drgt = q(i+1,j,k) - q(i,j,k);
                 Real dcen = Real(0.5)*(dlft+drgt);
-                Real dsgn = amrex::Math::copysign(Real(1.0), dcen);
-                Real dslop = Real(2.0) * ((amrex::Math::abs(dlft) < amrex::Math::abs(drgt)) ?
-                                           amrex::Math::abs(dlft) : amrex::Math::abs(drgt));
+                Real dsgn = std::copysign(Real(1.0), dcen);
+                Real dslop = Real(2.0) * ((std::abs(dlft) < std::abs(drgt)) ?
+                                           std::abs(dlft) : std::abs(drgt));
                 Real dlim = (dlft*drgt >= Real(0.0)) ? dslop : Real(0.0);
                 Real dq1 = Real(4.0/3.0)*dcen - Real(1.0/6.0)*(dq(i+1,j,k) + dq(i-1,j,k));
-                dq4(i,j,k) = dsgn*amrex::min(dlim, amrex::Math::abs(dq1));
+                dq4(i,j,k) = dsgn*amrex::min(dlim, std::abs(dq1));
             }
         }
     }
@@ -80,11 +80,11 @@ void slopey2(amrex::Box const& bx,
                 Real dlft = q(i,j,k) - q(i,j-1,k);
                 Real drgt = q(i,j+1,k) - q(i,j,k);
                 Real dcen = Real(0.5)*(dlft+drgt);
-                Real dsgn = amrex::Math::copysign(Real(1.0), dcen);
-                Real dslop = Real(2.0) * ((amrex::Math::abs(dlft) < amrex::Math::abs(drgt)) ?
-                                           amrex::Math::abs(dlft) : amrex::Math::abs(drgt));
+                Real dsgn = std::copysign(Real(1.0), dcen);
+                Real dslop = Real(2.0) * ((std::abs(dlft) < std::abs(drgt)) ?
+                                           std::abs(dlft) : std::abs(drgt));
                 Real dlim = (dlft*drgt >= Real(0.0)) ? dslop : Real(0.0);
-                dq(i,j,k) = dsgn*amrex::min(dlim, amrex::Math::abs(dcen));
+                dq(i,j,k) = dsgn*amrex::min(dlim, std::abs(dcen));
             }
         }
     }
@@ -108,12 +108,12 @@ void slopey4(amrex::Box const& bx,
                 Real dlft = q(i,j,k) - q(i,j-1,k);
                 Real drgt = q(i,j+1,k) - q(i,j,k);
                 Real dcen = Real(0.5)*(dlft+drgt);
-                Real dsgn = amrex::Math::copysign(Real(1.0), dcen);
-                Real dslop = Real(2.0) * ((amrex::Math::abs(dlft) < amrex::Math::abs(drgt)) ?
-                                           amrex::Math::abs(dlft) : amrex::Math::abs(drgt));
+                Real dsgn = std::copysign(Real(1.0), dcen);
+                Real dslop = Real(2.0) * ((std::abs(dlft) < std::abs(drgt)) ?
+                                           std::abs(dlft) : std::abs(drgt));
                 Real dlim = (dlft*drgt >= Real(0.0)) ? dslop : Real(0.0);
                 Real dq1 = Real(4.0/3.0)*dcen - Real(1.0/6.0)*(dq(i,j+1,k) + dq(i,j-1,k));
-                dq4(i,j,k) = dsgn*amrex::min(dlim, amrex::Math::abs(dq1));
+                dq4(i,j,k) = dsgn*amrex::min(dlim, std::abs(dq1));
             }
         }
     }
@@ -139,11 +139,11 @@ void slopez2(amrex::Box const& bx,
                 Real dlft = q(i,j,k) - q(i,j,k-1);
                 Real drgt = q(i,j,k+1) - q(i,j,k);
                 Real dcen = Real(0.5)*(dlft+drgt);
-                Real dsgn = amrex::Math::copysign(Real(1.0), dcen);
-                Real dslop = Real(2.0) * ((amrex::Math::abs(dlft) < amrex::Math::abs(drgt)) ?
-                                           amrex::Math::abs(dlft) : amrex::Math::abs(drgt));
+                Real dsgn = std::copysign(Real(1.0), dcen);
+                Real dslop = Real(2.0) * ((std::abs(dlft) < std::abs(drgt)) ?
+                                           std::abs(dlft) : std::abs(drgt));
                 Real dlim = (dlft*drgt >= Real(0.0)) ? dslop : Real(0.0);
-                dq(i,j,k) = dsgn*amrex::min(dlim, amrex::Math::abs(dcen));
+                dq(i,j,k) = dsgn*amrex::min(dlim, std::abs(dcen));
             }
         }
     }
@@ -167,12 +167,12 @@ void slopez4(amrex::Box const& bx,
                 Real dlft = q(i,j,k) - q(i,j,k-1);
                 Real drgt = q(i,j,k+1) - q(i,j,k);
                 Real dcen = Real(0.5)*(dlft+drgt);
-                Real dsgn = amrex::Math::copysign(Real(1.0), dcen);
-                Real dslop = Real(2.0) * ((amrex::Math::abs(dlft) < amrex::Math::abs(drgt)) ?
-                                           amrex::Math::abs(dlft) : amrex::Math::abs(drgt));
+                Real dsgn = std::copysign(Real(1.0), dcen);
+                Real dslop = Real(2.0) * ((std::abs(dlft) < std::abs(drgt)) ?
+                                           std::abs(dlft) : std::abs(drgt));
                 Real dlim = (dlft*drgt >= Real(0.0)) ? dslop : Real(0.0);
                 Real dq1 = Real(4.0/3.0)*dcen - Real(1.0/6.0)*(dq(i,j,k+1) + dq(i,j,k-1));
-                dq4(i,j,k) = dsgn*amrex::min(dlim, amrex::Math::abs(dq1));
+                dq4(i,j,k) = dsgn*amrex::min(dlim, std::abs(dq1));
             }
         }
     }

--- a/Tests/Amr/Advection_AmrLevel/Source/Src_K/tagging_K.H
+++ b/Tests/Amr/Advection_AmrLevel/Source/Src_K/tagging_K.H
@@ -29,16 +29,16 @@ grad_error (int i, int j, int k,
             amrex::Real const grad_threshold,
             char const tagval) noexcept
 {
-    amrex::Real ax = amrex::Math::abs(state(i-1,j,k) - state(i,j,k));
-    amrex::Real ay = amrex::Math::abs(state(i,j-1,k) - state(i,j,k));
-    ax = amrex::max(ax, amrex::Math::abs(state(i,j,k) - state(i+1,j,k)));
-    ay = amrex::max(ay, amrex::Math::abs(state(i,j,k) - state(i,j+1,k)));
+    amrex::Real ax = std::abs(state(i-1,j,k) - state(i,j,k));
+    amrex::Real ay = std::abs(state(i,j-1,k) - state(i,j,k));
+    ax = amrex::max(ax, std::abs(state(i,j,k) - state(i+1,j,k)));
+    ay = amrex::max(ay, std::abs(state(i,j,k) - state(i,j+1,k)));
     amrex::Real az;
     if (AMREX_SPACEDIM == 2) {
         az = 0.0;
     } else {
-        az = amrex::Math::abs(state(i,j,k-1) - state(i,j,k));
-        az = amrex::max(az, amrex::Math::abs(state(i,j,k) - state(i,j,k+1)));
+        az = std::abs(state(i,j,k-1) - state(i,j,k));
+        az = amrex::max(az, std::abs(state(i,j,k) - state(i,j,k+1)));
     }
     if (amrex::max(ax,ay,az) >= grad_threshold) {
         tag(i,j,k) = tagval;

--- a/Tests/EB_CNS/Source/CNS_K.H
+++ b/Tests/EB_CNS/Source/CNS_K.H
@@ -33,10 +33,10 @@ cns_estdt (int i, int j, int k, amrex::Array4<Real const> const& state,
 #endif
     Real p = amrex::max((parm.eos_gamma-Real(1.0))*ei, parm.smallp);
     Real cs = std::sqrt(parm.eos_gamma*p*rhoinv);
-    Real dtx = dx[0]/(amrex::Math::abs(vx)+cs);
-    Real dty = dx[1]/(amrex::Math::abs(vy)+cs);
+    Real dtx = dx[0]/(std::abs(vx)+cs);
+    Real dty = dx[1]/(std::abs(vy)+cs);
 #if (AMREX_SPACEDIM == 3)
-    Real dtz = dx[2]/(amrex::Math::abs(vz)+cs);
+    Real dtz = dx[2]/(std::abs(vz)+cs);
 #endif
 
 #if (AMREX_SPACEDIM == 2)

--- a/Tests/EB_CNS/Source/CNS_tagging.H
+++ b/Tests/EB_CNS/Source/CNS_tagging.H
@@ -12,12 +12,12 @@ cns_tag_denerror (int i, int j, int k,
                   amrex::Array4<amrex::Real const> const& rho,
                   amrex::Real dengrad_threshold, char tagval) noexcept
 {
-    amrex::Real ax = amrex::Math::abs(rho(i+1,j,k) - rho(i,j,k));
-    amrex::Real ay = amrex::Math::abs(rho(i,j+1,k) - rho(i,j,k));
-    amrex::Real az = amrex::Math::abs(rho(i,j,k+1) - rho(i,j,k));
-    ax = amrex::max(ax,amrex::Math::abs(rho(i,j,k) - rho(i-1,j,k)));
-    ay = amrex::max(ay,amrex::Math::abs(rho(i,j,k) - rho(i,j-1,k)));
-    az = amrex::max(az,amrex::Math::abs(rho(i,j,k) - rho(i,j,k-1)));
+    amrex::Real ax = std::abs(rho(i+1,j,k) - rho(i,j,k));
+    amrex::Real ay = std::abs(rho(i,j+1,k) - rho(i,j,k));
+    amrex::Real az = std::abs(rho(i,j,k+1) - rho(i,j,k));
+    ax = amrex::max(ax,std::abs(rho(i,j,k) - rho(i-1,j,k)));
+    ay = amrex::max(ay,std::abs(rho(i,j,k) - rho(i,j-1,k)));
+    az = amrex::max(az,std::abs(rho(i,j,k) - rho(i,j,k-1)));
     if (amrex::max(ax,ay,az) >= dengrad_threshold) {
         tag(i,j,k) = tagval;
     }

--- a/Tests/EB_CNS/Source/hydro/CNS_divop_K.H
+++ b/Tests/EB_CNS/Source/hydro/CNS_divop_K.H
@@ -67,8 +67,8 @@ void eb_compute_div (int i, int j, int k, int n, IntVect const& blo, IntVect con
     {
         Real fxm = u(i,j,k,n);
         if (apx(i,j,k) != 0.0 && apx(i,j,k) != 1.0) {
-            int jj = j + static_cast<int>(amrex::Math::copysign(1.0_rt, fcx(i,j,k,0)));
-            Real fracy = flag(i,j,k).isConnected(0,jj-j,0) ? amrex::Math::abs(fcx(i,j,k,0)) : 0.0_rt;
+            int jj = j + static_cast<int>(std::copysign(1.0_rt, fcx(i,j,k,0)));
+            Real fracy = flag(i,j,k).isConnected(0,jj-j,0) ? std::abs(fcx(i,j,k,0)) : 0.0_rt;
             fxm = (1.0-fracy)*fxm + fracy *u(i,jj,k ,n);
         }
         if (valid_cell) {
@@ -77,8 +77,8 @@ void eb_compute_div (int i, int j, int k, int n, IntVect const& blo, IntVect con
 
         Real fxp = u(i+1,j,k,n);
         if (apx(i+1,j,k) != 0.0 && apx(i+1,j,k) != 1.0) {
-            int jj = j + static_cast<int>(amrex::Math::copysign(1.0_rt,fcx(i+1,j,k,0)));
-            Real fracy = flag(i+1,j,k).isConnected(0,jj-j,0) ? amrex::Math::abs(fcx(i+1,j,k,0)) : 0.0_rt;
+            int jj = j + static_cast<int>(std::copysign(1.0_rt,fcx(i+1,j,k,0)));
+            Real fracy = flag(i+1,j,k).isConnected(0,jj-j,0) ? std::abs(fcx(i+1,j,k,0)) : 0.0_rt;
             fxp = (1.0-fracy)*fxp + fracy *u(i+1,jj,k,n);
 
         }
@@ -88,8 +88,8 @@ void eb_compute_div (int i, int j, int k, int n, IntVect const& blo, IntVect con
 
         Real fym = v(i,j,k,n);
         if (apy(i,j,k) != 0.0 && apy(i,j,k) != 1.0) {
-            int ii = i + static_cast<int>(amrex::Math::copysign(1.0_rt,fcy(i,j,k,0)));
-            Real fracx = flag(i,j,k).isConnected(ii-i,0,0) ? amrex::Math::abs(fcy(i,j,k,0)) : 0.0_rt;
+            int ii = i + static_cast<int>(std::copysign(1.0_rt,fcy(i,j,k,0)));
+            Real fracx = flag(i,j,k).isConnected(ii-i,0,0) ? std::abs(fcy(i,j,k,0)) : 0.0_rt;
             fym = (1.0-fracx)*fym +  fracx *v(ii,j,k,n);
         }
         if (valid_cell) {
@@ -98,8 +98,8 @@ void eb_compute_div (int i, int j, int k, int n, IntVect const& blo, IntVect con
 
         Real fyp = v(i,j+1,k,n);
         if (apy(i,j+1,k) != 0.0 && apy(i,j+1,k) != 1.0) {
-            int ii = i + static_cast<int>(amrex::Math::copysign(1.0_rt,fcy(i,j+1,k,0)));
-            Real fracx = flag(i,j+1,k).isConnected(ii-i,0,0) ? amrex::Math::abs(fcy(i,j+1,k,0)) : 0.0_rt;
+            int ii = i + static_cast<int>(std::copysign(1.0_rt,fcy(i,j+1,k,0)));
+            Real fracx = flag(i,j+1,k).isConnected(ii-i,0,0) ? std::abs(fcy(i,j+1,k,0)) : 0.0_rt;
             fyp = (1.0-fracx)*fyp + fracx *v(ii,j+1,k,n);
         }
         if (valid_cell && y_high) {
@@ -174,10 +174,10 @@ void eb_compute_div (int i, int j, int k, int n, IntVect const& blo, IntVect con
     {
         Real fxm = u(i,j,k,n);
         if (apx(i,j,k) != 0.0 && apx(i,j,k) != 1.0) {
-            int jj = j + static_cast<int>(amrex::Math::copysign(1.0_rt, fcx(i,j,k,0)));
-            int kk = k + static_cast<int>(amrex::Math::copysign(1.0_rt, fcx(i,j,k,1)));
-            Real fracy = flag(i,j,k).isConnected(0,jj-j,0) ? amrex::Math::abs(fcx(i,j,k,0)) : 0.0_rt;
-            Real fracz = flag(i,j,k).isConnected(0,0,kk-k) ? amrex::Math::abs(fcx(i,j,k,1)) : 0.0_rt;
+            int jj = j + static_cast<int>(std::copysign(1.0_rt, fcx(i,j,k,0)));
+            int kk = k + static_cast<int>(std::copysign(1.0_rt, fcx(i,j,k,1)));
+            Real fracy = flag(i,j,k).isConnected(0,jj-j,0) ? std::abs(fcx(i,j,k,0)) : 0.0_rt;
+            Real fracz = flag(i,j,k).isConnected(0,0,kk-k) ? std::abs(fcx(i,j,k,1)) : 0.0_rt;
             fxm = (1.0-fracy)*(1.0-fracz)*fxm
                 +      fracy *(1.0-fracz)*u(i,jj,k ,n)
                 +      fracz *(1.0-fracy)*u(i,j ,kk,n)
@@ -189,10 +189,10 @@ void eb_compute_div (int i, int j, int k, int n, IntVect const& blo, IntVect con
 
         Real fxp = u(i+1,j,k,n);
         if (apx(i+1,j,k) != 0.0 && apx(i+1,j,k) != 1.0) {
-            int jj = j + static_cast<int>(amrex::Math::copysign(1.0_rt,fcx(i+1,j,k,0)));
-            int kk = k + static_cast<int>(amrex::Math::copysign(1.0_rt,fcx(i+1,j,k,1)));
-            Real fracy = flag(i+1,j,k).isConnected(0,jj-j,0) ? amrex::Math::abs(fcx(i+1,j,k,0)) : 0.0_rt;
-            Real fracz = flag(i+1,j,k).isConnected(0,0,kk-k) ? amrex::Math::abs(fcx(i+1,j,k,1)) : 0.0_rt;
+            int jj = j + static_cast<int>(std::copysign(1.0_rt,fcx(i+1,j,k,0)));
+            int kk = k + static_cast<int>(std::copysign(1.0_rt,fcx(i+1,j,k,1)));
+            Real fracy = flag(i+1,j,k).isConnected(0,jj-j,0) ? std::abs(fcx(i+1,j,k,0)) : 0.0_rt;
+            Real fracz = flag(i+1,j,k).isConnected(0,0,kk-k) ? std::abs(fcx(i+1,j,k,1)) : 0.0_rt;
             fxp = (1.0-fracy)*(1.0-fracz)*fxp
                 +      fracy *(1.0-fracz)*u(i+1,jj,k ,n)
                 +      fracz *(1.0-fracy)*u(i+1,j ,kk,n)
@@ -205,10 +205,10 @@ void eb_compute_div (int i, int j, int k, int n, IntVect const& blo, IntVect con
 
         Real fym = v(i,j,k,n);
         if (apy(i,j,k) != 0.0 && apy(i,j,k) != 1.0) {
-            int ii = i + static_cast<int>(amrex::Math::copysign(1.0_rt,fcy(i,j,k,0)));
-            int kk = k + static_cast<int>(amrex::Math::copysign(1.0_rt,fcy(i,j,k,1)));
-            Real fracx = flag(i,j,k).isConnected(ii-i,0,0) ? amrex::Math::abs(fcy(i,j,k,0)) : 0.0_rt;
-            Real fracz = flag(i,j,k).isConnected(0,0,kk-k) ? amrex::Math::abs(fcy(i,j,k,1)) : 0.0_rt;
+            int ii = i + static_cast<int>(std::copysign(1.0_rt,fcy(i,j,k,0)));
+            int kk = k + static_cast<int>(std::copysign(1.0_rt,fcy(i,j,k,1)));
+            Real fracx = flag(i,j,k).isConnected(ii-i,0,0) ? std::abs(fcy(i,j,k,0)) : 0.0_rt;
+            Real fracz = flag(i,j,k).isConnected(0,0,kk-k) ? std::abs(fcy(i,j,k,1)) : 0.0_rt;
             fym = (1.0-fracx)*(1.0-fracz)*fym
                 +      fracx *(1.0-fracz)*v(ii,j,k ,n)
                 +      fracz *(1.0-fracx)*v(i ,j,kk,n)
@@ -220,10 +220,10 @@ void eb_compute_div (int i, int j, int k, int n, IntVect const& blo, IntVect con
 
         Real fyp = v(i,j+1,k,n);
         if (apy(i,j+1,k) != 0.0 && apy(i,j+1,k) != 1.0) {
-            int ii = i + static_cast<int>(amrex::Math::copysign(1.0_rt,fcy(i,j+1,k,0)));
-            int kk = k + static_cast<int>(amrex::Math::copysign(1.0_rt,fcy(i,j+1,k,1)));
-            Real fracx = flag(i,j+1,k).isConnected(ii-i,0,0) ? amrex::Math::abs(fcy(i,j+1,k,0)) : 0.0_rt;
-            Real fracz = flag(i,j+1,k).isConnected(0,0,kk-k) ? amrex::Math::abs(fcy(i,j+1,k,1)) : 0.0_rt;
+            int ii = i + static_cast<int>(std::copysign(1.0_rt,fcy(i,j+1,k,0)));
+            int kk = k + static_cast<int>(std::copysign(1.0_rt,fcy(i,j+1,k,1)));
+            Real fracx = flag(i,j+1,k).isConnected(ii-i,0,0) ? std::abs(fcy(i,j+1,k,0)) : 0.0_rt;
+            Real fracz = flag(i,j+1,k).isConnected(0,0,kk-k) ? std::abs(fcy(i,j+1,k,1)) : 0.0_rt;
             fyp = (1.0-fracx)*(1.0-fracz)*fyp
                 +      fracx *(1.0-fracz)*v(ii,j+1,k ,n)
                 +      fracz *(1.0-fracx)*v(i ,j+1,kk,n)
@@ -235,10 +235,10 @@ void eb_compute_div (int i, int j, int k, int n, IntVect const& blo, IntVect con
 
         Real fzm = w(i,j,k,n);
         if (apz(i,j,k) != 0.0 && apz(i,j,k) != 1.0) {
-            int ii = i + static_cast<int>(amrex::Math::copysign(1.0_rt,fcz(i,j,k,0)));
-            int jj = j + static_cast<int>(amrex::Math::copysign(1.0_rt,fcz(i,j,k,1)));
-            Real fracx = flag(i,j,k).isConnected(ii-i,0,0) ? amrex::Math::abs(fcz(i,j,k,0)) : 0.0_rt;
-            Real fracy = flag(i,j,k).isConnected(0,jj-j,0) ? amrex::Math::abs(fcz(i,j,k,1)) : 0.0_rt;
+            int ii = i + static_cast<int>(std::copysign(1.0_rt,fcz(i,j,k,0)));
+            int jj = j + static_cast<int>(std::copysign(1.0_rt,fcz(i,j,k,1)));
+            Real fracx = flag(i,j,k).isConnected(ii-i,0,0) ? std::abs(fcz(i,j,k,0)) : 0.0_rt;
+            Real fracy = flag(i,j,k).isConnected(0,jj-j,0) ? std::abs(fcz(i,j,k,1)) : 0.0_rt;
 
             fzm = (1.0-fracx)*(1.0-fracy)*fzm
                 +      fracx *(1.0-fracy)*w(ii,j ,k,n)
@@ -251,10 +251,10 @@ void eb_compute_div (int i, int j, int k, int n, IntVect const& blo, IntVect con
 
         Real fzp = w(i,j,k+1,n);
         if (apz(i,j,k+1) != 0.0 && apz(i,j,k+1) != 1.0) {
-            int ii = i + static_cast<int>(amrex::Math::copysign(1.0_rt,fcz(i,j,k+1,0)));
-            int jj = j + static_cast<int>(amrex::Math::copysign(1.0_rt,fcz(i,j,k+1,1)));
-            Real fracx = flag(i,j,k+1).isConnected(ii-i,0,0) ? amrex::Math::abs(fcz(i,j,k+1,0)) : 0.0_rt;
-            Real fracy = flag(i,j,k+1).isConnected(0,jj-j,0) ? amrex::Math::abs(fcz(i,j,k+1,1)) : 0.0_rt;
+            int ii = i + static_cast<int>(std::copysign(1.0_rt,fcz(i,j,k+1,0)));
+            int jj = j + static_cast<int>(std::copysign(1.0_rt,fcz(i,j,k+1,1)));
+            Real fracx = flag(i,j,k+1).isConnected(ii-i,0,0) ? std::abs(fcz(i,j,k+1,0)) : 0.0_rt;
+            Real fracy = flag(i,j,k+1).isConnected(0,jj-j,0) ? std::abs(fcz(i,j,k+1,1)) : 0.0_rt;
             fzp = (1.0-fracx)*(1.0-fracy)*fzp
                 +      fracx *(1.0-fracy)*w(ii,j ,k+1,n)
                 +      fracy *(1.0-fracx)*w(i ,jj,k+1,n)

--- a/Tests/EB_CNS/Source/hydro/CNS_hydro_K.H
+++ b/Tests/EB_CNS/Source/hydro/CNS_hydro_K.H
@@ -69,10 +69,10 @@ amrex::Real limiter (amrex::Real dlft, amrex::Real drgt, amrex::Real plm_theta) 
     using amrex::Real;
 
     Real dcen = Real(0.5)*(dlft+drgt);
-    Real dsgn = amrex::Math::copysign(Real(1.0), dcen);
-    Real slop = plm_theta * amrex::min(amrex::Math::abs(dlft),amrex::Math::abs(drgt));
+    Real dsgn = std::copysign(Real(1.0), dcen);
+    Real slop = plm_theta * amrex::min(std::abs(dlft),std::abs(drgt));
     Real dlim = (dlft*drgt >= Real(0.0)) ? slop : Real(0.0);
-    return dsgn * amrex::min(dlim,amrex::Math::abs(dcen));
+    return dsgn * amrex::min(dlim,std::abs(dcen));
 }
 
 }
@@ -286,12 +286,12 @@ riemann (const amrex::Real gamma, const amrex::Real smallp, const amrex::Real /*
         ustarm = ur - (pr - pstar)*wr;
         ustarp = ul + (pl - pstar)*wl;
 
-        Real dpditer = amrex::Math::abs(pstnm1-pstar);
-        Real zp = amrex::Math::abs(ustarp-ustnp1);
+        Real dpditer = std::abs(pstnm1-pstar);
+        Real zp = std::abs(ustarp-ustnp1);
         if (zp-weakwv*cleft < Real(0.0) ) {
             zp = dpditer*wl;
         }
-        Real zm = amrex::Math::abs(ustarm-ustnm1);
+        Real zm = std::abs(ustarm-ustnm1);
         if (zm-weakwv*cright < Real(0.0) ) {
             zm = dpditer*wr;
         }

--- a/Tests/EB_CNS/Source/hydro/CNS_hydro_eb_K.H
+++ b/Tests/EB_CNS/Source/hydro/CNS_hydro_eb_K.H
@@ -16,10 +16,10 @@ amrex::Real limiter_eb (amrex::Real dlft, amrex::Real drgt, amrex::Real plm_thet
     using amrex::Real;
 
     Real dcen = Real(0.5)*(dlft+drgt);
-    Real dsgn = amrex::Math::copysign(Real(1.0), dcen);
-    Real slop = plm_theta * amrex::min(amrex::Math::abs(dlft),amrex::Math::abs(drgt));
+    Real dsgn = std::copysign(Real(1.0), dcen);
+    Real slop = plm_theta * amrex::min(std::abs(dlft),std::abs(drgt));
     Real dlim = (dlft*drgt >= Real(0.0)) ? slop : Real(0.0);
-    return dsgn * amrex::min(dlim,amrex::Math::abs(dcen));
+    return dsgn * amrex::min(dlim,std::abs(dcen));
 }
 
 }

--- a/Tests/GPU/CNS/Source/CNS_K.H
+++ b/Tests/GPU/CNS/Source/CNS_K.H
@@ -36,9 +36,9 @@ cns_estdt (amrex::Box const& bx, amrex::Array4<Real const> const& state,
                 Real vz = mz*rhoinv;
                 Real p = amrex::max((parm.eos_gamma-Real(1.0))*ei, parm.smallp);
                 Real cs = std::sqrt(parm.eos_gamma*p*rhoinv);
-                Real dtx = dx[0]/(amrex::Math::abs(vx)+cs);
-                Real dty = dx[1]/(amrex::Math::abs(vy)+cs);
-                Real dtz = dx[2]/(amrex::Math::abs(vz)+cs);
+                Real dtx = dx[0]/(std::abs(vx)+cs);
+                Real dty = dx[1]/(std::abs(vy)+cs);
+                Real dtz = dx[2]/(std::abs(vz)+cs);
                 dt = amrex::min(dt,amrex::min(dtx,amrex::min(dty,dtz)));
             }
         }

--- a/Tests/GPU/CNS/Source/CNS_tagging.H
+++ b/Tests/GPU/CNS/Source/CNS_tagging.H
@@ -13,12 +13,12 @@ cns_tag_denerror (int i, int j, int k,
                   amrex::Array4<amrex::Real const> const& rho,
                   amrex::Real dengrad_threshold, char tagval) noexcept
 {
-    amrex::Real ax = amrex::Math::abs(rho(i+1,j,k) - rho(i,j,k));
-    amrex::Real ay = amrex::Math::abs(rho(i,j+1,k) - rho(i,j,k));
-    amrex::Real az = amrex::Math::abs(rho(i,j,k+1) - rho(i,j,k));
-    ax = amrex::max(ax,amrex::Math::abs(rho(i,j,k) - rho(i-1,j,k)));
-    ay = amrex::max(ay,amrex::Math::abs(rho(i,j,k) - rho(i,j-1,k)));
-    az = amrex::max(az,amrex::Math::abs(rho(i,j,k) - rho(i,j,k-1)));
+    amrex::Real ax = std::abs(rho(i+1,j,k) - rho(i,j,k));
+    amrex::Real ay = std::abs(rho(i,j+1,k) - rho(i,j,k));
+    amrex::Real az = std::abs(rho(i,j,k+1) - rho(i,j,k));
+    ax = amrex::max(ax,std::abs(rho(i,j,k) - rho(i-1,j,k)));
+    ay = amrex::max(ay,std::abs(rho(i,j,k) - rho(i,j-1,k)));
+    az = amrex::max(az,std::abs(rho(i,j,k) - rho(i,j,k-1)));
     if (amrex::max(ax,ay,az) >= dengrad_threshold) {
         tag(i,j,k) = tagval;
     }

--- a/Tests/GPU/CNS/Source/hydro/CNS_hydro_K.H
+++ b/Tests/GPU/CNS/Source/hydro/CNS_hydro_K.H
@@ -62,10 +62,10 @@ amrex::Real limiter (amrex::Real dlft, amrex::Real drgt) noexcept
     using amrex::Real;
 
     Real dcen = Real(0.5)*(dlft+drgt);
-    Real dsgn = amrex::Math::copysign(Real(1.0), dcen);
-    Real slop = Real(2.0) * amrex::min(amrex::Math::abs(dlft),amrex::Math::abs(drgt));
+    Real dsgn = std::copysign(Real(1.0), dcen);
+    Real slop = Real(2.0) * amrex::min(std::abs(dlft),std::abs(drgt));
     Real dlim = (dlft*drgt >= Real(0.0)) ? slop : Real(0.0);
-    return dsgn * amrex::min(dlim,amrex::Math::abs(dcen));
+    return dsgn * amrex::min(dlim,std::abs(dcen));
 }
 
 }
@@ -237,12 +237,12 @@ riemann (const amrex::Real gamma, const amrex::Real smallp, const amrex::Real /*
         ustarm = ur - (pr - pstar)*wr;
         ustarp = ul + (pl - pstar)*wl;
 
-        Real dpditer = amrex::Math::abs(pstnm1-pstar);
-        Real zp = amrex::Math::abs(ustarp-ustnp1);
+        Real dpditer = std::abs(pstnm1-pstar);
+        Real zp = std::abs(ustarp-ustnp1);
         if (zp-weakwv*cleft < Real(0.0) ) {
             zp = dpditer*wl;
         }
-        Real zm = amrex::Math::abs(ustarm-ustnm1);
+        Real zm = std::abs(ustarm-ustnm1);
         if (zm-weakwv*cright < Real(0.0) ) {
             zm = dpditer*wr;
         }

--- a/Tests/Particles/GhostsAndVirtuals/main.cpp
+++ b/Tests/Particles/GhostsAndVirtuals/main.cpp
@@ -245,16 +245,16 @@ void test_ghosts_and_virtuals_ascii (TestParams& parms)
         Real sum_test = amrex::ReduceSum(virtPC,
             [=] AMREX_GPU_HOST_DEVICE (const PType& p) -> Real
             {
-                return amrex::Math::abs(p.rdata(0)) +
-                       amrex::Math::abs(p.rdata(1)) +
-                       amrex::Math::abs(p.rdata(2)) +
-                       amrex::Math::abs(p.rdata(3));
+                return std::abs(p.rdata(0)) +
+                       std::abs(p.rdata(1)) +
+                       std::abs(p.rdata(2)) +
+                       std::abs(p.rdata(3));
             }
         );
         amrex::ParallelAllReduce::Sum(sum_test,ParallelContext::CommunicatorSub());
         amrex::Print().SetPrecision(18)<<"Found sum of virts: "<<sum_test<<std::endl;
         AMREX_ALWAYS_ASSERT(virtPC.TotalNumberOfParticles(true,false)==3);
-        AMREX_ALWAYS_ASSERT(amrex::Math::abs(sum_test-3029.00000028022578)<tol);
+        AMREX_ALWAYS_ASSERT(std::abs(sum_test-3029.00000028022578)<tol);
 
     }
 
@@ -267,16 +267,16 @@ void test_ghosts_and_virtuals_ascii (TestParams& parms)
         Real sum_test = amrex::ReduceSum(virtPC,
             [=] AMREX_GPU_HOST_DEVICE (const PType& p) -> Real
             {
-                return amrex::Math::abs(p.rdata(0)) +
-                       amrex::Math::abs(p.rdata(1)) +
-                       amrex::Math::abs(p.rdata(2)) +
-                       amrex::Math::abs(p.rdata(3));
+                return std::abs(p.rdata(0)) +
+                       std::abs(p.rdata(1)) +
+                       std::abs(p.rdata(2)) +
+                       std::abs(p.rdata(3));
             }
         );
         amrex::ParallelAllReduce::Sum(sum_test,ParallelContext::CommunicatorSub());
         amrex::Print().SetPrecision(18)<<"Found sum of virts: "<<sum_test<<std::endl;
         AMREX_ALWAYS_ASSERT(virtPC.TotalNumberOfParticles(true,false)==0);
-        AMREX_ALWAYS_ASSERT(amrex::Math::abs(sum_test-0.0)<tol);
+        AMREX_ALWAYS_ASSERT(std::abs(sum_test-0.0)<tol);
     }
 
     {
@@ -290,16 +290,16 @@ void test_ghosts_and_virtuals_ascii (TestParams& parms)
         Real sum_test = amrex::ReduceSum(ghostPC,
             [=] AMREX_GPU_HOST_DEVICE (const PType& p) -> Real
             {
-                return amrex::Math::abs(p.rdata(0)) +
-                       amrex::Math::abs(p.rdata(1)) +
-                       amrex::Math::abs(p.rdata(2)) +
-                       amrex::Math::abs(p.rdata(3));
+                return std::abs(p.rdata(0)) +
+                       std::abs(p.rdata(1)) +
+                       std::abs(p.rdata(2)) +
+                       std::abs(p.rdata(3));
             }
         );
         amrex::ParallelAllReduce::Sum(sum_test,ParallelContext::CommunicatorSub());
         amrex::Print().SetPrecision(18)<<"Found sum of ghosts: "<<sum_test<<std::endl;
         AMREX_ALWAYS_ASSERT(ghostPC.TotalNumberOfParticles(true,false)==0);
-        AMREX_ALWAYS_ASSERT(amrex::Math::abs(sum_test-0.0)<tol);
+        AMREX_ALWAYS_ASSERT(std::abs(sum_test-0.0)<tol);
     }
 
     {
@@ -313,16 +313,16 @@ void test_ghosts_and_virtuals_ascii (TestParams& parms)
         Real sum_test = amrex::ReduceSum(ghostPC,
             [=] AMREX_GPU_HOST_DEVICE (const PType& p) -> Real
             {
-                return amrex::Math::abs(p.rdata(0)) +
-                       amrex::Math::abs(p.rdata(1)) +
-                       amrex::Math::abs(p.rdata(2)) +
-                       amrex::Math::abs(p.rdata(3));
+                return std::abs(p.rdata(0)) +
+                       std::abs(p.rdata(1)) +
+                       std::abs(p.rdata(2)) +
+                       std::abs(p.rdata(3));
             }
         );
         amrex::ParallelAllReduce::Sum(sum_test,ParallelContext::CommunicatorSub());
         amrex::Print().SetPrecision(18)<<"Found sum of ghosts: "<<sum_test<<std::endl;
         AMREX_ALWAYS_ASSERT(ghostPC.TotalNumberOfParticles(true,false)==3);
-        AMREX_ALWAYS_ASSERT(amrex::Math::abs(sum_test-3035.00000001795206)<tol);
+        AMREX_ALWAYS_ASSERT(std::abs(sum_test-3035.00000001795206)<tol);
     }
 
     {
@@ -336,16 +336,16 @@ void test_ghosts_and_virtuals_ascii (TestParams& parms)
         Real sum_test = amrex::ReduceSum(ghostPC,
             [=] AMREX_GPU_HOST_DEVICE (const PType& p) -> Real
             {
-                return amrex::Math::abs(p.rdata(0)) +
-                       amrex::Math::abs(p.rdata(1)) +
-                       amrex::Math::abs(p.rdata(2)) +
-                       amrex::Math::abs(p.rdata(3));
+                return std::abs(p.rdata(0)) +
+                       std::abs(p.rdata(1)) +
+                       std::abs(p.rdata(2)) +
+                       std::abs(p.rdata(3));
             }
         );
         amrex::ParallelAllReduce::Sum(sum_test,ParallelContext::CommunicatorSub());
         amrex::Print().SetPrecision(18)<<"Found sum of ghosts: "<<sum_test<<std::endl;
         AMREX_ALWAYS_ASSERT(ghostPC.TotalNumberOfParticles(true,false)==1);
-        AMREX_ALWAYS_ASSERT(amrex::Math::abs(sum_test-1005.00000009692667)<tol);
+        AMREX_ALWAYS_ASSERT(std::abs(sum_test-1005.00000009692667)<tol);
     }
 }
 
@@ -450,15 +450,15 @@ void test_ghosts_and_virtuals_randomperbox (TestParams& parms)
         Real sum_test = amrex::ReduceSum(virtPC,
             [=] AMREX_GPU_HOST_DEVICE (const PType& p) -> Real
             {
-                return amrex::Math::abs(p.rdata(0)) +
-                       amrex::Math::abs(p.rdata(1)) +
-                       amrex::Math::abs(p.rdata(2)) +
-                       amrex::Math::abs(p.rdata(3));
+                return std::abs(p.rdata(0)) +
+                       std::abs(p.rdata(1)) +
+                       std::abs(p.rdata(2)) +
+                       std::abs(p.rdata(3));
             }
         );
         amrex::ParallelAllReduce::Sum(sum_test,ParallelContext::CommunicatorSub());
         amrex::Print().SetPrecision(18)<<"Found sum of virts: "<<sum_test<<std::endl;
-        AMREX_ALWAYS_ASSERT((virtPC.AggregationType()=="None" && amrex::Math::abs(sum_test - total_virts_test * parms.nx * parms.ny * parms.nz / (32 * 32 * 32) * (16 * 16 * 16) / (parms.max_grid_size * parms.max_grid_size * parms.max_grid_size) * parms.nppc * parms.nppc * parms.nppc) < tol) || ParallelDescriptor::NProcs() % 2 != 0 || virtPC.AggregationType() == "Cell");
+        AMREX_ALWAYS_ASSERT((virtPC.AggregationType()=="None" && std::abs(sum_test - total_virts_test * parms.nx * parms.ny * parms.nz / (32 * 32 * 32) * (16 * 16 * 16) / (parms.max_grid_size * parms.max_grid_size * parms.max_grid_size) * parms.nppc * parms.nppc * parms.nppc) < tol) || ParallelDescriptor::NProcs() % 2 != 0 || virtPC.AggregationType() == "Cell");
 
     }
 
@@ -473,10 +473,10 @@ void test_ghosts_and_virtuals_randomperbox (TestParams& parms)
         Real sum_test = amrex::ReduceSum(ghostPC,
             [=] AMREX_GPU_HOST_DEVICE (const PType& p) -> Real
             {
-                return amrex::Math::abs(p.rdata(0)) +
-                       amrex::Math::abs(p.rdata(1)) +
-                       amrex::Math::abs(p.rdata(2)) +
-                       amrex::Math::abs(p.rdata(3));
+                return std::abs(p.rdata(0)) +
+                       std::abs(p.rdata(1)) +
+                       std::abs(p.rdata(2)) +
+                       std::abs(p.rdata(3));
             }
         );
         amrex::ParallelAllReduce::Sum(sum_test,ParallelContext::CommunicatorSub());
@@ -500,10 +500,10 @@ void test_ghosts_and_virtuals_randomperbox (TestParams& parms)
         Real sum_test = amrex::ReduceSum(virtPC,
             [=] AMREX_GPU_HOST_DEVICE (const PType& p) -> Real
             {
-                return amrex::Math::abs(p.rdata(0)) +
-                       amrex::Math::abs(p.rdata(1)) +
-                       amrex::Math::abs(p.rdata(2)) +
-                       amrex::Math::abs(p.rdata(3));
+                return std::abs(p.rdata(0)) +
+                       std::abs(p.rdata(1)) +
+                       std::abs(p.rdata(2)) +
+                       std::abs(p.rdata(3));
             }
         );
         amrex::ParallelAllReduce::Sum(sum_test,ParallelContext::CommunicatorSub());
@@ -521,10 +521,10 @@ void test_ghosts_and_virtuals_randomperbox (TestParams& parms)
         Real sum_test = amrex::ReduceSum(ghostPC,
             [=] AMREX_GPU_HOST_DEVICE (const PType& p) -> Real
             {
-                return amrex::Math::abs(p.rdata(0)) +
-                       amrex::Math::abs(p.rdata(1)) +
-                       amrex::Math::abs(p.rdata(2)) +
-                       amrex::Math::abs(p.rdata(3));
+                return std::abs(p.rdata(0)) +
+                       std::abs(p.rdata(1)) +
+                       std::abs(p.rdata(2)) +
+                       std::abs(p.rdata(3));
             }
         );
         amrex::ParallelAllReduce::Sum(sum_test,ParallelContext::CommunicatorSub());
@@ -644,10 +644,10 @@ void test_ghosts_and_virtuals_onepercell (TestParams& parms)
         Real sum_test = amrex::ReduceSum(virtPC,
             [=] AMREX_GPU_HOST_DEVICE (const PType& p) -> Real
             {
-                return amrex::Math::abs(p.rdata(0)) +
-                       amrex::Math::abs(p.rdata(1)) +
-                       amrex::Math::abs(p.rdata(2)) +
-                       amrex::Math::abs(p.rdata(3));
+                return std::abs(p.rdata(0)) +
+                       std::abs(p.rdata(1)) +
+                       std::abs(p.rdata(2)) +
+                       std::abs(p.rdata(3));
             }
         );
         amrex::ParallelAllReduce::Sum(sum_test,ParallelContext::CommunicatorSub());
@@ -666,10 +666,10 @@ void test_ghosts_and_virtuals_onepercell (TestParams& parms)
         Real sum_test = amrex::ReduceSum(ghostPC,
             [=] AMREX_GPU_HOST_DEVICE (const PType& p) -> Real
             {
-                return amrex::Math::abs(p.rdata(0)) +
-                       amrex::Math::abs(p.rdata(1)) +
-                       amrex::Math::abs(p.rdata(2)) +
-                       amrex::Math::abs(p.rdata(3));
+                return std::abs(p.rdata(0)) +
+                       std::abs(p.rdata(1)) +
+                       std::abs(p.rdata(2)) +
+                       std::abs(p.rdata(3));
             }
         );
         amrex::ParallelAllReduce::Sum(sum_test,ParallelContext::CommunicatorSub());
@@ -694,10 +694,10 @@ void test_ghosts_and_virtuals_onepercell (TestParams& parms)
         Real sum_test = amrex::ReduceSum(virtPC,
             [=] AMREX_GPU_HOST_DEVICE (const PType& p) -> Real
             {
-                return amrex::Math::abs(p.rdata(0)) +
-                       amrex::Math::abs(p.rdata(1)) +
-                       amrex::Math::abs(p.rdata(2)) +
-                       amrex::Math::abs(p.rdata(3));
+                return std::abs(p.rdata(0)) +
+                       std::abs(p.rdata(1)) +
+                       std::abs(p.rdata(2)) +
+                       std::abs(p.rdata(3));
             }
         );
         amrex::ParallelAllReduce::Sum(sum_test,ParallelContext::CommunicatorSub());
@@ -715,10 +715,10 @@ void test_ghosts_and_virtuals_onepercell (TestParams& parms)
         Real sum_test = amrex::ReduceSum(ghostPC,
             [=] AMREX_GPU_HOST_DEVICE (const PType& p) -> Real
             {
-                return amrex::Math::abs(p.rdata(0)) +
-                       amrex::Math::abs(p.rdata(1)) +
-                       amrex::Math::abs(p.rdata(2)) +
-                       amrex::Math::abs(p.rdata(3));
+                return std::abs(p.rdata(0)) +
+                       std::abs(p.rdata(1)) +
+                       std::abs(p.rdata(2)) +
+                       std::abs(p.rdata(3));
             }
         );
         amrex::ParallelAllReduce::Sum(sum_test,ParallelContext::CommunicatorSub());


### PR DESCRIPTION
We introduced `amrex::Math::floor`, etc. because their std versions were not supported in device code by the Intel compiler at that time.  Otherwise, the user would have to call either sycl::floor or std::floor with the help of macros.  This is no longer the case.  Now we can switch to use the std versions.  The amrex::Math versions are kept for backward compatibility. The particle code is not updated because it's undergoing some large changes.