### PR TITLE
[DRAFT] fix zero_out_input bug in ParticleToMesh 

### DIFF
--- a/Src/AmrCore/AMReX_AmrParticles.H
+++ b/Src/AmrCore/AMReX_AmrParticles.H
@@ -195,8 +195,14 @@ ParticleToMesh (PC const& pc, const Vector<MultiFab*>& mf,
         mf_tmp[lev].define( pc.ParticleBoxArray(lev),
                             pc.ParticleDistributionMap(lev),
                             mf[lev]->nComp(), 0);
-        mf_part[lev].setVal(0.0);
-        mf_tmp[lev].setVal( 0.0);
+        
+        if (zero_out_input) {
+            mf_part[lev].setVal(0.0);
+        } else {
+            mf_part[lev].ParallelCopy(*mf[lev], 0, 0, mf[lev]->nComp(), 0, 0);
+        }
+        
+        mf_tmp[lev].setVal(0.0);
     }
 
     // configure this to do a no-op at the physical boundaries.


### PR DESCRIPTION
Fix zero_out_input bug in ParticleToMesh when `lev_max > 0`: use `mf_part[lev].ParallelCopy` instead of `mf_part[lev].setVal(0.0)` when `zero_out_input` is false. 

An alternative to #4396 

## Summary

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
