### PR TITLE
Amr Class: Synchronization of StateData's Time

### DIFF
--- a/Src/Amr/AMReX_Amr.cpp
+++ b/Src/Amr/AMReX_Amr.cpp
@@ -2108,8 +2108,15 @@ Amr::coarseTimeStep (Real stop_time)
 
     cumtime += dt_level[0];
 
-    amr_level[0]->postCoarseTimeStep(cumtime);
+    // sync up statedata time
+    for (int lev = 0; lev <= finestLevel(); ++lev) {
+        AmrLevel& amrlevel = getLevel(lev);
+        for (auto& statedata : amrlevel.state) {
+            statedata.syncNewTimeLevel(cumtime);
+        }
+    }
 
+    amr_level[0]->postCoarseTimeStep(cumtime);
 
     if (verbose > 0)
     {

--- a/Src/Amr/AMReX_AmrLevel.H
+++ b/Src/Amr/AMReX_AmrLevel.H
@@ -614,7 +614,7 @@ void AmrLevel::RK (int order, int state_type, Real time, Real dt, int iteration,
     MultiFab& S_new = get_new_data(state_type);
     const Real t_old = state[state_type].prevTime();
     const Real t_new = state[state_type].curTime();
-    AMREX_ALWAYS_ASSERT(amrex::almostEqual(time,t_old) && amrex::almostEqual(time+dt,t_new));
+    AMREX_ALWAYS_ASSERT(amrex::almostEqual(time,t_old,10) && amrex::almostEqual(time+dt,t_new,10));
 
     if (order == 2) {
         RungeKutta::RK2(S_old, S_new, time, dt, std::forward<F>(f),

--- a/Src/Amr/AMReX_AmrLevel.cpp
+++ b/Src/Amr/AMReX_AmrLevel.cpp
@@ -40,16 +40,8 @@ AmrLevel::post_timestep (int /*iteration*/)
 }
 
 void
-AmrLevel::postCoarseTimeStep (Real time)
+AmrLevel::postCoarseTimeStep (Real /*time*/)
 {
-    BL_ASSERT(level == 0);
-    // sync up statedata time
-    for (int lev = 0; lev <= parent->finestLevel(); ++lev) {
-        AmrLevel& amrlevel = parent->getLevel(lev);
-        for (int i = 0; i < amrlevel.state.size(); ++i) {
-            amrlevel.state[i].syncNewTimeLevel(time);
-        }
-    }
 }
 
 void


### PR DESCRIPTION
The synchronization of StateData's time is done in a virtual function, AmrLevel::postCoarseTime. However, the issue is the override version of the virtual function often forget to do it. In this PR, the job is instead done in the Amr class directly. This should make the code more robust.

Close #3374 