### PR TITLE
Fix Fortran interface compilation issue using `nvfortran`

### DIFF
--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -154,6 +154,7 @@ jobs:
             -DAMReX_ENABLE_TESTS=ON                      \
             -DAMReX_TEST_TYPE=Small                      \
             -DAMReX_FORTRAN=ON                           \
+            -DAMReX_FORTRAN_INTERFACES=ON                \
             -DAMReX_GPU_BACKEND=CUDA                     \
             -DCMAKE_C_COMPILER=$(which nvc)              \
             -DCMAKE_CXX_COMPILER=$(which nvc++)          \

--- a/Src/Base/AMReX_parmparse_mod.F90
+++ b/Src/Base/AMReX_parmparse_mod.F90
@@ -241,6 +241,10 @@ module amrex_parmparse_module
      end subroutine amrex_parmparse_add_stringarr
   end interface
 
+  interface amrex_parmparse_destroy
+     module procedure amrex_parmparse_destroy
+  end interface amrex_parmparse_destroy
+
 contains
 
   subroutine amrex_parmparse_build (pp, name)

--- a/Src/F_Interfaces/AmrCore/AMReX_fluxregister_mod.F90
+++ b/Src/F_Interfaces/AmrCore/AMReX_fluxregister_mod.F90
@@ -103,6 +103,10 @@ module amrex_fluxregister_module
      end subroutine amrex_fi_fluxregister_overwrite
   end interface
 
+  interface amrex_fluxregister_destroy
+     module procedure amrex_fluxregister_destroy
+  end interface amrex_fluxregister_destroy
+
 contains
 
   subroutine amrex_fluxregister_build (fr, ba, dm, ref_ratio, fine_lev, ncomp)

--- a/Src/F_Interfaces/Base/AMReX_boxarray_mod.F90
+++ b/Src/F_Interfaces/Base/AMReX_boxarray_mod.F90
@@ -45,6 +45,10 @@ module amrex_boxarray_module
      module procedure amrex_boxarray_print
   end interface amrex_print
 
+  interface amrex_boxarray_destroy
+     module procedure amrex_boxarray_destroy
+  end interface amrex_boxarray_destroy
+
   ! interfaces to cpp functions
 
   interface

--- a/Src/F_Interfaces/Base/AMReX_distromap_mod.F90
+++ b/Src/F_Interfaces/Base/AMReX_distromap_mod.F90
@@ -34,6 +34,10 @@ module amrex_distromap_module
      module procedure amrex_distromap_print
   end interface amrex_print
 
+  interface amrex_distromap_destroy
+     module procedure amrex_distromap_destroy
+  end interface amrex_distromap_destroy
+
   ! interfaces to cpp functions
 
   interface

--- a/Src/F_Interfaces/Base/AMReX_fab_mod.F90
+++ b/Src/F_Interfaces/Base/AMReX_fab_mod.F90
@@ -42,6 +42,10 @@ module amrex_fab_module
      module procedure amrex_fab_build_install
   end interface amrex_fab_build
 
+  interface amrex_fab_destroy
+     module procedure amrex_fab_destroy
+  end interface amrex_fab_destroy
+
 contains
 
   ! Build a fab, allocate own memory

--- a/Src/F_Interfaces/Base/AMReX_geometry_mod.F90
+++ b/Src/F_Interfaces/Base/AMReX_geometry_mod.F90
@@ -76,6 +76,10 @@ module amrex_geometry_module
      end subroutine amrex_fi_geometry_get_intdomain
   end interface
 
+  interface amrex_geometry_destroy
+     module procedure amrex_geometry_destroy
+  end interface amrex_geometry_destroy
+
 contains
 
   subroutine amrex_geometry_finalize ()

--- a/Src/F_Interfaces/Base/AMReX_multifab_mod.F90
+++ b/Src/F_Interfaces/Base/AMReX_multifab_mod.F90
@@ -101,6 +101,10 @@ module amrex_multifab_module
      module procedure amrex_multifab_build_a
   end interface amrex_multifab_build
 
+  interface amrex_multifab_destroy
+    module procedure amrex_multifab_destroy
+  end interface amrex_multifab_destroy
+
   type, public   :: amrex_imultifab
      logical               :: owner = .false.
      type   (c_ptr)        :: p     =  c_null_ptr
