### PR TITLE
New FillPatch function: FillPatchNLevels

### DIFF
--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -125,7 +125,7 @@ jobs:
         set +e
         source /opt/intel/oneapi/setvars.sh --include-intel-llvm
         set -e
-        # Test is disabled due to a compiler issue with some math functions.
+        # WATCH: Test is disabled due to a compiler issue with some math functions.
         # The fix did not make it to the next oneAPI release. So we will
         # enable it again after the next next oneAPI release.
         cmake -S . -B build                                \

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -121,7 +121,7 @@ jobs:
 
         cmake --build build --config Release --target install
 
-        set "PATH=%PATH%;D:\\a\amrex\amrex\installdir\bin"
+        # set "PATH=%PATH%;D:\\a\amrex\amrex\installdir\bin"
         # WATCH: cmake --build build --config Release --target test_install
 
   # If we add ccache back, don't forget to update cleanup-cache.yml

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -121,8 +121,8 @@ jobs:
 
         cmake --build build --config Release --target install
 
-        # set "PATH=%PATH%;D:\\a\amrex\amrex\installdir\bin"
-        # WATCH: cmake --build build --config Release --target test_install
+  #     set "PATH=%PATH%;D:\\a\amrex\amrex\installdir\bin"
+  #     WATCH: cmake --build build --config Release --target test_install
 
   # If we add ccache back, don't forget to update cleanup-cache.yml
   #save_pr_number:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -91,13 +91,13 @@ jobs:
         cmake --build build --config RelWithDebInfo -j 4
 
         cmake --build build --config RelWithDebInfo --target install
-        cmake --build build --config RelWithDebInfo --target test_install
+        # WATCH: cmake --build build --config RelWithDebInfo --target test_install
 
         #ccache -s
 
   # Build libamrex and all tests
   tests_clang:
-    name: Clang C++17 w/o Fortran w/o MPI
+    name: MSVC Clang C++17 w/o Fortran w/o MPI
     runs-on: windows-latest
     steps:
     - uses: actions/checkout@v4
@@ -122,7 +122,7 @@ jobs:
         cmake --build build --config Release --target install
 
         set "PATH=%PATH%;D:\\a\amrex\amrex\installdir\bin"
-        cmake --build build --config Release --target test_install
+        # WATCH: cmake --build build --config Release --target test_install
 
   # If we add ccache back, don't forget to update cleanup-cache.yml
   #save_pr_number:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -81,8 +81,13 @@ jobs:
         #$Env:CCACHE_MAXSIZE='135M'
         #ccache -z
 
+        # -DCMAKE_CXX_FLAGS=" /D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR" `
+        # is a workaround github windows runner 20240603.1.0.
+        # https://github.com/actions/runner-images/issues/10004
+
         cmake -S . -B build   `
               -DCMAKE_VERBOSE_MAKEFILE=ON   `
+              -DCMAKE_CXX_FLAGS=" /D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR" `
               -DAMReX_EB=ON                 `
               -DAMReX_ENABLE_TESTS=ON       `
               -DAMReX_FORTRAN=OFF           `
@@ -91,7 +96,7 @@ jobs:
         cmake --build build --config RelWithDebInfo -j 4
 
         cmake --build build --config RelWithDebInfo --target install
-        # WATCH: cmake --build build --config RelWithDebInfo --target test_install
+        cmake --build build --config RelWithDebInfo --target test_install
 
         #ccache -s
 
@@ -108,10 +113,15 @@ jobs:
         CMAKE_GENERATOR_TOOLSET: "ClangCl"
         CMAKE_GENERATOR: "Visual Studio 17 2022"
       run: |
+        # -DCMAKE_CXX_FLAGS=" /D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR" `
+        # is a workaround github windows runner 20240603.1.0.
+        # https://github.com/actions/runner-images/issues/10004
+
         call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\vc\Auxiliary\build\vcvarsall.bat" x64
         cmake -S . -B build   ^
               -DBUILD_SHARED_LIBS=ON        ^
               -DCMAKE_VERBOSE_MAKEFILE=ON   ^
+              -DCMAKE_CXX_FLAGS=" /D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR" ^
               -DAMReX_EB=ON                 ^
               -DAMReX_ENABLE_TESTS=ON       ^
               -DAMReX_FORTRAN=OFF           ^
@@ -121,8 +131,8 @@ jobs:
 
         cmake --build build --config Release --target install
 
-  #     set "PATH=%PATH%;D:\\a\amrex\amrex\installdir\bin"
-  #     WATCH: cmake --build build --config Release --target test_install
+        set "PATH=%PATH%;D:\\a\amrex\amrex\installdir\bin"
+        cmake --build build --config Release --target test_install
 
   # If we add ccache back, don't forget to update cleanup-cache.yml
   #save_pr_number:

--- a/Src/AmrCore/AMReX_FillPatchUtil.H
+++ b/Src/AmrCore/AMReX_FillPatchUtil.H
@@ -41,10 +41,46 @@ namespace amrex
         void operator() (MFFAB& /*mf*/, int /*icomp*/, int /*ncomp*/) const {}
     };
 
+    /**
+     * \brief Test if AMR grids are properly nested.
+     *
+     * If grids are not properly nested, FillPatch functions may fail.
+     *
+     * \tparam Interp Interpolater type
+     *
+     * \param ratio refinement ratio
+     * \param blocking_factor blocking factor on the fine level
+     * \param ngrow number of ghost cells of fine MultiFab
+     * \param boxType index type
+     * \param mapper an interpolater object
+     */
     template <typename Interp>
     bool ProperlyNested (const IntVect& ratio, const IntVect& blocking_factor, int ngrow,
                          const IndexType& boxType, Interp* mapper);
 
+    /**
+     * \brief FillPatch with data from the current level
+     *
+     * The destination MultiFab/FabArray is on the same AMR level as the
+     * source MultiFab/FabArray. Usually this can only be used on AMR level
+     * 0, because filling fine level MF usually requires coarse level
+     * data. If needed, interpolation in time is performed.
+     *
+     * \tparam MF the MultiFab/FabArray type
+     * \tparam BC functor for filling physical boundaries
+     *
+     * \param mf destination MF
+     * \param nghost number of ghost cells of mf needed to be filled
+     * \param time time associated with mf
+     * \param smf source MFs
+     * \param stime times associated smf
+     * \param scomp starting component of the source MFs
+     * \param dcomp starting component of the destination MF
+     * \param ncomp number of components
+     * \param geom Geometry for this level
+     * \param physbcf functor for physical boundaries
+     * \param bcfcomp starting component for physbcf
+     */
     template <typename MF, typename BC>
     std::enable_if_t<IsFabArray<MF>::value>
     FillPatchSingleLevel (MF& mf, IntVect const& nghost, Real time,
@@ -53,6 +89,29 @@ namespace amrex
                           const Geometry& geom,
                           BC& physbcf, int bcfcomp);
 
+    /**
+     * \brief FillPatch with data from the current level
+     *
+     * The destination MultiFab/FabArray is on the same AMR level as the
+     * source MultiFab/FabArray. Usually this can only be used on AMR level
+     * 0, because filling fine level MF usually requires coarse level
+     * data. If needed, interpolation in time is performed. Ghost cells of
+     * the destination MF are not filled.
+     *
+     * \tparam MF the MultiFab/FabArray type
+     * \tparam BC functor for filling physical boundaries
+     *
+     * \param mf destination MF
+     * \param time time associated with mf
+     * \param smf source MFs
+     * \param stime times associated smf
+     * \param scomp starting component of the source MFs
+     * \param dcomp starting component of the destination MF
+     * \param ncomp number of components
+     * \param geom Geometry for this level
+     * \param physbcf functor for physical boundaries
+     * \param bcfcomp starting component for physbcf
+     */
     template <typename MF, typename BC>
     std::enable_if_t<IsFabArray<MF>::value>
     FillPatchSingleLevel (MF& mf, Real time,
@@ -61,6 +120,44 @@ namespace amrex
                           const Geometry& geom,
                           BC& physbcf, int bcfcomp);
 
+    /**
+     * \brief FillPatch with data from the current level and the level below.
+     *
+     * First, we fill the destination MultiFab/FabArray with the current
+     * level data as much as possible. This may include interpolation in
+     * time. For the rest of the destination MF, we fill them with the
+     * coarse level data using interpolation in space (and in time if
+     * needed).
+     *
+     * \tparam MF the MultiFab/FabArray type
+     * \tparam BC functor for filling physical boundaries
+     * \tparam Interp spatial interpolater
+     * \tparam PreInterpHook pre-interpolation hook
+     * \tparam PostInterpHook post-interpolation hook
+     *
+     * \param mf destination MF on the fine level
+     * \param nghost number of ghost cells of mf needed to be filled
+     * \param time time associated with mf
+     * \param cmf source MFs on the coarse level
+     * \param ct times associated cmf
+     * \param fmf source MFs on the fine level
+     * \param ft times associated fmf
+     * \param scomp starting component of the source MFs
+     * \param dcomp starting component of the destination MF
+     * \param ncomp number of components
+     * \param cgeom Geometry for the coarse level
+     * \param fgeom Geometry for the fine level
+     * \param cbc functor for physical boundaries on the coarse level
+     * \param cbccomp starting component for cbc
+     * \param fbc functor for physical boundaries on the fine level
+     * \param fbccomp starting component for fbc
+     * \param ratio refinement ratio
+     * \param mapper spatial interpolater
+     * \param bcs boundary types for each component. We need this because some interpolaters need it.
+     * \param bcscomp starting component for bcs
+     * \param pre_interp pre-interpolation hook
+     * \param post_interp post-interpolation hook
+     */
     template <typename MF, typename BC, typename Interp,
               typename PreInterpHook=NullInterpHook<typename MF::FABType::value_type>,
               typename PostInterpHook=NullInterpHook<typename MF::FABType::value_type> >
@@ -78,6 +175,43 @@ namespace amrex
                         const PreInterpHook& pre_interp = {},
                         const PostInterpHook& post_interp = {});
 
+    /**
+     * \brief FillPatch with data from the current level and the level below.
+     *
+     * First, we fill the destination MultiFab/FabArray with the current
+     * level data as much as possible. This may include interpolation in
+     * time. For the rest of the destination MF, we fill them with the
+     * coarse level data using interpolation in space (and in time if
+     * needed). Ghost cells of the destination MF are not filled.
+     *
+     * \tparam MF the MultiFab/FabArray type
+     * \tparam BC functor for filling physical boundaries
+     * \tparam Interp spatial interpolater
+     * \tparam PreInterpHook pre-interpolation hook
+     * \tparam PostInterpHook post-interpolation hook
+     *
+     * \param mf destination MF on the fine level
+     * \param time time associated with mf
+     * \param cmf source MFs on the coarse level
+     * \param ct times associated cmf
+     * \param fmf source MFs on the fine level
+     * \param ft times associated fmf
+     * \param scomp starting component of the source MFs
+     * \param dcomp starting component of the destination MF
+     * \param ncomp number of components
+     * \param cgeom Geometry for the coarse level
+     * \param fgeom Geometry for the fine level
+     * \param cbc functor for physical boundaries on the coarse level
+     * \param cbccomp starting component for cbc
+     * \param fbc functor for physical boundaries on the fine level
+     * \param fbccomp starting component for fbc
+     * \param ratio refinement ratio
+     * \param mapper spatial interpolater
+     * \param bcs boundary types for each component. We need this because some interpolaters need it.
+     * \param bcscomp starting component for bcs
+     * \param pre_interp pre-interpolation hook
+     * \param post_interp post-interpolation hook
+     */
     template <typename MF, typename BC, typename Interp,
               typename PreInterpHook=NullInterpHook<typename MF::FABType::value_type>,
               typename PostInterpHook=NullInterpHook<typename MF::FABType::value_type> >
