### PR TITLE
Add utility to create non-periodic turbulence files from planes of ou…

### DIFF
--- a/Tools/Postprocessing/C_Src/OutflowPlanesToSwirlTypeTurb.cpp
+++ b/Tools/Postprocessing/C_Src/OutflowPlanesToSwirlTypeTurb.cpp
@@ -42,7 +42,7 @@ Extend (FArrayBox& xfab,
       xfab(IntVect(i,j,0),0) = vfab(iv,comp);
     }
   }
-  
+
   for (int i=0; i<3; ++i) {
     for (int j=0; j<vbx.length(jdir); ++j) {
       IntVect iv;
@@ -159,16 +159,16 @@ main (int   argc,
 
       for (int k = 0; k < nf; ++k)
       {
-	FArrayBox fileFab;
-	{
-	  std::ifstream ifs(ifiles[k]);
-	  fileFab.readFrom(ifs);
-	  if (d==0) {
-	    ifs >> fileTimes[k];
-	  }
-	  ifs.close();
-	}
-	Extend(TMP, fileFab, domain, idir, jdir, kdir, d);	
+        FArrayBox fileFab;
+        {
+          std::ifstream ifs(ifiles[k]);
+          fileFab.readFrom(ifs);
+          if (d==0) {
+            ifs >> fileTimes[k];
+          }
+          ifs.close();
+        }
+        Extend(TMP, fileFab, domain, idir, jdir, kdir, d);
         //
         // Write current position of data file to header file.
         //

--- a/Tools/Postprocessing/C_Src/OutflowPlanesToSwirlTypeTurb.cpp
+++ b/Tools/Postprocessing/C_Src/OutflowPlanesToSwirlTypeTurb.cpp
@@ -1,0 +1,190 @@
+#include <string>
+#include <iostream>
+
+#include "AMReX_ParmParse.H"
+#include <AMReX_ParallelDescriptor.H>
+#include <AMReX_DataServices.H>
+
+#include <AMReX_BLFort.H>
+
+using namespace amrex;
+
+static
+void
+print_usage (int,
+             char* argv[])
+{
+  std::cerr << "usage:\n";
+  std::cerr << argv[0] << " ifile=<pltfile> ofile=<turbname>\n";
+  exit(1);
+}
+
+static
+void
+Extend (FArrayBox& xfab,
+        FArrayBox& vfab,
+        const Box& domain, int idir, int jdir, int kdir, int comp)
+{
+  Box tbx;
+  tbx.setSmall(IntVect::TheZeroVector());
+  tbx.setBig(0, domain.bigEnd(idir) + 3);
+  tbx.setBig(1, domain.bigEnd(jdir) + 3);
+  tbx.setBig(2, 0);
+  const Box& vbx = vfab.box();
+
+  xfab.resize(tbx,1);
+  for (int i=0; i<vbx.length(idir); ++i) {
+    for (int j=0; j<vbx.length(jdir); ++j) {
+      IntVect iv;
+      iv[kdir] = vbx.smallEnd(kdir);
+      iv[idir] = i + vbx.smallEnd(idir);
+      iv[jdir] = j + vbx.smallEnd(jdir);
+      xfab(IntVect(i,j,0),0) = vfab(iv,comp);
+    }
+  }
+  
+  for (int i=0; i<3; ++i) {
+    for (int j=0; j<vbx.length(jdir); ++j) {
+      IntVect iv;
+      iv[kdir] = vbx.smallEnd(kdir);
+      iv[idir] = i + vbx.smallEnd(idir);
+      iv[jdir] = j + vbx.smallEnd(jdir);
+      xfab(IntVect(i+vbx.length(idir),j,0),0) = vfab(iv,comp);
+    }
+  }
+
+  for (int i=0; i<vbx.length(idir); ++i) {
+    for (int j=0; j<3; ++j) {
+      IntVect iv;
+      iv[kdir] = vbx.smallEnd(kdir);
+      iv[idir] = i + vbx.smallEnd(idir);
+      iv[jdir] = j + vbx.smallEnd(jdir);
+      xfab(IntVect(i,j+vbx.length(jdir),0),0) = vfab(iv,comp);
+    }
+  }
+
+  for (int i=0; i<3; ++i) {
+    for (int j=0; j<3; ++j) {
+      IntVect iv;
+      iv[kdir] = vbx.smallEnd(kdir);
+      iv[idir] = i + vbx.smallEnd(idir);
+      iv[jdir] = j + vbx.smallEnd(jdir);
+      xfab(IntVect(i+vbx.length(idir),j+vbx.length(jdir),0),0) = vfab(iv,comp);
+    }
+  }
+}
+
+int
+main (int   argc,
+      char* argv[])
+{
+  Initialize(argc,argv);
+  {
+    if (argc < 2)
+      print_usage(argc,argv);
+
+    ParmParse pp;
+
+    const std::string farg = amrex::get_command_argument(1);
+    if (farg == "-h" || farg == "--help")
+      print_usage(argc,argv);
+
+    if (pp.contains("verbose"))
+      AmrData::SetVerbose(true);
+
+    int nf = pp.countval("ifiles");
+    AMREX_ALWAYS_ASSERT(nf >= 3);
+    Vector<std::string> ifiles(nf);
+    pp.getarr("ifiles",ifiles,0,nf);
+
+    std::string ofile;
+    pp.get("ofile",ofile);
+
+    std::string TurbDir = ofile;
+
+    if (ParallelDescriptor::IOProcessor())
+      if (!UtilCreateDirectory(TurbDir, 0755))
+        CreateDirectoryFailed(TurbDir);
+
+    std::string Hdr = TurbDir; Hdr += "/HDR";
+    std::string Dat = TurbDir; Dat += "/DAT";
+
+    std::ofstream ifsd, ifsh;
+
+    ifsh.open(Hdr.c_str(), std::ios::out|std::ios::trunc);
+    if (!ifsh.good())
+      FileOpenFailed(Hdr);
+
+    ifsd.open(Dat.c_str(), std::ios::out|std::ios::trunc);
+    if (!ifsd.good())
+      FileOpenFailed(Dat);
+
+    Box domain;
+    {
+      std::ifstream ifs(ifiles[0]);
+      FArrayBox fab;
+      fab.readFrom(ifs);
+      ifs.close();
+      domain = fab.box();
+    }
+    int idir = 1;
+    int jdir = 2;
+    int kdir = 0;
+    IntVect bg;
+    bg[0] = domain.length(idir);
+    bg[1] = domain.length(jdir);
+    bg[2] = nf;
+    //
+    // Write the first part of the header.
+    //
+    ifsh << bg[0] + 3 << ' '
+         << bg[1] + 3 << ' '
+         << bg[2] << '\n';
+
+    Vector<Real> planeSize(2), dx(2);
+    pp.getarr("planeSize",planeSize,0,2);
+    dx[0] = planeSize[0] / bg[0];
+    dx[1] = planeSize[1] / bg[1];
+    ifsh << planeSize[0] + 2*dx[0] << ' '
+         << planeSize[1] + 2*dx[1] << ' '
+         << nf << '\n';
+
+    ifsh << 1 << ' ' << 1 << ' ' << 0 << '\n';
+
+    FArrayBox TMP;
+    Vector<Real> fileTimes(nf);
+    for (int d = 0; d < BL_SPACEDIM; ++d)
+    {
+      std::cout << "Loading component " << d << " ... " << std::flush;
+
+      for (int k = 0; k < nf; ++k)
+      {
+	FArrayBox fileFab;
+	{
+	  std::ifstream ifs(ifiles[k]);
+	  fileFab.readFrom(ifs);
+	  if (d==0) {
+	    ifs >> fileTimes[k];
+	  }
+	  ifs.close();
+	}
+	Extend(TMP, fileFab, domain, idir, jdir, kdir, d);	
+        //
+        // Write current position of data file to header file.
+        //
+        ifsh << ifsd.tellp() << std::endl;
+        //
+        // Write the FAB to the data file.
+        //
+        TMP.writeOn(ifsd);
+      }
+      std::cout << "done" << std::endl;
+    }
+    // Write plane times
+    for (int k = 0; k < nf; ++k)
+    {
+      ifsh << fileTimes[k] << std::endl;
+    }
+  }
+  Finalize();
+}


### PR DESCRIPTION
Add a utility to assemble FAB files (appended with the tilmestep of the plane) into "non-periodic turbulence inflow" files.  A similar capability exists to create a turbinflow file from a snapshot of a triply periodic dataset. Rather than assuming a Taylor hypothesis and inflowing into a domain at a fixed advection speed, this version provides a mechanism to essentially couple the outflow of one run as inflow into another, thus removing the assumption of a uniformly moving reference frame.

## Summary
Given a set of FAB files, each of which is appended with a timestamp, assemble a single folder/file to be used as source for inflowing a velocity field into an AMReX calculation.  The FAB data must be from a uniform grid (usually taken from level 0 data of a precursor run), and the timestamps are assumed to be increasing in the file list given here as input.  Example code to read and use files of this format can be found  [here](https://github.com/AMReX-Combustion/PelePhysics/tree/development/Source/Utility/TurbInflow) for example.

## Additional background
This (re-)implements the (ambiguously named) "swirl-type" turbulence that was dropped years prior when the turbulence inlet capability was upgraded for GPU implementation, adding the file generation tool in the same folder as the existing tool that creates data for the periodic (Taylor hypothesis) version.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
