### PR TITLE
compile MLCurlCurl for 1D in cmake

### DIFF
--- a/Src/LinearSolvers/CMakeLists.txt
+++ b/Src/LinearSolvers/CMakeLists.txt
@@ -55,14 +55,12 @@ foreach(D IN LISTS AMReX_SPACEDIM)
     endif ()
 
     if (AMReX_LINEAR_SOLVERS_EM)
-       if (NOT D EQUAL 1 AND AMReX_LINEAR_SOLVERS_EM)
-          target_sources(amrex_${D}d
-             PRIVATE
-             MLMG/AMReX_MLCurlCurl.H
-             MLMG/AMReX_MLCurlCurl.cpp
-             MLMG/AMReX_MLCurlCurl_K.H
-             )
-       endif ()
+       target_sources(amrex_${D}d
+          PRIVATE
+          MLMG/AMReX_MLCurlCurl.H
+          MLMG/AMReX_MLCurlCurl.cpp
+          MLMG/AMReX_MLCurlCurl_K.H
+          )
 
        target_sources(amrex_${D}d
           PRIVATE


### PR DESCRIPTION
## Summary

## Additional background
CurlCurl for 1D was added in #4242 
It compiles with make, and this PR ensures that it compiles with cmake option by removing optional compilation that did not include 1D for CurlCurl

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
