### PR TITLE
Handle ThetaGPU in GNU make system

### DIFF
--- a/Tools/GNUMake/Make.machines
+++ b/Tools/GNUMake/Make.machines
@@ -76,8 +76,10 @@ endif
 
 ifeq ($(findstring alcf.anl.gov, $(host_name)),alcf.anl.gov)
   ifeq ($(findstring theta, $(host_name)), theta)
+  ifneq ($(findstring thetagpu, $(host_name)), thetagpu)
     which_site := alcf
     which_computer := theta
+  endif
   endif
   ifeq ($(findstring polaris, $(host_name)), polaris)
     which_site := alcf


### PR DESCRIPTION
ThetaGPU gets incorrectly set to use the configuration for Theta, which does not work because the cray compiler wrappers are not available on ThetaGPU. However, Make.unknown works fine. So this PR reverts to using that on ThetaGPU.

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
