### PR TITLE
amrex::Stack

### DIFF
--- a/Src/Base/AMReX_Stack.H
+++ b/Src/Base/AMReX_Stack.H
@@ -1,0 +1,24 @@
+#ifndef AMREX_STACK_H_
+#define AMREX_STACK_H_
+
+namespace amrex {
+
+template <typename T, int N>
+struct Stack
+{
+public:
+    constexpr void push (T v) { m_data[m_size++] = v; }
+    constexpr void pop () { --m_size; }
+    [[nodiscard]] constexpr bool empty () const { return m_size == 0; }
+    [[nodiscard]] constexpr int size () const { return m_size; }
+    [[nodiscard]] constexpr T const& top () const { return m_data[m_size-1]; }
+    [[nodiscard]] constexpr T      & top ()       { return m_data[m_size-1]; }
+    [[nodiscard]] constexpr T operator[] (int i) const { return m_data[i]; }
+private:
+    T m_data[N];
+    int m_size = 0;
+};
+
+}
+
+#endif

--- a/Src/Base/CMakeLists.txt
+++ b/Src/Base/CMakeLists.txt
@@ -31,6 +31,7 @@ foreach(D IN LISTS AMReX_SPACEDIM)
        AMReX_parmparse_fi.cpp
        AMReX_ParmParse.H
        AMReX_Functional.H
+       AMReX_Stack.H
        AMReX_String.H
        AMReX_String.cpp
        AMReX_Utility.H

--- a/Src/Base/Make.package
+++ b/Src/Base/Make.package
@@ -23,6 +23,8 @@ C$(AMREX_BASE)_sources += AMReX_PODVector.cpp
 C$(AMREX_BASE)_headers += AMReX_BlockMutex.H
 C$(AMREX_BASE)_sources += AMReX_BlockMutex.cpp
 
+C$(AMREX_BASE)_headers += AMReX_Stack.H
+
 C$(AMREX_BASE)_headers += AMReX_String.H
 C$(AMREX_BASE)_sources += AMReX_String.cpp
 

--- a/Src/Base/Parser/AMReX_IParser_Exe.H
+++ b/Src/Base/Parser/AMReX_IParser_Exe.H
@@ -3,6 +3,7 @@
 #include <AMReX_Config.H>
 
 #include <AMReX_IParser_Y.H>
+#include <AMReX_Stack.H>
 #include <AMReX_Vector.H>
 
 #include <limits>
@@ -226,24 +227,12 @@ struct alignas(8) IParserExeJUMP {
     int offset;
 };
 
-template <int N>
-struct IParserStack
-{
-    long long m_data[N];
-    int m_size = 0;
-    constexpr void push (long long v) { m_data[m_size++] = v; }
-    constexpr void pop () { --m_size; }
-    [[nodiscard]] constexpr long long const& top () const { return m_data[m_size-1]; }
-    [[nodiscard]] constexpr long long      & top ()       { return m_data[m_size-1]; }
-    [[nodiscard]] constexpr long long operator[] (int i) const { return m_data[i]; }
-};
-
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 long long iparser_exe_eval (const char* p, long long const* x)
 {
     if (p == nullptr) { return std::numeric_limits<long long>::max(); }
 
-    IParserStack<AMREX_IPARSER_STACK_SIZE> pstack;
+    Stack<long long, AMREX_IPARSER_STACK_SIZE> pstack;
     while (*((iparser_exe_t*)p) != IPARSER_EXE_NULL) {
         switch (*((iparser_exe_t*)p))
         {

--- a/Src/Base/Parser/AMReX_Parser_Exe.H
+++ b/Src/Base/Parser/AMReX_Parser_Exe.H
@@ -3,6 +3,7 @@
 #include <AMReX_Config.H>
 
 #include <AMReX_Parser_Y.H>
+#include <AMReX_Stack.H>
 #include <AMReX_Vector.H>
 
 #include <limits>
@@ -217,24 +218,12 @@ struct alignas(8) ParserExeJUMP {
     int offset;
 };
 
-template <int N>
-struct ParserStack
-{
-    double m_data[N];
-    int m_size = 0;
-    constexpr void push (double v) { m_data[m_size++] = v; }
-    constexpr void pop () { --m_size; }
-    [[nodiscard]] constexpr double const& top () const { return m_data[m_size-1]; }
-    [[nodiscard]] constexpr double      & top ()       { return m_data[m_size-1]; }
-    [[nodiscard]] constexpr double operator[] (int i) const { return m_data[i]; }
-};
-
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 double parser_exe_eval (const char* p, double const* x)
 {
     if (p == nullptr) { return std::numeric_limits<double>::max(); }
 
-    ParserStack<AMREX_PARSER_STACK_SIZE> pstack;
+    Stack<double, AMREX_PARSER_STACK_SIZE> pstack;
     while (*((parser_exe_t*)p) != PARSER_EXE_NULL) { // NOLINT
         switch (*((parser_exe_t*)p))
         {


### PR DESCRIPTION
Move the Stack class used in Parser to its own header so that it can be used by others. The Stack class has a fixed maximum size. This is useful for traversing a tree on GPU, because recursive function does not work well in device code.
