### PR TITLE
CMake: Link option when HIP is a language

### DIFF
--- a/Tools/CMake/AMReXParallelBackends.cmake
+++ b/Tools/CMake/AMReXParallelBackends.cmake
@@ -320,6 +320,7 @@ if (AMReX_HIP)
    if(LINKER_HAS_WHOLE_ARCHIVE_OFFLOAD)
        foreach(D IN LISTS AMReX_SPACEDIM)
            target_link_options(amrex_${D}d PUBLIC
+               "$<$<LINK_LANGUAGE:HIP>:SHELL:-Xoffload-linker --whole-archive>"
                "$<$<LINK_LANGUAGE:CXX>:SHELL:-Xoffload-linker --whole-archive>")
        endforeach()
    endif()
@@ -345,6 +346,7 @@ if (AMReX_HIP)
                   -fgpu-rdc)
            else()
                target_link_options(amrex_${D}d PUBLIC
+                  "$<$<LINK_LANGUAGE:HIP>:-fgpu-rdc>"
                   "$<$<LINK_LANGUAGE:CXX>:-fgpu-rdc>")
            endif()
        endforeach()


### PR DESCRIPTION
## Summary

Although HIP is treated as C++ in AMReX CMake, we should add the link options `-Xoffload-linker --whole-archive -fgpu-rdc` when the link language is HIP, not just CXX. Otherwise, an AMReX application code that treats HIP as a CMake supported language will not get those flags.

## Additional background

https://github.com/xsdk-project/xsdk-examples/issues/50

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
