### PR TITLE
Add TupleSplit

### DIFF
--- a/Src/Base/AMReX_Tuple.H
+++ b/Src/Base/AMReX_Tuple.H
@@ -354,7 +354,7 @@ namespace detail {
     TupleSplitImp (const GpuTuple<Args...>& tup, std::index_sequence<Is...>, SIL) noexcept
     {
         return makeTuple(
-            GetSubTuple<SIL::template get_exclusive_sum<Is>()>(
+            GetSubTuple<(SIL::template get_exclusive_sum<Is>())>(
                 tup,
                 std::make_index_sequence<SIL::template get<Is>()>()
             )...

--- a/Src/Base/AMReX_Tuple.H
+++ b/Src/Base/AMReX_Tuple.H
@@ -315,6 +315,70 @@ TupleCat (TP1&& a, TP2&& b, TPs&&... args)
                     std::forward<TPs>(args)...);
 }
 
+// TupleSplit
+
+namespace detail {
+
+    template<std::size_t...Is>
+    struct SplitIndexList {
+        template<std::size_t J>
+        AMREX_GPU_HOST_DEVICE
+        static constexpr std::size_t get () noexcept {
+            std::size_t arr[sizeof...(Is)] = {Is...};
+            return arr[J];
+        }
+
+        template<std::size_t J>
+        AMREX_GPU_HOST_DEVICE
+        static constexpr std::size_t get_exclusive_sum () noexcept {
+            std::size_t arr[sizeof...(Is)] = {Is...};
+            std::size_t sum = 0;
+            for (std::size_t k=0; k<J; ++k) {
+                sum += arr[k];
+            }
+            return sum;
+        }
+    };
+
+    template <std::size_t start, typename... Args, std::size_t... Is>
+    AMREX_GPU_HOST_DEVICE
+    constexpr auto
+    GetSubTuple (const GpuTuple<Args...>& tup, std::index_sequence<Is...>) noexcept
+    {
+        return makeTuple(amrex::get<start+Is>(tup)...);
+    }
+
+    template <typename... Args, std::size_t... Is, typename SIL>
+    AMREX_GPU_HOST_DEVICE
+    constexpr auto
+    TupleSplitImp (const GpuTuple<Args...>& tup, std::index_sequence<Is...>, SIL) noexcept
+    {
+        return makeTuple(
+            GetSubTuple<SIL::template get_exclusive_sum<Is>()>(
+                tup,
+                std::make_index_sequence<SIL::template get<Is>()>()
+            )...
+        );
+    }
+}
+
+/**
+ * \brief Returns a GpuTuple of GpuTuples obtained by splitting the input GpuTuple
+ * according to the sizes specified by the template arguments.
+ */
+template <std::size_t... Is, typename... Args>
+AMREX_GPU_HOST_DEVICE
+constexpr auto
+TupleSplit (const GpuTuple<Args...>& tup) noexcept
+{
+    static_assert((0 + ... + Is) == sizeof...(Args), "Incorrect total size in TupleSplit");
+    return detail::TupleSplitImp(
+        tup,
+        std::make_index_sequence<sizeof...(Is)>(),
+        detail::SplitIndexList<Is...>()
+    );
+}
+
 // Apply
 
 namespace detail {


### PR DESCRIPTION
## Summary

This PR adds a `TupleSplit` function for `GpuTuple` similar to `IntVectSplit` in #3969. It can be used as an inverse function of `TupleCat` and `TypeMultiplier`.
Example:
```C++
auto tup = amrex::makeTuple(2,4,5,7,2.324,7,8,342.3f,4ull,1ll,-38,"test");
auto [t0,t1,t2,t3] = amrex::TupleSplit<3,3,4,2>(tup);
// t0 = GpuTuple( 2, 4, 5 )
// t1 = GpuTuple( 7, 2.324, 7 )
// t2 = GpuTuple( 8, 342.2999878, 4, 1 )
// t3 = GpuTuple( -38, test )
```

## Additional background

The current implementation does not move the tuple elements and makes a copy instead.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
