### PR TITLE
Derive: Add MultiFab version of DeriveFunc

### DIFF
--- a/Src/Amr/AMReX_AmrLevel.cpp
+++ b/Src/Amr/AMReX_AmrLevel.cpp
@@ -1667,6 +1667,10 @@ AmrLevel::derive (const std::string& name, Real time, int ngrow)
                 rec->derFuncFab()(bx, derfab, 0, dncomp, datafab, geom, time, rec->getBC(), level);
             }
         }
+        else if (rec->derFuncMF() != nullptr)
+        {
+            rec->derFuncMF()(*mf, 0, dncomp, srcMF, geom, time, rec->getBC(), level);
+        }
         else
         {
 #ifdef AMREX_USE_OMP
@@ -1778,6 +1782,11 @@ AmrLevel::derive (const std::string& name, Real time, MultiFab& mf, int dcomp)
                 const int dncomp = rec->numDerive();
                 rec->derFuncFab()(bx, derfab, dcomp, dncomp, datafab, geom, time, rec->getBC(), level);
             }
+        }
+        else if (rec->derFuncMF() != nullptr)
+        {
+            const int dncomp = rec->numDerive();
+            rec->derFuncMF()(mf, dcomp, dncomp, srcMF, geom, time, rec->getBC(), level);
         }
         else
         {

--- a/Src/Amr/AMReX_Derive.H
+++ b/Src/Amr/AMReX_Derive.H
@@ -6,6 +6,7 @@
 #include <AMReX_REAL.H>
 #include <AMReX_Box.H>
 #include <AMReX_Interpolater.H>
+#include <AMReX_MultiFab.H>
 
 #include <list>
 #include <string>
@@ -88,6 +89,10 @@ using DeriveFuncFab = std::function<void(const amrex::Box& bx, amrex::FArrayBox&
                                          const amrex::FArrayBox& datafab, const amrex::Geometry& geomdata,
                                          amrex::Real time, const int* bcrec, int level)>;
 
+using DeriveFuncMF = std::function<void(amrex::MultiFab& der_mf, int dcomp, int ncomp,
+                                        const amrex::MultiFab& data_mf, const amrex::Geometry& geomdata,
+                                        amrex::Real time, const int* bcrec, int level)>;
+
 class DescriptorList;
 
 
@@ -149,6 +154,7 @@ public:
     [[nodiscard]] DeriveFunc    derFunc    () const noexcept;
     [[nodiscard]] DeriveFunc3D  derFunc3D  () const noexcept;
     [[nodiscard]] DeriveFuncFab derFuncFab () const noexcept;
+    [[nodiscard]] DeriveFuncMF  derFuncMF () const noexcept;
 
     /**
     * \brief Maps state data box to derived data box.
@@ -227,6 +233,13 @@ public:
                DeriveBoxMap   box_map,
                Interpolater*  interp = &pc_interp);
 
+    DeriveRec (std::string    name,
+               IndexType      result_type,
+               int            nvar_derive,
+               DeriveFuncMF   der_func_mf,
+               DeriveBoxMap   box_map,
+               Interpolater*  interp = &pc_interp);
+
 
     /**
     * \brief Constructor without a Fortran function
@@ -276,6 +289,14 @@ public:
                DeriveBoxMap        box_map,
                Interpolater*       interp = &pc_interp);
 
+    DeriveRec (std::string         name,
+               IndexType           result_type,
+               int                 nvar_derive,
+               Vector<std::string> const& var_names,
+               DeriveFuncMF        der_func_mf,
+               DeriveBoxMap        box_map,
+               Interpolater*       interp = &pc_interp);
+
     void addRange (const DescriptorList& d_list,
                    int                   state_indx,
                    int                   src_comp,
@@ -311,6 +332,7 @@ private:
     DeriveFunc    func = nullptr;
     DeriveFunc3D  func_3d = nullptr;
     DeriveFuncFab func_fab = nullptr;
+    DeriveFuncMF  func_mf = nullptr;
 
     //! Interpolater for mapping crse grid derived data to finer levels.
     Interpolater* mapper = nullptr;
@@ -398,6 +420,12 @@ public:
               const DeriveRec::DeriveBoxMap& bx_map,
               Interpolater*           interp = &pc_interp);
 
+    void add (const std::string&      name,
+              IndexType               result_type,
+              int                     nvar_derive,
+              const DeriveFuncMF&           der_func_mf,
+              const DeriveRec::DeriveBoxMap& bx_map,
+              Interpolater*           interp = &pc_interp);
 
     /**
     * \brief This version doesn't take a Fortran function.
@@ -444,6 +472,14 @@ public:
               int                     nvar_derive,
               Vector<std::string> const&    vars,
               const DeriveFuncFab&           der_func_fab,
+              const DeriveRec::DeriveBoxMap& bx_map,
+              Interpolater*           interp = &pc_interp);
+
+    void add (const std::string&      name,
+              IndexType               res_typ,
+              int                     nvar_derive,
+              Vector<std::string> const&    vars,
+              const DeriveFuncMF&           der_func_mf,
               const DeriveRec::DeriveBoxMap& bx_map,
               Interpolater*           interp = &pc_interp);
 

--- a/Src/Amr/AMReX_Derive.cpp
+++ b/Src/Amr/AMReX_Derive.cpp
@@ -64,6 +64,21 @@ DeriveRec::DeriveRec (std::string    a_name,
     bx_map(std::move(box_map))
 {}
 
+DeriveRec::DeriveRec (std::string    a_name,
+                      IndexType      result_type,
+                      int            nvar_derive,
+                      DeriveFuncMF   der_func_mf,
+                      DeriveBoxMap   box_map,
+                      Interpolater*  a_interp)
+    :
+    derive_name(std::move(a_name)),
+    der_type(result_type),
+    n_derive(nvar_derive),
+    func_mf(std::move(der_func_mf)),
+    mapper(a_interp),
+    bx_map(std::move(box_map))
+{}
+
 // This version doesn't take a Fortran function name, it is entirely defined by the C++
 DeriveRec::DeriveRec (std::string             a_name,
                       IndexType               result_type,
@@ -127,6 +142,23 @@ DeriveRec::DeriveRec (std::string    a_name,
     bx_map(std::move(box_map))
 {}
 
+DeriveRec::DeriveRec (std::string    a_name,
+                      IndexType      result_type,
+                      int            nvar_derive,
+                      Vector<std::string> const& var_names,
+                      DeriveFuncMF   der_func_mf,
+                      DeriveBoxMap   box_map,
+                      Interpolater*  a_interp)
+    :
+    derive_name(std::move(a_name)),
+    variable_names(var_names),
+    der_type(result_type),
+    n_derive(nvar_derive),
+    func_mf(std::move(der_func_mf)),
+    mapper(a_interp),
+    bx_map(std::move(box_map))
+{}
+
 DeriveRec::~DeriveRec ()
 {
    delete [] bcr;
@@ -134,6 +166,7 @@ DeriveRec::~DeriveRec ()
    func     = nullptr;
    func_3d  = nullptr;
    func_fab = nullptr;
+   func_mf  = nullptr;
    mapper   = nullptr;
    bx_map   = nullptr;
    while (rng != nullptr)
@@ -172,6 +205,12 @@ DeriveFuncFab
 DeriveRec::derFuncFab () const noexcept
 {
     return func_fab;
+}
+
+DeriveFuncMF
+DeriveRec::derFuncMF () const noexcept
+{
+    return func_mf;
 }
 
 DeriveRec::DeriveBoxMap
@@ -368,6 +407,17 @@ DeriveList::add (const std::string&      name,
     lst.emplace_back(name,result_type,nvar_der,der_func_fab,bx_map,interp);
 }
 
+void
+DeriveList::add (const std::string&      name,
+                 IndexType               result_type,
+                 int                     nvar_der,
+                 const DeriveFuncMF&     der_func_mf,
+                 const DeriveRec::DeriveBoxMap& bx_map,
+                 Interpolater*           interp)
+{
+    lst.emplace_back(name,result_type,nvar_der,der_func_mf,bx_map,interp);
+}
+
 // This version doesn't take a Fortran function name, it is entirely defined by the C++
 void
 DeriveList::add (const std::string&      name,
@@ -412,6 +462,18 @@ DeriveList::add (const std::string&      name,
                  Interpolater*           interp)
 {
     lst.emplace_back(name,res_typ,nvar_der,vars,der_func_fab,bx_map,interp);
+}
+
+void
+DeriveList::add (const std::string&      name,
+                 IndexType               res_typ,
+                 int                     nvar_der,
+                 Vector<std::string> const&    vars,
+                 const DeriveFuncMF&     der_func_mf,
+                 const DeriveRec::DeriveBoxMap& bx_map,
+                 Interpolater*           interp)
+{
+    lst.emplace_back(name,res_typ,nvar_der,vars,der_func_mf,bx_map,interp);
 }
 
 std::list<DeriveRec>&


### PR DESCRIPTION
## Summary

This adds a new type of `DeriveFunc` which uses `MultiFab`s rather than `FArrayBox`es.

## Additional background

This allows the user to use the MultiFab version of `ParallelFor` to compute derived quantities.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
