### PR TITLE
Remove UB from is_aligned

### DIFF
--- a/Src/Base/AMReX_Arena.H
+++ b/Src/Base/AMReX_Arena.H
@@ -22,7 +22,9 @@ inline std::size_t aligned_size (std::size_t align_requirement, std::size_t size
 
 inline bool is_aligned (const void* p, std::size_t alignment) noexcept
 {
-    return (reinterpret_cast<std::size_t>(p) % alignment) == 0;
+    auto* q = const_cast<void*>(p);
+    auto space = alignment;
+    return std::align(alignment, alignment, q, space) == p;
 }
 
 class Arena;


### PR DESCRIPTION
Technically, testing alignment by converting the pointer to integer is undefined behavior. In this PR, we use std::align for the purpose of testing. It is more expensive to do it this way. But we only use it in MPI communication functions.
