### PR TITLE
Time integrator interface updates

### DIFF
--- a/Src/Base/AMReX_FEIntegrator.H
+++ b/Src/Base/AMReX_FEIntegrator.H
@@ -53,9 +53,6 @@ public:
         // So we initialize S_new by copying the old state.
         IntegratorOps<T>::Copy(S_new, S_old);
 
-        // Call the pre RHS hook
-        BaseT::pre_rhs_action(S_new, time);
-
         // F = RHS(S, t)
         T& F = *F_nodes[0];
         BaseT::Rhs(F, S_new, time);

--- a/Src/Base/AMReX_IntegratorBase.H
+++ b/Src/Base/AMReX_IntegratorBase.H
@@ -165,31 +165,25 @@ protected:
     /**
      * \brief Rhs is the right-hand-side function the integrator will use.
      */
-    std::function<void(T& rhs, const T& state, const amrex::Real time)> Rhs;
+    std::function<void(T& rhs, T& state, const amrex::Real time)> Rhs;
 
     /**
      * \brief RhsIm is the implicit right-hand-side function an ImEx integrator
      * will use.
      */
-    std::function<void(T& rhs, const T& state, const amrex::Real time)> RhsIm;
+    std::function<void(T& rhs, T& state, const amrex::Real time)> RhsIm;
 
     /**
      * \brief RhsEx is the explicit right-hand-side function an ImEx integrator
      * will use.
      */
-    std::function<void(T& rhs, const T& state, const amrex::Real time)> RhsEx;
+    std::function<void(T& rhs, T& state, const amrex::Real time)> RhsEx;
 
     /**
      * \brief RhsFast is the fast timescale right-hand-side function a multirate
      * integrator will use.
      */
-    std::function<void(T& rhs, const T& state, const amrex::Real time)> RhsFast;
-
-    /**
-     * \brief The pre_rhs_action function is called by the integrator on state
-     * data before using it to evaluate a right-hand side.
-     */
-    std::function<void (T&, amrex::Real)> pre_rhs_action;
+    std::function<void(T& rhs, T& state, const amrex::Real time)> RhsFast;
 
     /**
      * \brief The post_stage_action function is called by the integrator on
@@ -283,26 +277,21 @@ public:
 
     virtual ~IntegratorBase () = default;
 
-    void set_rhs (std::function<void(T&, const T&, const amrex::Real)> F)
+    void set_rhs (std::function<void(T&, T&, const amrex::Real)> F)
     {
         Rhs = F;
     }
 
-    void set_imex_rhs (std::function<void(T&, const T&, const amrex::Real)> Fi,
-                       std::function<void(T&, const T&, const amrex::Real)> Fe)
+    void set_imex_rhs (std::function<void(T&, T&, const amrex::Real)> Fi,
+                       std::function<void(T&, T&, const amrex::Real)> Fe)
     {
         RhsIm = Fi;
         RhsEx = Fe;
     }
 
-    void set_fast_rhs (std::function<void(T&, const T&, const amrex::Real)> F)
+    void set_fast_rhs (std::function<void(T&, T&, const amrex::Real)> F)
     {
         RhsFast = F;
-    }
-
-    void set_pre_rhs_action (std::function<void (T&, amrex::Real)> A)
-    {
-        pre_rhs_action = A;
     }
 
     void set_post_stage_action (std::function<void (T&, amrex::Real)> A)

--- a/Src/Base/AMReX_IntegratorBase.H
+++ b/Src/Base/AMReX_IntegratorBase.H
@@ -314,12 +314,6 @@ public:
         post_fast_step_action = A;
     }
 
-    void set_post_update (std::function<void (T&, amrex::Real)> A)
-    {
-        set_post_stage_action(A);
-        set_post_step_action(A);
-    }
-
     amrex::Real get_time_step ()
     {
         return time_step;

--- a/Src/Base/AMReX_RKIntegrator.H
+++ b/Src/Base/AMReX_RKIntegrator.H
@@ -217,9 +217,6 @@ public:
                 BaseT::post_stage_action(S_new, stage_time);
             }
 
-            // Call the update hook for the stage state value
-            BaseT::pre_rhs_action(S_new, stage_time);
-
             // Fill F[i], the RHS at the current stage
             // F[i] = RHS(y, t) at y = stage_value, t = stage_time
             BaseT::Rhs(*F_nodes[i], S_new, stage_time);

--- a/Src/Base/AMReX_TimeIntegrator.H
+++ b/Src/Base/AMReX_TimeIntegrator.H
@@ -167,11 +167,6 @@ public:
         integrator_ptr->set_post_fast_step_action(A);
     }
 
-    void set_post_update (std::function<void (T&, amrex::Real)> A)
-    {
-        integrator_ptr->set_post_update(A);
-    }
-
     amrex::Real get_time_step ()
     {
         return integrator_ptr->get_time_step();

--- a/Src/Base/AMReX_TimeIntegrator.H
+++ b/Src/Base/AMReX_TimeIntegrator.H
@@ -65,16 +65,13 @@ private:
     void set_default_functions ()
     {
         // By default, do nothing in the RHS
-        set_rhs([](T& /* S_rhs */, const T& /* S_data */, const amrex::Real /* time */){});
-        set_imex_rhs([](T& /* S_rhs */, const T& /* S_data */, const amrex::Real /* time */){},
-                     [](T& /* S_rhs */, const T& /* S_data */, const amrex::Real /* time */){});
-        set_fast_rhs([](T& /* S_rhs */, const T& /* S_data */, const amrex::Real /* time */){});
+        set_rhs([](T& /* S_rhs */, T& /* S_data */, const amrex::Real /* time */){});
+        set_imex_rhs([](T& /* S_rhs */, T& /* S_data */, const amrex::Real /* time */){},
+                     [](T& /* S_rhs */, T& /* S_data */, const amrex::Real /* time */){});
+        set_fast_rhs([](T& /* S_rhs */, T& /* S_data */, const amrex::Real /* time */){});
 
         // In general, the following functions can be used to fill BCs. Which
         // function to set will depend on the method type and intended use case
