### PR TITLE
EB: don't abort for no-op case in unsupported addFineLevels functions

### DIFF
--- a/Src/EB/AMReX_EB2_IndexSpace_STL.cpp
+++ b/Src/EB/AMReX_EB2_IndexSpace_STL.cpp
@@ -83,9 +83,12 @@ IndexSpaceSTL::getGeometry (const Box& dom) const
 }
 
 void
-IndexSpaceSTL::addFineLevels (int /*num_new_fine_levels*/)
+IndexSpaceSTL::addFineLevels (int num_new_fine_levels)
 {
-    amrex::Abort("IndexSpaceSTL::addFineLevels: todo");
+    // This function is a no op if not adding levels, otherwise TODO
+    if (num_new_fine_levels > 0) {
+        amrex::Abort("IndexSpaceSTL::addFineLevels: todo");
+    }
 }
 
 void

--- a/Src/EB/AMReX_EB2_IndexSpace_chkpt_file.cpp
+++ b/Src/EB/AMReX_EB2_IndexSpace_chkpt_file.cpp
@@ -78,9 +78,12 @@ IndexSpaceChkptFile::getGeometry (const Box& dom) const
 }
 
 void
-IndexSpaceChkptFile::addFineLevels (int /*num_new_fine_levels*/)
+IndexSpaceChkptFile::addFineLevels (int num_new_fine_levels)
 {
-    amrex::Abort("IndexSpaceChkptFile::addFineLevels: not supported");
+    // This function is a no op if not adding levels, otherwise TODO
+    if (num_new_fine_levels > 0) {
+        amrex::Abort("IndexSpaceChkptFile::addFineLevels: not supported");
+    }
 }
 
 void


### PR DESCRIPTION
## Summary

The `addFineLevels` function is not supported for EB2 for chk_file and stl geometries. However, it may be called in some for some trivial cases where it is adding 0 levels, in which case it is a no-op. There is no reason to abort in those cases. 

## Additional background

For PeleC, a work-around was put in to not call the function in the trivial cases (https://github.com/AMReX-Combustion/PeleC/pull/771). I was thinking about adding the same work around to address the same thing in PeleLMeX (https://github.com/AMReX-Combustion/PeleLMeX/issues/407), but maybe it would be better to simply allow the function to be called in trivial cases. If there's a reason not to do this, I'll just put the workaround in for PeleLMeX.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [X] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
