### PR TITLE
Silence Thread Sanitizer in `InitRandom`

### DIFF
--- a/Src/Base/AMReX_Random.cpp
+++ b/Src/Base/AMReX_Random.cpp
@@ -98,10 +98,10 @@ InitRandom (ULong cpu_seed, int nprocs, ULong gpu_seed)
 #endif
 
 #ifdef AMREX_USE_OMP
-#pragma omp parallel firstprivate(cpu_seed, nprocs)
+#pragma omp parallel for
 #endif
+    for (int tid = 0; tid < nthreads; tid++) {
     {
-        int tid = OpenMP::get_thread_num();
         ULong init_seed = cpu_seed + tid*nprocs;
         generators[tid].seed(init_seed);
     }

--- a/Src/Base/AMReX_Random.cpp
+++ b/Src/Base/AMReX_Random.cpp
@@ -98,7 +98,7 @@ InitRandom (ULong cpu_seed, int nprocs, ULong gpu_seed)
 #endif
 
 #ifdef AMREX_USE_OMP
-#pragma omp parallel
+#pragma omp parallel firstprivate(cpu_seed, nprocs)
 #endif
     {
         int tid = OpenMP::get_thread_num();

--- a/Src/Base/AMReX_Random.cpp
+++ b/Src/Base/AMReX_Random.cpp
@@ -100,7 +100,7 @@ InitRandom (ULong cpu_seed, int nprocs, ULong gpu_seed)
 #ifdef AMREX_USE_OMP
 #pragma omp parallel for
 #endif
-    for (int tid = 0; tid < nthreads; tid++) {
+    for (int tid = 0; tid < nthreads; tid++)
     {
         ULong init_seed = cpu_seed + tid*nprocs;
         generators[tid].seed(init_seed);


### PR DESCRIPTION
## Summary

Either making the shared variables constant (not sensible in the function signature) or using `firstprivate` should silence the warnings we see.

## Additional background

Fix #4279
cc @EZoni

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
