### PR TITLE
Fix bug in AMREX_ASSUME

### DIFF
--- a/Src/Base/AMReX_Extension.H
+++ b/Src/Base/AMReX_Extension.H
@@ -213,7 +213,7 @@
 #if defined(__has_cpp_attribute) && __has_cpp_attribute(assume)
 #   define AMREX_ASSUME(ASSUMPTION) [[assume(ASSUMPTION)]]
 #else
-#   if defined(__CUDACC__) && ( (__CUDACC_VER_MAJOR__ > 11) || ((__CUDACC_VER_MAJOR__ == 11) && (__CUDACC_VER_MINOR__ >= 1)) )
+#   if defined(__CUDA_ARCH__) && defined(__CUDACC__) && ( (__CUDACC_VER_MAJOR__ > 11) || ((__CUDACC_VER_MAJOR__ == 11) && (__CUDACC_VER_MINOR__ >= 1)) )
 #       define AMREX_ASSUME(ASSUMPTION) __builtin_assume(ASSUMPTION)
 #   elif defined(AMREX_CXX_INTEL) || defined(__clang__)
 #       define AMREX_ASSUME(ASSUMPTION) __builtin_assume(ASSUMPTION)

--- a/Src/Base/AMReX_Extension.H
+++ b/Src/Base/AMReX_Extension.H
@@ -213,7 +213,7 @@
 #if defined(__has_cpp_attribute) && __has_cpp_attribute(assume)
 #   define AMREX_ASSUME(ASSUMPTION) [[assume(ASSUMPTION)]]
 #else
-#   if defined(__CUDA_ARCH__) && defined(__CUDACC__) && ( (__CUDACC_VER_MAJOR__ > 11) || ((__CUDACC_VER_MAJOR__ == 11) && (__CUDACC_VER_MINOR__ >= 1)) )
+#   if defined(__CUDA_ARCH__) && defined(__CUDACC__) && ( (__CUDACC_VER_MAJOR__ > 11) || ((__CUDACC_VER_MAJOR__ == 11) && (__CUDACC_VER_MINOR__ >= 2)) )
 #       define AMREX_ASSUME(ASSUMPTION) __builtin_assume(ASSUMPTION)
 #   elif defined(AMREX_CXX_INTEL) || defined(__clang__)
 #       define AMREX_ASSUME(ASSUMPTION) __builtin_assume(ASSUMPTION)


### PR DESCRIPTION
## Summary

This PR fixes a couple of  bugs in `AMREX_ASSUME` :

- If `nvcc` is used with  `gcc/g++` as the host compiler we have to use  `__builtin_assume(ASSUMPTION)` in device code and `if (ASSUMPTION) {} else { __builtin_unreachable(); }` in host code. Therefore we need to add `if defined(__CUDA_ARCH__)`

- Even if `__builtin_assume` appears in the CUDA 11.1 documentation, tests carried out with the Compiler Explorer show that we actually need at least CUDA 11.2 . 

## Additional background

