### PR TITLE
BLBackTrace: Check for `addr2line` in path first

### DIFF
--- a/Src/Base/AMReX_BLBackTrace.cpp
+++ b/Src/Base/AMReX_BLBackTrace.cpp
@@ -182,12 +182,12 @@ namespace {
 #ifdef __linux__
     bool command_exists(std::string const &cmd)
     {
-      // command -v is part of POSIX so should be available
-      std::string check_command = "command -v " + cmd + " > /dev/null 2>&1";
-      int r = std::system(check_command.c_str());
-      // return value of std::system is implementation defined and can be
-      // decoded using WEXITSTATUS but it should be 0 on success
-      return r == 0;
+        // command -v is part of POSIX so should be available
+        std::string check_command = "command -v " + cmd + " > /dev/null 2>&1";
+        int r = std::system(check_command.c_str());
+        // return value of std::system is implementation defined and can be
+        // decoded using WEXITSTATUS but it should be 0 on success
+        return r == 0;
     }
 #endif
 }
@@ -222,14 +222,14 @@ BLBackTrace::print_backtrace_info (FILE* f)
         int have_addr2line = 0;
         std::string eu_cmd;
         {
-          if (command_exists("eu-addr2line")) {
-            have_eu_addr2line = 1;
-            eu_cmd = "eu-addr2line";
-          } else {
-            std::string eu_fallback_path = "/usr/bin/eu-addr2line";
-            have_eu_addr2line = file_exists(eu_fallback_path.c_str());
-            eu_cmd = eu_fallback_path;
-          }
+            if (command_exists("eu-addr2line")) {
+                have_eu_addr2line = 1;
+                eu_cmd = "eu-addr2line";
+            } else {
+                std::string eu_fallback_path = "/usr/bin/eu-addr2line";
+                have_eu_addr2line = file_exists(eu_fallback_path.c_str());
+                eu_cmd = eu_fallback_path;
+            }
             if (have_eu_addr2line) {
                 const pid_t pid = getpid();
                 // cmd = "/usr/bin/eu-addr2line -C -f -i --pretty-print -p "
@@ -238,16 +238,16 @@ BLBackTrace::print_backtrace_info (FILE* f)
         }
         std::string cmd;
         {
-          if (command_exists("addr2line")) {
-            have_addr2line = 1;
-            cmd = "addr2line";
-          } else {
-            std::string fallback_path = "/usr/bin/addr2line";
-            have_addr2line = file_exists(fallback_path.c_str());
-            cmd = fallback_path;
-          }
+            if (command_exists("addr2line")) {
+                have_addr2line = 1;
+                cmd = "addr2line";
+            } else {
+                std::string fallback_path = "/usr/bin/addr2line";
+                have_addr2line = file_exists(fallback_path.c_str());
+                cmd = fallback_path;
+            }
             if (have_addr2line) {
-              cmd += " -Cpfie " + amrex::system::exename;
+                cmd += " -Cpfie " + amrex::system::exename;
             }
         }
 

--- a/Src/Base/AMReX_BLBackTrace.cpp
+++ b/Src/Base/AMReX_BLBackTrace.cpp
@@ -228,7 +228,7 @@ BLBackTrace::print_backtrace_info (FILE* f)
             } else {
                 std::string eu_fallback_path = "/usr/bin/eu-addr2line";
                 have_eu_addr2line = file_exists(eu_fallback_path.c_str());
-                eu_cmd = eu_fallback_path;
+                eu_cmd = std::move(eu_fallback_path);
             }
             if (have_eu_addr2line) {
                 const pid_t pid = getpid();
@@ -244,7 +244,7 @@ BLBackTrace::print_backtrace_info (FILE* f)
             } else {
                 std::string fallback_path = "/usr/bin/addr2line";
                 have_addr2line = file_exists(fallback_path.c_str());
-                cmd = fallback_path;
+                cmd = std::move(fallback_path);
             }
             if (have_addr2line) {
                 cmd += " -Cpfie " + amrex::system::exename;

--- a/Src/Base/AMReX_BLBackTrace.cpp
+++ b/Src/Base/AMReX_BLBackTrace.cpp
@@ -13,12 +13,13 @@
 #include <AMReX_TinyProfiler.H>
 #endif
 
+#include <csignal>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <fstream>
 #include <iostream>
 #include <sstream>
-#include <fstream>
-#include <cstring>
-#include <cstdio>
-#include <csignal>
 
 #if !(defined(_MSC_VER) && defined(__CUDACC__))
 //MSVC can't pre-processor cfenv with `Zc:preprocessor`
@@ -177,6 +178,15 @@ namespace {
         }
         return r;
     }
+
+    bool command_exists(std::string const &cmd) {
+      // command -v is part of POSIX so should be available
+      std::string check_command = "command -v " + cmd + " > /dev/null 2>&1";
+      int r = std::system(check_command.c_str());
+      // return value of std::system is implementation defined and can be
+      // decoded using WEXITSTATUS but it should be 0 on success
+      return r == 0;
+    }
 }
 #endif
 
@@ -209,19 +219,32 @@ BLBackTrace::print_backtrace_info (FILE* f)
         int have_addr2line = 0;
         std::string eu_cmd;
         {
-            have_eu_addr2line = file_exists("/usr/bin/eu-addr2line");
+          if (command_exists("eu-addr2line")) {
+            have_eu_addr2line = 1;
+            eu_cmd = "eu-addr2line";
+          } else {
+            std::string eu_fallback_path = "/usr/bin/eu-addr2line";
+            have_eu_addr2line = file_exists(eu_fallback_path.c_str());
+            eu_cmd = eu_fallback_path;
+          }
             if (have_eu_addr2line) {
                 const pid_t pid = getpid();
                 // cmd = "/usr/bin/eu-addr2line -C -f -i --pretty-print -p "
-                eu_cmd = "/usr/bin/eu-addr2line -C -f -i -p "
-                    + std::to_string(pid);
+                eu_cmd += " -C -f -i -p " + std::to_string(pid);
             }
         }
         std::string cmd;
         {
-            have_addr2line = file_exists("/usr/bin/addr2line");
+          if (command_exists("addr2line")) {
+            have_addr2line = 1;
+            cmd = "addr2line";
+          } else {
+            std::string fallback_path = "/usr/bin/addr2line";
+            have_addr2line = file_exists(fallback_path.c_str());
+            cmd = fallback_path;
+          }
             if (have_addr2line) {
-                cmd = "/usr/bin/addr2line -Cpfie " + amrex::system::exename;
+              cmd += " -Cpfie " + amrex::system::exename;
             }
         }
 

--- a/Src/Base/AMReX_BLBackTrace.cpp
+++ b/Src/Base/AMReX_BLBackTrace.cpp
@@ -179,7 +179,9 @@ namespace {
         return r;
     }
 
-    bool command_exists(std::string const &cmd) {
+#ifdef __linux__
+    bool command_exists(std::string const &cmd)
+    {
       // command -v is part of POSIX so should be available
       std::string check_command = "command -v " + cmd + " > /dev/null 2>&1";
       int r = std::system(check_command.c_str());
@@ -187,6 +189,7 @@ namespace {
       // decoded using WEXITSTATUS but it should be 0 on success
       return r == 0;
     }
+#endif
 }
 #endif
 


### PR DESCRIPTION
## Summary
This fixes #4077 by first checking if `addr2line` or `eu-addr2line` is in the `PATH` first and then falls back to `/usr/bin/addr2line` or `/usr/bin/eu-addr2line` if not.

## Additional background
See #4077 for why using the hardcoded path is a problem.

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
