### PR TITLE
ParmParse::addfile needs Init

### DIFF
--- a/Src/Base/AMReX_ParmParse.cpp
+++ b/Src/Base/AMReX_ParmParse.cpp
@@ -17,6 +17,7 @@
 #include <list>
 #include <numeric>
 #include <regex>
+#include <stdexcept>
 #include <set>
 #include <sstream>
 #include <string>
@@ -538,6 +539,13 @@ read_file (const char* fname, std::list<ParmParse::PP_entry>& tab)
     //
     if ( fname != nullptr && fname[0] != 0 )
     {
+#ifdef AMREX_USE_MPI
+        if (ParallelDescriptor::Communicator() == MPI_COMM_NULL)
+        {
+            throw std::runtime_error("read_file: AMReX must be initialized");
+        }
+#endif
+
         Vector<char> fileCharPtr;
         std::string filename = fname;
         ParallelDescriptor::ReadAndBcastFile(filename, fileCharPtr);
@@ -1069,6 +1077,13 @@ ParmParse::prefixedName (const std::string& str) const
 
 void
 ParmParse::addfile (std::string const& filename) {
+#ifdef AMREX_USE_MPI
+    if (ParallelDescriptor::Communicator() == MPI_COMM_NULL)
+    {
+        throw std::runtime_error("ParmParse::addfile: AMReX must be initialized");
+    }
+#endif
+
     auto l = std::list<std::string>{filename};
     auto file = FileKeyword;
     addDefn(file,


### PR DESCRIPTION
## Summary

`ParmParse` can be used before AMReX is initialized for most functionality, which is greatly helpful for us. One function that cannot be used before init is reading from a file, because it needs an MPI context to broadcast.

Add a clean error message instead of a segfault.

## Additional background

cc @ezoni @RevathiJambunathan 

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
