### PR TITLE
Update hypreSynchronize

### DIFF
--- a/Src/Base/AMReX_GpuDevice.cpp
+++ b/Src/Base/AMReX_GpuDevice.cpp
@@ -1081,7 +1081,7 @@ Device::profilerStop ()
 void hypreSynchronize ()
 {
 #ifdef AMREX_USE_GPU
-#if (HYPRE_RELEASE_NUMBER > 23200) || (HYPRE_RELEASE_NUMBER == 23200 && HYPRE_DEVELOP_NUMBER >= 4)
+#if (HYPRE_RELEASE_NUMBER > 23200)
     hypre_SyncComputeStream();
 #else
     hypre_SyncCudaDevice(hypre_handle()); // works for non-cuda device too

--- a/Src/Base/AMReX_GpuDevice.cpp
+++ b/Src/Base/AMReX_GpuDevice.cpp
@@ -1081,7 +1081,11 @@ Device::profilerStop ()
 void hypreSynchronize ()
 {
 #ifdef AMREX_USE_GPU
+#if (HYPRE_RELEASE_NUMBER > 23200) || (HYPRE_RELEASE_NUMBER == 23200 && HYPRE_DEVELOP_NUMBER >= 4)
+    hypre_SyncComputeStream();
+#else
     hypre_SyncCudaDevice(hypre_handle()); // works for non-cuda device too
+#endif
 #endif
 }
 #endif


### PR DESCRIPTION
hypre_SyncCudaDevice has been removed since v2.32.0-31.
