### PR TITLE
Capability adds for ParmParse enum

### DIFF
--- a/Src/Base/AMReX_ParmParse.H
+++ b/Src/Base/AMReX_ParmParse.H
@@ -1393,9 +1393,9 @@ public:
 
     static std::string ParserPrefix;
 
-protected:
-
     [[nodiscard]] std::string prefixedName (const std::string_view& str) const;
+
+protected:
 
     std::string m_prefix; // Prefix used in keyword search
     std::string m_parser_prefix; // Prefix used by Parser

--- a/Src/Base/AMReX_ParmParse.H
+++ b/Src/Base/AMReX_ParmParse.H
@@ -1200,6 +1200,8 @@ public:
             try {
                 ref = amrex::getEnum<T>(s);
             } catch (...) {
+                amrex::Print() << "amrex::ParmParse::query (input name: "
+                               << this->prefixedName(name) << "):" << std::endl;
                 throw;
             }
         }
@@ -1223,6 +1225,8 @@ public:
         try {
             ref = amrex::getEnum<T>(s);
         } catch (...) {
+            amrex::Print() << "amrex::ParmParse::get (input name:  "
+                           << this->prefixedName(name) << "):" << std::endl;
             throw;
         }
     }
@@ -1240,7 +1244,13 @@ public:
         if (exist) {
             ref.resize(s.size());
             for (std::size_t i = 0; i < s.size(); ++i) {
-                ref[i] = amrex::getEnum<T>(s[i]);
+                try {
+                    ref[i] = amrex::getEnum<T>(s[i]);
+                }  catch (...) {
+                    amrex::Print() << "amrex::ParmParse::queryarr (input name:  "
+                                   << this->prefixedName(name) << "):" << std::endl;
+                    throw;
+                }
             }
         }
         return exist;
@@ -1258,7 +1268,13 @@ public:
         this->getarr(name, s, start_ix, num_val);
         ref.resize(s.size());
         for (std::size_t i = 0; i < s.size(); ++i) {
-            ref[i] = amrex::getEnum<T>(s[i]);
+            try {
+                ref[i] = amrex::getEnum<T>(s[i]);
+            }  catch (...) {
+                amrex::Print() << "amrex::ParmParse::getarr (input name:  "
+                               << this->prefixedName(name) << "):" << std::endl;
+                throw;
+            }
         }
     }
 

--- a/Src/Base/AMReX_ParmParse.H
+++ b/Src/Base/AMReX_ParmParse.H
@@ -1192,10 +1192,10 @@ public:
      */
     template <typename T, typename ET = amrex_enum_traits<T>,
               std::enable_if_t<ET::value,int> = 0>
