### PR TITLE
MLMG: Minimum domain width

### DIFF
--- a/Src/LinearSolvers/MLMG/AMReX_MLABecLaplacian.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLABecLaplacian.H
@@ -1281,7 +1281,7 @@ MLABecLaplacianT<MF>::supportNSolve () const
     bool support = false;
     if (this->m_overset_mask[0][0]) {
         if (this->m_geom[0].back().Domain().coarsenable(MLLinOp::mg_coarsen_ratio,
-                                                        MLLinOp::mg_domain_min_width)
+                                                        this->mg_domain_min_width)
             && this->m_grids[0].back().coarsenable(MLLinOp::mg_coarsen_ratio, MLLinOp::mg_box_min_width))
         {
             support = true;

--- a/Src/LinearSolvers/MLMG/AMReX_MLLinOp.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLLinOp.H
@@ -570,11 +570,7 @@ protected:
 
     static constexpr int mg_coarsen_ratio = 2;
     static constexpr int mg_box_min_width = 2;
-#ifdef AMREX_USE_EB
-    static constexpr int mg_domain_min_width = 4;
-#else
-    static constexpr int mg_domain_min_width = 2;
-#endif
+    int mg_domain_min_width = 2;
 
     LPInfo info;
 
@@ -802,6 +798,15 @@ MLLinOpT<MF>::defineGrids (const Vector<Geometry>& a_geom,
                            const Vector<FabFactory<FAB> const*>& a_factory)
 {
     BL_PROFILE("MLLinOp::defineGrids()");
+
+#ifdef AMREX_USE_EB
+    if ( ! a_factory.empty() ) {
+        auto const* ebf = dynamic_cast<EBFArrayBoxFactory const*>(a_factory[0]);
+        if (ebf && !(ebf->isAllRegular())) { // Has non-trivial EB
+            mg_domain_min_width = 4;
+        }
+    }
+#endif
 
     m_num_amr_levels = 0;
     for (int amrlev = 0; amrlev < a_geom.size(); amrlev++) {


### PR DESCRIPTION
By default, the minimum domain width at the coarsest multigrid level is 2 and 4, for non-EB and EB runs, respectively. Previously, it was set to 4 for runs compiled with EB support but without EB at run time. So the results of those runs would be different from runs not compiled with EB support. This is not a correctness issue. Nevertheless, for the sake of consistence, we set the minimum domain width to 4 only if there is non-trivial EB at run time.
