### PR TITLE
Fix offset in recv buffer of single precision particle communication

### DIFF
--- a/Src/Particle/AMReX_ParticleCommunication.H
+++ b/Src/Particle/AMReX_ParticleCommunication.H
@@ -481,10 +481,10 @@ void communicateParticlesStart (const PC& pc, ParticleCopyPlan& plan, const SndB
     for (int i = 0; i < NProcs; ++i) {
         if (plan.m_rcv_num_particles[i] > 0) {
             RcvProc.push_back(i);
-            rOffset.push_back(TotRcvBytes);
             Long nbytes = plan.m_rcv_num_particles[i]*psize;
             std::size_t acd = ParallelDescriptor::sizeof_selected_comm_data_type(nbytes);
             TotRcvBytes = Long(amrex::aligned_size(acd, TotRcvBytes));
+            rOffset.push_back(TotRcvBytes);
             TotRcvBytes += Long(amrex::aligned_size(acd, nbytes));
             plan.m_rcv_pad_correction_h.push_back(plan.m_rcv_pad_correction_h.back() + nbytes);
         }


### PR DESCRIPTION
A similar bug was fixed in #3758 for the particle send buffer. But we did not notice the issue in the receive buffer at the time. The offset for the `i`th buffer might be aligned for the `i`th buffer's communication data type, not the previous buffer.

The reason the bug only appears for large single precision runs is because for double precision the particle size is aligned with the size of unsigned long long used in communication, whereas for single precision this is not the case.
