### PR TITLE
GNU Make: use CLANG_TIDY_CONFIG_FILE if it's set

### DIFF
--- a/Tools/GNUMake/tools/Make.clang-tidy
+++ b/Tools/GNUMake/tools/Make.clang-tidy
@@ -6,10 +6,9 @@ clang_tidy_version = $(shell $(CLANG_TIDY) --version | grep "LLVM version" | awk
 clang_tidy_ge_12 = $(shell expr $(clang_tidy_version) \>= 12)
 
 ifeq ($(clang_tidy_ge_12),1)
-  ifndef CLANG_TIDY_CONFIG_FILE
-    # If you do not specify a config file, we will use the one in amrex.
-    CLANG_TIDY_ARGS += --config-file=$(AMREX_HOME)/.clang-tidy
-  endif
+  # If you do not specify a config file, we will use the one in amrex.
+  CLANG_TIDY_CONFIG_FILE ?= $(AMREX_HOME)/.clang-tidy
+  CLANG_TIDY_ARGS += --config-file=$(CLANG_TIDY_CONFIG_FILE)
 endif
 
 ifeq ($(CLANG_TIDY_WARN_ERROR),TRUE)


### PR DESCRIPTION
## Summary

If a downstream project defined `CLANG_TIDY_CONFIG_FILE` with their own config, it didn't actually get added to the clang-tidy arguments. This PR makes `CLANG_TIDY_CONFIG_FILE` default to the amrex config file instead.

## Additional background

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
