### PR TITLE
Fix roundoff issue in SUNDIALS evolve()

### DIFF
--- a/Src/Base/AMReX_RKIntegrator.H
+++ b/Src/Base/AMReX_RKIntegrator.H
@@ -252,7 +252,7 @@ public:
         {
             // Adjust step size to reach output time
             // protect against roundoff
-            if (std::abs(time_out - time_current - dt) <= 1.e5 * std::numeric_limits<amrex::Real>::epsilon() * std::abs(dt)) {
+            if (almostEqual(std::abs(time_out-time_current), std::abs(dt)), 10.) {
                 dt = time_out - time_current;
                 stop = true;
             }

--- a/Src/Base/AMReX_RKIntegrator.H
+++ b/Src/Base/AMReX_RKIntegrator.H
@@ -252,7 +252,7 @@ public:
         {
             // Adjust step size to reach output time
             // protect against roundoff
-            if (almostEqual(std::abs(time_out-time_current), std::abs(dt)), 10.) {
+            if (almostEqual(time_out-time_current, dt), 10) {
                 dt = time_out - time_current;
                 stop = true;
             }

--- a/Src/Base/AMReX_RKIntegrator.H
+++ b/Src/Base/AMReX_RKIntegrator.H
@@ -251,7 +251,8 @@ public:
         for (int step_number = 0; step_number < BaseT::max_steps && !stop; ++step_number)
         {
             // Adjust step size to reach output time
-            if (time_out - time_current < dt) {
+            // protect against roundoff
+            if (std::abs(time_out - time_current - dt) <= 1.e5 * std::numeric_limits<amrex::Real>::epsilon() * std::abs(dt)) {
                 dt = time_out - time_current;
                 stop = true;
             }

--- a/Src/Base/AMReX_RKIntegrator.H
+++ b/Src/Base/AMReX_RKIntegrator.H
@@ -252,7 +252,7 @@ public:
         {
             // Adjust step size to reach output time
             // protect against roundoff
-            if (almostEqual(time_out-time_current, dt), 10) {
+            if ((time_out-time_current) < dt || almostEqual(time_out-time_current,dt,10)) {
                 dt = time_out - time_current;
                 stop = true;
             }


### PR DESCRIPTION
## Summary
Fix a roundoff issue in the SUNDIALS evolve() function that caused the integrator to run a second time with a very tiny dt in a given time step.

## Additional background

## Checklist

The proposed changes:
- [X ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
