### PR TITLE
ParmParse: Add getline and queryline

### DIFF
--- a/Src/Base/AMReX_ParmParse.H
+++ b/Src/Base/AMReX_ParmParse.H
@@ -586,6 +586,27 @@ public:
     //! Add a key 'name'with value 'ref' to the end of the PP table.
     void add (const char* name, const std::string& val);
 
+
+    //! Similar to get() but store the whole line including empty spaces in
+    //! the middle if present as a single string. For example, `foo = a b c`
+    //! is treated by this function as a single string "a b c", whereas
+    //! get() will give only "a" and getarr() will store the results in
+    //! `std::vectcor<std::string>`. Note this does not preserve the number
+    //! of empty spaces, because of how ParmParse parses the line. For
+    //! example, `a b  c` with two spaces between `b` and `c` will become "a
+    //! b c".
+    void getline (const char* name, std::string& ref) const;
+
+    //! Similar to query() but store the whole line including empty spaces
+    //! in the middle if present as a single string. For example, `foo = a b
+    //! c` is treated by this function as a single string "a b c", whereas
+    //! query() will give only "a" and queryarr() will store the results in
+    //! `std::vectcor<std::string>`. Note this does not preserve the number
+    //! of empty spaces, because of how ParmParse parses the line. For
+    //! example, `a b  c` with two spaces between `b` and `c` will become "a
+    //! b c".
+    int queryline (const char* name, std::string& ref) const;
+
     /**
     * \brief Get the ival'th value of kth occurrence of the requested name.
     * If successful, the value is converted to an IntVect and stored

--- a/Src/Base/AMReX_ParmParse.cpp
+++ b/Src/Base/AMReX_ParmParse.cpp
@@ -5,6 +5,7 @@
 #include <AMReX_ParallelDescriptor.H>
 #include <AMReX_Print.H>
 #include <AMReX_RealVect.H>
+#include <AMReX_String.H>
 #include <AMReX_Utility.H>
 
 #include <algorithm>
@@ -1890,6 +1891,25 @@ ParmParse::getarr (const char* name, RealVect& ref) const
     this->getarr(name, v);
     AMREX_ALWAYS_ASSERT(v.size() == AMREX_SPACEDIM);
     for (int i = 0; i < AMREX_SPACEDIM; ++i) { ref[i] = v[i]; }
+}
+
+void
+ParmParse::getline (const char* name, std::string& ref) const
+{
+    std::vector<std::string> tmp;
+    getarr(name, tmp);
+    ref = amrex::join(tmp, ' ');
+}
+
+int
+ParmParse::queryline (const char* name, std::string& ref) const
+{
+    std::vector<std::string> tmp;
+    auto r = queryarr(name, tmp);
+    if (r) {
+        ref = amrex::join(tmp, ' ');
+    }
+    return r;
 }
 
 //

--- a/Src/Base/AMReX_String.H
+++ b/Src/Base/AMReX_String.H
@@ -25,6 +25,12 @@ namespace amrex {
     //! Split a string using given tokens in `sep`.
     std::vector<std::string> split (std::string const& s,
                                     std::string const& sep = " \t");
+
+    //! Join a vector of strings with given char `sep` as delimiter.
+    std::string join (std::vector<std::string> const& sv, char sep);
+
+    //! Join a vector of strings without delimiter.
+    std::string join (std::vector<std::string> const& sv);
 }
 
 #endif

--- a/Src/Base/AMReX_String.cpp
+++ b/Src/Base/AMReX_String.cpp
@@ -51,4 +51,25 @@ std::vector<std::string> split (std::string const& s, std::string const& sep)
     return result;
 }
 
+std::string join (std::vector<std::string> const& sv, char sep)
+{
+    std::string r;
+    for (auto const& s : sv) {
+        if (!r.empty()) {
+            r += sep;
+        }
+        r += s;
+    }
+    return r;
+}
+
+std::string join (std::vector<std::string> const& sv)
+{
+    std::string r;
+    for (auto const& s : sv) {
+        r += s;
+    }
+    return r;
+}
+
 }

--- a/Tests/ParmParse/inputs
+++ b/Tests/ParmParse/inputs
@@ -62,3 +62,6 @@ n_cell = nx nx nx
 ny = nx
 
 do_this = 1
+
+# queryline and getline
+my_string_line = a  b c

--- a/Tests/ParmParse/main.cpp
+++ b/Tests/ParmParse/main.cpp
@@ -137,6 +137,15 @@ int main(int argc, char* argv[])
         AMREX_ALWAYS_ASSERT(!o_do_that.has_value());
     }
     {
+        ParmParse pp;
+        std::string line;
+        pp.queryline("my_string_line", line);
+        AMREX_ALWAYS_ASSERT(line == "a b c");
+        line.clear();
+        pp.getline("my_string_line", line);
+        AMREX_ALWAYS_ASSERT(line == "a b c");
+    }
+    {
         amrex::Print() << "SUCCESS\n";
     }
     amrex::Finalize();


### PR DESCRIPTION
These functions will store the entry into a single std::string. This will be used in a WarpX PR.
