### PR TITLE
Use async sends in particle communication

### DIFF
--- a/Src/Base/AMReX_ParallelDescriptor.H
+++ b/Src/Base/AMReX_ParallelDescriptor.H
@@ -612,9 +612,9 @@ while ( false )
     */
     inline int SeqNum () noexcept { return ParallelContext::get_inc_mpi_tag(); }
 
-    template <class T> Message Asend(const T*, size_t n, int pid, int tag);
-    template <class T> Message Asend(const T*, size_t n, int pid, int tag, MPI_Comm comm);
-    template <class T> Message Asend(const std::vector<T>& buf, int pid, int tag);
+    template <class T> [[nodiscard]] Message Asend(const T*, size_t n, int pid, int tag);
+    template <class T> [[nodiscard]] Message Asend(const T*, size_t n, int pid, int tag, MPI_Comm comm);
+    template <class T> [[nodiscard]] Message Asend(const std::vector<T>& buf, int pid, int tag);
 
     template <class T> Message Arecv(T*, size_t n, int pid, int tag);
     template <class T> Message Arecv(T*, size_t n, int pid, int tag, MPI_Comm comm);

--- a/Src/Particle/AMReX_ParticleCommunication.H
+++ b/Src/Particle/AMReX_ParticleCommunication.H
@@ -571,8 +571,8 @@ void communicateParticlesStart (const PC& pc, ParticleCopyPlan& plan, const SndB
         AMREX_ASSERT(plan.m_snd_counts[i] % ParallelDescriptor::sizeof_selected_comm_data_type(plan.m_snd_num_particles[i]*psize) == 0);
         AMREX_ASSERT(Who >= 0 && Who < NProcs);
 
-        ParallelDescriptor::Send((char const*)(snd_buffer.dataPtr()+snd_offset), Cnt, Who, SeqNum,
-                                 ParallelContext::CommunicatorSub());
+        ParallelDescriptor::Asend((char const*)(snd_buffer.dataPtr()+snd_offset), Cnt, Who, SeqNum,
+                                  ParallelContext::CommunicatorSub());
     }
 
     amrex::ignore_unused(pc);

