### PR TITLE
Workaround MSVC issue in tupleToArray

### DIFF
--- a/Src/Base/AMReX_Tuple.H
+++ b/Src/Base/AMReX_Tuple.H
@@ -472,12 +472,12 @@ auto tupleToArray (GpuTuple<T> const& tup)
     return GpuArray<T,1>{amrex::get<0>(tup)};
 }
 
-//! Convert GpuTuple<T,Ts...> to GpuArray
-template <typename T, typename... Ts, std::enable_if_t<Same<T,Ts...>::value, int> = 0>
+//! Convert GpuTuple<T,T2,Ts...> to GpuArray
+template <typename T, typename T2, typename... Ts, std::enable_if_t<Same<T,T2,Ts...>::value, int> = 0>
 AMREX_GPU_HOST_DEVICE constexpr
-auto tupleToArray (GpuTuple<T,Ts...> const& tup)
+auto tupleToArray (GpuTuple<T,T2,Ts...> const& tup)
 {
-    return detail::tuple_to_array_helper(tup, std::index_sequence_for<T,Ts...>{});
+    return detail::tuple_to_array_helper(tup, std::index_sequence_for<T,T2,Ts...>{});
 }
 
 } // namespace amrex


### PR DESCRIPTION
## Summary

MSVC couldn't compile the old version of tupleToArray if the tuple only had one element.

## Additional background

See https://godbolt.org/z/bYqhGco99 and https://github.com/Hi-PACE/hipace/pull/1126

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
