### PR TITLE
Fix: queryAdd for resizing vectors

### DIFF
--- a/Src/Base/AMReX_ParmParse.H
+++ b/Src/Base/AMReX_ParmParse.H
@@ -966,8 +966,8 @@ public:
      * added to the ParmParse database.  The return value indicates if it
      * existed previously.
      *
-     * If `name` is found, then the ref argument will be resized
-     * (shrunk or extended) according to the number of values in the inputs.
+     * If `name` is found, then the ref argument will be reallocated
+     * (and resized) according to the number of values in the inputs.
      */
     template <typename T>
     int queryAdd (const char* name, std::vector<T>& ref) {

--- a/Src/Base/AMReX_ParmParse.H
+++ b/Src/Base/AMReX_ParmParse.H
@@ -965,10 +965,18 @@ public:
      * be stored in the `ref` argument.  If not, the value in `ref` will be
      * added to the ParmParse database.  The return value indicates if it
      * existed previously.
+     *
+     * If `name` is found, then the ref argument will be resized
+     * (shrunk or extended) according to the number of values in the inputs.
      */
     template <typename T>
     int queryAdd (const char* name, std::vector<T>& ref) {
-        int exist = this->queryarr(name, ref);
+        std::vector<T> empty;
+        int exist = this->queryarr(name, empty);
+        if (exist) {
+            ref.resize(empty.size());
+            this->queryarr(name, ref);
+        }
         if (!exist && !ref.empty()) {
             this->addarr(name, ref);
         }

--- a/Src/Base/AMReX_ParmParse.H
+++ b/Src/Base/AMReX_ParmParse.H
@@ -974,8 +974,7 @@ public:
         std::vector<T> empty;
         int exist = this->queryarr(name, empty);
         if (exist) {
-            ref.resize(empty.size());
-            this->queryarr(name, ref);
+            ref = std::move(empty);
         }
         if (!exist && !ref.empty()) {
             this->addarr(name, ref);

--- a/Src/Base/AMReX_ParmParse.cpp
+++ b/Src/Base/AMReX_ParmParse.cpp
@@ -867,7 +867,7 @@ squeryarr (const ParmParse::Table& table,
     if ( num_val == 0 ) return true;
 
     int stop_ix = start_ix + num_val - 1;
-    if ( static_cast<int>(ref.size()) <= stop_ix )
+    if ( static_cast<int>(ref.size()) != stop_ix + 1 )  // grow or shrink to fit
     {
         ref.resize(stop_ix + 1);
     }

--- a/Src/Base/AMReX_ParmParse.cpp
+++ b/Src/Base/AMReX_ParmParse.cpp
@@ -867,7 +867,7 @@ squeryarr (const ParmParse::Table& table,
     if ( num_val == 0 ) return true;
 
     int stop_ix = start_ix + num_val - 1;
-    if ( static_cast<int>(ref.size()) != stop_ix + 1 )  // grow or shrink to fit
+    if ( static_cast<int>(ref.size()) <= stop_ix )
     {
         ref.resize(stop_ix + 1);
     }


### PR DESCRIPTION
## Summary

I think there is a bug in `ParmParse::queryAdd` and `ParmParse::queryarr` for `std::vector` arguments.

The passed array is only up-sized if needed, but not down-sized if the key exists. This leads to bugs for long default values and shorter user-provided arrays.

Reproducer:
```C++
std::vector<amrex::ParticleReal> cos_coef = ez.default_cos_coef;  // long default vector
pp_element.queryAdd("cos_coefficients", cos_coef);                // can be shorter user input

amrex::Print() << "cos_coef.size()" << cos_coef.size() << "\n";   // size of the default vector
```

## Additional background

First seen in https://github.com/ECP-WarpX/impactx/pull/322

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
