### PR TITLE
Fix CI Setup

### DIFF
--- a/.github/workflows/dependencies/dependencies_llvm_cuda11_ubuntu22.sh
+++ b/.github/workflows/dependencies/dependencies_llvm_cuda11_ubuntu22.sh
@@ -10,6 +10,8 @@ sudo apt-get -qqq update
 sudo apt-get install -y \
     build-essential     \
     ca-certificates     \
+    libunwind-15        \
+    libunwind-15-dev    \
     clang-15            \
     libc++-15-dev       \
     libc++abi-15-dev    \

--- a/.github/workflows/gcc.yml
+++ b/.github/workflows/gcc.yml
@@ -442,7 +442,7 @@ jobs:
     - name: Dependencies
       run: |
         .github/workflows/dependencies/dependencies.sh
-        .github/workflows/dependencies/dependencies_clang-tidy.sh 12
+        .github/workflows/dependencies/dependencies_clang-tidy.sh 15
         .github/workflows/dependencies/dependencies_ccache.sh
     - name: Set Up Cache
       uses: actions/cache@v3
@@ -467,7 +467,7 @@ jobs:
 
         ${{github.workspace}}/Tools/C_scripts/mmclt.py --input ${{github.workspace}}/ccache.log.txt
         make -j2 -f clang-tidy-ccache-misses.mak \
-            CLANG_TIDY=clang-tidy-12 \
+            CLANG_TIDY=clang-tidy-15 \
             CLANG_TIDY_ARGS="--config-file=${{github.workspace}}/.clang-tidy --warnings-as-errors=*"
 
         ccache -s

--- a/Src/F_Interfaces/Base/AMReX_init_fi.cpp
+++ b/Src/F_Interfaces/Base/AMReX_init_fi.cpp
@@ -13,7 +13,7 @@ extern "C"
 {
     using amrex_void_cfun = void (*)();
 
-    void amrex_fi_init (char* cmd, int fcomm, int arg_parmparse, amrex_void_cfun proc_parmparse)
+    void amrex_fi_init (char const* cmd, int fcomm, int arg_parmparse, amrex_void_cfun proc_parmparse)
     {
         std::istringstream is(cmd);
         amrex::Vector<std::string> argv_string(std::istream_iterator<std::string>{is},


### PR DESCRIPTION
Two CIs (one GCC and one Clang/CUDA) have been failing because of libunwind package conflict issues. This PR fixes them by (1) switching to clang-tidy-15 in the GCC test and (2) explicitly installing libunwind-15 and libunwind-15-dev in Clang test.
