### PR TITLE
ParticleCopyPlan for SoA Particles

### DIFF
--- a/Src/Particle/AMReX_ParticleCommunication.H
+++ b/Src/Particle/AMReX_ParticleCommunication.H
@@ -220,9 +220,13 @@ struct ParticleCopyPlan
             if (int_comp_mask[i])  {++num_int_comm_comp;}
         }
 
-        m_superparticle_size = sizeof(typename PC::ParticleType)
-                             + num_real_comm_comp * sizeof(typename PC::ParticleType::RealType)
-                             + num_int_comm_comp  * sizeof(int);
+        if constexpr (PC::ParticleType::is_soa_particle) {
+            m_superparticle_size = sizeof(uint64_t);  // idcpu
+        } else {
+            m_superparticle_size = sizeof(typename PC::ParticleType);
+        }
+        m_superparticle_size += num_real_comm_comp * sizeof(typename PC::ParticleType::RealType)
+                              + num_int_comm_comp  * sizeof(int);
 
         buildMPIStart(pc.BufferMap(), m_superparticle_size);
     }

--- a/Src/Particle/AMReX_ParticleTransformation.H
+++ b/Src/Particle/AMReX_ParticleTransformation.H
@@ -81,7 +81,11 @@ void copyParticle (const ParticleTileData<T_ParticleType, NAR, NAI>& dst,
     AMREX_ASSERT(dst.m_num_runtime_real == src.m_num_runtime_real);
     AMREX_ASSERT(dst.m_num_runtime_int  == src.m_num_runtime_int );
 
-    dst.m_aos[dst_i] = src.m_aos[src_i];
+    if constexpr(!T_ParticleType::is_soa_particle) {
+        dst.m_aos[dst_i] = src.m_aos[src_i];
+    } else {
+        dst.m_idcpu[dst_i] = src.m_idcpu[src_i];
+    }
     for (int j = 0; j < NAR; ++j) {
         dst.m_rdata[j][dst_i] = src.m_rdata[j][src_i];
     }
@@ -119,7 +123,11 @@ void swapParticle (const ParticleTileData<T_ParticleType, NAR, NAI>& dst,
     AMREX_ASSERT(dst.m_num_runtime_real == src.m_num_runtime_real);
     AMREX_ASSERT(dst.m_num_runtime_int  == src.m_num_runtime_int );
 
-    amrex::Swap(src.m_aos[src_i], dst.m_aos[dst_i]);
+    if constexpr(!T_ParticleType::is_soa_particle) {
+        amrex::Swap(src.m_aos[src_i], dst.m_aos[dst_i]);
+    } else {
+        amrex::Swap(src.m_idcpu[src_i], dst.m_idcpu[dst_i]);
+    }
     for (int j = 0; j < NAR; ++j) {
         amrex::Swap(dst.m_rdata[j][dst_i], src.m_rdata[j][src_i]);
     }

--- a/Src/Particle/AMReX_ParticleTransformation.H
+++ b/Src/Particle/AMReX_ParticleTransformation.H
@@ -81,10 +81,10 @@ void copyParticle (const ParticleTileData<T_ParticleType, NAR, NAI>& dst,
     AMREX_ASSERT(dst.m_num_runtime_real == src.m_num_runtime_real);
     AMREX_ASSERT(dst.m_num_runtime_int  == src.m_num_runtime_int );
 
-    if constexpr(!T_ParticleType::is_soa_particle) {
-        dst.m_aos[dst_i] = src.m_aos[src_i];
-    } else {
+    if constexpr(T_ParticleType::is_soa_particle) {
         dst.m_idcpu[dst_i] = src.m_idcpu[src_i];
+    } else {
+        dst.m_aos[dst_i] = src.m_aos[src_i];
     }
     for (int j = 0; j < NAR; ++j) {
         dst.m_rdata[j][dst_i] = src.m_rdata[j][src_i];
@@ -123,10 +123,10 @@ void swapParticle (const ParticleTileData<T_ParticleType, NAR, NAI>& dst,
     AMREX_ASSERT(dst.m_num_runtime_real == src.m_num_runtime_real);
     AMREX_ASSERT(dst.m_num_runtime_int  == src.m_num_runtime_int );
 
-    if constexpr(!T_ParticleType::is_soa_particle) {
-        amrex::Swap(src.m_aos[src_i], dst.m_aos[dst_i]);
-    } else {
+    if constexpr(T_ParticleType::is_soa_particle) {
         amrex::Swap(src.m_idcpu[src_i], dst.m_idcpu[dst_i]);
+    } else {
+        amrex::Swap(src.m_aos[src_i], dst.m_aos[dst_i]);
     }
     for (int j = 0; j < NAR; ++j) {
         amrex::Swap(dst.m_rdata[j][dst_i], src.m_rdata[j][src_i]);


### PR DESCRIPTION
## Summary

Update `ParticleCopyPlan::build` for pure SoA particle layout.

## Additional background

- [x] testing on GPU in https://github.com/ECP-WarpX/WarpX/pull/4653

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
