### PR TITLE
bug fix in creating EB from STL files

### DIFF
--- a/Src/EB/AMReX_EB_STL_utils.cpp
+++ b/Src/EB/AMReX_EB_STL_utils.cpp
@@ -242,6 +242,7 @@ STLtools::prepare ()
     if (!ParallelDescriptor::IOProcessor()) {
         m_tri_pts_h.resize(m_num_tri);
     }
+    ParallelDescriptor::Bcast((char*)(m_tri_pts_h.dataPtr()), m_num_tri*sizeof(Triangle));
 
     //device vectors
     m_tri_pts_d.resize(m_num_tri);


### PR DESCRIPTION
## Summary
Triangle data from an STL file needs to be broadcasted across MPI ranks 

## Additional background
The STL file is currently read only by ioprocessor and the tri_data on host is set only on ioprocessor.
FillFab function would only fill the correct data for processor 0 

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
