### PR TITLE
Fix: `MPI_Comm_free(MPI_COMM_NULL)`

### DIFF
--- a/Src/Base/AMReX_ParallelContext.H
+++ b/Src/Base/AMReX_ParallelContext.H
@@ -106,7 +106,7 @@ inline void set_last_frame_ofs (const std::string & filename) {
 }
 //! Note that it's the user's responsibility to free the MPI_Comm
 inline void pop () {
-    if (frames.size() > 0) {
+    if (!frames.empty()) {
         frames.pop_back();
     }
 }

--- a/Src/Base/AMReX_ParallelContext.H
+++ b/Src/Base/AMReX_ParallelContext.H
@@ -106,7 +106,7 @@ inline void set_last_frame_ofs (const std::string & filename) {
 }
 //! Note that it's the user's responsibility to free the MPI_Comm
 inline void pop () {
-    if (frames.size() > 0u) {
+    if (frames.size() > 0) {
         frames.pop_back();
     }
 }

--- a/Src/Base/AMReX_ParallelContext.H
+++ b/Src/Base/AMReX_ParallelContext.H
@@ -105,7 +105,11 @@ inline void set_last_frame_ofs (const std::string & filename) {
     frames.back().set_ofs_name(filename);
 }
 //! Note that it's the user's responsibility to free the MPI_Comm
-inline void pop () { frames.pop_back(); }
+inline void pop () {
+    if (frames.size() > 0u) {
+        frames.pop_back();
+    }
+}
 
 }
 

--- a/Src/Base/AMReX_ParallelDescriptor.cpp
+++ b/Src/Base/AMReX_ParallelDescriptor.cpp
@@ -428,7 +428,7 @@ EndParallel ()
         m_mpi_ops.clear();
     }
 
-    if (!call_mpi_finalize) {
+    if (!call_mpi_finalize && m_comm != MPI_COMM_NULL) {
         BL_MPI_REQUIRE( MPI_Comm_free(&m_comm) );
     }
     m_comm = MPI_COMM_NULL;


### PR DESCRIPTION
## Summary

Avoid that a minimal cycle of MPI and AMReX init and finalize segfaults.

Situation: compiled with MPI, but run serially.

## Additional background

First seen in https://github.com/ECP-WarpX/impactx/pull/510

for the `test_impactx_module` pytest.

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
