### PR TITLE
Github Cache: Path and Hypre

### DIFF
--- a/.github/workflows/clang.yml
+++ b/.github/workflows/clang.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Set Up Cache
       uses: actions/cache@v3
       with:
-        path: ~/.cache
+        path: ~/.cache/ccache
         key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}
         restore-keys: |
              ccache-${{ github.workflow }}-${{ github.job }}-git-
@@ -70,6 +70,7 @@ jobs:
         ctest --output-on-failure
 
         ccache -s
+        du -hs ~/.cache/ccache
 
   tests_clang:
     name: Clang@14.0 C++17 SP Particles DP Mesh Debug [tests]
@@ -84,7 +85,7 @@ jobs:
     - name: Set Up Cache
       uses: actions/cache@v3
       with:
-        path: ~/.cache
+        path: ~/.cache/ccache
         key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}
         restore-keys: |
              ccache-${{ github.workflow }}-${{ github.job }}-git-
@@ -125,6 +126,7 @@ jobs:
         ctest --output-on-failure
 
         ccache -s
+        du -hs ~/.cache/ccache
 
   # Build 2D libamrex with configure
   configure-2d:
@@ -140,7 +142,7 @@ jobs:
     - name: Set Up Cache
       uses: actions/cache@v3
       with:
-        path: ~/.cache
+        path: ~/.cache/ccache
         key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}
         restore-keys: |
              ccache-${{ github.workflow }}-${{ github.job }}-git-
@@ -164,6 +166,7 @@ jobs:
             CLANG_TIDY_ARGS="--config-file=${{github.workspace}}/.clang-tidy --warnings-as-errors=*"
 
         ccache -s
+        du -hs ~/.cache/ccache
 
   save_pr_number:
     if: github.event_name == 'pull_request'

--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Set Up Cache
       uses: actions/cache@v3
       with:
-        path: ~/.cache
+        path: ~/.cache/ccache
         key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}
         restore-keys: |
              ccache-${{ github.workflow }}-${{ github.job }}-git-
@@ -56,6 +56,7 @@ jobs:
         cmake --build build -j 2
 
         ccache -s
+        du -hs ~/.cache/ccache
 
   # Build libamrex and all tests with NVHPC (recent supported)
   tests-nvhpc-nvcc:
@@ -70,7 +71,7 @@ jobs:
     - name: Set Up Cache
       uses: actions/cache@v3
       with:
-        path: ~/.cache
+        path: ~/.cache/ccache
         key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}
         restore-keys: |
              ccache-${{ github.workflow }}-${{ github.job }}-git-
@@ -115,6 +116,7 @@ jobs:
         cmake --build build -j 2
 
         ccache -s
+        du -hs ~/.cache/ccache
 
   # Build 3D libamrex cuda build with configure
   configure-3d-cuda:
@@ -129,7 +131,7 @@ jobs:
     - name: Set Up Cache
       uses: actions/cache@v3
       with:
-        path: ~/.cache
+        path: ~/.cache/ccache
         key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}
         restore-keys: |
              ccache-${{ github.workflow }}-${{ github.job }}-git-
@@ -150,6 +152,7 @@ jobs:
         make install
 
         ccache -s
+        du -hs ~/.cache/ccache
 
   save_pr_number:
     if: github.event_name == 'pull_request'

--- a/.github/workflows/gcc.yml
+++ b/.github/workflows/gcc.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Set Up Cache
       uses: actions/cache@v3
       with:
-        path: ~/.cache
+        path: ~/.cache/ccache
         key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}
         restore-keys: |
              ccache-${{ github.workflow }}-${{ github.job }}-git-
@@ -65,6 +65,7 @@ jobs:
         ctest --output-on-failure
 
         ccache -s
+        du -hs ~/.cache/ccache
 
   # Build libamrex and all tests
   tests_build_3D:
@@ -80,7 +81,7 @@ jobs:
     - name: Set Up Cache
       uses: actions/cache@v3
       with:
-        path: ~/.cache
+        path: ~/.cache/ccache
         key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}
         restore-keys: |
              ccache-${{ github.workflow }}-${{ github.job }}-git-
@@ -114,6 +115,7 @@ jobs:
         ctest --test-dir build --output-on-failure
 
         ccache -s
+        du -hs ~/.cache/ccache
 
   tests_build_2D:
     name: GNU@9.3 C++17 2D Debug Fortran [tests]
@@ -128,7 +130,7 @@ jobs:
     - name: Set Up Cache
       uses: actions/cache@v3
       with:
-        path: ~/.cache
+        path: ~/.cache/ccache
         key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}
         restore-keys: |
              ccache-${{ github.workflow }}-${{ github.job }}-git-
@@ -162,6 +164,7 @@ jobs:
         ctest --test-dir build --output-on-failure
 
         ccache -s
