### PR TITLE
CMake: Enforce >= C++17 for ROCm

### DIFF
--- a/Tools/CMake/AMReXParallelBackends.cmake
+++ b/Tools/CMake/AMReXParallelBackends.cmake
@@ -331,6 +331,11 @@ if (AMReX_HIP)
        # ROCm 4.5: use unsafe floating point atomics, otherwise atomicAdd is much slower
        # 
        target_compile_options(amrex_${D}d PUBLIC $<$<COMPILE_LANGUAGE:CXX>:-munsafe-fp-atomics>)
+
+       # ROCm 5.5: forgets to enforce C++17 (default seems lower)
+       # https://github.com/AMReX-Codes/amrex/issues/3337
+       #
+       target_compile_features(amrex_${D}d PUBLIC cxx_std_17)
    endforeach()
 
    # Equivalently, relocatable-device-code (RDC) flags are needed for `extern`

--- a/Tools/CMake/AMReXParallelBackends.cmake
+++ b/Tools/CMake/AMReXParallelBackends.cmake
@@ -335,7 +335,7 @@ if (AMReX_HIP)
        # ROCm 5.5: forgets to enforce C++17 (default seems lower)
        # https://github.com/AMReX-Codes/amrex/issues/3337
        #
-       target_compile_features(amrex_${D}d PUBLIC cxx_std_17)
+       target_compile_options(amrex_${D}d PUBLIC $<$<COMPILE_LANGUAGE:CXX>:-std=c++17>)
    endforeach()
 
    # Equivalently, relocatable-device-code (RDC) flags are needed for `extern`


### PR DESCRIPTION
## Summary

Check if this adds the C++17 flags again or if there is an undocumented change in defaults that we need to manually address for AMD's Clang fork'd compilers now.

## Additional background

For #3337

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
