### PR TITLE
Neumann BC at coarse/fine interface for cell-centered solvers

### DIFF
--- a/Src/LinearSolvers/MLMG/AMReX_MLABecLaplacian.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLABecLaplacian.H
@@ -719,10 +719,8 @@ MLABecLaplacianT<MF>::update_singular_flags ()
     m_is_singular.resize(this->m_num_amr_levels, false);
     auto itlo = std::find(this->m_lobc[0].begin(), this->m_lobc[0].end(), BCType::Dirichlet);
     auto ithi = std::find(this->m_hibc[0].begin(), this->m_hibc[0].end(), BCType::Dirichlet);
-    int lev0_a_is_zero = -1; // unknown
     if (itlo == this->m_lobc[0].end() && ithi == this->m_hibc[0].end())
     {  // No Dirichlet
-        lev0_a_is_zero = 0;
         for (int alev = 0; alev < this->m_num_amr_levels; ++alev)
         {
             // For now this assumes that overset regions are treated as Dirichlet bc's
@@ -731,15 +729,12 @@ MLABecLaplacianT<MF>::update_singular_flags ()
                 if (m_a_scalar == Real(0.0))
                 {
                     m_is_singular[alev] = true;
-                    if (alev == 0) { lev0_a_is_zero = true; }
                 }
                 else
                 {
                     RT asum = m_a_coeffs[alev].back().sum(0,IntVect(0));
                     RT amax = m_a_coeffs[alev].back().norminf(0,1,IntVect(0));
-                    bool a_is_almost_zero = std::abs(asum) <= amax * RT(1.e-12);
-                    m_is_singular[alev] = a_is_almost_zero;
-                    if (alev == 0) { lev0_a_is_zero = a_is_almost_zero; }
+                    m_is_singular[alev] = (std::abs(asum) <= amax * RT(1.e-12));
                 }
             }
         }