-
-        // By default, do nothing before calling the RHS
-        set_pre_rhs_action([](T& /* S_data */, amrex::Real /* time */){});
 
         // By default, do nothing after a stage or step
         set_post_stage_action([](T& /* S_data */, const amrex::Real /* time */){});
@@ -134,25 +131,20 @@ public:
         }
     }
 
-    void set_rhs (std::function<void(T&, const T&, const amrex::Real)> F)
+    void set_rhs (std::function<void(T&, T&, const amrex::Real)> F)
     {
         integrator_ptr->set_rhs(F);
     }
 
-    void set_imex_rhs (std::function<void(T&, const T&, const amrex::Real)> Fi,
-                       std::function<void(T&, const T&, const amrex::Real)> Fe)
+    void set_imex_rhs (std::function<void(T&, T&, const amrex::Real)> Fi,
+                       std::function<void(T&, T&, const amrex::Real)> Fe)
     {
         integrator_ptr->set_imex_rhs(Fi, Fe);
     }
 
-    void set_fast_rhs (std::function<void(T&, const T&, const amrex::Real)> F)
+    void set_fast_rhs (std::function<void(T&, T&, const amrex::Real)> F)
     {
         integrator_ptr->set_fast_rhs(F);
-    }
-
-    void set_pre_rhs_action (std::function<void (T&, amrex::Real)> A)
-    {
-        integrator_ptr->set_pre_rhs_action(A);
     }
 
     void set_post_stage_action (std::function<void (T&, amrex::Real)> A)

--- a/Src/Extern/SUNDIALS/AMReX_SundialsIntegrator.H
+++ b/Src/Extern/SUNDIALS/AMReX_SundialsIntegrator.H
@@ -428,7 +428,6 @@ public:
             T S_rhs;
             unpack_vector(y_rhs, S_rhs);
 
-            BaseT::pre_rhs_action(S_data, rhs_time);
             BaseT::Rhs(S_rhs, S_data, rhs_time);
 
             return 0;
@@ -443,7 +442,6 @@ public:
             T S_rhs;
             unpack_vector(y_rhs, S_rhs);
 
-            BaseT::pre_rhs_action(S_data, rhs_time);
             BaseT::RhsIm(S_rhs, S_data, rhs_time);
 
             return 0;
@@ -458,7 +456,6 @@ public:
             T S_rhs;
             unpack_vector(y_rhs, S_rhs);
 
-            BaseT::pre_rhs_action(S_data, rhs_time);
             BaseT::RhsEx(S_rhs, S_data, rhs_time);
 
             return 0;
@@ -473,7 +470,6 @@ public:
             T S_rhs;
             unpack_vector(y_rhs, S_rhs);
 
-            BaseT::pre_rhs_action(S_data, rhs_time);
             BaseT::RhsFast(S_rhs, S_data, rhs_time);
 
             return 0;


### PR DESCRIPTION
## Summary

Remove `const` on input state to time integrator right-hand side (RHS) functions to allow filling ghost cells within the RHS call. Remove the `set_pre_rhs_action` and `set_post_update` functions in the time integrator interface. Update documentation to reflect changes from #3984.

## Additional background

Before the updates in #3984 a `set_post_update` was used attach a function for filling ghost cells after computing a new stage or solution in a time integrator. #3984 expanded the time integrator interface with SUNDIALS to support implicit and ImEx methods which require updating the ghost cells for RHS evaluations inside iterative solvers. To support these methods, a new `set_pre_rhs_action` function was added to attach a function for filling ghost cells. This created some confusion/inconsistencies in how to fill ghost cells between explicit and implicit methods. To simplify things, this PR removes `const` from the input state to a RHS function so its ghost cells can be filled as part of the RHS callback and removes the `pre_rhs_action`/`set_post_update` functions. 

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [x] include documentation in the code and/or rst files, if appropriate

cc: @ajnonaka 