### PR TITLE
CI: Fix Catalyst CMAKE_PREFIX_PATH

### DIFF
--- a/.github/workflows/catalyst.yml
+++ b/.github/workflows/catalyst.yml
@@ -14,7 +14,7 @@ jobs:
     env:
       CXX: g++
       CC: gcc
-      CMAKE_PREFIX: "/opt/conduit;/opt/catalyst"
+      CMAKE_PREFIX_PATH: "/opt/conduit:/opt/catalyst"
     container:
       image: kitware/paraview:ci-catalyst-amrex-warpx-20240701
     steps:


### PR DESCRIPTION
## Summary

This appears to be a typo:
- env variable is `CMAKE_PREFIX_PATH`
- on Unix, paths are separated by `:` (Windows is `;`)

## Additional background

Follow-up to #4011

cc @ChristosT @c-wetterer-nelson

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
