### PR TITLE
VisMF::Read: Cache BoxArray and DistributionMapping

### DIFF
--- a/Src/Base/AMReX_BoxArray.H
+++ b/Src/Base/AMReX_BoxArray.H
@@ -12,6 +12,7 @@
 #include <iosfwd>
 #include <cstddef>
 #include <map>
+#include <memory>
 #include <unordered_map>
 
 namespace amrex
@@ -849,6 +850,10 @@ public:
     [[nodiscard]] BoxArray simplified () const; // For regular AMR grids only!!!
 
     [[nodiscard]] BATransformer const& transformer () const;
+
+    [[nodiscard]] std::weak_ptr<BARef> getWeakRef () const;
+    [[nodiscard]] std::shared_ptr<BARef> const& getSharedRef () const;
+    std::shared_ptr<BARef>& getSharedRef ();
 
     friend class AmrMesh;
     friend class FabArrayBase;

--- a/Src/Base/AMReX_BoxArray.cpp
+++ b/Src/Base/AMReX_BoxArray.cpp
@@ -1623,6 +1623,24 @@ BoxArray::transformer () const
     return m_bat;
 }
 
+std::weak_ptr<BARef>
+BoxArray::getWeakRef () const
+{
+    return std::weak_ptr<BARef>{m_ref};
+}
+
+std::shared_ptr<BARef> const&
+BoxArray::getSharedRef () const
+{
+    return m_ref;
+}
+
+std::shared_ptr<BARef>&
+BoxArray::getSharedRef ()
+{
+    return m_ref;
+}
+
 std::ostream&
 operator<< (std::ostream&   os,
             const BoxArray& ba)

--- a/Src/Base/AMReX_DistributionMapping.H
+++ b/Src/Base/AMReX_DistributionMapping.H
@@ -47,6 +47,26 @@ class DistributionMapping
     //! The distribution strategies
     enum Strategy { UNDEFINED = -1, ROUNDROBIN, KNAPSACK, SFC, RRSFC };
 
+    struct Ref
+    {
+        //! Constructors to match those in DistributionMapping ....
+        Ref () = default;
+
+        explicit Ref (int len) : m_pmap(len) {}
+
+        explicit Ref (const Vector<int>& pmap) : m_pmap(pmap) {}
+
+        explicit Ref (Vector<int>&& pmap) noexcept : m_pmap(std::move(pmap)) {}
+
+        //! dtor, copy-ctor, copy-op=, move-ctor, and move-op= are compiler generated.
+
+        void clear () { m_pmap.clear();  m_index_array.clear();   m_ownership.clear(); }
+
+        Vector<int> m_pmap; //!< index array for all boxes
+        Vector<int> m_index_array;  //!< index array for local boxes owned by the team
+        std::vector<bool> m_ownership; //!< true ownership
+    };
+
     //! The default constructor.
     DistributionMapping () noexcept;
 
@@ -73,6 +93,9 @@ class DistributionMapping
     //! Build mapping out of BoxArray over nprocs processors.
     explicit DistributionMapping (const BoxArray& boxes,
                                   int nprocs = ParallelDescriptor::NProcs());
+
+    explicit DistributionMapping (std::shared_ptr<Ref> a_ref);
+
     /**
     * \brief This is a very specialized distribution map.
     * Do NOT use it unless you really understand what it does.
@@ -259,6 +282,8 @@ class DistributionMapping
                                                       const std::vector<T>& cost,
                                                       Real* efficiency);
 
+    [[nodiscard]] std::weak_ptr<Ref> getWeakRef () const;
+
 private:
 
     const Vector<int>& getIndexArray ();
@@ -332,27 +357,6 @@ private:
     */
     static PVMF m_BuildMap;
 
-    struct Ref
-    {
-        friend class DistributionMapping;
-
-        //! Constructors to match those in DistributionMapping ....
-        Ref () = default;
-
-        explicit Ref (int len) : m_pmap(len) {}
-
-        explicit Ref (const Vector<int>& pmap) : m_pmap(pmap) {}
-
-        explicit Ref (Vector<int>&& pmap) noexcept : m_pmap(std::move(pmap)) {}
-
-        //! dtor, copy-ctor, copy-op=, move-ctor, and move-op= are compiler generated.
-
-        void clear () { m_pmap.clear();  m_index_array.clear();   m_ownership.clear(); }
-
-        Vector<int> m_pmap; //!< index array for all boxes
-        Vector<int> m_index_array;  //!< index array for local boxes owned by the team
-        std::vector<bool> m_ownership; //!< true ownership
-    };
     //
     //! The data -- a reference-counted pointer to a Ref.
     std::shared_ptr<Ref> m_ref;
@@ -374,6 +378,8 @@ public:
     //! This gives a unique ID of the reference, which is different from dmID above.
     [[nodiscard]] RefID getRefID () const noexcept { return RefID { m_ref.get() }; }
 };
+
+using DMRef = DistributionMapping::Ref;
 
 //! Our output operator.
 std::ostream& operator<< (std::ostream& os, const DistributionMapping& pmap);

--- a/Src/Base/AMReX_DistributionMapping.cpp
+++ b/Src/Base/AMReX_DistributionMapping.cpp
@@ -326,6 +326,11 @@ DistributionMapping::DistributionMapping (const BoxArray& boxes,
     define(boxes,nprocs);
 }
 
+DistributionMapping::DistributionMapping (std::shared_ptr<Ref> a_ref)
+    : m_ref(std::move(a_ref))
+{
+}
+
 DistributionMapping::DistributionMapping (const DistributionMapping& d1,
                                           const DistributionMapping& d2)
     :
@@ -1956,6 +1961,12 @@ DistributionMapping::getOwnerShip ()
         }
     }
     return m_ref->m_ownership;
+}
+
+std::weak_ptr<DMRef>
+DistributionMapping::getWeakRef () const
+{
+    return std::weak_ptr<DMRef>{m_ref};
 }
 
 std::ostream&


### PR DESCRIPTION
The cache ensures consistent DistributionMapping for the same BoxArray. It is now safe to call VisMF::Read twice with empty MultiFabs. Previously, even if the two MulitFabs had the same BoxArray, their DistributionMapping could be different, which was a potential source of bugs.
