### PR TITLE
GPU Launch Min Blocks

### DIFF
--- a/Src/Base/AMReX_GpuLaunchGlobal.H
+++ b/Src/Base/AMReX_GpuLaunchGlobal.H
@@ -14,6 +14,10 @@ namespace amrex {
     template<int amrex_launch_bounds_max_threads, class L>
     __launch_bounds__(amrex_launch_bounds_max_threads)
     AMREX_GPU_GLOBAL void launch_global (L f0) { f0(); }
+
+    template<int amrex_launch_bounds_max_threads, int min_blocks, class L>
+    __launch_bounds__(amrex_launch_bounds_max_threads, min_blocks)
+    AMREX_GPU_GLOBAL void launch_global (L f0) { f0(); }
 #endif
 
 }


### PR DESCRIPTION
Adding another launch configuration which specifies the minimum number of coresident blocks. This has shown good performance advantages for some Pele kernels.

## Summary

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
