### PR TITLE
Fix ReorderParticles for PureSoA

### DIFF
--- a/Src/Particle/AMReX_ParticleContainerI.H
+++ b/Src/Particle/AMReX_ParticleContainerI.H
@@ -1115,6 +1115,19 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
                 });
             }
             Gpu::streamSynchronize();
+        } else {
+            typename SoA::IdCPU tmp_idcpu(np_total);
+
+            auto src = ptile.GetStructOfArrays().GetIdCPUData().data();
+            uint64_t* dst = tmp_idcpu.data();
+            AMREX_HOST_DEVICE_FOR_1D( np_total, i,
+            {
+                dst[i] = i < np ? src[permutations[i]] : src[i];
+            });
+
+            Gpu::streamSynchronize();
+
+            ptile.GetStructOfArrays().GetIdCPUData().swap(tmp_idcpu);
         }
 
         { // Create a scope for the temporary vector below


### PR DESCRIPTION
## Summary

For PureSoA, ReorderParticles didn't reorder the IdCPU component.

## Additional background

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
