### PR TITLE
SYCL: Group and subgroup size

### DIFF
--- a/Src/Base/AMReX_GpuLaunchFunctsG.H
+++ b/Src/Base/AMReX_GpuLaunchFunctsG.H
@@ -34,7 +34,7 @@ void launch (int nblocks, int nthreads_per_block, std::size_t shared_mem_bytes,
             h.parallel_for(sycl::nd_range<1>(sycl::range<1>(nthreads_total),
                                              sycl::range<1>(nthreads_per_block)),
             [=] (sycl::nd_item<1> item)
-            AMREX_REQUIRE_SUBGROUP_SIZE(Gpu::Device::warp_size)
+            [[sycl::reqd_sub_group_size(Gpu::Device::warp_size)]]
             {
                 f(Gpu::Handler{&item,shared_data.get_pointer()});
             });
@@ -54,7 +54,7 @@ void launch (int nblocks, int nthreads_per_block, gpuStream_t stream, L&& f) noe
             h.parallel_for(sycl::nd_range<1>(sycl::range<1>(nthreads_total),
                                              sycl::range<1>(nthreads_per_block)),
             [=] (sycl::nd_item<1> item)
-            AMREX_REQUIRE_SUBGROUP_SIZE(Gpu::Device::warp_size)
+            [[sycl::reqd_sub_group_size(Gpu::Device::warp_size)]]
             {
                 f(item);
             });
@@ -68,13 +68,47 @@ template <int MT, typename L>
 void launch (int nblocks, std::size_t shared_mem_bytes, gpuStream_t stream,
              L&& f) noexcept
 {
-    launch(nblocks, MT, shared_mem_bytes, stream, std::forward<L>(f));
+    int nthreads_total = MT * nblocks;
+    std::size_t shared_mem_numull = (shared_mem_bytes+sizeof(unsigned long long)-1)
+        / sizeof(unsigned long long);
+    auto& q = *(stream.queue);
+    try {
+        q.submit([&] (sycl::handler& h) {
+            sycl::local_accessor<unsigned long long>
+                shared_data(sycl::range<1>(shared_mem_numull), h);
+            h.parallel_for(sycl::nd_range<1>(sycl::range<1>(nthreads_total),
+                                             sycl::range<1>(MT)),
+            [=] (sycl::nd_item<1> item)
+            [[sycl::reqd_work_group_size(1,1,MT)]]
+            [[sycl::reqd_sub_group_size(Gpu::Device::warp_size)]]
+            {
+                f(Gpu::Handler{&item,shared_data.get_pointer()});
+            });
+        });
+    } catch (sycl::exception const& ex) {
+        amrex::Abort(std::string("launch: ")+ex.what()+"!!!!!");
+    }
 }
 
 template <int MT, typename L>
 void launch (int nblocks, gpuStream_t stream, L&& f) noexcept
 {
-    launch(nblocks, MT, stream, std::forward<L>(f));
+    int nthreads_total = MT * nblocks;
+    auto& q = *(stream.queue);
+    try {
+        q.submit([&] (sycl::handler& h) {
+            h.parallel_for(sycl::nd_range<1>(sycl::range<1>(nthreads_total),
+                                             sycl::range<1>(MT)),
+            [=] (sycl::nd_item<1> item)
+            [[sycl::reqd_work_group_size(1,1,MT)]]
+            [[sycl::reqd_sub_group_size(Gpu::Device::warp_size)]]
+            {
+                f(item);
+            });
+        });
+    } catch (sycl::exception const& ex) {
+        amrex::Abort(std::string("launch: ")+ex.what()+"!!!!!");
+    }
 }
 
 template<int MT, typename T, typename L>
@@ -90,7 +124,8 @@ void launch (T const& n, L&& f) noexcept
             h.parallel_for(sycl::nd_range<1>(sycl::range<1>(nthreads_total),
                                              sycl::range<1>(nthreads_per_block)),
             [=] (sycl::nd_item<1> item)
-            AMREX_REQUIRE_SUBGROUP_SIZE(Gpu::Device::warp_size)
+            [[sycl::reqd_work_group_size(1,1,MT)]]
+            [[sycl::reqd_sub_group_size(Gpu::Device::warp_size)]]
             {
                 for (auto const i : Gpu::Range(n,item.get_global_id(0),item.get_global_range(0))) {
                     f(i);
@@ -168,7 +203,8 @@ void ParallelFor (Gpu::KernelInfo const& info, T n, L&& f) noexcept
                 h.parallel_for(sycl::nd_range<1>(sycl::range<1>(nthreads_total),
                                                  sycl::range<1>(nthreads_per_block)),
                 [=] (sycl::nd_item<1> item)
-                AMREX_REQUIRE_SUBGROUP_SIZE(Gpu::Device::warp_size)
+                [[sycl::reqd_work_group_size(1,1,MT)]]
+                [[sycl::reqd_sub_group_size(Gpu::Device::warp_size)]]
                 {
                     for (T i = item.get_global_id(0), stride = item.get_global_range(0);
                          i < n; i += stride) {
@@ -184,7 +220,8 @@ void ParallelFor (Gpu::KernelInfo const& info, T n, L&& f) noexcept
                 h.parallel_for(sycl::nd_range<1>(sycl::range<1>(nthreads_total),
                                                  sycl::range<1>(nthreads_per_block)),
                 [=] (sycl::nd_item<1> item)
-                AMREX_REQUIRE_SUBGROUP_SIZE(Gpu::Device::warp_size)
+                [[sycl::reqd_work_group_size(1,1,MT)]]
+                [[sycl::reqd_sub_group_size(Gpu::Device::warp_size)]]
                 {
                     for (T i = item.get_global_id(0), stride = item.get_global_range(0);
                          i < n; i += stride) {
@@ -219,7 +256,8 @@ void ParallelFor (Gpu::KernelInfo const& info, Box const& box, L&& f) noexcept
                 h.parallel_for(sycl::nd_range<1>(sycl::range<1>(nthreads_total),
                                                  sycl::range<1>(nthreads_per_block)),
                 [=] (sycl::nd_item<1> item)
-                AMREX_REQUIRE_SUBGROUP_SIZE(Gpu::Device::warp_size)
+                [[sycl::reqd_work_group_size(1,1,MT)]]
+                [[sycl::reqd_sub_group_size(Gpu::Device::warp_size)]]
                 {
                     for (int icell = item.get_global_id(0), stride = item.get_global_range(0);
                          icell < ncells; icell += stride) {
@@ -241,7 +279,8 @@ void ParallelFor (Gpu::KernelInfo const& info, Box const& box, L&& f) noexcept
                 h.parallel_for(sycl::nd_range<1>(sycl::range<1>(nthreads_total),
                                                  sycl::range<1>(nthreads_per_block)),
                 [=] (sycl::nd_item<1> item)
-                AMREX_REQUIRE_SUBGROUP_SIZE(Gpu::Device::warp_size)
+                [[sycl::reqd_work_group_size(1,1,MT)]]
+                [[sycl::reqd_sub_group_size(Gpu::Device::warp_size)]]
                 {
                     for (int icell = item.get_global_id(0), stride = item.get_global_range(0);
                          icell < ncells; icell += stride) {
@@ -282,7 +321,8 @@ void ParallelFor (Gpu::KernelInfo const& info, Box const& box, T ncomp, L&& f) n
                 h.parallel_for(sycl::nd_range<1>(sycl::range<1>(nthreads_total),
                                                  sycl::range<1>(nthreads_per_block)),
                 [=] (sycl::nd_item<1> item)
-                AMREX_REQUIRE_SUBGROUP_SIZE(Gpu::Device::warp_size)
+                [[sycl::reqd_work_group_size(1,1,MT)]]
+                [[sycl::reqd_sub_group_size(Gpu::Device::warp_size)]]
                 {
                     for (int icell = item.get_global_id(0), stride = item.get_global_range(0);
                          icell < ncells; icell += stride) {
@@ -305,7 +345,8 @@ void ParallelFor (Gpu::KernelInfo const& info, Box const& box, T ncomp, L&& f) n
                 h.parallel_for(sycl::nd_range<1>(sycl::range<1>(nthreads_total),
                                                  sycl::range<1>(nthreads_per_block)),
                 [=] (sycl::nd_item<1> item)
-                AMREX_REQUIRE_SUBGROUP_SIZE(Gpu::Device::warp_size)
+                [[sycl::reqd_work_group_size(1,1,MT)]]
+                [[sycl::reqd_sub_group_size(Gpu::Device::warp_size)]]
                 {
                     for (int icell = item.get_global_id(0), stride = item.get_global_range(0);
                          icell < ncells; icell += stride) {
@@ -340,7 +381,8 @@ void ParallelForRNG (T n, L&& f) noexcept
             h.parallel_for(sycl::nd_range<1>(sycl::range<1>(nthreads_total),
                                              sycl::range<1>(nthreads_per_block)),
             [=] (sycl::nd_item<1> item)
-            AMREX_REQUIRE_SUBGROUP_SIZE(Gpu::Device::warp_size)
+            [[sycl::reqd_work_group_size(1,1,AMREX_GPU_MAX_THREADS)]]
+            [[sycl::reqd_sub_group_size(Gpu::Device::warp_size)]]
             {
                 int tid = item.get_global_id(0);
                 auto engine = engine_acc.load(tid);
@@ -377,7 +419,8 @@ void ParallelForRNG (Box const& box, L&& f) noexcept
             h.parallel_for(sycl::nd_range<1>(sycl::range<1>(nthreads_total),
                                              sycl::range<1>(nthreads_per_block)),
             [=] (sycl::nd_item<1> item)
-            AMREX_REQUIRE_SUBGROUP_SIZE(Gpu::Device::warp_size)
+            [[sycl::reqd_work_group_size(1,1,AMREX_GPU_MAX_THREADS)]]
+            [[sycl::reqd_sub_group_size(Gpu::Device::warp_size)]]
             {
                 int tid = item.get_global_id(0);
                 auto engine = engine_acc.load(tid);
@@ -421,7 +464,8 @@ void ParallelForRNG (Box const& box, T ncomp, L&& f) noexcept
             h.parallel_for(sycl::nd_range<1>(sycl::range<1>(nthreads_total),
                                              sycl::range<1>(nthreads_per_block)),
             [=] (sycl::nd_item<1> item)
-            AMREX_REQUIRE_SUBGROUP_SIZE(Gpu::Device::warp_size)
+            [[sycl::reqd_work_group_size(1,1,AMREX_GPU_MAX_THREADS)]]
+            [[sycl::reqd_sub_group_size(Gpu::Device::warp_size)]]
             {
                 int tid = item.get_global_id(0);
                 auto engine = engine_acc.load(tid);
@@ -471,7 +515,8 @@ void ParallelFor (Gpu::KernelInfo const& /*info*/, Box const& box1, Box const& b
             h.parallel_for(sycl::nd_range<1>(sycl::range<1>(nthreads_total),
                                              sycl::range<1>(nthreads_per_block)),
             [=] (sycl::nd_item<1> item)
-            AMREX_REQUIRE_SUBGROUP_SIZE(Gpu::Device::warp_size)
+            [[sycl::reqd_work_group_size(1,1,MT)]]
+            [[sycl::reqd_sub_group_size(Gpu::Device::warp_size)]]
             {
                 for (int icell = item.get_global_id(0), stride = item.get_global_range(0);
                      icell < ncells; icell += stride) {
@@ -532,7 +577,8 @@ void ParallelFor (Gpu::KernelInfo const& /*info*/,
             h.parallel_for(sycl::nd_range<1>(sycl::range<1>(nthreads_total),
                                              sycl::range<1>(nthreads_per_block)),
             [=] (sycl::nd_item<1> item)
-            AMREX_REQUIRE_SUBGROUP_SIZE(Gpu::Device::warp_size)
+            [[sycl::reqd_work_group_size(1,1,MT)]]
+            [[sycl::reqd_sub_group_size(Gpu::Device::warp_size)]]
             {
                 for (int icell = item.get_global_id(0), stride = item.get_global_range(0);
                      icell < ncells; icell += stride) {
@@ -599,7 +645,8 @@ void ParallelFor (Gpu::KernelInfo const& /*info*/,
             h.parallel_for(sycl::nd_range<1>(sycl::range<1>(nthreads_total),
                                              sycl::range<1>(nthreads_per_block)),
             [=] (sycl::nd_item<1> item)
-            AMREX_REQUIRE_SUBGROUP_SIZE(Gpu::Device::warp_size)
+            [[sycl::reqd_work_group_size(1,1,MT)]]
+            [[sycl::reqd_sub_group_size(Gpu::Device::warp_size)]]
             {
                 for (int icell = item.get_global_id(0), stride = item.get_global_range(0);
                      icell < ncells; icell += stride) {
@@ -668,7 +715,8 @@ void ParallelFor (Gpu::KernelInfo const& /*info*/,
             h.parallel_for(sycl::nd_range<1>(sycl::range<1>(nthreads_total),
                                              sycl::range<1>(nthreads_per_block)),
             [=] (sycl::nd_item<1> item)
-            AMREX_REQUIRE_SUBGROUP_SIZE(Gpu::Device::warp_size)
+            [[sycl::reqd_work_group_size(1,1,MT)]]
+            [[sycl::reqd_sub_group_size(Gpu::Device::warp_size)]]
             {
                 for (int icell = item.get_global_id(0), stride = item.get_global_range(0);
                      icell < ncells; icell += stride) {

--- a/Src/Base/AMReX_GpuLaunchMacrosG.H
+++ b/Src/Base/AMReX_GpuLaunchMacrosG.H
@@ -17,7 +17,8 @@
                 amrex_i_h.parallel_for(sycl::nd_range<1>(sycl::range<1>(amrex_i_nthreads_total), \
                                                          sycl::range<1>(amrex_i_nthreads_per_block)), \
                 [=] (sycl::nd_item<1> amrex_i_item) \
-                AMREX_REQUIRE_SUBGROUP_SIZE(Gpu::Device::warp_size) \
+                [[sycl::reqd_work_group_size(1,1,AMREX_GPU_MAX_THREADS)]] \
+                [[sycl::reqd_sub_group_size(Gpu::Device::warp_size)]] \
                 { \
                     for (auto const TI : amrex::Gpu::Range(amrex_i_tn,amrex_i_item.get_global_id(0),amrex_i_item.get_global_range(0))) { \
                         block \
@@ -81,7 +82,8 @@
                 amrex_i_h.parallel_for(sycl::nd_range<2>(sycl::range<2>(amrex_i_nthreads_total,2), \
                                                          sycl::range<2>(amrex_i_nthreads_per_block,1)), \
                 [=] (sycl::nd_item<2> amrex_i_item) \
-                AMREX_REQUIRE_SUBGROUP_SIZE(Gpu::Device::warp_size) \
+                [[sycl::reqd_work_group_size(1,1,AMREX_GPU_MAX_THREADS)]] \
+                [[sycl::reqd_sub_group_size(Gpu::Device::warp_size)]] \
                 { \
                     switch (amrex_i_item.get_group(1)) { \
                     case 0: for (auto const TI1 : amrex::Gpu::Range(amrex_i_tn1,amrex_i_item.get_global_id(0),amrex_i_item.get_global_range(0))) { \
@@ -169,7 +171,8 @@
                 amrex_i_h.parallel_for(sycl::nd_range<2>(sycl::range<2>(amrex_i_nthreads_total,3), \
                                                          sycl::range<2>(amrex_i_nthreads_per_block,1)), \
                 [=] (sycl::nd_item<2> amrex_i_item) \
-                AMREX_REQUIRE_SUBGROUP_SIZE(Gpu::Device::warp_size) \
+                [[sycl::reqd_work_group_size(1,1,AMREX_GPU_MAX_THREADS)]] \
+                [[sycl::reqd_sub_group_size(Gpu::Device::warp_size)]] \
                 { \
                     switch (amrex_i_item.get_group(1)) { \
                     case 0: for (auto const TI1 : amrex::Gpu::Range(amrex_i_tn1,amrex_i_item.get_global_id(0),amrex_i_item.get_global_range(0))) { \
@@ -266,7 +269,8 @@
                 amrex_i_h.parallel_for(sycl::nd_range<1>(sycl::range<1>(amrex_i_nthreads_total), \
                                                          sycl::range<1>(amrex_i_nthreads_per_block)), \
                 [=] (sycl::nd_item<1> amrex_i_item) \
-                AMREX_REQUIRE_SUBGROUP_SIZE(Gpu::Device::warp_size) \
+                [[sycl::reqd_work_group_size(1,1,AMREX_GPU_MAX_THREADS)]] \
+                [[sycl::reqd_sub_group_size(Gpu::Device::warp_size)]] \
                 { \
                     for (auto const TI : amrex::Gpu::Range(amrex_i_tn,amrex_i_item.get_global_id(0),amrex_i_item.get_global_range(0))) { \
                         block \
@@ -320,7 +324,8 @@
                 amrex_i_h.parallel_for(sycl::nd_range<2>(sycl::range<2>(amrex_i_nthreads_total,2), \
                                                          sycl::range<2>(amrex_i_nthreads_per_block,1)), \
                 [=] (sycl::nd_item<2> amrex_i_item) \
-                AMREX_REQUIRE_SUBGROUP_SIZE(Gpu::Device::warp_size) \
+                [[sycl::reqd_work_group_size(1,1,AMREX_GPU_MAX_THREADS)]] \
+                [[sycl::reqd_sub_group_size(Gpu::Device::warp_size)]] \
                 { \
                     switch (amrex_i_item.get_group(1)) { \
                     case 0: for (auto const TI1 : amrex::Gpu::Range(amrex_i_tn1,amrex_i_item.get_global_id(0),amrex_i_item.get_global_range(0))) { \
@@ -392,7 +397,8 @@
                 amrex_i_h.parallel_for(sycl::nd_range<2>(sycl::range<2>(amrex_i_nthreads_total,3), \
                                                          sycl::range<2>(amrex_i_nthreads_per_block,1)), \
                 [=] (sycl::nd_item<2> amrex_i_item) \
-                AMREX_REQUIRE_SUBGROUP_SIZE(Gpu::Device::warp_size) \
+                [[sycl::reqd_work_group_size(1,1,AMREX_GPU_MAX_THREADS)]] \
+                [[sycl::reqd_sub_group_size(Gpu::Device::warp_size)]] \
                 { \
                     switch (amrex_i_item.get_group(1)) { \
                     case 0: for (auto const TI1 : amrex::Gpu::Range(amrex_i_tn1,amrex_i_item.get_global_id(0),amrex_i_item.get_global_range(0))) { \

--- a/Src/Base/AMReX_GpuQualifiers.H
+++ b/Src/Base/AMReX_GpuQualifiers.H
@@ -32,15 +32,7 @@
 #define AMREX_DEVICE_COMPILE (__CUDA_ARCH__ || __HIP_DEVICE_COMPILE__ || __SYCL_DEVICE_ONLY__)
 
 #ifdef AMREX_USE_SYCL
-
 # include <sycl/sycl.hpp>
-
-# define AMREX_REQUIRE_SUBGROUP_SIZE(x) \
-  _Pragma("clang diagnostic push") \
-  _Pragma("clang diagnostic ignored \"-Wattributes\"") \
-  [[intel::reqd_sub_group_size(x)]]                \
-  _Pragma("clang diagnostic pop")
-
-#endif // AMREX_USE_SYCL
+#endif
 
 #endif

--- a/Src/Base/AMReX_MFParallelForG.H
+++ b/Src/Base/AMReX_MFParallelForG.H
@@ -114,7 +114,7 @@ ParallelFor (MF const& mf, IntVect const& nghost, int ncomp, IntVect const&, boo
 
 #elif defined(AMREX_USE_SYCL)
 
-        amrex::launch(nblocks, MT, Gpu::gpuStream(),
+        amrex::launch<MT>(nblocks, Gpu::gpuStream(),
              [=] AMREX_GPU_DEVICE (sycl::nd_item<1> const& item) noexcept
              {
                  int ibox, icell;

--- a/Src/Base/AMReX_Reduce.H
+++ b/Src/Base/AMReX_Reduce.H
@@ -386,7 +386,7 @@ public:
 #ifdef AMREX_USE_SYCL
             // device reduce needs local(i.e., shared) memory
             constexpr std::size_t shared_mem_bytes = sizeof(unsigned long long)*Gpu::Device::warp_size;
-            amrex::launch(nblocks_ec, AMREX_GPU_MAX_THREADS, shared_mem_bytes, stream,
+            amrex::launch<AMREX_GPU_MAX_THREADS>(nblocks_ec, shared_mem_bytes, stream,
                           [=] AMREX_GPU_DEVICE (Gpu::Handler const& gh) noexcept
             {
                 Dim1 blockIdx {gh.blockIdx()};
@@ -515,7 +515,7 @@ public:
 #ifdef AMREX_USE_SYCL
         // device reduce needs local(i.e., shared) memory
         constexpr std::size_t shared_mem_bytes = sizeof(unsigned long long)*Gpu::Device::warp_size;
-        amrex::launch(nblocks_ec, AMREX_GPU_MAX_THREADS, shared_mem_bytes, stream,
+        amrex::launch<AMREX_GPU_MAX_THREADS>(nblocks_ec, shared_mem_bytes, stream,
         [=] AMREX_GPU_DEVICE (Gpu::Handler const& gh) noexcept
         {
             Dim1 blockIdx {gh.blockIdx()};
@@ -523,7 +523,7 @@ public:
             Dim1 blockDim {gh.blockDim()};
             Dim1 gridDim  {gh.gridDim()};
 #else
-        amrex::launch(nblocks_ec, AMREX_GPU_MAX_THREADS, 0, stream,
+        amrex::launch<AMREX_GPU_MAX_THREADS>(nblocks_ec, 0, stream,
         [=] AMREX_GPU_DEVICE () noexcept
         {
 #endif
@@ -574,7 +574,7 @@ public:
 #ifdef AMREX_USE_SYCL
         // device reduce needs local(i.e., shared) memory
         constexpr std::size_t shared_mem_bytes = sizeof(unsigned long long)*Gpu::Device::warp_size;
-        amrex::launch(nblocks_ec, AMREX_GPU_MAX_THREADS, shared_mem_bytes, stream,
+        amrex::launch<AMREX_GPU_MAX_THREADS>(nblocks_ec, shared_mem_bytes, stream,
         [=] AMREX_GPU_DEVICE (Gpu::Handler const& gh) noexcept
         {
             Dim1 blockIdx {gh.blockIdx()};
@@ -582,7 +582,7 @@ public:
             Dim1 blockDim {gh.blockDim()};
             Dim1 gridDim  {gh.gridDim()};
 #else
-        amrex::launch(nblocks_ec, AMREX_GPU_MAX_THREADS, 0, stream,
+        amrex::launch<AMREX_GPU_MAX_THREADS>(nblocks_ec, 0, stream,
         [=] AMREX_GPU_DEVICE () noexcept
         {
 #endif
@@ -631,7 +631,7 @@ public:
 #ifdef AMREX_USE_SYCL
         // device reduce needs local(i.e., shared) memory
         constexpr std::size_t shared_mem_bytes = sizeof(unsigned long long)*Gpu::Device::warp_size;
-        amrex::launch(nblocks_ec, AMREX_GPU_MAX_THREADS, shared_mem_bytes, stream,
+        amrex::launch<AMREX_GPU_MAX_THREADS>(nblocks_ec, shared_mem_bytes, stream,
         [=] AMREX_GPU_DEVICE (Gpu::Handler const& gh) noexcept
         {
             Dim1 blockIdx {gh.blockIdx()};
@@ -639,7 +639,7 @@ public:
             Dim1 blockDim {gh.blockDim()};
             Dim1 gridDim  {gh.gridDim()};
 #else
-        amrex::launch(nblocks_ec, AMREX_GPU_MAX_THREADS, 0, stream,
+        amrex::launch<AMREX_GPU_MAX_THREADS>(nblocks_ec, 0, stream,
         [=] AMREX_GPU_DEVICE () noexcept
         {
 #endif
@@ -700,7 +700,7 @@ public:
 #else
             auto presult = hp;
 #endif
-            amrex::launch(1, AMREX_GPU_MAX_THREADS, shared_mem_bytes, stream,
+            amrex::launch<AMREX_GPU_MAX_THREADS>(1, shared_mem_bytes, stream,
             [=] AMREX_GPU_DEVICE (Gpu::Handler const& gh) noexcept
             {
                 ReduceTuple r;
@@ -720,7 +720,7 @@ public:
             Gpu::dtoh_memcpy_async(hp, dtmp.data(), sizeof(ReduceTuple));
 #endif
 #else
-            amrex::launch(1, AMREX_GPU_MAX_THREADS, 0, stream,
+            amrex::launch<AMREX_GPU_MAX_THREADS>(1, 0, stream,
             [=] AMREX_GPU_DEVICE () noexcept
             {
                 ReduceTuple r;
@@ -854,7 +854,7 @@ bool AnyOf (N n, T const* v, P&& pred)
 #ifdef AMREX_USE_SYCL
     const int num_ints = std::max(Gpu::Device::warp_size, int(ec.numThreads.x)/Gpu::Device::warp_size) + 1;
     const std::size_t shared_mem_bytes = num_ints*sizeof(int);
-    amrex::launch(ec.numBlocks.x, ec.numThreads.x, shared_mem_bytes, Gpu::gpuStream(),
+    amrex::launch<AMREX_GPU_MAX_THREADS>(ec.numBlocks.x, shared_mem_bytes, Gpu::gpuStream(),
     [=] AMREX_GPU_DEVICE (Gpu::Handler const& gh) noexcept {
         int* has_any = &(static_cast<int*>(gh.sharedMemory())[num_ints-1]);
         if (gh.threadIdx() == 0) { *has_any = *dp; }
@@ -875,7 +875,7 @@ bool AnyOf (N n, T const* v, P&& pred)
         }
     });
 #else
-    amrex::launch(ec.numBlocks.x, ec.numThreads.x, 0, Gpu::gpuStream(),
+    amrex::launch<AMREX_GPU_MAX_THREADS>(ec.numBlocks.x, 0, Gpu::gpuStream(),
     [=] AMREX_GPU_DEVICE () noexcept {
         __shared__ int has_any;
         if (threadIdx.x == 0) has_any = *dp;
@@ -915,7 +915,7 @@ bool AnyOf (Box const& box, P&& pred)
 #ifdef AMREX_USE_SYCL
     const int num_ints = std::max(Gpu::Device::warp_size, int(ec.numThreads.x)/Gpu::Device::warp_size) + 1;
     const std::size_t shared_mem_bytes = num_ints*sizeof(int);
-    amrex::launch(ec.numBlocks.x, ec.numThreads.x, shared_mem_bytes, Gpu::gpuStream(),
+    amrex::launch<AMREX_GPU_MAX_THREADS>(ec.numBlocks.x, shared_mem_bytes, Gpu::gpuStream(),
     [=] AMREX_GPU_DEVICE (Gpu::Handler const& gh) noexcept {
         int* has_any = &(static_cast<int*>(gh.sharedMemory())[num_ints-1]);
         if (gh.threadIdx() == 0) { *has_any = *dp; }

--- a/Src/Base/AMReX_TagParallelFor.H
+++ b/Src/Base/AMReX_TagParallelFor.H
@@ -185,7 +185,8 @@ ParallelFor_doit (Vector<TagType> const& tags, F && f)
     amrex::launch(nblocks, nthreads, Gpu::gpuStream(),
 #ifdef AMREX_USE_SYCL
     [=] AMREX_GPU_DEVICE (sycl::nd_item<1> const& item) noexcept
-    AMREX_REQUIRE_SUBGROUP_SIZE(Gpu::Device::warp_size)
+    [[sycl::reqd_work_group_size(1,1,nthreads)]]
+    [[sycl::reqd_sub_group_size(Gpu::Device::warp_size)]]
 #else
     [=] AMREX_GPU_DEVICE () noexcept
 #endif


### PR DESCRIPTION
* Use [[sycl::reqd_work_group_size]] when we know the group size at compile time.  I have not seen perfromance difference, but it should not hurt.

* Replace [[intel::reqd_sub_group_size]] with [[sycl::reqd_sub_group_size]] since the Intel extension is in the standard now.