### PR TITLE
comply with C++ defect report on user-defined literals

### DIFF
--- a/Src/Base/AMReX_REAL.H
+++ b/Src/Base/AMReX_REAL.H
@@ -100,25 +100,25 @@ inline namespace literals {
       ```
     */
     constexpr Real
-    operator"" _rt( long double x )
+    operator""_rt( long double x )
     {
         return Real( x );
     }
 
     constexpr Real
-    operator"" _rt( unsigned long long int x )
+    operator""_rt( unsigned long long int x )
     {
         return Real( x );
     }
 
     constexpr ParticleReal
-    operator"" _prt( long double x )
+    operator""_prt( long double x )
     {
         return ParticleReal( x );
     }
 
     constexpr ParticleReal
-    operator"" _prt( unsigned long long int x )
+    operator""_prt( unsigned long long int x )
     {
         return ParticleReal( x );
     }


### PR DESCRIPTION
## Summary
C++ has new rules about user-defined literals. `AMReX_REAL.H` is updated to comply.

Old syntax:
```
operator"" _rt
```

New syntax required by the C++ standards committee:
```
operator""_rt
```

## Additional background
https://cplusplus.github.io/CWG/issues/2521.html

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
