### PR TITLE
Add comparison operator for boxarray and distromap. Add hdf5 to dep.py

### DIFF
--- a/Src/F_Interfaces/Base/AMReX_boxarray_fi.cpp
+++ b/Src/F_Interfaces/Base/AMReX_boxarray_fi.cpp
@@ -87,7 +87,7 @@ extern "C" {
         return ba->intersects(bx);
     }
 
-    bool amrex_fi_boxarray_issame (const BoxArray& baa, const BoxArray& bab)
+    int amrex_fi_boxarray_issame (const BoxArray* baa, const BoxArray* bab)
     {
         return baa == bab;
     }

--- a/Src/F_Interfaces/Base/AMReX_boxarray_fi.cpp
+++ b/Src/F_Interfaces/Base/AMReX_boxarray_fi.cpp
@@ -86,4 +86,9 @@ extern "C" {
         Box bx(IntVect(lo), IntVect(hi), ba->ixType());
         return ba->intersects(bx);
     }
+
+    bool amrex_fi_boxarray_issame (const BoxArray& baa, const BoxArray& bab)
+    {
+        return baa == bab;
+    }
 }

--- a/Src/F_Interfaces/Base/AMReX_boxarray_fi.cpp
+++ b/Src/F_Interfaces/Base/AMReX_boxarray_fi.cpp
@@ -89,6 +89,6 @@ extern "C" {
 
     int amrex_fi_boxarray_issame (const BoxArray* baa, const BoxArray* bab)
     {
-        return baa == bab;
+        return *baa == *bab;
     }
 }

--- a/Src/F_Interfaces/Base/AMReX_boxarray_mod.F90
+++ b/Src/F_Interfaces/Base/AMReX_boxarray_mod.F90
@@ -9,7 +9,8 @@ module amrex_boxarray_module
 
   private
 
-  public :: amrex_boxarray_build, amrex_boxarray_destroy, amrex_print
+  public :: amrex_boxarray_build, amrex_boxarray_destroy, amrex_print, &
+            amrex_boxarray_issame
 
   type, public :: amrex_boxarray
      logical     :: owner = .false.
@@ -128,6 +129,12 @@ module amrex_boxarray_module
        type(c_ptr), value, intent(in) :: ba
        integer, intent(in) :: lo(*), hi(*)
      end function amrex_fi_boxarray_intersects_box
+
+     pure logical function amrex_fi_boxarray_issame (baa, bab) bind(c)
+       import
+       implicit none
+       type(c_ptr), value, intent(in) :: baa, bab
+     end function amrex_fi_boxarray_issame
   end interface
 
 contains
@@ -257,5 +264,12 @@ contains
     ir = amrex_fi_boxarray_intersects_box(this%p, bx%lo, bx%hi)
     r = ir .ne. 0
   end function amrex_boxarray_intersects_box
+
+  pure function amrex_boxarray_issame(baa, bab) result(r)
+    class(amrex_boxarray), intent(in) :: baa
+    class(amrex_boxarray), intent(in) :: bab
+    logical :: r
+    r = amrex_fi_boxarray_issame(baa%p, bab%p)
+  end function amrex_boxarray_issame
 
 end module amrex_boxarray_module

--- a/Src/F_Interfaces/Base/AMReX_boxarray_mod.F90
+++ b/Src/F_Interfaces/Base/AMReX_boxarray_mod.F90
@@ -10,7 +10,7 @@ module amrex_boxarray_module
   private
 
   public :: amrex_boxarray_build, amrex_boxarray_destroy, amrex_print, &
-            amrex_boxarray_issame
+            operator(==)
 
   type, public :: amrex_boxarray
      logical     :: owner = .false.
@@ -36,6 +36,10 @@ module amrex_boxarray_module
      final :: amrex_boxarray_destroy
 #endif
   end type amrex_boxarray
+
+  interface operator(==)
+    module procedure amrex_boxarray_issame
+  end interface operator(==)
 
   interface amrex_boxarray_build
      module procedure amrex_boxarray_build_bx
@@ -130,7 +134,7 @@ module amrex_boxarray_module
        integer, intent(in) :: lo(*), hi(*)
      end function amrex_fi_boxarray_intersects_box
 
-     pure logical function amrex_fi_boxarray_issame (baa, bab) bind(c)
+     pure integer function amrex_fi_boxarray_issame (baa, bab) bind(c)
        import
        implicit none
        type(c_ptr), value, intent(in) :: baa, bab
