### PR TITLE
Use ccache in Github Actions

### DIFF
--- a/.github/workflows/clang.yml
+++ b/.github/workflows/clang.yml
@@ -14,15 +14,30 @@ jobs:
   library_clang:
     name: Clang@7.0 C++17 SP NOMPI Debug [lib]
     runs-on: ubuntu-20.04
-    env: {CXXFLAGS: "-fno-operator-names -Werror -Wall -Wextra -Wpedantic -Wnull-dereference -Wfloat-conversion -Wshadow -Woverloaded-virtual -Wextra-semi -Wunreachable-code -Wnon-virtual-dtor"}
     steps:
     - uses: actions/checkout@v3
     - name: Dependencies
       run: |
         .github/workflows/dependencies/dependencies_clang.sh 7
         .github/workflows/dependencies/dependencies_clang-tidy.sh 12
+        .github/workflows/dependencies/dependencies_ccache.sh
+    - name: Set Up Cache
+      uses: actions/cache@v3
+      env:
+        cache-name: library_clang
+      with:
+        path: ~/.cache
+        key: ccache-clang.yml-${{ env.cache-name }}-git-${{ github.sha }}
+        restore-keys: |
+             ccache-clang.yml-${{ env.cache-name }}-git-
     - name: Build & Install
+      env: {CXXFLAGS: "-fno-operator-names -Werror -Wall -Wextra -Wpedantic -Wnull-dereference -Wfloat-conversion -Wshadow -Woverloaded-virtual -Wextra-semi -Wunreachable-code -Wnon-virtual-dtor"}
       run: |
+        export CCACHE_COMPRESS=1
+        export CCACHE_COMPRESSLEVEL=10
+        export CCACHE_MAXSIZE=125M
+        ccache -z
+
         mkdir build
         cd build
         cmake ..                        \
@@ -40,7 +55,8 @@ jobs:
             -DCMAKE_CXX_COMPILER=$(which clang++-7)     \
             -DCMAKE_Fortran_COMPILER=$(which gfortran)  \
             -DAMReX_CLANG_TIDY=ON                     \
-            -DAMReX_CLANG_TIDY_WERROR=ON
+            -DAMReX_CLANG_TIDY_WERROR=ON              \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
         make -j 2
         make install
         make test_install
@@ -50,19 +66,36 @@ jobs:
 
         ctest --output-on-failure
 
+        ccache -s
+
   tests_clang:
     name: Clang@14.0 C++17 SP Particles DP Mesh Debug [tests]
     runs-on: ubuntu-22.04
-    env: {CXXFLAGS: "-fno-operator-names -Werror -Wall -Wextra -Wpedantic -Wnull-dereference -Wfloat-conversion -Wshadow -Woverloaded-virtual -Wextra-semi -Wunreachable-code -O1 -Wnon-virtual-dtor"}
-      # It's too slow with -O0
     steps:
     - uses: actions/checkout@v3
     - name: Dependencies
       run: |
         .github/workflows/dependencies/dependencies_clang.sh 14
         .github/workflows/dependencies/dependencies_clang-tidy.sh 14
+        .github/workflows/dependencies/dependencies_ccache.sh
+    - name: Set Up Cache
+      uses: actions/cache@v3
+      env:
+        cache-name: tests_clang
+      with:
+        path: ~/.cache
+        key: ccache-clang.yml-${{ env.cache-name }}-git-${{ github.sha }}
+        restore-keys: |
+             ccache-clang.yml-${{ env.cache-name }}-git-
     - name: Build & Install
+      env: {CXXFLAGS: "-fno-operator-names -Werror -Wall -Wextra -Wpedantic -Wnull-dereference -Wfloat-conversion -Wshadow -Woverloaded-virtual -Wextra-semi -Wunreachable-code -O1 -Wnon-virtual-dtor"}
+        # It's too slow with -O0
       run: |
+        export CCACHE_COMPRESS=1
+        export CCACHE_COMPRESSLEVEL=10
+        export CCACHE_MAXSIZE=125M
+        ccache -z
+
         mkdir build
         cd build
         cmake ..                                      \
@@ -79,14 +112,17 @@ jobs:
             -DCMAKE_CXX_COMPILER=$(which clang++-14)  \
             -DCMAKE_Fortran_COMPILER=$(which gfortran)  \
             -DAMReX_CLANG_TIDY=ON                     \
-            -DAMReX_CLANG_TIDY_WERROR=ON
+            -DAMReX_CLANG_TIDY_WERROR=ON              \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
         make -j 2
 
         ctest --output-on-failure -E GhostsAndVirtuals
 
+        ccache -s
+
   # Build 2D libamrex with configure
   configure-2d:
-    name: Clang@7.0 NOMPI Release [configure 2D]
+    name: Clang NOMPI Release [configure 2D]
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
@@ -94,9 +130,27 @@ jobs:
       run: |
         .github/workflows/dependencies/dependencies_clang.sh 14
         .github/workflows/dependencies/dependencies_clang-tidy.sh 14
+        .github/workflows/dependencies/dependencies_ccache.sh
+    - name: Set Up Cache
+      uses: actions/cache@v3
+      env:
+        cache-name: configure-2d
+      with:
+        path: ~/.cache
+        key: ccache-clang.yml-${{ env.cache-name }}-git-${{ github.sha }}
+        restore-keys: |
+             ccache-clang.yml-${{ env.cache-name }}-git-
     - name: Build & Install
       run: |
+        export CCACHE_COMPRESS=1
+        export CCACHE_COMPRESSLEVEL=10
+        export CCACHE_MAXSIZE=125M
+        ccache -z
+
         ./configure --dim 2 --with-fortran no --comp llvm --with-mpi no
         make -j2 WARN_ALL=TRUE WARN_ERROR=TRUE XTRA_CXXFLAGS="-fno-operator-names" \
-            USE_CLANG_TIDY=TRUE CLANG_TIDY=clang-tidy-14 CLANG_TIDY_WARN_ERROR=TRUE
+            USE_CLANG_TIDY=TRUE CLANG_TIDY=clang-tidy-14 CLANG_TIDY_WARN_ERROR=TRUE \
+            CCACHE=ccache
         make install
+
+        ccache -s

--- a/.github/workflows/clang.yml
+++ b/.github/workflows/clang.yml
@@ -1,6 +1,6 @@
 # -Wno-c++17-extensions: Clang complains about nodiscard if the standard is not set to c++17.
 
-name: Linux Clang
+name: LinuxClang
 
 on: [push, pull_request]
 
@@ -23,13 +23,11 @@ jobs:
         .github/workflows/dependencies/dependencies_ccache.sh
     - name: Set Up Cache
       uses: actions/cache@v3
-      env:
-        cache-name: library_clang
       with:
         path: ~/.cache
-        key: ccache-clang.yml-${{ env.cache-name }}-git-${{ github.sha }}
+        key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}
         restore-keys: |
-             ccache-clang.yml-${{ env.cache-name }}-git-
+             ccache-${{ github.workflow }}-${{ github.job }}-git-
     - name: Build & Install
       env: {CXXFLAGS: "-fno-operator-names -Werror -Wall -Wextra -Wpedantic -Wnull-dereference -Wfloat-conversion -Wshadow -Woverloaded-virtual -Wextra-semi -Wunreachable-code -Wnon-virtual-dtor"}
       run: |
@@ -80,13 +78,11 @@ jobs:
         .github/workflows/dependencies/dependencies_ccache.sh
     - name: Set Up Cache
       uses: actions/cache@v3
-      env:
-        cache-name: tests_clang
       with:
         path: ~/.cache
-        key: ccache-clang.yml-${{ env.cache-name }}-git-${{ github.sha }}
+        key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}
         restore-keys: |
-             ccache-clang.yml-${{ env.cache-name }}-git-
+             ccache-${{ github.workflow }}-${{ github.job }}-git-
     - name: Build & Install
       env: {CXXFLAGS: "-fno-operator-names -Werror -Wall -Wextra -Wpedantic -Wnull-dereference -Wfloat-conversion -Wshadow -Woverloaded-virtual -Wextra-semi -Wunreachable-code -O1 -Wnon-virtual-dtor"}
         # It's too slow with -O0
@@ -133,13 +129,11 @@ jobs:
         .github/workflows/dependencies/dependencies_ccache.sh
     - name: Set Up Cache
       uses: actions/cache@v3
-      env:
-        cache-name: configure-2d
       with:
         path: ~/.cache
-        key: ccache-clang.yml-${{ env.cache-name }}-git-${{ github.sha }}
+        key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}
         restore-keys: |
-             ccache-clang.yml-${{ env.cache-name }}-git-
+             ccache-${{ github.workflow }}-${{ github.job }}-git-
     - name: Build & Install
       run: |
         export CCACHE_COMPRESS=1

--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -11,13 +11,29 @@ jobs:
   tests-cuda11:
     name: CUDA@11.2 GNU@9.3.0 C++17 Release [tests]
     runs-on: ubuntu-20.04
-    env: {CXXFLAGS: "-fno-operator-names -Werror -Wall -Wextra -Wpedantic -Wnull-dereference -Wfloat-conversion -Wshadow -Woverloaded-virtual -Wextra-semi -Wunreachable-code -Wnon-virtual-dtor -Wlogical-op -Wmisleading-indentation -Wduplicated-cond -Wduplicated-branches"}
     steps:
     - uses: actions/checkout@v3
     - name: Dependencies
-      run: .github/workflows/dependencies/dependencies_nvcc11.sh
-    - name: Build & Install
       run: |
+        .github/workflows/dependencies/dependencies_nvcc11.sh
+        .github/workflows/dependencies/dependencies_ccache.sh
+    - name: Set Up Cache
+      uses: actions/cache@v3
+      env:
+        cache-name: tests-cuda11
+      with:
+        path: ~/.cache
+        key: ccache-cuda.yml-${{ env.cache-name }}-git-${{ github.sha }}
+        restore-keys: |
+             ccache-cuda.yml-${{ env.cache-name }}-git-
+    - name: Build & Install
+      env: {CXXFLAGS: "-fno-operator-names -Werror -Wall -Wextra -Wpedantic -Wnull-dereference -Wfloat-conversion -Wshadow -Woverloaded-virtual -Wextra-semi -Wunreachable-code -Wnon-virtual-dtor -Wlogical-op -Wmisleading-indentation -Wduplicated-cond -Wduplicated-branches"}
+      run: |
+        export CCACHE_COMPRESS=1
+        export CCACHE_COMPRESSLEVEL=10
+        export CCACHE_MAXSIZE=500M
+        ccache -z
+
         export PATH=/usr/local/nvidia/bin:/usr/local/cuda/bin:${PATH}
         export LD_LIBRARY_PATH=/usr/local/nvidia/lib:/usr/local/nvidia/lib64:/usr/local/cuda/lib64:${LD_LIBRARY_PATH}
         which nvcc || echo "nvcc not in PATH!"
@@ -35,21 +51,41 @@ jobs:
             -DCMAKE_Fortran_COMPILER=$(which gfortran)   \
             -DAMReX_CUDA_ARCH=7.0                        \
             -DAMReX_CUDA_ERROR_CROSS_EXECUTION_SPACE_CALL=ON \
-            -DAMReX_CUDA_ERROR_CAPTURE_THIS=ON
+            -DAMReX_CUDA_ERROR_CAPTURE_THIS=ON           \
+            -DCMAKE_CUDA_COMPILER_LAUNCHER=ccache        \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
 
         cmake --build build -j 2
+
+        ccache -s
 
   # Build libamrex and all tests with NVHPC (recent supported)
   tests-nvhpc23-1-nvcc:
     name: NVHPC@23.1 NVCC/NVC++ C++17 Release [tests]
     runs-on: ubuntu-20.04
-    env: {CXXFLAGS: "-Werror -Wall -Wextra -Wpedantic -Wshadow --diag_suppress=code_is_unreachable"}
     steps:
     - uses: actions/checkout@v3
     - name: Dependencies
-      run: .github/workflows/dependencies/dependencies_nvhpc23-1.sh
-    - name: Build & Install
       run: |
+        .github/workflows/dependencies/dependencies_nvhpc23-1.sh
+        .github/workflows/dependencies/dependencies_ccache.sh
+    - name: Set Up Cache
+      uses: actions/cache@v3
+      env:
+        cache-name: tests-nvhpc23-1-nvcc
+      with:
+        path: ~/.cache
+        key: ccache-cuda.yml-${{ env.cache-name }}-git-${{ github.sha }}
+        restore-keys: |
+             ccache-cuda.yml-${{ env.cache-name }}-git-
+    - name: Build & Install
+      env: {CXXFLAGS: "-Werror -Wall -Wextra -Wpedantic -Wshadow --diag_suppress=code_is_unreachable"}
+      run: |
+        export CCACHE_COMPRESS=1
+        export CCACHE_COMPRESSLEVEL=10
+        export CCACHE_MAXSIZE=500M
+        ccache -z
+
         source /etc/profile.d/modules.sh
         module load /opt/nvidia/hpc_sdk/modulefiles/nvhpc/23.1
 
