### PR TITLE
EB 2D: Fix levelset on nodes adjacent to covered edges

### DIFF
--- a/Src/EB/AMReX_EB2_2D_C.cpp
+++ b/Src/EB/AMReX_EB2_2D_C.cpp
@@ -171,13 +171,13 @@ bool set_eb_cell (int i, int j, Array4<EBCellFlag> const& cell,
 
 int build_faces (Box const& bx, Array4<EBCellFlag> const& cell,
                  Array4<Type_t> const& fx, Array4<Type_t> const& fy,
-                 Array4<Real const> const& levset,
+                 Array4<Real> const& levset,
                  Array4<Real const> const& interx, Array4<Real const> const& intery,
                  Array4<Real> const& apx, Array4<Real> const& apy,
                  Array4<Real> const& fcx, Array4<Real> const& fcy,
                  GpuArray<Real,AMREX_SPACEDIM> const& dx,
                  GpuArray<Real,AMREX_SPACEDIM> const& problo,
-                 bool cover_multiple_cuts) noexcept
+                 bool cover_multiple_cuts, int& nsmallfaces) noexcept
 {
 #ifdef AMREX_USE_FLOAT
     constexpr Real small = 1.e-5_rt;
@@ -256,7 +256,7 @@ int build_faces (Box const& bx, Array4<EBCellFlag> const& cell,
         }}
     });
 
-    Gpu::Buffer<int> nmulticuts = {0};
+    Gpu::Buffer<int> nmulticuts = {0, 0};
     int* hp = nmulticuts.hostData();
     int* dp = nmulticuts.data();
 
@@ -289,7 +289,31 @@ int build_faces (Box const& bx, Array4<EBCellFlag> const& cell,
         }
     });
 
+    const Box& nbxg1 = amrex::surroundingNodes(bxg1);
+    const Box& bxg1x = amrex::surroundingNodes(bxg1,0);
+    const Box& bxg1y = amrex::surroundingNodes(bxg1,1);
+    AMREX_HOST_DEVICE_FOR_3D ( nbxg1, i, j, k,
+    {
+        amrex::ignore_unused(k);
+        if (levset(i,j,0) < Real(0.0)) {
+            if ((bxg1x.contains(i  ,j-1,0)
+                 &&          fx(i  ,j-1,0) == Type::covered) ||
+                (bxg1x.contains(i  ,j  ,0)
+                 &&          fx(i  ,j  ,0) == Type::covered) ||
+                (bxg1y.contains(i-1,j  ,0)
+                 &&          fy(i-1,j  ,0) == Type::covered) ||
+                (bxg1y.contains(i  ,j  ,0)
+                 &&          fy(i  ,j  ,0) == Type::covered))
+            {
+                levset(i,j,k) = Real(0.0);
+                Gpu::Atomic::Add(dp+1,1);
+            }
+        }
+    });
+
     nmulticuts.copyToHost();
+
+    nsmallfaces += *(hp+1);
 
     if (*hp > 0 && !cover_multiple_cuts) {
         amrex::Abort("amrex::EB2::build_faces: more than 2 cuts not supported");

--- a/Src/EB/AMReX_EB2_C.H
+++ b/Src/EB/AMReX_EB2_C.H
@@ -19,13 +19,13 @@ namespace amrex::EB2 {
 
 int build_faces (Box const& bx, Array4<EBCellFlag> const& cell,
                  Array4<Type_t> const& fx, Array4<Type_t> const& fy,
-                 Array4<Real const> const& levset,
+                 Array4<Real> const& levset,
                  Array4<Real const> const& interx, Array4<Real const> const& intery,
                  Array4<Real> const& apx, Array4<Real> const& apy,
                  Array4<Real> const& fcx, Array4<Real> const& fcy,
                  GpuArray<Real,AMREX_SPACEDIM> const& dx,
                  GpuArray<Real,AMREX_SPACEDIM> const& problo,
-                 bool cover_multiple_cuts) noexcept;
+                 bool cover_multiple_cuts, int& nsmallcells) noexcept;
 
 void build_cells (Box const& bx, Array4<EBCellFlag> const& cell,
                   Array4<Type_t> const& fx, Array4<Type_t> const& fy,

--- a/Src/EB/AMReX_EB2_C.H
+++ b/Src/EB/AMReX_EB2_C.H
@@ -25,7 +25,7 @@ int build_faces (Box const& bx, Array4<EBCellFlag> const& cell,
                  Array4<Real> const& fcx, Array4<Real> const& fcy,
                  GpuArray<Real,AMREX_SPACEDIM> const& dx,
                  GpuArray<Real,AMREX_SPACEDIM> const& problo,
-                 bool cover_multiple_cuts, int& nsmallcells) noexcept;
+                 bool cover_multiple_cuts, int& nsmallfaces) noexcept;
 
 void build_cells (Box const& bx, Array4<EBCellFlag> const& cell,
                   Array4<Type_t> const& fx, Array4<Type_t> const& fy,

--- a/Src/EB/AMReX_EB2_Level.H
+++ b/Src/EB/AMReX_EB2_Level.H
@@ -438,8 +438,8 @@ GShopLevel<G>::define_fine (G const& gshop, const Geometry& geom,
                                           clst, geom);
                 }
 
-                nmc = build_faces(vbx, cfg, ftx, fty, clst, xip, yip, apx, apy, fcx, fcy,
-                                  dx, problo, cover_multiple_cuts);
+                nmc = build_faces(vbx, cfg, ftx, fty, lst, xip, yip, apx, apy, fcx, fcy,
+                                  dx, problo, cover_multiple_cuts, nsm);
 
                 build_cells(vbx, cfg, ftx, fty, apx, apy, dx, vfr, ctr,
                             bar, bct, bnm, lst, small_volfrac, geom, extend_domain_face,


### PR DESCRIPTION
## Summary

This fixes inconsistency in 2D EB data. When an edge is covered, its edge length is set to zero. If the level set value on its nodes is not set to less than zero, the EB solver LEBNodeFDLaplacian will treat them as normal nodes and that will cause floating point issues.

Note that we have already been doing this kind of fix in 3D.

## Additional background

This issue was reported by @RemiLehe.

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
