### PR TITLE
use r-strings for regex, avoid SyntaxWarning: invalid escape sequence

### DIFF
--- a/Tools/Backtrace/parse_bt.py
+++ b/Tools/Backtrace/parse_bt.py
@@ -17,14 +17,14 @@ with open(bt_file, 'rt') as f:
 
 for l in lines:
 
-  m = re.search("libc\.so", l)
+  m = re.search(r"libc\.so", l)
   if m:
     continue
 
   matched = False
 
   # gnu compiler
-  m = re.match("\s*(\d+): .*\(\+(0x[\dabcdef]+)\)", l)
+  m = re.match(r"\s*(\d+): .*\(\+(0x[\dabcdef]+)\)", l)
   if m:
     matched = True
     frame = m.group(1)
@@ -32,7 +32,7 @@ for l in lines:
 
   # intel compiler
   if not matched:
-    m = re.match("\s*(\d+): .*\[(0x[\dabcdef]+)\]", l)
+    m = re.match(r"\s*(\d+): .*\[(0x[\dabcdef]+)\]", l)
     if m:
       matched = True
       frame = m.group(1)


### PR DESCRIPTION
## Summary
parse_bt prints a SyntaxWarning with recent Python versions

## Additional background

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