You can compare the [new version](https://godbolt.org/#z:OYLghAFBqd5QCxAYwPYBMCmBRdBLAF1QCcAaPECAMzwBtMA7AQwFtMQByARg9KtQYEAysib0QXACx8BBAKoBnTAAUAHpwAMvAFYTStJg1DIAruiakl9ZATwDKjdAGFUtEywZ7HAGTwNMAHLuAEaYxCAAzBGkAA6oCoR2DC5uHnpxCbYCvv5BLKHhUZaY1lkMQgRMxAQp7p5cxaVJFVUEOYEhYZHRCpXVtWkNva3teQXdAJSWqCbEyOwcAKQATBF%2ByG5YANSLEU7Ivfiou9iLGgCCZ5ereFRbWDT%2B6BAA%2Bi8ITAovyDExL0wEAjEPDBEwETATHbLABsK2hWzeHy%2BPz%2BAKBILBmAgnwU7ghVxWES2xIefkwW3OAFkAErYAAaL3OQiEckp2AgTJZlOUABUAJIAeQCkMWAFYAEJi8U4vEc5ms3mC4VigAiqoJqxKSg1ROJt3umEemGebycchV50Z1KcAAk3iKYXCDUaTS8zRanE57cS4U6IFtXm7zedPS8AGrYakvSnnABSAqjLx2EWwWy4XBFAHYnItswHA%2B6Q16I1GY/HE8m1REVWmM1DYTCA6bg6GS9G%2BQEE29k6dq1tlhNIRMdcTRyTDWSKTT6Yz5Wy5VzFULIW9QXRbAx/gpcWwFwr%2BcuR8SSvrSU8OdOGU46QyOzzsN4szm82fjYGNoZgPaj2PnZOqbSDKcqy7LAdyB7CgiLxrrQG5bjuWJgUuyoXISo4nncr4mpSQjFpGw6oasv7jkaU6AbOXKgXOyErvBspIRBBHXLqWwYX%2B55vAA4gEchei8TFocRr5kTOYFUYujFbPqe7gUqWaSpmNZauSubilBMFwSYDDEJgTDIB8wT0BAw4RGpuZqoRLHKT%2BY7CQBolzuJ%2B5yT%2Bji3DqblUASqEXG8wC0KgwRiN2ABuqB4OgWymOY7wlAFxmqVcY5%2BAQUmVmmuyShcY72UBjkQHgPZbBoJlZecY4xMCghUBAKzLDacWoFsADqJC0JFVDEKgLBbJxyhyGAYBik4DB1aVBKKd55wpVsLBMH4xk7JmZXJYIWzaOlXCZUlo65RRIEQBtJzFeN2WjtFTCxbQAW7Dmey3Q0W0picJwJaZOxncSOkELMDDFdtqGTT55wcFMtCcKKvCeBwWikKgnCFlsObLJKKNbAoMxzCpqw8KQBCaKDUwANYgKKEQAHQAJwaNCGgaJmkiUxEXDQqKmbLPonCSFDBNw5wvAKCAGh4wTUxwLAMCICg3UxHQYTkJQaAsLL9DhAwIXIMg6YczQsFhILEDBLzwR%2BFUACenC4ybzDEGbArBNomA2JbvBK2wggCgwtAWzDvBYKCwBOGItCC9wfuYHNRjiL7pD4DpNh4CFmCh7DmCqE7mIu%2BQgglLztAgsQ5suFgvPoiwot8AYwAKGGeCYAA7gKMSMFn/CCCIYjsFIMiCIoKjqDHugNAYRgoGYFj58EguQFMqAxGUoe8KgSfEMCWDT8ZjRO2UDgMM4rh1F4e%2BjJ04QNBkiQCAM9SxPEl8MCf%2BRdEMJTb80fQ1AfgxbwnAgtNUj9xhDA/tfPQwwAFkjGM/KYGNZjzAkGDCGPMY7ww4FsAIYZPS1nJsscmGgAy4EICQKEzMJi8Hxr7QcpASZRHJhEAAHBoUUNNKZcA0Kw6E0hwYcG5qQcuopcFcGWJIehURKaU0zBESQERKbQlINDWGqCBZCxFpQ0g4spYzAIDEMECsIBKxVmEAIrAFgYKwUIuh5NcbGiIWvPQbdhCiHEN3Bxfc1C8yHqQeuhcYgu0QRwSG8jeaoIFGCHRqVUB3DMU4bBuD8EQBcMrOWxASEZnIaLKYCBdJYHCJvbhvDy5SHJqKSQXBREwmhEzZYyxMxCKCSg/mlgVEUK0GLSWEAkBYBCngeYeiDHJOMWwTg0TYl4PDt0%2BBHAhCcgDAoFgLwBFkNIDYogdiGgOI7s46QrilDuMHmA1%2Bv9PAQEcKAhoPhIGn3SHfMoZzb6ZCSIA5%2BP8yj/0/qkG%2BVg35/w/k8s%2BlgQFf0%2Bb8y5T8z5TCBJgTAEUhb%2BMCQopenAVSYAmeSWuDcwjoMwTE9MOC8EEPwKs1JpAkYy2SakpZLTCacx4bwcutCoiMqZcy%2BpijGmC2FlSqhJNJDQjwUzcRyxmHQlEdImlERkFso4Okyh/jliSsRdK1RrSpgrwSPYSQQA%3D%3D%3D) of the macro with the [old one](https://godbolt.org/#z:OYLghAFBqd5QCxAYwPYBMCmBRdBLAF1QCcAaPECAMzwBtMA7AQwFtMQByARg9KtQYEAysib0QXACx8BBAKoBnTAAUAHpwAMvAFYTStJg1DIAruiakl9ZATwDKjdAGFUtEywYSATNMcAZPAZMADl3ACNMYhAANlIAB1QFQjsGFzcPb2kEpNsBAKDQlgio2KtMGxShAiZiAjT3Ty4fS0xrXIYqmoJ8kPDImMtq2vqMpukFIe7A3qL%2B6IBKS1QTYmR2DgBSLwBmQOQ3LABqDe2nZAn8VBPsDY0AQVuHnbwqQ6waIPQIAH1vhCYFN9kHE4t8mAQCMQ8GETARMPNjl5oltoodfv9AcDQeDIdDYZgIACFO54Y8tttDpT3tNDncALIAJWwAA1vnchEI5HTsBB2Zy6coACoASQA8sEERsAKwAIWlMqJJN5HK5QrFEulABEtWSdq0lLqKZSXm9MB9MF9fk45Jq7k4nL8EYjkUjDhA3VabXaHQA1bAM750u4AKVFAe%2Bx222EOXC4koA7E4Nom3T9vtbbfbvn6A0HQ%2BHI9rtpqY3HnSiPemvVmc4HhcEw79IzdizH5gj5obKd2qWaafSmay%2BVyecOBSLxQjfjC6LYGGCFMS2Mr%2BWrJ13Ka0TdTPrzGSz08zWfXBdg/Amkymdxa0/tDMBHRue6bzbT90OVdyV6qJxK0d8Z1oOcFyXAkxzXDV7nJbst1ea9LTpIRfX9TsoJ2Z9e1fAcDzHUdPwgqcQKVcDf1Qp4jUOWCX2mS1vgAcWCOQHW%2BMjoIw6830HNlPzw1dSMOE1v3HdUEzleMS31TBjnjGV/0A4CTAYYhMCYZB/jCegIE7bZZOTbU0IoySnx7DjsI/fleJ/ESn0cF5DVsqgySg%2B5fmAWhUDCMQmwAN1QPB0EOUxzD%2BVp3K05M5XuHtAgIATCxjE5IruHszO4iyIDwZtDg0bSkp7OIoUEKgIC2LwAAlQtQQ4AHUSFoAKqGIVAWEOOjlDkMAwGlJwGFK3KyXEpy7hiw4WCYQItOkvLuxG7R4q4RLHhS980pHCA5uubL%2Bqi7sgqYELaHck4k1OY6uFIBao2ua5wp044dspZSCBWBhssWqDBucu4OEWWhOClXhPA4LRSFQTgM2SpMvDlaHDgUZZVik8keFIAhNB%2BxYAGsQClbYADoAE4NGiDQNHjSQCe2LhoileMvH0ThJEB9HQc4XgFBADRUfRxY4FgGBEBQZq4joSJyEoNAWBF%2BgogYbzkGQWN6ZoIDIg5iAwhZsJAhqABPTgUe15hiF10Uwm0co0e4XhJbYQRRQYWh9eB3gsBhYAnDEWgOet0gsDGoxxBdv28GUipvMwH2QcwVRynxA3eBi1oWdoaFiD1lwsBZ3EWB5vgDGABQfTwTAAHdRTiRgE5kQQRDEdgpBr%2BQlDUFndHOgwjBQMwLFTsIOcgRZUDidofd4VAI%2BIKEsAHrSWjaFIHAYZxXAaPR/GmQpij0bJkgEEZGniRI94YHot/6c6ygqAROmGVfRnny3KkmM%2B%2BiiS/JgPvQJi6V/ZnfxY8MVhrAkL9f6zNg5gw4IcYIPp7Sljxl4PGGg3S4EICQREVN5i8CtlodspBsbbHxtsAAHBoKUxMCZcA0FQ6I0g/ocCZqQXOUokFjBIUQgmBN4zbEkNsAmsQgYgygezTm3MXa8wFhAJAywCBxFhOLCAktpaRGCKwdYsD4FNDxvjFGFp0HTz0PwWuohxCN2Mc3FQ6hg7t1IKXdOcQE5gI4ADUgQjx6cFFLCeRsVUCvE0U4BBSCUEQBcFLUWxBMFxhwTzRYCAVJYCiHPBhTDc5SDxlKSQXAOFImiJTLwXh4xNDcSzERlgxG4J%2BqQPmgssDeTwGsRRyiIlqLYJwAJQTkGu0wPUkBHAhB8jdAoFg3xWHYNIPooghjzoWLrmY6QFjFBWLbt/VoT97AQEcF/c6G8Chvx3sfdo2yj45BSH/bel81nXw6J/e%2Bh8r7tFvlMPZ/9v63PSPcl%2Bm99lxlRspTA/lObONce41mHBNQ9IaVJYuZdIgwLgYE2MiDkGoPwFMqJpBDhhJUZE5G4zKn4JSbwXORCdFEPJRSilJTIFs3KVzAlWMQCSGiMgymXCvAUOiBwvhDMODbAgcI2lDLeVeAFR4jgMSJGLEnkkewkggA%3D)
## Checklist

The proposed changes:
- [X] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
