### PR TITLE
Update the clang-tidy/ccache script

### DIFF
--- a/.github/workflows/clang.yml
+++ b/.github/workflows/clang.yml
@@ -94,7 +94,7 @@ jobs:
       run: |
         export CCACHE_COMPRESS=1
         export CCACHE_COMPRESSLEVEL=10
-        export CCACHE_MAXSIZE=100M
+        export CCACHE_MAXSIZE=200M
         export CCACHE_EXTRAFILES=${{ github.workspace }}/.clang-tidy
         export CCACHE_LOGFILE=${{ github.workspace }}/ccache.log.txt
         ccache -z

--- a/.github/workflows/hip.yml
+++ b/.github/workflows/hip.yml
@@ -38,7 +38,7 @@ jobs:
       run: |
         export CCACHE_COMPRESS=1
         export CCACHE_COMPRESSLEVEL=10
-        export CCACHE_MAXSIZE=45M
+        export CCACHE_MAXSIZE=100M
         ccache -z
 
         source /etc/profile.d/rocm.sh
@@ -185,7 +185,7 @@ jobs:
       run: |
         export CCACHE_COMPRESS=1
         export CCACHE_COMPRESSLEVEL=10
-        export CCACHE_MAXSIZE=60M
+        export CCACHE_MAXSIZE=120M
         ccache -z
 
         cd Tests/LinearSolvers/NodeEB

--- a/Tools/C_scripts/mmclt.py
+++ b/Tools/C_scripts/mmclt.py
@@ -14,6 +14,11 @@ def mmclt(argv):
     parser.add_argument("--input",
                         help="Ccache log file",
                         default="ccache.log.txt")
+    parser.add_argument("--identifier",
+                        help="Unique identifier for finding compilaton line in the log file",
+                        default="Src/Base")
+    # We assume Src/Base can be used as an indentifier to distinguish amrex code
+    # from cmake's temporary files like build/CMakeFiles/CMakeScratch/TryCompile-hw3x4m/test_mpi.cpp
     parser.add_argument("--output",
                         help="Make file for clang-tidy",
                         default="clang-tidy-ccache-misses.mak")
@@ -30,9 +35,7 @@ def mmclt(argv):
     fout.write("clang-tidy: $$(all_targets)\n")
     fout.write("\t@echo SUCCESS\n\n")
 
-    # We assume Src/Base can be used as an indentifier to distinguish amrex code
-    # from cmake's temporary files like build/CMakeFiles/CMakeScratch/TryCompile-hw3x4m/test_mpi.cpp
-    exe_re = re.compile(r" Executing .*? (-.*Src/Base.*) -c .* -o .* (\S*)")
+    exe_re = re.compile(r" Executing .*? (-.*{}.*) -c .* -o .* (\S*)".format(args.identifier))
 
     count = 0
     for line in fin.readlines():


### PR DESCRIPTION
Add and argument specifying a unique identify. This makes it easier for the script to be used by other codes (e.g., AMReX-Hydro) in their CIs.

Also increase the cache size for some CIs. ROCm 5.6 seems to need more ccache spaces.