### PR TITLE
Fix a bug in ParmParse::remove

### DIFF
--- a/Src/Base/AMReX_ParmParse.cpp
+++ b/Src/Base/AMReX_ParmParse.cpp
@@ -1854,7 +1854,7 @@ int
 ParmParse::remove (const char* name)
 {
     auto const pname = prefixedName(name);
-    auto n = m_table->erase(name);
+    auto n = m_table->erase(pname);
     return static_cast<int>(n);
 }
 


### PR DESCRIPTION
Should have used prefixed name.