@@ -95,6 +229,47 @@ namespace amrex
                         const PreInterpHook& pre_interp = {},
                         const PostInterpHook& post_interp = {});
 
+    /**
+     * \brief FillPatch for face variables with data from the current level
+     * and the level below. Sometimes, we need to fillpatch all
+     * AMREX_SPACEDIM face MultiFabs togother to satisfy certain contraint
+     * such as divergence preserving.
+     *
+     * First, we fill the destination MultiFab/FabArray's with the current
+     * level data as much as possible. This may include interpolation in
+     * time. For the rest of the destination MFs, we fill them with the
+     * coarse level data using interpolation in space (and in time if
+     * needed).
+     *
+     * \tparam MF the MultiFab/FabArray type
+     * \tparam BC functor for filling physical boundaries
+     * \tparam Interp spatial interpolater
+     * \tparam PreInterpHook pre-interpolation hook
+     * \tparam PostInterpHook post-interpolation hook
+     *
+     * \param mf destination MFs on the fine level
+     * \param nghost number of ghost cells of mf needed to be filled
+     * \param time time associated with mf
+     * \param cmf source MFs on the coarse level
+     * \param ct times associated cmf
+     * \param fmf source MFs on the fine level
+     * \param ft times associated fmf
+     * \param scomp starting component of the source MFs
+     * \param dcomp starting component of the destination MFs
+     * \param ncomp number of components
+     * \param cgeom Geometry for the coarse level
+     * \param fgeom Geometry for the fine level
+     * \param cbc functor for physical boundaries on the coarse level
+     * \param cbccomp starting component for cbc
+     * \param fbc functor for physical boundaries on the fine level
+     * \param fbccomp starting component for fbc
+     * \param ratio refinement ratio
+     * \param mapper spatial interpolater
+     * \param bcs boundary types for each component. We need this because some interpolaters need it.
+     * \param bcscomp starting component for bcs
+     * \param pre_interp pre-interpolation hook
+     * \param post_interp post-interpolation hook
+     */
     template <typename MF, typename BC, typename Interp,
               typename PreInterpHook=NullInterpHook<typename MF::FABType::value_type>,
               typename PostInterpHook=NullInterpHook<typename MF::FABType::value_type> >
@@ -112,6 +287,47 @@ namespace amrex
                         const PreInterpHook& pre_interp = {},
                         const PostInterpHook& post_interp = {});
 
+    /**
+     * \brief FillPatch for face variables with data from the current level
+     * and the level below. Sometimes, we need to fillpatch all
+     * AMREX_SPACEDIM face MultiFabs togother to satisfy certain contraint
+     * such as divergence preserving.
+     *
+     * First, we fill the destination MultiFab/FabArray's with the current
+     * level data as much as possible. This may include interpolation in
+     * time. For the rest of the destination MFs, we fill them with the
+     * coarse level data using interpolation in space (and in time if
+     * needed).
+     *
+     * \tparam MF the MultiFab/FabArray type
+     * \tparam BC functor for filling physical boundaries
+     * \tparam Interp spatial interpolater
+     * \tparam PreInterpHook pre-interpolation hook
+     * \tparam PostInterpHook post-interpolation hook
+     *
+     * \param mf destination MFs on the fine level
+     * \param nghost number of ghost cells of mf needed to be filled
+     * \param time time associated with mf
+     * \param cmf source MFs on the coarse level
+     * \param ct times associated cmf
+     * \param fmf source MFs on the fine level
+     * \param ft times associated fmf
+     * \param scomp starting component of the source MFs
+     * \param dcomp starting component of the destination MFs
+     * \param ncomp number of components
+     * \param cgeom Geometry for the coarse level
+     * \param fgeom Geometry for the fine level
+     * \param cbc functor for physical boundaries on the coarse level
+     * \param cbccomp starting component for cbc
+     * \param fbc functor for physical boundaries on the fine level
+     * \param fbccomp starting component for fbc
+     * \param ratio refinement ratio
+     * \param mapper spatial interpolater
+     * \param bcs boundary types for each component. We need this because some interpolaters need it.
+     * \param bcscomp starting component for bcs
+     * \param pre_interp pre-interpolation hook
+     * \param post_interp post-interpolation hook
+     */
     template <typename MF, typename BC, typename Interp,
               typename PreInterpHook=NullInterpHook<typename MF::FABType::value_type>,
               typename PostInterpHook=NullInterpHook<typename MF::FABType::value_type> >
@@ -129,6 +345,46 @@ namespace amrex
                         const PreInterpHook& pre_interp = {},
                         const PostInterpHook& post_interp = {});
 
+    /**
+     * \brief FillPatch for face variables with data from the current level
+     * and the level below. Sometimes, we need to fillpatch all
+     * AMREX_SPACEDIM face MultiFabs togother to satisfy certain contraint
+     * such as divergence preserving.
+     *
+     * First, we fill the destination MultiFab/FabArray's with the current
+     * level data as much as possible. This may include interpolation in
+     * time. For the rest of the destination MFs, we fill them with the
+     * coarse level data using interpolation in space (and in time if
+     * needed). Ghost cells of the destination MFs are not filled.
+     *
+     * \tparam MF the MultiFab/FabArray type
+     * \tparam BC functor for filling physical boundaries
+     * \tparam Interp spatial interpolater
+     * \tparam PreInterpHook pre-interpolation hook
+     * \tparam PostInterpHook post-interpolation hook
+     *
+     * \param mf destination MFs on the fine level
+     * \param time time associated with mf
+     * \param cmf source MFs on the coarse level
+     * \param ct times associated cmf
+     * \param fmf source MFs on the fine level
+     * \param ft times associated fmf
+     * \param scomp starting component of the source MFs
+     * \param dcomp starting component of the destination MFs
+     * \param ncomp number of components
+     * \param cgeom Geometry for the coarse level
+     * \param fgeom Geometry for the fine level
+     * \param cbc functor for physical boundaries on the coarse level
+     * \param cbccomp starting component for cbc
+     * \param fbc functor for physical boundaries on the fine level
+     * \param fbccomp starting component for fbc
+     * \param ratio refinement ratio
+     * \param mapper spatial interpolater
+     * \param bcs boundary types for each component. We need this because some interpolaters need it.
+     * \param bcscomp starting component for bcs
+     * \param pre_interp pre-interpolation hook
+     * \param post_interp post-interpolation hook
+     */
     template <typename MF, typename BC, typename Interp,
               typename PreInterpHook=NullInterpHook<typename MF::FABType::value_type>,
               typename PostInterpHook=NullInterpHook<typename MF::FABType::value_type> >
@@ -147,6 +403,45 @@ namespace amrex
                         const PostInterpHook& post_interp = {});
 
 #ifdef AMREX_USE_EB
+    /**
+     * \brief FillPatch with data from the current level and the level below.
+     *
+     * First, we fill the destination MultiFab/FabArray with the current
+     * level data as much as possible. This may include interpolation in
+     * time. For the rest of the destination MF, we fill them with the
+     * coarse level data using interpolation in space (and in time if
+     * needed).
+     *
+     * \tparam MF the MultiFab/FabArray type
+     * \tparam BC functor for filling physical boundaries
+     * \tparam Interp spatial interpolater
+     * \tparam PreInterpHook pre-interpolation hook
+     * \tparam PostInterpHook post-interpolation hook
+     *
+     * \param mf destination MF on the fine level
+     * \param nghost number of ghost cells of mf needed to be filled
+     * \param time time associated with mf
+     * \param index_space EB IndexSpace
+     * \param cmf source MFs on the coarse level
+     * \param ct times associated cmf
+     * \param fmf source MFs on the fine level
+     * \param ft times associated fmf
+     * \param scomp starting component of the source MFs
+     * \param dcomp starting component of the destination MF
+     * \param ncomp number of components
+     * \param cgeom Geometry for the coarse level
+     * \param fgeom Geometry for the fine level
+     * \param cbc functor for physical boundaries on the coarse level
+     * \param cbccomp starting component for cbc
+     * \param fbc functor for physical boundaries on the fine level
+     * \param fbccomp starting component for fbc
+     * \param ratio refinement ratio
+     * \param mapper spatial interpolater
+     * \param bcs boundary types for each component. We need this because some interpolaters need it.
+     * \param bcscomp starting component for bcs
+     * \param pre_interp pre-interpolation hook
+     * \param post_interp post-interpolation hook
+     */
     template <typename MF, typename BC, typename Interp, typename PreInterpHook, typename PostInterpHook>
     std::enable_if_t<IsFabArray<MF>::value>
     FillPatchTwoLevels (MF& mf, IntVect const& nghost, Real time,
@@ -163,6 +458,44 @@ namespace amrex
                         const PreInterpHook& pre_interp,
                         const PostInterpHook& post_interp);
 
+    /**
+     * \brief FillPatch with data from the current level and the level below.
+     *
+     * First, we fill the destination MultiFab/FabArray with the current
+     * level data as much as possible. This may include interpolation in
+     * time. For the rest of the destination MF, we fill them with the
+     * coarse level data using interpolation in space (and in time if
+     * needed). Ghost cells of the destination MF are not filled.
+     *
+     * \tparam MF the MultiFab/FabArray type
+     * \tparam BC functor for filling physical boundaries
+     * \tparam Interp spatial interpolater
+     * \tparam PreInterpHook pre-interpolation hook
+     * \tparam PostInterpHook post-interpolation hook
+     *
+     * \param mf destination MF on the fine level
+     * \param time time associated with mf
+     * \param index_space EB IndexSpace
+     * \param cmf source MFs on the coarse level
+     * \param ct times associated cmf
+     * \param fmf source MFs on the fine level
+     * \param ft times associated fmf
+     * \param scomp starting component of the source MFs
+     * \param dcomp starting component of the destination MF
+     * \param ncomp number of components
+     * \param cgeom Geometry for the coarse level
+     * \param fgeom Geometry for the fine level
+     * \param cbc functor for physical boundaries on the coarse level
+     * \param cbccomp starting component for cbc
+     * \param fbc functor for physical boundaries on the fine level
+     * \param fbccomp starting component for fbc
+     * \param ratio refinement ratio
+     * \param mapper spatial interpolater
+     * \param bcs boundary types for each component. We need this because some interpolaters need it.
+     * \param bcscomp starting component for bcs
+     * \param pre_interp pre-interpolation hook
+     * \param post_interp post-interpolation hook
+     */
     template <typename MF, typename BC, typename Interp, typename PreInterpHook, typename PostInterpHook>
     std::enable_if_t<IsFabArray<MF>::value>
     FillPatchTwoLevels (MF& mf, Real time,
@@ -180,6 +513,36 @@ namespace amrex
                         const PostInterpHook& post_interp);
 #endif
 
