### PR TITLE
allow hidden dimension when calling FFlux routines

### DIFF
--- a/Src/LinearSolvers/MLMG/AMReX_MLALaplacian.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLALaplacian.H
@@ -588,8 +588,6 @@ MLALaplacianT<MF>::FFlux (int amrlev, const MFIter& mfi,
                           const Array<FAB*,AMREX_SPACEDIM>& flux,
                           const FAB& sol, Location, int face_only) const
 {
-    AMREX_ASSERT(!this->hasHiddenDimension());
-
     BL_PROFILE("MLALaplacian::FFlux()");
 
     const int ncomp = this->getNComp();
@@ -609,103 +607,143 @@ MLALaplacianT<MF>::FFlux (int amrlev, const MFIter& mfi,
 
 #if (AMREX_SPACEDIM == 3)
     if (face_only) {
-        RT fac = m_b_scalar * RT(dxinv[0]);
-        Box blo = amrex::bdryLo(box, 0);
-        int blen = box.length(0);
-        AMREX_LAUNCH_HOST_DEVICE_LAMBDA ( blo, tbox,
-        {
-            mlalap_flux_xface(tbox, fxarr, solarr, fac, blen, ncomp);
-        });
-        fac = m_b_scalar * RT(dxinv[1]);
-        blo = amrex::bdryLo(box, 1);
-        blen = box.length(1);
-        AMREX_LAUNCH_HOST_DEVICE_LAMBDA ( blo, tbox,
-        {
-            mlalap_flux_yface(tbox, fyarr, solarr, fac, blen, ncomp);
-        });
-        fac = m_b_scalar * RT(dxinv[2]);
-        blo = amrex::bdryLo(box, 2);
-        blen = box.length(2);
-        AMREX_LAUNCH_HOST_DEVICE_LAMBDA ( blo, tbox,
-        {
-            mlalap_flux_zface(tbox, fzarr, solarr, fac, blen, ncomp);
-        });
-    } else {
-        RT fac = m_b_scalar * RT(dxinv[0]);
-        Box bflux = amrex::surroundingNodes(box, 0);
-        AMREX_LAUNCH_HOST_DEVICE_LAMBDA ( bflux, tbox,
-        {
-            mlalap_flux_x(tbox, fxarr, solarr, fac, ncomp);
-        });
-        fac = m_b_scalar * RT(dxinv[1]);
-        bflux = amrex::surroundingNodes(box, 1);
-        AMREX_LAUNCH_HOST_DEVICE_LAMBDA ( bflux, tbox,
-        {
-            mlalap_flux_y(tbox, fyarr, solarr, fac, ncomp);
-        });
-        fac = m_b_scalar * RT(dxinv[2]);
-        bflux = amrex::surroundingNodes(box, 2);
-        AMREX_LAUNCH_HOST_DEVICE_LAMBDA ( bflux, tbox,
-        {
-            mlalap_flux_z(tbox, fzarr, solarr, fac, ncomp);
-        });
-    }
-#elif (AMREX_SPACEDIM == 2)
-    if (face_only) {
-        RT fac = m_b_scalar * RT(dxinv[0]);
-        Box blo = amrex::bdryLo(box, 0);
-        int blen = box.length(0);
-        if (this->m_has_metric_term) {
-            AMREX_LAUNCH_HOST_DEVICE_LAMBDA ( blo, tbox,
-            {
-                mlalap_flux_xface_m(tbox, fxarr, solarr, fac, blen, dx, probxlo, ncomp);
-            });
-        } else {
+        if (this->hiddenDirection() != 0) {
+            RT fac = m_b_scalar * RT(dxinv[0]);
+            Box blo = amrex::bdryLo(box, 0);
+            int blen = box.length(0);
             AMREX_LAUNCH_HOST_DEVICE_LAMBDA ( blo, tbox,
             {
                 mlalap_flux_xface(tbox, fxarr, solarr, fac, blen, ncomp);
             });
-        }
-        fac = m_b_scalar * RT(dxinv[1]);
-        blo = amrex::bdryLo(box, 1);
-        blen = box.length(1);
-        if (this->m_has_metric_term) {
-            AMREX_LAUNCH_HOST_DEVICE_LAMBDA ( blo, tbox,
-            {
-                mlalap_flux_yface_m(tbox, fyarr, solarr, fac, blen, dx, probxlo, ncomp);
-            });
         } else {
+            flux[0]->setVal(RT(0.0));
+        }
+        if (this->hiddenDirection() != 1) {
+            RT fac = m_b_scalar * RT(dxinv[1]);
+            Box blo = amrex::bdryLo(box, 1);
+            int blen = box.length(1);
             AMREX_LAUNCH_HOST_DEVICE_LAMBDA ( blo, tbox,
             {
                 mlalap_flux_yface(tbox, fyarr, solarr, fac, blen, ncomp);
             });
+        } else {
+            flux[1]->setVal(RT(0.0));
         }
-    } else {
-        RT fac = m_b_scalar * RT(dxinv[0]);
-        Box bflux = amrex::surroundingNodes(box, 0);
-        if (this->m_has_metric_term) {
-            AMREX_LAUNCH_HOST_DEVICE_LAMBDA ( bflux, tbox,
+        if (this->hiddenDirection() != 2) {
+            RT fac = m_b_scalar * RT(dxinv[2]);
+            Box blo = amrex::bdryLo(box, 2);
+            int blen = box.length(2);
+            AMREX_LAUNCH_HOST_DEVICE_LAMBDA ( blo, tbox,
             {
-                mlalap_flux_x_m(tbox, fxarr, solarr, fac, dx, probxlo, ncomp);
+                mlalap_flux_zface(tbox, fzarr, solarr, fac, blen, ncomp);
             });
         } else {
+            flux[2]->setVal(RT(0.0));
+        }
+    } else {
+        if (this->hiddenDirection() != 0) {
+            RT fac = m_b_scalar * RT(dxinv[0]);
+            Box bflux = amrex::surroundingNodes(box, 0);
             AMREX_LAUNCH_HOST_DEVICE_LAMBDA ( bflux, tbox,
             {
                 mlalap_flux_x(tbox, fxarr, solarr, fac, ncomp);
             });
-        }
-        fac = m_b_scalar * RT(dxinv[1]);
-        bflux = amrex::surroundingNodes(box, 1);
-        if (this->m_has_metric_term) {
-            AMREX_LAUNCH_HOST_DEVICE_LAMBDA ( bflux, tbox,
-            {
-                mlalap_flux_y_m(tbox, fyarr, solarr, fac, dx, probxlo, ncomp);
-            });
         } else {
+            flux[0]->setVal(RT(0.0));
+        }
+        if (this->hiddenDirection() != 1) {
+            RT fac = m_b_scalar * RT(dxinv[1]);
+            Box bflux = amrex::surroundingNodes(box, 1);
             AMREX_LAUNCH_HOST_DEVICE_LAMBDA ( bflux, tbox,
             {
                 mlalap_flux_y(tbox, fyarr, solarr, fac, ncomp);
             });
+        } else {
+            flux[1]->setVal(RT(0.0));
+        }
+        if (this->hiddenDirection() != 2) {
+            RT fac = m_b_scalar * RT(dxinv[2]);
+            Box bflux = amrex::surroundingNodes(box, 2);
+            AMREX_LAUNCH_HOST_DEVICE_LAMBDA ( bflux, tbox,
+            {
+                mlalap_flux_z(tbox, fzarr, solarr, fac, ncomp);
+            });
+        } else {
+            flux[2]->setVal(RT(0.0));
+        }
+    }
+#elif (AMREX_SPACEDIM == 2)
+    if (face_only) {
+        if (this->hiddenDirection() != 0) {
+            RT fac = m_b_scalar * RT(dxinv[0]);
+            Box blo = amrex::bdryLo(box, 0);
+            int blen = box.length(0);
+            if (this->m_has_metric_term) {
+                AMREX_LAUNCH_HOST_DEVICE_LAMBDA ( blo, tbox,
+                {
+                    mlalap_flux_xface_m(tbox, fxarr, solarr, fac, blen, dx, probxlo, ncomp);
+                });
+            } else {
+                AMREX_LAUNCH_HOST_DEVICE_LAMBDA ( blo, tbox,
+                {
+                    mlalap_flux_xface(tbox, fxarr, solarr, fac, blen, ncomp);
+                });
+            }
+        } else {
+            flux[0]->setVal(RT(0.0));
+        }
+        if (this->hiddenDirection() != 1) {
+            RT fac = m_b_scalar * RT(dxinv[1]);
+            Box blo = amrex::bdryLo(box, 1);
+            int blen = box.length(1);
+            if (this->m_has_metric_term) {
+                AMREX_LAUNCH_HOST_DEVICE_LAMBDA ( blo, tbox,
+                {
+                    mlalap_flux_yface_m(tbox, fyarr, solarr, fac, blen, dx, probxlo, ncomp);
+                });
+            } else {
+                AMREX_LAUNCH_HOST_DEVICE_LAMBDA ( blo, tbox,
+                {
+                    mlalap_flux_yface(tbox, fyarr, solarr, fac, blen, ncomp);
+                });
+            }
+        } else {
+            flux[1]->setVal(RT(0.0));
+        }
+    } else {
+        if (this->hiddenDirection() != 0) {
+            RT fac = m_b_scalar * RT(dxinv[0]);
+            Box bflux = amrex::surroundingNodes(box, 0);
+            if (this->m_has_metric_term) {
+                AMREX_LAUNCH_HOST_DEVICE_LAMBDA ( bflux, tbox,
+                {
+                    mlalap_flux_x_m(tbox, fxarr, solarr, fac, dx, probxlo, ncomp);
+                });
+            } else {
+                AMREX_LAUNCH_HOST_DEVICE_LAMBDA ( bflux, tbox,
+                {
+                    mlalap_flux_x(tbox, fxarr, solarr, fac, ncomp);
+                });
+            }
+        } else {
+            flux[0]->setVal(RT(0.0));
+        }
+        if (this->hiddenDirection() != 1) {
+            RT fac = m_b_scalar * RT(dxinv[1]);
+            Box bflux = amrex::surroundingNodes(box, 1);
+            if (this->m_has_metric_term) {
+                AMREX_LAUNCH_HOST_DEVICE_LAMBDA ( bflux, tbox,
+                {
+                    mlalap_flux_y_m(tbox, fyarr, solarr, fac, dx, probxlo, ncomp);
+                });
+            } else {
+                AMREX_LAUNCH_HOST_DEVICE_LAMBDA ( bflux, tbox,
+                {
+                    mlalap_flux_y(tbox, fyarr, solarr, fac, ncomp);
+                });
+            }
+        } else {
+            flux[1]->setVal(RT(0.0));
         }
     }
 #else

--- a/Src/LinearSolvers/MLMG/AMReX_MLALaplacian.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLALaplacian.H
@@ -616,7 +616,7 @@ MLALaplacianT<MF>::FFlux (int amrlev, const MFIter& mfi,
                 mlalap_flux_xface(tbox, fxarr, solarr, fac, blen, ncomp);
             });
         } else {
-            flux[0]->template setVal(RT(0.0));
+            flux[0]->template setVal<RunOn::Device>(RT(0.0));
         }
         if (this->hiddenDirection() != 1) {
             RT fac = m_b_scalar * RT(dxinv[1]);
@@ -627,7 +627,7 @@ MLALaplacianT<MF>::FFlux (int amrlev, const MFIter& mfi,
                 mlalap_flux_yface(tbox, fyarr, solarr, fac, blen, ncomp);
             });
         } else {
-            flux[1]->template setVal(RT(0.0));
+            flux[1]->template setVal<RunOn::Device>(RT(0.0));
         }
         if (this->hiddenDirection() != 2) {
             RT fac = m_b_scalar * RT(dxinv[2]);
@@ -638,7 +638,7 @@ MLALaplacianT<MF>::FFlux (int amrlev, const MFIter& mfi,
                 mlalap_flux_zface(tbox, fzarr, solarr, fac, blen, ncomp);
             });
         } else {
-            flux[2]->template setVal(RT(0.0));
+            flux[2]->template setVal<RunOn::Device>(RT(0.0));
         }
     } else {
         if (this->hiddenDirection() != 0) {
@@ -649,7 +649,7 @@ MLALaplacianT<MF>::FFlux (int amrlev, const MFIter& mfi,
                 mlalap_flux_x(tbox, fxarr, solarr, fac, ncomp);
             });
         } else {
-            flux[0]->template setVal(RT(0.0));
+            flux[0]->template setVal<RunOn::Device>(RT(0.0));
         }
         if (this->hiddenDirection() != 1) {
             RT fac = m_b_scalar * RT(dxinv[1]);
@@ -659,7 +659,7 @@ MLALaplacianT<MF>::FFlux (int amrlev, const MFIter& mfi,
                 mlalap_flux_y(tbox, fyarr, solarr, fac, ncomp);
             });
         } else {
-            flux[1]->template setVal(RT(0.0));
+            flux[1]->template setVal<RunOn::Device>(RT(0.0));
         }
         if (this->hiddenDirection() != 2) {
             RT fac = m_b_scalar * RT(dxinv[2]);
@@ -669,7 +669,7 @@ MLALaplacianT<MF>::FFlux (int amrlev, const MFIter& mfi,
                 mlalap_flux_z(tbox, fzarr, solarr, fac, ncomp);
             });
         } else {
-            flux[2]->template setVal(RT(0.0));
+            flux[2]->template setVal<RunOn::Device>(RT(0.0));
         }
     }
 #elif (AMREX_SPACEDIM == 2)
