### PR TITLE
[Breaking] Prefix `amrex_` to each plotfile Tool

### DIFF
--- a/.github/workflows/clang.yml
+++ b/.github/workflows/clang.yml
@@ -64,7 +64,7 @@ jobs:
             CLANG_TIDY_ARGS="--config-file=${{github.workspace}}/.clang-tidy --warnings-as-errors=*"
 
         export PATH=/tmp/my-amrex/bin:$PATH
-        which fcompare
+        which amrex_fcompare
 
         ctest --output-on-failure
 

--- a/.github/workflows/gcc.yml
+++ b/.github/workflows/gcc.yml
@@ -60,7 +60,7 @@ jobs:
             CLANG_TIDY_ARGS="--config-file=${{github.workspace}}/.clang-tidy --warnings-as-errors=*"
 
         export PATH=/tmp/my-amrex/bin:$PATH
-        which fcompare
+        which amrex_fcompare
 
         ctest --output-on-failure
 

--- a/Tools/Plotfile/CMakeLists.txt
+++ b/Tools/Plotfile/CMakeLists.txt
@@ -27,6 +27,11 @@ foreach( _exe IN LISTS _exe_names)
    if (AMReX_CUDA)
       set_source_files_properties(${_exe}.cpp PROPERTIES LANGUAGE CUDA)
    endif()
+
+    # Add prefix to each tool's name to make them unique when installed.
+    # This avoids potential collisions of names on user systems, e.g., in
+    # software packages (Spack/Conda/Debian/...).
+    set_target_properties(${_exe} PROPERTIES OUTPUT_NAME "amrex_${_exe}")
 endforeach()
 
 


### PR DESCRIPTION
## Summary

Packaging AMReX for Conda, we received feedback that our plotfile tool names are too generic and can collide with other packages.

Thus, we propose to rename them with a common prefix.

- [x] decide prefix or suffix (suffix: `<TAB>` completion will work; prefix: easier for new users)
- [x] decide name: `plt`/`amrex`/`amr`/...
  - Weiqun and Axel prefer `amrex_` so far
- [ ] also change for GNUmake
  - [ ] update [test harness](https://github.com/AMReX-Codes/regression_testing)
- [ ] update user-facing documentation for tools
- [x] ~update [tutorials](https://github.com/AMReX-Codes/amrex-tutorials)?~

## Additional background

https://github.com/conda-forge/staged-recipes/pull/24294

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
