### PR TITLE
print number of cells per level in fboxinfo

### DIFF
--- a/Tools/Plotfile/fboxinfo.cpp
+++ b/Tools/Plotfile/fboxinfo.cpp
@@ -110,7 +110,7 @@ void main_main()
                                << ", volume = "
                                << std::fixed << std::setw(6) << std::setprecision(2)
                                << 100.*static_cast<double>(ncells)/ncells_domain
-			       << "%, number of cells = " << std::setw(6) << ncells << "\n";
+                               << "%, number of cells = " << std::setw(6) << ncells << "\n";
                 if (dim == 1) {
                     amrex::Print() << "          maximum zones =   "
                                    << std::setw(7) << prob_domain.length(0) << "\n";

--- a/Tools/Plotfile/fboxinfo.cpp
+++ b/Tools/Plotfile/fboxinfo.cpp
@@ -109,7 +109,8 @@ void main_main()
                                << ": number of boxes = " << std::setw(6) << nboxes
                                << ", volume = "
                                << std::fixed << std::setw(6) << std::setprecision(2)
-                               << 100.*static_cast<double>(ncells)/ncells_domain << "%\n";
+                               << 100.*static_cast<double>(ncells)/ncells_domain
+			       << "%, number of cells = " << std::setw(6) << ncells << "\n";
                 if (dim == 1) {
                     amrex::Print() << "          maximum zones =   "
                                    << std::setw(7) << prob_domain.length(0) << "\n";


### PR DESCRIPTION
## Summary
This prints the number of cells per level in the fboxinfo output. This is sometimes convenient to see directly.

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