@@ -265,10 +269,9 @@ contains
     r = ir .ne. 0
   end function amrex_boxarray_intersects_box
 
-  pure function amrex_boxarray_issame(baa, bab) result(r)
-    class(amrex_boxarray), intent(in) :: baa
-    class(amrex_boxarray), intent(in) :: bab
-    logical :: r
+  pure logical function amrex_boxarray_issame(baa, bab) result(r)
+    type(amrex_boxarray), intent(in) :: baa
+    type(amrex_boxarray), intent(in) :: bab
     r = amrex_fi_boxarray_issame(baa%p, bab%p)
   end function amrex_boxarray_issame
 

--- a/Src/F_Interfaces/Base/AMReX_boxarray_mod.F90
+++ b/Src/F_Interfaces/Base/AMReX_boxarray_mod.F90
@@ -127,14 +127,14 @@ module amrex_boxarray_module
        integer(amrex_long) :: amrex_fi_boxarray_numpts
      end function amrex_fi_boxarray_numpts
 
-     pure integer function amrex_fi_boxarray_intersects_box (ba, lo, hi) bind(c)
+     pure integer(c_int) function amrex_fi_boxarray_intersects_box (ba, lo, hi) bind(c)
        import
        implicit none
        type(c_ptr), value, intent(in) :: ba
        integer, intent(in) :: lo(*), hi(*)
      end function amrex_fi_boxarray_intersects_box
 
-     pure integer function amrex_fi_boxarray_issame (baa, bab) bind(c)
+     pure integer(c_int) function amrex_fi_boxarray_issame (baa, bab) bind(c)
        import
        implicit none
        type(c_ptr), value, intent(in) :: baa, bab
@@ -272,7 +272,7 @@ contains
   pure logical function amrex_boxarray_issame(baa, bab) result(r)
     type(amrex_boxarray), intent(in) :: baa
     type(amrex_boxarray), intent(in) :: bab
-    r = amrex_fi_boxarray_issame(baa%p, bab%p)
+    r = amrex_fi_boxarray_issame(baa%p, bab%p) .ne. 0
   end function amrex_boxarray_issame
 
 end module amrex_boxarray_module

--- a/Src/F_Interfaces/Base/AMReX_distromap_fi.cpp
+++ b/Src/F_Interfaces/Base/AMReX_distromap_fi.cpp
@@ -42,7 +42,7 @@ extern "C" {
         AllPrint() << *dm;
     }
 
-    bool amrex_fi_distromap_issame (const DistributionMapping& dma, const DistributionMapping& dmb)
+    int amrex_fi_distromap_issame (const DistributionMapping* dma, const DistributionMapping* dmb)
     {
         return dma == dmb;
     }

--- a/Src/F_Interfaces/Base/AMReX_distromap_fi.cpp
+++ b/Src/F_Interfaces/Base/AMReX_distromap_fi.cpp
@@ -44,6 +44,6 @@ extern "C" {
 
     int amrex_fi_distromap_issame (const DistributionMapping* dma, const DistributionMapping* dmb)
     {
-        return dma == dmb;
+        return *dma == *dmb;
     }
 }

--- a/Src/F_Interfaces/Base/AMReX_distromap_fi.cpp
+++ b/Src/F_Interfaces/Base/AMReX_distromap_fi.cpp
@@ -41,4 +41,9 @@ extern "C" {
     {
         AllPrint() << *dm;
     }
+
+    bool amrex_fi_distromap_issame (const DistributionMapping& dma, const DistributionMapping& dmb)
+    {
+        return dma == dmb;
+    }
 }

--- a/Src/F_Interfaces/Base/AMReX_distromap_mod.F90
+++ b/Src/F_Interfaces/Base/AMReX_distromap_mod.F90
@@ -8,7 +8,8 @@ module amrex_distromap_module
 
   private
 
-  public :: amrex_distromap_build, amrex_distromap_destroy, amrex_print
+  public :: amrex_distromap_build, amrex_distromap_destroy, amrex_print, &
+            amrex_distromap_issame
 
   type, public :: amrex_distromap
      logical     :: owner = .false.
@@ -89,6 +90,12 @@ module amrex_distromap_module
        implicit none
        type(c_ptr), value :: dm
      end subroutine amrex_fi_print_distromap
