### PR TITLE
CMake: Enable AMReX_PARTICLES by default

### DIFF
--- a/.github/workflows/ascent.yml
+++ b/.github/workflows/ascent.yml
@@ -26,7 +26,6 @@ jobs:
             -DCMAKE_BUILD_TYPE=Debug \
             -DAMReX_ENABLE_TESTS=ON  \
             -DAMReX_FORTRAN=OFF      \
-            -DAMReX_PARTICLES=ON     \
             -DAMReX_ASCENT=ON
     - name: Build
       run: |

--- a/.github/workflows/clang.yml
+++ b/.github/workflows/clang.yml
@@ -47,7 +47,6 @@ jobs:
             -DAMReX_EB=ON                             \
             -DAMReX_FORTRAN=ON                        \
             -DAMReX_MPI=OFF                           \
-            -DAMReX_PARTICLES=ON                      \
             -DAMReX_PLOTFILE_TOOLS=ON                 \
             -DAMReX_PRECISION=SINGLE                  \
             -DAMReX_PARTICLES_PRECISION=SINGLE        \
@@ -109,7 +108,6 @@ jobs:
             -DAMReX_ENABLE_TESTS=ON                   \
             -DAMReX_FORTRAN=ON                        \
             -DAMReX_MPI=OFF                           \
-            -DAMReX_PARTICLES=ON                      \
             -DAMReX_PRECISION=DOUBLE                  \
             -DAMReX_PARTICLES_PRECISION=SINGLE        \
             -DCMAKE_C_COMPILER=$(which clang-14)      \

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -54,7 +54,6 @@ jobs:
               -DAMReX_EB=ON                              \
               -DAMReX_ENABLE_TESTS=ON                    \
               -DAMReX_FORTRAN=OFF                        \
-              -DAMReX_PARTICLES=ON                       \
               -DCMAKE_VERBOSE_MAKEFILE=ON                \
               -DCMAKE_CXX_COMPILER="/usr/local/bin/g++"
 

--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -41,7 +41,6 @@ jobs:
             -DAMReX_EB=ON                                \
             -DAMReX_ENABLE_TESTS=ON                      \
             -DAMReX_FORTRAN=OFF                          \
-            -DAMReX_PARTICLES=ON                         \
             -DAMReX_GPU_BACKEND=CUDA                     \
             -DCMAKE_C_COMPILER=$(which gcc)              \
             -DCMAKE_CXX_COMPILER=$(which g++)            \
@@ -100,7 +99,6 @@ jobs:
             -DAMReX_EB=ON                                \
             -DAMReX_ENABLE_TESTS=ON                      \
             -DAMReX_FORTRAN=OFF                          \
-            -DAMReX_PARTICLES=ON                         \
             -DAMReX_GPU_BACKEND=CUDA                     \
             -DCMAKE_CUDA_COMPILER_LAUNCHER=ccache        \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
@@ -153,7 +151,6 @@ jobs:
         cmake -S . -B build                              \
             -DCMAKE_VERBOSE_MAKEFILE=ON                  \
             -DAMReX_ENABLE_TESTS=OFF                     \
-            -DAMReX_PARTICLES=ON                         \
             -DAMReX_FORTRAN=OFF                          \
             -DAMReX_GPU_BACKEND=CUDA                     \
             -DCMAKE_C_COMPILER=$(which nvc)              \

--- a/.github/workflows/gcc.yml
+++ b/.github/workflows/gcc.yml
@@ -102,7 +102,6 @@ jobs:
             -DAMReX_EB=ON               \
             -DAMReX_ENABLE_TESTS=ON     \
             -DAMReX_FORTRAN=ON          \
-            -DAMReX_PARTICLES=ON        \
             -DAMReX_SPACEDIM=3          \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
         cmake --build build -j 2
@@ -151,7 +150,6 @@ jobs:
             -DAMReX_EB=ON               \
             -DAMReX_ENABLE_TESTS=ON     \
             -DAMReX_FORTRAN=ON          \
-            -DAMReX_PARTICLES=ON        \
             -DAMReX_SPACEDIM=2          \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
         cmake --build build -j 2
@@ -201,7 +199,6 @@ jobs:
             -DAMReX_EB=OFF              \
             -DAMReX_ENABLE_TESTS=ON     \
             -DAMReX_FORTRAN=ON          \
