### PR TITLE
SYCL: fix '-flink-huge-device-code' compiler flag

### DIFF
--- a/Tools/CMake/AMReXSYCL.cmake
+++ b/Tools/CMake/AMReXSYCL.cmake
@@ -83,9 +83,15 @@ if (AMReX_SYCL_AOT)
 endif ()
 
 if (CMAKE_SYSTEM_NAME STREQUAL "Linux" AND "${CMAKE_BUILD_TYPE}" MATCHES "Debug")
-   target_link_options( SYCL
-      INTERFACE
-      "$<${_cxx_sycl}:-fsycl-link-huge-device-code>" )
+   if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 2023.2)
+      target_link_options( SYCL
+          INTERFACE
+          "$<${_cxx_sycl}:-fsycl-link-huge-device-code>" )
+   else ()
+      target_link_options( SYCL
+          INTERFACE
+          "$<${_cxx_sycl}:-flink-huge-device-code>" )
+   endif ()
 endif ()
 
 if (AMReX_PARALLEL_LINK_JOBS GREATER 1)


### PR DESCRIPTION
The '-fsycl-link-huge-device-code' compiler flag is marked as deprecated starting with the oneAPI 2023.2 release.  It was removed with the 2025.0 release.  The equivalent setting '-flink-huge-device-code' was added in the 2023.2 release.  Use the new setting with compiler versions greater 2023.1.

## Summary

## Additional background

See release notes for more details:
https://www.intel.com/content/www/us/en/developer/articles/release-notes/intel-oneapi-dpc-c-compiler-release-notes.html

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
