### PR TITLE
Work-Around: CUDA 12.1 Non-Default Codelines

### DIFF
--- a/Tools/CMake/AMReXCUDAOptions.cmake
+++ b/Tools/CMake/AMReXCUDAOptions.cmake
@@ -85,8 +85,16 @@ cuda_print_option(AMReX_CUDA_DEBUG)
 
 # both are performance-neutral debug symbols
 option(AMReX_CUDA_SHOW_LINENUMBERS "Generate line-number information (optimizations: on)" ON)
-option(AMReX_CUDA_SHOW_CODELINES "Generate source information in PTX (optimizations: on)" ON)
 cuda_print_option(AMReX_CUDA_SHOW_LINENUMBERS)
+
+# https://github.com/AMReX-Codes/amrex/issues/3215
+# Nvidia Bug ID: 4088095
+if (CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL 12.1)
+    set(AMReX_CUDA_SHOW_CODELINES_DEFAULT OFF)
+else()
+    set(AMReX_CUDA_SHOW_CODELINES_DEFAULT ON)
+endif()
+option(AMReX_CUDA_SHOW_CODELINES "Generate source information in PTX (optimizations: on)" AMReX_CUDA_SHOW_CODELINES_DEFAULT)
 cuda_print_option(AMReX_CUDA_SHOW_CODELINES)
 
 option(AMReX_CUDA_BACKTRACE "Generate host function symbol names (better cuda-memcheck)" ${AMReX_CUDA_DEBUG})


### PR DESCRIPTION
## Summary

Set `AMReX_CUDA_SHOW_CODELINES` to be `FALSE`/`OFF` by default for CUDA 12.1, since we know that `--source-in-ptx` has a NVCC regression in debug mode.

## Additional background

- [x] rebase after #3274 was merged
- [x] close #3215

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
