### PR TITLE
CI: Clang CUDA

### DIFF
--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -66,7 +66,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Dependencies
-      run: .github/workflows/dependencies/dependencies_nvcc12.sh
+      run: .github/workflows/dependencies/dependencies_nvcc11_ubuntu22.sh
     - name: Build & Install
       run: |
         export PATH=/usr/local/nvidia/bin:/usr/local/cuda/bin:${PATH}

--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -73,7 +73,8 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Dependencies
-      run: .github/workflows/dependencies/dependencies_llvm_cuda11_ubuntu22.sh
+      run: |
+        .github/workflows/dependencies/dependencies_llvm_cuda11_ubuntu22.sh
         .github/workflows/dependencies/dependencies_ccache.sh
     - name: Set Up Cache
       uses: actions/cache@v3

--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -58,7 +58,7 @@ jobs:
         ccache -s
         du -hs ~/.cache/ccache
 
-  # Build libamrex and all tests for CUDA with LLVM Clang + libc++ + CTK 11.2
+  # Build libamrex and all tests for CUDA with LLVM Clang + libc++ + CTK 11.7
   tests-cuda11-clang:
     name: ClangCUDA@12 C++17 Release [tests]
     runs-on: ubuntu-22.04

--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -62,7 +62,9 @@ jobs:
   tests-cuda11-clang:
     name: ClangCUDA@12 C++17 Release [tests]
     runs-on: ubuntu-22.04
-    env: {CXXFLAGS: "--cuda-gpu-arch=sm_70 --no-cuda-version-check"}
+    env:
+      CXXFLAGS: "--cuda-gpu-arch=sm_70 --no-cuda-version-check"
+      CUDAFLAGS: "-stdlib=libc++"
     steps:
     - uses: actions/checkout@v3
     - name: Dependencies
@@ -80,13 +82,12 @@ jobs:
             -DAMReX_FORTRAN=OFF                          \
             -DAMReX_PARTICLES=ON                         \
             -DAMReX_GPU_BACKEND=CUDA                     \
-            -DCMAKE_C_COMPILER=$(which clang)            \
-            -DCMAKE_CXX_COMPILER=$(which clang++)        \
-            -DCMAKE_CUDA_COMPILER=$(which clang++)       \
-            -DCMAKE_CUDA_HOST_COMPILER=$(which clang++)  \
+            -DCMAKE_C_COMPILER=$(which clang-15)            \
+            -DCMAKE_CXX_COMPILER=$(which clang++-15)        \
+            -DCMAKE_CUDA_COMPILER=$(which clang++-15)       \
+            -DCMAKE_CUDA_HOST_COMPILER=$(which clang++-15)  \
             -DCMAKE_CUDA_ARCHITECTURES=70                \
-            -DAMReX_CUDA_ARCH=7.0 \
-            -D_CMAKE_CUDA_WHOLE_FLAG="-c"
+            -DAMReX_CUDA_ARCH=7.0
 
         cmake --build build -j 2
 

--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -60,7 +60,7 @@ jobs:
 
   # Build libamrex and all tests for CUDA with LLVM Clang + libc++ + CTK 11.7
   tests-cuda11-clang:
-    name: ClangCUDA@12 C++17 Release [tests]
+    name: Clang@15 CUDA@11.7 C++17 Release [tests]
     runs-on: ubuntu-22.04
     env:
       CC: clang-15

--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -58,6 +58,37 @@ jobs:
         ccache -s
         du -hs ~/.cache/ccache
 
+  # Build libamrex and all tests with CUDA 11.0.2 (recent supported)
+  tests-cuda11-clang:
+    name: ClangCUDA@12 C++17 Release [tests]
+    runs-on: ubuntu-22.04
+    env: {CXXFLAGS: "--cuda-gpu-arch=sm_70 --no-cuda-version-check"}
+    steps:
+    - uses: actions/checkout@v3
+    - name: Dependencies
+      run: .github/workflows/dependencies/dependencies_nvcc12.sh
+    - name: Build & Install
+      run: |
+        export PATH=/usr/local/nvidia/bin:/usr/local/cuda/bin:${PATH}
+        export LD_LIBRARY_PATH=/usr/local/nvidia/lib:/usr/local/nvidia/lib64:/usr/local/cuda/lib64:${LD_LIBRARY_PATH}
+        which nvcc || echo "nvcc not in PATH!"
+
+        cmake -S . -B build                              \
+            -DCMAKE_VERBOSE_MAKEFILE=ON                  \
+            -DAMReX_EB=ON                                \
+            -DAMReX_ENABLE_TESTS=ON                      \
+            -DAMReX_FORTRAN=OFF                          \
+            -DAMReX_PARTICLES=ON                         \
+            -DAMReX_GPU_BACKEND=CUDA                     \
+            -DCMAKE_C_COMPILER=$(which clang)            \
+            -DCMAKE_CXX_COMPILER=$(which clang++)        \
+            -DCMAKE_CUDA_COMPILER=$(which clang++)       \
+            -DCMAKE_CUDA_HOST_COMPILER=$(which clang++)  \
+            -DCMAKE_CUDA_ARCHITECTURES=70                \
+            -DAMReX_CUDA_ARCH=7.0
+
+        cmake --build build -j 2
+
   # Build libamrex and all tests with NVHPC (recent supported)
   tests-nvhpc-nvcc:
     name: NVHPC NVCC/NVC++ C++17 Release [tests]

