### PR TITLE
IParser: Use long long int

### DIFF
--- a/Docs/sphinx_documentation/source/Basics.rst
+++ b/Docs/sphinx_documentation/source/Basics.rst
@@ -453,7 +453,11 @@ Besides :cpp:`amrex::Parser` for floating point numbers, AMReX also provides
 similarity, but floating point number specific functions (e.g., ``sqrt``,
 ``sin``, etc.) are not supported in ``IParser``.  In addition to ``/`` whose
 result truncates towards zero, the integer parser also supports ``//`` whose
-result truncates towards negative infinity.
+result truncates towards negative infinity. Single quotes ``'`` are allowed
+as a separator for :cpp:`IParser` numbers just like C++ integer
+literals. Additionally, a floating point like number with a positive
+exponent may be accepted as an integer if it is reasonable to do so. For
+example, it's okay to have ``1.234e3``, but ``1.23e2`` is an error.
 
 .. _sec:basics:initialize:
 

--- a/Docs/sphinx_documentation/source/Basics.rst
+++ b/Docs/sphinx_documentation/source/Basics.rst
@@ -457,7 +457,7 @@ result truncates towards negative infinity. Single quotes ``'`` are allowed
 as a separator for :cpp:`IParser` numbers just like C++ integer
 literals. Additionally, a floating point like number with a positive
 exponent may be accepted as an integer if it is reasonable to do so. For
-example, it's okay to have ``1.234e3``, but ``1.23e2`` is an error.
+example, it's okay to have ``1.234e3``, but ``1.234e2`` is an error.
 
 .. _sec:basics:initialize:
 

