### PR TITLE
Print AMReX version at the beginning of Initialize

### DIFF
--- a/Src/Base/AMReX.cpp
+++ b/Src/Base/AMReX.cpp
@@ -443,6 +443,10 @@ amrex::Initialize (int& argc, char**& argv, bool build_parm_parse,
         pp.queryAdd("verbose", system::verbose);
     }
 
+    if (system::verbose > 0) {
+        amrex::Print() << "Initializing AMReX (" << amrex::Version() << ")...\n";
+    }
+
 #ifdef AMREX_USE_MPI
     if (system::verbose > 0) {
         amrex::Print() << "MPI initialized with "


### PR DESCRIPTION
Oftentimes, a GPU run dies at the first GPU kernel inside amrex::Initialize before printing a message showing AMReX with a certain version has been initialized. Adding a message at the beginning of amrex::Initialize can provide useful information.