--- a/Src/Particle/AMReX_ParticleCommunication.H
+++ b/Src/Particle/AMReX_ParticleCommunication.H
@@ -543,10 +543,7 @@ void communicateParticlesStart (const PC& pc, ParticleCopyPlan& plan, const SndB
     plan.m_particle_rreqs.resize(plan.m_nrcvs);
 
     plan.m_particle_sstats.resize(0);
-    plan.m_particle_sstats.resize(plan.m_NumSnds);
-
     plan.m_particle_sreqs.resize(0);
-    plan.m_particle_sreqs.resize(plan.m_NumSnds);
 
     const int SeqNum = ParallelDescriptor::SeqNum();
 
@@ -569,7 +566,6 @@ void communicateParticlesStart (const PC& pc, ParticleCopyPlan& plan, const SndB
     if (plan.m_NumSnds == 0) { return; }
 
     // Send.
-    int isnd = 0;
     for (int i = 0; i < NProcs; ++i)
     {
         if (i == MyProc) { continue; }
@@ -581,10 +577,11 @@ void communicateParticlesStart (const PC& pc, ParticleCopyPlan& plan, const SndB
         AMREX_ASSERT(plan.m_snd_counts[i] % ParallelDescriptor::sizeof_selected_comm_data_type(plan.m_snd_num_particles[i]*psize) == 0);
         AMREX_ASSERT(Who >= 0 && Who < NProcs);
 
-        plan.m_particle_sreqs[isnd++] = ParallelDescriptor::Asend((char const*)(snd_buffer.dataPtr()+snd_offset), Cnt, Who, SeqNum,
-                                                                  ParallelContext::CommunicatorSub()).req();
+        plan.m_particle_sreqs.push_back(ParallelDescriptor::Asend((char const*)(snd_buffer.dataPtr()+snd_offset), Cnt, Who, SeqNum,
+                                                                  ParallelContext::CommunicatorSub()).req());
     }
-    AMREX_ASSERT(isnd == plan.m_NumSnds - 1);
+
+    plan.m_particle_sstats.resize(plan.m_particle_sreqs.size());
 
     amrex::ignore_unused(pc);
 #else

--- a/Src/Particle/AMReX_ParticleCommunication.H
+++ b/Src/Particle/AMReX_ParticleCommunication.H
@@ -96,8 +96,11 @@ struct ParticleCopyPlan
     mutable Vector<MPI_Status> m_build_stats;
     mutable Vector<MPI_Request> m_build_rreqs;
 
-    mutable Vector<MPI_Status> m_particle_stats;
+    mutable Vector<MPI_Status> m_particle_rstats;
     mutable Vector<MPI_Request> m_particle_rreqs;
+
+    mutable Vector<MPI_Status> m_particle_sstats;
+    mutable Vector<MPI_Request> m_particle_sreqs;
 
     Vector<Long> m_snd_num_particles;
     Vector<Long> m_rcv_num_particles;
@@ -533,11 +536,17 @@ void communicateParticlesStart (const PC& pc, ParticleCopyPlan& plan, const SndB
 
     plan.m_nrcvs = int(RcvProc.size());
 
-    plan.m_particle_stats.resize(0);
-    plan.m_particle_stats.resize(plan.m_nrcvs);
+    plan.m_particle_rstats.resize(0);
+    plan.m_particle_rstats.resize(plan.m_nrcvs);
 
     plan.m_particle_rreqs.resize(0);
     plan.m_particle_rreqs.resize(plan.m_nrcvs);
+
+    plan.m_particle_sstats.resize(0);
+    plan.m_particle_sstats.resize(plan.m_NumSnds);
+
+    plan.m_particle_sreqs.resize(0);
+    plan.m_particle_sreqs.resize(plan.m_NumSnds);
 
     const int SeqNum = ParallelDescriptor::SeqNum();
 
@@ -560,6 +569,7 @@ void communicateParticlesStart (const PC& pc, ParticleCopyPlan& plan, const SndB
     if (plan.m_NumSnds == 0) { return; }
 
     // Send.
+    int isnd = 0;
     for (int i = 0; i < NProcs; ++i)
     {
         if (i == MyProc) { continue; }
@@ -571,9 +581,10 @@ void communicateParticlesStart (const PC& pc, ParticleCopyPlan& plan, const SndB
         AMREX_ASSERT(plan.m_snd_counts[i] % ParallelDescriptor::sizeof_selected_comm_data_type(plan.m_snd_num_particles[i]*psize) == 0);
         AMREX_ASSERT(Who >= 0 && Who < NProcs);
 
-        ParallelDescriptor::Asend((char const*)(snd_buffer.dataPtr()+snd_offset), Cnt, Who, SeqNum,
-                                  ParallelContext::CommunicatorSub());
+        plan.m_particle_sreqs[isnd++] = ParallelDescriptor::Asend((char const*)(snd_buffer.dataPtr()+snd_offset), Cnt, Who, SeqNum,
+                                                                  ParallelContext::CommunicatorSub()).req();
     }
+    AMREX_ASSERT(isnd == plan.m_NumSnds - 1);
 
     amrex::ignore_unused(pc);
 #else

--- a/Src/Particle/AMReX_ParticleCommunication.cpp
+++ b/Src/Particle/AMReX_ParticleCommunication.cpp
@@ -158,6 +158,7 @@ void ParticleCopyPlan::buildMPIStart (const ParticleBufferMap& map, Long psize) 
         m_build_rreqs[i] = ParallelDescriptor::Arecv((char*) (m_rcv_data.dataPtr() + offset), Cnt, Who, SeqNum, ParallelContext::CommunicatorSub()).req();
     }
 
+    Vector<ParallelDescriptor::Message> snd_messages;
     for (auto i : m_neighbor_procs)
     {
         if (i == MyProc) { continue; }
@@ -169,8 +170,9 @@ void ParticleCopyPlan::buildMPIStart (const ParticleBufferMap& map, Long psize) 
         AMREX_ASSERT(Who >= 0 && Who < NProcs);
         AMREX_ASSERT(Cnt < std::numeric_limits<int>::max());
 
-        ParallelDescriptor::Send((char*) snd_data[i].data(), Cnt, Who, SeqNum,
-                                 ParallelContext::CommunicatorSub());
+        auto msg = ParallelDescriptor::Asend((char*) snd_data[i].data(), Cnt, Who, SeqNum,
+                                             ParallelContext::CommunicatorSub());
+        snd_messages.push_back(msg);
     }
 
     m_snd_counts.resize(0);
@@ -199,6 +201,10 @@ void ParticleCopyPlan::buildMPIStart (const ParticleBufferMap& map, Long psize) 
     m_snd_pad_correction_d.resize(m_snd_pad_correction_h.size());
     Gpu::copy(Gpu::hostToDevice, m_snd_pad_correction_h.begin(), m_snd_pad_correction_h.end(),
               m_snd_pad_correction_d.begin());
+
+    for (auto& msg : snd_messages) {
+        msg.wait();
+    }
 #else
     amrex::ignore_unused(map,psize);
 #endif
@@ -288,8 +294,8 @@ void ParticleCopyPlan::doHandShakeLocal (const Vector<Long>& Snds, Vector<Long>&
 
         AMREX_ASSERT(Who >= 0 && Who < ParallelContext::NProcsSub());
 
-        ParallelDescriptor::Send(&Snds[Who], Cnt, Who, SeqNum,
-                                 ParallelContext::CommunicatorSub());
+        ParallelDescriptor::Asend(&Snds[Who], Cnt, Who, SeqNum,
+                                  ParallelContext::CommunicatorSub());
     }
 
     if (num_rcvs > 0)
@@ -352,11 +358,10 @@ void ParticleCopyPlan::doHandShakeGlobal (const Vector<Long>& Snds, Vector<Long>
     {
         if (Snds[i] == 0) { continue; }
         const Long Cnt = 1;
-        MPI_Send( &Snds[i], Cnt, ParallelDescriptor::Mpi_typemap<Long>::type(), i, SeqNum,
-                  ParallelContext::CommunicatorSub());
+        ParallelDescriptor::Asend( &Snds[i], Cnt, i, SeqNum, ParallelContext::CommunicatorSub());
     }
 
-    MPI_Waitall(static_cast<int>(num_rcvs), rreqs.data(), stats.data());
+    ParallelDescriptor::Waitall(rreqs, stats);
 
     for (int i = 0; i < num_rcvs; ++i)
     {

--- a/Src/Particle/AMReX_ParticleCommunication.cpp
+++ b/Src/Particle/AMReX_ParticleCommunication.cpp
@@ -158,7 +158,8 @@ void ParticleCopyPlan::buildMPIStart (const ParticleBufferMap& map, Long psize) 
         m_build_rreqs[i] = ParallelDescriptor::Arecv((char*) (m_rcv_data.dataPtr() + offset), Cnt, Who, SeqNum, ParallelContext::CommunicatorSub()).req();
     }
 
-    Vector<ParallelDescriptor::Message> snd_messages;
+    Vector<MPI_Request> snd_reqs;
+    Vector<MPI_Status>  snd_stats;
     for (auto i : m_neighbor_procs)
     {
         if (i == MyProc) { continue; }
@@ -170,9 +171,8 @@ void ParticleCopyPlan::buildMPIStart (const ParticleBufferMap& map, Long psize) 
         AMREX_ASSERT(Who >= 0 && Who < NProcs);
         AMREX_ASSERT(Cnt < std::numeric_limits<int>::max());
 
-        auto msg = ParallelDescriptor::Asend((char*) snd_data[i].data(), Cnt, Who, SeqNum,
-                                             ParallelContext::CommunicatorSub());
-        snd_messages.push_back(msg);
+        snd_reqs.push_back(ParallelDescriptor::Asend((char*) snd_data[i].data(), Cnt, Who, SeqNum,
+                                                      ParallelContext::CommunicatorSub()).req());
     }
 
     m_snd_counts.resize(0);
@@ -202,9 +202,9 @@ void ParticleCopyPlan::buildMPIStart (const ParticleBufferMap& map, Long psize) 
     Gpu::copy(Gpu::hostToDevice, m_snd_pad_correction_h.begin(), m_snd_pad_correction_h.end(),
               m_snd_pad_correction_d.begin());
 
-    for (auto& msg : snd_messages) {
-        msg.wait();
-    }
+    snd_stats.resize(0);
+    snd_stats.resize(snd_reqs.size());
+    ParallelDescriptor::Waitall(snd_reqs, snd_stats);
 #else
     amrex::ignore_unused(map,psize);
 #endif
@@ -271,8 +271,10 @@ void ParticleCopyPlan::doHandShakeLocal (const Vector<Long>& Snds, Vector<Long>&
 #ifdef AMREX_USE_MPI
     const int SeqNum = ParallelDescriptor::SeqNum();
     const auto num_rcvs = static_cast<int>(m_neighbor_procs.size());
-    Vector<MPI_Status>  stats(num_rcvs);
+    Vector<MPI_Status>  rstats(num_rcvs);
     Vector<MPI_Request> rreqs(num_rcvs);
+    Vector<MPI_Status>  sstats(num_rcvs);
+    Vector<MPI_Request> sreqs(num_rcvs);
 
     // Post receives
     for (int i = 0; i < num_rcvs; ++i)
@@ -294,13 +296,14 @@ void ParticleCopyPlan::doHandShakeLocal (const Vector<Long>& Snds, Vector<Long>&
 
         AMREX_ASSERT(Who >= 0 && Who < ParallelContext::NProcsSub());
 
-        ParallelDescriptor::Asend(&Snds[Who], Cnt, Who, SeqNum,
-                                  ParallelContext::CommunicatorSub());
+        sreqs[i] = ParallelDescriptor::Asend(&Snds[Who], Cnt, Who, SeqNum,
+                                             ParallelContext::CommunicatorSub()).req();
     }
 
     if (num_rcvs > 0)
     {
-        ParallelDescriptor::Waitall(rreqs, stats);
+        ParallelDescriptor::Waitall(sreqs, sstats);
+        ParallelDescriptor::Waitall(rreqs, rstats);
     }
 #else
     amrex::ignore_unused(Snds,Rcvs);
@@ -345,8 +348,10 @@ void ParticleCopyPlan::doHandShakeGlobal (const Vector<Long>& Snds, Vector<Long>
                        ParallelDescriptor::Mpi_typemap<Long>::type(), MPI_SUM,
                        ParallelContext::CommunicatorSub());
 
-    Vector<MPI_Status>  stats(num_rcvs);
+    Vector<MPI_Status>  rstats(num_rcvs);
     Vector<MPI_Request> rreqs(num_rcvs);
+    Vector<MPI_Status>  sstats;
+    Vector<MPI_Request> sreqs;
 
     Vector<Long> num_bytes_rcv(num_rcvs);
     for (int i = 0; i < static_cast<int>(num_rcvs); ++i)
@@ -358,14 +363,17 @@ void ParticleCopyPlan::doHandShakeGlobal (const Vector<Long>& Snds, Vector<Long>
     {
         if (Snds[i] == 0) { continue; }
         const Long Cnt = 1;
-        ParallelDescriptor::Asend( &Snds[i], Cnt, i, SeqNum, ParallelContext::CommunicatorSub());
+        sreqs.push_back(ParallelDescriptor::Asend( &Snds[i], Cnt, i, SeqNum, ParallelContext::CommunicatorSub()).req());
     }
 
-    ParallelDescriptor::Waitall(rreqs, stats);
+    sstats.resize(0);
+    sstats.resize(sreqs.size());
+    ParallelDescriptor::Waitall(sreqs, sstats);
+    ParallelDescriptor::Waitall(rreqs, rstats);
 
     for (int i = 0; i < num_rcvs; ++i)
     {
-        const auto Who = stats[i].MPI_SOURCE;
+        const auto Who = rstats[i].MPI_SOURCE;
         Rcvs[Who] = num_bytes_rcv[i];
     }
 #else

--- a/Src/Particle/AMReX_ParticleCommunication.cpp
+++ b/Src/Particle/AMReX_ParticleCommunication.cpp
@@ -377,9 +377,13 @@ void amrex::communicateParticlesFinish (const ParticleCopyPlan& plan)
 {
     BL_PROFILE("amrex::communicateParticlesFinish");
 #ifdef AMREX_USE_MPI
+    if (plan.m_NumSnds > 0)
+    {
+        ParallelDescriptor::Waitall(plan.m_particle_sreqs, plan.m_particle_sstats);
+    }
     if (plan.m_nrcvs > 0)
     {
-        ParallelDescriptor::Waitall(plan.m_particle_rreqs, plan.m_particle_stats);
+        ParallelDescriptor::Waitall(plan.m_particle_rreqs, plan.m_particle_rstats);
     }
 #else
     amrex::ignore_unused(plan);


### PR DESCRIPTION
This changes a few instances of `ParallelDescriptor::Send` to `ParallelDescriptor::Asend`. This improves the overall runtime of the redistribute benchmark by a few percent for multi-node runs:

```
Gpus      Send        Asend
4	  4.125       4.123
8	  4.29 	      4.198
16	  4.472       4.297
32	  4.62 	      4.456
```

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
