### PR TITLE
Particle Ids: Add int Constants

### DIFF
--- a/Src/Particle/AMReX_Particle.H
+++ b/Src/Particle/AMReX_Particle.H
@@ -15,11 +15,25 @@ namespace amrex {
 
 namespace
 {
-    constexpr Long GhostParticleID    = 549755813887L; // 2**39-1
-    constexpr Long VirtualParticleID  = GhostParticleID-1;
-    constexpr Long LastParticleID     = GhostParticleID-2;
-    constexpr Long DoSplitParticleID  = GhostParticleID-3;
-    constexpr Long NoSplitParticleID  = GhostParticleID-4;
+    /** Used for 64bit Long particle Ids as in AoS layout */
+    namespace LongParticleIds {
+        constexpr Long GhostParticleID = 549755813887L; // 2**39-1
+        constexpr Long VirtualParticleID = GhostParticleID - 1;
+        constexpr Long LastParticleID = GhostParticleID - 2;
+        constexpr Long DoSplitParticleID = GhostParticleID - 3;
+        constexpr Long NoSplitParticleID = GhostParticleID - 4;
+    }
+
+    /** Used for 32bit int particle Ids, as in pure SoA layout */
+    namespace IntParticleIds {
+        constexpr int GhostParticleID = 2147483647; // 2**31-1
+        constexpr int VirtualParticleID = GhostParticleID - 1;
+        constexpr int LastParticleID = GhostParticleID - 2;
+        constexpr int DoSplitParticleID = GhostParticleID - 3;
+        constexpr int NoSplitParticleID = GhostParticleID - 4;
+    }
+
+    using namespace LongParticleIds;
 }
 
 struct ParticleIDWrapper
@@ -427,7 +441,7 @@ Particle<NReal, NInt>::NextID ()
 #endif
     next = the_next_id++;
 
-    if (next > LastParticleID)
+    if (next > LongParticleIds::LastParticleID)
         amrex::Abort("Particle<NReal, NInt>::NextID() -- too many particles");
 
     return next;
@@ -438,7 +452,7 @@ Long
 Particle<NReal, NInt>::UnprotectedNextID ()
 {
     Long next = the_next_id++;
-    if (next > LastParticleID)
+    if (next > LongParticleIds::LastParticleID)
         amrex::Abort("Particle<NReal, NInt>::NextID() -- too many particles");
     return next;
 }

--- a/Src/Particle/AMReX_ParticleContainerI.H
+++ b/Src/Particle/AMReX_ParticleContainerI.H
@@ -677,7 +677,7 @@ struct TransformerVirt
     {
         copyParticle(dst, src, src_i, dst_i);
 
-        (dst.m_aos[dst_i]).id() = VirtualParticleID;
+        (dst.m_aos[dst_i]).id() = LongParticleIds::VirtualParticleID;
         (dst.m_aos[dst_i]).cpu() = 0;
     }
 };
@@ -829,7 +829,7 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator>
              {
                  SuperParticleType p;
                  p.cpu() = 0;
-                 p.id() = VirtualParticleID;
+                 p.id() = LongParticleIds::VirtualParticleID;
 
                  //Set rdata(0) first so we can normalize the weighted fields
                  p.rdata(0) = static_cast<ParticleReal>(partData(i,j,k,AMREX_SPACEDIM));
@@ -920,7 +920,7 @@ struct TransformerGhost
     {
         copyParticle(dst, src, src_i, dst_i);
 
-        (dst.m_aos[dst_i]).id() = GhostParticleID;
+        (dst.m_aos[dst_i]).id() = LongParticleIds::GhostParticleID;
         (dst.m_aos[dst_i]).cpu() = 0;
     }
 };

--- a/Src/Particle/AMReX_ParticleTile.H
+++ b/Src/Particle/AMReX_ParticleTile.H
@@ -347,7 +347,7 @@ struct SoAParticle : SoAParticleBase
     {
     }
 
-    static Long the_next_id;
+    static int the_next_id;
 
     //functions to get id and cpu in the SOA data
 
@@ -382,19 +382,19 @@ struct SoAParticle : SoAParticleBase
         return this->m_particle_tile_data.m_rdata[position_index][m_index];
     }
 
-    static Long NextID ();
+    static int NextID ();
 
     /**
     * \brief This version can only be used inside omp critical.
     */
-    static Long UnprotectedNextID ();
+    static int UnprotectedNextID ();
 
     /**
     * \brief Reset on restart.
     *
     * \param nextid
     */
-    static void NextID (Long nextid);
+    static void NextID (int nextid);
 
 private :
 
@@ -405,10 +405,10 @@ private :
 };
 
 //template <int NArrayReal, int NArrayInt> Long ConstSoAParticle<NArrayReal, NArrayInt>::the_next_id = 1;
-template <int NArrayReal, int NArrayInt> Long SoAParticle<NArrayReal, NArrayInt>::the_next_id = 1;
+template <int NArrayReal, int NArrayInt> int SoAParticle<NArrayReal, NArrayInt>::the_next_id = 1;
 
 template <int NArrayReal, int NArrayInt>
-Long
+int
 SoAParticle<NArrayReal, NArrayInt>::NextID ()
 {
     Long next;
@@ -421,25 +421,25 @@ SoAParticle<NArrayReal, NArrayInt>::NextID ()
 #endif
     next = the_next_id++;
 
-    if (next > LastParticleID)
+    if (next > IntParticleIds::LastParticleID)
         amrex::Abort("SoAParticle<NArrayReal, NArrayInt>::NextID() -- too many particles");
 
     return next;
 }
 
 template <int NArrayReal, int NArrayInt>
-Long
+int
 SoAParticle<NArrayReal, NArrayInt>::UnprotectedNextID ()
 {
-    Long next = the_next_id++;
-    if (next > LastParticleID)
+    int next = the_next_id++;
+    if (next > IntParticleIds::LastParticleID)
         amrex::Abort("SoAParticle<NArrayReal, NArrayInt>::NextID() -- too many particles");
     return next;
 }
 
 template <int NArrayReal, int NArrayInt>
 void
-SoAParticle<NArrayReal, NArrayInt>::NextID (Long nextid)
+SoAParticle<NArrayReal, NArrayInt>::NextID (int nextid)
 {
     the_next_id = nextid;
 }


### PR DESCRIPTION
## Summary

Ideally we do not need them, because 2B particles
generated per GPU is very low, but we do need this temporarily until we find a way to generalize large id values again for pure SoA particle layouts.

cc @AlexanderSinn 

## Additional background

Follow-up to #2878.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
