### PR TITLE
DataServices: Qualify math functions with `std::` namespace specifier

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,9 @@ Tutorials/EB/Donut/Exec/ls_plt*
 # local config
 Tools/GNUMake/Make.local
 Tools/GNUMake/Make.local-pre
+
+# profparser
+BLProfParser.lex.yy.cpp
+BLProfParser.tab.H
+BLProfParser.tab.cpp
+BLProfParserNC.y

--- a/Src/Extern/amrdata/AMReX_DataServices.cpp
+++ b/Src/Extern/amrdata/AMReX_DataServices.cpp
@@ -2488,7 +2488,7 @@ void DataServices::RunTimelinePF(std::map<int, std::string> &mpiFuncNames,
           int ntnSize(nameTagNames.size());
           ntnNumbers.resize(ntnSize, 0.0);
           if(ntnSize > 0) {
-            ntnMultiplier = std::pow(10, static_cast<int>( 1 + log10(ntnSize)));
+            ntnMultiplier = std::pow(10, static_cast<int>( 1 + std::log10(ntnSize)));
           }
           for(int i(0); i < ntnSize; ++i) {
             if(ntnMultiplier > 0.0) {
@@ -2501,7 +2501,7 @@ void DataServices::RunTimelinePF(std::map<int, std::string> &mpiFuncNames,
           int bnSize(barrierNames.size());
           bnNumbers.resize(bnSize, 0.0);
           if(bnSize > 0) {
-            bnMultiplier = std::pow(10, static_cast<int>( 1 + log10(bnSize)));
+            bnMultiplier = std::pow(10, static_cast<int>( 1 + std::log10(bnSize)));
           }
           for(int i(0); i < bnSize; ++i) {
             if(bnMultiplier > 0.0) {

--- a/Src/Extern/amrdata/AMReX_DataServices.cpp
+++ b/Src/Extern/amrdata/AMReX_DataServices.cpp
@@ -2488,7 +2488,7 @@ void DataServices::RunTimelinePF(std::map<int, std::string> &mpiFuncNames,
           int ntnSize(nameTagNames.size());
           ntnNumbers.resize(ntnSize, 0.0);
           if(ntnSize > 0) {
-            ntnMultiplier = pow(10, static_cast<int>( 1 + log10(ntnSize)));
+            ntnMultiplier = std::pow(10, static_cast<int>( 1 + log10(ntnSize)));
           }
           for(int i(0); i < ntnSize; ++i) {
             if(ntnMultiplier > 0.0) {
@@ -2501,7 +2501,7 @@ void DataServices::RunTimelinePF(std::map<int, std::string> &mpiFuncNames,
           int bnSize(barrierNames.size());
           bnNumbers.resize(bnSize, 0.0);
           if(bnSize > 0) {
-            bnMultiplier = pow(10, static_cast<int>( 1 + log10(bnSize)));
+            bnMultiplier = std::pow(10, static_cast<int>( 1 + log10(bnSize)));
           }
           for(int i(0); i < bnSize; ++i) {
             if(bnMultiplier > 0.0) {


### PR DESCRIPTION
## Summary
As in the title. This fixes #3405.

## Additional background
I did briefly look at using `powi`, but I don't think the exponents are known at compile time.

I also added some auto-generated source files to .gitignore.

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
