### PR TITLE
PC Names: Same Type, Multiple Vars/Instances

### DIFF
--- a/Src/Particle/AMReX_ParticleContainerI.H
+++ b/Src/Particle/AMReX_ParticleContainerI.H
@@ -42,6 +42,18 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
 
     SetParticleSize();
 
+    // add default names for SoA Real and Int compile-time arguments
+    m_soa_rdata_names.clear();
+    for (int i=0; i<NArrayReal; ++i)
+    {
+        m_soa_rdata_names.push_back(getDefaultCompNameReal<ParticleType>(i));
+    }
+    m_soa_idata_names.clear();
+    for (int i=0; i<NArrayInt; ++i)
+    {
+        m_soa_idata_names.push_back(getDefaultCompNameInt<ParticleType>(i));
+    }
+
     static bool initialized = false;
     if ( ! initialized)
     {
@@ -64,16 +76,6 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
         pp.query("do_unlink", doUnlink);
         pp.queryAdd("do_mem_efficient_sort", memEfficientSort);
         pp.queryAdd("use_comms_arena", use_comms_arena);
-
-        // add default names for SoA Real and Int compile-time arguments
-        for (int i=0; i<NArrayReal; ++i)
-        {
-            m_soa_rdata_names.push_back(getDefaultCompNameReal<ParticleType>(i));
-        }
-        for (int i=0; i<NArrayInt; ++i)
-        {
-            m_soa_idata_names.push_back(getDefaultCompNameInt<ParticleType>(i));
-        }
 
         initialized = true;
     }


### PR DESCRIPTION
## Summary

If the same particle container type is used to create multiple particle species, then the compile-time defined names were only added for the first particle species (instance) of the type and then skipped for any later species (another instance of the same type).

This is due to the global variable (so many globals...) used in the type init. This fixes the problem by moving the instance related name logic out of the once-per-type logic `if` branch.

## Additional background

First seen with ImpactX for its "lost" particle species (2nd instance of the same PC type in the code).
Needed for https://github.com/ECP-WarpX/impactx/pull/805

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
