### PR TITLE
GitHub Cache Management

### DIFF
--- a/.github/workflows/clang.yml
+++ b/.github/workflows/clang.yml
@@ -164,3 +164,18 @@ jobs:
             CLANG_TIDY_ARGS="--config-file=${{github.workspace}}/.clang-tidy --warnings-as-errors=*"
 
         ccache -s
+
+  save_pr_number:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Save PR number
+        env:
+          PR_NUMBER: ${{ github.event.number }}
+        run: |
+          echo $PR_NUMBER > pr_number.txt
+      - uses: actions/upload-artifact@v3
+        with:
+          name: pr_number
+          path: pr_number.txt
+          retention-days: 1

--- a/.github/workflows/cleanup-cache-postpr.yml
+++ b/.github/workflows/cleanup-cache-postpr.yml
@@ -1,0 +1,37 @@
+name: CleanUpCachePostPR
+
+on:
+  workflow_run:
+    workflows: [PostPR]
+    types:
+      - completed
+
+jobs:
+  CleanUpCcacheCachePostPR:
+    name: Clean Up Ccahe Cache Post PR
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: read
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Clean up ccahe
+        run: |
+          gh extension install actions/gh-actions-cache
+
+          REPO=${{ github.repository }}
+
+          gh run download ${{ github.event.workflow_run.id }} -n pr_number
+          pr_number=`cat pr_number.txt`
+          BRANCH=refs/pull/${pr_number}/merge
+
+          # Setting this to not fail the workflow while deleting cache keys.
+          set +e
+
+          keys=$(gh actions-cache list -L 100 -R $REPO -B $BRANCH | cut -f 1)
+          for k in $keys
+          do
+            gh actions-cache delete $k -R $REPO -B $BRANCH --confirm
+          done

--- a/.github/workflows/cleanup-cache.yml
+++ b/.github/workflows/cleanup-cache.yml
@@ -1,0 +1,64 @@
+name: CleanUpCache
+
+on:
+  workflow_run:
+    workflows: [LinuxClang, cuda, LinuxGcc, hip, Hypre, intel, macos, PETSc, SUNDIALS, windows]
+    types:
+      - completed
+
+concurrency:
+  group: ${{ github.ref }}-${{ github.head_ref }}-${{ github.event.workflow_run.name }}
+  cancel-in-progress: true
+
+jobs:
+  CleanUpCcacheCache:
+    name: Clean Up Ccahe Cache for ${{ github.event.workflow_run.name }}
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: read
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Clean up ccahe
+        run: |
+          gh extension install actions/gh-actions-cache
+
+          REPO=${{ github.repository }}
+
+          # push or pull_request
+          EVENT=${{ github.event.workflow_run.event }}
+
+          # Triggering workflow run name (e.g., LinuxClang)
+          WORKFLOW_NAME=${{ github.event.workflow_run.name }}
+
+          if [[ $EVENT == "push" ]]; then
+            BRANCH=${{ github.ref }}
+          else
+            gh run download ${{ github.event.workflow_run.id }} -n pr_number
+            pr_number=`cat pr_number.txt`
+            BRANCH=refs/pull/${pr_number}/merge
+          fi
+
+          # Setting this to not fail the workflow while deleting cache keys.
+          set +e
+
+          # In our cache keys, substring after `-git-` is git hash, substring
+          # before that is a unique id for jobs (e.g., `ccache-LinuxClang-configure-2d`).
+          # Th goal is to keep the last used key of each job and delete all otheres.
+
+          # something like ccache-LinuxClang-
+          keyprefix=ccache-${WORKFLOW_NAME}-
+
+          cached_jobs=$(gh actions-cache list -L 100 -R $REPO -B $BRANCH --key $keyprefix | awk -F '-git-' '{print $1}' | sort | uniq)
+
+          # cached_jobs is something like "ccache-LinuxClang-configure-1d ccache-LinuxClang-configure-2d".
+          for j in $cached_jobs
+          do
+            old_keys=$(gh actions-cache list -L 100 -R $REPO -B $BRANCH --key ${j}-git- --sort last-used | cut -f 1 | tail -n +2)
+            for k in $old_keys
+            do
+              gh actions-cache delete $k -R $REPO -B $BRANCH --confirm
+            done
+          done

--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -149,3 +149,18 @@ jobs:
         make install
 
         ccache -s
+
+  save_pr_number:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Save PR number
+        env:
+          PR_NUMBER: ${{ github.event.number }}
+        run: |
+          echo $PR_NUMBER > pr_number.txt
+      - uses: actions/upload-artifact@v3
+        with:
+          name: pr_number
+          path: pr_number.txt
+          retention-days: 1

--- a/.github/workflows/gcc.yml
+++ b/.github/workflows/gcc.yml
@@ -656,3 +656,18 @@ jobs:
         mpirun -np 2 ./main3d.gnu.TPROF.MPI.ex ./inputs
         h5dump -d "level_0/data:offsets=0"  -s "1" -c "1" ./plt00000.h5
         h5dump -d "level_0/data:datatype=1" -s "1" -c "1" ./plt00000/particle0/particle0.h5
+
+  save_pr_number:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Save PR number
+        env:
+          PR_NUMBER: ${{ github.event.number }}
+        run: |
+          echo $PR_NUMBER > pr_number.txt
+      - uses: actions/upload-artifact@v3
+        with:
+          name: pr_number
+          path: pr_number.txt
+          retention-days: 1

