### PR TITLE
Disable Managed Memory for The_Arena by default.

### DIFF
--- a/Src/Base/AMReX_Arena.cpp
+++ b/Src/Base/AMReX_Arena.cpp
@@ -47,11 +47,7 @@ namespace {
     Long the_pinned_arena_release_threshold = std::numeric_limits<Long>::max();
     Long the_comms_arena_release_threshold = std::numeric_limits<Long>::max();
     Long the_async_arena_release_threshold = std::numeric_limits<Long>::max();
-#ifdef AMREX_USE_HIP
-    bool the_arena_is_managed = false; // xxxxx HIP FIX HERE
-#else
-    bool the_arena_is_managed = true;
-#endif
+    bool the_arena_is_managed = false;
     bool abort_on_out_of_gpu_memory = false;
 }
 


### PR DESCRIPTION
It used to be that The_Arena was managed for CUDA and SYCL, but not for HIP. The users can still turn it on with
`amrex.the_arena_is_managed=1`. They can also use The_Managed_Arena explicitly.
