### PR TITLE
CMake: HIP Debug with -O1

### DIFF
--- a/Tools/CMake/AMReXParallelBackends.cmake
+++ b/Tools/CMake/AMReXParallelBackends.cmake
@@ -272,6 +272,15 @@ if (AMReX_HIP)
           )
        endforeach()
    endif()
+   
+   # Debug issues with -O0: internal compiler errors
+   # work-around for
+   #   https://github.com/AMReX-Codes/amrex/pull/3311
+   foreach(D IN LISTS AMReX_SPACEDIM)
+      target_compile_options(amrex_${D}d PUBLIC
+         "$<$<CONFIG:Debug>:-O1>"
+      )
+   endforeach()
 
    # Link to hiprand -- must include rocrand too
    find_package(rocrand REQUIRED CONFIG)


### PR DESCRIPTION
## Summary

Same work-around as in GNUmake, see
  https://github.com/AMReX-Codes/amrex/pull/3311

- [ ] testing

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
