### PR TITLE
Add std::setfill to PrintMemStats

### DIFF
--- a/Src/Base/AMReX_TinyProfiler.cpp
+++ b/Src/Base/AMReX_TinyProfiler.cpp
@@ -881,6 +881,7 @@ TinyProfiler::PrintMemStats (std::map<std::string, MemStat>& memstats,
     if (allstatsstr.size() == 1 || !os) { return; }
 
     IOFormatSaver iofmtsaver(*os);
+    *os << std::setfill(' ');
 
     int lenhline = 0;
     for (auto i : maxlen) {


### PR DESCRIPTION
## Summary

Set the fill in TinyProfiler::PrintMemStats to `' '` instead of `'0'`.

## Additional background

This PR fixes the output looking like this:
```
Device Memory Usage:
---------------------------------------------------------------------------------
Name00000000000000000000000000000000000000000000Nalloc00Nfree0000AvgMem0000MaxMem
---------------------------------------------------------------------------------
The_Arena::Initialize()00000000000000000000000000000010000001001259 KiB000029 GiB
MultiLaser::InitData()000000000000000000000000000000030000003002948 MiB002948 MiB
Fields::AllocData()000000000000000000000000000000000010000001002820 MiB002821 MiB
PlasmaParticleContainer::InitParticles()000000000000170000017001597 MiB001727 MiB
MultiLaser::AdvanceSliceMG()000000000000000000000000400000040001090 MiB001110 MiB
Hipace::ExplicitMGSolveBxBy()00000000000000000000000400000040000921 MiB000939 MiB
FFTPoissonSolverDirichletFast::define()0000000000000070000007000639 MiB000640 MiB
ResizeRandomSeed000000000000000000000000000000000000010000001000040 MiB000040 MiB
BeamParticleContainer::InSituComputeDiags()000000010000001000002115   B004968 KiB
MultiLaser::InSituComputeDiags()00000000000000000010000001000007572   B001728 KiB
hpmg::MultiGrid::solve2()000000000000000000000000029590002959000045 KiB000432 KiB
hpmg::MultiGrid::solve1()000000000000000000000000021990002199000030 KiB000432 KiB
shiftSlippedParticles()00000000000000000000000000001620000162000011   B000108 KiB
sortBeamParticlesByBox()0000000000000000000000000000040000004000078 KiB000094 KiB
BeamParticleContainer::InitBeamFixedWeight3D()000000010000001000078 KiB000078 KiB
BeamParticleContainer::resize()000000000000000000003380000338000014 KiB000054 KiB
main()0000000000000000000000000000000000000000000000090000009001087   B001088   B
Hipace::InitData()0000000000000000000000000000000000030000003000143   B000144   B
Fields::Copy()00000000000000000000000000000000000000010000001000031   B000032   B
DepositCurrent_PlasmaParticleContainer()000000000010010001001000000   B000016   B
---------------------------------------------------------------------------------

Managed Memory Usage:
----------------------------------------------------------------
Name00000000000000000000000000000Nalloc00Nfree00AvgMem0000MaxMem
----------------------------------------------------------------
The_Managed_Arena::Initialize()0000000100000010010   B008192 KiB
----------------------------------------------------------------

Pinned Memory Usage:
------------------------------------------------------------------------------
Name00000000000000000000000000000000000000000Nalloc00Nfree0000AvgMem0000MaxMem
------------------------------------------------------------------------------
Diagnostic::ResizeFDiagFAB()000000000000000000000020000002001183 MiB001187 MiB
The_Pinned_Arena::Initialize()0000000000000000000010000001000781   B008192 KiB
OpenPMDWriter::InitBeamData()00000000000000000000080000008000576 KiB000625 KiB
Hipace::InitData()0000000000000000000000000000000190000019000015 KiB000015 KiB
main()0000000000000000000000000000000000000000000670000067001087   B001120   B
Hipace::ExplicitMGSolveBxBy()00000000000000000000010000001000753   B000768   B
MultiLaser::AdvanceSliceMG()000000000000000000000010000001000754   B000768   B
BeamParticleContainer::InSituComputeDiags()000010000001000000000   B000192   B
MultiLaser::InSituComputeDiags()00000000000000010000001000000000   B000064   B
Fields::Copy()00000000000000000000000000000000000010000001000031   B000032   B
PlasmaParticleContainer::InitParticles()000000000010000001000000   B000016   B
hpmg::MultiGrid::solve1()000000000000000000000021990002199000001   B000016   B
hpmg::MultiGrid::solve2()000000000000000000000029590002959000002   B000016   B
shiftSlippedParticles()00000000000000000000000001620000162000000   B000016   B
------------------------------------------------------------------------------
```

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