+        du -hs ~/.cache/ccache
 
   tests_build_1D:
     name: GNU@9.3 C++17 1D Debug Fortran [tests]
@@ -176,7 +179,7 @@ jobs:
     - name: Set Up Cache
       uses: actions/cache@v3
       with:
-        path: ~/.cache
+        path: ~/.cache/ccache
         key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}
         restore-keys: |
              ccache-${{ github.workflow }}-${{ github.job }}-git-
@@ -211,6 +214,7 @@ jobs:
         ctest --test-dir build --output-on-failure
 
         ccache -s
+        du -hs ~/.cache/ccache
 
   # Build libamrex and all tests
   tests_cxx20:
@@ -226,7 +230,7 @@ jobs:
     - name: Set Up Cache
       uses: actions/cache@v3
       with:
-        path: ~/.cache
+        path: ~/.cache/ccache
         key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}
         restore-keys: |
              ccache-${{ github.workflow }}-${{ github.job }}-git-
@@ -270,6 +274,7 @@ jobs:
         ctest --output-on-failure
 
         ccache -s
+        du -hs ~/.cache/ccache
 
   # Build libamrex and all tests w/o MPI
   tests-nonmpi:
@@ -285,7 +290,7 @@ jobs:
     - name: Set Up Cache
       uses: actions/cache@v3
       with:
-        path: ~/.cache
+        path: ~/.cache/ccache
         key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}
         restore-keys: |
              ccache-${{ github.workflow }}-${{ github.job }}-git-
@@ -327,6 +332,7 @@ jobs:
         ctest --output-on-failure
 
         ccache -s
+        du -hs ~/.cache/ccache
 
   # Build libamrex and all tests
   tests-nofortran:
@@ -342,7 +348,7 @@ jobs:
     - name: Set Up Cache
       uses: actions/cache@v3
       with:
-        path: ~/.cache
+        path: ~/.cache/ccache
         key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}
         restore-keys: |
              ccache-${{ github.workflow }}-${{ github.job }}-git-
@@ -391,6 +397,7 @@ jobs:
         ctest --output-on-failure
 
         ccache -s
+        du -hs ~/.cache/ccache
 
   # Build 1D libamrex with configure
   configure-1d:
@@ -406,7 +413,7 @@ jobs:
     - name: Set Up Cache
       uses: actions/cache@v3
       with:
-        path: ~/.cache
+        path: ~/.cache/ccache
         key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}
         restore-keys: |
              ccache-${{ github.workflow }}-${{ github.job }}-git-
@@ -430,6 +437,7 @@ jobs:
             CLANG_TIDY_ARGS="--config-file=${{github.workspace}}/.clang-tidy --warnings-as-errors=*"
 
         ccache -s
+        du -hs ~/.cache/ccache
 
   # Build 3D libamrex with configure
   configure-3d:
@@ -445,7 +453,7 @@ jobs:
     - name: Set Up Cache
       uses: actions/cache@v3
       with:
-        path: ~/.cache
+        path: ~/.cache/ccache
         key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}
         restore-keys: |
              ccache-${{ github.workflow }}-${{ github.job }}-git-
@@ -469,6 +477,7 @@ jobs:
             CLANG_TIDY_ARGS="--config-file=${{github.workspace}}/.clang-tidy --warnings-as-errors=*"
 
         ccache -s
+        du -hs ~/.cache/ccache
 
   # Build 3D libamrex with single precision and tiny profiler
   configure-3d-single-tprof:
@@ -484,7 +493,7 @@ jobs:
     - name: Set Up Cache
       uses: actions/cache@v3
       with:
-        path: ~/.cache
+        path: ~/.cache/ccache
         key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}
         restore-keys: |
              ccache-${{ github.workflow }}-${{ github.job }}-git-
@@ -508,6 +517,7 @@ jobs:
             CLANG_TIDY_ARGS="--config-file=${{github.workspace}}/.clang-tidy --warnings-as-errors=*"
 
         ccache -s
+        du -hs ~/.cache/ccache
 
   # Build 3D libamrex debug omp build with configure
   configure-3d-omp-debug:
@@ -523,7 +533,7 @@ jobs:
     - name: Set Up Cache
       uses: actions/cache@v3
       with:
-        path: ~/.cache
+        path: ~/.cache/ccache
         key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}
         restore-keys: |
              ccache-${{ github.workflow }}-${{ github.job }}-git-
@@ -547,6 +557,7 @@ jobs:
             CLANG_TIDY_ARGS="--config-file=${{github.workspace}}/.clang-tidy --warnings-as-errors=*"
 
         ccache -s
+        du -hs ~/.cache/ccache
 
   # Build Tools/Plotfile
   plotfile-tools:
@@ -562,7 +573,7 @@ jobs:
     - name: Set Up Cache
       uses: actions/cache@v3
       with:
