### PR TITLE
SYCL: Allocate 3/4 of total global memory by default

### DIFF
--- a/Src/Base/AMReX_Arena.cpp
+++ b/Src/Base/AMReX_Arena.cpp
@@ -282,12 +282,10 @@ Arena::Initialize ()
     BL_ASSERT(the_comms_arena == nullptr || the_comms_arena == The_BArena());
 
 #ifdef AMREX_USE_GPU
-#ifdef AMREX_USE_SYCL
-    the_arena_init_size = 1024L*1024L*1024L; // xxxxx SYCL: todo
-#else
     the_arena_init_size = Gpu::Device::totalGlobalMem() / Gpu::Device::numDevicePartners() / 4L * 3L;
+#ifdef AMREX_USE_SYCL
+    the_arena_init_size = std::min(the_arena_init_size, Gpu::Device::maxMemAllocSize());
 #endif
-
     the_pinned_arena_release_threshold = Gpu::Device::totalGlobalMem();
 #endif
 


### PR DESCRIPTION
In the past, we had issues with allocating too big a chunk of memory on Intel GPUs, so we only allocated 1 GB by default. This is no longer the case.
