### PR TITLE
Call fftw_cleanup to deallocate all memory allocated by FFTW

### DIFF
--- a/Src/FFT/AMReX_FFT.cpp
+++ b/Src/FFT/AMReX_FFT.cpp
@@ -39,6 +39,10 @@ void Finalize ()
         AMREX_ROCFFT_SAFE_CALL(rocfft_cleanup());
 #endif
     }
+
+#if defined(AMREX_USE_FFT) && !defined(AMREX_USE_GPU)
+    fftw_cleanup();
+#endif
 }
 
 void Clear ()


### PR DESCRIPTION
FFTW caches a small amount of persistent memory. The memory "leak" is benign. Nevertheless, we call fftw_cleanup to deallocate all memory allocated by FFTW for sanitizers.