@@ -690,7 +690,7 @@ MLALaplacianT<MF>::FFlux (int amrlev, const MFIter& mfi,
                 });
             }
         } else {
-            flux[0]->template setVal(RT(0.0));
+            flux[0]->template setVal<RunOn::Device>(RT(0.0));
         }
         if (this->hiddenDirection() != 1) {
             RT fac = m_b_scalar * RT(dxinv[1]);
@@ -708,7 +708,7 @@ MLALaplacianT<MF>::FFlux (int amrlev, const MFIter& mfi,
                 });
             }
         } else {
-            flux[1]->template setVal(RT(0.0));
+            flux[1]->template setVal<RunOn::Device>(RT(0.0));
         }
     } else {
         if (this->hiddenDirection() != 0) {
@@ -726,7 +726,7 @@ MLALaplacianT<MF>::FFlux (int amrlev, const MFIter& mfi,
                 });
             }
         } else {
-            flux[0]->template setVal(RT(0.0));
+            flux[0]->template setVal<RunOn::Device>(RT(0.0));
         }
         if (this->hiddenDirection() != 1) {
             RT fac = m_b_scalar * RT(dxinv[1]);
@@ -743,7 +743,7 @@ MLALaplacianT<MF>::FFlux (int amrlev, const MFIter& mfi,
                 });
             }
         } else {
-            flux[1]->template setVal(RT(0.0));
+            flux[1]->template setVal<RunOn::Device>(RT(0.0));
         }
     }
 #else

