### PR TITLE
RealBox: Accept RealVect Setters

### DIFF
--- a/Src/Base/AMReX_RealBox.H
+++ b/Src/Base/AMReX_RealBox.H
@@ -30,7 +30,7 @@ public:
 
     //! Construct region given diagonal points.
     AMREX_GPU_HOST_DEVICE
-    RealBox (const Vector<Real>& a_lo, const Vector<Real>& a_hi) noexcept
+    RealBox (const RealVect& a_lo, const RealVect& a_hi) noexcept
         : xlo{AMREX_D_DECL(a_lo[0],a_lo[1],a_lo[2])}, xhi{AMREX_D_DECL(a_hi[0],a_hi[1],a_hi[2])} {}
 
     RealBox (const std::array<Real,AMREX_SPACEDIM>& a_lo,

--- a/Src/Base/AMReX_RealBox.H
+++ b/Src/Base/AMReX_RealBox.H
@@ -28,11 +28,6 @@ public:
     RealBox (const Real* a_lo, const Real* a_hi) noexcept
         : xlo{AMREX_D_DECL(a_lo[0],a_lo[1],a_lo[2])}, xhi{AMREX_D_DECL(a_hi[0],a_hi[1],a_hi[2])} {}
 
-    //! Construct region given diagonal points.
-    AMREX_GPU_HOST_DEVICE
-    RealBox (const RealVect& a_lo, const RealVect& a_hi) noexcept
-        : xlo{AMREX_D_DECL(a_lo[0],a_lo[1],a_lo[2])}, xhi{AMREX_D_DECL(a_hi[0],a_hi[1],a_hi[2])} {}
-
     RealBox (const std::array<Real,AMREX_SPACEDIM>& a_lo,
              const std::array<Real,AMREX_SPACEDIM>& a_hi) noexcept;
 

--- a/Src/Base/AMReX_RealBox.H
+++ b/Src/Base/AMReX_RealBox.H
@@ -28,6 +28,11 @@ public:
     RealBox (const Real* a_lo, const Real* a_hi) noexcept
         : xlo{AMREX_D_DECL(a_lo[0],a_lo[1],a_lo[2])}, xhi{AMREX_D_DECL(a_hi[0],a_hi[1],a_hi[2])} {}
 
+    //! Construct region given diagonal points.
+    AMREX_GPU_HOST_DEVICE
+    RealBox (const Vector<Real>& a_lo, const Vector<Real>& a_hi) noexcept
+        : xlo{AMREX_D_DECL(a_lo[0],a_lo[1],a_lo[2])}, xhi{AMREX_D_DECL(a_hi[0],a_hi[1],a_hi[2])} {}
+
     RealBox (const std::array<Real,AMREX_SPACEDIM>& a_lo,
              const std::array<Real,AMREX_SPACEDIM>& a_hi) noexcept;
 
@@ -64,12 +69,16 @@ public:
     void setLo (const Real* a_lo) noexcept { AMREX_D_EXPR(xlo[0] = a_lo[0], xlo[1] = a_lo[1], xlo[2] = a_lo[2]); }
     //! Sets lo side.
     void setLo (const Vector<Real>& a_lo) noexcept { AMREX_D_EXPR(xlo[0] = a_lo[0], xlo[1] = a_lo[1], xlo[2] = a_lo[2]); }
+    //! Sets lo side.
+    void setLo (const RealVect& a_lo) noexcept { AMREX_D_EXPR(xlo[0] = a_lo[0], xlo[1] = a_lo[1], xlo[2] = a_lo[2]); }
     //! Sets lo side in specified direction.
     void setLo (int dir, Real a_lo) noexcept { BL_ASSERT(dir >= 0 && dir < AMREX_SPACEDIM); xlo[dir] = a_lo; }
     //! Sets hi side.
     void setHi (const Real* a_hi) noexcept { AMREX_D_EXPR(xhi[0] = a_hi[0], xhi[1] = a_hi[1], xhi[2] = a_hi[2]); }
     //! Sets hi side.
     void setHi (const Vector<Real>& a_hi) noexcept { AMREX_D_EXPR(xhi[0] = a_hi[0], xhi[1] = a_hi[1], xhi[2] = a_hi[2]); }
+    //! Sets hi side.
+    void setHi (const RealVect& a_hi) noexcept { AMREX_D_EXPR(xhi[0] = a_hi[0], xhi[1] = a_hi[1], xhi[2] = a_hi[2]); }
     //! Sets hi side in specified direction.
     void setHi (int dir, Real a_hi) noexcept { BL_ASSERT(dir >= 0 && dir < AMREX_SPACEDIM); xhi[dir] = a_hi; }
     //! Is the RealBox OK; i.e. does it have non-negative volume?


### PR DESCRIPTION
## Summary

Add constructor and overloads to RealVect.

## Additional background

Best fitting type to set in compact math. Want to use in ImpactX.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
