### PR TITLE
use perl instead of sed in style checks for portability to MacOS

### DIFF
--- a/.github/workflows/style/check_tabs.sh
+++ b/.github/workflows/style/check_tabs.sh
@@ -20,7 +20,7 @@ find . -type d \( -name .git \
                     -a ! -name "*.lex.h" -a ! -name "*.lex.nolint.H" \) \
                \) \
     -exec grep -Iq . {} \; \
-    -exec sed -i 's/\t/\ \ \ \ /g' {} +
+    -exec perl -i -pe's/\t/\ \ \ \ /g' {} +
 
 gitdiff=`git diff`
 

--- a/.github/workflows/style/check_trailing_whitespaces.sh
+++ b/.github/workflows/style/check_trailing_whitespaces.sh
@@ -20,7 +20,7 @@ find . -type d \( -name .git \
                     -a ! -name "*.lex.h" -a ! -name "*.lex.nolint.H" \) \
                \) \
     -exec grep -Iq . {} \; \
-    -exec sed -i 's/[[:blank:]]\+$//g' {} +
+    -exec perl -i -pe's/[[:blank:]]+$//g' {} +
 
 gitdiff=`git diff`
 


### PR DESCRIPTION
## Summary

`sed -i` does not function the same for GNU and BSD sed and a simple portable command between the two is apparently not possible. Therefore, the style check scripts do not work by default when running on Macs, unless the user installs `gsed` and aliases `sed` to run that instead. For portability,`perl` can be used instead of `sed`.

## Additional background

Proposed solution taken from here: https://stackoverflow.com/questions/4247068/sed-command-with-i-option-failing-on-mac-but-works-on-linux

## Checklist

The proposed changes:
- [X] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