@@ -750,18 +745,17 @@ MLABecLaplacianT<MF>::update_singular_flags ()
     {
         AMREX_ASSERT(this->m_overset_mask[0][0] == nullptr);
 
-        if (lev0_a_is_zero == -1) {
-            if (m_a_scalar == Real(0.0)) {
-                lev0_a_is_zero = 1;
-            } else {
-                RT asum = m_a_coeffs[0].back().sum(0,IntVect(0));
-                RT amax = m_a_coeffs[0].back().norminf(0,1,IntVect(0));
-                bool a_is_almost_zero = std::abs(asum) <= amax * RT(1.e-12);
-                if (a_is_almost_zero) { lev0_a_is_zero = 1; }
-            }
+        bool lev0_a_is_zero = false;
+        if (m_a_scalar == Real(0.0)) {
+            lev0_a_is_zero = true;
+        } else {
+            RT asum = m_a_coeffs[0].back().sum(0,IntVect(0));
+            RT amax = m_a_coeffs[0].back().norminf(0,1,IntVect(0));
+            bool a_is_almost_zero = std::abs(asum) <= amax * RT(1.e-12);
+            if (a_is_almost_zero) { lev0_a_is_zero = true; }
         }
 
-        if (lev0_a_is_zero == 1) {
+        if (lev0_a_is_zero) {
             auto bbox = this->m_grids[0][0].minimalBox();
             for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
                 if (this->m_lobc[0][idim] == LinOpBCType::Dirichlet) {

--- a/Src/LinearSolvers/MLMG/AMReX_MLABecLaplacian.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLABecLaplacian.H
@@ -719,6 +719,7 @@ MLABecLaplacianT<MF>::update_singular_flags ()
     m_is_singular.resize(this->m_num_amr_levels, false);
     auto itlo = std::find(this->m_lobc[0].begin(), this->m_lobc[0].end(), BCType::Dirichlet);
     auto ithi = std::find(this->m_hibc[0].begin(), this->m_hibc[0].end(), BCType::Dirichlet);
+    bool lev0_a_is_zero = false;
     if (itlo == this->m_lobc[0].end() && ithi == this->m_hibc[0].end())
     {  // No Dirichlet
         for (int alev = 0; alev < this->m_num_amr_levels; ++alev)
@@ -729,14 +730,35 @@ MLABecLaplacianT<MF>::update_singular_flags ()
                 if (m_a_scalar == 0.0)
                 {
                     m_is_singular[alev] = true;
+                    if (alev == 0) { lev0_a_is_zero = true; }
                 }
                 else
                 {
                     RT asum = m_a_coeffs[alev].back().sum(0,IntVect(0));
                     RT amax = m_a_coeffs[alev].back().norminf(0,1,IntVect(0));
-                    m_is_singular[alev] = (std::abs(asum) <= amax * RT(1.e-12));
+                    bool a_is_almost_zero = std::abs(asum) <= amax * RT(1.e-12);
+                    m_is_singular[alev] = a_is_almost_zero;
+                    if (alev == 0) { lev0_a_is_zero = a_is_almost_zero; }
                 }
             }
+        }
+    }
+
+    if (lev0_a_is_zero && !m_is_singular[0] && this->m_needs_coarse_data_for_bc &&
+        this->m_coarse_fine_bc_type == LinOpBCType::Neumann)
+    {
+        AMREX_ASSERT(this->m_overset_mask[0][0] == nullptr);
+        auto bbox = this->m_grids[0][0].minimalBox();
+        for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+            if (this->m_lobc[0][idim] == LinOpBCType::Dirichlet) {
+                bbox.growLo(idim,1);
+            }
+            if (this->m_hibc[0][idim] == LinOpBCType::Dirichlet) {
+                bbox.growHi(idim,1);
+            }
+        }
+        if (this->m_geom[0][0].Domain().contains(bbox)) {
+            m_is_singular[0] = true;
         }
     }
 }

--- a/Src/LinearSolvers/MLMG/AMReX_MLABecLaplacian.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLABecLaplacian.H
@@ -719,9 +719,10 @@ MLABecLaplacianT<MF>::update_singular_flags ()
     m_is_singular.resize(this->m_num_amr_levels, false);
     auto itlo = std::find(this->m_lobc[0].begin(), this->m_lobc[0].end(), BCType::Dirichlet);
     auto ithi = std::find(this->m_hibc[0].begin(), this->m_hibc[0].end(), BCType::Dirichlet);
-    bool lev0_a_is_zero = false;
+    int lev0_a_is_zero = -1; // unknown
     if (itlo == this->m_lobc[0].end() && ithi == this->m_hibc[0].end())
     {  // No Dirichlet
+        lev0_a_is_zero = 0;
         for (int alev = 0; alev < this->m_num_amr_levels; ++alev)
         {
             // For now this assumes that overset regions are treated as Dirichlet bc's
@@ -744,21 +745,35 @@ MLABecLaplacianT<MF>::update_singular_flags ()
         }
     }
 
-    if (lev0_a_is_zero && !m_is_singular[0] && this->m_needs_coarse_data_for_bc &&
+    if (!m_is_singular[0] && this->m_needs_coarse_data_for_bc &&
         this->m_coarse_fine_bc_type == LinOpBCType::Neumann)
     {
         AMREX_ASSERT(this->m_overset_mask[0][0] == nullptr);
-        auto bbox = this->m_grids[0][0].minimalBox();
-        for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-            if (this->m_lobc[0][idim] == LinOpBCType::Dirichlet) {
-                bbox.growLo(idim,1);
-            }
-            if (this->m_hibc[0][idim] == LinOpBCType::Dirichlet) {
-                bbox.growHi(idim,1);
+
+        if (lev0_a_is_zero == -1) {
+            if (m_a_scalar == Real(0.0)) {
+                lev0_a_is_zero = 1;
+            } else {
+                RT asum = m_a_coeffs[alev].back().sum(0,IntVect(0));
+                RT amax = m_a_coeffs[alev].back().norminf(0,1,IntVect(0));
+                bool a_is_almost_zero = std::abs(asum) <= amax * RT(1.e-12);
+                if (a_is_almost_zero) { lev0_a_is_zero = 1; }
             }
         }
-        if (this->m_geom[0][0].Domain().contains(bbox)) {
-            m_is_singular[0] = true;
+
+        if (lev0_a_is_zero == 1) {
+            auto bbox = this->m_grids[0][0].minimalBox();
+            for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+                if (this->m_lobc[0][idim] == LinOpBCType::Dirichlet) {
+                    bbox.growLo(idim,1);
+                }
+                if (this->m_hibc[0][idim] == LinOpBCType::Dirichlet) {
+                    bbox.growHi(idim,1);
+                }
+            }
+            if (this->m_geom[0][0].Domain().contains(bbox)) {
+                m_is_singular[0] = true;
+            }
         }
     }
 }

--- a/Src/LinearSolvers/MLMG/AMReX_MLABecLaplacian.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLABecLaplacian.H
@@ -728,7 +728,7 @@ MLABecLaplacianT<MF>::update_singular_flags ()
             // For now this assumes that overset regions are treated as Dirichlet bc's
             if (this->m_domain_covered[alev] && !this->m_overset_mask[alev][0])
             {
-                if (m_a_scalar == 0.0)
+                if (m_a_scalar == Real(0.0))
                 {
                     m_is_singular[alev] = true;
                     if (alev == 0) { lev0_a_is_zero = true; }
@@ -754,8 +754,8 @@ MLABecLaplacianT<MF>::update_singular_flags ()
             if (m_a_scalar == Real(0.0)) {
                 lev0_a_is_zero = 1;
             } else {
-                RT asum = m_a_coeffs[alev].back().sum(0,IntVect(0));
-                RT amax = m_a_coeffs[alev].back().norminf(0,1,IntVect(0));
+                RT asum = m_a_coeffs[0].back().sum(0,IntVect(0));
+                RT amax = m_a_coeffs[0].back().norminf(0,1,IntVect(0));
                 bool a_is_almost_zero = std::abs(asum) <= amax * RT(1.e-12);
                 if (a_is_almost_zero) { lev0_a_is_zero = 1; }
             }

--- a/Src/LinearSolvers/MLMG/AMReX_MLABecLaplacian.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLABecLaplacian.H
@@ -1239,8 +1239,9 @@ MLABecLaplacianT<MF>::makeNLinOp (int /*grid_size*/) const
     if (this->needsCoarseDataForBC())
     {
         const Real* dx0 = this->m_geom[0][0].CellSize();
-        const Real fac = Real(0.5)*this->m_coarse_data_crse_ratio;
-        RealVect cbloc {AMREX_D_DECL(dx0[0]*fac, dx0[1]*fac, dx0[2]*fac)};
+        RealVect fac(this->m_coarse_data_crse_ratio);
+        fac *= Real(0.5);
+        RealVect cbloc {AMREX_D_DECL(dx0[0]*fac[0], dx0[1]*fac[1], dx0[2]*fac[2])};
         nop->setCoarseFineBCLocation(cbloc);
     }
 

--- a/Src/LinearSolvers/MLMG/AMReX_MLCellLinOp.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLCellLinOp.H
@@ -158,7 +158,8 @@ protected:
                               const Vector<Array<BCType,AMREX_SPACEDIM> >& hibc,
                               int ratio, const RealVect& interior_bloc,
                               const Array<Real,AMREX_SPACEDIM>& domain_bloc_lo,
-                              const Array<Real,AMREX_SPACEDIM>& domain_bloc_hi);
+                              const Array<Real,AMREX_SPACEDIM>& domain_bloc_hi,
+                              LinOpBCType crse_fine_bc_type);
 
         const Vector<BCTuple>& bndryConds (const MFIter& mfi) const noexcept {
             return bcond[mfi];
@@ -291,7 +292,8 @@ setLOBndryConds (const Geometry& geom, const Real* dx,
                  const Vector<Array<BCType,AMREX_SPACEDIM> >& hibc,
                  int ratio, const RealVect& interior_bloc,
                  const Array<Real,AMREX_SPACEDIM>& domain_bloc_lo,
-                 const Array<Real,AMREX_SPACEDIM>& domain_bloc_hi)
+                 const Array<Real,AMREX_SPACEDIM>& domain_bloc_hi,
+                 LinOpBCType crse_fine_bc_type)
 {
     const Box& domain = geom.Domain();
 
@@ -308,7 +310,8 @@ setLOBndryConds (const Geometry& geom, const Real* dx,
                                      lobc[icomp], hibc[icomp],
                                      dx, ratio, interior_bloc,
                                      domain_bloc_lo, domain_bloc_hi,
-                                     geom.isPeriodicArray());
+                                     geom.isPeriodicArray(),
+                                     crse_fine_bc_type);
         }
     }
 
