### PR TITLE
New CMake option: AMReX_CCACHE

### DIFF
--- a/.github/workflows/cleanup-cache.yml
+++ b/.github/workflows/cleanup-cache.yml
@@ -2,7 +2,7 @@ name: CleanUpCache
 
 on:
   workflow_run:
-    workflows: [bittree, LinuxClang, cuda, LinuxGcc, hip, Hypre, intel, macos, PETSc, SUNDIALS, CodeQL, smoke, apps]
+    workflows: [bittree, LinuxClang, cuda, LinuxGcc, hip, Hypre, intel, macos, PETSc, SUNDIALS, CodeQL, smoke, apps, windows]
     types:
       - completed
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -13,45 +13,44 @@ jobs:
     runs-on: windows-latest
     steps:
     - uses: actions/checkout@v4
-    #- name: Set Up Cache
-    #  uses: actions/cache@v3
-    #  with:
-    #    path: ~/.ccache
-    #    key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}
-    #    restore-keys: |
-    #         ccache-${{ github.workflow }}-${{ github.job }}-git-
-    #- name: Install Ccache
-    #  run: |
-    #    Invoke-WebRequest https://github.com/ccache/ccache/releases/download/v4.8/ccache-4.8-windows-x86_64.zip -OutFile ccache-4.8-windows-x86_64.zip
-    #    Expand-Archive ccache-4.8-windows-x86_64.zip
+    - name: Set Up Cache
+      uses: actions/cache@v4
+      with:
+        path: ~/.ccache
+        key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}
+        restore-keys: |
+             ccache-${{ github.workflow }}-${{ github.job }}-git-
+    - name: Install Ccache
+      run: |
+        Invoke-WebRequest -Uri "https://github.com/ccache/ccache/releases/download/v4.10/ccache-4.10-windows-x86_64.zip" -OutFile ccache.zip
+        Expand-Archive -Path ccache.zip -DestinationPath "ccache"
+        $ccachePath = Join-Path $pwd "ccache/ccache-4.10-windows-x86_64"
+        echo $ccachePath >> $Env:GITHUB_PATH
     - name: Build & Install
       run: |
-        #$ccachepath = Join-Path $pwd "ccache-4.8-windows-x86_64"
-        #$Env:PATH += ";$ccachepath"
-        #$ccachecachedir = Join-Path $HOME ".ccache"
-        #$Env:CCACHE_DIR="$ccachecachedir"
-        #$Env:CCACHE_DIR
-        #$Env:CCACHE_COMPRESS='1'
-        #$Env:CCACHE_COMPRESSLEVEL='10'
-        #$Env:CCACHE_MAXSIZE='105M'
-        #ccache -z
+        $ccachecachedir = Join-Path $HOME ".ccache"
+        $Env:CCACHE_DIR="$ccachecachedir"
+        $Env:CCACHE_COMPRESS='1'
+        $Env:CCACHE_COMPRESSLEVEL='10'
+        $Env:CCACHE_MAXSIZE='50M'
+        ccache -z
 
         cmake -S . -B build   `
               -DBUILD_SHARED_LIBS=ON        `
+              -DCMAKE_BUILD_TYPE=Release    `
               -DCMAKE_VERBOSE_MAKEFILE=ON   `
               -DAMReX_EB=OFF                `
               -DAMReX_ENABLE_TESTS=ON       `
               -DAMReX_FORTRAN=OFF           `
-              -DAMReX_MPI=OFF
-              #-DCMAKE_CXX_COMPILER_LAUNCHER=ccache
-        cmake --build build --config Debug -j 4
+              -DAMReX_MPI=OFF               `
+              -DAMReX_CCACHE=ON
 
-        cmake --build build --config Debug --target install
+        cmake --build build --target install
 
         $Env:PATH += ";D:\\a\amrex\amrex\installdir\bin"
-        cmake --build build --config Debug --target test_install
+        cmake --build build --target test_install
 
