### PR TITLE
Fix unused variable warnings in AMReX_ParmParse.cpp

### DIFF
--- a/Src/Base/AMReX_ParmParse.cpp
+++ b/Src/Base/AMReX_ParmParse.cpp
@@ -672,10 +672,13 @@ squeryval (const ParmParse::Table& table,
                       std::is_same_v<T,long> ||
                       std::is_same_v<T,long long> ||
                       std::is_same_v<T,float> ||
-                      std::is_same_v<T,double>) {
+                      std::is_same_v<T,double>)
+        {
             if (pp_parser(table, parser_prefix, name, valname, ref)) {
                 return true;
             }
+        } else {
+            amrex::ignore_unused(parser_prefix);
         }
 
         amrex::ErrorStream() << "ParmParse::queryval type mismatch on value number "
@@ -785,10 +788,13 @@ squeryarr (const ParmParse::Table& table,
                           std::is_same_v<T,long> ||
                           std::is_same_v<T,long long> ||
                           std::is_same_v<T,float> ||
-                          std::is_same_v<T,double>) {
+                          std::is_same_v<T,double>)
+            {
                 if (pp_parser(table, parser_prefix, name, valname, ref[n])) {
                     continue;
                 }
+            } else {
+                amrex::ignore_unused(parser_prefix);
             }
 
             amrex::ErrorStream() << "ParmParse::queryarr type mismatch on value number "


### PR DESCRIPTION
The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
