### PR TITLE
Fix race condition with TinyProfiler for memory

### DIFF
--- a/Src/Base/AMReX.cpp
+++ b/Src/Base/AMReX.cpp
@@ -677,8 +677,6 @@ amrex::Finalize (amrex::AMReX* pamrex)
     amrex::DeallocateRandomSeedDevArray();
 #endif
 
-    BL_TINY_PROFILE_MEMORYFINALIZE();
-
 #ifdef BL_LAZY
     Lazy::Finalize();
 #endif
@@ -733,6 +731,8 @@ amrex::Finalize (amrex::AMReX* pamrex)
 #ifdef AMREX_USE_SUNDIALS
     sundials::Finalize();
 #endif
+
+    BL_TINY_PROFILE_MEMORYFINALIZE();
 
     amrex_mempool_finalize();
     Arena::Finalize();

--- a/Src/Base/AMReX_Arena.H
+++ b/Src/Base/AMReX_Arena.H
@@ -123,6 +123,12 @@ public:
     virtual bool hasFreeDeviceMemory (std::size_t sz);
 
     /**
+     * \brief Add this Arena to the list of Arenas that are profiled by TinyProfiler.
+     * \param memory_name The name of this arena in the TinyProfiler output.
+     */
+    virtual void registerForProfiling (const std::string& memory_name);
+
+    /**
     * \brief Given a minimum required arena size of sz bytes, this returns
     * the next largest arena size that will align to align_size bytes
     */

--- a/Src/Base/AMReX_CArena.H
+++ b/Src/Base/AMReX_CArena.H
@@ -173,7 +173,7 @@ protected:
     //! The amount of memory given out via alloc().
     std::size_t m_actually_used;
     //! If this arena is profiled by TinyProfiler
-    bool m_do_profiling;
+    bool m_do_profiling = false;
     //! Data structure used for profiling with TinyProfiler
     std::map<std::string, MemStat> m_profiling_stats;
 

--- a/Src/Base/AMReX_CArena.H
+++ b/Src/Base/AMReX_CArena.H
@@ -7,6 +7,7 @@
 #include <cstddef>
 #include <set>
 #include <vector>
+#include <map>
 #include <mutex>
 #include <unordered_set>
 #include <functional>

--- a/Src/Base/AMReX_CArena.H
+++ b/Src/Base/AMReX_CArena.H
@@ -60,6 +60,12 @@ public:
      */
     virtual bool hasFreeDeviceMemory (std::size_t sz) override;
 
+    /**
+     * \brief Add this Arena to the list of Arenas that are profiled by TinyProfiler.
+     * \param memory_name The name of this arena in the TinyProfiler output.
+     */
+    virtual void registerForProfiling (const std::string& memory_name) override;
+
     //! The current amount of heap space used by the CArena object.
     std::size_t heap_space_used () const noexcept;
 
@@ -165,6 +171,11 @@ protected:
     std::size_t m_used;
     //! The amount of memory given out via alloc().
     std::size_t m_actually_used;
+    //! If this arena is profiled by TinyProfiler
+    bool m_do_profiling;
+    //! Data structure used for profiling with TinyProfiler
+    std::map<std::string, MemStat> m_profiling_stats;
+
 
     std::mutex carena_mutex;
 };

--- a/Src/Base/AMReX_CArena.cpp
+++ b/Src/Base/AMReX_CArena.cpp
@@ -47,14 +47,8 @@ CArena::alloc (std::size_t nbytes)
 
     MemStat* stat = nullptr;
 #ifdef AMREX_TINY_PROFILING
-    if (isDevice()) {
-        stat = TinyProfiler::memory_alloc(nbytes, MemStat::device);
-    } else if (isManaged()) {
-        stat = TinyProfiler::memory_alloc(nbytes, MemStat::managed);
-    } else if (isPinned()) {
-        stat = TinyProfiler::memory_alloc(nbytes, MemStat::pinned);
-    } else {
-        stat = TinyProfiler::memory_alloc(nbytes, MemStat::cpu);
+    if (m_do_profiling) {
+        stat = TinyProfiler::memory_alloc(nbytes, m_profiling_stats);
     }
 #endif
 
@@ -292,6 +286,15 @@ CArena::hasFreeDeviceMemory (std::size_t sz)
         amrex::ignore_unused(sz);
         return true;
     }
+}
+
+void
+CArena::registerForProfiling (const std::string& memory_name)
+{
+#ifdef AMREX_TINY_PROFILING
+    m_do_profiling = true;
+    TinyProfiler::RegisterArena(memory_name, m_profiling_stats);
+#endif
 }
 
 std::size_t

--- a/Src/Base/AMReX_CArena.cpp
+++ b/Src/Base/AMReX_CArena.cpp
@@ -289,7 +289,7 @@ CArena::hasFreeDeviceMemory (std::size_t sz)
 }
 
 void
-CArena::registerForProfiling (const std::string& memory_name)
+CArena::registerForProfiling ([[maybe_unused]] const std::string& memory_name)
 {
 #ifdef AMREX_TINY_PROFILING
     m_do_profiling = true;

--- a/Src/Base/AMReX_CArena.cpp
+++ b/Src/Base/AMReX_CArena.cpp
@@ -36,6 +36,12 @@ CArena::~CArena ()
     for (unsigned int i = 0, N = m_alloc.size(); i < N; i++) {
         deallocate_system(m_alloc[i].first, m_alloc[i].second);
     }
+
+#ifdef AMREX_TINY_PROFILING
+    if (m_do_profiling) {
+        TinyProfiler::DeregisterArena(m_profiling_stats);
+    }
+#endif
 }
 
 void*

