### PR TITLE
Make sure ChopGrids does not violate refinement ratio.

### DIFF
--- a/Src/AmrCore/AMReX_AmrMesh.cpp
+++ b/Src/AmrCore/AMReX_AmrMesh.cpp
@@ -501,9 +501,7 @@ AmrMesh::ChopGrids (int lev, BoxArray& ba, int target_size) const
                     } else {
                         IntVect bf(1);
                         bf[idim] = rr;
-                        ba.coarsen(bf); // It's safe to coarsen.
-                        ba.maxSize(chunk/bf);
-                        ba.refine(bf);
+                        ba.minmaxSize(bf, chunk);
                     }
                     break;
                 }

--- a/Src/AmrCore/AMReX_AmrMesh.cpp
+++ b/Src/AmrCore/AMReX_AmrMesh.cpp
@@ -489,14 +489,14 @@ AmrMesh::ChopGrids (int lev, BoxArray& ba, int target_size) const
             if (refine_grid_layout_dims[idim]) {
                 int new_chunk_size = chunk[idim] / 2;
                 int rr = (lev > 0) ? ref_ratio[lev-1][idim] : 1;
-                if (lev > 0) {
+                if (rr > 1) {
                     new_chunk_size = (new_chunk_size/rr) * rr;
                 }
                 if (new_chunk_size != 0 &&
                     new_chunk_size%blocking_factor[lev][idim] == 0)
                 {
                     chunk[idim] = new_chunk_size;
-                    if (lev == 0) {
+                    if (rr == 1) {
                         ba.maxSize(chunk);
                     } else {
                         IntVect bf(1);

--- a/Src/AmrCore/AMReX_AmrMesh.cpp
+++ b/Src/AmrCore/AMReX_AmrMesh.cpp
@@ -501,6 +501,9 @@ AmrMesh::ChopGrids (int lev, BoxArray& ba, int target_size) const
                     } else {
                         IntVect bf(1);
                         bf[idim] = rr;
+                        // Note that only idim-direction will be chopped by
+                        // minmaxSize because the sizes in other directions
+                        // are already smaller than chunk.
                         ba.minmaxSize(bf, chunk);
                     }
                     break;

--- a/Src/Base/AMReX_BoxArray.H
+++ b/Src/Base/AMReX_BoxArray.H
@@ -615,6 +615,11 @@ public:
 
     BoxArray& maxSize (const IntVect& block_size);
 
+    //! Forces each Box in BoxArray to have sizes >= min_size and <=
+    //! max_size. It's the caller's responsibility to make sure both the
+    //! BoxArray and max_size are coarsenable by min_size.
+    BoxArray& minmaxSize (const IntVect& min_size, const IntVect& max_size);
+
     //! Refine each Box in the BoxArray to the specified ratio.
     BoxArray& refine (int refinement_ratio);
 

--- a/Src/Base/AMReX_BoxArray.cpp
+++ b/Src/Base/AMReX_BoxArray.cpp
@@ -555,12 +555,26 @@ BoxArray::maxSize (const IntVect& block_size)
     blst.maxSize(block_size);
     const int N = static_cast<int>(blst.size());
     if (size() != N) { // If size doesn't change, do nothing.
-        BoxList bak = (m_simplified_list) ? *m_simplified_list : BoxList();
+        auto bak = m_simplified_list;
         define(std::move(blst));
-        if (bak.isNotEmpty()) {
-            m_simplified_list = std::make_shared<BoxList>(std::move(bak));
-        }
+        m_simplified_list = bak;
     }
+    return *this;
+}
+
+BoxArray&
+BoxArray::minmaxSize (const IntVect& min_size, const IntVect& max_size)
+{
+    AMREX_ASSERT(this->coarsenable(min_size) &&
+                 (max_size/min_size)*min_size == max_size);
+    std::shared_ptr<BoxList> bak;
+    if (m_bat.is_simple() && crseRatio() == IntVect::TheUnitVector()) {
+        bak = m_simplified_list;
+    }
+    this->coarsen(min_size);
+    this->maxSize(max_size/min_size);
+    this->refine(min_size);
+    m_simplified_list = bak;
     return *this;
 }
 


### PR DESCRIPTION
When using ChopGrids on fine level BoxArrays, we must make sure the box sizes are multiples of refinement ratios.
