### PR TITLE
make ParmParse::prefixedName public

### DIFF
--- a/Src/Base/AMReX_ParmParse.H
+++ b/Src/Base/AMReX_ParmParse.H
@@ -1153,9 +1153,13 @@ public:
 
     static std::string ParserPrefix;
 
-protected:
-
+    /**
+     * \brief Prepend the prefix that this ParmParse object was constructed with to str.
+     * It is a run-time error if str is empty.
+     */
     [[nodiscard]] std::string prefixedName (const std::string_view& str) const;
+
+protected:
 
     std::string m_prefix; // Prefix used in keyword search
     std::string m_parser_prefix; // Prefix used by Parser


### PR DESCRIPTION
## Summary

For writing custom error messages, it would be useful to read m_prefix from ParmParse.

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
