### PR TITLE
GNU Make: Allow choice of Intel compiler variant

### DIFF
--- a/Docs/sphinx_documentation/source/BuildingAMReX.rst
+++ b/Docs/sphinx_documentation/source/BuildingAMReX.rst
@@ -33,7 +33,8 @@ list of important variables.
    +=================+=====================================+====================+
    | AMREX_HOME      | Path to amrex                       | environment        |
    +-----------------+-------------------------------------+--------------------+
-   | COMP            | gnu, cray, ibm, intel, llvm, or pgi | none               |
+   | COMP            | gnu, cray, ibm, intel, intel-llvm,  |                    |
+   |                 | intel-classic, llvm, or pgi         | none               |
    +-----------------+-------------------------------------+--------------------+
    | CXXSTD          | C++ standard (``c++17``, ``c++20``) | compiler default,  |
    |                 |                                     | at least ``c++17`` |

--- a/Tools/GNUMake/Make.defs
+++ b/Tools/GNUMake/Make.defs
@@ -456,6 +456,10 @@ ifdef AMREX_CCOMP
     AMREX_CCOMP = gnu
   else ifeq ($(lowercase_amrex_ccomp),intel)
     AMREX_CCOMP = intel
+  else ifeq ($(lowercase_amrex_ccomp),intel-llvm)
+    AMREX_CCOMP = intel-llvm
+  else ifeq ($(lowercase_amrex_ccomp),intel-classic)
+    AMREX_CCOMP = intel-classic
   else ifeq ($(lowercase_amrex_ccomp),sycl)
     AMREX_CCOMP = sycl
   else ifeq ($(lowercase_amrex_ccomp),cray)
@@ -477,7 +481,7 @@ ifdef AMREX_CCOMP
   else ifeq ($(lowercase_amrex_ccomp),armclang)
     AMREX_CCOMP = armclang
   else
-    $(error Unknown compiler $(AMREX_CCOMP). Supported compilers are gnu, intel, sycl, cray, pgi, nvhpc, ibm, llvm, nag, nec, and armclang)
+    $(error Unknown compiler $(AMREX_CCOMP). Supported compilers are gnu, intel, intel-llvm, intel-classic, sycl, cray, pgi, nvhpc, ibm, llvm, nag, nec, and armclang)
   endif
 endif
 
@@ -494,6 +498,16 @@ else ifeq ($(lowercase_comp),intel)
   AMREX_CCOMP ?= intel
   $(info Loading $(AMREX_HOME)/Tools/GNUMake/comps/intel.mak...)
   include        $(AMREX_HOME)/Tools/GNUMake/comps/intel.mak
+else ifeq ($(lowercase_comp),intel-llvm)
+  AMREX_FCOMP ?= intel-llvm
+  AMREX_CCOMP ?= intel-llvm
+  $(info Loading $(AMREX_HOME)/Tools/GNUMake/comps/intel-llvm.mak...)
+  include        $(AMREX_HOME)/Tools/GNUMake/comps/intel-llvm.mak
+else ifeq ($(lowercase_comp),intel-classic)
+  AMREX_FCOMP ?= intel-classic
+  AMREX_CCOMP ?= intel-classic
+  $(info Loading $(AMREX_HOME)/Tools/GNUMake/comps/intel-classic.mak...)
+  include        $(AMREX_HOME)/Tools/GNUMake/comps/intel-classic.mak
 else ifeq ($(lowercase_comp),sycl)
   AMREX_FCOMP ?= none
   AMREX_CCOMP ?= sycl
@@ -552,7 +566,7 @@ else ifeq ($(lowercase_comp),hip)
   $(info Loading $(AMREX_HOME)/Tools/GNUMake/comps/hip.mak...)
   include        $(AMREX_HOME)/Tools/GNUMake/comps/hip.mak
 else
-  $(error Unknown compiler $(COMP). Supported compilers are gnu, intel, sycl, cray, pgi, nvhpc, ibm, llvm, nag, and nec)
+  $(error Unknown compiler $(COMP). Supported compilers are gnu, intel, intel-llvm, intel-classic, sycl, cray, pgi, nvhpc, ibm, llvm, nag, and nec)
 endif
 
 CXXFLAGS += $(XTRA_CXXFLAGS)

