### PR TITLE
Vis multicuts

### DIFF
--- a/Docs/sphinx_documentation/source/RuntimeParameters.rst
+++ b/Docs/sphinx_documentation/source/RuntimeParameters.rst
@@ -787,6 +787,15 @@ Embedded Boundary
    .. tip::  Because AMReX currently does not support multi-cut cells, it
              would be a runtime error if multi-cut cells are left unfixed.
 
+.. py:data:: eb2.plt_multiple_cuts
+   :type: bool
+   :value: false
+
+   If this parameter is set to true and multi-cut cells are present,
+   we produce plot files to see the location of the multi-cut issue.
+   In the plot file, a cell value of 2 indicates regular, 0 means covered,
+   and values greater than 2 indicate multi-cut cells.
+
 .. py:data:: eb2.maxiter
    :type: int
    :value: 32

--- a/Src/EB/AMReX_EB2_2D_C.cpp
+++ b/Src/EB/AMReX_EB2_2D_C.cpp
@@ -203,7 +203,8 @@ int build_faces (Box const& bx, Array4<EBCellFlag> const& cell,
                  Array4<Real> const& fcx, Array4<Real> const& fcy,
                  GpuArray<Real,AMREX_SPACEDIM> const& dx,
                  GpuArray<Real,AMREX_SPACEDIM> const& problo,
-                 bool cover_multiple_cuts, int& nsmallfaces) noexcept
+                 bool cover_multiple_cuts, int& nsmallfaces,
+                 bool plt_multiple_cuts, Array4<Real> const& mcx) noexcept
 {
 #ifdef AMREX_USE_FLOAT
     constexpr Real small = 1.e-5_rt;
@@ -311,6 +312,10 @@ int build_faces (Box const& bx, Array4<EBCellFlag> const& cell,
                 if (ncuts > 2) {
                     Gpu::Atomic::Add(dp,1);
                 }
+                if (plt_multiple_cuts)
+                {
+                    mcx(i,j,k) = ncuts;
+                }
             }
         }
     });
@@ -342,7 +347,10 @@ int build_faces (Box const& bx, Array4<EBCellFlag> const& cell,
     nsmallfaces += *(hp+1);
 
     if (*hp > 0 && !cover_multiple_cuts) {
-        amrex::Abort("amrex::EB2::build_faces: more than 2 cuts not supported");
+        if (!plt_multiple_cuts)
+        {
+            amrex::Abort("amrex::EB2::build_faces: more than 2 cuts not supported");
+        }
     }
 
     return *hp;

--- a/Src/EB/AMReX_EB2_3D_C.cpp
+++ b/Src/EB/AMReX_EB2_3D_C.cpp
@@ -370,7 +370,7 @@ int build_faces (Box const& bx, Array4<EBCellFlag> const& cell,
                  Array4<Real> const& m2z,
                  GpuArray<Real,AMREX_SPACEDIM> const& dx,
                  GpuArray<Real,AMREX_SPACEDIM> const& problo,
-                 bool cover_multiple_cuts, bool plt_multiple_cuts, 
+                 bool cover_multiple_cuts, bool plt_multiple_cuts,
                  Array4<Real> const& mcx, Array4<Real> const& mcy, Array4<Real> const& mcz) noexcept
 {
     Gpu::Buffer<int> nmulticuts = {0};

--- a/Src/EB/AMReX_EB2_3D_C.cpp
+++ b/Src/EB/AMReX_EB2_3D_C.cpp
@@ -370,7 +370,8 @@ int build_faces (Box const& bx, Array4<EBCellFlag> const& cell,
                  Array4<Real> const& m2z,
                  GpuArray<Real,AMREX_SPACEDIM> const& dx,
                  GpuArray<Real,AMREX_SPACEDIM> const& problo,
-                 bool cover_multiple_cuts) noexcept
+                 bool cover_multiple_cuts, bool plt_multiple_cuts, 
+                 Array4<Real> const& mcx, Array4<Real> const& mcy, Array4<Real> const& mcz) noexcept
 {
     Gpu::Buffer<int> nmulticuts = {0};
     int* hp = nmulticuts.hostData();
@@ -491,6 +492,11 @@ int build_faces (Box const& bx, Array4<EBCellFlag> const& cell,
             } else if (apx(i,j,k) == 1.0_rt) {
                 fx(i,j,k) = Type::regular;
             }
+
+            if (plt_multiple_cuts){
+                mcx(i,j,k) = ncuts;
+            }
+
         }
     });
 
