### PR TITLE
Missing header in AMReX_GpuComplex.H

### DIFF
--- a/Src/Base/AMReX_GpuComplex.H
+++ b/Src/Base/AMReX_GpuComplex.H
@@ -2,6 +2,7 @@
 #define AMREX_GPUCOMPLEX_H_
 #include <AMReX_Config.H>
 
+#include <AMReX_Algorithm.H>
 #include <AMReX_Math.H>
 #include <cmath>
 #include <iostream>


### PR DESCRIPTION
amrex::max is used in AMReX_GpuComplex.H, so we need to include AMReX_Algorithm.H.

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
