### PR TITLE
Fix typo in `MLMGT<MF>::getGradSolution` when `MF` is different from `AMF`

### DIFF
--- a/Src/LinearSolvers/MLMG/AMReX_MLMG.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLMG.H
@@ -545,7 +545,7 @@ MLMGT<MF>::getGradSolution (const Vector<Array<AMF*,AMREX_SPACEDIM> >& a_grad_so
             }
             linop.compGrad(alev, GetArrOfPtrs(grad_sol), sol[alev], a_loc);
             for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-                a_grad_sol[alev][idim]->LocalCopy(grad_sol, 0, 0, ncomp, IntVect(0));
+                a_grad_sol[alev][idim]->LocalCopy(grad_sol[idim], 0, 0, ncomp, IntVect(0));
             }
         }
     }

--- a/Tests/LinearSolvers/EBflux_grad/MyTest.H
+++ b/Tests/LinearSolvers/EBflux_grad/MyTest.H
@@ -45,6 +45,7 @@ private:
     amrex::Vector<amrex::MultiFab> phi;
     amrex::Vector<amrex::Array<amrex::MultiFab, AMREX_SPACEDIM>> flux;
     amrex::Vector<amrex::Array<amrex::MultiFab, AMREX_SPACEDIM>> grad;
+    amrex::Vector<amrex::Array<amrex::iMultiFab, AMREX_SPACEDIM>> igrad;
     amrex::Vector<amrex::MultiFab> rhs;
     amrex::Vector<amrex::MultiFab> acoef;
     amrex::Vector<amrex::Array<amrex::MultiFab,AMREX_SPACEDIM> > bcoef;

--- a/Tests/LinearSolvers/EBflux_grad/MyTest.H
+++ b/Tests/LinearSolvers/EBflux_grad/MyTest.H
@@ -45,7 +45,7 @@ private:
     amrex::Vector<amrex::MultiFab> phi;
     amrex::Vector<amrex::Array<amrex::MultiFab, AMREX_SPACEDIM>> flux;
     amrex::Vector<amrex::Array<amrex::MultiFab, AMREX_SPACEDIM>> grad;
-    amrex::Vector<amrex::Array<amrex::iMultiFab, AMREX_SPACEDIM>> igrad; // Used to test getGradSolution when MF is different from AMF
+    amrex::Vector<amrex::Array<amrex::fMultiFab, AMREX_SPACEDIM>> fgrad; // Used to test getGradSolution when MF is different from AMF
     amrex::Vector<amrex::MultiFab> rhs;
     amrex::Vector<amrex::MultiFab> acoef;
     amrex::Vector<amrex::Array<amrex::MultiFab,AMREX_SPACEDIM> > bcoef;

--- a/Tests/LinearSolvers/EBflux_grad/MyTest.H
+++ b/Tests/LinearSolvers/EBflux_grad/MyTest.H
@@ -45,7 +45,7 @@ private:
     amrex::Vector<amrex::MultiFab> phi;
     amrex::Vector<amrex::Array<amrex::MultiFab, AMREX_SPACEDIM>> flux;
     amrex::Vector<amrex::Array<amrex::MultiFab, AMREX_SPACEDIM>> grad;
-    amrex::Vector<amrex::Array<amrex::iMultiFab, AMREX_SPACEDIM>> igrad;
+    amrex::Vector<amrex::Array<amrex::iMultiFab, AMREX_SPACEDIM>> igrad; // Used to test getGradSolution when MF is different from AMF
     amrex::Vector<amrex::MultiFab> rhs;
     amrex::Vector<amrex::MultiFab> acoef;
     amrex::Vector<amrex::Array<amrex::MultiFab,AMREX_SPACEDIM> > bcoef;

--- a/Tests/LinearSolvers/EBflux_grad/MyTest.cpp
+++ b/Tests/LinearSolvers/EBflux_grad/MyTest.cpp
@@ -73,7 +73,7 @@ MyTest::solve ()
     mlmg.solve(amrex::GetVecOfPtrs(phi), amrex::GetVecOfConstPtrs(rhs), tol_rel, tol_abs);
     mlmg.getFluxes(amrex::GetVecOfArrOfPtrs(flux));
     mlmg.getGradSolution(amrex::GetVecOfArrOfPtrs(grad));
