### PR TITLE
Particle InitBinaryFromFile: Use reference instead of copy

### DIFF
--- a/Src/Particle/AMReX_ParticleInit.H
+++ b/Src/Particle/AMReX_ParticleInit.H
@@ -873,7 +873,7 @@ InitFromBinaryFile (const std::string& file,
             auto& pmap     = m_particles[lev];
             auto& tmp_pmap = tmp_particles[lev];
 
-            for (auto kv : pmap) {
+            for (auto& kv : pmap) {
                 auto& aos = kv.second.GetArrayOfStructs()();
                 auto& tmp_aos = tmp_pmap[kv.first].GetArrayOfStructs()();
 


### PR DESCRIPTION
This has better performance and the change is now necessary because of #3943.
