### PR TITLE
Skip empty particle tiles in operator++ to avoid race condition in constructor.

### DIFF
--- a/.github/workflows/apps.yml
+++ b/.github/workflows/apps.yml
@@ -70,7 +70,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         repository: 'ECP-WarpX/WarpX'
-        ref: ${{env.WARPX_TAG}}
+        ref: 'development'
         path: 'WarpX'
     - name: Dependencies
       run: |

--- a/.github/workflows/apps.yml
+++ b/.github/workflows/apps.yml
@@ -70,7 +70,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         repository: 'ECP-WarpX/WarpX'
-        ref: 'development'
+        ref: ${{env.WARPX_TAG}}
         path: 'WarpX'
     - name: Dependencies
       run: |

--- a/Src/Particle/AMReX_ParIter.H
+++ b/Src/Particle/AMReX_ParIter.H
@@ -73,7 +73,7 @@ public:
                 auto f = particles.find(key);
                 if (f != particles.end() && f->second.numParticles() > 0) {
                     m_particle_current_tile = &(f->second);
-                    break; // break if isValid() and non-empty particl tile found
+                    break; // break if isValid() and non-empty particle tile found
                 }
             } else {
                 break; // break if isValid() returns false

--- a/Src/Particle/AMReX_ParIter.H
+++ b/Src/Particle/AMReX_ParIter.H
@@ -62,39 +62,26 @@ public:
 
     ParIterBase_impl (ContainerRef pc, int level, MFItInfo& info);
 
-#ifdef AMREX_USE_OMP
     void operator++ ()
     {
-        bool has_particles = false;
-        while (isValid() && !has_particles) {
-            if (dynamic) {
-#pragma omp atomic capture
-                m_pariter_index = nextDynamicIndex++;
+        m_particle_current_tile = nullptr;
+        auto& particles = m_pc->GetParticles(m_level);
+        while (true) {
+            MFIter::operator++();
+            if (isValid()) {
+                auto key = std::make_pair(index(), LocalTileIndex());
+                auto f = particles.find(key);
+                if (f != particles.end() && f->second.numParticles() > 0) {
+                    m_particle_current_tile = &(f->second);
+                    break; // break if isValid() and non-empty particl tile found
+                }
             } else {
-                ++m_pariter_index;
+                break; // break if isValid() returns false
             }
-            if (m_pariter_index >= m_particle_tiles.size()) { break; }
-            has_particles = m_particle_tiles[m_pariter_index]->numParticles() > 0;
         }
-        currentIndex = m_valid_index[m_pariter_index];
     }
-#else
-    void operator++ ()
-    {
-        bool has_particles = false;
-        while (isValid() && !has_particles) {
-            ++m_pariter_index;
-            if (m_pariter_index >= m_particle_tiles.size()) { break; }
-            has_particles = m_particle_tiles[m_pariter_index]->numParticles() > 0;
-        }
-        currentIndex = m_valid_index[m_pariter_index];
-#ifdef AMREX_USE_GPU
-        Gpu::Device::setStreamIndex(currentIndex);
-#endif
-    }
-#endif
 
-    [[nodiscard]] ParticleTileRef GetParticleTile () const { return *m_particle_tiles[m_pariter_index]; }
+    [[nodiscard]] ParticleTileRef GetParticleTile () const { return *m_particle_current_tile; }
 
     [[nodiscard]] AoSRef GetArrayOfStructs () const { return GetParticleTile().GetArrayOfStructs(); }
 
@@ -115,9 +102,7 @@ public:
 protected:
 
     int m_level;
-    int m_pariter_index;
-    Vector<int> m_valid_index;
-    Vector<ParticleTilePtr> m_particle_tiles;
+    ParticleTilePtr m_particle_current_tile = nullptr;
     ContainerPtr m_pc;
 };
 
@@ -182,47 +167,20 @@ ParIterBase_impl<is_const, ParticleType, NArrayReal, NArrayInt, Allocator, CellA
     :
       MFIter(*pc.m_dummy_mf[level], pc.do_tiling ? info.EnableTiling(pc.tile_size) : info),
       m_level(level),
-      m_pariter_index(0),
       m_pc(&pc)
 {
-    auto& particles = pc.GetParticles(level);
-
-    int start = dynamic ? 0 : beginIndex;
-    for (int i = start; i < endIndex; ++i)
-    {
-        int grid = (*index_map)[i];
-        int tile = local_tile_index_map ? (*local_tile_index_map)[i] : 0;
-        auto key = std::make_pair(grid,tile);
-        auto f = particles.find(key);
-        if (f != particles.end())
-        {
-            m_valid_index.push_back(i);
-            m_particle_tiles.push_back(&(f->second));
-        }
-    }
-
-    if (m_valid_index.empty())
-    {
-        endIndex = beginIndex;
-    }
-    else
-    {
-        currentIndex = beginIndex = m_valid_index.front();
-        if (dynamic) {
-#ifdef AMREX_USE_OMP
-            int ind = omp_get_thread_num();
-            m_pariter_index += ind;
-            if (ind < m_valid_index.size()) {
-                currentIndex = beginIndex = m_valid_index[ind];
-            } else {
-                currentIndex = endIndex;
+    if (isValid()) {
+        auto& particles = m_pc->GetParticles(m_level);
+        while (true) {
+            auto key = std::make_pair(index(), LocalTileIndex());
+            auto f = particles.find(key);
+            if (f != particles.end() && f->second.numParticles() > 0) {
+                m_particle_current_tile = &(f->second);
+                break; // break if isValid() and non-empty particle tile found
             }
-            for (int i = 0; i < omp_get_num_threads(); ++i) {
-                m_valid_index.push_back(endIndex);
-            }
-#endif
+            MFIter::operator++();
+            if (!isValid()) { break; } // break if isValid() returns false
         }
-        m_valid_index.push_back(endIndex);
     }
 }
 
@@ -234,32 +192,20 @@ ParIterBase_impl<is_const, T_ParticleType, NArrayReal, NArrayInt, Allocator, Cel
     MFIter(*pc.m_dummy_mf[level],
            pc.do_tiling ? pc.tile_size : IntVect::TheZeroVector()),
     m_level(level),
-    m_pariter_index(0),
     m_pc(&pc)
 {
-    auto& particles = pc.GetParticles(level);
-
-    for (int i = beginIndex; i < endIndex; ++i)
-    {
-        int grid = (*index_map)[i];
-        int tile = local_tile_index_map ? (*local_tile_index_map)[i] : 0;
-        auto key = std::make_pair(grid,tile);
-        auto f = particles.find(key);
-        if (f != particles.end())
-        {
-            m_valid_index.push_back(i);
-            m_particle_tiles.push_back(&(f->second));
+    if (isValid()) {
+        auto& particles = m_pc->GetParticles(m_level);
+        while (true) {
+            auto key = std::make_pair(index(), LocalTileIndex());
+            auto f = particles.find(key);
+            if (f != particles.end() && f->second.numParticles() > 0) {
+                m_particle_current_tile = &(f->second);
+                break;
+            }
+            MFIter::operator++();
+            if (!isValid()) { break; }
         }
-    }
-
-    if (m_valid_index.empty())
-    {
-        endIndex = beginIndex;
-    }
-    else
-    {
-        currentIndex = beginIndex = m_valid_index.front();
-        m_valid_index.push_back(endIndex);
     }
 }
 

--- a/Src/Particle/AMReX_ParIter.H
+++ b/Src/Particle/AMReX_ParIter.H
@@ -65,18 +65,28 @@ public:
 #ifdef AMREX_USE_OMP
     void operator++ ()
     {
-        if (dynamic) {
+        bool has_particles = false;
+        while (isValid() && !has_particles) {
+            if (dynamic) {
 #pragma omp atomic capture
-            m_pariter_index = nextDynamicIndex++;
-        } else {
-            ++m_pariter_index;
+                m_pariter_index = nextDynamicIndex++;
+            } else {
+                ++m_pariter_index;
+            }
+            if (m_pariter_index >= m_particle_tiles.size()) { break; }
+            has_particles = m_particle_tiles[m_pariter_index]->numParticles() > 0;
         }
         currentIndex = m_valid_index[m_pariter_index];
     }
 #else
     void operator++ ()
     {
-        ++m_pariter_index;
+        bool has_particles = false;
+        while (isValid() && !has_particles) {
+            ++m_pariter_index;
+            if (m_pariter_index >= m_particle_tiles.size()) { break; }
+            has_particles = m_particle_tiles[m_pariter_index]->numParticles() > 0;
+        }
         currentIndex = m_valid_index[m_pariter_index];
 #ifdef AMREX_USE_GPU
         Gpu::Device::setStreamIndex(currentIndex);
@@ -184,7 +194,7 @@ ParIterBase_impl<is_const, ParticleType, NArrayReal, NArrayInt, Allocator, CellA
         int tile = local_tile_index_map ? (*local_tile_index_map)[i] : 0;
         auto key = std::make_pair(grid,tile);
         auto f = particles.find(key);
-        if (f != particles.end() && f->second.numParticles() > 0)
+        if (f != particles.end())
         {
             m_valid_index.push_back(i);
             m_particle_tiles.push_back(&(f->second));
@@ -235,7 +245,7 @@ ParIterBase_impl<is_const, T_ParticleType, NArrayReal, NArrayInt, Allocator, Cel
         int tile = local_tile_index_map ? (*local_tile_index_map)[i] : 0;
         auto key = std::make_pair(grid,tile);
         auto f = particles.find(key);
-        if (f != particles.end() && f->second.numParticles() > 0)
+        if (f != particles.end())
         {
             m_valid_index.push_back(i);
             m_particle_tiles.push_back(&(f->second));

--- a/Src/Particle/AMReX_ParticleContainerI.H
+++ b/Src/Particle/AMReX_ParticleContainerI.H
@@ -1803,7 +1803,7 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
             // we need to create any missing map entries in serial here
             for (pmap_it=tmp_local[lev].begin(); pmap_it != tmp_local[lev].end(); pmap_it++)
             {
-                m_particles[lev][pmap_it->first];
+                DefineAndReturnParticleTile(lev, pmap_it->first.first, pmap_it->first.second);
                 grid_tile_ids.push_back(pmap_it->first);
                 pvec_ptrs.push_back(&(pmap_it->second));
             }
@@ -1812,9 +1812,9 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
 #pragma omp parallel for
 #endif
             for (int pit = 0; pit < static_cast<int>(pvec_ptrs.size()); ++pit)
-            { // xxxxx is this thread safe?
+            {
                 auto index = grid_tile_ids[pit];
-                auto& ptile = DefineAndReturnParticleTile(lev, index.first, index.second);
+                auto& ptile = ParticlesAt(lev, index.first, index.second);
                 auto& aos = ptile.GetArrayOfStructs();
                 auto& soa = ptile.GetStructOfArrays();
                 auto& aos_tmp = *(pvec_ptrs[pit]);
@@ -1842,7 +1842,7 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
             // we need to create any missing map entries in serial here
             for (auto soa_map_it=soa_local[lev].begin(); soa_map_it != soa_local[lev].end(); soa_map_it++)
             {
-                m_particles[lev][soa_map_it->first];
+                DefineAndReturnParticleTile(lev, soa_map_it->first.first, soa_map_it->first.second);
                 grid_tile_ids.push_back(soa_map_it->first);
             }
 
@@ -1850,9 +1850,9 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
 #pragma omp parallel for
 #endif
             for (int pit = 0; pit < static_cast<int>(grid_tile_ids.size()); ++pit) // NOLINT(modernize-loop-convert)
-            { // xxxxx Is this thread safe?
+            {
                 auto index = grid_tile_ids[pit];
-                auto& ptile = DefineAndReturnParticleTile(lev, index.first, index.second);
+                auto& ptile = ParticlesAt(lev, index.first, index.second);
                 auto& soa = ptile.GetStructOfArrays();
                 auto& soa_tmp = soa_local[lev][index];
                 for (int i = 0; i < num_threads; ++i) {

--- a/Src/Particle/AMReX_ParticleContainerI.H
+++ b/Src/Particle/AMReX_ParticleContainerI.H
@@ -1812,7 +1812,7 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
 #pragma omp parallel for
 #endif
             for (int pit = 0; pit < static_cast<int>(pvec_ptrs.size()); ++pit)
-            {
+            { // xxxxx is this thread safe?
                 auto index = grid_tile_ids[pit];
                 auto& ptile = DefineAndReturnParticleTile(lev, index.first, index.second);
                 auto& aos = ptile.GetArrayOfStructs();
@@ -1850,7 +1850,7 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
 #pragma omp parallel for
 #endif
             for (int pit = 0; pit < static_cast<int>(grid_tile_ids.size()); ++pit) // NOLINT(modernize-loop-convert)
-            {
+            { // xxxxx Is this thread safe?
                 auto index = grid_tile_ids[pit];
                 auto& ptile = DefineAndReturnParticleTile(lev, index.first, index.second);
                 auto& soa = ptile.GetStructOfArrays();


### PR DESCRIPTION
The race condition was found by @lucafedeli88 using an automated tool.

## Summary

## Additional background

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
