### PR TITLE
Expose MLCellLinOP::setInterpBndryHalfWidth for non-hypre cases

### DIFF
--- a/Src/LinearSolvers/MLMG/AMReX_MLCellLinOp.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLCellLinOp.H
@@ -144,9 +144,7 @@ public:
 
     Vector<std::unique_ptr<MF> > m_robin_bcval;
 
-#ifdef AMREX_USE_HYPRE
     void setInterpBndryHalfWidth (int w) { m_interpbndry_halfwidth = w; }
-#endif
 
 protected:
 


### PR DESCRIPTION
It could be useful for special cases with small blocking factors.
