### PR TITLE
Copy comm flags in make_alike

### DIFF
--- a/Src/Particle/AMReX_ParticleContainer.H
+++ b/Src/Particle/AMReX_ParticleContainer.H
@@ -1376,13 +1376,16 @@ public:
 
         // add runtime real comps to tmp
         for (int ic = 0; ic < this->NumRuntimeRealComps(); ++ic) {
-            tmp.AddRealComp(real_names.at(ic + NArrayReal), false);
+            tmp.AddRealComp(real_names.at(ic + NArrayReal));
         }
 
         // add runtime int comps to tmp
         for (int ic = 0; ic < this->NumRuntimeIntComps(); ++ic) {
-            tmp.AddIntComp(int_names.at(ic + NArrayInt), false);
+            tmp.AddIntComp(int_names.at(ic + NArrayInt));
         }
+
+        tmp.h_redistribute_real_comp = h_redistribute_real_comp;
+        tmp.h_redistribute_int_comp = h_redistribute_int_comp;
 
         return tmp;
     }


### PR DESCRIPTION
Need to make sure these are preserved (we use them as IO flags in WarpX)

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
