### PR TITLE
Install Move Tools to `shared/amrex`

### DIFF
--- a/Tools/CMake/AMReXBuildInfo.cmake
+++ b/Tools/CMake/AMReXBuildInfo.cmake
@@ -38,14 +38,29 @@ include(AMReXTargetHelpers)
 #
 # Set paths
 #
-string(REPLACE "/Tools/CMake" "" AMREX_TOP_DIR ${CMAKE_CURRENT_LIST_DIR})
-set( AMREX_TOP_DIR ${AMREX_TOP_DIR} CACHE INTERNAL "Top level AMReX directory")
+if (AMReX_FOUND)
+   # AMReX is pre-installed and used as a library
+   string(REPLACE "/lib/cmake/AMReX/AMReXCMakeModules" "" AMREX_TOP_DIR_DEFAULT
+          ${CMAKE_CURRENT_LIST_DIR})
+else ()
+   # this is a superbuild
+   string(REPLACE "/Tools/CMake" "" AMREX_TOP_DIR_DEFAULT
+          ${CMAKE_CURRENT_LIST_DIR})
+endif ()
+set(AMREX_TOP_DIR "${AMREX_TOP_DIR_DEFAULT}" CACHE INTERNAL "Top level AMReX directory")
 
-set( AMREX_BUILDINFO_IFILE ${CMAKE_CURRENT_LIST_DIR}/AMReX_buildInfo.cpp.in
+if (AMReX_FOUND)
+   # AMReX is pre-installed and used as a library
+   set(AMREX_C_SCRIPTS_DIR "${AMREX_TOP_DIR}/share/amrex/C_scripts"
+       CACHE INTERNAL "Path to AMReX' C_scripts dir")
+else ()
+   # this is a superbuild
+   set(AMREX_C_SCRIPTS_DIR "${AMREX_TOP_DIR}/Tools/C_scripts"
+       CACHE INTERNAL "Path to AMReX' C_scripts dir")
+endif ()
+
+set(AMREX_BUILDINFO_IFILE ${CMAKE_CURRENT_LIST_DIR}/AMReX_buildInfo.cpp.in
    CACHE INTERNAL "Full path and name of AMReX_buildInfo.cpp.in")
-
-set( AMREX_C_SCRIPTS_DIR "${AMREX_TOP_DIR}/Tools/C_scripts"
-   CACHE INTERNAL "Path to AMReX' C_scripts dir")
 
 set(AMREX_BUILD_DATETIME "" CACHE STRING
    "User defined build date and time. Set ONLY for reproducibly built binary distributions")

--- a/Tools/CMake/AMReXInstallHelpers.cmake
+++ b/Tools/CMake/AMReXInstallHelpers.cmake
@@ -26,7 +26,7 @@ function (install_amrex_targets)
    else()
        set(CMAKE_FILES_DIR   lib/cmake/AMReX)
    endif()
-   set(MODULE_PATH       Tools/CMake)       # Relative path to top level installation/build-tree
+   set(MODULE_PATH       ${CMAKE_FILES_DIR}/AMReXCMakeModules)       # Relative path to top level installation/build-tree
 
    # Write Config file -- this is designed to work for both install and build trees
    configure_package_config_file(${AMREX_CMAKE_MODULES_PATH}/AMReXConfig.cmake.in
@@ -60,7 +60,7 @@ function (install_amrex_targets)
 
        install( EXPORT AMReXTargets
           NAMESPACE AMReX::
-          DESTINATION lib/cmake/AMReX )
+          DESTINATION ${CMAKE_FILES_DIR} )
 
        #
        # alias: last element will be legacy target
@@ -88,11 +88,17 @@ function (install_amrex_targets)
        # Install Tools directory
        install(
           DIRECTORY
-          ${PROJECT_SOURCE_DIR}/Tools/CMake
-          ${PROJECT_SOURCE_DIR}/Tools/C_scripts
-          ${PROJECT_SOURCE_DIR}/Tools/typechecker
+            ${PROJECT_SOURCE_DIR}/Tools/C_scripts
+            ${PROJECT_SOURCE_DIR}/Tools/typechecker
           DESTINATION
-          Tools
+            share/amrex
+          USE_SOURCE_PERMISSIONS
+          )
+       install(
+          DIRECTORY
+            ${PROJECT_SOURCE_DIR}/Tools/CMake/
+          DESTINATION
+            ${MODULE_PATH}
           USE_SOURCE_PERMISSIONS
           )
    endif()
@@ -106,11 +112,16 @@ function (install_amrex_targets)
    # Copy Tools directory to build tree
    file(
       COPY
-      ${PROJECT_SOURCE_DIR}/Tools/CMake
-      ${PROJECT_SOURCE_DIR}/Tools/C_scripts
-      ${PROJECT_SOURCE_DIR}/Tools/typechecker
+        ${PROJECT_SOURCE_DIR}/Tools/C_scripts
+        ${PROJECT_SOURCE_DIR}/Tools/typechecker
       DESTINATION
-      ${PROJECT_BINARY_DIR}/Tools
+        ${PROJECT_BINARY_DIR}/share/amrex
+      )
+   file(
+      COPY
+        ${PROJECT_SOURCE_DIR}/Tools/CMake/
+      DESTINATION
+        ${PROJECT_BINARY_DIR}/${MODULE_PATH}
       )
 
 

--- a/Tools/CMake/AMReXTypecheck.cmake
+++ b/Tools/CMake/AMReXTypecheck.cmake
@@ -296,9 +296,13 @@ function( add_typecheck_target _target)
    #
    set(_outfile  "${_typecheck_dir}/${_target}_typecheck.ou" )
 
-   # Find typechecker 
+   # Find typechecker
    find_file(_typechecker "typechecker.py"
-      HINTS ${AMReX_SOURCE_DIR} ${AMReX_ROOT} ENV AMReX_ROOT PATH_SUFFIXES Tools/typechecker)
+      HINTS ${AMReX_SOURCE_DIR} ${AMReX_ROOT} ENV AMReX_ROOT
+      PATH_SUFFIXES
+        Tools/typechecker        # in-source
+        share/amrex/typechecker  # installed
+   )
 
    add_custom_target( typecheck_${_target}
       COMMAND python3  ${_typechecker}


### PR DESCRIPTION
## Summary

Packaging AMReX for Conda, we realized that we break with common conventions on Unix systems by installing a top-level `Tools/` directory.

This moves its content in both the build directory and the install destination to `share/amrex/` and `<CMakePkgRoot>/AMReXCMakeModules/`, respectively.

## Additional background

https://github.com/conda-forge/staged-recipes/pull/24294

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
