### PR TITLE
Warn if USE_GPU_RDC=TRUE when HIP_SAVE_TEMPS=TRUE

### DIFF
--- a/Tools/GNUMake/Make.defs
+++ b/Tools/GNUMake/Make.defs
@@ -1086,11 +1086,11 @@ else ifeq ($(USE_HIP),TRUE)
     endif
 
     ifeq ($(HIP_SAVE_TEMPS),TRUE)
+      ifeq ($(USE_GPU_RDC),TRUE)
+        $(warning *** HIP_SAVE_TEMPS requires USE_GPU_RDC=FALSE to obtain the assembly files for AMD GPU kernels.)
+      endif
       # Issue: hipcc does not seem to respect the arg to --save-temps
       CXXFLAGS += --save-temps=$(objEXETempDir)
-      ifeq ($(DEBUG),TRUE) # --save-temps does not like AMREX_GPU_EXTERNAL
-        CPPFLAGS += -DNDEBUG
-      endif
     endif
 
 else ifeq ($(USE_CUDA),TRUE)


### PR DESCRIPTION
USE_GPU_RDC=FALSE is necessary to save the assembly files for AMD GPU kernels.

## Summary

## Additional background

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
