### PR TITLE
Fix circular header file dependency

### DIFF
--- a/Src/Base/AMReX_BaseFab.H
+++ b/Src/Base/AMReX_BaseFab.H
@@ -19,6 +19,7 @@
 #include <AMReX_Utility.H>
 #include <AMReX_Reduce.H>
 #include <AMReX_Gpu.H>
+#include <AMReX_Scan.H>
 #include <AMReX_Math.H>
 #include <AMReX_OpenMP.H>
 #include <AMReX_MemPool.H>

--- a/Src/Base/AMReX_GpuContainers.H
+++ b/Src/Base/AMReX_GpuContainers.H
@@ -5,7 +5,6 @@
 #include <AMReX_Vector.H>
 #include <AMReX_PODVector.H>
 #include <AMReX_GpuAllocators.H>
-#include <AMReX_Scan.H>
 #include <type_traits>
 
 #include <numeric>

--- a/Src/Particle/AMReX_DenseBins.H
+++ b/Src/Particle/AMReX_DenseBins.H
@@ -3,6 +3,7 @@
 #include <AMReX_Config.H>
 
 #include <AMReX_Gpu.H>
+#include <AMReX_Scan.H>
 #include <AMReX_IntVect.H>
 #include <AMReX_BLProfiler.H>
 #include <AMReX_BinIterator.H>

--- a/Src/Particle/AMReX_NeighborList.H
+++ b/Src/Particle/AMReX_NeighborList.H
@@ -1,5 +1,5 @@
-#ifndef NEIGHBOR_LIST_H_
-#define NEIGHBOR_LIST_H_
+#ifndef AMREX_NEIGHBOR_LIST_H_
+#define AMREX_NEIGHBOR_LIST_H_
 #include <AMReX_Config.H>
 
 #include <AMReX_Particles.H>

--- a/Src/Particle/AMReX_ParticleCommunication.H
+++ b/Src/Particle/AMReX_ParticleCommunication.H
@@ -7,6 +7,7 @@
 #include <AMReX_IntVect.H>
 #include <AMReX_ParticleBufferMap.H>
 #include <AMReX_MFIter.H>
+#include <AMReX_Scan.H>
 #include <AMReX_TypeTraits.H>
 #include <AMReX_MakeParticle.H>
 


### PR DESCRIPTION
AMReX_GpuContainers.H included AMReX_Scan.H, which in turn includes AMReX_Gpu.H, which in turn includes AMReX_GpuContainers.H.

In this PR, AMReX_Scan.H is removed from AMReX_GpuContainers.H, because it does not need it.

Thanks to @zingale and clang-tidy.
