### PR TITLE
use HIP stream-ordered allocator

### DIFF
--- a/Src/Base/AMReX_GpuControl.H
+++ b/Src/Base/AMReX_GpuControl.H
@@ -11,6 +11,10 @@
 #define AMREX_CUDA_GE_11_2 1
 #endif
 
+#if defined(AMREX_USE_HIP) || defined(AMREX_CUDA_GE_11_2)
+#define AMREX_GPU_STREAM_ALLOC_SUPPORT 1
+#endif
+
 #if defined(AMREX_USE_HIP)
 #define AMREX_HIP_OR_CUDA(a,b) a
 #elif defined(AMREX_USE_CUDA)

--- a/Src/Base/AMReX_GpuDevice.cpp
+++ b/Src/Base/AMReX_GpuDevice.cpp
@@ -386,13 +386,17 @@ Device::initialize_gpu ()
         AMREX_HIP_SAFE_CALL(hipStreamCreate(&gpu_stream_pool[i]));
     }
 
+#ifdef AMREX_GPU_STREAM_ALLOC_SUPPORT
+    hipDeviceGetAttribute(&memory_pools_supported, hipDevAttrMemoryPoolsSupported, device_id);
+#endif
+
 #elif defined(AMREX_USE_CUDA)
     AMREX_CUDA_SAFE_CALL(cudaGetDeviceProperties(&device_prop, device_id));
 
     AMREX_ALWAYS_ASSERT_WITH_MESSAGE(device_prop.major >= 4 || (device_prop.major == 3 && device_prop.minor >= 5),
                                      "Compute capability must be >= 3.5");
 
-#ifdef AMREX_CUDA_GE_11_2
+#ifdef AMREX_GPU_STREAM_ALLOC_SUPPORT
     cudaDeviceGetAttribute(&memory_pools_supported, cudaDevAttrMemoryPoolsSupported, device_id);
 #endif
 

--- a/Src/Base/AMReX_GpuDevice.cpp
+++ b/Src/Base/AMReX_GpuDevice.cpp
@@ -387,7 +387,7 @@ Device::initialize_gpu ()
     }
 
 #ifdef AMREX_GPU_STREAM_ALLOC_SUPPORT
-    hipDeviceGetAttribute(&memory_pools_supported, hipDevAttrMemoryPoolsSupported, device_id);
+    hipDeviceGetAttribute(&memory_pools_supported, hipDeviceAttributeMemoryPoolsSupported, device_id);
 #endif
 
 #elif defined(AMREX_USE_CUDA)

--- a/Src/Base/AMReX_GpuDevice.cpp
+++ b/Src/Base/AMReX_GpuDevice.cpp
@@ -387,7 +387,7 @@ Device::initialize_gpu ()
     }
 
 #ifdef AMREX_GPU_STREAM_ALLOC_SUPPORT
-    hipDeviceGetAttribute(&memory_pools_supported, hipDeviceAttributeMemoryPoolsSupported, device_id);
+    AMREX_HIP_SAFE_CALL(hipDeviceGetAttribute(&memory_pools_supported, hipDeviceAttributeMemoryPoolsSupported, device_id));
 #endif
 
 #elif defined(AMREX_USE_CUDA)

--- a/Src/Base/AMReX_PArena.H
+++ b/Src/Base/AMReX_PArena.H
@@ -44,8 +44,14 @@ public:
 
 #ifdef AMREX_GPU_STREAM_ALLOC_SUPPORT
 private:
-    cudaMemPool_t m_pool;
-    cuuint64_t m_old_release_threshold;
+    AMREX_HIP_OR_CUDA(
+        hipMemPool_t m_pool;,
+        cudaMemPool_t m_pool;
+    )
+    AMREX_HIP_OR_CUDA(
+        uint64_t m_old_release_threshold;
+        cuuint64_t m_old_release_threshold;
+    )
 #endif
 };
 

--- a/Src/Base/AMReX_PArena.H
+++ b/Src/Base/AMReX_PArena.H
@@ -49,7 +49,7 @@ private:
         cudaMemPool_t m_pool;
     )
     AMREX_HIP_OR_CUDA(
-        uint64_t m_old_release_threshold;
+        uint64_t m_old_release_threshold;,
         cuuint64_t m_old_release_threshold;
     )
 #endif

--- a/Src/Base/AMReX_PArena.H
+++ b/Src/Base/AMReX_PArena.H
@@ -42,7 +42,7 @@ public:
     [[nodiscard]] bool isStreamOrderedArena () const final { return true; }
 #endif
 
-#ifdef AMREX_CUDA_GE_11_2
+#ifdef AMREX_GPU_STREAM_ALLOC_SUPPORT
 private:
     cudaMemPool_t m_pool;
     cuuint64_t m_old_release_threshold;

--- a/Src/Base/AMReX_PArena.cpp
+++ b/Src/Base/AMReX_PArena.cpp
@@ -23,7 +23,10 @@ PArena::PArena (Long release_threshold)
             AMREX_CUDA_SAFE_CALL(cudaMemPoolGetAttribute(m_pool, cudaMemPoolAttrReleaseThreshold,
                                                          &m_old_release_threshold));
         )
