### PR TITLE
ParmParse: queryarrWithParser

### DIFF
--- a/Src/Base/AMReX_ParmParse.H
+++ b/Src/Base/AMReX_ParmParse.H
@@ -1040,13 +1040,26 @@ public:
     /**
      * \brief Query with Parser. If `name` is found, this uses amrex::Parser
      * to parse the entire list of empty space separated values as a single
-     * scalar. The return value indicates whether it's found.
+     * scalar. The return value indicates whether it's found. Note that
+     * queryWithParser will be used recursively for unresolved symbols.
      */
     int queryWithParser (const char* name, int& ref) const;
     int queryWithParser (const char* name, long& ref) const;
     int queryWithParser (const char* name, long long& ref) const;
     int queryWithParser (const char* name, float& ref) const;
     int queryWithParser (const char* name, double& ref) const;
+
+    /**
+     * \brief Query with Parser. The return value indicates whether it's
+     * found. Note that queryWithParser will be used for unresolved
+     * symbols. If the number of elements in the input does not equal to
+     * `nvals`, it's a runtime error.
+     */
+    int queryarrWithParser (const char* name, int nvals, std::vector<int>& ref) const;
+    int queryarrWithParser (const char* name, int nvals, std::vector<long>& ref) const;
+    int queryarrWithParser (const char* name, int nvals, std::vector<long long>& ref) const;
+    int queryarrWithParser (const char* name, int nvals, std::vector<float>& ref) const;
+    int queryarrWithParser (const char* name, int nvals, std::vector<double>& ref) const;
 
     /**
      * \brief Query with Parser. If `name` is found, this uses amrex::Parser

--- a/Src/Base/AMReX_ParmParse.H
+++ b/Src/Base/AMReX_ParmParse.H
@@ -1055,11 +1055,25 @@ public:
      * symbols. If the number of elements in the input does not equal to
      * `nvals`, it's a runtime error.
      */
