### PR TITLE
SYCL: Optimization of small reduction

### DIFF
--- a/Src/Base/AMReX_Reduce.H
+++ b/Src/Base/AMReX_Reduce.H
@@ -671,6 +671,7 @@ public:
         auto hp = reduce_data.hostPtr();
         auto dp = reduce_data.devicePtr();
         auto const& nblocks = reduce_data.nBlocks();
+#if defined(AMREX_USE_SYCL)
         if (reduce_data.maxStreamIndex() == 0 && nblocks[0] <= 4096) {
             const int N = nblocks[0];
             Gpu::PinnedVector<ReduceTuple> tmp(N);
@@ -680,7 +681,9 @@ public:
                 Reduce::detail::for_each_local<0, ReduceTuple, Ps...>(tmp[0], tmp[i]);
             }
             return tmp[0];
-        } else {
+        } else
+#endif
+        {
             int maxblocks = reduce_data.maxBlocks();
 #ifdef AMREX_USE_SYCL
             // device reduce needs local(i.e., shared) memory

--- a/Src/Base/AMReX_Reduce.H
+++ b/Src/Base/AMReX_Reduce.H
@@ -674,13 +674,18 @@ public:
 #if defined(AMREX_USE_SYCL)
         if (reduce_data.maxStreamIndex() == 0 && nblocks[0] <= 4096) {
             const int N = nblocks[0];
-            Gpu::PinnedVector<ReduceTuple> tmp(N);
-            Gpu::dtoh_memcpy_async(tmp.data(), dp, sizeof(ReduceTuple)*N);
-            Gpu::streamSynchronize();
-            for (int i = 1; i < N; ++i) {
-                Reduce::detail::for_each_local<0, ReduceTuple, Ps...>(tmp[0], tmp[i]);
+            if (N == 0) {
+                Reduce::detail::for_each_init<0, ReduceTuple, Ps...>(*hp);
+                return *hp;
+            } else {
+                Gpu::PinnedVector<ReduceTuple> tmp(N);
+                Gpu::dtoh_memcpy_async(tmp.data(), dp, sizeof(ReduceTuple)*N);
+                Gpu::streamSynchronize();
+                for (int i = 1; i < N; ++i) {
+                    Reduce::detail::for_each_local<0, ReduceTuple, Ps...>(tmp[0], tmp[i]);
+                }
+                return tmp[0];
             }
-            return tmp[0];
         } else
 #endif
         {

--- a/Src/Base/AMReX_Reduce.H
+++ b/Src/Base/AMReX_Reduce.H
@@ -103,7 +103,7 @@ struct ReduceOpSum
 #endif
 
     template <typename T>
-    AMREX_GPU_DEVICE AMREX_FORCE_INLINE
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     void local_update (T& d, T const& s) const noexcept { d += s; }
 
     template <typename T>
@@ -131,7 +131,7 @@ struct ReduceOpMin
 #endif
 
     template <typename T>
-    AMREX_GPU_DEVICE AMREX_FORCE_INLINE
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     void local_update (T& d, T const& s) const noexcept { d = amrex::min(d,s); }
 
     template <typename T>
@@ -164,7 +164,7 @@ struct ReduceOpMax
 #endif
 
     template <typename T>
-    AMREX_GPU_DEVICE AMREX_FORCE_INLINE
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     void local_update (T& d, T const& s) const noexcept { d = amrex::max(d,s); }
 
     template <typename T>
@@ -199,7 +199,7 @@ struct ReduceOpLogicalAnd
 #endif
 
     template <typename T>
-    AMREX_GPU_DEVICE AMREX_FORCE_INLINE
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     std::enable_if_t<std::is_integral<T>::value>
     local_update (T& d, T s) const noexcept { d = d && s; }
 
@@ -231,7 +231,7 @@ struct ReduceOpLogicalOr
 #endif
 
     template <typename T>
-    AMREX_GPU_DEVICE AMREX_FORCE_INLINE
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     std::enable_if_t<std::is_integral<T>::value>
     local_update (T& d, T s) const noexcept { d = d || s; }
 

--- a/Src/Base/AMReX_Reduce.H
+++ b/Src/Base/AMReX_Reduce.H
@@ -254,7 +254,7 @@ public:
     explicit ReduceData (ReduceOps<Ps...>& reduce_op)
         : m_max_blocks(Gpu::Device::maxBlocksPerLaunch()),
           m_host_tuple((Type*)(The_Pinned_Arena()->alloc(sizeof(Type)))),
-          m_device_tuple((Type*)(The_Arena()->alloc((AMREX_GPU_MAX_STREAMS+1)
+          m_device_tuple((Type*)(The_Arena()->alloc((AMREX_GPU_MAX_STREAMS)
                                                     * m_max_blocks * sizeof(Type)))),
           m_fn_value([&reduce_op,this] () -> Type { return this->value(reduce_op); })
     {
@@ -290,21 +290,27 @@ public:
 
     Type* devicePtr () { return m_device_tuple; }
     Type* devicePtr (gpuStream_t const& s) {
-        return m_device_tuple+(Gpu::Device::streamIndex(s)+1)*m_max_blocks;
+        return m_device_tuple+(Gpu::Device::streamIndex(s))*m_max_blocks;
     }
 
     Type* hostPtr () { return m_host_tuple; }
 
-    GpuArray<int,AMREX_GPU_MAX_STREAMS+1>& nBlocks () { return m_nblocks; }
-    int& nBlocks (gpuStream_t const& s) { return m_nblocks[Gpu::Device::streamIndex(s)+1]; }
+    GpuArray<int,AMREX_GPU_MAX_STREAMS>& nBlocks () { return m_nblocks; }
+    int& nBlocks (gpuStream_t const& s) { return m_nblocks[Gpu::Device::streamIndex(s)]; }
 
     int maxBlocks () const { return m_max_blocks; }
 
+    int maxStreamIndex () const { return m_max_stream_index; }
+    void updateMaxStreamIndex (gpuStream_t const& s) {
+        m_max_stream_index = std::max(m_max_stream_index,Gpu::Device::streamIndex(s));
+    }
+
 private:
     int m_max_blocks;
+    int m_max_stream_index = 0;
     Type* m_host_tuple = nullptr;
     Type* m_device_tuple = nullptr;
-    GpuArray<int,AMREX_GPU_MAX_STREAMS+1> m_nblocks;
+    GpuArray<int,AMREX_GPU_MAX_STREAMS> m_nblocks;
     std::function<Type()> m_fn_value;
 };
 
@@ -375,6 +381,7 @@ public:
             auto pdst = reduce_data.devicePtr(stream);
             int nblocks_ec = std::min(nblocks, reduce_data.maxBlocks());
             reduce_data.nBlocks(stream) = nblocks_ec;
+            reduce_data.updateMaxStreamIndex(stream);
 
 #ifdef AMREX_USE_SYCL
             // device reduce needs local(i.e., shared) memory
@@ -504,6 +511,7 @@ public:
         int nblocks_ec = (ncells + nitems_per_thread*AMREX_GPU_MAX_THREADS-1)
             / (nitems_per_thread*AMREX_GPU_MAX_THREADS);
         nblocks_ec = std::min(nblocks_ec, reduce_data.maxBlocks());
+        reduce_data.updateMaxStreamIndex(stream);
 #ifdef AMREX_USE_SYCL
         // device reduce needs local(i.e., shared) memory
         constexpr std::size_t shared_mem_bytes = sizeof(unsigned long long)*Gpu::Device::warp_size;
@@ -562,6 +570,7 @@ public:
         int nblocks_ec = (ncells + nitems_per_thread*AMREX_GPU_MAX_THREADS-1)
             / (nitems_per_thread*AMREX_GPU_MAX_THREADS);
         nblocks_ec = std::min(nblocks_ec, reduce_data.maxBlocks());
+        reduce_data.updateMaxStreamIndex(stream);
 #ifdef AMREX_USE_SYCL
         // device reduce needs local(i.e., shared) memory
         constexpr std::size_t shared_mem_bytes = sizeof(unsigned long long)*Gpu::Device::warp_size;
@@ -618,6 +627,7 @@ public:
         int nblocks_ec = (n + nitems_per_thread*AMREX_GPU_MAX_THREADS-1)
             / (nitems_per_thread*AMREX_GPU_MAX_THREADS);
         nblocks_ec = std::min(nblocks_ec, reduce_data.maxBlocks());
+        reduce_data.updateMaxStreamIndex(stream);
 #ifdef AMREX_USE_SYCL
         // device reduce needs local(i.e., shared) memory
         constexpr std::size_t shared_mem_bytes = sizeof(unsigned long long)*Gpu::Device::warp_size;
@@ -661,56 +671,67 @@ public:
         auto hp = reduce_data.hostPtr();
         auto dp = reduce_data.devicePtr();
         auto const& nblocks = reduce_data.nBlocks();
-        int maxblocks = reduce_data.maxBlocks();
+        if (reduce_data.maxStreamIndex() == 0 && nblocks[0] <= 4096) {
+            const int N = nblocks[0];
+            Gpu::PinnedVector<ReduceTuple> tmp(N);
+            Gpu::dtoh_memcpy_async(tmp.data(), dp, sizeof(ReduceTuple)*N);
+            Gpu::streamSynchronize();
+            for (int i = 1; i < N; ++i) {
+                Reduce::detail::for_each_local<0, ReduceTuple, Ps...>(tmp[0], tmp[i]);
+            }
+            return tmp[0];
+        } else {
+            int maxblocks = reduce_data.maxBlocks();
 #ifdef AMREX_USE_SYCL
-        // device reduce needs local(i.e., shared) memory
-        constexpr std::size_t shared_mem_bytes = sizeof(unsigned long long)*Gpu::Device::warp_size;
+            // device reduce needs local(i.e., shared) memory
+            constexpr std::size_t shared_mem_bytes = sizeof(unsigned long long)*Gpu::Device::warp_size;
 #ifndef AMREX_NO_SYCL_REDUCE_WORKAROUND
-        // xxxxx SYCL todo: reduce bug workaround
-        Gpu::DeviceVector<ReduceTuple> dtmp(1);
-        auto presult = dtmp.data();
+            // xxxxx SYCL todo: reduce bug workaround
+            Gpu::DeviceVector<ReduceTuple> dtmp(1);
+            auto presult = dtmp.data();
 #else
-        auto presult = hp;
+            auto presult = hp;
 #endif
-        amrex::launch(1, AMREX_GPU_MAX_THREADS, shared_mem_bytes, stream,
-        [=] AMREX_GPU_DEVICE (Gpu::Handler const& gh) noexcept
-        {
-            ReduceTuple r;
-            Reduce::detail::for_each_init<0, ReduceTuple, Ps...>(r);
-            ReduceTuple dst = r;
-            for (int istream = 0, nstreams = nblocks.size(); istream < nstreams; ++istream) {
-                auto dp_stream = dp+istream*maxblocks;
-                for (int i = gh.item->get_global_id(0), stride = gh.item->get_global_range(0);
-                     i < nblocks[istream]; i += stride) {
-                    Reduce::detail::for_each_local<0, ReduceTuple, Ps...>(r, dp_stream[i]);
+            amrex::launch(1, AMREX_GPU_MAX_THREADS, shared_mem_bytes, stream,
+            [=] AMREX_GPU_DEVICE (Gpu::Handler const& gh) noexcept
+            {
+                ReduceTuple r;
+                Reduce::detail::for_each_init<0, ReduceTuple, Ps...>(r);
+                ReduceTuple dst = r;
+                for (int istream = 0, nstreams = nblocks.size(); istream < nstreams; ++istream) {
+                    auto dp_stream = dp+istream*maxblocks;
+                    for (int i = gh.item->get_global_id(0), stride = gh.item->get_global_range(0);
+                         i < nblocks[istream]; i += stride) {
+                        Reduce::detail::for_each_local<0, ReduceTuple, Ps...>(r, dp_stream[i]);
+                    }
                 }
-            }
-            Reduce::detail::for_each_parallel<0, ReduceTuple, Ps...>(dst, r, gh);
-            if (gh.threadIdx() == 0) { *presult = dst; }
-        });
+                Reduce::detail::for_each_parallel<0, ReduceTuple, Ps...>(dst, r, gh);
+                if (gh.threadIdx() == 0) { *presult = dst; }
+            });
 #ifndef AMREX_NO_SYCL_REDUCE_WORKAROUND
-        Gpu::dtoh_memcpy_async(hp, dtmp.data(), sizeof(ReduceTuple));
+            Gpu::dtoh_memcpy_async(hp, dtmp.data(), sizeof(ReduceTuple));
 #endif
 #else
-        amrex::launch(1, AMREX_GPU_MAX_THREADS, 0, stream,
-        [=] AMREX_GPU_DEVICE () noexcept
-        {
-            ReduceTuple r;
-            Reduce::detail::for_each_init<0, ReduceTuple, Ps...>(r);
-            ReduceTuple dst = r;
-            for (int istream = 0, nstreams = nblocks.size(); istream < nstreams; ++istream) {
-                auto dp_stream = dp+istream*maxblocks;
-                for (int i = blockDim.x*blockIdx.x+threadIdx.x, stride = blockDim.x*gridDim.x;
-                     i < nblocks[istream]; i += stride) {
-                    Reduce::detail::for_each_local<0, ReduceTuple, Ps...>(r, dp_stream[i]);
+            amrex::launch(1, AMREX_GPU_MAX_THREADS, 0, stream,
+            [=] AMREX_GPU_DEVICE () noexcept
+            {
+                ReduceTuple r;
+                Reduce::detail::for_each_init<0, ReduceTuple, Ps...>(r);
+                ReduceTuple dst = r;
+                for (int istream = 0, nstreams = nblocks.size(); istream < nstreams; ++istream) {
+                    auto dp_stream = dp+istream*maxblocks;
+                    for (int i = blockDim.x*blockIdx.x+threadIdx.x, stride = blockDim.x*gridDim.x;
+                         i < nblocks[istream]; i += stride) {
+                        Reduce::detail::for_each_local<0, ReduceTuple, Ps...>(r, dp_stream[i]);
+                    }
                 }
-            }
-            Reduce::detail::for_each_parallel<0, ReduceTuple, Ps...>(dst, r);
-            if (threadIdx.x == 0) { *hp = dst; }
-        });
+                Reduce::detail::for_each_parallel<0, ReduceTuple, Ps...>(dst, r);
+                if (threadIdx.x == 0) { *hp = dst; }
+            });
 #endif
-        Gpu::streamSynchronize();
-        return *hp;
+            Gpu::streamSynchronize();
+            return *hp;
+        }
     }
 };
 


### PR DESCRIPTION
For small reductions, it's faster to do the second pass on CPU.  The change is for SYCL only.