--- a/Src/Base/AMReX_TinyProfiler.H
+++ b/Src/Base/AMReX_TinyProfiler.H
@@ -25,21 +25,8 @@
 
 namespace amrex {
 
-class CArena;
-
 struct MemStat
 {
-    enum memory_type {
-        device = 0,
-        managed = 1,
-        pinned = 2,
-        cpu = 3,
-    };
-
-    static constexpr std::array<const char *, 4> memory_name = {
-        "Device", "Managed", "Pinned", "Cpu (amrex_mempool)"
-    };
-
     Long nalloc = 0;        //!< number of allocations
     Long nfree = 0;         //!< number of frees
     Long currentmem = 0;    //!< amount of currently used memory in bytes
@@ -67,7 +54,8 @@ public:
     void memory_start () const noexcept;
     void memory_stop () const noexcept;
 
-    static MemStat* memory_alloc (std::size_t nbytes, int memtype) noexcept;
+    static MemStat* memory_alloc (std::size_t nbytes,
+                                  std::map<std::string, MemStat>& memstats) noexcept;
     static void memory_free (std::size_t nbytes, MemStat* stat) noexcept;
 
     static void Initialize () noexcept;
@@ -75,6 +63,9 @@ public:
 
     static void MemoryInitialize () noexcept;
     static void MemoryFinalize (bool bFlushing = false) noexcept;
+
+    static void RegisterArena (const std::string& memory_name,
+                               std::map<std::string, MemStat>& memstats) noexcept;
 
     static void StartRegion (std::string regname) noexcept;
     static void StopRegion (const std::string& regname) noexcept;
@@ -150,7 +141,8 @@ private:
 
     static std::vector<aligned_deque> mem_stack_thread_private;
 #endif
-    static std::array<std::map<std::string, MemStat>, 4> mem_statsmap;
+    static std::vector<std::map<std::string, MemStat>*> all_memstats;
+    static std::vector<std::string> all_memnames;
 
     static std::vector<std::string> regionstack;
     static std::deque<std::tuple<double,double,std::string*> > ttstack;

--- a/Src/Base/AMReX_TinyProfiler.H
+++ b/Src/Base/AMReX_TinyProfiler.H
@@ -67,6 +67,8 @@ public:
     static void RegisterArena (const std::string& memory_name,
                                std::map<std::string, MemStat>& memstats) noexcept;
 
+    static void DeregisterArena (std::map<std::string, MemStat>& memstats) noexcept;
+
     static void StartRegion (std::string regname) noexcept;
     static void StopRegion (const std::string& regname) noexcept;
 

--- a/Src/Base/AMReX_TinyProfiler.cpp
+++ b/Src/Base/AMReX_TinyProfiler.cpp
@@ -349,7 +349,7 @@ TinyProfiler::memory_stop () const noexcept {
 
 MemStat*
 TinyProfiler::memory_alloc (std::size_t nbytes, std::map<std::string, MemStat>& memstats) noexcept {
-    // this function is not thread save for the same memstats
+    // this function is not thread safe for the same memstats
     // the caller of this function (CArena::alloc) has a mutex
     MemStat* stat = nullptr;
 #ifdef AMREX_USE_OMP
@@ -375,7 +375,7 @@ TinyProfiler::memory_alloc (std::size_t nbytes, std::map<std::string, MemStat>& 
 
 void
 TinyProfiler::memory_free (std::size_t nbytes, MemStat* stat) noexcept {
-    // this function is not thread save for the same stat
+    // this function is not thread safe for the same stat
     // the caller of this function (CArena::free) has a mutex
     if (stat) {
         ++stat->nfree;
@@ -507,6 +507,17 @@ TinyProfiler::RegisterArena (const std::string& memory_name,
 {
     all_memstats.push_back(&memstats);
     all_memnames.push_back(memory_name);
+}
+
+void
+TinyProfiler::DeregisterArena (std::map<std::string, MemStat>& memstats) noexcept
+{
+    for (std::size_t i = 0; i < all_memstats.size(); ++i) {
+        if (all_memstats[i] == &memstats) {
+            all_memstats.erase(all_memstats.begin() + i);
+            all_memnames.erase(all_memnames.begin() + i);
+        }
+    }
 }
 
 void

--- a/Src/Base/AMReX_TinyProfiler.cpp
+++ b/Src/Base/AMReX_TinyProfiler.cpp
@@ -512,10 +512,12 @@ TinyProfiler::RegisterArena (const std::string& memory_name,
 void
 TinyProfiler::DeregisterArena (std::map<std::string, MemStat>& memstats) noexcept
 {
-    for (std::size_t i = 0; i < all_memstats.size(); ++i) {
+    for (std::size_t i = 0; i < all_memstats.size();) {
         if (all_memstats[i] == &memstats) {
             all_memstats.erase(all_memstats.begin() + i);
             all_memnames.erase(all_memnames.begin() + i);
+        } else {
+            ++i;
         }
     }
 }


### PR DESCRIPTION
## Summary

Fix #3156 by giving every Arena its own map for profiling.  

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
