### PR TITLE
Change the default value of The_Pinned_Arena release threshold

### DIFF
--- a/Src/Base/AMReX_Arena.cpp
+++ b/Src/Base/AMReX_Arena.cpp
@@ -282,7 +282,7 @@ Arena::Initialize ()
 #ifdef AMREX_USE_SYCL
     the_arena_init_size = std::min(the_arena_init_size, Gpu::Device::maxMemAllocSize());
 #endif
-    the_pinned_arena_release_threshold = Gpu::Device::totalGlobalMem();
+    the_pinned_arena_release_threshold = Gpu::Device::totalGlobalMem() / Gpu::Device::numDevicePartners() / 2L;
 #endif
 
     ParmParse pp("amrex");


### PR DESCRIPTION
The old default of the size of device memory is too big for some machines (e.g., Perlmutter 80 GB nodes). Some WarpX runs were out of memory during restart. It is now set to half of the device memory.
