### PR TITLE
ParmParse::prettyPrintTable

### DIFF
--- a/Src/Base/AMReX_ParmParse.H
+++ b/Src/Base/AMReX_ParmParse.H
@@ -1352,6 +1352,10 @@ public:
     //! Write the contents of the table in ASCII to the ostream.
     static void dumpTable (std::ostream& os, bool prettyPrint = false);
 
+    //! Write the table in a pretty way to the ostream. If there are
+    //! duplicates, only the last one is printed.
+    static void prettyPrintTable (std::ostream& os);
+
     //! Add keys and values from a file to the end of the PP table.
     static void addfile (std::string const& filename);
 

--- a/Src/Base/AMReX_ParmParse.cpp
+++ b/Src/Base/AMReX_ParmParse.cpp
@@ -12,6 +12,7 @@
 #include <iostream>
 #include <limits>
 #include <numeric>
+#include <unordered_map>
 #include <regex>
 #include <sstream>
 #include <stdexcept>
@@ -1204,6 +1205,32 @@ ParmParse::dumpTable (std::ostream& os, bool prettyPrint)
         else {
             for (auto const& vals : entry.m_vals) {
                 os << pp_to_string(name, vals) << '\n';
+            }
+        }
+    }
+}
+
+void
+ParmParse::prettyPrintTable (std::ostream& os)
+{
+    std::vector<std::string> sorted_names;
+    sorted_names.reserve(g_table.size());
+    for (auto const& [name, entry] : g_table) {
+        sorted_names.push_back(name);
+    }
+    std::sort(sorted_names.begin(), sorted_names.end());
+
+    for (auto const& name : sorted_names) {
+        auto const& entry = g_table[name];
+        std::vector<std::string> value_string;
+        std::unordered_map<std::string,int> count;
+        for (auto const& vals : entry.m_vals) {
+            value_string.emplace_back(pp_to_pretty_string(name, vals));
+            ++count[value_string.back()];
+        }
+        for (auto const& s : value_string) {
+            if (--count[s] == 0) {
+                os << s << '\n';
             }
         }
     }


### PR DESCRIPTION
Add a new function that prints the ParmParse table without duplicates. Note that these are not duplicates, because they have different values.

    foo.bar = 1
    foo.bar = 2

These are also not considered duplicates, even though the final results are the same.

    c = 3
    foo.bar = c
    foo.bar = 3

This should help WarpX to reduce duplicates when printing ParmParse parameters. However, there will still be "duplicates" like below because they are different strings.

    geometry.prob_hi = 20.e-6 20.e-6
    geometry.prob_hi = 2.0000000000000002e-05 2.0000000000000002e-05

Related to #4087 