### PR TITLE
Deregister BArena from Profiling in Arena::Finalize

### DIFF
--- a/Src/Base/AMReX_Arena.H
+++ b/Src/Base/AMReX_Arena.H
@@ -170,6 +170,12 @@ public:
      */
     void registerForProfiling (const std::string& memory_name);
 
+    /**
+     * \brief Remove this Arena from the list of Arenas that are profiled by TinyProfiler.
+     * This is equivalent to destructing and re-constructing the Arena
+     */
+    void deregisterFromProfiling ();
+
 #ifdef AMREX_USE_GPU
     //! Is this GPU stream ordered memory allocator?
     [[nodiscard]] virtual bool isStreamOrderedArena () const { return false; }

--- a/Src/Base/AMReX_Arena.cpp
+++ b/Src/Base/AMReX_Arena.cpp
@@ -126,6 +126,19 @@ Arena::registerForProfiling ([[maybe_unused]] const std::string& memory_name)
 #endif
 }
 
+void
+Arena::deregisterFromProfiling ()
+{
+#ifdef AMREX_TINY_PROFILING
+    if (m_profiler.m_do_profiling) {
+        TinyProfiler::DeregisterArena(m_profiler.m_profiling_stats);
+        m_profiler.m_do_profiling = false;
+        m_profiler.m_profiling_stats.clear();
+        m_profiler.m_currently_allocated.clear();
+    }
+#endif
+}
+
 std::size_t
 Arena::align (std::size_t s)
 {
@@ -588,6 +601,8 @@ Arena::Finalize ()
         delete the_cpu_arena;
         the_cpu_arena = nullptr;
     }
+
+    The_BArena()->deregisterFromProfiling();
 }
 
 Arena*


### PR DESCRIPTION
## Summary

Since the BArena is not destructed in Arena::Finalize, we need to manually deregister it from memory profiling to avoid an assert when initializing the next time.

## Additional background

https://github.com/ECP-WarpX/impactx/pull/711

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
