### PR TITLE
add AMREX_LIKELY and AMREX_UNLIKELY

### DIFF
--- a/Src/Base/AMReX_Extension.H
+++ b/Src/Base/AMReX_Extension.H
@@ -200,8 +200,8 @@
 #    define AMREX_LIKELY [[likely]]
 #    define AMREX_UNLIKELY [[unlikely]]
 #else
-#    define AMREX_LIKELY ((void)0)
-#    define AMREX_UNLIKELY ((void)0)
+#    define AMREX_LIKELY
+#    define AMREX_UNLIKELY
 #endif
 
 // CI uses -Werror -Wc++17-extension, thus we need to add the __cplusplus clause

--- a/Src/Base/AMReX_Extension.H
+++ b/Src/Base/AMReX_Extension.H
@@ -190,6 +190,20 @@
 #    define AMREX_FALLTHROUGH ((void)0)
 #endif
 
+// Note: following compilers support [[likely]] and [[unlikely]]
+//   - Clang >= 12.0
+//   - GCC >= 9.0
+//   - Intel >= 2021.7
+//   - MSVC >= 19.26
+//   - nvcc >= 12
+#if defined(__has_cpp_attribute) && __has_cpp_attribute(likely) >= 201803L
+#    define AMREX_LIKELY [[likely]]
+#    define AMREX_UNLIKELY [[unlikely]]
+#else
+#    define AMREX_LIKELY ((void)0)
+#    define AMREX_UNLIKELY ((void)0)
+#endif
+
 // CI uses -Werror -Wc++17-extension, thus we need to add the __cplusplus clause
 #if !defined(AMREX_NO_NODISCARD) && defined(__has_cpp_attribute) && __has_cpp_attribute(nodiscard) >= 201603L
 #   define AMREX_NODISCARD [[nodiscard]]


### PR DESCRIPTION
## Summary

This adds support for C++20 `[[likely]]` and `[[unlikely]]`.

Compiler support can be found here:
https://en.cppreference.com/w/cpp/compiler_support

This works with GCC >= 9, nvcc >= 12, clang >= 12

The feature testing info is here:
https://en.cppreference.com/w/cpp/feature_test

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
