### PR TITLE
Change FFTW rapth flag

### DIFF
--- a/Tools/GNUMake/Make.defs
+++ b/Tools/GNUMake/Make.defs
@@ -626,7 +626,7 @@ ifeq ($(USE_FFT),TRUE)
     ifneq ($(FFTW_HOME),NOT_SET)
       SYSTEM_INCLUDE_LOCATIONS += $(FFTW_HOME)/include
       LIBRARY_LOCATIONS += $(FFTW_HOME)/lib
-      LIBRARIES += -Wl,--rpath=$(FFTW_HOME)/lib
+      LIBRARIES += -Wl,-rpath,$(FFTW_HOME)/lib
     endif
     LIBRARIES += -lfftw3f -lfftw3
   endif


### PR DESCRIPTION
## Summary

Change `rpath` flag used when `FFTW_HOME` is set to work with Mac and Linux ld

## Additional background

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
