### PR TITLE
Mac Arm64 Architecture fpe handling

### DIFF
--- a/Docs/sphinx_documentation/source/Debugging.rst
+++ b/Docs/sphinx_documentation/source/Debugging.rst
@@ -27,7 +27,7 @@ use of uninitialized values, AMReX also initializes ``FArrayBox``\ s in
 ``MulitFab``\ s and arrays allocated by ``bl_allocate`` to signaling NaNs when it is compiled
 with ``TEST=TRUE`` or ``DEBUG=TRUE`` in GNU make, or with ``-DCMAKE_BUILD_TYPE=Debug`` in CMake.
 One can also control the setting for ``FArrayBox`` using the runtime parameter, ``fab.init_snan``.
-Note for Macs, M1 and M2 chips using Arm64 architecture are not able to trap division by zero.  
+Note for Macs, M1 and M2 chips using Arm64 architecture are not able to trap division by zero.
 
 One can get more information than the backtrace of the call stack by
 instrumenting the code.  Here is an example.

--- a/Docs/sphinx_documentation/source/Debugging.rst
+++ b/Docs/sphinx_documentation/source/Debugging.rst
@@ -27,6 +27,7 @@ use of uninitialized values, AMReX also initializes ``FArrayBox``\ s in
 ``MulitFab``\ s and arrays allocated by ``bl_allocate`` to signaling NaNs when it is compiled
 with ``TEST=TRUE`` or ``DEBUG=TRUE`` in GNU make, or with ``-DCMAKE_BUILD_TYPE=Debug`` in CMake.
 One can also control the setting for ``FArrayBox`` using the runtime parameter, ``fab.init_snan``.
+Note for Macs, M1 and M2 chips using Arm64 architecture are not able to trap division by zero.  
 
 One can get more information than the backtrace of the call stack by
 instrumenting the code.  Here is an example.

--- a/Src/Base/AMReX.cpp
+++ b/Src/Base/AMReX.cpp
@@ -554,6 +554,16 @@ amrex::Initialize (int& argc, char**& argv, bool build_parm_parse,
                     prev_handler_sigfpe = std::signal(SIGFPE,  BLBackTrace::handler);
                 }
 
+#elif defined(__APPLE__) && defined(__aarch64__)
+                fenv_t env;
+                fegetenv(&env);
+                if (invalid)   env.__fpcr |= __fpcr_trap_invalid;
+                if (divbyzero) env.__fpcr |= __fpcr_trap_divbyzero;
+                if (overflow)  env.__fpcr |= __fpcr_trap_overflow;
+                fesetenv(&env);
+                // SIGILL ref: https://developer.apple.com/forums/thread/689159
+                prev_handler_sigfpe = std::signal(SIGILL,  BLBackTrace::handler);
+
 #elif defined(__APPLE__) && defined(__x86_64__)
                 prev_fpe_mask = _MM_GET_EXCEPTION_MASK();
                 curr_fpe_excepts = 0u;

--- a/Src/Base/AMReX.cpp
+++ b/Src/Base/AMReX.cpp
@@ -558,16 +558,6 @@ amrex::Initialize (int& argc, char**& argv, bool build_parm_parse,
                     prev_handler_sigfpe = std::signal(SIGFPE,  BLBackTrace::handler);
                 }
 
-#elif defined(__APPLE__) && defined(__aarch64__)
-                fenv_t env;
-                fegetenv(&env);
-                if (invalid)   env.__fpcr |= __fpcr_trap_invalid;
-                if (divbyzero) env.__fpcr |= __fpcr_trap_divbyzero;
-                if (overflow)  env.__fpcr |= __fpcr_trap_overflow;
-                fesetenv(&env);
-                // SIGILL ref: https://developer.apple.com/forums/thread/689159
-                prev_handler_sigfpe = std::signal(SIGILL,  BLBackTrace::handler);
-
 #elif defined(__APPLE__) && defined(__x86_64__)
                 prev_fpe_mask = _MM_GET_EXCEPTION_MASK();
                 curr_fpe_excepts = 0u;

--- a/Src/Base/AMReX.cpp
+++ b/Src/Base/AMReX.cpp
@@ -574,11 +574,12 @@ amrex::Initialize (int& argc, char**& argv, bool build_parm_parse,
             prev_handler_sigill = SIG_ERR; // NOLINT(performance-no-int-to-ptr)
             if (system::handle_sigill)
             {
+#if defined(__APPLE__) && defined(__aarch64__)
                 int invalid = 0, divbyzero=0, overflow=0;
                 pp.queryAdd("fpe_trap_invalid", invalid);
                 pp.queryAdd("fpe_trap_zero", divbyzero);
                 pp.queryAdd("fpe_trap_overflow", overflow);
-#if defined(__APPLE__) && defined(__aarch64__)
+
                 fenv_t env;
                 fegetenv(&env);
                 if (invalid)   env.__fpcr |= __fpcr_trap_invalid;
@@ -586,8 +587,8 @@ amrex::Initialize (int& argc, char**& argv, bool build_parm_parse,
                 if (overflow)  env.__fpcr |= __fpcr_trap_overflow;
                 fesetenv(&env);
                 // SIGILL ref: https://developer.apple.com/forums/thread/689159
-                prev_handler_sigill = std::signal(SIGILL,  BLBackTrace::handler);
 #endif
+                prev_handler_sigill = std::signal(SIGILL,  BLBackTrace::handler);
             }
         }
 

--- a/Src/Base/AMReX_BLBackTrace.cpp
+++ b/Src/Base/AMReX_BLBackTrace.cpp
@@ -58,6 +58,9 @@ BLBackTrace::handler(int s)
     case SIGFPE:
         amrex::ErrorStream() << "Erroneous arithmetic operation\n";
         break;
+    case SIGILL:
+        amrex::ErrorStream() << "SIGILL Invalid, privileged, or ill-formed instruction\n";
+        break;
     case SIGTERM:
         amrex::ErrorStream() << "SIGTERM\n";
         break;

--- a/Tools/CMake/AMReXFlagsTargets.cmake
+++ b/Tools/CMake/AMReXFlagsTargets.cmake
@@ -131,6 +131,7 @@ target_compile_options ( Flags_FPE
    $<${_cxx_cray}:-K trap=fp>
    $<${_fortran_clang}:>
    $<${_cxx_clang}:-ftrapv>
+   $<${_cxx_appleclang}:-ftrapv>	
    )
 
 #


### PR DESCRIPTION
## Summary
Handles floating pointing exception when compiled on arch64 and Apple (for M1 and M2 chips). Only works for overflow currently, there is an apparent limitation to these architectures for catching division by zero.

## Additional background
SIGILL instead of SIGFPE is needed to catch arch64 signals, see ref: https://developer.apple.com/forums/thread/689159

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [x] include documentation in the code and/or rst files, if appropriate
