### PR TITLE
Fix a bug in 1d Curl Curl Solver

### DIFF
--- a/Src/LinearSolvers/MLMG/AMReX_MLCurlCurl.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLCurlCurl.cpp
@@ -364,6 +364,8 @@ void MLCurlCurl::smooth1D (int amrlev, int mglev, MF& sol, MF const& rhs,
         adxinv[idim] *= std::sqrt(m_alpha);
     }
 
+    int xhi = this->m_geom[amrlev][mglev].Domain().bigEnd(0);
+
     MultiFab nmf(amrex::convert(rhs[0].boxArray(),IntVect(1)),
                  rhs[0].DistributionMap(), 1, 0, MFInfo().SetAlloc(false));
 
@@ -373,17 +375,19 @@ void MLCurlCurl::smooth1D (int amrlev, int mglev, MF& sol, MF const& rhs,
         auto const& bcz = m_bcoefs[amrlev][mglev][2]->const_arrays();
         ParallelFor( nmf, [=] AMREX_GPU_DEVICE(int bno, int i, int j, int k)
         {
+            bool valid_x = i <= xhi; // x is cell-centered, not nodal
             mlcurlcurl_1D(i,j,k,ex[bno],ey[bno],ez[bno],
                           rhsx[bno],rhsy[bno],rhsz[bno],
                           bcx[bno],bcy[bno],bcz[bno],
-                          adxinv,color,dinfo);
+                          adxinv,color,dinfo,valid_x);
         });
     } else {
         ParallelFor( nmf, [=] AMREX_GPU_DEVICE(int bno, int i, int j, int k)
         {
+            bool valid_x = i <= xhi; // x is cell-centered, not nodal
             mlcurlcurl_1D(i,j,k,ex[bno],ey[bno],ez[bno],
                           rhsx[bno],rhsy[bno],rhsz[bno],
-                          b,adxinv,color,dinfo);
+                          b,adxinv,color,dinfo,valid_x);
         });
     }
     Gpu::streamSynchronize();

--- a/Src/LinearSolvers/MLMG/AMReX_MLCurlCurl_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLCurlCurl_K.H
@@ -470,7 +470,7 @@ void mlcurlcurl_1D (int i, int j, int k,
                     Real beta,
                     GpuArray<Real,AMREX_SPACEDIM> const& adxinv,
                     int color,
-                    CurlCurlDirichletInfo const& dinfo)
+                    CurlCurlDirichletInfo const& dinfo, bool valid_x)
 {
     if (dinfo.is_dirichlet_node(i,j,k)) {return; }
 
@@ -480,7 +480,9 @@ void mlcurlcurl_1D (int i, int j, int k,
 
     if (my_color == color)
     {
-        ex(i,j,k) = rhsx(i,j,k) / beta;
+        if (valid_x) {
+            ex(i,j,k) = rhsx(i,j,k) / beta;
+        }
 
         Real gamma_y = dxx * Real(2.0) + beta;
         Real ccey = - dxx * (ey(i-1,j  ,k  ) +
@@ -510,7 +512,7 @@ void mlcurlcurl_1D (int i, int j, int k,
                     Array4<Real const> const& betaz,
                     GpuArray<Real,AMREX_SPACEDIM> const& adxinv,
                     int color,
-                    CurlCurlDirichletInfo const& dinfo)
+                    CurlCurlDirichletInfo const& dinfo, bool valid_x)
 {
     if (dinfo.is_dirichlet_node(i,j,k)) {return; }
     Real dxx = adxinv[0] * adxinv[0];
@@ -519,7 +521,9 @@ void mlcurlcurl_1D (int i, int j, int k,
 
     if (my_color == color)
     {
-        ex(i,j,k) = rhsx(i,j,k) / betax(i,j,k);
+        if (valid_x) {
+            ex(i,j,k) = rhsx(i,j,k) / betax(i,j,k);
+        }
 
         Real gamma_y = dxx * Real(2.0) + betay(i,j,k);
         Real ccey = - dxx * (ey(i-1,j  ,k  ) +


### PR DESCRIPTION
Ex is a cell centered variable. So we need to skip it at the higher end of the nodal domain. Note that it's okay for interior ghost cells, because we do have valid data there.

