### PR TITLE
SmallMatrix: Assert Lower Bound Index

### DIFF
--- a/Src/Base/AMReX_SmallMatrix.H
+++ b/Src/Base/AMReX_SmallMatrix.H
@@ -100,6 +100,7 @@ namespace amrex {
                 --i;
                 --j;
             }
+            AMREX_ASSERT(i >= 0 && j >= 0);
             AMREX_ASSERT(i < NRows && j < NCols);
             if constexpr (ORDER == Order::F) {
                 return m_mat[i+j*NRows];
@@ -116,6 +117,7 @@ namespace amrex {
                 --i;
                 --j;
             }
+            AMREX_ASSERT(i >= 0 && j >= 0);
             AMREX_ASSERT(i < NRows && j < NCols);
             if constexpr (ORDER == Order::F) {
                 return m_mat[i+j*NRows];
@@ -132,6 +134,7 @@ namespace amrex {
             if constexpr (StartIndex == 1) {
                 --i;
             }
+            AMREX_ASSERT(i >= 0);
             AMREX_ASSERT(i < NRows*NCols);
             return m_mat[i];
         }
@@ -144,6 +147,7 @@ namespace amrex {
             if constexpr (StartIndex == 1) {
                 --i;
             }
+            AMREX_ASSERT(i >= 0);
             AMREX_ASSERT(i < NRows*NCols);
             return m_mat[i];
         }
@@ -156,6 +160,7 @@ namespace amrex {
             if constexpr (StartIndex == 1) {
                 --i;
             }
+            AMREX_ASSERT(i >= 0);
             AMREX_ASSERT(i < NRows*NCols);
             return m_mat[i];
         }
@@ -168,6 +173,7 @@ namespace amrex {
             if constexpr (StartIndex == 1) {
                 --i;
             }
+            AMREX_ASSERT(i >= 0);
             AMREX_ASSERT(i < NRows*NCols);
             return m_mat[i];
         }


### PR DESCRIPTION
## Summary

With 1-based indices, it is easy to access `0` and be out-of-bounds. Add an assert for the lower bound of the index range as well.

## Additional background

Follow-up to #4188

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
