### PR TITLE
Fix ccache setup for building CUDA with clang

### DIFF
--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -87,7 +87,8 @@ jobs:
       run: |
         export CCACHE_COMPRESS=1
         export CCACHE_COMPRESSLEVEL=10
-        export CCACHE_MAXSIZE=235M
+        export CCACHE_MAXSIZE=60M
+        export CCACHE_DEPEND=1
         ccache -z
 
         export PATH=/usr/local/nvidia/bin:/usr/local/cuda/bin:${PATH}


### PR DESCRIPTION
Need to set `CCACHE_DEPEND=1`.