### PR TITLE
GMRES/MLMG: Set the number of MG V-cycles per GMRES iteration

### DIFF
--- a/Src/LinearSolvers/AMReX_GMRES_MLMG.H
+++ b/Src/LinearSolvers/AMReX_GMRES_MLMG.H
@@ -91,7 +91,11 @@ public:
 
     void precond (MF& lhs, MF const& rhs) const;
 
+    //! Control whether or not to use MLMG as preconditioner.
     bool usePrecond (bool new_flag) { return std::exchange(m_use_precond, new_flag); }
+
+    //! Set the number of MLMG preconditioner iterations per GMRES iteration.
+    void setPrecondNumIters (int precond_niters) { m_precond_niters = precond_niters; }
 
 private:
     GM m_gmres;
@@ -99,6 +103,7 @@ private:
     MLLinOpT<MF>* m_linop;
     bool m_use_precond = true;
     bool m_prop_zero = false;
+    int m_precond_niters = 1;
 };
 
 template <typename MF>
@@ -184,12 +189,22 @@ void GMRESMLMGT<MF>::precond (MF& lhs, MF const& rhs) const
     if (m_use_precond) {
         m_mlmg->prepareMGcycle();
 
-        LocalCopy(m_mlmg->res[0][0], rhs, 0, 0, nComp(rhs), IntVect(0));
+        for (int icycle = 0; icycle < m_precond_niters; ++icycle) {
+            if (icycle == 0) {
+                LocalCopy(m_mlmg->res[0][0], rhs, 0, 0, nComp(rhs), IntVect(0));
+            } else {
+                m_mlmg->computeResOfCorrection(0,0);
+                LocalCopy(m_mlmg->res[0][0], m_mlmg->rescor[0][0], 0, 0, nComp(rhs), IntVect(0));
+            }
 
-        m_mlmg->mgVcycle(0,0);
+            m_mlmg->mgVcycle(0,0);
 
-        LocalCopy(lhs, m_mlmg->cor[0][0], 0, 0, nComp(rhs), IntVect(0));
-
+            if (icycle == 0) {
+                LocalCopy(lhs, m_mlmg->cor[0][0], 0, 0, nComp(rhs), IntVect(0));
+            } else {
+                increment(lhs, m_mlmg->cor[0][0], RT(1));
+            }
+        }
     } else {
         LocalCopy(lhs, rhs, 0, 0, nComp(lhs), IntVect(0));
     }

--- a/Tests/LinearSolvers/CurlCurl/MyTest.H
+++ b/Tests/LinearSolvers/CurlCurl/MyTest.H
@@ -32,6 +32,7 @@ private:
 
     bool use_gmres = false;
     bool gmres_use_precond = true;
+    int gmres_precond_niters = 1;
 
     amrex::Geometry geom;
     amrex::BoxArray grids;

--- a/Tests/LinearSolvers/CurlCurl/MyTest.cpp
+++ b/Tests/LinearSolvers/CurlCurl/MyTest.cpp
@@ -62,6 +62,7 @@ MyTest::solve ()
     {
         GMRESMLMGT<V> gmsolver(mlmg);
         gmsolver.usePrecond(gmres_use_precond);
+        gmsolver.setPrecondNumIters(gmres_precond_niters);
 
         // This system has homogeneous BC unlike
         // Tests/LinearSolvers/ABecLaplacian_C, so the setup is simpler.
@@ -106,6 +107,7 @@ MyTest::readParameters ()
 
     pp.query("use_gmres", use_gmres);
     pp.query("gmres_use_precond", gmres_use_precond);
+    pp.query("gmres_precond_niters", gmres_precond_niters);
 
     pp.query("beta_factor", beta_factor);
     pp.query("alpha", alpha);


### PR DESCRIPTION
Previously it was hardwired to 1 V-cycle per GMRES iteration.