### PR TITLE
HypreSolver: a new interface for Hypre

### DIFF
--- a/.github/workflows/hypre.yml
+++ b/.github/workflows/hypre.yml
@@ -107,6 +107,54 @@ jobs:
         ccache -s
         du -hs ~/.cache/ccache
 
+  test-hypre-solver-cpu-eb-2d:
+    name: GCC EB 2D Hypre@2.28.0
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Dependencies
+      run: |
+        .github/workflows/dependencies/dependencies.sh
+        .github/workflows/dependencies/dependencies_clang-tidy.sh 14
+        .github/workflows/dependencies/dependencies_ccache.sh
+    - name: Set Up Cache
+      uses: actions/cache@v3
+      with:
+        path: ~/.cache/ccache
+        key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}
+        restore-keys: |
+             ccache-${{ github.workflow }}-${{ github.job }}-git-
+    - name: Build Hypre
+      run: |
+        wget -q https://github.com/hypre-space/hypre/archive/refs/tags/v2.28.0.tar.gz
+        tar xfz v2.28.0.tar.gz
+        cd hypre-2.28.0/src
+        ./configure --with-cxxstandard=17
+        make -j 2
+        make install
+        cd ../../
+    - name: Build and Run Test
+      run: |
+        export CCACHE_COMPRESS=1
+        export CCACHE_COMPRESSLEVEL=10
+        export CCACHE_MAXSIZE=100M
+        export CCACHE_EXTRAFILES=${{ github.workspace }}/.clang-tidy
+        export CCACHE_LOGFILE=${{ github.workspace }}/ccache.log.txt
+        ccache -z
+
+        export AMREX_HYPRE_HOME=${PWD}/hypre-2.28.0/src/hypre
+        cd Tests/LinearSolvers/Hypre
+        make -j2 USE_MPI=TRUE USE_HYPRE=TRUE DIM=2 CCACHE=ccache
+        mpiexec -n 2 ./main2d.gnu.MPI.ex inputs.2d
+
+        ${{github.workspace}}/Tools/C_scripts/mmclt.py --input ${{github.workspace}}/ccache.log.txt
+        make -j2 -f clang-tidy-ccache-misses.mak \
+            CLANG_TIDY=clang-tidy-14 \
+            CLANG_TIDY_ARGS="--config-file=${{github.workspace}}/.clang-tidy --warnings-as-errors=*"
+
+        ccache -s
+        du -hs ~/.cache/ccache
+
   save_pr_number:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest

--- a/Src/Base/AMReX_FabArray.H
+++ b/Src/Base/AMReX_FabArray.H
@@ -1653,8 +1653,13 @@ FabArray<FAB>::build_arrays () const
         m_hp_arrays = (void*)std::malloc(n*2*sizeof(A));
 #endif
         for (int li = 0; li < n; ++li) {
-            new ((A*)m_hp_arrays+li) A(m_fabs_v[li]->array());
-            new ((AC*)m_hp_arrays+li+n) AC(m_fabs_v[li]->const_array());
+            if (m_fabs_v[li]) {
+                new ((A*)m_hp_arrays+li) A(m_fabs_v[li]->array());
+                new ((AC*)m_hp_arrays+li+n) AC(m_fabs_v[li]->const_array());
+            } else {
+                new ((A*)m_hp_arrays+li) A{};
+                new ((AC*)m_hp_arrays+li+n) AC{};
+            }
         }
         m_arrays.hp = (A*)m_hp_arrays;
         m_const_arrays.hp = (AC*)m_hp_arrays + n;

--- a/Src/EB/AMReX_MultiCutFab.H
+++ b/Src/EB/AMReX_MultiCutFab.H
@@ -107,6 +107,18 @@ public:
     Array4<Real const> array (const MFIter& mfi) const noexcept;
     Array4<Real const> const_array (const MFIter& mfi) const noexcept;
 
+    MultiArray4<Real> arrays () noexcept {
+        return m_data.arrays();
+    }
+
+    MultiArray4<Real const> arrays () const noexcept {
+        return m_data.const_arrays();
+    }
+
+    MultiArray4<Real const> const_arrays () const noexcept {
+        return m_data.const_arrays();
+    }
+
     //! Is it OK to call operator[] with this MFIter?
     bool ok (const MFIter& mfi) const noexcept;
 

