### PR TITLE
faverage fix

### DIFF
--- a/Tools/Plotfile/faverage.cpp
+++ b/Tools/Plotfile/faverage.cpp
@@ -13,7 +13,7 @@ using namespace amrex;
 
 std::string inputs_name = "";
 
-void PrintHelp ();
+void PrintUsage ();
 
 
 int main(int argc, char* argv[])
@@ -46,15 +46,8 @@ int main(int argc, char* argv[])
         }
 
         if (farg > narg) {
-            amrex::Print() << "\n"
-                           << " Report the extrema (min/max) for each variable in a plotfile\n"
-                           << " usage: \n"
-                           << "    faverage {[-v|--variable] name} {[-f|--favre]} plotfile\n"
-                           << "\n"
-                           << "   -v name    : variable to average (default: density)\n"
-                           << "   -f         : do Favre (density-weighted) average\n"
-                           << std::endl;
-            amrex::Error();
+            PrintUsage();
+            return -1;
         }
 
         const std::string& pltfile = amrex::get_command_argument(farg);
@@ -95,7 +88,7 @@ int main(int argc, char* argv[])
                                       std::find(var_names_pf.cbegin(), var_names_pf.cend(), "rho"));
         }
 
-        if (dens_comp == var_names_pf.size()) {
+        if (dens_comp == var_names_pf.size() && do_favre) {
             amrex::Error("density not found");
         }
 
@@ -276,14 +269,14 @@ int main(int argc, char* argv[])
 //
 // Print usage info
 //
-void PrintHelp ()
+void PrintUsage ()
 {
-    Print() << "\nusage: executable_name args"
-            << "\nargs [-p|--pltfile]     plotfile : plot file directory (required)"
-            << "\n     [-s|--slicefile] slice file : slice file          (required)"
-#if AMREX_SPACEDIM >= 2
-            << "\n     [--sphr]          spherical : spherical problem"
-#endif
-            << "\n\n" << std::endl;
-
+    amrex::Print() << "\n"
+                   << " Horizontally average a variable\n"
+                   << " Usage: \n"
+                   << "     faverage {[-v|--variable] name} {[-f|--favre]} plotfile\n"
+                   << "\n"
+                   << "    -v name    : variable to average (default: density)\n"
+                   << "    -f         : do Favre (density-weighted) average\n"
+                   << std::endl;
 }


### PR DESCRIPTION
## Summary
Make it so that Tools/Plotfile/faverage.cpp only *requires* density to be in the plotfile if the user wants to do a weighted average (-f option). Also cleans up the help message a bit.

## Additional background
In the new [amrex-astro-diag](https://github.com/AMReX-Astro/amrex-astro-diag) set of tools, we generate new plotfiles without density, but would still like to be able to average.

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
