### PR TITLE
Preparation for deprecation of `__AMDGCN_WAVEFRONT_SIZE`

### DIFF
--- a/Docs/sphinx_documentation/source/Basics.rst
+++ b/Docs/sphinx_documentation/source/Basics.rst
@@ -704,7 +704,7 @@ reading from command line or input file.
 
 Because many AMReX classes and functions (including destructors
 inserted by the compiler) do not function properly after
-:cpp:`amrex:Finalize` is called, it's best to put the codes between
+:cpp:`amrex::Finalize` is called, it's best to put the codes between
 :cpp:`amrex::Initialize` and :cpp:`amrex::Finalize` into its scope
 (e.g., a pair of curly braces or a separate function) to make sure
 resources are properly freed.

--- a/Src/Base/AMReX_GpuDevice.cpp
+++ b/Src/Base/AMReX_GpuDevice.cpp
@@ -65,11 +65,15 @@ namespace {
 namespace {
     __host__ __device__ void amrex_check_wavefront_size () {
 #ifdef __HIP_DEVICE_COMPILE__
-        // https://github.com/AMReX-Codes/amrex/issues/3792
-        // __AMDGCN_WAVEFRONT_SIZE is valid in device code only.
-        // Thus we have to check it this way.
+        // * https://github.com/AMReX-Codes/amrex/issues/3792
+        //   __AMDGCN_WAVEFRONT_SIZE is valid in device code only.
+        //   Thus we have to check it this way.
+        // * https://github.com/AMReX-Codes/amrex/issues/4270
+        //   __AMDGCN_WAVEFRONT_SIZE will be deprecated.
+#ifdef __AMDGCN_WAVEFRONT_SIZE
         static_assert(__AMDGCN_WAVEFRONT_SIZE == AMREX_AMDGCN_WAVEFRONT_SIZE,
                       "Please let the amrex team know if you encounter this");
+#endif
 #endif
     }
 }


### PR DESCRIPTION
See #4270 for more details.

Close @4270
