### PR TITLE
Add workflow for oneAPI SYCL on Nvidia GPUs

### DIFF
--- a/.github/workflows/dependencies/dependencies_codeplay.sh
+++ b/.github/workflows/dependencies/dependencies_codeplay.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+#
+# Copyright 2020 The AMReX Community
+#
+# License: BSD-3-Clause-LBNL
+
+set -eu -o pipefail
+
+curl -o oneapi_nvidia.sh -LJO "https://developer.codeplay.com/api/v1/products/download?product=oneapi&variant=nvidia&filters[]=linux&aat=$1"
+chmod +x oneapi_nvidia.sh
+sudo ./oneapi_nvidia.sh --yes

--- a/.github/workflows/dependencies/dependencies_codeplay.sh
+++ b/.github/workflows/dependencies/dependencies_codeplay.sh
@@ -6,6 +6,6 @@
 
 set -eu -o pipefail
 
-curl -o oneapi_nvidia.sh -LJO "https://developer.codeplay.com/api/v1/products/download?product=oneapi&variant=nvidia&filters[]=linux&aat=$1"
+curl -o oneapi_nvidia.sh -L "https://developer.codeplay.com/api/v1/products/download?product=oneapi&variant=nvidia&filters[]=linux&aat=$1"
 chmod +x oneapi_nvidia.sh
 sudo ./oneapi_nvidia.sh --yes

--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -96,6 +96,58 @@ jobs:
         ccache -s
         du -hs ~/.cache/ccache
 
+  tests-oneapi-sycl-eb-nvidia:
+    name: oneAPI SYCL for Nvidia GPUs [tests w/ EB]
+    runs-on: ubuntu-latest
+    env:
+      CODEPLAYTOKEN: ${{ secrets.CODEPLAYTOKEN }}
+    steps:
+    - uses: actions/checkout@v3
+    - name: Dependencies
+      if: ${{ env.CODEPLAYTOKEN != '' }}
+      run: |
+        .github/workflows/dependencies/dependencies_nvcc12.sh
+        .github/workflows/dependencies/dependencies_dpcpp.sh
+        .github/workflows/dependencies/dependencies_codeplay.sh ${{ env.CODEPLAYTOKEN }}
+        .github/workflows/dependencies/dependencies_ccache.sh
+    - name: Set Up Cache
+      if: ${{ env.CODEPLAYTOKEN != '' }}
+      uses: actions/cache@v3
+      with:
+        path: ~/.cache/ccache
+        key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}
+        restore-keys: |
+             ccache-${{ github.workflow }}-${{ github.job }}-git-
+    - name: Build & Install
+      if: ${{ env.CODEPLAYTOKEN != '' }}
+      # mkl/rng/device/detail/mrg32k3a_impl.hpp has a number of sign-compare error
+      # mkl/rng/device/detail/mrg32k3a_impl.hpp has missing braces in array-array initalization
+      # clang currently supports CUDA up to version 11.5 and a warning is issued with newer versions
+      env: {CXXFLAGS: "-fsycl -fsycl-targets=nvptx64-nvidia-cuda -fno-operator-names -Werror -Wall -Wextra -Wpedantic -Wnull-dereference -Wfloat-conversion -Wshadow -Woverloaded-virtual -Wextra-semi -Wunreachable-code -Wnon-virtual-dtor -Wno-sign-compare -Wno-missing-braces -Wno-unknown-cuda-version"}
+      run: |
+        export CCACHE_COMPRESS=1
+        export CCACHE_COMPRESSLEVEL=10
+        export CCACHE_MAXSIZE=55M
+        export CCACHE_DEPEND=1
+        ccache -z
+
+        set +e
+        source /opt/intel/oneapi/setvars.sh --include-intel-llvm
+        set -e
+        cmake -S . -B build                                \
+            -DCMAKE_VERBOSE_MAKEFILE=ON                    \
+            -DAMReX_EB=ON                                  \
+            -DAMReX_ENABLE_TESTS=ON                        \
+            -DAMReX_TEST_TYPE=Small                        \
+            -DAMReX_GPU_BACKEND=SYCL                       \
+            -DCMAKE_C_COMPILER=$(which icx)                \
+            -DCMAKE_CXX_COMPILER=$(which clang++)          \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+        cmake --build build --parallel 2
+
+        ccache -s
+        du -hs ~/.cache/ccache
+
 # "Classic" EDG Intel Compiler
   tests-icc:
     name: ICC [tests]


### PR DESCRIPTION
The Codeplay token used in this workflow is saved as a secret. Because of how GitHub secrets work, the workflow will only run when a PR is merged, not when it's trigger by a PR from an outside fork.
