### PR TITLE
fix multi-level ParticleToMesh when zero_out_input is false

### DIFF
--- a/Src/AmrCore/AMReX_AmrParticles.H
+++ b/Src/AmrCore/AMReX_AmrParticles.H
@@ -246,9 +246,9 @@ ParticleToMesh (PC const& pc, const Vector<MultiFab*>& mf,
     for (int lev = lev_min; lev <= lev_max; lev++)
     {
       if (zero_out_input) {
-        mf[lev]->ParallelCopy(mf_part[lev],0,0,mf_part[lev].nComp(),0,0,FabArrayBase::COPY);
-      } else {
-        mf[lev]->ParallelCopy(mf_part[lev],0,0,mf_part[lev].nComp(),0,0,FabArrayBase::ADD);	
+        mf[lev]->ParallelCopy(mf_part[lev],0,0,mf_part[lev].nComp(),0,0);
+      } else { // do not zero out input
+        mf[lev]->ParallelAdd(mf_part[lev],0,0,mf_part[lev].nComp(),0,0);
     }
 }
 

--- a/Src/AmrCore/AMReX_AmrParticles.H
+++ b/Src/AmrCore/AMReX_AmrParticles.H
@@ -249,6 +249,7 @@ ParticleToMesh (PC const& pc, const Vector<MultiFab*>& mf,
         mf[lev]->ParallelCopy(mf_part[lev],0,0,mf_part[lev].nComp(),0,0);
       } else { // do not zero out input
         mf[lev]->ParallelAdd(mf_part[lev],0,0,mf_part[lev].nComp(),0,0);
+      }
     }
 }
 