@@ -75,9 +111,13 @@ jobs:
             -DCMAKE_Fortran_COMPILER=$(which nvfortran)  \
             -DAMReX_CUDA_ARCH=8.0                        \
             -DAMReX_CUDA_ERROR_CROSS_EXECUTION_SPACE_CALL=ON \
-            -DAMReX_CUDA_ERROR_CAPTURE_THIS=ON
+            -DAMReX_CUDA_ERROR_CAPTURE_THIS=ON           \
+            -DCMAKE_CUDA_COMPILER_LAUNCHER=ccache        \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
 
         cmake --build build -j 2
+
+        ccache -s
 
   # Build 3D libamrex cuda build with configure
   configure-3d-cuda:
@@ -86,14 +126,32 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Dependencies
-      run: .github/workflows/dependencies/dependencies_nvcc11.sh
+      run: |
+        .github/workflows/dependencies/dependencies_nvcc11.sh
+        .github/workflows/dependencies/dependencies_ccache.sh
+    - name: Set Up Cache
+      uses: actions/cache@v3
+      env:
+        cache-name: configure-3d-cuda
+      with:
+        path: ~/.cache
+        key: ccache-cuda.yml-${{ env.cache-name }}-git-${{ github.sha }}
+        restore-keys: |
+             ccache-cuda.yml-${{ env.cache-name }}-git-
     - name: Build & Install
       run: |
+        export CCACHE_COMPRESS=1
+        export CCACHE_COMPRESSLEVEL=10
+        export CCACHE_MAXSIZE=500M
+        ccache -z
+
         export PATH=/usr/local/nvidia/bin:/usr/local/cuda/bin:${PATH}
         ./configure --dim 3 --with-cuda yes --enable-eb yes --enable-xsdk-defaults yes --with-fortran no
         #
         # /home/runner/work/amrex/amrex/Src/Base/AMReX_GpuLaunchGlobal.H:16:41: error: unused parameter ‘f0’ [-Werror=unused-parameter]
         #    16 |     AMREX_GPU_GLOBAL void launch_global (L f0) { f0(); }
         #
-        make -j2 WARN_ALL=TRUE WARN_ERROR=TRUE XTRA_CXXFLAGS="-fno-operator-names -Wno-unused-parameter"
+        make -j2 WARN_ALL=TRUE WARN_ERROR=TRUE XTRA_CXXFLAGS="-fno-operator-names -Wno-unused-parameter" CCACHE=ccache
         make install
+
+        ccache -s

--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -19,13 +19,11 @@ jobs:
         .github/workflows/dependencies/dependencies_ccache.sh
     - name: Set Up Cache
       uses: actions/cache@v3
-      env:
-        cache-name: tests-cuda11
       with:
         path: ~/.cache
-        key: ccache-cuda.yml-${{ env.cache-name }}-git-${{ github.sha }}
+        key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}
         restore-keys: |
-             ccache-cuda.yml-${{ env.cache-name }}-git-
+             ccache-${{ github.workflow }}-${{ github.job }}-git-
     - name: Build & Install
       env: {CXXFLAGS: "-fno-operator-names -Werror -Wall -Wextra -Wpedantic -Wnull-dereference -Wfloat-conversion -Wshadow -Woverloaded-virtual -Wextra-semi -Wunreachable-code -Wnon-virtual-dtor -Wlogical-op -Wmisleading-indentation -Wduplicated-cond -Wduplicated-branches"}
       run: |
@@ -71,13 +69,11 @@ jobs:
         .github/workflows/dependencies/dependencies_ccache.sh
     - name: Set Up Cache
       uses: actions/cache@v3
-      env:
-        cache-name: tests-nvhpc23-1-nvcc
       with:
         path: ~/.cache
-        key: ccache-cuda.yml-${{ env.cache-name }}-git-${{ github.sha }}
+        key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}
         restore-keys: |
-             ccache-cuda.yml-${{ env.cache-name }}-git-
+             ccache-${{ github.workflow }}-${{ github.job }}-git-
     - name: Build & Install
       env: {CXXFLAGS: "-Werror -Wall -Wextra -Wpedantic -Wshadow --diag_suppress=code_is_unreachable"}
       run: |
@@ -131,13 +127,11 @@ jobs:
         .github/workflows/dependencies/dependencies_ccache.sh
     - name: Set Up Cache
       uses: actions/cache@v3
-      env:
-        cache-name: configure-3d-cuda
       with:
         path: ~/.cache
-        key: ccache-cuda.yml-${{ env.cache-name }}-git-${{ github.sha }}
+        key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}
         restore-keys: |
-             ccache-cuda.yml-${{ env.cache-name }}-git-
+             ccache-${{ github.workflow }}-${{ github.job }}-git-
     - name: Build & Install
       run: |
         export CCACHE_COMPRESS=1

--- a/.github/workflows/dependencies/dependencies_ccache.sh
+++ b/.github/workflows/dependencies/dependencies_ccache.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+if [[ $# -eq 2 ]]; then
+  CVER=$1
+else
+  CVER=4.8
+fi
+
+wget https://github.com/ccache/ccache/releases/download/v${CVER}/ccache-${CVER}-linux-x86_64.tar.xz
+tar xvf ccache-${CVER}-linux-x86_64.tar.xz
+sudo cp -f ccache-${CVER}-linux-x86_64/ccache /usr/local/bin/

--- a/.github/workflows/gcc.yml
+++ b/.github/workflows/gcc.yml
@@ -1,7 +1,7 @@
 # -Wextra-semi: GCC < 10 does not have this.
 # -Wunreachable-code: GCC no longer has this option.
 
-name: Linux GCC
+name: LinuxGCC
 
 on: [push, pull_request]
 
@@ -24,13 +24,11 @@ jobs:
         .github/workflows/dependencies/dependencies_ccache.sh
     - name: Set Up Cache
       uses: actions/cache@v3
-      env:
-        cache-name: library
       with:
         path: ~/.cache
-        key: ccache-gcc.yml-${{ env.cache-name }}-git-${{ github.sha }}
+        key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}
         restore-keys: |
-             ccache-gcc.yml-${{ env.cache-name }}-git-
+             ccache-${{ github.workflow }}-${{ github.job }}-git-
     - name: Build & Install
       env: {CXXFLAGS: "-fno-operator-names -Werror -Wall -Wextra -Wpedantic -Wnull-dereference -Wfloat-conversion -Wshadow -Woverloaded-virtual -Wnon-virtual-dtor -Wlogical-op -Wmisleading-indentation -Wduplicated-cond -Wduplicated-branches -Wmissing-include-dirs"}
       run: |
@@ -76,13 +74,11 @@ jobs:
         .github/workflows/dependencies/dependencies_ccache.sh
     - name: Set Up Cache
       uses: actions/cache@v3
-      env:
-        cache-name: tests_build_3D
       with:
         path: ~/.cache
-        key: ccache-gcc.yml-${{ env.cache-name }}-git-${{ github.sha }}
+        key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}
         restore-keys: |
-             ccache-gcc.yml-${{ env.cache-name }}-git-
+             ccache-${{ github.workflow }}-${{ github.job }}-git-
     - name: Build & Install
       env: {CXXFLAGS: "-fno-operator-names -Werror -Wall -Wextra -Wpedantic -Wnull-dereference -Wfloat-conversion -Wshadow -Woverloaded-virtual -O1 -Wnon-virtual-dtor -Wlogical-op -Wmisleading-indentation -Wduplicated-cond -Wduplicated-branches -Wmissing-include-dirs"}
         # It's too slow with -O0
@@ -121,13 +117,11 @@ jobs:
         .github/workflows/dependencies/dependencies_ccache.sh
     - name: Set Up Cache
       uses: actions/cache@v3
-      env:
-        cache-name: tests_build_2D
       with:
         path: ~/.cache
-        key: ccache-gcc.yml-${{ env.cache-name }}-git-${{ github.sha }}
+        key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}
         restore-keys: |
-             ccache-gcc.yml-${{ env.cache-name }}-git-
+             ccache-${{ github.workflow }}-${{ github.job }}-git-
     - name: Build & Install
       env: {CXXFLAGS: "-fno-operator-names -Werror -Wall -Wextra -Wpedantic -Wnull-dereference -Wfloat-conversion -Wshadow -Woverloaded-virtual -O1 -Wnon-virtual-dtor -Wlogical-op -Wmisleading-indentation -Wduplicated-cond -Wduplicated-branches -Wmissing-include-dirs"}
         # It's too slow with -O0
@@ -166,13 +160,11 @@ jobs:
         .github/workflows/dependencies/dependencies_ccache.sh
     - name: Set Up Cache
       uses: actions/cache@v3
-      env:
-        cache-name: tests_build_1D
       with:
         path: ~/.cache
-        key: ccache-gcc.yml-${{ env.cache-name }}-git-${{ github.sha }}
+        key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}
         restore-keys: |
-             ccache-gcc.yml-${{ env.cache-name }}-git-
+             ccache-${{ github.workflow }}-${{ github.job }}-git-
     - name: Build & Install
       env: {CXXFLAGS: "-fno-operator-names -Werror -Wall -Wextra -Wpedantic -Wnull-dereference -Wfloat-conversion -Wshadow -Woverloaded-virtual -O1 -Wnon-virtual-dtor -Wlogical-op -Wmisleading-indentation -Wduplicated-cond -Wduplicated-branches -Wmissing-include-dirs"}
         # -Werror temporarily skipped until we have functional testing established
@@ -213,13 +205,11 @@ jobs:
         .github/workflows/dependencies/dependencies_ccache.sh
     - name: Set Up Cache
       uses: actions/cache@v3
-      env:
-        cache-name: tests_cxx20
       with:
         path: ~/.cache
-        key: ccache-gcc.yml-${{ env.cache-name }}-git-${{ github.sha }}
+        key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}
         restore-keys: |
-             ccache-gcc.yml-${{ env.cache-name }}-git-
+             ccache-${{ github.workflow }}-${{ github.job }}-git-
     - name: Build & Install
       env: {CXXFLAGS: "-fno-operator-names -Werror -Wall -Wextra -Wpedantic -Wnull-dereference -Wfloat-conversion -Wshadow -Woverloaded-virtual -Wextra-semi -Wnon-virtual-dtor -Wlogical-op -Wmisleading-indentation -Wduplicated-cond -Wduplicated-branches -Wmissing-include-dirs"}
       run: |
@@ -268,13 +258,11 @@ jobs:
         .github/workflows/dependencies/dependencies_ccache.sh
     - name: Set Up Cache
       uses: actions/cache@v3
-      env:
-        cache-name: tests-nonmpi
       with:
         path: ~/.cache
-        key: ccache-gcc.yml-${{ env.cache-name }}-git-${{ github.sha }}
+        key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}
         restore-keys: |
-             ccache-gcc.yml-${{ env.cache-name }}-git-
+             ccache-${{ github.workflow }}-${{ github.job }}-git-
     - name: Build & Install
       env: {CXXFLAGS: "-fno-operator-names -Werror -Wall -Wextra -Wpedantic -Wnull-dereference -Wfloat-conversion -Wshadow -Woverloaded-virtual -Wnon-virtual-dtor -Wlogical-op -Wmisleading-indentation -Wduplicated-cond -Wduplicated-branches -Wmissing-include-dirs"}
       run: |
@@ -322,13 +310,11 @@ jobs:
         .github/workflows/dependencies/dependencies_ccache.sh
     - name: Set Up Cache
       uses: actions/cache@v3
-      env:
-        cache-name: tests-nofortran
       with:
         path: ~/.cache
-        key: ccache-gcc.yml-${{ env.cache-name }}-git-${{ github.sha }}
+        key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}
         restore-keys: |
-             ccache-gcc.yml-${{ env.cache-name }}-git-
+             ccache-${{ github.workflow }}-${{ github.job }}-git-
     - name: Build & Install
       #
       # /home/runner/work/amrex/amrex/Src/Base/AMReX_IntVect.H:194:92: error: array subscript -1 is below array bounds of ‘int [3]’ [-Werror=array-bounds]
@@ -383,13 +369,11 @@ jobs:
         .github/workflows/dependencies/dependencies_ccache.sh
     - name: Set Up Cache
       uses: actions/cache@v3
-      env:
-        cache-name: configure-1d
       with:
         path: ~/.cache
-        key: ccache-gcc.yml-${{ env.cache-name }}-git-${{ github.sha }}
+        key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}
         restore-keys: |