-        path: ~/.cache
+        path: ~/.cache/ccache
         key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}
         restore-keys: |
              ccache-${{ github.workflow }}-${{ github.job }}-git-
@@ -585,6 +596,7 @@ jobs:
             CLANG_TIDY_ARGS="--config-file=${{github.workspace}}/.clang-tidy --warnings-as-errors=*"
 
         ccache -s
+        du -hs ~/.cache/ccache
 
   # Build libamrex and run all tests
   tests_run:
@@ -600,7 +612,7 @@ jobs:
     - name: Set Up Cache
       uses: actions/cache@v3
       with:
-        path: ~/.cache
+        path: ~/.cache/ccache
         key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}
         restore-keys: |
              ccache-${{ github.workflow }}-${{ github.job }}-git-
@@ -630,6 +642,7 @@ jobs:
             CLANG_TIDY_ARGS="--config-file=${{github.workspace}}/.clang-tidy --warnings-as-errors=*"
 
         ccache -s
+        du -hs ~/.cache/ccache
 
     - name: Run tests
       run: |

--- a/.github/workflows/hip.yml
+++ b/.github/workflows/hip.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set Up Cache
       uses: actions/cache@v3
       with:
-        path: ~/.cache
+        path: ~/.cache/ccache
         key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}
         restore-keys: |
              ccache-${{ github.workflow }}-${{ github.job }}-git-
@@ -70,6 +70,7 @@ jobs:
         cmake --build build -j 2
 
         ccache -s
+        du -hs ~/.cache/ccache
 
   tests-hip-wrapper:
     name: HIP ROCm GFortran@9.3 C++17 [tests-hipcc]
@@ -83,7 +84,7 @@ jobs:
     - name: Set Up Cache
       uses: actions/cache@v3
       with:
-        path: ~/.cache
+        path: ~/.cache/ccache
         key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}
         restore-keys: |
              ccache-${{ github.workflow }}-${{ github.job }}-git-
@@ -132,6 +133,7 @@ jobs:
         cmake --build build_full_legacywrapper -j 2
 
         ccache -s
+        du -hs ~/.cache/ccache
 
   # Build 2D libamrex hip build with configure
   configure-2d-single-hip:
@@ -146,7 +148,7 @@ jobs:
     - name: Set Up Cache
       uses: actions/cache@v3
       with:
-        path: ~/.cache
+        path: ~/.cache/ccache
         key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}
         restore-keys: |
              ccache-${{ github.workflow }}-${{ github.job }}-git-
@@ -162,6 +164,7 @@ jobs:
         make install
 
         ccache -s
+        du -hs ~/.cache/ccache
 
   save_pr_number:
     if: github.event_name == 'pull_request'

--- a/.github/workflows/hypre.yml
+++ b/.github/workflows/hypre.yml
@@ -10,6 +10,8 @@ jobs:
   compile-hypre-cuda-eb-2d:
     name: CUDA EB 2D Hypre@2.26.0
     runs-on: ubuntu-20.04
+    env:
+      AMREX_HYPRE_HOME: ${HOME}/.cache/hypre-2.26.0-cuda
     steps:
     - uses: actions/checkout@v3
     - name: Dependencies
@@ -20,20 +22,26 @@ jobs:
     - name: Set Up Cache
       uses: actions/cache@v3
       with:
-        path: ~/.cache
+        path: |
+          ~/.cache/ccache
+          ~/.cache/hypre-2.26.0-cuda
         key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}
         restore-keys: |
              ccache-${{ github.workflow }}-${{ github.job }}-git-
     - name: Build Hypre
       run: |
-        wget -q https://github.com/hypre-space/hypre/archive/refs/tags/v2.26.0.tar.gz
-        tar xfz v2.26.0.tar.gz
-        cd hypre-2.26.0/src
-        ./configure --with-cxxstandard=17 --with-cuda --enable-unified-memory \
-            --with-cuda-home=/usr/local/cuda --with-gpu-arch="80"
-        make -j 2
-        make install
-        cd ../../
+        if [ ! -d "${{ env.AMREX_HYPRE_HOME }}" ]
+        then
+          wget -q https://github.com/hypre-space/hypre/archive/refs/tags/v2.26.0.tar.gz
+          tar xfz v2.26.0.tar.gz
+          cd hypre-2.26.0/src
+          ./configure --with-cxxstandard=17 --with-cuda --enable-unified-memory \
+              --with-cuda-home=/usr/local/cuda --with-gpu-arch="80" \
+              --prefix=${{ env.AMREX_HYPRE_HOME }}
+          make -j 2
+          make install
+          cd ../../
+        fi
     - name: Compile Test
       run: |
         export CCACHE_COMPRESS=1
@@ -41,7 +49,6 @@ jobs:
         export CCACHE_MAXSIZE=290M
         ccache -z
 
