### PR TITLE
Windows: Fix Installed AMReXBuildInfo.cmake

### DIFF
--- a/Tools/CMake/AMReXBuildInfo.cmake
+++ b/Tools/CMake/AMReXBuildInfo.cmake
@@ -40,8 +40,15 @@ include(AMReXTargetHelpers)
 #
 if (AMReX_FOUND)
    # AMReX is pre-installed and used as a library
-   string(REPLACE "/lib/cmake/AMReX/AMReXCMakeModules" "" AMREX_TOP_DIR_DEFAULT
-          ${CMAKE_CURRENT_LIST_DIR})
+   if (WIN32)  # see AMReXInstallHelpers.cmake
+       string(REPLACE "/cmake/AMReXCMakeModules" ""
+              AMREX_TOP_DIR_DEFAULT
+              ${CMAKE_CURRENT_LIST_DIR})
+   else ()
+       string(REPLACE "/lib/cmake/AMReX/AMReXCMakeModules" ""
+              AMREX_TOP_DIR_DEFAULT
+              ${CMAKE_CURRENT_LIST_DIR})
+   endif ()
 else ()
    # this is a superbuild
    string(REPLACE "/Tools/CMake" "" AMREX_TOP_DIR_DEFAULT


### PR DESCRIPTION
## Summary

Account for different CMake path on Unix vs. Windows.
https://cmake.org/cmake/help/latest/command/find_package.html#config-mode-search-procedure

## Additional background

Follow-up to #3599

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