--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -85,7 +85,8 @@ jobs:
             -DCMAKE_CUDA_COMPILER=$(which clang++)       \
             -DCMAKE_CUDA_HOST_COMPILER=$(which clang++)  \
             -DCMAKE_CUDA_ARCHITECTURES=70                \
-            -DAMReX_CUDA_ARCH=7.0
+            -DAMReX_CUDA_ARCH=7.0 \
+            -D_CMAKE_CUDA_WHOLE_FLAG="-c"
 
         cmake --build build -j 2
 

--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -58,22 +58,39 @@ jobs:
         ccache -s
         du -hs ~/.cache/ccache
 
-  # Build libamrex and all tests with CUDA 11.0.2 (recent supported)
+  # Build libamrex and all tests for CUDA with LLVM Clang + libc++ + CTK 11.2
   tests-cuda11-clang:
     name: ClangCUDA@12 C++17 Release [tests]
     runs-on: ubuntu-22.04
     env:
-      CXXFLAGS: "--cuda-gpu-arch=sm_70 --no-cuda-version-check"
+      CC: clang-15
+      CXX: clang++-15
+      CUDACXX: clang++-15
+      CUDAHOSTCXX: clang++-15
       CUDAFLAGS: "-stdlib=libc++"
+      CUDAARCHS: 70
+      AMReX_CUDA_ARCH: 7.0
     steps:
     - uses: actions/checkout@v3
     - name: Dependencies
-      run: .github/workflows/dependencies/dependencies_nvcc11_ubuntu22.sh
+      run: .github/workflows/dependencies/dependencies_llvm_cuda11_ubuntu22.sh
+        .github/workflows/dependencies/dependencies_ccache.sh
+    - name: Set Up Cache
+      uses: actions/cache@v3
+      with:
+        path: ~/.cache/ccache
+        key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}
+        restore-keys: |
+             ccache-${{ github.workflow }}-${{ github.job }}-git-
     - name: Build & Install
       run: |
+        export CCACHE_COMPRESS=1
+        export CCACHE_COMPRESSLEVEL=10
+        export CCACHE_MAXSIZE=235M
+        ccache -z
+
         export PATH=/usr/local/nvidia/bin:/usr/local/cuda/bin:${PATH}
         export LD_LIBRARY_PATH=/usr/local/nvidia/lib:/usr/local/nvidia/lib64:/usr/local/cuda/lib64:${LD_LIBRARY_PATH}
-        which nvcc || echo "nvcc not in PATH!"
 
         cmake -S . -B build                              \
             -DCMAKE_VERBOSE_MAKEFILE=ON                  \
@@ -82,14 +99,13 @@ jobs:
             -DAMReX_FORTRAN=OFF                          \
             -DAMReX_PARTICLES=ON                         \
             -DAMReX_GPU_BACKEND=CUDA                     \
-            -DCMAKE_C_COMPILER=$(which clang-15)            \
-            -DCMAKE_CXX_COMPILER=$(which clang++-15)        \
-            -DCMAKE_CUDA_COMPILER=$(which clang++-15)       \
-            -DCMAKE_CUDA_HOST_COMPILER=$(which clang++-15)  \
-            -DCMAKE_CUDA_ARCHITECTURES=70                \
-            -DAMReX_CUDA_ARCH=7.0
+            -DCMAKE_CUDA_COMPILER_LAUNCHER=ccache        \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
 
         cmake --build build -j 2
+
+        ccache -s
+        du -hs ~/.cache/ccache
 
   # Build libamrex and all tests with NVHPC (recent supported)
   tests-nvhpc-nvcc:

--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -96,6 +96,7 @@ jobs:
 
         cmake -S . -B build                              \
             -DCMAKE_VERBOSE_MAKEFILE=ON                  \
