### PR TITLE
Add some profilers to AmrLevel and FillPatcher

### DIFF
--- a/Src/Amr/AMReX_AmrLevel.H
+++ b/Src/Amr/AMReX_AmrLevel.H
@@ -654,6 +654,7 @@ void AmrLevel::storeRKCoarseData (int state_type, Real time, Real dt,
                                   MultiFab const& S_old,
                                   Array<MultiFab,order> const& rkk)
 {
+    BL_PROFILE("AmrLevel::storeRKCoarseData()");
     if (level == parent->finestLevel()) { return; }
 
     const StateDescriptor& desc = AmrLevel::desc_lst[state_type];

--- a/Src/Amr/AMReX_AmrLevel.cpp
+++ b/Src/Amr/AMReX_AmrLevel.cpp
@@ -135,6 +135,7 @@ AmrLevel::writePlotFile (const std::string& dir,
                          std::ostream&      os,
                          VisMF::How         how)
 {
+    BL_PROFILE("AmrLevel::writePlotFile()");
     int i, n;
     //
     // The list of indices of State to write to plotfile.
@@ -1087,6 +1088,7 @@ FillPatchIterator::Initialize (int  boxGrow,
 void
 FillPatchIterator::FillFromLevel0 (Real time, int idx, int scomp, int dcomp, int ncomp)
 {
+    BL_PROFILE("FillPatchIterator::FillFromLevel0()");
     BL_ASSERT(m_amrlevel.level == 0);
 
     StateData& statedata = m_amrlevel.state[idx];
@@ -1105,6 +1107,7 @@ FillPatchIterator::FillFromLevel0 (Real time, int idx, int scomp, int dcomp, int
 void
 FillPatchIterator::FillFromTwoLevels (Real time, int idx, int scomp, int dcomp, int ncomp)
 {
+    BL_PROFILE("FillPatchIterator::FillFromTwoLevels()");
     int ilev_fine = m_amrlevel.level;
     int ilev_crse = ilev_fine-1;
 
@@ -1597,6 +1600,7 @@ AmrLevel::FillCoarsePatch (MultiFab& mf,
 std::unique_ptr<MultiFab>
 AmrLevel::derive (const std::string& name, Real time, int ngrow)
 {
+    BL_PROFILE("AmrLevel::derive()");
     BL_ASSERT(ngrow >= 0);
 
     std::unique_ptr<MultiFab> mf;
@@ -1713,6 +1717,7 @@ AmrLevel::derive (const std::string& name, Real time, int ngrow)
 void
 AmrLevel::derive (const std::string& name, Real time, MultiFab& mf, int dcomp)
 {
+    BL_PROFILE("AmrLevel::derive()");
     BL_ASSERT(dcomp < mf.nComp());
 
     const int ngrow = mf.nGrow();
@@ -2096,6 +2101,7 @@ void
 AmrLevel::FillPatcherFill (MultiFab& mf, int dcomp, int ncomp, int nghost,
                            Real time, int state_index, int scomp)
 {
+    BL_PROFILE("AmrLevel::FillPatcherFill()");
     if (level == 0) {
         FillPatch(*this, mf, nghost, time, state_index, scomp, ncomp, dcomp);
     } else {
@@ -2158,6 +2164,7 @@ AmrLevel::FillPatch (AmrLevel& amrlevel,
                      int       ncomp,
                      int       dcomp)
 {
+    BL_PROFILE("AmrLevel::FillPatch()");
     BL_ASSERT(dcomp+ncomp-1 <= leveldata.nComp());
     BL_ASSERT(boxGrow <= leveldata.nGrow());
     FillPatchIterator fpi(amrlevel, leveldata, boxGrow, time, index, scomp, ncomp);
@@ -2175,6 +2182,7 @@ AmrLevel::FillPatchAdd (AmrLevel& amrlevel,
                         int       ncomp,
                         int       dcomp)
 {
+    BL_PROFILE("AmrLevel::FillPatchAdd()");
     BL_ASSERT(dcomp+ncomp-1 <= leveldata.nComp());
     BL_ASSERT(boxGrow <= leveldata.nGrow());
     FillPatchIterator fpi(amrlevel, leveldata, boxGrow, time, index, scomp, ncomp);
@@ -2219,6 +2227,7 @@ void
 AmrLevel::FillRKPatch (int state_index, MultiFab& S, Real time,
                        int stage, int iteration, int ncycle)
 {
+    BL_PROFILE("AmrLevel::FillRKPatch()");
     StateDataPhysBCFunct physbcf(state[state_index], 0, geom);
 
     if (level == 0) {

--- a/Src/AmrCore/AMReX_FillPatcher.H
+++ b/Src/AmrCore/AMReX_FillPatcher.H
@@ -412,6 +412,7 @@ template <std::size_t order>
 void FillPatcher<MF>::storeRKCoarseData (Real /*time*/, Real dt, MF const& S_old,
                                          Array<MF,order> const& RK_k)
 {
+    BL_PROFILE("FillPatcher::storeRKCoarseData()");
     m_dt_coarse = dt;
     m_cf_crse_data.resize(order+1);
 
@@ -433,6 +434,7 @@ void FillPatcher<MF>::fillRK (int stage, int iteration, int ncycle,
                               MF& mf, Real time, BC& cbc, BC& fbc,
                               Vector<BCRec> const& bcs)
 {
+    BL_PROFILE("FillPatcher::fillRK()");
     int rk_order = m_cf_crse_data.size()-1;
     if (rk_order != 3 && rk_order != 4) {
         amrex::Abort("FillPatcher: unsupported RK order "+std::to_string(rk_order));


### PR DESCRIPTION
## Summary
Pretty much as in the title.

## Additional background
There are profilers in most of the other `AmrLevel` functions that look like they might be worth profiling.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
