### PR TITLE
Run PODVector::push_back on GPU

### DIFF
--- a/Src/Base/AMReX_PODVector.H
+++ b/Src/Base/AMReX_PODVector.H
@@ -476,7 +476,7 @@ namespace amrex
         void push_back (const T& a_value) noexcept
         {
             if (m_size == m_capacity) AllocateBuffer(GetNewCapacity(1));
-            m_data[m_size] = a_value;
+            detail::uninitializedFillNImpl<Allocator>(m_data+m_size, 1, a_value, *this);
             ++m_size;
         }
 


### PR DESCRIPTION
There are two versions of PODVector::push_back. The `const&` version previously ran on CPU, whereas the `&&` version on GPU. It seems that they should have the same behavior. Thus the `const&` version now runs on GPU.

(We may not even need to have two versions, because the move (i.e., `&&`) version does not move. It calls another function that takes `const&`.)
