### PR TITLE
Fix a bug in EB2::Level::fillLevelSet

### DIFF
--- a/Docs/sphinx_documentation/source/FFT.rst
+++ b/Docs/sphinx_documentation/source/FFT.rst
@@ -28,7 +28,7 @@ complex data also follows the FFTW convention, where the complex Hermitian
 output array has `(nx/2+1,ny,nz)` elements. Here `nx`, `ny` and `nz` are the
 sizes of the real array and the division is rounded down.
 
-Below are examples of using :cpp:`FFT:R2C`.
+Below are examples of using :cpp:`FFT::R2C`.
 
 .. highlight:: c++
 

--- a/Src/EB/AMReX_EB2_Level.cpp
+++ b/Src/EB/AMReX_EB2_Level.cpp
@@ -880,7 +880,7 @@ void
 Level::fillLevelSet (MultiFab& levelset, const Geometry& geom) const
 {
     levelset.setVal(-1.0);
-    levelset.ParallelCopy(m_levelset,0,0,1,0,0);
+    levelset.ParallelCopy(m_levelset,0,0,1,IntVect(0),levelset.nGrowVect(),geom.periodicity());
 
     const std::vector<IntVect>& pshifts = geom.periodicity().shiftIntVect();
 


### PR DESCRIPTION
We should fill ghost cells too. The linear solver used by WarpX relies on that information.
