### PR TITLE
CI: Test GCC-13

### DIFF
--- a/.github/workflows/gcc.yml
+++ b/.github/workflows/gcc.yml
@@ -86,7 +86,7 @@ jobs:
         restore-keys: |
              ccache-${{ github.workflow }}-${{ github.job }}-git-
     - name: Build & Install
-      env: {CXXFLAGS: "-fno-operator-names -Werror -Wall -Wextra -Wpedantic -Wnull-dereference -Wfloat-conversion -Wshadow -Woverloaded-virtual -O1 -Wnon-virtual-dtor -Wlogical-op -Wmisleading-indentation -Wduplicated-cond -Wduplicated-branches -Wmissing-include-dirs"}
+      env: {CXXFLAGS: "-fno-operator-names -Werror -Wall -Wextra -Wpedantic -Wnull-dereference -Wfloat-conversion -Wshadow -Woverloaded-virtual -O1 -Wnon-virtual-dtor -Wlogical-op -Wmisleading-indentation -Wduplicated-cond -Wduplicated-branches -Wmissing-include-dirs -Wno-null-dereference"}
         # It's too slow with -O0
       run: |
         export CCACHE_COMPRESS=1

--- a/.github/workflows/gcc.yml
+++ b/.github/workflows/gcc.yml
@@ -69,13 +69,13 @@ jobs:
 
   # Build libamrex and all tests
   tests_build_3D:
-    name: GNU@9.3 C++17 3D Debug Fortran [tests]
-    runs-on: ubuntu-20.04
+    name: GNU@13 C++17 3D Debug Fortran [tests]
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
     - name: Dependencies
       run: |
-        .github/workflows/dependencies/dependencies.sh
+        .github/workflows/dependencies/dependencies_gcc.sh 13
         .github/workflows/dependencies/dependencies_clang-tidy-apt-llvm.sh 17
         .github/workflows/dependencies/dependencies_ccache.sh
     - name: Set Up Cache
@@ -595,13 +595,13 @@ jobs:
 
   # Build libamrex and run all tests
   tests_run:
-    name: GNU@9.3 C++17 [tests]
-    runs-on: ubuntu-20.04
+    name: GNU@13 C++17 [tests]
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
     - name: Dependencies
       run: |
-        .github/workflows/dependencies/dependencies.sh
+        .github/workflows/dependencies/dependencies_gcc.sh 13
         .github/workflows/dependencies/dependencies_clang-tidy-apt-llvm.sh 17
         .github/workflows/dependencies/dependencies_ccache.sh
     - name: Set Up Cache

--- a/Src/Base/AMReX_NonLocalBC.H
+++ b/Src/Base/AMReX_NonLocalBC.H
@@ -882,9 +882,16 @@ ParallelCopy (FabArray<FAB>& dest, const FabArray<FAB>& src, const FabArrayBase:
     components.dest_component = destcomp.i;
     components.src_component = srccomp.i;
     components.n_components = numcomp.n;
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
     ApplyDtosAndProjectionOnReciever<DTOS, Proj> packing{components, dtos, proj};
     CommHandler handler = ParallelCopy_nowait(dest, src, cmd, packing);
     ParallelCopy_finish(dest, std::move(handler), cmd, packing); // NOLINT
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
 }
 
 //! \brief Call ParallelCopy_nowait followed by ParallelCopy_finish.

--- a/Src/Particle/AMReX_Particle_mod_K.H
+++ b/Src/Particle/AMReX_Particle_mod_K.H
@@ -14,6 +14,12 @@ void amrex_deposit_cic (P const& p, int nc, amrex::Array4<amrex::Real> const& rh
                         amrex::GpuArray<amrex::Real,AMREX_SPACEDIM> const& plo,
                         amrex::GpuArray<amrex::Real,AMREX_SPACEDIM> const& dxi)
 {
+// GCC does not like rdata(comp)
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Warray-bounds"
+#endif
+
 #if (AMREX_SPACEDIM == 1)
     amrex::Real lx = (p.pos(0) - plo[0]) * dxi[0] + Real(0.5);
 
@@ -101,6 +107,10 @@ void amrex_deposit_cic (P const& p, int nc, amrex::Array4<amrex::Real> const& rh
 #else
     amrex::Abort("Not implemented.");
 #endif
+
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
 }
 
 template <typename P>
@@ -110,6 +120,12 @@ void amrex_deposit_particle_dx_cic (P const& p, int nc, amrex::Array4<amrex::Rea
                                     amrex::GpuArray<amrex::Real,AMREX_SPACEDIM> const& dxi,
                                     amrex::GpuArray<amrex::Real,AMREX_SPACEDIM> const& pdxi)
 {
+// GCC does not like rdata(comp)
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Warray-bounds"
+#endif
+
 #if (AMREX_SPACEDIM == 1)
     amrex::Real factor = (pdxi[0]/dxi[0]);
 
@@ -229,6 +245,10 @@ void amrex_deposit_particle_dx_cic (P const& p, int nc, amrex::Array4<amrex::Rea
     }
 #else
     amrex::Abort("Not implemented.")
+#endif
+
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic pop
 #endif
 }
 

--- a/Src/Particle/AMReX_WriteBinaryParticleData.H
+++ b/Src/Particle/AMReX_WriteBinaryParticleData.H
@@ -1024,7 +1024,8 @@ void WriteBinaryParticleDataAsync (PC const& pc,
                     {
                         const auto& soa  = pbox.GetStructOfArrays();
 
-                        const auto& p = make_particle<typename PC::ConstParticleType>{}(ptd, pindex);
+                        make_particle<typename PC::ConstParticleType> mp{};
+                        const auto& p = mp(ptd, pindex);
                         if (p.id() <= 0) { continue; }
 
                         // note: for pure SoA particle layouts, we do write the id, cpu and positions as a struct
@@ -1101,7 +1102,8 @@ void WriteBinaryParticleDataAsync (PC const& pc,
                          pindex < pbox.numParticles(); ++pindex)
                     {
                         const auto& soa  = pbox.GetStructOfArrays();
-                        const auto& p = make_particle<typename PC::ConstParticleType>{}(ptd, pindex);
+                        make_particle<typename PC::ConstParticleType> mp{};
+                        const auto& p = mp(ptd, pindex);
 
                         if (p.id() <= 0) { continue; }
 


### PR DESCRIPTION
Incflo uses the latest GCC on the latest Ubuntu runner. Some of its CI tests failed because of a new warning by GCC-13. This commit adds GCC-13 to CI tests.

Most of our GCC CI tests use GCC-9. This commit converts two of them to use GCC-13 and Ubuntu 24.04.
