### PR TITLE
Fix SuperParticle `push_back`

### DIFF
--- a/Src/Particle/AMReX_ParticleTile.H
+++ b/Src/Particle/AMReX_ParticleTile.H
@@ -912,7 +912,7 @@ struct ParticleTile
         }
 
         m_soa_tile.resize(np+1);
-        if constexpr (!ParticleType::is_soa_particle) {
+        if constexpr (ParticleType::is_soa_particle) {
             m_soa_tile.GetIdCPUData()[np] = sp.m_idcpu;
         }
         auto& arr_rdata = m_soa_tile.GetRealData();


### PR DESCRIPTION
## Summary

From #3585 commit: fixes a segfault for the legacy particle layout:
```
Thread 1 "python3" received signal SIGSEGV, Segmentation fault.
0x00007ffff5951e5c in amrex::ParticleTile<amrex::Particle<1, 1>, 2, 1, std::allocator>::push_back<2, 1, 0> (this=0x555555f206e0, sp=...) at /home/axel/src/pyamrex/build/_deps/fetchedamrex-src/Src/Particle/AMReX_ParticleTile.H:916
916	            m_soa_tile.GetIdCPUData()[np] = sp.m_idcpu;
```

## Additional background

X-ref: https://github.com/AMReX-Codes/pyamrex/pull/232

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
