### PR TITLE
Add build option for Intel SYCL AOT GRF mode

### DIFF
--- a/Docs/sphinx_documentation/source/GPU.rst
+++ b/Docs/sphinx_documentation/source/GPU.rst
@@ -395,6 +395,9 @@ Below is an example configuration for SYCL:
    +==============================+=================================================+=============+=================+
    | AMReX_SYCL_AOT               | Enable SYCL ahead-of-time compilation           | NO          | YES, NO         |
    +------------------------------+-------------------------------------------------+-------------+-----------------+
+   | AMReX_SYCL_AOT_GRF_MODE      | Specify AOT register file mode                  | Default     | Default, Large, |
+   |                              |                                                 |             | AutoLarge       |
+   +------------------------------+-------------------------------------------------+-------------+-----------------+
    | AMREX_INTEL_ARCH             | Specify target if AOT is enabled                | None        | pvc, etc.       |
    +------------------------------+-------------------------------------------------+-------------+-----------------+
    | AMReX_SYCL_SPLIT_KERNEL      | Enable SYCL kernel splitting                    | YES         | YES, NO         |

--- a/Tools/CMake/AMReXOptions.cmake
+++ b/Tools/CMake/AMReXOptions.cmake
@@ -191,6 +191,16 @@ if (AMReX_SYCL)
    if (AMReX_SYCL_AOT AND NOT AMReX_INTEL_ARCH)
       message(FATAL_ERROR "\nMust specify AMReX_INTEL_ARCH if AMReX_GPU_BACKEND=SYCL and AMReX_SYCL_AOT=ON\n")
    endif()
+
+   if (AMReX_SYCL_AOT)
+      set(AMReX_SYCL_AOT_GRF_MODE_VALUES Default Large AutoLarge)
+      set(AMReX_SYCL_AOT_GRF_MODE Default CACHE STRING "SYCL AOT General Register File Mode")
+      set_property(CACHE AMReX_SYCL_AOT_GRF_MODE PROPERTY STRINGS ${AMReX_SYCL_AOT_GRF_MODE_VALUES})
+      if (NOT AMReX_SYCL_AOT_GRF_MODE IN_LIST AMReX_SYCL_AOT_GRF_MODE_VALUES)
+         message(FATAL_ERROR "AMReX_SYCL_AOT_GRF_MODE (${AMReX_SYCL_AOT_GRF_MODE}) must be one of ${AMReX_SYCL_AOT_GRF_MODE_VALUES}")
+      endif()
+   endif()
+
 endif ()
 
 # --- HIP ----

--- a/Tools/CMake/AMReXSYCL.cmake
+++ b/Tools/CMake/AMReXSYCL.cmake
@@ -67,10 +67,19 @@ if (AMReX_SYCL_AOT)
       INTERFACE
       "$<${_cxx_sycl}:-fsycl-targets=spir64_gen>" )
 
+   set(_sycl_backend_flags "-device ${AMReX_INTEL_ARCH}")
+   if (AMReX_SYCL_AOT_GRF_MODE STREQUAL "Large")
+      set(_sycl_backend_flags "${_sycl_backend_flags} -internal_options -ze-opt-large-register-file")
+   elseif (AMReX_SYCL_AOT_GRF_MODE STREQUAL "AutoLarge")
+      set(_sycl_backend_flags "${_sycl_backend_flags} -options -ze-intel-enable-auto-large-GRF-mode")
+   endif()
+
    target_link_options( SYCL
       INTERFACE
       "$<${_cxx_sycl}:-fsycl-targets=spir64_gen>"
-      "$<${_cxx_sycl}:SHELL:-Xsycl-target-backend \"-device ${AMReX_INTEL_ARCH}\">" )
+      "$<${_cxx_sycl}:SHELL:-Xsycl-target-backend \"${_sycl_backend_flags}\">" )
+
+   unset(_sycl_backend_flags)
 endif ()
 
 if (CMAKE_SYSTEM_NAME STREQUAL "Linux" AND "${CMAKE_BUILD_TYPE}" MATCHES "Debug")

--- a/Tools/GNUMake/comps/dpcpp.mak
+++ b/Tools/GNUMake/comps/dpcpp.mak
@@ -135,7 +135,18 @@ ifeq ($(SYCL_AOT),TRUE)
     $(error Either INTEL_ARCH or AMREX_INTEL_ARCH must be specified when SYCL_AOT is TRUE.)
   endif
   CXXFLAGS += -fsycl-targets=spir64_gen
-  LDFLAGS += -Xsycl-target-backend '-device $(amrex_intel_gpu_target)'
+  amrex_sycl_backend_flags = -device $(amrex_intel_gpu_target)
+  SYCL_AOT_GRF_MODE ?= Default
+  ifneq ($(SYCL_AOT_GRF_MODE),Default)
+    ifeq ($(SYCL_AOT_GRF_MODE),Large)
+      amrex_sycl_backend_flags += -internal_options -ze-opt-large-register-file
+    else ifeq ($(SYCL_AOT_GRF_MODE),AutoLarge)
+      amrex_sycl_backend_flags += -options -ze-intel-enable-auto-large-GRF-mode
+    else
+      $(error SYCL_AOT_GRF_MODE ($(SYCL_AOT_GRF_MODE)) must be either Default, Large, or AutoLarge)
+    endif
+  endif
+  LDFLAGS += -Xsycl-target-backend '$(amrex_sycl_backend_flags)'
 endif
 
 ifeq ($(DEBUG),TRUE)


### PR DESCRIPTION
By default, the Intel SYCL compiler uses up to 128 registers.  In the large register file mode, it's up to 256 registers.  There is also the auto-large mode.

For CMake, one can use `-DAMReX_SYCL_AOT_GRF_MODE=[Large|AutoLarge]` to choose the large register file or auto-large mode.  AOT must also be enabled with `-DAMReX_SYCL_AOT=TRUE`.

For GNU Make, one can use `SYCL_AOT_GRF_MODE=[Large|AutoLarge]`, and it depends on AOT being enabled by `SYCL_AOT=TRUE`.
