### PR TITLE
Robustify the Cache Cleanup Scripts

### DIFF
--- a/.github/workflows/cleanup-cache-postpr.yml
+++ b/.github/workflows/cleanup-cache-postpr.yml
@@ -31,7 +31,10 @@ jobs:
           set +e
 
           keys=$(gh actions-cache list -L 100 -R $REPO -B $BRANCH | cut -f 1)
+          # $keys might contain spaces. Thus we set IFS to \n.
+          IFS=$'\n'
           for k in $keys
           do
-            gh actions-cache delete $k -R $REPO -B $BRANCH --confirm
+            gh actions-cache delete "$k" -R $REPO -B $BRANCH --confirm
           done
+          unset IFS

--- a/.github/workflows/cleanup-cache.yml
+++ b/.github/workflows/cleanup-cache.yml
@@ -27,7 +27,7 @@ jobs:
           EVENT=${{ github.event.workflow_run.event }}
 
           # Triggering workflow run name (e.g., LinuxClang)
-          WORKFLOW_NAME=${{ github.event.workflow_run.name }}
+          WORKFLOW_NAME="${{ github.event.workflow_run.name }}"
 
           if [[ $EVENT == "pull_request" ]]; then
             gh run download ${{ github.event.workflow_run.id }} -n pr_number
@@ -45,16 +45,19 @@ jobs:
           # The goal is to keep the last used key of each job and delete all others.
 
           # something like ccache-LinuxClang-
-          keyprefix=ccache-${WORKFLOW_NAME}-
+          keyprefix="ccache-${WORKFLOW_NAME}-"
 
-          cached_jobs=$(gh actions-cache list -L 100 -R $REPO -B $BRANCH --key $keyprefix | awk -F '-git-' '{print $1}' | sort | uniq)
+          cached_jobs=$(gh actions-cache list -L 100 -R $REPO -B $BRANCH --key "$keyprefix" | awk -F '-git-' '{print $1}' | sort | uniq)
 
           # cached_jobs is something like "ccache-LinuxClang-configure-1d ccache-LinuxClang-configure-2d".
+          # It might also contain spaces. Thus we set IFS to \n.
+          IFS=$'\n'
           for j in $cached_jobs
           do
-            old_keys=$(gh actions-cache list -L 100 -R $REPO -B $BRANCH --key ${j}-git- --sort last-used | cut -f 1 | tail -n +2)
+            old_keys=$(gh actions-cache list -L 100 -R $REPO -B $BRANCH --key "${j}-git-" --sort last-used | cut -f 1 | tail -n +2)
             for k in $old_keys
             do
-              gh actions-cache delete $k -R $REPO -B $BRANCH --confirm
+              gh actions-cache delete "$k" -R $REPO -B $BRANCH --confirm
             done
           done
+          unset IFS


### PR DESCRIPTION
Make changes to handle the cases where the workflow names contain spaces. Note that none of the workflow names in amrex has spaces.
