### PR TITLE
Robin BC: Abort if solver is not safe for reuse

### DIFF
--- a/Src/LinearSolvers/MLMG/AMReX_MLABecLaplacian.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLABecLaplacian.H
@@ -409,6 +409,8 @@ MLABecLaplacianT<MF>::update ()
     applyMetricTermsCoeffs();
 #endif
 
+    applyRobinBCTermsCoeffs();
+
     averageDownCoeffs();
 
     update_singular_flags();

--- a/Src/LinearSolvers/MLMG/AMReX_MLABecLaplacian.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLABecLaplacian.H
@@ -207,6 +207,8 @@ private:
 
     int m_ncomp = 1;
 
+    bool m_applyRobinBCTermsCoeffs_called = false;
+
     void define_ab_coeffs ();
 
     void update_singular_flags ();
@@ -586,7 +588,10 @@ void
 MLABecLaplacianT<MF>::applyRobinBCTermsCoeffs ()
 {
     if (this->hasRobinBC()) {
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(!m_applyRobinBCTermsCoeffs_called,
+                                         "MLABecLaplacian cannot be reused when there is Robin BC");
         detail::applyRobinBCTermsCoeffs(*this);
+        m_applyRobinBCTermsCoeffs_called = true;
     }
 }
 

--- a/Src/LinearSolvers/MLMG/AMReX_MLABecLaplacian.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLABecLaplacian.H
@@ -195,6 +195,9 @@ public:
     Vector<Vector<MF> > m_a_coeffs;
     Vector<Vector<Array<MF,AMREX_SPACEDIM> > > m_b_coeffs;
 
+    bool m_scalars_set = false;
+    bool m_acoef_set = false;
+
 protected:
 
     bool m_needs_update = true;
@@ -206,8 +209,6 @@ protected:
 private:
 
     int m_ncomp = 1;
-
-    bool m_applyRobinBCTermsCoeffs_called = false;
 
     void define_ab_coeffs ();
 
@@ -310,7 +311,9 @@ MLABecLaplacianT<MF>::setScalars (T1 a, T2 b) noexcept
         for (int amrlev = 0; amrlev < this->m_num_amr_levels; ++amrlev) {
             m_a_coeffs[amrlev][0].setVal(RT(0.0));
         }
+        m_acoef_set = true;
     }
+    m_scalars_set = true;
 }
 
 template <typename MF>
@@ -325,6 +328,7 @@ MLABecLaplacianT<MF>::setACoeffs (int amrlev, const AMF& alpha)
                               "MLABecLaplacian::setACoeffs: alpha is supposed to be single component.");
     m_a_coeffs[amrlev][0].LocalCopy(alpha, 0, 0, 1, IntVect(0));
     m_needs_update = true;
+    m_acoef_set = true;
 }
 
 template <typename MF>
@@ -335,6 +339,7 @@ MLABecLaplacianT<MF>::setACoeffs (int amrlev, T alpha)
 {
     m_a_coeffs[amrlev][0].setVal(RT(alpha));
     m_needs_update = true;
+    m_acoef_set = true;
 }
 
 
@@ -490,6 +495,14 @@ void applyRobinBCTermsCoeffs (LP& linop)
     }
     const RT bovera = linop.m_b_scalar/linop.m_a_scalar;
 
+    if (!reset_alpha) {
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(linop.m_scalars_set && linop.m_acoef_set,
+                                         "To reuse solver With Robin BC, one must re-call setScalars (and setACoeffs if the scalar is not zero)");
+    }
+
+    linop.m_scalars_set = false;
+    linop.m_acoef_set = false;
+
     for (int amrlev = 0; amrlev < linop.NAMRLevels(); ++amrlev) {
         const int mglev = 0;
         const Box& domain = linop.Geom(amrlev,mglev).Domain();
@@ -588,10 +601,7 @@ void
 MLABecLaplacianT<MF>::applyRobinBCTermsCoeffs ()
 {
     if (this->hasRobinBC()) {
-        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(!m_applyRobinBCTermsCoeffs_called,
-                                         "MLABecLaplacian cannot be reused when there is Robin BC");
         detail::applyRobinBCTermsCoeffs(*this);
-        m_applyRobinBCTermsCoeffs_called = true;
     }
 }
 

--- a/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap.H
@@ -159,6 +159,10 @@ protected:
     void averageDownCoeffsToCoarseAmrLevel (int flev);
 
     [[nodiscard]] bool supportRobinBC () const noexcept override { return true; }
+
+private:
+
+    bool m_applyRobinBCTermsCoeffs_called = false;
 };
 
 }

--- a/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap.H
@@ -129,6 +129,9 @@ public:
     Vector<Vector<MultiFab> > m_a_coeffs;
     Vector<Vector<Array<MultiFab,AMREX_SPACEDIM> > > m_b_coeffs;
 
+    bool m_scalars_set = false;
+    bool m_acoef_set = false;
+
 protected:
 
     int m_ncomp = 1;
@@ -159,10 +162,6 @@ protected:
     void averageDownCoeffsToCoarseAmrLevel (int flev);
 
     [[nodiscard]] bool supportRobinBC () const noexcept override { return true; }
-
-private:
-
-    bool m_applyRobinBCTermsCoeffs_called = false;
 };
 
 }

--- a/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap.cpp
@@ -1291,7 +1291,10 @@ void
 MLEBABecLap::applyRobinBCTermsCoeffs ()
 {
     if (this->hasRobinBC()) {
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(!m_applyRobinBCTermsCoeffs_called,
+                                         "MLEBABecLap cannot be reused when there is Robin BC");
         detail::applyRobinBCTermsCoeffs(*this);
+        m_applyRobinBCTermsCoeffs_called = true;
     }
 }
 

--- a/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap.cpp
@@ -116,7 +116,9 @@ MLEBABecLap::setScalars (Real a, Real b)
         {
             m_a_coeffs[amrlev][0].setVal(0.0);
         }
+        m_acoef_set = true;
     }
+    m_scalars_set = true;
 }
 
 void
@@ -124,6 +126,7 @@ MLEBABecLap::setACoeffs (int amrlev, const MultiFab& alpha)
 {
     MultiFab::Copy(m_a_coeffs[amrlev][0], alpha, 0, 0, 1, 0);
     m_needs_update = true;
+    m_acoef_set = true;
 }
 
 void
@@ -131,6 +134,7 @@ MLEBABecLap::setACoeffs (int amrlev, Real alpha)
 {
     m_a_coeffs[amrlev][0].setVal(alpha);
     m_needs_update = true;
+    m_acoef_set = true;
 }
 
 void
@@ -1291,10 +1295,7 @@ void
 MLEBABecLap::applyRobinBCTermsCoeffs ()
 {
     if (this->hasRobinBC()) {
-        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(!m_applyRobinBCTermsCoeffs_called,
-                                         "MLEBABecLap cannot be reused when there is Robin BC");
         detail::applyRobinBCTermsCoeffs(*this);
-        m_applyRobinBCTermsCoeffs_called = true;
     }
 }
 

--- a/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap.cpp
@@ -1189,6 +1189,8 @@ MLEBABecLap::update ()
 {
     if (MLCellABecLap::needsUpdate()) { MLCellABecLap::update(); }
 
+    applyRobinBCTermsCoeffs();
+
     averageDownCoeffs();
 
     m_is_singular.clear();


### PR DESCRIPTION
Because the coefficients stored inside LinOp objects are irreversibly modified for Robin BC, it's unsafe to reuse the solver when there is Robin BC, unless the scalars and the coefficients are reset.
