### PR TITLE
GNU Make: Add support for CUDA LTO

### DIFF
--- a/Tools/GNUMake/Make.defs
+++ b/Tools/GNUMake/Make.defs
@@ -267,6 +267,9 @@ ifeq ($(USE_CUDA),TRUE)
   # Limit the maximum number of registers available.
   CUDA_MAXREGCOUNT ?= 255
 
+  # Link-time optimization
+  CUDA_LTO ?= FALSE
+
   # Enable verbosity in the CUDA compilation.
   CUDA_VERBOSE ?= TRUE
 endif
@@ -1176,7 +1179,7 @@ else ifeq ($(USE_CUDA),TRUE)
     endif
 
     ifneq ($(LINK_WITH_FORTRAN_COMPILER),TRUE)
-      LINKFLAGS = $(NVCC_FLAGS) $(CXXFLAGS_FROM_HOST)
+      LINKFLAGS = $(NVCC_FLAGS) $(NVCC_ARCH_LINK_FLAGS) $(CXXFLAGS_FROM_HOST)
       AMREX_LINKER = nvcc
     endif
 


### PR DESCRIPTION
## Summary

Pretty much as in the title. This is controlled with the `CUDA_LTO` makefile variable which defaults to `FALSE`.

## Additional background

This was added for CMake in #1095

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
