### PR TITLE
Named SoA Support

### DIFF
--- a/Src/Particle/AMReX_ParticleContainer.H
+++ b/Src/Particle/AMReX_ParticleContainer.H
@@ -1274,8 +1274,7 @@ public:
 
     void AddRealComp (int communicate=1)
     {
-        std::string default_name = "runtime_real" + std::to_string(m_num_runtime_real);
-        AddRealComp(default_name, communicate);
+        AddRealComp(getDefaultCompNameReal<ParticleType>(NArrayReal+m_num_runtime_real), communicate);
     }
 
     void AddIntComp (std::string const & name, int communicate=1)
@@ -1303,8 +1302,7 @@ public:
 
     void AddIntComp (int communicate=1)
     {
-        std::string default_name = "runtime_int" + std::to_string(m_num_runtime_int);
-        AddIntComp(default_name, communicate);
+        AddIntComp(getDefaultCompNameInt<ParticleType>(NArrayInt+m_num_runtime_int), communicate);
     }
 
     int NumRuntimeRealComps () const { return m_num_runtime_real; }

--- a/Src/Particle/AMReX_ParticleContainer.H
+++ b/Src/Particle/AMReX_ParticleContainer.H
@@ -1249,9 +1249,7 @@ public:
 
     Long superParticleSize() const { return superparticle_size; }
 
-    template <typename T,
-              std::enable_if_t<std::is_same_v<T,bool>,int> = 0>
-    void AddRealComp (std::string const & name, T communicate=true)
+    void AddRealComp (std::string const & name, bool communicate=true)
     {
         m_soa_rdata_names.push_back(name);
 
@@ -1274,17 +1272,13 @@ public:
         }
     }
 
-    template <typename T,
-              std::enable_if_t<std::is_same_v<T,bool>,int> = 0>
-    void AddRealComp (T communicate=true)
+    void AddRealComp (bool communicate=true)
     {
-        std::string default_name = "make-up-name"; //! @FIXME add naming scheme
+        std::string default_name = "runtime_real" + std::to_string(m_num_runtime_real);
         AddRealComp(default_name, communicate);
     }
 
-    template <typename T,
-              std::enable_if_t<std::is_same_v<T,bool>,int> = 0>
-    void AddIntComp (std::string const & name, T communicate=true)
+    void AddIntComp (std::string const & name, bool communicate=true)
     {
         m_soa_idata_names.push_back(name);
 
@@ -1307,11 +1301,9 @@ public:
         }
     }
 
-    template <typename T,
-              std::enable_if_t<std::is_same_v<T,bool>,int> = 0>
-    void AddIntComp (T communicate=true)
+    void AddIntComp (bool communicate=true)
     {
-        std::string default_name = "make-up-name"; //! @FIXME add naming scheme
+        std::string default_name = "runtime_int" + std::to_string(m_num_runtime_int);
         AddIntComp(default_name, communicate);
     }
 
@@ -1425,6 +1417,15 @@ public:
 #include "AMReX_ParticlesHDF5.H"
 #endif
 
+    /** Overwrite the default names for the compile-time SoA components */
+    void SetSoACompileTimeNames (std::vector<std::string> const & rdata_name, std::vector<std::string> const & idata_name);
+
+    /** Get the names for the real SoA components **/
+    std::vector<std::string> GetRealSoANames () const {return m_soa_rdata_names;}
+
+    /** Get the names for the int SoA components **/
+    std::vector<std::string> GetIntSoANames () const {return m_soa_idata_names;}
+
 protected:
 
     template <class RTYPE>
@@ -1449,9 +1450,6 @@ private:
                          int lev_min, int lev_max, int nGrow, int local_grid=-1) const;
 
     void Initialize ();
-
-    /** Overwrite the default names for the compile-time SoA components */
-    void SetSoACompileTimeNames (std::vector<std::string> const & rdata_name, std::vector<std::string> const & idata_name);
 
     bool m_runtime_comps_defined{false};
     int m_num_runtime_real{0};

--- a/Src/Particle/AMReX_ParticleContainer.H
+++ b/Src/Particle/AMReX_ParticleContainer.H
@@ -1249,7 +1249,7 @@ public:
 
     Long superParticleSize() const { return superparticle_size; }
 
-    void AddRealComp (std::string const & name, bool communicate=true)
+    void AddRealComp (std::string const & name, int communicate=1)
     {
         m_soa_rdata_names.push_back(name);
 
@@ -1272,13 +1272,13 @@ public:
         }
     }
 
-    void AddRealComp (bool communicate=true)
+    void AddRealComp (int communicate=1)
     {
         std::string default_name = "runtime_real" + std::to_string(m_num_runtime_real);
         AddRealComp(default_name, communicate);
     }
 
-    void AddIntComp (std::string const & name, bool communicate=true)
+    void AddIntComp (std::string const & name, int communicate=1)
     {
         m_soa_idata_names.push_back(name);
 
@@ -1301,7 +1301,7 @@ public:
         }
     }
 
