### PR TITLE
Reset EB Fab Type

### DIFF
--- a/Src/EB/AMReX_EB2_Level.cpp
+++ b/Src/EB/AMReX_EB2_Level.cpp
@@ -468,13 +468,7 @@ Level::fillEBCellFlag (FabArray<EBCellFlagFab>& cellflag, const Geometry& geom) 
             }
 
             // fix type for each fab
-            fab.setType(FabType::undefined);
-            auto typ = fab.getType(bx);
-            fab.setType(typ);
-            for (int nshrink = 1; nshrink < ng; ++nshrink) {
-                const Box& b = amrex::grow(bx,-nshrink);
-                fab.getType(b);
-            }
+            fab.resetType(ng);
         }
     }
 }

--- a/Src/EB/AMReX_EBCellFlag.H
+++ b/Src/EB/AMReX_EBCellFlag.H
@@ -318,6 +318,11 @@ public:
     FabType getType (const Box& bx) const noexcept;
 
     /**
+     * \brief Reset FabType
+     */
+    void resetType (int ng);
+
+    /**
      * \brief Returns the number of regular cells in the given Box.
      */
     int getNumRegularCells (const Box& bx) const noexcept;

--- a/Src/EB/AMReX_EBCellFlag.cpp
+++ b/Src/EB/AMReX_EBCellFlag.cpp
@@ -128,6 +128,21 @@ EBCellFlagFab::getType (const Box& bx_in) const noexcept
     }
 }
 
+void
+EBCellFlagFab::resetType (int ng)
+{
+    this->setType(FabType::undefined);
+    m_typemap.clear();
+
+    Box const& bx = this->box();
+    auto typ = this->getType(bx);
+    this->setType(typ);
+    for (int nshrink = 1; nshrink < ng; ++nshrink) {
+        const Box& b = amrex::grow(bx,-nshrink);
+        this->getType(b);
+    }
+}
+
 int
 EBCellFlagFab::getNumRegularCells (const Box& bx_in) const noexcept
 {


### PR DESCRIPTION
This is a follow-up on #3549. After extending EB data outside the domain, we need to update the EB Fab type.
