### PR TITLE
Fix: nosmt OMP Threads Default

### DIFF
--- a/Src/Base/AMReX_OpenMP.cpp
+++ b/Src/Base/AMReX_OpenMP.cpp
@@ -152,12 +152,13 @@ namespace amrex::OpenMP
             // default or OMP_NUM_THREADS environment variable
         } else if (omp_threads == "nosmt") {
             char const *env_omp_num_threads = std::getenv("OMP_NUM_THREADS");
-            if (env_omp_num_threads != nullptr && amrex::system::verbose > 1) {
+            if (env_omp_num_threads == nullptr) {
+                omp_set_num_threads(numUniquePhysicalCores());
+            }
+            else if (amrex::system::verbose > 1) {
                 amrex::Print() << "amrex.omp_threads was set to nosmt,"
                                << "but OMP_NUM_THREADS was set. Will keep "
                                << "OMP_NUM_THREADS=" << env_omp_num_threads << ".\n";
-            } else {
-                omp_set_num_threads(numUniquePhysicalCores());
             }
         } else {
             std::optional<int> num_omp_threads = to_int(omp_threads);


### PR DESCRIPTION
## Summary

Fix that `OMP_NUM_THREADS` was ignored in non-verbose runs.

## Additional background

Follow-up to #3607

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
