### PR TITLE
Clang-Tidy VI

### DIFF
--- a/.github/workflows/clang.yml
+++ b/.github/workflows/clang.yml
@@ -87,13 +87,16 @@ jobs:
   # Build 2D libamrex with configure
   configure-2d:
     name: Clang@7.0 NOMPI Release [configure 2D]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
     - name: Dependencies
-      run: .github/workflows/dependencies/dependencies_clang7.sh
+      run: |
+        .github/workflows/dependencies/dependencies_clang.sh 14
+        .github/workflows/dependencies/dependencies_clang-tidy.sh 14
     - name: Build & Install
       run: |
         ./configure --dim 2 --with-fortran no --comp llvm --with-mpi no
-        make -j2 WARN_ALL=TRUE WARN_ERROR=TRUE XTRA_CXXFLAGS="-fno-operator-names"
+        make -j2 WARN_ALL=TRUE WARN_ERROR=TRUE XTRA_CXXFLAGS="-fno-operator-names" \
+            USE_CLANG_TIDY=TRUE CLANG_TIDY=clang-tidy-14 CLANG_TIDY_WARN_ERROR=TRUE
         make install

--- a/.github/workflows/gcc.yml
+++ b/.github/workflows/gcc.yml
@@ -251,11 +251,14 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Dependencies
-      run: .github/workflows/dependencies/dependencies.sh
+      run: |
+        .github/workflows/dependencies/dependencies.sh
+        .github/workflows/dependencies/dependencies_clang-tidy.sh 12
     - name: Build & Install
       run: |
         ./configure --dim 1
-        make -j2 XTRA_CXXFLAGS=-fno-operator-names
+        make -j2 XTRA_CXXFLAGS=-fno-operator-names \
+            USE_CLANG_TIDY=TRUE CLANG_TIDY=clang-tidy-12 CLANG_TIDY_WARN_ERROR=TRUE
         make install
 
   # Build 3D libamrex with configure
@@ -265,11 +268,14 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Dependencies
-      run: .github/workflows/dependencies/dependencies.sh
+      run: |
+        .github/workflows/dependencies/dependencies.sh
+        .github/workflows/dependencies/dependencies_clang-tidy.sh 12
     - name: Build & Install
       run: |
         ./configure --dim 3 --enable-eb yes --enable-xsdk-defaults yes
-        make -j2 WARN_ALL=TRUE WARN_ERROR=TRUE XTRA_CXXFLAGS=-fno-operator-names
+        make -j2 WARN_ALL=TRUE WARN_ERROR=TRUE XTRA_CXXFLAGS=-fno-operator-names \
+            USE_CLANG_TIDY=TRUE CLANG_TIDY=clang-tidy-12 CLANG_TIDY_WARN_ERROR=TRUE
         make install
 
   # Build 3D libamrex with single precision and tiny profiler
@@ -279,11 +285,14 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Dependencies
-      run: .github/workflows/dependencies/dependencies.sh
+      run: |
+        .github/workflows/dependencies/dependencies.sh
+        .github/workflows/dependencies/dependencies_clang-tidy.sh 12
     - name: Build & Install
       run: |
         ./configure --dim 3 --enable-eb no --enable-xsdk-defaults no --single-precision yes --single-precision-particles yes --enable-tiny-profile yes
-        make -j2 WARN_ALL=TRUE WARN_ERROR=TRUE XTRA_CXXFLAGS=-fno-operator-names
+        make -j2 WARN_ALL=TRUE WARN_ERROR=TRUE XTRA_CXXFLAGS=-fno-operator-names \
+            USE_CLANG_TIDY=TRUE CLANG_TIDY=clang-tidy-12 CLANG_TIDY_WARN_ERROR=TRUE
         make install
 
   # Build 3D libamrex debug omp build with configure
@@ -293,11 +302,14 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Dependencies
-      run: .github/workflows/dependencies/dependencies.sh
+      run: |
+        .github/workflows/dependencies/dependencies.sh
+        .github/workflows/dependencies/dependencies_clang-tidy.sh 12
     - name: Build & Install
       run: |
         ./configure --dim 3 --enable-eb yes --enable-xsdk-defaults yes --with-omp yes --debug yes
-        make -j2 WARN_ALL=TRUE WARN_ERROR=TRUE XTRA_CXXFLAGS=-fno-operator-names
+        make -j2 WARN_ALL=TRUE WARN_ERROR=TRUE XTRA_CXXFLAGS=-fno-operator-names \
+            USE_CLANG_TIDY=TRUE CLANG_TIDY=clang-tidy-12 CLANG_TIDY_WARN_ERROR=TRUE
         make install
 
   # Build Tools/Plotfile
@@ -307,11 +319,14 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Dependencies
-      run: .github/workflows/dependencies/dependencies.sh
+      run: |
+        .github/workflows/dependencies/dependencies.sh
+        .github/workflows/dependencies/dependencies_clang-tidy.sh 12
     - name: Build & Install
       run: |
         cd Tools/Plotfile
-        make -j2 USE_MPI=FALSE USE_OMP=FALSE WARN_ALL=TRUE WARN_ERROR=TRUE XTRA_CXXFLAGS=-fno-operator-names
+        make -j2 USE_MPI=FALSE USE_OMP=FALSE WARN_ALL=TRUE WARN_ERROR=TRUE XTRA_CXXFLAGS=-fno-operator-names \
+            USE_CLANG_TIDY=TRUE CLANG_TIDY=clang-tidy-12 CLANG_TIDY_WARN_ERROR=TRUE
 
   # Build libamrex and run all tests
   tests_run:

--- a/Src/AmrCore/AMReX_AmrParticles.H
+++ b/Src/AmrCore/AMReX_AmrParticles.H
@@ -168,7 +168,7 @@ ParticleToMesh (PC const& pc, const Vector<MultiFab*>& mf,
         if (vol_weight) {
             const Real* dx = pc.Geom(0).CellSize();
             const Real vol = AMREX_D_TERM(dx[0], *dx[1], *dx[2]);
-            mf[0]->mult(1.0/vol, 0, mf[0]->nComp(), mf[0]->nGrow());
+            mf[0]->mult(Real(1.0)/vol, 0, mf[0]->nComp(), mf[0]->nGrow());
         }
         return;
     }