-             ccache-gcc.yml-${{ env.cache-name }}-git-
+             ccache-${{ github.workflow }}-${{ github.job }}-git-
     - name: Build & Install
       run: |
         export CCACHE_COMPRESS=1
@@ -418,13 +402,11 @@ jobs:
         .github/workflows/dependencies/dependencies_ccache.sh
     - name: Set Up Cache
       uses: actions/cache@v3
-      env:
-        cache-name: configure-3d
       with:
         path: ~/.cache
-        key: ccache-gcc.yml-${{ env.cache-name }}-git-${{ github.sha }}
+        key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}
         restore-keys: |
-             ccache-gcc.yml-${{ env.cache-name }}-git-
+             ccache-${{ github.workflow }}-${{ github.job }}-git-
     - name: Build & Install
       run: |
         export CCACHE_COMPRESS=1
@@ -453,13 +435,11 @@ jobs:
         .github/workflows/dependencies/dependencies_ccache.sh
     - name: Set Up Cache
       uses: actions/cache@v3
-      env:
-        cache-name: configure-3d-single-tprof
       with:
         path: ~/.cache
-        key: ccache-gcc.yml-${{ env.cache-name }}-git-${{ github.sha }}
+        key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}
         restore-keys: |
-             ccache-gcc.yml-${{ env.cache-name }}-git-
+             ccache-${{ github.workflow }}-${{ github.job }}-git-
     - name: Build & Install
       run: |
         export CCACHE_COMPRESS=1
@@ -488,13 +468,11 @@ jobs:
         .github/workflows/dependencies/dependencies_ccache.sh
     - name: Set Up Cache
       uses: actions/cache@v3
-      env:
-        cache-name: configure-3d-omp-debug
       with:
         path: ~/.cache
-        key: ccache-gcc.yml-${{ env.cache-name }}-git-${{ github.sha }}
+        key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}
         restore-keys: |
-             ccache-gcc.yml-${{ env.cache-name }}-git-
+             ccache-${{ github.workflow }}-${{ github.job }}-git-
     - name: Build & Install
       run: |
         export CCACHE_COMPRESS=1
@@ -523,13 +501,11 @@ jobs:
         .github/workflows/dependencies/dependencies_ccache.sh
     - name: Set Up Cache
       uses: actions/cache@v3
-      env:
-        cache-name: plotfile-tools
       with:
         path: ~/.cache
-        key: ccache-gcc.yml-${{ env.cache-name }}-git-${{ github.sha }}
+        key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}
         restore-keys: |
-             ccache-gcc.yml-${{ env.cache-name }}-git-
+             ccache-${{ github.workflow }}-${{ github.job }}-git-
     - name: Build & Install
       run: |
         export CCACHE_COMPRESS=1
@@ -557,13 +533,11 @@ jobs:
         .github/workflows/dependencies/dependencies_ccache.sh
     - name: Set Up Cache
       uses: actions/cache@v3
-      env:
-        cache-name: tests_run
       with:
         path: ~/.cache
-        key: ccache-gcc.yml-${{ env.cache-name }}-git-${{ github.sha }}
+        key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}
         restore-keys: |
-             ccache-gcc.yml-${{ env.cache-name }}-git-
+             ccache-${{ github.workflow }}-${{ github.job }}-git-
     - name: Build & Install
       env: {CXXFLAGS: "-fno-operator-names -Werror -Wall -Wextra -Wpedantic -Wnull-dereference -Wfloat-conversion -Wshadow -Woverloaded-virtual -Wunreachable-code -Wnon-virtual-dtor -Wlogical-op -Wmisleading-indentation -Wduplicated-cond -Wduplicated-branches -Wmissing-include-dirs"}
       run: |

--- a/.github/workflows/gcc.yml
+++ b/.github/workflows/gcc.yml
@@ -15,15 +15,30 @@ jobs:
   library:
     name: GNU@8.4 C++17 Release [lib]
     runs-on: ubuntu-20.04
-    env: {CXXFLAGS: "-fno-operator-names -Werror -Wall -Wextra -Wpedantic -Wnull-dereference -Wfloat-conversion -Wshadow -Woverloaded-virtual -Wnon-virtual-dtor -Wlogical-op -Wmisleading-indentation -Wduplicated-cond -Wduplicated-branches -Wmissing-include-dirs"}
     steps:
     - uses: actions/checkout@v3
     - name: Dependencies
       run: |
         .github/workflows/dependencies/dependencies_gcc.sh 8
         .github/workflows/dependencies/dependencies_clang-tidy.sh 12
+        .github/workflows/dependencies/dependencies_ccache.sh
+    - name: Set Up Cache
+      uses: actions/cache@v3
+      env:
+        cache-name: library
+      with:
+        path: ~/.cache
+        key: ccache-gcc.yml-${{ env.cache-name }}-git-${{ github.sha }}
+        restore-keys: |
+             ccache-gcc.yml-${{ env.cache-name }}-git-
     - name: Build & Install
+      env: {CXXFLAGS: "-fno-operator-names -Werror -Wall -Wextra -Wpedantic -Wnull-dereference -Wfloat-conversion -Wshadow -Woverloaded-virtual -Wnon-virtual-dtor -Wlogical-op -Wmisleading-indentation -Wduplicated-cond -Wduplicated-branches -Wmissing-include-dirs"}
       run: |
+        export CCACHE_COMPRESS=1
+        export CCACHE_COMPRESSLEVEL=10
+        export CCACHE_MAXSIZE=125M
+        ccache -z
+
         mkdir build
         cd build
         cmake ..                                  \
@@ -35,7 +50,8 @@ jobs:
             -DCMAKE_CXX_COMPILER=$(which g++-8)   \
             -DCMAKE_Fortran_COMPILER=$(which gfortran-8) \
             -DAMReX_CLANG_TIDY=ON                 \
-            -DAMReX_CLANG_TIDY_WERROR=ON
+            -DAMReX_CLANG_TIDY_WERROR=ON          \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
         make -j 2
         make install
         make test_install
@@ -45,20 +61,37 @@ jobs:
 
         ctest --output-on-failure
 
+        ccache -s
+
   # Build libamrex and all tests
   tests_build_3D:
     name: GNU@9.3 C++17 3D Debug Fortran [tests]
     runs-on: ubuntu-20.04
-    env: {CXXFLAGS: "-fno-operator-names -Werror -Wall -Wextra -Wpedantic -Wnull-dereference -Wfloat-conversion -Wshadow -Woverloaded-virtual -O1 -Wnon-virtual-dtor -Wlogical-op -Wmisleading-indentation -Wduplicated-cond -Wduplicated-branches -Wmissing-include-dirs"}
-      # It's too slow with -O0
     steps:
     - uses: actions/checkout@v3
     - name: Dependencies
       run: |
         .github/workflows/dependencies/dependencies.sh
         .github/workflows/dependencies/dependencies_clang-tidy.sh 12
+        .github/workflows/dependencies/dependencies_ccache.sh
+    - name: Set Up Cache
+      uses: actions/cache@v3
+      env:
+        cache-name: tests_build_3D
+      with:
+        path: ~/.cache
+        key: ccache-gcc.yml-${{ env.cache-name }}-git-${{ github.sha }}
+        restore-keys: |
+             ccache-gcc.yml-${{ env.cache-name }}-git-
     - name: Build & Install
+      env: {CXXFLAGS: "-fno-operator-names -Werror -Wall -Wextra -Wpedantic -Wnull-dereference -Wfloat-conversion -Wshadow -Woverloaded-virtual -O1 -Wnon-virtual-dtor -Wlogical-op -Wmisleading-indentation -Wduplicated-cond -Wduplicated-branches -Wmissing-include-dirs"}
+        # It's too slow with -O0
       run: |
+        export CCACHE_COMPRESS=1
+        export CCACHE_COMPRESSLEVEL=10
+        export CCACHE_MAXSIZE=500M
+        ccache -z
+
         cmake -S . -B build             \
             -DCMAKE_BUILD_TYPE=Debug    \
             -DCMAKE_VERBOSE_MAKEFILE=ON \
@@ -68,24 +101,42 @@ jobs:
             -DAMReX_PARTICLES=ON        \
             -DAMReX_SPACEDIM=3          \
             -DAMReX_CLANG_TIDY=ON       \
-            -DAMReX_CLANG_TIDY_WERROR=ON
+            -DAMReX_CLANG_TIDY_WERROR=ON \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
         cmake --build build -j 2
 
         ctest --test-dir build --output-on-failure
 
+        ccache -s
+
   tests_build_2D:
     name: GNU@9.3 C++17 2D Debug Fortran [tests]
     runs-on: ubuntu-20.04
-    env: {CXXFLAGS: "-fno-operator-names -Werror -Wall -Wextra -Wpedantic -Wnull-dereference -Wfloat-conversion -Wshadow -Woverloaded-virtual -O1 -Wnon-virtual-dtor -Wlogical-op -Wmisleading-indentation -Wduplicated-cond -Wduplicated-branches -Wmissing-include-dirs"}
-      # It's too slow with -O0
     steps:
     - uses: actions/checkout@v3
     - name: Dependencies
       run: |
         .github/workflows/dependencies/dependencies.sh
         .github/workflows/dependencies/dependencies_clang-tidy.sh 12
+        .github/workflows/dependencies/dependencies_ccache.sh
+    - name: Set Up Cache
+      uses: actions/cache@v3
+      env:
+        cache-name: tests_build_2D
+      with:
+        path: ~/.cache
+        key: ccache-gcc.yml-${{ env.cache-name }}-git-${{ github.sha }}
+        restore-keys: |
+             ccache-gcc.yml-${{ env.cache-name }}-git-
     - name: Build & Install
+      env: {CXXFLAGS: "-fno-operator-names -Werror -Wall -Wextra -Wpedantic -Wnull-dereference -Wfloat-conversion -Wshadow -Woverloaded-virtual -O1 -Wnon-virtual-dtor -Wlogical-op -Wmisleading-indentation -Wduplicated-cond -Wduplicated-branches -Wmissing-include-dirs"}
+        # It's too slow with -O0
       run: |
+        export CCACHE_COMPRESS=1
+        export CCACHE_COMPRESSLEVEL=10
+        export CCACHE_MAXSIZE=500M
+        ccache -z
+
         cmake -S . -B build             \
             -DCMAKE_BUILD_TYPE=Debug    \
             -DCMAKE_VERBOSE_MAKEFILE=ON \
@@ -95,25 +146,43 @@ jobs:
             -DAMReX_PARTICLES=ON        \
             -DAMReX_SPACEDIM=2          \
             -DAMReX_CLANG_TIDY=ON       \
-            -DAMReX_CLANG_TIDY_WERROR=ON
+            -DAMReX_CLANG_TIDY_WERROR=ON \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
         cmake --build build -j 2
 
         ctest --test-dir build --output-on-failure
 
+        ccache -s
+
   tests_build_1D:
     name: GNU@9.3 C++17 1D Debug Fortran [tests]
     runs-on: ubuntu-20.04
-    env: {CXXFLAGS: "-fno-operator-names -Werror -Wall -Wextra -Wpedantic -Wnull-dereference -Wfloat-conversion -Wshadow -Woverloaded-virtual -O1 -Wnon-virtual-dtor -Wlogical-op -Wmisleading-indentation -Wduplicated-cond -Wduplicated-branches -Wmissing-include-dirs"}
-      # -Werror temporarily skipped until we have functional testing established
-      # It's too slow with -O0
     steps:
     - uses: actions/checkout@v3
     - name: Dependencies
       run: |
         .github/workflows/dependencies/dependencies.sh
         .github/workflows/dependencies/dependencies_clang-tidy.sh 12
+        .github/workflows/dependencies/dependencies_ccache.sh
+    - name: Set Up Cache
+      uses: actions/cache@v3
+      env:
+        cache-name: tests_build_1D
+      with:
+        path: ~/.cache
+        key: ccache-gcc.yml-${{ env.cache-name }}-git-${{ github.sha }}
+        restore-keys: |
+             ccache-gcc.yml-${{ env.cache-name }}-git-
     - name: Build & Install
+      env: {CXXFLAGS: "-fno-operator-names -Werror -Wall -Wextra -Wpedantic -Wnull-dereference -Wfloat-conversion -Wshadow -Woverloaded-virtual -O1 -Wnon-virtual-dtor -Wlogical-op -Wmisleading-indentation -Wduplicated-cond -Wduplicated-branches -Wmissing-include-dirs"}
+        # -Werror temporarily skipped until we have functional testing established
+        # It's too slow with -O0
       run: |
+        export CCACHE_COMPRESS=1
+        export CCACHE_COMPRESSLEVEL=10
+        export CCACHE_MAXSIZE=250M
+        ccache -z
+
         cmake -S . -B build             \
             -DCMAKE_BUILD_TYPE=Debug    \
             -DCMAKE_VERBOSE_MAKEFILE=ON \
