### PR TITLE
Revert range based for-loop with OMP

### DIFF
--- a/Src/Particle/AMReX_ParticleContainerI.H
+++ b/Src/Particle/AMReX_ParticleContainerI.H
@@ -1836,8 +1836,9 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
 #ifdef AMREX_USE_OMP
 #pragma omp parallel for
 #endif
-            for (auto index : grid_tile_ids)
+            for (int pit = 0; pit < static_cast<int>(grid_tile_ids.size()); ++pit) // NOLINT(modernize-loop-convert)
             {
+                auto index = grid_tile_ids[pit];
                 auto& ptile = DefineAndReturnParticleTile(lev, index.first, index.second);
                 auto& soa = ptile.GetStructOfArrays();
                 auto& soa_tmp = soa_local[lev][index];


### PR DESCRIPTION
## Summary

WarpX CI build with OMP < 5 fails due to unsupported range based for-loop. This PR reverts the breaking for-loop to a normal one.

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [x] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
