### PR TITLE
Geometry: Fix operator>>

### DIFF
--- a/Src/Base/AMReX_Geometry.H
+++ b/Src/Base/AMReX_Geometry.H
@@ -440,6 +440,8 @@ private:
 
     //
     Box     domain;
+
+    friend std::istream& operator>> (std::istream&, Geometry&);
 };
 
 

--- a/Src/Base/AMReX_Geometry.cpp
+++ b/Src/Base/AMReX_Geometry.cpp
@@ -26,11 +26,9 @@ std::istream&
 operator>> (std::istream& is,
             Geometry&     g)
 {
-    Box     bx;
-    RealBox rb;
-    is >> (CoordSys&) g >> rb >> bx;
-    g.Domain(bx);
-    g.ProbDomain(rb);
+    is >> (CoordSys&) g >> g.prob_domain >> g.domain;
+
+    g.computeRoundoffDomain();
 
     int ic = is.peek();
     if (ic == static_cast<int>('P')) {


### PR DESCRIPTION
We cannot use Geometry::Domain in operator>> because it in turn calls Geometry::computeRoundoffDomain before prob_domain is set.
