### PR TITLE
Adjust debug info argument for HIP compiler

### DIFF
--- a/Tools/GNUMake/comps/hip.mak
+++ b/Tools/GNUMake/comps/hip.mak
@@ -91,10 +91,10 @@ ifeq ($(HIP_COMPILER),clang)
 
   else  # DEBUG=FALSE flags
 
-    CXXFLAGS += -g -O3 -munsafe-fp-atomics
-    CFLAGS   += -g -O3
-    FFLAGS   += -g -O3
-    F90FLAGS += -g -O3
+    CXXFLAGS += -gline-tables-only -fdebug-info-for-profiling -O3 -munsafe-fp-atomics
+    CFLAGS   += -gline-tables-only -fdebug-info-for-profiling -O3
+    FFLAGS   += -g1 -O3
+    F90FLAGS += -g1 -O3
 
   endif
 


### PR DESCRIPTION
It is reported in #3759 that ROCm 5.3.0-5.7.1 fail at the link stage since #3742. Replacing `-g` with `-gline-tables-only -fdebug-info-for-profiling` solves the issue. Note that for Intel SYCL compilers, we use these two arguments too.

No changes are made to CMake because in Realease build type, no debug info is added.
