### PR TITLE
Fix a memory leak in Open BC solver

### DIFF
--- a/Src/FFT/AMReX_FFT_R2C.H
+++ b/Src/FFT/AMReX_FFT_R2C.H
@@ -473,7 +473,7 @@ void R2C<T,D,S>::prepare_openbc ()
 #if (AMREX_SPACEDIM == 3)
     if (m_do_alld_fft) { return; }
 
-    if (m_slab_decomp) {
+    if (m_slab_decomp && ! m_fft_fwd_x_half.defined) {
         auto* fab = detail::get_fab(m_rx);
         if (fab) {
             Box bottom_half = m_real_domain;


### PR DESCRIPTION
We forgot a test to make sure We only build the plans once.

X-Ref:
- https://github.com/ECP-WarpX/impactx/pull/790
- https://github.com/ECP-WarpX/WarpX/issues/5547