-        #ccache -s
+        ccache -s -v
 
   # Build libamrex and all test (static)
   test_msvc_static:
@@ -59,27 +58,27 @@ jobs:
     runs-on: windows-latest
     steps:
     - uses: actions/checkout@v4
-    #- name: Set Up Cache
-    #  uses: actions/cache@v3
-    #  with:
-    #    path: ~/.ccache
-    #    key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}
-    #    restore-keys: |
-    #         ccache-${{ github.workflow }}-${{ github.job }}-git-
-    #- name: Install Ccache
-    #  run: |
-    #    Invoke-WebRequest https://github.com/ccache/ccache/releases/download/v4.8/ccache-4.8-windows-x86_64.zip -OutFile ccache-4.8-windows-x86_64.zip
-    #    Expand-Archive ccache-4.8-windows-x86_64.zip
+    - name: Set Up Cache
+      uses: actions/cache@v4
+      with:
+        path: ~/.ccache
+        key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}
+        restore-keys: |
+             ccache-${{ github.workflow }}-${{ github.job }}-git-
+    - name: Install Ccache
+      run: |
+        Invoke-WebRequest -Uri "https://github.com/ccache/ccache/releases/download/v4.10/ccache-4.10-windows-x86_64.zip" -OutFile ccache.zip
+        Expand-Archive -Path ccache.zip -DestinationPath "ccache"
+        $ccachePath = Join-Path $pwd "ccache/ccache-4.10-windows-x86_64"
+        echo $ccachePath >> $Env:GITHUB_PATH
     - name: Build & Install
       run: |
-        #$ccachepath = Join-Path $pwd "ccache-4.8-windows-x86_64"
-        #$Env:PATH += ";$ccachepath"
-        #$ccachecachedir = Join-Path $HOME ".ccache"
-        #$Env:CCACHE_DIR="$ccachecachedir"
-        #$Env:CCACHE_COMPRESS='1'
-        #$Env:CCACHE_COMPRESSLEVEL='10'
-        #$Env:CCACHE_MAXSIZE='135M'
-        #ccache -z
+        $ccachecachedir = Join-Path $HOME ".ccache"
+        $Env:CCACHE_DIR="$ccachecachedir"
+        $Env:CCACHE_COMPRESS='1'
+        $Env:CCACHE_COMPRESSLEVEL='10'
+        $Env:CCACHE_MAXSIZE='200M'
+        ccache -z
 
         # -DCMAKE_CXX_FLAGS=" /D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR" `
         # is a workaround github windows runner 20240603.1.0.
@@ -87,18 +86,20 @@ jobs:
 
         cmake -S . -B build   `
               -DCMAKE_VERBOSE_MAKEFILE=ON   `
+              -DCMAKE_BUILD_TYPE=Release    `
               -DCMAKE_CXX_FLAGS=" /D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR" `
               -DAMReX_EB=ON                 `
               -DAMReX_ENABLE_TESTS=ON       `
               -DAMReX_FORTRAN=OFF           `
-              -DAMReX_MPI=OFF
-              #-DCMAKE_CXX_COMPILER_LAUNCHER=ccache
-        cmake --build build --config RelWithDebInfo -j 4
+              -DAMReX_MPI=OFF               `
+              -DAMReX_CCACHE=ON
 
-        cmake --build build --config RelWithDebInfo --target install
-        cmake --build build --config RelWithDebInfo --target test_install
+        cmake --build build -j 4
 
-        #ccache -s
+        cmake --build build --target install
+        cmake --build build --target test_install
+
+        ccache -s -v
 
   # Build libamrex and all tests
   tests_clang:
@@ -134,18 +135,17 @@ jobs:
         set "PATH=%PATH%;D:\\a\amrex\amrex\installdir\bin"
         cmake --build build --config Release --target test_install
 
