### PR TITLE
Adjust build for upstream Mpich and OpenMPI modules on Perlmutter.

### DIFF
--- a/Tools/GNUMake/sites/Make.nersc
+++ b/Tools/GNUMake/sites/Make.nersc
@@ -25,6 +25,22 @@ ifeq ($(which_computer),$(filter $(which_computer),perlmutter))
   endif
 
   ifeq ($(USE_CUDA),TRUE)
+    ifdef MPICH_ROOT
+      CFLAGS += -Xcompiler='$(filter-out -Wl%, $(wordlist 2,1024,$(shell mpicc -show 2> /dev/null)))'
+      CXXFLAGS += -Xcompiler='$(filter-out -Wl%, $(wordlist 2,1024,$(shell mpicxx -show 2> /dev/null)))'
+    else ifdef OPENMPI_ROOT
+      CFLAGS += -Xcompiler='$(filter-out -Wl%, $(wordlist 2,1024,$(shell mpicc -show 2> /dev/null)))'
+      CXXFLAGS += -Xcompiler='$(filter-out -Wl%, $(wordlist 2,1024,$(shell mpicxx -show 2> /dev/null)))'
+    else
+      CFLAGS += -Xcompiler='$(wordlist 2,1024,$(shell cc -craype-verbose 2> /dev/null))'
+      CXXFLAGS += -Xcompiler='$(wordlist 2,1024,$(shell CC -craype-verbose 2> /dev/null))'
+    endif
+  else ifeq ($(USE_MPI),FALSE)
+    CFLAGS += $(wordlist 2,1024,$(shell cc -craype-verbose 2> /dev/null))
+    CXXFLAGS += $(wordlist 2,1024,$(shell CC -craype-verbose 2> /dev/null))
+  endif
+
+  ifeq ($(USE_CUDA),TRUE)
     ifdef NPE_VERSION
       CFLAGS += -Xcompiler='$(filter-out -Wl%, $(wordlist 2,1024,$(shell mpicc -show 2> /dev/null)))'
       CXXFLAGS += -Xcompiler='$(filter-out -Wl%, $(wordlist 2,1024,$(shell mpicxx -show 2> /dev/null)))'
@@ -64,13 +80,20 @@ ifeq ($(which_computer),$(filter $(which_computer),perlmutter))
 
     comm := ,
     ifneq ($(BL_NO_FORT),TRUE)
-      ifdef NPE_VERSION
+      ifdef MPICH_ROOT
+#       Set to mpicxx to avoid this warning:
+#       cc1plus: warning: command-line option '-fallow-argument-mismatch' is valid for Fortran but not for C++
+#       Can just be filtered out, or is cxx fine?
+        LIBRARIES += $(subst -Wl$(comm),-Xlinker=,$(wordlist 2,1024,$(shell mpicxx -show)))
+      else ifdef OPENMPI_ROOT
         LIBRARIES += $(subst -Wl$(comm),-Xlinker=,$(wordlist 2,1024,$(shell mpifort -show)))
       else
         LIBRARIES += $(subst -Wl$(comm),-Xlinker=,$(shell ftn --cray-print-opts=libs))
       endif
     else
-      ifdef NPE_VERSION
+      ifdef MPICH_ROOT
+        LIBRARIES += $(subst -Wl$(comm),-Xlinker=,$(wordlist 2,1024,$(shell mpicxx -show)))
+      else ifdef OPENMPI_ROOT
         LIBRARIES += $(subst -Wl$(comm),-Xlinker=,$(wordlist 2,1024,$(shell mpicxx -show)))
       else
         LIBRARIES += $(subst -Wl$(comm),-Xlinker=,$(shell CC --cray-print-opts=libs))


### PR DESCRIPTION
## Summary

Upstream MPICH and OpenMPI are available now on Perlmutter. To access them:
module load mpich
module load openmpi

With openmpi, srun also requires the flag --mpi=pmix, or equivalent.
(https://docs.nersc.gov/development/programming-models/mpi/openmpi/)

With these adjustments, HeatEquation runs fine, albeit with some errors at start and/or end, which may be srun flag related.

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
