### PR TITLE
FillRandom & FillRandomNormal

### DIFF
--- a/Src/Base/AMReX_GpuError.H
+++ b/Src/Base/AMReX_GpuError.H
@@ -79,6 +79,11 @@ namespace Gpu {
                            + ": " + cudaGetErrorString(amrex_i_err)); \
         amrex::Abort(errStr); \
     }}
+
+#define AMREX_CURAND_SAFE_CALL(x) do { if((x)!=CURAND_STATUS_SUCCESS) { \
+    std::string errStr(std::string("CURAND error in file ") + __FILE__  \
+                       + " line " + std::to_string(__LINE__));          \
+    amrex::Abort(errStr); }} while(0)
 #endif
 
 #ifdef AMREX_USE_HIP
@@ -90,6 +95,11 @@ namespace Gpu {
                            + " " + hipGetErrorString(amrex_i_err)); \
         amrex::Abort(errStr); \
     }}
+
+#define AMREX_HIPRAND_SAFE_CALL(x) do { if((x)!=HIPRAND_STATUS_SUCCESS) { \
+    std::string errStr(std::string("HIPRAND error in file ") + __FILE__  \
+                       + " line " + std::to_string(__LINE__));          \
+    amrex::Abort(errStr); }} while(0)
 #endif
 
 #define AMREX_GPU_ERROR_CHECK() amrex::Gpu::ErrorCheck(__FILE__, __LINE__)

--- a/Src/Base/AMReX_MultiFabUtil.H
+++ b/Src/Base/AMReX_MultiFabUtil.H
@@ -361,6 +361,31 @@ namespace amrex
     void FourthOrderInterpFromFineToCoarse (MultiFab& cmf, int scomp, int ncomp,
                                             MultiFab const& fmf,
                                             IntVect const& ratio);
+
+    /**
+     * \brief Fill MultiFab with random numbers from uniform distribution
+     *
+     * The uniform distribution range is [0.0, 1.0) for CPU and SYCL, it's
+     * (0,1] for CUDA and HIP. All cells including ghost cells are filled.
+     *
+     * \param mf    MultiFab
+     * \param scomp starting component
+     * \param ncomp number of component
+     */
+    void FillRandom (MultiFab& mf, int scomp, int ncomp);
+
+    /**
+     * \brief Fill MultiFab with random numbers from nornmal distribution
+     *
+     * All cells including ghost cells are filled.
+     *
+     * \param mf     MultiFab
+     * \param scomp  starting component
+     * \param ncomp  number of component
+     * \param mean   mean of normal distribution
+     * \param stddev standard deviation of normal distribution
+     */
+    void FillRandomNormal (MultiFab& mf, int scomp, int ncomp, Real mean, Real stddev);
 }
 
 namespace amrex {

--- a/Src/Base/AMReX_MultiFabUtil.cpp
+++ b/Src/Base/AMReX_MultiFabUtil.cpp
@@ -1,5 +1,6 @@
 
 #include <AMReX_MultiFabUtil.H>
+#include <AMReX_Random.H>
 #include <sstream>
 #include <iostream>
 
@@ -1183,5 +1184,31 @@ namespace amrex
         }
 
         cmf.ParallelCopy(tmp, 0, scomp, ncomp);
+    }
+
+    void FillRandom (MultiFab& mf, int scomp, int ncomp)
+    {
+#ifdef AMREX_USE_OMP
+#pragma omp parallel if (Gpu::notInLaunchRegion())
+#endif
+        for (MFIter mfi(mf); mfi.isValid(); ++mfi)
+        {
+            auto* p = mf[mfi].dataPtr(scomp);
+            Long npts = mf[mfi].box().numPts() * ncomp;
+            FillRandom(p, npts);
+        }
+    }
+
+    void FillRandomNormal (MultiFab& mf, int scomp, int ncomp, Real mean, Real stddev)
+    {
+#ifdef AMREX_USE_OMP
+#pragma omp parallel if (Gpu::notInLaunchRegion())
+#endif
+        for (MFIter mfi(mf); mfi.isValid(); ++mfi)
+        {
+            auto* p = mf[mfi].dataPtr(scomp);
+            Long npts = mf[mfi].box().numPts() * ncomp;
+            FillRandomNormal(p, npts, mean, stddev);
+        }
     }
 }

--- a/Src/Base/AMReX_Random.H
+++ b/Src/Base/AMReX_Random.H
@@ -144,6 +144,13 @@ namespace amrex
     */
     ULong Random_long (ULong n); // [0,n-1]
 
