### PR TITLE
Fix typo in profiler macro

### DIFF
--- a/Tests/EB_CNS/Source/CNS_advance_box.cpp
+++ b/Tests/EB_CNS/Source/CNS_advance_box.cpp
@@ -14,7 +14,7 @@ CNS::compute_dSdt_box (const Box& bx,
                        Array4<Real      >& dsdtfab,
                        const std::array<FArrayBox*, AMREX_SPACEDIM>& flux)
 {
-    BL_PROFILE("CNS::compute_dSdt__box()");
+    BL_PROFILE("CNS::compute_dSdt_box()");
 
     const auto dxinv = geom.InvCellSizeArray();
 


### PR DESCRIPTION
## Summary
This seems like a small typo in the profiler macro for `CNS::compute_dSdt_box()`.

## Checklist
The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
