### PR TITLE
`AMReXBuildInfo.cmake`: AMReX_DIR

### DIFF
--- a/Tools/CMake/AMReXBuildInfo.cmake
+++ b/Tools/CMake/AMReXBuildInfo.cmake
@@ -38,7 +38,7 @@ include(AMReXTargetHelpers)
 #
 # Set paths
 #
-if (AMReX_FOUND)
+if (AMReX_DIR)
    # AMReX is pre-installed and used as a library
    if (WIN32)  # see AMReXInstallHelpers.cmake
        string(REPLACE "/cmake/AMReXCMakeModules" ""
@@ -56,7 +56,7 @@ else ()
 endif ()
 set(AMREX_TOP_DIR "${AMREX_TOP_DIR_DEFAULT}" CACHE INTERNAL "Top level AMReX directory")
 
-if (AMReX_FOUND)
+if (AMReX_DIR)
    # AMReX is pre-installed and used as a library
    set(AMREX_C_SCRIPTS_DIR "${AMREX_TOP_DIR}/share/amrex/C_scripts"
        CACHE INTERNAL "Path to AMReX' C_scripts dir")


### PR DESCRIPTION
## Summary

The `AMReX_DIR` points if set to the CMake module path root.

The old logic did not work for me in a situation (ImpactX) where:
- AMReX is pre-installed but
- found through a superbuild of another transient lib (ABLASTR)

## Additional background

Follow-up to #3599

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
