### PR TITLE
CI: oneAPI SYCL for Nvidia GPUs

### DIFF
--- a/.github/workflows/dependencies/dependencies_dpcpp.sh
+++ b/.github/workflows/dependencies/dependencies_dpcpp.sh
@@ -35,3 +35,8 @@ do
         || { sleep 10; }
 done
 if [[ ${status} -ne 0 ]]; then exit 1; fi
+
+TOKEN=NDI2ODkwOWI1MjljZDI3ZmM1NThjMzE3ZN7wAAAuqxCriVveW7v4ZivecXw_ZUOqa34K5I_bXu6LG13SzmrOsy0GTZtMi2E3hpORpeDxCejBb-V70nwUqjOCPysp
+curl -o oneapi_nvidia.sh -L "https://developer.codeplay.com/api/v1/products/download?product=oneapi&variant=nvidia&aat=${TOKEN}"
+chmod +x oneapi_nvidia.sh
+sudo ./oneapi_nvidia.sh --yes

--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -98,6 +98,54 @@ jobs:
         ccache -s
         du -hs ~/.cache/ccache
 
+  tests-oneapi-sycl-eb-nvidia:
+    name: oneAPI SYCL for Nvidia GPUs [tests w/ EB]
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Dependencies
+      run: |
+        .github/workflows/dependencies/dependencies_nvcc12.sh
+        .github/workflows/dependencies/dependencies_dpcpp.sh
+        .github/workflows/dependencies/dependencies_ccache.sh
+    - name: Set Up Cache
+      uses: actions/cache@v3
+      with:
+        path: ~/.cache/ccache
+        key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}
+        restore-keys: |
+             ccache-${{ github.workflow }}-${{ github.job }}-git-
+    - name: Build & Install
+      # mkl/rng/device/detail/mrg32k3a_impl.hpp has a number of sign-compare error
+      # mkl/rng/device/detail/mrg32k3a_impl.hpp has missing braces in array-array initalization
+      # clang currently supports CUDA up to version 11.5 and a warning is issued with newer versions
+      env: {CXXFLAGS: "-fsycl -fsycl-targets=nvptx64-nvidia-cuda -fno-operator-names -Werror -Wall -Wextra -Wpedantic -Wnull-dereference -Wfloat-conversion -Wshadow -Woverloaded-virtual -Wextra-semi -Wunreachable-code -Wnon-virtual-dtor -Wno-sign-compare -Wno-missing-braces -Wno-unknown-cuda-version"}
+      run: |
+        export CCACHE_COMPRESS=1
+        export CCACHE_COMPRESSLEVEL=10
+        export CCACHE_MAXSIZE=55M
+        export CCACHE_DEPEND=1
+        ccache -z
+
+        set +e
+        source /opt/intel/oneapi/setvars.sh --include-intel-llvm
+        set -e
+        cmake -S . -B build                                \
+            -DCMAKE_VERBOSE_MAKEFILE=ON                    \
+            -DAMReX_EB=ON                                  \
+            -DAMReX_ENABLE_TESTS=ON                        \
+            -DAMReX_FORTRAN=ON                             \
+            -DAMReX_PARTICLES=ON                           \
+            -DAMReX_GPU_BACKEND=SYCL                       \
+            -DCMAKE_C_COMPILER=$(which icx)                \
+            -DCMAKE_CXX_COMPILER=$(which clang++)          \
+            -DCMAKE_Fortran_COMPILER=$(which ifx)          \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+        cmake --build build --parallel 2
+
+        ccache -s
+        du -hs ~/.cache/ccache
+
 # "Classic" EDG Intel Compiler
 # Ref.: https://github.com/rscohn2/oneapi-ci
 # intel-basekit intel-hpckit are too large in size


### PR DESCRIPTION
Hi @WeiqunZhang, @ax3l,

This is a spin-off from #3341 that targets Nvidia GPUs only and which downloads the required plug-in as part of the workflow's dependencies. A few notes/questions:

1) I'm currently using a (public) token with only 10 allowed daily usages. Apparently there's no IP check, it just works. I've asked Codeplay to generate one for us with a couple hundred allowed usages per day and I think then we should follow @ax3l's suggestion of hiding it from the public as a repo secret.

2) Can we use `ubuntu-latest` instead of `ubuntu-20.04`?

3) How do you decide on the size of the ccache?

4) Can I compile with `AMReX_EB` and `AMReX_Fortran` both `ON` on a single job?  The existing SYCL workflow has two separate jobs, but I couldn't understand why?

5) Even though the default sub-group size is 32, I chose to explicitly pass it to CMake for clarity. Do you think this is sensible or should I just remove the explicit variable?

6) Is there any documentation tweaks that need to (or should) be made? Or would you rather keep this fairly hidden for the time being?

Cheers,
-Nuno