### PR TITLE
Add special named flag for invalid particles

### DIFF
--- a/Src/Particle/AMReX_Particle.H
+++ b/Src/Particle/AMReX_Particle.H
@@ -22,7 +22,6 @@ namespace
         constexpr Long LastParticleID = GhostParticleID - 2;
         constexpr Long DoSplitParticleID = GhostParticleID - 3;
         constexpr Long NoSplitParticleID = GhostParticleID - 4;
-        constexpr Long InvalidParticleID = 16777216;  // corresponds to id = -1, cpu = 0
     }
 
     using namespace LongParticleIds;

--- a/Src/Particle/AMReX_Particle.H
+++ b/Src/Particle/AMReX_Particle.H
@@ -15,13 +15,14 @@ namespace amrex {
 
 namespace
 {
-    /** Used for 64bit Long particle Ids as in AoS layout */
+    /** Special flags used for 64-bit Long particle Ids */
     namespace LongParticleIds {
         constexpr Long GhostParticleID = 549755813887L; // 2**39-1
         constexpr Long VirtualParticleID = GhostParticleID - 1;
         constexpr Long LastParticleID = GhostParticleID - 2;
         constexpr Long DoSplitParticleID = GhostParticleID - 3;
         constexpr Long NoSplitParticleID = GhostParticleID - 4;
+        constexpr Long InvalidParticleID = 16777216;
     }
 
     using namespace LongParticleIds;

--- a/Src/Particle/AMReX_Particle.H
+++ b/Src/Particle/AMReX_Particle.H
@@ -22,7 +22,7 @@ namespace
         constexpr Long LastParticleID = GhostParticleID - 2;
         constexpr Long DoSplitParticleID = GhostParticleID - 3;
         constexpr Long NoSplitParticleID = GhostParticleID - 4;
-        constexpr Long InvalidParticleID = 16777216;
+        constexpr Long InvalidParticleID = 16777216;  // corresponds to id = -1, cpu = 0
     }
 
     using namespace LongParticleIds;

--- a/Src/Particle/AMReX_Particle.H
+++ b/Src/Particle/AMReX_Particle.H
@@ -32,6 +32,8 @@ namespace
     namespace ParticleIdCpus {
         constexpr std::uint64_t Invalid = 16777216; // corresponds to id = -1, cpu = 0
     }
+
+    using namespace ParticleIdCpus;
 }
 
 struct ParticleIDWrapper

--- a/Src/Particle/AMReX_Particle.H
+++ b/Src/Particle/AMReX_Particle.H
@@ -26,6 +26,13 @@ namespace
     }
 
     using namespace LongParticleIds;
+
+    /** Flags used to set the entire uint64_t idcpu
+        to special values at once.
+     */
+    namespace ParticleIdCpus {
+        constexpr std::uint64_t Invalid = 16777216; // corresponds to id = -1, cpu = 0
+    }
 }
 
 struct ParticleIDWrapper


### PR DESCRIPTION
This lets you do 

`p.m_idcpu = LongParticleIDs::InvalidParticleID;` 

instead of 

`amrex::ParticleIDWrapper{p.m_idcpu} = -1;`

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
