### PR TITLE
ParmParse: Fix assertion in new queryarr for IntVect & RealVect

### DIFF
--- a/Src/Base/AMReX_ParmParse.cpp
+++ b/Src/Base/AMReX_ParmParse.cpp
@@ -1774,8 +1774,8 @@ ParmParse::queryarr (const char* name, IntVect& ref) const
 {
     std::vector<int> v;
     int exist = this->queryarr(name, v);
-    AMREX_ALWAYS_ASSERT(v.size() == AMREX_SPACEDIM);
     if (exist) {
+        AMREX_ALWAYS_ASSERT(v.size() == AMREX_SPACEDIM);
         for (int i = 0; i < AMREX_SPACEDIM; ++i) { ref[i] = v[i]; }
     }
     return exist;
@@ -1795,8 +1795,8 @@ ParmParse::queryarr (const char* name, RealVect& ref) const
 {
     std::vector<Real> v;
     int exist = this->queryarr(name, v);
-    AMREX_ALWAYS_ASSERT(v.size() == AMREX_SPACEDIM);
     if (exist) {
+        AMREX_ALWAYS_ASSERT(v.size() == AMREX_SPACEDIM);
         for (int i = 0; i < AMREX_SPACEDIM; ++i) { ref[i] = v[i]; }
     }
     return exist;


### PR DESCRIPTION
For query functions, we should not assert the size unless the name actually exists.

This fixes a bug in the new functions added in #4050.
