### PR TITLE
Documentation: Fix default values

### DIFF
--- a/Docs/sphinx_documentation/source/GPU.rst
+++ b/Docs/sphinx_documentation/source/GPU.rst
@@ -1738,14 +1738,14 @@ by "amrex" in your :cpp:`inputs` file.
 +----------------------------+-----------------------------------------------------------------------+-------------+----------+
 |                            | Description                                                           |   Type      | Default  |
 +============================+=======================================================================+=============+==========+
-| use_gpu_aware_mpi          | Whether to use GPU memory for communication buffers during MPI calls. | Bool        | False    |
-|                            | If true, the buffers will use device memory. If false, they will use  |             |          |
-|                            | pinned memory. In practice, we find it is usually not worth it to use |             |          |
-|                            | GPU aware MPI.                                                        |             |          |
+| use_gpu_aware_mpi          | Whether to use GPU memory for communication buffers during MPI calls. | Bool        | 0        |
+|                            | If true, the buffers will use device memory. If false (i.e., 0), they |             |          |
+|                            | will use pinned memory. In practice, we find it is not always worth   |             |          |
+|                            | it to use GPU aware MPI.                                              |             |          |
 +----------------------------+-----------------------------------------------------------------------+-------------+----------+
-| abort_on_out_of_gpu_memory | If the size of free memory on the GPU is less than the size of a      | Bool        | False    |
+| abort_on_out_of_gpu_memory | If the size of free memory on the GPU is less than the size of a      | Bool        | 0        |
 |                            | requested allocation, AMReX will call AMReX::Abort() with an error    |             |          |
 |                            | describing how much free memory there is and what was requested.      |             |          |
 +----------------------------+-----------------------------------------------------------------------+-------------+----------+
-| the_arena_is_managed       | Whether :cpp:`The_Arena()` allocates managed memory.                  | Bool        | False    |
+| the_arena_is_managed       | Whether :cpp:`The_Arena()` allocates managed memory.                  | Bool        | 0        |
 +----------------------------+-----------------------------------------------------------------------+-------------+----------+

--- a/Docs/sphinx_documentation/source/InputsPlotFiles.rst
+++ b/Docs/sphinx_documentation/source/InputsPlotFiles.rst
@@ -12,7 +12,7 @@ as whether a plotfile should be written out immediately after restarting a simul
 | plot_int            | Frequency of plotfile output;                                         |    Int      | -1        |
 |                     | if -1 then no plotfiles will be written                               |             |           |
 +---------------------+-----------------------------------------------------------------------+-------------+-----------+
-| plotfile_on_restart | Should we write a plotfile when we restart (only used if plot_int>0)  |   Bool      | False     |
+| plotfile_on_restart | Should we write a plotfile when we restart (only used if plot_int>0)  |   Bool      | 0 (false) |
 +---------------------+-----------------------------------------------------------------------+-------------+-----------+
 | plot_file           | Prefix to use for plotfile output                                     |  String     | plt       |
 +---------------------+-----------------------------------------------------------------------+-------------+-----------+

--- a/Docs/sphinx_documentation/source/LinearSolvers.rst
+++ b/Docs/sphinx_documentation/source/LinearSolvers.rst
@@ -565,7 +565,7 @@ The following parameter should be set to True if the problem to be solved has a 
 In this case, the solution is only defined to within a constant.  Setting this parameter to True
 replaces one row in the matrix sent to hypre from AMReX by a row that sets the value at one cell to 0.
 
-- :cpp:`hypre.adjust_singular_matrix`:   Default is False.
+- :cpp:`hypre.adjust_singular_matrix`:   Default is false.
 
 
 The following parameters can be set in the inputs file to control the choice of preconditioner and smoother:

--- a/Docs/sphinx_documentation/source/Particle.rst
+++ b/Docs/sphinx_documentation/source/Particle.rst
@@ -713,7 +713,7 @@ with OpenMP, the first thing to look at is whether there are enough tiles availa
 +-------------------+-----------------------------------------------------------------------+-------------+-------------+
 |                   | Description                                                           |   Type      | Default     |
 +===================+=======================================================================+=============+=============+
-| do_tiling         | Whether to use tiling for particles. Should be on when using OpenMP,  | Bool        | False       |
+| do_tiling         | Whether to use tiling for particles. Should be on when using OpenMP,  | Bool        | false       |
 |                   | and off when running on GPUs.                                         |             |             |
 +-------------------+-----------------------------------------------------------------------+-------------+-------------+
 | tile_size         | If tiling is on, the maximum tile_size to in each direction           | Ints        | 1024000,8,8 |
@@ -739,7 +739,7 @@ problems with particle IO, you could try varying some / all of these parameters.
 | datadigits_read   | This for backwards compatibility, don't use unless you need to read   | Int         | 5           |
 |                   | and old (pre mid 2017) AMReX dataset.                                 |             |             |
 +-------------------+-----------------------------------------------------------------------+-------------+-------------+
-| use_prepost       | This is an optimization for large particle datasets that groups MPI   | Bool        | False       |
+| use_prepost       | This is an optimization for large particle datasets that groups MPI   | Bool        | false       |
 |                   | calls needed during the IO together. Try it seeing poor IO speeds     |             |             |
 |                   | on large problems.                                                    |             |             |
 +-------------------+-----------------------------------------------------------------------+-------------+-------------+


### PR DESCRIPTION
Boolean flag `amrex.use_gpu_aware_mpi` has `int` as its C++ type. So its default value should be 0 not False.

For some other boolean flags with `bool` as their C++ type, the default value should be `false`, not `False`.
