### PR TITLE
Avoid std::filesystem

### DIFF
--- a/Tools/Plotfile/fgradient.cpp
+++ b/Tools/Plotfile/fgradient.cpp
@@ -6,7 +6,6 @@
 #include <AMReX_Vector.H>
 #include <cstdlib>
 #include <iterator>
-#include <filesystem>
 #include <sstream>
 #include <string>
 
@@ -129,7 +128,7 @@ void main_main()
     }
 
     if (outfile.empty()) {
-        outfile = "grad."+std::filesystem::path(pltfile).filename().string();
+        outfile = "grad."+VisMF::BaseName(pltfile);
     }
 
     PlotFileData pf(pltfile);


### PR DESCRIPTION
It has caused a lot of issues on systems with a default gcc <= 8.  PR #3523 was trying to the issue. But unfortunately it does not always work. So we are going to simply avoid std::filesystem.
