### PR TITLE
Fix this version of WritePlotFile to use SuperParticle, as expected by WriteBinaryParticleData

### DIFF
--- a/Src/Particle/AMReX_ParticleIO.H
+++ b/Src/Particle/AMReX_ParticleIO.H
@@ -169,7 +169,7 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator>
     WriteBinaryParticleData(dir, name,
                             write_real_comp, write_int_comp,
                             real_comp_names, int_comp_names,
-                            [=] AMREX_GPU_HOST_DEVICE (const ParticleType& p)
+                            [=] AMREX_GPU_HOST_DEVICE (const SuperParticleType& p)
                             {
                                 return p.id() > 0;
                             });


### PR DESCRIPTION
Fixes these issues seen in the WarpX CI:

https://github.com/ECP-WarpX/WarpX/actions/runs/5649976693/job/15305447602?pr=3474
https://github.com/ECP-WarpX/WarpX/actions/runs/5649976693/job/15305447804?pr=3474

## Summary

## Additional background

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
