### PR TITLE
Update SUNDIALS NVector constructors

### DIFF
--- a/Src/Extern/SUNDIALS/AMReX_NVector_MultiFab.H
+++ b/Src/Extern/SUNDIALS/AMReX_NVector_MultiFab.H
@@ -20,7 +20,7 @@
 #include <AMReX_Geometry.H>
 #include <AMReX_MultiFab.H>
 #include <AMReX_MultiFabUtil.H>
-#include <AMReX_Sundials.H>
+#include <AMReX_Sundials_Core.H>
 
 #include <sundials/sundials_nvector.h>
 #include <cstdio>
@@ -48,16 +48,16 @@ typedef struct N_VectorContent_MultiFab_notptr *N_VectorContent_MultiFab;
  * -----------------------------------------------------------------*/
 
 N_Vector N_VNewEmpty_MultiFab(sunindextype vec_length,
-                              int i = amrex::OpenMP::get_thread_num());
+                              ::sundials::Context* sunctx = The_Sundials_Context());
 N_Vector N_VNew_MultiFab(sunindextype vec_length,
                          const amrex::BoxArray &ba,
                          const amrex::DistributionMapping &dm,
                          sunindextype nComp,
                          sunindextype nGhost,
-                         int i = amrex::OpenMP::get_thread_num());
+                         ::sundials::Context* sunctx = The_Sundials_Context());
 N_Vector N_VMake_MultiFab(sunindextype vec_length,
                           amrex::MultiFab *mf,
-                          int i = amrex::OpenMP::get_thread_num());
+                          ::sundials::Context* sunctx = The_Sundials_Context());
 sunindextype N_VGetLength_MultiFab(N_Vector v);
 int N_VGetOwnMF_MultiFab(N_Vector v);
 void N_VSetOwnMF_MultiFab(N_Vector v, int own_mf);

--- a/Src/Extern/SUNDIALS/AMReX_NVector_MultiFab.H
+++ b/Src/Extern/SUNDIALS/AMReX_NVector_MultiFab.H
@@ -1,20 +1,16 @@
-/*--------------------------------------------------------------------
-  Time Integration and Nonlinear Solvers
-  Hands-on Lessons with SUNDIALS + AMReX
-  2019 Argonne Training Program in Extreme-Scale Computing
+/*------------------------------------------------------------------------------
+  Header file for N_Vector wrap of an AMReX 'MultiFab'. Based on example codes
+  for the 2019 Argonne Training Program in Extreme-Scale Computing with SUNDIALS
+  and AMReX.
 
   Authors (alphabetical):
     David Gardner (gardner48@llnl.gov)
     John Loffeld (loffeld1@llnl.gov)
     Daniel Reynolds (reynolds@smu.edu)
     Donald Willcox (dewillcox@lbl.gov)
-
-  --------------------------------------------------------------------
-  Header file for N_Vector wrap of AMReX 'MultiFab' structure.
-  --------------------------------------------------------------------*/
-
-#ifndef AMREX_NVECTOR_MULTIFAB_H
-#define AMREX_NVECTOR_MULTIFAB_H
+  ----------------------------------------------------------------------------*/
+#ifndef AMREX_NVECTOR_MULTIFAB_H_
+#define AMREX_NVECTOR_MULTIFAB_H_
 
 #include <AMReX_Array.H>
 #include <AMReX_Geometry.H>

--- a/Src/Extern/SUNDIALS/AMReX_NVector_MultiFab.H
+++ b/Src/Extern/SUNDIALS/AMReX_NVector_MultiFab.H
@@ -16,10 +16,11 @@
 #ifndef AMREX_NVECTOR_MULTIFAB_H
 #define AMREX_NVECTOR_MULTIFAB_H
 
+#include <AMReX_Array.H>
 #include <AMReX_Geometry.H>
 #include <AMReX_MultiFab.H>
 #include <AMReX_MultiFabUtil.H>
-#include <AMReX_Array.H>
+#include <AMReX_Sundials.H>
 
 #include <sundials/sundials_nvector.h>
 #include <cstdio>
@@ -46,14 +47,17 @@ typedef struct N_VectorContent_MultiFab_notptr *N_VectorContent_MultiFab;
  * Exported functions
  * -----------------------------------------------------------------*/
 
