### PR TITLE
Add `PODVector::assign(value)`

### DIFF
--- a/Src/Base/AMReX_PODVector.H
+++ b/Src/Base/AMReX_PODVector.H
@@ -512,6 +512,15 @@ namespace amrex
                                    (Allocator const&)(*this));
         }
 
+        /** Set the same value to every element of the vector
+         *
+         * @param a_value the value to assign
+         */
+        void assign (const T& a_value)
+        {
+            assign(m_size, a_value);
+        }
+
         [[nodiscard]] allocator_type get_allocator () const noexcept { return *this; }
 
         void push_back (const T& a_value)


### PR DESCRIPTION
## Summary

```
vector.assign(vector.size(), 42);
```
is a bit verbose for a standard operation, even if it mirrors https://en.cppreference.com/w/cpp/container/vector/assign

Add another overload similar to `setVal(ue)` used in other AMReX containers.

## Additional background

https://github.com/AMReX-Codes/pyamrex/pull/222#discussion_r1384120148

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
