### PR TITLE
Implement StructOfArray::empty() and ParticleTile::empty() for pure SoA

### DIFF
--- a/Src/Particle/AMReX_ParticleTile.H
+++ b/Src/Particle/AMReX_ParticleTile.H
@@ -746,7 +746,11 @@ struct ParticleTile
     SoA&       GetStructOfArrays ()       { return m_soa_tile; }
     const SoA& GetStructOfArrays () const { return m_soa_tile; }
 
+    template <typename T = ParticleType, typename std::enable_if<!T::is_soa_particle, int>::type = 0>
     bool empty () const { return m_aos_tile.empty(); }
+
+    template <typename T = ParticleType, typename std::enable_if<T::is_soa_particle, int>::type = 0>
+    bool empty () const { return m_soa_tile.empty(); }
 
     /**
     * \brief Returns the total number of particles (real and neighbor)

--- a/Src/Particle/AMReX_StructOfArrays.H
+++ b/Src/Particle/AMReX_StructOfArrays.H
@@ -89,6 +89,12 @@ struct StructOfArrays {
     }
 
     /**
+    * \brief Returns whether the SoA is empty (i.e. has size() == 0)
+    *
+    */
+    [[nodiscard]] bool empty () const { return this->size() == 0; }
+
+    /**
     * \brief Returns the number of real particles (excluding neighbors)
     *
     */


### PR DESCRIPTION
The implementation of `ParticleTile::empty()` was wrong for pure SoA, which led to problems in ImpactX: https://github.com/ECP-WarpX/impactx/pull/348/

Follow-up to #2878.

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
