### PR TITLE
Ensure that particles are always < rhi after applying periodic bcs.

### DIFF
--- a/Src/Particle/AMReX_ParticleUtil.H
+++ b/Src/Particle/AMReX_ParticleUtil.H
@@ -623,8 +623,8 @@ bool enforcePeriodic (P& p,
                 p.pos(idim) += static_cast<ParticleReal>(phi[idim] - plo[idim]);
             }
             // clamp to avoid precision issues;
-            if (p.pos(idim) >= rhi[idim]) {
-                p.pos(idim) = std::nextafter(rhi[idim], rlo[idim]);
+            if (p.pos(idim) > rhi[idim]) {
+                p.pos(idim) = rhi[idim];
             }
             shifted = true;
         }

--- a/Src/Particle/AMReX_ParticleUtil.H
+++ b/Src/Particle/AMReX_ParticleUtil.H
@@ -624,7 +624,7 @@ bool enforcePeriodic (P& p,
             }
             // clamp to avoid precision issues;
             if (p.pos(idim) >= rhi[idim]) {
-                p.pos(idim) = std::nextafter(p.pos(idim), rlo[idim]);
+                p.pos(idim) = std::nextafter(rhi[idim], rlo[idim]);
             }
             shifted = true;
         }


### PR DESCRIPTION
We either need to iterate or just fix it this way, which is symmetric with the way rlo is handled. This relies on `rhi` being the largest point that is *inside* the domain, which is consistent with the ASSERT below.

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
