### PR TITLE
Comments: make AB linear solver convention match documentation

### DIFF
--- a/Docs/sphinx_documentation/source/LinearSolvers.rst
+++ b/Docs/sphinx_documentation/source/LinearSolvers.rst
@@ -690,7 +690,7 @@ viscous term `divtau` explicitly:
    // Note we call LPInfo().setMaxCoarseningLevel(0) because we are only applying the operator,
    //      not doing an implicit solve
    //
-   //       (alpha * a - beta * (del dot b grad)) sol
+   //       (A * alpha - B * (del dot beta grad)) sol
    //
    // LPInfo                       info;
    MLEBTensorOp ebtensorop(geom, grids, dmap, LPInfo().setMaxCoarseningLevel(0),

--- a/Src/LinearSolvers/MLMG/AMReX_MLABecLaplacian.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLABecLaplacian.H
@@ -7,8 +7,7 @@
 
 namespace amrex {
 
-// (alpha * a - beta * (del dot b grad)) phi
-
+// (A * alpha - B * (del dot beta grad)) phi
 template <typename MF>
 class MLABecLaplacianT
     : public MLCellABecLapT<MF>

--- a/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap.H
@@ -9,8 +9,7 @@
 
 namespace amrex {
 
-// (alpha * a - beta * (del dot b grad)) phi
-
+// (A * alpha - B * (del dot beta grad)) phi
 class MLEBABecLap
     : public MLCellABecLap
 {

--- a/Src/LinearSolvers/MLMG/AMReX_MLEBTensorOp.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBTensorOp.H
@@ -9,20 +9,19 @@ namespace amrex {
 // Tensor solver for high Reynolds flows with small gradient in viscosity.
 // The system it solves is
 //
-//   alpha a v - beta div dot tau = rhs
+//   A alpha v - B div dot tau = rhs
 //
 // where tau = eta [grad v + (grad v)^T] +  (kappa-(2/3)eta) (div v) I.
 // Here eta and kappa are shear and bulk viscosity, and I is identity tensor.
 //
-// The user needs to provide `a` by `setACoeffs`, eta by `setShearViscosity`,
-// and kappa by `setBulkViscosity`.  If `setBulkViscosity` is not called,
-// kappa is set to zero.  The user must also call `setEBShearViscosity` to set
+// The user needs to provide `alpha` by `setACoeffs`, `eta` by `setShearViscosity`,
+// and `kappa` by `setBulkViscosity`.  If `setBulkViscosity` is not called,
+// `kappa` is set to zero.  The user must also call `setEBShearViscosity` to set
 // viscosity on EB.  Optionally, `setEBBulkViscosity` can be used to set
 // bulk viscosity on EB.
 //
-// The scalars alpha and beta can be set with `setScalar(Real, Real)`.  If
+// The scalars `A` and `B` can be set with `setScalar(Real, Real)`.  If
 // they are not set, their default value is 1.
-
 class MLEBTensorOp
     : public MLEBABecLap
 {

--- a/Src/LinearSolvers/MLMG/AMReX_MLMG.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLMG.H
@@ -57,7 +57,7 @@ public:
                           Location a_loc = Location::FaceCenter);
 
     /**
-    * \brief For ``(alpha * a - beta * (del dot b grad)) phi = rhs``, flux means ``-b grad phi``
+    * \brief For ``(A * alpha - B * (del dot beta grad)) phi = rhs``, flux means ``-beta grad phi``
     */
     template <typename AMF>
     void getFluxes (const Vector<Array<AMF*,AMREX_SPACEDIM> >& a_flux,

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeABecLaplacian.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeABecLaplacian.H
@@ -6,9 +6,8 @@
 
 namespace amrex {
 
-// (alpha * a - beta * (del dot b grad)) phi = rhs
-// a, phi and rhs are nodal. b is cell-centered.
-
+// (A * alpha - B * (del dot beta grad)) phi = rhs
+// alpha, phi and rhs are nodal. beta is cell-centered.
 class MLNodeABecLaplacian
     : public MLNodeLinOp
 {

--- a/Src/LinearSolvers/MLMG/AMReX_MLTensorOp.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLTensorOp.H
@@ -10,18 +10,17 @@ namespace amrex {
 // Tensor solver for high Reynolds flows with small gradient in viscosity.
 // The system it solves is
 //
-//   alpha a v - beta div dot tau = rhs
+//   A alpha v - B div dot tau = rhs
 //
 // where tau = eta [grad v + (grad v)^T] +  (kappa-(2/3)eta) (div v) I.
 // Here eta and kappa are shear and bulk viscosity, and I is identity tensor.
 //
-// The user needs to provide `a` by `setACoeffs`, eta by `setShearViscosity`,
-// and kappa by `setBulkViscosity`.  If `setBulkViscosity` is not called,
-// kappa is set to zero.
+// The user needs to provide `alpha` by `setACoeffs`, `eta` by `setShearViscosity`,
+// and `kappa` by `setBulkViscosity`.  If `setBulkViscosity` is not called,
+// `kappa` is set to zero.
 //
-// The scalars alpha and beta can be set with `setScalar(Real, Real)`.  If
+// The scalars `A` and `B` can be set with `setScalar(Real, Real)`.  If
 // they are not set, their default value is 1.
-
 class MLTensorOp
     : public MLABecLaplacian
 {

--- a/Tests/LinearSolvers/ABecLaplacian_F/README
+++ b/Tests/LinearSolvers/ABecLaplacian_F/README
@@ -1,10 +1,10 @@
 This tutorial demonstrates how to solve the linear system in a
 canonical ABecLaplacian form
 
-    alpha * a * phi - beta * del dot (b grad phi) = rhs.
+    A * alpha * phi - B * del dot (beta grad phi) = rhs.
 
-Here phi is the unknown in a cell-centered MultiFab, alpha and beta
-are scalar constants, a is a cell-centered MultiFab, and b lives on
+Here phi is the unknown in a cell-centered MultiFab, A and B
+are scalar constants, alpha is a cell-centered MultiFab, and beta lives on
 cell faces and is thus represented by D face based MultiFabs, where D
 is the number of spatial dimensions.  The right-hand side, rhs, is
 also cell-centered.  A more specialized version of the ABecLaplacian
@@ -12,7 +12,7 @@ form is Poisson's equation.  This tutorial is written with AMReX's
 Fortran interfaces.
 
 After the solution is obtained, one can also ask for grad phi, or flux
-(defined as -b grad phi).  Note that they live on cell faces.  This
+(defined as -beta grad phi).  Note that they live on cell faces.  This
 step is not performed in this tutorial.  However, one can look at
 `amrex/Src/F_Interfaces/LinearSolvers/AMReX_multigrid_mod.F90` for the
 interface of `get_grad_solution` and `get_fluxes`.


### PR DESCRIPTION
## Summary

This PR adjusts comments to conform to the A-B-alpha-beta linear solver convention stated in the documentation: `A` and `B` are the scalar constants, while `alpha` and `beta` are the coefficient fields.

## Additional background

The convention is established throughout the Linear Solver chapter of the documentation.

From line 18 of `LinearSolvers_Chapers.rst`:
> In this Chapter we give an overview of the linear solvers in AMReX
> that solve linear systems in the canonical form
> 
> .. math:: (A \alpha - B \nabla \cdot \beta \nabla ) \phi = f,
>   :label: eqn::abeclap
> 
> where :math:`A` and :math:`B` are scalar constants,
> :math:`\alpha` and :math:`\beta` are coefficient fields,
> :math:`\phi` is the unknown,
> and :math:`f` is the right-hand side of the equation.

From line 71 of `LinearSolvers.rst':
> The :cpp:`setScalars` function sets the scalar constants :math:`A` and :math:`B`
> .. code-block::
>     void setScalars (Real a, Real b) noexcept;
>
> For the general case where :math:`\alpha` and :math:`\beta` are scalar fields, we use
>   .. code-block::
>       void setACoeffs (int amrlev, const MultiFab& alpha);
>       void setBCoeffs (int amrlev, const Array<MultiFab const*,AMREX_SPACEDIM>& beta);

We can also see this convention in code comments such as line 62 in `AMReX_MLEBABecLap.H`:
>     /**
>     * Set scalar constants A and B in the equation:
>     * (A \alpha - B \nabla \cdot \beta \nabla ) \phi = f
>     * for the Multi-Level AB Laplacian Solver.
>     */

However, several code comments contradict this, with `A` and `B` being the coefficient fields, and `alpha` and `beta` as the scalar constants, including on line 10 of the same file `AMReX_MLEBABecLap.H`:
> // (alpha * a - beta * (del dot b grad)) phi

I assume this is a hold-over when the opposite convention was used. From first hand experience, I can say this can be very confusing when reading the comments to understand how these linear operators work.

A forthcoming PR renames the Real variables `alpha` and `beta` to `ascalar` and `bscalar`, where appropriate.

## Checklist

The proposed changes:
- [x] include documentation in the code and/or rst files, if appropriate
