### PR TITLE
CI: oneAPI -Wmissing-braces

### DIFF
--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -10,7 +10,6 @@ jobs:
   tests-oneapi-sycl:
     name: oneAPI SYCL [tests]
     runs-on: ubuntu-20.04
-    # mkl/rng/device/detail/mrg32k3a_impl.hpp has a number of sign-compare error
     steps:
     - uses: actions/checkout@v3
     - name: Dependencies
@@ -25,7 +24,9 @@ jobs:
         restore-keys: |
              ccache-${{ github.workflow }}-${{ github.job }}-git-
     - name: Build & Install
-      env: {CXXFLAGS: "-fno-operator-names -Werror -Wall -Wextra -Wpedantic -Wnull-dereference -Wfloat-conversion -Wshadow -Woverloaded-virtual -Wextra-semi -Wunreachable-code -Wnon-virtual-dtor -Wno-sign-compare"}
+      # mkl/rng/device/detail/mrg32k3a_impl.hpp has a number of sign-compare error
+      # mkl/rng/device/detail/mrg32k3a_impl.hpp has missing braces in array-array initalization
+      env: {CXXFLAGS: "-fno-operator-names -Werror -Wall -Wextra -Wpedantic -Wnull-dereference -Wfloat-conversion -Wshadow -Woverloaded-virtual -Wextra-semi -Wunreachable-code -Wnon-virtual-dtor -Wno-sign-compare -Wno-missing-braces"}
       run: |
         export CCACHE_COMPRESS=1
         export CCACHE_COMPRESSLEVEL=10
@@ -69,7 +70,8 @@ jobs:
              ccache-${{ github.workflow }}-${{ github.job }}-git-
     - name: Build & Install
       # mkl/rng/device/detail/mrg32k3a_impl.hpp has a number of sign-compare error
-      env: {CXXFLAGS: "-fno-operator-names -Werror -Wall -Wextra -Wpedantic -Wnull-dereference -Wfloat-conversion -Wshadow -Woverloaded-virtual -Wextra-semi -Wunreachable-code -Wnon-virtual-dtor -Wno-sign-compare"}
+      # mkl/rng/device/detail/mrg32k3a_impl.hpp has missing braces in array-array initalization
+      env: {CXXFLAGS: "-fno-operator-names -Werror -Wall -Wextra -Wpedantic -Wnull-dereference -Wfloat-conversion -Wshadow -Woverloaded-virtual -Wextra-semi -Wunreachable-code -Wnon-virtual-dtor -Wno-sign-compare -Wno-missing-braces"}
       run: |
         export CCACHE_COMPRESS=1
         export CCACHE_COMPRESSLEVEL=10


### PR DESCRIPTION
## Summary

The latest oneAPI release, 2023.1.10, ships with `-Wmissing-braces` warnings in the public MKL headers...

```
/opt/intel/oneapi/mkl/2023.1.0/include/oneapi/mkl/rng/device/detail/mrg32k3a_impl.hpp:163:33: error: suggest braces around initialization of subobject [-Werror,-Wmissing-braces]
    std::uint32_t temp[3][3] = {1, 0, 0, 0, 1, 0, 0, 0, 1};
                                ^~~~~~~
                                {      }
/opt/intel/oneapi/mkl/2023.1.0/include/oneapi/mkl/rng/device/detail/mrg32k3a_impl.hpp:163:42: error: suggest braces around initialization of subobject [-Werror,-Wmissing-braces]
    std::uint32_t temp[3][3] = {1, 0, 0, 0, 1, 0, 0, 0, 1};
                                         ^~~~~~~
                                         {      }
/opt/intel/oneapi/mkl/2023.1.0/include/oneapi/mkl/rng/device/detail/mrg32k3a_impl.hpp:163:51: error: suggest braces around initialization of subobject [-Werror,-Wmissing-braces]
    std::uint32_t temp[3][3] = {1, 0, 0, 0, 1, 0, 0, 0, 1};
                                                  ^~~~~~~
                                                  {      }
```

## Additional background

Broke our CI.

attn @rscohn2 FYI - let's report this? :)

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