-            -DAMReX_PARTICLES=ON        \
             -DAMReX_SPACEDIM=1          \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
         cmake --build build -j 2
@@ -257,7 +254,6 @@ jobs:
             -DAMReX_FPE=ON              \
             -DAMReX_FORTRAN=ON          \
             -DAMReX_OMP=ON              \
-            -DAMReX_PARTICLES=ON        \
             -DCMAKE_CXX_STANDARD=20     \
             -DCMAKE_C_COMPILER=$(which gcc-10)              \
             -DCMAKE_CXX_COMPILER=$(which g++-10)            \
@@ -317,7 +313,6 @@ jobs:
             -DAMReX_ENABLE_TESTS=ON     \
             -DAMReX_FORTRAN=ON          \
             -DAMReX_MPI=OFF             \
-            -DAMReX_PARTICLES=ON        \
             -DCMAKE_C_COMPILER=$(which gcc-8)     \
             -DCMAKE_CXX_COMPILER=$(which g++-8)   \
             -DCMAKE_Fortran_COMPILER=$(which gfortran-8) \
@@ -381,7 +376,6 @@ jobs:
             -DAMReX_EB=ON               \
             -DAMReX_ENABLE_TESTS=ON     \
             -DAMReX_FORTRAN=OFF         \
-            -DAMReX_PARTICLES=ON        \
             -DAMReX_FORTRAN=OFF         \
             -DCMAKE_C_COMPILER=$(which gcc-12)     \
             -DCMAKE_CXX_COMPILER=$(which g++-12)   \
@@ -632,7 +626,6 @@ jobs:
             -DAMReX_OMP=ON              \
             -DCMAKE_VERBOSE_MAKEFILE=ON \
             -DAMReX_ENABLE_TESTS=ON     \
-            -DAMReX_PARTICLES=ON        \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
         make -j 2
 

--- a/.github/workflows/hip.yml
+++ b/.github/workflows/hip.yml
@@ -56,7 +56,6 @@ jobs:
             -DCMAKE_VERBOSE_MAKEFILE=ON                   \
             -DAMReX_EB=ON                                 \
             -DAMReX_ENABLE_TESTS=ON                       \
-            -DAMReX_PARTICLES=ON                          \
             -DAMReX_FORTRAN=ON                            \
             -DAMReX_LINEAR_SOLVERS=ON                     \
             -DAMReX_GPU_BACKEND=HIP                       \
@@ -118,7 +117,6 @@ jobs:
             -DCMAKE_VERBOSE_MAKEFILE=ON                   \
             -DAMReX_EB=OFF                                \
             -DAMReX_ENABLE_TESTS=ON                       \
-            -DAMReX_PARTICLES=ON                          \
             -DAMReX_FORTRAN=ON                            \
             -DAMReX_GPU_RDC=OFF                           \
             -DAMReX_LINEAR_SOLVERS=ON                     \

--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -42,7 +42,6 @@ jobs:
             -DAMReX_EB=OFF                                 \
             -DAMReX_ENABLE_TESTS=ON                        \
             -DAMReX_FORTRAN=ON                             \
-            -DAMReX_PARTICLES=ON                           \
             -DAMReX_GPU_BACKEND=SYCL                       \
             -DCMAKE_C_COMPILER=$(which icx)                \
             -DCMAKE_CXX_COMPILER=$(which icpx)             \
@@ -88,7 +87,6 @@ jobs:
             -DAMReX_EB=ON                                  \
             -DAMReX_ENABLE_TESTS=ON                        \
             -DAMReX_FORTRAN=OFF                            \
-            -DAMReX_PARTICLES=ON                           \
             -DAMReX_GPU_BACKEND=SYCL                       \
             -DCMAKE_C_COMPILER=$(which icx)                \
             -DCMAKE_CXX_COMPILER=$(which icpx)             \
@@ -144,7 +142,6 @@ jobs:
             -DAMReX_EB=ON                                  \
             -DAMReX_ENABLE_TESTS=ON                        \
             -DAMReX_FORTRAN=ON                             \
-            -DAMReX_PARTICLES=ON                           \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
         cmake --build build --parallel 2
         cmake --build build --target install

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -41,7 +41,6 @@ jobs:
             -DAMReX_EB=ON               \
             -DAMReX_MPI=OFF             \
             -DAMReX_ENABLE_TESTS=ON     \
