### PR TITLE
Initial and final function stacks: Use std::function

### DIFF
--- a/Src/Base/AMReX.H
+++ b/Src/Base/AMReX.H
@@ -102,8 +102,8 @@ namespace amrex
     * classes to clean up any "global" state that they maintain when we're
     * exiting from AMReX.
     */
-    void ExecOnFinalize (PTR_TO_VOID_FUNC);
-    void ExecOnInitialize (PTR_TO_VOID_FUNC);
+    void ExecOnFinalize (std::function<void()>);
+    void ExecOnInitialize (std::function<void()>);
 
     //! This shuts up the compiler about unused variables
     template <class... Ts>

--- a/Src/Base/AMReX.cpp
+++ b/Src/Base/AMReX.cpp
@@ -302,20 +302,20 @@ amrex::Assert_host (const char* EX, const char* file, int line, const char* msg)
 
 namespace
 {
-    std::stack<amrex::PTR_TO_VOID_FUNC> The_Finalize_Function_Stack;
-    std::stack<amrex::PTR_TO_VOID_FUNC> The_Initialize_Function_Stack;
+    std::stack<std::function<void()>> The_Finalize_Function_Stack;
+    std::stack<std::function<void()>> The_Initialize_Function_Stack;
 }
 
 void
-amrex::ExecOnFinalize (PTR_TO_VOID_FUNC fp)
+amrex::ExecOnFinalize (std::function<void()> f)
 {
-    The_Finalize_Function_Stack.push(fp);
+    The_Finalize_Function_Stack.push(std::move(f));
 }
 
 void
-amrex::ExecOnInitialize (PTR_TO_VOID_FUNC fp)
+amrex::ExecOnInitialize (std::function<void()> f)
 {
-    The_Initialize_Function_Stack.push(fp);
+    The_Initialize_Function_Stack.push(std::move(f));
 }
 
 amrex::AMReX*
@@ -391,7 +391,7 @@ amrex::Initialize (int& argc, char**& argv, bool build_parm_parse,
         //
         // Call the registered function.
         //
-        (*The_Initialize_Function_Stack.top())();
+        The_Initialize_Function_Stack.top()();
         //
         // And then remove it from the stack.
         //
@@ -756,7 +756,7 @@ amrex::Finalize (amrex::AMReX* pamrex)
         //
         // Call the registered function.
         //
-        (*The_Finalize_Function_Stack.top())();
+        The_Finalize_Function_Stack.top()();
         //
         // And then remove it from the stack.
         //


### PR DESCRIPTION
Use std::function instead of function pointer for the initial and final function stacks. This is more flexible because we can now use lambda functions with captures (which cannot be converted to function pointer, but can be converted std::function).
