### PR TITLE
Simplify filterParticles Kernel

### DIFF
--- a/Src/Particle/AMReX_ParticleContainerI.H
+++ b/Src/Particle/AMReX_ParticleContainerI.H
@@ -995,7 +995,7 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator>::
 copyParticles (const PCType& other, bool local)
 {
     using PData = ConstParticleTileData<typename ParticleType::StorageParticleType, NArrayReal, NArrayInt>;
-    copyParticles(other, [=] AMREX_GPU_HOST_DEVICE (const PData& /*data*/, int /*i*/) { return 1; }, local);
+    copyParticles(other, [] AMREX_GPU_HOST_DEVICE (const PData& /*data*/, int /*i*/) { return 1; }, local);
 }
 
 template <typename ParticleType, int NArrayReal, int NArrayInt,
@@ -1006,7 +1006,7 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator>::
 addParticles (const PCType& other, bool local)
 {
     using PData = ConstParticleTileData<typename ParticleType::StorageParticleType, NArrayReal, NArrayInt>;
-    addParticles(other, [=] AMREX_GPU_HOST_DEVICE (const PData& /*data*/, int /*i*/) { return 1; }, local);
+    addParticles(other, [] AMREX_GPU_HOST_DEVICE (const PData& /*data*/, int /*i*/) { return 1; }, local);
 }
 
 template <typename ParticleType, int NArrayReal, int NArrayInt,

--- a/Src/Particle/AMReX_ParticleTransformation.H
+++ b/Src/Particle/AMReX_ParticleTransformation.H
@@ -577,7 +577,7 @@ int filterAndTransformParticles (DstTile1& dst1, DstTile2& dst2, const SrcTile& 
     const auto src_data = src.getConstParticleTileData();
 
     amrex::ParallelForRNG(np,
-    [=] AMREX_GPU_DEVICE (int i, amrex::RandomEngine const& engine) noexcept
+    [p, p_mask, src_data] AMREX_GPU_DEVICE (int i, amrex::RandomEngine const& engine) noexcept
     {
         amrex::ignore_unused(p, p_mask, src_data, engine);
         if constexpr (IsCallable<Pred,decltype(src_data),int,RandomEngine>::value) {
@@ -620,7 +620,7 @@ Index filterAndTransformParticles (DstTile& dst, const SrcTile& src, Pred&& p, F
     const auto src_data = src.getConstParticleTileData();
 
     amrex::ParallelForRNG(np,
-    [=] AMREX_GPU_DEVICE (int i, amrex::RandomEngine const& engine) noexcept
+    [p, p_mask, src_data, src_start] AMREX_GPU_DEVICE (int i, amrex::RandomEngine const& engine) noexcept
     {
         amrex::ignore_unused(p, p_mask, src_data, src_start, engine);
         if constexpr (IsCallable<Pred,decltype(src_data),Index,RandomEngine>::value) {

--- a/Src/Particle/AMReX_ParticleTransformation.H
+++ b/Src/Particle/AMReX_ParticleTransformation.H
@@ -413,18 +413,6 @@ Index filterParticles (DstTile& dst, const SrcTile& src, Pred&& p,
             p_mask[i] = p(src_data, src_start+i);
         }
     });
-        amrex::ParallelForRNG(n,
-        [=] AMREX_GPU_DEVICE (int i, amrex::RandomEngine const& engine) noexcept
-        {
-            p_mask[i] = p(src_data, src_start+i, engine);
-        });
-    } else {
-        amrex::ParallelFor(n,
-        [=] AMREX_GPU_DEVICE (int i) noexcept
-        {
-            p_mask[i] = p(src_data, src_start+i);
-        });
-    }
     return filterParticles(dst, src, mask.dataPtr(), src_start, dst_start, n);
 }
 

--- a/Src/Particle/AMReX_ParticleTransformation.H
+++ b/Src/Particle/AMReX_ParticleTransformation.H
@@ -403,7 +403,16 @@ Index filterParticles (DstTile& dst, const SrcTile& src, Pred&& p,
     auto* p_mask = mask.dataPtr();
     const auto src_data = src.getConstParticleTileData();
 
-    if constexpr (IsCallable<Pred,decltype(src_data),Index,RandomEngine>::value) {
+    amrex::ParallelForRNG(n,
+    [p, p_mask, src_data, src_start] AMREX_GPU_DEVICE (int i, amrex::RandomEngine const& engine) noexcept
+    {
+        amrex::ignore_unused(p, p_mask, src_data, src_start, engine);
+        if constexpr (IsCallable<Pred,decltype(src_data),Index,RandomEngine>::value) {
+            p_mask[i] = p(src_data, src_start+i, engine);
+        } else {
+            p_mask[i] = p(src_data, src_start+i);
+        }
+    });
         amrex::ParallelForRNG(n,
         [=] AMREX_GPU_DEVICE (int i, amrex::RandomEngine const& engine) noexcept
         {

--- a/Src/Particle/AMReX_ParticleTransformation.H
+++ b/Src/Particle/AMReX_ParticleTransformation.H
@@ -403,16 +403,19 @@ Index filterParticles (DstTile& dst, const SrcTile& src, Pred&& p,
     auto* p_mask = mask.dataPtr();
     const auto src_data = src.getConstParticleTileData();
 
-    amrex::ParallelForRNG(n,
-    [=] AMREX_GPU_DEVICE (int i, amrex::RandomEngine const& engine) noexcept
-    {
-        amrex::ignore_unused(p, p_mask, src_data, src_start, engine);
-        if constexpr (IsCallable<Pred,decltype(src_data),Index,RandomEngine>::value) {
+    if constexpr (IsCallable<Pred,decltype(src_data),Index,RandomEngine>::value) {
+        amrex::ParallelForRNG(n,
+        [=] AMREX_GPU_DEVICE (int i, amrex::RandomEngine const& engine) noexcept
+        {
             p_mask[i] = p(src_data, src_start+i, engine);
-        } else {
+        });
+    } else {
+        amrex::ParallelFor(n,
+        [=] AMREX_GPU_DEVICE (int i) noexcept
+        {
             p_mask[i] = p(src_data, src_start+i);
-        }
-    });
+        });
+    }
     return filterParticles(dst, src, mask.dataPtr(), src_start, dst_start, n);
 }
 


### PR DESCRIPTION
## Summary

On Summit, generation of this kernel shows compiler issues with `nvcc` 11.3.109: it compiles without warnings but leads to a segmentation fault at runtime.

The fix for the compiler bug is to implement the trivial lambda that is passed to `copyParticles` w/o capture: `[]`.

We also add explicit capture to a few other lambdas, to simplify compiler intake complexity.

~~First commit: wow, this reliably triggereds the compiler bug (invalid device function) in step 1.~~ ([see reason below](https://github.com/AMReX-Codes/amrex/pull/3510#issuecomment-1692773745))

This simplifies the kernel generation, which also solves the issue seen with WarpX [for this line](https://github.com/ECP-WarpX/WarpX/blob/43d2ac7b54546c87d2cb540df7a2b3cb57592b84/Source/Diagnostics/WarpXOpenPMD.cpp#L585).

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
