### PR TITLE
Fix bug in MLEBABecLap getEBFluxes().

### DIFF
--- a/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap_2D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap_2D_K.H
@@ -358,7 +358,7 @@ void mlebabeclap_ebflux (int i, int j, int k, int n,
             +       (            - gy*sy - gx*gy*sx*sy) * x(i ,jj,k,n)
             +       (                    + gx*gy*sx*sy) * x(ii,jj,k,n) ;
 
-        Real dphidn = (phib-phig)/dg * bareascaling;
+        Real dphidn = (phib-phig)/(dg * bareascaling);
         feb(i,j,k,n) = -beb(i,j,k,n) * dphidn;
     }
 }


### PR DESCRIPTION
## Summary

Bug introduced when adding anisotropy to MLEBABecLap, bareascaling goes on the denominator when calculating the EBfluxes.

## Additional background

## Checklist

The proposed changes:
- [X] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
