### PR TITLE
Add a logspace-like function in AMReX_Algorithm.H

### DIFF
--- a/Src/Base/AMReX_Algorithm.H
+++ b/Src/Base/AMReX_Algorithm.H
@@ -227,6 +227,25 @@ namespace amrex
         }
     }
 
+    template<typename ItType, typename ValType,
+        typename std::enable_if<
+            std::is_floating_point<typename std::iterator_traits<ItType>::value_type>::value &&
+            std::is_floating_point<ValType>::value,
+        int>::type = 0>
+    AMREX_GPU_HOST_DEVICE
+    void logspace (ItType first, const ItType& last,
+        const ValType& start, const ValType& stop, const ValType& base)
+    {
+        const std::ptrdiff_t count = last-first;
+        if (count >= 2){
+            const auto delta = (stop - start)/(count - 1);
+            for (std::ptrdiff_t i = 0; i < count-1; ++i){
+                *(first++) = std::pow(base, start + i*delta);
+            }
+            *first = std::pow(base, stop);
+        }
+    }
+
 namespace detail {
 
 struct clzll_tag {};


### PR DESCRIPTION
## Summary

Similarly to what was done in  https://github.com/AMReX-Codes/amrex/pull/3698,  I would like to propose to add a `logspace-like` function in `AMReX_Algorithm.H`. Indeed, filling a container with logarithmically spaced numbers occurs rather frequently. This PR proposes a possible implementation. As for `linspace`, the container is modified (in place) only if it has at least 2 elements.

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [X] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