@@ -598,6 +604,10 @@ int build_faces (Box const& bx, Array4<EBCellFlag> const& cell,
                 fy(i,j,k) = Type::covered;
             } else if (apy(i,j,k) == 1.0_rt) {
                 fy(i,j,k) = Type::regular;
+            }
+
+            if (plt_multiple_cuts){
+                mcy(i,j,k) = ncuts;
             }
         }
     });
@@ -707,6 +717,10 @@ int build_faces (Box const& bx, Array4<EBCellFlag> const& cell,
             } else if (apz(i,j,k) == 1.0_rt) {
                 fz(i,j,k) = Type::regular;
             }
+
+            if (plt_multiple_cuts){
+                mcz(i,j,k) = ncuts;
+            }
         }
     });
 
@@ -768,7 +782,10 @@ int build_faces (Box const& bx, Array4<EBCellFlag> const& cell,
                 }
             });
         } else {
-            amrex::Abort("amrex::EB2::build_faces: more than 2 cuts not supported");
+            if (!plt_multiple_cuts)
+            {
+                amrex::Abort("amrex::EB2::build_faces: more than 2 cuts not supported");
+            }
         }
     }
 
@@ -787,7 +804,7 @@ void build_cells (Box const& bx, Array4<EBCellFlag> const& cell,
                   Array4<Real> const& barea, Array4<Real> const& bcent,
                   Array4<Real> const& bnorm, Array4<EBCellFlag> const& ctmp,
                   Array4<Real> const& levset, Real small_volfrac, Geometry const& geom,
-                  bool extend_domain_face, bool cover_multiple_cuts,
+                  bool extend_domain_face, bool cover_multiple_cuts, bool plt_multiple_cuts,
                   int& nsmallcells, int& nmulticuts) noexcept
 {
     Gpu::Buffer<int> n_smallcell_multicuts = {0,0};
@@ -932,7 +949,10 @@ void build_cells (Box const& bx, Array4<EBCellFlag> const& cell,
 
     if (nsmallcells > 0 || nmulticuts > 0) {
         if (!cover_multiple_cuts && nmulticuts > 0) {
-            amrex::Abort("amrex::EB2::build_cells: multi-cuts not supported");
+            if (!plt_multiple_cuts)
+            {
+                amrex::Abort("amrex::EB2::build_cells: multi-cuts not supported");
+            }
         }
         return;
     } else {

--- a/Src/EB/AMReX_EB2_C.H
+++ b/Src/EB/AMReX_EB2_C.H
@@ -56,7 +56,7 @@ int build_faces (Box const& bx, Array4<EBCellFlag> const& cell,
                  Array4<Real> const& m2z,
                  GpuArray<Real,AMREX_SPACEDIM> const& dx,
                  GpuArray<Real,AMREX_SPACEDIM> const& problo,
-                 bool cover_multiple_cuts, bool plt_multiple_cuts, 
+                 bool cover_multiple_cuts, bool plt_multiple_cuts,
                  Array4<Real> const& mcx, Array4<Real> const& mcy, Array4<Real> const& mcz) noexcept;
 
 void build_cells (Box const& bx, Array4<EBCellFlag> const& cell,

--- a/Src/EB/AMReX_EB2_C.H
+++ b/Src/EB/AMReX_EB2_C.H
@@ -25,7 +25,8 @@ int build_faces (Box const& bx, Array4<EBCellFlag> const& cell,
                  Array4<Real> const& fcx, Array4<Real> const& fcy,
                  GpuArray<Real,AMREX_SPACEDIM> const& dx,
                  GpuArray<Real,AMREX_SPACEDIM> const& problo,
-                 bool cover_multiple_cuts, int& nsmallfaces) noexcept;
+                 bool cover_multiple_cuts, int& nsmallfaces,
+                 bool plt_multiple_cuts, Array4<Real> const& mcx) noexcept;
 
 void build_cells (Box const& bx, Array4<EBCellFlag> const& cell,
                   Array4<Type_t> const& fx, Array4<Type_t> const& fy,
@@ -55,7 +56,8 @@ int build_faces (Box const& bx, Array4<EBCellFlag> const& cell,
                  Array4<Real> const& m2z,
                  GpuArray<Real,AMREX_SPACEDIM> const& dx,
                  GpuArray<Real,AMREX_SPACEDIM> const& problo,
-                 bool cover_multiple_cuts) noexcept;
+                 bool cover_multiple_cuts, bool plt_multiple_cuts, 
+                 Array4<Real> const& mcx, Array4<Real> const& mcy, Array4<Real> const& mcz) noexcept;
 
 void build_cells (Box const& bx, Array4<EBCellFlag> const& cell,
                   Array4<Type_t> const& fx, Array4<Type_t> const& fy,
@@ -69,7 +71,7 @@ void build_cells (Box const& bx, Array4<EBCellFlag> const& cell,
                   Array4<Real> const& barea, Array4<Real> const& bcent,
                   Array4<Real> const& bnorm, Array4<EBCellFlag> const& ctmp,
                   Array4<Real> const& levset, Real small_volfrac, Geometry const& geom,
-                  bool extend_domain_face, bool cover_multiple_cuts,
+                  bool extend_domain_face, bool cover_multiple_cuts, bool plt_multiple_cuts,
                   int& nsmallcells, int& nmulticuts) noexcept;
 
 void set_connection_flags(Box const& bx, Box const& bxg1,

--- a/Src/EB/AMReX_EB2_Level.H
+++ b/Src/EB/AMReX_EB2_Level.H
@@ -14,6 +14,7 @@
 #include <AMReX_EB2_MultiGFab.H>
 #include <AMReX_EB2_C.H>
 #include <AMReX_EB2_IF_AllRegular.H>
+#include <AMReX_PlotFileUtil.H>
 
 #ifdef AMREX_USE_OMP
 #include <omp.h>
@@ -92,6 +93,7 @@ protected:
     Array<MultiFab,AMREX_SPACEDIM> m_areafrac;
     Array<MultiFab,AMREX_SPACEDIM> m_facecent;
     Array<MultiFab,AMREX_SPACEDIM> m_edgecent;
+    Array<MultiFab,AMREX_SPACEDIM> m_multicuts;
     iMultiFab m_cutcellmask;
     bool m_allregular = false;
     bool m_ok = false;
@@ -167,12 +169,14 @@ GShopLevel<G>::define_fine (G const& gshop, const Geometry& geom,
     Real small_volfrac = 1.e-14;
 #endif
     bool cover_multiple_cuts = false;
+    bool plt_multiple_cuts = false;
     int maxiter = 32;
     {
         ParmParse pp("eb2");
         pp.queryAdd("small_volfrac", small_volfrac);
         pp.queryAdd("cover_multiple_cuts", cover_multiple_cuts);
         pp.queryAdd("maxiter", maxiter);
+        pp.queryAdd("plt_multiple_cuts", plt_multiple_cuts);
     }
     maxiter = std::min(100000, maxiter);
 
@@ -292,6 +296,8 @@ GShopLevel<G>::define_fine (G const& gshop, const Geometry& geom,
     m_bndrynorm.define(m_grids, m_dmap, AMREX_SPACEDIM, ng, mf_info);
     for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
         m_areafrac[idim].define(amrex::convert(m_grids, IntVect::TheDimensionVector(idim)),
+                                m_dmap, 1, ng, mf_info);
+        m_multicuts[idim].define(amrex::convert(m_grids, IntVect::TheDimensionVector(idim)),
                                 m_dmap, 1, ng, mf_info);
         m_facecent[idim].define(amrex::convert(m_grids, IntVect::TheDimensionVector(idim)),
                                 m_dmap, AMREX_SPACEDIM-1, ng, mf_info);
@@ -413,9 +419,14 @@ GShopLevel<G>::define_fine (G const& gshop, const Geometry& geom,
                 Array4<Real> const& ym2 = M2[1].array();
                 Array4<Real> const& zm2 = M2[2].array();
 
+                AMREX_D_TERM(Array4<Real> const& mcx = m_multicuts[0].array(mfi);,
+                             Array4<Real> const& mcy = m_multicuts[1].array(mfi);,
+                             Array4<Real> const& mcz = m_multicuts[2].array(mfi););
+
                 nmc = build_faces(vbx, cfg, ftx, fty, ftz, xdg, ydg, zdg, lst,
                                   xip, yip, zip, apx, apy, apz, fcx, fcy, fcz,
-                                  xm2, ym2, zm2, dx, problo, cover_multiple_cuts);
+                                  xm2, ym2, zm2, dx, problo, cover_multiple_cuts,
+                                  plt_multiple_cuts, mcx, mcy, mcz);
 
                 cellflagtmp.resize(m_cellflag[mfi].box());
                 Elixir cellflagtmp_eli = cellflagtmp.elixir();
@@ -424,7 +435,8 @@ GShopLevel<G>::define_fine (G const& gshop, const Geometry& geom,
                 build_cells(vbx, cfg, ftx, fty, ftz, apx, apy, apz,
                             fcx, fcy, fcz, xm2, ym2, zm2, dx, vfr, ctr,
                             bar, bct, bnm, cfgtmp, lst,
-                            small_volfrac, geom, extend_domain_face, cover_multiple_cuts,
+                            small_volfrac, geom, extend_domain_face, 
+                            cover_multiple_cuts, plt_multiple_cuts,
                             nsm, nmc);
 
                 // Because it is used in a synchronous reduction kernel in
@@ -466,8 +478,11 @@ GShopLevel<G>::define_fine (G const& gshop, const Geometry& geom,
                                           clst, geom);
                 }
 
+                Array4<Real> const& mcx = m_multicuts[0].array(mfi);
+
                 nmc = build_faces(vbx, cfg, ftx, fty, lst, xip, yip, apx, apy, fcx, fcy,
-                                  dx, problo, cover_multiple_cuts, nsm);
+                                  dx, problo, cover_multiple_cuts, nsm,
+                                  plt_multiple_cuts, mcx);
 
                 build_cells(vbx, cfg, ftx, fty, apx, apy, dx, vfr, ctr,
                             bar, bct, bnm, lst, small_volfrac, geom, extend_domain_face,
@@ -479,6 +494,34 @@ GShopLevel<G>::define_fine (G const& gshop, const Geometry& geom,
         }
 
         ParallelAllReduce::Sum<int>({nsmallcells,nmulticuts}, ParallelContext::CommunicatorSub());
+
+        if (plt_multiple_cuts && nmulticuts > 0)
+        {
+            amrex::Print() << "Total number of multicuts = " << nmulticuts << "\n";
+            amrex::Print() << "Plotting multicut locations..." << "\n";
+
+            #if (AMREX_SPACEDIM == 3)
+                if (m_multicuts[0].max(0) > 2)
+                {
+                    WriteSingleLevelPlotfile("plt.multicut.x", m_multicuts[0], {"multicut_fcx"}, geom, 0.0, 0);
+                }
+                if (m_multicuts[1].max(0) > 2)
+                {
+                    WriteSingleLevelPlotfile("plt.multicut.y", m_multicuts[1], {"multicut_fcy"}, geom, 0.0, 0);
+                }
+                if (m_multicuts[2].max(0) > 2)
+                {
+                    WriteSingleLevelPlotfile("plt.multicut.z", m_multicuts[2], {"multicut_fcz"}, geom, 0.0, 0);
+                }
+            #elif (AMREX_SPACEDIM == 2)
+                if (m_multicuts[0].max(0) > 2)
+                {
+                    WriteSingleLevelPlotfile("plt.multicut", m_multicuts[0], {"multicut_fcx"}, geom, 0.0, 0);
+                }
+            #endif
+            amrex::Abort("amrex::EB2:: more than 2 cuts not supported");
+        }
+
         if (nsmallcells == 0 && nmulticuts == 0) {
             break;
         } else {

--- a/Src/EB/AMReX_EB2_Level.H
+++ b/Src/EB/AMReX_EB2_Level.H
@@ -435,7 +435,7 @@ GShopLevel<G>::define_fine (G const& gshop, const Geometry& geom,
                 build_cells(vbx, cfg, ftx, fty, ftz, apx, apy, apz,
                             fcx, fcy, fcz, xm2, ym2, zm2, dx, vfr, ctr,
                             bar, bct, bnm, cfgtmp, lst,
-                            small_volfrac, geom, extend_domain_face, 
+                            small_volfrac, geom, extend_domain_face,
                             cover_multiple_cuts, plt_multiple_cuts,
                             nsm, nmc);
 

--- a/Src/EB/AMReX_EB2_Level.H
+++ b/Src/EB/AMReX_EB2_Level.H
@@ -93,7 +93,9 @@ protected:
     Array<MultiFab,AMREX_SPACEDIM> m_areafrac;
     Array<MultiFab,AMREX_SPACEDIM> m_facecent;
     Array<MultiFab,AMREX_SPACEDIM> m_edgecent;
-    Array<MultiFab,AMREX_SPACEDIM> m_multicuts;
+    MultiFab m_multicut_fcx;
+    MultiFab m_multicut_fcy;
+    MultiFab m_multicut_fcz;
     iMultiFab m_cutcellmask;
     bool m_allregular = false;
     bool m_ok = false;
@@ -294,10 +296,11 @@ GShopLevel<G>::define_fine (G const& gshop, const Geometry& geom,
     m_bndryarea.define(m_grids, m_dmap, 1, ng, mf_info);
     m_bndrycent.define(m_grids, m_dmap, AMREX_SPACEDIM, ng, mf_info);
     m_bndrynorm.define(m_grids, m_dmap, AMREX_SPACEDIM, ng, mf_info);
+    m_multicut_fcx.define(m_grids, m_dmap, 1, ng, mf_info);
+    m_multicut_fcy.define(m_grids, m_dmap, 1, ng, mf_info);
+    m_multicut_fcz.define(m_grids, m_dmap, 1, ng, mf_info);
     for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
         m_areafrac[idim].define(amrex::convert(m_grids, IntVect::TheDimensionVector(idim)),
-                                m_dmap, 1, ng, mf_info);
-        m_multicuts[idim].define(amrex::convert(m_grids, IntVect::TheDimensionVector(idim)),
                                 m_dmap, 1, ng, mf_info);
         m_facecent[idim].define(amrex::convert(m_grids, IntVect::TheDimensionVector(idim)),
                                 m_dmap, AMREX_SPACEDIM-1, ng, mf_info);
@@ -419,9 +422,9 @@ GShopLevel<G>::define_fine (G const& gshop, const Geometry& geom,
                 Array4<Real> const& ym2 = M2[1].array();
                 Array4<Real> const& zm2 = M2[2].array();
 
-                AMREX_D_TERM(Array4<Real> const& mcx = m_multicuts[0].array(mfi);,
-                             Array4<Real> const& mcy = m_multicuts[1].array(mfi);,
-                             Array4<Real> const& mcz = m_multicuts[2].array(mfi););
+                Array4<Real> const& mcx = m_multicut_fcx.array(mfi);
+                Array4<Real> const& mcy = m_multicut_fcy.array(mfi);
+                Array4<Real> const& mcz = m_multicut_fcz.array(mfi);
 
                 nmc = build_faces(vbx, cfg, ftx, fty, ftz, xdg, ydg, zdg, lst,
                                   xip, yip, zip, apx, apy, apz, fcx, fcy, fcz,
@@ -478,7 +481,7 @@ GShopLevel<G>::define_fine (G const& gshop, const Geometry& geom,
                                           clst, geom);
                 }
 
-                Array4<Real> const& mcx = m_multicuts[0].array(mfi);
+                Array4<Real> const& mcx = m_multicut_fcx.array(mfi);
 
                 nmc = build_faces(vbx, cfg, ftx, fty, lst, xip, yip, apx, apy, fcx, fcy,
                                   dx, problo, cover_multiple_cuts, nsm,
@@ -501,22 +504,22 @@ GShopLevel<G>::define_fine (G const& gshop, const Geometry& geom,
             amrex::Print() << "Plotting multicut locations..." << "\n";
 
             #if (AMREX_SPACEDIM == 3)
-                if (m_multicuts[0].max(0) > 2)
+                if (m_multicut_fcx.max(0) > 2)
                 {
-                    WriteSingleLevelPlotfile("plt.multicut.x", m_multicuts[0], {"multicut_fcx"}, geom, 0.0, 0);
+                    WriteSingleLevelPlotfile("plt.multicut.x", m_multicut_fcx, {"multicut_fcx"}, geom, 0.0, 0);
                 }
-                if (m_multicuts[1].max(0) > 2)
+                if (m_multicut_fcy.max(0) > 2)
                 {
-                    WriteSingleLevelPlotfile("plt.multicut.y", m_multicuts[1], {"multicut_fcy"}, geom, 0.0, 0);
+                    WriteSingleLevelPlotfile("plt.multicut.y", m_multicut_fcy, {"multicut_fcy"}, geom, 0.0, 0);
                 }
-                if (m_multicuts[2].max(0) > 2)
+                if (m_multicut_fcz.max(0) > 2)
                 {
-                    WriteSingleLevelPlotfile("plt.multicut.z", m_multicuts[2], {"multicut_fcz"}, geom, 0.0, 0);
+                    WriteSingleLevelPlotfile("plt.multicut.z", m_multicut_fcz, {"multicut_fcz"}, geom, 0.0, 0);
                 }
             #elif (AMREX_SPACEDIM == 2)
-                if (m_multicuts[0].max(0) > 2)
+                if (m_multicut_fcx.max(0) > 2)
                 {
-                    WriteSingleLevelPlotfile("plt.multicut", m_multicuts[0], {"multicut_fcx"}, geom, 0.0, 0);
+                    WriteSingleLevelPlotfile("plt.multicut", m_multicut_fcx, {"multicut_fcx"}, geom, 0.0, 0);
                 }
             #endif
             amrex::Abort("amrex::EB2:: more than 2 cuts not supported");


### PR DESCRIPTION
## Summary
Visualization of multi-cut locations.
1) In the input file, you can add eb2.plt_multiple_cuts = "true" to produce plot files to see the multi-cut cells.
-> The description was added to the RuntimeParameters.rst file.
* Note: If "eb2.plt_multiple_cuts" is true, we abort the code after creating the plot files. This is in the AMReX_EB2_Level.H.

2) For a 3D case, you would get up to three plot files: plt.multicut.x, plt.multicut.y, and plt.multicut.z.

This depends on which face has multi-cut issues.
-> See AMReX_EB2_3D_C.cpp

3) For a 2D case, the output name is plt.multicut.
-> See AMReX_EB2_2D_C.cpp

4) For any dimension, a cell value of 2 indicates regular, 0 means covered, and values greater than 2 indicate multi-cut cells.

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [x] include documentation in the code and/or rst files, if appropriate
