### PR TITLE
In allocateSlice, handle empty list of boxes

### DIFF
--- a/Src/Base/AMReX_MultiFabUtil.cpp
+++ b/Src/Base/AMReX_MultiFabUtil.cpp
@@ -46,11 +46,15 @@ namespace {
             boxes.push_back(is.second);
             slice_to_full_ba_map.push_back(is.first);
         }
-        BoxArray slice_ba(boxes.data(), static_cast<int>(boxes.size()));
-        DistributionMapping slice_dmap(std::move(procs));
+        if (boxes.size() > 0) {
+            BoxArray slice_ba(boxes.data(), static_cast<int>(boxes.size()));
+            DistributionMapping slice_dmap(std::move(procs));
 
-        return std::make_unique<MultiFab>(slice_ba, slice_dmap, ncomp, 0,
-                                          MFInfo(), FArrayBoxFactory());
+            return std::make_unique<MultiFab>(slice_ba, slice_dmap, ncomp, 0,
+                                              MFInfo(), FArrayBoxFactory());
+        } else {
+            return nullptr;
+        }
     }
 }
 
@@ -559,6 +563,10 @@ namespace amrex
 
         Vector<int> slice_to_full_ba_map;
         std::unique_ptr<MultiFab> slice = allocateSlice(dir, cc, ncomp, geom, coord, slice_to_full_ba_map);
+
+        if (!slice) {
+            return nullptr;
+        }
 
 #ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())

--- a/Src/Base/AMReX_MultiFabUtil.cpp
+++ b/Src/Base/AMReX_MultiFabUtil.cpp
@@ -46,7 +46,7 @@ namespace {
             boxes.push_back(is.second);
             slice_to_full_ba_map.push_back(is.first);
         }
-        if (boxes.size() > 0) {
+        if (!boxes.empty()) {
             BoxArray slice_ba(boxes.data(), static_cast<int>(boxes.size()));
             DistributionMapping slice_dmap(std::move(procs));
 


### PR DESCRIPTION
## Summary
In `allocateSlice` (which is called by `get_slice_data` in `Src/Base/AMReX_MultiFabUtil.cpp`) handle the case when no intersection is found between the slice and the box array.

## Additional background
When no intersection is found, the `boxes` array will be empty which would cause a segfault if the `data` would be accessed. The fix is to return `nullptr` in this case.
Also, `get_slice_data` is modified to return `nullptr` in this case as well.

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
