### PR TITLE
Clang-Tidy IV

### DIFF
--- a/Src/AmrCore/AMReX_AmrCore.H
+++ b/Src/AmrCore/AMReX_AmrCore.H
@@ -49,7 +49,7 @@ public:
     ~AmrCore () override;
 
 #ifdef AMREX_PARTICLES
-    AmrParGDB* GetParGDB () const noexcept { return m_gdb.get(); }
+    [[nodiscard]] AmrParGDB* GetParGDB () const noexcept { return m_gdb.get(); }
 #endif
 
     /**

--- a/Src/AmrCore/AMReX_AmrCore.cpp
+++ b/Src/AmrCore/AMReX_AmrCore.cpp
@@ -59,7 +59,7 @@ AmrCore::~AmrCore () {} // NOLINT
 
 AmrCore& AmrCore::operator= (AmrCore&& rhs) noexcept
 {
-    AmrMesh::operator=(std::move(rhs));
+    AmrMesh::operator=(static_cast<AmrMesh&&>(rhs));
 #ifdef AMREX_PARTICLES
     m_gdb = std::move(rhs.m_gdb);
     m_gdb->m_amrcore = this;

--- a/Src/AmrCore/AMReX_AmrParGDB.H
+++ b/Src/AmrCore/AMReX_AmrParGDB.H
@@ -22,42 +22,40 @@ public:
           m_ba(amr->maxLevel()+1)
     { }
 
-    virtual ~AmrParGDB () {;}
+    [[nodiscard]] const Geometry& ParticleGeom (int level) const override;
+    [[nodiscard]] const Geometry&         Geom (int level) const override;
 
-    virtual const Geometry& ParticleGeom (int level) const override;
-    virtual const Geometry&         Geom (int level) const override;
+    [[nodiscard]] const Vector<Geometry>& ParticleGeom () const override;
+    [[nodiscard]] const Vector<Geometry>&         Geom () const override;
 
-    virtual const Vector<Geometry>& ParticleGeom () const override;
-    virtual const Vector<Geometry>&         Geom () const override;
+    [[nodiscard]] const DistributionMapping& ParticleDistributionMap (int level) const override;
+    [[nodiscard]] const DistributionMapping&         DistributionMap (int level) const override;
 
-    virtual const DistributionMapping& ParticleDistributionMap (int level) const override;
-    virtual const DistributionMapping&         DistributionMap (int level) const override;
+    [[nodiscard]] const Vector<DistributionMapping>& ParticleDistributionMap () const override;
+    [[nodiscard]] const Vector<DistributionMapping>&         DistributionMap () const override;
 
-    virtual const Vector<DistributionMapping>& ParticleDistributionMap () const override;
-    virtual const Vector<DistributionMapping>&         DistributionMap () const override;
+    [[nodiscard]] const BoxArray& ParticleBoxArray (int level) const override;
+    [[nodiscard]] const BoxArray&         boxArray (int level) const override;
 
-    virtual const BoxArray& ParticleBoxArray (int level) const override;
-    virtual const BoxArray&         boxArray (int level) const override;
+    [[nodiscard]] const Vector<BoxArray>& ParticleBoxArray () const override;
+    [[nodiscard]] const Vector<BoxArray>&         boxArray () const override;
 
-    virtual const Vector<BoxArray>& ParticleBoxArray () const override;
-    virtual const Vector<BoxArray>&         boxArray () const override;
+    void SetParticleBoxArray (int level, const BoxArray& new_ba) override;
+    void SetParticleDistributionMap (int level, const DistributionMapping& new_dm) override;
+    void SetParticleGeometry (int level, const Geometry& new_geom) override;
 
-    virtual void SetParticleBoxArray (int level, const BoxArray& new_ba) override;
-    virtual void SetParticleDistributionMap (int level, const DistributionMapping& new_dm) override;
-    virtual void SetParticleGeometry (int level, const Geometry& new_geom) override;
+    void ClearParticleBoxArray (int level) override;
+    void ClearParticleDistributionMap (int level) override;
+    void ClearParticleGeometry (int level) override;
 
-    virtual void ClearParticleBoxArray (int level) override;
-    virtual void ClearParticleDistributionMap (int level) override;
-    virtual void ClearParticleGeometry (int level) override;
+    [[nodiscard]] bool LevelDefined (int level) const override;
+    [[nodiscard]] int finestLevel () const override;
+    [[nodiscard]] int maxLevel () const override;
 
-    virtual bool LevelDefined (int level) const override;
-    virtual int finestLevel () const override;
-    virtual int maxLevel () const override;
+    [[nodiscard]] IntVect refRatio (int level) const override;
+    [[nodiscard]] int MaxRefRatio (int level) const override;
 
-    virtual IntVect refRatio (int level) const override;
-    virtual int MaxRefRatio (int level) const override;
-
-    virtual Vector<IntVect> refRatio () const override;
+    [[nodiscard]] Vector<IntVect> refRatio () const override;
 
 protected:
 

--- a/Src/Base/AMReX_GpuAtomic.H
+++ b/Src/Base/AMReX_GpuAtomic.H
@@ -193,7 +193,7 @@ namespace detail {
     template<class T>
 #endif
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-    T Add (T* const sum, T const value) noexcept
+    T Add (T* sum, T value) noexcept
     {
 #if AMREX_DEVICE_COMPILE
 #ifdef AMREX_USE_SYCL
@@ -276,7 +276,7 @@ namespace detail {
     template<class T>
 #endif
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-    void AddNoRet (T* const sum, T const value) noexcept
+    void AddNoRet (T* sum, T value) noexcept
     {
 #if AMREX_DEVICE_COMPILE
 #ifdef AMREX_USE_SYCL
@@ -480,7 +480,7 @@ namespace detail {
 
     template <typename T>
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-    T Exch (T* const address, T const val) noexcept
+    T Exch (T* address, T val) noexcept
     {
 #if defined(__CUDA_ARCH__) && defined(AMREX_USE_CUDA) || \
     defined(__HIP_DEVICE_COMPILE__) && defined(AMREX_USE_HIP)

--- a/Src/Particle/AMReX_ArrayOfStructs.H
+++ b/Src/Particle/AMReX_ArrayOfStructs.H
@@ -22,41 +22,38 @@ public:
 
     static constexpr int SizeInReal = sizeof(ParticleType) / sizeof(RealType);
 
-    ArrayOfStructs()
-        : m_num_neighbor_particles(0) {}
-
-    const ParticleVector& operator() () const { return m_data; }
-    ParticleVector& operator() ()       { return m_data; }
+    [[nodiscard]] const ParticleVector& operator() () const { return m_data; }
+    [[nodiscard]]       ParticleVector& operator() ()       { return m_data; }
 
     /**
     * \brief Returns the total number of particles (real and neighbor)
     *
     */
-    std::size_t size () const { return m_data.size(); }
+    [[nodiscard]] std::size_t size () const { return m_data.size(); }
 
     /**
     * \brief Returns the number of real particles (excluding neighbors)
     *
     */
-    int numParticles () const { return numRealParticles(); }
+    [[nodiscard]] int numParticles () const { return numRealParticles(); }
 
     /**
     * \brief Returns the number of real particles (excluding neighbors)
     *
     */
-    int numRealParticles () const { return numTotalParticles()-m_num_neighbor_particles; }
+    [[nodiscard]] int numRealParticles () const { return numTotalParticles()-m_num_neighbor_particles; }
 
     /**
     * \brief Returns the number of neighbor particles (excluding reals)
     *
     */
-    int numNeighborParticles () const { return m_num_neighbor_particles; }
+    [[nodiscard]] int numNeighborParticles () const { return m_num_neighbor_particles; }
 
     /**
     * \brief Returns the total number of particles (real and neighbor)
     *
     */
-    int numTotalParticles () const { return m_data.size(); }
+    [[nodiscard]] int numTotalParticles () const { return m_data.size(); }
 
     void setNumNeighbors (int num_neighbors)
     {
@@ -65,29 +62,29 @@ public:
         resize(nrp + num_neighbors);
     }
 
-    int getNumNeighbors () { return m_num_neighbor_particles; }
+    [[nodiscard]] int getNumNeighbors () { return m_num_neighbor_particles; }
 
-    bool empty () const { return m_data.empty(); }
+    [[nodiscard]] bool empty () const { return m_data.empty(); }
 
-    const RealType* data () const { return &(m_data[0].m_pos[0]); }
-    RealType* data () { return &(m_data[0].pos(0)); }
+    [[nodiscard]] const RealType* data () const { return &(m_data[0].m_pos[0]); }
+    [[nodiscard]]       RealType* data ()       { return &(m_data[0].m_pos[0]); }
 
-    const RealType* dataPtr () const { return data(); }
-    RealType*       dataPtr ()       { return data(); }
+    [[nodiscard]] const RealType* dataPtr () const { return data(); }
+    [[nodiscard]]       RealType* dataPtr ()       { return data(); }
 
