### PR TITLE
Workaround for Intel compiler classic

### DIFF
--- a/Src/Base/Parser/AMReX_Parser_Y.H
+++ b/Src/Base/Parser/AMReX_Parser_Y.H
@@ -45,7 +45,13 @@ enum parser_f1_t {  // Built-in functions with one argument
     PARSER_COMP_ELLINT_2
 };
 
-static constexpr std::string_view parser_f1_s[] =
+static
+#if defined(__INTEL_COMPILER) && defined(__EDG__)
+    const
+#else
+    constexpr
+#endif
+std::string_view parser_f1_s[] =
 {
     "sqrt",
     "exp",
@@ -88,7 +94,13 @@ enum parser_f2_t {  // Built-in functions with two arguments
     PARSER_FMOD
 };
 
-static constexpr std::string_view parser_f2_s[] =
+static
+#if defined(__INTEL_COMPILER) && defined(__EDG__)
+    const
+#else
+    constexpr
+#endif
+std::string_view parser_f2_s[] =
 {
     "pow",
     "atan2",
@@ -111,7 +123,13 @@ enum parser_f3_t { // functions with three arguments
     PARSER_IF
 };
 
-static constexpr std::string_view parser_f3_s[] =
+static
+#if defined(__INTEL_COMPILER) && defined(__EDG__)
+    const
+#else
+    constexpr
+#endif
+std::string_view parser_f3_s[] =
 {
     "if"
 };
@@ -130,7 +148,13 @@ enum parser_node_t {
     PARSER_LIST
 };
 
-static constexpr std::string_view parser_node_s[] =
+static
+#if defined(__INTEL_COMPILER) && defined(__EDG__)
+    const
+#else
+    constexpr
+#endif
+std::string_view parser_node_s[] =
 {
     "number",
     "symbol",


### PR DESCRIPTION
It seems that they have issues with constexpr std::string_view.

https://github.com/xsdk-project/xsdk-issues/issues/221

