### PR TITLE
TinyProfiler:: Add more runtime parameters

### DIFF
--- a/Docs/sphinx_documentation/source/RuntimeParameters.rst
+++ b/Docs/sphinx_documentation/source/RuntimeParameters.rst
@@ -1204,3 +1204,35 @@ enabled.
   which are unnecessary for correctness, could potentially degrade the
   performance.
 
+.. py:data:: tiny_profiler.enabled
+   :type: bool
+   :value: true
+
+   .. versionadded:: 24.09
+      Runtime parameter `tiny_profiler.enabled``.
+
+   This parameter can be used to disable tiny profiling including
+   :cpp:`CArena` memory profiling at run time.
+
+.. py:data:: tiny_profiler.memprof_enabled
+   :type: bool
+   :value: true
+
+   .. versionadded:: 24.09
+      Runtime parameter ``tiny_profiler.memprof_enabled``.
+
+   This parameter can be used to disable :cpp:`CArena` memory profiling at
+   run time. If ``tiny_profiler.enabled`` is false, this parameter has no
+   effects.
+
+.. py:data:: tiny_profiler.output_file
+   :type: string
+   :value: [empty]
+
+   .. versionadded:: 24.09
+      Runtime parameter ``tiny_profiler.output_file``.
+
+   If this parameter is empty, the output of tiny profiling is dumped on the
+   default out stream of AMReX. If it's not empty, it specifies the file
+   name for the output. Note that ``/dev/null`` is a special name that mean
+   a null file.

--- a/Src/Base/AMReX_TinyProfiler.H
+++ b/Src/Base/AMReX_TinyProfiler.H
@@ -139,11 +139,15 @@ private:
     static int n_print_tabs;
     static int verbose;
     static double print_threshold;
+    static bool enabled;
+    static bool memprof_enabled;
+    static std::string output_file;
 
-    static void PrintStats (std::map<std::string,Stats>& regstats, double dt_max);
+    static void PrintStats (std::map<std::string,Stats>& regstats, double dt_max,
+                            std::ostream* os);
     static void PrintMemStats (std::map<std::string, MemStat>& memstats,
                                std::string const& memname, double dt_max,
-                               double t_final);
+                               double t_final, std::ostream* os);
 };
 
 class TinyProfileRegion


### PR DESCRIPTION
Add the following ParmParse parameters to TinyProfiler:

  * tiny_profiler.enabled

    This parameter can be used to disable tiny profiling including CArena memory profiling at run time.

  * tiny_profiler.memprof_enabled

    This parameter can be used to disable tiny profiler's memory arena profiling at run time. If tiny_profiler.enabled is false, this parameter has no effects.

  * tiny_profiler.output_file

    If this parameter is empty, the output of tiny profiling is dumped on the default out stream of AMReX. If it's not empty, it specifies the file name for the output. Note that `/dev/null` is a special name that mean a null file.

Close #3895