### PR TITLE
Fix ReduceToPlane

### DIFF
--- a/Src/Base/AMReX_MultiFabUtil.H
+++ b/Src/Base/AMReX_MultiFabUtil.H
@@ -325,7 +325,7 @@ namespace amrex
 #endif
                                , int> FOO = 0>
     BaseFab<T>
-    ReduceToPlane (int direction, Box const& domain, FabArray<FAB> const& mf, F&& f);
+    ReduceToPlane (int direction, Box const& domain, FabArray<FAB> const& mf, F const& f);
 
     /**
      * \brief Sum MultiFab data to line


### PR DESCRIPTION
## Summary

The declaration and the definition of `ReduceToPlane` did not match, leading to build errors. This PR fixes that. 

The actual error can be seen here for example: https://github.com/Exawind/amr-wind/actions/runs/8414958776/job/23039425812?pr=1003

## Checklist

The proposed changes:
- [X] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
