### PR TITLE
Add structured binding support to GpuTuple

### DIFF
--- a/Src/Base/AMReX_Tuple.H
+++ b/Src/Base/AMReX_Tuple.H
@@ -416,6 +416,23 @@ auto tupleToArray (GpuTuple<T,Ts...> const& tup)
     return detail::tuple_to_array_helper(tup, std::index_sequence_for<T,Ts...>{});
 }
 
-}
+} // namespace amrex
+
+// Spcialize std::tuple_size for GpuTuple. Used by structured bindings.
+template<typename... Ts>
+struct std::tuple_size<amrex::GpuTuple<Ts...>> {
+    static constexpr std::size_t value = sizeof...(Ts);
+};
+
+// Spcialize std::tuple_element for GpuTuple. Used by structured bindings.
+template<typename T, typename... Ts>
+struct std::tuple_element<std::size_t{0}, amrex::GpuTuple<T, Ts...>> {
+    using type = T;
+};
+
+template<std::size_t s, typename T, typename... Ts>
+struct std::tuple_element<s, amrex::GpuTuple<T, Ts...>> {
+    using type = typename std::tuple_element<s-1, amrex::GpuTuple<Ts...>>::type;
+};
 
 #endif /*AMREX_TUPLE_H_*/


### PR DESCRIPTION
## Summary

This PR adds C++17 structured binding support to `amrex::GpuTuple`.

## Additional background

See case 2 in https://en.cppreference.com/w/cpp/language/structured_binding.
Note that structured bindings will also use the existing `amrex::get`.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