--- a/Src/LinearSolvers/MLMG/AMReX_MLALaplacian.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLALaplacian.H
@@ -616,7 +616,7 @@ MLALaplacianT<MF>::FFlux (int amrlev, const MFIter& mfi,
                 mlalap_flux_xface(tbox, fxarr, solarr, fac, blen, ncomp);
             });
         } else {
-            flux[0]->setVal(RT(0.0));
+            flux[0]->template setVal(RT(0.0));
         }
         if (this->hiddenDirection() != 1) {
             RT fac = m_b_scalar * RT(dxinv[1]);
@@ -627,7 +627,7 @@ MLALaplacianT<MF>::FFlux (int amrlev, const MFIter& mfi,
                 mlalap_flux_yface(tbox, fyarr, solarr, fac, blen, ncomp);
             });
         } else {
-            flux[1]->setVal(RT(0.0));
+            flux[1]->template setVal(RT(0.0));
         }
         if (this->hiddenDirection() != 2) {
             RT fac = m_b_scalar * RT(dxinv[2]);
@@ -638,7 +638,7 @@ MLALaplacianT<MF>::FFlux (int amrlev, const MFIter& mfi,
                 mlalap_flux_zface(tbox, fzarr, solarr, fac, blen, ncomp);
             });
         } else {
-            flux[2]->setVal(RT(0.0));
+            flux[2]->template setVal(RT(0.0));
         }
     } else {
         if (this->hiddenDirection() != 0) {
@@ -649,7 +649,7 @@ MLALaplacianT<MF>::FFlux (int amrlev, const MFIter& mfi,
                 mlalap_flux_x(tbox, fxarr, solarr, fac, ncomp);
             });
         } else {
-            flux[0]->setVal(RT(0.0));
+            flux[0]->template setVal(RT(0.0));
         }
         if (this->hiddenDirection() != 1) {
             RT fac = m_b_scalar * RT(dxinv[1]);
@@ -659,7 +659,7 @@ MLALaplacianT<MF>::FFlux (int amrlev, const MFIter& mfi,
                 mlalap_flux_y(tbox, fyarr, solarr, fac, ncomp);
             });
         } else {
-            flux[1]->setVal(RT(0.0));
+            flux[1]->template setVal(RT(0.0));
         }
         if (this->hiddenDirection() != 2) {
             RT fac = m_b_scalar * RT(dxinv[2]);
@@ -669,7 +669,7 @@ MLALaplacianT<MF>::FFlux (int amrlev, const MFIter& mfi,
                 mlalap_flux_z(tbox, fzarr, solarr, fac, ncomp);
             });
         } else {
-            flux[2]->setVal(RT(0.0));
+            flux[2]->template setVal(RT(0.0));
         }
     }
 #elif (AMREX_SPACEDIM == 2)