-N_Vector N_VNewEmpty_MultiFab(sunindextype vec_length);
+N_Vector N_VNewEmpty_MultiFab(sunindextype vec_length,
+                              int i = amrex::OpenMP::get_thread_num());
 N_Vector N_VNew_MultiFab(sunindextype vec_length,
                          const amrex::BoxArray &ba,
                          const amrex::DistributionMapping &dm,
                          sunindextype nComp,
-                         sunindextype nGhost);
+                         sunindextype nGhost,
+                         int i = amrex::OpenMP::get_thread_num());
 N_Vector N_VMake_MultiFab(sunindextype vec_length,
-                          amrex::MultiFab *mf);
+                          amrex::MultiFab *mf,
+                          int i = amrex::OpenMP::get_thread_num());
 sunindextype N_VGetLength_MultiFab(N_Vector v);
 int N_VGetOwnMF_MultiFab(N_Vector v);
 void N_VSetOwnMF_MultiFab(N_Vector v, int own_mf);

--- a/Src/Extern/SUNDIALS/AMReX_NVector_MultiFab.cpp
+++ b/Src/Extern/SUNDIALS/AMReX_NVector_MultiFab.cpp
@@ -1,20 +1,14 @@
-/*--------------------------------------------------------------------
-  Time Integration and Nonlinear Solvers
-  Hands-on Lessons with SUNDIALS + AMReX
-  2019 Argonne Training Program in Extreme-Scale Computing
+/*------------------------------------------------------------------------------
+  Implementation file for N_Vector wrap of an AMReX 'MultiFab'. Based on example
+  codes for the 2019 Argonne Training Program in Extreme-Scale Computing with
+  SUNDIALS and AMReX.
 
   Authors (alphabetical):
-     David Gardner (gardner48@llnl.gov)
-     John Loffeld (loffeld1@llnl.gov)
-     Daniel Reynolds (reynolds@smu.edu)
-     Donald Willcox (dewillcox@lbl.gov)
-
-  --------------------------------------------------------------------
-  Implementation file for N_Vector wrap of AMReX 'MultiFab' structure.
-  --------------------------------------------------------------------*/
-
-#include <sundials/sundials_math.h>
-
+    David Gardner (gardner48@llnl.gov)
+    John Loffeld (loffeld1@llnl.gov)
+    Daniel Reynolds (reynolds@smu.edu)
+    Donald Willcox (dewillcox@lbl.gov)
+  ----------------------------------------------------------------------------*/
 #include "AMReX_NVector_MultiFab.H"
 
 namespace amrex {
@@ -594,7 +588,7 @@ int N_VConstrMask_MultiFab(N_Vector a_a, N_Vector a_x, N_Vector a_m)
                     int test = (amrex::Math::abs(a) > amrex::Real(1.5) && x*a <= amrex::Real(0.0)) ||
                         (amrex::Math::abs(a) > amrex::Real(0.5)   && x*a <  amrex::Real(0.0));
                     if (test) {
-                        m_fab(i,j,k,c) = amrex::Real(1.0);
+                      m_fab(i,j,k,c) = amrex::Real(1.0);
                     }
                 }
             });
@@ -632,7 +626,7 @@ amrex::Real N_VMinQuotient_MultiFab(N_Vector a_num, N_Vector a_denom)
                      {
                         amrex::Real num = num_fab(i,j,k,c);
                         amrex::Real denom = denom_fab(i,j,k,c);
-                        min_loc = SUNMIN(min_loc, num / denom);
+                        min_loc = std::min(min_loc, num / denom);
                      }
                   }
                }

