### PR TITLE
Fix ParmParse::query_enum_case_insensitive

### DIFF
--- a/Src/Base/AMReX_Enum.H
+++ b/Src/Base/AMReX_Enum.H
@@ -69,6 +69,26 @@ namespace amrex
 
     template <typename T, typename ET = amrex_enum_traits<T>,
               std::enable_if_t<ET::value,int> = 0>
+    T getEnumCaseInsensitive (std::string_view const& s)
+    {
+        auto const& kv = getEnumNameValuePairs<T>();
+        std::string ls = amrex::toLower(std::string(s));
+        auto it = std::find_if(kv.begin(), kv.end(),
+                               [&] (auto const& x) -> bool
+                                   { return amrex::toLower(x.first) == ls; });
+        if (it != kv.end()) {
+            return it->second;
+        } else {
+            std::string error_msg("amrex::getEnumCaseInsensitive: Unknown enum: ");
+            error_msg.append(s).append(" in AMREX_ENUM(").append(ET::class_name)
+                .append(", ").append(ET::enum_names).append(").");
+            throw std::runtime_error(error_msg);
+            return T();
+        }
+    }
+
+    template <typename T, typename ET = amrex_enum_traits<T>,
+              std::enable_if_t<ET::value,int> = 0>
     std::string getEnumNameString (T const& v)
     {
         auto const& kv = getEnumNameValuePairs<T>();

--- a/Src/Base/AMReX_ParmParse.H
+++ b/Src/Base/AMReX_ParmParse.H
@@ -1329,19 +1329,14 @@ public:
         std::string s;
         int exist = this->query(name, s, ival);
         if (exist) {
-            s = amrex::toLower(s);
-            auto const& enum_names = amrex::getEnumNameStrings<T>();
-            auto found = std::find_if(enum_names.begin(), enum_names.end(),
-                                      [&] (std::string const& ename) {
-                                          return amrex::toLower(ename) == s;
-                                      });
-            if (found != enum_names.end()) {
-                ref = static_cast<T>(std::distance(enum_names.begin(), found));
-            } else {
-                std::string msg("query_enum_case_insensitive(\"");
-                msg.append(name).append("\",").append(amrex::getEnumClassName<T>())
-                    .append("&) failed.");
-                throw std::runtime_error(msg);
+            try {
+                ref = amrex::getEnumCaseInsensitive<T>(s);
+            } catch (...) {
+                if (amrex::Verbose() > 0) {
+                    amrex::Print() << "amrex::ParmParse::query_enum_case_insensitive (input name: "
+                                   << this->prefixedName(name) << "):\n";
+                }
+                throw;
             }
         }
         return exist;

--- a/Tests/Enum/main.cpp
+++ b/Tests/Enum/main.cpp
@@ -129,6 +129,11 @@ int main (int argc, char* argv[])
         AMREX_ALWAYS_ASSERT(amrex::getEnum<MyColor2>("green") == MyColor2::green);
         AMREX_ALWAYS_ASSERT(amrex::getEnum<MyColor2>("blue") == MyColor2::blue);
         AMREX_ALWAYS_ASSERT(amrex::getEnum<MyColor2>("Default") == MyColor2::Default);
+
+        auto my_blue = MyColor2::Default;
+        ParmParse pp;
+        pp.query_enum_case_insensitive("color5", my_blue);
+        AMREX_ALWAYS_ASSERT(my_blue == MyColor2::blue);
     }
 
     amrex::Finalize();


### PR DESCRIPTION
Since #4143, we can no longer cast the position of the found string in the vector of all names to obtain its enum value, because the enum values can now have duplicates.
