### PR TITLE
Remove unsafe std::forward

### DIFF
--- a/Src/AmrCore/AMReX_AmrParticles.H
+++ b/Src/AmrCore/AMReX_AmrParticles.H
@@ -207,7 +207,7 @@ ParticleToMesh (PC const& pc, const Vector<MultiFab*>& mf,
 
     for (int lev = lev_min; lev <= lev_max; ++lev)
     {
-        ParticleToMesh(pc, mf_part[lev], lev, std::forward<F>(f), zero_out_input);
+        ParticleToMesh(pc, mf_part[lev], lev, f, zero_out_input);
         if (vol_weight) {
             const Real* dx = pc.Geom(lev).CellSize();
             const Real vol = AMREX_D_TERM(dx[0], *dx[1], *dx[2]);

--- a/Src/Extern/HDF5/AMReX_WriteBinaryParticleDataHDF5.H
+++ b/Src/Extern/HDF5/AMReX_WriteBinaryParticleDataHDF5.H
@@ -197,7 +197,7 @@ void WriteHDF5ParticleDataSync (PC const& pc,
         for (const auto& kv : pmap)
         {
             auto& flags = particle_io_flags[lev][kv.first];
-            particle_detail::fillFlags(flags, kv.second, std::forward<F>(f));
+            particle_detail::fillFlags(flags, kv.second, f);
         }
     }
 

--- a/Src/Particle/AMReX_NeighborParticlesI.H
+++ b/Src/Particle/AMReX_NeighborParticlesI.H
@@ -749,7 +749,7 @@ buildNeighborList (CheckPair&& check_pair, bool /*sort*/)
             plo_v.push_back(geom.ProbLoArray());
 
             m_neighbor_list[lev][index].build(ptile,
-                                              std::forward<CheckPair>(check_pair),
+                                              check_pair,
                                               off_bins_v, dxi_v, plo_v, lo_v, hi_v, ng);
 
 #ifndef AMREX_USE_GPU
@@ -834,7 +834,7 @@ buildNeighborList (CheckPair&& check_pair, OtherPCType& other,
             plo_v.push_back(geom.ProbLoArray());
 
             neighbor_lists[lev][index].build(ptile, other_ptile,
-                                             std::forward<CheckPair>(check_pair),
+                                             check_pair,
                                              off_bins_v, dxi_v, plo_v, lo_v, hi_v, ng);
         }
     }
@@ -951,7 +951,7 @@ buildNeighborList (CheckPair&& check_pair, int type_ind, int* ref_ratio,
             Gpu::exclusive_scan(nbins_v.begin(), nbins_v.end(), off_bins_v.begin());
 
             m_neighbor_list[lev][index].build(ptile,
-                                              std::forward<CheckPair>(check_pair),
+                                              check_pair,
                                               off_bins_v, dxi_v, plo_v, lo_v, hi_v,
                                               ng, num_bin_types, bin_type_array);
 

--- a/Src/Particle/AMReX_ParticleArray.H
+++ b/Src/Particle/AMReX_ParticleArray.H
@@ -178,7 +178,7 @@ private:
     {
         using expander = int[];
         (void) expander{ 0, (std::get<Is>(a_container).push_back(
-                                 std::get<Is>(std::forward<ValueType>(a_value))), 0)... };
+                                 std::get<Is>(a_value)), 0)... };
     }
 };
 

--- a/Src/Particle/AMReX_ParticleContainerI.H
+++ b/Src/Particle/AMReX_ParticleContainerI.H
@@ -1050,7 +1050,7 @@ addParticles (const PCType& other, F&& f, bool local)
             auto dst_index = ptile.numParticles();
             ptile.resize(dst_index + np);
 
-            auto count = amrex::filterParticles(ptile, ptile_other, std::forward<F>(f), 0, dst_index, np);
+            auto count = amrex::filterParticles(ptile, ptile_other, f, 0, dst_index, np);
 
             ptile.resize(dst_index + count);
         }

--- a/Src/Particle/AMReX_WriteBinaryParticleData.H
+++ b/Src/Particle/AMReX_WriteBinaryParticleData.H
@@ -424,7 +424,7 @@ void WriteBinaryParticleDataSync (PC const& pc,
         for (const auto& kv : pmap)
         {
             auto& flags = particle_io_flags[lev][kv.first];
-            particle_detail::fillFlags(flags, kv.second, std::forward<F>(f));
+            particle_detail::fillFlags(flags, kv.second, f);
         }
     }
 

--- a/Tests/Particles/ParticleTransformations/main.cpp
+++ b/Tests/Particles/ParticleTransformations/main.cpp
@@ -251,7 +251,7 @@ void transformParticles (PC& pc, F&& f)
             ParticleTileType ptile_tmp;
             ptile_tmp.resize(ptile.size());
 
-            amrex::transformParticles(ptile_tmp, ptile, std::forward<F>(f));
+            amrex::transformParticles(ptile_tmp, ptile, f);
             ptile.swap(ptile_tmp);
         }
     }
@@ -275,7 +275,7 @@ void twoWayTransformParticles (PC& dst1, PC& dst2, const PC& src, F&& f)
             ptile_dst1.resize(ptile_src.size());
             ptile_dst2.resize(ptile_src.size());
 
-            amrex::transformParticles(ptile_dst1, ptile_dst2, ptile_src, std::forward<F>(f));
+            amrex::transformParticles(ptile_dst1, ptile_dst2, ptile_src, f);
         }
     }
 }
@@ -331,7 +331,7 @@ void filterParticles (PC& pc, F&& f)
             ParticleTileType ptile_tmp;
             ptile_tmp.resize(ptile.size());
 
-            auto num_output = amrex::filterParticles(ptile_tmp, ptile, std::forward<F>(f));
+            auto num_output = amrex::filterParticles(ptile_tmp, ptile, f);
 
             ptile.swap(ptile_tmp);
             ptile.resize(num_output);
@@ -356,7 +356,7 @@ void filterAndTransformParticles (PC& pc, Pred&& p, F&& f)
             ParticleTileType ptile_tmp;
             ptile_tmp.resize(ptile.size());
 
-            auto num_output = amrex::filterAndTransformParticles(ptile_tmp, ptile, std::forward<Pred>(p), std::forward<F>(f));
+            auto num_output = amrex::filterAndTransformParticles(ptile_tmp, ptile, p, f);
 
             ptile.swap(ptile_tmp);
             ptile.resize(num_output);
@@ -384,8 +384,8 @@ void twoWayFilterAndTransformParticles (PC& dst1, PC& dst2, const PC& src, Pred&
             auto num_output = amrex::filterAndTransformParticles(ptile_dst1,
                                                                  ptile_dst2,
                                                                  ptile_src,
-                                                                 std::forward<Pred>(p),
-                                                                 std::forward<F>(f));
+                                                                 p,
+                                                                 f);
 
             ptile_dst1.resize(num_output);
             ptile_dst2.resize(num_output);


### PR DESCRIPTION
These are unsafe because they are used inside a loop.

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
