### PR TITLE
TinyProfiler with BArena and PArena

### DIFF
--- a/Src/Base/AMReX_Arena.H
+++ b/Src/Base/AMReX_Arena.H
@@ -223,10 +223,15 @@ protected:
         std::unordered_map<void*, std::pair<MemStat*, std::size_t>> m_currently_allocated;
 
         ~ArenaProfiler ();
+        ArenaProfiler () noexcept = default;
+        ArenaProfiler (const ArenaProfiler& rhs) = delete;
+        ArenaProfiler (ArenaProfiler&& rhs) = delete;
+        ArenaProfiler& operator= (const ArenaProfiler& rhs) = delete;
+        ArenaProfiler& operator= (ArenaProfiler&& rhs) = delete;
 
-        void alloc (void* ptr, std::size_t nbytes);
+        void profile_alloc (void* ptr, std::size_t nbytes);
 
-        void free (void* ptr);
+        void profile_free (void* ptr);
 
     } m_profiler;
 };

--- a/Src/Base/AMReX_Arena.H
+++ b/Src/Base/AMReX_Arena.H
@@ -4,9 +4,21 @@
 
 #include <AMReX_BLassert.H>
 #include <AMReX_INT.H>
+
+#ifdef AMREX_TINY_PROFILING
+#include <AMReX_TinyProfiler.H>
+#else
+namespace amrex {
+    struct MemStat {};
+}
+#endif
+
 #include <cstddef>
 #include <cstdlib>
 #include <limits>
+#include <map>
+#include <mutex>
+#include <unordered_map>
 #include <utility>
 
 namespace amrex {
@@ -156,7 +168,7 @@ public:
      * \brief Add this Arena to the list of Arenas that are profiled by TinyProfiler.
      * \param memory_name The name of this arena in the TinyProfiler output.
      */
-    virtual void registerForProfiling (const std::string& memory_name);
+    void registerForProfiling (const std::string& memory_name);
 
 #ifdef AMREX_USE_GPU
     //! Is this GPU stream ordered memory allocator?
@@ -199,6 +211,24 @@ protected:
     virtual std::size_t freeUnused_protected () { return 0; }
     void* allocate_system (std::size_t nbytes);
     void deallocate_system (void* p, std::size_t nbytes);
+
+    struct ArenaProfiler {
+        //! If this arena is profiled by TinyProfiler
+        bool m_do_profiling = false;
+        //! Mutex for the profiling
+        std::mutex m_arena_profiler_mutex;
+        //! Data structure used for profiling with TinyProfiler
+        std::map<std::string, MemStat> m_profiling_stats;
+        //! Track the currently allocated memory, not used by CArena
+        std::unordered_map<void*, std::pair<MemStat*, std::size_t>> m_currently_allocated;
+
+        ~ArenaProfiler ();
+
+        void alloc (void* ptr, std::size_t nbytes);
+
+        void free (void* ptr);
+
+    } m_profiler;
 };
 
 }

--- a/Src/Base/AMReX_Arena.cpp
+++ b/Src/Base/AMReX_Arena.cpp
@@ -668,7 +668,8 @@ Arena::ArenaProfiler::~ArenaProfiler () {
 #endif
 }
 
