### PR TITLE
iMulitFab: Add more methods

### DIFF
--- a/Src/Base/AMReX_FabArrayUtility.H
+++ b/Src/Base/AMReX_FabArrayUtility.H
@@ -1101,6 +1101,73 @@ printCell (FabArray<FAB> const& mf, const IntVect& cell, int comp = -1,
 template <class FAB,
           class bar = std::enable_if_t<IsBaseFab<FAB>::value> >
 void
+Swap (FabArray<FAB>& dst, FabArray<FAB>& src, int srccomp, int dstcomp, int numcomp, int nghost)
+{
+    Swap(dst,src,srccomp,dstcomp,numcomp,IntVect(nghost));
+}
+
+template <class FAB,
+          class bar = std::enable_if_t<IsBaseFab<FAB>::value> >
+void
+Swap (FabArray<FAB>& dst, FabArray<FAB>& src, int srccomp, int dstcomp, int numcomp, const IntVect& nghost)
+{
+    // We can take a shortcut and do a std::swap if we're swapping all of the data
+    // and they are allocated in the same Arena.
+
+    bool explicit_swap = true;
+
+    if (srccomp == dstcomp && dstcomp == 0 && src.nComp() == dst.nComp() &&
+        src.nGrowVect() == nghost && src.nGrowVect() == dst.nGrowVect() &&
+        src.arena() == dst.arena() && src.hasEBFabFactory() == dst.hasEBFabFactory()) {
+        explicit_swap = false;
+    }
+
+    if (!explicit_swap) {
+
+        std::swap(dst, src);
+
+    } else {
+#ifdef AMREX_USE_GPU
+        if (Gpu::inLaunchRegion() && dst.isFusingCandidate()) {
+            auto const& dstma = dst.arrays();
+            auto const& srcma = src.arrays();
+            ParallelFor(dst, nghost, numcomp,
+            [=] AMREX_GPU_DEVICE (int box_no, int i, int j, int k, int n) noexcept
+            {
+                const auto tmp                 = dstma[box_no](i,j,k,n+dstcomp);
+                dstma[box_no](i,j,k,n+dstcomp) = srcma[box_no](i,j,k,n+srccomp);
+                srcma[box_no](i,j,k,n+srccomp) = tmp;
+            });
+            if (!Gpu::inNoSyncRegion()) {
+                Gpu::streamSynchronize();
+            }
+        } else
+#endif
+        {
+#ifdef AMREX_USE_OMP
+#pragma omp parallel if (Gpu::notInLaunchRegion())
+#endif
+            for (MFIter mfi(dst,TilingIfNotGPU()); mfi.isValid(); ++mfi)
+            {
+                const Box& bx = mfi.growntilebox(nghost);
+                if (bx.ok()) {
+                    auto sfab = src.array(mfi);
+                    auto dfab = dst.array(mfi);
+                    AMREX_HOST_DEVICE_PARALLEL_FOR_4D( bx, numcomp, i, j, k, n,
+                    {
+                        const auto tmp        = dfab(i,j,k,n+dstcomp);
+                        dfab(i,j,k,n+dstcomp) = sfab(i,j,k,n+srccomp);
+                        sfab(i,j,k,n+srccomp) = tmp;
+                    });
+                }
+            }
+        }
+    }
+}
+
+template <class FAB,
+          class bar = std::enable_if_t<IsBaseFab<FAB>::value> >
+void
 Subtract (FabArray<FAB>& dst, FabArray<FAB> const& src, int srccomp, int dstcomp, int numcomp, int nghost)
 {
     Subtract(dst,src,srccomp,dstcomp,numcomp,IntVect(nghost));

--- a/Src/Base/AMReX_MultiFab.cpp
+++ b/Src/Base/AMReX_MultiFab.cpp
@@ -225,61 +225,8 @@ MultiFab::Swap (MultiFab& dst, MultiFab& src,
     BL_ASSERT(dst.nGrowVect().allGE(nghost) && src.nGrowVect().allGE(nghost));
 
     BL_PROFILE("MultiFab::Swap()");
-
-    // We can take a shortcut and do a std::swap if we're swapping all of the data
-    // and they are allocated in the same Arena.
-
-    bool explicit_swap = true;
-
-    if (srccomp == dstcomp && dstcomp == 0 && src.nComp() == dst.nComp() &&
-        src.nGrowVect() == nghost && src.nGrowVect() == dst.nGrowVect() &&
-        src.arena() == dst.arena() && src.hasEBFabFactory() == dst.hasEBFabFactory()) {
-        explicit_swap = false;
-    }
-
-    if (!explicit_swap) {
-
-        std::swap(dst, src);
-
-    } else {
-#ifdef AMREX_USE_GPU
-        if (Gpu::inLaunchRegion() && dst.isFusingCandidate()) {
-            auto const& dstma = dst.arrays();
-            auto const& srcma = src.arrays();
-            ParallelFor(dst, nghost, numcomp,
-            [=] AMREX_GPU_DEVICE (int box_no, int i, int j, int k, int n) noexcept
-            {
-                const amrex::Real tmp = dstma[box_no](i,j,k,n+dstcomp);
-                dstma[box_no](i,j,k,n+dstcomp) = srcma[box_no](i,j,k,n+srccomp);
-                srcma[box_no](i,j,k,n+srccomp) = tmp;
-            });
-            if (!Gpu::inNoSyncRegion()) {
-                Gpu::streamSynchronize();
-            }
-        } else
-#endif
-        {
-#ifdef AMREX_USE_OMP
-#pragma omp parallel if (Gpu::notInLaunchRegion())
-#endif
-            for (MFIter mfi(dst,TilingIfNotGPU()); mfi.isValid(); ++mfi)
-            {
-                const Box& bx = mfi.growntilebox(nghost);
-                if (bx.ok()) {
-                    auto sfab = src.array(mfi);
-                    auto dfab = dst.array(mfi);
-                    AMREX_HOST_DEVICE_PARALLEL_FOR_4D( bx, numcomp, i, j, k, n,
-                    {
-                        const amrex::Real tmp = dfab(i,j,k,n+dstcomp);
-                        dfab(i,j,k,n+dstcomp) = sfab(i,j,k,n+srccomp);
-                        sfab(i,j,k,n+srccomp) = tmp;
-                    });
-                }
-            }
-        }
-    }
+    amrex::Swap(dst,src,srccomp,dstcomp,numcomp,nghost);
 }
-
 
 void
 MultiFab::Subtract (MultiFab& dst, const MultiFab& src,

--- a/Src/Base/AMReX_iMultiFab.H
+++ b/Src/Base/AMReX_iMultiFab.H
@@ -423,10 +423,17 @@ public:
     */
     static void Add (iMultiFab&       dst,
                      const iMultiFab& src,
-                     int             srccomp,
-                     int             dstcomp,
-                     int             numcomp,
-                     int             nghost);
+                     int              srccomp,
+                     int              dstcomp,
+                     int              numcomp,
+                     int              nghost);
+
+    static void Add (iMultiFab&       dst,
+                     const iMultiFab& src,
+                     int              srccomp,
+                     int              dstcomp,
+                     int              numcomp,
+                     const IntVect&   nghost);
 
     /**
     * \brief Copy from src to dst including nghost ghost cells.
@@ -454,6 +461,25 @@ public:
                       const IntVect&  nghost);
 
     /**
+    * \brief Swap from src to dst including nghost ghost cells.
+    * The two iMultiFabs MUST have the same underlying BoxArray.
+    * The swap is local.
+    */
+    static void Swap (iMultiFab&      dst,
+                      iMultiFab&      src,
+                      int             srccomp,
+                      int             dstcomp,
+                      int             numcomp,
+                      int             nghost);
+
+    static void Swap (iMultiFab&      dst,
+                      iMultiFab&      src,
+                      int             srccomp,
+                      int             dstcomp,
+                      int             numcomp,
+                      const IntVect&  nghost);
+
+    /**
     * \brief Subtract src from dst including nghost ghost cells.
     * The two iMultiFabs MUST have the same underlying BoxArray.
     *
@@ -466,10 +492,17 @@ public:
     */
     static void Subtract (iMultiFab&       dst,
                           const iMultiFab& src,
-                          int             srccomp,
-                          int             dstcomp,
-                          int             numcomp,
-                          int             nghost);
+                          int              srccomp,
+                          int              dstcomp,
+                          int              numcomp,
+                          int              nghost);
+
+    static void Subtract (iMultiFab&       dst,
+                          const iMultiFab& src,
+                          int              srccomp,
+                          int              dstcomp,
+                          int              numcomp,
+                          const IntVect&   nghost);
 
     /**
     * \brief Multiply dst by src including nghost ghost cells.
@@ -484,10 +517,17 @@ public:
     */
     static void Multiply (iMultiFab&       dst,
                           const iMultiFab& src,
-                          int             srccomp,
-                          int             dstcomp,
-                          int             numcomp,
-                          int             nghost);
+                          int              srccomp,
+                          int              dstcomp,
+                          int              numcomp,
+                          int              nghost);
+
+    static void Multiply (iMultiFab&       dst,
+                          const iMultiFab& src,
+                          int              srccomp,
+                          int              dstcomp,
+                          int              numcomp,
+                          const IntVect&   nghost);
 
     /**
     * \brief Divide dst by src including nghost ghost cells.
@@ -502,10 +542,17 @@ public:
     */
     static void Divide (iMultiFab&       dst,
                         const iMultiFab& src,
-                        int             srccomp,
-                        int             dstcomp,
-                        int             numcomp,
-                        int             nghost);
+                        int              srccomp,
+                        int              dstcomp,
+                        int              numcomp,
+                        int              nghost);
+
+    static void Divide (iMultiFab&       dst,
+                        const iMultiFab& src,
+                        int              srccomp,
+                        int              dstcomp,
+                        int              numcomp,
+                        const IntVect&   nghost);
 
     void define (const BoxArray&            bxs,
                  const DistributionMapping& dm,

--- a/Src/Base/AMReX_iMultiFab.cpp
+++ b/Src/Base/AMReX_iMultiFab.cpp
@@ -22,32 +22,40 @@ namespace
 
 void
 iMultiFab::Add (iMultiFab&       dst,
-               const iMultiFab& src,
-               int             srccomp,
-               int             dstcomp,
-               int             numcomp,
-               int             nghost)
+                const iMultiFab& src,
+                int              srccomp,
+                int              dstcomp,
+                int              numcomp,
+                int              nghost)
+{
+    iMultiFab::Add(dst,src,srccomp,dstcomp,numcomp,IntVect(nghost));
+}
+
+void
+iMultiFab::Add (iMultiFab&       dst,
+                const iMultiFab& src,
+                int              srccomp,
+                int              dstcomp,
+                int              numcomp,
+                const IntVect&   nghost)
 {
     BL_ASSERT(dst.boxArray() == src.boxArray());
     BL_ASSERT(dst.distributionMap == src.distributionMap);
     BL_ASSERT(dst.nGrowVect().allGE(nghost) && src.nGrowVect().allGE(nghost));
 
-    amrex::Add(dst,src,srccomp,dstcomp,numcomp,IntVect(nghost));
+    BL_PROFILE("iMultiFab::Add()");
+    amrex::Add(dst,src,srccomp,dstcomp,numcomp,nghost);
 }
 
 void
 iMultiFab::Copy (iMultiFab&       dst,
-                const iMultiFab& src,
-                int             srccomp,
-                int             dstcomp,
-                int             numcomp,
-                int             nghost)
+                 const iMultiFab& src,
+                 int              srccomp,
+                 int              dstcomp,
+                 int              numcomp,
+                 int              nghost)
 {
-    BL_ASSERT(dst.boxArray() == src.boxArray());
-    BL_ASSERT(dst.distributionMap == src.distributionMap);
-    BL_ASSERT(dst.nGrowVect().allGE(nghost) && src.nGrowVect().allGE(nghost));
-
-    amrex::Copy(dst,src,srccomp,dstcomp,numcomp,IntVect(nghost));
+    iMultiFab::Copy(dst,src,srccomp,dstcomp,numcomp,IntVect(nghost));
 }
 
 void