+
+     pure logical function amrex_fi_distromap_issame (dma, dmb) bind(c)
+       import
+       implicit none
+       type(c_ptr), value :: dma, dmb
+     end function amrex_fi_distromap_issame
   end interface
 
 contains
@@ -157,5 +164,11 @@ contains
     type(amrex_distromap), intent(in) :: dm
     call amrex_fi_print_distromap(dm%p)
   end subroutine amrex_distromap_print
+
+  pure function amrex_distromap_issame (dma, dmb) result(r)
+     type(amrex_distromap), intent(in) :: dma, dmb
+     logical :: r
+     r =  amrex_fi_distromap_issame(dma%p, dmb%p)
+  end function amrex_distromap_issame
 
 end module amrex_distromap_module

--- a/Src/F_Interfaces/Base/AMReX_distromap_mod.F90
+++ b/Src/F_Interfaces/Base/AMReX_distromap_mod.F90
@@ -95,7 +95,7 @@ module amrex_distromap_module
        type(c_ptr), value :: dm
      end subroutine amrex_fi_print_distromap
 
-     pure integer function amrex_fi_distromap_issame (dma, dmb) bind(c)
+     pure integer(c_int) function amrex_fi_distromap_issame (dma, dmb) bind(c)
        import
        implicit none
        type(c_ptr), value, intent(in) :: dma, dmb
@@ -171,7 +171,7 @@ contains
 
   pure logical function amrex_distromap_issame (dma, dmb) result(r)
      type(amrex_distromap), intent(in) :: dma, dmb
-     r =  amrex_fi_distromap_issame(dma%p, dmb%p)
+     r = amrex_fi_distromap_issame(dma%p, dmb%p) .ne. 0
   end function amrex_distromap_issame
 
 end module amrex_distromap_module

--- a/Src/F_Interfaces/Base/AMReX_distromap_mod.F90
+++ b/Src/F_Interfaces/Base/AMReX_distromap_mod.F90
@@ -9,7 +9,7 @@ module amrex_distromap_module
   private
 
   public :: amrex_distromap_build, amrex_distromap_destroy, amrex_print, &
-            amrex_distromap_issame
+            operator(==)
 
   type, public :: amrex_distromap
      logical     :: owner = .false.
@@ -25,6 +25,10 @@ module amrex_distromap_module
      final :: amrex_distromap_destroy
 #endif
   end type amrex_distromap
+
+  interface operator(==)
+    module procedure amrex_distromap_issame
+  end interface operator(==)
 
   interface amrex_distromap_build
      module procedure amrex_distromap_build_ba
@@ -91,10 +95,10 @@ module amrex_distromap_module
        type(c_ptr), value :: dm
      end subroutine amrex_fi_print_distromap
 
-     pure logical function amrex_fi_distromap_issame (dma, dmb) bind(c)
+     pure integer function amrex_fi_distromap_issame (dma, dmb) bind(c)
        import
        implicit none
-       type(c_ptr), value :: dma, dmb
+       type(c_ptr), value, intent(in) :: dma, dmb
      end function amrex_fi_distromap_issame
   end interface
 
@@ -165,9 +169,8 @@ contains
     call amrex_fi_print_distromap(dm%p)
   end subroutine amrex_distromap_print
 
-  pure function amrex_distromap_issame (dma, dmb) result(r)
+  pure logical function amrex_distromap_issame (dma, dmb) result(r)
      type(amrex_distromap), intent(in) :: dma, dmb
-     logical :: r
      r =  amrex_fi_distromap_issame(dma%p, dmb%p)
   end function amrex_distromap_issame
 

--- a/Tools/F_scripts/dep.py
+++ b/Tools/F_scripts/dep.py
@@ -28,7 +28,7 @@ import argparse
 import preprocess
 
 # modules to ignore in the dependencies
-IGNORES = ["iso_c_binding", "iso_fortran_env", "omp_lib", "mpi", "cudafor", "openacc", "hdf"]
+IGNORES = ["iso_c_binding", "iso_fortran_env", "omp_lib", "mpi", "cudafor", "openacc", "hdf", "hdf5"]
 
 # regular expression for "{}module{}name", where {} can be any number
 # of spaces.  We use 4 groups here, denoted by (), so the name of the


### PR DESCRIPTION
## Summary

Add `issame` function for boxarray and for distromap for the Fortran interface. Also add "hdf5" to dep.py to suppress warnings.

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
