### PR TITLE
fix a HIP/Frontier issue

### DIFF
--- a/Src/Base/AMReX_GpuDevice.cpp
+++ b/Src/Base/AMReX_GpuDevice.cpp
@@ -323,7 +323,9 @@ Device::Initialize ()
 #endif
 
 #if defined(AMREX_USE_HIP)
-    amrex::single_task(amrex_check_wavefront_size);
+    if (num_devices_used < 0) {
+        amrex::single_task(amrex_check_wavefront_size);
+    }
 #endif
 
     Device::profilerStart();

--- a/Src/Base/AMReX_GpuDevice.cpp
+++ b/Src/Base/AMReX_GpuDevice.cpp
@@ -324,6 +324,8 @@ Device::Initialize ()
 
 #if defined(AMREX_USE_HIP)
     if (num_devices_used < 0) {
+        // This test is always false, but it makes the compiler no longer
+        // complain about unused function, amrex_check_wavefront_size.
         amrex::single_task(amrex_check_wavefront_size);
     }
 #endif


### PR DESCRIPTION

## Summary

the amrex::single_task(amrex_check_wavefront_size) check causes runtime errors

this is the check that Weiqun suggested in #3901 and I've tested that it works
on Frontier with Castro

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