--- a/Src/Extern/HYPRE/AMReX_Hypre.cpp
+++ b/Src/Extern/HYPRE/AMReX_Hypre.cpp
@@ -31,7 +31,11 @@ Hypre::Hypre (const BoxArray& grids, const DistributionMapping& dmap,
 {
     static_assert(AMREX_SPACEDIM > 1, "Hypre: 1D not supported");
 
-    static_assert(std::is_same<Real, HYPRE_Real>::value, "amrex::Real != HYPRE_Real");
+    // This is not static_assert because HypreSolver class does not require this.
+    if (!std::is_same<Real, HYPRE_Real>::value) {
+        amrex::Abort("amrex::Real != HYPRE_Real");
+    }
+
 #ifdef HYPRE_BIGINT
     static_assert(std::is_same<long long int, HYPRE_Int>::value, "long long int != HYPRE_Int");
 #else

--- a/Src/Extern/HYPRE/AMReX_HypreABecLap3.cpp
+++ b/Src/Extern/HYPRE/AMReX_HypreABecLap3.cpp
@@ -115,7 +115,7 @@ HypreABecLap3::prepareSolver ()
 
 #ifdef AMREX_USE_EB
 
-    auto ebfactory = dynamic_cast<EBFArrayBoxFactory const*>(m_factory);
+    auto const* ebfactory = dynamic_cast<EBFArrayBoxFactory const*>(m_factory);
     AMREX_ALWAYS_ASSERT_WITH_MESSAGE(m_overset_mask == nullptr || ebfactory == nullptr,
                                      "Cannot have both EB and overset");
     const FabArray<EBCellFlagFab>* flags = (ebfactory) ? &(ebfactory->getMultiEBCellFlagFab()) : nullptr;
@@ -124,8 +124,8 @@ HypreABecLap3::prepareSolver ()
         : Array<const MultiCutFab*,AMREX_SPACEDIM>{AMREX_D_DECL(nullptr,nullptr,nullptr)};
     auto fcent = (ebfactory) ? ebfactory->getFaceCent()
         : Array<const MultiCutFab*,AMREX_SPACEDIM>{AMREX_D_DECL(nullptr,nullptr,nullptr)};
-    auto barea = (ebfactory) ? &(ebfactory->getBndryArea()) : nullptr;
-    auto bcent = (ebfactory) ? &(ebfactory->getBndryCent()) : nullptr;
+    auto const* barea = (ebfactory) ? &(ebfactory->getBndryArea()) : nullptr;
+    auto const* bcent = (ebfactory) ? &(ebfactory->getBndryCent()) : nullptr;
 
     if (ebfactory)
     {
@@ -188,8 +188,8 @@ HypreABecLap3::prepareSolver ()
                 else
                 {
                     Long npts = bx.numPts();
-                    ncells_grid[mfi] = npts;
-                    ncells_proc += npts;
+                    ncells_grid[mfi] = static_cast<int>(npts);
+                    ncells_proc += static_cast<HYPRE_Int>(npts);
 
                     AMREX_HOST_DEVICE_PARALLEL_FOR_3D(gbx, i, j, k,
                     {
@@ -208,8 +208,8 @@ HypreABecLap3::prepareSolver ()
     {
         for (MFIter mfi(cell_id); mfi.isValid(); ++mfi) {
             Long npts = mfi.validbox().numPts();
-            ncells_grid[mfi] = npts;
-            ncells_proc += npts;
+            ncells_grid[mfi] = static_cast<int>(npts);
+            ncells_proc += static_cast<HYPRE_Int>(npts);
         }
 
 #ifdef AMREX_USE_GPU
@@ -513,7 +513,7 @@ HypreABecLap3::loadVectors (MultiFab& soln, const MultiFab& rhs)
     BL_PROFILE("HypreABecLap3::loadVectors()");
 
 #ifdef AMREX_USE_EB
-    auto ebfactory = dynamic_cast<EBFArrayBoxFactory const*>(m_factory);
+    auto const* ebfactory = dynamic_cast<EBFArrayBoxFactory const*>(m_factory);
     const FabArray<EBCellFlagFab>* flags = (ebfactory) ? &(ebfactory->getMultiEBCellFlagFab()) : nullptr;
 #endif
 

--- a/Src/Extern/HYPRE/AMReX_HypreNodeLap.cpp
+++ b/Src/Extern/HYPRE/AMReX_HypreNodeLap.cpp
@@ -181,7 +181,7 @@ HypreNodeLap::fill_local_node_id_gpu ()
         AMREX_ASSERT(ndbx.numPts() < static_cast<Long>(std::numeric_limits<int>::max()));
         const int npts = ndbx.numPts();
         int nnodes_box = amrex::Scan::PrefixSum<int>(npts,
-            [=] AMREX_GPU_DEVICE (int offset) noexcept
+            [=] AMREX_GPU_DEVICE (int offset) noexcept -> int
             {
                 int valid_node = 1;
                 const Dim3 cell = ndbx.atOffset(offset).dim3();

--- a/Src/Extern/HYPRE/AMReX_HypreSolver.H
+++ b/Src/Extern/HYPRE/AMReX_HypreSolver.H
@@ -1,0 +1,665 @@
+#ifndef AMREX_HYPRE_SOLVER_H_
+#define AMREX_HYPRE_SOLVER_H_
+
+#include <AMReX_Geometry.H>
+#include <AMReX_iMultiFab.H>
+#include <AMReX_HypreIJIface.H>
+#include <AMReX_BLProfiler.H>
+
+#include "HYPRE.h"
+#include "_hypre_utilities.h"
+
+#include <string>
+
+namespace amrex
+{
+
+template <int MSS>
+class HypreSolver
+{
+public:
+
+    template <class Marker, class Filler>
+    HypreSolver (Vector<IndexType>   const& a_index_type,
+                 IntVect             const& a_nghost,
+                 Geometry            const& a_geom,
+                 BoxArray            const& a_grids,
+                 DistributionMapping const& a_dmap,
+                 Marker                  && a_marker,
+                 Filler                  && a_filler,
+                 int                        a_verbose = 0,
+                 std::string         const& a_options_namespace = "hypre");
+
+    template <class MF, std::enable_if_t<IsFabArray<MF>::value &&
+                                         std::is_same_v<typename MF::value_type,
+                                                        HYPRE_Real>, int> = 0>
+    void solve (Vector<MF      *> const& a_soln,
+                Vector<MF const*> const& a_rhs,
+                HYPRE_Real rel_tol, HYPRE_Real abs_tol, int max_iter);
+
+    int getNumIters () const { return m_hypre_ij->getNumIters(); }
+
+    HYPRE_Real getFinalResidualNorm () const {
+        return m_hypre_ij->getFinalResidualNorm();
+    }
+
+    HYPRE_IJMatrix getA () const { return m_hypre_ij->A(); }
+    HYPRE_IJVector getb () const { return m_hypre_ij->b(); }
+    HYPRE_IJVector getx () const { return m_hypre_ij->x(); }
+
+public: // for cuda
+
+    template <class Marker>
+#ifdef AMREX_USE_CUDA
+    std::enable_if_t<IsCallable<Marker,int,int,int,int,int>::value>
+#else
+    std::enable_if_t<IsCallableR<bool,Marker,int,int,int,int,int>::value>
+#endif
+    fill_local_id (Marker const& marker);
+
+    void fill_global_id ();
+
+    template <class Filler,
+              std::enable_if_t<IsCallable<Filler,int,int,int,int,int,
+                                          Array4<HYPRE_Int const> const*,
+                                          HYPRE_Int&, HYPRE_Int*,
+                                          HYPRE_Real*>::value,int> FOO = 0>
+    void fill_matrix (Filler const& filler);
+
+    template <class MF, std::enable_if_t<IsFabArray<MF>::value &&
+                                         std::is_same_v<typename MF::value_type,
+                                                        HYPRE_Real>, int> = 0>
+    void load_vectors (Vector<MF      *> const& a_soln,
+                       Vector<MF const*> const& a_rhs);
+
+    template <class MF, std::enable_if_t<IsFabArray<MF>::value &&
+                                         std::is_same_v<typename MF::value_type,
+                                                        HYPRE_Real>, int> = 0>
+    void get_solution (Vector<MF*> const& a_soln);
+
+private:
+
+    int                 m_nvars;
+    Vector<IndexType>   m_index_type;
+    IntVect             m_nghost;
+    Geometry            m_geom;
+    Vector<BoxArray>    m_grids;
+    DistributionMapping m_dmap;
+
+    int         m_verbose;
+    std::string m_options_namespace;
+
+    MPI_Comm m_comm = MPI_COMM_NULL;
+
+    Vector<std::unique_ptr<iMultiFab>>        m_owner_mask;
+    Vector<iMultiFab>                         m_local_id;
+    Vector<FabArray<BaseFab<HYPRE_Int>>>      m_global_id;
+    LayoutData<Gpu::DeviceVector<HYPRE_Int>>  m_global_id_vec;
+
+#ifdef AMREX_USE_GPU
+    LayoutData<Gpu::DeviceVector<int>> m_cell_offset;
+#endif
+
+    Vector<LayoutData<HYPRE_Int>> m_nrows_grid;
+    Vector<LayoutData<HYPRE_Int>> m_id_offset;
+    LayoutData<HYPRE_Int>         m_nrows;
+    HYPRE_Int                     m_nrows_proc;
+
+    std::unique_ptr<HypreIJIface> m_hypre_ij;
+
+    // Non-owning references to Hypre matrix, rhs, and solution data
+    HYPRE_IJMatrix m_A = nullptr;
+    HYPRE_IJVector m_b = nullptr;
+    HYPRE_IJVector m_x = nullptr;
+};
+
+template <int MSS>
+template <class Marker, class Filler>
+HypreSolver<MSS>::HypreSolver (Vector<IndexType>   const& a_index_type,
+                               IntVect             const& a_nghost,
+                               Geometry            const& a_geom,
+                               BoxArray            const& a_grids,
+                               DistributionMapping const& a_dmap,
+                               Marker                  && a_marker,
+                               Filler                  && a_filler,
+                               int                        a_verbose,
+                               std::string         const& a_options_namespace)
+    : m_nvars            (a_index_type.size()),
+      m_index_type       (a_index_type),
+      m_nghost           (a_nghost),
+      m_geom             (a_geom),
+      m_dmap             (a_dmap),
+      m_verbose          (a_verbose),
+      m_options_namespace(a_options_namespace)
+{
+    BL_PROFILE("HypreSolver()");
+
+#ifdef AMREX_USE_MPI
+    m_comm = ParallelContext::CommunicatorSub();
+#endif
+
+    m_grids.resize(m_nvars);
+    m_local_id.resize(m_nvars);
+    m_global_id.resize(m_nvars);
+    m_nrows_grid.resize(m_nvars);
+    m_id_offset.resize(m_nvars);
+    Long nrows_max = 0;
+    for (int ivar = 0; ivar < m_nvars; ++ivar) {
+        m_grids     [ivar] = amrex::convert(a_grids,m_index_type[ivar]);
+        m_local_id  [ivar].define(m_grids[ivar], m_dmap, 1, 0);
+        m_global_id [ivar].define(m_grids[ivar], m_dmap, 1, m_nghost);
+        m_nrows_grid[ivar].define(m_grids[0], m_dmap);
+        m_id_offset [ivar].define(m_grids[0], m_dmap);
+        nrows_max += m_grids[ivar].numPts();
+    }
+    m_global_id_vec.define(m_grids[0], m_dmap);
+    m_nrows.define        (m_grids[0], m_dmap);
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(nrows_max < static_cast<Long>(std::numeric_limits<HYPRE_Int>::max()-1),
+                                     "Need to configure Hypre with --enable-bigint");
+
+    m_owner_mask.resize(m_nvars);
+    for (int ivar = 0; ivar < m_nvars; ++ivar) {
+        m_owner_mask[ivar] = amrex::OwnerMask(m_local_id[ivar], m_geom.periodicity());
+    }
+
+#ifdef AMREX_USE_GPU
+    m_cell_offset.define(m_grids[0], m_dmap);
+#endif
+
+    fill_local_id(a_marker);
+
+    // At this point, m_local_id stores the ids local to each box.
+    // m_nrows_grid stroes the number of unique points in each box.
+    // m_nrows_proc is the number of rowss for all variables on this MPI
+    // process.  If a point is invalid, its id is invalid (i.e., a very
+    // negative number).  Note that the data type of local_node_id is int,
+    // not HYPRE_Int for performance on GPU.
+
+    const int nprocs = ParallelContext::NProcsSub();
+    const int myproc = ParallelContext::MyProcSub();
+
+    Vector<HYPRE_Int> nrows_allprocs(nprocs);
+#ifdef AMREX_USE_MPI
+    if (nrows_allprocs.size() > 1) {
+        MPI_Allgather(&m_nrows_proc, sizeof(HYPRE_Int), MPI_CHAR,
+                      nrows_allprocs.data(), sizeof(HYPRE_Int), MPI_CHAR, m_comm);
+    } else
+#endif
+    {
+        nrows_allprocs[0] = m_nrows_proc;
+    }
+
+    HYPRE_Int proc_begin = 0;
+    for (int i = 0; i < myproc; ++i) {
+        proc_begin += nrows_allprocs[i];
+    }
+
+    HYPRE_Int proc_end = proc_begin;
+    for (MFIter mfi(m_nrows_grid[0]); mfi.isValid(); ++mfi) {
+        for (int ivar = 0; ivar < m_nvars; ++ivar) {
+            m_id_offset[ivar][mfi] = proc_end;
+            proc_end += m_nrows_grid[ivar][mfi];
+        }
+    }
+    AMREX_ASSERT(proc_end == proc_begin + m_nrows_proc);
+
+    fill_global_id();
+
+    // Create and initialize A, b & x
+    HYPRE_Int ilower = proc_begin;
+    HYPRE_Int iupper = proc_end-1;
+    m_hypre_ij = std::make_unique<HypreIJIface>(m_comm, ilower, iupper, m_verbose);
+    m_hypre_ij->parse_inputs(m_options_namespace);
+
+    // Obtain non-owning references to the matrix, rhs, and solution data
+    m_A = m_hypre_ij->A();
+    m_b = m_hypre_ij->b();
+    m_x = m_hypre_ij->x();
+
+    fill_matrix(a_filler);
+}
+
+template <int MSS>
+template <class Marker>
+#ifdef AMREX_USE_CUDA
+    std::enable_if_t<IsCallable<Marker,int,int,int,int,int>::value>
+#else
+    std::enable_if_t<IsCallableR<bool,Marker,int,int,int,int,int>::value>
+#endif
+HypreSolver<MSS>::fill_local_id (Marker const& marker)
+{
+    BL_PROFILE("HypreSolver::fill_local_id()");
+
+#ifdef AMREX_USE_GPU
+
+    for (MFIter mfi(m_local_id[0]); mfi.isValid(); ++mfi) {
+        int boxno = mfi.LocalIndex();
+        Long npts_tot = 0;
+        for (int ivar = 0; ivar < m_nvars; ++ivar) {
+            Box const& bx = amrex::convert(mfi.validbox(),m_index_type[ivar]);
+            npts_tot += bx.numPts();
+        }
+        m_cell_offset[mfi].resize(npts_tot);
+        npts_tot = 0;
+        int* p_cell_offset = m_cell_offset[mfi].data();
+        for (int ivar = 0; ivar < m_nvars; ++ivar) {
+            Box const& bx = amrex::convert(mfi.validbox(),m_index_type[ivar]);
+            auto const& lid = m_local_id[ivar].array(mfi);
+            auto const& owner = m_owner_mask[ivar]->const_array(mfi);
+            AMREX_ASSERT(bx.numPts() < static_cast<Long>(std::numeric_limits<int>::max()));
+            const auto npts = static_cast<int>(bx.numPts());
+            int npts_box = amrex::Scan::PrefixSum<int>(npts,
+                [=] AMREX_GPU_DEVICE (int offset) noexcept -> int
+                {
+                    const Dim3 cell = bx.atOffset(offset).dim3();
+                    int id = (owner (      cell.x,cell.y,cell.z     ) &&
+                              marker(boxno,cell.x,cell.y,cell.z,ivar)) ? 1 : 0;
+                    lid(cell.x,cell.y,cell.z) = id;
+                    return id;
+                },
+                [=] AMREX_GPU_DEVICE (int offset, int ps) noexcept
+                {
+                    const Dim3 cell = bx.atOffset(offset).dim3();
+                    if (lid(cell.x,cell.y,cell.z)) {
+                        lid(cell.x,cell.y,cell.z) = ps;
+                        p_cell_offset[ps] = offset;
+                    } else {
+                        lid(cell.x,cell.y,cell.z) = std::numeric_limits<int>::lowest();
+                    }
+                },
+                amrex::Scan::Type::exclusive);
+            m_nrows_grid[ivar][mfi] = npts_box;
+            npts_tot += npts_box;
+            p_cell_offset += npts_box;
+        }
+        m_cell_offset[mfi].resize(npts_tot);
+    }
+
+#else
+
+#ifdef AMREX_USE_OMP
+#pragma omp parallel
+#endif
+    for (MFIter mfi(m_local_id[0]); mfi.isValid(); ++mfi) {
+        int boxno = mfi.LocalIndex();
+        for (int ivar = 0; ivar < m_nvars; ++ivar) {
+            Box const& bx = amrex::convert(mfi.validbox(),m_index_type[ivar]);
+            auto const& lid = m_local_id[ivar].array(mfi);
+            auto const& owner = m_owner_mask[ivar]->const_array(mfi);
+            int id = 0;
+            const auto lo = amrex::lbound(bx);
+            const auto hi = amrex::ubound(bx);
+            for (int k = lo.z; k <= hi.z; ++k) {
+            for (int j = lo.y; j <= hi.y; ++j) {
+            for (int i = lo.x; i <= hi.x; ++i) {
+                if (owner(i,j,k) && marker(boxno,i,j,k,ivar)) {
+                    lid(i,j,k) = id++;
+                } else {
+                    lid(i,j,k) = std::numeric_limits<int>::lowest();
+                }
+            }}}
+            m_nrows_grid[ivar][mfi] = id;
+        }
+    }
+#endif
+
+    m_nrows_proc = 0;
+    for (MFIter mfi(m_nrows); mfi.isValid(); ++mfi) {
+        int nrows = 0;
+        for (int ivar = 0; ivar < m_nvars; ++ivar) {
+            nrows += m_nrows_grid[ivar][mfi];
+        }
+        m_nrows[mfi] = nrows;
+        m_nrows_proc += nrows;
+    }
+}
+
+template <int MSS>
+void
+HypreSolver<MSS>::fill_global_id ()
+{
+    BL_PROFILE("HypreSolver::fill_global_id()");
+
+    // To generate global ids for Hypre, we need to remove duplicates on
+    // nodes shared by multiple Boxes with OverrideSync.  So we need to use
+    // a type that supports atomicAdd.  HYPRE_Int is either int or long
+    // long.  The latter does not have native atomicAdd support in CUDA/HIP.
+    using AtomicInt = std::conditional_t<sizeof(HYPRE_Int) == 4,
+                                         HYPRE_Int, unsigned long long>;
+
+    Vector<FabArray<BaseFab<AtomicInt>>> global_id_raii;
+    Vector<FabArray<BaseFab<AtomicInt>>*> p_global_id;
+    if constexpr (std::is_same<HYPRE_Int, AtomicInt>()) {
+        for (int ivar = 0; ivar < m_nvars; ++ivar) {
+            p_global_id.push_back(&(m_global_id[ivar]));
+        }
+    } else {
+        for (int ivar = 0; ivar < m_nvars; ++ivar) {
+            global_id_raii[ivar].define(m_global_id[ivar].boxArray(),
+                                        m_global_id[ivar].DistributionMap(),
+                                        1, m_global_id[ivar].nGrowVect());
+            p_global_id.push_back(&(global_id_raii[ivar]));
+        }
+    }
+
+#ifdef AMREX_USE_OMP
+#pragma omp parallel if (Gpu::notInLaunchRegion())
+#endif
+    for (MFIter mfi(m_global_id[0]); mfi.isValid(); ++mfi) {
+        auto& rows_vec = m_global_id_vec[mfi];
+        rows_vec.resize(m_nrows[mfi]);
+
+        HYPRE_Int nrows = 0;
+        for (int ivar = 0; ivar < m_nvars; ++ivar) {
+            HYPRE_Int const os = m_id_offset[ivar][mfi];
+            Box bx = mfi.validbox();
+            bx.convert(m_index_type[ivar]).grow(m_nghost);
+            Array4<AtomicInt> const& gid = p_global_id[ivar]->array(mfi);
+            auto const& lid = m_local_id[ivar].const_array(mfi);
+            HYPRE_Int* rows = rows_vec.data() + nrows;
+            nrows += m_nrows_grid[ivar][mfi];
+            amrex::ParallelFor(bx,[=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+            {
+                if (lid.contains(i,j,k) && lid(i,j,k) >= 0) {
+                    const auto id = lid(i,j,k) + os;
+                    rows[lid(i,j,k)] = id;
+                    gid(i,j,k) = static_cast<AtomicInt>(id);
+                } else {
+                    gid(i,j,k) = static_cast<AtomicInt>
+                        (std::numeric_limits<HYPRE_Int>::max());
+                }
+            });
+        }
+    }
+
+    for (int ivar = 0; ivar < m_nvars; ++ivar) {
+        amrex::OverrideSync(*p_global_id[ivar], *m_owner_mask[ivar],
+                            m_geom.periodicity());
+        p_global_id[ivar]->FillBoundary(m_geom.periodicity());
+
+        if constexpr (!std::is_same<HYPRE_Int, AtomicInt>()) {
+            auto const& dst = m_global_id[ivar].arrays();
+            auto const& src = p_global_id[ivar]->const_arrays();
+            amrex::ParallelFor(m_global_id[ivar], m_global_id[ivar].nGrowVect(),
+                               [=] AMREX_GPU_DEVICE (int b, int i, int j, int k)
+            {
+                dst[b](i,j,k) = static_cast<HYPRE_Int>(src[b](i,j,k));
+            });
+        }
+    }
+}
+
+#ifdef AMREX_USE_GPU
+namespace detail {
+template <typename T>
+void pack_matrix_gpu (Gpu::DeviceVector<HYPRE_Int>& cols_tmp,
+                      Gpu::DeviceVector<HYPRE_Real> mat_tmp,
+                      Gpu::DeviceVector<HYPRE_Int>& cols,
+                      Gpu::DeviceVector<HYPRE_Real>& mat)
+{
+    auto* p_cols_tmp = cols_tmp.data();
+    auto* p_mat_tmp  =  mat_tmp.data();
+    auto const* p_cols = cols.data();
+    auto const* p_mat  =  mat.data();
+    const auto N = Long(cols.size());
+    Scan::PrefixSum<T>(N,
+        [=] AMREX_GPU_DEVICE (Long i) -> T
+        {
+            return static_cast<T>(p_cols[i] >= 0);
+        },
+        [=] AMREX_GPU_DEVICE (Long i, T s)
+        {
+            if (p_cols[i] >= 0) {
+                p_cols_tmp[s] = p_cols[i];
+                p_mat_tmp[s] = p_mat[i];
+            }
+        },
+        Scan::Type::exclusive, Scan::noRetSum);
+    std::swap(cols_tmp, cols);
+    std::swap(mat_tmp, mat);
+}
+}
+#endif
+
+template <int MSS>
+template <class Filler,
+          std::enable_if_t<IsCallable<Filler,int,int,int,int,int,
+                                      Array4<HYPRE_Int const> const*,
+                                      HYPRE_Int&, HYPRE_Int*,
+                                      HYPRE_Real*>::value,int> FOO>
+void
+HypreSolver<MSS>::fill_matrix (Filler const& filler)
+{
+    BL_PROFILE("HypreSolver::fill_matrix()");
+
+    Gpu::DeviceVector<HYPRE_Int> ncols_vec;
+    Gpu::DeviceVector<HYPRE_Int> cols_vec;
+    Gpu::DeviceVector<HYPRE_Real> mat_vec;
+
+    MFItInfo mfitinfo;
+    mfitinfo.UseDefaultStream().DisableDeviceSync();
+    for (MFIter mfi(m_local_id[0],mfitinfo); mfi.isValid(); ++mfi)
+    {
+        int boxno = mfi.LocalIndex();
+        const HYPRE_Int nrows = m_nrows[mfi];
+        if (nrows > 0)
+        {
+            ncols_vec.clear();
+            ncols_vec.resize(nrows);
+            HYPRE_Int* ncols = ncols_vec.data();
+
+            cols_vec.clear();
+            cols_vec.resize(Long(nrows)*MSS, -1);
+            HYPRE_Int* cols = cols_vec.data();
+
+            mat_vec.clear();
+            mat_vec.resize(Long(nrows)*MSS);
+            HYPRE_Real* mat = mat_vec.data();
+
+            Vector<Array4<HYPRE_Int const>> gid_v(m_nvars);
+            for (int ivar = 0; ivar < m_nvars; ++ivar) {
+                gid_v[ivar] = m_global_id[ivar].const_array(mfi);
+            }
+
+#ifdef AMREX_USE_GPU
+            const Gpu::Buffer<Array4<HYPRE_Int const>> gid_buf
+                (gid_v.data(), gid_v.size());
+            auto const* pgid = gid_buf.data();
+            auto const* p_cell_offset = m_cell_offset[mfi].data();
+            Long ntot = 0;
+            for (int ivar = 0; ivar < m_nvars; ++ivar) {
+                const HYPRE_Int nrows_var = m_nrows_grid[ivar][mfi];
+                if (nrows_var > 0) {
+                    Box const& bx = amrex::convert(mfi.validbox(),m_index_type[ivar]);
+                    ntot += Reduce::Sum<Long>(nrows_var,
+                                              [=] AMREX_GPU_DEVICE (HYPRE_Int offset)
+                    {
+                        const Dim3 cell = bx.atOffset(p_cell_offset[offset]).dim3();
+                        filler(boxno, cell.x, cell.y, cell.z, ivar, pgid,
+                               ncols[offset], cols+Long(offset)*MSS,
+                               mat+Long(offset)*MSS);
+                        return ncols[offset];
+                    });
+                    p_cell_offset += nrows_var;
+                    ncols += nrows_var;
+                    cols += Long(nrows_var)*MSS;
+                    mat  += Long(nrows_var)*MSS;
+                }
+            }
+            Gpu::DeviceVector<HYPRE_Int> cols_tmp(ntot);
+            Gpu::DeviceVector<HYPRE_Real> mat_tmp(ntot);
+            if (ntot >= Long(std::numeric_limits<int>::max())) {
+                detail::pack_matrix_gpu<Long>(cols_tmp, mat_tmp, cols_vec, mat_vec);
+            } else {
+                detail::pack_matrix_gpu<int>(cols_tmp, mat_tmp, cols_vec, mat_vec);
+            }
+#else
+            auto pgid = gid_v.data();
+            for (int ivar = 0; ivar < m_nvars; ++ivar) {
+                if (m_nrows_grid[ivar][mfi] > 0) {
+                    auto const& lid = m_local_id[ivar].const_array(mfi);
+                    amrex::Loop(amrex::convert(mfi.validbox(),m_index_type[ivar]),
+                                [=,&ncols,&cols,&mat] (int i, int j, int k)
+                    {
+                        if (lid(i,j,k) >= 0) {
+                            filler(boxno, i, j, k, ivar, pgid, *ncols, cols, mat);
+                            cols += (*ncols);
+                            mat  += (*ncols);
+                            ++ncols;
+                        }
+                    });
+                }
+            }
+#endif
+
+            const auto& rows_vec = m_global_id_vec[mfi];
+            HYPRE_Int const* rows = rows_vec.data();
+
+            Gpu::streamSynchronize();
+            HYPRE_IJMatrixSetValues(m_A, nrows, ncols_vec.data(), rows,
+                                    cols_vec.data(), mat_vec.data());
+            Gpu::synchronize();
+        }
+    }
+    HYPRE_IJMatrixAssemble(m_A);
+}
+
+template <int MSS>
+template <class MF, std::enable_if_t<IsFabArray<MF>::value &&
+                                     std::is_same_v<typename MF::value_type,
+                                                    HYPRE_Real>, int> FOO>
+void
+HypreSolver<MSS>::solve (Vector<MF      *> const& a_soln,
+                         Vector<MF const*> const& a_rhs,
+                         HYPRE_Real rel_tol, HYPRE_Real abs_tol, int max_iter)
+{
+    BL_PROFILE("HypreSolver::solve()");
+
+    AMREX_ASSERT(a_soln.size() == m_nvars && a_rhs.size() == m_nvars);
+
+    HYPRE_IJVectorInitialize(m_b);
+    HYPRE_IJVectorInitialize(m_x);
+
+    load_vectors(a_soln, a_rhs);
+
+    HYPRE_IJVectorAssemble(m_x);
+    HYPRE_IJVectorAssemble(m_b);
+
+    m_hypre_ij->solve(rel_tol, abs_tol, max_iter);
+
+    get_solution(a_soln);
+}
+
+template <int MSS>
+template <class MF, std::enable_if_t<IsFabArray<MF>::value &&
+                                     std::is_same_v<typename MF::value_type,
+                                                    HYPRE_Real>, int> FOO>
+void
+HypreSolver<MSS>::load_vectors (Vector<MF      *> const& a_soln,
+                                Vector<MF const*> const& a_rhs)
+{
+    BL_PROFILE("HypreSolver::load_vectors()");
+
+    MFItInfo mfitinfo;
+    mfitinfo.UseDefaultStream().DisableDeviceSync();
+
+    Gpu::DeviceVector<Real> xvec;
+    Gpu::DeviceVector<Real> bvec;
+    for (MFIter mfi(*a_soln[0],mfitinfo); mfi.isValid(); ++mfi)
+    {
+        const HYPRE_Int nrows = m_nrows[mfi];
+        if (nrows > 0)
+        {
+            xvec.clear();
+            xvec.resize(nrows);
+            bvec.clear();
+            bvec.resize(nrows);
+            auto xp = xvec.data();
+            auto bp = bvec.data();
+
+            HYPRE_Int const* rows = m_global_id_vec[mfi].data();
+
+            HYPRE_Int offset = 0;
+            for (int ivar = 0; ivar < m_nvars; ++ivar) {
+                if (m_nrows_grid[ivar][mfi] > 0) {
+                    auto const& xfab = a_soln[ivar]->const_array(mfi);
+                    auto const& bfab = a_rhs [ivar]->const_array(mfi);
+                    auto const& lid = m_local_id[ivar].const_array(mfi);
+                    HYPRE_Real* x = xp + offset;
+                    HYPRE_Real* b = bp + offset;
+                    Box box = amrex::convert(mfi.validbox(),m_index_type[ivar]);
+                    amrex::ParallelFor(box,[=] AMREX_GPU_DEVICE (int i, int j, int k)
+                    {
+                        if (lid(i,j,k) >= 0) {
+                            x[lid(i,j,k)] = xfab(i,j,k);
+                            b[lid(i,j,k)] = bfab(i,j,k);
+                        }
+                    });
+                    offset += m_nrows_grid[ivar][mfi];
+                }
+            }
+
+            Gpu::streamSynchronize();
+            HYPRE_IJVectorSetValues(m_x, nrows, rows, xp);
+            HYPRE_IJVectorSetValues(m_b, nrows, rows, bp);
+            Gpu::synchronize();
+        }
+    }
+}
+
+template <int MSS>
+template <class MF, std::enable_if_t<IsFabArray<MF>::value &&
+                                     std::is_same_v<typename MF::value_type,
+                                                    HYPRE_Real>, int> FOO>
+void
+HypreSolver<MSS>::get_solution (Vector<MF*> const& a_soln)
+{
+    BL_PROFILE("HypreSolver::get_solution()");
+
+    MFItInfo mfitinfo;
+    mfitinfo.UseDefaultStream().DisableDeviceSync();
+
+    Gpu::DeviceVector<Real> xvec;
+    for (MFIter mfi(*a_soln[0],mfitinfo); mfi.isValid(); ++mfi)
+    {
+        const HYPRE_Int nrows = m_nrows[mfi];
+        if (nrows > 0)
+        {
+            xvec.clear();
+            xvec.resize(nrows);
+            auto xp = xvec.data();
+
+            HYPRE_Int const* rows = m_global_id_vec[mfi].data();
+
+            HYPRE_IJVectorGetValues(m_x, nrows, rows, xp);
+            Gpu::synchronize();
+
+            HYPRE_Int offset = 0;
+            for (int ivar = 0; ivar < m_nvars; ++ivar) {
+                if (m_nrows_grid[ivar][mfi] > 0) {
+                    auto const& xfab = a_soln[ivar]->array(mfi);
+                    auto const& lid = m_local_id[ivar].const_array(mfi);
+                    HYPRE_Real* x = xp + offset;
+                    Box box = amrex::convert(mfi.validbox(),m_index_type[ivar]);
+                    amrex::ParallelFor(box,[=] AMREX_GPU_DEVICE (int i, int j, int k)
+                    {
+                        if (lid(i,j,k) >= 0) {
+                            xfab(i,j,k) = x[lid(i,j,k)];
+                        }
+                    });
+                    offset += m_nrows_grid[ivar][mfi];
+                }
+            }
+            Gpu::streamSynchronize();
+        }
+    }
+
+    for (int ivar = 0; ivar < m_nvars; ++ivar) {
+        amrex::OverrideSync(*a_soln[ivar], *m_owner_mask[ivar],
+                            m_geom.periodicity());
+    }
+}
+
+}
+
+#endif

--- a/Src/Extern/HYPRE/CMakeLists.txt
+++ b/Src/Extern/HYPRE/CMakeLists.txt
@@ -41,6 +41,7 @@ foreach(D IN LISTS AMReX_SPACEDIM)
           AMReX_HypreNodeLap.H
           AMReX_HypreIJIface.cpp
           AMReX_HypreIJIface.H
+          AMReX_HypreSolver.H
           )
 
     endif ()

--- a/Src/Extern/HYPRE/Make.package
+++ b/Src/Extern/HYPRE/Make.package
@@ -9,6 +9,7 @@ CEXE_headers += AMReX_Habec_$(DIM)D_K.H
 CEXE_headers += AMReX_Habec_K.H
 CEXE_headers += AMReX_HypreNodeLap.H AMReX_HypreIJIface.H
 CEXE_sources += AMReX_HypreNodeLap.cpp AMReX_HypreIJIface.cpp
+CEXE_headers += AMReX_HypreSolver.H
 
 VPATH_LOCATIONS += $(AMREX_HOME)/Src/Extern/HYPRE
 INCLUDE_LOCATIONS += $(AMREX_HOME)/Src/Extern/HYPRE

--- a/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap.cpp
@@ -1282,7 +1282,7 @@ std::unique_ptr<Hypre>
 MLEBABecLap::makeHypre (Hypre::Interface hypre_interface) const
 {
     auto hypre_solver = MLCellABecLap::makeHypre(hypre_interface);
-    auto ijmatrix_solver = dynamic_cast<HypreABecLap3*>(hypre_solver.get());
+    auto* ijmatrix_solver = dynamic_cast<HypreABecLap3*>(hypre_solver.get());
     ijmatrix_solver->setEBDirichlet(m_eb_b_coeffs[0].back().get());
     return hypre_solver;
 }

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLap_2D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLap_2D_K.H
@@ -2362,7 +2362,7 @@ template <typename HypreInt, typename AtomicInt>
 void mlndlap_fillijmat_sten_cpu (Box const& ndbx,
                                  Array4<AtomicInt const> const& gid,
                                  Array4<int const> const& lid,
-                                 HypreInt* const ncols, HypreInt* const cols, Real* const mat,
+                                 HypreInt* const ncols, HypreInt* const cols, Real* const mat, // NOLINT(readability-non-const-parameter)
                                  Array4<Real const> const& sten) noexcept
 {
     constexpr auto gidmax = std::numeric_limits<AtomicInt>::max();
@@ -2433,7 +2433,7 @@ template <typename HypreInt, typename AtomicInt>
 void mlndlap_fillijmat_aa_cpu (Box const& ndbx,
                                Array4<AtomicInt const> const& gid,
                                Array4<int const> const& lid,
-                               HypreInt* const ncols, HypreInt* const cols, Real* const mat,
+                               HypreInt* const ncols, HypreInt* const cols, Real* const mat, // NOLINT(readability-non-const-parameter)
                                Array4<Real const> const& sig,
                                GpuArray<Real,AMREX_SPACEDIM> const& dxinv,
                                Box const& ccdom, bool is_rz) noexcept
@@ -2580,7 +2580,7 @@ template <typename HypreInt, typename AtomicInt>
 void mlndlap_fillijmat_ha_cpu (Box const& ndbx,
                                Array4<AtomicInt const> const& gid,
                                Array4<int const> const& lid,
-                               HypreInt* const ncols, HypreInt* const cols, Real* const mat,
+                               HypreInt* const ncols, HypreInt* const cols, Real* const mat, // NOLINT(readability-non-const-parameter)
                                Array4<Real const> const& sx,
                                Array4<Real const> const& sy,
                                GpuArray<Real,AMREX_SPACEDIM> const& dxinv,
@@ -2733,7 +2733,7 @@ template <typename HypreInt, typename AtomicInt>
 void mlndlap_fillijmat_cs_cpu (Box const& ndbx,
                                Array4<AtomicInt const> const& gid,
                                Array4<int const> const& lid,
-                               HypreInt* const ncols, HypreInt* const cols, Real* const mat,
+                               HypreInt* const ncols, HypreInt* const cols, Real* const mat, // NOLINT(readability-non-const-parameter)
                                Real const sig,
                                GpuArray<Real,AMREX_SPACEDIM> const& dxinv,
                                Box const& ccdom, bool is_rz) noexcept

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeTensorLap_2D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeTensorLap_2D_K.H
@@ -121,7 +121,7 @@ template <typename HypreInt, typename AtomicInt>
 void mlndtslap_fill_ijmatrix_cpu (Box const& ndbx,
                                   Array4<AtomicInt const> const& gid,
                                   Array4<int const> const& lid,
-                                  HypreInt* const ncols, HypreInt* const cols, Real* const mat,
+                                  HypreInt* const ncols, HypreInt* const cols, Real* const mat, // NOLINT(readability-non-const-parameter)
                                   GpuArray<Real,3> const& s) noexcept
 {
     constexpr auto gidmax = std::numeric_limits<AtomicInt>::max();

--- a/Tests/LinearSolvers/Hypre/GNUmakefile
+++ b/Tests/LinearSolvers/Hypre/GNUmakefile
@@ -1,0 +1,33 @@
+DEBUG = FALSE
+TEST = FALSE
+USE_ASSERTION = FALSE
+
+USE_EB = TRUE
+
+USE_MPI  = TRUE
+USE_OMP  = FALSE
+
+USE_HYPRE = TRUE
+
+COMP = gnu
+
+DIM = 2
+
+BL_NO_FORT = TRUE
+
+AMREX_HOME = ../../..
+
+include $(AMREX_HOME)/Tools/GNUMake/Make.defs
+
+include ./Make.package
+
+Pdirs := Base Boundary AmrCore EB
+Pdirs += LinearSolvers/MLMG
+Pdirs += Extern/HYPRE
+
+Ppack	+= $(foreach dir, $(Pdirs), $(AMREX_HOME)/Src/$(dir)/Make.package)
+
+include $(Ppack)
+
+include $(AMREX_HOME)/Tools/GNUMake/Make.rules
+

--- a/Tests/LinearSolvers/Hypre/Make.package
+++ b/Tests/LinearSolvers/Hypre/Make.package
@@ -1,0 +1,5 @@
+
+CEXE_sources += main.cpp
+CEXE_sources += MyTest.cpp initEB.cpp
+CEXE_headers += MyTest.H
+

--- a/Tests/LinearSolvers/Hypre/MyTest.H
+++ b/Tests/LinearSolvers/Hypre/MyTest.H
@@ -1,0 +1,39 @@
+#ifndef MY_TEST_H_
+#define MY_TEST_H_
+
+#include <AMReX_MultiFab.H>
+
+class MyTest
+{
+public:
+
+    MyTest ();
+    void solve ();
+    void initData ();
+
+private:
+
+    void initializeEB ();
+    void readParameters ();
+    void initGrids ();
+
+    int n_cell = 128;
+    int max_grid_size = 64;
+
+    amrex::Real phi_domain = 0.0;
+    amrex::Real phi_eb = 1.0;
+
+    int verbose = 2;
+    int max_iter = 100;
+    amrex::Real reltol = 1.e-11;
+
+    amrex::Geometry geom;
+    amrex::BoxArray grids;
+    amrex::DistributionMapping dmap;
+    std::unique_ptr<amrex::EBFArrayBoxFactory> factory;
+
+    amrex::MultiFab phi;
+    amrex::MultiFab rhs;
+};
+
+#endif

--- a/Tests/LinearSolvers/Hypre/MyTest.cpp
+++ b/Tests/LinearSolvers/Hypre/MyTest.cpp
@@ -216,7 +216,7 @@ MyTest::solve ()
                 srhs -= s/hm * peb;
             }
 
-#if (AMREX_SPACEDIM == 3)
+#if (AMREX_SPACEDIM > 2)
             hp = (!ecz || ecz(i,j,k) == Real(1.0)) ? Real(1.0) : (Real(1.0)+Real(2.)*ecz(i,j,k));
             hm = (!ecz || ecz(i,j,k-1) == Real(1.0)) ? Real(1.0) : (Real(1.0)-Real(2.)*ecz(i,j,k-1));
             scale = std::min({scale, hp, hm});

--- a/Tests/LinearSolvers/Hypre/MyTest.cpp
+++ b/Tests/LinearSolvers/Hypre/MyTest.cpp
@@ -1,0 +1,321 @@
+#include "MyTest.H"
+
+#include <AMReX_ParmParse.H>
+#include <AMReX_MultiFabUtil.H>
+#include <AMReX_EBMultiFabUtil.H>
+#include <AMReX_VisMF.H>
+#include <AMReX_EB2.H>
+#include <AMReX_HypreSolver.H>
+
+#include <cmath>
+
+using namespace amrex;
+
+MyTest::MyTest ()
+{
+    readParameters();
+
+    initGrids();
+
+    initializeEB();
+
+    initData();
+}
+
+void
+MyTest::solve ()
+{
+    // In this example, we assume the domain boundary is homegeneous Dirichlet.
+
+    auto const& nddom = amrex::surroundingNodes(geom.Domain());
+    const auto dxi = geom.InvCellSizeArray();
+    GpuArray<HYPRE_Real,AMREX_SPACEDIM> fac
+        {AMREX_D_DECL(static_cast<HYPRE_Real>(dxi[0]*dxi[0]),
+                      static_cast<HYPRE_Real>(dxi[1]*dxi[1]),
+                      static_cast<HYPRE_Real>(dxi[2]*dxi[2]))};
+
+    if (factory->isAllRegular())
+    {
+        HYPRE_Real fac0 = HYPRE_Real(-2.)*(AMREX_D_TERM(fac[0],+fac[1],+fac[2]));
+
+        // Is variable n at (i,j,k) in Box boxno (local index) valid?
+        // (i.e., not exactly on Dirichlet boundary)
+        auto marker = [=] AMREX_GPU_DEVICE (int /*boxno*/, int i, int j, int k, int /*n*/)
+            -> bool
+        {
+            return nddom.strictly_contains(i,j,k);
+        };
+
+        // For variable n at (i,j,k) in Box boxno (local index), fill its row in
+        // the matrix.
+        // [in ] gid : gid[n] is the id for variable n at (i,j,k)
+        // [out] nols: # of columns in this row.
+        // [out] cols: column indices in this row.
+        // [out] mat : matrix elemens in this row.
+        auto filler = [=] AMREX_GPU_DEVICE (int /*boxno*/, int i, int j, int k, int n,
+                                            Array4<HYPRE_Int const> const* gid,
+                                            HYPRE_Int& ncols, HYPRE_Int* cols,
+                                            HYPRE_Real* mat)
+        {
+            ncols = 0;
+            if (i > nddom.smallEnd(0)+1) {
+                cols[ncols] = gid[n](i-1,j,k);
+                mat [ncols] = fac[0];
+                ++ncols;
+            }
+            if (i < nddom.bigEnd(0)-1) {
+                cols[ncols] = gid[n](i+1,j,k);
+                mat [ncols] = fac[0];
+                ++ncols;
+            }
+            if (j > nddom.smallEnd(1)+1) {
+                cols[ncols] = gid[n](i,j-1,k);
+                mat [ncols] = fac[1];
+                ++ncols;
+            }
+            if (j < nddom.bigEnd(1)-1) {
+                cols[ncols] = gid[n](i,j+1,k);
+                mat [ncols] = fac[1];
+                ++ncols;
+            }
+#if (AMREX_SPACEDIM > 2)
+            if (k > nddom.smallEnd(2)+1) {
+                cols[ncols] = gid[n](i,j,k-1);
+                mat [ncols] = fac[2];
+                ++ncols;
+            }
+            if (k < nddom.bigEnd(2)-1) {
+                cols[ncols] = gid[n](i,j,k+1);
+                mat [ncols] = fac[2];
+                ++ncols;
+            }
+#endif
+            cols[ncols] = gid[n](i,j,k);
+            mat [ncols] = fac0;
+            ++ncols;
+        };
+
+        constexpr int max_stencil_size = 2*AMREX_SPACEDIM+1;
+        HypreSolver<max_stencil_size> hypre_solver
+            ({IndexType::TheNodeType()}, IntVect(1), geom, grids, dmap,
+             marker, filler, verbose);
+
+        hypre_solver.solve(Vector<MultiFab*>{&phi}, Vector<MultiFab const*>{&rhs},
+                           reltol, 0.0, max_iter);
+    }
+    else
+    {
+        auto const& levset_mf = factory->getLevelSet();
+        auto const& levset_a = levset_mf.const_arrays();
+        auto const& edgecent = factory->getEdgeCent();
+        AMREX_D_TERM(auto const& ecx_a = edgecent[0]->const_arrays();,
+                     auto const& ecy_a = edgecent[1]->const_arrays();,
+                     auto const& ecz_a = edgecent[2]->const_arrays());
+        auto const& rhs_a = rhs.arrays();
+
+        // Is variable n at (i,j,k) in Box boxno (local index) valid?
+        // (i.e., not exactly on Dirichlet boundary, not covered)
+        auto marker = [=] AMREX_GPU_DEVICE (int boxno, int i, int j, int k, int /*n*/)
+            -> bool
+        {
+            // level set < 0 means the node is in the fluid and valid.
+            return nddom.strictly_contains(i,j,k) && (levset_a[boxno](i,j,k) < Real(0.));
+        };
+
+        auto peb = phi_eb;
+        auto pdom = phi_domain;
+        auto dlo = amrex::lbound(nddom);
+        auto dhi = amrex::ubound(nddom);
+
+        // For variable n at (i,j,k) in Box boxno (local index), fill its row in
+        // the matrix.
+        // [in ] gid : gid[n] is the id for variable n at (i,j,k)
+        // [out] nols: # of columns in this row.
+        // [out] cols: column indices in this row.
+        // [out] mat : matrix elemens in this row.
+        auto filler = [=] AMREX_GPU_DEVICE (int boxno, int i, int j, int k, int n,
+                                            Array4<HYPRE_Int const> const* gid,
+                                            HYPRE_Int& ncols, HYPRE_Int* cols,
+                                            HYPRE_Real* mat)
+        {
+            ncols = 0;
+
+            AMREX_D_TERM(auto const& ecx = ecx_a[boxno];,
+                         auto const& ecy = ecy_a[boxno];,
+                         auto const& ecz = ecz_a[boxno]);
+            auto const& levset = levset_a[boxno];
+
+            Real hp, hm;
+            Real scale = Real(1.0);
+            Real s0 = Real(0.0);
+            Real srhs = Real(0.0);
+
+            hp = (!ecx || ecx(i,j,k) == Real(1.0)) ? Real(1.0) : (Real(1.0)+Real(2.)*ecx(i,j,k));
+            hm = (!ecx || ecx(i-1,j,k) == Real(1.0)) ? Real(1.0) : (Real(1.0)-Real(2.)*ecx(i-1,j,k));
+            scale = std::min({scale, hp, hm});
+            Real s = fac[0]*Real(2.0)/(hp+hm);
+
+            if (levset(i+1,j,k) < Real(0.0)) {
+                s0 -= s;
+                if (i+1 < dhi.x) {
+                    cols[ncols] = gid[n](i+1,j,k);
+                    mat[ncols] = s;
+                    ++ncols;
+                } else {
+                    srhs -= s * pdom;
+                }
+            } else {
+                s0   -= s/hp;
+                srhs -= s/hp * peb;
+            }
+
+            if (levset(i-1,j,k) < Real(0.0)) {
+                s0 -= s;
+                if (i-1 > dlo.x) {
+                    cols[ncols] = gid[n](i-1,j,k);
+                    mat[ncols] = s;
+                    ++ncols;
+                } else {
+                    srhs -= s * pdom;
+                }
+            } else {
+                s0   -= s/hm;
+                srhs -= s/hm * peb;
+            }
+
+            hp = (!ecy || ecy(i,j,k) == Real(1.0)) ? Real(1.0) : (Real(1.0)+Real(2.)*ecy(i,j,k));
+            hm = (!ecy || ecy(i,j-1,k) == Real(1.0)) ? Real(1.0) : (Real(1.0)-Real(2.)*ecy(i,j-1,k));
+            scale = std::min({scale, hp, hm});
+            s = fac[1]*Real(2.0)/(hp+hm);
+
+            if (levset(i,j+1,k) < Real(0.0)) {
+                s0 -= s;
+                if (j+1 < dhi.y) {
+                    cols[ncols] = gid[n](i,j+1,k);
+                    mat[ncols] = s;
+                    ++ncols;
+                } else {
+                    srhs -= s * pdom;
+                }
+            } else {
+                s0   -= s/hp;
+                srhs -= s/hp * peb;
+            }
+
+            if (levset(i,j-1,k) < Real(0.0)) {
+                s0 -= s;
+                if (j-1 > dlo.y) {
+                    cols[ncols] = gid[n](i,j-1,k);
+                    mat[ncols] = s;
+                    ++ncols;
+                } else {
+                    srhs -= s * pdom;
+                }
+            } else {
+                s0   -= s/hm;
+                srhs -= s/hm * peb;
+            }
+
+#if (AMREX_SPACEDIM == 3)
+            hp = (!ecz || ecz(i,j,k) == Real(1.0)) ? Real(1.0) : (Real(1.0)+Real(2.)*ecz(i,j,k));
+            hm = (!ecz || ecz(i,j,k-1) == Real(1.0)) ? Real(1.0) : (Real(1.0)-Real(2.)*ecz(i,j,k-1));
+            scale = std::min({scale, hp, hm});
+            s = fac[2]*Real(2.0)/(hp+hm);
+
+            if (levset(i,j,k+1) < Real(0.0)) {
+                s0 -= s;
+                if (k+1 < dhi.z) {
+                    cols[ncols] = gid[n](i,j,k+1);
+                    mat[ncols] = s;
+                    ++ncols;
+                } else {
+                    srhs -= s * pdom;
+                }
+            } else {
+                s0   -= s/hp;
+                srhs -= s/hp * peb;
+            }
+
+            if (levset(i,j,k-1) < Real(0.0)) {
+                s0 -= s;
+                if (k-1 > dlo.z) {
+                    cols[ncols] = gid[n](i,j,k-1);
+                    mat[ncols] = s;
+                    ++ncols;
+                } else {
+                    srhs -= s * pdom;
+                }
+            } else {
+                s0   -= s/hm;
+                srhs -= s/hm * peb;
+            }
+#endif
+
+            for (int icol = 0; icol < ncols; ++icol) {
+                mat[icol] *= scale;
+            }
+
+            cols[ncols] = gid[n](i,j,k);
+            mat [ncols] = s0*scale;
+            ++ncols;
+
+            rhs_a[boxno](i,j,k,n) += srhs;
+            rhs_a[boxno](i,j,k,n) *= scale;
+        };
+
+        constexpr int max_stencil_size = 2*AMREX_SPACEDIM+1;
+        HypreSolver<max_stencil_size> hypre_solver
+            ({IndexType::TheNodeType()}, IntVect(1), geom, grids, dmap,
+             marker, filler, verbose);
+
+        hypre_solver.solve(Vector<MultiFab*>{&phi}, Vector<MultiFab const*>{&rhs},
+                           reltol, 0.0, max_iter);
+    }
+
+    amrex::VisMF::Write(phi, "phi");
+}
+
+void
+MyTest::readParameters ()
+{
+    ParmParse pp;
+    pp.query("n_cell", n_cell);
+    pp.query("max_grid_size", max_grid_size);
+
+    pp.query("phi_domain", phi_domain);
+    pp.query("phi_eb", phi_eb);
+
+    pp.query("verbose", verbose);
+    pp.query("max_iter", max_iter);
+    pp.query("reltol", reltol);
+}
+
+void
+MyTest::initGrids ()
+{
+    Box domain0(IntVect{AMREX_D_DECL(0,0,0)}, IntVect{AMREX_D_DECL(n_cell-1,n_cell-1,n_cell-1)});
+    RealBox rb({AMREX_D_DECL(0.,0.,0.)}, {AMREX_D_DECL(1.,1.,1.)});
+    std::array<int,AMREX_SPACEDIM> isperiodic{AMREX_D_DECL(0,0,0)};
+    geom.define(domain0, &rb, 0, isperiodic.data());
+
+    grids.define(domain0);
+    grids.maxSize(max_grid_size);
+}
+
+void
+MyTest::initData ()
+{
+    dmap.define(grids);
+    const EB2::IndexSpace& eb_is = EB2::IndexSpace::top();
+    const EB2::Level& eb_level = eb_is.getLevel(geom);
+    factory = std::make_unique<EBFArrayBoxFactory>
+        (eb_level, geom, grids, dmap, Vector<int>{1,1,1}, EBSupport::full);
+
+    BoxArray const& nba = amrex::convert(grids, IntVect(1));
+
+    phi.define(nba, dmap, 1, 0, MFInfo(), *factory);
+    rhs.define(nba, dmap, 1, 0, MFInfo(), *factory);
+
+    phi.setVal(0.0);
+    rhs.setVal(1.0);
+}

--- a/Tests/LinearSolvers/Hypre/MyTest.cpp
+++ b/Tests/LinearSolvers/Hypre/MyTest.cpp
@@ -49,7 +49,7 @@ MyTest::solve ()
         // For variable n at (i,j,k) in Box boxno (local index), fill its row in
         // the matrix.
         // [in ] gid : gid[n] is the id for variable n at (i,j,k)
-        // [out] nols: # of columns in this row.
+        // [out] ncols: # of columns in this row.
         // [out] cols: column indices in this row.
         // [out] mat : matrix elemens in this row.
         auto filler = [=] AMREX_GPU_DEVICE (int /*boxno*/, int i, int j, int k, int n,

--- a/Tests/LinearSolvers/Hypre/MyTest.cpp
+++ b/Tests/LinearSolvers/Hypre/MyTest.cpp
@@ -130,7 +130,7 @@ MyTest::solve ()
         // For variable n at (i,j,k) in Box boxno (local index), fill its row in
         // the matrix.
         // [in ] gid : gid[n] is the id for variable n at (i,j,k)
-        // [out] nols: # of columns in this row.
+        // [out] ncols: # of columns in this row.
         // [out] cols: column indices in this row.
         // [out] mat : matrix elemens in this row.
         auto filler = [=] AMREX_GPU_DEVICE (int boxno, int i, int j, int k, int n,

--- a/Tests/LinearSolvers/Hypre/initEB.cpp
+++ b/Tests/LinearSolvers/Hypre/initEB.cpp
@@ -1,0 +1,11 @@
+
+#include <AMReX_EB2.H>
+#include "MyTest.H"
+
+using namespace amrex;
+
+void
+MyTest::initializeEB ()
+{
+    EB2::Build(geom, 0, 0);
+}

--- a/Tests/LinearSolvers/Hypre/inputs.2d
+++ b/Tests/LinearSolvers/Hypre/inputs.2d
@@ -1,0 +1,14 @@
+amrex.fpe_trap_invalid = 1
+
+verbose = 2
+reltol = 1.e-11
+
+n_cell = 128
+max_grid_size = 64
+
+eb2.geom_type = sphere
+eb2.sphere_center = 0.5  0.5  0.5
+eb2.sphere_radius = 0.13
+eb2.sphere_has_fluid_inside = 0
+
+#eb2.geom_type = all_regular

--- a/Tests/LinearSolvers/Hypre/main.cpp
+++ b/Tests/LinearSolvers/Hypre/main.cpp
@@ -1,0 +1,17 @@
+
+#include <AMReX.H>
+#include <AMReX_ParmParse.H>
+#include "MyTest.H"
+
+int main (int argc, char* argv[])
+{
+    amrex::Initialize(argc, argv);
+
+    {
+        BL_PROFILE("main");
+        MyTest mytest;
+        mytest.solve();
+    }
+
+    amrex::Finalize();
+}


### PR DESCRIPTION
Add a new interface class for Hypre. The existing Hypre interface classes are all tightly coupled with MLMG, and are therefore not usable for linear systems not supported by MLMG. In that case, one can use this new class.
