### PR TITLE
solve_cg: consistent RT casting

### DIFF
--- a/Src/LinearSolvers/MLMG/AMReX_MLCGSolver.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLCGSolver.H
@@ -294,7 +294,7 @@ MLCGSolverT<MF>::solve_cg (MF& sol, const MF& rhs, RT eps_rel, RT eps_abs)
 
     for (; iter <= maxiter; ++iter)
     {
-        RT rho = dotxy(r,r);
+        const RT rho = dotxy(r,r);
 
         if ( rho == RT(0.0) )
         {

--- a/Src/LinearSolvers/MLMG/AMReX_MLCGSolver.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLCGSolver.H
@@ -306,17 +306,17 @@ MLCGSolverT<MF>::solve_cg (MF& sol, const MF& rhs, RT eps_rel, RT eps_abs)
         }
         else
         {
-            RT beta = rho/rho_1;
+            const RT beta = rho/rho_1;
             MF::Xpay(p, beta, r, 0, 0, ncomp, nghost); // p = r + beta * p
         }
         Lp.apply(amrlev, mglev, q, p, MLLinOpT<MF>::BCMode::Homogeneous, MLLinOpT<MF>::StateMode::Correction);
 
-        RT pw = dotxy(p,q);
+        const RT pw = dotxy(p,q);
         if ( pw == RT(0.0))
         {
             ret = 1; break;
         }
-        RT alpha = rho/pw;
+        const RT alpha = rho/pw;
 
         if ( verbose > 2 )
         {

--- a/Src/LinearSolvers/MLMG/AMReX_MLCGSolver.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLCGSolver.H
@@ -312,7 +312,7 @@ MLCGSolverT<MF>::solve_cg (MF& sol, const MF& rhs, RT eps_rel, RT eps_abs)
         Lp.apply(amrlev, mglev, q, p, MLLinOpT<MF>::BCMode::Homogeneous, MLLinOpT<MF>::StateMode::Correction);
 
         const RT pw = dotxy(p,q);
-        if ( pw == RT(0.0))
+        if ( pw == RT(0.0) )
         {
             ret = 1; break;
         }

--- a/Src/LinearSolvers/MLMG/AMReX_MLCGSolver.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLCGSolver.H
@@ -282,11 +282,11 @@ MLCGSolverT<MF>::solve_cg (MF& sol, const MF& rhs, RT eps_rel, RT eps_abs)
         amrex::Print() << "MLCGSolver_CG: Initial error (error0) :        " << rnorm0 << '\n';
     }
 
-    RT rho_1 = 0;
+    RT rho_1 = RT(0.0);
     int  ret = 0;
     iter = 1;
 
-    if ( rnorm0 == 0 || rnorm0 < eps_abs )
+    if ( rnorm0 == RT(0.0) || rnorm0 < eps_abs )
     {
         if ( verbose > 0 ) {
             amrex::Print() << "MLCGSolver_CG: niter = 0,"
@@ -302,7 +302,7 @@ MLCGSolverT<MF>::solve_cg (MF& sol, const MF& rhs, RT eps_rel, RT eps_abs)
 
         RT rho = dotxy(z,r);
 
-        if ( rho == 0 )
+        if ( rho == RT(0.0) )
         {
             ret = 1; break;
         }
@@ -317,16 +317,12 @@ MLCGSolverT<MF>::solve_cg (MF& sol, const MF& rhs, RT eps_rel, RT eps_abs)
         }
         Lp.apply(amrlev, mglev, q, p, MLLinOpT<MF>::BCMode::Homogeneous, MLLinOpT<MF>::StateMode::Correction);
 
-        RT alpha;
         RT pw = dotxy(p,q);
-        if ( pw != RT(0.0))
-        {
-            alpha = rho/pw;
-        }
-        else
+        if ( pw == RT(0.0))
         {
             ret = 1; break;
         }
+        RT alpha = rho/pw;
 
         if ( verbose > 2 )
         {


### PR DESCRIPTION
## Summary

This PR makes sure that every instance in `solve_cg` of setting an RT variable to 0 or checking if it is equal to 0 uses the explicit RT(0.0) cast.

## Additional background

This is similar to the PR made for `solve_bicgstab`.