### PR TITLE
[Draft] Simplify idcpu

### DIFF
--- a/Src/Particle/AMReX_Particle.H
+++ b/Src/Particle/AMReX_Particle.H
@@ -67,40 +67,31 @@ struct ParticleIDWrapper
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     ParticleIDWrapper& operator= (const Long id) noexcept
     {
-        // zero out the 40 leftmost bits, which store the sign and the abs of the id;
+        // zero out the 40 leftmost bits, store the id including its sign bit (0: +, 1: -)
         m_idata &= 0x00FFFFFF;
 
-        uint64_t val;
-        uint64_t sign = id >= 0;
-        if (sign)
-        {
-            // 2**39-1, the max value representable in this fashion
-            AMREX_ASSERT(id <= 549755813887L);
-            val = id;
-        }
-        else
-        {
-            // -2**39-1, the min value representable in this fashion
-            AMREX_ASSERT(id >= -549755813887L);
-            val = -id;
-        }
+        // note: although right-shifts of the sign-bit are implementation-
+        //       defined (arightmetic or logical), this operation will give the same result
+        int64_t const sign = (m_idata >> 63) << 63;  // leave only leftmost sign bit
 
-        m_idata |= (sign << 63);  // put the sign in the leftmost bit
-        m_idata |= (val << 24);   // put the val in the next 39
+        // flip to have ownly lowermost bits filled
+        int64_t const abs_id = std::abs(id);
+
+        // +/-2**39-1, the max value representable in this fashion
+        AMREX_ASSERT(abs_id <= 549755813887L);
+
+        m_idata |= sign | (id << 24);   // put the id in the 40 uppermost bits
         return *this;
     }
 
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     operator Long () const noexcept
     {
-        Long r = 0;
+        // remove uppermost bit
+        // extract next 39 id bits
+        int64_t const val  = (m_idata | uint64_t(1) << 63 ) >> 24;
 
-        uint64_t sign = m_idata >> 63;  // extract leftmost sign bit
-        uint64_t val  = ((m_idata >> 24) & 0x7FFFFFFFFF);  // extract next 39 id bits
-
-        Long lval = static_cast<Long>(val);  // bc we take -
-        r = (sign) ? lval : -lval;
-        return r;
+        return m_idata > 0 ? val : -val;
     }
 
     /** Mark the particle as invalid
@@ -111,8 +102,8 @@ struct ParticleIDWrapper
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     void make_invalid () noexcept
     {
-        // RHS mask: 0111...
-        m_idata &= ~(uint64_t(1) << 63);
+        // RHS mask: 1000...
+        m_idata |= uint64_t(1) << 63;
     }
 
     /** Mark the particle as valid
@@ -123,8 +114,9 @@ struct ParticleIDWrapper
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     void make_valid () noexcept
     {
-        // RHS mask: 1000...
-        m_idata |= uint64_t(1) << 63;
+
+        // RHS mask: 0111...
+        m_idata &= ~(uint64_t(1) << 63);
     }
 
     /** Check the particle is valid, via the sign of the id.
@@ -135,7 +127,7 @@ struct ParticleIDWrapper
     bool is_valid () const noexcept
     {
         // the leftmost bit is our id's valid sign
-        return m_idata >> 63;
+        return !(m_idata >> 63);
     }
 };
 
@@ -199,14 +191,11 @@ struct ConstParticleIDWrapper
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     operator Long () const noexcept
     {
-        Long r = 0;
+        // remove uppermost bit
+        // extract next 39 id bits
+        int64_t const val  = (m_idata | uint64_t(1) << 63 ) >> 24;
 
-        uint64_t sign = m_idata >> 63;  // extract leftmost sign bit
-        uint64_t val  = ((m_idata >> 24) & 0x7FFFFFFFFF);  // extract next 39 id bits
-
-        Long lval = static_cast<Long>(val);  // bc we take -
-        r = (sign) ? lval : -lval;
-        return r;
+        return m_idata > 0 ? val : -val;
     }
 
     /** Check the sign of the id.

--- a/Src/Particle/AMReX_Particle.H
+++ b/Src/Particle/AMReX_Particle.H
@@ -26,11 +26,11 @@ namespace
 
     using namespace LongParticleIds;
 
-    /** Flags used to set the entire uint64_t idcpu
+    /** Flags used to set the entire int64_t idcpu
         to special values at once.
      */
     namespace ParticleIdCpus {
-        constexpr std::uint64_t Invalid = 16777216; // corresponds to id = -1, cpu = 0
+        constexpr std::int64_t Invalid = -16777216LL; // corresponds to id = -1, cpu = 0
     }
 
     using namespace ParticleIdCpus;