@@ -690,7 +690,7 @@ MLALaplacianT<MF>::FFlux (int amrlev, const MFIter& mfi,
                 });
             }
         } else {
-            flux[0]->setVal(RT(0.0));
+            flux[0]->template setVal(RT(0.0));
         }
         if (this->hiddenDirection() != 1) {
             RT fac = m_b_scalar * RT(dxinv[1]);
@@ -708,7 +708,7 @@ MLALaplacianT<MF>::FFlux (int amrlev, const MFIter& mfi,
                 });
             }
         } else {
-            flux[1]->setVal(RT(0.0));
+            flux[1]->template setVal(RT(0.0));
         }
     } else {
         if (this->hiddenDirection() != 0) {
@@ -726,7 +726,7 @@ MLALaplacianT<MF>::FFlux (int amrlev, const MFIter& mfi,
                 });
             }
         } else {
-            flux[0]->setVal(RT(0.0));
+            flux[0]->template setVal(RT(0.0));
         }
         if (this->hiddenDirection() != 1) {
             RT fac = m_b_scalar * RT(dxinv[1]);
@@ -743,7 +743,7 @@ MLALaplacianT<MF>::FFlux (int amrlev, const MFIter& mfi,
                 });
             }
         } else {
-            flux[1]->setVal(RT(0.0));
+            flux[1]->template setVal(RT(0.0));
         }
     }
 #else

