### PR TITLE
Fix periodic boundary bug in #3199

### DIFF
--- a/Src/Base/AMReX_Geometry.cpp
+++ b/Src/Base/AMReX_Geometry.cpp
@@ -545,8 +545,9 @@ Geometry::computeRoundoffDomain ()
         ParticleReal rhi = roundoff_hi[idim];
         while (iters < 20) {
             rhi = std::nextafter(rhi, roundoff_lo[idim]);
-            roundoff_hi[idim] = rhi;
-            if (int(std::floor((rhi - plo)*dxinv)) < ihi + 1 - ilo) {
+            if (int(std::floor((rhi - plo)*dxinv)) >= ihi + 1 - ilo) {
+                roundoff_hi[idim] = rhi;
+            } else {
                 break;
             }
             iters++;

--- a/Src/Base/AMReX_Geometry.cpp
+++ b/Src/Base/AMReX_Geometry.cpp
@@ -545,9 +545,8 @@ Geometry::computeRoundoffDomain ()
         ParticleReal rhi = roundoff_hi[idim];
         while (iters < 20) {
             rhi = std::nextafter(rhi, roundoff_lo[idim]);
-            if (int(std::floor((rhi - plo)*dxinv)) >= ihi + 1 - ilo) {
-                roundoff_hi[idim] = rhi;
-            } else {
+            roundoff_hi[idim] = rhi;
+            if (int(std::floor((rhi - plo)*dxinv)) < ihi + 1 - ilo) {
                 break;
             }
             iters++;

--- a/Src/Particle/AMReX_ParticleUtil.H
+++ b/Src/Particle/AMReX_ParticleUtil.H
@@ -569,8 +569,8 @@ bool enforcePeriodic (P& p,
     for (int idim = 0; idim < AMREX_SPACEDIM; ++idim)
     {
         if (! is_per[idim]) continue;
-        if (p.pos(idim) >= phi[idim]) {
-            while (p.pos(idim) >= phi[idim]) {
+        if (p.pos(idim) >= rhi[idim]) {
+            while (p.pos(idim) >= rhi[idim]) {
                 p.pos(idim) -= static_cast<ParticleReal>(phi[idim] - plo[idim]);
             }
             // clamp to avoid precision issues;
@@ -579,8 +579,8 @@ bool enforcePeriodic (P& p,
             }
             shifted = true;
         }
-        else if (p.pos(idim) < plo[idim]) {
-            while (p.pos(idim) < plo[idim]) {
+        else if (p.pos(idim) < rlo[idim]) {
+            while (p.pos(idim) < rlo[idim]) {
                 p.pos(idim) += static_cast<ParticleReal>(phi[idim] - plo[idim]);
             }
             // clamp to avoid precision issues;

--- a/Src/Particle/AMReX_ParticleUtil.H
+++ b/Src/Particle/AMReX_ParticleUtil.H
@@ -584,8 +584,8 @@ bool enforcePeriodic (P& p,
                 p.pos(idim) += static_cast<ParticleReal>(phi[idim] - plo[idim]);
             }
             // clamp to avoid precision issues;
-            if (p.pos(idim) > rhi[idim]) {
-                p.pos(idim) = rhi[idim];
+            if (p.pos(idim) >= rhi[idim]) {
+                p.pos(idim) = std::nextafter(p.pos(idim), rlo[idim]);
             }
             shifted = true;
         }


### PR DESCRIPTION
PR #3199 broke the Nyx regression tests. The issue is we require the particle positions to be in [plo, phi). This won't happen if rhi is exactly equal to phi. The fix is to make sure rhi is always slightly inside the domain. 

EDIT - fixed this in a different way. Now, when applying periodic boundaries, the particle positions will be set to be strictly less than rhi.

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
