### PR TITLE
Slope limiting to corner of cell, not fine cell next to corner of cell

### DIFF
--- a/Src/AmrCore/AMReX_MFInterp_1D_C.H
+++ b/Src/AmrCore/AMReX_MFInterp_1D_C.H
@@ -80,7 +80,7 @@ void mf_cell_cons_lin_interp_mcslope (int i, int /*j*/, int /*k*/, int ns,
 
     Real alpha = Real(1.0);
     if (sx != Real(0.0)) {
-        Real dumax = std::abs(sx) * Real(ratio[0]-1)/Real(2*ratio[0]);
+        Real dumax = Real(0.5) * std::abs(sx);
         Real umax = u(i,0,0,nu);
         Real umin = u(i,0,0,nu);
         for (int ioff = -1; ioff <= 1; ++ioff) {

--- a/Src/AmrCore/AMReX_MFInterp_1D_C.H
+++ b/Src/AmrCore/AMReX_MFInterp_1D_C.H
@@ -66,7 +66,7 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 void mf_cell_cons_lin_interp_mcslope (int i, int /*j*/, int /*k*/, int ns,
                                       Array4<Real> const& slope,
                                       Array4<Real const> const& u, int scomp, int /*ncomp*/,
-                                      Box const& domain, IntVect const& ratio,
+                                      Box const& domain, IntVect const& /*ratio*/,
                                       BCRec const* bc) noexcept
 {
     int nu = ns + scomp;

--- a/Src/AmrCore/AMReX_MFInterp_2D_C.H
+++ b/Src/AmrCore/AMReX_MFInterp_2D_C.H
@@ -165,8 +165,7 @@ void mf_cell_cons_lin_interp_mcslope (int i, int j, int /*k*/, int ns, Array4<Re
 
     Real alpha = Real(1.0);
     if (sx != Real(0.0) || sy != Real(0.0)) {
-        Real dumax = std::abs(sx) * Real(ratio[0]-1)/Real(2*ratio[0])
-            +        std::abs(sy) * Real(ratio[1]-1)/Real(2*ratio[1]);
+        Real dumax = Real(0.5) * (std::abs(sx) + std::abs(sy));
         Real umax = u(i,j,0,nu);
         Real umin = u(i,j,0,nu);
         int ilim = ratio[0] > 1 ? 1 : 0;

--- a/Src/AmrCore/AMReX_MFInterp_3D_C.H
+++ b/Src/AmrCore/AMReX_MFInterp_3D_C.H
@@ -215,9 +215,7 @@ void mf_cell_cons_lin_interp_mcslope (int i, int j, int k, int ns, Array4<Real> 
 
     Real alpha = 1.0;
     if (sx != Real(0.0) || sy != Real(0.0) || sz != Real(0.0)) {
-        Real dumax = std::abs(sx) * Real(ratio[0]-1)/Real(2*ratio[0])
-            +        std::abs(sy) * Real(ratio[1]-1)/Real(2*ratio[1])
-            +        std::abs(sz) * Real(ratio[2]-1)/Real(2*ratio[2]);
+        Real dumax = Real(0.5) * (std::abs(sx) + std::abs(sy) + std::abs(sz));
         Real umax = u(i,j,k,nu);
         Real umin = u(i,j,k,nu);
         int ilim = ratio[0] > 1 ? 1 : 0;


### PR DESCRIPTION
## Summary

Proposed change to illustrate the issue being described in #4382
Slope limiting is based on value in the fine cell (and thus dependent on refinement ratio) instead of the corner of the cell.

## Additional background

See issue #4382

## Checklist

The proposed changes:
- [X] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [X] changes answers in the test suite to more than roundoff level
- [X] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