-    void AddIntComp (bool communicate=true)
+    void AddIntComp (int communicate=1)
     {
         std::string default_name = "runtime_int" + std::to_string(m_num_runtime_int);
         AddIntComp(default_name, communicate);

--- a/Src/Particle/AMReX_ParticleContainer.H
+++ b/Src/Particle/AMReX_ParticleContainer.H
@@ -60,6 +60,7 @@
 #include <memory>
 #include <numeric>
 #include <random>
+#include <string>
 #include <tuple>
 #include <type_traits>
 #include <utility>
@@ -1144,7 +1145,8 @@ public:
      */
     ParticleTileType& DefineAndReturnParticleTile (int lev, int grid, int tile)
     {
-        m_particles[lev][std::make_pair(grid, tile)].define(NumRuntimeRealComps(), NumRuntimeIntComps());
+        m_particles[lev][std::make_pair(grid, tile)].define(NumRuntimeRealComps(), NumRuntimeIntComps(), &m_soa_rdata_names, &m_soa_idata_names);
+
         return ParticlesAt(lev, grid, tile);
     }
 
@@ -1249,8 +1251,10 @@ public:
 
     template <typename T,
               std::enable_if_t<std::is_same_v<T,bool>,int> = 0>
-    void AddRealComp (T communicate=true)
+    void AddRealComp (std::string const & name, T communicate=true)
     {
+        m_soa_rdata_names.push_back(name);
+
         m_runtime_comps_defined = true;
         m_num_runtime_real++;
         h_redistribute_real_comp.push_back(communicate);
@@ -1272,8 +1276,18 @@ public:
 
     template <typename T,
               std::enable_if_t<std::is_same_v<T,bool>,int> = 0>
-    void AddIntComp (T communicate=true)
+    void AddRealComp (T communicate=true)
     {
+        std::string default_name = "make-up-name"; //! @FIXME add naming scheme
+        AddRealComp(default_name, communicate);
+    }
+
+    template <typename T,
+              std::enable_if_t<std::is_same_v<T,bool>,int> = 0>
+    void AddIntComp (std::string const & name, T communicate=true)
+    {
+        m_soa_idata_names.push_back(name);
+
         m_runtime_comps_defined = true;
         m_num_runtime_int++;
         h_redistribute_int_comp.push_back(communicate);
@@ -1291,6 +1305,14 @@ public:
                 }
             }
         }
+    }
+
+    template <typename T,
+              std::enable_if_t<std::is_same_v<T,bool>,int> = 0>
+    void AddIntComp (T communicate=true)
+    {
+        std::string default_name = "make-up-name"; //! @FIXME add naming scheme
+        AddIntComp(default_name, communicate);
     }
 
     int NumRuntimeRealComps () const { return m_num_runtime_real; }
@@ -1428,6 +1450,9 @@ private:
 
     void Initialize ();
 
+    /** Overwrite the default names for the compile-time SoA components */
+    void SetSoACompileTimeNames (std::vector<std::string> const & rdata_name, std::vector<std::string> const & idata_name);
+
     bool m_runtime_comps_defined{false};
     int m_num_runtime_real{0};
     int m_num_runtime_int{0};
@@ -1435,6 +1460,10 @@ private:
     size_t particle_size, superparticle_size;
     int num_real_comm_comps, num_int_comm_comps;
     Vector<ParticleLevel> m_particles;
+
+    // names of both compile-time and runtime Real and Int SoA data
+    std::vector<std::string> m_soa_rdata_names;
+    std::vector<std::string> m_soa_idata_names;
 };
 
 template <int T_NStructReal, int T_NStructInt, int T_NArrayReal, int T_NArrayInt, template<class> class Allocator, class CellAssignor>

--- a/Src/Particle/AMReX_ParticleContainerI.H
+++ b/Src/Particle/AMReX_ParticleContainerI.H
@@ -1,5 +1,9 @@
-#include <type_traits>
 #include <AMReX_MakeParticle.H>
+
+#include <string>
+#include <type_traits>
+#include <vector>
+
 
 template <typename ParticleType, int NArrayReal, int NArrayInt,
           template<class> class Allocator, class CellAssignor>
@@ -60,7 +64,48 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
         pp.query("do_unlink", doUnlink);
         pp.queryAdd("do_mem_efficient_sort", memEfficientSort);
 
+        // add default names for SoA Real and Int compile-time arguments
+        int first_r_name = 0;
+        // push back x,y,z
+        if constexpr (ParticleType::is_soa_particle) {
+            constexpr int x_in_ascii = 120;
+            for (int i=0; i<AMREX_SPACEDIM; ++i)
+            {
+                std::string const name{char(x_in_ascii+i)};
+                m_soa_rdata_names.push_back(name);
+            }
+            first_r_name = AMREX_SPACEDIM;
+        }
+        for (int i=first_r_name; i<NArrayReal; ++i)
+        {
+            m_soa_rdata_names.push_back("real_comp" + std::to_string(i-first_r_name));
+        }
+        for (int i=0; i<NArrayInt; ++i)
+        {
+            m_soa_idata_names.push_back("int_comp" + std::to_string(i));
+        }
+
         initialized = true;
+    }
+}
+
+template <typename ParticleType, int NArrayReal, int NArrayInt,
+        template<class> class Allocator, class CellAssignor>
+void
+ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssignor> :: SetSoACompileTimeNames (
+    std::vector<std::string> const & rdata_name, std::vector<std::string> const & idata_name
+)
+{
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(rdata_name.size() == NArrayReal, "rdata_name must be equal to NArrayReal");
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(idata_name.size() == NArrayInt, "idata_name must be equal to NArrayInt");
+
+    for (int i=0; i<NArrayReal; ++i)
+    {
+        m_soa_rdata_names.at(i) = rdata_name.at(i);
+    }
+    for (int i=0; i<NArrayInt; ++i)
+    {
+        m_soa_idata_names.at(i) = idata_name.at(i);
     }
 }
 
@@ -1161,7 +1206,7 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
         }
     } else {
         ParticleTileType ptile_tmp;
-        ptile_tmp.define(m_num_runtime_real, m_num_runtime_int);
+        ptile_tmp.define(m_num_runtime_real, m_num_runtime_int, &m_soa_rdata_names, &m_soa_idata_names);
         ptile_tmp.resize(np_total);
         // copy re-ordered particles
         gatherParticles(ptile_tmp, ptile, np, permutations);
@@ -1498,7 +1543,7 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
             tmp_local[lev][index].resize(num_threads);
             soa_local[lev][index].resize(num_threads);
             for (int t = 0; t < num_threads; ++t) {
-                soa_local[lev][index][t].define(m_num_runtime_real, m_num_runtime_int);
+                soa_local[lev][index][t].define(m_num_runtime_real, m_num_runtime_int, &m_soa_rdata_names, &m_soa_idata_names);
             }
         }
     }

