### PR TITLE
fix: wavefront_size for gfx11*

### DIFF
--- a/Tools/CMake/AMReXSetDefines.cmake
+++ b/Tools/CMake/AMReXSetDefines.cmake
@@ -62,7 +62,7 @@ endif()
 if (AMReX_HIP)
    add_amrex_define( AMREX_USE_HIP NO_LEGACY )
    add_amrex_define( NDEBUG )  # This address a bug that causes slow build times
-   if (${AMReX_AMD_ARCH} MATCHES "gfx10.*")
+   if (${AMReX_AMD_ARCH} MATCHES "gfx1[01].*")
       add_amrex_define( AMREX_AMDGCN_WAVEFRONT_SIZE=32 NO_LEGACY )
    else ()
       add_amrex_define( AMREX_AMDGCN_WAVEFRONT_SIZE=64 NO_LEGACY )

--- a/Tools/GNUMake/Make.defs
+++ b/Tools/GNUMake/Make.defs
@@ -1117,8 +1117,8 @@ else ifeq ($(USE_HIP),TRUE)
       AMD_ARCH = $(AMREX_AMD_ARCH)
     endif
 
-    # For AMD GPUs, the wavefront is 64 except for gfx10??.
-    ifeq ($(findstring gfx10,$(AMD_ARCH)),)
+    # For AMD GPUs, the wavefront is 64 except for gfx10?? and gfx11??.
+    ifeq ($(filter gfx10% gfx11%,$(AMD_ARCH)),)
        DEFINES += -DAMREX_AMDGCN_WAVEFRONT_SIZE=64
     else
        DEFINES += -DAMREX_AMDGCN_WAVEFRONT_SIZE=32


### PR DESCRIPTION
## Summary
GPUs with arch gfx11* were getting set to 64 and causing to fail. This PR aims to fix that by including in the Make and CMake defs. 
## Additional background
https://rocm.docs.amd.com/en/latest/reference/gpu-arch-specs.html

## Checklist

The proposed changes:
- [X] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
