### PR TITLE
Speedup clang tidy

### DIFF
--- a/.github/workflows/clang.yml
+++ b/.github/workflows/clang.yml
@@ -34,6 +34,8 @@ jobs:
         export CCACHE_COMPRESS=1
         export CCACHE_COMPRESSLEVEL=10
         export CCACHE_MAXSIZE=125M
+        export CCACHE_EXTRAFILES=${{ github.workspace }}/.clang-tidy
+        export CCACHE_LOGFILE=${{ github.workspace }}/ccache.log.txt
         ccache -z
 
         mkdir build
@@ -52,12 +54,15 @@ jobs:
             -DCMAKE_C_COMPILER=$(which clang-7)         \
             -DCMAKE_CXX_COMPILER=$(which clang++-7)     \
             -DCMAKE_Fortran_COMPILER=$(which gfortran)  \
-            -DAMReX_CLANG_TIDY=ON                     \
-            -DAMReX_CLANG_TIDY_WERROR=ON              \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
         make -j 2
         make install
         make test_install
+
+        ${{github.workspace}}/Tools/C_scripts/mmclt.py --input ${{github.workspace}}/ccache.log.txt
+        make -j2 -f clang-tidy-ccache-misses.mak \
+            CLANG_TIDY=clang-tidy-12 \
+            CLANG_TIDY_ARGS="--config-file=${{github.workspace}}/.clang-tidy --warnings-as-errors=*"
 
         export PATH=/tmp/my-amrex/bin:$PATH
         which fcompare
@@ -90,6 +95,8 @@ jobs:
         export CCACHE_COMPRESS=1
         export CCACHE_COMPRESSLEVEL=10
         export CCACHE_MAXSIZE=125M
+        export CCACHE_EXTRAFILES=${{ github.workspace }}/.clang-tidy
+        export CCACHE_LOGFILE=${{ github.workspace }}/ccache.log.txt
         ccache -z
 
         mkdir build
@@ -107,10 +114,13 @@ jobs:
             -DCMAKE_C_COMPILER=$(which clang-14)      \
             -DCMAKE_CXX_COMPILER=$(which clang++-14)  \
             -DCMAKE_Fortran_COMPILER=$(which gfortran)  \
-            -DAMReX_CLANG_TIDY=ON                     \
-            -DAMReX_CLANG_TIDY_WERROR=ON              \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
         make -j 2
+
+        ${{github.workspace}}/Tools/C_scripts/mmclt.py --input ${{github.workspace}}/ccache.log.txt
+        make -j2 -f clang-tidy-ccache-misses.mak \
+            CLANG_TIDY=clang-tidy-14 \
+            CLANG_TIDY_ARGS="--config-file=${{github.workspace}}/.clang-tidy --warnings-as-errors=*"
 
         ctest --output-on-failure -E GhostsAndVirtuals
 
@@ -139,12 +149,18 @@ jobs:
         export CCACHE_COMPRESS=1
         export CCACHE_COMPRESSLEVEL=10
         export CCACHE_MAXSIZE=125M
+        export CCACHE_EXTRAFILES=${{ github.workspace }}/.clang-tidy
+        export CCACHE_LOGFILE=${{ github.workspace }}/ccache.log.txt
         ccache -z
 
         ./configure --dim 2 --with-fortran no --comp llvm --with-mpi no
         make -j2 WARN_ALL=TRUE WARN_ERROR=TRUE XTRA_CXXFLAGS="-fno-operator-names" \
-            USE_CLANG_TIDY=TRUE CLANG_TIDY=clang-tidy-14 CLANG_TIDY_WARN_ERROR=TRUE \
             CCACHE=ccache
         make install
+
+        ${{github.workspace}}/Tools/C_scripts/mmclt.py --input ${{github.workspace}}/ccache.log.txt
+        make -j2 -f clang-tidy-ccache-misses.mak \
+            CLANG_TIDY=clang-tidy-14 \
+            CLANG_TIDY_ARGS="--config-file=${{github.workspace}}/.clang-tidy --warnings-as-errors=*"
 
         ccache -s

--- a/.github/workflows/gcc.yml
+++ b/.github/workflows/gcc.yml
@@ -35,6 +35,8 @@ jobs:
         export CCACHE_COMPRESS=1
         export CCACHE_COMPRESSLEVEL=10
         export CCACHE_MAXSIZE=125M
+        export CCACHE_EXTRAFILES=${{ github.workspace }}/.clang-tidy
+        export CCACHE_LOGFILE=${{ github.workspace }}/ccache.log.txt
         ccache -z
 
         mkdir build
@@ -47,12 +49,15 @@ jobs:
             -DCMAKE_C_COMPILER=$(which gcc-8)     \
             -DCMAKE_CXX_COMPILER=$(which g++-8)   \
             -DCMAKE_Fortran_COMPILER=$(which gfortran-8) \
-            -DAMReX_CLANG_TIDY=ON                 \
-            -DAMReX_CLANG_TIDY_WERROR=ON          \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
         make -j 2
         make install
         make test_install
+
+        ${{github.workspace}}/Tools/C_scripts/mmclt.py --input ${{github.workspace}}/ccache.log.txt
+        make -j2 -f clang-tidy-ccache-misses.mak \
+            CLANG_TIDY=clang-tidy-12 \
+            CLANG_TIDY_ARGS="--config-file=${{github.workspace}}/.clang-tidy --warnings-as-errors=*"
 
         export PATH=/tmp/my-amrex/bin:$PATH
         which fcompare
@@ -86,6 +91,8 @@ jobs:
         export CCACHE_COMPRESS=1
         export CCACHE_COMPRESSLEVEL=10
         export CCACHE_MAXSIZE=500M
+        export CCACHE_EXTRAFILES=${{ github.workspace }}/.clang-tidy
+        export CCACHE_LOGFILE=${{ github.workspace }}/ccache.log.txt
         ccache -z
 
         cmake -S . -B build             \
@@ -96,10 +103,13 @@ jobs:
             -DAMReX_FORTRAN=ON          \
             -DAMReX_PARTICLES=ON        \
             -DAMReX_SPACEDIM=3          \
-            -DAMReX_CLANG_TIDY=ON       \
-            -DAMReX_CLANG_TIDY_WERROR=ON \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
         cmake --build build -j 2
+
+        ${{github.workspace}}/Tools/C_scripts/mmclt.py --input ${{github.workspace}}/ccache.log.txt
+        make -j2 -f clang-tidy-ccache-misses.mak \
+            CLANG_TIDY=clang-tidy-12 \
+            CLANG_TIDY_ARGS="--config-file=${{github.workspace}}/.clang-tidy --warnings-as-errors=*"
 
         ctest --test-dir build --output-on-failure
 
@@ -129,6 +139,8 @@ jobs:
         export CCACHE_COMPRESS=1
         export CCACHE_COMPRESSLEVEL=10
         export CCACHE_MAXSIZE=500M
+        export CCACHE_EXTRAFILES=${{ github.workspace }}/.clang-tidy
+        export CCACHE_LOGFILE=${{ github.workspace }}/ccache.log.txt
         ccache -z
 
         cmake -S . -B build             \
@@ -139,10 +151,13 @@ jobs:
             -DAMReX_FORTRAN=ON          \
             -DAMReX_PARTICLES=ON        \
             -DAMReX_SPACEDIM=2          \
-            -DAMReX_CLANG_TIDY=ON       \
-            -DAMReX_CLANG_TIDY_WERROR=ON \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
         cmake --build build -j 2
+
+        ${{github.workspace}}/Tools/C_scripts/mmclt.py --input ${{github.workspace}}/ccache.log.txt
+        make -j2 -f clang-tidy-ccache-misses.mak \
+            CLANG_TIDY=clang-tidy-12 \
+            CLANG_TIDY_ARGS="--config-file=${{github.workspace}}/.clang-tidy --warnings-as-errors=*"
 
         ctest --test-dir build --output-on-failure
 
@@ -173,20 +188,25 @@ jobs:
         export CCACHE_COMPRESS=1
         export CCACHE_COMPRESSLEVEL=10
         export CCACHE_MAXSIZE=250M
+        export CCACHE_EXTRAFILES=${{ github.workspace }}/.clang-tidy
+        export CCACHE_LOGFILE=${{ github.workspace }}/ccache.log.txt
         ccache -z
 
         cmake -S . -B build             \
             -DCMAKE_BUILD_TYPE=Debug    \
             -DCMAKE_VERBOSE_MAKEFILE=ON \
-            -DAMReX_EB=ON               \
+            -DAMReX_EB=OFF              \
             -DAMReX_ENABLE_TESTS=ON     \
             -DAMReX_FORTRAN=ON          \
             -DAMReX_PARTICLES=ON        \
             -DAMReX_SPACEDIM=1          \
-            -DAMReX_CLANG_TIDY=ON       \
-            -DAMReX_CLANG_TIDY_WERROR=ON \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
         cmake --build build -j 2
+
+        ${{github.workspace}}/Tools/C_scripts/mmclt.py --input ${{github.workspace}}/ccache.log.txt
+        make -j2 -f clang-tidy-ccache-misses.mak \
+            CLANG_TIDY=clang-tidy-12 \
+            CLANG_TIDY_ARGS="--config-file=${{github.workspace}}/.clang-tidy --warnings-as-errors=*"
 
         ctest --test-dir build --output-on-failure
 
@@ -216,6 +236,8 @@ jobs:
         export CCACHE_COMPRESS=1
         export CCACHE_COMPRESSLEVEL=10
         export CCACHE_MAXSIZE=500M
+        export CCACHE_EXTRAFILES=${{ github.workspace }}/.clang-tidy
+        export CCACHE_LOGFILE=${{ github.workspace }}/ccache.log.txt
         ccache -z
 
         mkdir build
@@ -236,10 +258,13 @@ jobs:
             -DCMAKE_C_COMPILER=$(which gcc-10)              \
             -DCMAKE_CXX_COMPILER=$(which g++-10)            \
             -DCMAKE_Fortran_COMPILER=$(which gfortran-10)   \
-            -DAMReX_CLANG_TIDY=ON       \
-            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
             # Cannot use C++20 yet -DAMReX_CLANG_TIDY_WERROR=ON
         make -j 2
+
+        ${{github.workspace}}/Tools/C_scripts/mmclt.py --input ${{github.workspace}}/ccache.log.txt
+        make -j2 -f clang-tidy-ccache-misses.mak \
+            CLANG_TIDY=clang-tidy-12 \
+            CLANG_TIDY_ARGS="--config-file=${{github.workspace}}/.clang-tidy --warnings-as-errors=*"
 
         ctest --output-on-failure
 
@@ -269,6 +294,8 @@ jobs:
         export CCACHE_COMPRESS=1
         export CCACHE_COMPRESSLEVEL=10
         export CCACHE_MAXSIZE=125M
+        export CCACHE_EXTRAFILES=${{ github.workspace }}/.clang-tidy
+        export CCACHE_LOGFILE=${{ github.workspace }}/ccache.log.txt
         ccache -z
 
         mkdir build
@@ -288,10 +315,13 @@ jobs:
             -DCMAKE_C_COMPILER=$(which gcc-8)     \
             -DCMAKE_CXX_COMPILER=$(which g++-8)   \
             -DCMAKE_Fortran_COMPILER=$(which gfortran-8) \
-            -DAMReX_CLANG_TIDY=ON       \
-            -DAMReX_CLANG_TIDY_WERROR=ON \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
         make -j 2
+
+        ${{github.workspace}}/Tools/C_scripts/mmclt.py --input ${{github.workspace}}/ccache.log.txt
+        make -j2 -f clang-tidy-ccache-misses.mak \
+            CLANG_TIDY=clang-tidy-12 \
+            CLANG_TIDY_ARGS="--config-file=${{github.workspace}}/.clang-tidy --warnings-as-errors=*"
 
         ctest --output-on-failure
 
@@ -328,6 +358,8 @@ jobs:
         export CCACHE_COMPRESS=1
         export CCACHE_COMPRESSLEVEL=10
         export CCACHE_MAXSIZE=500M
+        export CCACHE_EXTRAFILES=${{ github.workspace }}/.clang-tidy
+        export CCACHE_LOGFILE=${{ github.workspace }}/ccache.log.txt
         ccache -z
 
         mkdir build
@@ -347,10 +379,13 @@ jobs:
             -DCMAKE_C_COMPILER=$(which gcc-12)     \
             -DCMAKE_CXX_COMPILER=$(which g++-12)   \
             -DCMAKE_CXX_STANDARD=17     \
-            -DAMReX_CLANG_TIDY=ON       \
-            -DAMReX_CLANG_TIDY_WERROR=ON \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
         make -j 2
+
+        ${{github.workspace}}/Tools/C_scripts/mmclt.py --input ${{github.workspace}}/ccache.log.txt
+        make -j2 -f clang-tidy-ccache-misses.mak \
+            CLANG_TIDY=clang-tidy-14 \
+            CLANG_TIDY_ARGS="--config-file=${{github.workspace}}/.clang-tidy --warnings-as-errors=*"
 
         ctest --output-on-failure
 
@@ -379,13 +414,19 @@ jobs:
         export CCACHE_COMPRESS=1
         export CCACHE_COMPRESSLEVEL=10
         export CCACHE_MAXSIZE=250M
+        export CCACHE_EXTRAFILES=${{ github.workspace }}/.clang-tidy
+        export CCACHE_LOGFILE=${{ github.workspace }}/ccache.log.txt
         ccache -z
 
         ./configure --dim 1
         make -j2 XTRA_CXXFLAGS=-fno-operator-names \
-            USE_CLANG_TIDY=TRUE CLANG_TIDY=clang-tidy-12 CLANG_TIDY_WARN_ERROR=TRUE \
             CCACHE=ccache
         make install
+
+        ${{github.workspace}}/Tools/C_scripts/mmclt.py --input ${{github.workspace}}/ccache.log.txt
+        make -j2 -f clang-tidy-ccache-misses.mak \
+            CLANG_TIDY=clang-tidy-12 \
+            CLANG_TIDY_ARGS="--config-file=${{github.workspace}}/.clang-tidy --warnings-as-errors=*"
 
         ccache -s
 
@@ -412,13 +453,19 @@ jobs:
         export CCACHE_COMPRESS=1
         export CCACHE_COMPRESSLEVEL=10
         export CCACHE_MAXSIZE=250M
+        export CCACHE_EXTRAFILES=${{ github.workspace }}/.clang-tidy
+        export CCACHE_LOGFILE=${{ github.workspace }}/ccache.log.txt
         ccache -z
 
         ./configure --dim 3 --enable-eb yes --enable-xsdk-defaults yes
         make -j2 WARN_ALL=TRUE WARN_ERROR=TRUE XTRA_CXXFLAGS=-fno-operator-names \
-            USE_CLANG_TIDY=TRUE CLANG_TIDY=clang-tidy-12 CLANG_TIDY_WARN_ERROR=TRUE \
             CCACHE=ccache
         make install
+
+        ${{github.workspace}}/Tools/C_scripts/mmclt.py --input ${{github.workspace}}/ccache.log.txt
+        make -j2 -f clang-tidy-ccache-misses.mak \
+            CLANG_TIDY=clang-tidy-12 \
+            CLANG_TIDY_ARGS="--config-file=${{github.workspace}}/.clang-tidy --warnings-as-errors=*"
 
         ccache -s
 
@@ -445,13 +492,19 @@ jobs:
         export CCACHE_COMPRESS=1
         export CCACHE_COMPRESSLEVEL=10
         export CCACHE_MAXSIZE=250M
+        export CCACHE_EXTRAFILES=${{ github.workspace }}/.clang-tidy
+        export CCACHE_LOGFILE=${{ github.workspace }}/ccache.log.txt
         ccache -z
 
         ./configure --dim 3 --enable-eb no --enable-xsdk-defaults no --single-precision yes --single-precision-particles yes --enable-tiny-profile yes
         make -j2 WARN_ALL=TRUE WARN_ERROR=TRUE XTRA_CXXFLAGS=-fno-operator-names \
-            USE_CLANG_TIDY=TRUE CLANG_TIDY=clang-tidy-12 CLANG_TIDY_WARN_ERROR=TRUE \
             CCACHE=ccache
         make install
+
+        ${{github.workspace}}/Tools/C_scripts/mmclt.py --input ${{github.workspace}}/ccache.log.txt
+        make -j2 -f clang-tidy-ccache-misses.mak \
+            CLANG_TIDY=clang-tidy-12 \
+            CLANG_TIDY_ARGS="--config-file=${{github.workspace}}/.clang-tidy --warnings-as-errors=*"
 
         ccache -s
 
@@ -478,13 +531,19 @@ jobs:
         export CCACHE_COMPRESS=1
         export CCACHE_COMPRESSLEVEL=10
         export CCACHE_MAXSIZE=250M
+        export CCACHE_EXTRAFILES=${{ github.workspace }}/.clang-tidy
+        export CCACHE_LOGFILE=${{ github.workspace }}/ccache.log.txt
         ccache -z
 
         ./configure --dim 3 --enable-eb yes --enable-xsdk-defaults yes --with-omp yes --debug yes
         make -j2 WARN_ALL=TRUE WARN_ERROR=TRUE XTRA_CXXFLAGS=-fno-operator-names \
-            USE_CLANG_TIDY=TRUE CLANG_TIDY=clang-tidy-12 CLANG_TIDY_WARN_ERROR=TRUE \
             CCACHE=ccache
         make install
+
+        ${{github.workspace}}/Tools/C_scripts/mmclt.py --input ${{github.workspace}}/ccache.log.txt
+        make -j2 -f clang-tidy-ccache-misses.mak \
+            CLANG_TIDY=clang-tidy-12 \
+            CLANG_TIDY_ARGS="--config-file=${{github.workspace}}/.clang-tidy --warnings-as-errors=*"
 
         ccache -s
 
@@ -511,12 +570,18 @@ jobs:
         export CCACHE_COMPRESS=1
         export CCACHE_COMPRESSLEVEL=10
         export CCACHE_MAXSIZE=125M
+        export CCACHE_EXTRAFILES=${{ github.workspace }}/.clang-tidy
+        export CCACHE_LOGFILE=${{ github.workspace }}/ccache.log.txt
         ccache -z
 
         cd Tools/Plotfile
         make -j2 USE_MPI=FALSE USE_OMP=FALSE WARN_ALL=TRUE WARN_ERROR=TRUE XTRA_CXXFLAGS=-fno-operator-names \
-            USE_CLANG_TIDY=TRUE CLANG_TIDY=clang-tidy-12 CLANG_TIDY_WARN_ERROR=TRUE \
             CCACHE=ccache
+
+        ${{github.workspace}}/Tools/C_scripts/mmclt.py --input ${{github.workspace}}/ccache.log.txt
+        make -j2 -f clang-tidy-ccache-misses.mak \
+            CLANG_TIDY=clang-tidy-12 \
+            CLANG_TIDY_ARGS="--config-file=${{github.workspace}}/.clang-tidy --warnings-as-errors=*"
 
         ccache -s
 
@@ -544,6 +609,8 @@ jobs:
         export CCACHE_COMPRESS=1
         export CCACHE_COMPRESSLEVEL=10
         export CCACHE_MAXSIZE=125M
+        export CCACHE_EXTRAFILES=${{ github.workspace }}/.clang-tidy
+        export CCACHE_LOGFILE=${{ github.workspace }}/ccache.log.txt
         ccache -z
 
         mkdir build
@@ -553,10 +620,13 @@ jobs:
             -DCMAKE_VERBOSE_MAKEFILE=ON \
             -DAMReX_ENABLE_TESTS=ON     \
             -DAMReX_PARTICLES=ON        \
