### PR TITLE
CI: Retry Apt Repos

### DIFF
--- a/.github/workflows/dependencies/dependencies.sh
+++ b/.github/workflows/dependencies/dependencies.sh
@@ -7,6 +7,11 @@
 
 set -eu -o pipefail
 
+# `man apt.conf`:
+#   Number of retries to perform. If this is non-zero APT will retry
+#   failed files the given number of times.
+echo 'Acquire::Retries "3";' | sudo tee /etc/apt/apt.conf.d/80-retries
+
 sudo apt-get update
 
 sudo apt-get install -y --no-install-recommends\

--- a/.github/workflows/dependencies/dependencies_clang-tidy.sh
+++ b/.github/workflows/dependencies/dependencies_clang-tidy.sh
@@ -2,5 +2,10 @@
 
 set -eu -o pipefail
 
+# `man apt.conf`:
+#   Number of retries to perform. If this is non-zero APT will retry
+#   failed files the given number of times.
+echo 'Acquire::Retries "3";' | sudo tee /etc/apt/apt.conf.d/80-retries
+
 sudo apt-get install -y --no-install-recommends \
     clang-tidy-$1 libomp-$1-dev

--- a/.github/workflows/dependencies/dependencies_clang.sh
+++ b/.github/workflows/dependencies/dependencies_clang.sh
@@ -7,6 +7,11 @@
 
 set -eu -o pipefail
 
+# `man apt.conf`:
+#   Number of retries to perform. If this is non-zero APT will retry
+#   failed files the given number of times.
+echo 'Acquire::Retries "3";' | sudo tee /etc/apt/apt.conf.d/80-retries
+
 sudo apt-get update
 
 sudo apt-get install -y --no-install-recommends \

--- a/.github/workflows/dependencies/dependencies_dpcpp.sh
+++ b/.github/workflows/dependencies/dependencies_dpcpp.sh
@@ -7,6 +7,11 @@
 
 set -eu -o pipefail
 
+# `man apt.conf`:
+#   Number of retries to perform. If this is non-zero APT will retry
+#   failed files the given number of times.
+echo 'Acquire::Retries "3";' | sudo tee /etc/apt/apt.conf.d/80-retries
+
 # Ref.: https://github.com/rscohn2/oneapi-ci
 # intel-basekit intel-hpckit are too large in size
 wget -q -O - https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB \
@@ -16,9 +21,17 @@ echo "deb https://apt.repos.intel.com/oneapi all main" \
 
 sudo apt-get update
 
-sudo apt-get install -y --no-install-recommends \
-    build-essential \
-    intel-oneapi-dpcpp-cpp-compiler \
-    intel-oneapi-compiler-fortran \
-    intel-oneapi-mkl-devel \
-    intel-oneapi-mpi-devel
+# try apt install up to five times, to avoid connection splits
+status=1
+for itry in {1..5}
+do
+    sudo apt-get install -y --no-install-recommends \
+        build-essential \
+        intel-oneapi-dpcpp-cpp-compiler \
+        intel-oneapi-compiler-fortran \
+        intel-oneapi-mkl-devel \
+        intel-oneapi-mpi-devel \
+        && { sudo apt-get clean; status=0; break; }  \
+        || { sleep 10; }
+done
+if [[ ${status} -ne 0 ]]; then exit 1; fi

--- a/.github/workflows/dependencies/dependencies_gcc.sh
+++ b/.github/workflows/dependencies/dependencies_gcc.sh
@@ -7,6 +7,11 @@
 
 set -eu -o pipefail
 
+# `man apt.conf`:
+#   Number of retries to perform. If this is non-zero APT will retry
+#   failed files the given number of times.
+echo 'Acquire::Retries "3";' | sudo tee /etc/apt/apt.conf.d/80-retries
+
 sudo add-apt-repository ppa:ubuntu-toolchain-r/test
 sudo apt-get update
 

--- a/.github/workflows/dependencies/dependencies_hip.sh
+++ b/.github/workflows/dependencies/dependencies_hip.sh
@@ -12,6 +12,10 @@
 
 set -eu -o pipefail
 