--- a/Tools/GNUMake/comps/intel-classic.mak
+++ b/Tools/GNUMake/comps/intel-classic.mak
@@ -11,6 +11,10 @@ CFLAGS   =
 FFLAGS   =
 F90FLAGS =
 
+AMREX_CCOMP = intel-classic
+AMREX_FCOMP = intel-classic
+lowercase_comp = intel-classic
+
 ########################################################################
 
 intel_version = $(shell $(CXX) -dumpversion)

--- a/Tools/GNUMake/comps/intel-llvm.mak
+++ b/Tools/GNUMake/comps/intel-llvm.mak
@@ -11,6 +11,10 @@ CFLAGS   =
 FFLAGS   =
 F90FLAGS =
 
+AMREX_CCOMP = intel-llvm
+AMREX_FCOMP = intel-llvm
+lowercase_comp = intel-llvm
+
 ########################################################################
 
 intel_version = $(shell $(CXX) -dumpversion)

--- a/Tools/GNUMake/tools/Make.vtune
+++ b/Tools/GNUMake/tools/Make.vtune
@@ -1,5 +1,5 @@
 
-ifeq ($(lowercase_comp),intel)
+ifeq ($(findstring $(lowercase_comp),intel),intel)
 
   DEFINES += -DAMREX_VTUNE
   

--- a/Tools/libamrex/configure.py
+++ b/Tools/libamrex/configure.py
@@ -43,7 +43,7 @@ def configure(argv):
                         default="no")
     parser.add_argument("--comp",
                         help="Compiler [default=gnu]",
-                        choices=["gnu","intel","cray","pgi","llvm","nag","nec","ibm","armclang"],
+                        choices=["gnu","intel","intel-llvm","intel-classic","cray","pgi","llvm","nag","nec","ibm","armclang"],
                         default="gnu")
     parser.add_argument("--debug",
                         help="Debug build [default=no]",

--- a/Tools/libamrex/mkconfig.py
+++ b/Tools/libamrex/mkconfig.py
@@ -31,8 +31,11 @@ def doit(defines, undefines, comp, allow_diff_comp):
         if comp == "gnu" or comp == "nag":
             comp_macro = "__GNUC__"
             comp_id    = "GNU"
-        elif comp == "intel":
+        elif comp == "intel" or comp == "intel-classic":
             comp_macro = "__INTEL_COMPILER"
+            comp_id    = "Intel"
+        elif comp == "intel-llvm":
+            comp_macro = "__INTEL_LLVM_COMPILER"
             comp_id    = "Intel"
         elif comp == "cray":
             comp_macro = "_CRAYC"
@@ -91,7 +94,7 @@ if __name__ == "__main__":
                         default="")
     parser.add_argument("--comp",
                         help="compiler",
-                        choices=["gnu","intel","cray","pgi","nvhpc","llvm","nag","nec","ibm",
+                        choices=["gnu","intel","intel-llvm","intel-classic","cray","pgi","nvhpc","llvm","nag","nec","ibm",
                                  "armclang","hip","sycl"])
     parser.add_argument("--allow-different-compiler",
                         help="allow an application to use a different compiler than the one used to build libamrex",


### PR DESCRIPTION
## Summary
This allows the user to specify `COMP = intel-classic` or `COMP = intel-llvm` if they wish to use a specific one.

## Additional background
Note that the existing behaviour is maintained if `COMP = intel` (i.e. intel-llvm is chosen if the `icpx` command exists and intel-classic is chosen otherwise following #3126). However, the `AMREX_FCOMP`, `AMREX_CCOMP` and `lowercase_comp` makefile variables are changed to one of `intel-llvm` or `intel-classic` depending on which is used. This further allows the user to use information about the used variant in their `Make.local`. For example they may wish to set something like
```
CXX = mpiicpc -cxx=icpx
```
in the case `AMREX_CCOMP = intel-llvm`, `USE_MPI = TRUE` and they are using Intel MPI.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [x] include documentation in the code and/or rst files, if appropriate