-            -DAMReX_PARTICLES=ON        \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
         cmake --build build --parallel 3
 
@@ -79,7 +78,6 @@ jobs:
             -DCMAKE_VERBOSE_MAKEFILE=ON \
             -DAMReX_EB=ON               \
             -DAMReX_ENABLE_TESTS=ON     \
-            -DAMReX_PARTICLES=ON        \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
         cmake --build build --parallel 3
         cmake --build build --target install

--- a/.github/workflows/sensei.yml
+++ b/.github/workflows/sensei.yml
@@ -31,7 +31,6 @@ jobs:
             -DCMAKE_BUILD_TYPE=Debug \
             -DAMReX_ENABLE_TESTS=ON  \
             -DAMReX_FORTRAN=OFF      \
-            -DAMReX_PARTICLES=ON     \
             -DAMReX_SENSEI=ON
     - name: Build
       run: |

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -39,7 +39,6 @@ jobs:
         cmake ..                                  \
             -DCMAKE_VERBOSE_MAKEFILE=ON           \
             -DAMReX_SPACEDIM="1;2;3"              \
-            -DAMReX_PARTICLES=ON                  \
             -DAMReX_EB=ON                         \
             -DCMAKE_CXX_STANDARD=17               \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -46,7 +46,6 @@ jobs:
               -DAMReX_ENABLE_TESTS=ON       `
               -DAMReX_FORTRAN=OFF           `
               -DAMReX_MPI=OFF               `
-              -DAMReX_PARTICLES=ON          `
               -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
         cmake --build build --config Debug -j 2
 
@@ -89,7 +88,6 @@ jobs:
               -DAMReX_ENABLE_TESTS=ON       `
               -DAMReX_FORTRAN=OFF           `
               -DAMReX_MPI=OFF               `
-              -DAMReX_PARTICLES=ON          `
               -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
         cmake --build build --config RelWithDebInfo -j 2
 
@@ -115,8 +113,7 @@ jobs:
               -DAMReX_ENABLE_TESTS=ON       ^
               -DAMReX_FORTRAN=OFF           ^
               -DAMReX_MPI=OFF               ^
-              -DAMReX_OMP=ON                ^
-              -DAMReX_PARTICLES=ON
+              -DAMReX_OMP=ON
         cmake --build build --config Release -j 2
 
   save_pr_number:

--- a/Docs/sphinx_documentation/source/BuildingAMReX.rst
+++ b/Docs/sphinx_documentation/source/BuildingAMReX.rst
@@ -469,7 +469,7 @@ The list of available options is reported in the :ref:`table <tab:cmakevar>` bel
    +------------------------------+-------------------------------------------------+-------------------------+-----------------------+
    | AMReX_EB                     |  Build Embedded Boundary support                | NO                      | YES, NO               |
    +------------------------------+-------------------------------------------------+-------------------------+-----------------------+
-   | AMReX_PARTICLES              |  Build particle classes                         | NO                      | YES, NO               |
+   | AMReX_PARTICLES              |  Build particle classes                         | YES                     | YES, NO               |
    +------------------------------+-------------------------------------------------+-------------------------+-----------------------+
    | AMReX_PARTICLES_PRECISION    |  Set reals precision in particle classes        | Same as AMReX_PRECISION | DOUBLE, SINGLE        |
    +------------------------------+-------------------------------------------------+-------------------------+-----------------------+

--- a/Tools/CMake/AMReXOptions.cmake
+++ b/Tools/CMake/AMReXOptions.cmake
@@ -286,7 +286,7 @@ cmake_dependent_option( AMReX_AMRDATA "Build data services" OFF
    "AMReX_FORTRAN" OFF )
 print_option( AMReX_AMRDATA )
 
-option( AMReX_PARTICLES "Build particle classes" OFF)
+option( AMReX_PARTICLES "Build particle classes" ON)
 print_option( AMReX_PARTICLES )
 
 if (AMReX_PARTICLES)


### PR DESCRIPTION
This adds very little time to building the amrex library because most of the particle codes are in headers. Note that `configure` using GNU Make has had particle on by default already. Also note that this does not affect amrex built with spack because it explicitly sets to the particles variant to false.