### PR TITLE
Explicitly flush when writing to the terse run log

### DIFF
--- a/Src/Amr/AMReX_Amr.cpp
+++ b/Src/Amr/AMReX_Amr.cpp
@@ -2205,7 +2205,8 @@ Amr::coarseTimeStep (Real stop_time)
                << " DT = "   << dt_level[0] << '\n';
     }
     if (record_run_info_terse && ParallelDescriptor::IOProcessor()) {
-        runlog_terse << level_steps[0] << " " << cumtime << " " << dt_level[0] << '\n';
+        runlog_terse << level_steps[0] << " " << cumtime << " " << dt_level[0];
+        runlog_terse << std::endl; // Make sure we flush!
     }
 
     int check_test = 0;


### PR DESCRIPTION
## Summary

The log files are block-buffered by default, so the (very small) writes to the terse run log were only getting flushed to disk every couple hundred lines or so.

## Additional background

The standard run log gets flushed at the end of `printGridInfo()` whenever there's a regrid (it also prints a lot more data, so it fills the buffer much faster).

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
