### PR TITLE
Bins: Index Type `int`

### DIFF
--- a/Src/Particle/AMReX_BinIterator.H
+++ b/Src/Particle/AMReX_BinIterator.H
@@ -22,7 +22,7 @@ constexpr bool IsParticleTileData (Args...) {
 template <typename T>
 struct BinIterator
 {
-    using index_type = unsigned int;
+    using index_type = int;
 
     using const_pointer_type = std::conditional_t<IsParticleTileData<T>(),
         T,

--- a/Src/Particle/AMReX_DenseBins.H
+++ b/Src/Particle/AMReX_DenseBins.H
@@ -30,7 +30,7 @@ namespace BinPolicy
 template <typename T>
 struct DenseBinIteratorFactory
 {
-    using index_type = unsigned int;
+    using index_type = int;
 
     using const_pointer_type = std::conditional_t<IsParticleTileData<T>(),
         T,
@@ -78,7 +78,7 @@ class DenseBins
 public:
 
     using BinIteratorFactory = DenseBinIteratorFactory<T>;
-    using index_type = unsigned int;
+    using index_type = int;
 
     using const_pointer_type = std::conditional_t<IsParticleTileData<T>(),
         T,

--- a/Src/Particle/AMReX_NeighborList.H
+++ b/Src/Particle/AMReX_NeighborList.H
@@ -310,8 +310,8 @@ public:
         m_pstruct = aos().dataPtr();
         auto* const pstruct_ptr = aos().dataPtr();
 
-        const size_t np_total = aos.size();
-        const size_t np_real  = src_tile.numRealParticles();
+        const int np_total = aos.size();
+        const int np_real  = src_tile.numRealParticles();
 
         auto const* off_bins_p = off_bins_v.data();
         auto const* dxi_p      = dxi_v.data();
@@ -333,7 +333,7 @@ public:
 
         // First pass: count the number of neighbors for each particle
         //---------------------------------------------------------------------------------------------------------
-        const size_t np_size  = (num_bin_types > 1) ? np_total : np_real;
+        const int np_size  = (num_bin_types > 1) ? np_total : np_real;
         m_nbor_counts.resize( np_size+1, 0);
         m_nbor_offsets.resize(np_size+1);
 

--- a/Src/Particle/AMReX_NeighborParticlesI.H
+++ b/Src/Particle/AMReX_NeighborParticlesI.H
@@ -1065,7 +1065,7 @@ selectActualNeighbors (CheckPair const& check_pair, int num_cells)
                             if (isActualNeighbor) { break; }
                             int nbr_cell_id = (ii * ny + jj) * nz + kk;
                             for (auto p = poffset[nbr_cell_id]; p < poffset[nbr_cell_id+1]; ++p) {
-                                if (pperm[p] == i) { continue; }
+                                if (pperm[p] == int(i)) { continue; }
                                 if (detail::call_check_pair(check_pair, ptile_data, ptile_data, i, pperm[p])) {
                                     IntVect cell_ijk = getParticleCell(pstruct[pperm[p]], plo, dxi, domain);
                                     if (!box.contains(cell_ijk)) {

--- a/Src/Particle/AMReX_SparseBins.H
+++ b/Src/Particle/AMReX_SparseBins.H
@@ -14,7 +14,7 @@ template <typename T>
 struct SparseBinIteratorFactory
 {
 
-    using index_type = unsigned int;
+    using index_type = int;
 
     using const_pointer_type = std::conditional_t<IsParticleTileData<T>(),
         T,
@@ -33,7 +33,7 @@ struct SparseBinIteratorFactory
         : m_bins_ptr(bins.dataPtr()),
           m_offsets_ptr(offsets.dataPtr()),
           m_permutation_ptr(permutation.dataPtr()),
-          m_items(items), m_num_bins(bins.size())
+          m_items(items), m_num_bins(int(bins.size()))
     {}
 
     [[nodiscard]] AMREX_GPU_HOST_DEVICE
@@ -97,7 +97,7 @@ public:
 
     using BinIteratorFactory = SparseBinIteratorFactory<T>;
     using bin_type = IntVect;
-    using index_type = unsigned int;
+    using index_type = int;
 
     using const_pointer_type = std::conditional_t<IsParticleTileData<T>(),
         T,


### PR DESCRIPTION
## Summary

For performance reasons, `int`/`long` are better index types since they do not have over/underflow checks and thus vectorize better.

Also, I see narrowing warnings casting from `int` to AMReX' `unsigned int` in WarpX.

## Additional background

Seen with clang-tidy in https://github.com/ECP-WarpX/WarpX/pull/3850

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
