### PR TITLE
Constness in buildInfo: num_modules

### DIFF
--- a/Tools/CMake/AMReXBuildInfo.cmake
+++ b/Tools/CMake/AMReXBuildInfo.cmake
@@ -145,7 +145,7 @@ function (generate_buildinfo _target _git_dir)
    set(LIBRARIES "${_CXX_link_line}")
 
    # Number of modules -- set to zero for now
-   set(NUM_MODULES "int num_modules = 0;")
+   set(NUM_MODULES "int const num_modules = 0;")
 
    #
    # Git hashes for both app code and AMReX if available

--- a/Tools/CMake/AMReX_buildInfo.cpp.in
+++ b/Tools/CMake/AMReX_buildInfo.cpp.in
@@ -100,7 +100,7 @@ const char* buildInfoGetAux(int i) {
 }
 
 int buildInfoGetNumModules() {
-  // int num_modules = X;
+  // int const num_modules = X;
   @NUM_MODULES@
   return num_modules;
 }

--- a/Tools/C_scripts/makebuildinfo_C.py
+++ b/Tools/C_scripts/makebuildinfo_C.py
@@ -110,7 +110,7 @@ const char* buildInfoGetAux(int i) {
 }
 
 int buildInfoGetNumModules() {
-  // int num_modules = X;
+  // int const num_modules = X;
   @@NUM_MODULES@@
   return num_modules;
 }

--- a/Tools/C_scripts/makebuildinfo_C.py
+++ b/Tools/C_scripts/makebuildinfo_C.py
@@ -366,7 +366,7 @@ if __name__ == "__main__":
             elif keyword == "NUM_MODULES":
                 num_modules = len(MODULES)
                 indent = index
-                fout.write("{}int num_modules = {};\n".format(
+                fout.write("{}int const num_modules = {};\n".format(
                     indent*" ", num_modules))
 
             elif keyword == "MNAME_DECLS":


### PR DESCRIPTION
## Summary

Clang-Tidy:
```
warning: variable 'num_modules' of type 'int' can be declared 'const' [misc-const-correctness]
```

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