+            -DAMReX_MPI=OFF                              \
             -DAMReX_EB=ON                                \
             -DAMReX_ENABLE_TESTS=ON                      \
             -DAMReX_FORTRAN=OFF                          \

--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -68,6 +68,7 @@ jobs:
       CUDACXX: clang++-15
       CUDAHOSTCXX: clang++-15
       CUDAFLAGS: "-stdlib=libc++"
+      LDFLAGS: "-stdlib=libc++"
       CUDAARCHS: 70
       AMReX_CUDA_ARCH: 7.0
     steps:

--- a/.github/workflows/dependencies/dependencies_llvm_cuda11_ubuntu22.sh
+++ b/.github/workflows/dependencies/dependencies_llvm_cuda11_ubuntu22.sh
@@ -10,10 +10,12 @@ sudo apt-get -qqq update
 sudo apt-get install -y \
     build-essential     \
     ca-certificates     \
-    clang-15 libc++-15-dev libc++abi-15-dev libc++1-15 libc++abi1-15 \
+    clang-15            \
+    libc++-15-dev       \
+    libc++abi-15-dev    \
+    libc++1-15          \
+    libc++abi1-15       \
     cmake               \
-    g++                 \
-    gfortran            \
     gnupg               \
     libopenmpi-dev      \
     openmpi-bin         \
@@ -32,4 +34,3 @@ sudo apt-get install -y \
     cuda-nvtx-11-2               \
     libcurand-dev-11-2
 sudo ln -s cuda-11.2 /usr/local/cuda
-

--- a/.github/workflows/dependencies/dependencies_llvm_cuda11_ubuntu22.sh
+++ b/.github/workflows/dependencies/dependencies_llvm_cuda11_ubuntu22.sh
@@ -26,11 +26,11 @@ curl -O https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_
 sudo dpkg -i cuda-keyring_1.0-1_all.deb
 sudo apt-get update
 sudo apt-get install -y \
-    cuda-command-line-tools-11-2 \
-    cuda-compiler-11-2           \
-    cuda-cupti-dev-11-2          \
-    cuda-minimal-build-11-2      \
-    cuda-nvml-dev-11-2           \
-    cuda-nvtx-11-2               \
-    libcurand-dev-11-2
-sudo ln -s cuda-11.2 /usr/local/cuda
+    cuda-command-line-tools-11-7 \
+    cuda-compiler-11-7           \
+    cuda-cupti-dev-11-7          \
+    cuda-minimal-build-11-7      \
+    cuda-nvml-dev-11-7           \
+    cuda-nvtx-11-7               \
+    libcurand-dev-11-7
+sudo ln -s cuda-11.7 /usr/local/cuda

--- a/.github/workflows/dependencies/dependencies_nvcc11_ubuntu22.sh
+++ b/.github/workflows/dependencies/dependencies_nvcc11_ubuntu22.sh
@@ -10,6 +10,7 @@ sudo apt-get -qqq update
 sudo apt-get install -y \
     build-essential     \
     ca-certificates     \
+    clang-15 libc++-15-dev libc++abi-15-dev libc++1-15 libc++abi1-15 \
     cmake               \
     g++                 \
     gfortran            \

--- a/.github/workflows/dependencies/dependencies_nvcc11_ubuntu22.sh
+++ b/.github/workflows/dependencies/dependencies_nvcc11_ubuntu22.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+#
+# Copyright 2020-2022 Axel Huebl
+#
+# License: BSD-3-Clause-LBNL
+
+set -eu -o pipefail
+
+sudo apt-get -qqq update
+sudo apt-get install -y \
+    build-essential     \
+    ca-certificates     \
+    cmake               \
+    g++                 \
+    gfortran            \
+    gnupg               \
+    libopenmpi-dev      \
+    openmpi-bin         \
+    pkg-config          \
+    wget
+
+curl -O https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-keyring_1.0-1_all.deb
+sudo dpkg -i cuda-keyring_1.0-1_all.deb
+sudo apt-get update
+sudo apt-get install -y \
+    cuda-command-line-tools-11-2 \
+    cuda-compiler-11-2           \
+    cuda-cupti-dev-11-2          \
+    cuda-minimal-build-11-2      \
+    cuda-nvml-dev-11-2           \
+    cuda-nvtx-11-2               \
+    libcurand-dev-11-2
+sudo ln -s cuda-11.2 /usr/local/cuda
+


### PR DESCRIPTION
## Summary

Try to compile with vanilla Clang/LLVM's CUDA C++ frontend & its LLVM PTX backend.

Vanilla LLVM is used in a variety of tools that we want to use for research.

## Additional background

ping @ludgerpaehler

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
