### PR TITLE
SYCL: Tweak #3164 and switch to multi_ptr for sincos

### DIFF
--- a/Src/Base/AMReX_GpuUtility.H
+++ b/Src/Base/AMReX_GpuUtility.H
@@ -139,10 +139,7 @@ namespace Gpu {
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     bool isnan (T m) noexcept
     {
-#if defined(__CUDA_ARCH__) && defined(AMREX_USE_CUDA) || \
-    defined(__HIP_DEVICE_COMPILE__) && defined(AMREX_USE_HIP)
-        return ::isnan(m);
-#elif defined(__SYCL_DEVICE_ONLY__)
+#if defined(AMREX_USE_SYCL)
         return sycl::isnan(m);
 #else
         return std::isnan(m);
@@ -153,10 +150,7 @@ namespace Gpu {
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     bool isinf (T m) noexcept
     {
-#if defined(__CUDA_ARCH__) && defined(AMREX_USE_CUDA) || \
-    defined(__HIP_DEVICE_COMPILE__) && defined(AMREX_USE_HIP)
-        return ::isinf(m);
-#elif defined(__SYCL_DEVICE_ONLY__)
+#if defined(AMREX_USE_SYCL)
         return sycl::isinf(m);
 #else
         return std::isinf(m);

--- a/Src/Base/AMReX_Math.H
+++ b/Src/Base/AMReX_Math.H
@@ -124,7 +124,7 @@ std::pair<double,double> sincos (double x)
 {
     std::pair<double,double> r;
 #if defined(AMREX_USE_SYCL)
-    r.first = sycl::sincos(x, &r.second);
+    r.first = sycl::sincos(x, sycl::private_ptr<double>(&r.second));
 #elif defined(__CUDA_ARCH__) && defined(AMREX_USE_CUDA) || \
       defined(__HIP_DEVICE_COMPILE__) && defined(AMREX_USE_HIP) || \
       (defined(_GNU_SOURCE) && !defined(__APPLE__))
@@ -142,7 +142,7 @@ std::pair<float,float> sincos (float x)
 {
     std::pair<float,float> r;
 #if defined(AMREX_USE_SYCL)
-    r.first = sycl::sincos(x, &r.second);
+    r.first = sycl::sincos(x, sycl::private_ptr<float>(&r.second));
 #elif defined(__CUDA_ARCH__) && defined(AMREX_USE_CUDA) || \
       defined(__HIP_DEVICE_COMPILE__) && defined(AMREX_USE_HIP) || \
       (defined(_GNU_SOURCE) && !defined(__APPLE__))
@@ -160,7 +160,7 @@ std::pair<double,double> sincospi (double x)
 {
     std::pair<double,double> r;
 #if defined(AMREX_USE_SYCL)
-    r.first = sycl::sincos(pi<double>()*x, &r.second);
+    r.first = sycl::sincos(pi<double>()*x, sycl::private_ptr<double>(&r.second));
 #elif defined(__CUDA_ARCH__) && defined(AMREX_USE_CUDA) || \
       defined(__HIP_DEVICE_COMPILE__) && defined(AMREX_USE_HIP)
     ::sincospi(x, &r.first, &r.second);
@@ -177,7 +177,7 @@ std::pair<float,float> sincospi (float x)
 {
     std::pair<float,float> r;
 #if defined(AMREX_USE_SYCL)
-    r.first = sycl::sincos(pi<float>()*x, &r.second);
+    r.first = sycl::sincos(pi<float>()*x, sycl::private_ptr<float>(&r.second));
 #elif defined(__CUDA_ARCH__) && defined(AMREX_USE_CUDA) || \
       defined(__HIP_DEVICE_COMPILE__) && defined(AMREX_USE_HIP)
     ::sincospif(x, &r.first, &r.second);

--- a/Src/Base/AMReX_Math.H
+++ b/Src/Base/AMReX_Math.H
@@ -159,14 +159,11 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 std::pair<double,double> sincospi (double x)
 {
     std::pair<double,double> r;
-#if defined(AMREX_USE_SYCL)
-    r.first = sycl::sincos(pi<double>()*x, sycl::private_ptr<double>(&r.second));
-#elif defined(__CUDA_ARCH__) && defined(AMREX_USE_CUDA) || \
-      defined(__HIP_DEVICE_COMPILE__) && defined(AMREX_USE_HIP)
+#if defined(__CUDA_ARCH__) && defined(AMREX_USE_CUDA) || \
+    defined(__HIP_DEVICE_COMPILE__) && defined(AMREX_USE_HIP)
     ::sincospi(x, &r.first, &r.second);
 #else
-    r.first  = std::sin(pi<double>()*x);
-    r.second = std::cos(pi<double>()*x);
+    r = sincos(pi<double>()*x);
 #endif
     return r;
 }
@@ -176,14 +173,11 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 std::pair<float,float> sincospi (float x)
 {
     std::pair<float,float> r;
-#if defined(AMREX_USE_SYCL)
-    r.first = sycl::sincos(pi<float>()*x, sycl::private_ptr<float>(&r.second));
-#elif defined(__CUDA_ARCH__) && defined(AMREX_USE_CUDA) || \
-      defined(__HIP_DEVICE_COMPILE__) && defined(AMREX_USE_HIP)
+#if defined(__CUDA_ARCH__) && defined(AMREX_USE_CUDA) || \
+    defined(__HIP_DEVICE_COMPILE__) && defined(AMREX_USE_HIP)
     ::sincospif(x, &r.first, &r.second);
 #else
-    r.first  = std::sin(pi<float>()*x);
-    r.second = std::cos(pi<float>()*x);
+    r = sincos(pi<float>()*x);
 #endif
     return r;
 }

--- a/Src/Base/AMReX_Math.H
+++ b/Src/Base/AMReX_Math.H
@@ -33,13 +33,28 @@ namespace amrex { namespace Math {
 // Since Intel's SYCL compiler now supports the following std functions on device,
 // one no longer needs to use amrex::Math::abs, etc.  They are kept here for
 // backward compatability.
+
 using std::abs;
 using std::ceil;
 using std::copysign;
 using std::floor;
 using std::round;
+
+// However, since Intel's SYCL compiler is very aggressive with fast floating
+// point optimisations, the following must be kept, as using the std functions
+// always evaluates to false (even at -O1).
+
+#ifdef AMREX_USE_SYCL
+
+using sycl::isfinite;
+using sycl::isinf;
+
+#else
+
 using std::isfinite;
 using std::isinf;
+
+#endif
 
 template <typename T>
 constexpr std::enable_if_t<std::is_floating_point<T>::value,T> pi ()


### PR DESCRIPTION
Hi @WeiqunZhang,

First, this includes a small addendum to fully get rid of the SYCL math functions.
Thanks a lot for #3164 by the way, I'm slowly phasing out the patches I once needed for Open SYCL (formerly hipSYCL).
Also, do we still need the conditional for CUDA/HIP, i.e. do we need to distinguish between `::isnan` and `std::isnan`?

Second, this makes explicit use of `multi_ptr` on the fairly new `sincos()` family of functions.
This seems to be what the [standard](https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#_description_of_the_built_in_types_available_for_sycl_host_and_device) asks for, see `genfloatptr`. However, having said that, it's clear DPC++ supported the previous, much simpler syntax and I don't know if that's an extension or if it's covered by the standard under some pointer conversion magic. This more cumbersome syntax does work with both DPC++ and Open SYCL. 

Lastly, I tried to slightly mitigate the clutter I created by reusing the code from `sincos()` in `sincospi()`...

Cheers
-Nuno