### PR TITLE
fix for ref_ratio=1

### DIFF
--- a/Src/AmrCore/AMReX_InterpFaceReg_3D_C.H
+++ b/Src/AmrCore/AMReX_InterpFaceReg_3D_C.H
@@ -12,11 +12,10 @@ void interp_face_reg (int i, int j, int k, IntVect const& rr, Array4<Real> const
     int jc = amrex::coarsen(j,rr[1]);
     int kc = amrex::coarsen(k,rr[2]);
     if (idim == 0) {
-        if (jc == domface.smallEnd(1) || jc == domface.bigEnd(1)) {
-            for (int n = 0; n < ncomp; ++n) {
-                fine(i,j,k,n+scomp) = crse(ic,jc,kc,n);
-            }
-        } else {
+        for (int n = 0; n < ncomp; ++n) {
+            fine(i,j,k,n+scomp) = crse(ic,jc,kc,n);
+        }
+        if (jc != domface.smallEnd(1) && jc != domface.bigEnd(1) && rr[1] > 1) {
             Real sfy = Real(1.0);
             for (int n = 0; n < ncomp; ++n) {
                 Real dc = Real(0.5) * (crse(ic,jc+1,kc,n) - crse(ic,jc-1,kc,n));
@@ -32,11 +31,11 @@ void interp_face_reg (int i, int j, int k, IntVect const& rr, Array4<Real> const
             }
             Real yoff = (static_cast<Real>(j - jc*rr[1]) + Real(0.5)) / Real(rr[1]) - Real(0.5);
             for (int n = 0; n < ncomp; ++n) {
-                fine(i,j,k,n+scomp) = crse(ic,jc,kc,n) + yoff * slope(i,j,k,n) * sfy;
+                fine(i,j,k,n+scomp) += yoff * slope(i,j,k,n) * sfy;
             }
         }
 
-        if (kc != domface.smallEnd(2) && kc != domface.bigEnd(2)) {
+        if (kc != domface.smallEnd(2) && kc != domface.bigEnd(2) && rr[2] > 1) {
             Real sfz = Real(1.0);
             for (int n = 0; n < ncomp; ++n) {
                 Real dc = Real(0.5) * (crse(ic,jc,kc+1,n) - crse(ic,jc,kc-1,n));
@@ -56,11 +55,10 @@ void interp_face_reg (int i, int j, int k, IntVect const& rr, Array4<Real> const
             }
         }
     } else if (idim == 1) {
-        if (ic == domface.smallEnd(0) || ic == domface.bigEnd(0)) {
-            for (int n = 0; n < ncomp; ++n) {
-                fine(i,j,k,n+scomp) = crse(ic,jc,kc,n);
-            }
-        } else {
+        for (int n = 0; n < ncomp; ++n) {
+            fine(i,j,k,n+scomp) = crse(ic,jc,kc,n);
+        }
+        if (ic != domface.smallEnd(0) && ic == domface.bigEnd(0) && rr[0] > 1) {
             Real sfx = Real(1.0);
             for (int n = 0; n < ncomp; ++n) {
                 Real dc = Real(0.5) * (crse(ic+1,jc,kc,n) - crse(ic-1,jc,kc,n));
@@ -76,11 +74,11 @@ void interp_face_reg (int i, int j, int k, IntVect const& rr, Array4<Real> const
             }
             Real xoff = (static_cast<Real>(i - ic*rr[0]) + Real(0.5)) / Real(rr[0]) - Real(0.5);
             for (int n = 0; n < ncomp; ++n) {
-                fine(i,j,k,n+scomp) = crse(ic,jc,kc,n) + xoff * slope(i,j,k,n) * sfx;
+                fine(i,j,k,n+scomp) += xoff * slope(i,j,k,n) * sfx;
             }
         }
 
-        if (kc != domface.smallEnd(2) && kc != domface.bigEnd(2)) {
+        if (kc != domface.smallEnd(2) && kc != domface.bigEnd(2) && rr[2] > 1) {
             Real sfz = Real(1.0);
             for (int n = 0; n < ncomp; ++n) {
                 Real dc = Real(0.5) * (crse(ic,jc,kc+1,n) - crse(ic,jc,kc-1,n));
@@ -100,11 +98,10 @@ void interp_face_reg (int i, int j, int k, IntVect const& rr, Array4<Real> const
             }
         }
     } else {
-        if (ic == domface.smallEnd(0) || ic == domface.bigEnd(0)) {
-            for (int n = 0; n < ncomp; ++n) {
-                fine(i,j,k,n+scomp) = crse(ic,jc,kc,n);
-            }
-        } else {
+        for (int n = 0; n < ncomp; ++n) {
+            fine(i,j,k,n+scomp) = crse(ic,jc,kc,n);
+        }
+        if (ic != domface.smallEnd(0) && ic != domface.bigEnd(0) && rr[0] > 1) {
             Real sfx = Real(1.0);
             for (int n = 0; n < ncomp; ++n) {
                 Real dc = Real(0.5) * (crse(ic+1,jc,kc,n) - crse(ic-1,jc,kc,n));
@@ -120,11 +117,11 @@ void interp_face_reg (int i, int j, int k, IntVect const& rr, Array4<Real> const
             }
             Real xoff = (static_cast<Real>(i - ic*rr[0]) + Real(0.5)) / Real(rr[0]) - Real(0.5);
             for (int n = 0; n < ncomp; ++n) {
-                fine(i,j,k,n+scomp) = crse(ic,jc,kc,n) + xoff * slope(i,j,k,n) * sfx;
+                fine(i,j,k,n+scomp) += xoff * slope(i,j,k,n) * sfx;
             }
         }
 
-        if (jc != domface.smallEnd(1) && jc != domface.bigEnd(1)) {
+        if (jc != domface.smallEnd(1) && jc != domface.bigEnd(1) && rr[1] > 1) {
             Real sfy = Real(1.0);
             for (int n = 0; n < ncomp; ++n) {
                 Real dc = Real(0.5) * (crse(ic,jc+1,kc,n) - crse(ic,jc-1,kc,n));

--- a/Src/AmrCore/AMReX_InterpFaceReg_3D_C.H
+++ b/Src/AmrCore/AMReX_InterpFaceReg_3D_C.H
@@ -58,7 +58,7 @@ void interp_face_reg (int i, int j, int k, IntVect const& rr, Array4<Real> const
         for (int n = 0; n < ncomp; ++n) {
             fine(i,j,k,n+scomp) = crse(ic,jc,kc,n);
         }
-        if (ic != domface.smallEnd(0) && ic == domface.bigEnd(0) && rr[0] > 1) {
+        if (ic != domface.smallEnd(0) && ic != domface.bigEnd(0) && rr[0] > 1) {
             Real sfx = Real(1.0);
             for (int n = 0; n < ncomp; ++n) {
                 Real dc = Real(0.5) * (crse(ic+1,jc,kc,n) - crse(ic-1,jc,kc,n));


### PR DESCRIPTION
## Summary

The current routines compute the slope even if ref_ratio = 1.  In this PR we test on ref_ratio before trying to compute slopes and if ref_ratio is equal to 1, we bypass the slope computation.

## Additional background

## Checklist

The proposed changes:
- [X] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
