### PR TITLE
CMake: Fix CUDA Options Order

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,8 +92,15 @@ endif()
 # Include options, utilities and other stuff we need
 #
 include( AMReXOptions )
-if (AMReX_GPU_BACKEND STREQUAL "CUDA")
-   include(AMReXCUDAOptions)
+
+#
+# Enable CUDA if requested
+#
+if (AMReX_CUDA)
+    enable_language(CUDA)
+    if(CMAKE_VERSION VERSION_LESS 3.20)
+        include(AMReX_SetupCUDA)
+    endif()
 endif ()
 
 #
@@ -104,13 +111,10 @@ if(AMReX_FORTRAN)
 endif ()
 
 #
-# Enable CUDA if requested
+# Include options specifically for CUDA
 #
-if (AMReX_CUDA)
-    enable_language(CUDA)
-    if(CMAKE_VERSION VERSION_LESS 3.20)
-        include(AMReX_SetupCUDA)
-    endif()
+if (AMReX_GPU_BACKEND STREQUAL "CUDA")
+   include(AMReXCUDAOptions)
 endif ()
 
 #


### PR DESCRIPTION
## Summary

Some options in the CMake CUDA logic check the CUDA version. Thus, the CUDA language needs to be enabled and the compiler be found already. This fixes this order.

## Additional background

Preparation of a work-around for #3215

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
