### PR TITLE
Fix a bug in AmrMesh::ChopGrids

### DIFF
--- a/Src/AmrCore/AMReX_AmrMesh.cpp
+++ b/Src/AmrCore/AMReX_AmrMesh.cpp
@@ -457,7 +457,9 @@ AmrMesh::ChopGrids (int lev, BoxArray& ba, int target_size) const
             int idim = chunk_dir[idx].second;
             if (refine_grid_layout_dims[idim]) {
                 int new_chunk_size = chunk[idim] / 2;
-                if (new_chunk_size%blocking_factor[lev][idim] == 0) {
+                if (new_chunk_size != 0 &&
+                    new_chunk_size%blocking_factor[lev][idim] == 0)
+                {
                     chunk[idim] = new_chunk_size;
                     ba.maxSize(chunk);
                     break;


### PR DESCRIPTION
Fix a corner case for AmrMesh::ChopGrids when there is only one cell in one dimension.

Close #3459 

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