+    /**
+     * \brief Fill with interpolation of coarse level data
+     *
+     * No ghost cells of the destination MF are filled.
+     *
+     * \tparam MF the MultiFab/FabArray type
+     * \tparam BC functor for filling physical boundaries
+     * \tparam Interp spatial interpolater
+     * \tparam PreInterpHook pre-interpolation hook
+     * \tparam PostInterpHook post-interpolation hook
+     *
+     * \param mf destination MF on the fine level
+     * \param time time associated with mf
+     * \param cmf source MF on the coarse level
+     * \param scomp starting component of the source MF
+     * \param dcomp starting component of the destination MF
+     * \param ncomp number of components
+     * \param cgeom Geometry for the coarse level
+     * \param fgeom Geometry for the fine level
+     * \param cbc functor for physical boundaries on the coarse level
+     * \param cbccomp starting component for cbc
+     * \param fbc functor for physical boundaries on the fine level
+     * \param fbccomp starting component for fbc
+     * \param ratio refinement ratio
+     * \param mapper spatial interpolater
+     * \param bcs boundary types for each component. We need this because some interpolaters need it.
+     * \param bcscomp starting component for bcs
+     * \param pre_interp pre-interpolation hook
+     * \param post_interp post-interpolation hook
+     */
     template <typename MF, typename BC, typename Interp,
               typename PreInterpHook=NullInterpHook<typename MF::FABType::value_type>,
               typename PostInterpHook=NullInterpHook<typename MF::FABType::value_type> >
@@ -195,6 +558,35 @@ namespace amrex
                            const PreInterpHook& pre_interp = {},
                            const PostInterpHook& post_interp = {});
 
+    /**
+     * \brief Fill with interpolation of coarse level data
+     *
+     * \tparam MF the MultiFab/FabArray type
+     * \tparam BC functor for filling physical boundaries
+     * \tparam Interp spatial interpolater
+     * \tparam PreInterpHook pre-interpolation hook
+     * \tparam PostInterpHook post-interpolation hook
+     *
+     * \param mf destination MF on the fine level
+     * \param nghost number of ghost cells of mf needed to be filled
+     * \param time time associated with mf
+     * \param cmf source MF on the coarse level
+     * \param scomp starting component of the source MF
+     * \param dcomp starting component of the destination MF
+     * \param ncomp number of components
+     * \param cgeom Geometry for the coarse level
+     * \param fgeom Geometry for the fine level
+     * \param cbc functor for physical boundaries on the coarse level
+     * \param cbccomp starting component for cbc
+     * \param fbc functor for physical boundaries on the fine level
+     * \param fbccomp starting component for fbc
+     * \param ratio refinement ratio
+     * \param mapper spatial interpolater
+     * \param bcs boundary types for each component. We need this because some interpolaters need it.
+     * \param bcscomp starting component for bcs
+     * \param pre_interp pre-interpolation hook
+     * \param post_interp post-interpolation hook
+     */
     template <typename MF, typename BC, typename Interp,
               typename PreInterpHook=NullInterpHook<typename MF::FABType::value_type>,
               typename PostInterpHook=NullInterpHook<typename MF::FABType::value_type> >
@@ -210,6 +602,36 @@ namespace amrex
                            const PreInterpHook& pre_interp = {},
                            const PostInterpHook& post_interp = {});
 
+    /**
+     * \brief Fill face variables with data from the coarse level.
+     * Sometimes, we need to fillpatch all AMREX_SPACEDIM face MultiFabs
+     * togother to satisfy certain contraint such as divergence preserving.
+     *
+     * \tparam MF the MultiFab/FabArray type
+     * \tparam BC functor for filling physical boundaries
+     * \tparam Interp spatial interpolater
+     * \tparam PreInterpHook pre-interpolation hook
+     * \tparam PostInterpHook post-interpolation hook
+     *
+     * \param mf destination MFs on the fine level
+     * \param time time associated with mf
+     * \param cmf source MFs on the coarse level
+     * \param scomp starting component of the source MFs
+     * \param dcomp starting component of the destination MFs
+     * \param ncomp number of components
+     * \param cgeom Geometry for the coarse level
+     * \param fgeom Geometry for the fine level
+     * \param cbc functor for physical boundaries on the coarse level
+     * \param cbccomp starting component for cbc
+     * \param fbc functor for physical boundaries on the fine level
+     * \param fbccomp starting component for fbc
+     * \param ratio refinement ratio
+     * \param mapper spatial interpolater
+     * \param bcs boundary types for each component. We need this because some interpolaters need it.
+     * \param bcscomp starting component for bcs
+     * \param pre_interp pre-interpolation hook
+     * \param post_interp post-interpolation hook
+     */
     template <typename MF, typename BC, typename Interp,
               typename PreInterpHook=NullInterpHook<typename MF::FABType::value_type>,
               typename PostInterpHook=NullInterpHook<typename MF::FABType::value_type> >
@@ -225,6 +647,37 @@ namespace amrex
                            const PreInterpHook& pre_interp = {},
                            const PostInterpHook& post_interp = {});
 
+    /**
+     * \brief Fill face variables with data from the coarse level.
+     * Sometimes, we need to fillpatch all AMREX_SPACEDIM face MultiFabs
+     * togother to satisfy certain contraint such as divergence preserving.
+     *
+     * \tparam MF the MultiFab/FabArray type
+     * \tparam BC functor for filling physical boundaries
+     * \tparam Interp spatial interpolater
+     * \tparam PreInterpHook pre-interpolation hook
+     * \tparam PostInterpHook post-interpolation hook
+     *
+     * \param mf destination MFs on the fine level
+     * \param nghost number of ghost cells of mf needed to be filled
+     * \param time time associated with mf
+     * \param cmf source MFs on the coarse level
+     * \param scomp starting component of the source MFs
+     * \param dcomp starting component of the destination MFs
+     * \param ncomp number of components
+     * \param cgeom Geometry for the coarse level
+     * \param fgeom Geometry for the fine level
+     * \param cbc functor for physical boundaries on the coarse level
+     * \param cbccomp starting component for cbc
+     * \param fbc functor for physical boundaries on the fine level
+     * \param fbccomp starting component for fbc
+     * \param ratio refinement ratio
+     * \param mapper spatial interpolater
+     * \param bcs boundary types for each component. We need this because some interpolaters need it.
+     * \param bcscomp starting component for bcs
+     * \param pre_interp pre-interpolation hook
+     * \param post_interp post-interpolation hook
+     */
     template <typename MF, typename BC, typename Interp,
               typename PreInterpHook=NullInterpHook<typename MF::FABType::value_type>,
               typename PostInterpHook=NullInterpHook<typename MF::FABType::value_type> >
@@ -256,6 +709,43 @@ namespace amrex
                                      int ref_ratio);
 #endif
 
+    /**
+     * \brief FillPatch with data from AMR levels.
+     *
+     * First, we try to fill the destination MultiFab/FabArray with this
+     * level's data if it's available. For the unfilled region, we try to
+     * fill with the level below if it's available. This process goes on
+     * till all regions are filled. This function is more expensive than
+     * FillPatchTwoLevels. So if one knows FillPatchTwoLevels can do the job
+     * because grids are properly nested, this function should be avoided.
+     *
+     * \tparam MF the MultiFab/FabArray type
+     * \tparam BC functor for filling physical boundaries
+     * \tparam Interp spatial interpolater
+     *
+     * \param mf destination MF
+     * \param level AMR level associated with mf
+     * \param nghost number of ghost cells of mf needed to be filled
+     * \param time time associated with mf
+     * \param smf source MFs. The outer Vector is for AMR levels, whereas the inner
+     *            Vector is for data at various times. It is not an error if the
+     *            level for the destination MF is finer than data in smf (i.e.,
+     *            level >= smf.size()).
+     * \param st times associated smf
+     * \param scomp starting component of the source MFs
+     * \param dcomp starting component of the destination MF
+     * \param ncomp number of components
+     * \param geom Geometry objects for AMR levels. The size must be big enough
+     *             such that level < geom.size().
+     * \param bc functors for physical boundaries on AMR levels. The size must be
+     *           big enough such that level < bc.size().
+     * \param bccomp starting component for bc
+     * \param ratio refinement ratio for AMR levels. The size must be big enough
+     *              such that level < bc.size()-1.
+     * \param mapper spatial interpolater
+     * \param bcr boundary types for each component. We need this because some interpolaters need it.
+     * \param bcrcomp starting component for bcr
+     */
     template <typename MF, typename BC, typename Interp>
     std::enable_if_t<IsFabArray<MF>::value>
     FillPatchNLevels (MF& mf, int level, const IntVect& nghost, Real time,

--- a/Src/AmrCore/AMReX_FillPatchUtil.H
+++ b/Src/AmrCore/AMReX_FillPatchUtil.H
@@ -256,7 +256,6 @@ namespace amrex
                                      int ref_ratio);
 #endif
 
-#ifndef _WIN32
     template <typename MF, typename BC, typename Interp>
     std::enable_if_t<IsFabArray<MF>::value>
     FillPatchNLevels (MF& mf, int level, const IntVect& nghost, Real time,
@@ -267,7 +266,6 @@ namespace amrex
                       const Vector<IntVect>& ratio,
                       Interp* mapper,
                       const Vector<BCRec>& bcr, int bcrcomp);
-#endif
 
 }
 

--- a/Src/AmrCore/AMReX_FillPatchUtil.H
+++ b/Src/AmrCore/AMReX_FillPatchUtil.H
@@ -714,10 +714,11 @@ namespace amrex
      *
      * First, we try to fill the destination MultiFab/FabArray with this
      * level's data if it's available. For the unfilled region, we try to
-     * fill with the level below if it's available. This process goes on
-     * till all regions are filled. This function is more expensive than
-     * FillPatchTwoLevels. So if one knows FillPatchTwoLevels can do the job
-     * because grids are properly nested, this function should be avoided.
+     * fill with the coarse level below if it's available. Even coarser
+     * levels will be used if necessary till all regions are filled. This
+     * function is more expensive than FillPatchTwoLevels. So if one knows
+     * FillPatchTwoLevels can do the job because grids are properly nested,
+     * this function should be avoided.
      *
      * \tparam MF the MultiFab/FabArray type
      * \tparam BC functor for filling physical boundaries
