### PR TITLE
Fixed EB data for anisotropic grids: boundary centroid, normal vector (backward compatible)

### DIFF
--- a/Src/EB/AMReX_EB2_3D_C.cpp
+++ b/Src/EB/AMReX_EB2_3D_C.cpp
@@ -125,10 +125,9 @@ void set_eb_data (const int i, const int j, const int k,
         return;
     }
 
-    Real bainv = ( (nx*dx[0])*(nx*dx[0]) + (ny*dx[1])*(ny*dx[1]) + (nz*dx[2])*(nz*dx[2]) ) * apnorminv;
-    bcent(i,j,k,0) = bainv * (Bx + nx*vfrac(i,j,k));
-    bcent(i,j,k,1) = bainv * (By + ny*vfrac(i,j,k));
-    bcent(i,j,k,2) = bainv * (Bz + nz*vfrac(i,j,k));
+    bcent(i,j,k,0) = (Bx + nx*vfrac(i,j,k)) * apnorminv * dx[1] * dx[2];
+    bcent(i,j,k,1) = (By + ny*vfrac(i,j,k)) * apnorminv * dx[0] * dx[2];
+    bcent(i,j,k,2) = (Bz + nz*vfrac(i,j,k)) * apnorminv * dx[0] * dx[1];
 
     Real b1 = 0.5_rt*(axp-axm) + 0.5_rt*(ayp*fcy(i,j+1,k,0) + aym*fcy(i,j,k,0)) + 0.5_rt*(azp*fcz(i,j,k+1,0) + azm*fcz(i,j,k,0));
     Real b2 = 0.5_rt*(axp*fcx(i+1,j,k,0) + axm*fcx(i,j,k,0)) + 0.5_rt*(ayp-aym) + 0.5_rt*(azp*fcz(i,j,k+1,1) + azm*fcz(i,j,k,1));

--- a/Src/EB/AMReX_EBToPVD.cpp
+++ b/Src/EB/AMReX_EBToPVD.cpp
@@ -54,15 +54,19 @@ void EBToPVD::EBToPolygon(const Real* problo, const Real* dx,
                Real azm = apz(i  ,j  ,k  );
                Real azp = apz(i  ,j  ,k+1);
 
-               Real apnorm = std::sqrt((axm-axp)*(axm-axp) + (aym-ayp)*(aym-ayp) + (azm-azp)*(azm-azp));
+               Real adx = (axm-axp) * dx[1] * dx[2];
+               Real ady = (aym-ayp) * dx[0] * dx[2];
+               Real adz = (azm-azp) * dx[0] * dx[1];
+
+               Real apnorm = std::sqrt(adx*adx + ady*ady + adz*adz);
                Real apnorminv = Real(1.0)/apnorm;
 
                std::array<Real,3> normal, centroid;
                std::array<std::array<Real,3>,8> vertex;
 
-               normal[0] = (axp-axm) * apnorminv;
-               normal[1] = (ayp-aym) * apnorminv;
-               normal[2] = (azp-azm) * apnorminv;
+               normal[0] = adx * apnorminv;
+               normal[1] = ady * apnorminv;
+               normal[2] = adz * apnorminv;
 
                // convert bcent to global coordinate system centered at plo
                centroid[0] = problo[0] + bcent(i,j,k,0)*dx[0] + (static_cast<Real>(i) + Real(0.5))*dx[0];


### PR DESCRIPTION
## Summary

1. This PR corrects two EB data quantities: the boundary centroid (`bcent`) in `set_eb_data` called within `build_cells`, and the normal vector (`normal`) in `EBToPVD::EBToPolygon`.
2. This correction only affects anisotropic grids (dx != dy != dz) and does not affect computations for isotropic grids (dx==dy==dz).

## Additional background

1. The current `bcent`, normalized using a single parameter (`(nx*dx[0])*(nx*dx[0]) + (ny*dx[1])*(ny*dx[1]) + (nz*dx[2])*(nz*dx[2])`) for all x-, y-, and z-components, results in inappropriate non-dimensional values. The proper physical coordinates can be calculated in user-end code (e.g. ERF) by re-normalizing the `bcent` parameters. 
2. However, when constructing multilevel EB data by coarsening the finest EB data in `Level::coarsenFromFine`, the `bcent` from the finest grid is used to construct coarse EB data. This process produces incorrect `bcent` on coarse grids, which cannot be recovered in user-end code. Therefore, I propose this PR.

@nataraj2 I am submitting a PR to fix normalization of `bcent` for anisotropic grids. So far, I have used the `bcent` as it is, by renormalizing it in ERF. However, I encountered an issue that cannot be fixed from ERF when coarsening the EB data from the fine grid to coarse grids. I discussed this issue with @WeiqunZhang.

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
