### PR TITLE
Allow users to change the default vector growth stategy

### DIFF
--- a/Src/Base/AMReX.cpp
+++ b/Src/Base/AMReX.cpp
@@ -604,6 +604,7 @@ amrex::Initialize (int& argc, char**& argv, bool build_parm_parse,
     iMultiFab::Initialize();
     VisMF::Initialize();
     AsyncOut::Initialize();
+    VectorGrowthStrategy::Initialize();
 
 #ifdef AMREX_USE_EB
     EB2::Initialize();

--- a/Src/Base/AMReX_PODVector.H
+++ b/Src/Base/AMReX_PODVector.H
@@ -621,7 +621,7 @@ namespace amrex
             while (new_capacity < (capacity() + a_num_to_be_added))
             {
                 new_capacity = static_cast<size_type>(
-                    VectorGrowthStrategy::GetFactor() * (new_capacity + 1));
+                    VectorGrowthStrategy::GetGrowthFactor() * (new_capacity + 1));
             }
 
             return new_capacity;

--- a/Src/Base/AMReX_PODVector.H
+++ b/Src/Base/AMReX_PODVector.H
@@ -621,7 +621,7 @@ namespace amrex
             while (new_capacity < (capacity() + a_num_to_be_added))
             {
                 new_capacity = static_cast<size_type>(
-                    VectorGrowthStrategy::GetGrowthFactor() * (new_capacity + 1));
+                    VectorGrowthStrategy::GetGrowthFactor() * static_cast<Real>(new_capacity + 1));
             }
 
             return new_capacity;

--- a/Src/Base/AMReX_PODVector.H
+++ b/Src/Base/AMReX_PODVector.H
@@ -218,6 +218,14 @@ namespace amrex
         }
     }
 
+    namespace VectorGrowthStrategy
+    {
+        extern AMREX_EXPORT Real growth_factor;
+        inline Real GetGrowthFactor () { return growth_factor; }
+
+        void Initialize ();
+    }
+
     template <class T, class Allocator = std::allocator<T> >
     class PODVector : public Allocator
     {
@@ -612,7 +620,8 @@ namespace amrex
 
             while (new_capacity < (capacity() + a_num_to_be_added))
             {
-                new_capacity = (3 * new_capacity + 1)/2;
+                new_capacity = static_cast<size_type>(
+                    VectorGrowthStrategy::GetFactor() * (new_capacity + 1));
             }
 
             return new_capacity;

--- a/Src/Base/AMReX_PODVector.cpp
+++ b/Src/Base/AMReX_PODVector.cpp
@@ -9,5 +9,13 @@ namespace amrex::VectorGrowthStrategy
     void Initialize () {
         ParmParse pp("amrex");
         pp.queryAdd("vector_growth_factor", growth_factor);
+
+        // sanity checks
+        auto eps = std::numeric_limits<Real>::epsilon();
+        auto huge = 1000._rt;  // huge enough for our purposes...
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(growth_factor - 1.0_rt >= eps,
+            "User-specified vector growth factor is too small.");
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(growth_factor < huge,
+            "User-specified vector growth factor is too large.");
     }
 }

--- a/Src/Base/AMReX_PODVector.cpp
+++ b/Src/Base/AMReX_PODVector.cpp
@@ -10,12 +10,24 @@ namespace amrex::VectorGrowthStrategy
         ParmParse pp("amrex");
         pp.queryAdd("vector_growth_factor", growth_factor);
 
-        // sanity checks
-        auto eps = std::numeric_limits<Real>::epsilon();
-        auto huge = 1000._rt;  // huge enough for our purposes...
-        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(growth_factor - 1.0_rt >= eps,
-            "User-specified vector growth factor is too small.");
-        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(growth_factor < huge,
-            "User-specified vector growth factor is too large.");
+        // clamp user input to reasonable values
+        constexpr Real min_factor = 1.05_rt;
+        constexpr Real max_factorf = 4._rt;
+
+        if (growth_factor < min_factor) {
+            if (Verbose()) {
+                amrex::Print() << "Warning: user-provided vector growth factor is to small."
+                               << " Clamping to " << min_factor << ". \n";
+            }
+            growth_factor = min_factor;
+        }
+
+        if (growth_factor > max_factor) {
+            if (Verbose()) {
+                amrex::Print() << "Warning: user-provided vector growth factor is to large."
+                               << " Clamping to " << max_factor << ". \n";
+            }
+            growth_factor = max_factor;
+        }
     }
 }

