### PR TITLE
Fix full plotfiles with only derived variables

### DIFF
--- a/Src/Amr/AMReX_Amr.cpp
+++ b/Src/Amr/AMReX_Amr.cpp
@@ -855,7 +855,7 @@ Amr::writePlotFile ()
 
     // Don't continue if we have no variables to plot.
 
-    if (statePlotVars().empty()) {
+    if (statePlotVars().empty() && derivePlotVars().empty()) {
         return;
     }
 


### PR DESCRIPTION
## Summary

Check for both state variables and derived variables when outputting a full plotfile.

## Additional background

I've been working through the plotfile output logic with one of my colleagues, and noticed that this didn't match up with the small plotfile code.

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
