### PR TITLE
Clang-Tidy II

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -3,6 +3,7 @@ Checks: >
      bugprone-*,
        -bugprone-exception-escape,
      clang-analyzer-*,
+       -clang-analyzer-optin.mpi.MPI-Checker,
      clang-diagnostic-*,
      cppcoreguidelines-*,
        -cppcoreguidelines-avoid-c-arrays,
@@ -31,11 +32,7 @@ Checks: >
        -readability-magic-numbers,
        -readability-named-parameter,
        -readability-simplify-boolean-expr,
-       -readability-convert-member-functions-to-static,
-     mpi-*,
-     openmp-*'
+     mpi-*
+    '
 
 HeaderFilterRegex: '[^n][^o][^l][^i][^n][^t]\.H$'
-
-# TODO
-# * readability-convert-member-functions-to-static

--- a/.github/workflows/gcc.yml
+++ b/.github/workflows/gcc.yml
@@ -19,7 +19,9 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Dependencies
-      run: .github/workflows/dependencies/dependencies_gcc8.sh
+      run: |
+        .github/workflows/dependencies/dependencies_gcc8.sh
+        sudo apt-get install -y --no-install-recommends clang-tidy-12
     - name: Build & Install
       run: |
         mkdir build
@@ -31,7 +33,9 @@ jobs:
             -DCMAKE_INSTALL_PREFIX=/tmp/my-amrex  \
             -DCMAKE_C_COMPILER=$(which gcc-8)     \
             -DCMAKE_CXX_COMPILER=$(which g++-8)   \
-            -DCMAKE_Fortran_COMPILER=$(which gfortran-8)
+            -DCMAKE_Fortran_COMPILER=$(which gfortran-8) \
+            -DAMReX_CLANG_TIDY=ON \
+            -DAMReX_CLANG_TIDY_WERROR=ON
         make -j 2
         make install
         make test_install

--- a/Src/Amr/AMReX_Amr.H
+++ b/Src/Amr/AMReX_Amr.H
@@ -44,19 +44,21 @@ public:
         LevelBld* a_levelbld /* One must pass LevelBld* as an argument now*/);
 
     Amr (const Amr& rhs) = delete;
+    Amr (Amr&& rhs) = delete;
     Amr& operator= (const Amr& rhs) = delete;
+    Amr& operator= (Amr&& rhs) = delete;
 
     void InitAmr ();
 
     //! The destructor.
-    virtual ~Amr ();
+    ~Amr () override;
 
     //! Init data after construction. Must be called before timestepping.
     virtual void init (Real strt_time, Real stop_time);
 
     //! First part of initialInit
     void InitializeInit (Real strt_time, Real stop_time,
-                         const BoxArray* lev0_grids = 0, const Vector<int>* pmap = 0);
+                         const BoxArray* lev0_grids = nullptr, const Vector<int>* pmap = nullptr);
 
     //! Second part of initialInit
     void FinalizeInit (Real strt_time, Real stop_time);
@@ -68,10 +70,10 @@ public:
     void setDtLevel (Real dt, int lev) noexcept;
 
     //! Set the dtmin on each level.
-    void setDtMin (const Vector<Real>& dt_lev) noexcept;
+    void setDtMin (const Vector<Real>& dt_min_in) noexcept;
 
     //! Set the cycle count on each level.
-    void setNCycle (const Vector<int>& mss) noexcept;
+    void setNCycle (const Vector<int>& ns) noexcept;
 
     //! Subcycle in time?
     int subCycle () const noexcept { return sub_cycle; }
@@ -107,7 +109,7 @@ public:
     //! Which step are we at for the specified level?
     void setLevelCount (int lev, int n) noexcept { level_count[lev] = n; }
     //! Whether to regrid right after restart
-    bool RegridOnRestart () const noexcept;
+    static bool RegridOnRestart () noexcept;
     //! Interval between regridding.
     int regridInt (int lev) const noexcept { return regrid_int[lev]; }
     //! Number of time steps between checkpoint files.
@@ -197,7 +199,7 @@ public:
     //! More work to be done?
     int okToContinue () noexcept;
     //! Rebuild grid hierarchy finer than lbase.
-    virtual void regrid (int  lbase,
+    void regrid (int  lbase,
                          Real time,
                          bool initial = false) override;
     //! Regrid only!
@@ -208,7 +210,7 @@ public:
     static const BoxArray& initialBa (int level) noexcept
         { BL_ASSERT(level-1 < initial_ba.size()); return initial_ba[level-1]; }
     //! Number of levels at which the grids are initially specified
-    static int initialBaLevels () noexcept { return initial_ba.size(); }
+    static int initialBaLevels () noexcept { return static_cast<int>(initial_ba.size()); }
     //! Do a complete integration cycle.
     virtual void coarseTimeStep (Real stop_time);
 
@@ -226,7 +228,7 @@ public:
     //! The ith datalog file.  Do with it what you want.
     std::ostream& DataLog (int i);
     //! The filename of the ith datalog file.
-    const std::string DataLogName (int i) const noexcept { return datalogname[i]; }
+    std::string DataLogName (int i) const noexcept { return datalogname[i]; }
     //! How many datalogs have been opened
     int NumDataLogs () noexcept;
     /**
@@ -238,9 +240,9 @@ public:
     */
     static Real computeOptimalSubcycling (int   n,
                                           int*  best,
-                                          Real* dt_max,
-                                          Real* est_work,
-                                          int*  cycle_max);
+                                          const Real* dt_max,
+                                          const Real* est_work,
+                                          const int*  cycle_max);
 
     //! Write the plot file to be used for visualization.
     virtual void writePlotFile ();
@@ -252,7 +254,7 @@ public:
     virtual void checkPoint ();
     int stepOfLastCheckPoint () const noexcept {return last_checkpoint;}
 
-    const Vector<BoxArray>& getInitialBA() noexcept;
+    static const Vector<BoxArray>& getInitialBA() noexcept;
 
     /**
     * \brief Specialized version:
@@ -325,13 +327,13 @@ public:
 
     void InstallNewDistributionMap (int lev, const DistributionMapping& newdm);
 
-    bool UsingPrecreateDirectories () noexcept;
+    static bool UsingPrecreateDirectories () noexcept;
 
 protected:
 
     //! Initialize grid hierarchy -- called by Amr::init.
     void initialInit (Real strt_time, Real stop_time,
-                      const BoxArray* lev0_grids = 0, const Vector<int>* pmap = 0);
+                      const BoxArray* lev0_grids = nullptr, const Vector<int>* pmap = nullptr);
 #ifndef AMREX_NO_PROBINIT
     //! Read the probin file.
     void readProbinFile (int& init);
@@ -341,9 +343,9 @@ protected:
     //! Restart from a checkpoint file.
     void restart (const std::string& filename);
     //! Define and initialize coarsest level.
-    void defBaseLevel (Real start_time, const BoxArray* lev0_grids = 0, const Vector<int>* pmap = 0);
+    void defBaseLevel (Real strt_time, const BoxArray* lev0_grids = nullptr, const Vector<int>* pmap = nullptr);
     //! Define and initialize refined levels.
-    void bldFineLevels (Real start_time);
+    void bldFineLevels (Real strt_time);
     //! Regrid level 0 on restart.
     virtual void regrid_level_0_on_restart ();
     //! Define new grid locations (called from regrid) and put into new_grids.
@@ -355,9 +357,9 @@ protected:
     DistributionMapping makeLoadBalanceDistributionMap (int lev, Real time, const BoxArray& ba) const;
     void LoadBalanceLevel0 (Real time);
 
-    virtual void ErrorEst (int lev, TagBoxArray& tags, Real time, int ngrow) override;
-    virtual BoxArray GetAreaNotToTag (int lev) override;
-    virtual void ManualTagsPlacement (int lev, TagBoxArray& tags, const Vector<IntVect>& bf_lev) override;
+    void ErrorEst (int lev, TagBoxArray& tags, Real time, int ngrow) override;
+    BoxArray GetAreaNotToTag (int lev) override;
+    void ManualTagsPlacement (int lev, TagBoxArray& tags, const Vector<IntVect>& bf_lev) override;
 
     //! Do a single timestep on level L.
     virtual void timeStep (int  level,
@@ -367,13 +369,13 @@ protected:
                            Real stop_time);
 
     // pure virtual function in AmrCore
-    virtual void MakeNewLevelFromScratch (int /*lev*/, Real /*time*/, const BoxArray& /*ba*/, const DistributionMapping& /*dm*/) override
+    void MakeNewLevelFromScratch (int /*lev*/, Real /*time*/, const BoxArray& /*ba*/, const DistributionMapping& /*dm*/) override
         { amrex::Abort("How did we get here!"); }
-    virtual void MakeNewLevelFromCoarse (int /*lev*/, Real /*time*/, const BoxArray& /*ba*/, const DistributionMapping& /*dm*/) override
+    void MakeNewLevelFromCoarse (int /*lev*/, Real /*time*/, const BoxArray& /*ba*/, const DistributionMapping& /*dm*/) override
         { amrex::Abort("How did we get here!"); }
-    virtual void RemakeLevel (int /*lev*/, Real /*time*/, const BoxArray& /*ba*/, const DistributionMapping& /*dm*/) override
+    void RemakeLevel (int /*lev*/, Real /*time*/, const BoxArray& /*ba*/, const DistributionMapping& /*dm*/) override
         { amrex::Abort("How did we get here!"); }
-    virtual void ClearLevel (int /*lev*/) override
+    void ClearLevel (int /*lev*/) override
         { amrex::Abort("How did we get here!"); }
 
     //! Whether to write a plotfile now
@@ -395,7 +397,7 @@ protected:
     void initSubcycle();
     void initPltAndChk();
 
-    int initInSitu();
+    static int initInSitu();
     int updateInSitu();
     static int finalizeInSitu();
 

--- a/Src/Amr/AMReX_Amr.cpp
+++ b/Src/Amr/AMReX_Amr.cpp
@@ -163,7 +163,7 @@ Amr::NumDataLogs () noexcept
 }
 
 bool
-Amr::RegridOnRestart () const noexcept
+Amr::RegridOnRestart () noexcept
 {
     return regrid_on_restart;
 }
