### PR TITLE
Add misc-misplaced-const check to clang-tidy CI test

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -20,6 +20,7 @@ Checks: >
        -cppcoreguidelines-non-private-member-variables-in-classes,
        -cppcoreguidelines-owning-memory,
        -cppcoreguidelines-pro-*,
+     misc-misplaced-const,
      modernize-*,
        -modernize-avoid-c-arrays,
        -modernize-macro-to-enum,


### PR DESCRIPTION
## Summary

This PR adds the [misc-misplaced-const](https://releases.llvm.org/14.0.0/tools/clang/tools/extra/docs/clang-tidy/checks/misc-misplaced-const.html) check to clang-tidy CI test.
I am not sure if you want to enforce this in AMReX, but I find the constructs it protects against quite misleading. 

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