--- a/Src/Base/AMReX_PODVector.cpp
+++ b/Src/Base/AMReX_PODVector.cpp
@@ -12,7 +12,7 @@ namespace amrex::VectorGrowthStrategy
 
         // clamp user input to reasonable values
         constexpr Real min_factor = 1.05_rt;
-        constexpr Real max_factorf = 4._rt;
+        constexpr Real max_factor = 4._rt;
 
         if (growth_factor < min_factor) {
             if (Verbose()) {

--- a/Src/Base/AMReX_PODVector.cpp
+++ b/Src/Base/AMReX_PODVector.cpp
@@ -24,7 +24,7 @@ namespace amrex::VectorGrowthStrategy
 
         if (growth_factor > max_factor) {
             if (Verbose()) {
-                amrex::Print() << "Warning: user-provided vector growth factor is to large."
+                amrex::Print() << "Warning: user-provided vector growth factor is too large."
                                << " Clamping to " << max_factor << ". \n";
             }
             growth_factor = max_factor;

--- a/Src/Base/AMReX_PODVector.cpp
+++ b/Src/Base/AMReX_PODVector.cpp
@@ -4,7 +4,7 @@
 
 namespace amrex::VectorGrowthStrategy
 {
-    Real growth_factor = 1.5._rt;
+    Real growth_factor = 1.5_rt;
 
     void Initialize () {
         ParmParse pp("amrex");

--- a/Src/Base/AMReX_PODVector.cpp
+++ b/Src/Base/AMReX_PODVector.cpp
@@ -16,7 +16,7 @@ namespace amrex::VectorGrowthStrategy
 
         if (growth_factor < min_factor) {
             if (Verbose()) {
-                amrex::Print() << "Warning: user-provided vector growth factor is to small."
+                amrex::Print() << "Warning: user-provided vector growth factor is too small."
                                << " Clamping to " << min_factor << ". \n";
             }
             growth_factor = min_factor;

--- a/Src/Base/AMReX_PODVector.cpp
+++ b/Src/Base/AMReX_PODVector.cpp
@@ -1,0 +1,13 @@
+#include <AMReX_PODVector.H>
+#include <AMReX_ParmParse.H>
+#include <AMReX_REAL.H>
+
+namespace amrex::VectorGrowthStrategy
+{
+    Real growth_factor = 1.5._rt;
+
+    void Initialize () {
+        ParmParse pp("amrex");
+        pp.queryAdd("vector_growth_factor", growth_factor);
+    }
+}

--- a/Src/Base/CMakeLists.txt
+++ b/Src/Base/CMakeLists.txt
@@ -25,6 +25,7 @@ foreach(D IN LISTS AMReX_SPACEDIM)
        AMReX_Exception.H
        AMReX_Extension.H
        AMReX_PODVector.H
+       AMReX_PODVector.cpp
        AMReX_ParmParse.cpp
        AMReX_parmparse_fi.cpp
        AMReX_ParmParse.H

--- a/Src/Base/Make.package
+++ b/Src/Base/Make.package
@@ -17,6 +17,7 @@ C$(AMREX_BASE)_headers += AMReX_Demangle.H AMReX_Extension.H
 C$(AMREX_BASE)_headers += AMReX_GpuComplex.H
 
 C$(AMREX_BASE)_headers += AMReX_PODVector.H
+C$(AMREX_BASE)_sources += AMReX_PODVector.cpp
 
 C$(AMREX_BASE)_headers += AMReX_BlockMutex.H
 C$(AMREX_BASE)_sources += AMReX_BlockMutex.cpp


### PR DESCRIPTION
This allows users to set at runtime an alternate to the default vector growth factor of 1.5. This could help save memory in simulations that use a lot of particles and are close to the capacity of the GPU device.

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
