### PR TITLE
NVHPC CI

### DIFF
--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -58,14 +58,14 @@ jobs:
         ccache -s
 
   # Build libamrex and all tests with NVHPC (recent supported)
-  tests-nvhpc23-1-nvcc:
-    name: NVHPC@23.1 NVCC/NVC++ C++17 Release [tests]
+  tests-nvhpc-nvcc:
+    name: NVHPC NVCC/NVC++ C++17 Release [tests]
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v3
     - name: Dependencies
       run: |
-        .github/workflows/dependencies/dependencies_nvhpc23-1.sh
+        .github/workflows/dependencies/dependencies_nvhpc.sh
         .github/workflows/dependencies/dependencies_ccache.sh
     - name: Set Up Cache
       uses: actions/cache@v3
@@ -83,7 +83,8 @@ jobs:
         ccache -z
 
         source /etc/profile.d/modules.sh
-        module load /opt/nvidia/hpc_sdk/modulefiles/nvhpc/23.1
+        nvhpc_version=`ls -v /opt/nvidia/hpc_sdk/modulefiles/nvhpc/ | tail -n 1`
+        module load /opt/nvidia/hpc_sdk/modulefiles/nvhpc/${nvhpc_version}
 
         which nvcc || echo "nvcc not in PATH!"
         which nvc++ || echo "nvc++ not in PATH!"

--- a/.github/workflows/dependencies/dependencies_nvhpc.sh
+++ b/.github/workflows/dependencies/dependencies_nvhpc.sh
@@ -22,11 +22,10 @@ curl https://developer.download.nvidia.com/hpc-sdk/ubuntu/DEB-GPG-KEY-NVIDIA-HPC
 echo 'deb [signed-by=/usr/share/keyrings/nvidia-hpcsdk-archive-keyring.gpg] https://developer.download.nvidia.com/hpc-sdk/ubuntu/amd64 /' | \
   sudo tee /etc/apt/sources.list.d/nvhpc.list
 sudo apt-get update -y
-sudo apt-get install -y --no-install-recommends nvhpc-23-1
+sudo apt-get install -y --no-install-recommends nvhpc
 
 # things should reside in /opt/nvidia/hpc_sdk now
 
 # activation via:
 #   source /etc/profile.d/modules.sh
-#   module load /opt/nvidia/hpc_sdk/modulefiles/nvhpc/23.1
-
+#   module load /opt/nvidia/hpc_sdk/modulefiles/nvhpc/23.3


### PR DESCRIPTION
Use the default version whatever that is. Right now, if we explicitly ask for 23.1, the latest version (i.e., 23.3) gets installed as well. Then we run out of space in GitHub CI.