--- a/Src/AmrCore/AMReX_AmrParticles.H
+++ b/Src/AmrCore/AMReX_AmrParticles.H
@@ -207,7 +207,6 @@ ParticleToMesh (PC const& pc, const Vector<MultiFab*>& mf,
 
     for (int lev = lev_min; lev <= lev_max; ++lev)
     {
-        //ParticleToMesh(pc, mf_part[lev], lev, f, zero_out_input);
         ParticleToMesh(pc, mf_part[lev], lev, f, true); // always zero out input on temp level
         if (vol_weight) {
             const Real* dx = pc.Geom(lev).CellSize();

--- a/Src/AmrCore/AMReX_AmrParticles.H
+++ b/Src/AmrCore/AMReX_AmrParticles.H
@@ -245,7 +245,10 @@ ParticleToMesh (PC const& pc, const Vector<MultiFab*>& mf,
 
     for (int lev = lev_min; lev <= lev_max; lev++)
     {
-        mf[lev]->ParallelCopy(mf_part[lev],0,0,mf_part[lev].nComp(),0,0);
+      if (zero_out_input) {
+        mf[lev]->ParallelCopy(mf_part[lev],0,0,mf_part[lev].nComp(),0,0,FabArrayBase::COPY);
+      } else {
+        mf[lev]->ParallelCopy(mf_part[lev],0,0,mf_part[lev].nComp(),0,0,FabArrayBase::ADD);	
     }
 }
 

--- a/Src/AmrCore/AMReX_AmrParticles.H
+++ b/Src/AmrCore/AMReX_AmrParticles.H
@@ -207,7 +207,8 @@ ParticleToMesh (PC const& pc, const Vector<MultiFab*>& mf,
 
     for (int lev = lev_min; lev <= lev_max; ++lev)
     {
-        ParticleToMesh(pc, mf_part[lev], lev, f, zero_out_input);
+        //ParticleToMesh(pc, mf_part[lev], lev, f, zero_out_input);
+        ParticleToMesh(pc, mf_part[lev], lev, f, true); // always zero out input on temp level
         if (vol_weight) {
             const Real* dx = pc.Geom(lev).CellSize();
             const Real vol = AMREX_D_TERM(dx[0], *dx[1], *dx[2]);

--- a/Tests/Particles/ParticleMeshMultiLevel/inputs.dont_zero_out_input
+++ b/Tests/Particles/ParticleMeshMultiLevel/inputs.dont_zero_out_input
@@ -1,0 +1,29 @@
+
+# Domain size
+
+#nx = 32 # number of grid points along the x axis
+#ny = 32 # number of grid points along the y axis
+#nz = 32 # number of grid points along the z axis
+
+#nx = 64 # number of grid points along the x axis
+#ny = 64 # number of grid points along the y axis
+#nz = 64 # number of grid points along the z axis
+
+nx = 128 # number of grid points along the x axis
+ny = 128 # number of grid points along the y axis
+nz = 128 # number of grid points along the z axis
+
+# Maximum allowable size of each subdomain in the problem domain;
+#    this is used to decompose the domain for parallel calculations.
+max_grid_size = 32
+
+# Number of particles per cell
+nppc = 10
+
+# Zero out input? (default: true)
+zero_out_input = false
+
+# Verbosity
+verbose = true   # set to true to get more verbosity
+
+nlevs=2

--- a/Tests/Particles/ParticleMeshMultiLevel/main.cpp
+++ b/Tests/Particles/ParticleMeshMultiLevel/main.cpp
@@ -19,6 +19,7 @@ struct TestParams {
     int nlevs;
     int max_grid_size;
     int nppc;
+    bool zero_out_input;
     bool verbose;
 };
 
@@ -91,7 +92,6 @@ void testParticleMesh (TestParams& parms)
     //
     // Here we provide an example of one way to call ParticleToMesh
     //
-    const bool zero_out_input = false; // setting this to false gives a different answer for density0 and density1, even when setVal(0.0) is done for both
 
     amrex::ParticleToMesh(myPC, GetVecOfPtrs(density0), 0, parms.nlevs-1,
         [=] AMREX_GPU_DEVICE (const MyParticleContainer::ParticleType& p,
@@ -106,7 +106,7 @@ void testParticleMesh (TestParams& parms)
                 {
                     return part.rdata(comp);  // no weighting
                 });
-        }, zero_out_input);
+        }, parms.zero_out_input);
 
     amrex::ParticleToMesh(myPC, GetVecOfPtrs(density1), 0, parms.nlevs-1,
         [=] AMREX_GPU_DEVICE (const MyParticleContainer::ParticleType& p,
@@ -194,6 +194,9 @@ int main(int argc, char* argv[])
     amrex::Abort("Must specify at least one particle per cell");
   }
 
+  parms.zero_out_input = true; // setting this to false gives a different answer for density0 and density1, even when setVal(0.0) is done for both
+  pp.query("zero_out_input", parms.zero_out_input);
+  
   parms.verbose = false;
   pp.query("verbose", parms.verbose);
 

--- a/Tests/Particles/ParticleMeshMultiLevel/main.cpp
+++ b/Tests/Particles/ParticleMeshMultiLevel/main.cpp
@@ -71,7 +71,7 @@ void testParticleMesh (TestParams& parms)
     for (int lev = 0; lev < parms.nlevs; lev++) {
         const_mf[lev].define(ba[lev], dm[lev], 1, 1);
         const_mf[lev].setVal(-2.0e8);
-	    density1[lev].define(ba[lev], dm[lev], 1, 1);
+        density1[lev].define(ba[lev], dm[lev], 1, 1);
         density1[lev].setVal(-2.0e8);
         density2[lev].define(ba[lev], dm[lev], 1, 1);
         density2[lev].setVal(0.0);
@@ -185,7 +185,7 @@ int main(int argc, char* argv[])
 
   parms.zero_out_input = true;
   pp.query("zero_out_input", parms.zero_out_input);
-  
+
   parms.verbose = false;
   pp.query("verbose", parms.verbose);
 

--- a/Tests/Particles/ParticleMeshMultiLevel/main.cpp
+++ b/Tests/Particles/ParticleMeshMultiLevel/main.cpp
@@ -67,11 +67,11 @@ void testParticleMesh (TestParams& parms)
     Vector<MultiFab> density2(parms.nlevs);
     for (int lev = 0; lev < parms.nlevs; lev++) {
         density1[lev].define(ba[lev], dm[lev], 1, 1);
-        density1[lev].setVal(0.0);
+        density1[lev].setVal(-2e8);
         density2[lev].define(ba[lev], dm[lev], 1, 1);
-        density2[lev].setVal(0.0);
+        density2[lev].setVal(-2e8);
     }
-
+    
     MyParticleContainer myPC(geom, dm, ba, rr);
     myPC.SetVerbose(false);
 
@@ -88,6 +88,8 @@ void testParticleMesh (TestParams& parms)
     //
     // Here we provide an example of one way to call ParticleToMesh
     //
+    const bool zero_out_input = false;
+
     amrex::ParticleToMesh(myPC, GetVecOfPtrs(density1), 0, parms.nlevs-1,
         [=] AMREX_GPU_DEVICE (const MyParticleContainer::ParticleType& p,
                               amrex::Array4<amrex::Real> const& rho,
@@ -101,7 +103,7 @@ void testParticleMesh (TestParams& parms)
                 {
                     return part.rdata(comp);  // no weighting
                 });
-        });
+        }, zero_out_input);
 
     //
     // Here we provide an example of another way to call ParticleToMesh
@@ -111,8 +113,12 @@ void testParticleMesh (TestParams& parms)
     int        num_comp = 1;
 
     amrex::ParticleToMesh(myPC,GetVecOfPtrs(density2),0,parms.nlevs-1,
-                          TrilinearDeposition{start_part_comp,start_mesh_comp,num_comp});
+                          TrilinearDeposition{start_part_comp,start_mesh_comp,num_comp}, zero_out_input);
 
+    // check that input is NOT zeroed-out
+    int lev = 0;
+    amrex::print_state(density1[lev], IntVect{0,0,0}); // should be a negative value
+    
     //
     // Now write the output from each into separate plotfiles for comparison
     //

--- a/Tests/Particles/ParticleMeshMultiLevel/main.cpp
+++ b/Tests/Particles/ParticleMeshMultiLevel/main.cpp
@@ -3,6 +3,7 @@
 #include <AMReX.H>
 #include <AMReX_MultiFab.H>
 #include <AMReX_MultiFabUtil.H>
+#include "AMReX_FabArrayUtility.H"
 #include "AMReX_Particles.H"
 #include "AMReX_PlotFileUtil.H"
 #include <AMReX_AmrParticles.H>
@@ -64,18 +65,18 @@ void testParticleMesh (TestParams& parms)
         domain.refine(2);
     }
 
-    Vector<MultiFab> density0(parms.nlevs);
+    Vector<MultiFab> const_mf(parms.nlevs);
     Vector<MultiFab> density1(parms.nlevs);
     Vector<MultiFab> density2(parms.nlevs);
     for (int lev = 0; lev < parms.nlevs; lev++) {
-        density0[lev].define(ba[lev], dm[lev], 1, 1);
-        density0[lev].setVal(0.0);
-	density1[lev].define(ba[lev], dm[lev], 1, 1);
-        density1[lev].setVal(0.0);
+        const_mf[lev].define(ba[lev], dm[lev], 1, 1);
+        const_mf[lev].setVal(-2.0e8);
+	    density1[lev].define(ba[lev], dm[lev], 1, 1);
+        density1[lev].setVal(-2.0e8);
         density2[lev].define(ba[lev], dm[lev], 1, 1);
         density2[lev].setVal(0.0);
     }
-    
+
     MyParticleContainer myPC(geom, dm, ba, rr);
     myPC.SetVerbose(false);
 
@@ -93,7 +94,7 @@ void testParticleMesh (TestParams& parms)
     // Here we provide an example of one way to call ParticleToMesh
     //
 
-    amrex::ParticleToMesh(myPC, GetVecOfPtrs(density0), 0, parms.nlevs-1,
+    amrex::ParticleToMesh(myPC, GetVecOfPtrs(density1), 0, parms.nlevs-1,
         [=] AMREX_GPU_DEVICE (const MyParticleContainer::ParticleType& p,
                               amrex::Array4<amrex::Real> const& rho,
                               amrex::GpuArray<amrex::Real,AMREX_SPACEDIM> const& plo,
@@ -108,20 +109,16 @@ void testParticleMesh (TestParams& parms)
                 });
         }, parms.zero_out_input);
 
