### PR TITLE
ParticleInit: Implicit Int Float Conversion

### DIFF
--- a/Src/Particle/AMReX_ParticleInit.H
+++ b/Src/Particle/AMReX_ParticleInit.H
@@ -998,7 +998,7 @@ InitRandom (Long                    icount,
                         amrex::Real(std::numeric_limits<int>::max()) /
                         amrex::Real(AMREX_SPACEDIM)
                     )
-                ) + "particles"
+                ) + " particles."
             );
         }
         //

--- a/Src/Particle/AMReX_ParticleInit.H
+++ b/Src/Particle/AMReX_ParticleInit.H
@@ -989,7 +989,17 @@ InitRandom (Long                    icount,
     {
         if(icount*AMREX_SPACEDIM >= std::numeric_limits<int>::max())
         {
-            amrex::Abort("InitRandom has serialize=true, but this would cause too much particle data to be sent from IOProc. Set serialize=false, or use fewer than "+std::to_string(amrex::Math::ceil(std::numeric_limits<int>::max()/amrex::Real(AMREX_SPACEDIM)))+ "particles");
+            amrex::Abort(
+                "InitRandom has serialize=true, but this would cause too much "
+                "particle data to be sent from IOProc. Set serialize=false, "
+                "or use fewer than " +
+                std::to_string(
+                    amrex::Math::ceil(
+                        amrex::Real(std::numeric_limits<int>::max()) /
+                        amrex::Real(AMREX_SPACEDIM)
+                    )
+                ) + "particles"
+            );
         }
         //
         // We'll let IOProc generate the particles so we get the same


### PR DESCRIPTION
## Summary

Fix ICX warning:
```
implicit conversion from 'int' to 'amrex::Real' (aka 'float') changes
value from 2147483647 to 2147483648 [-Wimplicit-const-int-float-conversion]
```

## Additional background

First seen in https://github.com/ECP-WarpX/impactx/pull/318 during built of pyAMReX.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
