### PR TITLE
`AMREX_DEVICE_PRINTF`: Host

### DIFF
--- a/Src/Base/AMReX_GpuPrint.H
+++ b/Src/Base/AMReX_GpuPrint.H
@@ -23,6 +23,9 @@
 #  define AMREX_DEVICE_PRINTF(...) std::printf(__VA_ARGS__);
 #elif defined(AMREX_USE_HIP)
 #  define AMREX_DEVICE_PRINTF(...) ::printf(__VA_ARGS__);
+#else
+#  define AMREX_DEVICE_PRINTF(format,...) { \
+      std::printf(format, __VA_ARGS__); }
 #endif
 
 #endif  // !defined(__APPLE__)

--- a/Src/Base/AMReX_GpuPrint.H
+++ b/Src/Base/AMReX_GpuPrint.H
@@ -2,8 +2,6 @@
 #define AMREX_GPU_PRINT_H_
 #include <AMReX_Config.H>
 
-#if !defined(__APPLE__)
-
 #include <cstdio>
 
 #ifdef AMREX_USE_SYCL
@@ -28,5 +26,4 @@
       std::printf(format, __VA_ARGS__); }
 #endif
 
-#endif  // !defined(__APPLE__)
 #endif  // AMREX_GPU_PRINT_H_


### PR DESCRIPTION
## Summary

In AMReX, device means host if compiled for CPUs.
Add support for printf debugging on CPUs for `AMREX_DEVICE_PRINTF`.

Currently, the macro was undefined, unless for the special case of SYCL compilation for host code paths where it worked.

## Additional background

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
