### PR TITLE
add geometric terms for spherical 2D support.

### DIFF
--- a/Src/Base/AMReX_CoordSys.cpp
+++ b/Src/Base/AMReX_CoordSys.cpp
@@ -164,7 +164,7 @@ CoordSys::UpperIndex(const Real* point) const noexcept
     IntVect ix;
     for (int k = 0; k < AMREX_SPACEDIM; k++)
     {
-        ix[k] = (int) ((point[k]-offset[k])/dx[k] + 1);
+        ix[k] = (int) ((point[k]-offset[k])/dx[k]) + 1;
     }
     return ix;
 }
@@ -512,7 +512,7 @@ CoordSys::Volume (const Real xlo[AMREX_SPACEDIM],
                             *(xhi[2]-xlo[2]));
 #if (AMREX_SPACEDIM==2)
     case RZ:
-        return static_cast<Real>(0.5*TWOPI)*(xhi[1]-xlo[1])*(xhi[0]+xlo[0])*(xhi[0]-xlo[0]);
+        return static_cast<Real>(0.5*TWOPI)*(xhi[1]-xlo[1])*(xhi[0]*xhi[0]-xlo[0]*xlo[0]);
     case SPHERICAL:
         return static_cast<Real>(TWOPI/3.)*(std::cos(xlo[1])-std::cos(xhi[1])) *
             (xhi[0]-xlo[0])*(xhi[0]*xhi[0]+xhi[0]*xlo[0]+xlo[0]*xlo[0]);

--- a/Src/Base/AMReX_CoordSys.cpp
+++ b/Src/Base/AMReX_CoordSys.cpp
@@ -164,8 +164,7 @@ CoordSys::UpperIndex(const Real* point) const noexcept
     IntVect ix;
     for (int k = 0; k < AMREX_SPACEDIM; k++)
     {
-        // +1 for UpperIndex?
-        ix[k] = (int) ((point[k]-offset[k])/dx[k]);
+        ix[k] = (int) ((point[k]-offset[k])/dx[k] + 1);
     }
     return ix;
 }

--- a/Src/Base/AMReX_Geometry.H
+++ b/Src/Base/AMReX_Geometry.H
@@ -264,7 +264,7 @@ public:
 
             vol = dx[0] * dx[1];
         }
-        else {
+        else if (coord == CoordSys::RZ) {
             // Cylindrical
 
             Real r_l = geomdata.ProbLo()[0] + static_cast<Real>(point[0]) * dx[0];
@@ -272,6 +272,19 @@ public:
 
             constexpr Real pi = Real(3.1415926535897932);
             vol = pi * (r_l + r_r) * dx[0] * dx[1];
+        }
+        else {
+            // Spherical
+
+            Real r_l = geomdata.ProbLo()[0] + static_cast<Real>(point[0]) * dx[0];
+            Real r_r = geomdata.ProbLo()[0] + static_cast<Real>(point[0]+1) * dx[0];
+
+            Real theta_l = geomdata.ProbLo()[1] + static_cast<Real>(point[1]) * dx[1];
+            Real theta_r = geomdata.ProbLo()[1] + static_cast<Real>(point[1]+1) * dx[1];
+
+            constexpr Real twoThirdsPi = static_cast<Real>(2.0 * 3.1415926535897932 / 3.0);
+            vol = twoThirdsPi * (std::cos(theta_l) - std::cos(theta_r)) * dx[0] *
+                (r_r*r_r + r_r*r_l + r_l*r_l);
         }
 
 #else


### PR DESCRIPTION
## Summary
This adds the appropriate geometric terms (area and volume) for spherical 2D geometry. We assume dx[0]=dr,  and dx[1]=d$`\theta`$.
## Additional background
This intended to deal with issue #3670 
## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