-void Arena::ArenaProfiler::alloc ([[maybe_unused]] void* ptr, [[maybe_unused]] std::size_t nbytes) {
+void Arena::ArenaProfiler::profile_alloc ([[maybe_unused]] void* ptr,
+                                          [[maybe_unused]] std::size_t nbytes) {
 #ifdef AMREX_TINY_PROFILING
     if (m_do_profiling) {
         std::lock_guard<std::mutex> lock(m_arena_profiler_mutex);
@@ -680,7 +681,7 @@ void Arena::ArenaProfiler::alloc ([[maybe_unused]] void* ptr, [[maybe_unused]] s
 #endif
 }
 
-void Arena::ArenaProfiler::free ([[maybe_unused]] void* ptr) {
+void Arena::ArenaProfiler::profile_free ([[maybe_unused]] void* ptr) {
 #ifdef AMREX_TINY_PROFILING
     if (m_do_profiling) {
         std::lock_guard<std::mutex> lock(m_arena_profiler_mutex);

--- a/Src/Base/AMReX_Arena.cpp
+++ b/Src/Base/AMReX_Arena.cpp
@@ -117,9 +117,13 @@ Arena::hasFreeDeviceMemory (std::size_t)
 }
 
 void
-Arena::registerForProfiling (const std::string&)
+Arena::registerForProfiling ([[maybe_unused]] const std::string& memory_name)
 {
-    amrex::Abort("Profiling is not implemented for this type of Arena");
+#ifdef AMREX_TINY_PROFILING
+    AMREX_ALWAYS_ASSERT(m_profiler.m_do_profiling == false);
+    m_profiler.m_do_profiling =
+        TinyProfiler::RegisterArena(memory_name, m_profiler.m_profiling_stats);
+#endif
 }
 
 std::size_t
@@ -330,6 +334,7 @@ Arena::Initialize ()
     }
 
     the_async_arena = new PArena(the_async_arena_release_threshold);
+    the_async_arena->registerForProfiling("Async Memory");
 
 #ifdef AMREX_USE_GPU
     if (the_arena->isDevice()) {
@@ -403,6 +408,7 @@ Arena::Initialize ()
     }
 
     the_cpu_arena = The_BArena();
+    the_cpu_arena->registerForProfiling("Cpu Memory");
 
     // Initialize the null arena
     auto* null_arena = The_Null_Arena();
@@ -652,6 +658,40 @@ The_Comms_Arena ()
     } else {
         return The_Null_Arena();
     }
+}
+
+Arena::ArenaProfiler::~ArenaProfiler () {
+#ifdef AMREX_TINY_PROFILING
+    if (m_do_profiling) {
+        TinyProfiler::DeregisterArena(m_profiling_stats);
+    }
+#endif
+}
+
+void Arena::ArenaProfiler::alloc ([[maybe_unused]] void* ptr, [[maybe_unused]] std::size_t nbytes) {
+#ifdef AMREX_TINY_PROFILING
+    if (m_do_profiling) {
+        std::lock_guard<std::mutex> lock(m_arena_profiler_mutex);
+        MemStat* stat = TinyProfiler::memory_alloc(nbytes, m_profiling_stats);
+        if (stat) {
+            m_currently_allocated.insert({ptr, {stat, nbytes}});
+        }
+    }
+#endif
+}
+
+void Arena::ArenaProfiler::free ([[maybe_unused]] void* ptr) {
+#ifdef AMREX_TINY_PROFILING
+    if (m_do_profiling) {
+        std::lock_guard<std::mutex> lock(m_arena_profiler_mutex);
+        auto it = m_currently_allocated.find(ptr);
+        if (it != m_currently_allocated.end()) {
+            auto [stat, nbytes] = it->second;
+            TinyProfiler::memory_free(nbytes, stat);
+            m_currently_allocated.erase(it);
+        }
+    }
+#endif
 }
 
 }

--- a/Src/Base/AMReX_BArena.cpp
+++ b/Src/Base/AMReX_BArena.cpp
@@ -11,8 +11,8 @@ amrex::BArena::alloc (std::size_t sz_)
 void
 amrex::BArena::free (void* pt)
 {
-    std::free(pt);
     m_profiler.free(pt);
+    std::free(pt);
 }
 
 bool

--- a/Src/Base/AMReX_BArena.cpp
+++ b/Src/Base/AMReX_BArena.cpp
@@ -4,14 +4,14 @@ void*
 amrex::BArena::alloc (std::size_t sz_)
 {
     void* pt = std::malloc(sz_);
-    m_profiler.alloc(pt, sz_);
+    m_profiler.profile_alloc(pt, sz_);
     return pt;
 }
 
 void
 amrex::BArena::free (void* pt)
 {
-    m_profiler.free(pt);
+    m_profiler.profile_free(pt);
     std::free(pt);
 }
 

--- a/Src/Base/AMReX_BArena.cpp
+++ b/Src/Base/AMReX_BArena.cpp
@@ -3,13 +3,16 @@
 void*
 amrex::BArena::alloc (std::size_t sz_)
 {
-    return std::malloc(sz_);
+    void* pt = std::malloc(sz_);
+    m_profiler.alloc(pt, sz_);
+    return pt;
 }
 
 void
 amrex::BArena::free (void* pt)
 {
     std::free(pt);
+    m_profiler.free(pt);
 }
 
 bool

--- a/Src/Base/AMReX_CArena.H
+++ b/Src/Base/AMReX_CArena.H
@@ -16,8 +16,6 @@
 
 namespace amrex {
 
-struct MemStat;
-
 /**
 * \brief A Concrete Class for Dynamic Memory Management using first fit.
 * This is a coalescing memory manager.  It allocates (possibly) large
@@ -74,12 +72,6 @@ public:
      * system.
      */
     [[nodiscard]] bool hasFreeDeviceMemory (std::size_t sz) final;
-
-    /**
-     * \brief Add this Arena to the list of Arenas that are profiled by TinyProfiler.
-     * \param memory_name The name of this arena in the TinyProfiler output.
-     */
-    void registerForProfiling (const std::string& memory_name) final;
 
     //! The current amount of heap space used by the CArena object.
     std::size_t heap_space_used () const noexcept;
@@ -191,10 +183,6 @@ protected:
     std::size_t m_used{0};
     //! The amount of memory given out via alloc().
     std::size_t m_actually_used{0};
-    //! If this arena is profiled by TinyProfiler
-    bool m_do_profiling = false;
-    //! Data structure used for profiling with TinyProfiler
-    std::map<std::string, MemStat> m_profiling_stats;
 
 
     std::mutex carena_mutex;

--- a/Src/Base/AMReX_PArena.cpp
+++ b/Src/Base/AMReX_PArena.cpp
@@ -94,11 +94,11 @@ PArena::free (void* p)
 
 #if defined (AMREX_GPU_STREAM_ALLOC_SUPPORT)
     if (Gpu::Device::memoryPoolsSupported()) {
+        m_profiler.free(p);
         AMREX_HIP_OR_CUDA(
             AMREX_HIP_SAFE_CALL(hipFreeAsync(p, Gpu::gpuStream()));,
             AMREX_CUDA_SAFE_CALL(cudaFreeAsync(p, Gpu::gpuStream()));
         )
-        m_profiler.free(p);
     } else
 #endif
     {

--- a/Src/Base/AMReX_PArena.cpp
+++ b/Src/Base/AMReX_PArena.cpp
@@ -62,7 +62,7 @@ PArena::alloc (std::size_t nbytes)
             AMREX_HIP_SAFE_CALL(hipMallocAsync(&p, nbytes, m_pool, Gpu::gpuStream()));,
             AMREX_CUDA_SAFE_CALL(cudaMallocAsync(&p, nbytes, m_pool, Gpu::gpuStream()));
         )
-        m_profiler.alloc(p, nbytes);
+        m_profiler.profile_alloc(p, nbytes);
         return p;
     } else
 #endif
@@ -94,7 +94,7 @@ PArena::free (void* p)
 
 #if defined (AMREX_GPU_STREAM_ALLOC_SUPPORT)
     if (Gpu::Device::memoryPoolsSupported()) {
-        m_profiler.free(p);
+        m_profiler.profile_free(p);
         AMREX_HIP_OR_CUDA(
             AMREX_HIP_SAFE_CALL(hipFreeAsync(p, Gpu::gpuStream()));,
             AMREX_CUDA_SAFE_CALL(cudaFreeAsync(p, Gpu::gpuStream()));

--- a/Src/Base/AMReX_PArena.cpp
+++ b/Src/Base/AMReX_PArena.cpp
@@ -62,6 +62,7 @@ PArena::alloc (std::size_t nbytes)
             AMREX_HIP_SAFE_CALL(hipMallocAsync(&p, nbytes, m_pool, Gpu::gpuStream()));,
             AMREX_CUDA_SAFE_CALL(cudaMallocAsync(&p, nbytes, m_pool, Gpu::gpuStream()));
         )
+        m_profiler.alloc(p, nbytes);
         return p;
     } else
 #endif
@@ -97,6 +98,7 @@ PArena::free (void* p)
             AMREX_HIP_SAFE_CALL(hipFreeAsync(p, Gpu::gpuStream()));,
             AMREX_CUDA_SAFE_CALL(cudaFreeAsync(p, Gpu::gpuStream()));
         )