-    int query (const char* name, T& ref)
+    int query (const char* name, T& ref, int ival = FIRST)
     {
         std::string s;
-        int exist = this->query(name, s);
+        int exist = this->query(name, s, ival);
         if (exist) {
             try {
                 ref = amrex::getEnum<T>(s);
@@ -1216,10 +1216,10 @@ public:
      */
     template <typename T, typename ET = amrex_enum_traits<T>,
               std::enable_if_t<ET::value,int> = 0>
-    void get (const char* name, T& ref)
+    void get (const char* name, T& ref, int ival = FIRST)
     {
         std::string s;
-        this->get(name, s);
+        this->get(name, s, ival);
         try {
             ref = amrex::getEnum<T>(s);
         } catch (...) {
@@ -1230,10 +1230,13 @@ public:
     //! Query an array of enum values using given name.
     template <typename T, typename ET = amrex_enum_traits<T>,
               std::enable_if_t<ET::value,int> = 0>
-    int queryarr (const char* name, std::vector<T>& ref)
+    int queryarr (const char* name,
+                  std::vector<T>& ref,
+                  int start_ix = FIRST,
+                  int num_val = ALL)
     {
         std::vector<std::string> s;
-        int exist = this->queryarr(name, s);
+        int exist = this->queryarr(name, s, start_ix, num_val);
         if (exist) {
             ref.resize(s.size());
             for (std::size_t i = 0; i < s.size(); ++i) {
@@ -1246,10 +1249,13 @@ public:
     //! Get an array of enum values using given name.
     template <typename T, typename ET = amrex_enum_traits<T>,
               std::enable_if_t<ET::value,int> = 0>
-    void getarr (const char* name, std::vector<T>& ref)
+    void getarr (const char* name,
+                 std::vector<T>& ref,
+                 int start_ix = FIRST,
+                 int num_val = ALL)
     {
         std::vector<std::string> s;
-        this->getarr(name, s);
+        this->getarr(name, s, start_ix, num_val);
         ref.resize(s.size());
         for (std::size_t i = 0; i < s.size(); ++i) {
             ref[i] = amrex::getEnum<T>(s[i]);
@@ -1268,10 +1274,10 @@ public:
      */
     template <typename T, typename ET = amrex_enum_traits<T>,
               std::enable_if_t<ET::value,int> = 0>
-    int query_enum_case_insensitive (const char* name, T& ref)
+    int query_enum_case_insensitive (const char* name, T& ref, int ival = FIRST)
     {
         std::string s;
-        int exist = this->query(name, s);
+        int exist = this->query(name, s, ival);
         if (exist) {
             s = amrex::toLower(s);
             auto const& enum_names = amrex::getEnumNameStrings<T>();
@@ -1303,9 +1309,9 @@ public:
      */
     template <typename T, typename ET = amrex_enum_traits<T>,
               std::enable_if_t<ET::value,int> = 0>
-    void get_enum_case_insensitive (const char* name, T& ref)
+    void get_enum_case_insensitive (const char* name, T& ref, int ival = FIRST)
     {
-        int exist = this->query_enum_case_insensitive(name, ref);
+        int exist = this->query_enum_case_insensitive(name, ref, ival);
         if (!exist) {
             std::string msg("get_enum_case_insensitive(\"");
             msg.append(name).append("\",").append(amrex::getEnumClassName<T>())

--- a/Src/Base/AMReX_ParmParse.H
+++ b/Src/Base/AMReX_ParmParse.H
@@ -1201,7 +1201,7 @@ public:
                 ref = amrex::getEnum<T>(s);
             } catch (...) {
                 amrex::Print() << "amrex::ParmParse::query (input name: "
-                               << this->prefixedName(name) << "):" << std::endl;
+                               << this->prefixedName(name) << "):\n";
                 throw;
             }
         }
@@ -1226,7 +1226,7 @@ public:
             ref = amrex::getEnum<T>(s);
         } catch (...) {
             amrex::Print() << "amrex::ParmParse::get (input name:  "
-                           << this->prefixedName(name) << "):" << std::endl;
+                           << this->prefixedName(name) << "):\n";
             throw;
         }
     }
@@ -1248,7 +1248,7 @@ public:
                     ref[i] = amrex::getEnum<T>(s[i]);
                 }  catch (...) {
                     amrex::Print() << "amrex::ParmParse::queryarr (input name:  "
-                                   << this->prefixedName(name) << "):" << std::endl;
+                                   << this->prefixedName(name) << "):\n";
                     throw;
                 }
             }
@@ -1272,7 +1272,7 @@ public:
                 ref[i] = amrex::getEnum<T>(s[i]);
             }  catch (...) {
                 amrex::Print() << "amrex::ParmParse::getarr (input name:  "
-                               << this->prefixedName(name) << "):" << std::endl;
+                               << this->prefixedName(name) << "):\n";
                 throw;
             }
         }

--- a/Src/Base/AMReX_ParmParse.H
+++ b/Src/Base/AMReX_ParmParse.H
@@ -1200,8 +1200,10 @@ public:
             try {
                 ref = amrex::getEnum<T>(s);
             } catch (...) {
-                amrex::Print() << "amrex::ParmParse::query (input name: "
-                               << this->prefixedName(name) << "):\n";
+                if (amrex::Verbose() > 0 ) {
+                    amrex::Print() << "amrex::ParmParse::query (input name: "
+                                   << this->prefixedName(name) << "):\n";
+                }
                 throw;
             }
         }
@@ -1225,8 +1227,10 @@ public:
         try {
             ref = amrex::getEnum<T>(s);
         } catch (...) {
-            amrex::Print() << "amrex::ParmParse::get (input name:  "
-                           << this->prefixedName(name) << "):\n";
+            if (amrex::Verbose() > 0 ) {
+                amrex::Print() << "amrex::ParmParse::get (input name:  "
+                               << this->prefixedName(name) << "):\n";
+            }
             throw;
         }
     }
@@ -1247,8 +1251,10 @@ public:
                 try {
                     ref[i] = amrex::getEnum<T>(s[i]);
                 }  catch (...) {
-                    amrex::Print() << "amrex::ParmParse::queryarr (input name:  "
-                                   << this->prefixedName(name) << "):\n";
+                    if (amrex::Verbose() > 0 ) {
+                        amrex::Print() << "amrex::ParmParse::queryarr (input name:  "
+                                       << this->prefixedName(name) << "):\n";
+                    }
                     throw;
                 }
             }
@@ -1271,8 +1277,10 @@ public:
             try {
                 ref[i] = amrex::getEnum<T>(s[i]);
             }  catch (...) {
-                amrex::Print() << "amrex::ParmParse::getarr (input name:  "
-                               << this->prefixedName(name) << "):\n";
+                if (amrex::Verbose() > 0 ) {
+                    amrex::Print() << "amrex::ParmParse::getarr (input name:  "
+                                   << this->prefixedName(name) << "):\n";
+                }
                 throw;
             }
         }

--- a/Src/Base/AMReX_ParmParse.H
+++ b/Src/Base/AMReX_ParmParse.H
@@ -1192,7 +1192,7 @@ public:
      */
     template <typename T, typename ET = amrex_enum_traits<T>,
               std::enable_if_t<ET::value,int> = 0>
-    int query (const char* name, T& ref, int ival = FIRST)
+    int query (const char* name, T& ref, int ival = FIRST) const
     {
         std::string s;
         int exist = this->query(name, s, ival);
@@ -1216,7 +1216,7 @@ public:
      */
     template <typename T, typename ET = amrex_enum_traits<T>,
               std::enable_if_t<ET::value,int> = 0>
-    void get (const char* name, T& ref, int ival = FIRST)
+    void get (const char* name, T& ref, int ival = FIRST) const
     {
         std::string s;
         this->get(name, s, ival);
@@ -1233,7 +1233,7 @@ public:
     int queryarr (const char* name,
                   std::vector<T>& ref,
                   int start_ix = FIRST,
-                  int num_val = ALL)
+                  int num_val = ALL) const
     {
         std::vector<std::string> s;
         int exist = this->queryarr(name, s, start_ix, num_val);
@@ -1252,7 +1252,7 @@ public:
     void getarr (const char* name,
                  std::vector<T>& ref,
                  int start_ix = FIRST,
-                 int num_val = ALL)
+                 int num_val = ALL) const
     {
         std::vector<std::string> s;
         this->getarr(name, s, start_ix, num_val);
@@ -1274,7 +1274,7 @@ public:
      */
     template <typename T, typename ET = amrex_enum_traits<T>,
               std::enable_if_t<ET::value,int> = 0>
-    int query_enum_case_insensitive (const char* name, T& ref, int ival = FIRST)
+    int query_enum_case_insensitive (const char* name, T& ref, int ival = FIRST) const
     {
         std::string s;
         int exist = this->query(name, s, ival);
@@ -1309,7 +1309,7 @@ public:
      */
     template <typename T, typename ET = amrex_enum_traits<T>,
               std::enable_if_t<ET::value,int> = 0>
-    void get_enum_case_insensitive (const char* name, T& ref, int ival = FIRST)
+    void get_enum_case_insensitive (const char* name, T& ref, int ival = FIRST) const
     {
         int exist = this->query_enum_case_insensitive(name, ref, ival);
         if (!exist) {

--- a/Src/Base/AMReX_ParmParse.cpp
+++ b/Src/Base/AMReX_ParmParse.cpp
@@ -1283,7 +1283,7 @@ ParmParse::query (const char* name,
 }
 
 void
-ParmParse::add (const char* name,
+ParmParse::add (const char* name, // NOLINT(readability-make-member-function-const)
                 const bool  val)
 {
     saddval(prefixedName(name),val);
@@ -1315,7 +1315,7 @@ ParmParse::query (const char* name, int& ref, int ival) const
 }
 
 void
-ParmParse::add (const char* name, const int val)
+ParmParse::add (const char* name, const int val) // NOLINT(readability-make-member-function-const)
 {
     saddval(prefixedName(name),val);
 }
@@ -1349,7 +1349,7 @@ ParmParse::queryarr (const char* name, std::vector<int>& ref, int start_ix,
 }
 
 void
-ParmParse::addarr (const char* name, const std::vector<int>& ref)
+ParmParse::addarr (const char* name, const std::vector<int>& ref) // NOLINT(readability-make-member-function-const)
 {
     saddarr(prefixedName(name),ref);
 }
@@ -1381,7 +1381,7 @@ ParmParse::query (const char* name, long& ref, int ival) const
 }
 
 void
-ParmParse::add (const char* name,
+ParmParse::add (const char* name, // NOLINT(readability-make-member-function-const)
                 const long  val)
 {
     saddval(prefixedName(name),val);
@@ -1416,7 +1416,7 @@ ParmParse::queryarr (const char* name, std::vector<long>& ref, int start_ix,
 }
 
 void
-ParmParse::addarr (const char* name, const std::vector<long>& ref)
+ParmParse::addarr (const char* name, const std::vector<long>& ref) // NOLINT(readability-make-member-function-const)
 {
     saddarr(prefixedName(name),ref);
 }
@@ -1447,7 +1447,7 @@ ParmParse::query (const char* name, long long& ref, int ival) const
 }
 
 void
-ParmParse::add (const char* name, const long long val)
+ParmParse::add (const char* name, const long long val) // NOLINT(readability-make-member-function-const)
 {
     saddval(prefixedName(name),val);
 }
@@ -1481,7 +1481,7 @@ ParmParse::queryarr (const char* name, std::vector<long long>& ref, int start_ix
 }
 
 void
-ParmParse::addarr (const char* name, const std::vector<long long>& ref)
+ParmParse::addarr (const char* name, const std::vector<long long>& ref) // NOLINT(readability-make-member-function-const)
 {
     saddarr(prefixedName(name),ref);
 }
@@ -1512,7 +1512,7 @@ ParmParse::query (const char* name, float& ref, int ival) const
 }
 
 void
-ParmParse::add (const char* name, const float val)
+ParmParse::add (const char* name, const float val) // NOLINT(readability-make-member-function-const)
 {
     saddval(prefixedName(name),val);
 }
@@ -1546,7 +1546,7 @@ ParmParse::queryarr (const char* name, std::vector<float>& ref, int start_ix,
 }
 
 void
-ParmParse::addarr (const char* name, const std::vector<float>& ref)
+ParmParse::addarr (const char* name, const std::vector<float>& ref) // NOLINT(readability-make-member-function-const)
 {
     saddarr(prefixedName(name),ref);
 }
@@ -1579,7 +1579,7 @@ ParmParse::query (const char* name, double& ref, int ival) const
 }
 
 void
-ParmParse::add (const char* name, const double val)
+ParmParse::add (const char* name, const double val) // NOLINT(readability-make-member-function-const)
 {
     saddval(prefixedName(name),val);
 }
@@ -1613,7 +1613,7 @@ ParmParse::queryarr (const char* name, std::vector<double>& ref, int start_ix,
 }
 
 void
-ParmParse::addarr (const char* name, const std::vector<double>& ref)
+ParmParse::addarr (const char* name, const std::vector<double>& ref) // NOLINT(readability-make-member-function-const)
 {
     saddarr(prefixedName(name),ref);
 }
@@ -1646,7 +1646,7 @@ ParmParse::query (const char* name, std::string& ref, int ival) const
 }
 
 void
-ParmParse::add (const char* name, const std::string& val)
+ParmParse::add (const char* name, const std::string& val) // NOLINT(readability-make-member-function-const)
 {
     saddval(prefixedName(name),val);
 }
@@ -1680,7 +1680,7 @@ ParmParse::queryarr (const char* name, std::vector<std::string>& ref,
 }
 
 void
-ParmParse::addarr (const char* name, const std::vector<std::string>& ref)
+ParmParse::addarr (const char* name, const std::vector<std::string>& ref) // NOLINT(readability-make-member-function-const)
 {
     saddarr(prefixedName(name),ref);
 }
@@ -1713,7 +1713,7 @@ ParmParse::query (const char* name, IntVect& ref, int ival) const
 }
 
 void
-ParmParse::add (const char* name, const IntVect& val)
+ParmParse::add (const char* name, const IntVect& val) // NOLINT(readability-make-member-function-const)
 {
     saddval(prefixedName(name),val);
 }
@@ -1747,7 +1747,7 @@ ParmParse::queryarr (const char* name, std::vector<IntVect>& ref,
 }
 
 void
-ParmParse::addarr (const char* name, const std::vector<IntVect>& ref)
+ParmParse::addarr (const char* name, const std::vector<IntVect>& ref) // NOLINT(readability-make-member-function-const)
 {
     saddarr(prefixedName(name),ref);
 }
@@ -1778,7 +1778,7 @@ ParmParse::query (const char* name, Box& ref, int ival) const
 }
 
 void
-ParmParse::add (const char* name, const Box& val)
+ParmParse::add (const char* name, const Box& val) // NOLINT(readability-make-member-function-const)
 {
     saddval(prefixedName(name),val);
 }
@@ -1812,7 +1812,7 @@ ParmParse::queryarr (const char* name, std::vector<Box>& ref,
 }
 
 void
-ParmParse::addarr (const char* name, const std::vector<Box>& ref)
+ParmParse::addarr (const char* name, const std::vector<Box>& ref) // NOLINT(readability-make-member-function-const)
 {
     saddarr(prefixedName(name),ref);
 }


### PR DESCRIPTION
## Summary

- The ParmParse functions for AMReX Enums added in #4069 did not carry the optional arguments found in other ParmParse functions. Those are added so that, for example, querying an enum has the same interface as querying other types.
- These functions shouldn't modify the ParmParse object, so they are made `const`
- The `prefixedName` function is made a public member instead of a protected member.

## Additional background

The use case for these changes is https://github.com/erf-model/ERF/pull/1772

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [X] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