@@ -123,24 +192,42 @@ jobs:
             -DAMReX_PARTICLES=ON        \
             -DAMReX_SPACEDIM=1          \
             -DAMReX_CLANG_TIDY=ON       \
-            -DAMReX_CLANG_TIDY_WERROR=ON
+            -DAMReX_CLANG_TIDY_WERROR=ON \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
         cmake --build build -j 2
 
         ctest --test-dir build --output-on-failure
+
+        ccache -s
 
   # Build libamrex and all tests
   tests_cxx20:
     name: GNU@10.1 C++20 OMP [tests]
     runs-on: ubuntu-20.04
-    env: {CXXFLAGS: "-fno-operator-names -Werror -Wall -Wextra -Wpedantic -Wnull-dereference -Wfloat-conversion -Wshadow -Woverloaded-virtual -Wextra-semi -Wnon-virtual-dtor -Wlogical-op -Wmisleading-indentation -Wduplicated-cond -Wduplicated-branches -Wmissing-include-dirs"}
     steps:
     - uses: actions/checkout@v3
     - name: Dependencies
       run: |
         .github/workflows/dependencies/dependencies_gcc.sh 10
         .github/workflows/dependencies/dependencies_clang-tidy.sh 12
+        .github/workflows/dependencies/dependencies_ccache.sh
+    - name: Set Up Cache
+      uses: actions/cache@v3
+      env:
+        cache-name: tests_cxx20
+      with:
+        path: ~/.cache
+        key: ccache-gcc.yml-${{ env.cache-name }}-git-${{ github.sha }}
+        restore-keys: |
+             ccache-gcc.yml-${{ env.cache-name }}-git-
     - name: Build & Install
+      env: {CXXFLAGS: "-fno-operator-names -Werror -Wall -Wextra -Wpedantic -Wnull-dereference -Wfloat-conversion -Wshadow -Woverloaded-virtual -Wextra-semi -Wnon-virtual-dtor -Wlogical-op -Wmisleading-indentation -Wduplicated-cond -Wduplicated-branches -Wmissing-include-dirs"}
       run: |
+        export CCACHE_COMPRESS=1
+        export CCACHE_COMPRESSLEVEL=10
+        export CCACHE_MAXSIZE=500M
+        ccache -z
+
         mkdir build
         cd build
         cmake ..                        \
@@ -159,25 +246,43 @@ jobs:
             -DCMAKE_C_COMPILER=$(which gcc-10)              \
             -DCMAKE_CXX_COMPILER=$(which g++-10)            \
             -DCMAKE_Fortran_COMPILER=$(which gfortran-10)   \
-            -DAMReX_CLANG_TIDY=ON
+            -DAMReX_CLANG_TIDY=ON       \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
             # Cannot use C++20 yet -DAMReX_CLANG_TIDY_WERROR=ON
         make -j 2
 
         ctest --output-on-failure
 
+        ccache -s
+
   # Build libamrex and all tests w/o MPI
   tests-nonmpi:
     name: GNU@8.4 C++17 NOMPI [tests]
     runs-on: ubuntu-20.04
-    env: {CXXFLAGS: "-fno-operator-names -Werror -Wall -Wextra -Wpedantic -Wnull-dereference -Wfloat-conversion -Wshadow -Woverloaded-virtual -Wnon-virtual-dtor -Wlogical-op -Wmisleading-indentation -Wduplicated-cond -Wduplicated-branches -Wmissing-include-dirs"}
     steps:
     - uses: actions/checkout@v3
     - name: Dependencies
       run: |
         .github/workflows/dependencies/dependencies_gcc.sh 8
         .github/workflows/dependencies/dependencies_clang-tidy.sh 12
+        .github/workflows/dependencies/dependencies_ccache.sh
+    - name: Set Up Cache
+      uses: actions/cache@v3
+      env:
+        cache-name: tests-nonmpi
+      with:
+        path: ~/.cache
+        key: ccache-gcc.yml-${{ env.cache-name }}-git-${{ github.sha }}
+        restore-keys: |
+             ccache-gcc.yml-${{ env.cache-name }}-git-
     - name: Build & Install
+      env: {CXXFLAGS: "-fno-operator-names -Werror -Wall -Wextra -Wpedantic -Wnull-dereference -Wfloat-conversion -Wshadow -Woverloaded-virtual -Wnon-virtual-dtor -Wlogical-op -Wmisleading-indentation -Wduplicated-cond -Wduplicated-branches -Wmissing-include-dirs"}
       run: |
+        export CCACHE_COMPRESS=1
+        export CCACHE_COMPRESSLEVEL=10
+        export CCACHE_MAXSIZE=125M
+        ccache -z
+
         mkdir build
         cd build
         cmake ..                        \
@@ -196,31 +301,49 @@ jobs:
             -DCMAKE_CXX_COMPILER=$(which g++-8)   \
             -DCMAKE_Fortran_COMPILER=$(which gfortran-8) \
             -DAMReX_CLANG_TIDY=ON       \
-            -DAMReX_CLANG_TIDY_WERROR=ON
+            -DAMReX_CLANG_TIDY_WERROR=ON \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
         make -j 2
 
         ctest --output-on-failure
+
+        ccache -s
 
   # Build libamrex and all tests
   tests-nofortran:
     name: GNU@12 C++17 w/o Fortran [tests]
     runs-on: ubuntu-22.04
-    #
-    # /home/runner/work/amrex/amrex/Src/Base/AMReX_IntVect.H:194:92: error: array subscript -1 is below array bounds of ‘int [3]’ [-Werror=array-bounds]
-    # int& operator[] (int i) noexcept { BL_ASSERT(i>=0 && i < AMREX_SPACEDIM); return vect[i]; }
-    #
-    # inlined from ‘const amrex::MultiFab& amrex::EBFArrayBoxFactory::getVolFrac() const’ at /home/runner/work/amrex/amrex/Src/EB/AMReX_EBFabFactory.H:53:91,
-    # /usr/include/c++/12/bits/shared_ptr_base.h:1666:16: error: potential null pointer dereference [-Werror=null-dereference]
-    #
-    env: {CXXFLAGS: "-fno-operator-names -Werror -Wall -Wextra -Wpedantic -Wnull-dereference -Wfloat-conversion -Wshadow -Woverloaded-virtual -Wunreachable-code -Wnon-virtual-dtor -Wlogical-op -Wmisleading-indentation -Wduplicated-cond -Wduplicated-branches -Wmissing-include-dirs -Wno-array-bounds -Wno-null-dereference"}
     steps:
     - uses: actions/checkout@v3
     - name: Dependencies
       run: |
         .github/workflows/dependencies/dependencies_gcc.sh 12
         .github/workflows/dependencies/dependencies_clang-tidy.sh 14
+        .github/workflows/dependencies/dependencies_ccache.sh
+    - name: Set Up Cache
+      uses: actions/cache@v3
+      env:
+        cache-name: tests-nofortran
+      with:
+        path: ~/.cache
+        key: ccache-gcc.yml-${{ env.cache-name }}-git-${{ github.sha }}
+        restore-keys: |
+             ccache-gcc.yml-${{ env.cache-name }}-git-
     - name: Build & Install
+      #
+      # /home/runner/work/amrex/amrex/Src/Base/AMReX_IntVect.H:194:92: error: array subscript -1 is below array bounds of ‘int [3]’ [-Werror=array-bounds]
+      # int& operator[] (int i) noexcept { BL_ASSERT(i>=0 && i < AMREX_SPACEDIM); return vect[i]; }
+      #
+      # inlined from ‘const amrex::MultiFab& amrex::EBFArrayBoxFactory::getVolFrac() const’ at /home/runner/work/amrex/amrex/Src/EB/AMReX_EBFabFactory.H:53:91,
+      # /usr/include/c++/12/bits/shared_ptr_base.h:1666:16: error: potential null pointer dereference [-Werror=null-dereference]
+      #
+      env: {CXXFLAGS: "-fno-operator-names -Werror -Wall -Wextra -Wpedantic -Wnull-dereference -Wfloat-conversion -Wshadow -Woverloaded-virtual -Wunreachable-code -Wnon-virtual-dtor -Wlogical-op -Wmisleading-indentation -Wduplicated-cond -Wduplicated-branches -Wmissing-include-dirs -Wno-array-bounds -Wno-null-dereference"}
       run: |
+        export CCACHE_COMPRESS=1
+        export CCACHE_COMPRESSLEVEL=10
+        export CCACHE_MAXSIZE=500M
+        ccache -z
+
         mkdir build
         cd build
         cmake ..                        \
@@ -239,10 +362,13 @@ jobs:
             -DCMAKE_CXX_COMPILER=$(which g++-12)   \
             -DCMAKE_CXX_STANDARD=17     \
             -DAMReX_CLANG_TIDY=ON       \
-            -DAMReX_CLANG_TIDY_WERROR=ON
+            -DAMReX_CLANG_TIDY_WERROR=ON \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
         make -j 2
 
         ctest --output-on-failure
+
+        ccache -s
 
   # Build 1D libamrex with configure
   configure-1d:
@@ -254,12 +380,30 @@ jobs:
       run: |
         .github/workflows/dependencies/dependencies.sh
         .github/workflows/dependencies/dependencies_clang-tidy.sh 12
+        .github/workflows/dependencies/dependencies_ccache.sh
+    - name: Set Up Cache
+      uses: actions/cache@v3
+      env:
+        cache-name: configure-1d
+      with:
+        path: ~/.cache
+        key: ccache-gcc.yml-${{ env.cache-name }}-git-${{ github.sha }}
+        restore-keys: |
+             ccache-gcc.yml-${{ env.cache-name }}-git-
     - name: Build & Install
       run: |
+        export CCACHE_COMPRESS=1
+        export CCACHE_COMPRESSLEVEL=10
+        export CCACHE_MAXSIZE=250M
+        ccache -z
+
         ./configure --dim 1
         make -j2 XTRA_CXXFLAGS=-fno-operator-names \
-            USE_CLANG_TIDY=TRUE CLANG_TIDY=clang-tidy-12 CLANG_TIDY_WARN_ERROR=TRUE
+            USE_CLANG_TIDY=TRUE CLANG_TIDY=clang-tidy-12 CLANG_TIDY_WARN_ERROR=TRUE \
+            CCACHE=ccache
         make install
+
+        ccache -s
 
   # Build 3D libamrex with configure
   configure-3d:
@@ -271,12 +415,30 @@ jobs:
       run: |
         .github/workflows/dependencies/dependencies.sh
         .github/workflows/dependencies/dependencies_clang-tidy.sh 12
+        .github/workflows/dependencies/dependencies_ccache.sh
+    - name: Set Up Cache
+      uses: actions/cache@v3
+      env:
+        cache-name: configure-3d
+      with:
+        path: ~/.cache
+        key: ccache-gcc.yml-${{ env.cache-name }}-git-${{ github.sha }}
+        restore-keys: |
+             ccache-gcc.yml-${{ env.cache-name }}-git-
     - name: Build & Install
       run: |
+        export CCACHE_COMPRESS=1
+        export CCACHE_COMPRESSLEVEL=10
+        export CCACHE_MAXSIZE=250M
+        ccache -z
+
         ./configure --dim 3 --enable-eb yes --enable-xsdk-defaults yes
         make -j2 WARN_ALL=TRUE WARN_ERROR=TRUE XTRA_CXXFLAGS=-fno-operator-names \
-            USE_CLANG_TIDY=TRUE CLANG_TIDY=clang-tidy-12 CLANG_TIDY_WARN_ERROR=TRUE
+            USE_CLANG_TIDY=TRUE CLANG_TIDY=clang-tidy-12 CLANG_TIDY_WARN_ERROR=TRUE \
+            CCACHE=ccache
         make install
+
+        ccache -s
 
   # Build 3D libamrex with single precision and tiny profiler
   configure-3d-single-tprof:
@@ -288,12 +450,30 @@ jobs:
       run: |
         .github/workflows/dependencies/dependencies.sh
         .github/workflows/dependencies/dependencies_clang-tidy.sh 12
+        .github/workflows/dependencies/dependencies_ccache.sh
+    - name: Set Up Cache
+      uses: actions/cache@v3
+      env:
+        cache-name: configure-3d-single-tprof
+      with:
+        path: ~/.cache
+        key: ccache-gcc.yml-${{ env.cache-name }}-git-${{ github.sha }}
+        restore-keys: |
+             ccache-gcc.yml-${{ env.cache-name }}-git-
     - name: Build & Install
       run: |