-        cuuint64_t value = release_threshold;
+        AMREX_HIP_OR_CUDA(
+            uint64_t value = release_threshold;,
+            cuuint64_t value = release_threshold;
+        )
         AMREX_HIP_OR_CUDA(
             AMREX_HIP_SAFE_CALL(hipMemPoolSetAttribute(m_pool, hipMemPoolAttrReleaseThreshold, &value));,
             AMREX_CUDA_SAFE_CALL(cudaMemPoolSetAttribute(m_pool, cudaMemPoolAttrReleaseThreshold, &value));

--- a/Src/Base/AMReX_PArena.cpp
+++ b/Src/Base/AMReX_PArena.cpp
@@ -14,18 +14,18 @@ PArena::PArena (Long release_threshold)
 #ifdef AMREX_GPU_STREAM_ALLOC_SUPPORT
     if (Gpu::Device::memoryPoolsSupported()) {
         AMREX_HIP_OR_CUDA(
-            AMREX_HIP_SAFE_CALL(hipDeviceGetMemPool(&m_pool, Gpu::Device::deviceId()));
+            AMREX_HIP_SAFE_CALL(hipDeviceGetMemPool(&m_pool, Gpu::Device::deviceId()));,
             AMREX_CUDA_SAFE_CALL(cudaDeviceGetMemPool(&m_pool, Gpu::Device::deviceId()));
         )
         AMREX_HIP_OR_CUDA(
             AMREX_HIP_SAFE_CALL(hipMemPoolGetAttribute(m_pool, hipMemPoolAttrReleaseThreshold,
-                                                       &m_old_release_threshold));
+                                                       &m_old_release_threshold));,
             AMREX_CUDA_SAFE_CALL(cudaMemPoolGetAttribute(m_pool, cudaMemPoolAttrReleaseThreshold,
                                                          &m_old_release_threshold));
         )
         cuuint64_t value = release_threshold;
         AMREX_HIP_OR_CUDA(
-            AMREX_HIP_SAFE_CALL(hipMemPoolSetAttribute(m_pool, hipMemPoolAttrReleaseThreshold, &value));
+            AMREX_HIP_SAFE_CALL(hipMemPoolSetAttribute(m_pool, hipMemPoolAttrReleaseThreshold, &value));,
             AMREX_CUDA_SAFE_CALL(cudaMemPoolSetAttribute(m_pool, cudaMemPoolAttrReleaseThreshold, &value));
         )
     }
@@ -39,7 +39,7 @@ PArena::~PArena () // NOLINT(modernize-use-equals-default)
     if (Gpu::Device::memoryPoolsSupported()) {
         AMREX_HIP_OR_CUDA(
             AMREX_HIP_SAFE_CALL(hipMemPoolSetAttribute(m_pool, hipMemPoolAttrReleaseThreshold,
-                                                        &m_old_release_threshold));
+                                                        &m_old_release_threshold));,
             AMREX_CUDA_SAFE_CALL(cudaMemPoolSetAttribute(m_pool, cudaMemPoolAttrReleaseThreshold,
                                                         &m_old_release_threshold));
         )
@@ -56,7 +56,7 @@ PArena::alloc (std::size_t nbytes)
     if (Gpu::Device::memoryPoolsSupported()) {
         void* p;
         AMREX_HIP_OR_CUDA(
-            AMREX_HIP_SAFE_CALL(hipMallocAsync(&p, nbytes, m_pool, Gpu::gpuStream()));
+            AMREX_HIP_SAFE_CALL(hipMallocAsync(&p, nbytes, m_pool, Gpu::gpuStream()));,
             AMREX_CUDA_SAFE_CALL(cudaMallocAsync(&p, nbytes, m_pool, Gpu::gpuStream()));
         )
         return p;
@@ -91,7 +91,7 @@ PArena::free (void* p)
 #if defined (AMREX_GPU_STREAM_ALLOC_SUPPORT)
     if (Gpu::Device::memoryPoolsSupported()) {
         AMREX_HIP_OR_CUDA(
-            AMREX_HIP_SAFE_CALL(hipFreeAsync(p, Gpu::gpuStream()));
+            AMREX_HIP_SAFE_CALL(hipFreeAsync(p, Gpu::gpuStream()));,
             AMREX_CUDA_SAFE_CALL(cudaFreeAsync(p, Gpu::gpuStream()));
         )
     } else


### PR DESCRIPTION
## Summary
When available, this uses the HIP stream-ordered memory allocator `hipMallocAsync`/`hipFreeAsync` to make device arena allocations. This should improve performance (performance testing TBD).

AMReX tests pass on MI210 with ROCm 6.0.

Closes https://github.com/AMReX-Codes/amrex/issues/3979.

## Additional background
ROCm 5.2.0 added these APIs: https://rocm.docs.amd.com/en/latest/about/changelog.html#id665
HIP documentation: https://rocm.docs.amd.com/projects/HIP/en/latest/doxygen/html/group___stream_o.html

The CUDA stream-ordered allocator is already used by AMReX (with CUDA >= 11.2).

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
