### PR TITLE
HDF5: Fix chunking warning (#4033)

### DIFF
--- a/Src/Extern/HDF5/AMReX_ParticleHDF5.H
+++ b/Src/Extern/HDF5/AMReX_ParticleHDF5.H
@@ -765,9 +765,11 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
 /* #endif */
 
     hsize_t chunk_size;
-    if (H5Pget_chunk(dcpl_int, 1, &chunk_size) > -1) {
-        if ((int)chunk_size > total_int_size) {
-            H5Pset_chunk(dcpl_int, 1, &total_int_size);
+    if (H5Pget_layout(dcpl_int) == H5D_CHUNKED) {
+        if (H5Pget_chunk(dcpl_int, 1, &chunk_size) > -1) {
+            if ((int)chunk_size > total_int_size) {
+                H5Pset_chunk(dcpl_int, 1, &total_int_size);
+            }
         }
     }
 
@@ -806,10 +808,11 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
         }
     }
 #endif
-
-    if (H5Pget_chunk(dcpl_real, 1, &chunk_size) > -1) {
-        if ((int)chunk_size > total_real_size) {
-            H5Pset_chunk(dcpl_real, 1, &total_real_size);
+    if (H5Pget_layout(dcpl_real) == H5D_CHUNKED) {
+        if (H5Pget_chunk(dcpl_real, 1, &chunk_size) > -1) {
+            if ((int)chunk_size > total_real_size) {
+                H5Pset_chunk(dcpl_real, 1, &total_real_size);
+            }
         }
     }
 

--- a/Src/Extern/HDF5/AMReX_PlotFileUtilHDF5.cpp
+++ b/Src/Extern/HDF5/AMReX_PlotFileUtilHDF5.cpp
@@ -720,10 +720,12 @@ void WriteMultiLevelPlotfileHDF5SingleDset (const std::string& plotfilename,
 #endif
 
         // Force maximum chunk size to be size of write
-        hsize_t chunk_size;
-        if (H5Pget_chunk(lev_dcpl_id, 1, &chunk_size) > -1) {
-            if ((int)chunk_size > hs_allprocsize[0]) {
-                H5Pset_chunk(lev_dcpl_id, 1, hs_allprocsize);
+        if (H5Pget_layout(lev_dcpl_id) == H5D_CHUNKED) {
+            if (H5Pget_chunk(lev_dcpl_id, 1, &chunk_size) > -1) {
+                hsize_t chunk_size;
+                if ((int)chunk_size > hs_allprocsize[0]) {
+                    H5Pset_chunk(lev_dcpl_id, 1, hs_allprocsize);
+                }
             }
         }
 
@@ -1190,10 +1192,12 @@ void WriteMultiLevelPlotfileHDF5MultiDset (const std::string& plotfilename,
             hid_t dataspace    = H5Screate_simple(1, hs_allprocsize, NULL);
             snprintf(dataname, sizeof dataname, "data:datatype=%d", jj);
             // Force maximum chunk size to be size of write
-            hsize_t chunk_size;
-            if (H5Pget_chunk(lev_dcpl_id, 1, &chunk_size) > -1) {
-                if ((int)chunk_size > hs_allprocsize[0]) {
-                    H5Pset_chunk(lev_dcpl_id, 1, hs_allprocsize);
+            if (H5Pget_layout(lev_dcpl_id) == H5D_CHUNKED) {
+                hsize_t chunk_size;
+                if (H5Pget_chunk(lev_dcpl_id, 1, &chunk_size) > -1) {
+                    if ((int)chunk_size > hs_allprocsize[0]) {
+                        H5Pset_chunk(lev_dcpl_id, 1, hs_allprocsize);
+                    }
                 }
             }
 #ifdef AMREX_USE_HDF5_ASYNC

--- a/Src/Extern/HDF5/AMReX_PlotFileUtilHDF5.cpp
+++ b/Src/Extern/HDF5/AMReX_PlotFileUtilHDF5.cpp
@@ -721,8 +721,8 @@ void WriteMultiLevelPlotfileHDF5SingleDset (const std::string& plotfilename,
 
         // Force maximum chunk size to be size of write
         if (H5Pget_layout(lev_dcpl_id) == H5D_CHUNKED) {
+            hsize_t chunk_size;
             if (H5Pget_chunk(lev_dcpl_id, 1, &chunk_size) > -1) {
-                hsize_t chunk_size;
                 if ((int)chunk_size > hs_allprocsize[0]) {
                     H5Pset_chunk(lev_dcpl_id, 1, hs_allprocsize);
                 }


### PR DESCRIPTION
## Summary
Fixes #4033, where chunk value is read regardless of storage format.

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