@@ -128,6 +132,10 @@ module amrex_multifab_module
      module procedure amrex_imultifab_build_s
      module procedure amrex_imultifab_build_a
   end interface amrex_imultifab_build
+
+  interface amrex_imultifab_destroy
+    module procedure amrex_imultifab_destroy
+  end interface amrex_imultifab_destroy
 
   type, public :: amrex_mfiter
      type(c_ptr)      :: p       = c_null_ptr
@@ -158,6 +166,10 @@ module amrex_multifab_module
      module procedure amrex_mfiter_build_badm
      module procedure amrex_mfiter_build_badm_s
   end interface amrex_mfiter_build
+
+  interface amrex_mfiter_destroy
+    module procedure amrex_mfiter_destroy
+  end interface amrex_mfiter_destroy
 
   ! interfaces to c++ functions
 

--- a/Src/F_Interfaces/Base/AMReX_physbc_mod.F90
+++ b/Src/F_Interfaces/Base/AMReX_physbc_mod.F90
@@ -47,6 +47,10 @@ module amrex_physbc_module
      end subroutine amrex_fi_delete_physbc
   end interface
 
+  interface amrex_physbc_destroy
+    module procedure amrex_physbc_destroy
+  end interface amrex_physbc_destroy
+
 contains
 
   subroutine amrex_physbc_build (pbc, fill, geom)

--- a/Src/F_Interfaces/LinearSolvers/AMReX_abeclaplacian_mod.F90
+++ b/Src/F_Interfaces/LinearSolvers/AMReX_abeclaplacian_mod.F90
@@ -58,6 +58,10 @@ module amrex_abeclaplacian_module
      end subroutine amrex_fi_abeclap_set_bcoeffs
   end interface
 
+  interface amrex_abeclaplacian_destroy
+     module procedure amrex_abeclaplacian_destroy
+  end interface amrex_abeclaplacian_destroy
+
 contains
 
   subroutine amrex_abeclaplacian_assign (dst, src)

--- a/Src/F_Interfaces/LinearSolvers/AMReX_multigrid_mod.F90
+++ b/Src/F_Interfaces/LinearSolvers/AMReX_multigrid_mod.F90
@@ -154,6 +154,10 @@ module amrex_multigrid_module
      end subroutine amrex_fi_multigrid_set_final_fill_bc
   end interface
 
+  interface amrex_multigrid_destroy
+     module procedure amrex_multigrid_destroy
+  end interface amrex_multigrid_destroy
+
 contains
 
   subroutine amrex_multigrid_assign (dst, src)

--- a/Src/F_Interfaces/LinearSolvers/AMReX_poisson_mod.F90
+++ b/Src/F_Interfaces/LinearSolvers/AMReX_poisson_mod.F90
@@ -35,6 +35,10 @@ module amrex_poisson_module
      end subroutine amrex_fi_delete_linop
   end interface
 
+  interface amrex_poisson_destroy
+     module procedure amrex_poisson_destroy
+  end interface amrex_poisson_destroy
+
 contains
 
   subroutine amrex_poisson_assign (dst, src)

--- a/Src/F_Interfaces/Particle/AMReX_particlecontainer_mod.F90
+++ b/Src/F_Interfaces/Particle/AMReX_particlecontainer_mod.F90
@@ -163,6 +163,10 @@ module amrex_particlecontainer_module
 
   end interface
 
+  interface amrex_particlecontainer_destroy
+     module procedure amrex_particlecontainer_destroy
+  end interface amrex_particlecontainer_destroy
+
 contains
 
   subroutine amrex_particlecontainer_build (pc, amrcore)


### PR DESCRIPTION
## Summary
This PR will fix the compilation issue for Fortran interfaces when using `nvfortran`, reported in #4111. 

## Additional background
The new `module procedure` interfaces for `final` subroutines are introduced to bypass the `nvfortran` compilation error. This change may not be needed according to the Fortran standard, but it effectively resolves compilation errors using `nvfortran` with `-DAMReX_FORTRAN_INTERFACES=ON`.

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