@@ -204,7 +204,6 @@ Amr::derive (const std::string& name,
 
 Amr::Amr (LevelBld* a_levelbld)
     :
-    AmrCore(),
     levelbld(a_levelbld)
 {
     Initialize();
@@ -513,7 +512,7 @@ Amr::initInSitu()
 }
 
 int
-Amr::updateInSitu()
+Amr::updateInSitu() // NOLINT(readability-convert-member-functions-to-static)
 {
 #if defined(AMREX_USE_SENSEI_INSITU) && !defined(AMREX_NO_SENSEI_AMR_INST)
     if (insitu_bridge && insitu_bridge->update(this))
@@ -841,7 +840,7 @@ Amr::writePlotFile ()
 
     // Don't continue if we have no variables to plot.
 
-    if (statePlotVars().size() == 0) {
+    if (statePlotVars().empty()) {
         return;
     }
 
@@ -880,7 +879,7 @@ Amr::writeSmallPlotFile ()
 
     // Don't continue if we have no variables to plot.
 
-    if (stateSmallPlotVars().size() == 0 && deriveSmallPlotVars().size() == 0) {
+    if (stateSmallPlotVars().empty() && deriveSmallPlotVars().empty()) {
         return;
     }
 
@@ -1396,14 +1395,15 @@ Amr::restart (const std::string& filename)
       bool bExitOnError(false);  // ---- dont exit if this file does not exist
       ParallelDescriptor::ReadAndBcastFile(faHeaderFilesName, faHeaderFileChars,
                                            bExitOnError);
-      if(faHeaderFileChars.size() > 0) {  // ---- headers were read
+      if(!faHeaderFileChars.empty()) {  // ---- headers were read
         std::string faFileCharPtrString(faHeaderFileChars.dataPtr());
         std::istringstream fais(faFileCharPtrString, std::istringstream::in);
         while ( ! fais.eof()) {  // ---- read and broadcast each header
           std::string faHeaderName;
           fais >> faHeaderName;
           if( ! fais.eof()) {
-              std::string faHeaderFullName(filename + '/' + faHeaderName + "_H");
+              std::string faHeaderFullName(filename);
+              faHeaderFullName.append("/").append(faHeaderName).append("_H");
               Vector<char> &tempCharArray = faHeaderMap[faHeaderFullName];
               ParallelDescriptor::ReadAndBcastFile(faHeaderFullName, tempCharArray);
               if(verbose > 2) {
@@ -1796,7 +1796,7 @@ Amr::checkPoint ()
 
     if (ParallelDescriptor::IOProcessor()) {
         const Vector<std::string> &FAHeaderNames = StateData::FabArrayHeaderNames();
-        if(FAHeaderNames.size() > 0) {
+        if(!FAHeaderNames.empty()) {
             std::string FAHeaderFilesName = ckfileTemp + "/FabArrayHeaders.txt";
             std::ofstream FAHeaderFile(FAHeaderFilesName.c_str(),
                                        std::ios::out | std::ios::trunc |
@@ -2475,7 +2475,7 @@ Amr::defBaseLevel (Real              strt_time,
 
     BoxArray lev0;
 
-    if (lev0_grids != nullptr && lev0_grids->size() > 0)
+    if (lev0_grids != nullptr && !lev0_grids->empty())
     {
         BL_ASSERT(pmap != nullptr);
 
@@ -3245,7 +3245,7 @@ Amr::okToRegrid(int level) noexcept
 }
 
 Real
-Amr::computeOptimalSubcycling(int n, int* best, Real* dt_max, Real* est_work, int* cycle_max)
+Amr::computeOptimalSubcycling(int n, int* best, const Real* dt_max, const Real* est_work, const int* cycle_max)
 {
     BL_ASSERT(cycle_max[0] == 1);
     // internally these represent the total number of steps at a level,

--- a/Src/Amr/AMReX_AmrLevel.H
+++ b/Src/Amr/AMReX_AmrLevel.H
@@ -51,10 +51,16 @@ public:
                      AmrOtherTime };
     //! The destructor.
     virtual ~AmrLevel ();
+
+    AmrLevel (const AmrLevel&) = delete;
+    AmrLevel (AmrLevel&&) = delete;
+    AmrLevel& operator= (const AmrLevel&) = delete;
+    AmrLevel& operator= (AmrLevel&&) = delete;
+
     //! Get the level directory names
     void LevelDirectoryNames (const std::string &dir,
                               std::string &LevelDir,
-                              std::string &FullPath);
+                              std::string &FullPath) const;
     //! Create the Level_ directory for checkpoint and plot files
     virtual void CreateLevelDirectory (const std::string &dir);
     /**
@@ -229,9 +235,9 @@ public:
     //
     const FabFactory<FArrayBox>& Factory () const noexcept { return *m_factory; }
     //! Number of grids at this level.
-    int numGrids () const noexcept { return grids.size(); }
+    int numGrids () const noexcept { return static_cast<int>(grids.size()); }
     //! Number of states at this level.
-    int numStates () const noexcept { return state.size(); }
+    int numStates () const noexcept { return static_cast<int>(state.size()); }
     //! Returns the indices defining physical domain.
     const Box& Domain () const noexcept { return geom.Domain(); }
     //! Timestep n at this level.
@@ -263,8 +269,8 @@ public:
                            Real         time,
                            int          n_error_buf = 0,
                            int          ngrow = 0) = 0;
-    //! Interpolate from coarse level to the valid area in dest.
-    void FillCoarsePatch (MultiFab& dest,
+    //! Interpolate from coarse level to the valid area in mf.
+    void FillCoarsePatch (MultiFab& mf,
                           int       dcomp,
                           Real      time,
                           int       state_idx,
@@ -310,7 +316,7 @@ public:
     //! Returns list of derived variables.
     static DeriveList& get_derive_lst () noexcept;
     //! Returns whether or not we want a post-timestep regrid.
-    int postStepRegrid () noexcept { return post_step_regrid; }
+    int postStepRegrid () const noexcept { return post_step_regrid; }
     //! Sets a new value for the post-timestep regrid trigger.
     void setPostStepRegrid (int new_val) noexcept { post_step_regrid = new_val; }
 
@@ -320,7 +326,7 @@ public:
     //! Boundary condition access function.
     Vector<int> getBCArray (int State_Type,
                             int gridno,
-                            int scomp,
+                            int strt_comp,
                             int ncomp);
     //! Get state data at specified index and time.
     MultiFab& get_data (int  state_indx, Real time) noexcept;
@@ -445,17 +451,14 @@ public:
 
 protected:
     //! The constructors -- for derived classes.
-    AmrLevel () noexcept;
+    AmrLevel () noexcept {} // NOLINT
 
     AmrLevel (Amr&            papa,
               int             lev,
               const Geometry& level_geom,
-              const BoxArray& bl,
+              const BoxArray& ba,
               const DistributionMapping& dm,
               Real            time);
-
-    AmrLevel (const AmrLevel&) = delete;
-    AmrLevel& operator = (const AmrLevel&) = delete;
 
     //! Common code used by all constructors.
     void finishConstructor ();
@@ -463,23 +466,23 @@ protected:
     //
     // The Data.
     //
-    int                   level;        // AMR level (0 is coarsest).
+    int                   level{-1};    // AMR level (0 is coarsest).
     Geometry              geom;         // Geom at this level.
     BoxArray              grids;        // Cell-centered locations of grids.
     DistributionMapping   dmap;         // Distribution of grids among processes
-    Amr*                  parent;       // Pointer to parent AMR structure.
+    Amr*                  parent{nullptr};// Pointer to parent AMR structure.
     IntVect               crse_ratio;   // Refinement ratio to coarser level.
     IntVect               fine_ratio;   // Refinement ratio to finer level.
     static DeriveList     derive_lst;   // List of derived quantities.
     static DescriptorList desc_lst;     // List of state variables.
     Vector<StateData>     state;        // Array of state data.
 
-    BoxArray              m_AreaNotToTag; //Area which shouldn't be tagged on this level.
-    Box                   m_AreaToTag;    //Area which is allowed to be tagged on this level.
+    BoxArray m_AreaNotToTag; //Area which shouldn't be tagged on this level.
+    Box      m_AreaToTag;    //Area which is allowed to be tagged on this level.
 
-    int                   post_step_regrid; // Whether or not to do a regrid after the timestep.
+    int post_step_regrid{0}; // Whether or not to do a regrid after the timestep.
 
-    bool                  levelDirectoryCreated;    // for checkpoints and plotfiles
+    bool levelDirectoryCreated{false}; // for checkpoints and plotfiles
 
     std::unique_ptr<FabFactory<FArrayBox> > m_factory;
 
@@ -519,17 +522,15 @@ class FillPatchIterator
                        MultiFab& leveldata,
                        int       boxGrow,
                        Real      time,
-                       int       state_indx,
+                       int       idx,
                        int       scomp,
                        int       ncomp);
 
     void Initialize (int  boxGrow,
                      Real time,
-                     int  state_indx,
+                     int  idx,
                      int  scomp,
                      int  ncomp);
-
-    ~FillPatchIterator () = default;
 
     FArrayBox& operator() () noexcept { return m_fabs[MFIter::index()]; }
 
@@ -538,15 +539,9 @@ class FillPatchIterator
     MultiFab& get_mf() noexcept { return m_fabs; }
 
 private:
-    //
-    // Disallowed.
-    //
-    FillPatchIterator ();
-    FillPatchIterator (const FillPatchIterator& rhs);
-    FillPatchIterator& operator= (const FillPatchIterator& rhs);
 
-    void FillFromLevel0 (Real time, int index, int scomp, int dcomp, int ncomp);
-    void FillFromTwoLevels (Real time, int index, int scomp, int dcomp, int ncomp);
+    void FillFromLevel0 (Real time, int idx, int scomp, int dcomp, int ncomp);
+    void FillFromTwoLevels (Real time, int idx, int scomp, int dcomp, int ncomp);
 
     //
     // The data.
@@ -571,29 +566,21 @@ public:
                              MultiFab&     leveldata,
                              int           boxGrow,
                              Real          time,
-                             int           state_indx,
+                             int           index,
                              int           scomp,
                              int           ncomp,
                              InterpBase*   mapper);
 
     void Initialize (int           boxGrow,
                      Real          time,
-                     int           state_indx,
+                     int           idx,
                      int           scomp,
                      int           ncomp,
                      InterpBase*   mapper);
 
-    ~FillPatchIteratorHelper () = default;
-
     void fill (FArrayBox& fab, int dcomp, int idx);
 
 private:
-    //
-    // Disallowed.
-    //
-    FillPatchIteratorHelper ();
-    FillPatchIteratorHelper (const FillPatchIteratorHelper& rhs);
-    FillPatchIteratorHelper& operator= (const FillPatchIteratorHelper& rhs);
     //
     // The data.
     //

--- a/Src/Amr/AMReX_AmrLevel.cpp
+++ b/Src/Amr/AMReX_AmrLevel.cpp
@@ -72,15 +72,6 @@ AmrLevel::manual_tags_placement (TagBoxArray& /*tags*/,
                                  const Vector<IntVect>& /*bf_lev*/)
 {}
 
-AmrLevel::AmrLevel () noexcept
-{
-
-   BL_PROFILE("AmrLevel::AmrLevel()");
-   parent = nullptr;
-   level = -1;
-   levelDirectoryCreated = false;
-}
-
 AmrLevel::AmrLevel (Amr&            papa,
                     int             lev,
                     const Geometry& level_geom,
@@ -164,7 +155,7 @@ AmrLevel::writePlotFile (const std::string& dir,
     {
         for (int comp = 0; comp < desc_lst[typ].nComp();comp++)
         {
-            if (parent->isStatePlotVar(desc_lst[typ].name(comp)) &&
+            if (amrex::Amr::isStatePlotVar(desc_lst[typ].name(comp)) &&
                 desc_lst[typ].getType() == IndexType::TheCellType())
             {
                 plot_var_map.emplace_back(typ,comp);
@@ -177,7 +168,7 @@ AmrLevel::writePlotFile (const std::string& dir,
     const std::list<DeriveRec>& dlist = derive_lst.dlist();
     for (auto const& d : dlist)
     {
-        if (parent->isDerivePlotVar(d.name()))
+        if (amrex::Amr::isDerivePlotVar(d.name()))
         {
             derive_names.push_back(d.name());
             num_derive += d.numDerive();
@@ -344,7 +335,7 @@ AmrLevel::writePlotFile (const std::string& dir,
     }
 
     // derived
-    if (derive_names.size() > 0)
+    if (!derive_names.empty())
     {
         for (auto const& dname : derive_names)
         {
@@ -490,11 +481,11 @@ AmrLevel::setTimeLevel (Real time,
 }
 
 bool
-AmrLevel::isStateVariable (const std::string& name, int& typ, int& n)
+AmrLevel::isStateVariable (const std::string& name, int& state_indx, int& n)
 {
-    for (typ = 0; typ < desc_lst.size(); typ++)
+    for (state_indx = 0; state_indx < desc_lst.size(); state_indx++)
     {
-        const StateDescriptor& desc = desc_lst[typ];
+        const StateDescriptor& desc = desc_lst[state_indx];
 
         for (n = 0; n < desc.nComp(); n++)
         {
@@ -1896,11 +1887,11 @@ AmrLevel::setPlotVariables ()
             pp.get("plot_vars", nm, i);
 
             if (nm == "ALL")
-                parent->fillStatePlotVarList();
+                amrex::Amr::fillStatePlotVarList();
             else if (nm == "NONE")
-                parent->clearStatePlotVarList();
+                amrex::Amr::clearStatePlotVarList();
             else
-                parent->addStatePlotVar(nm);
+                amrex::Amr::addStatePlotVar(nm);
         }
     }
     else
@@ -1908,7 +1899,7 @@ AmrLevel::setPlotVariables ()
         //
         // The default is to add them all.
         //
-        parent->fillStatePlotVarList();
+        amrex::Amr::fillStatePlotVarList();
     }
 
     if (pp.contains("derive_plot_vars"))
@@ -1922,11 +1913,11 @@ AmrLevel::setPlotVariables ()
             pp.get("derive_plot_vars", nm, i);
 
             if (nm == "ALL")
-                parent->fillDerivePlotVarList();
+                amrex::Amr::fillDerivePlotVarList();
             else if (nm == "NONE")
-                parent->clearDerivePlotVarList();
+                amrex::Amr::clearDerivePlotVarList();
             else
-                parent->addDerivePlotVar(nm);
+                amrex::Amr::addDerivePlotVar(nm);
         }
     }
     else
@@ -1934,7 +1925,7 @@ AmrLevel::setPlotVariables ()
         //
         // The default is to add none of them.
         //
-        parent->clearDerivePlotVarList();
+        amrex::Amr::clearDerivePlotVarList();
     }
 }
 
@@ -1954,11 +1945,11 @@ AmrLevel::setSmallPlotVariables ()
             pp.get("small_plot_vars", nm, i);
 
             if (nm == "ALL")
-                parent->fillStateSmallPlotVarList();
+                amrex::Amr::fillStateSmallPlotVarList();
             else if (nm == "NONE")
-                parent->clearStateSmallPlotVarList();
+                amrex::Amr::clearStateSmallPlotVarList();
             else
-                parent->addStateSmallPlotVar(nm);
+                amrex::Amr::addStateSmallPlotVar(nm);
         }
     }
     else
@@ -1966,7 +1957,7 @@ AmrLevel::setSmallPlotVariables ()
         //
         // The default is to use none.
         //
-        parent->clearStateSmallPlotVarList();
+        amrex::Amr::clearStateSmallPlotVarList();
     }
 
     if (pp.contains("derive_small_plot_vars"))
@@ -1980,11 +1971,11 @@ AmrLevel::setSmallPlotVariables ()
             pp.get("derive_small_plot_vars", nm, i);
 
             if (nm == "ALL")
-                parent->fillDeriveSmallPlotVarList();
+                amrex::Amr::fillDeriveSmallPlotVarList();
             else if (nm == "NONE")
-                parent->clearDeriveSmallPlotVarList();
+                amrex::Amr::clearDeriveSmallPlotVarList();
             else
-                parent->addDeriveSmallPlotVar(nm);
+                amrex::Amr::addDeriveSmallPlotVar(nm);
         }
     }
     else
@@ -1992,7 +1983,7 @@ AmrLevel::setSmallPlotVariables ()
         //
         // The default is to add none of them.
         //
-        parent->clearDeriveSmallPlotVarList();
+        amrex::Amr::clearDeriveSmallPlotVarList();
     }
 
 }
@@ -2077,7 +2068,7 @@ void AmrLevel::constructAreaNotToTag ()
         //    as the region in which we allow tagging.
         // Why level-1? Because we always use the full domain at level 0
         //    and therefore level 0 in initialba is level 1 in the AMR hierarchy, etc.
-        const Vector<BoxArray>& initialba = parent->getInitialBA();
+        const Vector<BoxArray>& initialba = amrex::Amr::getInitialBA();
         Box tagarea(initialba[level-1].minimalBox());
         tagarea.grow(-parent->blockingFactor(level));
         m_AreaToTag = tagarea;
@@ -2202,7 +2193,7 @@ AmrLevel::FillPatchAdd (AmrLevel& amrlevel,
 void
 AmrLevel::LevelDirectoryNames (const std::string &dir,
                                std::string &LevelDir,
-                               std::string &FullPath)
+                               std::string &FullPath) const
 {
     LevelDir = amrex::Concatenate("Level_", level, 1);
     //

--- a/Src/Amr/AMReX_AuxBoundaryData.H
+++ b/Src/Amr/AMReX_AuxBoundaryData.H
@@ -12,15 +12,19 @@ class AuxBoundaryData
 {
 public:
 
-    AuxBoundaryData () noexcept;
+    AuxBoundaryData () noexcept = default;
 
-    AuxBoundaryData (const BoxArray& grids,
+    AuxBoundaryData (const BoxArray& ba,
                      int             n_grow,
                      int             n_comp,
                      const Geometry& geom);
 
-    AuxBoundaryData (const AuxBoundaryData& rhs);
+    ~AuxBoundaryData () = default;
 
+    AuxBoundaryData (AuxBoundaryData&& rhs) = default;
+    AuxBoundaryData& operator= (AuxBoundaryData&& rhs) = default;
+
+    AuxBoundaryData (const AuxBoundaryData& rhs);
     AuxBoundaryData& operator= (const AuxBoundaryData& rhs) = delete;
 
     void copyTo (MultiFab& destmf,
@@ -44,7 +48,7 @@ public:
                int                    dst_comp,
                int                    num_comp);
 
-    void initialize (const BoxArray& grids,
+    void initialize (const BoxArray& ba,
                      int             n_grow,
                      int             n_comp,
                      const Geometry& geom);
@@ -82,9 +86,9 @@ public:
 private:
 
     MultiFab m_fabs;
-    int      m_ngrow;
-    bool     m_empty;
-    bool     m_initialized;
+    int      m_ngrow{0};
+    bool     m_empty{false};
+    bool     m_initialized{false};
 };
 // \endcond
 

--- a/Src/Amr/AMReX_AuxBoundaryData.cpp
+++ b/Src/Amr/AMReX_AuxBoundaryData.cpp
@@ -8,21 +8,13 @@
 
 namespace amrex {
 // \cond CODEGEN
-AuxBoundaryData::AuxBoundaryData () noexcept
-    :
-    m_ngrow(0),
-    m_empty(false),
-    m_initialized(false)
-{}
 
 AuxBoundaryData::AuxBoundaryData (const BoxArray& ba,
                                   int             n_grow,
                                   int             n_comp,
                                   const Geometry& geom)
     :
-    m_ngrow(n_grow),
-    m_empty(false),
-    m_initialized(false)
+    m_ngrow(n_grow)
 {
     initialize(ba,n_grow,n_comp,geom);
 }
@@ -96,7 +88,7 @@ AuxBoundaryData::initialize (const BoxArray& ba,
 
     gcells.clear();
 
-    if (nba.size() > 0)
+    if (!nba.empty())
     {
         m_fabs.define(nba, ndm, n_comp, 0, MFInfo(), FArrayBoxFactory());
     }
@@ -132,7 +124,7 @@ AuxBoundaryData::copyTo (MultiFab& mf,
 {
     BL_ASSERT(m_initialized);
 
-    if (!m_empty && mf.size() > 0)
+    if (!m_empty && !mf.empty())
     {
         mf.ParallelCopy(m_fabs,src_comp,dst_comp,num_comp,0,mf.nGrow());
     }
@@ -147,7 +139,7 @@ AuxBoundaryData::copyFrom (const MultiFab& mf,
 {
     BL_ASSERT(m_initialized);
 
-    if (!m_empty && mf.size() > 0)
+    if (!m_empty && !mf.empty())
     {
         m_fabs.ParallelCopy(mf,src_comp,dst_comp,num_comp,src_ng,0);
     }

--- a/Src/Amr/AMReX_Derive.H
+++ b/Src/Amr/AMReX_Derive.H
@@ -375,21 +375,21 @@ public:
               IndexType               result_type,
               int                     nvar_derive,
               DeriveFunc              der_func,
-              DeriveRec::DeriveBoxMap box_map,
+              const DeriveRec::DeriveBoxMap& bx_map,
               Interpolater*           interp = &pc_interp);
 
     void add (const std::string&      name,
               IndexType               result_type,
               int                     nvar_derive,
               DeriveFunc3D            der_func_3d,
-              DeriveRec::DeriveBoxMap box_map,
+              const DeriveRec::DeriveBoxMap& bx_map,
               Interpolater*           interp = &pc_interp);
 
     void add (const std::string&      name,
               IndexType               result_type,
               int                     nvar_derive,
-              DeriveFuncFab           der_func_fab,
-              DeriveRec::DeriveBoxMap box_map,
+              const DeriveFuncFab&           der_func_fab,
+              const DeriveRec::DeriveBoxMap& bx_map,
               Interpolater*           interp = &pc_interp);
 
 
@@ -404,7 +404,7 @@ public:
     void add (const std::string&      name,
               IndexType               result_type,
               int                     nvar_derive,
-              DeriveRec::DeriveBoxMap box_map = &DeriveRec::TheSameBox );
+              const DeriveRec::DeriveBoxMap& box_map = &DeriveRec::TheSameBox );
 
     /**
     * \brief Adds another entry to the registry.
@@ -418,27 +418,27 @@ public:
     * \param interp
     */
     void add (const std::string&      name,
-              IndexType               result_type,
+              IndexType               res_typ,
               int                     nvar_derive,
-              Vector<std::string> const&    var_names,
+              Vector<std::string> const&    vars,
               DeriveFunc              der_func,
-              DeriveRec::DeriveBoxMap box_map,
+              const DeriveRec::DeriveBoxMap& bx_map,
               Interpolater*           interp = &pc_interp);
 
     void add (const std::string&      name,
-              IndexType               result_type,
+              IndexType               res_typ,
               int                     nvar_derive,
-              Vector<std::string> const&    var_names,
+              Vector<std::string> const&    vars,
               DeriveFunc3D            der_func_3d,
-              DeriveRec::DeriveBoxMap box_map,
+              const DeriveRec::DeriveBoxMap& bx_map,
               Interpolater*           interp = &pc_interp);
 
     void add (const std::string&      name,
-              IndexType               result_type,
+              IndexType               res_typ,
               int                     nvar_derive,
-              Vector<std::string> const&    var_names,
-              DeriveFuncFab           der_func_fab,
-              DeriveRec::DeriveBoxMap box_map,
+              Vector<std::string> const&    vars,
+              const DeriveFuncFab&           der_func_fab,
+              const DeriveRec::DeriveBoxMap& bx_map,
               Interpolater*           interp = &pc_interp);
 
     /**
@@ -453,8 +453,8 @@ public:
     void addComponent (const std::string&    name,
                        const DescriptorList& d_list,
                        int                   state_indx,
-                       int                   start_comp,
-                       int                   ncomp);
+                       int                   s_comp,
+                       int                   n_comp);
 
     std::list<DeriveRec>& dlist ();
 

--- a/Src/Amr/AMReX_Derive.cpp
+++ b/Src/Amr/AMReX_Derive.cpp
@@ -27,7 +27,6 @@ DeriveRec::DeriveRec (std::string    a_name,
                       Interpolater*  a_interp)
     :
     derive_name(std::move(a_name)),
-    variable_names(),
     der_type(result_type),
     n_derive(nvar_derive),
     func(der_func),
@@ -43,7 +42,6 @@ DeriveRec::DeriveRec (std::string    a_name,
                       Interpolater*  a_interp)
     :
     derive_name(std::move(a_name)),
-    variable_names(),
     der_type(result_type),
     n_derive(nvar_derive),
     func_3d(der_func_3d),
@@ -59,7 +57,6 @@ DeriveRec::DeriveRec (std::string    a_name,
                       Interpolater*  a_interp)
     :
     derive_name(std::move(a_name)),
-    variable_names(),
     der_type(result_type),
     n_derive(nvar_derive),
     func_fab(std::move(der_func_fab)),
@@ -74,7 +71,6 @@ DeriveRec::DeriveRec (std::string             a_name,
                       DeriveRec::DeriveBoxMap box_map)
     :
     derive_name(std::move(a_name)),
-    variable_names(),
     der_type(result_type),
     n_derive(nvar_derive),
     bx_map(std::move(box_map))
@@ -343,7 +339,7 @@ DeriveList::add (const std::string&      name,
                  IndexType               result_type,
                  int                     nvar_der,
                  DeriveFunc              der_func,
-                 DeriveRec::DeriveBoxMap bx_map,
+                 const DeriveRec::DeriveBoxMap& bx_map,
                  Interpolater*           interp)
 {
     lst.emplace_back(name,result_type,nvar_der,der_func,bx_map,interp);
@@ -354,7 +350,7 @@ DeriveList::add (const std::string&      name,
                  IndexType               result_type,
                  int                     nvar_der,
                  DeriveFunc3D            der_func_3d,
-                 DeriveRec::DeriveBoxMap bx_map,
+                 const DeriveRec::DeriveBoxMap& bx_map,
                  Interpolater*           interp)
 {
     lst.emplace_back(name,result_type,nvar_der,der_func_3d,bx_map,interp);
@@ -364,8 +360,8 @@ void
 DeriveList::add (const std::string&      name,
                  IndexType               result_type,
                  int                     nvar_der,
-                 DeriveFuncFab           der_func_fab,
-                 DeriveRec::DeriveBoxMap bx_map,
+                 const DeriveFuncFab&           der_func_fab,
+                 const DeriveRec::DeriveBoxMap& bx_map,
                  Interpolater*           interp)
 {
     lst.emplace_back(name,result_type,nvar_der,der_func_fab,bx_map,interp);
@@ -376,7 +372,7 @@ void
 DeriveList::add (const std::string&      name,
                  IndexType               result_type,
                  int                     nvar_der,
-                 DeriveRec::DeriveBoxMap box_map)
+                 const DeriveRec::DeriveBoxMap& box_map)
 {
     lst.emplace_back(name,result_type,nvar_der,box_map);
 }
@@ -387,7 +383,7 @@ DeriveList::add (const std::string&      name,
                  int                     nvar_der,
                  Vector<std::string> const&    vars,
                  DeriveFunc              der_func,
-                 DeriveRec::DeriveBoxMap bx_map,
+                 const DeriveRec::DeriveBoxMap& bx_map,
                  Interpolater*           interp)
 {
     lst.emplace_back(name,res_typ,nvar_der,vars,der_func,bx_map,interp);
@@ -399,7 +395,7 @@ DeriveList::add (const std::string&      name,
                  int                     nvar_der,
                  Vector<std::string> const&    vars,
                  DeriveFunc3D            der_func_3d,
-                 DeriveRec::DeriveBoxMap bx_map,
+                 const DeriveRec::DeriveBoxMap& bx_map,
                  Interpolater*           interp)
 {
     lst.emplace_back(name,res_typ,nvar_der,vars,der_func_3d,bx_map,interp);
@@ -410,8 +406,8 @@ DeriveList::add (const std::string&      name,
                  IndexType               res_typ,
                  int                     nvar_der,
                  Vector<std::string> const&    vars,
-                 DeriveFuncFab           der_func_fab,
-                 DeriveRec::DeriveBoxMap bx_map,
+                 const DeriveFuncFab&           der_func_fab,
+                 const DeriveRec::DeriveBoxMap& bx_map,
                  Interpolater*           interp)
 {
     lst.emplace_back(name,res_typ,nvar_der,vars,der_func_fab,bx_map,interp);

--- a/Src/Amr/AMReX_StateData.H
+++ b/Src/Amr/AMReX_StateData.H
@@ -66,11 +66,10 @@ public:
     ~StateData ();
 
     StateData (StateData&& rhs) noexcept;
+    StateData& operator= (StateData const& rhs);
 
     StateData (StateData const& rhs) = delete;
-    void operator= (StateData && rhs) = delete;
-    void operator= (StateData const& rhs);
-
+    StateData& operator= (StateData && rhs) = delete;
 
     /**
     * \brief Initializes data members if you used default constructor.
@@ -169,7 +168,7 @@ public:
     * \param dt_old
     * \param dt_new
     */
-    void setTimeLevel (Real t_new,
+    void setTimeLevel (Real time,
                        Real dt_old,
                        Real dt_new);
 
@@ -178,16 +177,16 @@ public:
     *
     * \param t_old
     */
-    void setOldTimeLevel (Real t_old);
+    void setOldTimeLevel (Real time);
 
     /**
     * \brief Sets time of new data.
     *
     * \param t_new
     */
-    void setNewTimeLevel (Real t_new);
+    void setNewTimeLevel (Real time);
 
-    void syncNewTimeLevel (Real t_new);
+    void syncNewTimeLevel (Real time);
 
     void RegisterData (MultiFabCopyDescriptor& multiFabCopyDesc,
                        Vector<MultiFabId>&      mfid);
@@ -271,9 +270,9 @@ public:
                   const Box&             p_domain,
                   const BoxArray&        grds,
                   const DistributionMapping& dm,
-                  const FabFactory<FArrayBox>& factroy,
+                  const FabFactory<FArrayBox>& factory,
                   const StateDescriptor& d,
-                  const std::string&     restart_file);
+                  const std::string&     chkfile);
 
     /**
     * \brief or from another similar state
@@ -419,7 +418,7 @@ private:
     };
 
     //! Pointer to data descriptor.
-    const StateDescriptor* desc;
+    const StateDescriptor* desc{nullptr};
 
     //! Problem domain.
     Box domain;
@@ -442,7 +441,7 @@ private:
     std::unique_ptr<MultiFab> old_data;
 
     //! Arena we should use for allocating the data.
-    Arena* arena;
+    Arena* arena{nullptr};
 
     /**
     * \brief This is used as a temporary collection of FabArray header
@@ -453,7 +452,7 @@ private:
     //! This is used to store preread FabArray headers
     static std::map<std::string, Vector<char> > *faHeaderMap;  // ---- [faheader name, the header]
 
-    void restartDoit (std::istream& is, const std::string& restart_file);
+    void restartDoit (std::istream& is, const std::string& chkfile);
 };
 
 class StateDataPhysBCFunct
@@ -462,7 +461,7 @@ public:
 
     StateDataPhysBCFunct (StateData& sd, int sc, const Geometry& geom_);
 
-    void operator() (MultiFab& mf, int dcomp, int ncomp, IntVect const& nghost,
+    void operator() (MultiFab& mf, int dest_comp, int num_comp, IntVect const& nghost,
                      Real time, int bccomp);
 
     void FillBoundary (MultiFab& mf, int dcomp, int ncomp, IntVect const& nghost,

--- a/Src/Amr/AMReX_StateData.cpp
+++ b/Src/Amr/AMReX_StateData.cpp
@@ -29,10 +29,10 @@ std::map<std::string, Vector<char> > *StateData::faHeaderMap;
 
 
 StateData::StateData ()
-    : desc(nullptr),
+    :
       new_time{INVALID_TIME,INVALID_TIME},
-      old_time{INVALID_TIME,INVALID_TIME},
-      arena(nullptr)
+      old_time{INVALID_TIME,INVALID_TIME}
+
 {
 }
 
@@ -61,10 +61,10 @@ StateData::StateData (StateData&& rhs) noexcept
 {
 }
 
-void
+StateData&
 StateData::operator= (StateData const& rhs)
 {
-    if (this == &rhs) return;
+    if (this == &rhs) { return *this; };
     m_factory.reset(rhs.m_factory->clone());
     desc = rhs.desc;
     arena = rhs.arena;
@@ -85,6 +85,7 @@ StateData::operator= (StateData const& rhs)
     } else {
         old_data.reset();
     }
+    return *this;
 }
 
 void

--- a/Src/Amr/AMReX_StateDescriptor.H
+++ b/Src/Amr/AMReX_StateDescriptor.H
@@ -51,7 +51,7 @@ public:
         /**
         * \brief Bogus constructor.
         */
-        BndryFunc () noexcept {}
+        BndryFunc () noexcept = default;
 
         /**
         * \brief A Constructor.
@@ -60,7 +60,7 @@ public:
 
         BndryFunc (BndryFunc3DDefault inFunc) noexcept : m_func3D(inFunc) {}
 
-        BndryFunc (BndryFuncFabDefault inFunc) noexcept : m_funcfab(inFunc) {}
+        BndryFunc (BndryFuncFabDefault inFunc) noexcept : m_funcfab(std::move(std::move(inFunc))) {}
 
         /**
         * \brief Another Constructor.
@@ -75,17 +75,6 @@ public:
             : m_func3D(inFunc), m_gfunc3D(gFunc) {}
 
         /**
-        * \brief Return a ptr to a clone of this object.
-        * It is the responsibility of the caller to delete the result.
-        */
-        virtual BndryFunc* clone () const;
-
-        /**
-        * \brief Destructor.
-        */
-        virtual ~BndryFunc () = default;
-
-        /**
         * Fill boundary cells using "regular" function.
         *
         * \param data
@@ -98,10 +87,10 @@ public:
         * \param time
         * \param bc
         */
-        virtual void operator () (Real* data, const int* lo, const int* hi,
-                                  const int* dom_lo, const int* dom_hi,
-                                  const Real* dx, const Real* grd_lo,
-                                  const Real* time, const int* bc) const;
+        void operator () (Real* data, const int* lo, const int* hi,
+                          const int* dom_lo, const int* dom_hi,
+                          const Real* dx, const Real* grd_lo,
+                          const Real* time, const int* bc) const;
 
         /**
         * \brief Fill boundary cells using "group" function.
@@ -117,22 +106,22 @@ public:
         * \param bc
         * \param ng
         */
-        virtual void operator () (Real* data, const int* lo, const int* hi,
-                                  const int* dom_lo, const int* dom_hi,
-                                  const Real* dx, const Real* grd_lo,
-                                  const Real* time, const int* bc, int ng) const;
+        void operator () (Real* data, const int* lo, const int* hi,
+                          const int* dom_lo, const int* dom_hi,
+                          const Real* dx, const Real* grd_lo,
+                          const Real* time, const int* bc, int ng) const;
 
-        virtual void operator () (Box const& bx, FArrayBox& data,
-                                  const int dcomp, const int numcomp,
-                                  Geometry const& geom, const Real time,
-                                  const Vector<BCRec>& bcr, const int bcomp,
-                                  const int scomp) const;
+        void operator () (Box const& bx, FArrayBox& data,
+                          int dcomp, int numcomp,
+                          Geometry const& geom, Real time,
+                          const Vector<BCRec>& bcr, int bcomp,
+                          int scomp) const;
 
-        virtual bool RunOnGPU () const noexcept { return m_run_on_gpu; }
+        [[nodiscard]] bool RunOnGPU () const noexcept { return m_run_on_gpu; }
 
         void setRunOnGPU (bool b) noexcept { m_run_on_gpu = b; }
 
-        virtual bool hasFabVersion () const noexcept { return m_funcfab != nullptr; }
+        [[nodiscard]] bool hasFabVersion () const noexcept { return m_funcfab != nullptr; }
 
     private:
 
@@ -147,7 +136,7 @@ public:
     /**
     * \brief The default constructor.
     */
-    StateDescriptor () noexcept;
+    StateDescriptor () noexcept = default;
 
     /**
     * \brief Constructor that sets all data members.
@@ -169,11 +158,6 @@ public:
                      InterpBase*   interp,
                      bool          extrap = false,
                      bool          store_in_checkpoint = true);
-
-    /**
-    * \brief The destructor.
-    */
-    ~StateDescriptor ();
 
     /**
     * \brief Define the data members if constructed with default constructor.
@@ -211,7 +195,7 @@ public:
                        const std::string& nm,
                        const BCRec&       bc,
                        const BndryFunc&   func,
-                       InterpBase*        interp = 0,
+                       InterpBase*        interp = nullptr,
                        int                max_map_start_comp = -1,
                        int                min_map_end_comp   = -1);
 
@@ -231,7 +215,7 @@ public:
                        const BCRec&       bc,
                        const BndryFunc&   func,
                        InterpBase*        interp,
-                       bool               primary_or_secondary,
+                       bool               a_primary,
                        int                groupsize);
 
     /**
@@ -279,11 +263,11 @@ public:
     * \param max_start_comp
     * \param min_end_comp
     */
-    void cleanUpMaps (InterpBase**&   maps,
+    static void cleanUpMaps (InterpBase**&   maps,
                       int*&           map_start_comp,
                       int*&           map_num_comp,
                       int*&           max_start_comp,
-                      int*&           min_end_comp) const;
+                      int*&           min_end_comp) ;
 
     /**
     * \brief Output names of components.
@@ -299,60 +283,60 @@ public:
     /**
     * \brief Returns the IndexType.
     */
-    IndexType getType () const noexcept;
+    [[nodiscard]] IndexType getType () const noexcept;
 
     /**
     * \brief Returns StateDescriptor::TimeCenter.
     */
-    StateDescriptor::TimeCenter timeType () const noexcept;
+    [[nodiscard]] StateDescriptor::TimeCenter timeType () const noexcept;
 
     /**
     * \brief Returns number of components.
     */
-    int nComp () const noexcept;
+    [[nodiscard]] int nComp () const noexcept;
 
     /**
     * \brief Returns the grow factor.
     */
-    int nExtra () const noexcept;
+    [[nodiscard]] int nExtra () const noexcept;
 
     /**
     * \brief Returns the interpolater.
     */
-    InterpBase* interp () const noexcept;
+    [[nodiscard]] InterpBase* interp () const noexcept;
 
     /**
     * \brief Returns the interpolater of specified component.
     *
     * \param i
     */
-    InterpBase* interp (int i) const noexcept;
+    [[nodiscard]] InterpBase* interp (int i) const noexcept;
 
     /**
     * \brief Returns the name of specified component.
     *
     * \param i
     */
-    const std::string& name (int i) const noexcept;
+    [[nodiscard]] const std::string& name (int i) const noexcept;
 
     /**
     * \brief Returns the BCRec of specified component.
     *
     * \param i
     */
-    const BCRec& getBC (int i) const noexcept;
+    [[nodiscard]] const BCRec& getBC (int i) const noexcept;
 
     /**
     * \brief Returns all BCRecs.
     */
-    const Vector<BCRec>& getBCs () const noexcept;
+    [[nodiscard]] const Vector<BCRec>& getBCs () const noexcept;
 
     /**
     * \brief Returns the BndryFunc of specified component.
     *
     * \param i
     */
-    const BndryFunc& bndryFill (int i) const noexcept;
+    [[nodiscard]] const BndryFunc& bndryFill (int i) const noexcept;
 
     /**
     * \brief Is sc\>=0 \&\& sc+nc\<=ncomp ?
@@ -360,7 +344,7 @@ public:
     * \param sc
     * \param nc
     */
-    int inRange (int sc, int nc) const noexcept;
+    [[nodiscard]] int inRange (int sc, int nc) const noexcept;
 
     /**
     * \brief Are the interpolaters in the specified range identical?
@@ -368,36 +352,36 @@ public:
     * \param scomp
     * \param ncomp
     */
-    bool identicalInterps (int scomp, int ncomp) const noexcept;
+    [[nodiscard]] bool identicalInterps (int scomp, int ncomp) const noexcept;
     //
     // Returns contiguous ranges of comps with identical interpolaters.
     //
-    std::vector< std::pair<int,int> > sameInterps (int scomp, int ncomp) const;
+    [[nodiscard]] std::vector< std::pair<int,int> > sameInterps (int scomp, int ncomp) const;
 
     /**
     * \brief Can extrapolate in time.
     */
-    bool extrap () const noexcept;
+    [[nodiscard]] bool extrap () const noexcept;
 
     /**
     * \brief Should store this StateData in the checkpoint file
     */
-    bool store_in_checkpoint () const noexcept;
+    [[nodiscard]] bool store_in_checkpoint () const noexcept;
 
-    bool primary (int i) const noexcept { return m_primary[i]; }
+    [[nodiscard]] bool primary (int i) const noexcept { return m_primary[i]; }
 
-    int groupsize (int i) const noexcept { return m_groupsize[i]; }
+    [[nodiscard]] int groupsize (int i) const noexcept { return m_groupsize[i]; }
 
 
     /**
     * \brief will it run on gpu?
     */
-    bool RunOnGPU () const noexcept { return bc_func[0]->RunOnGPU(); }
+    [[nodiscard]] bool RunOnGPU () const noexcept { return bc_func[0]->RunOnGPU(); }
 
     /**
     * \brief has new fab version of BndryFunc?
     */
-    bool hasBndryFuncFab () const noexcept { return bc_func[0]->hasFabVersion(); }
+    [[nodiscard]] bool hasBndryFuncFab () const noexcept { return bc_func[0]->hasFabVersion(); }
 
     static void setBndryFuncThreadSafety (int ext_dir_safe) noexcept {
         bf_ext_dir_threadsafe = ext_dir_safe;
@@ -405,19 +389,19 @@ public:
 
 private:
 
-    IndexType          type;         //!< Cell centered, node centered ...
-    TimeCenter         t_type;       //!< Temporal centering
-    int                id;           //!< Unique id
-    int                ncomp;        //!< Number of components
-    int                ngrow;        //!< Grow factor
-    InterpBase*        mapper;       //!< Default interpolator
-    bool               m_extrap;     //!< Can extrapolate in time?
-    bool               m_store_in_checkpoint;     //!< Should store this in the checkpoint file?
-    Vector<std::string> names;        //!< Printable names of components
-    Vector<BCRec>       bc;           //!< Array of bndry types for entire level
-    Vector<std::unique_ptr<BndryFunc> >  bc_func;      //!< Array of pointers to bndry fill functions
+    IndexType           type;            //!< Cell centered, node centered ...
+    TimeCenter          t_type{Point};   //!< Temporal centering
+    int                 id{-1};          //!< Unique id
+    int                 ncomp{0};        //!< Number of components
+    int                 ngrow{0};        //!< Grow factor
+    InterpBase*         mapper{nullptr}; //!< Default interpolator
+    bool                m_extrap{false}; //!< Can extrapolate in time?
+    bool                m_store_in_checkpoint{true}; //!< Should store this in the checkpoint file?
+    Vector<std::string> names;         //!< Printable names of components
+    Vector<BCRec>       bc;            //!< Array of bndry types for entire level
+    Vector<std::unique_ptr<BndryFunc> >  bc_func; //!< Array of pointers to bndry fill functions
     Vector<int>         m_primary;     //!< Are we a primary or secondary? (true or false)
-    Vector<int>         m_groupsize;     //!< Groupsize if we're a primary
+    Vector<int>         m_groupsize;   //!< Groupsize if we're a primary
 
     /**
     * \brief If mapper_comp[icomp] != 0, that map is used instead of mapper
@@ -456,14 +440,6 @@ class DescriptorList
 public:
 
     /**
-    * \brief The constructor.
-    */
-    DescriptorList () noexcept = default;
-
-    DescriptorList (const DescriptorList&) = delete;
-    DescriptorList& operator= (const DescriptorList&) = delete;
-
-    /**
     * \brief Set the list to its default state.
     */
     void clear ();
@@ -471,7 +447,7 @@ public:
     /**
     * \brief Returns number of elements in the list.
     */
-    int size () const noexcept;
+    [[nodiscard]] int size () const noexcept;
 
     /**
     * \brief Adds new StateDescriptor at index indx to list.
@@ -524,7 +500,7 @@ public:
                        const std::string&                nm,
                        const BCRec&                      bc,
                        const StateDescriptor::BndryFunc& func,
-                       InterpBase*                       interp = 0,
+                       InterpBase*                       interp = nullptr,
                        int                               max_map_start_comp = -1,
                        int                               min_map_end_comp   = -1);
 
@@ -543,7 +519,7 @@ public:
                        const Vector<std::string>&         nm,
                        const Vector<BCRec>&               bc,
                        const StateDescriptor::BndryFunc& func,
-                       InterpBase*                       interp = 0);
+                       InterpBase*                       interp = nullptr);
     /**
     * Returns StateDescriptor at index k.
     */

--- a/Src/Amr/AMReX_StateDescriptor.H
+++ b/Src/Amr/AMReX_StateDescriptor.H
@@ -60,7 +60,7 @@ public:
 
         BndryFunc (BndryFunc3DDefault inFunc) noexcept : m_func3D(inFunc) {}
 
-        BndryFunc (BndryFuncFabDefault inFunc) noexcept : m_funcfab(std::move(std::move(inFunc))) {}
+        BndryFunc (BndryFuncFabDefault inFunc) noexcept : m_funcfab(std::move(inFunc)) {}
 
         /**
         * \brief Another Constructor.

--- a/Src/AmrCore/AMReX_AmrMesh.H
+++ b/Src/AmrCore/AMReX_AmrMesh.H
@@ -65,7 +65,7 @@ public:
 
     AmrMesh (const RealBox& rb, int max_level_in,
              const Vector<int>& n_cell_in, int coord,
-             Vector<IntVect> const& ref_ratios,
+             Vector<IntVect> const& a_refrat,
              Array<int,AMREX_SPACEDIM> const& is_per);
 
     AmrMesh (Geometry const& level_0_geom, AmrInfo const& amr_info);
@@ -274,7 +274,7 @@ private:
                       const RealBox* rb = nullptr, int coord = -1,
                       const int* is_per = nullptr);
 
-    static void ProjPeriodic (BoxList& bd, const Box& domain,
+    static void ProjPeriodic (BoxList& blout, const Box& domain,
                               Array<int,AMREX_SPACEDIM> const& is_per);
 };
 

--- a/Src/AmrCore/AMReX_AmrMesh.cpp
+++ b/Src/AmrCore/AMReX_AmrMesh.cpp
@@ -214,7 +214,7 @@ AmrMesh::InitAmrMesh (int max_level_in, const Vector<int>& n_cell_in,
         }
     }
     //if sent in, this wins over everything.
-    if(a_refrat.size() > 0)
+    if(!a_refrat.empty())
     {
       for (int i = 0; i < max_level; i++)
       {
@@ -685,7 +685,7 @@ AmrMesh::MakeNewGrids (int lbase, Real time, int& new_finest, Vector<BoxArray>& 
         tags.collate(tagvec);
         tags.clear();
 
-        if (tagvec.size() > 0)
+        if (!tagvec.empty())
         {
             //
             // Created new level, now generate efficient grids.

--- a/Src/AmrCore/AMReX_Cluster.H
+++ b/Src/AmrCore/AMReX_Cluster.H
@@ -49,8 +49,11 @@ public:
     */
     Cluster (Cluster& c, const Box& b);
 
+    ~Cluster () = default;
     Cluster (const Cluster&) = delete;
+    Cluster (Cluster&&) = delete;
     Cluster& operator= (const Cluster&) = delete;
+    Cluster& operator= (Cluster&&) = delete;
 
     /**
     * \brief Return minimal box containing all tagged points.
@@ -111,7 +114,10 @@ public:
     /**
     * \brief Compute ratio of tagged to total number of points in cluster.
     */
-    [[nodiscard]] Real eff () const noexcept { BL_ASSERT(ok()); return Real(numTag()/m_bx.d_numPts()); }
+    [[nodiscard]] Real eff () const noexcept {
+        BL_ASSERT(ok());
+        return static_cast<Real>(double(numTag()) / m_bx.d_numPts());
+    }
 
 private:
 
@@ -156,12 +162,14 @@ public:
     ~ClusterList ();
 
     ClusterList (const ClusterList&) = delete;
+    ClusterList (ClusterList&&) = delete;
     ClusterList& operator= (const ClusterList&) = delete;
+    ClusterList& operator= (ClusterList&&) = delete;
 
     /**
     * \brief Return number of clusters in list.
     */
-    [[nodiscard]] int length () const { return lst.size(); }
+    [[nodiscard]] int length () const { return static_cast<int>(lst.size()); }
 
     /**
     * \brief Add cluster to end of list.

--- a/Src/AmrCore/AMReX_FillPatchUtil_I.H
+++ b/Src/AmrCore/AMReX_FillPatchUtil_I.H
@@ -242,8 +242,8 @@ FillPatchInterp (MF& mf_fine_patch, int fcomp, MF const& mf_crse_patch, int ccom
 template <typename MF, typename iMF, typename Interp>
 std::enable_if_t<IsFabArray<MF>::value  && !std::is_same<Interp,MFInterpolater>::value>
 InterpFace (Interp *interp,
-            MF const& mf_crse_patch,    const int crse_comp,
-            MF&       mf_refined_patch, const int fine_comp,
+            MF const& mf_crse_patch,    int crse_comp,
+            MF&       mf_refined_patch, int fine_comp,
             int ncomp, const IntVect&   ratio,
             const iMF& solve_mask, const Geometry&  crse_geom, const Geometry&  fine_geom,
             int bcscomp, RunOn gpu_or_cpu,
@@ -490,7 +490,7 @@ namespace {
                     // which is done from this fine MF that's been partially filled
                     // (with only faces overlying coarse having valid data).
                     MF mf_refined_patch  = make_mf_refined_patch<MF>   (fpc, ncomp, mf.boxArray().ixType(), ratio);
-                    iMultiFab solve_mask = make_mf_crse_mask<iMultiFab>(fpc, ncomp, mf.boxArray().ixType(), ratio);
+                    auto solve_mask = make_mf_crse_mask<iMultiFab>(fpc, ncomp, mf.boxArray().ixType(), ratio);
 
                     mf_set_domain_bndry(mf_crse_patch, cgeom);
                     FillPatchSingleLevel(mf_crse_patch, time, cmf, ct, scomp, 0, ncomp,

--- a/Src/AmrCore/AMReX_FillPatcher.H
+++ b/Src/AmrCore/AMReX_FillPatcher.H
@@ -3,6 +3,7 @@
 #include <AMReX_Config.H>
 
 #include <AMReX_FillPatchUtil.H>
+#include <utility>
 
 namespace amrex {
 
@@ -89,7 +90,7 @@ public:
      */
     FillPatcher (BoxArray const& fba, DistributionMapping const& fdm,
                  Geometry const& fgeom,
-                 BoxArray const& cba, DistributionMapping const& cdm,
+                 BoxArray const& cba, DistributionMapping const& cdm, // NOLINT
                  Geometry const& cgeom,
                  IntVect const& nghost, int ncomp, InterpBase* interp,
 #ifdef AMREX_USE_EB
@@ -125,8 +126,8 @@ public:
               typename PreInterpHook=NullInterpHook<MF>,
               typename PostInterpHook=NullInterpHook<MF> >
     void fill (MF& mf, IntVect const& nghost, Real time,
-               Vector<MF*> const& crse_data, Vector<Real> const& crse_time,
-               Vector<MF*> const& fine_data, Vector<Real> const& fine_time,
+               Vector<MF*> const& cmf, Vector<Real> const& ct,
+               Vector<MF*> const& fmf, Vector<Real> const& ft,
                int scomp, int dcomp, int ncomp,
                BC& cbc, int cbccomp, BC& fbc, int fbccomp,
                Vector<BCRec> const& bcs, int bcscomp,
@@ -156,8 +157,8 @@ public:
               typename PreInterpHook=NullInterpHook<MF>,
               typename PostInterpHook=NullInterpHook<MF> >
     void fillCoarseFineBoundary (MF& mf, IntVect const& nghost, Real time,
-                                 Vector<MF*> const& crse_data,
-                                 Vector<Real> const& crse_time,
+                                 Vector<MF*> const& cmf,
+                                 Vector<Real> const& ct,
                                  int scomp, int dcomp, int ncomp,
                                  BC& cbc, int cbccomp,
                                  Vector<BCRec> const& bcs, int bcscomp,
@@ -220,7 +221,7 @@ private:
 template <class MF>
 FillPatcher<MF>::FillPatcher (BoxArray const& fba, DistributionMapping const& fdm,
                               Geometry const& fgeom,
-                              BoxArray const& cba, DistributionMapping const& cdm,
+                              BoxArray const& cba, DistributionMapping const& cdm, // NOLINT
                               Geometry const& cgeom,
                               IntVect const& nghost, int ncomp, InterpBase* interp,
                               EB2::IndexSpace const* eb_index_space)

--- a/Src/AmrCore/AMReX_InterpBase.H
+++ b/Src/AmrCore/AMReX_InterpBase.H
@@ -15,7 +15,6 @@ class InterpolaterBoxCoarsener final
 {
 public:
     InterpolaterBoxCoarsener (InterpBase* mapper_, const IntVect& ratio_);
-    ~InterpolaterBoxCoarsener () override = default;
     [[nodiscard]] Box doit (const Box& fine) const override;
     [[nodiscard]] BoxConverter* clone () const override;
 private:
@@ -26,7 +25,12 @@ private:
 class InterpBase
 {
 public:
+    InterpBase () = default;
     virtual ~InterpBase () = default;
+    InterpBase (InterpBase const&) noexcept = default;
+    InterpBase (InterpBase &&) noexcept = default;
+    InterpBase& operator= (InterpBase const&) noexcept = default;
+    InterpBase& operator= (InterpBase &&) noexcept = default;
 
     /**
     * \brief Returns coarsened box given fine box and refinement ratio.

--- a/Src/AmrCore/AMReX_Interp_3D_C.H
+++ b/Src/AmrCore/AMReX_Interp_3D_C.H
@@ -32,13 +32,13 @@ pcinterp_interp (Box const& bx,
 }
 
 namespace {
-    static constexpr int ix   = 0;
-    static constexpr int iy   = 1;
-    static constexpr int iz   = 2;
-    static constexpr int ixy  = 3;
-    static constexpr int ixz  = 4;
-    static constexpr int iyz  = 5;
-    static constexpr int ixyz = 6;
+    constexpr int ix   = 0;
+    constexpr int iy   = 1;
+    constexpr int iz   = 2;
+    constexpr int ixy  = 3;
+    constexpr int ixz  = 4;
+    constexpr int iyz  = 5;
+    constexpr int ixyz = 6;
 }
 
 // Let's keep these nodal functions even though amrex is no longer using

--- a/Src/AmrCore/AMReX_Interpolater.H
+++ b/Src/AmrCore/AMReX_Interpolater.H
@@ -22,9 +22,6 @@ class Interpolater
     : public InterpBase
 {
 public:
-
-    ~Interpolater () override = default;
-
     /**
     * \brief Coarse to fine interpolation in space.
     * This is a pure virtual function and hence MUST
@@ -55,7 +52,7 @@ public:
                          Vector<BCRec> const & bcr,
                          int              actual_comp,
                          int              actual_state,
-                         RunOn            gpu_or_cpu) = 0;
+                         RunOn            runon) = 0;
 
     /**
     * \brief Coarse to fine interpolation in space for face-based data.
@@ -87,7 +84,7 @@ public:
                               const Geometry&  /*fine_geom*/,
                               Vector<BCRec> const & /*bcr*/,
                               const int        /*bccomp*/,
-                              RunOn            /*gpu_or_cpu*/)
+                              RunOn            /*runon*/)
     { amrex::Abort("The version of this Interpolater for face-based data is not implemented or does not apply. Call 'interp' instead."); }
 
     /**
@@ -122,7 +119,7 @@ public:
                              Vector<Array<BCRec, AMREX_SPACEDIM> > const& /*bcr*/,
                              const int         /*actual_comp*/,
                              const int         /*actual_state*/,
-                             const RunOn       /*gpu_or_cpu*/)
+                             const RunOn       /*runon*/)
 
     { amrex::Abort("The Array<FArrayBox*, AMREX_SPACEDIM> version of this Interpolater is not implemented or does not apply. Call 'interp' instead."); }
 
@@ -154,7 +151,7 @@ public:
                           const Geometry&  /*crse_geom*/,
                           const Geometry&  /*fine_geom*/,
                           Vector<BCRec>&   /*bcr*/,
-                          RunOn            /*gpu_or_cpu*/) {}
+                          RunOn            /*runon*/) {}
 };
 
 
@@ -169,12 +166,6 @@ class NodeBilinear
     public Interpolater
 {
 public:
-
-    /**
-    * \brief The destructor.
-    */
-    ~NodeBilinear () override = default;
-
     /**
     * \brief Returns coarsened box given fine box and refinement ratio.
     *
@@ -219,7 +210,7 @@ public:
                          Vector<BCRec> const& bcr,
                          int              actual_comp,
                          int              actual_state,
-                         RunOn            gpu_or_cpu) override;
+                         RunOn            runon) override;
 };
 
 
@@ -234,12 +225,6 @@ class CellBilinear
     public Interpolater
 {
 public:
-
-    /**
-    * \brief The destructor.
-    */
-    ~CellBilinear () override = default;
-
     /**
     * \brief Returns coarsened box given fine box and refinement ratio.
     *
@@ -284,7 +269,7 @@ public:
                          Vector<BCRec> const& bcr,
                          int              actual_comp,
                          int              actual_state,
-                         RunOn            gpu_or_cpu) override;
+                         RunOn            runon) override;
 };
 
 
@@ -316,11 +301,6 @@ public:
     explicit CellConservativeLinear (bool do_linear_limiting_= true);
 
     /**
-    * \brief The destructor.
-    */
-    ~CellConservativeLinear () override = default;
-
-    /**
     * \brief Returns coarsened box given fine box and refinement ratio.
     *
     * \param fine
@@ -350,7 +330,7 @@ public:
                          Vector<BCRec> const& bcr,
                          int              /*actual_comp*/,
                          int              /*actual_state*/,
-                         RunOn            gpu_or_cpu) override;
+                         RunOn            runon) override;
 
 protected:
 
@@ -375,11 +355,6 @@ public:
     * \brief The constructor.
     */
     CellConservativeProtected ();
-
-    /**
-    * \brief The destructor.
-    */
-    ~CellConservativeProtected () override = default;
 
     /**
     * \brief Re-visit the interpolation to protect against under- or overshoots.
@@ -409,7 +384,7 @@ public:
                           const Geometry&  crse_geom,
                           const Geometry&  fine_geom,
                           Vector<BCRec>&   bcr,
-                          RunOn            gpu_or_cpu) override;
+                          RunOn            runon) override;
 };
 
 
@@ -431,11 +406,6 @@ public:
     * \param limit
     */
     explicit CellQuadratic (bool limit = true);
-
-    /**
-    * \brief The destructor.
-    */
-    ~CellQuadratic () override = default;
 
     /**
     * \brief Returns coarsened box given fine box and refinement ratio.
@@ -481,7 +451,7 @@ public:
                          Vector<BCRec> const& bcr,
                          int              actual_comp,
                          int              actual_state,
-                         RunOn            gpu_or_cpu) override;
+                         RunOn            runon) override;
 private:
 
     bool  do_limited_slope;
@@ -497,12 +467,6 @@ class PCInterp
     public Interpolater
 {
 public:
-
-    /**
-    * \brief The destructor.
-    */
-    ~PCInterp () override = default;
-
     /**
     * \brief Returns coarsened box given fine box and refinement ratio.
     *
@@ -547,7 +511,7 @@ public:
                          Vector<BCRec> const&  bcr,
                          int              actual_comp,
                          int              actual_state,
-                         RunOn            gpu_or_cpu) override;
+                         RunOn            runon) override;
 };
 
 
@@ -564,12 +528,6 @@ class CellConservativeQuartic
     public Interpolater
 {
 public:
-
-    /**
-    * \brief The destructor.
-    */
-    ~CellConservativeQuartic () override = default;
-
     /**
     * \brief Returns coarsened box given fine box and refinement ratio.
     *
@@ -614,7 +572,7 @@ public:
                          Vector<BCRec> const&  bcr,
                          int              actual_comp,
                          int              actual_state,
-                         RunOn            gpu_or_cpu) override;
+                         RunOn            runon) override;
 };
 
 /**
@@ -628,12 +586,6 @@ class FaceDivFree
     public Interpolater
 {
 public:
-
-    /**
-    * \brief The destructor.
-    */
-    ~FaceDivFree () override = default;
-
     /**
     * \brief Returns coarsened box given fine box and refinement ratio.
     *
@@ -679,7 +631,7 @@ public:
                          Vector<BCRec> const& bcr,
                          int              actual_comp,
                          int              actual_state,
-                         RunOn            gpu_or_cpu) override;
+                         RunOn            runon) override;
 
     /**
     * \brief Coarse to fine interpolation in space.
@@ -727,12 +679,6 @@ class FaceLinear
     public Interpolater
 {
 public:
-
-    /**
-    * \brief The destructor.
-    */
-    ~FaceLinear () override = default;
-
     /**
     * \brief Returns coarsened box given fine box and refinement ratio.
     *
@@ -777,7 +723,7 @@ public:
                          Vector<BCRec> const& bcr,
                          int              actual_comp,
                          int              actual_state,
-                         RunOn            gpu_or_cpu) override;
+                         RunOn            runon) override;
 
     /**
     * \brief Coarse to fine interpolation in space for face-based data.
@@ -808,7 +754,7 @@ public:
                               const Geometry&  fine_geom,
                               Vector<BCRec> const & bcr,
                               int        bccomp,
-                              RunOn            gpu_or_cpu) override;
+                              RunOn            runon) override;
 
     /**
     * \brief Coarse to fine interpolation in space.
@@ -855,17 +801,6 @@ class CellQuartic
     public Interpolater
 {
 public:
-
-    /**
-    * \brief The constructor.
-    */
-    explicit CellQuartic () = default;
-
-    /**
-    * \brief The destructor.
-    */
-    ~CellQuartic () override = default;
-
     /**
     * \brief Returns coarsened box given fine box and refinement ratio.
     *
@@ -910,7 +845,7 @@ public:
                          Vector<BCRec> const& bcr,
                          int              actual_comp,
                          int              actual_state,
-                         RunOn            gpu_or_cpu) override;
+                         RunOn            runon) override;
 };
 
 //! CONSTRUCT A GLOBAL OBJECT OF EACH VERSION.

--- a/Src/AmrCore/AMReX_MFInterpolater.H
+++ b/Src/AmrCore/AMReX_MFInterpolater.H
@@ -14,8 +14,6 @@ class MFInterpolater
     : public InterpBase
 {
 public:
-    ~MFInterpolater () override = default;
-
     virtual void interp (MultiFab const& crsemf, int ccomp, MultiFab& finemf, int fcomp, int ncomp,
                          IntVect const& ng, Geometry const& cgeom, Geometry const& fgeom,
                          Box const& dest_domain, IntVect const& ratio,
@@ -29,8 +27,6 @@ class MFPCInterp final
     : public MFInterpolater
 {
 public:
-    ~MFPCInterp () override = default;
-
     Box CoarseBox (Box const& fine, int ratio) override;
     Box CoarseBox (Box const& fine, IntVect const& ratio) override;
 
@@ -57,15 +53,13 @@ public:
     explicit MFCellConsLinInterp (bool do_linear_limiting_)
         : do_linear_limiting(do_linear_limiting_) {}
 
-    ~MFCellConsLinInterp () override = default;
-
     Box CoarseBox (Box const& fine, int ratio) override;
     Box CoarseBox (Box const& fine, IntVect const& ratio) override;
 
     void interp (MultiFab const& crsemf, int ccomp, MultiFab& finemf, int fcomp, int ncomp,
                          IntVect const& ng, Geometry const& cgeom, Geometry const& fgeom,
                          Box const& dest_domain, IntVect const& ratio,
-                         Vector<BCRec> const& bcs, int bcscomp) override;
+                         Vector<BCRec> const& bcs, int bcomp) override;
 protected:
     bool do_linear_limiting = true;
 };
@@ -85,17 +79,13 @@ class MFCellConsLinMinmaxLimitInterp
     : public MFInterpolater
 {
 public:
-    MFCellConsLinMinmaxLimitInterp () = default;
-
-    ~MFCellConsLinMinmaxLimitInterp () override = default;
-
     Box CoarseBox (Box const& fine, int ratio) override;
     Box CoarseBox (Box const& fine, IntVect const& ratio) override;
 
     void interp (MultiFab const& crsemf, int ccomp, MultiFab& finemf, int fcomp, int ncomp,
                          IntVect const& ng, Geometry const& cgeom, Geometry const& fgeom,
                          Box const& dest_domain, IntVect const& ratio,
-                         Vector<BCRec> const& bcs, int bcscomp) override;
+                         Vector<BCRec> const& bcs, int bcomp) override;
 };
 
 /**
@@ -105,8 +95,6 @@ class MFCellBilinear final
     : public MFInterpolater
 {
 public:
-    ~MFCellBilinear () override = default;
-
     Box CoarseBox (Box const& fine, int ratio) override;
     Box CoarseBox (Box const& fine, IntVect const& ratio) override;
 
@@ -123,8 +111,6 @@ class MFNodeBilinear final
     : public MFInterpolater
 {
 public:
-    ~MFNodeBilinear () override = default;
-
     Box CoarseBox (Box const& fine, int ratio) override;
     Box CoarseBox (Box const& fine, IntVect const& ratio) override;
 

--- a/Src/AmrCore/AMReX_TagBox.H
+++ b/Src/AmrCore/AMReX_TagBox.H
@@ -67,7 +67,7 @@ public:
     * \param nbuff
     * \param nwid
     */
-    void buffer (const IntVect& nbuf, const IntVect& nwid) noexcept;
+    void buffer (const IntVect& a_nbuff, const IntVect& nwid) noexcept;
 
     /**
     * \brief Returns Vector\<int\> of size domain.numPts() suitable for calling
@@ -162,8 +162,8 @@ public:
     * \param dm
     * \param _ngrow
     */
-    TagBoxArray (const BoxArray& bs, const DistributionMapping& dm, int _ngrow=0);
-    TagBoxArray (const BoxArray& bs, const DistributionMapping& dm, const IntVect& _ngrow);
+    TagBoxArray (const BoxArray& ba, const DistributionMapping& dm, int _ngrow=0);
+    TagBoxArray (const BoxArray& ba, const DistributionMapping& dm, const IntVect& _ngrow);
 
     ~TagBoxArray () = default;
 

--- a/Src/AmrCore/AMReX_TagBox.cpp
+++ b/Src/AmrCore/AMReX_TagBox.cpp
@@ -638,7 +638,7 @@ TagBoxArray::collate (Gpu::PinnedVector<IntVect>& TheGlobalCollateSpace) const
                                                                   IOProcNumber);
     std::vector<int> offset(countvec.size(),0);
     if (ParallelDescriptor::IOProcessor()) {
-        for (int i = 1, N = offset.size(); i < N; i++) {
+        for (std::size_t i = 1, N = offset.size(); i < N; i++) {
             offset[i] = offset[i-1] + countvec[i-1];
         }
     }
@@ -652,7 +652,7 @@ TagBoxArray::collate (Gpu::PinnedVector<IntVect>& TheGlobalCollateSpace) const
     // FujitsuMPI. The issue seems to be related to the use of MPI_Datatype. We can
     // bypasses the issue by exchanging simpler integer arrays.
 #if !(defined(__FUJITSU) || defined(__CLANG_FUJITSU))
-    ParallelDescriptor::Gatherv(psend, count, precv, countvec, offset, IOProcNumber);
+    ParallelDescriptor::Gatherv(psend, static_cast<int>(count), precv, countvec, offset, IOProcNumber);
 #else
     const int* psend_int = psend->begin();
     int* precv_int = precv->begin();

--- a/Src/Base/AMReX_Array.H
+++ b/Src/Base/AMReX_Array.H
@@ -157,62 +157,62 @@ namespace amrex {
          * Returns the number of elements in the Array1D object as an unsigned
          * integer.
          */
-        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         static constexpr unsigned int size () noexcept { return (XHI-XLO+1); }
 
         /**
          * Returns the index of the lower bound of the Array1D object.
          * Can be other than 0.
          */
-        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         static constexpr int lo () noexcept { return XLO; }
 
         /**
          * Returns the index of the upper bound of the Array1D object.
          */
-        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         static constexpr int hi () noexcept { return XHI; }
 
         /**
          * Returns the number of elements in the Array1D object as an unsigned
          * integer.
          */
-        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         static constexpr unsigned int len () noexcept { return (XHI-XLO+1); }
 
         /**
          * Returns a \c const pointer address to the first element of the
          * Array1D object.
          */
-        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         const T* begin () const noexcept { return arr; }
 
         /**
          * Returns a \c const pointer address right after the last element of the
          * Array1D object.
          */
-        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         const T* end () const noexcept { return arr + XHI-XLO+1; }
 
         /**
          * Returns a pointer address to the first element of the
          * Array1D object.
          */
-        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         T* begin () noexcept { return arr; }
 
         /**
          * Returns a pointer address right after the last element of the
          * Array1D object.
          */
-        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         T* end () noexcept { return arr + XHI-XLO+1; }
 
         /**
          * The elements of an Array1D object are accessed using parentheses,
          * e.g. \c array(i), instead of using square brackets.
          */
-        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         const T& operator() (int i) const noexcept {
             AMREX_ASSERT(i >= XLO && i <= XHI);
             return arr[i-XLO];
@@ -222,7 +222,7 @@ namespace amrex {
          * The elements of an Array1D object are accessed using parentheses,
          * e.g. array(i), instead of using square brackets.
          */
-        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         T& operator() (int i) noexcept {
             AMREX_ASSERT(i >= XLO && i <= XHI);
             return arr[i-XLO];
@@ -231,7 +231,7 @@ namespace amrex {
         /**
          * Returns the sum of all elements in the Array1D object.
          */
-        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         constexpr T sum () const noexcept
         {
             T s = 0;
@@ -242,7 +242,7 @@ namespace amrex {
         /**
          * Returns the product of all elements in the Array1D object.
          */
-        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         constexpr T product() const noexcept
         {
             T p = 1;
@@ -278,7 +278,7 @@ namespace amrex {
          * Returns the total number of elements of the Array2D object as an
          * unsigned integer.
          */
-        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         static constexpr unsigned int size() noexcept { return (XHI-XLO+1)*(YHI-YLO+1); }
 
         /**
@@ -286,14 +286,14 @@ namespace amrex {
          * \a x direction.
          * Can be other than 0.
          */
-        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         static constexpr int xlo () noexcept { return XLO; }
 
         /**
          * Returns the index of the upper bound of the Array2D object in the
          * \a x direction.
          */
-        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         static constexpr int xhi () noexcept { return XHI; }
 
 
@@ -301,7 +301,7 @@ namespace amrex {
          * Returns the number of elements of the Array2D object in the
          * \a x direction as an unsigned integer.
          */
-        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         static constexpr unsigned int xlen () noexcept { return (XHI-XLO+1); }
 
         /**
@@ -309,14 +309,14 @@ namespace amrex {
          * \a y direction.
          * Can be other than 0.
          */
-        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         static constexpr int ylo () noexcept { return YLO; }
 
         /**
          * Returns the index of the upper bound of the Array2D object in the
          * \a y direction.
          */
-        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         static constexpr int yhi () noexcept { return YHI; }
 
 
@@ -324,35 +324,35 @@ namespace amrex {
          * Returns the number of elements of the Array2D object in the
          * \a y direction as an unsigned integer.
          */
-        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         static constexpr unsigned int ylen () noexcept { return (YHI-YLO+1); }
 
         /**
          * Returns a \c const pointer address to the first element of the
          * Array2D object, as if the object is treated as one-dimensional.
          */
-        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         const T* begin () const noexcept { return arr; }
 
         /**
          * Returns a \c const pointer address right after the last element of the
          * Array2D object, as if the object is treated as one-dimensional.
          */
-        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         const T* end () const noexcept { return arr + (XHI-XLO+1)*(YHI-YLO+1); }
 
         /**
          * Returns a pointer address to the first element of the
          * Array2D object, as if the object is treated as one-dimensional.
          */
-        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         T* begin () noexcept { return arr; }
 
         /**
          * Returns a pointer address right after the last element of the
          * Array2D object, as if the object is treated as one-dimensional.
          */
-        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         T* end () noexcept { return arr + (XHI-XLO+1)*(YHI-YLO+1); }
 
         /**
@@ -363,7 +363,7 @@ namespace amrex {
          */
         template <typename O=ORDER,
                   typename std::enable_if<std::is_same<O,Order::F>::value,int>::type=0>
-        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         const T& operator() (int i, int j) const noexcept {
             AMREX_ASSERT(i >= XLO && i <= XHI && j >= YLO && j <= YHI);
             return arr[i+j*(XHI-XLO+1)-(YLO*(XHI-XLO+1)+XLO)];
@@ -377,7 +377,7 @@ namespace amrex {
          */
         template <typename O=ORDER,
                   typename std::enable_if<std::is_same<O,Order::F>::value,int>::type=0>
-        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         T& operator() (int i, int j) noexcept {
             AMREX_ASSERT(i >= XLO && i <= XHI && j >= YLO && j <= YHI);
             return arr[i+j*(XHI-XLO+1)-(YLO*(XHI-XLO+1)+XLO)];
@@ -391,7 +391,7 @@ namespace amrex {
          */
         template <typename O=ORDER,
                   typename std::enable_if<std::is_same<O,Order::C>::value,int>::type=0>
-        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         const T& operator() (int i, int j) const noexcept {
             AMREX_ASSERT(i >= XLO && i <= XHI && j >= YLO && j <= YHI);
             return arr[j+i*(YHI-YLO+1)-(XLO*(YHI-YLO+1)+YLO)];
@@ -405,7 +405,7 @@ namespace amrex {
          */
         template <typename O=ORDER,
                   typename std::enable_if<std::is_same<O,Order::C>::value,int>::type=0>
-        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         T& operator() (int i, int j) noexcept {
             AMREX_ASSERT(i >= XLO && i <= XHI && j >= YLO && j <= YHI);
             return arr[j+i*(YHI-YLO+1)-(XLO*(YHI-YLO+1)+YLO)];
@@ -415,7 +415,7 @@ namespace amrex {
          * When called without any arguments, returns the sum of all
          * elements in the Array2D object.
          */
-        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         constexpr T sum () const noexcept
         {
             T s = 0;
@@ -449,7 +449,7 @@ namespace amrex {
          * In this example, the axis is 1 and the location index is \c i.
          *
          */
-        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         constexpr T sum (int axis, int loc) const noexcept
         {
             T s = 0;
@@ -471,7 +471,7 @@ namespace amrex {
          * When called without any arguments, returns the product of all
          * elements in the Array2D object.
          */
-        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         constexpr T product () const noexcept
         {
             T p = 1;
@@ -506,7 +506,7 @@ namespace amrex {
          * In this example, the axis is 0 and the location index is \c j.
          *
          */
-        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         constexpr T product (int axis, int loc) const noexcept
         {
             T p = 1;
@@ -549,7 +549,7 @@ namespace amrex {
          * Returns the total number of elements in the Array3D object as an
          * unsigned integer.
          */
-        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         static constexpr unsigned int size () noexcept { return (XHI-XLO+1)*(YHI-YLO+1)*(ZHI-ZLO+1); }
 
         /**
@@ -557,21 +557,21 @@ namespace amrex {
          * \a x direction.
          * Can be other than 0.
          */
-        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         static constexpr int xlo () noexcept { return XLO; }
 
         /**
          * Returns the index of the upper bound of the Array3D object in the
          * \a x direction.
          */
-        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         static constexpr int xhi () noexcept { return XHI; }
 
         /**
          * Returns the number of elements of the Array3D object in the
          * \a x direction as an unsigned integer.
          */
-        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         static constexpr unsigned int xlen () noexcept { return (XHI-XLO+1); }
 
         /**
@@ -579,14 +579,14 @@ namespace amrex {
          * \a y direction.
          * Can be other than 0.
          */
-        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         static constexpr int ylo () noexcept { return YLO; }
 
         /**
          * Returns the index of the upper bound of the Array3D object in the
          * \a y direction.
          */
-        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         static constexpr int yhi () noexcept { return YHI; }
 
 
@@ -594,7 +594,7 @@ namespace amrex {
          * Returns the number of elements of the Array3D object in the
          * \a y direction as an unsigned integer.
          */
-        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         static constexpr unsigned int ylen () noexcept { return (YHI-YLO+1); }
 
         /**
@@ -602,49 +602,49 @@ namespace amrex {
          * \a z direction.
          * Can be other than 0.
          */
-        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         static constexpr int zlo () noexcept { return ZLO; }
 
         /**
          * Returns the index of the upper bound of the Array3D object in the
          * \a z direction.
          */
-        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         static constexpr int zhi () noexcept { return ZHI; }
 
         /**
          * Returns the number of elements of the Array3D object in the
          * \a z direction as an unsigned integer.
          */
-        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         static constexpr unsigned int zlen () noexcept { return (ZHI-ZLO+1); }
 
         /**
          * Returns a \c const pointer address to the first element of the
          * Array3D object, as if the object is treated as one-dimensional.
          */
-        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         const T* begin () const noexcept { return arr; }
 
         /**
          * Returns a \c const pointer address right after the last element of the
          * Array3D object, as if the object is treated as one-dimensional.
          */
-        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         const T* end () const noexcept { return arr + (XHI-XLO+1)*(YHI-YLO+1)*(ZHI-ZLO+1); }
 
         /**
          * Returns a pointer address to the first element of the
          * Array3D object, as if the object is treated as one-dimensional.
          */
-        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         T* begin () noexcept { return arr; }
 
         /**
          * Returns a pointer address right after the last element of the
          * Array3D object, as if the object is treated as one-dimensional.
          */
-        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         T* end () noexcept { return arr + (XHI-XLO+1)*(YHI-YLO+1)*(ZHI-ZLO+1); }
 
         /**
@@ -655,7 +655,7 @@ namespace amrex {
          */
         template <typename O=ORDER,
                   typename std::enable_if<std::is_same<O,Order::F>::value,int>::type=0>
-        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         const T& operator() (int i, int j, int k) const noexcept {
             return arr[i+j*(XHI-XLO+1)+k*((XHI-XLO+1)*(YHI-YLO+1))
                        -(ZLO*((XHI-XLO+1)*(YHI-YLO+1))+YLO*(XHI-XLO+1)+XLO)];
@@ -669,7 +669,7 @@ namespace amrex {
          */
         template <typename O=ORDER,
                   typename std::enable_if<std::is_same<O,Order::F>::value,int>::type=0>
-        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         T& operator() (int i, int j, int k) noexcept {
             return arr[i+j*(XHI-XLO+1)+k*((XHI-XLO+1)*(YHI-YLO+1))
                        -(ZLO*((XHI-XLO+1)*(YHI-YLO+1))+YLO*(XHI-XLO+1)+XLO)];
@@ -683,7 +683,7 @@ namespace amrex {
          */
         template <typename O=ORDER,
                   typename std::enable_if<std::is_same<O,Order::C>::value,int>::type=0>
-        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         const T& operator() (int i, int j, int k) const noexcept {
             return arr[k+j*(ZHI-ZLO+1)+i*((ZHI-ZLO+1)*(YHI-YLO+1))
                        -(XLO*((ZHI-ZLO+1)*(YHI-YLO+1))+YLO*(ZHI-ZLO+1)+ZLO)];
@@ -697,7 +697,7 @@ namespace amrex {
          */
         template <typename O=ORDER,
                   typename std::enable_if<std::is_same<O,Order::C>::value,int>::type=0>
-        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         T& operator() (int i, int j, int k) noexcept {
             return arr[k+j*(ZHI-ZLO+1)+i*((ZHI-ZLO+1)*(YHI-YLO+1))
                        -(XLO*((ZHI-ZLO+1)*(YHI-YLO+1))+YLO*(ZHI-ZLO+1)+ZLO)];
@@ -707,7 +707,7 @@ namespace amrex {
          * When called without any arguments, returns the sum of all
          * elements in the Array3D object.
          */
-        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         constexpr T sum () const noexcept
         {
             T s = 0;
@@ -747,7 +747,7 @@ namespace amrex {
          * \c loc0 = \c i and \c loc1 = \c k; for axis = 2, \c loc0 = \c j and \c loc1 = \c k.
          *
          */
-        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         constexpr T sum (int axis, int loc0, int loc1) const noexcept
         {
             T s = 0;
@@ -777,7 +777,7 @@ namespace amrex {
          * When called without any arguments, returns the product of all
          * elements in the Array3D object.
          */
-        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         constexpr T product () const noexcept
         {
             T p = 1;
@@ -818,7 +818,7 @@ namespace amrex {
          * \c loc0 = \c j and \c loc1 = \c k; for axis = 1, \c loc0 = \c i and \c loc1 = \c k.
          *
          */
-        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         constexpr T product (const int axis, const int loc0, const int loc1) const noexcept
         {
             T p = 1;

--- a/Src/Base/AMReX_BackgroundThread.H
+++ b/Src/Base/AMReX_BackgroundThread.H
@@ -17,6 +17,10 @@ class BackgroundThread
 public:
     BackgroundThread ();
     ~BackgroundThread ();
+    BackgroundThread (BackgroundThread const&) = delete;
+    BackgroundThread (BackgroundThread &&) = delete;
+    BackgroundThread& operator= (BackgroundThread const&) = delete;
+    BackgroundThread& operator= (BackgroundThread &&) = delete;
 
     void Submit (std::function<void()>&& a_f);
     void Submit (std::function<void()> const& a_f);

--- a/Src/Base/AMReX_BaseFab.H
+++ b/Src/Base/AMReX_BaseFab.H
@@ -431,7 +431,7 @@ public:
     }
 
     //! Returns true if the data for the FAB has been allocated.
-    [[nodiscard]] bool isAllocated () const noexcept { return this->dptr != 0; }
+    [[nodiscard]] bool isAllocated () const noexcept { return this->dptr != nullptr; }
 
     /**
     * \brief Returns a reference to the Nth component value

--- a/Src/Base/AMReX_Box.cpp
+++ b/Src/Base/AMReX_Box.cpp
@@ -142,7 +142,7 @@ AllGatherBoxes (Vector<Box>& bxs, int n_extra_reserve)
     const int root = ParallelContext::IOProcessorNumberSub();
     const int myproc = ParallelContext::MyProcSub();
     const int nprocs = ParallelContext::NProcsSub();
-    const int count = bxs.size();
+    const int count = static_cast<int>(bxs.size());
     Vector<int> countvec(nprocs);
     MPI_Gather(&count, 1, MPI_INT, countvec.data(), 1, MPI_INT, root, comm);
 
@@ -150,7 +150,7 @@ AllGatherBoxes (Vector<Box>& bxs, int n_extra_reserve)
     Vector<int> offset(countvec.size(),0);
     if (myproc == root) {
         count_tot = countvec[0];
-        for (int i = 1, N = offset.size(); i < N; ++i) {
+        for (int i = 1, N = static_cast<int>(offset.size()); i < N; ++i) {
             offset[i] = offset[i-1] + countvec[i-1];
             count_tot += countvec[i];
         }
@@ -170,7 +170,7 @@ AllGatherBoxes (Vector<Box>& bxs, int n_extra_reserve)
     MPI_Gatherv(bxs.data(), count, ParallelDescriptor::Mpi_typemap<Box>::type(),
                 recv_buffer.data(), countvec.data(), offset.data(),
                 ParallelDescriptor::Mpi_typemap<Box>::type(), root, comm);
-    MPI_Bcast(recv_buffer.data(), count_tot, ParallelDescriptor::Mpi_typemap<Box>::type(),
+    MPI_Bcast(recv_buffer.data(), static_cast<int>(count_tot), ParallelDescriptor::Mpi_typemap<Box>::type(),
               root, comm);
 
     std::swap(bxs,recv_buffer);

--- a/Src/Base/AMReX_BoxList.cpp
+++ b/Src/Base/AMReX_BoxList.cpp
@@ -236,10 +236,8 @@ BoxList::BoxList (const Box& bx, int nboxes, Direction dir)
 bool
 BoxList::ok () const noexcept
 {
-    for (const auto& b : *this) {
-        if (!b.ok()) return false;
-    }
-    return true;
+    return std::all_of(this->cbegin(), this->cend(),
+                       [] (Box const& b) { return b.ok(); });
 }
 
 bool
@@ -261,13 +259,8 @@ BoxList::contains (const BoxList&  bl) const
 
     BoxArray ba(*this);
 
-    for (const Box& bx : bl) {
-        if (!ba.contains(bx)) {
-            return false;
-        }
-    }
-
-    return true;
+    return std::all_of(bl.cbegin(), bl.cend(),
+                       [&ba] (Box const& b) { return ba.contains(b); });
 }
 
 BoxList&
@@ -446,7 +439,7 @@ BoxList::parallelComplementIn (const Box& b, BoxArray const& ba)
 
         const int block_size = 4 * std::max(1,static_cast<int>(std::ceil(s_avgbox/4.))*4);
         bl_mesh.maxSize(block_size);
-        const int N = bl_mesh.size();
+        const int N = static_cast<int>(bl_mesh.size());
 
         const int nprocs = ParallelContext::NProcsSub();
         const int myproc = ParallelContext::MyProcSub();
@@ -499,7 +492,7 @@ BoxList::parallelComplementIn (const Box& b, BoxArray const& ba)
             }
         }
 
-        amrex::AllGatherBoxes(local_boxes, this->size());
+        amrex::AllGatherBoxes(local_boxes, static_cast<int>(this->size()));
         local_boxes.insert(std::end(local_boxes), std::begin(m_lbox), std::end(m_lbox));
         std::swap(m_lbox, local_boxes);
 

--- a/Src/Base/AMReX_CoordSys.cpp
+++ b/Src/Base/AMReX_CoordSys.cpp
@@ -214,7 +214,7 @@ CoordSys::GetDLogA (FArrayBox& dloga,
 }
 
 void
-CoordSys::SetDLogA (FArrayBox& a_dlogafab,
+CoordSys::SetDLogA (FArrayBox& a_dlogafab, // NOLINT(readability-convert-member-functions-to-static)
                     const Box& region,
                     int        dir) const
 {

--- a/Src/Base/AMReX_FACopyDescriptor.H
+++ b/Src/Base/AMReX_FACopyDescriptor.H
@@ -67,7 +67,9 @@ struct FabCopyDescriptor
     ~FabCopyDescriptor ();
 
     FabCopyDescriptor (const FabCopyDescriptor&) = delete;
+    FabCopyDescriptor (FabCopyDescriptor&&) = delete;
     FabCopyDescriptor& operator= (const FabCopyDescriptor&) = delete;
+    FabCopyDescriptor& operator= (FabCopyDescriptor&&) = delete;
 
     FAB*     localFabSource;
     Box      subBox;
@@ -115,6 +117,11 @@ class FabArrayCopyDescriptor
     FabArrayCopyDescriptor () = default;
 
     ~FabArrayCopyDescriptor ();
+
+    FabArrayCopyDescriptor (const FabArrayCopyDescriptor<FAB>&) = delete;
+    FabArrayCopyDescriptor (FabArrayCopyDescriptor<FAB>&&) = delete;
+    FabArrayCopyDescriptor<FAB>& operator= (const FabArrayCopyDescriptor<FAB> &) = delete;
+    FabArrayCopyDescriptor<FAB>& operator= (FabArrayCopyDescriptor<FAB> &&) = delete;
 
     FabArrayId RegisterFabArray(FabArray<FAB> *fabarray);
 
@@ -164,12 +171,6 @@ class FabArrayCopyDescriptor
     [[nodiscard]] int nFabCopyDescs () const { return fabCopyDescList.size(); }
 
 private:
-    //!
-    //! These are disallowed.
-    //!
-    FabArrayCopyDescriptor (const FabArrayCopyDescriptor<FAB>&) = delete;
-
-    FabArrayCopyDescriptor<FAB>& operator= (const FabArrayCopyDescriptor<FAB> &) = delete;
     //!
     //! Helper function for AddBox() routines.
     //!
@@ -412,7 +413,7 @@ FabArrayCopyDescriptor<FAB>::clear ()
 {
     for (unsigned int i = 0, N = fabCopyDescList.size(); i < N; ++i)
     {
-        for (FCDMapIter fmi = fabCopyDescList[i].begin(), End = fabCopyDescList[i].end();
+        for (auto fmi = fabCopyDescList[i].begin(), End = fabCopyDescList[i].end();
              fmi != End;
              ++fmi)
         {
@@ -464,7 +465,7 @@ FabArrayCopyDescriptor<FAB>::CollectData ()
         BL_ASSERT(it->procThatHasData   != MyProc);
 
         const int Who = it->procThatHasData;
-        const int Cnt = (it->box.numPts())*(it->nComp);
+        const auto Cnt = static_cast<int>((it->box.numPts())*(it->nComp));
 
         RcvTags[Who].push_back(it);
 
@@ -534,8 +535,8 @@ FabArrayCopyDescriptor<FAB>::CollectData ()
     const int SeqNum_md   = ParallelDescriptor::SeqNum();
     const int SeqNum_data = ParallelDescriptor::SeqNum();
 
-    const int N_snds = Snds.size();
-    const int N_rcvs = Rcvs.size();
+    const auto N_snds = static_cast<int>(Snds.size());
+    const auto N_rcvs = static_cast<int>(Rcvs.size());
 
     if ( N_snds == 0 && N_rcvs == 0 ) return;
 
@@ -672,7 +673,7 @@ FabArrayCopyDescriptor<FAB>::CollectData ()
                 bxs.push_back(Box(IntVect(&md[4]),
                                   IntVect(&md[4+AMREX_SPACEDIM]),
                                   IntVect(&md[4+AMREX_SPACEDIM*2])));
-                npts[i] = bxs.back().numPts()*ncomp[i];
+                npts[i] = static_cast<int>(bxs.back().numPts()*ncomp[i]);
                 N += npts[i];
             }
 
@@ -714,7 +715,7 @@ FabArrayCopyDescriptor<FAB>::CollectData ()
             const int         Who  = data_sender[k];
             const value_type* dptr = &recv_data[data_offset[k]];
 
-            BL_ASSERT(dptr != 0);
+            BL_ASSERT(dptr != nullptr);
 
             found = RcvTags.find(Who);
 
@@ -730,7 +731,7 @@ FabArrayCopyDescriptor<FAB>::CollectData ()
 
                 match = fabCopyDescList[tag.fabArrayId].equal_range(tag.fillBoxId);
 
-                for (FCDMapIter fmi = match.first; fmi != match.second; ++fmi)
+                for (auto fmi = match.first; fmi != match.second; ++fmi)
                 {
                     FabCopyDescriptor<FAB>* fcdp = (*fmi).second;
 
@@ -738,9 +739,9 @@ FabArrayCopyDescriptor<FAB>::CollectData ()
 
                     if (fcdp->subBox == tag.box)
                     {
-                        BL_ASSERT(fcdp->localFabSource->dataPtr() != 0);
+                        BL_ASSERT(fcdp->localFabSource->dataPtr() != nullptr);
                         BL_ASSERT(fcdp->localFabSource->box() == tag.box);
-                        const int Cnt = tag.box.numPts()*tag.nComp;
+                        auto Cnt = static_cast<int>(tag.box.numPts()*tag.nComp);
                         fcdp->localFabSource->template copyFromMem<RunOn::Host>(tag.box,0,tag.nComp,dptr);
                         dptr += Cnt;
                         break;

--- a/Src/Base/AMReX_FBI.H
+++ b/Src/Base/AMReX_FBI.H
@@ -904,7 +904,7 @@ FabArray<FAB>::pack_send_buffer_cpu (FabArray<FAB> const& src, int scomp, int nc
 {
     amrex::ignore_unused(send_size);
 
-    const int N_snds = send_data.size();
+    auto const N_snds = static_cast<int>(send_data.size());
     if (N_snds == 0) return;
 
 #ifdef AMREX_USE_OMP
@@ -944,7 +944,7 @@ FabArray<FAB>::unpack_recv_buffer_cpu (FabArray<FAB>& dst, int dcomp, int ncomp,
 {
     amrex::ignore_unused(recv_size);
 
-    const int N_rcvs = recv_cctc.size();
+    auto const N_rcvs = static_cast<int>(recv_cctc.size());
     if (N_rcvs == 0) return;
 
     if (is_thread_safe)

--- a/Src/Base/AMReX_FabArray.H
+++ b/Src/Base/AMReX_FabArray.H
@@ -1899,7 +1899,7 @@ FabArray<FAB>::operator= (FabArray<FAB>&& rhs) noexcept
     {
         clear();
 
-        FabArrayBase::operator=(std::move(rhs));
+        FabArrayBase::operator=(static_cast<FabArrayBase&&>(rhs));
         m_factory = std::move(rhs.m_factory);
         m_dallocator = std::move(rhs.m_dallocator);
         define_function_called = rhs.define_function_called;

--- a/Src/Base/AMReX_FabArrayBase.cpp
+++ b/Src/Base/AMReX_FabArrayBase.cpp
@@ -2466,7 +2466,7 @@ FabArrayBase::updateBDKey ()
 bool
 CheckRcvStats (Vector<MPI_Status>& recv_stats, const Vector<std::size_t>& recv_size, int tag)
 {
-    for (int i = 0, n = recv_size.size(); i < n; ++i) {
+    for (int i = 0, n = static_cast<int>(recv_size.size()); i < n; ++i) {
         if (recv_size[i] > 0) {
             std::size_t count = 0;
             int tmp_count = 0;
@@ -2596,7 +2596,7 @@ FabArrayBase::is_cell_centered () const noexcept
 }
 
 bool
-FabArrayBase::isFusingCandidate () const noexcept
+FabArrayBase::isFusingCandidate () const noexcept // NOLINT(readability-convert-member-functions-to-static)
 {
 #ifdef AMREX_USE_GPU
     // This is fine tuned on MI100.

--- a/Src/Base/AMReX_FabArrayCommI.H
+++ b/Src/Base/AMReX_FabArrayCommI.H
@@ -175,7 +175,7 @@ FabArray<FAB>::FillBoundary_finish ()
     if (!fbd) { n_filled = IntVect::TheZeroVector(); return; }
 
     const FB* TheFB = fbd->fb;
-    const int N_rcvs = TheFB->m_RcvTags->size();
+    const auto N_rcvs = static_cast<int>(TheFB->m_RcvTags->size());
     if (N_rcvs > 0)
     {
         Vector<const CopyComTagsContainer*> recv_cctc(N_rcvs,nullptr);
@@ -233,7 +233,7 @@ FabArray<FAB>::FillBoundary_finish ()
         }
     }
 
-    const int N_snds = TheFB->m_SndTags->size();
+    const auto N_snds = static_cast<int>(TheFB->m_SndTags->size());
     if (N_snds > 0) {
         Vector<MPI_Status> stats(fbd->send_reqs.size());
         ParallelDescriptor::Waitall(fbd->send_reqs, stats);
@@ -505,8 +505,8 @@ FabArray<FAB>::ParallelCopy_finish ()
 
     const CPC* thecpc = pcd->cpc;
 
-    const int N_snds = thecpc->m_SndTags->size();
-    const int N_rcvs = thecpc->m_RcvTags->size();
+    const auto N_snds = static_cast<int>(thecpc->m_SndTags->size());
+    const auto N_rcvs = static_cast<int>(thecpc->m_RcvTags->size());
 
     if (N_rcvs > 0)
     {
@@ -646,7 +646,7 @@ FabArray<FAB>::PrepareSendBuffers (const MapOfCopyComTagContainers&     SndTags,
     send_rank.clear();
     send_reqs.clear();
     send_cctc.clear();
-    const int N_snds = SndTags.size();
+    const auto N_snds = SndTags.size();
     if (N_snds == 0) return;
     send_data.reserve(N_snds);
     send_size.reserve(N_snds);
@@ -686,7 +686,7 @@ FabArray<FAB>::PrepareSendBuffers (const MapOfCopyComTagContainers&     SndTags,
     if (total_volume > 0)
     {
         the_send_data = static_cast<char*>(amrex::The_FA_Arena()->alloc(total_volume));
-        for (int i = 0, N = send_size.size(); i < N; ++i) {
+        for (int i = 0, N = static_cast<int>(send_size.size()); i < N; ++i) {
             send_data[i] = the_send_data + offset[i];
         }
     } else {
@@ -704,7 +704,7 @@ FabArray<FAB>::PostSnds (Vector<char*> const&       send_data,
 {
     MPI_Comm comm = ParallelContext::CommunicatorSub();
 
-    const int N_snds = send_reqs.size();
+    const auto N_snds = static_cast<int>(send_reqs.size());
     for (int j = 0; j < N_snds; ++j)
     {
         if (send_size[j] > 0) {
@@ -773,7 +773,7 @@ FabArray<FAB>::PostRcvs (const MapOfCopyComTagContainers&  RcvTags,
         recv_reqs.push_back(MPI_REQUEST_NULL);
     }
 
-    const int nrecv = recv_from.size();
+    const auto nrecv = static_cast<int>(recv_from.size());
 
     MPI_Comm comm = ParallelContext::CommunicatorSub();
 

--- a/Src/Base/AMReX_FabFactory.H
+++ b/Src/Base/AMReX_FabFactory.H
@@ -48,7 +48,12 @@ template <class FAB>
 class FabFactory
 {
 public:
-    virtual ~FabFactory () = default;
+    FabFactory () noexcept = default;
+    FabFactory (FabFactory const&) noexcept = default;
+    FabFactory (FabFactory &&) noexcept = default;
+    FabFactory& operator= (FabFactory const&) noexcept = default;
+    FabFactory& operator= (FabFactory &&) noexcept = default;
+    virtual ~FabFactory () noexcept = default;
     AMREX_NODISCARD
     virtual FAB* create (const Box& box, int ncomps, const FabInfo& info, int box_index) const = 0;
     AMREX_NODISCARD

--- a/Src/Base/AMReX_ForkJoin.H
+++ b/Src/Base/AMReX_ForkJoin.H
@@ -37,7 +37,7 @@ class ForkJoin
     ForkJoin (int ntasks)
         : ForkJoin( Vector<double>(ntasks, 1.0 / ntasks) ) { }
 
-    int NTasks () const { return split_bounds.size() - 1; }
+    int NTasks () const { return static_cast<int>(split_bounds.size() - 1); }
 
     int MyTask () const { return task_me; }
 
@@ -113,7 +113,7 @@ class ForkJoin
 
     //! vector of pointers to all MFs under a name
     Vector<MultiFab *> get_mf_vec (const std::string &name) {
-        int dim = data.at(name).size();
+        int dim = static_cast<int>(data.at(name).size());
         Vector<MultiFab *> result(dim);
         for (int idx = 0; idx < dim; ++idx) {
             result[idx] = &get_mf(name, idx);
@@ -162,6 +162,7 @@ class ForkJoin
         Vector<MultiFab> forked; //!< holds new multifab for each task in fork
 
         MFFork () = default;
+        ~MFFork () = default;
         MFFork (const MFFork&) = delete;
         MFFork& operator= (const MFFork&) = delete;
         MFFork (MFFork&&) = default;

--- a/Src/Base/AMReX_GpuAsyncArray.H
+++ b/Src/Base/AMReX_GpuAsyncArray.H
@@ -67,7 +67,7 @@ public:
     void operator= (AsyncArray &&) = delete;
 
     [[nodiscard]] T const* data () const noexcept { return (d_data != nullptr) ? d_data : h_data; }
-    T* data () noexcept { return (d_data != nullptr) ? d_data : h_data; }
+    [[nodiscard]] T* data () noexcept { return (d_data != nullptr) ? d_data : h_data; }
     void clear ()
     {
 #ifdef AMREX_USE_GPU

--- a/Src/Base/AMReX_GpuBuffer.H
+++ b/Src/Base/AMReX_GpuBuffer.H
@@ -63,11 +63,11 @@ public:
     void operator= (Buffer const&) = delete;
     void operator= (Buffer &&) = delete;
 
-    T const* data () const noexcept { return (d_data != nullptr) ? d_data : h_data; }
-    T* data () noexcept { return (d_data != nullptr) ? d_data : h_data; }
+    [[nodiscard]] T const* data () const noexcept { return (d_data != nullptr) ? d_data : h_data; }
+    [[nodiscard]] T* data () noexcept { return (d_data != nullptr) ? d_data : h_data; }
 
-    T const* hostData () const noexcept { return h_data; }
-    T* hostData () noexcept { return h_data; }
+    [[nodiscard]] T const* hostData () const noexcept { return h_data; }
+    [[nodiscard]] T* hostData () noexcept { return h_data; }
 
     [[nodiscard]] std::size_t size () const noexcept { return m_size; }
 

--- a/Src/Base/AMReX_LayoutData.H
+++ b/Src/Base/AMReX_LayoutData.H
@@ -72,7 +72,7 @@ namespace amrex
             m_data.clear();
             if (m_need_to_clear_bd) clearThisBD();
 
-            FabArrayBase::operator=(std::move(rhs));
+            FabArrayBase::operator=(static_cast<FabArrayBase&&>(rhs));
             m_data = std::move(rhs.m_data);
             m_need_to_clear_bd = rhs.m_need_to_clear_bd;
 

--- a/Src/Base/AMReX_MFCopyDescriptor.H
+++ b/Src/Base/AMReX_MFCopyDescriptor.H
@@ -47,11 +47,12 @@ class MultiFabCopyDescriptor
   public:
 
     MultiFabCopyDescriptor () = default;
-
     ~MultiFabCopyDescriptor () = default;
 
     MultiFabCopyDescriptor (const MultiFabCopyDescriptor&) = delete;
+    MultiFabCopyDescriptor (MultiFabCopyDescriptor&&) = delete;
     MultiFabCopyDescriptor& operator= (const MultiFabCopyDescriptor&) = delete;
+    MultiFabCopyDescriptor& operator= (MultiFabCopyDescriptor&&) = delete;
 
     MultiFabId RegisterMultiFab (MultiFab* mf) { return RegisterFabArray(mf); }
 };

--- a/Src/Base/AMReX_MFIter.H
+++ b/Src/Base/AMReX_MFIter.H
@@ -99,6 +99,9 @@ public:
     MFIter (const BoxArray& ba, const DistributionMapping& dm, const MFItInfo& info);
 
     MFIter (MFIter&& rhs) = default;
+    MFIter (MFIter const&) = delete;
+    MFIter& operator= (MFIter const&) = delete;
+    MFIter& operator= (MFIter &&) = delete;
 
     // dtor
     ~MFIter ();
@@ -185,9 +188,12 @@ protected:
     bool          finalized = false;
 
     struct DeviceSync {
-        DeviceSync () = default;
         DeviceSync (bool f) : flag(f) {}
         DeviceSync (DeviceSync&& rhs)  noexcept : flag(std::exchange(rhs.flag,false)) {}
+        ~DeviceSync () = default;
+        DeviceSync (DeviceSync const&) = delete;
+        DeviceSync& operator= (DeviceSync const&) = delete;
+        DeviceSync& operator= (DeviceSync &&) = delete;
         explicit operator bool() const noexcept { return flag; }
         bool flag = true;
     };

--- a/Src/Base/AMReX_MPMD.H
+++ b/Src/Base/AMReX_MPMD.H
@@ -39,7 +39,7 @@ private:
 template <typename FAB>
 void Copier::send (FabArray<FAB> const& mf, int icomp, int ncomp) const
 {
-    const int N_snds = m_SndTags.size();
+    const auto N_snds = static_cast<int>(m_SndTags.size());
 
     if (N_snds == 0) return;
 
@@ -106,7 +106,7 @@ void Copier::send (FabArray<FAB> const& mf, int icomp, int ncomp) const
 template <typename FAB>
 void Copier::recv (FabArray<FAB>& mf, int icomp, int ncomp) const
 {
-    const int N_rcvs = m_RcvTags.size();
+    const auto N_rcvs = static_cast<int>(m_RcvTags.size());
 
     if (N_rcvs == 0) return;
 

--- a/Src/Base/AMReX_MPMD.cpp
+++ b/Src/Base/AMReX_MPMD.cpp
@@ -128,7 +128,7 @@ Copier::Copier (BoxArray const& ba, DistributionMapping const& dm)
 
     Vector<Box> bv = ba.boxList().data();
 
-    int this_nboxes = ba.size();
+    int this_nboxes = static_cast<int>(ba.size());
     Vector<int> procs = dm.ProcessorMap();
     if (rank_offset != 0) {
         for (int i = 0; i < this_nboxes; ++i) {

--- a/Src/Base/AMReX_Machine.cpp
+++ b/Src/Base/AMReX_Machine.cpp
@@ -199,7 +199,7 @@ class NeighborhoodCache
 
     // result is dependent on both the current set of ranks
     // and the size of the neighborhood desired
-    uint64_t hash (const Vector<int> & cur_ranks, int nbh_rank_n) {
+    static uint64_t hash (const Vector<int> & cur_ranks, int nbh_rank_n) {
         auto result = hash_vector(cur_ranks);
         hash_combine(result, nbh_rank_n);
         return result;
@@ -231,7 +231,7 @@ class Machine
         }
 
         Vector<int> result;
-        auto key = nbh_cache.hash(sg_g_ranks, nbh_rank_n);
+        auto key = NeighborhoodCache::hash(sg_g_ranks, nbh_rank_n);
         if (nbh_cache.get(key, result)) {
             if (flag_verbose) {
                 Print() << "Machine::find_best_nbh(): found neighborhood in cache" << std::endl;
@@ -279,10 +279,10 @@ class Machine
             int    winner_rank  = min_score_with_id.i;
 
             // broadcast the best hood from winner rank to everyone
-            int local_nbh_size = local_nbh.size();
+            auto local_nbh_size = static_cast<int>(local_nbh.size());
             MPI_Bcast(&local_nbh_size, 1, MPI_INT, winner_rank, ParallelContext::CommunicatorSub());
             local_nbh.resize(local_nbh_size);
-            MPI_Bcast(local_nbh.data(), local_nbh.size(), MPI_INT, winner_rank, ParallelContext::CommunicatorSub());
+            MPI_Bcast(local_nbh.data(), local_nbh_size, MPI_INT, winner_rank, ParallelContext::CommunicatorSub());
 
             std::sort(local_nbh.begin(), local_nbh.end());
             if (flag_verbose) {
@@ -332,7 +332,7 @@ class Machine
         pp.queryAdd("very_verbose", flag_very_verbose);
     }
 
-    std::string get_env_str (const std::string& env_key)
+    static std::string get_env_str (const std::string& env_key)
     {
         std::string result;
         auto *val_c_str = std::getenv(env_key.c_str());

--- a/Src/Base/AMReX_MemPool.cpp
+++ b/Src/Base/AMReX_MemPool.cpp
@@ -26,7 +26,7 @@ namespace
 #if defined(AMREX_TESTING) || defined(AMREX_DEBUG)
     int init_snan = 1;
 #else
-    static int init_snan = 0;
+    int init_snan = 0;
 #endif
     bool initialized = false;
 }

--- a/Src/Base/AMReX_MultiFabUtil.H
+++ b/Src/Base/AMReX_MultiFabUtil.H
@@ -240,7 +240,7 @@ namespace amrex
             auto psrc = mf_in [mfi].dataPtr();
             AMREX_HOST_DEVICE_PARALLEL_FOR_1D ( n, i,
             {
-                pdst[i] = static_cast<typename U::value_type>(psrc[i]);
+                pdst[i] = static_cast<typename U::value_type>(psrc[i]); // NOLINT(bugprone-signed-char-misuse)
             });
         }
         return mf_out;
@@ -949,12 +949,12 @@ MF get_line_data (MF const& mf, int dir, IntVect const& cell)
 {
     BoxArray const& ba = mf.boxArray();
     DistributionMapping const& dm = mf.DistributionMap();
-    const Long nboxes = ba.size();
+    const auto nboxes = static_cast<int>(ba.size());
 
     BoxList bl(ba.ixType());
     Vector<int> procmap;
     Vector<int> index_map;
-    for (Long i = 0; i < nboxes; ++i) {
+    for (int i = 0; i < nboxes; ++i) {
         Box const& b = ba[i];
         IntVect lo = cell;
         lo[dir] = b.smallEnd(dir);

--- a/Src/Base/AMReX_NFiles.H
+++ b/Src/Base/AMReX_NFiles.H
@@ -79,6 +79,10 @@ class NFilesIter
 
     ~NFilesIter();
 
+    NFilesIter (NFilesIter const&) = delete;
+    NFilesIter (NFilesIter &&) = delete;
+    NFilesIter& operator= (NFilesIter const&) = delete;
+    NFilesIter& operator= (NFilesIter &&) = delete;
 
     /**
     * \brief if appendFirst is true, the first set for this
@@ -235,8 +239,6 @@ class NFilesIter
     static const int indexUndefined = -1;
 
     static AMREX_EXPORT int minDigits;        //!< for Concatenate
-
-    NFilesIter() = delete;  //!< disallow
 };
 
 }

--- a/Src/Base/AMReX_NFiles.cpp
+++ b/Src/Base/AMReX_NFiles.cpp
@@ -437,7 +437,7 @@ NFilesIter &NFilesIter::operator++() {
             for(int nfn(0); nfn < procsToWrite.size(); ++nfn) {
               // ---- start with the current next file number
               // ---- get a proc from another file number if the queue is empty
-              int tempNFN((nextFileNumberToWrite + nfn) % procsToWrite.size());
+              auto tempNFN = static_cast<int>((nextFileNumberToWrite + nfn) % procsToWrite.size());
               if(!procsToWrite[tempNFN].empty()) {
                 nextProcToWrite = procsToWrite[tempNFN].front();
                 procsToWrite[tempNFN].pop_front();

--- a/Src/Base/AMReX_NonLocalBC.H
+++ b/Src/Base/AMReX_NonLocalBC.H
@@ -710,14 +710,12 @@ ParallelCopy_nowait (NoLocalCopy, FabArray<FAB>& dest, const FabArray<FAB>& src,
     //
     handler.mpi_tag = ParallelDescriptor::SeqNum();
 
-    const int N_rcvs = cmd.m_RcvTags ? cmd.m_RcvTags->size() : 0;
-    if (N_rcvs > 0) {
+    if (cmd.m_RcvTags && !(cmd.m_RcvTags->empty())) {
         PrepareRecvBuffers(data_packing, dest, src, handler.recv, *cmd.m_RcvTags);
         PostRecvs(handler.recv, handler.mpi_tag);
     }
 
-    const int N_snds = cmd.m_SndTags ? cmd.m_SndTags->size() : 0;
-    if (N_snds > 0) {
+    if (cmd.m_SndTags && !(cmd.m_SndTags->empty())) {
         PrepareSendBuffers(data_packing, dest, src, handler.send, *cmd.m_SndTags);
         PackSendBuffers(data_packing, src, handler.send);
         PostSends(handler.send, handler.mpi_tag);
@@ -803,8 +801,7 @@ ParallelCopy_finish (FabArray<FAB>& dest, CommHandler handler,
         return;
     }
     // Unpack receives
-    const int N_rcvs = cmd.m_RcvTags ? cmd.m_RcvTags->size() : 0;
-    if (N_rcvs > 0) {
+    if (cmd.m_RcvTags && !(cmd.m_RcvTags->empty())) {
         ParallelDescriptor::Waitall(handler.recv.request, handler.recv.stats);
 #ifdef AMREX_DEBUG
         if (!CheckRcvStats(handler.recv.stats, handler.recv.size, handler.mpi_tag)) {
@@ -815,8 +812,7 @@ ParallelCopy_finish (FabArray<FAB>& dest, CommHandler handler,
     }
 
     // Wait for all sends to be done
-    const int N_snds = cmd.m_SndTags ? cmd.m_SndTags->size() : 0;
-    if (N_snds > 0) {
+    if (cmd.m_SndTags && !(cmd.m_SndTags->empty())) {
         ParallelDescriptor::Waitall(handler.send.request, handler.send.stats);
     }
 }

--- a/Src/Base/AMReX_NonLocalBC.cpp
+++ b/Src/Base/AMReX_NonLocalBC.cpp
@@ -16,7 +16,7 @@ void PrepareCommBuffers(CommData& comm,
     comm.cctc.clear();
     comm.stats.clear();
 
-    const int N_comms = cctc.size();
+    const auto N_comms = static_cast<int>(cctc.size());
     if (N_comms == 0) return;
     // reserve for upcominf push_backs
     comm.data.reserve(N_comms);
@@ -85,12 +85,12 @@ void PostRecvs(CommData& recv, int mpi_tag) {
 }
 
 void PostSends(CommData& send, int mpi_tag) {
-    const int n_sends = send.data.size();
+    const auto n_sends = send.data.size();
     AMREX_ASSERT(n_sends == send.size.size());
     AMREX_ASSERT(n_sends == send.rank.size());
     AMREX_ASSERT(n_sends == send.request.size());
     MPI_Comm comm = ParallelContext::CommunicatorSub();
-    for (int j = 0; j < n_sends; ++j) {
+    for (int j = 0; j < static_cast<int>(n_sends); ++j) {
         if (send.size[j] > 0) {
             const int rank = ParallelContext::global_to_local_rank(send.rank[j]);
             AMREX_ASSERT(send.data[j] != nullptr);

--- a/Src/Base/AMReX_NonLocalBCImpl.H
+++ b/Src/Base/AMReX_NonLocalBCImpl.H
@@ -128,9 +128,9 @@ struct PolarFn2 { // for the x-y corners
 
     [[nodiscard]] AMREX_GPU_HOST_DEVICE
     int j_index (int j) const noexcept {
-        if (j < 0) {
+        if (j < 0) { // NOLINT
             return j+Ly/2;
-        } else if (j >= Ly) {
+        } else if (j >= Ly) { // NOLINT
             return j-Ly/2;
         } else if (j < Ly/2) {
             return j-Ly/2;
@@ -187,7 +187,7 @@ template <class FAB, class DTOS, class Proj>
 std::enable_if_t<IsBaseFab<FAB>() && IsCallableR<Dim3, DTOS, Dim3>() && IsFabProjection<Proj, FAB>()>
 local_copy_cpu (FabArray<FAB>& dest, const FabArray<FAB>& src, int dcomp, int scomp, int ncomp,
                 FabArrayBase::CopyComTagsContainer const& local_tags, DTOS dtos, Proj proj) noexcept {
-    const int N_locs = local_tags.size();
+    const auto N_locs = static_cast<int>(local_tags.size());
     if (N_locs == 0) return;
 #ifdef AMREX_USE_OMP
 #pragma omp parallel for
@@ -217,7 +217,7 @@ unpack_recv_buffer_cpu (FabArray<FAB>& mf, int dcomp, int ncomp, Vector<char*> c
                         DTOS dtos, Proj proj) noexcept {
     amrex::ignore_unused(recv_size);
 
-    const int N_rcvs = recv_cctc.size();
+    const auto N_rcvs = static_cast<int>(recv_cctc.size());
     if (N_rcvs == 0) return;
 
     using T = typename FAB::value_type;
@@ -357,7 +357,7 @@ MultiBlockCommMetaData::define (const BoxArray& dstba, const DistributionMapping
     m_SndTags = std::make_unique<FabArrayBase::MapOfCopyComTagContainers>();
     m_RcvTags = std::make_unique<FabArrayBase::MapOfCopyComTagContainers>();
     const int myproc = ParallelDescriptor::MyProc();
-    for (int i = 0, N = dstba.size(); i < N; ++i) {
+    for (int i = 0, N = static_cast<int>(dstba.size()); i < N; ++i) {
         const int dest_owner = dstdm[i];
         const Box partial_dstbox = grow(dstba[i], ngrow) & dstbox;
         if (partial_dstbox.isEmpty()) {
@@ -407,8 +407,7 @@ Comm_nowait (FabArray<FAB>& mf, int scomp, int ncomp, FabArrayBase::CommMetaData
     if (ParallelContext::NProcsSub() == 1)
 #endif
     {
-        int N_locs = (*cmd.m_LocTags).size();
-        if (N_locs == 0) return CommHandler{};
+        if (cmd.m_LocTags->empty()) { return CommHandler{}; }
 #ifdef AMREX_USE_GPU
         if (Gpu::inLaunchRegion()) {
             local_copy_gpu(mf, mf, scomp, scomp, ncomp, *cmd.m_LocTags, dtos);
@@ -427,9 +426,9 @@ Comm_nowait (FabArray<FAB>& mf, int scomp, int ncomp, FabArrayBase::CommMetaData
     //
     int SeqNum = ParallelDescriptor::SeqNum();
 
-    const int N_locs = cmd.m_LocTags->size();
-    const int N_rcvs = cmd.m_RcvTags->size();
-    const int N_snds = cmd.m_SndTags->size();
+    const auto N_locs = cmd.m_LocTags->size();
+    const auto N_rcvs = cmd.m_RcvTags->size();
+    const auto N_snds = cmd.m_SndTags->size();
 
     if (N_locs == 0 && N_rcvs == 0 && N_snds == 0) {
         // No work to do.
@@ -487,7 +486,7 @@ Comm_finish (FabArray<FAB>& mf, int scomp, int ncomp, FabArrayBase::CommMetaData
 {
     if (ParallelContext::NProcsSub() == 1) return;
 
-    const int N_rcvs = cmd.m_RcvTags->size();
+    const auto N_rcvs = static_cast<int>(cmd.m_RcvTags->size());
     if (N_rcvs > 0)
     {
         handler.recv.cctc.resize(N_rcvs, nullptr);
@@ -516,8 +515,7 @@ Comm_finish (FabArray<FAB>& mf, int scomp, int ncomp, FabArrayBase::CommMetaData
         }
     }
 
-    const int N_snds = cmd.m_SndTags->size();
-    if (N_snds > 0) {
+    if ( ! cmd.m_SndTags->empty() ) {
         handler.send.stats.resize(handler.send.request.size());
         ParallelDescriptor::Waitall(handler.send.request, handler.send.stats);
     }

--- a/Src/Base/AMReX_PCI.H
+++ b/Src/Base/AMReX_PCI.H
@@ -6,7 +6,7 @@ void
 FabArray<FAB>::PC_local_cpu (const CPC& thecpc, FabArray<FAB> const& src,
                              int scomp, int dcomp, int ncomp, CpOp op)
 {
-    int N_locs = thecpc.m_LocTags->size();
+    auto const N_locs = static_cast<int>(thecpc.m_LocTags->size());
     if (N_locs == 0) return;
     bool is_thread_safe = thecpc.m_threadsafe_loc;
 

--- a/Src/Base/AMReX_ParallelContext.H
+++ b/Src/Base/AMReX_ParallelContext.H
@@ -27,8 +27,8 @@ public:
     int NProcs () const noexcept { return m_nranks; }
     int IOProc () const noexcept { return m_io_rank; }
     static int local_to_global_rank (int lrank);
-    static void local_to_global_rank (int* global, const int* local, std::size_t n);
-    static void global_to_local_rank (int* local, const int* global, std::size_t n);
+    static void local_to_global_rank (int* global, const int* local, int n);
+    static void global_to_local_rank (int* local, const int* global, int n);
     static int global_to_local_rank (int grank);
     int get_inc_mpi_tag ();
     void set_ofs_name (std::string filename);

--- a/Src/Base/AMReX_ParallelContext.cpp
+++ b/Src/Base/AMReX_ParallelContext.cpp
@@ -59,20 +59,20 @@ Frame::local_to_global_rank (int lrank)
 }
 
 void
-Frame::local_to_global_rank (int* global, const int* local, std::size_t n)
+Frame::local_to_global_rank (int* global, const int* local, int n)
 {
 #ifdef BL_USE_MPI
     if (frames.size() > 1)
     {
-      MPI_Group_translate_ranks(GroupSub(), n, const_cast<int*>(local), GroupAll(), global);
+        MPI_Group_translate_ranks(GroupSub(), n, const_cast<int*>(local), GroupAll(), global);
     }
     else
     {
-        for (std::size_t i = 0; i < n; ++i) global[i] = local[i];
+        for (int i = 0; i < n; ++i) global[i] = local[i];
     }
 #else
     amrex::ignore_unused(local);
-    for (std::size_t i = 0; i < n; ++i) global[i] = 0;
+    for (int i = 0; i < n; ++i) global[i] = 0;
 #endif
 }
 
@@ -85,20 +85,20 @@ Frame::global_to_local_rank (int grank)
 }
 
 void
-Frame::global_to_local_rank (int* local, const int* global, std::size_t n)
+Frame::global_to_local_rank (int* local, const int* global, int n)
 {
 #ifdef BL_USE_MPI
     if (frames.size() > 1)
     {
-      MPI_Group_translate_ranks(GroupAll(), n, const_cast<int*>(global), GroupSub(), local);
+        MPI_Group_translate_ranks(GroupAll(), n, const_cast<int*>(global), GroupSub(), local);
     }
     else
     {
-        for (std::size_t i = 0; i < n; ++i) local[i] = global[i];
+        for (int i = 0; i < n; ++i) local[i] = global[i];
     }
 #else
     amrex::ignore_unused(global);
-    for (std::size_t i = 0; i < n; ++i) local[i] = 0;
+    for (int i = 0; i < n; ++i) local[i] = 0;
 #endif
 }
 

--- a/Src/Base/AMReX_ParallelDescriptor.cpp
+++ b/Src/Base/AMReX_ParallelDescriptor.cpp
@@ -594,7 +594,7 @@ ReduceIntSum (int* r, int cnt)
 void
 ReduceIntSum (Vector<std::reference_wrapper<int> >&& rvar)
 {
-    int cnt = rvar.size();
+    auto cnt = static_cast<int>(rvar.size());
     Vector<int> tmp{std::begin(rvar), std::end(rvar)};
     detail::DoAllReduce<int>(tmp.data(),MPI_SUM,cnt);
     for (int i = 0; i < cnt; ++i) {
@@ -617,7 +617,7 @@ ReduceIntSum (int* r, int cnt, int cpu)
 void
 ReduceIntSum (Vector<std::reference_wrapper<int> >&& rvar, int cpu)
 {
-    int cnt = rvar.size();
+    auto cnt = static_cast<int>(rvar.size());
     Vector<int> tmp{std::begin(rvar), std::end(rvar)};
     detail::DoReduce<int>(tmp.data(),MPI_SUM,cnt,cpu);
     for (int i = 0; i < cnt; ++i) {
@@ -640,7 +640,7 @@ ReduceIntMax (int* r, int cnt)
 void
 ReduceIntMax (Vector<std::reference_wrapper<int> >&& rvar)
 {
-    int cnt = rvar.size();
+    auto cnt = static_cast<int>(rvar.size());
     Vector<int> tmp{std::begin(rvar), std::end(rvar)};
     detail::DoAllReduce<int>(tmp.data(),MPI_MAX,cnt);
     for (int i = 0; i < cnt; ++i) {
@@ -663,7 +663,7 @@ ReduceIntMax (int* r, int cnt, int cpu)
 void
 ReduceIntMax (Vector<std::reference_wrapper<int> >&& rvar, int cpu)
 {
-    int cnt = rvar.size();
+    auto cnt = static_cast<int>(rvar.size());
     Vector<int> tmp{std::begin(rvar), std::end(rvar)};
     detail::DoReduce<int>(tmp.data(),MPI_MAX,cnt,cpu);
     for (int i = 0; i < cnt; ++i) {
@@ -686,7 +686,7 @@ ReduceIntMin (int* r, int cnt)
 void
 ReduceIntMin (Vector<std::reference_wrapper<int> >&& rvar)
 {
-    int cnt = rvar.size();
+    auto cnt = static_cast<int>(rvar.size());
     Vector<int> tmp{std::begin(rvar), std::end(rvar)};
     detail::DoAllReduce<int>(tmp.data(),MPI_MIN,cnt);
     for (int i = 0; i < cnt; ++i) {
@@ -709,7 +709,7 @@ ReduceIntMin (int* r, int cnt, int cpu)
 void
 ReduceIntMin (Vector<std::reference_wrapper<int> >&& rvar, int cpu)
 {
-    int cnt = rvar.size();
+    auto cnt = static_cast<int>(rvar.size());
     Vector<int> tmp{std::begin(rvar), std::end(rvar)};
     detail::DoReduce<int>(tmp.data(),MPI_MIN,cnt,cpu);
     for (int i = 0; i < cnt; ++i) {
@@ -732,7 +732,7 @@ ReduceLongSum (Long* r, int cnt)
 void
 ReduceLongSum (Vector<std::reference_wrapper<Long> >&& rvar)
 {
-    int cnt = rvar.size();
+    auto cnt = static_cast<int>(rvar.size());
     Vector<Long> tmp{std::begin(rvar), std::end(rvar)};
     detail::DoAllReduce<Long>(tmp.data(),MPI_SUM,cnt);
     for (int i = 0; i < cnt; ++i) {
@@ -755,7 +755,7 @@ ReduceLongSum (Long* r, int cnt, int cpu)
 void
 ReduceLongSum (Vector<std::reference_wrapper<Long> >&& rvar, int cpu)
 {
-    int cnt = rvar.size();
+    auto cnt = static_cast<int>(rvar.size());
     Vector<Long> tmp{std::begin(rvar), std::end(rvar)};
     detail::DoReduce<Long>(tmp.data(),MPI_SUM,cnt,cpu);
     for (int i = 0; i < cnt; ++i) {
@@ -778,7 +778,7 @@ ReduceLongMax (Long* r, int cnt)
 void
 ReduceLongMax (Vector<std::reference_wrapper<Long> >&& rvar)
 {
-    int cnt = rvar.size();
+    auto cnt = static_cast<int>(rvar.size());
     Vector<Long> tmp{std::begin(rvar), std::end(rvar)};
     detail::DoAllReduce<Long>(tmp.data(),MPI_MAX,cnt);
     for (int i = 0; i < cnt; ++i) {
@@ -801,7 +801,7 @@ ReduceLongMax (Long* r, int cnt, int cpu)
 void
 ReduceLongMax (Vector<std::reference_wrapper<Long> >&& rvar, int cpu)
 {
-    int cnt = rvar.size();
+    auto cnt = static_cast<int>(rvar.size());
     Vector<Long> tmp{std::begin(rvar), std::end(rvar)};
     detail::DoReduce<Long>(tmp.data(),MPI_MAX,cnt,cpu);
     for (int i = 0; i < cnt; ++i) {
@@ -824,7 +824,7 @@ ReduceLongMin (Long* r, int cnt)
 void
 ReduceLongMin (Vector<std::reference_wrapper<Long> >&& rvar)
 {
-    int cnt = rvar.size();
+    auto cnt = static_cast<int>(rvar.size());
     Vector<Long> tmp{std::begin(rvar), std::end(rvar)};
     detail::DoAllReduce<Long>(tmp.data(),MPI_MIN,cnt);
     for (int i = 0; i < cnt; ++i) {
@@ -847,7 +847,7 @@ ReduceLongMin (Long* r, int cnt, int cpu)
 void
 ReduceLongMin (Vector<std::reference_wrapper<Long> >&& rvar, int cpu)
 {
-    int cnt = rvar.size();
+    auto cnt = static_cast<int>(rvar.size());
     Vector<Long> tmp{std::begin(rvar), std::end(rvar)};
     detail::DoReduce<Long>(tmp.data(),MPI_MIN,cnt,cpu);
     for (int i = 0; i < cnt; ++i) {
@@ -870,7 +870,7 @@ ReduceLongAnd (Long* r, int cnt)
 void
 ReduceLongAnd (Vector<std::reference_wrapper<Long> >&& rvar)
 {
-    int cnt = rvar.size();
+    auto cnt = static_cast<int>(rvar.size());
     Vector<Long> tmp{std::begin(rvar), std::end(rvar)};
     detail::DoAllReduce<Long>(tmp.data(),MPI_LAND,cnt);
     for (int i = 0; i < cnt; ++i) {
@@ -893,7 +893,7 @@ ReduceLongAnd (Long* r, int cnt, int cpu)
 void
 ReduceLongAnd (Vector<std::reference_wrapper<Long> >&& rvar,int cpu)
 {
-    int cnt = rvar.size();
+    auto cnt = static_cast<int>(rvar.size());
     Vector<Long> tmp{std::begin(rvar), std::end(rvar)};
     detail::DoReduce<Long>(tmp.data(),MPI_LAND,cnt,cpu);
     for (int i = 0; i < cnt; ++i) {
@@ -1263,8 +1263,7 @@ BL_FORT_PROC_DECL(BL_PD_BARRIER,bl_pd_barrier)()
 
 BL_FORT_PROC_DECL(BL_PD_COMMUNICATOR,bl_pd_communicator)(void* vcomm)
 {
-    MPI_Comm* comm = reinterpret_cast<MPI_Comm*>(vcomm);
-
+    auto* comm = reinterpret_cast<MPI_Comm*>(vcomm);
     *comm = ParallelDescriptor::Communicator();
 }
 

--- a/Src/Base/AMReX_ParallelReduce.H
+++ b/Src/Base/AMReX_ParallelReduce.H
@@ -245,7 +245,7 @@ namespace ParallelReduce {
     template<typename K, typename V>
     void Max (KeyValuePair<K,V>* vi, int cnt, int root, MPI_Comm comm) {
 #ifdef AMREX_USE_MPI
-        auto sendbuf = (ParallelDescriptor::MyProc(comm) == root) ?
+        const auto *sendbuf = (ParallelDescriptor::MyProc(comm) == root) ?
             (void const*)(MPI_IN_PLACE) : (void const*)vi;
         using T = KeyValuePair<K,V>;
         MPI_Reduce(sendbuf, vi, cnt,
@@ -276,7 +276,7 @@ namespace ParallelReduce {
     template<typename K, typename V>
     void Min (KeyValuePair<K,V>* vi, int cnt, int root, MPI_Comm comm) {
 #ifdef AMREX_USE_MPI
-        auto sendbuf = (ParallelDescriptor::MyProc(comm) == root) ?
+        const auto *sendbuf = (ParallelDescriptor::MyProc(comm) == root) ?
             (void const*)(MPI_IN_PLACE) : (void const*)vi;
         using T = KeyValuePair<K,V>;
         MPI_Reduce(sendbuf, vi, cnt,

--- a/Src/Base/AMReX_ParmParse.cpp
+++ b/Src/Base/AMReX_ParmParse.cpp
@@ -1117,7 +1117,7 @@ static
 bool
 unused_table_entries_q (const ParmParse::Table& table, const std::string& prefix = std::string())
 {
-    for (auto const& li : table)
+    for (auto const& li : table) // NOLINT(readability-use-anyofallof)
     {
         if ( li.m_table )
         {

--- a/Src/Base/AMReX_Reduce.H
+++ b/Src/Base/AMReX_Reduce.H
@@ -989,6 +989,7 @@ public:
         }
     }
 
+    ~ReduceData () = default;
     ReduceData (ReduceData<Ts...> const&) = delete;
     ReduceData (ReduceData<Ts...> &&) = delete;
     void operator= (ReduceData<Ts...> const&) = delete;

--- a/Src/Base/AMReX_TinyProfiler.H
+++ b/Src/Base/AMReX_TinyProfiler.H
@@ -44,6 +44,11 @@ public:
     TinyProfiler (const char* funcname, bool start_, bool useCUPTI=false) noexcept;
     ~TinyProfiler ();
 
+    TinyProfiler (TinyProfiler const&) = delete;
+    TinyProfiler (TinyProfiler &&) = delete;
+    TinyProfiler& operator= (TinyProfiler const&) = delete;
+    TinyProfiler& operator= (TinyProfiler &&) = delete;
+
     void start () noexcept;
     void stop () noexcept;
 #ifdef AMREX_USE_CUPTI
@@ -128,7 +133,6 @@ private:
     int global_depth;
     std::vector<Stats*> stats;
 
-
     static std::deque<const TinyProfiler*> mem_stack;
 
 #ifdef AMREX_USE_OMP
@@ -151,7 +155,9 @@ private:
     static int verbose;
 
     static void PrintStats (std::map<std::string,Stats>& regstats, double dt_max);
-    static void PrintMemStats (int mem_type, double dt_max, double t_final);
+    static void PrintMemStats (std::map<std::string, MemStat>& memstats,
+                               std::string const& memname, double dt_max,
+                               double t_final);
 };
 
 class TinyProfileRegion
@@ -159,6 +165,10 @@ class TinyProfileRegion
 public:
     explicit TinyProfileRegion (std::string a_regname) noexcept;
     explicit TinyProfileRegion (const char* a_regname) noexcept;
+    TinyProfileRegion (TinyProfileRegion const&) = delete;
+    TinyProfileRegion (TinyProfileRegion &&) = delete;
+    TinyProfileRegion& operator= (TinyProfileRegion const&) = delete;
+    TinyProfileRegion& operator= (TinyProfileRegion &&) = delete;
     ~TinyProfileRegion ();
 private:
     std::string regname;

--- a/Src/Base/AMReX_Utility.cpp
+++ b/Src/Base/AMReX_Utility.cpp
@@ -715,13 +715,13 @@ void amrex::SyncStrings(const Vector<std::string> &localStrings,
     for(int i(0); i < localStringsCopy.size(); ++i) {
       pfStrings << localStringsCopy[i] << '\n';
     }
-    pfStringsSize = pfStrings.str().size();
+    pfStringsSize = static_cast<int>(pfStrings.str().size());
   }
   ParallelDescriptor::Bcast(&pfStringsSize, 1);
 
   Vector<char> pfCharArray(pfStringsSize + 1);
   if(ParallelDescriptor::IOProcessor()) {
-    std::strcpy(pfCharArray.dataPtr(), pfStrings.str().c_str());  // null terminated
+    std::strncpy(pfCharArray.dataPtr(), pfStrings.str().c_str(), pfCharArray.size());  // null terminated
   }
   ParallelDescriptor::Bcast(pfCharArray.dataPtr(), pfCharArray.size());
 
@@ -779,9 +779,9 @@ void amrex::SyncStrings(const Vector<std::string> &localStrings,
     for(int i(0); i < sendStrings.size(); ++i) {
       ossSendStrings << sendStrings[i] << '\n';
     }
-    sendStringsSize = ossSendStrings.str().size();
+    sendStringsSize = static_cast<int>(ossSendStrings.str().size());
     sendCharArray.resize(sendStringsSize + 1);
-    std::strcpy(sendCharArray.dataPtr(), ossSendStrings.str().c_str());  // null terminated
+    std::strncpy(sendCharArray.dataPtr(), ossSendStrings.str().c_str(), sendCharArray.size());  // null terminated
   }
 
   Vector<int> nChars(nProcs, 0);
@@ -832,13 +832,13 @@ void amrex::SyncStrings(const Vector<std::string> &localStrings,
     for(int i(0); i < syncedStrings.size(); ++i) {
       syncedStrStr << syncedStrings[i] << '\n';
     }
-    syncedStringsSize = syncedStrStr.str().size();
+    syncedStringsSize = static_cast<int>(syncedStrStr.str().size());
   }
   ParallelDescriptor::Bcast(&syncedStringsSize, 1);
 
   Vector<char> syncedCharArray(syncedStringsSize + 1);
   if(ParallelDescriptor::IOProcessor()) {
-    std::strcpy(syncedCharArray.dataPtr(), syncedStrStr.str().c_str());  // null terminated
+    std::strncpy(syncedCharArray.dataPtr(), syncedStrStr.str().c_str(), syncedCharArray.size());  // null terminated
   }
   ParallelDescriptor::Bcast(syncedCharArray.dataPtr(), syncedCharArray.size());
 

--- a/Src/Base/AMReX_VisMF.H
+++ b/Src/Base/AMReX_VisMF.H
@@ -49,7 +49,9 @@ public:
     explicit VisMF (std::string fafab_name);
     ~VisMF () = default;
     VisMF (const VisMF&) = delete;
+    VisMF (VisMF&&) = delete;
     VisMF& operator= (const VisMF&) = delete;
+    VisMF& operator= (VisMF&&) = delete;
     //! A structure containing info regarding an on-disk FAB.
     struct FabOnDisk
     {
@@ -82,7 +84,11 @@ public:
         Header (const FabArray<FArrayBox>& mf, VisMF::How how, Version version = Version_v1,
                 bool calcMinMax = true, MPI_Comm = ParallelDescriptor::Communicator());
 
+        ~Header () = default;
         Header (Header&& rhs) noexcept = default;
+        Header (Header const&) = delete;
+        Header& operator= (Header const&) = delete;
+        Header& operator= (Header &&) = delete;
 
         //! Calculate the min and max arrays
         void CalculateMinMax(const FabArray<FArrayBox>& mf,
@@ -115,7 +121,7 @@ public:
         Long fileOffset{-1};
         Box box;
 
-        FabReadLink();
+        FabReadLink() = default;
         FabReadLink(int ranktoread, int faindex, Long fileoffset, const Box &b);
     };
 
@@ -123,12 +129,16 @@ public:
     struct PersistentIFStream
     {
         std::ifstream   *pstr{nullptr};
-        std::streampos   currentPosition;
+        std::streampos   currentPosition{0};
         bool             isOpen{false};
         VisMF::IO_Buffer ioBuffer;
 
-        PersistentIFStream();
-        ~PersistentIFStream();
+        PersistentIFStream () = default;
+        ~PersistentIFStream ();
+        PersistentIFStream (PersistentIFStream const&) = delete;
+        PersistentIFStream (PersistentIFStream &&) = delete;
+        PersistentIFStream& operator= (PersistentIFStream const&) = delete;
+        PersistentIFStream& operator= (PersistentIFStream &&) = delete;
     };
 
     /**
@@ -611,7 +621,7 @@ Read (FabArray<FAB>& fa, const std::string& name)
         std::multiset<int> availablefiles;  // [whichFile]  supports multiple reads/file
         Vector<std::map<int,std::map<Long,int> > > allreads; // [file]<proc,<seek,index>>
 
-        const int nfiles = filenames.size();
+        const auto nfiles = static_cast<int>(filenames.size());
         for (int i = 0; i < nfiles; ++i) {
             for (int j = 0; j < nopensperfile; ++j) {
                 availablefiles.insert(i);
@@ -713,7 +723,7 @@ Read (FabArray<FAB>& fa, const std::string& name)
         while (nreqs > 0) {
             ParallelDescriptor::Message rmess = ParallelDescriptor::Recv(recreads, coordproc,
                                                                          readtag);
-            const int nrmess = rmess.count();
+            const auto nrmess = static_cast<int>(rmess.count());
             for (int ir = 0; ir < nrmess; ++ir) {
                 int i = recreads[ir];
                 detail::read_fab(fa[i], fod[i], name);

--- a/Src/Base/Parser/AMReX_IParser.H
+++ b/Src/Base/Parser/AMReX_IParser.H
@@ -17,7 +17,7 @@ template <int N>
 struct IParserExecutor
 {
     template <int M=N, typename std::enable_if_t<M==0,int> = 0>
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     int operator() () const noexcept
     {
 #if AMREX_DEVICE_COMPILE
@@ -28,7 +28,7 @@ struct IParserExecutor
     }
 
     template <typename... Ts>
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     std::enable_if_t<sizeof...(Ts) == N, int>
     operator() (Ts... var) const noexcept
     {
@@ -40,7 +40,7 @@ struct IParserExecutor
 #endif
     }
 
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     int operator() (GpuArray<int,N> const& var) const noexcept
     {
 #if AMREX_DEVICE_COMPILE
@@ -50,7 +50,7 @@ struct IParserExecutor
 #endif
     }
 
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     explicit operator bool () const {
 #if AMREX_DEVICE_COMPILE
         return m_device_executor != nullptr;
@@ -88,10 +88,10 @@ public:
     [[nodiscard]] std::set<std::string> symbols () const;
 
     //! This compiles for both GPU and CPU
-    template <int N> IParserExecutor<N> compile () const;
+    template <int N> [[nodiscard]] IParserExecutor<N> compile () const;
 
     //! This compiles for CPU only
-    template <int N> IParserExecutor<N> compileHost () const;
+    template <int N> [[nodiscard]] IParserExecutor<N> compileHost () const;
 
 private:
 
@@ -105,7 +105,12 @@ private:
 #endif
         mutable int m_max_stack_size = 0;
         mutable int m_exe_size = 0;
+        Data () = default;
         ~Data ();
+        Data (Data const&) = delete;
+        Data (Data &&) = delete;
+        Data& operator= (Data const&) = delete;
+        Data& operator= (Data &&) = delete;
     };
 
     std::shared_ptr<Data> m_data;

--- a/Src/Base/Parser/AMReX_Parser.H
+++ b/Src/Base/Parser/AMReX_Parser.H
@@ -18,7 +18,7 @@ template <int N>
 struct ParserExecutor
 {
     template <int M=N, typename std::enable_if_t<M==0,int> = 0>
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     double operator() () const noexcept
     {
 #if AMREX_DEVICE_COMPILE
@@ -29,7 +29,7 @@ struct ParserExecutor
     }
 
     template <typename... Ts>
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     std::enable_if_t<sizeof...(Ts) == N && !amrex::Same<float,Ts...>::value, double>
     operator() (Ts... var) const noexcept
     {
@@ -42,7 +42,7 @@ struct ParserExecutor
     }
 
     template <typename... Ts>
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     std::enable_if_t<sizeof...(Ts) == N &&  amrex::Same<float,Ts...>::value, float>
     operator() (Ts... var) const noexcept
     {
@@ -54,7 +54,7 @@ struct ParserExecutor
 #endif
     }
 
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     double operator() (GpuArray<double,N> const& var) const noexcept
     {
 #if AMREX_DEVICE_COMPILE
@@ -102,10 +102,10 @@ public:
     [[nodiscard]] std::set<std::string> symbols () const;
 
     //! This compiles for both GPU and CPU
-    template <int N> ParserExecutor<N> compile () const;
+    template <int N> [[nodiscard]] ParserExecutor<N> compile () const;
 
     //! This compiles for CPU only
-    template <int N> ParserExecutor<N> compileHost () const;
+    template <int N> [[nodiscard]] ParserExecutor<N> compileHost () const;
 
 private:
 
@@ -119,7 +119,12 @@ private:
 #endif
         mutable int m_max_stack_size = 0;
         mutable int m_exe_size = 0;
+        Data () = default;
         ~Data ();
+        Data (Data const&) = delete;
+        Data (Data &&) = delete;
+        Data& operator= (Data const&) = delete;
+        Data& operator= (Data &&) = delete;
     };
 
     std::shared_ptr<Data> m_data;

--- a/Src/Boundary/AMReX_BndryData.H
+++ b/Src/Boundary/AMReX_BndryData.H
@@ -46,7 +46,7 @@ public:
     using value_type = typename MF::value_type;
 
     //! Default constructor
-    BndryDataT() noexcept;
+    BndryDataT() = default;
 
     /**
     * \brief constructor specifying number of components and box of physical
@@ -157,18 +157,13 @@ private:
 };
 
 template <typename MF>
-BndryDataT<MF>::BndryDataT () noexcept
-     {}
-
-template <typename MF>
 BndryDataT<MF>::BndryDataT (const BoxArray& _grids,
                             const DistributionMapping& _dmap,
                             int             _ncomp,
                             const Geometry& _geom)
     :
     geom(_geom),
-    m_ncomp(_ncomp),
-    m_defined(false)
+    m_ncomp(_ncomp)
 {
     define(_grids,_dmap,_ncomp,_geom);
 }

--- a/Src/Boundary/AMReX_BndryRegister.H
+++ b/Src/Boundary/AMReX_BndryRegister.H
@@ -48,7 +48,8 @@ public:
     BndryRegisterT () = default;
 
     //! The constructor, given number of cells in/out, extent and number of components (assumes cell-centered boxes, and allocates cell-centered FABs)
-    BndryRegisterT (const BoxArray& grids_, const DistributionMapping& dmap,
+    BndryRegisterT (const BoxArray& grids_, // NOLINT(modernize-pass-by-value)
+                    const DistributionMapping& dmap,
                     int in_rad, int out_rad, int extent_rad, int ncomp);
 
     //! The destructor.

--- a/Src/Boundary/AMReX_Mask.H
+++ b/Src/Boundary/AMReX_Mask.H
@@ -29,7 +29,7 @@ class Mask final
 {
 public:
 
-    Mask () noexcept;
+    Mask () noexcept = default;
 
     explicit Mask (Arena* ar) noexcept;
 

--- a/Src/Boundary/AMReX_Mask.cpp
+++ b/Src/Boundary/AMReX_Mask.cpp
@@ -5,9 +5,6 @@
 
 namespace amrex {
 
-Mask::Mask () noexcept
-     {}
-
 Mask::Mask (Arena* ar) noexcept
     : BaseFab<int>(ar) {}
 

--- a/Src/Boundary/AMReX_YAFluxRegister.H
+++ b/Src/Boundary/AMReX_YAFluxRegister.H
@@ -48,11 +48,11 @@ public:
 
     void CrseAdd (const MFIter& mfi,
                   const std::array<FAB const*, AMREX_SPACEDIM>& flux,
-                  const Real* dx, Real dt, RunOn gpu_or_cpu) noexcept;
+                  const Real* dx, Real dt, RunOn runon) noexcept;
 
     void FineAdd (const MFIter& mfi,
                   const std::array<FAB const*, AMREX_SPACEDIM>& flux,
-                  const Real* dx, Real dt, RunOn gpu_or_cpu) noexcept;
+                  const Real* dx, Real dt, RunOn runon) noexcept;
 
     void Reflux (MF& state, int dc = 0);
 
@@ -155,7 +155,7 @@ YAFluxRegisterT<MF>::define (const BoxArray& fba, const BoxArray& cba,
     Vector<int> cfp_procmap;
     int nlocal = 0;
     const int myproc = ParallelDescriptor::MyProc();
-    const int n_cfba = cfba.size();
+    const auto n_cfba = static_cast<int>(cfba.size());
     cfba.uniqify();
 
 #ifdef AMREX_USE_OMP
@@ -218,7 +218,7 @@ YAFluxRegisterT<MF>::define (const BoxArray& fba, const BoxArray& cba,
         bx &= cdomain;
 
         cfba.complementIn(bl_tmp, bx);
-        const int ntmp = bl_tmp.size();
+        const auto ntmp = static_cast<int>(bl_tmp.size());
         cfp_bl.join(bl_tmp);
 
         int proc = fdm[i];

--- a/Src/Extern/amrdata/AMReX_AmrData.cpp
+++ b/Src/Extern/amrdata/AMReX_AmrData.cpp
@@ -267,12 +267,12 @@ bool AmrData::ReadData(const string &filename, Amrvis::FileType filetype) {
         if(bCartGrid) {  // check various permutations of vfrac name
           if(strcmp(plotVarName, "vol_frac") == 0) {
             cout << "+++++++++++++ found bad vfrac name:  " << plotVarName << endl;
-            strcpy(plotVarName, "vfrac");
+            std::strncpy(plotVarName, "vfrac", sizeof(plotVarName));
             cout << "+++++++++++++                  now:  " << plotVarName << endl;
           }
           if(strcmp(plotVarName, "volfrac") == 0) {
             cout << "+++++++++++++ found bad vfrac name:  " << plotVarName << endl;
-            strcpy(plotVarName, "vfrac");
+            std::strncpy(plotVarName, "vfrac", sizeof(plotVarName));
             cout << "+++++++++++++                  now:  " << plotVarName << endl;
           }
           if(strcmp(plotVarName, "vfrac") == 0) {

--- a/Src/Extern/amrdata/AMReX_DataServices.cpp
+++ b/Src/Extern/amrdata/AMReX_DataServices.cpp
@@ -455,7 +455,7 @@ void DataServices::Dispatch(DSRequestType requestType, DataServices *ds, ...) {
     fileNameLengthPadded += fileNameLengthPadded % 8;  // for alignment on the t3e
     fileNameCharPtr = new char[fileNameLengthPadded];
     if(ParallelDescriptor::IOProcessor()) {
-      strcpy(fileNameCharPtr, ds->fileName.c_str());
+      std::strncpy(fileNameCharPtr, ds->fileName.c_str(), fileNameLengthPadded);
     }
 
     ParallelDescriptor::Bcast(fileNameCharPtr, fileNameLengthPadded,0);
@@ -567,7 +567,7 @@ void DataServices::Dispatch(DSRequestType requestType, DataServices *ds, ...) {
       derivedLengthPadded += derivedLengthPadded % 8;
       derivedCharPtr = new char[derivedLengthPadded];
       if(ParallelDescriptor::IOProcessor()) {
-        strcpy(derivedCharPtr, derivedTemp.c_str());
+        std::strncpy(derivedCharPtr, derivedTemp.c_str(), derivedLengthPadded);
       }
 
       ParallelDescriptor::Bcast(derivedCharPtr, derivedLengthPadded, 0);
@@ -621,7 +621,7 @@ void DataServices::Dispatch(DSRequestType requestType, DataServices *ds, ...) {
       derivedLengthPadded += derivedLengthPadded % 8;
       derivedCharPtr = new char[derivedLengthPadded];
       if(ParallelDescriptor::IOProcessor()) {
-        strcpy(derivedCharPtr, derivedTemp.c_str());
+        std::strncpy(derivedCharPtr, derivedTemp.c_str(), derivedLengthPadded);
       }
 
       ParallelDescriptor::Bcast(derivedCharPtr, derivedLengthPadded, 0);
@@ -679,7 +679,7 @@ void DataServices::Dispatch(DSRequestType requestType, DataServices *ds, ...) {
       derivedLengthPadded += derivedLengthPadded % 8;
       derivedCharPtr = new char[derivedLengthPadded];
       if(ParallelDescriptor::IOProcessor()) {
-        strcpy(derivedCharPtr, derivedTemp.c_str());
+        std::strncpy(derivedCharPtr, derivedTemp.c_str(), derivedLengthPadded);
       }
       ParallelDescriptor::Bcast(derivedCharPtr, derivedLengthPadded, 0);
 
@@ -728,7 +728,7 @@ void DataServices::Dispatch(DSRequestType requestType, DataServices *ds, ...) {
       derivedLengthPadded += derivedLengthPadded % 8;
       derivedCharPtr = new char[derivedLengthPadded];
       if(ParallelDescriptor::IOProcessor()) {
-        strcpy(derivedCharPtr, derivedTemp.c_str());
+        std::strncpy(derivedCharPtr, derivedTemp.c_str(), derivedLengthPadded);
       }
       ParallelDescriptor::Bcast(derivedCharPtr, derivedLengthPadded, 0);
 
@@ -780,7 +780,7 @@ void DataServices::Dispatch(DSRequestType requestType, DataServices *ds, ...) {
       derivedLengthPadded += derivedLengthPadded % 8;
       derivedCharPtr = new char[derivedLengthPadded];
       if(ParallelDescriptor::IOProcessor()) {
-        strcpy(derivedCharPtr, derivedTemp.c_str());
+        std::strncpy(derivedCharPtr, derivedTemp.c_str(), derivedLengthPadded);
       }
       ParallelDescriptor::Bcast(derivedCharPtr, derivedLengthPadded, 0);
 
@@ -844,7 +844,7 @@ void DataServices::Dispatch(DSRequestType requestType, DataServices *ds, ...) {
       derivedLengthPadded += derivedLengthPadded % 8;
       derivedCharPtr = new char[derivedLengthPadded];
       if(ParallelDescriptor::IOProcessor()) {
-        strcpy(derivedCharPtr, derivedTemp.c_str());
+        std::strncpy(derivedCharPtr, derivedTemp.c_str(), derivedLengthPadded);
         for(int iBox = 0; iBox < pointBoxArraySize; ++iBox) {
           pointBoxArrayPtr[iBox] = pointBoxArrayTempPtr[iBox];
         }
@@ -932,7 +932,7 @@ void DataServices::Dispatch(DSRequestType requestType, DataServices *ds, ...) {
       derivedLengthPadded += derivedLengthPadded % 8;
       derivedCharPtr = new char[derivedLengthPadded];
       if(ParallelDescriptor::IOProcessor()) {
-        strcpy(derivedCharPtr, derivedTemp.c_str());
+        std::strncpy(derivedCharPtr, derivedTemp.c_str(), derivedLengthPadded);
         for(int iBox(0); iBox < lineBoxArraySize; ++iBox) {
           lineBoxArrayPtr[iBox] = lineBoxArrayTempPtr[iBox];
         }

--- a/Src/F_Interfaces/Base/AMReX_init_fi.cpp
+++ b/Src/F_Interfaces/Base/AMReX_init_fi.cpp
@@ -24,7 +24,7 @@ extern "C"
         for (int i = 0; i < argc; ++i)
         {
             argv[i] = (char*)malloc(argv_string[i].size()+1);
-            strcpy(argv[i], argv_string[i].c_str());
+            std::strncpy(argv[i], argv_string[i].c_str(), argv_string[i].size()+1);
         }
 
 #ifdef BL_USE_MPI

--- a/Src/LinearSolvers/MLMG/AMReX_MLCellABecLap.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLCellABecLap.H
@@ -19,7 +19,7 @@ public:
     using Location  = typename MLLinOpT<MF>::Location;
 
     MLCellABecLapT ();
-    virtual ~MLCellABecLapT ();
+    ~MLCellABecLapT () override;
 
     MLCellABecLapT (const MLCellABecLapT<MF>&) = delete;
     MLCellABecLapT (MLCellABecLapT<MF>&&) = delete;
@@ -39,22 +39,22 @@ public:
                  const LPInfo& a_info = LPInfo(),
                  const Vector<FabFactory<FAB> const*>& a_factory = {});
 
-    iMultiFab const* getOversetMask (int amrlev, int mglev) const {
+    [[nodiscard]] iMultiFab const* getOversetMask (int amrlev, int mglev) const {
         return m_overset_mask[amrlev][mglev].get();
     }
 
-    virtual bool needsUpdate () const override {
+    [[nodiscard]] bool needsUpdate () const override {
         return MLCellLinOpT<MF>::needsUpdate();
     }
-    virtual void update () override;
+    void update () override;
 
-    virtual void prepareForSolve () override;
+    void prepareForSolve () override;
 
-    virtual void getFluxes (const Vector<Array<MF*,AMREX_SPACEDIM> >& a_flux,
+    void getFluxes (const Vector<Array<MF*,AMREX_SPACEDIM> >& a_flux,
                             const Vector<MF*>& a_sol,
-                            Location a_loc) const final override;
-    virtual void getFluxes (const Vector<MF*>& /*a_flux*/,
-                            const Vector<MF*>& /*a_sol*/) const final override {
+                            Location a_loc) const final;
+    void getFluxes (const Vector<MF*>& /*a_flux*/,
+                            const Vector<MF*>& /*a_sol*/) const final {
         amrex::Abort("MLCellABecLap::getFluxes: How did we get here?");
     }
 
@@ -63,13 +63,13 @@ public:
     virtual MF const* getACoeffs (int amrlev, int mglev) const = 0;
     virtual Array<MF const*,AMREX_SPACEDIM> getBCoeffs (int amrlev, int mglev) const = 0;
 
-    virtual void applyInhomogNeumannTerm (int amrlev, MF& rhs) const final override;
+    void applyInhomogNeumannTerm (int amrlev, MF& rhs) const final;
 
-    virtual void addInhomogNeumannFlux (
+    void addInhomogNeumannFlux (
         int amrlev, const Array<MF*,AMREX_SPACEDIM>& grad,
-        MF const& sol, bool mult_bcoef) const final override;
+        MF const& sol, bool mult_bcoef) const final;
 
-    virtual void applyOverset (int amlev, MF& rhs) const override;
+    void applyOverset (int amrlev, MF& rhs) const override;
 
 #if defined(AMREX_USE_HYPRE) && (AMREX_SPACEDIM > 1)
     virtual std::unique_ptr<Hypre> makeHypre (Hypre::Interface hypre_interface) const override;
@@ -84,11 +84,11 @@ protected:
 
     LPInfo m_lpinfo_arg;
 
-    virtual bool supportInhomogNeumannBC () const noexcept override { return true; }
+    [[nodiscard]] bool supportInhomogNeumannBC () const noexcept override { return true; }
 };
 
-template <typename MF> MLCellABecLapT<MF>::MLCellABecLapT () {}
-template <typename MF> MLCellABecLapT<MF>::~MLCellABecLapT () {}
+template <typename MF> MLCellABecLapT<MF>::MLCellABecLapT () = default;
+template <typename MF> MLCellABecLapT<MF>::~MLCellABecLapT () = default;
 
 template <typename MF>
 void
@@ -121,7 +121,7 @@ MLCellABecLapT<MF>::define (const Vector<Geometry>& a_geom,
 
     this->m_lpinfo_arg = a_info;
 
-    int namrlevs = a_geom.size();
+    auto namrlevs = static_cast<int>(a_geom.size());
     this->m_overset_mask.resize(namrlevs);
     for (int amrlev = 0; amrlev < namrlevs; ++amrlev)
     {

--- a/Src/LinearSolvers/MLMG/AMReX_MLCellLinOp.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLCellLinOp.H
@@ -30,7 +30,7 @@ public:
     using Location  = typename MLLinOpT<MF>::Location;
 
     MLCellLinOpT ();
-    virtual ~MLCellLinOpT ();
+    ~MLCellLinOpT () override;
 
     MLCellLinOpT (const MLCellLinOpT<MF>&) = delete;
     MLCellLinOpT (MLCellLinOpT<MF>&&) = delete;
@@ -43,17 +43,17 @@ public:
                  const LPInfo& a_info = LPInfo(),
                  const Vector<FabFactory<FAB> const*>& a_factory = {});
 
-    virtual void setLevelBC (int amrlev, const MF* levelbcdata,
+    void setLevelBC (int amrlev, const MF* levelbcdata,
                              const MF* robinbc_a = nullptr,
                              const MF* robinbc_b = nullptr,
-                             const MF* robinbc_f = nullptr) final override;
+                             const MF* robinbc_f = nullptr) final;
 
     using MLLinOpT<MF>::setLevelBC;
 
-    virtual bool needsUpdate () const override {
+    bool needsUpdate () const override {
         return MLLinOpT<MF>::needsUpdate();
     }
-    virtual void update () override;
+    void update () override;
 
     virtual bool isCrossStencil () const { return true; }
     virtual bool isTensorOp () const { return false; }
@@ -66,65 +66,65 @@ public:
 
     BoxArray makeNGrids (int grid_size) const;
 
-    virtual void restriction (int, int, MF& crse, MF& fine) const override;
+    void restriction (int, int, MF& crse, MF& fine) const override;
 
-    virtual void interpolation (int amrlev, int fmglev, MF& fine, const MF& crse) const override;
+    void interpolation (int amrlev, int fmglev, MF& fine, const MF& crse) const override;
 
-    virtual void interpAssign (int amrlev, int fmglev, MF& fine, MF& crse) const override;
+    void interpAssign (int amrlev, int fmglev, MF& fine, MF& crse) const override;
 
-    virtual void interpolationAmr (int famrlev, MF& fine, const MF& crse,
+    void interpolationAmr (int famrlev, MF& fine, const MF& crse,
                                    IntVect const& nghost) const override;
 
-    virtual void averageDownSolutionRHS (int camrlev, MF& crse_sol, MF& crse_rhs,
+    void averageDownSolutionRHS (int camrlev, MF& crse_sol, MF& crse_rhs,
                                          const MF& fine_sol, const MF& fine_rhs) override;
 
-    virtual void apply (int amrlev, int mglev, MF& out, MF& in, BCMode bc_mode,
+    void apply (int amrlev, int mglev, MF& out, MF& in, BCMode bc_mode,
                         StateMode s_mode, const MLMGBndryT<MF>* bndry=nullptr) const override;
-    virtual void smooth (int amrlev, int mglev, MF& sol, const MF& rhs,
-                         bool skip_fillboundary=false) const final override;
+    void smooth (int amrlev, int mglev, MF& sol, const MF& rhs,
+                         bool skip_fillboundary=false) const final;
 
-    virtual void solutionResidual (int amrlev, MF& resid, MF& x, const MF& b,
+    void solutionResidual (int amrlev, MF& resid, MF& x, const MF& b,
                                    const MF* crse_bcdata=nullptr) override;
 
-    virtual void correctionResidual (int amrlev, int mglev, MF& resid, MF& x, const MF& b,
-                                     BCMode bc_mode, const MF* crse_bcdata=nullptr) final override;
+    void correctionResidual (int amrlev, int mglev, MF& resid, MF& x, const MF& b,
+                                     BCMode bc_mode, const MF* crse_bcdata=nullptr) final;
 
     // The assumption is crse_sol's boundary has been filled, but not fine_sol.
-    virtual void reflux (int crse_amrlev,
+    void reflux (int crse_amrlev,
                          MF& res, const MF& crse_sol, const MF&,
-                         MF&, MF& fine_sol, const MF&) const final override;
-    virtual void compFlux (int amrlev, const Array<MF*,AMREX_SPACEDIM>& fluxes,
+                         MF&, MF& fine_sol, const MF&) const final;
+    void compFlux (int amrlev, const Array<MF*,AMREX_SPACEDIM>& fluxes,
                            MF& sol, Location loc) const override;
-    virtual void compGrad (int amrlev, const Array<MF*,AMREX_SPACEDIM>& grad,
+    void compGrad (int amrlev, const Array<MF*,AMREX_SPACEDIM>& grad,
                            MF& sol, Location loc) const override;
 
-    virtual void applyMetricTerm (int amrlev, int mglev, MF& rhs) const final override;
-    virtual void unapplyMetricTerm (int amrlev, int mglev, MF& rhs) const final override;
-    virtual Vector<RT> getSolvabilityOffset (int amrlev, int mglev,
+    void applyMetricTerm (int amrlev, int mglev, MF& rhs) const final;
+    void unapplyMetricTerm (int amrlev, int mglev, MF& rhs) const final;
+    Vector<RT> getSolvabilityOffset (int amrlev, int mglev,
                                              MF const& rhs) const override;
-    virtual void fixSolvabilityByOffset (int amrlev, int mglev, MF& rhs,
+    void fixSolvabilityByOffset (int amrlev, int mglev, MF& rhs,
                                          Vector<RT> const& offset) const override;
 
-    virtual void prepareForSolve () override;
+    void prepareForSolve () override;
 
-    virtual RT xdoty (int amrlev, int mglev, const MF& x, const MF& y, bool local) const final override;
+    RT xdoty (int amrlev, int mglev, const MF& x, const MF& y, bool local) const final;
 
     virtual void Fapply (int amrlev, int mglev, MF& out, const MF& in) const = 0;
     virtual void Fsmooth (int amrlev, int mglev, MF& sol, const MF& rsh, int redblack) const = 0;
     virtual void FFlux (int amrlev, const MFIter& mfi,
                         const Array<FAB*,AMREX_SPACEDIM>& flux,
-                        const FAB& sol, Location loc, const int face_only=0) const = 0;
+                        const FAB& sol, Location loc, int face_only=0) const = 0;
 
     virtual void addInhomogNeumannFlux (int /*amrlev*/,
                                         const Array<MF*,AMREX_SPACEDIM>& /*grad*/,
                                         MF const& /*sol*/,
                                         bool /*mult_bcoef*/) const {}
 
-    virtual RT normInf (int amrlev, MF const& mf, bool local) const override;
+    RT normInf (int amrlev, MF const& mf, bool local) const override;
 
-    virtual void averageDownAndSync (Vector<MF>& mf) const override;
+    void averageDownAndSync (Vector<MF>& sol) const override;
 
-    virtual void avgDownResAmr (int clev, MF& cres, MF const& fres) const override;
+    void avgDownResAmr (int clev, MF& cres, MF const& fres) const override;
 
     struct BCTL {
         BoundCond type;
@@ -219,7 +219,7 @@ struct MLMGABCTag {
     int comp;
     int dir;
 
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     Box const& box() const noexcept { return bx; }
 };
 
@@ -238,7 +238,7 @@ struct MLMGPSTag {
     int comp;
     int dir;
 
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     Box const& box() const noexcept { return bx; }
 };
 
@@ -259,7 +259,7 @@ struct MLMGPSEBTag {
     int comp;
     int dir;
 
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     Box const& box() const noexcept { return bx; }
 };
 #endif
@@ -274,7 +274,7 @@ MLCellLinOpT<MF>::BndryCondLoc::BndryCondLoc (const BoxArray& ba,
       bctl_dv(bctl.local_size()*ncomp),
       m_ncomp(ncomp)
 {
-    auto dp = bctl_dv.data();
+    auto* dp = bctl_dv.data();
     for (MFIter mfi(bcloc); mfi.isValid(); ++mfi) {
         bcond[mfi].resize(ncomp);
         bcloc[mfi].resize(ncomp);
@@ -335,7 +335,7 @@ MLCellLinOpT<MF>::MLCellLinOpT ()
     this->m_ixtype = IntVect::TheCellVector();
 }
 
-template <typename MF> MLCellLinOpT<MF>::~MLCellLinOpT () {}
+template <typename MF> MLCellLinOpT<MF>::~MLCellLinOpT () = default;
 
 template <typename MF>
 void

--- a/Src/LinearSolvers/MLMG/AMReX_MLEBNodeFDLaplacian.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBNodeFDLaplacian.cpp
@@ -36,7 +36,7 @@ MLEBNodeFDLaplacian::setSigma (Array<Real,AMREX_SPACEDIM> const& a_sigma) noexce
 }
 
 void
-MLEBNodeFDLaplacian::setRZ (bool flag)
+MLEBNodeFDLaplacian::setRZ (bool flag) // NOLINT
 {
 #if (AMREX_SPACEDIM == 2)
     m_rz = flag;
@@ -46,7 +46,7 @@ MLEBNodeFDLaplacian::setRZ (bool flag)
 }
 
 void
-MLEBNodeFDLaplacian::setAlpha (Real a_alpha)
+MLEBNodeFDLaplacian::setAlpha (Real a_alpha) // NOLINT
 {
 #if (AMREX_SPACEDIM == 2)
     m_rz_alpha = a_alpha;

--- a/Src/LinearSolvers/MLMG/AMReX_MLLinOp.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLLinOp.H
@@ -57,7 +57,7 @@ struct LPInfo
     LPInfo& setSemicoarseningDirection (int n) noexcept { semicoarsening_direction = n; return *this; }
     LPInfo& setHiddenDirection (int n) noexcept { hidden_direction = n; return *this; }
 
-    bool hasHiddenDimension () const noexcept {
+    [[nodiscard]] bool hasHiddenDimension () const noexcept {
         return hidden_direction >=0 && hidden_direction < AMREX_SPACEDIM;
     }
 
@@ -108,8 +108,8 @@ public:
     using StateMode = LinOpEnumType::StateMode;
     using Location  = LinOpEnumType::Location;
 
-    MLLinOpT () {}
-    virtual ~MLLinOpT () {}
+    MLLinOpT () = default;
+    virtual ~MLLinOpT () = default;
 
     MLLinOpT (const MLLinOpT<MF>&) = delete;
     MLLinOpT (MLLinOpT<MF>&&) = delete;
@@ -123,7 +123,7 @@ public:
                  const Vector<FabFactory<FAB> const*>& a_factory,
                  bool eb_limit_coarsening = true);
 
-    virtual std::string name () const { return std::string("Unspecified"); }
+    [[nodiscard]] virtual std::string name () const { return std::string("Unspecified"); }
 
     /**
      * \brief Boundary of the whole domain.
@@ -169,7 +169,7 @@ public:
     * level data are needed for supplying Dirichlet bc at coarse/fine
     * boundary, even when the domain bc is not Dirichlet.
     */
-    bool needsCoarseDataForBC () const noexcept { return m_needs_coarse_data_for_bc; }
+    [[nodiscard]] bool needsCoarseDataForBC () const noexcept { return m_needs_coarse_data_for_bc; }
 
     /**
     * \brief Set coarse/fine boundary conditions. For cell-centered solves
@@ -229,24 +229,24 @@ public:
     //! Set order of interpolation at coarse/fine boundary
     void setMaxOrder (int o) noexcept { maxorder = o; }
     //! Get order of interpolation at coarse/fine boundary
-    int getMaxOrder () const noexcept { return maxorder; }
+    [[nodiscard]] int getMaxOrder () const noexcept { return maxorder; }
 
     //! Set the flag for whether the solver should try to make singular
     //! problem solvable, which is on by default.
     void setEnforceSingularSolvable (bool o) noexcept { enforceSingularSolvable = o; }
     //! Get the flag for whether the solver should try to make singular
     //! problem solvable.
-    bool getEnforceSingularSolvable () const noexcept { return enforceSingularSolvable; }
+    [[nodiscard]] bool getEnforceSingularSolvable () const noexcept { return enforceSingularSolvable; }
 
-    virtual BottomSolver getDefaultBottomSolver () const { return BottomSolver::bicgstab; }
+    [[nodiscard]] virtual BottomSolver getDefaultBottomSolver () const { return BottomSolver::bicgstab; }
 
     //! Return number of components
-    virtual int getNComp () const { return 1; }
+    [[nodiscard]] virtual int getNComp () const { return 1; }
 
-    virtual int getNGrow (int /*a_lev*/ = 0, int /*mg_lev*/ = 0) const { return 0; }
+    [[nodiscard]] virtual int getNGrow (int /*a_lev*/ = 0, int /*mg_lev*/ = 0) const { return 0; }
 
     //! Does it need update if it's reused?
-    virtual bool needsUpdate () const { return false; }
+    [[nodiscard]] virtual bool needsUpdate () const { return false; }
     //! Update for reuse.
     virtual void update () {}
 
@@ -426,9 +426,9 @@ public:
     virtual void prepareForSolve () = 0;
 
     //! Is it singular on given AMR level?
-    virtual bool isSingular (int amrlev) const = 0;
+    [[nodiscard]] virtual bool isSingular (int amrlev) const = 0;
     //! Is the bottom of MG singular?
-    virtual bool isBottomSingular () const = 0;
+    [[nodiscard]] virtual bool isBottomSingular () const = 0;
 
     //! x dot y, used by the bottom solver
     virtual RT xdoty (int amrlev, int mglev, const MF& x, const MF& y, bool local) const = 0;
@@ -473,7 +473,7 @@ public:
     }
 #endif
 
-    virtual bool supportNSolve () const { return false; }
+    [[nodiscard]] virtual bool supportNSolve () const { return false; }
 
     virtual void copyNSolveSolution (MF&, MF const&) const {}
 
@@ -486,7 +486,7 @@ public:
     virtual void avgDownResAmr (int clev, MF& cres, MF const& fres) const = 0;
     virtual void avgDownResMG (int clev, MF& cres, MF const& fres) const;
 
-    bool isMFIterSafe (int amrlev, int mglev1, int mglev2) const;
+    [[nodiscard]] bool isMFIterSafe (int amrlev, int mglev1, int mglev2) const;
 
 protected:
 
@@ -562,79 +562,79 @@ protected:
     MF m_coarse_data_for_bc_raii;
 
     //! Return the number of AMR levels
-    int NAMRLevels () const noexcept { return m_num_amr_levels; }
+    [[nodiscard]] int NAMRLevels () const noexcept { return m_num_amr_levels; }
 
     //! Return the number of MG levels at given AMR level
-    int NMGLevels (int amrlev) const noexcept { return m_num_mg_levels[amrlev]; }
+    [[nodiscard]] int NMGLevels (int amrlev) const noexcept { return m_num_mg_levels[amrlev]; }
 
     //! Return AMR refinement ratios
-    const Vector<int>& AMRRefRatio () const noexcept { return m_amr_ref_ratio; }
+    [[nodiscard]] const Vector<int>& AMRRefRatio () const noexcept { return m_amr_ref_ratio; }
 
     //! Return AMR refinement ratio at given AMR level
-    int AMRRefRatio (int amr_lev) const noexcept { return m_amr_ref_ratio[amr_lev]; }
+    [[nodiscard]] int AMRRefRatio (int amr_lev) const noexcept { return m_amr_ref_ratio[amr_lev]; }
 
-    const Geometry& Geom (int amr_lev, int mglev=0) const noexcept { return m_geom[amr_lev][mglev]; }
+    [[nodiscard]] const Geometry& Geom (int amr_lev, int mglev=0) const noexcept { return m_geom[amr_lev][mglev]; }
 
-    FabFactory<FAB> const* Factory (int amr_lev, int mglev=0) const noexcept {
+    [[nodiscard]] FabFactory<FAB> const* Factory (int amr_lev, int mglev=0) const noexcept {
         return m_factory[amr_lev][mglev].get();
     }
 
-    GpuArray<BCType,AMREX_SPACEDIM> LoBC (int icomp = 0) const noexcept {
+    [[nodiscard]] GpuArray<BCType,AMREX_SPACEDIM> LoBC (int icomp = 0) const noexcept {
         return GpuArray<BCType,AMREX_SPACEDIM>{{AMREX_D_DECL(m_lobc[icomp][0],
                                                              m_lobc[icomp][1],
                                                              m_lobc[icomp][2])}};
     }
-    GpuArray<BCType,AMREX_SPACEDIM> HiBC (int icomp = 0) const noexcept {
+    [[nodiscard]] GpuArray<BCType,AMREX_SPACEDIM> HiBC (int icomp = 0) const noexcept {
         return GpuArray<BCType,AMREX_SPACEDIM>{{AMREX_D_DECL(m_hibc[icomp][0],
                                                              m_hibc[icomp][1],
                                                              m_hibc[icomp][2])}};
     }
 
-    bool hasBC (BCType bct) const noexcept;
-    bool hasInhomogNeumannBC () const noexcept;
-    bool hasRobinBC () const noexcept;
+    [[nodiscard]] bool hasBC (BCType bct) const noexcept;
+    [[nodiscard]] bool hasInhomogNeumannBC () const noexcept;
+    [[nodiscard]] bool hasRobinBC () const noexcept;
 
-    virtual bool supportRobinBC () const noexcept { return false; }
-    virtual bool supportInhomogNeumannBC () const noexcept { return false; }
+    [[nodiscard]] virtual bool supportRobinBC () const noexcept { return false; }
+    [[nodiscard]] virtual bool supportInhomogNeumannBC () const noexcept { return false; }
 
 #ifdef BL_USE_MPI
-    bool isBottomActive () const noexcept { return m_bottom_comm != MPI_COMM_NULL; }
+    [[nodiscard]] bool isBottomActive () const noexcept { return m_bottom_comm != MPI_COMM_NULL; }
 #else
-    bool isBottomActive () const noexcept { return true; }
+    [[nodiscard]] bool isBottomActive () const noexcept { return true; }
 #endif
-    MPI_Comm BottomCommunicator () const noexcept { return m_bottom_comm; }
-    MPI_Comm Communicator () const noexcept { return m_default_comm; }
+    [[nodiscard]] MPI_Comm BottomCommunicator () const noexcept { return m_bottom_comm; }
+    [[nodiscard]] MPI_Comm Communicator () const noexcept { return m_default_comm; }
 
     void setCoarseFineBCLocation (const RealVect& cloc) noexcept { m_coarse_bc_loc = cloc; }
 
-    bool doAgglomeration () const noexcept { return m_do_agglomeration; }
-    bool doConsolidation () const noexcept { return m_do_consolidation; }
-    bool doSemicoarsening () const noexcept { return m_do_semicoarsening; }
+    [[nodiscard]] bool doAgglomeration () const noexcept { return m_do_agglomeration; }
+    [[nodiscard]] bool doConsolidation () const noexcept { return m_do_consolidation; }
+    [[nodiscard]] bool doSemicoarsening () const noexcept { return m_do_semicoarsening; }
 
-    bool isCellCentered () const noexcept { return m_ixtype == 0; }
+    [[nodiscard]] bool isCellCentered () const noexcept { return m_ixtype == 0; }
 
     virtual void make (Vector<Vector<MF> >& mf, IntVect const& ng) const;
 
-    virtual MF make (int amrlev, int mglev, IntVect const& ng) const;
+    [[nodiscard]] virtual MF make (int amrlev, int mglev, IntVect const& ng) const;
 
-    virtual MF makeAlias (MF const& mf) const;
+    [[nodiscard]] virtual MF makeAlias (MF const& mf) const;
 
-    virtual MF makeCoarseMG (int amrlev, int mglev, IntVect const& ng) const;
+    [[nodiscard]] virtual MF makeCoarseMG (int amrlev, int mglev, IntVect const& ng) const;
 
-    virtual MF makeCoarseAmr (int famrlev, IntVect const& ng) const;
+    [[nodiscard]] virtual MF makeCoarseAmr (int famrlev, IntVect const& ng) const;
 
-    virtual std::unique_ptr<FabFactory<FAB> > makeFactory (int /*amrlev*/, int /*mglev*/) const {
+    [[nodiscard]] virtual std::unique_ptr<FabFactory<FAB> > makeFactory (int /*amrlev*/, int /*mglev*/) const {
         return std::make_unique<DefaultFabFactory<FAB>>();
     }
 
     virtual void resizeMultiGrid (int new_size);
 
-    bool hasHiddenDimension () const noexcept { return info.hasHiddenDimension(); }
-    int hiddenDirection () const noexcept { return info.hidden_direction; }
-    Box compactify (Box const& b) const noexcept;
+    [[nodiscard]] bool hasHiddenDimension () const noexcept { return info.hasHiddenDimension(); }
+    [[nodiscard]] int hiddenDirection () const noexcept { return info.hidden_direction; }
+    [[nodiscard]] Box compactify (Box const& b) const noexcept;
 
     template <typename T>
-    Array4<T> compactify (Array4<T> const& a) const noexcept
+    [[nodiscard]] Array4<T> compactify (Array4<T> const& a) const noexcept
     {
         if (info.hidden_direction == 0) {
             return Array4<T>(a.dataPtr(), {a.begin.y,a.begin.z,0}, {a.end.y,a.end.z,1}, a.nComp());
@@ -648,7 +648,7 @@ protected:
     }
 
     template <typename T>
-    T get_d0 (T const& dx, T const& dy, T const&) const noexcept
+    [[nodiscard]] T get_d0 (T const& dx, T const& dy, T const&) const noexcept
     {
         if (info.hidden_direction == 0) {
             return dy;
@@ -658,7 +658,7 @@ protected:
     }
 
     template <typename T>
-    T get_d1 (T const&, T const& dy, T const& dz) const noexcept
+    [[nodiscard]] T get_d1 (T const&, T const& dy, T const& dz) const noexcept
     {
         if (info.hidden_direction == 0 || info.hidden_direction == 1) {
             return dz;
@@ -677,7 +677,7 @@ private:
     static void makeAgglomeratedDMap (const Vector<BoxArray>& ba, Vector<DistributionMapping>& dm);
     static void makeConsolidatedDMap (const Vector<BoxArray>& ba, Vector<DistributionMapping>& dm,
                                       int ratio, int strategy);
-    MPI_Comm makeSubCommunicator (const DistributionMapping& dm);
+    [[nodiscard]] MPI_Comm makeSubCommunicator (const DistributionMapping& dm);
 
     virtual void checkPoint (std::string const& /*file_name*/) const {
         amrex::Abort("MLLinOp:checkPoint: not implemented");
@@ -736,7 +736,7 @@ MLLinOpT<MF>::defineGrids (const Vector<Geometry>& a_geom,
 {
     BL_PROFILE("MLLinOp::defineGrids()");
 
-    m_num_amr_levels = a_geom.size();
+    m_num_amr_levels = static_cast<int>(a_geom.size());
 
     m_amr_ref_ratio.resize(m_num_amr_levels);
     m_num_mg_levels.resize(m_num_amr_levels);
@@ -810,7 +810,7 @@ MLLinOpT<MF>::defineGrids (const Vector<Geometry>& a_geom,
     m_geom[0].push_back(a_geom[0]);
     m_grids[0].push_back(a_grids[0]);
     m_dmap[0].push_back(a_dmap[0]);
-    if (a_factory.size() > 0) {
+    if (!a_factory.empty()) {
         m_factory[0].emplace_back(a_factory[0]->clone());
     } else {
         m_factory[0].push_back(std::make_unique<DefaultFabFactory<FAB>>());
@@ -912,7 +912,7 @@ MLLinOpT<MF>::defineGrids (const Vector<Geometry>& a_geom,
             agg_flag.push_back(to_agg);
         }
 
-        for (int lev = 1, nlevs = domainboxes.size(); lev < nlevs; ++lev) {
+        for (int lev = 1, nlevs = static_cast<int>(domainboxes.size()); lev < nlevs; ++lev) {
             if (!agged && !agg_flag[lev] &&
                 a_grids[0].coarsenable(accum_coarsen_ratio[lev], mg_box_min_width_v))
             {
@@ -1003,7 +1003,7 @@ MLLinOpT<MF>::defineGrids (const Vector<Geometry>& a_geom,
             if (info.do_consolidation)
             {
                 if (avg_npts/(AMREX_D_TERM(rr_vec[0], *rr_vec[1], *rr_vec[2]))
-                    < Real(0.999)*consolidation_threshold)
+                    < Real(0.999)*static_cast<Real>(consolidation_threshold))
                 {
                     coned = true;
                     con_lev = m_dmap[0].size();
@@ -1030,7 +1030,7 @@ MLLinOpT<MF>::defineGrids (const Vector<Geometry>& a_geom,
     }
 
     for (int amrlev = 0; amrlev < m_num_amr_levels; ++amrlev) {
-        if (AMRRefRatio(amrlev) == 4 && mg_coarsen_ratio_vec.size() == 0) {
+        if (AMRRefRatio(amrlev) == 4 && mg_coarsen_ratio_vec.empty()) {
             mg_coarsen_ratio_vec.push_back(IntVect(2));
         }
     }
@@ -1217,7 +1217,7 @@ MLLinOpT<MF>::makeAgglomeratedDMap (const Vector<BoxArray>& ba,
     BL_PROFILE("MLLinOp::makeAgglomeratedDMap");
 
     BL_ASSERT(!dm[0].empty());
-    for (int i = 1, N=ba.size(); i < N; ++i)
+    for (int i = 1, N=static_cast<int>(ba.size()); i < N; ++i)
     {
         if (dm[i].empty())
         {
@@ -1248,7 +1248,7 @@ MLLinOpT<MF>::makeConsolidatedDMap (const Vector<BoxArray>& ba,
 
     int factor = 1;
     BL_ASSERT(!dm[0].empty());
-    for (int i = 1, N=ba.size(); i < N; ++i)
+    for (int i = 1, N=static_cast<int>(ba.size()); i < N; ++i)
     {
         if (dm[i].empty())
         {
@@ -1257,7 +1257,7 @@ MLLinOpT<MF>::makeConsolidatedDMap (const Vector<BoxArray>& ba,
             const int nprocs = ParallelContext::NProcsSub();
             const auto& pmap_fine = dm[i-1].ProcessorMap();
             Vector<int> pmap(pmap_fine.size());
-            ParallelContext::global_to_local_rank(pmap.data(), pmap_fine.data(), pmap.size());
+            ParallelContext::global_to_local_rank(pmap.data(), pmap_fine.data(), static_cast<int>(pmap.size()));
             if (strategy == 1) {
                 for (auto& x: pmap) {
                     x /= ratio;
@@ -1287,7 +1287,7 @@ MLLinOpT<MF>::makeConsolidatedDMap (const Vector<BoxArray>& ba,
                 dm[i].define(std::move(pmap));
             } else {
                 Vector<int> pmap_g(pmap.size());
-                ParallelContext::local_to_global_rank(pmap_g.data(), pmap.data(), pmap.size());
+                ParallelContext::local_to_global_rank(pmap_g.data(), pmap.data(), static_cast<int>(pmap.size()));
                 dm[i].define(std::move(pmap_g));
             }
         }
@@ -1311,12 +1311,12 @@ MLLinOpT<MF>::makeSubCommunicator (const DistributionMapping& dm)
     MPI_Group defgrp, newgrp;
     MPI_Comm_group(m_default_comm, &defgrp);
     if (ParallelContext::CommunicatorSub() == ParallelDescriptor::Communicator()) {
-        MPI_Group_incl(defgrp, newgrp_ranks.size(), newgrp_ranks.data(), &newgrp);
+        MPI_Group_incl(defgrp, static_cast<int>(newgrp_ranks.size()), newgrp_ranks.data(), &newgrp);
     } else {
         Vector<int> local_newgrp_ranks(newgrp_ranks.size());
         ParallelContext::global_to_local_rank(local_newgrp_ranks.data(),
-                                              newgrp_ranks.data(), newgrp_ranks.size());
-        MPI_Group_incl(defgrp, local_newgrp_ranks.size(), local_newgrp_ranks.data(), &newgrp);
+                                              newgrp_ranks.data(), static_cast<int>(newgrp_ranks.size()));
+        MPI_Group_incl(defgrp, static_cast<int>(local_newgrp_ranks.size()), local_newgrp_ranks.data(), &newgrp);
     }
 
     MPI_Comm_create(m_default_comm, newgrp, &newcomm);

--- a/Src/LinearSolvers/MLMG/AMReX_MLLinOp_F.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLLinOp_F.H
@@ -11,10 +11,10 @@ extern "C" {
     void amrex_mllinop_apply_bc (const int* lo, const int* hi,
                                  amrex_real* phi, const int* philo, const int* phihi,
                                  const int* mask, const int* mlo, const int* mhi,
-                                 const int cdir, const int bct, const amrex_real bcl,
+                                 int cdir, int bct, amrex_real bcl,
                                  const amrex_real* bcval, const int* blo, const int* bhi,
-                                 const int maxorder, const amrex_real* dxinv,
-                                 const int inhomog, const int nc, const int cross);
+                                 int maxorder, const amrex_real* dxinv,
+                                 int inhomog, int nc, int cross);
 
 #ifdef __cplusplus
 }

--- a/Src/LinearSolvers/MLMG/AMReX_MLMG.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLMG.H
@@ -26,6 +26,11 @@ public:
     MLMGT (MLLinOpT<MF>& a_lp);
     ~MLMGT ();
 
+    MLMGT (MLMGT<MF> const&) = delete;
+    MLMGT (MLMGT<MF> &&) = delete;
+    MLMGT<MF>& operator= (MLMGT<MF> const&) = delete;
+    MLMGT<MF>& operator= (MLMGT<MF> &&) = delete;
+
     // Optional argument checkpoint_file is for debugging only.
     template <typename AMF>
     RT solve (const Vector<AMF*>& a_sol, const Vector<AMF const*>& a_rhs,
@@ -121,7 +126,7 @@ public:
 
     void setFinalFillBC (int flag) noexcept { final_fill_bc = flag; }
 
-    int numAMRLevels () const noexcept { return namrlevs; }
+    [[nodiscard]] int numAMRLevels () const noexcept { return namrlevs; }
 
     void setNSolve (int flag) noexcept { do_nsolve = flag; }
     void setNSolveGridSize (int s) noexcept { nsolve_grid_size = s; }
@@ -139,7 +144,7 @@ public:
     //! Set the namespace in input file for parsing HYPRE specific options
     void setHypreOptionsNamespace(const std::string& prefix) noexcept
     {
-     hypre_options_namespace = prefix;
+        hypre_options_namespace = prefix;
     }
 
     void setHypreOldDefault (bool l) noexcept {hypre_old_default = l;}
@@ -156,7 +161,7 @@ public:
 
     void oneIter (int iter);
 
-    void miniCycle (int alev);
+    void miniCycle (int amrlev);
 
     void mgVcycle (int amrlev, int mglev);
     void mgFcycle ();
@@ -167,15 +172,15 @@ public:
 
     void computeMLResidual (int amrlevmax);
     void computeResidual (int alev);
-    void computeResWithCrseSolFineCor (int crse_amr_lev, int fine_amr_lev);
-    void computeResWithCrseCorFineCor (int fine_amr_lev);
+    void computeResWithCrseSolFineCor (int calev, int falev);
+    void computeResWithCrseCorFineCor (int falev);
     void interpCorrection (int alev);
     void interpCorrection (int alev, int mglev);
     void addInterpCorrection (int alev, int mglev);
 
     void computeResOfCorrection (int amrlev, int mglev);
 
-    RT ResNormInf (int amrlev, bool local = false);
+    RT ResNormInf (int alev, bool local = false);
     RT MLResNormInf (int alevmax, bool local = false);
     RT MLRhsNormInf (bool local = false);
 
@@ -192,15 +197,15 @@ public:
 
     int bottomSolveWithCG (MF& x, const MF& b, typename MLCGSolverT<MF>::Type type);
 
-    RT getInitRHS () const noexcept { return m_rhsnorm0; }
+    [[nodiscard]] RT getInitRHS () const noexcept { return m_rhsnorm0; }
     // Initial composite residual
-    RT getInitResidual () const noexcept { return m_init_resnorm0; }
+    [[nodiscard]] RT getInitResidual () const noexcept { return m_init_resnorm0; }
     // Final composite residual
-    RT getFinalResidual () const noexcept { return m_final_resnorm0; }
+    [[nodiscard]] RT getFinalResidual () const noexcept { return m_final_resnorm0; }
     // Residuals on the *finest* AMR level after each iteration
-    Vector<RT> const& getResidualHistory () const noexcept { return m_iter_fine_resnorm0; }
-    int getNumIters () const noexcept { return m_iter_fine_resnorm0.size(); }
-    Vector<int> const& getNumCGIters () const noexcept { return m_niters_cg; }
+    [[nodiscard]] Vector<RT> const& getResidualHistory () const noexcept { return m_iter_fine_resnorm0; }
+    [[nodiscard]] int getNumIters () const noexcept { return m_iter_fine_resnorm0.size(); }
+    [[nodiscard]] Vector<int> const& getNumCGIters () const noexcept { return m_niters_cg; }
 
 private:
 
@@ -307,7 +312,7 @@ MLMGT<MF>::MLMGT (MLLinOpT<MF>& a_lp)
       finest_amr_lev(a_lp.NAMRLevels()-1)
 {}
 
-template <typename MF> MLMGT<MF>::~MLMGT () {}
+template <typename MF> MLMGT<MF>::~MLMGT () = default;
 
 template <typename MF>
 template <typename AMF>
@@ -1057,9 +1062,9 @@ MLMGT<MF>::prepareForSolve (Vector<AMF*> const& a_sol, Vector<AMF const*> const&
         cor_hold[alev][0].setVal(RT(0.0));
     }
 
-    if (linop.m_parent) {
-        do_nsolve = false;  // no embedded N-Solve
-    } else if (!linop.supportNSolve()) {
+    if (linop.m_parent // no embedded N-Solve
+        || !linop.supportNSolve())
+    {
         do_nsolve = false;
     }
 
@@ -1426,7 +1431,7 @@ MLMGT<MF>::actualBottomSolve ()
         }
 
         if (bottom_solver == BottomSolver::hypre)
-        {
+        { // NOLINT(bugprone-branch-clone)
 #if defined(AMREX_USE_HYPRE) && (AMREX_SPACEDIM > 1)
             bottomSolveWithHypre(x, *bottom_b);
 #endif

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLap_2D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLap_2D_K.H
@@ -1244,19 +1244,17 @@ namespace {
         const auto ndlo = amrex::lbound(nddom);
         const auto ndhi = amrex::ubound(nddom);
 
-        if (i == ndlo.x && ( bclo[0] == LinOpBCType::Neumann ||
-                             bclo[0] == LinOpBCType::inflow)) {
-            val *= Real(2.0);
-        } else if (i== ndhi.x && ( bchi[0] == LinOpBCType::Neumann ||
-                                   bchi[0] == LinOpBCType::inflow)) {
+        if ((i == ndlo.x && ( bclo[0] == LinOpBCType::Neumann ||
+                              bclo[0] == LinOpBCType::inflow)) ||
+            (i == ndhi.x && ( bchi[0] == LinOpBCType::Neumann ||
+                              bchi[0] == LinOpBCType::inflow))) {
             val *= Real(2.0);
         }
 
-        if (j == ndlo.y && ( bclo[1] == LinOpBCType::Neumann ||
-                             bclo[1] == LinOpBCType::inflow)) {
-            val *= Real(2.0);
-        } else if (j == ndhi.y && ( bchi[1] == LinOpBCType::Neumann ||
-                                    bchi[1] == LinOpBCType::inflow)) {
+        if ((j == ndlo.y && ( bclo[1] == LinOpBCType::Neumann ||
+                              bclo[1] == LinOpBCType::inflow)) ||
+            (j == ndhi.y && ( bchi[1] == LinOpBCType::Neumann ||
+                              bchi[1] == LinOpBCType::inflow))) {
             val *= Real(2.0);
         }
 
@@ -1341,18 +1339,16 @@ void mlndlap_crse_resid (int i, int j, int k, Array4<Real> const& resid,
         if (neumann_doubling) {
             const auto ndlo = amrex::lbound(nddom);
             const auto ndhi = amrex::ubound(nddom);
-            if (i == ndlo.x && ( bclo[0] == LinOpBCType::Neumann ||
-                                  bclo[0] == LinOpBCType::inflow)) {
-                fac *= Real(2.);
-            } else if (i== ndhi.x && ( bchi[0] == LinOpBCType::Neumann ||
-                                        bchi[0] == LinOpBCType::inflow)) {
+            if ((i == ndlo.x && ( bclo[0] == LinOpBCType::Neumann ||
+                                  bclo[0] == LinOpBCType::inflow)) ||
+                (i == ndhi.x && ( bchi[0] == LinOpBCType::Neumann ||
+                                  bchi[0] == LinOpBCType::inflow))) {
                 fac *= Real(2.);
             }
-            if (j == ndlo.y && ( bclo[1] == LinOpBCType::Neumann ||
-                                  bclo[1] == LinOpBCType::inflow)) {
-                fac *= Real(2.);
-            } else if (j == ndhi.y && ( bchi[1] == LinOpBCType::Neumann ||
-                                         bchi[1] == LinOpBCType::inflow)) {
+            if ((j == ndlo.y && ( bclo[1] == LinOpBCType::Neumann ||
+                                  bclo[1] == LinOpBCType::inflow)) ||
+                (j == ndhi.y && ( bchi[1] == LinOpBCType::Neumann ||
+                                  bchi[1] == LinOpBCType::inflow))) {
                 fac *= Real(2.);
             }
         }

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLap_3D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLap_3D_K.H
@@ -2302,27 +2302,24 @@ namespace {
         const auto ndlo = amrex::lbound(nddom);
         const auto ndhi = amrex::ubound(nddom);
 
-        if (i == ndlo.x && ( bclo[0] == LinOpBCType::Neumann ||
-                             bclo[0] == LinOpBCType::inflow)) {
-            val *= Real(2.);
-        } else if (i== ndhi.x && ( bchi[0] == LinOpBCType::Neumann ||
-                                   bchi[0] == LinOpBCType::inflow)) {
-            val *= Real(2.);
-        }
-
-        if (j == ndlo.y && ( bclo[1] == LinOpBCType::Neumann ||
-                             bclo[1] == LinOpBCType::inflow)) {
-            val *= Real(2.);
-        } else if (j == ndhi.y && ( bchi[1] == LinOpBCType::Neumann ||
-                                    bchi[1] == LinOpBCType::inflow)) {
+        if ((i == ndlo.x && ( bclo[0] == LinOpBCType::Neumann ||
+                              bclo[0] == LinOpBCType::inflow)) ||
+            (i == ndhi.x && ( bchi[0] == LinOpBCType::Neumann ||
+                              bchi[0] == LinOpBCType::inflow))) {
             val *= Real(2.);
         }
 
-        if (k == ndlo.z && ( bclo[2] == LinOpBCType::Neumann ||
-                             bclo[2] == LinOpBCType::inflow)) {
+        if ((j == ndlo.y && ( bclo[1] == LinOpBCType::Neumann ||
+                              bclo[1] == LinOpBCType::inflow)) ||
+            (j == ndhi.y && ( bchi[1] == LinOpBCType::Neumann ||
+                              bchi[1] == LinOpBCType::inflow))) {
             val *= Real(2.);
-        } else if (k == ndhi.z && ( bchi[2] == LinOpBCType::Neumann ||
-                                    bchi[2] == LinOpBCType::inflow)) {
+        }
+
+        if ((k == ndlo.z && ( bclo[2] == LinOpBCType::Neumann ||
+                              bclo[2] == LinOpBCType::inflow)) ||
+            (k == ndhi.z && ( bchi[2] == LinOpBCType::Neumann ||
+                              bchi[2] == LinOpBCType::inflow))) {
             val *= Real(2.);
         }
 
@@ -2441,25 +2438,22 @@ void mlndlap_crse_resid (int i, int j, int k, Array4<Real> const& resid,
         if (neumann_doubling) {
             const auto ndlo = amrex::lbound(nddom);
             const auto ndhi = amrex::ubound(nddom);
-            if (i == ndlo.x && ( bclo[0] == LinOpBCType::Neumann ||
-                                  bclo[0] == LinOpBCType::inflow)) {
-                fac *= Real(2.);
-            } else if (i== ndhi.x && ( bchi[0] == LinOpBCType::Neumann ||
-                                        bchi[0] == LinOpBCType::inflow)) {
-                fac *= Real(2.);
-            }
-            if (j == ndlo.y && ( bclo[1] == LinOpBCType::Neumann ||
-                                  bclo[1] == LinOpBCType::inflow)) {
-                fac *= Real(2.);
-            } else if (j == ndhi.y && ( bchi[1] == LinOpBCType::Neumann ||
-                                         bchi[1] == LinOpBCType::inflow)) {
+            if ((i == ndlo.x && ( bclo[0] == LinOpBCType::Neumann ||
+                                  bclo[0] == LinOpBCType::inflow)) ||
+                (i == ndhi.x && ( bchi[0] == LinOpBCType::Neumann ||
+                                  bchi[0] == LinOpBCType::inflow))) {
                 fac *= Real(2.);
             }
-            if (k == ndlo.z && ( bclo[2] == LinOpBCType::Neumann ||
-                                  bclo[2] == LinOpBCType::inflow)) {
+            if ((j == ndlo.y && ( bclo[1] == LinOpBCType::Neumann ||
+                                  bclo[1] == LinOpBCType::inflow)) ||
+                (j == ndhi.y && ( bchi[1] == LinOpBCType::Neumann ||
+                                  bchi[1] == LinOpBCType::inflow))) {
                 fac *= Real(2.);
-            } else if (k == ndhi.z && ( bchi[2] == LinOpBCType::Neumann ||
-                                         bchi[2] == LinOpBCType::inflow)) {
+            }
+            if ((k == ndlo.z && ( bclo[2] == LinOpBCType::Neumann ||
+                                  bclo[2] == LinOpBCType::inflow)) ||
+                (k == ndhi.z && ( bchi[2] == LinOpBCType::Neumann ||
+                                  bchi[2] == LinOpBCType::inflow))) {
                 fac *= Real(2.);
             }
         }

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian_sync.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian_sync.cpp
@@ -759,9 +759,7 @@ MLNodeLaplacian::reflux (int crse_amrlev,
 #endif
         } else {
             Real const_sigma = m_const_sigma;
-#if (AMREX_SPACEDIM == 1)
-            amrex::ignore_unused(const_sigma);
-#elif (AMREX_SPACEDIM == 2)
+#if (AMREX_SPACEDIM == 2)
             if (amrrr == 2) {
                 AMREX_HOST_DEVICE_FOR_3D(cbx, i, j, k,
                 {
@@ -842,9 +840,7 @@ MLNodeLaplacian::reflux (int crse_amrlev,
 #endif
             } else {
                 Real const_sigma = m_const_sigma;
-#if (AMREX_SPACEDIM == 1)
-                amrex::ignore_unused(const_sigma);
-#elif (AMREX_SPACEDIM == 2)
+#if (AMREX_SPACEDIM == 2)
                 AMREX_HOST_DEVICE_FOR_3D(bx, i, j, k,
                 {
                     mlndlap_res_cf_contrib_cs(i,j,k,resarr,csolarr,crhsarr,const_sigma,

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLinOp.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLinOp.H
@@ -19,7 +19,7 @@ public:
     enum struct CoarseningStrategy : int { Sigma, RAP };
 
     MLNodeLinOp ();
-    virtual ~MLNodeLinOp () = default;
+    ~MLNodeLinOp () override = default;
 
     MLNodeLinOp (const MLNodeLinOp&) = delete;
     MLNodeLinOp (MLNodeLinOp&&) = delete;
@@ -33,46 +33,46 @@ public:
                  const Vector<FabFactory<FArrayBox> const*>& a_factory = {},
                  int a_eb_limit_coarsening = -1);
 
-    virtual void setLevelBC (int /*amrlev*/, const MultiFab* /*levelbcdata*/,
+    void setLevelBC (int /*amrlev*/, const MultiFab* /*levelbcdata*/,
                              const MultiFab* = nullptr, const MultiFab* = nullptr,
-                             const MultiFab* = nullptr) final override {}
+                             const MultiFab* = nullptr) final {}
 
-    virtual void apply (int amrlev, int mglev, MultiFab& out, MultiFab& in, BCMode bc_mode,
-                        StateMode s_mode, const MLMGBndry* bndry=nullptr) const final override;
+    void apply (int amrlev, int mglev, MultiFab& out, MultiFab& in, BCMode bc_mode,
+                        StateMode s_mode, const MLMGBndry* bndry=nullptr) const final;
 
-    virtual void smooth (int amrlev, int mglev, MultiFab& sol, const MultiFab& rhs,
+    void smooth (int amrlev, int mglev, MultiFab& sol, const MultiFab& rhs,
                          bool skip_fillboundary=false) const override;
 
-    virtual void solutionResidual (int amrlev, MultiFab& resid, MultiFab& x, const MultiFab& b,
+    void solutionResidual (int amrlev, MultiFab& resid, MultiFab& x, const MultiFab& b,
                                    const MultiFab* crse_bcdata=nullptr) override;
-    virtual void correctionResidual (int amrlev, int mglev, MultiFab& resid, MultiFab& x, const MultiFab& b,
+    void correctionResidual (int amrlev, int mglev, MultiFab& resid, MultiFab& x, const MultiFab& b,
                                      BCMode bc_mode, const MultiFab* crse_bcdata=nullptr) override;
-    virtual void compFlux (int /*amrlev*/, const Array<MultiFab*,AMREX_SPACEDIM>& /*fluxes*/,
-                           MultiFab& /*sol*/, Location /*loc*/) const final override {
+    void compFlux (int /*amrlev*/, const Array<MultiFab*,AMREX_SPACEDIM>& /*fluxes*/,
+                           MultiFab& /*sol*/, Location /*loc*/) const final {
         amrex::Abort("AMReX_MLNodeLinOp::compFlux::How did we get here?");
     }
-    virtual void compGrad (int /*amrlev*/, const Array<MultiFab*,AMREX_SPACEDIM>& /*grad*/,
+    void compGrad (int /*amrlev*/, const Array<MultiFab*,AMREX_SPACEDIM>& /*grad*/,
                            MultiFab& /*sol*/, Location /*loc*/) const override {
         amrex::Abort("AMReX_MLNodeLinOp::compGrad::How did we get here?");
     }
 
-    virtual void applyMetricTerm (int /*amrlev*/, int /*mglev*/, MultiFab& /*rhs*/) const final override {}
-    virtual void unapplyMetricTerm (int /*amrlev*/, int /*mglev*/, MultiFab& /*rhs*/) const final override {}
+    void applyMetricTerm (int /*amrlev*/, int /*mglev*/, MultiFab& /*rhs*/) const final {}
+    void unapplyMetricTerm (int /*amrlev*/, int /*mglev*/, MultiFab& /*rhs*/) const final {}
 
-    virtual Vector<Real> getSolvabilityOffset (int amrlev, int mglev,
+    Vector<Real> getSolvabilityOffset (int amrlev, int mglev,
                                                MultiFab const& rhs) const override;
-    virtual void fixSolvabilityByOffset (int amrlev, int mglev, MultiFab& rhs,
+    void fixSolvabilityByOffset (int amrlev, int mglev, MultiFab& rhs,
                                          Vector<Real> const& offset) const override;
 
-    virtual void prepareForSolve () override;
+    void prepareForSolve () override;
 
-    virtual bool isSingular (int amrlev) const override
+    bool isSingular (int amrlev) const override
         { return (amrlev == 0) ? m_is_bottom_singular : false; }
-    virtual bool isBottomSingular () const override { return m_is_bottom_singular; }
+    bool isBottomSingular () const override { return m_is_bottom_singular; }
 
-    virtual Real xdoty (int amrlev, int mglev, const MultiFab& x, const MultiFab& y, bool local) const final override;
+    Real xdoty (int amrlev, int mglev, const MultiFab& x, const MultiFab& y, bool local) const final;
 
-    virtual void applyBC (int amrlev, int mglev, MultiFab& phi, BCMode bc_mode, StateMode s_mode,
+    virtual void applyBC (int amrlev, int mglev, MultiFab& phi, BCMode bc_mode, StateMode state_mode,
                           bool skip_fillboundary=false) const;
 
     virtual void Fapply (int amrlev, int mglev, MultiFab& out, const MultiFab& in) const = 0;
@@ -80,7 +80,7 @@ public:
 
     void nodalSync (int amrlev, int mglev, MultiFab& mf) const;
 
-    virtual std::unique_ptr<MLLinOp> makeNLinOp (int /*grid_size*/) const final override {
+    std::unique_ptr<MLLinOp> makeNLinOp (int /*grid_size*/) const final {
         amrex::Abort("MLNodeLinOp::makeNLinOp: N-Solve not supported");
         return std::unique_ptr<MLLinOp>{};
     }
@@ -92,20 +92,20 @@ public:
     void buildMasks ();
 
     // omask is either 0 or 1. 1 means the node is an unknown. 0 means it's known.
-    void setOversetMask (int amrlev, const iMultiFab& a_omask);
+    void setOversetMask (int amrlev, const iMultiFab& a_dmask);
 
     virtual void fixUpResidualMask (int /*amrlev*/, iMultiFab& /*resmsk*/) { }
 
-    virtual Real normInf (int amrlev, MultiFab const& a, bool local) const override;
+    Real normInf (int amrlev, MultiFab const& mf, bool local) const override;
 
-    virtual void avgDownResAmr (int, MultiFab&, MultiFab const&) const final override { }
+    void avgDownResAmr (int, MultiFab&, MultiFab const&) const final { }
 
-    virtual void interpolationAmr (int famrlev, MultiFab& fine, const MultiFab& crse,
+    void interpolationAmr (int famrlev, MultiFab& fine, const MultiFab& crse,
                                    IntVect const& nghost) const override;
 
-    virtual void averageDownAndSync (Vector<MultiFab>& sol) const override;
+    void averageDownAndSync (Vector<MultiFab>& sol) const override;
 
-    virtual void interpAssign (int amrlev, int fmglev, MultiFab& fine, MultiFab& crse) const override;
+    void interpAssign (int amrlev, int fmglev, MultiFab& fine, MultiFab& crse) const override;
 
 #if defined(AMREX_USE_HYPRE) && (AMREX_SPACEDIM > 1)
     virtual std::unique_ptr<HypreNodeLap> makeHypreNodeLap(
@@ -133,7 +133,7 @@ public:
 
 protected:
 
-    virtual void resizeMultiGrid (int new_size) override;
+    void resizeMultiGrid (int new_size) override;
 
     std::unique_ptr<iMultiFab> m_owner_mask_top;  // ownership of nodes
     std::unique_ptr<iMultiFab> m_owner_mask_bottom;

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLinOp.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLinOp.cpp
@@ -264,8 +264,8 @@ MLNodeLinOp::buildMasks ()
     m_masks_built = true;
 
     m_is_bottom_singular = false;
-    auto itlo = std::find(m_lobc[0].begin(), m_lobc[0].end(), BCType::Dirichlet);
-    auto ithi = std::find(m_hibc[0].begin(), m_hibc[0].end(), BCType::Dirichlet);
+    auto itlo = std::find(m_lobc[0].begin(), m_lobc[0].end(), BCType::Dirichlet); // NOLINT
+    auto ithi = std::find(m_hibc[0].begin(), m_hibc[0].end(), BCType::Dirichlet); // NOLINT
     if (itlo == m_lobc[0].end() && ithi == m_hibc[0].end())
     {  // No Dirichlet
         m_is_bottom_singular = (m_domain_covered[0] && !m_overset_dirichlet_mask);

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeTensorLaplacian.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeTensorLaplacian.cpp
@@ -269,7 +269,6 @@ void
 MLNodeTensorLaplacian::normalize (int amrlev, int mglev, MultiFab& mf) const
 {
     amrex::ignore_unused(amrlev,mglev,mf);
-    return;
 }
 
 void

--- a/Src/LinearSolvers/MLMG/AMReX_MLPoisson.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLPoisson.H
@@ -22,7 +22,7 @@ public:
     using BCType = LinOpBCType;
     using Location  = typename MLLinOpT<MF>::Location;
 
-    MLPoissonT () noexcept {}
+    MLPoissonT () noexcept = default;
     MLPoissonT (const Vector<Geometry>& a_geom,
                 const Vector<BoxArray>& a_grids,
                 const Vector<DistributionMapping>& a_dmap,
@@ -34,7 +34,7 @@ public:
                 const Vector<iMultiFab const*>& a_overset_mask, // 1: unknown, 0: known
                 const LPInfo& a_info = LPInfo(),
                 const Vector<FabFactory<FAB> const*>& a_factory = {});
-    virtual ~MLPoissonT ();
+    ~MLPoissonT () override;
 
     MLPoissonT (const MLPoissonT<MF>&) = delete;
     MLPoissonT (MLPoissonT<MF>&&) = delete;
@@ -54,28 +54,28 @@ public:
                  const LPInfo& a_info = LPInfo(),
                  const Vector<FabFactory<FAB> const*>& a_factory = {});
 
-    virtual void prepareForSolve () final override;
-    virtual bool isSingular (int amrlev) const final override { return m_is_singular[amrlev]; }
-    virtual bool isBottomSingular () const final override { return m_is_singular[0]; }
-    virtual void Fapply (int amrlev, int mglev, MF& out, const MF& in) const final override;
-    virtual void Fsmooth (int amrlev, int mglev, MF& sol, const MF& rsh, int redblack) const final override;
-    virtual void FFlux (int amrlev, const MFIter& mfi,
+    void prepareForSolve () final;
+    [[nodiscard]] bool isSingular (int amrlev) const final { return m_is_singular[amrlev]; }
+    [[nodiscard]] bool isBottomSingular () const final { return m_is_singular[0]; }
+    void Fapply (int amrlev, int mglev, MF& out, const MF& in) const final;
+    void Fsmooth (int amrlev, int mglev, MF& sol, const MF& rhs, int redblack) const final;
+    void FFlux (int amrlev, const MFIter& mfi,
                         const Array<FAB*,AMREX_SPACEDIM>& flux,
-                        const FAB& sol, Location loc, const int face_only=0) const final override;
+                        const FAB& sol, Location loc, int face_only=0) const final;
 
-    virtual void normalize (int amrlev, int mglev, MF& mf) const final override;
+    void normalize (int amrlev, int mglev, MF& mf) const final;
 
-    virtual RT getAScalar () const final override { return RT(0.0); }
-    virtual RT getBScalar () const final override { return RT(-1.0); }
-    virtual MF const* getACoeffs (int /*amrlev*/, int /*mglev*/) const final override { return nullptr; }
-    virtual Array<MF const*,AMREX_SPACEDIM> getBCoeffs (int /*amrlev*/, int /*mglev*/) const final override
+    [[nodiscard]] RT getAScalar () const final { return RT(0.0); }
+    [[nodiscard]] RT getBScalar () const final { return RT(-1.0); }
+    [[nodiscard]] MF const* getACoeffs (int /*amrlev*/, int /*mglev*/) const final { return nullptr; }
+    [[nodiscard]] Array<MF const*,AMREX_SPACEDIM> getBCoeffs (int /*amrlev*/, int /*mglev*/) const final
         { return {{ AMREX_D_DECL(nullptr,nullptr,nullptr)}}; }
 
-    virtual std::unique_ptr<MLLinOpT<MF>> makeNLinOp (int grid_size) const final override;
+    [[nodiscard]] std::unique_ptr<MLLinOpT<MF>> makeNLinOp (int grid_size) const final;
 
-    virtual bool supportNSolve () const final override;
+    [[nodiscard]] bool supportNSolve () const final;
 
-    virtual void copyNSolveSolution (MF& dst, MF const& src) const final override;
+    void copyNSolveSolution (MF& dst, MF const& src) const final;
 
     //! Compute dphi/dn on domain faces after the solver has converged.
     void get_dpdn_on_domain_faces (Array<MF*,AMREX_SPACEDIM> const& dpdn,
@@ -133,8 +133,7 @@ MLPoissonT<MF>::define (const Vector<Geometry>& a_geom,
 }
 
 template <typename MF>
-MLPoissonT<MF>::~MLPoissonT ()
-{}
+MLPoissonT<MF>::~MLPoissonT () = default;
 
 template <typename MF>
 void

--- a/Src/LinearSolvers/OpenBC/AMReX_OpenBC.H
+++ b/Src/LinearSolvers/OpenBC/AMReX_OpenBC.H
@@ -85,7 +85,7 @@ public:
     Real solve (const Vector<MultiFab*>& a_sol, const Vector<MultiFab const*>& a_rhs,
                 Real a_tol_rel, Real a_tol_abs);
 
-public: // public for cuda
+// public for cuda
 
     void compute_moments (Gpu::DeviceVector<openbc::Moments>& moments);
     void compute_potential (Gpu::DeviceVector<openbc::Moments> const& moments);

--- a/Tools/CMake/AMReXClangTidy.cmake
+++ b/Tools/CMake/AMReXClangTidy.cmake
@@ -1,9 +1,34 @@
 macro(setup_clang_tidy)
-   find_program(CLANG_TIDY_EXE NAMES "clang-tidy")
-   if (CLANG_TIDY_EXE)
-      set(CLANG_TIDY_COMMAND "${CLANG_TIDY_EXE}"
-        "--config-file=${PROJECT_SOURCE_DIR}/.clang-tidy")
-      set_target_properties(amrex PROPERTIES CXX_CLANG_TIDY "${CLANG_TIDY_COMMAND}")
+   find_program(AMReX_CLANG_TIDY_EXE NAMES "clang-tidy-17" "clang-tidy-16"
+	"clang-tidy-15" "clang-tidy-14" "clang-tidy-13" "clang-tidy-12" "clang-tidy")
+   if (AMReX_CLANG_TIDY_EXE)
+      set(_tmp "")
+
+      execute_process(COMMAND ${AMReX_CLANG_TIDY_EXE} --version
+                      OUTPUT_VARIABLE _tmp)
+      if (_tmp MATCHES "LLVM version ([0-9\.]+)")
+         message(STATUS "Found clang-tidy ${CMAKE_MATCH_1}")
+         if ("${CMAKE_MATCH_1}" VERSION_GREATER_EQUAL 12.0.0)
+            # Cofig file not supported in earlier versions
+            set(AMReX_CLANG_TIDY_CONFIG_FILE_NAME ${PROJECT_SOURCE_DIR}/.clang-tidy)
+         endif()
+      endif()
+
+      # Need --extra-arg to suppress warnings like clang-diagnostic-unknown-warning-option
+      # when GCC is used.
+      set(AMReX_CLANG_TIDY_COMMAND "${AMReX_CLANG_TIDY_EXE};--extra-arg=-Wno-unknown-warning-option")
+      if (AMReX_CLANG_TIDY_CONFIG_FILE_NAME)
+         set(AMReX_CLANG_TIDY_COMMAND "${AMReX_CLANG_TIDY_COMMAND}"
+             "--config-file=${AMReX_CLANG_TIDY_CONFIG_FILE_NAME}")
+      endif()
+      if (AMReX_CLANG_TIDY_WERROR)
+         set(AMReX_CLANG_TIDY_COMMAND "${AMReX_CLANG_TIDY_COMMAND}"
+             "--warnings-as-errors=*")
+      endif()
+
+      set_target_properties(amrex PROPERTIES CXX_CLANG_TIDY "${AMReX_CLANG_TIDY_COMMAND}")
+
+      unset(_tmp)
    else()
       message(WARNING "AMReX_CLANG_TIDY was enabled, but clang-tidy was not found.")
    endif()

--- a/Tools/CMake/AMReXOptions.cmake
+++ b/Tools/CMake/AMReXOptions.cmake
@@ -438,3 +438,7 @@ print_option(AMReX_PROBINIT)
 # Static code analysis  ===============================================
 #
 option(AMReX_CLANG_TIDY "Enable clang-tidy analysis" OFF)
+print_option(AMReX_CLANG_TIDY)
+cmake_dependent_option(AMReX_CLANG_TIDY_WERROR "Treat clang-tidy warnings as errors" OFF
+   "AMReX_CLANG_TIDY" OFF)
+print_option(AMReX_CLANG_TIDY_WERROR)


### PR DESCRIPTION
This is the second batch of changes fixing clang-tidy warnings.

Add CMake option AMReX_CLANG_TIDY_WERROR to update warnings to errors.

Use clang-tidy in CI: GNU@8.4 C++17 Release [lib].