### PR TITLE
ParmParse: Type Hints

### DIFF
--- a/Src/Base/AMReX_ParmParse.H
+++ b/Src/Base/AMReX_ParmParse.H
@@ -3,8 +3,10 @@
 #include <AMReX_Config.H>
 
 #include <AMReX_BLassert.H>
+#include <AMReX_Box.H>
 #include <AMReX_Enum.H>
 #include <AMReX_INT.H>
+#include <AMReX_IntVect.H>
 #include <AMReX_IParser.H>
 #include <AMReX_Parser.H>
 #include <AMReX_TypeTraits.H>
@@ -15,7 +17,9 @@
 #include <set>
 #include <string>
 #include <string_view>
+#include <type_traits>
 #include <unordered_map>
+#include <variant>
 #include <vector>
 
 namespace amrex {
@@ -1612,6 +1616,7 @@ public:
         // vector<vector<std::string>>.
         std::vector<std::vector<std::string>> m_vals;
         mutable Long                          m_count = 0;
+        std::variant<std::string, bool, int, long, long long, amrex::IntVect, amrex::Box, float, double> m_typehint = std::string{};
     };
     using Table = std::unordered_map<std::string, PP_entry>;
 

--- a/Src/Base/AMReX_ParmParse.H
+++ b/Src/Base/AMReX_ParmParse.H
@@ -1616,7 +1616,17 @@ public:
         // vector<vector<std::string>>.
         std::vector<std::vector<std::string>> m_vals;
         mutable Long                          m_count = 0;
-        std::variant<std::string, bool, int, long, long long, amrex::IntVect, amrex::Box, float, double> m_typehint = std::string{};
+        std::variant<
+            std::string*,
+            bool*,
+            int*,
+            long*,
+            long long*,
+            amrex::IntVect*,
+            amrex::Box*,
+            float*,
+            double*
+        > m_typehint = static_cast<std::string*>(nullptr);
     };
     using Table = std::unordered_map<std::string, PP_entry>;
 

--- a/Src/Base/AMReX_ParmParse.cpp
+++ b/Src/Base/AMReX_ParmParse.cpp
@@ -863,7 +863,8 @@ saddval (const std::string& name, const T& ref)
     auto& entry = g_table[name];
     entry.m_vals.emplace_back(std::vector<std::string>{val.str()});
     ++entry.m_count;
-    entry.m_typehint = T{};
+    using T_ptr = std::decay_t<T>*;
+    entry.m_typehint = static_cast<T_ptr>(nullptr);
 }
 
 template <class T>
@@ -881,7 +882,8 @@ saddarr (const std::string& name, const std::vector<T>& ref)
     auto& entry = g_table[name];
     entry.m_vals.emplace_back(std::move(arr));
     ++entry.m_count;
-    entry.m_typehint = T{};
+    using T_ptr = std::decay_t<T>*;
+    entry.m_typehint = static_cast<T_ptr>(nullptr);
 }
 
 // Initialize ParmParse.

--- a/Src/Base/AMReX_ParmParse.cpp
+++ b/Src/Base/AMReX_ParmParse.cpp
@@ -863,6 +863,7 @@ saddval (const std::string& name, const T& ref)
     auto& entry = g_table[name];
     entry.m_vals.emplace_back(std::vector<std::string>{val.str()});
     ++entry.m_count;
+    entry.m_typehint = T{};
 }
 
 template <class T>
@@ -880,6 +881,7 @@ saddarr (const std::string& name, const std::vector<T>& ref)
     auto& entry = g_table[name];
     entry.m_vals.emplace_back(std::move(arr));
     ++entry.m_count;
+    entry.m_typehint = T{};
 }
 
 // Initialize ParmParse.


### PR DESCRIPTION
## Summary

Today, we use the `ParmParse` object not only anymore to read text-based key-value pairs from input files and CLI options, but additionally and sometimes exclusively populate it heavily from the C++ and Python APIs directly.

This proposes a concept to store the type of the latest `add` with each entry, which can help to expose `ParmParse` options, e.g., when exporting them to Python dictionaries and other file formats (YAML, TOML, JSON, XML, etc.). When a typehint is found, we can cast to the correct type automatically for the value, instead of returning a string.

## Additional background

https://github.com/AMReX-Codes/pyamrex/pull/417#issuecomment-2699220142

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
