### PR TITLE
Fix an issue in #3176

### DIFF
--- a/Src/Base/AMReX_FabArray.H
+++ b/Src/Base/AMReX_FabArray.H
@@ -122,6 +122,8 @@ struct MFInfo {
 
     MFInfo& SetArena (Arena* ar) noexcept { arena = ar; return *this; }
 
+    MFInfo& SetTag () noexcept { return *this; }
+
     MFInfo& SetTag (const char* t) noexcept {
         tags.emplace_back(t);
         return *this;


### PR DESCRIPTION
We need to add another version of SetTag now, otherwise it breaks WarpX.
