### PR TITLE
Disable AMReX_FLATTEN_FOR by default

### DIFF
--- a/Docs/sphinx_documentation/source/BuildingAMReX.rst
+++ b/Docs/sphinx_documentation/source/BuildingAMReX.rst
@@ -532,8 +532,8 @@ The list of available options is reported in the :ref:`table <tab:cmakevar>` bel
    +------------------------------+-------------------------------------------------+-------------------------+-----------------------+
    | AMReX_PROBINIT               |  Enable support for probin file                 | Platform dependent      | YES, NO               |
    +------------------------------+-------------------------------------------------+-------------------------+-----------------------+
-   | AMReX_FLATTEN_FOR            |  Enable flattening of ParallelFor and similar   | YES unless for Debug    | YES, NO               |
-   |                              |  functions for host code                        | build                   |                       |
+   | AMReX_FLATTEN_FOR            |  Enable flattening of ParallelFor and similar   | NO                      | YES, NO               |
+   |                              |  functions for host code                        |                         |                       |
    +------------------------------+-------------------------------------------------+-------------------------+-----------------------+
 .. raw:: latex
 

--- a/Tools/CMake/AMReXOptions.cmake
+++ b/Tools/CMake/AMReXOptions.cmake
@@ -377,11 +377,7 @@ endif ()
 
 print_option( AMReX_ASSERTIONS )
 
-if ( "${CMAKE_BUILD_TYPE}" MATCHES "Debug" )
-   option( AMReX_FLATTEN_FOR "Enable flattening of ParallelFor and other similar functions" OFF)
-else ()
-   option( AMReX_FLATTEN_FOR "Enable flattening of ParallelFor and other similar functions" ON)
-endif ()
+option( AMReX_FLATTEN_FOR "Enable flattening of ParallelFor and other similar functions" OFF)
 print_option( AMReX_FLATTEN_FOR )
 
 option(AMReX_BOUND_CHECK  "Enable bound checking in Array4 class" OFF)

--- a/Tools/GNUMake/Make.defs
+++ b/Tools/GNUMake/Make.defs
@@ -314,7 +314,7 @@ endif
 ifdef USE_FLATTEN_FOR
   USE_FLATTEN_FOR := $(strip $(USE_FLATTEN_FOR))
 else
-  USE_FLATTEN_FOR := TRUE
+  USE_FLATTEN_FOR := FALSE
 endif
 
 ifdef WARN_ALL


### PR DESCRIPTION
Flattening (#3855) makes compilation too slow for some codes. For example, on my desktop, the compilation time for Castro_react.cpp increased from 3 minutes to 49 minutes.