+# `man apt.conf`:
+#   Number of retries to perform. If this is non-zero APT will retry
+#   failed files the given number of times.
+echo 'Acquire::Retries "3";' | sudo tee /etc/apt/apt.conf.d/80-retries
 
 # Ref.: https://rocmdocs.amd.com/en/latest/Installation_Guide/Installation-Guide.html#ubuntu
 curl -O https://repo.radeon.com/rocm/rocm.gpg.key

--- a/.github/workflows/dependencies/dependencies_mac.sh
+++ b/.github/workflows/dependencies/dependencies_mac.sh
@@ -7,6 +7,11 @@
 
 set -eu -o pipefail
 
+# `man apt.conf`:
+#   Number of retries to perform. If this is non-zero APT will retry
+#   failed files the given number of times.
+echo 'Acquire::Retries "3";' | sudo tee /etc/apt/apt.conf.d/80-retries
+
 brew update
 brew install gfortran || true
 brew install libomp || true

--- a/.github/workflows/dependencies/dependencies_mac.sh
+++ b/.github/workflows/dependencies/dependencies_mac.sh
@@ -7,11 +7,6 @@
 
 set -eu -o pipefail
 
-# `man apt.conf`:
-#   Number of retries to perform. If this is non-zero APT will retry
-#   failed files the given number of times.
-echo 'Acquire::Retries "3";' | sudo tee /etc/apt/apt.conf.d/80-retries
-
 brew update
 brew install gfortran || true
 brew install libomp || true

--- a/.github/workflows/dependencies/dependencies_nofortran.sh
+++ b/.github/workflows/dependencies/dependencies_nofortran.sh
@@ -12,6 +12,11 @@
 
 set -eu -o pipefail
 
+# `man apt.conf`:
+#   Number of retries to perform. If this is non-zero APT will retry
+#   failed files the given number of times.
+echo 'Acquire::Retries "3";' | sudo tee /etc/apt/apt.conf.d/80-retries
+
 sudo apt-get update
 
 sudo apt-get install -y --no-install-recommends\

--- a/.github/workflows/dependencies/dependencies_nvcc11.sh
+++ b/.github/workflows/dependencies/dependencies_nvcc11.sh
@@ -6,6 +6,11 @@
 
 set -eu -o pipefail
 
+# `man apt.conf`:
+#   Number of retries to perform. If this is non-zero APT will retry
+#   failed files the given number of times.
+echo 'Acquire::Retries "3";' | sudo tee /etc/apt/apt.conf.d/80-retries
+
 sudo apt-get -qqq update
 sudo apt-get install -y \
     build-essential     \

--- a/.github/workflows/dependencies/dependencies_nvcc12.sh
+++ b/.github/workflows/dependencies/dependencies_nvcc12.sh
@@ -6,6 +6,11 @@
 
 set -eu -o pipefail
 
+# `man apt.conf`:
+#   Number of retries to perform. If this is non-zero APT will retry
+#   failed files the given number of times.
+echo 'Acquire::Retries "3";' | sudo tee /etc/apt/apt.conf.d/80-retries
+
 sudo apt-get -qqq update
 sudo apt-get install -y \
     build-essential     \

--- a/.github/workflows/dependencies/dependencies_nvhpc.sh
+++ b/.github/workflows/dependencies/dependencies_nvhpc.sh
@@ -7,6 +7,11 @@
 
 set -eu -o pipefail
 
+# `man apt.conf`:
+#   Number of retries to perform. If this is non-zero APT will retry
+#   failed files the given number of times.
+echo 'Acquire::Retries "3";' | sudo tee /etc/apt/apt.conf.d/80-retries
+
 sudo apt-get -qqq update
 sudo apt-get install -y \
     build-essential     \

--- a/.github/workflows/dependencies/documentation.sh
+++ b/.github/workflows/dependencies/documentation.sh
@@ -7,6 +7,11 @@
 
 set -eu -o pipefail
 
+# `man apt.conf`:
+#   Number of retries to perform. If this is non-zero APT will retry
+#   failed files the given number of times.
+echo 'Acquire::Retries "3";' | sudo tee /etc/apt/apt.conf.d/80-retries
+
 sudo apt-get update
 
 sudo apt-get install -y --no-install-recommends\


### PR DESCRIPTION
## Summary

Since Intel Repos are often out-of-sync with each others for apt packages provided (checksum errors), we try to pause and retry up to five times to get them installed.

Also set apt retries to 3 for `apt update`.

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