--- a/Src/Particle/AMReX_ParticleContainerI.H
+++ b/Src/Particle/AMReX_ParticleContainerI.H
@@ -65,24 +65,13 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
         pp.queryAdd("do_mem_efficient_sort", memEfficientSort);
 
         // add default names for SoA Real and Int compile-time arguments
-        int first_r_name = 0;
-        // push back x,y,z
-        if constexpr (ParticleType::is_soa_particle) {
-            constexpr int x_in_ascii = 120;
-            for (int i=0; i<AMREX_SPACEDIM; ++i)
-            {
-                std::string const name{char(x_in_ascii+i)};
-                m_soa_rdata_names.push_back(name);
-            }
-            first_r_name = AMREX_SPACEDIM;
-        }
-        for (int i=first_r_name; i<NArrayReal; ++i)
+        for (int i=0; i<NArrayReal; ++i)
         {
-            m_soa_rdata_names.push_back("real_comp" + std::to_string(i-first_r_name));
+            m_soa_rdata_names.push_back(getDefaultCompNameReal<ParticleType>(i));
         }
         for (int i=0; i<NArrayInt; ++i)
         {
-            m_soa_idata_names.push_back("int_comp" + std::to_string(i));
+            m_soa_idata_names.push_back(getDefaultCompNameInt<ParticleType>(i));
         }
 
         initialized = true;

--- a/Src/Particle/AMReX_ParticleIO.H
+++ b/Src/Particle/AMReX_ParticleIO.H
@@ -62,7 +62,7 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
         }
         else
         {
-            tmp_real_comp_names.push_back(real_comp_names[i]);
+            tmp_real_comp_names.push_back(real_comp_names[i-first_rcomp]);
         }
     }
 

