### PR TITLE
SYCL RelWithDebInfo Build: Add -g1

### DIFF
--- a/Tools/CMake/AMReXFlagsTargets.cmake
+++ b/Tools/CMake/AMReXFlagsTargets.cmake
@@ -89,7 +89,7 @@ target_compile_options( Flags_CXX
    $<${_cxx_appleclang_rwdbg}:>
    $<${_cxx_appleclang_rel}:>
    $<${_cxx_intelllvm_dbg}:-O0 -Wall -Wextra -Wno-sign-compare -Wno-unused-parameter -Wno-unused-variable>
-   $<${_cxx_intelllvm_rwdbg}:>
+   $<${_cxx_intelllvm_rwdbg}:-g1>
    $<${_cxx_intelllvm_rel}:>
    )
 


### PR DESCRIPTION
Add `-g1` to RelWithDebInfo build with oneAPI SYCL compiler (i.e., IntelLLVM). This is because with `-g` the link step can be very slow and the final executable can be order of magnitude bigger than that generated with `-g1`.

This actually passes `-g -g1` to the compiler. The first flag `-g` comes from CMake with the RelWithDebInfo build type. Here, the order of the two flags matter, because the latter flag `-g1` overrides `-g`.
