### PR TITLE
Add unsigned int as comm data type

### DIFF
--- a/Src/Base/AMReX_FabArrayBase.cpp
+++ b/Src/Base/AMReX_FabArrayBase.cpp
@@ -2485,12 +2485,17 @@ CheckRcvStats (Vector<MPI_Status>& recv_stats, const Vector<std::size_t>& recv_s
                               ParallelDescriptor::Mpi_typemap<char>::type(),
                               &tmp_count);
                 count = tmp_count;
-            } else if (comm_data_type == 2) {
+            } else if (comm_data_type == 4) {
+                MPI_Get_count(&recv_stats[i],
+                              ParallelDescriptor::Mpi_typemap<unsigned int>::type(),
+                              &tmp_count);
+                count = sizeof(unsigned int) * tmp_count;
+            } else if (comm_data_type == 8) {
                 MPI_Get_count(&recv_stats[i],
                               ParallelDescriptor::Mpi_typemap<unsigned long long>::type(),
                               &tmp_count);
                 count = sizeof(unsigned long long) * tmp_count;
-            } else if (comm_data_type == 3) {
+            } else if (comm_data_type == 64) {
                 MPI_Get_count(&recv_stats[i],
                               ParallelDescriptor::Mpi_typemap<ParallelDescriptor::lull_t>::type(),
                               &tmp_count);

--- a/Tools/GNUMake/comps/dpcpp.mak
+++ b/Tools/GNUMake/comps/dpcpp.mak
@@ -157,6 +157,7 @@ ifeq ($(SYCL_AOT),TRUE)
 endif
 
 ifeq ($(DEBUG),TRUE)
+  # soon --> -flink-huge-device-code
   # This might be needed for linking device code larger than 2GB.
   LDFLAGS += -fsycl-link-huge-device-code
 endif


### PR DESCRIPTION
Previously, we had char, unsigned long long and unsigned long long [8] as comm data type. The issue is we cannot use them for floats or ints. So we add unsigned int, which has a size of 4.

This should solve an issue seen in single precision WarpX runs.