@@ -59,53 +67,107 @@ iMultiFab::Copy (iMultiFab& dst, const iMultiFab& src,
     BL_ASSERT(dst.nGrowVect().allGE(nghost));
 
     BL_PROFILE("iMultiFab::Copy()");
-
     amrex::Copy(dst,src,srccomp,dstcomp,numcomp,nghost);
 }
 
 void
-iMultiFab::Subtract (iMultiFab&       dst,
-                    const iMultiFab& src,
-                    int             srccomp,
-                    int             dstcomp,
-                    int             numcomp,
-                    int             nghost)
+iMultiFab::Swap (iMultiFab& dst, iMultiFab& src,
+                int srccomp, int dstcomp, int numcomp, int nghost)
+{
+    Swap(dst,src,srccomp,dstcomp,numcomp,IntVect(nghost));
+}
+
+void
+iMultiFab::Swap (iMultiFab& dst, iMultiFab& src,
+                int srccomp, int dstcomp, int numcomp, const IntVect& nghost)
 {
     BL_ASSERT(dst.boxArray() == src.boxArray());
     BL_ASSERT(dst.distributionMap == src.distributionMap);
     BL_ASSERT(dst.nGrowVect().allGE(nghost) && src.nGrowVect().allGE(nghost));
 
-    amrex::Subtract(dst,src,srccomp,dstcomp,numcomp,IntVect(nghost));
+    BL_PROFILE("iMultiFab::Swap()");
+    amrex::Swap(dst,src,srccomp,dstcomp,numcomp,nghost);
+}
+
+void
+iMultiFab::Subtract (iMultiFab&       dst,
+                     const iMultiFab& src,
+                     int              srccomp,
+                     int              dstcomp,
+                     int              numcomp,
+                     int              nghost)
+{
+    iMultiFab::Subtract(dst,src,srccomp,dstcomp,numcomp,IntVect(nghost));
+}
+
+void
+iMultiFab::Subtract (iMultiFab&       dst,
+                     const iMultiFab& src,
+                     int              srccomp,
+                     int              dstcomp,
+                     int              numcomp,
+                     const IntVect&   nghost)
+{
+    BL_ASSERT(dst.boxArray() == src.boxArray());
+    BL_ASSERT(dst.distributionMap == src.distributionMap);
+    BL_ASSERT(dst.nGrowVect().allGE(nghost) && src.nGrowVect().allGE(nghost));
+
+    BL_PROFILE("iMultiFab::Subtract()");
+    amrex::Subtract(dst,src,srccomp,dstcomp,numcomp,nghost);
 }
 
 void
 iMultiFab::Multiply (iMultiFab&       dst,
-                    const iMultiFab& src,
-                    int             srccomp,
-                    int             dstcomp,
-                    int             numcomp,
-                    int             nghost)
+                     const iMultiFab& src,
+                     int              srccomp,
+                     int              dstcomp,
+                     int              numcomp,
+                     int              nghost)
+{
+    iMultiFab::Multiply(dst,src,srccomp,dstcomp,numcomp,IntVect(nghost));
+}
+
+void
+iMultiFab::Multiply (iMultiFab&       dst,
+                     const iMultiFab& src,
+                     int              srccomp,
+                     int              dstcomp,
+                     int              numcomp,
+                     const IntVect&   nghost)
 {
     BL_ASSERT(dst.boxArray() == src.boxArray());
     BL_ASSERT(dst.distributionMap == src.distributionMap);
     BL_ASSERT(dst.nGrowVect().allGE(nghost) && src.nGrowVect().allGE(nghost));
 
-    amrex::Multiply(dst,src,srccomp,dstcomp,numcomp,IntVect(nghost));
+    BL_PROFILE("iMultiFab::Multiply()");
+    amrex::Multiply(dst,src,srccomp,dstcomp,numcomp,nghost);
 }
 
 void
 iMultiFab::Divide (iMultiFab&       dst,
-                  const iMultiFab& src,
-                  int             srccomp,
-                  int             dstcomp,
-                  int             numcomp,
-                  int             nghost)
+                   const iMultiFab& src,
+                   int              srccomp,
+                   int              dstcomp,
+                   int              numcomp,
+                   int              nghost)
+{
+    iMultiFab::Divide(dst,src,srccomp,dstcomp,numcomp,IntVect(nghost));
+}
+
+void
+iMultiFab::Divide (iMultiFab&       dst,
+                   const iMultiFab& src,
+                   int              srccomp,
+                   int              dstcomp,
+                   int              numcomp,
+                   const IntVect&   nghost)
 {
     BL_ASSERT(dst.boxArray() == src.boxArray());
     BL_ASSERT(dst.distributionMap == src.distributionMap);
     BL_ASSERT(dst.nGrowVect().allGE(nghost) && src.nGrowVect().allGE(nghost));
 
-    amrex::Divide(dst,src,srccomp,dstcomp,numcomp,IntVect(nghost));
+    BL_PROFILE("iMultiFab::Divide()");
+    amrex::Divide(dst,src,srccomp,dstcomp,numcomp,nghost);
 }
 
 void


### PR DESCRIPTION
Add Swap, Add(.,IntVect), Subtract(.,IntVect), Multiply(.,IntVect), and Divide(.,IntVect).

This addresses part of #4317. `sum_unique` is not added in this PR, because of potential integer overflow. If we really need it, we add add it in the future.
