### PR TITLE
Fix Advection_AmrCore test

### DIFF
--- a/Tests/Amr/Advection_AmrCore/Source/AmrCoreAdv.H
+++ b/Tests/Amr/Advection_AmrCore/Source/AmrCoreAdv.H
@@ -87,7 +87,7 @@ public:
     amrex::Real EstTimeStep (int lev, amrex::Real time);
 
 #ifdef AMREX_PARTICLES
-    static amrex::AmrTracerParticleContainer* theTracerPC () { return TracerPC.get(); }
+    amrex::AmrTracerParticleContainer* theTracerPC () { return TracerPC.get(); }
 #endif
 
 
@@ -217,8 +217,8 @@ private:
 
 #ifdef AMREX_PARTICLES
     void init_particles ();
-    static int       do_tracers;
-    static std::unique_ptr<amrex::AmrTracerParticleContainer> TracerPC;
+    int       do_tracers = 0;
+    std::unique_ptr<amrex::AmrTracerParticleContainer> TracerPC;
 #endif
 };
 

--- a/Tests/Amr/Advection_AmrCore/Source/AmrCoreAdv.cpp
+++ b/Tests/Amr/Advection_AmrCore/Source/AmrCoreAdv.cpp
@@ -15,14 +15,6 @@
 
 using namespace amrex;
 
-
-
-#ifdef AMREX_PARTICLES
-std::unique_ptr<AmrTracerParticleContainer> AmrCoreAdv::TracerPC =  nullptr;
-int AmrCoreAdv::do_tracers = 0;
-#endif
-
-
 // constructor - reads in parameters from inputs file
 //             - sizes multilevel arrays and data structures
 //             - initializes BCRec boundary condition object


### PR DESCRIPTION
The particle container should not be a static member, because it's a member of a class derived from AmrCore, not AmrLevel. The issue of its being a static member is that it is not deleted properly (unless we explicitly do it).

Note that in the AmrLevel case we must make it a static member because all AmrLevel objects need to share the same particle container.
