### PR TITLE
CMake: Parallel HDF5 Detection

### DIFF
--- a/Tools/CMake/AMReXThirdPartyLibraries.cmake
+++ b/Tools/CMake/AMReXThirdPartyLibraries.cmake
@@ -9,8 +9,9 @@ if (AMReX_HDF5)
 
     if (AMReX_MPI AND (NOT HDF5_IS_PARALLEL))
        if (CMAKE_VERSION VERSION_LESS 3.27)
-	  # The detection in earlier versions of cmake may not be reliable.
-          # So we will try to do it ourselves.
+	      # The detection in earlier versions of cmake may not be reliable.
+          # So we will try to do it ourselves. Work-around for:
+          # https://gitlab.kitware.com/cmake/cmake/-/merge_requests/8234
           execute_process(
              COMMAND ${HDF5_C_COMPILER_EXECUTABLE} -showconfig
              OUTPUT_VARIABLE amrex_hdf5_config_output

--- a/Tools/CMake/AMReXThirdPartyLibraries.cmake
+++ b/Tools/CMake/AMReXThirdPartyLibraries.cmake
@@ -6,9 +6,29 @@ if (AMReX_HDF5)
        set(HDF5_PREFER_PARALLEL TRUE)
     endif ()
     find_package(HDF5 1.10.4 REQUIRED)
+
     if (AMReX_MPI AND (NOT HDF5_IS_PARALLEL))
-       message(FATAL_ERROR "\nHDF5 library does not support parallel I/O")
+       if (CMAKE_VERSION VERSION_LESS 3.27)
+	  # The detection in earlier versions of cmake may not be reliable.
+          # So we will try to do it ourselves.
+          execute_process(
+             COMMAND ${HDF5_C_COMPILER_EXECUTABLE} -showconfig
+             OUTPUT_VARIABLE amrex_hdf5_config_output
+             ERROR_VARIABLE amrex_hdf5_config_output
+             OUTPUT_STRIP_TRAILING_WHITESPACE
+             )
+          if (amrex_hdf5_config_output MATCHES "Parallel HDF5: ([A-Za-z0-9]+)")
+             if (${CMAKE_MATCH_1})
+                set(HDF5_IS_PARALLEL TRUE)
+             endif ()
+          endif()
+          unset(amrex_hdf5_config_output)
+       endif ()
+       if (NOT HDF5_IS_PARALLEL)
+          message(FATAL_ERROR "\nHDF5 library does not support parallel I/O")
+       endif ()
     endif ()
+
     if (HDF5_IS_PARALLEL AND (NOT AMReX_MPI))
        message(FATAL_ERROR "\nMPI enabled in HDF5 but not in AMReX, which will likely fail to build")
     endif ()


### PR DESCRIPTION
## Summary

It turns out the words in the settings summary of HDF5 came from the words used when HDF5 was configured with CMake.  The issue is `h5pcc -showconfig` may show `Parallel HDF5: ON`, but the current versions of CMake uses `Parallel HDF5: yes` to detect Parallel HDF5.  This commit adds a more reliable way of detecting Parallel HDF5.

## Additional background

- https://github.com/spack/spack/issues/35546
- https://github.com/HDFGroup/hdf5/issues/2488
- https://gitlab.kitware.com/cmake/cmake/-/merge_requests/8234

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
