### PR TITLE
UniqueString tweak

### DIFF
--- a/Src/Base/AMReX_Utility.cpp
+++ b/Src/Base/AMReX_Utility.cpp
@@ -183,10 +183,17 @@ amrex::FileExists(const std::string &filename)
 std::string
 amrex::UniqueString()
 {
-  std::stringstream tempstring;
-  tempstring << std::setprecision(11) << std::fixed << ParallelDescriptor::second();
-  auto const tsl = tempstring.str().length();
-  return(tempstring.str().substr(tsl/2, tsl));
+    constexpr int len = 7;
+    static const auto n = std::max
+        (len,
+         static_cast<int>(
+             std::round(std::log10(double(MaxResSteadyClock::period::den)
+                                   /double(MaxResSteadyClock::period::num)))));
+    std::stringstream tempstring;
+    tempstring << std::setprecision(n) << std::fixed << amrex::second();
+    auto const ts = tempstring.str();
+    auto const tsl = ts.length();
+    return ts.substr(tsl-len,tsl); // tsl-len >= 0 becaues n >= len
 }
 
 void


### PR DESCRIPTION
# Summary

Previously UniqueString used MPI_Wtime, which could have a very low resolution (1e-5s) on some machines. In this PR, we switch to use amrex::second(), which uses the highest resolution steady clock (usually 1.e-9s). We have also changed a hardwired number according to resolution of the clock so that the digits are not wasted on trailing zeros.

## Additional background

https://github.com/ECP-WarpX/impactx/pull/424

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