@@ -556,7 +559,9 @@ MLCellLinOpT<MF>::setLevelBC (int amrlev, const MF* a_levelbcdata, const MF* rob
         br_ref_ratio = this->m_amr_ref_ratio[amrlev-1];
     }
 
-    m_bndry_sol[amrlev]->setLOBndryConds(this->m_lobc, this->m_hibc, br_ref_ratio, this->m_coarse_bc_loc);
+    auto crse_fine_bc_type = (amrlev == 0) ? this->m_coarse_fine_bc_type : LinOpBCType::Dirichlet;
+    m_bndry_sol[amrlev]->setLOBndryConds(this->m_lobc, this->m_hibc, br_ref_ratio,
+                                         this->m_coarse_bc_loc, crse_fine_bc_type);
 
     const Real* dx = this->m_geom[amrlev][0].CellSize();
     for (int mglev = 0; mglev < this->m_num_mg_levels[amrlev]; ++mglev)
@@ -564,7 +569,8 @@ MLCellLinOpT<MF>::setLevelBC (int amrlev, const MF* a_levelbcdata, const MF* rob
         m_bcondloc[amrlev][mglev]->setLOBndryConds(this->m_geom[amrlev][mglev], dx,
                                                    this->m_lobc, this->m_hibc,
                                                    br_ref_ratio, this->m_coarse_bc_loc,
-                                                   this->m_domain_bloc_lo, this->m_domain_bloc_hi);
+                                                   this->m_domain_bloc_lo, this->m_domain_bloc_hi,
+                                                   crse_fine_bc_type);
     }
 
     if (this->hasRobinBC()) {

--- a/Src/LinearSolvers/MLMG/AMReX_MLCellLinOp.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLCellLinOp.H
@@ -1917,6 +1917,8 @@ MLCellLinOpT<MF>::computeVolInv () const
         m_volinv[amrlev].resize(this->NMGLevels(amrlev));
     }
 
+    AMREX_ASSERT(this->m_coarse_fine_bc_type == LinOpBCType::Dirichlet || ! this->hasHiddenDimension());
+
     // We don't need to compute for every level
 
     auto f = [&] (int amrlev, int mglev) {
@@ -1934,8 +1936,13 @@ MLCellLinOpT<MF>::computeVolInv () const
         else
 #endif
         {
-            m_volinv[amrlev][mglev]
-                = RT(1.0 / this->compactify(this->Geom(amrlev,mglev).Domain()).d_numPts());
+            if (this->m_coarse_fine_bc_type == LinOpBCType::Dirichlet) {
+                m_volinv[amrlev][mglev]
+                    = RT(1.0 / this->compactify(this->Geom(amrlev,mglev).Domain()).d_numPts());
+            } else {
+                m_volinv[amrlev][mglev]
+                    = RT(1.0 / this->m_grids[amrlev][mglev].d_numPts());
+            }
         }
     };
 

--- a/Src/LinearSolvers/MLMG/AMReX_MLCellLinOp.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLCellLinOp.H
@@ -156,7 +156,7 @@ protected:
         void setLOBndryConds (const Geometry& geom, const Real* dx,
                               const Vector<Array<BCType,AMREX_SPACEDIM> >& lobc,
                               const Vector<Array<BCType,AMREX_SPACEDIM> >& hibc,
-                              int ratio, const RealVect& interior_bloc,
+                              IntVect const& ratio, const RealVect& interior_bloc,
                               const Array<Real,AMREX_SPACEDIM>& domain_bloc_lo,
                               const Array<Real,AMREX_SPACEDIM>& domain_bloc_hi,
                               LinOpBCType crse_fine_bc_type);
@@ -290,7 +290,7 @@ MLCellLinOpT<MF>::BndryCondLoc::
 setLOBndryConds (const Geometry& geom, const Real* dx,
                  const Vector<Array<BCType,AMREX_SPACEDIM> >& lobc,
                  const Vector<Array<BCType,AMREX_SPACEDIM> >& hibc,
-                 int ratio, const RealVect& interior_bloc,
+                 IntVect const& ratio, const RealVect& interior_bloc,
                  const Array<Real,AMREX_SPACEDIM>& domain_bloc_lo,
                  const Array<Real,AMREX_SPACEDIM>& domain_bloc_hi,
                  LinOpBCType crse_fine_bc_type)
@@ -516,27 +516,27 @@ MLCellLinOpT<MF>::setLevelBC (int amrlev, const MF* a_levelbcdata, const MF* rob
     }
     const MF& bcdata = (a_levelbcdata == nullptr) ? zero : *a_levelbcdata;
 
