### PR TITLE
Add `ParticleIDWrapper::make_invalid()`

### DIFF
--- a/Src/Particle/AMReX_Particle.H
+++ b/Src/Particle/AMReX_Particle.H
@@ -102,6 +102,41 @@ struct ParticleIDWrapper
         r = (sign) ? lval : -lval;
         return r;
     }
+
+    /** Mark the particle as invalid
+     *
+     * Swaps the is_valid (sign) bit to invalid.
+     * This is NOT identical to id = -id, but it is equally reversible via make_valid().
+     */
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    void make_invalid () noexcept
+    {
+        // RHS mask: 0111...
+        m_idata &= ~(uint64_t(1) << 63);
+    }
+
+    /** Mark the particle as valid
+     *
+     * Swaps the is_valid (sign) bit to valid.
+     * This is NOT identical to id = -id, but it is equally reversible via make_invalid().
+     */
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    void make_valid () noexcept
+    {
+        // RHS mask: 1000...
+        m_idata |= uint64_t(1) << 63;
+    }
+
+    /** Check the particle is valid, via the sign of the id.
+     *
+     * Returns true if the particle is valid (the id is positive), otherwise false (invalid particle).
+     */
+    [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    bool is_valid () const noexcept
+    {
+        // the leftmost bit is our id's valid sign
+        return m_idata >> 63;
+    }
 };
 
 struct ParticleCPUWrapper
@@ -172,6 +207,17 @@ struct ConstParticleIDWrapper
         Long lval = static_cast<Long>(val);  // bc we take -
         r = (sign) ? lval : -lval;
         return r;
+    }
+
+    /** Check the sign of the id.
+     *
+     * Returns true if the id is positive, otherwise false (invalid particle).
+     */
+    [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    bool is_valid () const noexcept
+    {
+        // the leftmost bit is our id's valid sign
+        return m_idata >> 63;
     }
 };
 


### PR DESCRIPTION
## Summary

A cheaper way to swap validity sign on particle ids, as needed to select and track particles from one kernel to another (e.g., boundary condition treatment, re-emission physics, scraping of particles, etc.).

With our current encoding, `ParticleIDWrapper::make_invalid()` is the same as `id = -id`, but cheaper.

Improvements:
- less code emitted, faster execution
- less code emitted, less instructions to store for occupancy limits on GPU
- faster, streamlined code: no jump calls
- explicit valid/invalid calls instead of swaps with input-dependent outcome

## Additional background

### Host Code

https://godbolt.org/z/KPjzExWz1

![id_flips](https://github.com/AMReX-Codes/amrex/assets/1353258/14b3deef-1431-4377-b7de-982b6451184a)

### CUDA Device Code

PTX: https://godbolt.org/z/6En5rK14o
SASS for SM_80: https://godbolt.org/z/d6zYfxaKG

- validation: old/new are same register usage and cost; new code uses a few less logical ops
- mark_(in)valid vs. `id = -id`: now saves 4 registers :tada: 
  - this is the one we often use in already heavy physics kernels - a win for occupancy

Interesting: there are still no 64bit shifts / but shuffles in CUDA hardware...

```
ptxas info    : 0 bytes gmem
ptxas info    : Compiling entry function '_Z12new_is_validPmPd' for 'sm_80'
ptxas info    : Function properties for _Z12new_is_validPmPd
    0 bytes stack frame, 0 bytes spill stores, 0 bytes spill loads
ptxas info    : Used 8 registers, 368 bytes cmem[0]

ptxas info    : Compiling entry function '_Z12old_is_validPmPd' for 'sm_80'
ptxas info    : Function properties for _Z12old_is_validPmPd
    0 bytes stack frame, 0 bytes spill stores, 0 bytes spill loads
ptxas info    : Used 8 registers, 368 bytes cmem[0]

ptxas info    : Compiling entry function '_Z14new_make_validPm' for 'sm_80'
ptxas info    : Function properties for _Z14new_make_validPm
    0 bytes stack frame, 0 bytes spill stores, 0 bytes spill loads
ptxas info    : Used 8 registers, 360 bytes cmem[0]

ptxas info    : Compiling entry function '_Z16new_make_invalidPm' for 'sm_80'
ptxas info    : Function properties for _Z16new_make_invalidPm
    0 bytes stack frame, 0 bytes spill stores, 0 bytes spill loads
ptxas info    : Used 8 registers, 360 bytes cmem[0]

ptxas info    : Compiling entry function '_Z15old_invert_signPm' for 'sm_80'
ptxas info    : Function properties for _Z15old_invert_signPm
    0 bytes stack frame, 0 bytes spill stores, 0 bytes spill loads
ptxas info    : Used 12 registers, 360 bytes cmem[0]
```

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
