### PR TITLE
HDF5: Correctly handle writing only some components when writing Particle

### DIFF
--- a/Src/Extern/HDF5/AMReX_ParticleHDF5.H
+++ b/Src/Extern/HDF5/AMReX_ParticleHDF5.H
@@ -704,20 +704,34 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
     hid_t          int_mem_space, int_dset_id, int_dset_space;
     hsize_t        total_mfi = 0, total_real_size = 0, total_int_size = 0, real_file_offset = 0, int_file_offset = 0;
     hsize_t        my_int_offset, my_int_count, my_real_offset, my_real_count;
+    
+    // Count total number of components written
+    int real_comp_count = AMREX_SPACEDIM; // position values
 
+    for (int i = 0; i < NStructReal + NumRealComps(); ++i ) {
+        if (write_real_comp[i]) { ++real_comp_count; }
+    }
+    
+    int int_comp_count = 2; // cpu and id values
+
+    for (int i = 0; i < NStructInt + NumIntComps(); ++i ) {
+        if (write_int_comp[i]) { ++int_comp_count; }
+    }
+    
     // Get the size for each mf so we know the amount of data from each rank
     for (MFIter mfi(state); mfi.isValid(); ++mfi) {
         const int grid = mfi.index();
         if (count[grid] == 0)
             continue;
 
-        int_size  = count[grid] * (2 + NStructInt + NumIntComps());
+        // int_size  = count[grid] * (2 + NStructInt + NumIntComps());
+        int_size  = count[grid] * int_comp_count;
         my_mfi_int_size.push_back(int_size);
         my_nparticles.push_back(count[grid]);
         my_mfi_int_total_size += int_size;
 
 
-        real_size = count[grid] * (AMREX_SPACEDIM + NStructReal + NumRealComps());
+        real_size = count[grid] * real_comp_count;
         my_mfi_real_size.push_back(real_size);
         my_mfi_real_total_size += real_size;
         my_mfi_cnt++;

--- a/Src/Extern/HDF5/AMReX_ParticleHDF5.H
+++ b/Src/Extern/HDF5/AMReX_ParticleHDF5.H
@@ -724,8 +724,7 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
         if (count[grid] == 0)
             continue;
 
-        // int_size  = count[grid] * (2 + NStructInt + NumIntComps());
-        int_size  = count[grid] * int_comp_count;
+        int_size = count[grid] * int_comp_count;
         my_mfi_int_size.push_back(int_size);
         my_nparticles.push_back(count[grid]);
         my_mfi_int_total_size += int_size;

--- a/Src/Extern/HDF5/AMReX_ParticleHDF5.H
+++ b/Src/Extern/HDF5/AMReX_ParticleHDF5.H
@@ -704,20 +704,20 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
     hid_t          int_mem_space, int_dset_id, int_dset_space;
     hsize_t        total_mfi = 0, total_real_size = 0, total_int_size = 0, real_file_offset = 0, int_file_offset = 0;
     hsize_t        my_int_offset, my_int_count, my_real_offset, my_real_count;
-    
+
     // Count total number of components written
     int real_comp_count = AMREX_SPACEDIM; // position values
 
     for (int i = 0; i < NStructReal + NumRealComps(); ++i ) {
         if (write_real_comp[i]) { ++real_comp_count; }
     }
-    
+
     int int_comp_count = 2; // cpu and id values
 
     for (int i = 0; i < NStructInt + NumIntComps(); ++i ) {
         if (write_int_comp[i]) { ++int_comp_count; }
     }
-    
+
     // Get the size for each mf so we know the amount of data from each rank
     for (MFIter mfi(state); mfi.isValid(); ++mfi) {
         const int grid = mfi.index();

--- a/Src/Extern/HDF5/AMReX_WriteBinaryParticleDataHDF5.H
+++ b/Src/Extern/HDF5/AMReX_WriteBinaryParticleDataHDF5.H
@@ -290,15 +290,15 @@ void WriteHDF5ParticleDataSync (PC const& pc,
 
         char comp_name[128];
         
-	// Real component names
-	int comp_idx = 0;
+        // Real component names
+        int real_comp_count = AMREX_SPACEDIM; // position values
 
         for (int i = 0; i < NStructReal + pc.NumRealComps(); ++i ) {
             if (write_real_comp[i]) {
                 /* HdrFile << real_comp_names[i] << '\n'; */
-                snprintf(comp_name, sizeof comp_name, "real_component_%d", comp_idx);
+                snprintf(comp_name, sizeof comp_name, "real_component_%d", real_comp_count);
                 CreateWriteHDF5AttrString(fid, comp_name, real_comp_names[i].c_str());
-		++comp_idx;
+                ++real_comp_count;
             }
         }
 
@@ -306,13 +306,13 @@ void WriteHDF5ParticleDataSync (PC const& pc,
         CreateWriteHDF5Attr(fid, "num_component_int", 1, &num_output_int, H5T_NATIVE_INT);
 	
         // int component names
-        comp_idx = 0;
+        int int_comp_count = 2;
 	
-	for (int i = 0; i < NStructInt + pc.NumIntComps(); ++i ) {
+        for (int i = 0; i < NStructInt + pc.NumIntComps(); ++i ) {
             if (write_int_comp[i]) {
-                snprintf(comp_name, sizeof comp_name, "int_component_%d", comp_idx);
+                snprintf(comp_name, sizeof comp_name, "int_component_%d", int_comp_count);
                 CreateWriteHDF5AttrString(fid, comp_name, int_comp_names[i].c_str());
-		++comp_idx;
+                ++int_comp_count;
             }
         }
 

--- a/Src/Extern/HDF5/AMReX_WriteBinaryParticleDataHDF5.H
+++ b/Src/Extern/HDF5/AMReX_WriteBinaryParticleDataHDF5.H
@@ -304,10 +304,10 @@ void WriteHDF5ParticleDataSync (PC const& pc,
 
         // The number of extra int parameters
         CreateWriteHDF5Attr(fid, "num_component_int", 1, &num_output_int, H5T_NATIVE_INT);
-	
+
         // int component names
         int int_comp_count = 2;
-	
+
         for (int i = 0; i < NStructInt + pc.NumIntComps(); ++i ) {
             if (write_int_comp[i]) {
                 snprintf(comp_name, sizeof comp_name, "int_component_%d", int_comp_count);

--- a/Src/Extern/HDF5/AMReX_WriteBinaryParticleDataHDF5.H
+++ b/Src/Extern/HDF5/AMReX_WriteBinaryParticleDataHDF5.H
@@ -289,23 +289,30 @@ void WriteHDF5ParticleDataSync (PC const& pc,
         CreateWriteHDF5Attr(fid, "num_component_real", 1, &num_output_real, H5T_NATIVE_INT);
 
         char comp_name[128];
-        // Real component names
+        
+	// Real component names
+	int comp_idx = 0;
+
         for (int i = 0; i < NStructReal + pc.NumRealComps(); ++i ) {
             if (write_real_comp[i]) {
                 /* HdrFile << real_comp_names[i] << '\n'; */
-                snprintf(comp_name, sizeof comp_name, "real_component_%d", i);
+                snprintf(comp_name, sizeof comp_name, "real_component_%d", comp_idx);
                 CreateWriteHDF5AttrString(fid, comp_name, real_comp_names[i].c_str());
+		++comp_idx;
             }
         }
 
         // The number of extra int parameters
         CreateWriteHDF5Attr(fid, "num_component_int", 1, &num_output_int, H5T_NATIVE_INT);
-
+	
         // int component names
-        for (int i = 0; i < NStructInt + pc.NumIntComps(); ++i ) {
+        comp_idx = 0;
+	
+	for (int i = 0; i < NStructInt + pc.NumIntComps(); ++i ) {
             if (write_int_comp[i]) {
-                snprintf(comp_name, sizeof comp_name, "int_component_%d", i);
+                snprintf(comp_name, sizeof comp_name, "int_component_%d", comp_idx);
                 CreateWriteHDF5AttrString(fid, comp_name, int_comp_names[i].c_str());
+		++comp_idx;
             }
         }
 

--- a/Src/Extern/HDF5/AMReX_WriteBinaryParticleDataHDF5.H
+++ b/Src/Extern/HDF5/AMReX_WriteBinaryParticleDataHDF5.H
@@ -289,7 +289,7 @@ void WriteHDF5ParticleDataSync (PC const& pc,
         CreateWriteHDF5Attr(fid, "num_component_real", 1, &num_output_real, H5T_NATIVE_INT);
 
         char comp_name[128];
-        
+
         // Real component names
         int real_comp_count = AMREX_SPACEDIM; // position values
 


### PR DESCRIPTION
## Summary
Correctly names file attribute to match component index with dataset index and correctly calculates size of each particle's data so that the dataset is aligned.
## Additional background
Previously, all components of a particle were being counted, whether written or not, leading to misalignment across different processes when writing.
## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