-    amrex::ParticleToMesh(myPC, GetVecOfPtrs(density1), 0, parms.nlevs-1,
-        [=] AMREX_GPU_DEVICE (const MyParticleContainer::ParticleType& p,
-                              amrex::Array4<amrex::Real> const& rho,
-                              amrex::GpuArray<amrex::Real,AMREX_SPACEDIM> const& plo,
-                              amrex::GpuArray<amrex::Real,AMREX_SPACEDIM> const& dxi) noexcept
-        {
-            ParticleInterpolator::Linear interp(p, plo, dxi);
+    //
+    // Subtract initial value if input was not zeroed-out.
+    // (Plotfiles will only agree to machine precision in this case.)
+    //
 
-            interp.ParticleToMesh(p, rho, 0, 0, 1,
-                [=] AMREX_GPU_DEVICE (const MyParticleContainer::ParticleType& part, int comp)
-                {
-                    return part.rdata(comp);  // no weighting
-                });
-        });
+    if (!parms.zero_out_input) {
+        for (int lev = 0; lev < parms.nlevs; ++lev) {
+            amrex::Subtract(density1[lev], const_mf[lev], 0, 0, 1, 1);
+        }
+    }
 
     //
     // Here we provide an example of another way to call ParticleToMesh
@@ -151,14 +148,6 @@ void testParticleMesh (TestParams& parms)
 
     Vector<const MultiFab*> outputMF(output_levs);
     Vector<IntVect> outputRR(output_levs);
