### PR TITLE
Update AoS Restrict

### DIFF
--- a/Src/Particle/AMReX_ParticleTile.H
+++ b/Src/Particle/AMReX_ParticleTile.H
@@ -44,8 +44,8 @@ struct ParticleTileData
     Long m_size;
 
     using AOS_PTR = std::conditional_t<T_ParticleType::is_soa_particle,
-                                       void*, ParticleType*>;
-    AOS_PTR AMREX_RESTRICT m_aos;
+                                       void * AMREX_RESTRICT, ParticleType * AMREX_RESTRICT>;
+    AOS_PTR m_aos;
 
     uint64_t* m_idcpu;
     GpuArray<ParticleReal*, NAR> m_rdata;
@@ -505,8 +505,8 @@ struct ConstParticleTileData
     Long m_size;
 
     using AOS_PTR = std::conditional_t<T_ParticleType::is_soa_particle,
-                                       void const*, ParticleType const*>;
-    AOS_PTR AMREX_RESTRICT m_aos;
+                                       void const * AMREX_RESTRICT, ParticleType const * AMREX_RESTRICT>;
+    AOS_PTR m_aos;
 
     const uint64_t* m_idcpu;
     GpuArray<const ParticleReal*, NArrayReal> m_rdata;


### PR DESCRIPTION
## Summary

Move into type to mitigate MSVC compile errors:
```
Src\Particle\AMReX_ParticleTile.H(48,5): error C2219:
  syntax error: type qualifier must be after '*'
```

## Additional background

Follow-up to #3736.

Seen in https://github.com/ECP-WarpX/WarpX/pull/4654

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
