### PR TITLE
Add Make.local-pre to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,4 @@ Tutorials/EB/Donut/Exec/ls_plt*
 
 # local config
 Tools/GNUMake/Make.local
+Tools/GNUMake/Make.local-pre


### PR DESCRIPTION
## Summary
(Pretty much in the title)

## Additional background
Given that `Make.local` files are in the `.gitignore`, this should probably be there too.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
