### PR TITLE
GNU Make: try nvidia-smi for CUDA arch if deviceQuery fails

### DIFF
--- a/Tools/GNUMake/sites/Make.unknown
+++ b/Tools/GNUMake/sites/Make.unknown
@@ -90,7 +90,12 @@ ifeq ($(USE_CUDA),TRUE)
   COMPILE_CUDA_PATH = $(CUDA_HOME)
   SYSTEM_CUDA_PATH = $(CUDA_HOME)
 
-  cuda_device_query_result := $(shell $(CUDA_HOME)/extras/demo_suite/deviceQuery | grep "CUDA Capability")
+  ifneq ($(wildcard $(CUDA_HOME)/extras/demo_suite/deviceQuery),)
+     cuda_device_query_result := $(shell $(CUDA_HOME)/extras/demo_suite/deviceQuery | grep "CUDA Capability")
+  else
+     # try nvidia-smi, as deviceQuery is no longer distributed with CUDA 12 and up
+     cuda_device_query_result := $(shell nvidia-smi --query-gpu=compute_cap --format=csv,noheader)
+  endif
   ifneq ($(cuda_device_query_result),)
      TEMP_CUDA_ARCH = $(lastword $(cuda_device_query_result))
 #      CUDA_ARCH = $(subst .,,$(TEMP_CUDA_ARCH))


### PR DESCRIPTION
## Summary

I recently updated my local workstation, and found that CUDA compilation wasn't working properly due to `CUDA_ARCH` not being detected properly. It turns out the `deviceQuery` utility is no longer distributed with the toolkit since CUDA 12 or so. `nvidia-smi` can get that info, so we can fall back to that if deviceQuery isn't present.

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
