### PR TITLE
GPU: Always deallocate gpu_rand_state in Finalize()

### DIFF
--- a/Src/Base/AMReX.cpp
+++ b/Src/Base/AMReX.cpp
@@ -693,7 +693,7 @@ amrex::Finalize (amrex::AMReX* pamrex)
     BL_TINY_PROFILE_FINALIZE();
     BL_PROFILE_FINALIZE();
 
-#ifdef AMREX_USE_CUDA
+#ifdef AMREX_USE_GPU
     amrex::DeallocateRandomSeedDevArray();
 #endif
 


### PR DESCRIPTION
## Summary
This fixes #3383.

## Additional background
I noticed this problem when I tried to build an application with multiple `Initialize()` and `Finalize()` calls with HIP e.g. something like:
```cpp
amrex::Initialize(MPI_COMM_WORLD);
<some AMReX code>
amrex::Finalize();
amrex::Initialize(MPI_COMM_WORLD);
<some AMReX code>
amrex::Finalize();
```
I'm not sure if this officially supported but it works fine with CUDA (and with MPI so long as you only initialize and finalize this once outside of the above code) but not with HIP which fails at the second initialization [here](https://github.com/AMReX-Codes/amrex/blob/239d4d89933488e1d8f6e39ceae211ab690aa855/Src/Base/AMReX_Random.cpp#L36) with the error message
```
amrex::Abort::0::CArena::free: unknown pointer !!!
SIGABRT
```

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