+        export CCACHE_COMPRESS=1
+        export CCACHE_COMPRESSLEVEL=10
+        export CCACHE_MAXSIZE=250M
+        ccache -z
+
         ./configure --dim 3 --enable-eb no --enable-xsdk-defaults no --single-precision yes --single-precision-particles yes --enable-tiny-profile yes
         make -j2 WARN_ALL=TRUE WARN_ERROR=TRUE XTRA_CXXFLAGS=-fno-operator-names \
-            USE_CLANG_TIDY=TRUE CLANG_TIDY=clang-tidy-12 CLANG_TIDY_WARN_ERROR=TRUE
+            USE_CLANG_TIDY=TRUE CLANG_TIDY=clang-tidy-12 CLANG_TIDY_WARN_ERROR=TRUE \
+            CCACHE=ccache
         make install
+
+        ccache -s
 
   # Build 3D libamrex debug omp build with configure
   configure-3d-omp-debug:
@@ -305,12 +485,30 @@ jobs:
       run: |
         .github/workflows/dependencies/dependencies.sh
         .github/workflows/dependencies/dependencies_clang-tidy.sh 12
+        .github/workflows/dependencies/dependencies_ccache.sh
+    - name: Set Up Cache
+      uses: actions/cache@v3
+      env:
+        cache-name: configure-3d-omp-debug
+      with:
+        path: ~/.cache
+        key: ccache-gcc.yml-${{ env.cache-name }}-git-${{ github.sha }}
+        restore-keys: |
+             ccache-gcc.yml-${{ env.cache-name }}-git-
     - name: Build & Install
       run: |
+        export CCACHE_COMPRESS=1
+        export CCACHE_COMPRESSLEVEL=10
+        export CCACHE_MAXSIZE=250M
+        ccache -z
+
         ./configure --dim 3 --enable-eb yes --enable-xsdk-defaults yes --with-omp yes --debug yes
         make -j2 WARN_ALL=TRUE WARN_ERROR=TRUE XTRA_CXXFLAGS=-fno-operator-names \
-            USE_CLANG_TIDY=TRUE CLANG_TIDY=clang-tidy-12 CLANG_TIDY_WARN_ERROR=TRUE
+            USE_CLANG_TIDY=TRUE CLANG_TIDY=clang-tidy-12 CLANG_TIDY_WARN_ERROR=TRUE \
+            CCACHE=ccache
         make install
+
+        ccache -s
 
   # Build Tools/Plotfile
   plotfile-tools:
@@ -322,25 +520,58 @@ jobs:
       run: |
         .github/workflows/dependencies/dependencies.sh
         .github/workflows/dependencies/dependencies_clang-tidy.sh 12
+        .github/workflows/dependencies/dependencies_ccache.sh
+    - name: Set Up Cache
+      uses: actions/cache@v3
+      env:
+        cache-name: plotfile-tools
+      with:
+        path: ~/.cache
+        key: ccache-gcc.yml-${{ env.cache-name }}-git-${{ github.sha }}
+        restore-keys: |
+             ccache-gcc.yml-${{ env.cache-name }}-git-
     - name: Build & Install
       run: |
+        export CCACHE_COMPRESS=1
+        export CCACHE_COMPRESSLEVEL=10
+        export CCACHE_MAXSIZE=125M
+        ccache -z
+
         cd Tools/Plotfile
         make -j2 USE_MPI=FALSE USE_OMP=FALSE WARN_ALL=TRUE WARN_ERROR=TRUE XTRA_CXXFLAGS=-fno-operator-names \
-            USE_CLANG_TIDY=TRUE CLANG_TIDY=clang-tidy-12 CLANG_TIDY_WARN_ERROR=TRUE
+            USE_CLANG_TIDY=TRUE CLANG_TIDY=clang-tidy-12 CLANG_TIDY_WARN_ERROR=TRUE \
+            CCACHE=ccache
+
+        ccache -s
 
   # Build libamrex and run all tests
   tests_run:
     name: GNU@9.3 C++17 [tests]
     runs-on: ubuntu-20.04
-    env: {CXXFLAGS: "-fno-operator-names -Werror -Wall -Wextra -Wpedantic -Wnull-dereference -Wfloat-conversion -Wshadow -Woverloaded-virtual -Wunreachable-code -Wnon-virtual-dtor -Wlogical-op -Wmisleading-indentation -Wduplicated-cond -Wduplicated-branches -Wmissing-include-dirs"}
     steps:
     - uses: actions/checkout@v3
     - name: Dependencies
       run: |
         .github/workflows/dependencies/dependencies.sh
         .github/workflows/dependencies/dependencies_clang-tidy.sh 12
+        .github/workflows/dependencies/dependencies_ccache.sh
+    - name: Set Up Cache
+      uses: actions/cache@v3
+      env:
+        cache-name: tests_run
+      with:
+        path: ~/.cache
+        key: ccache-gcc.yml-${{ env.cache-name }}-git-${{ github.sha }}
+        restore-keys: |
+             ccache-gcc.yml-${{ env.cache-name }}-git-
     - name: Build & Install
+      env: {CXXFLAGS: "-fno-operator-names -Werror -Wall -Wextra -Wpedantic -Wnull-dereference -Wfloat-conversion -Wshadow -Woverloaded-virtual -Wunreachable-code -Wnon-virtual-dtor -Wlogical-op -Wmisleading-indentation -Wduplicated-cond -Wduplicated-branches -Wmissing-include-dirs"}
       run: |
+        export CCACHE_COMPRESS=1
+        export CCACHE_COMPRESSLEVEL=10
+        export CCACHE_MAXSIZE=125M
+        ccache -z
+
         mkdir build
         cd build
         cmake ..                        \
@@ -349,8 +580,12 @@ jobs:
             -DAMReX_ENABLE_TESTS=ON     \
             -DAMReX_PARTICLES=ON        \
             -DAMReX_CLANG_TIDY=ON       \
-            -DAMReX_CLANG_TIDY_WERROR=ON
+            -DAMReX_CLANG_TIDY_WERROR=ON \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
         make -j 2
+
+        ccache -s
+
     - name: Run tests
       run: |
         cd build

--- a/.github/workflows/hip.yml
+++ b/.github/workflows/hip.yml
@@ -18,13 +18,11 @@ jobs:
         .github/workflows/dependencies/dependencies_ccache.sh
     - name: Set Up Cache
       uses: actions/cache@v3
-      env:
-        cache-name: tests-hip
       with:
         path: ~/.cache
-        key: ccache-hip.yml-${{ env.cache-name }}-git-${{ github.sha }}
+        key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}
         restore-keys: |
-             ccache-hip.yml-${{ env.cache-name }}-git-
+             ccache-${{ github.workflow }}-${{ github.job }}-git-
     - name: Build & Install
       # Have to have -Wno-deprecated-declarations due to deprecated atomicAddNoRet
       # Have to have -Wno-gnu-zero-variadic-macro-arguments to avoid
@@ -84,13 +82,11 @@ jobs:
         .github/workflows/dependencies/dependencies_ccache.sh
     - name: Set Up Cache
       uses: actions/cache@v3
-      env:
-        cache-name: tests-hip-wrapper
       with:
         path: ~/.cache
-        key: ccache-hip.yml-${{ env.cache-name }}-git-${{ github.sha }}
+        key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}
         restore-keys: |
-             ccache-hip.yml-${{ env.cache-name }}-git-
+             ccache-${{ github.workflow }}-${{ github.job }}-git-
     - name: Build & Install
       # Have to have -Wno-deprecated-declarations due to deprecated atomicAddNoRet
       # Have to have -Wno-gnu-zero-variadic-macro-arguments to avoid
@@ -149,13 +145,11 @@ jobs:
         .github/workflows/dependencies/dependencies_ccache.sh
     - name: Set Up Cache
       uses: actions/cache@v3
-      env:
-        cache-name: configure-2d-single-hip
       with:
         path: ~/.cache
-        key: ccache-hip.yml-${{ env.cache-name }}-git-${{ github.sha }}
+        key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}
         restore-keys: |
-             ccache-hip.yml-${{ env.cache-name }}-git-
+             ccache-${{ github.workflow }}-${{ github.job }}-git-
     - name: Build & Install
       run: |
         export CCACHE_COMPRESS=1

--- a/.github/workflows/hip.yml
+++ b/.github/workflows/hip.yml
@@ -10,23 +10,39 @@ jobs:
   tests-hip:
     name: HIP ROCm Flang C++17 [tests]
     runs-on: ubuntu-20.04
-    # Have to have -Wno-deprecated-declarations due to deprecated atomicAddNoRet
-    # Have to have -Wno-gnu-zero-variadic-macro-arguments to avoid
-    #    amrex/Src/Base/AMReX_GpuLaunchGlobal.H:15:5: error: must specify at least one argument for '...' parameter of variadic macro [-Werror,-Wgnu-zero-variadic-macro-arguments]
-    #        __launch_bounds__(amrex_launch_bounds_max_threads)
-    #        ^
-    #    /opt/rocm-4.1.1/hip/include/hip/hcc_detail/hip_runtime.h:178:71: note: expanded from macro '__launch_bounds__'
-    #        select_impl_(__VA_ARGS__, launch_bounds_impl1, launch_bounds_impl0)(__VA_ARGS__)
-    #                                                                          ^
-    #    /opt/rocm-4.1.1/hip/include/hip/hcc_detail/hip_runtime.h:176:9: note: macro 'select_impl_' defined here
-    #    #define select_impl_(_1, _2, impl_, ...) impl_
-    env: {CXXFLAGS: "-fno-operator-names -Werror -Wall -Wextra -Wpedantic -Wnull-dereference -Wfloat-conversion -Wshadow -Woverloaded-virtual -Wextra-semi -Wunreachable-code -Wnon-virtual-dtor -Wno-deprecated-declarations -Wno-gnu-zero-variadic-macro-arguments"}
     steps:
     - uses: actions/checkout@v3
     - name: Dependencies
-      run: .github/workflows/dependencies/dependencies_hip.sh
-    - name: Build & Install
       run: |
+        .github/workflows/dependencies/dependencies_hip.sh
+        .github/workflows/dependencies/dependencies_ccache.sh
+    - name: Set Up Cache
+      uses: actions/cache@v3
+      env:
+        cache-name: tests-hip
+      with:
+        path: ~/.cache
+        key: ccache-hip.yml-${{ env.cache-name }}-git-${{ github.sha }}
+        restore-keys: |
+             ccache-hip.yml-${{ env.cache-name }}-git-
+    - name: Build & Install
+      # Have to have -Wno-deprecated-declarations due to deprecated atomicAddNoRet
+      # Have to have -Wno-gnu-zero-variadic-macro-arguments to avoid
+      #    amrex/Src/Base/AMReX_GpuLaunchGlobal.H:15:5: error: must specify at least one argument for '...' parameter of variadic macro [-Werror,-Wgnu-zero-variadic-macro-arguments]
+      #        __launch_bounds__(amrex_launch_bounds_max_threads)
+      #        ^
+      #    /opt/rocm-4.1.1/hip/include/hip/hcc_detail/hip_runtime.h:178:71: note: expanded from macro '__launch_bounds__'
+      #        select_impl_(__VA_ARGS__, launch_bounds_impl1, launch_bounds_impl0)(__VA_ARGS__)
+      #                                                                          ^
+      #    /opt/rocm-4.1.1/hip/include/hip/hcc_detail/hip_runtime.h:176:9: note: macro 'select_impl_' defined here
+      #    #define select_impl_(_1, _2, impl_, ...) impl_
+      env: {CXXFLAGS: "-fno-operator-names -Werror -Wall -Wextra -Wpedantic -Wnull-dereference -Wfloat-conversion -Wshadow -Woverloaded-virtual -Wextra-semi -Wunreachable-code -Wnon-virtual-dtor -Wno-deprecated-declarations -Wno-gnu-zero-variadic-macro-arguments"}
+      run: |
+        export CCACHE_COMPRESS=1
+        export CCACHE_COMPRESSLEVEL=10
+        export CCACHE_MAXSIZE=125M
+        ccache -z
+
         source /etc/profile.d/rocm.sh
         hipcc --version
         which clang
@@ -51,29 +67,48 @@ jobs:
             -DCMAKE_C_COMPILER=$(which clang)             \
             -DCMAKE_CXX_COMPILER=$(which clang++)         \
             -DCMAKE_Fortran_COMPILER=$(which flang)       \
-            -DCMAKE_CXX_STANDARD=17
+            -DCMAKE_CXX_STANDARD=17                       \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
         cmake --build build -j 2
+
+        ccache -s
 
   tests-hip-wrapper:
     name: HIP ROCm GFortran@9.3 C++17 [tests-hipcc]
     runs-on: ubuntu-20.04
