### PR TITLE
ParmParse: Line Continuation

### DIFF
--- a/Src/Base/AMReX_ParmParse.H
+++ b/Src/Base/AMReX_ParmParse.H
@@ -32,18 +32,24 @@ class IntVect;
 //
 // Comments in an input file include all text from a '#' character to the
 // end of the line.  Here is an example input file:
-//
-//   niter = 100                # niter is an integer
-//   title = "Double Wammy"     # example of a string with spaces
-//   cell_size = 0.5 0.75       # cell spacing in each dimension
-//   plot.var = Density 1 10    # a list of values
-//   plot.var = Energy  5 12    # another list of values
-//   bigarray = 1 2 3 4 5 6 7 8 # first part of array
-//              9 10 11 12      # continuation of bigarray
-//   test = apple "boy blue" 10 20 30 40
-//   FILE = prob_file           # insert contents of this "prob_file" here
-//
-// The "FILE = <filename>" definition is special.  Rather than just
+/*
+   niter = 100                # niter is an integer
+   title = "Double Wammy"     # example of a string with spaces
+   cell_size = 0.5 0.75       # cell spacing in each dimension
+   plot.var = Density 1 10    # a list of values
+   plot.var = Energy  5 12    # another list of values
+   bigarray = 1 2 3 4 5 6 7 8 \
+              9 10 11 12      # continuation of bigarray
+   multi_line_string = "This is a
+                        multi-line string."
+   test = apple "boy blue" 10 20 30 40
+   FILE = prob_file           # insert contents of this "prob_file" here
+*/
+// For values spanning multiple lines, one must use '\' at the end of a line
+// for continuation, otherwise it's a runtime error. Note that there must be
+// at least one space before the continuation character `\`.  Multiple lines
+// inside a pair of double quotes are considered a single string containing
+// '\n's. The "FILE = <filename>" definition is special.  Rather than just
 // adding this entry to the database, it reads the contents of <filename>
 // into the database.
 //
@@ -229,9 +235,11 @@ class IntVect;
 *
 *     plot.var = Energy  5 12
 *
-*     bigarray = 1 2 3 4 5 6 7 8
-*
+*     bigarray = 1 2 3 4 5 6 7 8 \
 *                9 10 11 12
+*
+*     multi_line_string = "This is a
+*                          multi-line string."
 *
 *     aBox    = ((0,0) (5,5))
 *
@@ -1051,37 +1059,6 @@ public:
 
     //! Returns [prefix.]* parameters.
     [[nodiscard]] static std::set<std::string> getEntries (const std::string& prefix = std::string());
-
-    /**
-     * \brief Control multi-line support
-     *
-     * By default, ParmParse supports multi-line values. For example,
-     \verbatim
-         plot_vars = dens vx vy vx
-                     energy entropy
-     \endverbatim
-     * This can be disabled by calling this function setMultiLineSupport(false)
-     * before amrex::Initialize(). This can avoid errors in inputs like,
-     \verbatim
-         algo.current_deposition = direct
-
-         # Enable galilean
-         psatd.use_default_v_galilean # Unfortunately we forgot = 1
-     \endverbatim
-     * With multi-line support, this is equivalent to
-     \verbatim
-         algo.current_deposition = direct psatd.use_default_v_galilean
-     \endverbatim
-     * With multi-line support disabled, it will abort. Note that after
-     * multi-line support is disabled, one is still allowed to have
-     \verbatim
-         f = "x + y
-              + sin(z)"
-     \endverbatim
-     * because here what's inside the pair of double quotes is considered a
-     * single string.
-     */
-    static void setMultiLineSupport (bool b);
 
     struct PP_entry;
     using Table = std::list<PP_entry>;


### PR DESCRIPTION
In #3433, we added an option to disable multi-line support to avoid certain types of errors. Since multi-line support seems to be desirable feature, we add a new feature that uses `\` as line continuation. To avoid confusion, we have decided to stop supporting the old style of multi-line values and make it a runtime error. Hopefully it does not cause too much trouble for users.