--- a/Src/Extern/SUNDIALS/AMReX_NVector_MultiFab.cpp
+++ b/Src/Extern/SUNDIALS/AMReX_NVector_MultiFab.cpp
@@ -31,78 +31,49 @@ namespace sundials {
  * Function to create a new empty multifab vector
  */
 
-N_Vector N_VNewEmpty_MultiFab(sunindextype length)
+N_Vector N_VNewEmpty_MultiFab(sunindextype length, int i)
 {
-    N_Vector v;
-    N_Vector_Ops ops;
-    N_VectorContent_MultiFab content;
-
     /* Create vector */
-    v = NULL;
-    v = (N_Vector) malloc(sizeof *v);
+    N_Vector v = N_VNewEmpty(*The_Sundials_Context(i));
     if (v == NULL) return(NULL);
 
-    /* Create vector operation structure */
-    ops = NULL;
-    ops = (N_Vector_Ops) malloc(sizeof *ops);
-    if (ops == NULL) { free(v); return(NULL); }
-
-    ops->nvgetvectorid     = NULL;
-    ops->nvclone           = N_VClone_MultiFab;
-    ops->nvcloneempty      = N_VCloneEmpty_MultiFab;
-    ops->nvdestroy         = N_VDestroy_MultiFab;
-    ops->nvspace           = N_VSpace_MultiFab;
-    ops->nvgetarraypointer = NULL;
-    ops->nvsetarraypointer = NULL;
-    ops->nvgetlength       = N_VGetLength_MultiFab;
+    v->ops->nvclone      = N_VClone_MultiFab;
+    v->ops->nvcloneempty = N_VCloneEmpty_MultiFab;
+    v->ops->nvdestroy    = N_VDestroy_MultiFab;
+    v->ops->nvspace      = N_VSpace_MultiFab;
+    v->ops->nvgetlength  = N_VGetLength_MultiFab;
 
     /* standard vector operations */
-    ops->nvlinearsum    = N_VLinearSum_MultiFab;
-    ops->nvconst        = N_VConst_MultiFab;
-    ops->nvprod         = N_VProd_MultiFab;
-    ops->nvdiv          = N_VDiv_MultiFab;
-    ops->nvscale        = N_VScale_MultiFab;
-    ops->nvabs          = N_VAbs_MultiFab;
-    ops->nvinv          = N_VInv_MultiFab;
-    ops->nvaddconst     = N_VAddConst_MultiFab;
-    ops->nvdotprod      = N_VDotProd_MultiFab;
-    ops->nvmaxnorm      = N_VMaxNorm_MultiFab;
-    ops->nvwrmsnormmask = N_VWrmsNormMask_MultiFab;
-    ops->nvwrmsnorm     = N_VWrmsNorm_MultiFab;
-    ops->nvmin          = N_VMin_MultiFab;
-    ops->nvwl2norm      = N_VWL2Norm_MultiFab;
-    ops->nvl1norm       = N_VL1Norm_MultiFab;
-    ops->nvcompare      = N_VCompare_MultiFab;
-    ops->nvinvtest      = N_VInvTest_MultiFab;
-    ops->nvconstrmask   = N_VConstrMask_MultiFab;
-    ops->nvminquotient  = N_VMinQuotient_MultiFab;
-
-    /* fused vector operations (optional, NULL means disabled by default) */
-    ops->nvlinearcombination = NULL;
-    ops->nvscaleaddmulti     = NULL;
-    ops->nvdotprodmulti      = NULL;
-
-    /* vector array operations (optional, NULL means disabled by default) */
-    ops->nvlinearsumvectorarray         = NULL;
-    ops->nvscalevectorarray             = NULL;
-    ops->nvconstvectorarray             = NULL;
-    ops->nvwrmsnormvectorarray          = NULL;
-    ops->nvwrmsnormmaskvectorarray      = NULL;
-    ops->nvscaleaddmultivectorarray     = NULL;
-    ops->nvlinearcombinationvectorarray = NULL;
+    v->ops->nvlinearsum    = N_VLinearSum_MultiFab;
+    v->ops->nvconst        = N_VConst_MultiFab;
+    v->ops->nvprod         = N_VProd_MultiFab;
+    v->ops->nvdiv          = N_VDiv_MultiFab;
+    v->ops->nvscale        = N_VScale_MultiFab;
+    v->ops->nvabs          = N_VAbs_MultiFab;
+    v->ops->nvinv          = N_VInv_MultiFab;
+    v->ops->nvaddconst     = N_VAddConst_MultiFab;
+    v->ops->nvdotprod      = N_VDotProd_MultiFab;
+    v->ops->nvmaxnorm      = N_VMaxNorm_MultiFab;
+    v->ops->nvwrmsnormmask = N_VWrmsNormMask_MultiFab;
+    v->ops->nvwrmsnorm     = N_VWrmsNorm_MultiFab;
+    v->ops->nvmin          = N_VMin_MultiFab;
+    v->ops->nvwl2norm      = N_VWL2Norm_MultiFab;
+    v->ops->nvl1norm       = N_VL1Norm_MultiFab;
+    v->ops->nvcompare      = N_VCompare_MultiFab;
+    v->ops->nvinvtest      = N_VInvTest_MultiFab;
+    v->ops->nvconstrmask   = N_VConstrMask_MultiFab;
+    v->ops->nvminquotient  = N_VMinQuotient_MultiFab;
 
     /* Create content */
-    content = NULL;
-    content = (N_VectorContent_MultiFab) malloc(sizeof *content);
-    if (content == NULL) { free(ops); free(v); return(NULL); }
+    N_VectorContent_MultiFab content = (N_VectorContent_MultiFab) malloc(sizeof *content);
+    if (content == NULL) { N_VFreeEmpty(v); return(NULL); }
 
     content->length = length;
     content->own_mf = SUNFALSE;
     content->mf     = NULL;
 
-    /* Attach content and ops */
+    /* Attach content */
     v->content = content;
-    v->ops     = ops;
 
     return(v);
 }
@@ -112,15 +83,13 @@ N_Vector N_VNewEmpty_MultiFab(sunindextype length)
  */
 
 N_Vector N_VNew_MultiFab(sunindextype length,
-                            const amrex::BoxArray &ba,
-                            const amrex::DistributionMapping &dm,
-                            sunindextype nComp,
-                            sunindextype nGhost)
+                         const amrex::BoxArray &ba,
+                         const amrex::DistributionMapping &dm,
+                         sunindextype nComp,
+                         sunindextype nGhost,
+                         int i)
 {
-    N_Vector v;
-
-    v = NULL;
-    v = N_VNewEmpty_MultiFab(length);
+    N_Vector v = N_VNewEmpty_MultiFab(length, i);
     if (v == NULL) return(NULL);
 
     // Create and attach new MultiFab
@@ -138,12 +107,9 @@ N_Vector N_VNew_MultiFab(sunindextype length,
  * Function to create a MultiFab N_Vector with user-specific MultiFab
  */
 
-N_Vector N_VMake_MultiFab(sunindextype length, amrex::MultiFab *v_mf)
+N_Vector N_VMake_MultiFab(sunindextype length, amrex::MultiFab *v_mf, int i)
 {
-    N_Vector v;
-
-    v = NULL;
-    v = N_VNewEmpty_MultiFab(length);
+    N_Vector v = N_VNewEmpty_MultiFab(length, i);
     if (v == NULL) return(NULL);
 
     if (length > 0)
@@ -194,92 +160,33 @@ int N_VGetOwnMF_MultiFab(N_Vector v)
 
 N_Vector N_VCloneEmpty_MultiFab(N_Vector w)
 {
-    N_Vector v;
-    N_Vector_Ops ops;
-    N_VectorContent_MultiFab content;
-
     if (w == NULL) return(NULL);
 
-    /* Create vector */
-    v = NULL;
-    v = (N_Vector) malloc(sizeof *v);
+    /* Create vector and copy operations */
+    N_Vector v = N_VNewEmpty(w->sunctx);
     if (v == NULL) return(NULL);
-
-    /* Create vector operation structure */
-    ops = NULL;
-    ops = (N_Vector_Ops) malloc(sizeof *ops);
-    if (ops == NULL) { free(v); return(NULL); }
-
-    ops->nvgetvectorid     = w->ops->nvgetvectorid;
-    ops->nvclone           = w->ops->nvclone;
-    ops->nvcloneempty      = w->ops->nvcloneempty;
-    ops->nvdestroy         = w->ops->nvdestroy;
-    ops->nvspace           = w->ops->nvspace;
-    ops->nvgetarraypointer = w->ops->nvgetarraypointer;
-    ops->nvsetarraypointer = w->ops->nvsetarraypointer;
-    ops->nvgetlength       = w->ops->nvgetlength;
-
-    /* standard vector operations */
-    ops->nvlinearsum    = w->ops->nvlinearsum;
-    ops->nvconst        = w->ops->nvconst;
-    ops->nvprod         = w->ops->nvprod;
-    ops->nvdiv          = w->ops->nvdiv;
-    ops->nvscale        = w->ops->nvscale;
-    ops->nvabs          = w->ops->nvabs;
-    ops->nvinv          = w->ops->nvinv;
-    ops->nvaddconst     = w->ops->nvaddconst;
-    ops->nvdotprod      = w->ops->nvdotprod;
-    ops->nvmaxnorm      = w->ops->nvmaxnorm;
-    ops->nvwrmsnormmask = w->ops->nvwrmsnormmask;
-    ops->nvwrmsnorm     = w->ops->nvwrmsnorm;
-    ops->nvmin          = w->ops->nvmin;
-    ops->nvwl2norm      = w->ops->nvwl2norm;
-    ops->nvl1norm       = w->ops->nvl1norm;
-    ops->nvcompare      = w->ops->nvcompare;
-    ops->nvinvtest      = w->ops->nvinvtest;
-    ops->nvconstrmask   = w->ops->nvconstrmask;
-    ops->nvminquotient  = w->ops->nvminquotient;
-
-    /* fused vector operations */
-    ops->nvlinearcombination = w->ops->nvlinearcombination;
-    ops->nvscaleaddmulti     = w->ops->nvscaleaddmulti;
-    ops->nvdotprodmulti      = w->ops->nvdotprodmulti;
-
-    /* vector array operations */
-    ops->nvlinearsumvectorarray         = w->ops->nvlinearsumvectorarray;
-    ops->nvscalevectorarray             = w->ops->nvscalevectorarray;
-    ops->nvconstvectorarray             = w->ops->nvconstvectorarray;
-    ops->nvwrmsnormvectorarray          = w->ops->nvwrmsnormvectorarray;
-    ops->nvwrmsnormmaskvectorarray      = w->ops->nvwrmsnormmaskvectorarray;
-    ops->nvscaleaddmultivectorarray     = w->ops->nvscaleaddmultivectorarray;
-    ops->nvlinearcombinationvectorarray = w->ops->nvlinearcombinationvectorarray;
+    N_VCopyOps(w, v);
 
     /* Create content */
-    content = NULL;
-    content = (N_VectorContent_MultiFab) malloc(sizeof *content);
-    if (content == NULL) { free(ops); free(v); return(NULL); }
+    N_VectorContent_MultiFab content = (N_VectorContent_MultiFab) malloc(sizeof *content);
+    if (content == NULL) { N_VFreeEmpty(v); return(NULL); }
 
     content->length = amrex::sundials::N_VGetLength_MultiFab(w);
     content->own_mf = SUNFALSE;
     content->mf     = NULL;
 
-    /* Attach content and ops */
+    /* Attach content */
     v->content = content;
-    v->ops     = ops;
 
     return(v);
 }
 
 N_Vector N_VClone_MultiFab(N_Vector w)
 {
-    N_Vector v;
-    sunindextype length;
-
-    v = NULL;
-    v = N_VCloneEmpty_MultiFab(w);
+    N_Vector v = N_VCloneEmpty_MultiFab(w);
     if (v == NULL) return(NULL);
 
-    length = amrex::sundials::N_VGetLength_MultiFab(w);
+    sunindextype length = amrex::sundials::N_VGetLength_MultiFab(w);
 
     if (length > 0)
     {
@@ -306,9 +213,7 @@ void N_VDestroy_MultiFab(N_Vector v)
          delete amrex::sundials::getMFptr(v);
          amrex::sundials::getMFptr(v) = NULL;
     }
-    free(v->content); v->content = NULL;
-    free(v->ops); v->ops = NULL;
-    free(v); v = NULL;
+    N_VFreeEmpty(v);
 
     return;
 }

--- a/Src/Extern/SUNDIALS/AMReX_NVector_MultiFab.cpp
+++ b/Src/Extern/SUNDIALS/AMReX_NVector_MultiFab.cpp
@@ -31,10 +31,10 @@ namespace sundials {
  * Function to create a new empty multifab vector
  */
 
-N_Vector N_VNewEmpty_MultiFab(sunindextype length, int i)
+N_Vector N_VNewEmpty_MultiFab(sunindextype length, ::sundials::Context* sunctx)
 {
     /* Create vector */
-    N_Vector v = N_VNewEmpty(*The_Sundials_Context(i));
+    N_Vector v = N_VNewEmpty(*sunctx);
     if (v == NULL) return(NULL);
 
     v->ops->nvclone      = N_VClone_MultiFab;
@@ -87,9 +87,9 @@ N_Vector N_VNew_MultiFab(sunindextype length,
                          const amrex::DistributionMapping &dm,
                          sunindextype nComp,
                          sunindextype nGhost,
-                         int i)
+                         ::sundials::Context* sunctx)
 {
-    N_Vector v = N_VNewEmpty_MultiFab(length, i);
+    N_Vector v = N_VNewEmpty_MultiFab(length, sunctx);
     if (v == NULL) return(NULL);
 
     // Create and attach new MultiFab
@@ -107,9 +107,10 @@ N_Vector N_VNew_MultiFab(sunindextype length,
  * Function to create a MultiFab N_Vector with user-specific MultiFab
  */
 
-N_Vector N_VMake_MultiFab(sunindextype length, amrex::MultiFab *v_mf, int i)
+N_Vector N_VMake_MultiFab(sunindextype length, amrex::MultiFab *v_mf,
+                          ::sundials::Context* sunctx)
 {
-    N_Vector v = N_VNewEmpty_MultiFab(length, i);
+    N_Vector v = N_VNewEmpty_MultiFab(length, sunctx);
     if (v == NULL) return(NULL);
 
     if (length > 0)

--- a/Src/Extern/SUNDIALS/AMReX_SUNMemory.H
+++ b/Src/Extern/SUNDIALS/AMReX_SUNMemory.H
@@ -1,6 +1,8 @@
 #ifndef AMREX_SUNMEMORY_H_
 #define AMREX_SUNMEMORY_H_
 
+#include <AMReX_Arena.H>
+#include <AMReX_Sundials_Core.H>
 #include <sundials/sundials_context.h>
 #include <sundials/sundials_memory.h>
 

--- a/Src/Extern/SUNDIALS/AMReX_SUNMemory.cpp
+++ b/Src/Extern/SUNDIALS/AMReX_SUNMemory.cpp
@@ -1,8 +1,6 @@
 #include <AMReX.H>
 #include <AMReX_Gpu.H>
-#include <AMReX_Sundials.H>
 #include <AMReX_SUNMemory.H>
-#include <sundials/sundials_context.h>
 #if defined(AMREX_USE_HIP)
 #include <sunmemory/sunmemory_hip.h>
 #elif defined(AMREX_USE_CUDA)

--- a/Src/Extern/SUNDIALS/AMReX_Sundials.H
+++ b/Src/Extern/SUNDIALS/AMReX_Sundials.H
@@ -2,44 +2,11 @@
 #define AMREX_SUNDIALS_H_
 
 #include <AMReX.H>
-#include <AMReX_Arena.H>
 #include <AMReX_NVector_MultiFab.H>
-static_assert(std::is_same<amrex::Real,realtype>::value, "amrex::Real must be the same as SUNDIALS realtype");
+#include <AMReX_Sundials_Core.H>
 #include <AMReX_SUNMemory.H>
 
-namespace amrex {
-namespace sundials {
-
-/**
- * \brief Initialize the AMReX-SUNDIALS interface.
- *
- * \param[in] nthreads The number of threads that will be used with SUNDIALS.
- *
- * This will create the nthreads SUNDIALS context objects that are needed by
- * the SUNDIALS solver and vector objects. Called by amrex::Initialize.
- */
-
-void Initialize(int nthreads);
-
-/**
- * \brief Cleanup everything allocated for the AMReX-SUNDIALS interface.
- *
- * Called by amrex::Finalize.
- */
-
-void Finalize();
-
-/**
- * \brief Get the i-th SUNDIALS context instance.
- *
- * \param[in] i The index of the SUNDIALS context to return.
- *
- * A SUNDIALS context should not be used concurrently from different threads.
- */
-
-::sundials::Context* The_Sundials_Context(int i = amrex::OpenMP::get_thread_num());
-
-}//sundials
-}//amrex
+static_assert(std::is_same<amrex::Real,realtype>::value,
+              "amrex::Real must be the same as SUNDIALS realtype");
 
 #endif

--- a/Src/Extern/SUNDIALS/AMReX_Sundials_Core.H
+++ b/Src/Extern/SUNDIALS/AMReX_Sundials_Core.H
@@ -1,0 +1,43 @@
+#ifndef AMREX_SUNDIALS_CORE_H_
+#define AMREX_SUNDIALS_CORE_H_
+
+#include <AMReX.H>
+#include <AMReX_OpenMP.H>
+#include <sundials/sundials_context.h>
+
+namespace amrex {
+namespace sundials {
+
+/**
+ * \brief Initialize the AMReX-SUNDIALS interface.
+ *
+ * \param[in] nthreads The number of threads that will be used with SUNDIALS.
+ *
+ * This will create the nthreads SUNDIALS context objects that are needed by
+ * the SUNDIALS solver and vector objects. Called by amrex::Initialize.
+ */
+
+void Initialize(int nthreads);
+
+/**
+ * \brief Cleanup everything allocated for the AMReX-SUNDIALS interface.
+ *
+ * Called by amrex::Finalize.
+ */
+
+void Finalize();
+
+/**
+ * \brief Get the i-th SUNDIALS context instance.
+ *
+ * \param[in] i The index of the SUNDIALS context to return.
+ *
+ * A SUNDIALS context should not be used concurrently from different threads.
+ */
+
+::sundials::Context* The_Sundials_Context(int i = amrex::OpenMP::get_thread_num());
+
+}//sundials
+}//amrex
+
+#endif

--- a/Src/Extern/SUNDIALS/AMReX_Sundials_Core.cpp
+++ b/Src/Extern/SUNDIALS/AMReX_Sundials_Core.cpp
@@ -1,11 +1,14 @@
-#include <AMReX_Sundials.H>
+#include <AMReX_Print.H>
+#include <AMReX_Sundials_Core.H>
+#include <AMReX_SUNMemory.H>
+#include <AMReX_Vector.H>
 
 namespace amrex {
 namespace sundials {
 
 namespace {
-    Vector<int> initialized;
-    Vector<::sundials::Context*> the_sundials_context;
+    amrex::Vector<int> initialized;
+    amrex::Vector<::sundials::Context*> the_sundials_context;
 }
 
 void Initialize(int nthreads)

--- a/Src/Extern/SUNDIALS/CMakeLists.txt
+++ b/Src/Extern/SUNDIALS/CMakeLists.txt
@@ -4,11 +4,12 @@ target_include_directories( amrex
 
 target_sources( amrex
    PRIVATE
-   AMReX_Sundials.H
-   AMReX_Sundials.cpp
    AMReX_NVector_MultiFab.cpp
    AMReX_NVector_MultiFab.H
+   AMReX_Sundials_Core.cpp
+   AMReX_Sundials_Core.H
+   AMReX_Sundials.H
+   AMReX_SundialsIntegrator.H
    AMReX_SUNMemory.cpp
    AMReX_SUNMemory.H
-   AMReX_SundialsIntegrator.H
    )

--- a/Src/Extern/SUNDIALS/Make.package
+++ b/Src/Extern/SUNDIALS/Make.package
@@ -1,10 +1,11 @@
-CEXE_sources += AMReX_SUNMemory.cpp
-CEXE_headers += AMReX_SUNMemory.H
 CEXE_sources += AMReX_NVector_MultiFab.cpp
 CEXE_headers += AMReX_NVector_MultiFab.H
-CEXE_sources += AMReX_Sundials.cpp
+CEXE_sources += AMReX_Sundials_Core.cpp
+CEXE_headers += AMReX_Sundials_Core.H
 CEXE_headers += AMReX_Sundials.H
 CEXE_headers += AMReX_SundialsIntegrator.H
+CEXE_sources += AMReX_SUNMemory.cpp
+CEXE_headers += AMReX_SUNMemory.H
 
 VPATH_LOCATIONS += $(AMREX_HOME)/Src/Extern/SUNDIALS
 INCLUDE_LOCATIONS += $(AMREX_HOME)/Src/Extern/SUNDIALS


### PR DESCRIPTION
## Summary

Update MultiFab NVector wrappers to accept a sundials context object.

## Additional background

Profiling (and in the future error handling) in sundials requires objects to be create with a non-NULL context. This PR updates the MultiFab NVector wrappers with an optional input for the sundials context that defaults to the context created at initialization for the corresponding OpenMP thread.  

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