--- a/.github/workflows/hip.yml
+++ b/.github/workflows/hip.yml
@@ -162,3 +162,18 @@ jobs:
         make install
 
         ccache -s
+
+  save_pr_number:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Save PR number
+        env:
+          PR_NUMBER: ${{ github.event.number }}
+        run: |
+          echo $PR_NUMBER > pr_number.txt
+      - uses: actions/upload-artifact@v3
+        with:
+          name: pr_number
+          path: pr_number.txt
+          retention-days: 1

--- a/.github/workflows/hypre.yml
+++ b/.github/workflows/hypre.yml
@@ -97,3 +97,18 @@ jobs:
             CLANG_TIDY_ARGS="--config-file=${{github.workspace}}/.clang-tidy --warnings-as-errors=*"
 
         ccache -s
+
+  save_pr_number:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Save PR number
+        env:
+          PR_NUMBER: ${{ github.event.number }}
+        run: |
+          echo $PR_NUMBER > pr_number.txt
+      - uses: actions/upload-artifact@v3
+        with:
+          name: pr_number
+          path: pr_number.txt
+          retention-days: 1

--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -119,3 +119,18 @@ jobs:
         set -e
         cd build
         ctest --output-on-failure
+
+  save_pr_number:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Save PR number
+        env:
+          PR_NUMBER: ${{ github.event.number }}
+        run: |
+          echo $PR_NUMBER > pr_number.txt
+      - uses: actions/upload-artifact@v3
+        with:
+          name: pr_number
+          path: pr_number.txt
+          retention-days: 1

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -87,3 +87,18 @@ jobs:
         ctest --test-dir build --output-on-failure
 
         ccache -s
+
+  save_pr_number:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Save PR number
+        env:
+          PR_NUMBER: ${{ github.event.number }}
+        run: |
+          echo $PR_NUMBER > pr_number.txt
+      - uses: actions/upload-artifact@v3
+        with:
+          name: pr_number
+          path: pr_number.txt
+          retention-days: 1

--- a/.github/workflows/petsc.yml
+++ b/.github/workflows/petsc.yml
@@ -55,3 +55,18 @@ jobs:
             CLANG_TIDY_ARGS="--config-file=${{github.workspace}}/.clang-tidy --warnings-as-errors=*"
 
         ccache -s
+
+  save_pr_number:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Save PR number
+        env:
+          PR_NUMBER: ${{ github.event.number }}
+        run: |
+          echo $PR_NUMBER > pr_number.txt
+      - uses: actions/upload-artifact@v3
+        with:
+          name: pr_number
+          path: pr_number.txt
+          retention-days: 1

--- a/.github/workflows/post-pr.yml
+++ b/.github/workflows/post-pr.yml
@@ -1,0 +1,20 @@
+name: PostPR
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Save PR number
+        env:
+          PR_NUMBER: ${{ github.event.number }}
+        run: |
+          echo $PR_NUMBER > pr_number.txt
+      - uses: actions/upload-artifact@v3
+        with:
+          name: pr_number
+          path: pr_number.txt
+          retention-days: 1

--- a/.github/workflows/sundials.yml
+++ b/.github/workflows/sundials.yml
@@ -136,3 +136,18 @@ jobs:
         cmake --build build -j 2
 
         ccache -s
+
+  save_pr_number:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Save PR number
+        env:
+          PR_NUMBER: ${{ github.event.number }}
+        run: |
+          echo $PR_NUMBER > pr_number.txt
+      - uses: actions/upload-artifact@v3
+        with:
+          name: pr_number
+          path: pr_number.txt
+          retention-days: 1

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -118,3 +118,18 @@ jobs:
               -DAMReX_OMP=ON                ^
               -DAMReX_PARTICLES=ON
         cmake --build build --config Release -j 2
+
+  save_pr_number:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Save PR number
+        env:
+          PR_NUMBER: ${{ github.event.number }}
+        run: |
+          echo $PR_NUMBER > pr_number.txt
+      - uses: actions/upload-artifact@v3
+        with:
+          name: pr_number
+          path: pr_number.txt
+          retention-days: 1


### PR DESCRIPTION
The total size of all caches in a GitHub repo is limited to 10 GB. So we need to proactively manage the caches to avoid undesired cache eviction.

GitHub cache has its scope associated with branch. When a new PR is opened, the last used cache of the default branch (i.e., development for AMReX) is restored for the PR's actions. After the actions finish, the caches will be saved under a unique name every time and only that PR has access to it. (Presumably this is for security reason to avoid cache poison.) If the actions are run many times, a large number of caches will be accumulated. This uses a lot of space, even though we only need to keep the most recent cache. In this PR, we implement the following approach to keep only the last used cache for each job and remove all caches associated with a PR when it's closed.

We have added a workflow that is triggered by the events of completed workflows (e.g., LinuxClang workflow that has a number of jobs using cache.) This new workflow runs on the default branch and it's therefore safe to be granted write permission. Each triggering workflow saves the PR number as an artifact, if it's a pull request run. This is a way to pass the PR number to the cache cleanup workflow, which will clean up old caches associated with the jobs in the triggering workflow. When a PR is closed or merged, a post PR workflow is trigger, and it will in turn trigger another workflow that cleans up all the caches associated with the PR. After the merge, the actions will be run on the default branch. The newly added workflows will also clean up the old caches in the default branch.
