### PR TITLE
Introduce: `AMReX_ADDRLINES` (Default: ON)

### DIFF
--- a/Docs/sphinx_documentation/source/BuildingAMReX.rst
+++ b/Docs/sphinx_documentation/source/BuildingAMReX.rst
@@ -496,6 +496,8 @@ The list of available options is reported in the :ref:`table <tab:cmakevar>` bel
    +------------------------------+-------------------------------------------------+-------------------------+-----------------------+
    | AMReX_FPE                    |  Build with Floating Point Exceptions checks    | NO                      | YES, NO               |
    +------------------------------+-------------------------------------------------+-------------------------+-----------------------+
+   | AMReX_ADDRLINES              |  Build with minimal debug info for line numbers | YES                     | YES, NO               |
+   +------------------------------+-------------------------------------------------+-------------------------+-----------------------+
    | AMReX_ASSERTIONS             |  Build with assertions turned on                | NO                      | YES, NO               |
    +------------------------------+-------------------------------------------------+-------------------------+-----------------------+
    | AMReX_BOUND_CHECK            |  Enable bound checking in Array4 class          | NO                      | YES, NO               |
@@ -617,6 +619,8 @@ In the above snippet, ``<amrex-target-name>`` is any of the targets listed in th
    | Flags_Fortran         |  Fortran flags preset (interface)               |
    +-----------------------+-------------------------------------------------+
    | Flags_FPE             |  Floating Point Exception flags (interface)     |
+   +-----------------------+-------------------------------------------------+
+   | Flags_ADDRLINES       |  Minimal debug/line numbers flags (interface)   |
    +-----------------------+-------------------------------------------------+
 .. raw:: latex
 

--- a/Docs/sphinx_documentation/source/Debugging.rst
+++ b/Docs/sphinx_documentation/source/Debugging.rst
@@ -29,6 +29,9 @@ with ``TEST=TRUE`` or ``DEBUG=TRUE`` in GNU make, or with ``-DCMAKE_BUILD_TYPE=D
 One can also control the setting for ``FArrayBox`` using the runtime parameter, ``fab.init_snan``.
 Note for Macs, M1 and M2 chips using Arm64 architecture are not able to trap division by zero.
 
+By default, even AMReX release mode builds add minimal address to line debub information.
+This can be turned off via ``-DAMReX_ADDRLINES=NO``.
+
 One can get more information than the backtrace of the call stack by
 instrumenting the code.  Here is an example.
 You know the line ``Real rho = state(cell,0);`` is causing a segfault.  You

--- a/Src/CMakeLists.txt
+++ b/Src/CMakeLists.txt
@@ -86,6 +86,13 @@ foreach(D IN LISTS AMReX_SPACEDIM)
           $<BUILD_INTERFACE:Flags_FPE>
           )
     endif ()
+
+    if (AMReX_ADDRLINES)
+       target_link_libraries(amrex_${D}d
+          PUBLIC
+          $<BUILD_INTERFACE:Flags_ADDRLINES>
+          )
+    endif ()
 endforeach()
 
 # General configuration

--- a/Tools/CMake/AMReXConfig.cmake.in
+++ b/Tools/CMake/AMReXConfig.cmake.in
@@ -88,6 +88,7 @@ set(AMReX_HDF5_ZFP_FOUND            @AMReX_HDF5_ZFP@)
 
 # Compilation options
 set(AMReX_FPE_FOUND                 @AMReX_FPE@)
+set(AMReX_ADDRLINES_FOUND           @AMReX_ADDRLINES@)
 set(AMReX_PIC_FOUND                 @AMReX_PIC@)
 set(AMReX_ASSERTIONS_FOUND          @AMReX_ASSERTIONS@)
 

--- a/Tools/CMake/AMReXFlagsTargets.cmake
+++ b/Tools/CMake/AMReXFlagsTargets.cmake
@@ -5,6 +5,7 @@
 #   Flags_CXX                 --> Optional flags for C++ code
 #   Flags_Fortran             --> Optional flags for Fortran code
 #   Flags_FPE                 --> Floating-Point Exception flags for both C++ and Fortran
+#   Flags_ADDRLINES           --> Minimal debug flags that only record address to line number
 #
 # These INTERFACE targets can be added to the AMReX export set.
 #
