### PR TITLE
Silence "unreachable loop" warning for GPU builds

### DIFF
--- a/Src/Base/AMReX_PODVector.H
+++ b/Src/Base/AMReX_PODVector.H
@@ -122,6 +122,8 @@ namespace amrex
                     return;
                 }
             }
+#else
+            static_assert(RunOnGpu<Allocator<T>>::value == false);
 #endif
             if constexpr (! RunOnGpu<Allocator<T>>::value) {
                 for (Size i = 0; i < count; ++i) { dst[i] = src[i]; }

--- a/Src/Base/AMReX_PODVector.H
+++ b/Src/Base/AMReX_PODVector.H
@@ -123,7 +123,9 @@ namespace amrex
                 }
             }
 #endif
-            for (Size i = 0; i < count; ++i) { dst[i] = src[i]; }
+            if constexpr (! RunOnGpu<Allocator<T>>::value) {
+                for (Size i = 0; i < count; ++i) { dst[i] = src[i]; }
+            }
         }
 
         template <typename Allocator>


### PR DESCRIPTION
This silences warnings like `Src/Base/AMReX_PODVector.H(126): warning #128-D: loop is not reachable`

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