-  # If we add ccache back, don't forget to update cleanup-cache.yml
-  #save_pr_number:
-  #  if: github.event_name == 'pull_request'
-  #  runs-on: ubuntu-latest
-  #  steps:
-  #    - name: Save PR number
-  #      env:
-  #        PR_NUMBER: ${{ github.event.number }}
-  #      run: |
-  #        echo $PR_NUMBER > pr_number.txt
-  #    - uses: actions/upload-artifact@v3
-  #      with:
-  #        name: pr_number
-  #        path: pr_number.txt
-  #        retention-days: 1
+  save_pr_number:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Save PR number
+        env:
+          PR_NUMBER: ${{ github.event.number }}
+        run: |
+          echo $PR_NUMBER > pr_number.txt
+      - uses: actions/upload-artifact@v4
+        with:
+          name: pr_number
+          path: pr_number.txt
+          retention-days: 1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,6 +102,14 @@ endif()
 include( AMReXOptions )
 
 #
+# CCache
+#
+include(AMReXCCache)
+if (AMReX_CCACHE)
+   setup_ccache()
+endif()
+
+#
 # Enable CUDA if requested
 #
 if (AMReX_CUDA)

--- a/Tools/CMake/AMReXCCache.cmake
+++ b/Tools/CMake/AMReXCCache.cmake
@@ -1,0 +1,32 @@
+macro(setup_ccache)
+    find_program(AMReX_CCACHE_EXE ccache)
+    if (AMReX_CCACHE_EXE)
+        message(STATUS "Found CCache: ${AMReX_CCACHE_EXE}")
+        set(CMAKE_CXX_COMPILER_LAUNCHER "${AMReX_CCACHE_EXE}")
+        if (AMREX_GPU_BACKEND STREQUAL CUDA)
+            set(CMAKE_CUDA_COMPILER_LAUNCHER "${AMReX_CCACHE_EXE}")
+        endif()
+	if (MSVC AND (CMAKE_GENERATOR MATCHES "Visual Studio"))
+            # https://github.com/ccache/ccache/wiki/MS-Visual-Studio#usage-with-cmake
+            file(COPY_FILE
+                 ${AMReX_CCACHE_EXE} ${CMAKE_BINARY_DIR}/cl.exe
+                 ONLY_IF_DIFFERENT)
+
+            # By default Visual Studio generators will use /Zi which is not compatible
+            # with ccache, so tell Visual Studio to use /Z7 instead.
+            message(STATUS "Setting MSVC debug information format to 'Embedded'")
+            set(CMAKE_MSVC_DEBUG_INFORMATION_FORMAT "$<$<CONFIG:Debug,RelWithDebInfo>:Embedded>")
+
+            set(CMAKE_VS_GLOBALS
+              "CLToolExe=cl.exe"
+              "CLToolPath=${CMAKE_BINARY_DIR}"
+              "TrackFileAccess=false"
+              "UseMultiToolTask=true"
+              "DebugInformationFormat=OldStyle"
+            )
+        endif()
+    else()
+        message(WARNING "AMReX_CCACHE was enabled, but ccache was not found.")
+    endif()
+    mark_as_advanced(AMReX_CCACHE_EXE)
+endmacro(setup_ccache)

--- a/Tools/CMake/AMReXOptions.cmake
+++ b/Tools/CMake/AMReXOptions.cmake
@@ -484,6 +484,12 @@ cmake_dependent_option(AMReX_CLANG_TIDY_WERROR "Treat clang-tidy warnings as err
 print_option(AMReX_CLANG_TIDY_WERROR)
 
 #
+# CCache  =============================================================
+#
+option(AMReX_CCACHE "Enable CCache" OFF)
+print_option(AMReX_CCACHE)
+
+#
 # Tests  =============================================================
 #
 option(AMReX_ENABLE_TESTS "Enable CTest suite for AMReX" NO)


### PR DESCRIPTION
Add a new CMake option, AMReX_CCACHE[=OFF].

Enable ccache in a Windows CI that used to take about 1.5 hours. With ccache, it reduces to xxx.
