### PR TITLE
use abs for spherical 2d area

### DIFF
--- a/Src/Base/AMReX_COORDSYS_2D_C.H
+++ b/Src/Base/AMReX_COORDSYS_2D_C.H
@@ -118,7 +118,7 @@ amrex_setarea (Box const& bx, Array4<Real> const& area,
                 AMREX_PRAGMA_SIMD
                 for (int i = lo.x; i <= hi.x; ++i) {
                     Real ri = offset[0] + dx[0]*(i);
-                    Real a = tmp*ri*ri;
+                    Real a = std::abs(tmp*ri*ri);
                     area(i,j,0) = a;
                 }
             }
@@ -132,7 +132,7 @@ amrex_setarea (Box const& bx, Array4<Real> const& area,
                 for (int i = lo.x; i <= hi.x; ++i) {
                     Real ri = offset[0] + dx[0]*(i);
                     Real ro = ri + dx[0];
-                    Real a = tmp*(ro-ri)*(ro+ri);
+                    Real a = std::abs(tmp*(ro-ri)*(ro+ri));
                     area(i,j,0) = a;
                 }
             }


### PR DESCRIPTION
## Summary
2d area in theta direction goes negative at theta=0 symmetry axis due to negative theta. But when we integrate from 0 to 2pi in phi, area orientation is the same regardless of +/- theta.
## Additional background

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