-    for (int lev = 0; lev < output_levs; ++lev) {
-        outputMF[lev] = &density0[lev];
-        outputRR[lev] = IntVect(AMREX_D_DECL(2, 2, 2));
-    }
-    WriteMultiLevelPlotfile("plt00000_v0", output_levs, outputMF,
-                            varnames, geom, 0.0, level_steps, outputRR);
-    myPC.WritePlotFile("plt00000_v0", "particle0", particle_varnames);
-
     for (int lev = 0; lev < output_levs; ++lev) {
         outputMF[lev] = &density1[lev];
         outputRR[lev] = IntVect(AMREX_D_DECL(2, 2, 2));
@@ -194,7 +183,7 @@ int main(int argc, char* argv[])
     amrex::Abort("Must specify at least one particle per cell");
   }
 
-  parms.zero_out_input = true; // setting this to false gives a different answer for density0 and density1, even when setVal(0.0) is done for both
+  parms.zero_out_input = true;
   pp.query("zero_out_input", parms.zero_out_input);
   
   parms.verbose = false;

--- a/Tests/Particles/ParticleMeshMultiLevel/main.cpp
+++ b/Tests/Particles/ParticleMeshMultiLevel/main.cpp
@@ -91,7 +91,7 @@ void testParticleMesh (TestParams& parms)
     //
     // Here we provide an example of one way to call ParticleToMesh
     //
