### PR TITLE
Revert "add a dependabot.yml to checkout github actions versions (#3704)"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,0 @@
-# Dependabot configuration
-# ref: https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates
-version: 2
-updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "weekly"


### PR DESCRIPTION
This reverts commit 53a581cc802734846f1c102e593bddb828922cf0.

It creates too much noise for forks, and it cannot be disabled for forks.

Another issue. It appears that it just called docs.yml and push a new branch "main" to AMReX-Codes/amrex, not AMReX-Codes/AMReX-Codes.github.io.