### PR TITLE
Fix CMake Compiler Flag Summary: ID Regex Matching

### DIFF
--- a/Tools/CMake/AMReXGenexHelpers.cmake
+++ b/Tools/CMake/AMReXGenexHelpers.cmake
@@ -279,7 +279,7 @@ function ( eval_genex _list _lang _comp )
       string(REGEX REPLACE "\\$<PLATFORM_ID:[A-Za-z]*>" "0"  _in "${_in}")
 
       # Genex in the form $<*_COMPILER_ID:compiler_ids>
-      string(REGEX REPLACE "\\$<${_lang}_COMPILER_ID:[^>]*${_comp}[^>]*>" "1"  _in "${_in}")
+      string(REGEX REPLACE "\\$<${_lang}_COMPILER_ID[^>]*[:,]${_comp}[>,]" "1"  _in "${_in}")
       string(REGEX REPLACE "\\$<[A-Za-z]*_COMPILER_ID:[A-Za-z]*>" "0"  _in "${_in}")
 
       # Genex in the form $<*_COMPILER_VERSION:version>
@@ -290,7 +290,7 @@ function ( eval_genex _list _lang _comp )
       string(REGEX REPLACE "\\$<[A-Za-z]*_COMPILER_VERSION:[^\$>]*>" "0"  _in "${_in}")
 
       # Genex in the form $<COMPILE_LANG_AND_ID:language,compiler_ids>
-      string(REGEX REPLACE "\\$<COMPILE_LANG_AND_ID:${_lang},[^\$>]*${_comp}[^\$>]*>" "1"  _in "${_in}")
+      string(REGEX REPLACE "\\$<COMPILE_LANG_AND_ID:${_lang}[^\$>]*,${_comp}[>,]" "1"  _in "${_in}")
       string(REGEX REPLACE "\\$<COMPILE_LANG_AND_ID:[A-Za-z,]*>" "0"  _in "${_in}")
 
       # Genex in the form $<COMPILE_LANGUAGE:languages>
@@ -298,7 +298,7 @@ function ( eval_genex _list _lang _comp )
       string(REGEX REPLACE "\\$<COMPILE_LANGUAGE:[A-Za-z]*>" "0"  _in "${_in}")
 
       # Genex in the form $<LINK_LANGUAGE_AND_ID:language,compiler_ids>
-      string(REGEX REPLACE "\\$<LINK_LANGUAGE_AND_ID:${_lang},[^\$>]*${_comp}[^\$>]*>" "1"  _in "${_in}")
+      string(REGEX REPLACE "\\$<LINK_LANGUAGE_AND_ID:${_lang}[^\$>]*,${_comp}[>,]" "1"  _in "${_in}")
       string(REGEX REPLACE "\\$<LINK_LANGUAGE_AND_ID:[A-Za-z,]*>" "0"  _in "${_in}")
 
       # Genex in the form $<LINK_LANGUAGE:languages>


### PR DESCRIPTION
Fixes #2978.

## Summary
To understand what I'm trying to fix here, first note:

https://github.com/AMReX-Codes/amrex/blob/b3f67385e62f387b548389222840486c0fffca57/Tools/CMake/AMReXFlagsTargets.cmake#L71-L95

Then, with Intel's classic compilers, configure AMReX with `-DCMAKE_BUILD_TYPE=Debug` and note the C++ flags listed under "AMReX configuration summary", before and after the changes suggested here. The gist is `Intel` as a compiler id was matching `IntelLLVM` (and `Clang` was also matching `AppleClang` though the flags in that case are the same, so it's harder to tell).
EDIT: this actually only affects what's printed in the summary, the flags that are _actually_ used are already correct!

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