-            -DAMReX_CLANG_TIDY=ON       \
-            -DAMReX_CLANG_TIDY_WERROR=ON \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
         make -j 2
+
+        ${{github.workspace}}/Tools/C_scripts/mmclt.py --input ${{github.workspace}}/ccache.log.txt
+        make -j2 -f clang-tidy-ccache-misses.mak \
+            CLANG_TIDY=clang-tidy-12 \
+            CLANG_TIDY_ARGS="--config-file=${{github.workspace}}/.clang-tidy --warnings-as-errors=*"
 
         ccache -s
 

--- a/.github/workflows/hypre.yml
+++ b/.github/workflows/hypre.yml
@@ -81,13 +81,19 @@ jobs:
         export CCACHE_COMPRESS=1
         export CCACHE_COMPRESSLEVEL=10
         export CCACHE_MAXSIZE=125M
+        export CCACHE_EXTRAFILES=${{ github.workspace }}/.clang-tidy
+        export CCACHE_LOGFILE=${{ github.workspace }}/ccache.log.txt
         ccache -z
 
         export AMREX_HYPRE_HOME=${PWD}/hypre-2.21.0/src/hypre
         cd Tests/LinearSolvers/ABecLaplacian_C
         make -j2 USE_MPI=TRUE USE_HYPRE=TRUE DIM=3 \
-            USE_CLANG_TIDY=TRUE CLANG_TIDY=clang-tidy-14 CLANG_TIDY_WARN_ERROR=TRUE \
             CCACHE=ccache
         mpiexec -n 2 ./main3d.gnu.MPI.ex inputs.hypre
+
+        ${{github.workspace}}/Tools/C_scripts/mmclt.py --input ${{github.workspace}}/ccache.log.txt
+        make -j2 -f clang-tidy-ccache-misses.mak \
+            CLANG_TIDY=clang-tidy-14 \
+            CLANG_TIDY_ARGS="--config-file=${{github.workspace}}/.clang-tidy --warnings-as-errors=*"
 
         ccache -s

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -66,7 +66,7 @@ jobs:
              ccache-${{ github.workflow }}-${{ github.job }}-git-
     - name: Build & Install
       env:
-        CXXFLAGS: "-fno-operator-names -Werror -Wall -Wextra -Wpedantic -Wnull-dereference -Wfloat-conversion -Wshadow -Woverloaded-virtual -Wextra-semi -Wunreachable-code -Wnon-virtual-dtor -Wno-c++17-extensions -Wno-range-loop-analysis"
+        CXXFLAGS: "-fno-operator-names -Werror -Wall -Wextra -Wpedantic -Wnull-dereference -Wfloat-conversion -Wshadow -Woverloaded-virtual -Wextra-semi -Wunreachable-code -Wnon-virtual-dtor -Wno-c++17-extensions -Wno-range-loop-analysis -O1"
         # -Wno-range-loop-analysis: Apple clang has a bug in range-loop-analysis
       run: |
         export CCACHE_COMPRESS=1

--- a/.github/workflows/petsc.yml
+++ b/.github/workflows/petsc.yml
@@ -39,13 +39,19 @@ jobs:
         export CCACHE_COMPRESS=1
         export CCACHE_COMPRESSLEVEL=10
         export CCACHE_MAXSIZE=250M
+        export CCACHE_EXTRAFILES=${{ github.workspace }}/.clang-tidy
+        export CCACHE_LOGFILE=${{ github.workspace }}/ccache.log.txt
         ccache -z
 
         export AMREX_PETSC_HOME=${PWD}/petsc-3.18.1/petsc
         cd Tests/LinearSolvers/CellEB
         make -j2 USE_MPI=TRUE USE_PETSC=TRUE DIM=2 TEST=TRUE \
-            USE_CLANG_TIDY=TRUE CLANG_TIDY=clang-tidy-14 CLANG_TIDY_WARN_ERROR=TRUE \
             CCACHE=ccache
         mpiexec -n 2 ./main2d.gnu.TEST.MPI.ex inputs.rt.2d.petsc
+
+        ${{github.workspace}}/Tools/C_scripts/mmclt.py --input ${{github.workspace}}/ccache.log.txt
+        make -j2 -f clang-tidy-ccache-misses.mak \
+            CLANG_TIDY=clang-tidy-14 \
+            CLANG_TIDY_ARGS="--config-file=${{github.workspace}}/.clang-tidy --warnings-as-errors=*"
 
         ccache -s

--- a/.github/workflows/sundials.yml
+++ b/.github/workflows/sundials.yml
@@ -50,15 +50,22 @@ jobs:
         export CCACHE_COMPRESS=1
         export CCACHE_COMPRESSLEVEL=10
         export CCACHE_MAXSIZE=125M
+        export CCACHE_EXTRAFILES=${{ github.workspace }}/.clang-tidy
+        export CCACHE_LOGFILE=${{ github.workspace }}/ccache.log.txt
         cmake -S . -B build             \
             -DCMAKE_VERBOSE_MAKEFILE=ON \
             -DUSE_XSDK_DEFAULTS=ON      \
             -DAMReX_SUNDIALS=ON         \
             -DSUNDIALS_ROOT=${PWD}/sundials-6.5.0/instdir \
             -DCMAKE_CXX_STANDARD=17     \
-            -DAMReX_CLANG_TIDY=ON       \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
         cmake --build build -j 2
+
+        ${{github.workspace}}/Tools/C_scripts/mmclt.py --input ${{github.workspace}}/ccache.log.txt
+        make -j2 -f clang-tidy-ccache-misses.mak \
+            CLANG_TIDY=clang-tidy-14 \
+            CLANG_TIDY_ARGS="--config-file=${{github.workspace}}/.clang-tidy --warnings-as-errors=*"
+
         ccache -s
 
   sundials-cuda:

--- a/Src/AmrCore/AMReX_AmrParticles.H
+++ b/Src/AmrCore/AMReX_AmrParticles.H
@@ -251,7 +251,7 @@ ParticleToMesh (PC const& pc, const Vector<MultiFab*>& mf,
 
 template <int NStructReal, int NStructInt=0, int NArrayReal=0, int NArrayInt=0,
           template<class> class Allocator=DefaultAllocator>
-class AmrParticleContainer
+class AmrParticleContainer // NOLINT
     : public ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt, Allocator>
 {
 

--- a/Src/Base/AMReX_Any.H
+++ b/Src/Base/AMReX_Any.H
@@ -33,8 +33,9 @@ public:
 
     //! Assigns by moving the given object.
     template <typename MF>
-    void operator= (MF && mf) {
+    Any& operator= (MF && mf) {
         m_ptr = std::make_unique<innards<MF> >(std::forward<MF>(mf));
+        return *this;
     }
 
     //! Returns the contained type.

--- a/Src/Base/AMReX_BaseFab.H
+++ b/Src/Base/AMReX_BaseFab.H
@@ -371,7 +371,7 @@ public:
 
     [[nodiscard]] const T* dataPtr (const IntVect& p, int n = 0) const noexcept;
 
-    void setPtr (T* p, Long sz) noexcept { AMREX_ASSERT(this->dptr == 0 && this->truesize == 0); this->dptr = p; this->truesize = sz; }
+    void setPtr (T* p, Long sz) noexcept { AMREX_ASSERT(this->dptr == nullptr && this->truesize == 0); this->dptr = p; this->truesize = sz; }
 
     void prefetchToHost () const noexcept;
     void prefetchToDevice () const noexcept;
@@ -1640,7 +1640,7 @@ BaseFab<T>::dataPtr (const IntVect& p, int n) noexcept
 {
     AMREX_ASSERT(n >= 0);
     AMREX_ASSERT(n < this->nvar);
-    AMREX_ASSERT(!(this->dptr == 0));
+    AMREX_ASSERT(!(this->dptr == nullptr));
     AMREX_ASSERT(this->domain.contains(p));
 
     return this->dptr + (this->domain.index(p)+n*this->domain.numPts());
@@ -1653,7 +1653,7 @@ BaseFab<T>::dataPtr (const IntVect& p, int n) const noexcept
 {
     AMREX_ASSERT(n >= 0);
     AMREX_ASSERT(n < this->nvar);
-    AMREX_ASSERT(!(this->dptr == 0));
+    AMREX_ASSERT(!(this->dptr == nullptr));
     AMREX_ASSERT(this->domain.contains(p));
 
     return this->dptr + (this->domain.index(p)+n*this->domain.numPts());
@@ -1726,7 +1726,7 @@ AMREX_FORCE_INLINE
 T&
 BaseFab<T>::operator() (const IntVect& p) noexcept
 {
-    AMREX_ASSERT(!(this->dptr == 0));
+    AMREX_ASSERT(!(this->dptr == nullptr));
     AMREX_ASSERT(this->domain.contains(p));
 
     return this->dptr[this->domain.index(p)];
@@ -1750,7 +1750,7 @@ AMREX_FORCE_INLINE
 const T&
 BaseFab<T>::operator() (const IntVect& p) const noexcept
 {
-    AMREX_ASSERT(!(this->dptr == 0));
+    AMREX_ASSERT(!(this->dptr == nullptr));
     AMREX_ASSERT(this->domain.contains(p));
 
     return this->dptr[this->domain.index(p)];
@@ -1766,7 +1766,7 @@ BaseFab<T>::getVal  (T*             data,
     const int loc      = this->domain.index(pos);
     const Long sz    = this->domain.numPts();
 
-    AMREX_ASSERT(!(this->dptr == 0));
+    AMREX_ASSERT(!(this->dptr == nullptr));
     AMREX_ASSERT(n >= 0 && n + numcomp <= this->nvar);
 
     for (int k = 0; k < numcomp; k++)

--- a/Src/Base/AMReX_GpuMemory.H
+++ b/Src/Base/AMReX_GpuMemory.H
@@ -15,7 +15,7 @@ struct Managed {
 
 #ifdef AMREX_USE_GPU
 
-    void *operator new (std::size_t len)
+    [[nodiscard]] void *operator new (std::size_t len)
     {
         return The_Managed_Arena()->alloc(len);
     }
@@ -32,7 +32,7 @@ struct Pinned {
 
 #ifdef AMREX_USE_GPU
 
-    void *operator new (std::size_t len)
+    [[nodiscard]] void *operator new (std::size_t len)
     {
         return The_Pinned_Arena()->alloc(len);
     }
@@ -87,9 +87,9 @@ struct DeviceScalar
         }
     }
 
-    T* dataPtr () { return dp; }
-    T const* dataPtr () const { return dp; }
-    T dataValue () const {
+    [[nodiscard]] T* dataPtr () { return dp; }
+    [[nodiscard]] T const* dataPtr () const { return dp; }
+    [[nodiscard]] T dataValue () const {
         if (Gpu::inLaunchRegion()) {
             T r;
             Gpu::dtoh_memcpy(&r, dp, sizeof(T));
@@ -108,9 +108,9 @@ private:
     DeviceScalar () = default;
     ~DeviceScalar () = default;
 
-    T* dataPtr () { return &d; }
-    T const* dataPtr () const { return &d; }
-    T dataValue () const { return d; }
+    [[nodiscard]] T* dataPtr () { return &d; }
+    [[nodiscard]] T const* dataPtr () const { return &d; }
+    [[nodiscard]] T dataValue () const { return d; }
 
 private:
     T d;
@@ -123,7 +123,7 @@ private:
 template <class T>
 struct SharedMemory
 {
-    AMREX_GPU_DEVICE T* dataPtr () noexcept {
+    [[nodiscard]] AMREX_GPU_DEVICE T* dataPtr () noexcept {
         static_assert(sizeof(T) < 0, "We must specialize struct SharedMemory");
         return nullptr;
     }
@@ -135,7 +135,7 @@ struct SharedMemory
 template <>
 struct SharedMemory<double>
 {
-    AMREX_GPU_DEVICE double* dataPtr () noexcept {
+    [[nodiscard]] AMREX_GPU_DEVICE double* dataPtr () noexcept {
         AMREX_HIP_OR_CUDA(HIP_DYNAMIC_SHARED(double,amrex_sm_double);,
                           extern __shared__  double amrex_sm_double[];)
         return amrex_sm_double;
@@ -145,7 +145,7 @@ struct SharedMemory<double>
 template <>
 struct SharedMemory<float>
 {
-    AMREX_GPU_DEVICE float* dataPtr () noexcept {
+    [[nodiscard]] AMREX_GPU_DEVICE float* dataPtr () noexcept {
         AMREX_HIP_OR_CUDA(HIP_DYNAMIC_SHARED(float,amrex_sm_float);,
                           extern __shared__  float amrex_sm_float[];)
         return amrex_sm_float;
@@ -155,7 +155,7 @@ struct SharedMemory<float>
 template <>
 struct SharedMemory<long>
 {
-    AMREX_GPU_DEVICE long* dataPtr () noexcept {
+    [[nodiscard]] AMREX_GPU_DEVICE long* dataPtr () noexcept {
         AMREX_HIP_OR_CUDA(HIP_DYNAMIC_SHARED(long,amrex_sm_long);,
                           extern __shared__  long amrex_sm_long[];)
         return amrex_sm_long;
@@ -165,7 +165,7 @@ struct SharedMemory<long>
 template <>
 struct SharedMemory<long long>
 {
-    AMREX_GPU_DEVICE long long* dataPtr () noexcept {
+    [[nodiscard]] AMREX_GPU_DEVICE long long* dataPtr () noexcept {
         AMREX_HIP_OR_CUDA(HIP_DYNAMIC_SHARED(long long,amrex_sm_long_long);,
                           extern __shared__  long long amrex_sm_long_long[];)
         return amrex_sm_long_long;
@@ -175,7 +175,7 @@ struct SharedMemory<long long>
 template <>
 struct SharedMemory<int>
 {
-    AMREX_GPU_DEVICE int* dataPtr () noexcept {
+    [[nodiscard]] AMREX_GPU_DEVICE int* dataPtr () noexcept {
         AMREX_HIP_OR_CUDA(HIP_DYNAMIC_SHARED(int,amrex_sm_int);,
                           extern __shared__  int amrex_sm_int[];)
         return amrex_sm_int;
@@ -185,7 +185,7 @@ struct SharedMemory<int>
 template <>
 struct SharedMemory<short>
 {
-    AMREX_GPU_DEVICE short* dataPtr () noexcept {
+    [[nodiscard]] AMREX_GPU_DEVICE short* dataPtr () noexcept {
         AMREX_HIP_OR_CUDA(HIP_DYNAMIC_SHARED(short,amrex_sm_short);,
                           extern __shared__  short amrex_sm_short[];)
         return amrex_sm_short;
@@ -195,7 +195,7 @@ struct SharedMemory<short>
 template <>
 struct SharedMemory<char>
 {
-    AMREX_GPU_DEVICE char* dataPtr () noexcept {
+    [[nodiscard]] AMREX_GPU_DEVICE char* dataPtr () noexcept {
         AMREX_HIP_OR_CUDA(HIP_DYNAMIC_SHARED(char,amrex_sm_char);,
                           extern __shared__  char amrex_sm_char[];)
         return amrex_sm_char;
@@ -205,7 +205,7 @@ struct SharedMemory<char>
 template <>
 struct SharedMemory<unsigned long>
 {
-    AMREX_GPU_DEVICE unsigned long* dataPtr () noexcept {
+    [[nodiscard]] AMREX_GPU_DEVICE unsigned long* dataPtr () noexcept {
         AMREX_HIP_OR_CUDA(HIP_DYNAMIC_SHARED(unsigned long,amrex_sm_ulong);,
                           extern __shared__  unsigned long amrex_sm_ulong[];)
         return amrex_sm_ulong;
@@ -215,7 +215,7 @@ struct SharedMemory<unsigned long>
 template <>
 struct SharedMemory<unsigned long long>
 {
-    AMREX_GPU_DEVICE unsigned long long* dataPtr () noexcept {
+    [[nodiscard]] AMREX_GPU_DEVICE unsigned long long* dataPtr () noexcept {
         AMREX_HIP_OR_CUDA(HIP_DYNAMIC_SHARED(unsigned long long,amrex_sm_ulonglong);,
                           extern __shared__  unsigned long long amrex_sm_ulonglong[];)
         return amrex_sm_ulonglong;
@@ -225,7 +225,7 @@ struct SharedMemory<unsigned long long>
 template <>
 struct SharedMemory<unsigned int>
 {
-    AMREX_GPU_DEVICE unsigned int* dataPtr () noexcept {
+    [[nodiscard]] AMREX_GPU_DEVICE unsigned int* dataPtr () noexcept {
         AMREX_HIP_OR_CUDA(HIP_DYNAMIC_SHARED(unsigned int,amrex_sm_uint);,
                           extern __shared__  unsigned int amrex_sm_uint[];)
         return amrex_sm_uint;
@@ -235,7 +235,7 @@ struct SharedMemory<unsigned int>
 template <>
 struct SharedMemory<unsigned short>
 {
-    AMREX_GPU_DEVICE unsigned short* dataPtr () noexcept {
+    [[nodiscard]] AMREX_GPU_DEVICE unsigned short* dataPtr () noexcept {
         AMREX_HIP_OR_CUDA(HIP_DYNAMIC_SHARED(unsigned short,amrex_sm_ushort);,
                           extern __shared__  unsigned short amrex_sm_ushort[];)
         return amrex_sm_ushort;
@@ -245,7 +245,7 @@ struct SharedMemory<unsigned short>
 template <>
 struct SharedMemory<unsigned char>
 {
-    AMREX_GPU_DEVICE unsigned char* dataPtr () noexcept {
+    [[nodiscard]] AMREX_GPU_DEVICE unsigned char* dataPtr () noexcept {
         AMREX_HIP_OR_CUDA(HIP_DYNAMIC_SHARED(unsigned char,amrex_sm_uchar);,
                           extern __shared__  unsigned char amrex_sm_uchar[];)
         return amrex_sm_uchar;
@@ -255,7 +255,7 @@ struct SharedMemory<unsigned char>
 template <>
 struct SharedMemory<bool>
 {
-    AMREX_GPU_DEVICE bool* dataPtr () noexcept {
+    [[nodiscard]] AMREX_GPU_DEVICE bool* dataPtr () noexcept {
         AMREX_HIP_OR_CUDA(HIP_DYNAMIC_SHARED(bool,amrex_sm_bool);,
                           extern __shared__  bool amrex_sm_bool[];)
         return amrex_sm_bool;

--- a/Src/Base/AMReX_Lazy.cpp
+++ b/Src/Base/AMReX_Lazy.cpp
@@ -1,12 +1,10 @@
 #include <AMReX_Lazy.H>
 
-namespace amrex {
-
-namespace Lazy
+namespace amrex::Lazy
 {
     FuncQue reduction_queue;
 
-    void QueueReduction (Func f)
+    void QueueReduction (Func f) // NOLINT
     {
 #ifdef BL_USE_MPI
         reduction_queue.push_back(f);
@@ -36,6 +34,4 @@ namespace Lazy
     {
         EvalReduction();
     }
-}
-
 }

--- a/Src/Base/AMReX_NonLocalBC.H
+++ b/Src/Base/AMReX_NonLocalBC.H
@@ -196,7 +196,7 @@ InverseImage(DTOS dtos, const Box& box)
 }
 
 //! \brief This is the index mapping based on the DTOS MultiBlockDestToSrc.
-static_assert(IsIndexMapping<MultiBlockIndexMapping>(),
+static_assert(IsIndexMapping<MultiBlockIndexMapping>(), // NOLINT(bugprone-throw-keyword-missing)
               "MultiBlockIndexMapping is expected to satisfy IndexMapping");
 
 ////////////////////////////////////////////////////////////////////////////////////
@@ -299,8 +299,8 @@ static_assert(sizeof(Identity) == 1 );
 static_assert(std::is_trivially_default_constructible<Identity>::value );
 static_assert(std::is_trivially_copy_assignable<Identity>::value );
 static_assert(std::is_trivially_copy_constructible<Identity>::value );
-static_assert(IsIndexMapping<Identity>() );
-static_assert(IsFabProjection<Identity, FArrayBox>() );
+static_assert(IsIndexMapping<Identity>() ); // NOLINT(bugprone-throw-keyword-missing)
+static_assert(IsFabProjection<Identity, FArrayBox>() ); // NOLINT(bugprone-throw-keyword-missing)
 
 ////////////////////////////////////////////////////////////////////////////////////
 //                                                     [FabProjection.MapComponents]
@@ -330,9 +330,9 @@ template <typename Base, typename Map = Identity> struct MapComponents {
     }
 };
 
-static_assert(std::is_trivially_copy_assignable<MapComponents<Identity>>() );
-static_assert(std::is_trivially_copy_constructible<MapComponents<Identity>>() );
-static_assert(IsFabProjection<MapComponents<Identity>, FArrayBox>() );
+static_assert(std::is_trivially_copy_assignable<MapComponents<Identity>>() ); // NOLINT(bugprone-throw-keyword-missing)
+static_assert(std::is_trivially_copy_constructible<MapComponents<Identity>>() ); // NOLINT(bugprone-throw-keyword-missing)
+static_assert(IsFabProjection<MapComponents<Identity>, FArrayBox>() ); // NOLINT(bugprone-throw-keyword-missing)
 
 ////////////////////////////////////////////////////////////////////////////////////
 //                                      [FabProjection.MapComponents.SwapComponents]
@@ -391,10 +391,10 @@ static_assert(sizeof(SwapComponents<0, 1>) == 1 );
 static_assert(sizeof(DynamicSwapComponents) == 2 * sizeof(int) );
 static_assert(sizeof(SwapComponents<0, -1>) == sizeof(int) );
 static_assert(sizeof(SwapComponents<-1, 1>) == sizeof(int) );
-static_assert(std::is_trivially_default_constructible<MapComponents<Identity, SwapComponents<0, 1>>>() );
-static_assert(std::is_trivially_copy_assignable<MapComponents<Identity, SwapComponents<0, 1>>>() );
-static_assert(std::is_trivially_copy_constructible<MapComponents<Identity, SwapComponents<0, 1>>>() );
-static_assert(IsFabProjection<MapComponents<Identity, SwapComponents<0, 1>>, FArrayBox>() );
+static_assert(std::is_trivially_default_constructible<MapComponents<Identity, SwapComponents<0, 1>>>() ); // NOLINT(bugprone-throw-keyword-missing)
+static_assert(std::is_trivially_copy_assignable<MapComponents<Identity, SwapComponents<0, 1>>>() ); // NOLINT(bugprone-throw-keyword-missing)
+static_assert(std::is_trivially_copy_constructible<MapComponents<Identity, SwapComponents<0, 1>>>() ); // NOLINT(bugprone-throw-keyword-missing)
+static_assert(IsFabProjection<MapComponents<Identity, SwapComponents<0, 1>>, FArrayBox>() ); // NOLINT(bugprone-throw-keyword-missing)
 
 static_assert(swap_indices<0, 1>(0) == 1 );
 static_assert(swap_indices<0, 1>(1) == 0 );
@@ -602,7 +602,7 @@ UnpackRecvBuffers (const PackComponents& components, FabArray<FAB>& dest, const 
 }
 #endif // AMREX_USE_MPI
 
-static_assert(IsDataPacking<PackComponents, FArrayBox>(),
+static_assert(IsDataPacking<PackComponents, FArrayBox>(), // NOLINT(bugprone-throw-keyword-missing)
               "PackComponents is expected to satisfy the concept DataPacking.");
 
 ////////////////////////////////////////////////////////////////////////////////////
@@ -663,7 +663,7 @@ UnpackRecvBuffers (const ApplyDtosAndProjectionOnReciever<DTOS, FabProj>& packin
 }
 #endif // AMREX_USE_MPI
 
-static_assert(IsDataPacking<ApplyDtosAndProjectionOnReciever<>, FArrayBox>(),
+static_assert(IsDataPacking<ApplyDtosAndProjectionOnReciever<>, FArrayBox>(), // NOLINT(bugprone-throw-keyword-missing)
               "ApplyDtosAndProjectionOnReciever<> is expected to satisfy the DataPacking concept.");
 
 ////////////////////////////////////////////////////////////////////////////////////

--- a/Src/Base/Parser/AMReX_Parser_Exe.H
+++ b/Src/Base/Parser/AMReX_Parser_Exe.H
@@ -227,7 +227,7 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 double parser_exe_eval (const char* p, double const* x)
 {
     ParserStack<AMREX_PARSER_STACK_SIZE> pstack;
-    while (*((parser_exe_t*)p) != PARSER_EXE_NULL) {
+    while (*((parser_exe_t*)p) != PARSER_EXE_NULL) { // NOLINT
         switch (*((parser_exe_t*)p))
         {
         case PARSER_EXE_NUMBER:
@@ -246,69 +246,69 @@ double parser_exe_eval (const char* p, double const* x)
         }
         case PARSER_EXE_ADD:
         {
-            double b = pstack.top();
+            double b = pstack.top(); // NOLINT
             pstack.pop();
-            pstack.top() += b;
+            pstack.top() += b; // NOLINT
             p += sizeof(ParserExeADD);
             break;
         }
         case PARSER_EXE_SUB:
         {
-            double b = pstack.top();
+            double b = pstack.top(); // NOLINT
             pstack.pop();
-            pstack.top() = (pstack.top() - b) * (((ParserExeSUB*)p)->sign);
+            pstack.top() = (pstack.top() - b) * (((ParserExeSUB*)p)->sign); // NOLINT
             p += sizeof(ParserExeSUB);
             break;
         }
         case PARSER_EXE_MUL:
         {
-            double b = pstack.top();
+            double b = pstack.top(); // NOLINT
             pstack.pop();
-            pstack.top() *= b;
+            pstack.top() *= b; // NOLINT
             p += sizeof(ParserExeMUL);
             break;
         }
         case PARSER_EXE_DIV_F:
         {
-            double v = pstack.top();
+            double v = pstack.top(); // NOLINT
             pstack.pop();
-            pstack.top() /= v;
+            pstack.top() /= v; // NOLINT
             p += sizeof(ParserExeDIV_F);
             break;
         }
         case PARSER_EXE_DIV_B:
         {
-            double v = pstack.top();
+            double v = pstack.top(); // NOLINT
             pstack.pop();
-            pstack.top() = v / pstack.top();
+            pstack.top() = v / pstack.top(); // NOLINT
             p += sizeof(ParserExeDIV_B);
             break;
         }
         case PARSER_EXE_NEG:
         {
-            pstack.top() = -pstack.top();
+            pstack.top() = -pstack.top(); // NOLINT
             p += sizeof(ParserExeNEG);
             break;
         }
         case PARSER_EXE_F1:
         {
-            pstack.top() = parser_call_f1(((ParserExeF1*)p)->ftype, pstack.top());
+            pstack.top() = parser_call_f1(((ParserExeF1*)p)->ftype, pstack.top()); // NOLINT
             p += sizeof(ParserExeF1);
             break;
         }
         case PARSER_EXE_F2_F:
         {
-            double v = pstack.top();
+            double v = pstack.top(); // NOLINT
             pstack.pop();
-            pstack.top() = parser_call_f2(((ParserExeF2_F*)p)->ftype, pstack.top(), v);
+            pstack.top() = parser_call_f2(((ParserExeF2_F*)p)->ftype, pstack.top(), v); // NOLINT
             p += sizeof(ParserExeF2_F);
             break;
         }
         case PARSER_EXE_F2_B:
         {
-            double v = pstack.top();
+            double v = pstack.top(); // NOLINT
             pstack.pop();
-            pstack.top() = parser_call_f2(((ParserExeF2_B*)p)->ftype, v, pstack.top());
+            pstack.top() = parser_call_f2(((ParserExeF2_B*)p)->ftype, v, pstack.top()); // NOLINT
             p += sizeof(ParserExeF2_B);
             break;
         }
@@ -394,25 +394,25 @@ double parser_exe_eval (const char* p, double const* x)
         }
         case PARSER_EXE_ADD_VN:
         {
-            pstack.top() += ((ParserExeADD_VN*)p)->v;
+            pstack.top() += ((ParserExeADD_VN*)p)->v; // NOLINT
             p       += sizeof(ParserExeADD_VN);
             break;
         }
         case PARSER_EXE_SUB_VN:
         {
-            pstack.top() = ((ParserExeSUB_VN*)p)->v - pstack.top();
+            pstack.top() = ((ParserExeSUB_VN*)p)->v - pstack.top(); // NOLINT
             p      += sizeof(ParserExeSUB_VN);
             break;
         }
         case PARSER_EXE_MUL_VN:
         {
-            pstack.top() *= ((ParserExeMUL_VN*)p)->v;
+            pstack.top() *= ((ParserExeMUL_VN*)p)->v; // NOLINT
             p       += sizeof(ParserExeMUL_VN);
             break;
         }
         case PARSER_EXE_DIV_VN:
         {
-            pstack.top() = ((ParserExeDIV_VN*)p)->v / pstack.top();
+            pstack.top() = ((ParserExeDIV_VN*)p)->v / pstack.top(); // NOLINT
             p      += sizeof(ParserExeDIV_VN);
             break;
         }
@@ -420,7 +420,7 @@ double parser_exe_eval (const char* p, double const* x)
         {
             int i = ((ParserExeADD_PN*)p)->i;
             double d = AMREX_PARSER_GET_DATA(i);
-            pstack.top() += d;
+            pstack.top() += d; // NOLINT
             p         += sizeof(ParserExeADD_PN);
             break;
         }
@@ -428,7 +428,7 @@ double parser_exe_eval (const char* p, double const* x)
         {
             int i = ((ParserExeSUB_PN*)p)->i;
             double d = AMREX_PARSER_GET_DATA(i);
-            pstack.top() = (d - pstack.top()) * (((ParserExeSUB_PN*)p)->sign);
+            pstack.top() = (d - pstack.top()) * (((ParserExeSUB_PN*)p)->sign); // NOLINT
             p         += sizeof(ParserExeSUB_PN);
             break;
         }
@@ -436,7 +436,7 @@ double parser_exe_eval (const char* p, double const* x)
         {
             int i = ((ParserExeMUL_PN*)p)->i;
             double d = AMREX_PARSER_GET_DATA(i);
-            pstack.top() *= d;
+            pstack.top() *= d; // NOLINT
             p         += sizeof(ParserExeMUL_PN);
             break;
         }
@@ -445,16 +445,16 @@ double parser_exe_eval (const char* p, double const* x)
             int i = ((ParserExeDIV_PN*)p)->i;
             double d = AMREX_PARSER_GET_DATA(i);
             if (((ParserExeDIV_PN*)p)->reverse) {
-                pstack.top() /= d;
+                pstack.top() /= d; // NOLINT
             } else {
-                pstack.top() = d / pstack.top();
+                pstack.top() = d / pstack.top(); // NOLINT
             }
             p            += sizeof(ParserExeDIV_PN);
             break;
         }
         case PARSER_EXE_IF:
         {
-            double cond = pstack.top();
+            double cond = pstack.top(); // NOLINT
             pstack.pop();
             if (cond == 0.0) { // false branch
                 p += ((ParserExeIF*)p)->offset;
@@ -472,7 +472,7 @@ double parser_exe_eval (const char* p, double const* x)
             AMREX_ALWAYS_ASSERT_WITH_MESSAGE(false,"parser_exe_eval: unknown node type");
         }
     }
-    return pstack.top();
+    return pstack.top(); // NOLINT
 }
 
 void parser_compile_exe_size (struct parser_node* node, char*& p, std::size_t& exe_size,

--- a/Src/EB/AMReX_EB2_GeometryShop.H
+++ b/Src/EB/AMReX_EB2_GeometryShop.H
@@ -188,19 +188,11 @@ public:
 
     using FunctionType = F;
 
-    explicit GeometryShop (F const& f)
-        : m_f(f), m_resource()
-        {}
-
-    explicit GeometryShop (F && f)
+    explicit GeometryShop (F f)
         : m_f(std::move(f)), m_resource()
         {}
 
-    GeometryShop (F const& f, R r)
-        : m_f(f), m_resource(std::move(r))
-        {}
-
-    GeometryShop (F && f, R r)
+    GeometryShop (F f, R r)
         : m_f(std::move(f)), m_resource(std::move(r))
         {}
 

--- a/Src/EB/AMReX_EB2_IF_Complement.H
+++ b/Src/EB/AMReX_EB2_IF_Complement.H
@@ -16,13 +16,7 @@ class ComplementIF
 {
 public:
 
-    ComplementIF (F&& a_f) : m_f(std::move(a_f)) {}
-    ComplementIF (F const& a_f) : m_f(a_f) {}
-
-    ComplementIF (const ComplementIF& rhs) = default;
-    ComplementIF (ComplementIF&& rhs) = default;
-    ComplementIF& operator= (const ComplementIF& rhs) = delete;
-    ComplementIF& operator= (ComplementIF&& rhs) = delete;
+    ComplementIF (F a_f) : m_f(std::move(a_f)) {}
 
     inline Real operator() (const RealArray& p) const noexcept
     {

--- a/Src/EB/AMReX_EB2_IF_Difference.H
+++ b/Src/EB/AMReX_EB2_IF_Difference.H
@@ -18,14 +18,10 @@ class DifferenceIF
 {
 public:
 
-    DifferenceIF (F&& a_f, G&& a_g)
+    DifferenceIF (F a_f, G a_g)
         : m_f(std::move(a_f)),
           m_g(std::move(a_g))
         {}
-    DifferenceIF (F const& a_f, G const& a_g)
-        : m_f(a_f),
-          m_g(a_g)
-    {}
 
     inline Real operator() (const RealArray& p) const noexcept
     {

--- a/Src/EB/AMReX_EB2_IF_Extrusion.H
+++ b/Src/EB/AMReX_EB2_IF_Extrusion.H
@@ -16,19 +16,10 @@ class ExtrusionIF
 {
 public:
 
-    ExtrusionIF (F&& a_f, int direction)
+    ExtrusionIF (F a_f, int direction)
         : m_f(std::move(a_f)),
           m_direction(direction)
         {}
-    ExtrusionIF (F const& a_f, int direction)
-        : m_f(a_f),
-          m_direction(direction)
-    {}
-
-    ExtrusionIF (const ExtrusionIF& rhs) = default;
-    ExtrusionIF (ExtrusionIF&& rhs) = default;
-    ExtrusionIF& operator= (const ExtrusionIF& rhs) = delete;
-    ExtrusionIF& operator= (ExtrusionIF&& rhs) = delete;
 
     inline Real operator() (const RealArray& p) const
     {

--- a/Src/EB/AMReX_EB2_IF_Lathe.H
+++ b/Src/EB/AMReX_EB2_IF_Lathe.H
@@ -17,8 +17,7 @@ class LatheIF
 {
 public:
 
-    LatheIF (F&& a_f) : m_f(std::move(a_f)) {}
-    LatheIF (F const& a_f) : m_f(a_f) {}
+    LatheIF (F a_f) : m_f(std::move(a_f)) {}
 
     inline Real operator() (const RealArray& p) const noexcept
     {

--- a/Src/EB/AMReX_EB2_IF_Plane.H
+++ b/Src/EB/AMReX_EB2_IF_Plane.H
@@ -20,11 +20,6 @@ public:
           m_sign( a_inside ? 1.0 : -1.0 )
     {}
 
-    PlaneIF (const PlaneIF& rhs) noexcept = default;
-    PlaneIF (PlaneIF&& rhs) noexcept = default;
-    PlaneIF& operator= (const PlaneIF& rhs) = delete;
-    PlaneIF& operator= (PlaneIF&& rhs) = delete;
-
     AMREX_GPU_HOST_DEVICE inline
     Real operator() (AMREX_D_DECL(Real x, Real y, Real z)) const noexcept
     {

--- a/Src/EB/AMReX_EB2_IF_Polynomial.H
+++ b/Src/EB/AMReX_EB2_IF_Polynomial.H
@@ -41,11 +41,6 @@ public:
           m_sign( a_inside ? 1.0_rt : -1.0_rt )
     {}
 
-    PolyIF (const PolyIF& rhs) = default;
-    PolyIF (PolyIF&& rhs) = default;
-    PolyIF& operator= (const PolyIF& rhs) = delete;
-    PolyIF& operator= (PolyIF&& rhs) = delete;
-
     AMREX_GPU_HOST_DEVICE inline
     Real operator() (AMREX_D_DECL(Real x, Real y, Real z)) const noexcept
     {

--- a/Src/EB/AMReX_EB2_IF_Rotation.H
+++ b/Src/EB/AMReX_EB2_IF_Rotation.H
@@ -16,23 +16,12 @@ class RotationIF
 {
 public:
 
-    RotationIF (F&& a_f, Real angle, int dir)
+    RotationIF (F a_f, Real angle, int dir)
         : m_f(std::move(a_f)),
           m_cos_angle(std::cos(angle)),
           m_sin_angle(std::sin(angle)),
           m_dir(dir)
         {}
-    RotationIF (F const& a_f, Real angle, int dir)
-        : m_f(a_f),
-          m_cos_angle(std::cos(angle)),
-          m_sin_angle(std::sin(angle)),
-          m_dir(dir)
-        {}
-
-    RotationIF (const RotationIF& rhs) = default;
-    RotationIF (RotationIF&& rhs) = default;
-    RotationIF& operator= (const RotationIF& rhs) = delete;
-    RotationIF& operator= (RotationIF&& rhs) = delete;
 
 // Note that angle is measured in radians
 #if (AMREX_SPACEDIM==2)

--- a/Src/EB/AMReX_EB2_IF_Scale.H
+++ b/Src/EB/AMReX_EB2_IF_Scale.H
@@ -16,16 +16,8 @@ class ScaleIF
 {
 public:
 
-    ScaleIF (F&& a_f, const RealArray& a_scalefactor)
+    ScaleIF (F a_f, const RealArray& a_scalefactor)
         : m_f(std::move(a_f)),
-#if (AMREX_SPACEDIM == 3)
-          m_sfinv{1.0_rt/a_scalefactor[0], 1.0_rt/a_scalefactor[1], 1.0_rt/a_scalefactor[2]}
-#else
-          m_sfinv{1.0_rt/a_scalefactor[0], 1.0_rt/a_scalefactor[1], 0.0_rt}
-#endif
-        {}
-    ScaleIF (F const& a_f, const RealArray& a_scalefactor)
-        : m_f(a_f),
 #if (AMREX_SPACEDIM == 3)
           m_sfinv{1.0_rt/a_scalefactor[0], 1.0_rt/a_scalefactor[1], 1.0_rt/a_scalefactor[2]}
 #else

--- a/Src/EB/AMReX_EB2_IF_Translation.H
+++ b/Src/EB/AMReX_EB2_IF_Translation.H
@@ -16,20 +16,10 @@ class TranslationIF
 {
 public:
 
-    TranslationIF (F&& a_f, const RealArray& a_offset)
+    TranslationIF (F a_f, const RealArray& a_offset)
         : m_f(std::move(a_f)),
           m_offset(makeXDim3(a_offset))
         {}
-    TranslationIF (F const& a_f, const RealArray& a_offset)
-        : m_f(a_f),
-          m_offset(makeXDim3(a_offset))
-        {}
-
-    TranslationIF (const TranslationIF& rhs) = default;
-    TranslationIF (TranslationIF&& rhs) = default;
-
-    TranslationIF& operator= (const TranslationIF& rhs) = delete;
-    TranslationIF& operator= (TranslationIF&& rhs) = delete;
 
     inline Real operator() (const RealArray& p) const noexcept
     {

--- a/Src/Particle/AMReX_BinIterator.H
+++ b/Src/Particle/AMReX_BinIterator.H
@@ -24,10 +24,10 @@ struct BinIterator
         AMREX_GPU_HOST_DEVICE
         void operator++ () { ++m_index;; }
 
-        AMREX_GPU_HOST_DEVICE
+        [[nodiscard]] AMREX_GPU_HOST_DEVICE
         bool operator!= (iterator const& /*rhs*/) const { return m_index < m_stop; }
 
-        AMREX_GPU_HOST_DEVICE
+        [[nodiscard]] AMREX_GPU_HOST_DEVICE
         std::pair<index_type, T> operator* () const
         {
             return std::make_pair(m_perm[m_index], m_items[m_perm[m_index]]);
@@ -40,7 +40,7 @@ struct BinIterator
         index_type m_stop;
     };
 
-    AMREX_GPU_HOST_DEVICE
+    [[nodiscard]] AMREX_GPU_HOST_DEVICE
     iterator begin () const
     {
         if (m_i == m_not_found) {
@@ -49,7 +49,7 @@ struct BinIterator
         return iterator(m_offsets_ptr[m_i], m_offsets_ptr[m_i+1], m_permutation_ptr, m_items);
     }
 
-    AMREX_GPU_HOST_DEVICE
+    [[nodiscard]] AMREX_GPU_HOST_DEVICE
     iterator end () const {
         if (m_i == m_not_found) {
             return iterator(0, 0, m_permutation_ptr, m_items);

--- a/Src/Particle/AMReX_NeighborParticles.H
+++ b/Src/Particle/AMReX_NeighborParticles.H
@@ -30,7 +30,7 @@ namespace amrex {
 /// levels during a fine level time step.
 ///
 template <int NStructReal, int NStructInt, int NArrayReal=0, int NArrayInt=0>
-class NeighborParticleContainer
+class NeighborParticleContainer // NOLINT(cppcoreguidelines-virtual-class-destructor) // clang-tidy seems wrong.
     : public ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
 {
 public:
@@ -79,18 +79,17 @@ private:
     };
 
     struct NeighborCopyTag {
-        int level;
-        int grid;
-        int tile;
-        int src_index;
-        int dst_index;
-        IntVect periodic_shift;
+        int level = -1;
+        int grid = -1;
+        int tile = -1;
+        int src_index = 0;
+        int dst_index = 0;
+        IntVect periodic_shift = IntVect(0);
 
-        NeighborCopyTag () {}
+        NeighborCopyTag () = default;
 
         NeighborCopyTag (int a_level, int a_grid, int a_tile) :
-            level(a_level), grid(a_grid), tile(a_tile), src_index(0), dst_index(0),
-            periodic_shift(IntVect(AMREX_D_DECL(0, 0, 0)))
+            level(a_level), grid(a_grid), tile(a_tile)
             {}
 
         bool operator< (const NeighborCopyTag& other) const {
@@ -211,17 +210,19 @@ public:
                                const Vector<int>                 & rr,
                                int                               nneighbor);
 
+    ~NeighborParticleContainer () override = default;
+
     NeighborParticleContainer ( const NeighborParticleContainer &) = delete;
     NeighborParticleContainer& operator= ( const NeighborParticleContainer & ) = delete;
 
-    NeighborParticleContainer ( NeighborParticleContainer && ) = default;
-    NeighborParticleContainer& operator= ( NeighborParticleContainer && ) = default;
+    NeighborParticleContainer ( NeighborParticleContainer && ) = default; // NOLINT(performance-noexcept-move-constructor)
+    NeighborParticleContainer& operator= ( NeighborParticleContainer && ) = default; // NOLINT(performance-noexcept-move-constructor)
 
     ///
     /// Regrid functions
     ///
     void Regrid (const DistributionMapping& dmap, const BoxArray& ba);
-    void Regrid (const DistributionMapping& dmap, const BoxArray& ba, const int lev);
+    void Regrid (const DistributionMapping& dmap, const BoxArray& ba, int lev);
     void Regrid (const Vector<DistributionMapping>& dmap, const Vector<BoxArray>& ba);
 
     ///
@@ -264,7 +265,7 @@ public:
     /// Build a Neighbor List for each tile
     ///
     template <class CheckPair>
-    void buildNeighborList (CheckPair&& check_pair, int typeInd, int* RefRatio,
+    void buildNeighborList (CheckPair&& check_pair, int type_ind, int* ref_ratio,
                             int num_bin_types=1, bool sort=false);
 
     template <class CheckPair>
@@ -362,9 +363,9 @@ protected:
 
     void GetNeighborCommTags ();
 
-    void GetCommTagsBox (Vector<NeighborCommTag>& tags, const int lev, const Box& in_box);
+    void GetCommTagsBox (Vector<NeighborCommTag>& tags, int lev, const Box& in_box);
 
-    void resizeContainers (const int lev);
+    void resizeContainers (int num_levels);
 
     void initializeCommComps ();
 
@@ -384,17 +385,15 @@ protected:
     ///
     void getRcvCountsMPI ();
 
-    void GetNeighborCommTags (Vector<NeighborCommTag>& tags, const int lev, Box box);
-
     void getNeighborTags (Vector<NeighborCopyTag>& tags,
                          const ParticleType& p,
-                         const int nGrow, const NeighborCopyTag& src_tag, const MyParIter& pti);
+                          int nGrow, const NeighborCopyTag& src_tag, const MyParIter& pti);
 
     void getNeighborTags (Vector<NeighborCopyTag>& tags,
                          const ParticleType& p,
                          const IntVect& nGrow, const NeighborCopyTag& src_tag, const MyParIter& pti);
 
-    IntVect computeRefFac (const int src_lev, const int lev);
+    IntVect computeRefFac (int src_lev, int lev);
 
     Vector<std::map<PairIndex, Vector<InverseCopyTag> > > inverse_tags;
     Vector<std::map<PairIndex, ParticleTile> > neighbors;
@@ -475,7 +474,7 @@ protected:
 
     Vector<std::map<std::pair<int, int>, amrex::Gpu::DeviceVector<int> > > m_boundary_particle_ids;
 
-    bool hasNeighbors() const { return m_has_neighbors; }
+    [[nodiscard]] bool hasNeighbors() const { return m_has_neighbors; }
 
     bool m_has_neighbors = false;
 };

--- a/Src/Particle/AMReX_NeighborParticlesCPUImpl.H
+++ b/Src/Particle/AMReX_NeighborParticlesCPUImpl.H
@@ -177,7 +177,7 @@ sumNeighborsMPI (std::map<int, Vector<char> >& not_ours,
         }
     }
 
-    const int nrcvs = RcvProc.size();
+    const auto nrcvs = int(RcvProc.size());
     Vector<MPI_Status>  stats(nrcvs);
     Vector<MPI_Request> rreqs(nrcvs);
 
@@ -229,7 +229,7 @@ sumNeighborsMPI (std::map<int, Vector<char> >& not_ours,
             amrex::Abort("NeighborParticles::sumNeighbors: How did this happen?");
         }
 
-        int npart = recvdata.size() / data_size;
+        auto npart = int(recvdata.size() / data_size);
 
         char* buffer = recvdata.data();
         for (int j = 0; j < npart; ++j)
@@ -522,7 +522,7 @@ fillNeighborsMPI (bool reuse_rcv_counts) {
         }
     }
 
-    const int nrcvs = RcvProc.size();
+    const auto nrcvs = int(RcvProc.size());
     Vector<MPI_Status>  stats(nrcvs);
     Vector<MPI_Request> rreqs(nrcvs);
 
@@ -561,7 +561,7 @@ fillNeighborsMPI (bool reuse_rcv_counts) {
     if (nrcvs > 0) {
         ParallelDescriptor::Waitall(rreqs, stats);
         for (int i = 0; i < nrcvs; ++i) {
-            const int offset = rOffset[i];
+            const auto offset = int(rOffset[i]);
             char* buffer = &recvdata[offset];
             int num_tiles, lev, gid, tid, size, np;
             std::memcpy(&num_tiles, buffer, sizeof(int)); buffer += sizeof(int);

--- a/Src/Particle/AMReX_NeighborParticlesGPUImpl.H
+++ b/Src/Particle/AMReX_NeighborParticlesGPUImpl.H
@@ -4,7 +4,7 @@
 
 namespace detail
 {
-    inline Vector<Box> getBoundaryBoxes(const Box& box, const int ncells)
+    inline Vector<Box> getBoundaryBoxes(const Box& box, int ncells)
     {
         AMREX_ASSERT_WITH_MESSAGE(box.size() > 2*IntVect(AMREX_D_DECL(ncells, ncells, ncells)),
                                   "Too many cells requested in getBoundaryBoxes");

--- a/Src/Particle/AMReX_NeighborParticlesI.H
+++ b/Src/Particle/AMReX_NeighborParticlesI.H
@@ -19,9 +19,9 @@ NeighborParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
 ::NeighborParticleContainer (const Geometry            & geom,
                              const DistributionMapping & dmap,
                              const BoxArray            & ba,
-                             int                         ncells)
+                             int                         nneighbor)
     : ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt> (geom, dmap, ba),
-    m_num_neighbor_cells(ncells)
+    m_num_neighbor_cells(nneighbor)
 {
     initializeCommComps();
 }
@@ -32,9 +32,9 @@ NeighborParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
                              const Vector<DistributionMapping> & dmap,
                              const Vector<BoxArray>            & ba,
                              const Vector<int>                 & rr,
-                             int                               ncells)
+                             int                               nneighbor)
     : ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt> (geom, dmap, ba, rr),
-    m_num_neighbor_cells(ncells)
+    m_num_neighbor_cells(nneighbor)
 {
     initializeCommComps();
 }
@@ -99,7 +99,7 @@ NeighborParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
 template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt>
 void
 NeighborParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
-::Regrid (const DistributionMapping &dmap, const BoxArray &ba, const int lev) {
+::Regrid (const DistributionMapping &dmap, const BoxArray &ba, int lev) {
     AMREX_ASSERT(lev <= this->finestLevel());
     this->SetParticleBoxArray(lev, ba);
     this->SetParticleDistributionMap(lev, dmap);
@@ -239,7 +239,7 @@ NeighborParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
 template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt>
 IntVect
 NeighborParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
-::computeRefFac (const int src_lev, const int lev)
+::computeRefFac (int src_lev, int lev)
 {
     IntVect ref_fac = IntVect(AMREX_D_DECL(1,1,1));
     if (src_lev < lev) {
@@ -258,7 +258,7 @@ NeighborParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
 template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt>
 void
 NeighborParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
-::GetCommTagsBox (Vector<NeighborCommTag>& tags, const int src_lev, const Box& in_box)
+::GetCommTagsBox (Vector<NeighborCommTag>& tags, int src_lev, const Box& in_box)
 {
     std::vector< std::pair<int, Box> > isects;
     Box tbx;
@@ -529,7 +529,7 @@ template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt>
 void
 NeighborParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>::
 getNeighborTags (Vector<NeighborCopyTag>& tags, const ParticleType& p,
-                 const int nGrow, const NeighborCopyTag& src_tag, const MyParIter& pti)
+                 int nGrow, const NeighborCopyTag& src_tag, const MyParIter& pti)
 {
     getNeighborTags(tags, p, IntVect(AMREX_D_DECL(nGrow, nGrow, nGrow)), src_tag, pti);
 }
@@ -1104,7 +1104,7 @@ printNeighborList ()
 template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt>
 void
 NeighborParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>::
-resizeContainers (const int num_levels)
+resizeContainers (int num_levels)
 {
     this->reserveData();
     this->resizeData();

--- a/Src/Particle/AMReX_ParticleArray.H
+++ b/Src/Particle/AMReX_ParticleArray.H
@@ -47,16 +47,21 @@ public:
     AMREX_GPU_HOST_DEVICE
     ref_wrapper(T& ref) noexcept : _ptr(&ref) {}
     ref_wrapper(T&&) = delete;
-    ref_wrapper(const ref_wrapper&) noexcept = default;
+
+    ~ref_wrapper () = default;
+    ref_wrapper (const ref_wrapper&) noexcept = default;
+    ref_wrapper (ref_wrapper&&) noexcept = default;
 
     AMREX_GPU_HOST_DEVICE
-    void operator= (T&& a_other) {this->get()=a_other;}
-    ref_wrapper& operator=(const ref_wrapper& x) noexcept = default;
+    ref_wrapper& operator= (T&& a_other) { this->get()=a_other; return *this; }
 
-    AMREX_GPU_HOST_DEVICE
+    ref_wrapper& operator= (const ref_wrapper&) noexcept = default;
+    ref_wrapper& operator= (ref_wrapper&&) noexcept = default;
+
+    [[nodiscard]] AMREX_GPU_HOST_DEVICE
     operator T& () const noexcept { return *_ptr; }
 
-    AMREX_GPU_HOST_DEVICE
+    [[nodiscard]] AMREX_GPU_HOST_DEVICE
     T& get() const noexcept { return *_ptr; }
 
 private:
@@ -125,7 +130,7 @@ template <template <typename...> class ContainerType,
           typename... Types>
 struct DataLayoutPolicy<ContainerType, ParticleType<Types...>, DataLayout::SoA> {
     using container_type = std::tuple<ContainerType<Types>...>;
-    using raw_type = const amrex::GpuTuple<Types*...>;
+    using raw_type = amrex::GpuTuple<Types*...>;
     using value_type = ParticleType<ref_wrapper<Types>...>;
 
     static constexpr raw_type get_raw_data (container_type& a_container)
@@ -182,11 +187,11 @@ private:
  */
 template <template<typename...> class ParticleType, typename... Types>
 struct DataLayoutPolicyRaw<ParticleType<Types...>, DataLayout::SoA> {
-    using raw_type = const amrex::GpuTuple<Types*...>;
+    using raw_type = amrex::GpuTuple<Types*...>;
     using value_type = ParticleType<ref_wrapper<Types>...>;
 
     AMREX_GPU_HOST_DEVICE
-    static constexpr value_type get (raw_type& a_tuple, std::size_t a_index)
+    static constexpr value_type get (raw_type const& a_tuple, std::size_t a_index)
     {
         return get_impl(a_tuple, a_index, std::make_index_sequence<sizeof...(Types)>());
     }
@@ -195,7 +200,7 @@ private:
 
     template <std::size_t... Is>
     AMREX_GPU_HOST_DEVICE
-    static constexpr auto get_impl (raw_type& a_tuple, std::size_t a_index,
+    static constexpr auto get_impl (raw_type const& a_tuple, std::size_t a_index,
                                     std::index_sequence<Is...>)
     {
         return value_type{ref_wrapper<Types>(amrex::get<Is>(a_tuple)[a_index])... };
@@ -248,6 +253,10 @@ private:
 template <typename ParticleType, DataLayout DataLayoutTag>
 struct ParticleArrayAccessor
 {
+    // ParticleType: Particle<double, double, double, int, int>
+    // DataLayoutTag: amrex::DataLayout::SoA
+    // value_type: Particle<amrex::ref_wrapper<double>, amrex::ref_wrapper<double>, amrex::ref_wrapper<double>, amrex::ref_wrapper<int>, amrex::ref_wrapper<int> >
+
     using policy_type  = DataLayoutPolicyRaw<ParticleType, DataLayoutTag>;
     using value_type   = typename policy_type::value_type;
     using raw_type     = typename policy_type::raw_type;
@@ -258,11 +267,11 @@ struct ParticleArrayAccessor
         : m_size(a_size), m_data(a_data)
     {}
 
-    AMREX_GPU_HOST_DEVICE
+    [[nodiscard]] AMREX_GPU_HOST_DEVICE
     value_type operator[] (std::size_t a_index) const { return policy_type::get(m_data, a_index); }
 
-    AMREX_GPU_HOST_DEVICE
-    std::size_t size () { return m_size; }
+    [[nodiscard]] AMREX_GPU_HOST_DEVICE
+    std::size_t size () const { return m_size; }
 
 private:
     std::size_t m_size;

--- a/Src/Particle/AMReX_ParticleInterpolators.H
+++ b/Src/Particle/AMReX_ParticleInterpolators.H
@@ -6,9 +6,7 @@
 #include <AMReX_Gpu.H>
 #include <AMReX_Print.H>
 
-namespace amrex
-{
-namespace ParticleInterpolator
+namespace amrex::ParticleInterpolator
 {
 
 /** \brief A base class for doing general particle/mesh interpolation operations.
@@ -251,7 +249,6 @@ struct Linear : public Base<Linear, amrex::Real>
         }
     }
 };
-}
 }
 
 #endif // include guard

--- a/Tests/Amr/Advection_AmrCore/Source/AdvancePhiAllLevels.cpp
+++ b/Tests/Amr/Advection_AmrCore/Source/AdvancePhiAllLevels.cpp
@@ -227,7 +227,7 @@ AmrCoreAdv::AdvancePhiAllLevels (Real time, Real dt_lev, int /*iteration*/)
                 // zy --------------------
                 Array4<Real> phiz_y = tmpfab.array(itmp);
                 Array4<Real const> phiz_y_c = phiz_y;
-                itmp += 1;
+                itmp += 1; // NOLINT(clang-analyzer-deadcode.DeadStores)
 
                 b = bx;
                 amrex::ParallelFor(b.grow(Direction::x,1).surroundingNodes(Direction::z),

--- a/Tests/Amr/Advection_AmrCore/Source/AmrCoreAdv.H
+++ b/Tests/Amr/Advection_AmrCore/Source/AmrCoreAdv.H
@@ -32,7 +32,13 @@ public:
     // constructor - reads in parameters from inputs file
     //             - sizes multilevel arrays and data structures
     AmrCoreAdv ();
-    virtual ~AmrCoreAdv();
+    ~AmrCoreAdv () override;
+
+    AmrCoreAdv (AmrCoreAdv&& rhs) noexcept = default;
+    AmrCoreAdv& operator= (AmrCoreAdv&& rhs) noexcept = default;
+
+    AmrCoreAdv (const AmrCoreAdv& rhs) = delete;
+    AmrCoreAdv& operator= (const AmrCoreAdv& rhs) = delete;
 
     // advance solution to final time
     void Evolve ();
@@ -43,28 +49,28 @@ public:
     // Make a new level using provided BoxArray and DistributionMapping and
     // fill with interpolated coarse level data.
     // overrides the pure virtual function in AmrCore
-    virtual void MakeNewLevelFromCoarse (int lev, amrex::Real time, const amrex::BoxArray& ba,
-                                         const amrex::DistributionMapping& dm) override;
+    void MakeNewLevelFromCoarse (int lev, amrex::Real time, const amrex::BoxArray& ba,
+                                 const amrex::DistributionMapping& dm) override;
 
     // Remake an existing level using provided BoxArray and DistributionMapping and
     // fill with existing fine and coarse data.
     // overrides the pure virtual function in AmrCore
-    virtual void RemakeLevel (int lev, amrex::Real time, const amrex::BoxArray& ba,
-                              const amrex::DistributionMapping& dm) override;
+    void RemakeLevel (int lev, amrex::Real time, const amrex::BoxArray& ba,
+                      const amrex::DistributionMapping& dm) override;
 
     // Delete level data
     // overrides the pure virtual function in AmrCore
-    virtual void ClearLevel (int lev) override;
+    void ClearLevel (int lev) override;
 
     // Make a new level from scratch using provided BoxArray and DistributionMapping.
     // Only used during initialization.
     // overrides the pure virtual function in AmrCore
-    virtual void MakeNewLevelFromScratch (int lev, amrex::Real time, const amrex::BoxArray& ba,
-                                          const amrex::DistributionMapping& dm) override;
+    void MakeNewLevelFromScratch (int lev, amrex::Real time, const amrex::BoxArray& ba,
+                                  const amrex::DistributionMapping& dm) override;
 
     // tag all cells for refinement
     // overrides the pure virtual function in AmrCore
-    virtual void ErrorEst (int lev, amrex::TagBoxArray& tags, amrex::Real time, int ngrow) override;
+    void ErrorEst (int lev, amrex::TagBoxArray& tags, amrex::Real time, int ngrow) override;
 
     // Advance phi at a single level for a single time step, update flux registers
     void AdvancePhiAtLevel (int lev, amrex::Real time, amrex::Real dt_lev, int iteration, int ncycle);
@@ -124,13 +130,13 @@ private:
     void ComputeDt ();
 
     // get plotfile name
-    std::string PlotFileName (int lev) const;
+    [[nodiscard]] std::string PlotFileName (int lev) const;
 
     // put together an array of multifabs for writing
-    amrex::Vector<const amrex::MultiFab*> PlotFileMF () const;
+    [[nodiscard]] amrex::Vector<const amrex::MultiFab*> PlotFileMF () const;
 
     // set plotfile variables names
-    amrex::Vector<std::string> PlotFileVarNames () const;
+    [[nodiscard]] static amrex::Vector<std::string> PlotFileVarNames ();
 
     // write plotfile to disk
     void WritePlotFile () const;
@@ -183,7 +189,7 @@ private:
     amrex::Real stop_time = std::numeric_limits<amrex::Real>::max();
 
     // if >= 0 we restart from a checkpoint
-    std::string restart_chkfile = "";
+    std::string restart_chkfile;
 
     // advective cfl number - dt = cfl*dx/umax
     amrex::Real cfl = 0.7;

--- a/Tests/Amr/Advection_AmrCore/Source/AmrCoreAdv.cpp
+++ b/Tests/Amr/Advection_AmrCore/Source/AmrCoreAdv.cpp
@@ -100,9 +100,7 @@ AmrCoreAdv::AmrCoreAdv ()
     fillpatcher.resize(nlevs_max+1);
 }
 
-AmrCoreAdv::~AmrCoreAdv ()
-{
-}
+AmrCoreAdv::~AmrCoreAdv () = default;
 
 // advance solution to final time
 void
@@ -166,7 +164,7 @@ AmrCoreAdv::Evolve ()
 void
 AmrCoreAdv::InitData ()
 {
-    if (restart_chkfile == "") {
+    if (restart_chkfile.empty()) {
         // start simulation from the beginning
         const Real time = 0.0;
         InitFromScratch(time);
@@ -747,7 +745,7 @@ AmrCoreAdv::ComputeDt ()
     {
         dt_tmp[lev] = EstTimeStep(lev, t_new[lev]);
     }
-    ParallelDescriptor::ReduceRealMin(&dt_tmp[0], dt_tmp.size());
+    ParallelDescriptor::ReduceRealMin(&dt_tmp[0], int(dt_tmp.size()));
 
     constexpr Real change_max = 1.1;
     Real dt_0 = dt_tmp[0];
@@ -783,7 +781,7 @@ AmrCoreAdv::EstTimeStep (int lev, Real time)
 
     const Real* dx  =  geom[lev].CellSize();
 
-    if (time == 0.0) {
+    if (time == Real(0.0)) {
        DefineVelocityAtLevel(lev,time);
     } else {
        Real t_nph_predicted = time + 0.5 * dt[lev];
@@ -821,7 +819,7 @@ AmrCoreAdv::PlotFileMF () const
 
 // set plotfile variable names
 Vector<std::string>
-AmrCoreAdv::PlotFileVarNames () const
+AmrCoreAdv::PlotFileVarNames ()
 {
     return {"phi"};
 }
@@ -1056,7 +1054,7 @@ AmrCoreAdv::ReadCheckpointFile ()
 
 #ifdef AMREX_PARTICLES
     if (do_tracers) {
-        BL_ASSERT(TracerPC == 0);
+        BL_ASSERT(TracerPC == nullptr);
         TracerPC = std::make_unique<AmrTracerParticleContainer>(this);
         TracerPC->Restart(this->restart_chkfile, "particles");
     }

--- a/Tests/Amr/Advection_AmrCore/Source/Src_K/Adv_K.H
+++ b/Tests/Amr/Advection_AmrCore/Source/Src_K/Adv_K.H
@@ -1,5 +1,5 @@
-#ifndef _Adv_K_H_
-#define _Adv_K_H_
+#ifndef Adv_K_H_
+#define Adv_K_H_
 
 #include <AMReX_Box.H>
 #include <AMReX_FArrayBox.H>

--- a/Tests/Amr/Advection_AmrCore/Source/Src_K/compute_flux_2D_K.H
+++ b/Tests/Amr/Advection_AmrCore/Source/Src_K/compute_flux_2D_K.H
@@ -1,5 +1,5 @@
-#ifndef _compute_flux_2d_H_
-#define _compute_flux_2d_H_
+#ifndef compute_flux_2d_H_
+#define compute_flux_2d_H_
 
 #include <AMReX_BLFort.H>
 #include <AMReX_Box.H>

--- a/Tests/Amr/Advection_AmrCore/Source/Src_K/compute_flux_3D_K.H
+++ b/Tests/Amr/Advection_AmrCore/Source/Src_K/compute_flux_3D_K.H
@@ -1,5 +1,5 @@
-#ifndef _compute_flux_3d_H_
-#define _compute_flux_3d_H_
+#ifndef compute_flux_3d_H_
+#define compute_flux_3d_H_
 
 #include <AMReX_BLFort.H>
 #include <AMReX_Box.H>

--- a/Tests/Amr/Advection_AmrLevel/Exec/SingleVortex/face_velocity_2d_K.H
+++ b/Tests/Amr/Advection_AmrLevel/Exec/SingleVortex/face_velocity_2d_K.H
@@ -33,8 +33,6 @@ void get_face_velocity_psi(amrex::Box const& bx,
                        * std::cos(PI*time/2.0) * 1.0/PI;
         }
     }
-
-    return;
 }
 
 AMREX_GPU_DEVICE
@@ -110,8 +108,6 @@ void get_face_velocity(const amrex::Real time,
          {
              get_face_velocity_y(i, j, k, vel[1], psi, dx[0]);
          });
-
-    return;
 }
 
 #endif

--- a/Tests/Amr/Advection_AmrLevel/Exec/SingleVortex/face_velocity_3d_K.H
+++ b/Tests/Amr/Advection_AmrLevel/Exec/SingleVortex/face_velocity_3d_K.H
@@ -35,8 +35,6 @@ void get_face_velocity_psi(amrex::Box const& bx,
                        * std::cos(PI*time/2.0) * 1.0/PI;
         }
     }
-
-    return;
 }
 
 AMREX_GPU_DEVICE
@@ -125,8 +123,6 @@ void get_face_velocity(const amrex::Real time,
          {
              get_face_velocity_z(i, j, k, vel[2]);
          });
-
-    return;
 }
 
 #endif

--- a/Tests/Amr/Advection_AmrLevel/Exec/UniformVelocity/face_velocity_2d_K.H
+++ b/Tests/Amr/Advection_AmrLevel/Exec/UniformVelocity/face_velocity_2d_K.H
@@ -19,8 +19,6 @@ void get_face_velocity(const amrex::Real /*time*/,
 
     vx.setVal<RunOn::Device>(AmrLevelAdv::h_prob_parm->adv_vel[0]);
     vy.setVal<RunOn::Device>(AmrLevelAdv::h_prob_parm->adv_vel[1]);
-
-    return;
 }
 
 #endif

--- a/Tests/Amr/Advection_AmrLevel/Exec/UniformVelocity/face_velocity_3d_K.H
+++ b/Tests/Amr/Advection_AmrLevel/Exec/UniformVelocity/face_velocity_3d_K.H
@@ -21,8 +21,6 @@ void get_face_velocity(const amrex::Real /*time*/,
     vx.setVal<RunOn::Device>(AmrLevelAdv::h_prob_parm->adv_vel[0]);
     vy.setVal<RunOn::Device>(AmrLevelAdv::h_prob_parm->adv_vel[1]);
     vz.setVal<RunOn::Device>(AmrLevelAdv::h_prob_parm->adv_vel[2]);
-
-    return;
 }
 
 #endif

--- a/Tests/Amr/Advection_AmrLevel/Source/AmrLevelAdv.H
+++ b/Tests/Amr/Advection_AmrLevel/Source/AmrLevelAdv.H
@@ -50,29 +50,34 @@ public:
     /**
      * The destructor.
      */
-    virtual ~AmrLevelAdv () override;
+    ~AmrLevelAdv () override;
+
+    AmrLevelAdv (AmrLevelAdv const&) = delete;
+    AmrLevelAdv& operator= (AmrLevelAdv const&) = delete;
+    AmrLevelAdv (AmrLevelAdv &&) noexcept = delete;
+    AmrLevelAdv& operator= (AmrLevelAdv &&) noexcept = delete;
 
     /**
      * Restart from a checkpoint file.
      */
-    virtual void restart (amrex::Amr&   papa,
-                          std::istream& is,
-                          bool          bReadSpecial = false) override;
+    void restart (amrex::Amr&   papa,
+                  std::istream& is,
+                  bool          bReadSpecial = false) override;
 
     /**
      * Write a checkpoint file.
      */
-    virtual void checkPoint (const std::string& dir,
-                             std::ostream&      os,
-                             amrex::VisMF::How  how = amrex::VisMF::NFiles,
-                             bool               dump_old = true) override;
+    void checkPoint (const std::string& dir,
+                     std::ostream&      os,
+                     amrex::VisMF::How  how = amrex::VisMF::NFiles,
+                     bool               dump_old = true) override;
 
     /**
      * Write a plotfile to specified directory.
      */
-    virtual void writePlotFile (const std::string& dir,
-                                std::ostream&      os,
-                                amrex::VisMF::How  how) override;
+    void writePlotFile (const std::string& dir,
+                        std::ostream&      os,
+                        amrex::VisMF::How  how) override;
 
     /**
      * Define data descriptors.
@@ -87,25 +92,25 @@ public:
     /**
      * Initialize grid data at problem start-up.
      */
-    virtual void initData () override;
+    void initData () override;
 
     /**
      * Initialize data on this level from another AmrLevelAdv (during regrid).
      */
-    virtual void init (amrex::AmrLevel& old) override;
+    void init (amrex::AmrLevel& old) override;
 
     /**
      * Initialize data on this level after regridding if old level did not previously exist
      */
-    virtual void init () override;
+    void init () override;
 
     /**
      * Advance grids at this level in time.
      */
-    virtual amrex::Real advance (amrex::Real time,
-                                 amrex::Real dt,
-                                 int  iteration,
-                                 int  ncycle) override;
+     amrex::Real advance (amrex::Real time,
+                          amrex::Real dt,
+                          int  iteration,
+                          int  ncycle) override;
 
     /**
      * Estimate time step.
@@ -120,53 +125,53 @@ public:
     /**
      * Compute initial `dt'.
      */
-    virtual void computeInitialDt (int                   finest_level,
-                                   int                   sub_cycle,
-                                   amrex::Vector<int>&           n_cycle,
-                                   const amrex::Vector<amrex::IntVect>& ref_ratio,
-                                   amrex::Vector<amrex::Real>&          dt_level,
-                                   amrex::Real                  stop_time) override;
+    void computeInitialDt (int                   finest_level,
+                           int                   sub_cycle,
+                           amrex::Vector<int>&           n_cycle,
+                           const amrex::Vector<amrex::IntVect>& ref_ratio,
+                           amrex::Vector<amrex::Real>&          dt_level,
+                           amrex::Real                  stop_time) override;
 
     /**
      * Compute new `dt'.
      */
-    virtual void computeNewDt (int                   finest_level,
-                               int                   sub_cycle,
-                               amrex::Vector<int>&           n_cycle,
-                               const amrex::Vector<amrex::IntVect>& ref_ratio,
-                               amrex::Vector<amrex::Real>&          dt_min,
-                               amrex::Vector<amrex::Real>&          dt_level,
-                               amrex::Real                  stop_time,
-                               int                   post_regrid_flag) override;
+    void computeNewDt (int                   finest_level,
+                       int                   sub_cycle,
+                       amrex::Vector<int>&           n_cycle,
+                       const amrex::Vector<amrex::IntVect>& ref_ratio,
+                       amrex::Vector<amrex::Real>&          dt_min,
+                       amrex::Vector<amrex::Real>&          dt_level,
+                       amrex::Real                  stop_time,
+                       int                   post_regrid_flag) override;
 
     /**
      * Do work after timestep().
      */
-    virtual void post_timestep (int iteration) override;
+    void post_timestep (int iteration) override;
 
     /**
      * Do work after regrid().
      */
-    virtual void post_regrid (int lbase, int new_finest) override;
+    void post_regrid (int lbase, int new_finest) override;
 
     /**
      * Do work after a restart().
      */
-    virtual void post_restart () override;
+    void post_restart () override;
 
     /**
      * Do work after init().
      */
-    virtual void post_init (amrex::Real stop_time) override;
+    void post_init (amrex::Real stop_time) override;
 
     /**
      * Error estimation for regridding.
      */
-    virtual void errorEst (amrex::TagBoxArray& tb,
-                           int                 clearval,
-                           int                 tagval,
-                           amrex::Real         time,
-                           int          n_error_buf = 0, int ngrow = 0) override;
+    void errorEst (amrex::TagBoxArray& tags,
+                   int                 clearval,
+                   int                 tagval,
+                   amrex::Real         time,
+                   int n_error_buf = 0, int ngrow = 0) override;
 
 #ifdef AMREX_PARTICLES
     static amrex::AmrTracerParticleContainer* theTracerPC () { return TracerPC.get(); }

--- a/Tests/Amr/Advection_AmrLevel/Source/AmrLevelAdv.cpp
+++ b/Tests/Amr/Advection_AmrLevel/Source/AmrLevelAdv.cpp
@@ -34,9 +34,7 @@ int AmrLevelAdv::do_tracers                       =  0;
 /**
  * Default constructor.  Builds invalid object.
  */
-AmrLevelAdv::AmrLevelAdv ()
-{
-}
+AmrLevelAdv::AmrLevelAdv () = default;
 
 /**
  * The basic constructor.
@@ -58,9 +56,7 @@ AmrLevelAdv::AmrLevelAdv (Amr&            papa,
 /**
  * The destructor.
  */
-AmrLevelAdv::~AmrLevelAdv ()
-{
-}
+AmrLevelAdv::~AmrLevelAdv () = default;
 
 /**
  * Restart from a checkpoint file.
@@ -191,7 +187,7 @@ AmrLevelAdv::initData ()
 void
 AmrLevelAdv::init (AmrLevel &old)
 {
-    AmrLevelAdv* oldlev = (AmrLevelAdv*) &old;
+    auto* oldlev = (AmrLevelAdv*) &old;
 
     //
     // Create new grid data by fillpatching from old.
@@ -255,8 +251,8 @@ AmrLevelAdv::advance (Real time,
     //
     // Get pointers to Flux registers, or set pointer to zero if not there.
     //
-    FluxRegister *fine    = 0;
-    FluxRegister *current = 0;
+    FluxRegister *fine    = nullptr;
+    FluxRegister *current = nullptr;
 
     int finest_level = parent->finestLevel();
 
@@ -651,7 +647,7 @@ AmrLevelAdv::post_restart()
 {
 #ifdef AMREX_PARTICLES
     if (do_tracers && level == 0) {
-      BL_ASSERT(TracerPC == 0);
+      BL_ASSERT(TracerPC == nullptr);
       TracerPC = std::make_unique<AmrTracerParticleContainer>(parent);
       TracerPC->Restart(parent->theRestartFile(), "Tracer");
     }

--- a/Tests/Amr/Advection_AmrLevel/Source/LevelBldAdv.cpp
+++ b/Tests/Amr/Advection_AmrLevel/Source/LevelBldAdv.cpp
@@ -8,15 +8,15 @@ class LevelBldAdv
     :
     public LevelBld
 {
-    virtual void variableSetUp () override;
-    virtual void variableCleanUp () override;
-    virtual AmrLevel *operator() () override;
-    virtual AmrLevel *operator() (Amr&            papa,
-                                  int             lev,
-                                  const Geometry& level_geom,
-                                  const BoxArray& ba,
-                                  const DistributionMapping& dm,
-                                  Real            time) override;
+    void variableSetUp () override;
+    void variableCleanUp () override;
+    AmrLevel *operator() () override;
+    AmrLevel *operator() (Amr&            papa,
+                          int             lev,
+                          const Geometry& level_geom,
+                          const BoxArray& ba,
+                          const DistributionMapping& dm,
+                          Real            time) override;
 };
 
 LevelBldAdv Adv_bld;

--- a/Tests/AsyncOut/multifab/main.cpp
+++ b/Tests/AsyncOut/multifab/main.cpp
@@ -82,7 +82,7 @@ void main_main ()
 
         amrex::Gpu::copyAsync(Gpu::hostToDevice, h_arrs.begin(), h_arrs.end(), d_arrs.begin());
 
-        auto arrs_ptr = d_arrs.dataPtr();
+        auto* arrs_ptr = d_arrs.dataPtr();
 
         amrex::ParallelForRNG(bx,
         [=] AMREX_GPU_DEVICE (int i, int j, int k, RandomEngine const& engine) noexcept

--- a/Tests/EB/CNS/Source/CNS.H
+++ b/Tests/EB/CNS/Source/CNS.H
@@ -19,84 +19,86 @@ public:
          const amrex::BoxArray& bl,
          const amrex::DistributionMapping& dm,
          amrex::Real            time);
-    virtual ~CNS ();
+    ~CNS () override;
 
     CNS (const CNS& rhs) = delete;
+    CNS (CNS&& rhs) = delete;
     CNS& operator= (const CNS& rhs) = delete;
+    CNS& operator= (CNS&& rhs) = delete;
 
     // Restart from a checkpoint file.
-    virtual void restart (amrex::Amr&     papa,
-                          std::istream&   is,
-                          bool            bReadSpecial = false) override;
+    void restart (amrex::Amr&     papa,
+                  std::istream&   is,
+                  bool            bReadSpecial = false) override;
 
     // Write checkpoint
-    virtual void checkPoint(const std::string& dir,
-                            std::ostream&      os,
-                            amrex::VisMF::How  how = amrex::VisMF::NFiles,
-                            bool               dump_old = true) override;
+    void checkPoint(const std::string& dir,
+                    std::ostream&      os,
+                    amrex::VisMF::How  how = amrex::VisMF::NFiles,
+                    bool               dump_old = true) override;
 
-    virtual std::string thePlotFileType () const override {
+    std::string thePlotFileType () const override {
         return {"HyperCLaw-V1.1"};
     }
 
     // Write a plotfile to specified directory.
-    virtual void writePlotFile (const std::string& dir,
-                                std::ostream&      os,
-                                amrex::VisMF::How  how) override;
+    void writePlotFile (const std::string& dir,
+                        std::ostream&      os,
+                        amrex::VisMF::How  how) override;
 
     // Initialize data on this level from another CNS (during regrid).
-    virtual void init (amrex::AmrLevel& old) override;
+    void init (amrex::AmrLevel& old) override;
 
     // Initialize data on this level after regridding if old level did not previously exist
-    virtual void init () override;
+    void init () override;
 
     // Initialize grid data at problem start-up.
-    virtual void initData () override;
+    void initData () override;
 
     // Advance grids at this level in time.
-    virtual amrex::Real advance (amrex::Real time,
-                                 amrex::Real dt,
-                                 int  iteration,
-                                 int  ncycle) override;
+    amrex::Real advance (amrex::Real time,
+                         amrex::Real dt,
+                         int  iteration,
+                         int  ncycle) override;
 
-    virtual void computeInitialDt (int                                 finest_level,
-                                   int                                 sub_cycle,
-                                   amrex::Vector<int>&                  n_cycle,
-                                   const amrex::Vector<amrex::IntVect>& ref_ratio,
-                                   amrex::Vector<amrex::Real>&          dt_level,
-                                   amrex::Real                         stop_time) override;
+    void computeInitialDt (int                                 finest_level,
+                           int                                 sub_cycle,
+                           amrex::Vector<int>&                  n_cycle,
+                           const amrex::Vector<amrex::IntVect>& ref_ratio,
+                           amrex::Vector<amrex::Real>&          dt_level,
+                           amrex::Real                         stop_time) override;
 
-    virtual void computeNewDt (int                                 finest_level,
-                               int                                 sub_cycle,
-                               amrex::Vector<int>&                  n_cycle,
-                               const amrex::Vector<amrex::IntVect>& ref_ratio,
-                               amrex::Vector<amrex::Real>&          dt_min,
-                               amrex::Vector<amrex::Real>&          dt_level,
-                               amrex::Real                         stop_time,
-                               int                                 post_regrid_flag) override;
+    void computeNewDt (int                                 finest_level,
+                       int                                 sub_cycle,
+                       amrex::Vector<int>&                  n_cycle,
+                       const amrex::Vector<amrex::IntVect>& ref_ratio,
+                       amrex::Vector<amrex::Real>&          dt_min,
+                       amrex::Vector<amrex::Real>&          dt_level,
+                       amrex::Real                         stop_time,
+                       int                                 post_regrid_flag) override;
 
-    virtual void post_regrid (int lbase, int new_finest) override;
+    void post_regrid (int lbase, int new_finest) override;
 
     // Do work after timestep().
-    virtual void post_timestep (int iteration) override;
+    void post_timestep (int iteration) override;
 
     // After a full time step
-    virtual void postCoarseTimeStep (amrex::Real time) override;
+    void postCoarseTimeStep (amrex::Real time) override;
 
     // Do work after init().
-    virtual void post_init (amrex::Real stop_time) override;
+    void post_init (amrex::Real stop_time) override;
 
-    virtual void post_restart () override;
+    void post_restart () override;
 
     // Error estimation for regridding.
-    virtual void errorEst (amrex::TagBoxArray& tb,
-                           int                 clearval,
-                           int                 tagval,
-                           amrex::Real         time,
-                           int                 n_error_buf = 0,
-                           int                 ngrow = 0) override;
+    void errorEst (amrex::TagBoxArray& tags,
+                   int                 clearval,
+                   int                 tagval,
+                   amrex::Real         time,
+                   int                 n_error_buf = 0,
+                   int                 ngrow = 0) override;
 
-    virtual int WorkEstType () override { return Cost_Type; }
+    int WorkEstType () override { return Cost_Type; }
 
     // Define data descriptors.
     static void variableSetUp ();
@@ -123,7 +125,7 @@ protected:
     // Compute initial time step.
     amrex::Real initialTimeStep ();
 
-    void computeTemp (amrex::MultiFab& State, int ng);
+    static void computeTemp (amrex::MultiFab& State, int ng);
 
     void compute_dSdt (const amrex::MultiFab& S, amrex::MultiFab& dSdt, amrex::Real dt,
                        amrex::EBFluxRegister* fr_as_crse, amrex::EBFluxRegister* fr_as_fine);

--- a/Tests/EB/CNS/Source/CNS.cpp
+++ b/Tests/EB/CNS/Source/CNS.cpp
@@ -30,8 +30,7 @@ int       CNS::refine_max_dengrad_lev   = -1;
 Real      CNS::refine_dengrad           = 1.0e10;
 Vector<RealBox> CNS::refine_boxes;
 
-CNS::CNS ()
-{}
+CNS::CNS () = default;
 
 CNS::CNS (Amr&            papa,
           int             lev,
@@ -51,8 +50,7 @@ CNS::CNS (Amr&            papa,
     buildMetrics();
 }
 
-CNS::~CNS ()
-{}
+CNS::~CNS () = default;
 
 void
 CNS::init (AmrLevel& old)
@@ -530,4 +528,3 @@ CNS::computeTemp (MultiFab& State, int ng)
         }
     }
 }
-

--- a/Tests/EB/CNS/Source/CNSBld.cpp
+++ b/Tests/EB/CNS/Source/CNSBld.cpp
@@ -8,15 +8,15 @@ class CNSBld
     :
     public LevelBld
 {
-    virtual void variableSetUp () override;
-    virtual void variableCleanUp () override;
-    virtual AmrLevel *operator() () override;
-    virtual AmrLevel *operator() (Amr&            papa,
-                                  int             lev,
-                                  const Geometry& level_geom,
-                                  const BoxArray& ba,
-                                  const DistributionMapping& dm,
-                                  Real            time) override;
+    void variableSetUp () override;
+    void variableCleanUp () override;
+    AmrLevel *operator() () override;
+    AmrLevel *operator() (Amr&            papa,
+                          int             lev,
+                          const Geometry& level_geom,
+                          const BoxArray& ba,
+                          const DistributionMapping& dm,
+                          Real            time) override;
 };
 
 CNSBld CNS_bld;

--- a/Tests/EB/CNS/Source/CNS_advance.cpp
+++ b/Tests/EB/CNS/Source/CNS_advance.cpp
@@ -54,7 +54,7 @@ CNS::advance (Real time, Real dt, int /*iteration*/, int /*ncycle*/)
     // S_new = 0.5*(Sborder+S_old) = U^n + 0.5*dt*dUdt^n
     MultiFab::LinComb(S_new, 0.5, Sborder, 0, 0.5, S_old, 0, 0, NUM_STATE, 0);
     // S_new += 0.5*dt*dSdt
-    MultiFab::Saxpy(S_new, 0.5*dt, dSdt, 0, 0, NUM_STATE, 0);
+    MultiFab::Saxpy(S_new, 0.5*dt, dSdt, 0, 0, NUM_STATE, 0); // NOLINT(readability-suspicious-call-argument)
     // We now have S_new = U^{n+1} = (U^n+0.5*dt*dUdt^n) + 0.5*dt*dUdt^*
     computeTemp(S_new,0);
 

--- a/Tests/EB/CNS/Source/CNS_init_eb2.cpp
+++ b/Tests/EB/CNS/Source/CNS_init_eb2.cpp
@@ -10,8 +10,8 @@
 using namespace amrex;
 
 void
-initialize_EB2 (const Geometry& geom, const int /*required_coarsening_level*/,
-                const int max_coarsening_level)
+initialize_EB2 (const Geometry& geom, int /*required_coarsening_level*/,
+                int max_coarsening_level)
 {
     BL_PROFILE("initializeEB2");
 

--- a/Tests/EB/CNS/Source/main.cpp
+++ b/Tests/EB/CNS/Source/main.cpp
@@ -10,7 +10,7 @@
 using namespace amrex;
 
 amrex::LevelBld* getLevelBld ();
-void initialize_EB2 (const Geometry& geom, const int required_level, const int max_level);
+void initialize_EB2 (const Geometry& geom, int required_level, int max_level);
 
 int main (int argc, char* argv[])
 {

--- a/Tests/LinearSolvers/ABecLap_SP/MyTestPlotfile.cpp
+++ b/Tests/LinearSolvers/ABecLap_SP/MyTestPlotfile.cpp
@@ -60,7 +60,7 @@ MyTest::writePlotfile () const
                 MultiFab::Copy(plotmf[ilev], acoef[ilev], 0, 4, 1, 0);
                 MultiFab::Copy(plotmf[ilev], bcoef[ilev], 0, 5, 1, 0);
             }
-            auto dx = geom[ilev].CellSize();
+            const auto* dx = geom[ilev].CellSize();
             Real dvol = AMREX_D_TERM(dx[0],*dx[1],*dx[2]);
             amrex::Print() << "Level " << ilev
                            << " max-norm error: " << plotmf[ilev].norminf(3)
@@ -72,4 +72,3 @@ MyTest::writePlotfile () const
                                 Vector<IntVect>(nlevels, IntVect{ref_ratio}));
     }
 }
-

--- a/Tests/LinearSolvers/NodalPoisson/MyTestPlotfile.cpp
+++ b/Tests/LinearSolvers/NodalPoisson/MyTestPlotfile.cpp
@@ -14,7 +14,7 @@ MyTest::writePlotfile () const
     } else {
         varname = Vector<std::string>{"solution", "rhs", "exact_solution", "error"};
     }
-    int ncomp = varname.size();
+    auto ncomp = int(varname.size());
 
     const int nlevels = max_level+1;
 
@@ -38,4 +38,3 @@ MyTest::writePlotfile () const
                             varname, geom, 0.0, Vector<int>(nlevels, 0),
                             Vector<IntVect>(nlevels, IntVect{ref_ratio}));
 }
-

--- a/Tests/LinearSolvers/NodeTensorLap/CMakeLists.txt
+++ b/Tests/LinearSolvers/NodeTensorLap/CMakeLists.txt
@@ -1,4 +1,4 @@
-if (NOT AMReX_CUDA)
+if (NOT AMReX_CUDA AND NOT AMReX_SPACEDIM EQUAL 1)
 set(_sources main.cpp MyTest.cpp MyTest.H MyTestPlotfile.cpp)
 set(_input_files)
 

--- a/Tests/MultiBlock/Advection/main.cpp
+++ b/Tests/MultiBlock/Advection/main.cpp
@@ -74,7 +74,7 @@ class AdvectionAmrCore : public AmrCore {
         // Perform first order accurate upwinding with velocity 1 in the stored direction.
         const double dx = Geom(0).CellSize(0);
         const double a_dt_over_dx = dt / dx * (velocity == dir);
-        if (dir == Direction::x) {
+        if (dir == Direction::x) { // NOLINT(bugprone-branch-clone)
 #ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
@@ -168,13 +168,13 @@ struct OnesidedMultiBlockBoundaryFn {
 
   void FillBoundary_do_local_copy() const {
     AMREX_ASSERT(cmd && cached_dest_bd_key == dest->mass.getBDKey() && cached_src_bd_key == src->mass.getBDKey());
-    if (cmd->m_LocTags && cmd->m_LocTags->size() > 0) {
+    if (cmd->m_LocTags && !cmd->m_LocTags->empty()) {
         LocalCopy(packing, dest->mass, src->mass, *cmd->m_LocTags);
     }
   }
 
   void FillBoundary_finish(CommHandler handler) const {
-    ParallelCopy_finish(dest->mass, std::move(handler), *cmd, packing);
+    ParallelCopy_finish(dest->mass, std::move(handler), *cmd, packing); // NOLINT(performance-move-const-arg)
   }
 };
 
@@ -194,7 +194,7 @@ struct FillBoundaryFn {
         }
         const std::size_t n_boundaries = boundaries.size();
         for (std::size_t i = 0; i < n_boundaries; ++i) {
-            boundaries[i].FillBoundary_finish(std::move(comms[i]));
+            boundaries[i].FillBoundary_finish(std::move(comms[i])); // NOLINT(performance-move-const-arg)
         }
         AMREX_ASSERT(!core_x.mass.contains_nan());
     }

--- a/Tests/MultiBlock/IndexType/main.cpp
+++ b/Tests/MultiBlock/IndexType/main.cpp
@@ -72,7 +72,7 @@ int GetFaceDir(amrex::IndexType iv)
     static_assert(sizeof(amrex::IndexType) == sizeof(unsigned int), "IndexType is not punnable to unsigned int");
     unsigned int value{0};
     std::memcpy(&value, &iv, sizeof(unsigned int));
-    return ((value & 0b001) + (value & 0b010) + (value & 0b100)) >> 1;
+    return int(((value & 0b001) + (value & 0b010) + (value & 0b100)) >> 1);
 }
 
 amrex::Box GetFaceBoundary(const amrex::Box& domain, amrex::Orientation::Side side)

--- a/Tests/Parser/main.cpp
+++ b/Tests/Parser/main.cpp
@@ -370,7 +370,7 @@ int main (int argc, char* argv[])
         int count = 0;
         int x = 11;
         {
-            auto f = [&] (std::string s) -> int
+            auto f = [&] (std::string const& s) -> int
             {
                 amrex::Print() << count++ << ". Testing \"" << s << "\"\n";
                 IParser iparser(s);
@@ -387,7 +387,7 @@ int main (int argc, char* argv[])
             AMREX_ALWAYS_ASSERT(f("x/13/5") == ((x/13)/5));
             AMREX_ALWAYS_ASSERT(f("13/x/5") == ((13/x)/5));
 
-            auto g = [&] (std::string s, std::string c, int cv) -> int
+            auto g = [&] (std::string const& s, std::string const& c, int cv) -> int
             {
                 amrex::Print() << count++ << ". Testing \"" << s << "\"\n";
                 IParser iparser(s);
@@ -405,7 +405,7 @@ int main (int argc, char* argv[])
             AMREX_ALWAYS_ASSERT(g("x/b/5", "b", 13) == ((x/13)/5));
             AMREX_ALWAYS_ASSERT(g("b/x/5", "b", 13) == ((13/x)/5));
 
-            auto h = [&] (std::string s) -> int
+            auto h = [&] (std::string const& s) -> int
             {
                 amrex::Print() << count++ << ". Testing \"" << s << "\"\n";
                 IParser iparser(s);

--- a/Tests/Particles/AssignDensity/main.cpp
+++ b/Tests/Particles/AssignDensity/main.cpp
@@ -31,9 +31,7 @@ void test_assign_density(TestParams& parms)
   const Box domain(domain_lo, domain_hi);
 
   // This sets the boundary conditions to be doubly or triply periodic
-  int is_per[BL_SPACEDIM];
-  for (int i = 0; i < BL_SPACEDIM; i++)
-    is_per[i] = 1;
+  int is_per[] = {AMREX_D_DECL(1,1,1)};
   Geometry geom(domain, &real_box, CoordSys::cartesian, is_per);
 
   BoxArray ba(domain);

--- a/Tests/Particles/AssignMultiLevelDensity/main.cpp
+++ b/Tests/Particles/AssignMultiLevelDensity/main.cpp
@@ -46,9 +46,7 @@ void test_assign_density(TestParams& parms)
         rr[lev-1] = 2;
 
     // This sets the boundary conditions to be doubly or triply periodic
-    int is_per[BL_SPACEDIM];
-    for (int i = 0; i < BL_SPACEDIM; i++)
-        is_per[i] = 1;
+    int is_per[] = {AMREX_D_DECL(1,1,1)};
 
     // This defines a Geometry object which is useful for writing the plotfiles
     Vector<Geometry> geom(nlevs);

--- a/Tests/Particles/AsyncIO/main.cpp
+++ b/Tests/Particles/AsyncIO/main.cpp
@@ -101,18 +101,18 @@ public:
                     p.pos(2) = static_cast<ParticleReal> (plo[2] + (iv[2] + r[2])*dx[2]);
 #endif
 
-                    for (int i = 0; i < NSR; ++i) p.rdata(i) = p.id();
+                    for (int i = 0; i < NSR; ++i) p.rdata(i) = ParticleReal(p.id());
                     for (int i = 0; i < NSI; ++i) p.idata(i) = p.id();
 
                     host_particles.push_back(p);
                     for (int i = 0; i < NAR; ++i)
-                        host_real[i].push_back(p.id());
+                        host_real[i].push_back(ParticleReal(p.id()));
                     for (int i = 0; i < NAI; ++i)
-                        host_int[i].push_back(p.id());
+                        host_int[i].push_back(int(p.id()));
                     for (int i = 0; i < NumRuntimeRealComps(); ++i)
-                        host_runtime_real[i].push_back(p.id());
+                        host_runtime_real[i].push_back(ParticleReal(p.id()));
                     for (int i = 0; i < NumRuntimeIntComps(); ++i)
-                        host_runtime_int[i].push_back(p.id());
+                        host_runtime_int[i].push_back(int(p.id()));
                 }
             }
 
@@ -192,9 +192,7 @@ void test_async_io(TestParams& parms)
         rr[lev-1] = IntVect(AMREX_D_DECL(2, 2, 2));
 
     // This sets the boundary conditions to be doubly or triply periodic
-    int is_per[BL_SPACEDIM];
-    for (int i = 0; i < BL_SPACEDIM; i++)
-        is_per[i] = 1;
+    int is_per[] = {AMREX_D_DECL(1,1,1)};
 
     // This defines a Geometry object which is useful for writing the plotfiles
     Vector<Geometry> geom(nlevs);

--- a/Tests/Particles/CheckpointRestart/main.cpp
+++ b/Tests/Particles/CheckpointRestart/main.cpp
@@ -24,7 +24,7 @@ void test ()
     const int nghost = 0;
     int ncells, max_grid_size, ncomp, nlevs, nppc;
     int restart_check = 0, nplotfile = 1, nparticlefile = 1;
-    std::string directory = "";
+    std::string directory;
 
     ParmParse pp;
     pp.get("ncells", ncells);
@@ -37,7 +37,7 @@ void test ()
     pp.query("restart_check", restart_check);
     pp.query("directory", directory);
 
-    if (directory != "" && directory.back() != '/') {
+    if (!directory.empty() && directory.back() != '/') {
         // Include separator if one was not provided
         directory += "/";
     }
@@ -55,9 +55,7 @@ void test ()
     }
 
     // This sets the boundary conditions to be doubly or triply periodic
-    int is_per[AMREX_SPACEDIM];
-    for (int i = 0; i < AMREX_SPACEDIM; i++)
-        is_per[i] = 1;
+    int is_per[] = {AMREX_D_DECL(1,1,1)};
 
     // This defines a Geometry object for each level
     Vector<Geometry> geom(nlevs);

--- a/Tests/Particles/DenseBins/main.cpp
+++ b/Tests/Particles/DenseBins/main.cpp
@@ -9,9 +9,9 @@ using namespace amrex;
 void checkAnswer (const amrex::DenseBins<int>& bins)
 {
     BL_PROFILE("checkAnswer");
-    const auto perm = bins.permutationPtr();
-    const auto bins_ptr = bins.binsPtr();
-    const auto offsets = bins.offsetsPtr();
+    const auto* const perm = bins.permutationPtr();
+    const auto* const bins_ptr = bins.binsPtr();
+    const auto* const offsets = bins.offsetsPtr();
 
 #ifdef AMREX_USE_GPU
     amrex::ParallelFor(bins.numItems(), [=] AMREX_GPU_DEVICE (int i) noexcept
@@ -89,12 +89,12 @@ void initData (int nbins, amrex::Vector<int>& items)
 {
     BL_PROFILE("init");
 
-    const int nitems = items.size();
+    const auto nitems = int(items.size());
 
 #ifdef AMREX_USE_OMP
 #pragma omp parallel for
 #endif
-    for (int i = 0; i < nitems; ++i) { items[i] = amrex::Random_int(nbins); }
+    for (int i = 0; i < nitems; ++i) { items[i] = int(amrex::Random_int(nbins)); }
 }
 
 void testDenseBins ()

--- a/Tests/Particles/InitFromAscii/main.cpp
+++ b/Tests/Particles/InitFromAscii/main.cpp
@@ -30,9 +30,7 @@ void test_init_ascii (TestParams& parms)
     const Box domain(domain_lo, domain_hi);
 
     // This sets the boundary conditions to be doubly or triply periodic
-    int is_per[AMREX_SPACEDIM];
-    for (int i = 0; i < AMREX_SPACEDIM; i++)
-        is_per[i] = 1;
+    int is_per[] = {AMREX_D_DECL(1,1,1)};
     Geometry geom(domain, &real_box, CoordSys::cartesian, is_per);
 
     BoxArray ba(domain);

--- a/Tests/Particles/Intersection/main.cpp
+++ b/Tests/Particles/Intersection/main.cpp
@@ -27,9 +27,9 @@ void testIntersection()
     TestParams params;
     get_test_params(params, "intersect");
 
-    int is_per[BL_SPACEDIM];
-    for (int i = 0; i < BL_SPACEDIM; i++)
-        is_per[i] = params.is_periodic;
+    int is_per[] = {AMREX_D_DECL(params.is_periodic,
+                                 params.is_periodic,
+                                 params.is_periodic)};
 
     Vector<IntVect> rr(params.nlevs-1);
     for (int lev = 1; lev < params.nlevs; lev++)
@@ -54,7 +54,7 @@ void testIntersection()
     }
 
     Vector<BoxArray> ba(params.nlevs);
-    IntVect lo = IntVect(AMREX_D_DECL(0, 0, 0));
+    IntVect lo(0);
     IntVect size = params.size;
     for (int lev = 0; lev < params.nlevs; ++lev)
     {
@@ -80,15 +80,15 @@ void testIntersection()
             for (IntVect iv = box.smallEnd(); iv <= box.bigEnd(); box.next(iv)) host_cells.push_back(iv);
             //host_cells.push_back(box.smallEnd());
 
-            int num_cells = host_cells.size();
+            auto const num_cells = int(host_cells.size());
 
             Gpu::DeviceVector<IntVect> device_cells(num_cells);
             Gpu::copyAsync(Gpu::hostToDevice, host_cells.begin(), host_cells.end(), device_cells.begin());
 
             Gpu::DeviceVector<int> device_grids(num_cells);
 
-            const auto cells_ptr = device_cells.dataPtr();
-            const auto grids_ptr = device_grids.dataPtr();
+            auto* const cells_ptr = device_cells.dataPtr();
+            auto* const grids_ptr = device_grids.dataPtr();
             amrex::ParallelFor(num_cells, [=] AMREX_GPU_DEVICE (int j) noexcept
             {
                 grids_ptr[j] = assign_grid(cells_ptr[j]);

--- a/Tests/Particles/NeighborList/main.cpp
+++ b/Tests/Particles/NeighborList/main.cpp
@@ -107,9 +107,9 @@ void testNeighborList ()
     const Box domain(domain_lo, domain_hi);
 
     int coord = 0;
-    int is_per[BL_SPACEDIM];
-    for (int i = 0; i < BL_SPACEDIM; i++)
-        is_per[i] = params.is_periodic;
+    int is_per[] = {AMREX_D_DECL(params.is_periodic,
+                                 params.is_periodic,
+                                 params.is_periodic)};
     Geometry geom(domain, &real_box, coord, is_per);
 
     BoxArray ba(domain);

--- a/Tests/Particles/NeighborParticles/MDParticleContainer.H
+++ b/Tests/Particles/NeighborParticles/MDParticleContainer.H
@@ -38,10 +38,10 @@ public:
     }
 
     void InitParticles (const amrex::IntVect& a_num_particles_per_cell,
-                        const amrex::Real     a_thermal_momentum_std,
-                        const amrex::Real     a_thermal_momentum_mean);
+                        amrex::Real           a_thermal_momentum_std,
+                        amrex::Real           a_thermal_momentum_mean);
 
-    void writeParticles (const int n);
+    void writeParticles (int n);
 
     void reset_test_id ();
 

--- a/Tests/Particles/NeighborParticles/MDParticleContainer.cpp
+++ b/Tests/Particles/NeighborParticles/MDParticleContainer.cpp
@@ -45,8 +45,8 @@ namespace
 void
 MDParticleContainer::
 InitParticles(const IntVect& a_num_particles_per_cell,
-              const Real     a_thermal_momentum_std,
-              const Real     a_thermal_momentum_mean)
+              Real           a_thermal_momentum_std,
+              Real           a_thermal_momentum_mean)
 {
     BL_PROFILE("MDParticleContainer::InitParticles");
 
@@ -78,9 +78,9 @@ InitParticles(const IntVect& a_num_particles_per_cell,
                 get_gaussian_random_momentum(v, a_thermal_momentum_mean,
                                              a_thermal_momentum_std);
 
-                AMREX_D_TERM(ParticleReal x = static_cast<ParticleReal> (plo[0] + (iv[0] + r[0])*dx[0]);,
-                             ParticleReal y = static_cast<ParticleReal> (plo[1] + (iv[1] + r[1])*dx[1]);,
-                             ParticleReal z = static_cast<ParticleReal> (plo[2] + (iv[2] + r[2])*dx[2]);)
+                AMREX_D_TERM(auto x = static_cast<ParticleReal> (plo[0] + (iv[0] + r[0])*dx[0]);,
+                             auto y = static_cast<ParticleReal> (plo[1] + (iv[1] + r[1])*dx[1]);,
+                             auto z = static_cast<ParticleReal> (plo[2] + (iv[2] + r[2])*dx[2]);)
 
                 ParticleType p;
                 p.id()  = ParticleType::NextID();
@@ -101,7 +101,7 @@ InitParticles(const IntVect& a_num_particles_per_cell,
 
                 host_particles.push_back(p);
                 for (int i = 0; i < NumRealComps(); ++i)
-                    host_real[i].push_back(mfi.index());
+                    host_real[i].push_back(ParticleReal(mfi.index()));
                 for (int i = 0; i < NumIntComps(); ++i)
                     host_int[i].push_back(mfi.index());
             }
@@ -227,7 +227,7 @@ void MDParticleContainer::moveParticles(amrex::ParticleReal dx)
     }
 }
 
-void MDParticleContainer::writeParticles(const int n)
+void MDParticleContainer::writeParticles(int n)
 {
     BL_PROFILE("MDParticleContainer::writeParticles");
     const std::string& pltfile = amrex::Concatenate("particles", n, 5);
@@ -241,7 +241,7 @@ void MDParticleContainer::checkNeighborParticles()
     const int lev = 0;
     auto& plev  = GetParticles(lev);
 
-    int ngrids = ParticleBoxArray(0).size();
+    auto ngrids = int(ParticleBoxArray(0).size());
 
     amrex::Gpu::DeviceVector<int> d_num_per_grid(ngrids,0);
     amrex::Gpu::HostVector<int> h_num_per_grid(ngrids);
@@ -261,8 +261,8 @@ void MDParticleContainer::checkNeighborParticles()
         const int np = aos.numTotalParticles();
 
         ParticleType* pstruct = aos().dataPtr();
-        auto rdata = soa.GetRealData(0).dataPtr();
-        auto idata = soa.GetIntData(0).dataPtr();
+        auto* rdata = soa.GetRealData(0).dataPtr();
+        auto* idata = soa.GetIntData(0).dataPtr();
 
         int* p_num_per_grid = d_num_per_grid.data();
         amrex::ParallelFor( np, [=] AMREX_GPU_DEVICE (int i) noexcept
@@ -389,8 +389,8 @@ void MDParticleContainer::reset_test_id()
         const size_t np = aos.numTotalParticles();
 
         ParticleType* pstruct = aos().dataPtr();
-        auto rdata = soa.GetRealData(0).dataPtr();
-        auto idata = soa.GetIntData(0).dataPtr();
+        auto* rdata = soa.GetRealData(0).dataPtr();
+        auto* idata = soa.GetIntData(0).dataPtr();
 
         AMREX_FOR_1D ( np, i,
         {

--- a/Tests/Particles/NeighborParticles/main.cpp
+++ b/Tests/Particles/NeighborParticles/main.cpp
@@ -71,9 +71,9 @@ void testNeighborParticles ()
     const Box domain(domain_lo, domain_hi);
 
     int coord = 0;
-    int is_per[BL_SPACEDIM];
-    for (int i = 0; i < BL_SPACEDIM; i++)
-        is_per[i] = params.is_periodic;
+    int is_per[] = {AMREX_D_DECL(params.is_periodic,
+                                 params.is_periodic,
+                                 params.is_periodic)};
     Geometry geom(domain, &real_box, coord, is_per);
 
     BoxArray ba(domain);
@@ -83,8 +83,7 @@ void testNeighborParticles ()
     const int ncells = 1;
     MDParticleContainer pc(geom, dm, ba, ncells);
 
-    int npc = params.num_ppc;
-    IntVect nppc = IntVect(AMREX_D_DECL(npc, npc, npc));
+    IntVect nppc(params.num_ppc);
 
     if (ParallelDescriptor::MyProc() == dm[0])
         amrex::PrintToFile("neighbor_test") << "About to initialize particles \n";
@@ -169,9 +168,9 @@ void testNeighborList ()
     const Box domain(domain_lo, domain_hi);
 
     int coord = 0;
-    int is_per[BL_SPACEDIM];
-    for (int i = 0; i < BL_SPACEDIM; i++)
-        is_per[i] = params.is_periodic;
+    int is_per[] = {AMREX_D_DECL(params.is_periodic,
+                                 params.is_periodic,
+                                 params.is_periodic)};
     Geometry geom(domain, &real_box, coord, is_per);
 
     BoxArray ba(domain);
@@ -181,8 +180,7 @@ void testNeighborList ()
     const int ncells = 1;
     MDParticleContainer pc(geom, dm, ba, ncells);
 
-    int npc = params.num_ppc;
-    IntVect nppc = IntVect(AMREX_D_DECL(npc, npc, npc));
+    IntVect nppc(params.num_ppc);
 
     amrex::PrintToFile("neighbor_test") << "About to initialize particles" << std::endl;
 

--- a/Tests/Particles/ParallelContext/main.cpp
+++ b/Tests/Particles/ParallelContext/main.cpp
@@ -106,18 +106,18 @@ public:
                     p.pos(2) = static_cast<ParticleReal> (plo[2] + (iv[2] + r[2])*dx[2]);
 #endif
 
-                    for (int i = 0; i < NSR; ++i) p.rdata(i) = p.id();
-                    for (int i = 0; i < NSI; ++i) p.idata(i) = p.id();
+                    for (int i = 0; i < NSR; ++i) p.rdata(i) = ParticleReal(p.id());
+                    for (int i = 0; i < NSI; ++i) p.idata(i) = int(p.id());
 
                     host_particles.push_back(p);
                     for (int i = 0; i < NAR; ++i)
-                        host_real[i].push_back(p.id());
+                        host_real[i].push_back(ParticleReal(p.id()));
                     for (int i = 0; i < NAI; ++i)
-                        host_int[i].push_back(p.id());
+                        host_int[i].push_back(int(p.id()));
                     for (int i = 0; i < NumRuntimeRealComps(); ++i)
-                        host_runtime_real[i].push_back(p.id());
+                        host_runtime_real[i].push_back(ParticleReal(p.id()));
                     for (int i = 0; i < NumRuntimeIntComps(); ++i)
-                        host_runtime_int[i].push_back(p.id());
+                        host_runtime_int[i].push_back(int(p.id()));
                 }
             }
 
@@ -233,13 +233,13 @@ public:
 
         for (int lev = 0; lev <= finestLevel(); ++lev)
         {
-            auto& plev  = GetParticles(lev);
+            const auto& plev  = GetParticles(lev);
 
             for(MFIter mfi = MakeMFIter(lev); mfi.isValid(); ++mfi)
             {
                 int gid = mfi.index();
                 int tid = mfi.LocalTileIndex();
-                auto& ptile = plev.at(std::make_pair(gid, tid));
+                const auto& ptile = plev.at(std::make_pair(gid, tid));
                 const auto ptd = ptile.getConstParticleTileData();
                 const size_t np = ptile.numParticles();
 
@@ -344,9 +344,9 @@ void testParallelContext ()
         TestParams params;
         get_test_params(params, "redistribute");
 
-        int is_per[BL_SPACEDIM];
-        for (int i = 0; i < BL_SPACEDIM; i++)
-            is_per[i] = params.is_periodic;
+        int is_per[] = {AMREX_D_DECL(params.is_periodic,
+                                     params.is_periodic,
+                                     params.is_periodic)};
 
         // Each comm gets a different domain
         IntVect hs = params.size / 2;
@@ -382,8 +382,7 @@ void testParallelContext ()
         {
             TestParticleContainer pc(geom, dm, ba);
 
-            int npc = params.num_ppc;
-            IntVect nppc = IntVect(AMREX_D_DECL(npc, npc, npc));
+            IntVect nppc(params.num_ppc);
 
             pc.InitParticles(nppc);
 
@@ -406,8 +405,7 @@ void testParallelContext ()
         {
             TestParticleContainer pc(geom, dm, ba);
 
-            int npc = params.num_ppc;
-            IntVect nppc = IntVect(AMREX_D_DECL(npc, npc, npc));
+            IntVect nppc(params.num_ppc);
 
             pc.InitParticles(nppc);
 

--- a/Tests/Particles/ParticleIterator/main.cpp
+++ b/Tests/Particles/ParticleIterator/main.cpp
@@ -34,8 +34,7 @@ int main(int argc, char* argv[])
   for (int lev = 1; lev < nlevs; lev++)
     rr[lev-1] = 2;
 
-  int is_per[BL_SPACEDIM];
-  for (int i = 0; i < BL_SPACEDIM; i++) is_per[i] = 1;
+  int is_per[] = {AMREX_D_DECL(1,1,1)};
 
   Vector<Geometry> geom(nlevs);
   geom[0].define(domain, &real_box, coord, is_per);
@@ -55,7 +54,7 @@ int main(int argc, char* argv[])
 
   MyParticleContainer::ParticleInitData pdata = {{1.0},{},{},{}};
   MyPC.InitOnePerCell(0.5, 0.5, 0.5, pdata);
-  MyPC.do_tiling = true;
+  MyParticleContainer::do_tiling = true;
 
   amrex::AllPrintToFile("outside") << "outside parallel region. \n";
 

--- a/Tests/Particles/ParticleMesh/main.cpp
+++ b/Tests/Particles/ParticleMesh/main.cpp
@@ -33,9 +33,7 @@ void testParticleMesh (TestParams& parms)
   const Box domain(domain_lo, domain_hi);
 
   // This sets the boundary conditions to be doubly or triply periodic
-  int is_per[AMREX_SPACEDIM];
-  for (int i = 0; i < AMREX_SPACEDIM; i++)
-    is_per[i] = 1;
+  int is_per[] = {AMREX_D_DECL(1,1,1)};
   Geometry geom(domain, &real_box, CoordSys::cartesian, is_per);
 
   BoxArray ba(domain);
@@ -109,7 +107,7 @@ void testParticleMesh (TestParams& parms)
                   [=] AMREX_GPU_DEVICE (MyParticleContainer::ParticleType& part,
                                         int comp, amrex::Real val)
                   {
-                      part.rdata(comp) += val;
+                      part.rdata(comp) += ParticleReal(val);
                   });
       });
 

--- a/Tests/Particles/ParticleMeshMultiLevel/main.cpp
+++ b/Tests/Particles/ParticleMeshMultiLevel/main.cpp
@@ -39,9 +39,7 @@ void testParticleMesh (TestParams& parms)
     const Box base_domain(domain_lo, domain_hi);
 
     // This sets the boundary conditions to be doubly or triply periodic
-    int is_per[BL_SPACEDIM];
-    for (int i = 0; i < BL_SPACEDIM; i++)
-        is_per[i] = 1;
+    int is_per[] = {AMREX_D_DECL(1,1,1)};
 
     Vector<Geometry> geom(parms.nlevs);
     geom[0].define(base_domain, &real_box, CoordSys::cartesian, is_per);
@@ -54,7 +52,7 @@ void testParticleMesh (TestParams& parms)
     Vector<DistributionMapping> dm(parms.nlevs);
 
     Box domain = base_domain;
-    IntVect size = IntVect(AMREX_D_DECL(parms.nx, parms.ny, parms.nz));
+    IntVect size(AMREX_D_DECL(parms.nx, parms.ny, parms.nz));
     for (int lev = 0; lev < parms.nlevs; ++lev)
     {
         ba[lev].define(domain);

--- a/Tests/Particles/ParticleReduce/main.cpp
+++ b/Tests/Particles/ParticleReduce/main.cpp
@@ -71,9 +71,9 @@ public:
                     Real r[AMREX_SPACEDIM];
                     get_position_unit_cell(r, a_num_particles_per_cell, i_part);
 
-                    AMREX_D_TERM(ParticleReal x = static_cast<ParticleReal> (plo[0] + (iv[0] + r[0])*dx[0]);,
-                                 ParticleReal y = static_cast<ParticleReal> (plo[1] + (iv[1] + r[1])*dx[1]);,
-                                 ParticleReal z = static_cast<ParticleReal> (plo[2] + (iv[2] + r[2])*dx[2]);)
+                    AMREX_D_TERM(auto x = static_cast<ParticleReal> (plo[0] + (iv[0] + r[0])*dx[0]);,
+                                 auto y = static_cast<ParticleReal> (plo[1] + (iv[1] + r[1])*dx[1]);,
+                                 auto z = static_cast<ParticleReal> (plo[2] + (iv[2] + r[2])*dx[2]);)
 
                     ParticleType p;
                     p.id()  = ParticleType::NextID();
@@ -82,12 +82,12 @@ public:
                                  p.pos(1) = y;,
                                  p.pos(2) = z;)
 
-                    for (int i = 0; i < NSR; ++i) p.rdata(i) = i;
+                    for (int i = 0; i < NSR; ++i) p.rdata(i) = ParticleReal(i);
                     for (int i = 0; i < NSI; ++i) p.idata(i) = i;
 
                     host_particles.push_back(p);
                     for (int i = 0; i < NAR; ++i)
-                        host_real[i].push_back(i);
+                        host_real[i].push_back(ParticleReal(i));
                     for (int i = 0; i < NAI; ++i)
                         host_int[i].push_back(i);
                 }
@@ -165,9 +165,7 @@ void testReduce ()
     const Box domain(domain_lo, domain_hi);
 
     int coord = 0;
-    int is_per[BL_SPACEDIM];
-    for (int i = 0; i < BL_SPACEDIM; i++)
-        is_per[i] = 1;
+    int is_per[] = {AMREX_D_DECL(1,1,1)};
     Geometry geom(domain, &real_box, coord, is_per);
 
     BoxArray ba(domain);
@@ -176,8 +174,7 @@ void testReduce ()
 
     TestParticleContainer pc(geom, dm, ba);
 
-    int npc = params.num_ppc;
-    IntVect nppc = IntVect(AMREX_D_DECL(npc, npc, npc));
+    IntVect nppc(params.num_ppc);
 
     if (ParallelDescriptor::MyProc() == dm[0])
         amrex::Print() << "About to initialize particles \n";

--- a/Tests/Particles/ParticleTransformations/main.cpp
+++ b/Tests/Particles/ParticleTransformations/main.cpp
@@ -72,9 +72,9 @@ public:
                     Real r[3];
                     get_position_unit_cell(r, a_num_particles_per_cell, i_part);
 
-                    AMREX_D_TERM(ParticleReal x = static_cast<ParticleReal> (plo[0] + (iv[0] + r[0])*dx[0]);,
-                                 ParticleReal y = static_cast<ParticleReal> (plo[1] + (iv[1] + r[1])*dx[1]);,
-                                 ParticleReal z = static_cast<ParticleReal> (plo[2] + (iv[2] + r[2])*dx[2]);)
+                    AMREX_D_TERM(auto x = static_cast<ParticleReal> (plo[0] + (iv[0] + r[0])*dx[0]);,
+                                 auto y = static_cast<ParticleReal> (plo[1] + (iv[1] + r[1])*dx[1]);,
+                                 auto z = static_cast<ParticleReal> (plo[2] + (iv[2] + r[2])*dx[2]);)
 
                     ParticleType p;
                     p.id()  = ParticleType::NextID();
@@ -83,12 +83,12 @@ public:
                                  p.pos(1) = y;,
                                  p.pos(2) = z;)
 
-                    for (int i = 0; i < NSR; ++i) p.rdata(i) = i;
+                    for (int i = 0; i < NSR; ++i) p.rdata(i) = ParticleReal(i);
                     for (int i = 0; i < NSI; ++i) p.idata(i) = i;
 
                     host_particles.push_back(p);
                     for (int i = 0; i < NAR; ++i)
-                        host_real[i].push_back(i);
+                        host_real[i].push_back(ParticleReal(i));
                     for (int i = 0; i < NAI; ++i)
                         host_int[i].push_back(i);
                 }
@@ -534,9 +534,7 @@ void testTransformations ()
     const Box domain(domain_lo, domain_hi);
 
     int coord = 0;
-    int is_per[BL_SPACEDIM];
-    for (int i = 0; i < BL_SPACEDIM; i++)
-        is_per[i] = 1;
+    int is_per[] = {AMREX_D_DECL(1,1,1)};
     Geometry geom(domain, &real_box, coord, is_per);
 
     BoxArray ba(domain);
@@ -545,8 +543,7 @@ void testTransformations ()
 
     TestParticleContainer pc(geom, dm, ba);
 
-    int npc = params.num_ppc;
-    IntVect nppc = IntVect(AMREX_D_DECL(npc, npc, npc));
+    IntVect nppc(params.num_ppc);
 
     if (ParallelDescriptor::MyProc() == dm[0])
         amrex::Print() << "About to initialize particles \n";

--- a/Tests/Particles/Redistribute/main.cpp
+++ b/Tests/Particles/Redistribute/main.cpp
@@ -118,18 +118,18 @@ public:
                     p.pos(2) = static_cast<ParticleReal> (plo[2] + (iv[2] + r[2])*dx[2]);
 #endif
 
-                    for (int i = 0; i < NSR; ++i) p.rdata(i) = p.id();
-                    for (int i = 0; i < NSI; ++i) p.idata(i) = p.id();
+                    for (int i = 0; i < NSR; ++i) p.rdata(i) = ParticleReal(p.id());
+                    for (int i = 0; i < NSI; ++i) p.idata(i) = int(p.id());
 
                     host_particles.push_back(p);
                     for (int i = 0; i < NAR; ++i)
-                        host_real[i].push_back(p.id());
+                        host_real[i].push_back(ParticleReal(p.id()));
                     for (int i = 0; i < NAI; ++i)
-                        host_int[i].push_back(p.id());
+                        host_int[i].push_back(int(p.id()));
                     for (int i = 0; i < NumRuntimeRealComps(); ++i)
-                        host_runtime_real[i].push_back(p.id());
+                        host_runtime_real[i].push_back(ParticleReal(p.id()));
                     for (int i = 0; i < NumRuntimeIntComps(); ++i)
-                        host_runtime_int[i].push_back(p.id());
+                        host_runtime_int[i].push_back(int(p.id()));
                 }
             }
 
@@ -270,12 +270,12 @@ public:
 
         for (int lev = 0; lev <= finestLevel(); ++lev)
         {
-            auto& plev  = GetParticles(lev);
+            const auto& plev  = GetParticles(lev);
             for(MFIter mfi = MakeMFIter(lev); mfi.isValid(); ++mfi)
             {
                 int gid = mfi.index();
                 int tid = mfi.LocalTileIndex();
-                auto& ptile = plev.at(std::make_pair(gid, tid));
+                const auto& ptile = plev.at(std::make_pair(gid, tid));
                 const auto ptd = ptile.getConstParticleTileData();
                 const size_t np = ptile.numParticles();
 
@@ -365,9 +365,9 @@ void testRedistribute ()
     TestParams params;
     get_test_params(params, "redistribute");
 
-    int is_per[BL_SPACEDIM];
-    for (int i = 0; i < BL_SPACEDIM; i++)
-        is_per[i] = params.is_periodic;
+    int is_per[] = {AMREX_D_DECL(params.is_periodic,
+                                 params.is_periodic,
+                                 params.is_periodic)};
 
     Vector<IntVect> rr(params.nlevs-1);
     for (int lev = 1; lev < params.nlevs; lev++)
@@ -393,7 +393,7 @@ void testRedistribute ()
 
     Vector<BoxArray> ba(params.nlevs);
     Vector<DistributionMapping> dm(params.nlevs);
-    IntVect lo = IntVect(AMREX_D_DECL(0, 0, 0));
+    IntVect lo(0);
     IntVect size = params.size;
     for (int lev = 0; lev < params.nlevs; ++lev)
     {
@@ -406,8 +406,7 @@ void testRedistribute ()
 
     TestParticleContainer pc(geom, dm, ba, rr);
 
-    int npc = params.num_ppc;
-    IntVect nppc = IntVect(AMREX_D_DECL(npc, npc, npc));
+    IntVect nppc(params.num_ppc);
 
     amrex::Print() << "About to initialize particles \n";
 

--- a/Tests/Particles/SparseBins/main.cpp
+++ b/Tests/Particles/SparseBins/main.cpp
@@ -27,9 +27,9 @@ void testIntersection()
     TestParams params;
     get_test_params(params, "intersect");
 
-    int is_per[BL_SPACEDIM];
-    for (int i = 0; i < BL_SPACEDIM; i++)
-        is_per[i] = params.is_periodic;
+    int is_per[] = {AMREX_D_DECL(params.is_periodic,
+                                 params.is_periodic,
+                                 params.is_periodic)};
 
     Vector<IntVect> rr(params.nlevs-1);
     for (int lev = 1; lev < params.nlevs; lev++)
@@ -54,7 +54,7 @@ void testIntersection()
     }
 
     Vector<BoxArray> ba(params.nlevs);
-    IntVect lo = IntVect(AMREX_D_DECL(0, 0, 0));
+    IntVect lo(0);
     IntVect size = params.size;
     for (int lev = 0; lev < params.nlevs; ++lev)
     {

--- a/Tools/C_scripts/mmclt.py
+++ b/Tools/C_scripts/mmclt.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+
+"""
+A script processing ccache log file to make Make file for Clang-Tidy
+
+This generates a makefile for clang-tidying ccache-cache-missing files. This
+could be used to speed up clang-tidy in CIs.
+"""
+
+import argparse, re, sys
+
+def mmclt(argv):
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--input",
+                        help="Ccache log file",
+                        default="ccache.log.txt")
+    parser.add_argument("--output",
+                        help="Make file for clang-tidy",
+                        default="clang-tidy-ccache-misses.mak")
+    args = parser.parse_args()
+
+    fin = open(args.input, "r")
+    fout = open(args.output, "w")
+
+    fout.write("CLANG_TIDY ?= clang-tidy\n")
+    fout.write("override CLANG_TIDY_ARGS += --extra-arg=-Wno-unknown-warning-option --extra-arg-before=--driver-mode=g++\n")
+    fout.write("\n")
+
+    fout.write(".SECONDEXPANSION:\n")
+    fout.write("clang-tidy: $$(all_targets)\n")
+    fout.write("\t@echo SUCCESS\n\n")
+
+    # We assume Src/Base can be used as an indentifier to distinguish amrex code
+    # from cmake's temporary files like build/CMakeFiles/CMakeScratch/TryCompile-hw3x4m/test_mpi.cpp
+    exe_re = re.compile(r" Executing .*? (-.*Src/Base.*) -c .* -o .* (\S*)")
+
+    count = 0
+    for line in fin.readlines():
+        ret_exe_re = exe_re.search(line)
+        if (ret_exe_re):
+            fout.write("target_{}: {}\n".format(count, ret_exe_re.group(2)))
+            fout.write("\t$(CLANG_TIDY) $(CLANG_TIDY_ARGS) $< -- {}\n".format
+                       (ret_exe_re.group(1)))
+            fout.write("\ttouch target_{}\n\n".format(count))
+            count = count + 1
+
+    fout.write("all_targets =")
+    for i in range(count):
+        fout.write(" target_{}".format(i))
+    fout.write("\n\n")
+
+    fout.write("clean:\n\t$(RM) $(all_targets)\n\n")
+
+    fout.close()
+    fin.close()
+
+if __name__ == "__main__":
+    mmclt(sys.argv)

--- a/Tools/GNUMake/Make.rules
+++ b/Tools/GNUMake/Make.rules
@@ -78,7 +78,7 @@ else
 ifeq ($(USE_CLANG_TIDY),TRUE)
 	$(SILENT) $(CLANG_TIDY) $(CLANG_TIDY_ARGS) $< -- $(CXXFLAGS) $(EXTRACXXFLAGS) $(CPPFLAGS) $(includes) $(mpicxx_include_dirs)
 endif
-	$(SILENT) $(CCACHE) $(CXX) $(DEPFLAGS) $(CXXFLAGS) $(EXTRACXXFLAGS) $(CPPFLAGS) $(includes) -c $< -o $(objEXETempDir)/$(subst /,_,$<).o
+	$(SILENT) $(CCACHE) $(CXX) $(DEPFLAGS) $(CXXFLAGS) $(EXTRACXXFLAGS) $(CPPFLAGS) $(includes) $(mpicxx_include_dirs) -c $< -o $(objEXETempDir)/$(subst /,_,$<).o
 	@echo "Linking $@ ..."
 	$(SILENT) $(AMREX_LINKER) $(LINKFLAGS) $(CPPFLAGS) $(includes) $(LDFLAGS) -o $@ $(objEXETempDir)/$(subst /,_,$<).o $(objForExecs) $(FINAL_LIBS)
 
@@ -258,7 +258,7 @@ endif
 ifeq ($(USE_CLANG_TIDY),TRUE)
 	$(SILENT) $(CLANG_TIDY) $(CLANG_TIDY_ARGS) $< -- $(CXXFLAGS) $(EXTRACXXFLAGS) $(CPPFLAGS) $(includes) $(mpicxx_include_dirs)
 endif
-	$(SILENT) $(CCACHE) $(CXX) $(DEPFLAGS) $(CXXFLAGS) $(EXTRACXXFLAGS) $(CPPFLAGS) $(includes) -c $< $(EXE_OUTPUT_OPTION)
+	$(SILENT) $(CCACHE) $(CXX) $(DEPFLAGS) $(CXXFLAGS) $(EXTRACXXFLAGS) $(CPPFLAGS) $(includes) $(mpicxx_include_dirs) -c $< $(EXE_OUTPUT_OPTION)
 ifeq ($(LOG_BUILD_TIME),TRUE)
 	@date +"%s" >> $(tmpEXETempDir)/$(notdir $<).log
 endif

--- a/Tools/Plotfile/fboxinfo.cpp
+++ b/Tools/Plotfile/fboxinfo.cpp
@@ -104,12 +104,12 @@ void main_main()
                 const Long nboxes = plotfile.boxArray(ilev).size();
                 const Long ncells = plotfile.boxArray(ilev).numPts();
                 const Box prob_domain = plotfile.probDomain(ilev);
-                const Real ncells_domain = prob_domain.d_numPts();
+                const auto ncells_domain = prob_domain.d_numPts();
                 amrex::Print() << " level " << std::setw(3) << ilev
                                << ": number of boxes = " << std::setw(6) << nboxes
                                << ", volume = "
                                << std::fixed << std::setw(6) << std::setprecision(2)
-                               << Real(100.)*static_cast<Real>(ncells)/ncells_domain << "%\n";
+                               << 100.*static_cast<double>(ncells)/ncells_domain << "%\n";
                 if (dim == 1) {
                     amrex::Print() << "          maximum zones =   "
                                    << std::setw(7) << prob_domain.length(0) << "\n";

--- a/Tools/Plotfile/fcompare.cpp
+++ b/Tools/Plotfile/fcompare.cpp
@@ -82,9 +82,9 @@ int main_main()
         } else if (fname == "-a" || fname == "--allow_diff_grids") {
             allow_diff_grids = true;
         } else if (fname == "-r" || fname == "--rel_tol") {
-            rtol = std::stod(amrex::get_command_argument(++farg));
+            rtol = Real(std::stod(amrex::get_command_argument(++farg)));
         } else if (fname == "--abs_tol") {
-            atol = std::stod(amrex::get_command_argument(++farg));
+            atol = Real(std::stod(amrex::get_command_argument(++farg)));
         } else if (fname == "--abort_if_not_all_found") {
             abort_if_not_all_found = true;
         } else {
@@ -248,7 +248,7 @@ int main_main()
                     for (int idim = 0; idim < dm; ++idim) {
                         dv *= dx[idim];
                     }
-                    aerror[icomp_a] *= std::pow(dv,1./static_cast<Real>(norm));
+                    aerror[icomp_a] *= std::pow(dv,Real(1.)/static_cast<Real>(norm));
                     rerror[icomp_a] = rerror[icomp_a]/rerror_denom[icomp_a];
                 }
 

--- a/Tools/Plotfile/fextract.cpp
+++ b/Tools/Plotfile/fextract.cpp
@@ -39,11 +39,11 @@ void main_main()
         } else if (name == "-v" || name == "--variable") {
             varnames_arg = amrex::get_command_argument(++farg);
         } else if (name == "-x") {
-            xcoord = std::stod(amrex::get_command_argument(++farg));
+            xcoord = Real(std::stod(amrex::get_command_argument(++farg)));
         } else if (name == "-y") {
-            ycoord = std::stod(amrex::get_command_argument(++farg));
+            ycoord = Real(std::stod(amrex::get_command_argument(++farg)));
         } else if (name == "-z") {
-            zcoord = std::stod(amrex::get_command_argument(++farg));
+            zcoord = Real(std::stod(amrex::get_command_argument(++farg)));
         } else if (name == "-l" || name == "--lower_left") {
             center = false;
         } else if (name == "-c" || name == "--coarse_level") {
@@ -57,7 +57,7 @@ void main_main()
         } else if (name == "-p" || name == "--precision") {
             precision = std::stoi(amrex::get_command_argument(++farg));
         } else if (name == "-t" || name == "--tolerance") {
-            tolerance = std::stod(amrex::get_command_argument(++farg));
+            tolerance = Real(std::stod(amrex::get_command_argument(++farg)));
         } else if (name == "-i" || name == "--info") {
             print_info = true;
         } else {
@@ -152,7 +152,7 @@ void main_main()
         // we specified the x value to pass through
         iloc = hi0.x;
         for (int i = lo0.x; i <= hi0.x; ++i) {
-            amrex::Real xc = problo[0] + (i+0.5)*dx0[0];
+            amrex::Real xc = problo[0] + (Real(i)+Real(0.5))*dx0[0];
             if (xc > xcoord) {
                 iloc = i;
                 break;
@@ -164,7 +164,7 @@ void main_main()
         // we specified the y value to pass through
         jloc = hi0.y;
         for (int j = lo0.y; j <= hi0.y; ++j) {
-            amrex::Real yc = problo[1] + (j+0.5)*dx0[1];
+            amrex::Real yc = problo[1] + (Real(j)+Real(0.5))*dx0[1];
             if (yc > ycoord) {
                 jloc = j;
                 break;
@@ -176,7 +176,7 @@ void main_main()
         // we specified the z value to pass through
         kloc = hi0.z;
         for (int k = lo0.z; k <= hi0.z; ++k) {
-            amrex::Real zc = problo[2] + (k+0.5)*dx0[2];
+            amrex::Real zc = problo[2] + (Real(k)+Real(0.5))*dx0[2];
             if (zc > zcoord) {
                 kloc = k;
                 break;
@@ -284,7 +284,7 @@ void main_main()
 
 #ifdef BL_USE_MPI
     {
-        const int numpts = pos.size();
+        const auto numpts = int(pos.size());
         auto numpts_vec = ParallelDescriptor::Gather(numpts,
                                                      ParallelDescriptor::IOProcessorNumber());
         Vector<int> recvcnt, disp;
@@ -295,7 +295,7 @@ void main_main()
             disp.resize(numpts_vec.size());
             int ntot = 0;
             disp[0] = 0;
-            for (int i = 0, N = numpts_vec.size(); i < N; ++i) {
+            for (int i = 0, N = int(numpts_vec.size()); i < N; ++i) {
                 ntot += numpts_vec[i];
                 recvcnt[i] = numpts_vec[i];
                 if (i+1 < N) {

--- a/Tools/Plotfile/fsnapshot.cpp
+++ b/Tools/Plotfile/fsnapshot.cpp
@@ -45,10 +45,10 @@ void main_main()
         } else if (name == "-v" || name == "--variable") {
             compname = amrex::get_command_argument(++farg);
         } else if (name == "-M" || name == "--max") {
-            def_mx = std::stod(amrex::get_command_argument(++farg));
+            def_mx = Real(std::stod(amrex::get_command_argument(++farg)));
             ldef_mx = true;
         } else if (name == "-m" || name == "--min") {
-            def_mn = std::stod(amrex::get_command_argument(++farg));
+            def_mn = Real(std::stod(amrex::get_command_argument(++farg)));
             ldef_mn = true;
         } else if (name == "-L" || name == "--max_level") {
             max_level = std::stoi(amrex::get_command_argument(++farg));
@@ -57,9 +57,9 @@ void main_main()
         } else if (name == "-g" || name == "--origin") {
             origin = true;
         } else if (name == "-c" || name == "--coordinates") {
-            location[0] = std::stod(amrex::get_command_argument(++farg));
-            location[1] = std::stod(amrex::get_command_argument(++farg));
-            location[2] = std::stod(amrex::get_command_argument(++farg));
+            location[0] = Real(std::stod(amrex::get_command_argument(++farg)));
+            location[1] = Real(std::stod(amrex::get_command_argument(++farg)));
+            location[2] = Real(std::stod(amrex::get_command_argument(++farg)));
         } else {
             break;
         }
@@ -285,7 +285,7 @@ void main_main()
         const int height = (idir == 2) ? finebox[idir].length(1) : finebox[idir].length(2);
         const auto& intarr = intdat.array();
         const auto& realarr = datamf[idir].array(0);
-        Real fac = 253.999 / (gmx-gmn);
+        Real fac = Real(253.999) / (gmx-gmn);
         amrex::LoopOnCpu(finebox[idir], [=] (int i, int j, int k)
         {
             int jj = (idir == 2) ? height - 1 - j : j;  // flip the data in second image direction


### PR DESCRIPTION
We make ccache save a log file, from which we find out which files need a
rebuild. Instead of running clang-tidy on every file, we now only run it on
those files that had a miss in ccache. This significantly speeds up
clang-tidy in CIs.

Note that we treat clang-tidy warnings as errors in CIs. So if there is a
hit in the ccache's cache, the file is free of clang-tidy warnings. Also
note that we set CCACHE_EXTRAFILES to the clang-tidy configuration file. So
any changes to the config file will invalidate the cache as it should.

If a CI job successfully passes the compilation stage with ccache enabled,
but fails at the clang-tidy stage, the ccache's cache has been updated. One
might think this will cause issues because we now have files that have been
cached by ccache and meanwhile have failed the clang-tidy checks. However,
this is not an issue for Github CIs. This is because ccache's cache will not
be saved as a Github cache, if a CI fails.

Fix various clang-tidy warnings in Tests/. They were not reported before
because clang-tidy was not used on the tests.
