### PR TITLE
adding physical and math BC types for inflow-outflow BCs

### DIFF
--- a/Src/Base/AMReX_BC_TYPES.H
+++ b/Src/Base/AMReX_BC_TYPES.H
@@ -60,23 +60,24 @@ namespace amrex {
 
 namespace PhysBCType {
 enum physicalBndryTypes : int {interior=0,inflow,outflow,symmetry,
-                               slipwall,noslipwall};
+                               slipwall,noslipwall,inflowoutflow};
 }
 
 namespace BCType {
 enum mathematicalBndryTypes : int {
-    bogus        = -666,
-    reflect_odd  = -1,
-    int_dir      =  0,
-    reflect_even =  1,
-    foextrap     =  2,
-    ext_dir      =  3,
-    hoextrap     =  4,
-    hoextrapcc   =  5,
-    ext_dir_cc   =  6,
-    user_1       = 1001,
-    user_2       = 1002,
-    user_3       = 1003
+    bogus               = -666,
+    reflect_odd         = -1,
+    int_dir             =  0,
+    reflect_even        =  1,
+    foextrap            =  2,
+    ext_dir             =  3,
+    hoextrap            =  4,
+    hoextrapcc          =  5,
+    ext_dir_cc          =  6,
+    direction_dependent = 7,
+    user_1              = 1001,
+    user_2              = 1002,
+    user_3              = 1003
 };
 }
 

--- a/Src/Base/AMReX_BC_TYPES.H
+++ b/Src/Base/AMReX_BC_TYPES.H
@@ -74,7 +74,7 @@ enum mathematicalBndryTypes : int {
     hoextrap            =  4,
     hoextrapcc          =  5,
     ext_dir_cc          =  6,
-    direction_dependent = 7,
+    direction_dependent =  7,
     user_1              = 1001,
     user_2              = 1002,
     user_3              = 1003


### PR DESCRIPTION
## Summary
This feature would be useful for managing boundaries with both inflow and outflow cells. By adding these types in AMReX, they can be used consistently across various inter-dependent codes such as IAMR, AMReX-Hydro, and AMR-Wind.

## Additional background
The ongoing addition of an inflow-outflow BC in AMR-Wind is the primary motivation.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
