### PR TITLE
Fix `AMReX::FFTW` Once

### DIFF
--- a/Tools/CMake/FindAMReXFFTW.cmake
+++ b/Tools/CMake/FindAMReXFFTW.cmake
@@ -102,9 +102,6 @@ if(NOT AMReX_FFTW_SEARCH IN_LIST AMReX_FFTW_SEARCH_VALUES)
 endif()
 mark_as_advanced(AMReX_FFTW_SEARCH)
 
-# Create imported target
-add_library(AMReX::FFTW INTERFACE IMPORTED GLOBAL)
-
 function(fftw_find_precision HFFTWp)
     if(AMReX_FFTW_SEARCH STREQUAL CMAKE)
         find_package(FFTW3${HFFTWp} CONFIG REQUIRED)
@@ -138,9 +135,14 @@ function(fftw_find_precision HFFTWp)
     endif()
 endfunction()
 
-# floating point precision suffixes: we request float and double precision
-fftw_find_precision("")
-fftw_find_precision("f")
+if(NOT TARGET AMReX::FFTW)
+    # Create imported target
+    add_library(AMReX::FFTW INTERFACE IMPORTED GLOBAL)
+
+    # floating point precision suffixes: we request float and double precision
+    fftw_find_precision("")
+    fftw_find_precision("f")
+endif()
 
 # Vars for CMake config
 include(FindPackageHandleStandardArgs)


### PR DESCRIPTION
## Summary

In situations like superbuilds or other downstream usage, the `AMReX::FFTW` should only be created once.

## Additional background

First seen in https://github.com/conda-forge/impactx-feedstock/pull/42

```
...
-- Downloading ABLASTR ...
-- ABLASTR repository: https://github.com/ECP-WarpX/WarpX.git (25.01)
-- Searching for pre-installed AMReX ...
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Failed
-- Check if compiler accepts -pthread
-- Check if compiler accepts -pthread - yes
-- Found Threads: TRUE
-- Found OpenMP_CXX: -fopenmp (found version "4.5")
-- Found OpenMP: TRUE (found version "4.5") found components: CXX
-- Found AMReXFFTW: $PREFIX/lib/libfftw3.so;$PREFIX/lib/libfftw3f.so
-- AMReX: Found version '25.01'
-- HDF5 C compiler wrapper is unable to compile a minimal HDF5 program.
-- Found HDF5: $PREFIX/lib/libhdf5.so
-- Found ADIOS2: $PREFIX/lib/cmake/adios2/adios2-config.cmake (found version "2.10.1") found components: C CXX
-- openPMD-api: Found version '0.16.0'
-- Checking for module 'fftw3'
--   Found fftw3, version 3.3.10
-- Found FFTW: $PREFIX
-- FFTW: Found OpenMP support
-- Performing Test COMPILER_HAS_HIDDEN_VISIBILITY
-- Performing Test COMPILER_HAS_HIDDEN_VISIBILITY - Success
-- Performing Test COMPILER_HAS_HIDDEN_INLINE_VISIBILITY
-- Performing Test COMPILER_HAS_HIDDEN_INLINE_VISIBILITY - Success
-- Performing Test COMPILER_HAS_DEPRECATED_ATTR
-- Performing Test COMPILER_HAS_DEPRECATED_ATTR - Success

WarpX build configuration:
...
-- ABLASTR: Using version '' ()
-- HDF5 C compiler wrapper is unable to compile a minimal HDF5 program.
-- openPMD-api: Found version '0.16.0'
-- Found Python: $PREFIX/bin/python (found suitable version "3.10.16", minimum required is "3.8") found components: Interpreter Development.Module
-- Performing Test HAS_FLTO
-- Performing Test HAS_FLTO - Success
-- Found pybind11: $PREFIX/include (found version "2.13.6")
-- pybind11: Found version '2.13.6'
CMake Error at /home/conda/feedstock_root/build_artifacts/impactx_1736481863454/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_pla/lib/cmake/AMReX/AMReXCMakeModules/FindAMReXFFTW.cmake:48 (add_library):
  add_library cannot create imported target "AMReX::FFTW" because another
  target with the same name already exists.
```

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
