### PR TITLE
Fix Pure SOA RedistributeGPU: size from ptile, not the AoS

### DIFF
--- a/Src/Particle/AMReX_ParticleContainerI.H
+++ b/Src/Particle/AMReX_ParticleContainerI.H
@@ -1284,13 +1284,7 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator>
             auto index = std::make_pair(gid, tid);
 
             auto& src_tile = plev[index];
-            auto& aos = src_tile.GetArrayOfStructs();
-            const size_t np = aos.numParticles();
-
-            AMREX_ASSERT_WITH_MESSAGE((NumRealComps() == 0 && NumIntComps() == 0) ||
-                                      aos.size() == src_tile.GetStructOfArrays().size(),
-                "The AoS and SoA data on this tile are different sizes - "
-                "perhaps particles have not been initialized correctly?");
+            const size_t np = src_tile.numParticles();
 
             int num_stay = partitionParticlesByDest(src_tile, assign_grid, BufferMap(),
                                                     plo, phi, rlo, rhi, is_per, lev, gid, tid,


### PR DESCRIPTION
Follow-up to #2878.

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
