### PR TITLE
Disable CCache in Windows CIs

### DIFF
--- a/.github/workflows/cleanup-cache.yml
+++ b/.github/workflows/cleanup-cache.yml
@@ -2,7 +2,7 @@ name: CleanUpCache
 
 on:
   workflow_run:
-    workflows: [LinuxClang, cuda, LinuxGcc, hip, Hypre, intel, macos, PETSc, SUNDIALS, windows, CodeQL, smoke, apps]
+    workflows: [LinuxClang, cuda, LinuxGcc, hip, Hypre, intel, macos, PETSc, SUNDIALS, CodeQL, smoke, apps]
     types:
       - completed
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -14,28 +14,28 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: seanmiddleditch/gha-setup-ninja@master
-    - name: Set Up Cache
-      uses: actions/cache@v3
-      with:
-        path: ~/.ccache
-        key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}
-        restore-keys: |
-             ccache-${{ github.workflow }}-${{ github.job }}-git-
-    - name: Install Ccache
-      run: |
-        Invoke-WebRequest https://github.com/ccache/ccache/releases/download/v4.8/ccache-4.8-windows-x86_64.zip -OutFile ccache-4.8-windows-x86_64.zip
-        Expand-Archive ccache-4.8-windows-x86_64.zip
+    #- name: Set Up Cache
+    #  uses: actions/cache@v3
+    #  with:
+    #    path: ~/.ccache
+    #    key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}
+    #    restore-keys: |
+    #         ccache-${{ github.workflow }}-${{ github.job }}-git-
+    #- name: Install Ccache
+    #  run: |
+    #    Invoke-WebRequest https://github.com/ccache/ccache/releases/download/v4.8/ccache-4.8-windows-x86_64.zip -OutFile ccache-4.8-windows-x86_64.zip
+    #    Expand-Archive ccache-4.8-windows-x86_64.zip
     - name: Build & Install
       run: |
-        $ccachepath = Join-Path $pwd "ccache-4.8-windows-x86_64"
-        $Env:PATH += ";$ccachepath"
-        $ccachecachedir = Join-Path $HOME ".ccache"
-        $Env:CCACHE_DIR="$ccachecachedir"
-        $Env:CCACHE_DIR
-        $Env:CCACHE_COMPRESS='1'
-        $Env:CCACHE_COMPRESSLEVEL='10'
-        $Env:CCACHE_MAXSIZE='105M'
-        ccache -z
+        #$ccachepath = Join-Path $pwd "ccache-4.8-windows-x86_64"
+        #$Env:PATH += ";$ccachepath"
+        #$ccachecachedir = Join-Path $HOME ".ccache"
+        #$Env:CCACHE_DIR="$ccachecachedir"
+        #$Env:CCACHE_DIR
+        #$Env:CCACHE_COMPRESS='1'
+        #$Env:CCACHE_COMPRESSLEVEL='10'
+        #$Env:CCACHE_MAXSIZE='105M'
+        #ccache -z
 
         cmake -S . -B build   `
               -G "Ninja"      `
@@ -45,11 +45,11 @@ jobs:
               -DAMReX_EB=OFF                `
               -DAMReX_ENABLE_TESTS=ON       `
               -DAMReX_FORTRAN=OFF           `
-              -DAMReX_MPI=OFF               `
-              -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+              -DAMReX_MPI=OFF
+              #-DCMAKE_CXX_COMPILER_LAUNCHER=ccache
         cmake --build build --config Debug -j 2
 
-        ccache -s
+        #ccache -s
 
   # Build libamrex and all test (static)
   test_msvc_static:
@@ -58,27 +58,27 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: seanmiddleditch/gha-setup-ninja@master
-    - name: Set Up Cache
-      uses: actions/cache@v3
-      with:
-        path: ~/.ccache
-        key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}
-        restore-keys: |
-             ccache-${{ github.workflow }}-${{ github.job }}-git-
-    - name: Install Ccache
-      run: |
-        Invoke-WebRequest https://github.com/ccache/ccache/releases/download/v4.8/ccache-4.8-windows-x86_64.zip -OutFile ccache-4.8-windows-x86_64.zip
-        Expand-Archive ccache-4.8-windows-x86_64.zip
+    #- name: Set Up Cache
+    #  uses: actions/cache@v3
+    #  with:
+    #    path: ~/.ccache
+    #    key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}
+    #    restore-keys: |
+    #         ccache-${{ github.workflow }}-${{ github.job }}-git-
+    #- name: Install Ccache
+    #  run: |
+    #    Invoke-WebRequest https://github.com/ccache/ccache/releases/download/v4.8/ccache-4.8-windows-x86_64.zip -OutFile ccache-4.8-windows-x86_64.zip
+    #    Expand-Archive ccache-4.8-windows-x86_64.zip
     - name: Build & Install
       run: |
-        $ccachepath = Join-Path $pwd "ccache-4.8-windows-x86_64"
-        $Env:PATH += ";$ccachepath"
-        $ccachecachedir = Join-Path $HOME ".ccache"
-        $Env:CCACHE_DIR="$ccachecachedir"
-        $Env:CCACHE_COMPRESS='1'
-        $Env:CCACHE_COMPRESSLEVEL='10'
-        $Env:CCACHE_MAXSIZE='135M'
-        ccache -z
+        #$ccachepath = Join-Path $pwd "ccache-4.8-windows-x86_64"
+        #$Env:PATH += ";$ccachepath"
+        #$ccachecachedir = Join-Path $HOME ".ccache"
+        #$Env:CCACHE_DIR="$ccachecachedir"
+        #$Env:CCACHE_COMPRESS='1'
+        #$Env:CCACHE_COMPRESSLEVEL='10'
+        #$Env:CCACHE_MAXSIZE='135M'
+        #ccache -z
 
         cmake -S . -B build   `
               -G "Ninja"      `
@@ -87,11 +87,11 @@ jobs:
               -DAMReX_EB=ON                 `
               -DAMReX_ENABLE_TESTS=ON       `
               -DAMReX_FORTRAN=OFF           `
-              -DAMReX_MPI=OFF               `
-              -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+              -DAMReX_MPI=OFF
+              #-DCMAKE_CXX_COMPILER_LAUNCHER=ccache
         cmake --build build --config RelWithDebInfo -j 2
 
-        ccache -s
+        #ccache -s
 
   # Build libamrex and all tests
   tests_clang:
@@ -116,17 +116,18 @@ jobs:
               -DAMReX_OMP=ON
         cmake --build build --config Release -j 2
 
-  save_pr_number:
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Save PR number
-        env:
-          PR_NUMBER: ${{ github.event.number }}
-        run: |
-          echo $PR_NUMBER > pr_number.txt
-      - uses: actions/upload-artifact@v3
-        with:
-          name: pr_number
-          path: pr_number.txt
-          retention-days: 1
+  # If we add ccache back, don't forget to update cleanup-cache.yml
+  #save_pr_number:
+  #  if: github.event_name == 'pull_request'
+  #  runs-on: ubuntu-latest
+  #  steps:
+  #    - name: Save PR number
+  #      env:
+  #        PR_NUMBER: ${{ github.event.number }}
+  #      run: |
+  #        echo $PR_NUMBER > pr_number.txt
+  #    - uses: actions/upload-artifact@v3
+  #      with:
+  #        name: pr_number
+  #        path: pr_number.txt
+  #        retention-days: 1


### PR DESCRIPTION
CCache has stopped working on Windows since 2023-09-20 for unknown reasons. After a couple of hours of investigation, I still could not get it to work. So let's disable it for now.
