### PR TITLE
Fix FillPatcher after enforcing PhysBCFunct operator() fills nghost

### DIFF
--- a/Src/AmrCore/AMReX_FillPatcher.H
+++ b/Src/AmrCore/AMReX_FillPatcher.H
@@ -593,7 +593,7 @@ void FillPatcher<MF>::fillRK (int stage, int iteration, int ncycle,
     }
     Gpu::streamSynchronize();
 
-    cbc(*m_cf_crse_data_tmp, 0, m_ncomp, m_nghost, time, 0);
+    cbc(*m_cf_crse_data_tmp, 0, m_ncomp, m_cf_crse_data_tmp->nGrowVect(), time, 0);
 
     if (m_cf_fine_data == nullptr) {
         m_cf_fine_data = std::make_unique<MF>(detail::make_mf_fine_patch<MF>(fpc, m_ncomp));

--- a/Src/AmrCore/AMReX_FillPatcher.H
+++ b/Src/AmrCore/AMReX_FillPatcher.H
@@ -390,7 +390,7 @@ FillPatcher<MF>::fillCoarseFineBoundary (MF& mf, IntVect const& nghost, Real tim
         }
         Gpu::streamSynchronize();
 
-        cbc(*m_cf_crse_data_tmp, 0, ncomp, nghost, time, cbccomp);
+        cbc(*m_cf_crse_data_tmp, 0, ncomp, m_cf_crse_data_tmp->nGrowVect(), time, cbccomp);
 
         detail::call_interp_hook(pre_interp, *m_cf_crse_data_tmp, 0, ncomp);
 

--- a/Src/Base/AMReX_PhysBCFunct.H
+++ b/Src/Base/AMReX_PhysBCFunct.H
@@ -153,7 +153,7 @@ public:
 
         BL_PROFILE("PhysBCFunct::()");
 
-        AMREX_ASSERT(nghost <= mf.nGrowVect());
+        AMREX_ASSERT(nghost.allLE(mf.nGrowVect()));
 
         //! create a grown domain box containing valid + periodic cells
         const Box& domain = m_geom.Domain();

--- a/Src/Base/AMReX_PhysBCFunct.H
+++ b/Src/Base/AMReX_PhysBCFunct.H
@@ -153,6 +153,8 @@ public:
 
         BL_PROFILE("PhysBCFunct::()");
 
+        AMREX_ASSERT(nghost <= mf.nGrowVect());
+
         //! create a grown domain box containing valid + periodic cells
         const Box& domain = m_geom.Domain();
         Box gdomain = amrex::convert(domain, mf.boxArray().ixType());


### PR DESCRIPTION
grow cells (PR 3914)

Also assert in operator that mf has nghost grow cells to fill.

## Summary

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