@@ -181,7 +181,7 @@ ParticleToMesh (PC const& pc, const Vector<MultiFab*>& mf,
     {
         for (int lev = lev_min; lev <= lev_max; ++lev)
         {
-            mf[lev]->setVal(0.0);
+            mf[lev]->setVal(Real(0.0));
         }
     }
 
@@ -211,7 +211,7 @@ ParticleToMesh (PC const& pc, const Vector<MultiFab*>& mf,
         if (vol_weight) {
             const Real* dx = pc.Geom(lev).CellSize();
             const Real vol = AMREX_D_TERM(dx[0], *dx[1], *dx[2]);
-            mf_part[lev].mult(1.0/vol, 0, mf_part[lev].nComp(), mf_part[lev].nGrow());
+            mf_part[lev].mult(Real(1.0)/vol, 0, mf_part[lev].nComp(), mf_part[lev].nGrow());
         }
 
         if (lev < lev_max) {
@@ -259,10 +259,7 @@ public:
 
     typedef Particle<NStructReal, NStructInt> ParticleType;
 
-    AmrParticleContainer ()
-        : ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>()
-    {
-    }
+    AmrParticleContainer () = default;
 
     AmrParticleContainer (AmrCore* amr_core)
         : ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>(amr_core->GetParGDB())
@@ -277,13 +274,13 @@ public:
     {
     }
 
-    ~AmrParticleContainer () {}
+    ~AmrParticleContainer () override = default;
 
     AmrParticleContainer ( const AmrParticleContainer &) = delete;
     AmrParticleContainer& operator= ( const AmrParticleContainer & ) = delete;
 
-    AmrParticleContainer ( AmrParticleContainer && ) = default;
-    AmrParticleContainer& operator= ( AmrParticleContainer && ) = default;
+    AmrParticleContainer ( AmrParticleContainer && ) noexcept = default;
+    AmrParticleContainer& operator= ( AmrParticleContainer && ) noexcept = default;
 };
 
 class AmrTracerParticleContainer
@@ -296,13 +293,13 @@ public:
     {
     }
 
-    ~AmrTracerParticleContainer () {}
+    ~AmrTracerParticleContainer () override = default;
 
     AmrTracerParticleContainer ( const AmrTracerParticleContainer &) = delete;
     AmrTracerParticleContainer& operator= ( const AmrTracerParticleContainer & ) = delete;
 
-    AmrTracerParticleContainer ( AmrTracerParticleContainer && ) = default;
-    AmrTracerParticleContainer& operator= ( AmrTracerParticleContainer && ) = default;
+    AmrTracerParticleContainer ( AmrTracerParticleContainer && ) noexcept = default;
+    AmrTracerParticleContainer& operator= ( AmrTracerParticleContainer && ) noexcept = default;
 };
 
 }

