### PR TITLE
`omp_locks`: C Array

### DIFF
--- a/Src/Base/AMReX_OpenMP.H
+++ b/Src/Base/AMReX_OpenMP.H
@@ -5,7 +5,6 @@
 #ifdef AMREX_USE_OMP
 #include <AMReX_Extension.H>
 #include <omp.h>
-#include <array>
 
 namespace amrex::OpenMP {
 
@@ -19,7 +18,7 @@ namespace amrex::OpenMP {
     void Finalize ();
 
     static constexpr int nlocks = 128;
-    extern AMREX_EXPORT std::array<omp_lock_t,nlocks> omp_locks;
+    extern AMREX_EXPORT omp_lock_t omp_locks[nlocks];
 }
 
 #else // AMREX_USE_OMP

--- a/Src/Base/AMReX_OpenMP.cpp
+++ b/Src/Base/AMReX_OpenMP.cpp
@@ -135,7 +135,7 @@ namespace amrex
 #ifdef AMREX_USE_OMP
 namespace amrex::OpenMP
 {
-    std::array<omp_lock_t,nlocks> omp_locks;
+    omp_lock_t omp_locks[nlocks];
 
     namespace {
         unsigned int initialized = 0;


### PR DESCRIPTION
## Summary

Use a plain C array over a `std::array` for `omp_locks`. Primarily because this causes linker issues on MSVC/Clang-Cl, secondarily because `omp_locks` might violate in some implementations the type requirements of `std::array` (MoveConstructible and MoveAssignable type `T`).
https://en.cppreference.com/w/cpp/container/array

## Additional background

Potentially a fix for #3795

Testing in https://github.com/conda-forge/impactx-feedstock/pull/28

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
