### PR TITLE
Add argument for NeighborParticleContainer::Redistribute

### DIFF
--- a/Src/Particle/AMReX_NeighborParticles.H
+++ b/Src/Particle/AMReX_NeighborParticles.H
@@ -309,21 +309,22 @@ public:
         calcCommSize();
     }
 
-    void Redistribute (int lev_min=0, int lev_max=-1, int nGrow=0, int local=0)
+    void Redistribute (int lev_min=0, int lev_max=-1, int nGrow=0, int local=0,
+                       bool remove_negative=true)
     {
         clearNeighbors();
         ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
-            ::Redistribute(lev_min, lev_max, nGrow, local);
+            ::Redistribute(lev_min, lev_max, nGrow, local, remove_negative);
     }
 
-    void RedistributeLocal ()
+    void RedistributeLocal (bool remove_negative=true)
     {
         const int lev_min = 0;
         const int lev_max = 0;
         const int nGrow = 0;
         const int local = 1;
         clearNeighbors();
-        this->Redistribute(lev_min, lev_max, nGrow, local);
+        this->Redistribute(lev_min, lev_max, nGrow, local, remove_negative);
     }
 
 #ifdef AMREX_USE_GPU


### PR DESCRIPTION
## Summary
This PR allows the user to specify the argument `remove_negatives` for the `NeighborParticleContainer::Redistribute` method.

## Additional background
The argument `remove_negatives` is then passed to the call to the `ParticleContainerImpl::Redistribute` method, which allows us to avoid removing particles with negative IDs.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
