### PR TITLE
Fix: AMReXConfig.cmake Multi-Dim

### DIFF
--- a/Tools/CMake/AMReXConfig.cmake.in
+++ b/Tools/CMake/AMReXConfig.cmake.in
@@ -236,11 +236,13 @@ endif ()
 # CMake targets
 include( "${CMAKE_CURRENT_LIST_DIR}/AMReXTargets.cmake" )
 
-# CMake targets aliases: last dimension built will be our legacy target
-list(LENGTH AMReX_SPACEDIM list_len)
-math(EXPR list_last "${list_len} - 1")
-list(GET AMReX_SPACEDIM ${list_last} AMReX_SPACEDIM_LAST)
-add_library(AMReX::amrex ALIAS AMReX::amrex_${AMReX_SPACEDIM_LAST}d)
+# CMake targets aliase: last dimension built will be our legacy target
+if (NOT TARGET AMReX::amrex)  # protection in case of multiple inclusions
+    list(LENGTH AMReX_SPACEDIM list_len)
+    math(EXPR list_last "${list_len} - 1")
+    list(GET AMReX_SPACEDIM ${list_last} AMReX_SPACEDIM_LAST)
+    add_library(AMReX::amrex ALIAS AMReX::amrex_${AMReX_SPACEDIM_LAST}d)
+endif()
 
 # More Modern CUDA CMake
 if (@CMAKE_VERSION@ VERSION_GREATER_EQUAL 3.20 AND @AMReX_CUDA@)

--- a/Tools/CMake/AMReXConfig.cmake.in
+++ b/Tools/CMake/AMReXConfig.cmake.in
@@ -244,11 +244,13 @@ add_library(AMReX::amrex ALIAS AMReX::amrex_${AMReX_SPACEDIM_LAST}d)
 
 # More Modern CUDA CMake
 if (@CMAKE_VERSION@ VERSION_GREATER_EQUAL 3.20 AND @AMReX_CUDA@)
-   # CUDA architectures amrex was built for -- should we make
-   set(AMREX_CUDA_ARCHS @AMREX_CUDA_ARCHS@ CACHE INTERNAL "CUDA archs AMReX is built for")
-   set_target_properties(AMReX::amrex
-      PROPERTIES
-      CUDA_ARCHITECTURES ${AMREX_CUDA_ARCHS})
+    foreach(D IN LISTS AMReX_SPACEDIM)
+        # CUDA architectures amrex was built for -- should we make
+        set(AMREX_CUDA_ARCHS @AMREX_CUDA_ARCHS@ CACHE INTERNAL "CUDA archs AMReX is built for")
+        set_target_properties(AMReX::amrex_${D}d
+          PROPERTIES
+            CUDA_ARCHITECTURES ${AMREX_CUDA_ARCHS})
+    endforeach()
 endif ()
 
 #


### PR DESCRIPTION
## Summary

Fix two regressions from #3309 in the installed `AMReXConfig.cmake`:
```
CMake Error at lib/cmake/AMReX/AMReXConfig.cmake:257 (add_library):
  add_library cannot create ALIAS target "AMReX::amrex" because another
  target with the same name already exists.
```

and setting properties for newer CUDA.

## Additional background

Regression to #3309, spotted by @drangara, @ajnonaka, wdf et al. 

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
