### PR TITLE
SundialsIntegrator: Fix memory deallocation

### DIFF
--- a/Src/Extern/SUNDIALS/AMReX_SundialsIntegrator.H
+++ b/Src/Extern/SUNDIALS/AMReX_SundialsIntegrator.H
@@ -342,7 +342,10 @@ public:
         }
 
         // Clean up allocated memory
-        N_VDestroyVectorArray(nv_many_arr, NVar);
+        for (int i = 0; i < Nvar; ++i) {
+            N_VDestroy(nv_many_arr[i]);
+        }
+        delete[] nv_many_arr;
         N_VDestroy(nv_S);
         N_VDestroy(nv_stage_data);
 
@@ -623,7 +626,10 @@ public:
         }
 
         // Clean up allocated memory
-        N_VDestroyVectorArray(nv_many_arr, NVar);
+        for (int i = 0; i < Nvar; ++i) {
+            N_VDestroy(nv_many_arr[i]);
+        }
+        delete[] nv_many_arr;
         N_VDestroy(nv_S);
         N_VDestroy(nv_stage_data);
 


### PR DESCRIPTION
## Summary

nv_many_array is allocated with new[]. So it must be deallocated with delete[]. Therefore we cannot call Sundials's N_VDestroyVectorArray that uses std::free.

## Additional background

https://github.com/AMReX-Codes/amrex/pull/3436#issuecomment-1646938731

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
