### PR TITLE
TinyProfiler: remove CUPTI

### DIFF
--- a/Src/Base/AMReX_BLProfiler.H
+++ b/Src/Base/AMReX_BLProfiler.H
@@ -493,16 +493,9 @@ inline std::string BLProfiler::CommStats::CFTToString(CommFuncType cft) {
 #define BL_PROFILE_T_S(fname, T)
 
 #define BL_PROFILE_VAR(fname, vname)                      amrex::TinyProfiler tiny_profiler_##vname((fname))
-#define BL_PROFILE_VAR_NS(fname, vname)                   amrex::TinyProfiler tiny_profiler_##vname(fname, false, false)
+#define BL_PROFILE_VAR_NS(fname, vname)                   amrex::TinyProfiler tiny_profiler_##vname(fname, false)
 #define BL_PROFILE_VAR_START(vname)                       tiny_profiler_##vname.start()
 #define BL_PROFILE_VAR_STOP(vname)                        tiny_profiler_##vname.stop()
-#ifdef AMREX_USE_CUPTI
-#include <AMReX_CuptiTrace.H>
-#define BL_PROFILE_VAR_NS_CUPTI(fname, vname)             amrex::TinyProfiler tiny_profiler_##vname(fname, false, true)
-#define BL_PROFILE_VAR_START_CUPTI(vname)                 tiny_profiler_##vname.start()
-#define BL_PROFILE_VAR_STOP_CUPTI(vname)                  tiny_profiler_##vname.stop()
-#define BL_PROFILE_VAR_STOP_CUPTI_ID(vname, uintID)       tiny_profiler_##vname.stop(uintID)
-#endif // AMREX_USE_CUPTI
 #define BL_PROFILE_INIT_PARAMS(ptl,wall,wfabs)
 #define BL_PROFILE_ADD_STEP(snum)
 #define BL_PROFILE_SET_RUN_TIME(rtime)

--- a/Src/Base/AMReX_TinyProfiler.H
+++ b/Src/Base/AMReX_TinyProfiler.H
@@ -39,9 +39,9 @@ class TinyProfiler
 {
 public:
     explicit TinyProfiler (std::string funcname) noexcept;
-    TinyProfiler (std::string funcname, bool start_, bool useCUPTI=false) noexcept;
+    TinyProfiler (std::string funcname, bool start_) noexcept;
     explicit TinyProfiler (const char* funcname) noexcept;
-    TinyProfiler (const char* funcname, bool start_, bool useCUPTI=false) noexcept;
+    TinyProfiler (const char* funcname, bool start_) noexcept;
     ~TinyProfiler ();
 
     TinyProfiler (TinyProfiler const&) = delete;
@@ -51,10 +51,6 @@ public:
 
     void start () noexcept;
     void stop () noexcept;
-#ifdef AMREX_USE_CUPTI
-    void stop (unsigned boxUintID) noexcept;
-#endif // AMREX_USE_CUPTI
-
 
     void memory_start () const noexcept;
     void memory_stop () const noexcept;
@@ -87,8 +83,6 @@ private:
         Long n{0L};         //!< number of calls
         double dtin{0.0};    //!< inclusive dt
         double dtex{0.0};    //!< exclusive dt
-        bool usesCUPTI{false}; //!< uses CUPTI
-        Long nk{0};        //!< number of kernel calls
     };
 
     //! stats across processes
@@ -101,7 +95,6 @@ private:
         double dtinavg{0.0}, dtinmax{0.0};
         double dtexmin{std::numeric_limits<double>::max()};
         double dtexavg{0.0}, dtexmax{0.0};
-        bool usesCUPTI{false};
         std::string fname;
         static bool compex (const ProcStats& lhs, const ProcStats& rhs) {
             return lhs.dtexmax > rhs.dtexmax;
@@ -128,7 +121,6 @@ private:
     };
 
     std::string fname;
-    bool uCUPTI = false;
     bool in_parallel_region = false;
     int global_depth = -1;
     std::vector<Stats*> stats;


### PR DESCRIPTION
## Summary

To me, it looks like that TinyProfiler+CUPTI has been broken for one year (https://github.com/AMReX-Codes/amrex/pull/3190 didn't update CUPTI from `it->` to `allprocstat.`). If nobody uses it (please correct me if that's not the case), then TinyProfiler can be cleaned up by removing CUPTI.

## Additional background

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
