### PR TITLE
Add Doxygen comments for the reserveData and resizeData methods of ParticleContainerBase.

### DIFF
--- a/Src/Particle/AMReX_ParticleContainer.H
+++ b/Src/Particle/AMReX_ParticleContainer.H
@@ -369,7 +369,18 @@ public:
         return (lev < m_particles.size()) ? m_particles[lev].size() : 0;
     }
 
+    /**
+     * \brief This reserves data in the vector of dummy MultiFabs used by
+     * the ParticleContainer for the maximum number of levels possible.
+     */
     void reserveData () override;
+
+    /**
+     * \brief This resizes the vector of dummy MultiFabs used by the
+     * ParticleContainer for the current number of levels and calls
+     * RedefineDummyMF on each level. Note that this must be done prior
+     * to using ParticleIterator.
+     */
     void resizeData () override;
 
     void InitFromAsciiFile (const std::string& file, int extradata,


### PR DESCRIPTION
The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [x] include documentation in the code and/or rst files, if appropriate
