### PR TITLE
Amr: Add printing of simulation time

### DIFF
--- a/Src/Amr/AMReX_Amr.cpp
+++ b/Src/Amr/AMReX_Amr.cpp
@@ -1993,7 +1993,8 @@ Amr::timeStep (int  level,
     if (verbose > 0)
     {
         amrex::Print() << "[Level " << level << " step " << level_steps[level]+1 << "] "
-                       << "ADVANCE with dt = " << dt_level[level] << "\n";
+                       << "ADVANCE at time " << time
+                       << " with dt = " << dt_level[level] << "\n";
     }
 
     Real dt_new = amr_level[level]->advance(time,dt_level[level],iteration,niter);


### PR DESCRIPTION
## Summary
A very small PR to add the printing of simulation time in `Amr::timeStep` (for `Amr::verbose > 0`).

## Additional background
Though the time is already printed out every coarse timestep [here](https://github.com/AMReX-Codes/amrex/blob/9c256b12b89f86b30fe1a6f03dd79db351d56fb3/Src/Amr/AMReX_Amr.cpp#L2174), with deep AMR hierarchies, it can be a long amount of [wall]time between these printouts, hence I would find it useful to see the current simulation time more often

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
