### PR TITLE
Fix issues in ParticleContainerBase

### DIFF
--- a/Src/Particle/AMReX_ParticleContainerBase.H
+++ b/Src/Particle/AMReX_ParticleContainerBase.H
@@ -34,9 +34,9 @@ public:
                            const DistributionMapping & dmap,
                            const BoxArray            & ba)
         :
-        m_gdb_object(geom,dmap,ba)
+        m_gdb_object(std::make_unique<ParGDB>(geom,dmap,ba)),
+        m_gdb(static_cast<ParGDBBase*>(m_gdb_object.get()))
     {
-        m_gdb = &m_gdb_object;
     }
 
     ParticleContainerBase (const Vector<Geometry>            & geom,
@@ -44,9 +44,9 @@ public:
                            const Vector<BoxArray>            & ba,
                            const Vector<int>                 & rr)
         :
-        m_gdb_object(geom,dmap,ba,rr)
+        m_gdb_object(std::make_unique<ParGDB>(geom,dmap,ba,rr)),
+        m_gdb(static_cast<ParGDBBase*>(m_gdb_object.get()))
     {
-        m_gdb = &m_gdb_object;
     }
 
     ParticleContainerBase (const Vector<Geometry>            & geom,
@@ -54,7 +54,8 @@ public:
                            const Vector<BoxArray>            & ba,
                            const Vector<IntVect>             & rr)
         :
-        m_gdb_object(geom,dmap,ba, [&]() -> Vector<int> {
+        m_gdb_object
+        (std::make_unique<ParGDB>(geom,dmap,ba, [&]() -> Vector<int> {
                 Vector<int> ref_ratio;
                 for (int i = 0; i < static_cast<int>(rr.size()); ++i)
                 {
@@ -66,9 +67,9 @@ public:
 #endif
                     ref_ratio.push_back(rr[i][0]);
                 }
-                return ref_ratio;  }() )
+                return ref_ratio;  }() )),
+        m_gdb(static_cast<ParGDBBase*>(m_gdb_object.get()))
     {
-        m_gdb = &m_gdb_object;
     }
 
     virtual ~ParticleContainerBase () = default;
@@ -165,7 +166,7 @@ public:
     //! \param lev The level on which to set the BoxArray.
     //! \param new_ba The new BoxArray to use.
     //!
-    void SetParticleBoxArray (int lev, const BoxArray& new_ba);
+    void SetParticleBoxArray (int lev, BoxArray new_ba);
 
     //! \brief Set the particle DistributionMapping. If the container was previously set to
     //! to track the AMR hierarchy of an AmrCore or AmrLevel object, that correspondence
@@ -174,7 +175,7 @@ public:
     //! \param lev The level on which to set the dm.
     //! \param new_dmap The new DistributionMapping to use.
     //!
-    void SetParticleDistributionMap (int lev, const DistributionMapping& new_dmap);
+    void SetParticleDistributionMap (int lev, DistributionMapping new_dmap);
 
     //! \brief Set the particle Geometry. If the container was previously set to
     //! to track the AMR hierarchy of an AmrCore or AmrLevel object, that correspondence
@@ -183,7 +184,7 @@ public:
     //! \param lev The level on which to set the Geometry.
     //! \param new_geom The new Geometry to use.
     //!
-    void SetParticleGeometry (int lev, const Geometry& new_geom);
+    void SetParticleGeometry (int lev, Geometry new_geom);
 
     //! \brief Get the BoxArray for a given level
     //!
@@ -259,8 +260,8 @@ protected:
     void defineBufferMap () const;
 
     int         m_verbose{0};
+    std::unique_ptr<ParGDB> m_gdb_object = std::make_unique<ParGDB>();
     ParGDBBase* m_gdb{nullptr};
-    ParGDB      m_gdb_object;
     Vector<std::unique_ptr<MultiFab> > m_dummy_mf;
 
     mutable std::unique_ptr<iMultiFab> redistribute_mask_ptr;