-    const bool zero_out_input = false; // setting this to false gives a different answer for the two ways of interpolating below, even when input is identically zero
+    const bool zero_out_input = false; // setting this to false gives a different answer for density0 and density1, even when setVal(0.0) is done for both
 
     amrex::ParticleToMesh(myPC, GetVecOfPtrs(density0), 0, parms.nlevs-1,
         [=] AMREX_GPU_DEVICE (const MyParticleContainer::ParticleType& p,

--- a/Tests/Particles/ParticleMeshMultiLevel/main.cpp
+++ b/Tests/Particles/ParticleMeshMultiLevel/main.cpp
@@ -65,11 +65,12 @@ void testParticleMesh (TestParams& parms)
 
     Vector<MultiFab> density1(parms.nlevs);
     Vector<MultiFab> density2(parms.nlevs);
+    const amrex::Real originalVal = -2.0e8;
     for (int lev = 0; lev < parms.nlevs; lev++) {
         density1[lev].define(ba[lev], dm[lev], 1, 1);
-        density1[lev].setVal(-2e8);
+        density1[lev].setVal(originalVal);
         density2[lev].define(ba[lev], dm[lev], 1, 1);
-        density2[lev].setVal(-2e8);
+        density2[lev].setVal(originalVal);
     }
     
     MyParticleContainer myPC(geom, dm, ba, rr);
@@ -113,11 +114,12 @@ void testParticleMesh (TestParams& parms)
     int        num_comp = 1;
 
     amrex::ParticleToMesh(myPC,GetVecOfPtrs(density2),0,parms.nlevs-1,
-                          TrilinearDeposition{start_part_comp,start_mesh_comp,num_comp}, zero_out_input);
+                          TrilinearDeposition{start_part_comp,start_mesh_comp,num_comp}, !zero_out_input);
 
     // check that input is NOT zeroed-out
-    int lev = 0;
-    amrex::print_state(density1[lev], IntVect{0,0,0}); // should be a negative value
+    // density1 and density2 should differ by originalVal in each cell
+    amrex::print_state(density1[0], IntVect{0,0,0});
+    amrex::print_state(density2[0], IntVect{0,0,0});
     
     //
     // Now write the output from each into separate plotfiles for comparison

--- a/Tests/Particles/ParticleMeshMultiLevel/main.cpp
+++ b/Tests/Particles/ParticleMeshMultiLevel/main.cpp
@@ -65,12 +65,12 @@ void testParticleMesh (TestParams& parms)
 
     Vector<MultiFab> density1(parms.nlevs);
     Vector<MultiFab> density2(parms.nlevs);
-    const amrex::Real originalVal = -2.0e8;
+    const amrex::Real originalVal = 0.0;
     for (int lev = 0; lev < parms.nlevs; lev++) {
         density1[lev].define(ba[lev], dm[lev], 1, 1);
         density1[lev].setVal(originalVal);
         density2[lev].define(ba[lev], dm[lev], 1, 1);
-        density2[lev].setVal(originalVal);
+        density2[lev].setVal(0.0);
     }
     
     MyParticleContainer myPC(geom, dm, ba, rr);
@@ -89,7 +89,7 @@ void testParticleMesh (TestParams& parms)
     //
     // Here we provide an example of one way to call ParticleToMesh
     //
-    const bool zero_out_input = false;
+    const bool zero_out_input = false; // setting this to false gives a different answer for the two ways of interpolating below, even when input is identically zero
 
     amrex::ParticleToMesh(myPC, GetVecOfPtrs(density1), 0, parms.nlevs-1,
         [=] AMREX_GPU_DEVICE (const MyParticleContainer::ParticleType& p,
@@ -114,12 +114,29 @@ void testParticleMesh (TestParams& parms)
     int        num_comp = 1;
 
     amrex::ParticleToMesh(myPC,GetVecOfPtrs(density2),0,parms.nlevs-1,
-                          TrilinearDeposition{start_part_comp,start_mesh_comp,num_comp}, !zero_out_input);
+                          TrilinearDeposition{start_part_comp,start_mesh_comp,num_comp});
 
+#if 0
     // check that input is NOT zeroed-out
-    // density1 and density2 should differ by originalVal in each cell
-    amrex::print_state(density1[0], IntVect{0,0,0});
-    amrex::print_state(density2[0], IntVect{0,0,0});
+    for (int lev = 0; lev < parms.nlevs-1; ++lev) {
+      auto const rho1 = density1[lev].const_arrays();
+      auto const rho2 = density2[lev].const_arrays();
+      const amrex::Real eps_tol = 1.0e-6;
+
+      amrex::ParallelFor(density1[lev], [=] AMREX_GPU_DEVICE (int bx, int i, int j, int k) {
+	// density1 and density2 should differ by originalVal in each cell
+	amrex::Real const r1 = rho1[bx](i,j,k);
+	amrex::Real const r2 = rho2[bx](i,j,k);
+	amrex::Real const result = (r1 - r2) - originalVal;
+	amrex::Real const rel_err = result / std::max(r1, r2);
+	if (std::abs(rel_err) > eps_tol) {
+	  printf("rel_err = %g\n", rel_err);
+	  amrex::Abort("failed!!");
+	}
+      });
+    }
+    amrex::Gpu::streamSynchronize();
+#endif
     
     //
     // Now write the output from each into separate plotfiles for comparison

--- a/Tests/Particles/ParticleMeshMultiLevel/main.cpp
+++ b/Tests/Particles/ParticleMeshMultiLevel/main.cpp
@@ -63,14 +63,18 @@ void testParticleMesh (TestParams& parms)
         domain.refine(2);
     }
 
+    Vector<MultiFab> density0(parms.nlevs);
     Vector<MultiFab> density1(parms.nlevs);
     Vector<MultiFab> density2(parms.nlevs);
     for (int lev = 0; lev < parms.nlevs; lev++) {
-        density1[lev].define(ba[lev], dm[lev], 1, 1);
+        density0[lev].define(ba[lev], dm[lev], 1, 1);
+        density0[lev].setVal(0.0);
+	density1[lev].define(ba[lev], dm[lev], 1, 1);
         density1[lev].setVal(0.0);
         density2[lev].define(ba[lev], dm[lev], 1, 1);
         density2[lev].setVal(0.0);
     }
+    
     MyParticleContainer myPC(geom, dm, ba, rr);
     myPC.SetVerbose(false);
 
@@ -89,7 +93,7 @@ void testParticleMesh (TestParams& parms)
     //
     const bool zero_out_input = false; // setting this to false gives a different answer for the two ways of interpolating below, even when input is identically zero
 
-    amrex::ParticleToMesh(myPC, GetVecOfPtrs(density1), 0, parms.nlevs-1,
+    amrex::ParticleToMesh(myPC, GetVecOfPtrs(density0), 0, parms.nlevs-1,
         [=] AMREX_GPU_DEVICE (const MyParticleContainer::ParticleType& p,
                               amrex::Array4<amrex::Real> const& rho,
                               amrex::GpuArray<amrex::Real,AMREX_SPACEDIM> const& plo,
@@ -104,6 +108,21 @@ void testParticleMesh (TestParams& parms)
                 });
         }, zero_out_input);
 
