### PR TITLE
Fix bug in EBNodeFDLap

### DIFF
--- a/Src/LinearSolvers/MLMG/AMReX_MLEBNodeFDLap_2D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBNodeFDLap_2D_K.H
@@ -21,7 +21,8 @@ void mlebndfdlap_scale_rhs (int i, int j, int, Array4<Real> const& rhs,
 template <typename F>
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 void mlebndfdlap_adotx_eb_doit (int i, int j, int k, Array4<Real> const& y,
-                                Array4<Real const> const& x, Array4<int const> const& dmsk,
+                                Array4<Real const> const& x, Array4<Real const> const& levset,
+                                Array4<int const> const& dmsk,
                                 Array4<Real const> const& ecx, Array4<Real const> const& ecy,
                                 F && xeb, Real bx, Real by) noexcept
 {
@@ -30,38 +31,35 @@ void mlebndfdlap_adotx_eb_doit (int i, int j, int k, Array4<Real> const& y,
     } else {
         Real tmp;
         Real hp, hm, scale, out;
-        if (ecx(i,j,k) == Real(1.0)) { // regular
-            hp = Real(1.0);
+
+        hp = (ecx(i,j,k) == Real(1.0)) ? Real(1.0) : (Real(1.0)+Real(2.)*ecx(i,j,k));
+        if (levset(i+1,j,k) < Real(0.0)) {
             tmp = x(i+1,j,k) - x(i,j,k);
         } else {
-            hp = Real(1.0) + Real(2.) * ecx(i,j,k);
             tmp = (xeb(i+1,j,k) - x(i,j,k)) / hp;
         }
 
-        if (ecx(i-1,j,k) == Real(1.0)) {
-            hm = Real(1.0);
+        hm = (ecx(i-1,j,k) == Real(1.0)) ? Real(1.0) : (Real(1.0)-Real(2.)*ecx(i-1,j,k));
+        if (levset(i-1,j,k) < Real(0.0)) {
             tmp += x(i-1,j,k) - x(i,j,k);
         } else {
-            hm = Real(1.0) - Real(2.) * ecx(i-1,j,k);
             tmp += (xeb(i-1,j,k) - x(i,j,k)) / hm;
         }
 
         out = tmp * bx * Real(2.0) / (hp+hm);
         scale = amrex::min(hm, hp);
 
-        if (ecy(i,j,k) == Real(1.0)) {
-            hp = Real(1.0);
+        hp = (ecy(i,j,k) == Real(1.0)) ? Real(1.0) : (Real(1.0)+Real(2.)*ecy(i,j,k));
+        if (levset(i,j+1,k) < Real(0.0)) {
             tmp = x(i,j+1,k) - x(i,j,k);
         } else {
-            hp = Real(1.0) + Real(2.) * ecy(i,j,k);
             tmp = (xeb(i,j+1,k) - x(i,j,k)) / hp;
         }
 
-        if (ecy(i,j-1,k) == Real(1.0)) {
-            hm = Real(1.0);
+        hm = (ecy(i,j-1,k) == Real(1.0)) ? Real(1.0) : (Real(1.0)-Real(2.)*ecy(i,j-1,k));
+        if (levset(i,j-1,k) < Real(0.0)) {
             tmp += x(i,j-1,k) - x(i,j,k);
         } else {
-            hm = Real(1.0) - Real(2.) * ecy(i,j-1,k);
             tmp += (xeb(i,j-1,k) - x(i,j,k)) / hm;
         }
 
@@ -74,22 +72,24 @@ void mlebndfdlap_adotx_eb_doit (int i, int j, int k, Array4<Real> const& y,
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 void mlebndfdlap_adotx_eb (int i, int j, int k, Array4<Real> const& y,
-                           Array4<Real const> const& x, Array4<int const> const& dmsk,
+                           Array4<Real const> const& x, Array4<Real const> const& levset,
+                           Array4<int const> const& dmsk,
                            Array4<Real const> const& ecx, Array4<Real const> const& ecy,
                            Real xeb, Real bx, Real by) noexcept
 {
-    mlebndfdlap_adotx_eb_doit(i, j, k, y, x, dmsk, ecx, ecy,
+    mlebndfdlap_adotx_eb_doit(i, j, k, y, x, levset, dmsk, ecx, ecy,
                               [=] (int, int, int) -> Real { return xeb; },
                               bx, by);
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 void mlebndfdlap_adotx_eb (int i, int j, int k, Array4<Real> const& y,
-                           Array4<Real const> const& x, Array4<int const> const& dmsk,
+                           Array4<Real const> const& x, Array4<Real const> const& levset,
+                           Array4<int const> const& dmsk,
                            Array4<Real const> const& ecx, Array4<Real const> const& ecy,
                            Array4<Real const> const& xeb, Real bx, Real by) noexcept
 {
-    mlebndfdlap_adotx_eb_doit(i, j, k, y, x, dmsk, ecx, ecy,
+    mlebndfdlap_adotx_eb_doit(i, j, k, y, x, levset, dmsk, ecx, ecy,
                               [=] (int i1, int i2, int i3) -> Real {
                                   return xeb(i1,i2,i3); },
                               bx, by);
@@ -111,7 +111,8 @@ void mlebndfdlap_adotx (int i, int j, int k, Array4<Real> const& y,
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 void mlebndfdlap_gsrb_eb (int i, int j, int k, Array4<Real> const& x,
-                          Array4<Real const> const& rhs, Array4<int const> const& dmsk,
+                          Array4<Real const> const& rhs, Array4<Real const> const& levset,
+                          Array4<int const> const& dmsk,
                           Array4<Real const> const& ecx, Array4<Real const> const& ecy,
                           Real bx, Real by, int redblack) noexcept
 {
@@ -121,22 +122,21 @@ void mlebndfdlap_gsrb_eb (int i, int j, int k, Array4<Real> const& x,
         } else {
             Real tmp0, tmp1;
             Real hp, hm, scale;
-            if (ecx(i,j,k) == Real(1.0)) { // regular
-                hp = Real(1.0);
+
+            hp = (ecx(i,j,k) == Real(1.0)) ? Real(1.0) : (Real(1.0)+Real(2.)*ecx(i,j,k));
+            if (levset(i+1,j,k) < Real(0.0)) { // regular
                 tmp0 = Real(-1.0);
                 tmp1 = x(i+1,j,k);
             } else {
-                hp = Real(1.0) + Real(2.) * ecx(i,j,k);
                 tmp0 = Real(-1.0) / hp;
                 tmp1 = Real(0.0);
             }
 
-            if (ecx(i-1,j,k) == Real(1.0)) {
-                hm = Real(1.0);
+            hm = (ecx(i-1,j,k) == Real(1.0)) ? Real(1.0) : (Real(1.0)-Real(2.)*ecx(i-1,j,k));
+            if (levset(i-1,j,k) < Real(0.0)) {
                 tmp0 += Real(-1.0);
                 tmp1 += x(i-1,j,k);
             } else {
-                hm = Real(1.0) - Real(2.) * ecx(i-1,j,k);
                 tmp0 += Real(-1.0) / hm;
             }
 
@@ -144,22 +144,20 @@ void mlebndfdlap_gsrb_eb (int i, int j, int k, Array4<Real> const& x,
             Real rho   = tmp1 * (bx * Real(2.0) / (hp+hm));
             scale = amrex::min(hm, hp);
 
-            if (ecy(i,j,k) == Real(1.0)) {
-                hp = Real(1.0);
+            hp = (ecy(i,j,k) == Real(1.0)) ? Real(1.0) : (Real(1.0)+Real(2.)*ecy(i,j,k));
+            if (levset(i,j+1,k) < Real(0.0)) {
                 tmp0 = Real(-1.0);
                 tmp1 = x(i,j+1,k);
             } else {
-                hp = Real(1.0) + Real(2.) * ecy(i,j,k);
                 tmp0 = Real(-1.0) / hp;
                 tmp1 = Real(0.0);
             }
 
-            if (ecy(i,j-1,k) == Real(1.0)) {
-                hm = Real(1.0);
+            hm = (ecy(i,j-1,k) == Real(1.0)) ? Real(1.0) : (Real(1.0)-Real(2.)*ecy(i,j-1,k));
+            if (levset(i,j-1,k) < Real(0.0)) {
                 tmp0 += Real(-1.0);
                 tmp1 += x(i,j-1,k);
             } else {
-                hm = Real(1.0) - Real(2.) * ecy(i,j-1,k);
                 tmp0 += Real(-1.0) / hm;
             }
 
@@ -198,7 +196,8 @@ void mlebndfdlap_gsrb (int i, int j, int k, Array4<Real> const& x,
 template <typename F>
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 void mlebndfdlap_adotx_rz_eb_doit (int i, int j, int k, Array4<Real> const& y,
-                                   Array4<Real const> const& x, Array4<int const> const& dmsk,
+                                   Array4<Real const> const& x, Array4<Real const> const& levset,
+                                   Array4<int const> const& dmsk,
                                    Array4<Real const> const& ecx, Array4<Real const> const& ecy,
                                    F && xeb, Real sigr, Real dr, Real dz, Real rlo) noexcept
 {
@@ -210,48 +209,45 @@ void mlebndfdlap_adotx_rz_eb_doit (int i, int j, int k, Array4<Real> const& y,
 
         Real const r = rlo + Real(i) * dr;
         if (r == Real(0.0)) {
-            if (ecx(i,j,k) == Real(1.0)) { // regular
+            if (levset(i+1,j,k) < Real(0.0)) { // regular
                 out = Real(4.0) * sigr * (x(i+1,j,k)-x(i,j,k)) / (dr*dr);
                 scale = Real(1.0);
             } else {
-                hp = Real(1.0) + Real(2.) * ecx(i,j,k);
+                hp = (ecx(i,j,k) == Real(1.0)) ? Real(1.0) : (Real(1.0)+Real(2.)*ecx(i,j,k));
                 out = Real(4.0) * sigr * (xeb(i+1,j,k)-x(i,j,k)) / (dr*dr*hp*hp);
                 scale = hp;
             }
         } else {
-            if (ecx(i,j,k) == Real(1.0)) { // regular
-                hp = Real(1.0);
+            hp = (ecx(i,j,k) == Real(1.0)) ? Real(1.0) : (Real(1.0)+Real(2.)*ecx(i,j,k));
+            if (levset(i+1,j,k) < Real(0.0)) { // regular
                 tmp = (x(i+1,j,k) - x(i,j,k)) * (r + Real(0.5) * dr);
             } else {
-                hp = Real(1.0) + Real(2.) * ecx(i,j,k);
                 tmp = (xeb(i+1,j,k) - x(i,j,k)) / hp * (r + Real(0.5) * hp * dr);
             }
 
-            if (ecx(i-1,j,k) == Real(1.0)) {
-                hm = Real(1.0);
+            hm = (ecx(i-1,j,k) == Real(1.0)) ? Real(1.0) : (Real(1.0)-Real(2.)*ecx(i-1,j,k));
+            if (levset(i-1,j,k) < Real(0.0)) {
                 tmp += (x(i-1,j,k) - x(i,j,k)) * (r - Real(0.5) * dr);
             } else {
-                hm = Real(1.0) - Real(2.) * ecx(i-1,j,k);
-                tmp += (xeb(i-1,j,k) - x(i,j,k)) / hm * (r - Real(0.5) * hp * dr);
+                tmp += (xeb(i-1,j,k) - x(i,j,k)) / hm * (r - Real(0.5) * hm * dr);
             }
 
             out = tmp * Real(2.0) * sigr / ((hp+hm) * r * dr * dr);
             scale = amrex::min(hm, hp);
         }
 
-        if (ecy(i,j,k) == Real(1.0)) {
-            hp = Real(1.0);
+        hp = (ecy(i,j,k) == Real(1.0)) ? Real(1.0) : (Real(1.0)+Real(2.)*ecy(i,j,k));
+        if (levset(i,j+1,k) < Real(0.0)) {
             tmp = x(i,j+1,k) - x(i,j,k);
         } else {
-            hp = Real(1.0) + Real(2.) * ecy(i,j,k);
             tmp = (xeb(i,j+1,k) - x(i,j,k)) / hp;
         }
 
-        if (ecy(i,j-1,k) == Real(1.0)) {
-            hm = Real(1.0);
+
+        hm = (ecy(i,j-1,k) == Real(1.0)) ? Real(1.0) : (Real(1.0)-Real(2.)*ecy(i,j-1,k));
+        if (levset(i,j-1,k) < Real(0.0)) {
             tmp += x(i,j-1,k) - x(i,j,k);
         } else {
-            hm = Real(1.0) - Real(2.) * ecy(i,j-1,k);
             tmp += (xeb(i,j-1,k) - x(i,j,k)) / hm;
         }
 
@@ -264,22 +260,24 @@ void mlebndfdlap_adotx_rz_eb_doit (int i, int j, int k, Array4<Real> const& y,
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 void mlebndfdlap_adotx_rz_eb (int i, int j, int k, Array4<Real> const& y,
-                              Array4<Real const> const& x, Array4<int const> const& dmsk,
+                              Array4<Real const> const& x, Array4<Real const> const& levset,
+                              Array4<int const> const& dmsk,
                               Array4<Real const> const& ecx, Array4<Real const> const& ecy,
                               Real xeb, Real sigr, Real dr, Real dz, Real rlo) noexcept
 {
-    mlebndfdlap_adotx_rz_eb_doit(i, j, k, y, x, dmsk, ecx, ecy,
+    mlebndfdlap_adotx_rz_eb_doit(i, j, k, y, x, levset, dmsk, ecx, ecy,
                                  [=] (int, int, int) -> Real { return xeb; },
                                  sigr, dr, dz, rlo);
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 void mlebndfdlap_adotx_rz_eb (int i, int j, int k, Array4<Real> const& y,
-                              Array4<Real const> const& x, Array4<int const> const& dmsk,
+                              Array4<Real const> const& x, Array4<Real const> const& levset,
+                              Array4<int const> const& dmsk,
                               Array4<Real const> const& ecx, Array4<Real const> const& ecy,
                               Array4<Real const> const& xeb, Real sigr, Real dr, Real dz, Real rlo) noexcept
 {
-    mlebndfdlap_adotx_rz_eb_doit(i, j, k, y, x, dmsk, ecx, ecy,
+    mlebndfdlap_adotx_rz_eb_doit(i, j, k, y, x, levset, dmsk, ecx, ecy,
                                  [=] (int i1, int i2, int i3) -> Real {
                                      return xeb(i1,i2,i3); },
                                  sigr, dr, dz, rlo);
@@ -308,7 +306,8 @@ void mlebndfdlap_adotx_rz (int i, int j, int k, Array4<Real> const& y,
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 void mlebndfdlap_gsrb_rz_eb (int i, int j, int k, Array4<Real> const& x,
-                             Array4<Real const> const& rhs, Array4<int const> const& dmsk,
+                             Array4<Real const> const& rhs, Array4<Real const> const& levset,
+                             Array4<int const> const& dmsk,
                              Array4<Real const> const& ecx, Array4<Real const> const& ecy,
                              Real sigr, Real dr, Real dz, Real rlo, int redblack) noexcept
 {
@@ -321,35 +320,33 @@ void mlebndfdlap_gsrb_rz_eb (int i, int j, int k, Array4<Real> const& x,
 
             Real const r = rlo + Real(i) * dr;
             if (r == Real(0.0)) {
-                if (ecx(i,j,k) == Real(1.0)) { // regular
+                if (levset(i+1,j,k) < Real(0.0)) { // regular
                     Ax = (Real(4.0) * sigr / (dr*dr)) * (x(i+1,j,k)-x(i,j,k));
                     gamma = -(Real(4.0) * sigr / (dr*dr));
                     scale = Real(1.0);
                 } else {
-                    hp = Real(1.0) + Real(2.) * ecx(i,j,k);
+                    hp = (ecx(i,j,k) == Real(1.0)) ? Real(1.0) : (Real(1.0)+Real(2.)*ecx(i,j,k));
                     gamma = -(Real(4.0) * sigr / (dr*dr*hp*hp));
                     Ax = gamma * x(i,j,k);
                     scale = hp;
                 }
             } else {
-                if (ecx(i,j,k) == Real(1.0)) { // regular
-                    hp = Real(1.0);
+                hp = (ecx(i,j,k) == Real(1.0)) ? Real(1.0) : (Real(1.0)+Real(2.)*ecx(i,j,k));
+                if (levset(i+1,j,k) < Real(0.0)) { // regular
                     tmp = (x(i+1,j,k) - x(i,j,k)) * (r + Real(0.5) * dr);
                     tmp0 = -(r + Real(0.5) * dr);
                 } else {
-                    hp = Real(1.0) + Real(2.) * ecx(i,j,k);
                     tmp0 = Real(-1.0) / hp * (r + Real(0.5) * hp * dr);
                     tmp = tmp0 * x(i,j,k);
                 }
 
-                if (ecx(i-1,j,k) == Real(1.0)) {
-                    hm = Real(1.0);
+                hm = (ecx(i-1,j,k) == Real(1.0)) ? Real(1.0) : (Real(1.0)-Real(2.)*ecx(i-1,j,k));
+                if (levset(i-1,j,k) < Real(0.0)) {
                     tmp += (x(i-1,j,k) - x(i,j,k)) * (r - Real(0.5) * dr);
                     tmp0 += -(r - Real(0.5) * dr);
                 } else {
-                    hm = Real(1.0) - Real(2.) * ecx(i-1,j,k);
-                    tmp += -x(i,j,k) / hm * (r - Real(0.5) * hp * dr);
-                    tmp0 += Real(-1.0) / hm * (r - Real(0.5) * hp * dr);
+                    tmp += -x(i,j,k) / hm * (r - Real(0.5) * hm * dr);
+                    tmp0 += Real(-1.0) / hm * (r - Real(0.5) * hm * dr);
                 }
 
                 Ax = tmp * Real(2.0) * sigr / ((hp+hm) * r * dr * dr);
@@ -357,22 +354,20 @@ void mlebndfdlap_gsrb_rz_eb (int i, int j, int k, Array4<Real> const& x,
                 scale = amrex::min(hm, hp);
             }
 
-            if (ecy(i,j,k) == Real(1.0)) {
-                hp = Real(1.0);
+            hp = (ecy(i,j,k) == Real(1.0)) ? Real(1.0) : (Real(1.0)+Real(2.)*ecy(i,j,k));
+            if (levset(i,j+1,k) < Real(0.0)) {
                 tmp = x(i,j+1,k) - x(i,j,k);
                 tmp0 = Real(-1.0);
             } else {
-                hp = Real(1.0) + Real(2.) * ecy(i,j,k);
                 tmp0 = Real(-1.0) / hp;
                 tmp = tmp0 * x(i,j,k);
             }
 
-            if (ecy(i,j-1,k) == Real(1.0)) {
-                hm = Real(1.0);
+            hm = (ecy(i,j-1,k) == Real(1.0)) ? Real(1.0) : (Real(1.0)-Real(2.)*ecy(i,j-1,k));
+            if (levset(i,j-1,k) < Real(0.0)) {
                 tmp += x(i,j-1,k) - x(i,j,k);
                 tmp0 += Real(-1.0);
             } else {
-                hm = Real(1.0) - Real(2.) * ecy(i,j-1,k);
                 tmp += -x(i,j,k) / hm;
                 tmp0 += Real(-1.0) / hm;
             }

--- a/Src/LinearSolvers/MLMG/AMReX_MLEBNodeFDLap_3D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBNodeFDLap_3D_K.H
@@ -23,7 +23,8 @@ void mlebndfdlap_scale_rhs (int i, int j, int k, Array4<Real> const& rhs,
 template <typename F>
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 void mlebndfdlap_adotx_eb_doit (int i, int j, int k, Array4<Real> const& y,
-                                Array4<Real const> const& x, Array4<int const> const& dmsk,
+                                Array4<Real const> const& x, Array4<Real const> const& levset,
+                                Array4<int const> const& dmsk,
                                 Array4<Real const> const& ecx, Array4<Real const> const& ecy,
                                 Array4<Real const> const& ecz, F && xeb,
                                 Real bx, Real by, Real bz) noexcept
@@ -33,57 +34,52 @@ void mlebndfdlap_adotx_eb_doit (int i, int j, int k, Array4<Real> const& y,
     } else {
         Real tmp;
         Real hp, hm, scale, out;
-        if (ecx(i,j,k) == Real(1.0)) { // regular
-            hp = Real(1.0);
+
+        hp = (ecx(i,j,k) == Real(1.0)) ? Real(1.0) : (Real(1.0)+Real(2.)*ecx(i,j,k));
+        if (levset(i+1,j,k) < Real(0.0)) { // regular
             tmp = x(i+1,j,k) - x(i,j,k);
         } else {
-            hp = Real(1.0) + Real(2.) * ecx(i,j,k);
             tmp = (xeb(i+1,j,k) - x(i,j,k)) / hp;
         }
 
-        if (ecx(i-1,j,k) == Real(1.0)) {
-            hm = Real(1.0);
+        hm = (ecx(i-1,j,k) == Real(1.0)) ? Real(1.0) : (Real(1.0)-Real(2.)*ecx(i-1,j,k));
+        if (levset(i-1,j,k) < Real(0.0)) {
             tmp += x(i-1,j,k) - x(i,j,k);
         } else {
-            hm = Real(1.0) - Real(2.) * ecx(i-1,j,k);
             tmp += (xeb(i-1,j,k) - x(i,j,k)) / hm;
         }
 
         out = tmp * bx * Real(2.0) / (hp+hm);
         scale = amrex::min(hm, hp);
 
-        if (ecy(i,j,k) == Real(1.0)) {
-            hp = Real(1.0);
+        hp = (ecy(i,j,k) == Real(1.0)) ? Real(1.0) : (Real(1.0)+Real(2.)*ecy(i,j,k));
+        if (levset(i,j+1,k) < Real(0.0)) {
             tmp = x(i,j+1,k) - x(i,j,k);
         } else {
-            hp = Real(1.0) + Real(2.) * ecy(i,j,k);
             tmp = (xeb(i,j+1,k) - x(i,j,k)) / hp;
         }
 
-        if (ecy(i,j-1,k) == Real(1.0)) {
-            hm = Real(1.0);
+        hm = (ecy(i,j-1,k) == Real(1.0)) ? Real(1.0) : (Real(1.0)-Real(2.)*ecy(i,j-1,k));
+        if (levset(i,j-1,k) < Real(0.0)) {
             tmp += x(i,j-1,k) - x(i,j,k);
         } else {
-            hm = Real(1.0) - Real(2.) * ecy(i,j-1,k);
             tmp += (xeb(i,j-1,k) - x(i,j,k)) / hm;
         }
 
         out += tmp * by * Real(2.0) / (hp+hm);
         scale = amrex::min(scale, hm, hp);
 
-        if (ecz(i,j,k) == Real(1.0)) {
-            hp = Real(1.0);
+        hp = (ecz(i,j,k) == Real(1.0)) ? Real(1.0) : (Real(1.0)+Real(2.0)*ecz(i,j,k));
+        if (levset(i,j,k+1) < Real(0.0)) {
             tmp = x(i,j,k+1) - x(i,j,k);
         } else {
-            hp = Real(1.0) + Real(2.0) * ecz(i,j,k);
             tmp = (xeb(i,j,k+1) - x(i,j,k)) / hp;
         }
 
-        if (ecz(i,j,k-1) == Real(1.0)) {
-            hm = Real(1.0);
+        hm = (ecz(i,j,k-1) == Real(1.0)) ? Real(1.0) : (Real(1.0)-Real(2.)*ecz(i,j,k-1));
+        if (levset(i,j,k-1) < Real(0.0)) {
             tmp += x(i,j,k-1) - x(i,j,k);
         } else {
-            hm = Real(1.0) - Real(2.) * ecz(i,j,k-1);
             tmp += (xeb(i,j,k-1) - x(i,j,k)) / hm;
         }
 
@@ -96,24 +92,26 @@ void mlebndfdlap_adotx_eb_doit (int i, int j, int k, Array4<Real> const& y,
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 void mlebndfdlap_adotx_eb (int i, int j, int k, Array4<Real> const& y,
-                           Array4<Real const> const& x, Array4<int const> const& dmsk,
+                           Array4<Real const> const& x, Array4<Real const> const& levset,
+                           Array4<int const> const& dmsk,
                            Array4<Real const> const& ecx, Array4<Real const> const& ecy,
                            Array4<Real const> const& ecz, Real xeb,
                            Real bx, Real by, Real bz) noexcept
 {
-    mlebndfdlap_adotx_eb_doit(i, j, k, y, x, dmsk, ecx, ecy, ecz,
+    mlebndfdlap_adotx_eb_doit(i, j, k, y, x, levset, dmsk, ecx, ecy, ecz,
                               [=] (int, int, int) -> Real { return xeb; },
                               bx, by, bz);
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 void mlebndfdlap_adotx_eb (int i, int j, int k, Array4<Real> const& y,
-                           Array4<Real const> const& x, Array4<int const> const& dmsk,
+                           Array4<Real const> const& x, Array4<Real const> const& levset,
+                           Array4<int const> const& dmsk,
                            Array4<Real const> const& ecx, Array4<Real const> const& ecy,
                            Array4<Real const> const& ecz, Array4<Real const> const& xeb,
                            Real bx, Real by, Real bz) noexcept
 {
-    mlebndfdlap_adotx_eb_doit(i, j, k, y, x, dmsk, ecx, ecy, ecz,
+    mlebndfdlap_adotx_eb_doit(i, j, k, y, x, levset, dmsk, ecx, ecy, ecz,
                               [=] (int i1, int i2, int i3) -> Real {
                                   return xeb(i1,i2,i3); },
                               bx, by, bz);
@@ -136,7 +134,8 @@ void mlebndfdlap_adotx (int i, int j, int k, Array4<Real> const& y,
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 void mlebndfdlap_gsrb_eb (int i, int j, int k, Array4<Real> const& x,
-                          Array4<Real const> const& rhs, Array4<int const> const& dmsk,
+                          Array4<Real const> const& rhs, Array4<Real const> const& levset,
+                          Array4<int const> const& dmsk,
                           Array4<Real const> const& ecx, Array4<Real const> const& ecy,
                           Array4<Real const> const& ecz, Real bx, Real by, Real bz,
                           int redblack) noexcept
@@ -147,22 +146,20 @@ void mlebndfdlap_gsrb_eb (int i, int j, int k, Array4<Real> const& x,
         } else {
             Real tmp0, tmp1;
             Real hp, hm, scale;
-            if (ecx(i,j,k) == Real(1.0)) { // regular
-                hp = Real(1.0);
+            hp = (ecx(i,j,k) == Real(1.0)) ? Real(1.0) : (Real(1.0)+Real(2.)*ecx(i,j,k));
+            if (levset(i+1,j,k) < Real(0.0)) { // regular
                 tmp0 = Real(-1.0);
                 tmp1 = x(i+1,j,k);
             } else {
-                hp = Real(1.0) + Real(2.) * ecx(i,j,k);
                 tmp0 = Real(-1.0) / hp;
                 tmp1 = Real(0.0);
             }
 
-            if (ecx(i-1,j,k) == Real(1.0)) {
-                hm = Real(1.0);
+            hm = (ecx(i-1,j,k) == Real(1.0)) ? Real(1.0) : (Real(1.0)-Real(2.)*ecx(i-1,j,k));
+            if (levset(i-1,j,k) < Real(0.0)) {
                 tmp0 += Real(-1.0);
                 tmp1 += x(i-1,j,k);
             } else {
-                hm = Real(1.0) - Real(2.) * ecx(i-1,j,k);
                 tmp0 += Real(-1.0) / hm;
             }
 
@@ -170,22 +167,20 @@ void mlebndfdlap_gsrb_eb (int i, int j, int k, Array4<Real> const& x,
             Real rho   = tmp1 * (bx * Real(2.0) / (hp+hm));
             scale = amrex::min(hm, hp);
 
-            if (ecy(i,j,k) == Real(1.0)) {
-                hp = Real(1.0);
+            hp = (ecy(i,j,k) == Real(1.0)) ? Real(1.0) : (Real(1.0)+Real(2.)*ecy(i,j,k));
+            if (levset(i,j+1,k) < Real(0.0)) {
                 tmp0 = Real(-1.0);
                 tmp1 = x(i,j+1,k);
             } else {
-                hp = Real(1.0) + Real(2.) * ecy(i,j,k);
                 tmp0 = Real(-1.0) / hp;
                 tmp1 = Real(0.0);
             }
 
-            if (ecy(i,j-1,k) == Real(1.0)) {
-                hm = Real(1.0);
+            hm = (ecy(i,j-1,k) == Real(1.0)) ? Real(1.0) : (Real(1.0)-Real(2.)*ecy(i,j-1,k));
+            if (levset(i,j-1,k) < Real(0.0)) {
                 tmp0 += Real(-1.0);
                 tmp1 += x(i,j-1,k);
             } else {
-                hm = Real(1.0) - Real(2.) * ecy(i,j-1,k);
                 tmp0 += Real(-1.0) / hm;
             }
 
@@ -193,22 +188,20 @@ void mlebndfdlap_gsrb_eb (int i, int j, int k, Array4<Real> const& x,
             rho   += tmp1 * (by * Real(2.0) / (hp+hm));
             scale = amrex::min(scale, hm, hp);
 
-            if (ecz(i,j,k) == Real(1.0)) {
-                hp = Real(1.0);
+            hp = (ecz(i,j,k) == Real(1.0)) ? Real(1.0) : (Real(1.0)+Real(2.0)*ecz(i,j,k));
+            if (levset(i,j,k+1) < Real(0.0)) {
                 tmp0 = Real(-1.0);
                 tmp1 = x(i,j,k+1);
             } else {
-                hp = Real(1.0) + Real(2.) * ecz(i,j,k);
                 tmp0 = Real(-1.0) / hp;
                 tmp1 = Real(0.0);
             }
 
-            if (ecz(i,j,k-1) == Real(1.0)) {
-                hm = Real(1.0);
+            hm = (ecz(i,j,k-1) == Real(1.0)) ? Real(1.0) : (Real(1.0)-Real(2.)*ecz(i,j,k-1));
+            if (levset(i,j,k-1) < Real(0.0)) {
                 tmp0 += Real(-1.0);
                 tmp1 += x(i,j,k-1);
             } else {
-                hm = Real(1.0) - Real(2.) * ecz(i,j,k-1);
                 tmp0 += Real(-1.0) / hm;
             }
 

--- a/Src/LinearSolvers/MLMG/AMReX_MLEBNodeFDLaplacian.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBNodeFDLaplacian.cpp
@@ -368,6 +368,7 @@ MLEBNodeFDLaplacian::Fapply (int amrlev, int mglev, MultiFab& out, const MultiFa
     const auto phieb = (m_in_solution_mode) ? m_s_phi_eb : Real(0.0);
     const auto *factory = dynamic_cast<EBFArrayBoxFactory const*>(m_factory[amrlev][mglev].get());
     auto const& edgecent = factory->getEdgeCent();
+    auto const& levset_mf = factory->getLevelSet();
 #endif
 
 #ifdef AMREX_USE_OMP
@@ -385,13 +386,14 @@ MLEBNodeFDLaplacian::Fapply (int amrlev, int mglev, MultiFab& out, const MultiFa
             AMREX_D_TERM(Array4<Real const> const& ecx = edgecent[0]->const_array(mfi);,
                          Array4<Real const> const& ecy = edgecent[1]->const_array(mfi);,
                          Array4<Real const> const& ecz = edgecent[2]->const_array(mfi));
+            auto const& levset = levset_mf.const_array(mfi);
             if (phieb == std::numeric_limits<Real>::lowest()) {
                 auto const& phiebarr = m_phi_eb[amrlev].const_array(mfi);
 #if (AMREX_SPACEDIM == 2)
                 if (m_rz) {
                     AMREX_HOST_DEVICE_FOR_3D(box, i, j, k,
                     {
-                        mlebndfdlap_adotx_rz_eb(i,j,k,yarr,xarr,dmarr,ecx,ecy,
+                        mlebndfdlap_adotx_rz_eb(i,j,k,yarr,xarr,levset,dmarr,ecx,ecy,
                                                 phiebarr, sig0, dx0, dx1, xlo);
                     });
                 } else
@@ -399,7 +401,7 @@ MLEBNodeFDLaplacian::Fapply (int amrlev, int mglev, MultiFab& out, const MultiFa
                 {
                     AMREX_HOST_DEVICE_FOR_3D(box, i, j, k,
                     {
-                        mlebndfdlap_adotx_eb(i,j,k,yarr,xarr,dmarr,AMREX_D_DECL(ecx,ecy,ecz),
+                        mlebndfdlap_adotx_eb(i,j,k,yarr,xarr,levset,dmarr,AMREX_D_DECL(ecx,ecy,ecz),
                                              phiebarr, AMREX_D_DECL(bx,by,bz));
                     });
                 }
@@ -408,7 +410,7 @@ MLEBNodeFDLaplacian::Fapply (int amrlev, int mglev, MultiFab& out, const MultiFa
                 if (m_rz) {
                     AMREX_HOST_DEVICE_FOR_3D(box, i, j, k,
                     {
-                        mlebndfdlap_adotx_rz_eb(i,j,k,yarr,xarr,dmarr,ecx,ecy,
+                        mlebndfdlap_adotx_rz_eb(i,j,k,yarr,xarr,levset,dmarr,ecx,ecy,
                                                 phieb, sig0, dx0, dx1, xlo);
                     });
                 } else
@@ -416,7 +418,7 @@ MLEBNodeFDLaplacian::Fapply (int amrlev, int mglev, MultiFab& out, const MultiFa
                 {
                     AMREX_HOST_DEVICE_FOR_3D(box, i, j, k,
                     {
-                        mlebndfdlap_adotx_eb(i,j,k,yarr,xarr,dmarr,AMREX_D_DECL(ecx,ecy,ecz),
+                        mlebndfdlap_adotx_eb(i,j,k,yarr,xarr,levset,dmarr,AMREX_D_DECL(ecx,ecy,ecz),
                                              phieb, AMREX_D_DECL(bx,by,bz));
                     });
                 }
@@ -470,6 +472,7 @@ MLEBNodeFDLaplacian::Fsmooth (int amrlev, int mglev, MultiFab& sol, const MultiF
 #ifdef AMREX_USE_EB
         const auto *factory = dynamic_cast<EBFArrayBoxFactory const*>(m_factory[amrlev][mglev].get());
         auto const& edgecent = factory->getEdgeCent();
+        auto const& levset_mf = factory->getLevelSet();
 #endif
 
 #ifdef AMREX_USE_OMP
@@ -487,11 +490,12 @@ MLEBNodeFDLaplacian::Fsmooth (int amrlev, int mglev, MultiFab& sol, const MultiF
                 AMREX_D_TERM(Array4<Real const> const& ecx = edgecent[0]->const_array(mfi);,
                              Array4<Real const> const& ecy = edgecent[1]->const_array(mfi);,
                              Array4<Real const> const& ecz = edgecent[2]->const_array(mfi));
+                auto const& levset = levset_mf.const_array(mfi);
 #if (AMREX_SPACEDIM == 2)
                 if (m_rz) {
                     AMREX_HOST_DEVICE_FOR_3D(box, i, j, k,
                     {
-                        mlebndfdlap_gsrb_rz_eb(i,j,k,solarr,rhsarr,dmskarr,ecx,ecy,
+                        mlebndfdlap_gsrb_rz_eb(i,j,k,solarr,rhsarr,levset,dmskarr,ecx,ecy,
                                                sig0, dx0, dx1, xlo, redblack);
                     });
                 } else
@@ -499,7 +503,7 @@ MLEBNodeFDLaplacian::Fsmooth (int amrlev, int mglev, MultiFab& sol, const MultiF
                 {
                     AMREX_HOST_DEVICE_FOR_3D(box, i, j, k,
                     {
-                        mlebndfdlap_gsrb_eb(i,j,k,solarr,rhsarr,dmskarr,AMREX_D_DECL(ecx,ecy,ecz),
+                        mlebndfdlap_gsrb_eb(i,j,k,solarr,rhsarr,levset,dmskarr,AMREX_D_DECL(ecx,ecy,ecz),
                                             AMREX_D_DECL(bx,by,bz), redblack);
                     });
                 }


### PR DESCRIPTION
In this linear solver for WarpX, we missed a corner case where the edge with a length of exactly 1 has one end exactly on the EB surface. It is fixed by using the implicit function to detect covered nodes.