### PR TITLE
EBData: New class containing Array4's for all EB data

### DIFF
--- a/Src/EB/AMReX_EBData.H
+++ b/Src/EB/AMReX_EBData.H
@@ -1,0 +1,179 @@
+#ifndef AMREX_EB_DATA_H_
+#define AMREX_EB_DATA_H_
+#include <AMReX_Config.H>
+
+#include <AMReX_EBCellFlag.H>
+#include <AMReX_Random.H>
+
+namespace amrex
+{
+
+enum struct EBData_t : int
+{
+    levelset,     // level set
+    volfrac,      // volume fraction
+    centroid,     // volume centroid
+    bndrycent,    // boundary centroid
+    bndrynorm,    // boundary normal
+    bndryarea,    // boundary area
+    AMREX_D_DECL(apx, apy, apz), // area fraction
+    AMREX_D_DECL(fcx, fcy, fcz), // face centroid
+    AMREX_D_DECL(ecx, ecy, ecz), // edge centroid
+    cellflag      // EBCellFlag
+};
+
+struct EBData
+{
+    template <EBData_t T>
+    [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    auto get (int i, int j, int k) const noexcept
+    {
+        if constexpr (T == EBData_t::cellflag) {
+            return (*m_cell_flag)(i,j,k);
+        } else {
+            return m_real_data[static_cast<int>(T)](i,j,k);
+        }
+    }
+
+    template <EBData_t T, std::enable_if_t<   T == EBData_t::centroid
+                                           || T == EBData_t::bndrycent
+                                           || T == EBData_t::bndrynorm
+                                           AMREX_D_TERM(|| T==EBData_t::fcx,
+                                                        || T==EBData_t::fcy,
+                                                        || T==EBData_t::fcz), int> = 0>
+    [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    auto get (int i, int j, int k, int n) const noexcept
+    {
+        return m_real_data[static_cast<int>(T)](i,j,k,n);
+    }
+
+    [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    GpuArray<Real,AMREX_SPACEDIM>
+    randomPointOnEB (int i, int j, int k, RandomEngine const& engine) const
+    {
+        Real nx = this->get<EBData_t::bndrynorm>(i,j,k,0);
+        Real ny = this->get<EBData_t::bndrynorm>(i,j,k,1);
+        Real bcx = this->get<EBData_t::bndrycent>(i,j,k,0);
+        Real bcy = this->get<EBData_t::bndrycent>(i,j,k,1);
+        int dir = (std::abs(nx) >= std::abs(ny)) ? 0 : 1;
+#if (AMREX_SPACEDIM == 2)
+        auto f = [&] (Real n0, Real n1, Real bc0, Real bc1)
+        {
+            Real rn = amrex::Random(engine);
+            if (n1 == 0) {
+                return amrex::makeTuple(bc0, rn-Real(0.5));
+            } else {
+                Real nn = n0/n1; // Note that we have n0 >= n1. So nn != 0.
+                Real ym = bc1+nn*(bc0-Real(-0.5)); // where x=-0.5 and EB intersects
+                Real yp = bc1+nn*(bc0-Real( 0.5)); // where x= 0.5 and EB intersects
+                Real ymin = std::min(ym,yp);
+                Real ymax = std::max(ym,yp);
+                ymin = std::max(ymin, Real(-0.5));
+                ymax = std::min(ymax, Real( 0.5));
+                Real y = rn/(ymax-ymin) + ymin;
+                Real x = bc0 - (y-bc1)*n1/n0;
+                return amrex::makeTuple(x,y);
+            }
+        };
+
+        if (dir == 0) {
+            auto [x,y] = f( nx, ny,
+                           bcx,bcy);
+            return GpuArray<Real,2>{x,y};
+        } else {
+            auto [y,x] = f( ny, nx,
+                           bcy,bcx);
+            return GpuArray<Real,2>{x,y};
+        }
+#else
+        Real nz = this->get<EBData_t::bndrynorm>(i,j,k,2);
+        Real bcz = this->get<EBData_t::bndrycent>(i,j,k,2);
+        if (std::abs(nz) > std::abs(nx) && std::abs(nz) > std::abs(ny)) {
+            dir = 2;
+        }
+        auto f = [&] (Real n0, Real n1, Real n2, Real bc0, Real bc1, Real bc2)
+        { // Note that n0 >= n1 >= n2;
+            if (n1 == 0 && n2 == 0) {
+                return amrex::makeTuple(bc0,
+                                        amrex::Random(engine)-Real(0.5),
+                                        amrex::Random(engine)-Real(0.5));
+            } else if (n2 == 0) {
+                Real nn = n0/n1;
+                Real ym = bc1+nn*(bc0-Real(-0.5));
+                Real yp = bc1+nn*(bc0-Real( 0.5));
+                Real ymin = std::min(ym,yp);
+                Real ymax = std::max(ym,yp);
+                ymin = std::max(ymin, Real(-0.5));
+                ymax = std::min(ymax, Real( 0.5));
+                Real y = amrex::Random(engine)/(ymax-ymin) + ymin;
+                Real z = amrex::Random(engine) - Real(0.5);
+                Real x = bc0 - ((y-bc1)*n1+(z-bc2)*n2)/n0;
+                return amrex::makeTuple(x,y,z);
+            } else {
+                Real y0 = bc1 - ((Real(-0.5)-bc0)*n0+(Real(-0.5)-bc2)*n2)/n1;
+                Real y1 = bc1 - ((Real( 0.5)-bc0)*n0+(Real(-0.5)-bc2)*n2)/n1;
+                Real y2 = bc1 - ((Real(-0.5)-bc0)*n0+(Real( 0.5)-bc2)*n2)/n1;
+                Real y3 = bc1 - ((Real( 0.5)-bc0)*n0+(Real( 0.5)-bc2)*n2)/n1;
+                Real ymin = std::min({y0,y1,y2,y3});
+                Real ymax = std::max({y0,y1,y2,y3});
+                ymin = std::max(ymin, Real(-0.5));
+                ymax = std::min(ymax, Real( 0.5));
+                Real z0 = bc2 - ((Real(-0.5)-bc0)*n0+(Real(-0.5)-bc1)*n1)/n2;
+                Real z1 = bc2 - ((Real( 0.5)-bc0)*n0+(Real(-0.5)-bc1)*n1)/n2;
+                Real z2 = bc2 - ((Real(-0.5)-bc0)*n0+(Real( 0.5)-bc1)*n1)/n2;
+                Real z3 = bc2 - ((Real( 0.5)-bc0)*n0+(Real( 0.5)-bc1)*n1)/n2;
+                Real zmin = std::min({z0,z1,z2,z3});
+                Real zmax = std::max({z0,z1,z2,z3});
+                zmin = std::max(zmin, Real(-0.5));
+                zmax = std::min(zmax, Real( 0.5));
+                Real x, y, z;
+                do {
+                    y = amrex::Random(engine)/(ymax-ymin) + ymin;
+                    z = amrex::Random(engine)/(zmax-zmin) + zmin;
+                    x = bc0 - ((y-bc1)*n1+(z-bc2)*n2)/n0;
+                } while (x > Real(0.5) || x < Real(-0.5));
+                return amrex::makeTuple(x,y,z);
+            }
+        };
+        if (dir == 0) {
+            if (std::abs(ny) >= std::abs(nz)) {
+                auto [x,y,z] = f( nx, ny, nz,
+                                 bcx,bcy,bcz);
+                return GpuArray<Real,3>{x, y, z};
+            } else {
+                auto [x,z,y] = f( nx, nz, ny,
+                                 bcx,bcz,bcy);
+                return GpuArray<Real,3>{x, y, z};
+            }
+        } else if (dir == 1) {
+            if (std::abs(nx) >= std::abs(nz)) {
+                auto [y,x,z] = f( ny, nx, nz,
+                                 bcy,bcx,bcz);
+                return GpuArray<Real,3>{x, y, z};
+            } else {
+                auto [y,z,x] = f( ny, nz, nx,
+                                 bcy,bcz,bcx);
+                return GpuArray<Real,3>{x, y, z};
+            }
+        } else {
+            if (std::abs(nx) >= std::abs(ny)) {
+                auto [z,x,y] = f( nz, nx, ny,
+                                 bcz,bcx,bcy);
+                return GpuArray<Real,3>{x, y, z};
+            } else {
+                auto [z,y,x] = f( nz, ny, nx,
+                                 bcz,bcy,bcx);
+                return GpuArray<Real,3>{x, y, z};
+            }
+        }
+#endif
+    }
+
+    static constexpr int real_data_size = static_cast<int>(EBData_t::cellflag);
+
+    Array4<EBCellFlag const> const* m_cell_flag = nullptr;
+    Array4<Real const> const* m_real_data = nullptr;
+};
+
+}
+#endif

--- a/Src/EB/AMReX_EBDataCollection.H
+++ b/Src/EB/AMReX_EBDataCollection.H
@@ -9,6 +9,7 @@
 
 namespace amrex {
 
+class EBFArrayBoxFactory;
 template <class T> class FabArray;
 class MultiFab;
 class iMultiFab;
@@ -18,6 +19,8 @@ namespace EB2 { class Level; }
 class EBDataCollection
 {
 public:
+
+    friend class EBFArrayBoxFactory;
 
     EBDataCollection (const EB2::Level& a_level, const Geometry& a_geom,
                       const BoxArray& a_ba, const DistributionMapping& a_dm,

--- a/Src/EB/AMReX_EBFabFactory.H
+++ b/Src/EB/AMReX_EBFabFactory.H
@@ -4,10 +4,12 @@
 
 #include <AMReX_FabFactory.H>
 
+#include <AMReX_EBData.H>
 #include <AMReX_EBDataCollection.H>
 #include <AMReX_Geometry.H>
 #include <AMReX_EBSupport.H>
 #include <AMReX_Array.H>
+#include <AMReX_MFIter.H>
 
 namespace amrex
 {
@@ -89,12 +91,15 @@ public:
     //! One should use getMultiEBCellFlagFab for normal levels.
     [[nodiscard]] iMultiFab const* getCutCellMask () const noexcept { return m_ebdc->getCutCellMask(); }
 
+    [[nodiscard]] EBData getEBData (MFIter const& mfi) const noexcept;
+
 private:
 
     EBSupport m_support;
     Geometry m_geom;
     std::shared_ptr<EBDataCollection> m_ebdc;
     EB2::Level const* m_parent = nullptr;
+    Gpu::DeviceVector<Array4<Real const>> m_eb_data;
 };
 
 std::unique_ptr<EBFArrayBoxFactory>

--- a/Src/EB/CMakeLists.txt
+++ b/Src/EB/CMakeLists.txt
@@ -20,6 +20,7 @@ foreach(D IN LISTS AMReX_SPACEDIM)
        AMReX_EBMultiFabUtil.cpp
        AMReX_EBCellFlag.H
        AMReX_EBCellFlag.cpp
+       AMReX_EBData.H
        AMReX_EBDataCollection.H
        AMReX_EBDataCollection.cpp
        AMReX_MultiCutFab.H

--- a/Src/EB/Make.package
+++ b/Src/EB/Make.package
@@ -12,6 +12,8 @@ CEXE_sources += AMReX_EBMultiFabUtil.cpp
 CEXE_headers += AMReX_EBCellFlag.H
 CEXE_sources += AMReX_EBCellFlag.cpp
 
+CEXE_headers += AMReX_EBData.H
+
 CEXE_headers += AMReX_EBDataCollection.H
 CEXE_sources += AMReX_EBDataCollection.cpp
 

--- a/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap_2D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap_2D_K.H
@@ -378,12 +378,8 @@ void mlebabeclap_gsrb (Box const& box,
                        Array4<int const> const& m1, Array4<int const> const& m3,
                        Array4<Real const> const& f0, Array4<Real const> const& f2,
                        Array4<Real const> const& f1, Array4<Real const> const& f3,
-                       Array4<const int> const& ccm, Array4<EBCellFlag const> const& flag,
-                       Array4<Real const> const& vfrc,
-                       Array4<Real const> const& apx, Array4<Real const> const& apy,
-                       Array4<Real const> const& fcx, Array4<Real const> const& fcy,
-                       Array4<Real const> const& ba, Array4<Real const> const& bc,
-                       Array4<Real const> const& beb,
+                       Array4<const int> const& ccm, Array4<Real const> const& beb,
+                       EBData const& ebdata,
                        bool is_dirichlet, bool beta_on_centroid, bool phi_on_centroid,
                        Box const& vbox, int redblack, int ncomp) noexcept
 {
@@ -394,7 +390,8 @@ void mlebabeclap_gsrb (Box const& box,
     {
         if ((i+j+k+redblack) % 2 == 0)
         {
-            if (flag(i,j,k).isCovered())
+            auto const flag = ebdata.get<EBData_t::cellflag>(i,j,k);
+            if (flag.isCovered())
             {
                 phi(i,j,k,n) = Real(0.0);
             }
@@ -409,7 +406,7 @@ void mlebabeclap_gsrb (Box const& box,
                 Real cf3 = (j == vhi.y && m3(i,vhi.y+1,k) > 0)
                     ? f3(i,vhi.y,k,n) : Real(0.0);
 
-                if (flag(i,j,k).isRegular())
+                if (flag.isRegular())
                 {
                     Real gamma = alpha*a(i,j,k)
                         + dhx * (bX(i+1,j,k,n) + bX(i,j,k,n))
@@ -428,19 +425,19 @@ void mlebabeclap_gsrb (Box const& box,
                 }
                 else
                 {
-                    Real kappa = vfrc(i,j,k);
-                    Real apxm = apx(i,j,k);
-                    Real apxp = apx(i+1,j,k);
-                    Real apym = apy(i,j,k);
-                    Real apyp = apy(i,j+1,k);
+                    Real kappa = ebdata.get<EBData_t::volfrac>(i,j,k);
+                    Real apxm = ebdata.get<EBData_t::apx>(i  ,j  ,k);
+                    Real apxp = ebdata.get<EBData_t::apx>(i+1,j  ,k);
+                    Real apym = ebdata.get<EBData_t::apy>(i  ,j  ,k);
+                    Real apyp = ebdata.get<EBData_t::apy>(i  ,j+1,k);
 
                     Real fxm = -bX(i,j,k,n)*phi(i-1,j,k,n);
                     Real oxm = -bX(i,j,k,n)*cf0;
                     Real sxm =  bX(i,j,k,n);
                     if (apxm != Real(0.0) && apxm != Real(1.0)) {
-                        int jj = j + static_cast<int>(std::copysign(Real(1.0),fcx(i,j,k)));
-                        Real fracy = (ccm(i-1,jj,k) || ccm(i,jj,k))
-                            ? std::abs(fcx(i,j,k)) : Real(0.0);
+                        Real fcx = ebdata.get<EBData_t::fcx>(i,j,k);
+                        int jj = j + static_cast<int>(std::copysign(Real(1.0),fcx));
+                        Real fracy = (ccm(i-1,jj,k) || ccm(i,jj,k)) ? std::abs(fcx) : Real(0.0);
                         if (!beta_on_centroid && !phi_on_centroid)
                         {
                             fxm = (Real(1.0)-fracy)*fxm +
@@ -460,9 +457,9 @@ void mlebabeclap_gsrb (Box const& box,
                     Real oxp =  bX(i+1,j,k,n)*cf2;
                     Real sxp = -bX(i+1,j,k,n);
                     if (apxp != Real(0.0) && apxp != Real(1.0)) {
-                        int jj = j + static_cast<int>(std::copysign(Real(1.0),fcx(i+1,j,k)));
-                        Real fracy = (ccm(i,jj,k) || ccm(i+1,jj,k))
-                            ? std::abs(fcx(i+1,j,k)) : Real(0.0);
+                        Real fcx = ebdata.get<EBData_t::fcx>(i+1,j,k);
+                        int jj = j + static_cast<int>(std::copysign(Real(1.0),fcx));
+                        Real fracy = (ccm(i,jj,k) || ccm(i+1,jj,k)) ? std::abs(fcx) : Real(0.0);
                         if (!beta_on_centroid && !phi_on_centroid)
                         {
                             fxp = (Real(1.0)-fracy)*fxp +
@@ -482,9 +479,9 @@ void mlebabeclap_gsrb (Box const& box,
                     Real oym = -bY(i,j,k,n)*cf1;
                     Real sym =  bY(i,j,k,n);
                     if (apym != Real(0.0) && apym != Real(1.0)) {
-                        int ii = i + static_cast<int>(std::copysign(Real(1.0),fcy(i,j,k)));
-                        Real fracx = (ccm(ii,j-1,k) || ccm(ii,j,k))
-                            ? std::abs(fcy(i,j,k)) : Real(0.0);
+                        Real fcy = ebdata.get<EBData_t::fcy>(i,j,k);
+                        int ii = i + static_cast<int>(std::copysign(Real(1.0),fcy));
+                        Real fracx = (ccm(ii,j-1,k) || ccm(ii,j,k)) ? std::abs(fcy) : Real(0.0);
                         if (!beta_on_centroid && !phi_on_centroid)
                         {
                             fym = (Real(1.0)-fracx)*fym +
@@ -505,9 +502,9 @@ void mlebabeclap_gsrb (Box const& box,
                     Real oyp =  bY(i,j+1,k,n)*cf3;
                     Real syp = -bY(i,j+1,k,n);
                     if (apyp != Real(0.0) && apyp != Real(1.0)) {
-                        int ii = i + static_cast<int>(std::copysign(Real(1.0),fcy(i,j+1,k)));
-                        Real fracx = (ccm(ii,j,k) || ccm(ii,j+1,k))
-                            ? std::abs(fcy(i,j+1,k)) : Real(0.0);
+                        Real fcy = ebdata.get<EBData_t::fcy>(i,j+1,k);
+                        int ii = i + static_cast<int>(std::copysign(Real(1.0),fcy));
+                        Real fracx = (ccm(ii,j,k) || ccm(ii,j+1,k)) ? std::abs(fcy) : Real(0.0);
                         if (!beta_on_centroid && !phi_on_centroid)
                         {
                             fyp = (Real(1.0)-fracx)*fyp +
@@ -543,9 +540,9 @@ void mlebabeclap_gsrb (Box const& box,
                         Real anrmx = dapx * anorminv;
                         Real anrmy = dapy * anorminv;
 
-                        Real bctx = bc(i,j,k,0);
-                        Real bcty = bc(i,j,k,1);
-                        Real dx_eb = get_dx_eb(vfrc(i,j,k));
+                        Real bctx = ebdata.get<EBData_t::bndrycent>(i,j,k,0);
+                        Real bcty = ebdata.get<EBData_t::bndrycent>(i,j,k,1);
+                        Real dx_eb = get_dx_eb(kappa);
 
                         Real dg, gx, gy, sx, sy;
                         if (std::abs(anrmx) > std::abs(anrmy)) {
@@ -569,10 +566,12 @@ void mlebabeclap_gsrb (Box const& box,
                         // In gsrb we are always in residual-correction form so phib = 0
                         Real dphidn =  (    -phig)/dg;
 
-                        Real feb = dphidn * ba(i,j,k) * beb(i,j,k,n);
+                        Real ba = ebdata.get<EBData_t::bndryarea>(i,j,k);
+
+                        Real feb = dphidn * ba * beb(i,j,k,n);
                         rho += -vfrcinv*(-dh)*feb;
 
-                        Real feb_gamma = -phig_gamma/dg * ba(i,j,k) * beb(i,j,k,n);
+                        Real feb_gamma = -phig_gamma/dg * ba * beb(i,j,k,n);
                         gamma += vfrcinv*(-dh)*feb_gamma;
                     }
 

--- a/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap_3D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap_3D_K.H
@@ -557,14 +557,8 @@ void mlebabeclap_gsrb (Box const& box,
                        Array4<Real const> const& f4,
                        Array4<Real const> const& f1, Array4<Real const> const& f3,
                        Array4<Real const> const& f5,
-                       Array4<const int> const& ccm, Array4<EBCellFlag const> const& flag,
-                       Array4<Real const> const& vfrc,
-                       Array4<Real const> const& apx, Array4<Real const> const& apy,
-                       Array4<Real const> const& apz,
-                       Array4<Real const> const& fcx, Array4<Real const> const& fcy,
-                       Array4<Real const> const& fcz,
-                       Array4<Real const> const& ba, Array4<Real const> const& bc,
-                       Array4<Real const> const& beb,
+                       Array4<const int> const& ccm, Array4<Real const> const& beb,
+                       EBData const& ebdata,
                        bool is_dirichlet, bool beta_on_centroid, bool phi_on_centroid,
                        Box const& vbox, int redblack, int ncomp) noexcept
 {
@@ -584,7 +578,8 @@ void mlebabeclap_gsrb (Box const& box,
     {
         if ((i+j+k+redblack) % 2 == 0)
         {
-            if (flag(i,j,k).isCovered())
+            auto const flag = ebdata.get<EBData_t::cellflag>(i,j,k);
+            if (flag.isCovered())
             {
                 phi(i,j,k,n) = Real(0.0);
             }
@@ -603,7 +598,7 @@ void mlebabeclap_gsrb (Box const& box,
                 Real cf5 = (k == vhi.z && m5(i,j,vhi.z+1) > 0)
                     ? f5(i,j,vhi.z,n) : Real(0.0);
 
-                if (flag(i,j,k).isRegular())
+                if (flag.isRegular())
                 {
                     Real gamma = alpha*a(i,j,k)
                         + dhx*(bX(i+1,j,k,n) + bX(i,j,k,n))
@@ -626,24 +621,26 @@ void mlebabeclap_gsrb (Box const& box,
                 }
                 else
                 {
-                    Real kappa = vfrc(i,j,k);
-                    Real apxm = apx(i,j,k);
-                    Real apxp = apx(i+1,j,k);
-                    Real apym = apy(i,j,k);
-                    Real apyp = apy(i,j+1,k);
-                    Real apzm = apz(i,j,k);
-                    Real apzp = apz(i,j,k+1);
+                    Real kappa = ebdata.get<EBData_t::volfrac>(i,j,k);
+                    Real apxm = ebdata.get<EBData_t::apx>(i  ,j  ,k  );
+                    Real apxp = ebdata.get<EBData_t::apx>(i+1,j  ,k  );
+                    Real apym = ebdata.get<EBData_t::apy>(i  ,j  ,k  );
+                    Real apyp = ebdata.get<EBData_t::apy>(i  ,j+1,k  );
+                    Real apzm = ebdata.get<EBData_t::apz>(i  ,j  ,k  );
+                    Real apzp = ebdata.get<EBData_t::apz>(i  ,j  ,k+1);
 
                     Real fxm = -bX(i,j,k,n)*phi(i-1,j,k,n);
                     Real oxm = -bX(i,j,k,n)*cf0;
                     Real sxm =  bX(i,j,k,n);
                     if (apxm != Real(0.0) && apxm != Real(1.0)) {
-                        int jj = j + static_cast<int>(std::copysign(Real(1.0), fcx(i,j,k,0)));
-                        int kk = k + static_cast<int>(std::copysign(Real(1.0), fcx(i,j,k,1)));
+                        auto fcx0 = ebdata.get<EBData_t::fcx>(i,j,k,0);
+                        auto fcx1 = ebdata.get<EBData_t::fcx>(i,j,k,1);
+                        int jj = j + static_cast<int>(std::copysign(Real(1.0), fcx0));
+                        int kk = k + static_cast<int>(std::copysign(Real(1.0), fcx1));
                         Real fracy = (ccm(i-1,jj,k) || ccm(i,jj,k))
-                            ? std::abs(fcx(i,j,k,0)) : Real(0.0);
+                            ? std::abs(fcx0) : Real(0.0);
                         Real fracz = (ccm(i-1,j,kk) || ccm(i,j,kk))
-                            ? std::abs(fcx(i,j,k,1)) : Real(0.0);
+                            ? std::abs(fcx1) : Real(0.0);
                         if (!beta_on_centroid && !phi_on_centroid)
                         {
                             fxm = (Real(1.0)-fracy)*(Real(1.0)-fracz)*fxm
@@ -668,12 +665,14 @@ void mlebabeclap_gsrb (Box const& box,
                     Real oxp =  bX(i+1,j,k,n)*cf3;
                     Real sxp = -bX(i+1,j,k,n);
                     if (apxp != Real(0.0) && apxp != Real(1.0)) {
-                        int jj = j + static_cast<int>(std::copysign(Real(1.0),fcx(i+1,j,k,0)));
-                        int kk = k + static_cast<int>(std::copysign(Real(1.0),fcx(i+1,j,k,1)));
+                        auto fcx0 = ebdata.get<EBData_t::fcx>(i+1,j,k,0);
+                        auto fcx1 = ebdata.get<EBData_t::fcx>(i+1,j,k,1);
+                        int jj = j + static_cast<int>(std::copysign(Real(1.0),fcx0));
+                        int kk = k + static_cast<int>(std::copysign(Real(1.0),fcx1));
                         Real fracy = (ccm(i,jj,k) || ccm(i+1,jj,k))
-                            ? std::abs(fcx(i+1,j,k,0)) : Real(0.0);
+                            ? std::abs(fcx0) : Real(0.0);
                         Real fracz = (ccm(i,j,kk) || ccm(i+1,j,kk))
-                            ? std::abs(fcx(i+1,j,k,1)) : Real(0.0);
+                            ? std::abs(fcx1) : Real(0.0);
                         if (!beta_on_centroid && !phi_on_centroid)
                         {
                             fxp = (Real(1.0)-fracy)*(Real(1.0)-fracz)*fxp
@@ -699,12 +698,14 @@ void mlebabeclap_gsrb (Box const& box,
                     Real oym = -bY(i,j,k,n)*cf1;
                     Real sym =  bY(i,j,k,n);
                     if (apym != Real(0.0) && apym != Real(1.0)) {
-                        int ii = i + static_cast<int>(std::copysign(Real(1.0),fcy(i,j,k,0)));
-                        int kk = k + static_cast<int>(std::copysign(Real(1.0),fcy(i,j,k,1)));
+                        auto fcy0 = ebdata.get<EBData_t::fcy>(i,j,k,0);
+                        auto fcy1 = ebdata.get<EBData_t::fcy>(i,j,k,1);
+                        int ii = i + static_cast<int>(std::copysign(Real(1.0),fcy0));
+                        int kk = k + static_cast<int>(std::copysign(Real(1.0),fcy1));
                         Real fracx = (ccm(ii,j-1,k) || ccm(ii,j,k))
-                            ? std::abs(fcy(i,j,k,0)) : Real(0.0);
+                            ? std::abs(fcy0) : Real(0.0);
                         Real fracz = (ccm(i,j-1,kk) || ccm(i,j,kk))
-                            ? std::abs(fcy(i,j,k,1)) : Real(0.0);
+                            ? std::abs(fcy1) : Real(0.0);
                         if (!beta_on_centroid && !phi_on_centroid)
                         {
                             fym = (Real(1.0)-fracx)*(Real(1.0)-fracz)*fym
@@ -729,12 +730,14 @@ void mlebabeclap_gsrb (Box const& box,
                     Real oyp =  bY(i,j+1,k,n)*cf4;
                     Real syp = -bY(i,j+1,k,n);
                     if (apyp != Real(0.0) && apyp != Real(1.0)) {
-                        int ii = i + static_cast<int>(std::copysign(Real(1.0),fcy(i,j+1,k,0)));
-                        int kk = k + static_cast<int>(std::copysign(Real(1.0),fcy(i,j+1,k,1)));
+                        auto fcy0 = ebdata.get<EBData_t::fcy>(i,j+1,k,0);
+                        auto fcy1 = ebdata.get<EBData_t::fcy>(i,j+1,k,1);
+                        int ii = i + static_cast<int>(std::copysign(Real(1.0),fcy0));
+                        int kk = k + static_cast<int>(std::copysign(Real(1.0),fcy1));
                         Real fracx = (ccm(ii,j,k) || ccm(ii,j+1,k))
-                            ? std::abs(fcy(i,j+1,k,0)) : Real(0.0);
+                            ? std::abs(fcy0) : Real(0.0);
                         Real fracz = (ccm(i,j,kk) || ccm(i,j+1,kk))
-                            ? std::abs(fcy(i,j+1,k,1)) : Real(0.0);
+                            ? std::abs(fcy1) : Real(0.0);
                         if (!beta_on_centroid && !phi_on_centroid)
                         {
                             fyp = (Real(1.0)-fracx)*(Real(1.0)-fracz)*fyp
@@ -759,12 +762,14 @@ void mlebabeclap_gsrb (Box const& box,
                     Real ozm = -bZ(i,j,k,n)*cf2;
                     Real szm =  bZ(i,j,k,n);
                     if (apzm != Real(0.0) && apzm != Real(1.0)) {
-                        int ii = i + static_cast<int>(std::copysign(Real(1.0),fcz(i,j,k,0)));
-                        int jj = j + static_cast<int>(std::copysign(Real(1.0),fcz(i,j,k,1)));
+                        auto fcz0 = ebdata.get<EBData_t::fcz>(i,j,k,0);
+                        auto fcz1 = ebdata.get<EBData_t::fcz>(i,j,k,1);
+                        int ii = i + static_cast<int>(std::copysign(Real(1.0),fcz0));
+                        int jj = j + static_cast<int>(std::copysign(Real(1.0),fcz1));
                         Real fracx = (ccm(ii,j,k-1) || ccm(ii,j,k))
-                            ? std::abs(fcz(i,j,k,0)) : Real(0.0);
+                            ? std::abs(fcz0) : Real(0.0);
                         Real fracy = (ccm(i,jj,k-1) || ccm(i,jj,k))
-                            ? std::abs(fcz(i,j,k,1)) : Real(0.0);
+                            ? std::abs(fcz1) : Real(0.0);
                         if (!beta_on_centroid && !phi_on_centroid)
                         {
                             fzm = (Real(1.0)-fracx)*(Real(1.0)-fracy)*fzm
@@ -789,12 +794,14 @@ void mlebabeclap_gsrb (Box const& box,
                     Real ozp =  bZ(i,j,k+1,n)*cf5;
                     Real szp = -bZ(i,j,k+1,n);
                     if (apzp != Real(0.0) && apzp != Real(1.0)) {
-                        int ii = i + static_cast<int>(std::copysign(Real(1.0),fcz(i,j,k+1,0)));
-                        int jj = j + static_cast<int>(std::copysign(Real(1.0),fcz(i,j,k+1,1)));
+                        auto fcz0 = ebdata.get<EBData_t::fcz>(i,j,k+1,0);
+                        auto fcz1 = ebdata.get<EBData_t::fcz>(i,j,k+1,1);
+                        int ii = i + static_cast<int>(std::copysign(Real(1.0),fcz0));
+                        int jj = j + static_cast<int>(std::copysign(Real(1.0),fcz1));
                         Real fracx = (ccm(ii,j,k) || ccm(ii,j,k+1))
-                            ? std::abs(fcz(i,j,k+1,0)) : Real(0.0);
+                            ? std::abs(fcz0) : Real(0.0);
                         Real fracy = (ccm(i,jj,k) || ccm(i,jj,k+1))
-                            ? std::abs(fcz(i,j,k+1,1)) : Real(0.0);
+                            ? std::abs(fcz1) : Real(0.0);
                         if (!beta_on_centroid && !phi_on_centroid)
                         {
                             fzp = (Real(1.0)-fracx)*(Real(1.0)-fracy)*fzp
@@ -840,10 +847,10 @@ void mlebabeclap_gsrb (Box const& box,
                         Real anrmx = dapx * anorminv;
                         Real anrmy = dapy * anorminv;
                         Real anrmz = dapz * anorminv;
-                        Real bctx = bc(i,j,k,0);
-                        Real bcty = bc(i,j,k,1);
-                        Real bctz = bc(i,j,k,2);
-                        Real dx_eb = get_dx_eb(vfrc(i,j,k));
+                        Real bctx = ebdata.get<EBData_t::bndrycent>(i,j,k,0);
+                        Real bcty = ebdata.get<EBData_t::bndrycent>(i,j,k,1);
+                        Real bctz = ebdata.get<EBData_t::bndrycent>(i,j,k,2);
+                        Real dx_eb = get_dx_eb(kappa);
 
                         Real dg = dx_eb / amrex::max(std::abs(anrmx),std::abs(anrmy),
                                                      std::abs(anrmz));
@@ -874,10 +881,12 @@ void mlebabeclap_gsrb (Box const& box,
                             + (gxy + gxyz) * phi(ii,jj,k,n)
                             + (-gxyz) * phi(ii,jj,kk,n);
 
+                        Real ba = ebdata.get<EBData_t::bndryarea>(i,j,k);
+
                         Real dphidn    = (    -phig)/dg;
-                        Real feb_gamma = -phig_gamma/dg * ba(i,j,k) * beb(i,j,k,n);
+                        Real feb_gamma = -phig_gamma/dg * ba * beb(i,j,k,n);
                         gamma += vfrcinv*(-dhx)*feb_gamma;
-                        Real feb = dphidn * ba(i,j,k) * beb(i,j,k,n);
+                        Real feb = dphidn * ba * beb(i,j,k,n);
                         rho += -vfrcinv*(-dhx)*feb;
                     }
 


### PR DESCRIPTION
This can make the code cleaner because we can get access to all available EB data in one object. This also reduces many GPU kernels' register pressure because the GPU device lambdas are much smaller without the need to capture multiple Array4's. For example, the 3D EBABecLap's gsrb kernel's number of registers reduces from 198 to 130.

Add a new function that returns a random point on EB for WarpX.