-        export AMREX_HYPRE_HOME=${PWD}/hypre-2.26.0/src/hypre
         export AMREX_CUDA_ARCH=80
         export CUDA_PATH=/usr/local/cuda
         export PATH=${PATH}:/usr/local/cuda/bin
@@ -49,6 +56,7 @@ jobs:
         make -j2 USE_MPI=TRUE USE_HYPRE=TRUE DIM=2 USE_CUDA=TRUE CCACHE=ccache
 
         ccache -s
+        du -h -d1 ~/.cache
 
   test-hypre-cpu-3d:
     name: GCC 3D Hypre@2.21.0
@@ -63,7 +71,7 @@ jobs:
     - name: Set Up Cache
       uses: actions/cache@v3
       with:
-        path: ~/.cache
+        path: ~/.cache/ccache
         key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}
         restore-keys: |
              ccache-${{ github.workflow }}-${{ github.job }}-git-
@@ -97,6 +105,7 @@ jobs:
             CLANG_TIDY_ARGS="--config-file=${{github.workspace}}/.clang-tidy --warnings-as-errors=*"
 
         ccache -s
+        du -hs ~/.cache/ccache
 
   save_pr_number:
     if: github.event_name == 'pull_request'

--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set Up Cache
       uses: actions/cache@v3
       with:
-        path: ~/.cache
+        path: ~/.cache/ccache
         key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}
         restore-keys: |
              ccache-${{ github.workflow }}-${{ github.job }}-git-
@@ -51,6 +51,7 @@ jobs:
         cmake --build build --parallel 2
 
         ccache -s
+        du -hs ~/.cache/ccache
 
   tests-oneapi-sycl-eb:
     name: oneAPI SYCL [tests w/ EB]
@@ -64,7 +65,7 @@ jobs:
     - name: Set Up Cache
       uses: actions/cache@v3
       with:
-        path: ~/.cache
+        path: ~/.cache/ccache
         key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}
         restore-keys: |
              ccache-${{ github.workflow }}-${{ github.job }}-git-
@@ -95,6 +96,7 @@ jobs:
         cmake --build build --parallel 2
 
         ccache -s
+        du -hs ~/.cache/ccache
 
 # "Classic" EDG Intel Compiler
 # Ref.: https://github.com/rscohn2/oneapi-ci
@@ -118,7 +120,7 @@ jobs:
     - name: Set Up Cache
       uses: actions/cache@v3
       with:
-        path: ~/.cache
+        path: ~/.cache/ccache
         key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}
         restore-keys: |
              ccache-${{ github.workflow }}-${{ github.job }}-git-
@@ -149,6 +151,7 @@ jobs:
         cmake --build build --target test_install
 
         ccache -s
+        du -hs ~/.cache/ccache
 
     - name: Run tests
       run: |

--- a/.github/workflows/petsc.yml
+++ b/.github/workflows/petsc.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Set Up Cache
       uses: actions/cache@v3
       with:
-        path: ~/.cache
+        path: ~/.cache/ccache
         key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}
         restore-keys: |
              ccache-${{ github.workflow }}-${{ github.job }}-git-
@@ -55,6 +55,7 @@ jobs:
             CLANG_TIDY_ARGS="--config-file=${{github.workspace}}/.clang-tidy --warnings-as-errors=*"
 
         ccache -s
+        du -hs ~/.cache/ccache
 
   save_pr_number:
     if: github.event_name == 'pull_request'

--- a/.github/workflows/sundials.yml
+++ b/.github/workflows/sundials.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Set Up Cache
       uses: actions/cache@v3
       with:
-        path: ~/.cache
+        path: ~/.cache/ccache
         key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}
         restore-keys: |
              ccache-${{ github.workflow }}-${{ github.job }}-git-
@@ -65,6 +65,7 @@ jobs:
             CLANG_TIDY_ARGS="--config-file=${{github.workspace}}/.clang-tidy --warnings-as-errors=*"
 
         ccache -s
+        du -hs ~/.cache/ccache
 
   sundials-cuda:
     name: CUDA SUNDIALS@6.5.0
@@ -82,7 +83,7 @@ jobs:
     - name: Set Up Cache
       uses: actions/cache@v3
       with:
-        path: ~/.cache
+        path: ~/.cache/ccache
         key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}
         restore-keys: |
              ccache-${{ github.workflow }}-${{ github.job }}-git-
@@ -131,6 +132,7 @@ jobs:
         cmake --build build -j 2
 
         ccache -s
+        du -hs ~/.cache/ccache
 
   save_pr_number:
     if: github.event_name == 'pull_request'


### PR DESCRIPTION
Use ~/.cache/ccache instead of ~/.cache as path, because the system might store all kinds of caches in ~/.cache, but we only want to save ccache's cache. (Currently, this is not an issue, but it might be in the future.)

Cache hypre cuda build.