### PR TITLE
Use BL_PROFILE instead of BL_PROFILE_VAR to time in knapsack()swap

### DIFF
--- a/Src/Base/AMReX_DistributionMapping.cpp
+++ b/Src/Base/AMReX_DistributionMapping.cpp
@@ -651,7 +651,7 @@ knapsack (const std::vector<Long>&         wgts,
     if (efficiency < max_efficiency && do_full_knapsack
         && wblv.size() > 1 && wblv.begin()->size() > 1)
     {
-        BL_PROFILE_VAR("knapsack()swap", swap);
+        BL_PROFILE("knapsack()swap");
 top: ;
 
         if (efficiency < max_efficiency && wblv.begin()->size() > 1)
@@ -980,7 +980,7 @@ DistributionMapping::KnapSackProcessorMap (const DistributionMapping& olddm,
             new_efficiency = avg_weight / max_weight;
 
             if (new_efficiency < max_efficiency && wblv.size() > 1) {
-                BL_PROFILE_VAR("knapsack()swap", swap);
+                BL_PROFILE("knapsack()swap");
 
                 std::sort(wblv.begin(), wblv.end());
 


### PR DESCRIPTION
This timer was using `BL_PROFILE_VAR` without an associated `BL_PROFILE_STOP`, resulting in unused variable warnings. It seems to me that we can just use `BL_PROFILE` here and rely on scope to stop the timer.

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
