### PR TITLE
Remove HIP_INDIRECT_FUNCTION

### DIFF
--- a/Tools/GNUMake/Make.defs
+++ b/Tools/GNUMake/Make.defs
@@ -788,10 +788,6 @@ ifeq ($(USE_HIP),TRUE)
 
     GPUSuffix := .HIP
 
-    ifeq ($(HIP_INDIRECT_FUNCTION),TRUE)
-      DEFINES += -DAMREX_HIP_INDIRECT_FUNCTION
-    endif
-
     ifeq ($(USE_MPI),TRUE)
       # Make sure that the C/C++ MPI
       # wrappers are calling hipcc to compile the code.


### PR DESCRIPTION
We used it in the past for kernel fusion with function pointers. This is no longer supported.
