### PR TITLE
ParmParse `queryAddWithParser` No Const

### DIFF
--- a/Src/Base/AMReX_ParmParse.H
+++ b/Src/Base/AMReX_ParmParse.H
@@ -1117,7 +1117,7 @@ public:
                                            std::is_same_v<T,long long> ||
                                            std::is_same_v<T,float> ||
                                            std::is_same_v<T,double>,int> = 0>
-    int queryAddWithParser (const char* name, T& ref) const
+    int queryAddWithParser (const char* name, T& ref)
     {
         int exist = this->queryWithParser(name, ref);
         if (!exist) {


### PR DESCRIPTION
## Summary

`ParmParse::queryAddWithParser` might manipulate the internal state and should not be a const method.

These parser functions might need a unit test in AMReX?

## Additional background

First seen in https://github.com/ECP-WarpX/impactx/pull/743

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
