### PR TITLE
Warning about CPU core oversubscription

### DIFF
--- a/Src/Base/AMReX_ParallelDescriptor.H
+++ b/Src/Base/AMReX_ParallelDescriptor.H
@@ -213,6 +213,11 @@ while ( false )
     extern AMREX_EXPORT MPI_Comm m_comm;
     inline MPI_Comm Communicator () noexcept { return m_comm; }
 
+    extern AMREX_EXPORT int m_nprocs_per_node;
+    //! Return the number of MPI ranks per node.  This may not be correct if
+    //! MPI_COMM_TYPE_SHARED groups processes across nodes.
+    inline int NProcsPerNode () noexcept { return m_nprocs_per_node; }
+
 #ifdef AMREX_USE_MPI
     extern Vector<MPI_Datatype*> m_mpi_types;
     extern Vector<MPI_Op*> m_mpi_ops;


### PR DESCRIPTION
If the user forgets to set OMP_NUM_THREADS, OMP might be oversubscribing CPU cores. If that's the case (to the best of our knowledge) and verbosity is on, we print out a warning.

We use `std::thread::hardware_concurrency` to detect the number of cores available. Note that this is only a hint according to the C++ standard. To detect the number of MPI ranks per node, we use OMP_COMM_TYPE_NODE for Open MPI and MPI_COMM_TYPE_SHARED for others.  Since MPI_COMM_TYPE_SHARED might group processes across nodes, the return value of `ParallelDescriptor::NProcsPerNode` might also be wrong.  Nevertheless, both `std::thread::hardware_concurrency` and `ParallelDescriptor::NProcsPerNode` seem to work well.