+    //! Fill random numbers from uniform distribution.  The range is [0,1)
+    //! for CPU and SYCl, and (0,1] for CUADA and HIP.
+    void FillRandom (Real* p, Long N);
+
+    //! Fill random numbers from normal distribution
+    void FillRandomNormal (Real* p, Long N, Real mean, Real stddev);
+
     namespace detail {
         inline ULong DefaultGpuSeed () {
             return ParallelDescriptor::MyProc()*1234567ULL + 12345ULL;

--- a/Src/Base/AMReX_Random.cpp
+++ b/Src/Base/AMReX_Random.cpp
@@ -19,8 +19,10 @@ namespace
 namespace amrex {
 #ifdef AMREX_USE_SYCL
     sycl_rng_descr* rand_engine_descr = nullptr;
+//xxxxx    oneapi::mkl::rng::philox4x32x10* gpu_rand_generator = nullptr;
 #else
     amrex::randState_t* gpu_rand_state = nullptr;
+    amrex::randGenerator_t gpu_rand_generator = nullptr;
 #endif
 }
 #endif
@@ -42,6 +44,9 @@ void ResizeRandomSeed (amrex::ULong gpu_seed)
     rand_engine_descr = new sycl_rng_descr
         (Gpu::Device::streamQueue(), sycl::range<1>(N), gpu_seed, 1);
 
+//xxxxx    gpu_rand_generator = new std::remove_pointer_t<decltype(gpu_rand_generator)>
+//        (Gpu::Device::streamQueue(), gpu_seed+1234ULL);
+
 #elif defined(AMREX_USE_CUDA) || defined(AMREX_USE_HIP)
 
     gpu_rand_state =  static_cast<randState_t*>(The_Arena()->alloc(N*sizeof(randState_t)));
@@ -52,9 +57,22 @@ void ResizeRandomSeed (amrex::ULong gpu_seed)
         AMREX_HIP_OR_CUDA( hiprand_init(gpu_seed, seqstart, 0, &gpu_rand_state_local[idx]);,
                             curand_init(gpu_seed, seqstart, 0, &gpu_rand_state_local[idx]); )
     });
+
+#if defined(AMREX_USE_CUDA)
+    AMREX_CURAND_SAFE_CALL(curandCreateGenerator
+                           (&gpu_rand_generator, CURAND_RNG_PSEUDO_DEFAULT));
+    AMREX_CURAND_SAFE_CALL(curandSetPseudoRandomGeneratorSeed
+                           (gpu_rand_generator, gpu_seed+1234ULL));
+#else
+    AMREX_HIPRAND_SAFE_CALL(hiprandCreateGenerator
+                            (&gpu_rand_generator, HIPRAND_RNG_PSEUDO_DEFAULT));
+    AMREX_HIPRAND_SAFE_CALL(hiprandSetPseudoRandomGeneratorSeed
+                            (gpu_rand_generator, gpu_seed+1234ULL));
 #endif
 
-    Gpu::streamSynchronize();
+#endif
+
+    Gpu::synchronize();
 }
 }
 #endif
@@ -194,13 +212,111 @@ DeallocateRandomSeedDevArray ()
         Gpu::streamSynchronize();
         rand_engine_descr = nullptr;
     }
+//xxxxx    if (gpu_rand_generator != nullptr) {
+//        delete gpu_rand_generator;
+//        Gpu::streamSynchronize();
+//        gpu_rand_generator = nullptr;
+//    }
 #else
     if (gpu_rand_state != nullptr)
     {
         The_Arena()->free(gpu_rand_state);
         gpu_rand_state = nullptr;
     }