--- a/Src/Particle/AMReX_ParticleContainerBase.cpp
+++ b/Src/Particle/AMReX_ParticleContainerBase.cpp
@@ -15,8 +15,8 @@ void ParticleContainerBase::Define (const Geometry            & geom,
                                     const DistributionMapping & dmap,
                                     const BoxArray            & ba)
 {
-    m_gdb_object = ParGDB(geom, dmap, ba);
-    m_gdb = &m_gdb_object;
+    *m_gdb_object = ParGDB(geom, dmap, ba);
+    m_gdb = static_cast<ParGDBBase*>(m_gdb_object.get());
 }
 
 void ParticleContainerBase::Define (const Vector<Geometry>            & geom,
@@ -24,8 +24,8 @@ void ParticleContainerBase::Define (const Vector<Geometry>            & geom,
                                     const Vector<BoxArray>            & ba,
                                     const Vector<int>                 & rr)
 {
-    m_gdb_object = ParGDB(geom, dmap, ba, rr);
-    m_gdb = &m_gdb_object;
+    *m_gdb_object = ParGDB(geom, dmap, ba, rr);
+    m_gdb = static_cast<ParGDBBase*>(m_gdb_object.get());
 }
 
 void ParticleContainerBase::Define (const Vector<Geometry>            & geom,
@@ -33,8 +33,8 @@ void ParticleContainerBase::Define (const Vector<Geometry>            & geom,
                                     const Vector<BoxArray>            & ba,
                                     const Vector<IntVect>             & rr)
 {
-    m_gdb_object = ParGDB(geom, dmap, ba, rr);
-    m_gdb = &m_gdb_object;
+    *m_gdb_object = ParGDB(geom, dmap, ba, rr);
+    m_gdb = static_cast<ParGDBBase*>(m_gdb_object.get());
 }
 
 void ParticleContainerBase::reserveData ()
@@ -83,8 +83,8 @@ void ParticleContainerBase::SetParGDB (const Geometry            & geom,
                                        const DistributionMapping & dmap,
                                        const BoxArray            & ba)
 {
-    m_gdb_object = ParGDB(geom, dmap, ba);
-    m_gdb = &m_gdb_object;
+    *m_gdb_object = ParGDB(geom, dmap, ba);
+    m_gdb = static_cast<ParGDBBase*>(m_gdb_object.get());
     resizeData();
 }
 
@@ -93,8 +93,8 @@ void ParticleContainerBase::SetParGDB (const Vector<Geometry>            & geom,
                                        const Vector<BoxArray>            & ba,
                                        const Vector<int>                 & rr)
 {
-    m_gdb_object = ParGDB(geom, dmap, ba, rr);
-    m_gdb = &m_gdb_object;
+    *m_gdb_object = ParGDB(geom, dmap, ba, rr);
+    m_gdb = static_cast<ParGDBBase*>(m_gdb_object.get());
     resizeData();
 }
 
@@ -103,34 +103,46 @@ void ParticleContainerBase::SetParGDB (const Vector<Geometry>            & geom,
                                        const Vector<BoxArray>            & ba,
                                        const Vector<IntVect>             & rr)
 {
-    m_gdb_object = ParGDB(geom, dmap, ba, rr);
-    m_gdb = &m_gdb_object;
+    *m_gdb_object = ParGDB(geom, dmap, ba, rr);
+    m_gdb = static_cast<ParGDBBase*>(m_gdb_object.get());
     resizeData();
 }
 
-void ParticleContainerBase::SetParticleBoxArray (int lev, const BoxArray& new_ba)
+void ParticleContainerBase::SetParticleBoxArray (int lev, BoxArray new_ba)
 {
-    m_gdb_object = ParGDB(m_gdb->ParticleGeom(), m_gdb->ParticleDistributionMap(),
-                          m_gdb->ParticleBoxArray(), m_gdb->refRatio());
-    m_gdb = &m_gdb_object;
+    // Must take the new BoxArray by value to avoid aliasing with what's
+    // inside m_gdb_object
+    *m_gdb_object = ParGDB(m_gdb->ParticleGeom(),
+                           m_gdb->ParticleDistributionMap(),
+                           m_gdb->ParticleBoxArray(),
+                           m_gdb->refRatio());
+    m_gdb = static_cast<ParGDBBase*>(m_gdb_object.get());
     m_gdb->SetParticleBoxArray(lev, new_ba);
     RedefineDummyMF(lev);
 }
 
-void ParticleContainerBase::SetParticleDistributionMap (int lev, const DistributionMapping& new_dmap)
+void ParticleContainerBase::SetParticleDistributionMap (int lev, DistributionMapping new_dmap)
 {
-    m_gdb_object = ParGDB(m_gdb->ParticleGeom(), m_gdb->ParticleDistributionMap(),
-                          m_gdb->ParticleBoxArray(), m_gdb->refRatio());
-    m_gdb = &m_gdb_object;
+    // Must take the new DistributionMapping by value to avoid aliasing with
+    // what's inside m_gdb_object
+    *m_gdb_object = ParGDB(m_gdb->ParticleGeom(),
+                           m_gdb->ParticleDistributionMap(),
+                           m_gdb->ParticleBoxArray(),
+                           m_gdb->refRatio());
+    m_gdb = static_cast<ParGDBBase*>(m_gdb_object.get());
     m_gdb->SetParticleDistributionMap(lev, new_dmap);
     RedefineDummyMF(lev);
 }
 
-void ParticleContainerBase::SetParticleGeometry (int lev, const Geometry& new_geom)
+void ParticleContainerBase::SetParticleGeometry (int lev, Geometry new_geom)
 {
-    m_gdb_object = ParGDB(m_gdb->ParticleGeom(), m_gdb->ParticleDistributionMap(),
-                          m_gdb->ParticleBoxArray(), m_gdb->refRatio());
-    m_gdb = &m_gdb_object;
+    // Must take the new Geometry by value to avoid aliasing with what's
+    // inside m_gdb_object
+    *m_gdb_object = ParGDB(m_gdb->ParticleGeom(),
+                           m_gdb->ParticleDistributionMap(),
+                           m_gdb->ParticleBoxArray(),
+                           m_gdb->refRatio());
+    m_gdb = static_cast<ParGDBBase*>(m_gdb_object.get());
     m_gdb->SetParticleGeometry(lev, new_geom);
 }
 


### PR DESCRIPTION
* The move constructor and assignment operator were not safe, because the m_gdb member could be the address of m_gdb_object.  After the move that can no longer be true.  This is fixed by making m_gdb_object a unique_ptr. Moving a unique_ptr does not change its pointer inside.

* Fix SetParticleBoxArray, SetParticleDistributionMapping and SetParticleGeometry.  The issue was these functions took a reference, which could be aliasing what was inside the m_gdb_object.  ParGDB has a move assignment operator that could render the reference pointing to an invalid object.  So now these functions take by value.  This was not an issue before #3200, because the move assignment of ParGDB did copy instead of move.