-    mlmg.getGradSolution(amrex::GetVecOfArrOfPtrs(igrad));
+    mlmg.getGradSolution(amrex::GetVecOfArrOfPtrs(igrad)); // Test when MF is different from AMF
     for (int ilev = 0; ilev <= max_level; ++ilev) {
         amrex::VisMF::Write(phi[0], "phi-"+std::to_string(ilev));
     }

--- a/Tests/LinearSolvers/EBflux_grad/MyTest.cpp
+++ b/Tests/LinearSolvers/EBflux_grad/MyTest.cpp
@@ -73,6 +73,7 @@ MyTest::solve ()
     mlmg.solve(amrex::GetVecOfPtrs(phi), amrex::GetVecOfConstPtrs(rhs), tol_rel, tol_abs);
     mlmg.getFluxes(amrex::GetVecOfArrOfPtrs(flux));
     mlmg.getGradSolution(amrex::GetVecOfArrOfPtrs(grad));
+    mlmg.getGradSolution(amrex::GetVecOfArrOfPtrs(igrad));
     for (int ilev = 0; ilev <= max_level; ++ilev) {
         amrex::VisMF::Write(phi[0], "phi-"+std::to_string(ilev));
     }
@@ -146,6 +147,7 @@ MyTest::initData ()
     bcoef.resize(nlevels);
     flux.resize(1);
     grad.resize(1);
+    igrad.resize(1);
     for (int ilev = 0; ilev < nlevels; ++ilev)
     {
         dmap[ilev].define(grids[ilev]);
@@ -193,5 +195,7 @@ MyTest::initData ()
                                      dmap[0], 1, 0, MFInfo(), *factory[0]);
         grad[0][idim].define(amrex::convert(grids[0],IntVect::TheDimensionVector(idim)),
                                      dmap[0], 1, 0, MFInfo(), *factory[0]);
+        igrad[0][idim].define(amrex::convert(grids[0],IntVect::TheDimensionVector(idim)),
+                                      dmap[0], 1, 0, MFInfo(), DefaultFabFactory<IArrayBox>());
     }
 }

--- a/Tests/LinearSolvers/EBflux_grad/MyTest.cpp
+++ b/Tests/LinearSolvers/EBflux_grad/MyTest.cpp
@@ -73,7 +73,7 @@ MyTest::solve ()
     mlmg.solve(amrex::GetVecOfPtrs(phi), amrex::GetVecOfConstPtrs(rhs), tol_rel, tol_abs);
     mlmg.getFluxes(amrex::GetVecOfArrOfPtrs(flux));
     mlmg.getGradSolution(amrex::GetVecOfArrOfPtrs(grad));
-    mlmg.getGradSolution(amrex::GetVecOfArrOfPtrs(igrad)); // Test when MF is different from AMF
+    mlmg.getGradSolution(amrex::GetVecOfArrOfPtrs(fgrad)); // Test when MF is different from AMF
     for (int ilev = 0; ilev <= max_level; ++ilev) {
         amrex::VisMF::Write(phi[0], "phi-"+std::to_string(ilev));
     }
@@ -147,7 +147,7 @@ MyTest::initData ()
     bcoef.resize(nlevels);
     flux.resize(1);
     grad.resize(1);
-    igrad.resize(1);
+    fgrad.resize(1);
     for (int ilev = 0; ilev < nlevels; ++ilev)
     {
         dmap[ilev].define(grids[ilev]);
@@ -195,7 +195,7 @@ MyTest::initData ()
                                      dmap[0], 1, 0, MFInfo(), *factory[0]);
         grad[0][idim].define(amrex::convert(grids[0],IntVect::TheDimensionVector(idim)),
                                      dmap[0], 1, 0, MFInfo(), *factory[0]);
-        igrad[0][idim].define(amrex::convert(grids[0],IntVect::TheDimensionVector(idim)),
-                                      dmap[0], 1, 0, MFInfo(), DefaultFabFactory<IArrayBox>());
+        fgrad[0][idim].define(amrex::convert(grids[0],IntVect::TheDimensionVector(idim)),
+                                      dmap[0], 1, 0, MFInfo(), DefaultFabFactory<BaseFab<float>>());
     }
 }


### PR DESCRIPTION
## Summary

This PR fixes a small typo in `MLMGT<MF>::getGradSolution` that causes an error when `AMR` is distinct from `MF`. A test demonstrating the fix is added for the case where `MF`=`MultiFab` and `AMF`=`iMultiFab`.

## Additional background

This typo was noticed when working on generalizing the `MLMG` template to the WIP class `FabArraySet`.

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