+    if (gpu_rand_generator != nullptr)
+    {
+#if defined(AMREX_USE_CUDA)
+        AMREX_CURAND_SAFE_CALL(curandDestroyGenerator(gpu_rand_generator));
+#else
+        AMREX_HIPRAND_SAFE_CALL(hiprandDestroyGenerator(gpu_rand_generator));
 #endif
+        gpu_rand_generator = nullptr;
+    }
+#endif
+#endif
+}
+
+void FillRandom (Real* p, Long N)
+{
+#ifdef AMREX_USE_CUDA
+
+#  ifdef BL_USE_FLOAT
+    AMREX_CURAND_SAFE_CALL(curandGenerateUniform(gpu_rand_generator, p, N));
+#  else
+    AMREX_CURAND_SAFE_CALL(curandGenerateUniformDouble(gpu_rand_generator, p, N));
+#  endif
+    Gpu::synchronize();
+
+#elif defined(AMREX_USE_HIP)
+
+#  ifdef BL_USE_FLOAT
+    AMREX_HIPRAND_SAFE_CALL(hiprandGenerateUniform(gpu_rand_generator, p, N));
+#  else
+    AMREX_HIPRAND_SAFE_CALL(hiprandGenerateUniformDouble(gpu_rand_generator, p, N));
+#  endif
+    Gpu::synchronize();
+
+#elif defined(AMREX_USE_SYCL)
+
+//xxxxx    oneapi::mkl::rng::uniform<Real> distr;
+//    auto event = oneapi::mkl::rng::generate(distr, gpu_rand_generator, N, p);
+//    event.wait();
+
+    amrex::ParallelForRNG(N, [=] AMREX_GPU_DEVICE (Long i, RandomEngine const& eng)
+    {
+        p[i] = Random(eng);
+    });
+    Gpu::streamSynchronize();
+
+#else
+    std::uniform_real_distribution<Real> distribution(Real(0.0), Real(1.0));
+    auto& gen = generators[OpenMP::get_thread_num()];
+    for (Long i = 0; i < N; ++i) {
+        p[i] = distribution(gen);
+    }
+#endif
+}
+
+void FillRandomNormal (Real* p, Long N, Real mean, Real stddev)
+{
+#if defined(AMREX_USE_CUDA)
+
+#  ifdef BL_USE_FLOAT
+    AMREX_CURAND_SAFE_CALL(curandGenerateNormal(gpu_rand_generator, p, N, mean, stddev));
+#  else
+    AMREX_CURAND_SAFE_CALL(curandGenerateNormalDouble(gpu_rand_generator, p, N, mean, stddev));
+#  endif
+    Gpu::synchronize();
+
+#elif defined(AMREX_USE_HIP)
+
+#  ifdef BL_USE_FLOAT
+    AMREX_HIPRAND_SAFE_CALL(hiprandGenerateNormal(gpu_rand_generator, p, N, mean, stddev));
+#  else
+    AMREX_HIPRAND_SAFE_CALL(hiprandGenerateNormalDouble(gpu_rand_generator, p, N, mean, stddev));
+#  endif
+    Gpu::synchronize();
+
+#elif defined(AMREX_USE_SYCL)
+
+//xxxxx    oneapi::mkl::rng::gaussian<Real> distr(mean, stddev);
+//    auto event = oneapi::mkl::rng::generate(distr, gpu_rand_generator, N, p);
+//    event.wait();
+
+    amrex::ParallelForRNG(N, [=] AMREX_GPU_DEVICE (Long i, RandomEngine const& eng)
+    {
+        p[i] = RandomNormal(mean, stddev, eng);
+    });
+    Gpu::streamSynchronize();
+
+#else
+
+    std::normal_distribution<Real> distribution(mean, stddev);
+    auto& gen = generators[OpenMP::get_thread_num()];
+    for (Long i = 0; i < N; ++i) {
+        p[i] = distribution(gen);
+    }
+
 #endif
 }
 

--- a/Src/Base/AMReX_RandomEngine.H
+++ b/Src/Base/AMReX_RandomEngine.H
@@ -15,6 +15,7 @@
 #include <curand_kernel.h>
 #elif defined(AMREX_USE_SYCL)
 #include <sycl/sycl.hpp>
+#include <oneapi/mkl/rng.hpp>
 #include <oneapi/mkl/rng/device.hpp>
 namespace mkl = oneapi::mkl;
 #endif
@@ -42,8 +43,10 @@ namespace amrex
 
 #ifdef AMREX_USE_HIP
     using randState_t = hiprandState_t;
+    using randGenerator_t = hiprandGenerator_t;
 #else
     using randState_t = curandState_t;
+    using randGenerator_t = curandGenerator_t;
 #endif
 
     extern randState_t* gpu_rand_state;

--- a/Tools/GNUMake/Make.defs
+++ b/Tools/GNUMake/Make.defs
@@ -1113,7 +1113,7 @@ else ifeq ($(USE_CUDA),TRUE)
         MAKE_CUDA_PATH := $(SYSTEM_CUDA_PATH)
     endif
 
-    LIBRARIES += -lcuda
+    LIBRARIES += -lcuda -lcurand
 
     ifneq ($(MAKE_CUDA_PATH),)
         LIBRARY_LOCATIONS += $(MAKE_CUDA_PATH)/lib64


### PR DESCRIPTION
## Summary

Add new functions that fill a MultiFab or a 1d vector with random numbers from a uniform or normal distribution.

The functions use CUDA and HIP's host APIs for random number generations. Compared with our existing capability of using device APIs, the new functions are slightly (about 15%) faster on Nvidia GPUs, whereas they are 4x faster on the AMD GPU we tested. For Intel GPUs, we are still using the device APIs, because we have not figured out how to use its host APIs. More specially, we are missing some LDFLAGS at link time.

The functions work for CPU builds too, and for normal distribution they are about 2x faster than using `amrex::RandomNormal` because the latter only uses one of two random numbers generated by the Box-Muller transform.

The functions work for MultiFabs with any index types (e.g., nodal). However, if the numbers on shared nodes need to be consistent across boxes and MPI processes, it's the user's responsibility to call OverrideSync. (This gives the user a chance to cache the mask used by OverrideSync.) It's also the user's responsibility to fix data consistency between overlapping ghost and valid points, if that is needed.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