-    # Have to have -Wno-deprecated-declarations due to deprecated atomicAddNoRet
-    # Have to have -Wno-gnu-zero-variadic-macro-arguments to avoid
-    #    amrex/Src/Base/AMReX_GpuLaunchGlobal.H:15:5: error: must specify at least one argument for '...' parameter of variadic macro [-Werror,-Wgnu-zero-variadic-macro-arguments]
-    #        __launch_bounds__(amrex_launch_bounds_max_threads)
-    #        ^
-    #    /opt/rocm-4.1.1/hip/include/hip/hcc_detail/hip_runtime.h:178:71: note: expanded from macro '__launch_bounds__'
-    #        select_impl_(__VA_ARGS__, launch_bounds_impl1, launch_bounds_impl0)(__VA_ARGS__)
-    #                                                                          ^
-    #    /opt/rocm-4.1.1/hip/include/hip/hcc_detail/hip_runtime.h:176:9: note: macro 'select_impl_' defined here
-    #    #define select_impl_(_1, _2, impl_, ...) impl_
-    env: {CXXFLAGS: "-fno-operator-names -Werror -Wall -Wextra -Wpedantic -Wnull-dereference -Wfloat-conversion -Wshadow -Woverloaded-virtual -Wextra-semi -Wunreachable-code -Wnon-virtual-dtor -Wno-deprecated-declarations -Wno-gnu-zero-variadic-macro-arguments"}
     steps:
     - uses: actions/checkout@v3
     - name: Dependencies
-      run: .github/workflows/dependencies/dependencies_hip.sh
-    - name: Build & Install
       run: |
+        .github/workflows/dependencies/dependencies_hip.sh
+        .github/workflows/dependencies/dependencies_ccache.sh
+    - name: Set Up Cache
+      uses: actions/cache@v3
+      env:
+        cache-name: tests-hip-wrapper
+      with:
+        path: ~/.cache
+        key: ccache-hip.yml-${{ env.cache-name }}-git-${{ github.sha }}
+        restore-keys: |
+             ccache-hip.yml-${{ env.cache-name }}-git-
+    - name: Build & Install
+      # Have to have -Wno-deprecated-declarations due to deprecated atomicAddNoRet
+      # Have to have -Wno-gnu-zero-variadic-macro-arguments to avoid
+      #    amrex/Src/Base/AMReX_GpuLaunchGlobal.H:15:5: error: must specify at least one argument for '...' parameter of variadic macro [-Werror,-Wgnu-zero-variadic-macro-arguments]
+      #        __launch_bounds__(amrex_launch_bounds_max_threads)
+      #        ^
+      #    /opt/rocm-4.1.1/hip/include/hip/hcc_detail/hip_runtime.h:178:71: note: expanded from macro '__launch_bounds__'
+      #        select_impl_(__VA_ARGS__, launch_bounds_impl1, launch_bounds_impl0)(__VA_ARGS__)
+      #                                                                          ^
+      #    /opt/rocm-4.1.1/hip/include/hip/hcc_detail/hip_runtime.h:176:9: note: macro 'select_impl_' defined here
+      #    #define select_impl_(_1, _2, impl_, ...) impl_
+      env: {CXXFLAGS: "-fno-operator-names -Werror -Wall -Wextra -Wpedantic -Wnull-dereference -Wfloat-conversion -Wshadow -Woverloaded-virtual -Wextra-semi -Wunreachable-code -Wnon-virtual-dtor -Wno-deprecated-declarations -Wno-gnu-zero-variadic-macro-arguments"}
+      run: |
+        export CCACHE_COMPRESS=1
+        export CCACHE_COMPRESSLEVEL=10
+        export CCACHE_MAXSIZE=125M
+        ccache -z
+
         source /etc/profile.d/rocm.sh
         hipcc --version
 
@@ -96,8 +131,11 @@ jobs:
             -DCMAKE_C_COMPILER=$(which clang)             \
             -DCMAKE_CXX_COMPILER=$(which hipcc)           \
             -DCMAKE_Fortran_COMPILER=$(which gfortran)    \
-            -DCMAKE_CXX_STANDARD=17
+            -DCMAKE_CXX_STANDARD=17                       \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
         cmake --build build_full_legacywrapper -j 2
+
+        ccache -s
 
   # Build 2D libamrex hip build with configure
   configure-2d-single-hip:
@@ -106,9 +144,27 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Dependencies
-      run: .github/workflows/dependencies/dependencies_hip.sh
+      run: |
+        .github/workflows/dependencies/dependencies_hip.sh
+        .github/workflows/dependencies/dependencies_ccache.sh
+    - name: Set Up Cache
+      uses: actions/cache@v3
+      env:
+        cache-name: configure-2d-single-hip
+      with:
+        path: ~/.cache
+        key: ccache-hip.yml-${{ env.cache-name }}-git-${{ github.sha }}
+        restore-keys: |
+             ccache-hip.yml-${{ env.cache-name }}-git-
     - name: Build & Install
       run: |
+        export CCACHE_COMPRESS=1
+        export CCACHE_COMPRESSLEVEL=10
+        export CCACHE_MAXSIZE=125M
+        ccache -z
+
         ./configure --dim 2 --with-hip yes --enable-eb yes --enable-xsdk-defaults yes --with-mpi no --with-omp no --single-precision yes --single-precision-particles yes
-        make -j2 WARN_ALL=TRUE XTRA_CXXFLAGS="-fno-operator-names"
+        make -j2 WARN_ALL=TRUE XTRA_CXXFLAGS="-fno-operator-names" CCACHE=ccache
         make install
+
+        ccache -s

--- a/.github/workflows/hypre.yml
+++ b/.github/workflows/hypre.yml
@@ -19,13 +19,11 @@ jobs:
         .github/workflows/dependencies/dependencies_ccache.sh
     - name: Set Up Cache
       uses: actions/cache@v3
-      env:
-        cache-name: compile-hypre-cuda-eb-2d
       with:
         path: ~/.cache
-        key: ccache-hypre.yml-${{ env.cache-name }}-git-${{ github.sha }}
+        key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}
         restore-keys: |
-             ccache-hypre.yml-${{ env.cache-name }}-git-
+             ccache-${{ github.workflow }}-${{ github.job }}-git-
     - name: Build Hypre
       run: |
         wget -q https://github.com/hypre-space/hypre/archive/refs/tags/v2.26.0.tar.gz
@@ -64,13 +62,11 @@ jobs:
         .github/workflows/dependencies/dependencies_ccache.sh
     - name: Set Up Cache
       uses: actions/cache@v3
-      env:
-        cache-name: test-hypre-cpu-3d
       with:
         path: ~/.cache
-        key: ccache-hypre.yml-${{ env.cache-name }}-git-${{ github.sha }}
+        key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}
         restore-keys: |
-             ccache-hypre.yml-${{ env.cache-name }}-git-
+             ccache-${{ github.workflow }}-${{ github.job }}-git-
     - name: Build Hypre
       run: |
         wget -q https://github.com/hypre-space/hypre/archive/refs/tags/v2.21.0.tar.gz

--- a/.github/workflows/hypre.yml
+++ b/.github/workflows/hypre.yml
@@ -16,6 +16,16 @@ jobs:
       run: |
         .github/workflows/dependencies/dependencies_nvcc11.sh
         sudo apt-get install -y libcublas-dev-11-2 libcusparse-dev-11-2
+        .github/workflows/dependencies/dependencies_ccache.sh
+    - name: Set Up Cache
+      uses: actions/cache@v3
+      env:
+        cache-name: compile-hypre-cuda-eb-2d
+      with:
+        path: ~/.cache
+        key: ccache-hypre.yml-${{ env.cache-name }}-git-${{ github.sha }}
+        restore-keys: |
+             ccache-hypre.yml-${{ env.cache-name }}-git-
     - name: Build Hypre
       run: |
         wget -q https://github.com/hypre-space/hypre/archive/refs/tags/v2.26.0.tar.gz
@@ -28,12 +38,19 @@ jobs:
         cd ../../
     - name: Compile Test
       run: |
+        export CCACHE_COMPRESS=1
+        export CCACHE_COMPRESSLEVEL=10
+        export CCACHE_MAXSIZE=500M
+        ccache -z
+
         export AMREX_HYPRE_HOME=${PWD}/hypre-2.26.0/src/hypre
         export AMREX_CUDA_ARCH=80
         export CUDA_PATH=/usr/local/cuda
         export PATH=${PATH}:/usr/local/cuda/bin
         cd Tests/LinearSolvers/CellEB
-        make -j2 USE_MPI=TRUE USE_HYPRE=TRUE DIM=2 USE_CUDA=TRUE
+        make -j2 USE_MPI=TRUE USE_HYPRE=TRUE DIM=2 USE_CUDA=TRUE CCACHE=ccache
+
+        ccache -s
 
   test-hypre-cpu-3d:
     name: GCC 3D Hypre@2.21.0
@@ -44,6 +61,16 @@ jobs:
       run: |
         .github/workflows/dependencies/dependencies.sh
         .github/workflows/dependencies/dependencies_clang-tidy.sh 14
+        .github/workflows/dependencies/dependencies_ccache.sh
+    - name: Set Up Cache
+      uses: actions/cache@v3
+      env:
+        cache-name: test-hypre-cpu-3d
+      with:
+        path: ~/.cache
+        key: ccache-hypre.yml-${{ env.cache-name }}-git-${{ github.sha }}
+        restore-keys: |
+             ccache-hypre.yml-${{ env.cache-name }}-git-
     - name: Build Hypre
       run: |
         wget -q https://github.com/hypre-space/hypre/archive/refs/tags/v2.21.0.tar.gz
@@ -55,8 +82,16 @@ jobs:
         cd ../../
     - name: Build and Run Test
       run: |
+        export CCACHE_COMPRESS=1
+        export CCACHE_COMPRESSLEVEL=10
+        export CCACHE_MAXSIZE=125M
+        ccache -z
+
         export AMREX_HYPRE_HOME=${PWD}/hypre-2.21.0/src/hypre
         cd Tests/LinearSolvers/ABecLaplacian_C
         make -j2 USE_MPI=TRUE USE_HYPRE=TRUE DIM=3 \
-            USE_CLANG_TIDY=TRUE CLANG_TIDY=clang-tidy-14 CLANG_TIDY_WARN_ERROR=TRUE
+            USE_CLANG_TIDY=TRUE CLANG_TIDY=clang-tidy-14 CLANG_TIDY_WARN_ERROR=TRUE \
+            CCACHE=ccache
         mpiexec -n 2 ./main3d.gnu.MPI.ex inputs.hypre
+
+        ccache -s

--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -11,12 +11,12 @@ jobs:
     name: oneAPI SYCL [tests]
     runs-on: ubuntu-20.04
     # mkl/rng/device/detail/mrg32k3a_impl.hpp has a number of sign-compare error
-    env: {CXXFLAGS: "-fno-operator-names -Werror -Wall -Wextra -Wpedantic -Wnull-dereference -Wfloat-conversion -Wshadow -Woverloaded-virtual -Wextra-semi -Wunreachable-code -Wnon-virtual-dtor -Wno-sign-compare"}
     steps:
     - uses: actions/checkout@v3
     - name: Dependencies
       run: .github/workflows/dependencies/dependencies_dpcpp.sh
     - name: Build & Install
+      env: {CXXFLAGS: "-fno-operator-names -Werror -Wall -Wextra -Wpedantic -Wnull-dereference -Wfloat-conversion -Wshadow -Woverloaded-virtual -Wextra-semi -Wunreachable-code -Wnon-virtual-dtor -Wno-sign-compare"}
       run: |
         set +e
         source /opt/intel/oneapi/setvars.sh
@@ -36,13 +36,13 @@ jobs:
   tests-oneapi-sycl-eb:
     name: oneAPI SYCL [tests w/ EB]
     runs-on: ubuntu-20.04
-    # mkl/rng/device/detail/mrg32k3a_impl.hpp has a number of sign-compare error
-    env: {CXXFLAGS: "-fno-operator-names -Werror -Wall -Wextra -Wpedantic -Wnull-dereference -Wfloat-conversion -Wshadow -Woverloaded-virtual -Wextra-semi -Wunreachable-code -Wnon-virtual-dtor -Wno-sign-compare"}
     steps:
     - uses: actions/checkout@v3
     - name: Dependencies
       run: .github/workflows/dependencies/dependencies_dpcpp.sh
     - name: Build & Install
+      # mkl/rng/device/detail/mrg32k3a_impl.hpp has a number of sign-compare error
+      env: {CXXFLAGS: "-fno-operator-names -Werror -Wall -Wextra -Wpedantic -Wnull-dereference -Wfloat-conversion -Wshadow -Woverloaded-virtual -Wextra-semi -Wunreachable-code -Wnon-virtual-dtor -Wno-sign-compare"}
       run: |
         set +e
         source /opt/intel/oneapi/setvars.sh