--- a/Src/LinearSolvers/MLMG/AMReX_MLPoisson.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLPoisson.H
@@ -858,8 +858,6 @@ MLPoissonT<MF>::FFlux (int amrlev, const MFIter& mfi,
                        const Array<FAB*,AMREX_SPACEDIM>& flux,
                        const FAB& sol, Location, const int face_only) const
 {
-    AMREX_ASSERT(!this->hasHiddenDimension());
-
     BL_PROFILE("MLPoisson::FFlux()");
 
     const int mglev = 0;
@@ -878,103 +876,143 @@ MLPoissonT<MF>::FFlux (int amrlev, const MFIter& mfi,
 
 #if (AMREX_SPACEDIM == 3)
     if (face_only) {
-        RT fac = RT(dxinv[0]);
-        Box blo = amrex::bdryLo(box, 0);
-        int blen = box.length(0);
-        AMREX_LAUNCH_HOST_DEVICE_LAMBDA ( blo, tbox,
-        {
-            mlpoisson_flux_xface(tbox, fxarr, solarr, fac, blen);
-        });
-        fac = RT(dxinv[1]);
-        blo = amrex::bdryLo(box, 1);
-        blen = box.length(1);
-        AMREX_LAUNCH_HOST_DEVICE_LAMBDA ( blo, tbox,
-        {
-            mlpoisson_flux_yface(tbox, fyarr, solarr, fac, blen);
-        });
-        fac = RT(dxinv[2]);
-        blo = amrex::bdryLo(box, 2);
-        blen = box.length(2);
-        AMREX_LAUNCH_HOST_DEVICE_LAMBDA ( blo, tbox,
-        {
-            mlpoisson_flux_zface(tbox, fzarr, solarr, fac, blen);
-        });
-    } else {
-        RT fac = RT(dxinv[0]);
-        Box bflux = amrex::surroundingNodes(box, 0);
-        AMREX_LAUNCH_HOST_DEVICE_LAMBDA ( bflux, tbox,
-        {
-            mlpoisson_flux_x(tbox, fxarr, solarr, fac);
-        });
-        fac = RT(dxinv[1]);
-        bflux = amrex::surroundingNodes(box, 1);
-        AMREX_LAUNCH_HOST_DEVICE_LAMBDA ( bflux, tbox,
-        {
-            mlpoisson_flux_y(tbox, fyarr, solarr, fac);
-        });
-        fac = RT(dxinv[2]);
-        bflux = amrex::surroundingNodes(box, 2);
-        AMREX_LAUNCH_HOST_DEVICE_LAMBDA ( bflux, tbox,
-        {
-            mlpoisson_flux_z(tbox, fzarr, solarr, fac);
-        });
-    }
-#elif (AMREX_SPACEDIM == 2)
-    if (face_only) {
-        RT fac = RT(dxinv[0]);
-        Box blo = amrex::bdryLo(box, 0);
-        int blen = box.length(0);
-        if (this->m_has_metric_term) {
-            AMREX_LAUNCH_HOST_DEVICE_LAMBDA ( blo, tbox,
-            {
-                mlpoisson_flux_xface_m(tbox, fxarr, solarr, fac, blen, dx, probxlo);
-            });
-        } else {
+        if (this->hiddenDirection() != 0) {
+            RT fac = RT(dxinv[0]);
+            Box blo = amrex::bdryLo(box, 0);
+            int blen = box.length(0);
             AMREX_LAUNCH_HOST_DEVICE_LAMBDA ( blo, tbox,
             {
                 mlpoisson_flux_xface(tbox, fxarr, solarr, fac, blen);
             });
-        }
-        fac = RT(dxinv[1]);
-        blo = amrex::bdryLo(box, 1);
-        blen = box.length(1);
-        if (this->m_has_metric_term) {
-            AMREX_LAUNCH_HOST_DEVICE_LAMBDA ( blo, tbox,
-            {
-                mlpoisson_flux_yface_m(tbox, fyarr, solarr, fac, blen, dx, probxlo);
-            });
         } else {
+            flux[0]->setVal(RT(0.0));
+        }
+        if (this->hiddenDirection() != 1) {
+            RT fac = RT(dxinv[1]);
+            Box blo = amrex::bdryLo(box, 1);
+            int blen = box.length(1);
             AMREX_LAUNCH_HOST_DEVICE_LAMBDA ( blo, tbox,
             {
                 mlpoisson_flux_yface(tbox, fyarr, solarr, fac, blen);
             });
+        } else {
+            flux[1]->setVal(RT(0.0));
         }
-    } else {
-        RT fac = RT(dxinv[0]);
-        Box bflux = amrex::surroundingNodes(box, 0);
-        if (this->m_has_metric_term) {
-            AMREX_LAUNCH_HOST_DEVICE_LAMBDA ( bflux, tbox,
+        if (this->hiddenDirection() != 2) {
+            RT fac = RT(dxinv[2]);
+            Box blo = amrex::bdryLo(box, 2);
+            int blen = box.length(2);
+            AMREX_LAUNCH_HOST_DEVICE_LAMBDA ( blo, tbox,
             {
-                mlpoisson_flux_x_m(tbox, fxarr, solarr, fac, dx, probxlo);
+                mlpoisson_flux_zface(tbox, fzarr, solarr, fac, blen);
             });
         } else {
+            flux[2]->setVal(RT(0.0));
+        }
+    } else {
+        if (this->hiddenDirection() != 0) {
+            RT fac = RT(dxinv[0]);
+            Box bflux = amrex::surroundingNodes(box, 0);
             AMREX_LAUNCH_HOST_DEVICE_LAMBDA ( bflux, tbox,
             {
                 mlpoisson_flux_x(tbox, fxarr, solarr, fac);
             });
-        }
-        fac = RT(dxinv[1]);
-        bflux = amrex::surroundingNodes(box, 1);
-        if (this->m_has_metric_term) {
-            AMREX_LAUNCH_HOST_DEVICE_LAMBDA ( bflux, tbox,
-            {
-                mlpoisson_flux_y_m(tbox, fyarr, solarr, fac, dx, probxlo);
-            });
         } else {
+            flux[0]->setVal(RT(0.0));
+        }
+        if (this->hiddenDirection() != 1) {
+            RT fac = RT(dxinv[1]);
+            Box bflux = amrex::surroundingNodes(box, 1);
             AMREX_LAUNCH_HOST_DEVICE_LAMBDA ( bflux, tbox,
             {
                 mlpoisson_flux_y(tbox, fyarr, solarr, fac);
             });
+        } else {
+            flux[1]->setVal(RT(0.0));
+        }
+        if (this->hiddenDirection() != 2) {
+            RT fac = RT(dxinv[2]);
+            Box bflux = amrex::surroundingNodes(box, 2);
+            AMREX_LAUNCH_HOST_DEVICE_LAMBDA ( bflux, tbox,
+            {
+                mlpoisson_flux_z(tbox, fzarr, solarr, fac);
+            });
+        } else {
+            flux[2]->setVal(RT(0.0));
+        }
+    }
+#elif (AMREX_SPACEDIM == 2)
+    if (face_only) {
+        if (this->hiddenDirection() != 0) {
+            RT fac = RT(dxinv[0]);
+            Box blo = amrex::bdryLo(box, 0);
+            int blen = box.length(0);
+            if (this->m_has_metric_term) {
+                AMREX_LAUNCH_HOST_DEVICE_LAMBDA ( blo, tbox,
+                {
+                    mlpoisson_flux_xface_m(tbox, fxarr, solarr, fac, blen, dx, probxlo);
+                });
+            } else {
+                AMREX_LAUNCH_HOST_DEVICE_LAMBDA ( blo, tbox,
+                {
+                    mlpoisson_flux_xface(tbox, fxarr, solarr, fac, blen);
+                });
+            }
+        } else {
+            flux[0]->setVal(RT(0.0));
+        }
+        if (this->hiddenDirection() != 1) {
+            RT fac = RT(dxinv[1]);
+            Box blo = amrex::bdryLo(box, 1);
+            int blen = box.length(1);
+            if (this->m_has_metric_term) {
+                AMREX_LAUNCH_HOST_DEVICE_LAMBDA ( blo, tbox,
+                {
+                    mlpoisson_flux_yface_m(tbox, fyarr, solarr, fac, blen, dx, probxlo);
+                });
+            } else {
+                AMREX_LAUNCH_HOST_DEVICE_LAMBDA ( blo, tbox,
+                {
+                    mlpoisson_flux_yface(tbox, fyarr, solarr, fac, blen);
+                });
+            }
+        } else {
+            flux[1]->setVal(RT(0.0));
+        }
+    } else {
+        if (this->hiddenDirection() != 0) {
+            RT fac = RT(dxinv[0]);
+            Box bflux = amrex::surroundingNodes(box, 0);
+            if (this->m_has_metric_term) {
+                AMREX_LAUNCH_HOST_DEVICE_LAMBDA ( bflux, tbox,
+                {
+                    mlpoisson_flux_x_m(tbox, fxarr, solarr, fac, dx, probxlo);
+                });
+            } else {
+                AMREX_LAUNCH_HOST_DEVICE_LAMBDA ( bflux, tbox,
+                {
+                    mlpoisson_flux_x(tbox, fxarr, solarr, fac);
+                });
+            }
+        } else {
+            flux[0]->setVal(RT(0.0));
+        }
+        if (this->hiddenDirection() != 1) {
+            RT fac = RT(dxinv[1]);
+            Box bflux = amrex::surroundingNodes(box, 1);
+            if (this->m_has_metric_term) {
+                AMREX_LAUNCH_HOST_DEVICE_LAMBDA ( bflux, tbox,
+                {
+                    mlpoisson_flux_y_m(tbox, fyarr, solarr, fac, dx, probxlo);
+                });
+            } else {
+                AMREX_LAUNCH_HOST_DEVICE_LAMBDA ( bflux, tbox,
+                {
+                    mlpoisson_flux_y(tbox, fyarr, solarr, fac);
+                });
+            }
+        } else {
+            flux[1]->setVal(RT(0.0));
         }
     }
 #else

--- a/Src/LinearSolvers/MLMG/AMReX_MLPoisson.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLPoisson.H
@@ -885,7 +885,7 @@ MLPoissonT<MF>::FFlux (int amrlev, const MFIter& mfi,
                 mlpoisson_flux_xface(tbox, fxarr, solarr, fac, blen);
             });
         } else {
-            flux[0]->setVal(RT(0.0));
+            flux[0]->template setVal<RunOn::Device>(RT(0.0));
         }
         if (this->hiddenDirection() != 1) {
             RT fac = RT(dxinv[1]);
@@ -896,7 +896,7 @@ MLPoissonT<MF>::FFlux (int amrlev, const MFIter& mfi,
                 mlpoisson_flux_yface(tbox, fyarr, solarr, fac, blen);
             });
         } else {
-            flux[1]->setVal(RT(0.0));
+            flux[1]->template setVal<RunOn::Device>(RT(0.0));
         }
         if (this->hiddenDirection() != 2) {
             RT fac = RT(dxinv[2]);
@@ -907,7 +907,7 @@ MLPoissonT<MF>::FFlux (int amrlev, const MFIter& mfi,
                 mlpoisson_flux_zface(tbox, fzarr, solarr, fac, blen);
             });
         } else {
-            flux[2]->setVal(RT(0.0));
+            flux[2]->template setVal<RunOn::Device>(RT(0.0));
         }
     } else {
         if (this->hiddenDirection() != 0) {
@@ -918,7 +918,7 @@ MLPoissonT<MF>::FFlux (int amrlev, const MFIter& mfi,
                 mlpoisson_flux_x(tbox, fxarr, solarr, fac);
             });
         } else {
-            flux[0]->setVal(RT(0.0));
+            flux[0]->template setVal<RunOn::Device>(RT(0.0));
         }
         if (this->hiddenDirection() != 1) {
             RT fac = RT(dxinv[1]);
@@ -928,7 +928,7 @@ MLPoissonT<MF>::FFlux (int amrlev, const MFIter& mfi,
                 mlpoisson_flux_y(tbox, fyarr, solarr, fac);
             });
         } else {
-            flux[1]->setVal(RT(0.0));
+            flux[1]->template setVal<RunOn::Device>(RT(0.0));
         }
         if (this->hiddenDirection() != 2) {
             RT fac = RT(dxinv[2]);
@@ -938,7 +938,7 @@ MLPoissonT<MF>::FFlux (int amrlev, const MFIter& mfi,
                 mlpoisson_flux_z(tbox, fzarr, solarr, fac);
             });
         } else {
-            flux[2]->setVal(RT(0.0));
+            flux[2]->template setVal<RunOn::Device>(RT(0.0));
         }
     }
 #elif (AMREX_SPACEDIM == 2)
