### PR TITLE
Free Disk Space in Github CIs

### DIFF
--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -117,6 +117,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: Dependencies
       run: |
+        .github/workflows/dependencies/ubuntu_free_disk_space.sh
         .github/workflows/dependencies/dependencies_nvhpc.sh
         .github/workflows/dependencies/dependencies_ccache.sh
     - name: Set Up Cache

--- a/.github/workflows/dependencies/ubuntu_free_disk_space.sh
+++ b/.github/workflows/dependencies/ubuntu_free_disk_space.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+#
+# Copyright 2023 The AMReX Community
+#
+# License: BSD-3-Clause-LBNL
+
+# Don't want to use the following line because apt-get remove may fail if
+# the package specfied does not exist.
+# set -eu -o pipefail
+
+# Large packages
+dpkg-query -Wf '${Installed-Size}\t${Package}\n' | sort -n | tail -n 100
+
+echo 'Removing some packages we do not need'
+
+df -h
+
+apt list --installed
+
+sudo apt-get remove -y '^apache.*'
+sudo apt-get remove -y '^aspnetcore.*'
+sudo apt-get remove -y '^azure.*'
+sudo apt-get remove -y '^dotnet.*'
+sudo apt-get remove -y '^firebird.*'
+sudo apt-get remove -y '^firefox.*'
+sudo apt-get remove -y '^google.*'
+sudo apt-get remove -y '^hhvm.*'
+sudo apt-get remove -y '^microsoft.*'
+sudo apt-get remove -y '^mongodb.*'
+sudo apt-get remove -y '^mono-.*'
+sudo apt-get remove -y '^monodoc-.*'
+sudo apt-get remove -y '^mysql.*'
+sudo apt-get remove -y '^php.*'
+sudo apt-get remove -y '^powershell.*'
+sudo apt-get remove -y '^snapd.*'
+sudo apt-get remove -y '^temurin.*'
+
+sudo apt-get autoremove -y
+
+df -h

--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -152,6 +152,7 @@ jobs:
     - name: Dependencies
       if: ${{ env.CODEPLAYTOKEN != '' }}
       run: |
+        .github/workflows/dependencies/ubuntu_free_disk_space.sh
         .github/workflows/dependencies/dependencies_hip.sh 5.4.6
         .github/workflows/dependencies/dependencies_dpcpp.sh
         .github/workflows/dependencies/dependencies_codeplay.sh ${{ env.CODEPLAYTOKEN }}


### PR DESCRIPTION
Add a new script that removes some packages we do not need. It can free up about 7 GB of space on Ubuntu.

Use it in nvhpc and sycl/amd CIs. These CIs often run out of space. We don't want to use it in every CI, because it takes a few minutes to run the script.
