### PR TITLE
Fortran BoxArray: Add nboxes function returning the number of boxes.

### DIFF
--- a/Src/F_Interfaces/Base/AMReX_boxarray_fi.cpp
+++ b/Src/F_Interfaces/Base/AMReX_boxarray_fi.cpp
@@ -47,6 +47,11 @@ extern "C" {
         ba->maxSize(iv);
     }
 
+    Long amrex_fi_boxarray_nboxes (const BoxArray* ba)
+    {
+        return ba->size();
+    }
+
     void amrex_fi_boxarray_get_box (const BoxArray* ba, int i, int lo[3], int hi[3])
     {
         const Box& bx = (*ba)[i];

--- a/Src/F_Interfaces/Base/AMReX_boxarray_mod.F90
+++ b/Src/F_Interfaces/Base/AMReX_boxarray_mod.F90
@@ -20,6 +20,7 @@ module amrex_boxarray_module
      procedure :: move          => amrex_boxarray_move     ! transfer ownership
      generic   :: maxSize       => amrex_boxarray_maxsize_int, &  ! make the boxes smaller
           &                        amrex_boxarray_maxsize_int3, amrex_boxarray_maxsize_iv
+     procedure :: nboxes        => amrex_boxarray_nboxes
      procedure :: get_box       => amrex_boxarray_get_box
      procedure :: nodal_type    => amrex_boxarray_nodal_type  ! get index type
      procedure :: num_pts       => amrex_boxarray_num_pts
@@ -81,6 +82,13 @@ module amrex_boxarray_module
        type(c_ptr), value :: ba
        integer(c_int), intent(in) :: s(3)
      end subroutine amrex_fi_boxarray_maxsize
+
+     pure function amrex_fi_boxarray_nboxes (ba) bind(c)
+       import
+       implicit none
+       type(c_ptr), value, intent(in) :: ba
+       integer(amrex_long) :: amrex_fi_boxarray_nboxes
+     end function amrex_fi_boxarray_nboxes
 
      subroutine amrex_fi_boxarray_get_box (ba,i,lo,hi) bind(c)
        import
@@ -193,6 +201,12 @@ contains
     integer, intent(in)   :: s(3)
     call amrex_fi_boxarray_maxsize(this%p, s)
   end subroutine amrex_boxarray_maxsize_iv
+
+  pure function amrex_boxarray_nboxes (this) result(n)
+    class(amrex_boxarray), intent(in) :: this
+    integer(amrex_long) :: n
+    n = amrex_fi_boxarray_nboxes(this%p)
+  end function amrex_boxarray_nboxes
 
   function amrex_boxarray_get_box (this, i) result(bx)
     class(amrex_boxarray) :: this

--- a/Src/F_Interfaces/Base/AMReX_boxarray_mod.F90
+++ b/Src/F_Interfaces/Base/AMReX_boxarray_mod.F90
@@ -205,7 +205,11 @@ contains
   pure function amrex_boxarray_nboxes (this) result(n)
     class(amrex_boxarray), intent(in) :: this
     integer(amrex_long) :: n
-    n = amrex_fi_boxarray_nboxes(this%p)
+    if (c_associated(this%p)) then
+       n = amrex_fi_boxarray_nboxes(this%p)
+    else
+       n = 0
+    end if
   end function amrex_boxarray_nboxes
 
   function amrex_boxarray_get_box (this, i) result(bx)
@@ -234,7 +238,11 @@ contains
   pure function amrex_boxarray_num_pts (this) result(n)
     class(amrex_boxarray), intent(in) :: this
     integer(amrex_long) :: n
-    n = amrex_fi_boxarray_numpts(this%p)
+    if (c_associated(this%p)) then
+       n = amrex_fi_boxarray_numpts(this%p)
+    else
+       n = 0
+    end if
   end function amrex_boxarray_num_pts
 
   pure function amrex_boxarray_intersects_box (this, bx) result(r)


### PR DESCRIPTION
Note that the function returns the total number of boxes including ones not owned by the MPI process calling the function.