-    int queryarrWithParser (const char* name, int nvals, std::vector<int>& ref) const;
-    int queryarrWithParser (const char* name, int nvals, std::vector<long>& ref) const;
-    int queryarrWithParser (const char* name, int nvals, std::vector<long long>& ref) const;
-    int queryarrWithParser (const char* name, int nvals, std::vector<float>& ref) const;
-    int queryarrWithParser (const char* name, int nvals, std::vector<double>& ref) const;
+    int queryarrWithParser (const char* name, int nvals, int* ref) const;
+    int queryarrWithParser (const char* name, int nvals, long* ref) const;
+    int queryarrWithParser (const char* name, int nvals, long long* ref) const;
+    int queryarrWithParser (const char* name, int nvals, float* ref) const;
+    int queryarrWithParser (const char* name, int nvals, double* ref) const;
+    template <typename T, std::enable_if_t<std::is_same_v<T,int> ||
+                                           std::is_same_v<T,long> ||
+                                           std::is_same_v<T,long long> ||
+                                           std::is_same_v<T,float> ||
+                                           std::is_same_v<T,double>,int> = 0>
+    int queryarrWithParser (const char* name, int nvals, std::vector<T>& ref) const
+    {
+        if (this->contains(name)) {
+            if (int(ref.size()) < nvals) { ref.resize(nvals); }
+            return this->queryarrWithParser(name, nvals, ref.data());
+        } else {
+            return 0;
+        }
+    }
 
     /**
      * \brief Query with Parser. If `name` is found, this uses amrex::Parser

--- a/Src/Base/AMReX_ParmParse.H
+++ b/Src/Base/AMReX_ParmParse.H
@@ -1113,6 +1113,42 @@ public:
         }
     }
 
+    /**
+     * \brief Get with Parser. If `name` is not found, it's a runtime
+     * error. If the number of elements does not equal to `nvals`, it's also
+     * a runtime error.
+     */
+    template <typename T, std::enable_if_t<std::is_same_v<T,int> ||
+                                           std::is_same_v<T,long> ||
+                                           std::is_same_v<T,long long> ||
+                                           std::is_same_v<T,float> ||
+                                           std::is_same_v<T,double>,int> = 0>
+    void getarrWithParser (const char* name, int nvals, T* ref) const
+    {
+        int exist = this->queryarrWithParser(name, nvals, ref);
+        if (!exist) {
+            amrex::Error(std::string("ParmParse::getarrWithParser: failed to get ")+name);
+        }
+    }
+
+    /**
+     * \brief Get with Parser. If `name` is not found, it's a runtime
+     * error. If the number of elements does not equal to `nvals`, it's also
+     * a runtime error.
+     */
+    template <typename T, std::enable_if_t<std::is_same_v<T,int> ||
+                                           std::is_same_v<T,long> ||
+                                           std::is_same_v<T,long long> ||
+                                           std::is_same_v<T,float> ||
+                                           std::is_same_v<T,double>,int> = 0>
+    void getarrWithParser (const char* name, int nvals, std::vector<T>& ref) const
+    {
+        int exist = this->queryarrWithParser(name, nvals, ref);
+        if (!exist) {
+            amrex::Error(std::string("ParmParse::getarrWithParser: failed to get ")+name);
+        }
+    }
+
     /*
      * \brief Query two names.
      *

--- a/Src/Base/AMReX_ParmParse.cpp
+++ b/Src/Base/AMReX_ParmParse.cpp
@@ -1895,7 +1895,7 @@ bool squeryarrWithParser (const ParmParse::Table& table,
                           const std::string&      parser_prefix,
                           const std::string&      name,
                           int                     nvals,
-                          std::vector<T>&         ref)
+                          T*                      ref)
 {
     std::vector<std::string> vals;
     bool exist = squeryarr(table, parser_prefix, name, vals,
@@ -1903,9 +1903,6 @@ bool squeryarrWithParser (const ParmParse::Table& table,
     if (!exist) { return false; }
 
     AMREX_ALWAYS_ASSERT(int(vals.size()) == nvals);
-    if (ref.size() < vals.size()) {
-        ref.resize(nvals);
-    }
     for (int ival = 0; ival < nvals; ++ival) {
         bool r = pp_parser(table, parser_prefix, name, vals[ival], ref[ival], true);
         if (!r) { return false; }
@@ -1945,31 +1942,31 @@ ParmParse::queryWithParser (const char* name, double& ref) const
 }
 
 int
-ParmParse::queryarrWithParser (const char* name, int nvals, std::vector<int>& ref) const
+ParmParse::queryarrWithParser (const char* name, int nvals, int* ref) const
 {
     return squeryarrWithParser(*m_table,m_parser_prefix,prefixedName(name),nvals,ref);
 }
 
 int
-ParmParse::queryarrWithParser (const char* name, int nvals, std::vector<long>& ref) const
+ParmParse::queryarrWithParser (const char* name, int nvals, long* ref) const
 {
     return squeryarrWithParser(*m_table,m_parser_prefix,prefixedName(name),nvals,ref);
 }
 
 int
-ParmParse::queryarrWithParser (const char* name, int nvals, std::vector<long long>& ref) const
+ParmParse::queryarrWithParser (const char* name, int nvals, long long* ref) const
 {
     return squeryarrWithParser(*m_table,m_parser_prefix,prefixedName(name),nvals,ref);
 }
 
 int
-ParmParse::queryarrWithParser (const char* name, int nvals, std::vector<float>& ref) const
+ParmParse::queryarrWithParser (const char* name, int nvals, float* ref) const
 {
     return squeryarrWithParser(*m_table,m_parser_prefix,prefixedName(name),nvals,ref);
 }
 
 int
-ParmParse::queryarrWithParser (const char* name, int nvals, std::vector<double>& ref) const
+ParmParse::queryarrWithParser (const char* name, int nvals, double* ref) const
 {
     return squeryarrWithParser(*m_table,m_parser_prefix,prefixedName(name),nvals,ref);
 }

--- a/Src/Base/AMReX_ParmParse.cpp
+++ b/Src/Base/AMReX_ParmParse.cpp
@@ -625,7 +625,8 @@ bldTable (const char*& str, ParmParse::Table& tab)
 
 template <typename T>
 bool pp_parser (const ParmParse::Table& table, const std::string& parser_prefix,
-                const std::string& name, const std::string& val, T& ref);
+                const std::string& name, const std::string& val, T& ref,
+                bool use_querywithparser);
 
 template <class T>
 bool
@@ -673,7 +674,7 @@ squeryval (const ParmParse::Table& table,
                       std::is_same_v<T,long long> ||
                       std::is_same_v<T,float> ||
                       std::is_same_v<T,double>) {
-            if (pp_parser(table, parser_prefix, name, valname, ref)) {
+            if (pp_parser(table, parser_prefix, name, valname, ref, false)) {
                 return true;
             }
         }
@@ -786,7 +787,7 @@ squeryarr (const ParmParse::Table& table,
                           std::is_same_v<T,long long> ||
                           std::is_same_v<T,float> ||
                           std::is_same_v<T,double>) {
-                if (pp_parser(table, parser_prefix, name, valname, ref[n])) {
+                if (pp_parser(table, parser_prefix, name, valname, ref[n], false)) {
                     continue;
                 }
             }
@@ -938,11 +939,18 @@ void pp_print_unused (const std::string& pfx, const ParmParse::Table& table)
     }
 }
 
+template <class T>
+bool squeryWithParser (const ParmParse::Table& table,
+                       const std::string&      parser_prefix,
+                       const std::string&      name,
+                       T&                      ref);
+
 template <typename T, typename PARSER_t = std::conditional_t<std::is_integral_v<T>,
                                                              IParser, Parser>>
 PARSER_t
 pp_make_parser (std::string const& func, Vector<std::string> const& vars,
-                ParmParse::Table const& table, std::string const& parser_prefix)
+                ParmParse::Table const& table, std::string const& parser_prefix,
+                bool use_querywithparser)
 {
     using value_t =  std::conditional_t<std::is_integral_v<T>, long long, double>;
 
@@ -967,8 +975,12 @@ pp_make_parser (std::string const& func, Vector<std::string> const& vars,
         value_t v = 0;
         bool r = false;
         for (auto const& pf : prefixes) {
-            r = squeryval(table, parser_prefix, pf+s, v,
-                          ParmParse::FIRST, ParmParse::LAST);
+            if (use_querywithparser) {
+                r = squeryWithParser(table, parser_prefix, pf+s, v);
+            } else {
+                r = squeryval(table, parser_prefix, pf+s, v,
+                              ParmParse::FIRST, ParmParse::LAST);
+            }
             if (r) { break; }
         }
         if (r == false) {
@@ -985,7 +997,8 @@ pp_make_parser (std::string const& func, Vector<std::string> const& vars,
 
 template <typename T>
 bool pp_parser (const ParmParse::Table& table, const std::string& parser_prefix,
-                const std::string& name, const std::string& val, T& ref)
+                const std::string& name, const std::string& val, T& ref,
+                bool use_querywithparser)
 {
     auto& recursive_symbols = g_parser_recursive_symbols[OpenMP::get_thread_num()];
     if (auto found = recursive_symbols.find(name); found != recursive_symbols.end()) {
@@ -995,7 +1008,7 @@ bool pp_parser (const ParmParse::Table& table, const std::string& parser_prefix,
         recursive_symbols.insert(name);
     }
 
-    auto parser = pp_make_parser<T>(val, {}, table, parser_prefix);
+    auto parser = pp_make_parser<T>(val, {}, table, parser_prefix, use_querywithparser);
     auto exe = parser.template compileHost<0>();
     ref = static_cast<T>(exe());
 
@@ -1874,7 +1887,30 @@ bool squeryWithParser (const ParmParse::Table& table,
     for (auto const& v : vals) {
         combined_string.append(v);
     }
-    return pp_parser(table, parser_prefix, name, combined_string, ref);
+    return pp_parser(table, parser_prefix, name, combined_string, ref, true);
+}
+
+template <class T>
+bool squeryarrWithParser (const ParmParse::Table& table,
+                          const std::string&      parser_prefix,
+                          const std::string&      name,
+                          int                     nvals,
+                          std::vector<T>&         ref)
+{
+    std::vector<std::string> vals;
+    bool exist = squeryarr(table, parser_prefix, name, vals,
+                           ParmParse::FIRST, ParmParse::ALL, ParmParse::LAST);
+    if (!exist) { return false; }
+
+    AMREX_ALWAYS_ASSERT(int(vals.size()) == nvals);
+    if (ref.size() < vals.size()) {
+        ref.resize(nvals);
+    }
+    for (int ival = 0; ival < nvals; ++ival) {
+        bool r = pp_parser(table, parser_prefix, name, vals[ival], ref[ival], true);
+        if (!r) { return false; }
+    }
+    return true;
 }
 }
 
@@ -1908,18 +1944,48 @@ ParmParse::queryWithParser (const char* name, double& ref) const
     return squeryWithParser(*m_table,m_parser_prefix,prefixedName(name),ref);
 }
 
+int
+ParmParse::queryarrWithParser (const char* name, int nvals, std::vector<int>& ref) const
+{
+    return squeryarrWithParser(*m_table,m_parser_prefix,prefixedName(name),nvals,ref);
+}
+
+int
+ParmParse::queryarrWithParser (const char* name, int nvals, std::vector<long>& ref) const
+{
+    return squeryarrWithParser(*m_table,m_parser_prefix,prefixedName(name),nvals,ref);
+}
+
+int
+ParmParse::queryarrWithParser (const char* name, int nvals, std::vector<long long>& ref) const
+{
+    return squeryarrWithParser(*m_table,m_parser_prefix,prefixedName(name),nvals,ref);
+}
+
+int
+ParmParse::queryarrWithParser (const char* name, int nvals, std::vector<float>& ref) const
+{
+    return squeryarrWithParser(*m_table,m_parser_prefix,prefixedName(name),nvals,ref);
+}
+
+int
+ParmParse::queryarrWithParser (const char* name, int nvals, std::vector<double>& ref) const
+{
+    return squeryarrWithParser(*m_table,m_parser_prefix,prefixedName(name),nvals,ref);
+}
+
 Parser
 ParmParse::makeParser (std::string const& func,
                        Vector<std::string> const& vars) const
 {
-    return pp_make_parser<double>(func, vars, *m_table, m_parser_prefix);
+    return pp_make_parser<double>(func, vars, *m_table, m_parser_prefix, true);
 }
 
 IParser
 ParmParse::makeIParser (std::string const& func,
                         Vector<std::string> const& vars) const
 {
-    return pp_make_parser<long long>(func, vars, *m_table, m_parser_prefix);
+    return pp_make_parser<long long>(func, vars, *m_table, m_parser_prefix, true);
 }
 
 }


### PR DESCRIPTION
Add a new function queryarrWithParser that will query an array of values using Parser. The function takes the number of elements as an argument too. If the size of the input found with ParmParse does not match the size argument, it's a runtime error. For each individual array element, queryWithParser is used for the query.

The behavior of queryWithParser has changed. Previously, the query function is used for unresolved symbols. Now the queryWithParser function is used instead. The difference is that the latter will ignore the spaces in the input and combine the entire input into a single string.