--- a/Src/AmrCore/AMReX_Cluster.cpp
+++ b/Src/AmrCore/AMReX_Cluster.cpp
@@ -379,7 +379,7 @@ Cluster::new_chop ()
        int dir = -1;
        for (int n = 0, minlen = -1; n < AMREX_SPACEDIM; n++)
        {
-           if (status[n] == mincut)
+           if (status[n] == mincut) // NOLINT(clang-analyzer-core.UndefinedBinaryOperatorResult)
            {
                int mincutlen = std::min(cut[n]-lo[n],hi[n]-cut[n]);
                if (mincutlen >= minlen)

--- a/Src/AmrCore/AMReX_FillPatchUtil_I.H
+++ b/Src/AmrCore/AMReX_FillPatchUtil_I.H
@@ -268,8 +268,8 @@ InterpFace (Interp *interp,
 template <typename MF, typename iMF>
 std::enable_if_t<IsFabArray<MF>::value>
 InterpFace (InterpBase *interp,
-            MF const& mf_crse_patch,    const int crse_comp,
-            MF&       mf_refined_patch, const int fine_comp,
+            MF const& mf_crse_patch,    int crse_comp,
+            MF&       mf_refined_patch, int fine_comp,
             int ncomp, const IntVect&   ratio,
             const iMF& solve_mask, const Geometry&  crse_geom, const Geometry&  fine_geom,
             int bccomp, RunOn gpu_or_cpu,

--- a/Src/Base/AMReX_Box.H
+++ b/Src/Base/AMReX_Box.H
@@ -987,7 +987,7 @@ Box::setRange (int dir,
 AMREX_GPU_HOST_DEVICE
 AMREX_FORCE_INLINE
 void
-Box::next (IntVect& p) const noexcept
+Box::next (IntVect& p) const noexcept // NOLINT(readability-convert-member-functions-to-static)
 {
     BL_ASSERT(contains(p));
 

--- a/Src/Base/AMReX_PODVector.H
+++ b/Src/Base/AMReX_PODVector.H
@@ -440,7 +440,8 @@ namespace amrex
             {
                 detail::memMoveImpl<Allocator>(const_cast<iterator>(a_pos)+count, a_pos, (end() - a_pos) * sizeof(T), *this);
                 m_size += count;
-            }        auto dst = const_cast<iterator>(a_pos);
+            }
+            auto* dst = const_cast<iterator>(a_pos);
             detail::fillValuesImpl<Allocator>(dst, a_first, count, *this);
             return const_cast<iterator>(a_pos);
         }

--- a/Src/F_Interfaces/AmrCore/AMReX_FAmrCore.H
+++ b/Src/F_Interfaces/AmrCore/AMReX_FAmrCore.H
@@ -13,7 +13,6 @@ class FAmrCore
 {
 public:
     FAmrCore ();
-    virtual ~FAmrCore ();
 
     using make_level_funptr_t = void(*)(int lev, Real time, const BoxArray* ba,
                                       const DistributionMapping* dm);
@@ -38,17 +37,16 @@ public:
 
 protected:
 
-    virtual void MakeNewLevelFromScratch (int lev, Real time, const BoxArray& ba,
+    void MakeNewLevelFromScratch (int lev, Real time, const BoxArray& ba,
                                           const DistributionMapping& dm) override;
-    virtual void MakeNewLevelFromCoarse (int lev, Real time, const BoxArray& ba,
+    void MakeNewLevelFromCoarse (int lev, Real time, const BoxArray& ba,
                                          const DistributionMapping& dm) override;
-    virtual void RemakeLevel (int lev, Real time, const BoxArray& ba,
+    void RemakeLevel (int lev, Real time, const BoxArray& ba,
                               const DistributionMapping& dm) override;
-    virtual void ClearLevel (int lev) override;
-    virtual void ErrorEst (int lev, TagBoxArray& tags, Real time, int ngrow) override;
+    void ClearLevel (int lev) override;
+    void ErrorEst (int lev, TagBoxArray& tags, Real time, int ngrow) override;
 };
 
 }
 
 #endif
-

--- a/Src/F_Interfaces/AmrCore/AMReX_FAmrCore.cpp
+++ b/Src/F_Interfaces/AmrCore/AMReX_FAmrCore.cpp
@@ -4,7 +4,6 @@
 #include <string>
 
 amrex::FAmrCore::FAmrCore ()
-    : amrex::AmrCore()
 {
     for (int lev = 0; lev <= maxLevel(); ++lev)
     {
@@ -58,10 +57,6 @@ amrex::FAmrCore::FAmrCore ()
             }
         }
     }
-}
-
-amrex::FAmrCore::~FAmrCore ()
-{
 }
 
 void

--- a/Src/F_Interfaces/AmrCore/AMReX_FlashFluxRegister.H
+++ b/Src/F_Interfaces/AmrCore/AMReX_FlashFluxRegister.H
@@ -31,36 +31,36 @@ public:
                  IntVect const& ref_ratio, int nvar);
 
     // flux_in_register = scaling_factor * \sum{fine_flux} / (ref_ratio[0]*ref_ratio[1]*ref_ratio[2])
-    void store (int fine_global_index, int dir, FArrayBox const& fine_flux, Real scaling_factor);
+    void store (int fine_global_index, int dir, FArrayBox const& fine_flux, Real sf);
 
     // flux_in_register = scaling_factor * \sum{fine_flux * area}
     void store (int fine_global_index, int dir, FArrayBox const& fine_flux, FArrayBox const& area,
-                Real scaling_factor);
+                Real sf);
 
     // flux_in_register = scaling_factor * \sum{fine_flux * area}, if the component is flux density
     //                    scaling_factor * \sum{fine_flux}       , otherwise
     void store (int fine_global_index, int dir, FArrayBox const& fine_flux, FArrayBox const& area,
-                const int* isFluxDensity, Real scaling_factor);
+                const int* isFluxDensity, Real sf);
 
     void communicate ();
 
     // crse_flux = flux_in_register * scaling_factor
-    void load (int coarse_global_index, int dir, FArrayBox& crse_flux, Real scaling_factor) const;
+    void load (int crse_global_index, int dir, FArrayBox& crse_flux, Real sf) const;
 
     // crse_flux = flux_in_register * sf_f + cflux * sf_c
-    void load (int coarse_global_index, int dir, FArrayBox& crse_flux, FArrayBox const& cflux,
+    void load (int crse_global_index, int dir, FArrayBox& crse_flux, FArrayBox const& cflux,
                Real sf_f, Real sf_c) const;
 
     // crse_flux = flux_in_register / area
-    void load (int coarse_global_index, int dir, FArrayBox& crse_flux, FArrayBox const& area) const;
+    void load (int crse_global_index, int dir, FArrayBox& crse_flux, FArrayBox const& area) const;
 
     // crse_flux = flux_in_register/area * sf_f + cflux * sf_c
-    void load (int coarse_global_index, int dir, FArrayBox& crse_flux, FArrayBox const& cflux,
+    void load (int crse_global_index, int dir, FArrayBox& crse_flux, FArrayBox const& cflux,
                FArrayBox const& area, Real sf_f, Real sf_c) const;
 
     // crse_flux = flux_in_register/area * sf_f + cflux * sf_c, if the component is flux density
     //             flux_in_register      * sf_f + cflux * sf_c, otherwise
-    void load (int coarse_global_index, int dir, FArrayBox& crse_flux, FArrayBox const& cflux,
+    void load (int crse_global_index, int dir, FArrayBox& crse_flux, FArrayBox const& cflux,
                FArrayBox const& area, const int* isFluxDensity, Real sf_f, Real sf_c) const;
 
 protected:

--- a/Src/F_Interfaces/AmrCore/AMReX_FlashFluxRegister.cpp
+++ b/Src/F_Interfaces/AmrCore/AMReX_FlashFluxRegister.cpp
@@ -42,7 +42,7 @@ void FlashFluxRegister::define (const BoxArray& fba, const BoxArray& cba,
         std::vector<std::pair<int,Box> > isects;
         const std::vector<IntVect>& pshifts = m_fine_geom.periodicity().shiftIntVect();
         Vector<std::pair<Orientation,Box> > faces;
-        for (int i = 0, nfines = fba.size(); i < nfines; ++i)
+        for (int i = 0, nfines = static_cast<int>(fba.size()); i < nfines; ++i)
         {
             Box const& ccbx = fba[i];
             Box const& ndbx = amrex::surroundingNodes(ccbx);
@@ -105,7 +105,7 @@ void FlashFluxRegister::define (const BoxArray& fba, const BoxArray& cba,
         const std::vector<IntVect>& pshifts = m_crse_geom.periodicity().shiftIntVect();
         Vector<std::pair<Orientation,Box> > cell_faces;
         Vector<Orientation> crsefine_faces;
-        for (int i = 0, ncrses = cba.size(); i < ncrses; ++i)
+        for (int i = 0, ncrses = static_cast<int>(cba.size()); i < ncrses; ++i)
         {
             Box const& ccbx = cba[i];
             Box const& ccbxg1 = amrex::grow(ccbx,1);
@@ -212,7 +212,9 @@ void FlashFluxRegister::store (int fine_global_index, int dir, FArrayBox const& 
                                      src(2*i,2*j+1,2*k+1,n)) * (Real(0.25)*sf);
                 });
 #endif
-            } else if (dir == 1) {
+            }
+#if (AMREX_SPACEDIM >= 2)
+            else if (dir == 1) {
 #if (AMREX_SPACEDIM == 2)
                 AMREX_HOST_DEVICE_PARALLEL_FOR_4D (b, ncomp, i, j, k, n,
                 {
@@ -230,8 +232,9 @@ void FlashFluxRegister::store (int fine_global_index, int dir, FArrayBox const& 
                                      src(2*i+1,2*j,2*k+1,n)) * (Real(0.25)*sf);
                 });
 #endif
-            } else {
+            }
 #if (AMREX_SPACEDIM == 3)
+            else {
                 AMREX_HOST_DEVICE_PARALLEL_FOR_4D (b, ncomp, i, j, k, n,
                 {
                     dest(i,j,k,n) = (src(2*i  ,2*j  ,2*k,n) +
@@ -239,8 +242,9 @@ void FlashFluxRegister::store (int fine_global_index, int dir, FArrayBox const& 
                                      src(2*i  ,2*j+1,2*k,n) +
                                      src(2*i+1,2*j+1,2*k,n)) * (Real(0.25)*sf);
                 });
-#endif
             }
+#endif
+#endif
         }
     }
 }
@@ -283,7 +287,9 @@ void FlashFluxRegister::store (int fine_global_index, int dir, FArrayBox const& 
                                      src(2*i,2*j+1,2*k+1,n)*area(2*i,2*j+1,2*k+1)) * sf;
                 });
 #endif
-            } else if (dir == 1) {
+            }
+#if (AMREX_SPACEDIM >= 2)
+            else if (dir == 1) {
 #if (AMREX_SPACEDIM == 2)
                 AMREX_HOST_DEVICE_PARALLEL_FOR_4D (b, ncomp, i, j, k, n,
                 {
@@ -301,8 +307,9 @@ void FlashFluxRegister::store (int fine_global_index, int dir, FArrayBox const& 
                                      src(2*i+1,2*j,2*k+1,n)*area(2*i+1,2*j,2*k+1)) * sf;
                 });
 #endif
-            } else {
+            }
 #if (AMREX_SPACEDIM == 3)
