### PR TITLE
Do not use std::forward twice on the same object in AmrParticleLocator

### DIFF
--- a/Src/Particle/AMReX_ParticleLocator.H
+++ b/Src/Particle/AMReX_ParticleLocator.H
@@ -220,13 +220,13 @@ struct AmrAssignGrid
 
         for (int lev = lev_max; lev >= lev_min; --lev)
         {
-            int grid = m_funcs[lev](p, 0, std::forward<Assignor>(assignor));
+            int grid = m_funcs[lev](p, 0, assignor);
             if (grid >= 0) { return makeTuple(grid, lev); }
         }
 
         for (int lev = lev_min; lev >= lev_min; --lev)
         {
-            int grid = m_funcs[lev](p, nGrow, std::forward<Assignor>(assignor));
+            int grid = m_funcs[lev](p, nGrow, assignor);
             if (grid >= 0) { return makeTuple(grid, lev); }
         }
 


### PR DESCRIPTION
Bug found by @WeiqunZhang 

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