+        m_profiler.free(p);
     } else
 #endif
     {

--- a/Src/Base/AMReX_TinyProfiler.H
+++ b/Src/Base/AMReX_TinyProfiler.H
@@ -57,7 +57,7 @@ public:
     static void MemoryInitialize () noexcept;
     static void MemoryFinalize (bool bFlushing = false) noexcept;
 
-    static void RegisterArena (const std::string& memory_name,
+    static bool RegisterArena (const std::string& memory_name,
                                std::map<std::string, MemStat>& memstats) noexcept;
 
     static void DeregisterArena (std::map<std::string, MemStat>& memstats) noexcept;

--- a/Src/Base/AMReX_TinyProfiler.cpp
+++ b/Src/Base/AMReX_TinyProfiler.cpp
@@ -490,14 +490,15 @@ TinyProfiler::MemoryFinalize (bool bFlushing) noexcept
     if(os) { os->precision(oldprec); }
 }
 
-void
+bool
 TinyProfiler::RegisterArena (const std::string& memory_name,
                              std::map<std::string, MemStat>& memstats) noexcept
 {
-    if (!memprof_enabled) { return; }
+    if (!memprof_enabled) { return false; }
 
     all_memstats.push_back(&memstats);
     all_memnames.push_back(memory_name);
+    return true;
 }
 
 void


### PR DESCRIPTION
## Summary

This PR adds the capability to profile BArena and PArena with TinyProfiler. Previously, only CArena was profiled. Note that some allocations are still not profiled when running on CPU because `amrex::DefaultAllocator` and `amrex::PODVector` use `std::allocator<T>` instead of `amrex::ArenaAllocator<T>`.

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
