### PR TITLE
PC: Ensure Uniqueness of SoA Names

### DIFF
--- a/Src/Particle/AMReX_ParticleContainer.H
+++ b/Src/Particle/AMReX_ParticleContainer.H
@@ -60,6 +60,7 @@
 #include <memory>
 #include <numeric>
 #include <random>
+#include <stdexcept>
 #include <string>
 #include <tuple>
 #include <type_traits>
@@ -1269,6 +1270,11 @@ public:
 
     void AddRealComp (std::string const & name, int communicate=1)
     {
+        // names must be unique
+        auto const it = std::find(m_soa_rdata_names.begin(), m_soa_rdata_names.end(), name);
+        if (it != m_soa_rdata_names.end()) {
+            throw std::runtime_error("AddRealComp: name '" + name + "' is already present in the SoA.");
+        }
         m_soa_rdata_names.push_back(name);
 
         m_runtime_comps_defined = true;
@@ -1297,6 +1303,11 @@ public:
 
     void AddIntComp (std::string const & name, int communicate=1)
     {
+        // names must be unique
+        auto const it = std::find(m_soa_idata_names.begin(), m_soa_idata_names.end(), name);
+        if (it != m_soa_idata_names.end()) {
+            throw std::runtime_error("AddIntComp: name '" + name + "' is already present in the SoA.");
+        }
         m_soa_idata_names.push_back(name);
 
         m_runtime_comps_defined = true;

--- a/Src/Particle/AMReX_ParticleContainerI.H
+++ b/Src/Particle/AMReX_ParticleContainerI.H
@@ -1,5 +1,6 @@
 #include <AMReX_MakeParticle.H>
 
+#include <set>
 #include <string>
 #include <type_traits>
 #include <vector>
@@ -88,6 +89,12 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
 {
     AMREX_ALWAYS_ASSERT_WITH_MESSAGE(rdata_name.size() == NArrayReal, "rdata_name must be equal to NArrayReal");
     AMREX_ALWAYS_ASSERT_WITH_MESSAGE(idata_name.size() == NArrayInt, "idata_name must be equal to NArrayInt");
+
+    // ensure names for components are unique
+    std::set<std::string> const unique_r_names(rdata_name.begin(), rdata_name.end());
+    std::set<std::string> const unique_i_names(idata_name.begin(), idata_name.end());
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(rdata_name.size() == unique_r_names.size(), "SetSoACompileTimeNames: Provided names in rdata_name are not unique!");
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(idata_name.size() == unique_i_names.size(), "SetSoACompileTimeNames: Provided names in idata_name are not unique!");
 
     for (int i=0; i<NArrayReal; ++i)
     {


### PR DESCRIPTION
## Summary

Avoid user errors. Happened immediately to me: I added a runtime component with the same name as a compile-time SoA component and no error was thrown (now it will).

## Additional background

https://github.com/AMReX-Codes/pyamrex/pull/382

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