+    amrex::ParticleToMesh(myPC, GetVecOfPtrs(density1), 0, parms.nlevs-1,
+        [=] AMREX_GPU_DEVICE (const MyParticleContainer::ParticleType& p,
+                              amrex::Array4<amrex::Real> const& rho,
+                              amrex::GpuArray<amrex::Real,AMREX_SPACEDIM> const& plo,
+                              amrex::GpuArray<amrex::Real,AMREX_SPACEDIM> const& dxi) noexcept
+        {
+            ParticleInterpolator::Linear interp(p, plo, dxi);
+
+            interp.ParticleToMesh(p, rho, 0, 0, 1,
+                [=] AMREX_GPU_DEVICE (const MyParticleContainer::ParticleType& part, int comp)
+                {
+                    return part.rdata(comp);  // no weighting
+                });
+        });
+
     //
     // Here we provide an example of another way to call ParticleToMesh
     //
@@ -114,28 +133,6 @@ void testParticleMesh (TestParams& parms)
     amrex::ParticleToMesh(myPC,GetVecOfPtrs(density2),0,parms.nlevs-1,
                           TrilinearDeposition{start_part_comp,start_mesh_comp,num_comp});
 
-#if 0
-    // check that input is NOT zeroed-out
-    for (int lev = 0; lev < parms.nlevs-1; ++lev) {
-      auto const rho1 = density1[lev].const_arrays();
-      auto const rho2 = density2[lev].const_arrays();
-      const amrex::Real eps_tol = 1.0e-6;
-
-      amrex::ParallelFor(density1[lev], [=] AMREX_GPU_DEVICE (int bx, int i, int j, int k) {
-	// density1 and density2 should be identical
-	amrex::Real const r1 = rho1[bx](i,j,k);
-	amrex::Real const r2 = rho2[bx](i,j,k);
-	amrex::Real const result = (r1 - r2);
-	amrex::Real const rel_err = result / std::max(r1, r2);
-	if (std::abs(rel_err) > eps_tol) {
-	  printf("rel_err = %g\n", rel_err);
-	  amrex::Abort("failed!!");
-	}
-      });
-    }
-    amrex::Gpu::streamSynchronize();
-#endif
-    
     //
     // Now write the output from each into separate plotfiles for comparison
     //
