### PR TITLE
Follow-on to #3701

### DIFF
--- a/Src/Base/AMReX_Extension.H
+++ b/Src/Base/AMReX_Extension.H
@@ -138,9 +138,9 @@
 #define AMREX_TO_STRING(X)          AMREX_TO_STRING_HELPER(X)
 
 #if defined(__clang__) || defined(__CUDACC__) || defined(__HIP__) || defined(__INTEL_CLANG_COMPILER)
-#define AMREX_UNROLL_LOOP(n)  _Pragma(AMREX_TO_STRING(unroll (n)))
+#define AMREX_UNROLL_LOOP(n)  _Pragma(AMREX_TO_STRING(unroll n))
 #elif defined(__GNUC__)
-#define AMREX_UNROLL_LOOP(n)  _Pragma(AMREX_TO_STRING(GCC unroll (n)))
+#define AMREX_UNROLL_LOOP(n)  _Pragma(AMREX_TO_STRING(GCC unroll n))
 #else
 #define AMREX_UNROLL_LOOP(n)
 #endif


### PR DESCRIPTION
The parenthesis are not needed and some compilers warn about them.

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
