### PR TITLE
Fix a memory "leak" in VisMF's persistent streams

### DIFF
--- a/Src/Base/AMReX_VisMF.cpp
+++ b/Src/Base/AMReX_VisMF.cpp
@@ -2202,7 +2202,7 @@ void VisMF::CloseStream(const std::string &fileName, bool forceClose)
     pifs.pstr = nullptr;
     pifs.isOpen = false;
   }
-  pifs.ioBuffer.clear();
+  VisMFBuffer::ClearBuffer(pifs.ioBuffer);
 }
 
 

--- a/Src/Base/AMReX_VisMFBuffer.H
+++ b/Src/Base/AMReX_VisMFBuffer.H
@@ -29,6 +29,10 @@ public:
         ioBufferSize = iobuffersize;
     }
 
+    static void ClearBuffer (IO_Buffer& buf) {
+        IO_Buffer().swap(buf);
+    }
+
 protected:
 
     static AMREX_EXPORT Long ioBufferSize;   //!< ---- the settable buffer size


### PR DESCRIPTION
## Summary

VisMF uses a std::map to keep track of the streams it opens. Each PersistentIFStream object also has a vector used as IO buffer. When a stream is closed, we need to free to memory used by the buffer. The issue was it used std::vector::clear(), which only changes size() without reducing capacity() at all. So the memory was never freed. The issue is now fixed by std::vector::swap.

## Additional background

Thank Simon Guichandut (@simonguichandut) for reporting this! Thank Eric Johnson (@yut23) for pinning down the location of the leak with the help of the Massif heap profiler!

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
