### PR TITLE
Add runtime particle components to HDF5 wrapper

### DIFF
--- a/Src/Extern/HDF5/AMReX_ParticleHDF5.H
+++ b/Src/Extern/HDF5/AMReX_ParticleHDF5.H
@@ -711,13 +711,13 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
         if (count[grid] == 0)
             continue;
 
-        int_size  = count[grid] * (2 + NStructInt + NArrayInt + NumRuntimeIntComps());
+        int_size  = count[grid] * (2 + NStructInt + NumIntComps());
         my_mfi_int_size.push_back(int_size);
         my_nparticles.push_back(count[grid]);
         my_mfi_int_total_size += int_size;
 
 
-        real_size = count[grid] * (AMREX_SPACEDIM + NStructReal + NArrayReal + NumRuntimeRealComps() );
+        real_size = count[grid] * (AMREX_SPACEDIM + NStructReal + NumRealComps());
         my_mfi_real_size.push_back(real_size);
         my_mfi_real_total_size += real_size;
         my_mfi_cnt++;

--- a/Src/Extern/HDF5/AMReX_ParticleHDF5.H
+++ b/Src/Extern/HDF5/AMReX_ParticleHDF5.H
@@ -711,12 +711,13 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
         if (count[grid] == 0)
             continue;
 
-        int_size  = count[grid] * (2 + NStructInt + NArrayInt);
+        int_size  = count[grid] * (2 + NStructInt + NArrayInt + NumRuntimeIntComps());
         my_mfi_int_size.push_back(int_size);
         my_nparticles.push_back(count[grid]);
         my_mfi_int_total_size += int_size;
 
-        real_size = count[grid] * (AMREX_SPACEDIM + NStructReal + NArrayReal);
+
+        real_size = count[grid] * (AMREX_SPACEDIM + NStructReal + NArrayReal + NumRuntimeRealComps() );
         my_mfi_real_size.push_back(real_size);
         my_mfi_real_total_size += real_size;
         my_mfi_cnt++;


### PR DESCRIPTION
## Summary

Add runtime components when computing the sizes/offsets for particle HDF5 files. 

## Additional background

## Checklist

The proposed changes:
- [ x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