+            else {
                 AMREX_HOST_DEVICE_PARALLEL_FOR_4D (b, ncomp, i, j, k, n,
                 {
                     dest(i,j,k,n) = (src(2*i  ,2*j  ,2*k,n)*area(2*i  ,2*j  ,2*k) +
@@ -310,8 +317,9 @@ void FlashFluxRegister::store (int fine_global_index, int dir, FArrayBox const& 
                                      src(2*i  ,2*j+1,2*k,n)*area(2*i  ,2*j+1,2*k) +
                                      src(2*i+1,2*j+1,2*k,n)*area(2*i+1,2*j+1,2*k)) * sf;
                 });
-#endif
             }
+#endif
+#endif
         }
     }
 }
@@ -389,7 +397,9 @@ void FlashFluxRegister::store (int fine_global_index, int dir, FArrayBox const& 
                     }
                 });
 #endif
-            } else if (dir == 1) {
+            }
+#if (AMREX_SPACEDIM >= 2)
+            else if (dir == 1) {
 #if (AMREX_SPACEDIM == 2)
                 AMREX_HOST_DEVICE_PARALLEL_FOR_4D (b, ncomp, i, j, k, n,
                 {
@@ -419,8 +429,9 @@ void FlashFluxRegister::store (int fine_global_index, int dir, FArrayBox const& 
                     }
                 });
 #endif
-            } else {
+            }
 #if (AMREX_SPACEDIM == 3)
+            else {
                 AMREX_HOST_DEVICE_PARALLEL_FOR_4D (b, ncomp, i, j, k, n,
                 {
                     if (ifd[n]) {
@@ -435,8 +446,9 @@ void FlashFluxRegister::store (int fine_global_index, int dir, FArrayBox const& 
                                          src(2*i+1,2*j+1,2*k,n)) * sf;
                     }
                 });
-#endif
             }
+#endif
+#endif
         }
     }
 }