--- a/Src/Particle/AMReX_ParticleIO.H
+++ b/Src/Particle/AMReX_ParticleIO.H
@@ -51,16 +51,14 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
 {
     Vector<int> write_real_comp;
     Vector<std::string> tmp_real_comp_names;
-    int nrc = ParticleType::is_soa_particle ? NStructReal + NumRealComps() - AMREX_SPACEDIM : NStructReal + NumRealComps();
 
-    for (int i = 0; i < nrc; ++i )
+    int first_rcomp = ParticleType::is_soa_particle ? AMREX_SPACEDIM : 0;
+    for (int i = first_rcomp; i < NStructReal + NumRealComps(); ++i )
     {
         write_real_comp.push_back(1);
         if (real_comp_names.empty())
         {
-            std::stringstream ss;
-            ss << "real_comp" << i;
-            tmp_real_comp_names.push_back(ss.str());
+            tmp_real_comp_names.push_back(getDefaultCompNameReal<ParticleType>(i));
         }
         else
         {
@@ -75,9 +73,7 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
         write_int_comp.push_back(1);
         if (int_comp_names.empty())
         {
-            std::stringstream ss;
-            ss << "int_comp" << i;
-            tmp_int_comp_names.push_back(ss.str());
+            tmp_int_comp_names.push_back(getDefaultCompNameInt<ParticleType>(i));
         }
         else
         {
@@ -98,14 +94,12 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
 {
     Vector<int> write_real_comp;
     Vector<std::string> real_comp_names;
-    int nrc = ParticleType::is_soa_particle ? NStructReal + NumRealComps() - AMREX_SPACEDIM : NStructReal + NumRealComps();
 
-    for (int i = 0; i < nrc; ++i )
+    int first_rcomp = ParticleType::is_soa_particle ? AMREX_SPACEDIM : 0;
+    for (int i = first_rcomp; i < NStructReal + NumRealComps(); ++i )
     {
         write_real_comp.push_back(1);
-        std::stringstream ss;
-        ss << "real_comp" << i;
-        real_comp_names.push_back(ss.str());
+        real_comp_names.push_back(getDefaultCompNameReal<ParticleType>(i));
     }
 
     Vector<int> write_int_comp;
@@ -113,9 +107,7 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
     for (int i = 0; i < NStructInt + NumIntComps(); ++i )
     {
         write_int_comp.push_back(1);
-        std::stringstream ss;
-        ss << "int_comp" << i;
-        int_comp_names.push_back(ss.str());
+        int_comp_names.push_back(getDefaultCompNameInt<ParticleType>(i));
     }
 
     WriteBinaryParticleData(dir, name, write_real_comp, write_int_comp,
@@ -182,9 +174,7 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
     Vector<std::string> int_comp_names;
     for (int i = 0; i < NStructInt + NumIntComps(); ++i )
     {
-        std::stringstream ss;
-        ss << "int_comp" << i;
-        int_comp_names.push_back(ss.str());
+        int_comp_names.push_back(getDefaultCompNameInt<ParticleType>(i));
     }
 
     WriteBinaryParticleData(dir, name,
@@ -211,20 +201,16 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
     AMREX_ASSERT(write_int_comp.size()  == NStructInt  + NArrayInt );
 
     Vector<std::string> real_comp_names;
-    int nrc = ParticleType::is_soa_particle ? NStructReal + NumRealComps() - AMREX_SPACEDIM : NStructReal + NumRealComps();
-    for (int i = 0; i < nrc; ++i )
+    int first_rcomp = ParticleType::is_soa_particle ? AMREX_SPACEDIM : 0;
+    for (int i = first_rcomp; i < NStructReal + NumRealComps(); ++i )
     {
-        std::stringstream ss;
-        ss << "real_comp" << i;
-        real_comp_names.push_back(ss.str());
+        real_comp_names.push_back(getDefaultCompNameReal<ParticleType>(i));
     }
 
     Vector<std::string> int_comp_names;
     for (int i = 0; i < NStructInt + NumIntComps(); ++i )
     {
-        std::stringstream ss;
-        ss << "int_comp" << i;
-        int_comp_names.push_back(ss.str());
+        int_comp_names.push_back(getDefaultCompNameInt<ParticleType>(i));
     }
 
     WriteBinaryParticleData(dir, name, write_real_comp, write_int_comp,
@@ -259,14 +245,12 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
 {
     Vector<int> write_real_comp;
     Vector<std::string> real_comp_names;
-    int nrc = ParticleType::is_soa_particle ? NStructReal + NumRealComps() - AMREX_SPACEDIM : NStructReal + NumRealComps();
 
-    for (int i = 0; i < nrc; ++i )
+    int first_rcomp = ParticleType::is_soa_particle ? AMREX_SPACEDIM : 0;
+    for (int i = first_rcomp; i < NStructReal + NumRealComps(); ++i )
     {
         write_real_comp.push_back(1);
-        std::stringstream ss;
-        ss << "real_comp" << i;
-        real_comp_names.push_back(ss.str());
+        real_comp_names.push_back(getDefaultCompNameReal<ParticleType>(i));
     }
 
     Vector<int> write_int_comp;
@@ -274,9 +258,7 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
     for (int i = 0; i < NStructInt + NumIntComps(); ++i )
     {
         write_int_comp.push_back(1);
-        std::stringstream ss;
-        ss << "int_comp" << i;
-        int_comp_names.push_back(ss.str());
+        int_comp_names.push_back(getDefaultCompNameInt<ParticleType>(i));
     }
 
     WriteBinaryParticleData(dir, name, write_real_comp, write_int_comp,
@@ -345,9 +327,7 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
     Vector<std::string> int_comp_names;
     for (int i = 0; i < NStructInt + NumIntComps(); ++i )
     {
-        std::stringstream ss;
-        ss << "int_comp" << i;
-        int_comp_names.push_back(ss.str());
+        int_comp_names.push_back(getDefaultCompNameInt<ParticleType>(i));
     }
 
     WriteBinaryParticleData(dir, name,
@@ -374,20 +354,16 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
     AMREX_ASSERT(write_int_comp.size()  == NStructInt  + NumIntComps() );
 
     Vector<std::string> real_comp_names;
-    int nrc = ParticleType::is_soa_particle ? NStructReal + NumRealComps() - AMREX_SPACEDIM : NStructReal + NumRealComps();
-    for (int i = 0; i < nrc; ++i )
+    int first_rcomp = ParticleType::is_soa_particle ? AMREX_SPACEDIM : 0;
+    for (int i = first_rcomp; i < NStructReal + NumRealComps(); ++i )
     {
-        std::stringstream ss;
-        ss << "real_comp" << i;
-        real_comp_names.push_back(ss.str());
+        real_comp_names.push_back(getDefaultCompNameReal<ParticleType>(i));
     }
 
     Vector<std::string> int_comp_names;
     for (int i = 0; i < NStructInt + NumIntComps(); ++i )
     {
-        std::stringstream ss;
-        ss << "int_comp" << i;
-        int_comp_names.push_back(ss.str());
+        int_comp_names.push_back(getDefaultCompNameInt<ParticleType>(i));
     }
 
     WriteBinaryParticleData(dir, name, write_real_comp, write_int_comp,

--- a/Src/Particle/AMReX_ParticleTile.H
+++ b/Src/Particle/AMReX_ParticleTile.H
@@ -11,7 +11,10 @@
 #include <AMReX_RealVect.H>
 
 #include <array>
+#include <string>
 #include <type_traits>
+#include <vector>
+
 
 namespace amrex {
 
@@ -730,10 +733,15 @@ struct ParticleTile
     ParticleTile& operator= (ParticleTile &&) noexcept = default;
 #endif
 
-    void define (int a_num_runtime_real, int a_num_runtime_int)
+    void define (
+        int a_num_runtime_real,
+        int a_num_runtime_int,
+        std::vector<std::string>* soa_rdata_names=nullptr,
+        std::vector<std::string>* soa_idata_names=nullptr
+    )
     {
         m_defined = true;
-        GetStructOfArrays().define(a_num_runtime_real, a_num_runtime_int);
+        GetStructOfArrays().define(a_num_runtime_real, a_num_runtime_int, soa_rdata_names, soa_idata_names);
         m_runtime_r_ptrs.resize(a_num_runtime_real);
         m_runtime_i_ptrs.resize(a_num_runtime_int);
         m_runtime_r_cptrs.resize(a_num_runtime_real);

--- a/Src/Particle/AMReX_ParticleUtil.H
+++ b/Src/Particle/AMReX_ParticleUtil.H
@@ -883,6 +883,26 @@ void PermutationForDeposition (Gpu::DeviceVector<index_type>& perm, index_type n
         });
 }
 
+template <typename P>
+std::string getDefaultCompNameReal (const int i) {
+    int first_r_name = 0;
+    if constexpr (P::is_soa_particle) {
+        if (i < AMREX_SPACEDIM) {
+            constexpr int x_in_ascii = 120;
+            std::string const name{char(x_in_ascii+i)};
+            return name;
+        }
+        first_r_name = AMREX_SPACEDIM;
+    }
+    std::string const name{("real_comp" + std::to_string(i-first_r_name))};
+    return name;
+}
+
+template <typename P>
+std::string getDefaultCompNameInt (const int i) {
+    std::string const name{("int_comp" + std::to_string(i))};
+    return name;
+}
 
 #ifdef AMREX_USE_HDF5_ASYNC
 void async_vol_es_wait_particle();

--- a/Src/Particle/AMReX_StructOfArrays.H
+++ b/Src/Particle/AMReX_StructOfArrays.H
@@ -6,7 +6,11 @@
 #include <AMReX_Vector.H>
 #include <AMReX_GpuContainers.H>
 
+#include <algorithm>
 #include <array>
+#include <string>
+#include <vector>
+
 
 namespace amrex {
 
@@ -19,11 +23,18 @@ struct StructOfArrays {
     using RealVector = amrex::PODVector<ParticleReal, Allocator<ParticleReal> >;
     using IntVector = amrex::PODVector<int, Allocator<int> >;
 
-    void define (int a_num_runtime_real, int a_num_runtime_int)
+    void define (
+        int a_num_runtime_real,
+        int a_num_runtime_int,
+        std::vector<std::string>* soa_rdata_names=nullptr,
+        std::vector<std::string>* soa_idata_names=nullptr
+    )
     {
         m_defined = true;
         m_runtime_rdata.resize(a_num_runtime_real);
         m_runtime_idata.resize(a_num_runtime_int );
+        m_rdata_names = soa_rdata_names;
+        m_idata_names = soa_idata_names;
     }
 
     [[nodiscard]] int NumRealComps () const noexcept { return NReal + m_runtime_rdata.size(); }
@@ -79,6 +90,32 @@ struct StructOfArrays {
         }
     }
 
+    /** Get access to a particle Real component Array (compile-time and runtime component)
+     *
+     * @param name named component component with 0...NReal-1 compile-time and NReal... runtime arguments
+     */
+    [[nodiscard]] RealVector& GetRealData (std::string const & name) {
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(m_rdata_names != nullptr, "SoA Real names were not defined.");
+        auto const pos = std::find(m_rdata_names->begin(), m_rdata_names->end(), name);
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(pos != m_rdata_names->end(), "Soa Real name='" + name + "' was not found components");
+
+        int const index = std::distance(m_rdata_names->begin(), pos);
+        return GetRealData(index);
+    }
+
+    /** Get access to a particle Real component Array (compile-time and runtime component)
+     *
+     * @param name named component component with 0...NReal-1 compile-time and NReal... runtime arguments
+     */
+    [[nodiscard]] const RealVector& GetRealData (std::string const & name) const {
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(m_rdata_names != nullptr, "SoA Real names were not defined.");
+        auto const pos = std::find(m_rdata_names->begin(), m_rdata_names->end(), name);
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(pos != m_rdata_names->end(), "Soa Real name='" + name + "' was not found components");
+
+        int const index = std::distance(m_rdata_names->begin(), pos);
+        return GetRealData(index);
+    }
+
     /** Get access to a particle Int component Array (compile-time and runtime component)
      *
      * @param index component with 0...NInt-1 compile-time and NInt... runtime arguments
@@ -116,6 +153,34 @@ struct StructOfArrays {
                 return m_runtime_idata[index - NInt];
             }
         }
+    }
+
+    /** Get access to a particle Int component Array (compile-time and runtime component)
+     *
+     * @param index component with 0...NInt-1 compile-time and NInt... runtime arguments
+     * @return
+     */
+    [[nodiscard]] IntVector& GetIntData (std::string const & name) {
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(m_idata_names != nullptr, "SoA Int names were not defined.");
+        auto const pos = std::find(m_idata_names->begin(), m_idata_names->end(), name);
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(pos != m_idata_names->end(), "Soa Int name='" + name + "' was not found components");
+
+        int const index = std::distance(m_idata_names->begin(), pos);
+        return GetIntData(index);
+    }
+
+    /** Get access to a particle Int component Array (compile-time and runtime component)
+     *
+     * @param index component with 0...NInt-1 compile-time and NInt... runtime arguments
+     * @return
+     */
+    [[nodiscard]] const IntVector& GetIntData (std::string const & name) const {
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(m_idata_names != nullptr, "SoA Int names were not defined.");
+        auto const pos = std::find(m_idata_names->begin(), m_idata_names->end(), name);
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(pos != m_idata_names->end(), "Soa Int name='" + name + "' was not found components");
+
+        int const index = std::distance(m_idata_names->begin(), pos);
+        return GetIntData(index);
     }
 
     /**
@@ -226,13 +291,20 @@ struct StructOfArrays {
     int m_num_neighbor_particles{0};
 
 private:
+    // compile-time data
     IdCPU m_idcpu;
     std::array<RealVector, NReal> m_rdata;
     std::array< IntVector,  NInt> m_idata;
 
+    // runtime data
     std::vector<RealVector> m_runtime_rdata;
     std::vector<IntVector > m_runtime_idata;
 
+    // names of both compile-time and runtime Real and Int data
+    std::vector<std::string>* m_rdata_names = nullptr;
+    std::vector<std::string>* m_idata_names = nullptr;
+
+    //! whether the runtime components are sized correctly
     bool m_defined{false};
 };
 

--- a/Tests/Particles/NamedSoAComponents/CMakeLists.txt
+++ b/Tests/Particles/NamedSoAComponents/CMakeLists.txt
@@ -1,0 +1,10 @@
+foreach(D IN LISTS AMReX_SPACEDIM)
+    set(_sources     main.cpp)
+    #set(_input_files)
+    #set(_input_files inputs)
+
+    setup_test(${D} _sources _input_files NTHREADS 2)
+
+    unset(_sources)
+    unset(_input_files)
+endforeach()

--- a/Tests/Particles/NamedSoAComponents/GNUmakefile
+++ b/Tests/Particles/NamedSoAComponents/GNUmakefile
@@ -1,0 +1,22 @@
+AMREX_HOME = ../../../
+
+DEBUG	= FALSE
+
+DIM	= 3
+
+COMP    = gcc
+
+USE_MPI   = TRUE
+USE_OMP   = FALSE
+USE_CUDA  = FALSE
+
+#TINY_PROFILE = TRUE
+USE_PARTICLES = TRUE
+
+include $(AMREX_HOME)/Tools/GNUMake/Make.defs
+
+include ./Make.package
+include $(AMREX_HOME)/Src/Base/Make.package
+include $(AMREX_HOME)/Src/Particle/Make.package
+
+include $(AMREX_HOME)/Tools/GNUMake/Make.rules

--- a/Tests/Particles/NamedSoAComponents/Make.package
+++ b/Tests/Particles/NamedSoAComponents/Make.package
@@ -1,0 +1,1 @@
+CEXE_sources += main.cpp

--- a/Tests/Particles/NamedSoAComponents/main.cpp
+++ b/Tests/Particles/NamedSoAComponents/main.cpp
@@ -51,9 +51,9 @@ void addParticles ()
     amrex::Print() << "\n";
 
     amrex::Print() << "Adding runtime comps. \n";
-    pc.AddRealComp("runtime_rcomp0");
-    pc.AddRealComp(); // without name - should be runtime_rcomp1
-    pc.AddIntComp(); // without name - should be runtime_icomp0
+    pc.AddRealComp("real_comp1");
+    pc.AddRealComp(); // without name - should be real_comp2
+    pc.AddIntComp(); // without name - should be int_comp0
 
     amrex::Print() << "New Real SoA component names are: ";
     for (auto& n : pc.GetRealSoANames()) {

--- a/Tests/Particles/NamedSoAComponents/main.cpp
+++ b/Tests/Particles/NamedSoAComponents/main.cpp
@@ -84,12 +84,9 @@ void addParticles ()
 
     int const NArrayReal = pc.NArrayReal;
     int const NArrayInt = pc.NArrayInt;
-
     using ParticleType = typename PC::ParticleType;
-    using ParticleTileDataType = typename PC::ParticleTileType::ParticleTileDataType;
 
     const int add_num_particles = 5;
-
     auto& ptile1 = pc.DefineAndReturnParticleTile(0, 0, 0);
     ptile1.resize(add_num_particles);
 

--- a/Tests/Particles/NamedSoAComponents/main.cpp
+++ b/Tests/Particles/NamedSoAComponents/main.cpp
@@ -82,8 +82,8 @@ void addParticles ()
     }
     amrex::Print() << "\n";
 
-    int const NArrayReal = pc.NArrayReal;
-    int const NArrayInt = pc.NArrayInt;
+    int const NArrayReal = PC::NArrayReal;
+    int const NArrayInt = PC::NArrayInt;
     using ParticleType = typename PC::ParticleType;
 
     const int add_num_particles = 5;
@@ -97,7 +97,7 @@ void addParticles ()
         }
         ptile1.getParticleTileData().rdata(AMREX_SPACEDIM)[i] = 1.2;  // w
 
-        ptile1.push_back_int(0, ParticleType::NextID());
+        ptile1.push_back_int(0, int(ParticleType::NextID()));
         ptile1.push_back_int(1, amrex::ParallelDescriptor::MyProc());
     }
 
@@ -105,10 +105,10 @@ void addParticles ()
     using MyParIter = ParIter_impl<ParticleType, NArrayReal, NArrayInt>;
     for (MyParIter pti(pc, lev); pti.isValid(); ++pti) {
         auto& soa = pti.GetStructOfArrays();
-        auto xp = soa.GetRealData("x").data();
-        auto yp = soa.GetRealData("y").data();
-        auto zp = soa.GetRealData("z").data();
-        auto wp = soa.GetRealData("w").data();
+        auto *xp = soa.GetRealData("x").data();
+        auto *yp = soa.GetRealData("y").data();
+        auto *zp = soa.GetRealData("z").data();
+        auto *wp = soa.GetRealData("w").data();
 
         const int np = pti.numParticles();
         ParallelFor( np, [=] AMREX_GPU_DEVICE (long ip)

--- a/Tests/Particles/NamedSoAComponents/main.cpp
+++ b/Tests/Particles/NamedSoAComponents/main.cpp
@@ -1,0 +1,216 @@
+#include <AMReX.H>
+#include <AMReX_Particle.H>
+#include <AMReX_ParticleContainer.H>
+#include <AMReX_ParticleTile.H>
+#include <AMReX_ParIter.H>
+#include <AMReX_REAL.H>
+#include <AMReX_Vector.H>
+#include <AMReX_GpuContainers.H>
+
+#include <array>
+
+using namespace amrex;
+
+template <typename T_PC,template<class> class Allocator=DefaultAllocator>
+void addParticles ()
+{
+    int is_per[AMREX_SPACEDIM];
+    for (int & d : is_per) {
+        d = 1;
+    }
+
+    RealBox real_box;
+    for (int n = 0; n < AMREX_SPACEDIM; n++)
+    {
+        real_box.setLo(n, 0.0);
+        real_box.setHi(n, 100.0);
+    }
+
+    IntVect domain_lo(AMREX_D_DECL(0, 0, 0));
+    IntVect domain_hi(AMREX_D_DECL(127, 127, 127));
+    const Box base_domain(domain_lo, domain_hi);
+
+    Geometry geom(base_domain, &real_box, CoordSys::cartesian, is_per);
+    BoxArray ba(base_domain);
+    ba.maxSize(64);
+
+    DistributionMapping dm(ba);
+
+    T_PC pc(geom, dm, ba);
+
+    amrex::Print() << "Original Real SoA component names are: ";
+    for (auto& n : pc.GetRealSoANames()) {
+        amrex::Print() << n << ", ";
+    }
+    amrex::Print() << "\n";
+
+    amrex::Print() << "Original Int SoA component names are: ";
+    for (auto& n : pc.GetIntSoANames()) {
+        amrex::Print() << n << ", ";
+    }
+    amrex::Print() << "\n";
+
+    amrex::Print() << "Adding runtime comps. \n";
+    pc.AddRealComp("runtime_rcomp0");
+    pc.AddRealComp(); // without name - should be runtime_rcomp1
+    pc.AddIntComp(); // without name - should be runtime_icomp0
+
+    amrex::Print() << "New Real SoA component names are: ";
+    for (auto& n : pc.GetRealSoANames()) {
+        amrex::Print() << n << ", ";
+    }
+    amrex::Print() << "\n";
+
+    amrex::Print() << "New Int SoA component names are: ";
+    for (auto& n : pc.GetIntSoANames()) {
+        amrex::Print() << n << ", ";
+    }
+    amrex::Print() << "\n";
+
+    amrex::Print() << "Reset compile-time SoA names \n";
+    pc.SetSoACompileTimeNames({"x", "y", "z", "w"}, {"i1", "i2"});
+
+    amrex::Print() << "New Real SoA component names are: ";
+    for (auto& n : pc.GetRealSoANames()) {
+        amrex::Print() << n << ", ";
+    }
+    amrex::Print() << "\n";
+
+    amrex::Print() << "New Int SoA component names are: ";
+    for (auto& n : pc.GetIntSoANames()) {
+        amrex::Print() << n << ", ";
+    }
+    amrex::Print() << "\n";
+
+    int const NArrayReal = pc.NArrayReal;
+    int const NArrayInt = pc.NArrayInt;
+
+    using ParticleType = typename T_PC::ParticleType;
+    using ParticleTileDataType = typename T_PC::ParticleTileType::ParticleTileDataType;
+
+    const int add_num_particles = 5;
+
+    auto& ptile1 = pc.DefineAndReturnParticleTile(0, 0, 0);
+    ptile1.resize(add_num_particles);
+
+    for (int i = 0; i < add_num_particles; ++i)
+    {
+        for (int d = 0; d < AMREX_SPACEDIM; d++) {
+            ptile1.pos(i, d) = 12.0;
+        }
+        ptile1.getParticleTileData().rdata(AMREX_SPACEDIM)[i] = 1.2;  // w
+
+        ptile1.push_back_int(0, ParticleType::NextID());
+        ptile1.push_back_int(1, amrex::ParallelDescriptor::MyProc());
+    }
+
+    int lev=0;
+    using MyParIter = ParIter_impl<ParticleType, NArrayReal, NArrayInt>;
+    for (MyParIter pti(pc, lev); pti.isValid(); ++pti) {
+        const int np = pti.numParticles();
+        // preparing access to particle data: SoA of Reals
+        auto& soa = pti.GetStructOfArrays();
+        auto xp = soa.GetRealData("x").data();
+        auto yp = soa.GetRealData("y").data();
+        auto zp = soa.GetRealData("z").data();
+        auto wp = soa.GetRealData("w").data();
+        auto soa_real = soa.GetRealData();
+        auto size = soa.size();
+        amrex::ParticleReal* const AMREX_RESTRICT part_x = soa_real[0].dataPtr();
+        amrex::ParticleReal* const AMREX_RESTRICT part_y = AMREX_SPACEDIM >= 2 ? soa_real[1].dataPtr() : nullptr;
+        amrex::ParticleReal* const AMREX_RESTRICT part_z = AMREX_SPACEDIM >= 3 ? soa_real[2].dataPtr() : nullptr;
+        amrex::ParticleReal* const AMREX_RESTRICT part_w = soa_real[AMREX_SPACEDIM].dataPtr();
+        auto& soa_int = pti.GetStructOfArrays().GetIntData();
+        amrex::ignore_unused(size, part_x, part_y, part_z, part_w, soa_int);
+
+        // Iterating over SoA Particles
+        ParticleTileDataType ptd = pti.GetParticleTile().getParticleTileData();
+
+        ParallelFor( np, [=] AMREX_GPU_DEVICE (long ip)
+        {
+            AMREX_ALWAYS_ASSERT_WITH_MESSAGE(xp[ip] == 12_prt,
+                                             "pos attribute expected to be 12");
+            AMREX_ALWAYS_ASSERT_WITH_MESSAGE(yp[ip] == 12_prt,
+                                             "pos attribute expected to be 12");
+            AMREX_ALWAYS_ASSERT_WITH_MESSAGE(zp[ip] == 12_prt,
+                                             "pos attribute expected to be 12");
+            AMREX_ALWAYS_ASSERT_WITH_MESSAGE(wp[ip] == 1.2_prt,
+                                             "pos attribute expected to be 1.2");
+        });
+
+
+    }
+
+    // create a host-side particle buffer
+    auto tmp = pc.template make_alike<amrex::PinnedArenaAllocator>();
+    tmp.copyParticles(pc, true);
+
+    using MyPinnedParIter = ParIter_impl<ParticleType, NArrayReal, NArrayInt, amrex::PinnedArenaAllocator>;
+
+    for (MyPinnedParIter pti(tmp, lev); pti.isValid(); ++pti) {
+        auto& particle_attributes = pti.GetStructOfArrays();
+        auto& real_comp0 = particle_attributes.GetRealData(0);
+        auto&  int_comp1  = particle_attributes.GetIntData(1);
+        for (int i = 0; i < pti.numParticles(); ++i) {
+            real_comp0[i] += 1;
+            int_comp1[i] += 1;
+        }
+    }
+
+    tmp.Redistribute();
+
+    using ConstPTDType = typename T_PC::ParticleTileType::ConstParticleTileDataType;
+    amrex::ReduceOps<ReduceOpSum, ReduceOpMin, ReduceOpMax> reduce_ops;
+    auto r = amrex::ParticleReduce<
+        amrex::ReduceData<
+            amrex::ParticleReal, amrex::ParticleReal, amrex::ParticleReal,
+            amrex::ParticleReal, amrex::ParticleReal, amrex::ParticleReal,
+            amrex::ParticleReal>
+    >(
+        pc,
+        [=] AMREX_GPU_DEVICE(const ConstPTDType& ptd, const int i) noexcept
+        {
+            amrex::ParticleReal const x = ptd.rdata(0)[i];
+            amrex::ParticleReal const y = AMREX_SPACEDIM >= 2 ? ptd.rdata(1)[i] : 0.0;
+            amrex::ParticleReal const z = AMREX_SPACEDIM >= 3 ? ptd.rdata(2)[i] : 0.0;
+
+            amrex::ParticleReal const w = ptd.rdata(AMREX_SPACEDIM)[i];
+
+            return amrex::makeTuple(x, x*x, y, y*y, z, z*z, w);
+        },
+        reduce_ops
+    );
+    amrex::ignore_unused(r);
+
+    // Reduce for SoA Particle Struct
+    /*
+    using PTDType = typename T_PC::ParticleTileType::ConstParticleTileDataType;
+    amrex::ReduceOps<ReduceOpSum, ReduceOpMin, ReduceOpMax> reduce_ops;
+    auto r = amrex::ParticleReduce<ReduceData<amrex::Real, amrex::Real,int>> (
+                 pc, [=] AMREX_GPU_DEVICE (const PTDType& ptd, const int i) noexcept
+                               -> amrex::GpuTuple<amrex::Real,amrex::Real,int>
+             {
+
+                const amrex::Real a = ptd.rdata(1)[i];
+                const amrex::Real b = ptd.rdata(2)[i];
+                const int c = ptd.idata(1)[i];
+                return {a, b, c};
+             }, reduce_ops);
+
+    AMREX_ALWAYS_ASSERT(amrex::get<0>(r) == amrex::Real(std::pow(256, AMREX_SPACEDIM)));
+    AMREX_ALWAYS_ASSERT(amrex::get<1>(r) == 2.0);
+    AMREX_ALWAYS_ASSERT(amrex::get<2>(r) == 1);
+    */
+}
+
+
+
+
+int main(int argc, char* argv[])
+ {
+    amrex::Initialize(argc,argv);
+    {
+        addParticles< ParticleContainerPureSoA<4, 2> > ();
+    }
+    amrex::Finalize();
+ }

--- a/Tests/Particles/NamedSoAComponents/main.cpp
+++ b/Tests/Particles/NamedSoAComponents/main.cpp
@@ -13,7 +13,7 @@ using namespace amrex;
 
 void addParticles ()
 {
-    using PC = ParticleContainerPureSoA<4, 2>;
+    using PC = ParticleContainerPureSoA<AMREX_SPACEDIM+1, 2>;
     int is_per[AMREX_SPACEDIM];
     for (int & d : is_per) {
         d = 1;
@@ -68,7 +68,7 @@ void addParticles ()
     amrex::Print() << "\n";
 
     amrex::Print() << "Reset compile-time SoA names \n";
-    pc.SetSoACompileTimeNames({"x", "y", "z", "w"}, {"i1", "i2"});
+    pc.SetSoACompileTimeNames({AMREX_D_DECL("x", "y", "z"), "w"}, {"i1", "i2"});
 
     amrex::Print() << "New Real SoA component names are: ";
     for (auto& n : pc.GetRealSoANames()) {
@@ -105,20 +105,24 @@ void addParticles ()
     using MyParIter = ParIter_impl<ParticleType, NArrayReal, NArrayInt>;
     for (MyParIter pti(pc, lev); pti.isValid(); ++pti) {
         auto& soa = pti.GetStructOfArrays();
-        auto *xp = soa.GetRealData("x").data();
-        auto *yp = soa.GetRealData("y").data();
-        auto *zp = soa.GetRealData("z").data();
+        AMREX_D_TERM(
+                     auto *xp = soa.GetRealData("x").data();,
+                     auto *yp = soa.GetRealData("y").data();,
+                     auto *zp = soa.GetRealData("z").data();
+                     );
         auto *wp = soa.GetRealData("w").data();
 
         const int np = pti.numParticles();
         ParallelFor( np, [=] AMREX_GPU_DEVICE (long ip)
         {
-            AMREX_ALWAYS_ASSERT_WITH_MESSAGE(xp[ip] == 12_prt,
-                                             "pos attribute expected to be 12");
-            AMREX_ALWAYS_ASSERT_WITH_MESSAGE(yp[ip] == 12_prt,
-                                             "pos attribute expected to be 12");
-            AMREX_ALWAYS_ASSERT_WITH_MESSAGE(zp[ip] == 12_prt,
-                                             "pos attribute expected to be 12");
+            AMREX_D_TERM(
+                         AMREX_ALWAYS_ASSERT_WITH_MESSAGE(xp[ip] == 12_prt,
+                                                          "pos attribute expected to be 12");,
+                         AMREX_ALWAYS_ASSERT_WITH_MESSAGE(yp[ip] == 12_prt,
+                                                          "pos attribute expected to be 12");,
+                         AMREX_ALWAYS_ASSERT_WITH_MESSAGE(zp[ip] == 12_prt,
+                                                          "pos attribute expected to be 12");
+                         );
             AMREX_ALWAYS_ASSERT_WITH_MESSAGE(wp[ip] == 1.2_prt,
                                              "pos attribute expected to be 1.2");
         });


### PR DESCRIPTION
## Summary

Add support to optionally name SoA Real and Int components, both for compile-time and runtime components.

- [x] define and defaults
- [x] single tile `Get*Data(std::string)`
- [x] refactor out default name generation for reuse, finalize defaults in `AddReal/IntComp`
- [x] test

## Additional background

Close #3614 

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
