### PR TITLE
ParticleTileData: No Restrict in Storage

### DIFF
--- a/Src/Particle/AMReX_ParticleTile.H
+++ b/Src/Particle/AMReX_ParticleTile.H
@@ -22,8 +22,8 @@ struct ParticleTileData
 
     Long m_size;
     ParticleType* AMREX_RESTRICT m_aos;
-    GpuArray<ParticleReal* AMREX_RESTRICT, NArrayReal> m_rdata;
-    GpuArray<int* AMREX_RESTRICT, NArrayInt> m_idata;
+    GpuArray<ParticleReal*, NArrayReal> m_rdata;
+    GpuArray<int*, NArrayInt> m_idata;
 
     int m_num_runtime_real;
     int m_num_runtime_int;
@@ -170,8 +170,8 @@ struct ConstParticleTileData
 
     Long m_size;
     const ParticleType* AMREX_RESTRICT m_aos;
-    GpuArray<const ParticleReal* AMREX_RESTRICT, NArrayReal> m_rdata;
-    GpuArray<const int* AMREX_RESTRICT, NArrayInt > m_idata;
+    GpuArray<const ParticleReal*, NArrayReal> m_rdata;
+    GpuArray<const int*, NArrayInt> m_idata;
 
     int m_num_runtime_real;
     int m_num_runtime_int;


### PR DESCRIPTION
## Summary

Remove the `restrict` qualifier from `GpuArray` members in `ParticleTileData`. We see compilation problems with, among others Clang 14.0.6 and AppleClang, for this construct.

We expect that using `restrict` (`AMREX_RESTRICT`) on APIs as well as aliased pointers in these arrays before access should be sufficient to prevent that the compiler thinks that individual arrays alias each other in hot loops.

## Additional background

- WarpX build regressions since 23.03, e.g.,
  - https://github.com/conda-forge/warpx-feedstock/pull/63
  - https://github.com/conda-forge/warpx-feedstock/pull/64
  - https://github.com/ECP-WarpX/WarpX/pull/3817
- independently, about to be remove in https://github.com/AMReX-Codes/amrex/pull/2878

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
