### PR TITLE
Change Windows CI build type

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -87,16 +87,17 @@ jobs:
 
         cmake -S . -B build   `
               -DCMAKE_VERBOSE_MAKEFILE=ON   `
+              -DCMAKE_BUILD_TYPE=RelWithDebInfo `
               -DCMAKE_CXX_FLAGS=" /D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR" `
               -DAMReX_EB=ON                 `
               -DAMReX_ENABLE_TESTS=ON       `
               -DAMReX_FORTRAN=OFF           `
               -DAMReX_MPI=OFF
               #-DCMAKE_CXX_COMPILER_LAUNCHER=ccache
-        cmake --build build --config RelWithDebInfo -j 4
+        cmake --build build -j 4
 
-        cmake --build build --config RelWithDebInfo --target install
-        cmake --build build --config RelWithDebInfo --target test_install
+        cmake --build build --target install
+        cmake --build build --target test_install
 
         #ccache -s
 


### PR DESCRIPTION
In one of the Windows CI, we use `cmake --build build --config RelWithDebInfo`. This seems to suggest that the build type is `RelWithDebInfo`. However, for reasons we don't understand, that's not the case. In @ax3l's words,

> Usually, VS Studio (and a few other generators) are multi-config generators. That means their "makefiles" are configured to be able to build Debug/Release/RelWithDebInfo/etc. all at the same time in the build phase. Generally, that means we have to pass --config ... to the build and install step and -DCMAKE_BUILD_TYPE cannot be passed to the configure step.

Anyway, if we make the changes in this PR (i.e., setting CMAKE_BUILD_TYPE), the build type does become `RelWithDebInfo`. Furthermore, the CI time went down from 1.5 hours to 6 minutes.

Below is the diff of compiler flags used.
```
7,8c7,8
< /Od
< /Ob0
---
> /O2
> /Ob1
10a11
> /D NDEBUG
12c13
< /D "CMAKE_INTDIR=\"Debug\""
---
> /D "CMAKE_INTDIR=\"RelWithDebInfo\""
15,16c16
< /RTC1
< /MDd
---
> /MD
23,24c23,24
< /Fo"amrex_3d.dir\Debug\\"
< /Fd"D:\a\amrex\amrex\build\Src\Debug\amrex_3d.pdb"
---
> /Fo"amrex_3d.dir\RelWithDebInfo\\"
> /Fd"D:\a\amrex\amrex\build\Src\RelWithDebInfo\amrex_3d.pdb"
```
