### PR TITLE
Disable SYCL on Nvidia and AMD CIs

### DIFF
--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -97,6 +97,7 @@ jobs:
   tests-oneapi-sycl-eb-nvidia:
     name: oneAPI SYCL for Nvidia GPUs [tests w/ EB]
     runs-on: ubuntu-latest
+    if: 0
     steps:
     - uses: actions/checkout@v4
     - name: Dependencies
@@ -143,6 +144,7 @@ jobs:
   no-tests-oneapi-sycl-amd:
     name: oneAPI SYCL for AMD GPUs
     runs-on: ubuntu-20.04
+    if: 0
     steps:
     - uses: actions/checkout@v4
     - name: Dependencies


### PR DESCRIPTION
The Codeplay APT has stopped working for a few weeks now. It fails with error messages like

    The following packages have unmet dependencies:
     oneapi-nvidia-12.0 : Depends: intel-basekit (>= 2024.0.2) but it is not going to be installed
    E: Unable to correct problems, you have held broken packages.
    Error: Process completed with exit code 1.

To avoid confusion, let's disable them for now.