### PR TITLE
add DEBUG_LIBSTDCXX option to GNU Make gcc for libstdc++ debug

### DIFF
--- a/Tools/GNUMake/comps/gnu.mak
+++ b/Tools/GNUMake/comps/gnu.mak
@@ -104,7 +104,7 @@ else
 endif
 
 ifeq ($(DEBUG_LIBSTDCXX),TRUE)
-   CXXFLAGS += -D_GLIBCXX_DEBUG
+   CPPFLAGS += -D_GLIBCXX_DEBUG
 endif
 
 ifeq ($(WARN_ALL),TRUE)

--- a/Tools/GNUMake/comps/gnu.mak
+++ b/Tools/GNUMake/comps/gnu.mak
@@ -103,6 +103,10 @@ else
   endif
 endif
 
+ifeq ($(DEBUG_LIBSTDCXX),TRUE)
+   CXXFLAGS += -D_GLIBCXX_DEBUG
+endif
+
 ifeq ($(WARN_ALL),TRUE)
   warning_flags = -Wall -Wextra -Wlogical-op -Wfloat-conversion -Wnull-dereference -Wmisleading-indentation -Wduplicated-cond -Wduplicated-branches -Wmissing-include-dirs
 


### PR DESCRIPTION
this catches bounds errors in the standard library containers

## Summary

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
