### PR TITLE
Make sure amrex::Long is wider than int.

### DIFF
--- a/Src/Base/AMReX_INT.H
+++ b/Src/Base/AMReX_INT.H
@@ -5,6 +5,7 @@
 #ifdef __cplusplus
 #include <type_traits>
 #include <cinttypes>
+#include <climits>
 #else
 #ifdef AMREX_TYPECHECK
 #define __attribute__(x)
@@ -12,9 +13,10 @@
 #define __restrict
 #endif
 #include <inttypes.h>
+#include <limits.h>
 #endif
 
-#ifdef _WIN32
+#if (INT_MAX == LONG_MAX)
 typedef          long long amrex_long;
 typedef unsigned long long amrex_ulong;
 #else


### PR DESCRIPTION
This should work on both Windows and 32 bits systems.
 
Close #3344 