@@ -38,12 +38,12 @@ namespace
 
 struct ParticleIDWrapper
 {
-    uint64_t& m_idata;
+    int64_t& m_idata;
 
     ~ParticleIDWrapper () noexcept = default;
 
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-    ParticleIDWrapper (uint64_t& idata) noexcept
+    ParticleIDWrapper (int64_t& idata) noexcept
         : m_idata(idata)
     {}
 
@@ -89,7 +89,7 @@ struct ParticleIDWrapper
     {
         // remove uppermost bit
         // extract next 39 id bits
-        int64_t const val  = (m_idata | uint64_t(1) << 63 ) >> 24;
+        int64_t const val  = (m_idata | int64_t(1) << 63 ) >> 24;
 
         return m_idata > 0 ? val : -val;
     }
@@ -103,7 +103,7 @@ struct ParticleIDWrapper
     void make_invalid () noexcept
     {
         // RHS mask: 1000...
-        m_idata |= uint64_t(1) << 63;
+        m_idata |= int64_t(1) << 63;
     }
 
     /** Mark the particle as valid
@@ -116,7 +116,7 @@ struct ParticleIDWrapper
     {
 
         // RHS mask: 0111...
-        m_idata &= ~(uint64_t(1) << 63);
+        m_idata &= ~(int64_t(1) << 63);
     }
 
     /** Check the particle is valid, via the sign of the id.
@@ -133,12 +133,12 @@ struct ParticleIDWrapper
 
 struct ParticleCPUWrapper
 {
-    uint64_t& m_idata;
+    int64_t& m_idata;
 
     ~ParticleCPUWrapper () noexcept = default;
 
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-    ParticleCPUWrapper (uint64_t& idata) noexcept
+    ParticleCPUWrapper (int64_t& idata) noexcept
         : m_idata(idata)
     {}
 
@@ -181,10 +181,10 @@ struct ParticleCPUWrapper
 
 struct ConstParticleIDWrapper
 {
-    const uint64_t& m_idata;
+    const int64_t& m_idata;
 
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-    ConstParticleIDWrapper (const uint64_t& idata) noexcept
+    ConstParticleIDWrapper (const int64_t& idata) noexcept
         : m_idata(idata)
     {}
 
@@ -193,7 +193,7 @@ struct ConstParticleIDWrapper
     {
         // remove uppermost bit
         // extract next 39 id bits
-        int64_t const val  = (m_idata | uint64_t(1) << 63 ) >> 24;
+        int64_t const val  = (m_idata | int64_t(1) << 63 ) >> 24;
 
         return m_idata > 0 ? val : -val;
     }
@@ -212,10 +212,10 @@ struct ConstParticleIDWrapper
 
 struct ConstParticleCPUWrapper
 {
-    const uint64_t& m_idata;
+    const int64_t& m_idata;
 
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-    ConstParticleCPUWrapper (const uint64_t& idata) noexcept
+    ConstParticleCPUWrapper (const int64_t& idata) noexcept
         : m_idata(idata)
     {}
 
@@ -229,8 +229,8 @@ struct ConstParticleCPUWrapper
  * to avoid writing twice into the same memory bank.
  */
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-std::uint64_t SetParticleIDandCPU (Long id, int cpu) noexcept{
-    std::uint64_t idcpu = 0;
+std::int64_t SetParticleIDandCPU (Long id, int cpu) noexcept{
+    std::int64_t idcpu = 0;
     ParticleIDWrapper{idcpu} = id;
     ParticleCPUWrapper{idcpu} = cpu;
     return idcpu;
@@ -241,7 +241,7 @@ struct ParticleBase
 {
     T m_pos[AMREX_SPACEDIM];
     T m_rdata[NReal];
-    uint64_t m_idcpu = 0;
+    int64_t m_idcpu = 0;
     int m_idata[NInt];
 };
 
@@ -249,7 +249,7 @@ template <typename T, int NInt>
 struct ParticleBase<T,0,NInt>
 {
     T m_pos[AMREX_SPACEDIM];
-    uint64_t m_idcpu = 0;
+    int64_t m_idcpu = 0;
     int m_idata[NInt];
 };
 
@@ -258,14 +258,14 @@ struct ParticleBase<T,NReal,0>
 {
     T m_pos[AMREX_SPACEDIM];
     T m_rdata[NReal];
-    uint64_t m_idcpu = 0;
+    int64_t m_idcpu = 0;
 };
 
 template <typename T>
 struct ParticleBase<T,0,0>
 {
     T m_pos[AMREX_SPACEDIM];
-    uint64_t m_idcpu = 0;
+    int64_t m_idcpu = 0;
 };
 
 
@@ -314,7 +314,7 @@ struct Particle
 
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     void atomicSetID (const Long id) {
-        uint64_t tmp = 0;
+        int64_t tmp = 0;
         ParticleIDWrapper wrapper(tmp);
         wrapper = id;
 #if defined(AMREX_USE_OMP)
@@ -424,7 +424,7 @@ struct Particle
 
     template <int U = T_NInt, typename std::enable_if<U == 0, int>::type = 0>
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-    uint64_t& idata (int /*index*/) &
+    int64_t& idata (int /*index*/) &
     {
         AMREX_ALWAYS_ASSERT(false);
         return this->m_idcpu;  //bc we must return something

--- a/Src/Particle/AMReX_ParticleCommunication.H
+++ b/Src/Particle/AMReX_ParticleCommunication.H
@@ -221,7 +221,7 @@ struct ParticleCopyPlan
         }
 
         if constexpr (PC::ParticleType::is_soa_particle) {
-            m_superparticle_size = sizeof(uint64_t);  // idcpu
+            m_superparticle_size = sizeof(int64_t);  // idcpu
         } else {
             m_superparticle_size = sizeof(typename PC::ParticleType);
         }

--- a/Src/Particle/AMReX_ParticleContainerI.H
+++ b/Src/Particle/AMReX_ParticleContainerI.H
@@ -19,7 +19,7 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
     }
 
     if constexpr (ParticleType::is_soa_particle) {
-        particle_size = sizeof(uint64_t);  // idcpu
+        particle_size = sizeof(int64_t);  // idcpu
     } else {
         particle_size = sizeof(ParticleType);
     }
@@ -1098,7 +1098,7 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
         if constexpr (!ParticleType::is_soa_particle) {
             static_assert(sizeof(ParticleType)%4 == 0 && sizeof(uint32_t) == 4);
             using tmp_t = std::conditional_t<sizeof(ParticleType)%8 == 0,
-                                             uint64_t, uint32_t>;
+                                             int64_t, uint32_t>;
             constexpr std::size_t nchunks = sizeof(ParticleType) / sizeof(tmp_t);
             Gpu::DeviceVector<tmp_t> tmp(np);
             auto* ptmp = tmp.data();
@@ -1722,8 +1722,8 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
 
                             char* dst = &particles_to_send[old_size];
                             {
-                                std::memcpy(dst, &soa.GetIdCPUData()[pindex], sizeof(uint64_t));
-                                dst += sizeof(uint64_t);
+                                std::memcpy(dst, &soa.GetIdCPUData()[pindex], sizeof(int64_t));
+                                dst += sizeof(int64_t);
                             }
                             int array_comp_start = AMREX_SPACEDIM + NStructReal;
                             for (int comp = 0; comp < NumRealComps(); comp++) {
@@ -2067,10 +2067,10 @@ RedistributeMPI (std::map<int, Vector<char> >& not_ours,
                 Particle<NStructReal, NStructInt> p;
 
                 if constexpr (ParticleType::is_soa_particle) {
-                    std::memcpy(&p.m_idcpu, pbuf, sizeof(uint64_t));
+                    std::memcpy(&p.m_idcpu, pbuf, sizeof(int64_t));
 
                     ParticleReal pos[AMREX_SPACEDIM];
-                    std::memcpy(&pos[0], pbuf + sizeof(uint64_t), AMREX_SPACEDIM*sizeof(ParticleReal));
+                    std::memcpy(&pos[0], pbuf + sizeof(int64_t), AMREX_SPACEDIM*sizeof(ParticleReal));
                     AMREX_D_TERM(p.pos(0) = pos[0];,
                                  p.pos(1) = pos[1];,
                                  p.pos(2) = pos[2]);
@@ -2115,9 +2115,9 @@ RedistributeMPI (std::map<int, Vector<char> >& not_ours,
                 char* pbuf = ((char*) &recvdata[offset]) + j*superparticle_size;
 
                 if constexpr (ParticleType::is_soa_particle) {
-                    uint64_t idcpudata;
-                    std::memcpy(&idcpudata, pbuf, sizeof(uint64_t));
-                    pbuf += sizeof(uint64_t);
+                    int64_t idcpudata;
+                    std::memcpy(&idcpudata, pbuf, sizeof(int64_t));
+                    pbuf += sizeof(int64_t);
                     ptile.GetStructOfArrays().GetIdCPUData().push_back(idcpudata);
                 } else {
                     ParticleType p;
@@ -2168,7 +2168,7 @@ RedistributeMPI (std::map<int, Vector<char> >& not_ours,
         host_int_attribs.reserve(15);
         host_int_attribs.resize(finestLevel()+1);
 
-        Vector<std::map<std::pair<int, int>, Gpu::HostVector<uint64_t> > > host_idcpu;
+        Vector<std::map<std::pair<int, int>, Gpu::HostVector<int64_t> > > host_idcpu;
         host_idcpu.reserve(15);
         host_idcpu.resize(finestLevel()+1);
 
@@ -2189,9 +2189,9 @@ RedistributeMPI (std::map<int, Vector<char> >& not_ours,
                 host_int_attribs[lev][ind].resize(NumIntComps());
 
                 if constexpr (ParticleType::is_soa_particle) {
-                    uint64_t idcpudata;
-                    std::memcpy(&idcpudata, pbuf, sizeof(uint64_t));
-                    pbuf += sizeof(uint64_t);
+                    int64_t idcpudata;
+                    std::memcpy(&idcpudata, pbuf, sizeof(int64_t));
+                    pbuf += sizeof(int64_t);
                     host_idcpu[lev][ind].push_back(idcpudata);
                 } else {
                     ParticleType p;

--- a/Src/Particle/AMReX_ParticleIO.H
+++ b/Src/Particle/AMReX_ParticleIO.H
@@ -992,7 +992,7 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
     host_int_attribs.reserve(15);
     host_int_attribs.resize(finest_level_in_file+1);
 
-    Vector<std::map<std::pair<int, int>, Gpu::HostVector<uint64_t> > > host_idcpu;
+    Vector<std::map<std::pair<int, int>, Gpu::HostVector<int64_t> > > host_idcpu;
     host_idcpu.reserve(15);
     host_idcpu.resize(finestLevel()+1);
 
@@ -1006,7 +1006,7 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
             yi = iptr[1];
             std::memcpy(&xu, &xi, sizeof(xi));
             std::memcpy(&yu, &yi, sizeof(yi));
-            ptemp.m_idcpu = ((std::uint64_t)xu) << 32 | yu;
+            ptemp.m_idcpu = ((std::int64_t)xu) << 32 | yu;
         } else {
             ptemp.id()   = iptr[0];
             ptemp.cpu()  = iptr[1];

--- a/Src/Particle/AMReX_ParticleInit.H
+++ b/Src/Particle/AMReX_ParticleInit.H
@@ -1062,7 +1062,7 @@ InitRandom (Long                    icount,
         host_int_attribs.reserve(15);
         host_int_attribs.resize(finestLevel()+1);
 
-        Vector<std::map<std::pair<int, int>, Gpu::HostVector<uint64_t> > > host_idcpu;
+        Vector<std::map<std::pair<int, int>, Gpu::HostVector<int64_t> > > host_idcpu;
         host_idcpu.reserve(15);
         host_idcpu.resize(finestLevel()+1);
 
@@ -1211,7 +1211,7 @@ InitRandom (Long                    icount,
         host_int_attribs.reserve(15);
         host_int_attribs.resize(finestLevel()+1);
 
-        Vector<std::map<std::pair<int, int>, Gpu::HostVector<uint64_t> > > host_idcpu;
+        Vector<std::map<std::pair<int, int>, Gpu::HostVector<int64_t> > > host_idcpu;
         host_idcpu.reserve(15);
         host_idcpu.resize(finestLevel()+1);
 

--- a/Src/Particle/AMReX_ParticleTile.H
+++ b/Src/Particle/AMReX_ParticleTile.H
@@ -47,7 +47,7 @@ struct ParticleTileData
                                        void * AMREX_RESTRICT, ParticleType * AMREX_RESTRICT>;
     AOS_PTR m_aos;
 
-    uint64_t* m_idcpu;
+    int64_t* m_idcpu;
     GpuArray<ParticleReal*, NAR> m_rdata;
     GpuArray<int*, NAI> m_idata;
 
@@ -128,8 +128,8 @@ struct ParticleTileData
             memcpy(dst, m_aos + src_index, sizeof(ParticleType));
             dst += sizeof(ParticleType);
         } else {
-            memcpy(dst, m_idcpu + src_index, sizeof(uint64_t));
-            dst += sizeof(uint64_t);
+            memcpy(dst, m_idcpu + src_index, sizeof(int64_t));
+            dst += sizeof(int64_t);
         }
         int array_start_index  = AMREX_SPACEDIM + NStructReal;
         for (int i = 0; i < NAR; ++i)
@@ -179,8 +179,8 @@ struct ParticleTileData
             memcpy(m_aos + dst_index, src, sizeof(ParticleType));
             src += sizeof(ParticleType);
         } else {
-            memcpy(m_idcpu + dst_index, src, sizeof(uint64_t));
-            src += sizeof(uint64_t);
+            memcpy(m_idcpu + dst_index, src, sizeof(int64_t));
+            src += sizeof(int64_t);
         }
         int array_start_index  = AMREX_SPACEDIM + NStructReal;
         for (int i = 0; i < NAR; ++i)
@@ -393,7 +393,7 @@ struct SoAParticle : SoAParticleBase
     ParticleIDWrapper id () & { return this->m_particle_tile_data.m_idcpu[m_index]; }
 
     [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-    uint64_t& idcpu () & { return this->m_particle_tile_data.m_idcpu[m_index]; }
+    int64_t& idcpu () & { return this->m_particle_tile_data.m_idcpu[m_index]; }
 
     [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     ConstParticleCPUWrapper cpu () const & { return this->m_particle_tile_data.m_idcpu[m_index]; }
@@ -402,7 +402,7 @@ struct SoAParticle : SoAParticleBase
     ConstParticleIDWrapper id () const & { return this->m_particle_tile_data.m_idcpu[m_index]; }
 
     [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-    const uint64_t& idcpu () const & { return this->m_particle_tile_data.m_idcpu[m_index]; }
+    const int64_t& idcpu () const & { return this->m_particle_tile_data.m_idcpu[m_index]; }
 
     //functions to get positions of the particle in the SOA data
 
@@ -508,7 +508,7 @@ struct ConstParticleTileData
                                        void const * AMREX_RESTRICT, ParticleType const * AMREX_RESTRICT>;
     AOS_PTR m_aos;
 
-    const uint64_t* m_idcpu;
+    const int64_t* m_idcpu;
     GpuArray<const ParticleReal*, NArrayReal> m_rdata;
     GpuArray<const int*, NArrayInt > m_idata;
 
@@ -589,8 +589,8 @@ struct ConstParticleTileData
             memcpy(dst, m_aos + src_index, sizeof(ParticleType));
             dst += sizeof(ParticleType);
         } else {
-            memcpy(dst, m_idcpu + src_index, sizeof(uint64_t));
-            dst += sizeof(uint64_t);
+            memcpy(dst, m_idcpu + src_index, sizeof(int64_t));
+            dst += sizeof(int64_t);
         }
         int array_start_index  = AMREX_SPACEDIM + NStructReal;
         for (int i = 0; i < NArrayReal; ++i)
@@ -1069,7 +1069,7 @@ struct ParticleTile
     {
         Long nbytes = 0;
         if constexpr (ParticleType::is_soa_particle) {
-            nbytes += GetStructOfArrays().GetIdCPUData().capacity() * sizeof(uint64_t);
+            nbytes += GetStructOfArrays().GetIdCPUData().capacity() * sizeof(int64_t);
         } else {
             nbytes += m_aos_tile().capacity() * sizeof(ParticleType);
         }

--- a/Src/Particle/AMReX_StructOfArrays.H
+++ b/Src/Particle/AMReX_StructOfArrays.H
@@ -15,7 +15,7 @@ template <int NReal, int NInt,
           bool use64BitIdCpu=false>
 struct StructOfArrays {
 
-    using IdCPU = amrex::PODVector<uint64_t, Allocator<uint64_t> >;
+    using IdCPU = amrex::PODVector<int64_t, Allocator<int64_t> >;
     using RealVector = amrex::PODVector<ParticleReal, Allocator<ParticleReal> >;
     using IntVector = amrex::PODVector<int, Allocator<int> >;
 
@@ -195,7 +195,7 @@ struct StructOfArrays {
         for (int i = 0; i < int(m_runtime_idata.size()); ++i) { m_runtime_idata[i].resize(count); }
     }
 
-    [[nodiscard]] uint64_t* idcpuarray () {
+    [[nodiscard]] int64_t* idcpuarray () {
         if constexpr (use64BitIdCpu == true) {
             return m_idcpu.dataPtr();
         } else {

--- a/Src/Particle/AMReX_WriteBinaryParticleData.H
+++ b/Src/Particle/AMReX_WriteBinaryParticleData.H
@@ -338,7 +338,7 @@ packIOData (Vector<int>& idata, Vector<ParticleReal>& rdata, const PC& pc, int l
                 else {
                     amrex::ignore_unused(is_checkpoint);
                     // Int: id, cpu
-                    uint64_t idcpu = soa.GetIdCPUData()[pindex];
+                    int64_t idcpu = soa.GetIdCPUData()[pindex];
                     *iptr = (int) ParticleIDWrapper(idcpu);
                     iptr += 1;
                     *iptr = (int) ParticleCPUWrapper(idcpu);
@@ -1033,7 +1033,7 @@ void WriteBinaryParticleDataAsync (PC const& pc,
                         }
                         else {
                             // Ints: id, cpu
-                            uint64_t idcpu = soa.GetIdCPUData()[pindex];
+                            int64_t idcpu = soa.GetIdCPUData()[pindex];
                             *iptr = (int) ParticleIDWrapper(idcpu);
                             iptr += 1;
                             *iptr = (int) ParticleCPUWrapper(idcpu);

--- a/Tests/Particles/RedistributeSOA/main.cpp
+++ b/Tests/Particles/RedistributeSOA/main.cpp
@@ -92,7 +92,7 @@ public:
         {
             const Box& tile_box  = mfi.tilebox();
 
-            Gpu::HostVector<uint64_t> host_idcpu;
+            Gpu::HostVector<int64_t> host_idcpu;
             std::array<Gpu::HostVector<ParticleReal>, NR> host_real;
             std::array<Gpu::HostVector<int>, NI> host_int;
 


### PR DESCRIPTION
## Summary

Simplify `idcpu` by moving the `id` including its sign bit in the
uppermost 40 of 64 bytes.

Use a signed type for `idcpu`

This:
- allows users to interpret `idcpu` as a signed integer that is positive for valid and negative for invalid particles
  - this is visible in output as well as in user-written code, e.g., from Python
  - contrary to `id`, a global id does not need conversion and can be interpreted as a valid type as is
- simplifies conversions (assignment, extraction) significantly
- enable us to judge the `id` sign from the `idcpu` integer
  representation
- make use of compiler optimizations when directly operating on
  it (e.g., with `*= -1` or `< 0` requests).

## Additional background

- X-ref #3735 (rebase this after merged)
- https://en.wikipedia.org/wiki/Signed_number_representations
- https://www.simonv.fr/TypesConvert/?integers

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [x] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
