### PR TITLE
ParmParse: Fix a GCC warning

### DIFF
--- a/Src/Base/AMReX_ParmParse.cpp
+++ b/Src/Base/AMReX_ParmParse.cpp
@@ -184,16 +184,6 @@ enum lexState
     LIST
 };
 
-const char* const
-state_name[] =
-{
-   "START",
-   "STRING",
-   "QUOTED_STRING",
-   "IDENTIFIER",
-   "LIST"
-};
-
 int
 eat_garbage (const char*& str)
 {
@@ -348,7 +338,7 @@ getToken (const char*& str, std::string& ostr, int& num_linefeeds)
            break;
        default:
            amrex::ErrorStream() << "ParmParse::getToken(): invalid string = " << ostr << '\n'
-                                << "STATE = " << state_name[state]
+                                << "STATE = " << static_cast<int>(state)
                                 << ", next char = " << ch << '\n'
                                 << ", rest of input = \n" << str << '\n';
            amrex::Abort();


### PR DESCRIPTION
The default section of the switch statement, if reached, had an out-of-bound access to the state name array.