@@ -154,6 +151,14 @@ void testParticleMesh (TestParams& parms)
 
     Vector<const MultiFab*> outputMF(output_levs);
     Vector<IntVect> outputRR(output_levs);
+    for (int lev = 0; lev < output_levs; ++lev) {
+        outputMF[lev] = &density0[lev];
+        outputRR[lev] = IntVect(AMREX_D_DECL(2, 2, 2));
+    }
+    WriteMultiLevelPlotfile("plt00000_v0", output_levs, outputMF,
+                            varnames, geom, 0.0, level_steps, outputRR);
+    myPC.WritePlotFile("plt00000_v0", "particle0", particle_varnames);
+
     for (int lev = 0; lev < output_levs; ++lev) {
         outputMF[lev] = &density1[lev];
         outputRR[lev] = IntVect(AMREX_D_DECL(2, 2, 2));

--- a/Tests/Particles/ParticleMeshMultiLevel/main.cpp
+++ b/Tests/Particles/ParticleMeshMultiLevel/main.cpp
@@ -65,14 +65,12 @@ void testParticleMesh (TestParams& parms)
 
     Vector<MultiFab> density1(parms.nlevs);
     Vector<MultiFab> density2(parms.nlevs);
-    const amrex::Real originalVal = 0.0;
     for (int lev = 0; lev < parms.nlevs; lev++) {
         density1[lev].define(ba[lev], dm[lev], 1, 1);
-        density1[lev].setVal(originalVal);
+        density1[lev].setVal(0.0);
         density2[lev].define(ba[lev], dm[lev], 1, 1);
         density2[lev].setVal(0.0);
     }
-    
     MyParticleContainer myPC(geom, dm, ba, rr);
     myPC.SetVerbose(false);
 
@@ -124,10 +122,10 @@ void testParticleMesh (TestParams& parms)
       const amrex::Real eps_tol = 1.0e-6;
 
       amrex::ParallelFor(density1[lev], [=] AMREX_GPU_DEVICE (int bx, int i, int j, int k) {
-	// density1 and density2 should differ by originalVal in each cell
+	// density1 and density2 should be identical
 	amrex::Real const r1 = rho1[bx](i,j,k);
 	amrex::Real const r2 = rho2[bx](i,j,k);
-	amrex::Real const result = (r1 - r2) - originalVal;
+	amrex::Real const result = (r1 - r2);
 	amrex::Real const rel_err = result / std::max(r1, r2);
 	if (std::abs(rel_err) > eps_tol) {
 	  printf("rel_err = %g\n", rel_err);


### PR DESCRIPTION
## Summary
When more than one level is passed to `amrex::ParticleToMesh`, the input MultiFabs are always zeroed out before they are overwritten with the particle deposition, even if `zero_out_input` is set to false. This fixes the behavior for the multi-level case when `zero_out_input` is false.

## Additional background

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
