### PR TITLE
Reinforce __CUDACC__ conditionals w/ AMREX_USE_CUDA

### DIFF
--- a/Src/Base/AMReX_CudaGraph.H
+++ b/Src/Base/AMReX_CudaGraph.H
@@ -2,7 +2,7 @@
 #define AMREX_CUDA_GRAPH_H_
 #include <AMReX_Config.H>
 
-#if defined(__CUDACC__)
+#if defined(__CUDACC__) && defined(AMREX_USE_CUDA)
 
 #include <AMReX.H>
 #include <AMReX_Array.H>

--- a/Src/Base/AMReX_FBI.H
+++ b/Src/Base/AMReX_FBI.H
@@ -385,7 +385,7 @@ FabArray<FAB>::CMD_remote_setVal_gpu (typename FabArray<FAB>::value_type x,
     });
 }
 
-#if defined(__CUDACC__)
+#if defined(__CUDACC__) && defined (AMREX_USE_CUDA)
 template <class FAB>
 void
 FabArray<FAB>::FB_local_copy_cuda_graph_1 (const FB& TheFB, int scomp, int ncomp)
@@ -551,7 +551,7 @@ FabArray<FAB>::FB_local_copy_cuda_graph_n (const FB& TheFB, int scomp, int ncomp
 
 #ifdef AMREX_USE_GPU
 
-#if defined(__CUDACC__)
+#if defined(__CUDACC__) && defined(AMREX_USE_CUDA)
 
 template <class FAB>
 void

--- a/Src/Base/AMReX_FabArrayBase.H
+++ b/Src/Base/AMReX_FabArrayBase.H
@@ -492,7 +492,7 @@ public:
         Long         m_nuse{0};
         bool         m_multi_ghost = false;
         //
-#if defined(__CUDACC__)
+#if defined(__CUDACC__) && defined (AMREX_USE_CUDA)
         CudaGraph<CopyMemory> m_localCopy;
         CudaGraph<CopyMemory> m_copyToBuffer;
         CudaGraph<CopyMemory> m_copyFromBuffer;

--- a/Src/Base/AMReX_FabArrayCommI.H
+++ b/Src/Base/AMReX_FabArrayCommI.H
@@ -38,7 +38,7 @@ FabArray<FAB>::FBEP_nowait (int scomp, int ncomp, const IntVect& nghost,
 #ifdef AMREX_USE_GPU
         if (Gpu::inLaunchRegion())
         {
-#if defined(__CUDACC__)
+#if defined(__CUDACC__) && defined(AMREX_USE_CUDA)
             if (Gpu::inGraphRegion())
             {
                 FB_local_copy_cuda_graph_1(TheFB, scomp, ncomp);
@@ -110,7 +110,7 @@ FabArray<FAB>::FBEP_nowait (int scomp, int ncomp, const IntVect& nghost,
 #ifdef AMREX_USE_GPU
         if (Gpu::inLaunchRegion())
         {
-#if defined(__CUDACC__)
+#if defined(__CUDACC__) && defined(AMREX_USE_CUDA)
             if (Gpu::inGraphRegion()) {
                 FB_pack_send_buffer_cuda_graph(TheFB, scomp, ncomp, send_data, send_size, send_cctc);
             }
@@ -140,7 +140,7 @@ FabArray<FAB>::FBEP_nowait (int scomp, int ncomp, const IntVect& nghost,
 #ifdef AMREX_USE_GPU
         if (Gpu::inLaunchRegion())
         {
-#if defined(__CUDACC__)
+#if defined(__CUDACC__) && defined(AMREX_USE_CUDA)
             if (Gpu::inGraphRegion()) {
                 FB_local_copy_cuda_graph_n(TheFB, scomp, ncomp);
             }
@@ -205,7 +205,7 @@ FabArray<FAB>::FillBoundary_finish ()
 #ifdef AMREX_USE_GPU
         if (Gpu::inLaunchRegion())
         {
-#if defined(__CUDACC__)
+#if defined(__CUDACC__) && defined(AMREX_USE_CUDA)
             if (Gpu::inGraphRegion())
             {
                 FB_unpack_recv_buffer_cuda_graph(*TheFB, fbd->scomp, fbd->ncomp,

--- a/Src/Base/AMReX_GpuDevice.cpp
+++ b/Src/Base/AMReX_GpuDevice.cpp
@@ -93,7 +93,7 @@ namespace {
     {
         amrex::ignore_unused(graph_size);
 
-#if defined(__CUDACC__)
+#if defined(__CUDACC__) && defined(AMREX_USE_CUDA)
 
         BL_PROFILE("InitGraph");
 
@@ -693,7 +693,7 @@ Device::streamSynchronizeAll () noexcept
 #endif
 }
 
-#if defined(__CUDACC__)
+#if defined(__CUDACC__) && defined(AMREX_USE_CUDA)
 
 void
 Device::startGraphRecording(bool first_iter, void* h_ptr, void* d_ptr, size_t sz)


### PR DESCRIPTION
## Summary

Same motivation as #3090.
LLVM, the workhorse of most SYCL compilers, doesn't define `__NVCC__` but does define `__CUDACC__`, see [here](https://llvm.org/docs/CompileCudaWithLLVM.html#detecting-clang-vs-nvcc-from-code).
Even though [these aren't exactly the same](https://docs.nvidia.com/cuda/cuda-compiler-driver-nvcc/index.html#nvcc-identification-macro), it feels like for AMReX's purposes they should be fairly equivalent and this is a cleaner patch than checking for `AMREX_USE_CUDA`.

Cheers,
-Nuno