@@ -64,7 +64,6 @@ jobs:
   tests-icc:
     name: ICC [tests]
     runs-on: ubuntu-20.04
-    env: {CXXFLAGS: "-Werror"}
     steps:
     - uses: actions/checkout@v3
     - name: install dependencies
@@ -77,8 +76,24 @@ jobs:
         echo "deb https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
         sudo apt-get update
         sudo apt-get install -y intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic intel-oneapi-compiler-fortran intel-oneapi-mpi-devel
+        .github/workflows/dependencies/dependencies_ccache.sh
+    - name: Set Up Cache
+      uses: actions/cache@v3
+      env:
+        cache-name: tests-icc
+      with:
+        path: ~/.cache
+        key: ccache-intel.yml-${{ env.cache-name }}-git-${{ github.sha }}
+        restore-keys: |
+             ccache-intel.yml-${{ env.cache-name }}-git-
     - name: build
+      env: {CXXFLAGS: "-Werror"}
       run: |
+        export CCACHE_COMPRESS=1
+        export CCACHE_COMPRESSLEVEL=10
+        export CCACHE_MAXSIZE=125M
+        ccache -z
+
         set +e
         source /opt/intel/oneapi/setvars.sh
         set -e
@@ -91,10 +106,13 @@ jobs:
             -DAMReX_EB=ON                                  \
             -DAMReX_ENABLE_TESTS=ON                        \
             -DAMReX_FORTRAN=ON                             \
-            -DAMReX_PARTICLES=ON
+            -DAMReX_PARTICLES=ON                           \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
         cmake --build build --parallel 2
         cmake --build build --target install
         cmake --build build --target test_install
+
+        ccache -s
 
     - name: Run tests
       run: |

--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -79,13 +79,11 @@ jobs:
         .github/workflows/dependencies/dependencies_ccache.sh
     - name: Set Up Cache
       uses: actions/cache@v3
-      env:
-        cache-name: tests-icc
       with:
         path: ~/.cache
-        key: ccache-intel.yml-${{ env.cache-name }}-git-${{ github.sha }}
+        key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}
         restore-keys: |
-             ccache-intel.yml-${{ env.cache-name }}-git-
+             ccache-${{ github.workflow }}-${{ github.job }}-git-
     - name: build
       env: {CXXFLAGS: "-Werror"}
       run: |

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -11,17 +11,31 @@ jobs:
   tests-macos-universal-nompi:
     name: AppleClang Universal w/o MPI [tests-universal]
     runs-on: macos-latest
-    env:
-      # build universal binaries for M1 "Apple Silicon" and Intel CPUs
-      CMAKE_OSX_ARCHITECTURES: "arm64;x86_64"
-      CXXFLAGS: "-fno-operator-names -Werror -Wall -Wextra -Wpedantic -Wnull-dereference -Wfloat-conversion -Wshadow -Woverloaded-virtual -Wextra-semi -Wunreachable-code -Wnon-virtual-dtor -Wno-c++17-extensions -Wno-range-loop-analysis"
-      # -Wno-range-loop-analysis: Apple clang has a bug in range-loop-analysis
     steps:
     - uses: actions/checkout@v3
     - name: Dependencies
       run: .github/workflows/dependencies/dependencies_mac.sh
+    - name: Set Up Cache
+      uses: actions/cache@v3
+      env:
+        cache-name: tests-macos-universal-nompi
+      with:
+        path: /Users/runner/Library/Caches/ccache
+        key: ccache-macos.yml-${{ env.cache-name }}-git-${{ github.sha }}
+        restore-keys: |
+             ccache-macos.yml-${{ env.cache-name }}-git-
     - name: Build & Install
+      env:
+        # build universal binaries for M1 "Apple Silicon" and Intel CPUs
+        CMAKE_OSX_ARCHITECTURES: "arm64;x86_64"
+        CXXFLAGS: "-fno-operator-names -Werror -Wall -Wextra -Wpedantic -Wnull-dereference -Wfloat-conversion -Wshadow -Woverloaded-virtual -Wextra-semi -Wunreachable-code -Wnon-virtual-dtor -Wno-c++17-extensions -Wno-range-loop-analysis"
+        # -Wno-range-loop-analysis: Apple clang has a bug in range-loop-analysis
       run: |
+        export CCACHE_COMPRESS=1
+        export CCACHE_COMPRESSLEVEL=10
+        export CCACHE_MAXSIZE=125M
+        ccache -z
+
         cmake -S . -B build             \
             -DBUILD_SHARED_LIBS=ON      \
             -DCMAKE_BUILD_TYPE=Release  \
@@ -29,31 +43,51 @@ jobs:
             -DAMReX_EB=ON               \
             -DAMReX_MPI=OFF             \
             -DAMReX_ENABLE_TESTS=ON     \
-            -DAMReX_PARTICLES=ON
+            -DAMReX_PARTICLES=ON        \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
         cmake --build build --parallel 2
 
         ctest --test-dir build --output-on-failure
+
+        ccache -s
 
   # Build libamrex and all tests
   tests-macos:
     name: AppleClang@11.0 GFortran@9.3 [tests]
     runs-on: macos-latest
-    env:
-      CXXFLAGS: "-fno-operator-names -Werror -Wall -Wextra -Wpedantic -Wnull-dereference -Wfloat-conversion -Wshadow -Woverloaded-virtual -Wextra-semi -Wunreachable-code -Wnon-virtual-dtor -Wno-c++17-extensions -Wno-range-loop-analysis"
-      # -Wno-range-loop-analysis: Apple clang has a bug in range-loop-analysis
     steps:
     - uses: actions/checkout@v3
     - name: Dependencies
       run: .github/workflows/dependencies/dependencies_mac.sh
+    - name: Set Up Cache
+      uses: actions/cache@v3
+      env:
+        cache-name: tests-macos
+      with:
+        path: /Users/runner/Library/Caches/ccache
+        key: ccache-macos.yml-${{ env.cache-name }}-git-${{ github.sha }}
+        restore-keys: |
+             ccache-macos.yml-${{ env.cache-name }}-git-
     - name: Build & Install
+      env:
+        CXXFLAGS: "-fno-operator-names -Werror -Wall -Wextra -Wpedantic -Wnull-dereference -Wfloat-conversion -Wshadow -Woverloaded-virtual -Wextra-semi -Wunreachable-code -Wnon-virtual-dtor -Wno-c++17-extensions -Wno-range-loop-analysis"
+        # -Wno-range-loop-analysis: Apple clang has a bug in range-loop-analysis
       run: |
+        export CCACHE_COMPRESS=1
+        export CCACHE_COMPRESSLEVEL=10
+        export CCACHE_MAXSIZE=250M
+        ccache -z
+
         cmake -S . -B build             \
             -DCMAKE_BUILD_TYPE=Debug    \
             -DCMAKE_VERBOSE_MAKEFILE=ON \
             -DAMReX_EB=ON               \
             -DAMReX_ENABLE_TESTS=ON     \
-            -DAMReX_PARTICLES=ON
+            -DAMReX_PARTICLES=ON        \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
         cmake --build build --parallel 2
         cmake --build build --target install
 
         ctest --test-dir build --output-on-failure
+
+        ccache -s

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -17,13 +17,11 @@ jobs:
       run: .github/workflows/dependencies/dependencies_mac.sh
     - name: Set Up Cache
       uses: actions/cache@v3
-      env:
-        cache-name: tests-macos-universal-nompi
       with:
         path: /Users/runner/Library/Caches/ccache
-        key: ccache-macos.yml-${{ env.cache-name }}-git-${{ github.sha }}
+        key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}
         restore-keys: |
-             ccache-macos.yml-${{ env.cache-name }}-git-
+             ccache-${{ github.workflow }}-${{ github.job }}-git-
     - name: Build & Install
       env:
         # build universal binaries for M1 "Apple Silicon" and Intel CPUs
@@ -61,13 +59,11 @@ jobs:
       run: .github/workflows/dependencies/dependencies_mac.sh
     - name: Set Up Cache
       uses: actions/cache@v3
-      env:
-        cache-name: tests-macos
       with:
         path: /Users/runner/Library/Caches/ccache
-        key: ccache-macos.yml-${{ env.cache-name }}-git-${{ github.sha }}
+        key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}
         restore-keys: |
-             ccache-macos.yml-${{ env.cache-name }}-git-
+             ccache-${{ github.workflow }}-${{ github.job }}-git-
     - name: Build & Install
       env:
         CXXFLAGS: "-fno-operator-names -Werror -Wall -Wextra -Wpedantic -Wnull-dereference -Wfloat-conversion -Wshadow -Woverloaded-virtual -Wextra-semi -Wunreachable-code -Wnon-virtual-dtor -Wno-c++17-extensions -Wno-range-loop-analysis"

--- a/.github/workflows/petsc.yml
+++ b/.github/workflows/petsc.yml
@@ -19,13 +19,11 @@ jobs:
         .github/workflows/dependencies/dependencies_ccache.sh
     - name: Set Up Cache
       uses: actions/cache@v3
-      env:
-        cache-name: test-petsc-cpu-2d
       with:
         path: ~/.cache
-        key: ccache-petsc.yml-${{ env.cache-name }}-git-${{ github.sha }}
+        key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}
         restore-keys: |
-             ccache-petsc.yml-${{ env.cache-name }}-git-
+             ccache-${{ github.workflow }}-${{ github.job }}-git-
     - name: Build PETSc
       run: |
         wget -q https://github.com/petsc/petsc/archive/refs/tags/v3.18.1.tar.gz

--- a/.github/workflows/petsc.yml
+++ b/.github/workflows/petsc.yml
@@ -16,6 +16,16 @@ jobs:
       run: |
         .github/workflows/dependencies/dependencies.sh
         .github/workflows/dependencies/dependencies_clang-tidy.sh 14
+        .github/workflows/dependencies/dependencies_ccache.sh
+    - name: Set Up Cache
+      uses: actions/cache@v3
+      env:
+        cache-name: test-petsc-cpu-2d
+      with:
+        path: ~/.cache
+        key: ccache-petsc.yml-${{ env.cache-name }}-git-${{ github.sha }}
+        restore-keys: |
+             ccache-petsc.yml-${{ env.cache-name }}-git-
     - name: Build PETSc
       run: |
         wget -q https://github.com/petsc/petsc/archive/refs/tags/v3.18.1.tar.gz
@@ -28,8 +38,16 @@ jobs:
         cd ../
     - name: Build and Run Test
       run: |
+        export CCACHE_COMPRESS=1
+        export CCACHE_COMPRESSLEVEL=10
+        export CCACHE_MAXSIZE=250M
+        ccache -z
+
         export AMREX_PETSC_HOME=${PWD}/petsc-3.18.1/petsc
         cd Tests/LinearSolvers/CellEB
         make -j2 USE_MPI=TRUE USE_PETSC=TRUE DIM=2 TEST=TRUE \
-            USE_CLANG_TIDY=TRUE CLANG_TIDY=clang-tidy-14 CLANG_TIDY_WARN_ERROR=TRUE
+            USE_CLANG_TIDY=TRUE CLANG_TIDY=clang-tidy-14 CLANG_TIDY_WARN_ERROR=TRUE \
+            CCACHE=ccache
         mpiexec -n 2 ./main2d.gnu.TEST.MPI.ex inputs.rt.2d.petsc
+
+        ccache -s

--- a/.github/workflows/sundials.yml
+++ b/.github/workflows/sundials.yml
@@ -15,6 +15,23 @@ jobs:
     - name: Dependencies
       run: |
         .github/workflows/dependencies/dependencies.sh
+        .github/workflows/dependencies/dependencies_ccache.sh
+    - name: Set Up Cache
+      uses: actions/cache@v3
+      env:
+        cache-name: sundials-cpu
+      with:
+        path: ~/.cache
+        key: ccache-sundials.yml-${{ env.cache-name }}-git-${{ github.sha }}
+        restore-keys: |
+             ccache-sundials.yml-${{ env.cache-name }}-git-
+    - name: Build SUNDIALS
+      run: |
+        export CCACHE_COMPRESS=1
+        export CCACHE_COMPRESSLEVEL=10
+        export CCACHE_MAXSIZE=125M
+        ccache -z
+
         wget -q https://github.com/LLNL/sundials/archive/refs/tags/v6.5.0.tar.gz
         tar xfz v6.5.0.tar.gz
         cd sundials-6.5.0
@@ -22,7 +39,9 @@ jobs:
         cd builddir
         cmake .. \
             -DCMAKE_INSTALL_PREFIX=${PWD}/../instdir \
-            -DCMAKE_CXX_STANDARD=17
+            -DCMAKE_CXX_STANDARD=17                  \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache     \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache
         make -j2
         make install
         cd ../..
