### PR TITLE
Fix: Resize Component on Add

### DIFF
--- a/Src/Particle/AMReX_ParticleContainer.H
+++ b/Src/Particle/AMReX_ParticleContainer.H
@@ -1244,6 +1244,7 @@ public:
         m_num_runtime_real++;
         h_redistribute_real_comp.push_back(communicate);
         SetParticleSize();
+        this->resizeData();
 
         // resize runtime SoA
         for (int lev = 0; lev < numLevels(); ++lev) {
@@ -1266,6 +1267,7 @@ public:
         m_num_runtime_int++;
         h_redistribute_int_comp.push_back(communicate);
         SetParticleSize();
+        this->resizeData();
 
         // resize runtime SoA
         for (int lev = 0; lev < numLevels(); ++lev) {


### PR DESCRIPTION
## Summary

Some object called "dummy mf" needs to be resized to avoid segfaults.

## Additional background

Follow-up to #3615

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
