### PR TITLE
CMake: AMReX_TEST_TYPE

### DIFF
--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -149,12 +149,12 @@ jobs:
         nvfortran --version
         cmake --version
 
-        # Disable Fortran and Tests due to space limit
         cmake -S . -B build                              \
             -DCMAKE_VERBOSE_MAKEFILE=ON                  \
-            -DAMReX_ENABLE_TESTS=OFF                     \
+            -DAMReX_ENABLE_TESTS=ON                      \
+            -DAMReX_TEST_TYPE=Small                      \
             -DAMReX_PARTICLES=ON                         \
-            -DAMReX_FORTRAN=OFF                          \
+            -DAMReX_FORTRAN=ON                           \
             -DAMReX_GPU_BACKEND=CUDA                     \
             -DCMAKE_C_COMPILER=$(which nvc)              \
             -DCMAKE_CXX_COMPILER=$(which nvc++)          \

--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -152,7 +152,6 @@ jobs:
             -DCMAKE_VERBOSE_MAKEFILE=ON                  \
             -DAMReX_ENABLE_TESTS=ON                      \
             -DAMReX_TEST_TYPE=Small                      \
-            -DAMReX_PARTICLES=ON                         \
             -DAMReX_FORTRAN=ON                           \
             -DAMReX_GPU_BACKEND=CUDA                     \
             -DCMAKE_C_COMPILER=$(which nvc)              \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -169,7 +169,6 @@ endif()
 #
 # Enable CTests
 #
-option(AMReX_ENABLE_TESTS "Enable CTest suite for AMReX"  NO)
 if (AMReX_ENABLE_TESTS)
    enable_testing()
    add_subdirectory(Tests)

--- a/Docs/sphinx_documentation/source/BuildingAMReX.rst
+++ b/Docs/sphinx_documentation/source/BuildingAMReX.rst
@@ -524,6 +524,8 @@ The list of available options is reported in the :ref:`table <tab:cmakevar>` bel
    +------------------------------+-------------------------------------------------+-------------------------+-----------------------+
    | AMReX_ENABLE_TESTS           |  Enable CTest suite                             | NO                      | YES, NO               |
    +------------------------------+-------------------------------------------------+-------------------------+-----------------------+
+   | AMReX_TEST_TYPE              |  Test type -- affects the number of tests       | All                     | All, Small            |
+   +------------------------------+-------------------------------------------------+-------------------------+-----------------------+
    | AMReX_DIFFERENT_COMPILER     |  Allow an app to use a different compiler       | NO                      | YES, NO               |
    +------------------------------+-------------------------------------------------+-------------------------+-----------------------+
    | AMReX_INSTALL                |  Generate Install Targets                       | YES                     | YES, NO               |

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -1,35 +1,4 @@
 #
-# List of subdirectories to search for CMakeLists.
-#
-set( AMREX_TESTS_SUBDIRS AsyncOut MultiBlock Reinit Amr CLZ Parser Parser2 CTOParFor RoundoffDomain)
-
-if (AMReX_PARTICLES)
-   list(APPEND AMREX_TESTS_SUBDIRS Particles)
-endif ()
-
-if (AMReX_EB)
-   list(APPEND AMREX_TESTS_SUBDIRS EB)
-endif ()
-
-if (AMReX_LINEAR_SOLVERS)
-   list(APPEND AMREX_TESTS_SUBDIRS LinearSolvers)
-endif ()
-
-if (AMReX_HDF5)
-   list(APPEND AMREX_TESTS_SUBDIRS HDF5Benchmark)
-endif ()
-
-if (AMReX_FORTRAN_INTERFACES)
-   list(APPEND AMREX_TESTS_SUBDIRS FortranInterface)
-endif ()
-
-if (AMReX_CUDA)
-   list(APPEND AMREX_TESTS_SUBDIRS GPU)
-endif ()
-
-list(TRANSFORM AMREX_TESTS_SUBDIRS PREPEND "${CMAKE_CURRENT_LIST_DIR}/")
-
-#
 # Function to setup the tutorials
 #
 function (setup_test _dim _srcs  _inputs)
@@ -128,17 +97,65 @@ function (setup_test _dim _srcs  _inputs)
 
 endfunction ()
 
+if (AMReX_TEST_TYPE STREQUAL "Small")
 
-#
-# Loop over subdirs and add to the build those containing CMakeLists.txt
-#
-foreach (_subdir IN LISTS AMREX_TESTS_SUBDIRS)
+   add_subdirectory("Amr/Advection_AmrCore")
 
