### PR TITLE
`ParmParse`: Prefix to `FILE`

### DIFF
--- a/Src/Base/AMReX_ParmParse.H
+++ b/Src/Base/AMReX_ParmParse.H
@@ -60,6 +60,9 @@ class RealVect;
 // '\n's. The "FILE = <filename>" definition is special.  Rather than just
 // adding this entry to the database, it reads the contents of <filename>
 // into the database.
+// For CI/CD workflows and out-of-source tests, the environment variable
+// AMREX_INPUTS_FILE_PREFIX can be set to prefix every FILE = <filename>
+// with a custom path.
 //
 // ParmParse stores all entries in a static table which is built the
 // first time a ParmParse object is constructed (usually in main()).

--- a/Src/Base/AMReX_ParmParse.cpp
+++ b/Src/Base/AMReX_ParmParse.cpp
@@ -9,6 +9,7 @@
 
 #include <algorithm>
 #include <cctype>
+#include <cstdlib>
 #include <iostream>
 #include <limits>
 #include <numeric>
@@ -407,6 +408,14 @@ read_file (const char* fname, ParmParse::Table& tab)
     //
     if ( fname != nullptr && fname[0] != 0 )
     {
+        std::string filename = fname;
+
+        // optional prefix to search files in
+        char const *amrex_inputs_file_prefix = std::getenv("AMREX_INPUTS_FILE_PREFIX");
+        if (amrex_inputs_file_prefix != nullptr) {
+            filename = std::string(amrex_inputs_file_prefix) + filename;
+        }
+
 #ifdef AMREX_USE_MPI
         if (ParallelDescriptor::Communicator() == MPI_COMM_NULL)
         {
@@ -415,7 +424,6 @@ read_file (const char* fname, ParmParse::Table& tab)
 #endif
 
         Vector<char> fileCharPtr;
-        std::string filename = fname;
         ParallelDescriptor::ReadAndBcastFile(filename, fileCharPtr);
 
         std::istringstream is(fileCharPtr.data());

--- a/Src/Base/AMReX_ParmParse.cpp
+++ b/Src/Base/AMReX_ParmParse.cpp
@@ -411,9 +411,14 @@ read_file (const char* fname, ParmParse::Table& tab)
         std::string filename = fname;
 
         // optional prefix to search files in
-        char const *amrex_inputs_file_prefix = std::getenv("AMREX_INPUTS_FILE_PREFIX");
-        if (amrex_inputs_file_prefix != nullptr) {
-            filename = std::string(amrex_inputs_file_prefix) + filename;
+        char const *amrex_inputs_file_prefix_c = std::getenv("AMREX_INPUTS_FILE_PREFIX");
+        if (amrex_inputs_file_prefix_c != nullptr) {
+            // we expect a directory path as the prefix: append a trailing "/" if missing
+            auto amrex_inputs_file_prefix = std::string(amrex_inputs_file_prefix_c);
+            if (amrex_inputs_file_prefix.back() != '/') {
+                amrex_inputs_file_prefix += "/";
+            }
+            filename = amrex_inputs_file_prefix + filename;
         }
 
 #ifdef AMREX_USE_MPI


### PR DESCRIPTION
## Summary

For CI/CD workflows and out-of-source tests we often want to include dependent inputs files via `FILE = <filename>`. For development, we prefer to run in temporary run directories but want to avoid having to copy over the latest inputs file from a source directory (mostly to avoid confusion between source and copy and to enable rapid development cycles).

Now, the environment variable `AMREX_INPUTS_FILE_PREFIX` can be set to prefix every `FILE = <filename>` with a custom path. We will use this in the CTests integration of WarpX.

## Additional background

CC @EZoni
https://github.com/ECP-WarpX/WarpX/pull/5068

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [x] include documentation in the code and/or rst files, if appropriate
