### PR TITLE
Fix ICC CI by Freeing up Disk Space

### DIFF
--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -200,6 +200,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: Dependencies
       run: |
+        .github/workflows/dependencies/ubuntu_free_disk_space.sh
         .github/workflows/dependencies/dependencies_dpcpp.sh
         sudo apt-get install -y intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic
         .github/workflows/dependencies/dependencies_ccache.sh


### PR DESCRIPTION
The ICC CI has been failing in the last few days with following message, `System.IO.IOException: No space left on device`. So we need to free up more disk space.