@@ -30,14 +49,19 @@ jobs:
       run: |
         .github/workflows/dependencies/dependencies_clang-tidy.sh 14
         export CXXFLAGS="-fno-operator-names -Werror -Wall -Wextra -Wpedantic -Wnull-dereference -Wfloat-conversion -Wshadow -Woverloaded-virtual -Wnon-virtual-dtor -Wlogical-op -Wmisleading-indentation -Wduplicated-cond -Wduplicated-branches -Wmissing-include-dirs"
+        export CCACHE_COMPRESS=1
+        export CCACHE_COMPRESSLEVEL=10
+        export CCACHE_MAXSIZE=125M
         cmake -S . -B build             \
             -DCMAKE_VERBOSE_MAKEFILE=ON \
             -DUSE_XSDK_DEFAULTS=ON      \
             -DAMReX_SUNDIALS=ON         \
             -DSUNDIALS_ROOT=${PWD}/sundials-6.5.0/instdir \
             -DCMAKE_CXX_STANDARD=17     \
-            -DAMReX_CLANG_TIDY=ON
+            -DAMReX_CLANG_TIDY=ON       \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
         cmake --build build -j 2
+        ccache -s
 
   sundials-cuda:
     name: CUDA SUNDIALS@6.5.0
@@ -47,6 +71,23 @@ jobs:
     - name: Dependencies
       run: |
         .github/workflows/dependencies/dependencies_nvcc12.sh
+        .github/workflows/dependencies/dependencies_ccache.sh
+    - name: Set Up Cache
+      uses: actions/cache@v3
+      env:
+        cache-name: sundials-cuda
+      with:
+        path: ~/.cache
+        key: ccache-sundials.yml-${{ env.cache-name }}-git-${{ github.sha }}
+        restore-keys: |
+             ccache-sundials.yml-${{ env.cache-name }}-git-
+    - name: Build SUNDIALS
+      run: |
+        export CCACHE_COMPRESS=1
+        export CCACHE_COMPRESSLEVEL=10
+        export CCACHE_MAXSIZE=250M
+        ccache -z
+
         # sundials requirement
         sudo apt-get install -y libcusolver-dev-12-0 libcusparse-dev-12-0 libcublas-dev-12-0
         export PATH=/usr/local/nvidia/bin:/usr/local/cuda/bin:${PATH}
@@ -62,7 +103,10 @@ jobs:
             -DENABLE_CUDA=ON                         \
             -DCMAKE_INSTALL_PREFIX=${PWD}/../instdir \
             -DCMAKE_CUDA_ARCHITECTURES=80            \
-            -DCMAKE_CXX_STANDARD=17
+            -DCMAKE_CXX_STANDARD=17                  \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache     \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache       \
+            -DCMAKE_CUDA_COMPILER_LAUNCHER=ccache
         make -j2
         make install
         cd ../..
@@ -73,11 +117,19 @@ jobs:
         export LD_LIBRARY_PATH=/usr/local/nvidia/lib:/usr/local/nvidia/lib64:/usr/local/cuda/lib64:${LD_LIBRARY_PATH}
         which nvcc || echo "nvcc not in PATH!"
 
+        export CCACHE_COMPRESS=1
+        export CCACHE_COMPRESSLEVEL=10
+        export CCACHE_MAXSIZE=250M
+
         cmake -S . -B build             \
             -DCMAKE_VERBOSE_MAKEFILE=ON \
             -DUSE_XSDK_DEFAULTS=ON      \
             -DAMReX_GPU_BACKEND=CUDA    \
             -DAMReX_CUDA_ARCH=8.0       \
             -DAMReX_SUNDIALS=ON         \
-            -DSUNDIALS_ROOT=${PWD}/sundials-6.5.0/instdir
+            -DSUNDIALS_ROOT=${PWD}/sundials-6.5.0/instdir \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache  \
+            -DCMAKE_CUDA_COMPILER_LAUNCHER=ccache
         cmake --build build -j 2
+
+        ccache -s

--- a/.github/workflows/sundials.yml
+++ b/.github/workflows/sundials.yml
@@ -18,13 +18,11 @@ jobs:
         .github/workflows/dependencies/dependencies_ccache.sh
     - name: Set Up Cache
       uses: actions/cache@v3
-      env:
-        cache-name: sundials-cpu
       with:
         path: ~/.cache
-        key: ccache-sundials.yml-${{ env.cache-name }}-git-${{ github.sha }}
+        key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}
         restore-keys: |
-             ccache-sundials.yml-${{ env.cache-name }}-git-
+             ccache-${{ github.workflow }}-${{ github.job }}-git-
     - name: Build SUNDIALS
       run: |
         export CCACHE_COMPRESS=1
@@ -74,13 +72,11 @@ jobs:
         .github/workflows/dependencies/dependencies_ccache.sh
     - name: Set Up Cache
       uses: actions/cache@v3
-      env:
-        cache-name: sundials-cuda
       with:
         path: ~/.cache
-        key: ccache-sundials.yml-${{ env.cache-name }}-git-${{ github.sha }}
+        key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}
         restore-keys: |
-             ccache-sundials.yml-${{ env.cache-name }}-git-
+             ccache-${{ github.workflow }}-${{ github.job }}-git-
     - name: Build SUNDIALS
       run: |
         export CCACHE_COMPRESS=1

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -16,13 +16,11 @@ jobs:
     - uses: seanmiddleditch/gha-setup-ninja@master
     - name: Set Up Cache
       uses: actions/cache@v3
-      env:
-        cache-name: tests_msvc
       with:
         path: ~/.ccache
-        key: ccache-windows.yml-${{ env.cache-name }}-git-${{ github.sha }}
+        key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}
         restore-keys: |
-             ccache-windows.yml-${{ env.cache-name }}-git-
+             ccache-${{ github.workflow }}-${{ github.job }}-git-
     - name: Install Ccache
       run: |
         Invoke-WebRequest https://github.com/ccache/ccache/releases/download/v4.8/ccache-4.8-windows-x86_64.zip -OutFile ccache-4.8-windows-x86_64.zip
@@ -63,13 +61,11 @@ jobs:
     - uses: seanmiddleditch/gha-setup-ninja@master
     - name: Set Up Cache
       uses: actions/cache@v3
-      env:
-        cache-name: tests_msvc_static
       with:
         path: ~/.ccache
-        key: ccache-windows.yml-${{ env.cache-name }}-git-${{ github.sha }}
+        key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}
         restore-keys: |
-             ccache-windows.yml-${{ env.cache-name }}-git-
+             ccache-${{ github.workflow }}-${{ github.job }}-git-
     - name: Install Ccache
       run: |
         Invoke-WebRequest https://github.com/ccache/ccache/releases/download/v4.8/ccache-4.8-windows-x86_64.zip -OutFile ccache-4.8-windows-x86_64.zip

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -13,9 +13,34 @@ jobs:
     runs-on: windows-latest
     steps:
     - uses: actions/checkout@v3
+    - uses: seanmiddleditch/gha-setup-ninja@master
+    - name: Set Up Cache
+      uses: actions/cache@v3
+      env:
+        cache-name: tests_msvc
+      with:
+        path: ~/.ccache
+        key: ccache-windows.yml-${{ env.cache-name }}-git-${{ github.sha }}
+        restore-keys: |
+             ccache-windows.yml-${{ env.cache-name }}-git-
+    - name: Install Ccache
+      run: |
+        Invoke-WebRequest https://github.com/ccache/ccache/releases/download/v4.8/ccache-4.8-windows-x86_64.zip -OutFile ccache-4.8-windows-x86_64.zip
+        Expand-Archive ccache-4.8-windows-x86_64.zip
     - name: Build & Install
       run: |
+        $ccachepath = Join-Path $pwd "ccache-4.8-windows-x86_64"
+        $Env:PATH += ";$ccachepath"
+        $ccachecachedir = Join-Path $HOME ".ccache"
+        $Env:CCACHE_DIR="$ccachecachedir"
+        $Env:CCACHE_DIR
+        $Env:CCACHE_COMPRESS='1'
+        $Env:CCACHE_COMPRESSLEVEL='10'
+        $Env:CCACHE_MAXSIZE='200M'
+        ccache -z
+
         cmake -S . -B build   `
+              -G "Ninja"      `
               -DCMAKE_BUILD_TYPE=Debug      `
               -DBUILD_SHARED_LIBS=ON        `
               -DCMAKE_VERBOSE_MAKEFILE=ON   `
@@ -23,8 +48,11 @@ jobs:
               -DAMReX_ENABLE_TESTS=ON       `
               -DAMReX_FORTRAN=OFF           `
               -DAMReX_MPI=OFF               `
-              -DAMReX_PARTICLES=ON
+              -DAMReX_PARTICLES=ON          `
+              -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
         cmake --build build --config Debug -j 2
+
+        ccache -s
 
   # Build libamrex and all test (static)
   test_msvc_static:
@@ -32,17 +60,44 @@ jobs:
     runs-on: windows-latest
     steps:
     - uses: actions/checkout@v3
+    - uses: seanmiddleditch/gha-setup-ninja@master
+    - name: Set Up Cache
+      uses: actions/cache@v3
+      env:
+        cache-name: tests_msvc_static
+      with:
+        path: ~/.ccache
+        key: ccache-windows.yml-${{ env.cache-name }}-git-${{ github.sha }}
+        restore-keys: |
+             ccache-windows.yml-${{ env.cache-name }}-git-
+    - name: Install Ccache
+      run: |
+        Invoke-WebRequest https://github.com/ccache/ccache/releases/download/v4.8/ccache-4.8-windows-x86_64.zip -OutFile ccache-4.8-windows-x86_64.zip
+        Expand-Archive ccache-4.8-windows-x86_64.zip
     - name: Build & Install
       run: |
+        $ccachepath = Join-Path $pwd "ccache-4.8-windows-x86_64"
+        $Env:PATH += ";$ccachepath"
+        $ccachecachedir = Join-Path $HOME ".ccache"
+        $Env:CCACHE_DIR="$ccachecachedir"
+        $Env:CCACHE_COMPRESS='1'
+        $Env:CCACHE_COMPRESSLEVEL='10'
+        $Env:CCACHE_MAXSIZE='200M'
+        ccache -z
+
         cmake -S . -B build   `
+              -G "Ninja"      `
               -DCMAKE_BUILD_TYPE=RelWithDebInfo `
               -DCMAKE_VERBOSE_MAKEFILE=ON   `
               -DAMReX_EB=ON                 `
               -DAMReX_ENABLE_TESTS=ON       `
               -DAMReX_FORTRAN=OFF           `
               -DAMReX_MPI=OFF               `
-              -DAMReX_PARTICLES=ON
+              -DAMReX_PARTICLES=ON          `
+              -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
         cmake --build build --config RelWithDebInfo -j 2
+
+        ccache -s
 
   # Build libamrex and all tests
   tests_clang:
@@ -54,7 +109,7 @@ jobs:
     - name: Build & Install
       shell: cmd
       run: |
-        call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\vc\Auxiliary\build\vcvarsall.bat" x64
+        call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\vc\Auxiliary\build\vcvarsall.bat" x64
         cmake -S . -B build   ^
               -T "ClangCl"    ^
               -DCMAKE_BUILD_TYPE=Release    ^


### PR DESCRIPTION
This works very well for CUDA and HIP builds. However, the benefit is relatively small for GCC, Clang and Mac builds because most of their time are spent on clang-tidy and running tests.

There are two remaining issues. Ccache works with Intel classic compiler icpc, but it does not work with the Intel SYCL compiler, icpx. On Windows, MSVC works, but I cannot get ClangCl to work. We can revisit these two issues in the future.

In earlier versions of this PR, we compiled ccache from source because the package version on Ubuntu 20.04 is too old. Because of that, we had to move `env: {CXXFLAGS: ...}` down to AMReX's `Build & Install` section to avoid the flags being picked up when compiling ccache. In the current version, we download the binary version of ccache 4.8. However, we did not move the env setup back. It seems to make sense to keep it in the `Build & Install` section.
 
To use github cache, we need to provide a primary key and optionally restore keys. If the primary key is found, it will be used, but the change to the cache during the CI will NOT be saved at the end of the job. That's how github cache works. If it is not found, partially matched restore keys will be considered and the latest one will be used. At the end, the cache (whether it's updated or not) will be saved under the name of the primary key. Below is an example of our setup.
```
    with:
        path: ~/.cache
        key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}
        restore-keys: |
             ccache-clang.yml-${{ env.cache-name }}-git-
```
Here, we use the workflow string and job string as part of the names for the keys. We also include the git commit hash `${{github.sha}}` in the name of the primary key. In this setup, the CI will always fail to find the primary key. This is what we want because it guarantees the latest ccache data will be saved. Furthermore, the most recently saved cache from the last CI job will be used to restore the cache during initialization.
 
