### PR TITLE
Force the alignment of SoA and AoS Particles 

### DIFF
--- a/Src/Particle/AMReX_Particle.H
+++ b/Src/Particle/AMReX_Particle.H
@@ -290,8 +290,9 @@ struct SoAParticleBase
  * \tparam T_NInt The number of extra integer components
  */
 template <int T_NReal, int T_NInt=0>
-struct Particle
-    : ParticleBase<ParticleReal,T_NReal,T_NInt>
+struct alignas(sizeof(ParticleReal))
+       alignas(ParticleBase<ParticleReal,T_NReal,T_NInt>)
+Particle :     ParticleBase<ParticleReal,T_NReal,T_NInt>
 {
     static constexpr bool is_soa_particle = false;
     using StorageParticleType = Particle;

--- a/Src/Particle/AMReX_Particle.H
+++ b/Src/Particle/AMReX_Particle.H
@@ -290,9 +290,8 @@ struct SoAParticleBase
  * \tparam T_NInt The number of extra integer components
  */
 template <int T_NReal, int T_NInt=0>
-struct alignas(sizeof(ParticleReal))
-       alignas(ParticleBase<ParticleReal,T_NReal,T_NInt>)
-Particle :     ParticleBase<ParticleReal,T_NReal,T_NInt>
+struct alignas(sizeof(double)) Particle
+    : ParticleBase<ParticleReal,T_NReal,T_NInt>
 {
     static constexpr bool is_soa_particle = false;
     using StorageParticleType = Particle;

--- a/Src/Particle/AMReX_ParticleTile.H
+++ b/Src/Particle/AMReX_ParticleTile.H
@@ -311,7 +311,7 @@ struct ParticleTileData
 
 // SOA Particle Structure
 template <int T_NArrayReal, int T_NArrayInt>
-struct ConstSoAParticle : SoAParticleBase
+struct alignas(8) ConstSoAParticle : SoAParticleBase
 {
     static constexpr int NArrayReal = T_NArrayReal;
     static constexpr int NArrayInt = T_NArrayInt;
@@ -373,7 +373,7 @@ struct ConstSoAParticle : SoAParticleBase
 };
 
 template <int T_NArrayReal, int T_NArrayInt>
-struct SoAParticle : SoAParticleBase
+struct alignas(8) SoAParticle : SoAParticleBase
 {
     static constexpr int NArrayReal = T_NArrayReal;
     static constexpr int NArrayInt = T_NArrayInt;

--- a/Src/Particle/AMReX_ParticleTile.H
+++ b/Src/Particle/AMReX_ParticleTile.H
@@ -311,7 +311,7 @@ struct ParticleTileData
 
 // SOA Particle Structure
 template <int T_NArrayReal, int T_NArrayInt>
-struct alignas(8) ConstSoAParticle : SoAParticleBase
+struct alignas(sizeof(double)) ConstSoAParticle : SoAParticleBase
 {
     static constexpr int NArrayReal = T_NArrayReal;
     static constexpr int NArrayInt = T_NArrayInt;
@@ -373,7 +373,7 @@ struct alignas(8) ConstSoAParticle : SoAParticleBase
 };
 
 template <int T_NArrayReal, int T_NArrayInt>
-struct alignas(8) SoAParticle : SoAParticleBase
+struct alignas(sizeof(double)) SoAParticle : SoAParticleBase
 {
     static constexpr int NArrayReal = T_NArrayReal;
     static constexpr int NArrayInt = T_NArrayInt;


### PR DESCRIPTION
This fixes build issues on 32-bit Linux. This should not affect 64 bits machines.

Fix #4371 
