### PR TITLE
update docs for HYPRE installation

### DIFF
--- a/Docs/sphinx_documentation/source/LinearSolvers.rst
+++ b/Docs/sphinx_documentation/source/LinearSolvers.rst
@@ -554,31 +554,38 @@ problem as much as possible.  However, as we have mentioned, we can
 call :cpp:`setMaxCoarseningLevel(0)` on the :cpp:`LPInfo` object
 passed to the constructor of a linear operator to disable the
 coarsening completely.  In that case the bottom solver is solving the
-residual correction form of the original problem. To build Hypre, follow the next steps:
+residual correction form of the original problem.
+
+As of March 2025, AMReX supports and is tested with Hypre version 2.32.0 (check
+``amrex/.github/workflows/hypre.yml`` so see what versions are currently tested).
+To build Hypre, follow the next steps:
 
 .. highlight:: console
 
 ::
 
     1.- git clone https://github.com/hypre-space/hypre.git
-    2.- cd hypre/src
-    3.- ./configure
+    2.- git checkout v2.32.0
+    3.- cd hypre/src
+    4.- ./configure
         (if you want to build hypre with long long int, do ./configure --enable-bigint )
-    4.- make install
-    5.- Create an environment variable with the HYPRE directory --
+    5.- make install
+    6.- Create an environment variable with the HYPRE directory --
         HYPRE_DIR=/hypre_path/hypre/src/hypre
 
-To use Hypre with CUDA, nvcc compiler is needed along with all other requirements for CPU (e.g. gcc, mpicc). It is very important that the GPU architecture for Hypre matches with that of AMReX. By default, Hypre assumes its architecture number to be 70 and it is best to build Hypre for multiple architectures by specifying multiple compute capability numbers (e.g. 80 and 90).
+To use Hypre with CUDA, nvcc compiler is needed along with all other requirements for CPU (e.g. gcc, mpicc). It is very important that the GPU architecture for Hypre matches with that of AMReX. By default, Hypre assumes its architecture number to be 70 and it is best to build Hypre for multiple architectures by specifying multiple compute capability numbers (e.g. 80 and 90). If you see a runtime error similar to
+``terminate called after throwing an instance of 'thrust::system::system_error'``, you likely did not build for the correct architecture.
 
 ::
 
     1.- git clone https://github.com/hypre-space/hypre.git
-    2.- cd hypre/src
-    3.- ./configure --with-cuda -—with-gpu-arch=’80 90'
+    2.- git checkout v2.32.0
+    3.- cd hypre/src
+    4.- ./configure --with-cuda --with-gpu-arch='80 90' --enable-unified-memory
         (you can figure out the gpu arch from command line using
         nvidia-smi --query-gpu=compute_cap --format=csv, if it gives 9.0, gpu-arch is 90)
-    4.- make install
-    5.- Create an environment variable with the HYPRE directory --
+    5.- make install
+    6.- Create an environment variable with the HYPRE directory --
         HYPRE_DIR=/hypre_path/hypre/src/hypre
 
 To use hypre, one must include ``amrex/Src/Extern/HYPRE`` in the build system.

--- a/Docs/sphinx_documentation/source/LinearSolvers.rst
+++ b/Docs/sphinx_documentation/source/LinearSolvers.rst
@@ -565,8 +565,8 @@ To build Hypre, follow the next steps:
 ::
 
     1.- git clone https://github.com/hypre-space/hypre.git
-    2.- git checkout v2.32.0
-    3.- cd hypre/src
+    2.- cd hypre/src
+    3.- git checkout v2.32.0
     4.- ./configure
         (if you want to build hypre with long long int, do ./configure --enable-bigint )
     5.- make install
@@ -579,8 +579,8 @@ To use Hypre with CUDA, nvcc compiler is needed along with all other requirement
 ::
 
     1.- git clone https://github.com/hypre-space/hypre.git
-    2.- git checkout v2.32.0
-    3.- cd hypre/src
+    2.- cd hypre/src
+    3.- git checkout v2.32.0
     4.- ./configure --with-cuda --with-gpu-arch='80 90' --enable-unified-memory
         (you can figure out the gpu arch from command line using
         nvidia-smi --query-gpu=compute_cap --format=csv, if it gives 9.0, gpu-arch is 90)


### PR DESCRIPTION
## Summary

AMReX does not currently support the latest versions of hypre available from github, so instruct users to checkout the latest release that is supported (v2.32.0).

Also correct some formatting issues with the critical `--with-gpu-arch` flag and provide a debugging hint for what happens when built for the wrong architecture.

Add a recommendation for building with the `--enable-unified-memory` memory flag

CC: @hsitaram 

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [X] include documentation in the code and/or rst files, if appropriate
