### PR TITLE
Fix asan issue with tiny profiler

### DIFF
--- a/Src/Base/AMReX_TinyProfiler.cpp
+++ b/Src/Base/AMReX_TinyProfiler.cpp
@@ -419,7 +419,7 @@ TinyProfiler::PrintStats (std::map<std::string,Stats>& regstats, double dt_max)
         bool alreadySynced;
 
         for(auto const& kv : regstats) {
-            localStrings.push_back(kv.first);
+            localStrings.emplace_back(kv.first);
         }
 
         amrex::SyncStrings(localStrings, syncedStrings, alreadySynced);


### PR DESCRIPTION
## Summary
Fix a `container-overflow` AddressSanitizer error.

## Additional background

A `RelWithDebInfo`, clang 18 build gave me the following:
```
TinyProfiler total time across processes [min...avg...max]: 0.2733 ... 0.2733 ... 0.2733
=================================================================
==53679==ERROR: AddressSanitizer: container-overflow on address 0x60800000d768 at pc 0x000102d32e54 bp 0x00016d107dc0 sp 0x00016d107db8
WRITE of size 8 at 0x60800000d768 thread T0
    #0 0x102d32e50 in std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>::__init_copy_ctor_external(char const*, unsigned long) string:2240
    #1 0x102f00028 in amrex::TinyProfiler::PrintStats(std::__1::map<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, amrex::TinyProfiler::Stats, std::__1::less<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>, std::__1::allocator<std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const, amrex::TinyProfiler::Stats>>>&, double) AMReX_TinyProfiler.cpp:422
    #2 0x102effdb0 in amrex::TinyProfiler::Finalize(bool) AMReX_TinyProfiler.cpp:353
    #3 0x102e4eadc in amrex::Finalize(amrex::AMReX*) AMReX.cpp:743
    #4 0x102cf7da4 in main main.cpp:64
    #5 0x189f63fd4 in start+0x968 (dyld:arm64+0xfffffffffff63fd4)
    #6 0xb000fffffffffffc  (<unknown module>)
```

This change makes that error go away. Interestingly, I didn't see this error with a `Debug` build. 

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
