### PR TITLE
Doc: Real/ParticleReal Doxygen

### DIFF
--- a/Src/Base/AMReX_REAL.H
+++ b/Src/Base/AMReX_REAL.H
@@ -66,9 +66,28 @@ typedef double amrex_particle_real;
 
 #ifdef __cplusplus
 namespace amrex {
+    /** Floating Point Type for Fields
+     *
+     * This is a floating point type used by default for fields such as
+     * FabArray and MultiFab classes. This can be changed at compile time to
+     * run double, single or experimental floating point precisions for field
+     * computations and storage.
+     */
     using Real = amrex_real;
+
+    /** Floating Point Type for Particles
+     *
+     * This is a floating point type used by default for ParticleContainer and
+     * related particle classes. This can be changed at compile time to run
+     * double, single or experimental floating point precisions for particle
+     * computations and storage.
+     */
     using ParticleReal = amrex_particle_real;
 
+/** Floating point literals for AMReX precision.
+ *
+ * This namespace can be used to write typed numeric literals in expressions.
+ */
 inline namespace literals {
 
     /** @{

--- a/Src/Base/AMReX_REAL.H
+++ b/Src/Base/AMReX_REAL.H
@@ -69,7 +69,7 @@ namespace amrex {
     /** Floating Point Type for Fields
      *
      * This is a floating point type used by default for fields such as
-     * FabArray and MultiFab classes. This can be changed at compile time to
+     * FArrayBox and MultiFab classes. This can be changed at compile time to
      * run double, single or experimental floating point precisions for field
      * computations and storage.
      */


### PR DESCRIPTION
## Summary

Add missing doxygen string, so users can click through on important AMReX types when they look at API documentation.

## Additional background

First seen in missing links in https://impactx.readthedocs.io/en/latest/_static/doxyhtml/classimpactx_1_1_impact_x_particle_container.html#a8cabfd7912cd98a8871bc75734474472

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [x] include documentation in the code and/or rst files, if appropriate
