### PR TITLE
RealVect Static: Export

### DIFF
--- a/Src/Base/AMReX_RealVect.H
+++ b/Src/Base/AMReX_RealVect.H
@@ -521,13 +521,13 @@ public:
   /**
      This is a RealVect all of whose components are equal to zero.
   */
-  static const RealVect Zero;
+  static AMREX_EXPORT const RealVect Zero;
 
   ///
   /**
      This is a RealVect all of whose components are equal to one.
   */
-  static const RealVect Unit;
+  static AMREX_EXPORT const RealVect Unit;
 
   /*@}*/
 


### PR DESCRIPTION
## Summary

Export global symbols for Windows.

Seen in WarpX on conda-forge:
```
lld-link: warning: ignoring unknown argument '-lpthreads'
lld-link: error: undefined symbol: public: static class amrex::RealVect const amrex::RealVect::Zero
>>> referenced by libwarpx.rz.NOMPI.OMP.DP.PDP.OPMD.PSATD.QED.lib(SpectralKSpaceRZ.cpp.obj):(public: __cdecl SpectralKSpaceRZ::SpectralKSpaceRZ(class amrex::BoxArray const &, class amrex::DistributionMapping const &, class amrex::RealVect))
```

## Additional background

https://github.com/conda-forge/warpx-feedstock/pull/72

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
