### PR TITLE
Fix: Names in `PC::make_alike`

### DIFF
--- a/Src/Particle/AMReX_ParticleContainer.H
+++ b/Src/Particle/AMReX_ParticleContainer.H
@@ -1374,11 +1374,25 @@ public:
     {
         ContainerLike<NewAllocator> tmp(m_gdb);
 
+        std::vector<std::string> const real_names = this->GetRealSoANames();
+        std::vector<std::string> real_ct_names(NArrayReal);
+        for (int ic = 0; ic < NArrayReal; ++ic) { real_ct_names.at(ic) = real_names[ic]; }
+
+        std::vector<std::string> const int_names = this->GetIntSoANames();
+        std::vector<std::string> int_ct_names(NArrayInt);
+        for (int ic = 0; ic < NArrayInt; ++ic) { int_ct_names.at(ic) = int_names[ic]; }
+
+        tmp.SetSoACompileTimeNames(real_ct_names, int_ct_names);
+
         // add runtime real comps to tmp
-        for (int ic = 0; ic < this->NumRuntimeRealComps(); ++ic) { tmp.AddRealComp(false); }
+        for (int ic = 0; ic < this->NumRuntimeRealComps(); ++ic) {
+            tmp.AddRealComp(real_names.at(ic + NArrayReal), false);
+        }
 
         // add runtime int comps to tmp
-        for (int ic = 0; ic < this->NumRuntimeIntComps(); ++ic) { tmp.AddIntComp(false); }
+        for (int ic = 0; ic < this->NumRuntimeIntComps(); ++ic) {
+            tmp.AddIntComp(int_names.at(ic + NArrayInt), false);
+        }
 
         return tmp;
     }


### PR DESCRIPTION
## Summary

The ParticleContainer's `make_alike` function must not forget the names of the SoA components. Currently, it creates a new container with the same components, but default names.

## Additional background

First seen in https://github.com/ECP-WarpX/WarpX/pull/5481

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
