### PR TITLE
Hypre ILU options

### DIFF
--- a/Src/Extern/HYPRE/AMReX_HypreIJIface.cpp
+++ b/Src/Extern/HYPRE/AMReX_HypreIJIface.cpp
@@ -316,6 +316,10 @@ void HypreIJIface::boomeramg_precond_configure (const std::string& prefix)
             hpp("bamg_ilu_type", HYPRE_BoomerAMGSetILUType);
             hpp("bamg_ilu_level", HYPRE_BoomerAMGSetILULevel);
             hpp("bamg_ilu_max_iter", HYPRE_BoomerAMGSetILUMaxIter);
+            hpp("bamg_ilu_reordering_type", HYPRE_BoomerAMGSetILULocalReordering);
+            hpp("bamg_ilu_tri_solve", HYPRE_BoomerAMGSetILUTriSolve);
+            hpp("bamg_ilu_lower_jacobi_iters", HYPRE_BoomerAMGSetILULowerJacobiIters);
+            hpp("bamg_ilu_upper_jacobi_iters", HYPRE_BoomerAMGSetILUUpperJacobiIters);
         }
         else if (smooth_type == 7) { // Pilut
             hpp("bamg_smooth_num_sweeps", HYPRE_BoomerAMGSetSmoothNumSweeps);

--- a/Src/Extern/HYPRE/AMReX_HypreIJIface.cpp
+++ b/Src/Extern/HYPRE/AMReX_HypreIJIface.cpp
@@ -316,10 +316,12 @@ void HypreIJIface::boomeramg_precond_configure (const std::string& prefix)
             hpp("bamg_ilu_type", HYPRE_BoomerAMGSetILUType);
             hpp("bamg_ilu_level", HYPRE_BoomerAMGSetILULevel);
             hpp("bamg_ilu_max_iter", HYPRE_BoomerAMGSetILUMaxIter);
+#if defined(HYPRE_RELEASE_NUMBER) && (HYPRE_RELEASE_NUMBER >= 22900)
             hpp("bamg_ilu_reordering_type", HYPRE_BoomerAMGSetILULocalReordering);
             hpp("bamg_ilu_tri_solve", HYPRE_BoomerAMGSetILUTriSolve);
             hpp("bamg_ilu_lower_jacobi_iters", HYPRE_BoomerAMGSetILULowerJacobiIters);
             hpp("bamg_ilu_upper_jacobi_iters", HYPRE_BoomerAMGSetILUUpperJacobiIters);
+#endif
         }
         else if (smooth_type == 7) { // Pilut
             hpp("bamg_smooth_num_sweeps", HYPRE_BoomerAMGSetSmoothNumSweeps);


### PR DESCRIPTION
Adding more parameter hooks for ILU smoothers. These options are supported on AMD and Nvidia architectures as of Hypre commit
18b9880 (Jun-15-2023)

Not sure how to do the versioning protections given that this is such a recent push to Hypre master. I am open to suggestions.

## Summary

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