-    int br_ref_ratio = -1;
+    IntVect br_ref_ratio(-1);
 
     if (amrlev == 0)
     {
         if (this->needsCoarseDataForBC())
         {
             AMREX_ALWAYS_ASSERT(!this->hasHiddenDimension());
-            br_ref_ratio = this->m_coarse_data_crse_ratio > 0 ? this->m_coarse_data_crse_ratio : 2;
-            if (m_crse_sol_br[amrlev] == nullptr && br_ref_ratio > 0)
+            br_ref_ratio = this->m_coarse_data_crse_ratio.allGT(0) ? this->m_coarse_data_crse_ratio : IntVect(2);
+            if (m_crse_sol_br[amrlev] == nullptr && br_ref_ratio.allGT(0))
             {
                 const int in_rad = 0;
                 const int out_rad = 1;
                 const int extent_rad = 2;
-                const int crse_ratio = br_ref_ratio;
+                const IntVect crse_ratio = br_ref_ratio;
                 BoxArray cba = this->m_grids[amrlev][0];
                 cba.coarsen(crse_ratio);
                 m_crse_sol_br[amrlev] = std::make_unique<BndryRegisterT<MF>>
                     (cba, this->m_dmap[amrlev][0], in_rad, out_rad, extent_rad, ncomp);
             }
             if (this->m_coarse_data_for_bc != nullptr) {
-                AMREX_ALWAYS_ASSERT(this->m_coarse_data_crse_ratio > 0);
+                AMREX_ALWAYS_ASSERT(this->m_coarse_data_crse_ratio.allGT(0));
                 const Box& cbx = amrex::coarsen(this->m_geom[0][0].Domain(), this->m_coarse_data_crse_ratio);
                 m_crse_sol_br[amrlev]->copyFrom(*this->m_coarse_data_for_bc, 0, 0, 0, ncomp,
                                                 this->m_geom[0][0].periodicity(cbx));
@@ -544,19 +544,19 @@ MLCellLinOpT<MF>::setLevelBC (int amrlev, const MF* a_levelbcdata, const MF* rob
                 m_crse_sol_br[amrlev]->setVal(RT(0.0));
             }
             m_bndry_sol[amrlev]->setBndryValues(*m_crse_sol_br[amrlev], 0,
-                                                bcdata, 0, 0, ncomp, IntVect(br_ref_ratio));
+                                                bcdata, 0, 0, ncomp, br_ref_ratio);
             br_ref_ratio = this->m_coarse_data_crse_ratio;
         }
         else
         {
             m_bndry_sol[amrlev]->setPhysBndryValues(bcdata,0,0,ncomp);
-            br_ref_ratio = 1;
+            br_ref_ratio = IntVect(1);
         }
     }
     else
     {
         m_bndry_sol[amrlev]->setPhysBndryValues(bcdata,0,0,ncomp);
-        br_ref_ratio = this->m_amr_ref_ratio[amrlev-1];
+        br_ref_ratio = IntVect(this->m_amr_ref_ratio[amrlev-1]);
     }
 
     auto crse_fine_bc_type = (amrlev == 0) ? this->m_coarse_fine_bc_type : LinOpBCType::Dirichlet;

--- a/Src/LinearSolvers/MLMG/AMReX_MLLinOp.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLLinOp.H
@@ -191,8 +191,7 @@ public:
     * called, it must be called before `setLevelBC`.  If crse is nullptr,
     * then the bc values are assumed to be zero. The coarse/fine BC type
     * can be changed to homogeneous Neumann by the bc_type argument. In that
-    * case, use nullptr for the crse argument. Currently, only MLABecLaplacian
-    * supports homogeneous Neumann BC at the coarse/fine interface.
+    * case, use nullptr for the crse argument.
     *
     * \param crse       the coarse AMR level data
     * \param crse_ratio the coarsening ratio between fine and coarse AMR levels.

