### PR TITLE
NVHPC CI: Disable Tests

### DIFF
--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -149,10 +149,10 @@ jobs:
         nvfortran --version
         cmake --version
 
-        # Disable Fortran due to space limit
+        # Disable Fortran and Tests due to space limit
         cmake -S . -B build                              \
             -DCMAKE_VERBOSE_MAKEFILE=ON                  \
-            -DAMReX_ENABLE_TESTS=ON                      \
+            -DAMReX_ENABLE_TESTS=OFF                     \
             -DAMReX_PARTICLES=ON                         \
             -DAMReX_FORTRAN=OFF                          \
             -DAMReX_GPU_BACKEND=CUDA                     \


### PR DESCRIPTION
With Tests, the CI uses more space than available in a GitHub runner. Disable tests to avoid `LLVM ERROR: IO failure on output stream: No space left on device`.