### PR TITLE
HIP Debug Build

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -82,6 +82,12 @@ jobs:
           ccache -s
           du -hs ~/.cache/ccache
 
+          # Make sure CodeQL has something to do
+          touch Src/Base/AMReX.cpp
+          export CCACHE_DISABLE=1
+          cd build
+          make -j 2
+
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v2
         with:

--- a/Tools/GNUMake/Make.defs
+++ b/Tools/GNUMake/Make.defs
@@ -56,7 +56,6 @@ else
 endif
 
 ifeq ($(USE_HIP),TRUE)
-  DEBUG := FALSE  # Currently there is a compiler bug for DEBUG=TRUE.
   USE_CUDA := FALSE
   override COMP = hip
   ifneq ($(NO_CONFIG_CHECKING),TRUE)

--- a/Tools/GNUMake/comps/hip.mak
+++ b/Tools/GNUMake/comps/hip.mak
@@ -83,8 +83,8 @@ endif  # BL_NO_FORT
 ifeq ($(HIP_COMPILER),clang)
 
   ifeq ($(DEBUG),TRUE)
-    CXXFLAGS += -g -O0 #-ftrapv
-    CFLAGS   += -g -O0 #-ftrapv
+    CXXFLAGS += -g -O1 -munsafe-fp-atomics
+    CFLAGS   += -g -O0
 
     FFLAGS   += -g -O0 -ggdb -fbounds-check -fbacktrace -Wuninitialized -Wunused -ffpe-trap=invalid,zero -finit-real=snan -finit-integer=2147483647 -ftrapv
     F90FLAGS += -g -O0 -ggdb -fbounds-check -fbacktrace -Wuninitialized -Wunused -ffpe-trap=invalid,zero -finit-real=snan -finit-integer=2147483647 -ftrapv


### PR DESCRIPTION
Use -O1 instead of -O0, because the HIP compiler has various issues with the latter. For example, it segfaults when compiling WarpX. It fails with errors of size exceeding limit at link time when compiling Tests/Amr/Advection_AmrCore/Exec. Now both codes work (with GNU Make).

Add -munsafe-fp-atomics in debug mode too.

The changes are for GNU Make only. Even with `-O1`, CMake still does not work.