### PR TITLE
Fix queryktharr() return value/behaviour.

### DIFF
--- a/Src/Base/AMReX_ParmParse.cpp
+++ b/Src/Base/AMReX_ParmParse.cpp
@@ -365,7 +365,7 @@ ppindex (const ParmParse::Table& table, int n, const std::string& name)
     if (n == ParmParse::LAST) {
         return &(found->second.m_vals.back());
     } else {
-      if(found->second.m_vals.size() < (std::size_t)(n+1)) {
+      if(found->second.m_vals.size() < (std::size_t)n + 1) {
         return nullptr;
       }
       return &(found->second.m_vals[n]);

--- a/Src/Base/AMReX_ParmParse.cpp
+++ b/Src/Base/AMReX_ParmParse.cpp
@@ -365,10 +365,10 @@ ppindex (const ParmParse::Table& table, int n, const std::string& name)
     if (n == ParmParse::LAST) {
         return &(found->second.m_vals.back());
     } else {
-      if(found->second.m_vals.size() < (std::size_t)n + 1) {
-        return nullptr;
-      }
-      return &(found->second.m_vals[n]);
+        if(found->second.m_vals.size() < (std::size_t)n + 1) {
+            return nullptr;
+        }
+        return &(found->second.m_vals[n]);
     }
 }
 

--- a/Src/Base/AMReX_ParmParse.cpp
+++ b/Src/Base/AMReX_ParmParse.cpp
@@ -365,7 +365,7 @@ ppindex (const ParmParse::Table& table, int n, const std::string& name)
     if (n == ParmParse::LAST) {
         return &(found->second.m_vals.back());
     } else {
-      if(found->second.m_vals.size() < n+1) {
+      if(found->second.m_vals.size() < (std::size_t)(n+1)) {
         return nullptr;
       }
       return &(found->second.m_vals[n]);

--- a/Src/Base/AMReX_ParmParse.cpp
+++ b/Src/Base/AMReX_ParmParse.cpp
@@ -366,7 +366,7 @@ ppindex (const ParmParse::Table& table, int n, const std::string& name)
         return &(found->second.m_vals.back());
     } else {
       if(found->second.m_vals.size() < n+1) {
-	return nullptr;
+        return nullptr;
       }
       return &(found->second.m_vals[n]);
     }

--- a/Src/Base/AMReX_ParmParse.cpp
+++ b/Src/Base/AMReX_ParmParse.cpp
@@ -349,7 +349,7 @@ getToken (const char*& str, std::string& ostr, int& num_linefeeds)
 //
 // Return the index of the n'th occurrence of a parameter name,
 // except if n==-1, return the index of the last occurrence.
-// Return 0 if the specified occurrence does not exist.
+// Return nullptr if the specified occurrence does not exist.
 //
 std::vector<std::string> const*
 ppindex (const ParmParse::Table& table, int n, const std::string& name)
@@ -365,7 +365,10 @@ ppindex (const ParmParse::Table& table, int n, const std::string& name)
     if (n == ParmParse::LAST) {
         return &(found->second.m_vals.back());
     } else {
-        return &(found->second.m_vals[n]);
+      if(found->second.m_vals.size() < n+1) {
+	return nullptr;
+      }
+      return &(found->second.m_vals[n]);
     }
 }
 
@@ -642,7 +645,7 @@ squeryval (const ParmParse::Table& table,
            int                     occurrence)
 {
     //
-    // Get last occurrence of name in table.
+    // Get specified occurrence of name in table.
     //
     auto const* def = ppindex(table, occurrence, name);
     if ( def == nullptr )


### PR DESCRIPTION
## Summary

Up to AMReX 24.07 (at least), ParmParse::queryktharr() used to return 0 if the given k (2nd parameter) was out of range.
As of AMReX 24.10, this is not the case, and ppindex() attempts to access found->second.m_vals out-of-bounds, resulting in seg-fault/undefined behaviour.

This PR reverts to the original behaviour, which is now consistent with the documentation for querykth() in AMReX_ParmParse.H. It also makes minor corrections to the associated comments to align with this behaviour.

## Additional background

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
