### PR TITLE
Minor new functions in AMReX_MPMD to provide flexibility for python binding 

### DIFF
--- a/Src/Base/AMReX_MPMD.H
+++ b/Src/Base/AMReX_MPMD.H
@@ -20,7 +20,7 @@ bool Initialized ();
 
 int MyProc ();   //! Process ID in MPI_COMM_WORLD
 int NProcs ();   //! Number of processes in MPI_COMM_WORLD
-int AppNum ();   //! Get the appnum (color) required for MPI_Comm_split 
+int AppNum ();   //! Get the appnum (color) required for MPI_Comm_split
 int MyProgId (); //! Program ID
 
 class Copier

--- a/Src/Base/AMReX_MPMD.H
+++ b/Src/Base/AMReX_MPMD.H
@@ -10,9 +10,9 @@
 
 namespace amrex::MPMD {
 
-MPI_Comm Initialize (int argc, char* argv[]);
-
 void Initialize_without_split (int argc, char* argv[]);
+
+MPI_Comm Initialize (int argc, char* argv[]);
 
 void Finalize ();
 

--- a/Src/Base/AMReX_MPMD.H
+++ b/Src/Base/AMReX_MPMD.H
@@ -12,12 +12,15 @@ namespace amrex::MPMD {
 
 MPI_Comm Initialize (int argc, char* argv[]);
 
+void Initialize_without_split (int argc, char* argv[]);
+
 void Finalize ();
 
 bool Initialized ();
 
 int MyProc ();   //! Process ID in MPI_COMM_WORLD
 int NProcs ();   //! Number of processes in MPI_COMM_WORLD
+int AppNum ();   //! Get the appnum (color)
 int MyProgId (); //! Program ID
 
 class Copier

--- a/Src/Base/AMReX_MPMD.H
+++ b/Src/Base/AMReX_MPMD.H
@@ -20,7 +20,7 @@ bool Initialized ();
 
 int MyProc ();   //! Process ID in MPI_COMM_WORLD
 int NProcs ();   //! Number of processes in MPI_COMM_WORLD
-int AppNum ();   //! Get the appnum (color)
+int AppNum ();   //! Get the appnum (color) required for MPI_Comm_split 
 int MyProgId (); //! Program ID
 
 class Copier

--- a/Src/Base/AMReX_MPMD.cpp
+++ b/Src/Base/AMReX_MPMD.cpp
@@ -38,7 +38,7 @@ AMReX_MPMD variables. This function is internally leveraged by
 Initialize function.
 
 This function needs to be used EXPLICITLY ONLY with pyAMReX (python)
-so that the communication split can be performed using a python 
+so that the communication split can be performed using a python
 library, for example, mpi4py.
 */
 void Initialize_without_split (int argc, char* argv[])

--- a/Src/Base/AMReX_MPMD.cpp
+++ b/Src/Base/AMReX_MPMD.cpp
@@ -88,6 +88,14 @@ MPI_Comm Initialize (int argc, char* argv[])
     return app_comm;
 }
 
+/*
+Initialize_without_split function is a duplicate of Initialize
+with a minor change, i.e., MPI_Comm_split function is not called.
+
+This function needs to be used ONLY with pyAMReX (python) so that 
+the communication split can be performed using a python library,
+for example, mpi4py.
+*/
 void Initialize_without_split (int argc, char* argv[])
 {
     initialized = true;
@@ -163,6 +171,11 @@ int NProcs ()
     return nprocs;
 }
 
+/*
+AppNum function is provided so that appnum (color)
+can be passed to python library (mpi4py) to perform
+a pythonic version of MPI_Comm_split.
+*/
 int AppNum ()
 {
     return appnum;


### PR DESCRIPTION
## Summary
New functions (*void* **Initialize_without_split**, int **AppNum**) are created in Src/Base/AMReX_MPMD.* to provide additional flexibility of calling MPI_Comm_split equivalent in python instead of it being called inside of AMReX, which is the default behavior of *MPI_Comm* **Initialize**.  

The proposed changes:
- [ ] add minor new functions to AMReX_MPMD
