### PR TITLE
Fix a typo in a comment in AMReX_Math.H

### DIFF
--- a/Src/Base/AMReX_Math.H
+++ b/Src/Base/AMReX_Math.H
@@ -32,7 +32,7 @@ namespace amrex::Math {
 
 // Since Intel's SYCL compiler now supports the following std functions on device,
 // one no longer needs to use amrex::Math::abs, etc.  They are kept here for
-// backward compatability.
+// backward compatibility.
 
 using std::abs;
 using std::ceil;


### PR DESCRIPTION
## Summary
This tiny PR fixes a typo in a comment in  AMReX_Math.H

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