-   file( GLOB_RECURSE _tests "${_subdir}/*CMakeLists.txt" )
+   if (AMReX_PARTICLES)
+      add_subdirectory("Particles/Redistribute")
+   endif ()
 
-   foreach ( _item  IN LISTS _tests)
-      get_filename_component(_dir ${_item} DIRECTORY )
-      add_subdirectory(${_dir})
+   if (AMReX_EB)
+      add_subdirectory("EB/CNS")
+   endif()
+
+   if (AMReX_LINEAR_SOLVERS)
+      add_subdirectory("LinearSolvers/ABecLaplacian_C")
+   endif()
+
+else()
+   #
+   # List of subdirectories to search for CMakeLists.
+   #
+   set( AMREX_TESTS_SUBDIRS AsyncOut MultiBlock Reinit Amr CLZ Parser Parser2 CTOParFor RoundoffDomain)
+
+   if (AMReX_PARTICLES)
+      list(APPEND AMREX_TESTS_SUBDIRS Particles)
+   endif ()
+
+   if (AMReX_EB)
+      list(APPEND AMREX_TESTS_SUBDIRS EB)
+   endif ()
+
+   if (AMReX_LINEAR_SOLVERS)
+      list(APPEND AMREX_TESTS_SUBDIRS LinearSolvers)
+   endif ()
+
+   if (AMReX_HDF5)
+      list(APPEND AMREX_TESTS_SUBDIRS HDF5Benchmark)
+   endif ()
+
+   if (AMReX_FORTRAN_INTERFACES)
+      list(APPEND AMREX_TESTS_SUBDIRS FortranInterface)
+   endif ()
+
+   if (AMReX_CUDA)
+      list(APPEND AMREX_TESTS_SUBDIRS GPU)
+   endif ()
+
+   list(TRANSFORM AMREX_TESTS_SUBDIRS PREPEND "${CMAKE_CURRENT_LIST_DIR}/")
+
+   #
+   # Loop over subdirs and add to the build those containing CMakeLists.txt
+   #
+   foreach (_subdir IN LISTS AMREX_TESTS_SUBDIRS)
+
+      file( GLOB_RECURSE _tests "${_subdir}/*CMakeLists.txt" )
+
+      foreach ( _item  IN LISTS _tests)
+         get_filename_component(_dir ${_item} DIRECTORY )
+         add_subdirectory(${_dir})
+      endforeach ()
+
    endforeach ()
-
-endforeach ()
+endif()

--- a/Tools/CMake/AMReXOptions.cmake
+++ b/Tools/CMake/AMReXOptions.cmake
@@ -463,3 +463,20 @@ print_option(AMReX_CLANG_TIDY)
 cmake_dependent_option(AMReX_CLANG_TIDY_WERROR "Treat clang-tidy warnings as errors" OFF
    "AMReX_CLANG_TIDY" OFF)
 print_option(AMReX_CLANG_TIDY_WERROR)
+
+#
+# Tests  =============================================================
+#
+option(AMReX_ENABLE_TESTS "Enable CTest suite for AMReX" NO)
+print_option(AMReX_ENABLE_TESTS)
+set(AMReX_TEST_TYPE_VALUES "All;Small")
+set(AMReX_TEST_TYPE All CACHE STRING "Type of AMReX Tests: <All,Small>")
+set_property(CACHE AMReX_TEST_TYPE PROPERTY STRINGS ${AMReX_TEST_TYPE_VALUES})
+if (NOT AMReX_TEST_TYPE IN_LIST AMReX_TEST_TYPE_VALUES)
+   message(FATAL_ERROR "AMReX_TEST_TYPE=${AMReX_TEST_TYPE} is not allowed."
+                       " Must be one of ${AMReX_TEST_TYPE_VALUES}.")
+endif()
+if (AMReX_ENABLE_TESTS)
+   message(STATUS "   AMReX_TEST_TYPE = ${AMReX_TEST_TYPE}")
+endif()
+


### PR DESCRIPTION
Add a new option, AMReX_TEST_TYPE=[All|Small]. Be default, all tests are built when AMReX_ENABLE_TEST is on. When the type is small, only four tests are enabled. If a CI job takes too long to compile and run all the tests, we could switch to the small test type.

Re-enable tests and change the test type to Small for the nvhpc CI. We had to disable it due to space limit in. It should no longer be a problem for the small set of tests.
