### PR TITLE
Add partitionParticles Function

### DIFF
--- a/Src/Particle/AMReX_ParticleContainerI.H
+++ b/Src/Particle/AMReX_ParticleContainerI.H
@@ -1297,7 +1297,7 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
             auto& src_tile = plev[index];
             const size_t np = src_tile.numParticles();
 
-            int num_stay = partitionParticlesByDest_new_cache(src_tile, assign_grid,
+            int num_stay = partitionParticlesByDest(src_tile, assign_grid,
                                                     std::forward<CellAssignor>(CellAssignor{}),
                                                     BufferMap(),
                                                     plo, phi, rlo, rhi, is_per, lev, gid, tid,

--- a/Src/Particle/AMReX_ParticleContainerI.H
+++ b/Src/Particle/AMReX_ParticleContainerI.H
@@ -1297,7 +1297,7 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
             auto& src_tile = plev[index];
             const size_t np = src_tile.numParticles();
 
-            int num_stay = partitionParticlesByDest(src_tile, assign_grid,
+            int num_stay = partitionParticlesByDest_new_cache(src_tile, assign_grid,
                                                     std::forward<CellAssignor>(CellAssignor{}),
                                                     BufferMap(),
                                                     plo, phi, rlo, rhi, is_per, lev, gid, tid,

--- a/Src/Particle/AMReX_ParticleUtil.H
+++ b/Src/Particle/AMReX_ParticleUtil.H
@@ -555,8 +555,14 @@ partitionParticlesByDest (PTile& ptile, const PLocator& ploc, CellAssignor&& ass
     auto getPID = pmap.getPIDFunctor();
     int pid = ParallelContext::MyProcSub();
 
-    return partitionParticles(ptile,
-        [=] AMREX_GPU_DEVICE (auto& ptd, int i) -> bool
+    Gpu::DeviceVector<uint8_t> particle_stays(ptile.numParticles());
+    uint8_t * const p_particle_stays = particle_stays.dataPtr();
+    auto ptd = ptile.getParticleTileData();
+
+    // the function for determining if a particle stays on this grid is very slow,
+    // so we cache it in particle_stays to avoid evaluating it multiple times.
+    ParallelFor(ptile.numParticles(),
+        [=] AMREX_GPU_DEVICE (int i)
         {
             int assigned_grid;
             int assigned_lev;
@@ -590,11 +596,14 @@ partitionParticlesByDest (PTile& ptile, const PLocator& ploc, CellAssignor&& ass
                 }
             }
 
-            if ((remove_negative == false) && (!ptd.id(i).is_valid())) {
-                return true;
-            }
+            p_particle_stays[i] = uint8_t(
+                ((remove_negative == false) && (!ptd.id(i).is_valid())) ||
+                ((assigned_grid == gid) && (assigned_lev == lev) && (getPID(lev, gid) == pid)));
+        });
 
-            return ((assigned_grid == gid) && (assigned_lev == lev) && (getPID(lev, gid) == pid));
+    return partitionParticles(ptile,
+        [=] AMREX_GPU_DEVICE (auto& /* ptd */, int i) -> bool {
+            return p_particle_stays[i];
         });
 }
 

--- a/Src/Particle/AMReX_ParticleUtil.H
+++ b/Src/Particle/AMReX_ParticleUtil.H
@@ -542,7 +542,7 @@ removeInvalidParticles (PTile& ptile)
 
 template <typename PTile, typename PLocator, typename CellAssignor>
 int
-partitionParticlesByDest (PTile& ptile, const PLocator& ploc, CellAssignor&& assignor,
+partitionParticlesByDest_new_nocache (PTile& ptile, const PLocator& ploc, CellAssignor&& assignor,
                           const ParticleBufferMap& pmap,
                           const GpuArray<Real,AMREX_SPACEDIM>& plo,
                           const GpuArray<Real,AMREX_SPACEDIM>& phi,
@@ -552,6 +552,69 @@ partitionParticlesByDest (PTile& ptile, const PLocator& ploc, CellAssignor&& ass
                           int lev, int gid, int /*tid*/,
                           int lev_min, int lev_max, int nGrow, bool remove_negative)
 {
+    Gpu::streamSynchronize();
+    BL_PROFILE("partitionParticlesByDest_new_nocache");
+
+    auto getPID = pmap.getPIDFunctor();
+    int pid = ParallelContext::MyProcSub();
+
+    return partitionParticles(ptile,
+        [=] AMREX_GPU_DEVICE (auto& ptd, int i) -> bool {
+            int assigned_grid;
+            int assigned_lev;
+
+            if (!ptd.id(i).is_valid())
+            {
+                assigned_grid = -1;
+                assigned_lev  = -1;
+            }
+            else
+            {
+                auto p_prime = ptd.getSuperParticle(i);
+                enforcePeriodic(p_prime, plo, phi, rlo, rhi, is_per);
+                auto tup_prime = ploc(p_prime, lev_min, lev_max, nGrow, assignor);
+                assigned_grid = amrex::get<0>(tup_prime);
+                assigned_lev  = amrex::get<1>(tup_prime);
+                if (assigned_grid >= 0)
+                {
+                    AMREX_D_TERM(ptd.pos(0, i) = p_prime.pos(0);,
+                                 ptd.pos(1, i) = p_prime.pos(1);,
+                                 ptd.pos(2, i) = p_prime.pos(2););
+                }
+                else if (lev_min > 0)
+                {
+                    AMREX_D_TERM(p_prime.pos(0) = ptd.pos(0, i);,
+                                 p_prime.pos(1) = ptd.pos(1, i);,
+                                 p_prime.pos(2) = ptd.pos(2, i););
+                    auto tup = ploc(p_prime, lev_min, lev_max, nGrow, assignor);
+                    assigned_grid = amrex::get<0>(tup);
+                    assigned_lev  = amrex::get<1>(tup);
+                }
+            }
+
+            return (
+                ((remove_negative == false) && (!ptd.id(i).is_valid())) ||
+                ((assigned_grid == gid) && (assigned_lev == lev) && (getPID(lev, gid) == pid)));
+        });
+
+    Gpu::streamSynchronize();
+}
+
+template <typename PTile, typename PLocator, typename CellAssignor>
+int
+partitionParticlesByDest_new_cache (PTile& ptile, const PLocator& ploc, CellAssignor&& assignor,
+                          const ParticleBufferMap& pmap,
+                          const GpuArray<Real,AMREX_SPACEDIM>& plo,
+                          const GpuArray<Real,AMREX_SPACEDIM>& phi,
+                          const GpuArray<ParticleReal,AMREX_SPACEDIM>& rlo,
+                          const GpuArray<ParticleReal,AMREX_SPACEDIM>& rhi,
+                          const GpuArray<int ,AMREX_SPACEDIM>& is_per,
+                          int lev, int gid, int /*tid*/,
+                          int lev_min, int lev_max, int nGrow, bool remove_negative)
+{
+    Gpu::streamSynchronize();
+    BL_PROFILE("partitionParticlesByDest_new_cache");
+
     auto getPID = pmap.getPIDFunctor();
     int pid = ParallelContext::MyProcSub();
 
@@ -605,6 +668,261 @@ partitionParticlesByDest (PTile& ptile, const PLocator& ploc, CellAssignor&& ass
         [=] AMREX_GPU_DEVICE (auto& /* ptd */, int i) -> bool {
             return p_particle_stays[i];
         });
+
+    Gpu::streamSynchronize();
+}
+
+template <typename PTile, typename PLocator, typename CellAssignor>
+int
+partitionParticlesByDest_old_nocache (PTile& ptile, const PLocator& ploc, CellAssignor&& assignor,
+                          const ParticleBufferMap& pmap,
+                          const GpuArray<Real,AMREX_SPACEDIM>& plo,
+                          const GpuArray<Real,AMREX_SPACEDIM>& phi,
+                          const GpuArray<ParticleReal,AMREX_SPACEDIM>& rlo,
+                          const GpuArray<ParticleReal,AMREX_SPACEDIM>& rhi,
+                          const GpuArray<int ,AMREX_SPACEDIM>& is_per,
+                          int lev, int gid, int /*tid*/,
+                          int lev_min, int lev_max, int nGrow, bool remove_negative)
+{
+    Gpu::streamSynchronize();
+    BL_PROFILE("partitionParticlesByDest_old_nocache");
+
+    const int np = ptile.numParticles();
+    if (np == 0) { return 0; }
+
+    auto getPID = pmap.getPIDFunctor();
+
+    int pid = ParallelContext::MyProcSub();
+    constexpr int chunk_size = 256*256*256;
+    int num_chunks = std::max(1, (np + (chunk_size - 1)) / chunk_size);
+
+    PTile ptile_tmp;
+    ptile_tmp.define(ptile.NumRuntimeRealComps(), ptile.NumRuntimeIntComps());
+    ptile_tmp.resize(std::min(np, chunk_size));
+
+    auto src_data = ptile.getParticleTileData();
+    auto dst_data = ptile_tmp.getParticleTileData();
+
+    int last_offset = 0;
+    for (int ichunk = 0; ichunk < num_chunks; ++ichunk)
+    {
+        int this_offset = ichunk*chunk_size;
+        int this_chunk_size = std::min(chunk_size, np - this_offset);
+
+        int num_stay;
+        {
+            auto particle_stays = [=] AMREX_GPU_DEVICE (int i) -> int
+            {
+                int assigned_grid;
+                int assigned_lev;
+
+                if (src_data.id(i+this_offset) < 0 )
+                {
+                    assigned_grid = -1;
+                    assigned_lev  = -1;
+                }
+                else
+                {
+                    auto p_prime = src_data.getSuperParticle(i+this_offset);
+                    enforcePeriodic(p_prime, plo, phi, rlo, rhi, is_per);
+                    auto tup_prime = ploc(p_prime, lev_min, lev_max, nGrow, assignor);
+                    assigned_grid = amrex::get<0>(tup_prime);
+                    assigned_lev  = amrex::get<1>(tup_prime);
+                    if (assigned_grid >= 0)
+                    {
+                      AMREX_D_TERM(src_data.pos(0, i+this_offset) = p_prime.pos(0);,
+                                   src_data.pos(1, i+this_offset) = p_prime.pos(1);,
+                                   src_data.pos(2, i+this_offset) = p_prime.pos(2););
+                    }
+                    else if (lev_min > 0)
+                    {
+                      AMREX_D_TERM(p_prime.pos(0) = src_data.pos(0, i+this_offset);,
+                                   p_prime.pos(1) = src_data.pos(1, i+this_offset);,
+                                   p_prime.pos(2) = src_data.pos(2, i+this_offset););
+                      auto tup = ploc(p_prime, lev_min, lev_max, nGrow, assignor);
+                      assigned_grid = amrex::get<0>(tup);
+                      assigned_lev  = amrex::get<1>(tup);
+                    }
+                }
+
+                if ((remove_negative == false) && (src_data.id(i+this_offset) < 0)) {
+                    return true;
+                }
+
+                return ((assigned_grid == gid) && (assigned_lev == lev) && (getPID(lev, gid) == pid));
+            };
+
+            num_stay = Scan::PrefixSum<int> (this_chunk_size,
+                          [=] AMREX_GPU_DEVICE (int i) -> int
+                          {
+                              return particle_stays(i);
+                          },
+                          [=] AMREX_GPU_DEVICE (int i, int const& s)
+                          {
+                              int src_i = i + this_offset;
+                              int dst_i = particle_stays(i) ? s : this_chunk_size-1-(i-s);
+                              copyParticle(dst_data, src_data, src_i, dst_i);
+                          },
+                          Scan::Type::exclusive);
+        }
+
+        if (num_chunks == 1)
+        {
+            ptile.swap(ptile_tmp);
+        }
+        else
+        {
+            AMREX_FOR_1D(this_chunk_size, i,
+                         {
+                             copyParticle(src_data, dst_data, i, i + this_offset);
+                         });
+        }
+
+        if ( ichunk > 0 )
+        {
+            int num_swap = std::min(this_offset - last_offset, num_stay);
+            AMREX_FOR_1D( num_swap, i,
+            {
+                swapParticle(src_data, src_data, last_offset + i,
+                             this_offset + num_stay - 1 - i);
+            });
+        }
+
+        last_offset += num_stay;
+    }
+
+    Gpu::streamSynchronize();
+
+    return last_offset;
+}
+
+template <typename PTile, typename PLocator, typename CellAssignor>
+int
+partitionParticlesByDest_old_cache (PTile& ptile, const PLocator& ploc, CellAssignor&& assignor,
+                          const ParticleBufferMap& pmap,
+                          const GpuArray<Real,AMREX_SPACEDIM>& plo,
+                          const GpuArray<Real,AMREX_SPACEDIM>& phi,
+                          const GpuArray<ParticleReal,AMREX_SPACEDIM>& rlo,
+                          const GpuArray<ParticleReal,AMREX_SPACEDIM>& rhi,
+                          const GpuArray<int ,AMREX_SPACEDIM>& is_per,
+                          int lev, int gid, int /*tid*/,
+                          int lev_min, int lev_max, int nGrow, bool remove_negative)
+{
+    Gpu::streamSynchronize();
+    BL_PROFILE("partitionParticlesByDest_old_cache");
+
+    const int np = ptile.numParticles();
+    if (np == 0) { return 0; }
+
+    auto getPID = pmap.getPIDFunctor();
+
+    int pid = ParallelContext::MyProcSub();
+    constexpr int chunk_size = 256*256*256;
+    int num_chunks = std::max(1, (np + (chunk_size - 1)) / chunk_size);
+
+    PTile ptile_tmp;
+    ptile_tmp.define(ptile.NumRuntimeRealComps(), ptile.NumRuntimeIntComps());
+    ptile_tmp.resize(std::min(np, chunk_size));
+
+    auto src_data = ptile.getParticleTileData();
+    auto dst_data = ptile_tmp.getParticleTileData();
+
+    Gpu::DeviceVector<uint8_t> particle_stays(ptile.numParticles());
+    uint8_t * const p_particle_stays = particle_stays.dataPtr();
+
+    // the function for determining if a particle stays on this grid is very slow,
+    // so we cache it in particle_stays to avoid evaluating it multiple times.
+    ParallelFor(ptile.numParticles(),
+        [=] AMREX_GPU_DEVICE (int i)
+        {
+            int assigned_grid;
+            int assigned_lev;
+
+            if (!src_data.id(i).is_valid())
+            {
+                assigned_grid = -1;
+                assigned_lev  = -1;
+            }
+            else
+            {
+                auto p_prime = src_data.getSuperParticle(i);
+                enforcePeriodic(p_prime, plo, phi, rlo, rhi, is_per);
+                auto tup_prime = ploc(p_prime, lev_min, lev_max, nGrow, assignor);
+                assigned_grid = amrex::get<0>(tup_prime);
+                assigned_lev  = amrex::get<1>(tup_prime);
+                if (assigned_grid >= 0)
+                {
+                    AMREX_D_TERM(src_data.pos(0, i) = p_prime.pos(0);,
+                                 src_data.pos(1, i) = p_prime.pos(1);,
+                                 src_data.pos(2, i) = p_prime.pos(2););
+                }
+                else if (lev_min > 0)
+                {
+                    AMREX_D_TERM(p_prime.pos(0) = src_data.pos(0, i);,
+                                 p_prime.pos(1) = src_data.pos(1, i);,
+                                 p_prime.pos(2) = src_data.pos(2, i););
+                    auto tup = ploc(p_prime, lev_min, lev_max, nGrow, assignor);
+                    assigned_grid = amrex::get<0>(tup);
+                    assigned_lev  = amrex::get<1>(tup);
+                }
+            }
+
+            p_particle_stays[i] = uint8_t(
+                ((remove_negative == false) && (!src_data.id(i).is_valid())) ||
+                ((assigned_grid == gid) && (assigned_lev == lev) && (getPID(lev, gid) == pid)));
+        });
+
+    int last_offset = 0;
+    for (int ichunk = 0; ichunk < num_chunks; ++ichunk)
+    {
+        int this_offset = ichunk*chunk_size;
+        int this_chunk_size = std::min(chunk_size, np - this_offset);
+
+        int num_stay;
+        {
+
+            num_stay = Scan::PrefixSum<int> (this_chunk_size,
+                          [=] AMREX_GPU_DEVICE (int i) -> int
+                          {
+                              return p_particle_stays[i + this_offset];
+                          },
+                          [=] AMREX_GPU_DEVICE (int i, int const& s)
+                          {
+                              int src_i = i + this_offset;
+                              int dst_i = p_particle_stays[i + this_offset] ? s : this_chunk_size-1-(i-s);
+                              copyParticle(dst_data, src_data, src_i, dst_i);
+                          },
+                          Scan::Type::exclusive);
+        }
+
+        if (num_chunks == 1)
+        {
+            ptile.swap(ptile_tmp);
+        }
+        else
+        {
+            AMREX_FOR_1D(this_chunk_size, i,
+                         {
+                             copyParticle(src_data, dst_data, i, i + this_offset);
+                         });
+        }
+
+        if ( ichunk > 0 )
+        {
+            int num_swap = std::min(this_offset - last_offset, num_stay);
+            AMREX_FOR_1D( num_swap, i,
+            {
+                swapParticle(src_data, src_data, last_offset + i,
+                             this_offset + num_stay - 1 - i);
+            });
+        }
+
+        last_offset += num_stay;
+    }
+
+    Gpu::streamSynchronize();
+
+    return last_offset;
 }
 
 #endif

--- a/Src/Particle/AMReX_ParticleUtil.H
+++ b/Src/Particle/AMReX_ParticleUtil.H
@@ -456,6 +456,88 @@ bool enforcePeriodic (P& p,
     return shifted;
 }
 
+/**
+ * \brief Reorders the ParticleTile into two partitions
+ * left [0, num_left-1] and right [num_left, ptile.numParticles()-1]
+ * and returns the number of particles in the left partition.
+ *
+ * The functor is_left [(ParticleTileData ptd, int index) -> bool] maps each particle to
+ * either the left [return true] or the right [return false] partition.
+ * It must return the same result if evaluated multiple times for the same particle.
+ *
+ * \param ptile the ParticleTile to partition
+ * \param is_left functor to map particles to a partition
+ */
+template <typename PTile, typename ParFunc>
+int
+partitionParticles (PTile& ptile, ParFunc&& is_left)
+{
+    const int np = ptile.numParticles();
+    if (np == 0) { return 0; }
+
+    auto ptd = ptile.getParticleTileData();
+
+    const int num_left = Reduce::Sum<int>(np,
+        [=] AMREX_GPU_DEVICE (int i) -> int
+        {
+            return int(is_left(ptd, i));
+        });
+
+    const int num_swaps = std::min(num_left, np - num_left);
+    if (num_swaps == 0) { return num_left; }
+
+    Gpu::DeviceVector<int> index_left(num_swaps);
+    Gpu::DeviceVector<int> index_right(num_swaps);
+    int * const p_index_left = index_left.dataPtr();
+    int * const p_index_right = index_right.dataPtr();
+
+    Scan::PrefixSum<int>(np,
+        [=] AMREX_GPU_DEVICE (int i) -> int
+        {
+            return int(!is_left(ptd, i));
+        },
+        [=] AMREX_GPU_DEVICE (int i, int const& s)
+        {
+            if (!is_left(ptd, i)) {
+                int dst = s;
+                if (dst < num_swaps) {
+                    p_index_right[dst] = i;
+                }
+            } else {
+                int dst = num_left-1-(i-s);
+                if (dst < num_swaps) {
+                    p_index_left[dst] = i;
+                }
+            }
+        },
+        Scan::Type::exclusive, Scan::noRetSum);
+
+    ParallelFor(num_swaps,
+        [=] AMREX_GPU_DEVICE (int i)
+        {
+            int left_i = p_index_left[i];
+            int right_i = p_index_right[i];
+            if (right_i < left_i) {
+                swapParticle(ptd, ptd, left_i, right_i);
+            }
+        });
+
+    Gpu::streamSynchronize(); // for index_left and index_right
+
+    return num_left;
+}
+
+template <typename PTile>
+void
+removeInvalidParticles (PTile& ptile)
+{
+    const int new_size = partitionParticles(ptile,
+        [=] AMREX_GPU_DEVICE (auto& ptd, int i) {
+            return ptd.id(i).is_valid();
+        });
+    ptile.resize(new_size);
+}
+
 #if defined(AMREX_USE_GPU)
 
 template <typename PTile, typename PLocator, typename CellAssignor>
@@ -470,111 +552,50 @@ partitionParticlesByDest (PTile& ptile, const PLocator& ploc, CellAssignor&& ass
                           int lev, int gid, int /*tid*/,
                           int lev_min, int lev_max, int nGrow, bool remove_negative)
 {
-    const int np = ptile.numParticles();
-    if (np == 0) { return 0; }
-
     auto getPID = pmap.getPIDFunctor();
-
     int pid = ParallelContext::MyProcSub();
-    constexpr int chunk_size = 256*256*256;
-    int num_chunks = std::max(1, (np + (chunk_size - 1)) / chunk_size);
 
-    PTile ptile_tmp;
-    ptile_tmp.define(ptile.NumRuntimeRealComps(), ptile.NumRuntimeIntComps());
-    ptile_tmp.resize(std::min(np, chunk_size));
-
-    auto src_data = ptile.getParticleTileData();
-    auto dst_data = ptile_tmp.getParticleTileData();
-
-    int last_offset = 0;
-    for (int ichunk = 0; ichunk < num_chunks; ++ichunk)
-    {
-        int this_offset = ichunk*chunk_size;
-        int this_chunk_size = std::min(chunk_size, np - this_offset);
-
-        int num_stay;
+    return partitionParticles(ptile,
+        [=] AMREX_GPU_DEVICE (auto& ptd, int i) -> bool
         {
-            auto particle_stays = [=] AMREX_GPU_DEVICE (int i) -> int
+            int assigned_grid;
+            int assigned_lev;
+
+            if (ptd.id(i).is_valid())
             {
-                int assigned_grid;
-                int assigned_lev;
-
-                if (src_data.id(i+this_offset) < 0 )
-                {
-                    assigned_grid = -1;
-                    assigned_lev  = -1;
-                }
-                else
-                {
-                    auto p_prime = src_data.getSuperParticle(i+this_offset);
-                    enforcePeriodic(p_prime, plo, phi, rlo, rhi, is_per);
-                    auto tup_prime = ploc(p_prime, lev_min, lev_max, nGrow, assignor);
-                    assigned_grid = amrex::get<0>(tup_prime);
-                    assigned_lev  = amrex::get<1>(tup_prime);
-                    if (assigned_grid >= 0)
-                    {
-                      AMREX_D_TERM(src_data.pos(0, i+this_offset) = p_prime.pos(0);,
-                                   src_data.pos(1, i+this_offset) = p_prime.pos(1);,
-                                   src_data.pos(2, i+this_offset) = p_prime.pos(2););
-                    }
-                    else if (lev_min > 0)
-                    {
-                      AMREX_D_TERM(p_prime.pos(0) = src_data.pos(0, i+this_offset);,
-                                   p_prime.pos(1) = src_data.pos(1, i+this_offset);,
-                                   p_prime.pos(2) = src_data.pos(2, i+this_offset););
-                      auto tup = ploc(p_prime, lev_min, lev_max, nGrow, assignor);
-                      assigned_grid = amrex::get<0>(tup);
-                      assigned_lev  = amrex::get<1>(tup);
-                    }
-                }
-
-                if ((remove_negative == false) && (src_data.id(i+this_offset) < 0)) {
-                    return true;
-                }
-
-                return ((assigned_grid == gid) && (assigned_lev == lev) && (getPID(lev, gid) == pid));
-            };
-
-            num_stay = Scan::PrefixSum<int> (this_chunk_size,
-                          [=] AMREX_GPU_DEVICE (int i) -> int
-                          {
-                              return particle_stays(i);
-                          },
-                          [=] AMREX_GPU_DEVICE (int i, int const& s)
-                          {
-                              int src_i = i + this_offset;
-                              int dst_i = particle_stays(i) ? s : this_chunk_size-1-(i-s);
-                              copyParticle(dst_data, src_data, src_i, dst_i);
-                          },
-                          Scan::Type::exclusive);
-        }
-
-        if (num_chunks == 1)
-        {
-            ptile.swap(ptile_tmp);
-        }
-        else
-        {
-            AMREX_FOR_1D(this_chunk_size, i,
-                         {
-                             copyParticle(src_data, dst_data, i, i + this_offset);
-                         });
-        }
-
-        if ( ichunk > 0 )
-        {
-            int num_swap = std::min(this_offset - last_offset, num_stay);
-            AMREX_FOR_1D( num_swap, i,
+                assigned_grid = -1;
+                assigned_lev  = -1;
+            }
+            else
             {
-                swapParticle(src_data, src_data, last_offset + i,
-                             this_offset + num_stay - 1 - i);
-            });
-        }
+                auto p_prime = ptd.getSuperParticle(i);
+                enforcePeriodic(p_prime, plo, phi, rlo, rhi, is_per);
+                auto tup_prime = ploc(p_prime, lev_min, lev_max, nGrow, assignor);
+                assigned_grid = amrex::get<0>(tup_prime);
+                assigned_lev  = amrex::get<1>(tup_prime);
+                if (assigned_grid >= 0)
+                {
+                    AMREX_D_TERM(ptd.pos(0, i) = p_prime.pos(0);,
+                                 ptd.pos(1, i) = p_prime.pos(1);,
+                                 ptd.pos(2, i) = p_prime.pos(2););
+                }
+                else if (lev_min > 0)
+                {
+                    AMREX_D_TERM(p_prime.pos(0) = ptd.pos(0, i);,
+                                 p_prime.pos(1) = ptd.pos(1, i);,
+                                 p_prime.pos(2) = ptd.pos(2, i););
+                    auto tup = ploc(p_prime, lev_min, lev_max, nGrow, assignor);
+                    assigned_grid = amrex::get<0>(tup);
+                    assigned_lev  = amrex::get<1>(tup);
+                }
+            }
 
-        last_offset += num_stay;
-    }
+            if ((remove_negative == false) && (!ptd.id(i).is_valid())) {
+                return true;
+            }
 
-    return last_offset;
+            return ((assigned_grid == gid) && (assigned_lev == lev) && (getPID(lev, gid) == pid));
+        });
 }
 
 #endif

--- a/Src/Particle/AMReX_ParticleUtil.H
+++ b/Src/Particle/AMReX_ParticleUtil.H
@@ -561,7 +561,7 @@ partitionParticlesByDest (PTile& ptile, const PLocator& ploc, CellAssignor&& ass
             int assigned_grid;
             int assigned_lev;
 
-            if (ptd.id(i).is_valid())
+            if (!ptd.id(i).is_valid())
             {
                 assigned_grid = -1;
                 assigned_lev  = -1;

--- a/Src/Particle/AMReX_ParticleUtil.H
+++ b/Src/Particle/AMReX_ParticleUtil.H
@@ -483,13 +483,38 @@ partitionParticles (PTile& ptile, ParFunc&& is_left)
             return int(is_left(ptd, i));
         });
 
-    const int num_swaps = std::min(num_left, np - num_left);
-    if (num_swaps == 0) { return num_left; }
+    // The ptile will be partitioned into left [0, num_left-1] and right [num_left, np-1].
+    //
+    // Note that currently the number of particles in [0, num_left-1] that should belong to the
+    // right partition is equal to the number of particles in [num_left, np-1] that should belong
+    // in the left partition. We will define num_swaps to be this number. This is the minimum
+    // number of swaps that need to be performed to partition the ptile in-place for any algorithm.
+    //
+    // From this it is easy to see that
+    // max_num_swaps = min(size([0, num_left-1]), size([num_left, np-1]))
+    // is an upper bound for num_swaps.
 
-    Gpu::DeviceVector<int> index_left(num_swaps);
-    Gpu::DeviceVector<int> index_right(num_swaps);
+    const int max_num_swaps = std::min(num_left, np - num_left);
+    if (max_num_swaps == 0) { return num_left; }
+
+    Gpu::DeviceVector<int> index_left(max_num_swaps);
+    Gpu::DeviceVector<int> index_right(max_num_swaps);
     int * const p_index_left = index_left.dataPtr();
     int * const p_index_right = index_right.dataPtr();
+
+    // The num_swaps particles that are in [0, num_left-1] but should be moved to the right
+    // partiton are at the same time the first num_swaps particles for which is_left is false
+    // in all the ptile.
+    // Simularly the num_swaps particles in [num_left, np-1] that should be moved to the left
+    // partiton are the last num_swaps particles of the ptile for which is_left is true.
+    //
+    // The PrefixSum is used to find exactly these particles and store their indexes in
+    // index_left and index_right. Since num_swaps is not known, the first max_num_swaps
+    // particles are stored instead. Here, dst = num_left-1-(i-s) is used to effectively reverse
+    // the PrefixSum to store the last particles for which is_left is true.
+    //
+    // This way, all indexes in index_right are in ascending order, and all indexes in
+    // index_left are in descending order.
 
     Scan::PrefixSum<int>(np,
         [=] AMREX_GPU_DEVICE (int i) -> int
@@ -500,19 +525,37 @@ partitionParticles (PTile& ptile, ParFunc&& is_left)
         {
             if (!is_left(ptd, i)) {
                 int dst = s;
-                if (dst < num_swaps) {
+                if (dst < max_num_swaps) {
                     p_index_right[dst] = i;
                 }
             } else {
-                int dst = num_left-1-(i-s);
-                if (dst < num_swaps) {
+                int dst = num_left-1-(i-s); // avoid integer overflow
+                if (dst < max_num_swaps) {
                     p_index_left[dst] = i;
                 }
             }
         },
         Scan::Type::exclusive, Scan::noRetSum);
 
-    ParallelFor(num_swaps,
+    // Finally the particles are swapped. Since max_num_swaps is only an upper bound for num_swaps,
+    // some swaps should not be performed and need to be skipped. This is the case if the index
+    // in index_left[i] is already in the left partition or the index in index_right[i] is already
+    // in the right partition. These two cases coincide for the same i because index_right is in
+    // ascending order and index_left in descending order. This means for both index_left and
+    // index_right the first num_swaps particles need to be swapped, and the particles after that
+    // should be skipped.
+    //
+    // The check right_i < left_i makes sure that the particle going to the right partition is
+    // actually coming from the left partition, which has a lower index than the other particle and
+    // visa-versa.
+    //
+    // Since exactly num_swaps swap operations are performed in the end, which is the smallest
+    // number possible, this algorithm is optimal in the number of swap operations.
+    // This results in good performance in practice if the size of a particle is large enough that
+    // it compensates for the extra kernel launches and evaluations of is_left which this
+    // algorithm needs.
+
+    ParallelFor(max_num_swaps,
         [=] AMREX_GPU_DEVICE (int i)
         {
             int left_i = p_index_left[i];
@@ -522,7 +565,7 @@ partitionParticles (PTile& ptile, ParFunc&& is_left)
             }
         });
 
-    Gpu::streamSynchronize(); // for index_left and index_right
+    Gpu::streamSynchronize(); // for index_left and index_right deallocation
 
     return num_left;
 }
@@ -542,7 +585,7 @@ removeInvalidParticles (PTile& ptile)
 
 template <typename PTile, typename PLocator, typename CellAssignor>
 int
-partitionParticlesByDest_new_nocache (PTile& ptile, const PLocator& ploc, CellAssignor&& assignor,
+partitionParticlesByDest (PTile& ptile, const PLocator& ploc, CellAssignor&& assignor,
                           const ParticleBufferMap& pmap,
                           const GpuArray<Real,AMREX_SPACEDIM>& plo,
                           const GpuArray<Real,AMREX_SPACEDIM>& phi,
@@ -552,69 +595,6 @@ partitionParticlesByDest_new_nocache (PTile& ptile, const PLocator& ploc, CellAs
                           int lev, int gid, int /*tid*/,
                           int lev_min, int lev_max, int nGrow, bool remove_negative)
 {
-    Gpu::streamSynchronize();
-    BL_PROFILE("partitionParticlesByDest_new_nocache");
-
-    auto getPID = pmap.getPIDFunctor();
-    int pid = ParallelContext::MyProcSub();
-
-    return partitionParticles(ptile,
-        [=] AMREX_GPU_DEVICE (auto& ptd, int i) -> bool {
-            int assigned_grid;
-            int assigned_lev;
-
-            if (!ptd.id(i).is_valid())
-            {
-                assigned_grid = -1;
-                assigned_lev  = -1;
-            }
-            else
-            {
-                auto p_prime = ptd.getSuperParticle(i);
-                enforcePeriodic(p_prime, plo, phi, rlo, rhi, is_per);
-                auto tup_prime = ploc(p_prime, lev_min, lev_max, nGrow, assignor);
-                assigned_grid = amrex::get<0>(tup_prime);
-                assigned_lev  = amrex::get<1>(tup_prime);
-                if (assigned_grid >= 0)
-                {
-                    AMREX_D_TERM(ptd.pos(0, i) = p_prime.pos(0);,
-                                 ptd.pos(1, i) = p_prime.pos(1);,
-                                 ptd.pos(2, i) = p_prime.pos(2););
-                }
-                else if (lev_min > 0)
-                {
-                    AMREX_D_TERM(p_prime.pos(0) = ptd.pos(0, i);,
-                                 p_prime.pos(1) = ptd.pos(1, i);,
-                                 p_prime.pos(2) = ptd.pos(2, i););
-                    auto tup = ploc(p_prime, lev_min, lev_max, nGrow, assignor);
-                    assigned_grid = amrex::get<0>(tup);
-                    assigned_lev  = amrex::get<1>(tup);
-                }
-            }
-
-            return (
-                ((remove_negative == false) && (!ptd.id(i).is_valid())) ||
-                ((assigned_grid == gid) && (assigned_lev == lev) && (getPID(lev, gid) == pid)));
-        });
-
-    Gpu::streamSynchronize();
-}
-
-template <typename PTile, typename PLocator, typename CellAssignor>
-int
-partitionParticlesByDest_new_cache (PTile& ptile, const PLocator& ploc, CellAssignor&& assignor,
-                          const ParticleBufferMap& pmap,
-                          const GpuArray<Real,AMREX_SPACEDIM>& plo,
-                          const GpuArray<Real,AMREX_SPACEDIM>& phi,
-                          const GpuArray<ParticleReal,AMREX_SPACEDIM>& rlo,
-                          const GpuArray<ParticleReal,AMREX_SPACEDIM>& rhi,
-                          const GpuArray<int ,AMREX_SPACEDIM>& is_per,
-                          int lev, int gid, int /*tid*/,
-                          int lev_min, int lev_max, int nGrow, bool remove_negative)
-{
-    Gpu::streamSynchronize();
-    BL_PROFILE("partitionParticlesByDest_new_cache");
-
     auto getPID = pmap.getPIDFunctor();
     int pid = ParallelContext::MyProcSub();
 
@@ -668,261 +648,6 @@ partitionParticlesByDest_new_cache (PTile& ptile, const PLocator& ploc, CellAssi
         [=] AMREX_GPU_DEVICE (auto& /* ptd */, int i) -> bool {
             return p_particle_stays[i];
         });
-
-    Gpu::streamSynchronize();
-}
-
-template <typename PTile, typename PLocator, typename CellAssignor>
-int
-partitionParticlesByDest_old_nocache (PTile& ptile, const PLocator& ploc, CellAssignor&& assignor,
-                          const ParticleBufferMap& pmap,
-                          const GpuArray<Real,AMREX_SPACEDIM>& plo,
-                          const GpuArray<Real,AMREX_SPACEDIM>& phi,
-                          const GpuArray<ParticleReal,AMREX_SPACEDIM>& rlo,
-                          const GpuArray<ParticleReal,AMREX_SPACEDIM>& rhi,
-                          const GpuArray<int ,AMREX_SPACEDIM>& is_per,
-                          int lev, int gid, int /*tid*/,
-                          int lev_min, int lev_max, int nGrow, bool remove_negative)
-{
-    Gpu::streamSynchronize();
-    BL_PROFILE("partitionParticlesByDest_old_nocache");
-
-    const int np = ptile.numParticles();
-    if (np == 0) { return 0; }
-
-    auto getPID = pmap.getPIDFunctor();
-
-    int pid = ParallelContext::MyProcSub();
-    constexpr int chunk_size = 256*256*256;
-    int num_chunks = std::max(1, (np + (chunk_size - 1)) / chunk_size);
-
-    PTile ptile_tmp;
-    ptile_tmp.define(ptile.NumRuntimeRealComps(), ptile.NumRuntimeIntComps());
-    ptile_tmp.resize(std::min(np, chunk_size));
-
-    auto src_data = ptile.getParticleTileData();
-    auto dst_data = ptile_tmp.getParticleTileData();
-
-    int last_offset = 0;
-    for (int ichunk = 0; ichunk < num_chunks; ++ichunk)
-    {
-        int this_offset = ichunk*chunk_size;
-        int this_chunk_size = std::min(chunk_size, np - this_offset);
-
-        int num_stay;
-        {
-            auto particle_stays = [=] AMREX_GPU_DEVICE (int i) -> int
-            {
-                int assigned_grid;
-                int assigned_lev;
-
-                if (src_data.id(i+this_offset) < 0 )
-                {
-                    assigned_grid = -1;
-                    assigned_lev  = -1;
-                }
-                else
-                {
-                    auto p_prime = src_data.getSuperParticle(i+this_offset);
-                    enforcePeriodic(p_prime, plo, phi, rlo, rhi, is_per);
-                    auto tup_prime = ploc(p_prime, lev_min, lev_max, nGrow, assignor);
-                    assigned_grid = amrex::get<0>(tup_prime);
-                    assigned_lev  = amrex::get<1>(tup_prime);
-                    if (assigned_grid >= 0)
-                    {
-                      AMREX_D_TERM(src_data.pos(0, i+this_offset) = p_prime.pos(0);,
-                                   src_data.pos(1, i+this_offset) = p_prime.pos(1);,
-                                   src_data.pos(2, i+this_offset) = p_prime.pos(2););
-                    }
-                    else if (lev_min > 0)
-                    {
-                      AMREX_D_TERM(p_prime.pos(0) = src_data.pos(0, i+this_offset);,
-                                   p_prime.pos(1) = src_data.pos(1, i+this_offset);,
-                                   p_prime.pos(2) = src_data.pos(2, i+this_offset););
-                      auto tup = ploc(p_prime, lev_min, lev_max, nGrow, assignor);
-                      assigned_grid = amrex::get<0>(tup);
-                      assigned_lev  = amrex::get<1>(tup);
-                    }
-                }
-
-                if ((remove_negative == false) && (src_data.id(i+this_offset) < 0)) {
-                    return true;
-                }
-
-                return ((assigned_grid == gid) && (assigned_lev == lev) && (getPID(lev, gid) == pid));
-            };
-
-            num_stay = Scan::PrefixSum<int> (this_chunk_size,
-                          [=] AMREX_GPU_DEVICE (int i) -> int
-                          {
-                              return particle_stays(i);
-                          },
-                          [=] AMREX_GPU_DEVICE (int i, int const& s)
-                          {
-                              int src_i = i + this_offset;
-                              int dst_i = particle_stays(i) ? s : this_chunk_size-1-(i-s);
-                              copyParticle(dst_data, src_data, src_i, dst_i);
-                          },
-                          Scan::Type::exclusive);
-        }
-
-        if (num_chunks == 1)
-        {
-            ptile.swap(ptile_tmp);
-        }
-        else
-        {
-            AMREX_FOR_1D(this_chunk_size, i,
-                         {
-                             copyParticle(src_data, dst_data, i, i + this_offset);
-                         });
-        }
-
-        if ( ichunk > 0 )
-        {
-            int num_swap = std::min(this_offset - last_offset, num_stay);
-            AMREX_FOR_1D( num_swap, i,
-            {
-                swapParticle(src_data, src_data, last_offset + i,
-                             this_offset + num_stay - 1 - i);
-            });
-        }
-
-        last_offset += num_stay;
-    }
-
-    Gpu::streamSynchronize();
-
-    return last_offset;
-}
-
-template <typename PTile, typename PLocator, typename CellAssignor>
-int
-partitionParticlesByDest_old_cache (PTile& ptile, const PLocator& ploc, CellAssignor&& assignor,
-                          const ParticleBufferMap& pmap,
-                          const GpuArray<Real,AMREX_SPACEDIM>& plo,
-                          const GpuArray<Real,AMREX_SPACEDIM>& phi,
-                          const GpuArray<ParticleReal,AMREX_SPACEDIM>& rlo,
-                          const GpuArray<ParticleReal,AMREX_SPACEDIM>& rhi,
-                          const GpuArray<int ,AMREX_SPACEDIM>& is_per,
-                          int lev, int gid, int /*tid*/,
-                          int lev_min, int lev_max, int nGrow, bool remove_negative)
-{
-    Gpu::streamSynchronize();
-    BL_PROFILE("partitionParticlesByDest_old_cache");
-
-    const int np = ptile.numParticles();
-    if (np == 0) { return 0; }
-
-    auto getPID = pmap.getPIDFunctor();
-
-    int pid = ParallelContext::MyProcSub();
-    constexpr int chunk_size = 256*256*256;
-    int num_chunks = std::max(1, (np + (chunk_size - 1)) / chunk_size);
-
-    PTile ptile_tmp;
-    ptile_tmp.define(ptile.NumRuntimeRealComps(), ptile.NumRuntimeIntComps());
-    ptile_tmp.resize(std::min(np, chunk_size));
-
-    auto src_data = ptile.getParticleTileData();
-    auto dst_data = ptile_tmp.getParticleTileData();
-
-    Gpu::DeviceVector<uint8_t> particle_stays(ptile.numParticles());
-    uint8_t * const p_particle_stays = particle_stays.dataPtr();
-
-    // the function for determining if a particle stays on this grid is very slow,
-    // so we cache it in particle_stays to avoid evaluating it multiple times.
-    ParallelFor(ptile.numParticles(),
-        [=] AMREX_GPU_DEVICE (int i)
-        {
-            int assigned_grid;
-            int assigned_lev;
-
-            if (!src_data.id(i).is_valid())
-            {
-                assigned_grid = -1;
-                assigned_lev  = -1;
-            }
-            else
-            {
-                auto p_prime = src_data.getSuperParticle(i);
-                enforcePeriodic(p_prime, plo, phi, rlo, rhi, is_per);
-                auto tup_prime = ploc(p_prime, lev_min, lev_max, nGrow, assignor);
-                assigned_grid = amrex::get<0>(tup_prime);
-                assigned_lev  = amrex::get<1>(tup_prime);
-                if (assigned_grid >= 0)
-                {
-                    AMREX_D_TERM(src_data.pos(0, i) = p_prime.pos(0);,
-                                 src_data.pos(1, i) = p_prime.pos(1);,
-                                 src_data.pos(2, i) = p_prime.pos(2););
-                }
-                else if (lev_min > 0)
-                {
-                    AMREX_D_TERM(p_prime.pos(0) = src_data.pos(0, i);,
-                                 p_prime.pos(1) = src_data.pos(1, i);,
-                                 p_prime.pos(2) = src_data.pos(2, i););
-                    auto tup = ploc(p_prime, lev_min, lev_max, nGrow, assignor);
-                    assigned_grid = amrex::get<0>(tup);
-                    assigned_lev  = amrex::get<1>(tup);
-                }
-            }
-
-            p_particle_stays[i] = uint8_t(
-                ((remove_negative == false) && (!src_data.id(i).is_valid())) ||
-                ((assigned_grid == gid) && (assigned_lev == lev) && (getPID(lev, gid) == pid)));
-        });
-
-    int last_offset = 0;
-    for (int ichunk = 0; ichunk < num_chunks; ++ichunk)
-    {
-        int this_offset = ichunk*chunk_size;
-        int this_chunk_size = std::min(chunk_size, np - this_offset);
-
-        int num_stay;
-        {
-
-            num_stay = Scan::PrefixSum<int> (this_chunk_size,
-                          [=] AMREX_GPU_DEVICE (int i) -> int
-                          {
-                              return p_particle_stays[i + this_offset];
-                          },
-                          [=] AMREX_GPU_DEVICE (int i, int const& s)
-                          {
-                              int src_i = i + this_offset;
-                              int dst_i = p_particle_stays[i + this_offset] ? s : this_chunk_size-1-(i-s);
-                              copyParticle(dst_data, src_data, src_i, dst_i);
-                          },
-                          Scan::Type::exclusive);
-        }
-
-        if (num_chunks == 1)
-        {
-            ptile.swap(ptile_tmp);
-        }
-        else
-        {
-            AMREX_FOR_1D(this_chunk_size, i,
-                         {
-                             copyParticle(src_data, dst_data, i, i + this_offset);
-                         });
-        }
-
-        if ( ichunk > 0 )
-        {
-            int num_swap = std::min(this_offset - last_offset, num_stay);
-            AMREX_FOR_1D( num_swap, i,
-            {
-                swapParticle(src_data, src_data, last_offset + i,
-                             this_offset + num_stay - 1 - i);
-            });
-        }
-
-        last_offset += num_stay;
-    }
-
-    Gpu::streamSynchronize();
-
-    return last_offset;
 }
 
 #endif

--- a/Src/Particle/AMReX_ParticleUtil.H
+++ b/Src/Particle/AMReX_ParticleUtil.H
@@ -484,15 +484,15 @@ partitionParticles (PTile& ptile, ParFunc&& is_left)
         });
 
     // The ptile will be partitioned into left [0, num_left-1] and right [num_left, np-1].
-    //
-    // Note that currently the number of particles in [0, num_left-1] that should belong to the
-    // right partition is equal to the number of particles in [num_left, np-1] that should belong
-    // in the left partition. We will define num_swaps to be this number. This is the minimum
-    // number of swaps that need to be performed to partition the ptile in-place for any algorithm.
-    //
-    // From this it is easy to see that
-    // max_num_swaps = min(size([0, num_left-1]), size([num_left, np-1]))
-    // is an upper bound for num_swaps.
+    //
+    // Note that currently the number of particles in [0, num_left-1] that should belong to the
+    // right partition is equal to the number of particles in [num_left, np-1] that should belong
+    // in the left partition. We will define num_swaps to be this number. This is the minimum
+    // number of swaps that need to be performed to partition the ptile in place for any algorithm.
+    //
+    // From this it is easy to see that
+    // max_num_swaps = min(size([0, num_left-1]), size([num_left, np-1]))
+    // is an upper bound for num_swaps.
 
     const int max_num_swaps = std::min(num_left, np - num_left);
     if (max_num_swaps == 0) { return num_left; }
@@ -503,18 +503,18 @@ partitionParticles (PTile& ptile, ParFunc&& is_left)
     int * const p_index_right = index_right.dataPtr();
 
     // The num_swaps particles that are in [0, num_left-1] but should be moved to the right
-    // partiton are at the same time the first num_swaps particles for which is_left is false
-    // in all the ptile.
-    // Simularly the num_swaps particles in [num_left, np-1] that should be moved to the left
-    // partiton are the last num_swaps particles of the ptile for which is_left is true.
-    //
-    // The PrefixSum is used to find exactly these particles and store their indexes in
-    // index_left and index_right. Since num_swaps is not known, the first max_num_swaps
-    // particles are stored instead. Here, dst = num_left-1-(i-s) is used to effectively reverse
-    // the PrefixSum to store the last particles for which is_left is true.
-    //
-    // This way, all indexes in index_right are in ascending order, and all indexes in
-    // index_left are in descending order.
+    // partition are at the same time the first num_swaps particles for which is_left is false
+    // in all the ptile.
+    // Similarly, the num_swaps particles in [num_left, np-1] that should be moved to the left
+    // partition are the last num_swaps particles of the ptile for which is_left is true.
+    //
+    // The PrefixSum is used to find exactly these particles and store their indexes in
+    // index_left and index_right. Since num_swaps is not known, the first max_num_swaps
+    // particles are stored instead. Here, dst = num_left-1-(i-s) is used to effectively reverse
+    // the PrefixSum to store the last particles for which is_left is true.
+    //
+    // This way, all indexes in index_right are in ascending order, and all indexes in
+    // index_left are in descending order.
 
     Scan::PrefixSum<int>(np,
         [=] AMREX_GPU_DEVICE (int i) -> int
@@ -537,23 +537,23 @@ partitionParticles (PTile& ptile, ParFunc&& is_left)
         },
         Scan::Type::exclusive, Scan::noRetSum);
 
-    // Finally the particles are swapped. Since max_num_swaps is only an upper bound for num_swaps,
-    // some swaps should not be performed and need to be skipped. This is the case if the index
-    // in index_left[i] is already in the left partition or the index in index_right[i] is already
-    // in the right partition. These two cases coincide for the same i because index_right is in
-    // ascending order and index_left in descending order. This means for both index_left and
-    // index_right the first num_swaps particles need to be swapped, and the particles after that
-    // should be skipped.
-    //
-    // The check right_i < left_i makes sure that the particle going to the right partition is
-    // actually coming from the left partition, which has a lower index than the other particle and
-    // visa-versa.
-    //
-    // Since exactly num_swaps swap operations are performed in the end, which is the smallest
-    // number possible, this algorithm is optimal in the number of swap operations.
-    // This results in good performance in practice if the size of a particle is large enough that
-    // it compensates for the extra kernel launches and evaluations of is_left which this
-    // algorithm needs.
+    // Finally, the particles are swapped. Since max_num_swaps is only an upper bound for num_swaps,
+    // some swaps should not be performed and need to be skipped. This is the case if the index
+    // in index_left[i] is already in the left partition or the index in index_right[i] is already
+    // in the right partition. These two cases coincide for the same i because index_right is in
+    // ascending order and index_left in descending order. This means for both index_left and
+    // index_right the first num_swaps particles need to be swapped, and the particles after that
+    // should be skipped.
+    //
+    // The check right_i < left_i makes sure that the particle going to the right partition is
+    // actually coming from the left partition, which has a lower index than the other particle and
+    // visa-versa.
+    //
+    // Since exactly num_swaps swap operations are performed in the end, which is the smallest
+    // number possible, this algorithm is optimal in the number of swap operations.
+    // This results in good performance in practice if the size of a particle is large enough that
+    // it compensates for the extra kernel launches and evaluations of is_left which this
+    // algorithm needs.
 
     ParallelFor(max_num_swaps,
         [=] AMREX_GPU_DEVICE (int i)


### PR DESCRIPTION
## Summary

Add a function to quickly reorder particles of a particle tile into two partitions. This can be used to remove invalid particles. 

## Additional background

This partition function does not move any particles that don’t need to be moved. In exchange the predicate function needs to be evaluated three times per particle and the GPU stream needs to be synchronized three times.

I tested the performance of `removeInvalidParticles` against an out-of-place prefix sum version without tiling using HiPACE++ where a few random invalid particles were removed each slice and found `removeInvalidParticles` to be 5-10 times faster.

See benchmark of  `partitionParticlesByDest` commented below.

Originally I had a separate simple single-threaded CPU version, however in brief testing it was slightly slower than running the GPU version on the CPU.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
