### PR TITLE
GNU Make: Allow customizing tmp_build_dir

### DIFF
--- a/Tools/GNUMake/Make.defs
+++ b/Tools/GNUMake/Make.defs
@@ -920,12 +920,12 @@ optionsSuffix	= $(DIM)d.$(machineSuffix)
 
 executable	= $(addsuffix $(optionsSuffix).ex, $(EBASE))
 
-TmpBuildDir     = tmp_build_dir
-srcTempDir      = $(TmpBuildDir)/s/$(optionsSuffix).EXE
-depEXETempDir	= $(TmpBuildDir)/d/$(optionsSuffix).EXE
-objEXETempDir   = $(TmpBuildDir)/o/$(optionsSuffix).EXE
-f77EXETempDir	= $(TmpBuildDir)/f/$(optionsSuffix).EXE
-tmpEXETempDir	= $(TmpBuildDir)/t/$(optionsSuffix).EXE
+TMP_BUILD_DIR     ?= tmp_build_dir
+srcTempDir      = $(TMP_BUILD_DIR)/s/$(optionsSuffix).EXE
+depEXETempDir	= $(TMP_BUILD_DIR)/d/$(optionsSuffix).EXE
+objEXETempDir   = $(TMP_BUILD_DIR)/o/$(optionsSuffix).EXE
+f77EXETempDir	= $(TMP_BUILD_DIR)/f/$(optionsSuffix).EXE
+tmpEXETempDir	= $(TMP_BUILD_DIR)/t/$(optionsSuffix).EXE
 
 includes	= -I$(srcTempDir) -I. $(addprefix -I, $(INCLUDE_LOCATIONS)) $(addprefix -isystem , $(SYSTEM_INCLUDE_LOCATIONS))
 ifeq ($(lowercase_comp),pgi)
@@ -944,7 +944,7 @@ fmoddir         = $(objEXETempDir)
 
 amrexlib = $(objEXETempDir)/libamrex.a
 
-AMREX_INSTALL_DIR ?= tmp_build_dir
+AMREX_INSTALL_DIR ?= $(TMP_BUILD_DIR)
 amrexLibDir = $(AMREX_INSTALL_DIR)/lib
 amrexIncludeDir = $(AMREX_INSTALL_DIR)/include
 # Do different compilers have different name convention for mod files?

--- a/Tools/GNUMake/Make.rules
+++ b/Tools/GNUMake/Make.rules
@@ -215,7 +215,7 @@ cleanconfig::
 clean:: cleanconfig
 	@echo Cleaning ...
 	$(SILENT) $(RM) TAGS tags
-	$(SILENT) $(RM) -r $(TmpBuildDir) *~
+	$(SILENT) $(RM) -r $(TMP_BUILD_DIR) *~
 	$(SILENT) $(RM) *.ex *.o
 	$(SILENT) $(RM) *.mod
 	$(SILENT) $(RM) *.ptx


### PR DESCRIPTION
## Summary
This allows the user to change the default temporary build directory to something other than `tmp_build_dir`.

## Additional background
This would allow for users to build multiple AMReX applications using the same build directory and thus reduce compile times without having to use `ccache`. Of course, there might be a small risk in terms of users potentially accidentally mixing build configurations hence I would suggest not advertising this feature or at least advising caution.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
