### PR TITLE
Pure SoA: `NextID` as `Long`

### DIFF
--- a/Src/Particle/AMReX_ParticleTile.H
+++ b/Src/Particle/AMReX_ParticleTile.H
@@ -382,7 +382,7 @@ struct SoAParticle : SoAParticleBase
     {
     }
 
-    static int the_next_id;
+    static Long the_next_id;
 
     //functions to get id and cpu in the SOA data
 
@@ -423,19 +423,19 @@ struct SoAParticle : SoAParticleBase
         return this->m_particle_tile_data.m_rdata[position_index][m_index];
     }
 
-    static int NextID ();
+    static Long NextID ();
 
     /**
     * \brief This version can only be used inside omp critical.
     */
-    static int UnprotectedNextID ();
+    static Long UnprotectedNextID ();
 
     /**
     * \brief Reset on restart.
     *
     * \param nextid
     */
-    static void NextID (int nextid);
+    static void NextID (Long nextid);
 
 private :
 
@@ -446,10 +446,10 @@ private :
 };
 
 //template <int NArrayReal, int NArrayInt> Long ConstSoAParticle<NArrayReal, NArrayInt>::the_next_id = 1;
-template <int NArrayReal, int NArrayInt> int SoAParticle<NArrayReal, NArrayInt>::the_next_id = 1;
+template <int NArrayReal, int NArrayInt> Long SoAParticle<NArrayReal, NArrayInt>::the_next_id = 1;
 
 template <int NArrayReal, int NArrayInt>
-int
+Long
 SoAParticle<NArrayReal, NArrayInt>::NextID ()
 {
     Long next;
@@ -466,14 +466,14 @@ SoAParticle<NArrayReal, NArrayInt>::NextID ()
         amrex::Abort("SoAParticle<NArrayReal, NArrayInt>::NextID() -- too many particles");
     }
 
-    return int(next);
+    return next;
 }
 
 template <int NArrayReal, int NArrayInt>
-int
+Long
 SoAParticle<NArrayReal, NArrayInt>::UnprotectedNextID ()
 {
-    int next = the_next_id++;
+    Long next = the_next_id++;
     if (next > LongParticleIds::LastParticleID) {
         amrex::Abort("SoAParticle<NArrayReal, NArrayInt>::NextID() -- too many particles");
     }
@@ -482,7 +482,7 @@ SoAParticle<NArrayReal, NArrayInt>::UnprotectedNextID ()
 
 template <int NArrayReal, int NArrayInt>
 void
-SoAParticle<NArrayReal, NArrayInt>::NextID (int nextid)
+SoAParticle<NArrayReal, NArrayInt>::NextID (Long nextid)
 {
     the_next_id = nextid;
 }


### PR DESCRIPTION
## Summary

This is a leftover from an earlier implementation of pure SoA. Our 39bit particle ids must be stored in an `amrex::Long`. An `int` will crop them to 32bit range, which we quickly run out from.

## Additional background

Related to  #3569 / #3585.

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
