### PR TITLE
const auto ptd -> const auto& ptd

### DIFF
--- a/Src/Particle/AMReX_ParticleCommunication.H
+++ b/Src/Particle/AMReX_ParticleCommunication.H
@@ -341,7 +341,7 @@ void packBuffer (const PC& pc, const ParticleCopyOp& op, const ParticleCopyPlan&
             auto index = std::make_pair(gid, tid);
 
             auto& src_tile = plev.at(index);
-            const auto ptd = src_tile.getConstParticleTileData();
+            const auto& ptd = src_tile.getConstParticleTileData();
 
             int num_copies = op.numCopies(gid, lev);
             if (num_copies == 0) { continue; }

--- a/Src/Particle/AMReX_ParticleReduce.H
+++ b/Src/Particle/AMReX_ParticleReduce.H
@@ -193,7 +193,7 @@ ReduceSum (PC const& pc, int lev_min, int lev_max, F const& f)
             {
                 const auto& tile = plev.at(kv.first);
                 const auto np = tile.numParticles();
-                const auto ptd = tile.getConstParticleTileData();
+                const auto& ptd = tile.getConstParticleTileData();
                 reduce_op.eval(np, reduce_data,
                                [=] AMREX_GPU_DEVICE (const int i) -> ReduceTuple {
                                    return particle_detail::call_f(f, ptd, i);
@@ -224,7 +224,7 @@ ReduceSum (PC const& pc, int lev_min, int lev_max, F const& f)
             {
                 const auto& tile = plev.at(grid_tile_ids[pmap_it]);
                 const auto np = tile.numParticles();
-                const auto ptd = tile.getConstParticleTileData();
+                const auto& ptd = tile.getConstParticleTileData();
                 for (int i = 0; i < np; ++i) {
                     sm += particle_detail::call_f(f, ptd, i);
                 }
@@ -394,7 +394,7 @@ ReduceMax (PC const& pc, int lev_min, int lev_max, F const& f)
             {
                 const auto& tile = plev.at(kv.first);
                 const auto np = tile.numParticles();
-                const auto ptd = tile.getConstParticleTileData();
+                const auto& ptd = tile.getConstParticleTileData();
                 reduce_op.eval(np, reduce_data,
                                [=] AMREX_GPU_DEVICE (const int i) -> ReduceTuple {
                                    return particle_detail::call_f(f, ptd, i);
@@ -425,7 +425,7 @@ ReduceMax (PC const& pc, int lev_min, int lev_max, F const& f)
             {
                 const auto& tile = plev.at(grid_tile_ids[pmap_it]);
                 const auto np = tile.numParticles();
-                const auto ptd = tile.getConstParticleTileData();
+                const auto& ptd = tile.getConstParticleTileData();
                 for (int i = 0; i < np; ++i) {
                     r = std::max(r, particle_detail::call_f(f, ptd, i));
                 }
@@ -595,7 +595,7 @@ ReduceMin (PC const& pc, int lev_min, int lev_max, F const& f)
             {
                 const auto& tile = plev.at(kv.first);
                 const auto np = tile.numParticles();
-                const auto ptd = tile.getConstParticleTileData();
+                const auto& ptd = tile.getConstParticleTileData();
                 reduce_op.eval(np, reduce_data,
                                [=] AMREX_GPU_DEVICE (const int i) -> ReduceTuple {
                                    return particle_detail::call_f(f, ptd, i);
@@ -626,7 +626,7 @@ ReduceMin (PC const& pc, int lev_min, int lev_max, F const& f)
             {
                 const auto& tile = plev.at(grid_tile_ids[pmap_it]);
                 const auto np = tile.numParticles();
-                const auto ptd = tile.getConstParticleTileData();
+                const auto& ptd = tile.getConstParticleTileData();
                 for (int i = 0; i < np; ++i) {
                     r = std::min(r, particle_detail::call_f(f, ptd, i));
                 }
@@ -791,7 +791,7 @@ ReduceLogicalAnd (PC const& pc, int lev_min, int lev_max, F const& f)
             {
                 const auto& tile = plev.at(kv.first);
                 const auto np = tile.numParticles();
-                const auto ptd = tile.getConstParticleTileData();
+                const auto& ptd = tile.getConstParticleTileData();
                 reduce_op.eval(np, reduce_data,
                                [=] AMREX_GPU_DEVICE (const int i) -> ReduceTuple {
                                    return particle_detail::call_f(f, ptd, i);
@@ -822,7 +822,7 @@ ReduceLogicalAnd (PC const& pc, int lev_min, int lev_max, F const& f)
             {
                 const auto& tile = plev.at(grid_tile_ids[pmap_it]);
                 const auto np = tile.numParticles();
-                const auto ptd = tile.getConstParticleTileData();
+                const auto& ptd = tile.getConstParticleTileData();
                 for (int i = 0; i < np; ++i) {
                     r = r && particle_detail::call_f(f, ptd, i);
                 }
@@ -987,7 +987,7 @@ ReduceLogicalOr (PC const& pc, int lev_min, int lev_max, F const& f)
             {
                 const auto& tile = plev.at(kv.first);
                 const auto np = tile.numParticles();
-                const auto ptd = tile.getConstParticleTileData();
+                const auto& ptd = tile.getConstParticleTileData();
                 reduce_op.eval(np, reduce_data,
                                [=] AMREX_GPU_DEVICE (const int i) -> ReduceTuple
                                {
@@ -1019,7 +1019,7 @@ ReduceLogicalOr (PC const& pc, int lev_min, int lev_max, F const& f)
             {
                 const auto& tile = plev.at(grid_tile_ids[pmap_it]);
                 const auto np = tile.numParticles();
-                const auto ptd = tile.getConstParticleTileData();
+                const auto& ptd = tile.getConstParticleTileData();
                 for (int i = 0; i < np; ++i) {
                     r = r || particle_detail::call_f(f, ptd, i);
                 }
@@ -1254,7 +1254,7 @@ ParticleReduce (PC const& pc, int lev_min, int lev_max, F const& f, ReduceOps& r
         {
             const auto& tile = plev.at(grid_tile_ids[pmap_it]);
             const auto np = tile.numParticles();
-            const auto ptd = tile.getConstParticleTileData();
+            const auto& ptd = tile.getConstParticleTileData();
             reduce_ops.eval(np, reduce_data,
                             [=] AMREX_GPU_DEVICE (const int i) noexcept
                             {

--- a/Src/Particle/AMReX_ParticleUtil.H
+++ b/Src/Particle/AMReX_ParticleUtil.H
@@ -55,7 +55,7 @@ numParticlesOutOfRange (Iterator const& pti, IntVect nGrow)
 
     const auto& tile = pti.GetParticleTile();
     const auto np = tile.numParticles();
-    const auto ptd = tile.getConstParticleTileData();
+    const auto& ptd = tile.getConstParticleTileData();
     const auto& geom = pti.Geom(pti.GetLevel());
 
     const auto domain = geom.Domain();

--- a/Src/Particle/AMReX_WriteBinaryParticleData.H
+++ b/Src/Particle/AMReX_WriteBinaryParticleData.H
@@ -33,7 +33,7 @@ template <template <class, class> class Container,
 std::enable_if_t<RunOnGpu<typename Container<int, Allocator>::allocator_type>::value>
 fillFlags (Container<int, Allocator>& pflags, const PTile& ptile, F const& f)
 {
-    const auto ptd = ptile.getConstParticleTileData();
+    const auto& ptd = ptile.getConstParticleTileData();
     const auto np = ptile.numParticles();
     pflags.resize(np, 0);
     auto flag_ptr = pflags.data();
@@ -57,7 +57,7 @@ template <template <class, class> class Container,
 std::enable_if_t<!RunOnGpu<typename Container<int, Allocator>::allocator_type>::value>
 fillFlags (Container<int, Allocator>& pflags, const PTile& ptile, F const& f)
 {
-    const auto ptd = ptile.getConstParticleTileData();
+    const auto& ptd = ptile.getConstParticleTileData();
     const auto np = ptile.numParticles();
     pflags.resize(np, 0);
     auto flag_ptr = pflags.data();
@@ -215,7 +215,7 @@ packIOData (Vector<int>& idata, Vector<ParticleReal>& rdata, const PC& pc, int l
         auto idata_d_ptr = idata_d.data();
         auto rdata_d_ptr = rdata_d.data();
 
-        const auto ptd = ptile.getConstParticleTileData();
+        const auto& ptd = ptile.getConstParticleTileData();
         amrex::ParallelFor(num_copies,
         [=] AMREX_GPU_DEVICE (int pindex) noexcept
         {
@@ -1019,7 +1019,7 @@ void WriteBinaryParticleDataAsync (PC const& pc,
                 for (unsigned i = 0; i < tile_map[grid].size(); i++) {
                     auto ptile_index = std::make_pair(grid, tile_map[grid][i]);
                     const auto& pbox = (*myptiles)[lev][ptile_index];
-                    const auto ptd = pbox.getConstParticleTileData();
+                    const auto& ptd = pbox.getConstParticleTileData();
                     for (int pindex = 0; pindex < pbox.numParticles(); ++pindex)
                     {
                         const auto& soa  = pbox.GetStructOfArrays();
@@ -1096,7 +1096,7 @@ void WriteBinaryParticleDataAsync (PC const& pc,
                 for (unsigned i = 0; i < tile_map[grid].size(); i++) {
                     auto ptile_index = std::make_pair(grid, tile_map[grid][i]);
                     const auto& pbox = (*myptiles)[lev][ptile_index];
-                    const auto ptd = pbox.getConstParticleTileData();
+                    const auto& ptd = pbox.getConstParticleTileData();
                     for (int pindex = 0;
                          pindex < pbox.numParticles(); ++pindex)
                     {

--- a/Tests/Particles/ParallelContext/main.cpp
+++ b/Tests/Particles/ParallelContext/main.cpp
@@ -244,7 +244,7 @@ public:
                 int gid = mfi.index();
                 int tid = mfi.LocalTileIndex();
                 const auto& ptile = plev.at(std::make_pair(gid, tid));
-                const auto ptd = ptile.getConstParticleTileData();
+                const auto& ptd = ptile.getConstParticleTileData();
                 const size_t np = ptile.numParticles();
 
                 AMREX_FOR_1D ( np, i,

--- a/Tests/Particles/Redistribute/main.cpp
+++ b/Tests/Particles/Redistribute/main.cpp
@@ -280,7 +280,7 @@ public:
                 int gid = mfi.index();
                 int tid = mfi.LocalTileIndex();
                 const auto& ptile = plev.at(std::make_pair(gid, tid));
-                const auto ptd = ptile.getConstParticleTileData();
+                const auto& ptd = ptile.getConstParticleTileData();
                 const size_t np = ptile.numParticles();
 
                 AMREX_FOR_1D ( np, i,

--- a/Tests/Particles/RedistributeSOA/main.cpp
+++ b/Tests/Particles/RedistributeSOA/main.cpp
@@ -278,7 +278,7 @@ public:
                 int gid = mfi.index();
                 int tid = mfi.LocalTileIndex();
                 const auto & ptile = plev.at(std::make_pair(gid, tid));
-                const auto ptd = ptile.getConstParticleTileData();
+                const auto& ptd = ptile.getConstParticleTileData();
                 const size_t np = ptile.numParticles();
 
                 AMREX_FOR_1D ( np, i,


### PR DESCRIPTION
This could be more efficient depending on how well a given compiler does RVO.

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
