### PR TITLE
Fix Doxygen with default void std::enable_if_t

### DIFF
--- a/Src/Base/AMReX_TagParallelFor.H
+++ b/Src/Base/AMReX_TagParallelFor.H
@@ -125,7 +125,7 @@ get_tag_size (T const& tag) noexcept
 
 template <typename T, typename F>
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-std::enable_if_t<std::is_same<std::decay_t<decltype(std::declval<T>().box())>, Box>::value>
+std::enable_if_t<std::is_same<std::decay_t<decltype(std::declval<T>().box())>, Box>::value, void>
 tagparfor_call_f (
 #ifdef AMREX_USE_SYCL
     sycl::nd_item<1> const& item,
@@ -150,7 +150,7 @@ tagparfor_call_f (
 
 template <typename T, typename F>
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-std::enable_if_t<std::is_integral<std::decay_t<decltype(std::declval<T>().size())> >::value>
+std::enable_if_t<std::is_integral<std::decay_t<decltype(std::declval<T>().size())> >::value, void>
 tagparfor_call_f (
 #ifdef AMREX_USE_SYCL
     sycl::nd_item<1> const& item,
@@ -270,7 +270,7 @@ ParallelFor (Vector<TagType> const& tags, int ncomp, F && f)
 }
 
 template <class TagType, class F>
-std::enable_if_t<std::is_same<std::decay_t<decltype(std::declval<TagType>().box())>, Box>::value>
+std::enable_if_t<std::is_same<std::decay_t<decltype(std::declval<TagType>().box())>, Box>::value, void>
 ParallelFor (Vector<TagType> const& tags, F && f)
 {
     detail::ParallelFor_doit(tags,
@@ -287,7 +287,7 @@ ParallelFor (Vector<TagType> const& tags, F && f)
 }
 
 template <class TagType, class F>
-std::enable_if_t<std::is_integral<std::decay_t<decltype(std::declval<TagType>().size())> >::value>
+std::enable_if_t<std::is_integral<std::decay_t<decltype(std::declval<TagType>().size())> >::value, void>
 ParallelFor (Vector<TagType> const& tags, F && f)
 {
     detail::ParallelFor_doit(tags,

--- a/Src/Particle/AMReX_WriteBinaryParticleData.H
+++ b/Src/Particle/AMReX_WriteBinaryParticleData.H
@@ -169,7 +169,7 @@ void packParticleIDs (I* idata, const P& p, bool is_checkpoint) noexcept
 }
 
 template <class PC>
-std::enable_if_t<RunOnGpu<typename PC::template AllocatorType<int>>::value>
+std::enable_if_t<RunOnGpu<typename PC::template AllocatorType<int>>::value, void>
 packIOData (Vector<int>& idata, Vector<ParticleReal>& rdata, const PC& pc, int lev, int grid,
             const Vector<int>& write_real_comp, const Vector<int>& write_int_comp,
             const Vector<std::map<std::pair<int, int>, typename PC::IntVector>>& particle_io_flags,
@@ -279,7 +279,7 @@ packIOData (Vector<int>& idata, Vector<ParticleReal>& rdata, const PC& pc, int l
 }
 
 template <class PC>
-std::enable_if_t<!RunOnGpu<typename PC::template AllocatorType<int>>::value>
+std::enable_if_t<!RunOnGpu<typename PC::template AllocatorType<int>>::value, void>
 packIOData (Vector<int>& idata, Vector<ParticleReal>& rdata, const PC& pc, int lev, int grid,
             const Vector<int>& write_real_comp, const Vector<int>& write_int_comp,
             const Vector<std::map<std::pair<int, int>, typename PC::IntVector>>& particle_io_flags,


### PR DESCRIPTION
## Summary

Since the Doxygen version changed from 1.9.1 to 1.9.8 in the job runner, that generates
https://amrex-codes.github.io/amrex/docs_xml/doxygen/amrex-doxygen-web.tag.xml, there is a problem where if a function is overloaded where the only difference is the std::enable_if in the return value and the second argument of std::enable_if is not specified, so it defaults to void, then errors are caused in downstream doxygen builds causing CI failures.

## Additional background

In the example below, it can be seen how if there is a second argument in the std::enable_if expression, both overloads get combined into one in the documentation where the return value is replaced by the second argument of std::enable_if. But if there is no second argument both versions end up in the xml file with the full std::enable_if expressions.
```C++
template <typename T>
std::enable_if_t<std::is_same<std::decay_t<decltype(std::declval<T>().box())>, Box>::value,
                 Long>
get_tag_size (T const& tag) noexcept
{...}

template <typename T>
std::enable_if_t<std::is_integral<std::decay_t<decltype(std::declval<T>().size())> >::value,
                 Long>
get_tag_size (T const& tag) noexcept
{...}

template <typename T, typename F>
AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
std::enable_if_t<std::is_same<std::decay_t<decltype(std::declval<T>().box())>, Box>::value>
tagparfor_call_f (
#ifdef AMREX_USE_SYCL
    sycl::nd_item<1> const& item,
#endif
    int icell, T const& tag, F&& f) noexcept
{...}

template <typename T, typename F>
AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
std::enable_if_t<std::is_integral<std::decay_t<decltype(std::declval<T>().size())> >::value>
tagparfor_call_f (
#ifdef AMREX_USE_SYCL
    sycl::nd_item<1> const& item,
#endif
    int i, T const& tag, F&& f) noexcept
{...}
```

```xml
    <member kind="function">
      <type>Long</type>
      <name>get_tag_size</name>
      <anchorfile>namespaceamrex_1_1detail.html</anchorfile>
      <anchor>a5dabf23fc1d6b0482df819bdd5d465c9</anchor>
      <arglist>(T const &amp;tag) noexcept</arglist>
    </member>
    <member kind="function">
      <type>AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE std::enable_if_t&lt; std::is_same&lt; std::decay_t&lt; decltype(std::declval&lt; T &gt;().box())&gt;, Box &gt;::value</type>
      <name>tagparfor_call_f</name>
      <anchorfile>namespaceamrex_1_1detail.html</anchorfile>
      <anchor>a3d1c62850c82bc09be970a6c864d52aa</anchor>
      <arglist>(int icell, T const &amp;tag, F &amp;&amp;f) noexcept</arglist>
    </member>
    <member kind="function">
      <type>AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE std::enable_if_t&lt; std::is_integral&lt; std::decay_t&lt; decltype(std::declval&lt; T &gt;().size())&gt; &gt;::value</type>
      <name>tagparfor_call_f</name>
      <anchorfile>namespaceamrex_1_1detail.html</anchorfile>
      <anchor>ad534e2d6a6e6d52339476c692cbccd78</anchor>
      <arglist>(int i, T const &amp;tag, F &amp;&amp;f) noexcept</arglist>
    </member>
```

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
