### PR TITLE
Fix CI for ROCm 6.0

### DIFF
--- a/.github/workflows/dependencies/dependencies_hip.sh
+++ b/.github/workflows/dependencies/dependencies_hip.sh
@@ -43,7 +43,8 @@ sudo apt-get install -y --no-install-recommends \
     roctracer-dev   \
     rocprofiler-dev \
     rocrand-dev     \
-    rocprim-dev
+    rocprim-dev     \
+    hiprand-dev
 
 # activate
 #


### PR DESCRIPTION
Need to explicitly install hiprand package in CI because it's now a standalone project, not a submodule for rocRand according to the release notes.
