### PR TITLE
Option to force regrid level zero

### DIFF
--- a/Src/Amr/AMReX_Amr.cpp
+++ b/Src/Amr/AMReX_Amr.cpp
@@ -1933,7 +1933,9 @@ Amr::timeStep (int  level,
     // Update so that by default, we don't force a post-step regrid.
     amr_level[level]->setPostStepRegrid(0);
 
-    if(max_level==0 && force_regrid_level_zero)regrid_level_0_on_restart();
+    if(max_level==0 && force_regrid_level_zero){
+		regrid_level_0_on_restart();
+	}
 
     //
     // Allow regridding of level 0 calculation on restart.
@@ -2585,7 +2587,9 @@ Amr::regrid (int  lbase,
     bool regrid_level_zero = (!initial) && (lbase == 0)
         && ( loadbalance_with_workestimates || (new_grid_places[0] != amr_level[0]->boxArray()));
 
-    if(lbase==0 && force_regrid_level_zero)regrid_level_zero = true;
+    if(lbase==0 && force_regrid_level_zero){
+		regrid_level_zero = true;
+	}
 
     const int start = regrid_level_zero ? 0 : lbase+1;
 

--- a/Src/Amr/AMReX_Amr.cpp
+++ b/Src/Amr/AMReX_Amr.cpp
@@ -81,6 +81,7 @@ namespace
     bool plot_files_output;
     int  checkpoint_nfiles;
     int  regrid_on_restart;
+	int  force_regrid_level_zero;
     int  use_efficient_regrid;
     int  plotfile_on_restart;
     int  insitu_on_restart;
@@ -117,6 +118,7 @@ Amr::Initialize ()
     plot_files_output        = true;
     checkpoint_nfiles        = 64;
     regrid_on_restart        = 0;
+	force_regrid_level_zero  = 0;
     use_efficient_regrid     = 0;
     plotfile_on_restart      = 0;
     insitu_on_restart        = 0;
@@ -254,6 +256,7 @@ Amr::InitAmr ()
     // Check for command line flags.
     //
     pp.queryAdd("regrid_on_restart",regrid_on_restart);
+    pp.queryAdd("force_regrid_level_zero",force_regrid_level_zero);
     pp.queryAdd("use_efficient_regrid",use_efficient_regrid);
     pp.queryAdd("plotfile_on_restart",plotfile_on_restart);
     pp.queryAdd("insitu_on_restart",insitu_on_restart);
@@ -1930,6 +1933,8 @@ Amr::timeStep (int  level,
     // Update so that by default, we don't force a post-step regrid.
     amr_level[level]->setPostStepRegrid(0);
 
+	if(max_level==0 && force_regrid_level_zero)regrid_level_0_on_restart();
+
     //
     // Allow regridding of level 0 calculation on restart.
     //
@@ -2579,6 +2584,8 @@ Amr::regrid (int  lbase,
 
     bool regrid_level_zero = (!initial) && (lbase == 0)
         && ( loadbalance_with_workestimates || (new_grid_places[0] != amr_level[0]->boxArray()));
+
+	if(lbase==0 && force_regrid_level_zero)regrid_level_zero = true;
 
     const int start = regrid_level_zero ? 0 : lbase+1;
 

--- a/Src/Amr/AMReX_Amr.cpp
+++ b/Src/Amr/AMReX_Amr.cpp
@@ -81,7 +81,7 @@ namespace
     bool plot_files_output;
     int  checkpoint_nfiles;
     int  regrid_on_restart;
-	int  force_regrid_level_zero;
+    int  force_regrid_level_zero;
     int  use_efficient_regrid;
     int  plotfile_on_restart;
     int  insitu_on_restart;
@@ -118,7 +118,7 @@ Amr::Initialize ()
     plot_files_output        = true;
     checkpoint_nfiles        = 64;
     regrid_on_restart        = 0;
-	force_regrid_level_zero  = 0;
+    force_regrid_level_zero  = 0;
     use_efficient_regrid     = 0;
     plotfile_on_restart      = 0;
     insitu_on_restart        = 0;
@@ -1933,7 +1933,7 @@ Amr::timeStep (int  level,
     // Update so that by default, we don't force a post-step regrid.
     amr_level[level]->setPostStepRegrid(0);
 
-	if(max_level==0 && force_regrid_level_zero)regrid_level_0_on_restart();
+    if(max_level==0 && force_regrid_level_zero)regrid_level_0_on_restart();
 
     //
     // Allow regridding of level 0 calculation on restart.
@@ -2585,7 +2585,7 @@ Amr::regrid (int  lbase,
     bool regrid_level_zero = (!initial) && (lbase == 0)
         && ( loadbalance_with_workestimates || (new_grid_places[0] != amr_level[0]->boxArray()));
 
-	if(lbase==0 && force_regrid_level_zero)regrid_level_zero = true;
+    if(lbase==0 && force_regrid_level_zero)regrid_level_zero = true;
 
     const int start = regrid_level_zero ? 0 : lbase+1;
 

--- a/Src/Amr/AMReX_Amr.cpp
+++ b/Src/Amr/AMReX_Amr.cpp
@@ -1934,8 +1934,8 @@ Amr::timeStep (int  level,
     amr_level[level]->setPostStepRegrid(0);
 
     if(max_level==0 && force_regrid_level_zero){
-		regrid_level_0_on_restart();
-	}
+        regrid_level_0_on_restart();
+    }
 
     //
     // Allow regridding of level 0 calculation on restart.
@@ -2588,8 +2588,8 @@ Amr::regrid (int  lbase,
         && ( loadbalance_with_workestimates || (new_grid_places[0] != amr_level[0]->boxArray()));
 
     if(lbase==0 && force_regrid_level_zero){
-		regrid_level_zero = true;
-	}
+        regrid_level_zero = true;
+    }
 
     const int start = regrid_level_zero ? 0 : lbase+1;
 

--- a/Tools/GNUMake/Make.defs
+++ b/Tools/GNUMake/Make.defs
@@ -901,6 +901,10 @@ ifeq ($(USE_EB),TRUE)
     DEFINES += -DAMREX_USE_EB
 endif
 
+ifeq ($(USE_MOVING_EB),TRUE)
+    DEFINES += -DAMREX_USE_MOVING_EB
+endif
+
 ifeq ($(AMREX_XSDK),TRUE)
    DEFINES += -DAMREX_XSDK
 endif

--- a/Tools/GNUMake/Make.defs
+++ b/Tools/GNUMake/Make.defs
@@ -901,10 +901,6 @@ ifeq ($(USE_EB),TRUE)
     DEFINES += -DAMREX_USE_EB
 endif
 
-ifeq ($(USE_MOVING_EB),TRUE)
-    DEFINES += -DAMREX_USE_MOVING_EB
-endif
-
 ifeq ($(AMREX_XSDK),TRUE)
    DEFINES += -DAMREX_XSDK
 endif


### PR DESCRIPTION
## Summary
This PR gives the user an option to force regrid level zero.

## Additional background
This is needed for moving EB cases.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
