### PR TITLE
Clang: -Wno-null-conversion for Lexer

### DIFF
--- a/Src/Base/Parser/amrex_parser.lex.cpp
+++ b/Src/Base/Parser/amrex_parser.lex.cpp
@@ -4,6 +4,7 @@
 #pragma GCC diagnostic ignored "-Wfloat-conversion"
 #pragma GCC diagnostic ignored "-Wsign-compare"
 #elif defined(__clang__)
+#pragma clang diagnostic ignored "-Wnull-conversion"
 #pragma clang diagnostic ignored "-Wnull-dereference"
 #pragma clang diagnostic ignored "-Wunreachable-code"
 #pragma clang diagnostic ignored "-Wfloat-conversion"


### PR DESCRIPTION
## Summary

Silence a warning in the lexer used in the parser for Clang 12.

## Additional background

```
/g/g90/huebl1/src/warpx/build_lassen/_deps/fetchedamrex-src/Src/Base/Parser/amrex_iparser.lex.nolint.H:2010:68: warning: implicit conversion of NULL constant to 'bool' [-Wnull-conversion]
while ((yy_buffer_stack) ? yy_buffer_stack[yy_buffer_stack_top] : (__null)) { 
...
```
et al.

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
