### PR TITLE
Refactor call_f in ParticleTransformation and WriteBinaryParticleData to use constexpr if

### DIFF
--- a/Src/Particle/AMReX_ParticleTransformation.H
+++ b/Src/Particle/AMReX_ParticleTransformation.H
@@ -379,7 +379,8 @@ int filterParticles (DstTile& dst, const SrcTile& src, Pred&& p) noexcept
  * \param n the number of particles to apply the operation to
  *
  */
-template <typename DstTile, typename SrcTile, typename Pred, typename Index, typename N>
+template <typename DstTile, typename SrcTile, typename Pred, typename Index, typename N,
+          std::enable_if_t<!std::is_pointer_v<std::decay_t<Pred>>,Index> = 0>
 Index filterParticles (DstTile& dst, const SrcTile& src, Pred&& p,
                        Index src_start, Index dst_start, N n) noexcept
 {
@@ -592,7 +593,8 @@ int filterAndTransformParticles (DstTile1& dst1, DstTile2& dst2, const SrcTile& 
  *
  */
 
-template <typename DstTile, typename SrcTile, typename Pred, typename F, typename Index>
+template <typename DstTile, typename SrcTile, typename Pred, typename F, typename Index,
+          std::enable_if_t<!std::is_pointer_v<std::decay_t<Pred>>,Index> = 0>
 Index filterAndTransformParticles (DstTile& dst, const SrcTile& src, Pred&& p, F&& f,
                                    Index src_start, Index dst_start) noexcept
 {

--- a/Src/Particle/AMReX_ParticleTransformation.H
+++ b/Src/Particle/AMReX_ParticleTransformation.H
@@ -392,7 +392,13 @@ auto filterParticles (DstTile& dst, const SrcTile& src, Pred&& p,
     amrex::ParallelForRNG(n,
     [=] AMREX_GPU_DEVICE (int i, amrex::RandomEngine const& engine) noexcept
     {
-        p_mask[i] = particle_detail::call_f(p, src_data, src_start+i, engine);
+        amrex::ignore_unused(src_data, src_start);
+        if constexpr (IsCallable<Pred,decltype(src_data),Index,RandomEngine>::value) {
+            p_mask[i] = p(src_data, src_start+i, engine);
+        } else {
+            amrex::ignore_unused(engine);
+            p_mask[i] = p(src_data, src_start+i);
+        }
     });
     return filterParticles(dst, src, mask.dataPtr(), src_start, dst_start, n);
 }
@@ -558,7 +564,13 @@ int filterAndTransformParticles (DstTile1& dst1, DstTile2& dst2, const SrcTile& 
     amrex::ParallelForRNG(np,
     [=] AMREX_GPU_DEVICE (int i, amrex::RandomEngine const& engine) noexcept
     {
-        p_mask[i] = particle_detail::call_f(p, src_data, i, engine);
+        amrex::ignore_unused(src_data);
+        if constexpr (IsCallable<Pred,decltype(src_data),int,RandomEngine>::value) {
+            p_mask[i] = p(src_data, i, engine);
+        } else {
+            amrex::ignore_unused(engine);
+            p_mask[i] = p(src_data, i);
+        }
     });
     return filterAndTransformParticles(dst1, dst2, src, mask.dataPtr(), std::forward<F>(f));
 }
@@ -596,7 +608,13 @@ auto filterAndTransformParticles (DstTile& dst, const SrcTile& src, Pred&& p, F&
     amrex::ParallelForRNG(np,
     [=] AMREX_GPU_DEVICE (int i, amrex::RandomEngine const& engine) noexcept
     {
-        p_mask[i] = particle_detail::call_f(p, src_data, src_start+i, engine);
+        amrex::ignore_unused(src_data, src_start);
+        if constexpr (IsCallable<Pred,decltype(src_data),Index,RandomEngine>::value) {
+            p_mask[i] = p(src_data, src_start+i, engine);
+        } else {
+            amrex::ignore_unused(engine);
+            p_mask[i] = p(src_data, src_start+i);
+        }
     });
     return filterAndTransformParticles(dst, src, mask.dataPtr(), std::forward<F>(f), src_start, dst_start);
 }

--- a/Src/Particle/AMReX_ParticleTransformation.H
+++ b/Src/Particle/AMReX_ParticleTransformation.H
@@ -380,9 +380,8 @@ int filterParticles (DstTile& dst, const SrcTile& src, Pred&& p) noexcept
  *
  */
 template <typename DstTile, typename SrcTile, typename Pred, typename Index, typename N>
-auto filterParticles (DstTile& dst, const SrcTile& src, Pred&& p,
-                      Index src_start, Index dst_start, N n) noexcept
-    -> decltype(Index(particle_detail::call_f(p, typename SrcTile::ConstParticleTileDataType(), int{}, RandomEngine{})))
+Index filterParticles (DstTile& dst, const SrcTile& src, Pred&& p,
+                       Index src_start, Index dst_start, N n) noexcept
 {
     Gpu::DeviceVector<Index> mask(n);
 
@@ -595,9 +594,8 @@ int filterAndTransformParticles (DstTile1& dst1, DstTile2& dst2, const SrcTile& 
  */
 
 template <typename DstTile, typename SrcTile, typename Pred, typename F, typename Index>
-auto filterAndTransformParticles (DstTile& dst, const SrcTile& src, Pred&& p, F&& f,
-                      Index src_start, Index dst_start) noexcept
-    -> decltype(Index(particle_detail::call_f(p, typename SrcTile::ConstParticleTileDataType(), int{}, RandomEngine{})))
+Index filterAndTransformParticles (DstTile& dst, const SrcTile& src, Pred&& p, F&& f,
+                                   Index src_start, Index dst_start) noexcept
 {
     auto np = src.numParticles();
     Gpu::DeviceVector<Index> mask(np);

--- a/Src/Particle/AMReX_ParticleTransformation.H
+++ b/Src/Particle/AMReX_ParticleTransformation.H
@@ -380,7 +380,7 @@ int filterParticles (DstTile& dst, const SrcTile& src, Pred&& p) noexcept
  *
  */
 template <typename DstTile, typename SrcTile, typename Pred, typename Index, typename N,
-          std::enable_if_t<!std::is_pointer_v<std::decay_t<Pred>>,Index> = 0>
+          std::enable_if_t<!std::is_pointer_v<std::decay_t<Pred>>,Index> nvccfoo = 0>
 Index filterParticles (DstTile& dst, const SrcTile& src, Pred&& p,
                        Index src_start, Index dst_start, N n) noexcept
 {
@@ -593,7 +593,7 @@ int filterAndTransformParticles (DstTile1& dst1, DstTile2& dst2, const SrcTile& 
  */
 
 template <typename DstTile, typename SrcTile, typename Pred, typename F, typename Index,
-          std::enable_if_t<!std::is_pointer_v<std::decay_t<Pred>>,Index> = 0>
+          std::enable_if_t<!std::is_pointer_v<std::decay_t<Pred>>,Index> nvccfoo = 0>
 Index filterAndTransformParticles (DstTile& dst, const SrcTile& src, Pred&& p, F&& f,
                                    Index src_start, Index dst_start) noexcept
 {
@@ -610,7 +610,6 @@ Index filterAndTransformParticles (DstTile& dst, const SrcTile& src, Pred&& p, F
         if constexpr (IsCallable<Pred,decltype(src_data),Index,RandomEngine>::value) {
             p_mask[i] = p(src_data, src_start+i, engine);
         } else {
-            amrex::ignore_unused(engine);
             p_mask[i] = p(src_data, src_start+i);
         }
     });

--- a/Src/Particle/AMReX_ParticleTransformation.H
+++ b/Src/Particle/AMReX_ParticleTransformation.H
@@ -392,7 +392,7 @@ Index filterParticles (DstTile& dst, const SrcTile& src, Pred&& p,
     amrex::ParallelForRNG(n,
     [=] AMREX_GPU_DEVICE (int i, amrex::RandomEngine const& engine) noexcept
     {
-        amrex::ignore_unused(p_mask, src_data, src_start, engine);
+        amrex::ignore_unused(p, p_mask, src_data, src_start, engine);
         if constexpr (IsCallable<Pred,decltype(src_data),Index,RandomEngine>::value) {
             p_mask[i] = p(src_data, src_start+i, engine);
         } else {
@@ -563,11 +563,10 @@ int filterAndTransformParticles (DstTile1& dst1, DstTile2& dst2, const SrcTile& 
     amrex::ParallelForRNG(np,
     [=] AMREX_GPU_DEVICE (int i, amrex::RandomEngine const& engine) noexcept
     {
-        amrex::ignore_unused(p_mask, src_data, engine);
+        amrex::ignore_unused(p, p_mask, src_data, engine);
         if constexpr (IsCallable<Pred,decltype(src_data),int,RandomEngine>::value) {
             p_mask[i] = p(src_data, i, engine);
         } else {
-            amrex::ignore_unused(engine);
             p_mask[i] = p(src_data, i);
         }
     });
@@ -607,7 +606,7 @@ Index filterAndTransformParticles (DstTile& dst, const SrcTile& src, Pred&& p, F
     amrex::ParallelForRNG(np,
     [=] AMREX_GPU_DEVICE (int i, amrex::RandomEngine const& engine) noexcept
     {
-        amrex::ignore_unused(p_mask, src_data, src_start, engine);
+        amrex::ignore_unused(p, p_mask, src_data, src_start, engine);
         if constexpr (IsCallable<Pred,decltype(src_data),Index,RandomEngine>::value) {
             p_mask[i] = p(src_data, src_start+i, engine);
         } else {

--- a/Src/Particle/AMReX_ParticleTransformation.H
+++ b/Src/Particle/AMReX_ParticleTransformation.H
@@ -391,11 +391,10 @@ Index filterParticles (DstTile& dst, const SrcTile& src, Pred&& p,
     amrex::ParallelForRNG(n,
     [=] AMREX_GPU_DEVICE (int i, amrex::RandomEngine const& engine) noexcept
     {
-        amrex::ignore_unused(src_data, src_start);
+        amrex::ignore_unused(p_mask, src_data, src_start, engine);
         if constexpr (IsCallable<Pred,decltype(src_data),Index,RandomEngine>::value) {
             p_mask[i] = p(src_data, src_start+i, engine);
         } else {
-            amrex::ignore_unused(engine);
             p_mask[i] = p(src_data, src_start+i);
         }
     });
@@ -563,7 +562,7 @@ int filterAndTransformParticles (DstTile1& dst1, DstTile2& dst2, const SrcTile& 
     amrex::ParallelForRNG(np,
     [=] AMREX_GPU_DEVICE (int i, amrex::RandomEngine const& engine) noexcept
     {
-        amrex::ignore_unused(src_data);
+        amrex::ignore_unused(p_mask, src_data, engine);
         if constexpr (IsCallable<Pred,decltype(src_data),int,RandomEngine>::value) {
             p_mask[i] = p(src_data, i, engine);
         } else {
@@ -606,7 +605,7 @@ Index filterAndTransformParticles (DstTile& dst, const SrcTile& src, Pred&& p, F
     amrex::ParallelForRNG(np,
     [=] AMREX_GPU_DEVICE (int i, amrex::RandomEngine const& engine) noexcept
     {
-        amrex::ignore_unused(src_data, src_start);
+        amrex::ignore_unused(p_mask, src_data, src_start, engine);
         if constexpr (IsCallable<Pred,decltype(src_data),Index,RandomEngine>::value) {
             p_mask[i] = p(src_data, src_start+i, engine);
         } else {

--- a/Src/Particle/AMReX_ParticleUtil.H
+++ b/Src/Particle/AMReX_ParticleUtil.H
@@ -22,22 +22,6 @@ namespace amrex
 
 namespace particle_detail {
 
-template <typename F, typename P>
-AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-auto call_f (F const& f, P const& p, amrex::RandomEngine const& engine) noexcept
-    -> decltype(f(P{},RandomEngine{}))
-{
-    return f(p,engine);
-}
-
-template <typename F, typename P>
-AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-auto call_f (F const& f, P const& p, amrex::RandomEngine const&) noexcept
-    -> decltype(f(P{}))
-{
-    return f(p);
-}
-
 // The next several functions are used by ParticleReduce
 
 // Lambda takes a Particle

--- a/Src/Particle/AMReX_ParticleUtil.H
+++ b/Src/Particle/AMReX_ParticleUtil.H
@@ -38,22 +38,6 @@ auto call_f (F const& f, P const& p, amrex::RandomEngine const&) noexcept
     return f(p);
 }
 
-template <typename F, typename SrcData, typename N>
-AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-auto call_f (F const& f, SrcData const& src, N i, amrex::RandomEngine const& engine) noexcept
-    -> decltype(f(SrcData{},N{},RandomEngine{}))
-{
-    return f(src,i,engine);
-}
-
-template <typename F, typename SrcData, typename N>
-AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-auto call_f (F const& f, SrcData const& src, N i, amrex::RandomEngine const&) noexcept
-    -> decltype(f(SrcData{},N{}))
-{
-    return f(src,i);
-}
-
 // The next several functions are used by ParticleReduce
 
 // Lambda takes a Particle

--- a/Src/Particle/AMReX_WriteBinaryParticleData.H
+++ b/Src/Particle/AMReX_WriteBinaryParticleData.H
@@ -42,11 +42,10 @@ fillFlags (Container<int, Allocator>& pflags, const PTile& ptile, F&& f)
         [=] AMREX_GPU_DEVICE (int k, amrex::RandomEngine const& engine) noexcept
         {
             const auto p = ptd.getSuperParticle(k);
-            amrex::ignore_unused(flag_ptr, f);
+            amrex::ignore_unused(flag_ptr, f, engine);
             if constexpr (IsCallable<F,decltype(p),RandomEngine>::value) {
                 flag_ptr[k] = f(p,engine);
             } else {
-                amrex::ignore_unused(engine);
                 flag_ptr[k] = f(p);
             }
         });

--- a/Src/Particle/AMReX_WriteBinaryParticleData.H
+++ b/Src/Particle/AMReX_WriteBinaryParticleData.H
@@ -42,7 +42,13 @@ fillFlags (Container<int, Allocator>& pflags, const PTile& ptile, F&& f)
         [=] AMREX_GPU_DEVICE (int k, amrex::RandomEngine const& engine) noexcept
         {
             const auto p = ptd.getSuperParticle(k);
-            flag_ptr[k] = particle_detail::call_f(f,p,engine);
+            amrex::ignore_unused(flag_ptr, f);
+            if constexpr (IsCallable<F,decltype(p),RandomEngine>::value) {
+                flag_ptr[k] = f(p,engine);
+            } else {
+                amrex::ignore_unused(engine);
+                flag_ptr[k] = f(p);
+            }
         });
 }
 
@@ -59,7 +65,11 @@ fillFlags (Container<int, Allocator>& pflags, const PTile& ptile, F&& f)
     auto flag_ptr = pflags.data();
     for (int k = 0; k < np; ++k) {
         const auto p = ptd.getSuperParticle(k);
-        flag_ptr[k] = particle_detail::call_f(f,p,RandomEngine{});
+        if constexpr (IsCallable<F,decltype(p),RandomEngine>::value) {
+            flag_ptr[k] = f(p,RandomEngine{});
+        } else {
+            flag_ptr[k] = f(p);
+        }
     }
 }
 


### PR DESCRIPTION
This results in much easier-to-interpret error messages, useful in finding #3449 and #3450

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