@@ -730,18 +731,18 @@ namespace amrex
      * \param smf source MFs. The outer Vector is for AMR levels, whereas the inner
      *            Vector is for data at various times. It is not an error if the
      *            level for the destination MF is finer than data in smf (i.e.,
-     *            level >= smf.size()).
+     *            `level >= smf.size()`).
      * \param st times associated smf
      * \param scomp starting component of the source MFs
      * \param dcomp starting component of the destination MF
      * \param ncomp number of components
      * \param geom Geometry objects for AMR levels. The size must be big enough
-     *             such that level < geom.size().
+     *             such that `level < geom.size()`.
      * \param bc functors for physical boundaries on AMR levels. The size must be
-     *           big enough such that level < bc.size().
+     *           big enough such that `level < bc.size()`.
      * \param bccomp starting component for bc
      * \param ratio refinement ratio for AMR levels. The size must be big enough
-     *              such that level < bc.size()-1.
+     *              such that `level < bc.size()-1`.
      * \param mapper spatial interpolater
      * \param bcr boundary types for each component. We need this because some interpolaters need it.
      * \param bcrcomp starting component for bcr

--- a/Src/AmrCore/AMReX_FillPatchUtil.H
+++ b/Src/AmrCore/AMReX_FillPatchUtil.H
@@ -232,7 +232,7 @@ namespace amrex
     /**
      * \brief FillPatch for face variables with data from the current level
      * and the level below. Sometimes, we need to fillpatch all
-     * AMREX_SPACEDIM face MultiFabs togother to satisfy certain contraint
+     * AMREX_SPACEDIM face MultiFabs togother to satisfy certain constraint
      * such as divergence preserving.
      *
      * First, we fill the destination MultiFab/FabArray's with the current
@@ -290,7 +290,7 @@ namespace amrex
     /**
      * \brief FillPatch for face variables with data from the current level
      * and the level below. Sometimes, we need to fillpatch all
-     * AMREX_SPACEDIM face MultiFabs togother to satisfy certain contraint
+     * AMREX_SPACEDIM face MultiFabs togother to satisfy certain constraint
      * such as divergence preserving.
      *
      * First, we fill the destination MultiFab/FabArray's with the current
@@ -348,7 +348,7 @@ namespace amrex
     /**
      * \brief FillPatch for face variables with data from the current level
      * and the level below. Sometimes, we need to fillpatch all
-     * AMREX_SPACEDIM face MultiFabs togother to satisfy certain contraint
+     * AMREX_SPACEDIM face MultiFabs togother to satisfy certain constraint
      * such as divergence preserving.
      *
      * First, we fill the destination MultiFab/FabArray's with the current
@@ -605,7 +605,7 @@ namespace amrex
     /**
      * \brief Fill face variables with data from the coarse level.
      * Sometimes, we need to fillpatch all AMREX_SPACEDIM face MultiFabs
-     * togother to satisfy certain contraint such as divergence preserving.
+     * togother to satisfy certain constraint such as divergence preserving.
      *
      * \tparam MF the MultiFab/FabArray type
      * \tparam BC functor for filling physical boundaries
@@ -650,7 +650,7 @@ namespace amrex
     /**
      * \brief Fill face variables with data from the coarse level.
      * Sometimes, we need to fillpatch all AMREX_SPACEDIM face MultiFabs
-     * togother to satisfy certain contraint such as divergence preserving.
+     * togother to satisfy certain constraint such as divergence preserving.
      *
      * \tparam MF the MultiFab/FabArray type
      * \tparam BC functor for filling physical boundaries

--- a/Src/AmrCore/AMReX_FillPatchUtil.H
+++ b/Src/AmrCore/AMReX_FillPatchUtil.H
@@ -256,6 +256,7 @@ namespace amrex
                                      int ref_ratio);
 #endif
 
+#ifndef _WIN32
     template <typename MF, typename BC, typename Interp>
     std::enable_if_t<IsFabArray<MF>::value>
     FillPatchNLevels (MF& mf, int level, const IntVect& nghost, Real time,
@@ -266,6 +267,7 @@ namespace amrex
                       const Vector<IntVect>& ratio,
                       Interp* mapper,
                       const Vector<BCRec>& bcr, int bcrcomp);
+#endif
 
 }
 

--- a/Src/AmrCore/AMReX_FillPatchUtil.H
+++ b/Src/AmrCore/AMReX_FillPatchUtil.H
@@ -255,6 +255,18 @@ namespace amrex
                                      const Geometry& cgeom, const Geometry& fgeom,
                                      int ref_ratio);
 #endif
+
+    template <typename MF, typename BC, typename Interp>
+    std::enable_if_t<IsFabArray<MF>::value>
+    FillPatchNLevels (MF& mf, int level, const IntVect& nghost, Real time,
+                      const Vector<Vector<MF*>>& smf, const Vector<Vector<Real>>& st,
+                      int scomp, int dcomp, int ncomp,
+                      const Vector<Geometry>& geom,
+                      Vector<BC>& bc, int bccomp,
+                      const Vector<IntVect>& ratio,
+                      Interp* mapper,
+                      const Vector<BCRec>& bcr, int bcrcomp);
+
 }
 
 #include <AMReX_FillPatchUtil_I.H>

--- a/Src/AmrCore/AMReX_FillPatchUtil_I.H
+++ b/Src/AmrCore/AMReX_FillPatchUtil_I.H
@@ -438,8 +438,62 @@ namespace detail {
         // nothing
     }
 
+    inline BoxArray periodic_wrap_boxarray (BoxArray const& a_ba, Geometry const& geom)
+    {
+        if (geom.isAnyPeriodic()) {
+            BoxList bl(a_ba.ixType());
+            bool is_same = true;
+            Box domain = geom.growNonPeriodicDomain(2048); // 2048 should be big enough
+            domain.convert(a_ba.ixType());
+            for (int i = 0, N = int(a_ba.size()); i < N; ++i) {
+                Box const& b = a_ba[i];
+                if (domain.contains(b)) {
+                    bl.push_back(b);
+                } else {
+                    is_same = false;
+                    Box isect = b & domain;
+                    auto shift = [&geom] (Box obox)
+                    {
+                        for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+                            if (geom.isPeriodic(idim)) {
+                                int dlo = geom.Domain().smallEnd(idim);
+                                int dhi = geom.Domain().bigEnd(idim);
+                                int len = dhi-dlo+1;
+                                if (obox.type(idim) == IndexType::NODE) {
+                                    ++dhi;
+                                }
+                                if (obox.bigEnd(idim) < dlo) {
+                                    obox.shift(idim, len);
+                                } else if (obox.smallEnd(idim) > dhi) {
+                                    obox.shift(idim, -len);
+                                }
+                            }
+                        }
+                        return obox;
+                    };
+                    if (isect.isEmpty()) {
+                        bl.push_back(shift(b));
+                    } else {
+                        bl.push_back(isect);
+                        BoxList bltmp = amrex::boxDiff(b, isect);
+                        for (auto const& btmp : bltmp) {
+                            bl.push_back(shift(btmp));
+                        }
+                    }
+                }
+            }
+            if (is_same) {
+                return a_ba;
+            } else {
+                return BoxArray(std::move(bl));
+            }
+        } else {
+            return a_ba;
+        }
+    }
+
     template <typename MF, typename BC, typename Interp, typename PreInterpHook, typename PostInterpHook>
-    std::enable_if_t<IsFabArray<MF>::value>
+    std::enable_if_t<IsFabArray<MF>::value,int>
     FillPatchTwoLevels_doit (MF& mf, IntVect const& nghost, Real time,
                              const Vector<MF*>& cmf, const Vector<Real>& ct,
                              const Vector<MF*>& fmf, const Vector<Real>& ft,
@@ -452,9 +506,13 @@ namespace detail {
                              const Vector<BCRec>& bcs, int bcscomp,
                              const PreInterpHook& pre_interp,
                              const PostInterpHook& post_interp,
-                             EB2::IndexSpace const* index_space)
+                             EB2::IndexSpace const* index_space,
+                             bool return_error_code = false)
     {
         BL_PROFILE("FillPatchTwoLevels");
+
+        int success_code = return_error_code ? 0 : -1;
+        int failure_code = 1;
 
         if (nghost.max() > 0 || mf.getBDKey() != fmf[0]->getBDKey())
         {
@@ -484,6 +542,13 @@ namespace detail {
 
                 if ( ! fpc.ba_crse_patch.empty())
                 {
+                    if (return_error_code) {
+                        BoxArray const& cba = amrex::convert(cmf[0]->boxArray(), IntVect(0));
+                        if (!cba.contains(detail::periodic_wrap_boxarray(fpc.ba_crse_patch,cgeom))) {
+                            return failure_code;
+                        }
+                    }
+
                     MF mf_crse_patch     = make_mf_crse_patch<MF>      (fpc, ncomp, mf.boxArray().ixType());
                     // Must make sure fine exists under needed coarse faces.
                     // It stores values for the final (interior) interpolation,
@@ -544,6 +609,12 @@ namespace detail {
 
                 if ( ! fpc.ba_crse_patch.empty())
                 {
+                    if (return_error_code) {
+                        BoxArray const& cba = cmf[0]->boxArray();
+                        if (!cba.contains(detail::periodic_wrap_boxarray(fpc.ba_crse_patch,cgeom))) {
+                            return failure_code;
+                        }
+                    }
 
                     MF mf_crse_patch = make_mf_crse_patch<MF>(fpc, ncomp);
                     mf_set_domain_bndry (mf_crse_patch, cgeom);
@@ -568,6 +639,8 @@ namespace detail {
 
         FillPatchSingleLevel(mf, nghost, time, fmf, ft, scomp, dcomp, ncomp,
                              fgeom, fbc, fbccomp);
+
+        return success_code;
     }
 
     template <typename MF, typename BC, typename Interp, typename PreInterpHook, typename PostInterpHook>
@@ -1188,6 +1261,88 @@ InterpFromCoarseLevel (Array<MF*, AMREX_SPACEDIM> const& mf, IntVect const& ngho
         }
 
         fbc[d](*mf[d], dcomp, ncomp, nghost, time, fbccomp);
+    }
+}
+
+template <typename MF, typename BC, typename Interp>
+std::enable_if_t<IsFabArray<MF>::value>
+FillPatchNLevels (MF& mf, int level, const IntVect& nghost, Real time,
+                  const Vector<Vector<MF*>>& smf, const Vector<Vector<Real>>& st,
+                  int scomp, int dcomp, int ncomp,
+                  const Vector<Geometry>& geom,
+                  Vector<BC>& bc, int bccomp,
+                  const Vector<IntVect>& ratio,
+                  Interp* mapper,
+                  const Vector<BCRec>& bcr, int bcrcomp)
+{
+    AMREX_ALWAYS_ASSERT(level < int(geom.size()) &&
+                        level < int(bc.size()) &&
+                        level < int(ratio.size()+1));
+    if (level == 0) {
+        FillPatchSingleLevel(mf, nghost, time, smf[0], st[0], scomp, dcomp, ncomp, geom[0],
+                             bc[0], bccomp);
+    } else if (level >= int(smf.size())) {
+        BoxArray const& ba = mf.boxArray();
+        auto const& typ = ba.ixType();
+        Box domain_g = geom[level].growPeriodicDomain(nghost);
+        domain_g.convert(typ);
+        BoxArray cba;
+        {
+            BoxList cbl(typ);
+            cbl.reserve(ba.size());
+            for (int i = 0, N = int(ba.size()); i < N; ++i) {
+                cbl.push_back(mapper->CoarseBox(amrex::grow(ba[i],nghost), ratio[level-1]));
+            }
+            cba = BoxArray(std::move(cbl));
+        }
+        MultiFab cmf_tmp(cba, mf.DistributionMap(), ncomp, 0);
+        FillPatchNLevels(cmf_tmp, level-1, IntVect(0), time, smf, st, scomp, 0, ncomp,
+                         geom, bc, bccomp, ratio, mapper, bcr, bcrcomp);
+        FillPatchInterp(mf, dcomp, cmf_tmp, 0, ncomp, nghost, geom[level-1], geom[level],
+                        domain_g, ratio[level-1], mapper, bcr, bcrcomp);
+    } else {
+        NullInterpHook<typename MF::FABType::value_type> hook{};
+        int error_code = detail::FillPatchTwoLevels_doit(mf, nghost, time,
+                                                         smf[level-1], st[level-1],
+                                                         smf[level  ], st[level  ],
+                                                         scomp, dcomp, ncomp,
+                                                         geom[level-1], geom[level],
+                                                         bc[level-1], bccomp,
+                                                         bc[level  ], bccomp,
+                                                         ratio[level-1], mapper, bcr, bcrcomp,
+                                                         hook, hook, nullptr, true);
+        if (error_code == 0) { return; }
+
+        BoxArray cba;
+        {
+            BoxArray const& ba = mf.boxArray();
+            BoxList cbl(mf.ixType());
+            cbl.reserve(ba.size());
+            for (int i = 0; i < int(ba.size()); ++i) {
+                cbl.push_back(mapper->CoarseBox(amrex::grow(ba[i], nghost), ratio[level-1]));
+            }
+            cba = BoxArray(std::move(cbl));
+        }
+        MultiFab cmf_tmp(cba, mf.DistributionMap(), ncomp, 0);
+        FillPatchNLevels(cmf_tmp, level-1, IntVect(0), time, smf, st, scomp, 0, ncomp,
+                         geom, bc, bccomp, ratio, mapper, bcr, bcrcomp);
+        Vector<MF*> cmf{&cmf_tmp};
+        Vector<MF*> fmf = smf[level];
+        Vector<MF> fmf_raii;
+        if (scomp != 0) {
+            for (auto const* p : fmf) {
+                fmf_raii.emplace_back(*p,  amrex::make_alias, 0, ncomp);
+            }
+        }
+        detail::FillPatchTwoLevels_doit(mf, nghost, time,
+                                        cmf, {time},
+                                        fmf, st[level],
+                                        0, dcomp, ncomp,
+                                        geom[level-1], geom[level],
+                                        bc[level-1], bccomp,
+                                        bc[level  ], bccomp,
+                                        ratio[level-1], mapper, bcr, bccomp,
+                                        hook, hook, nullptr);
     }
 }
 

--- a/Src/AmrCore/AMReX_FillPatchUtil_I.H
+++ b/Src/AmrCore/AMReX_FillPatchUtil_I.H
@@ -438,7 +438,6 @@ namespace detail {
         // nothing
     }
 
-#ifndef _WIN32
     inline BoxArray periodic_wrap_boxarray (BoxArray const& a_ba, Geometry const& geom)
     {
         if (geom.isAnyPeriodic()) {
@@ -492,14 +491,9 @@ namespace detail {
             return a_ba;
         }
     }
-#endif
 
     template <typename MF, typename BC, typename Interp, typename PreInterpHook, typename PostInterpHook>
-#ifndef _WIN32
     std::enable_if_t<IsFabArray<MF>::value,int>
-#else
-    std::enable_if_t<IsFabArray<MF>::value>
-#endif
     FillPatchTwoLevels_doit (MF& mf, IntVect const& nghost, Real time,
                              const Vector<MF*>& cmf, const Vector<Real>& ct,
                              const Vector<MF*>& fmf, const Vector<Real>& ft,
@@ -512,18 +506,13 @@ namespace detail {
                              const Vector<BCRec>& bcs, int bcscomp,
                              const PreInterpHook& pre_interp,
                              const PostInterpHook& post_interp,
-                             EB2::IndexSpace const* index_space
-#ifndef _WIN32
-                             , bool return_error_code = false
-#endif
-                             )
+                             EB2::IndexSpace const* index_space,
+                             bool return_error_code = false)
     {
         BL_PROFILE("FillPatchTwoLevels");
 
-#ifndef _WIN32
         int success_code = return_error_code ? 0 : -1;
         int failure_code = 1;
-#endif
 
         if (nghost.max() > 0 || mf.getBDKey() != fmf[0]->getBDKey())
         {
@@ -553,14 +542,12 @@ namespace detail {
 
                 if ( ! fpc.ba_crse_patch.empty())
                 {
-#ifndef _WIN32
                     if (return_error_code) {
                         BoxArray const& cba = amrex::convert(cmf[0]->boxArray(), IntVect(0));
                         if (!cba.contains(detail::periodic_wrap_boxarray(fpc.ba_crse_patch,cgeom))) {
                             return failure_code;
                         }
                     }
-#endif
 
                     MF mf_crse_patch     = make_mf_crse_patch<MF>      (fpc, ncomp, mf.boxArray().ixType());
                     // Must make sure fine exists under needed coarse faces.
@@ -622,14 +609,12 @@ namespace detail {
 
                 if ( ! fpc.ba_crse_patch.empty())
                 {
-#ifndef _WIN32
                     if (return_error_code) {
                         BoxArray const& cba = cmf[0]->boxArray();
                         if (!cba.contains(detail::periodic_wrap_boxarray(fpc.ba_crse_patch,cgeom))) {
                             return failure_code;
                         }
                     }
-#endif
 
                     MF mf_crse_patch = make_mf_crse_patch<MF>(fpc, ncomp);
                     mf_set_domain_bndry (mf_crse_patch, cgeom);
@@ -655,9 +640,7 @@ namespace detail {
         FillPatchSingleLevel(mf, nghost, time, fmf, ft, scomp, dcomp, ncomp,
                              fgeom, fbc, fbccomp);
 
-#ifndef _WIN32
         return success_code;
-#endif
     }
 
     template <typename MF, typename BC, typename Interp, typename PreInterpHook, typename PostInterpHook>
@@ -1281,8 +1264,6 @@ InterpFromCoarseLevel (Array<MF*, AMREX_SPACEDIM> const& mf, IntVect const& ngho
     }
 }
 
-#ifndef _WIN32
-
 template <typename MF, typename BC, typename Interp>
 std::enable_if_t<IsFabArray<MF>::value>
 FillPatchNLevels (MF& mf, int level, const IntVect& nghost, Real time,
@@ -1394,8 +1375,6 @@ FillPatchNLevels (MF& mf, int level, const IntVect& nghost, Real time,
                                         hook, hook, index_space);
     }
 }
-
-#endif /*ifndef _WIN32 */
 
 }
 