--- a/Src/F_Interfaces/AmrCore/AMReX_fillpatch_fi.cpp
+++ b/Src/F_Interfaces/AmrCore/AMReX_fillpatch_fi.cpp
@@ -6,7 +6,7 @@ using namespace amrex;
 namespace
 {
     // THIS MUST BE CONSISTENT WITH amrex_interpolater_module in AMReX_interpolater_mod.F90!!!
-    static Vector<Interpolater*> interp = {
+    Vector<Interpolater*> interp = {
         &amrex::pc_interp,               // 0
         &amrex::node_bilinear_interp,    // 1
         &amrex::cell_bilinear_interp,    // 2

--- a/Src/F_Interfaces/Base/AMReX_FPhysBC.H
+++ b/Src/F_Interfaces/Base/AMReX_FPhysBC.H
@@ -14,7 +14,6 @@ public:
 
     FPhysBC (fill_physbc_funptr_t fill, const Geometry* geom_) : fill_physbc(fill), geom(geom_) {}
 
-    ~FPhysBC () {}
     void operator() (MultiFab& mf, int scomp, int ncomp, IntVect const& nghost,
                      Real time, int bccomp);
 

--- a/Src/F_Interfaces/Base/AMReX_init_fi.cpp
+++ b/Src/F_Interfaces/Base/AMReX_init_fi.cpp
@@ -11,7 +11,7 @@
 
 extern "C"
 {
-    typedef void (*amrex_void_cfun)(void);
+    typedef void (*amrex_void_cfun)();
 
     void amrex_fi_init (char* cmd, int fcomm, int arg_parmparse, amrex_void_cfun proc_parmparse)
     {
@@ -19,8 +19,8 @@ extern "C"
         amrex::Vector<std::string> argv_string(std::istream_iterator<std::string>{is},
                                               std::istream_iterator<std::string>{  });
 
-        int argc = argv_string.size();
-        char** argv = (char**)malloc(argc*sizeof(char*));
+        auto argc = static_cast<int>(argv_string.size());
+        auto** argv = (char**)malloc(argc*sizeof(char*));
         for (int i = 0; i < argc; ++i)
         {
             argv[i] = (char*)malloc(argv_string[i].size()+1);

--- a/Src/F_Interfaces/LinearSolvers/AMReX_abeclaplacian_fi.cpp
+++ b/Src/F_Interfaces/LinearSolvers/AMReX_abeclaplacian_fi.cpp
@@ -24,25 +24,25 @@ extern "C" {
             d.push_back(*dm[i]);
         }
 
-        MLABecLaplacian* abeclap = new MLABecLaplacian(g,b,d,info);
+        auto* abeclap = new MLABecLaplacian(g,b,d,info);
         linop = static_cast<MLLinOp*>(abeclap);
     }
 
     void amrex_fi_abeclap_set_scalars (MLLinOp* linop, Real a, Real b)
     {
-        MLABecLaplacian& abeclap = dynamic_cast<MLABecLaplacian&>(*linop);
+        auto& abeclap = dynamic_cast<MLABecLaplacian&>(*linop);
         abeclap.setScalars(a,b);
     }
 
     void amrex_fi_abeclap_set_acoeffs (MLLinOp* linop, int amrlev, const MultiFab* alpha)
     {
-        MLABecLaplacian& abeclap = dynamic_cast<MLABecLaplacian&>(*linop);
+        auto& abeclap = dynamic_cast<MLABecLaplacian&>(*linop);
         abeclap.setACoeffs(amrlev, *alpha);
     }
 
     void amrex_fi_abeclap_set_bcoeffs (MLLinOp* linop, int amrlev, const MultiFab* beta[])
     {
-        MLABecLaplacian& abeclap = dynamic_cast<MLABecLaplacian&>(*linop);
+        auto& abeclap = dynamic_cast<MLABecLaplacian&>(*linop);
         std::array<MultiFab const*, AMREX_SPACEDIM> b{{AMREX_D_DECL(beta[0],beta[1],beta[2])}};
         abeclap.setBCoeffs(amrlev, b);
     }

--- a/Src/F_Interfaces/LinearSolvers/AMReX_poisson_fi.cpp
+++ b/Src/F_Interfaces/LinearSolvers/AMReX_poisson_fi.cpp
@@ -24,7 +24,7 @@ extern "C" {
             d.push_back(*dm[i]);
         }
 
-        MLPoisson* poisson = new MLPoisson(g,b,d,info);
+        auto* poisson = new MLPoisson(g,b,d,info);
         linop = static_cast<MLLinOp*>(poisson);
     }
 

--- a/Src/F_Interfaces/Octree/AMReX_octree_fi.cpp
+++ b/Src/F_Interfaces/Octree/AMReX_octree_fi.cpp
@@ -70,7 +70,7 @@ extern "C" {
         const int finest_level = amrcore->finestLevel();
         const int myproc = ParallelDescriptor::MyProc();
 
-        FAmrCore* famrcore = dynamic_cast<FAmrCore*>(amrcore);
+        auto* famrcore = dynamic_cast<FAmrCore*>(amrcore);
 
         famrcore->octree_leaf_grids.resize(finest_level+1);
         famrcore->octree_leaf_dmap.resize(finest_level+1);
@@ -83,14 +83,14 @@ extern "C" {
 
         for (int lev = 0; lev <= finest_level; ++lev)
         {
-            level_offset[lev] = leaves->size();
+            level_offset[lev] = static_cast<int>(leaves->size());
 
             famrcore->octree_li_full_to_leaf[lev].clear();
             famrcore->octree_li_leaf_to_full[lev].clear();
 
             const BoxArray& ba = amrcore->boxArray(lev);
             const DistributionMapping& dm = amrcore->DistributionMap(lev);
-            const int ngrids = ba.size();
+            const auto ngrids = static_cast<int>(ba.size());
             BL_ASSERT(ba.size() < std::numeric_limits<int>::max());
 
             if (lev == finest_level)
@@ -159,13 +159,13 @@ extern "C" {
                 }
             }
         }
-        level_offset[finest_level+1] = leaves->size();
-        *n = leaves->size();
+        level_offset[finest_level+1] = static_cast<int>(leaves->size());
+        *n = static_cast<int>(leaves->size());
     }
 
     void amrex_fi_copy_octree_leaves (Vector<treenode>* leaves, treenode a_copy[])
     {
-        const int n = leaves->size();
+        const auto n = static_cast<int>(leaves->size());
 
 #ifdef AMREX_USE_OMP
 #pragma omp parallel for
@@ -182,7 +182,7 @@ extern "C" {
                                              MultiFab * const crse,
                                              int scomp, int ncomp)
     {
-        FAmrCore* famrcore = dynamic_cast<FAmrCore*>(amrcore);
+        auto* famrcore = dynamic_cast<FAmrCore*>(amrcore);
         const BoxArray& lba = famrcore->octree_leaf_grids[flev];
         const DistributionMapping& ldm = famrcore->octree_leaf_dmap[flev];
         const Vector<int>& li_leaf_to_full = famrcore->octree_li_leaf_to_full[flev];

--- a/Src/Particle/AMReX_ParticleContainer.H
+++ b/Src/Particle/AMReX_ParticleContainer.H
@@ -210,8 +210,8 @@ public:
         h_redistribute_int_comp(2 + NStructInt + NArrayInt, true)
     {
         Initialize ();
-        reserveData();
-        resizeData();
+        ParticleContainer::reserveData();
+        ParticleContainer::resizeData();
     }
 
     //! \brief Construct a particle container using a given Geometry, DistributionMapping,
@@ -230,8 +230,8 @@ public:
         h_redistribute_int_comp(2 + NStructInt + NArrayInt, true)
     {
         Initialize ();
-        reserveData();
-        resizeData();
+        ParticleContainer::reserveData();
+        ParticleContainer::resizeData();
     }
 
     //! \brief Construct a particle container using a given Geometry, DistributionMapping,
@@ -253,8 +253,8 @@ public:
         h_redistribute_int_comp(2 + NStructInt + NArrayInt, true)
     {
         Initialize ();
-        reserveData();
-        resizeData();
+        ParticleContainer::reserveData();
+        ParticleContainer::resizeData();
     }
 
     //! \brief Same as the above, but accepts different refinement ratios in each direction.
@@ -275,8 +275,8 @@ public:
         h_redistribute_int_comp(2 + NStructInt + NArrayInt, true)
     {
         Initialize ();
-        reserveData();
-        resizeData();
+        ParticleContainer::reserveData();
+        ParticleContainer::resizeData();
     }
 
     ~ParticleContainer () override = default;

--- a/Src/Particle/AMReX_ParticleContainerBase.cpp
+++ b/Src/Particle/AMReX_ParticleContainerBase.cpp
@@ -108,7 +108,7 @@ void ParticleContainerBase::SetParGDB (const Vector<Geometry>            & geom,
     resizeData();
 }
 
-void ParticleContainerBase::SetParticleBoxArray (int lev, BoxArray new_ba)
+void ParticleContainerBase::SetParticleBoxArray (int lev, BoxArray new_ba) // NOLINT(performance-unnecessary-value-param)
 {
     // Must take the new BoxArray by value to avoid aliasing with what's
     // inside m_gdb_object
@@ -121,7 +121,7 @@ void ParticleContainerBase::SetParticleBoxArray (int lev, BoxArray new_ba)
     RedefineDummyMF(lev);
 }
 
-void ParticleContainerBase::SetParticleDistributionMap (int lev, DistributionMapping new_dmap)
+void ParticleContainerBase::SetParticleDistributionMap (int lev, DistributionMapping new_dmap) // NOLINT(performance-unnecessary-value-param)
 {
     // Must take the new DistributionMapping by value to avoid aliasing with
     // what's inside m_gdb_object
@@ -134,7 +134,7 @@ void ParticleContainerBase::SetParticleDistributionMap (int lev, DistributionMap
     RedefineDummyMF(lev);
 }
 
-void ParticleContainerBase::SetParticleGeometry (int lev, Geometry new_geom)
+void ParticleContainerBase::SetParticleGeometry (int lev, Geometry new_geom) // NOLINT(performance-unnecessary-value-param)
 {
     // Must take the new Geometry by value to avoid aliasing with what's
     // inside m_gdb_object

--- a/Src/Particle/AMReX_ParticleContainerI.H
+++ b/Src/Particle/AMReX_ParticleContainerI.H
@@ -89,7 +89,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>
          int                 local_grid) const
 {
 
-  AMREX_ASSERT(m_gdb != 0);
+  AMREX_ASSERT(m_gdb != nullptr);
 
   if (lev_max == -1)
       lev_max = finestLevel();
@@ -167,7 +167,7 @@ ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>
                         int              local_grid) const
 {
 
-    AMREX_ASSERT(m_gdb != 0);
+    AMREX_ASSERT(m_gdb != nullptr);
 
     if (!Geom(0).isAnyPeriodic()) return false;
 
@@ -255,7 +255,7 @@ Reset (ParticleType& p,
        bool          verbose,
        ParticleLocData pld) const
 {
-    AMREX_ASSERT(m_gdb != 0);
+    AMREX_ASSERT(m_gdb != nullptr);
 
     bool ok = Where(p, pld);
 

--- a/Src/Particle/AMReX_TracerParticles.H
+++ b/Src/Particle/AMReX_TracerParticles.H
@@ -21,13 +21,14 @@ public:
         : ParticleContainer<AMREX_SPACEDIM>(geom,dmap,ba)
         {}
 
+    TracerParticleContainer () = default;
     ~TracerParticleContainer () override = default;
 
     TracerParticleContainer ( const TracerParticleContainer &) = delete;
     TracerParticleContainer& operator= ( const TracerParticleContainer & ) = delete;
 
-    TracerParticleContainer ( TracerParticleContainer && ) = default;
-    TracerParticleContainer& operator= ( TracerParticleContainer && ) = default;
+    TracerParticleContainer ( TracerParticleContainer && ) noexcept = default;
+    TracerParticleContainer& operator= ( TracerParticleContainer && ) noexcept = default;
 
     void AdvectWithUmac (MultiFab* umac, int level, Real dt);
 
@@ -42,4 +43,3 @@ using TracerParIter = ParIter<AMREX_SPACEDIM>;
 }
 
 #endif
-

--- a/Tools/GNUMake/Make.defs
+++ b/Tools/GNUMake/Make.defs
@@ -985,21 +985,26 @@ else
   CCACHE =
 endif
 
+ifeq ($(USE_CLANG_TIDY),TRUE)
+  $(info Loading $(AMREX_HOME)/Tools/GNUMake/tools/Make.clang-tidy)
+  include        $(AMREX_HOME)/Tools/GNUMake/tools/Make.clang-tidy
+endif
+
 # place holder
 F90CACHE =
 
 ifeq ($(TP_PROFILING),VTUNE)
-  $(info Loading $(AMREX_HOME)/Tools/GNUMake/tools/Make.vtune
+  $(info Loading $(AMREX_HOME)/Tools/GNUMake/tools/Make.vtune)
   include        $(AMREX_HOME)/Tools/GNUMake/tools/Make.vtune
 endif
 
 ifeq ($(TP_PROFILING),CRAYPAT)
-  $(info Loading $(AMREX_HOME)/Tools/GNUMake/tools/Make.craypat
+  $(info Loading $(AMREX_HOME)/Tools/GNUMake/tools/Make.craypat)
   include        $(AMREX_HOME)/Tools/GNUMake/tools/Make.craypat
 endif
 
 ifeq ($(TP_PROFILING),FORGE)
-  $(info Loading $(AMREX_HOME)/Tools/GNUMake/tools/Make.forge
+  $(info Loading $(AMREX_HOME)/Tools/GNUMake/tools/Make.forge)
   include        $(AMREX_HOME)/Tools/GNUMake/tools/Make.forge
 endif
 

--- a/Tools/GNUMake/Make.rules
+++ b/Tools/GNUMake/Make.rules
@@ -75,6 +75,9 @@ else
 
 # multiple executables
 %.$(machineSuffix).ex:%.cpp $(objForExecs)
+ifeq ($(USE_CLANG_TIDY),TRUE)
+	$(SILENT) $(CLANG_TIDY) $(CLANG_TIDY_ARGS) $< -- $(CXXFLAGS) $(EXTRACXXFLAGS) $(CPPFLAGS) $(includes) $(mpicxx_include_dirs)
+endif
 	$(SILENT) $(CCACHE) $(CXX) $(DEPFLAGS) $(CXXFLAGS) $(EXTRACXXFLAGS) $(CPPFLAGS) $(includes) -c $< -o $(objEXETempDir)/$(subst /,_,$<).o
 	@echo "Linking $@ ..."
 	$(SILENT) $(AMREX_LINKER) $(LINKFLAGS) $(CPPFLAGS) $(includes) $(LDFLAGS) -o $@ $(objEXETempDir)/$(subst /,_,$<).o $(objForExecs) $(FINAL_LIBS)
@@ -238,15 +241,9 @@ TAGS:	$(allSources)
 	@echo etags $< ...
 	$(SILENT) etags $(abspath $^)
 
-clang-analyze: $(CEXE_sources)
-	clang++ --analyze --analyzer-output html $(CXXFLAGS) $(CPPFLAGS) $(includes) $^
-
-clang-tidy: $(CEXE_sources)
-	clang-tidy $^ -checks=clang-diagnostic-*,performance-*,mpi-* -- $(CXXFLAGS) $(CPPFLAGS) $(includes)
-
 FORCE:
 
-.PHONY:	all cleanconfig clean realclean file_locations tags TAGS clang-analyze clang-tidy install_lib install_headers install_fortran_modules install_pkg_config
+.PHONY:	all cleanconfig clean realclean file_locations tags TAGS install_lib install_headers install_fortran_modules install_pkg_config
 
 #
 # Rules for objects.
@@ -257,6 +254,9 @@ $(objEXETempDir)/%.o: %.cpp $(srcTempDir)/AMReX_Config.H $(srcTempDir)/AMReX_Ver
 ifeq ($(LOG_BUILD_TIME),TRUE)
 	@if [ ! -d $(tmpEXETempDir) ]; then mkdir -p $(tmpEXETempDir); fi
 	@date +"%s" > $(tmpEXETempDir)/$(notdir $<).log
+endif
+ifeq ($(USE_CLANG_TIDY),TRUE)
+	$(SILENT) $(CLANG_TIDY) $(CLANG_TIDY_ARGS) $< -- $(CXXFLAGS) $(EXTRACXXFLAGS) $(CPPFLAGS) $(includes) $(mpicxx_include_dirs)
 endif
 	$(SILENT) $(CCACHE) $(CXX) $(DEPFLAGS) $(CXXFLAGS) $(EXTRACXXFLAGS) $(CPPFLAGS) $(includes) -c $< $(EXE_OUTPUT_OPTION)
 ifeq ($(LOG_BUILD_TIME),TRUE)

--- a/Tools/GNUMake/sites/Make.unknown
+++ b/Tools/GNUMake/sites/Make.unknown
@@ -43,9 +43,11 @@ ifeq ($(USE_MPI),TRUE)
   ifeq ($(code_sml), 0)
      mpi_link_flags  := $(shell $(MPI_OTHER_COMP) -showme:link)
      mpicxx_link_libs := $(filter -l%,$(shell mpicxx -showme:link))
+     mpicxx_include_dirs := $(addprefix -isystem ,$(shell mpicxx -showme:incdirs))
   else ifeq ($(code_li), 0)
      mpi_link_flags  := $(shell $(MPI_OTHER_COMP) -link_info)
      mpicxx_link_libs := $(filter -l%,$(shell mpicxx -link_info))
+     mpicxx_include_dirs := $(subst -I,-isystem ,$(filter -I%,$(shell mpicxx -compile_info)))
   else
      $(error Unknown mpi wrapper.  You can try setting MPI stuff in amrex/Tools/GNUMake/Make.local and then compile with NO_MPI_CHECKING=TRUE.)
   endif

--- a/Tools/GNUMake/tools/Make.clang-tidy
+++ b/Tools/GNUMake/tools/Make.clang-tidy
@@ -1,0 +1,17 @@
+
+CLANG_TIDY = clang-tidy
+CLANG_TIDY_ARGS = --extra-arg=-Wno-unknown-warning-option --extra-arg-before=--driver-mode=g++
+
+clang_tidy_version = $(shell $(CLANG_TIDY) --version | grep "LLVM version" | awk '{print $$3}' | awk 'BEGIN {FS = "."} {print $$1}')
+clang_tidy_ge_12 = $(shell expr $(clang_tidy_version) \>= 12)
+
+ifeq ($(clang_tidy_ge_12),1)
+  ifndef CLANG_TIDY_CONFIG_FILE
+    # If you do not specify a config file, we will use the one in amrex.
+    CLANG_TIDY_ARGS += --config-file=$(AMREX_HOME)/.clang-tidy
+  endif
+endif
+
+ifeq ($(CLANG_TIDY_WARN_ERROR),TRUE)
+  CLANG_TIDY_ARGS += --warnings-as-errors=*
+endif

--- a/Tools/Plotfile/AMReX_PPMUtil.cpp
+++ b/Tools/Plotfile/AMReX_PPMUtil.cpp
@@ -27,7 +27,7 @@ int loadPalette (const std::string& filename,
     std::fseek(fp, 0, SEEK_SET);
 
     /* check for RGB or RGBA palette */
-    int num_elements = length/(NCOLOR*sizeof(unsigned char));
+    int num_elements = static_cast<int>(length/(NCOLOR*sizeof(unsigned char)));
 
     if ( num_elements != 3 && num_elements != 4 )
     {
@@ -71,11 +71,13 @@ void storePPM (const std::string& filename,
     FILE* fp = std::fopen(filename.c_str(), "w");
     if (!fp) {
         amrex::Abort("storePPM: cannot open output file "+filename);
+        return;
     }
 
-    unsigned char* image = (unsigned char*) std::malloc(3*width*height*sizeof(unsigned char));
+    auto* image = (unsigned char*) std::malloc(3*width*height*sizeof(unsigned char));
     if (image == nullptr) {
         amrex::Abort("storePPM: malloc failed");
+        return;
     }
 
     for (int i = 0; i < width*height; ++i) {

--- a/Tools/Plotfile/fboxinfo.cpp
+++ b/Tools/Plotfile/fboxinfo.cpp
@@ -109,7 +109,7 @@ void main_main()
                                << ": number of boxes = " << std::setw(6) << nboxes
                                << ", volume = "
                                << std::fixed << std::setw(6) << std::setprecision(2)
-                               << 100.*(ncells/ncells_domain) << "%\n";
+                               << Real(100.)*static_cast<Real>(ncells)/ncells_domain << "%\n";
                 if (dim == 1) {
                     amrex::Print() << "          maximum zones =   "
                                    << std::setw(7) << prob_domain.length(0) << "\n";
@@ -134,8 +134,8 @@ void main_main()
             for (int ilev = 0; ilev < nlevels; ++ilev) {
                 amrex::Print() << "\n  level " << ilev << "\n";
                 const BoxArray& ba = plotfile.boxArray(ilev);
-                const Long nboxes = ba.size();
-                for (Long ibox = 0; ibox < nboxes; ++ibox) {
+                const auto nboxes = static_cast<int>(ba.size());
+                for (int ibox = 0; ibox < nboxes; ++ibox) {
                     const Box& b = ba[ibox];
                     if (dim == 1) {
                         amrex::Print() << "   box " << std::setw(5) << ibox

--- a/Tools/Plotfile/fcompare.cpp
+++ b/Tools/Plotfile/fcompare.cpp
@@ -137,7 +137,7 @@ int main_main()
             amrex::Print() << " WARNING: variable " << names_a[n_a] << " not found in plotfile 2\n";
             all_variables_found = false;
         } else {
-            ivar_b[n_a] = std::distance(std::begin(names_b), r);
+            ivar_b[n_a] = static_cast<int>(std::distance(std::begin(names_b), r));
         }
 
         if (names_a[n_a] == diffvar) {
@@ -369,7 +369,7 @@ int main_main()
         if (abort_if_not_all_found) return EXIT_FAILURE;
     }
 
-    if (any_nans) {
+    if (any_nans) { // NOLINT(bugprone-branch-clone)
         return EXIT_FAILURE;
     } else if (global_error == 0.0) {
         amrex::Print() << " PLOTFILE AGREE" << std::endl;

--- a/Tools/Plotfile/fextrema.cpp
+++ b/Tools/Plotfile/fextrema.cpp
@@ -101,8 +101,8 @@ void main_main()
             }
         }
 
-        ParallelDescriptor::ReduceRealMin(vvmin.data(), vvmin.size());
-        ParallelDescriptor::ReduceRealMax(vvmax.data(), vvmax.size());
+        ParallelDescriptor::ReduceRealMin(vvmin.data(), static_cast<int>(vvmin.size()));
+        ParallelDescriptor::ReduceRealMax(vvmax.data(), static_cast<int>(vvmax.size()));
 
         if (ntime == 1) {
             amrex::Print() << " plotfile = " << filename << "\n"

--- a/Tools/Plotfile/fsnapshot.cpp
+++ b/Tools/Plotfile/fsnapshot.cpp
@@ -293,9 +293,9 @@ void main_main()
             Real rd = realarr(i,jj,kk);
             if (do_log) rd = std::log10(rd);
             int id = std::max(0,std::min(255,static_cast<int>((rd-gmn)*fac)));
-            unsigned char c = static_cast<unsigned char>(id);
-            constexpr unsigned char cmn = static_cast<unsigned char>(1);  // avoid zero
-            constexpr unsigned char cmx = static_cast<unsigned char>(255);
+            auto c = static_cast<unsigned char>(id);
+            constexpr auto cmn = static_cast<unsigned char>(1);  // avoid zero
+            constexpr auto cmx = static_cast<unsigned char>(255);
             intarr(i,j,k) = std::max(cmn,std::min(cmx,c));
         });
 

--- a/Tools/Plotfile/fvolumesum.cpp
+++ b/Tools/Plotfile/fvolumesum.cpp
@@ -64,7 +64,7 @@ void main_main()
     // make sure that variable name is valid
 
     bool found = false;
-    for (auto vpf : var_names_pf) {
+    for (auto const& vpf : var_names_pf) {
         if (var_name == vpf) {
             found = true;
             break;


### PR DESCRIPTION
* Update GNU Make.  One can use `USE_CLANG_TIDY=TRUE` to enable clang-tidy check.  For example, to enable clang-tidy check, specify the clang-tidy command (if it's the default clang-tidy), and treat warnings as errors,  one can run

      make USE_CLANG_TIDY=TRUE CLANG_TIDY=clang-tidy-12 CLANG_TIDY_WARN_ERROR=TRUE

  By default amrex/.clang-tidy is used as the config file.  One can change it with CLANG_TIDY_CONFIG_FILE=my_clang-tidy-conf.  If you want to let clang-tidy fix errors for you, you can run

      make USE_CLANG_TIDY=TRUE CLANG_TIDY="clang-tidy --fix-errors"

  To avoid race conditions, the make job should not use `-j` (unless it's `-j1`) when fixing errors.

* Add clang-tidy to GNU Make CIs.

* Fix warnings in Fortran interface, particle and plotfile tools.