### PR TITLE
Remove HYPRE version requirement

### DIFF
--- a/Tools/CMake/AMReXThirdPartyLibraries.cmake
+++ b/Tools/CMake/AMReXThirdPartyLibraries.cmake
@@ -143,7 +143,7 @@ endif ()
 # HYPRE
 #
 if (AMReX_HYPRE)
-    find_package(HYPRE 2.20.0 REQUIRED)
+    find_package(HYPRE REQUIRED)
     if(AMReX_CUDA)
         find_package(CUDAToolkit REQUIRED)
 


### PR DESCRIPTION
## Summary
If Hypre dependency is added through CMake `find_package` AMReX enforces version 2.20.0.
This is version seems to be outdated (at least 5 years old). Therefore, I suggest to remove the version requirement for HYPRE from AMReX (or update it if a specific version is promoted.)

## Additional background
I added HYPRE using CMake `find_package` as a dependency to AMReX and found that the required version was v2.20.0.
Using HYPRE v2.20.0 lead to a SegFault within the AMReX HYPRE interface.
This SegFault could be removed by using the latest HYPRE version. To prevent such confusions in future removing the version requirement would be a solution.