### PR TITLE
Add get/set of AMRErrorTagInfo in AMRErrorTag

### DIFF
--- a/Src/AmrCore/AMReX_ErrorList.H
+++ b/Src/AmrCore/AMReX_ErrorList.H
@@ -482,6 +482,10 @@ std::ostream& operator << (std::ostream& os, const ErrorList& elst);
     int NGrow() const noexcept {return m_ngrow;}
     const std::string& Field () const noexcept {return m_field;}
 
+    AMRErrorTagInfo& GetInfo () noexcept {return m_info;}
+    AMRErrorTagInfo const& GetInfo () noexcept {return m_info;}
+    void SetInfo (AMRErrorTagInfo info) noexcept {m_info = info;}
+
   protected:
     int SetNGrow () const noexcept;
 

--- a/Src/AmrCore/AMReX_ErrorList.H
+++ b/Src/AmrCore/AMReX_ErrorList.H
@@ -483,7 +483,7 @@ std::ostream& operator << (std::ostream& os, const ErrorList& elst);
     const std::string& Field () const noexcept {return m_field;}
 
     AMRErrorTagInfo& GetInfo () noexcept {return m_info;}
-    AMRErrorTagInfo const& GetInfo () noexcept {return m_info;}
+    AMRErrorTagInfo const& GetInfo () const noexcept {return m_info;}
     void SetInfo (AMRErrorTagInfo info) noexcept {m_info = info;}
 
   protected:

--- a/Src/AmrCore/AMReX_ErrorList.H
+++ b/Src/AmrCore/AMReX_ErrorList.H
@@ -484,7 +484,7 @@ std::ostream& operator << (std::ostream& os, const ErrorList& elst);
 
     AMRErrorTagInfo& GetInfo () noexcept {return m_info;}
     AMRErrorTagInfo const& GetInfo () const noexcept {return m_info;}
-    void SetInfo (AMRErrorTagInfo info) noexcept {m_info = info;}
+    void SetInfo (AMRErrorTagInfo const& info) noexcept {m_info = info;}
 
   protected:
     int SetNGrow () const noexcept;


### PR DESCRIPTION
## Summary
This add Get/Set routines of the AMRErrorTagInfo object in AMRErrorTag.

## Additional background
The purpose of this change is to allow dynamically changing the error tag info objects (without creating whole new ones). The larger goal is to allow more control over whether a regard is done or not.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