--- a/Src/AmrCore/AMReX_FillPatchUtil_I.H
+++ b/Src/AmrCore/AMReX_FillPatchUtil_I.H
@@ -438,60 +438,6 @@ namespace detail {
         // nothing
     }
 
-    inline BoxArray periodic_wrap_boxarray (BoxArray const& a_ba, Geometry const& geom)
-    {
-        if (geom.isAnyPeriodic()) {
-            BoxList bl(a_ba.ixType());
-            bool is_same = true;
-            Box domain = geom.growNonPeriodicDomain(2048); // 2048 should be big enough
-            domain.convert(a_ba.ixType());
-            for (int i = 0, N = int(a_ba.size()); i < N; ++i) {
-                Box const& b = a_ba[i];
-                if (domain.contains(b)) {
-                    bl.push_back(b);
-                } else {
-                    is_same = false;
-                    auto shift = [&geom] (Box obox)
-                    {
-                        for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-                            if (geom.isPeriodic(idim)) {
-                                int dlo = geom.Domain().smallEnd(idim);
-                                int dhi = geom.Domain().bigEnd(idim);
-                                int len = dhi-dlo+1;
-                                if (obox.type(idim) == IndexType::NODE) {
-                                    ++dhi;
-                                }
-                                if (obox.bigEnd(idim) < dlo) {
-                                    obox.shift(idim, len);
-                                } else if (obox.smallEnd(idim) > dhi) {
-                                    obox.shift(idim, -len);
-                                }
-                            }
-                        }
-                        return obox;
-                    };
-                    Box const& isect = b & domain;
-                    if (isect.isEmpty()) {
-                        bl.push_back(shift(b));
-                    } else {
-                        bl.push_back(isect);
-                        BoxList const& bltmp = amrex::boxDiff(b, isect);
-                        for (auto const& btmp : bltmp) {
-                            bl.push_back(shift(btmp));
-                        }
-                    }
-                }
-            }
-            if (is_same) {
-                return a_ba;
-            } else {
-                return BoxArray(std::move(bl));
-            }
-        } else {
-            return a_ba;
-        }
-    }
-
     template <typename MF, typename BC, typename Interp, typename PreInterpHook, typename PostInterpHook>
     std::enable_if_t<IsFabArray<MF>::value,int>
     FillPatchTwoLevels_doit (MF& mf, IntVect const& nghost, Real time,
@@ -544,7 +490,7 @@ namespace detail {
                 {
                     if (return_error_code) {
                         BoxArray const& cba = amrex::convert(cmf[0]->boxArray(), IntVect(0));
-                        if (!cba.contains(detail::periodic_wrap_boxarray(fpc.ba_crse_patch,cgeom))) {
+                        if (!cba.contains(fpc.ba_crse_patch,cgeom.periodicity())) {
                             return failure_code;
                         }
                     }
@@ -611,7 +557,7 @@ namespace detail {
                 {
                     if (return_error_code) {
                         BoxArray const& cba = cmf[0]->boxArray();
-                        if (!cba.contains(detail::periodic_wrap_boxarray(fpc.ba_crse_patch,cgeom))) {
+                        if (!cba.contains(fpc.ba_crse_patch,cgeom.periodicity())) {
                             return failure_code;
                         }
                     }

--- a/Src/AmrCore/AMReX_FillPatchUtil_I.H
+++ b/Src/AmrCore/AMReX_FillPatchUtil_I.H
@@ -1294,6 +1294,14 @@ FillPatchNLevels (MF& mf, int level, const IntVect& nghost, Real time,
                   Interp* mapper,
                   const Vector<BCRec>& bcr, int bcrcomp)
 {
+    BL_PROFILE("FillPatchNLevels");
+
+#ifdef AMREX_USE_EB
+    EB2::IndexSpace const* index_space = EB2::TopIndexSpaceIfPresent();
+#else
+    EB2::IndexSpace const* index_space = nullptr;
+#endif
+
     AMREX_ALWAYS_ASSERT(level < int(geom.size()) &&
                         level < int(bc.size()) &&
                         level < int(ratio.size()+1));
@@ -1314,7 +1322,18 @@ FillPatchNLevels (MF& mf, int level, const IntVect& nghost, Real time,
             }
             cba = BoxArray(std::move(cbl));
         }
-        MultiFab cmf_tmp(cba, mf.DistributionMap(), ncomp, 0);
+        MultiFab cmf_tmp;
+#ifdef AMREX_USE_EB
+        if (index_space) {
+            auto factory = makeEBFabFactory(index_space, geom[level-1], cba,
+                                            mf.DistributionMap(), {0,0,0},
+                                            EBSupport::basic);
+            cmf_tmp.define(cba, mf.DistributionMap(), ncomp, 0, MFInfo(), *factory);
+        } else
+#endif
+        {
+            cmf_tmp.define(cba, mf.DistributionMap(), ncomp, 0);
+        }
         FillPatchNLevels(cmf_tmp, level-1, IntVect(0), time, smf, st, scomp, 0, ncomp,
                          geom, bc, bccomp, ratio, mapper, bcr, bcrcomp);
         FillPatchInterp(mf, dcomp, cmf_tmp, 0, ncomp, nghost, geom[level-1], geom[level],
@@ -1329,7 +1348,7 @@ FillPatchNLevels (MF& mf, int level, const IntVect& nghost, Real time,
                                                          bc[level-1], bccomp,
                                                          bc[level  ], bccomp,
                                                          ratio[level-1], mapper, bcr, bcrcomp,
-                                                         hook, hook, nullptr, true);
+                                                         hook, hook, index_space, true);
         if (error_code == 0) { return; }
 
         BoxArray cba;
@@ -1342,7 +1361,18 @@ FillPatchNLevels (MF& mf, int level, const IntVect& nghost, Real time,
             }
             cba = BoxArray(std::move(cbl));
         }
-        MultiFab cmf_tmp(cba, mf.DistributionMap(), ncomp, 0);
+        MultiFab cmf_tmp;
+#ifdef AMREX_USE_EB
+        if (index_space) {
+            auto factory = makeEBFabFactory(index_space, geom[level-1], cba,
+                                            mf.DistributionMap(), {0,0,0},
+                                            EBSupport::basic);
+            cmf_tmp.define(cba, mf.DistributionMap(), ncomp, 0, MFInfo(), *factory);
+        } else
+#endif
+        {
+            cmf_tmp.define(cba, mf.DistributionMap(), ncomp, 0);
+        }
         FillPatchNLevels(cmf_tmp, level-1, IntVect(0), time, smf, st, scomp, 0, ncomp,
                          geom, bc, bccomp, ratio, mapper, bcr, bcrcomp);
         Vector<MF*> cmf{&cmf_tmp};
@@ -1361,7 +1391,7 @@ FillPatchNLevels (MF& mf, int level, const IntVect& nghost, Real time,
                                         bc[level-1], bccomp,
                                         bc[level  ], bccomp,
                                         ratio[level-1], mapper, bcr, bccomp,
-                                        hook, hook, nullptr);
+                                        hook, hook, index_space);
     }
 }
 

--- a/Src/AmrCore/AMReX_FillPatchUtil_I.H
+++ b/Src/AmrCore/AMReX_FillPatchUtil_I.H
@@ -451,7 +451,6 @@ namespace detail {
                     bl.push_back(b);
                 } else {
                     is_same = false;
-                    Box isect = b & domain;
                     auto shift = [&geom] (Box obox)
                     {
                         for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
@@ -471,11 +470,12 @@ namespace detail {
                         }
                         return obox;
                     };
+                    Box const& isect = b & domain;
                     if (isect.isEmpty()) {
                         bl.push_back(shift(b));
                     } else {
                         bl.push_back(isect);
-                        BoxList bltmp = amrex::boxDiff(b, isect);
+                        BoxList const& bltmp = amrex::boxDiff(b, isect);
                         for (auto const& btmp : bltmp) {
                             bl.push_back(shift(btmp));
                         }
@@ -1361,7 +1361,7 @@ FillPatchNLevels (MF& mf, int level, const IntVect& nghost, Real time,
         Vector<MF> fmf_raii;
         if (scomp != 0) {
             for (auto const* p : fmf) {
-                fmf_raii.emplace_back(*p,  amrex::make_alias, 0, ncomp);
+                fmf_raii.emplace_back(*p,  amrex::make_alias, scomp, ncomp);
             }
         }
         detail::FillPatchTwoLevels_doit(mf, nghost, time,

--- a/Src/AmrCore/AMReX_FillPatchUtil_I.H
+++ b/Src/AmrCore/AMReX_FillPatchUtil_I.H
@@ -438,6 +438,7 @@ namespace detail {
         // nothing
     }
 
+#ifndef _WIN32
     inline BoxArray periodic_wrap_boxarray (BoxArray const& a_ba, Geometry const& geom)
     {
         if (geom.isAnyPeriodic()) {
@@ -491,9 +492,14 @@ namespace detail {
             return a_ba;
         }
     }
+#endif
 
     template <typename MF, typename BC, typename Interp, typename PreInterpHook, typename PostInterpHook>
+#ifndef _WIN32
     std::enable_if_t<IsFabArray<MF>::value,int>
+#else
+    std::enable_if_t<IsFabArray<MF>::value>
+#endif
     FillPatchTwoLevels_doit (MF& mf, IntVect const& nghost, Real time,
                              const Vector<MF*>& cmf, const Vector<Real>& ct,
                              const Vector<MF*>& fmf, const Vector<Real>& ft,
@@ -506,13 +512,18 @@ namespace detail {
                              const Vector<BCRec>& bcs, int bcscomp,
                              const PreInterpHook& pre_interp,
                              const PostInterpHook& post_interp,
-                             EB2::IndexSpace const* index_space,
-                             bool return_error_code = false)
+                             EB2::IndexSpace const* index_space
+#ifndef _WIN32
+                             , bool return_error_code = false
+#endif
+                             )
     {
         BL_PROFILE("FillPatchTwoLevels");
 
+#ifndef _WIN32
         int success_code = return_error_code ? 0 : -1;
         int failure_code = 1;
+#endif
 
         if (nghost.max() > 0 || mf.getBDKey() != fmf[0]->getBDKey())
         {
@@ -542,12 +553,14 @@ namespace detail {
 
                 if ( ! fpc.ba_crse_patch.empty())
                 {
+#ifndef _WIN32
                     if (return_error_code) {
                         BoxArray const& cba = amrex::convert(cmf[0]->boxArray(), IntVect(0));
                         if (!cba.contains(detail::periodic_wrap_boxarray(fpc.ba_crse_patch,cgeom))) {
                             return failure_code;
                         }
                     }
+#endif
 
                     MF mf_crse_patch     = make_mf_crse_patch<MF>      (fpc, ncomp, mf.boxArray().ixType());
                     // Must make sure fine exists under needed coarse faces.
@@ -609,12 +622,14 @@ namespace detail {
 
                 if ( ! fpc.ba_crse_patch.empty())
                 {
+#ifndef _WIN32
                     if (return_error_code) {
                         BoxArray const& cba = cmf[0]->boxArray();
                         if (!cba.contains(detail::periodic_wrap_boxarray(fpc.ba_crse_patch,cgeom))) {
                             return failure_code;
                         }
                     }
+#endif
 
                     MF mf_crse_patch = make_mf_crse_patch<MF>(fpc, ncomp);
                     mf_set_domain_bndry (mf_crse_patch, cgeom);
@@ -640,7 +655,9 @@ namespace detail {
         FillPatchSingleLevel(mf, nghost, time, fmf, ft, scomp, dcomp, ncomp,
                              fgeom, fbc, fbccomp);
 
+#ifndef _WIN32
         return success_code;
+#endif
     }
 
     template <typename MF, typename BC, typename Interp, typename PreInterpHook, typename PostInterpHook>
@@ -1264,6 +1281,8 @@ InterpFromCoarseLevel (Array<MF*, AMREX_SPACEDIM> const& mf, IntVect const& ngho
     }
 }
 
+#ifndef _WIN32
+
 template <typename MF, typename BC, typename Interp>
 std::enable_if_t<IsFabArray<MF>::value>
 FillPatchNLevels (MF& mf, int level, const IntVect& nghost, Real time,
@@ -1345,6 +1364,8 @@ FillPatchNLevels (MF& mf, int level, const IntVect& nghost, Real time,
                                         hook, hook, nullptr);
     }
 }
+
+#endif /*ifndef _WIN32 */
 
 }
 

--- a/Src/AmrCore/AMReX_FillPatchUtil_I.H
+++ b/Src/AmrCore/AMReX_FillPatchUtil_I.H
@@ -493,7 +493,7 @@ namespace detail {
     }
 
     template <typename MF, typename BC, typename Interp, typename PreInterpHook, typename PostInterpHook>
-    std::enable_if_t<IsFabArray<MF>::value,int>
+    std::enable_if_t<IsFabArray<MF>::value>
     FillPatchTwoLevels_doit (MF& mf, IntVect const& nghost, Real time,
                              const Vector<MF*>& cmf, const Vector<Real>& ct,
                              const Vector<MF*>& fmf, const Vector<Real>& ft,
@@ -507,12 +507,9 @@ namespace detail {
                              const PreInterpHook& pre_interp,
                              const PostInterpHook& post_interp,
                              EB2::IndexSpace const* index_space,
-                             bool return_error_code = false)
+                             int& return_error_code) // Have to return error this way because windows su*ks.
     {
         BL_PROFILE("FillPatchTwoLevels");
-
-        int success_code = return_error_code ? 0 : -1;
-        int failure_code = 1;
 
         if (nghost.max() > 0 || mf.getBDKey() != fmf[0]->getBDKey())
         {
@@ -545,7 +542,7 @@ namespace detail {
                     if (return_error_code) {
                         BoxArray const& cba = amrex::convert(cmf[0]->boxArray(), IntVect(0));
                         if (!cba.contains(detail::periodic_wrap_boxarray(fpc.ba_crse_patch,cgeom))) {
-                            return failure_code;
+                            return;
                         }
                     }
 
@@ -612,7 +609,7 @@ namespace detail {
                     if (return_error_code) {
                         BoxArray const& cba = cmf[0]->boxArray();
                         if (!cba.contains(detail::periodic_wrap_boxarray(fpc.ba_crse_patch,cgeom))) {
-                            return failure_code;
+                            return;
                         }
                     }
 
@@ -640,7 +637,7 @@ namespace detail {
         FillPatchSingleLevel(mf, nghost, time, fmf, ft, scomp, dcomp, ncomp,
                              fgeom, fbc, fbccomp);
 
-        return success_code;
+        return_error_code = 0;
     }
 
     template <typename MF, typename BC, typename Interp, typename PreInterpHook, typename PostInterpHook>
@@ -834,10 +831,11 @@ FillPatchTwoLevels (MF& mf, IntVect const& nghost, Real time,
 #else
     EB2::IndexSpace const* index_space = nullptr;
 #endif
+    int return_error_code = 0;
     detail::FillPatchTwoLevels_doit(mf,nghost,time,cmf,ct,fmf,ft,
                             scomp,dcomp,ncomp,cgeom,fgeom,
                             cbc,cbccomp,fbc,fbccomp,ratio,mapper,bcs,bcscomp,
-                            pre_interp,post_interp,index_space);
+                            pre_interp,post_interp,index_space,return_error_code);
 }
 
 template <typename MF, typename BC, typename Interp, typename PreInterpHook, typename PostInterpHook>
@@ -861,10 +859,11 @@ FillPatchTwoLevels (MF& mf, Real time,
     EB2::IndexSpace const* index_space = nullptr;
 #endif
 
+    int return_error_code = 0;
     detail::FillPatchTwoLevels_doit(mf,mf.nGrowVect(),time,cmf,ct,fmf,ft,
                             scomp,dcomp,ncomp,cgeom,fgeom,
                             cbc,cbccomp,fbc,fbccomp,ratio,mapper,bcs,bcscomp,
-                            pre_interp,post_interp,index_space);
+                            pre_interp,post_interp,index_space,return_error_code);
 }
 
 template <typename MF, typename BC, typename Interp, typename PreInterpHook, typename PostInterpHook>
@@ -973,10 +972,11 @@ FillPatchTwoLevels (MF& mf, IntVect const& nghost, Real time,
                     const PreInterpHook& pre_interp,
                     const PostInterpHook& post_interp)
 {
+    int return_error_code = 0;
     detail::FillPatchTwoLevels_doit(mf,nghost,time,cmf,ct,fmf,ft,
                             scomp,dcomp,ncomp,cgeom,fgeom,
                             cbc,cbccomp,fbc,fbccomp,ratio,mapper,bcs,bcscomp,
-                            pre_interp,post_interp,&index_space);
+                            pre_interp,post_interp,&index_space,return_error_code);
 }
 
 template <typename MF, typename BC, typename Interp, typename PreInterpHook, typename PostInterpHook>
@@ -995,10 +995,11 @@ FillPatchTwoLevels (MF& mf, Real time,
                     const PreInterpHook& pre_interp,
                     const PostInterpHook& post_interp)
 {
+    int return_error_code = 0;
     detail::FillPatchTwoLevels_doit(mf,mf.nGrowVect(),time,cmf,ct,fmf,ft,
                             scomp,dcomp,ncomp,cgeom,fgeom,
                             cbc,cbccomp,fbc,fbccomp,ratio,mapper,bcs,bcscomp,
-                            pre_interp,post_interp,&index_space);
+                            pre_interp,post_interp,&index_space,return_error_code);
 }
 #endif
 
@@ -1302,16 +1303,17 @@ FillPatchNLevels (MF& mf, int level, const IntVect& nghost, Real time,
                         domain_g, ratio[level-1], mapper, bcr, bcrcomp);
     } else {
         NullInterpHook<typename MF::FABType::value_type> hook{};
-        int error_code = detail::FillPatchTwoLevels_doit(mf, nghost, time,
-                                                         smf[level-1], st[level-1],
-                                                         smf[level  ], st[level  ],
-                                                         scomp, dcomp, ncomp,
-                                                         geom[level-1], geom[level],
-                                                         bc[level-1], bccomp,
-                                                         bc[level  ], bccomp,
-                                                         ratio[level-1], mapper, bcr, bcrcomp,
-                                                         hook, hook, nullptr, true);
-        if (error_code == 0) { return; }
+        int return_error_code = 1;
+        detail::FillPatchTwoLevels_doit(mf, nghost, time,
+                                        smf[level-1], st[level-1],
+                                        smf[level  ], st[level  ],
+                                        scomp, dcomp, ncomp,
+                                        geom[level-1], geom[level],
+                                        bc[level-1], bccomp,
+                                        bc[level  ], bccomp,
+                                        ratio[level-1], mapper, bcr, bcrcomp,
+                                        hook, hook, nullptr, return_error_code);
+        if (return_error_code != 0) { return; }
 
         BoxArray cba;
         {
@@ -1334,6 +1336,7 @@ FillPatchNLevels (MF& mf, int level, const IntVect& nghost, Real time,
                 fmf_raii.emplace_back(*p,  amrex::make_alias, 0, ncomp);
             }
         }
+        return_error_code = 0;
         detail::FillPatchTwoLevels_doit(mf, nghost, time,
                                         cmf, {time},
                                         fmf, st[level],
@@ -1342,7 +1345,7 @@ FillPatchNLevels (MF& mf, int level, const IntVect& nghost, Real time,
                                         bc[level-1], bccomp,
                                         bc[level  ], bccomp,
                                         ratio[level-1], mapper, bcr, bccomp,
-                                        hook, hook, nullptr);
+                                        hook, hook, nullptr, return_error_code);
     }
 }
 

--- a/Src/AmrCore/AMReX_FillPatchUtil_I.H
+++ b/Src/AmrCore/AMReX_FillPatchUtil_I.H
@@ -493,7 +493,7 @@ namespace detail {
     }
 
     template <typename MF, typename BC, typename Interp, typename PreInterpHook, typename PostInterpHook>
-    std::enable_if_t<IsFabArray<MF>::value>
+    std::enable_if_t<IsFabArray<MF>::value,int>
     FillPatchTwoLevels_doit (MF& mf, IntVect const& nghost, Real time,
                              const Vector<MF*>& cmf, const Vector<Real>& ct,
                              const Vector<MF*>& fmf, const Vector<Real>& ft,
@@ -507,9 +507,12 @@ namespace detail {
                              const PreInterpHook& pre_interp,
                              const PostInterpHook& post_interp,
                              EB2::IndexSpace const* index_space,
-                             int& return_error_code) // Have to return error this way because windows su*ks.
+                             bool return_error_code = false)
     {
         BL_PROFILE("FillPatchTwoLevels");
+
+        int success_code = return_error_code ? 0 : -1;
+        int failure_code = 1;
 
         if (nghost.max() > 0 || mf.getBDKey() != fmf[0]->getBDKey())
         {
@@ -542,7 +545,7 @@ namespace detail {
                     if (return_error_code) {
                         BoxArray const& cba = amrex::convert(cmf[0]->boxArray(), IntVect(0));
                         if (!cba.contains(detail::periodic_wrap_boxarray(fpc.ba_crse_patch,cgeom))) {
-                            return;
+                            return failure_code;
                         }
                     }
 
@@ -609,7 +612,7 @@ namespace detail {
                     if (return_error_code) {
                         BoxArray const& cba = cmf[0]->boxArray();
                         if (!cba.contains(detail::periodic_wrap_boxarray(fpc.ba_crse_patch,cgeom))) {
-                            return;
+                            return failure_code;
                         }
                     }
 
@@ -637,7 +640,7 @@ namespace detail {
         FillPatchSingleLevel(mf, nghost, time, fmf, ft, scomp, dcomp, ncomp,
                              fgeom, fbc, fbccomp);
 
-        return_error_code = 0;
+        return success_code;
     }
 
     template <typename MF, typename BC, typename Interp, typename PreInterpHook, typename PostInterpHook>
@@ -831,11 +834,10 @@ FillPatchTwoLevels (MF& mf, IntVect const& nghost, Real time,
 #else
     EB2::IndexSpace const* index_space = nullptr;
 #endif
-    int return_error_code = 0;
     detail::FillPatchTwoLevels_doit(mf,nghost,time,cmf,ct,fmf,ft,
                             scomp,dcomp,ncomp,cgeom,fgeom,
                             cbc,cbccomp,fbc,fbccomp,ratio,mapper,bcs,bcscomp,
-                            pre_interp,post_interp,index_space,return_error_code);
+                            pre_interp,post_interp,index_space);
 }
 
 template <typename MF, typename BC, typename Interp, typename PreInterpHook, typename PostInterpHook>
@@ -859,11 +861,10 @@ FillPatchTwoLevels (MF& mf, Real time,
     EB2::IndexSpace const* index_space = nullptr;
 #endif
 
-    int return_error_code = 0;
     detail::FillPatchTwoLevels_doit(mf,mf.nGrowVect(),time,cmf,ct,fmf,ft,
                             scomp,dcomp,ncomp,cgeom,fgeom,
                             cbc,cbccomp,fbc,fbccomp,ratio,mapper,bcs,bcscomp,
-                            pre_interp,post_interp,index_space,return_error_code);
+                            pre_interp,post_interp,index_space);
 }
 
 template <typename MF, typename BC, typename Interp, typename PreInterpHook, typename PostInterpHook>
@@ -972,11 +973,10 @@ FillPatchTwoLevels (MF& mf, IntVect const& nghost, Real time,
                     const PreInterpHook& pre_interp,
                     const PostInterpHook& post_interp)
 {
-    int return_error_code = 0;
     detail::FillPatchTwoLevels_doit(mf,nghost,time,cmf,ct,fmf,ft,
                             scomp,dcomp,ncomp,cgeom,fgeom,
                             cbc,cbccomp,fbc,fbccomp,ratio,mapper,bcs,bcscomp,
-                            pre_interp,post_interp,&index_space,return_error_code);
+                            pre_interp,post_interp,&index_space);
 }
 
 template <typename MF, typename BC, typename Interp, typename PreInterpHook, typename PostInterpHook>
@@ -995,11 +995,10 @@ FillPatchTwoLevels (MF& mf, Real time,
                     const PreInterpHook& pre_interp,
                     const PostInterpHook& post_interp)
 {
-    int return_error_code = 0;
     detail::FillPatchTwoLevels_doit(mf,mf.nGrowVect(),time,cmf,ct,fmf,ft,
                             scomp,dcomp,ncomp,cgeom,fgeom,
                             cbc,cbccomp,fbc,fbccomp,ratio,mapper,bcs,bcscomp,
-                            pre_interp,post_interp,&index_space,return_error_code);
+                            pre_interp,post_interp,&index_space);
 }
 #endif
 
@@ -1303,17 +1302,16 @@ FillPatchNLevels (MF& mf, int level, const IntVect& nghost, Real time,
                         domain_g, ratio[level-1], mapper, bcr, bcrcomp);
     } else {
         NullInterpHook<typename MF::FABType::value_type> hook{};
-        int return_error_code = 1;
-        detail::FillPatchTwoLevels_doit(mf, nghost, time,
-                                        smf[level-1], st[level-1],
-                                        smf[level  ], st[level  ],
-                                        scomp, dcomp, ncomp,
-                                        geom[level-1], geom[level],
-                                        bc[level-1], bccomp,
-                                        bc[level  ], bccomp,
-                                        ratio[level-1], mapper, bcr, bcrcomp,
-                                        hook, hook, nullptr, return_error_code);
-        if (return_error_code != 0) { return; }
+        int error_code = detail::FillPatchTwoLevels_doit(mf, nghost, time,
+                                                         smf[level-1], st[level-1],
+                                                         smf[level  ], st[level  ],
+                                                         scomp, dcomp, ncomp,
+                                                         geom[level-1], geom[level],
+                                                         bc[level-1], bccomp,
+                                                         bc[level  ], bccomp,
+                                                         ratio[level-1], mapper, bcr, bcrcomp,
+                                                         hook, hook, nullptr, true);
+        if (error_code == 0) { return; }
 
         BoxArray cba;
         {
@@ -1336,7 +1334,6 @@ FillPatchNLevels (MF& mf, int level, const IntVect& nghost, Real time,
                 fmf_raii.emplace_back(*p,  amrex::make_alias, 0, ncomp);
             }
         }
-        return_error_code = 0;
         detail::FillPatchTwoLevels_doit(mf, nghost, time,
                                         cmf, {time},
                                         fmf, st[level],
@@ -1345,7 +1342,7 @@ FillPatchNLevels (MF& mf, int level, const IntVect& nghost, Real time,
                                         bc[level-1], bccomp,
                                         bc[level  ], bccomp,
                                         ratio[level-1], mapper, bcr, bccomp,
-                                        hook, hook, nullptr, return_error_code);
+                                        hook, hook, nullptr);
     }
 }
 

--- a/Src/Base/AMReX_BoxArray.H
+++ b/Src/Base/AMReX_BoxArray.H
@@ -6,6 +6,7 @@
 #include <AMReX_IndexType.H>
 #include <AMReX_BoxList.H>
 #include <AMReX_Array.H>
+#include <AMReX_Periodicity.H>
 #include <AMReX_Vector.H>
 
 #include <iosfwd>
@@ -734,6 +735,16 @@ public:
     [[nodiscard]]
     bool contains (const BoxArray& ba, bool assume_disjoint_ba = false,
                    const IntVect& ng = IntVect(0)) const;
+
+    /**
+     * \brief True if all cells in ba are periodically contained in this
+     * BoxArray.
+     *
+     * If a cell after being periodically shifted is contained in this
+     * BoxArray, it's considered being periodically contained.
+     */
+    [[nodiscard]]
+    bool contains (const BoxArray& ba, Periodicity const& period) const;
 
     //! Return smallest Box that contains all Boxes in this BoxArray.
     [[nodiscard]] Box minimalBox () const;

--- a/Src/Base/AMReX_BoxArray.cpp
+++ b/Src/Base/AMReX_BoxArray.cpp
@@ -1010,6 +1010,34 @@ BoxArray::contains (const BoxArray& ba, bool assume_disjoint_ba, const IntVect& 
     return true;
 }
 
+bool
+BoxArray::contains (const BoxArray& ba, Periodicity const& period) const
+{
+    if (size() == 0) { return false; }
+
+    if (! period.isAnyPeriodic()) { return contains(ba); }
+
+    auto const& pshifts = period.shiftIntVect();
+
+    std::vector< std::pair<int,Box> > isects;
+    BoxList bl(ba.ixType());
+
+    for (int i = 0, N = static_cast<int>(ba.size()); i < N; ++i) {
+        Box const& b = ba[i];
+        bl.clear();
+        for (auto const& pit: pshifts) {
+            intersections(b+pit, isects);
+            for (auto const& is : isects) {
+                bl.push_back(is.second - pit);
+            }
+        }
+        BoxList const& left = amrex::complementIn(b, bl);
+        if (left.isNotEmpty()) { return false; }
+    }
+
+    return true;
+}
+
 Box
 BoxArray::minimalBox () const
 {

--- a/Src/Base/AMReX_BoxList.H
+++ b/Src/Base/AMReX_BoxList.H
@@ -90,7 +90,11 @@ public:
     void reserve (std::size_t n) { m_lbox.reserve(n); }
 
     //! Append a Box to this BoxList.
-    void push_back (const Box& bn) { BL_ASSERT(ixType() == bn.ixType()); m_lbox.push_back(bn); }
+    void push_back (const Box& bn) {
+        if (m_lbox.empty()) { btype = bn.ixType(); }
+        BL_ASSERT(ixType() == bn.ixType());
+        m_lbox.push_back(bn);
+    }
 
     [[nodiscard]] Box& front () noexcept { BL_ASSERT(!m_lbox.empty()); return m_lbox.front(); }
 

--- a/Src/Base/AMReX_MultiFab.H
+++ b/Src/Base/AMReX_MultiFab.H
@@ -658,6 +658,17 @@ public:
                             const IntVect&  nghost);
 
     /**
+    * \brief Are the numbers in the MF finite (i.e., neither nan nor inf)?
+    * This may return true, even if the MF contains NaNs or Infs, if the
+    * machine doesn't support the appropriate NaN and Inf testing functions.
+    *
+    * This version checks all components and grow cells.
+    */
+    [[nodiscard]] bool is_finite (bool local=false) const;
+    [[nodiscard]] bool is_finite (int scomp, int ncomp, int ngrow = 0, bool local=false) const;
+    [[nodiscard]] bool is_finite (int scomp, int ncomp, const IntVect& ngrow, bool local=false) const;
+
+    /**
     * \brief Are there any NaNs in the MF?
     * This may return false, even if the MF contains NaNs, if the machine
     * doesn't support the appropriate NaN testing functions.

--- a/Tests/Amr/Advection_AmrCore/Exec/inputs-ci
+++ b/Tests/Amr/Advection_AmrCore/Exec/inputs-ci
@@ -81,3 +81,5 @@ amr.chk_int  = -1       # number of timesteps between checkpoint files
 # Particles
 # *****************************************************************
 amr.do_tracers = 1      # Turn tracer particles on or off
+
+test_fillpatchnlevels = 1 # Test amrex::FillPatchNLevels

--- a/Tests/Amr/Advection_AmrCore/Source/AmrCoreAdv.cpp
+++ b/Tests/Amr/Advection_AmrCore/Source/AmrCoreAdv.cpp
@@ -101,6 +101,25 @@ AmrCoreAdv::Evolve ()
     Real cur_time = t_new[0];
     int last_plot_file_step = 0;
 
+#ifndef _WIN32
+    int levmean = max_level;
+    MultiFab mfmean;
+    int test_fillpatchnlevels = 0;
+    {
+        ParmParse pp;
+        pp.query("test_fillpatchnlevels", test_fillpatchnlevels);
+    }
+    if (test_fillpatchnlevels) {
+        Box bxmean = geom[levmean].Domain();
+        IntVect shrink = geom[levmean].Domain().length() / 4;
+        bxmean.grow(-shrink);
+        BoxArray bamean(bxmean);
+        bamean.maxSize(32);
+        mfmean.define(bamean,DistributionMapping{bamean},1,0);
+        mfmean.setVal(0.0);
+    }
+#endif
+
     for (int step = istep[0]; step < max_step && cur_time < stop_time; ++step)
     {
         amrex::Print() << "\nCoarse STEP " << step+1 << " starts ..." << '\n';
@@ -146,7 +165,39 @@ AmrCoreAdv::Evolve ()
 #endif
 
         if (cur_time >= stop_time - 1.e-6*dt[0]) { break; }
+
+#ifndef _WIN32
+        if (test_fillpatchnlevels)
+        {
+            MultiFab mftmp(mfmean.boxArray(), mfmean.DistributionMap(), 1, 0);
+
+            CpuBndryFuncFab bndry_func(nullptr);
+            Vector<PhysBCFunct<CpuBndryFuncFab>> physbcs;
+            for (int ilev = 0; ilev <= max_level; ++ilev) {
+                physbcs.emplace_back(geom[ilev],bcs,bndry_func);
+            }
+            Vector<Vector<MultiFab*>> smf(finest_level+1);
+            Vector<Vector<Real>> st(finest_level+1);
+            for (int ilev = 0; ilev <= finest_level; ++ilev) {
+                smf[ilev].push_back(&phi_new[ilev]);
+                st[ilev].push_back(0.0);
+            }
+            FillPatchNLevels(mftmp, levmean, IntVect(0), 0.0, smf, st, 0, 0, 1, geom,
+                             physbcs, 0, refRatio(), &cell_cons_interp, bcs, 0);
+            MultiFab::Add(mfmean, mftmp, 0, 0, 1, 0);
+        }
+#endif
     }
+
+#ifndef _WIN32
+    if (test_fillpatchnlevels) {
+        if (mfmean.is_finite()) {
+            amrex::Print() << "\namrex::FillPatchNLevels test passed\n\n";
+        } else {
+            amrex::Abort("amrex::FillPatchNLevels test failed");
+        }
+    }
+#endif
 
     if (plot_int > 0 && istep[0] > last_plot_file_step) {
         WritePlotFile();

--- a/Tests/Amr/Advection_AmrCore/Source/AmrCoreAdv.cpp
+++ b/Tests/Amr/Advection_AmrCore/Source/AmrCoreAdv.cpp
@@ -101,7 +101,6 @@ AmrCoreAdv::Evolve ()
     Real cur_time = t_new[0];
     int last_plot_file_step = 0;
 
-#ifndef _WIN32
     int levmean = max_level;
     MultiFab mfmean;
     int test_fillpatchnlevels = 0;
@@ -118,7 +117,6 @@ AmrCoreAdv::Evolve ()
         mfmean.define(bamean,DistributionMapping{bamean},1,0);
         mfmean.setVal(0.0);
     }
-#endif
 
     for (int step = istep[0]; step < max_step && cur_time < stop_time; ++step)
     {
@@ -166,7 +164,6 @@ AmrCoreAdv::Evolve ()
 
         if (cur_time >= stop_time - 1.e-6*dt[0]) { break; }
 
-#ifndef _WIN32
         if (test_fillpatchnlevels)
         {
             MultiFab mftmp(mfmean.boxArray(), mfmean.DistributionMap(), 1, 0);
@@ -186,10 +183,8 @@ AmrCoreAdv::Evolve ()
                              physbcs, 0, refRatio(), &cell_cons_interp, bcs, 0);
             MultiFab::Add(mfmean, mftmp, 0, 0, 1, 0);
         }
-#endif
     }
 
-#ifndef _WIN32
     if (test_fillpatchnlevels) {
         if (mfmean.is_finite()) {
             amrex::Print() << "\namrex::FillPatchNLevels test passed\n\n";
@@ -197,7 +192,6 @@ AmrCoreAdv::Evolve ()
             amrex::Abort("amrex::FillPatchNLevels test failed");
         }
     }
-#endif
 
     if (plot_int > 0 && istep[0] > last_plot_file_step) {
         WritePlotFile();


### PR DESCRIPTION
The existing FillPatchSingleLevel fills with the data from the same AMR level, and FillPatchTwoLevels fills with the data form the same AMR level and the coarse level below if needed.  This new function will go down the AMR levels as deep as necessary.