### PR TITLE
generalize interpolaters to not need or use extra values in a directi…

### DIFF
--- a/Src/AmrCore/AMReX_Interpolater.cpp
+++ b/Src/AmrCore/AMReX_Interpolater.cpp
@@ -850,13 +850,7 @@ CellConservativeQuartic::interp (const FArrayBox&  crse,
                                  RunOn             runon)
 {
     BL_PROFILE("CellConservativeQuartic::interp()");
-    AMREX_ASSERT(ratio[0] == 2);
-#if (AMREX_SPACEDIM >= 2)
-    AMREX_ASSERT(ratio[0] == ratio[1]);
-#endif
-#if (AMREX_SPACEDIM == 3)
-    AMREX_ASSERT(ratio[1] == ratio[2]);
-#endif
+    AMREX_ASSERT(ratio == 2);
     amrex::ignore_unused(ratio);
 
     //

--- a/Src/AmrCore/AMReX_Interpolater.cpp
+++ b/Src/AmrCore/AMReX_Interpolater.cpp
@@ -411,7 +411,11 @@ CellConservativeLinear::CoarseBox (const Box&     fine,
                                    const IntVect& ratio)
 {
     Box crse = amrex::coarsen(fine,ratio);
-    crse.grow(1);
+    for (int dim = 0; dim < AMREX_SPACEDIM; dim++) {
+        if (ratio[dim] > 1) {
+            crse.grow(dim,1);
+        }
+    }
     return crse;
 }
 
@@ -454,7 +458,12 @@ CellConservativeLinear::interp (const FArrayBox& crse,
     Array4<Real> const& finearr = fine.array();
 
     const Box& crse_region = CoarseBox(fine_region,ratio);
-    const Box& cslope_bx = amrex::grow(crse_region,-1);
+    Box cslope_bx(crse_region);
+    for (int dim = 0; dim < AMREX_SPACEDIM; dim++) {
+        if (ratio[dim] > 1) {
+            cslope_bx.grow(dim,-1);
+        }
+    }
 
     FArrayBox ccfab(cslope_bx, ncomp*AMREX_SPACEDIM);
     Array4<Real> const& tmp = ccfab.array();
@@ -551,7 +560,11 @@ CellQuadratic::CoarseBox (const Box&     fine,
                           const IntVect& ratio)
 {
     Box crse = amrex::coarsen(fine,ratio);
-    crse.grow(1);
+    for (int dim = 0; dim < AMREX_SPACEDIM; dim++) {
+        if (ratio[dim] > 1) {
+            crse.grow(dim,1);
+        }
+    }
     return crse;
 }
 

--- a/Src/AmrCore/AMReX_Interpolater.cpp
+++ b/Src/AmrCore/AMReX_Interpolater.cpp
@@ -14,8 +14,6 @@ namespace amrex {
  * PCInterp, NodeBilinear, FaceLinear, CellConservativeLinear, and
  * CellBilinear are supported for all dimensions on cpu and gpu.
  *
- * FaceLinear assumes that ratio > 1 in all directions
- *
  * CellConservativeProtected only works in 2D and 3D on cpu and gpu
  * and assumes that ratio > 1 in all directions
  *
@@ -170,14 +168,6 @@ FaceLinear::interp_face (const FArrayBox&  crse,
 {
     BL_PROFILE("FaceLinear::interp_face()");
 
-    AMREX_ALWAYS_ASSERT(ratio[0] > 1);
-#if (AMREX_SPACEDIM >= 2)
-    AMREX_ALWAYS_ASSERT(ratio[1] > 1);
-#endif
-#if (AMREX_SPACEDIM == 3)
-    AMREX_ALWAYS_ASSERT(ratio[2] > 1);
-#endif
-
     AMREX_ASSERT(AMREX_D_TERM(fine_region.type(0),+fine_region.type(1),+fine_region.type(2)) == 1);
 
     Array4<Real> const& fine_arr = fine.array(fine_comp);
@@ -267,14 +257,6 @@ void FaceLinear::interp_arr (Array<FArrayBox*, AMREX_SPACEDIM> const& crse,
                              const RunOn       runon)
 {
     BL_PROFILE("FaceLinear::interp_arr()");
-
-    AMREX_ALWAYS_ASSERT(ratio[0] > 1);
-#if (AMREX_SPACEDIM >= 2)
-    AMREX_ALWAYS_ASSERT(ratio[1] > 1);
-#endif
-#if (AMREX_SPACEDIM == 3)
-    AMREX_ALWAYS_ASSERT(ratio[2] > 1);
-#endif
 
     Array<IndexType, AMREX_SPACEDIM> types;
     for (int d=0; d<AMREX_SPACEDIM; ++d)
@@ -385,10 +367,10 @@ CellBilinear::CoarseBox (const Box& fine, const IntVect& ratio)
     const int* chi = crse.hiVect();
 
     for (int i = 0; i < AMREX_SPACEDIM; i++) {
-        if ( ratio[i] > 1 && ((lo[i]-clo[i]*ratio[i])*2 < ratio[i]) ) {
+        if ((lo[i]-clo[i]*ratio[i])*2 < ratio[i]) {
             crse.growLo(i,1);
         }
-        if ( ratio[i] > 1 && ((hi[i]-chi[i]*ratio[i])*2 >= ratio[i]) ) {
+        if ((hi[i]-chi[i]*ratio[i])*2 >= ratio[i]) {
             crse.growHi(i,1);
         }
     }
@@ -579,11 +561,7 @@ CellQuadratic::CoarseBox (const Box&     fine,
                           const IntVect& ratio)
 {
     Box crse = amrex::coarsen(fine,ratio);
-    for (int dim = 0; dim < AMREX_SPACEDIM; dim++) {
-        if (ratio[dim] > 1) {
-            crse.grow(dim,1);
-        }
-    }
+    crse.grow(1);
     return crse;
 }
 
@@ -915,12 +893,7 @@ Box
 FaceDivFree::CoarseBox (const Box&     fine,
                         const IntVect& ratio)
 {
-    Box crse = amrex::coarsen(fine,ratio);
-    for (int dim = 0; dim < AMREX_SPACEDIM; dim++) {
-        if (ratio[dim] > 1) {
-            crse.grow(dim,1);
-        }
-    }
+    Box crse = amrex::coarsen(fine,ratio).grow(1);
     return crse;
 }
 

--- a/Src/AmrCore/AMReX_Interpolater.cpp
+++ b/Src/AmrCore/AMReX_Interpolater.cpp
@@ -170,14 +170,7 @@ FaceLinear::interp_face (const FArrayBox&  crse,
 {
     BL_PROFILE("FaceLinear::interp_face()");
 
-    AMREX_ALWAYS_ASSERT(ratio[0] > 1);
-#if (AMREX_SPACEDIM >= 2)
-    AMREX_ALWAYS_ASSERT(ratio[1] > 1);
-#endif
-#if (AMREX_SPACEDIM == 3)
-    AMREX_ALWAYS_ASSERT(ratio[2] > 1);
-#endif
-
+    AMREX_ALWAYS_ASSERT(ratio.allGT(IntVect(1)));
     AMREX_ASSERT(AMREX_D_TERM(fine_region.type(0),+fine_region.type(1),+fine_region.type(2)) == 1);
 
     Array4<Real> const& fine_arr = fine.array(fine_comp);
@@ -268,13 +261,7 @@ void FaceLinear::interp_arr (Array<FArrayBox*, AMREX_SPACEDIM> const& crse,
 {
     BL_PROFILE("FaceLinear::interp_arr()");
 
-    AMREX_ALWAYS_ASSERT(ratio[0] > 1);
-#if (AMREX_SPACEDIM >= 2)
-    AMREX_ALWAYS_ASSERT(ratio[1] > 1);
-#endif
-#if (AMREX_SPACEDIM == 3)
-    AMREX_ALWAYS_ASSERT(ratio[2] > 1);
-#endif
+    AMREX_ALWAYS_ASSERT(ratio.allGT(IntVect(1)));
 
     Array<IndexType, AMREX_SPACEDIM> types;
     for (int d=0; d<AMREX_SPACEDIM; ++d)
@@ -771,13 +758,7 @@ CellConservativeProtected::protect (const FArrayBox& /*crse*/,
                                     Vector<BCRec>&   /*bcr*/,
                                     RunOn            runon)
 {
-    AMREX_ALWAYS_ASSERT(ratio[0] > 1);
-#if (AMREX_SPACEDIM >= 2)
-    AMREX_ALWAYS_ASSERT(ratio[1] > 1);
-#endif
-#if (AMREX_SPACEDIM == 3)
-    AMREX_ALWAYS_ASSERT(ratio[2] > 1);
-#endif
+    AMREX_ALWAYS_ASSERT(ratio.allGT(IntVect(1)));
 
 #if (AMREX_SPACEDIM == 1)
     amrex::ignore_unused(fine,fine_state,

--- a/Src/AmrCore/AMReX_MFInterp_1D_C.H
+++ b/Src/AmrCore/AMReX_MFInterp_1D_C.H
@@ -38,7 +38,7 @@ void mf_cell_cons_lin_interp_limit_minmax_llslope (int i, int, int, Array4<Real>
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 void mf_cell_cons_lin_interp_llslope (int i, int, int, Array4<Real> const& slope,
                                       Array4<Real const> const& u, int scomp, int ncomp,
-                                      Box const& domain, BCRec const* bc) noexcept
+                                      Box const& domain, IntVect const& /*ratio*/, BCRec const* bc) noexcept
 {
     Real sfx = Real(1.0);
 

--- a/Src/AmrCore/AMReX_MFInterp_2D_C.H
+++ b/Src/AmrCore/AMReX_MFInterp_2D_C.H
@@ -89,7 +89,7 @@ void mf_cell_cons_lin_interp_limit_minmax_llslope (int i, int j, int, Array4<Rea
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 void mf_cell_cons_lin_interp_llslope (int i, int j, int, Array4<Real> const& slope,
                                       Array4<Real const> const& u, int scomp, int ncomp,
-                                      Box const& domain, BCRec const* bc) noexcept
+                                      Box const& domain, IntVect const& ratio, BCRec const* bc) noexcept
 {
     Real sfx = Real(1.0);
     Real sfy = Real(1.0);
@@ -98,26 +98,34 @@ void mf_cell_cons_lin_interp_llslope (int i, int j, int, Array4<Real> const& slo
         int nu = ns + scomp;
 
         // x-direction
-        Real dc = mf_compute_slopes_x(i, j, 0, u, nu, domain, bc[ns]);
-        Real df = Real(2.0) * (u(i+1,j,0,nu) - u(i  ,j,0,nu));
-        Real db = Real(2.0) * (u(i  ,j,0,nu) - u(i-1,j,0,nu));
-        Real sx = (df*db >= Real(0.0)) ? amrex::min(std::abs(df),std::abs(db)) : Real(0.);
-        sx = std::copysign(Real(1.),dc)*amrex::min(sx,std::abs(dc));
-        if (dc != Real(0.0)) {
-            sfx = amrex::min(sfx, sx / dc);
+        if (ratio[0] > 1) {
+            Real dc = mf_compute_slopes_x(i, j, 0, u, nu, domain, bc[ns]);
+            Real df = Real(2.0) * (u(i+1,j,0,nu) - u(i  ,j,0,nu));
+            Real db = Real(2.0) * (u(i  ,j,0,nu) - u(i-1,j,0,nu));
+            Real sx = (df*db >= Real(0.0)) ? amrex::min(std::abs(df),std::abs(db)) : Real(0.);
+            sx = std::copysign(Real(1.),dc)*amrex::min(sx,std::abs(dc));
+            if (dc != Real(0.0)) {
+                sfx = amrex::min(sfx, sx / dc);
+            }
+            slope(i,j,0,ns        ) = dc;
+        } else {
+            slope(i,j,0,ns        ) = Real(0.0);
         }
-        slope(i,j,0,ns        ) = dc;
 
         // y-direction
-        dc = mf_compute_slopes_y(i, j, 0, u, nu, domain, bc[ns]);
-        df = Real(2.0) * (u(i,j+1,0,nu) - u(i,j  ,0,nu));
-        db = Real(2.0) * (u(i,j  ,0,nu) - u(i,j-1,0,nu));
-        Real sy = (df*db >= Real(0.0)) ? amrex::min(std::abs(df),std::abs(db)) : Real(0.);
-        sy = std::copysign(Real(1.),dc)*amrex::min(sy,std::abs(dc));
-        if (dc != Real(0.0)) {
-            sfy = amrex::min(sfy, sy / dc);
+        if (ratio[1] > 1) {
+            Real dc = mf_compute_slopes_y(i, j, 0, u, nu, domain, bc[ns]);
+            Real df = Real(2.0) * (u(i,j+1,0,nu) - u(i,j  ,0,nu));
+            Real db = Real(2.0) * (u(i,j  ,0,nu) - u(i,j-1,0,nu));
+            Real sy = (df*db >= Real(0.0)) ? amrex::min(std::abs(df),std::abs(db)) : Real(0.);
+            sy = std::copysign(Real(1.),dc)*amrex::min(sy,std::abs(dc));
+            if (dc != Real(0.0)) {
+                sfy = amrex::min(sfy, sy / dc);
+            }
+            slope(i,j,0,ns+  ncomp) = dc;
+        } else {
+            slope(i,j,0,ns+  ncomp) = Real(0.0);
         }
-        slope(i,j,0,ns+  ncomp) = dc;
     }
 
     for (int ns = 0; ns < ncomp; ++ns) {
@@ -202,19 +210,26 @@ void mf_cell_cons_lin_interp_mcslope_rz (int i, int j, int ns, Array4<Real> cons
 {
     int nu = ns + scomp;
 
+    Real sx = Real(0.0);
+    Real sy = Real(0.0);
+
     // x-direction
-    Real dc = mf_compute_slopes_x(i, j, 0, u, nu, domain, bc[ns]);
-    Real df = Real(2.0) * (u(i+1,j,0,nu) - u(i  ,j,0,nu));
-    Real db = Real(2.0) * (u(i  ,j,0,nu) - u(i-1,j,0,nu));
-    Real sx = (df*db >= Real(0.0)) ? amrex::min(std::abs(df),std::abs(db)) : Real(0.);
-    sx = std::copysign(Real(1.),dc)*amrex::min(sx,std::abs(dc));
+    if (ratio[0] > 1) {
+        Real dc = mf_compute_slopes_x(i, j, 0, u, nu, domain, bc[ns]);
+        Real df = Real(2.0) * (u(i+1,j,0,nu) - u(i  ,j,0,nu));
+        Real db = Real(2.0) * (u(i  ,j,0,nu) - u(i-1,j,0,nu));
+        sx = (df*db >= Real(0.0)) ? amrex::min(std::abs(df),std::abs(db)) : Real(0.);
+        sx = std::copysign(Real(1.),dc)*amrex::min(sx,std::abs(dc));
+    }
 
     // y-direction
-    dc = mf_compute_slopes_y(i, j, 0, u, nu, domain, bc[ns]);
-    df = Real(2.0) * (u(i,j+1,0,nu) - u(i,j  ,0,nu));
-    db = Real(2.0) * (u(i,j  ,0,nu) - u(i,j-1,0,nu));
-    Real sy = (df*db >= Real(0.0)) ? amrex::min(std::abs(df),std::abs(db)) : Real(0.);
-    sy = std::copysign(Real(1.),dc)*amrex::min(sy,std::abs(dc));
+    if (ratio[1] > 1) {
+        Real dc = mf_compute_slopes_y(i, j, 0, u, nu, domain, bc[ns]);
+        Real df = Real(2.0) * (u(i,j+1,0,nu) - u(i,j  ,0,nu));
+        Real db = Real(2.0) * (u(i,j  ,0,nu) - u(i,j-1,0,nu));
+        sy = (df*db >= Real(0.0)) ? amrex::min(std::abs(df),std::abs(db)) : Real(0.);
+        sy = std::copysign(Real(1.),dc)*amrex::min(sy,std::abs(dc));
+    }
 
     Real alpha = Real(1.0);
     if (sx != Real(0.0) || sy != Real(0.0)) {
@@ -239,8 +254,10 @@ void mf_cell_cons_lin_interp_mcslope_rz (int i, int j, int ns, Array4<Real> cons
             + std::abs(sy) * Real(ratio[1]-1)/Real(2*ratio[1]);
         Real umax = u(i,j,0,nu);
         Real umin = u(i,j,0,nu);
-        for (int joff = -1; joff <= 1; ++joff) {
-        for (int ioff = -1; ioff <= 1; ++ioff) {
+        int ilim = ratio[0] > 1 ? 1 : 0;
+        int jlim = ratio[1] > 1 ? 1 : 0;
+        for (int joff = -jlim; joff <= jlim; ++joff) {
+        for (int ioff = -ilim; ioff <= ilim; ++ioff) {
             umin = amrex::min(umin, u(i+ioff,j+joff,0,nu));
             umax = amrex::max(umax, u(i+ioff,j+joff,0,nu));
         }}

--- a/Src/AmrCore/AMReX_MFInterp_2D_C.H
+++ b/Src/AmrCore/AMReX_MFInterp_2D_C.H
@@ -13,24 +13,38 @@ void mf_cell_cons_lin_interp_limit_minmax_llslope (int i, int j, int, Array4<Rea
     Real sfx = Real(1.0);
     Real sfy = Real(1.0);
 
+    Real sx = Real(0.0);
+    Real sy = Real(0.0);
+
+    Real dcx = Real(0.0);
+    Real dcy = Real(0.0);
+
     for (int ns = 0; ns < ncomp; ++ns) {
         int nu = ns + scomp;
 
         // x-direction
-        Real dcx = mf_compute_slopes_x(i, j, 0, u, nu, domain, bc[ns]);
-        Real df = Real(2.0) * (u(i+1,j,0,nu) - u(i  ,j,0,nu));
-        Real db = Real(2.0) * (u(i  ,j,0,nu) - u(i-1,j,0,nu));
-        Real sx = (df*db >= Real(0.0)) ? amrex::min(std::abs(df),std::abs(db)) : Real(0.);
-        sx = std::copysign(Real(1.),dcx)*amrex::min(sx,std::abs(dcx));
-        slope(i,j,0,ns        ) = dcx;
+        if (ratio[0] > 1) {
+            dcx = mf_compute_slopes_x(i, j, 0, u, nu, domain, bc[ns]);
+            Real df = Real(2.0) * (u(i+1,j,0,nu) - u(i  ,j,0,nu));
+            Real db = Real(2.0) * (u(i  ,j,0,nu) - u(i-1,j,0,nu));
+            sx = (df*db >= Real(0.0)) ? amrex::min(std::abs(df),std::abs(db)) : Real(0.);
+            sx = std::copysign(Real(1.),dcx)*amrex::min(sx,std::abs(dcx));
+            slope(i,j,0,ns        ) = dcx;
+        } else {
+            slope(i,j,0,ns        ) = Real(0.0);
+        }
 
         // y-direction
-        Real dcy = mf_compute_slopes_y(i, j, 0, u, nu, domain, bc[ns]);
-        df = Real(2.0) * (u(i,j+1,0,nu) - u(i,j  ,0,nu));
-        db = Real(2.0) * (u(i,j  ,0,nu) - u(i,j-1,0,nu));
-        Real sy = (df*db >= Real(0.0)) ? amrex::min(std::abs(df),std::abs(db)) : Real(0.);
-        sy = std::copysign(Real(1.),dcy)*amrex::min(sy,std::abs(dcy));
-        slope(i,j,0,ns+  ncomp) = dcy;
+        if (ratio[1] > 1) {
+            dcy = mf_compute_slopes_y(i, j, 0, u, nu, domain, bc[ns]);
+            Real df = Real(2.0) * (u(i,j+1,0,nu) - u(i,j  ,0,nu));
+            Real db = Real(2.0) * (u(i,j  ,0,nu) - u(i,j-1,0,nu));
+            sy = (df*db >= Real(0.0)) ? amrex::min(std::abs(df),std::abs(db)) : Real(0.);
+            sy = std::copysign(Real(1.),dcy)*amrex::min(sy,std::abs(dcy));
+            slope(i,j,0,ns+  ncomp) = dcy;
+        } else {
+            slope(i,j,0,ns+  ncomp) = Real(0.0);
+        }
 
         // adjust limited slopes to prevent new min/max for this component
         Real alpha = Real(1.0);
@@ -39,8 +53,10 @@ void mf_cell_cons_lin_interp_limit_minmax_llslope (int i, int j, int, Array4<Rea
                 +        std::abs(sy) * Real(ratio[1]-1)/Real(2*ratio[1]);
             Real umax = u(i,j,0,nu);
             Real umin = u(i,j,0,nu);
-            for (int joff = -1; joff <= 1; ++joff) {
-            for (int ioff = -1; ioff <= 1; ++ioff) {
+            int ilim = ratio[0] > 1 ? 1 : 0;
+            int jlim = ratio[1] > 1 ? 1 : 0;
+            for (int joff = -jlim; joff <= jlim; ++joff) {
+            for (int ioff = -ilim; ioff <= ilim; ++ioff) {
                 umin = amrex::min(umin, u(i+ioff,j+joff,0,nu));
                 umax = amrex::max(umax, u(i+ioff,j+joff,0,nu));
             }}
@@ -118,19 +134,26 @@ void mf_cell_cons_lin_interp_mcslope (int i, int j, int /*k*/, int ns, Array4<Re
 {
     int nu = ns + scomp;
 
+    Real sx = Real(0.);
+    Real sy = Real(0.);
+
     // x-direction
-    Real dc = mf_compute_slopes_x(i, j, 0, u, nu, domain, bc[ns]);
-    Real df = Real(2.0) * (u(i+1,j,0,nu) - u(i  ,j,0,nu));
-    Real db = Real(2.0) * (u(i  ,j,0,nu) - u(i-1,j,0,nu));
-    Real sx = (df*db >= Real(0.0)) ? amrex::min(std::abs(df),std::abs(db)) : Real(0.);
-    sx = std::copysign(Real(1.),dc)*amrex::min(sx,std::abs(dc));
+    if (ratio[0] > 1) {
+        Real dc = mf_compute_slopes_x(i, j, 0, u, nu, domain, bc[ns]);
+        Real df = Real(2.0) * (u(i+1,j,0,nu) - u(i  ,j,0,nu));
+        Real db = Real(2.0) * (u(i  ,j,0,nu) - u(i-1,j,0,nu));
+        sx = (df*db >= Real(0.0)) ? amrex::min(std::abs(df),std::abs(db)) : Real(0.);
+        sx = std::copysign(Real(1.),dc)*amrex::min(sx,std::abs(dc));
+    }
 
     // y-direction
-    dc = mf_compute_slopes_y(i, j, 0, u, nu, domain, bc[ns]);
-    df = Real(2.0) * (u(i,j+1,0,nu) - u(i,j  ,0,nu));
-    db = Real(2.0) * (u(i,j  ,0,nu) - u(i,j-1,0,nu));
-    Real sy = (df*db >= Real(0.0)) ? amrex::min(std::abs(df),std::abs(db)) : Real(0.);
-    sy = std::copysign(Real(1.),dc)*amrex::min(sy,std::abs(dc));
+    if (ratio[1] > 1) {
+        Real dc = mf_compute_slopes_y(i, j, 0, u, nu, domain, bc[ns]);
+        Real df = Real(2.0) * (u(i,j+1,0,nu) - u(i,j  ,0,nu));
+        Real db = Real(2.0) * (u(i,j  ,0,nu) - u(i,j-1,0,nu));
+        sy = (df*db >= Real(0.0)) ? amrex::min(std::abs(df),std::abs(db)) : Real(0.);
+        sy = std::copysign(Real(1.),dc)*amrex::min(sy,std::abs(dc));
+    }
 
     Real alpha = Real(1.0);
     if (sx != Real(0.0) || sy != Real(0.0)) {
@@ -138,8 +161,10 @@ void mf_cell_cons_lin_interp_mcslope (int i, int j, int /*k*/, int ns, Array4<Re
             +        std::abs(sy) * Real(ratio[1]-1)/Real(2*ratio[1]);
         Real umax = u(i,j,0,nu);
         Real umin = u(i,j,0,nu);
-        for (int joff = -1; joff <= 1; ++joff) {
-        for (int ioff = -1; ioff <= 1; ++ioff) {
+        int ilim = ratio[0] > 1 ? 1 : 0;
+        int jlim = ratio[1] > 1 ? 1 : 0;
+        for (int joff = -jlim; joff <= jlim; ++joff) {
+        for (int ioff = -ilim; ioff <= ilim; ++ioff) {
             umin = amrex::min(umin, u(i+ioff,j+joff,0,nu));
             umax = amrex::max(umax, u(i+ioff,j+joff,0,nu));
         }}

--- a/Src/AmrCore/AMReX_MFInterp_3D_C.H
+++ b/Src/AmrCore/AMReX_MFInterp_3D_C.H
@@ -12,32 +12,52 @@ void mf_cell_cons_lin_interp_limit_minmax_llslope (int i, int j, int k, Array4<R
     Real sfy = Real(1.0);
     Real sfz = Real(1.0);
 
+    Real sx = Real(0.0);
+    Real sy = Real(0.0);
+    Real sz = Real(0.0);
+
+    Real dcx = Real(0.0);
+    Real dcy = Real(0.0);
+    Real dcz = Real(0.0);
+
     for (int ns = 0; ns < ncomp; ++ns) {
         int nu = ns + scomp;
 
         // x-direction
-        Real dcx = mf_compute_slopes_x(i, j, k, u, nu, domain, bc[ns]);
-        Real df = Real(2.0) * (u(i+1,j,k,nu) - u(i  ,j,k,nu));
-        Real db = Real(2.0) * (u(i  ,j,k,nu) - u(i-1,j,k,nu));
-        Real sx = (df*db >= Real(0.0)) ? amrex::min(std::abs(df),std::abs(db)) : Real(0.);
-        sx = std::copysign(Real(1.),dcx)*amrex::min(sx,std::abs(dcx));
-        slope(i,j,k,ns        ) = dcx;  // unlimited slope
+        if (ratio[0] > 1) {
+            dcx = mf_compute_slopes_x(i, j, k, u, nu, domain, bc[ns]);
+            Real df  = Real(2.0) * (u(i+1,j,k,nu) - u(i  ,j,k,nu));
+            Real db  = Real(2.0) * (u(i  ,j,k,nu) - u(i-1,j,k,nu));
+            sx = (df*db >= Real(0.0)) ? amrex::min(std::abs(df),std::abs(db)) : Real(0.);
+            sx = std::copysign(Real(1.),dcx)*amrex::min(sx,std::abs(dcx));
+            slope(i,j,k,ns        ) = dcx;  // unlimited slope
+        } else {
+            slope(i,j,k,ns        ) = Real(0.0);
+        }
 
         // y-direction
-        Real dcy = mf_compute_slopes_y(i, j, k, u, nu, domain, bc[ns]);
-        df = Real(2.0) * (u(i,j+1,k,nu) - u(i,j  ,k,nu));
-        db = Real(2.0) * (u(i,j  ,k,nu) - u(i,j-1,k,nu));
-        Real sy = (df*db >= Real(0.0)) ? amrex::min(std::abs(df),std::abs(db)) : Real(0.);
-        sy = std::copysign(Real(1.),dcy)*amrex::min(sy,std::abs(dcy));
-        slope(i,j,k,ns+  ncomp) = dcy;  // unlimited slope
+        if (ratio[1] > 1) {
+            dcy = mf_compute_slopes_y(i, j, k, u, nu, domain, bc[ns]);
+            Real df  = Real(2.0) * (u(i,j+1,k,nu) - u(i,j  ,k,nu));
+            Real db  = Real(2.0) * (u(i,j  ,k,nu) - u(i,j-1,k,nu));
+            sy = (df*db >= Real(0.0)) ? amrex::min(std::abs(df),std::abs(db)) : Real(0.);
+            sy = std::copysign(Real(1.),dcy)*amrex::min(sy,std::abs(dcy));
+            slope(i,j,k,ns+  ncomp) = dcy;  // unlimited slope
+        } else {
+            slope(i,j,k,ns+  ncomp) = Real(0.0);
+        }
 
         // z-direction
-        Real dcz = mf_compute_slopes_z(i, j, k, u, nu, domain, bc[ns]);
-        df = Real(2.0) * (u(i,j,k+1,nu) - u(i,j,k  ,nu));
-        db = Real(2.0) * (u(i,j,k  ,nu) - u(i,j,k-1,nu));
-        Real sz = (df*db >= Real(0.0)) ? amrex::min(std::abs(df),std::abs(db)) : Real(0.);
-        sz = std::copysign(Real(1.),dcz)*amrex::min(sz,std::abs(dcz));
-        slope(i,j,k,ns+2*ncomp) = dcz;  // unlimited slope
+        if (ratio[2] > 1) {
+            dcz = mf_compute_slopes_z(i, j, k, u, nu, domain, bc[ns]);
+            Real df  = Real(2.0) * (u(i,j,k+1,nu) - u(i,j,k  ,nu));
+            Real db  = Real(2.0) * (u(i,j,k  ,nu) - u(i,j,k-1,nu));
+            sz = (df*db >= Real(0.0)) ? amrex::min(std::abs(df),std::abs(db)) : Real(0.);
+            sz = std::copysign(Real(1.),dcz)*amrex::min(sz,std::abs(dcz));
+            slope(i,j,k,ns+2*ncomp) = dcz;  // unlimited slope
+        } else {
+            slope(i,j,k,ns+2*ncomp) = Real(0.0);
+        }
 
         // adjust limited slopes to prevent new min/max for this component
         Real alpha = 1.0;
@@ -47,9 +67,12 @@ void mf_cell_cons_lin_interp_limit_minmax_llslope (int i, int j, int k, Array4<R
                 +        std::abs(sz) * Real(ratio[2]-1)/Real(2*ratio[2]);
             Real umax = u(i,j,k,nu);
             Real umin = u(i,j,k,nu);
-            for (int koff = -1; koff <= 1; ++koff) {
-            for (int joff = -1; joff <= 1; ++joff) {
-            for (int ioff = -1; ioff <= 1; ++ioff) {
+            int ilim = ratio[0] > 1 ? 1 : 0;
+            int jlim = ratio[1] > 1 ? 1 : 0;
+            int klim = ratio[2] > 1 ? 1 : 0;
+            for (int koff = -klim; koff <= klim; ++koff) {
+            for (int joff = -jlim; joff <= jlim; ++joff) {
+            for (int ioff = -ilim; ioff <= ilim; ++ioff) {
                 umin = amrex::min(umin, u(i+ioff,j+joff,k+koff,nu));
                 umax = amrex::max(umax, u(i+ioff,j+joff,k+koff,nu));
             }}}
@@ -145,26 +168,36 @@ void mf_cell_cons_lin_interp_mcslope (int i, int j, int k, int ns, Array4<Real> 
 {
     int nu = ns + scomp;
 
+    Real sx = Real(0.);
+    Real sy = Real(0.);
+    Real sz = Real(0.);
+
     // x-direction
-    Real dc = mf_compute_slopes_x(i, j, k, u, nu, domain, bc[ns]);
-    Real df = Real(2.0) * (u(i+1,j,k,nu) - u(i  ,j,k,nu));
-    Real db = Real(2.0) * (u(i  ,j,k,nu) - u(i-1,j,k,nu));
-    Real sx = (df*db >= Real(0.0)) ? amrex::min(std::abs(df),std::abs(db)) : Real(0.);
-    sx = std::copysign(Real(1.),dc)*amrex::min(sx,std::abs(dc));
+    if (ratio[0] > 1) {
+        Real dc = mf_compute_slopes_x(i, j, k, u, nu, domain, bc[ns]);
+        Real df = Real(2.0) * (u(i+1,j,k,nu) - u(i  ,j,k,nu));
+        Real db = Real(2.0) * (u(i  ,j,k,nu) - u(i-1,j,k,nu));
+        sx = (df*db >= Real(0.0)) ? amrex::min(std::abs(df),std::abs(db)) : Real(0.);
+        sx = std::copysign(Real(1.),dc)*amrex::min(sx,std::abs(dc));
+    }
 
     // y-direction
-    dc = mf_compute_slopes_y(i, j, k, u, nu, domain, bc[ns]);
-    df = Real(2.0) * (u(i,j+1,k,nu) - u(i,j  ,k,nu));
-    db = Real(2.0) * (u(i,j  ,k,nu) - u(i,j-1,k,nu));
-    Real sy = (df*db >= Real(0.0)) ? amrex::min(std::abs(df),std::abs(db)) : Real(0.);
-    sy = std::copysign(Real(1.),dc)*amrex::min(sy,std::abs(dc));
+    if (ratio[1] > 1) {
+        Real dc = mf_compute_slopes_y(i, j, k, u, nu, domain, bc[ns]);
+        Real df = Real(2.0) * (u(i,j+1,k,nu) - u(i,j  ,k,nu));
+        Real db = Real(2.0) * (u(i,j  ,k,nu) - u(i,j-1,k,nu));
+        sy = (df*db >= Real(0.0)) ? amrex::min(std::abs(df),std::abs(db)) : Real(0.);
+        sy = std::copysign(Real(1.),dc)*amrex::min(sy,std::abs(dc));
+    }
 
     // z-direction
-    dc = mf_compute_slopes_z(i, j, k, u, nu, domain, bc[ns]);
-    df = Real(2.0) * (u(i,j,k+1,nu) - u(i,j,k  ,nu));
-    db = Real(2.0) * (u(i,j,k  ,nu) - u(i,j,k-1,nu));
-    Real sz = (df*db >= Real(0.0)) ? amrex::min(std::abs(df),std::abs(db)) : Real(0.);
-    sz = std::copysign(Real(1.),dc)*amrex::min(sz,std::abs(dc));
+    if (ratio[2] > 1) {
+        Real dc = mf_compute_slopes_z(i, j, k, u, nu, domain, bc[ns]);
+        Real df = Real(2.0) * (u(i,j,k+1,nu) - u(i,j,k  ,nu));
+        Real db = Real(2.0) * (u(i,j,k  ,nu) - u(i,j,k-1,nu));
+        sz = (df*db >= Real(0.0)) ? amrex::min(std::abs(df),std::abs(db)) : Real(0.);
+        sz = std::copysign(Real(1.),dc)*amrex::min(sz,std::abs(dc));
+    }
 
     Real alpha = 1.0;
     if (sx != Real(0.0) || sy != Real(0.0) || sz != Real(0.0)) {
@@ -173,9 +206,12 @@ void mf_cell_cons_lin_interp_mcslope (int i, int j, int k, int ns, Array4<Real> 
             +        std::abs(sz) * Real(ratio[2]-1)/Real(2*ratio[2]);
         Real umax = u(i,j,k,nu);
         Real umin = u(i,j,k,nu);
-        for (int koff = -1; koff <= 1; ++koff) {
-        for (int joff = -1; joff <= 1; ++joff) {
-        for (int ioff = -1; ioff <= 1; ++ioff) {
+        int ilim = ratio[0] > 1 ? 1 : 0;
+        int jlim = ratio[1] > 1 ? 1 : 0;
+        int klim = ratio[2] > 1 ? 1 : 0;
+        for (int koff = -klim; koff <= klim; ++koff) {
+        for (int joff = -jlim; joff <= jlim; ++joff) {
+        for (int ioff = -ilim; ioff <= ilim; ++ioff) {
             umin = amrex::min(umin, u(i+ioff,j+joff,k+koff,nu));
             umax = amrex::max(umax, u(i+ioff,j+joff,k+koff,nu));
         }}}

--- a/Src/AmrCore/AMReX_MFInterp_3D_C.H
+++ b/Src/AmrCore/AMReX_MFInterp_3D_C.H
@@ -110,7 +110,7 @@ void mf_cell_cons_lin_interp_limit_minmax_llslope (int i, int j, int k, Array4<R
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 void mf_cell_cons_lin_interp_llslope (int i, int j, int k, Array4<Real> const& slope,
                                       Array4<Real const> const& u, int scomp, int ncomp,
-                                      Box const& domain, BCRec const* bc) noexcept
+                                      Box const& domain, IntVect const& ratio, BCRec const* bc) noexcept
 {
     Real sfx = Real(1.0);
     Real sfy = Real(1.0);
@@ -120,37 +120,51 @@ void mf_cell_cons_lin_interp_llslope (int i, int j, int k, Array4<Real> const& s
         int nu = ns + scomp;
 
         // x-direction
-        Real dc = mf_compute_slopes_x(i, j, k, u, nu, domain, bc[ns]);
-        Real df = Real(2.0) * (u(i+1,j,k,nu) - u(i  ,j,k,nu));
-        Real db = Real(2.0) * (u(i  ,j,k,nu) - u(i-1,j,k,nu));
-        Real sx = (df*db >= Real(0.0)) ? amrex::min(std::abs(df),std::abs(db)) : Real(0.);
-        sx = std::copysign(Real(1.),dc)*amrex::min(sx,std::abs(dc));
-        if (dc != Real(0.0)) {
-            sfx = amrex::min(sfx, sx / dc);
+        if (ratio[0] > 1) {
+            Real dc = mf_compute_slopes_x(i, j, k, u, nu, domain, bc[ns]);
+            Real df = Real(2.0) * (u(i+1,j,k,nu) - u(i  ,j,k,nu));
+            Real db = Real(2.0) * (u(i  ,j,k,nu) - u(i-1,j,k,nu));
+            Real sx = (df*db >= Real(0.0)) ? amrex::min(std::abs(df),std::abs(db)) : Real(0.);
+            sx = std::copysign(Real(1.),dc)*amrex::min(sx,std::abs(dc));
+            if (dc != Real(0.0)) {
+                sfx = amrex::min(sfx, sx / dc);
+            }
+            slope(i,j,k,ns        ) = dc;
+        } else {
+            slope(i,j,k,ns        ) = Real(0.0);
         }
-        slope(i,j,k,ns        ) = dc;
 
         // y-direction
-        dc = mf_compute_slopes_y(i, j, k, u, nu, domain, bc[ns]);
-        df = Real(2.0) * (u(i,j+1,k,nu) - u(i,j  ,k,nu));
-        db = Real(2.0) * (u(i,j  ,k,nu) - u(i,j-1,k,nu));
-        Real sy = (df*db >= Real(0.0)) ? amrex::min(std::abs(df),std::abs(db)) : Real(0.);
-        sy = std::copysign(Real(1.),dc)*amrex::min(sy,std::abs(dc));
-        if (dc != Real(0.0)) {
-            sfy = amrex::min(sfy, sy / dc);
+        if (ratio[1] > 1) {
+            Real dc = mf_compute_slopes_y(i, j, k, u, nu, domain, bc[ns]);
+            Real df = Real(2.0) * (u(i,j+1,k,nu) - u(i,j  ,k,nu));
+            Real db = Real(2.0) * (u(i,j  ,k,nu) - u(i,j-1,k,nu));
+            Real sy = (df*db >= Real(0.0)) ? amrex::min(std::abs(df),std::abs(db)) : Real(0.);
+            sy = std::copysign(Real(1.),dc)*amrex::min(sy,std::abs(dc));
+            if (dc != Real(0.0)) {
+                sfy = amrex::min(sfy, sy / dc);
+            }
+            slope(i,j,k,ns+  ncomp) = dc;
+        } else {
+            slope(i,j,k,ns+  ncomp) = Real(0.0);
         }
-        slope(i,j,k,ns+  ncomp) = dc;
+
 
         // z-direction
-        dc = mf_compute_slopes_z(i, j, k, u, nu, domain, bc[ns]);
-        df = Real(2.0) * (u(i,j,k+1,nu) - u(i,j,k  ,nu));
-        db = Real(2.0) * (u(i,j,k  ,nu) - u(i,j,k-1,nu));
-        Real sz = (df*db >= Real(0.0)) ? amrex::min(std::abs(df),std::abs(db)) : Real(0.);
-        sz = std::copysign(Real(1.),dc)*amrex::min(sz,std::abs(dc));
-        if (dc != Real(0.0)) {
-            sfz = amrex::min(sfz, sz / dc);
+        if (ratio[2] > 1) {
+            Real dc = mf_compute_slopes_z(i, j, k, u, nu, domain, bc[ns]);
+            Real df = Real(2.0) * (u(i,j,k+1,nu) - u(i,j,k  ,nu));
+            Real db = Real(2.0) * (u(i,j,k  ,nu) - u(i,j,k-1,nu));
+            Real sz = (df*db >= Real(0.0)) ? amrex::min(std::abs(df),std::abs(db)) : Real(0.);
+            sz = std::copysign(Real(1.),dc)*amrex::min(sz,std::abs(dc));
+            if (dc != Real(0.0)) {
+                sfz = amrex::min(sfz, sz / dc);
+            }
+            slope(i,j,k,ns+2*ncomp) = dc;
+        } else {
+            slope(i,j,k,ns+2*ncomp) = Real(0.0);
         }
-        slope(i,j,k,ns+2*ncomp) = dc;
+
     }
 
     for (int ns = 0; ns < ncomp; ++ns) {

--- a/Src/AmrCore/AMReX_MFInterpolater.cpp
+++ b/Src/AmrCore/AMReX_MFInterpolater.cpp
@@ -99,6 +99,11 @@ MFCellConsLinInterp::interp (MultiFab const& crsemf, int ccomp, MultiFab& finemf
 
     Box const& cdomain = cgeom.Domain();
 
+    IntVect minus1;
+    for (int dim = 0; dim < AMREX_SPACEDIM; dim++) {
+        minus1[dim] = (ratio[dim] > 1) ? -1 : 0;
+    }
+
 #ifdef AMREX_USE_GPU
     if (Gpu::inLaunchRegion()) {
         MultiFab crse_tmp(crsemf.boxArray(), crsemf.DistributionMap(), AMREX_SPACEDIM*nc, 0);
@@ -116,14 +121,14 @@ MFCellConsLinInterp::interp (MultiFab const& crsemf, int ccomp, MultiFab& finemf
             Real drf = fgeom.CellSize(0);
             Real rlo = fgeom.Offset(0);
             if (do_linear_limiting) {
-                ParallelFor(crsemf, IntVect(-1),
+                ParallelFor(crsemf, minus1,
                 [=] AMREX_GPU_DEVICE (int box_no, int i, int, int) noexcept
                 {
                     mf_cell_cons_lin_interp_llslope(i,0,0, tmp[box_no], crse[box_no], ccomp, nc,
                                                     cdomain, ratio, pbc);
                 });
             } else {
-                ParallelFor(crsemf, IntVect(-1), nc,
+                ParallelFor(crsemf, minus1, nc,
                 [=] AMREX_GPU_DEVICE (int box_no, int i, int, int, int n) noexcept
                 {
                     mf_cell_cons_lin_interp_mcslope_sph(i, n, tmp[box_no], crse[box_no], ccomp, nc,
@@ -145,14 +150,14 @@ MFCellConsLinInterp::interp (MultiFab const& crsemf, int ccomp, MultiFab& finemf
             Real drf = fgeom.CellSize(0);
             Real rlo = fgeom.Offset(0);
             if (do_linear_limiting) {
-                ParallelFor(crsemf, IntVect(-1),
+                ParallelFor(crsemf, minus1,
                 [=] AMREX_GPU_DEVICE (int box_no, int i, int j, int) noexcept
                 {
                     mf_cell_cons_lin_interp_llslope(i,j,0, tmp[box_no], crse[box_no], ccomp, nc,
                                                     cdomain, ratio, pbc);
                 });
             } else {
-                ParallelFor(crsemf, IntVect(-1), nc,
+                ParallelFor(crsemf, minus1, nc,
                 [=] AMREX_GPU_DEVICE (int box_no, int i, int j, int, int n) noexcept
                 {
                     mf_cell_cons_lin_interp_mcslope_rz(i,j,n, tmp[box_no], crse[box_no], ccomp, nc,
@@ -172,14 +177,14 @@ MFCellConsLinInterp::interp (MultiFab const& crsemf, int ccomp, MultiFab& finemf
 #endif
         {
             if (do_linear_limiting) {
-                ParallelFor(crsemf, IntVect(-1),
+                ParallelFor(crsemf, minus1,
                 [=] AMREX_GPU_DEVICE (int box_no, int i, int j, int k) noexcept
                 {
                     mf_cell_cons_lin_interp_llslope(i,j,k, tmp[box_no], crse[box_no], ccomp, nc,
                                                     cdomain, ratio, pbc);
                 });
             } else {
-                ParallelFor(crsemf, IntVect(-1), nc,
+                ParallelFor(crsemf, minus1, nc,
                 [=] AMREX_GPU_DEVICE (int box_no, int i, int j, int k, int n) noexcept
                 {
                     mf_cell_cons_lin_interp_mcslope(i,j,k,n, tmp[box_no], crse[box_no], ccomp, nc,
@@ -212,7 +217,7 @@ MFCellConsLinInterp::interp (MultiFab const& crsemf, int ccomp, MultiFab& finemf
                 auto const& fine = finemf.array(mfi);
                 auto const& crse = crsemf.const_array(mfi);
 
-                Box const& cbox = amrex::grow(crsemf[mfi].box(), -1);
+                Box const& cbox = amrex::grow(crsemf[mfi].box(), minus1);
                 tmpfab.resize(cbox, AMREX_SPACEDIM*nc);
                 auto const& tmp = tmpfab.array();
                 auto const& ctmp = tmpfab.const_array();
@@ -335,6 +340,11 @@ MFCellConsLinMinmaxLimitInterp::interp (MultiFab const& crsemf, int ccomp, Multi
 
     Box const& cdomain = cgeom.Domain();
 
+    IntVect minus1;
+    for (int dim = 0; dim < AMREX_SPACEDIM; dim++) {
+        minus1[dim] = (ratio[dim] > 1) ? -1 : 0;
+    }
+
 #ifdef AMREX_USE_GPU
     if (Gpu::inLaunchRegion()) {
         MultiFab crse_tmp(crsemf.boxArray(), crsemf.DistributionMap(), AMREX_SPACEDIM*nc, 0);
@@ -347,7 +357,7 @@ MFCellConsLinMinmaxLimitInterp::interp (MultiFab const& crsemf, int ccomp, Multi
         BCRec const* pbc = d_bc.data();
         Gpu::copyAsync(Gpu::hostToDevice, bcs.begin()+bcomp, bcs.begin()+bcomp+nc, d_bc.begin());
 
-        ParallelFor(crsemf, IntVect(-1),
+        ParallelFor(crsemf, minus1,
         [=] AMREX_GPU_DEVICE (int box_no, int i, int j, int k) noexcept
         {
             mf_cell_cons_lin_interp_limit_minmax_llslope(i,j,k, tmp[box_no], crse[box_no], ccomp, nc,
@@ -378,7 +388,7 @@ MFCellConsLinMinmaxLimitInterp::interp (MultiFab const& crsemf, int ccomp, Multi
                 auto const& fine = finemf.array(mfi);
                 auto const& crse = crsemf.const_array(mfi);
 
-                Box const& cbox = amrex::grow(crsemf[mfi].box(), -1);
+                Box const& cbox = amrex::grow(crsemf[mfi].box(), minus1);
                 tmpfab.resize(cbox, AMREX_SPACEDIM*nc);
                 auto const& tmp = tmpfab.array();
                 auto const& ctmp = tmpfab.const_array();

--- a/Src/AmrCore/AMReX_MFInterpolater.cpp
+++ b/Src/AmrCore/AMReX_MFInterpolater.cpp
@@ -414,10 +414,10 @@ MFCellBilinear::CoarseBox (const Box& fine, const IntVect& ratio)
     const int* chi = crse.hiVect();
 
     for (int i = 0; i < AMREX_SPACEDIM; i++) {
-        if ( ratio[i] > 1 && ((lo[i]-clo[i]*ratio[i])*2 < ratio[i]) ) {
+        if ((lo[i]-clo[i]*ratio[i])*2 < ratio[i]) {
             crse.growLo(i,1);
         }
-        if ( ratio[i] > 1 && ((hi[i]-chi[i]*ratio[i])*2 >= ratio[i]) ) {
+        if ((hi[i]-chi[i]*ratio[i])*2 >= ratio[i]) {
             crse.growHi(i,1);
         }
     }

--- a/Src/AmrCore/AMReX_MFInterpolater.cpp
+++ b/Src/AmrCore/AMReX_MFInterpolater.cpp
@@ -72,7 +72,11 @@ Box
 MFCellConsLinInterp::CoarseBox (const Box& fine, const IntVect& ratio)
 {
     Box crse = amrex::coarsen(fine,ratio);
-    crse.grow(1);
+    for (int dim = 0; dim < AMREX_SPACEDIM; dim++) {
+        if (ratio[dim] > 1) {
+            crse.grow(dim,1);
+        }
+    }
     return crse;
 }
 
@@ -116,7 +120,7 @@ MFCellConsLinInterp::interp (MultiFab const& crsemf, int ccomp, MultiFab& finemf
                 [=] AMREX_GPU_DEVICE (int box_no, int i, int, int) noexcept
                 {
                     mf_cell_cons_lin_interp_llslope(i,0,0, tmp[box_no], crse[box_no], ccomp, nc,
-                                                    cdomain, pbc);
+                                                    cdomain, ratio, pbc);
                 });
             } else {
                 ParallelFor(crsemf, IntVect(-1), nc,
@@ -145,7 +149,7 @@ MFCellConsLinInterp::interp (MultiFab const& crsemf, int ccomp, MultiFab& finemf
                 [=] AMREX_GPU_DEVICE (int box_no, int i, int j, int) noexcept
                 {
                     mf_cell_cons_lin_interp_llslope(i,j,0, tmp[box_no], crse[box_no], ccomp, nc,
-                                                    cdomain, pbc);
+                                                    cdomain, ratio, pbc);
                 });
             } else {
                 ParallelFor(crsemf, IntVect(-1), nc,
@@ -172,7 +176,7 @@ MFCellConsLinInterp::interp (MultiFab const& crsemf, int ccomp, MultiFab& finemf
                 [=] AMREX_GPU_DEVICE (int box_no, int i, int j, int k) noexcept
                 {
                     mf_cell_cons_lin_interp_llslope(i,j,k, tmp[box_no], crse[box_no], ccomp, nc,
-                                                    cdomain, pbc);
+                                                    cdomain, ratio, pbc);
                 });
             } else {
                 ParallelFor(crsemf, IntVect(-1), nc,
@@ -224,7 +228,7 @@ MFCellConsLinInterp::interp (MultiFab const& crsemf, int ccomp, MultiFab& finemf
                         [&] (int i, int, int) noexcept
                         {
                             mf_cell_cons_lin_interp_llslope(i,0,0, tmp, crse, ccomp, nc,
-                                                            cdomain, pbc);
+                                                            cdomain, ratio, pbc);
                         });
                     } else {
                         amrex::LoopConcurrentOnCpu(cbox, nc,
@@ -251,7 +255,7 @@ MFCellConsLinInterp::interp (MultiFab const& crsemf, int ccomp, MultiFab& finemf
                         [&] (int i, int j, int) noexcept
                         {
                             mf_cell_cons_lin_interp_llslope(i,j,0, tmp, crse, ccomp, nc,
-                                                            cdomain, pbc);
+                                                            cdomain, ratio, pbc);
                         });
                     } else {
                         amrex::LoopConcurrentOnCpu(cbox, nc,
@@ -276,7 +280,7 @@ MFCellConsLinInterp::interp (MultiFab const& crsemf, int ccomp, MultiFab& finemf
                         [&] (int i, int j, int k) noexcept
                         {
                             mf_cell_cons_lin_interp_llslope(i,j,k, tmp, crse, ccomp, nc,
-                                                            cdomain, pbc);
+                                                            cdomain, ratio, pbc);
                         });
                     } else {
                         amrex::LoopConcurrentOnCpu(cbox, nc,
@@ -304,7 +308,11 @@ Box
 MFCellConsLinMinmaxLimitInterp::CoarseBox (const Box& fine, const IntVect& ratio)
 {
     Box crse = amrex::coarsen(fine,ratio);
-    crse.grow(1);
+    for (int dim = 0; dim < AMREX_SPACEDIM; dim++) {
+        if (ratio[dim] > 1) {
+            crse.grow(dim,1);
+        }
+    }
     return crse;
 }
 
@@ -406,10 +414,10 @@ MFCellBilinear::CoarseBox (const Box& fine, const IntVect& ratio)
     const int* chi = crse.hiVect();
 
     for (int i = 0; i < AMREX_SPACEDIM; i++) {
-        if ((lo[i]-clo[i]*ratio[i])*2 < ratio[i]) {
+        if ( ratio[i] > 1 && ((lo[i]-clo[i]*ratio[i])*2 < ratio[i]) ) {
             crse.growLo(i,1);
         }
-        if ((hi[i]-chi[i]*ratio[i])*2 >= ratio[i]) {
+        if ( ratio[i] > 1 && ((hi[i]-chi[i]*ratio[i])*2 >= ratio[i]) ) {
             crse.growHi(i,1);
         }
     }


### PR DESCRIPTION
…on for which the refinement ratio is 1

## Summary
The previous version of the interpolation routines in AmrCore would grow the "CoarseBox" in all directions even if one of the directions had refinement ratio 1.  This PR changes that behavior so the CoarseBox is not grown, and slopes are not computed, in any direction for which the refinement ratio is 1.

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [X ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
