### PR TITLE
Fix L2 norms in C_util/Convergence codes

### DIFF
--- a/Tools/C_util/Convergence/DiffSameDomainRefined.cpp
+++ b/Tools/C_util/Convergence/DiffSameDomainRefined.cpp
@@ -245,7 +245,7 @@ main (int   argc,
 
                     if (norm != 0)
                     {
-                        norms[iComp] = norms[iComp] + pow(grdL2, norm);
+                        norms[iComp] = norms[iComp] + grdL2;
                     }
                     else
                     {

--- a/Tools/C_util/Convergence/DiffSameDomainRefinedComposite.cpp
+++ b/Tools/C_util/Convergence/DiffSameDomainRefinedComposite.cpp
@@ -269,7 +269,7 @@ main (int   argc,
 
                     if (norm != 0)
                     {
-                        norms[iComp] = norms[iComp] + pow(grdL2, norm);
+                        norms[iComp] = norms[iComp] + grdL2;
                     }
                     else
                     {

--- a/Tools/C_util/Convergence/DiffSameDomainRefinedFD.cpp
+++ b/Tools/C_util/Convergence/DiffSameDomainRefinedFD.cpp
@@ -245,7 +245,7 @@ main (int   argc,
 
                     if (norm != 0)
                     {
-                        norms[iComp] = norms[iComp] + pow(grdL2, norm);
+                        norms[iComp] = norms[iComp] + grdL2;
                     }
                     else
                     {

--- a/Tools/C_util/Convergence/DiffSameDomainRefinedStag.cpp
+++ b/Tools/C_util/Convergence/DiffSameDomainRefinedStag.cpp
@@ -272,7 +272,7 @@ main (int   argc,
 
                     if (norm != 0)
                     {
-                        norms[iComp] = norms[iComp] + pow(grdL2, norm);
+                        norms[iComp] = norms[iComp] + grdL2;
                     }
                     else
                     {

--- a/Tools/C_util/Convergence/DiffSameGridRefined.cpp
+++ b/Tools/C_util/Convergence/DiffSameGridRefined.cpp
@@ -238,7 +238,7 @@ main (int   argc,
 
                     if (norm != 0)
                     {
-                        norms[iComp] = norms[iComp] + pow(grdL2, norm);
+                        norms[iComp] = norms[iComp] + grdL2;
                     }
                     else
                     {

--- a/Tools/C_util/Convergence/PltFileNormB.cpp
+++ b/Tools/C_util/Convergence/PltFileNormB.cpp
@@ -131,7 +131,7 @@ main (int   argc,
 
                     if (norm != 0)
                     {
-                        norms[iComp] = norms[iComp] + pow(grdL2, norm);
+                        norms[iComp] = norms[iComp] + grdL2;
                     }
                     else
                     {

--- a/Tools/C_util/Convergence/RichardsonConvergenceTest.cpp
+++ b/Tools/C_util/Convergence/RichardsonConvergenceTest.cpp
@@ -306,7 +306,7 @@ getErrorNorms(Vector<Real>& a_norms, //one for each comp
 
         if (norm != 0)
         {
-          norms[iComp] = norms[iComp] + pow(grdL2, norm);
+           norms[iComp] = norms[iComp] + grdL2;
         }
         else
         {


### PR DESCRIPTION
## Summary

The multifab L2 norm routines simply return sum(a dot a). Thus, when you sum up norms from each grid you do NOT need to take them to the ^NORM power. The cell count (i.e. volume) scaling is performed lower

The formula is now implemented correctly, for p!=0:

L^p = ( 1/Ncell sum (phi_f - phi_c)^p ) ^(1/p)

(note that using cell volume instead of 1/Ncell accomplishes the proper scaling as well, which is what the code does)

## Additional background

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
