### PR TITLE
GNU Make: Link flags

### DIFF
--- a/Tools/GNUMake/sites/Make.unknown
+++ b/Tools/GNUMake/sites/Make.unknown
@@ -59,6 +59,10 @@ ifeq ($(USE_MPI),TRUE)
      mpi_link_flags := $(filter-out $(mpi_filter), $(mpi_link_flags))
   endif
 
+  # Some wrappers include `-fallow-argument-mismatch`, `-g` etc in the link line info.
+  mpi_link_flags := $(filter-out -f%,$(mpi_link_flags))
+  mpi_link_flags := $(filter-out -g%,$(mpi_link_flags))
+
   LIBRARIES += $(mpi_link_flags)
   ifneq ($(MPI_OTHER_COMP),mpicxx)
     LIBRARIES += $(mpicxx_link_libs)


### PR DESCRIPTION
The link information returned by mpich may include some compiler flags like `-fallow-argument-mismatch -g`. On Mac, this causes an issue for the clang based linker because `-fallow-argument-mismatch` is a gfortran flag. So we need to filter them out.