-    std::pair<int,int> dataShape () const {
+    [[nodiscard]] std::pair<int,int> dataShape () const {
         return std::make_pair(SizeInReal, static_cast<int>(m_data.size()));
     }
 
     void push_back (const ParticleType& p) { return m_data.push_back(p); }
     void pop_back() {m_data.pop_back(); }
-    bool empty() {return m_data.empty(); }
+    [[nodiscard]] bool empty() {return m_data.empty(); }
 
-    const ParticleType& back() const {return m_data.back(); }
-    ParticleType      & back()       {return m_data.back(); }
+    [[nodiscard]] const ParticleType& back() const {return m_data.back(); }
+    [[nodiscard]]       ParticleType& back()       {return m_data.back(); }
 
-    const ParticleType& operator[] (int i) const { return m_data[i]; }
-    ParticleType      & operator[] (int i)       { return m_data[i]; }
+    [[nodiscard]] const ParticleType& operator[] (int i) const { return m_data[i]; }
+    [[nodiscard]]       ParticleType& operator[] (int i)       { return m_data[i]; }
 
     void swap (ArrayOfStructs<NReal, NInt>& other)
     {
@@ -101,15 +98,15 @@ public:
     template< class InputIt >
     void insert ( Iterator pos, InputIt first, InputIt last ) { m_data.insert(pos, first, last); }
 
-    typename ParticleVector::iterator begin () { return m_data.begin(); }
-    typename ParticleVector::const_iterator begin () const { return m_data.begin(); }
-    typename ParticleVector::const_iterator cbegin () const { return m_data.cbegin(); }
+    [[nodiscard]] typename ParticleVector::iterator begin () { return m_data.begin(); }
+    [[nodiscard]] typename ParticleVector::const_iterator begin () const { return m_data.begin(); }
+    [[nodiscard]] typename ParticleVector::const_iterator cbegin () const { return m_data.cbegin(); }
 
-    typename ParticleVector::iterator end () { return m_data.end(); }
-    typename ParticleVector::const_iterator end () const { return m_data.end(); }
-    typename ParticleVector::const_iterator cend () const { return m_data.cend(); }
+    [[nodiscard]] typename ParticleVector::iterator end () { return m_data.end(); }
+    [[nodiscard]] typename ParticleVector::const_iterator end () const { return m_data.end(); }
+    [[nodiscard]] typename ParticleVector::const_iterator cend () const { return m_data.cend(); }
 
-    int m_num_neighbor_particles;
+    int m_num_neighbor_particles{0};
 
 private:
     ParticleVector m_data;

--- a/Src/Particle/AMReX_ParGDB.H
+++ b/Src/Particle/AMReX_ParGDB.H
@@ -13,26 +13,30 @@ class ParGDBBase
 {
 public:
 
-    ParGDBBase () {;}
-    virtual ~ParGDBBase () {;}
+    ParGDBBase () noexcept = default;
+    virtual ~ParGDBBase () = default;
+    ParGDBBase (ParGDBBase const&) noexcept = default;
+    ParGDBBase (ParGDBBase &&) noexcept = default;
+    ParGDBBase& operator= (ParGDBBase const&) noexcept = default;
+    ParGDBBase& operator= (ParGDBBase &&) noexcept = default;
 
-    virtual const Geometry& ParticleGeom (int level) const = 0;
-    virtual const Geometry& Geom (int level) const = 0;
+    [[nodiscard]] virtual const Geometry& ParticleGeom (int level) const = 0;
+    [[nodiscard]] virtual const Geometry& Geom (int level) const = 0;
 
-    virtual const Vector<Geometry>& ParticleGeom () const = 0;
-    virtual const Vector<Geometry>&         Geom () const = 0;
+    [[nodiscard]] virtual const Vector<Geometry>& ParticleGeom () const = 0;
+    [[nodiscard]] virtual const Vector<Geometry>&         Geom () const = 0;
 
-    virtual const DistributionMapping& ParticleDistributionMap (int level) const = 0;
-    virtual const DistributionMapping&         DistributionMap (int level) const = 0;
+    [[nodiscard]] virtual const DistributionMapping& ParticleDistributionMap (int level) const = 0;
+    [[nodiscard]] virtual const DistributionMapping&         DistributionMap (int level) const = 0;
 
-    virtual const Vector<DistributionMapping>& ParticleDistributionMap () const = 0;
-    virtual const Vector<DistributionMapping>&         DistributionMap () const = 0;
+    [[nodiscard]] virtual const Vector<DistributionMapping>& ParticleDistributionMap () const = 0;
+    [[nodiscard]] virtual const Vector<DistributionMapping>&         DistributionMap () const = 0;
 
-    virtual const BoxArray& ParticleBoxArray (int level) const = 0;
-    virtual const BoxArray&         boxArray (int level) const = 0;
+    [[nodiscard]] virtual const BoxArray& ParticleBoxArray (int level) const = 0;
+    [[nodiscard]] virtual const BoxArray&         boxArray (int level) const = 0;
 
-    virtual const Vector<BoxArray>& ParticleBoxArray () const = 0;
-    virtual const Vector<BoxArray>&         boxArray () const = 0;
+    [[nodiscard]] virtual const Vector<BoxArray>& ParticleBoxArray () const = 0;
+    [[nodiscard]] virtual const Vector<BoxArray>&         boxArray () const = 0;
 
     virtual void SetParticleBoxArray (int level, const BoxArray& new_ba) = 0;
     virtual void SetParticleDistributionMap (int level, const DistributionMapping& new_dm) = 0;
@@ -42,17 +46,17 @@ public:
     virtual void ClearParticleDistributionMap (int level) = 0;
     virtual void ClearParticleGeometry (int level) = 0;
 
-    virtual bool LevelDefined (int level) const = 0;
-    virtual int finestLevel () const = 0;
-    virtual int maxLevel () const = 0;
+    [[nodiscard]] virtual bool LevelDefined (int level) const = 0;
+    [[nodiscard]] virtual int finestLevel () const = 0;
+    [[nodiscard]] virtual int maxLevel () const = 0;
 
-    virtual IntVect refRatio (int level) const = 0;
-    virtual int MaxRefRatio (int level) const = 0;
+    [[nodiscard]] virtual IntVect refRatio (int level) const = 0;
+    [[nodiscard]] virtual int MaxRefRatio (int level) const = 0;
 
-    virtual Vector<IntVect> refRatio () const = 0;
+    [[nodiscard]] virtual Vector<IntVect> refRatio () const = 0;
 
     template <class MF>
-    bool OnSameGrids (int level, const MF& mf) const;
+    [[nodiscard]] bool OnSameGrids (int level, const MF& mf) const;
 };
 
 //
@@ -62,7 +66,7 @@ class ParGDB
 {
 public:
 
-    ParGDB () { ; }
+    ParGDB () = default;
 
     ParGDB (const Geometry            & geom,
             const DistributionMapping & dmap,
@@ -78,44 +82,42 @@ public:
             const Vector<BoxArray>            & ba,
             const Vector<IntVect>             & rr);
 
-    virtual ~ParGDB () {;}
+    [[nodiscard]] const Geometry& ParticleGeom (int level) const override;
+    [[nodiscard]] const Geometry& Geom (int level) const override;
 
-    virtual const Geometry& ParticleGeom (int level) const override;
-    virtual const Geometry& Geom (int level) const override;
+    [[nodiscard]] const Vector<Geometry>& ParticleGeom () const override;
+    [[nodiscard]] const Vector<Geometry>&         Geom () const override;
 
-    virtual const Vector<Geometry>& ParticleGeom () const override;
-    virtual const Vector<Geometry>&         Geom () const override;
-
-    virtual const DistributionMapping& ParticleDistributionMap
+    [[nodiscard]] const DistributionMapping& ParticleDistributionMap
                                              (int level) const override;
-    virtual const DistributionMapping&         DistributionMap
+    [[nodiscard]] const DistributionMapping&         DistributionMap
                                              (int level) const override;
 
-    virtual const Vector<DistributionMapping>& ParticleDistributionMap () const override;
-    virtual const Vector<DistributionMapping>&         DistributionMap () const override;
+    [[nodiscard]] const Vector<DistributionMapping>& ParticleDistributionMap () const override;
+    [[nodiscard]] const Vector<DistributionMapping>&         DistributionMap () const override;
 
-    virtual const BoxArray& ParticleBoxArray (int level) const override;
-    virtual const BoxArray&         boxArray (int level) const override;
+    [[nodiscard]] const BoxArray& ParticleBoxArray (int level) const override;
+    [[nodiscard]] const BoxArray&         boxArray (int level) const override;
 
-    virtual const Vector<BoxArray>& ParticleBoxArray () const override;
-    virtual const Vector<BoxArray>&         boxArray () const override;
+    [[nodiscard]] const Vector<BoxArray>& ParticleBoxArray () const override;
+    [[nodiscard]] const Vector<BoxArray>&         boxArray () const override;
 
-    virtual void SetParticleBoxArray (int level, const BoxArray& new_ba) override;
-    virtual void SetParticleDistributionMap (int level,        const DistributionMapping& new_dm) override;
-    virtual void SetParticleGeometry (int level, const Geometry& new_geom) override;
+    void SetParticleBoxArray (int level, const BoxArray& new_ba) override;
+    void SetParticleDistributionMap (int level,        const DistributionMapping& new_dm) override;
+    void SetParticleGeometry (int level, const Geometry& new_geom) override;
 
-    virtual void ClearParticleBoxArray (int level) override;
-    virtual void ClearParticleDistributionMap (int level) override;
-    virtual void ClearParticleGeometry (int level) override;
+    void ClearParticleBoxArray (int level) override;
+    void ClearParticleDistributionMap (int level) override;
+    void ClearParticleGeometry (int level) override;
 
-    virtual bool LevelDefined (int level) const override;
-    virtual int finestLevel () const override;
-    virtual int maxLevel () const override;
+    [[nodiscard]] bool LevelDefined (int level) const override;
+    [[nodiscard]] int finestLevel () const override;
+    [[nodiscard]] int maxLevel () const override;
 
-    virtual IntVect refRatio (int level) const override;
-    virtual int MaxRefRatio (int level) const override;
+    [[nodiscard]] IntVect refRatio (int level) const override;
+    [[nodiscard]] int MaxRefRatio (int level) const override;
 
-    virtual Vector<IntVect> refRatio () const override;
+    [[nodiscard]] Vector<IntVect> refRatio () const override;
 
 protected:
 
@@ -155,7 +157,7 @@ ParGDB::ParGDB (const Vector<Geometry>            & geom,
     m_dmap(dmap),
     m_ba(ba),
     m_rr(rr),
-    m_nlevels(ba.size())
+    m_nlevels(static_cast<int>(ba.size()))
 { }
 
 inline
@@ -167,7 +169,7 @@ ParGDB::ParGDB (const Vector<Geometry>            & geom,
     m_geom(geom),
     m_dmap(dmap),
     m_ba(ba),
-    m_nlevels(ba.size())
+    m_nlevels(static_cast<int>(ba.size()))
 {
     for (int level = 0; level < static_cast<int>(rr.size()); ++level)
     {

--- a/Src/Particle/AMReX_ParIter.H
+++ b/Src/Particle/AMReX_ParIter.H
@@ -67,23 +67,23 @@ public:
     }
 #endif
 
-    ParticleTileRef GetParticleTile () const { return *m_particle_tiles[m_pariter_index]; }
+    [[nodiscard]] ParticleTileRef GetParticleTile () const { return *m_particle_tiles[m_pariter_index]; }
 
-    AoSRef GetArrayOfStructs () const { return GetParticleTile().GetArrayOfStructs(); }
+    [[nodiscard]] AoSRef GetArrayOfStructs () const { return GetParticleTile().GetArrayOfStructs(); }
 
-    SoARef GetStructOfArrays () const { return GetParticleTile().GetStructOfArrays(); }
+    [[nodiscard]] SoARef GetStructOfArrays () const { return GetParticleTile().GetStructOfArrays(); }
 
-    int numParticles () const { return GetArrayOfStructs().numParticles(); }
+    [[nodiscard]] int numParticles () const { return GetArrayOfStructs().numParticles(); }
 
-    int numRealParticles () const { return GetArrayOfStructs().numRealParticles(); }
+    [[nodiscard]] int numRealParticles () const { return GetArrayOfStructs().numRealParticles(); }
 
-    int numNeighborParticles () const { return GetArrayOfStructs().numNeighborParticles(); }
+    [[nodiscard]] int numNeighborParticles () const { return GetArrayOfStructs().numNeighborParticles(); }
 
-    int GetLevel () const { return m_level; }
+    [[nodiscard]] int GetLevel () const { return m_level; }
 
-    std::pair<int, int> GetPairIndex () const { return std::make_pair(this->index(), this->LocalTileIndex()); }
+    [[nodiscard]] std::pair<int, int> GetPairIndex () const { return std::make_pair(this->index(), this->LocalTileIndex()); }
 
-    const Geometry& Geom (int lev) const { return m_pc.Geom(lev); }
+    [[nodiscard]] const Geometry& Geom (int lev) const { return m_pc.Geom(lev); }
 
 protected:
 

--- a/Src/Particle/AMReX_Particle.H
+++ b/Src/Particle/AMReX_Particle.H
@@ -26,6 +26,10 @@ struct ParticleIDWrapper
 {
     uint64_t& m_idata;
 
+    ~ParticleIDWrapper () noexcept = default;
+    ParticleIDWrapper (ParticleIDWrapper&&) = delete;
+    ParticleIDWrapper& operator= (ParticleIDWrapper&&) = delete;
+
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     ParticleIDWrapper (uint64_t& idata) noexcept
         : m_idata(idata)
@@ -37,7 +41,7 @@ struct ParticleIDWrapper
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     ParticleIDWrapper& operator= (const ParticleIDWrapper& pidw) noexcept
     {
-        return this->operator=(Long(pidw));
+        return this->operator=(Long(pidw)); // NOLINT(cppcoreguidelines-c-copy-assignment-signature)
     }
 
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
@@ -84,6 +88,10 @@ struct ParticleCPUWrapper
 {
     uint64_t& m_idata;
 
+    ~ParticleCPUWrapper () noexcept = default;
+    ParticleCPUWrapper (ParticleCPUWrapper&&) = delete;
+    ParticleCPUWrapper& operator= (ParticleCPUWrapper&&) = delete;
+
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     ParticleCPUWrapper (uint64_t& idata) noexcept
         : m_idata(idata)
@@ -95,7 +103,7 @@ struct ParticleCPUWrapper
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     ParticleCPUWrapper& operator= (const ParticleCPUWrapper& pcpuw) noexcept
     {
-        return this->operator=(int(pcpuw));
+        return this->operator=(int(pcpuw));  // NOLINT(cppcoreguidelines-c-copy-assignment-signature)
     }
 
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
@@ -114,7 +122,7 @@ struct ParticleCPUWrapper
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     operator int () const noexcept
     {
-        return (m_idata & 0x00FFFFFF);
+        return static_cast<int>(m_idata & 0x00FFFFFF);
     }
 };
 
@@ -151,7 +159,7 @@ struct ConstParticleCPUWrapper
     {}
 
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-    operator int () const noexcept { return (m_idata & 0x00FFFFFF); }
+    operator int () const noexcept { return static_cast<int>(m_idata & 0x00FFFFFF); }
 };
 
 
@@ -208,16 +216,16 @@ struct Particle
 
     static Long the_next_id;
 
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     ParticleCPUWrapper cpu () & { return ParticleCPUWrapper(this->m_idcpu); }
 
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     ParticleIDWrapper id () & { return ParticleIDWrapper(this->m_idcpu); }
 
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     ConstParticleCPUWrapper cpu () const & { return ConstParticleCPUWrapper(this->m_idcpu); }
 
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     ConstParticleIDWrapper id () const & { return ConstParticleIDWrapper(this->m_idcpu); }
 
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
@@ -229,22 +237,22 @@ struct Particle
 #pragma omp atomic write
         this->m_idcpu = wrapper.m_idata;
 #else
-        auto old_ptr = reinterpret_cast<unsigned long long*>(&(this->m_idcpu));
+        auto *old_ptr = reinterpret_cast<unsigned long long*>(&(this->m_idcpu));
         amrex::Gpu::Atomic::Exch(old_ptr, (unsigned long long) wrapper.m_idata);
 #endif
     }
 
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     RealVect pos () const & {return RealVect(AMREX_D_DECL(this->m_pos[0], this->m_pos[1], this->m_pos[2]));}
 
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     RealType& pos (int index) &
     {
         AMREX_ASSERT(index < AMREX_SPACEDIM);
         return this->m_pos[index];
     }
 
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     RealType  pos (int index) const &
     {
         AMREX_ASSERT(index < AMREX_SPACEDIM);
@@ -252,7 +260,7 @@ struct Particle
     }
 
     template <int U = T_NReal, typename std::enable_if<U != 0, int>::type = 0>
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     RealType& rdata (int index) &
     {
         AMREX_ASSERT(index < NReal);
@@ -260,7 +268,7 @@ struct Particle
     }
 
     template <int U = T_NReal, typename std::enable_if<U == 0, int>::type = 0>
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     RealType& rdata (int /*index*/) &
     {
         AMREX_ALWAYS_ASSERT(false);
@@ -268,7 +276,7 @@ struct Particle
     }
 
     template <int U = T_NReal, typename std::enable_if<U != 0, int>::type = 0>
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     const RealType& rdata (int index) const &
     {
         AMREX_ASSERT(index < NReal);
@@ -276,7 +284,7 @@ struct Particle
     }
 
     template <int U = T_NReal, typename std::enable_if<U == 0, int>::type = 0>
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     RealType rdata (int /*index*/) const &
     {
         AMREX_ALWAYS_ASSERT(false);
@@ -287,7 +295,7 @@ struct Particle
     RealType rdata (int /*index*/) && = delete;
 
     template <int U = T_NReal, typename std::enable_if<U != 0, int>::type = 0>
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     RealVect rvec (AMREX_D_DECL(int indx, int indy, int indz)) const &
     {
         AMREX_ASSERT(AMREX_D_TERM(indx < NReal, && indy < NReal, && indz < NReal));
@@ -297,7 +305,7 @@ struct Particle
     }
 
     template <int U = T_NReal, typename std::enable_if<U == 0, int>::type = 0>
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     RealVect rvec (AMREX_D_DECL(int /*indx*/, int /*indy*/, int /*indz*/)) const &
     {
         AMREX_ALWAYS_ASSERT(false);
@@ -305,7 +313,7 @@ struct Particle
     }
 
     template <int U = T_NReal, typename std::enable_if<U != 0, int>::type = 0>
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     RealVect rvec (const IntVect& indices) const &
     {
         AMREX_ASSERT(indices.max() < NReal);
@@ -315,7 +323,7 @@ struct Particle
     }
 
     template <int U = T_NReal, typename std::enable_if<U == 0, int>::type = 0>
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     RealVect rvec (const IntVect& /*indices*/) const &
     {
         AMREX_ALWAYS_ASSERT(false);
@@ -323,7 +331,7 @@ struct Particle
     }
 
     template <int U = T_NInt, typename std::enable_if<U != 0, int>::type = 0>
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     int& idata (int index) &
     {
         AMREX_ASSERT(index < NInt);
@@ -339,7 +347,7 @@ struct Particle
     }
 
     template <int U = T_NInt, typename std::enable_if<U != 0, int>::type = 0>
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     const int& idata (int index) const &
     {
         AMREX_ASSERT(index < NInt);
@@ -347,7 +355,7 @@ struct Particle
     }
 
     template <int U = T_NInt, typename std::enable_if<U == 0, int>::type = 0>
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     int idata (int /*index*/) const &
     {
         AMREX_ALWAYS_ASSERT(false);
@@ -365,12 +373,12 @@ struct Particle
     * across all processors must be checkpointed and then restored on restart
     * so that we don't reuse particle IDs.
     */
-    static Long NextID ();
+    [[nodiscard]] static Long NextID ();
 
     /**
     * \brief This version can only be used inside omp critical.
     */
-    static Long UnprotectedNextID ();
+    [[nodiscard]] static Long UnprotectedNextID ();
 
     /**
     * \brief Reset on restart.

--- a/Src/Particle/AMReX_ParticleBufferMap.H
+++ b/Src/Particle/AMReX_ParticleBufferMap.H
@@ -51,7 +51,7 @@ struct GetBucket
 
 class ParticleBufferMap
 {
-    bool m_defined;
+    bool m_defined{false};
     Vector<BoxArray> m_ba;
     Vector<DistributionMapping> m_dm;
 
@@ -70,9 +70,7 @@ class ParticleBufferMap
     Gpu::DeviceVector<int> d_lev_offsets;
 
 public:
-    ParticleBufferMap ()
-        : m_defined(false), m_ba(), m_dm()
-        {}
+    ParticleBufferMap () = default;
 
     ParticleBufferMap (const ParGDBBase* a_gdb);
 
@@ -80,63 +78,63 @@ public:
 
     bool isValid (const ParGDBBase* a_gdb) const;
 
-    AMREX_FORCE_INLINE
+    [[nodiscard]] AMREX_FORCE_INLINE
     int numLevels () const
     {
         AMREX_ASSERT(m_defined);
-        return m_lev_offsets.size()-1;
+        return static_cast<int>(m_lev_offsets.size()-1);
     }
 
-    AMREX_FORCE_INLINE
+    [[nodiscard]] AMREX_FORCE_INLINE
     int numBuckets () const
     {
         AMREX_ASSERT(m_defined);
-        return m_bucket_to_gid.size();
+        return static_cast<int>(m_bucket_to_gid.size());
     }
 
-    AMREX_FORCE_INLINE
+    [[nodiscard]] AMREX_FORCE_INLINE
     int bucketToGrid (int bid) const
     {
         AMREX_ASSERT(m_defined);
         return m_bucket_to_gid[bid];
     }
 
-    AMREX_FORCE_INLINE
+    [[nodiscard]] AMREX_FORCE_INLINE
     int bucketToLevel (int bid) const
     {
         AMREX_ASSERT(m_defined);
         return m_bucket_to_lev[bid];
     }
 
-    AMREX_FORCE_INLINE
+    [[nodiscard]] AMREX_FORCE_INLINE
     int bucketToProc (int bid) const
     {
         AMREX_ASSERT(m_defined);
         return m_bucket_to_pid[bid];
     }
 
-    AMREX_FORCE_INLINE
+    [[nodiscard]] AMREX_FORCE_INLINE
     int gridAndLevToBucket (int gid, int lev) const
     {
         AMREX_ASSERT(m_defined);
         return m_lev_gid_to_bucket[m_lev_offsets[lev] + gid];
     }
 
-    AMREX_FORCE_INLINE
+    [[nodiscard]] AMREX_FORCE_INLINE
     int firstBucketOnProc (int pid) const
     {
         AMREX_ASSERT(m_defined);
         return m_proc_box_offsets[pid];
     }
 
-    AMREX_FORCE_INLINE
+    [[nodiscard]] AMREX_FORCE_INLINE
     int numBoxesOnProc (int pid) const
     {
         AMREX_ASSERT(m_defined);
         return m_proc_box_counts[pid];
     }
 
-    AMREX_FORCE_INLINE
+    [[nodiscard]] AMREX_FORCE_INLINE
     Vector<int> allBucketsOnProc (int pid) const
     {
         AMREX_ASSERT(m_defined);
@@ -148,15 +146,15 @@ public:
         return buckets;
     }
 
-    AMREX_FORCE_INLINE
+    [[nodiscard]] AMREX_FORCE_INLINE
     int procID (int gid, int lev) const
     {
         AMREX_ASSERT(m_defined);
         return m_dm[lev][gid];
     }
 
-    GetPID getPIDFunctor () const noexcept { return GetPID(d_bucket_to_pid, d_lev_gid_to_bucket, d_lev_offsets);}
-    GetBucket getBucketFunctor () const noexcept { return GetBucket(d_lev_gid_to_bucket, d_lev_offsets);}
+    [[nodiscard]] GetPID getPIDFunctor () const noexcept { return GetPID(d_bucket_to_pid, d_lev_gid_to_bucket, d_lev_offsets);}
+    [[nodiscard]] GetBucket getBucketFunctor () const noexcept { return GetBucket(d_lev_gid_to_bucket, d_lev_offsets);}
 };
 
 } // namespace amrex

--- a/Src/Particle/AMReX_ParticleBufferMap.cpp
+++ b/Src/Particle/AMReX_ParticleBufferMap.cpp
@@ -26,8 +26,9 @@ void ParticleBufferMap::define (const ParGDBBase* a_gdb)
 
     m_lev_offsets.resize(0);
     m_lev_offsets.push_back(0);
-    for (int lev = 0; lev < num_levels; ++lev)
-        m_lev_offsets.push_back(m_lev_offsets.back() + m_ba[lev].size());
+    for (int lev = 0; lev < num_levels; ++lev) {
+        m_lev_offsets.push_back(m_lev_offsets.back() +static_cast<int>( m_ba[lev].size()));
+    }
 
     int num_buckets = m_lev_offsets.back();
 
@@ -47,7 +48,7 @@ void ParticleBufferMap::define (const ParGDBBase* a_gdb)
     for (int lev = 0; lev < num_levels; ++lev) {
         for (int i = 0; i < m_ba[lev].size(); ++i) {
             int rank = ParallelContext::global_to_local_rank(m_dm[lev][i]);
-            box_lev_proc_ids.push_back(std::make_tuple(i, lev, rank));
+            box_lev_proc_ids.emplace_back(i, lev, rank);
         }
     }
 

--- a/Src/Particle/AMReX_ParticleCommunication.H
+++ b/Src/Particle/AMReX_ParticleCommunication.H
@@ -249,12 +249,12 @@ private:
     // In the global version, we don't know who we'll receive from, so we
     // need to do some collective communication first.
     //
-    void doHandShakeGlobal (const Vector<Long>& Snds, Vector<Long>& Rcvs) const;
+    static void doHandShakeGlobal (const Vector<Long>& Snds, Vector<Long>& Rcvs);
 
     //
     // Another version of the above that is implemented using MPI All-to-All
     //
-    void doHandShakeAllToAll (const Vector<Long>& Snds, Vector<Long>& Rcvs) const;
+    static void doHandShakeAllToAll (const Vector<Long>& Snds, Vector<Long>& Rcvs);
 
     bool m_local;
 };

--- a/Src/Particle/AMReX_ParticleCommunication.cpp
+++ b/Src/Particle/AMReX_ParticleCommunication.cpp
@@ -52,7 +52,7 @@ void ParticleCopyPlan::buildMPIStart (const ParticleBufferMap& map, Long psize)
 #ifdef AMREX_USE_MPI
     const int NProcs = ParallelContext::NProcsSub();
     const int MyProc = ParallelContext::MyProcSub();
-    const int NNeighborProcs = m_neighbor_procs.size();
+    const int NNeighborProcs = static_cast<int>(m_neighbor_procs.size());
 
     if (NProcs == 1) return;
 
@@ -135,7 +135,7 @@ void ParticleCopyPlan::buildMPIStart (const ParticleBufferMap& map, Long psize)
         }
     }
 
-    m_nrcvs = m_RcvProc.size();
+    m_nrcvs = static_cast<int>(m_RcvProc.size());
 
     m_build_stats.resize(0);
     m_build_stats.resize(m_nrcvs);
@@ -183,7 +183,7 @@ void ParticleCopyPlan::buildMPIStart (const ParticleBufferMap& map, Long psize)
     {
         Long nbytes = m_snd_num_particles[i]*psize;
         std::size_t acd = ParallelDescriptor::alignof_comm_data(nbytes);
-        Long Cnt = amrex::aligned_size(acd, nbytes);
+        auto Cnt = static_cast<Long>(amrex::aligned_size(acd, nbytes));
         Long bytes_to_send = (i == MyProc) ? 0 : Cnt;
         m_snd_counts.push_back(bytes_to_send);
         m_snd_offsets.push_back(amrex::aligned_size(acd, m_snd_offsets.back()) + Cnt);
@@ -225,7 +225,7 @@ void ParticleCopyPlan::buildMPIFinish (const ParticleBufferMap& map)
         m_rcv_box_pids.resize(0);
 
         m_rcv_box_offsets.push_back(0);
-        for (int i = 0, N = m_rcv_data.size(); i < N; i+=4)
+        for (int i = 0, N = static_cast<int>(m_rcv_data.size()); i < N; i+=4)
         {
             m_rcv_box_counts.push_back(m_rcv_data[i]);
             AMREX_ASSERT(ParallelContext::MyProcSub() == map.procID(m_rcv_data[i+1], m_rcv_data[i+2]));
@@ -263,7 +263,7 @@ void ParticleCopyPlan::doHandShakeLocal (const Vector<Long>& Snds, Vector<Long>&
 {
 #ifdef AMREX_USE_MPI
     const int SeqNum = ParallelDescriptor::SeqNum();
-    const int num_rcvs = m_neighbor_procs.size();
+    const auto num_rcvs = static_cast<int>(m_neighbor_procs.size());
     Vector<MPI_Status>  stats(num_rcvs);
     Vector<MPI_Request> rreqs(num_rcvs);
 
@@ -300,7 +300,7 @@ void ParticleCopyPlan::doHandShakeLocal (const Vector<Long>& Snds, Vector<Long>&
 #endif
 }
 
-void ParticleCopyPlan::doHandShakeAllToAll (const Vector<Long>& Snds, Vector<Long>& Rcvs) const
+void ParticleCopyPlan::doHandShakeAllToAll (const Vector<Long>& Snds, Vector<Long>& Rcvs)
 {
 #ifdef AMREX_USE_MPI
     BL_COMM_PROFILE(BLProfiler::Alltoall, sizeof(Long),
@@ -323,7 +323,7 @@ void ParticleCopyPlan::doHandShakeAllToAll (const Vector<Long>& Snds, Vector<Lon
 #endif
 }
 
-void ParticleCopyPlan::doHandShakeGlobal (const Vector<Long>& Snds, Vector<Long>& Rcvs) const
+void ParticleCopyPlan::doHandShakeGlobal (const Vector<Long>& Snds, Vector<Long>& Rcvs)
 {
 #ifdef AMREX_USE_MPI
     const int SeqNum = ParallelDescriptor::SeqNum();
@@ -342,7 +342,7 @@ void ParticleCopyPlan::doHandShakeGlobal (const Vector<Long>& Snds, Vector<Long>
     Vector<MPI_Request> rreqs(num_rcvs);
 
     Vector<Long> num_bytes_rcv(num_rcvs);
-    for (int i = 0; i < num_rcvs; ++i)
+    for (int i = 0; i < static_cast<int>(num_rcvs); ++i)
     {
         MPI_Irecv( &num_bytes_rcv[i], 1, ParallelDescriptor::Mpi_typemap<Long>::type(),
                    MPI_ANY_SOURCE, SeqNum, ParallelContext::CommunicatorSub(), &rreqs[i] );
@@ -355,7 +355,7 @@ void ParticleCopyPlan::doHandShakeGlobal (const Vector<Long>& Snds, Vector<Long>
                   ParallelContext::CommunicatorSub());
     }
 
-    MPI_Waitall(num_rcvs, rreqs.data(), stats.data());
+    MPI_Waitall(static_cast<int>(num_rcvs), rreqs.data(), stats.data());
 
     for (int i = 0; i < num_rcvs; ++i)
     {

--- a/Src/Particle/AMReX_ParticleContainer.H
+++ b/Src/Particle/AMReX_ParticleContainer.H
@@ -191,10 +191,7 @@ public:
       :
       ParticleContainerBase(),
       h_redistribute_real_comp(AMREX_SPACEDIM + NStructReal + NArrayReal, true),
-      h_redistribute_int_comp(2 + NStructInt + NArrayInt, true),
-      m_runtime_comps_defined(false),
-      m_num_runtime_real(0),
-      m_num_runtime_int(0)
+      h_redistribute_int_comp(2 + NStructInt + NArrayInt, true)
     {
         Initialize ();
     }
@@ -210,10 +207,7 @@ public:
         :
         ParticleContainerBase(gdb),
         h_redistribute_real_comp(AMREX_SPACEDIM + NStructReal + NArrayReal, true),
-        h_redistribute_int_comp(2 + NStructInt + NArrayInt, true),
-        m_runtime_comps_defined(false),
-        m_num_runtime_real(0),
-        m_num_runtime_int(0)
+        h_redistribute_int_comp(2 + NStructInt + NArrayInt, true)
     {
         Initialize ();
         reserveData();
@@ -233,10 +227,7 @@ public:
         :
         ParticleContainerBase(geom, dmap, ba),
         h_redistribute_real_comp(AMREX_SPACEDIM + NStructReal + NArrayReal, true),
-        h_redistribute_int_comp(2 + NStructInt + NArrayInt, true),
-        m_runtime_comps_defined(false),
-        m_num_runtime_real(0),
-        m_num_runtime_int(0)
+        h_redistribute_int_comp(2 + NStructInt + NArrayInt, true)
     {
         Initialize ();
         reserveData();
@@ -259,10 +250,7 @@ public:
         :
         ParticleContainerBase(geom, dmap, ba, rr),
         h_redistribute_real_comp(AMREX_SPACEDIM + NStructReal + NArrayReal, true),
-        h_redistribute_int_comp(2 + NStructInt + NArrayInt, true),
-        m_runtime_comps_defined(false),
-        m_num_runtime_real(0),
-        m_num_runtime_int(0)
+        h_redistribute_int_comp(2 + NStructInt + NArrayInt, true)
     {
         Initialize ();
         reserveData();
@@ -284,23 +272,20 @@ public:
         :
         ParticleContainerBase(geom, dmap, ba, rr),
         h_redistribute_real_comp(AMREX_SPACEDIM + NStructReal + NArrayReal, true),
-        h_redistribute_int_comp(2 + NStructInt + NArrayInt, true),
-        m_runtime_comps_defined(false),
-        m_num_runtime_real(0),
-        m_num_runtime_int(0)
+        h_redistribute_int_comp(2 + NStructInt + NArrayInt, true)
     {
         Initialize ();
         reserveData();
         resizeData();
     }
 
-    virtual ~ParticleContainer () = default;
+    ~ParticleContainer () override = default;
 
     ParticleContainer ( const ParticleContainer &) = delete;
     ParticleContainer& operator= ( const ParticleContainer & ) = delete;
 
-    ParticleContainer ( ParticleContainer && ) = default;
-    ParticleContainer& operator= ( ParticleContainer && ) = default;
+    ParticleContainer ( ParticleContainer && )  noexcept = default;
+    ParticleContainer& operator= ( ParticleContainer && )  noexcept = default;
 
 
     //! \brief Define a default-constructed ParticleContainer using a ParGDB object.
@@ -403,7 +388,7 @@ public:
     * \param bx
     */
     void InitRandom (Long icount, ULong iseed,
-                     const ParticleInitData& mass,
+                     const ParticleInitData& pdata,
                      bool serialize = false, RealBox bx = RealBox());
 
 
@@ -1388,9 +1373,9 @@ private:
 
     void Initialize ();
 
-    bool m_runtime_comps_defined;
-    int m_num_runtime_real;
-    int m_num_runtime_int;
+    bool m_runtime_comps_defined{false};
+    int m_num_runtime_real{0};
+    int m_num_runtime_int{0};
 
     size_t particle_size, superparticle_size;
     int num_real_comm_comps, num_int_comm_comps;

--- a/Src/Particle/AMReX_ParticleContainerBase.H
+++ b/Src/Particle/AMReX_ParticleContainerBase.H
@@ -23,15 +23,10 @@ class ParticleContainerBase
 {
 public:
 
-    ParticleContainerBase ()
-        :
-        m_verbose(0),
-        m_gdb(nullptr)
-    {}
+    ParticleContainerBase () = default;
 
     ParticleContainerBase (ParGDBBase* gdb)
         :
-        m_verbose(0),
         m_gdb(gdb)
     {}
 
@@ -39,7 +34,6 @@ public:
                            const DistributionMapping & dmap,
                            const BoxArray            & ba)
         :
-        m_verbose(0),
         m_gdb_object(geom,dmap,ba)
     {
         m_gdb = &m_gdb_object;
@@ -50,7 +44,6 @@ public:
                            const Vector<BoxArray>            & ba,
                            const Vector<int>                 & rr)
         :
-        m_verbose(0),
         m_gdb_object(geom,dmap,ba,rr)
     {
         m_gdb = &m_gdb_object;
@@ -61,7 +54,6 @@ public:
                            const Vector<BoxArray>            & ba,
                            const Vector<IntVect>             & rr)
         :
-        m_verbose(0),
         m_gdb_object(geom,dmap,ba, [&]() -> Vector<int> {
                 Vector<int> ref_ratio;
                 for (int i = 0; i < static_cast<int>(rr.size()); ++i)
@@ -234,7 +226,7 @@ public:
     //! \brief Get the ParGDB object used to define this container
     ParGDBBase* GetParGDB ()       { return m_gdb; }
 
-    int Verbose () { return m_verbose; }
+    int Verbose () const { return m_verbose; }
 
     void SetVerbose (int verbose) { m_verbose = verbose; }
 
@@ -266,8 +258,8 @@ protected:
     void BuildRedistributeMask (int lev, int nghost=1) const;
     void defineBufferMap () const;
 
-    int         m_verbose;
-    ParGDBBase* m_gdb;
+    int         m_verbose{0};
+    ParGDBBase* m_gdb{nullptr};
     ParGDB      m_gdb_object;
     Vector<std::unique_ptr<MultiFab> > m_dummy_mf;
 

--- a/Src/Particle/AMReX_ParticleContainerBase.cpp
+++ b/Src/Particle/AMReX_ParticleContainerBase.cpp
@@ -280,7 +280,7 @@ void ParticleContainerBase::BuildRedistributeMask (int lev, int nghost) const
         redistribute_mask_ptr = std::make_unique<iMultiFab>(ba, dmap, 2, nghost);
         redistribute_mask_ptr->setVal(-1, nghost);
 
-        const auto tile_size_do = this->do_tiling ? this->tile_size : IntVect::TheZeroVector();
+        const auto tile_size_do = amrex::ParticleContainerBase::do_tiling ? amrex::ParticleContainerBase::tile_size : IntVect::TheZeroVector();
 
 #ifdef AMREX_USE_OMP
 #pragma omp parallel

--- a/Src/Particle/AMReX_ParticleContainerI.H
+++ b/Src/Particle/AMReX_ParticleContainerI.H
@@ -124,15 +124,15 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>
           ba.intersections(Box(iv, iv), isects, findfirst, nGrow);
           grid = isects.empty() ? -1 : isects[0].first;
           if (nGrow > 0 && isects.size() > 1) {
-             for (std::size_t n = 0; n < isects.size(); ++n) {
-                 Box bx = ba.getCellCenteredBox(isects[n].first);
+             for (auto & isect : isects) {
+                 Box bx = ba.getCellCenteredBox(isect.first);
                  for (int dir = 0; dir < AMREX_SPACEDIM; ++dir) {
                      Box gbx = bx;
                      IntVect gr(IntVect::TheZeroVector());
                      gr[dir] = nGrow;
                      gbx.grow(gr);
                      if (gbx.contains(iv)) {
-                        grid = isects[n].first;
+                        grid = isect.first;
                      }
                  }
              }
@@ -836,7 +836,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>
         const auto imf_arr = imf.array(mfi);
 
         Gpu::DeviceVector<int> offsets(bx.numPts());
-        auto offsets_ptr = offsets.dataPtr();
+        auto *offsets_ptr = offsets.dataPtr();
         int next_offset = Scan::ExclusiveSum((int) bx.numPts(),(imf_arr.ptr(bx.smallEnd(),0)),(offsets.dataPtr()),Scan::retSum);
         auto dst = virts.getParticleTileData();
         ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k)
@@ -1782,7 +1782,7 @@ RedistributeMPI (std::map<int, Vector<char> >& not_ours,
     std::map<int, Vector<buffer_type> > mpi_snd_data;
     for (const auto& kv : not_ours)
     {
-        int nbt = (kv.second.size() + sizeof(buffer_type)-1)/sizeof(buffer_type);
+        auto nbt = (kv.second.size() + sizeof(buffer_type)-1)/sizeof(buffer_type);
         mpi_snd_data[kv.first].resize(nbt);
         std::memcpy((char*) mpi_snd_data[kv.first].data(), kv.second.data(), kv.second.size());
     }
@@ -1834,12 +1834,12 @@ RedistributeMPI (std::map<int, Vector<char> >& not_ours,
             RcvProc.push_back(i);
             rOffset.push_back(TotRcvInts);
             TotRcvBytes += Rcvs[i];
-            int nbt = (Rcvs[i] + sizeof(buffer_type)-1)/sizeof(buffer_type);
+            auto nbt = (Rcvs[i] + sizeof(buffer_type)-1)/sizeof(buffer_type);
             TotRcvInts += nbt;
         }
     }
 
-    const int nrcvs = RcvProc.size();
+    const auto nrcvs = static_cast<int>(RcvProc.size());
     Vector<MPI_Status>  stats(nrcvs);
     Vector<MPI_Request> rreqs(nrcvs);
 

--- a/Src/Particle/AMReX_ParticleIO.H
+++ b/Src/Particle/AMReX_ParticleIO.H
@@ -755,7 +755,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>
     if (dual_grid) {
         for (int lev = 0; lev <= finestLevel(); lev++) {
             // this can happen if there are no particles at a given level in the checkpoint
-            if (particle_box_arrays[lev].size() == 0) {
+            if (particle_box_arrays[lev].empty()) {
                 particle_box_arrays[lev] = BoxArray(Geom(lev).Domain());
             }
             SetParticleBoxArray(lev, particle_box_arrays[lev]);

--- a/Src/Particle/AMReX_ParticleLocator.H
+++ b/Src/Particle/AMReX_ParticleLocator.H
@@ -24,7 +24,7 @@ struct AssignGrid
     GpuArray<Real, AMREX_SPACEDIM> m_dxi;
 
     AMREX_GPU_HOST_DEVICE
-    AssignGrid () {}
+    AssignGrid () = default;
 
     AssignGrid (BinIteratorFactory a_bif,
                 const IntVect& a_bins_lo, const IntVect& a_bins_hi, const IntVect& a_bin_size,
@@ -103,14 +103,14 @@ public:
 
     using BinIteratorFactory = typename Bins::BinIteratorFactory;
 
-    ParticleLocator () : m_defined(false) {}
+    ParticleLocator ()  = default;
 
     void build (const BoxArray& ba, const Geometry& geom)
     {
         m_defined = true;
         m_ba = ba;
         m_geom = geom;
-        int num_boxes = ba.size();
+        int num_boxes = static_cast<int>(ba.size());
         m_host_boxes.resize(0);
         for (int i = 0; i < num_boxes; ++i) m_host_boxes.push_back(ba[i]);
 
@@ -126,7 +126,7 @@ public:
                    AMREX_D_DECL(int, int, int)> reduce_data(reduce_op);
         using ReduceTuple = typename decltype(reduce_data)::Type;
 
-        const auto boxes_ptr = m_device_boxes.dataPtr();
+        auto *const boxes_ptr = m_device_boxes.dataPtr();
         reduce_op.eval(num_boxes, reduce_data,
         [=] AMREX_GPU_DEVICE (int i) -> ReduceTuple
         {
@@ -184,7 +184,7 @@ public:
 
 protected:
 
-    bool m_defined;
+    bool m_defined{false};
 
     BoxArray m_ba;
     Geometry m_geom;
@@ -246,7 +246,7 @@ private:
 
 public:
 
-    AmrParticleLocator() {}
+    AmrParticleLocator() = default;
 
     AmrParticleLocator(const Vector<BoxArray>& a_ba,
                        const Vector<Geometry>& a_geom)
@@ -263,7 +263,7 @@ public:
                 const Vector<Geometry>& a_geom)
     {
         m_defined = true;
-        int num_levels = a_ba.size();
+        int num_levels = static_cast<int>(a_ba.size());
         m_locators.resize(num_levels);
         m_grid_assignors.resize(num_levels);
 #ifdef AMREX_USE_GPU
@@ -298,9 +298,9 @@ public:
         build(ba, geom);
     }
 
-    bool isValid (const Vector<BoxArray>& a_ba) const
+    [[nodiscard]] bool isValid (const Vector<BoxArray>& a_ba) const
     {
-        if ( !m_defined || (m_locators.size() == 0) ||
+        if ( !m_defined || (m_locators.empty()) ||
              (m_locators.size() != a_ba.size()) ) return false;
         bool all_valid = true;
         int num_levels = m_locators.size();
@@ -340,7 +340,7 @@ public:
 #endif
     }
 
-    AmrAssignGrid<BinIteratorFactory> getGridAssignor () const noexcept
+    [[nodiscard]] AmrAssignGrid<BinIteratorFactory> getGridAssignor () const noexcept
     {
         AMREX_ASSERT(m_defined);
         return AmrAssignGrid<BinIteratorFactory>(m_grid_assignors.dataPtr(), m_locators.size());

--- a/Src/Particle/AMReX_ParticleMPIUtil.cpp
+++ b/Src/Particle/AMReX_ParticleMPIUtil.cpp
@@ -60,7 +60,7 @@ namespace amrex {
 
         const int SeqNum = ParallelDescriptor::SeqNum();
 
-        const int num_rcvs = neighbor_procs.size();
+        const int num_rcvs = static_cast<int>(neighbor_procs.size());
         Vector<MPI_Status>  stats(num_rcvs);
         Vector<MPI_Request> rreqs(num_rcvs);
 

--- a/Src/Particle/AMReX_ParticleUtil.cpp
+++ b/Src/Particle/AMReX_ParticleUtil.cpp
@@ -44,9 +44,9 @@ Vector<int> computeNeighborProcs (const ParGDBBase* a_gdb, int ngrow)
                 const std::vector<IntVect>& pshifts = periodicity.shiftIntVect();
                 const BoxArray& ba = a_gdb->ParticleBoxArray(lev);
 
-                for (auto pit=pshifts.cbegin(); pit!=pshifts.cend(); ++pit)
+                for (auto pshift : pshifts)
                 {
-                    const Box& pbox = box + (*pit);
+                    const Box& pbox = box + pshift;
                     bool first_only = false;
                     ba.intersections(pbox, isects, first_only, 0);
                     for (const auto& isec : isects)

--- a/Src/Particle/AMReX_StructOfArrays.H
+++ b/Src/Particle/AMReX_StructOfArrays.H
@@ -17,11 +17,6 @@ struct StructOfArrays {
     using RealVector = amrex::PODVector<ParticleReal, Allocator<ParticleReal> >;
     using IntVector = amrex::PODVector<int, Allocator<int> >;
 
-    StructOfArrays()
-        : m_num_neighbor_particles(0),
-          m_defined(false)
-        {}
-
     void define (int a_num_runtime_real, int a_num_runtime_int)
     {
         m_defined = true;
@@ -29,17 +24,17 @@ struct StructOfArrays {
         m_runtime_idata.resize(a_num_runtime_int );
     }
 
-    int NumRealComps () const noexcept { return NReal + m_runtime_rdata.size(); }
+    [[nodiscard]] int NumRealComps () const noexcept { return NReal + m_runtime_rdata.size(); }
 
-    int NumIntComps () const noexcept { return NInt + m_runtime_idata.size(); }
+    [[nodiscard]] int NumIntComps () const noexcept { return NInt + m_runtime_idata.size(); }
 
-    std::array<RealVector, NReal>& GetRealData () { return m_rdata; }
-    std::array< IntVector,  NInt>& GetIntData  () { return m_idata; }
+    [[nodiscard]] std::array<RealVector, NReal>& GetRealData () { return m_rdata; }
+    [[nodiscard]] std::array< IntVector,  NInt>& GetIntData  () { return m_idata; }
 
-    const std::array<RealVector, NReal>& GetRealData () const { return m_rdata; }
-    const std::array< IntVector,  NInt>& GetIntData  () const { return m_idata; }
+    [[nodiscard]] const std::array<RealVector, NReal>& GetRealData () const { return m_rdata; }
+    [[nodiscard]] const std::array< IntVector,  NInt>& GetIntData  () const { return m_idata; }
 
-    RealVector& GetRealData (const int index) {
+    [[nodiscard]] RealVector& GetRealData (const int index) {
         AMREX_ASSERT(index >= 0 && index < NReal + static_cast<int>(m_runtime_rdata.size()));
         if (index >= 0 && index < NReal) return m_rdata[index];
         else {
@@ -48,7 +43,7 @@ struct StructOfArrays {
         }
     }
 
-    const RealVector& GetRealData (const int index) const {
+    [[nodiscard]] const RealVector& GetRealData (const int index) const {
         AMREX_ASSERT(index >= 0 && index < NReal + static_cast<int>(m_runtime_rdata.size()));
         if (index >= 0 && index < NReal) return m_rdata[index];
         else {
@@ -57,7 +52,7 @@ struct StructOfArrays {
         }
     }
 
-    IntVector& GetIntData (const int index) {
+    [[nodiscard]] IntVector& GetIntData (const int index) {
         AMREX_ASSERT(index >= 0 && index < NInt + static_cast<int>(m_runtime_idata.size()));
         if (index >= 0 && index < NInt) return m_idata[index];
         else {
@@ -66,7 +61,7 @@ struct StructOfArrays {
         }
    }
 
-    const IntVector& GetIntData (const int index) const {
+    [[nodiscard]] const IntVector& GetIntData (const int index) const {
         AMREX_ASSERT(index >= 0 && index < NInt + static_cast<int>(m_runtime_idata.size()));
         if (index >= 0 && index < NInt) return m_idata[index];
         else {
@@ -79,15 +74,15 @@ struct StructOfArrays {
     * \brief Returns the total number of particles (real and neighbor)
     *
     */
-    std::size_t size () const
+    [[nodiscard]] std::size_t size () const
     {
         if (NReal > 0)
             return m_rdata[0].size();
         else if (NInt > 0)
             return m_idata[0].size();
-        else if (m_runtime_rdata.size() > 0)
+        else if (!m_runtime_rdata.empty())
             return m_runtime_rdata[0].size();
-        else if (m_runtime_idata.size() > 0)
+        else if (!m_runtime_idata.empty())
             return m_runtime_idata[0].size();
         else
             return 0;
@@ -97,25 +92,25 @@ struct StructOfArrays {
     * \brief Returns the number of real particles (excluding neighbors)
     *
     */
-    int numParticles () const { return numRealParticles(); }
+    [[nodiscard]] int numParticles () const { return numRealParticles(); }
 
     /**
     * \brief Returns the number of real particles (excluding neighbors)
     *
     */
-    int numRealParticles () const { return numTotalParticles()-m_num_neighbor_particles; }
+    [[nodiscard]] int numRealParticles () const { return numTotalParticles()-m_num_neighbor_particles; }
 
     /**
     * \brief Returns the number of neighbor particles (excluding reals)
     *
     */
-    int numNeighborParticles () const { return m_num_neighbor_particles; }
+    [[nodiscard]] int numNeighborParticles () const { return m_num_neighbor_particles; }
 
     /**
     * \brief Returns the total number of particles (real and neighbor)
     *
     */
-    int numTotalParticles () const { return size(); }
+    [[nodiscard]] int numTotalParticles () const { return size(); }
 
     void setNumNeighbors (int num_neighbors)
     {
@@ -124,7 +119,7 @@ struct StructOfArrays {
         resize(nrp + num_neighbors);
     }
 
-    int getNumNeighbors () { return m_num_neighbor_particles; }
+    [[nodiscard]] int getNumNeighbors () { return m_num_neighbor_particles; }
 
     void resize (size_t count)
     {
@@ -134,7 +129,7 @@ struct StructOfArrays {
         for (int i = 0; i < int(m_runtime_idata.size()); ++i) m_runtime_idata[i].resize(count);
     }
 
-    GpuArray<ParticleReal*, NReal> realarray ()
+    [[nodiscard]] GpuArray<ParticleReal*, NReal> realarray ()
     {
         GpuArray<Real*, NReal> arr;
         for (int i = 0; i < NReal; ++i)
@@ -144,7 +139,7 @@ struct StructOfArrays {
         return arr;
     }
 
-    GpuArray<int*, NInt> intarray ()
+    [[nodiscard]] GpuArray<int*, NInt> intarray ()
     {
         GpuArray<int*, NInt> arr;
         for (int i = 0; i < NInt; ++i)
@@ -154,7 +149,7 @@ struct StructOfArrays {
         return arr;
     }
 
-    int m_num_neighbor_particles;
+    int m_num_neighbor_particles{0};
 
 private:
     std::array<RealVector, NReal> m_rdata;
@@ -163,7 +158,7 @@ private:
     std::vector<RealVector> m_runtime_rdata;
     std::vector<IntVector > m_runtime_idata;
 
-    bool m_defined;
+    bool m_defined{false};
 };
 
 } // namespace amrex

--- a/Src/Particle/AMReX_TracerParticles.H
+++ b/Src/Particle/AMReX_TracerParticles.H
@@ -21,7 +21,7 @@ public:
         : ParticleContainer<AMREX_SPACEDIM>(geom,dmap,ba)
         {}
 
-    ~TracerParticleContainer () {}
+    ~TracerParticleContainer () override = default;
 
     TracerParticleContainer ( const TracerParticleContainer &) = delete;
     TracerParticleContainer& operator= ( const TracerParticleContainer & ) = delete;
@@ -33,8 +33,8 @@ public:
 
     void AdvectWithUcc (const MultiFab& ucc, int level, Real dt);
 
-    void Timestamp (const std::string& file, const MultiFab& mf, int lev, Real time,
-                    const std::vector<int>& idx);
+    void Timestamp (const std::string& basename, const MultiFab& mf, int lev, Real time,
+                    const std::vector<int>& indices);
 };
 
 using TracerParIter = ParIter<AMREX_SPACEDIM>;

--- a/Src/Particle/AMReX_TracerParticles.cpp
+++ b/Src/Particle/AMReX_TracerParticles.cpp
@@ -60,7 +60,7 @@ TracerParticleContainer::AdvectWithUmac (MultiFab* umac, int lev, Real dt)
             auto& ptile = ParticlesAt(lev, pti);
             auto& aos  = ptile.GetArrayOfStructs();
             const int n = aos.numParticles();
-            auto p_pbox = aos().data();
+            auto *p_pbox = aos().data();
             const FArrayBox* fab[AMREX_SPACEDIM] = { AMREX_D_DECL(&((*umac_pointer[0])[grid]),
                                                                   &((*umac_pointer[1])[grid]),
                                                                   &((*umac_pointer[2])[grid])) };
@@ -147,7 +147,7 @@ TracerParticleContainer::AdvectWithUcc (const MultiFab& Ucc, int lev, Real dt)
             const int n          = aos.numParticles();
             const FArrayBox& fab = Ucc[grid];
             const auto uccarr = fab.array();
-            auto  p_pbox = aos().data();
+            auto *  p_pbox = aos().data();
 
             amrex::ParallelFor(n,
                                [=] AMREX_GPU_DEVICE (int i)
@@ -243,7 +243,7 @@ TracerParticleContainer::Timestamp (const std::string&      basename,
             bool gotwork = false;
 
             const auto& pmap = GetParticles(lev);
-            for (auto& kv : pmap) {
+            for (const auto& kv : pmap) {
               const auto& pbox = kv.second.GetArrayOfStructs();
               for (int k = 0; k < pbox.numParticles(); ++k)
               {
@@ -277,12 +277,12 @@ TracerParticleContainer::Timestamp (const std::string&      basename,
                 if (!TimeStampFile.good())
                     amrex::FileOpenFailed(FileName);
 
-                const int       M  = indices.size();
+                const auto M  = static_cast<int>(indices.size());
                 const BoxArray& ba = mf.boxArray();
 
                 std::vector<ParticleReal> vals(M);
 
-                for (auto& kv : pmap) {
+                for (const auto& kv : pmap) {
                   int grid = kv.first.first;
                   const auto& pbox = kv.second.GetArrayOfStructs();
                   const Box&       bx   = ba[grid];

--- a/Src/Particle/AMReX_WriteBinaryParticleData.H
+++ b/Src/Particle/AMReX_WriteBinaryParticleData.H
@@ -505,7 +505,7 @@ void WriteBinaryParticleDataSync (PC const& pc,
         {
             if ( ! LevelDir.empty() && LevelDir[LevelDir.size()-1] != '/') LevelDir += '/';
 
-            LevelDir = amrex::Concatenate(LevelDir + "Level_", lev, 1);
+            LevelDir = amrex::Concatenate(LevelDir.append("Level_"), lev, 1);
 
             if ( ! pc.GetLevelDirectoriesCreated())
             {
@@ -553,7 +553,7 @@ void WriteBinaryParticleDataSync (PC const& pc,
         {
             for(NFilesIter nfi(nOutFiles, filePrefix, groupSets, setBuf); nfi.ReadyToWrite(); ++nfi)
             {
-                std::ofstream& myStream = (std::ofstream&) nfi.Stream();
+                auto& myStream = (std::ofstream&) nfi.Stream();
                 pc.WriteParticles(lev, myStream, nfi.FileNumber(), which, count, where,
                                   write_real_comp, write_int_comp, particle_io_flags, is_checkpoint);
             }
@@ -563,9 +563,9 @@ void WriteBinaryParticleDataSync (PC const& pc,
                 pc.countPrePost[lev] = count;
                 pc.wherePrePost[lev] = where;
             } else {
-                ParallelDescriptor::ReduceIntSum (which.dataPtr(), which.size(), IOProcNumber);
-                ParallelDescriptor::ReduceIntSum (count.dataPtr(), count.size(), IOProcNumber);
-                ParallelDescriptor::ReduceLongSum(where.dataPtr(), where.size(), IOProcNumber);
+                ParallelDescriptor::ReduceIntSum (which.dataPtr(), static_cast<int>(which.size()), IOProcNumber);
+                ParallelDescriptor::ReduceIntSum (count.dataPtr(), static_cast<int>(count.size()), IOProcNumber);
+                ParallelDescriptor::ReduceLongSum(where.dataPtr(), static_cast<int>(where.size()), IOProcNumber);
             }
         }
 
@@ -584,11 +584,11 @@ void WriteBinaryParticleDataSync (PC const& pc,
                     // Unlink any zero-length data files.
                     Vector<Long> cnt(nOutFiles,0);
 
-                    for (int i = 0, N=count.size(); i < N; i++) {
+                    for (int i = 0, N=static_cast<int>(count.size()); i < N; i++) {
                         cnt[which[i]] += count[i];
                     }
 
-                    for (int i = 0, N=cnt.size(); i < N; i++)
+                    for (int i = 0, N=static_cast<int>(cnt.size()); i < N; i++)
                     {
                         if (cnt[i] == 0)
                         {
@@ -703,7 +703,7 @@ void WriteBinaryParticleDataAsync (PC const& pc,
             {
                 if ( ! LevelDir.empty() && LevelDir[LevelDir.size()-1] != '/') LevelDir += '/';
 
-                LevelDir = amrex::Concatenate(LevelDir + "Level_", lev, 1);
+                LevelDir = amrex::Concatenate(LevelDir.append("Level_"), lev, 1);
 
                 if ( ! pc.GetLevelDirectoriesCreated())
                 {
@@ -747,7 +747,7 @@ void WriteBinaryParticleDataAsync (PC const& pc,
         for (int ip = 0; ip < NProcs; ++ip)
         {
             auto info = AsyncOut::GetWriteInfo(ip);
-            rank_start_offset[ip] = (info.ispot == 0) ? 0 : rank_start_offset[ip-1] + np_on_rank[ip-1]*psize;
+            rank_start_offset[ip] = (info.ispot == 0) ? 0 : static_cast<int64_t>(rank_start_offset[ip-1] + np_on_rank[ip-1]*psize);
         }
     }
 
@@ -881,7 +881,7 @@ void WriteBinaryParticleDataAsync (PC const& pc,
                     HdrFile << info.ifile << ' '
                             << np_per_grid_global[lev][k] << ' '
                             << grid_offset[rank] + rank_start_offset[rank] << '\n';
-                    grid_offset[rank] += np_per_grid_global[lev][k]*psize;
+                    grid_offset[rank] += static_cast<int64_t>(np_per_grid_global[lev][k]*psize);
                 }
             }
 
@@ -909,7 +909,7 @@ void WriteBinaryParticleDataAsync (PC const& pc,
 
             std::string LevelDir = pdir;
             if ( ! LevelDir.empty() && LevelDir[LevelDir.size()-1] != '/') LevelDir += '/';
-            LevelDir = amrex::Concatenate(LevelDir + "Level_", lev, 1);
+            LevelDir = amrex::Concatenate(LevelDir.append("Level_"), lev, 1);
             std::string filePrefix(LevelDir);
             filePrefix += '/';
             filePrefix += PC::DataPrefix();


### PR DESCRIPTION
This is the fourth batch of changes fixing clang-tidy warnings. Most of them are in particle code.
