### PR TITLE
FabArray: Make some functions static

### DIFF
--- a/Src/Base/AMReX_FabArray.H
+++ b/Src/Base/AMReX_FabArray.H
@@ -1343,42 +1343,44 @@ public:
 
     //! Prepost nonblocking receives
     template <typename BUF=value_type>
-    void PostRcvs (const MapOfCopyComTagContainers&       RcvTags,
+    static void PostRcvs (const MapOfCopyComTagContainers&       RcvTags,
                    char*&                                 the_recv_data,
                    Vector<char*>&                         recv_data,
                    Vector<std::size_t>&                   recv_size,
                    Vector<int>&                           recv_from,
                    Vector<MPI_Request>&                   recv_reqs,
                    int                                    ncomp,
-                   int                                    SeqNum) const;
+                   int                                    SeqNum);
 
     template <typename BUF=value_type>
-    AMREX_NODISCARD TheFaArenaPointer PostRcvs (const MapOfCopyComTagContainers&       RcvTags,
+    AMREX_NODISCARD
+    static TheFaArenaPointer PostRcvs (const MapOfCopyComTagContainers&       RcvTags,
                    Vector<char*>&                         recv_data,
                    Vector<std::size_t>&                   recv_size,
                    Vector<int>&                           recv_from,
                    Vector<MPI_Request>&                   recv_reqs,
                    int                                    ncomp,
-                   int                                    SeqNum) const;
+                   int                                    SeqNum);
 
     template <typename BUF=value_type>
-    void PrepareSendBuffers (const MapOfCopyComTagContainers&     SndTags,
+    static void PrepareSendBuffers (const MapOfCopyComTagContainers&     SndTags,
                              char*&                               the_send_data,
                              Vector<char*>&                       send_data,
                              Vector<std::size_t>&                 send_size,
                              Vector<int>&                         send_rank,
                              Vector<MPI_Request>&                 send_reqs,
                              Vector<const CopyComTagsContainer*>& send_cctc,
-                             int                                  ncomp) const;
+                             int                                  ncomp);
 
     template <typename BUF=value_type>
-    AMREX_NODISCARD TheFaArenaPointer PrepareSendBuffers (const MapOfCopyComTagContainers&     SndTags,
+    AMREX_NODISCARD
+    static TheFaArenaPointer PrepareSendBuffers (const MapOfCopyComTagContainers&     SndTags,
                              Vector<char*>&                       send_data,
                              Vector<std::size_t>&                 send_size,
                              Vector<int>&                         send_rank,
                              Vector<MPI_Request>&                 send_reqs,
                              Vector<const CopyComTagsContainer*>& send_cctc,
-                             int                                  ncomp) const;
+                             int                                  ncomp);
 
     static void PostSnds (Vector<char*> const&       send_data,
                           Vector<std::size_t> const& send_size,

--- a/Src/Base/AMReX_FabArrayCommI.H
+++ b/Src/Base/AMReX_FabArrayCommI.H
@@ -622,7 +622,7 @@ FabArray<FAB>::PrepareSendBuffers (const MapOfCopyComTagContainers&     SndTags,
                                    Vector<int>&                         send_rank,
                                    Vector<MPI_Request>&                 send_reqs,
                                    Vector<const CopyComTagsContainer*>& send_cctc,
-                                   int                                  ncomp) const
+                                   int                                  ncomp)
 {
     char* pointer = nullptr;
     PrepareSendBuffers<BUF>(SndTags, pointer, send_data, send_size, send_rank, send_reqs, send_cctc, ncomp);
@@ -639,7 +639,7 @@ FabArray<FAB>::PrepareSendBuffers (const MapOfCopyComTagContainers&     SndTags,
                                    Vector<int>&                         send_rank,
                                    Vector<MPI_Request>&                 send_reqs,
                                    Vector<const CopyComTagsContainer*>& send_cctc,
-                                   int                                  ncomp) const
+                                   int                                  ncomp)
 {
     send_data.clear();
     send_size.clear();
@@ -723,7 +723,7 @@ TheFaArenaPointer FabArray<FAB>::PostRcvs (const MapOfCopyComTagContainers&     
                    Vector<int>&                           recv_from,
                    Vector<MPI_Request>&                   recv_reqs,
                    int                                    ncomp,
-                   int                                    SeqNum) const
+                   int                                    SeqNum)
 {
     char* pointer = nullptr;
     PostRcvs(RcvTags, pointer, recv_data, recv_size, recv_from, recv_reqs, ncomp, SeqNum);
@@ -740,7 +740,7 @@ FabArray<FAB>::PostRcvs (const MapOfCopyComTagContainers&  RcvTags,
                          Vector<int>&                      recv_from,
                          Vector<MPI_Request>&              recv_reqs,
                          int                               ncomp,
-                         int                               SeqNum) const
+                         int                               SeqNum)
 {
     recv_data.clear();
     recv_size.clear();

--- a/Src/Base/AMReX_NonLocalBCImpl.H
+++ b/Src/Base/AMReX_NonLocalBCImpl.H
@@ -439,13 +439,13 @@ Comm_nowait (FabArray<FAB>& mf, int scomp, int ncomp, FabArrayBase::CommMetaData
     handler.mpi_tag = SeqNum;
 
     if (N_rcvs > 0) {
-        handler.recv.the_data = mf.PostRcvs(*cmd.m_RcvTags, handler.recv.data, handler.recv.size,
+        handler.recv.the_data = FabArray<FAB>::PostRcvs(*cmd.m_RcvTags, handler.recv.data, handler.recv.size,
                                             handler.recv.rank, handler.recv.request, ncomp, SeqNum);
     }
 
     if (N_snds > 0) {
         handler.send.the_data =
-            mf.PrepareSendBuffers(*cmd.m_SndTags, handler.send.data, handler.send.size,
+            FabArray<FAB>::PrepareSendBuffers(*cmd.m_SndTags, handler.send.data, handler.send.size,
                                   handler.send.rank, handler.send.request, handler.send.cctc, ncomp);
 
 #ifdef AMREX_USE_GPU


### PR DESCRIPTION
These communication help functions can now be used outside FabArray.
