### PR TITLE
Fix assertions involving IntVect

### DIFF
--- a/Src/Amr/AMReX_AmrLevel.cpp
+++ b/Src/Amr/AMReX_AmrLevel.cpp
@@ -1531,7 +1531,7 @@ AmrLevel::FillCoarsePatch (MultiFab& mf,
     //
     BL_ASSERT(level != 0);
     BL_ASSERT(ncomp <= (mf.nComp()-dcomp));
-    BL_ASSERT(nghost <= mf.nGrow());
+    BL_ASSERT(mf.nGrowVect().allGE(nghost));
     BL_ASSERT(0 <= idx && idx < desc_lst.size());
 
     int                     DComp   = dcomp;
@@ -2186,7 +2186,7 @@ AmrLevel::FillPatch (AmrLevel& amrlevel,
 {
     BL_PROFILE("AmrLevel::FillPatch()");
     BL_ASSERT(dcomp+ncomp-1 <= leveldata.nComp());
-    BL_ASSERT(boxGrow <= leveldata.nGrow());
+    BL_ASSERT(leveldata.nGrowVect().allGE(boxGrow));
     FillPatchIterator fpi(amrlevel, leveldata, boxGrow, time, index, scomp, ncomp);
     const MultiFab& mf_fillpatched = fpi.get_mf();
     MultiFab::Copy(leveldata, mf_fillpatched, 0, dcomp, ncomp, boxGrow);
@@ -2204,7 +2204,7 @@ AmrLevel::FillPatchAdd (AmrLevel& amrlevel,
 {
     BL_PROFILE("AmrLevel::FillPatchAdd()");
     BL_ASSERT(dcomp+ncomp-1 <= leveldata.nComp());
-    BL_ASSERT(boxGrow <= leveldata.nGrow());
+    BL_ASSERT(leveldata.nGrowVect().allGE(boxGrow));
     FillPatchIterator fpi(amrlevel, leveldata, boxGrow, time, index, scomp, ncomp);
     const MultiFab& mf_fillpatched = fpi.get_mf();
     MultiFab::Add(leveldata, mf_fillpatched, 0, dcomp, ncomp, boxGrow);

--- a/Src/Amr/AMReX_Extrapolater.cpp
+++ b/Src/Amr/AMReX_Extrapolater.cpp
@@ -17,7 +17,7 @@ namespace amrex::Extrapolater
 
     void FirstOrderExtrap (MultiFab& mf, const Geometry& geom, int scomp, int ncomp, int ngrow)
     {
-        BL_ASSERT(mf.nGrow() >= ngrow);
+        BL_ASSERT(mf.nGrowVect().allGE(ngrow));
         BL_ASSERT(scomp >= 0);
         BL_ASSERT((scomp+ncomp) <= mf.nComp());
 

--- a/Src/Amr/AMReX_StateData.cpp
+++ b/Src/Amr/AMReX_StateData.cpp
@@ -140,10 +140,10 @@ StateData::copyOld (const StateData& state)
     const MultiFab& MF = state.oldData();
 
     int nc = MF.nComp();
-    int ng = MF.nGrow();
+    auto ng = MF.nGrowVect();
 
     BL_ASSERT(nc == (*old_data).nComp());
-    BL_ASSERT(ng == (*old_data).nGrow());
+    BL_ASSERT(ng == (*old_data).nGrowVect());
 
     MultiFab::Copy(*old_data, state.oldData(), 0, 0, nc, ng);
 
@@ -156,10 +156,10 @@ StateData::copyNew (const StateData& state)
     const MultiFab& MF = state.newData();
 
     int nc = MF.nComp();
-    int ng = MF.nGrow();
+    auto ng = MF.nGrowVect();
 
     BL_ASSERT(nc == (*new_data).nComp());
-    BL_ASSERT(ng == (*new_data).nGrow());
+    BL_ASSERT(ng == (*new_data).nGrowVect());
 
     MultiFab::Copy(*new_data, state.newData(), 0, 0, nc, ng);
 

--- a/Src/AmrCore/AMReX_Interpolater.cpp
+++ b/Src/AmrCore/AMReX_Interpolater.cpp
@@ -1110,7 +1110,7 @@ CellConservativeProtected::protect (const FArrayBox& /*crse*/,
                                     Vector<BCRec>&   /*bcr*/,
                                     RunOn            runon)
 {
-    AMREX_ALWAYS_ASSERT(ratio.allGT(IntVect(1)));
+    AMREX_ALWAYS_ASSERT(ratio.allGT(1));
 
 #if (AMREX_SPACEDIM == 1)
     amrex::ignore_unused(fine,fine_state,

--- a/Src/Base/AMReX_BCUtil.cpp
+++ b/Src/Base/AMReX_BCUtil.cpp
@@ -36,7 +36,7 @@ struct dummy_gpu_fill_extdir
 void FillDomainBoundary (MultiFab& phi, const Geometry& geom, const Vector<BCRec>& bc)
 {
     if (geom.isAllPeriodic()) { return; }
-    if (phi.nGrow() == 0) { return; }
+    if (phi.nGrowVect() == 0) { return; }
 
     AMREX_ALWAYS_ASSERT(phi.ixType().cellCentered());
 

--- a/Src/Base/AMReX_Box.H
+++ b/Src/Base/AMReX_Box.H
@@ -78,7 +78,7 @@ public:
           bigend(big),
           btype(typ)
         {
-            BL_ASSERT(typ.allGE(IntVect::TheZeroVector()) && typ.allLE(IntVect::TheUnitVector()));
+            BL_ASSERT(typ.allGE(0) && typ.allLE(1));
         }
 
     //! Construct dimension specific Boxes.
@@ -829,7 +829,7 @@ AMREX_FORCE_INLINE
 Box&
 Box::convert (const IntVect& typ) noexcept
 {
-    BL_ASSERT(typ.allGE(IntVect::TheZeroVector()) && typ.allLE(IntVect::TheUnitVector()));
+    BL_ASSERT(typ.allGE(0) && typ.allLE(1));
     IntVect shft(typ - btype.ixType());
     bigend += shft;
     btype = IndexType(typ);

--- a/Src/Base/AMReX_FabArray.H
+++ b/Src/Base/AMReX_FabArray.H
@@ -2035,7 +2035,7 @@ FabArray<FAB>::define (const BoxArray&            bxs,
 
     define_function_called = true;
 
-    AMREX_ASSERT(ngrow.allGE(IntVect::TheZeroVector()));
+    AMREX_ASSERT(ngrow.allGE(0));
     AMREX_ASSERT(boxarray.empty());
     FabArrayBase::define(bxs, dm, nvar, ngrow);
 
@@ -2509,7 +2509,7 @@ FabArray<FAB>::setVal (value_type val,
                        int        ncomp,
                        const IntVect& nghost)
 {
-    AMREX_ASSERT(nghost.allGE(IntVect::TheZeroVector()) && nghost.allLE(n_grow));
+    AMREX_ASSERT(nghost.allGE(0) && nghost.allLE(n_grow));
     AMREX_ALWAYS_ASSERT(comp+ncomp <= n_comp);
 
     BL_PROFILE("FabArray::setVal()");
@@ -2564,7 +2564,7 @@ FabArray<FAB>::setVal (value_type val,
                        int        ncomp,
                        const IntVect& nghost)
 {
-    AMREX_ASSERT(nghost.allGE(IntVect::TheZeroVector()) && nghost.allLE(n_grow));
+    AMREX_ASSERT(nghost.allGE(0) && nghost.allLE(n_grow));
     AMREX_ALWAYS_ASSERT(comp+ncomp <= n_comp);
 
     BL_PROFILE("FabArray::setVal(val,region,comp,ncomp,nghost)");
@@ -2617,7 +2617,7 @@ template <class F, std::enable_if_t<IsBaseFab<F>::value,int>Z>
 void
 FabArray<FAB>::abs (int comp, int ncomp, const IntVect& nghost)
 {
-    AMREX_ASSERT(nghost.allGE(IntVect::TheZeroVector()) && nghost.allLE(n_grow));
+    AMREX_ASSERT(nghost.allGE(0) && nghost.allLE(n_grow));
     AMREX_ALWAYS_ASSERT(comp+ncomp <= n_comp);
     BL_PROFILE("FabArray::abs()");
 

--- a/Src/Base/AMReX_FabArrayBase.cpp
+++ b/Src/Base/AMReX_FabArrayBase.cpp
@@ -184,7 +184,7 @@ FabArrayBase::define (const BoxArray&            bxs,
                       int                        nvar,
                       const IntVect&             ngrow)
 {
-    BL_ASSERT(ngrow.allGE(IntVect::TheZeroVector()));
+    BL_ASSERT(ngrow.allGE(0));
     BL_ASSERT(boxarray.empty());
     indexArray.clear();
     ownership.clear();
@@ -875,7 +875,7 @@ FabArrayBase::define_fb_metadata (CommMetaData& cmd, const IntVect& nghost,
 void
 FabArrayBase::FB::define_fb (const FabArrayBase& fa)
 {
-    AMREX_ASSERT(m_multi_ghost ? fa.nGrow() >= 2 : true); // must have >= 2 ghost nodes
+    AMREX_ASSERT(m_multi_ghost ? fa.nGrowVect().allGE(2) : true); // must have >= 2 ghost nodes
     AMREX_ASSERT(m_multi_ghost ? !m_period.isAnyPeriodic() : true); // this only works for non-periodic
 
     fa.define_fb_metadata(*this, m_ngrow, m_cross, m_period, m_multi_ghost);

--- a/Src/Base/AMReX_IntVect.H
+++ b/Src/Base/AMReX_IntVect.H
@@ -299,6 +299,14 @@ public:
         return AMREX_D_TERM(vect[0] < rhs[0], && vect[1] < rhs[1], && vect[2] < rhs[2]);
     }
     /**
+    * \brief Returns true if this is less than argument for all components.
+    */
+    [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    bool allLT (int rhs) const noexcept
+    {
+        return AMREX_D_TERM(vect[0] < rhs, && vect[1] < rhs, && vect[2] < rhs);
+    }
+    /**
     * \brief Returns true if this is less than or equal to argument for all components.
     * NOTE: This is NOT a strict weak ordering usable by STL sorting algorithms.
     */
@@ -306,6 +314,14 @@ public:
     bool allLE (const IntVect& rhs) const noexcept
     {
         return AMREX_D_TERM(vect[0] <= rhs[0], && vect[1] <= rhs[1], && vect[2] <= rhs[2]);
+    }
+    /**
+    * \brief Returns true if this is less than or equal to argument for all components.
+    */
+    [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    bool allLE (int rhs) const noexcept
+    {
+        return AMREX_D_TERM(vect[0] <= rhs, && vect[1] <= rhs, && vect[2] <= rhs);
     }
     /**
     * \brief Returns true if this is greater than argument for all components.
@@ -317,6 +333,14 @@ public:
         return AMREX_D_TERM(vect[0] > rhs[0], && vect[1] > rhs[1], && vect[2] > rhs[2]);
     }
     /**
+    * \brief Returns true if this is greater than argument for all components.
+    */
+    [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    bool allGT (int rhs) const noexcept
+    {
+        return AMREX_D_TERM(vect[0] > rhs, && vect[1] > rhs, && vect[2] > rhs);
+    }
+    /**
     * \brief Returns true if this is greater than or equal to argument for all components.
     * NOTE: This is NOT a strict weak ordering usable by STL sorting algorithms.
     */
@@ -324,6 +348,14 @@ public:
     bool allGE (const IntVect& rhs) const noexcept
     {
         return AMREX_D_TERM(vect[0] >= rhs[0], && vect[1] >= rhs[1], && vect[2] >= rhs[2]);
+    }
+    /**
+    * \brief Returns true if this is greater than or equal to argument for all components.
+    */
+    [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    bool allGE (int rhs) const noexcept
+    {
+        return AMREX_D_TERM(vect[0] >= rhs, && vect[1] >= rhs, && vect[2] >= rhs);
     }
     //! Unary plus -- for completeness.
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
@@ -580,7 +612,7 @@ AMREX_FORCE_INLINE
 IntVect&
 IntVect::coarsen (const IntVect& p) noexcept
 {
-    BL_ASSERT(p.allGT(IntVect::TheZeroVector()));
+    BL_ASSERT(p.allGT(0));
     AMREX_D_TERM(vect[0] = amrex::coarsen(vect[0], p.vect[0]);,
                  vect[1] = amrex::coarsen(vect[1], p.vect[1]);,
                  vect[2] = amrex::coarsen(vect[2], p.vect[2]););

--- a/Src/Base/AMReX_MultiFab.cpp
+++ b/Src/Base/AMReX_MultiFab.cpp
@@ -44,7 +44,7 @@ MultiFab::Dot (const MultiFab& x, int xcomp,
 Real
 MultiFab::Dot (const MultiFab& x, int xcomp, int numcomp, int nghost, bool local)
 {
-    BL_ASSERT(x.nGrow() >= nghost);
+    BL_ASSERT(x.nGrowVect().allGE(nghost));
 
     BL_PROFILE("MultiFab::Dot()");
 
@@ -97,8 +97,8 @@ MultiFab::Dot (const iMultiFab& mask,
     BL_ASSERT(x.boxArray() == mask.boxArray());
     BL_ASSERT(x.DistributionMap() == y.DistributionMap());
     BL_ASSERT(x.DistributionMap() == mask.DistributionMap());
-    BL_ASSERT(x.nGrow() >= nghost && y.nGrow() >= nghost);
-    BL_ASSERT(mask.nGrow() >= nghost);
+    BL_ASSERT(x.nGrowVect().allGE(nghost) && y.nGrowVect().allGE(nghost));
+    BL_ASSERT(mask.nGrowVect().allGE(nghost));
 
     Real sm = Real(0.0);
 #ifdef AMREX_USE_GPU
@@ -712,7 +712,7 @@ MultiFab::contains_inf (int scomp, int ncomp, int ngrow, bool local) const
 bool
 MultiFab::contains_inf (bool local) const
 {
-    return contains_inf(0,nComp(),nGrow(),local);
+    return contains_inf(0,nComp(),nGrowVect(),local);
 }
 
 Real
@@ -720,7 +720,7 @@ MultiFab::min (int comp, int nghost, bool local) const
 {
     BL_PROFILE("MultiFab::min()");
 
-    BL_ASSERT(nghost >= 0 && nghost <= n_grow.min());
+    BL_ASSERT(nghost >= 0 && n_grow.allGE(nghost));
 
     Real mn = std::numeric_limits<Real>::max();
 
@@ -801,7 +801,7 @@ MultiFab::min (int comp, int nghost, bool local) const
 Real
 MultiFab::min (const Box& region, int comp, int nghost, bool local) const
 {
-    BL_ASSERT(nghost >= 0 && nghost <= n_grow.min());
+    BL_ASSERT(nghost >= 0 && n_grow.allGE(nghost));
 
     BL_PROFILE("MultiFab::min(region)");
 
@@ -847,7 +847,7 @@ MultiFab::min (const Box& region, int comp, int nghost, bool local) const
 Real
 MultiFab::max (int comp, int nghost, bool local) const
 {
-    BL_ASSERT(nghost >= 0 && nghost <= n_grow.min());
+    BL_ASSERT(nghost >= 0 && n_grow.allGE(nghost));
 
     BL_PROFILE("MultiFab::max()");
 
@@ -1006,7 +1006,7 @@ indexFromValue (MultiFab const& mf, int comp, int nghost, Real value, MPI_Op mml
 IntVect
 MultiFab::minIndex (int comp, int nghost) const
 {
-    BL_ASSERT(nghost >= 0 && nghost <= n_grow.min());
+    BL_ASSERT(nghost >= 0 && n_grow.allGE(nghost));
     Real mn = this->min(comp, nghost, true);
     return indexFromValue(*this, comp, nghost, mn, MPI_MINLOC);
 }
@@ -1014,7 +1014,7 @@ MultiFab::minIndex (int comp, int nghost) const
 IntVect
 MultiFab::maxIndex (int comp, int nghost) const
 {
-    BL_ASSERT(nghost >= 0 && nghost <= n_grow.min());
+    BL_ASSERT(nghost >= 0 && n_grow.allGE(nghost));
     Real mx = this->max(comp, nghost, true);
     return indexFromValue(*this, comp, nghost, mx, MPI_MAXLOC);
 }
@@ -1374,7 +1374,7 @@ void
 MultiFab::plus (Real val, int comp, int num_comp, int nghost)
 {
 
-    BL_ASSERT(nghost >= 0 && nghost <= n_grow.min());
+    BL_ASSERT(nghost >= 0 && n_grow.allGE(nghost));
     BL_ASSERT(comp+num_comp <= n_comp);
     BL_ASSERT(num_comp > 0);
 
@@ -1384,7 +1384,7 @@ MultiFab::plus (Real val, int comp, int num_comp, int nghost)
 void
 MultiFab::plus (Real val, const Box& region, int comp, int num_comp, int nghost)
 {
-    BL_ASSERT(nghost >= 0 && nghost <= n_grow.min());
+    BL_ASSERT(nghost >= 0 && n_grow.allGE(nghost));
     BL_ASSERT(comp+num_comp <= n_comp);
     BL_ASSERT(num_comp > 0);
 
@@ -1400,7 +1400,7 @@ MultiFab::plus (const MultiFab& mf, int strt_comp, int num_comp, int nghost)
 void
 MultiFab::mult (Real val, int comp, int num_comp, int  nghost)
 {
-    BL_ASSERT(nghost >= 0 && nghost <= n_grow.min());
+    BL_ASSERT(nghost >= 0 && n_grow.allGE(nghost));
     BL_ASSERT(comp+num_comp <= n_comp);
     BL_ASSERT(num_comp > 0);
 
@@ -1410,7 +1410,7 @@ MultiFab::mult (Real val, int comp, int num_comp, int  nghost)
 void
 MultiFab::mult (Real val, const Box& region, int comp, int num_comp, int nghost)
 {
-    BL_ASSERT(nghost >= 0 && nghost <= n_grow.min());
+    BL_ASSERT(nghost >= 0 && n_grow.allGE(nghost));
     BL_ASSERT(comp+num_comp <= n_comp);
     BL_ASSERT(num_comp > 0);
 
@@ -1420,7 +1420,7 @@ MultiFab::mult (Real val, const Box& region, int comp, int num_comp, int nghost)
 void
 MultiFab::invert (Real numerator, int comp, int num_comp, int nghost)
 {
-    BL_ASSERT(nghost >= 0 && nghost <= n_grow.min());
+    BL_ASSERT(nghost >= 0 && n_grow.allGE(nghost));
     BL_ASSERT(comp+num_comp <= n_comp);
     BL_ASSERT(num_comp > 0);
 
@@ -1430,7 +1430,7 @@ MultiFab::invert (Real numerator, int comp, int num_comp, int nghost)
 void
 MultiFab::invert (Real numerator, const Box& region, int comp, int num_comp, int nghost)
 {
-    BL_ASSERT(nghost >= 0 && nghost <= n_grow.min());
+    BL_ASSERT(nghost >= 0 && n_grow.allGE(nghost));
     BL_ASSERT(comp+num_comp <= n_comp);
     BL_ASSERT(num_comp > 0);
 
@@ -1440,7 +1440,7 @@ MultiFab::invert (Real numerator, const Box& region, int comp, int num_comp, int
 void
 MultiFab::negate (int comp, int num_comp, int nghost)
 {
-    BL_ASSERT(nghost >= 0 && nghost <= n_grow.min());
+    BL_ASSERT(nghost >= 0 && n_grow.allGE(nghost));
     BL_ASSERT(comp+num_comp <= n_comp);
 
     FabArray<FArrayBox>::mult(-1., comp, num_comp, nghost);
@@ -1449,7 +1449,7 @@ MultiFab::negate (int comp, int num_comp, int nghost)
 void
 MultiFab::negate (const Box& region, int comp, int num_comp, int nghost)
 {
-    BL_ASSERT(nghost >= 0 && nghost <= n_grow.min());
+    BL_ASSERT(nghost >= 0 && n_grow.allGE(nghost));
     BL_ASSERT(comp+num_comp <= n_comp);
 
     FabArray<FArrayBox>::mult(-1.,region,comp,num_comp,nghost);

--- a/Src/Base/AMReX_MultiFabUtil.cpp
+++ b/Src/Base/AMReX_MultiFabUtil.cpp
@@ -228,7 +228,7 @@ namespace amrex
                                     const Geometry& geom, int ncomp, bool use_harmonic_averaging)
     {
         AMREX_ASSERT(cc.nComp() == ncomp);
-        AMREX_ASSERT(cc.nGrow() >= 1);
+        AMREX_ASSERT(cc.nGrowVect().allGE(1));
         AMREX_ASSERT(fc[0]->nComp() == ncomp); // We only expect fc to have the gradient perpendicular to the face
 #if (AMREX_SPACEDIM >= 2)
         AMREX_ASSERT(fc[1]->nComp() == ncomp); // We only expect fc to have the gradient perpendicular to the face
@@ -396,10 +396,9 @@ namespace amrex
                             const Geometry& cgeom, const Geometry& /*fgeom*/)
     {
         AMREX_ASSERT(S_crse.nComp() == S_fine.nComp());
-        AMREX_ASSERT(ratio == ratio[0]);
-        AMREX_ASSERT(S_fine.nGrow() % ratio[0] == 0);
 
-        const int nGrow = S_fine.nGrow() / ratio[0];
+        const IntVect nGrow = S_fine.nGrowVect() / ratio;
+        AMREX_ASSERT((nGrow*ratio) == S_fine.nGrowVect());
 
         //
         // Coarsen() the fine stuff on processors owning the fine data.
@@ -412,7 +411,7 @@ namespace amrex
         if (Gpu::inLaunchRegion() && crse_S_fine.isFusingCandidate()) {
             auto const& crsema = crse_S_fine.arrays();
             auto const& finema = S_fine.const_arrays();
-            ParallelFor(crse_S_fine, IntVect(nGrow), ncomp,
+            ParallelFor(crse_S_fine, nGrow, ncomp,
             [=] AMREX_GPU_DEVICE (int box_no, int i, int j, int k, int n) noexcept
             {
                 amrex_avgdown(i,j,k,n,crsema[box_no],finema[box_no],0,scomp,ratio);
@@ -440,7 +439,7 @@ namespace amrex
             }
         }
 
-        S_crse.ParallelCopy(crse_S_fine, 0, scomp, ncomp, nGrow, 0,
+        S_crse.ParallelCopy(crse_S_fine, 0, scomp, ncomp, nGrow, IntVect(0),
                             cgeom.periodicity(), FabArrayBase::ADD);
     }
 
@@ -556,7 +555,7 @@ namespace amrex
         BL_PROFILE("amrex::get_slice_data");
 
         if (interpolate) {
-            AMREX_ASSERT(cc.nGrow() >= 1);
+            AMREX_ASSERT(cc.nGrowVect().allGE(1));
         }
 
         const auto geomdata = geom.data();

--- a/Src/Base/AMReX_VisMF.cpp
+++ b/Src/Base/AMReX_VisMF.cpp
@@ -368,7 +368,7 @@ operator>> (std::istream  &is,
         is >> ng;
         hd.m_ngrow = IntVect(AMREX_D_DECL(ng,ng,ng));
     }
-    BL_ASSERT(hd.m_ngrow.min() >= 0);
+    BL_ASSERT(hd.m_ngrow.allGE(0));
 
     int ba_ndims = hd.m_ba.readFrom(is);
     for (int i = ba_ndims; i < AMREX_SPACEDIM; ++i) {

--- a/Src/Base/AMReX_iMultiFab.cpp
+++ b/Src/Base/AMReX_iMultiFab.cpp
@@ -31,7 +31,7 @@ iMultiFab::Add (iMultiFab&       dst,
 {
     BL_ASSERT(dst.boxArray() == src.boxArray());
     BL_ASSERT(dst.distributionMap == src.distributionMap);
-    BL_ASSERT(dst.nGrow() >= nghost && src.nGrow() >= nghost);
+    BL_ASSERT(dst.nGrowVect().allGE(nghost) && src.nGrowVect().allGE(nghost));
 
     amrex::Add(dst,src,srccomp,dstcomp,numcomp,IntVect(nghost));
 }
@@ -46,7 +46,7 @@ iMultiFab::Copy (iMultiFab&       dst,
 {
     BL_ASSERT(dst.boxArray() == src.boxArray());
     BL_ASSERT(dst.distributionMap == src.distributionMap);
-    BL_ASSERT(dst.nGrow() >= nghost && src.nGrow() >= nghost);
+    BL_ASSERT(dst.nGrowVect().allGE(nghost) && src.nGrowVect().allGE(nghost));
 
     amrex::Copy(dst,src,srccomp,dstcomp,numcomp,IntVect(nghost));
 }
@@ -74,7 +74,7 @@ iMultiFab::Subtract (iMultiFab&       dst,
 {
     BL_ASSERT(dst.boxArray() == src.boxArray());
     BL_ASSERT(dst.distributionMap == src.distributionMap);
-    BL_ASSERT(dst.nGrow() >= nghost && src.nGrow() >= nghost);
+    BL_ASSERT(dst.nGrowVect().allGE(nghost) && src.nGrowVect().allGE(nghost));
 
     amrex::Subtract(dst,src,srccomp,dstcomp,numcomp,IntVect(nghost));
 }
@@ -89,7 +89,7 @@ iMultiFab::Multiply (iMultiFab&       dst,
 {
     BL_ASSERT(dst.boxArray() == src.boxArray());
     BL_ASSERT(dst.distributionMap == src.distributionMap);
-    BL_ASSERT(dst.nGrow() >= nghost && src.nGrow() >= nghost);
+    BL_ASSERT(dst.nGrowVect().allGE(nghost) && src.nGrowVect().allGE(nghost));
 
     amrex::Multiply(dst,src,srccomp,dstcomp,numcomp,IntVect(nghost));
 }
@@ -104,7 +104,7 @@ iMultiFab::Divide (iMultiFab&       dst,
 {
     BL_ASSERT(dst.boxArray() == src.boxArray());
     BL_ASSERT(dst.distributionMap == src.distributionMap);
-    BL_ASSERT(dst.nGrow() >= nghost && src.nGrow() >= nghost);
+    BL_ASSERT(dst.nGrowVect().allGE(nghost) && src.nGrowVect().allGE(nghost));
 
     amrex::Divide(dst,src,srccomp,dstcomp,numcomp,IntVect(nghost));
 }
@@ -226,7 +226,7 @@ iMultiFab::min (int comp, int nghost, bool local) const
 {
     BL_PROFILE("iMultiFab::min()");
 
-    BL_ASSERT(nghost >= 0 && nghost <= n_grow.min());
+    BL_ASSERT(nghost >= 0 && n_grow.allGE(nghost));
 
     int mn = std::numeric_limits<int>::max();
 
@@ -266,7 +266,7 @@ iMultiFab::min (const Box& region, int comp, int nghost, bool local) const
 {
     BL_PROFILE("iMultiFab::min(region)");
 
-    BL_ASSERT(nghost >= 0 && nghost <= n_grow.min());
+    BL_ASSERT(nghost >= 0 && n_grow.allGE(nghost));
 
     int mn = std::numeric_limits<int>::max();
 
@@ -310,7 +310,7 @@ iMultiFab::max (int comp, int nghost, bool local) const
 {
     BL_PROFILE("iMultiFab::max()");
 
-    BL_ASSERT(nghost >= 0 && nghost <= n_grow.min());
+    BL_ASSERT(nghost >= 0 && n_grow.allGE(nghost));
 
     int mx = std::numeric_limits<int>::lowest();
 
@@ -350,7 +350,7 @@ iMultiFab::max (const Box& region, int comp, int nghost, bool local) const
 {
     BL_PROFILE("iMultiFab::max(region)");
 
-    BL_ASSERT(nghost >= 0 && nghost <= n_grow.min());
+    BL_ASSERT(nghost >= 0 && n_grow.allGE(nghost));
 
     int mx = std::numeric_limits<int>::lowest();
 
@@ -394,7 +394,7 @@ iMultiFab::sum (int comp, int nghost, bool local) const
 {
     BL_PROFILE("iMultiFab::sum()");
 
-    AMREX_ASSERT(nghost >= 0 && nghost <= n_grow.min());
+    AMREX_ASSERT(nghost >= 0 && n_grow.allGE(nghost));
 
     Long sm = 0;
 
@@ -466,7 +466,7 @@ indexFromValue (iMultiFab const& mf, int comp, int nghost, int value, MPI_Op mml
 IntVect
 iMultiFab::minIndex (int comp, int nghost) const
 {
-    BL_ASSERT(nghost >= 0 && nghost <= n_grow.min());
+    BL_ASSERT(nghost >= 0 && n_grow.allGE(nghost));
     int mn = this->min(comp, nghost, true);
     return indexFromValue(*this, comp, nghost, mn, MPI_MINLOC);
 }
@@ -474,7 +474,7 @@ iMultiFab::minIndex (int comp, int nghost) const
 IntVect
 iMultiFab::maxIndex (int comp, int nghost) const
 {
-    BL_ASSERT(nghost >= 0 && nghost <= n_grow.min());
+    BL_ASSERT(nghost >= 0 && n_grow.allGE(nghost));
     int mx = this->max(comp, nghost, true);
     return indexFromValue(*this, comp, nghost, mx, MPI_MAXLOC);
 }
@@ -503,7 +503,7 @@ iMultiFab::plus (int val,
                  int  num_comp,
                  int  nghost)
 {
-    BL_ASSERT(nghost >= 0 && nghost <= n_grow.min());
+    BL_ASSERT(nghost >= 0 && n_grow.allGE(nghost));
     BL_ASSERT(comp+num_comp <= n_comp);
     BL_ASSERT(num_comp > 0);
 
@@ -517,7 +517,7 @@ iMultiFab::plus (int       val,
                  int        num_comp,
                  int        nghost)
 {
-    BL_ASSERT(nghost >= 0 && nghost <= n_grow.min());
+    BL_ASSERT(nghost >= 0 && n_grow.allGE(nghost));
     BL_ASSERT(comp+num_comp <= n_comp);
     BL_ASSERT(num_comp > 0);
 
@@ -534,7 +534,7 @@ iMultiFab::plus (const iMultiFab& mf,
     BL_ASSERT(strt_comp >= 0);
     BL_ASSERT(num_comp > 0);
     BL_ASSERT(strt_comp + num_comp - 1 < n_comp && strt_comp + num_comp - 1 < mf.n_comp);
-    BL_ASSERT(nghost <= n_grow.min() && nghost <= mf.n_grow.min());
+    BL_ASSERT(n_grow.allGE(nghost) && mf.n_grow.allGE(nghost));
 
     amrex::Add(*this, mf, strt_comp, strt_comp, num_comp, nghost);
 }
@@ -545,7 +545,7 @@ iMultiFab::mult (int val,
                  int  num_comp,
                  int  nghost)
 {
-    BL_ASSERT(nghost >= 0 && nghost <= n_grow.min());
+    BL_ASSERT(nghost >= 0 && n_grow.allGE(nghost));
     BL_ASSERT(comp+num_comp <= n_comp);
     BL_ASSERT(num_comp > 0);
 
@@ -559,7 +559,7 @@ iMultiFab::mult (int       val,
                  int        num_comp,
                  int        nghost)
 {
-    BL_ASSERT(nghost >= 0 && nghost <= n_grow.min());
+    BL_ASSERT(nghost >= 0 && n_grow.allGE(nghost));
     BL_ASSERT(comp+num_comp <= n_comp);
     BL_ASSERT(num_comp > 0);
 
@@ -571,7 +571,7 @@ iMultiFab::negate (int comp,
                   int num_comp,
                   int nghost)
 {
-    BL_ASSERT(nghost >= 0 && nghost <= n_grow.min());
+    BL_ASSERT(nghost >= 0 && n_grow.allGE(nghost));
     BL_ASSERT(comp+num_comp <= n_comp);
 
     FabArray<IArrayBox>::mult(-1,comp,num_comp,nghost);
@@ -583,7 +583,7 @@ iMultiFab::negate (const Box& region,
                   int        num_comp,
                   int        nghost)
 {
-    BL_ASSERT(nghost >= 0 && nghost <= n_grow.min());
+    BL_ASSERT(nghost >= 0 && n_grow.allGE(nghost));
     BL_ASSERT(comp+num_comp <= n_comp);
 
     FabArray<IArrayBox>::mult(-1,region,comp,num_comp,nghost);

--- a/Src/Boundary/AMReX_FabSet.H
+++ b/Src/Boundary/AMReX_FabSet.H
@@ -318,8 +318,7 @@ FabSetT<MF>::linComb (value_type a, const MF& mfa, int a_comp,
                       int dcomp, int ncomp, int ngrow)
 {
     BL_PROFILE("FabSetT<MF>::linComb()");
-    BL_ASSERT(ngrow <= mfa.nGrow());
-    BL_ASSERT(ngrow <= mfb.nGrow());
+    BL_ASSERT(mfa.nGrowVect().allGE(ngrow) && mfb.nGrowVect().allGE(ngrow));
     BL_ASSERT(mfa.boxArray() == mfb.boxArray());
     BL_ASSERT(boxArray() != mfa.boxArray());
 

--- a/Src/EB/AMReX_EB_Redistribution.cpp
+++ b/Src/EB/AMReX_EB_Redistribution.cpp
@@ -64,7 +64,7 @@ namespace amrex {
         Box domain(geom.Domain());
 
         int nghost = 2;
-        AMREX_ASSERT(div_tmp_in.nGrow() >= nghost);
+        AMREX_ASSERT(div_tmp_in.nGrowVect().allGE(nghost));
 
         EB_set_covered(div_tmp_in, 0, ncomp, div_tmp_in.nGrow(), eb_covered_val);
 

--- a/Src/LinearSolvers/MLMG/AMReX_MLCurlCurl.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLCurlCurl.cpp
@@ -312,7 +312,7 @@ MLCurlCurl::apply (int amrlev, int mglev, MF& out, MF& in, BCMode /*bc_mode*/,
 void MLCurlCurl::smooth (int amrlev, int mglev, MF& sol, const MF& rhs,
                          bool skip_fillboundary) const
 {
-    AMREX_ASSERT(rhs[0].nGrowVect().allGE(IntVect(1)));
+    AMREX_ASSERT(rhs[0].nGrowVect().allGE(1));
 
     applyBC(amrlev, mglev, const_cast<MF&>(rhs), CurlCurlStateType::b);
 

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian.cpp
@@ -750,7 +750,7 @@ MLNodeLaplacian::restrictInteriorNodes (int camrlev, MultiFab& crhs, MultiFab& a
 
     MultiFab* frhs = nullptr;
     std::unique_ptr<MultiFab> mf;
-    if (a_frhs.nGrowVect().allGE(IntVect(amrrr-1)))
+    if (a_frhs.nGrowVect().allGE(amrrr-1))
     {
         frhs = &a_frhs;
     }

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian_misc.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian_misc.cpp
@@ -937,7 +937,7 @@ MLNodeLaplacian::compRHS (const Vector<MultiFab*>& rhs, const Vector<MultiFab*>&
     {
         const Geometry& geom = m_geom[ilev][0];
         AMREX_ASSERT(vel[ilev]->nComp() >= AMREX_SPACEDIM);
-        AMREX_ASSERT(vel[ilev]->nGrow() >= 1);
+        AMREX_ASSERT(vel[ilev]->nGrowVect().allGE(1));
 
         if (has_inflow) { // Zero out transverse velocity so that it's not seen.
             Box domain = geom.Domain();

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian_sync.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian_sync.cpp
@@ -674,7 +674,7 @@ MLNodeLaplacian::reflux (int crse_amrlev,
     MultiFab fine_res_for_coarse(amrex::coarsen(fba, amrrr), fdm, 1, 0);
 
     std::unique_ptr<MultiFab> tmp_fine_res;
-    if (amrrr == 4 && !a_fine_res.nGrowVect().allGE(IntVect(3))) {
+    if (amrrr == 4 && !a_fine_res.nGrowVect().allGE(3)) {
         tmp_fine_res = std::make_unique<MultiFab>(a_fine_res.boxArray(),
                                                   a_fine_res.DistributionMap(), 1, 3);
         MultiFab::Copy(*tmp_fine_res, a_fine_res, 0, 0, 1, 0);

--- a/Src/Particle/AMReX_Particle.H
+++ b/Src/Particle/AMReX_Particle.H
@@ -408,7 +408,7 @@ struct Particle
     [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     RealVect rvec (const IntVect& indices) const &
     {
-        AMREX_ASSERT(indices.max() < NReal);
+        AMREX_ASSERT(indices.allLT(NReal));
         return RealVect(AMREX_D_DECL(this->m_rdata[indices[0]],
                                      this->m_rdata[indices[1]],
                                      this->m_rdata[indices[2]]));

--- a/Src/Particle/AMReX_ParticleUtil.H
+++ b/Src/Particle/AMReX_ParticleUtil.H
@@ -778,7 +778,7 @@ template <class index_type, class PTile>
 void PermutationForDeposition (Gpu::DeviceVector<index_type>& perm, index_type nitems,
                                const PTile& ptile, Box bx, Geometry geom, const IntVect idx_type)
 {
-    AMREX_ALWAYS_ASSERT(idx_type.allGE(IntVect(0)) && idx_type.allLE(IntVect(2)));
+    AMREX_ALWAYS_ASSERT(idx_type.allGE(0) && idx_type.allLE(2));
 
     const IntVect refine_vect = max(idx_type, IntVect(1)).min(IntVect(2));
     const IntVect type_vect = idx_type - idx_type / 2 * 2;

--- a/Src/Particle/AMReX_TracerParticles.cpp
+++ b/Src/Particle/AMReX_TracerParticles.cpp
@@ -13,13 +13,13 @@ TracerParticleContainer::AdvectWithUmac (MultiFab* umac, int lev, Real dt)
     AMREX_ASSERT(OK(lev, lev, umac[0].nGrow()-1));
     AMREX_ASSERT(lev >= 0 && lev < GetParticles().size());
 
-    AMREX_D_TERM(AMREX_ASSERT(umac[0].nGrow() >= 1);,
-                 AMREX_ASSERT(umac[1].nGrow() >= 1);,
-                 AMREX_ASSERT(umac[2].nGrow() >= 1););
+    AMREX_ASSERT(AMREX_D_TERM(umac[0].nGrowVect().allGE(1),
+                           && umac[1].nGrowVect().allGE(1),
+                           && umac[2].nGrowVect().allGE(1)));
 
-    AMREX_D_TERM(AMREX_ASSERT(!umac[0].contains_nan());,
-                 AMREX_ASSERT(!umac[1].contains_nan());,
-                 AMREX_ASSERT(!umac[2].contains_nan()););
+    AMREX_ASSERT(AMREX_D_TERM(!umac[0].contains_nan(),
+                           && !umac[1].contains_nan(),
+                           && !umac[2].contains_nan()));
 
     const auto      strttime = amrex::second();
     const Geometry& geom     = m_gdb->Geom(lev);
@@ -120,7 +120,7 @@ void
 TracerParticleContainer::AdvectWithUcc (const MultiFab& Ucc, int lev, Real dt)
 {
     BL_PROFILE("TracerParticleContainer::AdvectWithUcc()");
-    AMREX_ASSERT(Ucc.nGrow() > 0);
+    AMREX_ASSERT(Ucc.nGrowVect().allGT(0));
     AMREX_ASSERT(OK(lev, lev, Ucc.nGrow()-1));
     AMREX_ASSERT(lev >= 0 && lev < GetParticles().size());
     AMREX_ASSERT(!Ucc.contains_nan());


### PR DESCRIPTION
A MultiFab used to have the same number of ghost cells in all directions. This has no longer been the case for many years. But many assertions have not been updated for this change. This commit fixes various assertions to make it more appropriate.

Also added are overloaded functions for element-wise comparison between an IntVect and an integer. This makes the code cleaner.