@@ -60,6 +61,24 @@ else ()
    endforeach ()
 endif ()
 
+
+#
+# Minimal Debug info for address --> line
+#
+add_library(Flags_ADDRLINES INTERFACE)
+add_library(AMReX::Flags_ADDRLINES ALIAS Flags_ADDRLINES)
+
+target_compile_options( Flags_ADDRLINES
+   INTERFACE
+   $<${_cxx_gnu}:-g1>
+   $<${_cxx_intel}:>  # TODO: help wanted
+   $<${_cxx_pgi}:>  # TODO: help wanted
+   $<${_cxx_cray}:>  # TODO: help wanted
+   $<${_cxx_clang}:-gline-tables-only>
+   $<${_cxx_appleclang}:-gline-tables-only>
+   # info for profiling: minimal addition and needed for Intel VTune
+   $<${_cxx_intelllvm}:-gline-tables-only -fdebug-info-for-profiling>
+)
 
 #
 # C++ flags

--- a/Tools/CMake/AMReXOptions.cmake
+++ b/Tools/CMake/AMReXOptions.cmake
@@ -369,6 +369,9 @@ print_option( AMReX_IPO )
 option(AMReX_FPE "Enable Floating Point Exceptions checks" OFF)
 print_option( AMReX_FPE )
 
+option(AMReX_ADDRLINES "Add minimal debug info that only records line numbers" ON)
+print_option( AMReX_ADDRLINES )
+
 if ( "${CMAKE_BUILD_TYPE}" MATCHES "Debug" )
    option( AMReX_ASSERTIONS "Enable assertions" ON)
 else ()
@@ -377,7 +380,7 @@ endif ()
 
 print_option( AMReX_ASSERTIONS )
 
-option(AMReX_BOUND_CHECK  "Enable bound checking in Array4 class" OFF)
+option(AMReX_BOUND_CHECK "Enable bound checking in Array4 class" OFF)
 print_option( AMReX_BOUND_CHECK )
 
 if("${CMAKE_SYSTEM_NAME}" MATCHES "Darwin")

--- a/Tools/CMake/AMReX_Config.cmake
+++ b/Tools/CMake/AMReX_Config.cmake
@@ -23,8 +23,10 @@ function (configure_amrex AMREX_TARGET)
    #
    # Check that needed options have already been defined
    #
-   if ( ( NOT ( DEFINED AMReX_MPI ) ) OR ( NOT (DEFINED AMReX_OMP) )
-	 OR ( NOT (DEFINED AMReX_PIC) ) OR (NOT (DEFINED AMReX_FPE)))
+   if ( (NOT (DEFINED AMReX_MPI) ) OR (NOT (DEFINED AMReX_OMP) )
+	 OR (NOT (DEFINED AMReX_PIC) ) OR (NOT (DEFINED AMReX_FPE) )
+	 OR (NOT (DEFINED AMReX_ADDRLINES) )
+   )
       message ( AUTHOR_WARNING "Required options are not defined" )
    endif ()
 


### PR DESCRIPTION
## Summary

This is adding the new CMake option `AMReX_ADDRLINES` and CMake public interface target `AMReX::FLAGS_ADDRLINES`. This option adds *minimal* debug info (`-g1` / `-gline-tables-only`) to executables, which generates more usable backtraces on crashes.

In symmetry to GNUmake, we turn this now ON. This is a breaking change.

Note that this flag still creates significant binary size overheads, so package managers might decide to turn if off in deployments. Also, if the increased binary sizes lead to significant startup overhead at scale on HPC systems, we might need to reconsider the default (for CMake and GNUmake) in the future.

## Additional background

Binary size benchmarks on WarpX.

```
|                           | HIP Size (MiB) | GCC Size (MiB) |
|---------------------------+----------------+----------------|
| release, no debug info    |           30.7 |           12.1 |
| release, addr lines/`-g1` |           69.1 |           53.9 |
| release, `-g`             |          158.7 |          257.9 |
| debug                     |          489.0 |          173.3 |
```

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [x] are likely to significantly affect the results of downstream AMReX users
- [x] include documentation in the code and/or rst files, if appropriate