### PR TITLE
Fix allocateSlice for EB

### DIFF
--- a/Src/Base/AMReX_MultiFabUtil.cpp
+++ b/Src/Base/AMReX_MultiFabUtil.cpp
@@ -47,9 +47,9 @@ namespace {
         }
         BoxArray slice_ba(&boxes[0], static_cast<int>(boxes.size()));
         DistributionMapping slice_dmap(std::move(procs));
-        std::unique_ptr<MultiFab> slice(new MultiFab(slice_ba, slice_dmap, ncomp, 0,
-                                                     MFInfo(), cell_centered_data.Factory()));
-        return slice;
+
+        return std::make_unique<MultiFab>(slice_ba, slice_dmap, ncomp, 0,
+                                          MFInfo(), FArrayBoxFactory());
     }
 }
 


### PR DESCRIPTION
The slice data has a different BoxArray, so we cannot use the original Factory.

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
