### PR TITLE
Fix particle restart when finestLevel() < finest_level_in_file

### DIFF
--- a/Src/Particle/AMReX_ParticleIO.H
+++ b/Src/Particle/AMReX_ParticleIO.H
@@ -921,7 +921,7 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
     }
 
     if (dual_grid) {
-        for (int lev = 0; lev <= finest_level_in_file; lev++) {
+        for (int lev = 0; lev <= finestLevel(); lev++) {
             SetParticleBoxArray(lev, old_bas[lev]);
             SetParticleDistributionMap(lev, old_dms[lev]);
         }

--- a/Src/Particle/AMReX_ParticleIO.H
+++ b/Src/Particle/AMReX_ParticleIO.H
@@ -775,7 +775,7 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
 
     if (have_pheaders)
     {
-        for (int lev = 0; lev <= finest_level_in_file; lev++)
+        for (int lev = 0; lev <= finestLevel(); lev++)
         {
             old_dms[lev] = ParticleDistributionMap(lev);
             old_bas[lev] = ParticleBoxArray(lev);
@@ -790,12 +790,6 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
             ParallelDescriptor::ReadAndBcastFile(phdr_name, phdr_chars);
             std::string phdr_string(phdr_chars.dataPtr());
             std::istringstream phdr_file(phdr_string, std::istringstream::in);
-
-            if (lev > finestLevel())
-            {
-                dual_grid = true;
-                break;
-            }
 
             particle_box_arrays[lev].readFrom(phdr_file);
             if (! particle_box_arrays[lev].CellEqual(ParticleBoxArray(lev))) { dual_grid = true; }


### PR DESCRIPTION
## Summary
In the restart for particles, there is a loop up to `lev = finest_level_in_file` but is accessing `ParticleDistributionMap(lev)`. In the case when `finestLevel() < finest_level_in_file`, this was causing an assertion error (with DEBUG) and a seg fault (without DEBUG). This fixes the loop to only go up to `finestLevel()`. This fixes the issue and still works properly (all of the particles are read in). This also removes the `if` block that would no longer ever be called.

## Additional background
Curiously, previously it would work with `finestLevel() < finest_level_in_file`, but none of this code had changed recently. I don't know how it worked before.

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