--- a/Src/LinearSolvers/MLMG/AMReX_MLLinOp.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLLinOp.H
@@ -902,7 +902,7 @@ MLLinOpT<MF>::defineGrids (const Vector<Geometry>& a_geom,
     Box aggbox;
     bool aggable = false;
 
-    if (info.do_agglomeration)
+    if (m_grids[0][0].size() > 1 && info.do_agglomeration)
     {
         if (m_domain_covered[0])
         {

--- a/Src/LinearSolvers/MLMG/AMReX_MLLinOp.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLLinOp.H
@@ -184,20 +184,26 @@ public:
     * coarsest AMR level of the solve come from a coarser level (e.g. the
     * base AMR level of the solve is > 0 and does not cover the entire
     * domain), we must explicitly provide the coarser data.  Boundary
-    * conditions from a coarser level are always Dirichlet.  The MultiFab
+    * conditions from a coarser level are Dirichlet by default.  The MultiFab
     * crse does not need to have ghost cells and is at a coarser resolution
     * than the coarsest AMR level of the solve; it is used to supply
     * (interpolated) boundary conditions for the solve.  NOTE: If this is
     * called, it must be called before `setLevelBC`.  If crse is nullptr,
-    * then the bc values are assumed to be zero.
+    * then the bc values are assumed to be zero. The coarse/fine BC type
+    * can be changed to homogeneous Neumann by the bc_type argument. In that
+    * case, use nullptr for the crse argument. Currently, only MLABecLaplacian
+    * supports homogeneous Neumann BC at the coarse/fine interface.
     *
     * \param crse       the coarse AMR level data
     * \param crse_ratio the coarsening ratio between fine and coarse AMR levels.
+    * \param bc_type    optional. It's Dirichlet by default, and can be Neumann.
     */
-    void setCoarseFineBC (const MF* crse, int crse_ratio) noexcept;
+    void setCoarseFineBC (const MF* crse, int crse_ratio,
+                          LinOpBCType bc_type = LinOpBCType::Dirichlet) noexcept;
 
     template <typename AMF, std::enable_if_t<!std::is_same_v<MF,AMF>,int> = 0>
-    void setCoarseFineBC (const AMF* crse, int crse_ratio) noexcept;
+    void setCoarseFineBC (const AMF* crse, int crse_ratio,
+                          LinOpBCType bc_type = LinOpBCType::Dirichlet) noexcept;
 
     /**
     * \brief Set boundary conditions for given level. For cell-centered
@@ -612,6 +618,7 @@ protected:
     Array<Real, AMREX_SPACEDIM> m_domain_bloc_hi {{AMREX_D_DECL(0._rt,0._rt,0._rt)}};
 
     bool m_needs_coarse_data_for_bc = false;
+    LinOpBCType m_coarse_fine_bc_type = LinOpBCType::Dirichlet;
     int m_coarse_data_crse_ratio = -1;
     RealVect m_coarse_bc_loc;
     const MF* m_coarse_data_for_bc = nullptr;
@@ -1404,16 +1411,19 @@ MLLinOpT<MF>::setDomainBCLoc (const Array<Real,AMREX_SPACEDIM>& lo_bcloc,
 
 template <typename MF>
 void
-MLLinOpT<MF>::setCoarseFineBC (const MF* crse, int crse_ratio) noexcept
+MLLinOpT<MF>::setCoarseFineBC (const MF* crse, int crse_ratio,
+                               LinOpBCType bc_type) noexcept
 {
     m_coarse_data_for_bc = crse;
     m_coarse_data_crse_ratio = crse_ratio;
+    m_coarse_fine_bc_type = bc_type;
 }
 
 template <typename MF>
 template <typename AMF, std::enable_if_t<!std::is_same_v<MF,AMF>,int>>
 void
-MLLinOpT<MF>::setCoarseFineBC (const AMF* crse, int crse_ratio) noexcept
+MLLinOpT<MF>::setCoarseFineBC (const AMF* crse, int crse_ratio,
+                               LinOpBCType bc_type) noexcept
 {
     m_coarse_data_for_bc_raii = MF(crse->boxArray(), crse->DistributionMap(),
                                    crse->nComp(), crse->nGrowVect());
@@ -1421,6 +1431,7 @@ MLLinOpT<MF>::setCoarseFineBC (const AMF* crse, int crse_ratio) noexcept
                                         crse->nGrowVect());
     m_coarse_data_for_bc = &m_coarse_data_for_bc_raii;
     m_coarse_data_crse_ratio = crse_ratio;
+    m_coarse_fine_bc_type = bc_type;
 }
 
 template <typename MF>

--- a/Src/LinearSolvers/MLMG/AMReX_MLLinOp.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLLinOp.H
@@ -200,8 +200,15 @@ public:
     void setCoarseFineBC (const MF* crse, int crse_ratio,
                           LinOpBCType bc_type = LinOpBCType::Dirichlet) noexcept;
 
+    void setCoarseFineBC (const MF* crse, IntVect const& crse_ratio,
+                          LinOpBCType bc_type = LinOpBCType::Dirichlet) noexcept;
+
     template <typename AMF, std::enable_if_t<!std::is_same_v<MF,AMF>,int> = 0>
     void setCoarseFineBC (const AMF* crse, int crse_ratio,
+                          LinOpBCType bc_type = LinOpBCType::Dirichlet) noexcept;
+
+    template <typename AMF, std::enable_if_t<!std::is_same_v<MF,AMF>,int> = 0>
+    void setCoarseFineBC (const AMF* crse, IntVect const& crse_ratio,
                           LinOpBCType bc_type = LinOpBCType::Dirichlet) noexcept;
 
     /**
@@ -618,7 +625,7 @@ protected:
 
     bool m_needs_coarse_data_for_bc = false;
     LinOpBCType m_coarse_fine_bc_type = LinOpBCType::Dirichlet;
-    int m_coarse_data_crse_ratio = -1;
+    IntVect m_coarse_data_crse_ratio = IntVect(-1);
     RealVect m_coarse_bc_loc;
     const MF* m_coarse_data_for_bc = nullptr;
     MF m_coarse_data_for_bc_raii;
@@ -1413,6 +1420,14 @@ void
 MLLinOpT<MF>::setCoarseFineBC (const MF* crse, int crse_ratio,
                                LinOpBCType bc_type) noexcept
 {
+    setCoarseFineBC(crse, IntVect(crse_ratio), bc_type);
+}
+
+template <typename MF>
+void
+MLLinOpT<MF>::setCoarseFineBC (const MF* crse, IntVect const& crse_ratio,
+                               LinOpBCType bc_type) noexcept
+{
     m_coarse_data_for_bc = crse;
     m_coarse_data_crse_ratio = crse_ratio;
     m_coarse_fine_bc_type = bc_type;
@@ -1422,6 +1437,15 @@ template <typename MF>
 template <typename AMF, std::enable_if_t<!std::is_same_v<MF,AMF>,int>>
 void
 MLLinOpT<MF>::setCoarseFineBC (const AMF* crse, int crse_ratio,
+                               LinOpBCType bc_type) noexcept
+{
+    setCoarseFineBC(crse, IntVect(crse_ratio), bc_type);
+}
+
+template <typename MF>
+template <typename AMF, std::enable_if_t<!std::is_same_v<MF,AMF>,int>>
+void
+MLLinOpT<MF>::setCoarseFineBC (const AMF* crse, IntVect const& crse_ratio,
                                LinOpBCType bc_type) noexcept
 {
     m_coarse_data_for_bc_raii = MF(crse->boxArray(), crse->DistributionMap(),

--- a/Src/LinearSolvers/MLMG/AMReX_MLMG.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLMG.H
@@ -1897,7 +1897,8 @@ MLMGT<MF>::bottomSolveWithHypre (MF& x, const MF& b)
             RealVect bclocation(AMREX_D_DECL(0.5*dx[0]*crse_ratio,
                                              0.5*dx[1]*crse_ratio,
                                              0.5*dx[2]*crse_ratio));
-            hypre_bndry->setLOBndryConds(linop.m_lobc, linop.m_hibc, -1, bclocation);
+            hypre_bndry->setLOBndryConds(linop.m_lobc, linop.m_hibc, -1, bclocation,
+                                         linop.m_coarse_fine_bc_type);
         }
 
         // IJ interface understands absolute tolerance API of hypre
@@ -1951,7 +1952,8 @@ MLMGT<MF>::bottomSolveWithPETSc (MF& x, const MF& b)
         RealVect bclocation(AMREX_D_DECL(0.5*dx[0]*crse_ratio,
                                          0.5*dx[1]*crse_ratio,
                                          0.5*dx[2]*crse_ratio));
-        petsc_bndry->setLOBndryConds(linop.m_lobc, linop.m_hibc, -1, bclocation);
+        petsc_bndry->setLOBndryConds(linop.m_lobc, linop.m_hibc, -1, bclocation,
+                                     linop.m_coarse_fine_bc_type);
     }
     petsc_solver->solve(x, b, bottom_reltol, Real(-1.), bottom_maxiter, *petsc_bndry,
                         linop.getMaxOrder());

--- a/Src/LinearSolvers/MLMG/AMReX_MLMG.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLMG.H
@@ -1948,7 +1948,7 @@ MLMGT<MF>::bottomSolveWithPETSc (MF& x, const MF& b)
         petsc_bndry = std::make_unique<MLMGBndryT<MF>>(ba, dm, ncomp, geom);
         petsc_bndry->setHomogValues();
         const Real* dx = linop.m_geom[0][0].CellSize();
-        int crse_ratio = linop.m_coarse_data_crse_ratio.allGT(0) ? linop.m_coarse_data_crse_ratio : IntVect(1);
+        auto crse_ratio = linop.m_coarse_data_crse_ratio.allGT(0) ? linop.m_coarse_data_crse_ratio : IntVect(1);
         RealVect bclocation(AMREX_D_DECL(0.5*dx[0]*crse_ratio[0],
                                          0.5*dx[1]*crse_ratio[1],
                                          0.5*dx[2]*crse_ratio[2]));

--- a/Src/LinearSolvers/MLMG/AMReX_MLMG.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLMG.H
@@ -1893,11 +1893,11 @@ MLMGT<MF>::bottomSolveWithHypre (MF& x, const MF& b)
             hypre_bndry = std::make_unique<MLMGBndryT<MF>>(ba, dm, ncomp, geom);
             hypre_bndry->setHomogValues();
             const Real* dx = linop.m_geom[0][0].CellSize();
-            int crse_ratio = linop.m_coarse_data_crse_ratio > 0 ? linop.m_coarse_data_crse_ratio : 1;
-            RealVect bclocation(AMREX_D_DECL(0.5*dx[0]*crse_ratio,
-                                             0.5*dx[1]*crse_ratio,
-                                             0.5*dx[2]*crse_ratio));
-            hypre_bndry->setLOBndryConds(linop.m_lobc, linop.m_hibc, -1, bclocation,
+            IntVect crse_ratio = linop.m_coarse_data_crse_ratio.allGT(0) ? linop.m_coarse_data_crse_ratio : IntVect(1);
+            RealVect bclocation(AMREX_D_DECL(0.5*dx[0]*crse_ratio[0],
+                                             0.5*dx[1]*crse_ratio[1],
+                                             0.5*dx[2]*crse_ratio[2]));
+            hypre_bndry->setLOBndryConds(linop.m_lobc, linop.m_hibc, IntVect(-1), bclocation,
                                          linop.m_coarse_fine_bc_type);
         }
 
@@ -1948,11 +1948,11 @@ MLMGT<MF>::bottomSolveWithPETSc (MF& x, const MF& b)
         petsc_bndry = std::make_unique<MLMGBndryT<MF>>(ba, dm, ncomp, geom);
         petsc_bndry->setHomogValues();
         const Real* dx = linop.m_geom[0][0].CellSize();
-        int crse_ratio = linop.m_coarse_data_crse_ratio > 0 ? linop.m_coarse_data_crse_ratio : 1;
-        RealVect bclocation(AMREX_D_DECL(0.5*dx[0]*crse_ratio,
-                                         0.5*dx[1]*crse_ratio,
-                                         0.5*dx[2]*crse_ratio));
-        petsc_bndry->setLOBndryConds(linop.m_lobc, linop.m_hibc, -1, bclocation,
+        int crse_ratio = linop.m_coarse_data_crse_ratio.allGT(0) ? linop.m_coarse_data_crse_ratio : IntVect(1);
+        RealVect bclocation(AMREX_D_DECL(0.5*dx[0]*crse_ratio[0],
+                                         0.5*dx[1]*crse_ratio[1],
+                                         0.5*dx[2]*crse_ratio[2]));
+        petsc_bndry->setLOBndryConds(linop.m_lobc, linop.m_hibc, IntVect(-1), bclocation,
                                      linop.m_coarse_fine_bc_type);
     }
     petsc_solver->solve(x, b, bottom_reltol, Real(-1.), bottom_maxiter, *petsc_bndry,

--- a/Src/LinearSolvers/MLMG/AMReX_MLMGBndry.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLMGBndry.H
@@ -27,7 +27,8 @@ public:
 
     void setLOBndryConds (const Vector<Array<LinOpBCType,AMREX_SPACEDIM> >& lo,
                           const Vector<Array<LinOpBCType,AMREX_SPACEDIM> >& hi,
-                          int ratio, const RealVect& a_loc);
+                          int ratio, const RealVect& a_loc,
+                          LinOpBCType a_crse_fine_bc_type = LinOpBCType::Dirichlet);
 
     static void setBoxBC (RealTuple& bloc, BCTuple& bctag, const Box& bx,
                           const Box& domain,
@@ -37,7 +38,8 @@ public:
                           const RealVect& interior_bloc,
                           const Array<Real,AMREX_SPACEDIM>& domain_bloc_lo,
                           const Array<Real,AMREX_SPACEDIM>& domain_bloc_hi,
-                          const GpuArray<int,AMREX_SPACEDIM>& is_periodic);
+                          const GpuArray<int,AMREX_SPACEDIM>& is_periodic,
+                          LinOpBCType a_crse_fine_bc_type);
 };
 
 template <typename MF>
@@ -50,12 +52,16 @@ template <typename MF>
 void
 MLMGBndryT<MF>::setLOBndryConds (const Vector<Array<LinOpBCType,AMREX_SPACEDIM> >& lo,
                                  const Vector<Array<LinOpBCType,AMREX_SPACEDIM> >& hi,
-                                 int ratio, const RealVect& a_loc)
+                                 int ratio, const RealVect& a_loc,
+                                 LinOpBCType a_crse_fine_bc_type)
 {
     const BoxArray& ba     = this->boxes();
     const Real*     dx     = this->geom.CellSize();
     const Box&      domain = this->geom.Domain();
     const GpuArray<int,AMREX_SPACEDIM>& is_periodic = this->geom.isPeriodicArray();
+
+    AMREX_ASSERT(a_crse_fine_bc_type == LinOpBCType::Dirichlet ||
+                 a_crse_fine_bc_type == LinOpBCType::Neumann);
 
 #ifdef AMREX_USE_OMP
 #pragma omp parallel
@@ -72,7 +78,8 @@ MLMGBndryT<MF>::setLOBndryConds (const Vector<Array<LinOpBCType,AMREX_SPACEDIM> 
             BCTuple bct;
             setBoxBC(bloc, bct, grd, domain, lo[icomp], hi[icomp], dx, ratio, a_loc,
                      {{AMREX_D_DECL(Real(0.),Real(0.),Real(0.))}},
-                     {{AMREX_D_DECL(Real(0.),Real(0.),Real(0.))}}, is_periodic);
+                     {{AMREX_D_DECL(Real(0.),Real(0.),Real(0.))}},
+                     is_periodic, a_crse_fine_bc_type);
             for (int idim = 0; idim < 2*AMREX_SPACEDIM; ++idim) {
                 bctag[idim][icomp] = bct[idim];
             }
@@ -90,7 +97,8 @@ MLMGBndryT<MF>::setBoxBC (RealTuple& bloc, BCTuple& bctag,
                           const RealVect& interior_bloc,
                           const Array<Real,AMREX_SPACEDIM>& domain_bloc_lo,
                           const Array<Real,AMREX_SPACEDIM>& domain_bloc_hi,
-                          const GpuArray<int,AMREX_SPACEDIM>& is_periodic)
+                          const GpuArray<int,AMREX_SPACEDIM>& is_periodic,
+                          LinOpBCType a_crse_fine_bc_type)
 {
     using T = typename MF::value_type;
 
@@ -118,13 +126,13 @@ MLMGBndryT<MF>::setBoxBC (RealTuple& bloc, BCTuple& bctag,
         else
         {
             // Internal bndry.
-            bctag[face] = AMREX_LO_DIRICHLET;
+            bctag[face] = static_cast<int>(a_crse_fine_bc_type);
             bloc[face]  = static_cast<T>(ratio > 0 ? Real(0.5)*static_cast<Real>(ratio)*dx[dir]
                                                    : interior_bloc[dir]);
-            // If this is next to another same level box, bloc is
-            // wrong.  But it doesn't matter, because we also have
-            // mask.  It is used only if mask says it is next to
-            // coarse cells.
+            // If this is next to another same level box, BC type is wrong
+            // and bloc is wrong.  But it doesn't matter, because we also
+            // have mask.  It is used only if mask says it is next to coarse
+            // cells.
         }
     }
 }

--- a/Src/LinearSolvers/MLMG/AMReX_MLMGBndry.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLMGBndry.H
@@ -30,11 +30,16 @@ public:
                           int ratio, const RealVect& a_loc,
                           LinOpBCType a_crse_fine_bc_type = LinOpBCType::Dirichlet);
 
+    void setLOBndryConds (const Vector<Array<LinOpBCType,AMREX_SPACEDIM> >& lo,
+                          const Vector<Array<LinOpBCType,AMREX_SPACEDIM> >& hi,
+                          IntVect const& ratio, const RealVect& a_loc,
+                          LinOpBCType a_crse_fine_bc_type = LinOpBCType::Dirichlet);
+
     static void setBoxBC (RealTuple& bloc, BCTuple& bctag, const Box& bx,
                           const Box& domain,
                           const Array<LinOpBCType,AMREX_SPACEDIM>& lo,
                           const Array<LinOpBCType,AMREX_SPACEDIM>& hi,
-                          const Real* dx, int ratio,
+                          const Real* dx, IntVect const& ratio,
                           const RealVect& interior_bloc,
                           const Array<Real,AMREX_SPACEDIM>& domain_bloc_lo,
                           const Array<Real,AMREX_SPACEDIM>& domain_bloc_hi,
@@ -53,6 +58,16 @@ void
 MLMGBndryT<MF>::setLOBndryConds (const Vector<Array<LinOpBCType,AMREX_SPACEDIM> >& lo,
                                  const Vector<Array<LinOpBCType,AMREX_SPACEDIM> >& hi,
                                  int ratio, const RealVect& a_loc,
+                                 LinOpBCType a_crse_fine_bc_type)
+{
+    setLOBndryConds(lo, hi, IntVect(ratio), a_loc, a_crse_fine_bc_type);
+}
+
+template <typename MF>
+void
+MLMGBndryT<MF>::setLOBndryConds (const Vector<Array<LinOpBCType,AMREX_SPACEDIM> >& lo,
+                                 const Vector<Array<LinOpBCType,AMREX_SPACEDIM> >& hi,
+                                 IntVect const& ratio, const RealVect& a_loc,
                                  LinOpBCType a_crse_fine_bc_type)
 {
     const BoxArray& ba     = this->boxes();
@@ -93,7 +108,7 @@ MLMGBndryT<MF>::setBoxBC (RealTuple& bloc, BCTuple& bctag,
                           const Box& bx, const Box& domain,
                           const Array<LinOpBCType,AMREX_SPACEDIM>& lo,
                           const Array<LinOpBCType,AMREX_SPACEDIM>& hi,
-                          const Real* dx, int ratio,
+                          const Real* dx, IntVect const& ratio,
                           const RealVect& interior_bloc,
                           const Array<Real,AMREX_SPACEDIM>& domain_bloc_lo,
                           const Array<Real,AMREX_SPACEDIM>& domain_bloc_hi,
@@ -127,7 +142,7 @@ MLMGBndryT<MF>::setBoxBC (RealTuple& bloc, BCTuple& bctag,
         {
             // Internal bndry.
             bctag[face] = static_cast<int>(a_crse_fine_bc_type);
-            bloc[face]  = static_cast<T>(ratio > 0 ? Real(0.5)*static_cast<Real>(ratio)*dx[dir]
+            bloc[face]  = static_cast<T>(ratio[dir] > 0 ? Real(0.5)*static_cast<Real>(ratio[dir])*dx[dir]
                                                    : interior_bloc[dir]);
             // If this is next to another same level box, BC type is wrong
             // and bloc is wrong.  But it doesn't matter, because we also

--- a/Src/LinearSolvers/MLMG/AMReX_MLPoisson.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLPoisson.H
@@ -928,8 +928,9 @@ MLPoissonT<MF>::makeNLinOp (int grid_size) const
     if (this->needsCoarseDataForBC())
     {
         const Real* dx0 = this->m_geom[0][0].CellSize();
-        const Real fac = Real(0.5)*this->m_coarse_data_crse_ratio;
-        RealVect cbloc {AMREX_D_DECL(dx0[0]*fac, dx0[1]*fac, dx0[2]*fac)};
+        RealVect fac(this->m_coarse_data_crse_ratio);
+        fac *= Real(0.5);
+        RealVect cbloc {AMREX_D_DECL(dx0[0]*fac[0], dx0[1]*fac[1], dx0[2]*fac[2])};
         nop->setCoarseFineBCLocation(cbloc);
     }
 

--- a/Src/LinearSolvers/MLMG/AMReX_MLPoisson.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLPoisson.H
@@ -158,6 +158,23 @@ MLPoissonT<MF>::prepareForSolve ()
             }
         }
     }
+    if (!m_is_singular[0] && this->m_needs_coarse_data_for_bc &&
+        this->m_coarse_fine_bc_type == LinOpBCType::Neumann)
+    {
+        AMREX_ASSERT(this->m_overset_mask[0][0] == nullptr);
+        auto bbox = this->m_grids[0][0].minimalBox();
+        for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+            if (this->m_lobc[0][idim] == LinOpBCType::Dirichlet) {
+                bbox.growLo(idim,1);
+            }
+            if (this->m_hibc[0][idim] == LinOpBCType::Dirichlet) {
+                bbox.growHi(idim,1);
+            }
+        }
+        if (this->m_geom[0][0].Domain().contains(bbox)) {
+            m_is_singular[0] = true;
+        }
+    }
 }
 
 template <typename MF>

--- a/Tests/LinearSolvers/ABecLaplacian_C/MyTest.cpp
+++ b/Tests/LinearSolvers/ABecLaplacian_C/MyTest.cpp
@@ -105,7 +105,7 @@ MyTest::solvePoisson ()
                                                 LinOpBCType::Dirichlet)});
 
             if (ilev > 0) {
-                mlpoisson.setCoarseFineBC(&solution[ilev-1], ref_ratio, LinOpBCType::Neumann);
+                mlpoisson.setCoarseFineBC(&solution[ilev-1], ref_ratio);
             }
 
             mlpoisson.setLevelBC(0, &solution[ilev]);

--- a/Tests/LinearSolvers/ABecLaplacian_C/MyTest.cpp
+++ b/Tests/LinearSolvers/ABecLaplacian_C/MyTest.cpp
@@ -105,7 +105,7 @@ MyTest::solvePoisson ()
                                                 LinOpBCType::Dirichlet)});
 
             if (ilev > 0) {
-                mlpoisson.setCoarseFineBC(&solution[ilev-1], ref_ratio);
+                mlpoisson.setCoarseFineBC(&solution[ilev-1], ref_ratio, LinOpBCType::Neumann);
             }
 
             mlpoisson.setLevelBC(0, &solution[ilev]);


### PR DESCRIPTION
For cell-centered linear solvers, if the lowest AMR level in the solver is not AMR level 0, the coarse/fine interface was previously assumed to be Dirichlet. In this commit, this has been relaxed to allow for homogeneous Neumann BC at the coarse/fine interface.

