### PR TITLE
GNU Make: allow skipping paths when running clang-tidy

### DIFF
--- a/Tools/GNUMake/Make.rules
+++ b/Tools/GNUMake/Make.rules
@@ -264,7 +264,9 @@ ifeq ($(LOG_BUILD_TIME),TRUE)
 	@date +"%s" > $(tmpEXETempDir)/$(notdir $<).log
 endif
 ifeq ($(USE_CLANG_TIDY),TRUE)
-	$(SILENT) $(CLANG_TIDY) $(CLANG_TIDY_ARGS) $< -- $(CXXFLAGS) $(EXTRACXXFLAGS) $(CPPFLAGS) $(includes) $(mpicxx_include_dirs)
+# for each word in CLANG_TIDY_IGNORE_SOURCES, check if that word is in the absolute path of the source file
+# if any word matches, the result will be non-empty after stripping whitespace, so clang-tidy won't be run
+	$(if $(strip $(foreach pat,$(CLANG_TIDY_IGNORE_SOURCES),$(findstring $(pat),$(abspath $<)))),,$(SILENT) $(CLANG_TIDY) $(CLANG_TIDY_ARGS) $< -- $(CXXFLAGS) $(EXTRACXXFLAGS) $(CPPFLAGS) $(includes) $(mpicxx_include_dirs))
 endif
 	$(SILENT) $(CCACHE_COMMAND) $(CCACHEFLAGS) $(CXX) $(DEPFLAGS) $(CXXFLAGS) $(EXTRACXXFLAGS) $(CPPFLAGS) $(includes) $(mpicxx_include_dirs) -c $< $(EXE_OUTPUT_OPTION)
 ifeq ($(LOG_BUILD_TIME),TRUE)

--- a/Tools/GNUMake/tools/Make.clang-tidy
+++ b/Tools/GNUMake/tools/Make.clang-tidy
@@ -1,6 +1,8 @@
 
 CLANG_TIDY = clang-tidy
 CLANG_TIDY_ARGS = --extra-arg=-Wno-unknown-warning-option --extra-arg-before=--driver-mode=g++
+# space-separated list of paths to skip, matched against the absolute path of each source file
+CLANG_TIDY_IGNORE_SOURCES ?=
 
 clang_tidy_version = $(shell $(CLANG_TIDY) --version | grep "LLVM version" | awk '{print $$3}' | awk 'BEGIN {FS = "."} {print $$1}')
 clang_tidy_ge_12 = $(shell expr $(clang_tidy_version) \>= 12)


### PR DESCRIPTION
## Summary

Downstream projects can set `CLANG_TIDY_IGNORE_SOURCES` to a space-separated list of paths under which clang-tidy should not be run.

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
