### PR TITLE
Suppress implicit return warnings with nvcc

### DIFF
--- a/Tools/CMake/AMReXParallelBackends.cmake
+++ b/Tools/CMake/AMReXParallelBackends.cmake
@@ -84,6 +84,7 @@ if (  AMReX_GPU_BACKEND STREQUAL "CUDA"
           $<${_genex}:
           --expt-relaxed-constexpr --expt-extended-lambda
           "SHELL:-Xcudafe --diag_suppress=esa_on_defaulted_function_ignored"
+          "SHELL:-Xcudafe --diag_suppress=implicit_return_from_non_void_function"
           -maxrregcount=${AMReX_CUDA_MAXREGCOUNT}
           "SHELL:-Xcudafe --display_error_number"
           $<$<STREQUAL:$<PLATFORM_ID>,Windows>:-m64> >

--- a/Tools/CMake/AMReX_SetupCUDA.cmake
+++ b/Tools/CMake/AMReX_SetupCUDA.cmake
@@ -54,6 +54,9 @@ string(APPEND CMAKE_CUDA_FLAGS " -maxrregcount=${AMReX_CUDA_MAXREGCOUNT}")
 # This is to work around a bug with nvcc, see: https://github.com/kokkos/kokkos/issues/1473
 string(APPEND CMAKE_CUDA_FLAGS " -Xcudafe --diag_suppress=esa_on_defaulted_function_ignored")
 
+# and another bug related to implicit returns with if constexpr, see: https://stackoverflow.com/questions/64523302/cuda-missing-return-statement-at-end-of-non-void-function-in-constexpr-if-fun
+string(APPEND CMAKE_CUDA_FLAGS " -Xcudafe --diag_suppress=implicit_return_from_non_void_function")
+
 if (AMReX_CUDA_FASTMATH)
    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --use_fast_math")
 endif ()

--- a/Tools/GNUMake/comps/nvcc.mak
+++ b/Tools/GNUMake/comps/nvcc.mak
@@ -92,6 +92,8 @@ endif
 NVCC_FLAGS = -Wno-deprecated-gpu-targets -m64 -arch=compute_$(CUDA_ARCH) -code=sm_$(CUDA_ARCH) -maxrregcount=$(CUDA_MAXREGCOUNT) --expt-relaxed-constexpr --expt-extended-lambda --forward-unknown-to-host-compiler
 # This is to work around a bug with nvcc, see: https://github.com/kokkos/kokkos/issues/1473
 NVCC_FLAGS += -Xcudafe --diag_suppress=esa_on_defaulted_function_ignored
+# and another bug related to implicit returns with if constexpr, see: https://stackoverflow.com/questions/64523302/cuda-missing-return-statement-at-end-of-non-void-function-in-constexpr-if-fun
+NVCC_FLAGS += -Xcudafe --diag_suppress=implicit_return_from_non_void_function
 
 ifeq ($(GPU_ERROR_CROSS_EXECUTION_SPACE_CALL),TRUE)
   NVCC_FLAGS += --Werror cross-execution-space-call


### PR DESCRIPTION
A bug in nvcc results in spurious warnings about implicit return statements when `if constexpr` is involved: https://stackoverflow.com/questions/64523302/cuda-missing-return-statement-at-end-of-non-void-function-in-constexpr-if-fun

Suppress those for now. 

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