@@ -959,7 +959,7 @@ MLPoissonT<MF>::FFlux (int amrlev, const MFIter& mfi,
                 });
             }
         } else {
-            flux[0]->setVal(RT(0.0));
+            flux[0]->template setVal<RunOn::Device>(RT(0.0));
         }
         if (this->hiddenDirection() != 1) {
             RT fac = RT(dxinv[1]);
@@ -977,7 +977,7 @@ MLPoissonT<MF>::FFlux (int amrlev, const MFIter& mfi,
                 });
             }
         } else {
-            flux[1]->setVal(RT(0.0));
+            flux[1]->template setVal<RunOn::Device>(RT(0.0));
         }
     } else {
         if (this->hiddenDirection() != 0) {
@@ -995,7 +995,7 @@ MLPoissonT<MF>::FFlux (int amrlev, const MFIter& mfi,
                 });
             }
         } else {
-            flux[0]->setVal(RT(0.0));
+            flux[0]->template setVal<RunOn::Device>(RT(0.0));
         }
         if (this->hiddenDirection() != 1) {
             RT fac = RT(dxinv[1]);
@@ -1012,7 +1012,7 @@ MLPoissonT<MF>::FFlux (int amrlev, const MFIter& mfi,
                 });
             }
         } else {
-            flux[1]->setVal(RT(0.0));
+            flux[1]->template setVal<RunOn::Device>(RT(0.0));
         }
     }
 #else


### PR DESCRIPTION
## Summary
The FFlux routines in AMReX_MLPoisson.H and AMReX_MLALaplacian.H previously had assertions that there were no hidden directions.  We have replaced that by if tests that only compute the fluxes if the direction is not hidden and otherwise fill the flux array with 0.

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [X] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
