### PR TITLE
Fix dangling-reference warnings for particle functions.

### DIFF
--- a/Src/Particle/AMReX_ParticleContainerI.H
+++ b/Src/Particle/AMReX_ParticleContainerI.H
@@ -619,7 +619,7 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
         [=] AMREX_GPU_DEVICE (const typename ParticleTileType::ConstParticleTileDataType& ptd, int ip,
                               amrex::Array4<amrex::Real> const& count)
         {
-            const auto& p = make_particle<ConstParticleType>{}(ptd, ip);
+            const auto p = make_particle<ConstParticleType>{}(ptd, ip);
             CellAssignor assignor;
             IntVect iv = assignor(p, plo, dxi, domain);
             amrex::Gpu::Atomic::AddNoRet(&count(iv), 1.0_rt);

--- a/Src/Particle/AMReX_ParticleUtil.H
+++ b/Src/Particle/AMReX_ParticleUtil.H
@@ -870,7 +870,7 @@ void PermutationForDeposition (Gpu::DeviceVector<index_type>& perm, index_type n
     PermutationForDeposition<index_type>(perm, nitems, bx.numPts() * ref_product,
         [=] AMREX_GPU_DEVICE (index_type idx) noexcept
             {
-                const auto& p = make_particle<ParticleType>{}(ptd,idx);
+                const auto p = make_particle<ParticleType>{}(ptd,idx);
 
                 IntVect iv = ((p.pos() - pos_offset) * dxi).round();
 


### PR DESCRIPTION
## Summary

With gcc 13.2 and all warnings/errors turned on, some particle functions generate a dangling-reference error. 
This PR fixes those errors.

## Additional background

To reproduce, in `Tests/Particles/ParticleMesh/main.cpp` add lines 149-150:
```
myPC.IncrementWithTotal(acceleration , 0);
myPC.SortParticlesForDeposition({0,0,0});
```

and in `Tests/Particles/ParticleMesh/GNUmakefile`
add a final line:
```
CXXFLAGS += -Werror -Wall -Wextra
```

Similar lines in:
`./Src/Extern/SENSEI/AMReX_ParticleDataAdaptorI.H`
may also have the same error, but I don't have SENSEI installed to check.

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