--- a/Src/Base/Parser/AMReX_IParser.H
+++ b/Src/Base/Parser/AMReX_IParser.H
@@ -18,7 +18,7 @@ struct IParserExecutor
 {
     template <int M=N, std::enable_if_t<M==0,int> = 0>
     [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-    int operator() () const noexcept
+    long long operator() () const noexcept
     {
         AMREX_IF_ON_DEVICE((return iparser_exe_eval(m_device_executor, nullptr);))
         AMREX_IF_ON_HOST((return iparser_exe_eval(m_host_executor, nullptr);))
@@ -26,16 +26,17 @@ struct IParserExecutor
 
     template <typename... Ts>
     [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-    std::enable_if_t<sizeof...(Ts) == N, int>
+    std::enable_if_t<sizeof...(Ts) == N && std::conjunction_v<std::is_integral<Ts>...>,
+                     long long>
     operator() (Ts... var) const noexcept
     {
-        amrex::GpuArray<int,N> l_var{var...};
+        amrex::GpuArray<long long,N> l_var{var...};
         AMREX_IF_ON_DEVICE((return iparser_exe_eval(m_device_executor, l_var.data());))
         AMREX_IF_ON_HOST((return iparser_exe_eval(m_host_executor, l_var.data());))
     }
 
     [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-    int operator() (GpuArray<int,N> const& var) const noexcept
+    long long operator() (GpuArray<long long, N> const& var) const noexcept
     {
         AMREX_IF_ON_DEVICE((return iparser_exe_eval(m_device_executor, var.data());))
         AMREX_IF_ON_HOST((return iparser_exe_eval(m_host_executor, var.data());))
@@ -62,7 +63,7 @@ public:
 
     explicit operator bool () const;
 
-    void setConstant (std::string const& name, int c);
+    void setConstant (std::string const& name, long long c);
 
     void registerVariables (Vector<std::string> const& vars);
 

--- a/Src/Base/Parser/AMReX_IParser.cpp
+++ b/Src/Base/Parser/AMReX_IParser.cpp
@@ -54,7 +54,7 @@ IParser::operator bool () const
 }
 
 void
-IParser::setConstant (std::string const& name, int c)
+IParser::setConstant (std::string const& name, long long c)
 {
     if (m_data && m_data->m_iparser) {
         iparser_setconst(m_data->m_iparser, name.c_str(), c);

--- a/Src/Base/Parser/AMReX_IParser_Exe.H
+++ b/Src/Base/Parser/AMReX_IParser_Exe.H
@@ -62,7 +62,7 @@ struct alignas(8) IParserExeNull {
 
 struct alignas(8) IParserExeNumber {
     enum iparser_exe_t type = IPARSER_EXE_NUMBER;
-    int v;
+    long long v;
 };
 
 struct alignas(8) IParserExeSymbol {
@@ -76,7 +76,7 @@ struct alignas(8) IParserExeADD {
 
 struct alignas(8) IParserExeSUB {
     enum iparser_exe_t type = IPARSER_EXE_SUB;
-    int sign;
+    long long sign;
 };
 
 struct alignas(8) IParserExeMUL {
@@ -113,31 +113,31 @@ struct alignas(8) IParserExeF2_B {
 struct alignas(8) IParserExeADD_VP {
     enum iparser_exe_t type = IPARSER_EXE_ADD_VP;
     int i;
-    int v;
+    long long v;
 };
 
 struct alignas(8) IParserExeSUB_VP {
     enum iparser_exe_t type = IPARSER_EXE_SUB_VP;
     int i;
-    int v;
+    long long v;
 };
 
 struct alignas(8) IParserExeMUL_VP {
     enum iparser_exe_t type = IPARSER_EXE_MUL_VP;
     int i;
-    int v;
+    long long v;
 };
 
 struct alignas(8) IParserExeDIV_VP {
     enum iparser_exe_t type = IPARSER_EXE_DIV_VP;
     int i;
-    int v;
+    long long v;
 };
 
 struct alignas(8) IParserExeDIV_PV {
     enum iparser_exe_t type = IPARSER_EXE_DIV_PV;
     int i;
-    int v;
+    long long v;
 };
 
 struct alignas(8) IParserExeADD_PP {
@@ -171,27 +171,27 @@ struct alignas(8) IParserExeNEG_P {
 
 struct alignas(8) IParserExeADD_VN {
     enum iparser_exe_t type = IPARSER_EXE_ADD_VN;
-    int v;
+    long long v;
 };
 
 struct alignas(8) IParserExeSUB_VN {
     enum iparser_exe_t type = IPARSER_EXE_SUB_VN;
-    int v;
+    long long v;
 };
 
 struct alignas(8) IParserExeMUL_VN {
     enum iparser_exe_t type = IPARSER_EXE_MUL_VN;
-    int v;
+    long long v;
 };
 
 struct alignas(8) IParserExeDIV_VN {
     enum iparser_exe_t type = IPARSER_EXE_DIV_VN;
-    int v;
+    long long v;
 };
 
 struct alignas(8) IParserExeDIV_NV {
     enum iparser_exe_t type = IPARSER_EXE_DIV_NV;
-    int v;
+    long long v;
 };
 
 struct alignas(8) IParserExeADD_PN {
@@ -202,7 +202,7 @@ struct alignas(8) IParserExeADD_PN {
 struct alignas(8) IParserExeSUB_PN {
     enum iparser_exe_t type = IPARSER_EXE_SUB_PN;
     int i;
-    int sign;
+    long long sign;
 };
 
 struct alignas(8) IParserExeMUL_PN {
@@ -229,19 +229,19 @@ struct alignas(8) IParserExeJUMP {
 template <int N>
 struct IParserStack
 {
-    int m_data[N];
+    long long m_data[N];
     int m_size = 0;
-    constexpr void push (int v) { m_data[m_size++] = v; }
+    constexpr void push (long long v) { m_data[m_size++] = v; }
     constexpr void pop () { --m_size; }
-    [[nodiscard]] constexpr int const& top () const { return m_data[m_size-1]; }
-    [[nodiscard]] constexpr int      & top ()       { return m_data[m_size-1]; }
-    [[nodiscard]] constexpr int operator[] (int i) const { return m_data[i]; }
+    [[nodiscard]] constexpr long long const& top () const { return m_data[m_size-1]; }
+    [[nodiscard]] constexpr long long      & top ()       { return m_data[m_size-1]; }
+    [[nodiscard]] constexpr long long operator[] (int i) const { return m_data[i]; }
 };
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-int iparser_exe_eval (const char* p, int const* x)
+long long iparser_exe_eval (const char* p, long long const* x)
 {
-    if (p == nullptr) { return std::numeric_limits<int>::max(); }
+    if (p == nullptr) { return std::numeric_limits<long long>::max(); }
 
     IParserStack<AMREX_IPARSER_STACK_SIZE> pstack;
     while (*((iparser_exe_t*)p) != IPARSER_EXE_NULL) {
@@ -256,14 +256,14 @@ int iparser_exe_eval (const char* p, int const* x)
         case IPARSER_EXE_SYMBOL:
         {
             int i = ((IParserExeSymbol*)p)->i;
-            int d = AMREX_IPARSER_GET_DATA(i);
+            auto d = AMREX_IPARSER_GET_DATA(i);
             pstack.push(d);
             p    += sizeof(IParserExeSymbol);
             break;
         }
         case IPARSER_EXE_ADD:
         {
-            int b = pstack.top();
+            auto b = pstack.top();
             pstack.pop();
             pstack.top() += b;
             p += sizeof(IParserExeADD);
@@ -271,7 +271,7 @@ int iparser_exe_eval (const char* p, int const* x)
         }
         case IPARSER_EXE_SUB:
         {
-            int b = pstack.top();
+            auto b = pstack.top();
             pstack.pop();
             pstack.top() = (pstack.top() - b) * (((IParserExeSUB*)p)->sign);
             p += sizeof(IParserExeSUB);
@@ -279,7 +279,7 @@ int iparser_exe_eval (const char* p, int const* x)
         }
         case IPARSER_EXE_MUL:
         {
-            int b = pstack.top();
+            auto b = pstack.top();
             pstack.pop();
             pstack.top() *= b;
             p += sizeof(IParserExeMUL);
@@ -287,7 +287,7 @@ int iparser_exe_eval (const char* p, int const* x)
         }
         case IPARSER_EXE_DIV_F:
         {
-            int v = pstack.top();
+            auto v = pstack.top();
             pstack.pop();
             pstack.top() /= v;
             p += sizeof(IParserExeDIV_F);
@@ -295,7 +295,7 @@ int iparser_exe_eval (const char* p, int const* x)
         }
         case IPARSER_EXE_DIV_B:
         {
-            int v = pstack.top();
+            auto v = pstack.top();
             pstack.pop();
             pstack.top() = v / pstack.top();
             p += sizeof(IParserExeDIV_B);
@@ -315,7 +315,7 @@ int iparser_exe_eval (const char* p, int const* x)
         }
         case IPARSER_EXE_F2_F:
         {
-            int v = pstack.top();
+            auto v = pstack.top();
             pstack.pop();
             pstack.top() = iparser_call_f2(((IParserExeF2_F*)p)->ftype, pstack.top(), v);
             p += sizeof(IParserExeF2_F);
@@ -323,7 +323,7 @@ int iparser_exe_eval (const char* p, int const* x)
         }
         case IPARSER_EXE_F2_B:
         {
-            int v = pstack.top();
+            auto v = pstack.top();
             pstack.pop();
             pstack.top() = iparser_call_f2(((IParserExeF2_B*)p)->ftype, v, pstack.top());
             p += sizeof(IParserExeF2_B);
@@ -332,7 +332,7 @@ int iparser_exe_eval (const char* p, int const* x)
         case IPARSER_EXE_ADD_VP:
         {
             int i = ((IParserExeADD_VP*)p)->i;
-            int d = AMREX_IPARSER_GET_DATA(i);
+            auto d = AMREX_IPARSER_GET_DATA(i);
             pstack.push(((IParserExeADD_VP*)p)->v + d);
             p   += sizeof(IParserExeADD_VP);
             break;
@@ -340,7 +340,7 @@ int iparser_exe_eval (const char* p, int const* x)
         case IPARSER_EXE_SUB_VP:
         {
             int i = ((IParserExeSUB_VP*)p)->i;
-            int d = AMREX_IPARSER_GET_DATA(i);
+            auto d = AMREX_IPARSER_GET_DATA(i);
             pstack.push(((IParserExeSUB_VP*)p)->v - d);
             p   += sizeof(IParserExeSUB_VP);
             break;
@@ -348,7 +348,7 @@ int iparser_exe_eval (const char* p, int const* x)
         case IPARSER_EXE_MUL_VP:
         {
             int i = ((IParserExeMUL_VP*)p)->i;
-            int d = AMREX_IPARSER_GET_DATA(i);
+            auto d = AMREX_IPARSER_GET_DATA(i);
             pstack.push(((IParserExeMUL_VP*)p)->v * d);
             p   += sizeof(IParserExeMUL_VP);
             break;
@@ -356,7 +356,7 @@ int iparser_exe_eval (const char* p, int const* x)
         case IPARSER_EXE_DIV_VP:
         {
             int i = ((IParserExeDIV_VP*)p)->i;
-            int d = AMREX_IPARSER_GET_DATA(i);
+            auto d = AMREX_IPARSER_GET_DATA(i);
             pstack.push(((IParserExeDIV_VP*)p)->v / d);
             p   += sizeof(IParserExeDIV_VP);
             break;
@@ -364,7 +364,7 @@ int iparser_exe_eval (const char* p, int const* x)
         case IPARSER_EXE_DIV_PV:
         {
             int i = ((IParserExeDIV_PV*)p)->i;
-            int d = AMREX_IPARSER_GET_DATA(i);
+            auto d = AMREX_IPARSER_GET_DATA(i);
             pstack.push(d / ((IParserExeDIV_PV*)p)->v);
             p       += sizeof(IParserExeDIV_PV);
             break;
@@ -372,9 +372,9 @@ int iparser_exe_eval (const char* p, int const* x)
         case IPARSER_EXE_ADD_PP:
         {
             int i = ((IParserExeADD_PP*)p)->i1;
-            int d1 = AMREX_IPARSER_GET_DATA(i);
+            auto d1 = AMREX_IPARSER_GET_DATA(i);
             i     = ((IParserExeADD_PP*)p)->i2;
-            int d2 = AMREX_IPARSER_GET_DATA(i);
+            auto d2 = AMREX_IPARSER_GET_DATA(i);
             pstack.push(d1+d2);
             p     += sizeof(IParserExeADD_PP);
             break;
@@ -382,9 +382,9 @@ int iparser_exe_eval (const char* p, int const* x)
         case IPARSER_EXE_SUB_PP:
         {
             int i = ((IParserExeSUB_PP*)p)->i1;
-            int d1 = AMREX_IPARSER_GET_DATA(i);
+            auto d1 = AMREX_IPARSER_GET_DATA(i);
             i     = ((IParserExeSUB_PP*)p)->i2;
-            int d2 = AMREX_IPARSER_GET_DATA(i);
+            auto d2 = AMREX_IPARSER_GET_DATA(i);
             pstack.push(d1-d2);
             p     += sizeof(IParserExeSUB_PP);
             break;
@@ -392,9 +392,9 @@ int iparser_exe_eval (const char* p, int const* x)
         case IPARSER_EXE_MUL_PP:
         {
             int i = ((IParserExeMUL_PP*)p)->i1;
-            int d1 = AMREX_IPARSER_GET_DATA(i);
+            auto d1 = AMREX_IPARSER_GET_DATA(i);
             i     = ((IParserExeMUL_PP*)p)->i2;
-            int d2 = AMREX_IPARSER_GET_DATA(i);
+            auto d2 = AMREX_IPARSER_GET_DATA(i);
             pstack.push(d1*d2);
             p     += sizeof(IParserExeMUL_PP);
             break;
@@ -402,9 +402,9 @@ int iparser_exe_eval (const char* p, int const* x)
         case IPARSER_EXE_DIV_PP:
         {
             int i = ((IParserExeDIV_PP*)p)->i1;
-            int d1 = AMREX_IPARSER_GET_DATA(i);
+            auto d1 = AMREX_IPARSER_GET_DATA(i);
             i     = ((IParserExeDIV_PP*)p)->i2;
-            int d2 = AMREX_IPARSER_GET_DATA(i);
+            auto d2 = AMREX_IPARSER_GET_DATA(i);
             pstack.push(d1/d2);
             p      += sizeof(IParserExeDIV_PP);
             break;
@@ -412,7 +412,7 @@ int iparser_exe_eval (const char* p, int const* x)
         case IPARSER_EXE_NEG_P:
         {
             int i = ((IParserExeNEG_P*)p)->i;
-            int d = AMREX_IPARSER_GET_DATA(i);
+            auto d = AMREX_IPARSER_GET_DATA(i);
             pstack.push(-d);
             p     += sizeof(IParserExeNEG_P);
             break;
@@ -450,7 +450,7 @@ int iparser_exe_eval (const char* p, int const* x)
         case IPARSER_EXE_ADD_PN:
         {
             int i = ((IParserExeADD_PN*)p)->i;
-            int d = AMREX_IPARSER_GET_DATA(i);
+            auto d = AMREX_IPARSER_GET_DATA(i);
             pstack.top() += d;
             p         += sizeof(IParserExeADD_PN);
             break;
@@ -458,7 +458,7 @@ int iparser_exe_eval (const char* p, int const* x)
         case IPARSER_EXE_SUB_PN:
         {
             int i = ((IParserExeSUB_PN*)p)->i;
-            int d = AMREX_IPARSER_GET_DATA(i);
+            auto d = AMREX_IPARSER_GET_DATA(i);
             pstack.top() = (d - pstack.top()) * (((IParserExeSUB_PN*)p)->sign);
             p         += sizeof(IParserExeSUB_PN);
             break;
@@ -466,7 +466,7 @@ int iparser_exe_eval (const char* p, int const* x)
         case IPARSER_EXE_MUL_PN:
         {
             int i = ((IParserExeMUL_PN*)p)->i;
-            int d = AMREX_IPARSER_GET_DATA(i);
+            auto d = AMREX_IPARSER_GET_DATA(i);
             pstack.top() *= d;
             p         += sizeof(IParserExeMUL_PN);
             break;
@@ -474,7 +474,7 @@ int iparser_exe_eval (const char* p, int const* x)
         case IPARSER_EXE_DIV_PN:
         {
             int i = ((IParserExeDIV_PN*)p)->i;
-            int d = AMREX_IPARSER_GET_DATA(i);
+            auto d = AMREX_IPARSER_GET_DATA(i);
             if (((IParserExeDIV_PN*)p)->reverse) {
                 pstack.top() /= d;
             } else {
@@ -485,9 +485,9 @@ int iparser_exe_eval (const char* p, int const* x)
         }
         case IPARSER_EXE_IF:
         {
-            int cond = pstack.top();
+            auto cond = pstack.top();
             pstack.pop();
-            if (cond == 0.0) { // false branch
+            if (cond == 0) { // false branch
                 p += ((IParserExeIF*)p)->offset;
             }
             p += sizeof(IParserExeIF);

--- a/Src/Base/Parser/AMReX_IParser_Y.H
+++ b/Src/Base/Parser/AMReX_IParser_Y.H
@@ -75,7 +75,7 @@ enum iparser_node_t {
 
 union iparser_nvp {
     struct iparser_node* n;
-    int v;
+    long long v;
     int ip;
 };
 
@@ -89,7 +89,7 @@ struct iparser_node {
 
 struct iparser_number {
     enum iparser_node_t type;
-    int value;
+    long long value;
 };
 
 struct iparser_symbol {
@@ -134,7 +134,7 @@ void iparser_defexpr (struct iparser_node* body);
 struct iparser_symbol* iparser_makesymbol (char* name);
 struct iparser_node* iparser_newnode (enum iparser_node_t type, struct iparser_node* l,
                                       struct iparser_node* r);
-struct iparser_node* iparser_newnumber (int d);
+struct iparser_node* iparser_newnumber (long long d);
 struct iparser_node* iparser_newsymbol (struct iparser_symbol* sym);
 struct iparser_node* iparser_newf1 (enum iparser_f1_t ftype, struct iparser_node* l);
 struct iparser_node* iparser_newf2 (enum iparser_f2_t ftype, struct iparser_node* l,
@@ -164,7 +164,7 @@ struct amrex_iparser* iparser_dup (struct amrex_iparser* source);
 struct iparser_node* iparser_ast_dup (struct amrex_iparser* iparser, struct iparser_node* node, int move);
 
 void iparser_regvar (struct amrex_iparser* iparser, char const* name, int i);
-void iparser_setconst (struct amrex_iparser* iparser, char const* name, int c);
+void iparser_setconst (struct amrex_iparser* iparser, char const* name, long long c);
 void iparser_print (struct amrex_iparser* iparser);
 std::set<std::string> iparser_get_symbols (struct amrex_iparser* iparser);
 int iparser_depth (struct amrex_iparser* iparser);
@@ -174,27 +174,27 @@ void iparser_ast_optimize (struct iparser_node* node);
 std::size_t iparser_ast_size (struct iparser_node* node);
 void iparser_ast_print (struct iparser_node* node, std::string const& space, AllPrint& printer);
 void iparser_ast_regvar (struct iparser_node* node, char const* name, int i);
-void iparser_ast_setconst (struct iparser_node* node, char const* name, int c);
+void iparser_ast_setconst (struct iparser_node* node, char const* name, long long c);
 void iparser_ast_get_symbols (struct iparser_node* node, std::set<std::string>& symbols,
                               std::set<std::string>& local_symbols);
 int iparser_ast_depth (struct iparser_node* node);
 
 /*******************************************************************/
 
-AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE int
-iparser_call_f1 (enum iparser_f1_t /*type*/, int a)
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE long long
+iparser_call_f1 (enum iparser_f1_t /*type*/, long long a)
 {
     /// There is only one type for now
     return std::abs(a);
 }
 
-AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE int
-iparser_call_f2 (enum iparser_f2_t type, int a, int b)
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE long long
+iparser_call_f2 (enum iparser_f2_t type, long long a, long long b)
 {
     switch (type) {
     case IPARSER_FLRDIV:
     {
-        int r = a/b;
+        long long r = a/b;
         if (r*b == a || (a < 0 && b < 0) || (a > 0 && b > 0)) {
             return r;
         } else {
@@ -206,13 +206,13 @@ iparser_call_f2 (enum iparser_f2_t type, int a, int b)
         if (b < 0) {
             return 0;
         } else {
-            int r = 1;
+            long long r = 1;
             while (b != 0) {
                 if (b & 1) {
                     r *= a;
                 }
                 b >>= 1;
-                a *= a;
+                if (b > 0) { a *= a; } // to avoid overflow
             }
             return r;
         }
@@ -243,12 +243,14 @@ iparser_call_f2 (enum iparser_f2_t type, int a, int b)
     }
 }
 
-AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE int
-iparser_call_f3 (enum iparser_f3_t /*type*/, int a, int b, int c)
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE long long
+iparser_call_f3 (enum iparser_f3_t /*type*/, long long a, long long b, long long c)
 {
     // There is only one type currently
     return (a != 0) ? b : c;
 }
+
+long long iparser_atoll (const char* str);
 
 }
 

--- a/Src/Base/Parser/AMReX_IParser_Y.cpp
+++ b/Src/Base/Parser/AMReX_IParser_Y.cpp
@@ -51,7 +51,7 @@ iparser_newnode (enum iparser_node_t type, struct iparser_node* l, struct iparse
 }
 
 struct iparser_node*
-iparser_newnumber (int d)
+iparser_newnumber (long long d)
 {
     auto *r = (struct iparser_number*) std::malloc(sizeof(struct iparser_number));
     r->type = IPARSER_NUMBER;
@@ -398,7 +398,7 @@ iparser_ast_optimize (struct iparser_node* node)
         if (node->l->type == IPARSER_NUMBER &&
             node->r->type == IPARSER_NUMBER)
         {
-            int v = ((struct iparser_number*)(node->l))->value
+            auto v= ((struct iparser_number*)(node->l))->value
                 +   ((struct iparser_number*)(node->r))->value;
             ((struct iparser_number*)node)->type = IPARSER_NUMBER;
             ((struct iparser_number*)node)->value = v;
@@ -428,28 +428,28 @@ iparser_ast_optimize (struct iparser_node* node)
         else if (node->l->type == IPARSER_NUMBER &&
                  node->r->type == IPARSER_ADD_VP)
         {
-            int v = ((struct iparser_number*)(node->l))->value + IPARSER_EVAL_R(node);
+            auto v = ((struct iparser_number*)(node->l))->value + IPARSER_EVAL_R(node);
             IPARSER_MOVEUP_R(node, v);
             node->type = IPARSER_ADD_VP;
         }
         else if (node->l->type == IPARSER_NUMBER &&
                  node->r->type == IPARSER_SUB_VP)
         {
-            int v = ((struct iparser_number*)(node->l))->value + IPARSER_EVAL_R(node);
+            auto v = ((struct iparser_number*)(node->l))->value + IPARSER_EVAL_R(node);
             IPARSER_MOVEUP_R(node, v);
             node->type = IPARSER_SUB_VP;
         }
         else if (node->l->type == IPARSER_ADD_VP &&
                  node->r->type == IPARSER_NUMBER)
         {
-            int v = IPARSER_EVAL_L(node) + ((struct iparser_number*)(node->r))->value;
+            auto v = IPARSER_EVAL_L(node) + ((struct iparser_number*)(node->r))->value;
             IPARSER_MOVEUP_L(node, v);
             node->type = IPARSER_ADD_VP;
         }
         else if (node->l->type == IPARSER_SUB_VP &&
                  node->r->type == IPARSER_NUMBER)
         {
-            int v = IPARSER_EVAL_L(node) + ((struct iparser_number*)(node->r))->value;
+            auto v = IPARSER_EVAL_L(node) + ((struct iparser_number*)(node->r))->value;
             IPARSER_MOVEUP_L(node, v);
             node->type = IPARSER_SUB_VP;
         }
@@ -458,14 +458,14 @@ iparser_ast_optimize (struct iparser_node* node)
         {
             if (node->r->l->type == IPARSER_NUMBER)
             { // #l + (#rl + node_rr) -> (#l + #rl) + node_rr, same type
-                int v = ((struct iparser_number*)(node->l))->value
+                auto v= ((struct iparser_number*)(node->l))->value
                     +   ((struct iparser_number*)(node->r->l))->value;
                 node->r = node->r->r;
                 ((struct iparser_number*)(node->l))->value = v;
             }
             else if (node->r->r->type == IPARSER_NUMBER)
             { // #l + (node_rl + #rr) -> (#l + #rr) + node_rl, same type
-                int v = ((struct iparser_number*)(node->l))->value
+                auto v= ((struct iparser_number*)(node->l))->value
                     +   ((struct iparser_number*)(node->r->r))->value;
                 node->r = node->r->l;
                 ((struct iparser_number*)(node->l))->value = v;
@@ -476,7 +476,7 @@ iparser_ast_optimize (struct iparser_node* node)
         {
             if (node->r->l->type == IPARSER_NUMBER)
             { // #l + (#rl - node_rr) -> (#l + #rl) - node_rr, type change
-                int v = ((struct iparser_number*)(node->l))->value
+                auto v= ((struct iparser_number*)(node->l))->value
                     +   ((struct iparser_number*)(node->r->l))->value;
                 node->r = node->r->r;
                 ((struct iparser_number*)(node->l))->value = v;
@@ -484,7 +484,7 @@ iparser_ast_optimize (struct iparser_node* node)
             }
             else if (node->r->r->type == IPARSER_NUMBER)
             { // #l + (node_rl - #rr) -> (#l - #rr) + node_rl, same type
-                int v = ((struct iparser_number*)(node->l))->value
+                auto v= ((struct iparser_number*)(node->l))->value
                     -   ((struct iparser_number*)(node->r->r))->value;
                 node->r = node->r->l;
                 ((struct iparser_number*)(node->l))->value = v;
@@ -495,14 +495,14 @@ iparser_ast_optimize (struct iparser_node* node)
         {
             if (node->l->l->type == IPARSER_NUMBER)
             { // (#ll + node_lr) + #r -> nodel_lr + (#ll + #r), same type
-                int v = ((struct iparser_number*)(node->l->l))->value
+                auto v= ((struct iparser_number*)(node->l->l))->value
                     +   ((struct iparser_number*)(node->r))->value;
                 node->l = node->l->r;
                 ((struct iparser_number*)(node->r))->value = v;
             }
             else if (node->l->r->type == IPARSER_NUMBER)
             { // (node_ll + #lr) + #r -> node_ll + (#lr + #r), same type
-                int v = ((struct iparser_number*)(node->l->r))->value
+                auto v= ((struct iparser_number*)(node->l->r))->value
                     +   ((struct iparser_number*)(node->r))->value;
                 node->l = node->l->l;
                 ((struct iparser_number*)(node->r))->value = v;
@@ -513,7 +513,7 @@ iparser_ast_optimize (struct iparser_node* node)
         {
             if (node->l->l->type == IPARSER_NUMBER)
             { // (#ll - node_lr) + #r -> (#ll + #r) - node_lr, type change
-                int v = ((struct iparser_number*)(node->l->l))->value
+                auto v= ((struct iparser_number*)(node->l->l))->value
                     +   ((struct iparser_number*)(node->r))->value;
                 node->r = node->l->r;
                 ((struct iparser_number*)(node->l))->type = IPARSER_NUMBER;
@@ -522,7 +522,7 @@ iparser_ast_optimize (struct iparser_node* node)
             }
             else if (node->l->r->type == IPARSER_NUMBER)
             { // (node_ll - #lr) + #r -> node_ll + (#r - #lr), same type
-                int v = ((struct iparser_number*)(node->r))->value
+                auto v= ((struct iparser_number*)(node->r))->value
                     -   ((struct iparser_number*)(node->l->r))->value;
                 node->l = node->l->l;
                 ((struct iparser_number*)(node->r))->value = v;
@@ -536,7 +536,7 @@ iparser_ast_optimize (struct iparser_node* node)
         if (node->l->type == IPARSER_NUMBER &&
             node->r->type == IPARSER_NUMBER)
         {
-            int v = ((struct iparser_number*)(node->l))->value
+            auto v= ((struct iparser_number*)(node->l))->value
                 -   ((struct iparser_number*)(node->r))->value;
             ((struct iparser_number*)node)->type = IPARSER_NUMBER;
             ((struct iparser_number*)node)->value = v;
@@ -566,28 +566,28 @@ iparser_ast_optimize (struct iparser_node* node)
         else if (node->l->type == IPARSER_NUMBER &&
                  node->r->type == IPARSER_ADD_VP)
         {
-            int v = ((struct iparser_number*)(node->l))->value - IPARSER_EVAL_R(node);
+            auto v= ((struct iparser_number*)(node->l))->value - IPARSER_EVAL_R(node);
             IPARSER_MOVEUP_R(node, v);
             node->type = IPARSER_SUB_VP;
         }
         else if (node->l->type == IPARSER_NUMBER &&
                  node->r->type == IPARSER_SUB_VP)
         {
-            int v = ((struct iparser_number*)(node->l))->value - IPARSER_EVAL_R(node);
+            auto v= ((struct iparser_number*)(node->l))->value - IPARSER_EVAL_R(node);
             IPARSER_MOVEUP_R(node, v);
             node->type = IPARSER_ADD_VP;
         }
         else if (node->l->type == IPARSER_ADD_VP &&
                  node->r->type == IPARSER_NUMBER)
         {
-            int v = IPARSER_EVAL_L(node) - ((struct iparser_number*)(node->r))->value;
+            auto v= IPARSER_EVAL_L(node) - ((struct iparser_number*)(node->r))->value;
             IPARSER_MOVEUP_L(node, v);
             node->type = IPARSER_ADD_VP;
         }
         else if (node->l->type == IPARSER_SUB_VP &&
                  node->r->type == IPARSER_NUMBER)
         {
-            int v = IPARSER_EVAL_L(node) - ((struct iparser_number*)(node->r))->value;
+            auto v= IPARSER_EVAL_L(node) - ((struct iparser_number*)(node->r))->value;
             IPARSER_MOVEUP_L(node, v);
             node->type = IPARSER_SUB_VP;
         }
@@ -596,14 +596,14 @@ iparser_ast_optimize (struct iparser_node* node)
         {
             if (node->r->l->type == IPARSER_NUMBER)
             { // #l - (#rl + node_rr) -> (#l - #rl) - node_rr, same type
-                int v = ((struct iparser_number*)(node->l))->value
+                auto v= ((struct iparser_number*)(node->l))->value
                     -   ((struct iparser_number*)(node->r->l))->value;
                 node->r = node->r->r;
                 ((struct iparser_number*)(node->l))->value = v;
             }
             else if (node->r->r->type == IPARSER_NUMBER)
             { // #l - (node_rl + #rr) -> (#l - #rr) - node_rl, same type
-                int v = ((struct iparser_number*)(node->l))->value
+                auto v= ((struct iparser_number*)(node->l))->value
                     -   ((struct iparser_number*)(node->r->r))->value;
                 node->r = node->r->l;
                 ((struct iparser_number*)(node->l))->value = v;
@@ -614,7 +614,7 @@ iparser_ast_optimize (struct iparser_node* node)
         {
             if (node->r->l->type == IPARSER_NUMBER)
             { // #l - (#rl - node_rr) -> (#l - #rl) + node_rr, type change
-                int v = ((struct iparser_number*)(node->l))->value
+                auto v= ((struct iparser_number*)(node->l))->value
                     -   ((struct iparser_number*)(node->r->l))->value;
                 node->r = node->r->r;
                 ((struct iparser_number*)(node->l))->value = v;
@@ -622,7 +622,7 @@ iparser_ast_optimize (struct iparser_node* node)
             }
             else if (node->r->r->type == IPARSER_NUMBER)
             { // #l - (node_rl - #rr) -> (#l + #rr) - node_rl, same type
-                int v = ((struct iparser_number*)(node->l))->value
+                auto v= ((struct iparser_number*)(node->l))->value
                     +   ((struct iparser_number*)(node->r->r))->value;
                 node->r = node->r->l;
                 ((struct iparser_number*)(node->l))->value = v;
@@ -633,14 +633,14 @@ iparser_ast_optimize (struct iparser_node* node)
         {
             if (node->l->l->type == IPARSER_NUMBER)
             { // (#ll + node_lr) - #r -> node_lr - (#r - #ll), same type
-                int v = ((struct iparser_number*)(node->r))->value
+                auto v= ((struct iparser_number*)(node->r))->value
                     -   ((struct iparser_number*)(node->l->l))->value;
                 node->l = node->l->r;
                 ((struct iparser_number*)(node->r))->value = v;
             }
             else if (node->l->r->type == IPARSER_NUMBER)
             { // (node_ll + #lr) - #r -> node_ll - (#r - #lr), same type
-                int v = ((struct iparser_number*)(node->r))->value
+                auto v= ((struct iparser_number*)(node->r))->value
                     -   ((struct iparser_number*)(node->l->r))->value;
                 node->l = node->l->l;
                 ((struct iparser_number*)(node->r))->value = v;
@@ -651,7 +651,7 @@ iparser_ast_optimize (struct iparser_node* node)
         {
             if (node->l->l->type == IPARSER_NUMBER)
             { // (#ll - node_lr) - #r -> (#ll - #r) - node_lr, type change
-                int v = ((struct iparser_number*)(node->l->l))->value
+                auto v= ((struct iparser_number*)(node->l->l))->value
                     -   ((struct iparser_number*)(node->r))->value;
                 node->r = node->l->r;
                 node->l->type = IPARSER_NUMBER;
@@ -659,7 +659,7 @@ iparser_ast_optimize (struct iparser_node* node)
             }
             else if (node->l->r->type == IPARSER_NUMBER)
             { // (node_ll - #lr) - #r -> node_ll - (#r + #lr), same type
-                int v = ((struct iparser_number*)(node->r))->value
+                auto v= ((struct iparser_number*)(node->r))->value
                     +   ((struct iparser_number*)(node->l->r))->value;
                 node->l = node->l->l;
                 ((struct iparser_number*)(node->r))->value = v;
@@ -673,7 +673,7 @@ iparser_ast_optimize (struct iparser_node* node)
         if (node->l->type == IPARSER_NUMBER &&
             node->r->type == IPARSER_NUMBER)
         {
-            int v = ((struct iparser_number*)(node->l))->value
+            auto v= ((struct iparser_number*)(node->l))->value
                 *   ((struct iparser_number*)(node->r))->value;
             ((struct iparser_number*)node)->type = IPARSER_NUMBER;
             ((struct iparser_number*)node)->value = v;
@@ -703,14 +703,14 @@ iparser_ast_optimize (struct iparser_node* node)
         else if (node->l->type == IPARSER_NUMBER &&
                  node->r->type == IPARSER_MUL_VP)
         {
-            int v = ((struct iparser_number*)(node->l))->value * IPARSER_EVAL_R(node);
+            auto v= ((struct iparser_number*)(node->l))->value * IPARSER_EVAL_R(node);
             IPARSER_MOVEUP_R(node, v);
             node->type = IPARSER_MUL_VP;
         }
         else if (node->l->type == IPARSER_MUL_VP &&
                  node->r->type == IPARSER_NUMBER)
         {
-            int v = IPARSER_EVAL_L(node) * ((struct iparser_number*)(node->r))->value;
+            auto v= IPARSER_EVAL_L(node) * ((struct iparser_number*)(node->r))->value;
             IPARSER_MOVEUP_L(node, v);
             node->type = IPARSER_MUL_VP;
         }
@@ -719,14 +719,14 @@ iparser_ast_optimize (struct iparser_node* node)
         {
             if (node->r->l->type == IPARSER_NUMBER)
             { // #l * (#rl * node_rr) -> (#l * #rl) * node_rr, same type
-                int v = ((struct iparser_number*)(node->l))->value
+                auto v= ((struct iparser_number*)(node->l))->value
                     *   ((struct iparser_number*)(node->r->l))->value;
                 node->r = node->r->r;
                 ((struct iparser_number*)(node->l))->value = v;
             }
             else if (node->r->r->type == IPARSER_NUMBER)
             { // #l * (node_rl * #rr) -> (#l * #rr) * node_rl, same type
-                int v = ((struct iparser_number*)(node->l))->value
+                auto v= ((struct iparser_number*)(node->l))->value
                     *   ((struct iparser_number*)(node->r->r))->value;
                 node->r = node->r->l;
                 ((struct iparser_number*)(node->l))->value = v;
@@ -737,14 +737,14 @@ iparser_ast_optimize (struct iparser_node* node)
         {
             if (node->l->l->type == IPARSER_NUMBER)
             { // (#ll * node_lr) * #r -> nodel_lr * (#ll * #r), same type
-                int v = ((struct iparser_number*)(node->l->l))->value
+                auto v= ((struct iparser_number*)(node->l->l))->value
                     *   ((struct iparser_number*)(node->r))->value;
                 node->l = node->l->r;
                 ((struct iparser_number*)(node->r))->value = v;
             }
             else if (node->l->r->type == IPARSER_NUMBER)
             { // (node_ll * #lr) * #r -> node_ll + (#lr * #r), same type
-                int v = ((struct iparser_number*)(node->l->r))->value
+                auto v= ((struct iparser_number*)(node->l->r))->value
                     *   ((struct iparser_number*)(node->r))->value;
                 node->l = node->l->l;
                 ((struct iparser_number*)(node->r))->value = v;
@@ -758,7 +758,7 @@ iparser_ast_optimize (struct iparser_node* node)
         if (node->l->type == IPARSER_NUMBER &&
             node->r->type == IPARSER_NUMBER)
         {
-            int v = ((struct iparser_number*)(node->l))->value
+            auto v= ((struct iparser_number*)(node->l))->value
                 /   ((struct iparser_number*)(node->r))->value;
             ((struct iparser_number*)node)->type = IPARSER_NUMBER;
             ((struct iparser_number*)node)->value = v;
@@ -790,7 +790,7 @@ iparser_ast_optimize (struct iparser_node* node)
         iparser_ast_optimize(node->l);
         if (node->l->type == IPARSER_NUMBER)
         {
-            int v = -((struct iparser_number*)(node->l))->value;
+            auto v= -((struct iparser_number*)(node->l))->value;
             ((struct iparser_number*)node)->type = IPARSER_NUMBER;
             ((struct iparser_number*)node)->value = v;
         }
@@ -876,7 +876,7 @@ iparser_ast_optimize (struct iparser_node* node)
         iparser_ast_optimize(node->l);
         if (node->l->type == IPARSER_NUMBER)
         {
-            int v = iparser_call_f1
+            auto v= iparser_call_f1
                 (((struct iparser_f1*)node)->ftype,
                  ((struct iparser_number*)(((struct iparser_f1*)node)->l))->value);
             ((struct iparser_number*)node)->type = IPARSER_NUMBER;
@@ -889,7 +889,7 @@ iparser_ast_optimize (struct iparser_node* node)
         if (node->l->type == IPARSER_NUMBER &&
             node->r->type == IPARSER_NUMBER)
         {
-            int v = iparser_call_f2
+            auto v= iparser_call_f2
                 (((struct iparser_f2*)node)->ftype,
                  ((struct iparser_number*)(((struct iparser_f2*)node)->l))->value,
                  ((struct iparser_number*)(((struct iparser_f2*)node)->r))->value);
@@ -905,7 +905,7 @@ iparser_ast_optimize (struct iparser_node* node)
             ((struct iparser_f3*)node)->n2->type == IPARSER_NUMBER &&
             ((struct iparser_f3*)node)->n3->type == IPARSER_NUMBER)
         {
-            int v = iparser_call_f3
+            auto v= iparser_call_f3
                 (((struct iparser_f3*)node)->ftype,
                  ((struct iparser_number*)(((struct iparser_f3*)node)->n1))->value,
                  ((struct iparser_number*)(((struct iparser_f3*)node)->n2))->value,
@@ -918,7 +918,7 @@ iparser_ast_optimize (struct iparser_node* node)
         iparser_ast_optimize(node->r);
         if (node->r->type == IPARSER_NUMBER)
         {
-            int v = node->lvp.v + ((struct iparser_number*)(node->r))->value;
+            auto v= node->lvp.v + ((struct iparser_number*)(node->r))->value;
             ((struct iparser_number*)node)->type = IPARSER_NUMBER;
             ((struct iparser_number*)node)->value = v;
         }
@@ -927,7 +927,7 @@ iparser_ast_optimize (struct iparser_node* node)
         iparser_ast_optimize(node->r);
         if (node->r->type == IPARSER_NUMBER)
         {
-            int v = node->lvp.v - ((struct iparser_number*)(node->r))->value;
+            auto v= node->lvp.v - ((struct iparser_number*)(node->r))->value;
             ((struct iparser_number*)node)->type = IPARSER_NUMBER;
             ((struct iparser_number*)node)->value = v;
         }
@@ -936,7 +936,7 @@ iparser_ast_optimize (struct iparser_node* node)
         iparser_ast_optimize(node->r);
         if (node->r->type == IPARSER_NUMBER)
         {
-            int v = node->lvp.v * ((struct iparser_number*)(node->r))->value;
+            auto v= node->lvp.v * ((struct iparser_number*)(node->r))->value;
             ((struct iparser_number*)node)->type = IPARSER_NUMBER;
             ((struct iparser_number*)node)->value = v;
         }
@@ -945,7 +945,7 @@ iparser_ast_optimize (struct iparser_node* node)
         iparser_ast_optimize(node->r);
         if (node->r->type == IPARSER_NUMBER)
         {
-            int v = node->lvp.v / ((struct iparser_number*)(node->r))->value;
+            auto v= node->lvp.v / ((struct iparser_number*)(node->r))->value;
             ((struct iparser_number*)node)->type = IPARSER_NUMBER;
             ((struct iparser_number*)node)->value = v;
         }
@@ -954,7 +954,7 @@ iparser_ast_optimize (struct iparser_node* node)
         iparser_ast_optimize(node->r);
         if (node->r->type == IPARSER_NUMBER)
         {
-            int v = ((struct iparser_number*)(node->r))->value / node->lvp.v;
+            auto v= ((struct iparser_number*)(node->r))->value / node->lvp.v;
             ((struct iparser_number*)node)->type = IPARSER_NUMBER;
             ((struct iparser_number*)node)->value = v;
         }
@@ -963,7 +963,7 @@ iparser_ast_optimize (struct iparser_node* node)
         iparser_ast_optimize(node->l);
         if (node->l->type == IPARSER_NUMBER)
         {
-            int v = -((struct iparser_number*)(node->l))->value;
+            auto v= -((struct iparser_number*)(node->l))->value;
             ((struct iparser_number*)node)->type = IPARSER_NUMBER;
             ((struct iparser_number*)node)->value = v;
         }
@@ -1280,7 +1280,7 @@ iparser_ast_regvar (struct iparser_node* node, char const* name, int i)
     }
 }
 
-void iparser_ast_setconst (struct iparser_node* node, char const* name, int c)
+void iparser_ast_setconst (struct iparser_node* node, char const* name, long long c)
 {
     switch (node->type)
     {
@@ -1396,7 +1396,7 @@ iparser_regvar (struct amrex_iparser* iparser, char const* name, int i)
 }
 
 void
-iparser_setconst (struct amrex_iparser* iparser, char const* name, int c)
+iparser_setconst (struct amrex_iparser* iparser, char const* name, long long c)
 {
     iparser_ast_setconst(iparser->ast, name, c);
     iparser_ast_optimize(iparser->ast);
@@ -1425,6 +1425,41 @@ int
 iparser_depth (struct amrex_iparser* iparser)
 {
     return iparser_ast_depth(iparser->ast);
+}
+
+long long
+iparser_atoll (const char* str)
+{
+    std::string s(str);
+    s.erase(std::remove(s.begin(), s.end(), '\''), s.end());
+
+    auto pos_E = s.find('E');
+    if (pos_E != std::string::npos) {
+        s[pos_E] = 'e';
+    }
+    auto pos_e = s.find('e');
+    if (pos_e != std::string::npos) {
+        std::string part_1 = s.substr(0, pos_e);
+        int ex = std::atoi(s.c_str()+pos_e+1);
+        auto pos_dot = part_1.find('.');
+        if (pos_dot != std::string::npos) {
+            // iparser'number does not have more than one dot.
+            ex -= static_cast<int>(part_1.size()-(pos_dot+1));
+            part_1.erase(pos_dot,1);
+        }
+        if (ex < 0) {
+            throw std::runtime_error(std::string(str) + " is not an integer");
+        }
+        part_1.resize(part_1.size()+ex,'0');
+        return std::atoll(part_1.c_str());
+    } else {
+        auto pos_dot = s.find('.');
+        if (pos_dot != std::string::npos && pos_dot+1 < s.size()) {
+            throw std::runtime_error(std::string(str) + " is not an integer");
+        }
+        // Note that atoll works as expected for numbers ending with `.` like `123.`.
+        return std::atoll(s.c_str());
+    }
 }
 
 }

--- a/Src/Base/Parser/amrex_iparser.l
+++ b/Src/Base/Parser/amrex_iparser.l
@@ -15,6 +15,9 @@
  /* Tokens NUMBER, SYMBOL, F1, POW, F2, etc. are defined in amrex_iparser.y. */
  /* Types IPARSER_ABS, IPARSER_MIN etc. are defined in AMReX_IParser_y.H. */
 
+ /* Used later to define NUMBER */
+EXP	([Ee][0-9]+)
+
 %%
 
 "+" |
@@ -51,7 +54,9 @@
 [a-zA-Z_][a-zA-Z0-9_\.]*  { amrex_iparserlval.s = amrex::iparser_makesymbol(amrex_iparsertext); return SYMBOL; }
 
  /* Number */
-[0-9]+        { amrex_iparserlval.d = std::atoi(amrex_iparsertext);   return NUMBER; }
+[0-9][0-9']*          |
+[0-9]+"."[0-9]*{EXP}? |
+"."?[0-9]+{EXP}?  { amrex_iparserlval.d = amrex::iparser_atoll(amrex_iparsertext);   return NUMBER; }
 
  /* Special characters */
 [ \t]   /* ignore white space */

--- a/Src/Base/Parser/amrex_iparser.lex.nolint.H
+++ b/Src/Base/Parser/amrex_iparser.lex.nolint.H
@@ -611,8 +611,8 @@ static void yynoreturn yy_fatal_error ( const char* msg  );
 	(yy_hold_char) = *yy_cp; \
 	*yy_cp = '\0'; \
 	(yy_c_buf_p) = yy_cp;
-#define YY_NUM_RULES 32
-#define YY_END_OF_BUFFER 33
+#define YY_NUM_RULES 34
+#define YY_END_OF_BUFFER 35
 /* This struct is not used in this scanner,
    but its presence is necessary. */
 struct yy_trans_info
@@ -620,13 +620,14 @@ struct yy_trans_info
 	flex_int32_t yy_verify;
 	flex_int32_t yy_nxt;
 	};
-static const flex_int16_t yy_accept[50] =
+static const flex_int16_t yy_accept[59] =
     {   0,
-        0,    0,   33,   31,   28,   30,   31,   10,   11,    3,
-        1,    6,    2,    4,   27,    9,    7,    5,    8,   26,
-       31,   16,   26,   26,   26,   26,   20,   15,   14,   27,
-       18,   19,   17,   26,   29,   26,   26,   26,   25,   26,
-       26,   22,   12,   21,   26,   24,   23,   13,    0
+        0,    0,   35,   33,   30,   32,   33,   10,   11,    3,
+        1,    6,    2,   33,    4,   27,    9,    7,    5,    8,
+       26,   33,   16,   26,   26,   26,   26,   20,   15,   29,
+       14,   27,   28,   27,    0,   18,   19,   17,   26,   31,
+       26,   26,   26,   25,   26,   26,   22,   28,    0,   29,
+       12,   21,   26,   24,   23,   28,   13,    0
     } ;
 
 static const YY_CHAR yy_ec[256] =
@@ -634,17 +635,17 @@ static const YY_CHAR yy_ec[256] =
         1,    1,    1,    1,    1,    1,    1,    1,    2,    3,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
-        1,    2,    4,    1,    1,    1,    1,    1,    1,    5,
-        6,    7,    8,    9,   10,   11,   12,   13,   13,   13,
-       13,   13,   13,   13,   13,   13,   13,    1,   14,   15,
-       16,   17,    1,    1,   18,   18,   18,   18,   18,   18,
-       18,   18,   18,   18,   18,   18,   18,   18,   18,   18,
-       18,   18,   18,   18,   18,   18,   18,   18,   18,   18,
-        1,   19,    1,   20,   18,    1,   21,   22,   18,   23,
+        1,    2,    4,    1,    1,    1,    1,    1,    5,    6,
+        7,    8,    9,   10,   11,   12,   13,   14,   14,   14,
+       14,   14,   14,   14,   14,   14,   14,    1,   15,   16,
+       17,   18,    1,    1,   19,   19,   19,   19,   20,   19,
+       19,   19,   19,   19,   19,   19,   19,   19,   19,   19,
+       19,   19,   19,   19,   19,   19,   19,   19,   19,   19,
+        1,   21,    1,   22,   19,    1,   23,   24,   19,   25,
 
-       18,   24,   18,   18,   25,   18,   18,   18,   26,   27,
-       28,   18,   18,   29,   30,   18,   18,   18,   18,   31,
-       18,   18,    1,    1,    1,    1,    1,    1,    1,    1,
+       20,   26,   19,   19,   27,   19,   19,   19,   28,   29,
+       30,   19,   19,   31,   32,   19,   19,   19,   19,   33,
+       19,   19,    1,    1,    1,    1,    1,    1,    1,    1,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
@@ -661,56 +662,64 @@ static const YY_CHAR yy_ec[256] =
         1,    1,    1,    1,    1
     } ;
 
-static const YY_CHAR yy_meta[32] =
+static const YY_CHAR yy_meta[34] =
     {   0,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
-        2,    1,    2,    1,    1,    1,    1,    2,    1,    1,
-        2,    2,    2,    2,    2,    2,    2,    2,    2,    2,
-        2
+        1,    2,    1,    2,    1,    1,    1,    1,    2,    2,
+        1,    1,    2,    2,    2,    2,    2,    2,    2,    2,
+        2,    2,    2
     } ;
 
-static const flex_int16_t yy_base[51] =
+static const flex_int16_t yy_base[60] =
     {   0,
-        0,    0,   55,   56,   56,   56,   38,   56,   56,   46,
-       56,   56,   56,   40,   38,   56,   34,   33,   32,    0,
-       44,   56,   10,   12,   13,   17,   56,   56,   56,   32,
-       56,   56,   56,    0,   56,   14,   20,   20,    0,   10,
-       13,    0,    0,    0,    9,    0,    0,    0,   56,   33
+        0,    0,   76,   77,   77,   77,   58,   77,   77,   66,
+       77,   77,   77,   59,   59,   29,   77,   54,   53,   52,
+        0,   65,   77,   11,   13,   15,   36,   77,   77,   30,
+       77,   32,   31,   42,   52,   77,   77,   77,    0,   77,
+       33,   39,   39,    0,   28,   31,    0,   38,   45,   43,
+        0,    0,   23,    0,    0,   39,    0,   77,   46
     } ;
 
-static const flex_int16_t yy_def[51] =
+static const flex_int16_t yy_def[60] =
     {   0,
-       49,    1,   49,   49,   49,   49,   49,   49,   49,   49,
-       49,   49,   49,   49,   49,   49,   49,   49,   49,   50,
-       49,   49,   50,   50,   50,   50,   49,   49,   49,   49,
-       49,   49,   49,   50,   49,   50,   50,   50,   50,   50,
-       50,   50,   50,   50,   50,   50,   50,   50,    0,   49
+       58,    1,   58,   58,   58,   58,   58,   58,   58,   58,
+       58,   58,   58,   58,   58,   58,   58,   58,   58,   58,
+       59,   58,   58,   59,   59,   59,   59,   58,   58,   58,
+       58,   58,   58,   58,   58,   58,   58,   58,   59,   58,
+       59,   59,   59,   59,   59,   59,   59,   58,   58,   58,
+       59,   59,   59,   59,   59,   58,   59,    0,   58
     } ;
 
-static const flex_int16_t yy_nxt[88] =
+static const flex_int16_t yy_nxt[111] =
     {   0,
-        4,    5,    6,    7,    8,    9,   10,   11,   12,   13,
-        4,   14,   15,   16,   17,   18,   19,   20,   21,   22,
-       23,   20,   20,   20,   24,   25,   20,   26,   20,   20,
-       20,   36,   38,   40,   34,   39,   37,   41,   48,   47,
-       46,   45,   44,   43,   30,   42,   35,   33,   32,   31,
-       30,   29,   28,   27,   49,    3,   49,   49,   49,   49,
-       49,   49,   49,   49,   49,   49,   49,   49,   49,   49,
-       49,   49,   49,   49,   49,   49,   49,   49,   49,   49,
-       49,   49,   49,   49,   49,   49,   49
+        4,    5,    6,    7,    4,    8,    9,   10,   11,   12,
+       13,   14,   15,   16,   17,   18,   19,   20,   21,   21,
+       22,   23,   24,   21,   21,   21,   25,   26,   21,   27,
+       21,   21,   21,   32,   41,   43,   32,   45,   44,   42,
+       33,   46,   34,   30,   48,   32,   32,   39,   35,   35,
+       49,   48,   56,   33,   57,   34,   50,   49,   56,   55,
+       54,   35,   53,   52,   51,   50,   47,   40,   38,   37,
+       36,   31,   30,   29,   28,   58,    3,   58,   58,   58,
+       58,   58,   58,   58,   58,   58,   58,   58,   58,   58,
+       58,   58,   58,   58,   58,   58,   58,   58,   58,   58,
+
+       58,   58,   58,   58,   58,   58,   58,   58,   58,   58
     } ;
 
-static const flex_int16_t yy_chk[88] =
+static const flex_int16_t yy_chk[111] =
     {   0,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
-        1,   23,   24,   25,   50,   24,   23,   25,   45,   41,
-       40,   38,   37,   36,   30,   26,   21,   19,   18,   17,
-       15,   14,   10,    7,    3,   49,   49,   49,   49,   49,
-       49,   49,   49,   49,   49,   49,   49,   49,   49,   49,
-       49,   49,   49,   49,   49,   49,   49,   49,   49,   49,
-       49,   49,   49,   49,   49,   49,   49
+        1,    1,    1,   16,   24,   25,   32,   26,   25,   24,
+       16,   26,   16,   30,   33,   32,   34,   59,   16,   30,
+       33,   48,   56,   34,   53,   34,   50,   48,   49,   46,
+       45,   34,   43,   42,   41,   35,   27,   22,   20,   19,
+       18,   15,   14,   10,    7,    3,   58,   58,   58,   58,
+       58,   58,   58,   58,   58,   58,   58,   58,   58,   58,
+       58,   58,   58,   58,   58,   58,   58,   58,   58,   58,
+
+       58,   58,   58,   58,   58,   58,   58,   58,   58,   58
     } ;
 
 static yy_state_type yy_last_accepting_state;
@@ -735,6 +744,7 @@ char *yytext;
 #define YY_NO_INPUT 1
  /* Tokens NUMBER, SYMBOL, F1, POW, F2, etc. are defined in amrex_iparser.y. */
  /* Types IPARSER_ABS, IPARSER_MIN etc. are defined in AMReX_IParser_y.H. */
+ /* Used later to define NUMBER */
 
 #define INITIAL 0
 
@@ -975,13 +985,13 @@ yy_match:
 			while ( yy_chk[yy_base[yy_current_state] + yy_c] != yy_current_state )
 				{
 				yy_current_state = (int) yy_def[yy_current_state];
-				if ( yy_current_state >= 50 )
+				if ( yy_current_state >= 59 )
 					yy_c = yy_meta[yy_c];
 				}
 			yy_current_state = yy_nxt[yy_base[yy_current_state] + yy_c];
 			++yy_cp;
 			}
-		while ( yy_current_state != 49 );
+		while ( yy_current_state != 58 );
 		yy_cp = (yy_last_accepting_cpos);
 		yy_current_state = (yy_last_accepting_state);
 
@@ -1080,30 +1090,32 @@ YY_RULE_SETUP
 	YY_BREAK
 /* Number */
 case 27:
+case 28:
+case 29:
 YY_RULE_SETUP
-{ amrex_iparserlval.d = std::atoi(amrex_iparsertext);   return NUMBER; }
+{ amrex_iparserlval.d = amrex::iparser_atoll(amrex_iparsertext);   return NUMBER; }
 	YY_BREAK
 /* Special characters */
-case 28:
+case 30:
 YY_RULE_SETUP
 /* ignore white space */
 	YY_BREAK
-case 29:
-/* rule 29 can match eol */
+case 31:
+/* rule 31 can match eol */
 YY_RULE_SETUP
 /* ignore line continuation */
 	YY_BREAK
-case 30:
-/* rule 30 can match eol */
+case 32:
+/* rule 32 can match eol */
 YY_RULE_SETUP
 { return EOL; }
 	YY_BREAK
 /* everything else */
-case 31:
+case 33:
 YY_RULE_SETUP
 { amrex_iparsererror("Unknown character %c", *amrex_iparsertext); }
 	YY_BREAK
-case 32:
+case 34:
 YY_RULE_SETUP
 YY_FATAL_ERROR( "flex scanner jammed" );
 	YY_BREAK
@@ -1404,7 +1416,7 @@ static int yy_get_next_buffer (void)
 		while ( yy_chk[yy_base[yy_current_state] + yy_c] != yy_current_state )
 			{
 			yy_current_state = (int) yy_def[yy_current_state];
-			if ( yy_current_state >= 50 )
+			if ( yy_current_state >= 59 )
 				yy_c = yy_meta[yy_c];
 			}
 		yy_current_state = yy_nxt[yy_base[yy_current_state] + yy_c];
@@ -1432,11 +1444,11 @@ static int yy_get_next_buffer (void)
 	while ( yy_chk[yy_base[yy_current_state] + yy_c] != yy_current_state )
 		{
 		yy_current_state = (int) yy_def[yy_current_state];
-		if ( yy_current_state >= 50 )
+		if ( yy_current_state >= 59 )
 			yy_c = yy_meta[yy_c];
 		}
 	yy_current_state = yy_nxt[yy_base[yy_current_state] + yy_c];
-	yy_is_jam = (yy_current_state == 49);
+	yy_is_jam = (yy_current_state == 58);
 
 		return yy_is_jam ? 0 : yy_current_state;
 }

--- a/Src/Base/Parser/amrex_iparser.tab.h
+++ b/Src/Base/Parser/amrex_iparser.tab.h
@@ -89,7 +89,7 @@ union AMREX_IPARSERSTYPE
 {
 
     struct amrex::iparser_node* n;
-    int d;
+    long long d;
     struct amrex::iparser_symbol* s;
     enum amrex::iparser_f1_t f1;
     enum amrex::iparser_f2_t f2;

--- a/Src/Base/Parser/amrex_iparser.y
+++ b/Src/Base/Parser/amrex_iparser.y
@@ -26,7 +26,7 @@ int amrex_iparserlex (void);
 */
 %union {
     struct amrex::iparser_node* n;
-    int d;
+    long long d;
     struct amrex::iparser_symbol* s;
     enum amrex::iparser_f1_t f1;
     enum amrex::iparser_f2_t f2;

--- a/Tests/Parser/main.cpp
+++ b/Tests/Parser/main.cpp
@@ -373,7 +373,7 @@ int main (int argc, char* argv[])
         int count = 0;
         int x = 11;
         {
-            auto f = [&] (std::string const& s) -> int
+            auto f = [&] (std::string const& s)
             {
                 amrex::Print() << count++ << ". Testing \"" << s << "\"\n";
                 IParser iparser(s);
@@ -390,7 +390,7 @@ int main (int argc, char* argv[])
             AMREX_ALWAYS_ASSERT(f("x/13/5") == ((x/13)/5));
             AMREX_ALWAYS_ASSERT(f("13/x/5") == ((13/x)/5));
 
-            auto g = [&] (std::string const& s, std::string const& c, int cv) -> int
+            auto g = [&] (std::string const& s, std::string const& c, int cv)
             {
                 amrex::Print() << count++ << ". Testing \"" << s << "\"\n";
                 IParser iparser(s);
@@ -408,7 +408,7 @@ int main (int argc, char* argv[])
             AMREX_ALWAYS_ASSERT(g("x/b/5", "b", 13) == ((x/13)/5));
             AMREX_ALWAYS_ASSERT(g("b/x/5", "b", 13) == ((13/x)/5));
 
-            auto h = [&] (std::string const& s) -> int
+            auto h = [&] (std::string const& s)
             {
                 amrex::Print() << count++ << ". Testing \"" << s << "\"\n";
                 IParser iparser(s);
@@ -435,6 +435,31 @@ int main (int argc, char* argv[])
                     }
                 }
             }
+
+            AMREX_ALWAYS_ASSERT(h("123456789012345") == 123456789012345LL);
+            AMREX_ALWAYS_ASSERT(h("123456789012345.") == 123456789012345LL);
+            AMREX_ALWAYS_ASSERT(h("123'456'789'012'345") == 123456789012345LL);
+            AMREX_ALWAYS_ASSERT(h("1.23456789012345e14") == 123456789012345LL);
+            AMREX_ALWAYS_ASSERT(h("1.0E3") == 1000);
+            AMREX_ALWAYS_ASSERT(h("2**40") == 1024LL*1024LL*1024LL*1024LL);
+
+            auto test_bad_number = [&] (std::string const& s)
+            {
+                amrex::Print() << count++ << ". Testing \"" << s << "\"\n";
+                try {
+                    IParser iparser(s);
+                    auto exe = iparser.compileHost<0>();
+                    auto r = exe();
+                    amrex::ignore_unused(r);
+                    return false;
+                } catch (std::runtime_error const& e) {
+                    amrex::Print() << "    Expected error: " << e.what() << '\n';
+                    return true;
+                }
+            };
+            AMREX_ALWAYS_ASSERT(test_bad_number("1000000e-4"));
+            AMREX_ALWAYS_ASSERT(test_bad_number("1.234e2"));
+            AMREX_ALWAYS_ASSERT(test_bad_number("3.14"));
         }
         amrex::Print() << "\nAll IParser tests passed\n\n";
     }


### PR DESCRIPTION
* Use long long int as the underlying integer data type in IParser.

* Extend number format to include `3e9`, `2.34e6`, `1'000'000`, etc.
